### PR TITLE
feat: add decision-brief skill for executive decision summaries

### DIFF
--- a/.agents/skills/decision-brief/SKILL.md
+++ b/.agents/skills/decision-brief/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: decision-brief
+description: >-
+  Produce a reconciled executive brief of every current Captain's Call or other action requiring the captain's input.
+  Use when the captain invokes /decision-brief or asks for a breakdown, executive brief, background, or decision analysis of all current Captain's Calls or decisions requiring their input.
+user-invocable: true
+metadata:
+  internal: true
+---
+
+# decision-brief
+
+Give the captain a self-contained executive explanation of every current unresolved decision or action that requires their input.
+Write for a high-level executive audience that needs business context, realistic choices, consequences, and copyable approval language rather than implementation detail.
+This skill is read-only unless the captain explicitly asks for a file or durable report.
+It never approves a choice, merges a PR, dispatches or steers work, changes a decision record, resets a credential, performs an interactive login, or otherwise mutates fleet or project state.
+
+## Reconcile the current decision set
+
+Do not draft from conversation memory, a previous brief, report prose alone, or the latest event line.
+Build a fresh current inventory before writing.
+
+1. Gather the complete read-only structured fleet snapshot across the main home and every registered secondmate home.
+   Inspect every omission, truncation, unavailable home, and inventory contradiction, and use the snapshot helper's current `--help` rather than inventing another state parser.
+2. Inventory every structured captain-actionable backlog item, every currently open keyed decision associated with live work, every PR that is currently ready and awaiting the captain's merge approval, every credential or interactive login currently needed, and every destructive, irreversible, security-sensitive, or operational action that current state assigns to the captain.
+3. Inspect each candidate's full authoritative backlog record in its owning home and the current task state for any associated live work.
+   Follow referenced investigation reports, decision records, review artifacts, and full PR URLs only as needed to explain context, history, options, and consequences.
+   Never read a secondmate's chat or treat raw terminal text as authoritative state.
+4. Reconcile event history against current structured state.
+   Exclude resolved, declined, superseded, historical, not-yet-actionable, and duplicate requests.
+   A durable captain decision remains current until its authoritative record is closed, while an event-only request is current only when the associated task's reconciled state still confirms that it needs the captain.
+   Treat differently worded records as one duplicate only when they ask for the same answer and resolving either necessarily resolves the other.
+5. Group related findings only when one captain answer genuinely resolves every grouped finding.
+   Otherwise preserve them as separate decisions, even when they concern the same project or feature.
+6. Account for every candidate before drafting so no current decision is omitted.
+   If an authoritative home or record remains unavailable, disclose the exact coverage gap near the top and do not claim the brief is complete.
+   Do not fill an evidence gap with assumptions.
+
+## Classify the calls
+
+Assign every included item one primary category and add cross-cutting labels only when they materially affect the choice.
+Use these categories distinctly:
+
+- **Product or policy choice** - changes customer value, market position, pricing, workflow, product behavior, or a standing business policy.
+- **Engineering-risk choice** - accepts or reduces material architecture, reliability, maintainability, migration, or delivery risk without primarily redefining the product.
+- **Credential or login action** - requires account access, authorization, a secret, or an authenticated interactive step.
+- **Destructive or security-sensitive action** - can irreversibly remove or expose data, weaken safeguards, change trust boundaries, or materially affect privacy, compliance, or security.
+- **Operational action** - requires the captain to approve a merge, coordinate timing, contact a party, perform a reversible administrative step, or clear another execution dependency.
+
+When an item fits more than one category, choose the category that explains why the captain must own it and list the other material dimensions as labels.
+Never downplay a destructive or security-sensitive aspect by presenting the item only as routine operations.
+
+## Executive brief format
+
+Start with `# Captain's Calls - <YYYY-MM-DD>` and a two- or three-sentence executive summary stating the number of current calls, the projects or suite areas affected, the most consequential choice, and any coverage limitation.
+Then provide a compact action index grouped by the five categories above, including every call exactly once with its qualitative risk and recommended answer.
+After the index, give every call its own numbered section using the following contract.
+
+### Required content for every call
+
+1. **Title** - a plain-language title that names the outcome at stake rather than the implementation symptom.
+2. **Executive decision** - one sentence stating exactly what the captain is being asked to decide or do now.
+3. **Business and product context** - explain where the subject fits in the product suite, which business capability or customer promise it supports, and why it matters now.
+4. **Relevant history** - summarize how the situation arose, prior accepted goals or decisions that constrain it, and the evidence that brought it to the captain.
+5. **Underlying problem** - state the real business, product, user, delivery, or risk problem rather than merely repeating a technical failure or tool message.
+6. **Options** - include every realistic option and include defer or decline when either is meaningful.
+   For each option, state its advantages, disadvantages, tradeoffs, dependencies, and what it leaves unresolved.
+7. **Impact** - assess every relevant business, product, user, delivery, operational, privacy, compliance, security, cost, and schedule dimension.
+   State `No material impact identified` for a named dimension only after checking it, rather than silently omitting the dimension.
+8. **Risk if approved** - rate the downside of approving as **Low**, **Medium**, **High**, or **Critical**, explain the credible failure modes, and give practical mitigations.
+9. **Risk if declined or deferred** - use the same rating scale, explain the opportunity cost or exposure that remains, and give practical mitigations.
+10. **Recommendation** - name one specific option and tie it to accepted product goals, delivery priorities, and the captain's established risk posture.
+    Separate evidence from judgment and state any assumption that could change the recommendation.
+11. **Exact response** - provide concise language the captain can copy verbatim or answer with a short option label.
+    Include any required scope, conditions, PR URL, or acknowledgment so the answer is operationally unambiguous.
+
+Use **Low** for limited reversible downside, **Medium** for meaningful but contained downside, **High** for major customer, business, delivery, privacy, compliance, security, cost, or schedule harm, and **Critical** for existential, broadly irreversible, or severe safety or trust harm.
+Rate consequence and likelihood together, and do not lower a rating merely because a mitigation exists.
+
+## Language and evidence rules
+
+Define every unavoidable technical term in plain language at first use.
+Prefer the captain's product, customer, business, and project nouns over internal fleet terminology.
+Translate worker and tool evidence into outcomes and consequences instead of quoting raw output, internal labels, or unexplained implementation jargon.
+Preserve every PR as its full `https://...` URL, including inside copyable approval language when the PR is the subject of the action.
+Never reveal a secret, token, credential value, or private customer data.
+For a credential or login action, distinguish information firstmate can safely use from an authentication step that only the captain can perform.
+State clearly when the captain must complete an interactive login, approval screen, multifactor prompt, or account recovery because firstmate cannot handle the credential or impersonate the captain.
+Do not imply that preparing the brief performed or authorized any listed action.
+
+## Output mode
+
+Answer in chat by default.
+Write a private dated report only when the captain explicitly asks for a file or durable report.
+In file mode, write the complete brief to `data/decision-brief-<YYYY-MM-DD>.md`, replace that day's prior brief with the newly reconciled current version, and return a concise chat summary with the path.
+The report is the only write this skill permits.
+If no current calls remain after reconciliation, say `Captain, no current decision or action requires your input.` and include any coverage limitation that prevents a complete inventory.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -422,6 +422,8 @@ Load `stuck-crewmate-recovery` after a stale wake, looping or confused pane, ans
 
 ## 9. Escalation and captain etiquette
 
