### PR TITLE
fix(spawn,teardown): compare worktree paths by identity, not string equality

### DIFF
--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -684,6 +684,17 @@ resolved_existing_dir() {
   cd "$path" && pwd -P
 }
 
+same_directory() {
+  local left=$1 right=$2
+  [ -n "$left" ] || return 1
+  [ -n "$right" ] || return 1
+  if [ -e "$left" ] && [ -e "$right" ]; then
+    [ "$left" -ef "$right" ]
+  else
+    [ "$left" = "$right" ]
+  fi
+}
+
 resolve_project_dir_arg() {
   local path=$1
   case "$path" in
@@ -693,13 +704,16 @@ resolve_project_dir_arg() {
 }
 
 path_is_ancestor_of() {
-  local ancestor=$1 path=$2
+  local ancestor=$1 path=$2 parent
   [ -n "$ancestor" ] || return 1
   [ -n "$path" ] || return 1
-  [ "$ancestor" != "$path" ] || return 1
-  case "$path" in
-    "$ancestor"/*) return 0 ;;
-  esac
+  same_directory "$ancestor" "$path" && return 1
+  while [ "$path" != "/" ]; do
+    parent=${path%/*}
+    [ -n "$parent" ] || parent=/
+    same_directory "$ancestor" "$parent" && return 0
+    path=$parent
+  done
   return 1
 }
 
@@ -712,11 +726,11 @@ validate_firstmate_home_for_spawn() {
     echo "error: secondmate home cannot be the filesystem root: $home" >&2
     return 1
   fi
-  if [ "$abs_home" = "$abs_active_home" ]; then
+  if same_directory "$abs_home" "$abs_active_home"; then
     echo "error: secondmate home cannot be the active firstmate home: $home" >&2
     return 1
   fi
-  if [ "$abs_home" = "$abs_root" ]; then
+  if same_directory "$abs_home" "$abs_root"; then
     echo "error: secondmate home cannot be the firstmate repo: $home" >&2
     return 1
   fi
@@ -777,11 +791,11 @@ validate_firstmate_operational_dirs() {
       echo "error: secondmate $name directory must resolve inside the secondmate home: $dir" >&2
       return 1
     fi
-    if [ "$abs_dir" = "$abs_active_home" ] || path_is_ancestor_of "$abs_active_home" "$abs_dir"; then
+    if same_directory "$abs_dir" "$abs_active_home" || path_is_ancestor_of "$abs_active_home" "$abs_dir"; then
       echo "error: secondmate $name directory cannot be inside the active firstmate home: $dir" >&2
       return 1
     fi
-    if [ "$abs_dir" = "$abs_root" ] || path_is_ancestor_of "$abs_root" "$abs_dir"; then
+    if same_directory "$abs_dir" "$abs_root" || path_is_ancestor_of "$abs_root" "$abs_dir"; then
       echo "error: secondmate $name directory cannot be inside the firstmate repo: $dir" >&2
       return 1
     fi
@@ -893,7 +907,9 @@ validate_spawn_worktree() {  # <source> <inspect-target>
   if ! wt_top_real=$(cd "$wt_top" 2>/dev/null && pwd -P); then
     wt_top_real=
   fi
-  if [ -z "$wt_real" ] || [ -z "$wt_top_real" ] || [ "$wt_real" != "$wt_top_real" ] || [ "$wt_real" = "$proj_real" ]; then
+  if [ -z "$wt_real" ] || [ -z "$wt_top_real" ] \
+     || ! same_directory "$wt_real" "$wt_top_real" \
+     || same_directory "$wt_real" "$proj_real"; then
     echo "error: $source did not yield an isolated worktree (resolved '$WT'; worktree root '${wt_top:-none}'; primary '$PROJ_ABS'); refusing to launch to avoid tangling the primary checkout. Inspect target $inspect_target" >&2
     exit 1
   fi
@@ -1324,8 +1340,8 @@ if [ "$KIND" != secondmate ] && [ "$BACKEND" != orca ]; then
     p=$(spawn_current_path "$WT_TARGET" || true)
     if [ -n "$p" ]; then
       p_real=$(real_path_or_raw "$p")
-      if [ "$p_real" != "$PROJ_ABS_REAL" ]; then
-        if [ -n "$candidate" ] && [ "$p_real" = "$candidate" ]; then
+      if ! same_directory "$p_real" "$PROJ_ABS_REAL"; then
+        if [ -n "$candidate" ] && same_directory "$p_real" "$candidate"; then
           WT="$p"
           break
         fi

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -121,14 +121,25 @@ FM_LOCK_LOG_PREFIX=teardown
 
 META="$STATE/$ID.meta"
 [ -f "$META" ] || { echo "error: no meta for task $ID at $META" >&2; exit 1; }
+WT=$(fm_meta_get "$META" worktree)
+PROJ=$(fm_meta_get "$META" project)
+KIND=$(fm_meta_get "$META" kind)
+[ -n "$KIND" ] || KIND=ship
+if [ "$KIND" != secondmate ] \
+   && [ -n "$WT" ] && [ -n "$PROJ" ] && [ -d "$WT" ] && [ -d "$PROJ" ] \
+   && [ "$WT" -ef "$PROJ" ]; then
+  echo "REFUSED: task $ID records the project clone as its worktree." >&2
+  echo "Recorded worktree: $WT" >&2
+  echo "Recorded project: $PROJ" >&2
+  echo "Inspect suspect task metadata at $META before retrying teardown." >&2
+  exit 1
+fi
 # This is the first cleanup authorization check. It is metadata-only and must
 # complete before fm-guard, a backend command, file removal, branch deletion,
 # worktree return, registry change, or process termination can run.
 fm_backend_validate_task_endpoint "$META" "$ID" || exit 1
 BACKEND=$FM_BACKEND_VALIDATED_BACKEND
 T=$FM_BACKEND_VALIDATED_TARGET
-WT=$(fm_meta_get "$META" worktree)
-PROJ=$(fm_meta_get "$META" project)
 T_ORCA=
 [ "$BACKEND" != orca ] || T_ORCA=$T
 "$FM_ROOT/bin/fm-guard.sh" || true
@@ -144,8 +155,6 @@ fi
 ORCA_WORKTREE_ID=$(fm_meta_get "$META" orca_worktree_id)
 ORCA_PATH_MATCH_VERIFIED=0
 
-KIND=$(grep '^kind=' "$META" | cut -d= -f2- || true)
-[ -n "$KIND" ] || KIND=ship
 MODE=$(grep '^mode=' "$META" | cut -d= -f2- || true)
 [ -n "$MODE" ] || MODE=no-mistakes
 PUBLIC_FOLLOWUP_HOME=$FM_HOME
@@ -1406,27 +1415,21 @@ if [ "$BACKEND" = orca ] && [ "$KIND" != secondmate ]; then
   fi
   if [ -d "$WT" ]; then
     branch=$(git -C "$WT" rev-parse --abbrev-ref HEAD 2>/dev/null || echo HEAD)
-    if [ "$branch" != "HEAD" ]; then
-      if git -C "$WT" checkout --detach -q 2>/dev/null; then
-        git -C "$WT" branch -D "$branch" >/dev/null 2>&1 || true
-      fi
-    fi
+  else
+    branch=HEAD
+  fi
+  [ -z "$T_ORCA" ] || fm_backend_kill "$BACKEND" "$T" "$(meta_value "$META" zellij_tab_id)" "fm-$ID" 2>/dev/null || true
+  fm_backend_remove_worktree "$BACKEND" "$ORCA_WORKTREE_ID"
+  if [ -n "$WT" ]; then
     rm -f "$WT/.claude/settings.local.json" "$WT/.opencode/plugins/fm-turn-end.js" \
       "$WT/.opencode/plugins/fm-busy-state.js" \
       "$WT/.fm-grok-turnend" "$WT/.fm-kimi-turnend"
   fi
-  [ -z "$T_ORCA" ] || fm_backend_kill "$BACKEND" "$T" "$(meta_value "$META" zellij_tab_id)" "fm-$ID" 2>/dev/null || true
-  fm_backend_remove_worktree "$BACKEND" "$ORCA_WORKTREE_ID"
+  if [ "$branch" != "HEAD" ]; then
+    git -C "$PROJ" branch -D "$branch" >/dev/null 2>&1 || true
+  fi
 elif [ -d "$WT" ] && [ "$KIND" != secondmate ]; then
   branch=$(git -C "$WT" rev-parse --abbrev-ref HEAD 2>/dev/null || echo HEAD)
-  if [ "$branch" != "HEAD" ]; then
-    if git -C "$WT" checkout --detach -q 2>/dev/null; then
-      git -C "$WT" branch -D "$branch" >/dev/null 2>&1 || true
-    fi
-  fi
-  # Remove our hook file so a reused pool worktree cannot fire signals for a dead task.
-  rm -f "$WT/.claude/settings.local.json" "$WT/.opencode/plugins/fm-turn-end.js" \
-    "$WT/.fm-grok-turnend" "$WT/.fm-kimi-turnend"
   # Kills remaining processes in the worktree (including the agent), resets, returns
   # to pool. treehouse resolves the pool from the working directory, so run it from
   # the project. teardown_treehouse_return tolerates transient and stale git locks
@@ -1439,6 +1442,13 @@ elif [ -d "$WT" ] && [ "$KIND" != secondmate ]; then
     echo "error: treehouse return failed for worktree $WT; teardown aborted" >&2
     exit 1
   }
+  # Remove our hook file so a reused pool worktree cannot fire signals for a dead task.
+  rm -f "$WT/.claude/settings.local.json" "$WT/.opencode/plugins/fm-turn-end.js" \
+    "$WT/.opencode/plugins/fm-busy-state.js" \
+    "$WT/.fm-grok-turnend" "$WT/.fm-kimi-turnend"
+  if [ "$branch" != "HEAD" ]; then
+    git -C "$PROJ" branch -D "$branch" >/dev/null 2>&1 || true
+  fi
 fi
 
 HERDR_PRESENTATION_JOURNAL="$STATE/$ID.herdr-presentation"

--- a/tests/fm-spawn-worktree-settle.test.sh
+++ b/tests/fm-spawn-worktree-settle.test.sh
@@ -12,6 +12,12 @@
 # transient-then-settled pane_current_path sequence with a fake tmux and
 # asserts the recorded worktree resolves to the real, settled worktree, never
 # the stale first read.
+#
+# It also reproduces a case-variant project path without requiring a
+# case-insensitive host filesystem. The fake tmux renames `coding` to `Coding`
+# after spawn records the original physical project path. On a case-sensitive
+# host, it adds a symlink at the original spelling. Both spellings then identify
+# the same real directory, but their strings remain different.
 set -u
 
 # shellcheck source=tests/lib.sh
@@ -49,7 +55,17 @@ case "${1:-}" in
   display-message) printf 'firstmate\n'; exit 0 ;;
   list-windows) exit 0 ;;
   has-session|new-session|new-window|kill-window) exit 0 ;;
-  send-keys) exit 0 ;;
+  send-keys)
+    if [ -n "${FM_FAKE_CASE_RENAME_FROM:-}" ] \
+       && [ ! -e "${FM_FAKE_CASE_RENAME_MARKER:?}" ]; then
+      mv "$FM_FAKE_CASE_RENAME_FROM" "${FM_FAKE_CASE_RENAME_TO:?}"
+      if [ ! -e "$FM_FAKE_CASE_RENAME_FROM" ]; then
+        ln -s "$FM_FAKE_CASE_RENAME_TO" "$FM_FAKE_CASE_RENAME_FROM"
+      fi
+      : > "$FM_FAKE_CASE_RENAME_MARKER"
+    fi
+    exit 0
+    ;;
 esac
 exit 0
 SH
@@ -64,13 +80,24 @@ SH
 # entirely, distinct from both the project and the worktree - mirroring the
 # live incident where the stale read was another real firstmate home).
 make_settle_case() {
-  local name=$1 id=$2 stale_reads=$3 case_dir home proj wt stale fakebin countfile
+  local name=$1 id=$2 stale_reads=$3 rename_case=${4:-0}
+  local case_dir home proj wt stale fakebin countfile case_from case_to case_marker
   case_dir="$TMP_ROOT/$name"
   home="$case_dir/home"
-  proj="$case_dir/project"
   wt="$case_dir/wt"
   stale="$case_dir/stale-other-checkout"
   countfile="$case_dir/pane-call-count"
+  case_from=
+  case_to=
+  case_marker=
+  if [ "$rename_case" = 1 ]; then
+    case_from="$case_dir/coding"
+    case_to="$case_dir/Coding"
+    case_marker="$case_dir/case-renamed"
+    proj="$case_from/project"
+  else
+    proj="$case_dir/project"
+  fi
   fakebin=$(make_settle_fakebin "$case_dir/fake")
   mkdir -p "$home/data" "$home/projects" "$home/state" "$home/config"
   printf 'codex\n' > "$home/config/crew-harness"
@@ -79,11 +106,11 @@ make_settle_case() {
   mkdir -p "$home/data/$id"
   printf 'brief for %s\n' "$id" > "$home/data/$id/brief.md"
   touch "$home/state/.last-watcher-beat"
-  printf '%s\n' "$case_dir|$home|$proj|$wt|$stale|$fakebin|$countfile|$stale_reads"
+  printf '%s\n' "$case_dir|$home|$proj|$wt|$stale|$fakebin|$countfile|$stale_reads|$case_from|$case_to|$case_marker"
 }
 
 read_settle_record() {
-  IFS='|' read -r _ HOME_DIR PROJ_DIR WT_DIR STALE_DIR FAKEBIN_DIR COUNTFILE STALE_READS <<EOF
+  IFS='|' read -r _ HOME_DIR PROJ_DIR WT_DIR STALE_DIR FAKEBIN_DIR COUNTFILE STALE_READS CASE_FROM CASE_TO CASE_MARKER <<EOF
 $1
 EOF
 }
@@ -96,6 +123,8 @@ run_settle_spawn() {
     FM_SPAWN_NO_GUARD=1 TMUX="fake,1,0" \
     FM_FAKE_PANE_PATH="$WT_DIR" FM_FAKE_PANE_STALE="$STALE_DIR" \
     FM_FAKE_PANE_STALE_READS="$STALE_READS" FM_FAKE_PANE_COUNTFILE="$COUNTFILE" \
+    FM_FAKE_CASE_RENAME_FROM="$CASE_FROM" FM_FAKE_CASE_RENAME_TO="$CASE_TO" \
+    FM_FAKE_CASE_RENAME_MARKER="$CASE_MARKER" \
     PATH="$FAKEBIN_DIR:$PATH" \
     "$SPAWN" "$id" "$PROJ_DIR" 2>&1
 }
@@ -141,7 +170,27 @@ test_already_settled_pane_costs_one_confirm_sleep() {
   pass "an already-settled pane confirms via the existing inter-poll sleep, not an extra full cycle"
 }
 
+test_case_variant_project_alias_is_not_accepted() {
+  local rec id out status
+  id=settle-case-variant-z3
+  rec=$(make_settle_case settle-case-variant "$id" 2 1)
+  read_settle_record "$rec"
+  STALE_DIR="$CASE_TO/project"
+
+  out=$(run_settle_spawn "$id")
+  status=$?
+  expect_code 0 "$status" "spawn should wait past a case-variant path to the project"
+  [ "$CASE_FROM/project" -ef "$CASE_TO/project" ] \
+    || fail "case-variant fixture paths do not identify the same directory"
+  assert_grep "worktree=$WT_DIR" "$HOME_DIR/state/$id.meta" \
+    "meta did not record the isolated worktree after the case-variant project reads"
+  assert_no_grep "worktree=$CASE_TO/project" "$HOME_DIR/state/$id.meta" \
+    "meta recorded the case-variant project clone as the worktree"
+  pass "case-variant path spellings of the project are treated as the same directory"
+}
+
 test_single_stale_first_read_is_not_accepted
 test_already_settled_pane_costs_one_confirm_sleep
+test_case_variant_project_alias_is_not_accepted
 
 echo "# all fm-spawn-worktree-settle tests passed"

--- a/tests/fm-teardown.test.sh
+++ b/tests/fm-teardown.test.sh
@@ -49,6 +49,8 @@
 #   (w) index.lock mtime read failure                         -> lock kept, REFUSE
 #   (x) transient lock cleared after first failed return      -> retry ALLOW
 #   (y) persistent lock (never clears, not provably stale)    -> REFUSE loudly
+#   (z) worktree and project identify the same directory      -> REFUSE unchanged
+#   (aa) non-lock treehouse return failure                    -> branch preserved
 set -u
 
 # shellcheck source=tests/lib.sh disable=SC1091
@@ -394,6 +396,16 @@ if [ "${1:-}" = return ]; then
   exit 128
 fi
 exit 0
+SH
+  chmod +x "$case_dir/fakebin/treehouse"
+}
+
+add_failing_treehouse() {
+  local case_dir=$1
+  cat > "$case_dir/fakebin/treehouse" <<'SH'
+#!/usr/bin/env bash
+echo "treehouse: simulated non-lock return failure" >&2
+exit 9
 SH
   chmod +x "$case_dir/fakebin/treehouse"
 }
@@ -1264,6 +1276,70 @@ test_teardown_missing_busy_sidecar_completes() {
   pass "teardown completes when an exact busy-state sidecar is already absent"
 }
 
+test_same_directory_metadata_refuses_without_changing_project() {
+  local case_dir rc branch_before branch_after
+  case_dir=$(make_case same-directory-metadata)
+  fm_write_meta "$case_dir/state/task-x1.meta" \
+    "window=firstmate:fm-task-x1" \
+    "endpoint_task_id=task-x1" \
+    "worktree=$case_dir/project" \
+    "project=$case_dir/project" \
+    "kind=ship" \
+    "mode=local-only"
+  branch_before=$(git -C "$case_dir/project" symbolic-ref --quiet --short HEAD)
+
+  set +e
+  run_teardown "$case_dir" --force > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 1 "$rc" "same-directory-metadata: teardown should refuse even with --force"
+  assert_grep "REFUSED: task task-x1 records the project clone as its worktree." "$case_dir/stderr" \
+    "same-directory-metadata: refusal did not explain the metadata defect"
+  assert_grep "Recorded worktree: $case_dir/project" "$case_dir/stderr" \
+    "same-directory-metadata: refusal did not name the worktree path"
+  assert_grep "Recorded project: $case_dir/project" "$case_dir/stderr" \
+    "same-directory-metadata: refusal did not name the project path"
+  assert_grep "$case_dir/state/task-x1.meta" "$case_dir/stderr" \
+    "same-directory-metadata: refusal did not name the suspect metadata"
+  branch_after=$(git -C "$case_dir/project" symbolic-ref --quiet --short HEAD)
+  [ "$branch_after" = "$branch_before" ] \
+    || fail "same-directory-metadata: teardown changed the project branch"
+  git -C "$case_dir/project" show-ref --verify --quiet "refs/heads/$branch_before" \
+    || fail "same-directory-metadata: teardown deleted the project branch"
+  pass "teardown refuses same-directory metadata before changing the project clone"
+}
+
+test_treehouse_return_failure_preserves_task_branch() {
+  local case_dir rc branch_before branch_after
+  case_dir=$(make_case treehouse-return-abort)
+  write_meta "$case_dir" local-only ship
+  add_failing_treehouse "$case_dir"
+  mkdir -p "$case_dir/wt/.claude"
+  : > "$case_dir/wt/.claude/settings.local.json"
+  : > "$case_dir/wt/.fm-grok-turnend"
+  branch_before=$(git -C "$case_dir/wt" symbolic-ref --quiet --short HEAD)
+
+  set +e
+  run_teardown "$case_dir" --force > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 1 "$rc" "treehouse-return-abort: teardown should report the provider failure"
+  assert_grep "treehouse: simulated non-lock return failure" "$case_dir/stderr" \
+    "treehouse-return-abort: teardown hid the provider failure"
+  branch_after=$(git -C "$case_dir/wt" symbolic-ref --quiet --short HEAD)
+  [ "$branch_after" = "$branch_before" ] \
+    || fail "treehouse-return-abort: teardown detached the task worktree"
+  git -C "$case_dir/project" show-ref --verify --quiet "refs/heads/$branch_before" \
+    || fail "treehouse-return-abort: teardown deleted the task branch"
+  assert_present "$case_dir/wt/.claude/settings.local.json" \
+    "treehouse-return-abort: teardown removed the Claude hook before return succeeded"
+  assert_present "$case_dir/wt/.fm-grok-turnend" \
+    "treehouse-return-abort: teardown removed the Grok hook before return succeeded"
+  pass "treehouse return failure leaves the task worktree and branch unchanged"
+}
+
 test_herdr_teardown_clears_escalation_marker() {
   local case_dir marker
   case_dir=$(make_case herdr-marker-cleanup)
@@ -1833,6 +1909,8 @@ test_no_mistakes_origin_remote_allows
 test_no_mistakes_truly_unpushed_refuses
 test_local_only_force_overrides_unpushed
 test_teardown_missing_busy_sidecar_completes
+test_same_directory_metadata_refuses_without_changing_project
+test_treehouse_return_failure_preserves_task_branch
 test_herdr_teardown_clears_escalation_marker
 test_herdr_flat_teardown_refuses_orphaning_records_then_retry_completes
 test_herdr_flat_teardown_refuses_records_on_unparseable_presence


### PR DESCRIPTION
## Problem

Spawn compared directory paths as strings. On a case-insensitive, case-preserving filesystem (macOS default), `/x/Coding/y` and `/x/coding/y` name the same directory but compare as different strings.

The worktree-settle loop in `fm-spawn.sh` waits for the pane's cwd to differ from the project path before accepting it as the isolated task worktree. When `FM_ROOT` and the pane's reported cwd disagree only in case, that check passes immediately and spawn records **the project clone itself** as `worktree=` in `state/<id>.meta`.

That defeats the isolation assertion: it fails open, accepting the primary project directory as an "isolated worktree".

`fm-teardown.sh` then made it destructive. It ran, in this order:

```sh
branch=$(git -C "$WT" rev-parse --abbrev-ref HEAD)   # = main, because WT is the clone
git -C "$WT" checkout --detach -q
git -C "$WT" branch -D "$branch"                     # deletes the clone's default branch
...
teardown_treehouse_return ... || { echo "error: ..."; exit 1; }   # fails, aborts AFTER the delete
```

The project clone is left on a detached HEAD with its default branch deleted, and teardown exits non-zero with no rollback.

## Reproduction

Observed live on macOS, twice, with `FM_ROOT` resolving as `/Users/<u>/coding/firstmate` while the pane reported `/Users/<u>/Coding/firstmate`:

```
project=  /Users/<u>/coding/firstmate/projects/loadout
worktree= /Users/<u>/Coding/firstmate/projects/loadout
```

```sh
[ "$a" = "$b" ]   # false  <- what the code used
[ "$a" -ef "$b" ] # true   <- the actual truth
```

Teardown deleted `main` in the clone and aborted. Correcting `worktree=` by hand made the same teardown succeed, isolating the cause.

## Fix

**`bin/fm-spawn.sh`** — added `same_directory()` using the POSIX `-ef` same-file test, with a string fallback when a path does not exist yet. Applied to the worktree-settle comparison, `validate_spawn_worktree`, and the secondmate home/operational-dir guards. `path_is_ancestor_of` now walks parents with the same identity test instead of a string prefix match, so it is also correct across case variants and symlinks.

**`bin/fm-teardown.sh`** — two changes:

1. Refuses up front, before any mutation, when the recorded worktree and project are the same directory, naming both paths and the suspect metadata file.
2. Defers hook cleanup and branch deletion until **after** `teardown_treehouse_return` succeeds, and deletes the branch via `$PROJ` rather than detaching `$WT`. An aborted teardown can no longer leave the repository worse than it found it.

## Tests

- `tests/fm-spawn-worktree-settle.test.sh` — case-variant spellings of the project are treated as the same directory
- `tests/fm-teardown.test.sh` — teardown refuses same-directory metadata before changing the project clone; branch is preserved when the return step fails

Full suites pass: spawn-worktree-settle, teardown, teardown-endpoint-safety, spawn-dispatch-profile, secondmate-safety (134 assertions). ShellCheck clean on both scripts (the one remaining SC2034 is pre-existing).
