### PR TITLE
feat(bin): report a known-wrong program squatting a required tool name

### DIFF
--- a/.agents/skills/bootstrap-diagnostics/SKILL.md
+++ b/.agents/skills/bootstrap-diagnostics/SKILL.md
@@ -2,7 +2,7 @@
 name: bootstrap-diagnostics
 description: >-
   Agent-only handling playbook for session-start bootstrap diagnostics.
-  Use whenever the session-start digest's bootstrap or network-checks section prints an actionable diagnostic line - MISSING, MISSING_MANUAL, BACKEND_INVALID, NEEDS_GH_AUTH, TANGLE, STARTUP_MEMORY_BUDGET, CREW_DISPATCH invalid, FLEET_SYNC, NETWORK_CHECKS, PR_CHECK_MIGRATION, SECONDMATE_SYNC, SECONDMATE_LIVENESS, SECONDMATE_HANDOFF, NUDGE_SECONDMATES, or FMX - or when a standalone bin/fm-bootstrap.sh or bin/fm-startup-network.sh run prints one of those lines.
+  Use whenever the session-start digest's bootstrap or network-checks section prints an actionable diagnostic line - MISSING, MISSING_MANUAL, WRONG_PROGRAM, BACKEND_INVALID, NEEDS_GH_AUTH, TANGLE, STARTUP_MEMORY_BUDGET, CREW_DISPATCH invalid, FLEET_SYNC, NETWORK_CHECKS, PR_CHECK_MIGRATION, SECONDMATE_SYNC, SECONDMATE_LIVENESS, SECONDMATE_HANDOFF, NUDGE_SECONDMATES, or FMX - or when a standalone bin/fm-bootstrap.sh or bin/fm-startup-network.sh run prints one of those lines.
   A silent bootstrap section, or a BOOTSTRAP_INFO fact, means no skill load.
 user-invocable: false
 metadata:
@@ -23,6 +23,9 @@ When any diagnostic needs captain attention, report the plain consequence and re
   For `tasks-axi`, this additionally covers an installed build that fails the separate feature probe (`bin/fm-tasks-axi-lib.sh` owns the definition); `config/backlog-backend=manual` only suppresses the verbose `BOOTSTRAP_INFO: tasks-axi available` fact, not this missing-tool report.
   For `quota-axi`, bootstrap requires it because firstmate reads its current output directly before resolving every crew-dispatch profile array; without it, report the missing requirement and do not choose around an unexamined candidate.
 - `MISSING_MANUAL: <tool> (instructions: <url>)` - tell the captain why the tool is required and give them the printed instructions URL, but do not pass the tool to `bin/fm-bootstrap.sh install`; wait for the captain to complete the manual installation, then rerun session start to confirm the dependency is present.
+- `WRONG_PROGRAM: <tool> - <path> is <known-wrong program>, not the '<tool>' CLI this home needs (install: <command>)` - the required name is occupied by a different, positively identified program, so the tool this home dispatches into is effectively absent even though the name resolves.
+  This is a name collision on the captain's machine, not a plain missing tool: report the collision and the printed path to the captain and do not dispatch work that needs `<tool>`.
+  Never run the printed install command as a silent overwrite of the squatting binary; it applies only after the captain has resolved the collision (removed, renamed, or shadowed the other program on `PATH`), and it still needs the ordinary consent step first.
 - `BACKEND_INVALID: <name> (known: <names>)` - the resolved runtime backend has no verified dependency or lifecycle contract, so do not dispatch work until the invalid `FM_BACKEND` or `config/backend` value is corrected to one of the listed backends.
 - `NEEDS_GH_AUTH` - ask the captain to run `! gh auth login` (interactive; you cannot run it for them).
   This probe now arrives from the deferred network stage, so it is also how an unreachable network shows up: `gh` cannot validate its token offline and reports the same failure. Confirm reachability before asking the captain to re-authenticate a credential that may be fine.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -519,7 +519,7 @@ It performs guarded fast-forward updates of firstmate and registered secondmate 
 
 These skills are not captain-invocable; load them only at their precise triggers.
 
-- `bootstrap-diagnostics` - load whenever the session-start digest's bootstrap or network-checks section prints an actionable diagnostic line (`MISSING:`, `MISSING_MANUAL:`, `BACKEND_INVALID:`, `NEEDS_GH_AUTH`, `TANGLE:`, `STARTUP_MEMORY_BUDGET:`, `CREW_DISPATCH: invalid`, `FLEET_SYNC:`, `NETWORK_CHECKS:`, `PR_CHECK_MIGRATION:`, `SECONDMATE_SYNC:`, `SECONDMATE_LIVENESS:`, `SECONDMATE_HANDOFF:`, `NUDGE_SECONDMATES:`, or `FMX:`); silence and `BOOTSTRAP_INFO:` need no load.
+- `bootstrap-diagnostics` - load whenever the session-start digest's bootstrap or network-checks section prints an actionable diagnostic line (`MISSING:`, `MISSING_MANUAL:`, `WRONG_PROGRAM:`, `BACKEND_INVALID:`, `NEEDS_GH_AUTH`, `TANGLE:`, `STARTUP_MEMORY_BUDGET:`, `CREW_DISPATCH: invalid`, `FLEET_SYNC:`, `NETWORK_CHECKS:`, `PR_CHECK_MIGRATION:`, `SECONDMATE_SYNC:`, `SECONDMATE_LIVENESS:`, `SECONDMATE_HANDOFF:`, `NUDGE_SECONDMATES:`, or `FMX:`); silence and `BOOTSTRAP_INFO:` need no load.
 - `diagnostic-reasoning` - load before scoping a reported bug and before acting on a diagnostic report.
 - `ask-user-authority` - load before deciding any ask-user finding, regardless of the project's `yolo` posture.
 - `quota-array-dispatch` - load before choosing among a matched crew-dispatch profile array from current quota-axi output.

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -7,6 +7,7 @@
 #          Silent = all good.
 #          Lines: "MISSING: <tool> (install: <command>)",
 #                 "MISSING_MANUAL: <tool> (instructions: <url>)", "NEEDS_GH_AUTH",
+#                 "WRONG_PROGRAM: <tool> - <path> is not the intended program; install the real '<tool>' CLI (install: <command>)",
 #                 "BACKEND_INVALID: <name> (known: <names>)",
 #                 "STARTUP_MEMORY_BUDGET: invalid config/startup-memory-budget - <reason>",
 #                 "CREW_DISPATCH: invalid config/crew-dispatch.json - <reason>",
@@ -779,6 +780,64 @@ missing_tool_diagnostic() {
   echo "MISSING: $tool (install: $(install_cmd "$tool"))"
 }
 
