### PR TITLE
fix: recognize fork-pushed work during teardown

### DIFF
--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -14,8 +14,9 @@
 # squash-merge-then-delete-branch flow, where the branch's own commits live nowhere
 # on a remote yet the change is fully in main.
 # Before declaring a branch unpushed, teardown fetches it from every remote the task
-# legitimately pushes to: the project's configured remotes and the fork URL no-mistakes
-# records as its push target. A fork-pushed branch this clone never fetched is then
+# legitimately pushes to: the project's configured remotes and the fork target no-mistakes
+# records. Credential-bearing targets resolve through matching local remote configuration
+# and credential-free targets can be fetched directly. A fork-pushed branch this clone never fetched is then
 # recognized as landed instead of forcing a manual override. That consultation is
 # strictly additive: a failed or unavailable remote leaves the existing remote-tracking
 # refs untouched, so the refusal is exactly as before and now names the remotes that
@@ -903,6 +904,33 @@ work_is_landed() {
 # fetched for the task branch, used by the refusal message and ref cleanup.
 TEARDOWN_REMOTES_CHECKED=
 TEARDOWN_LANDED_REFS=
+TEARDOWN_REMOTE_CHECK_ERROR=
+
+redact_git_remote_url() {
+  case "$1" in
+    http://*@*|https://*@*)
+      printf '%s\n' "$1" | sed -E 's#^(https?://)[^/@]+@#\1redacted@#'
+      ;;
+    *) printf '%s\n' "$1" ;;
+  esac
+}
+
+configured_remote_url_for() {
+  local wanted=$1 remote key candidate redacted
+  for remote in $(git -C "$WT" remote 2>/dev/null || true); do
+    for key in "remote.$remote.url" "remote.$remote.pushurl"; do
+      while IFS= read -r candidate; do
+        [ -n "$candidate" ] || continue
+        redacted=$(redact_git_remote_url "$candidate")
+        if [ "$candidate" = "$wanted" ] || [ "$redacted" = "$wanted" ]; then
+          printf '%s\n' "$candidate"
+          return 0
+        fi
+      done < <(git -C "$WT" config --get-all "$key" 2>/dev/null || true)
+    done
+  done
+  return 1
+}
 
 # Restore the remote-tracking refs consulted by refresh_landed_check_remotes, so
 # the shared project repo returns to its prior state after the safety check: refs
