### PR TITLE
feat: add code-intelligence routing policy

### DIFF
--- a/.agents/skills/code-intelligence-routing/SKILL.md
+++ b/.agents/skills/code-intelligence-routing/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: code-intelligence-routing
+description: >-
+  Agent-only routing for CodeGraph and Graphify during coding and code-focused investigation.
+  Use before repository inspection or edits to choose the proportionate graph tool and preserve project authority.
+user-invocable: false
+metadata:
+  internal: true
+---
+
+# code-intelligence-routing
+
+Use this procedure before coding work or a code-focused investigation.
+This skill is the single owner of Firstmate's CodeGraph and Graphify routing policy.
+
+## Choose the proportionate tool
+
+Use CodeGraph by default for bounded coding work and code-focused investigation.
+Use the installed `graphify` skill instead when a large architecture or research investigation needs a persistent, broader knowledge graph to connect code with substantial documentation or other source material.
+Do not use Graphify for an ordinary bounded implementation, bug fix, or narrow code question.
+
+## CodeGraph
+
+Call the CodeGraph MCP `codegraph_explore` tool first with a focused query and the absolute project path.
+Use the returned source, call paths, and blast-radius summary to guide the next inspection or edit.
+If CodeGraph is unavailable, the project has no `.codegraph/` index, or the query cannot be served, continue with ordinary repository inspection using available read, search, and file-listing tools.
+Do not block the task, run `codegraph init`, or otherwise create or commit `.codegraph/` data without explicit project authority.
+
+## Graphify
+
+Use the installed `graphify` skill for the selected larger investigation and follow its procedure.
+Run it only in the authorized isolated task copy, never in a project's primary local copy.
+Treat `graphify-out/` and other generated graph material as investigation output, not source changes to commit, unless the task and project authority explicitly require retaining it.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -488,6 +488,7 @@ These skills are not captain-invocable; load them only at their precise triggers
 
 - `bootstrap-diagnostics` - load whenever the session-start digest's bootstrap section prints an actionable diagnostic line (`MISSING:`, `MISSING_MANUAL:`, `BACKEND_INVALID:`, `NEEDS_GH_AUTH`, `TANGLE:`, `STARTUP_MEMORY_BUDGET:`, `CREW_DISPATCH: invalid`, `FLEET_SYNC:`, `PR_CHECK_MIGRATION:`, `SECONDMATE_SYNC:`, `SECONDMATE_LIVENESS:`, `NUDGE_SECONDMATES:`, or `FMX:`); silence and `BOOTSTRAP_INFO:` need no load.
 - `diagnostic-reasoning` - load before scoping a reported bug and before acting on a diagnostic report.
+- `code-intelligence-routing` - load before coding work or a code-focused investigation to select CodeGraph or Graphify proportionately.
 - `ask-user-authority` - load before deciding any ask-user finding, regardless of the project's `yolo` posture.
 - `quota-array-dispatch` - load before choosing among a matched crew-dispatch profile array from current quota-axi output.
 - `harness-adapters` - load before spawning or recovering a crewmate or secondmate, handling a trust dialog, sending a harness-specific skill invocation, interrupting or exiting an agent, resuming an exited agent, or verifying a new harness adapter.

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -256,6 +256,9 @@ You are a crewmate: an autonomous worker agent managed by firstmate. Work on you
 
 $HERDR_SECTION
 
