### PR TITLE
feat: add staged subagent review workflow

### DIFF
--- a/.agents/skills/subagent-review-workflow/SKILL.md
+++ b/.agents/skills/subagent-review-workflow/SKILL.md
@@ -1,0 +1,122 @@
+---
+name: subagent-review-workflow
+description: >-
+  Compact procedure for staged coding workflows using subagents (@explore, @plan, @oracle, @fixer).
+  Use when coordinating non-trivial coding tasks that require structured exploration, planning, pre-implementation review, sole-editor implementation, and post-implementation review.
+user-invocable: false
+metadata:
+  internal: true
+---
+
+# subagent-review-workflow
+
+This skill owns the staged coding workflow for subagent-assisted implementation tasks.
+It enforces role isolation, strict artifact handoffs, pre- and post-implementation review gates with revision loops, and sole-editor authority.
+
+## Role verification and dynamic mapping
+
+Before dispatching subagents, verify available agent definitions in `.pi/agents/*.md`, `~/.pi/agent/agents/*.md`, or the active harness tool definitions.
+Do not assume fixed role identifiers; dynamically map requested roles to verified local agent definitions.
+
+- `@explore` -> `Explore` or `explorer`: Read-only codebase investigator.
+  Searches codebase facts, traces execution paths, and gathers technical evidence.
+  Performs no file edits or test executions.
+- `@plan` -> `Plan`: Read-only implementation planner.
+  Designs minimal architecture, file modifications, and verification strategies based on exploration findings.
+  Performs no file edits or test executions.
+- `@oracle` -> `oracle` or `lelouch`: Read-only pre- and post-implementation reviewer.
+  Audits exploration and plan artifacts before editing starts, and audits complete diffs against test evidence after editing completes.
+  Performs no file edits or test executions.
+- `@implement` -> `@fixer` / `fixer`: Sole editor and test runner.
+  Applies code modifications, executes test suites, and fixes verification failures.
+  Holds exclusive authority to mutate workspace files and run verification commands.
+
+Dynamic mapping alters role selection only and never weakens the sole-editor rule.
+
+## Role availability and error fallback protocol
+
+Before starting Stage 1, test subagent invocation availability in the current environment.
+If any requested subagent role is undefined, unavailable, or subagent dispatch is blocked by security seatbelts:
+
+- Do not attempt partial subagent delegation.
+- Fall back immediately to the self-executed multi-pass protocol.
+- Perform separate, dedicated passes in exact sequence: read-only exploration pass -> read-only planning pass -> read-only pre-implementation review pass -> fixer editing and test pass -> read-only post-implementation review pass.
+- Enforce strict separation of duties during self-execution by keeping all read-only passes completely free of file edits.
+
+## Staged execution procedure and explicit gated handoffs
+
+```
+[Stage 1: Explore & Plan]
+   │
+   ▼ (Exploration Findings & Plan Artifact)
+[Stage 2: Pre-Implementation Oracle Review Gate]
+   │
+   ├── (Findings / Risks Raised) ──► [Revision Loop: Update Plan / Re-explore]
+   │                                           │
+   ▼ (Approved Plan)                           │
+[Stage 3: Assumption Filtering & Handoff] ◄────┘
+   │
+   ▼ (Sanitized Handoff Packet)
+[Stage 4: Implementation & Verification (@fixer)]
+   │
+   ▼ (Git Diff & Test Evidence)
+[Stage 5: Post-Implementation Oracle Review Gate]
+   │
+   ├── (Findings / Defects Raised) ──► [Revision Loop: Fix & Rerun Tests (@fixer)]
+   │                                             │
+   ▼ (Approved Diff & Passing Evidence)          │
+[Stage 6: Gate Clearance & Commit/PR] ◄──────────┘
+```
+
+### Stage 1: Exploration and planning
+
+- Launch `@explore` to investigate codebase facts, existing patterns, and dependency structures.
+- Where safe, run independent read-only investigation queries concurrently.
+- Produce the Exploration Findings artifact (`EXPLORE_FINDINGS`).
+- Pass `EXPLORE_FINDINGS` to `@plan` to construct the Plan Proposal artifact (`PLAN_PROPOSAL`).
+
+### Stage 2: Pre-implementation review and revision loop
+
+- Pass `EXPLORE_FINDINGS` and `PLAN_PROPOSAL` to `@oracle` for pre-implementation review.
+- `@oracle` audits the proposal for architectural risks, edge-case gaps, and unnecessary complexity.
+- Pre-Implementation Revision Loop: If `@oracle` identifies findings or risks, return to `@plan` (or `@explore` if facts are missing) to revise `PLAN_PROPOSAL`.
+- Re-submit updated artifacts to `@oracle` until `@oracle` explicitly approves the plan.
+
+### Stage 3: Handoff and assumption filtering
+
+- Synthesize `EXPLORE_FINDINGS`, approved `PLAN_PROPOSAL`, and `@oracle` review notes into a Fixer Handoff Packet (`HANDOFF_PACKET`).
+- Audit `HANDOFF_PACKET` to strip unverified assumptions, speculative guesses, and obsolete code references.
+- Require every instruction in `HANDOFF_PACKET` to be grounded in verified exploration facts or explicit captain intent.
+
+### Stage 4: Implementation and verification
+
+- Pass sanitized `HANDOFF_PACKET` exclusively to `@fixer`.
+- `@fixer` applies file modifications in controlled batches and runs verification tests.
+- No other subagent or pass may edit workspace files or execute state-changing commands.
+- Produce the Git Diff (`git diff`) and Test Execution Evidence (`TEST_EVIDENCE`).
+
+### Stage 5: Post-implementation review and revision loop
+
+- Provide `@oracle` with the complete Git Diff (`git diff`) and full `TEST_EVIDENCE`.
+- `@oracle` audits the diff for plan adherence, regression risks, and code quality.
+- Post-Implementation Revision Loop: If `@oracle` raises review findings, return to `@fixer` to apply corrections and rerun affected verification checks.
+- Submit updated Git Diff and `TEST_EVIDENCE` to `@oracle` for re-review until `@oracle` approves.
+
+### Stage 6: Gate clearance and delivery
+
+- Confirm that both `@oracle` gates (pre-implementation plan approval and post-implementation diff/test approval) are passed.
+- Confirm all verification checks pass cleanly.
+- Proceed to commit or PR preparation under project delivery rules.
+
+## Firstmate integration boundaries
+
+- This workflow operates inside an isolated task worktree and does not replace `fm-spawn.sh` or worktree verification.
+- Captain merge authority, `yolo` posture rules, `ask-user` escalation boundaries, and no-mistakes delivery paths remain fully in force.
+
+## Pressure-test verification evidence
+
+Verification evidence for this skill was validated across three core dimensions:
+
+- Ordering Discipline: Executed scenarios verified strict sequence enforcement (Explore -> Plan -> Pre-Impl Review -> Fixer -> Post-Impl Review). Attempts to skip exploration or leap to code editing were rejected by the gate protocol.
+- Artifact Handoff Rigor: Handoff packets were audited to strip unverified assumptions before reaching `@fixer`, preventing speculative code edits.
+- Dual Oracle Review Gates with Revision Loops: Both the pre-implementation plan gate and post-implementation diff gate were verified. Findings raised by `@oracle` triggered mandated revision loops back to `@plan` or `@fixer` respectively, requiring re-review before clearance.

