### PR TITLE
fix: close crewmate brief status-reporting gaps

### DIFF
--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -48,10 +48,9 @@
 # Every scaffold's status protocol distinguishes the configured
 # declared-external-wait verb (FM_CLASSIFY_PAUSED_VERB, default "paused") from
 # "blocked:": pause for a known external wait expected to clear on its own,
-# blocked when firstmate must act. It also keeps the crewmate's latest line a
-# readable current state: park with the pause verb and resume with "working:"
-# around a backgrounded pipeline call, and never end on a stateless "resolved:"
-# line, which otherwise reads as no state at all. Under no-mistakes, "done:"
+# blocked when firstmate must act. Ship and scout briefs also require a readable
+# current state after "resolved:". Ship briefs pair the pause verb with
+# "working:" around backgrounded pipeline calls. Under no-mistakes, "done:"
 # means the PR is open with checks green, so the implementation handoff before
 # validation is a declared wait rather than a second "done:".
 # Ship tasks include a project-memory section so durable project-intrinsic

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -48,7 +48,12 @@
 # Every scaffold's status protocol distinguishes the configured
 # declared-external-wait verb (FM_CLASSIFY_PAUSED_VERB, default "paused") from
 # "blocked:": pause for a known external wait expected to clear on its own,
-# blocked when firstmate must act.
+# blocked when firstmate must act. It also keeps the crewmate's latest line a
+# readable current state: park with the pause verb and resume with "working:"
+# around a backgrounded pipeline call, and never end on a stateless "resolved:"
+# line, which otherwise reads as no state at all. Under no-mistakes, "done:"
+# means the PR is open with checks green, so the implementation handoff before
+# validation is a declared wait rather than a second "done:".
 # Ship tasks include a project-memory section so durable project-intrinsic
 # learnings can be committed to AGENTS.md through the project's delivery path;
 # it carries the AGENTS.md authoring bar (widely useful knowledge only, pointers
