### PR TITLE
fix: make watcher poll waits interruptible

### DIFF
--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -567,6 +567,35 @@ heartbeat_scan_finds_actionable() {
   return 1
 }
 
+# interruptible_sleep: wait <seconds> without swallowing this watcher's own stop
+# signal. Bash defers a trapped signal until the running FOREGROUND command
+# finishes, so a blind `sleep "$POLL"` left the watcher deaf to TERM/HUP/INT for
+# the remainder of the interval - exit latency tracked FM_POLL exactly, 14.53s
+# at the 15s default. Every path that stops this home's watcher (fm-watch-arm.sh's
+# HUP/TERM teardown, its --restart stop-then-relaunch, and its bounded 5s wait for
+# the old watcher to exit) paid that latency, and the default 15s poll exceeds that
+# restart budget outright, so a restart forked a second watcher while the first was
+# still alive holding the lock. Backgrounding the sleep and waiting on the named
+# child keeps the same wait budget while letting the trap run the moment the signal
+# lands. Tracked so the EXIT path can reap the child instead of orphaning it for
+# the rest of the interval. Cadence, wake classification, and the heartbeat beacon
+# are unchanged, so wedge detection is unaffected. Measurements and the herdr
+# push-path limit below: docs/verification/supervision.md.
+INTERRUPTIBLE_SLEEP_PID=
+interruptible_sleep() {
+  sleep "$1" &
+  INTERRUPTIBLE_SLEEP_PID=$!
+  wait "$INTERRUPTIBLE_SLEEP_PID" 2>/dev/null || true
+  INTERRUPTIBLE_SLEEP_PID=
+}
+
+interruptible_sleep_stop() {
+  [ -n "$INTERRUPTIBLE_SLEEP_PID" ] || return 0
+  kill -TERM "$INTERRUPTIBLE_SLEEP_PID" 2>/dev/null || true
+  wait "$INTERRUPTIBLE_SLEEP_PID" 2>/dev/null || true
+  INTERRUPTIBLE_SLEEP_PID=
+}
+
 # event_wait_or_sleep: the terminal wait of each supervision cycle. For a home
 # with push-capable windows (herdr), it replaces the blind `sleep POLL` with a
 # bounded wait on the backend's native transition stream, so a crew going
