### PR TITLE
fix: resolve Pi authentication surfaces from catalog evidence

### DIFF
--- a/.agents/skills/quota-array-dispatch/SKILL.md
+++ b/.agents/skills/quota-array-dispatch/SKILL.md
@@ -68,11 +68,11 @@ Keep the two questions separate for every candidate, because collapsing them is 
 - Is the surface resolved? Answer from the candidate's own tuple - its harness catalog and the credential source it actually selects.
 - Is the applicable quota known? Answer from `quota-axi`, which may legitimately have no coverage for that vendor.
 
-An unmodeled vendor is a quota unknown on a resolved surface, never an unresolved surface.
+When an auth-gated catalog supplies that positive evidence, an unmodeled vendor is a quota unknown on a resolved surface, never an unresolved surface.
 
 Uncertainty and ineligibility are different findings:
 
-- No model-level window, no matching auth source, an absent `state.authStatus`, an unmeasurable or `unknown` scope, or a surface quota-axi does not model at all is disclosed uncertainty.
+- No model-level window, no matching auth source, an absent `state.authStatus`, or an unmeasurable or `unknown` scope is disclosed uncertainty.
   Keep the candidate eligible, state the unknown, and prefer known sustainable evidence when otherwise comparable.
 - An expired credential is a short-lived session token the owning vendor renews on next use, not a sign-out.
 - Only concrete contradictory evidence blocks: an authoritative catalog proving the model unsupported, or proof that the credential the candidate actually selects is unusable.
@@ -98,7 +98,7 @@ Apply only among candidates satisfying required fit and strongest reasoning clas
 Never use headroom, runway, pace, or reserve to silently replace that reasoning class.
 
 1. Concrete contradictory evidence or malformed configuration: stop and report the tuple and that evidence.
-   Unmeasurable quota, a missing model-level window, an absent runway field, and a credential surface quota-axi does not model are uncertainty, never this rule.
+   Unmeasurable quota, a missing model-level window, an absent runway field, and a provider family quota-axi does not model are uncertainty, never this rule.
 2. Honor any explicit captain instruction that sets a floor for that candidate before the generic comparison.
    Do not invent a generic percentage floor or treat a low percentage as an automatic failure.
 3. Keep the strongest-reasoning class when every candidate is tight or completion evidence is poor.

--- a/.agents/skills/quota-array-dispatch/SKILL.md
+++ b/.agents/skills/quota-array-dispatch/SKILL.md
@@ -44,6 +44,7 @@ Name the evidence for each relation you assert so the conclusion is inspectable.
 
 1. Confirm the catalog lists the candidate's model and record the provider family it reports.
    A model the authoritative catalog does not list is concrete contradictory evidence: block that candidate and quote the catalog result.
+   Carry that row forward: on an auth-gated catalog it also resolves the candidate's authentication surface, per "Authentication is scoped to the selected surface" below.
 2. Apply quota at the granularity the vendor actually supplies.
    A provider-level or `all_models`/`all_products` scope bounds every model you established in that family, including one with no window of its own.
    A named-model or named-product scope is an additional bound for that model alone and is irrelevant to every other model in the family.
@@ -56,6 +57,18 @@ A candidate authenticates through its own tuple's surface; another harness's CLI
 `quota-axi auth --json` lists each provider's credential sources independently, so read the one source the candidate actually uses rather than collapsing a provider to a single status.
 A provider can carry a healthy source beside a missing or expired one; the unused source's state is not the candidate's state.
 A Pi-hosted family may authenticate through the vendor's own store with no `pi:`-prefixed source at all, which is normal and never evidence against the candidate.
