### PR TITLE
fix(bin): enforce terminal task cleanup contract

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -329,6 +329,7 @@ A captain instruction to merge is explicit authority; `yolo` is the only standin
 For any custom `state/<id>.check.sh` you write yourself, keep it an ordinary single-link mode-`0700` file, print one line only when firstmate should wake, print nothing otherwise, finish before `FM_CHECK_TIMEOUT`, then bind its current bytes with `bin/fm-check-register.sh <id>` before the watcher may execute it.
 
 Tear down a ship task only after landing is confirmed.
+Handling any terminal completion (`done:`, `failed:`, or a completed scout report) ends with an unconditional `bin/fm-teardown.sh <id>` attempt in that same handling turn; teardown's fail-closed gates decide readiness, and a refusal parks the task with the refusal reason as the durable record of what it waits on.
 A teardown refusal for uncommitted or unlanded work is a stop-and-investigate result, never an obstacle to bypass.
 Never force teardown without explicit discard authority.
 After successful teardown, record completion, retain only the configured recent Done history, and re-evaluate queued work whose blockers and time gates have cleared.

--- a/bin/fm-backend.sh
+++ b/bin/fm-backend.sh
@@ -383,8 +383,8 @@ fm_backend_endpoint_atom_valid() {  # <value>
   esac
 }
 