+# Code intelligence
+For coding work or code-focused investigation, read and follow \`$FM_ROOT/.agents/skills/code-intelligence-routing/SKILL.md\` before repository inspection or edits.
+
 # Setup
 You are in a disposable git worktree of $REPO, at a detached HEAD on a clean default branch.
 This is a SCOUT task: the deliverable is a written report, not a PR.
@@ -364,6 +367,9 @@ You are a crewmate: an autonomous worker agent managed by firstmate. Work on you
 {TASK}
 
 $HERDR_SECTION
+
+# Code intelligence
+For coding work or code-focused investigation, read and follow \`$FM_ROOT/.agents/skills/code-intelligence-routing/SKILL.md\` before repository inspection or edits.
 
 # Setup
 You are in a disposable git worktree of $REPO, at a detached HEAD on a clean default branch.

--- a/docs/documentation-audiences.json
+++ b/docs/documentation-audiences.json
@@ -124,6 +124,10 @@
       "audience": "agent-runtime"
     },
     {
+      "path": ".agents/skills/code-intelligence-routing/SKILL.md",
+      "audience": "agent-runtime"
+    },
+    {
       "path": ".agents/skills/decision-hold-lifecycle/SKILL.md",
       "audience": "agent-runtime"
     },

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -278,6 +278,23 @@ test_no_mistakes_dod_wording() {
   pass "fm-brief.sh: no-mistakes DOD keeps its apostrophe prose, now parse-safe"
 }
 
+test_code_intelligence_routing_pointer() {
+  local home ship scout
+  home="$TMP_ROOT/code-intelligence-routing-home"
+  mkdir -p "$home/data"
+  FM_HOME="$home" FM_ROOT_OVERRIDE="$ROOT" \
+    "$ROOT/bin/fm-brief.sh" code-intelligence-ship sample >/dev/null 2>&1
+  ship="$home/data/code-intelligence-ship/brief.md"
+  assert_grep "$ROOT/.agents/skills/code-intelligence-routing/SKILL.md" "$ship" \
+    "ship brief did not point coding work to the code-intelligence routing policy"
+  FM_HOME="$home" FM_ROOT_OVERRIDE="$ROOT" \
+    "$ROOT/bin/fm-brief.sh" code-intelligence-scout sample --scout >/dev/null 2>&1
+  scout="$home/data/code-intelligence-scout/brief.md"
+  assert_grep "$ROOT/.agents/skills/code-intelligence-routing/SKILL.md" "$scout" \
+    "scout brief did not point code-focused investigation to the code-intelligence routing policy"
+  pass "fm-brief.sh: ship and scout briefs load the code-intelligence routing policy"
+}
+
 test_ship_project_memory_wording() {
   local home id brief
   home="$TMP_ROOT/project-memory-home"
@@ -638,6 +655,7 @@ test_help_includes_entire_header
 test_ship_modes_generate_clean_briefs
 test_faster_paths_use_configured_authority_without_stacked_review
 test_no_mistakes_dod_wording
+test_code_intelligence_routing_pointer
 test_ship_project_memory_wording
 test_herdr_lab_contract_is_explicit_and_complete
 test_herdr_lab_contract_quotes_foreign_firstmate_path


### PR DESCRIPTION
## Intent

Implement Firstmate's standing code-intelligence routing policy in the shared tracked instruction surface. CodeGraph is the default first inspection for bounded coding work and code-focused investigation, with an ordinary repository-inspection fallback when unavailable or unindexed; do not auto-initialize or commit graph data without project authority. Graphify is reserved for large architecture or research investigations where a persistent broader knowledge graph is materially useful, never ordinary bounded coding. Keep one concise policy owner and only necessary trigger pointers so future dispatched workers discover the policy consistently while preserving project-write boundaries.

## What Changed

- Add a shared routing policy that defaults bounded coding work to CodeGraph, falls back to ordinary repository inspection when unavailable, and reserves Graphify for broader investigations.
- Surface the policy through root agent instructions and generated ship/scout briefs, with documentation inventory coverage and brief-generation tests.

## Risk Assessment

✅ Low: The change cleanly centralizes the routing policy, adds proportionate discovery pointers, preserves fallback and project-authority boundaries, and introduces no material source risks.

## Testing

Baseline diff inspection, the required CodeGraph-first fallback exercise, focused brief and documentation tests, real ship/scout CLI generation, and manual ownership/boundary checks all succeeded; the worktree remained clean. Reviewer-visible evidence is generated Markdown because this change affects agent instruction briefs rather than a rendered UI.

<details>
<summary>Evidence: Generated ship-worker brief</summary>

```text
You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.

# Task
{TASK}

# Herdr lifecycle declaration - NOT ENABLED
**HARD SAFETY GATE:** this scaffold cannot inspect the task text that replaces `{TASK}` later.
If the task will start, stop, delete, restart, profile, or otherwise drive Herdr lifecycle behavior, stop and regenerate the brief with `--herdr-lab` before dispatch.
Do not add Herdr lifecycle commands to this unguarded brief by hand.

# Code intelligence
For coding work or code-focused investigation, read and follow `/Users/alex/.no-mistakes/worktrees/577f711a0daa/01KYZNGVM2ZSC8GBNMNKPJ3DD1/.agents/skills/code-intelligence-routing/SKILL.md` before repository inspection or edits.

# Setup
You are in a disposable git worktree of sample, at a detached HEAD on a clean default branch.

**Verify isolation before anything else.** Run `pwd -P` and `git rev-parse --show-toplevel`; both must resolve to the disposable task worktree you were launched in, such as a treehouse pool path or an Orca-managed worktree, not the primary checkout firstmate operates from.
The path check is authoritative: `git rev-parse --git-dir` and `git rev-parse --git-common-dir` can help inspect the repo, but they do not prove you are outside the primary checkout.
If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not branch or commit here - append `blocked: launched in primary checkout, not an isolated worktree` to the status file and stop.