+When the captain asks for a breakdown, executive brief, background, or decision analysis of all current Captain's Calls or decisions requiring their input, load `decision-brief`.
+
 **Talk in outcomes, not mechanics.**
 Every captain-facing message must translate internal state into the project outcome, consequence, and next decision.
 Use the captain's nouns: the investigation, the scout, the fix, the PR, the review, the decision, the blocker, the credential, the local copy, the worker, or the project.

--- a/README.md
+++ b/README.md
@@ -173,8 +173,8 @@ Claude and grok use the slash form shown here; codex uses the same names with `$
 | `/ahoy`            | Recap visible session events since the prior real captain message plus visibly unanswered captain decisions, falling back to Bearings when invoked as the session's first real captain message |
 | `/bearings`        | Generate a concise four-section chat digest from bounded local fleet and registered-secondmate state; use `/bearings file` to also replace today's dated report in `data/`, and add `include PRs` when live PR enrichment is wanted |
 | `/decision-brief`  | Produce a reconciled executive brief of every current Captain's Call or other action requiring the captain's input, with plain-language framing, realistic options, multidimensional impact, rated risks with mitigations, and copyable approval language |
-| `/updatefirstmate` | Self-update the running firstmate and its secondmates to the latest from origin with fast-forward-only pulls, then re-read instructions and nudge secondmates |
 | `/stow`            | Sweep the session for uncaptured durable knowledge, curate tiered startup memory with decay and cold archival, propose captain-gated offloads when still over budget, cascade to registered second mates, and report what is safe to reset |
+| `/updatefirstmate` | Self-update the running firstmate and its secondmates to the latest from origin with fast-forward-only pulls, then re-read instructions and nudge secondmates |
 
 Bearings invocation examples:
 

--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ Claude and grok use the slash form shown here; codex uses the same names with `$
 | `/afk`             | Enter away-mode supervision: the sub-supervisor self-handles routine notifications in bash, escalates captain-relevant events and bounded declared-external-wait rechecks as batched digests, and actively alerts if delivery gets stuck while you step away |
 | `/ahoy`            | Recap visible session events since the prior real captain message plus visibly unanswered captain decisions, falling back to Bearings when invoked as the session's first real captain message |
 | `/bearings`        | Generate a concise four-section chat digest from bounded local fleet and registered-secondmate state; use `/bearings file` to also replace today's dated report in `data/`, and add `include PRs` when live PR enrichment is wanted |
