### PR TITLE
feat(dispatch): reapply Antigravity quota preflight before spawn

### DIFF
--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -89,6 +89,14 @@
 #   secondmate receives the primary's read-only shared captain-preference file
 #   (fm-config-inherit-lib.sh). A successful launch clears pending inherited
 #   config reread generations because the new agent reads the converged files.
+#   Before any worktree, backend endpoint, agent process, or task metadata is
+#   created, every final model beginning with antigravity/ runs the installed
+#   deterministic quota checker with `check`. FM_ANTIGRAVITY_PREFLIGHT_BIN is
+#   the test override; otherwise the checker is resolved under
+#   ${PI_CODING_AGENT_DIR:-$HOME/.pi/agent}/extensions/antigravity-account-switcher/.
+#   The checker runs with a bounded timeout and output stream. Exit 0 preserves
+#   the requested model and effort; documented exit 1 changes them to
+#   cockpit/gpt-5.6-luna and high; every other result refuses the spawn.
 #   --scout records kind=scout in the task's meta (report deliverable, scratch worktree;
 #   see AGENTS.md task lifecycle); --secondmate records kind=secondmate and launches in a
 #   provisioned firstmate home; the default is kind=ship.
@@ -422,6 +430,7 @@ SPAWN_TASK_LOCK_HELD=1
 PROJ=
 ARG3=
 FIRSTMATE_HOME=
+RAW_LAUNCH=0
 
 if [ "$KIND" = secondmate ]; then
   case "${POS[1]:-}" in
@@ -498,6 +507,7 @@ launch_template() {
 case "$ARG3" in
   *' '*)  # raw launch command (unverified-adapter escape hatch)
     LAUNCH=$ARG3
+    RAW_LAUNCH=1
     HARNESS=""
     for word in $LAUNCH; do
       case "$word" in [A-Za-z_]*=*) continue ;; *) HARNESS=$(basename "$word"); break ;; esac
@@ -563,6 +573,153 @@ if [ "$KIND" = secondmate ] && [ -z "$ARG3" ]; then
       esac
     fi
   fi
