### PR TITLE
feat(bin): allow evidenced pre-merge task teardown

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,8 +27,8 @@ Hard rules, in priority order:
    Firstmate may directly edit, create, move, or delete project files or directories only when the captain clearly and concretely approves, in the moment, for a specific project, either a specific operation or a concrete scope whose authorized action needs no inference; firstmate performs exactly that approval with its own file tools, never infers or broadens it, and gains no standing authority, while the force, discard, unlanded-work, merge-authority, destructive, irreversible, and security-sensitive boundaries remain independently in force.
 2. **Never merge a PR without the captain's explicit word.**
    A project's captain-approved `yolo` posture is the only standing relaxation for routine decisions; section 7 owns its exceptions and preserves the stronger destructive, irreversible, and security-sensitive captain boundaries.
-3. **Never tear down unlanded work.**
-   Uncommitted changes are never landed, and `bin/fm-teardown.sh` owns the complete landed-work test.
+3. **Never tear down work without a durable recovery path.**
+   Uncommitted changes never qualify, and `bin/fm-teardown.sh` owns the complete landed-work and narrow pre-merge recovery proofs.
    Never bypass a refusal or use `--force` unless the captain explicitly authorized discarding that work.
    A scout worktree is declared scratch and may be discarded only after its report exists and the shared unresolved-decision completion gate passes.
 4. **Crewmates never address the captain.**
@@ -320,8 +320,8 @@ Tell the captain the PR's full URL, always the complete `https://...` link rathe
 A captain instruction to merge is explicit authority; `yolo` is the only standing routine authority.
 For any custom `state/<id>.check.sh` you write yourself, keep it an ordinary single-link mode-`0700` file, print one line only when firstmate should wake, print nothing otherwise, finish before `FM_CHECK_TIMEOUT`, then bind its current bytes with `bin/fm-check-register.sh <id>` before the watcher may execute it.
 
-Tear down a ship task only after landing is confirmed.
-A teardown refusal for uncommitted or unlanded work is a stop-and-investigate result, never an obstacle to bypass.
+Tear down a ship task only after landing is confirmed or `bin/fm-teardown.sh` confirms its narrow pre-merge recovery path.
+A teardown refusal for uncommitted, unlanded, or insufficiently evidenced work is a stop-and-investigate result, never an obstacle to bypass.
 Never force teardown without explicit discard authority.
 After successful teardown, record completion, retain only the configured recent Done history, and re-evaluate queued work whose blockers and time gates have cleared.
 

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -458,6 +458,12 @@ local_work_is_in_pr_head() {
     || unpushed_patches_are_in_pr_head "$pr_head"
 }
 
