### PR TITLE
fix(watch): attach --restart to a healthy watcher instead of force-replacing

### DIFF
--- a/bin/fm-watch-arm.sh
+++ b/bin/fm-watch-arm.sh
@@ -49,11 +49,10 @@
 # state/.watch-triage.log remains exclusively the watcher's absorbed-wake debug
 # log and is never written here.
 #
-# --restart: stop ONLY this FM_HOME's watcher (the pid recorded in THIS home's
-# state/.watch.lock) and own a fresh cycle, or attach if a verified live peer
-# wins the singleton while the duplicate child stands down. It
-# resolves and signals exactly that pid, so it can never touch another home's
-# watcher. NEVER `pkill -f
+# --restart: attach when THIS home's recorded watcher is identity-verified and
+# healthy. Only when replacement is required does it stop the recorded watcher
+# and own a fresh cycle. It resolves and signals exactly that pid, so it can
+# never touch another home's watcher. NEVER `pkill -f
 # bin/fm-watch.sh`: that pattern matches every firstmate home's watcher
 # (secondmate homes run the same script) and would kill siblings.
 set -u
@@ -331,8 +330,20 @@ case "${1:-}" in
   *) echo "usage: $(basename "$0") [--restart]" >&2; exit 2 ;;
 esac
 
+# If a genuinely live+fresh watcher already holds the lock, both arm modes
+# attach to that cycle and wait until it ends so the harness notify fires then,
+# not as an immediate empty wake. A healthy singleton already satisfies restart;
+# replacement is reserved for a holder that fails this shared health gate.
+if healthy_watcher; then
+  cycle_mark_predecessor_successor "attached:$HEALTHY_PID"
+  cycle_begin "$HEALTHY_PID" attached
+  report_attached
+  attach_and_wait "$HEALTHY_PID"
+  exit $?
+fi
+
 if [ "$mode" = restart ]; then
-  # Home-scoped stop: only the watcher pid recorded in THIS home's lock.
+  # Home-scoped stop: only an unhealthy watcher pid recorded in THIS home's lock.
   lock_pid=$(cat "$WATCH_LOCK/pid" 2>/dev/null || true)
   if fm_pid_alive "$lock_pid"; then
     if fm_watcher_lock_matches_pid "$STATE" "$WATCH" "$lock_pid" "$FM_HOME"; then
@@ -349,18 +360,6 @@ if [ "$mode" = restart ]; then
       clear_stale_recorded_watcher_lock
     fi
   fi
-fi
-
-# If a genuinely live+fresh watcher already holds the lock, do not start a second
-# one - attach to that cycle and wait until it ends so the harness notify fires
-# then, not as an immediate empty wake. (--restart skips this: it just stopped
-# this home's watcher and wants a fresh one.)
-if [ "$mode" = arm ] && healthy_watcher; then
-  cycle_mark_predecessor_successor "attached:$HEALTHY_PID"
-  cycle_begin "$HEALTHY_PID" attached
-  report_attached
-  attach_and_wait "$HEALTHY_PID"
-  exit $?
 fi
 
 # Start a watcher as a tracked child and confirm it before settling in. The child

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -63,7 +63,7 @@ Pi and OpenCode verify session-lock ownership and launch one singleton successor
 Claude's `bin/fm-claude-stop-autoarm.sh` hook fires on every Stop and, when the home is eligible and still needs supervision, claims one home-scoped cycle, foregrounds the arm wrapper, and translates an actionable close or typed failure into one exit-2 rewake.
 [`watcher-continuity.md`](watcher-continuity.md) owns Claude's residual active-turn coverage and watcher-status command-gating boundary.
 The existing turn-end guard remains the final backstop for all five harness-engine protocols, with pi-signed sharing Pi's protocol and the `--claude` mode cooperating with the auto-arm claim.
-Its `--restart` mode signals only the watcher recorded in the current home's `state/.watch.lock`, so restarting one home cannot kill sibling secondmate watchers.
+Its `--restart` mode attaches to a healthy identity-matched watcher recorded in the current home's `state/.watch.lock`; only a holder that fails the shared health gate may be replaced, and any signal remains scoped to that exact recorded process so sibling secondmate watchers cannot be killed.
 A pull-based guard (`bin/fm-guard.sh`) warns through supervision tool output if the primary checkout is tangled, or if tasks are in flight and that watcher stops running or queued wakes are waiting to be drained.
 The drain script calls that guard after emptying the queue, which avoids repeating the queued-wakes warning for records it just consumed while still warning on stale watcher liveness.
 It leads with a prominent bordered tangle banner, while `bin/fm-guard.sh` owns the stale-watcher banner/reminder policy so repeated guarded commands stay noisy without reprinting the full watcher-down banner in the same episode.