1. First action: create your branch: `git checkout -b fm/routing-ship`
2. Run `no-mistakes doctor`; if it reports the repo is not initialized here, run `no-mistakes init`.

# Rules
1. Never push to the default branch. Never merge a PR.
2. Stay inside this worktree; modify nothing outside it.
3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
4. Report status by appending one line:
   `echo "{state}: {one short line}" >> '/var/folders/nt/rdk7cjs538l8zphln24q2k900000gn/T/no-mistakes-evidence/01KYZNGVM2ZSC8GBNMNKPJ3DD1/code-intelligence-routing/fm-home/state/routing-ship.status'`
   States: working, needs-decision, blocked, paused, done, failed.
   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
   would act on (setup done, bug reproduced, fix implemented, validation passed) and the
   needs-decision/blocked/paused/done/failed states. No step-by-step FYI progress lines;
   firstmate reads your pane for that.
   A mid-task `working:` line (including setup complete) is nonterminal: do not end the
   turn after it; continue the same stage until a defined `done:` gate under Definition of done.
   Use `paused: {why}` - distinct from `blocked:` - ONLY when you are deliberately idling on a
   known external wait you expect to clear on its own (an upstream release, a rate-limit reset,
   a scheduled window): firstmate then leaves your idle pane alone and rechecks it on a long
   cadence instead of treating it as a possible wedge. Use `blocked:` when you are stuck and need help.
5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
6. If a decision belongs above the implementation worker (product choices, destructive actions, ask-user findings),
   append `needs-decision: {summary of options}` and stop. Firstmate will apply the configured authority and reply with the decision.
   When firstmate replies or a blocker clears and you resume, append `resolved: {how it was decided or unblocked}` (add the same `[key=<slug>]` if you opened it with one) so the decision or blocker is durably closed and does not keep resurfacing.
7. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving
   every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
   daemon error, append `blocked: {the daemon error}` and stop; only firstmate manages the daemon.

# Project memory
If `AGENTS.md` or `CLAUDE.md` already exists, or if this task produced durable project-intrinsic knowledge, run `/Users/alex/.no-mistakes/worktrees/577f711a0daa/01KYZNGVM2ZSC8GBNMNKPJ3DD1/bin/fm-ensure-agents-md.sh .` in the worktree.
Record only project knowledge useful to almost every future session.
For anything the codebase already shows, prefer a pointer to the authoritative file, command, or doc over copying the detail.
If you touch a project `AGENTS.md` that lacks `## Maintaining this file`, add that short self-governance section from `/Users/alex/.no-mistakes/worktrees/577f711a0daa/01KYZNGVM2ZSC8GBNMNKPJ3DD1/bin/fm-ensure-agents-md.sh` in the same pass.
Keep it proportionate: skip `AGENTS.md` edits for trivial tasks that produced no durable project knowledge.

# Definition of done
The task is complete only when committed on your branch.
When you believe it is complete, append `done: {summary}` to the status file and stop.
Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.

You drive no-mistakes by responding to its gates, not by implementing fixes.
Follow the guidance no-mistakes itself provides for the mechanics: it loads when you invoke /no-mistakes, and `no-mistakes axi run --help` plus the `help` lines in each `axi` response are authoritative and version-matched to the installed binary.
When starting no-mistakes, make `--intent` preserve all relevant content from this brief's `# Task` section plus every later accepted Firstmate requirement, clarification, constraint, exclusion, and supersession, carrying only each requirement's current accepted form; retain direct requirements instead of substituting a diff summary, and exclude generic operational, status, delivery, and other scaffold boilerplate unless it is task-specific.
Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix.

Two firstmate-specific rules layer on top of that guidance:
- ask-user findings are never yours to answer: escalate to firstmate (rule 6) and stop.
  Firstmate applies the authority contract in its `AGENTS.md` and obtains any required captain decision.
  When the decision comes back, feed it to the gate with `no-mistakes axi respond` and let the pipeline apply it - do not route the question to "the user" or implement the fix yourself.
- Avoid `--yes`: it would silently bypass firstmate's authority check and any required captain escalation.

After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append `done: PR {url} checks green` and stop. You are finished.
```
</details>
<details>
<summary>Evidence: Generated scout-worker brief</summary>

```text
You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.

# Task
{TASK}