--- a/.agents/skills/subagent-review-workflow/SKILL.md
+++ b/.agents/skills/subagent-review-workflow/SKILL.md
@@ -27,7 +27,7 @@ Do not assume fixed role identifiers; dynamically map requested roles to verifie
 - `@oracle` -> `oracle` or `lelouch`: Read-only pre- and post-implementation reviewer.
   Audits exploration and plan artifacts before editing starts, and audits complete diffs against test evidence after editing completes.
   Performs no file edits or test executions.
-- `@implement` -> `@fixer` / `fixer`: Sole editor and test runner.
+- `@fixer` -> `@fixer` or `fixer`: Sole editor and test runner.
   Applies code modifications, executes test suites, and fixes verification failures.
   Holds exclusive authority to mutate workspace files and run verification commands.
 
@@ -111,12 +111,5 @@ If any requested subagent role is undefined, unavailable, or subagent dispatch i
 ## Firstmate integration boundaries
 
 - This workflow operates inside an isolated task worktree and does not replace `fm-spawn.sh` or worktree verification.
+- Use it for Firstmate work only when the captain explicitly requests this staged workflow, and never layer its review or verification stages onto a no-mistakes delivery path.
 - Captain merge authority, `yolo` posture rules, `ask-user` escalation boundaries, and no-mistakes delivery paths remain fully in force.
-
-## Pressure-test verification evidence
-
-Verification evidence for this skill was validated across three core dimensions:
-
-- Ordering Discipline: Executed scenarios verified strict sequence enforcement (Explore -> Plan -> Pre-Impl Review -> Fixer -> Post-Impl Review). Attempts to skip exploration or leap to code editing were rejected by the gate protocol.
-- Artifact Handoff Rigor: Handoff packets were audited to strip unverified assumptions before reaching `@fixer`, preventing speculative code edits.
-- Dual Oracle Review Gates with Revision Loops: Both the pre-implementation plan gate and post-implementation diff gate were verified. Findings raised by `@oracle` triggered mandated revision loops back to `@plan` or `@fixer` respectively, requiring re-review before clearance.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -500,7 +500,7 @@ These skills are not captain-invocable; load them only at their precise triggers
 - `fmx-respond` - load on an `x-mention <request_id>` `check:` wake to handle the mention, on an `x-mode-error ...` `check:` wake to report the X-mode configuration blocker, on a `public-followup ...` `check:` wake or a startup-surfaced public commitment, and on any milestone or terminal wake for an X-mode-linked task before posting its completion follow-up; relevant only when X mode is on.
 - `firstmate-codexapp` - load before coordinating a visible Codex Desktop thread, evaluating a Codex App backend request, or reconciling Codex Desktop host-tool smoke evidence for Firstmate work.
 - `firstmate-coding-guidelines` - load before changing firstmate's shared, tracked material, as defined by section 1's list, whether editing directly or briefing a crewmate for a firstmate-repo task.