+
+`quota-axi` is not the only surface evidence, and it is not the surface's owner.
+The candidate's own harness catalog resolves the surface positively when that harness lists a model only once its auth is configured; `docs/verification/dispatch-auth.md` verifies that rule for Pi, and it must be established from the harness's own documentation before being relied on for another harness.
+So a family that `quota-axi` does not model at all can still have a fully resolved surface, established from the catalog row alone.
+Never read a provider's absence from `quota-axi` as an unresolved or missing surface; `quota-axi` bounds quota, and coverage it never claimed is not a finding about credentials.
+
+Keep the two questions separate for every candidate, because collapsing them is what silently retires a whole lane:
+
+- Is the surface resolved? Answer from the candidate's own tuple - its harness catalog and the credential source it actually selects.
+- Is the applicable quota known? Answer from `quota-axi`, which may legitimately have no coverage for that vendor.
+
+An unmodeled vendor is a quota unknown on a resolved surface, never an unresolved surface.
 
 Uncertainty and ineligibility are different findings:
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -284,7 +284,7 @@ When X mode is opted in, bootstrap also requires `curl` and `jq` before arming t
 `tasks-axi` and `quota-axi` are required bootstrap tools in every profile, the same class as `lavish-axi`.
 An absent or incompatible `tasks-axi` reports `MISSING: tasks-axi (install: npm install -g tasks-axi)`; when `config/backlog-backend` is not `manual` and compatible `tasks-axi` is on `PATH`, bootstrap stays silent and firstmate uses its verbs for routine backlog mutations, otherwise it hand-edits `data/backlog.md` until installation is approved and completed.
 An absent or too-old `quota-axi` reports `MISSING: quota-axi (install: npm install -g quota-axi)`; firstmate cannot resolve a profile array without a compatible binary.
-That floor exists because it is the first build reporting per-credential auth sources, without which a candidate cannot be judged against the authentication surface it actually uses.
+That floor exists because it is the first build reporting per-credential auth sources, which Firstmate uses when the candidate's authoritative catalog does not itself establish the selected authentication surface.
 Bootstrap also reports a `TANGLE:` line when `FM_ROOT` is on a named non-default branch; follow the printed checkout remediation rather than treating it as an installable tool problem.
 In a read-only session that did not get the fleet lock, the same line is advisory and omits the checkout command.
 The locked session-start bootstrap step also runs a best-effort project clone refresh through `fm-fleet-sync.sh`.

--- a/docs/verification/dispatch-auth.md
+++ b/docs/verification/dispatch-auth.md
@@ -114,6 +114,68 @@ No models matching "gpt-9.9-nonexistent"
 
 A listing that reaches the account and returns no row is the authoritative negative that does block a candidate.
 
+## The Pi catalog is itself positive authentication-surface evidence
+
+Verified 2026-08-02 on Pi 0.82.1.
+
+Pi's installed `docs/models.md` states the availability rule for its own catalog:
+
+```text
+apiKey is not required to load the file: models become available when auth is
+configured through /login/auth.json, CLI --api-key, or provider apiKey. If no
+auth is configured, the models load but stay unavailable in /model and
+--list-models.
+```
+
+A row in `pi --list-models` therefore proves Pi holds configured auth for that provider family.
+The catalog resolves the surface positively; it is not merely support evidence.
+This matters because it is the only surface evidence available for a family that `quota-axi` does not model, and without it such a family looks indistinguishable from one with no surface at all.
+
+## Provider family that quota-axi does not model at all
+
+Verified 2026-08-02 on Pi 0.82.1 and quota-axi 0.1.16.
+
+```sh
+quota-axi --json | jq -r '.providers[].provider'
+quota-axi auth --json | jq -r '.auth[].provider'
+```
+
+Both commands return the same six names, and `minimax` is absent from each:
+
+```text
+claude
+codex
+cursor
+copilot
+grok
+kimi
+```
+
+```sh
+pi --list-models minimax
+```
+
+```text
+provider     model                   context  max-out  thinking  images
+minimax      MiniMax-M2.7            204.8K   131.1K   yes       no
+minimax      MiniMax-M2.7-highspeed  204.8K   131.1K   yes       no
+minimax      MiniMax-M3              1M       128K     yes       yes
+opencode-go  minimax-m2.7            204.8K   131.1K   yes       no
+opencode-go  minimax-m3              1M       131.1K   yes       yes
+```
+
+For `harness=pi`, `model=minimax/MiniMax-M3` the catalog establishes the model is supported, places it in the `minimax` family, and by the availability rule above proves Pi holds configured `minimax` auth.
+The surface is Pi's own credential store for that family, and `quota-axi` models no `minimax` provider, so it supplies no window and no auth entry for it.
+
+Two distinct findings must not be collapsed here:
+
+- The authentication surface is resolved, by the catalog, not by `quota-axi`.
+- The applicable quota is unknown, because the vendor is outside `quota-axi`'s coverage.
+
+Unknown quota is disclosed uncertainty and keeps the candidate eligible.
+A family's absence from `quota-axi` is never absence of a surface, and never a credential fault.
+This is the shape of the whole flat-subscription lane in `config/crew-dispatch.json`, so reading it as unresolved silently retires that lane to the premium default.
+
 ## Credential sources are independent per provider
 
 Verified 2026-07-30 against quota-axi 0.1.16.
