### PR TITLE
feat(bin): add task lifecycle notification hook

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,6 +74,7 @@ config/startup-memory-budget     primary-authoritative per-home startup-memory b
 config/herdr-presentation-spaces  optional presence flag for Herdr's default-off disposable single-task visual projection; LOCAL, gitignored; inherited by secondmate homes; see docs/herdr-backend.md "Optional presentation spaces"
 config/cmux-socket-password  optional cmux control-socket password; LOCAL, gitignored; read fresh on every cmux CLI call and passed through without ever overriding an operator's own ambient CMUX_SOCKET_PASSWORD when absent (docs/cmux-backend.md "Setup")
 config/wedge-alarm  optional away-mode wedge-alarm active-alert directives; LOCAL, gitignored; absent means auto (macOS Notification Center when available); see docs/wedge-alarm.md
+config/notification-hook  optional absolute path of the task lifecycle notification hook executable; LOCAL, gitignored, and not inherited; see docs/configuration.md "Task lifecycle notification hook"
 config/x-mode.env    generated X-mode watcher cadence; LOCAL, gitignored; source before arming watcher when present
 data/                personal fleet records; LOCAL, gitignored as a whole
   backlog.md         task queue, dependencies, history
@@ -113,6 +114,7 @@ state/               volatile runtime signals; gitignored
   .claude-autoarm.lock .claude-autoarm-epoch .turnend-claude-blocks   Claude Stop auto-arm single-flight, epoch, and guard-budget records; never touch
   .hash-* .count-* .stale-* .stale-since-* .paused-* .wedge-escalations-* .seen-* .hb-surfaced-* .last-* .heartbeat-streak   watcher internals; never touch
   .watch-triage.log  watcher's absorbed-wake debug log (size-capped); never relied on, safe to delete
+  notification-hook.log  notifier's bounded fixed-token failure diagnostics (size-capped); never relied on, safe to delete (bin/fm-notify.sh)
   .last-watcher-beat watcher liveness beacon, touched every poll (including while absorbing benign wakes); guard scripts read it
   .subsuper-* .supervise-daemon.*   sub-supervisor internals; never touch
 .no-mistakes/        local validation state and evidence; gitignored