+| `/decision-brief`  | Produce a reconciled executive brief of every current Captain's Call or other action requiring the captain's input, with plain-language framing, realistic options, multidimensional impact, rated risks with mitigations, and copyable approval language |
 | `/updatefirstmate` | Self-update the running firstmate and its secondmates to the latest from origin with fast-forward-only pulls, then re-read instructions and nudge secondmates |
 | `/stow`            | Sweep the session for uncaptured durable knowledge, curate tiered startup memory with decay and cold archival, propose captain-gated offloads when still over budget, cascade to registered second mates, and report what is safe to reset |
 

--- a/docs/documentation-audiences.json
+++ b/docs/documentation-audiences.json
@@ -129,11 +129,11 @@
       "audience": "agent-runtime"
     },
     {
-      "path": ".agents/skills/decision-hold-lifecycle/SKILL.md",
+      "path": ".agents/skills/decision-brief/SKILL.md",
       "audience": "agent-runtime"
     },
     {
-      "path": ".agents/skills/decision-brief/SKILL.md",
+      "path": ".agents/skills/decision-hold-lifecycle/SKILL.md",
       "audience": "agent-runtime"
     },
     {

--- a/docs/documentation-audiences.json
+++ b/docs/documentation-audiences.json
@@ -133,6 +133,10 @@
       "audience": "agent-runtime"
     },
     {
+      "path": ".agents/skills/decision-brief/SKILL.md",
+      "audience": "agent-runtime"
+    },
+    {
       "path": ".agents/skills/diagnostic-reasoning/SKILL.md",
       "audience": "agent-runtime"
     },


### PR DESCRIPTION
## Intent

The developer wanted to create a new firstmate skill that generates executive decision briefs for the captain when asked for a breakdown or decision analysis of current Captain's Calls. The skill must reconcile structured decisions and task state to exclude resolved or duplicate items, then produce a self-contained explanation of every unresolved decision with full business context, history, underlying problems, realistic options with tradeoffs, impact analysis across multiple dimensions, risk ratings with mitigations, and specific actionable approval language. It should distinguish different decision types such as product choices, engineering risks, credentials, and destructive actions, avoiding jargon while preserving PR URLs and identifying when actions require interactive handling. The skill must not mutate fleet or project state as a side effect and should follow existing skill naming and front-matter conventions with one-sentence-per-line Markdown style. The implementation should be committed and validated through no-mistakes to a green PR targeting the captain's fork while preserving all pipeline fix commits, but not merged.

## What Changed

- Added `.agents/skills/decision-brief/SKILL.md` defining a new user-invocable skill that generates reconciled executive briefs of all current Captain's Calls and pending decisions
- Registered the skill in `docs/documentation-audiences.json` with `agent-runtime` audience
- Added `/decision-brief` slash command entry to README.md skill table with description
- Added escalation trigger in AGENTS.md section 9 to load `decision-brief` when captain requests breakdown or decision analysis