@@ -175,4 +237,4 @@ It asserts that the script accepts no harness, model, or provider input, never c
 `tests/fm-spawn-dispatch-profile.test.sh` owns spawn's deterministic profile and harness refusals.
 `tests/fm-bootstrap.test.sh` owns the quota-axi version-floor diagnostic.
 `tests/fm-quota-array-dispatch-live-e2e.test.sh` drives the public Pi skill-loading interface against one fake `quota-axi --json` snapshot per case.
-It covers the Claude 1 percent versus Codex 55 percent reserve regression, explicit accounting for unmeasurable runway, and the strongest-reasoning constraint.
+It covers the Claude 1 percent versus Codex 55 percent reserve regression, explicit accounting for unmeasurable runway, the strongest-reasoning constraint, and a provider family absent from the snapshot that must stay eligible on its catalog-resolved surface.

--- a/tests/fm-quota-array-dispatch-live-e2e.test.sh
+++ b/tests/fm-quota-array-dispatch-live-e2e.test.sh
@@ -26,6 +26,7 @@ LAB=$(mktemp -d "${TMPDIR:-/tmp}/fm-quota-array-dispatch-live.XXXXXX")
 PROJECT="$LAB/project"
 FAKEBIN="$LAB/fakebin"
 FIXTURE="$LAB/quota.json"