--- a/bin/fm-notify.sh
+++ b/bin/fm-notify.sh
@@ -1,0 +1,283 @@
+#!/usr/bin/env bash
+# Emit Firstmate's optional, transport-neutral task lifecycle notification.
+#
+# Configuration:
+#   - The effective home is FM_HOME, then FM_ROOT_OVERRIDE, then the tracked root.
+#   - FM_CONFIG_OVERRIDE may select an alternate configuration directory.
+#   - config/notification-hook contains exactly one absolute executable path.
+#   - The file is a path, not a command: no arguments, quoting syntax, variable
+#     expansion, or shell evaluation is accepted.
+#   - An absent configuration file disables notifications silently.
+#
+# Interface:
+#   fm-notify.sh status <task-id>
+#     Read the task's current status and emit task.ready only at the delivery-mode
+#     ready boundary: any scout done event, direct-PR PR readiness, local-only
+#     branch readiness, or a no-mistakes PR whose checks are green.
+#   fm-notify.sh completed <task-id>
+#     Emit task.completed after the lifecycle owner has formally completed the
+#     task. Callers must establish that lifecycle truth before invoking this path.
+#
+# Hook contract:
+#   - The executable receives one UTF-8 firstmate.notification.v1 JSON object on
+#     standard input and no arguments.
+#   - Payloads are at most 512 bytes. task_id and project are privacy-safe slugs
+#     of at most 64 bytes; event_id is a stable SHA-256 identity derived only from
+#     schema, project, task id, kind, and event; no prompt, status prose, path,
+#     endpoint, credential, or environment value is forwarded.
+#   - FM_NOTIFICATION_TIMEOUT_SECS is a positive integer timeout in seconds and
+#     defaults to 5. Invalid values use the default; values above 60 clamp to 60.
+#   - Hook output is discarded. Absence, malformed configuration, timeout,
+#     execution failure, or payload-construction failure is non-fatal and exits 0.
+#   - Bounded diagnostics use fixed reason tokens in
+#     state/notification-hook.log, never hook output, configured paths, or
+#     environment values. The mode-0600 log is capped by retaining its newest
+#     200 lines whenever it exceeds 65536 bytes.
+#
+# Usage: fm-notify.sh <status|completed> <task-id>
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
+STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
+CONFIG="${FM_CONFIG_OVERRIDE:-$FM_HOME/config}"
+HOOK_CONFIG="$CONFIG/notification-hook"
+DIAG_LOG="$STATE/notification-hook.log"
+SCHEMA=firstmate.notification.v1
+PAYLOAD_MAX_BYTES=512
+
+# shellcheck source=bin/fm-classify-lib.sh
+. "$SCRIPT_DIR/fm-classify-lib.sh"
+
+usage() {
+  awk '
+    NR == 1 { next }
+    /^#/ { sub(/^# ?/, ""); print; next }
+    { exit }
+  ' "$0"
+}
+
+fm_notify_slug_valid() {  # <value>
+  case "$1" in
+    ''|*[!A-Za-z0-9._-]*) return 1 ;;
+  esac
+  [ "${#1}" -le 64 ]
+}
+
+fm_notify_diag() {  # <fixed-reason> <event> <task-id>
+  local reason=$1 event=${2:-unknown} task=${3:-unknown} tmp size
+  fm_notify_slug_valid "$task" || task=unknown
+  case "$event" in task.ready|task.completed) ;; *) event=unknown ;; esac
+  case "$reason" in
+    config-unreadable|config-malformed|hook-not-executable|hash-unavailable|payload-invalid|hook-timeout|hook-failed) ;;
+    *) reason=internal-error ;;
+  esac
+  mkdir -p "$STATE" 2>/dev/null || return 0
+  [ ! -L "$DIAG_LOG" ] || return 0
+  umask 077
+  printf '%s event=%s task=%s result=%s\n' \
+    "$(date -u '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || printf unknown)" \
+    "$event" "$task" "$reason" >> "$DIAG_LOG" 2>/dev/null || return 0
+  chmod 0600 "$DIAG_LOG" 2>/dev/null || true
+  size=$(LC_ALL=C wc -c < "$DIAG_LOG" 2>/dev/null | tr -d '[:space:]')
+  case "$size" in ''|*[!0-9]*) return 0 ;; esac
+  [ "$size" -le 65536 ] && return 0
+  tmp="$DIAG_LOG.tmp.$$"
+  if tail -n 200 "$DIAG_LOG" > "$tmp" 2>/dev/null \
+    && chmod 0600 "$tmp" 2>/dev/null \
+    && mv "$tmp" "$DIAG_LOG" 2>/dev/null; then
+    return 0
+  fi
+  rm -f "$tmp" 2>/dev/null || true
+}
+
+FM_NOTIFY_HOOK=
+fm_notify_load_hook() {
+  local bytes lines hook
+  [ -e "$HOOK_CONFIG" ] || return 1
+  [ -f "$HOOK_CONFIG" ] || {
+    fm_notify_diag config-malformed unknown unknown
+    return 2
+  }
+  bytes=$(LC_ALL=C wc -c < "$HOOK_CONFIG" 2>/dev/null | tr -d '[:space:]') || {
+    fm_notify_diag config-unreadable unknown unknown
+    return 2
+  }
+  case "$bytes" in ''|*[!0-9]*) bytes=4097 ;; esac
+  [ "$bytes" -le 4096 ] || {
+    fm_notify_diag config-malformed unknown unknown
+    return 2
+  }
+  lines=$(awk 'END { print NR + 0 }' "$HOOK_CONFIG" 2>/dev/null) || {
+    fm_notify_diag config-unreadable unknown unknown
+    return 2
+  }
+  [ "$lines" -eq 1 ] || {
+    fm_notify_diag config-malformed unknown unknown
+    return 2
+  }
+  IFS= read -r hook < "$HOOK_CONFIG" || [ -n "$hook" ] || {
+    fm_notify_diag config-unreadable unknown unknown
+    return 2
+  }
+  case "$hook" in
+    /*) ;;
+    *) fm_notify_diag config-malformed unknown unknown; return 2 ;;
+  esac
+  case "$hook" in *$'\r'*|*$'\n'*) fm_notify_diag config-malformed unknown unknown; return 2 ;; esac
+  [ -f "$hook" ] && [ -x "$hook" ] || {
+    fm_notify_diag hook-not-executable unknown unknown
+    return 2
+  }
+  FM_NOTIFY_HOOK=$hook
+  return 0
+}
+
+fm_notify_meta_value() {  # <meta> <key>
+  local meta=$1 key=$2
+  sed -n "s/^${key}=//p" "$meta" 2>/dev/null | tail -1
+}
+
+fm_notify_project_slug() {  # <project-value>
+  local project=$1
+  project=${project%/}
+  project=${project##*/}
+  project=$(printf '%s' "$project" | LC_ALL=C tr -c 'A-Za-z0-9._-' '_')
+  project=${project:0:64}
+  [ -n "$project" ] || project=unknown
+  printf '%s' "$project"
+}
+
+fm_notify_sha256() {
+  if command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 | awk '{ print $1 }'
+  elif command -v sha256sum >/dev/null 2>&1; then
+    sha256sum | awk '{ print $1 }'
+  elif command -v openssl >/dev/null 2>&1; then
+    openssl dgst -sha256 | sed 's/^.*= //'
+  else
+    return 1
+  fi
+}
+
+FM_NOTIFY_TASK=
+FM_NOTIFY_PROJECT=
+FM_NOTIFY_KIND=
+FM_NOTIFY_MODE=
+fm_notify_load_task() {  # <task-id>
+  local id=$1 meta project kind mode
+  fm_notify_slug_valid "$id" || return 1
+  meta="$STATE/$id.meta"
+  [ -f "$meta" ] && [ ! -L "$meta" ] || return 1
+  project=$(fm_notify_meta_value "$meta" project)
+  kind=$(fm_notify_meta_value "$meta" kind)
+  mode=$(fm_notify_meta_value "$meta" mode)
+  [ -n "$kind" ] || kind=ship
+  [ -n "$mode" ] || mode=no-mistakes
+  case "$kind" in ship|scout) ;; *) return 1 ;; esac
+  case "$mode" in no-mistakes|direct-PR|local-only) ;; *) [ "$kind" = scout ] || return 1 ;; esac
+  FM_NOTIFY_TASK=$id
+  FM_NOTIFY_PROJECT=$(fm_notify_project_slug "$project")
+  FM_NOTIFY_KIND=$kind
+  FM_NOTIFY_MODE=$mode
+}
+
+fm_notify_status_ready() {  # <task-id>
+  local status line verb
+  status="$STATE/$1.status"
+  [ -f "$status" ] && [ ! -L "$status" ] || return 1
+  line=$(last_status_line "$status")
+  verb=$(status_line_verb "$line")
+  [ "$verb" = done ] || return 1
+  if [ "$FM_NOTIFY_KIND" = scout ]; then
+    return 0
+  fi
+  case "$FM_NOTIFY_MODE" in
+    local-only) printf '%s' "$line" | grep -qE '^done([^:]*)?:[[:space:]]+ready in branch fm/' ;;
+    direct-PR) printf '%s' "$line" | grep -qE '^done([^:]*)?:[[:space:]]+PR https://[^[:space:]]+' ;;
+    no-mistakes) printf '%s' "$line" | grep -qE '^done([^:]*)?:[[:space:]]+PR https://[^[:space:]]+ checks green([[:space:]]|$)' ;;
+    *) return 1 ;;
+  esac
+}
+
+fm_notify_timeout() {
+  local timeout_secs=${FM_NOTIFICATION_TIMEOUT_SECS:-5}
+  case "$timeout_secs" in ''|*[!0-9]*|0) timeout_secs=5 ;; esac
+  [ "$timeout_secs" -le 60 ] || timeout_secs=60
+  printf '%s' "$timeout_secs"
+}
+
+fm_notify_run_hook() {  # <hook> <timeout-secs>
+  local hook=$1 timeout_secs=$2
+  if command -v timeout >/dev/null 2>&1; then
+    exec timeout --kill-after=1 "$timeout_secs" "$hook"
+  elif command -v gtimeout >/dev/null 2>&1; then
+    exec gtimeout --kill-after=1 "$timeout_secs" "$hook"
+  else
+    # shellcheck disable=SC2016
+    exec perl -e 'my $t = shift; my $pid = fork; exit 125 unless defined $pid; if (!$pid) { setpgrp(0, 0); exec @ARGV; exit 126 } my $stop = sub { kill "TERM", -$pid; select undef, undef, undef, 0.2; kill "KILL", -$pid; waitpid $pid, 0; exit 124 }; local $SIG{ALRM} = $stop; local $SIG{HUP} = $stop; local $SIG{INT} = $stop; local $SIG{TERM} = $stop; alarm $t; waitpid $pid, 0; exit($? >> 8)' "$timeout_secs" "$hook"
+  fi
+}
+
+fm_notify_emit() {  # <task.ready|task.completed>
+  local event=$1 outcome identity event_id occurred payload bytes timeout_secs rc
+  case "$event" in
+    task.ready) outcome=ready ;;
+    task.completed) outcome=completed ;;
+    *) return 0 ;;
+  esac
+  identity=$(printf '%s\n%s\n%s\n%s\n%s' \
+    "$SCHEMA" "$FM_NOTIFY_PROJECT" "$FM_NOTIFY_TASK" "$FM_NOTIFY_KIND" "$event")
+  event_id=$(printf '%s' "$identity" | fm_notify_sha256) || {
+    fm_notify_diag hash-unavailable "$event" "$FM_NOTIFY_TASK"
+    return 0
+  }
+  case "$event_id" in ''|*[!0-9a-f]*) fm_notify_diag hash-unavailable "$event" "$FM_NOTIFY_TASK"; return 0 ;; esac
+  occurred=$(date -u '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null) || occurred=1970-01-01T00:00:00Z
+  payload=$(printf '{"schema":"%s","event_id":"%s","event":"%s","task_id":"%s","project":"%s","kind":"%s","outcome":"%s","occurred_at":"%s"}\n' \
+    "$SCHEMA" "$event_id" "$event" "$FM_NOTIFY_TASK" "$FM_NOTIFY_PROJECT" \
+    "$FM_NOTIFY_KIND" "$outcome" "$occurred")
+  bytes=$(printf '%s\n' "$payload" | LC_ALL=C wc -c | tr -d '[:space:]')
+  case "$bytes" in ''|*[!0-9]*) bytes=$((PAYLOAD_MAX_BYTES + 1)) ;; esac
+  if [ "$bytes" -gt "$PAYLOAD_MAX_BYTES" ]; then
+    fm_notify_diag payload-invalid "$event" "$FM_NOTIFY_TASK"
+    return 0
+  fi
+  timeout_secs=$(fm_notify_timeout)
+  printf '%s\n' "$payload" | (fm_notify_run_hook "$FM_NOTIFY_HOOK" "$timeout_secs") >/dev/null 2>&1
+  rc=$?
+  case "$rc" in
+    0) ;;
+    124|137) fm_notify_diag hook-timeout "$event" "$FM_NOTIFY_TASK" ;;
+    *) fm_notify_diag hook-failed "$event" "$FM_NOTIFY_TASK" ;;
+  esac
+  return 0
+}
+
+case "${1:-}" in
+  -h|--help) usage; exit 0 ;;
+esac
+if [ "$#" -ne 2 ]; then
+  usage >&2
+  exit 2
+fi
+COMMAND=$1
+TASK_ID=$2
+case "$COMMAND" in status|completed) ;; *) usage >&2; exit 2 ;; esac
+
+fm_notify_load_hook
+HOOK_RESULT=$?
+[ "$HOOK_RESULT" -eq 0 ] || exit 0
+fm_notify_load_task "$TASK_ID" || exit 0
+
+case "$COMMAND" in
+  status)
+    fm_notify_status_ready "$TASK_ID" || exit 0
+    fm_notify_emit task.ready
+    ;;
+  completed)
+    fm_notify_emit task.completed
+    ;;
+esac
+exit 0

