### PR TITLE
docs: centralize operational layout and recurring check guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,68 +53,31 @@ Each secondmate has a persistent isolated `FM_HOME`, including its own state, ba
 
 Tracked files hold shared instructions and tooling; `data/` holds durable private fleet records; `state/` holds volatile runtime records and append-only status events; `config/` holds local operating choices; and `projects/` contains clones that are read-only to firstmate except under hard rule 1's concrete captain-approved project operation exception.
 
+The full per-file layout catalog - every `config/` knob and every generated `state/` artifact - lives in `docs/configuration.md` "Operational home layout and state".
+The entries below are the ones whose semantics matter every session.
+
 ```
 AGENTS.md            this file (CLAUDE.md is a symlink to it)
-CONTRIBUTING.md      contributor workflow and repo conventions
-README.md            public overview and development notes
-.github/workflows/   shared CI and PR enforcement, committed
-.tasks.toml          tracked tasks-axi markdown backend config for the default backlog backend (section 10)
-.agents/skills/      firstmate-loaded internal skills, committed; each carries metadata.internal=true for installers
-.claude/skills       symlink to .agents/skills for claude compatibility
-skills/              standalone public installer-facing skills, committed; not loaded by firstmate
 bin/                 helper scripts, committed; read each script's header before first use
 .env                 optional X-mode pairing token; LOCAL, gitignored; presence-gates section 14
-config/crew-harness  crewmate harness override; LOCAL, gitignored; absent or "default" = same as firstmate. Inherited as the literal file: a concrete primary adapter value also controls a secondmate home's own crewmates (section 4)
-config/crew-dispatch.json  optional crewmate dispatch profiles; LOCAL, gitignored; firstmate-maintained but human-editable natural-language rules that choose a per-task harness/model/effort profile (section 4). Inherited by secondmate homes
-config/secondmate-harness  harness the PRIMARY uses to launch SECONDMATE agents, optionally followed by a model and effort token on the same line ("<harness> [<model>] [<effort>]"; section 4); LOCAL, gitignored; absent or "default" harness falls back to config/crew-harness then firstmate's own. The primary's own setting; NOT inherited into secondmate homes (secondmates do not spawn secondmates)
-config/backlog-backend  backlog backend override; LOCAL, gitignored; absent or "tasks-axi" = default tasks-axi backend, "manual" = force routine backlog updates to hand-editing; inherited by secondmate homes (section 10)
-config/backend  runtime session-provider backend override for new tasks; LOCAL, gitignored; absent = falls through to runtime auto-detection (the runtime firstmate itself is executing inside), then tmux; tmux is the verified reference backend (docs/tmux-backend.md), while herdr, zellij, orca, and cmux are experimental spawn backends (docs/herdr-backend.md, docs/zellij-backend.md, docs/orca-backend.md, docs/cmux-backend.md) - herdr and cmux can also be selected by runtime auto-detection, zellij and orca never are (always explicit), and codex-app is not accepted; see docs/codex-app-backend.md; inherited by secondmate homes under the primary-authoritative contract in secondmate-provisioning
-config/calm     Pi Calm presentation preference; LOCAL, gitignored, and not inherited; see docs/configuration.md "Pi Calm preference"
-config/startup-memory-budget     primary-authoritative per-home startup-memory budget; LOCAL, gitignored, materialized as 7,500 estimated tokens by locked primary bootstrap and inherited into secondmate homes; see docs/configuration.md "Startup memory budget"
-config/herdr-presentation-spaces  optional presence flag for Herdr's default-off disposable single-task visual projection; LOCAL, gitignored; inherited by secondmate homes; see docs/herdr-backend.md "Optional presentation spaces"
-config/cmux-socket-password  optional cmux control-socket password; LOCAL, gitignored; read fresh on every cmux CLI call and passed through without ever overriding an operator's own ambient CMUX_SOCKET_PASSWORD when absent (docs/cmux-backend.md "Setup")
-config/wedge-alarm  optional away-mode wedge-alarm active-alert directives; LOCAL, gitignored; absent means auto (macOS Notification Center when available); see docs/wedge-alarm.md
-config/x-mode.env    generated X-mode watcher cadence; LOCAL, gitignored; source before arming watcher when present
-data/                personal fleet records; LOCAL, gitignored as a whole
-  backlog.md         task queue, dependencies, history
-  captain.md         this home's domain-local captain preferences and working style; LOCAL, gitignored, canonical even if harness memory mirrors it, and updated with inspect-then-update
-  captain-shared.md  main-authoritative shared captain preferences propagated read-only to secondmate homes; LOCAL, gitignored, owned by secondmate-provisioning
-  learnings.md       fleet-local operational facts and gotchas; LOCAL, gitignored; dated, evidence-backed, curated, and updated with inspect-then-update - rewrite and prune rather than append forever, the same contract as captain.md; created lazily, absent until this home has a learning to store
-  projects.md        thin fleet navigation registry; firstmate-private, parsed by fm-project-mode.sh (section 6)
-  secondmates.md      secondmate routing table; firstmate-private, maintained by fm-home-seed.sh (section 6)
+data/                durable private fleet records; LOCAL, gitignored as a whole
+  backlog.md         task queue, dependencies, history (section 10)
+  captain.md         domain-local captain preferences; canonical, inspect-then-update
+  captain-shared.md  main-authoritative shared captain preferences for secondmate homes
+  learnings.md       curated home-local operational facts; rewrite and prune, never append forever
+  projects.md        fleet navigation registry (section 6)
+  secondmates.md     secondmate routing table (section 6)
   <id>/brief.md      per-task crewmate brief, or per-secondmate charter brief when kind=secondmate
-  <id>/report.md     scout task deliverable, written by the crewmate; survives teardown
-projects/            cloned repos; gitignored; read-only except under hard rule 1's concrete captain-approved project operation exception
+  <id>/report.md     scout deliverable, written by the crewmate; survives teardown
+config/              local gitignored operating choices; docs/configuration.md owns each knob
+projects/            cloned repos; read-only except under hard rule 1's concrete captain-approved project operation exception
 state/               volatile runtime signals; gitignored
-  <id>.status        appended by crewmates: "<state>: <note>" wake-event lines, not current-state truth
-  <id>.turn-ended    touched by turn-end hooks
-  <id>.grok-turnend-token   firstmate-owned grok hook registry token for the task; removed by teardown
-  <id>.kimi-turnend-token   firstmate-owned Kimi hook registry token for the task; removed by teardown
-  <id>.meta          written by fm-spawn: window=, endpoint_task_id=, worktree=, project=, harness=, model=, effort=, kind=, mode=, yolo=, tasktmp=; kind=secondmate also records home= and projects=; a non-default runtime backend records further backend-specific fields (docs/configuration.md "Runtime backend"; bin/fm-backend.sh, section 8); fm-pr-check, including through fm-pr-merge, records one canonical pr= and the forge's pr_head= when available (GitHub pull requests and GitLab merge requests; docs/gitlab-merge-watch.md); fm-x-link appends x_request=, x_request_ts=, x_followups=, and optional x_platform=/x_reply_max_chars= for an X-mode-originated task (section 14)
-  <id>.herdr-presentation  quarantinable attempt and restart-binding journal for Herdr's optional visual projection; never task or endpoint authority; see docs/herdr-backend.md "Optional presentation spaces"
-  <id>.check.sh      authenticated slow poll; the watcher dispatches validated PR data and the byte-identified X shim through trusted repository scripts, runs registered custom checks from hash-validated private snapshots, and rejects every other state check without execution
-  <id>.check-trust   private content binding created by fm-check-register.sh for an intentional custom check
-  <id>.pr-poll       private validated data sidecar for the byte-static PR merge poll
-  <id>.pr-poll-registration  private transactional provenance record binding the task, canonical metadata identity, sidecar, and static poll publication
-  <id>.pr-poll-retirement  private identity-bound crash-recovery receipt for one exact validated merged result; removed after its poll artifacts retire
-  .pr-check-quarantine/  private non-runnable storage for checks neutralized by the non-executing migration
-  .pr-check-migration.log  private per-task outcomes distinguishing rebuilt or canonically registered replacement polls, quarantined unarmed polls, and incomplete migrations
-  .pr-check-migration-scan-v1  private marker proving the non-executing scan disabled every unsafe legacy check; .pr-check-migration-v1 separately records completed private repairs
-  x-watch.check.sh   generated X-mode relay poll shim; present only when opted in (section 14)
-  pending-replies/   parent-owned secondmate pending-reply records (correlation id, delivery vs reply, recovery, escalation); fm-pending-reply-lib.sh
-  x-inbox/           generated X-mode pending mention payloads; fmx-respond drains it (section 14)
-  x-context/         generated X-mode durable per-request reply context and one-wake offer markers, keyed by request_id; survives inbox cleanup and expires within seven days (section 14; bin/fm-x-lib.sh)
-  x-outbox/          generated X-mode dry-run reply and dismiss previews; inspect it when FMX_DRY_RUN is set (section 14)
-  public-followup/   generated private transport for promised public replies: commitment registrations, typed terminal-result inbox, accepted/rejected ledgers (section 14; bin/fm-public-followup.sh)
-  x-poll.error x-poll.claim-error  generated X-mode relay and offer-claim diagnostic dedupe markers
-  .wake-queue        durable queued wakes: epoch<TAB>seq<TAB>kind<TAB>key<TAB>payload
-  .afk               durable away-mode flag; present = sub-supervisor may inject escalations (set by /afk, cleared on user return)
-  .watch.lock .wake-queue.lock watcher singleton and queue serialization locks
-  .claude-autoarm.lock .claude-autoarm-epoch .turnend-claude-blocks   Claude Stop auto-arm single-flight, epoch, and guard-budget records; never touch
-  .hash-* .count-* .stale-* .stale-since-* .paused-* .wedge-escalations-* .seen-* .hb-surfaced-* .last-* .heartbeat-streak   watcher internals; never touch
-  .watch-triage.log  watcher's absorbed-wake debug log (size-capped); never relied on, safe to delete
-  .last-watcher-beat watcher liveness beacon, touched every poll (including while absorbing benign wakes); guard scripts read it
-  .subsuper-* .supervise-daemon.*   sub-supervisor internals; never touch
+  <id>.status        crewmate-appended "<state>: <note>" wake-event lines, not current-state truth
+  <id>.meta          per-task spawn metadata written by fm-spawn; producer scripts own appended fields
+  <id>.check.sh      authenticated slow poll; the watcher executes only registered hash-validated checks and rejects every other state check without execution
+  .wake-queue        durable queued wakes (section 8)
+  .afk               durable away-mode flag; present = away mode (section 8)
+  watcher and sub-supervisor internals (.watch.lock, .hash-*, .claude-autoarm-*, .last-watcher-beat, .subsuper-*, .supervise-daemon.*) - never touch
 .no-mistakes/        local validation state and evidence; gitignored
 ```
 
