### PR TITLE
feat: improve generated brief routing

### DIFF
--- a/.agents/skills/project-management/SKILL.md
+++ b/.agents/skills/project-management/SKILL.md
@@ -37,17 +37,18 @@ Do not overwrite or repurpose an existing path.
 
 Choose the delivery mode when adding or creating the project:
 
-- `no-mistakes` runs the full validation pipeline before a PR and is the default when the captain does not specify a mode.
 - `direct-PR` pushes and opens a PR without the no-mistakes pipeline.
+- `no-mistakes` runs the full validation pipeline before a PR.
 - `local-only` has no required remote or PR and lands only through the approved local fast-forward path.
 
-The optional `+yolo` posture changes routine approval authority but does not change the delivery mode.
-Default it off, and enable it only on the captain's explicit instruction.
+When the captain omits the mode, default to `direct-PR +yolo`.
+An explicit mode without `+yolo` keeps routine approval authority off; an explicit `+yolo` enables it without changing delivery mode.
 `AGENTS.md` section 7 owns the complete authority boundary and exceptions when it is on.
 
 ## Add or clone an existing project
 
 Confirm the source URL, local project name, delivery mode, and autonomy posture.
+If the captain omits delivery mode, use `direct-PR +yolo`.
 Clone into `projects/<name>` and add the registry entry only after the destination is known to be unused.
 A `no-mistakes` project must have an `origin` remote and must complete the initialization procedure below.
 A `direct-PR` project needs an `origin` remote but skips no-mistakes initialization.
@@ -56,7 +57,7 @@ A `local-only` project may have no remote and skips no-mistakes initialization.
 ## Create a project
 
 Creating a GitHub repository is outward-facing.
-Before making that remote change, propose the repository name, owner or organization, visibility, and delivery mode, defaulting visibility to private and delivery mode to `no-mistakes`, then obtain the captain's explicit consent for those values.
+Before making that remote change, propose the repository name, owner or organization, visibility, and delivery mode, defaulting visibility to private and delivery mode to `direct-PR +yolo`, then obtain the captain's explicit consent for those values.
 Use `gh-axi` for the approved GitHub operation and consult its current help rather than relying on remembered flags.
 After remote creation succeeds, clone it locally, add the registry entry, and initialize it according to its delivery mode.
 

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -29,8 +29,8 @@
 # For ship tasks, the definition of done is shaped by the project's delivery mode
 # (data/projects.md via fm-project-mode.sh; see the project-management skill
 # and AGENTS.md task lifecycle):
-#   no-mistakes  implement -> /no-mistakes pipeline -> PR -> captain merge (default)
-#   direct-PR    implement -> push + open PR via gh-axi (no pipeline) -> captain merge
+#   direct-PR    implement -> push + open PR via gh-axi (no pipeline) -> captain merge (omitted mode defaults to direct-PR +yolo)
+#   no-mistakes  implement -> /no-mistakes pipeline -> PR -> captain merge
 #   local-only   implement on branch, stop and report "ready in branch" (no push/PR);
 #                captain approves, firstmate merges to local main
 # Ship briefs begin with a worktree-isolation assertion before the branch step.
@@ -247,6 +247,10 @@ EOF
 HERDR_SECTION=${HERDR_SECTION%$'\n'}
 fi
 
+SPECIALIST_RULE="8. When it would materially improve the result, delegate non-trivial supporting work narrowly to the appropriate installed specialist: use \`@explorer\` for repository mapping and search, \`@plan\` for architecture or implementation planning, \`@oracle\` for independent correctness and risk review, and \`@designer\` for frontend, UI, and visual work. Inspect and incorporate returned findings yourself, while preserving this brief's isolation, approval, and delivery rules."
+WEB_RESEARCH_RULE="9. For web research, use Firecrawl MCP first: call \`firecrawl_search\`, call \`firecrawl_search_feedback\` after using its results, and use \`firecrawl_scrape\` for known pages. If Firecrawl is unavailable, use another tool only as a fallback and disclose that fallback in your findings."
+REVIEW_PATH_RULE="10. Before pre-commit review, record the base and HEAD SHAs, then have the reviewer inspect the exact committed range with \`git show <HEAD>\` or \`git diff <base>...<HEAD>\`; if the review tool cannot access those commits or shows an empty range, report the mismatch instead of reviewing it."
+
 if [ "$KIND" = scout ]; then
 cat > "$BRIEF" <<EOF
 You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.