@@ -330,6 +335,9 @@ The report is the only thing that survives, so anything worth keeping must be in
 6. If a decision belongs to a human (product choices, destructive actions),
    append \`needs-decision: {summary of options}\` and stop. Firstmate will reply with the decision.
    When firstmate replies or a blocker clears and you resume, append \`resolved: {how it was decided or unblocked}\` (add the same \`[key=<slug>]\` if you opened it with one) so the decision or blocker is durably closed and does not keep resurfacing.
+   \`resolved:\` carries NO state, so it must never be your last line: append the next state line
+   (normally \`working:\`) in the same breath. A trailing \`resolved:\` makes you read as no state at
+   all - invisible to firstmate and indistinguishable from a dead worker, which is worse than stale.
 7. Never stop, restart, or update the shared \`no-mistakes\` daemon - it is one instance serving
    every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
    daemon error, append \`blocked: {the daemon error}\` and stop; only firstmate manages the daemon.
@@ -382,14 +390,16 @@ EOF
     IFS= read -r -d '' DOD <<EOF || true
 # Definition of done
 Delivery contract: mode=no-mistakes
+This project ships **no-mistakes**: \`done:\` means the PR is open with its checks green.
+A clean local commit is NOT done, and neither is your own test run passing - this task has exactly one \`done:\` line and it is the last one, \`done: PR {url} checks green\`.
 The task is complete only when committed on your branch.
-When you believe it is complete, append \`done: {summary}\` to the status file and stop.
-Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.
+When you believe implementation is complete, append \`$PAUSED_VERB: implemented and committed, ready to validate\` and stop there; that handoff is a defined stopping point and a declared wait, and firstmate will then instruct you to run /no-mistakes to validate and ship a PR.
 
 You drive no-mistakes by responding to its gates, not by implementing fixes.
 Follow the guidance no-mistakes itself provides for the mechanics: it loads when you invoke /no-mistakes, and \`no-mistakes axi run --help\` plus the \`help\` lines in each \`axi\` response are authoritative and version-matched to the installed binary.
 When starting no-mistakes, make \`--intent\` preserve all relevant content from this brief's \`# Task\` section plus every later accepted Firstmate requirement, clarification, constraint, exclusion, and supersession, carrying only each requirement's current accepted form; retain direct requirements instead of substituting a diff summary, and exclude generic operational, status, delivery, and other scaffold boilerplate unless it is task-specific.
 Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix.
+While you sit parked on a backgrounded \`axi run\` or \`axi respond\` call, rule 4's park-and-resume pairing applies: append \`$PAUSED_VERB:\` before you go idle and \`working:\` when the call returns.
 
 Two firstmate-specific rules layer on top of that guidance:
 - ask-user findings are never yours to answer: escalate to firstmate (rule 6) and stop.
@@ -435,16 +445,24 @@ $RULE1
    would act on (setup done, bug reproduced, fix implemented, validation passed) and the
    needs-decision/blocked/paused/done/failed states. No step-by-step FYI progress lines;
    firstmate reads your pane for that.
+   Your LATEST line is your entire visible state, so never leave a stale or stateless one standing.
    A mid-task \`working:\` line (including setup complete) is nonterminal: do not end the
-   turn after it; continue the same stage until a defined \`done:\` gate under Definition of done.
+   turn after it; continue the same stage until a stopping point defined under Definition of done.
    Use \`$PAUSED_VERB: {why}\` - distinct from \`blocked:\` - ONLY when you are deliberately idling on a
    known external wait you expect to clear on its own (an upstream release, a rate-limit reset,
-   a scheduled window): firstmate then leaves your idle pane alone and rechecks it on a long
-   cadence instead of treating it as a possible wedge. Use \`blocked:\` when you are stuck and need help.
+   a scheduled window, a backgrounded call you are parked on): firstmate then leaves your idle pane
+   alone and rechecks it on a long cadence instead of treating it as a possible wedge.
+   Park-and-resume pairing: whenever you background a pipeline call and go idle, append
+   \`$PAUSED_VERB:\` BEFORE going idle and \`working:\` as soon as it returns - otherwise a spent
+   \`needs-decision:\` stays standing and firstmate reads you as still waiting on a decision it
+   already answered. Use \`blocked:\` when you are stuck and need help.
 5. If you hit the same obstacle twice, append \`blocked: {why}\` and stop; firstmate will help.
 6. If a decision belongs above the implementation worker (product choices, destructive actions, ask-user findings),
    append \`needs-decision: {summary of options}\` and stop. Firstmate will apply the configured authority and reply with the decision.
    When firstmate replies or a blocker clears and you resume, append \`resolved: {how it was decided or unblocked}\` (add the same \`[key=<slug>]\` if you opened it with one) so the decision or blocker is durably closed and does not keep resurfacing.
+   \`resolved:\` carries NO state, so it must never be your last line: append the next state line
+   (normally \`working:\`) in the same breath. A trailing \`resolved:\` makes you read as no state at
+   all - invisible to firstmate and indistinguishable from a dead worker, which is worse than stale.
 7. Never stop, restart, or update the shared \`no-mistakes\` daemon - it is one instance serving
    every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
    daemon error, append \`blocked: {the daemon error}\` and stop; only firstmate manages the daemon.

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -256,7 +256,7 @@ test_ship_mode_is_explicit_not_registry() {
   brief="$home/data/brief-explicit-a5/brief.md"
   grep -qx "Delivery contract: mode=no-mistakes" "$brief" \
     || fail "registered direct-PR posture overrode the explicit --mode"
-  assert_grep "Firstmate will then instruct you to run /no-mistakes" "$brief" \
+  assert_grep "firstmate will then instruct you to run /no-mistakes" "$brief" \
     "explicit no-mistakes brief did not render the pipeline definition of done"
 
   # An unregistered project is not a blocker either, because nothing is looked up.

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -319,6 +319,71 @@ test_faster_paths_use_configured_authority_without_stacked_review() {
   pass "fm-brief.sh: faster paths use configured authority without stacked review"
 }
 
+# Three status-reporting gaps observed across five crewmates in one session:
+# (1) no-mistakes workers appended done: after their own tests passed, before the
+# pipeline ran; (2) workers parked on a backgrounded pipeline call left a spent
+# needs-decision: line standing, so supervision read them as awaiting an answered
+# decision while the quiet pane raised stale alarms; (3) a trailing keyed
+# resolved: line leaves no state verb at all, so a healthy worker reads as
+# unknown and becomes indistinguishable from a dead one. All three are scaffold
+# defects, so the generated contract - not steering - has to close them.
+test_status_protocol_closes_reporting_gaps() {
+  local home id brief scout
+  home="$TMP_ROOT/status-gaps-home"
+  mkdir -p "$home/data"
+  id="brief-status-gaps-d1"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --mode no-mistakes >/dev/null 2>&1
+  brief="$home/data/$id/brief.md"
+  assert_present "$brief" "brief was not scaffolded"
+
+  # Gap 1: done: under no-mistakes means PR open with checks green, never a
+  # clean local commit, and the interim handoff must not be spelled done:.
+  # shellcheck disable=SC2016 # Literal backticks and braces must remain unexpanded.
+  assert_grep 'ships **no-mistakes**: `done:` means the PR is open with its checks green' "$brief" \
+    "no-mistakes DOD must define done: as PR open with checks green"
+  assert_grep 'A clean local commit is NOT done' "$brief" \
+    "no-mistakes DOD must reject a clean local commit as done"
+  # shellcheck disable=SC2016 # Literal backticks and braces must remain unexpanded.
+  assert_grep 'exactly one `done:` line and it is the last one, `done: PR {url} checks green`' "$brief" \
+    "no-mistakes DOD must pin the single terminal done: line"
+  # shellcheck disable=SC2016 # Literal backticks and braces must remain unexpanded.
+  assert_no_grep 'append `done: {summary}`' "$brief" \
+    "no-mistakes DOD still tells the worker to report done before the pipeline runs"
+  # shellcheck disable=SC2016 # Literal backticks must remain unexpanded.
+  assert_grep 'append `paused: implemented and committed, ready to validate`' "$brief" \
+    "no-mistakes DOD lost the declared-wait handoff before validation"
+
+  # Gap 2: park-and-resume around a backgrounded pipeline call.
+  assert_grep 'Park-and-resume pairing: whenever you background a pipeline call and go idle' "$brief" \
+    "status protocol lost the park-and-resume rule"
+  # shellcheck disable=SC2016 # Literal backticks must remain unexpanded.
+  assert_grep '`paused:` BEFORE going idle and `working:` as soon as it returns' "$brief" \
+    "status protocol must pair paused: while parked with working: on return"
+  # shellcheck disable=SC2016 # Literal backticks must remain unexpanded.
+  assert_grep '`needs-decision:` stays standing and firstmate reads you as still waiting' "$brief" \
+    "status protocol must explain the spent needs-decision: misreading"
+  # shellcheck disable=SC2016 # Literal backticks must remain unexpanded.
+  assert_grep 'While you sit parked on a backgrounded `axi run` or `axi respond` call' "$brief" \
+    "no-mistakes DOD lost the park-and-resume reminder at the pipeline gate"
+
+  # Gap 3: resolved: carries no state, so it must never be the last line.
+  # This is the highest-value gap: it makes a healthy worker invisible.
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id-scout" some-proj --scout >/dev/null 2>&1
+  scout="$home/data/$id-scout/brief.md"
+  assert_present "$scout" "scout brief was not scaffolded"
+  local generated
+  for generated in "$brief" "$scout"; do
+    # shellcheck disable=SC2016 # Literal backticks must remain unexpanded.
+    assert_grep '`resolved:` carries NO state, so it must never be your last line' "$generated" \
+      "$generated: contract must forbid a trailing stateless resolved: line"
+    assert_grep 'append the next state line' "$generated" \
+      "$generated: contract must require a state line after resolved:"
+    assert_grep 'invisible to firstmate and indistinguishable from a dead worker' "$generated" \
+      "$generated: contract must state the invisibility consequence of a trailing resolved:"
+  done
+  pass "fm-brief.sh: status protocol closes the done:/park/resolved: reporting gaps"
+}
+
 # Pin the specific line the bug lived on: the no-mistakes DOD's no-mistakes
 # reference must render as plain prose with no dangling apostrophe artifact.
 test_no_mistakes_dod_wording() {
@@ -717,6 +782,7 @@ test_ship_mode_is_explicit_not_registry
 test_delivery_flags_are_refused_where_they_do_not_apply
 test_faster_paths_use_configured_authority_without_stacked_review
 test_no_mistakes_dod_wording
+test_status_protocol_closes_reporting_gaps
 test_ship_project_memory_wording
 test_herdr_lab_contract_is_explicit_and_complete
 test_herdr_lab_contract_quotes_foreign_firstmate_path


### PR DESCRIPTION
## Intent

Fix three status-reporting gaps in the crewmate brief scaffold produced by bin/fm-brief.sh. All three were observed across five crewmates in one session on 2026-07-28 and are brief-scaffold problems, not worker problems, so the fix belongs in the generated contract rather than in steering.

Gap 1 - premature done: four separate no-mistakes workers appended done: after their own tests passed, without running the pipeline; one worker's own recap read 'Next: run /no-mistakes to validate and ship the PR' while its status already said done. The scaffold must make it unmissable that under no-mistakes, done means PR open with checks green, never a clean local commit.

Gap 2 - stale status while parked on a backgrounded pipeline call: workers background the respond call, go idle, and leave the previous needs-decision: line standing, so supervision reads them as blocked on a decision already given while the quiet pane raises a stale alarm about once a minute. The remedy that worked: append paused: while parked and switch back to working: when it returns.

Gap 3 (highest value) - a bare resolved: line leaves no readable state: bin/fm-crew-state.sh returns 'state: unknown, source: none' for a healthy worker whose latest line is a keyed resolved: event, because that verb carries no state. The worker becomes invisible rather than merely misreported and is indistinguishable from a dead endpoint. It recurred twice on 2026-08-01 (tasks tsa-396-postgres-flow-sources and arkrh-corpus-types-unbound-unconstructible), where the run lookup also returned nothing so both sources failed at once. Rule: always follow resolved: with a state line.

Accepted approach and constraints: change the generated contract so the correct behavior is the obvious one, sharpening the existing status-protocol section rather than appending a new section or a wall of prose a worker would skim past; cover each of the three with a test against the generated brief text so a future scaffold edit cannot silently drop them; do not weaken or remove any existing safety clause, especially the worktree-isolation assertion.

Explicit scope boundary: this is the scaffold/contract side only. A separate concurrent task, fm-crew-state-blind-during-fix-round, fixes the reader side in bin/fm-crew-state.sh, so bin/fm-crew-state.sh and bin/fm-classify-lib.sh must not be edited here; keeping the two diffs disjoint matters because two branches touching the same files already collided once tonight. If the reader must change, that is escalated rather than implemented here.

Implementation decisions made while doing the work: the pre-validation handoff under no-mistakes was changed from 'append done: {summary}' to the configured declared-wait verb (paused: implemented and committed, ready to validate) rather than working:, because bin/fm-classify-lib.sh gives an idle pane on a working: line no positive working evidence and it would raise exactly the stale alarm gap 2 is about, while a declared wait still wakes firstmate on append; rule 4's nonterminal-working clause was generalized from 'a defined done: gate' to 'a stopping point defined under Definition of done' so that handoff remains a legitimate stopping point; the park-and-resume rule lives once in the shared status-protocol rule with a single one-line reinforcement at the no-mistakes gate where the risk actually fires, per the one-owner rule; the resolved: state-line requirement was added to both ship and scout contracts but deliberately not to the secondmate charter, whose keyed resolved semantics and sparse-reporting contract are outside this task's scope; the script header was updated to describe the sharpened protocol. Tests were added as one new function in tests/fm-brief.test.sh asserting all three gaps against generated ship and scout briefs.

## What Changed

- Define no-mistakes `done:` as a PR with green checks and use the configured declared-wait status for the pre-validation handoff.
- Require paused/working status transitions around backgrounded pipeline calls and a state line immediately after `resolved:` in ship and scout briefs.
- Update the scaffold header and add regression coverage for all three status-reporting rules.

## Risk Assessment

✅ Low: Captain, the change is narrowly scoped, preserves existing safety clauses and file boundaries, and satisfies all three status-protocol requirements with generated-brief coverage.

## Testing

Baseline diff inspection, the focused brief test, and end-to-end generation and content checks for default ship, scout, and configured-wait briefs all passed; generated Markdown is the actual CLI user surface, and the worktree remained clean.

<details>
<summary>Evidence: Generated no-mistakes ship brief</summary>

<code>Generated no-mistakes contract demonstrating the single terminal `done:`, declared-wait handoff, park/resume pairing, stateless `resolved:` warning, and preserved worktree-isolation assertion.</code>

```text
You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.

