### PR TITLE
fix(snapshot): route registry parsing through the #1452 owner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -350,8 +350,8 @@ jobs:
           snapshot_output=$(/bin/bash tests/fm-fleet-snapshot-view.test.sh)
           printf '%s\n' "$snapshot_output"
           snapshot_count=$(printf '%s\n' "$snapshot_output" | grep -c '^ok - ')
-          [ "$snapshot_count" -eq 15 ] || {
-            echo "::error::expected 15 snapshot/fleet-view tests, got $snapshot_count"
+          [ "$snapshot_count" -eq 16 ] || {
+            echo "::error::expected 16 snapshot/fleet-view tests, got $snapshot_count"
             exit 1
           }
 

--- a/bin/fm-fleet-snapshot.sh
+++ b/bin/fm-fleet-snapshot.sh
@@ -812,7 +812,7 @@ else
 fi
 
 registry_secondmates_json() {
-  local reg="$DATA/secondmates.md" out rc reason mode script parse_filter output_filter
+  local reg="$DATA/secondmates.md" registry_lib out rc reason mode script output_filter
   if [ ! -f "$reg" ]; then
     jq -n --arg path "$reg" --arg observed "$SNAPSHOT_NOW" \
       '{present:false,available:true,complete:true,reason:null,provenance:"registered-table",path:$path,freshness:{status:"fresh",observed_at:$observed},records:[],input_truncated:false,records_truncated:false,reasons:[],lines_in_window:0,records_in_window:0}'
@@ -832,8 +832,9 @@ registry_secondmates_json() {
     max_records=$4
     path=$5
     observed=$6
-    parse_filter=$7
+    registry_lib=$7
     output_filter=$8
+    . "$registry_lib" || exit 3
     content=$(LC_ALL=C head -c "$((max_bytes + 1))" "$f" || exit 3; printf "\036") || exit 3
     content=${content%$'\036'}
     bytes=$(printf "%s" "$content" | LC_ALL=C wc -c | tr -d " ")
@@ -861,7 +862,33 @@ registry_secondmates_json() {
     else
       lines_in_window=0
     fi
-    records=$(printf "%s\n" "$window" | jq -Rn "$parse_filter") || exit 3
+    records=$(
+      printf "%s\n" "$window" | (
+        while IFS= read -r line || [ -n "$line" ]; do
+          [[ "$line" == "- "* ]] || continue
+          if secondmate_registry_parse_line "$line"; then
+            printf '%s\000%s\000%s\000%s\000%s\000%s\000' \
+              valid "$SECONDMATE_REGISTRY_ID" "$SECONDMATE_REGISTRY_HOME" \
+              "$SECONDMATE_REGISTRY_HOST" "$SECONDMATE_REGISTRY_ROOT" "$SECONDMATE_REGISTRY_REMOTE"
+          elif secondmate_registry_parse_id "$line"; then
+            printf '%s\000%s\000%s\000%s\000%s\000%s\000' \
+              invalid "$SECONDMATE_REGISTRY_ID" '' '' '' 0
+          fi
+        done
+      ) | jq -Rsc '
+        split("\u0000") as $parts
+        | [range(0; (($parts | length) - 1); 6) as $i
+           | {id:$parts[$i + 1],
+              home:(if $parts[$i] == "valid" then $parts[$i + 2] else null end),
+              host:(if $parts[$i] == "valid" and $parts[$i + 5] == "1" then $parts[$i + 3] else null end),
+              root:(if $parts[$i] == "valid" and $parts[$i + 5] == "1" then $parts[$i + 4] else null end),
+              remote:($parts[$i] == "valid" and $parts[$i + 5] == "1"),
+              registered:true,
+              registry_error:(if $parts[$i] == "valid" then null else "registry entry has no home" end)}]
+        | group_by(.id)
+        | map(if length > 1 then .[0] + {registry_error:"duplicate secondmate id in registry"} else .[0] end)
+      '
+    ) || exit 3
     records_in_window=$(printf "%s" "$records" | jq "length") || exit 3
     records_truncated=false
     if [ "$records_in_window" -gt "$max_records" ]; then records_truncated=true; fi
@@ -875,22 +902,7 @@ registry_secondmates_json() {
       --argjson max_records "$max_records" "$output_filter"
 BASH
   )
-  parse_filter=$(cat <<'JQ'
-      [ inputs
-        | select(startswith("- "))
-        | (capture("^- (?<id>[^[:space:]]+)")?) as $id
-        | select($id != null)
-        | ([capture("^.*\\(host:[[:space:]]*(?<host>[^;)]*);[[:space:]]*root:[[:space:]]*(?<root>[^;)]*);[[:space:]]*home:[[:space:]]*(?<home>[^;)]*);[[:space:]]*scope:[[:space:]]*.*;[[:space:]]*projects:[[:space:]]*[^;)]*;[[:space:]]*added[[:space:]]+[0-9]{4}-[0-9]{2}-[0-9]{2}\\)[[:space:]]*$")?][0] // null) as $remote
-        | ([capture("^.*\\(home:[[:space:]]*(?<home>[^;)]*);[[:space:]]*scope:[[:space:]]*.*;[[:space:]]*projects:[[:space:]]*[^;)]*;[[:space:]]*added[[:space:]]+[0-9]{4}-[0-9]{2}-[0-9]{2}\\)[[:space:]]*$")?][0] // null) as $local
-        | ($local // $remote) as $route
-        | (($local == null) and ($remote != null)) as $is_remote
-        | {id:$id.id,home:($route.home // null),host:(if $is_remote then $remote.host else null end),root:(if $is_remote then $remote.root else null end),
-           remote:$is_remote,registered:true,
-           registry_error:(if $route == null or ($route.home | length) == 0 then "registry entry has no home" else null end)} ]
-      | group_by(.id)
-      | map(if length > 1 then .[0] + {registry_error:"duplicate secondmate id in registry"} else .[0] end)
-JQ
-  )
+  registry_lib="$SCRIPT_DIR/fm-secondmate-registry-lib.sh"
   output_filter=$(cat <<'JQ'
       {present:true,available:true,reason:null,provenance:"registered-table",path:$path,
        freshness:{status:"fresh",observed_at:$observed},
@@ -907,7 +919,7 @@ JQ
   out=$(run_timed "$FM_SNAPSHOT_REGISTRY_TIMEOUT" bash -c "$script" \
     fm-secondmate-registry "$reg" "$FM_SNAPSHOT_REGISTRY_LINES" \
     "$FM_SNAPSHOT_REGISTRY_BYTES" "$FM_SNAPSHOT_REGISTRY_RECORDS" "$reg" "$SNAPSHOT_NOW" \
-    "$parse_filter" "$output_filter" 2>/dev/null)
+    "$registry_lib" "$output_filter" 2>/dev/null)
   rc=$?
   if [ "$rc" -eq 0 ] && printf '%s' "$out" | jq -e '
     .available == true and (.records | type) == "array"

--- a/bin/fm-secondmate-registry-lib.sh
+++ b/bin/fm-secondmate-registry-lib.sh
@@ -31,6 +31,17 @@ SECONDMATE_REGISTRY_ERROR=
 secondmate_registry_lock_path() { printf '%s/.secondmate-registry.lock\n' "$1"; }
 secondmate_reply_lifecycle_lock_path() { printf '%s/.remote-reply-lifecycle-%s.lock\n' "$1" "$2"; }
 
+secondmate_registry_parse_id() {
+  local line=$1
+  local id_re='^- ([A-Za-z0-9._-]+)([[:space:]]|$)'
+  SECONDMATE_REGISTRY_ID=
+  if [[ "$line" =~ $id_re ]]; then
+    SECONDMATE_REGISTRY_ID=${BASH_REMATCH[1]}
+  else
+    return 1
+  fi
+}
+
 secondmate_registry_parse_line() {
   local line=$1
   local local_re='^- ([A-Za-z0-9._-]+) - (.+) \(home:[[:space:]]*([^;)]*);[[:space:]]*scope:[[:space:]]*(.*);[[:space:]]*projects:[[:space:]]*([^;)]*);[[:space:]]*added[[:space:]]+([0-9]{4}-[0-9]{2}-[0-9]{2})\)[[:space:]]*$'

--- a/tests/fm-fleet-snapshot-view.test.sh
+++ b/tests/fm-fleet-snapshot-view.test.sh
@@ -151,6 +151,41 @@ test_empty_fleet_json() {
   pass "empty fleet snapshot and view use explicit absence markers"
 }
 
+test_snapshot_registry_records_follow_strict_shared_parser() {
+  local home out valid_home invalid_home remote_home ids
+  home=$(make_home registry-owner)
+  valid_home="$home/valid-home"
+  invalid_home="$home/invalid-home"
+  remote_home=/srv/firstmate-secondmates/remote
+  cat > "$home/data/secondmates.md" <<EOF
+- valid - summary with punctuation (kept) (home: $valid_home; scope: route (one); projects: alpha; added 2026-08-03)
+- remote - remote route (host: build-mac; root: /opt/firstmate; home: $remote_home; scope: remote route; projects: gamma; added 2026-08-03)
+- bad/id - invalid id (home: $invalid_home; scope: route; projects: beta; added 2026-08-03)
+- malformed - missing structured suffix
+EOF
+  out=$(FM_HOME="$home" "$SNAPSHOT" --json)
+  ids=$(printf '%s' "$out" | jq -r '.secondmate_current.registry.records | map(.id) | sort | join(",")')
+  [ "$ids" = "malformed,remote,valid" ] \
+    || fail "snapshot registry parser diverged from the strict owner: ids='$ids'"
+  printf '%s' "$out" | jq -e --arg home "$valid_home" '
+    .secondmate_current.registry.records[]
+    | select(.id == "valid")
+    | .home == $home and .registry_error == null
+  ' >/dev/null || fail "snapshot registry parser lost a valid punctuated strict-owner row"
+  printf '%s' "$out" | jq -e --arg home "$remote_home" '
+    .secondmate_current.registry.records[]
+    | select(.id == "remote")
+    | .home == $home and .host == "build-mac" and .root == "/opt/firstmate"
+      and .remote == true and .registry_error == null
+  ' >/dev/null || fail "snapshot registry parser lost strict-owner remote route fields"
+  printf '%s' "$out" | jq -e '
+    .secondmate_current.registry.records[]
+    | select(.id == "malformed")
+    | .home == null and .registry_error == "registry entry has no home"
+  ' >/dev/null || fail "snapshot registry parser did not preserve a malformed-row diagnostic"
+  pass "snapshot registry records follow the strict shared parser"
+}
+
 test_fixture_snapshot_json() {
   local home fakebin out ids
   home=$(make_home fixture)
@@ -780,6 +815,7 @@ test_parked_scout_decision_stays_pending() {
 }
 
 test_empty_fleet_json
+test_snapshot_registry_records_follow_strict_shared_parser
 test_fixture_snapshot_json
 test_main_inventory_orphan_and_unstructured_disclosure
 test_normalized_roles_and_plural_blocker_readiness


### PR DESCRIPTION
## Rescope

This pull request now builds on #1452, which established `bin/fm-secondmate-registry-lib.sh` as the strict owner of `data/secondmates.md` parsing and rejects ambiguous duplicate bindings.
The former competing `fm-registry-lib.sh` implementation and its last-match-wins contract have been removed from this branch.

## What changed

- `bin/fm-fleet-snapshot.sh` now parses its bounded registry window through the #1452 owner instead of carrying an independent jq field extractor.
- The owner exposes a strict ID-only helper so malformed rows with valid IDs can retain their existing snapshot diagnostic while invalid IDs remain rejected.
- Duplicate IDs remain errors; no row is silently selected.
- The stock macOS Bash snapshot check now expects the added 16th behavior test.

## Reference audit

- `bin/fm-bootstrap.sh` already routes its parser call and registry helper handoffs through `fm-ff-lib.sh` to the strict owner, so it is unchanged.
- `bin/fm-spawn.sh` already uses the strict field and binding validators; its remaining registry reference is only an existence check, so it is unchanged.
- `bin/fm-update.sh` already calls the strict line parser through `fm-ff-lib.sh`; its other registry references are the path variable and explanatory comment, so it is unchanged.
- `bin/fm-fleet-snapshot.sh` contained the only remaining independent parser among the four audited scripts, and that parser is replaced here.
- `bin/fm-test-run.sh` has no registry references on current `main` and is unchanged.

## Validation

- The new snapshot behavior test was observed failing against the independent jq parser and passing after the owner integration.
- Stock `/bin/bash` snapshot suite: 16 tests passed.
- Adjacent update, bootstrap, and secondmate safety suites passed.
- Documentation audience check and pinned ShellCheck gate passed.
- A 256-row full snapshot completed in 1.12 seconds with the registry timeout set to 2 seconds.

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)