@@ -283,6 +287,9 @@ The report is the only thing that survives, so anything worth keeping must be in
 7. Never stop, restart, or update the shared \`no-mistakes\` daemon - it is one instance serving
    every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
    daemon error, append \`blocked: {the daemon error}\` and stop; only firstmate manages the daemon.
+$SPECIALIST_RULE
+$WEB_RESEARCH_RULE
+$REVIEW_PATH_RULE
 
 # Definition of done
 Write your findings to \`$DATA/$ID/report.md\`.
@@ -310,7 +317,9 @@ case "$MODE" in
 # Definition of done
 This project ships **direct-PR**: you raise the PR yourself, without the no-mistakes pipeline.
 The task is complete only when committed on your branch.
-When it is implemented and committed, push your branch and open a PR with \`gh-axi\`, then append \`done: PR {url}\` to the status file and stop.
+Before pushing or requesting a PR, ask \`@oracle\` for a fresh read-only review of the complete diff and verification evidence.
+Resolve every finding and rerun affected checks; if \`@oracle\` is unavailable, append \`blocked: {why}\` and stop without requesting a PR.
+When it is implemented, reviewed, and committed, push your branch and open a PR with \`gh-axi\`, then append \`done: PR {url}\` to the status file and stop.
 Do NOT run /no-mistakes. The configured merge authority decides whether to merge the PR; firstmate relays the outcome.
 EOF
     ;;
@@ -326,7 +335,7 @@ When it is implemented and committed, append \`done: ready in branch fm/$ID\` to
 The configured merge authority approves the ready branch, then firstmate merges it into local \`main\` through the guarded fast-forward path.
 EOF
     ;;
-  *)  # no-mistakes (default)
+  *)  # no-mistakes fallback
     SETUP2="
 2. Run \`no-mistakes doctor\`; if it reports the repo is not initialized here, run \`no-mistakes init\`."
     RULE1='1. Never push to the default branch. Never merge a PR.'
@@ -398,6 +407,9 @@ $RULE1
 7. Never stop, restart, or update the shared \`no-mistakes\` daemon - it is one instance serving
    every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
    daemon error, append \`blocked: {the daemon error}\` and stop; only firstmate manages the daemon.
+$SPECIALIST_RULE
+$WEB_RESEARCH_RULE
+$REVIEW_PATH_RULE
 
 # Project memory
 If \`AGENTS.md\` or \`CLAUDE.md\` already exists, or if this task produced durable project-intrinsic knowledge, run \`$FM_ROOT/bin/fm-ensure-agents-md.sh .\` in the worktree.

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -317,8 +317,8 @@ case "$MODE" in
 # Definition of done
 This project ships **direct-PR**: you raise the PR yourself, without the no-mistakes pipeline.
 The task is complete only when committed on your branch.
-Before pushing or requesting a PR, ask \`@oracle\` for a fresh read-only review of the complete diff and verification evidence.
-Resolve every finding and rerun affected checks; if \`@oracle\` is unavailable, append \`blocked: {why}\` and stop without requesting a PR.
+Before pushing or requesting a PR, if this task or the captain requires an independent review, ask \`@oracle\` for a fresh read-only review of the complete diff and verification evidence.
+Resolve every finding and rerun affected checks; if that review is required but \`@oracle\` is unavailable, append \`blocked: {why}\` and stop without requesting a PR.
 When it is implemented, reviewed, and committed, push your branch and open a PR with \`gh-axi\`, then append \`done: PR {url}\` to the status file and stop.
 Do NOT run /no-mistakes. The configured merge authority decides whether to merge the PR; firstmate relays the outcome.
 EOF

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -247,7 +247,7 @@ EOF
 HERDR_SECTION=${HERDR_SECTION%$'\n'}
 fi
 
-SPECIALIST_RULE="8. When it would materially improve the result, delegate non-trivial supporting work narrowly to the appropriate installed specialist: use \`@explorer\` for repository mapping and search, \`@plan\` for architecture or implementation planning, \`@oracle\` for explicitly authorized independent correctness and risk review, and \`@designer\` for frontend, UI, and visual work. Inspect and incorporate returned findings yourself, while preserving this brief's isolation, approval, and delivery rules."
+SPECIALIST_RULE="8. Standard implementation uses one \`antigravity/gemini-3.6-flash\` crewmate at high effort unless Firstmate explicitly overrides dispatch. You own narrow supporting calls to installed specialists: use \`@fixer\` for targeted implementation, \`@explorer\` for repository mapping and search, \`@plan\` for architecture or implementation planning, \`@designer\` for frontend, UI, and visual work, and \`@oracle\` for independent correctness and risk review when authorized. Inspect and incorporate returned findings yourself, then return implementation, evidence, and any required PR to Firstmate while preserving this brief's isolation, approval, and delivery rules."
 WEB_RESEARCH_RULE="9. For web research, use Firecrawl MCP first: call \`firecrawl_search\`, call \`firecrawl_search_feedback\` after using its results, and use \`firecrawl_scrape\` for known pages. If Firecrawl is unavailable, use another tool only as a fallback and disclose that fallback in your findings."
 REVIEW_PATH_RULE="10. Before pre-commit review, record the base and HEAD SHAs, then have the reviewer inspect the exact committed range with \`git diff <base>...<HEAD>\` and use \`git show <base>..<HEAD>\` for commit details; if the review tool cannot access those commits or shows an empty range, report the mismatch instead of reviewing it."
 
@@ -317,8 +317,8 @@ case "$MODE" in
 # Definition of done
 This project ships **direct-PR**: you raise the PR yourself, without the no-mistakes pipeline.
 The task is complete only when committed on your branch.
-Before pushing or requesting a PR, if this task or the captain requires an independent review, ask \`@oracle\` for a fresh read-only review of the complete diff and verification evidence.
-Resolve every finding and rerun affected checks; if that review is required but \`@oracle\` is unavailable, append \`blocked: {why}\` and stop without requesting a PR.
+Before pushing or requesting a PR, you must ask \`@oracle\` for a fresh read-only review of the complete committed range and verification evidence, using rule 10's exact base/HEAD commands.
+Resolve every finding and rerun affected checks; if \`@oracle\` is unavailable, append \`blocked: {why}\` and stop without requesting a PR.
 When it is implemented, reviewed, and committed, push your branch and open a PR with \`gh-axi\`, then append \`done: PR {url}\` to the status file and stop.
 Do NOT run /no-mistakes. The configured merge authority decides whether to merge the PR; firstmate relays the outcome.
 EOF

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -247,7 +247,12 @@ EOF
 HERDR_SECTION=${HERDR_SECTION%$'\n'}
 fi
 
-SPECIALIST_RULE="8. Standard implementation uses one \`antigravity/gemini-3.6-flash\` crewmate at high effort unless Firstmate explicitly overrides dispatch. You own narrow supporting calls to installed specialists: use \`@fixer\` for targeted implementation, \`@explorer\` for repository mapping and search, \`@plan\` for architecture or implementation planning, \`@designer\` for frontend, UI, and visual work, and \`@oracle\` for independent correctness and risk review when authorized. Inspect and incorporate returned findings yourself, then return implementation, evidence, and any required PR to Firstmate while preserving this brief's isolation, approval, and delivery rules."
+if [ "$KIND" = scout ]; then
+  SPECIALIST_RESULT="your findings and evidence"
+else
+  SPECIALIST_RESULT="implementation, evidence, and any required PR"
+fi
+SPECIALIST_RULE="8. Standard implementation uses one \`antigravity/gemini-3.6-flash\` crewmate at high effort unless Firstmate explicitly overrides dispatch. You own narrow supporting calls to installed specialists: use \`@fixer\` for targeted implementation, \`@explorer\` for repository mapping and search, \`@plan\` for architecture or implementation planning, \`@designer\` for frontend, UI, and visual work, and \`@oracle\` for independent correctness and risk review when authorized. Inspect and incorporate returned findings yourself, then return $SPECIALIST_RESULT to Firstmate while preserving this brief's isolation, approval, and delivery rules."
 WEB_RESEARCH_RULE="9. For web research, use Firecrawl MCP first: call \`firecrawl_search\`, call \`firecrawl_search_feedback\` after using its results, and use \`firecrawl_scrape\` for known pages. If Firecrawl is unavailable, use another tool only as a fallback and disclose that fallback in your findings."
 REVIEW_PATH_RULE="10. Before pre-commit review, record the base and HEAD SHAs, then have the reviewer inspect the exact committed range with \`git diff <base>...<HEAD>\` and use \`git show <base>..<HEAD>\` for commit details; if the review tool cannot access those commits or shows an empty range, report the mismatch instead of reviewing it."
 

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -247,9 +247,9 @@ EOF
 HERDR_SECTION=${HERDR_SECTION%$'\n'}
 fi
 
-SPECIALIST_RULE="8. When it would materially improve the result, delegate non-trivial supporting work narrowly to the appropriate installed specialist: use \`@explorer\` for repository mapping and search, \`@plan\` for architecture or implementation planning, \`@oracle\` for independent correctness and risk review, and \`@designer\` for frontend, UI, and visual work. Inspect and incorporate returned findings yourself, while preserving this brief's isolation, approval, and delivery rules."
+SPECIALIST_RULE="8. When it would materially improve the result, delegate non-trivial supporting work narrowly to the appropriate installed specialist: use \`@explorer\` for repository mapping and search, \`@plan\` for architecture or implementation planning, \`@oracle\` for explicitly authorized independent correctness and risk review, and \`@designer\` for frontend, UI, and visual work. Inspect and incorporate returned findings yourself, while preserving this brief's isolation, approval, and delivery rules."
 WEB_RESEARCH_RULE="9. For web research, use Firecrawl MCP first: call \`firecrawl_search\`, call \`firecrawl_search_feedback\` after using its results, and use \`firecrawl_scrape\` for known pages. If Firecrawl is unavailable, use another tool only as a fallback and disclose that fallback in your findings."
-REVIEW_PATH_RULE="10. Before pre-commit review, record the base and HEAD SHAs, then have the reviewer inspect the exact committed range with \`git show <HEAD>\` or \`git diff <base>...<HEAD>\`; if the review tool cannot access those commits or shows an empty range, report the mismatch instead of reviewing it."
+REVIEW_PATH_RULE="10. Before pre-commit review, record the base and HEAD SHAs, then have the reviewer inspect the exact committed range with \`git diff <base>...<HEAD>\` and use \`git show <base>..<HEAD>\` for commit details; if the review tool cannot access those commits or shows an empty range, report the mismatch instead of reviewing it."
 
 if [ "$KIND" = scout ]; then
 cat > "$BRIEF" <<EOF

--- a/bin/fm-project-mode.sh
+++ b/bin/fm-project-mode.sh
@@ -4,20 +4,20 @@
 # no-mistakes|direct-PR|local-only and yolo is on|off.
 #
 # Registry line format (data/projects.md):
-#   - <name> - <desc> (added <date>)                  -> no-mistakes off  (legacy default)
+#   - <name> - <desc> (added <date>)                  -> direct-PR on  (omitted mode default)
 #   - <name> [<mode>] - <desc> (added <date>)          -> <mode> off
 #   - <name> [<mode> +yolo] - <desc> (added <date>)    -> <mode> on
 #
 # mode = how a finished change reaches main:
-#   no-mistakes  full pipeline -> PR -> captain merge (default)
+#   no-mistakes  full pipeline -> PR -> captain merge
 #   direct-PR    push + PR via gh-axi, no pipeline -> captain merge
 #   local-only   local branch, no remote/PR -> captain approve -> guarded local merge
 # yolo (orthogonal) = when on, firstmate may make routine approval decisions itself.
 #   AGENTS.md section 7 is the single owner of authority exceptions, including
 #   ask-user contract expansion and stronger captain boundaries.
 #
-# An unknown/missing project or unknown mode falls back to "no-mistakes off" and warns
-# to stderr, so a typo never silently drops the gate.
+# An unknown/missing project or malformed explicit mode falls back to
+# "no-mistakes off" and warns to stderr, so uncertainty never drops the gate.
 # Usage: fm-project-mode.sh <project-name>
 set -eu
 
@@ -37,14 +37,25 @@ fi
 # awk emits "<mode> <yolo>" (one line) or nothing if the project is absent.
 parsed=$(awk -v n="$NAME" '
   $1=="-" && $2==n {
-    mode="no-mistakes"; yolo="off";
+    mode="direct-PR"; yolo="on";
     if ($3 ~ /^\[/) {
-      s="";
-      for (i=3; i<=NF; i++) { s = s (s==""?"":" ") $i; if ($i ~ /\]$/) break }
-      gsub(/^\[|\]$/, "", s);           # strip the surrounding brackets
-      k = split(s, a, " ");
-      if (a[1] != "" && a[1] != "+yolo") mode = a[1];
-      for (j=1; j<=k; j++) if (a[j]=="+yolo") yolo="on";
+      s=""; closed=0;
+      for (i=3; i<=NF; i++) {
+        s = s (s==""?"":" ") $i;
+        if ($i ~ /\]$/) { closed=1; break }
+      }
+      if (!closed) { print "invalid"; exit }
+      gsub(/^\[/, "", s); gsub(/\]$/, "", s);
+      k = split(s, a, " "); valid=1;
+      if (k < 1 || a[1] == "") valid=0;
+      if (a[1] !~ /^(no-mistakes|direct-PR|local-only)$/) valid=0;
+      else mode=a[1];
+      yolo="off";
+      for (j=2; j<=k; j++) {
+        if (a[j] == "+yolo" && yolo == "off") yolo="on";
+        else valid=0;
+      }
+      if (!valid) { print "invalid"; exit }
     }
     print mode, yolo; exit
   }
@@ -52,6 +63,12 @@ parsed=$(awk -v n="$NAME" '
 
 if [ -z "$parsed" ]; then
   echo "warn: project \"$NAME\" not in registry; defaulting to no-mistakes off" >&2
+  echo "no-mistakes off"
+  exit 0
+fi
+
+if [ "$parsed" = invalid ]; then
+  echo "warn: malformed mode for $NAME; defaulting to no-mistakes off" >&2
   echo "no-mistakes off"
   exit 0
 fi

--- a/bin/fm-project-mode.sh
+++ b/bin/fm-project-mode.sh
@@ -38,6 +38,7 @@ fi
 parsed=$(awk -v n="$NAME" '
   $1=="-" && $2==n {
     mode="direct-PR"; yolo="on";
+    if ($3 != "-" && $3 !~ /^\[/) { print "invalid"; exit }
     if ($3 ~ /^\[/) {
       s=""; closed=0;
       for (i=3; i<=NF; i++) {

--- a/bin/fm-project-mode.sh
+++ b/bin/fm-project-mode.sh
@@ -45,7 +45,7 @@ parsed=$(awk -v n="$NAME" '
         s = s (s==""?"":" ") $i;
         if ($i ~ /\]$/) { closed=1; break }
       }
-      if (!closed) { print "invalid"; exit }
+      if (!closed || i >= NF || $(i+1) != "-") { print "invalid"; exit }
       gsub(/^\[/, "", s); gsub(/\]$/, "", s);
       k = split(s, a, " "); valid=1;
       if (k < 1 || a[1] == "") valid=0;

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -192,7 +192,7 @@ assert_specialist_rule() {
   local brief=$1 context=$2
   assert_grep "When it would materially improve the result, delegate non-trivial supporting work narrowly to the appropriate installed specialist" "$brief" \
     "$context brief missing specialist delegation rule"
-  assert_grep "use \`@explorer\` for repository mapping and search, \`@plan\` for architecture or implementation planning, \`@oracle\` for independent correctness and risk review, and \`@designer\` for frontend, UI, and visual work." "$brief" \
+  assert_grep "use \`@explorer\` for repository mapping and search, \`@plan\` for architecture or implementation planning, \`@oracle\` for explicitly authorized independent correctness and risk review, and \`@designer\` for frontend, UI, and visual work." "$brief" \
     "$context brief missing specialist selection guidance"
   assert_grep "Inspect and incorporate returned findings yourself, while preserving this brief's isolation, approval, and delivery rules." "$brief" \
     "$context brief missing delegation boundary guidance"
@@ -208,7 +208,7 @@ assert_web_research_rule() {
 
 assert_review_path_rule() {
   local brief=$1 context=$2
-  assert_grep "Before pre-commit review, record the base and HEAD SHAs, then have the reviewer inspect the exact committed range with \`git show <HEAD>\` or \`git diff <base>...<HEAD>\`" "$brief" \
+  assert_grep "Before pre-commit review, record the base and HEAD SHAs, then have the reviewer inspect the exact committed range with \`git diff <base>...<HEAD>\` and use \`git show <base>..<HEAD>\` for commit details" "$brief" \
     "$context brief missing committed-range review verification"
   assert_grep "if the review tool cannot access those commits or shows an empty range, report the mismatch instead of reviewing it." "$brief" \
     "$context brief missing committed-range mismatch handling"

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -215,7 +215,7 @@ assert_review_path_rule() {
 }
 
 test_project_mode_defaults_and_rejects_malformed() {
-  local home out brief
+  local home out brief err
   home="$TMP_ROOT/project-mode-home"
   mkdir -p "$home/data"
   cat > "$home/data/projects.md" <<'EOF'
@@ -224,6 +224,7 @@ test_project_mode_defaults_and_rejects_malformed() {
 - malformed-proj [bogus +yolo] - malformed mode (added 2026-07-01)
 - malformed-yolo-proj [+yolo] - missing explicit mode (added 2026-07-01)
 - malformed-extra-proj [direct-PR +yolo unexpected] - malformed option (added 2026-07-01)
+- malformed-third-proj unexpected - malformed third token (added 2026-07-01)
 EOF
   out=$(FM_HOME="$home" "$ROOT/bin/fm-project-mode.sh" omitted-proj)
   [ "$out" = "direct-PR on" ] || fail "omitted delivery mode did not default to direct-PR on"
@@ -235,6 +236,11 @@ EOF
   [ "$out" = "no-mistakes off" ] || fail "malformed [+yolo] mode did not fall back to no-mistakes off"
   out=$(FM_HOME="$home" "$ROOT/bin/fm-project-mode.sh" malformed-extra-proj 2>/dev/null)
   [ "$out" = "no-mistakes off" ] || fail "malformed explicit option did not fall back to no-mistakes off"
+  err="$home/malformed-third.err"
+  out=$(FM_HOME="$home" "$ROOT/bin/fm-project-mode.sh" malformed-third-proj 2>"$err")
+  [ "$out" = "no-mistakes off" ] || fail "malformed third token did not fall back to no-mistakes off"
+  grep -F 'malformed mode' "$err" >/dev/null \
+    || fail "malformed third token did not emit a warning"
   FM_HOME="$home" "$ROOT/bin/fm-brief.sh" omitted-brief omitted-proj >/dev/null
   brief="$home/data/omitted-brief/brief.md"
   assert_grep "This project ships **direct-PR**" "$brief" \

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -189,12 +189,17 @@ EOF
 }
 
 assert_specialist_rule() {
-  local brief=$1 context=$2
+  local brief=$1 context=$2 expected_return
+  if [ "$context" = scout ]; then
+    expected_return="your findings and evidence"
+  else
+    expected_return="implementation, evidence, and any required PR"
+  fi
   assert_grep "Standard implementation uses one \`antigravity/gemini-3.6-flash\` crewmate at high effort unless Firstmate explicitly overrides dispatch." "$brief" \
     "$context brief missing standard crewmate dispatch"
   assert_grep "You own narrow supporting calls to installed specialists: use \`@fixer\` for targeted implementation, \`@explorer\` for repository mapping and search, \`@plan\` for architecture or implementation planning, \`@designer\` for frontend, UI, and visual work, and \`@oracle\` for independent correctness and risk review when authorized." "$brief" \
     "$context brief missing worker-owned specialist routing"
-  assert_grep "Inspect and incorporate returned findings yourself, then return implementation, evidence, and any required PR to Firstmate while preserving this brief's isolation, approval, and delivery rules." "$brief" \
+  assert_grep "Inspect and incorporate returned findings yourself, then return $expected_return to Firstmate while preserving this brief's isolation, approval, and delivery rules." "$brief" \
     "$context brief missing delegation boundary guidance"
   assert_no_grep "lelouch" "$brief" "$context brief must not add an automatic Lelouch review"
 }
@@ -225,6 +230,7 @@ test_project_mode_defaults_and_rejects_malformed() {
 - malformed-proj [bogus +yolo] - malformed mode (added 2026-07-01)
 - malformed-yolo-proj [+yolo] - missing explicit mode (added 2026-07-01)
 - malformed-extra-proj [direct-PR +yolo unexpected] - malformed option (added 2026-07-01)
+- malformed-trailing-proj [direct-PR +yolo] unexpected - malformed trailing token (added 2026-07-01)
 - malformed-third-proj unexpected - malformed third token (added 2026-07-01)
 EOF
   out=$(FM_HOME="$home" "$ROOT/bin/fm-project-mode.sh" omitted-proj)
@@ -237,6 +243,8 @@ EOF
   [ "$out" = "no-mistakes off" ] || fail "malformed [+yolo] mode did not fall back to no-mistakes off"
   out=$(FM_HOME="$home" "$ROOT/bin/fm-project-mode.sh" malformed-extra-proj 2>/dev/null)
   [ "$out" = "no-mistakes off" ] || fail "malformed explicit option did not fall back to no-mistakes off"
+  out=$(FM_HOME="$home" "$ROOT/bin/fm-project-mode.sh" malformed-trailing-proj 2>/dev/null)
+  [ "$out" = "no-mistakes off" ] || fail "malformed trailing token did not fall back to no-mistakes off"
   err="$home/malformed-third.err"
   out=$(FM_HOME="$home" "$ROOT/bin/fm-project-mode.sh" malformed-third-proj 2>"$err")
   [ "$out" = "no-mistakes off" ] || fail "malformed third token did not fall back to no-mistakes off"

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -190,12 +190,13 @@ EOF
 
 assert_specialist_rule() {
   local brief=$1 context=$2
-  assert_grep "When it would materially improve the result, delegate non-trivial supporting work narrowly to the appropriate installed specialist" "$brief" \
-    "$context brief missing specialist delegation rule"
-  assert_grep "use \`@explorer\` for repository mapping and search, \`@plan\` for architecture or implementation planning, \`@oracle\` for explicitly authorized independent correctness and risk review, and \`@designer\` for frontend, UI, and visual work." "$brief" \
-    "$context brief missing specialist selection guidance"
-  assert_grep "Inspect and incorporate returned findings yourself, while preserving this brief's isolation, approval, and delivery rules." "$brief" \
+  assert_grep "Standard implementation uses one \`antigravity/gemini-3.6-flash\` crewmate at high effort unless Firstmate explicitly overrides dispatch." "$brief" \
+    "$context brief missing standard crewmate dispatch"
+  assert_grep "You own narrow supporting calls to installed specialists: use \`@fixer\` for targeted implementation, \`@explorer\` for repository mapping and search, \`@plan\` for architecture or implementation planning, \`@designer\` for frontend, UI, and visual work, and \`@oracle\` for independent correctness and risk review when authorized." "$brief" \
+    "$context brief missing worker-owned specialist routing"
+  assert_grep "Inspect and incorporate returned findings yourself, then return implementation, evidence, and any required PR to Firstmate while preserving this brief's isolation, approval, and delivery rules." "$brief" \
     "$context brief missing delegation boundary guidance"
+  assert_no_grep "lelouch" "$brief" "$context brief must not add an automatic Lelouch review"
 }
 
 assert_web_research_rule() {
@@ -288,8 +289,8 @@ test_faster_paths_use_configured_authority_without_stacked_review() {
   brief="$home/data/$id/brief.md"
   assert_grep "The configured merge authority decides whether to merge the PR; firstmate relays the outcome." "$brief" \
     "direct-PR brief lost configured merge authority"
-  assert_grep "Before pushing or requesting a PR, if this task or the captain requires an independent review, ask \`@oracle\` for a fresh read-only review" "$brief" \
-    "direct-PR brief lost its Oracle review guidance"
+  assert_grep "Before pushing or requesting a PR, you must ask \`@oracle\` for a fresh read-only review of the complete committed range and verification evidence, using rule 10's exact base/HEAD commands." "$brief" \
+    "direct-PR brief lost its mandatory exact-range Oracle review"
   assert_no_grep "The captain reviews and merges the PR" "$brief" \
     "direct-PR brief hard-coded captain-only authority"
   id="brief-local-authority-a4"

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -282,8 +282,8 @@ test_faster_paths_use_configured_authority_without_stacked_review() {
   brief="$home/data/$id/brief.md"
   assert_grep "The configured merge authority decides whether to merge the PR; firstmate relays the outcome." "$brief" \
     "direct-PR brief lost configured merge authority"
-  assert_grep "Before pushing or requesting a PR, ask \`@oracle\` for a fresh read-only review" "$brief" \
-    "direct-PR brief lost its Oracle review gate"
+  assert_grep "Before pushing or requesting a PR, if this task or the captain requires an independent review, ask \`@oracle\` for a fresh read-only review" "$brief" \
+    "direct-PR brief lost its Oracle review guidance"
   assert_no_grep "The captain reviews and merges the PR" "$brief" \
     "direct-PR brief hard-coded captain-only authority"
   id="brief-local-authority-a4"

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -188,6 +188,62 @@ write_registry() {
 EOF
 }
 
+assert_specialist_rule() {
+  local brief=$1 context=$2
+  assert_grep "When it would materially improve the result, delegate non-trivial supporting work narrowly to the appropriate installed specialist" "$brief" \
+    "$context brief missing specialist delegation rule"
+  assert_grep "use \`@explorer\` for repository mapping and search, \`@plan\` for architecture or implementation planning, \`@oracle\` for independent correctness and risk review, and \`@designer\` for frontend, UI, and visual work." "$brief" \
+    "$context brief missing specialist selection guidance"
+  assert_grep "Inspect and incorporate returned findings yourself, while preserving this brief's isolation, approval, and delivery rules." "$brief" \
+    "$context brief missing delegation boundary guidance"
+}
+
+assert_web_research_rule() {
+  local brief=$1 context=$2
+  assert_grep "For web research, use Firecrawl MCP first: call \`firecrawl_search\`, call \`firecrawl_search_feedback\` after using its results, and use \`firecrawl_scrape\` for known pages." "$brief" \
+    "$context brief missing Firecrawl MCP routing rule"
+  assert_grep "If Firecrawl is unavailable, use another tool only as a fallback and disclose that fallback in your findings." "$brief" \
+    "$context brief missing Firecrawl fallback disclosure"
+}
+
+assert_review_path_rule() {
+  local brief=$1 context=$2
+  assert_grep "Before pre-commit review, record the base and HEAD SHAs, then have the reviewer inspect the exact committed range with \`git show <HEAD>\` or \`git diff <base>...<HEAD>\`" "$brief" \
+    "$context brief missing committed-range review verification"
+  assert_grep "if the review tool cannot access those commits or shows an empty range, report the mismatch instead of reviewing it." "$brief" \
+    "$context brief missing committed-range mismatch handling"
+}
+
+test_project_mode_defaults_and_rejects_malformed() {
+  local home out brief
+  home="$TMP_ROOT/project-mode-home"
+  mkdir -p "$home/data"
+  cat > "$home/data/projects.md" <<'EOF'
+- omitted-proj - omitted mode (added 2026-07-01)
+- explicit-proj [direct-PR] - explicit mode (added 2026-07-01)
+- malformed-proj [bogus +yolo] - malformed mode (added 2026-07-01)
+- malformed-yolo-proj [+yolo] - missing explicit mode (added 2026-07-01)
+- malformed-extra-proj [direct-PR +yolo unexpected] - malformed option (added 2026-07-01)
+EOF
+  out=$(FM_HOME="$home" "$ROOT/bin/fm-project-mode.sh" omitted-proj)
+  [ "$out" = "direct-PR on" ] || fail "omitted delivery mode did not default to direct-PR on"
+  out=$(FM_HOME="$home" "$ROOT/bin/fm-project-mode.sh" explicit-proj)
+  [ "$out" = "direct-PR off" ] || fail "explicit delivery mode did not preserve yolo off"
+  out=$(FM_HOME="$home" "$ROOT/bin/fm-project-mode.sh" malformed-proj 2>/dev/null)
+  [ "$out" = "no-mistakes off" ] || fail "malformed explicit mode did not fall back to no-mistakes off"
+  out=$(FM_HOME="$home" "$ROOT/bin/fm-project-mode.sh" malformed-yolo-proj 2>/dev/null)
+  [ "$out" = "no-mistakes off" ] || fail "malformed [+yolo] mode did not fall back to no-mistakes off"
+  out=$(FM_HOME="$home" "$ROOT/bin/fm-project-mode.sh" malformed-extra-proj 2>/dev/null)
+  [ "$out" = "no-mistakes off" ] || fail "malformed explicit option did not fall back to no-mistakes off"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" omitted-brief omitted-proj >/dev/null
+  brief="$home/data/omitted-brief/brief.md"
+  assert_grep "This project ships **direct-PR**" "$brief" \
+    "omitted mode brief did not use direct-PR delivery"
+  assert_no_grep "This project ships **no-mistakes**" "$brief" \
+    "omitted mode brief used no-mistakes delivery"
+  pass "fm-project-mode: omitted mode defaults to direct-PR on and malformed modes fall back safely"
+}
+
 # fm-brief.sh must exit 0 and produce a brief with no unreplaced shell
 # metacharacter corruption for every ship delivery mode. This also guards
 # against any *new* unescaped apostrophe or unbalanced quote later added to
@@ -209,6 +265,9 @@ test_ship_modes_generate_clean_briefs() {
     assert_grep "{TASK}" "$brief" "$id: brief missing the {TASK} placeholder"
     assert_grep "mid-task \`working:\` line (including setup complete) is nonterminal" "$brief" \
       "$id: brief missing nonterminal working:/setup-complete gate protection"
+    assert_specialist_rule "$brief" "$id"
+    assert_web_research_rule "$brief" "$id"
+    assert_review_path_rule "$brief" "$id"
     assert_no_grep "EOF" "$brief" "$id: brief leaked a heredoc EOF marker (unterminated heredoc)"
   done
   pass "fm-brief.sh: no-mistakes/direct-PR/local-only briefs generate cleanly"
@@ -223,6 +282,8 @@ test_faster_paths_use_configured_authority_without_stacked_review() {
   brief="$home/data/$id/brief.md"
   assert_grep "The configured merge authority decides whether to merge the PR; firstmate relays the outcome." "$brief" \
     "direct-PR brief lost configured merge authority"
+  assert_grep "Before pushing or requesting a PR, ask \`@oracle\` for a fresh read-only review" "$brief" \
+    "direct-PR brief lost its Oracle review gate"
   assert_no_grep "The captain reviews and merges the PR" "$brief" \
     "direct-PR brief hard-coded captain-only authority"
   id="brief-local-authority-a4"
@@ -275,7 +336,9 @@ test_no_mistakes_dod_wording() {
   # guards the structure that makes it safe.
   assert_grep "firstmate's authority check" "$brief" \
     "no-mistakes DOD lost the apostrophe prose that the structural fix makes parse-safe"
-  pass "fm-brief.sh: no-mistakes DOD keeps its apostrophe prose, now parse-safe"
+  assert_no_grep "Before pushing or requesting a PR" "$brief" \
+    "no-mistakes brief must not add the direct-PR Oracle review gate"
+  pass "fm-brief.sh: no-mistakes DOD keeps its apostrophe prose without a direct-PR Oracle gate"
 }
 
 test_ship_project_memory_wording() {
@@ -621,6 +684,9 @@ test_scout_and_secondmate_scaffold() {
   assert_present "$brief" "scout brief was not scaffolded"
   assert_grep "SCOUT task" "$brief" "scout brief must declare itself a scout task"
   assert_grep "report.md" "$brief" "scout brief must point at the report deliverable"
+  assert_specialist_rule "$brief" "scout"
+  assert_web_research_rule "$brief" "scout"
+  assert_review_path_rule "$brief" "scout"
 
   FM_SECONDMATE_CHARTER='Supervise the alpha domain.' \
     FM_HOME="$BRIEF_HOME" "$ROOT/bin/fm-brief.sh" brief-sm-q6 --secondmate alpha >/dev/null 2>&1 \
@@ -633,6 +699,7 @@ test_scout_and_secondmate_scaffold() {
 }
 
 test_script_parses
+test_project_mode_defaults_and_rejects_malformed
 test_no_heredoc_in_command_substitution
 test_help_includes_entire_header
 test_ship_modes_generate_clean_briefs

--- a/tests/fm-secondmate-lifecycle-e2e.test.sh
+++ b/tests/fm-secondmate-lifecycle-e2e.test.sh
@@ -51,7 +51,7 @@ setup_world() {
   cat > "$HOME_DIR/data/projects.md" <<EOF
 - alpha [direct-PR +yolo] - alpha project (added 2026-06-22)
 - beta [direct-PR] - beta project (added 2026-06-22)
-- gamma - gamma project (added 2026-06-22)
+- gamma [no-mistakes] - gamma project (added 2026-06-22)
 EOF
   ALPHA_ORIGIN=$(git -C "$HOME_DIR/projects/alpha" remote get-url origin)
   BETA_ORIGIN=$(git -C "$HOME_DIR/projects/beta" remote get-url origin)

--- a/tests/fm-secondmate-safety.test.sh
+++ b/tests/fm-secondmate-safety.test.sh
@@ -1132,7 +1132,7 @@ test_home_seed_skips_initialized_existing_no_mistakes_projects() {
   origin=$(git -C "$home/projects/alpha" remote get-url origin)
   git clone --quiet "$origin" "$subhome/projects/alpha"
   git -C "$subhome/projects/alpha" remote add no-mistakes "$TMP_ROOT/no-mistakes-alpha.git"
-  printf '%s\n' '- alpha - alpha project (added 2026-06-22)' '- beta - beta project (added 2026-06-22)' > "$home/data/projects.md"
+  printf '%s\n' '- alpha [no-mistakes] - alpha project (added 2026-06-22)' '- beta [no-mistakes] - beta project (added 2026-06-22)' > "$home/data/projects.md"
   fakebin=$(make_recording_no_mistakes "$TMP_ROOT/existing-initialized-fake")
   : > "$log"
 
@@ -1164,7 +1164,7 @@ test_home_seed_refuses_uninitialized_existing_no_mistakes_project() {
   mkdir -p "$subhome/projects"
   origin=$(git -C "$home/projects/alpha" remote get-url origin)
   git clone --quiet "$origin" "$subhome/projects/alpha"
-  printf '%s\n' '- alpha - alpha project (added 2026-06-22)' > "$home/data/projects.md"
+  printf '%s\n' '- alpha [no-mistakes] - alpha project (added 2026-06-22)' > "$home/data/projects.md"
   fakebin=$(make_recording_no_mistakes "$TMP_ROOT/existing-uninitialized-fake")
   : > "$log"
 


### PR DESCRIPTION
## Summary
- Route narrow fixer, explorer, plan, designer, and Oracle support through the single standard `antigravity/gemini-3.6-flash` high-effort crewmate.
- Route Firecrawl MCP web research and committed-range review guidance in generated ship/scout briefs.
- Require worker-owned exact-range Oracle review before direct-PR push or PR request; keep no-mistakes opt-in without that gate.
- Keep omitted project modes at `direct-PR +yolo` and reject malformed explicit modes safely.
- Keep post-PR Lelouch review out of generated briefs and optional for Firstmate to request.

## Verification
- `bash tests/fm-brief.test.sh`
- `bash tests/fm-secondmate-safety.test.sh`
- `bash tests/fm-secondmate-lifecycle-e2e.test.sh`
- `bin/fm-lint.sh`
- `git diff --check`
- Oracle reviewed exact range `1e247571aa75e00b00c7a01c4830025ecd44dc61...e9682bb9b9d72c024ea47d1d525051a23ea90521`: CLEAN.