## Risk Assessment

✅ Low: Documentation-only change that adds a new skill following established patterns with no executable code or behavioral changes to existing functionality.

## Testing

Validated the decision-brief skill through structural checks (YAML frontmatter parsing, documentation audience validation passing with 68 surfaces), content verification (7 sections, 5 decision categories, 11 required fields, 4 risk levels), integration testing (README, AGENTS.md, and documentation-audiences.json all updated correctly), and style compliance (one-sentence-per-line markdown, read-only guarantees). Created comprehensive evidence artifacts documenting the skill structure, invocation flow, and compliance with all user intent requirements. All validation checks passed with no issues found.

<details>
<summary>Evidence: Comprehensive Test Report</summary>

```text
# Decision Brief Skill - Test Validation Report

## Test Date: 2026-08-10

## 1. File Structure Validation ✓

### Skill File Created
- Location: `.agents/skills/decision-brief/SKILL.md`
- Size: 97 lines
- Format: Markdown with YAML frontmatter

### YAML Frontmatter Validation
`` `
✓ YAML frontmatter is valid
  name: decision-brief
  user-invocable: True
  metadata.internal: True
  description length: 302 chars
`` `

## 2. Documentation Integration ✓

### README.md
- Added to slash command reference table
- Entry: `/decision-brief` with complete description
- Position: Between `/bearings` and `/updatefirstmate`

### AGENTS.md
- Added invocation trigger in Section 9 (Escalation and captain etiquette)
- Instruction: "When the captain asks for a breakdown, executive brief, background, or decision analysis of all current Captain's Calls or decisions requiring their input, load `decision-brief`."

### docs/documentation-audiences.json
- Registered as agent-runtime surface
- Alphabetically sorted in surfaces array
- Path: `.agents/skills/decision-brief/SKILL.md`

### Documentation Validation
`` `
fm-doc-audience-check: ok surfaces=68 local_links=233
`` `

## 3. Skill Content Validation ✓

### Section Structure
1. ✓ # decision-brief (title)
2. ✓ ## Reconcile the current decision set
3. ✓ ## Classify the calls
4. ✓ ## Executive brief format
5. ✓ ### Required content for every call
6. ✓ ## Language and evidence rules
7. ✓ ## Output mode

### Decision Classification (5 categories)
1. ✓ Product or policy choice
2. ✓ Engineering-risk choice
3. ✓ Credential or login action
4. ✓ Destructive or security-sensitive action
5. ✓ Operational action

### Required Content per Call (11 fields)
1. ✓ Title
2. ✓ Executive decision
3. ✓ Business and product context
4. ✓ Relevant history
5. ✓ Underlying problem
6. ✓ Options
7. ✓ Impact
8. ✓ Risk if approved
9. ✓ Risk if declined or deferred
10. ✓ Recommendation
11. ✓ Exact response

### Risk Rating Scale
- ✓ Low (limited reversible downside)
- ✓ Medium (meaningful but contained)
- ✓ High (major harm)
- ✓ Critical (existential/severe)

## 4. Language and Style Validation ✓

### One-Sentence-Per-Line Markdown
- ✓ Verified throughout document
- Sample checked: lines 11-30, 55-80
- Compliant with firstmate conventions

### Plain Language Requirements
- ✓ Executive audience focus
- ✓ Business context over technical jargon
- ✓ Preserve full PR URLs
- ✓ Never reveal secrets
- ✓ Distinguish interactive authentication

## 5. Safety and Side-Effects ✓

### Read-Only Guarantees
The skill explicitly NEVER:
- ✓ Approves a choice
- ✓ Merges a PR
- ✓ Dispatches or steers work
- ✓ Changes a decision record
- ✓ Resets a credential
- ✓ Performs an interactive login
- ✓ Mutates fleet or project state

### Only Permitted Write
- ✓ `data/decision-brief-<YYYY-MM-DD>.md` when captain explicitly requests file mode

## 6. Invocation Triggers ✓

The skill loads when captain:
- ✓ Types `/decision-brief`
- ✓ Asks for "breakdown"
- ✓ Asks for "executive brief"
- ✓ Asks for "background"
- ✓ Asks for "decision analysis"
- ✓ References "Captain's Calls"

## 7. User Intent Compliance ✓

All requirements from user intent satisfied:
- ✓ Creates executive decision briefs for Captain's Calls
- ✓ Reconciles structured decisions and task state
- ✓ Excludes resolved or duplicate items
- ✓ Produces self-contained explanation of every unresolved decision
- ✓ Includes full business context
- ✓ Provides history and underlying problems
- ✓ Lists realistic options with tradeoffs
- ✓ Impact analysis across multiple dimensions
- ✓ Risk ratings with mitigations
- ✓ Specific actionable approval language
- ✓ Distinguishes decision types (product, engineering, credentials, destructive, operational)
- ✓ Avoids jargon while preserving PR URLs
- ✓ Identifies actions requiring interactive handling
- ✓ Does not mutate fleet or project state as side effect
- ✓ Follows existing skill naming and frontmatter conventions
- ✓ Uses one-sentence-per-line Markdown style

## Test Summary

**All validation checks passed.**

The decision-brief skill:
1. Is properly structured with valid YAML frontmatter
2. Is correctly integrated into all required documentation surfaces
3. Passes structural validation (fm-doc-audience-check)
4. Implements all required content sections and decision categories
5. Follows one-sentence-per-line markdown conventions
6. Provides read-only safety guarantees
7. Matches all user intent requirements

**Status: READY FOR USE**

The skill can be invoked via `/decision-brief` or natural language triggers and will produce executive decision briefs as specified.
```
</details>
<details>
<summary>Evidence: Skill Structure Diagram</summary>