+fi
+
+antigravity_preflight() {
+  if [ "$RAW_LAUNCH" -eq 1 ] && [ -z "$MODEL" ]; then
+    local cleaned_word
+    for word in $LAUNCH; do
+      cleaned_word=$(printf '%s' "$word" | tr -d "\"'")
+      case "$cleaned_word" in
+        --model=antigravity/*) MODEL=${cleaned_word#--model=} ;;
+        antigravity/*) MODEL=$cleaned_word ;;
+      esac
+    done
+  fi
+
+  case "$MODEL" in
+    antigravity/*) ;;
+    *) return 0 ;;
+  esac
+
+  local checker agent_dir timeout_seconds output_bytes tmp_out rc
+  checker=${FM_ANTIGRAVITY_PREFLIGHT_BIN:-}
+  if [ -z "$checker" ]; then
+    agent_dir=${PI_CODING_AGENT_DIR:-${HOME:-}/.pi/agent}
+    checker="$agent_dir/extensions/antigravity-account-switcher/bin/antigravity-account-check.js"
+  fi
+  if [ ! -f "$checker" ] || [ ! -x "$checker" ]; then
+    echo "error: Antigravity quota preflight checker is missing or not executable: $checker" >&2
+    return 1
+  fi
+
+  timeout_seconds=${FM_ANTIGRAVITY_PREFLIGHT_TIMEOUT_SECONDS:-30}
+  output_bytes=${FM_ANTIGRAVITY_PREFLIGHT_OUTPUT_BYTES:-8192}
+  case "$timeout_seconds" in
+    ''|*[!0-9]*)
+      echo "error: Antigravity quota preflight timeout is not a positive integer" >&2
+      return 1
+      ;;
+  esac
+  case "$output_bytes" in
+    ''|*[!0-9]*)
+      echo "error: Antigravity quota preflight output limit is not a positive integer" >&2
+      return 1
+      ;;
+  esac
+  [ "$timeout_seconds" -gt 0 ] || {
+    echo "error: Antigravity quota preflight timeout must be positive" >&2
+    return 1
+  }
+  [ "$output_bytes" -gt 0 ] || {
+    echo "error: Antigravity quota preflight output limit must be positive" >&2
+    return 1
+  }
+
+  if ! command -v perl >/dev/null 2>&1; then
+    echo "error: Antigravity quota preflight requires perl" >&2
+    return 1
+  fi
+
+  tmp_out=$(mktemp "${STATE}/.preflight-${ID}.XXXXXXXX" 2>/dev/null || mktemp "/tmp/.preflight-${ID}.XXXXXXXX")
+
+  set +e
+  perl -e '
+    my $t = shift; my $file = shift; my $limit = shift;
+    pipe(my $r, my $w) or die;
+    my $pid = fork; die "fork failed" unless defined $pid;
+    if (!$pid) {
+      close $r;
+      setpgrp(0, 0);
+      open(STDOUT, ">&", $w) or die;
+      open(STDERR, ">&", $w) or die;
+      close $w;
+      exec @ARGV;
+    }
+    close $w;
+    local $SIG{ALRM} = sub {
+      kill "TERM", -$pid;
+      select undef, undef, undef, 0.2;
+      kill "KILL", -$pid;
+      exit 124;
+    };
+    alarm $t;
+    open(my $out_fh, ">", $file) or die;
+    my $bytes_read = 0;
+    my $buf;
+    while (sysread($r, $buf, 4096)) {
+      if ($bytes_read < $limit) {
+        my $to_write = length($buf);
+        if ($bytes_read + $to_write > $limit) {
+          $to_write = $limit - $bytes_read;
+        }
+        syswrite($out_fh, substr($buf, 0, $to_write));
+        $bytes_read += $to_write;
+      }
+    }
+    close $out_fh;
+    close $r;
+    waitpid($pid, 0);
+    alarm 0;
+    my $sig = $? & 127;
+    my $rc = $sig ? 255 : ($? >> 8);
+    kill "TERM", -$pid;
+    select undef, undef, undef, 0.1;
+    kill "KILL", -$pid;
+    exit $rc;
+  ' "$timeout_seconds" "$tmp_out" "$output_bytes" "$checker" check >/dev/null 2>&1
+  rc=$?
+  set -e
+  rm -f "$tmp_out"
+
+  case "$rc" in
+    0) return 0 ;;
+    1)
+      MODEL=cockpit/gpt-5.6-luna
+      EFFORT=high
+      ANTIGRAVITY_FALLBACK=1
+      return 0
+      ;;
+    124)
+      echo "error: Antigravity quota preflight timed out" >&2
+      return 1
+      ;;
+    *)
+      echo "error: Antigravity quota preflight failed with unrecognized result (exit $rc)" >&2
+      return 1
+      ;;
+  esac
+}
+
+ANTIGRAVITY_FALLBACK=0
+antigravity_preflight || exit 1
+if [ "$ANTIGRAVITY_FALLBACK" -eq 1 ] && [ "$RAW_LAUNCH" -eq 1 ]; then
+  case "$LAUNCH" in
+    *'antigravity/'*)
+      LAUNCH=$(printf '%s' "$LAUNCH" | sed -E "s/['\"]?antigravity\/[^'\" ]+['\"]?/'cockpit\/gpt-5.6-luna'/g")
+      case "$LAUNCH" in
+        *--effort*)
+          LAUNCH=$(printf '%s' "$LAUNCH" | sed -E "s/--effort[ =]['\"]?[^'\" ]+['\"]?/--effort 'high'/g")
+          ;;
+        *)
+          LAUNCH="$LAUNCH --effort 'high'"
+          ;;
+      esac
+      ;;
+    *)
+      LAUNCH="$LAUNCH --model 'cockpit/gpt-5.6-luna' --effort 'high'"
+      ;;
+  esac
 fi
 
 secondmate_registry_value() {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -168,6 +168,7 @@ When the file exists, `fm-spawn.sh` refuses crewmate and scout launches without 
 Secondmate launches are exempt because they resolve the secondmate harness and any optional secondmate model or effort tokens instead.
 Unsupported effort values are still recorded in task meta when passed to `fm-spawn.sh`, but the launch template omits any effort flag that the selected harness does not accept.
 That keeps spawn launch compatible across claude, codex, grok, pi, opencode, and kimi while preserving the requested profile for later audit.
+The final model also passes through the Antigravity quota preflight owned by [configuration.md](configuration.md#antigravity-quota-preflight) before spawn side effects begin.
 
 ## Optional secondmates
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -265,6 +265,16 @@ Malformed JSON, an empty or malformed rule/default array, an unverified harness,
 While the file remains present, no crewmate or scout spawn may proceed without an explicit resolved harness; malformed configuration must be reported and corrected rather than selected around.
 Secondmate homes inherit this file from the primary, so a secondmate's own crewmates apply the same dispatch profile behavior.
 
+## Antigravity quota preflight
+
+Before `fm-spawn.sh` creates a worktree, backend endpoint, agent process, or task metadata, every final model whose name begins with `antigravity/` must pass the Antigravity quota preflight.
+The checker is the executable `antigravity-account-check.js` under `${PI_CODING_AGENT_DIR:-$HOME/.pi/agent}/extensions/antigravity-account-switcher/bin/`, unless the test-only `FM_ANTIGRAVITY_PREFLIGHT_BIN` override is set.
+The preflight invokes that checker with `check`, bounds its runtime with `FM_ANTIGRAVITY_PREFLIGHT_TIMEOUT_SECONDS` (default `30` seconds), and discards output after the bounded `FM_ANTIGRAVITY_PREFLIGHT_OUTPUT_BYTES` limit (default `8192` bytes) so checker output cannot be surfaced as a secret-bearing diagnostic.
+Exit `0` preserves the requested model and effort.
+The checker's documented exit `1` means all configured accounts are unusable and changes the final profile to `cockpit/gpt-5.6-luna` at `high` effort.
+Missing or non-executable checkers, invalid limits, missing timeout support, timeouts, crashes, errors, and unknown exit results refuse the spawn before those side effects occur.
+The same boundary applies to explicit models, dispatch-profile models, scouts, secondmates, and raw launch commands, while non-Antigravity models bypass it.
+
 ## Toolchain
 
 On session start the first mate detects what its required toolchain is missing or too old and lists each problem with either an exact install command or manual instructions.

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -72,6 +72,12 @@ enable_dispatch_profile() {
     > "$home/config/crew-dispatch.json"
 }
 
+enable_antigravity_dispatch_profile() {
+  local home=$1
+  printf '%s\n' '{"rules":[{"when":"current events","use":{"harness":"pi","model":"antigravity/gemini-3.6-flash","effort":"high"}}],"default":{"harness":"pi","model":"antigravity/gemini-3.6-flash","effort":"high"}}' \
+    > "$home/config/crew-dispatch.json"
+}
+
 make_seeded_secondmate_home() {
   local home=$1 id=$2
   mkdir -p "$home/bin" "$home/data"
@@ -93,8 +99,59 @@ run_spawn() {
     FM_PROJECTS_OVERRIDE="$home/projects" FM_CONFIG_OVERRIDE="$home/config" \
     FM_SPAWN_NO_GUARD=1 FM_FAKE_PANE_PATH="$wt" TMUX="fake,1,0" \
     CLAUDE_CONFIG_DIR="${FM_TEST_CLAUDE_CONFIG_DIR:-}" \
-    FM_FAKE_LAUNCH_LOG="$launchlog" GROK_HOME="$home/grok-home" PATH="$fakebin:$PATH" \
+    FM_FAKE_LAUNCH_LOG="$launchlog" \
+    FM_ANTIGRAVITY_PREFLIGHT_BIN="${PREFLIGHT_BIN:-}" \
+    FM_ANTIGRAVITY_PREFLIGHT_TIMEOUT_SECONDS="${PREFLIGHT_TIMEOUT:-30}" \
+    FM_PREFLIGHT_LOG="${PREFLIGHT_LOG:-}" FM_PREFLIGHT_RESULT="${PREFLIGHT_RESULT:-ok}" \
+    GROK_HOME="$home/grok-home" PATH="$fakebin:$PATH" \
     "$SPAWN" "$@" 2>&1
+}
+
+make_preflight_checker() {
+  local path=$1
+  cat > "$path" <<'SH'
+#!/usr/bin/env bash
+set -u
+[ -z "${FM_PREFLIGHT_LOG:-}" ] || printf '%s\n' "$*" >> "$FM_PREFLIGHT_LOG"
+case "${FM_PREFLIGHT_RESULT:-ok}" in
+  ok) printf '%s\n' 'OK: active re***@example.invalid is usable (rotated: false)'; exit 0 ;;
+  exhausted) printf '%s\n' 'EXHAUSTED: all configured accounts are exhausted or unavailable'; exit 1 ;;
+  secret-error) printf '%s\n' 'ERROR: refresh_token=super-secret-value leaked@example.invalid'; exit 2 ;;
+  timeout) sleep 5; exit 0 ;;
+  signal-kill) kill -9 $$ ;;
+  *) exit 23 ;;
+esac
+SH
+  chmod +x "$path"
+}
+
+make_forked_preflight_checker() {
+  local path=$1
+  cat > "$path" <<'SH'
+#!/usr/bin/env bash
+set -u
+[ -z "${FM_PREFLIGHT_LOG:-}" ] || printf '%s\n' "$*" >> "$FM_PREFLIGHT_LOG"
+( sleep 10 >/dev/null 2>&1 & )
+printf '%s\n' 'OK: active re***@example.invalid is usable'
+exit 0
+SH
+  chmod +x "$path"
+}
+
+make_large_preflight_checker() {
+  local path=$1 result=${2:-ok}
+  cat > "$path" <<SH
+#!/usr/bin/env bash
+set -u
+[ -z "\${FM_PREFLIGHT_LOG:-}" ] || printf '%s\n' "\$*" >> "\$FM_PREFLIGHT_LOG"
+python3 -c 'print("X" * 50000)'
+case "$result" in
+  ok) exit 0 ;;
+  exhausted) exit 1 ;;
+  *) exit 2 ;;
+esac
+SH
+  chmod +x "$path"
 }
 
 read_case_record() {
@@ -667,6 +724,367 @@ test_active_dispatch_profile_does_not_block_secondmate_launch() {
   pass "active crew-dispatch profile does not block secondmate launches"
 }
 
+test_antigravity_preflight_exit_zero_preserves_profile() {
+  local rec id out status
+  id=preflight-ok-z17
+  rec=$(make_spawn_case preflight-ok pi "$id")
+  read_case_record "$rec"
+  PREFLIGHT_BIN="$CASE_DIR/checker"
+  PREFLIGHT_LOG="$CASE_DIR/checker.log"
+  PREFLIGHT_RESULT=ok
+  make_preflight_checker "$PREFLIGHT_BIN"
+
+  out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR" \
+    --model antigravity/gemini-3.6-flash --effort high)
+  status=$?
+  expect_code 0 "$status" "usable Antigravity quota should permit the spawn"
+  assert_meta_profile "$HOME_DIR/state/$id.meta" pi antigravity/gemini-3.6-flash high
+  assert_grep "check" "$PREFLIGHT_LOG" "preflight checker was not invoked with check"
+  pass "exit 0 keeps the requested Antigravity model and effort"
+}
+
+test_antigravity_preflight_configured_profile_covers_scouts() {
+  local rec id out status
+  id=preflight-profile-scout-z17b
+  rec=$(make_spawn_case preflight-profile-scout pi "$id")
+  read_case_record "$rec"
+  enable_antigravity_dispatch_profile "$HOME_DIR"
+  PREFLIGHT_BIN="$CASE_DIR/checker"
+  PREFLIGHT_LOG="$CASE_DIR/checker.log"
+  PREFLIGHT_RESULT=ok
+  make_preflight_checker "$PREFLIGHT_BIN"
+
+  out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR" \
+    --harness pi --model antigravity/gemini-3.6-flash --effort high --scout)
+  status=$?
+  expect_code 0 "$status" "configured Antigravity scout profile should permit the spawn"
+  assert_grep "kind=scout" "$HOME_DIR/state/$id.meta" "configured Antigravity scout did not record kind=scout"
+  assert_meta_profile "$HOME_DIR/state/$id.meta" pi antigravity/gemini-3.6-flash high
+  assert_grep "check" "$PREFLIGHT_LOG" "configured Antigravity scout did not invoke preflight"
+  pass "configured Antigravity profiles use the shared scout boundary"
+}
+
+test_antigravity_preflight_all_unusable_falls_back_before_metadata() {
+  local rec id out status launch
+  id=preflight-exhausted-z18
+  rec=$(make_spawn_case preflight-exhausted pi "$id")
+  read_case_record "$rec"
+  PREFLIGHT_BIN="$CASE_DIR/checker"
+  PREFLIGHT_LOG="$CASE_DIR/checker.log"
+  PREFLIGHT_RESULT=exhausted
+  make_preflight_checker "$PREFLIGHT_BIN"
+
+  out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR" \
+    --model antigravity/gemini-3.6-flash --effort xhigh)
+  status=$?
+  expect_code 0 "$status" "exhausted Antigravity accounts should fall back to Luna high"
+  assert_meta_profile "$HOME_DIR/state/$id.meta" pi cockpit/gpt-5.6-luna high
+  launch=$(cat "$LAUNCH_LOG")
+  assert_contains "$launch" "--model 'cockpit/gpt-5.6-luna' --thinking 'high'" \
+    "launch command did not receive the Luna high fallback profile"
+  assert_grep "check" "$PREFLIGHT_LOG" "exhausted accounts test did not run the quota checker"
+  pass "exit 1 falls back to Luna high before endpoint and metadata publication"
+}
+
+test_antigravity_preflight_raw_launch_uses_fallback() {
+  local rec id out status launch
+  id=preflight-raw-fallback-z18b
+  rec=$(make_spawn_case preflight-raw-fallback pi "$id")
+  read_case_record "$rec"
+  PREFLIGHT_BIN="$CASE_DIR/checker"
+  PREFLIGHT_LOG="$CASE_DIR/checker.log"
+  PREFLIGHT_RESULT=exhausted
+  make_preflight_checker "$PREFLIGHT_BIN"
+
+  out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR" \
+    "custom-agent --flag" --model antigravity/gemini-3.6-flash --effort xhigh)
+  status=$?
+  expect_code 0 "$status" "raw launch should use the documented Luna fallback"
+  assert_meta_profile "$HOME_DIR/state/$id.meta" custom-agent cockpit/gpt-5.6-luna high
+  launch=$(cat "$LAUNCH_LOG")
+  assert_contains "$launch" "custom-agent --flag --model 'cockpit/gpt-5.6-luna' --effort 'high'" \
+    "raw launch did not receive the Luna fallback"
+  pass "exit 1 applies the Luna fallback to raw launch commands"
+}
+
+test_antigravity_preflight_error_is_secret_safe_and_refuses() {
+  local rec id out status
+  id=preflight-error-z19
+  rec=$(make_spawn_case preflight-error pi "$id")
+  read_case_record "$rec"
+  PREFLIGHT_BIN="$CASE_DIR/checker"
+  PREFLIGHT_LOG="$CASE_DIR/checker.log"
+  PREFLIGHT_RESULT=secret-error
+  make_preflight_checker "$PREFLIGHT_BIN"
+
+  out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR" \
+    --model antigravity/gemini-3.6-flash --effort high)
+  status=$?
+  expect_code 1 "$status" "checker error exit code must refuse Antigravity launch"
+  assert_contains "$out" "unrecognized result (exit 2)" "preflight error refusal was not concrete"
+  assert_not_contains "$out" "super-secret-value" "preflight error leaked secret diagnostic text"
+  assert_absent "$HOME_DIR/state/$id.meta" "checker error wrote task metadata"
+  pass "checker error exit code refuses without leaking checker stdout"
+}
+
+test_antigravity_preflight_missing_and_non_executable_refuse() {
+  local rec id out status
+  id=preflight-missing-z20
+  rec=$(make_spawn_case preflight-missing pi "$id")
+  read_case_record "$rec"
+  PREFLIGHT_BIN="$CASE_DIR/missing-checker"
+
+  out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR" \
+    --model antigravity/gemini-3.6-flash --effort high)
+  status=$?
+  expect_code 1 "$status" "missing checker must refuse Antigravity launch"
+  assert_contains "$out" "missing or not executable" "missing checker refusal was not concrete"
+  assert_absent "$HOME_DIR/state/$id.meta" "missing checker wrote task metadata"
+
+  touch "$PREFLIGHT_BIN"
+  chmod -x "$PREFLIGHT_BIN"
+  out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR" \
+    --model antigravity/gemini-3.6-flash --effort high)
+  status=$?
+  expect_code 1 "$status" "non-executable checker must refuse Antigravity launch"
+  assert_contains "$out" "missing or not executable" "non-executable refusal was not concrete"
+  assert_absent "$HOME_DIR/state/$id.meta" "non-executable checker wrote task metadata"
+  pass "missing or non-executable checker refuses before endpoint creation"
+}
+
+test_antigravity_preflight_timeout_refuses() {
+  local rec id out status
+  id=preflight-timeout-z21
+  rec=$(make_spawn_case preflight-timeout pi "$id")
+  read_case_record "$rec"
+  PREFLIGHT_BIN="$CASE_DIR/checker"
+  PREFLIGHT_LOG="$CASE_DIR/checker.log"
+  PREFLIGHT_RESULT=timeout
+  make_preflight_checker "$PREFLIGHT_BIN"
+
+  out=$(PREFLIGHT_TIMEOUT=1 \
+    run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR" \
+    --model antigravity/gemini-3.6-flash --effort high)
+  status=$?
+  expect_code 1 "$status" "preflight timeout must refuse Antigravity launch"
+  assert_contains "$out" "timed out" "timeout refusal was not concrete"
+  assert_absent "$HOME_DIR/state/$id.meta" "timeout wrote task metadata"
+  pass "preflight timeout refuses before endpoint creation"
+}
+
+test_antigravity_preflight_skips_non_antigravity_models() {
+  local rec id out status
+  id=preflight-luna-z23
+  rec=$(make_spawn_case preflight-luna pi "$id")
+  read_case_record "$rec"
+  PREFLIGHT_BIN="$CASE_DIR/missing-checker"
+  PREFLIGHT_LOG="$CASE_DIR/checker.log"
+  PREFLIGHT_RESULT=ok
+
+  out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR" \
+    --model cockpit/gpt-5.6-luna --effort high)
+  status=$?
+  expect_code 0 "$status" "Luna must not require Antigravity preflight"
+  assert_meta_profile "$HOME_DIR/state/$id.meta" pi cockpit/gpt-5.6-luna high
+  assert_absent "$PREFLIGHT_LOG" "Luna launch unexpectedly invoked Antigravity preflight"
+  pass "Luna and other non-Antigravity models bypass the checker"
+}
+
+test_antigravity_preflight_applies_to_configured_secondmate_model() {
+  local rec id sm out status
+  id=preflight-secondmate-z24
+  rec=$(make_spawn_case preflight-secondmate codex "$id")
+  read_case_record "$rec"
+  sm="$CASE_DIR/secondmate-home"
+  make_seeded_secondmate_home "$sm" "$id"
+  mkdir -p "$sm/state" "$sm/config" "$sm/projects"
+  printf '%s\n' 'pi antigravity/gemini-3.6-flash medium' > "$HOME_DIR/config/secondmate-harness"
+  PREFLIGHT_BIN="$CASE_DIR/checker"
+  PREFLIGHT_LOG="$CASE_DIR/checker.log"
+  PREFLIGHT_RESULT=exhausted
+  make_preflight_checker "$PREFLIGHT_BIN"
+
+  out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$sm" --secondmate)
+  status=$?
+  expect_code 0 "$status" "secondmate Antigravity model should use the shared preflight boundary"
+  assert_meta_profile "$HOME_DIR/state/$id.meta" pi cockpit/gpt-5.6-luna high
+  assert_grep "check" "$PREFLIGHT_LOG" "secondmate did not invoke the quota checker"
+  pass "secondmate config models use the same preflight and accurate fallback metadata"
+}
+
+test_antigravity_preflight_forked_checker_does_not_hang() {
+  local rec id out status
+  id=preflight-forked-z25
+  rec=$(make_spawn_case preflight-forked pi "$id")
+  read_case_record "$rec"
+  PREFLIGHT_BIN="$CASE_DIR/checker"
+  PREFLIGHT_LOG="$CASE_DIR/checker.log"
+  make_forked_preflight_checker "$PREFLIGHT_BIN"
+
+  out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR" \
+    --model antigravity/gemini-3.6-flash --effort high)
+  status=$?
+  expect_code 0 "$status" "forked checker should return promptly and permit spawn"
+  assert_meta_profile "$HOME_DIR/state/$id.meta" pi antigravity/gemini-3.6-flash high
+  assert_grep "check" "$PREFLIGHT_LOG" "forked checker was not invoked"
+  pass "forked checker process does not hang the preflight"
+}
+
+test_antigravity_preflight_invalid_limits_refuse() {
+  local rec id out status
+  id=preflight-invalid-limits-z26
+  rec=$(make_spawn_case preflight-invalid-limits pi "$id")
+  read_case_record "$rec"
+  PREFLIGHT_BIN="$CASE_DIR/checker"
+  PREFLIGHT_LOG="$CASE_DIR/checker.log"
+  PREFLIGHT_RESULT=ok
+  make_preflight_checker "$PREFLIGHT_BIN"
+
+  out=$(PREFLIGHT_TIMEOUT=invalid \
+    run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR" \
+    --model antigravity/gemini-3.6-flash --effort high)
+  status=$?
+  expect_code 1 "$status" "non-integer timeout must refuse spawn"
+  assert_contains "$out" "timeout is not a positive integer" "invalid timeout refusal missing diagnostic"
+  assert_absent "$HOME_DIR/state/$id.meta" "invalid timeout written metadata"
+
+  out=$(FM_ANTIGRAVITY_PREFLIGHT_OUTPUT_BYTES=0 \
+    run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR" \
+    --model antigravity/gemini-3.6-flash --effort high)
+  status=$?
+  expect_code 1 "$status" "zero output limit must refuse spawn"
+  assert_contains "$out" "output limit must be positive" "invalid output limit refusal missing diagnostic"
+  assert_absent "$HOME_DIR/state/$id.meta" "invalid output limit written metadata"
+  pass "invalid timeout and output limit settings refuse before endpoint creation"
+}
+
+test_antigravity_preflight_uses_default_checker_path() {
+  local rec id out status agent_dir checker_path
+  id=preflight-default-path-z27
+  rec=$(make_spawn_case preflight-default-path pi "$id")
+  read_case_record "$rec"
+  agent_dir="$CASE_DIR/pi-agent"
+  checker_path="$agent_dir/extensions/antigravity-account-switcher/bin/antigravity-account-check.js"
+  mkdir -p "$(dirname "$checker_path")"
+  PREFLIGHT_LOG="$CASE_DIR/checker.log"
+  PREFLIGHT_RESULT=ok
+  make_preflight_checker "$checker_path"
+
+  out=$(PI_CODING_AGENT_DIR="$agent_dir" PREFLIGHT_BIN="" \
+    run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR" \
+    --model antigravity/gemini-3.6-flash --effort high)
+  status=$?
+  expect_code 0 "$status" "default checker path under PI_CODING_AGENT_DIR should succeed"
+  assert_meta_profile "$HOME_DIR/state/$id.meta" pi antigravity/gemini-3.6-flash high
+  assert_grep "check" "$PREFLIGHT_LOG" "default checker path was not invoked"
+  pass "default checker path under PI_CODING_AGENT_DIR is resolved and executed"
+}
+
+test_antigravity_preflight_embedded_raw_launch_model_uses_fallback() {
+  local rec id out status launch
+  id=preflight-raw-embedded-z28
+  rec=$(make_spawn_case preflight-raw-embedded pi "$id")
+  read_case_record "$rec"
+  PREFLIGHT_BIN="$CASE_DIR/checker"
+  PREFLIGHT_LOG="$CASE_DIR/checker.log"
+  PREFLIGHT_RESULT=exhausted
+  make_preflight_checker "$PREFLIGHT_BIN"
+
+  out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR" \
+    "custom-agent --model=antigravity/gemini-3.6-flash --effort xhigh")
+  status=$?
+  expect_code 0 "$status" "raw launch with embedded antigravity model flag should trigger preflight fallback"
+  assert_meta_profile "$HOME_DIR/state/$id.meta" custom-agent cockpit/gpt-5.6-luna high
+  launch=$(cat "$LAUNCH_LOG")
+  assert_contains "$launch" "--model='cockpit/gpt-5.6-luna'" \
+    "embedded raw launch model did not receive Luna fallback"
+  assert_grep "check" "$PREFLIGHT_LOG" "embedded raw launch model did not invoke checker"
+  pass "raw launch commands with embedded model flag trigger preflight and Luna fallback"
+}
+
+test_antigravity_preflight_large_output_does_not_fail() {
+  local rec id out status
+  id=preflight-large-out-z29
+  rec=$(make_spawn_case preflight-large-out pi "$id")
+  read_case_record "$rec"
+  PREFLIGHT_BIN="$CASE_DIR/checker"
+  PREFLIGHT_LOG="$CASE_DIR/checker.log"
+  make_large_preflight_checker "$PREFLIGHT_BIN" ok
+
+  out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR" \
+    --model antigravity/gemini-3.6-flash --effort high)
+  status=$?
+  expect_code 0 "$status" "checker writing large output with exit 0 should succeed"
+  assert_meta_profile "$HOME_DIR/state/$id.meta" pi antigravity/gemini-3.6-flash high
+  pass "checker writing >8KB output with exit 0 does not receive SIGPIPE or fail"
+}
+
+test_antigravity_preflight_space_in_home_path_succeeds() {
+  local rec id out status home_space
+  id=preflight-space-z30
+  rec=$(make_spawn_case preflight-space pi "$id")
+  read_case_record "$rec"
+  home_space="$CASE_DIR/home with spaces"
+  mkdir -p "$home_space/data/$id" "$home_space/projects" "$home_space/state" "$home_space/config"
+  touch "$home_space/state/.last-watcher-beat"
+  printf 'brief for %s\n' "$id" > "$home_space/data/$id/brief.md"
+  PREFLIGHT_BIN="$CASE_DIR/checker"
+  PREFLIGHT_LOG="$CASE_DIR/checker.log"
+  PREFLIGHT_RESULT=ok
+  make_preflight_checker "$PREFLIGHT_BIN"
+
+  out=$(run_spawn "$home_space" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR" \
+    --model antigravity/gemini-3.6-flash --effort high)
+  status=$?
+  expect_code 0 "$status" "preflight with space in home path should succeed"
+  assert_meta_profile "$home_space/state/$id.meta" pi antigravity/gemini-3.6-flash high
+  pass "state path containing spaces is handled safely"
+}
+
+test_antigravity_preflight_quoted_embedded_raw_launch_model_uses_fallback() {
+  local rec id out status launch
+  id=preflight-raw-quoted-z31
+  rec=$(make_spawn_case preflight-raw-quoted pi "$id")
+  read_case_record "$rec"
+  PREFLIGHT_BIN="$CASE_DIR/checker"
+  PREFLIGHT_LOG="$CASE_DIR/checker.log"
+  PREFLIGHT_RESULT=exhausted
+  make_preflight_checker "$PREFLIGHT_BIN"
+
+  out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR" \
+    "custom-agent --model 'antigravity/gemini-3.6-flash' --effort xhigh")
+  status=$?
+  expect_code 0 "$status" "raw launch with single-quoted antigravity model should trigger fallback and replace flag"
+  assert_meta_profile "$HOME_DIR/state/$id.meta" custom-agent cockpit/gpt-5.6-luna high
+  launch=$(cat "$LAUNCH_LOG")
+  assert_contains "$launch" "custom-agent --model 'cockpit/gpt-5.6-luna' --effort 'high'" \
+    "quoted raw launch model and effort were not cleanly replaced"
+  assert_not_contains "$launch" "antigravity" \
+    "quoted raw launch model still contains old antigravity string"
+  assert_not_contains "$launch" "xhigh" \
+    "quoted raw launch effort still contains old xhigh string"
+  pass "single-quoted raw launch model and effort flags are parsed and cleanly replaced on fallback"
+}
+
+test_antigravity_preflight_signal_killed_checker_refuses() {
+  local rec id out status
+  id=preflight-sigkill-z32
+  rec=$(make_spawn_case preflight-sigkill pi "$id")
+  read_case_record "$rec"
+  PREFLIGHT_BIN="$CASE_DIR/checker"
+  PREFLIGHT_LOG="$CASE_DIR/checker.log"
+  PREFLIGHT_RESULT=signal-kill
+  make_preflight_checker "$PREFLIGHT_BIN"
+
+  out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR" \
+    --model antigravity/gemini-3.6-flash --effort high)
+  status=$?
+  expect_code 1 "$status" "signal-killed checker must refuse Antigravity launch"
+  assert_contains "$out" "unrecognized result (exit 255)" "signal-killed refusal did not report exit 255"
+  assert_absent "$HOME_DIR/state/$id.meta" "signal-killed checker wrote task metadata"
+  pass "checker killed by signal refuses spawn and reports unrecognized result"
+}
+
 test_no_profile_keeps_claude_profile_defaults
 test_relative_home_overrides_launch_with_absolute_cross_process_paths
 test_home_defaults_preserve_absolute_or_resolve_relative_paths
@@ -693,5 +1111,22 @@ test_claude_forwards_firstmate_config_dir_when_set
 test_claude_omits_config_dir_prefix_when_unset
 test_non_claude_harness_ignores_config_dir
 test_active_dispatch_profile_does_not_block_secondmate_launch
+test_antigravity_preflight_exit_zero_preserves_profile
+test_antigravity_preflight_configured_profile_covers_scouts
+test_antigravity_preflight_all_unusable_falls_back_before_metadata
+test_antigravity_preflight_raw_launch_uses_fallback
+test_antigravity_preflight_error_is_secret_safe_and_refuses
+test_antigravity_preflight_missing_and_non_executable_refuse
+test_antigravity_preflight_timeout_refuses
+test_antigravity_preflight_skips_non_antigravity_models
+test_antigravity_preflight_applies_to_configured_secondmate_model
+test_antigravity_preflight_forked_checker_does_not_hang
+test_antigravity_preflight_invalid_limits_refuse
+test_antigravity_preflight_uses_default_checker_path
+test_antigravity_preflight_embedded_raw_launch_model_uses_fallback
+test_antigravity_preflight_large_output_does_not_fail
+test_antigravity_preflight_space_in_home_path_succeeds
+test_antigravity_preflight_quoted_embedded_raw_launch_model_uses_fallback
+test_antigravity_preflight_signal_killed_checker_refuses
 
 echo "# all fm-spawn-dispatch-profile tests passed"


### PR DESCRIPTION
### Summary
Reapplies the Antigravity quota-preflight track onto upstream `firstmate` (`origin/main`), restoring the deterministic preflight check before task worktree, backend endpoint, or task metadata creation.

### Upstream Comparison & Changes
- `bin/fm-spawn.sh`:
  - Added header documentation detailing the Antigravity quota preflight contract.
  - Tracked raw launch command invocations (`RAW_LAUNCH=1`).
  - Implemented process-group bounded `antigravity_preflight()` using native Perl process-group supervision (`setpgrp(0,0)`, pipe streaming, byte limits, and alarm cancellation).
  - Exit 0 preserves requested model/effort. Exit 1 (exhausted accounts) updates model to `cockpit/gpt-5.6-luna` at `high` effort (and replaces or appends raw launch flags on raw launch). Unrecognized exit codes or timeout exit 124 refuse spawn with secret-safe diagnostics.
- `docs/architecture.md` & `docs/configuration.md`:
  - Added authoritative specification for Antigravity quota preflight under Dispatch Profiles.
- `tests/fm-spawn-dispatch-profile.test.sh`:
  - Added targeted tests (totaling 43 tests) covering exit 0, scout profiles, exit 1 Luna fallback, raw launch embedded replacement, secret-safe errors, missing/non-executable checker, process-group timeouts, forked checkers, large output (>8KB), space-containing state paths, and non-Antigravity bypass.

### Review & Verification
- Obtained read-only `@oracle` review of the diff and test evidence (Oracle approved).
- All 43 tests in `tests/fm-spawn-dispatch-profile.test.sh` passed cleanly.
- `tests/fm-lint.test.sh` passed clean.
- `git diff --check` clean.