### PR TITLE
fix: stream fleet-sized JSON into snapshot projections

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -358,8 +358,8 @@ jobs:
           bearings_output=$(/bin/bash tests/fm-bearings-snapshot.test.sh)
           printf '%s\n' "$bearings_output"
           bearings_count=$(printf '%s\n' "$bearings_output" | grep -c '^ok - ')
-          [ "$bearings_count" -eq 41 ] || {
-            echo "::error::expected 41 Bearings tests, got $bearings_count"
+          [ "$bearings_count" -eq 42 ] || {
+            echo "::error::expected 42 Bearings tests, got $bearings_count"
             exit 1
           }
 

--- a/bin/fm-bearings-snapshot.sh
+++ b/bin/fm-bearings-snapshot.sh
@@ -158,6 +158,9 @@ done
 
 command -v jq >/dev/null 2>&1 || { echo "fm-bearings-snapshot: jq not found" >&2; exit 1; }
 
+# JSON documents that grow with the fleet are bound with --slurpfile and unwrapped
+# by `doc(...)`, never with --argjson; bin/fm-fleet-snapshot.sh owns the reason.
+
 # The deterministic return-catch-up owner must clear before this or any other
 # ordinary captain request proceeds. Bearings does not reproduce that policy;
 # it only consults the shared read-only gate.
@@ -255,7 +258,11 @@ EOF
       cnt=$(printf '%s' "$repo_rows" | jq 'length')
       [ "$returned" -gt "$FM_BEARINGS_PR_LIMIT" ] && ncapped=$((ncapped + 1))
       npr=$((npr + cnt))
-      rows=$(jq -n --argjson a "$rows" --argjson b "$repo_rows" '$a + $b')
+      rows=$(jq -n \
+        --slurpfile a_doc <(printf '%s' "$rows") \
+        --slurpfile b_doc <(printf '%s' "$repo_rows") '
+        def doc($v): ($v[0] // error("fm-bearings-snapshot: empty jq payload"));
+        doc($a_doc) + doc($b_doc)')
     done
     PR_REPOS_SHOWN=$nrepos
     PR_ROWS_CAPPED=$ncapped
@@ -301,7 +308,8 @@ MODEL=$(printf '%s' "$SNAP" | jq \
   --argjson pr_repos_shown "$PR_REPOS_SHOWN" \
   --argjson pr_rows_capped "$PR_ROWS_CAPPED" \
   --argjson pr_rows_min_total "$PR_ROWS_MIN_TOTAL" \
-  --argjson candidate_prs "$CANDIDATE_PRS" '
+  --slurpfile candidate_prs_doc <(printf '%s' "$CANDIDATE_PRS") '
+  def doc($v): ($v[0] // error("fm-bearings-snapshot: empty jq payload"));
   def trunc($n): if . == null then null else
     (tostring | gsub("\\s+"; " ") | if (length > $n) then (.[:$n] + "…") else . end) end;
   def round_robin_landed($n):
@@ -310,7 +318,8 @@ MODEL=$(printf '%s' "$SNAP" | jq \
        | $groups[]
        | select(length > $i)
        | .[$i]][:$n];
-  ($fields | split(",") | map(gsub("^\\s+|\\s+$"; "")) | map(select(. != ""))) as $fl
+  doc($candidate_prs_doc) as $candidate_prs
+  | ($fields | split(",") | map(gsub("^\\s+|\\s+$"; "")) | map(select(. != ""))) as $fl
   | (($fl | index("bodies")) != null) as $f_bodies
   | (($fl | index("paths")) != null) as $f_paths
   | (($fl | index("actions")) != null) as $f_actions

--- a/bin/fm-fleet-snapshot.sh
+++ b/bin/fm-fleet-snapshot.sh
@@ -174,6 +174,22 @@ esac
 
 command -v jq >/dev/null 2>&1 || { echo "fm-fleet-snapshot: jq not found" >&2; exit 1; }
 
+# jq payload convention, applied by every call site below that binds a JSON
+# document whose size grows with the fleet (backlog, task inventory, secondmate
+# summaries, aggregation accumulators).
+# Such a document is bound with `--slurpfile <name>_doc <(printf '%s' "$x")` and
+# unwrapped in the filter by `doc($<name>_doc) as $<name>`, never with --argjson.
+# Reason: Linux caps a SINGLE argv string at MAX_ARG_STRLEN (32 pages = 131072
+# bytes), independently of the much larger total ARG_MAX, so --argjson makes
+# execve fail with E2BIG ("Argument list too long") once one payload crosses that
+# ceiling - which a working fleet's backlog JSON already does. Reading the payload
+# from a stream removes the ceiling without touching the filters' data model.
+# `doc` also keeps the previous fail-closed behavior of --argjson: an empty or
+# missing payload aborts the filter instead of silently projecting a null.
+# Scalars, single paths, and per-record documents bounded by this script's
+# FM_SNAPSHOT_* read bounds stay on --arg/--argjson: they cannot grow with the
+# fleet, and argv keeps them adjacent to the names they bind.
+
 bool_json() {
   if [ "$1" = 1 ]; then printf 'true'; else printf 'false'; fi
 }
@@ -606,9 +622,12 @@ task_json_lines() {
 # discloses backlog↔task inconsistency for renderers (Bearings omitted/gates).
 main_inventory_json() {  # <backlog-json> <tasks-json>
   jq -n \
-    --argjson backlog "$1" \
-    --argjson tasks "$2" '
-    ([ $backlog.records[]?
+    --slurpfile backlog_doc <(printf '%s' "$1") \
+    --slurpfile tasks_doc <(printf '%s' "$2") '
+    def doc($v): ($v[0] // error("fm-fleet-snapshot: empty jq payload"));
+    doc($backlog_doc) as $backlog
+    | doc($tasks_doc) as $tasks
+    | ([ $backlog.records[]?
        | select((.state == "in_flight" or .state == "queued") and (.structured | not)) ]) as $unstructured_current
     | ([ $backlog.records[]?
          | select(.state == "in_flight" and .structured and .requires_child_metadata) ]) as $owned_in_flight
@@ -640,12 +659,15 @@ secondmate_home_summary_json() {  # <backlog-json> <tasks-json>
     --argjson queued_n "$FM_SNAPSHOT_SECONDMATE_QUEUED" \
     --argjson decisions_n "$FM_SNAPSHOT_SECONDMATE_DECISIONS" \
     --argjson landed_n "$FM_SNAPSHOT_SECONDMATE_LANDED_PER_HOME" \
-    --argjson backlog "$1" \
-    --argjson tasks "$2" '
+    --slurpfile backlog_doc <(printf '%s' "$1") \
+    --slurpfile tasks_doc <(printf '%s' "$2") '
+    def doc($v): ($v[0] // error("fm-fleet-snapshot: empty jq payload"));
     def trunc($n):
       tostring | gsub("\\s+"; " ")
       | if length > $n then .[:$n] + "…" else . end;
-    ([ $backlog.records[]?
+    doc($backlog_doc) as $backlog
+    | doc($tasks_doc) as $tasks
+    | ([ $backlog.records[]?
        | select((.state == "in_flight" or .state == "queued") and (.structured | not)) ]) as $unstructured_current
     | ([ $backlog.records[]? | select(.state == "in_flight" and .structured) ]) as $owned_in_flight
     | ([ $backlog.records[]?
@@ -1062,7 +1084,10 @@ terminal_evidence_json() {  # <parent-task-json> <event-note> <evidence-contradi
 }
 
 parent_evidence_reconciliation_json() {  # <summary-json> <activities-json> <decisions-json>
-  jq -n --argjson summary "$1" --argjson activities "$2" --argjson decisions "$3" '
+  jq -n \
+    --slurpfile summary_doc <(printf '%s' "$1") \
+    --argjson activities "$2" --argjson decisions "$3" '
+    def doc($v): ($v[0] // error("fm-fleet-snapshot: empty jq payload"));
     def keyed: . != null and . != "" and . != "default";
     def result($e; $matches; $complete; $surface):
       $e + {
@@ -1073,7 +1098,8 @@ parent_evidence_reconciliation_json() {  # <summary-json> <activities-json> <dec
         compared_to:$surface,
         matched:(if ($e.key | keyed) then ($matches[0] // null) else null end)
       };
-    ([ $activities[] as $e
+    doc($summary_doc) as $summary
+    | ([ $activities[] as $e
        | if $e.verb == "working" then
            ([ $summary.active_children[]
               | select(if ($e.key | keyed) then .id == $e.key else true end)
@@ -1127,8 +1153,13 @@ secondmate_current_json() {  # <parent-tasks-json>
   local activity_scan activities decisions reconciliation provenance freshness reason summary summary_rc summary_bytes summary_valid summary_reason summary_invalidity state current_reason terminal terminal_contradiction contradiction
   local records='[]' seen_homes=''
   registry=$(registry_secondmates_json) || return 1
-  union=$(jq -n --argjson registry "$registry" --argjson tasks "$tasks" '
-    ($registry.records // []) as $registered
+  union=$(jq -n \
+    --slurpfile registry_doc <(printf '%s' "$registry") \
+    --slurpfile tasks_doc <(printf '%s' "$tasks") '
+    def doc($v): ($v[0] // error("fm-fleet-snapshot: empty jq payload"));
+    doc($registry_doc) as $registry
+    | doc($tasks_doc) as $tasks
+    | ($registry.records // []) as $registered
     | (($registered | map(.id)) // []) as $registered_ids
     | ([ $registered[] as $r
          | $r + {parent_task:([$tasks[] | select(.id == $r.id)][0] // null)} ]
@@ -1268,11 +1299,14 @@ secondmate_current_json() {  # <parent-tasks-json>
       if printf '%s' "$terminal" | jq -e '.contradiction == true' >/dev/null; then contradiction=true; fi
       record=$(jq -n \
         --arg id "$id" --arg home "$home" --arg host "$host" --argjson remote "$remote" --arg state "$state" --arg current_reason "$current_reason" --arg observed "$SNAPSHOT_NOW" \
-        --argjson registered "$registered" --argjson summary "$summary" --argjson summary_valid "$summary_valid" --argjson decisions "$decisions" \
+        --argjson registered "$registered" --argjson summary_valid "$summary_valid" --argjson decisions "$decisions" \
+        --slurpfile summary_doc <(printf '%s' "$summary") \
         --argjson activities "$activities" --argjson activity_scan "$activity_scan" \
         --argjson reconciliation "$reconciliation" --argjson terminal "$terminal" --argjson contradiction "$contradiction" \
         --arg event_raw "$event_raw" --arg event_note "$event_note" --argjson event_age "$event_age" '
-        {id:$id,home:$home,host:($host | if . == "" then null else . end),remote:$remote,registered:$registered,
+        def doc($v): ($v[0] // error("fm-fleet-snapshot: empty jq payload"));
+        doc($summary_doc) as $summary
+        | {id:$id,home:$home,host:($host | if . == "" then null else . end),remote:$remote,registered:$registered,
          current:{state:$state,reason:($current_reason | if . == "" then null else . end)},invalidity:$summary.invalidity,
          provenance:{selected:"structured-home",structured_home:$home,summary_valid:$summary_valid,
            trust:(if $summary_valid then "complete" else "partial-structured" end),parent_event_role:"historical-only"},
@@ -1309,23 +1343,32 @@ secondmate_current_json() {  # <parent-tasks-json>
          parent_event:{raw:$event_raw,note:$event_note,age_seconds:$event_age,open_activities:$activities,open_decisions:$decisions,activity_scan:$activity_scan},
          terminal_evidence:$terminal,contradiction:false}')
     fi
-    records=$(jq -n --argjson records "$records" --argjson record "$record" '$records + [$record]')
+    records=$(jq -n \
+      --slurpfile records_doc <(printf '%s' "$records") \
+      --slurpfile record_doc <(printf '%s' "$record") '
+      def doc($v): ($v[0] // error("fm-fleet-snapshot: empty jq payload"));
+      doc($records_doc) + [doc($record_doc)]')
   done <<EOF
 $rows
 EOF
   jq -n \
-    --argjson registry "$(printf '%s' "$union" | jq '.registry')" \
-    --argjson records "$records" \
+    --slurpfile registry_doc <(printf '%s' "$union" | jq '.registry') \
+    --slurpfile records_doc <(printf '%s' "$records") \
     --argjson total_registered "$total_registered" \
     --argjson total "$total" \
     --argjson shown "$shown" \
     --argjson truncated "$truncated" \
-    '{registry:$registry,records:$records,total_registered:$total_registered,total:$total,shown:$shown,truncated:$truncated}'
+    'def doc($v): ($v[0] // error("fm-fleet-snapshot: empty jq payload"));
+     doc($registry_doc) as $registry
+     | doc($records_doc) as $records
+     | {registry:$registry,records:$records,total_registered:$total_registered,total:$total,shown:$shown,truncated:$truncated}'
 }
 
 secondmate_landed_from_current_json() {  # <secondmate-current-json>
-  jq -n --argjson current "$1" '
-    {records:[ $current.records[]
+  jq -n --slurpfile current_doc <(printf '%s' "$1") '
+    def doc($v): ($v[0] // error("fm-fleet-snapshot: empty jq payload"));
+    doc($current_doc) as $current
+    | {records:[ $current.records[]
       | select(.provenance.selected == "structured-home") as $mate
       | $mate.landed[]
       | . + {home:$mate.home,home_id:$mate.id}],
@@ -1381,13 +1424,20 @@ jq -n \
   --arg data "$DATA" \
   --arg config "$CONFIG" \
   --arg projects "$PROJECTS" \
-  --argjson backlog "$BACKLOG_JSON" \
-  --argjson tasks "$TASKS_JSON" \
-  --argjson main_inventory "$MAIN_INVENTORY_JSON" \
-  --argjson scout_reports "$SCOUT_REPORTS_JSON" \
-  --argjson secondmate_current "$SECONDMATE_CURRENT_JSON" \
-  --argjson secondmate_landed "$SECONDMATE_LANDED_JSON" \
-  'def backlog_by_id($id): ($backlog.records[]? | select(.structured == true and .id == $id) | .) // null;
+  --slurpfile backlog_doc <(printf '%s' "$BACKLOG_JSON") \
+  --slurpfile tasks_doc <(printf '%s' "$TASKS_JSON") \
+  --slurpfile main_inventory_doc <(printf '%s' "$MAIN_INVENTORY_JSON") \
+  --slurpfile scout_reports_doc <(printf '%s' "$SCOUT_REPORTS_JSON") \
+  --slurpfile secondmate_current_doc <(printf '%s' "$SECONDMATE_CURRENT_JSON") \
+  --slurpfile secondmate_landed_doc <(printf '%s' "$SECONDMATE_LANDED_JSON") \
+  'def doc($v): ($v[0] // error("fm-fleet-snapshot: empty jq payload"));
+   doc($backlog_doc) as $backlog
+   | doc($tasks_doc) as $tasks
+   | doc($main_inventory_doc) as $main_inventory
+   | doc($scout_reports_doc) as $scout_reports
+   | doc($secondmate_current_doc) as $secondmate_current
+   | doc($secondmate_landed_doc) as $secondmate_landed
+   | def backlog_by_id($id): ($backlog.records[]? | select(.structured == true and .id == $id) | .) // null;
    def task_by_id($id): ($tasks[]? | select(.id == $id) | .) // null;
    def report_kind($id): (task_by_id($id).kind // backlog_by_id($id).kind // "scout");
    {

--- a/tests/fm-bearings-snapshot.test.sh
+++ b/tests/fm-bearings-snapshot.test.sh
@@ -1889,6 +1889,66 @@ EOF
   pass "main and secondmate captain actionability use the same blocker readiness"
 }
 
+# Write a Done-heavy backlog whose parsed JSON is comfortably past the 131072-byte
+# per-argument execve ceiling, so a payload passed through argv cannot survive.
+write_oversized_backlog() {  # <home>
+  local i=1
+  {
+    printf '## In flight\n\n## Queued\n\n## Done\n'
+    while [ "$i" -le 200 ]; do
+      printf -- '- [x] landed-%04d - Landed change number %04d in the oversized fixture backlog https://github.com/kunchenguid/firstmate/pull/%d (repo: firstmate) (kind: ship) (merged 2026-07-10)\n' \
+        "$i" "$i" "$i"
+      i=$((i + 1))
+    done
+  } > "$1/data/backlog.md"
+}
+
+# A home whose backlog JSON is larger than a single argv string may be.
+# Linux caps ONE argv element at MAX_ARG_STRLEN (32 pages = 131072 bytes),
+# independently of the much larger total ARG_MAX, so any jq payload handed over
+# as --argjson makes execve fail with E2BIG once the fleet's backlog gets real.
+# Every snapshot mode must keep working, and the projection must stay complete.
+test_oversized_backlog_survives_the_per_argument_execve_limit() {
+  local home mate fakebin json backlog_bytes toon summary
+  home=$(make_home oversized-backlog)
+  mate=$(fixture_mate_home "$home")
+  write_fixture "$home"
+  write_oversized_backlog "$home"
+  write_oversized_backlog "$mate"
+  fakebin=$(make_fakebin "$home"); : > "$home/net.log"
+
+  json=$(FM_HOME="$home" FM_SNAPSHOT_NOW=2026-07-11T18:00:00Z PATH="$fakebin:$PATH" \
+    "$ROOT/bin/fm-fleet-snapshot.sh" --json) \
+    || fail "canonical snapshot failed on an oversized backlog"
+
+  # Guard the fixture itself: if the parsed backlog ever shrinks back under the
+  # ceiling this test stops proving anything, so it must fail rather than pass.
+  backlog_bytes=$(printf '%s' "$json" | jq -c '.backlog' | LC_ALL=C wc -c | tr -d ' ')
+  [ "$backlog_bytes" -gt 131072 ] \
+    || fail "fixture backlog JSON is only $backlog_bytes bytes; it no longer exceeds the 131072-byte per-argument limit"
+
+  printf '%s' "$json" | jq -e '
+    .schema == "fm-fleet-snapshot.v1"
+    and (.backlog.present == true)
+    and ([.backlog.records[] | select(.state == "done")] | length) >= 200
+    and (.main_inventory.valid | type) == "boolean"
+    and (.secondmate_current.records | type) == "array"
+    and (.secondmate_landed.records | type) == "array"
+  ' >/dev/null || fail "oversized-backlog snapshot lost projection completeness: $json"
+
+  summary=$(FM_HOME="$mate" FM_SNAPSHOT_NOW=2026-07-11T18:00:00Z PATH="$fakebin:$PATH" \
+    "$ROOT/bin/fm-fleet-snapshot.sh" --secondmate-home-summary) \
+    || fail "secondmate home summary failed on an oversized backlog"
+  printf '%s' "$summary" | jq -e '.schema == "fm-secondmate-home-summary.v1"' >/dev/null \
+    || fail "oversized-backlog secondmate home summary is malformed: $summary"
+
+  toon=$(run "$home" "$fakebin") || fail "bearings failed on an oversized backlog"
+  assert_contains "$toon" 'schema: fm-bearings.v1' "bearings output is not a bearings projection"
+  assert_contains "$toon" 'landed-' "bearings lost the oversized backlog's landed work"
+  pass "oversized backlog survives the per-argument execve limit in every snapshot mode"
+}
+
+test_oversized_backlog_survives_the_per_argument_execve_limit
 test_domain_alpha_stale_parent_event_does_not_become_current_work
 test_gnu_stat_uses_file_formats_without_bsd_fallback_pollution
 test_parent_activity_evidence_is_bounded_and_disclosed


### PR DESCRIPTION
## Intent

Fix /bearings, which is completely broken in any firstmate home with a real backlog: bin/fm-bearings-snapshot.sh and bin/fm-fleet-snapshot.sh --json both exit 1 with 'jq: Argument list too long' (the same shared snapshot code also broke /fleet).

Root cause, and a correction to the original bug report: the failure is the PER-ARGUMENT limit, not the total one. Linux caps a SINGLE argv string at MAX_ARG_STRLEN (32 pages = 131072 bytes), independently of the much larger total ARG_MAX. The primary home's backlog JSON is 216172 bytes, so passing it via --argjson makes execve fail with E2BIG even though total argv size is far under ARG_MAX. The backlog note blaming ARG_MAX was wrong.

Deliberate decisions made while doing the work, so they are not mistakes:

1. Chosen fix shape: every jq payload whose size grows with the fleet is now bound with --slurpfile from a process substitution and unwrapped inside the filter by a small local 'def doc($v): ($v[0] // error(...))' helper. The reference patch in the task brief used --slurpfile plus a leading rebinding line and was explicitly offered as evidence the approach works, not as a mandate; I kept that shape because it keeps each payload's name adjacent to its value and leaves the filters' data model untouched. The 'doc' helper is deliberate: plain $x[0] would turn an empty payload into a silently-null projection, whereas --argjson used to hard-error, so 'doc' preserves the previous fail-closed behavior.

2. Scope of the audit was deliberately wider than the three sites that fail today, as the task required. Nine sites were converted: main inventory, secondmate home summary, the top-level assembly, the secondmate registry/task union, the per-secondmate record, the record accumulator, the final secondmate assembly, the secondmate landed projection, the parent-evidence reconciliation, plus Bearings' candidate-PR rows and their per-repo accumulator. The per-secondmate summary was the sharpest non-obvious one: its own byte bound FM_SNAPSHOT_SECONDMATE_MAX_BYTES defaults to 262144, twice the argv ceiling, so it could fail on its own.

3. Deliberately NOT converted: scalars, single paths, and per-record documents already bounded by the script's FM_SNAPSHOT_* read bounds (parent activities bounded at 65536 bytes / 20 records, terminal evidence at 4096, registry at 65536 / 40 records, per-task fields derived from one task's own bounded reads). These cannot grow with the fleet, and argv keeps them adjacent to the names they bind. That reasoning is recorded as a comment in fm-fleet-snapshot.sh so a future reader knows the split was considered rather than missed.

4. Explicitly out of scope by instruction: no trimming, capping, or truncating of the backlog; no restructuring of the snapshot's data model or bounds; no change to schema, field names, bounds, or TOON rendering. Output was verified byte-identical to pre-fix behavior across --json, TOON, and --secondmate-home-summary on a fixture the old code could still handle.

5. The regression test in tests/fm-bearings-snapshot.test.sh was required to actually fail without the fix, and it does ('not ok - canonical snapshot failed on an oversized backlog'). It deliberately asserts its own precondition - that the parsed backlog JSON exceeds 131072 bytes - so it fails loudly rather than silently becoming a no-op if the record shape ever shrinks. It was colocated in the existing bearings test file rather than a new runner, per repo convention.

6. AGENTS.md was deliberately left untouched. This is script mechanics, which firstmate's own coding guidelines route to the script's header/comments rather than the always-loaded contract file; adding it to AGENTS.md would violate that file's size-discipline rule.

Constraint context: this is firstmate's shared tracked material, so repo style rules apply - one sentence per line in tracked prose, plain dash never em dash, shellcheck-clean bin scripts, colocated tests. bin/fm-lint.sh and bin/fm-doc-audience-check.sh both pass. This account has pull-only access upstream, so the PR is expected to wait for upstream approval.

## What Changed

- Stream fleet-sized backlog, inventory, secondmate aggregation, and candidate PR JSON into `jq` instead of passing it through argument strings, preventing `/bearings` and `/fleet` failures at the per-argument limit.
- Preserve fail-closed handling for empty streamed payloads without changing snapshot schemas, bounds, or rendering.
- Add regression coverage for oversized main and secondmate backlogs across fleet JSON, secondmate summaries, and Bearings output.

## Risk Assessment

✅ Low: The change consistently moves fleet-growing JSON payloads off argv while preserving the existing data model, fail-closed behavior, output contract, and explicitly scoped bounds.

## Testing

Diff/status baselines were clean, focused regression and adjacent-path tests passed, the base-versus-target counterfactual confirmed the argv defect, manual CLI evidence demonstrated all oversized snapshot modes, and small-fixture output remained byte-identical.

<details>
<summary>Evidence: End-to-end oversized CLI transcript</summary>

`Oversized 180,063-byte backlog produced valid fleet JSON, a valid secondmate summary accounting for 200 landed records, and actual Bearings TOON with zero network calls.`

```text
OVERSIZED INPUT
parsed backlog JSON bytes: 180063
Linux single-argument ceiling used by regression: 131072

FLEET --JSON RESPONSE SUMMARY
{"schema":"fm-fleet-snapshot.v1","backlog_present":true,"backlog_records":200,"done_records":200,"main_inventory_valid":true,"secondmate_records":1,"secondmate_landed_records":1}

SECONDMATE HOME SUMMARY
{"schema":"fm-secondmate-home-summary.v1","valid":true,"landed_records":10,"total_landed":200}

BEARINGS DEFAULT TOON (actual output)
schema: fm-bearings.v1
home: fm-bearings.Oc19H0/manual-oversized
generated: "2026-07-11T18:00:00Z"
prs: "not_requested (run: /bearings include PRs)"
in_flight[3]{id,kind,state,doing}:
  external-wait,ship,paused,declared external-wait for upstream release
  scout-x,scout,done,report ready
  ship-task,ship,working,harness busy (claude-hook)
secondmates[1]{id,state,doing,provenance,freshness,age_seconds,contradiction,reason}:
  mate,captain_decision,Choose subscription order,structured-home,fresh,0,false,"-"
decisions_open[1]{id,key,verb,summary,owner}:
  mate/mate-decision-race,mate-decision-race,captain-hold,"Choose subscription order: captain choice pending",mate
landed[6]{id,what,artifact,owner}:
  landed-0200,Landed change number 0200 in the oversized fixture backlog,"https://github.com/kunchenguid/firstmate/pull/200",(main)
  mate-landed,Secondmate-managed fix,"https://github.com/kunchenguid/firstmate/pull/50",mate
  landed-0199,Landed change number 0199 in the oversized fixture backlog,"https://github.com/kunchenguid/firstmate/pull/199",(main)
  landed-0198,Landed change number 0198 in the oversized fixture backlog,"https://github.com/kunchenguid/firstmate/pull/198",(main)
  landed-0197,Landed change number 0197 in the oversized fixture backlog,"https://github.com/kunchenguid/firstmate/pull/197",(main)
  landed-0196,Landed change number 0196 in the oversized fixture backlog,"https://github.com/kunchenguid/firstmate/pull/196",(main)
gates: []
reports[1]{id,path}:
  scout-x,/tmp/fm-bearings.Oc19H0/manual-oversized/data/scout-x/report.md
recorded_prs[1]{id,url}:
  ship-task,"https://github.com/kunchenguid/firstmate/pull/9"
unhealthy_endpoints[1]{id,backend,target,exists,agent}:
  mate,tmux,"firstmate:fm-mate",true,dead
omitted[9]{surface,reveal}:
  backlog item bodies,"--fields bodies"
  task paths,"--fields paths"
  watch/steer actions,"--fields actions"
  healthy endpoint detail,"--fields endpoints"
  full scout-report inventory,"--all-reports"
  superseded queued items,"--all-queued"
  landed showing 6 of 7 (incl. 1 secondmate home(s)),"--all-landed"
  landed per-home capped at 6 for 1 home(s),"--all-landed"
  live PR discovery + checks,"--include-prs"
NETWORK CALL LOG BYTES: 0
```
</details>
<details>
<summary>Evidence: Base-commit counterfactual</summary>

<code>Base commit fails on the identical oversized workload with `jq: Argument list too long`.</code>

```text
/tmp/no-mistakes-evidence/01KYXFEDG4EH9QCDSAA3QX5557/base-counterfactual/bin/fm-fleet-snapshot.sh: line 567: /home/sungin/.nix-profile/bin/jq: Argument list too long
fm-fleet-snapshot: main inventory summary failed
not ok - canonical snapshot failed on an oversized backlog
```
</details>
<details>
<summary>Evidence: Output compatibility evidence</summary>

`Fleet JSON, secondmate summary, Bearings JSON, and Bearings TOON were byte-identical to the base implementation on a supported-size fixture.`

```text
byte-identical: fm-fleet-snapshot.sh --json
byte-identical: fm-fleet-snapshot.sh --secondmate-home-summary
byte-identical: fm-bearings-snapshot.sh --json
byte-identical: fm-bearings-snapshot.sh TOON
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>Baseline inspection: `git status --short`, `git diff --stat`, `git diff --name-only`, and `git diff --check a8057666..cd026797`.</code>
- <code>Focused selector `tests/fm-bearings-snapshot.test.sh::test_oversized_backlog_survives_the_per_argument_execve_limit`.</code>
- <code>Focused selectors `test_include_prs_is_the_only_fetch_path`, `test_pr_repository_cap_and_expansion`, `test_per_repository_pr_cap_is_disclosed`, and `test_projection_and_toon_fail_closed`.</code>
- <code>Ran the oversized regression against base commit `a805766622afb291681a15a80c5135517f1cb5ed`; confirmed the expected `Argument list too long` failure.</code>
- <code>Manually exercised `bin/fm-fleet-snapshot.sh --json`, `--secondmate-home-summary`, and default `bin/fm-bearings-snapshot.sh` with a parsed 180,063-byte backlog.</code>
- <code>Used `cmp` to compare target and base output streams for fleet JSON, secondmate summary, Bearings JSON, and Bearings TOON on a supported-size fixture.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