+# Required tools with a verifiable identity signal. Presence by name alone is
+# not identity: a distribution can occupy a short generic name with an
+# unrelated program - on Linux /usr/bin/orca is GNOME's screen reader, not the
+# Orca terminal runtime this home dispatches into. A binary of the right name
+# must therefore prove it is the intended program before bootstrap reports it
+# present; a wrong program squatting the name is WRONG_PROGRAM (distinct from
+# MISSING, never a silent pass). A tool without a reliable, unambiguous
+# self-identification signal is deliberately absent from this list and keeps
+# the plain presence check - the absence of a signal is not a reason to start
+# rejecting tools that were fine yesterday.
+tool_identity_spec() {  # <tool> -> prints '<marker>\t<program-description>', or returns 1 when unverified
+  case "$1" in
+    # The Orca terminal runtime CLI (stablyai) prints a command-dispatch help
+    # opening with 'Usage: orca <command> [options]' and listing its
+    # status/worktree/terminal commands; GNOME's screen reader prints its own
+    # option list and never that string.
+    orca) printf '%s\t%s\n' 'Usage: orca <command> [options]' 'the Orca terminal runtime' ;;
+    *) return 1 ;;
+  esac
+}
+
+# Run '<tool> --help' bounded by TOOL_IDENTITY_TIMEOUT_SECS so a squatting or
+# broken program cannot hang startup. Same timeout/gtimeout/perl ladder as the
+# watcher's check runner (bin/fm-watch.sh). Echoes combined output.
+TOOL_IDENTITY_TIMEOUT_SECS=5
+tool_help_with_timeout() {  # <tool>
+  local tool=$1
+  if command -v timeout >/dev/null 2>&1; then
+    timeout --kill-after=1 "$TOOL_IDENTITY_TIMEOUT_SECS" "$tool" --help 2>&1
+  elif command -v gtimeout >/dev/null 2>&1; then
+    gtimeout --kill-after=1 "$TOOL_IDENTITY_TIMEOUT_SECS" "$tool" --help 2>&1
+  else
+    # shellcheck disable=SC2016  # single quotes are deliberate: Perl expands its own variables.
+    perl -e 'my $t = shift; my $pid = fork; die "fork failed" unless defined $pid; if (!$pid) { setpgrp(0, 0); exec @ARGV } my $stop = sub { kill "TERM", -$pid; select undef, undef, undef, 0.2; kill "KILL", -$pid; waitpid $pid, 0; exit 124 }; local $SIG{ALRM} = $stop; local $SIG{TERM} = $stop; local $SIG{INT} = $stop; local $SIG{HUP} = $stop; alarm $t; waitpid $pid, 0; exit($? >> 8)' "$TOOL_IDENTITY_TIMEOUT_SECS" "$tool" --help 2>&1
+  fi
+}
+
+# required_tool_identity_verify <tool>: report WRONG_PROGRAM when a present
+# binary of <tool> fails to self-identify as the intended program. The caller
+# establishes presence first, so an absent tool never runs a subprocess; a tool
+# with no identity spec is silent; a probe that yields no usable signal (fails,
+# times out, or prints nothing identifiable) keeps the presence result rather
+# than inventing a rejection.
+required_tool_identity_verify() {  # <tool>
+  local tool=$1 spec marker desc path output rc
+  spec=$(tool_identity_spec "$tool") || return 0
+  marker=${spec%%$'\t'*}
+  desc=${spec#*$'\t'}
+  command -v "$tool" >/dev/null 2>&1 || return 0
+  path=$(command -v "$tool")
+  output=$(tool_help_with_timeout "$tool"); rc=$?
+  [ "$rc" -eq 0 ] || return 0
+  case "$output" in
+    *"$marker"*) return 0 ;;
+  esac
+  echo "WRONG_PROGRAM: $tool - $path is not $desc; install the real '$tool' CLI (install: $(install_cmd "$tool"))"
+}
+
 # Required-tool detection follows the RESOLVED backend, not a one-size default:
 # a universal toolchain every home needs plus the backend-specific delta owned by
 # fm_backend_required_tools (bin/fm-backend.sh). So a herdr/zellij/cmux home is
@@ -1130,11 +1189,18 @@ detect_local_tools() {
     echo "BACKEND_INVALID: $BACKEND (known: $FM_BACKEND_KNOWN)"
   fi
   for t in $BACKEND_TOOLS; do
-    fm_backend_required_tool_available "$BACKEND" "$t" \
-      || missing_tool_diagnostic "$t"
+    if fm_backend_required_tool_available "$BACKEND" "$t"; then
+      required_tool_identity_verify "$t"
+    else
+      missing_tool_diagnostic "$t"
+    fi
   done
   for t in $COMMON_TOOLS; do
-    command -v "$t" >/dev/null || missing_tool_diagnostic "$t"
+    if command -v "$t" >/dev/null; then
+      required_tool_identity_verify "$t"
+    else
+      missing_tool_diagnostic "$t"
+    fi
   done
   # The treehouse lease-support upgrade check is only relevant when the resolved
   # backend actually requires treehouse (every backend except orca, which owns its
@@ -1211,34 +1277,11 @@ if network_phase; then
   gh auth status >/dev/null 2>&1 || echo "NEEDS_GH_AUTH"
   fm_timing_record phase gh-auth "$__fm_timing_stamp"
 fi
-local_phase && detect_local_config
-
-if [ "${FM_BOOTSTRAP_DETECT_ONLY:-0}" != 1 ]; then
-  # secondmate_sync consumes SECONDMATE_RESPAWNED_IDS from the liveness sweep, so
-  # those two always run together in the same phase.
-  if network_phase; then
-    if network_sweep_authorized 'dead-secondmate relaunch'; then
-      __fm_timing_stamp=$(fm_timing_now_ms)
-      secondmate_liveness_sweep
-      fm_timing_record phase secondmate-liveness "$__fm_timing_stamp"
-    fi
-    if network_sweep_authorized 'secondmate convergence'; then
-      __fm_timing_stamp=$(fm_timing_now_ms)
-      secondmate_sync
-      fm_timing_record phase secondmate-sync "$__fm_timing_stamp"
-    fi
-    if network_sweep_authorized 'pending handoff delivery'; then
-      __fm_timing_stamp=$(fm_timing_now_ms)
-      secondmate_handoff_resume
-      fm_timing_record phase handoff-delivery "$__fm_timing_stamp"
-    fi
-  fi
-  # x_mode_setup writes local Relay artifacts only and never leaves the machine.
-  local_phase && x_mode_setup
-  if network_phase && network_sweep_authorized 'project clone refresh'; then
-    __fm_timing_stamp=$(fm_timing_now_ms)
-    fleet_sync
     fm_timing_record phase fleet-sync "$__fm_timing_stamp"
+  fi
+fi
+local_phase && secondmate_handoff_detect
+exit 0
   fi
 fi
 local_phase && secondmate_handoff_detect

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -1234,23 +1234,7 @@ detect_local_tools() {
     echo "MISSING: tasks-axi (install: $(install_cmd tasks-axi))"
   fi
 }
-  fi
-  if command -v no-mistakes >/dev/null 2>&1 && ! tool_version_at_least no-mistakes "$NO_MISTAKES_MIN"; then
-    echo "MISSING: no-mistakes (install: $(install_cmd no-mistakes))"
-  fi
-  if command -v gh-axi >/dev/null 2>&1 && ! tool_version_at_least gh-axi "$GH_AXI_MIN"; then
-    echo "MISSING: gh-axi (install: $(install_cmd gh-axi))"
-  fi
-  if command -v lavish-axi >/dev/null 2>&1 && ! tool_version_at_least lavish-axi "$LAVISH_AXI_MIN"; then
-    echo "MISSING: lavish-axi (install: $(install_cmd lavish-axi))"
-  fi
-  if command -v quota-axi >/dev/null 2>&1 && ! fm_quota_axi_compatible; then
-    echo "MISSING: quota-axi (install: $(install_cmd quota-axi))"
-  fi
-  if command -v tasks-axi >/dev/null 2>&1 && ! fm_tasks_axi_compatible; then
-    echo "MISSING: tasks-axi (install: $(install_cmd tasks-axi))"
-  fi
-}
+
 
 detect_local_config() {
   # Worktree-tangle check: the firstmate primary checkout (FM_ROOT) must sit on its
@@ -1303,11 +1287,34 @@ if network_phase; then
   gh auth status >/dev/null 2>&1 || echo "NEEDS_GH_AUTH"
   fm_timing_record phase gh-auth "$__fm_timing_stamp"
 fi
-    fm_timing_record phase fleet-sync "$__fm_timing_stamp"
+local_phase && detect_local_config
+
+if [ "${FM_BOOTSTRAP_DETECT_ONLY:-0}" != 1 ]; then
+  # secondmate_sync consumes SECONDMATE_RESPAWNED_IDS from the liveness sweep, so
+  # those two always run together in the same phase.
+  if network_phase; then
+    if network_sweep_authorized 'dead-secondmate relaunch'; then
+      __fm_timing_stamp=$(fm_timing_now_ms)
+      secondmate_liveness_sweep
+      fm_timing_record phase secondmate-liveness "$__fm_timing_stamp"
+    fi
+    if network_sweep_authorized 'secondmate convergence'; then
+      __fm_timing_stamp=$(fm_timing_now_ms)
+      secondmate_sync
+      fm_timing_record phase secondmate-sync "$__fm_timing_stamp"
+    fi
+    if network_sweep_authorized 'pending handoff delivery'; then
+      __fm_timing_stamp=$(fm_timing_now_ms)
+      secondmate_handoff_resume
+      fm_timing_record phase handoff-delivery "$__fm_timing_stamp"
+    fi
   fi
-fi
-local_phase && secondmate_handoff_detect
-exit 0
+  # x_mode_setup writes local Relay artifacts only and never leaves the machine.
+  local_phase && x_mode_setup
+  if network_phase && network_sweep_authorized 'project clone refresh'; then
+    __fm_timing_stamp=$(fm_timing_now_ms)
+    fleet_sync
+    fm_timing_record phase fleet-sync "$__fm_timing_stamp"
   fi
 fi
 local_phase && secondmate_handoff_detect

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -7,7 +7,7 @@
 #          Silent = all good.
 #          Lines: "MISSING: <tool> (install: <command>)",
 #                 "MISSING_MANUAL: <tool> (instructions: <url>)", "NEEDS_GH_AUTH",
-#                 "WRONG_PROGRAM: <tool> - <path> is not the intended program; install the real '<tool>' CLI (install: <command>)",
+#                 "WRONG_PROGRAM: <tool> - <path> is <known-wrong program>, not the '<tool>' CLI this home needs (install: <command>)",
 #                 "BACKEND_INVALID: <name> (known: <names>)",
 #                 "STARTUP_MEMORY_BUDGET: invalid config/startup-memory-budget - <reason>",
 #                 "CREW_DISPATCH: invalid config/crew-dispatch.json - <reason>",
@@ -780,23 +780,24 @@ missing_tool_diagnostic() {
   echo "MISSING: $tool (install: $(install_cmd "$tool"))"
 }
 
-# Required tools with a verifiable identity signal. Presence by name alone is
-# not identity: a distribution can occupy a short generic name with an
-# unrelated program - on Linux /usr/bin/orca is GNOME's screen reader, not the
-# Orca terminal runtime this home dispatches into. A binary of the right name
-# must therefore prove it is the intended program before bootstrap reports it
-# present; a wrong program squatting the name is WRONG_PROGRAM (distinct from
-# MISSING, never a silent pass). A tool without a reliable, unambiguous
-# self-identification signal is deliberately absent from this list and keeps
-# the plain presence check - the absence of a signal is not a reason to start
-# rejecting tools that were fine yesterday.
-tool_identity_spec() {  # <tool> -> prints '<marker>\t<program-description>', or returns 1 when unverified
+# Presence by name alone is not identity: a distribution can occupy a short
+# generic name with an unrelated program - on Linux /usr/bin/orca is GNOME's
+# screen reader, not the Orca terminal runtime this home dispatches into.
+# Bootstrap keeps the plain presence check as the default and never guesses a
+# binary is the intended program from unverified help output: the real Orca
+# runtime CLI is not installed on this machine, so its help text is unknown.
+# WRONG_PROGRAM is reported only when a present binary positively identifies as
+# a KNOWN-WRONG program, using a marker verified on this machine (2026-08-01).
+# Any other outcome - the real CLI's help, unknown help, no help, a crash, a
+# timeout - keeps the presence result rather than inventing a rejection.
+known_wrong_program_spec() {  # <tool> -> prints '<marker>\t<program-description>', or returns 1 when unverified
   case "$1" in
-    # The Orca terminal runtime CLI (stablyai) prints a command-dispatch help
-    # opening with 'Usage: orca <command> [options]' and listing its
-    # status/worktree/terminal commands; GNOME's screen reader prints its own
-    # option list and never that string.
-    orca) printf '%s\t%s\n' 'Usage: orca <command> [options]' 'the Orca terminal runtime' ;;
+    # GNOME's screen reader occupies /usr/bin/orca on Linux. Its --help output
+    # (verified on this machine, 2026-08-01: GNOME Orca 46.1) begins with this
+    # Python-argparse usage line, and its -r/--replace option reads "Replace a
+    # currently running instance of this screen reader". The stablyai Orca
+    # terminal runtime CLI never prints that screen-reader usage.
+    orca) printf '%s\t%s\n' 'Usage: orca [-h] [-v] [-r] [-s] [-l] [-e OPTION] [-d OPTION] [-p NAME]' "GNOME's screen reader" ;;
     *) return 1 ;;
   esac
 }
