### PR TITLE
feat: keep opted-in Lavish reviews listening for feedback

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -470,6 +470,7 @@ Every ship brief must retain the worktree-isolation assertion and stop if launch
 If a ship task touches firstmate's shared tracked material, explicitly require `firstmate-coding-guidelines` before editing.
 If a task will drive Herdr lifecycle behavior, scaffold with `--herdr-lab`; if that need appears after an unguarded scaffold, stop and regenerate rather than adding commands by hand.
 The generated Herdr contract must use a named non-`default` isolated lab and its guarded helper for every lifecycle action.
+If a task will create, refresh, or operate a captain-facing Lavish review, scaffold with `--lavish-review`; the generated contract owns its listener and recovery mechanics, and ordinary briefs stay unchanged.
 
 Load `secondmate-provisioning` before creating or using a charter brief and preserve its idle-by-default and marked-return-channel contracts.
 Status appends are sparse supervisor-actionable events, not routine progress; `bin/fm-classify-lib.sh` owns keyed open and resolved semantics.

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -259,6 +259,9 @@ EOF
 HERDR_SECTION=${HERDR_SECTION%$'\n'}
 fi
 
+# These assignments intentionally use single-quoted literal brief text; embedded
+# dollar expressions and command examples must remain literal in generated briefs.
+# shellcheck disable=SC2016
 if [ "$LAVISH_REVIEW" -eq 1 ]; then
   LAVISH_COMPLETION_GATE=""
   if [ "$KIND" = ship ]; then
@@ -293,6 +296,7 @@ LAVISH_COMPLETION_GATE=""
 LAVISH_REVIEW_SECTION=""
 fi
 
+# shellcheck disable=SC2016
 if [ "$LAVISH_REVIEW" -eq 1 ]; then
   LAVISH_DECISION_RULE='6. If a decision belongs above the implementation worker (product choices, destructive actions, ask-user findings), append `needs-decision: {summary of options}` and do not stop.
    Keep the active `lavish-axi poll "$LAVISH_ARTIFACT"` running while waiting for firstmate'\''s reply; if the decision came from a poll prompt or layout warning, first complete the reply-and-repoll rule above.
@@ -305,6 +309,7 @@ else
    append `needs-decision: {summary of options}` and stop. Firstmate will apply the configured authority and reply with the decision.'
 fi
 
+# shellcheck disable=SC2016
 if [ "$KIND" = scout ]; then
 if [ "$LAVISH_REVIEW" -eq 1 ]; then
   SCOUT_DOD_LINE='When the report is complete and captain feedback is complete and the final Lavish response has re-established the poll listener, append `done: {one-line conclusion}` to the status file and stop.'
@@ -364,6 +369,7 @@ read -r MODE _ <<EOF
 $("$FM_ROOT/bin/fm-project-mode.sh" "$REPO")
 EOF
 
+# shellcheck disable=SC2016
 case "$MODE" in
   direct-PR)
     SETUP2=""

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -29,6 +29,8 @@
 #   --lavish-review adds the opt-in lifecycle contract for a captain-facing
 #   Lavish review. Use it only when the task will create, refresh, or operate
 #   such a review; ordinary briefs stay unchanged.
+#   The flag applies only to crewmate ship or scout briefs; secondmate charters
+#   reject it.
 # For ship tasks, the definition of done is shaped by the project's delivery mode
 # (data/projects.md via fm-project-mode.sh; see the project-management skill
 # and AGENTS.md task lifecycle):

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -6,7 +6,7 @@
 # description, acceptance criteria, and context, and may adjust other sections
 # when the task genuinely deviates (e.g. working an existing external PR instead
 # of shipping a new one).
-# Usage: fm-brief.sh <task-id> <repo-name> [--scout] [--herdr-lab]
+# Usage: fm-brief.sh <task-id> <repo-name> [--scout] [--herdr-lab] [--lavish-review]
 #        fm-brief.sh <task-id> --secondmate {<project>...|--no-projects}
 #   --scout writes the scout contract instead: the deliverable is a report at
 #   data/<task-id>/report.md (no branch, no push, no PR) and the worktree is scratch.
@@ -26,6 +26,9 @@
 #   The flag must be explicit because {TASK} is filled after scaffolding and the
 #   caller-supplied repo string cannot reliably identify this repo. Briefs made
 #   without it carry a loud declaration so an omitted contract cannot be silent.
+#   --lavish-review adds the opt-in lifecycle contract for a captain-facing
+#   Lavish review. Use it only when the task will create, refresh, or operate
+#   such a review; ordinary briefs stay unchanged.
 # For ship tasks, the definition of done is shaped by the project's delivery mode
 # (data/projects.md via fm-project-mode.sh; see the project-management skill
 # and AGENTS.md task lifecycle):
@@ -93,6 +96,7 @@ else
 fi
 KIND=ship
 HERDR_LAB=0
+LAVISH_REVIEW=0
 NO_PROJECTS=0
 POS=()
 for a in "$@"; do
@@ -100,6 +104,7 @@ for a in "$@"; do
     --scout) KIND=scout ;;
     --secondmate) KIND=secondmate ;;
     --herdr-lab) HERDR_LAB=1 ;;
