### PR TITLE
feat(watcher): add a hot-check fast path for event-driven checks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,6 +94,7 @@ state/               volatile runtime signals; gitignored
   <id>.herdr-presentation  quarantinable attempt and restart-binding journal for Herdr's optional visual projection; never task or endpoint authority; see docs/herdr-backend.md "Optional presentation spaces"
   <id>.check.sh      authenticated slow poll; the watcher dispatches validated PR data and the byte-identified X shim through trusted repository scripts, runs registered custom checks from hash-validated private snapshots, and rejects every other state check without execution
   <id>.check-trust   private content binding created by fm-check-register.sh for an intentional custom check
+  <id>.check-hot     optional local marker naming an events-pending file; while that file is non-empty the watcher runs the paired check.sh immediately instead of waiting for the next sweep, through the identical trusted dispatch (bin/fm-watch.sh header)
   <id>.pr-poll       private validated data sidecar for the byte-static PR merge poll
   <id>.pr-poll-registration  private transactional provenance record binding the task, canonical metadata identity, sidecar, and static poll publication
   <id>.pr-poll-retirement  private identity-bound crash-recovery receipt for one exact validated merged result; removed after its poll artifacts retire
@@ -327,6 +328,7 @@ Run `bin/fm-pr-check.sh <id> <PR url>` - it records `pr=` and the forge's `pr_he
 Tell the captain the PR's full URL, always the complete `https://...` link rather than a bare `#number`, a concise outcome summary, and the no-mistakes risk level when applicable.
 A captain instruction to merge is explicit authority; `yolo` is the only standing routine authority.
 For any custom `state/<id>.check.sh` you write yourself, keep it an ordinary single-link mode-`0700` file, print one line only when firstmate should wake, print nothing otherwise, finish before `FM_CHECK_TIMEOUT`, then bind its current bytes with `bin/fm-check-register.sh <id>` before the watcher may execute it.
+A check that needs faster-than-sweep reaction may add a `state/<id>.check-hot` marker (`bin/fm-watch.sh` header owns the full contract) without weakening that same trust binding.
 
 Tear down a ship task only after landing is confirmed.
 A teardown refusal for uncommitted or unlanded work is a stop-and-investigate result, never an obstacle to bypass.

--- a/bin/fm-check-register.sh
+++ b/bin/fm-check-register.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 # Bind an intentional custom watcher check to its current bytes.
 # Usage: fm-check-register.sh <id>
+# A registered check that needs faster-than-sweep reaction may also add a
+# sibling state/<id>.check-hot marker; bin/fm-watch.sh's header owns that
+# contract, and this registration is unchanged either way.
 set -u
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -133,8 +133,8 @@ family_for_basename() {
       ;;
     fm-daemon.test.sh|fm-guard-stale-banner.test.sh|fm-pi-watch-extension.test.sh|\
     fm-supervision-events.test.sh|fm-turnend-guard.test.sh|fm-wake-daemon-lifecycle-e2e.test.sh|\
-    fm-wake-queue.test.sh|fm-watch-checkpoint.test.sh|fm-watch-triage.test.sh|\
-    fm-watcher-lock.test.sh)
+    fm-wake-queue.test.sh|fm-watch-checkpoint.test.sh|fm-watch-hot-check.test.sh|\
+    fm-watch-triage.test.sh|fm-watcher-lock.test.sh)
       printf '%s\n' watcher-wake-lock
       ;;
     fm-afk-inject-herdr-e2e.test.sh|fm-afk-launch.test.sh|fm-backend-autodetect-smoke.test.sh|\

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -40,7 +40,12 @@
 #                          count, and demand-deep-inspection marker, for human
 #                          inspection only - never an automatic interrupt,
 #                          signal, or restart of the worker or its tool process.
-#   check: <script>: <out> authenticated check output, always actionable
+#   check: <script>: <out> authenticated check output, always actionable. A
+#                          check paired with a state/<id>.check-hot marker (see
+#                          hot_check_scan below for the full contract) can
+#                          produce this reason on any cycle, not just a
+#                          CHECK_INTERVAL sweep - the reason line itself is
+#                          identical either way.
 #   check: rejected unauthenticated state checks: <paths>
 #                          unsafe state checks were refused without execution
 #   check: rejected unauthenticated PR poll retirement receipts: <paths>
@@ -471,6 +476,112 @@ run_check() {
   ( run_check_process "$@" ) 2>/dev/null || true
 }
 