# Task
{TASK}

# Herdr lifecycle declaration - NOT ENABLED
**HARD SAFETY GATE:** this scaffold cannot inspect the task text that replaces `{TASK}` later.
If the task will start, stop, delete, restart, profile, or otherwise drive Herdr lifecycle behavior, stop and regenerate the brief with `--herdr-lab` before dispatch.
Do not add Herdr lifecycle commands to this unguarded brief by hand.

# Setup
You are in a disposable git worktree of demo-project, at a detached HEAD on a clean default branch.

**Verify isolation before anything else.** Run `pwd -P` and `git rev-parse --show-toplevel`; both must resolve to the disposable task worktree you were launched in, such as a treehouse pool path or an Orca-managed worktree, not the primary checkout firstmate operates from.
The path check is authoritative: `git rev-parse --git-dir` and `git rev-parse --git-common-dir` can help inspect the repo, but they do not prove you are outside the primary checkout.
If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not branch or commit here - append `blocked: launched in primary checkout, not an isolated worktree` to the status file and stop.

1. First action: create your branch: `git checkout -b fm/status-protocol-ship`
2. Run `no-mistakes doctor`; if it reports the repo is not initialized here, run `no-mistakes init`.

# Rules
1. Never push to the default branch. Never merge a PR.
2. Stay inside this worktree; modify nothing outside it.
3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
4. Report status by appending one line:
   `echo "{state}: {one short line}" >> '/tmp/no-mistakes-evidence/01KYZM5P217GDJET6BWKWDQ0B6/e2e-home/state/status-protocol-ship.status'`
   States: working, needs-decision, blocked, paused, done, failed.
   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
   would act on (setup done, bug reproduced, fix implemented, validation passed) and the
   needs-decision/blocked/paused/done/failed states. No step-by-step FYI progress lines;
   firstmate reads your pane for that.
   Your LATEST line is your entire visible state, so never leave a stale or stateless one standing.
   A mid-task `working:` line (including setup complete) is nonterminal: do not end the
   turn after it; continue the same stage until a stopping point defined under Definition of done.
   Use `paused: {why}` - distinct from `blocked:` - ONLY when you are deliberately idling on a
   known external wait you expect to clear on its own (an upstream release, a rate-limit reset,
   a scheduled window, a backgrounded call you are parked on): firstmate then leaves your idle pane
   alone and rechecks it on a long cadence instead of treating it as a possible wedge.
   Park-and-resume pairing: whenever you background a pipeline call and go idle, append
   `paused:` BEFORE going idle and `working:` as soon as it returns - otherwise a spent
   `needs-decision:` stays standing and firstmate reads you as still waiting on a decision it
   already answered. Use `blocked:` when you are stuck and need help.