--- a/bin/fm-notify.sh
+++ b/bin/fm-notify.sh
@@ -189,7 +189,7 @@ fm_notify_status_ready() {  # <task-id>
   [ -f "$status" ] && [ ! -L "$status" ] || return 1
   line=$(last_status_line "$status")
   verb=$(status_line_verb "$line")
-  [ "$verb" = done ] || return 1
+  [ "$verb" = "done" ] || return 1
   if [ "$FM_NOTIFY_KIND" = scout ]; then
     return 0
   fi

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -1345,6 +1345,13 @@ fm_backend_clear_transition "$BACKEND" "$STATE" "$T" || true
 [ -n "$TASK_TMP" ] && rm -rf "$TASK_TMP"
 remove_pr_poll_artifacts "$STATE" "$ID" || exit 1
 retire_busy_state "$STATE" "$ID" "$BUSY_GEN" || exit 1
+# Successful non-forced teardown is the single task.completed owner across
+# local-only, direct-PR, no-mistakes, and scout paths. All landing/report and
+# cleanup checks have succeeded here, while task metadata still exists for the
+# notifier's bounded privacy-safe payload.
+if [ "$FORCE" != "--force" ] && { [ "$KIND" = ship ] || [ "$KIND" = scout ]; }; then
+  "$SCRIPT_DIR/fm-notify.sh" completed "$ID" || true
+fi
 rm -f "$STATE/$ID.status" "$STATE/$ID.turn-ended" "$STATE/$ID.meta" \
   "$STATE/$ID.pi-ext.ts" "$STATE/$ID.grok-turnend-token" \
   "$STATE/$ID.kimi-turnend-token"

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -454,6 +454,23 @@ scan_signals() {
   return 0
 }
 
+# The watcher is the single task.ready emission owner because every supported
+# harness and runtime backend converges on the same append-only status signal.
+# The notifier itself applies the delivery-mode boundary and is always fail-open.
+notify_ready_signals() {  # <pending scan rows>
+  local pending=$1 sf sig f id seen=$'\n'
+  while IFS=$(printf '\t') read -r sf sig f; do
+    [ -n "$sf" ] || continue
+    case "$f" in "$STATE"/*.status) ;; *) continue ;; esac
+    case "$seen" in *$'\n'"$f"$'\n'*) continue ;; esac
+    seen="$seen$f"$'\n'
+    id=$(basename "$f" .status)
+    "$SCRIPT_DIR/fm-notify.sh" status "$id" || true
+  done <<EOF
+$pending
+EOF
+}
+
 run_check_process() {
   local c=$1
   shift
@@ -812,6 +829,7 @@ while :; do
 $pending
 EOF
     reason="signal:$files"
+    notify_ready_signals "$pending"
     # Triage: a signal is ACTIONABLE when any of these holds (cheapest first):
     #   - the away-mode daemon owns triage (afk) and wants every wake;
     #   - any status file carries a captain-relevant verb;

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -158,6 +158,16 @@ The helper's header owns the exact signal detection, relocated-home limitation, 
 Ship tasks change projects and ship by project mode (`no-mistakes`, `direct-PR`, or `local-only`); scout tasks leave standalone investigation reports at `data/<id>/report.md` and never push.
 The intake and authority contract in `AGENTS.md` owns when separate scout research is warranted.
 
+## Optional task lifecycle notifications
+
+The optional notification hook is an informational observer and never participates in task, merge, cleanup, or backlog truth.
+`bin/fm-watch.sh` is the single `task.ready` emission owner because all supported worker tools and runtime providers converge on the same append-only status-event path.
+The watcher delegates mode-specific readiness recognition to `bin/fm-notify.sh`, so local-only branch readiness, direct-PR readiness, green no-mistakes PR readiness, and scout report readiness share one bounded payload contract without treating the no-mistakes pre-validation handoff as delivery-ready.
+`bin/fm-teardown.sh` is the single `task.completed` emission owner for local-only, direct-PR, no-mistakes, and scout work after the existing landing or report proof and non-forced cleanup have succeeded.
+Keeping completion at that common owner also covers a PR merged outside `fm-pr-merge.sh` and prevents explicit discard from being reported as completion.
+The stable event identity is derived only from the schema, bounded project name, task id, kind, and event, so retries, restarts, worker-tool changes, and runtime-provider changes retain the same semantic identity.
+[`configuration.md`](configuration.md#task-lifecycle-notification-hook-confignotification-hook) owns operator setup, while `bin/fm-notify.sh` owns the executable interface and exact data mechanics.
+
 ## Dispatch profiles
 
 Crewmate and scout dispatch can stay on the static crewmate harness resolved by `config/crew-harness`, or it can use local dispatch profiles in `config/crew-dispatch.json`.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -31,6 +31,17 @@ The `/calm` command replaces the file atomically before changing live presentati
 The extension reloads this preference on every Pi `session_start`, including startup, new, resume, fork, and reload reasons.
 This preference is local to each Firstmate home and is not part of secondmate inherited configuration.
 
+## Task lifecycle notification hook (config/notification-hook)
+
+Firstmate can send optional transport-neutral `task.ready` and `task.completed` events to one local executable without depending on an HTTP client or notification service.
+To enable it, write the executable's absolute path as the only line of the effective home's gitignored `config/notification-hook` file.
+The executable receives one bounded `firstmate.notification.v1` JSON object on standard input and no arguments, so it can forward the event to any locally chosen service.
+Firstmate never evaluates this configuration as shell syntax, and relative paths, command strings, directories, and non-executable files are ignored with a bounded local diagnostic.
+An absent file disables the feature silently, while hook failures and timeouts leave task, merge, cleanup, backlog, and command exit status unchanged.
+Failure diagnostics are recorded without hook output, configured paths, prompts, or environment values in the gitignored `state/notification-hook.log` file.
+The exact payload fields, bounds, timeout, diagnostics retention, and executable invocation mechanics are owned by [`bin/fm-notify.sh`](../bin/fm-notify.sh)'s header and `--help` output.
+The hook is local to each Firstmate home and is not inherited into secondmate homes.
+
 ## Backlog backend (.tasks.toml / config/backlog-backend)
 
 The tracked `.tasks.toml` pins the default `tasks-axi` markdown backend to `data/backlog.md`, with `done_keep = 10` and an archive at `data/done-archive.md`.
@@ -441,6 +452,7 @@ FM_CODEX_WATCH_CHECKPOINT=180   # seconds per foreground watcher checkpoint in C
 FM_CREW_STATE_NM_TIMEOUT=10   # seconds allowed per no-mistakes query inside fm-crew-state.sh
 FM_CREW_STATE_RUNS_LIMIT=200  # recent no-mistakes run rows scanned when axi status cannot be attributed to the current code
 FM_CREW_STATE_BIN=bin/fm-crew-state.sh   # test override for the current-state reader used by working/paused watcher triage
+FM_NOTIFICATION_TIMEOUT_SECS=5   # seconds allowed for the optional config/notification-hook executable; positive integers only, capped at 60
 FMX_PAIRING_TOKEN=      # X mode pairing token; .env opt-in authorizes replies and eligible lifecycle actions
 FMX_RELAY_URL=https://myfirstmate.io   # optional X relay override, mainly for local relay development
 FMX_ENV_FILE=           # optional alternate .env file for direct X client invocations; bootstrap still checks $FM_HOME/.env

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -75,6 +75,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-wake-drain.sh`       | Atomically drain queued watcher wakes, emit bounded best-effort status-event annotations, then assert watcher liveness |
 | `fm-wake-lib.sh`         | Shared durable wake queue, portable locks, and watcher identity/health helpers       |
 | `fm-classify-lib.sh`     | Shared captain-relevant and declared-external-wait wake classification vocabulary    |
+| `fm-notify.sh`           | Emit the optional bounded fail-open `task.ready`/`task.completed` lifecycle notification through the configured hook |
 | `fm-send.sh`             | Send one verified literal line or supported key through the target's recorded backend |
 | `fm-busy-lib.sh`         | Single owner of the semantic busy-state contract: verdicts, source attribution, and per-harness sources |
 | `fm-busy-event.sh`       | The only writer of a task's semantic busy-state record; arms an incarnation and applies lifecycle events |

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -6,6 +6,33 @@ This record contains reusable version-scoped evidence for active runtime guarant
 The backend guides own current setup, safety boundaries, and limitations.
 Exact task chronology, branch names, temporary homes, local paths, process ids, thread ids, and delivery transcripts remain in private reports or PR evidence.
 
+## Task lifecycle notification neutrality
+
+The transport-neutral task lifecycle notification contract was verified on 2026-08-01 with GNU Bash 5.2.21, Git 2.43.0, and jq 1.7 on Linux x86_64.
+The executable-interface matrix covers absent and configured hooks, failure and timeout behavior, malformed path refusal, payload bounds, readiness and completion semantics for every delivery mode and scouts, stable retry identity, and watcher ownership.
+The same matrix varies task metadata across Claude, Codex, OpenCode, Pi, pi-signed, Grok, and Kimi plus tmux, Herdr, Zellij, Orca, and cmux, and requires the event identity to remain unchanged.
+This is applicable to every worker tool and runtime provider because readiness is consumed only after their common status-file convergence and completion is emitted only from their common cleanup path.
+No tool-specific hook or runtime-provider adapter participates in payload construction or execution.
+
+```sh
+tests/fm-notify.test.sh
+GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=safe.bareRepository GIT_CONFIG_VALUE_0=all tests/fm-teardown.test.sh | grep -F 'successful teardown solely emits completion'
+```
+
+Observed bounded output:
+
+```text
+ok - an absent notification hook is silent and non-fatal
+ok - a configured hook receives bounded privacy-safe JSON on standard input
+ok - hook failures and timeouts stay non-fatal with privacy-safe diagnostics
+ok - relative paths, command strings, directories, and non-executables are never evaluated
+ok - ready emission matches local-only, direct-PR, no-mistakes, and scout delivery boundaries
+ok - retries and every supported harness/runtime backend preserve one event identity
+ok - completed emission supports local-only, direct-PR, no-mistakes, and scout tasks
+ok - the backend-neutral watcher owns task.ready emission from status events
+ok - successful teardown solely emits completion for every delivery path and never for forced discard
+```
+
 ## tmux
 
 Foreground-process behavior was verified on 2026-07-07 with tmux 3.6a on macOS.

--- a/tests/fm-notify.test.sh
+++ b/tests/fm-notify.test.sh
@@ -26,7 +26,8 @@ SH
 }
 
 write_task() {  # <case> <mode> <kind> [task-id] [project]
-  local dir=$1 mode=$2 kind=$3 id=${4:-task-x1} project=${5:-$dir/projects/example-project}
+  local dir=$1 mode=$2 kind=$3 id=${4:-task-x1} project
+  project=${5:-$dir/projects/example-project}
   fm_write_meta "$dir/state/$id.meta" \
     "window=fm-$id" \
     "endpoint_task_id=$id" \

--- a/tests/fm-notify.test.sh
+++ b/tests/fm-notify.test.sh
@@ -1,0 +1,275 @@
+#!/usr/bin/env bash
+# Executable-interface tests for Firstmate's optional task lifecycle notifier.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+NOTIFY="$ROOT/bin/fm-notify.sh"
+WATCH="$ROOT/bin/fm-watch.sh"
+TMP_ROOT=$(fm_test_tmproot fm-notify-tests)
+
+make_case() {  # <name>
+  local name=$1 dir hook
+  dir="$TMP_ROOT/$name"
+  mkdir -p "$dir/state" "$dir/config" "$dir/fakebin"
+  hook="$dir/hook"
+  cat > "$hook" <<'SH'
+#!/usr/bin/env bash
+IFS= read -r payload || exit 1
+printf '%s\n' "$payload" >> "${FM_NOTIFY_CAPTURE:?}"
+SH
+  chmod +x "$hook"
+  printf '%s\n' "$hook" > "$dir/config/notification-hook"
+  : > "$dir/capture"
+  printf '%s\n' "$dir"
+}
+
+write_task() {  # <case> <mode> <kind> [task-id] [project]
+  local dir=$1 mode=$2 kind=$3 id=${4:-task-x1} project=${5:-$dir/projects/example-project}
+  fm_write_meta "$dir/state/$id.meta" \
+    "window=fm-$id" \
+    "endpoint_task_id=$id" \
+    "worktree=$dir/wt" \
+    "project=$project" \
+    "harness=codex" \
+    "kind=$kind" \
+    "mode=$mode"
+}
+
+run_notify() {  # <case> <command> <task-id>
+  local dir=$1 command=$2 id=$3
+  FM_ROOT_OVERRIDE="$ROOT" \
+  FM_STATE_OVERRIDE="$dir/state" \
+  FM_CONFIG_OVERRIDE="$dir/config" \
+  FM_NOTIFY_CAPTURE="$dir/capture" \
+    "$NOTIFY" "$command" "$id"
+}
+
+capture_count() {  # <case>
+  awk 'END { print NR + 0 }' "$1/capture"
+}
+
+last_payload() {  # <case>
+  tail -1 "$1/capture"
+}
+
+assert_payload() {  # <json> <event> <task> <project> <kind> <outcome>
+  local payload=$1 event=$2 task=$3 project=$4 kind=$5 outcome=$6
+  printf '%s\n' "$payload" | jq -e \
+    --arg event "$event" --arg task "$task" --arg project "$project" \
+    --arg kind "$kind" --arg outcome "$outcome" \
+    '.schema == "firstmate.notification.v1"
+     and .event == $event
+     and .task_id == $task
+     and .project == $project
+     and .kind == $kind
+     and .outcome == $outcome
+     and (.event_id | test("^[0-9a-f]{64}$"))
+     and (.occurred_at | test("^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$"))' \
+    >/dev/null || fail "unexpected notification payload: $payload"
+}
+
+test_absent_hook_is_silent() {
+  local dir rc
+  dir=$(make_case absent)
+  write_task "$dir" local-only ship
+  rm -f "$dir/config/notification-hook"
+  set +e
+  run_notify "$dir" completed task-x1 > "$dir/stdout" 2> "$dir/stderr"
+  rc=$?
+  set -e
+  expect_code 0 "$rc" "absent hook changed notifier exit status"
+  [ ! -s "$dir/stdout" ] || fail "absent hook wrote stdout"
+  [ ! -s "$dir/stderr" ] || fail "absent hook wrote stderr"
+  [ ! -e "$dir/state/notification-hook.log" ] || fail "absent hook wrote a diagnostic"
+  pass "an absent notification hook is silent and non-fatal"
+}
+
+test_configured_hook_receives_bounded_json() {
+  local dir id project payload bytes
+  dir=$(make_case configured)
+  id=abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789._
+  project="$(printf 'private/%.0s' {1..30})$(printf 'project-name-with-extra-characters-%.0s' {1..4})"
+  write_task "$dir" local-only ship "$id" "$project"
+  run_notify "$dir" completed "$id" || fail "configured hook invocation failed"
+  payload=$(last_payload "$dir")
+  bytes=$(printf '%s\n' "$payload" | LC_ALL=C wc -c | tr -d '[:space:]')
+  [ "$bytes" -le 512 ] || fail "payload exceeded 512 bytes: $bytes"
+  [ "$(printf '%s\n' "$payload" | jq -r '.task_id | length')" -le 64 ] || fail "task id exceeded bound"
+  [ "$(printf '%s\n' "$payload" | jq -r '.project | length')" -le 64 ] || fail "project exceeded bound"
+  assert_no_grep 'private/' "$dir/capture" "payload leaked a project path"
+  assert_payload "$payload" task.completed "$id" \
+    "$(printf '%s' "${project##*/}" | LC_ALL=C tr -c 'A-Za-z0-9._-' '_' | cut -c1-64)" \
+    ship completed
+  pass "a configured hook receives bounded privacy-safe JSON on standard input"
+}
+
+test_hook_failure_and_timeout_are_nonfatal_and_inspectable() {
+  local dir rc
+  dir=$(make_case failure)
+  write_task "$dir" local-only ship
+  cat > "$dir/hook" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' 'secret stdout' >&1
+printf '%s\n' 'secret stderr' >&2
+exit 7
+SH
+  chmod +x "$dir/hook"
+  set +e
+  run_notify "$dir" completed task-x1 > "$dir/stdout" 2> "$dir/stderr"
+  rc=$?
+  set -e
+  expect_code 0 "$rc" "failing hook changed notifier exit status"
+  [ ! -s "$dir/stdout" ] || fail "failing hook output escaped to stdout"
+  [ ! -s "$dir/stderr" ] || fail "failing hook output escaped to stderr"
+  assert_grep 'result=hook-failed' "$dir/state/notification-hook.log" "hook failure diagnostic missing"
+  assert_no_grep 'secret' "$dir/state/notification-hook.log" "hook output leaked into diagnostics"
+
+  cat > "$dir/hook" <<'SH'
+#!/usr/bin/env bash
+sleep 5
+SH
+  chmod +x "$dir/hook"
+  : > "$dir/state/notification-hook.log"
+  set +e
+  FM_NOTIFICATION_TIMEOUT_SECS=1 run_notify "$dir" completed task-x1 > "$dir/stdout" 2> "$dir/stderr"
+  rc=$?
+  set -e
+  expect_code 0 "$rc" "timed-out hook changed notifier exit status"
+  assert_grep 'result=hook-timeout' "$dir/state/notification-hook.log" "hook timeout diagnostic missing"
+  pass "hook failures and timeouts stay non-fatal with privacy-safe diagnostics"
+}
+
+test_malformed_paths_never_become_commands() {
+  local dir marker value
+  dir=$(make_case malformed)
+  write_task "$dir" local-only ship
+  marker="$dir/executed"
+  for value in 'relative-hook' "$dir/hook --argument" "$dir" "$dir/not-executable"; do
+    printf '%s\n' "$value" > "$dir/config/notification-hook"
+    printf '#!/usr/bin/env bash\ntouch %q\n' "$marker" > "$dir/not-executable"
+    chmod 0600 "$dir/not-executable"
+    run_notify "$dir" completed task-x1 || fail "malformed hook path changed exit status"
+  done
+  [ ! -e "$marker" ] || fail "malformed hook configuration was shell-evaluated"
+  grep -qE 'result=(config-malformed|hook-not-executable)' "$dir/state/notification-hook.log" \
+    || fail "malformed hook path diagnostic missing"
+  pass "relative paths, command strings, directories, and non-executables are never evaluated"
+}
+
+test_ready_semantics_cover_every_delivery_mode_and_scouts() {
+  local dir payload
+  dir=$(make_case ready-matrix)
+
+  write_task "$dir" local-only ship
+  printf '%s\n' 'working: rebased onto merged main' > "$dir/state/task-x1.status"
+  run_notify "$dir" status task-x1
+  [ "$(capture_count "$dir")" -eq 0 ] || fail "nonterminal local-only status emitted ready"
+  printf '%s\n' 'done: ready in branch fm/task-x1' >> "$dir/state/task-x1.status"
+  run_notify "$dir" status task-x1
+  payload=$(last_payload "$dir")
+  assert_payload "$payload" task.ready task-x1 example-project ship ready
+
+  : > "$dir/capture"
+  write_task "$dir" direct-PR ship
+  printf '%s\n' 'done: PR https://example.invalid/repo/pull/1' > "$dir/state/task-x1.status"
+  run_notify "$dir" status task-x1
+  [ "$(capture_count "$dir")" -eq 1 ] || fail "direct-PR ready status did not emit once"
+
+  : > "$dir/capture"
+  write_task "$dir" no-mistakes ship
+  printf '%s\n' 'done: implementation ready for validation' > "$dir/state/task-x1.status"
+  run_notify "$dir" status task-x1
+  [ "$(capture_count "$dir")" -eq 0 ] || fail "pre-validation no-mistakes status emitted ready"
+  printf '%s\n' 'done: PR https://example.invalid/repo/pull/2 checks green' >> "$dir/state/task-x1.status"
+  run_notify "$dir" status task-x1
+  [ "$(capture_count "$dir")" -eq 1 ] || fail "green no-mistakes PR did not emit ready"
+
+  : > "$dir/capture"
+  write_task "$dir" no-mistakes scout
+  printf '%s\n' 'done: report complete' > "$dir/state/task-x1.status"
+  run_notify "$dir" status task-x1
+  payload=$(last_payload "$dir")
+  assert_payload "$payload" task.ready task-x1 example-project scout ready
+  pass "ready emission matches local-only, direct-PR, no-mistakes, and scout delivery boundaries"
+}
+
+test_identities_ignore_retries_harnesses_and_backends() {
+  local dir first id backend harness payload
+  dir=$(make_case identity)
+  first=
+  for harness in claude codex opencode pi pi-signed grok kimi; do
+    for backend in tmux herdr zellij orca cmux; do
+      : > "$dir/capture"
+      write_task "$dir" local-only ship
+      printf 'harness=%s\nbackend=%s\n' "$harness" "$backend" >> "$dir/state/task-x1.meta"
+      printf '%s\n' 'done: ready in branch fm/task-x1' > "$dir/state/task-x1.status"
+      run_notify "$dir" status task-x1
+      run_notify "$dir" status task-x1
+      [ "$(capture_count "$dir")" -eq 2 ] || fail "retry did not exercise hook twice for $harness/$backend"
+      payload=$(last_payload "$dir")
+      id=$(printf '%s\n' "$payload" | jq -r '.event_id')
+      [ -n "$first" ] || first=$id
+      [ "$id" = "$first" ] || fail "identity changed for $harness/$backend"
+      [ "$(jq -r '.event_id' "$dir/capture" | sort -u | wc -l | tr -d '[:space:]')" -eq 1 ] \
+        || fail "retry identity changed for $harness/$backend"
+    done
+  done
+  pass "retries and every supported harness/runtime backend preserve one event identity"
+}
+
+test_completed_semantics_cover_all_modes_and_scouts() {
+  local dir spec mode kind payload
+  dir=$(make_case completed-matrix)
+  for spec in local-only:ship direct-PR:ship no-mistakes:ship no-mistakes:scout; do
+    mode=${spec%%:*}
+    kind=${spec#*:}
+    : > "$dir/capture"
+    write_task "$dir" "$mode" "$kind"
+    run_notify "$dir" completed task-x1
+    payload=$(last_payload "$dir")
+    assert_payload "$payload" task.completed task-x1 example-project "$kind" completed
+  done
+  pass "completed emission supports local-only, direct-PR, no-mistakes, and scout tasks"
+}
+
+test_watcher_is_the_ready_emission_owner() {
+  local dir hook rc
+  dir=$(make_case watcher-owner)
+  write_task "$dir" local-only ship
+  printf '%s\n' 'done: ready in branch fm/task-x1' > "$dir/state/task-x1.status"
+  hook="$dir/hook"
+  cat > "$dir/fakebin/tmux" <<'SH'
+#!/usr/bin/env bash
+case "${1:-}" in
+  list-windows) exit 0 ;;
+esac
+exit 1
+SH
+  chmod +x "$dir/fakebin/tmux"
+  set +e
+  PATH="$dir/fakebin:$PATH" \
+  FM_ROOT_OVERRIDE="$ROOT" \
+  FM_STATE_OVERRIDE="$dir/state" \
+  FM_CONFIG_OVERRIDE="$dir/config" \
+  FM_NOTIFY_CAPTURE="$dir/capture" \
+  FM_SIGNAL_GRACE=0 FM_POLL=1 FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 \
+    "$WATCH" > "$dir/stdout" 2> "$dir/stderr"
+  rc=$?
+  set -e
+  expect_code 0 "$rc" "watcher ready-owner run failed"
+  [ "$(capture_count "$dir")" -eq 1 ] || fail "watcher did not emit exactly one ready notification"
+  assert_payload "$(last_payload "$dir")" task.ready task-x1 example-project ship ready
+  [ -x "$hook" ] || fail "configured hook changed during watcher run"
+  pass "the backend-neutral watcher owns task.ready emission from status events"
+}
+
+test_absent_hook_is_silent
+test_configured_hook_receives_bounded_json
+test_hook_failure_and_timeout_are_nonfatal_and_inspectable
+test_malformed_paths_never_become_commands
+test_ready_semantics_cover_every_delivery_mode_and_scouts
+test_identities_ignore_retries_harnesses_and_backends
+test_completed_semantics_cover_all_modes_and_scouts
+test_watcher_is_the_ready_emission_owner