+local_head_is_ancestor_of_pr_head() {
+  local pr_head=$1 current
+  current=$(git -C "$WT" rev-parse --verify HEAD 2>/dev/null) || return 1
+  git -C "$WT" merge-base --is-ancestor "$current" "$pr_head" 2>/dev/null
+}
+
 single_top_level_api_field() {
   local text=$1 key=$2 values count
   values=$(printf '%s\n' "$text" | awk -v prefix="$key: " \
@@ -531,7 +537,7 @@ parse_check_summary_counts() {
 TEARDOWN_PRESERVE_TASK_BRANCH=0
 TEARDOWN_PR_EVIDENCE_ERROR=
 pr_is_complete_green_and_mergeable() {
-  local branch=$1 status_file last_status provider url path number
+  local branch=$1 status_file last_status completion_count provider url path number
   local recorded_head_count recorded_head api state draft mergeable live_head
   local checks summary_body parsed_summary parsed_count
   local passed failed skipped pending total
@@ -561,6 +567,11 @@ pr_is_complete_green_and_mergeable() {
   fi
   last_status=$(awk 'NF { line = $0 } END { print line }' "$status_file" 2>/dev/null) || {
     TEARDOWN_PR_EVIDENCE_ERROR="the task completion record is unreadable"
+    return 1
+  }
+  completion_count=$(grep -c '^done: PR ' "$status_file" 2>/dev/null || true)
+  [ "$completion_count" -eq 1 ] || {
+    TEARDOWN_PR_EVIDENCE_ERROR="the task completion record is absent or duplicated"
     return 1
   }
   case "$last_status" in
@@ -641,7 +652,7 @@ pr_is_complete_green_and_mergeable() {
 $parsed_summary
 EOF
   if [ "$total" -eq 0 ] || [ "$passed" -eq 0 ] || [ "$failed" -ne 0 ] \
-    || [ "$pending" -ne 0 ] || [ $((passed + skipped)) -ne "$total" ]; then
+    || [ "$skipped" -ne 0 ] || [ "$pending" -ne 0 ] || [ "$passed" -ne "$total" ]; then
     TEARDOWN_PR_EVIDENCE_ERROR="the recorded PR does not have an all-passing completed check suite"
     return 1
   fi
@@ -650,7 +661,7 @@ EOF
     TEARDOWN_PR_EVIDENCE_ERROR="the validated live PR head is unavailable in the task repository"
     return 1
   }
-  local_work_is_in_pr_head "$live_head" || {
+  local_head_is_ancestor_of_pr_head "$live_head" || {
     TEARDOWN_PR_EVIDENCE_ERROR="local HEAD is not contained in the validated live PR head; genuinely unpublished commits may be present"
     return 1
   }
@@ -725,6 +736,21 @@ work_is_landed() {
 announce_preserved_task_branch() {
   local branch=$1 pr=${PR_URL:-the recorded PR}
   printf '%s\n' "Preserved local branch $branch: $ID was cleaned up before $pr merged. Delete the branch once that PR lands."
+}
+
+finalize_task_branch() {
+  local branch
+  branch=$(git -C "$WT" rev-parse --abbrev-ref HEAD 2>/dev/null || echo HEAD)
+  [ "$branch" != HEAD ] || return 0
+  git -C "$WT" checkout --detach -q 2>/dev/null || {
+    [ "$TEARDOWN_PRESERVE_TASK_BRANCH" = 1 ] && announce_preserved_task_branch "$branch"
+    return 0
+  }
+  if [ "$TEARDOWN_PRESERVE_TASK_BRANCH" = 1 ]; then
+    announce_preserved_task_branch "$branch"
+  else
+    git -C "$WT" branch -D "$branch" >/dev/null 2>&1 || true
+  fi
 }
 
 backlog_refresh_reminder() {
@@ -1471,16 +1497,7 @@ if [ "$BACKEND" = orca ] && [ "$KIND" != secondmate ]; then
     ORCA_PATH_MATCH_VERIFIED=1
   fi
   if [ -d "$WT" ]; then
-    branch=$(git -C "$WT" rev-parse --abbrev-ref HEAD 2>/dev/null || echo HEAD)
-    if [ "$branch" != "HEAD" ]; then
-      if git -C "$WT" checkout --detach -q 2>/dev/null; then
-        if [ "$TEARDOWN_PRESERVE_TASK_BRANCH" = 1 ]; then
-          announce_preserved_task_branch "$branch"
-        else
-          git -C "$WT" branch -D "$branch" >/dev/null 2>&1 || true
-        fi
-      fi
-    fi
+    finalize_task_branch
     rm -f "$WT/.claude/settings.local.json" "$WT/.opencode/plugins/fm-turn-end.js" \
       "$WT/.opencode/plugins/fm-busy-state.js" \
       "$WT/.fm-grok-turnend" "$WT/.fm-kimi-turnend"
@@ -1488,16 +1505,7 @@ if [ "$BACKEND" = orca ] && [ "$KIND" != secondmate ]; then
   [ -z "$T_ORCA" ] || fm_backend_kill "$BACKEND" "$T" "$(meta_value "$META" zellij_tab_id)" "fm-$ID" 2>/dev/null || true
   fm_backend_remove_worktree "$BACKEND" "$ORCA_WORKTREE_ID"
 elif [ -d "$WT" ] && [ "$KIND" != secondmate ]; then
-  branch=$(git -C "$WT" rev-parse --abbrev-ref HEAD 2>/dev/null || echo HEAD)
-  if [ "$branch" != "HEAD" ]; then
-    if git -C "$WT" checkout --detach -q 2>/dev/null; then
-      if [ "$TEARDOWN_PRESERVE_TASK_BRANCH" = 1 ]; then
-        announce_preserved_task_branch "$branch"
-      else
-        git -C "$WT" branch -D "$branch" >/dev/null 2>&1 || true
-      fi
-    fi
-  fi
+  finalize_task_branch
   # Remove our hook file so a reused pool worktree cannot fire signals for a dead task.
   rm -f "$WT/.claude/settings.local.json" "$WT/.opencode/plugins/fm-turn-end.js" \
     "$WT/.fm-grok-turnend" "$WT/.fm-kimi-turnend"

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -479,14 +479,53 @@ single_api_head_sha() {
   printf '%s\n' "$values"
 }
 
-ensure_live_pr_head_object() {
-  local path=$1 number=$2 head=$3 fetched
-  git -C "$WT" cat-file -e "$head^{commit}" 2>/dev/null && return 0
-  fetched=$(git -C "$WT" fetch --quiet --no-tags \
-    "https://github.com/$path.git" "refs/pull/$number/head" 2>/dev/null \
-    && git -C "$WT" rev-parse --verify FETCH_HEAD 2>/dev/null) || return 1
+# Fetch refs/pull/<number>/head from one source and accept it only when the
+# fetched tip is exactly the already-validated head, so a stale mirror or a
+# fork remote cannot substitute a different commit.
+pr_head_fetch_matches() {
+  local source=$1 number=$2 head=$3 fetched
+  git -C "$WT" fetch --quiet --no-tags "$source" "refs/pull/$number/head" >/dev/null 2>&1 || return 1
+  fetched=$(git -C "$WT" rev-parse --verify FETCH_HEAD 2>/dev/null) || return 1
   [ "$fetched" = "$head" ] || return 1
   git -C "$WT" cat-file -e "$head^{commit}" 2>/dev/null
+}
+
+# Try the configured origin remote first so an SSH-authenticated private repo
+# works, then fall back to the canonical GitHub URL for clones whose origin
+# points elsewhere (e.g. a fork).
+ensure_live_pr_head_object() {
+  local path=$1 number=$2 head=$3
+  git -C "$WT" cat-file -e "$head^{commit}" 2>/dev/null && return 0
+  if git -C "$WT" remote get-url origin >/dev/null 2>&1 \
+    && pr_head_fetch_matches origin "$number" "$head"; then
+    return 0
+  fi
+  pr_head_fetch_matches "https://github.com/$path.git" "$number" "$head"
+}
+
+# Parse gh-axi's PR check summary body - "<n> passed, <n> failed[, <n> skipped]
+# [, <n> pending], <n> total" - into "passed failed skipped pending total".
+# Refuses an unrecognized label, a repeated label, a malformed segment, or a
+# missing passed/failed/total so a future summary shape fails safe instead of
+# being silently misread.
+parse_check_summary_counts() {
+  awk '
+    {
+      known["passed"] = 1; known["failed"] = 1; known["skipped"] = 1
+      known["pending"] = 1; known["total"] = 1
+      n = split($0, seg, ", ")
+      for (i = 1; i <= n; i++) {
+        if (split(seg[i], f, " ") != 2) exit 1
+        if (f[1] !~ /^[0-9]+$/) exit 1
+        if (!(f[2] in known) || (f[2] in count)) exit 1
+        count[f[2]] = f[1]
+      }
+      if (!("passed" in count) || !("failed" in count) || !("total" in count)) exit 1
+      printf "%s %s %s %s %s\n", count["passed"], count["failed"], \
+        ("skipped" in count) ? count["skipped"] : 0, \
+        ("pending" in count) ? count["pending"] : 0, count["total"]
+    }
+  '
 }
 
 TEARDOWN_PRESERVE_TASK_BRANCH=0
@@ -494,7 +533,8 @@ TEARDOWN_PR_EVIDENCE_ERROR=
 pr_is_complete_green_and_mergeable() {
   local branch=$1 status_file last_status provider url path number
   local recorded_head_count recorded_head api state draft mergeable live_head
-  local checks parsed_summary parsed_count passed failed pending total
+  local checks summary_body parsed_summary parsed_count
+  local passed failed skipped pending total
   TEARDOWN_PR_EVIDENCE_ERROR=
   [ -n "$branch" ] && [ "$branch" != HEAD ] || {
     TEARDOWN_PR_EVIDENCE_ERROR="the task has no named local branch to preserve"
@@ -583,19 +623,25 @@ pr_is_complete_green_and_mergeable() {
     TEARDOWN_PR_EVIDENCE_ERROR="the live PR check result is unavailable"
     return 1
   }
-  parsed_summary=$(printf '%s\n' "$checks" | sed -n \
-    -e 's/^summary: "\([0-9][0-9]*\) passed, \([0-9][0-9]*\) failed, \([0-9][0-9]*\) total"$/\1 \2 0 \3/p' \
-    -e 's/^summary: "\([0-9][0-9]*\) passed, \([0-9][0-9]*\) failed, \([0-9][0-9]*\) pending, \([0-9][0-9]*\) total"$/\1 \2 \3 \4/p')
-  parsed_count=$(printf '%s\n' "$parsed_summary" | grep -c . || true)
-  [ "$parsed_count" -eq 1 ] || {
-    TEARDOWN_PR_EVIDENCE_ERROR="the live PR check summary is absent or ambiguous"
+  summary_body=$(printf '%s\n' "$checks" | sed -n 's/^summary: "\(.*\)"$/\1/p')
+  parsed_count=$(printf '%s\n' "$summary_body" | grep -c . || true)
+  if [ "$parsed_count" -ne 1 ]; then
+    if [ "$(printf '%s\n' "$checks" | grep -c '^checks: "' || true)" -eq 1 ]; then
+      TEARDOWN_PR_EVIDENCE_ERROR="the recorded PR has no CI checks configured, so no check suite proves it is green"
+    else
+      TEARDOWN_PR_EVIDENCE_ERROR="the live PR check summary is absent or ambiguous"
+    fi
+    return 1
+  fi
+  parsed_summary=$(printf '%s\n' "$summary_body" | parse_check_summary_counts) || {
+    TEARDOWN_PR_EVIDENCE_ERROR="the live PR check summary is not in a recognized form"
     return 1
   }
-  IFS=' ' read -r passed failed pending total <<EOF
+  IFS=' ' read -r passed failed skipped pending total <<EOF
 $parsed_summary
 EOF
-  if [ "$total" -eq 0 ] || [ "$passed" -ne "$total" ] \
-    || [ "$failed" -ne 0 ] || [ "$pending" -ne 0 ]; then
+  if [ "$total" -eq 0 ] || [ "$passed" -eq 0 ] || [ "$failed" -ne 0 ] \
+    || [ "$pending" -ne 0 ] || [ $((passed + skipped)) -ne "$total" ]; then
     TEARDOWN_PR_EVIDENCE_ERROR="the recorded PR does not have an all-passing completed check suite"
     return 1
   fi
@@ -671,6 +717,14 @@ work_is_landed() {
   local branch=$1
   pr_is_merged "$branch" && return 0
   content_in_default
+}
+
+# Record the surviving ref for the operator: the pre-merge cleanup path detaches
+# but keeps the task branch, and teardown removes the task's state files, so this
+# line is the only remaining link between the branch and the PR it backs.
+announce_preserved_task_branch() {
+  local branch=$1 pr=${PR_URL:-the recorded PR}
+  printf '%s\n' "Preserved local branch $branch: $ID was cleaned up before $pr merged. Delete the branch once that PR lands."
 }
 
 backlog_refresh_reminder() {
@@ -1409,7 +1463,8 @@ if [ -d "$WT" ] && [ "$FORCE" != "--force" ]; then
   fi
 fi
 
-# Best-effort: drop the local task branch so the shared repo does not accumulate refs.
+# Best-effort: drop the local task branch so the shared repo does not accumulate
+# refs, except on the pre-merge cleanup path, which preserves it and says so.
 if [ "$BACKEND" = orca ] && [ "$KIND" != secondmate ]; then
   if [ "$ORCA_PATH_MATCH_VERIFIED" != 1 ]; then
     require_orca_worktree_path_match_if_present "$ORCA_WORKTREE_ID" "$WT" || exit 1
@@ -1418,9 +1473,12 @@ if [ "$BACKEND" = orca ] && [ "$KIND" != secondmate ]; then
   if [ -d "$WT" ]; then
     branch=$(git -C "$WT" rev-parse --abbrev-ref HEAD 2>/dev/null || echo HEAD)
     if [ "$branch" != "HEAD" ]; then
-      if git -C "$WT" checkout --detach -q 2>/dev/null \
-        && [ "$TEARDOWN_PRESERVE_TASK_BRANCH" != 1 ]; then
-        git -C "$WT" branch -D "$branch" >/dev/null 2>&1 || true
+      if git -C "$WT" checkout --detach -q 2>/dev/null; then
+        if [ "$TEARDOWN_PRESERVE_TASK_BRANCH" = 1 ]; then
+          announce_preserved_task_branch "$branch"
+        else
+          git -C "$WT" branch -D "$branch" >/dev/null 2>&1 || true
+        fi
       fi
     fi
     rm -f "$WT/.claude/settings.local.json" "$WT/.opencode/plugins/fm-turn-end.js" \
@@ -1432,9 +1490,12 @@ if [ "$BACKEND" = orca ] && [ "$KIND" != secondmate ]; then
 elif [ -d "$WT" ] && [ "$KIND" != secondmate ]; then
   branch=$(git -C "$WT" rev-parse --abbrev-ref HEAD 2>/dev/null || echo HEAD)
   if [ "$branch" != "HEAD" ]; then
-    if git -C "$WT" checkout --detach -q 2>/dev/null \
-      && [ "$TEARDOWN_PRESERVE_TASK_BRANCH" != 1 ]; then
-      git -C "$WT" branch -D "$branch" >/dev/null 2>&1 || true
+    if git -C "$WT" checkout --detach -q 2>/dev/null; then
+      if [ "$TEARDOWN_PRESERVE_TASK_BRANCH" = 1 ]; then
+        announce_preserved_task_branch "$branch"
+      else
+        git -C "$WT" branch -D "$branch" >/dev/null 2>&1 || true
+      fi
     fi
   fi
   # Remove our hook file so a reused pool worktree cannot fire signals for a dead task.

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -4,15 +4,23 @@
 # clear volatile state, refresh/prune the project's clone for PR-based ship
 # tasks, then print a backlog-refresh reminder for ship and scout teardowns
 # (a secondmate teardown prints none, since secondmates are not backlog items).
-# REFUSES if the worktree holds work that has not LANDED, because cleanup
-# hard-resets/removes the worktree and kills its processes. Work has landed when it is
-# reachable from any remote-tracking branch (a fork counts as a remote, so
-# upstream-contribution PRs pushed to a fork satisfy this in any mode), OR - for a
-# normal ship task whose commits are not so reachable - when its PR is merged and
-# GitHub reports a PR head that contains the current local work, or its content is
-# already present in the up-to-date default branch. This recognizes the common
-# squash-merge-then-delete-branch flow, where the branch's own commits live nowhere
-# on a remote yet the change is fully in main.
+# REFUSES if cleanup would discard work without a durable recovery path, because
+# cleanup hard-resets/removes the worktree and kills its processes. A PR-based ship
+# may be cleaned before merge only when its last status is the exact completion for
+# its canonically recorded PR, GitHub reports that same open non-draft PR green and
+# mergeable, the live head exactly matches the recorded PR head, and repository
+# evidence proves the local HEAD is contained in that PR head. That path detaches
+# but preserves the local task branch. Missing, duplicated, stale, contradictory,
+# or unavailable completion, PR identity, check, mergeability, or head evidence
+# refuses cleanup. A red, pending, or conflicted PR therefore never qualifies.
+#
+# Otherwise PR-based work has landed only when its PR is merged and GitHub reports
+# a PR head that contains the current local work, or its content is already present
+# in the up-to-date default branch. This recognizes the common squash-merge-then-
+# delete-branch flow, where the branch's own commits live nowhere on a remote yet
+# the change is fully in main. Merely reaching a remote-tracking branch is not
+# enough for a pre-merge PR-based ship. local-only work keeps its separate remote
+# or local-default reachability contract below.
 # The PR itself is resolved from the task's recorded pr= when present, or - when
 # no pr= was ever recorded (e.g. a yolo-authorized merge on a repo with no PR CI,
 # where the usual "checks green" fm-pr-check.sh trigger never fires) - by looking
@@ -443,13 +451,173 @@ $unpushed
 EOF
 }
 
+local_work_is_in_pr_head() {
+  local pr_head=$1 current
+  current=$(git -C "$WT" rev-parse --verify HEAD 2>/dev/null) || return 1
+  git -C "$WT" merge-base --is-ancestor "$current" "$pr_head" 2>/dev/null \
+    || unpushed_patches_are_in_pr_head "$pr_head"
+}
+
+single_top_level_api_field() {
+  local text=$1 key=$2 values count
+  values=$(printf '%s\n' "$text" | awk -v prefix="$key: " \
+    'index($0, prefix) == 1 { print substr($0, length(prefix) + 1) }') || return 1
+  count=$(printf '%s\n' "$values" | grep -c . || true)
+  [ "$count" -eq 1 ] || return 1
+  printf '%s\n' "$values"
+}
+
+single_api_head_sha() {
+  local text=$1 values count
+  values=$(printf '%s\n' "$text" | awk '
+    $0 == "head:" { in_head = 1; next }
+    in_head && $0 !~ /^ / { in_head = 0 }
+    in_head && /^  sha: / { print substr($0, 8) }
+  ') || return 1
+  count=$(printf '%s\n' "$values" | grep -c . || true)
+  [ "$count" -eq 1 ] || return 1
+  printf '%s\n' "$values"
+}
+
+ensure_live_pr_head_object() {
+  local path=$1 number=$2 head=$3 fetched
+  git -C "$WT" cat-file -e "$head^{commit}" 2>/dev/null && return 0
+  fetched=$(git -C "$WT" fetch --quiet --no-tags \
+    "https://github.com/$path.git" "refs/pull/$number/head" 2>/dev/null \
+    && git -C "$WT" rev-parse --verify FETCH_HEAD 2>/dev/null) || return 1
+  [ "$fetched" = "$head" ] || return 1
+  git -C "$WT" cat-file -e "$head^{commit}" 2>/dev/null
+}
+
+TEARDOWN_PRESERVE_TASK_BRANCH=0
+TEARDOWN_PR_EVIDENCE_ERROR=
+pr_is_complete_green_and_mergeable() {
+  local branch=$1 status_file last_status provider url path number
+  local recorded_head_count recorded_head api state draft mergeable live_head
+  local checks parsed_summary parsed_count passed failed pending total
+  TEARDOWN_PR_EVIDENCE_ERROR=
+  [ -n "$branch" ] && [ "$branch" != HEAD ] || {
+    TEARDOWN_PR_EVIDENCE_ERROR="the task has no named local branch to preserve"
+    return 1
+  }
+  if ! fm_pr_metadata_identity_parse "$META"; then
+    TEARDOWN_PR_EVIDENCE_ERROR="the task has no single canonical recorded PR identity"
+    return 1
+  fi
+  provider=$FM_PR_META_PROVIDER
+  url=$FM_PR_META_URL
+  path=$FM_PR_META_PATH
+  number=$FM_PR_META_NUMBER
+  [ "$provider" = github ] || {
+    TEARDOWN_PR_EVIDENCE_ERROR="green-and-mergeable cleanup evidence is unavailable for provider $provider"
+    return 1
+  }
+
+  status_file="$STATE/$ID.status"
+  if [ ! -f "$status_file" ] || [ -L "$status_file" ] \
+    || [ "$(fm_pr_file_link_count "$status_file")" != 1 ]; then
+    TEARDOWN_PR_EVIDENCE_ERROR="the task completion record is absent or unsafe"
+    return 1
+  fi
+  last_status=$(awk 'NF { line = $0 } END { print line }' "$status_file" 2>/dev/null) || {
+    TEARDOWN_PR_EVIDENCE_ERROR="the task completion record is unreadable"
+    return 1
+  }
+  case "$last_status" in
+    "done: PR $url"|"done: PR $url checks green") ;;
+    *)
+      TEARDOWN_PR_EVIDENCE_ERROR="the latest task event is not an unambiguous completion for the recorded PR"
+      return 1
+      ;;
+  esac
+
+  recorded_head_count=$(grep -c '^pr_head=' "$META" 2>/dev/null || true)
+  [ "$recorded_head_count" -eq 1 ] || {
+    TEARDOWN_PR_EVIDENCE_ERROR="the recorded PR head is absent or ambiguous"
+    return 1
+  }
+  recorded_head=$(grep '^pr_head=' "$META" | cut -d= -f2-)
+  fm_pr_head_valid "$recorded_head" || {
+    TEARDOWN_PR_EVIDENCE_ERROR="the recorded PR head is invalid"
+    return 1
+  }
+
+  api=$(gh-axi api "/repos/$path/pulls/$number" 2>/dev/null) || {
+    TEARDOWN_PR_EVIDENCE_ERROR="the live PR identity, mergeability, or head is unavailable"
+    return 1
+  }
+  state=$(single_top_level_api_field "$api" state) || {
+    TEARDOWN_PR_EVIDENCE_ERROR="the live PR state is absent or ambiguous"
+    return 1
+  }
+  draft=$(single_top_level_api_field "$api" draft) || {
+    TEARDOWN_PR_EVIDENCE_ERROR="the live PR draft state is absent or ambiguous"
+    return 1
+  }
+  mergeable=$(single_top_level_api_field "$api" mergeable) || {
+    TEARDOWN_PR_EVIDENCE_ERROR="the live PR mergeability is absent or ambiguous"
+    return 1
+  }
+  live_head=$(single_api_head_sha "$api") || {
+    TEARDOWN_PR_EVIDENCE_ERROR="the live PR head is absent or ambiguous"
+    return 1
+  }
+  [ "$state" = open ] || {
+    TEARDOWN_PR_EVIDENCE_ERROR="the recorded PR is not open"
+    return 1
+  }
+  [ "$draft" = false ] || {
+    TEARDOWN_PR_EVIDENCE_ERROR="the recorded PR is still a draft"
+    return 1
+  }
+  [ "$mergeable" = true ] || {
+    TEARDOWN_PR_EVIDENCE_ERROR="the recorded PR is conflicted or not provably mergeable"
+    return 1
+  }
+  fm_pr_head_valid "$live_head" && [ "$live_head" = "$recorded_head" ] || {
+    TEARDOWN_PR_EVIDENCE_ERROR="the live PR head does not exactly match the recorded PR head"
+    return 1
+  }
+
+  checks=$(gh-axi pr checks "$number" --repo "$path" 2>/dev/null) || {
+    TEARDOWN_PR_EVIDENCE_ERROR="the live PR check result is unavailable"
+    return 1
+  }
+  parsed_summary=$(printf '%s\n' "$checks" | sed -n \
+    -e 's/^summary: "\([0-9][0-9]*\) passed, \([0-9][0-9]*\) failed, \([0-9][0-9]*\) total"$/\1 \2 0 \3/p' \
+    -e 's/^summary: "\([0-9][0-9]*\) passed, \([0-9][0-9]*\) failed, \([0-9][0-9]*\) pending, \([0-9][0-9]*\) total"$/\1 \2 \3 \4/p')
+  parsed_count=$(printf '%s\n' "$parsed_summary" | grep -c . || true)
+  [ "$parsed_count" -eq 1 ] || {
+    TEARDOWN_PR_EVIDENCE_ERROR="the live PR check summary is absent or ambiguous"
+    return 1
+  }
+  IFS=' ' read -r passed failed pending total <<EOF
+$parsed_summary
+EOF
+  if [ "$total" -eq 0 ] || [ "$passed" -ne "$total" ] \
+    || [ "$failed" -ne 0 ] || [ "$pending" -ne 0 ]; then
+    TEARDOWN_PR_EVIDENCE_ERROR="the recorded PR does not have an all-passing completed check suite"
+    return 1
+  fi
+
+  ensure_live_pr_head_object "$path" "$number" "$live_head" || {
+    TEARDOWN_PR_EVIDENCE_ERROR="the validated live PR head is unavailable in the task repository"
+    return 1
+  }
+  local_work_is_in_pr_head "$live_head" || {
+    TEARDOWN_PR_EVIDENCE_ERROR="local HEAD is not contained in the validated live PR head; genuinely unpublished commits may be present"
+    return 1
+  }
+  TEARDOWN_PRESERVE_TASK_BRANCH=1
+}
+
 # Is the worktree's PR merged for local work contained in that PR? Resolves the
 # PR from the recorded pr= URL first, then from the branch name, and asks GitHub
 # for both the PR state and head. Returns non-zero when the PR is not merged, the
 # current work is not contained in the PR head, no PR is found, or any gh error
 # occurs - the caller then falls back to the content check.
 pr_is_merged() {
-  local branch=$1 target view state head current
+  local branch=$1 target view state head
   if [ -n "$PR_URL" ]; then
     target=$PR_URL
   else
@@ -466,9 +634,7 @@ pr_is_merged() {
   esac
   [ -n "$head" ] || return 1
   ensure_commit_object "$target" "$head" || return 1
-  current=$(git -C "$WT" rev-parse --verify HEAD 2>/dev/null) || return 1
-  git -C "$WT" merge-base --is-ancestor "$current" "$head" 2>/dev/null && return 0
-  unpushed_patches_are_in_pr_head "$head"
+  local_work_is_in_pr_head "$head"
 }
 
 # Is the branch's content already present in the up-to-date default branch? Fetches
@@ -780,42 +946,54 @@ validate_worktree_teardown_safety() {
   fi
   unpushed=$(printf '%s\n' "$unpushed_raw" | head -5)
 
-  if [ -n "$unpushed" ] && [ "$MODE" = local-only ]; then
-    DEFAULT=$(default_branch) || { echo "REFUSED: cannot determine default branch for $PROJ; expected origin/HEAD, main, or master." >&2; return 1; }
-    if ! unmerged_raw=$(git -C "$WT" log --oneline HEAD --not "$DEFAULT" -- 2>/dev/null); then
-      if worktree_safety_blocked_by_lock "commits not on $DEFAULT"; then
-        return "$TEARDOWN_WORKTREE_SAFETY_LOCK_BLOCKED"
+  if [ "$MODE" = local-only ]; then
+    if [ -n "$unpushed" ]; then
+      DEFAULT=$(default_branch) || { echo "REFUSED: cannot determine default branch for $PROJ; expected origin/HEAD, main, or master." >&2; return 1; }
+      if ! unmerged_raw=$(git -C "$WT" log --oneline HEAD --not "$DEFAULT" -- 2>/dev/null); then
+        if worktree_safety_blocked_by_lock "commits not on $DEFAULT"; then
+          return "$TEARDOWN_WORKTREE_SAFETY_LOCK_BLOCKED"
+        fi
+        echo "REFUSED: cannot inspect worktree $WT for commits not on $DEFAULT." >&2
+        echo "Restore the git index state, or get the captain's explicit OK to discard, then --force." >&2
+        return 1
       fi
-      echo "REFUSED: cannot inspect worktree $WT for commits not on $DEFAULT." >&2
-      echo "Restore the git index state, or get the captain's explicit OK to discard, then --force." >&2
+      unmerged=$(printf '%s\n' "$unmerged_raw" | head -5)
+      if [ -n "$dirty" ] || [ -n "$unmerged" ]; then
+        echo "REFUSED: local-only worktree $WT has work not yet merged into $DEFAULT and not on any remote." >&2
+        [ -n "$dirty" ] && echo "uncommitted changes present" >&2
+        [ -n "$unmerged" ] && printf 'commits not yet on %s:\n%s\n' "$DEFAULT" "$unmerged" >&2
+        echo "Merge the branch into local $DEFAULT first (bin/fm-merge-local.sh after the captain approves), or push to a fork/remote, or get the captain's explicit OK to discard, then --force." >&2
+        return 1
+      fi
+    elif [ -n "$dirty" ]; then
+      echo "REFUSED: local-only worktree $WT has uncommitted changes." >&2
+      echo "uncommitted changes present" >&2
+      echo "Commit them (or get the captain's explicit OK to discard, then --force)." >&2
       return 1
     fi
-    unmerged=$(printf '%s\n' "$unmerged_raw" | head -5)
-    if [ -n "$dirty" ] || [ -n "$unmerged" ]; then
-      echo "REFUSED: local-only worktree $WT has work not yet merged into $DEFAULT and not on any remote." >&2
-      [ -n "$dirty" ] && echo "uncommitted changes present" >&2
-      [ -n "$unmerged" ] && printf 'commits not yet on %s:\n%s\n' "$DEFAULT" "$unmerged" >&2
-      echo "Merge the branch into local $DEFAULT first (bin/fm-merge-local.sh after the captain approves), or push to a fork/remote, or get the captain's explicit OK to discard, then --force." >&2
-      return 1
-    fi
-  elif [ -n "$dirty" ]; then
+    return 0
+  fi
+
+  if [ -n "$dirty" ]; then
     echo "REFUSED: worktree $WT has uncommitted changes." >&2
     echo "uncommitted changes present" >&2
     echo "Commit them (or get the captain's explicit OK to discard, then --force)." >&2
     return 1
-  elif [ -n "$unpushed" ]; then
-    branch=${TEARDOWN_WORKTREE_BRANCH_FOR_SAFETY:-}
-    if [ -z "$branch" ]; then
-      branch=$(git -C "$WT" rev-parse --abbrev-ref HEAD 2>/dev/null || echo HEAD)
-      TEARDOWN_WORKTREE_BRANCH_FOR_SAFETY=$branch
-    fi
-    if ! work_is_landed "$branch"; then
-      echo "REFUSED: worktree $WT has work not on any remote and not landed." >&2
-      printf 'unpushed commits:\n%s\n' "$unpushed" >&2
-      echo "Push the branch, land its PR, or get the captain's explicit OK to discard, then --force." >&2
-      return 1
-    fi
   fi
+
+  branch=${TEARDOWN_WORKTREE_BRANCH_FOR_SAFETY:-}
+  if [ -z "$branch" ]; then
+    branch=$(git -C "$WT" rev-parse --abbrev-ref HEAD 2>/dev/null || echo HEAD)
+    TEARDOWN_WORKTREE_BRANCH_FOR_SAFETY=$branch
+  fi
+  work_is_landed "$branch" && return 0
+  pr_is_complete_green_and_mergeable "$branch" && return 0
+
+  echo "REFUSED: PR-based worktree $WT is neither landed nor backed by complete green-and-mergeable cleanup evidence." >&2
+  [ -z "$TEARDOWN_PR_EVIDENCE_ERROR" ] || printf 'evidence: %s\n' "$TEARDOWN_PR_EVIDENCE_ERROR" >&2
+  [ -z "$unpushed" ] || printf 'commits absent from configured remote-tracking refs:\n%s\n' "$unpushed" >&2
+  echo "Resolve the cited evidence, merge the PR, or get the captain's explicit OK to discard, then --force." >&2
+  return 1
 }
 
 require_orca_worktree_path_match() {
@@ -1240,7 +1418,8 @@ if [ "$BACKEND" = orca ] && [ "$KIND" != secondmate ]; then
   if [ -d "$WT" ]; then
     branch=$(git -C "$WT" rev-parse --abbrev-ref HEAD 2>/dev/null || echo HEAD)
     if [ "$branch" != "HEAD" ]; then
-      if git -C "$WT" checkout --detach -q 2>/dev/null; then
+      if git -C "$WT" checkout --detach -q 2>/dev/null \
+        && [ "$TEARDOWN_PRESERVE_TASK_BRANCH" != 1 ]; then
         git -C "$WT" branch -D "$branch" >/dev/null 2>&1 || true
       fi
     fi
@@ -1253,7 +1432,8 @@ if [ "$BACKEND" = orca ] && [ "$KIND" != secondmate ]; then
 elif [ -d "$WT" ] && [ "$KIND" != secondmate ]; then
   branch=$(git -C "$WT" rev-parse --abbrev-ref HEAD 2>/dev/null || echo HEAD)
   if [ "$branch" != "HEAD" ]; then
-    if git -C "$WT" checkout --detach -q 2>/dev/null; then
+    if git -C "$WT" checkout --detach -q 2>/dev/null \
+      && [ "$TEARDOWN_PRESERVE_TASK_BRANCH" != 1 ]; then
       git -C "$WT" branch -D "$branch" >/dev/null 2>&1 || true
     fi
   fi

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -213,8 +213,8 @@ For target project repos shipped through their own no-mistakes pipeline, commits
 The firstmate repo itself is the exception: its `.no-mistakes/` directory is local state, stays gitignored, and is rejected by CI if tracked.
 PR-based task merges go through `bin/fm-pr-merge.sh`, which records `pr=` and any available `pr_head=` through `bin/fm-pr-check.sh` before calling `gh-axi pr merge`.
 The helper requires a full `https://github.com/<owner>/<repo>/pull/<n>` URL, invokes `gh-axi pr merge <n> --repo <owner>/<repo>`, defaults to `--squash`, preserves explicit merge-method flags, and rejects malformed URLs or repo override flags before recording merge state; a well-formed GitLab merge request URL (see [docs/gitlab-merge-watch.md](gitlab-merge-watch.md)) is refused too, explicitly, rather than sent to the wrong forge.
-Teardown is fail-closed for ship worktrees: dirty worktrees refuse, and committed work must be landed before the worktree is returned.
-[`bin/fm-teardown.sh`](../bin/fm-teardown.sh)'s header owns the landed-work proofs, PR-discovery fallback, and stale-lock recovery procedure.
+Teardown is fail-closed for ship worktrees: dirty worktrees refuse, and committed work needs either a landed-work proof or the narrow pre-merge recovery proof before the worktree is returned.
+[`bin/fm-teardown.sh`](../bin/fm-teardown.sh)'s header owns those proofs, the PR-discovery fallback, branch-preservation behavior, and stale-lock recovery procedure.
 
 ## Optional X mode
 

--- a/docs/orca-backend.md
+++ b/docs/orca-backend.md
@@ -30,7 +30,7 @@ Enter and Ctrl-C are supported; Escape is not.
 
 Each task has one Orca-managed git worktree and one Orca terminal.
 `fm-spawn.sh` does not call Treehouse for Orca tasks.
-The normal isolation and unlanded-work refusal rules still apply.
+The normal isolation and unsafe-work refusal rules still apply.
 
 ```text
 backend=orca
@@ -56,7 +56,7 @@ Grok alone retains its isolated rendered-tail fallback.
 
 Cleanup keeps all shared Firstmate safety checks.
 A scout still requires its report and completed decision inventory.
-A ship still refuses dirty or unlanded work.
+A ship still refuses dirty work or committed work without an accepted teardown recovery proof.
 Before release, cleanup resolves the recorded Orca worktree id and verifies its path matches the recorded worktree path.
 A missing, unreadable, or mismatched identity preserves metadata and stops rather than deleting anything.
 After those checks, Firstmate closes the exact terminal and releases the exact worktree with Orca's worktree command.

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -88,7 +88,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-pr-check.sh`         | Record validated `pr=` and `pr_head=` values, then atomically arm a static merge poll |
 | `fm-pr-merge.sh`         | Record PR metadata, then merge a task's canonical full GitHub URL                    |
 | `fm-promote.sh`          | Promote a scout task in place to a protected ship task                               |
-| `fm-teardown.sh`         | Fail-closed teardown: return landed ship worktrees, require completed scout deliverables, retire secondmate homes |
+| `fm-teardown.sh`         | Fail-closed teardown: return safely recoverable ship worktrees, require completed scout deliverables, retire secondmate homes |
 | `fm-harness.sh`          | Detect the running harness and resolve crew or secondmate harness, model, and effort |
 | `fm-lock.sh`             | Per-home firstmate session lock                                                      |
 | `fm-x-lib.sh`            | Shared X-mode config, relay, and reply-threading helpers                             |

--- a/tests/fm-teardown.test.sh
+++ b/tests/fm-teardown.test.sh
@@ -1,11 +1,12 @@
 #!/usr/bin/env bash
 # Tests for bin/fm-teardown.sh's landed-work safety and stale-lock recovery.
 #
-# The check refuses to tear down a worktree whose work has not LANDED, because
-# treehouse return hard-resets the worktree. "Landed" means reachable from a remote
-# OR - for a normal ship task whose commits are not so reachable - its PR is merged
-# and GitHub reports a PR head that contains the current local work, or its content
-# is already in the up-to-date default branch.
+# The check refuses to tear down a worktree without a durable recovery path because
+# treehouse return hard-resets the worktree. A PR-based ship can be cleaned before
+# merge only with exact completion, canonical PR identity, all-passing checks,
+# unambiguous mergeability, exact recorded/live head identity, and repository proof
+# that the local work is contained in that head; this path preserves the branch.
+# Otherwise its PR must be merged or its content present in the default branch.
 #
 # Covers three fixes:
 #   - local-only fork-remote: a fork IS a remote, so fork-pushed upstream-
@@ -24,7 +25,7 @@
 #   (a) local-only + HEAD on a fork remote-tracking branch     -> ALLOW  (fork fix)
 #   (b) local-only + truly unpushed work (no remote, not main) -> REFUSE (safety)
 #   (c) local-only + merged into local main, no remote         -> ALLOW  (no regression)
-#   (d) no-mistakes + HEAD on origin remote-tracking branch    -> ALLOW  (no regression)
+#   (d) no-mistakes + completed green mergeable open PR       -> ALLOW + preserve branch
 #   (e) no-mistakes + unpushed, no PR, content not in default  -> REFUSE (safety)
 #   (f) local-only + truly unpushed + --force                  -> ALLOW  (escape hatch)
 #   (g) no-mistakes + squash-merged PR, exact PR head          -> ALLOW  (squash fix)
@@ -38,6 +39,11 @@
 #   (o) fm-pr-check rerun after HEAD moved                      -> no stale pr_head
 #   (p) fm-pr-check when local HEAD lags                        -> record remote PR head
 #   (q) no-mistakes + NO pr= recorded, PR discovered by branch  -> ALLOW  (yolo/no-CI merge)
+#   (z) open PR + failed checks                                  -> REFUSE (red)
+#   (aa) open PR + merge conflict                                -> REFUSE (conflict)
+#   (ab) green PR + later local commit                           -> REFUSE (unpublished)
+#   (ac) absent/ambiguous completion, check, mergeability,
+#        identity, or head evidence                              -> REFUSE (evidence)
 #
 # Also covers backlog teardown-lock-race: a git index.lock left in the worktree by a
 # killed crew process (bin/fm-teardown.sh's teardown_treehouse_return).
@@ -248,6 +254,51 @@ append_pr_meta_for_current_head() {
 append_pr_meta_url() {
   local case_dir=$1
   printf '%s\n' 'pr=https://github.com/example/repo/pull/7' >> "$case_dir/state/task-x1.meta"
+}
+
+write_pr_completion() {
+  local case_dir=$1 suffix=${2:- checks green}
+  printf 'done: PR https://github.com/example/repo/pull/7%s\n' "$suffix" \
+    > "$case_dir/state/task-x1.status"
+}
+
+# Supply hermetic live evidence for the pre-merge cleanup path. The API and
+# checks files can be edited by refusal cases to make one field missing,
+# duplicated, stale, red, pending, or conflicting without changing the others.
+add_gh_pr_open_evidence() {
+  local case_dir=$1 head=$2 mergeable=${3:-true} summary=${4:-3 passed, 0 failed, 3 total}
+  cat > "$case_dir/gh-api" <<EOF
+state: open
+draft: false
+head:
+  sha: $head
+mergeable: $mergeable
+EOF
+  printf 'summary: "%s"\n' "$summary" > "$case_dir/gh-checks"
+  cat > "$case_dir/fakebin/gh-axi" <<'SH'
+#!/usr/bin/env bash
+set -u
+fixture=$(CDPATH='' cd -- "$(dirname "$0")/.." && pwd -P)
+case "${1:-} ${2:-}" in
+  "api /repos/example/repo/pulls/7") cat "$fixture/gh-api" ;;
+  "pr checks") cat "$fixture/gh-checks" ;;
+  "pr list") printf '%s\n' "count: 0 (showing first 0)" "pull_requests[]: []" ;;
+  *) exit 1 ;;
+esac
+SH
+  chmod +x "$case_dir/fakebin/gh-axi"
+}
+
+setup_open_green_case() {
+  local name=$1 case_dir head
+  case_dir=$(make_case "$name")
+  write_meta "$case_dir" no-mistakes ship
+  wt_commit_file "$case_dir" feature.txt "$name" "implement $name"
+  head=$(git -C "$case_dir/wt" rev-parse HEAD)
+  append_pr_meta_for_current_head "$case_dir"
+  write_pr_completion "$case_dir"
+  add_gh_pr_open_evidence "$case_dir" "$head"
+  printf '%s\t%s\n' "$case_dir" "$head"
 }
 
 commit_tree_from_wt_head() {
@@ -589,25 +640,28 @@ test_local_only_merged_to_local_main_allows() {
   pass "local-only worktree with work merged into local main is torn down (no regression)"
 }
 
-test_no_mistakes_origin_remote_allows() {
-  local case_dir rc
-  case_dir=$(make_case nm-origin)
-  write_meta "$case_dir" no-mistakes ship
-  wt_commit "$case_dir" "shippable work"
-  # Push the task branch to origin and fetch so the worktree sees it.
-  git -C "$case_dir/wt" push -q origin fm/task-x1
-  git -C "$case_dir/project" fetch -q origin
+test_completed_green_mergeable_pr_allows_and_preserves_branch() {
+  local setup case_dir head rc kept_head
+  setup=$(setup_open_green_case green-mergeable)
+  IFS=$'\t' read -r case_dir head <<EOF
+$setup
+EOF
 
   set +e
   run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr"
   rc=$?
   set -e
 
-  expect_code 0 "$rc" "nm-origin: teardown should succeed when HEAD is on origin"
-  ! grep -q REFUSED "$case_dir/stderr" || fail "nm-origin: teardown printed a REFUSED line"
+  expect_code 0 "$rc" "green-mergeable: completed green mergeable PR should allow cleanup"
+  ! grep -q REFUSED "$case_dir/stderr" || fail "green-mergeable: teardown printed a REFUSED line"
+  assert_not_contains "$(cat "$case_dir/stderr")" "land its PR" \
+    "green-mergeable: teardown retained the obsolete land-its-PR refusal"
+  kept_head=$(git -C "$case_dir/project" rev-parse refs/heads/fm/task-x1 2>/dev/null) \
+    || fail "green-mergeable: cleanup deleted the task branch"
+  [ "$kept_head" = "$head" ] || fail "green-mergeable: preserved branch moved from the validated PR head"
   grep -F 'blockers are gone and date is due' "$case_dir/stdout" >/dev/null \
-    || fail "nm-origin: teardown manual prompt did not preserve date-gate check"
-  pass "no-mistakes worktree with HEAD on origin is torn down (no regression)"
+    || fail "green-mergeable: teardown manual prompt did not preserve date-gate check"
+  pass "completed green mergeable PR is cleaned before merge with its local branch preserved"
 }
 
 test_no_mistakes_truly_unpushed_refuses() {
@@ -625,7 +679,194 @@ test_no_mistakes_truly_unpushed_refuses() {
 
   expect_code 1 "$rc" "nm-unpushed: teardown should refuse"
   grep -q REFUSED "$case_dir/stderr" || fail "nm-unpushed: no REFUSED line in stderr"
+  assert_not_contains "$(cat "$case_dir/stderr")" "land its PR" \
+    "nm-unpushed: refusal used the obsolete land-its-PR diagnosis"
   pass "no-mistakes worktree with genuinely unlanded work is refused (safety preserved)"
+}
+
+test_red_pr_refuses_cleanup() {
+  local setup case_dir head rc
+  setup=$(setup_open_green_case red-pr)
+  IFS=$'\t' read -r case_dir head <<EOF
+$setup
+EOF
+  printf '%s\n' 'summary: "2 passed, 1 failed, 3 total"' > "$case_dir/gh-checks"
+  git -C "$case_dir/wt" push -q origin fm/task-x1
+  git -C "$case_dir/project" fetch -q origin
+
+  set +e
+  run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 1 "$rc" "red-pr: teardown should refuse failed checks"
+  assert_grep "all-passing completed check suite" "$case_dir/stderr" \
+    "red-pr: refusal did not identify the red PR"
+  assert_present "$case_dir/state/task-x1.meta" "red-pr: cleanup removed task metadata"
+  [ "$(git -C "$case_dir/project" rev-parse refs/heads/fm/task-x1)" = "$head" ] \
+    || fail "red-pr: refusal changed the task branch"
+  pass "red PR refuses cleanup and preserves all task recovery state"
+}
+
+test_pending_pr_refuses_cleanup() {
+  local setup case_dir head rc
+  setup=$(setup_open_green_case pending-pr)
+  IFS=$'\t' read -r case_dir head <<EOF
+$setup
+EOF
+  printf '%s\n' 'summary: "2 passed, 0 failed, 1 pending, 3 total"' > "$case_dir/gh-checks"
+
+  set +e
+  run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 1 "$rc" "pending-pr: teardown should refuse pending checks"
+  assert_grep "all-passing completed check suite" "$case_dir/stderr" \
+    "pending-pr: refusal did not identify incomplete checks"
+  pass "pending PR checks refuse cleanup"
+}
+
+test_conflicted_pr_refuses_cleanup() {
+  local setup case_dir head rc
+  setup=$(setup_open_green_case conflicted-pr)
+  IFS=$'\t' read -r case_dir head <<EOF
+$setup
+EOF
+  sed -i.bak 's/^mergeable: true$/mergeable: false/' "$case_dir/gh-api"
+  rm -f "$case_dir/gh-api.bak"
+  git -C "$case_dir/wt" push -q origin fm/task-x1
+  git -C "$case_dir/project" fetch -q origin
+
+  set +e
+  run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 1 "$rc" "conflicted-pr: teardown should refuse a conflict"
+  assert_grep "conflicted or not provably mergeable" "$case_dir/stderr" \
+    "conflicted-pr: refusal did not identify mergeability"
+  assert_present "$case_dir/state/task-x1.meta" "conflicted-pr: cleanup removed task metadata"
+  [ "$(git -C "$case_dir/project" rev-parse refs/heads/fm/task-x1)" = "$head" ] \
+    || fail "conflicted-pr: refusal changed the task branch"
+  pass "conflicted PR refuses cleanup and preserves all task recovery state"
+}
+
+test_green_pr_with_genuinely_unpublished_commit_refuses() {
+  local setup case_dir pr_head local_head rc
+  setup=$(setup_open_green_case unpublished-after-pr)
+  IFS=$'\t' read -r case_dir pr_head <<EOF
+$setup
+EOF
+  wt_commit_file "$case_dir" local-only.txt unpublished "later unpublished work"
+  local_head=$(git -C "$case_dir/wt" rev-parse HEAD)
+
+  set +e
+  run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 1 "$rc" "unpublished-after-pr: teardown should refuse local work beyond the PR head"
+  assert_grep "genuinely unpublished commits may be present" "$case_dir/stderr" \
+    "unpublished-after-pr: refusal did not distinguish unpublished work"
+  assert_not_contains "$(cat "$case_dir/stderr")" "land its PR" \
+    "unpublished-after-pr: refusal used the obsolete land-its-PR diagnosis"
+  [ "$local_head" != "$pr_head" ] || fail "unpublished-after-pr: test setup did not advance HEAD"
+  [ "$(git -C "$case_dir/project" rev-parse refs/heads/fm/task-x1)" = "$local_head" ] \
+    || fail "unpublished-after-pr: refusal changed the unpublished branch"
+  pass "green PR does not authorize cleanup of a genuinely unpublished later commit"
+}
+
+test_absent_and_ambiguous_pr_cleanup_evidence_refuses() {
+  local variant setup case_dir head rc expected tmp
+  for variant in \
+    completion-absent completion-ambiguous \
+    checks-absent checks-ambiguous \
+    mergeability-absent mergeability-ambiguous \
+    identity-absent identity-ambiguous \
+    recorded-head-absent recorded-head-ambiguous \
+    live-head-absent live-head-ambiguous; do
+    setup=$(setup_open_green_case "evidence-$variant")
+    IFS=$'\t' read -r case_dir head <<EOF
+$setup
+EOF
+    case "$variant" in
+      completion-absent)
+        rm -f "$case_dir/state/task-x1.status"
+        expected="completion record is absent"
+        ;;
+      completion-ambiguous)
+        printf '%s\n' 'working: completion was reopened' >> "$case_dir/state/task-x1.status"
+        expected="not an unambiguous completion"
+        ;;
+      checks-absent)
+        : > "$case_dir/gh-checks"
+        expected="check summary is absent or ambiguous"
+        ;;
+      checks-ambiguous)
+        cat "$case_dir/gh-checks" >> "$case_dir/gh-checks.duplicate"
+        cat "$case_dir/gh-checks.duplicate" >> "$case_dir/gh-checks"
+        expected="check summary is absent or ambiguous"
+        ;;
+      mergeability-absent)
+        tmp="$case_dir/gh-api.tmp"
+        grep -v '^mergeable:' "$case_dir/gh-api" > "$tmp"
+        mv "$tmp" "$case_dir/gh-api"
+        expected="mergeability is absent or ambiguous"
+        ;;
+      mergeability-ambiguous)
+        printf '%s\n' 'mergeable: false' >> "$case_dir/gh-api"
+        expected="mergeability is absent or ambiguous"
+        ;;
+      identity-absent)
+        tmp="$case_dir/state/task-x1.meta.tmp"
+        grep -vE '^(pr|pr_head)=' "$case_dir/state/task-x1.meta" > "$tmp"
+        mv "$tmp" "$case_dir/state/task-x1.meta"
+        expected="no single canonical recorded PR identity"
+        ;;
+      identity-ambiguous)
+        printf '%s\n' 'pr=https://github.com/example/repo/pull/7' \
+          >> "$case_dir/state/task-x1.meta"
+        expected="no single canonical recorded PR identity"
+        ;;
+      recorded-head-absent)
+        tmp="$case_dir/state/task-x1.meta.tmp"
+        grep -v '^pr_head=' "$case_dir/state/task-x1.meta" > "$tmp"
+        mv "$tmp" "$case_dir/state/task-x1.meta"
+        expected="recorded PR head is absent or ambiguous"
+        ;;
+      recorded-head-ambiguous)
+        printf 'pr_head=%s\n' "$head" >> "$case_dir/state/task-x1.meta"
+        expected="recorded PR head is absent or ambiguous"
+        ;;
+      live-head-absent)
+        tmp="$case_dir/gh-api.tmp"
+        grep -v '^  sha:' "$case_dir/gh-api" > "$tmp"
+        mv "$tmp" "$case_dir/gh-api"
+        expected="live PR head is absent or ambiguous"
+        ;;
+      live-head-ambiguous)
+        tmp="$case_dir/gh-api.tmp"
+        awk '/^  sha:/ { print; print; next } { print }' "$case_dir/gh-api" > "$tmp"
+        mv "$tmp" "$case_dir/gh-api"
+        expected="live PR head is absent or ambiguous"
+        ;;
+    esac
+
+    set +e
+    run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr"
+    rc=$?
+    set -e
+
+    expect_code 1 "$rc" "evidence-$variant: teardown should refuse"
+    assert_grep "$expected" "$case_dir/stderr" \
+      "evidence-$variant: refusal did not identify the missing or ambiguous evidence"
+    assert_present "$case_dir/state/task-x1.meta" \
+      "evidence-$variant: cleanup removed task metadata after refusal"
+    [ "$(git -C "$case_dir/project" rev-parse refs/heads/fm/task-x1)" = "$head" ] \
+      || fail "evidence-$variant: refusal changed the task branch"
+  done
+  pass "absent or ambiguous completion, check, mergeability, identity, and head evidence all refuse cleanup"
 }
 
 test_squash_merged_branch_deleted_allows() {
@@ -1403,8 +1644,13 @@ test_teardown_prompts_tasks_axi_done_when_compatible
 test_teardown_manual_backend_prompts_hand_edit_even_when_tasks_axi_present
 test_local_only_truly_unpushed_refuses
 test_local_only_merged_to_local_main_allows
-test_no_mistakes_origin_remote_allows
+test_completed_green_mergeable_pr_allows_and_preserves_branch
 test_no_mistakes_truly_unpushed_refuses
+test_red_pr_refuses_cleanup
+test_pending_pr_refuses_cleanup
+test_conflicted_pr_refuses_cleanup
+test_green_pr_with_genuinely_unpublished_commit_refuses
+test_absent_and_ambiguous_pr_cleanup_evidence_refuses
 test_local_only_force_overrides_unpushed
 test_teardown_missing_busy_sidecar_completes
 test_herdr_teardown_clears_escalation_marker

--- a/tests/fm-teardown.test.sh
+++ b/tests/fm-teardown.test.sh
@@ -44,6 +44,10 @@
 #   (ab) green PR + later local commit                           -> REFUSE (unpublished)
 #   (ac) absent/ambiguous completion, check, mergeability,
 #        identity, or head evidence                              -> REFUSE (evidence)
+#   (ad) green PR whose suite also reports skipped checks         -> ALLOW  (skipped)
+#   (ae) PR with no CI checks configured                          -> REFUSE (no suite)
+#   (af) check summary in an unrecognized shape                   -> REFUSE (fail-safe)
+#   (ag) suite where every check is skipped                       -> REFUSE (nothing passed)
 #
 # Also covers backlog teardown-lock-race: a git index.lock left in the worktree by a
 # killed crew process (bin/fm-teardown.sh's teardown_treehouse_return).
@@ -281,7 +285,10 @@ set -u
 fixture=$(CDPATH='' cd -- "$(dirname "$0")/.." && pwd -P)
 case "${1:-} ${2:-}" in
   "api /repos/example/repo/pulls/7") cat "$fixture/gh-api" ;;
-  "pr checks") cat "$fixture/gh-checks" ;;
+  "pr checks")
+    [ "${3:-}" = 7 ] && [ "${4:-}" = --repo ] && [ "${5:-}" = example/repo ] || exit 1
+    cat "$fixture/gh-checks"
+    ;;
   "pr list") printf '%s\n' "count: 0 (showing first 0)" "pull_requests[]: []" ;;
   *) exit 1 ;;
 esac