5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
6. If a decision belongs above the implementation worker (product choices, destructive actions, ask-user findings),
   append `needs-decision: {summary of options}` and stop. Firstmate will apply the configured authority and reply with the decision.
   When firstmate replies or a blocker clears and you resume, append `resolved: {how it was decided or unblocked}` (add the same `[key=<slug>]` if you opened it with one) so the decision or blocker is durably closed and does not keep resurfacing.
   `resolved:` carries NO state, so it must never be your last line: append the next state line
   (normally `working:`) in the same breath. A trailing `resolved:` makes you read as no state at
   all - invisible to firstmate and indistinguishable from a dead worker, which is worse than stale.
7. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving
   every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
   daemon error, append `blocked: {the daemon error}` and stop; only firstmate manages the daemon.

# Project memory
If `AGENTS.md` or `CLAUDE.md` already exists, or if this task produced durable project-intrinsic knowledge, run `/home/sungin/.no-mistakes/worktrees/bc8432f7c9f8/01KYZM5P217GDJET6BWKWDQ0B6/bin/fm-ensure-agents-md.sh .` in the worktree.
Record only project knowledge useful to almost every future session.
For anything the codebase already shows, prefer a pointer to the authoritative file, command, or doc over copying the detail.
If you touch a project `AGENTS.md` that lacks `## Maintaining this file`, add that short self-governance section from `/home/sungin/.no-mistakes/worktrees/bc8432f7c9f8/01KYZM5P217GDJET6BWKWDQ0B6/bin/fm-ensure-agents-md.sh` in the same pass.
Keep it proportionate: skip `AGENTS.md` edits for trivial tasks that produced no durable project knowledge.