--- a/tests/fm-watcher-lock.test.sh
+++ b/tests/fm-watcher-lock.test.sh
@@ -438,15 +438,37 @@ test_watch_restart_rejects_reused_pid() {
 }
 
 test_watch_restart_attaches_to_healthy_peer() {
-  local dir state fakebin out peer identity armpid status i
+  local dir state fakebin out ready term_log peer identity armpid status failure i
   dir=$(make_case restart-healthy-peer)
   state="$dir/state"
   fakebin="$dir/fakebin"
   out="$dir/restart.out"
+  ready="$dir/peer.ready"
+  term_log="$dir/peer.term"
   mark_pr_check_migration_complete "$state"
-  node -e 'process.on("SIGTERM", () => {}); setTimeout(() => {}, 300000)' &
+  FM_PEER_READY="$ready" FM_PEER_TERM_LOG="$term_log" node -e '
+    const fs = require("fs");
+    process.on("SIGTERM", () => fs.appendFileSync(process.env.FM_PEER_TERM_LOG, "TERM\n"));
+    fs.writeFileSync(process.env.FM_PEER_READY, "ready\n");
+    setTimeout(() => {}, 300000);
+  ' &
   peer=$!
-  identity=$(FM_STATE_OVERRIDE="$state" bash -c '. "$1"; fm_pid_identity "$2"' _ "$LIB" "$peer") || fail "could not identify peer pid"
+  i=0
+  while [ "$i" -lt 80 ]; do
+    [ -s "$ready" ] && break
+    sleep 0.1
+    i=$((i + 1))
+  done
+  if [ ! -s "$ready" ]; then
+    kill -KILL "$peer" 2>/dev/null || true
+    wait "$peer" 2>/dev/null || true
+    fail "TERM-resistant peer did not become ready"
+  fi
+  identity=$(FM_STATE_OVERRIDE="$state" bash -c '. "$1"; fm_pid_identity "$2"' _ "$LIB" "$peer") || {
+    kill -KILL "$peer" 2>/dev/null || true
+    wait "$peer" 2>/dev/null || true
+    fail "could not identify peer pid"
+  }
   mkdir "$state/.watch.lock"
   printf '%s\n' "$peer" > "$state/.watch.lock/pid"
   printf '%s\n' "$dir" > "$state/.watch.lock/fm-home"
@@ -461,9 +483,25 @@ test_watch_restart_attaches_to_healthy_peer() {
     sleep 0.1
     i=$((i + 1))
   done
-  grep -qF "watcher: attached pid=$peer" "$out" || fail "restart did not attach to the verified healthy peer: $(cat "$out")"
-  is_live_non_zombie "$armpid" || fail "restart arm exited instead of following the healthy peer"
-  is_live_non_zombie "$peer" || fail "restart killed a TERM-resistant peer unexpectedly"
+  failure=
+  grep -qF "watcher: attached pid=$peer" "$out" \
+    || failure="restart did not attach to the verified healthy peer: $(cat "$out")"
+  if [ -z "$failure" ] && ! is_live_non_zombie "$armpid"; then
+    failure="restart arm exited instead of following the healthy peer"
+  fi
+  if [ -z "$failure" ] && ! is_live_non_zombie "$peer"; then
+    failure="restart killed a TERM-resistant peer unexpectedly"
+  fi
+  if [ -z "$failure" ] && [ -s "$term_log" ]; then
+    failure="restart signaled a verified healthy peer before attaching"
+  fi
+  if [ -n "$failure" ]; then
+    kill -TERM "$armpid" 2>/dev/null || true
+    kill -KILL "$peer" 2>/dev/null || true
+    wait "$armpid" 2>/dev/null || true
+    wait "$peer" 2>/dev/null || true
+    fail "$failure"
+  fi
   kill -KILL "$peer" 2>/dev/null || true
   wait "$peer" 2>/dev/null || true
   wait_for_exit "$armpid" 80


### PR DESCRIPTION
## Intent

Repair the watcher restart contract so `bin/fm-watch-arm.sh --restart` attaches to an already healthy, identity-verified watcher without signaling it. Preserve home scoping, singleton ownership, stale-lock recovery, PID-reuse resistance, bounded replacement behavior, Bash 3.2 compatibility, and the live primary watcher. Keep this change separate from the parked #1336 branch.

## What changed

- Moved the shared healthy-watcher gate ahead of arm/restart mode dispatch.
- Both ordinary arm and `--restart` now attach to a healthy identity-matched watcher and follow that cycle.
- Replacement remains limited to an unhealthy holder recorded in the same `FM_HOME` lock.
- Strengthened `tests/fm-watcher-lock.test.sh` with a ready-synchronized TERM-resistant peer, a no-TERM assertion, and failure-path fixture cleanup.
- Updated the maintained architecture contract for the new restart behavior.

## Diagnosis

- Initiating trigger: `--restart` entered its replacement path before checking shared watcher health.
- Masking condition: a peer that had already installed its TERM handler could survive the signal and make the later attach path appear correct.
- Visible symptom: the focused test observed `watcher: started` instead of attaching to the verified healthy peer, and the failed fixture could retain the test pipe.
- Counterfactual: ordinary arm attached successfully to the same healthy, identity-verified state, isolating the divergence to restart mode.

## Validation

No-mistakes run `01KYWKT69M4Y1NT901Z8JTEXW1` completed rebase, independent review, full tests, documentation review, lint, fork push, PR creation, and its checks-passed decision point on rebased head `eaf5c96`.

The branch was pushed to the approved public fork `calebkeller2/firstmate` and this PR targets `kunchenguid/firstmate`. The pull request is intentionally unmerged.