@@ -932,9 +960,10 @@ drop_landed_check_refs() {
 # TEARDOWN_REMOTES_CHECKED for the refusal message and TEARDOWN_LANDED_REFS for
 # drop_landed_check_refs.
 refresh_landed_check_remotes() {
-  local branch=$1 remote fork_url ref old
+  local branch=$1 remote fork_url configured_fork_url ref old
   TEARDOWN_REMOTES_CHECKED=
   TEARDOWN_LANDED_REFS=
+  TEARDOWN_REMOTE_CHECK_ERROR=
   [ -n "$branch" ] && [ "$branch" != HEAD ] || return 0
   for remote in $(git -C "$WT" remote 2>/dev/null || true); do
     TEARDOWN_REMOTES_CHECKED="${TEARDOWN_REMOTES_CHECKED:+$TEARDOWN_REMOTES_CHECKED, }$remote"
@@ -949,10 +978,22 @@ refresh_landed_check_remotes() {
       | sed -n 's/^[[:space:]]*fork:[[:space:]]*//p' | head -1) || true
     if [ -n "$fork_url" ]; then
       TEARDOWN_REMOTES_CHECKED="${TEARDOWN_REMOTES_CHECKED:+$TEARDOWN_REMOTES_CHECKED, }fork (via no-mistakes)"
-      ref="refs/remotes/fm-no-mistakes-fork/$branch"
-      old=$(git -C "$WT" rev-parse --quiet --verify "$ref^{commit}" 2>/dev/null) || old=
-      if git -C "$WT" fetch --quiet --no-tags "$fork_url" "+refs/heads/$branch:$ref" >/dev/null 2>&1; then
-        TEARDOWN_LANDED_REFS="${TEARDOWN_LANDED_REFS:+$TEARDOWN_LANDED_REFS }$ref|$old"
+      if configured_fork_url=$(configured_remote_url_for "$fork_url"); then
+        fork_url=$configured_fork_url
+      else
+        case "$fork_url" in
+          http://redacted@*|https://redacted@*)
+            TEARDOWN_REMOTE_CHECK_ERROR="no configured git remote matches the credential-masked no-mistakes fork target"
+            fork_url=
+            ;;
+        esac
+      fi
+      if [ -n "$fork_url" ]; then
+        ref="refs/remotes/fm-no-mistakes-fork/$branch"
+        old=$(git -C "$WT" rev-parse --quiet --verify "$ref^{commit}" 2>/dev/null) || old=
+        if git -C "$WT" fetch --quiet --no-tags "$fork_url" "+refs/heads/$branch:$ref" >/dev/null 2>&1; then
+          TEARDOWN_LANDED_REFS="${TEARDOWN_LANDED_REFS:+$TEARDOWN_LANDED_REFS }$ref|$old"
+        fi
       fi
     fi
   fi
@@ -1272,6 +1313,8 @@ validate_worktree_teardown_safety() {
     if [ -n "$unpushed" ] && ! work_is_landed "$branch"; then
       echo "REFUSED: worktree $WT has work not on any remote and not landed." >&2
       printf 'remotes checked: %s\n' "${TEARDOWN_REMOTES_CHECKED:-none}" >&2
+      [ -z "$TEARDOWN_REMOTE_CHECK_ERROR" ] \
+        || printf 'fork push target could not be checked: %s.\n' "$TEARDOWN_REMOTE_CHECK_ERROR" >&2
       printf 'unpushed commits:\n%s\n' "$unpushed" >&2
       echo "Push the branch, land its PR, or get the captain's explicit OK to discard, then --force." >&2
       return 1

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -916,20 +916,25 @@ redact_git_remote_url() {
 }
 
 configured_remote_url_for() {
-  local wanted=$1 remote key candidate redacted
+  local wanted=$1 remote candidate redacted candidates matched=
   for remote in $(git -C "$WT" remote 2>/dev/null || true); do
-    for key in "remote.$remote.url" "remote.$remote.pushurl"; do
-      while IFS= read -r candidate; do
-        [ -n "$candidate" ] || continue
-        redacted=$(redact_git_remote_url "$candidate")
-        if [ "$candidate" = "$wanted" ] || [ "$redacted" = "$wanted" ]; then
-          printf '%s\n' "$candidate"
-          return 0
+    candidates=$(git -C "$WT" config --get-all "remote.$remote.pushurl" 2>/dev/null || true)
+    if [ -z "$candidates" ]; then
+      candidates=$(git -C "$WT" config --get-all "remote.$remote.url" 2>/dev/null || true)
+    fi
+    while IFS= read -r candidate; do
+      [ -n "$candidate" ] || continue
+      redacted=$(redact_git_remote_url "$candidate")
+      if [ "$candidate" = "$wanted" ] || [ "$redacted" = "$wanted" ]; then
+        if [ -n "$matched" ] && [ "$candidate" != "$matched" ]; then
+          return 2
         fi
-      done < <(git -C "$WT" config --get-all "$key" 2>/dev/null || true)
-    done
+        matched=$candidate
+      fi
+    done <<< "$candidates"
   done
-  return 1
+  [ -n "$matched" ] || return 1
+  printf '%s\n' "$matched"
 }
 
 # Restore the remote-tracking refs consulted by refresh_landed_check_remotes, so
@@ -960,7 +965,7 @@ drop_landed_check_refs() {
 # TEARDOWN_REMOTES_CHECKED for the refusal message and TEARDOWN_LANDED_REFS for
 # drop_landed_check_refs.
 refresh_landed_check_remotes() {
-  local branch=$1 remote fork_url configured_fork_url ref old
+  local branch=$1 remote fork_url configured_fork_url configured_fork_status ref old
   TEARDOWN_REMOTES_CHECKED=
   TEARDOWN_LANDED_REFS=
   TEARDOWN_REMOTE_CHECK_ERROR=
@@ -981,12 +986,18 @@ refresh_landed_check_remotes() {
       if configured_fork_url=$(configured_remote_url_for "$fork_url"); then
         fork_url=$configured_fork_url
       else
-        case "$fork_url" in
-          http://redacted@*|https://redacted@*)
-            TEARDOWN_REMOTE_CHECK_ERROR="no configured git remote matches the credential-masked no-mistakes fork target"
-            fork_url=
-            ;;
-        esac
+        configured_fork_status=$?
+        if [ "$configured_fork_status" -eq 2 ]; then
+          TEARDOWN_REMOTE_CHECK_ERROR="multiple configured git push destinations match the credential-masked no-mistakes fork target"
+          fork_url=
+        else
+          case "$fork_url" in
+            http://redacted@*|https://redacted@*)
+              TEARDOWN_REMOTE_CHECK_ERROR="no configured git remote matches the credential-masked no-mistakes fork target"
+              fork_url=
+              ;;
+          esac
+        fi
       fi
       if [ -n "$fork_url" ]; then
         ref="refs/remotes/fm-no-mistakes-fork/$branch"

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -13,14 +13,13 @@
 # already present in the up-to-date default branch. This recognizes the common
 # squash-merge-then-delete-branch flow, where the branch's own commits live nowhere
 # on a remote yet the change is fully in main.
-# Before declaring a branch unpushed, teardown fetches it from every remote the task
-# legitimately pushes to: the project's configured remotes and the fork target no-mistakes
-# records. Credential-bearing targets resolve through matching local remote configuration
-# and credential-free targets can be fetched directly. A fork-pushed branch this clone never fetched is then
-# recognized as landed instead of forcing a manual override. That consultation is
-# strictly additive: a failed or unavailable remote leaves the existing remote-tracking
-# refs untouched, so the refusal is exactly as before and now names the remotes that
-# were consulted.
+# Before declaring a branch unpushed, teardown fetches the task branch from every
+# configured Git remote and from the fork push target recorded by no-mistakes.
+# Credential-bearing targets resolve through matching local remote configuration;
+# credential-free targets can be fetched directly. A fork-pushed branch that this
+# clone never fetched is therefore recognized as landed without a manual override.
+# The consultation remains fail-closed: a failed, unavailable, or ambiguous target
+# cannot weaken refusal, and a refusal names the remotes that were consulted.
 # The PR itself is resolved from the task's recorded pr= when present, or - when
 # no pr= was ever recorded (e.g. a yolo-authorized merge on a repo with no PR CI,
 # where the usual "checks green" fm-pr-check.sh trigger never fires) - by looking
@@ -937,10 +936,9 @@ configured_remote_url_for() {
   printf '%s\n' "$matched"
 }
 
-# Restore the remote-tracking refs consulted by refresh_landed_check_remotes, so
-# the shared project repo returns to its prior state after the safety check: refs
-# that already existed are set back to their prior value, and refs this check
-# created are deleted.
+# Best-effort restore the remote-tracking refs consulted by
+# refresh_landed_check_remotes: reset prior refs and delete refs created for the
+# safety check.
 drop_landed_check_refs() {
   local entry ref old
   for entry in $TEARDOWN_LANDED_REFS; do
@@ -955,13 +953,9 @@ drop_landed_check_refs() {
   TEARDOWN_LANDED_REFS=
 }
 
-# Fetch the task branch from every remote this task legitimately pushes to, so
-# the reachability check recognizes work pushed to a fork that this clone never
-# fetched. Consults each remote configured on the worktree's repo, plus the fork
-# URL no-mistakes records as its push target (the branch name is preserved when
-# the pipeline pushes it). Best-effort and strictly additive: a failed or
-# unavailable remote leaves the existing remote-tracking refs untouched, so an
-# unresolvable remote never loosens the safety check. Sets
+# Refresh temporary task-branch refs from each configured remote and from the
+# optional no-mistakes fork push target. Only successful fetches become evidence,
+# so a failed or unresolvable target cannot loosen the safety check. Sets
 # TEARDOWN_REMOTES_CHECKED for the refusal message and TEARDOWN_LANDED_REFS for
 # drop_landed_check_refs.
 refresh_landed_check_remotes() {
@@ -1309,11 +1303,10 @@ validate_worktree_teardown_safety() {
       branch=$(git -C "$WT" rev-parse --abbrev-ref HEAD 2>/dev/null || echo HEAD)
       TEARDOWN_WORKTREE_BRANCH_FOR_SAFETY=$branch
     fi
-    # Consult every remote this task may have pushed to (configured remotes and
-    # the no-mistakes fork target) before declaring the work unlanded, then
-    # re-run the reachability check against the fresh refs. The recompute is
-    # trusted only when it succeeds; a failure keeps the original unpushed set
-    # so the check below still decides on the pre-fetch evidence.
+    # Consult configured remotes and the no-mistakes fork target before declaring
+    # the work unlanded, then re-run the reachability check against the fresh refs.
+    # The recompute is trusted only when it succeeds; a failure keeps the original
+    # unpushed set, so the check below still decides on the pre-fetch evidence.
     refresh_landed_check_remotes "$branch"
     if [ "$branch" != HEAD ]; then
       if unpushed2=$(git -C "$WT" log --oneline HEAD --not --remotes -- 2>/dev/null); then

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -13,6 +13,13 @@
 # already present in the up-to-date default branch. This recognizes the common
 # squash-merge-then-delete-branch flow, where the branch's own commits live nowhere
 # on a remote yet the change is fully in main.
+# Before declaring a branch unpushed, teardown fetches it from every remote the task
+# legitimately pushes to: the project's configured remotes and the fork URL no-mistakes
+# records as its push target. A fork-pushed branch this clone never fetched is then
+# recognized as landed instead of forcing a manual override. That consultation is
+# strictly additive: a failed or unavailable remote leaves the existing remote-tracking
+# refs untouched, so the refusal is exactly as before and now names the remotes that
+# were consulted.
 # The PR itself is resolved from the task's recorded pr= when present, or - when
 # no pr= was ever recorded (e.g. a yolo-authorized merge on a repo with no PR CI,
 # where the usual "checks green" fm-pr-check.sh trigger never fires) - by looking
@@ -892,6 +899,65 @@ work_is_landed() {
   content_in_default
 }
 
+# Remotes consulted by the reachability check and the remote-tracking refs it
+# fetched for the task branch, used by the refusal message and ref cleanup.
+TEARDOWN_REMOTES_CHECKED=
+TEARDOWN_LANDED_REFS=
+
+# Restore the remote-tracking refs consulted by refresh_landed_check_remotes, so
+# the shared project repo returns to its prior state after the safety check: refs
+# that already existed are set back to their prior value, and refs this check
+# created are deleted.
+drop_landed_check_refs() {
+  local entry ref old
+  for entry in $TEARDOWN_LANDED_REFS; do
+    ref=${entry%%|*}
+    old=${entry#*|}
+    if [ -n "$old" ]; then
+      git -C "$WT" update-ref "$ref" "$old" 2>/dev/null || true
+    else
+      git -C "$WT" update-ref -d "$ref" 2>/dev/null || true
+    fi
+  done
+  TEARDOWN_LANDED_REFS=
+}
+
+# Fetch the task branch from every remote this task legitimately pushes to, so
+# the reachability check recognizes work pushed to a fork that this clone never
+# fetched. Consults each remote configured on the worktree's repo, plus the fork
+# URL no-mistakes records as its push target (the branch name is preserved when
+# the pipeline pushes it). Best-effort and strictly additive: a failed or
+# unavailable remote leaves the existing remote-tracking refs untouched, so an
+# unresolvable remote never loosens the safety check. Sets
+# TEARDOWN_REMOTES_CHECKED for the refusal message and TEARDOWN_LANDED_REFS for
+# drop_landed_check_refs.
+refresh_landed_check_remotes() {
+  local branch=$1 remote fork_url ref old
+  TEARDOWN_REMOTES_CHECKED=
+  TEARDOWN_LANDED_REFS=
+  [ -n "$branch" ] && [ "$branch" != HEAD ] || return 0
+  for remote in $(git -C "$WT" remote 2>/dev/null || true); do
+    TEARDOWN_REMOTES_CHECKED="${TEARDOWN_REMOTES_CHECKED:+$TEARDOWN_REMOTES_CHECKED, }$remote"
+    ref="refs/remotes/$remote/$branch"
+    old=$(git -C "$WT" rev-parse --quiet --verify "$ref^{commit}" 2>/dev/null) || old=
+    if git -C "$WT" fetch --quiet --no-tags "$remote" "+refs/heads/$branch:$ref" >/dev/null 2>&1; then
+      TEARDOWN_LANDED_REFS="${TEARDOWN_LANDED_REFS:+$TEARDOWN_LANDED_REFS }$ref|$old"
+    fi
+  done
+  if command -v no-mistakes >/dev/null 2>&1; then
+    fork_url=$(cd "$WT" && no-mistakes status 2>/dev/null \
+      | sed -n 's/^[[:space:]]*fork:[[:space:]]*//p' | head -1) || true
+    if [ -n "$fork_url" ]; then
+      TEARDOWN_REMOTES_CHECKED="${TEARDOWN_REMOTES_CHECKED:+$TEARDOWN_REMOTES_CHECKED, }fork (via no-mistakes)"
+      ref="refs/remotes/fm-no-mistakes-fork/$branch"
+      old=$(git -C "$WT" rev-parse --quiet --verify "$ref^{commit}" 2>/dev/null) || old=
+      if git -C "$WT" fetch --quiet --no-tags "$fork_url" "+refs/heads/$branch:$ref" >/dev/null 2>&1; then
+        TEARDOWN_LANDED_REFS="${TEARDOWN_LANDED_REFS:+$TEARDOWN_LANDED_REFS }$ref|$old"
+      fi
+    fi
+  fi
+}
+
 backlog_refresh_reminder() {
   local pr done_cmd report_path
   [ "$KIND" = secondmate ] && return 0
@@ -1191,8 +1257,21 @@ validate_worktree_teardown_safety() {
       branch=$(git -C "$WT" rev-parse --abbrev-ref HEAD 2>/dev/null || echo HEAD)
       TEARDOWN_WORKTREE_BRANCH_FOR_SAFETY=$branch
     fi
-    if ! work_is_landed "$branch"; then
+    # Consult every remote this task may have pushed to (configured remotes and
+    # the no-mistakes fork target) before declaring the work unlanded, then
+    # re-run the reachability check against the fresh refs. The recompute is
+    # trusted only when it succeeds; a failure keeps the original unpushed set
+    # so the check below still decides on the pre-fetch evidence.
+    refresh_landed_check_remotes "$branch"
+    if [ "$branch" != HEAD ]; then
+      if unpushed2=$(git -C "$WT" log --oneline HEAD --not --remotes -- 2>/dev/null); then
+        unpushed=$(printf '%s\n' "$unpushed2" | head -5)
+      fi
+    fi
+    drop_landed_check_refs
+    if [ -n "$unpushed" ] && ! work_is_landed "$branch"; then
       echo "REFUSED: worktree $WT has work not on any remote and not landed." >&2
+      printf 'remotes checked: %s\n' "${TEARDOWN_REMOTES_CHECKED:-none}" >&2
       printf 'unpushed commits:\n%s\n' "$unpushed" >&2
       echo "Push the branch, land its PR, or get the captain's explicit OK to discard, then --force." >&2
       return 1

--- a/tests/fm-teardown.test.sh
+++ b/tests/fm-teardown.test.sh
@@ -666,6 +666,80 @@ SH
   pass "no-mistakes worktree resolves an authenticated fork target from git remote configuration"
 }
 
+test_no_mistakes_rotated_fork_pushurl_allows() {
+  local case_dir rc
+  case_dir=$(make_case nm-rotated-fork)
+  write_meta "$case_dir" no-mistakes ship
+  wt_commit_file "$case_dir" fork-work.txt shippable "rotated fork credential work"
+  git init -q --bare "$case_dir/fork-expired.git"
+  git init -q --bare "$case_dir/fork-current.git"
+  git -C "$case_dir/project" remote add fork-auth 'https://old:expired@fork.invalid/repo.git'
+  git -C "$case_dir/project" config remote.fork-auth.pushurl 'https://new:token@fork.invalid/repo.git'
+  git -C "$case_dir/project" config url."$case_dir/fork-expired.git".insteadOf 'https://old:expired@fork.invalid/repo.git'
+  git -C "$case_dir/project" config url."$case_dir/fork-current.git".insteadOf 'https://new:token@fork.invalid/repo.git'
+  git -C "$case_dir/wt" push -q fork-auth fm/task-x1
+  git -C "$case_dir/project" update-ref -d refs/remotes/fork-auth/fm/task-x1
+  cat > "$case_dir/fakebin/no-mistakes" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' 'fork:  https://redacted@fork.invalid/repo.git'
+exit 0
+SH
+  chmod +x "$case_dir/fakebin/no-mistakes"
+
+  set +e
+  run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 0 "$rc" "nm-rotated-fork: teardown should prefer the current push URL over the expired fetch URL"
+  ! grep -q REFUSED "$case_dir/stderr" || fail "nm-rotated-fork: teardown printed a REFUSED line"
+  ! grep -E 'old:expired|new:token' "$case_dir/stdout" "$case_dir/stderr" >/dev/null \
+    || fail "nm-rotated-fork: teardown exposed fork credentials"
+  pass "no-mistakes teardown prefers a rotated authenticated fork push URL"
+}
+
+test_no_mistakes_ambiguous_masked_fork_refuses() {
+  local case_dir rc checked
+  case_dir=$(make_case nm-ambiguous-fork)
+  write_meta "$case_dir" no-mistakes ship
+  wt_commit_file "$case_dir" fork-work.txt shippable "ambiguous fork work"
+  git init -q --bare "$case_dir/fork-a-fetch.git"
+  git init -q --bare "$case_dir/fork-a-push.git"
+  git init -q --bare "$case_dir/fork-b-fetch.git"
+  git init -q --bare "$case_dir/fork-b-push.git"
+  git -C "$case_dir/project" remote add fork-a "$case_dir/fork-a-fetch.git"
+  git -C "$case_dir/project" remote add fork-b "$case_dir/fork-b-fetch.git"
+  git -C "$case_dir/project" config remote.fork-a.pushurl 'https://one:token@fork.invalid/repo.git'
+  git -C "$case_dir/project" config remote.fork-b.pushurl 'https://two:token@fork.invalid/repo.git'
+  git -C "$case_dir/project" config url."$case_dir/fork-a-push.git".insteadOf 'https://one:token@fork.invalid/repo.git'
+  git -C "$case_dir/project" config url."$case_dir/fork-b-push.git".insteadOf 'https://two:token@fork.invalid/repo.git'
+  git -C "$case_dir/wt" push -q fork-a fm/task-x1
+  git -C "$case_dir/project" update-ref -d refs/remotes/fork-a/fm/task-x1
+  cat > "$case_dir/fakebin/no-mistakes" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' 'fork:  https://redacted@fork.invalid/repo.git'
+exit 0
+SH
+  chmod +x "$case_dir/fakebin/no-mistakes"
+
+  set +e
+  run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 1 "$rc" "nm-ambiguous-fork: teardown should fail closed rather than choose a masked target"
+  grep -F 'fork push target could not be checked: multiple configured git push destinations match the credential-masked no-mistakes fork target.' "$case_dir/stderr" >/dev/null \
+    || fail "nm-ambiguous-fork: refusal did not explain the ambiguous authenticated targets"
+  checked=$(grep -F 'remotes checked:' "$case_dir/stderr" | head -1)
+  printf '%s\n' "$checked" | grep -F 'fork-a' >/dev/null \
+    || fail "nm-ambiguous-fork: refusal did not name fork-a"
+  printf '%s\n' "$checked" | grep -F 'fork-b' >/dev/null \
+    || fail "nm-ambiguous-fork: refusal did not name fork-b"
+  printf '%s\n' "$checked" | grep -F 'fork (via no-mistakes)' >/dev/null \
+    || fail "nm-ambiguous-fork: refusal did not name the no-mistakes fork target"
+  pass "ambiguous credential-masked fork targets fail closed with named remotes"
+}
+
 test_no_mistakes_unmatched_masked_fork_refuses_clearly() {
   local case_dir rc
   case_dir=$(make_case nm-masked-fork-unmatched)
@@ -2709,6 +2783,8 @@ test_local_only_fork_remote_allows
 test_no_mistakes_fork_push_remote_allows
 test_no_mistakes_configured_fork_remote_allows
 test_no_mistakes_authenticated_fork_pushurl_allows
+test_no_mistakes_rotated_fork_pushurl_allows
+test_no_mistakes_ambiguous_masked_fork_refuses
 test_no_mistakes_unmatched_masked_fork_refuses_clearly
 test_teardown_prompts_tasks_axi_done_when_compatible
 test_teardown_manual_backend_prompts_hand_edit_even_when_tasks_axi_present

--- a/tests/fm-teardown.test.sh
+++ b/tests/fm-teardown.test.sh
@@ -7,7 +7,7 @@
 # and GitHub reports a PR head that contains the current local work, or its content
 # is already in the up-to-date default branch.
 #
-# Covers three fixes:
+# Covers four fixes:
 #   - local-only fork-remote: a fork IS a remote, so fork-pushed upstream-
 #     contribution PRs are teardown-eligible (the pre-fix code false-refused them).
 #   - squash-merge-then-delete-branch: the branch's own commits live nowhere on a
@@ -19,13 +19,17 @@
 #     git index.lock that blocks teardown. The return path retries on the lock
 #     error signature (even if the lock self-clears mid-check), then only removes a
 #     provably stale lock before re-running safety checks.
+#   - no-mistakes fork target: teardown refreshes the task branch from configured
+#     remotes and from no-mistakes' recorded fork push target before deciding that
+#     committed work is unpushed. Credential-masked targets resolve through local
+#     push URLs and remain fail-closed when no unique match exists.
 #
 # Matrix:
 #   (a) local-only + HEAD on a fork remote-tracking branch     -> ALLOW  (fork fix)
 #   (b) local-only + truly unpushed work (no remote, not main) -> REFUSE (safety)
 #   (c) local-only + merged into local main, no remote         -> ALLOW  (no regression)
 #   (d) no-mistakes + HEAD on origin remote-tracking branch    -> ALLOW  (no regression)
-#   (e) no-mistakes + unpushed, no PR, content not in default  -> REFUSE (safety)
+#   (e) no-mistakes + unpushed, no PR, content not in default  -> REFUSE, name origin
 #   (f) local-only + truly unpushed + --force                  -> ALLOW  (escape hatch)
 #   (g) no-mistakes + squash-merged PR, exact PR head          -> ALLOW  (squash fix)
 #   (h) no-mistakes + no PR but content already in default     -> ALLOW  (content fallback)
@@ -40,18 +44,21 @@
 #   (q) no-mistakes + NO pr= recorded, PR discovered by branch  -> ALLOW  (yolo/no-CI merge)
 #   (r) no-mistakes + branch on the no-mistakes fork push target -> ALLOW  (fork fix)
 #   (s) no-mistakes + branch on a configured, never-fetched fork -> ALLOW  (fork fix)
-#   (t) no-mistakes + refusal names the remote consulted        -> message
+#   (t) masked fork target + matching authenticated push URL     -> ALLOW  (safe resolution)
+#   (u) masked fork target + rotated authenticated push URL      -> ALLOW  (current push URL)
+#   (v) masked fork target + multiple matching push URLs         -> REFUSE (ambiguous)
+#   (w) masked fork target + no matching configured push URL     -> REFUSE (unavailable)
 #
 # Also covers backlog teardown-lock-race: a git index.lock left in the worktree by a
 # killed crew process (bin/fm-teardown.sh's teardown_treehouse_return).
-#   (r) provably-stale index.lock (old mtime, no live holder) -> lock removed, ALLOW
-#   (s) index.lock with a live holder, any age                -> lock kept, REFUSE
-#   (t) lsof error while checking index.lock                  -> lock kept, REFUSE
-#   (u) dirty worktree after stale lock cleanup               -> lock removed, REFUSE
-#   (v) non-linked repo index.lock                            -> lock removed, ALLOW
-#   (w) index.lock mtime read failure                         -> lock kept, REFUSE
-#   (x) transient lock cleared after first failed return      -> retry ALLOW
-#   (y) persistent lock (never clears, not provably stale)    -> REFUSE loudly
+#   (lock-a) provably-stale index.lock (old mtime, no live holder) -> lock removed, ALLOW
+#   (lock-b) index.lock with a live holder, any age                -> lock kept, REFUSE
+#   (lock-c) lsof error while checking index.lock                  -> lock kept, REFUSE
+#   (lock-d) dirty worktree after stale lock cleanup               -> lock removed, REFUSE
+#   (lock-e) non-linked repo index.lock                            -> lock removed, ALLOW
+#   (lock-f) index.lock mtime read failure                         -> lock kept, REFUSE
+#   (lock-g) transient lock cleared after first failed return      -> retry ALLOW
+#   (lock-h) persistent lock (never clears, not provably stale)    -> REFUSE loudly
 set -u
 
 # shellcheck source=tests/lib.sh disable=SC1091
@@ -154,7 +161,6 @@ case "${1:-}" in
     ;;
 esac
 exit 0
-SH
 SH
   chmod +x "$fakebin/treehouse" "$fakebin/tmux" "$fakebin/gh-axi" "$fakebin/gh" "$fakebin/no-mistakes"
 

--- a/tests/fm-teardown.test.sh
+++ b/tests/fm-teardown.test.sh
@@ -587,7 +587,7 @@ test_no_mistakes_fork_push_remote_allows() {
   local case_dir rc
   case_dir=$(make_case nm-fork-remote)
   write_meta "$case_dir" no-mistakes ship
-  wt_commit "$case_dir" "shippable fork work"
+  wt_commit_file "$case_dir" fork-work.txt shippable "shippable fork work"
   # Reproduces the real false refusal: the pipeline pushes the branch to a fork
   # that is NOT a configured remote here and whose branch this clone never
   # fetched, so the reachability check shows the work as unpushed. no-mistakes
@@ -618,7 +618,7 @@ test_no_mistakes_configured_fork_remote_allows() {
   local case_dir rc
   case_dir=$(make_case nm-configured-fork)
   write_meta "$case_dir" no-mistakes ship
-  wt_commit "$case_dir" "shippable fork work"
+  wt_commit_file "$case_dir" fork-work.txt shippable "shippable fork work"
   # The fork is a configured remote, but this clone never fetched its branch, so
   # the reachability check still shows the work as unpushed. Teardown must fetch
   # the task branch from the fork remote before concluding.

--- a/tests/fm-teardown.test.sh
+++ b/tests/fm-teardown.test.sh
@@ -38,6 +38,9 @@
 #   (o) fm-pr-check rerun after HEAD moved                      -> no stale pr_head
 #   (p) fm-pr-check when local HEAD lags                        -> record remote PR head
 #   (q) no-mistakes + NO pr= recorded, PR discovered by branch  -> ALLOW  (yolo/no-CI merge)
+#   (r) no-mistakes + branch on the no-mistakes fork push target -> ALLOW  (fork fix)
+#   (s) no-mistakes + branch on a configured, never-fetched fork -> ALLOW  (fork fix)
+#   (t) no-mistakes + refusal names the remote consulted        -> message
 #
 # Also covers backlog teardown-lock-race: a git index.lock left in the worktree by a
 # killed crew process (bin/fm-teardown.sh's teardown_treehouse_return).
@@ -130,7 +133,7 @@ case "${1:-}" in
            && grep -Fxq "abort --run $run_id" "$FM_FAKE_NM_ABORT_LOG" 2>/dev/null \
            && [ "${FM_FAKE_NM_ABORT_NOOP:-0}" != 1 ]; then
           if [ "${FM_FAKE_NM_NOT_FOUND_AFTER_ABORT:-0}" = 1 ]; then
-            printf 'error: "run \\"%s\\" not found"\n' "$run_id" >&2
+            printf 'error: "run \"%s\" not found"\n' "$run_id" >&2
             exit 1
           elif [ "${FM_FAKE_NM_EMPTY_AFTER_ABORT:-0}" = 1 ]; then
             exit 0
@@ -151,6 +154,7 @@ case "${1:-}" in
     ;;
 esac
 exit 0
+SH
 SH
   chmod +x "$fakebin/treehouse" "$fakebin/tmux" "$fakebin/gh-axi" "$fakebin/gh" "$fakebin/no-mistakes"
 
@@ -579,6 +583,59 @@ test_local_only_fork_remote_allows() {
   pass "local-only worktree with HEAD on a fork remote is torn down (fix holds)"
 }
 
+test_no_mistakes_fork_push_remote_allows() {
+  local case_dir rc
+  case_dir=$(make_case nm-fork-remote)
+  write_meta "$case_dir" no-mistakes ship
+  wt_commit "$case_dir" "shippable fork work"
+  # Reproduces the real false refusal: the pipeline pushes the branch to a fork
+  # that is NOT a configured remote here and whose branch this clone never
+  # fetched, so the reachability check shows the work as unpushed. no-mistakes
+  # status is the only record of the push target.
+  git init -q --bare "$case_dir/fork.git"
+  git -C "$case_dir/wt" push -q "$case_dir/fork.git" fm/task-x1
+  cat > "$case_dir/fakebin/no-mistakes" <<SH
+#!/usr/bin/env bash
+printf '%s\n' "repo:  $case_dir/project"
+printf '%s\n' "remote:  https://github.com/example/upstream.git"
+printf '%s\n' "fork:  $case_dir/fork.git"
+printf '%s\n' "gate:  $case_dir/gate.git"
+exit 0
+SH
+  chmod +x "$case_dir/fakebin/no-mistakes"
+
+  set +e
+  run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 0 "$rc" "nm-fork-remote: teardown should succeed when the branch is on the fork no-mistakes pushes to"
+  ! grep -q REFUSED "$case_dir/stderr" || fail "nm-fork-remote: teardown printed a REFUSED line"
+  pass "no-mistakes worktree with the branch on the no-mistakes fork push target is torn down (fork fix)"
+}
+
+test_no_mistakes_configured_fork_remote_allows() {
+  local case_dir rc
+  case_dir=$(make_case nm-configured-fork)
+  write_meta "$case_dir" no-mistakes ship
+  wt_commit "$case_dir" "shippable fork work"
+  # The fork is a configured remote, but this clone never fetched its branch, so
+  # the reachability check still shows the work as unpushed. Teardown must fetch
+  # the task branch from the fork remote before concluding.
+  git init -q --bare "$case_dir/fork.git"
+  git -C "$case_dir/project" remote add fork "$case_dir/fork.git"
+  git -C "$case_dir/wt" push -q "$case_dir/fork.git" fm/task-x1
+
+  set +e
+  run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 0 "$rc" "nm-configured-fork: teardown should succeed when the branch is on a configured fork remote"
+  ! grep -q REFUSED "$case_dir/stderr" || fail "nm-configured-fork: teardown printed a REFUSED line"
+  pass "no-mistakes worktree with the branch on a configured but never-fetched fork remote is torn down"
+}
+
 test_teardown_prompts_tasks_axi_done_when_compatible() {
   local case_dir out
   case_dir=$(make_case tasks-axi-reminder)
@@ -689,6 +746,8 @@ test_no_mistakes_truly_unpushed_refuses() {
 
   expect_code 1 "$rc" "nm-unpushed: teardown should refuse"
   grep -q REFUSED "$case_dir/stderr" || fail "nm-unpushed: no REFUSED line in stderr"
+  grep -F 'remotes checked: origin' "$case_dir/stderr" >/dev/null \
+    || fail "nm-unpushed: refusal did not name the remote consulted"
   pass "no-mistakes worktree with genuinely unlanded work is refused (safety preserved)"
 }
 
@@ -2592,6 +2651,8 @@ EOF
 }
 
 test_local_only_fork_remote_allows
+test_no_mistakes_fork_push_remote_allows
+test_no_mistakes_configured_fork_remote_allows
 test_teardown_prompts_tasks_axi_done_when_compatible
 test_teardown_manual_backend_prompts_hand_edit_even_when_tasks_axi_present
 test_local_only_truly_unpushed_refuses

--- a/tests/fm-teardown.test.sh
+++ b/tests/fm-teardown.test.sh
@@ -636,6 +636,61 @@ test_no_mistakes_configured_fork_remote_allows() {
   pass "no-mistakes worktree with the branch on a configured but never-fetched fork remote is torn down"
 }
 
+test_no_mistakes_authenticated_fork_pushurl_allows() {
+  local case_dir rc
+  case_dir=$(make_case nm-authenticated-fork)
+  write_meta "$case_dir" no-mistakes ship
+  wt_commit_file "$case_dir" fork-work.txt shippable "authenticated fork work"
+  git init -q --bare "$case_dir/fork.git"
+  git init -q --bare "$case_dir/fork-fetch.git"
+  git -C "$case_dir/project" remote add fork-auth "$case_dir/fork-fetch.git"
+  git -C "$case_dir/project" config remote.fork-auth.pushurl 'https://user:token@fork.invalid/repo.git'
+  git -C "$case_dir/project" config url."$case_dir/fork.git".insteadOf 'https://user:token@fork.invalid/repo.git'
+  git -C "$case_dir/wt" push -q "$case_dir/fork.git" fm/task-x1
+  cat > "$case_dir/fakebin/no-mistakes" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' 'fork:  https://redacted@fork.invalid/repo.git'
+exit 0
+SH
+  chmod +x "$case_dir/fakebin/no-mistakes"
+
+  set +e
+  run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 0 "$rc" "nm-authenticated-fork: teardown should use the configured authenticated fork push URL"
+  ! grep -q REFUSED "$case_dir/stderr" || fail "nm-authenticated-fork: teardown printed a REFUSED line"
+  ! grep -F 'user:token' "$case_dir/stdout" "$case_dir/stderr" >/dev/null \
+    || fail "nm-authenticated-fork: teardown exposed fork credentials"
+  pass "no-mistakes worktree resolves an authenticated fork target from git remote configuration"
+}
+
+test_no_mistakes_unmatched_masked_fork_refuses_clearly() {
+  local case_dir rc
+  case_dir=$(make_case nm-masked-fork-unmatched)
+  write_meta "$case_dir" no-mistakes ship
+  wt_commit_file "$case_dir" fork-work.txt unpushed "unverifiable fork work"
+  cat > "$case_dir/fakebin/no-mistakes" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' 'fork:  https://redacted@fork.invalid/repo.git'
+exit 0
+SH
+  chmod +x "$case_dir/fakebin/no-mistakes"
+
+  set +e
+  run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 1 "$rc" "nm-masked-fork-unmatched: teardown should fail closed"
+  grep -F 'fork push target could not be checked: no configured git remote matches the credential-masked no-mistakes fork target.' "$case_dir/stderr" >/dev/null \
+    || fail "nm-masked-fork-unmatched: refusal did not explain the unavailable authenticated fork target"
+  grep -F 'remotes checked: origin, fork (via no-mistakes)' "$case_dir/stderr" >/dev/null \
+    || fail "nm-masked-fork-unmatched: refusal did not name the consulted remotes"
+  pass "credential-masked fork target without matching git configuration fails closed clearly"
+}
+
 test_teardown_prompts_tasks_axi_done_when_compatible() {
   local case_dir out
   case_dir=$(make_case tasks-axi-reminder)
@@ -2653,6 +2708,8 @@ EOF
 test_local_only_fork_remote_allows
 test_no_mistakes_fork_push_remote_allows
 test_no_mistakes_configured_fork_remote_allows
+test_no_mistakes_authenticated_fork_pushurl_allows
+test_no_mistakes_unmatched_masked_fork_refuses_clearly
 test_teardown_prompts_tasks_axi_done_when_compatible
 test_teardown_manual_backend_prompts_hand_edit_even_when_tasks_axi_present
 test_local_only_truly_unpushed_refuses


### PR DESCRIPTION
## Intent

Fix bin/fm-teardown.sh so its landed-work check consults the remote the task actually pushes to, including the fork no-mistakes records as its push target (config.ForkURL), not only origin. Finished work pushed to that fork must tear down without manual --force; refusal must never be weakened; refusal messages must name the remotes that were consulted; ordinary single-remote behavior stays unchanged. Changes to bin/fm-teardown.sh and its regression tests in tests/fm-teardown.test.sh.

## What Changed

- Refresh the task branch from configured Git remotes and the fork push target recorded by no-mistakes before deciding work is unpushed.
- Resolve credential-masked fork targets through configured push URLs, clean up temporary tracking refs, and fail closed on unavailable or ambiguous targets with consulted remotes named in refusal output.
- Expand teardown regression coverage for direct, configured, authenticated, rotated, ambiguous, and unverifiable fork targets.

## Risk Assessment

✅ Low: The change is well-bounded, preserves fail-closed teardown behavior, prefers unambiguous pushurl targets, and covers the identified fork and credential-rotation paths without source-verifiable regressions.

## Testing

With no prior baseline results supplied, the targeted regression file passed and end-to-end CLI evidence confirmed fork-pushed teardown succeeds without `--force` while ordinary and unverifiable unpushed work remains fail-closed with named remotes.

<details>
<summary>Evidence: End-to-end teardown CLI transcript</summary>

```text
SCENARIO 1: branch exists only on the fork recorded by no-mistakes
$ no-mistakes status
repo:  /tmp/fm-teardown-tests.Ii7Bmz/nm-fork-remote/project
remote:  https://github.com/example/upstream.git
fork:  /tmp/fm-teardown-tests.Ii7Bmz/nm-fork-remote/fork.git
gate:  /tmp/fm-teardown-tests.Ii7Bmz/nm-fork-remote/gate.git
$ git remote -v
origin	/tmp/fm-teardown-tests.Ii7Bmz/nm-fork-remote/origin.git (fetch)
origin	/tmp/fm-teardown-tests.Ii7Bmz/nm-fork-remote/origin.git (push)
$ git log --oneline HEAD --not --remotes --
375b70a shippable fork work
$ git --git-dir=<recorded-fork> show-ref refs/heads/fm/task-x1
375b70a1cb7813f2a8839de4e89472d039c6d49a refs/heads/fm/task-x1
$ bin/fm-teardown.sh task-x1
/tmp/fm-teardown-tests.Ii7Bmz/nm-fork-remote/project: already current
teardown task-x1 complete (window firstmate:fm-task-x1, worktree /tmp/fm-teardown-tests.Ii7Bmz/nm-fork-remote/wt)
Backlog: task-x1 just finished. Run tasks-axi done task-x1 --pr PR_URL, then run tasks-axi ready for dependency-cleared candidates, check date gates, and dispatch only work whose blockers are gone and date is due.
RESULT: success — exit 0, no REFUSED message, task metadata removed, and no --force was used
$ git show-ref --verify refs/remotes/fm-no-mistakes-fork/fm/task-x1  # after teardown
RESULT: no temporary fork tracking ref remains after the safety check

SCENARIO 2: ordinary origin-only task has a genuinely unpushed commit
$ git remote
origin
$ bin/fm-teardown.sh task-x1
REFUSED: worktree /tmp/fm-teardown-tests.Ii7Bmz/nm-unpushed/wt has work not on any remote and not landed.
remotes checked: origin
unpushed commits:
4f7a104 unpushed work
Push the branch, land its PR, or get the captain's explicit OK to discard, then --force.
RESULT: refused — exit 1 and task metadata preserved

SCENARIO 3: credential-masked fork target cannot be resolved safely
$ bin/fm-teardown.sh task-x1
REFUSED: worktree /tmp/fm-teardown-tests.Ii7Bmz/nm-masked-fork-unmatched/wt has work not on any remote and not landed.
remotes checked: origin, fork (via no-mistakes)
fork push target could not be checked: no configured git remote matches the credential-masked no-mistakes fork target.
unpushed commits:
fa57f06 unverifiable fork work
Push the branch, land its PR, or get the captain's explicit OK to discard, then --force.
RESULT: refused — exit 1 and task metadata preserved
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed (3) ✅</summary>

- 🚨 `tests/fm-teardown.test.sh:532` - Both new fork tests use `wt_commit`, which creates an empty commit. Because its tree already matches `origin/main`, the pre-fix `content_in_default` fallback accepts it, so these tests pass without the new remote-fetch logic. Use `wt_commit_file` in both cases so the required regression tests fail on the base implementation.

🔧 Fix: Strengthen fork teardown regression coverage
1 error still open:
- 🚨 `bin/fm-teardown.sh:558` - Intent requires consulting `config.ForkURL` so finished fork-pushed work tears down, but this parses `no-mistakes status`, whose implementation prints `safeurl.Redact(repo.ForkURL)` rather than the raw push target. For a supported URL such as `https://user:token@host/repo.git`, no-mistakes pushes with the raw URL while teardown fetches `https://redacted@host/repo.git`, fails, and still refuses. Use a supported authenticated machine-readable/probe boundary that does not expose secrets, or explicitly decide that credential-bearing ForkURLs are unsupported.

🔧 Fix: Resolve authenticated fork targets safely
1 error still open:
- 🚨 `bin/fm-teardown.sh:531` - The criterion requires consulting “the remote the task actually pushes to,” but this returns the first masked match after checking `remote.&lt;name&gt;.url` before Git’s actual push destination, `remote.&lt;name&gt;.pushurl`. With `url=https://old:expired@host/repo.git` and `pushurl=https://new:token@host/repo.git`, both redact identically; teardown selects the stale fetch URL, fails to see the branch pushed through `pushurl`, and still refuses. Prefer/try matching pushurl candidates first and fail closed on unresolved ambiguity; cover this credential-rotation sequence.

🔧 Fix: Prefer unambiguous configured push targets
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bash tests/fm-teardown.test.sh`
- <code>Exercised `bin/fm-teardown.sh task-x1` through fork-only, origin-only unpushed, configured/authenticated fork, and unverifiable-fork fixtures.</code>
- <code>Verified teardown removed task metadata without `--force` for fork-pushed work, preserved metadata on refusals, named consulted remotes, and removed temporary fork tracking refs.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
