### PR TITLE
fix(spawn): isolate each task's chrome-devtools-axi browser session

### DIFF
--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -265,7 +265,7 @@ The report is the only thing that survives, so anything worth keeping must be in
 # Rules
 1. Never push to any remote and never open a PR.
 2. Stay inside this worktree; the only files you may write outside it are the report and the status file below.
-3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
+3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations (each task's chrome-devtools-axi session is isolated automatically).
 4. Report status by appending one line:
    \`echo "{state}: {one short line}" >> $STATUS_FILE\`
    States: working, needs-decision, blocked, $PAUSED_VERB, done, failed.
@@ -376,7 +376,7 @@ If the top-level path is the primary checkout or not the worktree you were launc
 # Rules
 $RULE1
 2. Stay inside this worktree; modify nothing outside it.
-3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
+3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations (each task's chrome-devtools-axi session is isolated automatically).
 4. Report status by appending one line:
    \`echo "{state}: {one short line}" >> $STATUS_FILE\`
    States: working, needs-decision, blocked, $PAUSED_VERB, done, failed.

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1686,6 +1686,11 @@ fi
 # the env is set when the agent starts; the brief sleep lets the export land.
 spawn_send_text_line "$T" "export GOTMPDIR=$TASK_TMP/gotmp"
 sleep 0.3
+# Bind this task to its own chrome-devtools-axi browser session so concurrent
+# crewmates never share one Chrome instance (and thus each other's tabs/auth).
+# Same pattern and timing as GOTMPDIR above.
+spawn_send_text_line "$T" "export CHROME_DEVTOOLS_AXI_SESSION=$ID"
+sleep 0.3
 spawn_send_literal "$T" "$LAUNCH"
 sleep 0.3
 if [ "${HERDR_PROJECTED:-0}" -eq 1 ]; then

--- a/tests/fm-kimi-harness.test.sh
+++ b/tests/fm-kimi-harness.test.sh
@@ -209,6 +209,8 @@ test_kimi_launch_then_send_is_verified() {
   assert_present "$task_tmp/gotmp" "kimi spawn did not create its Go temp directory"
   assert_grep "export GOTMPDIR=$task_tmp/gotmp" "$CASE_DIR/tmux-calls.log" \
     "kimi spawn did not export its Go temp directory into the pane"
+  assert_grep "export CHROME_DEVTOOLS_AXI_SESSION=$id" "$CASE_DIR/tmux-calls.log" \
+    "kimi spawn did not export its own chrome-devtools-axi session into the pane"
   assert_grep 'BEGIN FIRSTMATE KIMI TURN-END HOOK' "$HOME_DIR/.kimi-code/config.toml" \
     "kimi spawn did not install its guarded global hook region"
   assert_grep 'token=' "$WT_DIR/.fm-kimi-turnend" "kimi spawn did not write its token pointer"


### PR DESCRIPTION
## Summary
- Two concurrent crewmates doing live browser verification with chrome-devtools-axi were sharing one Chrome instance, because nothing set `CHROME_DEVTOOLS_AXI_SESSION` (chrome-devtools-axi's own per-task isolation env var, which defaults to a single shared session). One task's authenticated tab became visible to another task's crewmate.
- `bin/fm-spawn.sh` now exports `CHROME_DEVTOOLS_AXI_SESSION=<task id>` into every launched crewmate/secondmate pane, following the exact pattern and timing already used for the per-task `GOTMPDIR` export, so browser-session isolation is structural and automatic instead of something a brief has to remember to request.
- Added a one-line cross-reference to `bin/fm-brief.sh`'s existing chrome-devtools-axi rule line (both scout and ship templates) without restating the mechanism, per the one-owner rule.
- Extended the existing GOTMPDIR pane-export regression assertion in `tests/fm-kimi-harness.test.sh` with an equivalent assertion for the new export - the only existing test pattern for asserting fm-spawn.sh's per-task pane environment exports.
- Out of scope: the destructive admin action from the same incident (an account deleted after being incidentally observed via the shared session) is a separate fix dispatched elsewhere.

## Test plan
- [x] `bin/fm-lint.sh` clean
- [x] `bin/fm-doc-audience-check.sh` clean
- [x] Full changed-scope test run: 35 scripts, 684 assertions, 0 failures
- [x] no-mistakes pipeline: intent/rebase/review/test/document/lint all completed clean (run 01KYWYCSXA30P60K69771KGH4E)