@@ -661,7 +668,71 @@ EOF
   [ "$kept_head" = "$head" ] || fail "green-mergeable: preserved branch moved from the validated PR head"
   grep -F 'blockers are gone and date is due' "$case_dir/stdout" >/dev/null \
     || fail "green-mergeable: teardown manual prompt did not preserve date-gate check"
+  assert_grep 'Preserved local branch fm/task-x1' "$case_dir/stdout" \
+    "green-mergeable: teardown did not record the preserved branch"
+  assert_grep 'https://github.com/example/repo/pull/7' "$case_dir/stdout" \
+    "green-mergeable: preserved-branch notice did not name the PR it backs"
   pass "completed green mergeable PR is cleaned before merge with its local branch preserved"
+}
+
+test_green_pr_with_skipped_checks_allows_cleanup() {
+  local setup case_dir head rc
+  setup=$(setup_open_green_case green-skipped)
+  IFS=$'\t' read -r case_dir head <<EOF
+$setup
+EOF
+  # gh-axi emits an extra "<n> skipped" segment whenever a conditional job does
+  # not run. Every check that ran passed, so the suite is still complete.
+  printf '%s\n' 'summary: "3 passed, 0 failed, 1 skipped, 4 total"' > "$case_dir/gh-checks"
+
+  set +e
+  run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 0 "$rc" "green-skipped: a green suite with a skipped check should allow cleanup"
+  ! grep -q REFUSED "$case_dir/stderr" || fail "green-skipped: teardown printed a REFUSED line"
+  git -C "$case_dir/project" rev-parse refs/heads/fm/task-x1 >/dev/null 2>&1 \
+    || fail "green-skipped: cleanup deleted the task branch"
+  pass "green PR whose suite reports skipped checks is cleaned before merge"
+}
+
+test_unusable_check_suites_refuse_cleanup() {
+  local variant setup case_dir head rc expected
+  for variant in no-checks unrecognized-summary all-skipped; do
+    setup=$(setup_open_green_case "suite-$variant")
+    IFS=$'\t' read -r case_dir head <<EOF
+$setup
+EOF
+    case "$variant" in
+      no-checks)
+        printf '%s\n' 'checks: "0 passed, 0 failed — this PR has no CI checks configured"' \
+          > "$case_dir/gh-checks"
+        expected="no CI checks configured"
+        ;;
+      unrecognized-summary)
+        printf '%s\n' 'summary: "3 passed, 0 failed, 1 stalled, 4 total"' > "$case_dir/gh-checks"
+        expected="not in a recognized form"
+        ;;
+      all-skipped)
+        printf '%s\n' 'summary: "0 passed, 0 failed, 4 skipped, 4 total"' > "$case_dir/gh-checks"
+        expected="all-passing completed check suite"
+        ;;
+    esac
+
+    set +e
+    run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr"
+    rc=$?
+    set -e
+
+    expect_code 1 "$rc" "suite-$variant: teardown should refuse"
+    grep -q REFUSED "$case_dir/stderr" || fail "suite-$variant: no REFUSED line in stderr"
+    assert_grep "$expected" "$case_dir/stderr" \
+      "suite-$variant: refusal did not cite the specific check-suite evidence gap"
+    git -C "$case_dir/project" rev-parse refs/heads/fm/task-x1 >/dev/null 2>&1 \
+      || fail "suite-$variant: refused teardown still dropped the task branch"
+  done
+  pass "unusable check suites refuse pre-merge cleanup with evidence-specific reasons"
 }
 
 test_no_mistakes_truly_unpushed_refuses() {
@@ -1645,6 +1716,8 @@ test_teardown_manual_backend_prompts_hand_edit_even_when_tasks_axi_present
 test_local_only_truly_unpushed_refuses
 test_local_only_merged_to_local_main_allows
 test_completed_green_mergeable_pr_allows_and_preserves_branch
+test_green_pr_with_skipped_checks_allows_cleanup
+test_unusable_check_suites_refuse_cleanup
 test_no_mistakes_truly_unpushed_refuses
 test_red_pr_refuses_cleanup
 test_pending_pr_refuses_cleanup

--- a/tests/fm-teardown.test.sh
+++ b/tests/fm-teardown.test.sh
@@ -44,10 +44,12 @@
 #   (ab) green PR + later local commit                           -> REFUSE (unpublished)
 #   (ac) absent/ambiguous completion, check, mergeability,
 #        identity, or head evidence                              -> REFUSE (evidence)
-#   (ad) green PR whose suite also reports skipped checks         -> ALLOW  (skipped)
+#   (ad) green PR whose suite also reports skipped checks         -> REFUSE (skipped)
 #   (ae) PR with no CI checks configured                          -> REFUSE (no suite)
 #   (af) check summary in an unrecognized shape                   -> REFUSE (fail-safe)
 #   (ag) suite where every check is skipped                       -> REFUSE (nothing passed)
+#   (ah) green PR with only patch-equivalent divergent HEAD       -> REFUSE (not contained)
+#   (ai) preserve-path detach failure                              -> ALLOW + print identity
 #
 # Also covers backlog teardown-lock-race: a git index.lock left in the worktree by a
 # killed crew process (bin/fm-teardown.sh's teardown_treehouse_return).
@@ -546,6 +548,19 @@ SH
   chmod +x "$case_dir/fakebin/git"
 }
 