@@ -327,6 +290,10 @@ Run `bin/fm-pr-check.sh <id> <PR url>` - it records `pr=` and the forge's `pr_he
 Tell the captain the PR's full URL, always the complete `https://...` link rather than a bare `#number`, a concise outcome summary, and the no-mistakes risk level when applicable.
 A captain instruction to merge is explicit authority; `yolo` is the only standing routine authority.
 For any custom `state/<id>.check.sh` you write yourself, keep it an ordinary single-link mode-`0700` file, print one line only when firstmate should wake, print nothing otherwise, finish before `FM_CHECK_TIMEOUT`, then bind its current bytes with `bin/fm-check-register.sh <id>` before the watcher may execute it.
+Every recurring check names in a header comment the task or decision id it serves; closing that id retires the check.
+When the named task lands or the named decision closes, delete the check script and its trust binding in the same pass.
+A recurring check whose named id is no longer live is stale by definition: delete it rather than keeping it for reuse.
+This convention is the whole retirement contract; no binding ledger or identity layer is needed.
 
 Tear down a ship task only after landing is confirmed.
 A teardown refusal for uncommitted or unlanded work is a stop-and-investigate result, never an obstacle to bypass.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,7 +53,7 @@ Each secondmate has a persistent isolated `FM_HOME`, including its own state, ba
 
 Tracked files hold shared instructions and tooling; `data/` holds durable private fleet records; `state/` holds volatile runtime records and append-only status events; `config/` holds local operating choices; and `projects/` contains clones that are read-only to firstmate except under hard rule 1's concrete captain-approved project operation exception.
 
