### PR TITLE
test: eliminate watcher peer startup race

### DIFF
--- a/tests/fm-watcher-lock.test.sh
+++ b/tests/fm-watcher-lock.test.sh
@@ -438,14 +438,28 @@ test_watch_restart_rejects_reused_pid() {
 }
 
 test_watch_restart_attaches_to_healthy_peer() {
-  local dir state fakebin out peer identity armpid status i
+  local dir state fakebin out peer ready identity armpid status i
   dir=$(make_case restart-healthy-peer)
   state="$dir/state"
   fakebin="$dir/fakebin"
   out="$dir/restart.out"
+  ready="$dir/peer-ready"
   mark_pr_check_migration_complete "$state"
-  node -e 'process.on("SIGTERM", () => {}); setTimeout(() => {}, 300000)' &
+  # The peer must already be TERM-resistant when --restart signals it: node's
+  # default disposition kills it until the interpreter has actually evaluated
+  # process.on("SIGTERM"), and the restart below sends TERM milliseconds after
+  # this launch. A peer that dies there leaves a dead-pid lock the fresh child
+  # legitimately steals, so the arm reports "started" and this fixture fails for
+  # a reason it does not test. Have the peer announce that its handler is
+  # installed and wait on that exact condition.
+  node -e 'process.on("SIGTERM", () => {}); require("fs").writeFileSync(process.argv[1], "ready"); setTimeout(() => {}, 300000)' "$ready" &
   peer=$!
+  i=0
+  while [ "$i" -lt 200 ] && [ ! -s "$ready" ]; do
+    sleep 0.05
+    i=$((i + 1))
+  done
+  [ -s "$ready" ] || fail "TERM-resistant peer did not install its handler"
   identity=$(FM_STATE_OVERRIDE="$state" bash -c '. "$1"; fm_pid_identity "$2"' _ "$LIB" "$peer") || fail "could not identify peer pid"
   mkdir "$state/.watch.lock"
   printf '%s\n' "$peer" > "$state/.watch.lock/pid"


### PR DESCRIPTION
## Intent

Fix the pre-existing flake in tests/fm-watcher-lock.test.sh, which was reported as a beacon-timing flake and reproduces on origin/main. Required approach was: reproduce in a loop of at least 50 iterations and record the baseline failure rate first; root-cause the specific racing timing assumption; fix the race rather than masking it (explicitly NOT by widening a sleep, adding a retry loop around an assertion, or loosening an assertion until it passes); wait on the actual condition rather than elapsed wall-clock time; then re-run the same 50-iteration loop and show 0 failures.

Investigation result: despite the 'beacon-timing' framing, the beacon and lock-identity paths were ruled out by instrumentation. The real cause is a peer STARTUP race in the fixture test_watch_restart_attaches_to_healthy_peer. It launches a supposedly TERM-resistant node peer, records it as the watcher lock holder, and expects fm-watch-arm.sh --restart to attach to it. node is not actually TERM-resistant until the interpreter has evaluated process.on('SIGTERM'), and the restart sends TERM milliseconds after launch. When the peer lost that race it died on the default disposition, so the lock named a dead pid, the fresh child legitimately stole it, and the arm honestly reported 'watcher: started pid=N (beacon fresh)'. Instrumentation captured peer_alive=no with the recorded identity and beacon intact, which is what ruled out the beacon/identity hypotheses. The fix has the peer announce that its SIGTERM handler is installed, and the fixture waits on that exact condition (a readiness file) before recording the lock and arming. No assertion was loosened, no sleep widened, no retry wrapped around an assertion. The 200-iteration 0.05s readiness poll is a bounded wait on the real condition with an explicit failure message, not a blind sleep.

Evidence: before, 50 runs from a pristine 'git archive HEAD' copy of origin/main under identical load, 10/50 failed, all of them this peer race. After, same command and load, 0/50. Also 0/50 in 50 consecutive one-at-a-time runs. All 10 suites selected by bin/fm-test-run.sh --changed pass, and bin/fm-lint.sh is clean.

Deliberate scope decision by the captain, so it should not be flagged as an omission: while chasing this I separately found and fixed a real defect in bin/fm-watch.sh - the watcher ignores TERM/HUP for the remainder of its poll interval because bash defers a trapped signal until the running foreground command finishes, measured at 14.68s at the 15s default poll, which exceeds the 5s restart budget in fm-watch-arm.sh --restart. That verified fix plus its regression test were deliberately EXCLUDED from this PR to keep it scoped to the fixture race, on the captain's explicit decision, and are preserved as data/firstmate-watcher-lock-flake/term-hup-latency.patch for a separate follow-up task. Do not fold watcher changes into this PR.

One methodology note in the commit message is deliberate and load-bearing: early loop runs were launched under nohup, which sets SIGHUP to SIG_IGN; an ignored disposition is inherited through fork and exec and cannot then be trapped, so kill -HUP inside test_arm_hup_cleans_child_and_temp_output became a no-op and produced a false 50/50 failure rate. That warning is recorded so the next person re-running this loop does not repeat it.

## What Changed

- Make the TERM-resistant Node test peer publish a readiness file after installing its SIGTERM handler.
- Wait for that exact readiness condition before recording the peer as lock holder and restarting the watcher, with an explicit timeout failure.

## Risk Assessment

✅ Low: The narrowly scoped fixture change closes the demonstrated startup race by waiting on the exact handler-readiness condition, while preserving all behavioral assertions and avoiding production watcher changes.

## Testing

The author-recorded baseline was 10 failures in 50 runs on origin/main; this phase independently exercised 50 full watcher-lock suites under six-way load and observed 0/50 failures, with the healthy-peer attach behavior present in every transcript and no test-created worktree changes. This is a CLI-only test-fixture change, so CLI transcripts rather than visual UI evidence were captured.

<details>
<summary>Evidence: 50-run healthy-peer attach evidence</summary>

`healthy-peer attach summary: passes=50 failures=0`

```text
target commit: 3db0341fbc750bae8f94024c3e21296ab515080b
command shape: seq 1 50 | xargs -P 6 ... bash tests/fm-watcher-lock.test.sh (no nohup)
assertion: ok - watch restart attaches to a verified healthy peer and later surfaces a successor gap

iteration 01: PASS - verified healthy-peer attach
iteration 02: PASS - verified healthy-peer attach
iteration 03: PASS - verified healthy-peer attach
iteration 04: PASS - verified healthy-peer attach
iteration 05: PASS - verified healthy-peer attach
iteration 06: PASS - verified healthy-peer attach
iteration 07: PASS - verified healthy-peer attach
iteration 08: PASS - verified healthy-peer attach
iteration 09: PASS - verified healthy-peer attach
iteration 10: PASS - verified healthy-peer attach
iteration 11: PASS - verified healthy-peer attach
iteration 12: PASS - verified healthy-peer attach
iteration 13: PASS - verified healthy-peer attach
iteration 14: PASS - verified healthy-peer attach
iteration 15: PASS - verified healthy-peer attach
iteration 16: PASS - verified healthy-peer attach
iteration 17: PASS - verified healthy-peer attach
iteration 18: PASS - verified healthy-peer attach
iteration 19: PASS - verified healthy-peer attach
iteration 20: PASS - verified healthy-peer attach
iteration 21: PASS - verified healthy-peer attach
iteration 22: PASS - verified healthy-peer attach
iteration 23: PASS - verified healthy-peer attach
iteration 24: PASS - verified healthy-peer attach
iteration 25: PASS - verified healthy-peer attach
iteration 26: PASS - verified healthy-peer attach
iteration 27: PASS - verified healthy-peer attach
iteration 28: PASS - verified healthy-peer attach
iteration 29: PASS - verified healthy-peer attach
iteration 30: PASS - verified healthy-peer attach
iteration 31: PASS - verified healthy-peer attach
iteration 32: PASS - verified healthy-peer attach
iteration 33: PASS - verified healthy-peer attach
iteration 34: PASS - verified healthy-peer attach
iteration 35: PASS - verified healthy-peer attach
iteration 36: PASS - verified healthy-peer attach
iteration 37: PASS - verified healthy-peer attach
iteration 38: PASS - verified healthy-peer attach
iteration 39: PASS - verified healthy-peer attach
iteration 40: PASS - verified healthy-peer attach
iteration 41: PASS - verified healthy-peer attach
iteration 42: PASS - verified healthy-peer attach
iteration 43: PASS - verified healthy-peer attach
iteration 44: PASS - verified healthy-peer attach
iteration 45: PASS - verified healthy-peer attach
iteration 46: PASS - verified healthy-peer attach
iteration 47: PASS - verified healthy-peer attach
iteration 48: PASS - verified healthy-peer attach
iteration 49: PASS - verified healthy-peer attach
iteration 50: PASS - verified healthy-peer attach

healthy-peer attach summary: passes=50 failures=0
```
</details>
<details>
<summary>Evidence: Stress-loop aggregate</summary>

`summary passes=50 failures=0`

```text
summary	passes=50	failures=0
```
</details>
<details>
<summary>Evidence: Representative complete watcher-lock suite transcript</summary>

```text
ok - simultaneous watcher starts leave exactly one live process
ok - fm_pid_identity real ps fallback is locale-invariant
ok - fm_pid_identity is locale-invariant across LC_ALL/LC_TIME
ok - /proc process identity ignores simulated btime changes
ok - /proc process identity detects pid reuse
ok - MSYS /proc process identity regression skipped on non-Windows host
ok - killed watcher stale lock is reclaimed
ok - live watcher lock with stale heartbeat is actionable
ok - guard banner leads when down with pending wakes (repair-after-drain) and stays silent when fresh
ok - concurrent fm_lock_try_acquire yields exactly one winner
ok - dead-pid stale lock is reclaimed by a single acquirer
ok - concurrent stale-lock steal yields exactly one winner
ok - live steal mutex is not reclaimed
ok - live-held lock is not stolen
ok - empty mid-acquire lock keeps a minimum grace
ok - late original claimant cannot claim a recreated lock
ok - paused mid-acquire claimant backs off to active stealer
ok - watch restart refuses to signal a reused pid
ok - watch restart attaches to a verified healthy peer and later surfaces a successor gap
ok - watcher self-evicts when the lock pid no longer names it
ok - arm turns clean self-eviction without a successor into a typed failure
ok - arm attaches to a live fresh watcher and fails loudly when that cycle has no successor
ok - attached arm signals record a classified lifecycle entry
ok - arm starts+confirms a fresh watcher on a clean lock and self-heals a dead-pid lock (never healthy off a dead pid)
ok - arm cleans child watcher and temp output on HUP
ok - arm propagates an immediate watcher wake before confirmation
ok - arm attaches to a peer watcher after child stands down and surfaces a missing successor
watcher: lock held by live pid 2431954 but heartbeat is stale for 838938258s (>300s); inspect or stop that watcher before re-arming.
ok - arm reports FAILED and exits non-zero when no fresh watcher can be confirmed
ok - cycle-exit ledger links a verified successor and remains size-capped
ok - SIGSTOP distinguishes live PID from stale beacon and termination records the exit class
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>Inspected `git diff 1e247571aa75e00b00c7a01c4830025ecd44dc61..3db0341fbc750bae8f94024c3e21296ab515080b -- tests/fm-watcher-lock.test.sh` and `git log -1 3db0341fbc750bae8f94024c3e21296ab515080b` to verify the causal readiness wait, recorded 10/50 baseline, and test-only scope.</code>
- <code>Ran 50 complete suites under equivalent concurrent load using `seq 1 50 | xargs -P 6 ... bash tests/fm-watcher-lock.test.sh`, without `nohup`; result: 50 passed, 0 failed.</code>
- <code>Verified all 50 logs contain `ok - watch restart attaches to a verified healthy peer and later surfaces a successor gap`; no `not ok` or readiness-timeout logs were found.</code>
- <code>Ran `git status --short` after testing and confirmed the worktree remained unchanged.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