+add_git_detach_failure() {
+  local case_dir=$1
+  cat > "$case_dir/fakebin/git" <<'SH'
+#!/usr/bin/env bash
+real=${REAL_GIT_FOR_TEST:?}
+case " $* " in
+  *" checkout --detach -q "*) exit 1 ;;
+esac
+exec "$real" "$@"
+SH
+  chmod +x "$case_dir/fakebin/git"
+}
+
 # Run teardown with PATH mocking. Args: case_dir [extra args...]
 run_teardown() {
   local case_dir=$1; shift
@@ -675,14 +690,33 @@ EOF
   pass "completed green mergeable PR is cleaned before merge with its local branch preserved"
 }
 
-test_green_pr_with_skipped_checks_allows_cleanup() {
+test_preserve_notice_survives_detach_failure() {
+  local setup case_dir head rc
+  setup=$(setup_open_green_case preserve-detach-failure)
+  IFS=$'\t' read -r case_dir head <<EOF
+$setup
+EOF
+  add_git_detach_failure "$case_dir"
+
+  set +e
+  run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 0 "$rc" "preserve-detach-failure: teardown should retain best-effort detach behavior"
+  assert_grep 'Preserved local branch fm/task-x1' "$case_dir/stdout" \
+    "preserve-detach-failure: preserve notice was lost"
+  assert_grep 'https://github.com/example/repo/pull/7' "$case_dir/stdout" \
+    "preserve-detach-failure: notice omitted the PR identity"
+  pass "preserved branch identity survives detach failure"
+}
+
+test_green_pr_with_skipped_checks_refuses_cleanup() {
   local setup case_dir head rc
   setup=$(setup_open_green_case green-skipped)
   IFS=$'\t' read -r case_dir head <<EOF
 $setup
 EOF
-  # gh-axi emits an extra "<n> skipped" segment whenever a conditional job does
-  # not run. Every check that ran passed, so the suite is still complete.
   printf '%s\n' 'summary: "3 passed, 0 failed, 1 skipped, 4 total"' > "$case_dir/gh-checks"
 
   set +e
@@ -690,11 +724,12 @@ EOF
   rc=$?
   set -e
 
-  expect_code 0 "$rc" "green-skipped: a green suite with a skipped check should allow cleanup"
-  ! grep -q REFUSED "$case_dir/stderr" || fail "green-skipped: teardown printed a REFUSED line"
+  expect_code 1 "$rc" "green-skipped: a suite with a skipped check should refuse cleanup"
+  assert_grep "all-passing completed check suite" "$case_dir/stderr" \
+    "green-skipped: refusal did not identify skipped checks"
   git -C "$case_dir/project" rev-parse refs/heads/fm/task-x1 >/dev/null 2>&1 \
-    || fail "green-skipped: cleanup deleted the task branch"
-  pass "green PR whose suite reports skipped checks is cleaned before merge"
+    || fail "green-skipped: refusal deleted the task branch"
+  pass "green PR whose suite reports skipped checks refuses cleanup"
 }
 
 test_unusable_check_suites_refuse_cleanup() {
@@ -848,10 +883,36 @@ EOF
   pass "green PR does not authorize cleanup of a genuinely unpublished later commit"
 }
 
+test_green_pr_with_patch_equivalent_divergent_head_refuses() {
+  local case_dir local_head pr_head rc tmp
+  case_dir=$(make_case divergent-equivalent-head)
+  write_meta "$case_dir" no-mistakes ship
+  wt_commit_file "$case_dir" feature.txt hello "add feature"
+  local_head=$(git -C "$case_dir/wt" rev-parse HEAD)
+  pr_head=$(land_equivalent_patch_on_origin_branch "$case_dir" pr-head feature.txt hello "replay feature")
+  printf '%s\n' \
+    'pr=https://github.com/example/repo/pull/7' \
+    "pr_head=$pr_head" >> "$case_dir/state/task-x1.meta"
+  write_pr_completion "$case_dir"
+  add_gh_pr_open_evidence "$case_dir" "$pr_head"
+
+  set +e
+  run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 1 "$rc" "divergent-equivalent-head: patch equivalence must not prove containment"
+  assert_grep "local HEAD is not contained" "$case_dir/stderr" \
+    "divergent-equivalent-head: refusal did not identify failed ancestry"
+  tmp=$(git -C "$case_dir/project" rev-parse refs/heads/fm/task-x1)
+  [ "$tmp" = "$local_head" ] || fail "divergent-equivalent-head: refusal changed the task branch"
+  pass "patch-equivalent divergent local HEAD refuses pre-merge cleanup"
+}
+
 test_absent_and_ambiguous_pr_cleanup_evidence_refuses() {
   local variant setup case_dir head rc expected tmp
   for variant in \
-    completion-absent completion-ambiguous \
+    completion-absent completion-ambiguous completion-duplicated \
     checks-absent checks-ambiguous \
     mergeability-absent mergeability-ambiguous \
     identity-absent identity-ambiguous \
@@ -869,6 +930,12 @@ EOF
       completion-ambiguous)
         printf '%s\n' 'working: completion was reopened' >> "$case_dir/state/task-x1.status"
         expected="not an unambiguous completion"
+        ;;
+      completion-duplicated)
+        write_pr_completion "$case_dir"
+        printf '%s\n' 'done: PR https://github.com/example/repo/pull/7 checks green' \
+          >> "$case_dir/state/task-x1.status"
+        expected="completion record is absent or duplicated"
         ;;
       checks-absent)
         : > "$case_dir/gh-checks"