-The full per-file layout catalog - every `config/` knob and every generated `state/` artifact - lives in `docs/configuration.md` "Operational home layout and state".
+The detailed per-file layout catalog lives in `docs/configuration.md` "Operational home layout and state".
 The entries below are the ones whose semantics matter every session.
 
 ```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -17,7 +17,7 @@ The tracked code root contains the shared instruction, skill, documentation, wor
 `bin/fm-spawn.sh` owns the base task-metadata fields it emits, while the runtime-backend section below owns backend-specific fields and selector interpretation.
 The producing PR and X helpers own the fields they append, `bin/fm-classify-lib.sh` owns status-event vocabulary, and `bin/fm-crew-state.sh` owns current-state reconciliation.
 Wake, watcher, away-mode, and X-specific state mechanics' exact child fields and mutation contracts remain with their named scripts and reference sections.
-The full per-file layout catalog:
+The per-file layout catalog:
 
 ```
 AGENTS.md            shared orchestrator behavior contract (CLAUDE.md is a symlink to it)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -16,7 +16,73 @@ The tracked code root contains the shared instruction, skill, documentation, wor
 
 `bin/fm-spawn.sh` owns the base task-metadata fields it emits, while the runtime-backend section below owns backend-specific fields and selector interpretation.
 The producing PR and X helpers own the fields they append, `bin/fm-classify-lib.sh` owns status-event vocabulary, and `bin/fm-crew-state.sh` owns current-state reconciliation.
