### PR TITLE
fix(fm-spawn): forward Anthropic API env vars to crewmate panes for Pioneer/TokenRouter lanes

### DIFF
--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1667,12 +1667,27 @@ LAUNCH=${LAUNCH//__PITURNEND__/$sq_piturnend}
 LAUNCH=${LAUNCH//__PIWATCH__/$sq_piwatch}
 LAUNCH=${LAUNCH//__OPINPUT__/$sq_opinput}
 # Crewmate panes are created by a long-lived tmux/herdr daemon that does not
-# inherit firstmate's current environment, so a bare `claude` in the pane falls
-# back to the default ~/.claude store even when firstmate itself runs under a
-# different CLAUDE_CONFIG_DIR (for example a work-vs-personal subscription split).
-# Forward firstmate's own resolved store onto the claude launch so the crewmate
-# uses the same credential/config firstmate is authenticated with. Only when set;
-# an unset value is the single-store default and needs no prefix.
+# inherit firstmate's current environment, so a bare agent in the pane falls
+# back to default credentials even when firstmate itself runs under a
+# different API key, base URL, or config directory. Forward firstmate's own
+# resolved environment onto the launch so the crewmate authenticates against
+# the same provider (Pioneer/TokenRouter lanes).  Only when set; an unset
+# value is the default and needs no prefix.
+if [ -n "${ANTHROPIC_API_KEY:-}" ]; then
+  LAUNCH="ANTHROPIC_API_KEY=$(shell_quote "$ANTHROPIC_API_KEY") $LAUNCH"
+fi
+if [ -n "${ANTHROPIC_BASE_URL:-}" ]; then
+  LAUNCH="ANTHROPIC_BASE_URL=$(shell_quote "$ANTHROPIC_BASE_URL") $LAUNCH"
+fi
+if [ -n "${ANTHROPIC_DEFAULT_OPUS_MODEL:-}" ]; then
+  LAUNCH="ANTHROPIC_DEFAULT_OPUS_MODEL=$(shell_quote "$ANTHROPIC_DEFAULT_OPUS_MODEL") $LAUNCH"
+fi
+if [ -n "${ANTHROPIC_DEFAULT_SONNET_MODEL:-}" ]; then
+  LAUNCH="ANTHROPIC_DEFAULT_SONNET_MODEL=$(shell_quote "$ANTHROPIC_DEFAULT_SONNET_MODEL") $LAUNCH"
+fi
+if [ -n "${ANTHROPIC_DEFAULT_HAIKU_MODEL:-}" ]; then
+  LAUNCH="ANTHROPIC_DEFAULT_HAIKU_MODEL=$(shell_quote "$ANTHROPIC_DEFAULT_HAIKU_MODEL") $LAUNCH"
+fi
 if [ "$HARNESS" = claude ] && [ -n "${CLAUDE_CONFIG_DIR:-}" ]; then
   LAUNCH="CLAUDE_CONFIG_DIR=$(shell_quote "$CLAUDE_CONFIG_DIR") $LAUNCH"
 fi

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -88,11 +88,14 @@ run_spawn() {
   # explicitly (empty by default) instead of leaking the invoking shell's value,
   # which would make launch assertions depend on the developer's environment.
   # A test opts in to the set case via FM_TEST_CLAUDE_CONFIG_DIR.
+  # Same for Anthropic API env vars forwarded by fm-spawn for Pioneer/TokenRouter lanes.
   FM_ROOT_OVERRIDE='' FM_HOME="$home" \
     FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
     FM_PROJECTS_OVERRIDE="$home/projects" FM_CONFIG_OVERRIDE="$home/config" \
     FM_SPAWN_NO_GUARD=1 FM_FAKE_PANE_PATH="$wt" TMUX="fake,1,0" \
     CLAUDE_CONFIG_DIR="${FM_TEST_CLAUDE_CONFIG_DIR:-}" \
+    ANTHROPIC_API_KEY='' ANTHROPIC_BASE_URL='' \
+    ANTHROPIC_DEFAULT_OPUS_MODEL='' ANTHROPIC_DEFAULT_SONNET_MODEL='' ANTHROPIC_DEFAULT_HAIKU_MODEL='' \
     FM_FAKE_LAUNCH_LOG="$launchlog" GROK_HOME="$home/grok-home" PATH="$fakebin:$PATH" \
     "$SPAWN" "$@" 2>&1
 }

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -652,6 +652,92 @@ test_non_claude_harness_ignores_config_dir() {
   pass "non-claude harnesses do not receive the claude CLAUDE_CONFIG_DIR prefix"
 }
 
+# --- ANTHROPIC_* env var forwarding (Pioneer/TokenRouter lanes) ---------------
+
+test_claude_forwards_anthropic_env_vars_when_set() {
+  local rec id out status launch
+  id=profile-anthropic-env-z20
+  rec=$(make_spawn_case profile-anthropic-env claude "$id")
+  read_case_record "$rec"
+
+  # Run spawn directly (not through run_spawn which pins env vars to empty)
+  # to verify that ANTHROPIC_* env vars are forwarded to the launch command.
+  : > "$LAUNCH_LOG"
+  out=$(FM_ROOT_OVERRIDE='' FM_HOME="$HOME_DIR" \
+    FM_STATE_OVERRIDE="$HOME_DIR/state" FM_DATA_OVERRIDE="$HOME_DIR/data" \
+    FM_PROJECTS_OVERRIDE="$HOME_DIR/projects" FM_CONFIG_OVERRIDE="$HOME_DIR/config" \
+    FM_SPAWN_NO_GUARD=1 FM_FAKE_PANE_PATH="$WT_DIR" TMUX="fake,1,0" \
+    ANTHROPIC_API_KEY="sk-test-key-12345" \
+    ANTHROPIC_BASE_URL="https://test.anthropic.example.com" \
+    ANTHROPIC_DEFAULT_OPUS_MODEL="claude-3-opus-20240229" \
+    ANTHROPIC_DEFAULT_SONNET_MODEL="claude-3-sonnet-20240229" \
+    ANTHROPIC_DEFAULT_HAIKU_MODEL="claude-3-haiku-20240307" \
+    FM_FAKE_LAUNCH_LOG="$LAUNCH_LOG" PATH="$FAKEBIN_DIR:$PATH" \
+    "$SPAWN" "$id" "$PROJ_DIR" 2>&1)
+  status=$?
+  expect_code 0 "$status" "claude spawn with ANTHROPIC_* env vars set should succeed"
+  launch=$(cat "$LAUNCH_LOG")
+  assert_contains "$launch" "ANTHROPIC_API_KEY='sk-test-key-12345'" \
+    "claude launch did not forward ANTHROPIC_API_KEY"
+  assert_contains "$launch" "ANTHROPIC_BASE_URL='https://test.anthropic.example.com'" \
+    "claude launch did not forward ANTHROPIC_BASE_URL"
+  assert_contains "$launch" "ANTHROPIC_DEFAULT_OPUS_MODEL='claude-3-opus-20240229'" \
+    "claude launch did not forward ANTHROPIC_DEFAULT_OPUS_MODEL"
+  assert_contains "$launch" "ANTHROPIC_DEFAULT_SONNET_MODEL='claude-3-sonnet-20240229'" \
+    "claude launch did not forward ANTHROPIC_DEFAULT_SONNET_MODEL"
+  assert_contains "$launch" "ANTHROPIC_DEFAULT_HAIKU_MODEL='claude-3-haiku-20240307'" \
+    "claude launch did not forward ANTHROPIC_DEFAULT_HAIKU_MODEL"
+  pass "claude forwards firstmate's ANTHROPIC_* env vars so the crewmate authenticates against the same provider"
+}
+
+test_claude_omits_anthropic_env_vars_when_unset() {
+  local rec id out status launch
+  id=profile-no-anthropic-env-z21
+  rec=$(make_spawn_case profile-no-anthropic-env claude "$id")
+  read_case_record "$rec"
+
+  # run_spawn pins ANTHROPIC_* vars empty by default, exercising the default
+  # path where fm-spawn adds no prefix.
+  out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR")
+  status=$?
+  expect_code 0 "$status" "claude spawn without ANTHROPIC_* env vars should succeed"
+  launch=$(cat "$LAUNCH_LOG")
+  assert_not_contains "$launch" "ANTHROPIC_API_KEY=" \
+    "claude launch must not add API key prefix when firstmate has no ANTHROPIC_API_KEY set"
+  assert_not_contains "$launch" "ANTHROPIC_BASE_URL=" \
+    "claude launch must not add base URL prefix when firstmate has no ANTHROPIC_BASE_URL set"
+  assert_not_contains "$launch" "ANTHROPIC_DEFAULT_OPUS_MODEL=" \
+    "claude launch must not add model prefix when firstmate has no ANTHROPIC_DEFAULT_OPUS_MODEL set"
+  pass "claude omits the ANTHROPIC_* env prefix when firstmate runs with default credentials"
+}
+
+test_anthropic_env_vars_forwarded_for_all_harnesses() {
+  local rec id out status launch
+  id=profile-anthropic-all-harness-z22
+  rec=$(make_spawn_case profile-anthropic-all-harness codex "$id")
+  read_case_record "$rec"
+
+  # ANTHROPIC_* env vars are forwarded for ALL harnesses (not just claude),
+  # since they authenticate the provider, not the agent tool.
+  : > "$LAUNCH_LOG"
+  out=$(FM_ROOT_OVERRIDE='' FM_HOME="$HOME_DIR" \
+    FM_STATE_OVERRIDE="$HOME_DIR/state" FM_DATA_OVERRIDE="$HOME_DIR/data" \
+    FM_PROJECTS_OVERRIDE="$HOME_DIR/projects" FM_CONFIG_OVERRIDE="$HOME_DIR/config" \
+    FM_SPAWN_NO_GUARD=1 FM_FAKE_PANE_PATH="$WT_DIR" TMUX="fake,1,0" \
+    ANTHROPIC_API_KEY="sk-test-key-99999" \
+    ANTHROPIC_BASE_URL="https://test.anthropic.example.com" \
+    FM_FAKE_LAUNCH_LOG="$LAUNCH_LOG" PATH="$FAKEBIN_DIR:$PATH" \
+    "$SPAWN" "$id" "$PROJ_DIR" --model gpt-5 --effort high 2>&1)
+  status=$?
+  expect_code 0 "$status" "codex spawn with ANTHROPIC_* env vars set should succeed"
+  launch=$(cat "$LAUNCH_LOG")
+  assert_contains "$launch" "ANTHROPIC_API_KEY='sk-test-key-99999'" \
+    "codex launch did not forward ANTHROPIC_API_KEY"
+  assert_contains "$launch" "ANTHROPIC_BASE_URL='https://test.anthropic.example.com'" \
+    "codex launch did not forward ANTHROPIC_BASE_URL"
+  pass "ANTHROPIC_* env vars are forwarded for all harnesses, not just claude"
+}
+
 test_active_dispatch_profile_does_not_block_secondmate_launch() {
   local rec id sm out status
   id=profile-secondmate-z16
@@ -696,5 +782,8 @@ test_claude_forwards_firstmate_config_dir_when_set
 test_claude_omits_config_dir_prefix_when_unset
 test_non_claude_harness_ignores_config_dir
 test_active_dispatch_profile_does_not_block_secondmate_launch
+test_claude_forwards_anthropic_env_vars_when_set
+test_claude_omits_anthropic_env_vars_when_unset
+test_anthropic_env_vars_forwarded_for_all_harnesses
 
 echo "# all fm-spawn-dispatch-profile tests passed"


### PR DESCRIPTION
## Intent

Forward ANTHROPIC_API_KEY, ANTHROPIC_BASE_URL, and model discovery env vars (ANTHROPIC_DEFAULT_OPUS_MODEL, ANTHROPIC_DEFAULT_SONNET_MODEL, ANTHROPIC_DEFAULT_HAIKU_MODEL) from firstmate's environment into the crewmate launch command in bin/fm-spawn.sh, so crewmates authenticate against the correct provider for Pioneer/TokenRouter lanes. The existing CLAUDE_CONFIG_DIR forwarding for the claude harness is preserved unchanged.

## What Changed

- **`bin/fm-spawn.sh`**: Forward `ANTHROPIC_API_KEY`, `ANTHROPIC_BASE_URL`, `ANTHROPIC_DEFAULT_OPUS_MODEL`, `ANTHROPIC_DEFAULT_SONNET_MODEL`, and `ANTHROPIC_DEFAULT_HAIKU_MODEL` from firstmate's environment into the crewmate launch command, so crewmates authenticate against the correct provider for Pioneer/TokenRouter lanes. Only prepended when the corresponding env var is set; unset values are skipped. The existing `CLAUDE_CONFIG_DIR` forwarding for the claude harness is preserved unchanged.
- **`tests/fm-spawn-dispatch-profile.test.sh`**: Pin all five `ANTHROPIC_*` env vars to empty in `run_spawn()` to prevent env-leak flakiness from the developer's shell. Add three new tests covering the forwarding behavior: when vars are set (all harnesses), when vars are unset (no prefix emitted), and verification that forwarding applies to all harnesses, not only claude.

## Risk Assessment

✅ Low: Change is well-bounded, follows existing patterns, has good test coverage, and fully conforms to the stated user intent.

## Testing

Ran the full fm-spawn-dispatch-profile test suite (28 tests). All passed, including the 3 new tests for ANTHROPIC_* env var forwarding (set, unset, and all-harnesses cases) and the 3 existing CLAUDE_CONFIG_DIR tests confirming the existing behavior is preserved. The evidence file is at /var/folders/sj/b3pb98ls4mx03dx50srzyq380000gn/T/no-mistakes-evidence/01KYX34J92A4GH76FWE1M1HTAB/fm-spawn-dispatch-profile-test-output.txt.

<details>
<summary>Evidence: Full test suite run</summary>

```text
ok - no --model/--effort records defaults and types the claude launch instructions
ok - relative home overrides ignore CDPATH and become absolute before spawn launch construction
ok - FM_HOME defaults resolve relative paths and preserve absolute spellings
ok - absolute override spellings are preserved in spawn launch paths
ok - unresolvable relative spawn overrides fail with named diagnostics
ok - active crew-dispatch profile requires an explicit harness for ship spawns
ok - active crew-dispatch profile requires an explicit harness for scout spawns
ok - active crew-dispatch profile allows an explicit resolved harness
ok - active crew-dispatch profile allows the legacy positional harness form
ok - active crew-dispatch profile allows the raw launch-command escape hatch
ok - claude receives --model and --effort profile flags
ok - codex receives --model and model_reasoning_effort profile flags
ok - codex omits unsupported max effort instead of passing a bad config value
ok - grok receives --model and --reasoning-effort profile flags
ok - grok omits unsupported max reasoning effort
ok - grok omits unsupported xhigh reasoning effort
ok - opencode receives --model and omits the unsupported effort axis
ok - pi receives --model and --thinking max profile flags
ok - pi-signed shares Pi launch semantics while preserving its configured and recorded identity
ok - pi-signed refuses safely and actionably when the selected executable is unavailable
ok - pi-signed is a distinct persistent secondmate runtime with shared Pi supervision semantics
ok - batch dispatch forwards shared --harness, --model, and --effort to every pair
ok - claude forwards firstmate's CLAUDE_CONFIG_DIR so the crewmate uses the same credential store
ok - claude omits the config-dir prefix when firstmate runs with the single-store default
ok - non-claude harnesses do not receive the claude CLAUDE_CONFIG_DIR prefix
ok - active crew-dispatch profile does not block secondmate launches
ok - claude forwards firstmate's ANTHROPIC_* env vars so the crewmate authenticates against the same provider
ok - claude omits the ANTHROPIC_* env prefix when firstmate runs with default credentials
ok - ANTHROPIC_* env vars are forwarded for all harnesses, not just claude
# all fm-spawn-dispatch-profile tests passed
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bash tests/fm-spawn-dispatch-profile.test.sh`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