-- `subagent-review-workflow` - load before coordinating a staged coding task using subagents (`@explore`, `@plan`, `@oracle`, `@fixer`), or when a coding task requires structured exploration, planning, pre-implementation review, sole-editor implementation, and post-implementation review.
+- `subagent-review-workflow` - load in an isolated task worktree when the captain explicitly requests a staged coding workflow using subagents (`@explore`, `@plan`, `@oracle`, `@fixer`).
 
 ## 14. X mode
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -500,6 +500,7 @@ These skills are not captain-invocable; load them only at their precise triggers
 - `fmx-respond` - load on an `x-mention <request_id>` `check:` wake to handle the mention, on an `x-mode-error ...` `check:` wake to report the X-mode configuration blocker, on a `public-followup ...` `check:` wake or a startup-surfaced public commitment, and on any milestone or terminal wake for an X-mode-linked task before posting its completion follow-up; relevant only when X mode is on.
 - `firstmate-codexapp` - load before coordinating a visible Codex Desktop thread, evaluating a Codex App backend request, or reconciling Codex Desktop host-tool smoke evidence for Firstmate work.
 - `firstmate-coding-guidelines` - load before changing firstmate's shared, tracked material, as defined by section 1's list, whether editing directly or briefing a crewmate for a firstmate-repo task.
+- `subagent-review-workflow` - load before coordinating a staged coding task using subagents (`@explore`, `@plan`, `@oracle`, `@fixer`), or when a coding task requires structured exploration, planning, pre-implementation review, sole-editor implementation, and post-implementation review.
 
 ## 14. X mode
 

--- a/docs/documentation-audiences.json
+++ b/docs/documentation-audiences.json
@@ -164,6 +164,10 @@
       "audience": "agent-runtime"
     },
     {
+      "path": ".agents/skills/subagent-review-workflow/SKILL.md",
+      "audience": "agent-runtime"
+    },
+    {
       "path": ".agents/skills/stow/SKILL.md",
       "audience": "agent-runtime"
     },


### PR DESCRIPTION
## Intent

Create reusable internal skill for subagent staged coding workflow at .agents/skills/subagent-review-workflow/SKILL.md and register in AGENTS.md section 13

## What Changed

- Add an internal staged workflow for explore, plan, oracle review, sole-editor implementation, verification, and revision handoffs.
- Register the workflow’s explicit trigger in `AGENTS.md` and classify its skill documentation as an agent-runtime surface.

## Risk Assessment

🚨 High: Captain, the new workflow creates a reachable path around Firstmate's core project-isolation rule and should not merge without resolving that behavior.

## Testing

Inspected the base-to-target diff, confirmed the Pi runtime interface, and ran an end-to-end loader check: the skill loaded with zero diagnostics, appeared in runtime discovery, was registered in AGENTS.md Section 13, and contained all six stages, both Oracle revision loops, and the sole-editor Fixer handoff; the worktree remained clean.

<details>
<summary>Evidence: End-to-end skill discovery transcript</summary>

<code>Pi loaded `subagent-review-workflow` with zero diagnostics, exposed it in runtime discovery, and confirmed its Section 13 registration and staged workflow contract.</code>

```text
END-USER SKILL DISCOVERY
name: subagent-review-workflow
location: .agents/skills/subagent-review-workflow/SKILL.md
description: Compact procedure for staged coding workflows using subagents (@explore, @plan, @oracle, @fixer). Use when coordinating non-trivial coding tasks that require structured exploration, planning, pre-implementation review, sole-editor implementation, and post-implementation review.
loader diagnostics: 0
runtime prompt entry: present
AGENTS.md Section 13 registry entry: present
workflow contract: Explore -> Plan -> pre-review -> sole-editor Fixer -> post-review -> delivery
revision loops: pre-implementation and post-implementation present
RESULT: PASS — registered internal skill is discoverable and contains the required staged review workflow
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 error</summary>

- 🚨 `.agents/skills/subagent-review-workflow/SKILL.md:42` - In a Firstmate primary, AGENTS.md:503 loads this skill, the primary delegation guard makes the availability check fail, and this fallback then directs the primary to edit and test the project itself, violating AGENTS.md:16-27. Make the skill first assert it is running inside a spawned task worktree; when invoked from a primary, stop and route work through `fm-spawn.sh` instead of entering the self-executed fixer pass.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `git diff --stat/--name-status 1e247571aa75e00b00c7a01c4830025ecd44dc61..a8cea50ef4f3a5a55dbea6f6525ee810bded356c`
- `git diff 1e247571aa75e00b00c7a01c4830025ecd44dc61..a8cea50ef4f3a5a55dbea6f6525ee810bded356c -- AGENTS.md .agents/skills/subagent-review-workflow/SKILL.md`
- <code>`pi --help` to confirm the actual runtime skill-loading interface</code>
- <code>Focused Node end-to-end assertions using Pi `loadSkillsFromDir` and `formatSkillsForPrompt`, with transcript captured in the evidence directory</code>
- <code>`git status --short` to confirm testing left no transient worktree artifacts</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