# Herdr lifecycle declaration - NOT ENABLED
**HARD SAFETY GATE:** this scaffold cannot inspect the task text that replaces `{TASK}` later.
If the task will start, stop, delete, restart, profile, or otherwise drive Herdr lifecycle behavior, stop and regenerate the brief with `--herdr-lab` before dispatch.
Do not add Herdr lifecycle commands to this unguarded brief by hand.

# Code intelligence
For coding work or code-focused investigation, read and follow `/Users/alex/.no-mistakes/worktrees/577f711a0daa/01KYZNGVM2ZSC8GBNMNKPJ3DD1/.agents/skills/code-intelligence-routing/SKILL.md` before repository inspection or edits.

# Setup
You are in a disposable git worktree of sample, at a detached HEAD on a clean default branch.
This is a SCOUT task: the deliverable is a written report, not a PR.
The worktree is your laboratory - install, run, edit, and make scratch commits freely; all of it is discarded at teardown.
The report is the only thing that survives, so anything worth keeping must be in it.

# Rules
1. Never push to any remote and never open a PR.
2. Stay inside this worktree; the only files you may write outside it are the report and the status file below.
3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
4. Report status by appending one line:
   `echo "{state}: {one short line}" >> '/var/folders/nt/rdk7cjs538l8zphln24q2k900000gn/T/no-mistakes-evidence/01KYZNGVM2ZSC8GBNMNKPJ3DD1/code-intelligence-routing/fm-home/state/routing-scout.status'`
   States: working, needs-decision, blocked, paused, done, failed.
   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
   would act on and the needs-decision/blocked/paused/done/failed states. No step-by-step
   FYI progress lines; firstmate reads your pane for that.
   Use `paused: {why}` - distinct from `blocked:` - ONLY when you are deliberately idling on a
   known external wait you expect to clear on its own (an upstream release, a rate-limit reset):
   firstmate then leaves your idle pane alone and rechecks it on a long cadence instead of
   treating it as a possible wedge. Use `blocked:` when you are stuck and need help.
5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
6. If a decision belongs to a human (product choices, destructive actions),
   append `needs-decision: {summary of options}` and stop. Firstmate will reply with the decision.
   When firstmate replies or a blocker clears and you resume, append `resolved: {how it was decided or unblocked}` (add the same `[key=<slug>]` if you opened it with one) so the decision or blocker is durably closed and does not keep resurfacing.
7. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving
   every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
   daemon error, append `blocked: {the daemon error}` and stop; only firstmate manages the daemon.

# Definition of done
Write your findings to `/var/folders/nt/rdk7cjs538l8zphln24q2k900000gn/T/no-mistakes-evidence/01KYZNGVM2ZSC8GBNMNKPJ3DD1/code-intelligence-routing/fm-home/data/routing-scout/report.md`.
The report must stand alone: what you did, what you found, the evidence (commands run, output, file:line references), and what you recommend.
Before reporting done, read and follow `/Users/alex/.no-mistakes/worktrees/577f711a0daa/01KYZNGVM2ZSC8GBNMNKPJ3DD1/.agents/skills/decision-hold-lifecycle/SKILL.md` and pass its shared completion gate for the report and any visual review.
When the report is complete, append `done: {one-line conclusion}` to the status file and stop.
If your findings reveal work that should ship (e.g. you reproduced a bug and the fix is clear), say so in the report; firstmate may promote this task in place, and you would then receive mode-specific ship instructions as a follow-up message.
```
</details>
<details>
<summary>Evidence: Manual acceptance matrix</summary>

```text
Both generated briefs contain exactly one `# Code intelligence` pointer to the shared routing skill. Policy semantics have one owner; the root trigger and documentation inventory each contain one pointer; no `.codegraph` data was initialized.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>CodeGraph `codegraph_explore` against the current worktree, confirming the unindexed-project fallback without initialization</code>
- `git diff --find-renames --find-copies 1e247571aa75e00b00c7a01c4830025ecd44dc61..9d83b143305aa983ca2111a067eca0ac0f81471a`
- `bash tests/fm-brief.test.sh`
- `bash tests/fm-documentation-audiences.test.sh`
- <code>Generated real ship and scout briefs with `FM_HOME=&lt;evidence-home&gt; FM_ROOT_OVERRIDE=&#34;$PWD&#34; bin/fm-brief.sh ...` and inspected their rendered code-intelligence sections</code>
- <code>Manual `rg` acceptance checks for a single policy owner, one root trigger, one pointer per generated brief, one documentation-inventory entry, and absence of `.codegraph`</code>
- <code>`git status --short` after testing to confirm the worktree remained clean</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
