### PR TITLE
fix(orca): make teardown removal idempotent and loud

### DIFF
--- a/bin/backends/orca.sh
+++ b/bin/backends/orca.sh
@@ -177,11 +177,39 @@ fm_backend_orca_send_literal() {  # <terminal-id> <text>
   fm_backend_orca_run_json orca terminal send --terminal "$terminal" --text "$text" --json
 }
 
+fm_backend_orca_selector_not_found() {  # <json>
+  node -e '
+const fs = require("fs");
+let data;
+try {
+  data = JSON.parse(fs.readFileSync(0, "utf8"));
+} catch (err) {
+  process.exit(1);
+}
+process.exit(data.ok === false && data.error && data.error.code === "selector_not_found" ? 0 : 1);
+'
+}
+
 fm_backend_orca_remove_worktree() {  # <worktree-id>
-  local worktree_id=${1:-}
+  local worktree_id=${1:-} out status=0
   [ -n "$worktree_id" ] || { echo "error: missing Orca worktree id; cannot remove worktree" >&2; return 1; }
   fm_backend_orca_tool_check || return 1
-  fm_backend_orca_run_json orca worktree rm --worktree "id:$worktree_id" --force --json
+  if out=$(orca worktree rm --worktree "id:$worktree_id" --force --json 2>&1); then
+    :
+  else
+    status=$?
+  fi
+  if printf '%s' "$out" | fm_backend_orca_selector_not_found; then
+    echo "notice: Orca worktree $worktree_id is already absent; removal is complete" >&2
+    return 0
+  fi
+  if [ -n "$out" ]; then
+    if ! printf '%s' "$out" | fm_backend_orca_json_ok; then
+      [ "$status" -eq 0 ] || return "$status"
+      return 1
+    fi
+  fi
+  [ "$status" -eq 0 ] || return "$status"
 }
 
 fm_backend_orca_worktree_path() {

--- a/bin/fm-backend.sh
+++ b/bin/fm-backend.sh
@@ -383,6 +383,43 @@ fm_backend_endpoint_atom_valid() {  # <value>
   esac
 }
 
+# fm_backend_endpoint_orca_worktree_id_valid: validate an Orca worktree id.
+# An Orca worktree id is <repo-id>::<absolute-path> by construction (see
+# bin/backends/orca.sh's worktree-id parsing), so it legitimately contains ':'
+# and '/'. The generic atom validator bans both and therefore rejects every real
+# Orca id, which made Orca endpoint validation - and so every Orca teardown -
+# refuse and leak worktrees. This keeps validation strict for the real shape
+# without borrowing the atom rule: a safe charset (the atom set plus ':' and
+# '/'), a required '::' separator, an atom-clean repo id before it (no ':' or
+# '/'), and an absolute path after it. A plain atom-clean value with no colon is
+# still accepted so simple recorded ids stay valid. Control characters, spaces,
+# shell metacharacters, a lone ':' separator, and a relative path are refused.
+fm_backend_endpoint_orca_worktree_id_valid() {  # <value>
+  local id_part path_part
+  case "$1" in
+    ''|*[!A-Za-z0-9._@%+:/-]*) return 1 ;;
+  esac
+  case "$1" in
+    *::*)
+      id_part=${1%%::*}
+      path_part=${1#*::}
+      case "$id_part" in
+        ''|*[!A-Za-z0-9._@%+-]*) return 1 ;;
+      esac
+      case "$path_part" in
+        /*) return 0 ;;
+        *) return 1 ;;
+      esac
+      ;;
+    *:*)
+      return 1
+      ;;
+    *)
+      return 0
+      ;;
+  esac
+}
+
 fm_backend_validate_task_endpoint() {  # <meta-file> <task-id>
   local meta=$1 id=$2 backend_count backend window worktree project binding_count binding
   local session pane recorded_session workspace tab terminal worktree_id surface
@@ -501,10 +538,12 @@ fm_backend_validate_task_endpoint() {  # <meta-file> <task-id>
         echo "REFUSED: missing orca_worktree_id in $meta; cannot remove Orca worktree; preserving task state." >&2
         return 1
       }
-      if [ "$window" != "fm-$id" ] \
-        || ! fm_backend_endpoint_atom_valid "$terminal" \
-        || ! fm_backend_endpoint_atom_valid "$worktree_id"; then
-        echo "REFUSED: Orca endpoint metadata for task $id is malformed or inconsistent; preserving task state." >&2
+      if [ "$window" != "fm-$id" ] || ! fm_backend_endpoint_atom_valid "$terminal"; then
+        echo "REFUSED: endpoint identity validation failed for Orca task $id (window or terminal); this is a metadata identity problem, not an unlanded-work refusal; preserving task state." >&2
+        return 1
+      fi
+      if ! fm_backend_endpoint_orca_worktree_id_valid "$worktree_id"; then
+        echo "REFUSED: endpoint identity validation failed for Orca task $id: worktree id '$worktree_id' is not a valid <repo-id>::<absolute-path> identity; this is a metadata identity problem, not an unlanded-work refusal; preserving task state." >&2
         return 1
       fi
       window=$terminal

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -1249,7 +1249,10 @@ if [ "$BACKEND" = orca ] && [ "$KIND" != secondmate ]; then
       "$WT/.fm-grok-turnend" "$WT/.fm-kimi-turnend"
   fi
   [ -z "$T_ORCA" ] || fm_backend_kill "$BACKEND" "$T" "$(meta_value "$META" zellij_tab_id)" "fm-$ID" 2>/dev/null || true
-  fm_backend_remove_worktree "$BACKEND" "$ORCA_WORKTREE_ID"
+  if ! fm_backend_remove_worktree "$BACKEND" "$ORCA_WORKTREE_ID"; then
+    echo "error: Orca worktree removal failed for $ORCA_WORKTREE_ID; preserving task state after partial cleanup" >&2
+    exit 1
+  fi
 elif [ -d "$WT" ] && [ "$KIND" != secondmate ]; then
   branch=$(git -C "$WT" rev-parse --abbrev-ref HEAD 2>/dev/null || echo HEAD)
   if [ "$branch" != "HEAD" ]; then

--- a/tests/fm-backend-orca.test.sh
+++ b/tests/fm-backend-orca.test.sh
@@ -807,6 +807,156 @@ test_scout_teardown_removes_orca_worktree_via_helper() {
   pass "fm-teardown.sh backend=orca: scout report gate then helper-backed worktree removal"
 }
 
+# Real Orca worktree ids are <repo-id>::<absolute-path> by construction, so they
+# contain ':' and '/'. The generic atom validator bans both, which made every
+# Orca endpoint validation - and so every Orca teardown - refuse and leak the
+# worktree. These tests pin the dedicated Orca worktree-id validator and the
+# teardown behavior for the real shape, plus the loud, categorized refusal that
+# must stay distinct from an unlanded-work refusal.
+ORCA_TEST_UUID="3bbb3ee8-c628-4390-992c-af5118987e86"
+
+test_orca_worktree_id_validator_accepts_real_shape() {
+  local out
+  out=$( bash -c '
+    . "$0/bin/fm-backend.sh"
+    t() { if fm_backend_endpoint_orca_worktree_id_valid "$1"; then echo "ACCEPT $2"; else echo "REJECT $2"; fi; }
+    t "3bbb3ee8-c628-4390-992c-af5118987e86::/Users/x/orca/workspaces/diffusal/fm-a" real-shape
+    t "wt-teardown" plain-legacy-id
+    t "3bbb3ee8-c628-4390-992c-af5118987e86::relative/path" relative-path
+    t "repo:/single/colon" single-colon
+    t "repo::" empty-path
+    t "::/abs/path" empty-repo-id
+    t "" empty
+    t "a/b::/x" slash-in-repo-id
+    t "$(printf "repo::/evil\nrm")" control-char
+  ' "$ROOT" 2>&1 ) || fail "Orca worktree-id validator is not callable"$'\n'"$out"
+  assert_contains "$out" "ACCEPT real-shape" "validator must accept a real <repo-id>::<absolute-path> id"
+  assert_contains "$out" "ACCEPT plain-legacy-id" "validator must keep accepting a plain atom-clean id"
+  assert_contains "$out" "REJECT relative-path" "validator must refuse a relative path after ::"
+  assert_contains "$out" "REJECT single-colon" "validator must refuse a lone ':' separator"
+  assert_contains "$out" "REJECT empty-path" "validator must refuse an empty path"
+  assert_contains "$out" "REJECT empty-repo-id" "validator must refuse an empty repo id"
+  assert_contains "$out" "REJECT empty" "validator must refuse an empty id"
+  assert_contains "$out" "REJECT slash-in-repo-id" "validator must refuse a '/' in the repo id"
+  assert_contains "$out" "REJECT control-char" "validator must refuse a control character"
+  pass "fm_backend_endpoint_orca_worktree_id_valid: accepts the real shape and plain ids, refuses malformed ids"
+}
+
+test_atom_validator_stays_strict_for_other_backends() {
+  local out
+  out=$( bash -c '
+    . "$0/bin/fm-backend.sh"
+    t() { if fm_backend_endpoint_atom_valid "$1"; then echo "ACCEPT $2"; else echo "REJECT $2"; fi; }
+    t "term_2a46-0870" terminal-shape
+    t "3bbb3ee8-c628-4390-992c-af5118987e86::/Users/x" real-orca-shape
+    t "a:b" colon
+    t "a/b" slash
+  ' "$ROOT" 2>&1 ) || fail "atom validator is not callable"$'\n'"$out"
+  assert_contains "$out" "ACCEPT terminal-shape" "atom validator must still accept an atom-clean terminal id"
+  assert_contains "$out" "REJECT real-orca-shape" "atom validator must stay strict and still reject ':' and '/'"
+  assert_contains "$out" "REJECT colon" "atom validator must still reject a colon"
+  assert_contains "$out" "REJECT slash" "atom validator must still reject a slash"
+  pass "fm_backend_endpoint_atom_valid: unchanged and still strict (Orca fix did not widen it)"
+}
+
+test_validate_endpoint_accepts_real_shaped_orca_id() {
+  local dir id meta
+  id="orcavalidatez1"
+  dir="$TMP_ROOT/validate-real"; mkdir -p "$dir"
+  meta="$dir/$id.meta"
+  fm_write_meta "$meta" \
+    "window=fm-$id" "endpoint_task_id=$id" "terminal=term-real" \
+    "worktree=/Users/x/orca/workspaces/diffusal/$id" "project=/Users/x/orca/workspaces/diffusal" \
+    "backend=orca" "orca_worktree_id=$ORCA_TEST_UUID::/Users/x/orca/workspaces/diffusal/$id"
+  bash -c '
+    . "$0/bin/fm-backend.sh"
+    fm_backend_validate_task_endpoint "$1" "$2" || { echo "REFUSED-CALL"; exit 1; }
+    echo "BACKEND=$FM_BACKEND_VALIDATED_BACKEND TARGET=$FM_BACKEND_VALIDATED_TARGET"
+  ' "$ROOT" "$meta" "$id" > "$dir/out" 2> "$dir/err"
+  assert_not_contains "$(cat "$dir/out")$(cat "$dir/err")" "REFUSED-CALL" \
+    "a real-shaped Orca worktree id must validate, not refuse"$'\n'"$(cat "$dir/err")"
+  assert_contains "$(cat "$dir/out")" "BACKEND=orca TARGET=term-real" \
+    "Orca validation must select the backend and its terminal target"
+  pass "fm_backend_validate_task_endpoint: accepts a real <repo-id>::<absolute-path> Orca worktree id"
+}
+
+test_teardown_removes_real_shaped_orca_worktree() {
+  local proj wt data state config id orca_id out rc neutral
+  id="orcarealidz2"
+  proj="$TMP_ROOT/real-id-project"
+  wt="$TMP_ROOT/real-id-wt"
+  data="$TMP_ROOT/real-id-data"
+  state="$TMP_ROOT/real-id-state"
+  config="$TMP_ROOT/real-id-config"
+  fm_git_worktree "$proj" "$wt" "fm/$id"
+  mkdir -p "$data/$id" "$state" "$config"
+  printf 'report\n' > "$data/$id/report.md"
+  touch "$state/.last-watcher-beat"
+  orca_id="$ORCA_TEST_UUID::$wt"
+  fm_write_meta "$state/$id.meta" \
+    "window=fm-$id" "endpoint_task_id=$id" "terminal=term-real-id" "worktree=$wt" "project=$proj" \
+    "harness=claude" "kind=scout" "mode=no-mistakes" "yolo=off" \
+    "backend=orca" "orca_worktree_id=$orca_id" \
+    "decisions_reviewed=1" "decision_keys="
+  orca_case real-id-teardown
+  printf '{"ok":true,"result":{"worktree":{"id":"%s","path":"%s"}}}\n' "$orca_id" "$wt" > "$RESP/1.out"
+  neutral=$(neutral_fm_root "$CASE_DIR/neutral")
+  set +e
+  out=$( PATH="$FB:$PATH" FM_ORCA_LOG="$LOG" FM_ORCA_RESPONSES="$RESP" \
+    FM_ROOT_OVERRIDE="$neutral" FM_STATE_OVERRIDE="$state" FM_DATA_OVERRIDE="$data" FM_CONFIG_OVERRIDE="$config" \
+    "$ROOT/bin/fm-teardown.sh" "$id" 2>&1 )
+  rc=$?
+  set -e
+  expect_code 0 "$rc" "Orca teardown with a real-shaped worktree id must succeed"$'\n'"$out"
+  assert_contains "$(cat "$LOG")" $'orca\x1f''worktree'$'\x1f''rm'$'\x1f''--worktree'$'\x1f'"id:$orca_id"$'\x1f''--force'$'\x1f''--json' \
+    "teardown did not remove the real-shaped Orca worktree through orca worktree rm"
+  assert_contains "$(cat "$LOG")" $'orca\x1f''terminal'$'\x1f''close'$'\x1f''--terminal'$'\x1f''term-real-id'$'\x1f''--json' \
+    "teardown did not close the recorded Orca terminal"
+  assert_absent "$state/$id.meta" "successful Orca teardown must remove task metadata"
+  pass "fm-teardown.sh backend=orca: a real <repo-id>::<absolute-path> id is validated and the worktree is removed"
+}
+
+test_teardown_refuses_malformed_orca_id_as_endpoint_identity_not_unlanded_work() {
+  local proj wt data state config id orca_id out rc neutral log
+  id="orcabadidz4"
+  proj="$TMP_ROOT/bad-id-project"
+  wt="$TMP_ROOT/bad-id-wt"
+  data="$TMP_ROOT/bad-id-data"
+  state="$TMP_ROOT/bad-id-state"
+  config="$TMP_ROOT/bad-id-config"
+  fm_git_worktree "$proj" "$wt" "fm/$id"
+  mkdir -p "$data/$id" "$state" "$config"
+  printf 'report\n' > "$data/$id/report.md"
+  touch "$state/.last-watcher-beat"
+  orca_id="$ORCA_TEST_UUID::relative/path/not/absolute"
+  fm_write_meta "$state/$id.meta" \
+    "window=fm-$id" "endpoint_task_id=$id" "terminal=term-bad-id" "worktree=$wt" "project=$proj" \
+    "harness=claude" "kind=scout" "mode=no-mistakes" "yolo=off" \
+    "backend=orca" "orca_worktree_id=$orca_id" \
+    "decisions_reviewed=1" "decision_keys="
+  orca_case bad-id-teardown
+  neutral=$(neutral_fm_root "$CASE_DIR/neutral")
+  set +e
+  out=$( PATH="$FB:$PATH" FM_ORCA_LOG="$LOG" FM_ORCA_RESPONSES="$RESP" \
+    FM_ROOT_OVERRIDE="$neutral" FM_STATE_OVERRIDE="$state" FM_DATA_OVERRIDE="$data" FM_CONFIG_OVERRIDE="$config" \
+    "$ROOT/bin/fm-teardown.sh" "$id" 2>&1 )
+  rc=$?
+  set -e
+  log=$(cat "$LOG")
+  [ "$rc" -ne 0 ] || fail "teardown must refuse a malformed Orca worktree id and exit non-zero"$'\n'"$out"
+  assert_contains "$out" "endpoint identity validation failed" \
+    "refusal must name itself as an endpoint-identity validation failure"
+  assert_contains "$out" "not an unlanded-work refusal" \
+    "refusal must state explicitly that it is not an unlanded-work refusal"
+  assert_not_contains "$out" "uncommitted changes" "endpoint-identity refusal must not read like an unlanded-work refusal"
+  assert_not_contains "$out" "not landed" "endpoint-identity refusal must not read like an unlanded-work refusal"
+  assert_not_contains "$out" "not yet merged" "endpoint-identity refusal must not read like an unlanded-work refusal"
+  assert_not_contains "$log" $'worktree'$'\x1f''rm' \
+    "a refused endpoint-identity validation must not reach orca worktree rm"
+  assert_present "$state/$id.meta" "refused teardown must preserve task metadata"
+  pass "fm-teardown.sh backend=orca: a malformed id refuses loudly as an endpoint-identity problem, distinct from unlanded work"
+}
+
 test_scout_teardown_refuses_orca_id_path_mismatch() {
   local proj wt other_wt data state config id out rc neutral
   id="orcascoutmismatchz5"
@@ -1313,6 +1463,11 @@ test_peek_send_and_crew_state_route_through_orca_meta
 test_peek_and_crew_state_fail_closed_on_orca_error_json
 test_target_exists_rejects_orca_error_json
 test_scout_teardown_removes_orca_worktree_via_helper
+test_orca_worktree_id_validator_accepts_real_shape
+test_atom_validator_stays_strict_for_other_backends
+test_validate_endpoint_accepts_real_shaped_orca_id
+test_teardown_removes_real_shaped_orca_worktree
+test_teardown_refuses_malformed_orca_id_as_endpoint_identity_not_unlanded_work
 test_scout_teardown_refuses_orca_id_path_mismatch
 test_teardown_removes_orca_worktree_when_path_missing
 test_teardown_preserves_metadata_when_orca_remove_error_json

--- a/tests/fm-backend-orca.test.sh
+++ b/tests/fm-backend-orca.test.sh
@@ -29,10 +29,10 @@ if [ "${1:-}" = status ] && [ "${FM_ORCA_STATUS_RESPONSE:-ready}" != sequence ];
 fi
 n=$next
 echo "$n" > "$COUNT_FILE"
+[ -f "$RESP/$n.out" ] && cat "$RESP/$n.out"
 if [ -f "$RESP/$n.exit" ]; then
   exit "$(cat "$RESP/$n.exit")"
 fi
-[ -f "$RESP/$n.out" ] && cat "$RESP/$n.out"
 exit 0
 SH
   chmod +x "$fb/orca"
@@ -348,6 +348,22 @@ test_remove_worktree_rejects_orca_error_json() {
   [ "$status" -ne 0 ] || fail "remove_worktree should fail on Orca ok:false JSON"
   assert_contains "$out" "worktree not found" "remove_worktree should surface the Orca removal error"
   pass "fm_backend_orca_remove_worktree: fails closed on ok:false JSON"
+}
+
+test_remove_worktree_treats_selector_not_found_as_already_absent() {
+  local out status
+  orca_case remove-selector-not-found
+  printf '{"ok":false,"error":{"code":"selector_not_found","message":"worktree selector not found"}}\n' > "$RESP/1.out"
+  printf '1\n' > "$RESP/1.exit"
+  out=$( PATH="$FB:$PATH" FM_ORCA_LOG="$LOG" FM_ORCA_RESPONSES="$RESP" \
+    bash -c '. "$0/bin/backends/orca.sh"; fm_backend_orca_remove_worktree wt-already-gone' "$ROOT" 2>&1 )
+  status=$?
+  [ "$status" -eq 0 ] || fail "selector_not_found should be treated as an already-absent worktree"
+  assert_contains "$out" "already absent" \
+    "idempotent removal should report that the Orca worktree was already absent"
+  assert_contains "$(cat "$LOG")" $'orca\x1f''worktree'$'\x1f''rm'$'\x1f''--worktree'$'\x1f''id:wt-already-gone' \
+    "idempotent removal should still call Orca with the recorded selector"
+  pass "fm_backend_orca_remove_worktree: selector_not_found is successful idempotent cleanup"
 }
 
 test_worktree_path_resolves_id() {
@@ -1061,6 +1077,42 @@ test_teardown_preserves_metadata_when_orca_remove_error_json() {
   pass "fm-teardown.sh backend=orca: preserves metadata on remove ok:false JSON"
 }
 
+test_teardown_remove_failure_is_loud_when_errexit_is_ignored() {
+  local proj wt data state config id out rc neutral
+  id="orcaremoveerrconditionalz3"
+  proj="$TMP_ROOT/remove-error-conditional-project"
+  wt="$TMP_ROOT/remove-error-conditional-wt"
+  data="$TMP_ROOT/remove-error-conditional-data"
+  state="$TMP_ROOT/remove-error-conditional-state"
+  config="$TMP_ROOT/remove-error-conditional-config"
+  mkdir -p "$data/$id" "$state" "$config"
+  printf 'report\n' > "$data/$id/report.md"
+  touch "$state/.last-watcher-beat"
+  fm_write_meta "$state/$id.meta" \
+    "window=fm-$id" "endpoint_task_id=$id" "terminal=term-remove-error-conditional" "worktree=$wt" "project=$proj" \
+    "harness=claude" "kind=scout" "mode=no-mistakes" "yolo=off" \
+    "backend=orca" "orca_worktree_id=wt-remove-error-conditional" \
+    "decisions_reviewed=1" "decision_keys="
+  orca_case remove-error-conditional-teardown
+  printf '{"ok":true,"result":{}}\n' > "$RESP/1.out"
+  printf '{"ok":false,"error":{"code":"worktree_not_removed","message":"worktree not removed"}}\n' > "$RESP/2.out"
+  neutral=$(neutral_fm_root "$CASE_DIR/neutral")
+  set +e
+  out=$( PATH="$FB:$PATH" FM_ORCA_LOG="$LOG" FM_ORCA_RESPONSES="$RESP" \
+    FM_ROOT_OVERRIDE="$neutral" FM_STATE_OVERRIDE="$state" FM_DATA_OVERRIDE="$data" FM_CONFIG_OVERRIDE="$config" \
+    bash -c 'if . "$1" "$2"; then exit 0; else exit "$?"; fi' _ "$ROOT/bin/fm-teardown.sh" "$id" 2>&1 )
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "teardown must not return success after Orca removal failure when errexit is ignored"
+  assert_contains "$out" "Orca worktree removal failed" \
+    "teardown should explain that Orca worktree removal failed"
+  assert_contains "$out" "preserving task state" \
+    "teardown should explain why cleanup records remain"
+  assert_present "$state/$id.meta" \
+    "teardown must preserve metadata after a partial Orca cleanup"
+  pass "fm-teardown.sh: Orca removal failure stays loud and non-zero without relying on errexit"
+}
+
 test_scout_teardown_refuses_orca_missing_report_when_path_missing() {
   local proj wt data state config id out rc neutral
   id="orcanoreportz4"
@@ -1446,6 +1498,7 @@ test_send_key_refuses_escape_until_supported
 test_kill_is_best_effort_close
 test_remove_worktree_refuses_empty_id
 test_remove_worktree_rejects_orca_error_json
+test_remove_worktree_treats_selector_not_found_as_already_absent
 test_worktree_path_resolves_id
 test_dispatcher_sources_orca_and_routes_primitives
 test_json_get_ignores_undocumented_terminal_id_shapes
@@ -1471,6 +1524,7 @@ test_teardown_refuses_malformed_orca_id_as_endpoint_identity_not_unlanded_work
 test_scout_teardown_refuses_orca_id_path_mismatch
 test_teardown_removes_orca_worktree_when_path_missing
 test_teardown_preserves_metadata_when_orca_remove_error_json
+test_teardown_remove_failure_is_loud_when_errexit_is_ignored
 test_scout_teardown_refuses_orca_missing_report_when_path_missing
 test_ship_teardown_refuses_orca_missing_worktree_path
 test_ship_teardown_removes_orca_worktree_when_id_path_matches

--- a/tests/fm-teardown-endpoint-safety.test.sh
+++ b/tests/fm-teardown-endpoint-safety.test.sh
@@ -146,6 +146,46 @@ test_supported_backend_endpoint_records_validate() {
   pass "cleanup identity: valid tmux, Herdr, Zellij, Orca, and cmux records validate while every empty backend target refuses"
 }
 
+test_atom_validator_stays_strict_while_orca_shape_validates() {
+  local dir id
+  dir=$(make_case atom-strict)
+  # shellcheck source=/dev/null
+  . "$ROOT/bin/fm-backend.sh"
+
+  # The generic atom validator must stay strict: the Orca fix routes Orca
+  # worktree ids through a dedicated validator and must NOT widen the atom rule
+  # that guards every other backend's fields.
+  fm_backend_endpoint_atom_valid "term-7" || fail "atom validator regressed on an atom-clean value"
+  if fm_backend_endpoint_atom_valid "3bbb3ee8-c628-4390-992c-af5118987e86::/Users/x/wt"; then
+    fail "atom validator was widened: it now accepts ':' and '/'"
+  fi
+  if fm_backend_endpoint_atom_valid "surface/2"; then
+    fail "atom validator was widened: it now accepts '/'"
+  fi
+
+  # A non-Orca backend field carrying a '/' must still be refused by the strict
+  # atom validator, proving the Orca carve-out did not leak into other backends.
+  id=cmux-slash
+  fm_write_meta "$dir/home/state/$id.meta" \
+    "window=workspace-1:surface/2" "endpoint_task_id=$id" "worktree=$dir/worktree" "project=$dir/project" \
+    "backend=cmux" "cmux_workspace_id=workspace-1" "cmux_surface_id=surface/2"
+  if fm_backend_validate_task_endpoint "$dir/home/state/$id.meta" "$id" 2>/dev/null; then
+    fail "cmux surface id with a '/' must still be refused by the strict atom validator"
+  fi
+
+  # The real Orca shape validates only through the dedicated Orca validator.
+  id=orca-real-shape
+  fm_write_meta "$dir/home/state/$id.meta" \
+    "window=fm-$id" "endpoint_task_id=$id" "terminal=term-9" \
+    "worktree=$dir/worktree" "project=$dir/project" "backend=orca" \
+    "orca_worktree_id=3bbb3ee8-c628-4390-992c-af5118987e86::$dir/worktree"
+  fm_backend_validate_task_endpoint "$dir/home/state/$id.meta" "$id" \
+    || fail "real-shaped Orca worktree id must validate through the dedicated validator"
+  [ "$FM_BACKEND_VALIDATED_TARGET" = term-9 ] || fail "Orca validation did not select its terminal target"
+
+  pass "endpoint validation: atom rule stays strict for other backends while the real Orca shape validates"
+}
+
 test_tmux_empty_target_refuses_without_invocation() {
   local dir rc
   dir=$(make_case direct-empty)
@@ -270,6 +310,7 @@ SH
 
 test_invalid_endpoint_records_refuse_before_mutation
 test_supported_backend_endpoint_records_validate
+test_atom_validator_stays_strict_while_orca_shape_validates
 test_tmux_empty_target_refuses_without_invocation
 test_recorded_process_identity_cleanup_is_exact
 test_isolated_tmux_invalid_and_valid_cleanup


### PR DESCRIPTION
## Root cause

`fm_backend_orca_remove_worktree` routed `orca worktree rm` through the generic JSON success check. Orca returns `ok: false` with `error.code=selector_not_found` when the recorded worktree is already absent, so teardown treated the desired end state as a removal failure. The teardown call also relied on `set -e`, which is not a sufficient contract when invoked from an errexit-ignored shell context.

## Fix

- Treat only Orca `selector_not_found` removal responses as successful idempotent cleanup, including when the CLI exits non-zero.
- Preserve non-zero failures for missing tools, malformed or genuine error responses, and emit the concrete Orca error.
- Make `fm-teardown.sh` explicitly refuse and preserve task state after a failed Orca worktree removal instead of relying on implicit errexit behavior.
- Preserve dirty/unlanded-work checks unchanged.

## Verification

- Red-green tests cover a non-zero `selector_not_found` response and a genuine removal error.
- Mutation testing: changing idempotent success back to failure breaks the selector test; removing the explicit teardown failure guard breaks the loud partial-cleanup test.
- `bin/fm-lint.sh` passes.
- `tests/fm-teardown-endpoint-safety.test.sh` passes.
- `tests/fm-teardown.test.sh` passes.
- A real Orca scout worktree was created, given a completed report, torn down end to end, and verified absent afterward; a subsequent real `orca worktree show` returned `selector_not_found`.