```text
# Decision Brief Skill - Structure and Integration

## File Tree
`` `
.agents/skills/decision-brief/
└── SKILL.md (97 lines)
`` `

## Documentation Integration Points

### 1. README.md - Slash Command Reference
`` `markdown
| `/decision-brief`  | Produce a reconciled executive brief of every current Captain's Call... |
`` `
Position: In the main captain slash command table

### 2. AGENTS.md - Escalation Guidance
`` `markdown
## 9. Escalation and captain etiquette

When the captain asks for a breakdown, executive brief, background, or decision analysis 
of all current Captain's Calls or decisions requiring their input, load `decision-brief`.
`` `
Position: Section 9, before "Talk in outcomes, not mechanics"

### 3. docs/documentation-audiences.json
`` `json
{
  "path": ".agents/skills/decision-brief/SKILL.md",
  "audience": "agent-runtime"
}
`` `
Position: Alphabetically sorted in surfaces array

## Skill Invocation Flow

`` `
Captain Request
    |
    ├─ "/decision-brief" (explicit command)
    ├─ "breakdown of Captain's Calls"
    ├─ "executive brief"
    ├─ "background on decisions"
    └─ "decision analysis"
    |
    v
Load skill via Skill tool
    |
    v
Reconcile current decision set
    ├─ Gather fleet snapshot (main + secondmates)
    ├─ Inventory captain-actionable items
    ├─ Inspect authoritative backlog records
    ├─ Reconcile event history vs structured state
    ├─ Exclude resolved/duplicate/historical items
    └─ Group related findings
    |
    v
Classify decisions
    ├─ Product or policy choice
    ├─ Engineering-risk choice
    ├─ Credential or login action
    ├─ Destructive or security-sensitive action
    └─ Operational action
    |
    v
Generate executive brief
    ├─ Dated header + executive summary
    ├─ Action index (grouped by category)
    └─ Numbered sections (11 required fields each)
    |
    v
Output mode decision
    ├─ Chat (default)
    └─ File: data/decision-brief-YYYY-MM-DD.md (if requested)
`` `

## Read-Only Safety Guarantees

The skill explicitly NEVER:
- Approves a choice
- Merges a PR
- Dispatches or steers work
- Changes a decision record
- Resets a credential
- Performs an interactive login
- Mutates fleet or project state

Only permitted write: data/decision-brief-<YYYY-MM-DD>.md when captain explicitly requests file mode

## Validation Results

✓ Documentation audience check: PASS (68 surfaces, 233 local links)
✓ Skill frontmatter: Valid YAML with all required fields
✓ Naming convention: kebab-case ✓
✓ user-invocable: true ✓
✓ One-sentence-per-line markdown: ✓
✓ Integration points updated: 3/3 ✓
```
</details>
<details>
<summary>Evidence: Skill Validation Report</summary>