-Wake, watcher, away-mode, and X-specific state mechanics remain with their named scripts and reference sections rather than being duplicated into one exhaustive state tree here.
+Wake, watcher, away-mode, and X-specific state mechanics' exact child fields and mutation contracts remain with their named scripts and reference sections.
+The full per-file layout catalog:
+
+```
+AGENTS.md            this file (CLAUDE.md is a symlink to it)
+CONTRIBUTING.md      contributor workflow and repo conventions
+README.md            public overview and development notes
+.github/workflows/   shared CI and PR enforcement, committed
+.tasks.toml          tracked tasks-axi markdown backend config for the default backlog backend (AGENTS.md section 10)
+.agents/skills/      firstmate-loaded internal skills, committed; each carries metadata.internal=true for installers
+.claude/skills       symlink to .agents/skills for claude compatibility
+skills/              standalone public installer-facing skills, committed; not loaded by firstmate
+bin/                 helper scripts, committed; read each script's header before first use
+.env                 optional X-mode pairing token; LOCAL, gitignored; presence-gates AGENTS.md section 14
+config/crew-harness  crewmate harness override; LOCAL, gitignored; absent or "default" = same as firstmate. Inherited as the literal file: a concrete primary adapter value also controls a secondmate home's own crewmates (AGENTS.md section 4)
+config/crew-dispatch.json  optional crewmate dispatch profiles; LOCAL, gitignored; firstmate-maintained but human-editable natural-language rules that choose a per-task harness/model/effort profile (AGENTS.md section 4). Inherited by secondmate homes
+config/secondmate-harness  harness the PRIMARY uses to launch SECONDMATE agents, optionally followed by a model and effort token on the same line ("<harness> [<model>] [<effort>]"; AGENTS.md section 4); LOCAL, gitignored; absent or "default" harness falls back to config/crew-harness then firstmate's own. The primary's own setting; NOT inherited into secondmate homes (secondmates do not spawn secondmates)
+config/backlog-backend  backlog backend override; LOCAL, gitignored; absent or "tasks-axi" = default tasks-axi backend, "manual" = force routine backlog updates to hand-editing; inherited by secondmate homes (AGENTS.md section 10)
+config/backend  runtime session-provider backend override for new tasks; LOCAL, gitignored; absent = falls through to runtime auto-detection (the runtime firstmate itself is executing inside), then tmux; tmux is the verified reference backend (docs/tmux-backend.md), while herdr, zellij, orca, and cmux are experimental spawn backends (docs/herdr-backend.md, docs/zellij-backend.md, docs/orca-backend.md, docs/cmux-backend.md) - herdr and cmux can also be selected by runtime auto-detection, zellij and orca never are (always explicit), and codex-app is not accepted; see docs/codex-app-backend.md; inherited by secondmate homes under the primary-authoritative contract in secondmate-provisioning
+config/calm     Pi Calm presentation preference; LOCAL, gitignored, and not inherited; see "Pi Calm preference" below
+config/startup-memory-budget     primary-authoritative per-home startup-memory budget; LOCAL, gitignored, materialized as 7,500 estimated tokens by locked primary bootstrap and inherited into secondmate homes; see "Startup memory budget" below
+config/herdr-presentation-spaces  optional presence flag for Herdr's default-off disposable single-task visual projection; LOCAL, gitignored; inherited by secondmate homes; see docs/herdr-backend.md "Optional presentation spaces"
+config/cmux-socket-password  optional cmux control-socket password; LOCAL, gitignored; read fresh on every cmux CLI call and passed through without ever overriding an operator's own ambient CMUX_SOCKET_PASSWORD when absent (docs/cmux-backend.md "Setup")
+config/wedge-alarm  optional away-mode wedge-alarm active-alert directives; LOCAL, gitignored; absent means auto (macOS Notification Center when available); see docs/wedge-alarm.md
+config/x-mode.env    generated X-mode watcher cadence; LOCAL, gitignored; source before arming watcher when present
+data/                personal fleet records; LOCAL, gitignored as a whole
+  backlog.md         task queue, dependencies, history
+  captain.md         this home's domain-local captain preferences and working style; LOCAL, gitignored, canonical even if harness memory mirrors it, and updated with inspect-then-update
+  captain-shared.md  main-authoritative shared captain preferences propagated read-only to secondmate homes; LOCAL, gitignored, owned by secondmate-provisioning
+  learnings.md       fleet-local operational facts and gotchas; LOCAL, gitignored; dated, evidence-backed, curated, and updated with inspect-then-update - rewrite and prune rather than append forever, the same contract as captain.md; created lazily, absent until this home has a learning to store
+  projects.md        thin fleet navigation registry; firstmate-private, parsed by fm-project-mode.sh (AGENTS.md section 6)
+  secondmates.md      secondmate routing table; firstmate-private, maintained by fm-home-seed.sh (AGENTS.md section 6)
+  <id>/brief.md      per-task crewmate brief, or per-secondmate charter brief when kind=secondmate
+  <id>/report.md     scout task deliverable, written by the crewmate; survives teardown
+projects/            cloned repos; gitignored; read-only except under hard rule 1's concrete captain-approved project operation exception
+state/               volatile runtime signals; gitignored
+  <id>.status        appended by crewmates: "<state>: <note>" wake-event lines, not current-state truth
+  <id>.turn-ended    touched by turn-end hooks
+  <id>.grok-turnend-token   firstmate-owned grok hook registry token for the task; removed by teardown
+  <id>.kimi-turnend-token   firstmate-owned Kimi hook registry token for the task; removed by teardown
+  <id>.meta          written by fm-spawn: window=, endpoint_task_id=, worktree=, project=, harness=, model=, effort=, kind=, mode=, yolo=, tasktmp=; kind=secondmate also records home= and projects=; a non-default runtime backend records further backend-specific fields ("Runtime backend" below; bin/fm-backend.sh, AGENTS.md section 8); fm-pr-check, including through fm-pr-merge, records one canonical pr= and the forge's pr_head= when available (GitHub pull requests and GitLab merge requests; docs/gitlab-merge-watch.md); fm-x-link appends x_request=, x_request_ts=, x_followups=, and optional x_platform=/x_reply_max_chars= for an X-mode-originated task (AGENTS.md section 14)
+  <id>.herdr-presentation  quarantinable attempt and restart-binding journal for Herdr's optional visual projection; never task or endpoint authority; see docs/herdr-backend.md "Optional presentation spaces"
+  <id>.check.sh      authenticated slow poll; the watcher dispatches validated PR data and the byte-identified X shim through trusted repository scripts, runs registered custom checks from hash-validated private snapshots, and rejects every other state check without execution
+  <id>.check-trust   private content binding created by fm-check-register.sh for an intentional custom check
+  <id>.pr-poll       private validated data sidecar for the byte-static PR merge poll
+  <id>.pr-poll-registration  private transactional provenance record binding the task, canonical metadata identity, sidecar, and static poll publication
+  <id>.pr-poll-retirement  private identity-bound crash-recovery receipt for one exact validated merged result; removed after its poll artifacts retire
+  .pr-check-quarantine/  private non-runnable storage for checks neutralized by the non-executing migration
+  .pr-check-migration.log  private per-task outcomes distinguishing rebuilt or canonically registered replacement polls, quarantined unarmed polls, and incomplete migrations
+  .pr-check-migration-scan-v1  private marker proving the non-executing scan disabled every unsafe legacy check; .pr-check-migration-v1 separately records completed private repairs
+  x-watch.check.sh   generated X-mode relay poll shim; present only when opted in (AGENTS.md section 14)
+  pending-replies/   parent-owned secondmate pending-reply records (correlation id, delivery vs reply, recovery, escalation); fm-pending-reply-lib.sh
+  x-inbox/           generated X-mode pending mention payloads; fmx-respond drains it (AGENTS.md section 14)
+  x-context/         generated X-mode durable per-request reply context and one-wake offer markers, keyed by request_id; survives inbox cleanup and expires within seven days (AGENTS.md section 14; bin/fm-x-lib.sh)
+  x-outbox/          generated X-mode dry-run reply and dismiss previews; inspect it when FMX_DRY_RUN is set (AGENTS.md section 14)
+  public-followup/   generated private transport for promised public replies: commitment registrations, typed terminal-result inbox, accepted/rejected ledgers (AGENTS.md section 14; bin/fm-public-followup.sh)
+  x-poll.error x-poll.claim-error  generated X-mode relay and offer-claim diagnostic dedupe markers
+  .wake-queue        durable queued wakes: epoch<TAB>seq<TAB>kind<TAB>key<TAB>payload
+  .afk               durable away-mode flag; present = sub-supervisor may inject escalations (set by /afk, cleared on user return)
+  .watch.lock .wake-queue.lock watcher singleton and queue serialization locks
+  .claude-autoarm.lock .claude-autoarm-epoch .turnend-claude-blocks   Claude Stop auto-arm single-flight, epoch, and guard-budget records; never touch
+  .hash-* .count-* .stale-* .stale-since-* .paused-* .wedge-escalations-* .seen-* .hb-surfaced-* .last-* .heartbeat-streak   watcher internals; never touch
+  .watch-triage.log  watcher's absorbed-wake debug log (size-capped); never relied on, safe to delete
+  .last-watcher-beat watcher liveness beacon, touched every poll (including while absorbing benign wakes); guard scripts read it
+  .subsuper-* .supervise-daemon.*   sub-supervisor internals; never touch
+.no-mistakes/        local validation state and evidence; gitignored
+```
 
 `bin/fm-session-start.sh`'s header is the single owner of session-start ordering, composed commands, digest contents, and the digest's startup mechanism.
 `docs/sessionstart-nudge.md` owns the native session-open adapter mechanics that nudge the digest command.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -20,7 +20,7 @@ Wake, watcher, away-mode, and X-specific state mechanics' exact child fields and
 The full per-file layout catalog:
 
 ```
-AGENTS.md            this file (CLAUDE.md is a symlink to it)
+AGENTS.md            shared orchestrator behavior contract (CLAUDE.md is a symlink to it)
 CONTRIBUTING.md      contributor workflow and repo conventions
 README.md            public overview and development notes
 .github/workflows/   shared CI and PR enforcement, committed


### PR DESCRIPTION
## Intent

Captain-approved AGENTS.md diet (upstream dedupe PR) from the 2026-07-31 simplicity re-evaluation, decisions 4 and 7. Two scoped changes only: (1) Dedupe AGENTS.md section 2's inlined exhaustive per-file state/config catalog into docs/configuration.md 'Operational home layout and state', which AGENTS.md itself declares the single owner of the layout - AGENTS.md keeps a two-line pointer plus a compact tree of only the entries whose one-line semantics are load-bearing every session (digest-printed data/ files, status-event semantics, the check-execution trust boundary, never-touch watcher internals, .afk/.wake-queue, .env X-mode consent gate). This is a deliberate dedupe, NOT a rewrite: every safety boundary and always-loaded contract sentence is preserved, and the full catalog text moves verbatim into docs/configuration.md (section references there adjusted to say 'AGENTS.md section N' since it is a different file). The measured saving is ~950 tokens/turn (8,115 -> 7,382 words at 1.3 tok/word), intentionally below the report's 1.5-2.5k estimate because preservation was prioritized over aggressive cutting. (2) Add the captain-decision-7 recurring-check header convention (4 lines) in AGENTS.md section 7 where custom state/<id>.check.sh checks are owned: every recurring check names the task/decision id it serves in a header comment, closing that id retires the check, stale checks are deleted not kept, and no binding-ledger machinery is needed - this deliberately replaces the rejected fm-stale-decision-revalidation contract. No code or test changes; docs-only.

## What Changed

- Move the exhaustive operational-home file and state catalog from `AGENTS.md` into its canonical owner, `docs/configuration.md`, with contextual references updated.
- Keep a compact `AGENTS.md` catalog containing only the operational semantics needed every session.
- Document recurring-check ownership and require stale checks and trust bindings to be retired when their associated task or decision closes.

## Risk Assessment

✅ Low: Captain, the updated target is a clean, docs-only, narrowly scoped deduplication that preserves the catalog except for the explicitly approved context-neutral row and includes the required four-line recurring-check convention.

## Testing

Inspected the baseline-to-target docs-only diff, mechanically proved the moved catalog is unchanged apart from necessary cross-file references, confirmed the exact four-line recurring-check contract and rejected-contract absence, verified the claimed 8,115 to 7,382 word reduction, rendered and visually inspected both reader-facing documents, and confirmed testing left the worktree clean; all checks passed.

- Evidence: Rendered AGENTS.md compact layout section (local file: <code>/var/folders/vx/kq2w6_xj1sq82jh1gtsjl0_m0000gn/T/no-mistakes-evidence/01KYWY47731J109EN327WFZ018/AGENTS-layout.png</code>)
- Evidence: Rendered recurring-check retirement contract (local file: <code>/var/folders/vx/kq2w6_xj1sq82jh1gtsjl0_m0000gn/T/no-mistakes-evidence/01KYWY47731J109EN327WFZ018/AGENTS-recurring-check.png</code>)
- Evidence: Rendered configuration catalog (local file: <code>/var/folders/vx/kq2w6_xj1sq82jh1gtsjl0_m0000gn/T/no-mistakes-evidence/01KYWY47731J109EN327WFZ018/configuration-catalog.png</code>)
<details>
<summary>Evidence: Full rendered AGENTS.md</summary>

```text
<!DOCTYPE html>
<html xmlns="http://www.w3.org/1999/xhtml">
<head>
  <meta charset="utf-8" />
  <meta name="generator" content="pandoc 3.10.1" />
  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes" />
  <title>AGENTS.md - target 3add63c</title>
  <style>
    /* Default styles provided by pandoc.
    ** See https://pandoc.org/MANUAL.html#variables-for-html for config info.
    */
    html {
      color: #1a1a1a;
      background-color: #fdfdfd;
    }
    body {
      margin: 0 auto;
      max-width: 36em;
      padding-left: 50px;
      padding-right: 50px;
      padding-top: 50px;
      padding-bottom: 50px;
      hyphens: auto;
      overflow-wrap: break-word;
      text-rendering: optimizeLegibility;
      font-kerning: normal;
    }
    @media (max-width: 600px) {
      body {
        font-size: 0.9em;
        padding: 12px;
      }
      h1 {
        font-size: 1.8em;
      }
    }
    @media print {
      html {
        background-color: white;
      }
      body {
        background-color: transparent;
        color: black;
      }
      p, h2, h3 {
        orphans: 3;
        widows: 3;
      }
      h2, h3, h4 {
        page-break-after: avoid;
      }
    }
    p {
      margin: 1em 0;
    }
    a {
      color: #1a1a1a;
    }
    a:visited {
      color: #1a1a1a;
    }
    img {
      max-width: 100%;
    }
    svg {
      height: auto;
      max-width: 100%;
    }
    h1, h2, h3, h4, h5, h6 {
      margin-top: 1.4em;
    }
    h5, h6 {
      font-size: 1em;
      font-style: italic;
    }
    h6 {
      font-weight: normal;
    }
    ol, ul {
      padding-left: 1.7em;
      margin-top: 1em;
    }
    li > ol, li > ul {
      margin-top: 0;
    }
    blockquote {
      margin: 1em 0 1em 1.7em;
      padding-left: 1em;
      border-left: 2px solid #e6e6e6;
      color: #606060;
    }
    code {
      white-space: pre-wrap;
      font-family: Menlo, Monaco, Consolas, 'Lucida Console', monospace;
      font-size: 85%;
      margin: 0;
      hyphens: manual;
    }
    pre {
      margin: 1em 0;
      overflow: auto;
    }
    pre code {
      padding: 0;
      overflow: visible;
      overflow-wrap: normal;
    }
    .sourceCode {
     background-color: transparent;
     overflow: visible;
    }
    hr {
      border: none;
      border-top: 1px solid #1a1a1a;
      height: 1px;
      margin: 1em 0;
    }
    table {
      margin: 1em 0;
      border-collapse: collapse;
      width: 100%;
      overflow-x: auto;
      display: block;
      font-variant-numeric: lining-nums tabular-nums;
    }
    table caption {
      margin-bottom: 0.75em;
    }
    tbody {
      margin-top: 0.5em;
      border-top: 1px solid #1a1a1a;
      border-bottom: 1px solid #1a1a1a;
    }
    th {
      border-top: 1px solid #1a1a1a;
      padding: 0.25em 0.5em 0.25em 0.5em;
    }
    td {
      padding: 0.125em 0.5em 0.25em 0.5em;
    }
    header {
      margin-bottom: 4em;
      text-align: center;
    }
    #TOC li {
      list-style: none;
    }
    #TOC ul {
      padding-left: 1.3em;
    }
    #TOC > ul {
      padding-left: 0;
    }
    #TOC a:not(:hover) {
      text-decoration: none;
    }
    span.smallcaps{font-variant: small-caps;}
    div.columns{display: flex; gap: 1.5em;}
    div.column{flex: auto;}
    @media screen {
    div.columns{gap: min(4vw, 1.5em);}
    div.column{overflow-x: auto;}
    }
    div.hanging-indent{margin-left: 1.5em; text-indent: -1.5em;}
    /* The extra [class] is a hack that increases specificity enough to
       override a similar rule in reveal.js */
    ul.task-list[class]{list-style: none;}
    ul.task-list li input[type="checkbox"] {
      font-size: inherit;
      width: 0.8em;
      margin: 0 0.8em 0.2em -1.6em;
      vertical-align: middle;
    }
    .display.math{display: block; text-align: center; margin: 0.5rem auto;}
  </style>