@@ -1716,13 +1783,15 @@ test_teardown_manual_backend_prompts_hand_edit_even_when_tasks_axi_present
 test_local_only_truly_unpushed_refuses
 test_local_only_merged_to_local_main_allows
 test_completed_green_mergeable_pr_allows_and_preserves_branch
-test_green_pr_with_skipped_checks_allows_cleanup
+test_preserve_notice_survives_detach_failure
+test_green_pr_with_skipped_checks_refuses_cleanup
 test_unusable_check_suites_refuse_cleanup
 test_no_mistakes_truly_unpushed_refuses
 test_red_pr_refuses_cleanup
 test_pending_pr_refuses_cleanup
 test_conflicted_pr_refuses_cleanup
 test_green_pr_with_genuinely_unpublished_commit_refuses
+test_green_pr_with_patch_equivalent_divergent_head_refuses
 test_absent_and_ambiguous_pr_cleanup_evidence_refuses
 test_local_only_force_overrides_unpushed
 test_teardown_missing_busy_sidecar_completes


### PR DESCRIPTION
## Intent

Implement the captain's 2026-07-31 cleanup ruling in bin/fm-teardown.sh. Permit cleanup of a completed PR-based task before merge only when the latest completion exactly names the canonically recorded GitHub PR, live GitHub evidence shows that same open non-draft PR has an all-passing completed check suite with zero failed, pending, or skipped/cancelled/expected buckets and is mergeable, the live head exactly matches the recorded PR head, and repository evidence proves local HEAD is contained in that PR head; preserve the local task branch on this path and print its branch/PR identity on successful cleanup, without adding retention metadata or a reaper. Treat absent, duplicated, stale, contradictory, or unavailable completion, check, mergeability, identity, or head evidence as a refusal. Continue refusing red, pending, skipped, or conflicted PRs, uncommitted work, genuinely unpublished commits, and every existing unlanded-work safety condition; merely pushed remote reachability is intentionally insufficient and GitHub outages refuse. Replace the obsolete generic 'land its PR' diagnosis with evidence-specific refusal. Reuse the authenticated configured-remote PR-head fetch path, pin GitHub test mocks to exact canonical arguments, centralize branch finalization, and ensure the preserve notice survives detach failure without broadening retention behavior. Add regression coverage for the allowed path and every refusal boundary, retain existing merged/content/local-only/lock/backend behavior, and run required lint and focused teardown suites.

