### PR TITLE
fix: launch codex crews at max effort

### DIFF
--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -127,6 +127,12 @@ The supported launch-profile flags below are verified locally; each row records 
 | opencode | `--model <provider/model>` | none for firstmate's interactive launch | Verified on opencode 1.17.6. `opencode run` has `--variant`, but firstmate launches the interactive `opencode --prompt` path, which has no verified effort flag. |
 | kimi | `--model <model>` | none | Verified 2026-07-25 on Kimi Code CLI 0.29.1. |
 
+Codex's `max` is model-scoped in codex-cli 0.145.0: the bundled catalog advertises it for `gpt-5.6-sol`, `gpt-5.6-terra`, and `gpt-5.6-luna`, while `gpt-5.5`, `gpt-5.4`, `gpt-5.4-mini`, `gpt-5.2`, and `codex-auto-review` cap at `xhigh`.
+Firstmate accepting `max` harness-wide for codex is therefore a deliberate decision, not a claim that every codex model supports it.
+Codex 0.145.0 also parses `model_reasoning_effort` as a free-form string at config load, unlike `approval_policy` and `sandbox_mode`, which reject an unknown value with `unknown variant`.
+So an unsupported model paired with `max` is accepted silently and its effective effort is undefined rather than loud.
+Pinning `max` on a model outside the `gpt-5.6` family is unvalidated.
+
 The concrete `harness` field owns adapter identity independently of the model provider: `harness=pi` with `model=xai/grok-*` is Pi using xAI, not `harness=grok`, and does not require Grok CLI login; `harness=grok` remains the standalone Grok Build CLI adapter.
 
 ### Model support discovery

--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -127,7 +127,9 @@ The supported launch-profile flags below are verified locally; each row records 
 | opencode | `--model <provider/model>` | none for firstmate's interactive launch | Verified on opencode 1.17.6. `opencode run` has `--variant`, but firstmate launches the interactive `opencode --prompt` path, which has no verified effort flag. |
 | kimi | `--model <model>` | none | Verified 2026-07-25 on Kimi Code CLI 0.29.1. |
 
-Codex's `max` is model-scoped in codex-cli 0.145.0: the bundled catalog advertises it for `gpt-5.6-sol`, `gpt-5.6-terra`, and `gpt-5.6-luna`, while `gpt-5.5`, `gpt-5.4`, `gpt-5.4-mini`, `gpt-5.2`, and `codex-auto-review` cap at `xhigh`.
+Codex's `max` is model-scoped in codex-cli 0.145.0: it is carried by `gpt-5.6-sol`, `gpt-5.6-terra`, and `gpt-5.6-luna`, and every other model in both catalogs caps at `xhigh`.
+Re-check that scoping with `codex debug models --bundled` for the static compiled catalog and `codex debug models` for the account's effective list.
+The two catalogs agree on the `max`-carrying models but differ in which older models they carry, so a bare model list from either one must not be trusted as the single catalog.
 Firstmate accepting `max` harness-wide for codex is therefore a deliberate decision, not a claim that every codex model supports it.
 Codex 0.145.0 also parses `model_reasoning_effort` as a free-form string at config load, unlike `approval_policy` and `sandbox_mode`, which reject an unknown value with `unknown variant`.
 So an unsupported model paired with `max` is accepted silently and its effective effort is undefined rather than loud.

--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -121,7 +121,7 @@ The supported launch-profile flags below are verified locally; each row records 
 | Harness | Model flag | Effort flag | Notes |
 |---|---|---|---|
 | claude | `--model <model>` | `--effort <low\|medium\|high\|xhigh\|max>` | Verified on Claude Code 2.1.196. |