--- a/tests/fm-teardown.test.sh
+++ b/tests/fm-teardown.test.sh
@@ -493,9 +493,80 @@ run_teardown() {
   local case_dir=$1; shift
   FM_ROOT_OVERRIDE="$ROOT" \
   FM_STATE_OVERRIDE="$case_dir/state" \
+  FM_DATA_OVERRIDE="$case_dir/data" \
   FM_CONFIG_OVERRIDE="$case_dir/config" \
+  FM_NOTIFY_CAPTURE="${FM_NOTIFY_CAPTURE:-$case_dir/capture}" \
   PATH="$case_dir/fakebin:$PATH" \
     "$TEARDOWN" task-x1 "$@"
+}
+
+configure_notification_hook() {  # <case-dir>
+  local case_dir=$1
+  cat > "$case_dir/notification-hook" <<'SH'
+#!/usr/bin/env bash
+IFS= read -r payload || exit 1
+printf '%s\n' "$payload" >> "${FM_NOTIFY_CAPTURE:?}"
+SH
+  chmod +x "$case_dir/notification-hook"
+  printf '%s\n' "$case_dir/notification-hook" > "$case_dir/config/notification-hook"
+  : > "$case_dir/capture"
+}
+
+add_decision_verify_tasks_axi() {  # <case-dir>
+  local case_dir=$1
+  cat > "$case_dir/fakebin/tasks-axi" <<'SH'
+#!/usr/bin/env bash
+case "${1:-} ${2:-}" in
+  "--version ") printf '%s\n' '0.2.2'; exit 0 ;;
+  "update --help") printf '%s\n' 'usage: tasks-axi update --archive-body'; exit 0 ;;
+  "mv --help") printf '%s\n' 'usage: tasks-axi mv <id> [<id>...] --to <path>'; exit 0 ;;
+  "hold --help") printf '%s\n' 'usage: tasks-axi hold <id> --kind captain'; exit 0 ;;
+esac
+exit 0
+SH
+  chmod +x "$case_dir/fakebin/tasks-axi"
+}
+
+test_completed_notification_uses_successful_teardown_for_all_delivery_paths() {
+  local spec mode kind case_dir count event outcome payload force_case
+  for spec in local-only:ship direct-PR:ship no-mistakes:ship no-mistakes:scout; do
+    mode=${spec%%:*}
+    kind=${spec#*:}
+    case_dir=$(make_case "notify-${mode}-${kind}")
+    write_meta "$case_dir" "$mode" "$kind"
+    configure_notification_hook "$case_dir"
+    if [ "$kind" = scout ]; then
+      mkdir -p "$case_dir/data/task-x1"
+      printf '%s\n' '# Report' > "$case_dir/data/task-x1/report.md"
+      printf '%s\n' 'decisions_reviewed=1' 'decision_keys=' >> "$case_dir/state/task-x1.meta"
+      add_decision_verify_tasks_axi "$case_dir"
+    else
+      wt_commit "$case_dir" "landed $mode work"
+      if [ "$mode" = local-only ]; then
+        git -C "$case_dir/project" merge -q --ff-only fm/task-x1
+      else
+        add_fork_with_pushed_branch "$case_dir"
+      fi
+    fi
+    run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr" \
+      || fail "notification teardown failed for $mode/$kind"
+    count=$(awk 'END { print NR + 0 }' "$case_dir/capture")
+    [ "$count" -eq 1 ] || fail "teardown emitted $count completion notifications for $mode/$kind"
+    payload=$(tail -1 "$case_dir/capture")
+    event=$(printf '%s\n' "$payload" | jq -r '.event')
+    outcome=$(printf '%s\n' "$payload" | jq -r '.outcome')
+    [ "$event/$outcome" = task.completed/completed ] \
+      || fail "teardown emitted the wrong completion payload for $mode/$kind"
+  done
+
+  force_case=$(make_case notify-force-discard)
+  write_meta "$force_case" local-only ship
+  configure_notification_hook "$force_case"
+  wt_commit "$force_case" "discarded work"
+  run_teardown "$force_case" --force > "$force_case/stdout" 2> "$force_case/stderr" \
+    || fail "forced discard fixture failed"
+  [ ! -s "$force_case/capture" ] || fail "forced discard emitted task.completed"
+  pass "successful teardown solely emits completion for every delivery path and never for forced discard"
 }
 
 test_local_only_fork_remote_allows() {
@@ -1399,6 +1470,7 @@ test_herdr_projection_teardown_retains_journal_when_close_unconfirmed() {
 }
 
 test_local_only_fork_remote_allows
+test_completed_notification_uses_successful_teardown_for_all_delivery_paths
 test_teardown_prompts_tasks_axi_done_when_compatible
 test_teardown_manual_backend_prompts_hand_edit_even_when_tasks_axi_present
 test_local_only_truly_unpushed_refuses


### PR DESCRIPTION
## Intent

Publish the already fully validated Firstmate task-lifecycle notification hook branch through the authenticated fork, open its pull request against kunchenguid/firstmate, and verify CI.

## What Changed

- New `bin/fm-notify.sh` emits optional, fail-open `task.ready`/`task.completed` events to a local executable configured via `config/notification-hook`, sending one bounded privacy-safe `firstmate.notification.v1` JSON payload (≤512 bytes, stable SHA-256 event identity) on stdin with a clamped `FM_NOTIFICATION_TIMEOUT_SECS` timeout and size-capped fixed-token diagnostics in `state/notification-hook.log`.
- `bin/fm-watch.sh` becomes the single `task.ready` emission owner, invoking the notifier on pending status signals with mode-specific readiness (local-only, direct-PR, green no-mistakes PR, scout report) resolved inside `fm-notify.sh`; `bin/fm-teardown.sh` becomes the single `task.completed` owner, emitting only after a successful non-forced ship/scout teardown.
- Adds `tests/fm-notify.test.sh` and a teardown completion-emission test, and documents the hook across `AGENTS.md`, `docs/configuration.md`, `docs/architecture.md`, `docs/scripts.md`, and `docs/verification/runtime-backends.md`.

## Testing

- ⏭️ **Test** - skipped

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⏭️ **Review** - skipped</summary>

Step was skipped.

</details>

<details>
<summary>⏭️ **Test** - skipped</summary>

Step was skipped.

</details>

<details>
<summary>⏭️ **Document** - skipped</summary>

Step was skipped.

</details>

<details>
<summary>⏭️ **Lint** - skipped</summary>

Step was skipped.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