+    --lavish-review) LAVISH_REVIEW=1 ;;
     --no-projects) NO_PROJECTS=1 ;;
     *) POS+=("$a") ;;
   esac
@@ -108,6 +113,11 @@ ID=${POS[0]}
 
 if [ "$KIND" = secondmate ] && [ "$HERDR_LAB" -eq 1 ]; then
   echo "error: --herdr-lab applies only to crewmate ship or scout briefs" >&2
+  exit 1
+fi
+
+if [ "$KIND" = secondmate ] && [ "$LAVISH_REVIEW" -eq 1 ]; then
+  echo "error: --lavish-review applies only to crewmate ship or scout briefs" >&2
   exit 1
 fi
 
@@ -247,6 +257,34 @@ EOF
 HERDR_SECTION=${HERDR_SECTION%$'\n'}
 fi
 
+if [ "$LAVISH_REVIEW" -eq 1 ]; then
+IFS= read -r -d '' LAVISH_REVIEW_SECTION <<EOF || true
+# Lavish review lifecycle - OPT IN
+This task creates, refreshes, or operates a captain-facing Lavish review, so the review stays nonterminal while captain feedback is expected.
+Set \`LAVISH_ARTIFACT\` to the canonical HTML artifact path for the review and keep using that same path.
+After every \`lavish-axi <artifact>\` open or refresh, immediately run \`lavish-axi poll "\$LAVISH_ARTIFACT"\` with no timeout.
+Leave that poll running; if the harness cannot keep a foreground command alive, run the same normal poll in the background and wait for it.
+If the poll process exits because it was killed or timed out, re-run \`lavish-axi poll "\$LAVISH_ARTIFACT"\`; queued feedback is persistent and the listener must be re-established.
+When a poll returns prompts or layout warnings, handle every returned item.
+Fix layout warnings before involving the captain.
+After handling any prompt or layout warning returned by poll, finish by running \`lavish-axi poll "\$LAVISH_ARTIFACT" --agent-reply "<visible response>"\`.
+The visible response must state what changed, what was answered, or why nothing changed, and that command becomes the next active feedback wait.
+Do not append \`done:\` merely because the page, report, or PR is open.
+Use \`$PAUSED_VERB:\` for a Lavish review wait only while a \`lavish-axi poll\` listener is active or while you are restarting that listener.
+Use \`blocked:\` if the listener cannot be restarted after the same obstacle repeats twice.
+
+## Lavish recovery
+If interrupted, resume with the same \`LAVISH_ARTIFACT\` path and run \`lavish-axi poll "\$LAVISH_ARTIFACT"\` again.
+Do not reopen a healthy already-open review merely to restore the agent listener.
+If the Lavish server or browser was restored, run \`lavish-axi "\$LAVISH_ARTIFACT"\` only to open or resume that same artifact, then immediately return to \`lavish-axi poll "\$LAVISH_ARTIFACT"\`.
+Do not open a second artifact path, end unrelated sessions, run \`lavish-axi stop\`, or disturb unrelated Lavish reviews.
+EOF
+LAVISH_REVIEW_SECTION=${LAVISH_REVIEW_SECTION%$'\n'}
+LAVISH_REVIEW_SECTION=$'\n'"$LAVISH_REVIEW_SECTION"
+else
+LAVISH_REVIEW_SECTION=""
+fi
+
 if [ "$KIND" = scout ]; then
 cat > "$BRIEF" <<EOF
 You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.
@@ -254,7 +292,7 @@ You are a crewmate: an autonomous worker agent managed by firstmate. Work on you
 # Task
 {TASK}
 
-$HERDR_SECTION
+$HERDR_SECTION$LAVISH_REVIEW_SECTION
 
 # Setup
 You are in a disposable git worktree of $REPO, at a detached HEAD on a clean default branch.
@@ -362,7 +400,7 @@ You are a crewmate: an autonomous worker agent managed by firstmate. Work on you
 # Task
 {TASK}
 
-$HERDR_SECTION
+$HERDR_SECTION$LAVISH_REVIEW_SECTION
 
 # Setup
 You are in a disposable git worktree of $REPO, at a detached HEAD on a clean default branch.

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -258,6 +258,10 @@ HERDR_SECTION=${HERDR_SECTION%$'\n'}
 fi
 
 if [ "$LAVISH_REVIEW" -eq 1 ]; then
+  LAVISH_COMPLETION_GATE=""
+  if [ "$KIND" = ship ]; then
+    LAVISH_COMPLETION_GATE='Before reporting any terminal `done:` or ready state, read and follow `'"$FM_ROOT"'/.agents/skills/decision-hold-lifecycle/SKILL.md` and pass its shared completion gate for the ship and this Lavish review.'
+  fi
 IFS= read -r -d '' LAVISH_REVIEW_SECTION <<EOF || true
 # Lavish review lifecycle - OPT IN
 This task creates, refreshes, or operates a captain-facing Lavish review, so the review stays nonterminal while captain feedback is expected.
@@ -278,14 +282,33 @@ If interrupted, resume with the same \`LAVISH_ARTIFACT\` path and run \`lavish-a
 Do not reopen a healthy already-open review merely to restore the agent listener.
 If the Lavish server or browser was restored, run \`lavish-axi "\$LAVISH_ARTIFACT"\` only to open or resume that same artifact, then immediately return to \`lavish-axi poll "\$LAVISH_ARTIFACT"\`.
 Do not open a second artifact path, end unrelated sessions, run \`lavish-axi stop\`, or disturb unrelated Lavish reviews.
+$LAVISH_COMPLETION_GATE
 EOF
 LAVISH_REVIEW_SECTION=${LAVISH_REVIEW_SECTION%$'\n'}
 LAVISH_REVIEW_SECTION=$'\n'"$LAVISH_REVIEW_SECTION"
 else
+LAVISH_COMPLETION_GATE=""
 LAVISH_REVIEW_SECTION=""
 fi
 
+if [ "$LAVISH_REVIEW" -eq 1 ]; then
+  LAVISH_DECISION_RULE='6. If a decision belongs above the implementation worker (product choices, destructive actions, ask-user findings), append `needs-decision: {summary of options}` and do not stop.
+   Keep the active `lavish-axi poll "$LAVISH_ARTIFACT"` running while waiting for firstmate'\''s reply; if the decision came from a poll prompt or layout warning, first complete the reply-and-repoll rule above.
+   When firstmate replies, append `resolved: {how it was decided or unblocked}` (add the same `[key=<slug>]` if you opened it with one) and continue.'
+elif [ "$KIND" = scout ]; then
+  LAVISH_DECISION_RULE='6. If a decision belongs to a human (product choices, destructive actions),
+   append `needs-decision: {summary of options}` and stop. Firstmate will reply with the decision.'
+else
+  LAVISH_DECISION_RULE='6. If a decision belongs above the implementation worker (product choices, destructive actions, ask-user findings),
+   append `needs-decision: {summary of options}` and stop. Firstmate will apply the configured authority and reply with the decision.'
+fi
+
 if [ "$KIND" = scout ]; then
+if [ "$LAVISH_REVIEW" -eq 1 ]; then
+  SCOUT_DOD_LINE='When the report is complete and captain feedback is complete and the final Lavish response has re-established the poll listener, append `done: {one-line conclusion}` to the status file and stop.'
+else
+  SCOUT_DOD_LINE='When the report is complete, append `done: {one-line conclusion}` to the status file and stop.'
+fi
 cat > "$BRIEF" <<EOF
 You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.
 
@@ -315,8 +338,7 @@ The report is the only thing that survives, so anything worth keeping must be in
    firstmate then leaves your idle pane alone and rechecks it on a long cadence instead of
    treating it as a possible wedge. Use \`blocked:\` when you are stuck and need help.
 5. If you hit the same obstacle twice, append \`blocked: {why}\` and stop; firstmate will help.
-6. If a decision belongs to a human (product choices, destructive actions),
-   append \`needs-decision: {summary of options}\` and stop. Firstmate will reply with the decision.
+$LAVISH_DECISION_RULE
    When firstmate replies or a blocker clears and you resume, append \`resolved: {how it was decided or unblocked}\` (add the same \`[key=<slug>]\` if you opened it with one) so the decision or blocker is durably closed and does not keep resurfacing.
 7. Never stop, restart, or update the shared \`no-mistakes\` daemon - it is one instance serving
    every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
@@ -326,7 +348,7 @@ The report is the only thing that survives, so anything worth keeping must be in
 Write your findings to \`$DATA/$ID/report.md\`.
 The report must stand alone: what you did, what you found, the evidence (commands run, output, file:line references), and what you recommend.
 Before reporting done, read and follow \`$FM_ROOT/.agents/skills/decision-hold-lifecycle/SKILL.md\` and pass its shared completion gate for the report and any visual review.
-When the report is complete, append \`done: {one-line conclusion}\` to the status file and stop.
+$SCOUT_DOD_LINE
 If your findings reveal work that should ship (e.g. you reproduced a bug and the fix is clear), say so in the report; firstmate may promote this task in place, and you would then receive mode-specific ship instructions as a follow-up message.
 EOF
 echo "scaffolded: $BRIEF (scout; replace {TASK})"
@@ -343,24 +365,34 @@ EOF
 case "$MODE" in
   direct-PR)
     SETUP2=""
+    if [ "$LAVISH_REVIEW" -eq 1 ]; then
+      SHIP_DOD_LINE='When it is implemented and committed, push your branch and open a PR with `gh-axi`. Keep the Lavish poll listener active while captain feedback is expected. When captain feedback is complete and the final Lavish response has re-established the poll listener, append `done: PR {url}` to the status file and stop.'
+    else
+      SHIP_DOD_LINE='When it is implemented and committed, push your branch and open a PR with `gh-axi`, then append `done: PR {url}` to the status file and stop.'
+    fi
     RULE1='1. Never push to the default branch (push only your `fm/'"$ID"'` branch). Never merge a PR.'
     IFS= read -r -d '' DOD <<EOF || true
 # Definition of done
 This project ships **direct-PR**: you raise the PR yourself, without the no-mistakes pipeline.
 The task is complete only when committed on your branch.
-When it is implemented and committed, push your branch and open a PR with \`gh-axi\`, then append \`done: PR {url}\` to the status file and stop.
+$SHIP_DOD_LINE
 Do NOT run /no-mistakes. The configured merge authority decides whether to merge the PR; firstmate relays the outcome.
 EOF
     ;;
   local-only)
     SETUP2=""
+    if [ "$LAVISH_REVIEW" -eq 1 ]; then
+      SHIP_DOD_LINE='When it is implemented and committed, keep the Lavish poll listener active while captain feedback is expected. When captain feedback is complete and the final Lavish response has re-established the poll listener, append `done: ready in branch fm/'"$ID"'` to the status file and stop.'
+    else
+      SHIP_DOD_LINE='When it is implemented and committed, append `done: ready in branch fm/'"$ID"'` to the status file and stop.'
+    fi
     RULE1="1. Never push to any remote and never open a PR. Work only on your \`fm/$ID\` branch; firstmate handles the merge into local \`main\`."
     IFS= read -r -d '' DOD <<EOF || true
 # Definition of done
 This project ships **local-only**: no remote, no PR, no pipeline.
 The task is complete only when committed on your branch \`fm/$ID\`. Do NOT push, do NOT open a PR, do NOT merge.
 Keep your branch a clean fast-forward onto the current default branch - if \`main\` has advanced, rebase onto it so the eventual merge stays a fast-forward.
-When it is implemented and committed, append \`done: ready in branch fm/$ID\` to the status file and stop.
+$SHIP_DOD_LINE
 The configured merge authority approves the ready branch, then firstmate merges it into local \`main\` through the guarded fast-forward path.
 EOF
     ;;
@@ -368,10 +400,19 @@ EOF
     SETUP2="
 2. Run \`no-mistakes doctor\`; if it reports the repo is not initialized here, run \`no-mistakes init\`."
     RULE1='1. Never push to the default branch. Never merge a PR.'
+    if [ "$LAVISH_REVIEW" -eq 1 ]; then
+      SHIP_DOD_LINE='When you believe the implementation is complete, keep the Lavish poll listener active while captain feedback is expected. When captain feedback is complete and the final Lavish response has re-established the poll listener, append `done: {summary}` to the status file and stop.'
+      NO_MISTAKES_DECISION_LINE='- ask-user findings are never yours to answer: escalate to firstmate (rule 6), keep the Lavish poll listener active, and do not stop.'
+      NO_MISTAKES_CI_LINE='After /no-mistakes reports CI green, keep the Lavish poll listener active until captain feedback is complete and the final Lavish response has re-established the poll listener, then append `done: PR {url} checks green` and stop. You are finished.'
+    else
+      SHIP_DOD_LINE='When you believe it is complete, append `done: {summary}` to the status file and stop.'
+      NO_MISTAKES_DECISION_LINE='- ask-user findings are never yours to answer: escalate to firstmate (rule 6) and stop.'
+      NO_MISTAKES_CI_LINE='After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append `done: PR {url} checks green` and stop. You are finished.'
+    fi
     IFS= read -r -d '' DOD <<EOF || true
 # Definition of done
 The task is complete only when committed on your branch.
-When you believe it is complete, append \`done: {summary}\` to the status file and stop.
+$SHIP_DOD_LINE
 Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.
 
 You drive no-mistakes by responding to its gates, not by implementing fixes.
@@ -379,12 +420,12 @@ Follow the guidance no-mistakes itself provides for the mechanics: it loads when
 Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix.
 
 Two firstmate-specific rules layer on top of that guidance:
-- ask-user findings are never yours to answer: escalate to firstmate (rule 6) and stop.
+$NO_MISTAKES_DECISION_LINE
   Firstmate applies the authority contract in its \`AGENTS.md\` and obtains any required captain decision.
   When the decision comes back, feed it to the gate with \`no-mistakes axi respond\` and let the pipeline apply it - do not route the question to "the user" or implement the fix yourself.
 - Avoid \`--yes\`: it would silently bypass firstmate's authority check and any required captain escalation.
 
-After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append \`done: PR {url} checks green\` and stop. You are finished.
+$NO_MISTAKES_CI_LINE
 EOF
     ;;
 esac
@@ -429,8 +470,7 @@ $RULE1
    a scheduled window): firstmate then leaves your idle pane alone and rechecks it on a long
    cadence instead of treating it as a possible wedge. Use \`blocked:\` when you are stuck and need help.
 5. If you hit the same obstacle twice, append \`blocked: {why}\` and stop; firstmate will help.
-6. If a decision belongs above the implementation worker (product choices, destructive actions, ask-user findings),
-   append \`needs-decision: {summary of options}\` and stop. Firstmate will apply the configured authority and reply with the decision.
+$LAVISH_DECISION_RULE
    When firstmate replies or a blocker clears and you resume, append \`resolved: {how it was decided or unblocked}\` (add the same \`[key=<slug>]\` if you opened it with one) so the decision or blocker is durably closed and does not keep resurfacing.
 7. Never stop, restart, or update the shared \`no-mistakes\` daemon - it is one instance serving
    every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -18,7 +18,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-update.sh`           | Fast-forward-only self-update of firstmate and secondmate homes from origin          |
 | `fm-backlog-handoff.sh`  | Validate and delegate queued backlog-item moves into a secondmate home               |
 | `fm-decision-hold.sh`    | Create, verify, complete, and resolve durable captain-held decisions                 |