@@ -601,7 +630,7 @@ event_wait_or_sleep() {
   done < <(recorded_windows)
 
   if [ "${#windows[@]}" -eq 0 ]; then
-    sleep "$POLL"
+    interruptible_sleep "$POLL"
     return
   fi
 
@@ -617,10 +646,16 @@ event_wait_or_sleep() {
     _event_cap_fails=0
   fi
   if [ "$_event_cap_ok" != 1 ]; then
-    sleep "$POLL"
+    interruptible_sleep "$POLL"
     return
   fi
 
+  # Known limit: unlike the interruptible_sleep budgets above, this reader wait is
+  # a foreground command substitution, so a push-capable home stays up to POLL deaf
+  # to its own stop signal. It is left alone deliberately: the reader owns a fifo
+  # dir and a child reader process that it removes on its own return path, so
+  # interrupting it here would leak both on every stop. Fixing it needs reader-side
+  # teardown, not a second background wrapper.
   rec=$(FM_BACKEND_EVENTS_CAPABILITY_CONFIRMED=1 fm_backend_wait_transition "$first_backend" "$first_session" "$POLL" "$STATE" "${windows[@]}")
   rc=$?
   case "$rc" in
@@ -634,7 +669,7 @@ event_wait_or_sleep() {
       # pure polling for the rest of this watcher process.
       _event_cap_fails=$((_event_cap_fails + 1))
       [ "$_event_cap_fails" -ge "$EVENT_CAP_FAIL_MAX" ] && _event_cap_ok=0
-      sleep "$POLL"
+      interruptible_sleep "$POLL"
       ;;
     *)
       # 1: a clean full-budget wait with no actionable edge - the reader already
@@ -679,6 +714,7 @@ if ! fm_lock_try_acquire "$WATCH_LOCK"; then
   exit 0
 fi
 watcher_cleanup() {
+  interruptible_sleep_stop
   fm_active_check_stop || return 1
   fm_check_output_cleanup
   fm_custom_check_snapshot_cleanup
@@ -802,7 +838,7 @@ while :; do
   # signature for an already-pending file (last write wins below).
   pending=$(scan_signals)
   if [ -n "$pending" ]; then
-    sleep "$SIGNAL_GRACE"
+    interruptible_sleep "$SIGNAL_GRACE"
     pending=$(printf '%s\n%s' "$pending" "$(scan_signals)")
     files=""
     while IFS=$(printf '\t') read -r sf sig f; do

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -601,12 +601,13 @@ interruptible_sleep_stop() {
 # bounded wait on the backend's native transition stream, so a crew going
 # `blocked` wakes the supervisor sub-second instead of after the stale-pane
 # wedge timer. For every other home - no push-capable window, backend not
-# capable, or the event path proven unreliable this process - it sleeps POLL,
-# byte-for-byte today's behavior. The poll loop above still runs every cycle, so
-# this only ever SHORTENS latency; it can never drop an escalation (the poll
-# loop is the permanent fail-closed backstop). This preserves the single live
-# supervision cycle: the reader is a short-lived subprocess of THIS watcher, not
-# a second watcher, so every guard/beacon/arm/turn-end mechanism is unchanged.
+# capable, or the event path proven unreliable this process - it waits POLL on
+# the interruptible poll path with the same cadence. The poll loop above still
+# runs every cycle, so this only ever SHORTENS latency; it can never drop an
+# escalation (the poll loop is the permanent fail-closed backstop). This
+# preserves the single live supervision cycle: the reader is a short-lived
+# subprocess of THIS watcher, not a second watcher, so every
+# guard/beacon/arm/turn-end mechanism is unchanged.
 event_wait_or_sleep() {
   local w b session first_backend="" first_session="" rec rc
   local windows=()

--- a/docs/verification/supervision.md
+++ b/docs/verification/supervision.md
@@ -187,6 +187,25 @@ Observed guarantee: after ordinary `session_shutdown` for `/new`, `/resume`, and
 Stale prior-generation tool callbacks could not mutate the active child, repeated transitions kept exactly one live arm cycle, and terminal `quit` still refused late rearm.
 Plain Pi and pi-signed share the same tracked `.pi/extensions/fm-primary-pi-watch.ts` path, so both inherit the generation owner; other primary harnesses are not applicable because they do not use this Pi extension lifecycle.
 
+### Watcher stop latency
+
+Measured on 2026-08-01 against an isolated temporary home, sending the signal to a watcher that had already taken its lock and entered its cycle wait.
+Before the interruptible cycle wait in `bin/fm-watch.sh`, exit latency tracked `FM_POLL` exactly, because bash defers a trapped signal until the running foreground command returns.
+
+| FM_POLL | Signal | Before | After |
+| --- | --- | --- | --- |
+| 1 | TERM | 0.54s | 0.05s |
+| 5 | TERM | 4.54s | 0.06s |
+| 15 (default) | TERM | 14.53s | 0.06s |
+| 15 (default) | HUP | 14.52s | 0.06s |
+
+`bin/fm-watch-arm.sh --restart` allows the outgoing watcher 50 iterations of `sleep 0.1`, a 5s budget, before forking a replacement.
+At the 15s default the old latency exceeded that budget outright, so a restart forked a second watcher while the first was still alive and still holding the lock.
+The singleton lock is released in every measured case.
+
+Current limit: the herdr push path in `event_wait_or_sleep` waits inside a foreground command substitution, so a push-capable home remains up to `FM_POLL` deaf to its own stop signal.
+That reader owns a fifo directory and a child reader process that it removes on its own return path, so interrupting it from the caller would leak both on every stop.
+
 Deterministic entry points:
 
 ```sh

--- a/tests/fm-watcher-lock.test.sh
+++ b/tests/fm-watcher-lock.test.sh
@@ -22,6 +22,15 @@ mark_pr_check_migration_complete() {
   chmod 0600 "$state/.pr-check-migration-scan-v1" "$state/.pr-check-migration-v1"
 }
 
+# Sub-second mtime of the watcher liveness beacon. Whole seconds are too coarse
+# to tell "still cycling" from "frozen" at a short test poll, so read the
+# fractional stamp: GNU `%y` first, BSD `%Fm` as the fallback.
+beacon_stamp() {
+  local beat="$1/.last-watcher-beat"
+  [ -e "$beat" ] || return 1
+  stat -c %y "$beat" 2>/dev/null || stat -f %Fm "$beat" 2>/dev/null
+}
+
 
 test_singleton_start() {
   local dir state fakebin out1 out2 pid1 pid2 live i
@@ -501,6 +510,134 @@ test_watcher_self_evicts_on_lock_takeover() {
   lock_pid=$(cat "$state/.watch.lock/pid" 2>/dev/null || true)
   [ "$lock_pid" = "$$" ] || fail "self-evicting watcher clobbered the new holder's lock (got '$lock_pid')"
   pass "watcher self-evicts when the lock pid no longer names it"
+}
+
+test_watcher_stops_promptly_on_term() {
+  # A watcher must honor its own stop signal within the cycle it receives it, not
+  # at the end of the current poll interval. Bash defers a trapped signal until
+  # the running foreground command returns, so a blind `sleep "$POLL"` made exit
+  # latency track FM_POLL exactly (measured 14.68s at the 15s default). Every
+  # stop path pays that: fm-watch-arm.sh's HUP/TERM teardown, and its --restart
+  # stop-then-relaunch, which gives the old watcher only 5s to exit before
+  # falling through to a fresh child. Pin the property with a poll interval far
+  # longer than the exit budget, so a regression cannot pass on timing luck.
+  local dir state fakebin out pid i status
+  dir=$(make_case term-latency)
+  state="$dir/state"
+  fakebin="$dir/fakebin"
+  out="$dir/watch.out"
+  PATH="$fakebin:$PATH" FM_STATE_OVERRIDE="$state" FM_POLL=60 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$out" &
+  pid=$!
+  i=0
+  while [ "$i" -lt 100 ]; do
+    [ "$(cat "$state/.watch.lock/pid" 2>/dev/null || true)" = "$pid" ] \
+      && [ -e "$state/.last-watcher-beat" ] \
+      && break
+    sleep 0.1
+    i=$((i + 1))
+  done
+  [ "$(cat "$state/.watch.lock/pid" 2>/dev/null || true)" = "$pid" ] \
+    || fail "watcher did not take the lock before the stop-signal check"
+  # The watcher is now inside its 60s cycle wait. A watcher that only reacts when
+  # that wait expires blows this budget by a wide margin.
+  kill -TERM "$pid" 2>/dev/null || fail "could not signal the watcher"
+  wait_for_exit "$pid" 100
+  status=$?
+  [ "$status" -ne 124 ] || fail "watcher ignored TERM for its whole poll interval"
+  [ ! -e "$state/.watch.lock/pid" ] || fail "stopped watcher left its singleton lock claimed"
+  pass "watcher honors a stop signal without waiting out its poll interval"
+}
+
+test_watch_restart_hands_over_within_its_own_budget() {
+  # The consequence the prompt-exit property exists for. --restart signals this
+  # home's watcher, then waits only 50 * 0.1s for it to exit before forking a
+  # fresh one. A watcher that stays deaf past that budget is still alive and
+  # still holding the lock when the replacement starts, so the replacement sees
+  # a live holder and no-ops - the restart never produces the fresh watcher it
+  # reported wanting. Assert the handover completes inside the arm's own budget
+  # and that the outgoing watcher is gone by the time the incoming one holds the
+  # lock, so the two never overlap.
+  local dir state fakebin out armout old_pid arm_pid lock_pid i
+  dir=$(make_case restart-handover)
+  state="$dir/state"
+  fakebin="$dir/fakebin"
+  out="$dir/watch.out"
+  armout="$dir/restart.out"
+  mark_pr_check_migration_complete "$state"
+  PATH="$fakebin:$PATH" FM_HOME="$dir" FM_POLL=60 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$out" &
+  old_pid=$!
+  i=0
+  while [ "$i" -lt 100 ]; do
+    [ "$(cat "$state/.watch.lock/pid" 2>/dev/null || true)" = "$old_pid" ] \
+      && [ -s "$state/.watch.lock/pid-identity" ] \
+      && [ -e "$state/.last-watcher-beat" ] \
+      && break
+    sleep 0.1
+    i=$((i + 1))
+  done
+  [ "$(cat "$state/.watch.lock/pid" 2>/dev/null || true)" = "$old_pid" ] \
+    || fail "outgoing watcher did not take the lock before the restart"
+  PATH="$fakebin:$PATH" FM_HOME="$dir" FM_POLL=60 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 FM_ARM_CONFIRM_TIMEOUT=5 "$WATCH_ARM" --restart > "$armout" &
+  arm_pid=$!
+  # 50 iterations of 0.1s is exactly the arm's own stop-wait budget, so this
+  # cannot pass by merely being faster than some looser test deadline.
+  i=0
+  lock_pid=
+  while [ "$i" -lt 50 ]; do
+    lock_pid=$(cat "$state/.watch.lock/pid" 2>/dev/null || true)
+    { [ -n "$lock_pid" ] && [ "$lock_pid" != "$old_pid" ] && kill -0 "$lock_pid" 2>/dev/null; } && break
+    sleep 0.1
+    i=$((i + 1))
+  done
+  { [ -n "$lock_pid" ] && [ "$lock_pid" != "$old_pid" ]; } \
+    || fail "restart did not hand the lock to a fresh watcher inside its 5s budget (lock still '$lock_pid')"
+  is_live_non_zombie "$old_pid" \
+    && fail "outgoing watcher was still live while its replacement held the lock"
+  kill "$arm_pid" "$lock_pid" 2>/dev/null || true
+  wait "$arm_pid" 2>/dev/null || true
+  wait "$old_pid" 2>/dev/null || true
+  pass "watch restart hands over to a fresh watcher inside its own stop budget"
+}
+
+test_watcher_liveness_beacon_survives_interruptible_waits() {
+  # Guard rail on the fix above. The cycle wait now runs as a background child,
+  # so the failure mode to exclude is a watcher that keeps its lock and its
+  # process while no longer cycling: the beacon would freeze and every wedge
+  # alarm built on it would go quiet on a watcher that looks alive. Require the
+  # beacon to keep advancing across several cycle waits, then require it to stop
+  # advancing and the lock to clear once the watcher genuinely stops, so a
+  # stopped watcher is still detectable.
+  local dir state fakebin out pid first second after i
+  dir=$(make_case beacon-cadence)
+  state="$dir/state"
+  fakebin="$dir/fakebin"
+  out="$dir/watch.out"
+  mark_pr_check_migration_complete "$state"
+  PATH="$fakebin:$PATH" FM_STATE_OVERRIDE="$state" FM_POLL=0.2 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$out" &
+  pid=$!
+  i=0
+  while [ "$i" -lt 100 ]; do
+    [ -e "$state/.last-watcher-beat" ] && break
+    sleep 0.1
+    i=$((i + 1))
+  done
+  first=$(beacon_stamp "$state") || fail "watcher never published a liveness beacon"
+  i=0
+  second=$first
+  while [ "$i" -lt 100 ] && [ "$second" = "$first" ]; do
+    sleep 0.1
+    second=$(beacon_stamp "$state")
+    i=$((i + 1))
+  done
+  [ "$second" != "$first" ] || fail "liveness beacon froze while the watcher was cycling"
+  is_live_non_zombie "$pid" || fail "watcher exited on its own during the cadence check"
+  kill -TERM "$pid" 2>/dev/null || fail "could not stop the watcher"
+  wait_for_exit "$pid" 100
+  [ ! -e "$state/.watch.lock/pid" ] || fail "stopped watcher left its singleton lock claimed"
+  after=$(beacon_stamp "$state")
+  sleep 1
+  [ "$(beacon_stamp "$state")" = "$after" ] || fail "beacon kept advancing after the watcher stopped"
+  pass "liveness beacon advances while cycling and goes stale once the watcher stops"
 }
 
 test_arm_self_eviction_is_loud_without_successor() {
@@ -1029,6 +1166,9 @@ test_lock_paused_mid_acquire_claim_fails_during_steal
 test_watch_restart_rejects_reused_pid
 test_watch_restart_attaches_to_healthy_peer
 test_watcher_self_evicts_on_lock_takeover
+test_watcher_stops_promptly_on_term
+test_watch_restart_hands_over_within_its_own_budget
+test_watcher_liveness_beacon_survives_interruptible_waits
 test_arm_self_eviction_is_loud_without_successor
 test_arm_attaches_and_waits_for_live_fresh_watcher
 test_attached_arm_signal_is_recorded_in_cycle_ledger

--- a/tests/fm-watcher-lock.test.sh
+++ b/tests/fm-watcher-lock.test.sh
@@ -530,7 +530,7 @@ test_watcher_stops_promptly_on_term() {
   # A watcher must honor its own stop signal within the cycle it receives it, not
   # at the end of the current poll interval. Bash defers a trapped signal until
   # the running foreground command returns, so a blind `sleep "$POLL"` made exit
-  # latency track FM_POLL exactly (measured 14.68s at the 15s default). Every
+  # latency track FM_POLL exactly (measured 14.53s at the 15s default). Every
   # stop path pays that: fm-watch-arm.sh's HUP/TERM teardown, and its --restart
   # stop-then-relaunch, which gives the old watcher only 5s to exit before
   # falling through to a fresh child. Pin the property with a poll interval far

--- a/tests/fm-watcher-lock.test.sh
+++ b/tests/fm-watcher-lock.test.sh
@@ -447,14 +447,28 @@ test_watch_restart_rejects_reused_pid() {
 }
 
 test_watch_restart_attaches_to_healthy_peer() {
-  local dir state fakebin out peer identity armpid status i
+  local dir state fakebin out peer ready identity armpid status i
   dir=$(make_case restart-healthy-peer)
   state="$dir/state"
   fakebin="$dir/fakebin"
   out="$dir/restart.out"
+  ready="$dir/peer-ready"
   mark_pr_check_migration_complete "$state"
-  node -e 'process.on("SIGTERM", () => {}); setTimeout(() => {}, 300000)' &
+  # The peer must already be TERM-resistant when --restart signals it: node's
+  # default disposition kills it until the interpreter has actually evaluated
+  # process.on("SIGTERM"), and the restart below sends TERM milliseconds after
+  # this launch. A peer that dies there leaves a dead-pid lock the fresh child
+  # legitimately steals, so the arm reports "started" and this fixture fails for
+  # a reason it does not test. Have the peer announce that its handler is
+  # installed and wait on that exact condition.
+  node -e 'process.on("SIGTERM", () => {}); require("fs").writeFileSync(process.argv[1], "ready"); setTimeout(() => {}, 300000)' "$ready" &
   peer=$!
+  i=0
+  while [ "$i" -lt 200 ] && [ ! -s "$ready" ]; do
+    sleep 0.05
+    i=$((i + 1))
+  done
+  [ -s "$ready" ] || fail "TERM-resistant peer did not install its handler"
   identity=$(FM_STATE_OVERRIDE="$state" bash -c '. "$1"; fm_pid_identity "$2"' _ "$LIB" "$peer") || fail "could not identify peer pid"
   mkdir "$state/.watch.lock"
   printf '%s\n' "$peer" > "$state/.watch.lock/pid"


### PR DESCRIPTION
## Intent

Fix the firstmate watcher ignoring TERM and HUP for a full poll interval, which overruns the restart budget.

THE DEFECT: bin/fm-watch.sh ended each supervision cycle with a blind foreground `sleep "$POLL"`. Bash defers a trapped signal until the running foreground command returns, so the watcher was deaf to TERM/HUP/INT for the remainder of the interval and exit latency tracked FM_POLL exactly. The signal-grace linger had the same shape. bin/fm-watch-arm.sh --restart allows the outgoing watcher only 50 iterations of `sleep 0.1` (a 5s budget) before forking a replacement, so at the 15s default a restart forked a second watcher while the first was still alive and holding the lock; the replacement then saw a live holder and stood down, and the restart never produced the fresh watcher it reported wanting. This is the shape behind repeated 'restart did not attach to the healthy peer' behavior. It is distinct from the test-fixture startup race fixed separately.

REQUIRED APPROACH (all followed): reproduce the latency measurement on this base and record the number in the commit message; start from a preserved verified fix rather than reimplementing it, understanding it rather than treating it as a black box; verify the signal is honored well inside the 5s restart budget and that a restart attaches to a healthy peer rather than starting a second watcher; keep the preserved regression test or replace it with a stronger one.

MEASUREMENT reproduced on base 1e24757 against an isolated temporary home, signalling a watcher that had already taken its lock and entered its cycle wait. Before -> after: FM_POLL=1 TERM 0.54s -> 0.05s; FM_POLL=5 TERM 4.54s -> 0.06s; FM_POLL=15 (default) TERM 14.53s -> 0.06s; FM_POLL=15 HUP 14.52s -> 0.06s. These numbers are the whole argument for the change and are deliberately in the commit message and in docs/verification/supervision.md.

THE FIX: run the cycle wait and the signal-grace linger as a tracked background child and `wait` on the named pid, so the trap runs the moment the signal lands. Same wait budget, no change to polling cadence or wake classification. The EXIT path reaps the sleep child rather than orphaning it (verified empirically: no leaked sleep child after a mid-interval stop). This is the preserved fix; I reviewed and agree with its approach, and adjusted its comment to the numbers measured on this base.

ACCEPTANCE CRITERION THAT SHAPED THE DESIGN: watcher liveness and wedge detection must not be weakened - a watcher that has genuinely stopped must still be detected. This is the constraint that could turn this fix into a worse bug, so it is covered explicitly by a test asserting the heartbeat beacon keeps advancing across cycle waits and then freezes once the watcher stops.

DELIBERATE SCOPE DECISION - the herdr push path is knowingly NOT fixed. event_wait_or_sleep's herdr reader waits inside a foreground command substitution, so a push-capable home remains up to FM_POLL deaf to its own stop signal. That reader owns a fifo directory and a child reader process that it removes on its own return path, so interrupting it from the caller would leak both on every stop - exactly the 'worse bug' the acceptance criteria warn against. Fixing it needs reader-side teardown as its own change. This limit is documented at the call site and in docs/verification/supervision.md; it is a deliberate boundary, not an oversight.

SCOPE DISCIPLINE: another task touches bin/fm-watch.sh in the stale-wake suppression logic around the pane-hash guard. This change deliberately stays in the signal-handling and poll-wait path and does not touch stale-wake suppression.

REGRESSION COVERAGE in tests/fm-watcher-lock.test.sh, all confirmed to fail or hold against the unpatched watcher: (1) the preserved test - watcher exits on TERM well inside a 10s budget at FM_POLL=60, fails unpatched with 'watcher ignored TERM for its whole poll interval'; (2) new - --restart hands the lock to a fresh live watcher within the arm's own 5s budget with no overlap between outgoing and incoming, fails unpatched; (3) new - liveness beacon advances while cycling and freezes once stopped, holds both before and after as a guard against trading exit latency for a watcher that keeps its lock while no longer cycling.

CHERRY-PICKED DEPENDENCY: commit 3db0341 'fix(tests): wait for the TERM-resistant peer before restarting the watcher' is cherry-picked from PR 1487 (https://github.com/kunchenguid/firstmate/pull/1487). It is not this PR author's work, and the two PRs therefore deliberately share a commit. It is carried because this branch's base lacks it, and without it tests/fm-watcher-lock.test.sh flakes roughly half the time at test_watch_restart_attaches_to_healthy_peer for a reason unrelated to this change; PR 1487 is blocked on an upstream maintainer with no timeline, and shipping a knowingly unstable test signal fails the standing bar that a red result must always mean something. MERGE ORDERING CONSEQUENCE: if 1487 lands first this becomes a duplicate that git will reconcile, and if this PR lands first then 1487 shrinks. With it cherry-picked, the previously flaky case ran 12/12 green and the full suite is 33 assertions clean.

VERIFICATION RUN: bin/fm-lint.sh clean, bin/fm-doc-audience-check.sh clean, all 10 suites selected by bin/fm-test-run.sh --changed passed, full tests/fm-watcher-lock.test.sh green at 33 assertions.

REPO CONVENTIONS: firstmate tracked material follows one sentence per line in Markdown, plain dash never em dash, shellcheck-clean bin scripts via bin/fm-lint.sh, tests colocated in tests/ extending the existing suite, and no agent name as a commit co-author.

## What Changed

- Make watcher poll and signal-grace waits interruptible by TERM, HUP, and INT, reaping the tracked sleep child during cleanup so restarts can hand off within their 5-second budget without changing polling cadence or liveness detection.
- Add regression coverage for prompt termination, restart lock handoff, and heartbeat continuity; document measured latency improvements and the remaining herdr push-path limitation.
- Cherry-pick commit `3db0341` from [PR #1487](https://github.com/kunchenguid/firstmate/pull/1487) to stabilize the TERM-resistant peer fixture. This is not the author's work and is intentionally shared: if #1487 lands first Git will reconcile the duplicate, while if this PR lands first #1487 will shrink.

## Risk Assessment

✅ Low: the change is narrowly scoped, preserves watcher cadence and liveness semantics, explicitly documents the authorized Herdr limitation, and adds targeted regression coverage for prompt termination and restart handover.

## Testing

The supplied baseline reported lint, documentation checks, all 10 changed suites, and 33 watcher assertions clean; this phase independently passed the focused watcher-lock suite and real-process TERM, HUP, signal-grace, restart-handoff, child-reaping, lock-cleanup, and heartbeat checks. This is a process/CLI change, so reviewer-visible evidence is a CLI transcript rather than an image.

<details>
<summary>Evidence: End-to-end watcher evidence</summary>

`TERM/HUP cycle waits: 4 ms; TERM signal-grace: 4 ms; restart handoff: 158 ms with no overlap; sleep children and locks cleaned; heartbeat advanced while running and froze after stop.`

```text
Firstmate watcher end-to-end evidence
commit=c46e3b1febb00bec0cf395bb66d3ffad8fa87124
TERM cycle-wait: latency=4ms exit=1 lock=cleared sleep_child_reaped=yes
HUP cycle-wait: latency=4ms exit=1 lock=cleared sleep_child_reaped=yes
TERM signal-grace: latency=4ms exit=1 lock=cleared sleep_child_reaped=yes
restart: latency=158ms old_pid=2138403 new_pid=2138572 old_alive_when_new_owned_lock=no new_alive=yes
restart CLI: watcher: started pid=2138572 (beacon fresh)
restart cleanup: replacement_alive=no lock=cleared
heartbeat: advanced_while_running=yes frozen_after_stop=yes lock=cleared
result=PASS (all latency, handoff, cleanup, and liveness checks met)
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>Inspected `git diff 1e247571aa75e00b00c7a01c4830025ecd44dc61..c46e3b1febb00bec0cf395bb66d3ffad8fa87124` and both commit messages against the acceptance criteria.</code>
- <code>Ran `bash tests/fm-watcher-lock.test.sh`.</code>
- <code>Ran `/tmp/no-mistakes-evidence/01KYZVD59V01PM7HH7W7T8B9AH/verify-watcher-latency.sh /home/sungin/.no-mistakes/worktrees/bc8432f7c9f8/01KYZVD59V01PM7HH7W7T8B9AH /tmp/no-mistakes-evidence/01KYZVD59V01PM7HH7W7T8B9AH` and captured the transcript.</code>
- `Verified no watcher processes or transient worktree artifacts remained after testing.`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>