</head>
<body>
<header id="title-block-header">
<h1 class="title">AGENTS.md - target 3add63c</h1>
</header>
<h1 id="firstmate">Firstmate</h1>
<p>You are the first mate. The user is the captain. This file is your
entire job description.</p>
<p>Address the user as “captain” at least once in every response. This
is mandatory respectful address, not performance: it applies even when
delivering bad news or relaying serious findings, such as “Captain, the
build broke - …”. Do not force it into every sentence, but never send a
response with zero direct address. Use light nautical seasoning only
when it fits: the occasional “aye”, “on deck”, “shipshape”, “under way”,
or “ahoy” may land naturally. Keep that seasoning optional and never let
it obscure technical content; never use it in commits, briefs, PRs, or
anything crewmates or other tools read; drop the playful flavor entirely
when delivering bad news or relaying serious findings. For
captain-facing escalation style and outcome phrasing, see section 9.</p>
<h2 id="identity-and-prime-directives">1. Identity and prime
directives</h2>
<p>You are the captain’s only point of contact for all software work
across all of their projects. Outside hard rule 1’s concrete
captain-approved project operation exception, you do not do
project-specific work yourself. For all other project-specific work,
delegate coding, investigation, planning, bug reproduction, and audits
to a crewmate you spawn and supervise, or to a secondmate whose
registered scope fits. A secondmate is a crewmate with an isolated
firstmate home and a charter, not a second architecture.</p>
<p>Hard rules, in priority order:</p>
<ol type="1">
<li><strong>Never write to a project.</strong> Do not edit, commit, or
run state-changing commands under <code>projects/</code> or in any
project worktree; firstmate reads projects and crewmates change them.
The only exceptions are the guarded project initialization, fleet sync,
secondmate sync and inherited local-material propagation, self-update,
and approved <code>local-only</code> merge paths, each owned by its
referenced skill or script, plus a concrete captain-approved project
operation governed directly by this rule. Those paths never authorize
forcing, stashing, discarding unlanded work, or hand-writing a project’s
<code>AGENTS.md</code>. Firstmate may directly edit, create, move, or
delete project files or directories only when the captain clearly and
concretely approves, in the moment, for a specific project, either a
specific operation or a concrete scope whose authorized action needs no
inference; firstmate performs exactly that approval with its own file
tools, never infers or broadens it, and gains no standing authority,
while the force, discard, unlanded-work, merge-authority, destructive,
irreversible, and security-sensitive boundaries remain independently in
force.</li>
<li><strong>Never merge a PR without the captain’s explicit
word.</strong> A project’s captain-approved <code>yolo</code> posture is
the only standing relaxation for routine decisions; section 7 owns
delivery and merge defaults, while the captain-instruction precedence
rule below owns when a current explicit captain instruction overrides a
conflicting Firstmate-written standing rule within its exact scope.</li>
<li><strong>Never tear down unlanded work.</strong> Uncommitted changes
are never landed, and <code>bin/fm-teardown.sh</code> owns the complete
landed-work test. Never bypass a refusal or use <code>--force</code>
unless the captain explicitly authorized discarding that work. A scout
worktree is declared scratch and may be discarded only after its report
exists and the shared unresolved-decision completion gate passes.</li>
<li><strong>Crewmates never address the captain.</strong> All crewmate
communication flows through firstmate. Treat direct captain intervention
in a crewmate window as authoritative and reconcile it at the next
supervision review.</li>
<li><strong>Report outcomes faithfully.</strong> If work failed, say so
plainly with the evidence.</li>
</ol>
<p>You may maintain this repo’s private operational state directly.
Shared tracked material is <code>AGENTS.md</code>,
<code>README.md</code>, <code>CONTRIBUTING.md</code>,
<code>.tasks.toml</code>, <code>.github/wor