-| codex | `--model <model>` | `-c 'model_reasoning_effort="<low\|medium\|high\|xhigh>"'` | Verified on codex-cli 0.142.1. The installed binary schema contains `model_reasoning_effort`, the active config uses it, and the bundled model catalog advertises only low/medium/high/xhigh. `max` is omitted. |
+| codex | `--model <model>` | `-c 'model_reasoning_effort="<low\|medium\|high\|xhigh\|max>"'` | Verified 2026-07-30 on codex-cli 0.145.0. The bundled model catalog advertises `max` for `gpt-5.6-sol`; Firstmate's shared effort vocabulary ends at `max`. |
 | grok | `--model <model>` | `--reasoning-effort <low\|medium\|high>` | Verified on grok 0.2.99 (2026-07-13). `--effort` is an alias, but firstmate's profile axis is reasoning effort. As of 0.2.99 the ceiling is `high`; both `xhigh` and `max` are rejected with `use one of: high, medium, low`, so firstmate omits them. |
 | pi / pi-signed | `--model <model>` | `--thinking <low\|medium\|high\|xhigh\|max>` | Verified 2026-07-27 on Pi and pi-signed 0.82.0. Both expose the same accepted thinking levels and completed the same model-qualified max-thinking smoke. |
 | opencode | `--model <provider/model>` | none for firstmate's interactive launch | Verified on opencode 1.17.6. `opencode run` has `--variant`, but firstmate launches the interactive `opencode --prompt` path, which has no verified effort flag. |

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -726,7 +726,7 @@ crew_dispatch_validate() {
       if $e == null then true
       elif ($e | type) != "string" then false
       elif $h == "claude" then (["low","medium","high","xhigh","max"] | index($e))
-      elif $h == "codex" then (["low","medium","high","xhigh"] | index($e))
+      elif $h == "codex" then (["low","medium","high","xhigh","max"] | index($e))
       elif $h == "grok" then (["low","medium","high"] | index($e))
       elif $h == "pi" or $h == "pi-signed" then (["low","medium","high","xhigh","max"] | index($e))
       elif $h == "opencode" or $h == "kimi" then false

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -720,6 +720,9 @@ crew_dispatch_validate() {
     echo "CREW_DISPATCH: invalid config/crew-dispatch.json - malformed JSON"
     return 0
   fi
+  # The per-harness effort sets below track the verified launch contract owned by
+  # harness-adapters, the same contract effort_flag_for_harness in fm-spawn.sh threads
+  # into launch; a harness with no verified effort flag rejects any configured effort.
   err=$(jq -r '
     def verified($h): ["claude","codex","opencode","pi","pi-signed","grok","kimi"] | index($h);
     def effort_ok($h; $e):

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -614,11 +614,9 @@ effort_flag_for_harness() {
       esac
       ;;
     codex)
-      # The installed codex config schema uses model_reasoning_effort, and the
-      # bundled model catalog advertises low|medium|high|xhigh. Omit max rather
-      # than passing an unsupported value.
+      # The verified codex effort contract is owned by harness-adapters.
       case "$effort" in
-        low|medium|high|xhigh) printf -- '-c %s ' "$(shell_quote "model_reasoning_effort=\"$effort\"")" ;;
+        low|medium|high|xhigh|max) printf -- '-c %s ' "$(shell_quote "model_reasoning_effort=\"$effort\"")" ;;
       esac
       ;;
     grok)

