### PR TITLE
feat(bin): add read-only PR stack inventory catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ Firstmate's skills live in two separate places with different audiences:
 - [docs/herdr-backend.md](docs/herdr-backend.md) - current setup, safety boundaries, and limits for the experimental Herdr backend.
 - [docs/zellij-backend.md](docs/zellij-backend.md) - current setup and limits for the experimental Zellij backend.
 - [docs/orca-backend.md](docs/orca-backend.md) - current setup and limits for the experimental Orca backend.
+- [docs/pr-stack-orchestrator.md](docs/pr-stack-orchestrator.md) - current read-only local branch/worktree inventory and shared SQLite catalog interface.
 - [docs/cmux-backend.md](docs/cmux-backend.md) - current setup, socket security, and limits for the experimental cmux backend.
 - [docs/codex-app-backend.md](docs/codex-app-backend.md) - the current blocked Codex App backend boundary and rollout contract.
 - [docs/verification/runtime-backends.md](docs/verification/runtime-backends.md) - active maintainer verification for runtime backend guarantees.

--- a/bin/fm-pr-stack.py
+++ b/bin/fm-pr-stack.py
@@ -1,0 +1,831 @@
+#!/usr/bin/env python3
+"""Read-only Git inventory backed by the shared PR-stack SQLite catalog.
+
+The stable public command is:
+
+    bin/fm-pr-stack.py inventory [--base <revision>] [--json]
+
+Git owns refs, worktrees, ancestry, upstreams, and cleanliness.  This command
+observes those facts without fetching or changing Git state, then replaces the
+catalog's current observation tables in one transaction.  The catalog owns only
+orchestrator declarations, operations, and append-only reconciliation evidence.
+See docs/pr-stack-orchestrator.md for the operator contract.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sqlite3
+import subprocess
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, NoReturn, Sequence
+
+
+SCHEMA_VERSION = 1
+CATALOG_RELATIVE_PATH = Path("pr-stack") / "orchestrator.sqlite"
+DEFAULT_LOCK_TIMEOUT_MS = 2_000
+
+
+class InventoryError(Exception):
+    """A deterministic, user-actionable inventory failure."""
+
+
+class CatalogBusyError(InventoryError):
+    """The bounded catalog writer wait expired."""
+
+
+@dataclass(frozen=True)
+class GitResult:
+    stdout: bytes
+    stderr: bytes
+    returncode: int
+
+
+def now_utc() -> str:
+    return (
+        datetime.now(timezone.utc)
+        .isoformat(timespec="milliseconds")
+        .replace("+00:00", "Z")
+    )
+
+
+def decode(raw: bytes) -> str:
+    return os.fsdecode(raw)
+
+
+def run_git(repo: Path, args: Sequence[str], *, check: bool = True) -> GitResult:
+    environment = os.environ.copy()
+    environment["GIT_OPTIONAL_LOCKS"] = "0"
+    environment["LC_ALL"] = "C"
+    process = subprocess.run(
+        ["git", "-C", os.fspath(repo), *args],
+        check=False,
+        env=environment,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    result = GitResult(process.stdout, process.stderr, process.returncode)
+    if check and result.returncode != 0:
+        detail = result.stderr.decode("utf-8", "replace").strip()
+        command = "git " + " ".join(args)
+        raise InventoryError(
+            f"{command} failed: {detail or f'exit {result.returncode}'}"
+        )
+    return result
+
+
+def one_line(result: GitResult) -> str:
+    return decode(result.stdout.rstrip(b"\n"))
+
+
+def repository_root() -> Path:
+    result = run_git(
+        Path.cwd(), ["rev-parse", "--path-format=absolute", "--show-toplevel"]
+    )
+    return Path(one_line(result))
+
+
+def common_git_dir(repo: Path) -> Path:
+    result = run_git(repo, ["rev-parse", "--path-format=absolute", "--git-common-dir"])
+    return Path(one_line(result))
+
+
+def resolve_commit(repo: Path, revision: str, label: str) -> str:
+    result = run_git(
+        repo,
+        ["rev-parse", "--verify", "--end-of-options", f"{revision}^{{commit}}"],
+        check=False,
+    )
+    if result.returncode != 0:
+        detail = result.stderr.decode("utf-8", "replace").strip()
+        raise InventoryError(
+            f"{label} {revision!r} does not resolve to one commit: {detail or 'not found'}"
+        )
+    return one_line(result)
+
+
+def short_ref_name(ref: str) -> str:
+    for prefix in ("refs/heads/", "refs/remotes/", "refs/tags/"):
+        if ref.startswith(prefix):
+            return ref[len(prefix) :]
+    return ref
+
+
+def canonical_ref(repo: Path, revision: str) -> str | None:
+    result = run_git(
+        repo,
+        ["rev-parse", "--symbolic-full-name", "--verify", "--end-of-options", revision],
+        check=False,
+    )
+    if result.returncode != 0:
+        return None
+    value = one_line(result)
+    return value or None
+
+
+def select_base(repo: Path, override: str | None) -> dict[str, Any]:
+    if override is not None:
+        if not override:
+            raise InventoryError("--base requires a non-empty revision")
+        oid = resolve_commit(repo, override, "explicit integration base")
+        ref = canonical_ref(repo, override)
+        return {
+            "source": "explicit",
+            "input": override,
+            "ref": ref,
+            "name": short_ref_name(ref) if ref else override,
+            "oid": oid,
+        }
+
+    remote_head = run_git(
+        repo,
+        ["symbolic-ref", "--quiet", "refs/remotes/origin/HEAD"],
+        check=False,
+    )
+    if remote_head.returncode == 0:
+        ref = one_line(remote_head)
+        oid = resolve_commit(repo, ref, "default integration base")
+        return {
+            "source": "origin_head",
+            "input": None,
+            "ref": ref,
+            "name": short_ref_name(ref),
+            "oid": oid,
+        }
+    if remote_head.returncode not in (1, 128):
+        detail = remote_head.stderr.decode("utf-8", "replace").strip()
+        raise InventoryError(
+            f"could not inspect refs/remotes/origin/HEAD: {detail or 'unknown error'}"
+        )
+
+    candidates: list[str] = []
+    for name in ("main", "master"):
+        ref = f"refs/heads/{name}"
+        exists = run_git(repo, ["show-ref", "--verify", "--quiet", ref], check=False)
+        if exists.returncode == 0:
+            candidates.append(ref)
+        elif exists.returncode != 1:
+            raise InventoryError(f"could not inspect default-base candidate {ref}")
+    if not candidates:
+        raise InventoryError(
+            "no default integration base: origin/HEAD is unset and neither local main nor master exists; "
+            "pass --base <revision>"
+        )
+    if len(candidates) > 1:
+        names = ", ".join(short_ref_name(ref) for ref in candidates)
+        raise InventoryError(
+            f"ambiguous default integration base: origin/HEAD is unset and local {names} both exist; "
+            "pass --base <revision>"
+        )
+    ref = candidates[0]
+    return {
+        "source": "local_convention",
+        "input": None,
+        "ref": ref,
+        "name": short_ref_name(ref),
+        "oid": resolve_commit(repo, ref, "default integration base"),
+    }
+
+
+def parse_worktree_porcelain(raw: bytes) -> list[dict[str, bytes]]:
+    records: list[dict[str, bytes]] = []
+    current: dict[str, bytes] = {}
+    for field in raw.split(b"\0"):
+        if not field:
+            if current:
+                records.append(current)
+                current = {}
+            continue
+        key, separator, value = field.partition(b" ")
+        current[key.decode("ascii")] = value if separator else b""
+    if current:
+        records.append(current)
+    return records
+
+
+def worktree_cleanliness(
+    path: str, *, bare: bool
+) -> tuple[bool | None, str, str | None]:
+    if bare:
+        return None, "not_applicable", "bare worktree record"
+    worktree = Path(path)
+    if not worktree.is_dir():
+        return None, "unavailable", "worktree path is missing"
+    result = run_git(
+        worktree,
+        [
+            "status",
+            "--porcelain=v1",
+            "-z",
+            "--untracked-files=normal",
+            "--ignore-submodules=none",
+        ],
+        check=False,
+    )
+    if result.returncode != 0:
+        detail = result.stderr.decode("utf-8", "replace").strip()
+        raise InventoryError(
+            f"could not inspect cleanliness for worktree {path!r}: {detail or 'git status failed'}"
+        )
+    clean = result.stdout == b""
+    return clean, "clean" if clean else "dirty", None
+
+
+def scan_worktrees(repo: Path) -> list[dict[str, Any]]:
+    result = run_git(repo, ["worktree", "list", "--porcelain", "-z"])
+    worktrees: list[dict[str, Any]] = []
+    for record in parse_worktree_porcelain(result.stdout):
+        if "worktree" not in record or "HEAD" not in record:
+            raise InventoryError(
+                "git worktree list returned an incomplete porcelain record"
+            )
+        path = decode(record["worktree"])
+        bare = "bare" in record
+        branch_ref = decode(record["branch"]) if "branch" in record else None
+        clean, cleanliness, cleanliness_reason = worktree_cleanliness(path, bare=bare)
+        worktrees.append(
+            {
+                "path": path,
+                "head_oid": decode(record["HEAD"]),
+                "branch_ref": branch_ref,
+                "detached": "detached" in record or (branch_ref is None and not bare),
+                "bare": bare,
+                "clean": clean,
+                "cleanliness": cleanliness,
+                "cleanliness_reason": cleanliness_reason,
+                "locked_reason": decode(record["locked"])
+                if "locked" in record
+                else None,
+                "prunable_reason": decode(record["prunable"])
+                if "prunable" in record
+                else None,
+            }
+        )
+    return sorted(worktrees, key=lambda item: item["path"])
+
+
+def parse_branch_refs(raw: bytes) -> list[tuple[str, str, str | None, str | None]]:
+    branches: list[tuple[str, str, str | None, str | None]] = []
+    for line in raw.splitlines():
+        if not line:
+            continue
+        fields = line.split(b"\0")
+        if len(fields) < 4:
+            raise InventoryError(
+                "git for-each-ref returned an incomplete branch record"
+            )
+        ref, oid, upstream_ref, upstream_name = (decode(value) for value in fields[:4])
+        branches.append((ref, oid, upstream_ref or None, upstream_name or None))
+    return sorted(branches, key=lambda item: item[0])
+
+
+def is_ancestor(repo: Path, ancestor: str, descendant: str) -> bool:
+    result = run_git(
+        repo, ["merge-base", "--is-ancestor", ancestor, descendant], check=False
+    )
+    if result.returncode == 0:
+        return True
+    if result.returncode == 1:
+        return False
+    detail = result.stderr.decode("utf-8", "replace").strip()
+    raise InventoryError(
+        f"could not compare commits {ancestor} and {descendant}: {detail or 'git merge-base failed'}"
+    )
+
+
+def unique_commit_count(repo: Path, base_oid: str, head_oid: str) -> int:
+    result = run_git(repo, ["rev-list", "--count", f"{base_oid}..{head_oid}"])
+    value = one_line(result)
+    try:
+        return int(value)
+    except ValueError as exc:
+        raise InventoryError(
+            f"git rev-list returned a non-integer count: {value!r}"
+        ) from exc
+
+
+def aggregate_cleanliness(checkouts: list[dict[str, Any]]) -> bool | None:
+    if not checkouts:
+        return None
+    values = [checkout["clean"] for checkout in checkouts]
+    if any(value is False for value in values):
+        return False
+    if all(value is True for value in values):
+        return True
+    return None
+
+
+def scan_branches(
+    repo: Path, base: dict[str, Any], worktrees: list[dict[str, Any]]
+) -> list[dict[str, Any]]:
+    result = run_git(
+        repo,
+        [
+            "for-each-ref",
+            "--format=%(refname)%00%(objectname)%00%(upstream)%00%(upstream:short)%00",
+            "refs/heads",
+        ],
+    )
+    by_branch: dict[str, list[dict[str, Any]]] = {}
+    for worktree in worktrees:
+        if worktree["branch_ref"]:
+            by_branch.setdefault(worktree["branch_ref"], []).append(worktree)
+
+    branches: list[dict[str, Any]] = []
+    for ref, oid, upstream_ref, upstream_name in parse_branch_refs(result.stdout):
+        checkouts = sorted(by_branch.get(ref, []), key=lambda item: item["path"])
+        unique_count = unique_commit_count(repo, base["oid"], oid)
+        branches.append(
+            {
+                "ref": ref,
+                "name": short_ref_name(ref),
+                "head_oid": oid,
+                "upstream_ref": upstream_ref,
+                "upstream": upstream_name,
+                "checked_out_worktree": checkouts[0]["path"] if checkouts else None,
+                "checked_out_worktrees": [
+                    {
+                        "path": checkout["path"],
+                        "clean": checkout["clean"],
+                        "cleanliness": checkout["cleanliness"],
+                        "cleanliness_reason": checkout["cleanliness_reason"],
+                    }
+                    for checkout in checkouts
+                ],
+                "worktree_clean": aggregate_cleanliness(checkouts),
+                "reachable_from_base": is_ancestor(repo, oid, base["oid"]),
+                "unique_commit_count": unique_count,
+                "unique_commit_proof": {
+                    "revision_range": f"{base['oid']}..{oid}",
+                    "count": unique_count,
+                },
+            }
+        )
+    return branches
+
+
+SCHEMA_STATEMENTS = (
+    """
+    CREATE TABLE schema_migrations (
+      version INTEGER PRIMARY KEY,
+      applied_at TEXT NOT NULL
+    )
+    """,
+    """
+    CREATE TABLE repositories (
+      id INTEGER PRIMARY KEY,
+      common_git_dir TEXT NOT NULL UNIQUE,
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL
+    )
+    """,
+    """
+    CREATE TABLE reconciliations (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      repository_id INTEGER NOT NULL REFERENCES repositories(id),
+      observed_at TEXT NOT NULL,
+      base_source TEXT NOT NULL,
+      base_ref TEXT,
+      base_oid TEXT NOT NULL,
+      invoking_head_oid TEXT NOT NULL,
+      worktree_count INTEGER NOT NULL,
+      branch_count INTEGER NOT NULL,
+      journal_mode TEXT NOT NULL
+    )
+    """,
+    """
+    CREATE TABLE branch_declarations (
+      repository_id INTEGER NOT NULL REFERENCES repositories(id),
+      branch_ref TEXT NOT NULL,
+      disposition TEXT NOT NULL CHECK (disposition IN ('registered', 'ignored')),
+      reason TEXT,
+      owner_id TEXT,
+      intent TEXT,
+      metadata_json TEXT NOT NULL DEFAULT '{}',
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL,
+      PRIMARY KEY (repository_id, branch_ref),
+      CHECK (disposition <> 'ignored' OR reason IS NOT NULL)
+    )
+    """,
+    """
+    CREATE TABLE worktree_observations (
+      repository_id INTEGER NOT NULL REFERENCES repositories(id),
+      path TEXT NOT NULL,
+      reconciliation_id INTEGER NOT NULL REFERENCES reconciliations(id),
+      head_oid TEXT NOT NULL,
+      branch_ref TEXT,
+      detached INTEGER NOT NULL CHECK (detached IN (0, 1)),
+      bare INTEGER NOT NULL CHECK (bare IN (0, 1)),
+      clean INTEGER CHECK (clean IN (0, 1)),
+      cleanliness TEXT NOT NULL,
+      cleanliness_reason TEXT,
+      locked_reason TEXT,
+      prunable_reason TEXT,
+      observed_at TEXT NOT NULL,
+      PRIMARY KEY (repository_id, path)
+    )
+    """,
+    """
+    CREATE TABLE branch_observations (
+      repository_id INTEGER NOT NULL REFERENCES repositories(id),
+      branch_ref TEXT NOT NULL,
+      reconciliation_id INTEGER NOT NULL REFERENCES reconciliations(id),
+      name TEXT NOT NULL,
+      head_oid TEXT NOT NULL,
+      upstream_ref TEXT,
+      checked_out_worktree TEXT,
+      worktree_clean INTEGER CHECK (worktree_clean IN (0, 1)),
+      reachable_from_base INTEGER NOT NULL CHECK (reachable_from_base IN (0, 1)),
+      unique_commit_count INTEGER NOT NULL CHECK (unique_commit_count >= 0),
+      disposition TEXT NOT NULL CHECK (disposition IN ('registered', 'unregistered', 'ignored')),
+      disposition_reason TEXT,
+      observed_at TEXT NOT NULL,
+      PRIMARY KEY (repository_id, branch_ref)
+    )
+    """,
+    """
+    CREATE TABLE operations (
+      id TEXT PRIMARY KEY,
+      repository_id INTEGER NOT NULL REFERENCES repositories(id),
+      idempotency_key TEXT NOT NULL UNIQUE,
+      action TEXT NOT NULL,
+      state TEXT NOT NULL,
+      preconditions_json TEXT NOT NULL,
+      plan_json TEXT NOT NULL,
+      created_at TEXT NOT NULL,
+      started_at TEXT,
+      completed_at TEXT
+    )
+    """,
+    """
+    CREATE TABLE events (
+      seq INTEGER PRIMARY KEY AUTOINCREMENT,
+      repository_id INTEGER NOT NULL REFERENCES repositories(id),
+      reconciliation_id INTEGER REFERENCES reconciliations(id),
+      operation_id TEXT REFERENCES operations(id),
+      occurred_at TEXT NOT NULL,
+      actor TEXT NOT NULL,
+      action TEXT NOT NULL,
+      detail_json TEXT NOT NULL
+    )
+    """,
+    "CREATE INDEX events_reconciliation_idx ON events (reconciliation_id, seq)",
+    "CREATE INDEX branch_observations_disposition_idx ON branch_observations (repository_id, disposition, branch_ref)",
+)
+
+
+def sqlite_bool(value: bool | None) -> int | None:
+    if value is None:
+        return None
+    return int(value)
+
+
+def is_busy_error(error: sqlite3.Error) -> bool:
+    return "locked" in str(error).lower() or "busy" in str(error).lower()
+
+
+def migrate(connection: sqlite3.Connection, observed_at: str) -> None:
+    version = int(connection.execute("PRAGMA user_version").fetchone()[0])
+    if version > SCHEMA_VERSION:
+        raise InventoryError(
+            f"catalog schema version {version} is newer than supported version {SCHEMA_VERSION}"
+        )
+    if version == 0:
+        for statement in SCHEMA_STATEMENTS:
+            connection.execute(statement)
+        connection.execute(
+            "INSERT INTO schema_migrations(version, applied_at) VALUES (?, ?)",
+            (SCHEMA_VERSION, observed_at),
+        )
+        connection.execute(f"PRAGMA user_version = {SCHEMA_VERSION}")
+    elif version != SCHEMA_VERSION:
+        raise InventoryError(
+            f"no deterministic migration path from catalog schema version {version}"
+        )
+
+
+def disposition_for(
+    branch: dict[str, Any], declaration: sqlite3.Row | None
+) -> tuple[str, str | None]:
+    if declaration is not None:
+        return declaration["disposition"], declaration["reason"]
+    if branch["unique_commit_count"] > 0:
+        return "unregistered", "no orchestrator declaration exists"
+    return "ignored", "no commits unique to the selected integration base"
+
+
+def reconcile_catalog(
+    catalog: Path,
+    common_dir: Path,
+    observed_at: str,
+    base: dict[str, Any],
+    invoking_head_oid: str,
+    worktrees: list[dict[str, Any]],
+    branches: list[dict[str, Any]],
+    lock_timeout_ms: int,
+) -> tuple[int, str]:
+    try:
+        catalog.parent.mkdir(parents=True, exist_ok=True)
+    except OSError as error:
+        raise InventoryError(f"could not create catalog directory: {error}") from error
+    try:
+        connection = sqlite3.connect(
+            catalog,
+            timeout=lock_timeout_ms / 1_000,
+            isolation_level=None,
+        )
+    except sqlite3.Error as error:
+        raise InventoryError(f"could not open catalog: {error}") from error
+    connection.row_factory = sqlite3.Row
+    try:
+        connection.execute(f"PRAGMA busy_timeout = {lock_timeout_ms}")
+        connection.execute("PRAGMA foreign_keys = ON")
+        try:
+            journal_mode = str(
+                connection.execute("PRAGMA journal_mode = WAL").fetchone()[0]
+            ).lower()
+            connection.execute("BEGIN IMMEDIATE")
+        except sqlite3.OperationalError as error:
+            if is_busy_error(error):
+                raise CatalogBusyError(
+                    f"catalog writer remained busy for {lock_timeout_ms} ms; retry inventory after the other refresh finishes"
+                ) from error
+            raise
+        try:
+            migrate(connection, observed_at)
+            connection.execute(
+                """
+                INSERT INTO repositories(id, common_git_dir, created_at, updated_at)
+                VALUES (1, ?, ?, ?)
+                ON CONFLICT(id) DO UPDATE SET
+                  common_git_dir = excluded.common_git_dir,
+                  updated_at = excluded.updated_at
+                """,
+                (os.fspath(common_dir), observed_at, observed_at),
+            )
+            cursor = connection.execute(
+                """
+                INSERT INTO reconciliations(
+                  repository_id, observed_at, base_source, base_ref, base_oid,
+                  invoking_head_oid, worktree_count, branch_count, journal_mode
+                ) VALUES (1, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    observed_at,
+                    base["source"],
+                    base["ref"],
+                    base["oid"],
+                    invoking_head_oid,
+                    len(worktrees),
+                    len(branches),
+                    journal_mode,
+                ),
+            )
+            reconciliation_id = int(cursor.lastrowid)
+            declarations = {
+                row["branch_ref"]: row
+                for row in connection.execute(
+                    "SELECT branch_ref, disposition, reason FROM branch_declarations WHERE repository_id = 1"
+                )
+            }
+            connection.execute(
+                "DELETE FROM worktree_observations WHERE repository_id = 1"
+            )
+            connection.execute(
+                "DELETE FROM branch_observations WHERE repository_id = 1"
+            )
+            for worktree in worktrees:
+                connection.execute(
+                    """
+                    INSERT INTO worktree_observations(
+                      repository_id, path, reconciliation_id, head_oid, branch_ref,
+                      detached, bare, clean, cleanliness, cleanliness_reason,
+                      locked_reason, prunable_reason, observed_at
+                    ) VALUES (1, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        worktree["path"],
+                        reconciliation_id,
+                        worktree["head_oid"],
+                        worktree["branch_ref"],
+                        int(worktree["detached"]),
+                        int(worktree["bare"]),
+                        sqlite_bool(worktree["clean"]),
+                        worktree["cleanliness"],
+                        worktree["cleanliness_reason"],
+                        worktree["locked_reason"],
+                        worktree["prunable_reason"],
+                        observed_at,
+                    ),
+                )
+            for branch in branches:
+                disposition, reason = disposition_for(
+                    branch, declarations.get(branch["ref"])
+                )
+                branch["disposition"] = disposition
+                branch["disposition_reason"] = reason
+                connection.execute(
+                    """
+                    INSERT INTO branch_observations(
+                      repository_id, branch_ref, reconciliation_id, name, head_oid,
+                      upstream_ref, checked_out_worktree, worktree_clean,
+                      reachable_from_base, unique_commit_count, disposition,
+                      disposition_reason, observed_at
+                    ) VALUES (1, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        branch["ref"],
+                        reconciliation_id,
+                        branch["name"],
+                        branch["head_oid"],
+                        branch["upstream_ref"],
+                        branch["checked_out_worktree"],
+                        sqlite_bool(branch["worktree_clean"]),
+                        int(branch["reachable_from_base"]),
+                        branch["unique_commit_count"],
+                        disposition,
+                        reason,
+                        observed_at,
+                    ),
+                )
+            event_detail = json.dumps(
+                {
+                    "base_oid": base["oid"],
+                    "base_ref": base["ref"],
+                    "branch_count": len(branches),
+                    "worktree_count": len(worktrees),
+                },
+                separators=(",", ":"),
+                sort_keys=True,
+            )
+            connection.execute(
+                """
+                INSERT INTO events(
+                  repository_id, reconciliation_id, operation_id, occurred_at,
+                  actor, action, detail_json
+                ) VALUES (1, ?, NULL, ?, 'fm-pr-stack', 'inventory.reconciled', ?)
+                """,
+                (reconciliation_id, observed_at, event_detail),
+            )
+            connection.commit()
+            return reconciliation_id, journal_mode
+        except Exception:
+            connection.rollback()
+            raise
+    except sqlite3.OperationalError as error:
+        if is_busy_error(error):
+            raise CatalogBusyError(
+                f"catalog writer remained busy for {lock_timeout_ms} ms; retry inventory after the other refresh finishes"
+            ) from error
+        raise InventoryError(f"could not update catalog: {error}") from error
+    except sqlite3.DatabaseError as error:
+        raise InventoryError(f"could not update catalog: {error}") from error
+    finally:
+        connection.close()
+
+
+def inventory(
+    repo: Path, base_override: str | None, lock_timeout_ms: int
+) -> dict[str, Any]:
+    observed_at = now_utc()
+    common_dir = common_git_dir(repo)
+    base = select_base(repo, base_override)
+    invoking_head_oid = resolve_commit(repo, "HEAD", "repository HEAD")
+    worktrees = scan_worktrees(repo)
+    branches = scan_branches(repo, base, worktrees)
+    catalog = common_dir / CATALOG_RELATIVE_PATH
+    reconciliation_id, journal_mode = reconcile_catalog(
+        catalog,
+        common_dir,
+        observed_at,
+        base,
+        invoking_head_oid,
+        worktrees,
+        branches,
+        lock_timeout_ms,
+    )
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "observed_at": observed_at,
+        "query": "inventory",
+        "repository_head": invoking_head_oid,
+        "selected_base": base,
+        "catalog": {
+            "path": os.fspath(catalog),
+            "schema_version": SCHEMA_VERSION,
+            "reconciliation_id": reconciliation_id,
+            "journal_mode": journal_mode,
+        },
+        "worktrees": worktrees,
+        "items": branches,
+    }
+
+
+def render_human(snapshot: dict[str, Any]) -> None:
+    base = snapshot["selected_base"]
+    worktrees = snapshot["worktrees"]
+    branches = snapshot["items"]
+    dirty = sum(worktree["clean"] is False for worktree in worktrees)
+    detached = sum(worktree["detached"] for worktree in worktrees)
+    print(f"PR-stack inventory observed {snapshot['observed_at']}")
+    print(f"Base: {base['name']} @ {base['oid'][:12]} ({base['source']})")
+    print(f"Worktrees: {len(worktrees)} ({dirty} dirty, {detached} detached)")
+    print("Branches:")
+    for branch in branches:
+        clean = "-"
+        if branch["worktree_clean"] is True:
+            clean = "clean"
+        elif branch["worktree_clean"] is False:
+            clean = "dirty"
+        location = ""
+        if branch["checked_out_worktree"]:
+            location = (
+                f" @ {json.dumps(branch['checked_out_worktree'], ensure_ascii=False)}"
+            )
+        upstream = f" -> {branch['upstream']}" if branch["upstream"] else ""
+        print(
+            f"  {branch['disposition']:<12} unique={branch['unique_commit_count']:<4} "
+            f"{clean:<5} {branch['name']}{upstream}{location}"
+        )
+    catalog = snapshot["catalog"]
+    print(
+        f"Catalog: {catalog['path']} "
+        f"(schema {catalog['schema_version']}, reconciliation {catalog['reconciliation_id']})"
+    )
+
+
+def positive_timeout(value: str) -> int:
+    try:
+        timeout = int(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(
+            "must be an integer number of milliseconds"
+        ) from exc
+    if timeout < 1 or timeout > 60_000:
+        raise argparse.ArgumentTypeError("must be between 1 and 60000 milliseconds")
+    return timeout
+
+
+def parser() -> argparse.ArgumentParser:
+    command = argparse.ArgumentParser(
+        prog="fm-pr-stack.py",
+        description="Reconcile read-only Git branch/worktree inventory into the shared PR-stack catalog.",
+    )
+    subcommands = command.add_subparsers(dest="command", required=True)
+    inventory_parser = subcommands.add_parser(
+        "inventory",
+        help="observe all linked worktrees and local branches",
+    )
+    inventory_parser.add_argument(
+        "--base",
+        metavar="REVISION",
+        help="explicit integration base (otherwise origin/HEAD, then an unambiguous local main or master)",
+    )
+    inventory_parser.add_argument(
+        "--json",
+        action="store_true",
+        help="print the stable agent-readable JSON object",
+    )
+    inventory_parser.add_argument(
+        "--lock-timeout-ms",
+        type=positive_timeout,
+        default=positive_timeout(
+            os.environ.get("FM_PR_STACK_LOCK_TIMEOUT_MS", str(DEFAULT_LOCK_TIMEOUT_MS))
+        ),
+        help=argparse.SUPPRESS,
+    )
+    return command
+
+
+def fail(message: str, code: int = 1) -> NoReturn:
+    print(f"fm-pr-stack: {message}", file=sys.stderr)
+    raise SystemExit(code)
+
+
+def main() -> int:
+    arguments = parser().parse_args()
+    try:
+        repo = repository_root()
+        if arguments.command == "inventory":
+            snapshot = inventory(repo, arguments.base, arguments.lock_timeout_ms)
+            if arguments.json:
+                print(json.dumps(snapshot, indent=2, sort_keys=True, ensure_ascii=True))
+            else:
+                render_human(snapshot)
+            return 0
+        raise AssertionError(f"unhandled command {arguments.command}")
+    except CatalogBusyError as error:
+        fail(str(error), 3)
+    except InventoryError as error:
+        fail(str(error), 2)
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/bin/fm-pr-stack.py
+++ b/bin/fm-pr-stack.py
@@ -23,7 +23,7 @@ import sys
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, NoReturn, Sequence
+from typing import Any, NoReturn, Optional, Sequence
 
 
 SCHEMA_VERSION = 1
@@ -795,12 +795,22 @@ def parser() -> argparse.ArgumentParser:
     inventory_parser.add_argument(
         "--lock-timeout-ms",
         type=positive_timeout,
-        default=positive_timeout(
-            os.environ.get("FM_PR_STACK_LOCK_TIMEOUT_MS", str(DEFAULT_LOCK_TIMEOUT_MS))
-        ),
+        default=None,
         help=argparse.SUPPRESS,
     )
     return command
+
+
+def resolve_lock_timeout_ms(explicit: Optional[int]) -> int:
+    if explicit is not None:
+        return explicit
+    raw = os.environ.get("FM_PR_STACK_LOCK_TIMEOUT_MS", str(DEFAULT_LOCK_TIMEOUT_MS))
+    try:
+        return positive_timeout(raw)
+    except argparse.ArgumentTypeError as exc:
+        raise InventoryError(
+            f"invalid FM_PR_STACK_LOCK_TIMEOUT_MS environment value: {exc}"
+        ) from exc
 
 
 def fail(message: str, code: int = 1) -> NoReturn:
@@ -813,7 +823,8 @@ def main() -> int:
     try:
         repo = repository_root()
         if arguments.command == "inventory":
-            snapshot = inventory(repo, arguments.base, arguments.lock_timeout_ms)
+            lock_timeout_ms = resolve_lock_timeout_ms(arguments.lock_timeout_ms)
+            snapshot = inventory(repo, arguments.base, lock_timeout_ms)
             if arguments.json:
                 print(json.dumps(snapshot, indent=2, sort_keys=True, ensure_ascii=True))
             else:

--- a/bin/fm-pr-stack.py
+++ b/bin/fm-pr-stack.py
@@ -240,18 +240,22 @@ def scan_worktrees(repo: Path) -> list[dict[str, Any]]:
     result = run_git(repo, ["worktree", "list", "--porcelain", "-z"])
     worktrees: list[dict[str, Any]] = []
     for record in parse_worktree_porcelain(result.stdout):
-        if "worktree" not in record or "HEAD" not in record:
+        bare = "bare" in record
+        if "worktree" not in record or ("HEAD" not in record and not bare):
             raise InventoryError(
                 "git worktree list returned an incomplete porcelain record"
             )
         path = decode(record["worktree"])
-        bare = "bare" in record
         branch_ref = decode(record["branch"]) if "branch" in record else None
         clean, cleanliness, cleanliness_reason = worktree_cleanliness(path, bare=bare)
+        head_oid = decode(record["HEAD"]) if "HEAD" in record else None
         worktrees.append(
             {
                 "path": path,
-                "head_oid": decode(record["HEAD"]),
+                "head_oid": head_oid,
+                "head_oid_reason": None
+                if head_oid is not None
+                else "bare worktree record reports no HEAD",
                 "branch_ref": branch_ref,
                 "detached": "detached" in record or (branch_ref is None and not bare),
                 "bare": bare,
@@ -418,7 +422,8 @@ SCHEMA_STATEMENTS = (
       repository_id INTEGER NOT NULL REFERENCES repositories(id),
       path TEXT NOT NULL,
       reconciliation_id INTEGER NOT NULL REFERENCES reconciliations(id),
-      head_oid TEXT NOT NULL,
+      head_oid TEXT,
+      head_oid_reason TEXT,
       branch_ref TEXT,
       detached INTEGER NOT NULL CHECK (detached IN (0, 1)),
       bare INTEGER NOT NULL CHECK (bare IN (0, 1)),
@@ -604,15 +609,16 @@ def reconcile_catalog(
                 connection.execute(
                     """
                     INSERT INTO worktree_observations(
-                      repository_id, path, reconciliation_id, head_oid, branch_ref,
-                      detached, bare, clean, cleanliness, cleanliness_reason,
+                      repository_id, path, reconciliation_id, head_oid, head_oid_reason,
+                      branch_ref, detached, bare, clean, cleanliness, cleanliness_reason,
                       locked_reason, prunable_reason, observed_at
-                    ) VALUES (1, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    ) VALUES (1, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """,
                     (
                         worktree["path"],
                         reconciliation_id,
                         worktree["head_oid"],
+                        worktree["head_oid_reason"],
                         worktree["branch_ref"],
                         int(worktree["detached"]),
                         int(worktree["bare"]),

--- a/docs/documentation-audiences.json
+++ b/docs/documentation-audiences.json
@@ -260,6 +260,10 @@
       "audience": "operator-current"
     },
     {
+      "path": "docs/pr-stack-orchestrator.md",
+      "audience": "operator-current"
+    },
+    {
       "path": "docs/scripts.md",
       "audience": "operator-current"
     },

--- a/docs/pr-stack-orchestrator.md
+++ b/docs/pr-stack-orchestrator.md
@@ -1,0 +1,42 @@
+# PR-stack inventory
+
+The first bounded PR-stack orchestrator surface is a read-only Git inventory with a local SQLite catalog.
+It does not publish stacks, contact GitHub, run Mergify, fetch, or mutate refs, branches, commits, remotes, worktrees, reviewer state, or queues.
+
+## Run inventory
+
+From any linked worktree, run:
+
+```sh
+bin/fm-pr-stack.py inventory
+bin/fm-pr-stack.py inventory --json
+bin/fm-pr-stack.py inventory --base <revision> --json
+```
+
+The human view summarizes the selected integration base, linked-worktree state, and every local branch.
+The JSON form is the stable agent interface and includes `schema_version`, `observed_at`, the selected base identity, repository HEAD, every linked worktree, and deterministically ordered branch items.
+Diagnostics use stderr, so successful JSON stdout remains parseable.
+
+Without `--base`, inventory selects `refs/remotes/origin/HEAD` when it resolves to a commit.
+If that symbolic ref is absent, exactly one local `main` or `master` branch is accepted.
+If neither exists or both exist, inventory stops with an actionable diagnostic and requires `--base`.
+
+Every local branch appears in `items` with its full ref, short name, head OID, configured upstream when any, checked-out worktree information, cleanliness when checked out, base reachability, and a `base..head` unique-commit count.
+A branch with unique commits is `unregistered` until a future declaration workflow registers or explicitly ignores it.
+Branches without unique commits are retained as `ignored` with the reason stated; they are not silently filtered.
+Detached and prunable linked worktrees remain visible in the top-level `worktrees` array.
+
+## Catalog and authority
+
+The command stores the catalog at `pr-stack/orchestrator.sqlite` under Git's common directory, so every linked worktree uses the same database.
+The database schema version is also stored in SQLite `user_version`, and schema upgrades run in the same writer transaction as reconciliation.
+Foreign keys are enabled for each writer connection, WAL is requested where SQLite supports it, and a bounded immediate transaction serializes refreshes.
+If another writer remains active beyond the timeout, inventory exits with a retry diagnostic instead of exposing a partial refresh.
+
+Git remains authoritative for refs, worktrees, ancestry, upstreams, and cleanliness.
+Each invocation observes Git again and transactionally replaces only the catalog's current observation rows.
+The catalog is authoritative only for future orchestrator declarations and operations, while the append-only `events` and `reconciliations` tables preserve refresh evidence.
+
+The version-one schema includes current worktree and branch observations plus minimal `branch_declarations`, `operations`, and append-only `events` foundations.
+This stage deliberately exposes no command that creates declarations or operations.
+Mergify publication, GitHub reconciliation, review scheduling, history rewriting, pushes, cleanup, and queue actions remain deferred.

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -14,6 +14,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-fleet-sync.sh`       | Refresh project clones with safe fast-forwards, self-heals, `STUCK:` reports, branch pruning, and bounded recovery from an orphaned `.git/packed-refs.lock` |
 | `fm-fleet-snapshot.sh`   | Print the read-only structured fleet snapshot JSON (schema `fm-fleet-snapshot.v1`)   |
 | `fm-fleet-view.sh`       | Render the fleet snapshot as a human Markdown view                                   |
+| `fm-pr-stack.py`         | Reconcile read-only linked-worktree and local-branch inventory into the shared SQLite catalog |
 | `fm-bearings-snapshot.sh` | Project the fleet snapshot to the compact TOON bearings view; local-only unless `--include-prs` |
 | `fm-update.sh`           | Fast-forward-only self-update of firstmate and secondmate homes from origin          |
 | `fm-backlog-handoff.sh`  | Validate and delegate queued backlog-item moves into a secondmate home               |

--- a/tests/fm-pr-stack.test.sh
+++ b/tests/fm-pr-stack.test.sh
@@ -292,6 +292,26 @@ PY
   pass "concurrent writer contention fails within a bound and leaves no partial refresh"
 }
 
+test_invalid_lock_timeout_env_diagnoses_cleanly() {
+  local repo=$TMP_ROOT/inventory/repo out err rc
+  out=$TMP_ROOT/badtimeout.out
+  err=$TMP_ROOT/badtimeout.err
+  rc=0
+  (cd "$repo" && FM_PR_STACK_LOCK_TIMEOUT_MS=abc "$CLI" inventory --json > "$out" 2> "$err") || rc=$?
+  expect_code 2 "$rc" "non-integer FM_PR_STACK_LOCK_TIMEOUT_MS"
+  [ ! -s "$out" ] || fail "non-integer timeout diagnostic corrupted JSON stdout"
+  assert_grep "fm-pr-stack: invalid FM_PR_STACK_LOCK_TIMEOUT_MS" "$err" \
+    "non-integer timeout diagnostic is not clean/actionable"
+
+  rc=0
+  (cd "$repo" && FM_PR_STACK_LOCK_TIMEOUT_MS=999999 "$CLI" inventory --json > "$out" 2> "$err") || rc=$?
+  expect_code 2 "$rc" "out-of-range FM_PR_STACK_LOCK_TIMEOUT_MS"
+  [ ! -s "$out" ] || fail "out-of-range timeout diagnostic corrupted JSON stdout"
+  assert_grep "fm-pr-stack: invalid FM_PR_STACK_LOCK_TIMEOUT_MS" "$err" \
+    "out-of-range timeout diagnostic is not clean/actionable"
+  pass "invalid FM_PR_STACK_LOCK_TIMEOUT_MS values fail cleanly with a bounded diagnostic"
+}
+
 test_human_output_is_concise() {
   local repo=$TMP_ROOT/inventory/repo out
   out=$(cd "$repo" && "$CLI" inventory --base main) || fail "human inventory failed"
@@ -308,4 +328,5 @@ test_inventory_json_and_read_only_git
 test_refresh_reobserves_and_catalog_is_shared
 test_missing_and_ambiguous_default_base
 test_bounded_concurrent_writer_failure_is_atomic
+test_invalid_lock_timeout_env_diagnoses_cleanly
 test_human_output_is_concise

--- a/tests/fm-pr-stack.test.sh
+++ b/tests/fm-pr-stack.test.sh
@@ -1,0 +1,311 @@
+#!/usr/bin/env bash
+# Behavior tests for the read-only PR-stack inventory and shared SQLite catalog.
+set -u
+
+# shellcheck source=tests/lib.sh
+# shellcheck disable=SC1091
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+CLI="$ROOT/bin/fm-pr-stack.py"
+TMP_ROOT=$(fm_test_tmproot fm-pr-stack)
+
+command -v python3 >/dev/null 2>&1 || { echo "skip: python3 not found"; exit 0; }
+command -v jq >/dev/null 2>&1 || { echo "skip: jq not found"; exit 0; }
+command -v sqlite3 >/dev/null 2>&1 || { echo "skip: sqlite3 not found"; exit 0; }
+
+assert_present "$CLI" "bin/fm-pr-stack.py is missing"
+[ -x "$CLI" ] || fail "bin/fm-pr-stack.py must be executable"
+
+make_inventory_repo() {  # <name>
+  local case_dir=$TMP_ROOT/$1 repo=$TMP_ROOT/$1/repo bare=$TMP_ROOT/$1/origin.git odd detached
+  mkdir -p "$case_dir"
+  git init -q -b main "$repo"
+  printf 'base\n' > "$repo/tracked.txt"
+  git -C "$repo" add tracked.txt
+  git -C "$repo" -c user.name='Firstmate Tests' -c user.email='tests@example.invalid' commit -qm base
+  git clone --quiet --bare "$repo" "$bare"
+  git -C "$repo" remote add origin "file://$bare"
+  git -C "$repo" fetch -q origin
+  git -C "$repo" remote set-head origin main
+  git -C "$repo" branch --set-upstream-to=origin/main main >/dev/null
+  git -C "$repo" branch zero main
+
+  odd="$case_dir/odd"$'\n'"worktree with spaces"
+  git -C "$repo" worktree add --quiet -b topic "$odd" main
+  printf 'topic\n' > "$odd/topic.txt"
+  git -C "$odd" add topic.txt
+  git -C "$odd" -c user.name='Firstmate Tests' -c user.email='tests@example.invalid' commit -qm topic
+  git -C "$repo" branch --set-upstream-to=origin/main topic >/dev/null
+  git -C "$repo" branch orphan topic
+  printf 'dirty\n' >> "$odd/topic.txt"
+
+  git -C "$repo" switch --quiet --detach main
+  printf 'divergent\n' > "$repo/divergent.txt"
+  git -C "$repo" add divergent.txt
+  git -C "$repo" -c user.name='Firstmate Tests' -c user.email='tests@example.invalid' commit -qm divergent
+  git -C "$repo" branch divergent HEAD
+  git -C "$repo" switch --quiet main
+
+  detached="$case_dir/detached worktree"
+  git -C "$repo" worktree add --quiet --detach "$detached" main
+  printf '%s\n' "$repo"
+}
+
+working_tree_digest() {  # <worktree>...
+  python3 - "$@" <<'PY'
+from __future__ import annotations
+
+import hashlib
+import os
+import sys
+from pathlib import Path
+
+digest = hashlib.sha256()
+for raw_root in sys.argv[1:]:
+    root = Path(raw_root)
+    digest.update(os.fsencode(str(root)))
+    for path in sorted(root.rglob("*"), key=lambda item: os.fsencode(str(item))):
+        relative = path.relative_to(root)
+        if relative.parts and relative.parts[0] == ".git":
+            continue
+        digest.update(os.fsencode(str(relative)))
+        if path.is_symlink():
+            digest.update(b"L" + os.fsencode(os.readlink(path)))
+        elif path.is_file():
+            digest.update(b"F" + path.read_bytes())
+        elif path.is_dir():
+            digest.update(b"D")
+print(digest.hexdigest())
+PY
+}
+
+test_inventory_json_and_read_only_git() {
+  local repo case_dir odd detached out err before_digest after_digest catalog names
+  local before_refs=$TMP_ROOT/before.refs after_refs=$TMP_ROOT/after.refs
+  local before_worktrees=$TMP_ROOT/before.worktrees after_worktrees=$TMP_ROOT/after.worktrees
+  local before_remotes=$TMP_ROOT/before.remotes after_remotes=$TMP_ROOT/after.remotes
+  repo=$(make_inventory_repo inventory)
+  case_dir=$(dirname "$repo")
+  odd="$case_dir/odd"$'\n'"worktree with spaces"
+  detached="$case_dir/detached worktree"
+  out=$case_dir/out.json
+  err=$case_dir/err.txt
+
+  git -C "$repo" for-each-ref --format='%(refname) %(objectname)' refs/heads refs/remotes > "$before_refs"
+  git -C "$repo" worktree list --porcelain -z > "$before_worktrees"
+  git -C "$repo" remote -v > "$before_remotes"
+  before_digest=$(working_tree_digest "$repo" "$odd" "$detached")
+
+  (cd "$repo" && "$CLI" inventory --json > "$out" 2> "$err") \
+    || fail "inventory JSON failed: $(cat "$err")"
+  [ ! -s "$err" ] || fail "successful JSON inventory wrote diagnostics: $(cat "$err")"
+  jq -e . "$out" >/dev/null || fail "inventory stdout is not valid JSON"
+
+  git -C "$repo" for-each-ref --format='%(refname) %(objectname)' refs/heads refs/remotes > "$after_refs"
+  git -C "$repo" worktree list --porcelain -z > "$after_worktrees"
+  git -C "$repo" remote -v > "$after_remotes"
+  after_digest=$(working_tree_digest "$repo" "$odd" "$detached")
+  cmp -s "$before_refs" "$after_refs" || fail "inventory changed refs"
+  cmp -s "$before_worktrees" "$after_worktrees" || fail "inventory changed worktree HEADs or branch attachments"
+  cmp -s "$before_remotes" "$after_remotes" || fail "inventory changed remotes"
+  [ "$before_digest" = "$after_digest" ] || fail "inventory changed worktree contents"
+
+  jq -e '
+    .schema_version == 1
+      and .query == "inventory"
+      and (.observed_at | test("Z$"))
+      and (.repository_head | test("^[0-9a-f]{40,64}$"))
+      and .selected_base.source == "origin_head"
+      and .selected_base.ref == "refs/remotes/origin/main"
+      and (.selected_base.oid | test("^[0-9a-f]{40,64}$"))
+      and (.worktrees | length) == 3
+      and ([.worktrees[] | select(.detached == true)] | length) == 1
+      and ([.worktrees[] | select(.path | contains("odd\nworktree with spaces"))] | length) == 1
+      and ([.items[].ref] == ([.items[].ref] | sort))
+      and ([.worktrees[].path] == ([.worktrees[].path] | sort))
+  ' "$out" >/dev/null || fail "top-level inventory/base/worktree schema is wrong"
+
+  names=$(jq -r '[.items[].name] | join(",")' "$out")
+  [ "$names" = "divergent,main,orphan,topic,zero" ] \
+    || fail "inventory omitted or reordered local branches: $names"
+  jq -e '
+    .items[] | select(.name == "topic")
+    | .ref == "refs/heads/topic"
+      and (.head_oid | test("^[0-9a-f]{40,64}$"))
+      and .upstream_ref == "refs/remotes/origin/main"
+      and .upstream == "origin/main"
+      and (.checked_out_worktree | contains("odd\nworktree with spaces"))
+      and .worktree_clean == false
+      and .reachable_from_base == false
+      and .unique_commit_count == 1
+      and .unique_commit_proof.count == 1
+      and (.unique_commit_proof.revision_range | contains(".."))
+      and .disposition == "unregistered"
+      and .disposition_reason == "no orchestrator declaration exists"
+  ' "$out" >/dev/null || fail "dirty checked-out unique branch facts are wrong"
+  jq -e '
+    .items[] | select(.name == "orphan")
+    | .upstream == null
+      and .checked_out_worktree == null
+      and .worktree_clean == null
+      and .unique_commit_count == 1
+      and .disposition == "unregistered"
+  ' "$out" >/dev/null || fail "missing-upstream unregistered branch facts are wrong"
+  jq -e '
+    .items[] | select(.name == "zero")
+    | .reachable_from_base == true
+      and .unique_commit_count == 0
+      and .disposition == "ignored"
+      and (.disposition_reason | contains("no commits unique"))
+  ' "$out" >/dev/null || fail "zero-unique branch behavior is wrong"
+  jq -e '
+    .items[] | select(.name == "divergent")
+    | .reachable_from_base == false
+      and .unique_commit_count == 1
+      and .disposition == "unregistered"
+  ' "$out" >/dev/null || fail "divergent branch behavior is wrong"
+
+  catalog=$(jq -r .catalog.path "$out")
+  [ "$catalog" = "$(git -C "$repo" rev-parse --path-format=absolute --git-common-dir)/pr-stack/orchestrator.sqlite" ] \
+    || fail "catalog is not under the common Git directory: $catalog"
+  [ "$(sqlite3 "$catalog" 'PRAGMA user_version;')" = 1 ] || fail "catalog user_version is not 1"
+  [ "$(sqlite3 "$catalog" 'PRAGMA journal_mode;')" = wal ] || fail "catalog did not enable WAL"
+  [ -z "$(sqlite3 "$catalog" 'PRAGMA foreign_key_check;')" ] || fail "catalog foreign keys are invalid"
+  for table in branch_declarations branch_observations events operations reconciliations worktree_observations; do
+    [ "$(sqlite3 "$catalog" "SELECT count(*) FROM sqlite_master WHERE type='table' AND name='$table';")" = 1 ] \
+      || fail "catalog table missing: $table"
+  done
+  [ "$(sqlite3 "$catalog" 'SELECT count(*) FROM branch_observations;')" = 5 ] \
+    || fail "catalog current branch observations are incomplete"
+  [ "$(sqlite3 "$catalog" 'SELECT count(*) FROM events WHERE action="inventory.reconciled";')" = 1 ] \
+    || fail "catalog reconciliation event missing"
+  pass "inventory is complete, NUL-safe, agent-readable, cataloged, and read-only for Git"
+}
+
+test_refresh_reobserves_and_catalog_is_shared() {
+  local repo case_dir odd first second catalog first_event_count
+  repo="$TMP_ROOT/inventory/repo"
+  case_dir=$(dirname "$repo")
+  odd="$case_dir/odd"$'\n'"worktree with spaces"
+  first=$case_dir/first-refresh.json
+  second=$case_dir/second-refresh.json
+  (cd "$repo" && "$CLI" inventory --json > "$first") || fail "first refresh failed"
+  catalog=$(jq -r .catalog.path "$first")
+  first_event_count=$(sqlite3 "$catalog" 'SELECT count(*) FROM events;')
+  sqlite3 "$catalog" <<'SQL'
+INSERT INTO branch_declarations(
+  repository_id, branch_ref, disposition, reason, owner_id, intent,
+  metadata_json, created_at, updated_at
+) VALUES
+  (1, 'refs/heads/topic', 'registered', NULL, 'agent-7', 'topic work', '{}', '2026-08-01T00:00:00Z', '2026-08-01T00:00:00Z'),
+  (1, 'refs/heads/orphan', 'ignored', 'fixture exception', NULL, NULL, '{}', '2026-08-01T00:00:00Z', '2026-08-01T00:00:00Z');
+SQL
+
+  printf 'second dirty line\n' >> "$odd/topic.txt"
+  (cd "$odd" && "$CLI" inventory --base main --json > "$second") || fail "linked-worktree refresh failed"
+  [ "$(jq -r .catalog.path "$second")" = "$catalog" ] \
+    || fail "linked worktree did not share the common-dir catalog"
+  [ "$(jq -r '.items[] | select(.name == "topic") | .worktree_clean' "$second")" = false ] \
+    || fail "refresh did not reobserve live dirty state"
+  [ "$(sqlite3 "$catalog" 'SELECT count(*) FROM events;')" -eq $((first_event_count + 1)) ] \
+    || fail "refresh did not append one audit event"
+  [ "$(sqlite3 "$catalog" 'SELECT count(*) FROM reconciliations;')" -eq $((first_event_count + 1)) ] \
+    || fail "refresh did not append reconciliation evidence"
+  [ "$(jq -r .selected_base.source "$second")" = explicit ] \
+    || fail "explicit base override identity was not preserved"
+  [ "$(jq -r .selected_base.ref "$second")" = refs/heads/main ] \
+    || fail "explicit base override did not resolve the full ref"
+  jq -e '
+    (.items[] | select(.name == "topic") | .disposition == "registered")
+      and (.items[] | select(.name == "orphan")
+        | .disposition == "ignored" and .disposition_reason == "fixture exception")
+  ' "$second" >/dev/null || fail "refresh did not preserve orchestrator declarations"
+  pass "refresh reobserves Git and all linked worktrees share one append-only catalog"
+}
+
+test_missing_and_ambiguous_default_base() {
+  local missing=$TMP_ROOT/missing-base ambiguous=$TMP_ROOT/ambiguous-base out err rc
+  git init -q -b topic "$missing"
+  printf 'topic\n' > "$missing/file"
+  git -C "$missing" add file
+  git -C "$missing" -c user.name='Firstmate Tests' -c user.email='tests@example.invalid' commit -qm topic
+  out=$TMP_ROOT/missing.out
+  err=$TMP_ROOT/missing.err
+  rc=0
+  (cd "$missing" && "$CLI" inventory --json > "$out" 2> "$err") || rc=$?
+  expect_code 2 "$rc" "missing default base"
+  [ ! -s "$out" ] || fail "missing-base diagnostics corrupted JSON stdout"
+  assert_grep "no default integration base" "$err" "missing-base diagnostic is not actionable"
+  (cd "$missing" && "$CLI" inventory --base HEAD --json | jq -e '.selected_base.source == "explicit"') >/dev/null \
+    || fail "explicit base did not recover missing-default repository"
+
+  git init -q -b main "$ambiguous"
+  printf 'main\n' > "$ambiguous/file"
+  git -C "$ambiguous" add file
+  git -C "$ambiguous" -c user.name='Firstmate Tests' -c user.email='tests@example.invalid' commit -qm main
+  git -C "$ambiguous" branch master
+  out=$TMP_ROOT/ambiguous.out
+  err=$TMP_ROOT/ambiguous.err
+  rc=0
+  (cd "$ambiguous" && "$CLI" inventory --json > "$out" 2> "$err") || rc=$?
+  expect_code 2 "$rc" "ambiguous default base"
+  [ ! -s "$out" ] || fail "ambiguous-base diagnostics corrupted JSON stdout"
+  assert_grep "ambiguous default integration base" "$err" "ambiguous-base diagnostic is not actionable"
+  (cd "$ambiguous" && "$CLI" inventory --base main --json | jq -e '.selected_base.ref == "refs/heads/main"') >/dev/null \
+    || fail "explicit base did not recover ambiguous-default repository"
+  pass "missing and ambiguous defaults stop clearly while explicit base overrides recover"
+}
+
+test_bounded_concurrent_writer_failure_is_atomic() {
+  local repo=$TMP_ROOT/inventory/repo catalog ready=$TMP_ROOT/holder.ready holder out err rc before after
+  catalog=$(cd "$repo" && "$CLI" inventory --json | jq -r .catalog.path) || fail "catalog setup failed"
+  before=$(sqlite3 "$catalog" 'SELECT count(*) FROM events;')
+  python3 - "$catalog" "$ready" <<'PY' &
+import sqlite3
+import sys
+import time
+
+connection = sqlite3.connect(sys.argv[1], isolation_level=None)
+connection.execute("BEGIN IMMEDIATE")
+open(sys.argv[2], "w", encoding="utf-8").write("ready\n")
+time.sleep(1.5)
+connection.rollback()
+connection.close()
+PY
+  holder=$!
+  for _ in 1 2 3 4 5 6 7 8 9 10; do
+    [ -f "$ready" ] && break
+    sleep 0.05
+  done
+  [ -f "$ready" ] || { kill "$holder" 2>/dev/null || true; fail "catalog lock holder did not start"; }
+  out=$TMP_ROOT/busy.out
+  err=$TMP_ROOT/busy.err
+  rc=0
+  (cd "$repo" && FM_PR_STACK_LOCK_TIMEOUT_MS=50 "$CLI" inventory --json > "$out" 2> "$err") || rc=$?
+  expect_code 3 "$rc" "bounded concurrent refresh"
+  [ ! -s "$out" ] || fail "busy-writer diagnostic corrupted JSON stdout"
+  assert_grep "catalog writer remained busy for 50 ms" "$err" "busy-writer diagnostic is not bounded/actionable"
+  wait "$holder" || fail "catalog lock holder failed"
+  after=$(sqlite3 "$catalog" 'SELECT count(*) FROM events;')
+  [ "$before" = "$after" ] || fail "failed refresh exposed a partial catalog event"
+  [ -z "$(sqlite3 "$catalog" 'PRAGMA foreign_key_check;')" ] || fail "failed refresh left invalid catalog rows"
+  pass "concurrent writer contention fails within a bound and leaves no partial refresh"
+}
+
+test_human_output_is_concise() {
+  local repo=$TMP_ROOT/inventory/repo out
+  out=$(cd "$repo" && "$CLI" inventory --base main) || fail "human inventory failed"
+  assert_contains "$out" "Base: main @" "human output omitted selected base"
+  assert_contains "$out" "Worktrees: 3" "human output omitted worktree summary"
+  assert_contains "$out" "unregistered" "human output omitted unregistered work"
+  assert_contains "$out" "Catalog:" "human output omitted catalog evidence"
+  [ "$(printf '%s\n' "$out" | wc -l | tr -d ' ')" -le 10 ] \
+    || fail "human inventory is not concise: $out"
+  pass "human inventory is concise and highlights unregistered work"
+}
+
+test_inventory_json_and_read_only_git
+test_refresh_reobserves_and_catalog_is_shared
+test_missing_and_ambiguous_default_base
+test_bounded_concurrent_writer_failure_is_atomic
+test_human_output_is_concise

--- a/tests/fm-pr-stack.test.sh
+++ b/tests/fm-pr-stack.test.sh
@@ -312,6 +312,25 @@ test_invalid_lock_timeout_env_diagnoses_cleanly() {
   pass "invalid FM_PR_STACK_LOCK_TIMEOUT_MS values fail cleanly with a bounded diagnostic"
 }
 
+test_bare_repository_with_linked_worktree_is_observed() {
+  local case_dir=$TMP_ROOT/bare-linked bare=$TMP_ROOT/bare-linked/gate.git wt=$TMP_ROOT/bare-linked/wt out
+  mkdir -p "$case_dir"
+  git init --bare -q "$bare"
+  git -C "$bare" worktree add -q -b feature "$wt" \
+    || fail "could not add linked worktree to bare repository"
+  git -C "$wt" -c user.name='Firstmate Tests' -c user.email='tests@example.invalid' \
+    commit -q --allow-empty -m feature
+  out=$(cd "$wt" && "$CLI" inventory --base HEAD~0 --json) \
+    || fail "inventory crashed against a bare repository with a linked committed worktree"
+  [ "$(printf '%s' "$out" | jq -r '.worktrees[] | select(.bare == true) | .head_oid')" = "null" ] \
+    || fail "bare worktree record should report head_oid null instead of fabricating an OID"
+  [ -n "$(printf '%s' "$out" | jq -r '.worktrees[] | select(.bare == true) | .head_oid_reason')" ] \
+    || fail "bare worktree record should carry an explicit reason for its missing HEAD"
+  [ "$(printf '%s' "$out" | jq -r '.worktrees[] | select(.bare == false) | .head_oid')" != "null" ] \
+    || fail "linked worktree with a real commit should still report a head_oid"
+  pass "a bare repository with a linked committed worktree is observed without a HEAD-parsing crash"
+}
+
 test_human_output_is_concise() {
   local repo=$TMP_ROOT/inventory/repo out
   out=$(cd "$repo" && "$CLI" inventory --base main) || fail "human inventory failed"
@@ -329,4 +348,5 @@ test_refresh_reobserves_and_catalog_is_shared
 test_missing_and_ambiguous_default_base
 test_bounded_concurrent_writer_failure_is_atomic
 test_invalid_lock_timeout_env_diagnoses_cleanly
+test_bare_repository_with_linked_worktree_is_observed
 test_human_output_is_concise


### PR DESCRIPTION
## What Changed
- Added `bin/fm-pr-stack.py`, a new read-only CLI that inventories git worktrees and branches to build a PR stack catalog (JSON output support included).
- Hardened the CLI's argument/env handling: `--lock-timeout-ms` now validates the `FM_PR_STACK_LOCK_TIMEOUT_MS` env var lazily inside `main()` instead of eagerly during parser construction, so a malformed value produces the tool's normal `fm-pr-stack: <message>` diagnostic instead of a raw traceback.
- Fixed worktree scanning to tolerate `git worktree list --porcelain` records with no `HEAD` field (the bare/main worktree record when its ref is unborn), storing a nullable `head_oid`/`head_oid_reason` instead of raising `InventoryError`.
- Added `tests/fm-pr-stack.test.sh` covering the new tool, and documented it in `docs/pr-stack-orchestrator.md`, `docs/scripts.md`, `docs/documentation-audiences.json`, and `README.md`.

## Risk Assessment

✅ Low: Both previously-identified defects (eager env-var crash, bare-worktree unborn-HEAD crash) are fixed with correctly-scoped changes and verified by direct reproduction plus added executable test coverage, and no new issues surfaced in this diff.

## Testing

Targeted test file tests/fm-pr-stack.test.sh (7/7 tests) passed cleanly, and manual CLI reproduction of both previously-crashing scenarios (invalid/out-of-range FM_PR_STACK_LOCK_TIMEOUT_MS env var, and a bare repo with a linked committed worktree) confirmed the fixes work end-to-end: clean bounded diagnostics with exit code 2 for the env var case, and valid JSON output with head_oid=null/head_oid_reason set (no crash) for the bare-worktree case. No regressions or missing evidence found.

<details>
<summary>Evidence: CLI transcript: invalid/out-of-range FM_PR_STACK_LOCK_TIMEOUT_MS diagnostics</summary>

```text
=== FM_PR_STACK_LOCK_TIMEOUT_MS=abc (non-integer) ===
fm-pr-stack: invalid FM_PR_STACK_LOCK_TIMEOUT_MS environment value: must be an integer number of milliseconds
exit code: 2

=== FM_PR_STACK_LOCK_TIMEOUT_MS=999999 (out of range) ===
fm-pr-stack: invalid FM_PR_STACK_LOCK_TIMEOUT_MS environment value: must be between 1 and 60000 milliseconds
exit code: 2
```
</details>
<details>
<summary>Evidence: CLI transcript: bare repo + linked worktree inventory JSON output</summary>

```text
=== fm-pr-stack.py inventory --json against a bare repo + linked worktree ===
{
    "catalog": {
        "journal_mode": "wal",
        "path": "/private/var/folders/w6/cmdzc4px2d70tc2hzmkg00j80000gn/T/tmp.W6RsLlwBP6/gate.git/pr-stack/orchestrator.sqlite",
        "reconciliation_id": 1,
        "schema_version": 1
    },
    "items": [
        {
            "checked_out_worktree": "/private/var/folders/w6/cmdzc4px2d70tc2hzmkg00j80000gn/T/tmp.W6RsLlwBP6/wt",
            "checked_out_worktrees": [
                {
                    "clean": true,
                    "cleanliness": "clean",
                    "cleanliness_reason": null,
                    "path": "/private/var/folders/w6/cmdzc4px2d70tc2hzmkg00j80000gn/T/tmp.W6RsLlwBP6/wt"
                }
            ],
            "disposition": "ignored",
            "disposition_reason": "no commits unique to the selected integration base",
            "head_oid": "8f01fffbc2f1183c627dc25318362f80feaa8b8a",
            "name": "feature",
            "reachable_from_base": true,
            "ref": "refs/heads/feature",
            "unique_commit_count": 0,
            "unique_commit_proof": {
                "count": 0,
                "revision_range": "8f01fffbc2f1183c627dc25318362f80feaa8b8a..8f01fffbc2f1183c627dc25318362f80feaa8b8a"
            },
            "upstream": null,
            "upstream_ref": null,
            "worktree_clean": true
        }
    ],
    "observed_at": "2026-08-01T06:12:23.214Z",
    "query": "inventory",
    "repository_head": "8f01fffbc2f1183c627dc25318362f80feaa8b8a",
    "schema_version": 1,
    "selected_base": {
        "input": "HEAD~0",
        "name": "HEAD~0",
        "oid": "8f01fffbc2f1183c627dc25318362f80feaa8b8a",
        "ref": null,
        "source": "explicit"
    },
    "worktrees": [
        {
            "bare": true,
            "branch_ref": null,
            "clean": null,
            "cleanliness": "not_applicable",
            "cleanliness_reason": "bare worktree record",
            "detached": false,
            "head_oid": null,
            "head_oid_reason": "bare worktree record reports no HEAD",
            "locked_reason": null,
            "path": "/private/var/folders/w6/cmdzc4px2d70tc2hzmkg00j80000gn/T/tmp.W6RsLlwBP6/gate.git",
            "prunable_reason": null
        },
        {
            "bare": false,
            "branch_ref": "refs/heads/feature",
            "clean": true,
            "cleanliness": "clean",
            "cleanliness_reason": null,
            "detached": false,
            "head_oid": "8f01fffbc2f1183c627dc25318362f80feaa8b8a",
            "head_oid_reason": null,
            "locked_reason": null,
            "path": "/private/var/folders/w6/cmdzc4px2d70tc2hzmkg00j80000gn/T/tmp.W6RsLlwBP6/wt",
            "prunable_reason": null
        }
    ]
}

stderr:
exit code: 0
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>⏭️ **intent** - skipped</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed (2) ✅</summary>

- ⚠️ `bin/fm-pr-stack.py:798` - parser() calls positive_timeout(os.environ.get(&#39;FM_PR_STACK_LOCK_TIMEOUT_MS&#39;, ...)) eagerly to compute the --lock-timeout-ms default. If that env var is set to an out-of-range or non-integer value, positive_timeout raises argparse.ArgumentTypeError during parser construction, which happens in main() before the try/except that handles InventoryError/CatalogBusyError. Reproduced directly: `FM_PR_STACK_LOCK_TIMEOUT_MS=abc bin/fm-pr-stack.py inventory --json` exits 1 with a raw Python traceback on stderr instead of the tool&#39;s normal `fm-pr-stack: &lt;message&gt;` diagnostic with a documented exit code (2 or 3). This is a genuine reachable path (any misconfigured environment, e.g. a CI/agent wrapper exporting a bad value) — not just theoretical — and breaks the tool&#39;s own contract of clean, actionable diagnostics. Fix by validating the env var lazily (e.g. inside main(), inside the try block, or via a custom argparse type that tolerates a bad env default and reports it the same way CLI-arg validation errors are reported).

🔧 Fix: Validate lock-timeout env var lazily to avoid traceback crash
1 error still open:
- 🚨 `bin/fm-pr-stack.py:243` - scan_worktrees() requires every `git worktree list --porcelain` record to contain a `HEAD` field, raising InventoryError(&#34;git worktree list returned an incomplete porcelain record&#34;) otherwise. But git legitimately omits the `HEAD &lt;oid&gt;` line for the bare/main worktree record when that bare repo&#39;s own default-branch ref is unborn (i.e. refs/heads/main doesn&#39;t resolve to a commit in the bare repo itself) — this is exactly the topology of a bare &#39;gate&#39; repo with linked worktrees where all commits live only in the linked worktrees&#39; branches, never in the bare repo&#39;s own ref. I reproduced this directly in this session: running `bin/fm-pr-stack.py inventory --base 68641a3 --json` from this very worktree crashes with exactly that error, and isolated repro (`git init --bare gate.git; git -C gate.git worktree add -b feature wt; commit in wt`) confirms `git -C gate.git worktree list --porcelain` never emits a HEAD line for the bare entry while its HEAD stays unborn — not a fluke, standard git behavior. This means the tool&#39;s core `inventory` command fails in the exact bare-repo-backed-worktree shape this project&#39;s own no-mistakes pipeline uses to run every gate step, i.e. it is broken for its own natural deployment environment. Fix at the observation boundary in scan_worktrees/parse_worktree_porcelain: tolerate a worktree record (particularly a `bare` one) with no resolvable HEAD — e.g. treat missing HEAD as null/unborn rather than a hard parse error — and adjust the downstream worktree_observations.head_oid column (currently `NOT NULL`) and any code assuming head_oid is always a real OID accordingly, rather than only patching this one raise site.

🔧 Fix: Tolerate missing HEAD for bare worktree records
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `./tests/fm-pr-stack.test.sh (all 7 cases, including new test_invalid_lock_timeout_env_diagnoses_cleanly and test_bare_repository_with_linked_worktree_is_observed)`
- `Manual: FM_PR_STACK_LOCK_TIMEOUT_MS=abc bin/fm-pr-stack.py inventory --base main --json -> clean exit-code-2 diagnostic instead of a Python traceback`
- `Manual: FM_PR_STACK_LOCK_TIMEOUT_MS=999999 bin/fm-pr-stack.py inventory --base main --json -> clean exit-code-2 diagnostic instead of a Python traceback`
- `Manual: bin/fm-pr-stack.py inventory --base HEAD~0 --json run from a linked worktree of a bare repo -> exit 0, valid JSON with bare worktree's head_oid=null and head_oid_reason set, linked worktree still reports a real head_oid`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