## What Changed

- Allow completed PR-based tasks to tear down before merge only when canonical completion, live GitHub checks, mergeability, PR-head identity, and local commit ancestry all validate.
- Preserve the task branch and report its PR identity on successful pre-merge cleanup, while returning evidence-specific refusals for missing, ambiguous, stale, failing, pending, skipped, conflicted, or unpublished states.
- Centralize branch finalization, update teardown policy documentation, and expand regression coverage across allowed and refusal paths while retaining existing teardown behavior.

## Risk Assessment

✅ Low: Captain, the fix commit resolves all prior findings and the full branch diff now conforms to the source-verifiable teardown safety criteria without introducing another material issue.

## Testing

After session bootstrap and diff/coverage inspection, the focused teardown suite passed across the permitted pre-merge path and its refusal boundaries, and a separate CLI-level scenario demonstrated successful cleanup, exact branch/PR preservation notice, and an unchanged preserved ref; no UI artifact applies because this is a shell CLI policy change, and no source or transient working-tree artifacts remained.

<details>
<summary>Evidence: Focused teardown test suite</summary>

```text
ok - local-only worktree with HEAD on a fork remote is torn down (fix holds)
ok - teardown prompts tasks-axi backlog refresh when compatible
ok - teardown honors config/backlog-backend=manual even when tasks-axi is compatible
ok - local-only worktree with truly unpushed work is refused (safety preserved)
ok - local-only worktree with work merged into local main is torn down (no regression)
ok - completed green mergeable PR is cleaned before merge with its local branch preserved
ok - preserved branch identity survives detach failure
ok - green PR whose suite reports skipped checks refuses cleanup
ok - unusable check suites refuse pre-merge cleanup with evidence-specific reasons
ok - no-mistakes worktree with genuinely unlanded work is refused (safety preserved)
ok - red PR refuses cleanup and preserves all task recovery state
ok - pending PR checks refuse cleanup
ok - conflicted PR refuses cleanup and preserves all task recovery state
ok - green PR does not authorize cleanup of a genuinely unpublished later commit
ok - patch-equivalent divergent local HEAD refuses pre-merge cleanup
ok - absent or ambiguous completion, check, mergeability, identity, and head evidence all refuse cleanup
ok - local-only worktree with unpushed work is torn down under --force (escape hatch)
ok - teardown completes when an exact busy-state sidecar is already absent
ok - herdr teardown removes pane-owned escalation dedupe state
ok - herdr projection teardown retires its journal only after confirming the exact recorded pane is gone
ok - herdr projection teardown retains the stale journal and attempts no workspace cleanup when exact-pane close is unconfirmed
ok - squash-merged + deleted-branch worktree (PR merged) is torn down (the fix)
ok - squash-merged PR accepts a local HEAD that is an ancestor of the final PR head
ok - teardown discovers a merged PR by branch name and tears down when no pr= was ever recorded
ok - squash-merged PR accepts replayed unpushed local patches contained in the PR head
ok - merged PR does not allow teardown after a later local commit
ok - fm-pr-check does not refresh PR head after HEAD moves
ok - fm-pr-check records the remote PR head when the local worktree lags
ok - worktree whose content already landed in the default branch is torn down (content fallback)
ok - content fallback refreshes origin default before comparing trees
ok - dirty worktree is refused even when its committed work has landed (dirty always wins)
ok - gh lookup error with content not in default refuses (fail-safe)
ok - provably-stale worktree index.lock (old, no live holder) is cleared and teardown succeeds
ok - live-held worktree index.lock is never removed and teardown refuses
ok - lsof errors leave worktree index.lock in place and refuse teardown
ok - stale lock cleanup rechecks and refuses dirty worktree before return
ok - normal repo index.lock is resolved from the worktree and cleared when stale
ok - lock mtime read failures leave worktree index.lock in place and refuse teardown
ok - transient index.lock cleared after first failed return is retried successfully without force-remove
ok - persistent index.lock exhausts retries and refuses without force-removing the lock
ok - empty retry wait overrides use the default without aborting teardown
ok - fractional legacy retry wait remains supported without arithmetic
```
</details>
<details>
<summary>Evidence: Successful green, mergeable pre-merge teardown transcript</summary>