```text
# Decision Brief Skill Validation

## Skill File Structure

### Frontmatter
`` `yaml
---
name: decision-brief
description: >-
  Produce a reconciled executive brief of every current Captain's Call or other action requiring the captain's input.
  Use when the captain invokes /decision-brief or asks for a breakdown, executive brief, background, or decision analysis of all current Captain's Calls or decisions requiring their input.
user-invocable: true
metadata:
  internal: true
---
`` `

✓ Follows standard skill naming convention (kebab-case)
✓ Has clear description with invocation triggers
✓ Marked as user-invocable
✓ Properly tagged as internal

### Content Structure
# decision-brief
## Reconcile the current decision set
## Classify the calls
## Executive brief format
### Required content for every call
## Language and evidence rules
## Output mode

✓ Well-organized sections covering reconciliation, classification, format, language rules, and output mode
✓ 97 lines - appropriate depth for an executive-facing skill

## Documentation Updates

### README.md
| `/decision-brief`  | Produce a reconciled executive brief of every current Captain's Call or other action requiring the captain's input, with plain-language framing, realistic options, multidimensional impact, rated risks with mitigations, and copyable approval language |

✓ Added to slash command reference table
✓ Description matches skill purpose

### AGENTS.md

When the captain asks for a breakdown, executive brief, background, or decision analysis of all current Captain's Calls or decisions requiring their input, load `decision-brief`.


✓ Added escalation guidance in "Escalation and captain etiquette" section

### docs/documentation-audiences.json
{
  "path": ".agents/skills/decision-brief/SKILL.md",
  "audience": "agent-runtime"
}

✓ Registered as agent-runtime audience

## Key Requirements Validation

### Executive Brief Format ✓
- Starts with dated header and executive summary
- Includes action index grouped by 5 categories
- Each call has 11 required content sections:
  1. Title
  2. Executive decision
  3. Business and product context
  4. Relevant history
  5. Underlying problem
  6. Options with tradeoffs
  7. Impact assessment
  8. Risk if approved (rated)
  9. Risk if declined/deferred (rated)
  10. Recommendation
  11. Exact response (copyable)

### Decision Classification ✓
Five distinct categories:
- Product or policy choice
- Engineering-risk choice
- Credential or login action
- Destructive or security-sensitive action
- Operational action

### Language and Evidence Rules ✓
- Plain language for executives
- Preserve full PR URLs
- Never reveal secrets
- Distinguish interactive authentication needs
- No side effects or state mutation

### Output Mode ✓
- Chat by default
- File mode when explicitly requested
- Writes to data/decision-brief-<YYYY-MM-DD>.md
- Read-only unless captain asks for file

## Compliance with User Intent

The skill successfully:
✓ Creates executive decision briefs for Captain's Calls
✓ Reconciles structured decisions and task state
✓ Excludes resolved/duplicate items
✓ Provides full business context, history, problems, options, tradeoffs
✓ Includes multidimensional impact analysis
✓ Rates risks with mitigations
✓ Offers specific actionable approval language
✓ Distinguishes decision types (product, engineering, credentials, destructive, operational)
✓ Avoids jargon while preserving PR URLs
✓ Identifies interactive handling requirements
✓ Does not mutate fleet/project state as side effect
✓ Follows skill naming and frontmatter conventions
✓ Uses one-sentence-per-line Markdown style
```
</details>
<details>
<summary>Evidence: Invocation Flow Example</summary>

```text
# Decision Brief Skill - Invocation Example

## How the Skill Works End-to-End

### 1. Captain Trigger (Any of these)
`` `
/decision-brief
"give me a breakdown of Captain's Calls"
"I need an executive brief"
"what's the background on current decisions?"
"decision analysis please"
`` `

### 2. Skill Loading
The agent runtime:
- Detects the trigger phrase from AGENTS.md Section 9
- Loads `.agents/skills/decision-brief/SKILL.md`
- Follows the skill's instructions

### 3. Data Reconciliation Phase
The skill instructs the agent to:
`` `
1. Gather fleet snapshot (main + all secondmate homes)
2. Inventory captain-actionable items:
   - Structured backlog items
   - Open keyed decisions on live work
   - PRs awaiting captain merge approval
   - Credentials/logins needed
   - Destructive/security-sensitive actions