# Definition of done
This project ships **no-mistakes**: `done:` means the PR is open with its checks green.
A clean local commit is NOT done, and neither is your own test run passing - this task has exactly one `done:` line and it is the last one, `done: PR {url} checks green`.
The task is complete only when committed on your branch.
When you believe implementation is complete, append `paused: implemented and committed, ready to validate` and stop there; that handoff is a defined stopping point and a declared wait, and firstmate will then instruct you to run /no-mistakes to validate and ship a PR.

You drive no-mistakes by responding to its gates, not by implementing fixes.
Follow the guidance no-mistakes itself provides for the mechanics: it loads when you invoke /no-mistakes, and `no-mistakes axi run --help` plus the `help` lines in each `axi` response are authoritative and version-matched to the installed binary.
When starting no-mistakes, make `--intent` preserve all relevant content from this brief's `# Task` section plus every later accepted Firstmate requirement, clarification, constraint, exclusion, and supersession, carrying only each requirement's current accepted form; retain direct requirements instead of substituting a diff summary, and exclude generic operational, status, delivery, and other scaffold boilerplate unless it is task-specific.
Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix.
While you sit parked on a backgrounded `axi run` or `axi respond` call, rule 4's park-and-resume pairing applies: append `paused:` before you go idle and `working:` when the call returns.