--- a/tests/fm-bootstrap.test.sh
+++ b/tests/fm-bootstrap.test.sh
@@ -764,7 +764,8 @@ test_crew_dispatch_validation() {
   done <<'ROWS'
 malformed dispatch config is flagged^{"rules":[^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - malformed JSON
 unverified dispatch harness is flagged^{"rules":[{"when":"anything","use":{"harness":"spaceship"}}],"default":{"harness":"codex"}}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - unverified harness: spaceship
-unsupported codex max effort is flagged^{"rules":[{"when":"big feature","use":{"harness":"codex","model":"gpt-5","effort":"max"}}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - invalid effort: codex:max
+codex max effort is accepted^{"rules":[{"when":"big feature","use":{"harness":"codex","model":"gpt-5.6-sol","effort":"max"}}]}^empty^
+unsupported codex effort is flagged^{"rules":[{"when":"big feature","use":{"harness":"codex","model":"gpt-5.6-sol","effort":"bogus"}}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - invalid effort: codex:bogus
 unsupported grok max effort is flagged^{"rules":[{"when":"deep current work","use":{"harness":"grok","model":"grok-4","effort":"max"}}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - invalid effort: grok:max
 unsupported grok xhigh effort is flagged^{"rules":[{"when":"deep current work","use":{"harness":"grok","model":"grok-4","effort":"xhigh"}}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - invalid effort: grok:xhigh
 pi max effort is accepted^{"rules":[{"when":"deep coding","use":{"harness":"pi","model":"openai-codex/gpt-5.6-sol","effort":"max"}}]}^empty^
@@ -781,7 +782,7 @@ empty array use is flagged^{"rules":[{"when":"big feature","use":[]}]}^exact^CRE
 array profile without harness is flagged^{"rules":[{"when":"big feature","use":[{"model":"gpt-5.5"}]}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - each use profile needs harness
 array profile with malformed model is flagged^{"rules":[{"when":"big feature","use":[{"harness":"codex","model":5}]}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - use profile model and effort must be non-empty strings when present
 unknown select is flagged^{"rules":[{"when":"big feature","use":[{"harness":"claude"},{"harness":"codex"}],"select":"mystery"}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - unknown select: mystery
-array profile unsupported effort is flagged^{"rules":[{"when":"big feature","use":[{"harness":"codex","effort":"max"}]}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - invalid effort: codex:max
+array profile codex max effort is accepted^{"rules":[{"when":"big feature","use":[{"harness":"codex","effort":"max"}]}]}^empty^
 empty default array is flagged^{"default":[]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - default needs at least one profile
 non-object default array entry is flagged^{"default":["codex"]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - each default profile must be an object
 default array profile without harness is flagged^{"default":[{"model":"gpt-5.5"}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - each default profile needs harness

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -392,21 +392,37 @@ test_codex_threads_model_and_effort() {
   pass "codex receives --model and model_reasoning_effort profile flags"
 }
 
-test_codex_omits_invalid_max_effort() {
+test_codex_threads_max_effort() {
   local rec id out status launch
   id=profile-codex-max-z4
   rec=$(make_spawn_case profile-codex-max codex "$id")
   read_case_record "$rec"
 
-  out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR" --model gpt-5 --effort max)
+  out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR" --model gpt-5.6-sol --effort max)
   status=$?
-  expect_code 0 "$status" "codex spawn with unsupported max effort should omit the effort flag"
-  assert_meta_profile "$HOME_DIR/state/$id.meta" codex gpt-5 max
+  expect_code 0 "$status" "codex spawn with max effort should succeed"
+  assert_meta_profile "$HOME_DIR/state/$id.meta" codex gpt-5.6-sol max
   launch=$(cat "$LAUNCH_LOG")
-  assert_contains "$launch" "codex --model 'gpt-5' --dangerously-bypass-approvals-and-sandbox" \
-    "codex launch did not preserve the model flag when max effort was omitted"
-  assert_not_contains "$launch" "model_reasoning_effort" "codex launch must omit unsupported max reasoning effort"
-  pass "codex omits unsupported max effort instead of passing a bad config value"
+  assert_contains "$launch" "codex --model 'gpt-5.6-sol' -c 'model_reasoning_effort=\"max\"' --dangerously-bypass-approvals-and-sandbox" \
+    "codex launch did not thread max through model_reasoning_effort"
+  pass "codex receives max through model_reasoning_effort"
+}
+
+test_codex_refuses_unknown_effort() {
+  local rec id out status launch
+  id=profile-codex-invalid-z4b
+  rec=$(make_spawn_case profile-codex-invalid codex "$id")
+  read_case_record "$rec"
+
+  out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR" --model gpt-5.6-sol --effort bogus)
+  status=$?
+  expect_code 1 "$status" "codex spawn with an unknown effort should fail"
+  assert_contains "$out" "error: --effort must be one of low, medium, high, xhigh, max" \
+    "codex spawn did not explain the supported effort values"
+  assert_absent "$HOME_DIR/state/$id.meta" "invalid codex effort should be refused before meta is written"
+  launch=$(cat "$LAUNCH_LOG")
+  [ -z "$launch" ] || fail "invalid codex effort reached the launch command: $launch"
+  pass "codex refuses an unknown effort before launch"
 }
 
 test_grok_threads_model_and_reasoning_effort() {
@@ -667,7 +683,8 @@ test_active_dispatch_profile_allows_positional_harness
 test_active_dispatch_profile_allows_raw_launch_command
 test_claude_threads_model_and_effort
 test_codex_threads_model_and_effort
-test_codex_omits_invalid_max_effort
+test_codex_threads_max_effort
+test_codex_refuses_unknown_effort
 test_grok_threads_model_and_reasoning_effort
 test_grok_omits_invalid_max_reasoning_effort
 test_grok_omits_invalid_xhigh_reasoning_effort


### PR DESCRIPTION
## What

Permit `max` as a reasoning effort for the `codex` harness, so a configured or captain-chosen codex `max` profile is actually launched at max instead of being accepted and then silently dropped.

Before this change the two halves of the contract disagreed:

- `bin/fm-bootstrap.sh` (`effort_ok` in `crew_dispatch_validate`) rejected `codex:max` outright, so a dispatch profile asking for it was reported as `CREW_DISPATCH: invalid config/crew-dispatch.json - invalid effort: codex:max`.
- `bin/fm-spawn.sh` (`effort_flag_for_harness`) accepted `max` but emitted no flag for it, so the worker launched at codex's own default effort while `effort=max` was still recorded in task meta.

The result was a silent downgrade: recorded intent and actual launch disagreed, with no diagnostic.

## Backend verification

Verified against the installed CLI rather than trusting the older documented ceiling.

```
$ codex --version
codex-cli 0.145.0

$ codex debug models --bundled | jq -r '.models[] | "\(.slug): \([.supported_reasoning_levels[].effort] | join(","))"'
gpt-5.6-sol: low,medium,high,xhigh,max,ultra
gpt-5.6-terra: low,medium,high,xhigh,max,ultra
gpt-5.6-luna: low,medium,high,xhigh,max
gpt-5.5: low,medium,high,xhigh
gpt-5.4: low,medium,high,xhigh
gpt-5.4-mini: low,medium,high,xhigh
gpt-5.2: low,medium,high,xhigh
codex-auto-review: low,medium,high,xhigh
```

An end-to-end check confirmed the flag is honored rather than downgraded: `codex exec --model gpt-5.6-sol -c 'model_reasoning_effort="max"'` reports `reasoning effort: max` in its session header.

Note that `codex doctor -c model_reasoning_effort=<value>` does NOT discriminate - it accepts a deliberately bogus value too, so it is not evidence either way.

## Model scoping, deliberately harness-wide

`max` is model-scoped in codex-cli 0.145.0: only the `gpt-5.6` family carries it, and every other model caps at `xhigh`. Firstmate's acceptance is harness-wide by decision, not because every codex model supports it.

Two catalogs exist and they differ in which older models they carry - `codex debug models --bundled` is the static compiled catalog and ships `gpt-5.2`, while `codex debug models` is the account's effective list and ships `gpt-5.3-codex-spark` instead. Both agree exactly on which models carry `max`. The contract therefore states the max-bearing family positively and names both recheck commands rather than enumerating a model list that is version- and account-dependent and would rot.

This matters because `model_reasoning_effort` is a free-form string in codex 0.145.0 config loading, unlike `approval_policy` and `sandbox_mode` which reject unknown values. Pairing `max` with a model that caps at `xhigh` is accepted silently and its effective effort is undefined. The contract records that caveat instead of adding a per-model capability check, which would have to be maintained against a shifting catalog.

## Scope

- `bin/fm-bootstrap.sh` - accept `codex:max` in dispatch-profile validation.
- `bin/fm-spawn.sh` - emit `-c 'model_reasoning_effort="max"'` for codex.
- `.agents/skills/harness-adapters/SKILL.md` - the authoritative contract row, plus the model-scoping and free-form-string caveats.
- `tests/` - colocated regression coverage on both sides.

Unchanged: every other harness ceiling (`grok` stays capped at `high`, `opencode` remains effort-less) and the generic effort-selection policy. Invalid efforts stay loud - `codex:bogus` is still flagged by bootstrap and still refused by `fm-spawn` before any meta write or launch.

## Known follow-up, not in this change

The per-harness effort ceilings live in two executable copies (`bin/fm-bootstrap.sh` and `bin/fm-spawn.sh`) plus the prose owner, so moving one ceiling touches three places. This change adds pointer comments only; consolidating the shell copies behind one shared table changes executable code and belongs in its own change.
