### PR TITLE
fix(bin): parse punctuated secondmate registry entries safely

### DIFF
--- a/.agents/skills/secondmate-provisioning/SKILL.md
+++ b/.agents/skills/secondmate-provisioning/SKILL.md
@@ -24,6 +24,7 @@ Keep the always-inline routing rules in `AGENTS.md` authoritative: route by natu
 ```
 
 Each registry entry stays concise and single-line: the summary is one sentence naming the durable charter, `scope:` is the natural-language intake responsibility, `projects:` is the non-exclusive clone list, and any extra prose is limited to genuinely domain-specific hard rules that change routing or safety for that secondmate.
+Natural-language summary and `scope:` text may contain parentheses and semicolons; keep the generated `(home: ...; scope: ...; projects: ...; added ...)` suffix intact so operational consumers resolve its explicit field markers.
 The `home:` path points to the seeded home containing `data/charter.md`; no extra registry pointer field is needed.
 The home-seeded `data/charter.md` is the sole owner of boilerplate idle-by-default behavior, the normal delegation lifecycle, and standard escalation contracts, so point to that charter rather than restating those contracts in the registry entry.
 The `scope:` field is used during intake.
@@ -116,7 +117,7 @@ It uses the same live-home discovery and propagation helper as bootstrap, report
 `bin/fm-home-seed.sh` refuses to copy a missing or placeholder charter.
 
 Direct seed without a preexisting brief requires `FM_SECONDMATE_CHARTER`.
-Run `bin/fm-home-seed.sh validate` when checking registry integrity; it refuses duplicate ids, duplicate homes, and nested or overlapping homes.
+Run `bin/fm-home-seed.sh validate` when checking registry integrity; its header owns the complete validation and refusal mechanics.
 
 Seeding is transactional.
 If validation, cloning, no-mistakes initialization, or registry update fails, generated briefs, new homes, new project clones, and registry edits are rolled back.

--- a/bin/fm-backlog-handoff.sh
+++ b/bin/fm-backlog-handoff.sh
@@ -53,21 +53,19 @@ REG="$DATA/secondmates.md"
 MAIN_BACKLOG="$DATA/backlog.md"
 # shellcheck source=bin/fm-tasks-axi-lib.sh disable=SC1091
 . "$SCRIPT_DIR/fm-tasks-axi-lib.sh"
+# shellcheck source=bin/fm-secondmate-registry-lib.sh
+. "$SCRIPT_DIR/fm-secondmate-registry-lib.sh"
 
 [ $# -ge 2 ] || { echo "usage: fm-backlog-handoff.sh <secondmate-id> <item-key>..." >&2; exit 1; }
 ID=$1
 shift
 
 secondmate_home() {
-  local id=$1 line
+  local id=$1 home
   [ -f "$REG" ] || { echo "error: no secondmate registry at $REG" >&2; return 1; }
-  line=$(grep -E "^- $id( |$)" "$REG" | tail -1 || true)
-  [ -n "$line" ] || { echo "error: secondmate $id is not registered in $REG" >&2; return 1; }
-  # Match the (home: ...) field itself; do not require zero parentheses before it.
-  # Summary/scope prose often contains parentheticals (e.g. "(id is legacy)"), and
-  # ^[^(]* would leave those entries looking like "has no home". Greedy prefix so the
-  # last (home: ...) on the line wins. Empty when the field is absent.
-  printf '%s\n' "$line" | sed -n 's/.*(home:[[:space:]]*\([^;)]*\);.*/\1/p' | sed 's/[[:space:]]*$//'
+  home=$(secondmate_registry_field "$REG" "$id" home || true)
+  [ -n "$home" ] || { echo "error: secondmate $id has no home in $REG" >&2; return 1; }
+  printf '%s\n' "$home"
 }
 
 path_is_ancestor_of() {

--- a/bin/fm-ff-lib.sh
+++ b/bin/fm-ff-lib.sh
@@ -25,6 +25,8 @@
 # shared default branch or any other worktree's checkout.
 
 SUB_HOME_MARKER="${SUB_HOME_MARKER:-.fm-secondmate-home}"
+# shellcheck source=bin/fm-secondmate-registry-lib.sh
+. "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/fm-secondmate-registry-lib.sh"
 
 # --- helpers ---------------------------------------------------------------
 
@@ -229,20 +231,6 @@ dirty_status() {
   else
     git -C "$dir" status --porcelain 2>/dev/null | head -1
   fi
-}
-
-secondmate_registry_field() {
-  local reg=$1 id=$2 key=$3 line value
-  [ -f "$reg" ] || return 1
-  line=$(grep -E "^- $id( |$)" "$reg" | tail -1 || true)
-  [ -n "$line" ] || return 1
-  case "$key" in
-    home) value=$(printf '%s\n' "$line" | sed -n 's/.*(home:[[:space:]]*\([^;)]*\);.*/\1/p' | sed 's/[[:space:]]*$//') ;;
-    projects) value=$(printf '%s\n' "$line" | sed -n 's/.*; projects:[[:space:]]*\([^;)]*\); added .*/\1/p' | sed 's/[[:space:]]*$//') ;;
-    *) return 1 ;;
-  esac
-  [ -n "$value" ] || return 1
-  printf '%s\n' "$value"
 }
 
 # List this home's LIVE secondmate direct reports from state/<id>.meta records.

--- a/bin/fm-fleet-snapshot.sh
+++ b/bin/fm-fleet-snapshot.sh
@@ -839,7 +839,7 @@ BASH
         | select(startswith("- "))
         | (capture("^- (?<id>[^[:space:]]+)")?) as $id
         | select($id != null)
-        | (capture("\\(home:[[:space:]]*(?<home>[^;)]*);")?) as $home
+        | (capture("^.*\\(home:[[:space:]]*(?<home>[^;)]*);[[:space:]]*scope:[[:space:]]*.*;[[:space:]]*projects:[[:space:]]*[^;)]*;[[:space:]]*added[[:space:]]+[0-9]{4}-[0-9]{2}-[0-9]{2}\\)[[:space:]]*$")?) as $home
         | {id:$id.id,home:($home.home // null),registered:true,
            registry_error:(if $home == null or ($home.home | length) == 0 then "registry entry has no home" else null end)} ]
       | group_by(.id)

--- a/bin/fm-home-seed.sh
+++ b/bin/fm-home-seed.sh
@@ -38,14 +38,12 @@ DATA="${FM_DATA_OVERRIDE:-$FM_HOME/data}"
 PROJECTS="${FM_PROJECTS_OVERRIDE:-$FM_HOME/projects}"
 REG="$DATA/secondmates.md"
 SUB_HOME_MARKER=".fm-secondmate-home"
+# shellcheck source=bin/fm-secondmate-registry-lib.sh
+. "$SCRIPT_DIR/fm-secondmate-registry-lib.sh"
 
 usage() {
   echo "usage: fm-home-seed.sh <id> <home|-> {<project>...|--no-projects}" >&2
   echo "       fm-home-seed.sh validate" >&2
-}
-
-registry_home_for_line() {
-  sed -n 's/^[^(]*(home: \([^;)]*\);.*/\1/p'
 }
 
 normalize_registry_text() {
@@ -182,10 +180,12 @@ registry_home_conflict_for_assignment() {
   while IFS= read -r line; do
     case "$line" in
       "- "*)
-        registered_id=${line#- }
-        registered_id=${registered_id%% *}
-        registered_home=$(printf '%s\n' "$line" | registry_home_for_line)
-        [ -n "$registered_home" ] || continue
+        if ! secondmate_registry_parse_line "$line"; then
+          echo "error: malformed secondmate registry entry: $line" >&2
+          return 1
+        fi
+        registered_id=$SECONDMATE_REGISTRY_ID
+        registered_home=$SECONDMATE_REGISTRY_HOME
         registered_key=$(resolved_path "$registered_home")
         if [ "$registered_key" = "$target" ]; then
           [ "$registered_id" = "$id" ] && continue
@@ -209,11 +209,13 @@ registry_id_conflict_for_assignment() {
   while IFS= read -r line; do
     case "$line" in
       "- "*)
-        registered_id=${line#- }
-        registered_id=${registered_id%% *}
+        secondmate_registry_parse_line "$line" || {
+          echo "error: malformed secondmate registry entry: $line" >&2
+          return 1
+        }
+        registered_id=$SECONDMATE_REGISTRY_ID
         [ "$registered_id" = "$id" ] || continue
-        registered_home=$(printf '%s\n' "$line" | registry_home_for_line)
-        [ -n "$registered_home" ] || continue
+        registered_home=$SECONDMATE_REGISTRY_HOME
         registered_key=$(resolved_path "$registered_home")
         [ "$registered_key" = "$target" ] && continue
         printf '%s\n' "$registered_key"
@@ -231,11 +233,13 @@ validate_registry() {
     while IFS= read -r line; do
       case "$line" in
         "- "*)
-          id=${line#- }
-          id=${id%% *}
-          registered_home=$(printf '%s\n' "$line" | registry_home_for_line)
-          [ -n "$registered_home" ] || continue
-          home_key=$(resolved_path "$registered_home")
+          if ! secondmate_registry_parse_line "$line"; then
+            rm -f "$tmp"
+            printf 'error: malformed secondmate registry entry:\n%s\n' "$line" >&2
+            return 1
+          fi
+          id=$SECONDMATE_REGISTRY_ID
+          home_key=$(resolved_path "$SECONDMATE_REGISTRY_HOME")
           printf '%s\t%s\n' "$home_key" "$id" >> "$tmp"
           ;;
       esac

--- a/bin/fm-home-seed.sh
+++ b/bin/fm-home-seed.sh
@@ -177,7 +177,7 @@ registry_home_conflict_for_assignment() {
   local id=$1 home=$2 target line registered_id registered_home registered_key
   [ -f "$REG" ] || return 1
   target=$(resolved_path "$home")
-  while IFS= read -r line; do
+  while IFS= read -r line || [ -n "$line" ]; do
     case "$line" in
       "- "*)
         if ! secondmate_registry_parse_line "$line"; then
@@ -206,7 +206,7 @@ registry_id_conflict_for_assignment() {
   local id=$1 home=$2 target line registered_id registered_home registered_key
   [ -f "$REG" ] || return 1
   target=$(resolved_path "$home")
-  while IFS= read -r line; do
+  while IFS= read -r line || [ -n "$line" ]; do
     case "$line" in
       "- "*)
         secondmate_registry_parse_line "$line" || {
@@ -227,7 +227,8 @@ registry_id_conflict_for_assignment() {
 }
 
 validate_registry() {
-  [ ! -f "$REG" ] || secondmate_registry_validate_bindings "$REG" resolved_path || {
+  [ -e "$REG" ] || [ -L "$REG" ] || return 0
+  secondmate_registry_validate_bindings "$REG" resolved_path || {
     printf 'error: %s\n' "$SECONDMATE_REGISTRY_ERROR" >&2
     return 1
   }

--- a/bin/fm-home-seed.sh
+++ b/bin/fm-home-seed.sh
@@ -27,8 +27,9 @@
 #       to override the registry routing scope. Otherwise the registry summary
 #       and scope are derived from the filled charter brief.
 #   fm-home-seed.sh validate
-#       Refuse duplicate ids, duplicate homes, and nested or overlapping homes in
-#       data/secondmates.md.
+#       Refuse records that operational consumers cannot parse, unavailable or
+#       unsafe registry files when present, non-absolute or unresolvable homes,
+#       duplicate ids or homes, and nested or overlapping homes.
 set -eu
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/bin/fm-home-seed.sh
+++ b/bin/fm-home-seed.sh
@@ -227,78 +227,10 @@ registry_id_conflict_for_assignment() {
 }
 
 validate_registry() {
-  local tmp line id registered_home home_key duplicate_homes duplicate_ids overlaps
-  tmp=$(mktemp "${TMPDIR:-/tmp}/fm-firstmates.XXXXXX")
-  if [ -f "$REG" ]; then
-    while IFS= read -r line; do
-      case "$line" in
-        "- "*)
-          if ! secondmate_registry_parse_line "$line"; then
-            rm -f "$tmp"
-            printf 'error: malformed secondmate registry entry:\n%s\n' "$line" >&2
-            return 1
-          fi
-          id=$SECONDMATE_REGISTRY_ID
-          home_key=$(resolved_path "$SECONDMATE_REGISTRY_HOME")
-          printf '%s\t%s\n' "$home_key" "$id" >> "$tmp"
-          ;;
-      esac
-    done < "$REG"
-  fi
-  duplicate_homes=$(awk -F '\t' '
-    {
-      if (($1 in owner) && owner[$1] != $2) {
-        print $1 ": " owner[$1] ", " $2
-        bad=1
-      } else {
-        owner[$1]=$2
-      }
-    }
-    END { exit bad ? 1 : 0 }
-  ' "$tmp" 2>/dev/null) || {
-    rm -f "$tmp"
-    printf 'error: duplicate secondmate home assignment:\n%s\n' "$duplicate_homes" >&2
+  [ ! -f "$REG" ] || secondmate_registry_validate_bindings "$REG" resolved_path || {
+    printf 'error: %s\n' "$SECONDMATE_REGISTRY_ERROR" >&2
     return 1
   }
-  duplicate_ids=$(awk -F '\t' '
-    {
-      if ($2 in home) {
-        print $2 ": " home[$2] ", " $1
-        bad=1
-      } else {
-        home[$2]=$1
-      }
-    }
-    END { exit bad ? 1 : 0 }
-  ' "$tmp" 2>/dev/null) || {
-    rm -f "$tmp"
-    printf 'error: duplicate secondmate id assignment:\n%s\n' "$duplicate_ids" >&2
-    return 1
-  }
-  overlaps=$(awk -F '\t' '
-    function ancestor(a, b) { return a != b && index(b, a "/") == 1 }
-    {
-      for (i = 1; i <= count; i++) {
-        if (ancestor($1, path[i])) {
-          print $1 " (" $2 ") contains " path[i] " (" id[i] ")"
-          bad=1
-        } else if (ancestor(path[i], $1)) {
-          print path[i] " (" id[i] ") contains " $1 " (" $2 ")"
-          bad=1
-        }
-      }
-      count++
-      path[count]=$1
-      id[count]=$2
-    }
-    END { exit bad ? 1 : 0 }
-  ' "$tmp" 2>/dev/null) || {
-    rm -f "$tmp"
-    printf 'error: overlapping secondmate home assignment:\n%s\n' "$overlaps" >&2
-    return 1
-  }
-  rm -f "$tmp"
-  return 0
 }
 
 join_projects() {

--- a/bin/fm-public-followup.sh
+++ b/bin/fm-public-followup.sh
@@ -103,6 +103,8 @@ DATA="${FM_DATA_OVERRIDE:-$FM_HOME/data}"
 
 # shellcheck source=bin/fm-public-followup-lib.sh
 . "$SCRIPT_DIR/fm-public-followup-lib.sh"
+# shellcheck source=bin/fm-secondmate-registry-lib.sh
+. "$SCRIPT_DIR/fm-secondmate-registry-lib.sh"
 
 RETRY_BACKOFF=${FM_PF_RETRY_BACKOFF_SECS:-900}
 case "$RETRY_BACKOFF" in ''|*[!0-9]*) RETRY_BACKOFF=900 ;; esac
@@ -521,8 +523,7 @@ public_followup_secondmate_home() {
   meta="$STATE/$id.meta"
   home=$(fmx_meta_get "$meta" home)
   if [ -z "$home" ] && [ -f "$DATA/secondmates.md" ] && [ ! -L "$DATA/secondmates.md" ]; then
-    home=$(awk -v id="$id" '$1 == "-" && $2 == id { line=$0 } END { print line }' "$DATA/secondmates.md" 2>/dev/null \
-      | sed -n 's/.*(home:[[:space:]]*\([^;)]*\);.*/\1/p' | sed 's/[[:space:]]*$//')
+    home=$(secondmate_registry_field "$DATA/secondmates.md" "$id" home || true)
   fi
   [ -n "$home" ] || return 1
   case "$home" in /*) ;; *) return 1 ;; esac

--- a/bin/fm-secondmate-registry-lib.sh
+++ b/bin/fm-secondmate-registry-lib.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2034 # parsed fields are output globals for sourcing callers.
+# Shared parser for data/secondmates.md records.
+#
+# A generated record ends with an explicit structured suffix:
+#   (home: ...; scope: ...; projects: ...; added YYYY-MM-DD)
+# Summary text and scope text are natural language and may contain parentheses
+# and semicolons, so field boundaries are anchored to the suffix markers rather
+# than to the first incidental punctuation.
+
+SECONDMATE_REGISTRY_ID=
+SECONDMATE_REGISTRY_SUMMARY=
+SECONDMATE_REGISTRY_HOME=
+SECONDMATE_REGISTRY_SCOPE=
+SECONDMATE_REGISTRY_PROJECTS=
+SECONDMATE_REGISTRY_ADDED=
+SECONDMATE_REGISTRY_LINE=
+
+secondmate_registry_parse_line() {
+  local line=$1
+  local record_re='^- ([A-Za-z0-9._-]+) - (.+) \(home:[[:space:]]*([^;)]*);[[:space:]]*scope:[[:space:]]*(.*);[[:space:]]*projects:[[:space:]]*([^;)]*);[[:space:]]*added[[:space:]]+([0-9]{4}-[0-9]{2}-[0-9]{2})\)[[:space:]]*$'
+  SECONDMATE_REGISTRY_ID=
+  SECONDMATE_REGISTRY_SUMMARY=
+  SECONDMATE_REGISTRY_HOME=
+  SECONDMATE_REGISTRY_SCOPE=
+  SECONDMATE_REGISTRY_PROJECTS=
+  SECONDMATE_REGISTRY_ADDED=
+  if [[ "$line" =~ $record_re ]]; then
+    SECONDMATE_REGISTRY_ID=${BASH_REMATCH[1]}
+    SECONDMATE_REGISTRY_SUMMARY=${BASH_REMATCH[2]}
+    SECONDMATE_REGISTRY_HOME=${BASH_REMATCH[3]}
+    SECONDMATE_REGISTRY_SCOPE=${BASH_REMATCH[4]}
+    SECONDMATE_REGISTRY_PROJECTS=${BASH_REMATCH[5]}
+    SECONDMATE_REGISTRY_ADDED=${BASH_REMATCH[6]}
+  else
+    return 1
+  fi
+  [ -n "$SECONDMATE_REGISTRY_HOME" ] || return 1
+  [ -n "$SECONDMATE_REGISTRY_SCOPE" ] || return 1
+  return 0
+}
+
+secondmate_registry_line_for_id() {
+  local reg=$1 id=$2 line count=0
+  case "$id" in ''|*[!A-Za-z0-9._-]*) return 1 ;; esac
+  [ -f "$reg" ] && [ ! -L "$reg" ] || return 1
+  while IFS= read -r line; do
+    [ "$line" = "- $id" ] || case "$line" in "- $id "*) ;; *) continue ;; esac
+    count=$((count + 1))
+    [ "$count" -eq 1 ] || return 1
+    SECONDMATE_REGISTRY_LINE=$line
+  done < "$reg"
+  [ "$count" -eq 1 ] || return 1
+  secondmate_registry_parse_line "$SECONDMATE_REGISTRY_LINE"
+}
+
+secondmate_registry_field() {
+  local reg=$1 id=$2 key=$3
+  secondmate_registry_line_for_id "$reg" "$id" || return 1
+  case "$key" in
+    home) printf '%s\n' "$SECONDMATE_REGISTRY_HOME" ;;
+    projects) printf '%s\n' "$SECONDMATE_REGISTRY_PROJECTS" ;;
+    *) return 1 ;;
+  esac
+}

--- a/bin/fm-secondmate-registry-lib.sh
+++ b/bin/fm-secondmate-registry-lib.sh
@@ -82,7 +82,7 @@ secondmate_registry_path_key() {
 
 secondmate_registry_validate_bindings() {
   local reg=$1 resolver=$2 expected_id=${3:-} expected_home=${4:-}
-  local tmp line id home home_key duplicate_homes duplicate_ids overlaps expected_home_key
+  local tmp snapshot bindings line id home home_key duplicate_homes duplicate_ids overlaps expected_home_key
   SECONDMATE_REGISTRY_MATCH_HOME=
   SECONDMATE_REGISTRY_MATCH_HOME_KEY=
   SECONDMATE_REGISTRY_MATCH_PROJECTS=
@@ -92,15 +92,22 @@ secondmate_registry_validate_bindings() {
     SECONDMATE_REGISTRY_ERROR="secondmate registry is unavailable or unsafe: $reg"
     return 1
   fi
-  tmp=$(mktemp "${TMPDIR:-/tmp}/fm-secondmate-registry.XXXXXX") || {
+  tmp=$(mktemp -d "${TMPDIR:-/tmp}/fm-secondmate-registry.XXXXXX") || {
     SECONDMATE_REGISTRY_ERROR="could not create secondmate registry validation state"
     return 1
   }
+  snapshot="$tmp/registry"
+  bindings="$tmp/bindings"
+  if ! cat "$reg" > "$snapshot" 2>/dev/null || ! : > "$bindings"; then
+    rm -rf -- "$tmp"
+    SECONDMATE_REGISTRY_ERROR="secondmate registry is unavailable or unsafe: $reg"
+    return 1
+  fi
   while IFS= read -r line || [ -n "$line" ]; do
     case "$line" in
       "- "*)
         if ! secondmate_registry_parse_line "$line"; then
-          rm -f "$tmp"
+          rm -rf -- "$tmp"
           SECONDMATE_REGISTRY_ERROR="malformed secondmate registry entry: $line"
           return 1
         fi
@@ -109,25 +116,25 @@ secondmate_registry_validate_bindings() {
         case "$home" in
           /*) ;;
           *)
-            rm -f "$tmp"
+            rm -rf -- "$tmp"
             SECONDMATE_REGISTRY_ERROR="unsafe non-absolute secondmate home for $id: $home"
             return 1
             ;;
         esac
         case "$home" in
           *$'\t'*)
-            rm -f "$tmp"
+            rm -rf -- "$tmp"
             SECONDMATE_REGISTRY_ERROR="unsafe secondmate home for $id"
             return 1
             ;;
         esac
         home_key=$("$resolver" "$home" 2>/dev/null || true)
         if [ -z "$home_key" ]; then
-          rm -f "$tmp"
+          rm -rf -- "$tmp"
           SECONDMATE_REGISTRY_ERROR="unresolvable secondmate home for $id: $home"
           return 1
         fi
-        printf '%s\t%s\n' "$home_key" "$id" >> "$tmp"
+        printf '%s\t%s\n' "$home_key" "$id" >> "$bindings"
         if [ -n "$expected_id" ] && [ "$id" = "$expected_id" ]; then
           SECONDMATE_REGISTRY_MATCH_HOME=$home
           SECONDMATE_REGISTRY_MATCH_HOME_KEY=$home_key
@@ -135,7 +142,7 @@ secondmate_registry_validate_bindings() {
         fi
         ;;
     esac
-  done < "$reg"
+  done < "$snapshot"
   duplicate_homes=$(awk -F '\t' '
     {
       if ($1 in owner) {
@@ -146,8 +153,8 @@ secondmate_registry_validate_bindings() {
       }
     }
     END { exit bad ? 1 : 0 }
-  ' "$tmp" 2>/dev/null) || {
-    rm -f "$tmp"
+  ' "$bindings" 2>/dev/null) || {
+    rm -rf -- "$tmp"
     SECONDMATE_REGISTRY_ERROR="duplicate secondmate home assignment: $duplicate_homes"
     return 1
   }
@@ -161,8 +168,8 @@ secondmate_registry_validate_bindings() {
       }
     }
     END { exit bad ? 1 : 0 }
-  ' "$tmp" 2>/dev/null) || {
-    rm -f "$tmp"
+  ' "$bindings" 2>/dev/null) || {
+    rm -rf -- "$tmp"
     SECONDMATE_REGISTRY_ERROR="duplicate secondmate id assignment: $duplicate_ids"
     return 1
   }
@@ -183,12 +190,12 @@ secondmate_registry_validate_bindings() {
       id[count]=$2
     }
     END { exit bad ? 1 : 0 }
-  ' "$tmp" 2>/dev/null) || {
-    rm -f "$tmp"
+  ' "$bindings" 2>/dev/null) || {
+    rm -rf -- "$tmp"
     SECONDMATE_REGISTRY_ERROR="overlapping secondmate home assignment: $overlaps"
     return 1
   }
-  rm -f "$tmp"
+  rm -rf -- "$tmp"
   if [ -n "$expected_id" ] && [ -z "$SECONDMATE_REGISTRY_MATCH_HOME" ]; then
     SECONDMATE_REGISTRY_ERROR="no registry binding for secondmate $expected_id"
     return 1

--- a/bin/fm-secondmate-registry-lib.sh
+++ b/bin/fm-secondmate-registry-lib.sh
@@ -48,7 +48,7 @@ secondmate_registry_line_for_id() {
   local reg=$1 id=$2 line count=0
   case "$id" in ''|*[!A-Za-z0-9._-]*) return 1 ;; esac
   [ -f "$reg" ] && [ ! -L "$reg" ] || return 1
-  while IFS= read -r line; do
+  while IFS= read -r line || [ -n "$line" ]; do
     [ "$line" = "- $id" ] || case "$line" in "- $id "*) ;; *) continue ;; esac
     count=$((count + 1))
     [ "$count" -eq 1 ] || return 1
@@ -96,7 +96,7 @@ secondmate_registry_validate_bindings() {
     SECONDMATE_REGISTRY_ERROR="could not create secondmate registry validation state"
     return 1
   }
-  while IFS= read -r line; do
+  while IFS= read -r line || [ -n "$line" ]; do
     case "$line" in
       "- "*)
         if ! secondmate_registry_parse_line "$line"; then

--- a/bin/fm-secondmate-registry-lib.sh
+++ b/bin/fm-secondmate-registry-lib.sh
@@ -15,6 +15,10 @@ SECONDMATE_REGISTRY_SCOPE=
 SECONDMATE_REGISTRY_PROJECTS=
 SECONDMATE_REGISTRY_ADDED=
 SECONDMATE_REGISTRY_LINE=
+SECONDMATE_REGISTRY_MATCH_HOME=
+SECONDMATE_REGISTRY_MATCH_HOME_KEY=
+SECONDMATE_REGISTRY_MATCH_PROJECTS=
+SECONDMATE_REGISTRY_ERROR=
 
 secondmate_registry_parse_line() {
   local line=$1
@@ -62,4 +66,139 @@ secondmate_registry_field() {
     projects) printf '%s\n' "$SECONDMATE_REGISTRY_PROJECTS" ;;
     *) return 1 ;;
   esac
+}
+
+secondmate_registry_path_key() {
+  local path=$1 parent base
+  case "$path" in /*) ;; *) return 1 ;; esac
+  if [ -d "$path" ]; then
+    cd "$path" && pwd -P
+  else
+    parent=$(dirname "$path")
+    base=$(basename "$path")
+    cd "$parent" && printf '%s/%s\n' "$(pwd -P)" "$base"
+  fi
+}
+
+secondmate_registry_validate_bindings() {
+  local reg=$1 resolver=$2 expected_id=${3:-} expected_home=${4:-}
+  local tmp line id home home_key duplicate_homes duplicate_ids overlaps expected_home_key
+  SECONDMATE_REGISTRY_MATCH_HOME=
+  SECONDMATE_REGISTRY_MATCH_HOME_KEY=
+  SECONDMATE_REGISTRY_MATCH_PROJECTS=
+  SECONDMATE_REGISTRY_ERROR=
+  case "$expected_id" in *[!A-Za-z0-9._-]*) SECONDMATE_REGISTRY_ERROR="invalid secondmate id: $expected_id"; return 1 ;; esac
+  if [ ! -f "$reg" ] || [ -L "$reg" ]; then
+    SECONDMATE_REGISTRY_ERROR="secondmate registry is unavailable or unsafe: $reg"
+    return 1
+  fi
+  tmp=$(mktemp "${TMPDIR:-/tmp}/fm-secondmate-registry.XXXXXX") || {
+    SECONDMATE_REGISTRY_ERROR="could not create secondmate registry validation state"
+    return 1
+  }
+  while IFS= read -r line; do
+    case "$line" in
+      "- "*)
+        if ! secondmate_registry_parse_line "$line"; then
+          rm -f "$tmp"
+          SECONDMATE_REGISTRY_ERROR="malformed secondmate registry entry: $line"
+          return 1
+        fi
+        id=$SECONDMATE_REGISTRY_ID
+        home=$SECONDMATE_REGISTRY_HOME
+        case "$home" in
+          /*) ;;
+          *)
+            rm -f "$tmp"
+            SECONDMATE_REGISTRY_ERROR="unsafe non-absolute secondmate home for $id: $home"
+            return 1
+            ;;
+        esac
+        case "$home" in
+          *$'\t'*)
+            rm -f "$tmp"
+            SECONDMATE_REGISTRY_ERROR="unsafe secondmate home for $id"
+            return 1
+            ;;
+        esac
+        home_key=$("$resolver" "$home" 2>/dev/null || true)
+        if [ -z "$home_key" ]; then
+          rm -f "$tmp"
+          SECONDMATE_REGISTRY_ERROR="unresolvable secondmate home for $id: $home"
+          return 1
+        fi
+        printf '%s\t%s\n' "$home_key" "$id" >> "$tmp"
+        if [ -n "$expected_id" ] && [ "$id" = "$expected_id" ]; then
+          SECONDMATE_REGISTRY_MATCH_HOME=$home
+          SECONDMATE_REGISTRY_MATCH_HOME_KEY=$home_key
+          SECONDMATE_REGISTRY_MATCH_PROJECTS=$SECONDMATE_REGISTRY_PROJECTS
+        fi
+        ;;
+    esac
+  done < "$reg"
+  duplicate_homes=$(awk -F '\t' '
+    {
+      if ($1 in owner) {
+        print $1 ": " owner[$1] ", " $2
+        bad=1
+      } else {
+        owner[$1]=$2
+      }
+    }
+    END { exit bad ? 1 : 0 }
+  ' "$tmp" 2>/dev/null) || {
+    rm -f "$tmp"
+    SECONDMATE_REGISTRY_ERROR="duplicate secondmate home assignment: $duplicate_homes"
+    return 1
+  }
+  duplicate_ids=$(awk -F '\t' '
+    {
+      if ($2 in home) {
+        print $2 ": " home[$2] ", " $1
+        bad=1
+      } else {
+        home[$2]=$1
+      }
+    }
+    END { exit bad ? 1 : 0 }
+  ' "$tmp" 2>/dev/null) || {
+    rm -f "$tmp"
+    SECONDMATE_REGISTRY_ERROR="duplicate secondmate id assignment: $duplicate_ids"
+    return 1
+  }
+  overlaps=$(awk -F '\t' '
+    function ancestor(a, b) { return a != b && index(b, a "/") == 1 }
+    {
+      for (i = 1; i <= count; i++) {
+        if (ancestor($1, path[i])) {
+          print $1 " (" $2 ") contains " path[i] " (" id[i] ")"
+          bad=1
+        } else if (ancestor(path[i], $1)) {
+          print path[i] " (" id[i] ") contains " $1 " (" $2 ")"
+          bad=1
+        }
+      }
+      count++
+      path[count]=$1
+      id[count]=$2
+    }
+    END { exit bad ? 1 : 0 }
+  ' "$tmp" 2>/dev/null) || {
+    rm -f "$tmp"
+    SECONDMATE_REGISTRY_ERROR="overlapping secondmate home assignment: $overlaps"
+    return 1
+  }
+  rm -f "$tmp"
+  if [ -n "$expected_id" ] && [ -z "$SECONDMATE_REGISTRY_MATCH_HOME" ]; then
+    SECONDMATE_REGISTRY_ERROR="no registry binding for secondmate $expected_id"
+    return 1
+  fi
+  if [ -n "$expected_home" ]; then
+    expected_home_key=$("$resolver" "$expected_home" 2>/dev/null || true)
+    if [ -z "$expected_home_key" ] || [ "$expected_home_key" != "$SECONDMATE_REGISTRY_MATCH_HOME_KEY" ]; then
+      SECONDMATE_REGISTRY_ERROR="secondmate $expected_id is registered at $SECONDMATE_REGISTRY_MATCH_HOME, not $expected_home"
+      return 1
+    fi
+  fi
+  return 0
 }

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -789,6 +789,11 @@ fi
 if [ "$KIND" = secondmate ]; then
   [ -n "$FIRSTMATE_HOME" ] || { echo "error: no firstmate home supplied or registered for $ID" >&2; exit 1; }
   PROJ_ABS=$(validate_firstmate_home_for_spawn "$ID" "$FIRSTMATE_HOME")
+  if ! secondmate_registry_validate_bindings "$DATA/secondmates.md" resolve_path "$ID" "$FIRSTMATE_HOME"; then
+    echo "error: $SECONDMATE_REGISTRY_ERROR" >&2
+    exit 1
+  fi
+  SECONDMATE_PROJECTS=$SECONDMATE_REGISTRY_MATCH_PROJECTS
   WT="$PROJ_ABS"
   # Local-HEAD sync: before launch, fast-forward this secondmate's worktree to the
   # PRIMARY checkout's current default-branch commit, so a freshly spawned or
@@ -1582,11 +1587,10 @@ fi
 # Recorded in meta so fm-teardown's safety check and the validate/merge stages can
 # branch on them. Mode governs ship tasks; a scout's deliverable is a report, not a
 # merge, so scout teardown ignores mode.
-SECONDMATE_PROJECTS=
 if [ "$KIND" = secondmate ]; then
   MODE=secondmate
   YOLO=off
-  SECONDMATE_PROJECTS=$(secondmate_registry_value "$ID" projects || true)
+  : "${SECONDMATE_PROJECTS:=}"
 else
   PROJ_NAME=$(basename "$PROJ_ABS")
   read -r MODE YOLO <<EOF

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -566,18 +566,7 @@ if [ "$KIND" = secondmate ] && [ -z "$ARG3" ]; then
 fi
 
 secondmate_registry_value() {
-  local id=$1 key=$2 reg line value
-  reg="$DATA/secondmates.md"
-  [ -f "$reg" ] || return 1
-  line=$(grep -E "^- $id( |$)" "$reg" | tail -1 || true)
-  [ -n "$line" ] || return 1
-  case "$key" in
-    home) value=$(printf '%s\n' "$line" | sed -n 's/^[^(]*(home: \([^;)]*\);.*/\1/p') ;;
-    projects) value=$(printf '%s\n' "$line" | sed -n 's/^[^(]*(home: [^;)]*; scope: [^;)]*; projects: \([^;)]*\); added .*/\1/p') ;;
-    *) return 1 ;;
-  esac
-  [ -n "$value" ] || return 1
-  printf '%s\n' "$value"
+  secondmate_registry_field "$DATA/secondmates.md" "$1" "$2"
 }
 
 shell_quote() {

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -789,11 +789,13 @@ fi
 if [ "$KIND" = secondmate ]; then
   [ -n "$FIRSTMATE_HOME" ] || { echo "error: no firstmate home supplied or registered for $ID" >&2; exit 1; }
   PROJ_ABS=$(validate_firstmate_home_for_spawn "$ID" "$FIRSTMATE_HOME")
-  if ! secondmate_registry_validate_bindings "$DATA/secondmates.md" resolve_path "$ID" "$FIRSTMATE_HOME"; then
-    echo "error: $SECONDMATE_REGISTRY_ERROR" >&2
-    exit 1
+  if [ -e "$DATA/secondmates.md" ] || [ -L "$DATA/secondmates.md" ]; then
+    if ! secondmate_registry_validate_bindings "$DATA/secondmates.md" resolve_path "$ID" "$FIRSTMATE_HOME"; then
+      echo "error: $SECONDMATE_REGISTRY_ERROR" >&2
+      exit 1
+    fi
+    SECONDMATE_PROJECTS=$SECONDMATE_REGISTRY_MATCH_PROJECTS
   fi
-  SECONDMATE_PROJECTS=$SECONDMATE_REGISTRY_MATCH_PROJECTS
   WT="$PROJ_ABS"
   # Local-HEAD sync: before launch, fast-forward this secondmate's worktree to the
   # PRIMARY checkout's current default-branch commit, so a freshly spawned or

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -889,7 +889,7 @@ registered_descendant_home_for_removal() {
     echo "REFUSED: $SECONDMATE_REGISTRY_ERROR" >&2
     return 2
   fi
-  while IFS= read -r line; do
+  while IFS= read -r line || [ -n "$line" ]; do
     case "$line" in
       "- "*)
         secondmate_registry_parse_line "$line" || {

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -108,6 +108,8 @@ SUB_HOME_MARKER=".fm-secondmate-home"
 . "$SCRIPT_DIR/fm-pr-lib.sh"
 # shellcheck source=bin/fm-public-followup-lib.sh
 . "$SCRIPT_DIR/fm-public-followup-lib.sh"
+# shellcheck source=bin/fm-secondmate-registry-lib.sh
+. "$SCRIPT_DIR/fm-secondmate-registry-lib.sh"
 if [ "$#" -lt 1 ] || ! fm_task_id_path_safe "$1"; then
   echo "error: invalid teardown request" >&2
   exit 2
@@ -173,7 +175,8 @@ public_followup_resolve_primary_home() {
   line_count=$(printf '%s\n' "$lines" | grep -c . || true)
   [ "$line_count" -eq 1 ] || return 1
   line=$(printf '%s\n' "$lines")
-  registry_home=$(printf '%s\n' "$line" | sed -n 's/^[^(]*(home: \([^;)]*\);.*/\1/p')
+  secondmate_registry_parse_line "$line" || return 1
+  registry_home=$SECONDMATE_REGISTRY_HOME
   registry_home=$(CDPATH='' cd -- "$registry_home" 2>/dev/null && pwd -P) || return 1
   [ "$registry_home" = "$child" ] || return 1
   printf '%s\n' "$parent"
@@ -535,10 +538,6 @@ backlog_refresh_reminder() {
   fi
 }
 
-registry_home_for_line() {
-  sed -n 's/^[^(]*(home: \([^;)]*\);.*/\1/p'
-}
-
 path_is_ancestor_of() {
   local ancestor=$1 path=$2
   [ -n "$ancestor" ] || return 1
@@ -897,10 +896,12 @@ registered_descendant_home_for_removal() {
   while IFS= read -r line; do
     case "$line" in
       "- "*)
-        id=${line#- }
-        id=${id%% *}
-        registered_home=$(printf '%s\n' "$line" | registry_home_for_line)
-        [ -n "$registered_home" ] || continue
+        secondmate_registry_parse_line "$line" || {
+          echo "REFUSED: malformed secondmate registry entry: $line" >&2
+          return 2
+        }
+        id=$SECONDMATE_REGISTRY_ID
+        registered_home=$SECONDMATE_REGISTRY_HOME
         registered_abs=$(removal_target_abs_path "$registered_home" 2>/dev/null || true)
         [ -n "$registered_abs" ] || continue
         [ "$registered_abs" = "$target" ] && continue
@@ -991,9 +992,20 @@ validate_firstmate_home_for_removal() {
     fi
   fi
   validate_firstmate_operational_dirs_for_removal "$abs_home_path" "$label" || return 1
-  conflict=$(registered_descendant_home_for_removal "$SECONDMATE_REG" "$abs_home_path" || true)
+  conflict=
+  if conflict=$(registered_descendant_home_for_removal "$SECONDMATE_REG" "$abs_home_path"); then
+    :
+  else
+    conflict_rc=$?
+    [ "$conflict_rc" -eq 1 ] || return 1
+  fi
   if [ -z "$conflict" ]; then
-    conflict=$(registered_descendant_home_for_removal "$abs_home_path/data/secondmates.md" "$abs_home_path" || true)
+    if conflict=$(registered_descendant_home_for_removal "$abs_home_path/data/secondmates.md" "$abs_home_path"); then
+      :
+    else
+      conflict_rc=$?
+      [ "$conflict_rc" -eq 1 ] || return 1
+    fi
   fi
   if [ -n "$conflict" ]; then
     IFS=$'\t' read -r child_id child_home <<EOF

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -157,7 +157,7 @@ PUBLIC_FOLLOWUP_PARENT_UNRESOLVED=0
 PUBLIC_FOLLOWUP_PARENT_RELAY_ACTIVE=0
 PUBLIC_FOLLOWUP_RELAY_ACTIVE=0
 public_followup_resolve_primary_home() {
-  local parent=$1 child=$2 id=$3 parent_meta registry lines line_count meta_home registry_home
+  local parent=$1 child=$2 id=$3 parent_meta registry meta_home
   fm_pf_home_id_valid "secondmate:$id" || return 1
   case "$parent" in /*) ;; *) return 1 ;; esac
   parent=$(CDPATH='' cd -- "$parent" 2>/dev/null && pwd -P) || return 1
@@ -170,15 +170,7 @@ public_followup_resolve_primary_home() {
   meta_home=$(CDPATH='' cd -- "$meta_home" 2>/dev/null && pwd -P) || return 1
   [ "$meta_home" = "$child" ] || return 1
   registry="$parent/data/secondmates.md"
-  [ -f "$registry" ] && [ ! -L "$registry" ] || return 1
-  lines=$(awk -v wanted="$id" '$1 == "-" && $2 == wanted { print }' "$registry" 2>/dev/null || true)
-  line_count=$(printf '%s\n' "$lines" | grep -c . || true)
-  [ "$line_count" -eq 1 ] || return 1
-  line=$(printf '%s\n' "$lines")
-  secondmate_registry_parse_line "$line" || return 1
-  registry_home=$SECONDMATE_REGISTRY_HOME
-  registry_home=$(CDPATH='' cd -- "$registry_home" 2>/dev/null && pwd -P) || return 1
-  [ "$registry_home" = "$child" ] || return 1
+  secondmate_registry_validate_bindings "$registry" secondmate_registry_path_key "$id" "$child" || return 1
   printf '%s\n' "$parent"
 }
 if [ -f "$FM_HOME/$SUB_HOME_MARKER" ]; then
@@ -893,6 +885,10 @@ validate_removal_target() {
 registered_descendant_home_for_removal() {
   local reg=$1 target=$2 line id registered_home registered_abs
   [ -f "$reg" ] || return 1
+  if ! secondmate_registry_validate_bindings "$reg" secondmate_registry_path_key; then
+    echo "REFUSED: $SECONDMATE_REGISTRY_ERROR" >&2
+    return 2
+  fi
   while IFS= read -r line; do
     case "$line" in
       "- "*)
@@ -988,6 +984,15 @@ validate_firstmate_home_for_removal() {
     marker_id=$(cat "$abs_home_path/$SUB_HOME_MARKER" 2>/dev/null || true)
     if [ "$marker_id" != "$expected_id" ]; then
       echo "REFUSED: unsafe $label removal target $home is marked for secondmate ${marker_id:-unknown}, expected $expected_id" >&2
+      return 1
+    fi
+    if ! secondmate_registry_validate_bindings "$SECONDMATE_REG" secondmate_registry_path_key "$expected_id" "$abs_home_path"; then
+      case "$SECONDMATE_REGISTRY_ERROR" in
+        overlapping\ secondmate\ home\ assignment:*)
+          echo "REFUSED: unsafe $label removal target $home contains registered secondmate home; $SECONDMATE_REGISTRY_ERROR" >&2
+          ;;
+        *) echo "REFUSED: $SECONDMATE_REGISTRY_ERROR" >&2 ;;
+      esac
       return 1
     fi
   fi

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -986,14 +986,16 @@ validate_firstmate_home_for_removal() {
       echo "REFUSED: unsafe $label removal target $home is marked for secondmate ${marker_id:-unknown}, expected $expected_id" >&2
       return 1
     fi
-    if ! secondmate_registry_validate_bindings "$SECONDMATE_REG" secondmate_registry_path_key "$expected_id" "$abs_home_path"; then
-      case "$SECONDMATE_REGISTRY_ERROR" in
-        overlapping\ secondmate\ home\ assignment:*)
-          echo "REFUSED: unsafe $label removal target $home contains registered secondmate home; $SECONDMATE_REGISTRY_ERROR" >&2
-          ;;
-        *) echo "REFUSED: $SECONDMATE_REGISTRY_ERROR" >&2 ;;
-      esac
-      return 1
+    if [ -e "$SECONDMATE_REG" ] || [ -L "$SECONDMATE_REG" ]; then
+      if ! secondmate_registry_validate_bindings "$SECONDMATE_REG" secondmate_registry_path_key "$expected_id" "$abs_home_path"; then
+        case "$SECONDMATE_REGISTRY_ERROR" in
+          overlapping\ secondmate\ home\ assignment:*)
+            echo "REFUSED: unsafe $label removal target $home contains registered secondmate home; $SECONDMATE_REGISTRY_ERROR" >&2
+            ;;
+          *) echo "REFUSED: $SECONDMATE_REGISTRY_ERROR" >&2 ;;
+        esac
+        return 1
+      fi
     fi
   fi
   validate_firstmate_operational_dirs_for_removal "$abs_home_path" "$label" || return 1

--- a/bin/fm-update.sh
+++ b/bin/fm-update.sh
@@ -75,8 +75,12 @@ if [ -f "$SECONDMATES_MD" ]; then
       "- "*) ;;
       *) continue ;;
     esac
-    id=$(printf '%s\n' "$line" | sed -n 's/^- \([^ ][^ ]*\) - .*/\1/p')
-    home=$(printf '%s\n' "$line" | sed -n 's/.*(home:[[:space:]]*\([^;]*\);.*/\1/p' | sed 's/[[:space:]]*$//')
+    if ! secondmate_registry_parse_line "$line"; then
+      echo "secondmate registry: skipped malformed entry: $line" >&2
+      continue
+    fi
+    id=$SECONDMATE_REGISTRY_ID
+    home=$SECONDMATE_REGISTRY_HOME
     process_secondmate "$id" "$home" "" origin no
   done < "$SECONDMATES_MD"
 fi

--- a/bin/fm-update.sh
+++ b/bin/fm-update.sh
@@ -70,7 +70,7 @@ sweep_live_secondmate_metas "$STATE" origin no
 # Registry backstop: a secondmate registered in data/secondmates.md but without
 # a live meta (e.g. between restarts) is still its persistent on-disk home.
 if [ -f "$SECONDMATES_MD" ]; then
-  while IFS= read -r line; do
+  while IFS= read -r line || [ -n "$line" ]; do
     case "$line" in
       "- "*) ;;
       *) continue ;;

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -155,7 +155,7 @@ The helper's header owns exact parsing, publication, and report output mechanics
 
 Persistent secondmate routes live locally in `data/secondmates.md`.
 The concise single-line route contract is owned by the [`secondmate-provisioning` skill](../.agents/skills/secondmate-provisioning/SKILL.md#routing-table), including the parser-compatible fields, one-sentence summary requirement, `home:` pointer to the seeded charter, and limit on extra registry prose.
-`fm-home-seed.sh validate` refuses duplicate ids, duplicate homes, and nested or overlapping homes.
+Use `fm-home-seed.sh validate` to check the complete operational registry contract documented by the command itself.
 The main first mate routes by reading those scopes with judgment; the project list is provisioning data, not exclusive ownership.
 Use `fm-home-seed.sh <id> - {<project>...|--no-projects}` to lease a fresh firstmate worktree for the secondmate home.
 Use the deliberate `--no-projects` signal only for a firstmate-repo domain that needs no separate project clones.

--- a/tests/fm-backend.test.sh
+++ b/tests/fm-backend.test.sh
@@ -141,7 +141,7 @@ resolve_permissive_tmux_kill_ref() {
 # hence the dispatcher is a copied sibling, while the tmux adapter is extracted
 # from BASE_REF so conformance tests retain the exact historical behavior even
 # when this branch changes tmux dispatch semantics.
-OLD_BIN_UNCHANGED_SIBLINGS="fm-gate-refuse-lib.sh fm-guard.sh fm-lock-lib.sh fm-tasks-axi-lib.sh fm-pr-lib.sh fm-tangle-lib.sh fm-tmux-lib.sh fm-composer-lib.sh fm-wake-lib.sh fm-classify-lib.sh fm-supervision-lib.sh fm-ff-lib.sh fm-config-inherit-lib.sh fm-project-mode.sh fm-harness.sh fm-crew-state.sh fm-decision-hold.sh fm-backend.sh fm-operational-input.sh fm-public-followup-lib.sh fm-x-lib.sh"
+OLD_BIN_UNCHANGED_SIBLINGS="fm-gate-refuse-lib.sh fm-guard.sh fm-lock-lib.sh fm-tasks-axi-lib.sh fm-pr-lib.sh fm-tangle-lib.sh fm-tmux-lib.sh fm-composer-lib.sh fm-wake-lib.sh fm-classify-lib.sh fm-supervision-lib.sh fm-ff-lib.sh fm-config-inherit-lib.sh fm-project-mode.sh fm-harness.sh fm-crew-state.sh fm-decision-hold.sh fm-backend.sh fm-operational-input.sh fm-public-followup-lib.sh fm-secondmate-registry-lib.sh fm-x-lib.sh"
 # A pull-request merge may add a new main-only dependency that the branch's older baseline does not have yet.
 OLD_BIN_OPTIONAL_SIBLINGS="fm-pending-reply-lib.sh"
 OLD_BIN_REFACTORED="fm-send.sh fm-peek.sh fm-watch.sh fm-spawn.sh fm-teardown.sh fm-marker-lib.sh"

--- a/tests/fm-backlog-handoff.test.sh
+++ b/tests/fm-backlog-handoff.test.sh
@@ -482,9 +482,11 @@ test_registry_home_with_pre_home_parentheses() {
   setup_homes "$home" "$sub" "$id"
   local sub_abs
   sub_abs=$(cd "$sub" && pwd -P)
-  # Prose parentheses before (home: ...), matching live registry shape.
-  printf -- '- %s - issue triage (id is legacy) (home: %s; scope: issue triage; projects: alpha; added 2026-07-09)\n' \
+  # Prose parentheses before (home: ...) and punctuation inside scope match the live registry shape.
+  printf -- '- %s - issue triage (id is legacy) (home: %s; scope: issue triage (child); semicolon is meaningful; projects: alpha; added 2026-07-09)\n' \
     "$id" "$sub_abs" > "$home/data/secondmates.md"
+  FM_HOME="$home" "$ROOT/bin/fm-home-seed.sh" validate >/dev/null \
+    || fail "home-seed validation rejected punctuation-bearing registry fields"
 
   cat > "$home/data/backlog.md" <<'EOF'
 ## Queued

--- a/tests/fm-gotmp.test.sh
+++ b/tests/fm-gotmp.test.sh
@@ -70,6 +70,7 @@ make_fake_root() {
   # teardown now requires.
   ln -s "$ROOT/bin/fm-public-followup-lib.sh" "$fake/bin/fm-public-followup-lib.sh"
   ln -s "$ROOT/bin/fm-x-lib.sh" "$fake/bin/fm-x-lib.sh"
+  ln -s "$ROOT/bin/fm-secondmate-registry-lib.sh" "$fake/bin/fm-secondmate-registry-lib.sh"
   # fm-guard.sh: stub (teardown calls it with `|| true`).
   cat > "$fake/bin/fm-guard.sh" <<'SH'
 #!/usr/bin/env bash
@@ -142,6 +143,7 @@ test_teardown_skips_gracefully_without_tasktmp() {
   # teardown now requires.
   ln -s "$ROOT/bin/fm-public-followup-lib.sh" "$fake/bin/fm-public-followup-lib.sh"
   ln -s "$ROOT/bin/fm-x-lib.sh" "$fake/bin/fm-x-lib.sh"
+  ln -s "$ROOT/bin/fm-secondmate-registry-lib.sh" "$fake/bin/fm-secondmate-registry-lib.sh"
   cat > "$fake/bin/fm-guard.sh" <<'SH'
 #!/usr/bin/env bash
 exit 0

--- a/tests/fm-public-followup.test.sh
+++ b/tests/fm-public-followup.test.sh
@@ -585,7 +585,7 @@ test_delivery_requires_registration_before_posting() {
 }
 
 test_secondmate_teardown_requires_parent_binding() {
-  local parent child
+  local parent child registry_before marker_before
   parent=$(make_home teardown-parent)
   child=$(make_home teardown-child)
   printf '%s\n' mate > "$child/.fm-secondmate-home"
@@ -607,8 +607,12 @@ test_secondmate_teardown_requires_parent_binding() {
   parent=$(make_home teardown-valid-parent)
   child=$(make_home teardown-valid-child)
   printf '%s\n' mate > "$child/.fm-secondmate-home"
-  printf -- '- mate - synthetic (home: %s; scope: synthetic; projects: ; added 2026-07-30)\n' \
+  printf -- '- mate - synthetic (id is legacy); preserve this (home: %s; scope: synthetic (child); semicolon remains meaningful; projects: ; added 2026-07-30)\n' \
     "$child" > "$parent/data/secondmates.md"
+  FM_HOME="$parent" "$ROOT/bin/fm-home-seed.sh" validate >/dev/null \
+    || fail "home-seed validation rejected a punctuation-bearing operational registry record"
+  registry_before=$(cat "$parent/data/secondmates.md")
+  marker_before=$(cat "$child/.fm-secondmate-home")
   seed_commitment "$parent" pf-teardown-valid req-teardown-valid x secondmate:mate work-child
   fm_write_meta "$parent/state/mate.meta" "kind=secondmate" "home=$child"
   fm_write_meta "$child/state/work-child.meta" \
@@ -627,6 +631,10 @@ test_secondmate_teardown_requires_parent_binding() {
   esac
   assert_present "$child/state/work-child.meta" \
     "an owed parent commitment must preserve the child work metadata"
+  [ "$registry_before" = "$(cat "$parent/data/secondmates.md")" ] \
+    || fail "guarded cleanup refusal changed the parent registry"
+  [ "$marker_before" = "$(cat "$child/.fm-secondmate-home")" ] \
+    || fail "guarded cleanup refusal changed the child identity marker"
   pass "marked secondmate teardown resolves its parent and fails closed when unavailable"
 }
 

--- a/tests/fm-secondmate-safety.test.sh
+++ b/tests/fm-secondmate-safety.test.sh
@@ -485,6 +485,63 @@ test_secondmate_spawn_resolves_punctuated_registry_projects() {
   pass "secondmate spawn resolves home validation and projects from punctuated registry fields"
 }
 
+test_secondmate_spawn_refuses_ambiguous_and_mismatched_registry_bindings() {
+  local row case_name home sub other fakebin log err meta_before
+  for row in duplicate-id duplicate-home supplied-mismatch metadata-mismatch; do
+    case_name=${row%%|*}
+    home="$TMP_ROOT/spawn-binding-$case_name-home"
+    sub="$TMP_ROOT/spawn-binding-$case_name-sub"
+    other="$TMP_ROOT/spawn-binding-$case_name-other"
+    mkdir -p "$home/data" "$home/state" "$home/config" "$home/projects"
+    mark_firstmate_home "$sub"
+    mark_firstmate_home "$other"
+    printf 'domain\n' > "$sub/.fm-secondmate-home"
+    printf 'domain\n' > "$other/.fm-secondmate-home"
+    case "$case_name" in
+      duplicate-id)
+        cat > "$home/data/secondmates.md" <<EOF
+- domain - primary route (home: $sub; scope: valid (scope); punctuation; projects: alpha; added 2026-07-30)
+- domain - duplicate route (home: $other; scope: duplicate; projects: beta; added 2026-07-30)
+EOF
+        ;;
+      duplicate-home)
+        cat > "$home/data/secondmates.md" <<EOF
+- domain - primary route (home: $sub; scope: valid (scope); punctuation; projects: alpha; added 2026-07-30)
+- other - duplicate home route (home: $sub; scope: duplicate; projects: beta; added 2026-07-30)
+EOF
+        ;;
+      supplied-mismatch|metadata-mismatch)
+        printf -- '- domain - mismatched route (home: %s; scope: valid (scope); punctuation; projects: alpha; added 2026-07-30)\n' \
+          "$other" > "$home/data/secondmates.md"
+        ;;
+    esac
+    fakebin=$(make_fake_tmux "$TMP_ROOT/spawn-binding-$case_name-fake")
+    log="$TMP_ROOT/spawn-binding-$case_name-fake/tmux.log"
+    err="$TMP_ROOT/spawn-binding-$case_name.err"
+    if [ "$case_name" = metadata-mismatch ]; then
+      fm_write_secondmate_meta "$home/state/domain.meta" "$sub"
+      meta_before="$TMP_ROOT/spawn-binding-$case_name.meta.before"
+      cp "$home/state/domain.meta" "$meta_before"
+      if PATH="$fakebin:$PATH" FM_HOME="$home" FM_FAKE_TMUX_LOG="$log" \
+        FM_FAKE_TMUX_CAPTURE="$TMP_ROOT/spawn-binding-$case_name-fake/pane.txt" \
+        "$ROOT/bin/fm-spawn.sh" domain codex --secondmate >/dev/null 2>"$err"; then
+        fail "secondmate spawn accepted $case_name registry binding"
+      fi
+      cmp -s "$meta_before" "$home/state/domain.meta" || fail "secondmate spawn changed metadata after $case_name refusal"
+    else
+      if PATH="$fakebin:$PATH" FM_HOME="$home" FM_FAKE_TMUX_LOG="$log" \
+        FM_FAKE_TMUX_CAPTURE="$TMP_ROOT/spawn-binding-$case_name-fake/pane.txt" \
+        "$ROOT/bin/fm-spawn.sh" domain "$sub" codex --secondmate >/dev/null 2>"$err"; then
+        fail "secondmate spawn accepted $case_name registry binding"
+      fi
+      [ ! -e "$home/state/domain.meta" ] || fail "secondmate spawn wrote metadata after $case_name refusal"
+    fi
+    [ ! -e "$home/state/.spawn-domain.lock" ] || fail "secondmate spawn left a lock after $case_name refusal"
+    grep -F 'new-window' "$log" >/dev/null && fail "secondmate spawn created an endpoint before $case_name refusal"
+  done
+  pass "secondmate spawn refuses ambiguous, supplied-home, and metadata-home registry bindings"
+}
+
 test_home_seed_refuses_projectful_reused_charter_for_projectless_home() {
   local home reusable_sub stale_sub stale_brief stale_brief_before err
   home="$TMP_ROOT/no-projects-reused-charter-home"
@@ -1357,6 +1414,53 @@ EOF
   pass "secondmate teardown retires empty homes and releases routing"
 }
 
+test_secondmate_teardown_refuses_ambiguous_and_mismatched_registry_bindings() {
+  local case_name home sub other fakebin log err meta_before registry_before
+  for case_name in duplicate-id duplicate-home home-mismatch; do
+    home="$TMP_ROOT/teardown-binding-$case_name-home"
+    sub="$TMP_ROOT/teardown-binding-$case_name-sub"
+    other="$TMP_ROOT/teardown-binding-$case_name-other"
+    mkdir -p "$home/state" "$home/data" "$sub/state" "$sub/data" "$sub/config" "$sub/projects" "$other"
+    printf 'domain\n' > "$sub/.fm-secondmate-home"
+    fm_write_secondmate_meta "$home/state/domain.meta" "$sub"
+    case "$case_name" in
+      duplicate-id)
+        cat > "$home/data/secondmates.md" <<EOF
+- domain - primary route (home: $sub; scope: valid (scope); punctuation; projects: alpha; added 2026-07-30)
+- domain - duplicate route (home: $other; scope: duplicate; projects: beta; added 2026-07-30)
+EOF
+        ;;
+      duplicate-home)
+        cat > "$home/data/secondmates.md" <<EOF
+- domain - primary route (home: $sub; scope: valid (scope); punctuation; projects: alpha; added 2026-07-30)
+- other - duplicate home route (home: $sub; scope: duplicate; projects: beta; added 2026-07-30)
+EOF
+        ;;
+      home-mismatch)
+        printf -- '- domain - mismatched route (home: %s; scope: valid (scope); punctuation; projects: alpha; added 2026-07-30)\n' \
+          "$other" > "$home/data/secondmates.md"
+        ;;
+    esac
+    meta_before="$TMP_ROOT/teardown-binding-$case_name.meta.before"
+    registry_before="$TMP_ROOT/teardown-binding-$case_name.registry.before"
+    cp "$home/state/domain.meta" "$meta_before"
+    cp "$home/data/secondmates.md" "$registry_before"
+    fakebin=$(make_fake_tmux "$TMP_ROOT/teardown-binding-$case_name-fake")
+    log="$TMP_ROOT/teardown-binding-$case_name-fake/tmux.log"
+    err="$TMP_ROOT/teardown-binding-$case_name.err"
+    if PATH="$fakebin:$PATH" FM_HOME="$home" FM_FAKE_TMUX_LOG="$log" \
+      FM_FAKE_TMUX_CAPTURE="$TMP_ROOT/teardown-binding-$case_name-fake/pane.txt" \
+      "$ROOT/bin/fm-teardown.sh" domain --force >/dev/null 2>"$err"; then
+      fail "secondmate teardown accepted $case_name registry binding"
+    fi
+    [ -d "$sub" ] || fail "secondmate teardown removed the home after $case_name refusal"
+    cmp -s "$meta_before" "$home/state/domain.meta" || fail "secondmate teardown changed metadata after $case_name refusal"
+    cmp -s "$registry_before" "$home/data/secondmates.md" || fail "secondmate teardown changed registry after $case_name refusal"
+    grep -F 'kill-window' "$log" >/dev/null && fail "secondmate teardown killed an endpoint before $case_name refusal"
+  done
+  pass "secondmate teardown refuses ambiguous and identity-mismatched registry bindings"
+}
+
 test_secondmate_teardown_refuses_failed_leased_home_return() {
   local home subhome subhome_abs fakebin log fmroot err rc
   home="$TMP_ROOT/teardown-return-fail-home"
@@ -2222,6 +2326,7 @@ test_home_seed_refuses_placeholder_charter
 test_home_seed_refuses_empty_charter_fields
 test_home_seed_no_projects_end_to_end
 test_secondmate_spawn_resolves_punctuated_registry_projects
+test_secondmate_spawn_refuses_ambiguous_and_mismatched_registry_bindings
 test_home_seed_refuses_projectful_reused_charter_for_projectless_home
 test_home_seed_refuses_projectless_conversion_of_populated_home
 test_home_seed_refuses_projectless_home_with_uninspectable_projects
@@ -2248,6 +2353,7 @@ test_secondmate_spawn_requires_seeded_matching_home
 test_secondmate_spawn_refuses_operational_dirs_outside_subhome
 test_fm_send_refuses_bare_window_without_home_meta
 test_secondmate_teardown_retires_empty_home
+test_secondmate_teardown_refuses_ambiguous_and_mismatched_registry_bindings
 test_secondmate_teardown_refuses_failed_leased_home_return
 test_secondmate_teardown_removes_plain_clone_home_without_treehouse_return
 test_secondmate_force_teardown_discards_child_work

--- a/tests/fm-secondmate-safety.test.sh
+++ b/tests/fm-secondmate-safety.test.sh
@@ -147,6 +147,34 @@ test_home_seed_refuses_broken_registry_symlink() {
   pass "home seeding refuses broken registry symlinks before provisioning"
 }
 
+test_home_seed_refuses_unreadable_registry() {
+  local home sub err registry
+  home="$TMP_ROOT/unreadable-registry-home"
+  sub="$TMP_ROOT/unreadable-registry-subhome"
+  err="$TMP_ROOT/unreadable-registry.err"
+  registry="$home/data/secondmates.md"
+  mkdir -p "$home/data" "$home/state" "$home/projects"
+  printf '%s\n' '- design - design domain (home: /tmp/design; scope: design; projects: alpha; added 2026-07-30)' > "$registry"
+  chmod 000 "$registry"
+  if FM_HOME="$home" "$ROOT/bin/fm-home-seed.sh" validate >/dev/null 2>"$err"; then
+    chmod 600 "$registry"
+    fail "home-seed validation accepted an unreadable registry"
+  fi
+  grep -F 'secondmate registry is unavailable or unsafe' "$err" >/dev/null || {
+    chmod 600 "$registry"
+    fail "home-seed validation did not explain the unreadable registry"
+  }
+  if FM_HOME="$home" FM_SECONDMATE_CHARTER='design domain' \
+    "$ROOT/bin/fm-home-seed.sh" design "$sub" alpha >/dev/null 2>"$err"; then
+    chmod 600 "$registry"
+    fail "home seeding accepted an unreadable registry"
+  fi
+  chmod 600 "$registry"
+  [ ! -e "$sub" ] || fail "home seeding provisioned a home before unreadable registry refusal"
+  [ ! -e "$home/data/design" ] || fail "home seeding created a brief before unreadable registry refusal"
+  pass "home seeding refuses unreadable registries before provisioning"
+}
+
 test_home_seed_validate_rejects_duplicate_homes() {
   local home subhome subhome_abs err
   home="$TMP_ROOT/duplicate-home"
@@ -2342,6 +2370,7 @@ test_lock_status_is_per_home
 test_seed_allows_overlapping_clones_and_drops_owner
 test_home_seed_validate_rejects_unparseable_registry_entry
 test_home_seed_refuses_broken_registry_symlink
+test_home_seed_refuses_unreadable_registry
 test_home_seed_validate_rejects_duplicate_homes
 test_home_seed_validate_rejects_duplicate_ids
 test_home_seed_validate_rejects_nested_homes

--- a/tests/fm-secondmate-safety.test.sh
+++ b/tests/fm-secondmate-safety.test.sh
@@ -123,6 +123,30 @@ test_home_seed_validate_rejects_unparseable_registry_entry() {
   pass "home-seed validation rejects registry records no operational parser can consume"
 }
 
+test_home_seed_refuses_broken_registry_symlink() {
+  local home sub err target
+  home="$TMP_ROOT/broken-registry-symlink-home"
+  sub="$TMP_ROOT/broken-registry-symlink-subhome"
+  err="$TMP_ROOT/broken-registry-symlink.err"
+  target="$home/data/missing-secondmates.md"
+  mkdir -p "$home/data" "$home/state" "$home/projects"
+  ln -s "$target" "$home/data/secondmates.md"
+  if FM_HOME="$home" "$ROOT/bin/fm-home-seed.sh" validate >/dev/null 2>"$err"; then
+    fail "home-seed validation accepted a broken registry symlink"
+  fi
+  grep -F 'secondmate registry is unavailable or unsafe' "$err" >/dev/null \
+    || fail "home-seed validation did not explain the broken registry symlink"
+  if FM_HOME="$home" FM_SECONDMATE_CHARTER='design domain' \
+    "$ROOT/bin/fm-home-seed.sh" design "$sub" alpha >/dev/null 2>"$err"; then
+    fail "home seeding accepted a broken registry symlink"
+  fi
+  [ -L "$home/data/secondmates.md" ] || fail "home seeding replaced the broken registry symlink"
+  [ ! -e "$target" ] || fail "home seeding wrote through the broken registry symlink"
+  [ ! -e "$sub" ] || fail "home seeding provisioned a home before broken registry refusal"
+  [ ! -e "$home/data/design" ] || fail "home seeding created a brief before broken registry refusal"
+  pass "home seeding refuses broken registry symlinks before provisioning"
+}
+
 test_home_seed_validate_rejects_duplicate_homes() {
   local home subhome subhome_abs err
   home="$TMP_ROOT/duplicate-home"
@@ -468,7 +492,7 @@ test_secondmate_spawn_resolves_punctuated_registry_projects() {
   printf 'punctuated\n' > "$sub/.fm-secondmate-home"
   printf '# Charter\n\nHandled work.\n' > "$sub/data/charter.md"
   sub_abs=$(cd "$sub" && pwd -P)
-  printf -- '- punctuated - launch notes (parenthetical) (home: %s; scope: launch (child); semicolon is valid; projects: alpha, beta; added 2026-07-30)\n' \
+  printf -- '- punctuated - launch notes (parenthetical) (home: %s; scope: launch (child); semicolon is valid; projects: alpha, beta; added 2026-07-30)' \
     "$sub_abs" > "$home/data/secondmates.md"
   FM_HOME="$home" "$ROOT/bin/fm-home-seed.sh" validate >/dev/null \
     || fail "home-seed validation rejected punctuated registry fields before spawn"
@@ -476,7 +500,7 @@ test_secondmate_spawn_resolves_punctuated_registry_projects() {
   log="$TMP_ROOT/punctuated-spawn-fake/tmux.log"
   PATH="$fakebin:$PATH" FM_HOME="$home" FM_FAKE_TMUX_LOG="$log" \
     FM_FAKE_TMUX_CAPTURE="$TMP_ROOT/punctuated-spawn-fake/pane.txt" \
-    "$ROOT/bin/fm-spawn.sh" punctuated "$sub" codex --secondmate >/dev/null 2>&1 \
+    "$ROOT/bin/fm-spawn.sh" punctuated codex --secondmate >/dev/null 2>&1 \
     || fail "secondmate spawn failed for punctuated registry fields"
   meta="$home/state/punctuated.meta"
   projects=$(grep '^projects=' "$meta" | cut -d= -f2-)
@@ -487,7 +511,7 @@ test_secondmate_spawn_resolves_punctuated_registry_projects() {
 
 test_secondmate_spawn_refuses_ambiguous_and_mismatched_registry_bindings() {
   local row case_name home sub other fakebin log err meta_before
-  for row in duplicate-id duplicate-home supplied-mismatch metadata-mismatch; do
+  for row in duplicate-id unterminated-duplicate-id duplicate-home supplied-mismatch metadata-mismatch; do
     case_name=${row%%|*}
     home="$TMP_ROOT/spawn-binding-$case_name-home"
     sub="$TMP_ROOT/spawn-binding-$case_name-sub"
@@ -503,6 +527,10 @@ test_secondmate_spawn_refuses_ambiguous_and_mismatched_registry_bindings() {
 - domain - primary route (home: $sub; scope: valid (scope); punctuation; projects: alpha; added 2026-07-30)
 - domain - duplicate route (home: $other; scope: duplicate; projects: beta; added 2026-07-30)
 EOF
+        ;;
+      unterminated-duplicate-id)
+        printf -- '- domain - primary route (home: %s; scope: valid (scope); punctuation; projects: alpha; added 2026-07-30)\n- domain - duplicate route (home: %s; scope: duplicate; projects: beta; added 2026-07-30)' \
+          "$sub" "$other" > "$home/data/secondmates.md"
         ;;
       duplicate-home)
         cat > "$home/data/secondmates.md" <<EOF
@@ -2313,6 +2341,7 @@ test_fm_home_parameterization
 test_lock_status_is_per_home
 test_seed_allows_overlapping_clones_and_drops_owner
 test_home_seed_validate_rejects_unparseable_registry_entry
+test_home_seed_refuses_broken_registry_symlink
 test_home_seed_validate_rejects_duplicate_homes
 test_home_seed_validate_rejects_duplicate_ids
 test_home_seed_validate_rejects_nested_homes

--- a/tests/fm-secondmate-safety.test.sh
+++ b/tests/fm-secondmate-safety.test.sh
@@ -109,6 +109,20 @@ EOF
   pass "seed allows overlapping project clone lists and drops the owns/owner routing"
 }
 
+test_home_seed_validate_rejects_unparseable_registry_entry() {
+  local home err
+  home="$TMP_ROOT/unparseable-registry-home"
+  err="$TMP_ROOT/unparseable-registry.err"
+  mkdir -p "$home/data"
+  printf '%s\n' '- broken - prose (home: /tmp/child; scope: missing projects and date)' > "$home/data/secondmates.md"
+  if FM_HOME="$home" "$ROOT/bin/fm-home-seed.sh" validate >/dev/null 2>"$err"; then
+    fail "home-seed validation accepted an operationally unparseable registry record"
+  fi
+  grep -F 'malformed secondmate registry entry' "$err" >/dev/null \
+    || fail "home-seed validation did not explain the malformed registry record"
+  pass "home-seed validation rejects registry records no operational parser can consume"
+}
+
 test_home_seed_validate_rejects_duplicate_homes() {
   local home subhome subhome_abs err
   home="$TMP_ROOT/duplicate-home"
@@ -442,6 +456,33 @@ test_home_seed_no_projects_end_to_end() {
   proj_val=$(grep '^projects=' "$meta" | head -1 | cut -d= -f2-)
   [ -z "$proj_val" ] || fail "project-less spawn recorded a non-empty projects meta: '$proj_val'"
   pass "home seeding scaffolds, registers, and spawns a project-less home end to end"
+}
+
+test_secondmate_spawn_resolves_punctuated_registry_projects() {
+  local home sub sub_abs fakebin log meta projects
+  home="$TMP_ROOT/punctuated-spawn-home"
+  sub="$TMP_ROOT/punctuated-spawn-subhome"
+  mkdir -p "$home/data" "$home/state" "$home/config" "$home/projects"
+  mkdir -p "$sub/data" "$sub/state" "$sub/config" "$sub/projects"
+  mark_firstmate_home "$sub"
+  printf 'punctuated\n' > "$sub/.fm-secondmate-home"
+  printf '# Charter\n\nHandled work.\n' > "$sub/data/charter.md"
+  sub_abs=$(cd "$sub" && pwd -P)
+  printf -- '- punctuated - launch notes (parenthetical) (home: %s; scope: launch (child); semicolon is valid; projects: alpha, beta; added 2026-07-30)\n' \
+    "$sub_abs" > "$home/data/secondmates.md"
+  FM_HOME="$home" "$ROOT/bin/fm-home-seed.sh" validate >/dev/null \
+    || fail "home-seed validation rejected punctuated registry fields before spawn"
+  fakebin=$(make_fake_tmux "$TMP_ROOT/punctuated-spawn-fake")
+  log="$TMP_ROOT/punctuated-spawn-fake/tmux.log"
+  PATH="$fakebin:$PATH" FM_HOME="$home" FM_FAKE_TMUX_LOG="$log" \
+    FM_FAKE_TMUX_CAPTURE="$TMP_ROOT/punctuated-spawn-fake/pane.txt" \
+    "$ROOT/bin/fm-spawn.sh" punctuated "$sub" codex --secondmate >/dev/null 2>&1 \
+    || fail "secondmate spawn failed for punctuated registry fields"
+  meta="$home/state/punctuated.meta"
+  projects=$(grep '^projects=' "$meta" | cut -d= -f2-)
+  [ "$projects" = 'alpha, beta' ] \
+    || fail "secondmate spawn resolved the wrong projects field: '$projects'"
+  pass "secondmate spawn resolves home validation and projects from punctuated registry fields"
 }
 
 test_home_seed_refuses_projectful_reused_charter_for_projectless_home() {
@@ -2167,6 +2208,7 @@ EOF
 test_fm_home_parameterization
 test_lock_status_is_per_home
 test_seed_allows_overlapping_clones_and_drops_owner
+test_home_seed_validate_rejects_unparseable_registry_entry
 test_home_seed_validate_rejects_duplicate_homes
 test_home_seed_validate_rejects_duplicate_ids
 test_home_seed_validate_rejects_nested_homes
@@ -2179,6 +2221,7 @@ test_home_seed_refuses_missing_filled_charter
 test_home_seed_refuses_placeholder_charter
 test_home_seed_refuses_empty_charter_fields
 test_home_seed_no_projects_end_to_end
+test_secondmate_spawn_resolves_punctuated_registry_projects
 test_home_seed_refuses_projectful_reused_charter_for_projectless_home
 test_home_seed_refuses_projectless_conversion_of_populated_home
 test_home_seed_refuses_projectless_home_with_uninspectable_projects


### PR DESCRIPTION
## Intent

Fix the shared secondmate-registry parsing contract so valid natural-language punctuation cannot break guarded operations.

Before editing, reproduce the landed child-cleanup failure through end-user public interfaces using an isolated fixture with an earlier parenthetical in a valid registered secondmate summary and parentheses plus semicolons in natural-language scope before the explicit structured suffix ends. Exercise guarded fm-teardown.sh child cleanup while a durable parent public-followup binding requires resolving the main home data/secondmates.md record. Show the old parser returns no home and cleanup refuses despite matching registered home and task metadata. Separate the punctuation trigger, the simple parser-compatible registry line that masks it, and the visible cleanup refusal. Confirm fm-home-seed.sh validate accepted the same operationally unparseable record. Do not mutate a real home, public reply, or existing task during reproduction.

Fix parsing so generated structured fields resolve from their explicit suffix rather than the first parenthesis or first incidental semicolon. Audit every duplicated secondmate-registry parser in fm-home-seed.sh, fm-spawn.sh, fm-teardown.sh, and shared helpers. Use one authoritative parser owner where appropriate under the one-owner rule, with callers sharing validation and refusal behavior. Make validation reject every record operational consumers cannot parse. Preserve refusal without mutation for malformed, duplicate, ambiguous, unsafe, or identity-mismatched records. Do not weaken cleanup, public-followup, home identity, symlink, force, discard, or unlanded-work safeguards.

Inspect divergent parsing paths and relevant history, test the punctuation counterfactual against the simple line, and seek disconfirming evidence before settling on the cause. Add executable regressions through public interfaces for home and project resolution, secondmate spawn or validation where relevant, and the exact guarded child-cleanup path that failed. Use isolated fixtures and never assert implementation source bytes.

Run focused and full relevant tests, bin/fm-lint.sh, bin/fm-doc-audience-check.sh where maintained prose changes, and the complete configured no-mistakes pipeline. Preserve this complete task-specific contract and all accepted follow-ups in this intent, excluding generic scaffold boilerplate.

This task is independent of the intent-handoff change and PR 1446. Do not change, synchronize, recover, resume, validate, or merge either unrelated task, either PR 1446 validation run, or any preserved PR 1446 head.

## What Changed

- Add an authoritative secondmate registry parser that anchors structured fields to their explicit suffix, allowing parentheses and semicolons in natural-language summaries and scopes.
- Share hardened binding validation across registry consumers so malformed, unsafe, duplicate, overlapping, or identity-mismatched records fail before guarded mutations.
- Add public-interface regressions and documentation for punctuation-safe parsing, spawn resolution, validation, and guarded teardown behavior.

## Risk Assessment

✅ Low: The shared parser now snapshots only a successfully and fully read regular registry, handles unterminated final records, rejects symlinks and ambiguous bindings, and validates identity before spawn or teardown mutation with matching public-interface regressions.

## Testing

Inspected the parser consolidation and history, ran five focused relevant suites covering public-followup cleanup, secondmate safety, project handoff, registry-backed updates, and fleet snapshots, then manually exercised the punctuation-bearing guarded child-cleanup path. All checks passed, and the CLI evidence shows correct parent resolution, refusal for the owed reply, and preservation without mutation.

<details>
<summary>Evidence: Punctuated registry guarded-cleanup transcript</summary>

<code>Punctuation-bearing registry validation: accepted.&#10;Guarded teardown: refused because work-child still owes public commitment pf-teardown-valid.&#10;Child metadata and identity marker preserved; parent registry unchanged; no endpoint kill requested.</code>

```text
ok - marked secondmate teardown resolves its parent and fails closed when unavailable
USER-SURFACE CHECK: punctuated registry validation
result: accepted
registry: - mate - synthetic (id is legacy); preserve this (home: /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T//fm-public-followup.YyPwGL/teardown-valid-child; scope: synthetic (child); semicolon remains meaningful; projects: ; added 2026-07-30)

GUARDED CHILD CLEANUP RESULT
●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
●  WATCHER DOWN - SUPERVISION IS OFF
●  1 task(s) in flight, but no watcher has a fresh beacon (last beat: never, grace 300s).
●  Trust the emitted supervision protocol for this harness; do not use shell & for watcher repair.
●  This is a supervision warning only; the guarded operation WILL still run.
●  repair missing watcher supervision according to the session-start block for this harness; do not use shell &.
●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
REFUSED: task work-child still owes a public reply through the myfirstmate relay.
public commitment pf-teardown-valid is still pending-work for secondmate:mate/work-child
Deliver it with bin/fm-public-followup.sh deliver <obligation-id>, waive it with tasks-axi public-followup waive, or use --force after explicit discard approval.

PRESERVED DURABLE STATE
child metadata: present
child identity marker: mate
parent registry binding: - mate - synthetic (id is legacy); preserve this (home: /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T//fm-public-followup.YyPwGL/teardown-valid-child; scope: synthetic (child); semicolon remains meaningful; projects: ; added 2026-07-30)
endpoint kill requested: no
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed (3) ✅</summary>

- 🚨 `bin/fm-teardown.sh:899` - Intent requires: “Preserve refusal without mutation for malformed, duplicate, ambiguous, unsafe, or identity-mismatched records.” This loop rejects malformed syntax but never proves a unique ID-to-home binding. Registries containing `A -&gt; H` plus `B -&gt; H`, or `A -&gt; H` plus `A -&gt; H2`, pass teardown preflight when H2 is unrelated. Teardown can then delete H and either leave B pointing at a deleted home or remove both A records. Move whole-registry uniqueness validation and the expected ID/home match to a shared pre-removal boundary.
- 🚨 `bin/fm-spawn.sh:569` - Intent requires callers to share refusal behavior for duplicate, ambiguous, and identity-mismatched records. The shared lookup now returns failure for malformed or duplicate matching records, but secondmate spawn bypasses home lookup when an explicit or metadata home exists, and its projects lookup failure is swallowed. Consequently `fm-spawn &lt;id&gt; &lt;home&gt; ... --secondmate` can create an endpoint and metadata despite a duplicate registry ID or a registry home that disagrees with the supplied home. Resolve one unique registry record and compare its canonical home before any spawn mutation.

🔧 Fix: Centralize secondmate registry binding validation
2 errors still open:
- 🚨 `bin/fm-secondmate-registry-lib.sh:99` - Intent requires refusal for every malformed or duplicate record. The new authoritative loop drops a final record when the file lacks a trailing newline because `read` assigns the text but returns nonzero before executing the body. A valid `A -&gt; H` line followed by an unterminated duplicate `A -&gt; H2` is therefore accepted, allowing spawn or teardown mutation under the same ambiguity this boundary is meant to reject. Process the final nonempty read with `while read ... || [ -n &#34;$line&#34; ]`.
- 🚨 `bin/fm-home-seed.sh:230` - Intent says: “Do not weaken ... symlink ... safeguards.” The new wrapper treats any path failing `-f` as an absent registry, so a broken `data/secondmates.md` symlink bypasses the shared validator even though that validator explicitly rejects symlinks. `fm-home-seed.sh validate` reports success, and a seed can later replace the unsafe symlink after other provisioning mutations. Distinguish a genuinely absent path from `[ -L &#34;$REG&#34; ]` and refuse the symlink before mutation.

🔧 Fix: Harden registry EOF and symlink validation
1 error still open:
- 🚨 `bin/fm-secondmate-registry-lib.sh:91` - Intent requires: “Make validation reject every record operational consumers cannot parse.” This boundary checks only file type and symlink status. If a regular registry cannot be opened for reading, the redirected loop processes zero records and an expected-ID-free `fm-home-seed.sh validate` reaches success with an empty temporary table. Explicitly open the registry before validation and convert any open/read failure into `SECONDMATE_REGISTRY_ERROR`.

🔧 Fix: Reject unreadable registries before parsing
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>Inspected `git diff` and relevant history from `68641a33c25e220ab3cab6cafe84eff971008714` through `cb222b3a4d93c35d68e2477b11d3dfc7f7511751`.</code>
- `tests/fm-public-followup.test.sh`
- `tests/fm-secondmate-safety.test.sh`
- `tests/fm-backlog-handoff.test.sh`
- `tests/fm-update.test.sh`
- `tests/fm-bearings-snapshot.test.sh`
- <code>Ran the isolated `test_secondmate_teardown_requires_parent_binding` fixture and recorded validation, teardown refusal, preserved durable state, and absence of endpoint mutation.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