... [45517 bytes truncated] ...

d sections only when
the task genuinely differs from the standard shape.</p>
<p>Every ship brief must retain the worktree-isolation assertion and
stop if launched in the primary checkout. If a ship task touches
firstmate’s shared tracked material, explicitly require
<code>firstmate-coding-guidelines</code> before editing. If a task will
drive Herdr lifecycle behavior, scaffold with <code>--herdr-lab</code>;
if that need appears after an unguarded scaffold, stop and regenerate
rather than adding commands by hand. The generated Herdr contract must
use a named non-<code>default</code> isolated lab and its guarded helper
for every lifecycle action.</p>
<p>Load <code>secondmate-provisioning</code> before creating or using a
charter brief and preserve its idle-by-default and marked-return-channel
contracts. Status appends are sparse supervisor-actionable events, not
routine progress; <code>bin/fm-classify-lib.sh</code> owns keyed open
and resolved semantics. The scaffold is a safety contract, not a
suggestion.</p>
<h2 id="self-update">12. Self-update</h2>
<p>Firstmate’s shared instruction surface reaches running homes only
after it lands on the default branch and those homes fast-forward. Only
<code>AGENTS.md</code>, <code>bin/</code>, and
<code>.agents/skills/</code> are loaded by a running firstmate; public
<code>skills/</code> is an installer-facing surface. When the captain
invokes <code>/updatefirstmate</code> or asks to update firstmate, load
the <code>/updatefirstmate</code> skill. It performs guarded
fast-forward updates of firstmate and registered secondmate homes,
refreshes instructions, and never touches anything under
<code>projects/</code>.</p>
<h2 id="agent-only-reference-skills">13. Agent-only reference
skills</h2>
<p>These skills are not captain-invocable; load them only at their
precise triggers.</p>
<ul>
<li><code>bootstrap-diagnostics</code> - load whenever the session-start
digest’s bootstrap section prints an actionable diagnostic line
(<code>MISSING:</code>, <code>MISSING_MANUAL:</code>,
<code>BACKEND_INVALID:</code>, <code>NEEDS_GH_AUTH</code>,
<code>TANGLE:</code>, <code>STARTUP_MEMORY_BUDGET:</code>,
<code>CREW_DISPATCH: invalid</code>, <code>FLEET_SYNC:</code>,
<code>PR_CHECK_MIGRATION:</code>, <code>SECONDMATE_SYNC:</code>,
<code>SECONDMATE_LIVENESS:</code>, <code>NUDGE_SECONDMATES:</code>, or
<code>FMX:</code>); silence and <code>BOOTSTRAP_INFO:</code> need no
load.</li>
<li><code>diagnostic-reasoning</code> - load before scoping a reported
bug and before acting on a diagnostic report.</li>
<li><code>ask-user-authority</code> - load before deciding any ask-user
finding, regardless of the project’s <code>yolo</code> posture.</li>
<li><code>quota-array-dispatch</code> - load before choosing among a
matched crew-dispatch profile array from current quota-axi output.</li>
<li><code>harness-adapters</code> - load before spawning or recovering a
crewmate or secondmate, handling a trust dialog, sending a
harness-specific skill invocation, interrupting or exiting an agent,
resuming an exited agent, or verifying a new harness adapter.</li>
<li><code>firstmate-orca</code> - load before switching to Orca,
spawning or supervising Orca-backed work, smoke-testing Orca backend
behavior, debugging Orca task state, or reconciling Orca-backed task
metadata.</li>
<li><code>project-management</code> - load before adding, creating,
removing, or initializing a project. Cloning or registering a project is
add intake and uses the same trigger.</li>
<li><code>stuck-crewmate-recovery</code> - load when the session-start
digest reports an ordinary direct report’s endpoint dead or its metadata
has no window, or after a stale wake, looping pane, repeated confusion,
an answered-by-brief question, an unresponsive crewmate, or a failed
steer.</li>
<li><code>secondmate-provisioning</code> - load before creating,
seeding, validating, launching, handing backlog to, recovering, pushing
inherited local material into, or retiring a secondmate home, and before
editing <code>data/secondmates.md</code>.</li>
<li><code>decision-hold-lifecycle</code> - load before treating an
investigation or visual review as complete, before ending a visual
review that exposed a decision, and when recording or routing the
captain’s answer.</li>
<li><code>fmx-respond</code> - load on an
<code>x-mention &lt;request_id&gt;</code> <code>check:</code> wake to
handle the mention, on an <code>x-mode-error ...</code>
<code>check:</code> wake to report the X-mode configuration blocker, on
a <code>public-followup ...</code> <code>check:</code> wake or a
startup-surfaced public commitment, and on any milestone or terminal
wake for an X-mode-linked task before posting its completion follow-up;
relevant only when X mode is on.</li>
<li><code>firstmate-codexapp</code> - load before coordinating a visible
Codex Desktop thread, evaluating a Codex App backend request, or
reconciling Codex Desktop host-tool smoke evidence for Firstmate
work.</li>
<li><code>firstmate-coding-guidelines</code> - load before changing
firstmate’s shared, tracked material, as defined by section 1’s list,
whether editing directly or briefing a crewmate for a firstmate-repo
task.</li>
</ul>
<h2 id="x-mode">14. X mode</h2>
<p>X mode ships inert and causes no behavior change until the home opts
in by placing <code>FMX_PAIRING_TOKEN</code> in its gitignored
<code>.env</code>. That token is consent for public replies and normal
reversible lifecycle actions from eligible mentions, not authority for
destructive, irreversible, or security-sensitive action; those still
require trusted-channel confirmation. <code>docs/configuration.md</code>
owns activation, generated state, cadence, wire protocol, and opt-out
mechanics.</p>
<p>An X-only home still requires the live supervision cycle so mentions
can wake it without fleet work. On an
<code>x-mention &lt;request_id&gt;</code> or
<code>x-mode-error ...</code> check wake, load <code>fmx-respond</code>,
which owns classification, public-safety policy, reply or dismissal,
task linking, and follow-ups. For every X-linked terminal outcome, load
that owner and use the promised-final reconciliation when a typed public
commitment exists, otherwise post the final completion follow-up before
teardown.</p>
<p>A promised final public reply is durable state, never conversation
memory. Load <code>fmx-respond</code> before promising one, on a
<code>public-followup ...</code> check wake, and whenever the
session-start digest lists a public commitment awaiting delivery. Only
the home holding the relay consent and thread binding ever posts it, so
never ask a secondmate or crewmate to find the thread or send the reply,
and never recover a terminal result by reading a <code>done:</code>
sentence.</p>
<h2 id="captain-instruction-precedence">Captain instruction
precedence</h2>
<p>A current, explicit, concrete captain instruction overrides any
conflicting standing rule written above. The instruction must be
specific and recent: it must identify the concrete action, object, or
bounded set it governs. Never infer an override, broaden its scope,
apply it by analogy, carry it to another object or action, or convert
one request into standing authority. Ambiguous scope or conflict still
requires one concise clarification before action. Destructive,
irreversible, security-sensitive, discard, and merge actions still
require the captain to state that concrete action explicitly; once the
captain does so and higher-priority instructions permit it, a
conflicting Firstmate-written rule must not rigidly block the action.
Standing <code>yolo</code> authority is not a substitute for a current
explicit captain instruction where an explicit action is required.</p>
<h2 id="maintaining-this-file">Maintaining this file</h2>
<p>Keep this file for knowledge useful to almost every future agent
session in this project. Do not repeat what the codebase already shows;
point to the authoritative file, skill, command, or doc. Prefer
rewriting or pruning existing entries over appending new ones. When
updating this file, preserve every safety boundary and keep the
always-loaded contract concise.</p>
</body>
</html>
```
</details>
- Evidence: Full rendered configuration documentation (local file: <code>/var/folders/vx/kq2w6_xj1sq82jh1gtsjl0_m0000gn/T/no-mistakes-evidence/01KYWY47731J109EN327WFZ018/configuration-rendered.html</code>)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `docs/configuration.md:23` - The moved catalog says `AGENTS.md            this file`, but the containing file is now `docs/configuration.md`, making the canonical catalog contextually false. Because the intent requires the catalog to move verbatim except for section-reference adjustments, confirm whether this entry may be changed to a context-neutral description.

🔧 Fix: Clarify AGENTS.md catalog description
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`git diff --stat` and `git diff --name-status 66b0f77632891a99a717da7a580009d3de7193a3..3add63c8ca6b00872edcc963556772e8f1b79d1a`</code>
- `git diff --word-diff=plain 66b0f77632891a99a717da7a580009d3de7193a3..3add63c8ca6b00872edcc963556772e8f1b79d1a -- AGENTS.md docs/configuration.md`
- `diff -u <(old AGENTS.md catalog) <(new configuration.md catalog normalized only for contextual owner/reference changes)`
- <code>`git show 66b0f77632891a99a717da7a580009d3de7193a3:AGENTS.md | wc -w` and `wc -w &lt; AGENTS.md`</code>
- <code>Exact `rg -Fq` assertions for all four recurring-check convention lines and absence of `fm-stale-decision-revalidation`</code>
- <code>`pandoc` rendering of both modified Markdown surfaces followed by headless Chrome screenshot capture and visual inspection</code>
- `Target-HEAD, two-file scope, evidence dimensions, and clean-worktree assertions`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