@@ -817,15 +818,15 @@ tool_help_with_timeout() {  # <tool>
   fi
 }
 
-# required_tool_identity_verify <tool>: report WRONG_PROGRAM when a present
-# binary of <tool> fails to self-identify as the intended program. The caller
-# establishes presence first, so an absent tool never runs a subprocess; a tool
-# with no identity spec is silent; a probe that yields no usable signal (fails,
-# times out, or prints nothing identifiable) keeps the presence result rather
+# required_tool_known_wrong_verify <tool>: report WRONG_PROGRAM only when a
+# present binary of <tool> positively identifies as a known-wrong program. The
+# caller establishes presence first, so an absent tool never runs a subprocess;
+# a tool with no verified known-wrong signature is silent; and output that does
+# not match the verified wrong-program marker keeps the presence result rather
 # than inventing a rejection.
-required_tool_identity_verify() {  # <tool>
+required_tool_known_wrong_verify() {  # <tool>
   local tool=$1 spec marker desc path output rc
-  spec=$(tool_identity_spec "$tool") || return 0
+  spec=$(known_wrong_program_spec "$tool") || return 0
   marker=${spec%%$'\t'*}
   desc=${spec#*$'\t'}
   command -v "$tool" >/dev/null 2>&1 || return 0
@@ -833,9 +834,10 @@ required_tool_identity_verify() {  # <tool>
   output=$(tool_help_with_timeout "$tool"); rc=$?
   [ "$rc" -eq 0 ] || return 0
   case "$output" in
-    *"$marker"*) return 0 ;;
+    *"$marker"*)
+      echo "WRONG_PROGRAM: $tool - $path is $desc, not the '$tool' CLI this home needs (install: $(install_cmd "$tool"))"
+      ;;
   esac
-  echo "WRONG_PROGRAM: $tool - $path is not $desc; install the real '$tool' CLI (install: $(install_cmd "$tool"))"
 }
 
 # Required-tool detection follows the RESOLVED backend, not a one-size default:
@@ -1190,14 +1192,14 @@ detect_local_tools() {
   fi
   for t in $BACKEND_TOOLS; do
     if fm_backend_required_tool_available "$BACKEND" "$t"; then
-      required_tool_identity_verify "$t"
+      required_tool_known_wrong_verify "$t"
     else
       missing_tool_diagnostic "$t"
     fi
   done
   for t in $COMMON_TOOLS; do
     if command -v "$t" >/dev/null; then
-      required_tool_identity_verify "$t"
+      required_tool_known_wrong_verify "$t"
     else
       missing_tool_diagnostic "$t"
     fi
@@ -1208,6 +1210,23 @@ detect_local_tools() {
   if fm_backend_list_contains "$TOOLS" treehouse \
     && command -v treehouse >/dev/null 2>&1 && ! treehouse_supports_lease; then
     echo "MISSING: treehouse (install: $(install_cmd treehouse))"
+  fi
+  if command -v no-mistakes >/dev/null 2>&1 && ! tool_version_at_least no-mistakes "$NO_MISTAKES_MIN"; then
+    echo "MISSING: no-mistakes (install: $(install_cmd no-mistakes))"
+  fi
+  if command -v gh-axi >/dev/null 2>&1 && ! tool_version_at_least gh-axi "$GH_AXI_MIN"; then
+    echo "MISSING: gh-axi (install: $(install_cmd gh-axi))"
+  fi
+  if command -v lavish-axi >/dev/null 2>&1 && ! tool_version_at_least lavish-axi "$LAVISH_AXI_MIN"; then
+    echo "MISSING: lavish-axi (install: $(install_cmd lavish-axi))"
+  fi
+  if command -v quota-axi >/dev/null 2>&1 && ! fm_quota_axi_compatible; then
+    echo "MISSING: quota-axi (install: $(install_cmd quota-axi))"
+  fi
+  if command -v tasks-axi >/dev/null 2>&1 && ! fm_tasks_axi_compatible; then
+    echo "MISSING: tasks-axi (install: $(install_cmd tasks-axi))"
+  fi
+}
   fi
   if command -v no-mistakes >/dev/null 2>&1 && ! tool_version_at_least no-mistakes "$NO_MISTAKES_MIN"; then
     echo "MISSING: no-mistakes (install: $(install_cmd no-mistakes))"

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -793,28 +793,35 @@ missing_tool_diagnostic() {
 known_wrong_program_spec() {  # <tool> -> prints '<marker>\t<program-description>', or returns 1 when unverified
   case "$1" in
     # GNOME's screen reader occupies /usr/bin/orca on Linux. Its --help output
-    # (verified on this machine, 2026-08-01: GNOME Orca 46.1) begins with this
-    # Python-argparse usage line, and its -r/--replace option reads "Replace a
-    # currently running instance of this screen reader". The stablyai Orca
-    # terminal runtime CLI never prints that screen-reader usage.
-    orca) printf '%s\t%s\n' 'Usage: orca [-h] [-v] [-r] [-s] [-l] [-e OPTION] [-d OPTION] [-p NAME]' "GNOME's screen reader" ;;
+    # (verified on this machine, 2026-08-01: GNOME Orca 46.1) advertises a
+    # --speech-system option, which no terminal runtime CLI has. The marker must
+    # be an option string, not a usage or help-text line: Python argparse
+    # rewraps usage and help text to the terminal width (verified at COLUMNS
+    # 40/60/80/120/200) and gettext translates the prose, while an option string
+    # is never wrapped mid-token and never localized.
+    orca) printf '%s\t%s\n' '--speech-system' "GNOME's screen reader" ;;
     *) return 1 ;;
   esac
 }
 
 # Run '<tool> --help' bounded by TOOL_IDENTITY_TIMEOUT_SECS so a squatting or
 # broken program cannot hang startup. Same timeout/gtimeout/perl ladder as the