+# The single owner of *.check.sh dispatch: the x-watch shim, a validated
+# PR-poll snapshot, or a hash-bound custom-check snapshot (fm-check-register.sh
+# binding). Both the CHECK_INTERVAL sweep and the hot-check fast path below
+# call this so a hot marker runs through the exact same trusted validation - it
+# can never bypass or weaken check-trust. On non-empty output this enqueues and
+# calls wake() (which exits the watcher), identically to a sweep-produced wake.
+# <touch-last-check> is 1 for the sweep (preserves its original .last-check
+# bookkeeping before an exiting wake) and 0 for the hot path, which must never
+# touch .last-check - that timer belongs to the sweep alone.
+# Sets RUN_CHECK_REJECTED to <c> when the check could not be authenticated, so
+# the caller can accumulate one combined "rejected unauthenticated state
+# checks" wake; left empty otherwise.
+RUN_CHECK_REJECTED=
+run_one_check() {  # <check-path> <touch-last-check:0|1>
+  local c=$1 touch_last=$2
+  local is_pr_poll=0 out id provider url host path number custom_snapshot reason
+  RUN_CHECK_REJECTED=
+  if [ "$(basename "$c")" = x-watch.check.sh ]; then
+    if fmx_poll_shim_valid "$c" "$FM_HOME" "$FM_ROOT" \
+      && [ -f "$FM_ROOT/bin/fm-x-poll.sh" ] && [ ! -L "$FM_ROOT/bin/fm-x-poll.sh" ]; then
+      FM_HOME="$FM_HOME" run_check_capture "$FM_ROOT/bin/fm-x-poll.sh" || exit 1
+      out=$FM_CHECK_RESULT
+    else
+      RUN_CHECK_REJECTED=$c
+      return 0
+    fi
+  else
+    id=$(basename "$c" .check.sh)
+    if fm_pr_poll_snapshot_capture "$STATE" "$id" "$SCRIPT_DIR/fm-pr-poll.sh"; then
+      is_pr_poll=1
+      provider=$FM_PR_POLL_SNAPSHOT_PROVIDER
+      url=$FM_PR_POLL_SNAPSHOT_URL
+      host=$FM_PR_POLL_SNAPSHOT_HOST
+      path=$FM_PR_POLL_SNAPSHOT_PATH
+      number=$FM_PR_POLL_SNAPSHOT_NUMBER
+      run_check_capture "$SCRIPT_DIR/fm-pr-poll.sh" --validated \
+        "$provider" "$url" "$host" "$path" "$number" || exit 1
+      out=$FM_CHECK_RESULT
+    elif fm_custom_check_snapshot_prepare "$STATE" "$id"; then
+      custom_snapshot=$FM_CUSTOM_CHECK_SNAPSHOT
+      run_check_capture "$custom_snapshot" || exit 1
+      out=$FM_CHECK_RESULT
+      fm_custom_check_snapshot_cleanup
+    else
+      fm_custom_check_snapshot_cleanup
+      RUN_CHECK_REJECTED=$c
+      return 0
+    fi
+  fi
+  if [ -n "$out" ]; then
+    reason="check: $c: $out"
+    fm_wake_append check "$c" "$reason" || exit 1
+    if [ "$is_pr_poll" -eq 1 ] && [ "$out" = merged ]; then
+      if fm_pr_poll_retirement_publish "$STATE" "$id" "$SCRIPT_DIR/fm-pr-poll.sh" "$out"; then
+        fm_pr_poll_retirement_recover_one "$STATE" "$id" "$SCRIPT_DIR/fm-pr-poll.sh" \
+          || triage_log "merged PR poll retirement remains recoverable for $id"
+      else
+        triage_log "merged PR poll retirement deferred because its canonical snapshot changed for $id"
+      fi
+    fi
+    [ "$touch_last" != 1 ] || touch "$STATE/.last-check"
+    wake "$reason"
+  fi
+}
+
+# Hot-check fast path: a check may opt in to sub-poll-cycle reaction by pairing
+# state/<id>.check.sh with a sibling state/<id>.check-hot marker file whose
+# content is the absolute path of an "events pending" file (typically appended
+# to by an external daemon, e.g. a launchd watcher). Each cycle, any such check
+# whose events file currently exists and is non-empty runs immediately through
+# run_one_check above - the identical trusted execution/validation path the
+# CHECK_INTERVAL sweep uses, check-trust binding included - independent of
+# .last-check, so a pending event waits out this ~POLL-second loop instead of
+# the full sweep window. The CHECK_INTERVAL sweep still runs every check on its
+# own cadence regardless, the fallback if whatever feeds the events file dies.
+# Bounded to at most one hot run per check per cycle by construction (this
+# block makes exactly one pass per outer while iteration) and never touches
+# .last-check, so it can neither starve nor accelerate the sweep's own cadence
+# for other checks - a check that never clears its events file simply reruns
+# once every POLL seconds, not in a tighter loop.
+# The marker is local gitignored state (state/*.check-hot is not a tracked
+# schema), so opting a check in is a home-local choice with no config change.
+hot_check_scan() {
+  local hotf id c events_file reason
+  local rejected=
+  for hotf in "$STATE"/*.check-hot; do
+    [ -e "$hotf" ] || continue
+    [ -f "$hotf" ] && [ ! -L "$hotf" ] || continue
+    id=$(basename "$hotf" .check-hot)
+    fm_pr_task_id_valid "$id" || continue
+    c="$STATE/$id.check.sh"
+    [ -e "$c" ] || continue
+    events_file=
+    IFS= read -r events_file < "$hotf" 2>/dev/null || true
+    [ -n "$events_file" ] || continue
+    [ -s "$events_file" ] || continue
+    run_one_check "$c" 0
+    [ -z "$RUN_CHECK_REJECTED" ] || rejected="$rejected $RUN_CHECK_REJECTED"
+  done
+  if [ -n "$rejected" ]; then
+    reason="check: rejected unauthenticated state checks:$rejected"
+    fm_wake_append check unauthenticated-state-checks "$reason" || exit 1
+    wake "$reason"
+  fi
+}
+
 FM_ACTIVE_CHECK_PID=
 FM_ACTIVE_CHECK_PGID=
 FM_CHECK_OUTPUT=
@@ -727,6 +838,13 @@ while :; do
   # No conversation scraping; unresolved records are never silently expired.
   fm_pending_reply_tick "$STATE" || true
 
+  # Hot-check fast path: any state/<id>.check.sh paired with a state/<id>.check-hot
+  # marker whose events file is currently non-empty runs now, ahead of the
+  # CHECK_INTERVAL sweep below. See hot_check_scan's own comment for the
+  # contract. Evaluated first for the same starvation reason the sweep below
+  # is evaluated before the signal scan.
+  hot_check_scan
+
   # Slow per-task checks (firstmate writes these, e.g. a merged-PR poll).
   # Time-based via .last-check mtime so the cadence survives watcher restarts.
   # Evaluated BEFORE the signal scan: wake() exits the cycle, so a check placed
@@ -738,53 +856,8 @@ while :; do
     rejected_checks=
     for c in "$STATE"/*.check.sh; do
       [ -e "$c" ] || continue
-      is_pr_poll=0
-      if [ "$(basename "$c")" = x-watch.check.sh ]; then
-        if fmx_poll_shim_valid "$c" "$FM_HOME" "$FM_ROOT" \
-          && [ -f "$FM_ROOT/bin/fm-x-poll.sh" ] && [ ! -L "$FM_ROOT/bin/fm-x-poll.sh" ]; then
-          FM_HOME="$FM_HOME" run_check_capture "$FM_ROOT/bin/fm-x-poll.sh" || exit 1
-          out=$FM_CHECK_RESULT
-        else
-          rejected_checks="$rejected_checks $c"
-          continue
-        fi
-      else
-        id=$(basename "$c" .check.sh)
-        if fm_pr_poll_snapshot_capture "$STATE" "$id" "$SCRIPT_DIR/fm-pr-poll.sh"; then
-          is_pr_poll=1
-          provider=$FM_PR_POLL_SNAPSHOT_PROVIDER
-          url=$FM_PR_POLL_SNAPSHOT_URL
-          host=$FM_PR_POLL_SNAPSHOT_HOST
-          path=$FM_PR_POLL_SNAPSHOT_PATH
-          number=$FM_PR_POLL_SNAPSHOT_NUMBER
-          run_check_capture "$SCRIPT_DIR/fm-pr-poll.sh" --validated \
-            "$provider" "$url" "$host" "$path" "$number" || exit 1
-          out=$FM_CHECK_RESULT
-        elif fm_custom_check_snapshot_prepare "$STATE" "$id"; then
-          custom_snapshot=$FM_CUSTOM_CHECK_SNAPSHOT
-          run_check_capture "$custom_snapshot" || exit 1
-          out=$FM_CHECK_RESULT
-          fm_custom_check_snapshot_cleanup
-        else
-          fm_custom_check_snapshot_cleanup
-          rejected_checks="$rejected_checks $c"
-          continue
-        fi
-      fi
-      if [ -n "$out" ]; then
-        reason="check: $c: $out"
-        fm_wake_append check "$c" "$reason" || exit 1
-        if [ "$is_pr_poll" -eq 1 ] && [ "$out" = merged ]; then
-          if fm_pr_poll_retirement_publish "$STATE" "$id" "$SCRIPT_DIR/fm-pr-poll.sh" "$out"; then
-            fm_pr_poll_retirement_recover_one "$STATE" "$id" "$SCRIPT_DIR/fm-pr-poll.sh" \
-              || triage_log "merged PR poll retirement remains recoverable for $id"
-          else
-            triage_log "merged PR poll retirement deferred because its canonical snapshot changed for $id"
-          fi
-        fi
-        touch "$STATE/.last-check"
-        wake "$reason"
-      fi
+      run_one_check "$c" 1
+      [ -z "$RUN_CHECK_REJECTED" ] || rejected_checks="$rejected_checks $RUN_CHECK_REJECTED"
     done
     if [ -n "$rejected_checks" ]; then
       reason="check: rejected unauthenticated state checks:$rejected_checks"

--- a/tests/fm-watch-hot-check.test.sh
+++ b/tests/fm-watch-hot-check.test.sh
@@ -1,0 +1,205 @@
+#!/usr/bin/env bash
+# Tests for bin/fm-watch.sh's hot-check fast path: a check may pair
+# state/<id>.check.sh with a sibling state/<id>.check-hot marker naming an
+# events-pending file, so it runs immediately (through the same trusted
+# dispatch as the CHECK_INTERVAL sweep) instead of waiting out the sweep
+# window. Uses the same bounded foreground checkpoint wrapper as
+# fm-watch-checkpoint.test.sh, since check dispatch does not depend on any
+# recorded tmux window.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+CHECKPOINT="$ROOT/bin/fm-watch-checkpoint.sh"
+TMP_ROOT=$(fm_test_tmproot fm-watch-hot-check)
+
+make_home() {
+  local name=$1 home
+  home="$TMP_ROOT/$name"
+  mkdir -p "$home/state" "$home/data" "$home/config"
+  printf '%s\n' "$home"
+}
+
+# install_check <home> <id> <script-body>: write and register a valid custom
+# check under <id>, returning nothing (the caller reads state/<id>.check.sh).
+install_check() {
+  local home=$1 id=$2 body=$3
+  printf '%s\n' "$body" > "$home/state/$id.check.sh"
+  chmod 0700 "$home/state/$id.check.sh"
+  FM_HOME="$home" "$ROOT/bin/fm-check-register.sh" "$id" >/dev/null \
+    || fail "could not register check $id"
+}
+
+# install_hot_marker <home> <id> <events-file>: pair a check with a hot marker
+# naming <events-file> (created if absent, left untouched otherwise).
+install_hot_marker() {
+  local home=$1 id=$2 events=$3
+  printf '%s\n' "$events" > "$home/state/$id.check-hot"
+}
+
+file_mtime() {
+  if [ "$(uname)" = Darwin ]; then stat -f %m "$1" 2>/dev/null; else stat -c %Y "$1" 2>/dev/null; fi
+}
+
+test_hot_marker_fires_before_sweep_interval() {
+  local home events out err status
+  home=$(make_home fires)
+  events="$home/data/hotid.events"
+  mkdir -p "$home/data"
+  printf 'event\n' > "$events"
+  install_check "$home" hotid $'#!/usr/bin/env bash\nprintf "hot check fired\\n"'
+  install_hot_marker "$home" hotid "$events"
+  # A fresh .last-check keeps this cycle's sweep gate genuinely not-due (a
+  # missing .last-check reads as maximally stale and would sweep once on its
+  # own on the very first cycle), isolating the assertion to the hot path.
+  touch "$home/state/.last-check"
+  out="$home/out.txt"; err="$home/err.txt"
+  status=0
+  FM_HOME="$home" FM_POLL=1 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=999999 \
+    "$CHECKPOINT" --seconds 5 >"$out" 2>"$err" || status=$?
+  expect_code 0 "$status" "hot marker checkpoint exit"
+  assert_contains "$(cat "$out")" "check:" "hot-triggered check did not produce a check wake"
+  assert_contains "$(cat "$out")" "hot check fired" "hot-triggered check output missing"
+  pass "a non-empty events file fires its paired check well inside the sweep window"
+}
+
+test_empty_events_file_does_not_fire() {
+  local home events out err status
+  home=$(make_home empty)
+  events="$home/data/hotid.events"
+  mkdir -p "$home/data"
+  : > "$events"
+  install_check "$home" hotid $'#!/usr/bin/env bash\nprintf "should-not-fire\\n"'
+  install_hot_marker "$home" hotid "$events"
+  touch "$home/state/.last-check"
+  out="$home/out.txt"; err="$home/err.txt"
+  status=0
+  FM_HOME="$home" FM_POLL=1 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=999999 \
+    "$CHECKPOINT" --seconds 3 >"$out" 2>"$err" || status=$?
+  expect_code 124 "$status" "empty-events-file checkpoint exit"
+  assert_not_contains "$(cat "$out")" "should-not-fire" "check ran despite an empty events file"
+  pass "an empty (or missing) events file never triggers the hot path"
+}
+
+test_hot_marker_without_matching_check_is_noop() {
+  local home events out err status
+  home=$(make_home orphan)
+  events="$home/data/orphan.events"
+  mkdir -p "$home/data"
+  printf 'event\n' > "$events"
+  install_hot_marker "$home" orphan "$events"
+  touch "$home/state/.last-check"
+  out="$home/out.txt"; err="$home/err.txt"
+  status=0
+  FM_HOME="$home" FM_POLL=1 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=999999 \
+    "$CHECKPOINT" --seconds 3 >"$out" 2>"$err" || status=$?
+  expect_code 124 "$status" "orphan hot-marker checkpoint exit"
+  pass "a check-hot marker with no matching check.sh is a silent no-op"
+}
+
+test_hot_path_never_touches_last_check() {
+  local home events out err status before after
+  home=$(make_home lastcheck)
+  events="$home/data/hotid.events"
+  mkdir -p "$home/data"
+  printf 'event\n' > "$events"
+  install_check "$home" hotid $'#!/usr/bin/env bash\nprintf "hot check fired\\n"'
+  install_hot_marker "$home" hotid "$events"
+  touch "$home/state/.last-check"
+  before=$(file_mtime "$home/state/.last-check")
+  out="$home/out.txt"; err="$home/err.txt"
+  status=0
+  FM_HOME="$home" FM_POLL=1 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=999999 \
+    "$CHECKPOINT" --seconds 5 >"$out" 2>"$err" || status=$?
+  expect_code 0 "$status" "hot marker (last-check probe) checkpoint exit"
+  assert_contains "$(cat "$out")" "hot check fired" "hot path did not fire despite a fresh .last-check"
+  after=$(file_mtime "$home/state/.last-check")
+  [ "$before" = "$after" ] || fail ".last-check mtime changed from a hot run ($before -> $after); the sweep cadence must stay independent of hot activity"
+  pass "a hot run fires independently of .last-check and never advances the sweep's own timer"
+}
+
+test_hot_marker_never_bypasses_check_trust() {
+  local home events out pid i ran_marker
+  home=$(make_home tamper)
+  events="$home/data/hotid.events"
+  ran_marker="$home/state/hotid.tampered-run.marker"
+  mkdir -p "$home/data"
+  printf 'event\n' > "$events"
+  install_check "$home" hotid $'#!/usr/bin/env bash\nexit 0'
+  out="$home/out.txt"
+  # Run the real watcher (not the bounded checkpoint) in the background so it
+  # is long-lived past its own startup: fm-pr-check-migrate.sh already
+  # quarantines any *.check.sh whose bytes mismatch its trust hash BEFORE the
+  # main loop starts, which would confound this test by removing the file
+  # before hot_check_scan ever saw it. Tampering only after the watcher is
+  # confirmed past that one-time startup step isolates the assertion to the
+  # live sweep/hot rejection path this feature adds.
+  FM_HOME="$home" FM_POLL=1 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=999999 \
+    "$ROOT/bin/fm-watch.sh" >"$out" 2>&1 &
+  pid=$!
+  i=0
+  while [ ! -e "$home/state/.pr-check-migration-v1" ] && [ "$i" -lt 50 ]; do
+    sleep 0.1
+    i=$((i + 1))
+  done
+  assert_present "$home/state/.pr-check-migration-v1" "startup migration never completed"
+  assert_present "$home/state/hotid.check.sh" "check.sh was removed before it could be tampered live"
+
+  # Tamper the check's bytes without re-registering, so its check-trust hash
+  # no longer matches, then arm the hot marker on the freshly-tampered check.
+  printf '%s\n' '#!/usr/bin/env bash' "printf 'tampered\\n' >> '$ran_marker'" \
+    > "$home/state/hotid.check.sh"
+  chmod 0700 "$home/state/hotid.check.sh"
+  install_hot_marker "$home" hotid "$events"
+
+  i=0
+  while kill -0 "$pid" 2>/dev/null && [ "$i" -lt 50 ]; do
+    sleep 0.1
+    i=$((i + 1))
+  done
+  if kill -0 "$pid" 2>/dev/null; then
+    kill "$pid" 2>/dev/null || true
+    wait "$pid" 2>/dev/null || true
+    fail "watcher never exited with a rejection wake for the live-tampered check"
+  fi
+  wait "$pid" 2>/dev/null || true
+  assert_contains "$(cat "$out")" "check: rejected unauthenticated state checks:" \
+    "a hot marker paired with a live-tampered check must be rejected, not executed"
+  assert_contains "$(cat "$out")" "hotid.check.sh" "rejection reason must name the tampered check"
+  assert_absent "$ran_marker" "the tampered check must never actually run"
+  pass "a hot marker never bypasses or weakens check-trust validation"
+}
+
+test_hot_path_bounded_to_one_run_per_cycle() {
+  local home events counter out err status lines
+  home=$(make_home bounded)
+  events="$home/data/hotid.events"
+  counter="$home/data/hotid.count"
+  mkdir -p "$home/data"
+  printf 'event\n' > "$events"
+  : > "$counter"
+  # Never produces output (never wakes), so the checkpoint keeps running for
+  # its full bounded window while the events file stays non-empty throughout -
+  # the scenario a busy-looping hot path would blow up on.
+  install_check "$home" hotid "#!/usr/bin/env bash
+printf x >> '$counter'"
+  install_hot_marker "$home" hotid "$events"
+  touch "$home/state/.last-check"
+  out="$home/out.txt"; err="$home/err.txt"
+  status=0
+  FM_HOME="$home" FM_POLL=1 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=999999 \
+    "$CHECKPOINT" --seconds 4 >"$out" 2>"$err" || status=$?
+  expect_code 124 "$status" "silent hot-run checkpoint exit"
+  lines=$(wc -c < "$counter" | tr -d '[:space:]')
+  [ "$lines" -ge 1 ] || fail "hot path never ran despite a non-empty events file the whole time"
+  [ "$lines" -le 20 ] || fail "hot path ran $lines times in ~4s of FM_POLL=1 cycles - looks like a busy loop, not one run per cycle"
+  pass "a check that never clears its events file reruns at most once per poll cycle, not in a tight loop"
+}
+
+test_hot_marker_fires_before_sweep_interval
+test_empty_events_file_does_not_fire
+test_hot_marker_without_matching_check_is_noop
+test_hot_path_never_touches_last_check
+test_hot_marker_never_bypasses_check_trust
+test_hot_path_bounded_to_one_run_per_cycle


### PR DESCRIPTION
## Summary
- `state/<id>.check.sh` may pair with a sibling `state/<id>.check-hot` marker naming an events-pending file; each watcher cycle, if that file is currently non-empty, the check runs immediately through the exact same trusted dispatch as the `CHECK_INTERVAL` sweep (check-trust binding included), independent of `.last-check`.
- Refactored the per-check dispatch (x-watch shim / validated PR-poll snapshot / hash-bound custom-check snapshot) into a shared `run_one_check()` so the hot path and the sweep share identical trusted validation; the sweep itself is unchanged and remains the fallback.
- Bounded to at most one hot execution per check per cycle by construction; the hot path never touches `.last-check`, so it can neither starve nor accelerate the sweep's own cadence.
- Documented the mechanism in `bin/fm-watch.sh`'s own header/function comments, plus one-line pointers in `AGENTS.md` (layout entry + section 7) and `bin/fm-check-register.sh`.
- Added `tests/fm-watch-hot-check.test.sh` (6 cases) and classified it into the existing `watcher-wake-lock` test family.

## Test plan
- [x] `bin/fm-lint.sh` clean on all changed files
- [x] `tests/fm-watch-hot-check.test.sh` passes (6/6)
- [x] No regression in `tests/fm-watch-triage.test.sh` / `tests/fm-watcher-lock.test.sh` (isolated re-runs of the two tests that flaked under concurrent load passed cleanly against both original and modified `fm-watch.sh`)
- [x] `no-mistakes` pipeline: intent/rebase/review/test/document/lint all completed with 0 findings