-fm_backend_validate_task_endpoint() {  # <meta-file> <task-id>
-  local meta=$1 id=$2 backend_count backend window worktree project binding_count binding
+fm_backend_validate_task_endpoint() {  # <meta-file> <task-id> [allow-empty-worktree]
+  local meta=$1 id=$2 allow_empty_worktree=${3:-0} backend_count backend window worktree project binding_count binding
   local session pane recorded_session workspace tab terminal worktree_id surface
   FM_BACKEND_VALIDATED_BACKEND=
   FM_BACKEND_VALIDATED_TARGET=
@@ -400,10 +400,16 @@ fm_backend_validate_task_endpoint() {  # <meta-file> <task-id>
     echo "REFUSED: task $id has a missing, empty, or ambiguous window endpoint; preserving task state." >&2
     return 1
   }
-  worktree=$(fm_backend_meta_exact_value "$meta" worktree) || {
-    echo "REFUSED: task $id has a missing, empty, or ambiguous worktree identity; preserving task state." >&2
-    return 1
-  }
+  if ! worktree=$(fm_backend_meta_exact_value "$meta" worktree); then
+    if [ "$allow_empty_worktree" = 1 ] \
+       && [ "$(grep -c '^worktree=' "$meta" 2>/dev/null || true)" -eq 1 ] \
+       && grep -qx 'worktree=' "$meta" 2>/dev/null; then
+      worktree=
+    else
+      echo "REFUSED: task $id has a missing, empty, or ambiguous worktree identity; preserving task state." >&2
+      return 1
+    fi
+  fi
   project=$(fm_backend_meta_exact_value "$meta" project) || {
     echo "REFUSED: task $id has a missing, empty, or ambiguous project identity; preserving task state." >&2
     return 1

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -64,6 +64,12 @@
 #   Every single-task invocation holds one task-id-scoped lock across backend
 #   creation through metadata publication, so concurrent same-id spawns serialize
 #   even when they select different backends.
+#   A spawn that fails after its pane/endpoint may exist still leaves state
+#   behind: spawn_abort_cleanup writes state/<id>.meta (when the normal
+#   publication never ran) and appends a failed: line to state/<id>.status, so
+#   the failed spawn presents as an ordinary terminal state the same reap path
+#   handles (upstream issue 1336). Orca is the exception: its abort cleanup
+#   already records meta exactly when the worktree survives for a retry.
 #   With no harness arg, a crewmate/scout spawn resolves the CREW harness only when
 #   config/crew-dispatch.json is absent. When that file exists, crewmate/scout
 #   spawns require an explicit harness so firstmate cannot silently skip dispatch
@@ -271,6 +277,12 @@ SPAWN_TASK_LOCK=
 SPAWN_TASK_LOCK_HELD=0
 CONFIG_INHERIT_LOCK=
 CONFIG_INHERIT_LOCK_HELD=0
+# Set to 1 once the spawn's backend pane/endpoint may exist (immediately after
+# the endpoint-creation case below). From that point a failing spawn must not
+# vanish statelessly: spawn_abort_cleanup leaves a meta record and a failed:
+# status line so the failure presents as an ordinary terminal state the same
+# reap path handles (upstream issue 1336).
+SPAWN_ENDPOINT_MAY_EXIST=0
 
 parse_orca_worktree_result() {
   local raw=$1 rest
@@ -334,6 +346,55 @@ spawn_abort_cleanup() {
             [ -z "${ORCA_TERMINAL:-}" ] || echo "terminal=$ORCA_TERMINAL"
           } > "$STATE/$ID.meta" 2>/dev/null || true
         fi
+      fi
+    fi
+  fi
+  # Upstream issue 1336: a spawn that fails after its pane/endpoint may exist
+  # must still be born with state. Leave a meta record (written here only when
+  # the normal publication below never ran) and a failed: status line, so the
+  # failed spawn presents as an ordinary terminal state the same done/failed
+  # reap path handles instead of an invisible orphan pane. Orca is excluded
+  # from the meta write: its abort cleanup above already records meta exactly
+  # when the worktree survives for a retry, and a removed orca worktree would
+  # make a fresh meta record un-reapable without --force.
+  if [ "$status" -ne 0 ] && [ "$SPAWN_ENDPOINT_MAY_EXIST" = 1 ]; then
+    mkdir -p "$STATE" 2>/dev/null || true
+    if [ -d "$STATE" ]; then
+      if [ "${BACKEND:-}" != orca ] && [ ! -e "$STATE/$ID.meta" ] && [ ! -L "$STATE/$ID.meta" ]; then
+        {
+          echo "window=${T:-$W}"
+          echo "endpoint_task_id=$ID"
+          echo "worktree=${WT:-}"
+          echo "project=$PROJ_ABS"
+          echo "harness=$HARNESS"
+          echo "kind=$KIND"
+          echo "mode=${MODE:-no-mistakes}"
+          echo "yolo=${YOLO:-off}"
+          echo "tasktmp=${TASK_TMP:-/tmp/fm-$ID}"
+          echo "model=${MODEL:-default}"
+          echo "effort=${EFFORT:-default}"
+          [ "${BACKEND:-tmux}" = tmux ] || echo "backend=$BACKEND"
+          if [ "${BACKEND:-}" = herdr ]; then
+            echo "herdr_session=${HERDR_SES:-}"
+            echo "herdr_workspace_id=${HERDR_WORKSPACE_ID:-}"
+            echo "herdr_tab_id=${HERDR_TAB_ID:-}"
+            echo "herdr_pane_id=${HERDR_PANE_ID:-}"
+          fi
+          if [ "${BACKEND:-}" = zellij ]; then
+            echo "zellij_session=${ZELLIJ_SES:-}"
+            echo "zellij_tab_id=${ZELLIJ_TAB_ID:-}"
+            echo "zellij_pane_id=${ZELLIJ_PANE_ID:-}"
+          fi
+          if [ "${BACKEND:-}" = cmux ]; then
+            echo "cmux_workspace_id=${CMUX_WORKSPACE_ID:-}"
+            echo "cmux_surface_id=${CMUX_SURFACE_ID:-}"
+          fi
+        } > "$STATE/$ID.meta" 2>/dev/null || true
+      fi
+      if { [ -e "$STATE/$ID.meta" ] || [ -L "$STATE/$ID.meta" ]; } \
+         && ! grep -q '^failed:' "$STATE/$ID.status" 2>/dev/null; then
+        printf 'failed: spawn failed before launch completed (exit %s); inspect endpoint %s\n' \
+          "$status" "${T:-$W}" >> "$STATE/$ID.status" 2>/dev/null || true
       fi
     fi
   fi
@@ -1203,6 +1264,9 @@ EOF
     T="$ORCA_TERMINAL"
     ;;
 esac
+# Past this point the task's pane/endpoint may exist, so a failure must leave
+# state behind (see spawn_abort_cleanup and upstream issue 1336).
+SPAWN_ENDPOINT_MAY_EXIST=1
 # #134 robustness: only tmux needs a worktree-detection target distinct from $T -
 # its rename-safe stable window id, set as WT_TARGET=$WID in the tmux branch above.
 # Every other backend addresses its pane/surface by the id already in $T, so default
@@ -1320,7 +1384,8 @@ if [ "$KIND" != secondmate ] && [ "$BACKEND" != orca ]; then
   # pane that is already settled by the first real read only costs the one existing
   # inter-poll sleep as confirmation, not a whole extra cycle on top.
   candidate=""
-  for _ in $(seq 1 60); do
+  worktree_polls=${FM_SPAWN_WORKTREE_POLLS:-60}
+  for _ in $(seq 1 "$worktree_polls"); do
     p=$(spawn_current_path "$WT_TARGET" || true)
     if [ -n "$p" ]; then
       p_real=$(real_path_or_raw "$p")
@@ -1339,7 +1404,7 @@ if [ "$KIND" != secondmate ] && [ "$BACKEND" != orca ]; then
     sleep 1
   done
   if [ -z "$WT" ]; then
-    echo "error: treehouse get did not enter a worktree within 60s; inspect window $T" >&2
+    echo "error: treehouse get did not enter a worktree within ${worktree_polls}s; inspect window $T" >&2
     exit 1
   fi
 

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -277,11 +277,10 @@ SPAWN_TASK_LOCK=
 SPAWN_TASK_LOCK_HELD=0
 CONFIG_INHERIT_LOCK=
 CONFIG_INHERIT_LOCK_HELD=0
-# Set to 1 once the spawn's backend pane/endpoint may exist (immediately after
-# the endpoint-creation case below). From that point a failing spawn must not
-# vanish statelessly: spawn_abort_cleanup leaves a meta record and a failed:
-# status line so the failure presents as an ordinary terminal state the same
-# reap path handles (upstream issue 1336).
+# Set to 1 once this invocation owns the valid task id under its spawn lock.
+# Any later failure must not vanish statelessly: spawn_abort_cleanup leaves a
+# meta record and a failed: status line so the failure presents as an ordinary
+# terminal state the same reap path handles (upstream issue 1336).
 SPAWN_ENDPOINT_MAY_EXIST=0
 
 parse_orca_worktree_result() {
@@ -362,11 +361,11 @@ spawn_abort_cleanup() {
     if [ -d "$STATE" ]; then
       if [ "${BACKEND:-}" != orca ] && [ ! -e "$STATE/$ID.meta" ] && [ ! -L "$STATE/$ID.meta" ]; then
         {
-          echo "window=${T:-$W}"
+          echo "window=${T:-${W:-}}"
           echo "endpoint_task_id=$ID"
           echo "worktree=${WT:-}"
-          echo "project=$PROJ_ABS"
-          echo "harness=$HARNESS"
+          echo "project=${PROJ_ABS:-}"
+          echo "harness=${HARNESS:-}"
           echo "kind=$KIND"
           echo "mode=${MODE:-no-mistakes}"
           echo "yolo=${YOLO:-off}"
@@ -394,7 +393,7 @@ spawn_abort_cleanup() {
       if { [ -e "$STATE/$ID.meta" ] || [ -L "$STATE/$ID.meta" ]; } \
          && ! grep -q '^failed:' "$STATE/$ID.status" 2>/dev/null; then
         printf 'failed: spawn failed before launch completed (exit %s); inspect endpoint %s\n' \
-          "$status" "${T:-$W}" >> "$STATE/$ID.status" 2>/dev/null || true
+          "$status" "${T:-${W:-unpublished}}" >> "$STATE/$ID.status" 2>/dev/null || true
       fi
     fi
   fi
@@ -480,6 +479,7 @@ if ! fm_lock_try_acquire "$SPAWN_TASK_LOCK"; then
   exit 1
 fi
 SPAWN_TASK_LOCK_HELD=1
+SPAWN_ENDPOINT_MAY_EXIST=1
 PROJ=
 ARG3=
 FIRSTMATE_HOME=
@@ -1264,9 +1264,6 @@ EOF
     T="$ORCA_TERMINAL"
     ;;
 esac
-# Past this point the task's pane/endpoint may exist, so a failure must leave
-# state behind (see spawn_abort_cleanup and upstream issue 1336).
-SPAWN_ENDPOINT_MAY_EXIST=1
 # #134 robustness: only tmux needs a worktree-detection target distinct from $T -
 # its rename-safe stable window id, set as WT_TARGET=$WID in the tmux branch above.
 # Every other backend addresses its pane/surface by the id already in $T, so default

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -277,11 +277,9 @@ SPAWN_TASK_LOCK=
 SPAWN_TASK_LOCK_HELD=0
 CONFIG_INHERIT_LOCK=
 CONFIG_INHERIT_LOCK_HELD=0
-# Set to 1 once this invocation owns the valid task id under its spawn lock.
-# Any later failure must not vanish statelessly: spawn_abort_cleanup leaves a
-# meta record and a failed: status line so the failure presents as an ordinary
-# terminal state the same reap path handles (upstream issue 1336).
-SPAWN_ENDPOINT_MAY_EXIST=0
+SPAWN_FAILURE_RECORD_OWNED=0
+SPAWN_ABORT_META_READY=0
+SPAWN_META_OWNED=0
 
 parse_orca_worktree_result() {
   local raw=$1 rest
@@ -328,8 +326,9 @@ spawn_abort_cleanup() {
     if [ -n "${ORCA_WORKTREE_ID:-}" ]; then
       if ! fm_backend_remove_worktree orca "$ORCA_WORKTREE_ID" 2>/dev/null; then
         mkdir -p "$STATE" 2>/dev/null || true
-        if [ -d "$STATE" ]; then
-          {
+        if [ -d "$STATE" ] && [ "$SPAWN_FAILURE_RECORD_OWNED" = 1 ] \
+           && [ ! -e "$STATE/$ID.meta" ] && [ ! -L "$STATE/$ID.meta" ]; then
+          if {
             echo "window=$W"
             echo "worktree=${WT:-}"
             echo "project=$PROJ_ABS"
@@ -343,7 +342,9 @@ spawn_abort_cleanup() {
             echo "backend=orca"
             echo "orca_worktree_id=$ORCA_WORKTREE_ID"
             [ -z "${ORCA_TERMINAL:-}" ] || echo "terminal=$ORCA_TERMINAL"
-          } > "$STATE/$ID.meta" 2>/dev/null || true
+          } > "$STATE/$ID.meta" 2>/dev/null; then
+            SPAWN_META_OWNED=1
+          fi
         fi
       fi
     fi
@@ -356,11 +357,13 @@ spawn_abort_cleanup() {
   # from the meta write: its abort cleanup above already records meta exactly
   # when the worktree survives for a retry, and a removed orca worktree would
   # make a fresh meta record un-reapable without --force.
-  if [ "$status" -ne 0 ] && [ "$SPAWN_ENDPOINT_MAY_EXIST" = 1 ]; then
+  if [ "$status" -ne 0 ] \
+     && { [ "$SPAWN_FAILURE_RECORD_OWNED" = 1 ] || [ "$SPAWN_META_OWNED" = 1 ]; }; then
     mkdir -p "$STATE" 2>/dev/null || true
     if [ -d "$STATE" ]; then
-      if [ "${BACKEND:-}" != orca ] && [ ! -e "$STATE/$ID.meta" ] && [ ! -L "$STATE/$ID.meta" ]; then
-        {
+      if [ "${BACKEND:-}" != orca ] && [ "$SPAWN_ABORT_META_READY" = 1 ] \
+         && [ ! -e "$STATE/$ID.meta" ] && [ ! -L "$STATE/$ID.meta" ]; then
+        if {
           echo "window=${T:-${W:-}}"
           echo "endpoint_task_id=$ID"
           echo "worktree=${WT:-}"
@@ -388,9 +391,13 @@ spawn_abort_cleanup() {
             echo "cmux_workspace_id=${CMUX_WORKSPACE_ID:-}"
             echo "cmux_surface_id=${CMUX_SURFACE_ID:-}"
           fi
-        } > "$STATE/$ID.meta" 2>/dev/null || true
+        } > "$STATE/$ID.meta" 2>/dev/null; then
+          SPAWN_META_OWNED=1
+        fi
       fi
-      if { [ -e "$STATE/$ID.meta" ] || [ -L "$STATE/$ID.meta" ]; } \
+      if { [ "$SPAWN_META_OWNED" = 1 ] \
+           || { [ "${BACKEND:-}" != orca ] && [ "$SPAWN_ABORT_META_READY" = 0 ] \
+                && [ ! -e "$STATE/$ID.meta" ] && [ ! -L "$STATE/$ID.meta" ]; }; } \
          && ! grep -q '^failed:' "$STATE/$ID.status" 2>/dev/null; then
         printf 'failed: spawn failed before launch completed (exit %s); inspect endpoint %s\n' \
           "$status" "${T:-${W:-unpublished}}" >> "$STATE/$ID.status" 2>/dev/null || true
@@ -479,7 +486,9 @@ if ! fm_lock_try_acquire "$SPAWN_TASK_LOCK"; then
   exit 1
 fi
 SPAWN_TASK_LOCK_HELD=1
-SPAWN_ENDPOINT_MAY_EXIST=1
+if [ ! -e "$STATE/$ID.meta" ] && [ ! -L "$STATE/$ID.meta" ]; then
+  SPAWN_FAILURE_RECORD_OWNED=1
+fi
 PROJ=
 ARG3=
 FIRSTMATE_HOME=
@@ -1041,6 +1050,7 @@ case "$BACKEND" in
   tmux)
     SES=$(fm_backend_tmux_container_ensure)
     T="$SES:$W"
+    SPAWN_ABORT_META_READY=1
     # #134 robustness (tmux): fm_backend_tmux_create_task captures a stable window
     # id and pins the window name (automatic-rename/allow-rename off) so a captain's
     # non-default tmux config cannot rename the window away from fm-<id> once
@@ -1213,6 +1223,7 @@ EOF
       exit 1
     fi
     T="$HERDR_SES:$HERDR_PANE_ID"
+    SPAWN_ABORT_META_READY=1
     ;;
   zellij)
     ZELLIJ_SES=$(fm_backend_zellij_container_ensure) || exit 1
@@ -1225,6 +1236,7 @@ EOF
       exit 1
     fi
     T="$ZELLIJ_SES:$ZELLIJ_PANE_ID"
+    SPAWN_ABORT_META_READY=1
     ;;
   cmux)
     fm_backend_cmux_container_ensure || exit 1
@@ -1237,6 +1249,7 @@ EOF
       exit 1
     fi
     T="$CMUX_WORKSPACE_ID:$CMUX_SURFACE_ID"
+    SPAWN_ABORT_META_READY=1
     ;;
   orca)
     set +e
@@ -1710,6 +1723,7 @@ META_WINDOW=$T
     echo "projects=$SECONDMATE_PROJECTS"
   fi
 } > "$STATE/$ID.meta"
+SPAWN_META_OWNED=1
 [ "$BACKEND" = orca ] && ORCA_ABORT_CLEANUP=0
 
 sq_brief=$(shell_quote "$BRIEF")

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -396,7 +396,7 @@ spawn_abort_cleanup() {
         fi
       fi
       if { [ "$SPAWN_META_OWNED" = 1 ] \
-           || { [ "${BACKEND:-}" != orca ] && [ "$SPAWN_ABORT_META_READY" = 0 ] \
+           || { [ "$SPAWN_ABORT_META_READY" = 0 ] \
                 && [ ! -e "$STATE/$ID.meta" ] && [ ! -L "$STATE/$ID.meta" ]; }; } \
          && ! grep -q '^failed:' "$STATE/$ID.status" 2>/dev/null; then
         printf 'failed: spawn failed before launch completed (exit %s); inspect endpoint %s\n' \

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -486,6 +486,12 @@ if ! fm_lock_try_acquire "$SPAWN_TASK_LOCK"; then
   exit 1
 fi
 SPAWN_TASK_LOCK_HELD=1
+if [ ! -e "$STATE/$ID.meta" ] && [ ! -L "$STATE/$ID.meta" ] \
+   && [ -f "$STATE/$ID.status" ] && [ ! -L "$STATE/$ID.status" ] \
+   && [ "$(wc -l < "$STATE/$ID.status" 2>/dev/null | tr -d '[:space:]')" = 1 ] \
+   && grep -q '^failed: spawn failed before launch completed ' "$STATE/$ID.status"; then
+  rm -f "$STATE/$ID.status"
+fi
 if [ ! -e "$STATE/$ID.meta" ] && [ ! -L "$STATE/$ID.meta" ]; then
   SPAWN_FAILURE_RECORD_OWNED=1
 fi

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -128,7 +128,13 @@ META="$STATE/$ID.meta"
 # This is the first cleanup authorization check. It is metadata-only and must
 # complete before fm-guard, a backend command, file removal, branch deletion,
 # worktree return, registry change, or process termination can run.
-fm_backend_validate_task_endpoint "$META" "$ID" || exit 1
+ALLOW_EMPTY_FAILURE_WORKTREE=0
+if [ "$FORCE" = "--force" ] \
+   && [ -f "$STATE/$ID.status" ] && [ ! -L "$STATE/$ID.status" ] \
+   && grep -q '^failed: spawn failed before launch completed ' "$STATE/$ID.status"; then
+  ALLOW_EMPTY_FAILURE_WORKTREE=1
+fi
+fm_backend_validate_task_endpoint "$META" "$ID" "$ALLOW_EMPTY_FAILURE_WORKTREE" || exit 1
 BACKEND=$FM_BACKEND_VALIDATED_BACKEND
 T=$FM_BACKEND_VALIDATED_TARGET
 WT=$(fm_meta_get "$META" worktree)
@@ -1455,12 +1461,20 @@ if [ "$BACKEND" = herdr ] \
   fm_backend_source herdr || true
   HERDR_PRESENTATION_SESSION=$(meta_value "$META" herdr_session)
   HERDR_PRESENTATION_WORKSPACE=$(meta_value "$META" herdr_workspace_id)
+  HERDR_PRESENTATION_TAB=$(meta_value "$META" herdr_tab_id)
   HERDR_PRESENTATION_PANE=$(meta_value "$META" herdr_pane_id)
   if [ -n "$HERDR_PRESENTATION_SESSION" ] \
      && [ -n "$HERDR_PRESENTATION_WORKSPACE" ] \
+     && [ -n "$HERDR_PRESENTATION_TAB" ] \
      && [ -n "$HERDR_PRESENTATION_PANE" ] \
      && [ "$T" = "$HERDR_PRESENTATION_SESSION:$HERDR_PRESENTATION_PANE" ]; then
-    if [ "$(fm_backend_herdr_pane_agent_state "$HERDR_PRESENTATION_SESSION" "$HERDR_PRESENTATION_PANE")" = dead ]; then
+    if fm_backend_herdr_projection_journal_snapshot "$HERDR_PRESENTATION_JOURNAL" "$ID" \
+       && [ "$FM_BACKEND_HERDR_JOURNAL_VERSION" = 2 ] \
+       && [ "$FM_BACKEND_HERDR_JOURNAL_SESSION" = "$HERDR_PRESENTATION_SESSION" ] \
+       && [ "$FM_BACKEND_HERDR_JOURNAL_WORKSPACE_ID" = "$HERDR_PRESENTATION_WORKSPACE" ] \
+       && [ "$FM_BACKEND_HERDR_JOURNAL_TAB_ID" = "$HERDR_PRESENTATION_TAB" ] \
+       && [ "$FM_BACKEND_HERDR_JOURNAL_PANE_ID" = "$HERDR_PRESENTATION_PANE" ] \
+       && [ "$(fm_backend_herdr_pane_agent_state "$HERDR_PRESENTATION_SESSION" "$HERDR_PRESENTATION_PANE")" = dead ]; then
       # Upstream issue 1337: a pane the backend already reports dead is
       # confirmed-closed by definition - the exact case where journal
       # retirement is safest. Retire without a close attempt; requiring the

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -41,7 +41,11 @@
 # only the exact task pane from ordinary endpoint metadata and never calls
 # `workspace close`. It retires the non-authoritative journal only when a
 # read-only token correlation agrees with that endpoint and pane closure is
-# confirmed. Otherwise the journal stays quarantined for manual inspection.
+# confirmed; a pane the backend already reports dead counts as confirmed-closed
+# (upstream issue 1337). A close that cannot be confirmed is a loud teardown
+# failure before any state deletion, so the handling turn retries instead of
+# the pane outliving its records; any other unmatched journal stays quarantined
+# for manual inspection.
 # Projected closes share the presentation-order lock, refuse to close the
 # captain's active tab, and restore the exact response-derived pre-close tab
 # if Herdr's last-pane cleanup focuses an unrelated neighboring workspace.
@@ -1443,6 +1447,7 @@ fi
 
 HERDR_PRESENTATION_JOURNAL="$STATE/$ID.herdr-presentation"
 HERDR_PRESENTATION_RETIRE_CANDIDATE=0
+HERDR_PRESENTATION_PANE_PREDEAD=0
 HERDR_PRESENTATION_SESSION=
 HERDR_PRESENTATION_PANE=
 if [ "$BACKEND" = herdr ] \
@@ -1454,11 +1459,20 @@ if [ "$BACKEND" = herdr ] \
   if [ -n "$HERDR_PRESENTATION_SESSION" ] \
      && [ -n "$HERDR_PRESENTATION_WORKSPACE" ] \
      && [ -n "$HERDR_PRESENTATION_PANE" ] \
-     && [ "$T" = "$HERDR_PRESENTATION_SESSION:$HERDR_PRESENTATION_PANE" ] \
-     && fm_backend_herdr_projection_endpoint_matches_journal \
-       "$HERDR_PRESENTATION_SESSION" "$HERDR_PRESENTATION_WORKSPACE" \
-       "$HERDR_PRESENTATION_JOURNAL" "$ID"; then
-    HERDR_PRESENTATION_RETIRE_CANDIDATE=1
+     && [ "$T" = "$HERDR_PRESENTATION_SESSION:$HERDR_PRESENTATION_PANE" ]; then
+    if [ "$(fm_backend_herdr_pane_agent_state "$HERDR_PRESENTATION_SESSION" "$HERDR_PRESENTATION_PANE")" = dead ]; then
+      # Upstream issue 1337: a pane the backend already reports dead is
+      # confirmed-closed by definition - the exact case where journal
+      # retirement is safest. Retire without a close attempt; requiring the
+      # token-bearing workspace to still be listed would quarantine the
+      # journal forever once herdr has reaped the pane (and possibly the
+      # whole projected workspace).
+      HERDR_PRESENTATION_PANE_PREDEAD=1
+    elif fm_backend_herdr_projection_endpoint_matches_journal \
+      "$HERDR_PRESENTATION_SESSION" "$HERDR_PRESENTATION_WORKSPACE" \
+      "$HERDR_PRESENTATION_JOURNAL" "$ID"; then
+      HERDR_PRESENTATION_RETIRE_CANDIDATE=1
+    fi
   fi
 fi
 
@@ -1471,7 +1485,7 @@ if [ "$HERDR_PRESENTATION_RETIRE_CANDIDATE" = 1 ]; then
   else
     echo "warning: herdr presentation focus lock unavailable; refusing a concurrent focus-unsafe pane close" >&2
   fi
-elif [ "$BACKEND" = herdr ]; then
+elif [ "$BACKEND" = herdr ] && [ "$HERDR_PRESENTATION_PANE_PREDEAD" != 1 ]; then
   if teardown_herdr_session_lock_held "$TEARDOWN_HERDR_SESSION"; then
     fm_backend_herdr_kill_serialized "$TEARDOWN_HERDR_SESSION" "$TEARDOWN_HERDR_PANE" 2>/dev/null || true
   else
@@ -1480,11 +1494,20 @@ elif [ "$BACKEND" = herdr ]; then
 elif [ "$BACKEND" != orca ]; then
   fm_backend_kill "$BACKEND" "$T" "$(meta_value "$META" zellij_tab_id)" "fm-$ID" 2>/dev/null || true
 fi
-if [ "$HERDR_PRESENTATION_RETIRE_CANDIDATE" = 1 ]; then
+if [ "$HERDR_PRESENTATION_PANE_PREDEAD" = 1 ]; then
+  rm -f "$HERDR_PRESENTATION_JOURNAL"
+elif [ "$HERDR_PRESENTATION_RETIRE_CANDIDATE" = 1 ]; then
   if [ "$(fm_backend_herdr_pane_agent_state "$HERDR_PRESENTATION_SESSION" "$HERDR_PRESENTATION_PANE")" = dead ]; then
     rm -f "$HERDR_PRESENTATION_JOURNAL"
   else
-    echo "warning: exact herdr task-pane close could not be confirmed for $ID; retaining the presentation journal and attempting no workspace cleanup" >&2
+    # Upstream issue 1337: an unconfirmed close must be loud, not silently
+    # tolerated. Refuse before any state deletion so the pane cannot outlive
+    # the records that could reap it, and the handling turn's retry can
+    # converge once the close completes (or the pane dies, which the pre-dead
+    # branch above then treats as confirmed-closed).
+    echo "error: exact herdr task-pane close could not be confirmed for $ID; the pane may still exist" >&2
+    echo "retaining the presentation journal and all task state; retry bin/fm-teardown.sh $ID once the pane close can complete" >&2
+    exit 1
   fi
 elif [ "$BACKEND" = herdr ] \
      && { [ -e "$HERDR_PRESENTATION_JOURNAL" ] || [ -L "$HERDR_PRESENTATION_JOURNAL" ]; }; then

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -109,7 +109,9 @@ Task cleanup acquires that session lock before the task's isolated copy is retur
 Forced secondmate cleanup recursively preflights every Herdr child endpoint and acquires every affected named-session lock before mutating any child, then retains each child's durable identity unless that exact pane returns structured not-found after its close.
 Durable task records are erased only once the exact pane is confirmed gone through its structured presence: after every close path, only a structured not-found response counts as gone, while a present or unknown result retains every record with a visible, retryable error.
 Missing or malformed endpoint identity and missing confirmation machinery are ambiguity, never proof of a gone pane, and refuse record removal the same way.
-If lock, snapshot, pane identity, or restoration is ambiguous, cleanup warns and preserves the journal for manual inspection.
+An exactly bound presentation journal is retired when the backend already reports its recorded pane dead or after a requested close is confirmed; if that close cannot be confirmed, teardown fails before deleting task state so the same cleanup can be retried.
+If the journal cannot be bound exactly, teardown grants it no cleanup authority and preserves it for manual inspection; a focus-restoration error after the pane is confirmed dead does not prevent retirement.
+If lock, snapshot, pane identity, or restoration authority is ambiguous before close, cleanup warns and preserves the journal for manual inspection.
 
 Recovery is deliberately conservative and presentation-only.
 An existing journal suppresses another projected create.

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -279,7 +279,7 @@ ok - real Herdr lab: missing, renamed, and duplicate tokens trigger zero destruc
 ok - real Herdr lab validation completed on Herdr 0.7.5 with the default-session tripwire intact
 ```
 
-The projection and teardown suites ran again on 2026-07-30 against Herdr 0.7.5 after the upstream-issue-1336/1337 done-means-cleanup changes (failed spawns leave state; pre-dead panes count as confirmed-closed for journal retirement; unconfirmed closes fail loudly for retry):
+The projection and teardown suites ran again on 2026-07-30 against Herdr 0.7.5 after the upstream-issue-1336/1337 done-means-cleanup changes (post-endpoint aborts leave ordinary terminal state; pre-dead panes count as confirmed-closed for journal retirement; unconfirmed closes fail loudly for retry):
 
 ```sh
 tests/fm-backend-herdr-presentation-e2e.test.sh
@@ -294,7 +294,7 @@ ok - real Herdr lab: concurrent post-create abort cleanup stays serialized with 
 ok - herdr projection teardown retires its journal only after confirming the exact recorded pane is gone
 ok - herdr projection teardown reports an unconfirmed close loudly, keeps state, and converges on retry
 ok - herdr projection teardown retires the journal when the pane is already dead
-ok - a failed spawn leaves meta and a failed: status line (upstream issue 1336)
+ok - a failed spawn leaves ordinary terminal state that forced teardown can reap (upstream issue 1336)
 ```
 
 The post-create abort fixtures now also prove the issue-1336 contract against real Herdr: both failed spawns left a meta record and a failed: status line even though abort cleanup removed their exact panes.

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -279,6 +279,26 @@ ok - real Herdr lab: missing, renamed, and duplicate tokens trigger zero destruc
 ok - real Herdr lab validation completed on Herdr 0.7.5 with the default-session tripwire intact
 ```
 
+The projection and teardown suites ran again on 2026-07-30 against Herdr 0.7.5 after the upstream-issue-1336/1337 done-means-cleanup changes (failed spawns leave state; pre-dead panes count as confirmed-closed for journal retirement; unconfirmed closes fail loudly for retry):
+
+```sh
+tests/fm-backend-herdr-presentation-e2e.test.sh
+tests/fm-teardown.test.sh
+tests/fm-spawn-worktree-settle.test.sh
+```
+
+Observed guarantees:
+
+```text
+ok - real Herdr lab: concurrent post-create abort cleanup stays serialized with exact focus restoration
+ok - herdr projection teardown retires its journal only after confirming the exact recorded pane is gone
+ok - herdr projection teardown reports an unconfirmed close loudly, keeps state, and converges on retry
+ok - herdr projection teardown retires the journal when the pane is already dead
+ok - a failed spawn leaves meta and a failed: status line (upstream issue 1336)
+```
+
+The post-create abort fixtures now also prove the issue-1336 contract against real Herdr: both failed spawns left a meta record and a failed: status line even though abort cleanup removed their exact panes.
+
 The restored-shell session-start cleanup ran on 2026-07-24 against Herdr 0.7.5 protocol 17:
 
 ```sh

--- a/tests/fm-backend-herdr-presentation-e2e.test.sh
+++ b/tests/fm-backend-herdr-presentation-e2e.test.sh
@@ -776,10 +776,20 @@ for ABORT_PANE in "$ABORT_A_PANE" "$ABORT_B_PANE"; do
     fail "serialized post-create abort cleanup left exact task pane $ABORT_PANE alive"
   fi
 done
-[ ! -e "$HOME_DIR/state/abort-a.meta" ] && [ ! -e "$HOME_DIR/state/abort-b.meta" ] \
-  || fail "post-create abort fixtures published task metadata before launch"
+# Upstream issue 1336: even though abort cleanup removed their panes, the
+# failed spawns still leave state behind - a meta record and a failed: status
+# line - so they present as ordinary terminal states the same reap path
+# handles instead of invisible orphan state.
+for ABORT_ID in abort-a abort-b; do
+  [ -e "$HOME_DIR/state/$ABORT_ID.meta" ] \
+    || fail "post-create abort fixture $ABORT_ID left no meta record behind"
+  grep -F "failed:" "$HOME_DIR/state/$ABORT_ID.status" >/dev/null 2>&1 \
+    || fail "post-create abort fixture $ABORT_ID left no failed: status line"
+done
 rm -rf "$POST_CREATE_ABORT_CONTROL"
-rm -f "$HOME_DIR/state/abort-a.herdr-presentation" "$HOME_DIR/state/abort-b.herdr-presentation"
+rm -f "$HOME_DIR/state/abort-a.herdr-presentation" "$HOME_DIR/state/abort-b.herdr-presentation" \
+  "$HOME_DIR/state/abort-a.meta" "$HOME_DIR/state/abort-b.meta" \
+  "$HOME_DIR/state/abort-a.status" "$HOME_DIR/state/abort-b.status"
 pass "real Herdr lab: concurrent post-create abort cleanup stays serialized with exact focus restoration"
 
 SHAPE_CLEANUP_AUDIT_START=$(focus_audit_line_count)

--- a/tests/fm-backend-orca.test.sh
+++ b/tests/fm-backend-orca.test.sh
@@ -621,6 +621,8 @@ test_spawn_removes_orca_worktree_when_terminal_create_fails() {
   status=$?
   [ "$status" -ne 0 ] || fail "Orca spawn should fail when terminal creation fails"
   assert_absent "$state/$id.meta" "terminal-create abort should not record metadata after successful cleanup"
+  assert_grep "failed: spawn failed before launch completed" "$state/$id.status" \
+    "terminal-create abort should leave a visible failed status after successful cleanup"
   assert_contains "$(cat "$LOG")" $'orca\x1f''terminal'$'\x1f''create'$'\x1f''--worktree'$'\x1f''id:wt-terminal-fail'$'\x1f''--title'$'\x1f'"fm-$id"$'\x1f''--json' \
     "Orca spawn should attempt terminal creation before abort cleanup"
   assert_contains "$(cat "$LOG")" $'orca\x1f''worktree'$'\x1f''rm'$'\x1f''--worktree'$'\x1f''id:wt-terminal-fail'$'\x1f''--force'$'\x1f''--json' \

--- a/tests/fm-spawn-worktree-settle.test.sh
+++ b/tests/fm-spawn-worktree-settle.test.sh
@@ -12,6 +12,11 @@
 # transient-then-settled pane_current_path sequence with a fake tmux and
 # asserts the recorded worktree resolves to the real, settled worktree, never
 # the stale first read.
+#
+# Also covers upstream issue 1336: when the settle loop expires (the pane never
+# enters a worktree, as when treehouse get refuses), the failed spawn must
+# still leave state/<id>.meta and a failed: line in state/<id>.status so the
+# ordinary terminal-state reap path can see it.
 set -u
 
 # shellcheck source=tests/lib.sh
@@ -89,12 +94,12 @@ EOF
 }
 
 run_settle_spawn() {
-  local id=$1
+  local id=$1 pane_path=${2:-$WT_DIR}
   FM_ROOT_OVERRIDE='' FM_HOME="$HOME_DIR" \
     FM_STATE_OVERRIDE="$HOME_DIR/state" FM_DATA_OVERRIDE="$HOME_DIR/data" \
     FM_PROJECTS_OVERRIDE="$HOME_DIR/projects" FM_CONFIG_OVERRIDE="$HOME_DIR/config" \
     FM_SPAWN_NO_GUARD=1 TMUX="fake,1,0" \
-    FM_FAKE_PANE_PATH="$WT_DIR" FM_FAKE_PANE_STALE="$STALE_DIR" \
+    FM_FAKE_PANE_PATH="$pane_path" FM_FAKE_PANE_STALE="$STALE_DIR" \
     FM_FAKE_PANE_STALE_READS="$STALE_READS" FM_FAKE_PANE_COUNTFILE="$COUNTFILE" \
     PATH="$FAKEBIN_DIR:$PATH" \
     "$SPAWN" "$id" "$PROJ_DIR" 2>&1
@@ -143,5 +148,31 @@ test_already_settled_pane_costs_one_confirm_sleep() {
 
 test_single_stale_first_read_is_not_accepted
 test_already_settled_pane_costs_one_confirm_sleep
+
+# Upstream issue 1336: a bootstrap that fails after the pane exists (here the
+# pane never leaves the project, as when treehouse get refuses on an exhausted
+# pool) must still leave a meta record and a failed: status line, so the failed
+# spawn presents as an ordinary terminal state the same reap path handles
+# instead of an invisible orphan pane.
+test_failed_bootstrap_leaves_meta_and_failed_status() {
+  local rec id out rc
+  id=settle-never-settles-z3
+  rec=$(make_settle_case settle-never "$id" 0)
+  read_settle_record "$rec"
+
+  rc=0
+  out=$(FM_SPAWN_WORKTREE_POLLS=2 run_settle_spawn "$id" "$PROJ_DIR") || rc=$?
+  [ "$rc" -ne 0 ] || fail "a pane that never enters a worktree should fail the spawn"
+  assert_contains "$out" "did not enter a worktree" "spawn failure lost its diagnostic"
+  [ -e "$HOME_DIR/state/$id.meta" ] \
+    || fail "failed spawn left no meta record behind"
+  assert_grep "window=" "$HOME_DIR/state/$id.meta" \
+    "failed spawn's meta does not record its endpoint"
+  assert_grep "failed: spawn failed before launch completed" "$HOME_DIR/state/$id.status" \
+    "failed spawn left no supervisor-visible failed: status line"
+  pass "a failed spawn leaves meta and a failed: status line (upstream issue 1336)"
+}
+
+test_failed_bootstrap_leaves_meta_and_failed_status
 
 echo "# all fm-spawn-worktree-settle tests passed"

--- a/tests/fm-spawn-worktree-settle.test.sh
+++ b/tests/fm-spawn-worktree-settle.test.sh
@@ -53,7 +53,12 @@ esac
 case "${1:-}" in
   display-message) printf 'firstmate\n'; exit 0 ;;
   list-windows) exit 0 ;;
-  has-session|new-session|new-window|kill-window) exit 0 ;;
+  new-window)
+    printf '@1\n'
+    [ "${FM_FAKE_NEW_WINDOW_FAIL_AFTER_CREATE:-0}" != 1 ]
+    exit
+    ;;
+  has-session|new-session|kill-window) exit 0 ;;
   send-keys) exit 0 ;;
 esac
 exit 0
@@ -103,6 +108,15 @@ run_settle_spawn() {
     FM_FAKE_PANE_STALE_READS="$STALE_READS" FM_FAKE_PANE_COUNTFILE="$COUNTFILE" \
     PATH="$FAKEBIN_DIR:$PATH" \
     "$SPAWN" "$id" "$PROJ_DIR" 2>&1
+}
+
+run_settle_teardown() {
+  local id=$1
+  FM_ROOT_OVERRIDE='' FM_HOME="$HOME_DIR" \
+    FM_STATE_OVERRIDE="$HOME_DIR/state" FM_DATA_OVERRIDE="$HOME_DIR/data" \
+    FM_PROJECTS_OVERRIDE="$HOME_DIR/projects" FM_CONFIG_OVERRIDE="$HOME_DIR/config" \
+    FM_SPAWN_NO_GUARD=1 TMUX="fake,1,0" PATH="$FAKEBIN_DIR:$PATH" \
+    "$ROOT/bin/fm-teardown.sh" "$id" --force 2>&1
 }
 
 # A single stale first read (the exact incident) must not be accepted: the
@@ -170,9 +184,35 @@ test_failed_bootstrap_leaves_meta_and_failed_status() {
     "failed spawn's meta does not record its endpoint"
   assert_grep "failed: spawn failed before launch completed" "$HOME_DIR/state/$id.status" \
     "failed spawn left no supervisor-visible failed: status line"
-  pass "a failed spawn leaves meta and a failed: status line (upstream issue 1336)"
+  run_settle_teardown "$id" >/dev/null \
+    || fail "forced teardown could not reap a failed-spawn stub with no worktree"
+  [ ! -e "$HOME_DIR/state/$id.meta" ] \
+    || fail "forced teardown left the failed-spawn meta behind"
+  [ ! -e "$HOME_DIR/state/$id.status" ] \
+    || fail "forced teardown left the failed-spawn status behind"
+  pass "a failed spawn leaves ordinary terminal state that forced teardown can reap (upstream issue 1336)"
 }
 
 test_failed_bootstrap_leaves_meta_and_failed_status
+
+test_backend_partial_create_failure_leaves_terminal_state() {
+  local rec id out rc
+  id=settle-partial-create-z4
+  rec=$(make_settle_case settle-partial-create "$id" 0)
+  read_settle_record "$rec"
+
+  rc=0
+  out=$(FM_FAKE_NEW_WINDOW_FAIL_AFTER_CREATE=1 run_settle_spawn "$id") || rc=$?
+  [ "$rc" -ne 0 ] || fail "a backend create helper failure should fail the spawn"
+  [ -e "$HOME_DIR/state/$id.meta" ] \
+    || fail "partial backend create failure left no meta record behind"
+  assert_grep "window=firstmate:fm-$id" "$HOME_DIR/state/$id.meta" \
+    "partial backend create failure lost its owned endpoint"
+  assert_grep "failed: spawn failed before launch completed" "$HOME_DIR/state/$id.status" \
+    "partial backend create failure left no terminal status"
+  pass "a backend helper failure after partial creation leaves terminal state"
+}
+
+test_backend_partial_create_failure_leaves_terminal_state
 
 echo "# all fm-spawn-worktree-settle tests passed"

--- a/tests/fm-spawn-worktree-settle.test.sh
+++ b/tests/fm-spawn-worktree-settle.test.sh
@@ -232,7 +232,27 @@ test_preendpoint_failure_leaves_status_without_meta() {
     || fail "pre-endpoint failure wrote unreapable endpoint metadata"
   assert_grep 'failed: spawn failed before launch completed' "$HOME_DIR/state/$id.status" \
     "pre-endpoint failure left no visible failed status"
-  pass "a pre-endpoint failure leaves status without unreapable metadata"
+
+  printf '%s\n' 'failed: spawn failed before launch completed (exit 99); inspect endpoint old' \
+    > "$HOME_DIR/state/$id.status"
+  rc=0
+  out=$(run_settle_spawn "$id") || rc=$?
+  [ "$rc" -ne 0 ] || fail "a repeated spawn with no brief should fail"
+  assert_no_grep 'exit 99' "$HOME_DIR/state/$id.status" \
+    "repeated failure retained the prior status-only spawn verdict"
+  assert_grep 'failed: spawn failed before launch completed (exit 1)' "$HOME_DIR/state/$id.status" \
+    "repeated failure did not record its current reason"
+
+  printf 'brief for %s\n' "$id" > "$HOME_DIR/data/$id/brief.md"
+  out=$(run_settle_spawn "$id")
+  rc=$?
+  expect_code 0 "$rc" "corrected same-id retry should spawn successfully"
+  assert_contains "$out" "spawned $id" "corrected same-id retry did not report success"
+  [ -e "$HOME_DIR/state/$id.meta" ] \
+    || fail "corrected same-id retry did not publish live metadata"
+  ! grep -q '^failed:' "$HOME_DIR/state/$id.status" 2>/dev/null \
+    || fail "corrected same-id retry retained the stale terminal verdict"
+  pass "a status-only failure is retired before deliberate same-id reuse"
 }
 
 test_preendpoint_failure_leaves_status_without_meta

--- a/tests/fm-spawn-worktree-settle.test.sh
+++ b/tests/fm-spawn-worktree-settle.test.sh
@@ -52,7 +52,10 @@ case "$*" in
 esac
 case "${1:-}" in
   display-message) printf 'firstmate\n'; exit 0 ;;
-  list-windows) exit 0 ;;
+  list-windows)
+    [ -z "${FM_FAKE_EXISTING_WINDOW:-}" ] || printf '%s\n' "$FM_FAKE_EXISTING_WINDOW"
+    exit 0
+    ;;
   new-window)
     printf '@1\n'
     [ "${FM_FAKE_NEW_WINDOW_FAIL_AFTER_CREATE:-0}" != 1 ]
@@ -214,5 +217,45 @@ test_backend_partial_create_failure_leaves_terminal_state() {
 }
 
 test_backend_partial_create_failure_leaves_terminal_state
+
+test_preendpoint_failure_leaves_status_without_meta() {
+  local rec id out rc
+  id=settle-preendpoint-z5
+  rec=$(make_settle_case settle-preendpoint "$id" 0)
+  read_settle_record "$rec"
+  rm -f "$HOME_DIR/data/$id/brief.md"
+
+  rc=0
+  out=$(run_settle_spawn "$id") || rc=$?
+  [ "$rc" -ne 0 ] || fail "a spawn with no brief should fail"
+  [ ! -e "$HOME_DIR/state/$id.meta" ] \
+    || fail "pre-endpoint failure wrote unreapable endpoint metadata"
+  assert_grep 'failed: spawn failed before launch completed' "$HOME_DIR/state/$id.status" \
+    "pre-endpoint failure left no visible failed status"
+  pass "a pre-endpoint failure leaves status without unreapable metadata"
+}
+
+test_preendpoint_failure_leaves_status_without_meta
+
+test_duplicate_spawn_does_not_terminalize_live_task() {
+  local rec id out rc meta_before meta_after
+  id=settle-duplicate-z6
+  rec=$(make_settle_case settle-duplicate "$id" 0)
+  read_settle_record "$rec"
+  run_settle_spawn "$id" >/dev/null || fail "duplicate-spawn setup failed"
+  meta_before=$(cat "$HOME_DIR/state/$id.meta")
+
+  rc=0
+  out=$(FM_FAKE_EXISTING_WINDOW="fm-$id" run_settle_spawn "$id") || rc=$?
+  [ "$rc" -ne 0 ] || fail "duplicate spawn should be refused"
+  assert_contains "$out" "already exists" "duplicate spawn lost its refusal diagnostic"
+  meta_after=$(cat "$HOME_DIR/state/$id.meta")
+  [ "$meta_after" = "$meta_before" ] || fail "duplicate spawn mutated the live task metadata"
+  ! grep -q '^failed:' "$HOME_DIR/state/$id.status" 2>/dev/null \
+    || fail "duplicate spawn falsely marked the live task terminal"
+  pass "a duplicate spawn cannot terminalize an existing live task"
+}
+
+test_duplicate_spawn_does_not_terminalize_live_task
 
 echo "# all fm-spawn-worktree-settle tests passed"

--- a/tests/fm-teardown.test.sh
+++ b/tests/fm-teardown.test.sh
@@ -1797,14 +1797,14 @@ test_herdr_projection_teardown_retires_journal_only_after_confirmed_close() {
   pass "herdr projection teardown retires its journal only after confirming the exact recorded pane is gone"
 }
 
-test_herdr_projection_teardown_retains_journal_when_close_unconfirmed() {
-  local case_dir log closed restored
+test_herdr_projection_teardown_retains_records_when_presence_unknown() {
+  local case_dir log closed restored rc
   case_dir=$(make_case herdr-projection-unconfirmed-close)
   write_meta "$case_dir" local-only ship
   configure_herdr_projection_teardown_case "$case_dir"
   log="$case_dir/herdr.log"; closed="$case_dir/closed"; restored="$case_dir/restored"; : > "$log"
 
-  local rc=0
+  rc=0
   FM_FAKE_HERDR_LOG="$log" FM_FAKE_HERDR_CLOSED="$closed" FM_FAKE_HERDR_RESTORED="$restored" FM_FAKE_HERDR_PRESENCE_UNKNOWN=1 \
     run_teardown "$case_dir" --force > "$case_dir/stdout" 2> "$case_dir/stderr" || rc=$?
   [ "$rc" -ne 0 ] \
@@ -1817,11 +1817,70 @@ test_herdr_projection_teardown_retains_journal_when_close_unconfirmed() {
     || fail "unconfirmed task-pane close erased the durable endpoint metadata"
   assert_grep "close could not be confirmed" "$case_dir/stderr" \
     "unconfirmed projected close did not explain why the journal was retained"
-  assert_grep "not confirmed gone" "$case_dir/stderr" \
-    "unconfirmed projected close did not explain why the records were retained"
   assert_not_contains "$(cat "$log")" "workspace close" \
     "unconfirmed projected close must not escalate to workspace cleanup"
   pass "herdr projection teardown retains every record when post-close presence is unknown"
+}
+
+test_herdr_projection_teardown_reports_unconfirmed_close_loudly_for_retry() {
+  local case_dir log closed restored rc
+  case_dir=$(make_case herdr-projection-close-failed)
+  write_meta "$case_dir" local-only ship
+  configure_herdr_projection_teardown_case "$case_dir"
+  log="$case_dir/herdr.log"; closed="$case_dir/closed"; restored="$case_dir/restored"; : > "$log"
+
+  set +e
+  FM_FAKE_HERDR_LOG="$log" FM_FAKE_HERDR_CLOSED="$closed" FM_FAKE_HERDR_RESTORED="$restored" FM_FAKE_HERDR_CLOSE_FAIL=1 \
+    run_teardown "$case_dir" --force > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 1 "$rc" "unconfirmed-close: teardown must fail loudly so the handling turn retries"
+  [ -e "$case_dir/state/task-x1.herdr-presentation" ] \
+    || fail "unconfirmed-close: unconfirmed task-pane close incorrectly retired the presentation journal"
+  [ -e "$case_dir/state/task-x1.meta" ] \
+    || fail "unconfirmed-close: task state was deleted even though the pane close was never confirmed"
+  assert_grep "close could not be confirmed" "$case_dir/stderr" \
+    "unconfirmed-close: teardown did not report the unconfirmed close loudly"
+  assert_not_contains "$(cat "$log")" "workspace close" \
+    "unconfirmed-close: unconfirmed projected close must not escalate to workspace cleanup"
+
+  # The handling turn's retry converges: once the close can complete, the same
+  # teardown finishes and retires the journal. Reset only the fake's restored
+  # marker so its workspace list again shows the projected workspace.
+  rm -f "$restored"
+  FM_FAKE_HERDR_LOG="$log" FM_FAKE_HERDR_CLOSED="$closed" FM_FAKE_HERDR_RESTORED="$restored" \
+    run_teardown "$case_dir" --force > "$case_dir/stdout-retry" 2> "$case_dir/stderr-retry" \
+    || fail "unconfirmed-close retry: teardown failed once the pane close could complete"
+  [ ! -e "$case_dir/state/task-x1.herdr-presentation" ] \
+    || fail "unconfirmed-close retry: journal was not retired after the close completed"
+  pass "herdr projection teardown reports an unconfirmed close loudly, keeps state, and converges on retry"
+}
+
+test_herdr_projection_teardown_retires_journal_for_predead_pane() {
+  local case_dir log closed restored
+  case_dir=$(make_case herdr-projection-predead-pane)
+  write_meta "$case_dir" local-only ship
+  configure_herdr_projection_teardown_case "$case_dir"
+  log="$case_dir/herdr.log"; closed="$case_dir/closed"; restored="$case_dir/restored"; : > "$log"
+  # The pane died before teardown ran: pane get reports pane_not_found and the
+  # projected workspace is already gone from the workspace list. Retirement
+  # must treat the dead pane as confirmed-closed (upstream issue 1337) rather
+  # than quarantining the journal forever.
+  : > "$closed"
+
+  FM_FAKE_HERDR_LOG="$log" FM_FAKE_HERDR_CLOSED="$closed" FM_FAKE_HERDR_RESTORED="$restored" \
+    run_teardown "$case_dir" --force > "$case_dir/stdout" 2> "$case_dir/stderr" \
+    || fail "herdr-projection-predead-pane: teardown of a pre-dead pane failed"
+  [ ! -e "$case_dir/state/task-x1.herdr-presentation" ] \
+    || fail "herdr-projection-predead-pane: pre-dead pane did not retire its presentation journal"
+  assert_not_contains "$(cat "$case_dir/stderr")" "quarantined" \
+    "herdr-projection-predead-pane: pre-dead pane journal was quarantined instead of retired"
+  assert_not_contains "$(cat "$case_dir/stderr")" "could not be confirmed" \
+    "herdr-projection-predead-pane: pre-dead pane was misreported as an unconfirmed close"
+  assert_not_contains "$(cat "$log")" "pane close" \
+    "herdr-projection-predead-pane: a close was attempted against an already-dead pane"
+  pass "herdr projection teardown retires the journal when the pane is already dead"
 }
 
 test_local_only_fork_remote_allows
@@ -1841,7 +1900,9 @@ test_forced_secondmate_herdr_child_preflight_refuses_before_changes
 test_forced_secondmate_herdr_child_retains_records_when_close_unconfirmed
 test_forced_teardown_retains_nested_secondmate_home_when_grandchild_close_unconfirmed
 test_herdr_projection_teardown_retires_journal_only_after_confirmed_close
-test_herdr_projection_teardown_retains_journal_when_close_unconfirmed
+test_herdr_projection_teardown_retains_records_when_presence_unknown
+test_herdr_projection_teardown_reports_unconfirmed_close_loudly_for_retry
+test_herdr_projection_teardown_retires_journal_for_predead_pane
 test_squash_merged_branch_deleted_allows
 test_squash_merged_pr_allows_when_head_ancestor_of_pr_head
 test_no_pr_recorded_discovers_merged_pr_by_branch_allows

--- a/tests/fm-teardown.test.sh
+++ b/tests/fm-teardown.test.sh
@@ -1778,11 +1778,29 @@ SH
   chmod +x "$case_dir/fakebin/herdr"
 }
 
+write_bound_herdr_projection_journal() {  # <case-dir> [pane-id]
+  local case_dir=$1 pane_id=${2:-w1:p2} token=AbCdEfGhIjKlMnOpQrStUv
+  printf '%s\n' \
+    'version=2' \
+    'task_id=task-x1' \
+    "projection_id=$token" \
+    "home=$case_dir" \
+    'session=fmtest' \
+    'workspace_id=w1' \
+    'tab_id=w1:t2' \
+    "pane_id=$pane_id" \
+    'parent_workspace_id=w0' \
+    'parent_label=firstmate' \
+    "workspace_label=└ task-x1 · p:$token" \
+    'task_label=fm-task-x1' > "$case_dir/state/task-x1.herdr-presentation"
+}
+
 test_herdr_projection_teardown_retires_journal_only_after_confirmed_close() {
   local case_dir log closed restored
   case_dir=$(make_case herdr-projection-confirmed-close)
   write_meta "$case_dir" local-only ship
   configure_herdr_projection_teardown_case "$case_dir"
+  write_bound_herdr_projection_journal "$case_dir"
   log="$case_dir/herdr.log"; closed="$case_dir/closed"; restored="$case_dir/restored"; : > "$log"
 
   FM_FAKE_HERDR_LOG="$log" FM_FAKE_HERDR_CLOSED="$closed" FM_FAKE_HERDR_RESTORED="$restored" \
@@ -1862,6 +1880,7 @@ test_herdr_projection_teardown_retires_journal_for_predead_pane() {
   case_dir=$(make_case herdr-projection-predead-pane)
   write_meta "$case_dir" local-only ship
   configure_herdr_projection_teardown_case "$case_dir"
+  write_bound_herdr_projection_journal "$case_dir"
   log="$case_dir/herdr.log"; closed="$case_dir/closed"; restored="$case_dir/restored"; : > "$log"
   # The pane died before teardown ran: pane get reports pane_not_found and the
   # projected workspace is already gone from the workspace list. Retirement
@@ -1881,6 +1900,25 @@ test_herdr_projection_teardown_retires_journal_for_predead_pane() {
   assert_not_contains "$(cat "$log")" "pane close" \
     "herdr-projection-predead-pane: a close was attempted against an already-dead pane"
   pass "herdr projection teardown retires the journal when the pane is already dead"
+}
+
+test_herdr_projection_teardown_quarantines_mismatched_predead_journal() {
+  local case_dir log closed restored
+  case_dir=$(make_case herdr-projection-predead-mismatch)
+  write_meta "$case_dir" local-only ship
+  configure_herdr_projection_teardown_case "$case_dir"
+  write_bound_herdr_projection_journal "$case_dir" w1:p9
+  log="$case_dir/herdr.log"; closed="$case_dir/closed"; restored="$case_dir/restored"; : > "$log"
+  : > "$closed"
+
+  FM_FAKE_HERDR_LOG="$log" FM_FAKE_HERDR_CLOSED="$closed" FM_FAKE_HERDR_RESTORED="$restored" \
+    run_teardown "$case_dir" --force > "$case_dir/stdout" 2> "$case_dir/stderr" \
+    || fail "herdr-projection-predead-mismatch: forced teardown failed"
+  [ -e "$case_dir/state/task-x1.herdr-presentation" ] \
+    || fail "herdr-projection-predead-mismatch: mismatched journal was incorrectly retired"
+  assert_grep "remains quarantined" "$case_dir/stderr" \
+    "herdr-projection-predead-mismatch: mismatched journal was not reported quarantined"
+  pass "herdr projection teardown quarantines a mismatched pre-dead journal"
 }
 
 test_local_only_fork_remote_allows
@@ -1903,6 +1941,7 @@ test_herdr_projection_teardown_retires_journal_only_after_confirmed_close
 test_herdr_projection_teardown_retains_records_when_presence_unknown
 test_herdr_projection_teardown_reports_unconfirmed_close_loudly_for_retry
 test_herdr_projection_teardown_retires_journal_for_predead_pane
+test_herdr_projection_teardown_quarantines_mismatched_predead_journal
 test_squash_merged_branch_deleted_allows
 test_squash_merged_pr_allows_when_head_ancestor_of_pr_head
 test_no_pr_recorded_discovers_merged_pr_by_branch_allows


### PR DESCRIPTION
## Intent

Adopt the captain-approved 'done means a cleanup attempt' contract in firstmate's shared tracked material (captain ruling 2026-07-30 adopted all three fixes from the teardown-latency root-cause report; decision record at data/fm-teardown-latency-rootcause/captain-decision-adopt-fixes-2026-07-30.md). Fix 1: AGENTS.md section 7 gains one terse sentence making any terminal completion (done:/failed:/completed scout report) end with an unconditional bin/fm-teardown.sh attempt in the same handling turn, refusal parking the task with the reason as durable record - all existing refusal gates and never-discard language deliberately untouched. Fix 2 (upstream issue 1336): fm-spawn's abort cleanup writes state/<id>.meta (when normal publication never ran; Orca deliberately excepted because its abort cleanup already records meta exactly when the worktree survives for retry) and appends a failed: status line, so a spawn that fails after its pane may exist presents as an ordinary terminal state. Fix 3 (upstream issue 1337): fm-teardown treats a herdr presentation pane the backend already reports dead as confirmed-closed for journal retirement (previously the journal quarantined forever once herdr reaped the pane), and an unconfirmed close now exits 1 loudly before any state deletion so the handling turn retries, instead of silently tolerating it. The FM_SPAWN_WORKTREE_POLLS env override exists only to let tests exercise the settle-timeout path quickly; default 60 unchanged. tests/fm-backend-herdr-presentation-e2e.test.sh has ONE known failing assertion (workspace-ordering, stray '~' workspace in the local live Herdr 0.7.5 session) that reproduces byte-identically on the unmodified base tree; the captain has reviewed this evidence and accepted it as pre-existing and unrelated - it must be noted in the PR body, not 'fixed' by weakening the assertion.

## What Changed

- Require every terminal task outcome to attempt teardown in the same handling turn, preserving refusal reasons as durable parked state.
- Publish owned spawn failures as ordinary terminal state, make incomplete worktree records safely reapable, and retire stale failure status before same-ID retries without terminalizing live duplicates.
- Make Herdr teardown retire exactly bound journals for already-dead panes and preserve all task state when a close cannot be confirmed. The live Herdr 0.7.5 suite retains one pre-existing workspace-ordering failure caused by a stray `~` workspace; it reproduces byte-identically on the base commit and is unrelated to this change.

## Risk Assessment

✅ Low: The same-ID retry fix narrowly retires only a regular, single-line status-only spawn failure while preserving meta-backed and live-task records, and the accumulated change now conforms to the stated cleanup contract.

## Testing

Diff inspection, focused automated regressions, direct CLI/state demonstrations, endpoint safety checks, and the live Herdr 0.7.5 suite all validated the target behavior; the author-supplied base-only ordering failure did not reproduce on target, the worktree remained clean, and only the unavailable PR-body disclosure remains unverified.

<details>
<summary>Evidence: Failed spawn terminal-state and reap transcript</summary>

```text
COMMAND: FM_SPAWN_WORKTREE_POLLS=2 bin/fm-spawn.sh settle-evidence-z3 <project>
EXIT: 1
error: treehouse get did not enter a worktree within 2s; inspect window firstmate:fm-settle-evidence-z3

PERSISTED state/settle-evidence-z3.meta:
window=firstmate:fm-settle-evidence-z3
endpoint_task_id=settle-evidence-z3
worktree=
project=/var/folders/vx/kq2w6_xj1sq82jh1gtsjl0_m0000gn/T/fm-spawn-worktree-settle.N3IEfO/settle-evidence/project
harness=codex
kind=ship
mode=no-mistakes
yolo=off
tasktmp=/tmp/fm-settle-evidence-z3
model=default
effort=default

PERSISTED state/settle-evidence-z3.status:
failed: spawn failed before launch completed (exit 1); inspect endpoint firstmate:fm-settle-evidence-z3

COMMAND: bin/fm-teardown.sh settle-evidence-z3 --force
EXIT: 0
/var/folders/vx/kq2w6_xj1sq82jh1gtsjl0_m0000gn/T/fm-spawn-worktree-settle.N3IEfO/settle-evidence/project: skipped: no origin remote
teardown settle-evidence-z3 complete (window firstmate:fm-settle-evidence-z3, worktree )
Backlog: settle-evidence-z3 just finished. Run tasks-axi done settle-evidence-z3 --pr PR_URL, then run tasks-axi ready for dependency-cleared candidates, check date gates, and dispatch only work whose blockers are gone and date is due.
POSTCONDITION: terminal spawn state was reaped
```
</details>
<details>
<summary>Evidence: Herdr refusal, retry, and pre-dead pane transcript</summary>

```text
COMMAND: bin/fm-teardown.sh task-x1 --force (backend close refuses)
EXIT: 1
STDERR:
error: exact herdr task-pane close could not be confirmed for task-x1; the pane may still exist
retaining the presentation journal and all task state; retry bin/fm-teardown.sh task-x1 once the pane close can complete
STATE AFTER REFUSAL:
present  state/task-x1.meta
missing  state/task-x1.status
present  state/task-x1.herdr-presentation

COMMAND: bin/fm-teardown.sh task-x1 --force (retry after close succeeds)
EXIT: 0
teardown task-x1 complete (window fmtest:w1:p2, worktree /var/folders/vx/kq2w6_xj1sq82jh1gtsjl0_m0000gn/T//fm-teardown-tests.oUxUAH/herdr-evidence-unconfirmed/wt)
Backlog: task-x1 just finished. Run tasks-axi done task-x1 --note "local main", then run tasks-axi ready for dependency-cleared candidates, check date gates, and dispatch only work whose blockers are gone and date is due.
STATE AFTER RETRY:
missing  state/task-x1.meta
missing  state/task-x1.status
missing  state/task-x1.herdr-presentation

COMMAND: bin/fm-teardown.sh task-x1 --force (backend already reports pane dead)
EXIT: 0
teardown task-x1 complete (window fmtest:w1:p2, worktree /var/folders/vx/kq2w6_xj1sq82jh1gtsjl0_m0000gn/T//fm-teardown-tests.oUxUAH/herdr-evidence-predead/wt)
Backlog: task-x1 just finished. Run tasks-axi done task-x1 --note "local main", then run tasks-axi ready for dependency-cleared candidates, check date gates, and dispatch only work whose blockers are gone and date is due.
BACKEND CALLS: no pane close attempted for pre-dead pane
POSTCONDITION: pre-dead presentation journal retired
```
</details>
<details>
<summary>Evidence: Live Herdr 0.7.5 E2E results</summary>

```text
ok - real Herdr lab: flag-off spawn retains the Stage 1 Herdr command sequence with zero ordering calls
ok - real Herdr lab: every projected create, task-tab create, seeded prune, and move preserves active workspace and tab
warning: herdr presentation cleanup could not verify the exact pane; refusing focus-unsafe pane close
ok - real Herdr lab: active seeded-tab pruning refuses the exact pane and preserves exact focus
ok - real Herdr lab: bounded lock contention warns and falls back flat without projection or focus drift
ok - real Herdr lab: concurrent primary workers form one stable contiguous block without active workspace/tab drift
ok - real Herdr lab: forced workspace.move failure leaves a successful worker in default order with a warning and no cleanup
ok - real Herdr lab: concurrent post-create abort cleanup stays serialized with exact focus restoration
ok - real Herdr lab: Treehouse commands and metadata shape are byte-identical except for Herdr container IDs
ok - real Herdr lab: exact task-pane close restores the exact captain workspace/tab after Herdr's raw focus steal
ok - real Herdr lab: concurrent projected cleanup is serialized and leaves active workspace/tab unchanged
ok - real Herdr lab: three repeated concurrent create/order/cleanup waves have zero active workspace or tab drift
ok - real Herdr lab: primary presentation opt-in inherits into real secondmate homes
ok - real Herdr lab: primary and two secondmate homes each own a top-level contiguous child block
ok - real Herdr lab: concurrent primary/A/B spawns preserve parent order and exact focus
ok - real Herdr lab: session lock contention from a secondmate home falls back flat with no journal
ok - real Herdr lab: Hi Bit and Wheelhouse-style same-identity restarts reclaim one nested space with exact focus and idempotence
ok - real Herdr lab: secondmate restart binding and reclaim stay isolated to the exact child home and parent
ok - real Herdr lab: concurrent cross-home recoveries replace exact husks under one session lock with no focus drift
ok - real Herdr lab: legacy projection labels and flat secondmate tabs are left unmigrated
ok - real Herdr lab: multi-home exact-pane teardowns restore captain focus without workspace close authority
warning: no exact herdr presentation token match for missing1; leaving any stale space untouched and spawning flat
warning: no exact herdr presentation token match for renamed1; leaving any stale space untouched and spawning flat
warning: 2 exact herdr presentation token matches for duplicate1 are quarantined; inspecting only for duplicate-agent risk
warning: quarantined herdr presentation for duplicate1 is dead or agent-free; exact bound reclaim may proceed, otherwise spawning flat
warning: 2 exact herdr presentation token matches for duplicate1 are quarantined; inspecting only for duplicate-agent risk
error: quarantined herdr presentation for duplicate1 has a live pane; refusing duplicate launch
ok - real Herdr lab: missing, renamed, and duplicate tokens trigger zero destructive or adoptive calls, and live duplicate risk refuses launch
ok - real Herdr lab validation completed on Herdr 0.7.5 with the default-session tripwire intact
```
</details>
<details>
<summary>Evidence: AGENTS done-cleanup contract diff</summary>

```text
diff --git a/AGENTS.md b/AGENTS.md
index 199d914..b691b72 100644
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -326,12 +326,13 @@ For PR-based ship tasks, the ready signal depends on mode: `no-mistakes` reports
 Run `bin/fm-pr-check.sh <id> <PR url>` - it records `pr=` and the forge's `pr_head=` when available in the task's meta and arms the watcher's merge poll.
 Tell the captain the PR's full URL, always the complete `https://...` link rather than a bare `#number`, a concise outcome summary, and the no-mistakes risk level when applicable.
 A captain instruction to merge is explicit authority; `yolo` is the only standing routine authority.
 For any custom `state/<id>.check.sh` you write yourself, keep it an ordinary single-link mode-`0700` file, print one line only when firstmate should wake, print nothing otherwise, finish before `FM_CHECK_TIMEOUT`, then bind its current bytes with `bin/fm-check-register.sh <id>` before the watcher may execute it.
 
 Tear down a ship task only after landing is confirmed.
+Handling any terminal completion (`done:`, `failed:`, or a completed scout report) ends with an unconditional `bin/fm-teardown.sh <id>` attempt in that same handling turn; teardown's fail-closed gates decide readiness, and a refusal parks the task with the refusal reason as the durable record of what it waits on.
 A teardown refusal for uncommitted or unlanded work is a stop-and-investigate result, never an obstacle to bypass.
 Never force teardown without explicit discard authority.
 After successful teardown, record completion, retain only the configured recent Done history, and re-evaluate queued work whose blockers and time gates have cleared.
 
 A secondmate is persistent and an empty queue is healthy.
 Retire one only on an explicit captain or main-firstmate decision, after loading `secondmate-provisioning`; its home must contain no work under way, and forced discard still requires explicit captain authority.
```
</details>
<details>
<summary>Evidence: Spawn worktree-settle regression results</summary>

```text
ok - a single transient stale pane_current_path read is not accepted as the worktree
ok - an already-settled pane confirms via the existing inter-poll sleep, not an extra full cycle
ok - a failed spawn leaves ordinary terminal state that forced teardown can reap (upstream issue 1336)
ok - a backend helper failure after partial creation leaves terminal state
ok - a status-only failure is retired before deliberate same-id reuse
ok - a duplicate spawn cannot terminalize an existing live task
# all fm-spawn-worktree-settle tests passed
```
</details>
<details>
<summary>Evidence: Teardown regression results</summary>

```text
ok - local-only worktree with HEAD on a fork remote is torn down (fix holds)
ok - teardown prompts tasks-axi backlog refresh when compatible
ok - teardown honors config/backlog-backend=manual even when tasks-axi is compatible
ok - local-only worktree with truly unpushed work is refused (safety preserved)
ok - local-only worktree with work merged into local main is torn down (no regression)
ok - no-mistakes worktree with HEAD on origin is torn down (no regression)
ok - no-mistakes worktree with genuinely unlanded work is refused (safety preserved)
ok - local-only worktree with unpushed work is torn down under --force (escape hatch)
ok - teardown completes when an exact busy-state sidecar is already absent
ok - herdr teardown removes pane-owned escalation dedupe state
ok - herdr projection teardown retires its journal only after confirming the exact recorded pane is gone
ok - herdr projection teardown reports an unconfirmed close loudly, keeps state, and converges on retry
ok - herdr projection teardown retires the journal when the pane is already dead
ok - herdr projection teardown quarantines a mismatched pre-dead journal
ok - squash-merged + deleted-branch worktree (PR merged) is torn down (the fix)
ok - squash-merged PR accepts a local HEAD that is an ancestor of the final PR head
ok - teardown discovers a merged PR by branch name and tears down when no pr= was ever recorded
ok - squash-merged PR accepts replayed unpushed local patches contained in the PR head
ok - merged PR does not allow teardown after a later local commit
ok - fm-pr-check does not refresh PR head after HEAD moves
ok - fm-pr-check records the remote PR head when the local worktree lags
ok - worktree whose content already landed in the default branch is torn down (content fallback)
ok - content fallback refreshes origin default before comparing trees
ok - dirty worktree is refused even when its committed work has landed (dirty always wins)
ok - gh lookup error with content not in default refuses (fail-safe)
ok - provably-stale worktree index.lock (old, no live holder) is cleared and teardown succeeds
ok - live-held worktree index.lock is never removed and teardown refuses
ok - lsof errors leave worktree index.lock in place and refuse teardown
ok - stale lock cleanup rechecks and refuses dirty worktree before return
ok - normal repo index.lock is resolved from the worktree and cleared when stale
ok - lock mtime read failures leave worktree index.lock in place and refuse teardown
ok - transient index.lock cleared after first failed return is retried successfully without force-remove
ok - persistent index.lock exhausts retries and refuses without force-removing the lock
ok - empty retry wait overrides use the default without aborting teardown
ok - fractional legacy retry wait remains supported without arithmetic
```
</details>
<details>
<summary>Evidence: Orca abort-cleanup regression results</summary>

```text
ok - fm_backend_orca_capture: parses result.terminal.tail and calls terminal read
ok - fm_backend_orca_capture: falls back to result text fields
ok - fm_backend_orca_capture: fails closed on Orca read error JSON
ok - fm_backend_orca_runtime_check: accepts reachable ready runtime
ok - fm_backend_orca_runtime_check: fails closed when runtime is not ready
ok - fm_backend_orca_send_text_submit: verifies empty composer after Enter
ok - fm_backend_orca_send_text_submit: preserves current tail when limited reads fetch older cursor text
ok - fm_backend_orca_send_text_submit: retries Enter while composer remains pending
ok - fm_backend_orca_composer_state: a slash-command popup's argument-hint placeholder still reads pending
ok - fm_backend_orca_composer_state: a bare dead-shell prompt reads unknown (unsafe-for-injection), never empty
ok - fm_backend_orca_send_text_submit: a slash-command popup's placeholder fill on Enter #1 does not short-circuit as submitted; Enter #2 is retried and lands it
ok - fm_backend_orca_send_literal: sends text without submitting
ok - fm_backend_orca_send_text_submit: reports send-failed when Orca send fails
ok - Orca send helpers: fail closed on ok:false JSON
ok - fm_backend_orca_send_key: Enter maps to empty enter, C-c maps to interrupt
ok - fm_backend_orca_send_key: refuses unsupported keys loudly
ok - fm_backend_orca_send_key: refuses Escape instead of mapping it to interrupt
ok - fm_backend_orca_kill: calls terminal close and stays best-effort
ok - fm_backend_orca_remove_worktree: refuses empty worktree ids
ok - fm_backend_orca_remove_worktree: fails closed on ok:false JSON
ok - fm_backend_orca_worktree_path: resolves an Orca worktree id to its path
ok - fm-backend dispatcher: accepts orca and routes capture through bin/backends/orca.sh
ok - fm_backend_orca_json_get: ignores undocumented terminal id shapes
ok - Orca lifecycle helpers: register repo, create worktree, create terminal, parse stable ids
ok - fm_backend_orca_worktree_create: removes created worktree when path is missing
ok - fm-spawn.sh --backend orca: preserves metadata when pathless cleanup fails
ok - fm-spawn.sh --backend orca: reuses implicit terminal, records metadata, launches harness
ok - fm-spawn.sh --backend orca --secondmate: refuses before secondmate-home mutation
ok - fm-spawn.sh --backend orca: refuses before mutation when Orca runtime is not ready
ok - fm-spawn.sh --backend orca: refuses non-isolated worktrees and closes implicit terminals
ok - fm-spawn.sh --backend orca: removes worktree when terminal creation fails
ok - fm-spawn.sh --backend orca: preserves metadata when abort cleanup fails
ok - fm-spawn.sh --backend orca: releases terminal and worktree on later aborts
ok - fm-peek/fm-send/fm-crew-state route through backend=orca metadata
ok - fm-peek/fm-crew-state: Orca read error JSON fails closed
ok - fm_backend_target_exists: Orca ok:false read JSON is not live
ok - fm-teardown.sh backend=orca: scout report gate then helper-backed worktree removal
ok - fm-teardown.sh backend=orca: scout teardown refuses id/path mismatches
ok - fm-teardown.sh backend=orca: releases terminal/worktree when path is absent
ok - fm-teardown.sh backend=orca: preserves metadata on remove ok:false JSON
ok - fm-teardown.sh backend=orca: scout report gate precedes pathless helper cleanup
ok - fm-teardown.sh backend=orca: ship teardown fails closed when worktree path is missing
ok - fm-teardown.sh backend=orca: ship teardown requires a matching Orca id path
ok - fm-teardown.sh backend=orca: ship teardown fails closed when id resolution fails
ok - fm-teardown.sh backend=orca: ship teardown refuses id/path mismatches
ok - fm-teardown.sh backend=orca: refuses missing worktree ids before cleanup
ok - fm-teardown.sh backend=orca: refuses incomplete worktree-only endpoint metadata before runtime dispatch
ok - fm-teardown.sh --force: removes Orca secondmate children through Orca
ok - fm-teardown.sh --force: refuses Orca child id/path mismatches
ok - fm-teardown.sh --force: refuses partial Orca secondmate children before runtime dispatch
```
</details>
<details>
<summary>Evidence: Endpoint safety regression results</summary>

```text
ok - fm-teardown: missing, empty, malformed, ambiguous, and task-mismatched endpoints refuse before every mutation or runtime call
ok - cleanup identity: valid tmux, Herdr, Zellij, Orca, and cmux records validate while every empty backend target refuses
ok - tmux backend: direct empty target returns nonzero without invoking tmux
ok - process cleanup: creation-time PID identity removes only the exact child and preserves the control child
ok - fm-teardown: exact tmux cleanup preserves invalid and prefix-matched neighbors while removing only the recorded target
```
</details>
- Outcome: ⚠️ 1 warning across 1 run (12m29s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 3 issues found → auto-fixed (4) ✅</summary>

- 🚨 `bin/fm-spawn.sh:1267` - Required intent says a spawn failing after its pane may exist must become an ordinary terminal state. The new flag is enabled only after the entire backend-creation case, but Zellij, Herdr, cmux, and Orca helpers can create an endpoint and then fail while resolving IDs or verification. Those exits leave the flag unset, so abort cleanup still publishes neither usable metadata nor a failed status. Move endpoint ownership/state publication into each backend path as soon as creation may have occurred, including Orca&#39;s surviving-worktree failure path.
- 🚨 `bin/fm-spawn.sh:365` - Required intent says failed-spawn metadata must present through the ordinary terminal-state reap path. On the tested settle-timeout path WT is still empty, so this writes `worktree=`. `fm_backend_validate_task_endpoint` rejects empty worktree metadata before teardown performs any cleanup, even with `--force`, permanently parking the task and pane. Introduce a teardown-valid representation for a failed spawn that acquired no worktree, and test the actual teardown path rather than only file existence.
- 🚨 `bin/fm-teardown.sh:1303` - The pre-dead branch retires the journal solely from task metadata and pane death, without validating that the journal is a regular, well-formed version-2 binding matching the recorded session/workspace/tab/pane. A malformed, version-1, or mismatched quarantined journal is therefore deleted despite the stated invariant that unmatched journals remain quarantined, potentially losing the only record of another live projection. Validate the journal&#39;s static binding against metadata before setting the pre-dead flag; live workspace-token lookup can remain skipped.

🔧 Fix: Make failed spawns reapable and validate Herdr journals
2 errors still open:
- 🚨 `bin/fm-spawn.sh:480` - Arming abort publication immediately after acquiring the task lock makes every later failure append `failed:` whenever any meta file already exists. A duplicate spawn of a live task reaches the backend&#39;s duplicate-endpoint refusal, preserves the live task&#39;s meta, then falsely marks that live task terminal. Track whether this invocation created the abort meta (or Orca preserved its worktree) and append status only for that owned record.
- 🚨 `bin/fm-spawn.sh:362` - Required intent says the failed spawn must present as an ordinary terminal state handled by the reap path. Because publication is now armed before project, harness, window, or backend endpoint fields exist, failures such as a missing project or brief write empty `window=`/`project=` and, for non-tmux backends, empty required IDs. Forced teardown only relaxes `worktree=`, so endpoint validation permanently refuses these new stubs. Either define a safely reapable pre-endpoint stub or delay publication until teardown-required identity is available while preserving the captain&#39;s failure-record requirement.

🔧 Fix: Prevent duplicate spawn terminalization and invalid failure metadata
2 errors still open:
- 🚨 `bin/fm-spawn.sh:397` - The required contract excepts Orca only from abort meta publication, not from appending `failed:`. This status-only fallback explicitly excludes Orca, so an Orca failure before worktree creation or after successful abort cleanup leaves neither meta nor status despite owning a fresh task ID. Remove the backend exclusion while retaining the existing-meta ownership guard.
- 🚨 `bin/fm-spawn.sh:1224` - The required contract says a failure after its pane may exist must present as an ordinary terminal state. Herdr, Zellij, and cmux set metadata readiness only after their create helpers return complete IDs, but those helpers can create a tab/workspace and then fail parsing or resolving the pane/surface. Abort then writes status without meta and cannot reap the orphan endpoint. Have each helper expose teardown identity or clean up internally before returning failure.

🔧 Fix: Report cleaned Orca spawn failures as terminal
1 error still open:
- 🚨 `bin/fm-spawn.sh:487` - Absence of `.meta` is treated as a fresh task ID even when the new status-only `failed:` record already exists. A corrected same-ID retry can therefore succeed and publish live metadata while retaining the old terminal line; session restore and `stale_is_terminal` can then present the live retry as failed, while another failed retry cannot record its new reason because cleanup rejects any existing `failed:` line. Retire or rotate the recognized status-only spawn failure before reuse, or explicitly refuse reuse with a recovery path.

🔧 Fix: Retire stale spawn failures before same-ID retry
✅ Re-checked - no issues remain.

</details>

<details>
<summary>⚠️ **Test** - 1 warning</summary>

- ⚠️ No PR currently exists for `fm/fm-done-cleanup-contract`, so the required PR-body disclosure of the known base-only Herdr workspace-ordering assertion could not be verified. Add that note when the PR is created, then recheck the body.
- <code>`git diff --stat 9fdef649450a35d46f3e539a9bede5cc60f3783c..f5c6e41bd06b825e5d0dea9602e7f62773de7fca` and focused implementation diff inspection</code>
- `tests/fm-spawn-worktree-settle.test.sh`
- `tests/fm-teardown.test.sh`
- `tests/fm-backend-orca.test.sh`
- `tests/fm-teardown-endpoint-safety.test.sh`
- <code>`tests/fm-backend-herdr-presentation-e2e.test.sh` against live Herdr 0.7.5</code>
- <code>Manual `FM_SPAWN_WORKTREE_POLLS=2 bin/fm-spawn.sh settle-evidence-z3 &lt;project&gt;` failure, persisted-state inspection, and `bin/fm-teardown.sh settle-evidence-z3 --force` reap</code>
- <code>Manual `bin/fm-teardown.sh task-x1 --force` checks for Herdr close refusal, successful retry, and pre-dead pane retirement</code>
- `git diff --numstat 9fdef649450a35d46f3e539a9bede5cc60f3783c..f5c6e41bd06b825e5d0dea9602e7f62773de7fca -- AGENTS.md`
- `gh-axi pr list --head fm/fm-done-cleanup-contract`
- `git status --short`

</details>

<details>
<summary>⚠️ **Document** - 1 warning</summary>

- ⚠️ `tests/fm-backend-herdr-presentation-e2e.test.sh:695` - No PR exists for this branch, so the required PR-body note about the accepted pre-existing Herdr workspace-ordering failure remains to be added when the PR is opened.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
