### PR TITLE
test: make session-start missing-tool fixture host-independent

### DIFF
--- a/tests/fm-session-start.test.sh
+++ b/tests/fm-session-start.test.sh
@@ -86,6 +86,25 @@ SH
   printf '%s\n' manual > "${fakebin%/*}/home-placeholder" 2>/dev/null || true
 }
 
+# hide_node <fakebin> <home>: make node genuinely undetectable so bootstrap emits
+# its real "MISSING: node" diagnostic. Deleting the fake binary alone is not
+# enough on hosts that ship node in the base PATH, so this also masks the lookup
+# the same way the Herdr cases mask tmux. Echoes the mask path for BASH_ENV.
+hide_node() {
+  local fakebin=$1 home=$2 mask
+  rm -f "$fakebin/node"
+  mask="$home/mask-node.bash"
+  cat > "$mask" <<'SH'
+command() {
+  if [ "${1:-}" = -v ] && [ "${2:-}" = node ]; then
+    return 1
+  fi
+  builtin command "$@"
+}
+SH
+  printf '%s\n' "$mask"
+}
+
 make_fake_tasks_axi_compact() {
   local fakebin=$1
   cat > "$fakebin/tasks-axi" <<'SH'
@@ -760,7 +779,7 @@ SH
 # --- output ordering ----------------------------------------------------------
 
 test_output_ordering_diagnostics_lead() {
-  local rec root home fakebin out lock_line boot_line wake_line context_line fleet_line next_line
+  local rec root home fakebin mask out lock_line boot_line wake_line context_line fleet_line next_line
   rec=$(new_world ordering)
   IFS='|' read -r root home fakebin <<EOF
 $rec
@@ -768,11 +787,11 @@ EOF
   make_fake_toolchain "$fakebin"
   make_fake_ps_claude "$fakebin"
   # Force a MISSING diagnostic line so the bootstrap section is non-trivial.
-  rm -f "$fakebin/node"
+  mask=$(hide_node "$fakebin" "$home")
 
   printf 'window=fm-sess:w1\nkind=ship\n' > "$home/state/task-a.meta"
 
-  out=$(run_session_start "$home" "$root" "$fakebin:$BASE_PATH")
+  out=$(BASH_ENV="$mask" run_session_start "$home" "$root" "$fakebin:$BASE_PATH")
 
   lock_line=$(printf '%s\n' "$out" | grep -n '^LOCK$' | head -1 | cut -d: -f1)
   boot_line=$(printf '%s\n' "$out" | grep -n '^BOOTSTRAP$' | head -1 | cut -d: -f1)
@@ -1043,19 +1062,19 @@ EOF
 # --- composition: real scripts run, not reimplemented ------------------------
 
 test_composition_invokes_real_scripts() {
-  local rec root home fakebin out
+  local rec root home fakebin mask out
   rec=$(new_world composition)
   IFS='|' read -r root home fakebin <<EOF
 $rec
 EOF
   make_fake_toolchain "$fakebin"
   make_fake_ps_claude "$fakebin"
-  rm -f "$fakebin/node"
+  mask=$(hide_node "$fakebin" "$home")
 
   printf 'needs-decision: pick a library\n' > "$home/state/task-z.status"
   append_wake "$home/state" signal task-z.status "needs-decision: pick a library"
 
-  out=$(run_session_start "$home" "$root" "$fakebin:$BASE_PATH")
+  out=$(BASH_ENV="$mask" run_session_start "$home" "$root" "$fakebin:$BASE_PATH")
 
   # fm-lock.sh's own exact success text.
   assert_contains "$out" "lock acquired: harness pid" "fm-lock.sh's real output did not appear (composition, not reimplementation)"


### PR DESCRIPTION
## Intent

Fix the pre-existing failure in tests/fm-session-start.test.sh, which failed on clean origin/main with "not ok - MISSING diagnostic did not appear at all". The captain queued this as a low-priority, minimal fix and explicitly required deciding whether the test or the script was at fault before writing any fix, with that verdict and the failing output recorded in the commit message, and with no assertion weakened or deleted purely to get green and no unrelated behavior change to session start.

Diagnosis: the TEST was at fault, not bin/fm-session-start.sh or bin/fm-bootstrap.sh. Two tests (test_output_ordering_diagnostics_lead and test_composition_invokes_real_scripts) force a bootstrap "MISSING: node" diagnostic by deleting the fake node from the fixture bin. That only works when node is absent from the test base PATH (/usr/bin:/bin:/usr/sbin:/sbin). On a host that ships node in /usr/bin, bootstrap command -v node still succeeds and it correctly reports nothing missing. Bootstrap detection is right - node really is installed - so the fixture, not the script, encoded the stale host assumption. The second site was hidden behind the first because the runner stops at the first failure.

Deliberate decisions a reviewer reading only the diff would not know:
- Fix is confined to tests/; bin/ is intentionally untouched, because the script behaved correctly. Editing the assertion to match "no diagnostic" would have been weakening it, which the task forbade.
- The chosen mechanism is a hide_node helper that deletes the fake binary AND masks the lookup through BASH_ENV. That masking idiom is not new: this same test file already masks tmux the same way for the Herdr auto-detection cases, so this follows the file own established pattern rather than inventing one.
- Deliberately factored into one shared helper rather than duplicating the mask at both call sites, per the repo one-owner rule in the firstmate-coding-guidelines skill.
- All assertions are preserved unchanged, including both MISSING assertions and the diagnostics-before-bulk-context ordering assertion; they are now actually exercised rather than passing or failing by host accident.
- Scope was deliberately kept minimal per the recorded low priority: no refactor of session start, and the separately queued tests/fm-calm-pi-extension.test.sh failure was explicitly left alone as a different task.

Verified before submitting: tests/fm-session-start.test.sh 28/28 pass (exit 0), sibling tests/fm-bootstrap.test.sh 21/21 pass, bin/fm-lint.sh clean.

## What Changed

- Add a shared `hide_node` fixture helper that removes the fake binary and masks host-level `node` lookup through `BASH_ENV`.
- Use the host-independent fixture in both session-start tests that require a real `MISSING: node` diagnostic, preserving the existing assertions and production behavior.

## Risk Assessment

✅ Low: Captain, this is a narrowly scoped test-only fix that durably masks host-installed node lookup at both affected call sites while preserving every assertion and leaving session-start behavior unchanged.

## Testing

The author-reported baseline included both focused suites and clean `bin/fm-lint.sh`; this phase reran the session-start and bootstrap suites successfully and directly demonstrated that host `/usr/bin/node` hides the diagnostic without masking while the committed mask produces `MISSING: node` before the fleet digest; visual evidence was not applicable to this test-only CLI fixture change.

<details>
<summary>Evidence: Direct session-start CLI evidence</summary>

<code>Host PATH resolves node as /usr/bin/node.&#10;Old fixture without mask: MISSING count=0.&#10;Fixed BASH_ENV mask: lookup exits 1.&#10;Session start emits MISSING: node at line 12, before FLEET STATE at line 90.</code>

```text
Host precondition: PATH=/usr/bin:/bin:/usr/sbin:/sbin resolves node as /usr/bin/node
Old fixture behavior: fake node deleted without mask; MISSING diagnostic count=0
Fixed fixture behavior: BASH_ENV masked lookup status=1 (nonzero means hidden)
6:LOCK
8:lock acquired: harness pid 1815944
10:BOOTSTRAP
12:MISSING: node (install: brew install node  # or the platform's package manager)
16:WAKE QUEUE
18:1785613089	1	signal	task-z.status	needs-decision: pick a library
19:wake annotation: latest wake-EVENT observed at drain, not current state: task-z.status: needs-decision: pick a library
66:CONTEXT
90:FLEET STATE
118:NEXT STEP
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bash tests/fm-session-start.test.sh`
- `bash tests/fm-bootstrap.test.sh`
- <code>Direct `bin/fm-session-start.sh` fixture comparison with fake node deleted first without masking, then with the committed `hide_node` BASH_ENV mask</code>
- `git diff 1e247571aa75e00b00c7a01c4830025ecd44dc61..38951b1d1908f7dca7007a66f805371a36466509 -- tests/fm-session-start.test.sh`
- `git log -1 --format=fuller 38951b1d1908f7dca7007a66f805371a36466509`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