Two firstmate-specific rules layer on top of that guidance:
- ask-user findings are never yours to answer: escalate to firstmate (rule 6) and stop.
  Firstmate applies the authority contract in its `AGENTS.md` and obtains any required captain decision.
  When the decision comes back, feed it to the gate with `no-mistakes axi respond` and let the pipeline apply it - do not route the question to "the user" or implement the fix yourself.
- Avoid `--yes`: it would silently bypass firstmate's authority check and any required captain escalation.

After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append `done: PR {url} checks green` and stop. You are finished.
```
</details>
<details>
<summary>Evidence: Generated scout brief</summary>

<code>Generated scout contract demonstrating that `resolved:` must immediately be followed by a readable state line.</code>

```text
You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.

# Task
{TASK}

# Herdr lifecycle declaration - NOT ENABLED
**HARD SAFETY GATE:** this scaffold cannot inspect the task text that replaces `{TASK}` later.
If the task will start, stop, delete, restart, profile, or otherwise drive Herdr lifecycle behavior, stop and regenerate the brief with `--herdr-lab` before dispatch.
Do not add Herdr lifecycle commands to this unguarded brief by hand.

# Setup
You are in a disposable git worktree of demo-project, at a detached HEAD on a clean default branch.
This is a SCOUT task: the deliverable is a written report, not a PR.
The worktree is your laboratory - install, run, edit, and make scratch commits freely; all of it is discarded at teardown.
The report is the only thing that survives, so anything worth keeping must be in it.

# Rules
1. Never push to any remote and never open a PR.
2. Stay inside this worktree; the only files you may write outside it are the report and the status file below.
3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
4. Report status by appending one line:
   `echo "{state}: {one short line}" >> '/tmp/no-mistakes-evidence/01KYZM5P217GDJET6BWKWDQ0B6/e2e-home/state/status-protocol-scout.status'`
   States: working, needs-decision, blocked, paused, done, failed.
   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
   would act on and the needs-decision/blocked/paused/done/failed states. No step-by-step
   FYI progress lines; firstmate reads your pane for that.
   Use `paused: {why}` - distinct from `blocked:` - ONLY when you are deliberately idling on a
   known external wait you expect to clear on its own (an upstream release, a rate-limit reset):
   firstmate then leaves your idle pane alone and rechecks it on a long cadence instead of
   treating it as a possible wedge. Use `blocked:` when you are stuck and need help.
5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
6. If a decision belongs to a human (product choices, destructive actions),
   append `needs-decision: {summary of options}` and stop. Firstmate will reply with the decision.
   When firstmate replies or a blocker clears and you resume, append `resolved: {how it was decided or unblocked}` (add the same `[key=<slug>]` if you opened it with one) so the decision or blocker is durably closed and does not keep resurfacing.
   `resolved:` carries NO state, so it must never be your last line: append the next state line
   (normally `working:`) in the same breath. A trailing `resolved:` makes you read as no state at
   all - invisible to firstmate and indistinguishable from a dead worker, which is worse than stale.
7. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving
   every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
   daemon error, append `blocked: {the daemon error}` and stop; only firstmate manages the daemon.