-# watcher's check runner (bin/fm-watch.sh). Echoes combined output.
+# watcher's check runner (bin/fm-watch.sh). Echoes combined output. stdin is
+# closed on every rung, the same way bin/fm-quota-axi-lib.sh's ladder closes it:
+# session start captures bootstrap in a command substitution, so the probe would
+# otherwise inherit the captain's live terminal and a squatting program that
+# reads stdin instead of honoring --help - exactly the case this check exists
+# for - would swallow keystrokes until the timeout fires.
 TOOL_IDENTITY_TIMEOUT_SECS=5
 tool_help_with_timeout() {  # <tool>
   local tool=$1
   if command -v timeout >/dev/null 2>&1; then
-    timeout --kill-after=1 "$TOOL_IDENTITY_TIMEOUT_SECS" "$tool" --help 2>&1
+    timeout --kill-after=1 "$TOOL_IDENTITY_TIMEOUT_SECS" "$tool" --help 2>&1 </dev/null
   elif command -v gtimeout >/dev/null 2>&1; then
-    gtimeout --kill-after=1 "$TOOL_IDENTITY_TIMEOUT_SECS" "$tool" --help 2>&1
+    gtimeout --kill-after=1 "$TOOL_IDENTITY_TIMEOUT_SECS" "$tool" --help 2>&1 </dev/null
   else
     # shellcheck disable=SC2016  # single quotes are deliberate: Perl expands its own variables.
-    perl -e 'my $t = shift; my $pid = fork; die "fork failed" unless defined $pid; if (!$pid) { setpgrp(0, 0); exec @ARGV } my $stop = sub { kill "TERM", -$pid; select undef, undef, undef, 0.2; kill "KILL", -$pid; waitpid $pid, 0; exit 124 }; local $SIG{ALRM} = $stop; local $SIG{TERM} = $stop; local $SIG{INT} = $stop; local $SIG{HUP} = $stop; alarm $t; waitpid $pid, 0; exit($? >> 8)' "$TOOL_IDENTITY_TIMEOUT_SECS" "$tool" --help 2>&1
+    perl -e 'my $t = shift; my $pid = fork; die "fork failed" unless defined $pid; if (!$pid) { setpgrp(0, 0); exec @ARGV } my $stop = sub { kill "TERM", -$pid; select undef, undef, undef, 0.2; kill "KILL", -$pid; waitpid $pid, 0; exit 124 }; local $SIG{ALRM} = $stop; local $SIG{TERM} = $stop; local $SIG{INT} = $stop; local $SIG{HUP} = $stop; alarm $t; waitpid $pid, 0; exit($? >> 8)' "$TOOL_IDENTITY_TIMEOUT_SECS" "$tool" --help 2>&1 </dev/null
   fi
 }
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -292,6 +292,8 @@ Secondmate homes inherit this file from the primary, so a secondmate's own crewm
 
 On session start the first mate detects what its required toolchain is missing or too old and lists each problem with either an exact install command or manual instructions.
 It installs automatically supported tools only after you say go; manual-only tools remain for you to install from the printed instructions.
+Presence on `PATH` is not identity, so a present binary that positively identifies as a known-wrong program squatting a required name is reported as `WRONG_PROGRAM: <tool> - <path> is <program>, not the '<tool>' CLI this home needs (install: <command>)` instead of being accepted; today the only such signature is GNOME's screen reader at `/usr/bin/orca` on Linux, which is not the Orca runtime CLI.
+Every other outcome keeps the plain presence result, and the printed install command applies only after you resolve the name collision yourself rather than overwriting the other program.
 Required tools come in two parts: a universal toolchain every home needs regardless of backend, and a per-backend delta that follows the runtime backend actually resolved for this home.
 The universal toolchain is node, git, gh with GitHub auth via `gh auth login`, no-mistakes v1.31.2 or newer, compatible gh-axi, chrome-devtools-axi, compatible lavish-axi, compatible tasks-axi per "Backlog backend" above, and compatible quota-axi.
 [`bin/fm-bootstrap.sh`](../bin/fm-bootstrap.sh) owns the axi-family floor policy and the gh-axi and lavish-axi floors, while [`bin/fm-tasks-axi-lib.sh`](../bin/fm-tasks-axi-lib.sh) and [`bin/fm-quota-axi-lib.sh`](../bin/fm-quota-axi-lib.sh) hold their own tools' floor constants.

--- a/tests/fm-bootstrap.test.sh
+++ b/tests/fm-bootstrap.test.sh
@@ -141,11 +141,14 @@ SH
 }
 
 # Drop a fake 'orca' CLI with a deterministic --help identity probe, so the