-| `fm-brief.sh`            | Scaffold ship, scout, secondmate-charter, and Herdr-lab briefs                       |
+| `fm-brief.sh`            | Scaffold ship, scout, secondmate-charter, Herdr-lab, and opt-in Lavish-review briefs |
 | `fm-herdr-lab.sh`        | Provision and guardedly operate an isolated, never-default Herdr lab session         |
 | `fm-install-herdr.sh`    | Install CI's exact-version Herdr pin with official asset URL, SHA-256, and protocol checks |
 | `fm-install-treehouse.sh`| Install CI's exact-version Treehouse pin for real-Herdr E2E that needs spawn worktrees |

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -543,6 +543,57 @@ test_herdr_lab_contract_applies_to_scouts_but_not_secondmates() {
   pass "fm-brief.sh: Herdr lab contract covers scouts and rejects secondmate misuse"
 }
 
+test_lavish_review_lifecycle_is_explicit_opt_in() {
+  local home ship scout plain_ship plain_scout rejected_status=0
+  home="$TMP_ROOT/lavish-review-home"
+  mkdir -p "$home/data"
+
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" lavish-ship firstmate --lavish-review >/dev/null 2>&1
+  ship="$home/data/lavish-ship/brief.md"
+  assert_grep "# Lavish review lifecycle - OPT IN" "$ship" \
+    "ship --lavish-review brief missing its explicit lifecycle heading"
+  assert_grep "Set \`LAVISH_ARTIFACT\` to the canonical HTML artifact path for the review and keep using that same path." "$ship" \
+    "Lavish review brief missing canonical artifact path ownership"
+  assert_grep "After every \`lavish-axi <artifact>\` open or refresh, immediately run \`lavish-axi poll \"\$LAVISH_ARTIFACT\"\` with no timeout." "$ship" \
+    "Lavish review brief missing the initial unbounded poll contract"
+  assert_grep "After handling any prompt or layout warning returned by poll, finish by running \`lavish-axi poll \"\$LAVISH_ARTIFACT\" --agent-reply \"<visible response>\"\`." "$ship" \
+    "Lavish review brief missing the reply-and-repoll contract"
+  assert_grep "Do not append \`done:\` merely because the page, report, or PR is open." "$ship" \
+    "Lavish review brief missing nonterminal open-review protection"
+  assert_grep "Use \`paused:\` for a Lavish review wait only while a \`lavish-axi poll\` listener is active or while you are restarting that listener." "$ship" \
+    "Lavish review brief missing status vocabulary boundary"
+  assert_grep "If interrupted, resume with the same \`LAVISH_ARTIFACT\` path and run \`lavish-axi poll \"\$LAVISH_ARTIFACT\"\` again." "$ship" \
+    "Lavish review brief missing interrupted-worker recovery"
+  assert_grep "If the Lavish server or browser was restored, run \`lavish-axi \"\$LAVISH_ARTIFACT\"\` only to open or resume that same artifact, then immediately return to \`lavish-axi poll \"\$LAVISH_ARTIFACT\"\`." "$ship" \
+    "Lavish review brief missing restored-server recovery"
+  assert_grep "Do not open a second artifact path, end unrelated sessions, run \`lavish-axi stop\`, or disturb unrelated Lavish reviews." "$ship" \
+    "Lavish review brief missing unrelated-session safety"
+
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" lavish-scout firstmate --scout --lavish-review >/dev/null 2>&1
+  scout="$home/data/lavish-scout/brief.md"
+  assert_grep "# Lavish review lifecycle - OPT IN" "$scout" \
+    "scout --lavish-review brief missing its lifecycle section"
+  assert_grep "Before reporting done, read and follow" "$scout" \
+    "Lavish scout brief lost the decision-hold completion gate"
+
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" ordinary-ship firstmate >/dev/null 2>&1
+  plain_ship="$home/data/ordinary-ship/brief.md"
+  assert_no_grep "# Lavish review lifecycle - OPT IN" "$plain_ship" \
+    "ordinary ship brief gained Lavish review lifecycle text without opt-in"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" ordinary-scout firstmate --scout >/dev/null 2>&1
+  plain_scout="$home/data/ordinary-scout/brief.md"
+  assert_no_grep "# Lavish review lifecycle - OPT IN" "$plain_scout" \
+    "ordinary scout brief gained Lavish review lifecycle text without opt-in"
+
+  FM_HOME="$home" FM_SECONDMATE_CHARTER=ops \
+    "$ROOT/bin/fm-brief.sh" lavish-secondmate --secondmate --no-projects --lavish-review >/dev/null 2>&1 || rejected_status=$?
+  expect_code 1 "$rejected_status" "secondmate --lavish-review must be rejected"
+  assert_absent "$home/data/lavish-secondmate/brief.md" \
+    "rejected secondmate --lavish-review still wrote a brief"
+
+  pass "fm-brief.sh: Lavish review lifecycle is explicit opt-in for ship and scout briefs"
+}
+
 test_pause_verb_override_renders_all_brief_scaffolds() {
   local home kind id brief
   home="$TMP_ROOT/pause-verb-home"
@@ -629,6 +680,7 @@ test_herdr_lab_contract_is_explicit_and_complete
 test_herdr_lab_contract_quotes_foreign_firstmate_path
 test_herdr_lab_omission_is_loud_for_ship_and_scout
 test_herdr_lab_contract_applies_to_scouts_but_not_secondmates
+test_lavish_review_lifecycle_is_explicit_opt_in
 test_secondmate_no_projects_charter
 test_secondmate_marked_request_reporting_contract
 test_secondmate_directory_paths_are_absolute_and_output_is_stable

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -544,9 +544,10 @@ test_herdr_lab_contract_applies_to_scouts_but_not_secondmates() {
 }
 
 test_lavish_review_lifecycle_is_explicit_opt_in() {
-  local home ship scout plain_ship plain_scout rejected_status=0
+  local home ship scout direct local_only plain_ship plain_scout rejected_status=0
   home="$TMP_ROOT/lavish-review-home"
   mkdir -p "$home/data"
+  write_registry "$home"
 
   FM_HOME="$home" "$ROOT/bin/fm-brief.sh" lavish-ship firstmate --lavish-review >/dev/null 2>&1
   ship="$home/data/lavish-ship/brief.md"
@@ -568,6 +569,28 @@ test_lavish_review_lifecycle_is_explicit_opt_in() {
     "Lavish review brief missing restored-server recovery"
   assert_grep "Do not open a second artifact path, end unrelated sessions, run \`lavish-axi stop\`, or disturb unrelated Lavish reviews." "$ship" \
     "Lavish review brief missing unrelated-session safety"
+  assert_grep "Before reporting any terminal \`done:\` or ready state, read and follow \`$ROOT/.agents/skills/decision-hold-lifecycle/SKILL.md\` and pass its shared completion gate for the ship and this Lavish review." "$ship" \
+    "Lavish ship brief missing the decision-hold completion gate"
+  assert_grep "append \`needs-decision: {summary of options}\` and do not stop." "$ship" \
+    "Lavish ship brief still makes a captain decision terminal"
+  assert_grep "Keep the active \`lavish-axi poll \"\$LAVISH_ARTIFACT\"\` running while waiting for firstmate's reply" "$ship" \
+    "Lavish ship brief does not keep its listener active while waiting on a decision"
+  assert_grep "After /no-mistakes reports CI green, keep the Lavish poll listener active until captain feedback is complete" "$ship" \
+    "Lavish no-mistakes brief still makes CI completion terminal"
+
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" lavish-direct direct-proj --lavish-review >/dev/null 2>&1
+  direct="$home/data/lavish-direct/brief.md"
+  assert_grep "When it is implemented and committed, push your branch and open a PR with \`gh-axi\`. Keep the Lavish poll listener active while captain feedback is expected." "$direct" \
+    "Lavish direct-PR brief lost the push/open-PR action or active listener"
+  assert_grep "When captain feedback is complete and the final Lavish response has re-established the poll listener, append \`done: PR {url}\` to the status file and stop." "$direct" \
+    "Lavish direct-PR brief still treats opening the PR as terminal"
+
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" lavish-local local-proj --lavish-review >/dev/null 2>&1
+  local_only="$home/data/lavish-local/brief.md"
+  assert_grep "When it is implemented and committed, keep the Lavish poll listener active while captain feedback is expected." "$local_only" \
+    "Lavish local-only brief lost its implementation completion condition"
+  assert_grep "When captain feedback is complete and the final Lavish response has re-established the poll listener, append \`done: ready in branch fm/lavish-local\` to the status file and stop." "$local_only" \
+    "Lavish local-only brief still treats implementation as terminal"
 
   FM_HOME="$home" "$ROOT/bin/fm-brief.sh" lavish-scout firstmate --scout --lavish-review >/dev/null 2>&1
   scout="$home/data/lavish-scout/brief.md"
@@ -580,6 +603,8 @@ test_lavish_review_lifecycle_is_explicit_opt_in() {
   plain_ship="$home/data/ordinary-ship/brief.md"
   assert_no_grep "# Lavish review lifecycle - OPT IN" "$plain_ship" \
     "ordinary ship brief gained Lavish review lifecycle text without opt-in"
+  assert_no_grep "captain feedback is complete" "$plain_ship" \
+    "ordinary ship brief gained Lavish terminal wording without opt-in"
   FM_HOME="$home" "$ROOT/bin/fm-brief.sh" ordinary-scout firstmate --scout >/dev/null 2>&1
   plain_scout="$home/data/ordinary-scout/brief.md"
   assert_no_grep "# Lavish review lifecycle - OPT IN" "$plain_scout" \


### PR DESCRIPTION
## Intent

Harden Firstmate review briefs so an explicitly opted-in captain-facing Lavish review keeps its responsible agent listening for feedback across open, refresh, prompt handling, layout-warning handling, worker interruption, and server or browser recovery. The authoritative brief-generation path must require an immediate normal unbounded lavish-axi poll after opening or refreshing the canonical artifact, and every handled prompt or layout warning must finish with lavish-axi poll using --agent-reply with a visible response so the next wait is active. Open reviews remain nonterminal while feedback is expected; bounded external-wait status vocabulary is used only while the listener is active or being restarted. Recovery must reuse persistent state and the canonical artifact without opening a second browser or disturbing unrelated sessions. Keep ordinary non-Lavish ship and scout briefs unchanged unless opted in, reject unsupported modes, use only documented public Lavish CLI behavior, preserve all safety, decision-hold, browser, and teardown boundaries, and add focused lifecycle and brief-generation tests without touching captain-facing Lavish sessions.

## What Changed

- Adds the opt-in `--lavish-review` brief contract with canonical artifact ownership, persistent polling, prompt/layout-warning replies, nonterminal open reviews, and same-artifact recovery.
- Updates ship and scout completion rules across delivery modes, preserves ordinary briefs unchanged, and rejects unsupported secondmate usage.
- Documents the new lifecycle and adds focused brief-generation coverage for lifecycle, recovery, decision-hold, and opt-in behavior.

## Risk Assessment

✅ Low: Captain, the follow-up diff addresses the prior lifecycle conflicts, preserves ordinary non-Lavish generation, and introduces no additional material risks in the reviewed scope.

## Testing

Focused tests, adjacent guards, isolated end-to-end brief generation, public CLI syntax verification, and base compatibility checks all passed. No live Lavish or captain-facing browser sessions were opened; the generated CLI transcript is the reviewer-visible evidence for this non-UI brief-contract change.

<details>
<summary>Evidence: Lavish brief end-to-end transcript</summary>

```text
$ fm-brief.sh lavish-e2e firstmate --lavish-review
scaffolded: /tmp/no-mistakes-evidence/01KYWY8TS640DFF8RD9B66DSPZ/brief-home/data/lavish-e2e/brief.md (ship, mode=no-mistakes; replace {TASK})

$ generated captain-facing lifecycle section (canonical artifact: LAVISH_ARTIFACT)
# Lavish review lifecycle - OPT IN
This task creates, refreshes, or operates a captain-facing Lavish review, so the review stays nonterminal while captain feedback is expected.
Set `LAVISH_ARTIFACT` to the canonical HTML artifact path for the review and keep using that same path.
After every `lavish-axi <artifact>` open or refresh, immediately run `lavish-axi poll "$LAVISH_ARTIFACT"` with no timeout.
Leave that poll running; if the harness cannot keep a foreground command alive, run the same normal poll in the background and wait for it.
If the poll process exits because it was killed or timed out, re-run `lavish-axi poll "$LAVISH_ARTIFACT"`; queued feedback is persistent and the listener must be re-established.
When a poll returns prompts or layout warnings, handle every returned item.
Fix layout warnings before involving the captain.
After handling any prompt or layout warning returned by poll, finish by running `lavish-axi poll "$LAVISH_ARTIFACT" --agent-reply "<visible response>"`.
The visible response must state what changed, what was answered, or why nothing changed, and that command becomes the next active feedback wait.
Do not append `done:` merely because the page, report, or PR is open.
Use `paused:` for a Lavish review wait only while a `lavish-axi poll` listener is active or while you are restarting that listener.
Use `blocked:` if the listener cannot be restarted after the same obstacle repeats twice.

## Lavish recovery
If interrupted, resume with the same `LAVISH_ARTIFACT` path and run `lavish-axi poll "$LAVISH_ARTIFACT"` again.
Do not reopen a healthy already-open review merely to restore the agent listener.
If the Lavish server or browser was restored, run `lavish-axi "$LAVISH_ARTIFACT"` only to open or resume that same artifact, then immediately return to `lavish-axi poll "$LAVISH_ARTIFACT"`.
Do not open a second artifact path, end unrelated sessions, run `lavish-axi stop`, or disturb unrelated Lavish reviews.
Before reporting any terminal `done:` or ready state, read and follow `/home/avi/.no-mistakes/worktrees/5ac65bd3299a/01KYWY8TS640DFF8RD9B66DSPZ/.agents/skills/decision-hold-lifecycle/SKILL.md` and pass its shared completion gate for the ship and this Lavish review.

# Setup

$ generated definition-of-done and decision lines
20:Do not append `done:` merely because the page, report, or PR is open.
22:Use `blocked:` if the listener cannot be restarted after the same obstacle repeats twice.
29:Before reporting any terminal `done:` or ready state, read and follow `/home/avi/.no-mistakes/worktrees/5ac65bd3299a/01KYWY8TS640DFF8RD9B66DSPZ/.agents/skills/decision-hold-lifecycle/SKILL.md` and pass its shared completion gate for the ship and this Lavish review.
36:If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not branch or commit here - append `blocked: launched in primary checkout, not an isolated worktree` to the status file and stop.
47:   States: working, needs-decision, blocked, paused, done, failed.
50:   needs-decision/blocked/paused/done/failed states. No step-by-step FYI progress lines;
53:   turn after it; continue the same stage until a defined `done:` gate under Definition of done.
54:   Use `paused: {why}` - distinct from `blocked:` - ONLY when you are deliberately idling on a
57:   cadence instead of treating it as a possible wedge. Use `blocked:` when you are stuck and need help.
58:5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
59:6. If a decision belongs above the implementation worker (product choices, destructive actions, ask-user findings), append `needs-decision: {summary of options}` and do not stop.
65:   daemon error, append `blocked: {the daemon error}` and stop; only firstmate manages the daemon.
76:When you believe the implementation is complete, keep the Lavish poll listener active while captain feedback is expected. When captain feedback is complete and the final Lavish response has re-established the poll listener, append `done: {summary}` to the status file and stop.
89:After /no-mistakes reports CI green, keep the Lavish poll listener active until captain feedback is complete and the final Lavish response has re-established the poll listener, then append `done: PR {url} checks green` and stop. You are finished.

$ generated direct-PR and scout terminal boundaries
/tmp/no-mistakes-evidence/01KYWY8TS640DFF8RD9B66DSPZ/brief-home/data/scout-e2e/brief.md:63:Before reporting done, read and follow `/home/avi/.no-mistakes/worktrees/5ac65bd3299a/01KYWY8TS640DFF8RD9B66DSPZ/.agents/skills/decision-hold-lifecycle/SKILL.md` and pass its shared completion gate for the report and any visual review.
/tmp/no-mistakes-evidence/01KYWY8TS640DFF8RD9B66DSPZ/brief-home/data/scout-e2e/brief.md:64:When the report is complete and captain feedback is complete and the final Lavish response has re-established the poll listener, append `done: {one-line conclusion}` to the status file and stop.
/tmp/no-mistakes-evidence/01KYWY8TS640DFF8RD9B66DSPZ/brief-home/data/direct-e2e/brief.md:76:When it is implemented and committed, push your branch and open a PR with `gh-axi`. Keep the Lavish poll listener active while captain feedback is expected. When captain feedback is complete and the final Lavish response has re-established the poll listener, append `done: PR {url}` to the status file and stop.

$ ordinary ship opt-in check
PASS: ordinary brief has no Lavish lifecycle text

$ unsupported secondmate mode check
exit=1
error: --lavish-review applies only to crewmate ship or scout briefs
PASS: rejected mode wrote no brief

$ lavish-axi poll --help (installed public CLI)
Usage: lavish-axi poll <html-file> [--agent-reply "..."]

This command long-polls indefinitely for queued user prompts and browser-reported layout_warnings, then returns them to the agent. It stays silent while it waits - that is normal, never kill it. Fix layout_warnings before involving the human. Do not pass --timeout-ms during normal agent use; it is for tests and debugging only. If your harness limits how long a foreground command may run, run the poll as a background task and wait for it to finish; if it still gets killed or times out, just re-run it - queued feedback is never lost. Use --agent-reply after applying prior feedback to display your response in Lavish Editor before waiting again.


contract ordering check: PASS (same-line open/refresh + immediate normal poll; reply-and-repoll requirement precedes recovery guidance)
```
</details>
<details>
<summary>Evidence: Ordinary brief compatibility check</summary>

```text
ordinary brief byte comparison against base 66b0f77: PASS
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 3 issues found → auto-fixed ✅</summary>

- 🚨 `bin/fm-brief.sh:272` - The new opt-in rule says not to append `done:` merely because a PR is open, but the generated direct-PR definition still requires appending `done: PR {url}` immediately after opening the PR (and local-only/no-mistakes modes have analogous terminal instructions). An opted-in worker can therefore stop listening while feedback is still expected, contradicting: “Open reviews remain nonterminal while feedback is expected.”
- 🚨 `bin/fm-brief.sh:270` - The new prompt/warning contract requires a final `lavish-axi poll ... --agent-reply` at this line, but the generated Rules still instruct the worker to append `needs-decision` and stop when feedback is a human decision. That path can exit before the required next wait becomes active, contradicting: “every handled prompt or layout warning must finish with lavish-axi poll using --agent-reply with a visible response so the next wait is active.”
- 🚨 `bin/fm-brief.sh:260` - `--lavish-review` is enabled for ship briefs, but only scout briefs include the `decision-hold-lifecycle` completion gate. A ship-side Lavish review can expose an unresolved captain decision and still reach its normal ship completion path without durable decision-hold handling, contradicting: “preserve all safety, decision-hold, browser, and teardown boundaries.”

🔧 Fix: Hardened Lavish briefs; focused lifecycle tests pass
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bash tests/fm-brief.test.sh`
- `bash tests/fm-ask-user-authority.test.sh`
- `bash tests/fm-tangle-guard.test.sh`
- `Generated Lavish ship, direct-PR, local-only, and scout briefs in isolated temporary state.`
- <code>Compared ordinary ship/scout brief bytes against base `66b0f77`.</code>
- `lavish-axi poll --help`
- `Verified generated lifecycle clause ordering and unsupported secondmate rejection.`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Lint** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ linter found issues (exit code 1)

🔧 Fix: Captain: silence intentional SC2016 brief-text warnings
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