```text
LIVE PR FIXTURE:
state: open
draft: false
head:
  sha: dd7ffd60a98d8593e2f09a267d2169875dbb5e8c
mergeable: true
summary: "3 passed, 0 failed, 3 total"
TEARDOWN CLI OUTPUT:
Preserved local branch fm/task-x1: task-x1 was cleaned up before https://github.com/example/repo/pull/7 merged. Delete the branch once that PR lands.
/tmp/fm-teardown-tests.IFeOgf/reviewer-e2e/project: already current
teardown task-x1 complete (window firstmate:fm-task-x1, worktree /tmp/fm-teardown-tests.IFeOgf/reviewer-e2e/wt)
Backlog: task-x1 just finished. Run tasks-axi done task-x1 --pr https://github.com/example/repo/pull/7, then run tasks-axi ready for dependency-cleared candidates, check date gates, and dispatch only work whose blockers are gone and date is due.
EXIT STATUS: 0
PRESERVED REF: refs/heads/fm/task-x1 -> dd7ffd60a98d8593e2f09a267d2169875dbb5e8c
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 5 issues found → auto-fixed ✅</summary>

- 🚨 `bin/fm-teardown.sh:643` - Intent requires “zero failed, pending, or skipped/cancelled/expected buckets” and explicitly says to continue refusing skipped PRs. This condition instead accepts skipped checks whenever `passed + skipped == total`; require `skipped == 0` and update the regression that currently expects skipped checks to pass.
- 🚨 `bin/fm-teardown.sh:458` - Intent requires repository proof that local HEAD is contained in the PR head and refusal of genuinely unpublished commits. The patch-ID fallback accepts a divergent local commit merely because its patch matches a PR commit, even though local HEAD is not an ancestor of the PR head; use strict ancestry for the pre-merge path.
- 🚨 `bin/fm-teardown.sh:562` - Intent says duplicated completion evidence must refuse. Only the final non-empty status line is inspected, so two identical completion events—or an earlier contradictory completion followed by a valid one—still authorize cleanup. Count and validate completion records rather than accepting solely from the last line.
- 🚨 `bin/fm-teardown.sh:1476` - Intent requires that the preserve notice survive detach failure. The notice is emitted only inside the successful `checkout --detach` branch, so a detach failure silently omits the sole surviving branch/PR identity even though cleanup continues. Emit the preservation notice independently of detach success.
- ⚠️ `bin/fm-teardown.sh:1491` - Intent requires branch finalization to be centralized, but the Orca and non-Orca paths duplicate branch discovery, detach, preserve announcement, and deletion logic. Extract one finalization helper so both backends cannot drift—particularly around detach-failure handling.

🔧 Fix: Enforce strict pre-merge teardown evidence
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bin/fm-session-start.sh`
- <code>Inspected `git diff f7d0d0a703a717880656709d7906615505b3f2c0..052d4ce166b73f6c1f2edb4a59097abaa5230ccf` and the teardown test matrix.</code>
- `bash tests/fm-teardown.test.sh > /tmp/no-mistakes-evidence/01KYWDZ21C7BTCTPBSPAH5EF5Q/fm-teardown-focused-suite.log 2>&1`
- <code>Ran a hermetic end-to-end `bin/fm-teardown.sh task-x1` scenario using exact canonical GitHub mock arguments and captured live-PR fixtures, CLI output, exit status, and the surviving branch ref in `green-mergeable-teardown-transcript.txt`.</code>
- <code>Checked `git status --short` and searched for transient build/cache directories after testing; the working tree remained clean.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