-# identity check runs against a controlled binary instead of whatever the host
-# happens to have installed as 'orca' (e.g. GNOME's screen reader in /usr/bin).
-# mode=genuine prints the stablyai Orca CLI's command-dispatch help marker;
-# mode=wrong prints a plainly different help (the GNOME screen-reader shape).
-add_fake_orca() {  # <fakebin> <genuine|wrong>
+# known-wrong check runs against a controlled binary instead of whatever the
+# host happens to have installed as 'orca' (e.g. GNOME's screen reader in
+# /usr/bin). mode=wrong prints the GNOME screen-reader help, which bootstrap
+# positively identifies as the known-wrong program (marker verified on this
+# machine, 2026-08-01); mode=genuine prints the stablyai Orca CLI's command-
+# dispatch help, which is unverified and therefore treated as present;
+# mode=unknown prints a plainly unrelated help, also treated as present.
+add_fake_orca() {  # <fakebin> <genuine|wrong|unknown>
   local fakebin=$1 mode=$2 help
   if [ "$mode" = wrong ]; then
     help='Usage: orca [-h] [-v] [-r] [-s] [-l] [-e OPTION] [-d OPTION] [-p NAME]
@@ -153,7 +156,14 @@ add_fake_orca() {  # <fakebin> <genuine|wrong>
 
 Optional arguments:
   -h, --help                   Show this help message and exit
-  -v, --version                Version of this application'
+  -v, --version                Version of this application
+  -r, --replace                Replace a currently running instance of this
+                               screen reader'
+  elif [ "$mode" = unknown ]; then
+    help='zap version 9.3
+Usage: zap [options] <file>
+  --sparkle        enable sparkle mode
+  -f, --frobnicate target'
   else
     help='orca
 
@@ -589,19 +599,20 @@ test_orca_wrong_program_reports_distinct_diagnostic() {
   printf '%s\n' manual > "$case_dir/home/config/backlog-backend"
   printf '%s\n' orca > "$case_dir/home/config/backend"
   fakebin=$(make_fake_toolchain "$case_dir")
-  # A program that prints a plainly non-Orca help (the GNOME screen-reader
-  # shape) occupies the name and must be called out, never accepted silently.
+  # A binary that prints the GNOME screen-reader help positively matches the
+  # known-wrong signature (verified on this machine, 2026-08-01) and must be
+  # called out, never accepted silently.
   add_fake_orca "$fakebin" wrong
   out=$(PATH="$fakebin:$BASE_PATH" FM_HOME="$case_dir/home" FM_ROOT_OVERRIDE="$case_dir/home" \
     FM_FAKE_TREEHOUSE_LEASE_HELP=1 "$ROOT/bin/fm-bootstrap.sh")
-  [ -n "$out" ] || fail "a wrong-program orca must not pass the identity check silently"
+  [ -n "$out" ] || fail "a known-wrong orca must not pass the check silently"
   assert_contains "$out" "WRONG_PROGRAM: orca - $fakebin/orca" \
     "the wrong-program diagnostic must name the squatting binary's path"
-  assert_contains "$out" "is not the Orca terminal runtime" \
-    "the wrong-program diagnostic must say what the binary is not"
+  assert_contains "$out" "is GNOME's screen reader" \
+    "the wrong-program diagnostic must name the verified known-wrong program"
   assert_not_contains "$out" "MISSING: orca" \
-    "a wrong program must not be reported as a plain missing tool"
-  pass "bootstrap: a wrong-program orca is reported as WRONG_PROGRAM with its path, never silent or MISSING"
+    "a known-wrong program must not be reported as a plain missing tool"
+  pass "bootstrap: a known-wrong orca is reported as WRONG_PROGRAM with its path, never silent or MISSING"
 }
 
 test_orca_identity_genuine_fake_passes() {
@@ -611,11 +622,32 @@ test_orca_identity_genuine_fake_passes() {
   printf '%s\n' manual > "$case_dir/home/config/backlog-backend"
   printf '%s\n' orca > "$case_dir/home/config/backend"
   fakebin=$(make_fake_toolchain "$case_dir")
+  # A plausible orca CLI help that is NOT the verified known-wrong signature is
+  # unverified, so bootstrap must keep the presence result, never reject it.
   add_fake_orca "$fakebin" genuine
   out=$(PATH="$fakebin:$BASE_PATH" FM_HOME="$case_dir/home" FM_ROOT_OVERRIDE="$case_dir/home" \
     FM_FAKE_TREEHOUSE_LEASE_HELP=1 "$ROOT/bin/fm-bootstrap.sh")
-  [ -z "$out" ] || fail "a genuine orca CLI should pass the identity check silently, got: $out"
-  pass "bootstrap: a genuine (faked-but-correct) orca passes the identity check"
+  [ -z "$out" ] || fail "an unverified orca help must be treated as present, got: $out"
+  pass "bootstrap: an orca help that is not the known-wrong program passes"
+}
+
+test_orca_unrecognised_help_is_treated_as_present() {
+  local case_dir fakebin out
+  case_dir="$TMP_ROOT/orca-unrecognised"
+  mkdir -p "$case_dir/home/config"
+  printf '%s\n' manual > "$case_dir/home/config/backlog-backend"
+  printf '%s\n' orca > "$case_dir/home/config/backend"
+  fakebin=$(make_fake_toolchain "$case_dir")
+  # A present binary whose help matches neither the known-wrong signature nor
+  # anything else recognizable must keep the presence result: not WRONG_PROGRAM,
+  # not MISSING, no rejection invented from unrecognized output.
+  add_fake_orca "$fakebin" unknown
+  out=$(PATH="$fakebin:$BASE_PATH" FM_HOME="$case_dir/home" FM_ROOT_OVERRIDE="$case_dir/home" \
+    FM_FAKE_TREEHOUSE_LEASE_HELP=1 "$ROOT/bin/fm-bootstrap.sh")
+  [ -z "$out" ] || fail "unrecognised help must not be rejected, got: $out"
+  assert_not_contains "$out" "WRONG_PROGRAM" \
+    "unrecognised help must never be labeled a known-wrong program"
+  pass "bootstrap: an unrecognised orca help is treated as present, never WRONG_PROGRAM"
 }
 
 test_tool_without_identity_signal_is_not_probed() {
@@ -1267,6 +1299,7 @@ test_git_is_required_with_supported_install_instruction
 test_orca_backend_gates_orca_tool_only_when_selected
 test_orca_wrong_program_reports_distinct_diagnostic
 test_orca_identity_genuine_fake_passes
+test_orca_unrecognised_help_is_treated_as_present
 test_tool_without_identity_signal_is_not_probed
 test_session_provider_backends_do_not_require_tmux
 test_session_provider_backends_gate_own_cli_not_tmux

--- a/tests/fm-bootstrap.test.sh
+++ b/tests/fm-bootstrap.test.sh
@@ -148,7 +148,11 @@ SH
 # machine, 2026-08-01); mode=genuine prints the stablyai Orca CLI's command-
 # dispatch help, which is unverified and therefore treated as present;
 # mode=unknown prints a plainly unrelated help, also treated as present.
-add_fake_orca() {  # <fakebin> <genuine|wrong|unknown>
+# mode=wrong-narrow is the same screen reader with its Python-argparse usage
+# rewrapped to a narrow terminal and its help prose localized - the two things
+# that vary per install - so the identification is pinned to the option string
+# that survives both, not to a width- or locale-dependent line.
+add_fake_orca() {  # <fakebin> <genuine|wrong|wrong-narrow|unknown>
   local fakebin=$1 mode=$2 help
   if [ "$mode" = wrong ]; then
     help='Usage: orca [-h] [-v] [-r] [-s] [-l] [-e OPTION] [-d OPTION] [-p NAME]
@@ -159,6 +163,20 @@ Optional arguments:
   -v, --version                Version of this application
   -r, --replace                Replace a currently running instance of this
                                screen reader'
+  elif [ "$mode" = wrong-narrow ]; then
+    help='Uso: orca [-h] [-v] [-r] [-s] [-l]
+          [-e OPTION] [-d OPTION]
+          [-p NAME] [-u DIR]
+          [--speech-system NAME]
+          [--debug-file FILE] [--debug]
+
+Argomenti opzionali:
+  -h, --help
+        Mostra questo messaggio
+  -r, --replace
+        Sostituisci una istanza
+  --speech-system NAME
+        Sistema di sintesi vocale'
   elif [ "$mode" = unknown ]; then
     help='zap version 9.3
 Usage: zap [options] <file>
@@ -613,6 +631,25 @@ test_orca_wrong_program_reports_distinct_diagnostic() {
   assert_not_contains "$out" "MISSING: orca" \
     "a known-wrong program must not be reported as a plain missing tool"
   pass "bootstrap: a known-wrong orca is reported as WRONG_PROGRAM with its path, never silent or MISSING"
+}
+
+test_orca_wrong_program_survives_rewrapped_and_localized_help() {
+  local case_dir fakebin out
+  case_dir="$TMP_ROOT/orca-wrong-program-narrow"
+  mkdir -p "$case_dir/home/config"
+  printf '%s\n' manual > "$case_dir/home/config/backlog-backend"
+  printf '%s\n' orca > "$case_dir/home/config/backend"
+  fakebin=$(make_fake_toolchain "$case_dir")
+  # The same screen reader, rewrapped to a narrow terminal and localized: the
+  # identification must not depend on terminal width or the captain's locale,
+  # or the check silently degrades to the plain presence result it exists to
+  # improve on.
+  add_fake_orca "$fakebin" wrong-narrow
+  out=$(PATH="$fakebin:$BASE_PATH" FM_HOME="$case_dir/home" FM_ROOT_OVERRIDE="$case_dir/home" \
+    FM_FAKE_TREEHOUSE_LEASE_HELP=1 "$ROOT/bin/fm-bootstrap.sh")
+  assert_contains "$out" "WRONG_PROGRAM: orca - $fakebin/orca" \
+    "rewrapped, localized screen-reader help must still be identified as the known-wrong program"
+  pass "bootstrap: the known-wrong identification survives terminal rewrapping and localization"
 }
 
 test_orca_identity_genuine_fake_passes() {
@@ -1298,6 +1335,7 @@ test_quota_axi_min_version
 test_git_is_required_with_supported_install_instruction
 test_orca_backend_gates_orca_tool_only_when_selected
 test_orca_wrong_program_reports_distinct_diagnostic
+test_orca_wrong_program_survives_rewrapped_and_localized_help
 test_orca_identity_genuine_fake_passes
 test_orca_unrecognised_help_is_treated_as_present
 test_tool_without_identity_signal_is_not_probed

--- a/tests/fm-bootstrap.test.sh
+++ b/tests/fm-bootstrap.test.sh
@@ -140,6 +140,39 @@ SH
   chmod +x "$fakebin/jq"
 }
 
+# Drop a fake 'orca' CLI with a deterministic --help identity probe, so the
+# identity check runs against a controlled binary instead of whatever the host
+# happens to have installed as 'orca' (e.g. GNOME's screen reader in /usr/bin).
+# mode=genuine prints the stablyai Orca CLI's command-dispatch help marker;
+# mode=wrong prints a plainly different help (the GNOME screen-reader shape).
+add_fake_orca() {  # <fakebin> <genuine|wrong>
+  local fakebin=$1 mode=$2 help
+  if [ "$mode" = wrong ]; then
+    help='Usage: orca [-h] [-v] [-r] [-s] [-l] [-e OPTION] [-d OPTION] [-p NAME]
+            [-u DIR] [--speech-system NAME] [--debug-file FILE] [--debug]
+
+Optional arguments:
+  -h, --help                   Show this help message and exit
+  -v, --version                Version of this application'
+  else
+    help='orca
+
+Usage: orca <command> [options]
+
+Startup:
+  status                    Show app/runtime/graph readiness'
+  fi
+  cat > "$fakebin/orca" <<SH
+#!/usr/bin/env bash
+if [ "\${1:-}" = --help ]; then
+  printf '%s\n' '$help'
+  exit 0
+fi
+exit 0
+SH
+  chmod +x "$fakebin/orca"
+}
+
 make_fake_fleet_sync_root() {
   local dir=$1 fake_root
   fake_root="$dir/fake-root"
@@ -511,7 +544,7 @@ SH
 }
 
 test_orca_backend_gates_orca_tool_only_when_selected() {
-  local case_dir fakebin out missing_orca
+  local case_dir fakebin out missing_orca bash_env
   missing_orca="MISSING: orca (install: brew install orca  # or the platform's package manager)"
 
   case_dir="$TMP_ROOT/orca-backend-selected"
@@ -519,7 +552,23 @@ test_orca_backend_gates_orca_tool_only_when_selected() {
   printf '%s\n' manual > "$case_dir/home/config/backlog-backend"
   printf '%s\n' orca > "$case_dir/home/config/backend"
   fakebin=$(make_fake_toolchain "$case_dir")
-  out=$(PATH="$fakebin:$BASE_PATH" FM_HOME="$case_dir/home" FM_ROOT_OVERRIDE="$case_dir/home" \
+  # Mask any ambient 'orca' on the base PATH (e.g. GNOME's screen reader in
+  # /usr/bin) so this case deterministically exercises the missing-tool report
+  # rather than whatever program the host happens to ship under that name - the
+  # same command()/tool() masking the git and jq cases use.
+  bash_env="$case_dir/no-orca.bash"
+  cat > "$bash_env" <<'SH'
+command() {
+  if [ "${1:-}" = -v ] && [ "${2:-}" = orca ]; then
+    return 1
+  fi
+  builtin command "$@"
+}
+orca() {
+  return 127
+}
+SH
+  out=$(PATH="$fakebin:$BASE_PATH" BASH_ENV="$bash_env" FM_HOME="$case_dir/home" FM_ROOT_OVERRIDE="$case_dir/home" \
     FM_FAKE_TREEHOUSE_LEASE_HELP=1 "$ROOT/bin/fm-bootstrap.sh")
   [ "$out" = "$missing_orca" ] || fail "backend=orca should require only the Orca-specific missing tool, got: $out"
 
@@ -531,6 +580,66 @@ test_orca_backend_gates_orca_tool_only_when_selected() {
     FM_FAKE_TREEHOUSE_LEASE_HELP=1 "$ROOT/bin/fm-bootstrap.sh")
   assert_not_contains "$out" "MISSING: orca" "bootstrap should not require orca unless backend=orca is selected"
   pass "bootstrap: backend=orca gates the Orca CLI without requiring it on the default backend"
+}
+
+test_orca_wrong_program_reports_distinct_diagnostic() {
+  local case_dir fakebin out
+  case_dir="$TMP_ROOT/orca-wrong-program"
+  mkdir -p "$case_dir/home/config"
+  printf '%s\n' manual > "$case_dir/home/config/backlog-backend"
+  printf '%s\n' orca > "$case_dir/home/config/backend"
+  fakebin=$(make_fake_toolchain "$case_dir")
+  # A program that prints a plainly non-Orca help (the GNOME screen-reader
+  # shape) occupies the name and must be called out, never accepted silently.
+  add_fake_orca "$fakebin" wrong
+  out=$(PATH="$fakebin:$BASE_PATH" FM_HOME="$case_dir/home" FM_ROOT_OVERRIDE="$case_dir/home" \
+    FM_FAKE_TREEHOUSE_LEASE_HELP=1 "$ROOT/bin/fm-bootstrap.sh")
+  [ -n "$out" ] || fail "a wrong-program orca must not pass the identity check silently"
+  assert_contains "$out" "WRONG_PROGRAM: orca - $fakebin/orca" \
+    "the wrong-program diagnostic must name the squatting binary's path"
+  assert_contains "$out" "is not the Orca terminal runtime" \
+    "the wrong-program diagnostic must say what the binary is not"
+  assert_not_contains "$out" "MISSING: orca" \
+    "a wrong program must not be reported as a plain missing tool"
+  pass "bootstrap: a wrong-program orca is reported as WRONG_PROGRAM with its path, never silent or MISSING"
+}
+
+test_orca_identity_genuine_fake_passes() {
+  local case_dir fakebin out
+  case_dir="$TMP_ROOT/orca-genuine"
+  mkdir -p "$case_dir/home/config"
+  printf '%s\n' manual > "$case_dir/home/config/backlog-backend"
+  printf '%s\n' orca > "$case_dir/home/config/backend"
+  fakebin=$(make_fake_toolchain "$case_dir")
+  add_fake_orca "$fakebin" genuine
+  out=$(PATH="$fakebin:$BASE_PATH" FM_HOME="$case_dir/home" FM_ROOT_OVERRIDE="$case_dir/home" \
+    FM_FAKE_TREEHOUSE_LEASE_HELP=1 "$ROOT/bin/fm-bootstrap.sh")
+  [ -z "$out" ] || fail "a genuine orca CLI should pass the identity check silently, got: $out"
+  pass "bootstrap: a genuine (faked-but-correct) orca passes the identity check"
+}
+
+test_tool_without_identity_signal_is_not_probed() {
+  local case_dir fakebin out log
+  case_dir="$TMP_ROOT/no-identity-tool"
+  log="$case_dir/node-log"
+  mkdir -p "$case_dir/home/config"
+  printf '%s\n' manual > "$case_dir/home/config/backlog-backend"
+  fakebin=$(make_fake_toolchain "$case_dir")
+  # node has no verifiable identity signal: bootstrap must keep the plain
+  # presence check for it - no --help subprocess and no rejection, even when a
+  # present binary would print garbage for --help.
+  cat > "$fakebin/node" <<SH
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> '$log'
+printf '%s\n' 'garbage --help output for a tool with no identity signal'
+exit 0
+SH
+  chmod +x "$fakebin/node"
+  out=$(PATH="$fakebin:$BASE_PATH" FM_HOME="$case_dir/home" FM_ROOT_OVERRIDE="$case_dir/home" \
+    FM_FAKE_TREEHOUSE_LEASE_HELP=1 "$ROOT/bin/fm-bootstrap.sh")
+  [ -z "$out" ] || fail "a present tool with no identity signal must not be rejected, got: $out"
+  [ ! -s "$log" ] || fail "bootstrap must not probe --help for a tool with no identity signal"
+  pass "bootstrap: tools without an identity signal keep the presence check and run no subprocess"
 }
 
 # Build a fake toolchain with tmux REMOVED and the named backend session CLI(s)
@@ -694,7 +803,7 @@ test_treehouse_lease_check_follows_resolved_backend() {
   printf '%s\n' orca > "$case_dir/home/config/backend"
   fakebin=$(make_fake_toolchain "$case_dir")
   rm -f "$fakebin/tmux"
-  fm_fake_exit0 "$fakebin" orca
+  add_fake_orca "$fakebin" genuine
   # FM_FAKE_TREEHOUSE_LEASE_HELP unset: the fake treehouse advertises NO --lease.
   out=$(PATH="$fakebin:$BASE_PATH" FM_HOME="$case_dir/home" FM_ROOT_OVERRIDE="$case_dir/home" \
     "$ROOT/bin/fm-bootstrap.sh")
@@ -1156,6 +1265,9 @@ test_tasks_axi_min_version
 test_quota_axi_min_version
 test_git_is_required_with_supported_install_instruction
 test_orca_backend_gates_orca_tool_only_when_selected
+test_orca_wrong_program_reports_distinct_diagnostic
+test_orca_identity_genuine_fake_passes
+test_tool_without_identity_signal_is_not_probed
 test_session_provider_backends_do_not_require_tmux
 test_session_provider_backends_gate_own_cli_not_tmux
 test_herdr_install_requires_manual_action


### PR DESCRIPTION
## Intent

The captain asked that startup bootstrap report a wrong program squatting a required tool's name as a distinct WRONG_PROGRAM diagnostic instead of silently accepting it - on Linux /usr/bin/orca is GNOME's screen reader, not the Orca terminal runtime the home dispatches into. After review the captain corrected the approach: keep the plain presence check as the default and report WRONG_PROGRAM only when a present binary positively identifies as a KNOWN-WRONG program, matched against evidence verified on this machine (2026-08-01, GNOME Orca 46.1). The real Orca runtime CLI's help output was never observed on this machine, so a positive identity marker must never be guessed. Only orca gets a known-wrong signature; any other outcome (real CLI help, unknown help, no help, crash, timeout) keeps the presence result. Tests cover: known-wrong reported with its path, non-wrong help passes, unrecognised help treated as present, and tools without a known-wrong signature are never probed.

## What Changed

- `bin/fm-bootstrap.sh` now prints a distinct `WRONG_PROGRAM: <tool> - <path> is <program>, not the '<tool>' CLI this home needs (install: <command>)` line when a required tool is present on `PATH` but positively identifies as a known-wrong program. The plain presence check stays the default: only `orca` has a verified known-wrong signature (GNOME's screen reader, matched on the width-stable `--speech-system` option string), tools without a signature are never probed, and real-CLI help, unrecognised help, no help, a crash, or a timeout all keep the presence result.
- The identity probe runs `<tool> --help` through the existing `timeout`/`gtimeout`/`perl` ladder bounded at 5s with stdin closed on every rung, so a squatting binary that reads stdin cannot hang session start or swallow the captain's keystrokes.
- Documented the new line in the `bin/fm-bootstrap.sh` header contract, the `bootstrap-diagnostics` skill (report the collision, never run the install command as a silent overwrite), the `AGENTS.md` prefix list that triggers that skill, and `docs/configuration.md`. `tests/fm-bootstrap.test.sh` adds 5 cases covering the reported path, rewrapped/localized help, a non-wrong help match, unrecognised help, and unprobed tools.

## Risk Assessment

✅ Low: All three prior findings are fixed at the right boundary and re-verified against the real binary - the identity marker is now a width- and locale-stable option string, the probe closes stdin on every timeout rung, and the new diagnostic is documented in both the trigger list and the handling playbook - leaving a small, conservative change that can only ever degrade to the pre-existing presence result.

## Testing

Ran the targeted bootstrap test file (all 26 checks pass, covering the five new known-wrong cases) plus the documentation-audiences test for the AGENTS.md and skill-doc edits, then proved the intent at the product level on this machine, which genuinely has GNOME Orca 46.1 at /usr/bin/orca: the base-commit script accepts that binary silently while the target commit prints the distinct WRONG_PROGRAM line naming the squatting path, and the same line is what the session-start digest passes through verbatim. Also exercised the forbidden side of the contract manually — a present orca whose help does not match the verified marker (including one that ignores --help and reads stdin) keeps the presence result with no invented rejection and no startup hang. The change is CLI-only, so the reviewer-visible artifact is a command transcript rather than a screenshot; the working tree was left clean.

<details>
<summary>Evidence: Bootstrap WRONG_PROGRAM before/after transcript (real /usr/bin/orca)</summary>

<code>== Host fact: /usr/bin/orca is GNOME&#39;s screen reader (GNOME Orca 46.1) ==&#10;$ command -v orca &amp;&amp; orca --help | head -3&#10;/usr/bin/orca&#10;Usage: orca [-h] [-v] [-r] [-s] [-l] [-e OPTION] [-d OPTION] [-p NAME]&#10;[-u DIR] [--speech-system NAME] [--debug-file FILE] [--debug]&#10;&#10;== BEFORE (base 68641a3, real run): squatting screen reader silently accepted ==&#10;$ FM_HOME=&lt;home with config/backend=orca&gt; bin/fm-bootstrap.sh # base-commit script&#10;MISSING: quota-axi (install: npm install -g quota-axi)&#10;(no orca line at all - /usr/bin/orca accepted as the Orca runtime CLI)&#10;&#10;== AFTER (2c9b9b7, real run): distinct WRONG_PROGRAM diagnostic on the real host binary ==&#10;$ FM_HOME=&lt;home with config/backend=orca&gt; bin/fm-bootstrap.sh&#10;WRONG_PROGRAM: orca - /usr/bin/orca is GNOME&#39;s screen reader, not the &#39;orca&#39; CLI this home needs (install: brew install orca # or the platform&#39;s package manager)&#10;MISSING: quota-axi (install: npm install -g quota-axi)&#10;&#10;== A present orca that does NOT match the known-wrong marker keeps the presence result ==&#10;(fake squatter that ignores --help and reads stdin forever)&#10;$ PATH=&lt;fakebin&gt;:$PATH bin/fm-bootstrap.sh&#10;MISSING: quota-axi (install: npm install -g quota-axi)&#10;(no WRONG_PROGRAM invented from non-matching output; run returned in ~1s, stdin closed, no hang)&#10;&#10;== Session-start digest surface (bin/fm-session-start.sh:273 prints this verbatim under BOOTSTRAP) ==&#10;$ FM_BOOTSTRAP_DETECT_ONLY=1 bin/fm-bootstrap.sh&#10;WRONG_PROGRAM: orca - /usr/bin/orca is GNOME&#39;s screen reader, not the &#39;orca&#39; CLI this home needs (install: brew install orca # or the platform&#39;s package manager)&#10;MISSING: quota-axi (install: npm install -g quota-axi)</code>

```text
== Host fact: /usr/bin/orca is GNOME's screen reader (GNOME Orca 46.1) ==
$ command -v orca && orca --help | head -3
/usr/bin/orca
Usage: orca [-h] [-v] [-r] [-s] [-l] [-e OPTION] [-d OPTION] [-p NAME]
            [-u DIR] [--speech-system NAME] [--debug-file FILE] [--debug]


== BEFORE (base 68641a3, real run): squatting screen reader silently accepted ==
$ FM_HOME=<home with config/backend=orca> bin/fm-bootstrap.sh   # base-commit script
MISSING: quota-axi (install: npm install -g quota-axi)
(no orca line at all - /usr/bin/orca accepted as the Orca runtime CLI)

== AFTER (2c9b9b7, real run): distinct WRONG_PROGRAM diagnostic on the real host binary ==
$ FM_HOME=<home with config/backend=orca> bin/fm-bootstrap.sh
WRONG_PROGRAM: orca - /usr/bin/orca is GNOME's screen reader, not the 'orca' CLI this home needs (install: brew install orca  # or the platform's package manager)
MISSING: quota-axi (install: npm install -g quota-axi)

== A present orca that does NOT match the known-wrong marker keeps the presence result ==
   (fake squatter that ignores --help and reads stdin forever)
$ PATH=<fakebin>:$PATH bin/fm-bootstrap.sh
MISSING: quota-axi (install: npm install -g quota-axi)
(no WRONG_PROGRAM invented from non-matching output; run returned in ~1s, stdin closed, no hang)

== Session-start digest surface (bin/fm-session-start.sh:273 prints this verbatim under BOOTSTRAP) ==
$ FM_BOOTSTRAP_DETECT_ONLY=1 bin/fm-bootstrap.sh
WRONG_PROGRAM: orca - /usr/bin/orca is GNOME's screen reader, not the 'orca' CLI this home needs (install: brew install orca  # or the platform's package manager)
MISSING: quota-axi (install: npm install -g quota-axi)
```
</details>
<details>
<summary>Evidence: New bootstrap test cases result</summary>

```text
$ bash tests/fm-bootstrap.test.sh (exit 0, 26 ok)
ok - bootstrap: a known-wrong orca is reported as WRONG_PROGRAM with its path, never silent or MISSING
ok - bootstrap: the known-wrong identification survives terminal rewrapping and localization
ok - bootstrap: an orca help that is not the known-wrong program passes
ok - bootstrap: an unrecognised orca help is treated as present, never WRONG_PROGRAM
ok - bootstrap: tools without an identity signal keep the presence check and run no subprocess
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 3 issues found → auto-fixed ✅</summary>

- ⚠️ `bin/fm-bootstrap.sh:543` - The known-wrong marker is GNOME Orca&#39;s full wrapped usage line, which argparse rewraps by terminal width, so the positive identification silently fails and the tool falls back to plain presence - the exact bug this change exists to fix. Verified on this machine: `COLUMNS=60 orca --help` prints `Usage: orca [-h] [-v] [-r] [-s] [-l] [-e OPTION]` on line 1, and the marker does not match; `COLUMNS=200` puts the whole option list on one line, also no match. Only the 80-column fallback (used when stdout is a pipe and COLUMNS is unexported) matches. A localized GNOME install translating the `Usage:` prefix fails the same way. Use a width-stable, screen-reader-specific token from the same verified output instead - `--speech-system NAME` and `-l, --list-apps` both appear verbatim at widths 40, 60, 80 and 200, and `--speech-system` is already present in the test&#39;s `wrong` fixture, so the existing tests still cover it.
- ⚠️ `bin/fm-bootstrap.sh:552` - tool_help_with_timeout runs `&#34;$tool&#34; --help` with bootstrap&#39;s stdin inherited on all three ladder rungs. bin/fm-session-start.sh:273 captures bootstrap inside a command substitution, so that stdin is the captain&#39;s live session terminal. A squatting binary that ignores --help and reads stdin (a REPL or a prompt - precisely the wrong-program scenario this feature targets) swallows keystrokes for the full 5s bound before the timeout kills it. The repo already has the convention: bin/fm-quota-axi-lib.sh:26-35 appends `&lt;/dev/null` to every rung of the identical timeout/gtimeout/perl ladder. Add `&lt;/dev/null` to the timeout, gtimeout, and perl invocations.
- ⚠️ `.agents/skills/bootstrap-diagnostics/SKILL.md:19` - The new actionable `WRONG_PROGRAM:` line was added to bin/fm-bootstrap.sh&#39;s header contract but not to the agent-facing catalog that consumes it. AGENTS.md:489 enumerates the prefixes that trigger loading the bootstrap-diagnostics skill (MISSING, MISSING_MANUAL, BACKEND_INVALID, NEEDS_GH_AUTH, TANGLE, ...) and WRONG_PROGRAM is not listed, so an agent seeing the line in the session-start digest loads no playbook, and SKILL.md has no per-line handling entry either - despite stating that bin/fm-bootstrap.sh&#39;s header owns the line formats while the playbook owns the response to actionable lines. Failure sequence: backend=orca home on Linux where /usr/bin/orca is GNOME&#39;s screen reader, session start prints `WRONG_PROGRAM: orca - /usr/bin/orca is GNOME&#39;s screen reader, ...`, the agent has no defined response and may dispatch anyway or blindly run `bin/fm-bootstrap.sh install orca` over the existing binary. Add the prefix to AGENTS.md:489 and a handling bullet to SKILL.md (report the name collision to the captain; the printed install command applies only after the squatting binary is resolved, never as a silent overwrite).

🔧 Fix: harden wrong-program identity marker, close probe stdin, document diagnostic
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash tests/fm-bootstrap.test.sh` — 26 checks pass, including the 5 new cases: `test_orca_wrong_program_reports_distinct_diagnostic`, `test_orca_wrong_program_survives_rewrapped_and_localized_help`, `test_orca_identity_genuine_fake_passes`, `test_orca_unrecognised_help_is_treated_as_present`, `test_tool_without_identity_signal_is_not_probed`</code>
- <code>`bash tests/fm-documentation-audiences.test.sh` — covers the AGENTS.md / bootstrap-diagnostics SKILL.md prose changes in the diff</code>
- <code>Host identity confirmation: `command -v orca &amp;&amp; orca --help` shows `/usr/bin/orca` is GNOME&#39;s screen reader (advertises `--speech-system`), the exact collision the change targets</code>
- <code>Before/after on the real host binary: ran the base-commit script (`git show 68641a3:bin/fm-bootstrap.sh`) and the target `bin/fm-bootstrap.sh` against a temp `FM_HOME` with `config/backend=orca` — base prints no orca line, target prints `WRONG_PROGRAM: orca - /usr/bin/orca is GNOME&#39;s screen reader ...`</code>
- <code>Negative/robustness manual check: `PATH=&lt;fakebin with an orca that ignores --help and reads stdin forever&gt;:$PATH bin/fm-bootstrap.sh` — no WRONG_PROGRAM invented, completed in ~1s (stdin closed, no startup hang)</code>
- <code>Digest surface reproduction: `FM_BOOTSTRAP_DETECT_ONLY=1 bin/fm-bootstrap.sh`, the exact invocation `bin/fm-session-start.sh:273` prints verbatim under the BOOTSTRAP subsection</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