3. Inspect authoritative backlog records
4. Reconcile event history vs current state
5. Exclude resolved/duplicate/historical items
6. Group related findings (when one answer resolves multiple)
`` `

### 4. Classification Phase
Each decision gets categorized:
`` `
- Product or policy choice
- Engineering-risk choice  
- Credential or login action
- Destructive or security-sensitive action
- Operational action
`` `

### 5. Brief Generation
Output format:
`` `markdown
# Captain's Calls - 2026-08-10

[Executive summary: 2-3 sentences]

## Action Index
### Product or Policy Choices
1. [Title] - Risk: Medium - Recommendation: [Option]

### Engineering-Risk Choices
2. [Title] - Risk: Low - Recommendation: [Option]

[etc for all 5 categories]

## 1. [First Decision Title]

### Executive decision
[One sentence: what captain must decide now]

### Business and product context
[Where it fits, what capability it supports, why now]

### Relevant history
[How situation arose, prior decisions, evidence]

### Underlying problem
[Real business/product/user/delivery problem]

### Options
#### Option A: [Name]
- Advantages: ...
- Disadvantages: ...
- Tradeoffs: ...
- Dependencies: ...
- Leaves unresolved: ...

#### Option B: [Name]
[same structure]

### Impact
- Business: ...
- Product: ...
- User: ...
- Delivery: ...
- Security: ...
- Cost: ...
- Schedule: ...

### Risk if approved
Rating: Medium

Credible failure modes: ...
Mitigations: ...

### Risk if declined or deferred
Rating: High

Opportunity cost: ...
Mitigations: ...

### Recommendation
Option A

Rationale tied to product goals and risk posture.
Key assumptions: ...

### Exact response
`` `
Approve Option A for [context]. Proceed with [https://github.com/org/repo/pull/123].
`` `

[Repeat for all decisions]
`` `

### 6. Output Mode Decision
`` `
Default: Chat output
If captain said "file" or "write a report": 
  Write to data/decision-brief-2026-08-10.md
  Return chat summary with path
`` `

## Safety Verification

The skill includes explicit "never" clauses:
`` `
It never approves a choice, merges a PR, dispatches or steers work, 
changes a decision record, resets a credential, performs an interactive 
login, or otherwise mutates fleet or project state.
`` `

The only allowed write: `data/decision-brief-<YYYY-MM-DD>.md` in explicit file mode.

## Example Captain Experience

**Captain types:** `/decision-brief`

**Agent responds with:** Structured markdown brief containing:
- Executive summary of all current decisions
- Categorized action index
- Detailed analysis of each decision with:
  - Plain-language framing
  - Business context (not technical jargon)
  - Multiple options with realistic tradeoffs
  - Multidimensional impact assessment
  - Risk ratings (Low/Medium/High/Critical)
  - Specific mitigations
  - Clear recommendation
  - Copyable approval language

**Captain can:** 
- Copy exact response language to approve
- Ask follow-up questions
- Request file mode: `/decision-brief file`
- Review full PR URLs preserved in text

**Captain gets:**
- No mutations to fleet state
- No automatic approvals
- No dispatched work
- Just analysis and recommendations
```
</details>
<details>
<summary>Evidence: Documentation Validation Output</summary>

```text
fm-doc-audience-check: ok surfaces=68 local_links=233
```
</details>
<details>
<summary>Evidence: YAML Frontmatter Validation</summary>

```text
✓ YAML frontmatter is valid
name: decision-brief
user-invocable: True
metadata.internal: True
description length: 302 chars
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`./bin/fm-doc-audience-check.sh` - documentation structure validation</code>
- `YAML frontmatter parsing with Python yaml.safe_load`
- `Manual verification of skill file structure (.agents/skills/decision-brief/SKILL.md)`
- `Manual verification of README.md slash command table entry`
- `Manual verification of AGENTS.md escalation guidance`
- `Manual verification of docs/documentation-audiences.json registration`
- `Content structure validation: 7 main sections, 5 decision categories, 11 required fields per call`
- `One-sentence-per-line markdown style verification (lines 11-30, 55-80)`
- `Read-only safety guarantee verification`
- `Git status check for clean worktree`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