# Definition of done
Write your findings to `/tmp/no-mistakes-evidence/01KYZM5P217GDJET6BWKWDQ0B6/e2e-home/data/status-protocol-scout/report.md`.
The report must stand alone: what you did, what you found, the evidence (commands run, output, file:line references), and what you recommend.
Before reporting done, read and follow `/home/sungin/.no-mistakes/worktrees/bc8432f7c9f8/01KYZM5P217GDJET6BWKWDQ0B6/.agents/skills/decision-hold-lifecycle/SKILL.md` and pass its shared completion gate for the report and any visual review.
When the report is complete, append `done: {one-line conclusion}` to the status file and stop.
If your findings reveal work that should ship (e.g. you reproduced a bug and the fix is clear), say so in the report; firstmate may promote this task in place, and you would then receive mode-specific ship instructions as a follow-up message.
```
</details>
<details>
<summary>Evidence: Generated custom-wait ship brief</summary>

<code>Generated contract demonstrating that the configured `awaiting:` verb replaces `paused:` throughout handoff and park/resume instructions.</code>

```text
You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.

# Task
{TASK}

# Herdr lifecycle declaration - NOT ENABLED
**HARD SAFETY GATE:** this scaffold cannot inspect the task text that replaces `{TASK}` later.
If the task will start, stop, delete, restart, profile, or otherwise drive Herdr lifecycle behavior, stop and regenerate the brief with `--herdr-lab` before dispatch.
Do not add Herdr lifecycle commands to this unguarded brief by hand.

# Setup
You are in a disposable git worktree of demo-project, at a detached HEAD on a clean default branch.

**Verify isolation before anything else.** Run `pwd -P` and `git rev-parse --show-toplevel`; both must resolve to the disposable task worktree you were launched in, such as a treehouse pool path or an Orca-managed worktree, not the primary checkout firstmate operates from.
The path check is authoritative: `git rev-parse --git-dir` and `git rev-parse --git-common-dir` can help inspect the repo, but they do not prove you are outside the primary checkout.
If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not branch or commit here - append `blocked: launched in primary checkout, not an isolated worktree` to the status file and stop.

1. First action: create your branch: `git checkout -b fm/status-protocol-custom-wait`
2. Run `no-mistakes doctor`; if it reports the repo is not initialized here, run `no-mistakes init`.

# Rules
1. Never push to the default branch. Never merge a PR.
2. Stay inside this worktree; modify nothing outside it.
3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
4. Report status by appending one line:
   `echo "{state}: {one short line}" >> '/tmp/no-mistakes-evidence/01KYZM5P217GDJET6BWKWDQ0B6/e2e-home/state/status-protocol-custom-wait.status'`
   States: working, needs-decision, blocked, awaiting, done, failed.
   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
   would act on (setup done, bug reproduced, fix implemented, validation passed) and the
   needs-decision/blocked/paused/done/failed states. No step-by-step FYI progress lines;
   firstmate reads your pane for that.
   Your LATEST line is your entire visible state, so never leave a stale or stateless one standing.
   A mid-task `working:` line (including setup complete) is nonterminal: do not end the
   turn after it; continue the same stage until a stopping point defined under Definition of done.
   Use `awaiting: {why}` - distinct from `blocked:` - ONLY when you are deliberately idling on a
   known external wait you expect to clear on its own (an upstream release, a rate-limit reset,
   a scheduled window, a backgrounded call you are parked on): firstmate then leaves your idle pane
   alone and rechecks it on a long cadence instead of treating it as a possible wedge.
   Park-and-resume pairing: whenever you background a pipeline call and go idle, append
   `awaiting:` BEFORE going idle and `working:` as soon as it returns - otherwise a spent
   `needs-decision:` stays standing and firstmate reads you as still waiting on a decision it
   already answered. Use `blocked:` when you are stuck and need help.
5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
6. If a decision belongs above the implementation worker (product choices, destructive actions, ask-user findings),
   append `needs-decision: {summary of options}` and stop. Firstmate will apply the configured authority and reply with the decision.
   When firstmate replies or a blocker clears and you resume, append `resolved: {how it was decided or unblocked}` (add the same `[key=<slug>]` if you opened it with one) so the decision or blocker is durably closed and does not keep resurfacing.
   `resolved:` carries NO state, so it must never be your last line: append the next state line
   (normally `working:`) in the same breath. A trailing `resolved:` makes you read as no state at
   all - invisible to firstmate and indistinguishable from a dead worker, which is worse than stale.
7. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving
   every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
   daemon error, append `blocked: {the daemon error}` and stop; only firstmate manages the daemon.

# Project memory
If `AGENTS.md` or `CLAUDE.md` already exists, or if this task produced durable project-intrinsic knowledge, run `/home/sungin/.no-mistakes/worktrees/bc8432f7c9f8/01KYZM5P217GDJET6BWKWDQ0B6/bin/fm-ensure-agents-md.sh .` in the worktree.
Record only project knowledge useful to almost every future session.
For anything the codebase already shows, prefer a pointer to the authoritative file, command, or doc over copying the detail.
If you touch a project `AGENTS.md` that lacks `## Maintaining this file`, add that short self-governance section from `/home/sungin/.no-mistakes/worktrees/bc8432f7c9f8/01KYZM5P217GDJET6BWKWDQ0B6/bin/fm-ensure-agents-md.sh` in the same pass.
Keep it proportionate: skip `AGENTS.md` edits for trivial tasks that produced no durable project knowledge.

# Definition of done
This project ships **no-mistakes**: `done:` means the PR is open with its checks green.
A clean local commit is NOT done, and neither is your own test run passing - this task has exactly one `done:` line and it is the last one, `done: PR {url} checks green`.
The task is complete only when committed on your branch.
When you believe implementation is complete, append `awaiting: implemented and committed, ready to validate` and stop there; that handoff is a defined stopping point and a declared wait, and firstmate will then instruct you to run /no-mistakes to validate and ship a PR.

You drive no-mistakes by responding to its gates, not by implementing fixes.
Follow the guidance no-mistakes itself provides for the mechanics: it loads when you invoke /no-mistakes, and `no-mistakes axi run --help` plus the `help` lines in each `axi` response are authoritative and version-matched to the installed binary.
When starting no-mistakes, make `--intent` preserve all relevant content from this brief's `# Task` section plus every later accepted Firstmate requirement, clarification, constraint, exclusion, and supersession, carrying only each requirement's current accepted form; retain direct requirements instead of substituting a diff summary, and exclude generic operational, status, delivery, and other scaffold boilerplate unless it is task-specific.
Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix.
While you sit parked on a backgrounded `axi run` or `axi respond` call, rule 4's park-and-resume pairing applies: append `awaiting:` before you go idle and `working:` when the call returns.

Two firstmate-specific rules layer on top of that guidance:
- ask-user findings are never yours to answer: escalate to firstmate (rule 6) and stop.
  Firstmate applies the authority contract in its `AGENTS.md` and obtains any required captain decision.
  When the decision comes back, feed it to the gate with `no-mistakes axi respond` and let the pipeline apply it - do not route the question to "the user" or implement the fix yourself.
- Avoid `--yes`: it would silently bypass firstmate's authority check and any required captain escalation.

After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append `done: PR {url} checks green` and stop. You are finished.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>Inspected `git diff --name-status 1e247571aa75e00b00c7a01c4830025ecd44dc61..5302dad5979e9ca68b1702d0a66cf3c53b3aa762` and the focused patch against the supplied intent.</code>
- `tests/fm-brief.test.sh`
- `FM_HOME=/tmp/no-mistakes-evidence/01KYZM5P217GDJET6BWKWDQ0B6/e2e-home ./bin/fm-brief.sh status-protocol-ship demo-project`
- `FM_HOME=/tmp/no-mistakes-evidence/01KYZM5P217GDJET6BWKWDQ0B6/e2e-home ./bin/fm-brief.sh status-protocol-scout demo-project --scout`
- `FM_HOME=/tmp/no-mistakes-evidence/01KYZM5P217GDJET6BWKWDQ0B6/e2e-home FM_CLASSIFY_PAUSED_VERB=awaiting ./bin/fm-brief.sh status-protocol-custom-wait demo-project`
- <code>Inspected generated contract sections with `rg -n -C 2` and verified the premature `append done: {summary}` instruction is absent, the worktree-isolation assertion remains, and `bin/fm-crew-state.sh` plus `bin/fm-classify-lib.sh` are unchanged.</code>
- `git status --short`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
