### PR TITLE
fix(bin): make coverage guard collation independent

### DIFF
--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -562,6 +562,12 @@ select_lane() {
   [ "$found" -eq 1 ] || die "lane '$want' selected no tests"
 }
 
+# Every list below is built with `LC_ALL=C sort`, so every set operation over
+# those files must also run under LC_ALL=C. Under a UTF-8 collation `comm` reads
+# byte-sorted paths as unsorted (glibc's en_US.UTF-8 ignores `-` at the primary
+# weight, so "fm-backend.test.sh" collates before "fm-backend-tmux-smoke.test.sh"
+# while C orders them the other way), which makes `comm` emit a bogus
+# "not in sorted order" warning and either exit 1 or return a wrong set diff.
 run_coverage_guard() {
   local tmp missing extra a b shard
   local -a saved_scripts=()
@@ -580,8 +586,8 @@ run_coverage_guard() {
     return 1
   fi
   cat "$tmp/s1" "$tmp/s2" | LC_ALL=C sort -u >"$tmp/shards_union"
-  missing=$(comm -23 "$tmp/proven" "$tmp/shards_union" || true)
-  extra=$(comm -13 "$tmp/proven" "$tmp/shards_union" || true)
+  missing=$(LC_ALL=C comm -23 "$tmp/proven" "$tmp/shards_union" || true)
+  extra=$(LC_ALL=C comm -13 "$tmp/proven" "$tmp/shards_union" || true)
   if [ -n "$missing" ] || [ -n "$extra" ]; then
     log "coverage guard: portable shards must equal the proven-isolated set"
     [ -z "$missing" ] || { log "missing from shards:"; printf '%s\n' "$missing" >&2; }
@@ -625,8 +631,8 @@ run_coverage_guard() {
     return 1
   fi
   LC_ALL=C sort -u "$tmp/serial_shards_raw" >"$tmp/serial_shards"
-  missing=$(comm -23 "$tmp/serial" "$tmp/serial_shards" || true)
-  extra=$(comm -13 "$tmp/serial" "$tmp/serial_shards" || true)
+  missing=$(LC_ALL=C comm -23 "$tmp/serial" "$tmp/serial_shards" || true)
+  extra=$(LC_ALL=C comm -13 "$tmp/serial" "$tmp/serial_shards" || true)
   if [ -n "$missing" ] || [ -n "$extra" ]; then
     log "coverage guard: portable serial shards must equal the portable serial lane"
     [ -z "$missing" ] || { log "missing from serial shards:"; printf '%s\n' "$missing" >&2; }
@@ -638,7 +644,7 @@ run_coverage_guard() {
   for pair in "shards_union:serial" "shards_union:herdr" "serial:herdr"; do
     a=${pair%%:*}
     b=${pair#*:}
-    comm -12 "$tmp/$a" "$tmp/$b" >"$tmp/overlap"
+    LC_ALL=C comm -12 "$tmp/$a" "$tmp/$b" >"$tmp/overlap"
     if [ -s "$tmp/overlap" ]; then
       log "coverage guard: overlap between $a and $b:"
       cat "$tmp/overlap" >&2
@@ -656,8 +662,8 @@ run_coverage_guard() {
     return 1
   fi
   LC_ALL=C sort -u "$tmp/union_raw" >"$tmp/union"
-  missing=$(comm -23 "$tmp/all" "$tmp/union" || true)
-  extra=$(comm -13 "$tmp/all" "$tmp/union" || true)
+  missing=$(LC_ALL=C comm -23 "$tmp/all" "$tmp/union" || true)
+  extra=$(LC_ALL=C comm -13 "$tmp/all" "$tmp/union" || true)
   if [ -n "$missing" ] || [ -n "$extra" ]; then
     log "coverage guard: union of portable shards + portable serial + Herdr must equal tests/*.test.sh"
     [ -z "$missing" ] || { log "missing from union:"; printf '%s\n' "$missing" >&2; }
@@ -670,7 +676,7 @@ run_coverage_guard() {
     "$ROOT/bin/fm-test-isolation-proof.sh" --list | LC_ALL=C sort -u >"$tmp/proof_list"
     if ! cmp -s "$tmp/proven" "$tmp/proof_list"; then
       log "coverage guard: embedded proven-isolated set diverges from bin/fm-test-isolation-proof.sh --list"
-      comm -3 "$tmp/proven" "$tmp/proof_list" >&2 || true
+      LC_ALL=C comm -3 "$tmp/proven" "$tmp/proof_list" >&2 || true
       rm -rf "$tmp"
       return 1
     fi

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -563,11 +563,11 @@ select_lane() {
 }
 
 # Every list below is built with `LC_ALL=C sort`, so every set operation over
-# those files must also run under LC_ALL=C. Under a UTF-8 collation `comm` reads
-# byte-sorted paths as unsorted (glibc's en_US.UTF-8 ignores `-` at the primary
-# weight, so "fm-backend.test.sh" collates before "fm-backend-tmux-smoke.test.sh"
-# while C orders them the other way), which makes `comm` emit a bogus
-# "not in sorted order" warning and either exit 1 or return a wrong set diff.
+# those files must also run under LC_ALL=C. Under dictionary-style collation,
+# `comm` can read byte-sorted paths as unsorted (glibc's en_US.UTF-8 ignores `-`
+# at the primary weight, so "fm-backend.test.sh" collates before
+# "fm-backend-tmux-smoke.test.sh" while C orders them the other way), which
+# makes `comm` emit a bogus warning and either exit 1 or return a wrong set diff.
 run_coverage_guard() {
   local tmp missing extra a b shard
   local -a saved_scripts=()

--- a/tests/fm-test-run.test.sh
+++ b/tests/fm-test-run.test.sh
@@ -25,8 +25,8 @@ test_list_all_exact_suite_coverage() {
     done | LC_ALL=C sort
   )
   [ -n "$listed" ] || fail "--list --all printed nothing"
-  missing=$(comm -23 <(printf '%s\n' "$expected") <(printf '%s\n' "$listed") || true)
-  extra=$(comm -13 <(printf '%s\n' "$expected") <(printf '%s\n' "$listed") || true)
+  missing=$(LC_ALL=C comm -23 <(printf '%s\n' "$expected") <(printf '%s\n' "$listed") || true)
+  extra=$(LC_ALL=C comm -13 <(printf '%s\n' "$expected") <(printf '%s\n' "$listed") || true)
   [ -z "$missing" ] || fail "--list --all missing scripts: $missing"
   [ -z "$extra" ] || fail "--list --all unexpected scripts: $extra"
   # No duplicates.
@@ -171,10 +171,8 @@ test_changed_dependency_selection_and_unmapped_failure() {
   git -C "$repo" -c user.name=test -c user.email=test@example.invalid commit -qm non-bin-source-change
 
   printf '\n' >>"$repo/src/unmapped.ts"
-  set +e
-  (cd "$repo" && bin/fm-test-run.sh --list --changed --base HEAD) >"$tmp/out" 2>"$tmp/err"
-  rc=$?
-  set -e
+  rc=0
+  (cd "$repo" && bin/fm-test-run.sh --list --changed --base HEAD) >"$tmp/out" 2>"$tmp/err" || rc=$?
   [ "$rc" -eq 2 ] || fail "unmapped changed source must fail with exit 2, got $rc"
   grep -Fq 'no changed-test mapping for source path: src/unmapped.ts' "$tmp/err" \
     || fail "unmapped changed source failure is not actionable: $(cat "$tmp/err")"
@@ -266,18 +264,14 @@ echo "not ok - fail"
 exit 1
 SH
   chmod +x "$pass_f" "$fail_f"
-  set +e
-  "$RUNNER" "$pass_f" "$fail_f" >"$tmp/out.txt" 2>"$tmp/err.txt"
-  rc=$?
-  set -e
+  rc=0
+  "$RUNNER" "$pass_f" "$fail_f" >"$tmp/out.txt" 2>"$tmp/err.txt" || rc=$?
   [ "$rc" -ne 0 ] || fail "aggregate exit must be non-zero when any script fails"
   grep -q 'FM_TEST_SUMMARY total=2 failed=1' "$tmp/out.txt" \
     || fail "summary should report total=2 failed=1: $(grep FM_TEST_SUMMARY "$tmp/out.txt")"
   # All-green stays 0.
-  set +e
-  "$RUNNER" "$pass_f" >"$tmp/out2.txt" 2>"$tmp/err2.txt"
-  rc=$?
-  set -e
+  rc=0
+  "$RUNNER" "$pass_f" >"$tmp/out2.txt" 2>"$tmp/err2.txt" || rc=$?
   [ "$rc" -eq 0 ] || { rm -rf "$tmp"; fail "aggregate exit must be 0 when every script passes"; }
   rm -rf "$tmp"
   pass "aggregate exit reflects any script failure"
@@ -323,10 +317,8 @@ echo "skip: herdr not found"
 exit 0
 SH
   chmod +x "$skip_f"
-  set +e
-  "$RUNNER" --fail-on-gate-skip 'herdr not found' "$skip_f" >"$out" 2>"$tmp/err.txt"
-  rc=$?
-  set -e
+  rc=0
+  "$RUNNER" --fail-on-gate-skip 'herdr not found' "$skip_f" >"$out" 2>"$tmp/err.txt" || rc=$?
   [ "$rc" -ne 0 ] || fail "fail-on-gate-skip must make herdr-not-found a hard failure"
   grep -q 'FM_TEST_SUMMARY total=1 failed=1' "$out" \
     || fail "summary must report failed=1 under fail-on-gate-skip: $(grep FM_TEST_SUMMARY "$out")"
@@ -359,7 +351,7 @@ test_portable_shard_union_and_coverage_guard() {
   herdr=$("$RUNNER" --list --family real-herdr-gated)
   [ -n "$s1" ] && [ -n "$s2" ] || fail "portable parallel shards must be non-empty"
   # Shards disjoint.
-  overlap=$(comm -12 <(printf '%s\n' "$s1" | LC_ALL=C sort) <(printf '%s\n' "$s2" | LC_ALL=C sort) || true)
+  overlap=$(LC_ALL=C comm -12 <(printf '%s\n' "$s1" | LC_ALL=C sort) <(printf '%s\n' "$s2" | LC_ALL=C sort) || true)
   [ -z "$overlap" ] || fail "portable parallel shards overlap: $overlap"
   # Union of shards equals proven-isolated.
   [ "$(printf '%s\n' "$s1" "$s2" | LC_ALL=C sort -u)" = \
@@ -440,53 +432,87 @@ test_portable_serial_shard_lane_refusals() {
 
   # A lane built for a different shard count must refuse rather than run a
   # partial suite: this is what keeps a CI matrix from silently dropping tests.
-  set +e
-  "$RUNNER" --list --lane "portable-serial-1of${other}" >"$tmp/out" 2>"$tmp/err"
-  rc=$?
-  set -e
+  rc=0
+  "$RUNNER" --list --lane "portable-serial-1of${other}" >"$tmp/out" 2>"$tmp/err" || rc=$?
   [ "$rc" -eq 2 ] || fail "mismatched shard count must refuse (exit 2), got $rc"
   [ ! -s "$tmp/out" ] || fail "mismatched shard count must not list tests"
   grep -Fq "configured for $count" "$tmp/err" \
     || fail "mismatch refusal must name the configured count: $(cat "$tmp/err")"
 
-  set +e
-  "$RUNNER" --list --lane "portable-serial-$((count + 1))of${count}" >"$tmp/out2" 2>"$tmp/err2"
-  rc=$?
-  set -e
+  rc=0
+  "$RUNNER" --list --lane "portable-serial-$((count + 1))of${count}" >"$tmp/out2" 2>"$tmp/err2" || rc=$?
   [ "$rc" -eq 2 ] || fail "out-of-range shard index must refuse (exit 2), got $rc"
   grep -Fq "outside 1..$count" "$tmp/err2" \
     || fail "range refusal message missing: $(cat "$tmp/err2")"
 
-  set +e
-  "$RUNNER" --list --lane portable-serial-1 >"$tmp/out3" 2>"$tmp/err3"
-  rc=$?
-  set -e
+  rc=0
+  "$RUNNER" --list --lane portable-serial-1 >"$tmp/out3" 2>"$tmp/err3" || rc=$?
   [ "$rc" -eq 2 ] || fail "shard lane without a count must refuse (exit 2), got $rc"
   rm -rf "$tmp"
   pass "portable serial shard lanes refuse mismatched, out-of-range, and countless names"
 }
 
+# The coverage guard builds every list with `LC_ALL=C sort`, so its set
+# operations must run under LC_ALL=C too. Under a dictionary-collation locale
+# (glibc en_US.UTF-8 ignores `-` at the primary weight, so "fm-backend.test.sh"
+# collates before "fm-backend-tmux-smoke.test.sh" while C orders them the other
+# way) an ambient-locale `comm` reads the byte-sorted lists as unsorted, warns
+# "not in sorted order", and exits 1 under the runner's `set -e`.
+test_coverage_guard_is_collation_independent() {
+  local tmp loc probe divergent rc n
+  tmp=$(mktemp -d "${TMPDIR:-/tmp}/fm-test-run-collation.XXXXXX")
+
+  # Locales to prove clean: always C plus the ambient one the caller runs under.
+  # Any installed locale whose collation disagrees with byte order is the case
+  # that actually catches a locale-unsafe set operation, so add the first one.
+  divergent=
+  while IFS= read -r loc; do
+    [ -n "$loc" ] || continue
+    probe=$(printf 'a-b\na.a\n' | LC_ALL="$loc" sort 2>/dev/null | head -n 1) || continue
+    # Byte order puts "a-b" first ('-' 0x2D < '.' 0x2E). Dictionary collation
+    # ignores both separators at the primary weight and compares "ab" to "aa",
+    # putting "a.a" first - the exact disagreement that trips the guard.
+    [ "$probe" = "a.a" ] || continue
+    divergent="$loc"
+    break
+  done <<<"$(locale -a 2>/dev/null || true)"
+
+  n=0
+  for loc in C "${LC_ALL:-${LANG:-C}}" ${divergent:+"$divergent"}; do
+    rc=0
+    LC_ALL="$loc" "$RUNNER" --check-coverage >"$tmp/out" 2>"$tmp/err" || rc=$?
+    [ "$rc" -eq 0 ] \
+      || fail "coverage guard exited $rc under LC_ALL=$loc: $(cat "$tmp/err")"
+    [ ! -s "$tmp/err" ] \
+      || fail "coverage guard emitted stderr under LC_ALL=$loc: $(cat "$tmp/err")"
+    assert_contains "$(cat "$tmp/out")" "FM_TEST_COVERAGE ok" \
+      "coverage guard success marker under LC_ALL=$loc"
+    n=$((n + 1))
+  done
+
+  rm -rf "$tmp"
+  if [ -z "$divergent" ]; then
+    printf 'note: no dictionary-collation locale installed; ' >&2
+    printf 'collation-divergence leg not exercised\n' >&2
+  fi
+  pass "coverage guard is clean under $n locale(s), including collation divergence"
+}
+
 test_jobs_requires_proven_isolated() {
   local tmp rc shard_lane
   tmp=$(mktemp -d "${TMPDIR:-/tmp}/fm-test-run-jobs.XXXXXX")
-  set +e
-  "$RUNNER" --jobs 2 --lane portable-serial >"$tmp/out" 2>"$tmp/err"
-  rc=$?
-  set -e
+  rc=0
+  "$RUNNER" --jobs 2 --lane portable-serial >"$tmp/out" 2>"$tmp/err" || rc=$?
   [ "$rc" -eq 2 ] || fail "--jobs with portable-serial must refuse (exit 2), got $rc"
   grep -Fq 'not in the proven-isolated set' "$tmp/err" \
     || fail "--jobs refusal message missing: $(cat "$tmp/err")"
-  set +e
-  "$RUNNER" --jobs 2 tests/fm-watcher-lock.test.sh >"$tmp/out2" 2>"$tmp/err2"
-  rc=$?
-  set -e
+  rc=0
+  "$RUNNER" --jobs 2 tests/fm-watcher-lock.test.sh >"$tmp/out2" 2>"$tmp/err2" || rc=$?
   [ "$rc" -eq 2 ] || fail "--jobs on watcher-lock must refuse, got $rc"
   # Sharding across runners never relaxes the serial rule inside one shard.
   shard_lane=$("$RUNNER" --list-lanes | grep -m1 '^portable-serial-[0-9]*of[0-9]*$')
-  set +e
-  "$RUNNER" --jobs 2 --lane "$shard_lane" >"$tmp/out3" 2>"$tmp/err3"
-  rc=$?
-  set -e
+  rc=0
+  "$RUNNER" --jobs 2 --lane "$shard_lane" >"$tmp/out3" 2>"$tmp/err3" || rc=$?
   [ "$rc" -eq 2 ] || fail "--jobs with a portable serial shard must refuse, got $rc"
   grep -Fq 'not in the proven-isolated set' "$tmp/err3" \
     || fail "shard --jobs refusal message missing: $(cat "$tmp/err3")"
@@ -553,12 +579,10 @@ touch "$SCHED_EVIDENCE/replacement-started"
 echo "ok - replacement fixture started before slow fixture finished"
 SH
   chmod +x "$runner" "$repo/$a" "$repo/$b" "$repo/$c" "$fake_bin/stat"
-  set +e
+  rc=0
   PATH="$fake_bin:$PATH" SCHED_EVIDENCE="$evidence" SCHED_WAIT_FOR_REPLACEMENT=1 \
     "$runner" --jobs 2 --json "$tmp/timing.json" \
-    "$a" "$b" "$c" >"$tmp/out" 2>"$tmp/err"
-  rc=$?
-  set -e
+    "$a" "$b" "$c" >"$tmp/out" 2>"$tmp/err" || rc=$?
   [ "$rc" -eq 0 ] || { cat "$tmp/out" "$tmp/err"; rm -rf "$tmp"; fail "jobs=2 must refill the first completed slot"; }
   begin_n=$(grep -c '^FM_TEST_BEGIN ' "$tmp/out" || true)
   end_n=$(grep -c '^FM_TEST_END ' "$tmp/out" || true)
@@ -581,10 +605,8 @@ echo "not ok - deliberate fail"
 exit 1
 SH
   chmod +x "$tmp/fail.test.sh"
-  set +e
-  "$runner" --jobs 2 "$a" "$tmp/fail.test.sh" >"$tmp/out3" 2>"$tmp/err3"
-  rc=$?
-  set -e
+  rc=0
+  "$runner" --jobs 2 "$a" "$tmp/fail.test.sh" >"$tmp/out3" 2>"$tmp/err3" || rc=$?
   [ "$rc" -eq 2 ] || fail "jobs with non-proven fail fixture must refuse before run, got $rc"
 
   # Parallel failure propagation stays inside the private runner fixture.
@@ -594,10 +616,9 @@ echo "not ok - deliberate proven-set fail"
 exit 1
 SH
   chmod +x "$repo/$b"
-  set +e
-  SCHED_EVIDENCE="$evidence" "$runner" --jobs 2 "$a" "$b" >"$tmp/out4" 2>"$tmp/err4"
-  rc=$?
-  set -e
+  rm -f "$evidence/slow-done"
+  rc=0
+  SCHED_EVIDENCE="$evidence" "$runner" --jobs 2 "$a" "$b" >"$tmp/out4" 2>"$tmp/err4" || rc=$?
   [ "$rc" -ne 0 ] || { rm -rf "$tmp"; fail "jobs aggregate must be non-zero when a proven worker fails"; }
   grep -q 'FM_TEST_SUMMARY total=2 failed=1' "$tmp/out4" \
     || { rm -rf "$tmp"; fail "jobs failure summary wrong: $(grep FM_TEST_SUMMARY "$tmp/out4")"; }
@@ -608,10 +629,8 @@ echo "skip: herdr not found" >&2
 exit 0
 SH
   chmod +x "$repo/$d"
-  set +e
-  "$runner" --jobs 2 --fail-on-gate-skip 'herdr not found' "$d" >"$tmp/out5" 2>"$tmp/err5"
-  rc=$?
-  set -e
+  rc=0
+  "$runner" --jobs 2 --fail-on-gate-skip 'herdr not found' "$d" >"$tmp/out5" 2>"$tmp/err5" || rc=$?
   [ "$rc" -ne 0 ] || { rm -rf "$tmp"; fail "parallel stderr gate skip must hard-fail"; }
   grep -q 'FM_TEST_SUMMARY total=1 failed=1' "$tmp/out5" \
     || { rm -rf "$tmp"; fail "parallel stderr hard-fail summary wrong: $(grep FM_TEST_SUMMARY "$tmp/out5")"; }
@@ -683,6 +702,7 @@ test_exclude_family
 test_portable_shard_union_and_coverage_guard
 test_portable_serial_shards_partition_the_serial_lane
 test_portable_serial_shard_lane_refusals
+test_coverage_guard_is_collation_independent
 test_jobs_requires_proven_isolated
 test_jobs_parallel_scheduler_and_failure_propagation
 test_aggregate_json

--- a/tests/fm-test-run.test.sh
+++ b/tests/fm-test-run.test.sh
@@ -452,12 +452,7 @@ test_portable_serial_shard_lane_refusals() {
   pass "portable serial shard lanes refuse mismatched, out-of-range, and countless names"
 }
 
-# The coverage guard builds every list with `LC_ALL=C sort`, so its set
-# operations must run under LC_ALL=C too. Under a dictionary-collation locale
-# (glibc en_US.UTF-8 ignores `-` at the primary weight, so "fm-backend.test.sh"
-# collates before "fm-backend-tmux-smoke.test.sh" while C orders them the other
-# way) an ambient-locale `comm` reads the byte-sorted lists as unsorted, warns
-# "not in sorted order", and exits 1 under the runner's `set -e`.
+# Regression for the C-collation invariant documented by run_coverage_guard.
 test_coverage_guard_is_collation_independent() {
   local tmp loc probe divergent rc n
   tmp=$(mktemp -d "${TMPDIR:-/tmp}/fm-test-run-collation.XXXXXX")


### PR DESCRIPTION
## Intent

Fix tests/fm-test-run.test.sh exiting 1 while every assertion passes.

Symptom found on a clean baseline: the suite exits 1 with all assertions passing, and a stray 'comm: not in sorted order' warning emitted during the run. A test that goes red without a failed assertion is the worst possible signal - it trains people to discount red results, and two separate workers recently had to spend effort proving their own changes innocent against pre-existing failures like this.

Required approach the user specified: (1) reproduce on a clean baseline and capture which comm invocation emits the warning; (2) establish which side is actually wrong BEFORE fixing - either the input genuinely is unsorted (a real defect in what bin/fm-test-run.sh compares) or the sort ordering and comm's expectation disagree (a locale collation mismatch) - and state which in the commit message with the evidence that settled it; (3) fix the cause.

Explicit trap the user said to avoid: do NOT silence the warning to get green. If comm is right, something upstream is producing unsorted input and that is the actual bug; suppressing its complaint would hide a real comparison defect while making the suite look healthy. Equally, do not make the suite ignore a non-zero exit - the exit status must keep meaning something.

Acceptance criteria: suite exits 0 on a clean baseline with no stray warning; the commit message states plainly whether the input or the comparison was at fault, with evidence; no warning is suppressed and no assertion is weakened or removed to achieve green; covered by a test that fails against the current (pre-fix) code.

Scope constraint the user set: two other pending branches touch bin/fm-test-run.sh (one added a coverage-guard locale fix, another touched it while building a vault check). Rebase onto the default branch first and keep the change tightly scoped to the sorting defect so reconciliation stays trivial. If the fix appears to collide with an existing locale fix there, say so in the PR rather than silently reworking it. (Investigated: no existing locale fix was present at the default-branch baseline, so nothing was reworked.)

What I determined and why the diff looks the way it does:

The COMPARISON was at fault, not the input. run_coverage_guard in bin/fm-test-run.sh builds every lane list with 'LC_ALL=C sort -u' but then called comm under the ambient locale. Evidence that settled it: the portable-serial list passes 'LC_ALL=C sort -c' cleanly, while the byte-identical file fails 'sort -c' under en_US.UTF-8 at tests/fm-backend.test.sh. glibc's en_US.UTF-8 collation ignores '-' at the primary weight, so it orders fm-backend.test.sh before fm-backend-tmux-smoke.test.sh, whereas C compares bytes where '-' (0x2D) precedes '.' (0x2E). The lists were correctly sorted for the ordering the runner chose; comm was applying a different one. The unguarded 'comm -12' in the lane-overlap loop therefore exited 1 under the script's 'set -eu', killing the guard before it printed its verdict.

Fix: prefix every comm in the coverage guard (and the three in the test file) with LC_ALL=C so set operations use the same collation as the sorts that produced their inputs. This is deliberately NOT suppression - no warning is silenced and no exit status is ignored; the comparison is corrected to match its input's actual ordering. Note the '|| true'-guarded comm calls were worse in kind than the crashing one: on mis-collated input they silently return a WRONG set difference, so a real coverage hole could have passed the guard. That is why all nine sites were fixed rather than only the one that crashed.

Second, deliberate in-scope change - why the failure was invisible: each 'set +e ... rc=$?; set -e' pair in tests/fm-test-run.test.sh ENABLED errexit rather than restoring it, because the file's baseline is 'set -u' only. From the first such pair onward, any unguarded non-zero exited the suite silently with no 'not ok' line. That is precisely the reported symptom (exits 1 while every assertion passes), so fixing it is in scope, not scope creep. All ten sites were replaced with 'rc=0; <cmd> || rc=$?', which captures the status correctly whether or not errexit is on and leaks no shell option. This makes failures loud again; it does NOT make the suite ignore non-zero exits.

New regression test test_coverage_guard_is_collation_independent asserts --check-coverage exits 0 with empty stderr and prints the FM_TEST_COVERAGE ok marker under three locales: C, the ambient locale, and the first installed locale whose collation actually disagrees with byte order. That third locale is discovered by an empirical probe ('a-b' vs 'a.a' - dictionary collation puts 'a.a' first, byte order puts 'a-b' first) rather than hardcoding en_US.UTF-8, so it stays correct on machines with different locale sets; when no such locale is installed it prints an honest note to stderr rather than silently pretending the leg ran. Verified it fails loudly against the pre-fix runner by stashing the fix.

Deliberate choice a reviewer might question: the new test uses 'mktemp -d' directly rather than the tests/lib.sh fm_test_tmproot helper. That is because fm_test_tmproot is itself broken - it installs its EXIT trap inside the command-substitution subshell, so the trap fires as that subshell exits and deletes the directory it just created. 72 test files call it. That is a separate latent defect well outside this task's scope, so it was reported to the user rather than fixed here, and the new test follows the mktemp -d pattern the rest of this file already uses.

Verified before commit: suite exits 0, coverage guard reports FM_TEST_COVERAGE ok total=103, bin/fm-lint.sh exits 0, and tests/fm-lint.test.sh plus tests/fm-test-isolation-proof.test.sh pass.

## What Changed

- Run coverage-guard `comm` operations under C collation to match their byte-sorted inputs, preventing locale-dependent warnings, exits, and incorrect set differences.
- Capture expected non-zero statuses in runner tests without leaking `errexit`, ensuring unexpected failures remain visible.
- Add regression coverage that exercises the coverage guard under C, ambient, and available divergent-collation locales.

## Risk Assessment

✅ Low: The change consistently aligns every coverage-guard comm operation with its C-sorted inputs, restores reliable status capture, includes a targeted regression test, and satisfies the stated commit-history and intent requirements.

## Testing

A clean base reproduced exit 1 with only successful assertions and the stray warning; the trace identified the lane-overlap comparison, identical-input sort checks proved the locale mismatch, the regression test rejected the pre-fix runner explicitly, and both the fixed suite and direct coverage command exited 0 with empty stderr. This is CLI-only behavior, so reviewer-visible transcripts and logs were captured instead of screenshots.

<details>
<summary>Evidence: Baseline assertions</summary>

`Pre-fix suite exited 1 after only successful assertions.`

```text
ok - exact suite coverage: --all lists every tests/*.test.sh once
ok - family selection returns a proper subset of the suite
ok - single-script selection lists exactly that path
ok - changed-file selection stays conservative (never silent full suite)
ok - changed selection covers dependents and fails closed for unmapped source
ok - empty changed selection emits deterministic text and JSON summaries
ok - timing markers and JSON artifact are valid
ok - aggregate exit reflects any script failure
ok - gate-skip accounting is honest and non-failing
ok - fail-on-gate-skip converts herdr-not-found into a hard failure
ok - exclude-family drops the named primary family after selection
```
</details>
<details>
<summary>Evidence: Baseline warning</summary>

<code>comm: file 2 is not in sorted order&#10;comm: input is not in sorted order</code>

```text
comm: file 2 is not in sorted order
comm: input is not in sorted order
```
</details>
<details>
<summary>Evidence: Fixed suite transcript</summary>

`Fixed suite exited 0 with empty stderr.`

```text
ok - exact suite coverage: --all lists every tests/*.test.sh once
ok - family selection returns a proper subset of the suite
ok - single-script selection lists exactly that path
ok - changed-file selection stays conservative (never silent full suite)
ok - changed selection covers dependents and fails closed for unmapped source
ok - empty changed selection emits deterministic text and JSON summaries
ok - timing markers and JSON artifact are valid
ok - aggregate exit reflects any script failure
ok - gate-skip accounting is honest and non-failing
ok - fail-on-gate-skip converts herdr-not-found into a hard failure
ok - exclude-family drops the named primary family after selection
ok - portable shard union, disjointness, and coverage guard hold
ok - coverage guard is clean under 3 locale(s), including collation divergence
ok - --jobs refuses non-proven / stateful selections
ok - jobs scheduler runs proven scripts; failure propagates; non-proven refused
ok - aggregate-json merges lane timing artifacts
```
</details>
<details>
<summary>Evidence: Fixed coverage guard</summary>

`FM_TEST_COVERAGE ok total=103 parallel=24 serial=68 herdr=11`

```text
FM_TEST_COVERAGE ok total=103 parallel=24 serial=68 herdr=11
```
</details>
<details>
<summary>Evidence: Baseline causal trace</summary>

<code>Trace identifies the unguarded lane-overlap `comm -12` as the warning source.</code>

```text
+406: b=serial
+407: comm -12 /tmp/fm-test-coverage.sAigh0/shards_union /tmp/fm-test-coverage.sAigh0/serial
comm: file 2 is not in sorted order
comm: input is not in sorted order
```
</details>
<details>
<summary>Evidence: Collation comparison</summary>

`The identical lane list passes C-order validation and fails en_US.utf8 validation at tests/fm-backend.test.sh.`

```text
LC_ALL=C sort -c exit: 0
LC_ALL=en_US.utf8 sort -c exit: 1
sort: /tmp/no-mistakes-evidence/01KYZXERY6YAQRFY2TASF44D5G/portable-serial-list.txt:12: disorder: tests/fm-backend.test.sh
Relevant byte-sorted list order:
     9	tests/fm-backend-tmux-smoke.test.sh
    12	tests/fm-backend.test.sh
```
</details>
<details>
<summary>Evidence: Regression counterfactual</summary>

`The isolated new regression test exits 1 against the pre-fix runner with an explicit failed assertion.`

```text
not ok - coverage guard exited 1 under LC_ALL=en_US.utf8: comm: file 2 is not in sorted order
comm: input is not in sorted order
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>Inspected the target diff, commit message, and ancestry from `origin/main`</code>
- <code>Ran `LC_ALL=en_US.utf8 tests/fm-test-run.test.sh` on a clean snapshot of base `1e247571aa75e00b00c7a01c4830025ecd44dc61`</code>
- <code>Ran `LC_ALL=en_US.utf8 tests/fm-test-run.test.sh` on target `6d8af30040ac9f264c5fba5c858d337978c984d7`</code>
- <code>Ran `LC_ALL=en_US.utf8 bin/fm-test-run.sh --check-coverage`</code>
- <code>Traced the base command with `bash -x bin/fm-test-run.sh --check-coverage`</code>
- <code>Compared the same portable-serial list with `LC_ALL=C sort -c` and `LC_ALL=en_US.utf8 sort -c`</code>
- <code>Ran isolated `test_coverage_guard_is_collation_independent` against the pre-fix runner</code>
- `Verified temporary fixtures were removed and the working tree remained clean`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
