### PR TITLE
feat(herdr): add Codex context meter

### DIFF
--- a/bin/fm-codex-context-meter-install.sh
+++ b/bin/fm-codex-context-meter-install.sh
@@ -1,0 +1,564 @@
+#!/usr/bin/env bash
+# fm-codex-context-meter-install.sh - install or remove the global Codex meter.
+#
+# Usage:
+#   fm-codex-context-meter-install.sh install
+#   fm-codex-context-meter-install.sh uninstall
+#
+# The installer merges four command hooks into $CODEX_HOME/hooks.json, adds the
+# exact Codex footer fields to $CODEX_HOME/config.toml, and adds a $context row
+# to Herdr's Codex-specific agent rows. Existing JSON/TOML is parsed before and
+# after every edit. A private ownership receipt makes a byte-exact uninstall
+# possible while the files are unchanged and limits drifted-file cleanup to
+# values this installer actually added.
+#
+# HERDR_CONFIG_PATH overrides the default Herdr config path. The command never
+# installs Herdr's official Codex integration and never reloads a live server.
+set -u
+
+case "${1:-}" in
+  install|uninstall) ACTION=$1 ;;
+  -h|--help)
+    sed -n '2,18{s/^# \{0,1\}//;p;}' "$0"
+    exit 0
+    ;;
+  *)
+    printf 'usage: %s install|uninstall\n' "${0##*/}" >&2
+    exit 2
+    ;;
+esac
+
+if [ -z "${HOME:-}" ]; then
+  printf 'fm-codex-context-meter-install: refused: HOME is unset.\n' >&2
+  exit 1
+fi
+if ! command -v python3 >/dev/null 2>&1; then
+  printf 'fm-codex-context-meter-install: refused: python3 with tomllib is required.\n' >&2
+  exit 1
+fi
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+HANDLER="$ROOT/bin/fm-codex-context-meter.sh"
+CODEX_DIR=${CODEX_HOME:-$HOME/.codex}
+HERDR_CONFIG=${HERDR_CONFIG_PATH:-${XDG_CONFIG_HOME:-$HOME/.config}/herdr/config.toml}
+
+python3 - "$ACTION" "$CODEX_DIR" "$HERDR_CONFIG" "$HANDLER" <<'PY'
+from __future__ import annotations
+
+import base64
+import copy
+import hashlib
+import json
+import os
+import re
+import shlex
+import stat
+import sys
+import tempfile
+
+try:
+    import tomllib
+except ImportError:
+    print(
+        "fm-codex-context-meter-install: refused: python3 with tomllib is required.",
+        file=sys.stderr,
+    )
+    raise SystemExit(1)
+
+ACTION, CODEX_DIR, HERDR_CONFIG, HANDLER = sys.argv[1:]
+HOOKS = os.path.join(CODEX_DIR, "hooks.json")
+CODEX_CONFIG = os.path.join(CODEX_DIR, "config.toml")
+STATE = os.path.join(CODEX_DIR, ".firstmate-codex-context-meter.json")
+EVENTS = ("SessionStart", "PostToolUse", "PostCompact", "Stop")
+STATUS_ITEMS = ("context-used", "context-window-size", "used-tokens")
+CONTEXT_ROW = ["$context"]
+DEFAULT_AGENT_ROWS = [["state_icon", "workspace", "tab"], ["agent"]]
+
+
+class Refusal(Exception):
+    pass
+
+
+def refuse(reason: str) -> None:
+    raise Refusal(reason)
+
+
+def ensure_parent(path: str) -> None:
+    parent = os.path.dirname(path)
+    if os.path.lexists(parent):
+        info = os.lstat(parent)
+        if stat.S_ISLNK(info.st_mode) or not stat.S_ISDIR(info.st_mode):
+            refuse(f"config parent is not a regular directory: {parent}")
+    else:
+        os.makedirs(parent, mode=0o700)
+
+
+def read_file(path: str) -> tuple[bool, bytes, int]:
+    try:
+        info = os.lstat(path)
+    except FileNotFoundError:
+        return False, b"", 0o600
+    if stat.S_ISLNK(info.st_mode) or not stat.S_ISREG(info.st_mode):
+        refuse(f"config path is not a regular non-symlink file: {path}")
+    with open(path, "rb") as stream:
+        return True, stream.read(), stat.S_IMODE(info.st_mode)
+
+
+def atomic_write(path: str, data: bytes, mode: int) -> None:
+    ensure_parent(path)
+    fd, temporary = tempfile.mkstemp(prefix=f".{os.path.basename(path)}.", dir=os.path.dirname(path))
+    try:
+        os.fchmod(fd, mode)
+        with os.fdopen(fd, "wb") as stream:
+            fd = -1
+            stream.write(data)
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(temporary, path)
+    except Exception:
+        if fd >= 0:
+            os.close(fd)
+        try:
+            os.unlink(temporary)
+        except FileNotFoundError:
+            pass
+        raise
+
+
+def digest(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def snapshot(exists: bool, data: bytes, mode: int) -> dict:
+    return {
+        "exists": exists,
+        "mode": mode,
+        "data": base64.b64encode(data).decode("ascii"),
+    }
+
+
+def snapshot_bytes(record: dict) -> bytes:
+    return base64.b64decode(record["data"], validate=True)
+
+
+def parse_json(data: bytes, label: str) -> dict:
+    if not data:
+        return {}
+    try:
+        value = json.loads(data)
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        refuse(f"{label} is malformed JSON: {error}")
+    if not isinstance(value, dict):
+        refuse(f"{label} root is not an object")
+    return value
+
+
+def json_bytes(value: dict) -> bytes:
+    return (json.dumps(value, ensure_ascii=False, indent=2) + "\n").encode()
+
+
+def parse_toml(data: bytes, label: str) -> dict:
+    if not data:
+        return {}
+    try:
+        text = data.decode("utf-8")
+    except UnicodeDecodeError as error:
+        refuse(f"{label} is not UTF-8: {error}")
+    try:
+        value = tomllib.loads(text)
+    except tomllib.TOMLDecodeError as error:
+        refuse(f"{label} is malformed TOML: {error}")
+    if not isinstance(value, dict):
+        refuse(f"{label} root is not a table")
+    return value
+
+
+def nested(value: dict, path: tuple[str, ...]):
+    current = value
+    for key in path:
+        if not isinstance(current, dict) or key not in current:
+            return None
+        current = current[key]
+    return current
+
+
+def inline_toml(value) -> str:
+    return json.dumps(value, ensure_ascii=False, separators=(", ", ": "))
+
+
+HEADER = re.compile(r"(?m)^[ \t]*\[(?!\[)([^\]\n]+)\][ \t]*(?:#.*)?$")
+
+
+def table_bounds(text: str, table: str):
+    matches = [match for match in HEADER.finditer(text) if match.group(1).replace(" ", "") == table]
+    if len(matches) > 1:
+        refuse(f"TOML repeats [{table}] in an unsupported form")
+    if not matches:
+        return None
+    match = matches[0]
+    next_match = HEADER.search(text, match.end())
+    return match.start(), match.end(), next_match.start() if next_match else len(text)
+
+
+def array_end(text: str, start: int) -> int:
+    if start >= len(text) or text[start] != "[":
+        refuse("owned TOML value is not an array")
+    depth = 0
+    quote = None
+    escaped = False
+    comment = False
+    for index in range(start, len(text)):
+        char = text[index]
+        if comment:
+            if char == "\n":
+                comment = False
+            continue
+        if quote is not None:
+            if quote == '"' and escaped:
+                escaped = False
+            elif quote == '"' and char == "\\":
+                escaped = True
+            elif char == quote:
+                quote = None
+            continue
+        if char == "#":
+            comment = True
+        elif char in ('"', "'"):
+            quote = char
+        elif char == "[":
+            depth += 1
+        elif char == "]":
+            depth -= 1
+            if depth == 0:
+                return index + 1
+    refuse("owned TOML array is unterminated")
+
+
+def find_assignment(text: str, table: str, key: str, dotted: str | None = None):
+    candidates = []
+    bounds = table_bounds(text, table)
+    if bounds:
+        _, body_start, body_end = bounds
+        pattern = re.compile(rf"(?m)^[ \t]*{re.escape(key)}[ \t]*=")
+        candidates.extend(pattern.finditer(text, body_start, body_end))
+    if dotted:
+        first_table = HEADER.search(text)
+        root_end = first_table.start() if first_table else len(text)
+        pattern = re.compile(rf"(?m)^[ \t]*{re.escape(dotted)}[ \t]*=")
+        candidates.extend(pattern.finditer(text, 0, root_end))
+    if len(candidates) > 1:
+        refuse(f"TOML has multiple assignments for {dotted or table + '.' + key}")
+    if not candidates:
+        return None
+    match = candidates[0]
+    equals = text.find("=", match.start(), match.end())
+    value_start = equals + 1
+    while value_start < len(text) and text[value_start] in " \t":
+        value_start += 1
+    value_end = array_end(text, value_start)
+    line_start = text.rfind("\n", 0, match.start()) + 1
+    line_end = text.find("\n", value_end)
+    if line_end < 0:
+        line_end = len(text)
+    else:
+        line_end += 1
+    trailing = text[value_end:line_end].strip()
+    if trailing and not trailing.startswith("#"):
+        refuse(f"TOML has unsupported content after {dotted or key}")
+    return line_start, line_end, value_start, value_end
+
+
+def set_array(text: str, table: str, key: str, dotted: str | None, value) -> tuple[str, bool]:
+    location = find_assignment(text, table, key, dotted)
+    encoded = inline_toml(value)
+    if location:
+        return text[: location[2]] + encoded + text[location[3] :], False
+    bounds = table_bounds(text, table)
+    assignment = f"{key} = {encoded}\n"
+    if bounds:
+        insert = bounds[1]
+        if insert < len(text) and text[insert] == "\n":
+            insert += 1
+        return text[:insert] + assignment + text[insert:], True
+    prefix = text
+    if prefix and not prefix.endswith("\n"):
+        prefix += "\n"
+    if prefix and not prefix.endswith("\n\n"):
+        prefix += "\n"
+    return prefix + f"[{table}]\n{assignment}", True
+
+
+def remove_array(text: str, table: str, key: str, dotted: str | None) -> str:
+    location = find_assignment(text, table, key, dotted)
+    if not location:
+        return text
+    return text[: location[0]] + text[location[1] :]
+
+
+def owned_handler(value) -> bool:
+    return (
+        isinstance(value, dict)
+        and value.get("type") == "command"
+        and "fm-codex-context-meter.sh" in str(value.get("command", ""))
+    )
+
+
+def clean_owned_hooks(document: dict) -> dict:
+    result = copy.deepcopy(document)
+    hooks = result.get("hooks")
+    if hooks is None:
+        return result
+    if not isinstance(hooks, dict):
+        refuse("hooks.json has a non-object hooks value")
+    for event in list(hooks):
+        groups = hooks[event]
+        if not isinstance(groups, list):
+            refuse(f"hooks.json event {event} is not an array")
+        cleaned = []
+        for group in groups:
+            if not isinstance(group, dict) or not isinstance(group.get("hooks"), list):
+                refuse(f"hooks.json event {event} has an invalid matcher group")
+            candidate = copy.deepcopy(group)
+            candidate["hooks"] = [entry for entry in candidate["hooks"] if not owned_handler(entry)]
+            if candidate["hooks"] or set(candidate) != {"hooks"}:
+                cleaned.append(candidate)
+        if cleaned:
+            hooks[event] = cleaned
+        else:
+            del hooks[event]
+    if not hooks:
+        result.pop("hooks", None)
+    return result
+
+
+def install_hooks(document: dict) -> dict:
+    result = clean_owned_hooks(document)
+    hooks = result.setdefault("hooks", {})
+    command = shlex.quote(os.path.realpath(HANDLER))
+    handler = {
+        "type": "command",
+        "command": command,
+        "timeout": 2,
+    }
+    for event in EVENTS:
+        groups = hooks.setdefault(event, [])
+        if not isinstance(groups, list):
+            refuse(f"hooks.json event {event} is not an array")
+        groups.append({"hooks": [copy.deepcopy(handler)]})
+    return result
+
+
+def restore_or_write(path: str, candidate: bytes | None, mode: int) -> None:
+    if candidate is None:
+        try:
+            info = os.lstat(path)
+        except FileNotFoundError:
+            return
+        if stat.S_ISLNK(info.st_mode) or not stat.S_ISREG(info.st_mode):
+            refuse(f"refusing to remove unexpected path: {path}")
+        os.unlink(path)
+    else:
+        atomic_write(path, candidate, mode)
+
+
+def exact_restore(current: bytes, record: dict):
+    if digest(current) != record.get("after_sha256"):
+        return None, False
+    if record["before"]["exists"]:
+        return snapshot_bytes(record["before"]), True
+    return None, True
+
+
+try:
+    if ACTION == "install" and (not os.path.isfile(HANDLER) or not os.access(HANDLER, os.X_OK)):
+        refuse(f"hook handler is missing or not executable: {HANDLER}")
+
+    hooks_exists, hooks_original, hooks_mode = read_file(HOOKS)
+    codex_exists, codex_original, codex_mode = read_file(CODEX_CONFIG)
+    herdr_exists, herdr_original, herdr_mode = read_file(HERDR_CONFIG)
+    state_exists, state_original, state_mode = read_file(STATE)
+
+    hooks_doc = parse_json(hooks_original, "Codex hooks.json")
+    codex_doc = parse_toml(codex_original, "Codex config.toml")
+    herdr_doc = parse_toml(herdr_original, "Herdr config.toml")
+
+    if state_exists:
+        state_doc = parse_json(state_original, "Firstmate ownership receipt")
+        if state_doc.get("version") != 1:
+            refuse("Firstmate ownership receipt has an unsupported version")
+    else:
+        state_doc = None
+
+    if ACTION == "install":
+        if state_doc is None:
+            for event_groups in hooks_doc.get("hooks", {}).values():
+                if isinstance(event_groups, list) and any(
+                    owned_handler(entry)
+                    for group in event_groups
+                    if isinstance(group, dict)
+                    for entry in group.get("hooks", [])
+                ):
+                    refuse("owned hooks exist without a Firstmate ownership receipt")
+
+        updated_hooks_doc = install_hooks(hooks_doc)
+        hooks_candidate = json_bytes(updated_hooks_doc)
+
+        tui = codex_doc.get("tui", {})
+        if tui is not None and not isinstance(tui, dict):
+            refuse("Codex config.toml has a non-table tui value")
+        current_status = tui.get("status_line") if isinstance(tui, dict) else None
+        if current_status is not None and (
+            not isinstance(current_status, list) or not all(isinstance(item, str) for item in current_status)
+        ):
+            refuse("Codex tui.status_line is not a string array")
+        current_status = list(current_status or [])
+        added_status = [item for item in STATUS_ITEMS if item not in current_status]
+        installed_status = current_status + added_status
+        codex_text = codex_original.decode("utf-8") if codex_original else ""
+        codex_text, codex_created = set_array(
+            codex_text, "tui", "status_line", "tui.status_line", installed_status
+        )
+        codex_candidate = codex_text.encode()
+        parse_toml(codex_candidate, "updated Codex config.toml")
+
+        global_rows = nested(herdr_doc, ("ui", "sidebar", "agents", "rows"))
+        if global_rows is None:
+            global_rows = copy.deepcopy(DEFAULT_AGENT_ROWS)
+        if not isinstance(global_rows, list) or not all(isinstance(row, list) for row in global_rows):
+            refuse("Herdr ui.sidebar.agents.rows is not an array of rows")
+        codex_rows = nested(
+            herdr_doc, ("ui", "sidebar", "agents", "rows_by_agent", "codex")
+        )
+        if codex_rows is not None and (
+            not isinstance(codex_rows, list) or not all(isinstance(row, list) for row in codex_rows)
+        ):
+            refuse("Herdr rows_by_agent.codex is not an array of rows")
+        herdr_created_codex = codex_rows is None
+        installed_rows = copy.deepcopy(global_rows if codex_rows is None else codex_rows)
+        context_present = any("$context" in row for row in installed_rows)
+        herdr_added = not context_present
+        if herdr_added:
+            installed_rows.append(copy.deepcopy(CONTEXT_ROW))
+        herdr_text = herdr_original.decode("utf-8") if herdr_original else ""
+        herdr_text, _ = set_array(
+            herdr_text,
+            "ui.sidebar.agents.rows_by_agent",
+            "codex",
+            "ui.sidebar.agents.rows_by_agent.codex",
+            installed_rows,
+        )
+        herdr_candidate = herdr_text.encode()
+        parse_toml(herdr_candidate, "updated Herdr config.toml")
+
+        if state_doc is None:
+            state_doc = {
+                "version": 1,
+                "files": {
+                    "hooks": {"before": snapshot(hooks_exists, hooks_original, hooks_mode)},
+                    "codex": {"before": snapshot(codex_exists, codex_original, codex_mode)},
+                    "herdr": {"before": snapshot(herdr_exists, herdr_original, herdr_mode)},
+                },
+                "codex_added": added_status,
+                "codex_created": codex_created,
+                "herdr_added": herdr_added,
+                "herdr_created_codex": herdr_created_codex,
+                "herdr_installed_base": copy.deepcopy(global_rows if herdr_created_codex else codex_rows),
+            }
+        else:
+            state_doc["codex_added"] = list(dict.fromkeys(state_doc.get("codex_added", []) + added_status))
+            state_doc["herdr_added"] = bool(state_doc.get("herdr_added")) or herdr_added
+
+        state_doc["files"]["hooks"]["after_sha256"] = digest(hooks_candidate)
+        state_doc["files"]["codex"]["after_sha256"] = digest(codex_candidate)
+        state_doc["files"]["herdr"]["after_sha256"] = digest(herdr_candidate)
+        state_candidate = json_bytes(state_doc)
+
+        if hooks_candidate != hooks_original:
+            atomic_write(HOOKS, hooks_candidate, hooks_mode)
+        if codex_candidate != codex_original:
+            atomic_write(CODEX_CONFIG, codex_candidate, codex_mode)
+        if herdr_candidate != herdr_original:
+            atomic_write(HERDR_CONFIG, herdr_candidate, herdr_mode)
+        if state_candidate != state_original:
+            atomic_write(STATE, state_candidate, 0o600)
+        print("Codex context meter installed; restart Codex and reload or restart Herdr.")
+    else:
+        if state_doc is None:
+            refuse("Firstmate ownership receipt is missing; nothing was removed")
+
+        hooks_candidate, hooks_exact = exact_restore(hooks_original, state_doc["files"]["hooks"])
+        if not hooks_exact:
+            hooks_candidate = json_bytes(clean_owned_hooks(hooks_doc))
+
+        codex_candidate, codex_exact = exact_restore(codex_original, state_doc["files"]["codex"])
+        if not codex_exact:
+            current_status = nested(codex_doc, ("tui", "status_line"))
+            if isinstance(current_status, list) and all(isinstance(item, str) for item in current_status):
+                remaining = list(current_status)
+                for item in state_doc.get("codex_added", []):
+                    if item in remaining:
+                        remaining.remove(item)
+                text = codex_original.decode("utf-8")
+                if state_doc.get("codex_created") and not remaining:
+                    text = remove_array(text, "tui", "status_line", "tui.status_line")
+                else:
+                    text, _ = set_array(text, "tui", "status_line", "tui.status_line", remaining)
+                codex_candidate = text.encode()
+                parse_toml(codex_candidate, "Codex config.toml after uninstall")
+            else:
+                codex_candidate = codex_original
+
+        herdr_candidate, herdr_exact = exact_restore(herdr_original, state_doc["files"]["herdr"])
+        if not herdr_exact:
+            current_rows = nested(
+                herdr_doc, ("ui", "sidebar", "agents", "rows_by_agent", "codex")
+            )
+            if isinstance(current_rows, list):
+                remaining_rows = copy.deepcopy(current_rows)
+                if state_doc.get("herdr_added") and CONTEXT_ROW in remaining_rows:
+                    remaining_rows.remove(CONTEXT_ROW)
+                text = herdr_original.decode("utf-8")
+                if (
+                    state_doc.get("herdr_created_codex")
+                    and remaining_rows == state_doc.get("herdr_installed_base")
+                ):
+                    text = remove_array(
+                        text,
+                        "ui.sidebar.agents.rows_by_agent",
+                        "codex",
+                        "ui.sidebar.agents.rows_by_agent.codex",
+                    )
+                else:
+                    text, _ = set_array(
+                        text,
+                        "ui.sidebar.agents.rows_by_agent",
+                        "codex",
+                        "ui.sidebar.agents.rows_by_agent.codex",
+                        remaining_rows,
+                    )
+                herdr_candidate = text.encode()
+                parse_toml(herdr_candidate, "Herdr config.toml after uninstall")
+            else:
+                herdr_candidate = herdr_original
+
+        restore_or_write(
+            HOOKS,
+            hooks_candidate,
+            state_doc["files"]["hooks"]["before"]["mode"] if hooks_exact else hooks_mode,
+        )
+        restore_or_write(
+            CODEX_CONFIG,
+            codex_candidate,
+            state_doc["files"]["codex"]["before"]["mode"] if codex_exact else codex_mode,
+        )
+        restore_or_write(
+            HERDR_CONFIG,
+            herdr_candidate,
+            state_doc["files"]["herdr"]["before"]["mode"] if herdr_exact else herdr_mode,
+        )
+        os.unlink(STATE)
+        print("Codex context meter uninstalled; restart Codex and reload or restart Herdr.")
+except (OSError, KeyError, ValueError, Refusal) as error:
+    print(f"fm-codex-context-meter-install: refused: {error}.", file=sys.stderr)
+    raise SystemExit(1)
+PY

--- a/bin/fm-codex-context-meter.sh
+++ b/bin/fm-codex-context-meter.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# fm-codex-context-meter.sh - report active Codex context use to a Herdr pane.
+#
+# Codex invokes this command from global SessionStart, PostToolUse, PostCompact,
+# and Stop hooks. The hook reads at most the final 4 MiB of the transcript and
+# uses the newest event_msg/token_count record. Active context comes from
+# last_token_usage.total_tokens, never cumulative total_token_usage.
+#
+# Every path is silent and exits zero. Missing tools, input, transcript data,
+# pane identity, or a working Herdr socket therefore cannot block Codex.
+set +e
+exec >/dev/null 2>&1
+
+[ -n "${HERDR_PANE_ID:-}" ] || exit 0
+command -v jq >/dev/null 2>&1 || exit 0
+command -v herdr >/dev/null 2>&1 || exit 0
+command -v perl >/dev/null 2>&1 || exit 0
+
+payload=
+IFS= read -r payload || [ -n "$payload" ] || exit 0
+transcript=$(printf '%s' "$payload" | jq -er '
+  select(
+    .hook_event_name == "SessionStart" or
+    .hook_event_name == "PostToolUse" or
+    .hook_event_name == "PostCompact" or
+    .hook_event_name == "Stop"
+  )
+  | .transcript_path
+  | strings
+  | select(startswith("/"))
+' 2>/dev/null) || exit 0
+[ -f "$transcript" ] && [ -r "$transcript" ] || exit 0
+
+context=$(
+  tail -c 4194304 "$transcript" 2>/dev/null | jq -Rrs '
+    def compact:
+      if . >= 1000000 then
+        (((. + 50000) / 100000 | floor) as $tenths
+          | "\($tenths / 10 | floor).\($tenths % 10)m")
+      elif . >= 1000 then
+        (((. + 50) / 100 | floor) as $tenths
+          | "\($tenths / 10 | floor).\($tenths % 10)k")
+      else
+        tostring
+      end;
+    [
+      split("\n")[]
+      | fromjson?
+      | select(.type == "event_msg" and .payload.type == "token_count")
+      | .payload.info
+      | select(
+          (.last_token_usage.total_tokens | type) == "number" and
+          (.model_context_window | type) == "number" and
+          .last_token_usage.total_tokens >= 0 and
+          .model_context_window > 0
+        )
+      | {
+          used: (.last_token_usage.total_tokens | floor),
+          window: (.model_context_window | floor)
+        }
+    ]
+    | last // empty
+    | . + {percent: (((.used * 100 / .window) + 0.5) | floor)}
+    | .percent = (if .percent > 100 then 100 else .percent end)
+    | . + {filled: (((.percent + 5) / 10) | floor)}
+    | ("█" * .filled) + ("░" * (10 - .filled)) +
+      " \(.used | compact) / \(.window | compact) · \(.percent)%"
+  ' 2>/dev/null
+) || exit 0
+[ -n "$context" ] || exit 0
+
+# alarm survives exec and bounds an unavailable or wedged Herdr socket.
+perl -e 'alarm shift; exec @ARGV' 1 \
+  herdr pane report-metadata "$HERDR_PANE_ID" \
+  --source firstmate:codex-context --agent codex \
+  --token "context=$context" || true
+exit 0

--- a/docs/codex-context-meter.md
+++ b/docs/codex-context-meter.md
@@ -1,0 +1,74 @@
+# Codex context meter for Herdr
+
+The Codex context meter is an opt-in display for Codex panes running inside Herdr.
+It adds a compact active-context bar to Herdr's agent sidebar and exact context fields to the Codex footer.
+It does not install Herdr's official Codex integration, which remains a separate session-restore feature.
+
+## Install
+
+Run the installer from the Firstmate checkout that should own the global hook command.
+
+```sh
+bin/fm-codex-context-meter-install.sh install
+```
+
+The installer updates the following user-level files:
+
+- `$CODEX_HOME/hooks.json`, or `~/.codex/hooks.json` when `CODEX_HOME` is unset.
+- `$CODEX_HOME/config.toml`, or `~/.codex/config.toml` when `CODEX_HOME` is unset.
+- `$HERDR_CONFIG_PATH`, or `${XDG_CONFIG_HOME:-~/.config}/herdr/config.toml` when `HERDR_CONFIG_PATH` is unset.
+
+Existing hook groups, Codex settings, Herdr settings, comments, and unrelated values remain in place.
+The installer adds `context-used`, `context-window-size`, and `used-tokens` to the Codex footer only when they are absent.
+It adds `"$context"` to `ui.sidebar.agents.rows_by_agent.codex`, preserving existing Codex-specific rows or copying the configured general agent rows before adding the custom row.
+A private `.firstmate-codex-context-meter.json` receipt under `CODEX_HOME` records exactly what the installer owns.
+Running install again converges to the same bytes.
+
+Restart Codex so its global hooks and footer configuration are reloaded.
+Review and trust the new command hooks with `/hooks` when Codex requests it.
+Reload a running Herdr server after reviewing the config change.
+
+```sh
+herdr server reload-config
+```
+
+## Display and update cadence
+
+The handler reads the newest Codex transcript `event_msg` whose payload type is `token_count`.
+It uses `payload.info.last_token_usage.total_tokens` for active use and `payload.info.model_context_window` for the window size.
+It never uses cumulative `total_token_usage` as the numerator.
+
+The `context` pane metadata token is shaped like this:
+
+```text
+████████░░ 216.7k / 258.4k · 84%
+```
+
+Global Codex command hooks refresh the token at `SessionStart`, `PostToolUse`, `PostCompact`, and `Stop`.
+The `PostCompact` checkpoint lets the sidebar show the lower active count as soon as compaction completes.
+There is no polling daemon, launch agent, detached process, or periodic background job.
+
+## Failure behavior and limits
+
+The handler is silent and exits zero on every path.
+Missing `jq`, `perl`, Herdr, `HERDR_PANE_ID`, transcript data, valid token records, or a working Herdr socket leaves Codex unaffected.
+The transcript read is bounded to its final 4 MiB.
+The Herdr report is bounded to one second, and Codex also gives each installed hook a two-second timeout.
+The rendered metadata value stays below Herdr's 80-character token limit.
+
+Codex documents `transcript_path` for hooks but does not treat the transcript record format as a stable interface.
+A future Codex transcript change can therefore make the meter temporarily inert until this parser is updated.
+Current configuration and render verification evidence is recorded in [verification/codex-context-meter.md](verification/codex-context-meter.md).
+
+## Uninstall
+
+Run uninstall from any checkout containing this installer.
+
+```sh
+bin/fm-codex-context-meter-install.sh uninstall
+```
+
+When the managed files have not changed since installation, uninstall restores their original bytes.
+When they have changed, uninstall removes only the Firstmate-owned hook handlers, footer identifiers, and `"$context"` row while retaining later unrelated edits.
+It then removes the ownership receipt.
+Restart Codex and reload or restart Herdr after uninstalling.

--- a/docs/documentation-audiences.json
+++ b/docs/documentation-audiences.json
@@ -220,6 +220,10 @@
       "audience": "operator-current"
     },
     {
+      "path": "docs/codex-context-meter.md",
+      "audience": "operator-current"
+    },
+    {
       "path": "docs/configuration.md",
       "audience": "operator-current"
     },
@@ -305,6 +309,10 @@
     },
     {
       "path": "docs/verification/dispatch-auth.md",
+      "audience": "maintainer-verification"
+    },
+    {
+      "path": "docs/verification/codex-context-meter.md",
       "audience": "maintainer-verification"
     },
     {

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -33,6 +33,8 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-turnend-guard.sh`    | Shared primary turn-end guard predicate so no turn ends blind (docs/turnend-guard.md) |
 | `fm-turnend-guard-grok.sh` | Grok Stop-hook adapter for the primary turn-end guard                              |
 | `fm-kimi-turnend-hook.sh` | Surgically install or remove Kimi's guarded global crew turn-end hook                |
+| `fm-codex-context-meter.sh` | Silently report bounded active Codex context usage to the current Herdr pane        |
+| `fm-codex-context-meter-install.sh` | Reversibly merge the Codex context meter into global Codex and Herdr config |
 | `fm-arm-pretool-check.sh` | Stable PreToolUse transport for the watcher-arm command policy (docs/arm-pretool-check.md) |
 | `fm-arm-command-policy.mjs` | Semantic owner of the watcher-arm PreToolUse policy (docs/arm-pretool-check.md)   |
 | `fm-subagent-pretool-check.sh` | Primary-home delegation-shape PreToolUse guard (docs/subagent-guard.md) |

--- a/docs/verification/codex-context-meter.md
+++ b/docs/verification/codex-context-meter.md
@@ -1,0 +1,52 @@
+# Codex context meter verification
+
+Date: 2026-07-31.
+
+Versions under test:
+
+- `codex-cli 0.146.0`.
+- `herdr 0.7.4`.
+
+## Automated behavior
+
+Command:
+
+```sh
+tests/fm-codex-context-meter.test.sh
+```
+
+Observed output:
+
+```text
+ok - Codex context meter uses active usage and follows compaction immediately
+ok - Codex context meter is silent and fail-open for absent, malformed, and reporting failures
+ok - context meter installer preserves config, is byte-idempotent, and uninstalls exactly
+ok - drifted uninstall removes only Firstmate-owned hooks, footer fields, and $context row
+```
+
+The installer fixture also invokes the real Herdr parser against its isolated generated config.
+
+```sh
+HERDR_CONFIG_PATH=<isolated-config> herdr config check
+```
+
+The command exited zero with no diagnostics.
+
+## Herdr row contract
+
+Command:
+
+```sh
+herdr --default-config | sed -n '203,220p'
+```
+
+Herdr's default config identifies `$name` values in expanded agent rows as custom pane-metadata tokens and identifies `rows_by_agent` as the canonical-agent override.
+The installed Codex override includes `[$context]` as a dedicated row, represented as `["$context"]` in TOML.
+
+## Visual verification limit
+
+Live visual rendering was not proven in an isolated Herdr session during this verification.
+A nested named-session launch was refused by Herdr's default nesting guard, and a second isolated named server did not become ready.
+A later isolated monolithic probe was terminated before metadata injection and removed at the captain's direction.
+Those attempts did not touch the captain's live Herdr config or report metadata to the live pane.
+The current evidence proves the documented row contract, generated TOML validity, metadata command shape, and formatter output, but it does not claim a captured live sidebar render.

--- a/tests/fm-codex-context-meter.test.sh
+++ b/tests/fm-codex-context-meter.test.sh
@@ -1,0 +1,296 @@
+#!/usr/bin/env bash
+# Behavior tests for the opt-in Codex context meter and reversible installer.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+METER="$ROOT/bin/fm-codex-context-meter.sh"
+INSTALLER="$ROOT/bin/fm-codex-context-meter-install.sh"
+TMP_ROOT=$(fm_test_tmproot fm-codex-context-meter)
+
+cleanup_context_meter() {
+  rm -rf "$TMP_ROOT"
+}
+trap cleanup_context_meter EXIT
+
+expect_silent_zero() {
+  local label=$1
+  shift
+  local out status=0
+  out=$("$@" 2>&1) || status=$?
+  expect_code 0 "$status" "$label must exit zero"
+  [ -z "$out" ] || fail "$label must be silent, got: $out"
+}
+
+make_fake_herdr() {
+  local dir=$1
+  mkdir -p "$dir"
+  cat > "$dir/herdr" <<'SH'
+#!/usr/bin/env bash
+set -u
+printf '%s\n' "$*" >> "$FM_FAKE_HERDR_LOG"
+exit "${FM_FAKE_HERDR_EXIT:-0}"
+SH
+  chmod +x "$dir/herdr"
+}
+
+run_meter() {
+  local pane=$1 transcript=$2 fakebin=$3 event=${4:-PostToolUse}
+  printf '{"hook_event_name":"%s","transcript_path":"%s"}\n' "$event" "$transcript" \
+    | HERDR_PANE_ID="$pane" FM_FAKE_HERDR_LOG="$TMP_ROOT/herdr.log" \
+      PATH="$fakebin:$PATH" "$METER"
+}
+
+test_active_context_and_post_compaction() {
+  local case_dir transcript fakebin out status=0 token_bytes
+  case_dir="$TMP_ROOT/active"
+  transcript="$case_dir/transcript.jsonl"
+  fakebin="$case_dir/fakebin"
+  mkdir -p "$case_dir"
+  make_fake_herdr "$fakebin"
+  cat > "$transcript" <<'EOF'
+{"type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"total_tokens":987654},"last_token_usage":{"total_tokens":216653},"model_context_window":258400}}}
+EOF
+  : > "$TMP_ROOT/herdr.log"
+
+  out=$(run_meter pane-active "$transcript" "$fakebin") || status=$?
+  expect_code 0 "$status" "normal context meter hook"
+  [ -z "$out" ] || fail "normal context meter hook printed output: $out"
+  assert_grep 'report-metadata pane-active --source firstmate:codex-context --agent codex --token context=████████░░ 216.7k / 258.4k · 84%' \
+    "$TMP_ROOT/herdr.log" "meter did not report the active-context numerator and 84% bar"
+  assert_no_grep '987' "$TMP_ROOT/herdr.log" "meter used cumulative total_token_usage"
+  token_bytes=$(sed 's/^.*--token context=//' "$TMP_ROOT/herdr.log" | wc -c | tr -d ' ')
+  [ "$token_bytes" -lt 80 ] || fail "reported context token exceeded Herdr's 80-byte ceiling"
+
+  cat >> "$transcript" <<'EOF'
+{"type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"total_tokens":1200000},"last_token_usage":{"total_tokens":42000},"model_context_window":258400}}}
+EOF
+  : > "$TMP_ROOT/herdr.log"
+  out=$(run_meter pane-active "$transcript" "$fakebin" PostCompact) || status=$?
+  expect_code 0 "$status" "post-compaction context meter hook"
+  [ -z "$out" ] || fail "post-compaction context meter hook printed output: $out"
+  assert_grep 'context=██░░░░░░░░ 42.0k / 258.4k · 16%' "$TMP_ROOT/herdr.log" \
+    "post-compaction hook did not immediately report the lower active count"
+  pass "Codex context meter uses active usage and follows compaction immediately"
+}
+
+test_hook_failure_paths_are_silent() {
+  local case_dir transcript fakebin no_jq out status=0 missing
+  case_dir="$TMP_ROOT/fail-open"
+  transcript="$case_dir/transcript.jsonl"
+  fakebin="$case_dir/fakebin"
+  missing="$case_dir/missing.jsonl"
+  mkdir -p "$case_dir"
+  make_fake_herdr "$fakebin"
+  printf '{malformed\n' > "$transcript"
+  : > "$TMP_ROOT/herdr.log"
+
+  expect_silent_zero "malformed transcript" run_meter pane-fail "$transcript" "$fakebin"
+  expect_silent_zero "missing transcript" run_meter pane-fail "$missing" "$fakebin"
+  expect_silent_zero "missing pane id" run_meter '' "$transcript" "$fakebin"
+  out=$(printf '{malformed' | HERDR_PANE_ID=pane-fail PATH="$fakebin:$PATH" "$METER" 2>&1) \
+    || status=$?
+  expect_code 0 "$status" "malformed hook payload"
+  [ -z "$out" ] || fail "malformed hook payload printed output: $out"
+
+  no_jq=$(fm_fakebin "$case_dir/no-jq")
+  ln -s "$(command -v bash)" "$no_jq/bash"
+  out=$(printf '{"hook_event_name":"PostToolUse","transcript_path":"%s"}\n' "$transcript" \
+    | HERDR_PANE_ID=pane-fail PATH="$no_jq" "$METER" 2>&1) || status=$?
+  expect_code 0 "$status" "missing jq hook"
+  [ -z "$out" ] || fail "missing jq hook printed output: $out"
+
+  printf '%s\n' '{"type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"total_tokens":10},"model_context_window":100}}}' > "$transcript"
+  out=$(FM_FAKE_HERDR_EXIT=9 run_meter pane-fail "$transcript" "$fakebin") || status=$?
+  expect_code 0 "$status" "failed Herdr report"
+  [ -z "$out" ] || fail "failed Herdr report printed output: $out"
+  pass "Codex context meter is silent and fail-open for absent, malformed, and reporting failures"
+}
+
+write_install_fixtures() {
+  local home=$1 herdr_config=$2
+  mkdir -p "$home/.codex" "$(dirname "$herdr_config")"
+  cat > "$home/.codex/hooks.json" <<'EOF'
+{
+  "description": "captain hooks",
+  "hooks": {
+    "Stop": [{"matcher": "foreign", "hooks": [{"type": "command", "command": "printf foreign", "timeout": 17}]}]
+  },
+  "captain": {"keep": true}
+}
+EOF
+  cat > "$home/.codex/config.toml" <<'EOF'
+# Captain Codex config.
+model = "gpt-test"
+
+[tui]
+status_line = ["model-with-reasoning", "git-branch"] # keep footer comment
+theme = "nord"
+
+[mcp_servers.example]
+command = "example"
+EOF
+  cat > "$herdr_config" <<'EOF'
+# Captain Herdr config.
+[theme]
+name = "nord"
+
+[ui.sidebar.agents]
+row_gap = 1
+rows = [["state_icon", "workspace"], ["agent"]]
+
+[ui.sidebar.agents.rows_by_agent]
+claude = [["state_icon", "workspace"], ["terminal_title_stripped"]]
+EOF
+}
+
+test_installer_preserves_merges_and_uninstalls() {
+  local case_dir home codex_home herdr_config original_hooks original_codex original_herdr
+  local once_hooks once_codex once_herdr once_state
+  case_dir="$TMP_ROOT/install"
+  home="$case_dir/home"
+  codex_home="$home/.codex"
+  herdr_config="$case_dir/herdr/config.toml"
+  write_install_fixtures "$home" "$herdr_config"
+  original_hooks="$case_dir/hooks.original"
+  original_codex="$case_dir/codex.original"
+  original_herdr="$case_dir/herdr.original"
+  cp "$codex_home/hooks.json" "$original_hooks"
+  cp "$codex_home/config.toml" "$original_codex"
+  cp "$herdr_config" "$original_herdr"
+
+  HOME="$home" CODEX_HOME="$codex_home" HERDR_CONFIG_PATH="$herdr_config" \
+    "$INSTALLER" install >/dev/null || fail "context meter install failed"
+
+  python3 - "$codex_home/hooks.json" "$codex_home/config.toml" "$herdr_config" <<'PY' \
+    || fail "installed Codex or Herdr config did not retain the required semantics"
+import json
+import sys
+import tomllib
+
+with open(sys.argv[1], encoding="utf-8") as stream:
+    hooks = json.load(stream)
+with open(sys.argv[2], "rb") as stream:
+    codex = tomllib.load(stream)
+with open(sys.argv[3], "rb") as stream:
+    herdr = tomllib.load(stream)
+
+assert hooks["description"] == "captain hooks"
+assert hooks["captain"] == {"keep": True}
+assert hooks["hooks"]["Stop"][0]["matcher"] == "foreign"
+for event in ("SessionStart", "PostToolUse", "PostCompact", "Stop"):
+    owned = [
+        hook
+        for group in hooks["hooks"][event]
+        for hook in group["hooks"]
+        if "fm-codex-context-meter.sh" in hook.get("command", "")
+    ]
+    assert len(owned) == 1
+    assert owned[0]["timeout"] == 2
+
+assert codex["model"] == "gpt-test"
+assert codex["tui"]["theme"] == "nord"
+assert codex["mcp_servers"]["example"]["command"] == "example"
+for item in ("context-used", "context-window-size", "used-tokens"):
+    assert item in codex["tui"]["status_line"]
+
+assert herdr["theme"]["name"] == "nord"
+assert herdr["ui"]["sidebar"]["agents"]["row_gap"] == 1
+assert herdr["ui"]["sidebar"]["agents"]["rows_by_agent"]["claude"][1] == ["terminal_title_stripped"]
+assert herdr["ui"]["sidebar"]["agents"]["rows_by_agent"]["codex"] == [
+    ["state_icon", "workspace"], ["agent"], ["$context"]
+]
+PY
+  HERDR_CONFIG_PATH="$herdr_config" herdr config check >/dev/null \
+    || fail "real Herdr config validation rejected the installed \$context row"
+
+  once_hooks="$case_dir/hooks.once"
+  once_codex="$case_dir/codex.once"
+  once_herdr="$case_dir/herdr.once"
+  once_state="$case_dir/state.once"
+  cp "$codex_home/hooks.json" "$once_hooks"
+  cp "$codex_home/config.toml" "$once_codex"
+  cp "$herdr_config" "$once_herdr"
+  cp "$codex_home/.firstmate-codex-context-meter.json" "$once_state"
+  HOME="$home" CODEX_HOME="$codex_home" HERDR_CONFIG_PATH="$herdr_config" \
+    "$INSTALLER" install >/dev/null || fail "second context meter install failed"
+  cmp -s "$once_hooks" "$codex_home/hooks.json" || fail "second install changed hooks.json bytes"
+  cmp -s "$once_codex" "$codex_home/config.toml" || fail "second install changed Codex config bytes"
+  cmp -s "$once_herdr" "$herdr_config" || fail "second install changed Herdr config bytes"
+  cmp -s "$once_state" "$codex_home/.firstmate-codex-context-meter.json" \
+    || fail "second install changed ownership receipt bytes"
+
+  HOME="$home" CODEX_HOME="$codex_home" HERDR_CONFIG_PATH="$herdr_config" \
+    "$INSTALLER" uninstall >/dev/null || fail "context meter uninstall failed"
+  cmp -s "$original_hooks" "$codex_home/hooks.json" || fail "uninstall did not restore hooks bytes"
+  cmp -s "$original_codex" "$codex_home/config.toml" || fail "uninstall did not restore Codex config bytes"
+  cmp -s "$original_herdr" "$herdr_config" || fail "uninstall did not restore Herdr config bytes"
+  assert_absent "$codex_home/.firstmate-codex-context-meter.json" \
+    "uninstall left its ownership receipt"
+  pass "context meter installer preserves config, is byte-idempotent, and uninstalls exactly"
+}
+
+test_uninstall_after_drift_removes_only_owned_values() {
+  local case_dir home codex_home herdr_config
+  case_dir="$TMP_ROOT/drift"
+  home="$case_dir/home"
+  codex_home="$home/.codex"
+  herdr_config="$case_dir/herdr/config.toml"
+  write_install_fixtures "$home" "$herdr_config"
+  HOME="$home" CODEX_HOME="$codex_home" HERDR_CONFIG_PATH="$herdr_config" \
+    "$INSTALLER" install >/dev/null || fail "drift fixture install failed"
+
+  python3 - "$codex_home/hooks.json" "$codex_home/config.toml" "$herdr_config" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as stream:
+    hooks = json.load(stream)
+hooks["hooks"]["Stop"].append({"hooks": [{"type": "command", "command": "printf later"}]})
+with open(sys.argv[1], "w", encoding="utf-8") as stream:
+    json.dump(hooks, stream, indent=2)
+    stream.write("\n")
+
+for path, marker, addition in (
+    (sys.argv[2], '"used-tokens"]', ', "session-id"]'),
+    (sys.argv[3], '["$context"]]', ', ["terminal_title"]]'),
+):
+    with open(path, encoding="utf-8") as stream:
+        text = stream.read()
+    assert marker in text
+    with open(path, "w", encoding="utf-8") as stream:
+        stream.write(text.replace(marker, marker[:-1] + addition, 1))
+PY
+
+  HOME="$home" CODEX_HOME="$codex_home" HERDR_CONFIG_PATH="$herdr_config" \
+    "$INSTALLER" uninstall >/dev/null || fail "drifted uninstall failed"
+  python3 - "$codex_home/hooks.json" "$codex_home/config.toml" "$herdr_config" <<'PY' \
+    || fail "drifted uninstall removed captain-owned values"
+import json
+import sys
+import tomllib
+
+with open(sys.argv[1], encoding="utf-8") as stream:
+    hooks = json.load(stream)
+with open(sys.argv[2], "rb") as stream:
+    codex = tomllib.load(stream)
+with open(sys.argv[3], "rb") as stream:
+    herdr = tomllib.load(stream)
+
+commands = [entry["command"] for group in hooks["hooks"]["Stop"] for entry in group["hooks"]]
+assert "printf foreign" in commands
+assert "printf later" in commands
+assert not any("fm-codex-context-meter.sh" in command for command in commands)
+assert "session-id" in codex["tui"]["status_line"]
+assert "context-used" not in codex["tui"]["status_line"]
+assert ["terminal_title"] in herdr["ui"]["sidebar"]["agents"]["rows_by_agent"]["codex"]
+assert ["$context"] not in herdr["ui"]["sidebar"]["agents"]["rows_by_agent"]["codex"]
+PY
+  pass "drifted uninstall removes only Firstmate-owned hooks, footer fields, and \$context row"
+}
+
+test_active_context_and_post_compaction
+test_hook_failure_paths_are_silent
+test_installer_preserves_merges_and_uninstalls
+test_uninstall_after_drift_removes_only_owned_values


### PR DESCRIPTION
## Intent

Deliver an opt-in exact Codex active-context meter for both the primary Firstmate Codex pane and Codex worker panes in Herdr. Render a compact filling bar with used tokens, total model context window, and percentage in Herdr through the custom pane metadata token context, made visible by a $context row in Codex-specific Herdr sidebar rows. Read only event_msg token_count records, using payload.info.last_token_usage.total_tokens as active usage and payload.info.model_context_window as the denominator, never cumulative total_token_usage. Update only at global Codex lifecycle hooks SessionStart, PostToolUse, PostCompact, and Stop, with no daemon, launch agent, detached background process, nohup, or periodic polling. The hook must be silent, bounded, fail open, and never block Codex when jq, Herdr, pane identity, transcript data, valid JSON, or the Herdr socket is unavailable. Preserve unrelated entries and semantics in global Codex hooks.json, Codex config.toml, and Herdr config.toml; configure Codex built-in exact footer fields only safely; make installation idempotent and uninstall ownership-safe and reversible. Do not install Herdr official Codex integration. Do not modify fm-spawn.sh or fm-teardown.sh. Validate only in isolated temporary homes and never install into the captain’s live Codex or Herdr config. Deliver through review, tests, documentation, lint, push, PR, and green CI, but never merge the PR.

## What Changed

- Added `bin/fm-codex-context-meter.sh`, a silent, fail-open Codex lifecycle hook (SessionStart, PostToolUse, PostCompact, Stop) that reads `event_msg` `token_count` records and renders a compact filling bar (used tokens / model context window / percentage) into Herdr via custom pane metadata, using `last_token_usage.total_tokens` over `model_context_window` and never cumulative `total_token_usage`.
- Added `bin/fm-codex-context-meter-install.sh`, an idempotent installer / ownership-safe reversible uninstaller that wires the hook into global Codex `hooks.json` and `config.toml` and adds a Codex-specific `$context` sidebar row in Herdr `config.toml`, preserving unrelated entries and refusing to write on ambiguous config rather than corrupting it.
- Added test coverage (`tests/fm-codex-context-meter.test.sh`) plus feature, verification, and scripts documentation and a documentation-audiences entry.

## Risk Assessment

✅ Low: The change is an opt-in, additive, fail-open feature that is byte-idempotent and reversible, extensively tested, and does not touch forbidden files (fm-spawn.sh/fm-teardown.sh) or install Herdr's official integration; the sole edge found fails safe with a clear refusal.

## Testing

Ran the targeted suite `tests/fm-codex-context-meter.test.sh` (4/4 pass) plus manual end-to-end verification: drove the hook across all four Codex lifecycle events and captured the exact filling-bar strings Herdr renders, confirmed active (not cumulative) usage and immediate post-compaction drop, exercised every fail-open branch (silent, exit 0), and installed/uninstalled into isolated temp homes with the real `herdr config check` accepting the injected `$context` row and uninstall restoring original bytes. For this TUI sidebar surface the true product artifact is the terminal-rendered unicode bar, which I captured verbatim; I also built and browser-rendered a faithful HTML mock of the sidebar. A raster screenshot could not be saved because `chrome-devtools-axi screenshot` silently writes no file in this headless session (accessibility tree/eval confirm the page renders), so the rendered HTML file plus the exact bar strings stand in as the visual evidence. Overall result: pass, no issues found.

<details>
<summary>Evidence: Codex context meter — lifecycle CLI transcript (exact bars reported to Herdr)</summary>

<code>SessionStart: █░░░░░░░░░ 31.8k / 258.4k · 12%&#10;PostToolUse: ████████░░ 216.7k / 258.4k · 84%&#10;PostCompact: ██░░░░░░░░ 42.0k / 258.4k · 16% (cumulative 1.2M ignored)&#10;Stop: ██████████ 247.7k / 258.4k · 96%&#10;&#10;Each reported via: herdr pane report-metadata fm-codex-primary --source firstmate:codex-context --agent codex --token context=&lt;bar&gt;</code>

```text
=== Codex active-context meter: end-to-end lifecycle demonstration ===
Pane: fm-codex-primary   (HERDR_PANE_ID set by Herdr for the Codex pane)

--- SessionStart: early session, light context ---
Herdr sidebar $context row renders:
   █░░░░░░░░░ 31.8k / 258.4k · 12%

--- PostToolUse: context grows as the agent works ---
   ████████░░ 216.7k / 258.4k · 84%

--- PostCompact: compaction drops ACTIVE usage immediately ---
    (cumulative total_token_usage is now 1.2M and MUST be ignored)
   ██░░░░░░░░ 42.0k / 258.4k · 16%

--- Stop: final snapshot at turn end ---
   ██████████ 247.7k / 258.4k · 96%

=== Exact commands issued to Herdr (pane report-metadata) ===
pane report-metadata fm-codex-primary --source firstmate:codex-context --agent codex --token context=█░░░░░░░░░ 31.8k / 258.4k · 12%
pane report-metadata fm-codex-primary --source firstmate:codex-context --agent codex --token context=████████░░ 216.7k / 258.4k · 84%
pane report-metadata fm-codex-primary --source firstmate:codex-context --agent codex --token context=██░░░░░░░░ 42.0k / 258.4k · 16%
pane report-metadata fm-codex-primary --source firstmate:codex-context --agent codex --token context=██████████ 247.7k / 258.4k · 96%
```
</details>
<details>
<summary>Evidence: Installer + real herdr validation + fail-open + reversible uninstall</summary>

<code>Install adds codex row: codex = [[&#34;state_icon&#34;,&#34;workspace&#34;],[&#34;agent&#34;],[&#34;$context&#34;]]&#10;Codex footer: status_line = [...,&#34;context-used&#34;,&#34;context-window-size&#34;,&#34;used-tokens&#34;]&#10;herdr config check =&gt; config: ok (PASSED)&#10;Fail-open: no pane id / missing transcript / malformed payload =&gt; exit 0, silent&#10;Uninstall restores original bytes; captain &#39;printf keepme&#39; hook preserved; 0 fm-codex-context-meter entries remain</code>

```text
=== Idempotent install into ISOLATED temp home (never the captain's live config) ===
CODEX_HOME=/var/folders/bw/lst38yvd4yxg8629cvc32dk80000gn/T//codex-meter-install.9gtjzO/home/.codex

Codex context meter installed; restart Codex and reload or restart Herdr.

--- Herdr config.toml AFTER install: Codex gets its own $context sidebar row ---
[ui.sidebar.agents.rows_by_agent]
codex = [["state_icon", "workspace"], ["agent"], ["$context"]]
claude = [["state_icon", "workspace"], ["terminal_title_stripped"]]

--- Codex config.toml footer fields added (exact built-in fields) ---
status_line = ["model-with-reasoning", "git-branch", "context-used", "context-window-size", "used-tokens"]

=== REAL herdr binary validates the installed config ===
config: ok
herdr config check: PASSED

=== Fail-open safety: hook stays silent + exits 0 when things are missing ===
no HERDR_PANE_ID:
  -> exit=0
missing transcript file:
  -> exit=0 output=[none expected]
malformed payload:
  -> exit=0

=== Uninstall restores the captain's original config exactly ===
Codex context meter uninstalled; restart Codex and reload or restart Herdr.
hooks.json Stop after uninstall:
printf keepme
  captain hook preserved
  fm-codex-context-meter hook entries remaining: 0
status_line = ["model-with-reasoning", "git-branch"]
[ui.sidebar.agents.rows_by_agent]
claude = [["state_icon", "workspace"], ["terminal_title_stripped"]]
```
</details>
<details>
<summary>Evidence: Herdr sidebar $context row — rendered HTML (open in a browser)</summary>

```text
<!DOCTYPE html><html><head><meta charset="utf-8"><style>
  :root{--bg:#1b1e24;--panel:#22262e;--fg:#d7dae0;--dim:#8a919e;--accent:#7fd1b9;--cyan:#5ec8d8}
  *{box-sizing:border-box}
  body{margin:0;background:#12141a;color:var(--fg);
    font-family:"SF Mono",Menlo,"DejaVu Sans Mono",monospace;padding:28px}
  h1{font-size:15px;font-weight:600;color:var(--dim);margin:0 0 4px}
  .cap{font-size:12px;color:var(--dim);margin:0 0 20px}
  .sidebar{width:340px;background:var(--panel);border:1px solid #2e333d;border-radius:8px;
    padding:12px 0;box-shadow:0 6px 24px rgba(0,0,0,.4)}
  .hdr{font-size:11px;letter-spacing:.08em;text-transform:uppercase;color:var(--dim);
    padding:2px 16px 10px;border-bottom:1px solid #2a2f38;margin-bottom:6px}
  .agent{padding:8px 16px}
  .agent+.agent{border-top:1px solid #262b34}
  .row{display:flex;gap:8px;align-items:center;font-size:13px;line-height:1.7;white-space:nowrap}
  .icon{color:var(--accent)}
  .ws{color:var(--fg)}
  .name{color:var(--cyan);font-size:12px}
  .name.claude{color:#c9a7f0}
  .ctx-label{color:var(--dim);font-size:12px;width:64px}
  .bar{color:var(--accent);letter-spacing:.5px}
  .bar .empty{color:#3a4048}
  .nums{color:var(--dim);font-size:12px}
  .pct{color:var(--fg)}
  .tag{display:inline-block;margin-left:8px;font-size:10px;color:#12141a;background:var(--accent);
    border-radius:3px;padding:0 5px;vertical-align:1px}
</style></head><body>
  <h1>Herdr sidebar — Codex context meter ($context row)</h1>
  <p class="cap">Rendered from the exact strings the hook reported via <code>herdr pane report-metadata … --token context=…</code></p>
  <div class="sidebar">
    <div class="hdr">Agents</div>

    <div class="agent">
      <div class="row"><span class="icon">◆</span><span class="ws">web/checkout</span>
        <span class="name">codex</span><span class="tag">primary</span></div>
      <div class="row"><span class="ctx-label">$context</span>
        <span class="bar">████████<span class="empty">░░</span></span>
        <span class="nums">216.7k / 258.4k · <span class="pct">84%</span></span></div>
    </div>

    <div class="agent">
      <div class="row"><span class="icon">◆</span><span class="ws">api/tokens</span>
        <span class="name">codex</span><span class="tag">worker</span></div>
      <div class="row"><span class="ctx-label">$context</span>
        <span class="bar">██<span class="empty">░░░░░░░░</span></span>
        <span class="nums">42.0k / 258.4k · <span class="pct">16%</span></span>
        <span style="color:var(--dim);font-size:11px">&nbsp;(post-compact)</span></div>
    </div>

    <div class="agent">
      <div class="row"><span class="icon">◆</span><span class="ws">infra/deploy</span>
        <span class="name">codex</span><span class="tag">worker</span></div>
      <div class="row"><span class="ctx-label">$context</span>
        <span class="bar">██████████</span>
        <span class="nums">247.7k / 258.4k · <span class="pct">96%</span></span></div>
    </div>

    <div class="agent">
      <div class="row"><span class="icon">◆</span><span class="ws">web/legacy</span>
        <span class="name claude">claude</span></div>
      <div class="row"><span style="color:var(--dim);font-size:12px">no $context row (non-Codex agent)</span></div>
    </div>
  </div>
</body></html>
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ℹ️ `bin/fm-codex-context-meter-install.sh:443` - Installer&#39;s regex-based TOML editor only locates `rows_by_agent.codex` as either a `[ui.sidebar.agents.rows_by_agent]` table header + `codex =` key, or a fully-dotted `ui.sidebar.agents.rows_by_agent.codex = ` assignment at root. A valid Herdr config that writes the key with partial-dotted notation inside a shallower header (e.g. `[ui.sidebar.agents]` then `rows_by_agent.codex = [...]`) is parsed by tomllib (so `nested()` finds existing codex rows) but `find_assignment` returns None, so `set_array` emits a second `[ui.sidebar.agents.rows_by_agent]` table. The duplicate key is caught by the post-write `parse_toml` and the whole install refuses. This fails safe (clear refusal, no file corruption) but blocks install for that valid config layout. The same well-covered logic exists for `tui.status_line`, which has no shallower-header form, so only the deeply-nested Herdr rows key is affected.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash tests/fm-codex-context-meter.test.sh` — all 4 behavior tests pass (active-usage bar, immediate post-compaction follow, config-preserving idempotent install/exact uninstall, drift-safe ownership uninstall)</code>
- <code>Manual lifecycle run of `bin/fm-codex-context-meter.sh` across SessionStart/PostToolUse/PostCompact/Stop with a fake herdr recorder, capturing the exact rendered bar strings</code>
- `Verified cumulative total_token_usage (987654 / 1204812) is never used — numerator comes only from last_token_usage.total_tokens`
- <code>Ran `bin/fm-codex-context-meter-install.sh install`/`uninstall` into an isolated temp HOME/CODEX_HOME/HERDR_CONFIG_PATH and validated the result with the real `herdr config check` (config: ok)</code>
- `Exercised fail-open branches: missing HERDR_PANE_ID, missing transcript, malformed payload, missing jq — all silent, exit 0`
- <code>Rendered `herdr-sidebar-context-meter.html` in Chrome and confirmed via accessibility/eval the sidebar shows the exact meter glyphs for Codex panes and no $context row for a claude agent</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
