### PR TITLE
fix(tmux): force session resolution in list-windows and agent-state probes

### DIFF
--- a/bin/backends/tmux.sh
+++ b/bin/backends/tmux.sh
@@ -168,6 +168,8 @@ fm_backend_tmux_agent_state() {  # <target>
   esac
   session=${target%%:*}
   window=${target#*:}
+  # Trailing colon forces tmux to resolve $session as a session, not a window
+  # whose name happens to match (e.g. session "DarkOrbit" + window "DarkOrbit").
   if windows=$(LC_ALL=C tmux list-windows -t "$session:" -F '#{window_name}' 2>&1); then
     inventory_status=0
   else

--- a/bin/backends/tmux.sh
+++ b/bin/backends/tmux.sh
@@ -168,7 +168,7 @@ fm_backend_tmux_agent_state() {  # <target>
   esac
   session=${target%%:*}
   window=${target#*:}
-  if windows=$(LC_ALL=C tmux list-windows -t "$session" -F '#{window_name}' 2>&1); then
+  if windows=$(LC_ALL=C tmux list-windows -t "$session:" -F '#{window_name}' 2>&1); then
     inventory_status=0
   else
     inventory_status=$?

--- a/bin/backends/tmux.sh
+++ b/bin/backends/tmux.sh
@@ -84,7 +84,9 @@ fm_backend_tmux_container_ensure() {
 # lost, so worktree discovery cannot fall back to the active client's window.
 fm_backend_tmux_create_task() {  # <session> <window-name> <proj-abs> -> prints window id
   local ses=$1 wname=$2 proj_abs=$3 wid
-  if tmux list-windows -t "$ses" -F '#{window_name}' | grep -qx "$wname"; then
+  # Trailing colon forces tmux to resolve $ses as a session, not a window
+  # whose name happens to match (e.g. session "DarkOrbit" + window "DarkOrbit").
+  if tmux list-windows -t "$ses:" -F '#{window_name}' | grep -qx "$wname"; then
     echo "error: window $ses:$wname already exists" >&2
     return 1
   fi

--- a/docs/tmux-backend.md
+++ b/docs/tmux-backend.md
@@ -33,9 +33,11 @@ tmux attach -t firstmate
 Each task window is named `fm-<id>`.
 
 ```sh
-tmux list-windows -t <session-name>
+tmux list-windows -t '<session-name>:'
 tmux select-window -t <session-name>:fm-<id>
 ```
+
+The trailing colon forces tmux to resolve the target as a session rather than a window whose name happens to match the session's.
 
 Typing into an attached task window is authoritative direct intervention.
 Routine supervision does not require attachment: `bin/fm-peek.sh <id>` captures a bounded tail and `FM_HOME=<home> bin/fm-send.sh <id> '<text>'` steers the recorded endpoint.
@@ -48,6 +50,7 @@ A target-existence check proves only that the pane exists.
 The deeper tmux agent-liveness probe first verifies exact window membership, then reads `#{pane_current_command}` to distinguish a running harness process from a bare idle shell.
 It classifies recognized Claude, Codex, OpenCode, Pi, pi-signed, Grok, and Kimi process names as `alive`, common shells as `dead`, an authoritatively absent window as `missing`, unreadable state as `unreadable`, and every other process as `ambiguous`.
 Only `dead` and `missing` authorize recovery because a false dead result could launch a duplicate agent.
+Both the spawn-time duplicate-window check and this probe's membership inventory force session resolution with a trailing colon, so a window named after its session can never shadow the session target.
 
 The verified Pi Launcher path reports the exact foreground command `pi-launcher` for both pi and pi-signed, while direct executable identities `pi`, `pi-signed`, and `Pi` remain accepted exactly.
 Similar or prefixed process names are not accepted through those exact Pi-family entries.


### PR DESCRIPTION
## Summary

- Apply trailing-colon form (`"$ses:"`) to `tmux list-windows` in `fm_backend_tmux_create_task` so a session and a window sharing the same name (e.g. session "DarkOrbit" with a window also named "DarkOrbit") cannot collide during the duplicate-window check. The `new-window` call two lines below already uses this form.
- Apply the same fix to `fm_backend_tmux_agent_state`'s `tmux list-windows` call, which feeds the recovery-grade agent liveness probe - a false `missing` verdict there can authorize relaunching a duplicate agent.

## Test plan

- [ ] Existing `tests/fm-backend-herdr.test.sh` passes (verified locally)
- [ ] Existing `tests/fm-backend-herdr-smoke.test.sh` passes (verified locally)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)