+AUTH_FIXTURE="$LAB/quota-auth.json"
 CALLS="$LAB/quota-axi.calls"
 
 cleanup() {
@@ -39,12 +40,21 @@ cp "$OWNER" "$PROJECT/.agents/skills/quota-array-dispatch/SKILL.md"
 cat > "$FAKEBIN/quota-axi" <<'SH'
 #!/usr/bin/env bash
 set -u
-if [ "${1:-}" != --json ] || [ "$#" -ne 1 ]; then
-  printf 'unexpected quota-axi invocation: %s\n' "$*" >&2
-  exit 64
-fi
 printf '%s\n' "$*" >> "${QUOTA_AXI_CALLS:?}"
-cat "${QUOTA_AXI_FIXTURE:?}"
+if [ "${1:-}" = --json ] && [ "$#" -eq 1 ]; then
+  cat "${QUOTA_AXI_FIXTURE:?}"
+  exit 0
+fi
+# `quota-axi auth --json` is the credential-surface read the skill is allowed to
+# take when a candidate's surface is in question. It is served only when the case
+# supplied an auth fixture, so a case that never intended one still fails loudly.
+if [ "${1:-}" = auth ] && [ "${2:-}" = --json ] && [ "$#" -eq 2 ] \
+  && [ -s "${QUOTA_AXI_AUTH_FIXTURE:-/nonexistent}" ]; then
+  cat "$QUOTA_AXI_AUTH_FIXTURE"
+  exit 0
+fi
+printf 'unexpected quota-axi invocation: %s\n' "$*" >&2
+exit 64
 SH
 chmod +x "$FAKEBIN/quota-axi"
 
@@ -52,20 +62,31 @@ write_fixture() {
   cat > "$FIXTURE"
 }
 
+write_auth_fixture() {
+  cat > "$AUTH_FIXTURE"
+}
+
 run_case() {
-  local label=$1 expected=$2 prompt=$3 out calls required
+  local label=$1 expected=$2 prompt=$3 out calls required snapshots stray
   shift 3
   : > "$CALLS"
   out=$(
     cd "$PROJECT" &&
       PATH="$FAKEBIN:$PATH" QUOTA_AXI_CALLS="$CALLS" QUOTA_AXI_FIXTURE="$FIXTURE" \
+        QUOTA_AXI_AUTH_FIXTURE="$AUTH_FIXTURE" \
         pi --print --approve --no-session --no-context-files --no-extensions \
           --no-skills --skill .agents/skills --tools bash \
           --model openai-codex/gpt-5.6-sol --thinking high \
           "$prompt"
   ) || fail "$label: Pi skill run failed: $out"
   calls=$(cat "$CALLS")
-  [ "$calls" = "--json" ] || fail "$label: skill did not use one quota-axi --json snapshot: $calls"
+  # The one-snapshot rule binds the quota read. A credential-surface read is a
+  # separate, explicitly permitted command, so it is allowed but nothing else is.
+  snapshots=$(grep -Fxc -- "--json" "$CALLS" || true)
+  [ "$snapshots" = 1 ] \
+    || fail "$label: skill did not use exactly one quota-axi --json snapshot: $calls"
+  stray=$(grep -Fxv -- "--json" "$CALLS" | grep -Fxv -- "auth --json" || true)
+  [ -z "$stray" ] || fail "$label: unexpected quota-axi invocation(s): $stray"
   printf '%s\n' "$out" | grep -Fxq "$expected" \
     || fail "$label: expected final line $expected, got: $out"
   for required in "$@"; do
@@ -105,5 +126,25 @@ run_case \
   "Resolve this matched dispatch profile array now. Load quota-array-dispatch and run quota-axi --json exactly once. The likely task-completion horizon is two hours with established confidence. Claude/Sonnet is catalog-supported with usable authentication and is the only profile that meets the task's required strongest reasoning class. Codex/GPT is catalog-supported with usable authentication but is a weaker reasoning class and cannot meet the requirement. Return exact lines FACT=claude|reasoning=required|headroom=1|runway_seconds=10800 and FACT=codex|reasoning=weaker|headroom=80|runway_seconds=28800, then an exact final line SELECTED=<claude|codex>. Do not use other vendor or model commands and do not modify files." \
   "FACT=claude|reasoning=required|headroom=1|runway_seconds=10800" \
   "FACT=codex|reasoning=weaker|headroom=80|runway_seconds=28800"
+
+# A provider family quota-axi does not model at all must stay eligible on the
+# strength of its own harness catalog. The retired bin/fm-auth-preflight.sh
+# resolved surfaces from a hard-coded harness-to-provider table plus a
+# `pi:<prefix>` source matcher, so it reported every such candidate as
+# `eligible=no reason=surface-unresolved`. That silently retired the whole
+# zero-premium flat-subscription lane to the premium default. The script is gone;
+# this pins the judgment that replaced it.
+write_fixture <<'JSON'
+{"schemaVersion":3,"providers":[{"provider":"claude","quotaSemantics":{"description":"The all_models scope bounds every Claude model.","effectiveAvailability":[{"scope":"all_models","status":"known","effectivePercentRemaining":60,"boundedBy":["weekly"],"runway":{"status":"projected_exhaustion","usableRunwaySeconds":14400,"projectedExhaustedAt":"2030-01-01T04:00:00Z","limitingWindowId":"weekly","projectionConfidence":"established","projectionBasis":"cycle_average"}}]}}]}
+JSON
+write_auth_fixture <<'JSON'
+{"schemaVersion":1,"auth":[{"provider":"claude","sources":[{"source":"oauth-file","status":"available"}]}]}
+JSON
+run_case \
+  "a provider family quota-axi does not model keeps a catalog-resolved surface" \
+  "ELIGIBLE=BOTH" \
+  "Resolve this matched dispatch profile array now. Load quota-array-dispatch and run quota-axi --json exactly once; you may also run quota-axi auth --json. Candidate A is harness=claude model=opus. Candidate B is harness=pi model=minimax/MiniMax-M3. Take this raw observation as given and draw your own conclusions from it: running the authoritative Pi catalog command printed the row 'minimax  MiniMax-M3  1M  128K  yes  yes'. That is the entire catalog evidence available; no other command may be run to gather more. Both candidates have comparable required task fit and the same reasoning class for this work. For each candidate decide whether its authentication surface is resolved or unresolved, whether its applicable quota is known or unmodeled, and whether it is eligible. Return exact lines FACT=claude|eligible=<yes|no>|surface=<resolved|unresolved>|quota=<known|unmodeled> and FACT=minimax|eligible=<yes|no>|surface=<resolved|unresolved>|quota=<known|unmodeled>, then an exact final line ELIGIBLE=<BOTH|CLAUDE_ONLY>. Do not use other vendor or model commands and do not modify files." \
+  "FACT=claude|eligible=yes|surface=resolved|quota=known" \
+  "FACT=minimax|eligible=yes|surface=resolved|quota=unmodeled"
 
 echo "# all quota-array-dispatch live behavior tests passed"

--- a/tests/fm-quota-array-dispatch-live-e2e.test.sh
+++ b/tests/fm-quota-array-dispatch-live-e2e.test.sh
@@ -127,13 +127,9 @@ run_case \
   "FACT=claude|reasoning=required|headroom=1|runway_seconds=10800" \
   "FACT=codex|reasoning=weaker|headroom=80|runway_seconds=28800"
 
-# A provider family quota-axi does not model at all must stay eligible on the
-# strength of its own harness catalog. The retired bin/fm-auth-preflight.sh
-# resolved surfaces from a hard-coded harness-to-provider table plus a
-# `pi:<prefix>` source matcher, so it reported every such candidate as
-# `eligible=no reason=surface-unresolved`. That silently retired the whole
-# zero-premium flat-subscription lane to the premium default. The script is gone;
-# this pins the judgment that replaced it.
+# An auth-gated catalog row can resolve a candidate's surface even when
+# quota-axi does not model that provider family; this pins the distinction
+# between positive surface evidence and unknown quota.
 write_fixture <<'JSON'
 {"schemaVersion":3,"providers":[{"provider":"claude","quotaSemantics":{"description":"The all_models scope bounds every Claude model.","effectiveAvailability":[{"scope":"all_models","status":"known","effectivePercentRemaining":60,"boundedBy":["weekly"],"runway":{"status":"projected_exhaustion","usableRunwaySeconds":14400,"projectedExhaustedAt":"2030-01-01T04:00:00Z","limitingWindowId":"weekly","projectionConfidence":"established","projectionBasis":"cycle_average"}}]}}]}
 JSON


### PR DESCRIPTION
## Intent

Establish why the entire pi dispatch lane resolves no authentication surface, then fix it.

Reported problem: bin/fm-auth-preflight.sh was observed returning eligible=no reason=surface-unresolved for BOTH pi tuples in config/crew-dispatch.json - pi + openai-codex/gpt-5.6-sol and pi + minimax/MiniMax-M3 - with provider=none surface=none authStatus=unresolved. quota-axi lists claude, codex, cursor, copilot, grok and kimi as providers but no pi surface at all. Consequence: dispatch rule 2's OpenAI candidate and rule 3's entire MiniMax lane are unusable, so bulk/documentation/background work configured to burn ZERO premium quota silently falls through to the configured default of claude/opus and draws on the premium pool. Confirmed 2026-08-01: every dispatch that session went to claude, including documentation work rule 3 routes explicitly to MiniMax.

Required: establish the cause with evidence FIRST and name it explicitly as one of three candidates - (1) a genuine credential problem, (2) a quota-axi coverage gap for the pi harness, (3) a config/crew-dispatch.json tuple that no longer matches what quota-axi emits - or a fourth that can be proven. Specifically worth checking: whether a pi-hosted model reached through a provider prefix should be declared under THAT PROVIDER's surface rather than under the pi harness name, since harness=pi with an OpenAI or MiniMax model may legitimately authenticate through the vendor's own store with no pi: source at all.

What was established (a fourth cause, proven): NOT a credential problem, NOT a quota-axi defect, NOT a stale tuple. The surface-unresolved verdict originated in bin/fm-auth-preflight.sh, which resolved surfaces from a hard-coded harness-to-provider table plus a pi:<prefix> source-id matcher. That script was added in #1349 (2026-07-30 18:59) and DELETED four hours later in #1358 (23:16); no such script or mapping survives anywhere in bin/. #1358 returned eligibility to open agent judgment resting on docs/verification/dispatch-auth.md, but that record had no evidence that a provider family absent from quota-axi can still have a resolved surface, and no record that a harness catalog is itself surface evidence. With nothing contradicting it, the retired conclusion kept being re-derived at each intake and the zero-premium lane stayed unused. Decisive fact: Pi's installed docs/models.md states a provider's models 'load but stay unavailable in /model and --list-models' when no auth is configured, so a catalog row proves configured auth. Verified on Pi 0.82.1 and quota-axi 0.1.16: minimax/MiniMax-M3 is listed by pi --list-models while quota-axi models no minimax provider at all; the surface is resolved by Pi's own credential store and only the quota is unknown, which is disclosed uncertainty. Both tuples resolve: openai-codex/gpt-5.6-sol maps to the codex provider whose auth-json and cli-rpc sources are both available; minimax/MiniMax-M3 resolves by catalog with quota unmodeled.

Changes made: docs/verification/dispatch-auth.md records both verified facts (the Pi catalog is positive authentication-surface evidence; a provider family quota-axi does not model at all still has a resolved surface), with dates, versions, exact commands and exact output. .agents/skills/quota-array-dispatch/SKILL.md separates 'is the surface resolved' from 'is the quota known' so an unmodeled vendor can no longer read as a missing surface, and step 1 of the provider-relation procedure carries the catalog row forward as surface evidence. tests/fm-quota-array-dispatch-live-e2e.test.sh gains a case supplying only the catalog row and a snapshot without the family; the fake quota-axi now also serves 'auth --json' when a case provides an auth fixture, and the one-snapshot assertion was widened to allow that explicitly permitted credential-surface read while still rejecting anything else.

Hard constraints that were accepted and honored: (a) Do NOT present this as a login or credential problem - AGENTS.md section 4 reserves credential wording for authStatus=unusable or a genuinely failed preflight and treats missing coverage as disclosed uncertainty; nothing here reached that bar, so no credential wording is used and nothing needs re-authenticating. (b) NEVER make a tuple eligible by weakening the check - this deliberately ADDS a positive evidence source rather than removing or relaxing any requirement; an eligible verdict still means a surface was actually resolved. (c) Do not edit config/crew-dispatch.json to route around the problem; it was left untouched because the tuples were verified correct as written. (d) Do not launch other harnesses' CLIs to probe credentials; only pi --list-models (the candidate's own authoritative catalog, sanctioned by harness-adapters for model discovery) and quota-axi were used, and bin/fm-vendor-auth-probe.sh was left unchanged. (e) Covered by tests.

Test-quality decision worth knowing: the first version of the new regression passed against the UNPATCHED skill because its prompt handed the agent the Pi docs quote and did the reasoning for it. It was deliberately rewritten to supply only what a real intake supplies - the catalog row and a snapshot without the family - and re-verified both ways: against the previous procedure it reports surface=unresolved (the reported defect wording), and with this change it reports surface=resolved. The suite is gated behind FM_QUOTA_ARRAY_DISPATCH_LIVE_E2E=1 following the existing pattern for credentialed live-harness tests.

This is firstmate's own shared tracked material, so firstmate-coding-guidelines applies: knowledge was routed by the placement decision tree (empirical verified facts to the maintainer-verification record under docs/verification/, decision-procedure changes to the owning agent-only skill, no AGENTS.md growth), the one-owner rule was followed by patching existing language rather than appending a parallel copy, one sentence per line, plain dash never em dash, and no agent co-author on the commit. bin/fm-lint.sh, bin/fm-doc-audience-check.sh, tests/fm-vendor-auth-probe.test.sh and the full live dispatch suite were all run green before committing.

## What Changed

- Treat auth-gated Pi catalog entries as positive authentication-surface evidence, keeping unmodeled vendor families eligible while disclosing unknown quota.
- Document the verified Pi and MiniMax behavior and clarify when `quota-axi` credential-source data is required.
- Add live dispatch regression coverage for catalog-resolved providers absent from `quota-axi`, while preserving single-snapshot enforcement and permitted auth reads.

## Risk Assessment

✅ Low: The change is narrowly scoped to the owning dispatch procedure, supported by versioned Pi evidence, and adds positive surface evidence without weakening eligibility checks or altering routing configuration.

## Testing

Author-supplied baseline checks were already green; this phase independently verified both live Pi catalog surfaces, quota-axi coverage, causal history, the base-to-target counterfactual, and the complete focused Pi-driven regression, captured a CLI transcript, and found no issues. No screenshot was applicable because the end-user surface is CLI dispatch output.

<details>
<summary>Evidence: Pi dispatch surface evidence transcript</summary>

<code>Base: FACT=minimax|eligible=yes|surface=unresolved|quota=unmodeled&#10;Target: FACT=minimax|eligible=yes|surface=resolved|quota=unmodeled&#10;Target final verdict: ELIGIBLE=BOTH</code>

```text
Direct surface evidence

$ pi --version
0.82.1

$ quota-axi --version
0.1.16

$ pi --list-models minimax
provider     model                   context  max-out  thinking  images
minimax      MiniMax-M2.7            204.8K   131.1K   yes       no
minimax      MiniMax-M2.7-highspeed  204.8K   131.1K   yes       no
minimax      MiniMax-M3              1M       128K     yes       yes
opencode-go  minimax-m2.7            204.8K   131.1K   yes       no
opencode-go  minimax-m3              1M       131.1K   yes       yes

$ quota-axi --json | jq -r '.providers[].provider'
claude
codex
cursor
copilot
grok
kimi

$ quota-axi auth --json | jq -r '.auth[].provider'
claude
codex
cursor
copilot
grok
kimi

$ pi --list-models gpt-5.6-sol
provider      model        context  max-out  thinking  images
openai-codex  gpt-5.6-sol  272K     128K     yes       yes

$ quota-axi auth --json | jq -r '.auth[] | select(.provider == "codex") | .sources[] | [.source, .status] | @tsv'
auth-json  available
cli-rpc    available

Causal history evidence

$ test ! -e bin/fm-auth-preflight.sh
fm-auth-preflight: absent

$ rg the retired surface mapping under bin/
retired surface mapping: absent from bin

$ git log --format='%h %ad %s' --date=iso-strict --diff-filter=AD -- bin/fm-auth-preflight.sh
f7d0d0a 2026-07-30T23:16:34-07:00 fix: restore evidence-based dispatch eligibility (#1358)
28b02d2 2026-07-30T18:59:28-07:00 fix(dispatch): preflight candidate auth before quota escalation (#1349)

Focused end-to-end regression

$ FM_QUOTA_ARRAY_DISPATCH_LIVE_E2E=1 bash tests/fm-quota-array-dispatch-live-e2e.test.sh
FACT=claude|headroom=1|runway_seconds=600|reserve=-1
FACT=codex|headroom=55|runway_seconds=14400|reserve=-40
SELECTED=codex
ok - higher headroom and viable runway beat a less-negative reserve
FACT=claude|eligible=yes|headroom=55|runway=unknown|unmeasurable=weekly
FACT=codex|eligible=yes|headroom=45|runway_seconds=14400|supports_horizon=yes
DECISION=CODEX
ok - unmeasurable runway stays eligible and is accounted for explicitly
FACT=claude|reasoning=required|headroom=1|runway_seconds=10800
FACT=codex|reasoning=weaker|headroom=80|runway_seconds=28800
SELECTED=claude
ok - required strongest reasoning class is not downgraded for quota
FACT=claude|eligible=yes|surface=resolved|quota=known
FACT=minimax|eligible=yes|surface=resolved|quota=unmodeled
ELIGIBLE=BOTH
ok - a provider family quota-axi does not model keeps a catalog-resolved surface
# all quota-array-dispatch live behavior tests passed

Base-procedure counterfactual

The same realistic intake prompt was run through the quota-array-dispatch skill from base commit 1e247571aa75e00b00c7a01c4830025ecd44dc61.

FACT=claude|eligible=yes|surface=resolved|quota=known
FACT=minimax|eligible=yes|surface=unresolved|quota=unmodeled
ELIGIBLE=BOTH

The base procedure re-derived surface=unresolved from the same catalog row and quota snapshot shape.
The target procedure instead returns surface=resolved while keeping quota=unmodeled.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>Author-supplied baseline reported green: `bin/fm-lint.sh`, `bin/fm-doc-audience-check.sh`, `tests/fm-vendor-auth-probe.test.sh`, and the live dispatch suite.</code>
- `FM_QUOTA_ARRAY_DISPATCH_LIVE_E2E=1 bash tests/fm-quota-array-dispatch-live-e2e.test.sh`
- <code>`pi --version`; `quota-axi --version`; `pi --list-models minimax`; filtered `quota-axi --json` and `quota-axi auth --json` provider lists.</code>
- <code>`pi --list-models gpt-5.6-sol`; filtered Codex source/status output from `quota-axi auth --json`.</code>
- <code>Ran the realistic catalog-row intake through Pi with the base commit&#39;s dispatch skill, confirming `surface=unresolved`, then compared it with the target&#39;s `surface=resolved` result.</code>
- <code>Verified `bin/fm-auth-preflight.sh` and its retired mapping are absent, and inspected its add/delete history with `git log --diff-filter=AD -- bin/fm-auth-preflight.sh`.</code>
- `git diff --quiet 1e247571aa75e00b00c7a01c4830025ecd44dc61..343bb9ffc4f33cd20d2a6ad8e9d839cf24797da1 -- config/crew-dispatch.json bin/fm-vendor-auth-probe.sh`
- <code>Attempted to inspect the private `config/crew-dispatch.json`; it is absent from this isolated test copy, while the commit range confirms no change to it.</code>
- <code>Final `git status --short` confirmed testing left no worktree changes.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
