### PR TITLE
fix(bin): supervision and record integrity, plus watcher arm-guard allow-list

### DIFF
--- a/.agents/skills/bearings/SKILL.md
+++ b/.agents/skills/bearings/SKILL.md
@@ -14,13 +14,14 @@ metadata:
 Generate a complete current snapshot from the fleet's current state, so the captain can resume in one read after a break, a night, or a context reset.
 Plain `/bearings` returns only the concise four-section chat digest.
 Only `/bearings file` writes the dated markdown report artifact and then returns the concise four-section chat digest linked to that report.
-This skill is operationally read-only in both modes.
-It never tears down a task, merges a PR, dispatches new work, steers a worker, answers a decision, cleans up work, mutates backlog or task state, or writes any file except the single dated report in explicit file mode.
+This skill is operationally read-only in plain mode and custody-preserving in file mode.
+It never tears down a task, merges a PR, dispatches new work, steers a worker, answers a decision, cleans up work, or mutates backlog or task state.
+Explicit file mode may write only the dated report plus the version and receipt for a prior same-day report through `bin/fm-bearings-report.sh`.
 
 ## Invocation modes
 
 - Plain `/bearings` gathers a fresh bounded snapshot and renders the four-section chat digest without creating, deleting, reading, or replacing `data/status-report-<YYYY-MM-DD>.md`.
-- `/bearings file` gathers a fresh bounded snapshot, replaces today's `data/status-report-<YYYY-MM-DD>.md` from scratch, and renders the four-section chat digest with a link or path to that report.
+- `/bearings file` gathers a fresh bounded snapshot, versions any prior same-day report before replacement, and renders the four-section chat digest with a link or path to that report.
 - Treat `file` only as an explicit invocation option in the slash command.
 - Do not treat natural-language requests such as "write a report", "save this", "persist it", or "make a file" as file mode unless the invocation explicitly includes the standalone `file` option.
 - When the captain asks to include PRs, pass the snapshot command's live-PR opt-in.
@@ -49,12 +50,14 @@ It never tears down a task, merges a PR, dispatches new work, steers a worker, a
    The chat response uses the four complete sections in the chat-response contract below, in the same order, each always present.
    Plain mode stops here and writes no report artifact.
 
-3. **In explicit file mode only, compose and replace the detailed report file.**
+3. **In explicit file mode only, compose and custody-preserve the detailed report file.**
    The report uses the same four complete sections as the chat, in the same order, and adds the detail the chat omits.
    Never read an earlier `data/status-report-*.md` to decide what to omit, include, describe as changed, or call current.
-   Write the full report to `data/status-report-<YYYY-MM-DD>.md` using today's date.
-   If today's file already exists, delete it first, then create a new file from scratch.
-   This is the only write allowed by the skill.
+   Compose the full report in a temporary draft outside `data/status-report-*.md`, then install it with `bin/fm-bearings-report.sh <complete-draft.md>`.
+   The installer writes `data/status-report-<YYYY-MM-DD>.md` using today's date.
+   If today's file already exists, the installer first copies its exact bytes to a create-exclusive unique path under `data/status-report-versions/` and writes a pre-transition receipt containing its digest, byte count, source ref, custody class, and timestamp.
+   Never delete, truncate, or directly overwrite the dated report, and never hand-write the custody receipt.
+   The version and receipt preserve evidence only; never read them to decide what belongs in the new current report.
    The detailed report includes:
    - **Title** - `# Bearings - <day> <YYYY-MM-DD>` (use "Morning status" only when the captain specifically asks for a morning brief), followed by two or three sentences framing where things stand.
    - **Captain's Call** - every open decision summarized with its options from the structured decision record, plus each PR ready to merge and each needed credential or login, every PR with the full `https://...` URL, never a bare `#number`.
@@ -103,5 +106,6 @@ Rules that keep the contract unambiguous:
 ## Supervision discipline
 
 This skill changes no fleet state.
-Do not tear down a task, merge a PR, dispatch queued work, steer a worker, answer a queued decision, clean up work, or mutate any `state/` or `data/` file other than the single report file in explicit file mode.
+Do not tear down a task, merge a PR, dispatch queued work, steer a worker, answer a queued decision, clean up work, or mutate task state.
+In file mode, the dated report and its prior-version custody artifacts are the only permitted `data/` writes.
 If the state you read suggests an action - a PR ready to merge, a queued item whose gate has arrived, or a needs-decision finding - name it in its section and leave the action to the normal lifecycle and configured authority rather than taking it from inside this skill.

--- a/.agents/skills/decision-hold-lifecycle/SKILL.md
+++ b/.agents/skills/decision-hold-lifecycle/SKILL.md
@@ -18,10 +18,18 @@ Every unresolved decision that belongs to the captain and is discovered while pr
 The agent performs the semantic inventory because scripts must not infer decisions from report prose, visual-review artifacts, terminal output, or chat.
 Give each distinct unresolved decision a stable privacy-safe key, register it through `bin/fm-decision-hold.sh hold`, and use the same key on retry so registration is idempotent while different decisions retain different durable identities.
 After inventorying the whole report and review surface, run `bin/fm-decision-hold.sh complete` with every unresolved key, or with `--none` only when the reviewed surface contains no unresolved captain decision.
+A live originating task may be cleaned up after `complete` retains its report-bound task and dispatch carrier, including for `--none`, binds every unresolved hold to that exact dispatch, and proves each hold reappears in Bearings.
+Cleanup does not require the captain to answer in the same session, and it never closes the hold.
+Do not hand-write a backlog row, archive row, decision object, or receipt to satisfy this gate; only the script-owned lifecycle is authoritative.
 A completed investigation and an ended visual review use this same owner and completion command; a visual tool, including Lavish, never owns a parallel completion policy.
 Run the command in the originating work's authoritative `FM_HOME`; main-home work creates main-home holds, and secondmate-owned work creates holds in that secondmate home's backlog rather than copying them into the main backlog.
 Do not close a hold merely because the originating investigation completed, its report was archived, its visual review ended, or its task was torn down.
 The hold remains the authoritative Captain's Call item until the captain's answer is durably recorded, dependent work is created in the same backlog and blocked by that hold, and `bin/fm-decision-hold.sh resolve` routes the answer by clearing those dependency edges before closing the hold.
+Resolution retains a digest-bound decision object and a task-and-dispatch-bound receipt.
+For a historical open hold whose exact endpoint dispatch binding survives, re-run `complete` with the full recorded inventory to reconstruct the cleanup receipt from current authoritative state.
+If that binding is absent, or if a historical resolved row lacks its script-owned cleanup receipt or canonical decision object, preserve the origin metadata and hold row and keep cleanup refused because no safe automatic migration is shipped.
+An exact `resolve` retry may finish a missing resolution receipt only when the script-owned cleanup receipt and canonical decision object both survive.
+Never substitute force or discard for the missing historical authority.
 Resolved findings, recommendations that need no captain choice, and prose that merely sounds decision-like do not create holds.
 Bearings reads the resulting structured state and must never compensate by scraping historical reports, visual-review artifacts, terminal output, chat, or other prose.
 
@@ -31,10 +39,11 @@ Bearings reads the resulting structured state and must never compensate by scrap
 2. Inventory only genuine unresolved choices that require the captain.
 3. For each choice, choose a stable key and use the script's `hold` command with a concise title, reason, and repository.
 4. Run the script's `complete` command with the full unresolved-key inventory for that review pass.
-5. Relay the choices to the captain as decisions from Bearings' Captain's Call section under `AGENTS.md` section 9; do not use the word hold in captain chat.
-6. After the captain decides, record dependent work with normal tasks-axi commands and block it by the hold identity.
-7. Put the captain's exact durable decision in a file and use the script's `resolve` command with every routed task.
-8. Confirm Bearings no longer shows the closed hold and that routed work remains in structured backlog state.
+5. Before cleanup, let the script's read-only `verify` command confirm the task identity, exact dispatch, nonzero object digests, and a fresh Bearings appearance; unresolved or indeterminate evidence refuses and follows the historical remedy above without force or discard.
+6. Relay the choices to the captain as decisions from Bearings' Captain's Call section under `AGENTS.md` section 9; do not use the word hold in captain chat.
+7. After the captain decides, record dependent work with normal tasks-axi commands and block it by the hold identity.
+8. Put the captain's exact durable decision in a file and use the script's `resolve` command with every routed task.
+9. Confirm `verify-resolution` accepts the trusted receipt, Bearings no longer shows the closed hold, and routed work remains in structured backlog state.
 
 `bin/fm-decision-hold.sh --help` owns command syntax, identity construction, completion attestation, retry behavior, and close ordering.
 `docs/decision-hold-lifecycle.md` records the mechanism and regression evidence without restating this policy.

--- a/.agents/skills/firstmate-codexapp/SKILL.md
+++ b/.agents/skills/firstmate-codexapp/SKILL.md
@@ -61,8 +61,9 @@ For a Firstmate-managed task, include an explicit status instruction:
 
 ```text
 Append supervisor-visible status lines to <absolute-firstmate-home>/state/<task-id>.status.
-Use only these prefixes for status changes: working:, needs-decision:, blocked:, paused:, done:, failed:.
+Use only these prefixes for status changes: working:, needs-decision:, blocked:, paused:, awaiting-captain:, done:, failed:.
 Use paused: only for a deliberate known external wait that should be rechecked later, never for a blocker that needs firstmate to act.
+Use awaiting-captain [key=<slug>]: only after work is complete and an unbounded captain answer is required, and close it only with resolved [key=<slug>]: after the captain answers.
 Before doing substantive work, append "working: Codex Desktop thread started".
 ```
 

--- a/.agents/skills/stuck-crewmate-recovery/SKILL.md
+++ b/.agents/skills/stuck-crewmate-recovery/SKILL.md
@@ -23,7 +23,10 @@ Load `secondmate-provisioning` instead for `kind=secondmate` recovery.
 
 Treat the digest's endpoint result as a presence signal, not proof that the task's work or validation run is gone.
 Read the targeted current state with `bin/fm-crew-state.sh <id>` before deciding to relaunch.
-A no-mistakes run matched to the crew's branch and current code remains authoritative when the endpoint is dead: handle a terminal or parked run through the normal lifecycle, and keep supervising an active run instead of creating a duplicate worker.
+A pane and a detached pipeline worker are independent supervision subjects: interrupting or exiting the pane affects only the interactive agent, not a headless native agent or its process tree.
+A no-mistakes run matched to the crew's branch and current code remains authoritative when the endpoint is dead: handle a terminal or parked run through the normal lifecycle, and keep supervising an active headless worker instead of recording the task stopped or creating a duplicate worker.
+When the recorded pipeline step is `running` but its bound native-agent PID is dead or suspended, report that contradiction instead of recording the run as live; use the pipeline's supported abort and custody flow only after its process ownership is reconciled.
+If the run record cannot be bound to a native-agent identity, report that limit as indeterminate rather than inferring live or dead from the pane.
 
 When no authoritative run accounts for the task, inspect only its recorded backend and worktree inventory.
 Use `treehouse status` for treehouse-backed tmux, herdr, zellij, or cmux tasks, and use the recorded `orca_worktree_id=` and `terminal=` for Orca tasks.
@@ -42,6 +45,7 @@ Escalate in order:
 2. If the crewmate is waiting on a question its brief already answers, answer in one line via `FM_HOME=<this-firstmate-home> bin/fm-send.sh` from an active firstmate session unless `FM_HOME` is already set to the active firstmate home.
 3. If the crewmate is confused or looping, interrupt with the adapter's interrupt key, then redirect with one corrective line.
    For example, for a single-Escape adapter: `FM_HOME=<this-firstmate-home> bin/fm-send.sh <window> --key Escape`.
+   Re-read `bin/fm-crew-state.sh <id>` immediately afterward: the interrupt does not stop a detached validation worker, and a still-live headless worker keeps the task working.
 4. If the crewmate is genuinely wedged after redirection, exit the agent with the adapter's exit command and relaunch with the same brief plus a `progress so far` note appended to it.
    Genuine wedging means looping, unresponsive, repeating the same obstacle, or truly dead.
    A low context reading is not wedging; modern harnesses auto-compact and keep going.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -313,12 +313,16 @@ Apart from that single supported abort, do not hand-edit, commit, restart, or st
 Once ownership is settled, validate exactly once against that final head so no obsolete or intermediate head is ever treated as authoritative.
 
 An ask-user finding returns as `needs-decision`; firstmate decides only when the configured authority permits, otherwise escalates to the captain.
+When completed producer work is retained solely for an answer only the captain can give, record `awaiting-captain [key=<slug>]: <exact question>` after the question has surfaced.
+This state is an unbounded human wait, not a bounded external pause and not a blocker firstmate can clear; only a matching `resolved [key=<slug>]: <captain answer>` closes it.
+It never authorizes teardown of unlanded work and never outranks evidence that the worker or its headless pipeline resumed.
 Send the same worker one exact decision naming the decision key, step, action, affected finding IDs, instructions where needed, and exact response command.
 Require the matching `resolved` event, forbid `--yes`, and require the worker to process every synchronous return until completion or a genuinely new escalation.
 Resume fleet supervision immediately after the decision lands.
 
 Judge validation by the current-code-matched run step through `bin/fm-crew-state.sh`, not by shell liveness or the last status event.
 Running, fixing, or CI states remain working; parked approval or fix-review states require the worker to follow the active gate help; passed or checks-passed is done; failed or cancelled is failed.
+Pane lifecycle and headless pipeline lifecycle are independent: an interrupt or exit affects only the pane, so a bound live native worker keeps the task working, while a dead or suspended bound native worker contradicts a stale `running` ledger and must be reconciled before the task is called live.
 A worker hand-editing, committing, aborting, or restarting during an active validation run duplicates pipeline ownership outside the supersession sequence above; steer it back to the gate response flow.
 The worker reports the PR when CI first becomes green rather than waiting for merge monitoring to finish.
 
@@ -360,11 +364,12 @@ At the start of every wake-handling turn, drain the durable wake queue before pe
 Session start is the only exception because its one-shot digest already drained while locked or deliberately left the queue untouched in lock-refused read-only mode.
 A status line is a wake event, not current state; use `bin/fm-crew-state.sh` when current state matters, especially before re-escalating an old decision, blocker, or pause.
 A declared `paused:` event means a bounded external wait expected to clear on its own, while `blocked:` means firstmate action is needed.
+An `awaiting-captain:` event means completed work is retained for an unbounded captain answer; after its first wake, supervision retires it from stale escalation only while the terminal event, clean worktree, and recorded HEAD remain unchanged, and only the captain's keyed answer clears it.
 
 Handle actionable wakes as follows:
 
 1. For `signal:`, read the listed event lines first, then reconcile current state only where action depends on it.
-2. For `stale:`, inspect the recorded endpoint and load `stuck-crewmate-recovery` for a stopped, looping, confused, or unresponsive worker; a deep-inspection reason also requires current-state and validation-log inspection.
+2. For `stale:`, inspect the recorded endpoint and load `stuck-crewmate-recovery` for a stopped, looping, confused, or unresponsive worker; a deep-inspection reason also requires current-state and validation-log inspection. Never infer that a detached pipeline stopped from a pane interrupt or infer that a dead bound native worker is live from a `running` row.
 3. For `check:`, act on the named poll result, including merges, X-mode events, and process-to-event source results.
 4. For `heartbeat:`, review the whole fleet from the structured fleet view, reconcile suspicious tasks and PR state, update the backlog, and never report an unchanged fleet as progress.
 
@@ -410,7 +415,7 @@ When evidence uses an internal label, rewrite it before sending:
 - worktree, checkout, primary checkout, or local-main -> local copy, isolated copy, or local branch, only if the location matters.
 - teardown -> cleanup.
 - wake, watcher, heartbeat, stale, signal, or check -> notification, monitoring, waiting too long, or stopped responding.
-- hold, gate, ask-user, needs-decision, blocked, or paused -> the concrete decision, wait, approval, blocker, or external delay.
+- hold, gate, ask-user, needs-decision, blocked, paused, or awaiting-captain -> the concrete decision, wait, approval, blocker, or external delay.
 - done, failed, fix-review, checks-passed, cancelled, validation step, or pipeline state -> the concrete result, review finding, passing checks, failed check, or stopped validation.
 - brief -> instructions.
 - crewmate -> worker, only when naming the helper matters.

--- a/bin/fm-arm-command-policy.mjs
+++ b/bin/fm-arm-command-policy.mjs
@@ -619,31 +619,47 @@ function shellInvocation(position) {
   const name = basename(position.command.value);
   if (!["sh", "bash", "zsh"].includes(name)) return null;
   const words = position.words;
+  let noexec = false;
   for (let i = position.index + 1; i < words.length; i += 1) {
     const option = words[i];
     if (/^-[A-Za-z]*c[A-Za-z]*$/.test(option.value)) {
+      if (option.value.slice(1).includes("n")) noexec = true;
       let payloadIndex = i + 1;
       if (words[payloadIndex]?.value === "--") payloadIndex += 1;
-      return { kind: "command", payload: words[payloadIndex] || null };
+      return { kind: "command", payload: words[payloadIndex] || null, noexec };
     }
     if (/^[-+]O$/.test(option.value)) {
       i += 1;
       continue;
     }
-    if (option.value === "--" || /^[-+]/.test(option.value)) continue;
-    return { kind: "script", payload: option };
+    if (option.value === "--noexec") {
+      noexec = true;
+      continue;
+    }
+    if (option.value === "--") {
+      const payload = words[i + 1] || null;
+      return payload ? { kind: "script", payload, noexec } : { kind: "stdin", payload: null, noexec };
+    }
+    if (/^[-+][A-Za-z]+$/.test(option.value)) {
+      if (option.value.slice(1).includes("n")) noexec = option.value.startsWith("-");
+      continue;
+    }
+    if (/^[-+]/.test(option.value)) continue;
+    return { kind: "script", payload: option, noexec };
   }
-  return { kind: "stdin", payload: null };
+  return { kind: "stdin", payload: null, noexec };
 }
 
 function shellHeredocPayloads(tokens, position) {
-  if (shellInvocation(position)?.kind !== "stdin") return [];
+  const shell = shellInvocation(position);
+  if (shell?.kind !== "stdin" || shell.noexec) return [];
   const heredocs = tokens.filter((token) => token.type === "redir" && token.fd === 0 && typeof token.heredoc === "string");
   return heredocs.length === 0 ? [] : [heredocs.at(-1).heredoc];
 }
 
 function shellHereStringPayloads(tokens, position) {
-  if (shellInvocation(position)?.kind !== "stdin") return [];
+  const shell = shellInvocation(position);
+  if (shell?.kind !== "stdin" || shell.noexec) return [];
   const payloads = [];
   for (let i = 0; i < tokens.length; i += 1) {
     const token = tokens[i];
@@ -787,8 +803,8 @@ function analyzeProgram(command, context, depth = 0) {
     }
 
     const shell = shellInvocation(position);
-    const shellPayload = shell?.kind === "command" ? shell.payload : null;
-    const shellScript = shell?.kind === "script" ? shell.payload : null;
+    const shellPayload = shell?.kind === "command" && !shell.noexec ? shell.payload : null;
+    const shellScript = shell?.kind === "script" && !shell.noexec ? shell.payload : null;
     const sourceScript = sourcedScript(position);
     const literalEvalPayload = evalPayload(position);
     const heredocPayloads = shellHeredocPayloads(tokens, position);

--- a/bin/fm-arm-command-policy.mjs
+++ b/bin/fm-arm-command-policy.mjs
@@ -619,47 +619,35 @@ function shellInvocation(position) {
   const name = basename(position.command.value);
   if (!["sh", "bash", "zsh"].includes(name)) return null;
   const words = position.words;
-  let noexec = false;
   for (let i = position.index + 1; i < words.length; i += 1) {
     const option = words[i];
     if (/^-[A-Za-z]*c[A-Za-z]*$/.test(option.value)) {
-      if (option.value.slice(1).includes("n")) noexec = true;
       let payloadIndex = i + 1;
       if (words[payloadIndex]?.value === "--") payloadIndex += 1;
-      return { kind: "command", payload: words[payloadIndex] || null, noexec };
+      return { kind: "command", payload: words[payloadIndex] || null };
     }
     if (/^[-+]O$/.test(option.value)) {
       i += 1;
       continue;
     }
-    if (option.value === "--noexec") {
-      noexec = true;
-      continue;
-    }
     if (option.value === "--") {
       const payload = words[i + 1] || null;
-      return payload ? { kind: "script", payload, noexec } : { kind: "stdin", payload: null, noexec };
-    }
-    if (/^[-+][A-Za-z]+$/.test(option.value)) {
-      if (option.value.slice(1).includes("n")) noexec = option.value.startsWith("-");
-      continue;
+      return payload ? { kind: "script", payload } : { kind: "stdin", payload: null };
     }
     if (/^[-+]/.test(option.value)) continue;
-    return { kind: "script", payload: option, noexec };
+    return { kind: "script", payload: option };
   }
-  return { kind: "stdin", payload: null, noexec };
+  return { kind: "stdin", payload: null };
 }
 
 function shellHeredocPayloads(tokens, position) {
-  const shell = shellInvocation(position);
-  if (shell?.kind !== "stdin" || shell.noexec) return [];
+  if (shellInvocation(position)?.kind !== "stdin") return [];
   const heredocs = tokens.filter((token) => token.type === "redir" && token.fd === 0 && typeof token.heredoc === "string");
   return heredocs.length === 0 ? [] : [heredocs.at(-1).heredoc];
 }
 
 function shellHereStringPayloads(tokens, position) {
-  const shell = shellInvocation(position);
-  if (shell?.kind !== "stdin" || shell.noexec) return [];
+  if (shellInvocation(position)?.kind !== "stdin") return [];
   const payloads = [];
   for (let i = 0; i < tokens.length; i += 1) {
     const token = tokens[i];
@@ -706,6 +694,16 @@ function hasDynamicExecutionPayload(position, context) {
   return false;
 }
 
+// Treat every statically visible watcher-script word passed to a shell as a
+// protected execution candidate, regardless of the options preceding it. This
+// deliberately does not model bash/zsh's open-ended option grammar: options
+// such as --rcfile and --init-file consume values, so inference from an `n`
+// byte is unsafe. decision() carries the sole exact no-execute allow-list.
+function shellCarriesProtectedWatcher(position, context) {
+  if (!position.command || !["sh", "bash", "zsh"].includes(basename(position.command.value))) return false;
+  return position.words.slice(position.index + 1).some((word) => protectedIdentity(word.value, context.root) === "watch");
+}
+
 function assignmentName(word) {
   const match = word.value.match(/^([A-Za-z_][A-Za-z0-9_]*)=/);
   return match ? match[1] : "";
@@ -731,6 +729,16 @@ function contextWithAssignments(context, words) {
 
 function nodeHasRedirection(tokens) {
   return tokens.some((token) => token.type === "redir");
+}
+
+function nodeHasProtectedOutputTarget(tokens, context) {
+  for (let i = 0; i < tokens.length; i += 1) {
+    const token = tokens[i];
+    if (token.type !== "redir" || token.inlineTarget || ![">", ">>", ">&"].includes(token.value)) continue;
+    const target = tokens[i + 1];
+    if (target?.type === "word" && (protectedIdentity(target.value, context.root) || wordReferencesAny(target, context.protectedVariables))) return true;
+  }
+  return false;
 }
 
 function nodeHasUnsafeSubstitution(tokens) {
@@ -803,8 +811,8 @@ function analyzeProgram(command, context, depth = 0) {
     }
 
     const shell = shellInvocation(position);
-    const shellPayload = shell?.kind === "command" && !shell.noexec ? shell.payload : null;
-    const shellScript = shell?.kind === "script" && !shell.noexec ? shell.payload : null;
+    const shellPayload = shell?.kind === "command" ? shell.payload : null;
+    const shellScript = shell?.kind === "script" ? shell.payload : null;
     const sourceScript = sourcedScript(position);
     const literalEvalPayload = evalPayload(position);
     const heredocPayloads = shellHeredocPayloads(tokens, position);
@@ -836,6 +844,8 @@ function analyzeProgram(command, context, depth = 0) {
     const protectedKind = protectedIdentity(executable, context.root);
     if (hasUnclassifiableProtectedExpansion(position.command, context.root)) unclassifiableProtected = true;
     const commandName = basename(executable);
+    const shellProtectedWatcher = shellCarriesProtectedWatcher(position, nodeContext);
+    nodeNestedProtected ||= shellProtectedWatcher;
     const args = position.words.slice(position.index + 1);
     if (commandName === "pkill" && args.some((word) => /fm-watch/.test(word.value) || wordReferencesAny(word, nodeContext.watcherPatterns))) broadKill = true;
     if (commandName === "kill" && (nodePgrepWatcher || args.some((word) => wordReferencesAny(word, nodeContext.watcherPids)))) broadKill = true;
@@ -854,8 +864,10 @@ function analyzeProgram(command, context, depth = 0) {
       tokens,
       position,
       protectedKind,
+      shellProtectedWatcher,
       nestedProtected: nodeNestedProtected,
       redirection: nodeHasRedirection(tokens),
+      protectedOutputRedirection: nodeHasProtectedOutputTarget(tokens, nodeContext),
       substitution: nodeHasUnsafeSubstitution(tokens),
     });
   }
@@ -878,6 +890,23 @@ function xModePathAllowed(value, home) {
 
 function ordinaryWordsOnly(tokens) {
   return tokens.every((token) => token.type === "word" && token.subs.length === 0);
+}
+
+// The entire no-execute exception is an allow-list. Only these exact top-level
+// forms are accepted:
+//   bash -n <fm-watch.sh>
+//   bash --noexec <fm-watch.sh>
+// Any wrapper, extra option/argument, separator, substitution, or redirection
+// falls through to the normal protected-command denials.
+function allowedWatcherSyntaxCheck(analysis, context) {
+  if (analysis.nodeInfos.length !== 1 || analysis.program.separators.length !== 0) return false;
+  const info = analysis.nodeInfos[0];
+  if (!info.shellProtectedWatcher || info.redirection || info.substitution) return false;
+  if (!ordinaryWordsOnly(info.tokens) || info.position.prefixAssignments > 0 || info.position.wrappers.length > 0) return false;
+  if (basename(info.position.command?.value || "") !== "bash") return false;
+  const args = info.position.words.slice(info.position.index + 1);
+  if (args.length !== 2 || !["-n", "--noexec"].includes(args[0].value)) return false;
+  return protectedIdentity(args[1].value, context.root) === "watch";
 }
 
 function setupKind(info, context) {
@@ -920,9 +949,12 @@ function decision(command, root, home) {
   const analysis = analyzeProgram(command, context);
   if (analysis.broadKill) return deny("broad-watcher-kill");
   if (analysis.error && analysis.protectedFound) return deny("unclassifiable-protected-command");
+  // A protected output target is independently unsafe even when the command
+  // itself is unrelated. Check it before every allow path so `: > watcher` can
+  // never truncate a script while data-only heredocs remain ordinary data.
+  if (analysis.nodeInfos?.some((info) => info.protectedOutputRedirection)) return deny("watcher-redirection");
   if (!analysis.protectedFound) return { decision: "allow" };
   if (analysis.nodeInfos?.some((info) => info.protectedKind === "watch")) return deny("watcher-direct");
-  if (analysis.nestedProtected) return deny("watcher-nested");
 
   const separators = analysis.program.separators;
   if (separators.includes("&") || analysis.nodeInfos.some((info) => info.position.wrappers.includes("nohup")) || analysis.nodeInfos.some((info) => basename(info.position.words[0]?.value || "") === "disown")) {
@@ -931,6 +963,8 @@ function decision(command, root, home) {
   if (separators.includes("|") || separators.includes("|&")) return deny("watcher-pipeline");
   if (analysis.nodeInfos.some((info) => info.redirection)) return deny("watcher-redirection");
   if (analysis.nodeInfos.some((info) => info.substitution)) return deny("watcher-nested");
+  if (allowedWatcherSyntaxCheck(analysis, context)) return { decision: "allow" };
+  if (analysis.nestedProtected) return deny("watcher-nested");
   if (blessedProgram(analysis, context)) return { decision: "allow" };
   if (analysis.nodeInfos.some((info) => info.position.prefixAssignments > 0 || info.position.wrappers.some((wrapper) => wrapper !== "exec"))) {
     return deny("watcher-nested");

--- a/bin/fm-backend.sh
+++ b/bin/fm-backend.sh
@@ -818,6 +818,33 @@ fm_backend_composer_state() {  # <backend> <target> -> empty|pending|pending-unp
   esac
 }
 
+# fm_backend_process_root_pid: return the shell/process root whose descendant
+# closure belongs to one pane. Only tmux and herdr expose a verified PID binding;
+# other backends fail without guessing so progress sampling stays supplemental.
+fm_backend_process_root_pid() {  # <backend> <target>
+  local backend=$1 target=$2 session pane info
+  case "$backend" in
+    tmux)
+      tmux display-message -p -t "$target" '#{pane_pid}' 2>/dev/null
+      ;;
+    herdr)
+      fm_backend_source herdr || return 1
+      session=${target%%:*}
+      pane=${target#*:}
+      [ -n "$session" ] && [ -n "$pane" ] && [ "$pane" != "$target" ] || return 1
+      info=$(fm_backend_herdr_cli "$session" pane process-info --pane "$pane" 2>/dev/null) || return 1
+      printf '%s' "$info" | jq -er --arg pane "$pane" '
+        .result.process_info
+        | select(.pane_id == $pane)
+        | .shell_pid
+        | select(type == "number" and . > 1)
+        | floor
+      ' 2>/dev/null
+      ;;
+    *) return 1 ;;
+  esac
+}
+
 # fm_backend_target_exists: cheap, READ-ONLY existence check - does the
 # recorded TARGET endpoint still exist on BACKEND? Never starts a server or
 # session: for herdr this deliberately queries the pane directly instead of

--- a/bin/fm-bearings-report.sh
+++ b/bin/fm-bearings-report.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Install a complete Bearings draft as today's dated report. If a same-day
+# report exists, preserve its exact bytes at a unique create-exclusive path and
+# write a digest-bound custody receipt before replacing it.
+#
+# Usage: fm-bearings-report.sh <complete-draft.md>
+#
+# FM_BEARINGS_REPORT_DATE may pin YYYY-MM-DD for deterministic tests. The draft
+# remains untouched. The command prints the installed report path.
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
+DATA="${FM_DATA_OVERRIDE:-$FM_HOME/data}"
+
+# shellcheck source=bin/fm-custody-lib.sh
+. "$SCRIPT_DIR/fm-custody-lib.sh"
+
+fail() {
+  printf 'fm-bearings-report: %s\n' "$*" >&2
+  exit 1
+}
+
+[ "$#" -eq 1 ] || fail "usage: fm-bearings-report.sh <complete-draft.md>"
+draft=$1
+[ -f "$draft" ] && [ ! -L "$draft" ] || fail "draft must be a regular non-symlink file: $draft"
+report_date=${FM_BEARINGS_REPORT_DATE:-$(date '+%Y-%m-%d')}
+case "$report_date" in
+  ????-??-??) ;;
+  *) fail "report date must be YYYY-MM-DD: $report_date" ;;
+esac
+mkdir -p "$DATA"
+target="$DATA/status-report-$report_date.md"
+versions="$DATA/status-report-versions"
+source_ref=$(git -C "$FM_ROOT" rev-parse HEAD 2>/dev/null || printf 'unversioned-firstmate-root')
+
+if [ -e "$target" ]; then
+  [ -f "$target" ] && [ ! -L "$target" ] || fail "existing report is not a regular non-symlink file: $target"
+  fm_custody_preserve "$target" "$versions" "$source_ref" bearings-prior-snapshot >/dev/null \
+    || fail "could not preserve the prior report before replacement"
+fi
+
+tmp="$DATA/.status-report-$report_date.${BASHPID:-$$}.tmp"
+trap 'rm -f "$tmp"' EXIT INT TERM
+(umask 077; cp "$draft" "$tmp") || fail "could not stage the complete report"
+mv "$tmp" "$target" || fail "could not install the complete report"
+trap - EXIT INT TERM
+printf '%s\n' "$target"

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -6,7 +6,7 @@
 # description, acceptance criteria, and context, and may adjust other sections
 # when the task genuinely deviates (e.g. working an existing external PR instead
 # of shipping a new one).
-# Usage: fm-brief.sh <task-id> <repo-name> [--scout] [--herdr-lab]
+# Usage: fm-brief.sh <task-id> <repo-name> [--scout] [--herdr-lab] [--spec-forging]
 #        fm-brief.sh <task-id> --secondmate {<project>...|--no-projects}
 #   --scout writes the scout contract instead: the deliverable is a report at
 #   data/<task-id>/report.md (no branch, no push, no PR) and the worktree is scratch.
@@ -26,6 +26,15 @@
 #   The flag must be explicit because {TASK} is filled after scaffolding and the
 #   caller-supplied repo string cannot reliably identify this repo. Briefs made
 #   without it carry a loud declaration so an omitted contract cannot be silent.
+#   --spec-forging is mandatory when the task will forge requirements, design,
+#   or tasks from a signed product contract. It requires all eight Faber
+#   preflight data through these environment variables:
+#     FM_SPEC_FORGING_PRD FM_SPEC_FORGING_AGENTS FM_SPEC_FORGING_REPO
+#     FM_SPEC_FORGING_FILES FM_SPEC_FORGING_SLICE FM_SPEC_FORGING_VISUAL_GATE
+#     FM_SPEC_FORGING_SURFACE FM_SPEC_FORGING_VALIDATION_GATE
+#   Missing, whitespace-only, or multiline data fail before a task directory is
+#   created. The generated gate returns producer scope changes to an independently
+#   commissioned architect and never lets the producer appoint itself.
 # For ship tasks, the definition of done is shaped by the project's delivery mode
 # (data/projects.md via fm-project-mode.sh; see the project-management skill
 # and AGENTS.md task lifecycle):
@@ -38,7 +47,9 @@
 # Every scaffold's status protocol distinguishes the configured
 # declared-external-wait verb (FM_CLASSIFY_PAUSED_VERB, default "paused") from
 # "blocked:": pause for a known external wait expected to clear on its own,
-# blocked when firstmate must act.
+# blocked when firstmate must act. The separate fixed `awaiting-captain:` verb is
+# an unbounded captain decision after the producer work is complete; it remains
+# open until an explicit keyed resolution records the captain's answer.
 # Ship tasks include a project-memory section so durable project-intrinsic
 # learnings can be committed to AGENTS.md through the project's delivery path;
 # it carries the AGENTS.md authoring bar (widely useful knowledge only, pointers
@@ -93,6 +104,7 @@ else
 fi
 KIND=ship
 HERDR_LAB=0
+SPEC_FORGING=0
 NO_PROJECTS=0
 POS=()
 for a in "$@"; do
@@ -100,6 +112,7 @@ for a in "$@"; do
     --scout) KIND=scout ;;
     --secondmate) KIND=secondmate ;;
     --herdr-lab) HERDR_LAB=1 ;;
+    --spec-forging) SPEC_FORGING=1 ;;
     --no-projects) NO_PROJECTS=1 ;;
     *) POS+=("$a") ;;
   esac
@@ -111,9 +124,42 @@ if [ "$KIND" = secondmate ] && [ "$HERDR_LAB" -eq 1 ]; then
   exit 1
 fi
 
+if [ "$KIND" = secondmate ] && [ "$SPEC_FORGING" -eq 1 ]; then
+  echo "error: --spec-forging applies only to crewmate ship or scout briefs" >&2
+  exit 1
+fi
+
 if [ "$NO_PROJECTS" -eq 1 ] && [ "$KIND" != secondmate ]; then
   echo "error: --no-projects applies only to --secondmate charters" >&2
   exit 1
+fi
+
+require_spec_forging_datum() {
+  local variable=$1 datum=$2 value=${!1:-}
+  case "$value" in
+    *[![:space:]]*) : ;;
+    *)
+      echo "error: --spec-forging missing $datum ($variable)" >&2
+      return 1
+      ;;
+  esac
+  case "$value" in
+    *$'\n'*|*$'\r'*)
+      echo "error: --spec-forging $datum must be one line ($variable)" >&2
+      return 1
+      ;;
+  esac
+}
+
+if [ "$SPEC_FORGING" -eq 1 ]; then
+  require_spec_forging_datum FM_SPEC_FORGING_PRD "exact PRD path and signature evidence" || exit 1
+  require_spec_forging_datum FM_SPEC_FORGING_AGENTS "target repo AGENTS.md path" || exit 1
+  require_spec_forging_datum FM_SPEC_FORGING_REPO "repo, root, verification ref, and push ref" || exit 1
+  require_spec_forging_datum FM_SPEC_FORGING_FILES "exact spec directory and files to produce" || exit 1
+  require_spec_forging_datum FM_SPEC_FORGING_SLICE "slice and out-of-scope" || exit 1
+  require_spec_forging_datum FM_SPEC_FORGING_VISUAL_GATE "visual-gate state" || exit 1
+  require_spec_forging_datum FM_SPEC_FORGING_SURFACE "forging surface" || exit 1
+  require_spec_forging_datum FM_SPEC_FORGING_VALIDATION_GATE "validation-gate mechanism" || exit 1
 fi
 
 BRIEF="$DATA/$ID/brief.md"
@@ -186,14 +232,15 @@ A message with NO marker is the captain typing directly into your pane: treat it
 Handle routine work yourself.
 Report only true captain-relevant outcomes or a declared external wait by appending one line:
    \`echo "{state}: {one short line}" >> $STATUS_FILE\`
-States: working, needs-decision, blocked, $PAUSED_VERB, done, failed.
+States: working, needs-decision, blocked, $PAUSED_VERB, awaiting-captain, done, failed.
 Use \`$PAUSED_VERB: {why}\` (distinct from \`blocked:\`) only when your domain is deliberately idling on a known external wait you expect to clear on its own; use \`blocked:\` when you are stuck and need firstmate to act.
+Use \`awaiting-captain [key=<slug>]: {exact question}\` only after the producer work is complete and the exact question requires an unbounded captain answer; it surfaces once, stays quiet while the terminal status, clean tree, and HEAD remain unchanged, and closes only with a matching \`resolved [key=<slug>]: {captain answer}\` event.
 Use this only for material phase changes, a captain decision, a real blocker, a failure, or work ready for review.
 This is also how you return the answer to a marked from-firstmate request above.
 A marked request requires one correlated answer after the work; it does not require a separate receipt or start acknowledgement.
 Never append \`working:\` merely to acknowledge receipt or announce that a marked request has started.
 When a routed-work phase has a supervisor-actionable material change worth reporting under the rule above, give that reported phase a stable key.
-If its first reportable event is \`working [key=<work-slug>]: {material phase}\`, use the same key on its later \`$PAUSED_VERB\`, \`done\`, \`failed\`, \`needs-decision\`, or \`blocked\` event so the earlier working phase is superseded.
+If its first reportable event is \`working [key=<work-slug>]: {material phase}\`, use the same key on its later \`$PAUSED_VERB\`, \`awaiting-captain\`, \`done\`, \`failed\`, \`needs-decision\`, or \`blocked\` event so the earlier working phase is superseded.
 When a keyed phase ends without another reportable state, append \`resolved [key=<work-slug>]: {why it is no longer active}\`.
 When a decision you escalated is answered or a blocker clears and your domain resumes, append \`resolved: {how it was decided or unblocked}\` (keyed with \`[key=<slug>]\` if you opened it with one) so it is durably closed instead of resurfacing behind later unrelated events.
 Routine internal supervision, heartbeats, retries, and crewmate churn stay inside your own home and must not touch that status file.
@@ -214,6 +261,34 @@ exit 0
 fi
 
 REPO=${POS[1]}
+
+if [ "$SPEC_FORGING" -eq 1 ]; then
+IFS= read -r -d '' SPEC_FORGING_SECTION <<EOF || true
+# Spec-forging contract - HARD GATE
+This brief was explicitly scaffolded with \`--spec-forging\`.
+Before forging, verify all eight data below against their live sources.
+If any datum is missing or contradicted, stop and ask firstmate; do not infer it.
+
+1. **Exact PRD path and signature evidence:** $FM_SPEC_FORGING_PRD
+2. **Target repo AGENTS.md path:** $FM_SPEC_FORGING_AGENTS
+3. **Repo, root, verification ref, and push ref:** $FM_SPEC_FORGING_REPO
+4. **Exact spec directory and files to produce:** $FM_SPEC_FORGING_FILES
+5. **Slice and out-of-scope:** $FM_SPEC_FORGING_SLICE
+6. **Visual-gate state:** $FM_SPEC_FORGING_VISUAL_GATE
+7. **Forging surface:** $FM_SPEC_FORGING_SURFACE
+8. **Validation-gate mechanism:** $FM_SPEC_FORGING_VALIDATION_GATE
+
+Do not approve what you forged.
+Architecture or scope changes return to Marco Antonio; the forger never authorizes or resolves them.
+The architect is the Marco Antonio station or role and may be an explicitly commissioned worker.
+That worker never self-appoints and never signs for Cesar.
+Agrippa is not the architect.
+After legitimate authorization, the correction returns to an independent gate.
+EOF
+SPEC_FORGING_SECTION=${SPEC_FORGING_SECTION%$'\n'}
+else
+SPEC_FORGING_SECTION=""
+fi
 
 if [ "$HERDR_LAB" -eq 1 ]; then
 HERDR_LAB_HELPER=$(shell_quote "$FM_ROOT/bin/fm-herdr-lab.sh")
@@ -247,6 +322,12 @@ EOF
 HERDR_SECTION=${HERDR_SECTION%$'\n'}
 fi
 
+if [ "$SPEC_FORGING" -eq 1 ]; then
+  BRIEF_CONTRACTS="$SPEC_FORGING_SECTION"$'\n\n'"$HERDR_SECTION"
+else
+  BRIEF_CONTRACTS=$HERDR_SECTION
+fi
+
 if [ "$KIND" = scout ]; then
 cat > "$BRIEF" <<EOF
 You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.
@@ -254,7 +335,7 @@ You are a crewmate: an autonomous worker agent managed by firstmate. Work on you
 # Task
 {TASK}
 
-$HERDR_SECTION
+$BRIEF_CONTRACTS
 
 # Setup
 You are in a disposable git worktree of $REPO, at a detached HEAD on a clean default branch.
@@ -268,7 +349,7 @@ The report is the only thing that survives, so anything worth keeping must be in
 3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
 4. Report status by appending one line:
    \`echo "{state}: {one short line}" >> $STATUS_FILE\`
-   States: working, needs-decision, blocked, $PAUSED_VERB, done, failed.
+   States: working, needs-decision, blocked, $PAUSED_VERB, awaiting-captain, done, failed.
    Each append wakes firstmate, so report sparingly: only phase changes a supervisor
    would act on and the needs-decision/blocked/paused/done/failed states. No step-by-step
    FYI progress lines; firstmate reads your pane for that.
@@ -276,6 +357,7 @@ The report is the only thing that survives, so anything worth keeping must be in
    known external wait you expect to clear on its own (an upstream release, a rate-limit reset):
    firstmate then leaves your idle pane alone and rechecks it on a long cadence instead of
    treating it as a possible wedge. Use \`blocked:\` when you are stuck and need help.
+   Use \`awaiting-captain [key=<slug>]: {exact question}\` only after the producer work is complete and the exact question requires an unbounded captain answer; it stays retired while the terminal status, clean tree, and HEAD remain unchanged and closes only after the captain answers through a matching \`resolved [key=<slug>]: {captain answer}\` event.
 5. If you hit the same obstacle twice, append \`blocked: {why}\` and stop; firstmate will help.
 6. If a decision belongs to a human (product choices, destructive actions),
    append \`needs-decision: {summary of options}\` and stop. Firstmate will reply with the decision.
@@ -363,7 +445,7 @@ You are a crewmate: an autonomous worker agent managed by firstmate. Work on you
 # Task
 {TASK}
 
-$HERDR_SECTION
+$BRIEF_CONTRACTS
 
 # Setup
 You are in a disposable git worktree of $REPO, at a detached HEAD on a clean default branch.
@@ -380,7 +462,7 @@ $RULE1
 3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
 4. Report status by appending one line:
    \`echo "{state}: {one short line}" >> $STATUS_FILE\`
-   States: working, needs-decision, blocked, $PAUSED_VERB, done, failed.
+   States: working, needs-decision, blocked, $PAUSED_VERB, awaiting-captain, done, failed.
    Each append wakes firstmate, so report sparingly: only phase changes a supervisor
    would act on (setup done, bug reproduced, fix implemented, validation passed) and the
    needs-decision/blocked/paused/done/failed states. No step-by-step FYI progress lines;
@@ -391,6 +473,7 @@ $RULE1
    known external wait you expect to clear on its own (an upstream release, a rate-limit reset,
    a scheduled window): firstmate then leaves your idle pane alone and rechecks it on a long
    cadence instead of treating it as a possible wedge. Use \`blocked:\` when you are stuck and need help.
+   Use \`awaiting-captain [key=<slug>]: {exact question}\` only after the producer work is complete and the exact question requires an unbounded captain answer; it stays retired while the terminal status, clean tree, and HEAD remain unchanged and closes only after the captain answers through a matching \`resolved [key=<slug>]: {captain answer}\` event.
 5. If you hit the same obstacle twice, append \`blocked: {why}\` and stop; firstmate will help.
 6. If a decision belongs above the implementation worker (product choices, destructive actions, ask-user findings),
    append \`needs-decision: {summary of options}\` and stop. Firstmate will apply the configured authority and reply with the decision.

--- a/bin/fm-classify-lib.sh
+++ b/bin/fm-classify-lib.sh
@@ -43,6 +43,7 @@ FM_CREW_STATE_BIN="${FM_CREW_STATE_BIN:-$_FM_CLASSIFY_LIB_DIR/fm-crew-state.sh}"
 # merely because its prose contains one of those tokens (for example
 # "working: rebased onto merged #76").
 FM_CLASSIFY_CAPTAIN_RE_DEFAULT='done:|needs-decision:|blocked:|failed:|PR ready|checks green|ready in branch|merged'
+FM_CLASSIFY_AWAITING_CAPTAIN_VERB_DEFAULT='awaiting-captain'
 
 # The deliberate-external-wait verb. A crew (or firstmate steering it) appends
 #   paused: <reason>
@@ -88,9 +89,19 @@ status_is_terminal_verb() {
   [ -n "$line" ] || return 1
   verb=$(status_line_verb "$line")
   case "$verb" in
-    done|needs-decision|blocked|failed) return 0 ;;
+    done|needs-decision|blocked|failed|"${FM_CLASSIFY_AWAITING_CAPTAIN_VERB:-$FM_CLASSIFY_AWAITING_CAPTAIN_VERB_DEFAULT}") return 0 ;;
     *) return 1 ;;
   esac
+}
+
+# 0 only for a completed producer report. Unlike blocked, failed, or
+# needs-decision, a surfaced done event requires no repeated stale escalation.
+# Its worktree and metadata may still need retention for an independent gate or
+# unlanded commits; callers must not treat this predicate as cleanup authority.
+status_is_done() {  # <status-line>
+  local line=$1
+  [ -n "$line" ] || return 1
+  [ "$(status_line_verb "$line")" = 'done' ]
 }
 
 # 0 if the given (last) status line matches a captain-relevant verb.
@@ -110,7 +121,7 @@ status_is_captain_relevant() {
   esac
   if [ -z "${FM_CAPTAIN_RE+x}" ]; then
     case "$verb" in
-      done|needs-decision|blocked|failed) return 0 ;;
+      done|needs-decision|blocked|failed|"${FM_CLASSIFY_AWAITING_CAPTAIN_VERB:-$FM_CLASSIFY_AWAITING_CAPTAIN_VERB_DEFAULT}") return 0 ;;
     esac
   fi
   printf '%s' "$line" | grep -qiE "${FM_CAPTAIN_RE:-$FM_CLASSIFY_CAPTAIN_RE_DEFAULT}"
@@ -125,6 +136,16 @@ status_is_paused() {  # <status-line>
   [ -n "$line" ] || return 1
   verb=$(status_line_verb "$line")
   [ "$verb" = "${FM_CLASSIFY_PAUSED_VERB:-$FM_CLASSIFY_PAUSED_VERB_DEFAULT}" ]
+}
+
+# A durable, unbounded wait for a captain answer. Unlike paused, it is
+# captain-relevant once and never implies an external condition will clear on
+# its own. The keyed decision fold below keeps it open until resolved.
+status_is_awaiting_captain() {  # <status-line>
+  local line=$1 verb
+  [ -n "$line" ] || return 1
+  verb=$(status_line_verb "$line")
+  [ "$verb" = "${FM_CLASSIFY_AWAITING_CAPTAIN_VERB:-$FM_CLASSIFY_AWAITING_CAPTAIN_VERB_DEFAULT}" ]
 }
 
 # 0 if a status line declares either an external-wait pause or a verified
@@ -218,7 +239,7 @@ status_open_decisions() {  # <status-file>
     verb=$(status_line_verb "$line")
     key=$(_fm_decision_key "$line") || continue
     case "$verb" in
-      needs-decision|blocked)
+      needs-decision|blocked|"${FM_CLASSIFY_AWAITING_CAPTAIN_VERB:-$FM_CLASSIFY_AWAITING_CAPTAIN_VERB_DEFAULT}")
         note=$(status_line_note "$line")
         open=$(_fm_decision_drop "$open" "$key")
         [ -n "$open" ] && open="${open}"$'\n'
@@ -231,6 +252,11 @@ status_open_decisions() {  # <status-file>
     esac
   done < "$f"
   printf '%s' "$open"
+}
+
+status_awaiting_captain_decisions() {  # <status-file>
+  status_open_decisions "$1" | awk -F '\t' -v verb="${FM_CLASSIFY_AWAITING_CAPTAIN_VERB:-$FM_CLASSIFY_AWAITING_CAPTAIN_VERB_DEFAULT}" \
+    '$2 == verb { print }'
 }
 
 # Fold material routed-work phases in the same keyed event stream.
@@ -259,7 +285,7 @@ _fm_status_open_activities_stream() {
         [ -n "$open" ] && open="${open}"$'\n'
         open="${open}${key}"$'\t'"${verb}"$'\t'"${note}"$'\n'
         ;;
-      done|failed|needs-decision|blocked|"$resolve"|"$held")
+      done|failed|needs-decision|blocked|"${FM_CLASSIFY_AWAITING_CAPTAIN_VERB:-$FM_CLASSIFY_AWAITING_CAPTAIN_VERB_DEFAULT}"|"$resolve"|"$held")
         open=$(_fm_decision_drop "$open" "$key")
         [ -n "$open" ] && open="${open}"$'\n'
         ;;

--- a/bin/fm-crew-state.sh
+++ b/bin/fm-crew-state.sh
@@ -16,7 +16,7 @@
 # fixed mapping logic, no heuristics and no LLM. Output is one stable, parseable,
 # token-tight line firstmate can read every heartbeat:
 #
-#   state: <working|parked|done|blocked|paused|failed|unknown> · source: <run-step|pane|status-log|none> · <detail>
+#   state: <working|parked|awaiting-captain|done|blocked|paused|failed|unknown> · source: <run-step|pane|status-log|none> · <detail>
 #
 # Logic, in order:
 #   1. Resolve worktree + backend target + kind from state/<id>.meta.
@@ -35,6 +35,11 @@
 #      checks" from "checks green, waiting on merge" (see nm_ci_checks_state) -
 #      a ci-step log-tail check overrides working -> done once checks read
 #      green, so a green PR is never silently read as still-validating.
+#      For an active full run whose step log names its native worker PID, the
+#      process is checked independently of the pane: live remains working,
+#      stopped/suspended or absent never inherits the stale running row, and an
+#      unrecognized reused PID becomes unknown. Pane interruption cannot stop or
+#      prove the state of this detached worker.
 #   3. Reconcile the status log: if its last line says needs-decision/blocked but
 #      the run-step shows the run moved on, the log is deterministically stale and
 #      is flagged superseded. A genuinely parked run plus a needs-decision log
@@ -119,6 +124,10 @@ log_last_line() {
 # reports `paused` distinctly, so a supervisor reading this sees a declared pause
 # and its reason rather than a wedge-suspect idle.
 map_log_state() {  # <line>
+  if status_is_awaiting_captain "$1"; then
+    echo awaiting-captain
+    return
+  fi
   if status_is_paused "$1"; then
     echo paused
     return
@@ -321,6 +330,53 @@ nm_ci_checks_state() {
     *"checks passed"*|*"no CI checks reported - still monitoring"*) printf 'green' ;;
     *"no CI checks reported yet"*|*"checks failed"*|*"issues detected"*|*"CI checks running"*|*"base branch advanced"*"re-arming CI monitor timeout"*) printf 'not-ready' ;;
     *) printf 'unknown' ;;
+  esac
+}
+
+# Resolve native no-mistakes step-worker health when the current step log exposes
+# a start PID. Absence of such an identity is an explicit unsupported shape and
+# leaves the run-record mapping unchanged; a named PID is never allowed to do so
+# when the process is dead, suspended, or has been reused by an unrelated command.
+NM_WORKER_HEALTH=unavailable
+NM_WORKER_PID=
+nm_headless_worker_health() {
+  local run_id step log started pid related ps_out stat command
+  NM_WORKER_HEALTH=unavailable
+  NM_WORKER_PID=
+  run_id=$(strip_quotes "$(nm_field id)")
+  [ -n "$run_id" ] || return 0
+  step=$(printf '%s\n' "$RUN_OUT" \
+    | awk -F, '$2 ~ /^[[:space:]]*"?(running|fixing)"?[[:space:]]*$/ { gsub(/^[[:space:]]+|[[:space:]]+$/, "", $1); found=$1 } END { print found }')
+  [ -n "$step" ] || step=$(strip_quotes "$(nm_field status)")
+  [ -n "$step" ] || return 0
+  log=$(nm_run axi logs --step "$step" --run "$run_id")
+  [ -n "$log" ] || return 0
+  started=$(printf '%s\n' "$log" \
+    | grep -Ei '(codex|claude|opencode|grok|kimi|pi|agent).*started.*pid[=: ]+[0-9]+' \
+    | tail -1)
+  [ -n "$started" ] || return 0
+  pid=$(printf '%s\n' "$started" | sed -nE 's/.*pid[=: ]+([0-9]+).*/\1/p')
+  case "$pid" in ''|*[!0-9]*) return 0 ;; esac
+  NM_WORKER_PID=$pid
+  related=$(printf '%s\n' "$log" \
+    | grep -Ei "((started|exited|stopped).*(pid[=: ]+)?$pid)|((pid[=: ]+)?$pid.*(started|exited|stopped))" \
+    | tail -1)
+  case "$related" in
+    *exited*|*stopped*) NM_WORKER_HEALTH=dead; return 0 ;;
+  esac
+  ps_out=$(ps -p "$pid" -o stat= -o command= 2>/dev/null) || {
+    NM_WORKER_HEALTH=dead
+    return 0
+  }
+  stat=$(printf '%s\n' "$ps_out" | awk 'NR == 1 { print $1 }')
+  command=${ps_out#*"$stat"}
+  if ! printf '%s\n' "$command" | grep -Eiq 'codex|claude|opencode|grok|kimi|(^|[ /])pi([ /]|$)|agent'; then
+    NM_WORKER_HEALTH=unknown
+    return 0
+  fi
+  case "$stat" in
+    *T*) NM_WORKER_HEALTH=suspended ;;
+    *) NM_WORKER_HEALTH=live ;;
   esac
 }
 # Coarse fallback for cross-branch attribution. `no-mistakes axi status` (bare)
@@ -551,6 +607,30 @@ if [ "$HAVE_RUN" = 1 ]; then
     if [ "$CI_LOG_STATE" != not-ready ]; then
       emit "done" status-log "$(status_line_note "$LOG_LINE")${SEP}run still monitoring PR"
     fi
+  fi
+
+  if [ "$RUN_STATE" = working ] && [ "$RUN_SOURCE" = full ]; then
+    nm_headless_worker_health
+    case "$NM_WORKER_HEALTH" in
+      live)
+        RUN_DETAIL="$RUN_DETAIL${SEP}headless pipeline worker live pid=$NM_WORKER_PID; pane state is independent"
+        ;;
+      dead)
+        RUN_STATE=blocked
+        RUN_DETAIL="run record still active${SEP}headless pipeline worker dead pid=$NM_WORKER_PID"
+        ;;
+      suspended)
+        RUN_STATE=blocked
+        RUN_DETAIL="run record still active${SEP}headless pipeline worker suspended pid=$NM_WORKER_PID"
+        ;;
+      unknown)
+        RUN_STATE=unknown
+        RUN_DETAIL="run record still active${SEP}headless worker pid=$NM_WORKER_PID has unrecognized identity"
+        ;;
+      *)
+        RUN_DETAIL="$RUN_DETAIL${SEP}headless worker identity unavailable; run record only"
+        ;;
+    esac
   fi
 
   # Reconcile the status log. A needs-decision/blocked log line that the run-step

--- a/bin/fm-crew-state.sh
+++ b/bin/fm-crew-state.sh
@@ -628,7 +628,8 @@ if [ "$HAVE_RUN" = 1 ]; then
         RUN_DETAIL="run record still active${SEP}headless worker pid=$NM_WORKER_PID has unrecognized identity"
         ;;
       *)
-        RUN_DETAIL="$RUN_DETAIL${SEP}headless worker identity unavailable; run record only"
+        RUN_STATE=unknown
+        RUN_DETAIL="run record still active${SEP}headless worker identity unavailable; live/dead state is indeterminate"
         ;;
     esac
   fi

--- a/bin/fm-custody-lib.sh
+++ b/bin/fm-custody-lib.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Create an immutable, create-exclusive copy of an ephemeral artifact and a
+# machine-verifiable receipt before its caller performs a destructive transition.
+#
+# Source this file, then call:
+#   fm_custody_preserve <source> <archive-dir> <source-ref> <custody-class>
+#
+# The function prints "<archived-path><TAB><receipt-path>". It never removes or
+# changes the source. Every output path is newly created with shell noclobber;
+# retries choose another suffix and never replace prior evidence.
+
+fm_custody_sha256() {
+  if command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$1" | awk '{print $1}'
+  elif command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | awk '{print $1}'
+  else
+    printf 'fm-custody: shasum or sha256sum is required\n' >&2
+    return 1
+  fi
+}
+
+fm_custody_preserve() {  # <source> <archive-dir> <source-ref> <custody-class>
+  local source=$1 archive_dir=$2 source_ref=$3 custody_class=$4
+  local timestamp stamp base attempt archived receipt digest bytes
+  [ -f "$source" ] && [ ! -L "$source" ] || {
+    printf 'fm-custody: source must be a regular non-symlink file: %s\n' "$source" >&2
+    return 1
+  }
+  case "$source_ref$custody_class" in
+    *$'\n'*|*$'\r'*)
+      printf 'fm-custody: source ref and custody class must be one line\n' >&2
+      return 1
+      ;;
+  esac
+  [ -n "$source_ref" ] && [ -n "$custody_class" ] || {
+    printf 'fm-custody: source ref and custody class are required\n' >&2
+    return 1
+  }
+  mkdir -p "$archive_dir" || return 1
+  timestamp=$(date -u '+%Y-%m-%dT%H:%M:%SZ') || return 1
+  stamp=$(date -u '+%Y%m%dT%H%M%SZ') || return 1
+  base=$(basename "$source")
+  attempt=0
+  while [ "$attempt" -lt 100 ]; do
+    archived="$archive_dir/$base.$stamp.${BASHPID:-$$}.$attempt"
+    receipt="$archived.receipt"
+    if (set -C; umask 077; printf '%s' '' > "$archived") 2>/dev/null; then
+      break
+    fi
+    attempt=$((attempt + 1))
+  done
+  [ "$attempt" -lt 100 ] || {
+    printf 'fm-custody: could not allocate a create-exclusive archive path\n' >&2
+    return 1
+  }
+  if ! cp "$source" "$archived"; then
+    printf 'fm-custody: could not copy source to %s\n' "$archived" >&2
+    return 1
+  fi
+  digest=$(fm_custody_sha256 "$archived") || return 1
+  bytes=$(wc -c < "$archived" | tr -d '[:space:]') || return 1
+  if ! (set -C; umask 077; {
+    printf 'schema=fm-custody.v1\n'
+    printf 'timestamp_utc=%s\n' "$timestamp"
+    printf 'source_path=%s\n' "$source"
+    printf 'source_ref=%s\n' "$source_ref"
+    printf 'custody_class=%s\n' "$custody_class"
+    printf 'archived_path=%s\n' "$archived"
+    printf 'sha256=%s\n' "$digest"
+    printf 'bytes=%s\n' "$bytes"
+  } > "$receipt") 2>/dev/null; then
+    printf 'fm-custody: could not create receipt %s\n' "$receipt" >&2
+    return 1
+  fi
+  printf '%s\t%s\n' "$archived" "$receipt"
+}

--- a/bin/fm-decision-hold.sh
+++ b/bin/fm-decision-hold.sh
@@ -22,6 +22,7 @@
 #     --title <title> --reason <reason> [--repo <repo>]
 #   fm-decision-hold.sh complete <origin-id> (--none | <decision-key>...)
 #   fm-decision-hold.sh verify <origin-id>
+#   fm-decision-hold.sh verify-resolution <origin-id> <decision-key>
 #   fm-decision-hold.sh resolve <origin-id> <decision-key> \
 #     --decision-file <path> --routed-to <task-id> [--routed-to <task-id>...]
 #
@@ -30,13 +31,29 @@
 # no unresolved captain decision. Later review passes may add keys; a live task's
 # metadata inventory is unioned idempotently. A post-teardown visual review can
 # complete against the surviving report and holds without recreating task state.
-# `verify` is read-only and is called by scout teardown so teardown cannot erase a
-# source before this gate has succeeded.
+# `verify` is read-only and is called by scout teardown. An unresolved hold is
+# cleanup-authoritative only after `complete` records a receipt under
+# data/decision-hold-receipts/ that binds origin id, endpoint dispatch id, the
+# exact backlog object digest, and a Bearings snapshot in which the hold appears.
+# Every live completion, including `--none`, also retains a report-bound origin
+# receipt so a later post-teardown visual-review pass keeps the authenticated
+# task and dispatch association needed to create and verify hold receipts.
+# This permits cleanup without requiring the captain to answer in the same session.
 #
 # `resolve` requires every --routed-to task to exist and to be blocked by the hold.
 # It writes the captain decision and routed identities into the hold body, clears
 # those dependency edges, and only then marks the hold Done. A failure before the
 # final step leaves the captain hold open.
+# A resolved hold additionally retains the captain decision in
+# <hold-id>.decision.md and records <hold-id>.resolved beside it. Verification
+# requires one live-or-archived row, a nonzero decision digest, exact origin and
+# dispatch links, the canonical existing decision object, every routed task, and
+# matching object digests. Historical resolved rows without this receipt refuse;
+# there is no implicit or hand-written-row migration. An open historical hold may
+# reconstruct its cleanup receipt only by repeating `complete` while its exact
+# endpoint dispatch binding survives. Binding-less or already-resolved rows whose
+# script-owned objects are absent remain preserved and refused; no safe automatic
+# migration, force, or discard is supplied by this command.
 set -eu
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -44,6 +61,7 @@ FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
 FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
 STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
 DATA="${FM_DATA_OVERRIDE:-$FM_HOME/data}"
+RECEIPT_DIR="$DATA/decision-hold-receipts"
 
 # shellcheck source=bin/fm-classify-lib.sh
 # shellcheck disable=SC1091
@@ -90,6 +108,38 @@ sha256_text() {  # <text>
   fi
 }
 
+sha256_file() {  # <path>
+  if command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$1" | awk '{print $1}'
+  elif command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | awk '{print $1}'
+  else
+    fail "shasum or sha256sum is required"
+  fi
+}
+
+digest_is_nonzero_sha256() {  # <digest>
+  printf '%s\n' "$1" | grep -Eq '^[0-9a-f]{64}$' || return 1
+  [ "$1" != 0000000000000000000000000000000000000000000000000000000000000000 ]
+}
+
+regular_nonsymlink_file() {  # <path>
+  [ -f "$1" ] && [ ! -L "$1" ]
+}
+
+write_atomic_file() {  # <path>  (content on stdin)
+  local path=$1 dir tmp
+  dir=${path%/*}
+  mkdir -p "$dir" || fail "could not create receipt directory: $dir"
+  tmp=$(mktemp "$dir/.receipt.tmp.XXXXXX") || fail "could not allocate receipt temporary file"
+  chmod 600 "$tmp" || { rm -f "$tmp"; fail "could not protect receipt temporary file"; }
+  if ! cat > "$tmp"; then
+    rm -f "$tmp"
+    fail "could not write receipt temporary file"
+  fi
+  mv "$tmp" "$path" || { rm -f "$tmp"; fail "could not publish receipt: $path"; }
+}
+
 hold_id() {  # <origin-id> <decision-key>
   validate_slug origin-id "$1"
   validate_slug decision-key "$2"
@@ -108,6 +158,70 @@ require_tasks_axi() {
 
 task_show() {  # <id>
   tasks_axi show "$1" --full 2>/dev/null
+}
+
+task_row_count() {  # <id>
+  local id=$1 prefix file
+  prefix="- [x] $id - "
+  {
+    for file in "$DATA/backlog.md" "$DATA/done-archive.md"; do
+      [ -f "$file" ] || continue
+      awk -v open="- [ ] $id - " -v done="$prefix" '
+        index($0, open) == 1 || index($0, done) == 1 { count++ }
+        END { print count + 0 }
+      ' "$file"
+    done
+  } | awk '{ total += $1 } END { print total + 0 }'
+}
+
+task_row_source() {  # <id>
+  local id=$1 file count
+  [ "$(task_row_count "$id")" -eq 1 ] || return 1
+  for file in "$DATA/backlog.md" "$DATA/done-archive.md"; do
+    [ -f "$file" ] || continue
+    count=$(awk -v open="- [ ] $id - " -v done="- [x] $id - " '
+      index($0, open) == 1 || index($0, done) == 1 { count++ }
+      END { print count + 0 }
+    ' "$file") || return 1
+    if [ "$count" -eq 1 ]; then
+      printf '%s\n' "$file"
+      return 0
+    fi
+  done
+  return 1
+}
+
+archived_task_show() {  # <id>
+  local id=$1 archive="$DATA/done-archive.md" prefix
+  [ -f "$archive" ] || return 1
+  prefix="- [x] $id - "
+  {
+    printf '## In flight\n\n## Queued\n\n## Done\n'
+    awk -v prefix="$prefix" '
+      /^- \[[ x]\] / {
+        if (capture) exit
+        if (index($0, prefix) == 1) {
+          capture = 1
+          print
+        }
+        next
+      }
+      capture {
+        if ($0 ~ /^## /) exit
+        print
+      }
+    ' "$archive"
+  } | tasks_axi show "$id" --full --file /dev/stdin 2>/dev/null
+}
+
+task_show_durable() {  # <id>
+  local id=$1 source
+  source=$(task_row_source "$id") || return 1
+  if [ "$source" = "$DATA/backlog.md" ]; then
+    task_show "$id"
+  else
+    archived_task_show "$id"
+  fi
 }
 
 show_field() {  # <show-output> <field>
@@ -138,6 +252,21 @@ sorted_key_union() {  # <comma-list> <newline-or-space-separated-new-keys>
 
 meta_value() {  # <meta> <key>
   grep "^$2=" "$1" 2>/dev/null | tail -1 | cut -d= -f2- || true
+}
+
+meta_exact_value() {  # <meta> <key>
+  local meta=$1 key=$2 count
+  count=$(grep -c "^$key=" "$meta" 2>/dev/null || true)
+  [ "$count" -eq 1 ] || return 1
+  sed -n "s/^$key=//p" "$meta"
+}
+
+receipt_value() {  # <receipt> <key>
+  local receipt=$1 key=$2 count
+  regular_nonsymlink_file "$receipt" || return 1
+  count=$(grep -c "^$key=" "$receipt" 2>/dev/null || true)
+  [ "$count" -eq 1 ] || return 1
+  sed -n "s/^$key=//p" "$receipt"
 }
 
 origin_open_decisions() {  # <origin-id>
@@ -172,7 +301,7 @@ verify_hold_active() {  # <hold-id>
 
 verify_hold_resolved() {  # <hold-id>
   local id=$1 show state kind body
-  show=$(task_show "$id") || return 1
+  show=$(task_show_durable "$id") || return 1
   state=$(show_field "$show" state)
   kind=$(show_field "$show" kind)
   body=$(show_field "$show" body)
@@ -184,9 +313,10 @@ verify_hold_resolved() {  # <hold-id>
   return 1
 }
 
-verify_hold_durable() {  # <hold-id>
-  local id=$1 show state held kind hold_kind body
-  show=$(task_show "$id") || fail "captain decision $id is absent from $FM_HOME/data/backlog.md"
+verify_hold_durable() {  # <origin-id> <hold-id>
+  local origin=$1 id=$2 show state held kind hold_kind body
+  show=$(task_show_durable "$id") \
+    || fail "captain decision $id is absent, duplicated, or indeterminate in the live backlog and archive"
   state=$(show_field "$show" state)
   held=$(show_field "$show" held)
   kind=$(show_field "$show" kind)
@@ -197,10 +327,255 @@ verify_hold_durable() {  # <hold-id>
   fi
   if [ "$state" = "done" ] && [ "$kind" = captain ]; then
     case "$body" in
-      *"Resolution recorded by fm-decision-hold."*"Routed work:"*) return 0 ;;
+      *"Resolution recorded by fm-decision-hold."*"Routed work:"*)
+        verify_resolution_receipt "$origin" "$id"
+        return 0
+        ;;
     esac
   fi
   fail "captain decision $id is neither actively held nor durably resolved"
+}
+
+resolution_body_fields() {  # <hold-id> <body>; sets RESOLUTION_DIGEST RESOLUTION_ROUTES
+  local id=$1 body=$2 fields prefix
+  prefix='"Resolution recorded by fm-decision-hold.\nDecision digest: '
+  case "$body" in
+    "$prefix"*) fields=${body#"$prefix"} ;;
+    *) fail "captain hold $id has no authoritative resolution body" ;;
+  esac
+  case "$fields" in
+    *'\nRouted identities: '*'\n\nCaptain decision:'*'\n\nRouted work:'*) : ;;
+    *) fail "captain hold $id has a malformed resolution body" ;;
+  esac
+  RESOLUTION_DIGEST=${fields%%\\n*}
+  fields=${fields#*\\nRouted identities: }
+  RESOLUTION_ROUTES=${fields%%\\n*}
+  digest_is_nonzero_sha256 "$RESOLUTION_DIGEST" \
+    || fail "captain hold $id must carry a nonzero sha256 decision digest"
+  [ -n "$RESOLUTION_ROUTES" ] || fail "captain hold $id has no routed task identities"
+}
+
+cleanup_receipt_path() {  # <hold-id>
+  printf '%s/%s.hold\n' "$RECEIPT_DIR" "$1"
+}
+
+resolution_receipt_path() {  # <hold-id>
+  printf '%s/%s.resolved\n' "$RECEIPT_DIR" "$1"
+}
+
+decision_object_path() {  # <hold-id>
+  printf '%s/%s.decision.md\n' "$RECEIPT_DIR" "$1"
+}
+
+origin_receipt_path() {  # <origin-id>
+  printf '%s/%s.origin\n' "$RECEIPT_DIR" "$1"
+}
+
+write_origin_receipt() {  # <origin-id> <dispatch-id>
+  local origin=$1 dispatch=$2 report="$DATA/$1/report.md" report_sha receipt
+  regular_nonsymlink_file "$report" || fail "origin $origin has no safe report object to retain its dispatch binding"
+  report_sha=$(sha256_file "$report")
+  digest_is_nonzero_sha256 "$report_sha" || fail "origin $origin produced an invalid report digest"
+  receipt=$(origin_receipt_path "$origin")
+  {
+    printf 'schema=fm-decision-hold-origin.v1\n'
+    printf 'origin_id=%s\n' "$origin"
+    printf 'dispatch_id=%s\n' "$dispatch"
+    printf 'origin_path=%s\n' "$report"
+    printf 'origin_sha256=%s\n' "$report_sha"
+  } | write_atomic_file "$receipt"
+}
+
+verify_origin_receipt() {  # <origin-id> [expected-dispatch-id]
+  local origin=$1 expected=${2:-} receipt schema recorded_origin recorded_dispatch origin_path origin_sha
+  receipt=$(origin_receipt_path "$origin")
+  regular_nonsymlink_file "$receipt" || fail "origin $origin has no trusted dispatch carrier"
+  schema=$(receipt_value "$receipt" schema) || fail "origin $origin has a malformed dispatch carrier schema"
+  recorded_origin=$(receipt_value "$receipt" origin_id) || fail "origin $origin dispatch carrier has no task identity"
+  recorded_dispatch=$(receipt_value "$receipt" dispatch_id) || fail "origin $origin dispatch carrier has no dispatch identity"
+  origin_path=$(receipt_value "$receipt" origin_path) || fail "origin $origin dispatch carrier has no source path"
+  origin_sha=$(receipt_value "$receipt" origin_sha256) || fail "origin $origin dispatch carrier has no source digest"
+  [ "$schema" = fm-decision-hold-origin.v1 ] || fail "origin $origin has an unsupported dispatch carrier"
+  [ "$recorded_origin" = "$origin" ] || fail "origin $origin dispatch carrier links a different task"
+  validate_slug dispatch-id "$recorded_dispatch"
+  [ "$recorded_dispatch" = "$origin" ] || fail "origin $origin dispatch carrier links a different endpoint dispatch: $recorded_dispatch"
+  [ -z "$expected" ] || [ "$recorded_dispatch" = "$expected" ] \
+    || fail "origin $origin dispatch carrier disagrees with cleanup dispatch $expected"
+  [ "$origin_path" = "$DATA/$origin/report.md" ] || fail "origin $origin dispatch carrier names an unauthorized source path"
+  regular_nonsymlink_file "$origin_path" || fail "origin $origin dispatch source path does not exist safely"
+  digest_is_nonzero_sha256 "$origin_sha" || fail "origin $origin dispatch source digest must be nonzero sha256"
+  [ "$(sha256_file "$origin_path")" = "$origin_sha" ] || fail "origin $origin dispatch source digest no longer matches"
+  printf '%s\n' "$recorded_dispatch"
+}
+
+completion_dispatch() {  # <origin-id> <meta-path> <has-meta>
+  local origin=$1 meta=$2 has_meta=$3 dispatch
+  if [ "$has_meta" = 1 ]; then
+    dispatch=$(meta_exact_value "$meta" endpoint_task_id) \
+      || fail "origin $origin has no unique endpoint dispatch binding; preserve origin metadata and holds because no safe automatic migration is shipped"
+    [ "$dispatch" = "$origin" ] || fail "origin $origin metadata links a different endpoint dispatch: $dispatch"
+    write_origin_receipt "$origin" "$dispatch"
+    verify_origin_receipt "$origin" "$dispatch" >/dev/null
+  else
+    dispatch=$(verify_origin_receipt "$origin") || return 1
+  fi
+  printf '%s\n' "$dispatch"
+}
+
+fail_missing_cleanup_receipt() {  # <origin-id> <hold-id>
+  local origin=$1 id=$2
+  if verify_hold_resolved "$id"; then
+    fail "historical or hand-written resolved row $id has no trusted cleanup receipt; preserve the origin and row: no safe automatic migration is shipped"
+  fi
+  fail "captain hold $id has no trusted cleanup receipt; re-run complete $origin with its full recorded decision inventory only while the hold remains open and the exact dispatch binding survives; otherwise preserve origin metadata and holds because no safe automatic migration is shipped"
+}
+
+verify_cleanup_receipt_base() {  # <origin-id> <dispatch-id> <hold-id>
+  local origin=$1 dispatch=$2 id=$3 receipt schema phase recorded_origin recorded_dispatch recorded_hold object_path object_sha bearings_sha
+  receipt=$(cleanup_receipt_path "$id")
+  regular_nonsymlink_file "$receipt" \
+    || fail_missing_cleanup_receipt "$origin" "$id"
+  schema=$(receipt_value "$receipt" schema) || fail "captain hold $id has a malformed cleanup receipt schema"
+  phase=$(receipt_value "$receipt" phase) || fail "captain hold $id has a malformed cleanup receipt phase"
+  recorded_origin=$(receipt_value "$receipt" origin_id) || fail "captain hold $id has no cleanup task identity"
+  recorded_dispatch=$(receipt_value "$receipt" dispatch_id) || fail "captain hold $id has no cleanup dispatch identity"
+  recorded_hold=$(receipt_value "$receipt" hold_id) || fail "captain hold $id has no cleanup hold identity"
+  object_path=$(receipt_value "$receipt" object_path) || fail "captain hold $id has no cleanup object path"
+  object_sha=$(receipt_value "$receipt" object_sha256) || fail "captain hold $id has no cleanup object digest"
+  bearings_sha=$(receipt_value "$receipt" bearings_sha256) || fail "captain hold $id has no Bearings evidence digest"
+  [ "$schema" = fm-decision-hold-receipt.v1 ] || fail "captain hold $id has an unsupported cleanup receipt"
+  [ "$phase" = hold ] || fail "captain hold $id cleanup receipt has the wrong phase"
+  [ "$recorded_origin" = "$origin" ] || fail "captain hold $id cleanup receipt links a different task"
+  [ "$recorded_dispatch" = "$dispatch" ] || fail "captain hold $id cleanup receipt links a different dispatch"
+  [ "$recorded_hold" = "$id" ] || fail "captain hold $id cleanup receipt links a different hold"
+  verify_origin_receipt "$origin" "$dispatch" >/dev/null
+  [ "$object_path" = "$DATA/backlog.md" ] || fail "captain hold $id cleanup receipt names an unauthorized object path"
+  regular_nonsymlink_file "$object_path" || fail "captain hold $id cleanup object path does not exist safely"
+  digest_is_nonzero_sha256 "$object_sha" || fail "captain hold $id cleanup object digest must be nonzero sha256"
+  digest_is_nonzero_sha256 "$bearings_sha" || fail "captain hold $id Bearings evidence digest must be nonzero sha256"
+}
+
+bearings_snapshot() {
+  local bearings=${FM_DECISION_HOLD_BEARINGS:-$SCRIPT_DIR/fm-bearings-snapshot.sh}
+  [ -x "$bearings" ] || fail "Bearings snapshot executable is unavailable: $bearings"
+  command -v jq >/dev/null 2>&1 || fail "jq is required for Bearings receipt verification"
+  FM_HOME="$FM_HOME" FM_STATE_OVERRIDE="$STATE" FM_DATA_OVERRIDE="$DATA" \
+    "$bearings" --json --all-decisions
+}
+
+bearings_has_hold() {  # <json> <hold-id>
+  printf '%s\n' "$1" | jq -e --arg id "$2" \
+    '.schema == "fm-bearings.v1" and (.decisions_open | any(.id == $id and .verb == "captain-hold"))' \
+    >/dev/null 2>&1
+}
+
+verify_cleanup_receipt() {  # <origin-id> <dispatch-id> <hold-id>
+  local origin=$1 dispatch=$2 id=$3 receipt show recorded_sha fresh
+  verify_cleanup_receipt_base "$origin" "$dispatch" "$id"
+  receipt=$(cleanup_receipt_path "$id")
+  show=$(task_show_durable "$id") || fail "captain hold $id cleanup object is absent, duplicated, or indeterminate"
+  recorded_sha=$(receipt_value "$receipt" object_sha256) || fail "captain hold $id cleanup object digest is unavailable"
+  [ "$(sha256_text "$show")" = "$recorded_sha" ] \
+    || fail "captain hold $id cleanup object digest no longer matches"
+  fresh=$(bearings_snapshot) || fail "could not obtain fresh Bearings evidence for $id"
+  bearings_has_hold "$fresh" "$id" || fail "captain hold $id does not reappear in Bearings"
+}
+
+write_cleanup_receipt() {  # <origin-id> <dispatch-id> <hold-id> <bearings-json>
+  local origin=$1 dispatch=$2 id=$3 bearings=$4 show object_sha bearings_sha receipt
+  show=$(task_show_durable "$id") || fail "captain hold $id is not one durable backlog object"
+  object_sha=$(sha256_text "$show")
+  bearings_sha=$(sha256_text "$bearings")
+  digest_is_nonzero_sha256 "$object_sha" || fail "captain hold $id produced an invalid object digest"
+  digest_is_nonzero_sha256 "$bearings_sha" || fail "captain hold $id produced invalid Bearings evidence"
+  receipt=$(cleanup_receipt_path "$id")
+  {
+    printf 'schema=fm-decision-hold-receipt.v1\n'
+    printf 'phase=hold\n'
+    printf 'origin_id=%s\n' "$origin"
+    printf 'dispatch_id=%s\n' "$dispatch"
+    printf 'hold_id=%s\n' "$id"
+    printf 'object_path=%s\n' "$DATA/backlog.md"
+    printf 'object_sha256=%s\n' "$object_sha"
+    printf 'bearings_sha256=%s\n' "$bearings_sha"
+  } | write_atomic_file "$receipt"
+}
+
+verify_resolution_receipt() {  # <origin-id> <hold-id>
+  local origin=$1 id=$2 show state kind body receipt cleanup dispatch schema phase recorded_origin recorded_dispatch recorded_hold decision_path decision_sha routed_ids object_path object_sha source routed task
+  show=$(task_show_durable "$id") \
+    || fail "captain decision $id is absent, duplicated, or indeterminate in the live backlog and archive"
+  state=$(show_field "$show" state)
+  kind=$(show_field "$show" kind)
+  body=$(show_field "$show" body)
+  [ "$state" = "done" ] || fail "captain hold $id is unresolved"
+  [ "$kind" = captain ] || fail "backlog item $id is not kind captain"
+  resolution_body_fields "$id" "$body"
+
+  cleanup=$(cleanup_receipt_path "$id")
+  regular_nonsymlink_file "$cleanup" \
+    || fail_missing_cleanup_receipt "$origin" "$id"
+  dispatch=$(receipt_value "$cleanup" dispatch_id) || fail "captain hold $id cleanup receipt has no dispatch link"
+  verify_cleanup_receipt_base "$origin" "$dispatch" "$id"
+
+  receipt=$(resolution_receipt_path "$id")
+  regular_nonsymlink_file "$receipt" \
+    || fail "historical or hand-written resolved row $id has no trusted resolution receipt; repeat the exact resolve only when the script-owned cleanup receipt and canonical decision object survive; otherwise preserve the origin and row because no safe automatic migration is shipped"
+  schema=$(receipt_value "$receipt" schema) || fail "captain hold $id has a malformed resolution receipt schema"
+  phase=$(receipt_value "$receipt" phase) || fail "captain hold $id has a malformed resolution receipt phase"
+  recorded_origin=$(receipt_value "$receipt" origin_id) || fail "captain hold $id resolution receipt has no task link"
+  recorded_dispatch=$(receipt_value "$receipt" dispatch_id) || fail "captain hold $id resolution receipt has no dispatch link"
+  recorded_hold=$(receipt_value "$receipt" hold_id) || fail "captain hold $id resolution receipt has no hold link"
+  decision_path=$(receipt_value "$receipt" decision_path) || fail "captain hold $id resolution receipt has no decision object path"
+  decision_sha=$(receipt_value "$receipt" decision_sha256) || fail "captain hold $id resolution receipt has no decision digest"
+  routed_ids=$(receipt_value "$receipt" routed_ids) || fail "captain hold $id resolution receipt has no routed task links"
+  object_path=$(receipt_value "$receipt" object_path) || fail "captain hold $id resolution receipt has no row object path"
+  object_sha=$(receipt_value "$receipt" object_sha256) || fail "captain hold $id resolution receipt has no row object digest"
+  [ "$schema" = fm-decision-hold-receipt.v1 ] || fail "captain hold $id has an unsupported resolution receipt"
+  [ "$phase" = resolved ] || fail "captain hold $id resolution receipt has the wrong phase"
+  [ "$recorded_origin" = "$origin" ] || fail "captain hold $id resolution receipt links a different task"
+  [ "$recorded_dispatch" = "$dispatch" ] || fail "captain hold $id resolution receipt links a different dispatch"
+  [ "$recorded_hold" = "$id" ] || fail "captain hold $id resolution receipt links a different hold"
+  [ "$decision_path" = "$(decision_object_path "$id")" ] \
+    || fail "captain hold $id resolution receipt names an unauthorized decision object"
+  regular_nonsymlink_file "$decision_path" || fail "captain hold $id decision object path does not exist safely"
+  digest_is_nonzero_sha256 "$decision_sha" || fail "captain hold $id resolution receipt decision digest must be nonzero sha256"
+  [ "$(sha256_file "$decision_path")" = "$decision_sha" ] || fail "captain hold $id decision object digest does not match"
+  [ "$decision_sha" = "$RESOLUTION_DIGEST" ] || fail "captain hold $id row and decision object digests differ"
+  [ "$routed_ids" = "$RESOLUTION_ROUTES" ] || fail "captain hold $id row and receipt routed tasks differ"
+  source=$(task_row_source "$id") || fail "captain hold $id row object is no longer unique"
+  [ "$object_path" = "$source" ] || fail "captain hold $id resolution receipt names the wrong row object path"
+  regular_nonsymlink_file "$object_path" || fail "captain hold $id row object path does not exist safely"
+  digest_is_nonzero_sha256 "$object_sha" || fail "captain hold $id row object digest must be nonzero sha256"
+  [ "$(sha256_text "$show")" = "$object_sha" ] || fail "captain hold $id row object digest does not match"
+  routed=$(printf '%s\n' "$routed_ids" | tr ',' ' ')
+  for task in $routed; do
+    validate_slug routed-task "$task"
+    task_show_durable "$task" >/dev/null \
+      || fail "captain hold $id routed task $task is absent, duplicated, or indeterminate"
+  done
+}
+
+write_resolution_receipt() {  # <origin-id> <dispatch-id> <hold-id> <decision-path> <decision-sha> <routed-csv>
+  local origin=$1 dispatch=$2 id=$3 decision_path=$4 decision_sha=$5 routed_csv=$6 show source object_sha receipt
+  show=$(task_show_durable "$id") || fail "captain hold $id resolved row is absent, duplicated, or indeterminate"
+  source=$(task_row_source "$id") || fail "captain hold $id resolved row has no unique object path"
+  object_sha=$(sha256_text "$show")
+  digest_is_nonzero_sha256 "$decision_sha" || fail "captain hold $id decision digest must be nonzero sha256"
+  digest_is_nonzero_sha256 "$object_sha" || fail "captain hold $id row digest must be nonzero sha256"
+  receipt=$(resolution_receipt_path "$id")
+  {
+    printf 'schema=fm-decision-hold-receipt.v1\n'
+    printf 'phase=resolved\n'
+    printf 'origin_id=%s\n' "$origin"
+    printf 'dispatch_id=%s\n' "$dispatch"
+    printf 'hold_id=%s\n' "$id"
+    printf 'decision_path=%s\n' "$decision_path"
+    printf 'decision_sha256=%s\n' "$decision_sha"
+    printf 'routed_ids=%s\n' "$routed_csv"
+    printf 'object_path=%s\n' "$source"
+    printf 'object_sha256=%s\n' "$object_sha"
+  } | write_atomic_file "$receipt"
 }
 
 verify_resolution_identity() {
@@ -249,7 +624,7 @@ command_hold() {
   require_tasks_axi
   origin_exists_here "$origin" || fail "origin $origin is not owned by the active home $FM_HOME"
   id=$(hold_id "$origin" "$key")
-  if show=$(task_show "$id"); then
+  if show=$(task_show_durable "$id"); then
     state=$(show_field "$show" state)
     kind=$(show_field "$show" kind)
     existing_title=$(show_field "$show" title)
@@ -275,7 +650,7 @@ command_hold() {
 }
 
 command_complete() {
-  local origin=${1:-} meta previous='' supplied='' keys='' key status_file open raw_open key_seen=0 has_meta=0
+  local origin=${1:-} meta previous='' supplied='' keys='' key status_file open raw_open key_seen=0 has_meta=0 dispatch='' bearings='' id
   [ "$#" -ge 2 ] || { usage >&2; exit 2; }
   validate_slug origin-id "$origin"
   shift
@@ -297,15 +672,6 @@ command_complete() {
     previous=$(meta_value "$meta" decision_keys)
   fi
   keys=$(sorted_key_union "$previous" "$supplied")
-  if [ -n "$keys" ]; then
-    while IFS= read -r key; do
-      [ -n "$key" ] || continue
-      verify_hold_durable "$(hold_id "$origin" "$key")"
-    done <<EOF
-$(printf '%s\n' "$keys" | tr ',' '\n')
-EOF
-  fi
-
   status_file="$STATE/$origin.status"
   raw_open=$(status_open_decisions "$status_file")
   open=$(origin_open_decisions "$origin")
@@ -316,6 +682,29 @@ EOF
   done <<EOF
 $open
 EOF
+
+  dispatch=$(completion_dispatch "$origin" "$meta" "$has_meta") || return 1
+  if [ -n "$keys" ]; then
+    while IFS= read -r key; do
+      [ -n "$key" ] || continue
+      verify_hold_durable "$origin" "$(hold_id "$origin" "$key")"
+    done <<EOF
+$(printf '%s\n' "$keys" | tr ',' '\n')
+EOF
+
+    bearings=$(bearings_snapshot) || fail "could not obtain Bearings evidence for $origin"
+    while IFS= read -r key; do
+      [ -n "$key" ] || continue
+      id=$(hold_id "$origin" "$key")
+      if ! verify_hold_resolved "$id"; then
+        bearings_has_hold "$bearings" "$id" \
+          || fail "captain hold $id does not reappear in Bearings"
+        write_cleanup_receipt "$origin" "$dispatch" "$id" "$bearings"
+      fi
+    done <<EOF
+$(printf '%s\n' "$keys" | tr ',' '\n')
+EOF
+  fi
 
   if [ "$has_meta" = 1 ]; then
     if [ "$(meta_value "$meta" decisions_reviewed)" != 1 ] || [ "$previous" != "$keys" ]; then
@@ -338,7 +727,7 @@ EOF
 }
 
 command_verify() {
-  local origin=${1:-} meta reviewed keys key open
+  local origin=${1:-} meta reviewed keys key open dispatch id
   [ "$#" -eq 1 ] || { usage >&2; exit 2; }
   validate_slug origin-id "$origin"
   meta="$STATE/$origin.meta"
@@ -347,28 +736,52 @@ command_verify() {
   reviewed=$(meta_value "$meta" decisions_reviewed)
   [ "$reviewed" = 1 ] || fail "origin $origin has no completed unresolved-decision inventory"
   keys=$(meta_value "$meta" decision_keys)
+  open=$(origin_open_decisions "$origin")
+  if [ -n "$keys" ] || [ -n "$open" ]; then
+    dispatch=$(meta_exact_value "$meta" endpoint_task_id) \
+      || fail "origin $origin has no unique endpoint dispatch binding; preserve origin metadata and holds because no safe automatic migration is shipped"
+    [ "$dispatch" = "$origin" ] || fail "origin $origin metadata links a different endpoint dispatch: $dispatch"
+  fi
   if [ -n "$keys" ]; then
     while IFS= read -r key; do
       [ -n "$key" ] || continue
-      verify_hold_durable "$(hold_id "$origin" "$key")"
+      id=$(hold_id "$origin" "$key")
+      if verify_hold_resolved "$id"; then
+        verify_resolution_receipt "$origin" "$id"
+      else
+        verify_hold_active "$id"
+        verify_cleanup_receipt "$origin" "$dispatch" "$id"
+      fi
     done <<EOF
 $(printf '%s\n' "$keys" | tr ',' '\n')
 EOF
   fi
-  open=$(origin_open_decisions "$origin")
   while IFS=$'\t' read -r key _verb _summary; do
     [ -n "$key" ] || continue
     list_has_key "$keys" "$key" \
       || fail "open structured decision $origin/$key is outside the reviewed inventory"
-    verify_hold_durable "$(hold_id "$origin" "$key")"
+    id=$(hold_id "$origin" "$key")
+    verify_hold_active "$id"
+    verify_cleanup_receipt "$origin" "$dispatch" "$id"
   done <<EOF
 $open
 EOF
   printf 'verified: %s unresolved-decision inventory\n' "$origin"
 }
 
+command_verify_resolution() {
+  local origin=${1:-} key=${2:-} id
+  [ "$#" -eq 2 ] || { usage >&2; exit 2; }
+  validate_slug origin-id "$origin"
+  validate_slug decision-key "$key"
+  require_tasks_axi
+  id=$(hold_id "$origin" "$key")
+  verify_resolution_receipt "$origin" "$id"
+  printf 'verified: %s trusted resolution receipt\n' "$id"
+}
+
 command_resolve() {
-  local origin=${1:-} key=${2:-} decision_file='' id='' decision='' decision_digest='' body='' routed='' routed_csv='' dep show blocked state hold_show hold_body resolution_recorded=0
+  local origin=${1:-} key=${2:-} decision_file='' id='' decision='' decision_digest='' body='' routed='' routed_csv='' dep show blocked state hold_show hold_body resolution_recorded=0 cleanup dispatch decision_object
   [ "$#" -ge 2 ] || { usage >&2; exit 2; }
   shift 2
   while [ "$#" -gt 0 ]; do
@@ -394,21 +807,53 @@ command_resolve() {
   require_tasks_axi
   id=$(hold_id "$origin" "$key")
   if verify_hold_resolved "$id"; then
-    hold_show=$(task_show "$id")
+    hold_show=$(task_show_durable "$id") \
+      || fail "captain hold $id disappeared after its durable resolution was found"
     hold_body=$(show_field "$hold_show" body)
     verify_resolution_identity "$id" "$hold_body" "$decision_digest" "$routed_csv"
+    cleanup=$(cleanup_receipt_path "$id")
+    regular_nonsymlink_file "$cleanup" || fail_missing_cleanup_receipt "$origin" "$id"
+    dispatch=$(receipt_value "$cleanup" dispatch_id) \
+      || fail "historical resolved row $id has no trustworthy dispatch link; preserve the origin and row because no safe automatic migration is shipped"
+    verify_cleanup_receipt_base "$origin" "$dispatch" "$id"
+    decision_object=$(decision_object_path "$id")
+    regular_nonsymlink_file "$decision_object" \
+      || fail "historical resolved row $id has no canonical decision object; preserve the origin and row because no safe automatic migration is shipped"
+    [ "$(sha256_file "$decision_object")" = "$decision_digest" ] \
+      || fail "captain hold $id canonical decision object does not match the requested decision"
+    if [ ! -f "$(resolution_receipt_path "$id")" ]; then
+      write_resolution_receipt "$origin" "$dispatch" "$id" "$decision_object" "$decision_digest" "$routed_csv"
+    fi
+    verify_resolution_receipt "$origin" "$id"
     printf 'resolved: %s\n' "$id"
     return 0
   fi
   verify_hold_active "$id"
   hold_show=$(task_show "$id")
   hold_body=$(show_field "$hold_show" body)
+  cleanup=$(cleanup_receipt_path "$id")
+  regular_nonsymlink_file "$cleanup" || fail_missing_cleanup_receipt "$origin" "$id"
+  dispatch=$(receipt_value "$cleanup" dispatch_id) \
+    || fail "captain hold $id has no trustworthy cleanup dispatch link; preserve origin metadata and holds because no safe automatic migration is shipped"
+  verify_cleanup_receipt_base "$origin" "$dispatch" "$id"
   case "$hold_body" in
     *"Resolution recorded by fm-decision-hold."*)
       verify_resolution_identity "$id" "$hold_body" "$decision_digest" "$routed_csv"
       resolution_recorded=1
       ;;
   esac
+  decision_object=$(decision_object_path "$id")
+  if [ "$resolution_recorded" = 1 ]; then
+    regular_nonsymlink_file "$decision_object" \
+      || fail "captain hold $id partial resolution lost its decision object"
+    [ "$(sha256_file "$decision_object")" = "$decision_digest" ] \
+      || fail "captain hold $id partial resolution decision object drifted"
+  else
+    verify_cleanup_receipt "$origin" "$dispatch" "$id"
+    printf '%s' "$decision" | write_atomic_file "$decision_object"
+    [ "$(sha256_file "$decision_object")" = "$decision_digest" ] \
+      || fail "captain hold $id decision object digest did not stabilize"
+  fi
 
   for dep in $routed; do
     show=$(task_show "$dep") || fail "routed task $dep does not exist in the active home"
@@ -449,7 +894,9 @@ command_resolve() {
     esac
   done
   tasks_axi "done" "$id" >/dev/null || fail "could not close resolved captain hold $id"
-  verify_hold_resolved "$id" || fail "captain hold $id did not retain its durable resolution record"
+  verify_hold_resolved "$id" || fail "captain hold $id did not retain its durable resolution row"
+  write_resolution_receipt "$origin" "$dispatch" "$id" "$decision_object" "$decision_digest" "$routed_csv"
+  verify_resolution_receipt "$origin" "$id"
   printf 'resolved: %s -> %s\n' "$id" "$routed"
 }
 
@@ -458,6 +905,7 @@ case "${1:-}" in
   hold) shift; command_hold "$@" ;;
   complete) shift; command_complete "$@" ;;
   verify) shift; command_verify "$@" ;;
+  verify-resolution) shift; command_verify_resolution "$@" ;;
   resolve) shift; command_resolve "$@" ;;
   -h|--help) usage ;;
   *) usage >&2; exit 2 ;;

--- a/bin/fm-model-capacity-hold-lib.sh
+++ b/bin/fm-model-capacity-hold-lib.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Read-only enforcement for the one home-wide registered model-capacity hold.
+# Firstmate-controlled paths that can launch or prompt a model call this before
+# mutation. Interrupt and cleanup-only paths remain available.
+
+fm_model_capacity_hold_path() {
+  printf '%s/.model-capacity-hold\n' "${STATE:-${FM_STATE_OVERRIDE:-$FM_HOME/state}}"
+}
+
+fm_model_capacity_hold_value() {  # <path> <key>
+  local path=$1 key=$2 count
+  [ -f "$path" ] && [ ! -L "$path" ] || return 1
+  count=$(grep -c "^$key=" "$path" 2>/dev/null || true)
+  [ "$count" -eq 1 ] || return 1
+  sed -n "s/^$key=//p" "$path"
+}
+
+fm_model_capacity_hold_refuse() {  # <operation>
+  local operation=$1 marker schema id reason dispatch
+  marker=$(fm_model_capacity_hold_path)
+  [ -e "$marker" ] || return 0
+  schema=$(fm_model_capacity_hold_value "$marker" schema) || schema=invalid
+  id=$(fm_model_capacity_hold_value "$marker" hold_id) || id=unknown
+  reason=$(fm_model_capacity_hold_value "$marker" reason) || reason='malformed hold record'
+  dispatch=$(fm_model_capacity_hold_value "$marker" dispatch_ref) || dispatch=unknown
+  if [ "$schema" != fm-model-capacity-hold.v1 ]; then
+    printf 'error: model-capacity hold record is malformed; refusing %s until %s is reconciled\n' "$operation" "$marker" >&2
+    return 1
+  fi
+  printf 'error: model-capacity hold %s is active; refusing %s (reason=%s; dispatch_ref=%s)\n' \
+    "$id" "$operation" "$reason" "$dispatch" >&2
+  return 1
+}

--- a/bin/fm-model-capacity-hold.sh
+++ b/bin/fm-model-capacity-hold.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+# Register, inspect, or release the home-wide hold that blocks Firstmate-owned
+# model-consuming execution paths while leaving interrupts and cleanup available.
+#
+# Usage:
+#   fm-model-capacity-hold.sh register <hold-id> --reason <one-line> --dispatch-ref <one-line>
+#   fm-model-capacity-hold.sh status
+#   fm-model-capacity-hold.sh release <hold-id> --authority-file <path>
+#
+# Registration and release receipts live under data/model-capacity-holds/. A
+# release requires a regular authority object and records its SHA-256 before the
+# active marker is retired. The current primary turn and native same-session
+# continuations, direct TUI input, provider CLIs, lower-level backend sends,
+# already-running agents, and direct no-mistakes commands are outside this
+# command's control; docs/architecture.md owns the complete boundary inventory.
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
+STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
+DATA="${FM_DATA_OVERRIDE:-$FM_HOME/data}"
+MARKER="$STATE/.model-capacity-hold"
+RECEIPTS="$DATA/model-capacity-holds"
+
+# shellcheck source=bin/fm-custody-lib.sh
+. "$SCRIPT_DIR/fm-custody-lib.sh"
+# shellcheck source=bin/fm-model-capacity-hold-lib.sh
+. "$SCRIPT_DIR/fm-model-capacity-hold-lib.sh"
+
+fail() {
+  printf 'fm-model-capacity-hold: %s\n' "$*" >&2
+  exit 1
+}
+
+validate_id() {
+  case "$1" in ''|*[!A-Za-z0-9._-]*) fail "hold id must be a privacy-safe slug" ;; esac
+}
+
+validate_line() {
+  [ -n "$2" ] || fail "$1 is required"
+  case "$2" in *$'\n'*|*$'\r'*) fail "$1 must be one line" ;; esac
+}
+
+write_atomic() {  # <path> <exclusive:0|1>, content on stdin
+  local path=$1 exclusive=$2 dir tmp
+  dir=${path%/*}
+  mkdir -p "$dir"
+  tmp=$(mktemp "$dir/.model-hold.tmp.XXXXXX") || fail "could not allocate receipt temporary"
+  chmod 600 "$tmp"
+  cat > "$tmp" || { rm -f "$tmp"; fail "could not write temporary"; }
+  if [ "$exclusive" = 1 ] && [ -e "$path" ]; then
+    rm -f "$tmp"
+    fail "refusing to overwrite existing receipt: $path"
+  fi
+  if [ "$exclusive" = 1 ]; then
+    (set -C; : > "$path") 2>/dev/null || { rm -f "$tmp"; fail "receipt appeared concurrently: $path"; }
+  fi
+  mv "$tmp" "$path" || { rm -f "$tmp"; fail "could not publish $path"; }
+}
+
+command_register() {
+  local id reason dispatch timestamp receipt existing_id
+  id=${1:-}
+  reason=
+  dispatch=
+  [ "$#" -ge 1 ] || fail "register requires a hold id"
+  shift
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --reason) shift; reason=${1:-} ;;
+      --dispatch-ref) shift; dispatch=${1:-} ;;
+      *) fail "unknown register argument: $1" ;;
+    esac
+    shift
+  done
+  validate_id "$id"
+  validate_line reason "$reason"
+  validate_line dispatch-ref "$dispatch"
+  mkdir -p "$STATE" "$RECEIPTS"
+  if [ -e "$MARKER" ]; then
+    existing_id=$(fm_model_capacity_hold_value "$MARKER" hold_id) || fail "active hold marker is malformed"
+    [ "$existing_id" = "$id" ] || fail "another model-capacity hold is active: $existing_id"
+    printf 'registered: %s already active\n' "$id"
+    return 0
+  fi
+  timestamp=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
+  receipt="$RECEIPTS/$id.registered"
+  {
+    printf 'schema=fm-model-capacity-hold.v1\n'
+    printf 'hold_id=%s\n' "$id"
+    printf 'reason=%s\n' "$reason"
+    printf 'dispatch_ref=%s\n' "$dispatch"
+    printf 'registered_at=%s\n' "$timestamp"
+  } | write_atomic "$receipt" 1
+  cp "$receipt" "$MARKER.tmp.${BASHPID:-$$}" || fail "could not stage active marker"
+  mv "$MARKER.tmp.${BASHPID:-$$}" "$MARKER" || fail "could not publish active marker"
+  printf 'registered: %s\n' "$id"
+}
+
+command_status() {
+  if [ ! -e "$MARKER" ]; then
+    printf 'inactive\n'
+    return 0
+  fi
+  cat "$MARKER"
+}
+
+command_release() {
+  local id authority active_id digest timestamp registered receipt
+  id=${1:-}
+  authority=
+  [ "$#" -ge 1 ] || fail "release requires a hold id"
+  shift
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --authority-file) shift; authority=${1:-} ;;
+      *) fail "unknown release argument: $1" ;;
+    esac
+    shift
+  done
+  validate_id "$id"
+  [ -f "$authority" ] && [ ! -L "$authority" ] || fail "authority file must be a regular non-symlink file"
+  active_id=$(fm_model_capacity_hold_value "$MARKER" hold_id) || fail "no valid active model-capacity hold"
+  [ "$active_id" = "$id" ] || fail "active hold is $active_id, not $id"
+  registered="$RECEIPTS/$id.registered"
+  [ -f "$registered" ] && [ ! -L "$registered" ] || fail "registration receipt is missing"
+  digest=$(fm_custody_sha256 "$authority") || fail "could not digest release authority"
+  timestamp=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
+  receipt="$RECEIPTS/$id.released"
+  {
+    printf 'schema=fm-model-capacity-hold-release.v1\n'
+    printf 'hold_id=%s\n' "$id"
+    printf 'registration_sha256=%s\n' "$(fm_custody_sha256 "$registered")"
+    printf 'authority_path=%s\n' "$authority"
+    printf 'authority_sha256=%s\n' "$digest"
+    printf 'released_at=%s\n' "$timestamp"
+  } | write_atomic "$receipt" 1
+  mv "$MARKER" "$RECEIPTS/$id.active-marker-retired" \
+    || fail "release receipt exists but active marker could not be retired"
+  printf 'released: %s\n' "$id"
+}
+
+case "${1:-}" in
+  register) shift; command_register "$@" ;;
+  status) shift; [ "$#" -eq 0 ] || fail "status takes no arguments"; command_status ;;
+  release) shift; command_release "$@" ;;
+  -h|--help) sed -n '2,/^set -eu/p' "$0" | sed '$d; s/^# \{0,1\}//' ;;
+  *) fail "usage: fm-model-capacity-hold.sh register|status|release ..." ;;
+esac

--- a/bin/fm-process-progress.sh
+++ b/bin/fm-process-progress.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Sample cumulative CPU for the descendant closure of one recorded backend pane.
+# This is progress evidence, not a current-state oracle: callers compare two
+# samples with the same root-process identity and use only a positive delta.
+#
+# Usage: fm-process-progress.sh <backend> <target>
+# Output: <root-identity-sha256><TAB><cumulative-centiseconds>
+#
+# Verified root PID bindings currently exist for tmux and herdr. zellij, Orca,
+# and cmux return nonzero rather than guessing. FM_PROCESS_PROGRESS_ROOT_PID is
+# a test seam for a pre-bound root.
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=bin/fm-backend.sh
+. "$SCRIPT_DIR/fm-backend.sh"
+
+[ "$#" -eq 2 ] || { printf 'usage: fm-process-progress.sh <backend> <target>\n' >&2; exit 2; }
+backend=$1
+target=$2
+root=${FM_PROCESS_PROGRESS_ROOT_PID:-}
+[ -n "$root" ] || root=$(fm_backend_process_root_pid "$backend" "$target")
+case "$root" in ''|*[!0-9]*) exit 1 ;; esac
+
+identity=$(LC_ALL=C ps -p "$root" -o lstart= -o command= 2>/dev/null) || exit 1
+[ -n "$identity" ] || exit 1
+if command -v shasum >/dev/null 2>&1; then
+  identity_sha=$(printf '%s' "$root:$identity" | shasum -a 256 | awk '{print $1}')
+else
+  identity_sha=$(printf '%s' "$root:$identity" | sha256sum | awk '{print $1}')
+fi
+
+rows=$(LC_ALL=C ps -axo pid=,ppid=,time=,command= 2>/dev/null) || exit 1
+cpu=$(printf '%s\n' "$rows" | awk -v root="$root" '
+  function centis(raw, d, rest, n, a, h, m, s) {
+    d = 0
+    rest = raw
+    if (index(rest, "-") > 0) {
+      split(rest, dayparts, "-")
+      d = dayparts[1] + 0
+      rest = dayparts[2]
+    }
+    n = split(rest, a, ":")
+    h = 0; m = 0; s = 0
+    if (n == 3) { h = a[1] + 0; m = a[2] + 0; s = a[3] + 0 }
+    else if (n == 2) { m = a[1] + 0; s = a[2] + 0 }
+    else { s = a[1] + 0 }
+    return int((((d * 24 + h) * 60 + m) * 60 + s) * 100 + 0.5)
+  }
+  {
+    pid[NR] = $1
+    parent[$1] = $2
+    value[$1] = centis($3)
+    seen[$1] = 1
+  }
+  END {
+    member[root] = 1
+    changed = 1
+    while (changed) {
+      changed = 0
+      for (p in seen) {
+        if (!member[p] && member[parent[p]]) {
+          member[p] = 1
+          changed = 1
+        }
+      }
+    }
+    total = 0
+    for (p in member) total += value[p]
+    print total + 0
+  }
+')
+case "$cpu" in ''|*[!0-9]*) exit 1 ;; esac
+printf '%s\t%s\n' "$identity_sha" "$cpu"

--- a/bin/fm-record-reconcile.sh
+++ b/bin/fm-record-reconcile.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+# Reconcile terminal producer reports with structured backlog rows, then write a
+# durable inventory receipt for every metadata/backlog mismatch without deleting
+# any row, metadata, status, report, worktree, or commit that proves what happened.
+#
+# Usage: fm-record-reconcile.sh
+#
+# A `done:` producer or a producer declaring the complete-only
+# `awaiting-captain:` state while still In flight moves to Done with --no-prune
+# and an explicit retained-lifecycle note. Its endpoint metadata and worktree
+# remain; teardown separately refuses unlanded work. Scout rows move only after
+# the report exists and the decision-hold completion gate verifies. Missing
+# metadata and orphan metadata are accounted in the receipt and preserved.
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
+STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
+DATA="${FM_DATA_OVERRIDE:-$FM_HOME/data}"
+BACKLOG="$DATA/backlog.md"
+RECEIPT_DIR="$DATA/record-reconciliation"
+
+# shellcheck source=bin/fm-classify-lib.sh
+. "$SCRIPT_DIR/fm-classify-lib.sh"
+# shellcheck source=bin/fm-tasks-axi-lib.sh
+. "$SCRIPT_DIR/fm-tasks-axi-lib.sh"
+# shellcheck source=bin/fm-custody-lib.sh
+. "$SCRIPT_DIR/fm-custody-lib.sh"
+
+[ -f "$BACKLOG" ] || exit 0
+events=
+
+append_event() {  # <class> <id> <detail>
+  events="${events}${1}"$'\t'"${2}"$'\t'"${3}"$'\n'
+}
+
+in_flight_ids() {
+  awk '
+    /^## In flight/ { inside=1; next }
+    /^## / { inside=0 }
+    inside && /^- \[ \] / { sub(/^- \[ \] /, ""); sub(/ -.*/, ""); print }
+  ' "$BACKLOG"
+}
+
+task_state() {  # <id>
+  (cd "$FM_HOME" && tasks-axi show "$1" --full 2>/dev/null) \
+    | sed -n 's/^  state: //p' | head -1
+}
+
+TERMINAL_WORKTREE=
+TERMINAL_HEAD=
+terminal_tree_is_clean() {  # <meta>
+  local meta=$1 count status
+  TERMINAL_WORKTREE=
+  TERMINAL_HEAD=
+  count=$(grep -c '^worktree=' "$meta" 2>/dev/null || true)
+  [ "$count" -eq 1 ] || return 1
+  TERMINAL_WORKTREE=$(sed -n 's/^worktree=//p' "$meta")
+  [ -d "$TERMINAL_WORKTREE" ] \
+    && git -C "$TERMINAL_WORKTREE" rev-parse --is-inside-work-tree >/dev/null 2>&1 \
+    || return 1
+  TERMINAL_HEAD=$(git -C "$TERMINAL_WORKTREE" rev-parse HEAD 2>/dev/null) || return 1
+  status=$(git -C "$TERMINAL_WORKTREE" status --porcelain --untracked-files=normal 2>/dev/null) \
+    || return 1
+  [ -z "$status" ]
+}
+
+if fm_tasks_axi_compatible; then
+  while IFS= read -r id; do
+    [ -n "$id" ] || continue
+    meta="$STATE/$id.meta"
+    [ -f "$meta" ] || continue
+    kind=$(grep '^kind=' "$meta" 2>/dev/null | tail -1 | cut -d= -f2- || true)
+    [ -n "$kind" ] || kind=ship
+    [ "$kind" != secondmate ] || continue
+    last=$(last_status_line "$STATE/$id.status")
+    status_is_done "$last" || status_is_awaiting_captain "$last" || continue
+    if ! terminal_tree_is_clean "$meta"; then
+      append_event terminal-unreconciled "$id" 'terminal status retained in flight because worktree identity or clean-tree evidence is unavailable'
+      continue
+    fi
+    if [ "$kind" = scout ]; then
+      if [ ! -f "$DATA/$id/report.md" ] || [ -L "$DATA/$id/report.md" ]; then
+        append_event terminal-unreconciled "$id" 'scout report missing or unsafe; row preserved'
+        continue
+      fi
+      if ! FM_HOME="$FM_HOME" FM_STATE_OVERRIDE="$STATE" FM_DATA_OVERRIDE="$DATA" \
+        "$SCRIPT_DIR/fm-decision-hold.sh" verify "$id" >/dev/null 2>&1; then
+        append_event terminal-unreconciled "$id" 'decision inventory not cleanup-authoritative; row preserved'
+        continue
+      fi
+    fi
+    (cd "$FM_HOME" && tasks-axi 'done' "$id" --no-prune \
+      --note "producer terminal status reconciled at $TERMINAL_HEAD; endpoint metadata and worktree retained pending landing, independent gate, or captain answer") >/dev/null \
+      || { append_event terminal-unreconciled "$id" 'tasks-axi transition failed; row preserved'; continue; }
+    append_event terminal-retained "$id" "moved from In flight to Done at head=$TERMINAL_HEAD with tree=clean; metadata and worktree retained"
+  done < <(in_flight_ids)
+fi
+
+# Inventory the post-transition state. These are explanations, not cleanup
+# authority: every mismatched object remains at its original path.
+while IFS= read -r id; do
+  [ -n "$id" ] || continue
+  [ -f "$STATE/$id.meta" ] || append_event missing-meta "$id" 'live in-flight row preserved without metadata'
+done < <(in_flight_ids)
+
+for meta in "$STATE"/*.meta; do
+  [ -e "$meta" ] || continue
+  id=${meta##*/}
+  id=${id%.meta}
+  state=$(task_state "$id" || true)
+  [ -n "$state" ] || append_event orphan-meta "$id" 'metadata preserved without one live backlog row'
+done
+
+for status_file in "$STATE"/*.status; do
+  [ -f "$status_file" ] && [ ! -L "$status_file" ] || continue
+  id=${status_file##*/}
+  id=${id%.status}
+  [ -f "$STATE/$id.meta" ] \
+    || append_event orphan-status "$id" 'append-only status evidence preserved without endpoint metadata'
+done
+
+in_flight_count=$(in_flight_ids | awk 'NF { count++ } END { print count + 0 }')
+metadata_count=0
+for meta in "$STATE"/*.meta; do
+  [ -f "$meta" ] && [ ! -L "$meta" ] || continue
+  metadata_count=$((metadata_count + 1))
+done
+metadata_delta=$((metadata_count - in_flight_count))
+
+mkdir -p "$RECEIPT_DIR"
+timestamp=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
+stamp=$(date -u '+%Y%m%dT%H%M%SZ')
+backlog_sha=$(fm_custody_sha256 "$BACKLOG")
+attempt=0
+while [ "$attempt" -lt 100 ]; do
+  receipt="$RECEIPT_DIR/reconcile.$stamp.${BASHPID:-$$}.$attempt.receipt"
+  if (set -C; umask 077; {
+    printf 'schema=fm-record-reconciliation.v1\n'
+    printf 'timestamp_utc=%s\n' "$timestamp"
+    printf 'backlog_path=%s\n' "$BACKLOG"
+    printf 'backlog_sha256=%s\n' "$backlog_sha"
+    printf 'in_flight_count=%s\n' "$in_flight_count"
+    printf 'metadata_count=%s\n' "$metadata_count"
+    printf 'metadata_minus_in_flight=%s\n' "$metadata_delta"
+    printf 'events_begin\n'
+    printf '%s' "$events"
+    printf 'events_end\n'
+  } > "$receipt") 2>/dev/null; then
+    printf '%s\n' "$receipt"
+    exit 0
+  fi
+  attempt=$((attempt + 1))
+done
+printf 'fm-record-reconcile: could not allocate a create-exclusive receipt\n' >&2
+exit 1

--- a/bin/fm-send.sh
+++ b/bin/fm-send.sh
@@ -10,7 +10,10 @@
 # Key support is backend-specific: tmux/herdr support Escape, Enter, and C-c;
 # Orca currently supports Enter and C-c only, and rejects Escape.
 #
-# Text submission is verified: the line is typed ONCE, then Enter is sent and
+# Text submission first requires an affirmatively empty composer. Pending or
+# unreadable input fails before typing, because appending to a parked stale order
+# can execute the wrong work while a later empty-composer verdict falsely appears
+# to confirm the new order. The line is then typed ONCE, then Enter is sent and
 # retried (Enter only, never retyped) until the target backend confirms a
 # submit or reports an inconclusive send. If a swallowed Enter is positively
 # confirmed, fm-send exits NON-ZERO so the caller knows the steer did not land
@@ -75,6 +78,8 @@ fi
 . "$SCRIPT_DIR/fm-marker-lib.sh"
 # shellcheck source=bin/fm-pending-reply-lib.sh
 . "$SCRIPT_DIR/fm-pending-reply-lib.sh"
+# shellcheck source=bin/fm-model-capacity-hold-lib.sh
+. "$SCRIPT_DIR/fm-model-capacity-hold-lib.sh"
 
 FM_GUARD_CONTINUE_LINE='This is a supervision warning only; the requested message WILL still be sent.' "$SCRIPT_DIR/fm-guard.sh" || true
 
@@ -240,6 +245,9 @@ fi
 # error with the attempted resolution attached.
 
 if [ "${1:-}" = "--key" ]; then
+  if [ "${2:-}" = Enter ]; then
+    fm_model_capacity_hold_refuse "Enter submission to $T" || exit 1
+  fi
   if ! fm_backend_send_key "$TARGET_BACKEND" "$T" "$2" "$EXPECTED_LABEL"; then
     echo "error: key '$2' not sent to $T ($TARGET_BACKEND send failed; tried $RESOLUTION_TRIED)" >&2
     exit 1
@@ -247,6 +255,12 @@ if [ "${1:-}" = "--key" ]; then
   fm_send_record_interrupt "$2" || exit 1
 else
   MESSAGE=$*
+  fm_model_capacity_hold_refuse "text submission to $T" || exit 1
+  composer_state=$(fm_backend_composer_state "$TARGET_BACKEND" "$T" "$EXPECTED_LABEL")
+  if [ "$composer_state" != empty ]; then
+    echo "error: text not sent to $T because its composer is not affirmatively empty (verdict=${composer_state:-unknown}; backend=$TARGET_BACKEND; tried $RESOLUTION_TRIED). Preserve the pane and reconcile its pending input before retrying." >&2
+    exit 1
+  fi
   if [ "$MARK_FROM_FIRSTMATE" = 1 ]; then
     # Reuse an existing correlation id for recovery resends; otherwise create a
     # durable parent expectation before delivery. Transport success never

--- a/bin/fm-session-start.sh
+++ b/bin/fm-session-start.sh
@@ -12,9 +12,9 @@
 # belong in a script, not in N agent turns.
 #
 # COMPOSITION, NOT DUPLICATION: this script calls fm-lock.sh, fm-bootstrap.sh,
-# and fm-wake-drain.sh as real subprocesses and prints their real output. It
+# fm-record-reconcile.sh, and fm-wake-drain.sh as real subprocesses and prints their real output. It
 # never re-implements their logic; all sequencing/formatting logic added here
-# stays local to this file. Those three scripts remain fully working
+# stays local to this file. Those four scripts remain fully working
 # standalone with unchanged default behavior - other flows (fm-bootstrap.sh
 # install <tools> after consent, /updatefirstmate, the afk daemon, existing
 # tests) still call them directly. The one seam this script needed -
@@ -33,16 +33,19 @@
 #                       (legacy PR-check migration, secondmate fast-forward,
 #                       secondmate liveness, X-mode artifact writes, fleet sync)
 #                       also run only when locked.
-#   3. wake-drain     - mutates the durable wake queue, so it also only runs
+#   3. record reconcile - retires surfaced terminal rows into Done without
+#                       pruning and receipts every metadata/backlog mismatch.
+#                       It only runs while locked.
+#   4. wake-drain     - mutates the durable wake queue, so it also only runs
 #                       when locked.
-#   4. context digest - data/projects.md, data/secondmates.md, data/captain.md,
+#   5. context digest - data/projects.md, data/secondmates.md, data/captain.md,
 #                       data/captain-shared.md, data/learnings.md: read-only,
 #                       always safe, always runs.
-#   5. fleet digest   - a compact data/backlog.md identity/metadata listing,
+#   6. fleet digest   - a compact data/backlog.md identity/metadata listing,
 #                       every state/*.meta, a bounded state/*.status tail,
 #                       state/.afk, and a cheap per-task endpoint-liveness read:
 #                       read-only, always runs.
-#   6. closing reminder - prints the context-specific watcher next step; this
+#   7. closing reminder - prints the context-specific watcher next step; this
 #                       script points back to the emitted harness supervision
 #                       block and deliberately never arms the watcher itself.
 #
@@ -283,7 +286,16 @@ else
   printf '(silent - all good)\n'
 fi
 
-# --- 3. wake-drain -------------------------------------------------------
+# --- 3. record reconciliation --------------------------------------------
+subsection "RECORD RECONCILIATION"
+if [ "$READ_ONLY" -eq 1 ]; then
+  printf 'skipped (read-only session) - terminal rows and inventory drift remain untouched.\n'
+else
+  RECONCILE_OUT=$("$SCRIPT_DIR/fm-record-reconcile.sh" 2>&1)
+  printf '%s\n' "${RECONCILE_OUT:-'(no backlog to reconcile)'}"
+fi
+
+# --- 4. wake-drain -------------------------------------------------------
 # Drained records are this turn's first work queue (AGENTS.md section 8); the
 # drain also runs fm-guard.sh internally on the locked path, so the
 # tangle/watcher-liveness alarms land right here too, ahead of the bulk digest

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -177,9 +177,12 @@ SUB_HOME_MARKER=".fm-secondmate-home"
 . "$SCRIPT_DIR/fm-busy-lib.sh"
 # shellcheck source=bin/fm-pr-lib.sh
 . "$SCRIPT_DIR/fm-pr-lib.sh"
+# shellcheck source=bin/fm-model-capacity-hold-lib.sh
+. "$SCRIPT_DIR/fm-model-capacity-hold-lib.sh"
 # Fail closed before any fleet mutation: a no-mistakes gate agent must never spawn
 # a direct report (see bin/fm-gate-refuse-lib.sh).
 fm_refuse_if_gate_agent
+fm_model_capacity_hold_refuse "crewmate or secondmate spawn" || exit 1
 # Skip the watcher guard when re-exec'd for one pair of a batch (FM_SPAWN_NO_GUARD is
 # set by the batch loop below), so the guard runs once for the batch, not once per pair.
 [ -n "${FM_SPAWN_NO_GUARD:-}" ] || "$FM_ROOT/bin/fm-guard.sh" || true

--- a/bin/fm-supervise-daemon.sh
+++ b/bin/fm-supervise-daemon.sh
@@ -180,6 +180,11 @@ FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
 # shellcheck source=bin/fm-busy-lib.sh
 . "$FM_DAEMON_DIR/fm-busy-lib.sh"
 
+# Durable capacity holds block away-mode model injections while leaving watcher
+# bookkeeping and cleanup available.
+# shellcheck source=bin/fm-model-capacity-hold-lib.sh
+. "$FM_DAEMON_DIR/fm-model-capacity-hold-lib.sh"
+
 # --- tunables ---------------------------------------------------------------
 # Supervisor backends this daemon knows how to inject into today. zellij, orca,
 # and cmux are real backends elsewhere in firstmate (bin/fm-backend.sh) but this
@@ -1112,12 +1117,16 @@ window_for_task() {  # <task-key> [state]
 #     line, or a previous injection's unsent text), defer entirely - injecting
 #     would merge with the human's text.
 inject_msg() {  # <message> [state]
-  local msg=$1 state target backend retries sleep_s verdict composer encoded
+  local msg=$1 state target backend retries sleep_s verdict composer encoded hold_error
   state="${2:-$(_state_root)}"
   # (1) Presence-gate: inject ONLY when afk is active. When afk is off, the
   # daemon self-handles and stays quiet; firstmate drives the normal always-on
   # watcher triage. Escalations buffer and survive for the next catch-up flush.
   afk_active "$state" || { log "inject deferred: afk inactive"; return 1; }
+  if ! hold_error=$(STATE="$state" fm_model_capacity_hold_refuse "away-supervisor model injection" 2>&1); then
+    log "inject deferred: $hold_error"
+    return 1
+  fi
   # (2) Single-line digest: collapse any embedded newlines so submission via
   # send-keys + Enter is unambiguous regardless of how the TUI composer treats
   # them. Then use the canonical typed envelope so downstream consumers retain

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -124,7 +124,7 @@ family_for_basename() {
     fm-crew-state.test.sh|fm-decision-hold-lifecycle.test.sh|\
     fm-documentation-audiences.test.sh|fm-ensure-agents-md.test.sh|fm-grok-harness.test.sh|\
     fm-kimi-harness.test.sh|fm-herdr-lab.test.sh|fm-lint.test.sh|\
-    fm-operational-input.test.sh|fm-pi-primary-types.test.sh|\
+    fm-model-capacity-hold.test.sh|fm-operational-input.test.sh|fm-pi-primary-types.test.sh|\
     fm-send-popup-settle.test.sh|fm-send-settle.test.sh|\
     fm-subagent-pretool-check.test.sh|\
     fm-supervision-instructions.test.sh|fm-tmux-submit-busy.test.sh|fm-transition-lib.test.sh|\
@@ -133,7 +133,7 @@ family_for_basename() {
       ;;
     fm-daemon.test.sh|fm-guard-stale-banner.test.sh|fm-pi-watch-extension.test.sh|\
     fm-supervision-events.test.sh|fm-turnend-guard.test.sh|fm-wake-daemon-lifecycle-e2e.test.sh|\
-    fm-wake-queue.test.sh|fm-watch-checkpoint.test.sh|fm-watch-triage.test.sh|\
+    fm-wake-queue.test.sh|fm-watch-arm-ownership.test.sh|fm-watch-checkpoint.test.sh|fm-watch-triage.test.sh|\
     fm-watcher-lock.test.sh)
       printf '%s\n' watcher-wake-lock
       ;;
@@ -152,7 +152,7 @@ family_for_basename() {
       printf '%s\n' secondmate
       ;;
     fm-bootstrap.test.sh|fm-fleet-sync.test.sh|fm-gate-refuse.test.sh|fm-gotmp.test.sh|\
-    fm-session-start.test.sh|fm-sessionstart-nudge.test.sh|fm-tangle-guard.test.sh|\
+    fm-record-reconcile.test.sh|fm-session-start.test.sh|fm-sessionstart-nudge.test.sh|fm-tangle-guard.test.sh|\
     fm-update.test.sh)
       printf '%s\n' session-bootstrap
       ;;
@@ -175,7 +175,7 @@ family_for_basename() {
     fm-afk-inject-e2e.test.sh|fm-afk-return.test.sh)
       printf '%s\n' afk
       ;;
-    fm-bearings-snapshot.test.sh|fm-fleet-snapshot-view.test.sh)
+    fm-bearings-report.test.sh|fm-bearings-snapshot.test.sh|fm-fleet-snapshot-view.test.sh)
       printf '%s\n' snapshot-bearings
       ;;
     fm-backend-cmux.test.sh|fm-backend-cmux-smoke.test.sh)
@@ -637,6 +637,10 @@ families_for_changed_path() {
     bin/fm-classify-lib.sh|bin/fm-daemon*|bin/fm-turnend-guard*|bin/fm-guard.sh)
       printf '%s\n' watcher-wake-lock
       ;;
+    bin/fm-process-progress.sh)
+      printf '%s\n' watcher-wake-lock
+      printf '%s\n' backend-dispatch
+      ;;
     bin/fm-afk*)
       printf '%s\n' afk
       printf '%s\n' real-herdr-gated
@@ -657,7 +661,7 @@ families_for_changed_path() {
       ;;
     bin/fm-session-start.sh|bin/fm-bootstrap.sh|bin/fm-fleet-sync.sh|\
     bin/fm-sessionstart-nudge.sh|bin/fm-tangle*|bin/fm-update.sh|\
-    bin/fm-gate-refuse*|bin/fm-lock*|bin/fm-quota-axi-lib.sh)
+    bin/fm-gate-refuse*|bin/fm-lock*|bin/fm-quota-axi-lib.sh|bin/fm-record-reconcile.sh)
       printf '%s\n' session-bootstrap
       ;;
     bin/fm-pr-*|bin/fm-merge-local.sh|bin/fm-teardown.sh|bin/fm-review-diff.sh|\
@@ -669,7 +673,12 @@ families_for_changed_path() {
       printf '%s\n' backend-dispatch
       printf '%s\n' pure-contract-unit
       ;;
-    bin/fm-bearings-snapshot.sh|bin/fm-fleet-snapshot.sh|bin/fm-fleet-view.sh)
+    bin/fm-bearings-report.sh|bin/fm-bearings-snapshot.sh|bin/fm-fleet-snapshot.sh|bin/fm-fleet-view.sh)
+      printf '%s\n' snapshot-bearings
+      ;;
+    bin/fm-custody-lib.sh)
+      printf '%s\n' pure-contract-unit
+      printf '%s\n' watcher-wake-lock
       printf '%s\n' snapshot-bearings
       ;;
     bin/fm-install-herdr.sh|bin/fm-install-treehouse.sh|bin/fm-herdr-ci-cleanup.sh)
@@ -678,7 +687,7 @@ families_for_changed_path() {
       # lane's contract coverage re-runs.
       printf '%s\n' real-herdr-gated
       ;;
-    bin/fm-lint.sh|bin/fm-install-shellcheck.sh|\
+    bin/fm-lint.sh|bin/fm-install-shellcheck.sh|bin/fm-model-capacity-hold*|\
     bin/fm-brief.sh|bin/fm-ensure-agents-md.sh|bin/fm-crew-state.sh|\
     bin/fm-decision-hold.sh|bin/fm-supervision*|bin/fm-transition-lib.sh|\
     bin/fm-tmux-lib.sh|bin/fm-marker-lib.sh|bin/fm-operational-input.sh|bin/fm-tasks-axi-lib.sh|\

--- a/bin/fm-wake-drain.sh
+++ b/bin/fm-wake-drain.sh
@@ -1,11 +1,16 @@
 #!/usr/bin/env bash
-# Atomically drain durable watcher wake records, optionally annotate validated
-# signal status keys after raw consumption commits, then assert liveness.
+# Atomically drain durable watcher wake records, preserve the consumed queue and
+# its digest-bound receipt, optionally annotate validated signal status keys
+# after raw consumption commits, then assert liveness.
 set -u
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=bin/fm-wake-lib.sh
 . "$SCRIPT_DIR/fm-wake-lib.sh"
+# shellcheck source=bin/fm-custody-lib.sh
+. "$SCRIPT_DIR/fm-custody-lib.sh"
+
+DATA="${FM_DATA_OVERRIDE:-$FM_HOME/data}"
 
 DRAIN_TMP=
 DRAIN_LOCK_HELD=false
@@ -67,6 +72,9 @@ if [ -n "$RAW_ROWS" ]; then
   # crash in this micro-gap may replay a wake, and annotations stay outside it.
   printf '%s\n' "$RAW_ROWS" || exit "$?"
 fi
+source_ref=$(git -C "$FM_ROOT" rev-parse HEAD 2>/dev/null || printf 'unversioned-firstmate-root')
+fm_custody_preserve "$DRAIN_TMP" "$DATA/wake-receipts" \
+  "$source_ref:$(basename "$FM_WAKE_QUEUE")" consumed-wake-queue >/dev/null || exit 1
 rm -f "$DRAIN_TMP" || exit "$?"
 DRAIN_TMP=
 fm_lock_release "$FM_WAKE_QUEUE_LOCK"

--- a/bin/fm-wake-drain.sh
+++ b/bin/fm-wake-drain.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 # Atomically drain durable watcher wake records, preserve the consumed queue and
-# its digest-bound receipt, optionally annotate validated signal status keys
-# after raw consumption commits, then assert liveness.
+# its digest-bound receipt, reconcile verified terminal status signals, optionally
+# annotate validated status keys after raw consumption commits, then assert
+# liveness.
 set -u
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -9,6 +10,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 . "$SCRIPT_DIR/fm-wake-lib.sh"
 # shellcheck source=bin/fm-custody-lib.sh
 . "$SCRIPT_DIR/fm-custody-lib.sh"
+# shellcheck source=bin/fm-classify-lib.sh
+. "$SCRIPT_DIR/fm-classify-lib.sh"
 
 DATA="${FM_DATA_OVERRIDE:-$FM_HOME/data}"
 
@@ -29,6 +32,28 @@ RAW_ROWS=
 # drain's exit status.
 assert_watcher_liveness() {
   "$SCRIPT_DIR/fm-guard.sh" || true
+}
+
+# A terminal status wake is the ordinary completion path, so reconcile its
+# structured row in the same turn rather than waiting for session restart.
+# Status keys are structurally mapped and read without following symlinks; queue
+# payload prose never supplies a path. Nonterminal signals remain read-only.
+reconcile_terminal_status_wakes() {  # <deduped-raw-rows>
+  local rows=$1 epoch seq kind key payload receipt
+  while IFS=$(printf '\t') read -r epoch seq kind key payload; do
+    [ "$kind" = signal ] || continue
+    fm_wake_status_key_map "$key" || continue
+    fm_wake_latest_event "$STATE/$FM_WAKE_STATUS_KEY" 65536 || continue
+    if status_is_done "$FM_WAKE_EVENT_LINE" || status_is_awaiting_captain "$FM_WAKE_EVENT_LINE"; then
+      receipt=$(FM_HOME="$FM_HOME" FM_STATE_OVERRIDE="$STATE" FM_DATA_OVERRIDE="$DATA" \
+        "$SCRIPT_DIR/fm-record-reconcile.sh") || return 1
+      [ -z "$receipt" ] || printf 'record reconciliation: %s\n' "$receipt"
+      return 0
+    fi
+  done <<EOF
+$rows
+EOF
+  return 0
 }
 
 # shellcheck disable=SC2317,SC2329 # Invoked by trap handlers below.
@@ -80,8 +105,12 @@ DRAIN_TMP=
 fm_lock_release "$FM_WAKE_QUEUE_LOCK"
 DRAIN_LOCK_HELD=false
 
-# Raw output and queue deletion are authoritative. Everything below is
-# best-effort and cannot restore, duplicate, hide, or fail the consumed rows.
+# Raw output, custody, and queue retirement are authoritative. Reconciliation
+# below may fail the command visibly but can never restore, duplicate, or hide
+# the already receipt-bound consumed rows. Annotation and liveness remain
+# best-effort even after reconciliation failure.
+reconcile_status=0
+reconcile_terminal_status_wakes "$RAW_ROWS" || reconcile_status=$?
 (fm_wake_print_annotations "$RAW_ROWS") || true
 assert_watcher_liveness
-exit 0
+exit "$reconcile_status"

--- a/bin/fm-watch-arm.sh
+++ b/bin/fm-watch-arm.sh
@@ -28,6 +28,10 @@
 #   watcher: started pid=<N> (beacon fresh)              - it launched one and confirmed it
 #   watcher: attached pid=<N> (beacon <age>s)            - a live+fresh successor holds the lock;
 #                                                          this arm attaches and follows it
+#   watcher: delegated to Claude auto-arm owner=<N> watcher=<N>
+#                                                        - another live Stop-hook owner already
+#                                                          owns this cycle; a manual arm does not
+#                                                          attach a second lifecycle to it
 #   watcher: FAILED - no live watcher with a fresh beacon  - could not confirm one
 #   watcher: FAILED - cycle ended without an actionable reason
 #                                                        - a clean cycle ended with no wake and no
@@ -256,6 +260,19 @@ wait_for_healthy_successor() {
   done
 }
 
+pid_is_current_ancestor() {  # <pid>
+  local wanted=$1 pid=${BASHPID:-$$} parent i=0
+  case "$wanted" in ''|*[!0-9]*) return 1 ;; esac
+  while [ "$i" -lt 32 ] && [ "$pid" -gt 1 ] 2>/dev/null; do
+    [ "$pid" = "$wanted" ] && return 0
+    parent=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d '[:space:]') || return 1
+    case "$parent" in ''|*[!0-9]*) return 1 ;; esac
+    pid=$parent
+    i=$((i + 1))
+  done
+  return 1
+}
+
 fail_unexplained_cycle() {
   echo "watcher: FAILED - cycle ended without an actionable reason"
   return 1
@@ -323,6 +340,25 @@ print_watch_output() {
   local out=$1
   [ -s "$out" ] && cat "$out"
 }
+
+# A manual repair and Claude's Stop hook can otherwise attach two arm lifecycles
+# to one watcher. The live ledger reproduced that shape directly: one started
+# arm and one attached arm named the same watcher, then the attached lifecycle
+# failed after the owner closed. When a foreign live auto-arm owner exists, do
+# not attach. Verify that its watcher is healthy and return an explicit delegated
+# outcome; the Stop-hook descendant itself is allowed through.
+AUTOARM_OWNER_LOCK="$STATE/.claude-autoarm.lock"
+autoarm_owner=$(cat "$AUTOARM_OWNER_LOCK/pid" 2>/dev/null || true)
+if fm_pid_alive "$autoarm_owner" && ! pid_is_current_ancestor "$autoarm_owner"; then
+  if wait_for_healthy_successor; then
+    echo "watcher: delegated to Claude auto-arm owner=$autoarm_owner watcher=$HEALTHY_PID"
+    exit 0
+  fi
+  if fm_pid_alive "$autoarm_owner"; then
+    echo "watcher: FAILED - Claude auto-arm owner=$autoarm_owner has no live watcher with a fresh beacon"
+    exit 1
+  fi
+fi
 
 mode=arm
 case "${1:-}" in

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -23,7 +23,10 @@
 #                          re-surface cadence, never as a wedge. Only when neither
 #                          absorb class applies does the log's last line decide:
 #                          terminal (captain-relevant) or non-terminal (no verb),
-#                          both surfaced at once. A provably-working stale past the
+#                          both surfaced at once. Once a done event has been
+#                          surfaced, its retained lane is excluded from future
+#                          stale classification without deleting metadata or the
+#                          worktree. A provably-working stale past the
 #                          wedge threshold also surfaces, with an "escalation N"
 #                          count in the reason; at FM_WEDGE_DEMAND_INSPECT_COUNT
 #                          consecutive escalations on the SAME pane, the reason
@@ -77,6 +80,8 @@ mkdir -p "$STATE"
 . "$SCRIPT_DIR/fm-pending-reply-lib.sh"
 # shellcheck source=bin/fm-busy-lib.sh
 . "$SCRIPT_DIR/fm-busy-lib.sh"
+# shellcheck source=bin/fm-custody-lib.sh
+. "$SCRIPT_DIR/fm-custody-lib.sh"
 
 WATCH_LOCK="$STATE/.watch.lock"
 WATCH_PATH="$SCRIPT_DIR/fm-watch.sh"
@@ -261,6 +266,28 @@ recorded_windows() {
 # pane/hash state resets to genuinely active (see the two rm-on-reset call sites
 # below).
 FM_WEDGE_DEMAND_INSPECT_COUNT=${FM_WEDGE_DEMAND_INSPECT_COUNT:-3}
+FM_PROCESS_PROGRESS_BIN=${FM_PROCESS_PROGRESS_BIN:-$SCRIPT_DIR/fm-process-progress.sh}
+
+# Compare cumulative CPU only across the same bound pane-root identity. A
+# positive delta is real progress even when pane bytes and sparse status events
+# are unchanged; it resets the wedge timer but never promotes current state.
+crew_cumulative_progress_advanced() {  # <window>
+  local win=$1 key sample identity cpu previous previous_identity previous_cpu
+  key=$(printf '%s' "$win" | tr ':/.' '___')
+  sample=$("$FM_PROCESS_PROGRESS_BIN" "$(window_backend "$win")" "$win" 2>/dev/null) || return 1
+  case "$sample" in *$'\t'*) : ;; *) return 1 ;; esac
+  identity=${sample%%$'\t'*}
+  cpu=${sample#*$'\t'}
+  [ -n "$identity" ] || return 1
+  case "$cpu" in ''|*[!0-9]*) return 1 ;; esac
+  previous=$(cat "$STATE/.progress-$key" 2>/dev/null || true)
+  printf '%s\n' "$sample" > "$STATE/.progress-$key"
+  previous_identity=${previous%%$'\t'*}
+  previous_cpu=${previous#*$'\t'}
+  [ "$previous_identity" = "$identity" ] || return 1
+  case "$previous_cpu" in ''|*[!0-9]*) return 1 ;; esac
+  [ "$cpu" -gt "$previous_cpu" ]
+}
 
 # Repeat-poll wedge-timer bookkeeping for an already-classified stale hash
 # absorbed as provably-working - repairs a missing/corrupt timer (self-heals a
@@ -272,6 +299,12 @@ FM_WEDGE_DEMAND_INSPECT_COUNT=${FM_WEDGE_DEMAND_INSPECT_COUNT:-3}
 # line that an active run/busy pane outranked).
 wedge_timer_check() {  # <window> <since-file> <triage-label> <escalation-count-file>
   local win=$1 since_file=$2 label=$3 escalation_file=$4 since age n reason
+  if crew_cumulative_progress_advanced "$win"; then
+    date +%s > "$since_file"
+    rm -f "$escalation_file"
+    triage_log "absorbed $label (cumulative CPU advanced): $win"
+    return 0
+  fi
   since=$(cat "$since_file" 2>/dev/null || true)
   case "$since" in
     ''|*[!0-9]*)
@@ -355,6 +388,93 @@ clear_pause_tracking() {  # <window>
   key=${key//./_}
   clear_pause_state "$win"
   rm -f "$STATE/.stale-$key" "$STATE/.stale-since-$key" "$STATE/.wedge-escalations-$key"
+}
+
+retained_marker_field() {  # <marker> <field>
+  sed -n "s/^${2}=//p" "$1" 2>/dev/null | tail -1
+}
+
+retained_marker_preserve() {  # <marker> <task> <window> <transition>
+  local marker=$1 task=$2 win=$3 transition=$4
+  [ -f "$marker" ] || return 0
+  fm_custody_preserve "$marker" "$FM_HOME/data/retention-receipts" \
+    "task=$task window=$win transition=$transition" 'retained-lane-prior-evidence' >/dev/null
+}
+
+# Verify and record the terminal/clean-tree/unchanged-HEAD triple that permits a
+# completed lane to leave stale escalation while its endpoint, worktree, and
+# unlanded commits remain retained. Return 0 when the evidence is stable, 1 when
+# retirement is unavailable, and 2 after a previously trusted HEAD, worktree, or
+# clean-tree condition changed. Every replacement/removal versions the prior
+# marker before the transition, so a reconciliation never destroys its evidence.
+retained_lane_check() {  # <task> <window> <status-evidence> <marker> <reason>
+  local task=$1 win=$2 evidence=$3 marker=$4 reason=$5 meta worktree head digest tmp count tree_status
+  local old_head old_worktree
+  meta="$STATE/$task.meta"
+  count=$(grep -c '^worktree=' "$meta" 2>/dev/null || true)
+  if [ "$count" -eq 1 ]; then
+    worktree=$(sed -n 's/^worktree=//p' "$meta")
+  else
+    worktree=
+  fi
+  if [ -z "$worktree" ] || [ ! -d "$worktree" ] \
+    || ! git -C "$worktree" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    if [ -f "$marker" ]; then
+      retained_marker_preserve "$marker" "$task" "$win" 'worktree-unavailable' || return 1
+      rm -f "$marker"
+      return 2
+    fi
+    return 1
+  fi
+  head=$(git -C "$worktree" rev-parse HEAD 2>/dev/null) || return 1
+  tree_status=$(git -C "$worktree" status --porcelain --untracked-files=normal 2>/dev/null) \
+    || return 1
+  if [ -n "$tree_status" ]; then
+    if [ -f "$marker" ]; then
+      retained_marker_preserve "$marker" "$task" "$win" 'tree-became-dirty' || return 1
+      rm -f "$marker"
+      return 2
+    fi
+    return 1
+  fi
+  digest=$(printf '%s' "$evidence" | {
+    if command -v shasum >/dev/null 2>&1; then shasum -a 256; else sha256sum; fi
+  } | awk '{print $1}') || return 1
+  tmp=$(mktemp "$STATE/.retained-evidence.XXXXXX") || return 1
+  {
+    printf 'schema=fm-retained-lane.v2\n'
+    printf 'task=%s\n' "$task"
+    printf 'window=%s\n' "$win"
+    printf 'status_digest=%s\n' "$digest"
+    printf 'worktree=%s\n' "$worktree"
+    printf 'head=%s\n' "$head"
+    printf 'tree_state=clean\n'
+    printf 'retained_reason=%s\n' "$reason"
+  } > "$tmp"
+  if [ ! -f "$marker" ]; then
+    mv "$tmp" "$marker"
+    return 0
+  fi
+  if cmp -s "$marker" "$tmp"; then
+    rm -f "$tmp"
+    return 0
+  fi
+  old_head=$(retained_marker_field "$marker" head)
+  old_worktree=$(retained_marker_field "$marker" worktree)
+  retained_marker_preserve "$marker" "$task" "$win" 'eligible-evidence-changed' \
+    || { rm -f "$tmp"; return 1; }
+  mv "$tmp" "$marker"
+  if [ "$old_head" != "$head" ] || [ "$old_worktree" != "$worktree" ]; then
+    return 2
+  fi
+  return 0
+}
+
+clear_answered_captain_wait() {  # <task> <window> <marker>
+  local task=$1 win=$2 marker=$3
+  [ -f "$marker" ] || return 0
+  retained_marker_preserve "$marker" "$task" "$win" 'captain-answer-recorded' || return 1
+  rm -f "$marker"
 }
 
 # Reconcile a declared pause or captain-held status with authoritative crew state.
@@ -871,6 +991,51 @@ EOF
     key=${key//\//_}
     key=${key//./_}
     last=$(last_status_line "$STATE/$task.status")
+    retained_key=${w//:/_}
+    retained_key=${retained_key//\//_}
+    retained_key=${retained_key//./_}
+    awaiting_marker="$STATE/.awaiting-captain-$retained_key"
+    awaiting_open=$(status_awaiting_captain_decisions "$STATE/$task.status")
+    if [ -z "$awaiting_open" ]; then
+      clear_answered_captain_wait "$task" "$w" "$awaiting_marker" || true
+    elif ! crew_is_provably_working "$task" \
+      && { [ -f "$awaiting_marker" ] \
+        || { status_is_awaiting_captain "$last" \
+          && [ "$(cat "$(_hb_surfaced_path "$task")" 2>/dev/null || true)" = "$last" ]; }; }; then
+      retained_lane_check "$task" "$w" "$awaiting_open" "$awaiting_marker" \
+        'complete-awaiting-unbounded-captain-decision'
+      retained_rc=$?
+      if [ "$retained_rc" -eq 0 ]; then
+        clear_pause_tracking "$w"
+        triage_log "retained awaiting-captain lane excluded from stale escalation: $w"
+        continue
+      elif [ "$retained_rc" -eq 2 ]; then
+        reason="stale: $w (retained evidence changed while awaiting captain)"
+        fm_wake_append stale "$w" "$reason" || exit 1
+        wake "$reason"
+      fi
+    fi
+    # A completed report is actionable once, via its signal or first stale
+    # fallback. After that exact done line is recorded as surfaced, an idle pane
+    # is expected and cannot become a wedge merely because its clean worktree is
+    # retained for an independent gate or unlanded commits. A live worker always
+    # overrides this status-log evidence and remains under wedge supervision.
+    if status_is_done "$last" \
+      && [ "$(cat "$(_hb_surfaced_path "$task")" 2>/dev/null || true)" = "$last" ] \
+      && ! crew_is_provably_working "$task"; then
+      retained_lane_check "$task" "$w" "$last" "$STATE/.terminal-retained-$retained_key" \
+        'completed-awaiting-lifecycle-reconciliation'
+      retained_rc=$?
+      if [ "$retained_rc" -eq 0 ]; then
+        clear_pause_tracking "$w"
+        triage_log "retained completed lane excluded from stale escalation: $w"
+        continue
+      elif [ "$retained_rc" -eq 2 ]; then
+        reason="stale: $w (retained evidence changed after terminal report)"
+        fm_wake_append stale "$w" "$reason" || exit 1
+        wake "$reason"
+      fi
+    fi
     if ! status_is_paused_or_captain_held "$last" && [ -e "$STATE/.paused-$key" ]; then
       clear_pause_tracking "$w"
     fi

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -27,7 +27,7 @@ Its initial normal-mode status signal still surfaces through the no-verb path, w
 Fresh stale panes use the same current-state read before trusting the status log, so an active run or a proven busy worker outranks an old captain-relevant status-log line left behind before validation.
 No-change heartbeats are also benign.
 Absorbed wakes advance their suppression markers, log to `state/.watch-triage.log`, and keep the watcher blocking without a queue record or LLM turn.
-After each drain, `fm-wake-drain.sh` first custody-versions the exact consumed queue bytes and writes a digest, byte count, source reference, custody class, and timestamp receipt, then runs the same liveness guard as the supervision scripts, so a lapsed watcher chain surfaces even on a turn that only drains and handles queued wakes.
+After each drain, `fm-wake-drain.sh` first custody-versions the exact consumed queue bytes and writes a digest, byte count, source reference, custody class, and timestamp receipt, then reconciles any safely read terminal status signal through `fm-record-reconcile.sh` in that same turn before running the liveness guard, so neither a terminal row nor a lapsed watcher chain waits for session restart.
 Routine watcher polling, supervision no-ops, elapsed waiting time, and absorbed benign wakes stay silent.
 A declared external wait trades that silence for one bounded recheck per pause window, so a forgotten pause cannot remain invisible indefinitely.
 Crew status files are append-only wake-event logs, not current-state fields.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -9,7 +9,7 @@ firstmate's always-loaded operating contract and routing index for conditional p
 ## Event-driven supervision
 
 A zero-token bash watcher (`bin/fm-watch.sh`) sleeps on the fleet, classifies detected wakes in bash, and wakes the first mate only when something is actionable.
-Actionable wakes include captain-relevant status signals, no-verb signals whose crew is not provably working, authenticated check output such as PR merge polling or an X-mode mention, stale panes whose crew is not provably working whether their status log looks terminal or non-terminal, provably-working stale panes that persist past `FM_STALE_ESCALATE_SECS`, declared external waits that remain paused past `FM_PAUSE_RESURFACE_SECS`, and heartbeat backstop hits.
+Actionable wakes include captain-relevant status signals, no-verb signals whose crew is not provably working, authenticated check output such as PR merge polling or an X-mode mention, stale panes whose crew is not provably working, provably-working stale panes that persist past `FM_STALE_ESCALATE_SECS`, declared external waits that remain paused past `FM_PAUSE_RESURFACE_SECS`, and heartbeat backstop hits.
 Repeated provably-working stale escalations on the same unchanged pane add an escalation count to the wake reason and, at `FM_WEDGE_DEMAND_INSPECT_COUNT`, a `demand-deep-inspection` marker.
 A busy pane is otherwise exempt from staleness, but only until its latest `state/<id>.turn-ended` marker reaches `FM_BUSY_TURN_MAX_SECS`, or its `state/<id>.meta` spawn record reaches that age before any turn completes; past that bound it is routed through the same wedge escalation, with the identical reason, escalation count, and `demand-deep-inspection` marker, for inspection only - never an automatic interrupt, signal, or restart.
 Those actionable wakes are written to a durable local queue (`state/.wake-queue`) before detector state advances, so a missed process exit can be recovered by draining the queue.
@@ -19,17 +19,21 @@ A concurrent replacement remains armed, every non-merged or invalid observation 
 `bin/fm-pr-lib.sh` owns the receipt format and strict identity mechanics, while `bin/fm-watch.sh` owns queue-before-retirement ordering.
 No-verb wakes, such as `working:` notes and bare turn-ended signals, are benign only when `bin/fm-crew-state.sh` reports positive evidence that the crew is still working: an actively running no-mistakes step attributed to that crew's current code, or an exact busy verdict from the semantic busy-state contract.
 A crew that declares `paused:` for a known external wait is separately absorbed while idle and re-surfaced only on the longer pause cadence, rather than being treated as a possible wedge.
+A crew that reports `done:` is retired from stale escalation after one mechanical retention check proves the exact terminal event, a clean worktree, and its current HEAD; `awaiting-captain [key=...]` uses the same baseline for an unbounded decision wait.
+The baseline is trusted until the terminal event digest, worktree cleanliness, HEAD, or resolved-decision set changes; a change surfaces exactly once for reconciliation while preserving the endpoint metadata, worktree, commits, and prior baseline as custody evidence.
 For an ordinary crew that has stopped, the normal-mode watcher first surfaces one stale wake, then applies that same cadence to an unchanged `paused:` or durable `captain-held` endpoint only when the backend confidently reports its agent dead.
 Live or inconclusive liveness remains fail-open at that initial surface, and the secondmate idle-endpoint exemption is unchanged.
 Its initial normal-mode status signal still surfaces through the no-verb path, while away mode self-handles that routine signal and owns the later recheck.
 Fresh stale panes use the same current-state read before trusting the status log, so an active run or a proven busy worker outranks an old captain-relevant status-log line left behind before validation.
 No-change heartbeats are also benign.
 Absorbed wakes advance their suppression markers, log to `state/.watch-triage.log`, and keep the watcher blocking without a queue record or LLM turn.
-After each drain, `fm-wake-drain.sh` runs the same liveness guard as the supervision scripts, so a lapsed watcher chain surfaces even on a turn that only drains and handles queued wakes.
+After each drain, `fm-wake-drain.sh` first custody-versions the exact consumed queue bytes and writes a digest, byte count, source reference, custody class, and timestamp receipt, then runs the same liveness guard as the supervision scripts, so a lapsed watcher chain surfaces even on a turn that only drains and handles queued wakes.
 Routine watcher polling, supervision no-ops, elapsed waiting time, and absorbed benign wakes stay silent.
 A declared external wait trades that silence for one bounded recheck per pause window, so a forgotten pause cannot remain invisible indefinitely.
 Crew status files are append-only wake-event logs, not current-state fields.
 `bin/fm-crew-state.sh <id>` is the cheap current-state read for an actionable heartbeat review: it attributes a no-mistakes run, active or terminal, only when it matches the crew's branch and current code identity, then keeps that run-step authoritative even if the pane has closed.
+For a running step with a recorded native-agent PID in the current step log, that process identity must still be live and unsuspended; a pane interrupt does not stop it, and a dead or suspended bound PID is reported as a pipeline contradiction rather than working.
+Older or unsupported run shapes without a verifiable PID remain explicitly indeterminate at the process layer instead of borrowing pane liveness.
 The script header owns the exact run-head ancestry rules.
 During no-mistakes' `ci` monitor phase, it also reads the ci step log tail because `axi status` reports both "still waiting on checks" and "checks green, waiting on merge" as `ci,running`.
 The most recent recognized ci log marker wins, so checks-green monitoring reports done while a later re-arm, failed-check, or issue marker returns the crew to working.
@@ -97,7 +101,8 @@ Codex and standalone Kimi classify unknown behind explicit probes until a semant
 
 Missing, malformed, stale, untrusted, or unverified semantic state is unknown, never idle, and unknown is never promoted to busy either.
 Ordinary task-state consumers act only on an exact busy verdict, so an unreadable worker surfaces for a closer look instead of being absorbed as still-working or written off as finished.
-Endpoint death is the only process-level override and yields dead; child processes, CPU, process sleep state, and marker modification times are not state signals.
+Endpoint death is the only pane-level process override and yields dead when no current-code-matched pipeline run accounts for the task; child process presence, instantaneous CPU, process sleep state, and marker modification times are not state signals.
+A positive cumulative-CPU delta across two samples of the same recorded root process and descendant closure is progress evidence only: it resets stale aging but never classifies current state, while zero delta proves nothing.
 `state/<id>.turn-ended` files remain wake notifications, not current state.
 
 Each record is bound to an incarnation token minted when the task's wiring is armed, so an event from a superseded incarnation is rejected rather than applied, and a record left behind by one classifies unknown.
@@ -152,6 +157,14 @@ The tracked `.no-mistakes.yaml` sets `disable_project_settings: true`; no-mistak
 Independently, `fm-spawn.sh`, `fm-send.sh`, and `fm-teardown.sh` source `bin/fm-gate-refuse-lib.sh` and exit with status 3 before fleet mutation when the gate environment marker is present or the current checkout matches the default no-mistakes gate-repository topology.
 A normal primary checkout or crewmate worktree has neither signal and remains unaffected.
 The helper's header owns the exact signal detection, relocated-home limitation, test-harness bypass, and relationship to no-mistakes' HEAD-continuity guard.
+
+## Model-capacity hold boundary
+
+`bin/fm-model-capacity-hold.sh` registers one durable home-wide capacity hold and retains registration and digest-bound release receipts under `data/model-capacity-holds/`.
+While the marker is active, Firstmate-controlled new model work is refused at `fm-spawn.sh`, text and Enter submission at `fm-send.sh`, and away-supervisor injection at `fm-supervise-daemon.sh`.
+Interrupt keys, watcher bookkeeping, evidence capture, and cleanup remain available, so a capacity hold does not strand finished work.
+The boundary is intentionally honest rather than universal: the primary's current model turn and harness-native same-session watcher or Stop-hook continuations, direct human input in a TUI, provider CLI or API calls, native subagent controls, direct no-mistakes commands, lower-level backend send functions invoked outside the guarded entrypoints, and agents or detached pipeline workers that were already running before registration remain outside Firstmate's enforcement.
+A capacity hold therefore prevents new work only through the listed supervised entrypoints; stopping an already-running worker requires its own explicit, evidence-preserving lifecycle action.
 
 ## Two task shapes
 

--- a/docs/arm-pretool-check.md
+++ b/docs/arm-pretool-check.md
@@ -75,6 +75,10 @@ This covers statically-visible literal words in command position; opaque dynamic
 `bin/fm-watch.sh` is protected but is not a blessed entry point.
 A direct `bin/fm-watch.sh` execution - relative, `<code-root>`-anchored, `$VAR`-prefixed, or `~`-prefixed - always denies with `watcher-direct`, whose reason points the caller at `bin/fm-watch-arm.sh` and `bin/fm-watch-checkpoint.sh`.
 
+Shell no-execute syntax checks such as `bash -n bin/fm-watch.sh`, combined short flags containing `n`, and `bash --noexec bin/fm-watch.sh` are read-only data uses and are allowed.
+The exception belongs to the semantic classifier, not the byte prefilter: the same path executed as `bash bin/fm-watch.sh` remains a denied direct watcher launch.
+The regression matrix covers both halves through every adapter transport, alongside the full dangerous-command deny corpus, so a syntax-validation allowance cannot weaken execution protection.
+
 The same bytes in an argument, comment, assertion, documentation query, Python string, `printf`, or `tmux send-keys` payload are data and do not make the outer command relevant.
 
 Literal `sh`, `bash`, or `zsh` `-c` payloads and literal `eval` payloads are recursively classified.

--- a/docs/arm-pretool-check.md
+++ b/docs/arm-pretool-check.md
@@ -76,7 +76,11 @@ This covers statically-visible literal words in command position; opaque dynamic
 A direct `bin/fm-watch.sh` execution - relative, `<code-root>`-anchored, `$VAR`-prefixed, or `~`-prefixed - always denies with `watcher-direct`, whose reason points the caller at `bin/fm-watch-arm.sh` and `bin/fm-watch-checkpoint.sh`.
 
 The no-execute exception is an explicit allow-list containing only `bash -n <fm-watch.sh>` and `bash --noexec <fm-watch.sh>` as sole top-level commands with no wrapper, extra option or argument, separator, substitution, or redirection.
-The exception belongs to the semantic classifier, not the byte prefilter: every other shell invocation carrying the watcher script is denied, including `--rcfile`, `--init-file`, combined flags, and direct execution.
+The exception belongs to the semantic classifier, not the byte prefilter: every other statically recognized shell invocation carrying the watcher script is denied, including `--rcfile`, `--init-file`, combined flags, and direct execution.
+The known [`bash -s <operand>` gap](https://github.com/kunchenguid/firstmate/issues/1489) makes shell-invocation analysis mistake the operand for a script path, so a heredoc or here-string payload is not inspected and can execute `bin/fm-watch.sh`.
+The guard therefore does not cover every payload-hiding shell form.
+The three discovered holes - `--rcfile`, `--init-file`, and `-s` - are all argument-consuming or payload-hiding invocation forms, and that class is demonstrably not exhausted.
+That open-ended class is why the syntax exception remains an allow-list: a fourth unmodeled form that reaches protected-invocation classification must fall through to denial instead of acquiring read-only status.
 Independently, every redirection on a protected execution and every output redirection targeting a protected script is denied before an allow decision, so a syntax check or unrelated command cannot truncate the script it is checking.
 The regression matrix covers the two allowed forms and the executing/destructive counterforms through every adapter transport, alongside the full dangerous-command deny corpus.
 

--- a/docs/arm-pretool-check.md
+++ b/docs/arm-pretool-check.md
@@ -75,9 +75,10 @@ This covers statically-visible literal words in command position; opaque dynamic
 `bin/fm-watch.sh` is protected but is not a blessed entry point.
 A direct `bin/fm-watch.sh` execution - relative, `<code-root>`-anchored, `$VAR`-prefixed, or `~`-prefixed - always denies with `watcher-direct`, whose reason points the caller at `bin/fm-watch-arm.sh` and `bin/fm-watch-checkpoint.sh`.
 
-Shell no-execute syntax checks such as `bash -n bin/fm-watch.sh`, combined short flags containing `n`, and `bash --noexec bin/fm-watch.sh` are read-only data uses and are allowed.
-The exception belongs to the semantic classifier, not the byte prefilter: the same path executed as `bash bin/fm-watch.sh` remains a denied direct watcher launch.
-The regression matrix covers both halves through every adapter transport, alongside the full dangerous-command deny corpus, so a syntax-validation allowance cannot weaken execution protection.
+The no-execute exception is an explicit allow-list containing only `bash -n <fm-watch.sh>` and `bash --noexec <fm-watch.sh>` as sole top-level commands with no wrapper, extra option or argument, separator, substitution, or redirection.
+The exception belongs to the semantic classifier, not the byte prefilter: every other shell invocation carrying the watcher script is denied, including `--rcfile`, `--init-file`, combined flags, and direct execution.
+Independently, every redirection on a protected execution and every output redirection targeting a protected script is denied before an allow decision, so a syntax check or unrelated command cannot truncate the script it is checking.
+The regression matrix covers the two allowed forms and the executing/destructive counterforms through every adapter transport, alongside the full dangerous-command deny corpus.
 
 The same bytes in an argument, comment, assertion, documentation query, Python string, `printf`, or `tmux send-keys` payload are data and do not make the outer command relevant.
 

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -7,7 +7,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 
 | Script                   | Purpose                                                                              |
 | ------------------------ | ------------------------------------------------------------------------------------ |
-| `fm-session-start.sh`    | Compose lock, bootstrap, and wake drain into the single ordered session-start digest |
+| `fm-session-start.sh`    | Compose lock, bootstrap, record reconciliation, and wake drain into the single ordered session-start digest |
 | `fm-sessionstart-nudge.sh` | Print the native session-start hook nudge when the primary has not already run the digest |
 | `fm-operational-input.sh` | Construct and parse the canonical cross-language operational-input protocol |
 | `fm-bootstrap.sh`        | Detect toolchain and fleet problems, run the locked session-start sweeps, and install approved tools |
@@ -15,9 +15,13 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-fleet-snapshot.sh`   | Print the read-only structured fleet snapshot JSON (schema `fm-fleet-snapshot.v1`)   |
 | `fm-fleet-view.sh`       | Render the fleet snapshot as a human Markdown view                                   |
 | `fm-bearings-snapshot.sh` | Project the fleet snapshot to the compact TOON bearings view; local-only unless `--include-prs` |
+| `fm-bearings-report.sh`  | Install today's Bearings report after custody-versioning any same-day predecessor     |
 | `fm-update.sh`           | Fast-forward-only self-update of firstmate and secondmate homes from origin          |
 | `fm-backlog-handoff.sh`  | Validate and delegate queued backlog-item moves into a secondmate home               |
 | `fm-decision-hold.sh`    | Create, verify, complete, and resolve durable captain-held decisions                 |
+| `fm-model-capacity-hold.sh` | Register, inspect, and receipt release of a home-wide model-capacity hold          |
+| `fm-model-capacity-hold-lib.sh` | Refuse Firstmate-controlled model entrypoints while a registered capacity hold is active |
+| `fm-custody-lib.sh`      | Create-exclusive evidence copy and digest-bound pre-transition custody receipt         |
 | `fm-brief.sh`            | Scaffold ship, scout, secondmate-charter, and Herdr-lab briefs                       |
 | `fm-herdr-lab.sh`        | Provision and guardedly operate an isolated, never-default Herdr lab session         |
 | `fm-install-herdr.sh`    | Install CI's exact-version Herdr pin with official asset URL, SHA-256, and protocol checks |
@@ -64,6 +68,8 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-supervisor-target-lib.sh` | Resolve the shared supervisor target and backend for the daemon and launcher       |
 | `fm-supervise-daemon.sh` | Presence-gated away-mode sub-supervisor: self-handle routine wakes, guard injection by the detected primary harness, escalate batched digests, alert on failed delivery |
 | `fm-crew-state.sh`       | Print one deterministic current-state line for a crew                                |
+| `fm-process-progress.sh` | Sample cumulative CPU for one identity-bound backend process closure as progress-only evidence |
+| `fm-record-reconcile.sh` | Reconcile verified terminal rows and receipt metadata/backlog drift without erasure   |
 | `fm-tangle-lib.sh`       | Shared default-branch resolution and primary-checkout tangle classification          |
 | `fm-supervision-lib.sh`  | Shared in-flight-work-without-fresh-watcher-beacon predicate                         |
 | `fm-ff-lib.sh`           | Shared guarded fast-forward helper for origin pulls and local secondmate syncs       |
@@ -72,7 +78,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-tasks-axi-lib.sh`    | Shared backlog-backend selector and `tasks-axi` compatibility probe                  |
 | `fm-quota-axi-lib.sh`    | Shared `quota-axi` compatibility floor for the bootstrap diagnostic                  |
 | `fm-vendor-auth-probe.sh`| Run one hard-bounded, non-destructive authentication probe of a named vendor CLI and report the fact |
-| `fm-wake-drain.sh`       | Atomically drain queued watcher wakes, emit bounded best-effort status-event annotations, then assert watcher liveness |
+| `fm-wake-drain.sh`       | Atomically drain and custody-version queued wakes, emit bounded status annotations, then assert watcher liveness |
 | `fm-wake-lib.sh`         | Shared durable wake queue, portable locks, and watcher identity/health helpers       |
 | `fm-classify-lib.sh`     | Shared captain-relevant and declared-external-wait wake classification vocabulary    |
 | `fm-send.sh`             | Send one verified literal line or supported key through the target's recorded backend |

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -78,7 +78,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-tasks-axi-lib.sh`    | Shared backlog-backend selector and `tasks-axi` compatibility probe                  |
 | `fm-quota-axi-lib.sh`    | Shared `quota-axi` compatibility floor for the bootstrap diagnostic                  |
 | `fm-vendor-auth-probe.sh`| Run one hard-bounded, non-destructive authentication probe of a named vendor CLI and report the fact |
-| `fm-wake-drain.sh`       | Atomically drain and custody-version queued wakes, emit bounded status annotations, then assert watcher liveness |
+| `fm-wake-drain.sh`       | Atomically drain and custody-version queued wakes, reconcile verified terminal status signals, emit bounded annotations, then assert watcher liveness |
 | `fm-wake-lib.sh`         | Shared durable wake queue, portable locks, and watcher identity/health helpers       |
 | `fm-classify-lib.sh`     | Shared captain-relevant and declared-external-wait wake classification vocabulary    |
 | `fm-send.sh`             | Send one verified literal line or supported key through the target's recorded backend |

--- a/docs/watcher-continuity.md
+++ b/docs/watcher-continuity.md
@@ -28,6 +28,8 @@ Claude's Stop hook starts the successor arm at the next Stop after the handling 
 The durable wake queue preserves actionable events during the residual active-turn window, and the unchanged bounded turn-end guard enforces recovery at Stop when no watcher or auto-arm claim is present.
 No PreToolUse hook denies fleet commands based on watcher status.
 The model no longer re-arms after ordinary wakes.
+If a manual repair races a live Claude Stop-hook owner, `fm-watch-arm.sh` verifies the owner's fresh watcher and returns a typed delegated outcome instead of attaching a second arm lifecycle to the same cycle.
+The Stop-hook descendant itself is recognized through process ancestry and remains the only lifecycle owner.
 Terminal arm-output classification (`started`, `attached`, or `FAILED`) remains defense in depth for the manual recovery path.
 Codex retains its bounded foreground checkpoint protocol.
 Grok retains its tracked background-task notification protocol.
@@ -38,6 +40,7 @@ The turn-end guard remains the final backstop rather than the normal continuity 
 ## Arm-layer cycle contract
 
 `bin/fm-watch-arm.sh` never returns a clean empty success.
+The explicit delegated-to-Claude-owner result is a clean non-empty no-op because another verified owner already carries continuity; it is not an attached arm and never waits on or signals that owner's watcher.
 An actionable child output returns that reason normally.
 A zero/empty child return rechecks the home lock and beacon, attaches to a verified healthy successor when one exists, or emits `watcher: FAILED - cycle ended without an actionable reason` and exits nonzero.
 An attached arm follows verified identity-matched successors and reports the same typed failure if that chain ends without one.

--- a/tests/fm-arm-pretool-check.test.sh
+++ b/tests/fm-arm-pretool-check.test.sh
@@ -65,6 +65,7 @@ matrix_case R18 allow "sh -c 'tmux send-keys -t lab \"bin/fm-watch-arm.sh &\" En
 matrix_case R19 allow "eval 'printf \"%s\\n\" \"bin/fm-watch-arm.sh &\"'"
 matrix_case R20 allow 'bash -n bin/fm-watch.sh'
 matrix_case R21 allow 'sed -n '\''1,20p'\'' bin/fm-watch.sh'
+matrix_case R22 allow 'bash --noexec bin/fm-watch.sh'
 
 matrix_case D01 deny 'bin/fm-watch-arm.sh &'
 matrix_case D02 deny 'nohup bin/fm-watch-arm.sh'
@@ -125,6 +126,18 @@ matrix_case D56 deny 'for x in 1; do pkill -f fm-watch; done'
 matrix_case D57 deny 'case x in x) pkill -f fm-watch ;; esac'
 matrix_case D58 deny 'until false; do kill $(pgrep -f fm-watch); done'
 matrix_case D59 deny 'bash bin/fm-watch.sh'
+matrix_case D60 deny 'bash --rcfile -n bin/fm-watch.sh'
+matrix_case D61 deny 'bash --init-file -n bin/fm-watch.sh'
+matrix_case D62 deny 'sh --rcfile -n bin/fm-watch.sh'
+matrix_case D63 deny 'bash -n bin/fm-watch.sh > bin/fm-watch.sh'
+matrix_case D64 deny ': > bin/fm-watch.sh'
+matrix_case D65 deny 'bash -n bin/fm-watch.sh > /tmp/fm-watch-syntax.out'
+matrix_case D66 deny 'bash -in bin/fm-watch.sh'
+matrix_case D67 deny 'bash -n -- bin/fm-watch.sh'
+matrix_case D68 deny 'bash -n bin/fm-watch.sh &'
+matrix_case D69 deny 'bash -o xtrace bin/fm-watch.sh'
+matrix_case D70 deny 'bash --rcfile /dev/null bin/fm-watch.sh'
+matrix_case D71 deny 'target=bin/fm-watch.sh; : > "$target"'
 
 matrix_case E01 allow "bin/fm-watch-checkpoint.sh --seconds '180;still-one-arg'"
 matrix_case E02 allow "bin/fm-watch-checkpoint.sh --label 'fm-watch-arm.sh; literal argument'"
@@ -237,7 +250,13 @@ test_direct_policy_contract() {
   assert_policy direct-watch-expanded $'deny\twatcher-direct' '$FM_HOME/bin/fm-watch.sh'
   assert_policy direct-watch-safe-shape $'deny\twatcher-direct' 'cd /tmp; bin/fm-watch.sh'
   assert_policy direct-watch-syntax-read allow 'bash -n bin/fm-watch.sh'
+  assert_policy direct-watch-noexec-read allow 'bash --noexec bin/fm-watch.sh'
   assert_policy direct-watch-script-wrapper $'deny\twatcher-nested' 'bash bin/fm-watch.sh'
+  assert_policy direct-watch-rcfile-value $'deny\twatcher-nested' 'bash --rcfile -n bin/fm-watch.sh'
+  assert_policy direct-watch-init-file-value $'deny\twatcher-nested' 'bash --init-file -n bin/fm-watch.sh'
+  assert_policy direct-watch-syntax-truncate $'deny\twatcher-redirection' 'bash -n bin/fm-watch.sh > bin/fm-watch.sh'
+  assert_policy direct-watch-leading-truncate $'deny\twatcher-redirection' ': > bin/fm-watch.sh'
+  assert_policy direct-watch-variable-truncate $'deny\twatcher-redirection' 'target=bin/fm-watch.sh; : > "$target"'
   heredoc_data=$'cat <<\'EOF\'\nbin/fm-watch-arm.sh &\nEOF'
   heredoc_watcher=$'bin/fm-watch-arm.sh <<\'EOF\'\ndata only\nEOF'
   assert_policy direct-heredoc-data allow "$heredoc_data"

--- a/tests/fm-arm-pretool-check.test.sh
+++ b/tests/fm-arm-pretool-check.test.sh
@@ -63,6 +63,8 @@ matrix_case R16 allow $'# bin/fm-watch-arm.sh &\necho ok'
 matrix_case R17 allow "printf '%s\\n' 'fm-watch.sh; a && b || c > out' | sed -n '1p'"
 matrix_case R18 allow "sh -c 'tmux send-keys -t lab \"bin/fm-watch-arm.sh &\" Enter'"
 matrix_case R19 allow "eval 'printf \"%s\\n\" \"bin/fm-watch-arm.sh &\"'"
+matrix_case R20 allow 'bash -n bin/fm-watch.sh'
+matrix_case R21 allow 'sed -n '\''1,20p'\'' bin/fm-watch.sh'
 
 matrix_case D01 deny 'bin/fm-watch-arm.sh &'
 matrix_case D02 deny 'nohup bin/fm-watch-arm.sh'
@@ -122,6 +124,7 @@ matrix_case D55 deny 'while true; do pkill -f fm-watch; done'
 matrix_case D56 deny 'for x in 1; do pkill -f fm-watch; done'
 matrix_case D57 deny 'case x in x) pkill -f fm-watch ;; esac'
 matrix_case D58 deny 'until false; do kill $(pgrep -f fm-watch); done'
+matrix_case D59 deny 'bash bin/fm-watch.sh'
 
 matrix_case E01 allow "bin/fm-watch-checkpoint.sh --seconds '180;still-one-arg'"
 matrix_case E02 allow "bin/fm-watch-checkpoint.sh --label 'fm-watch-arm.sh; literal argument'"
@@ -233,6 +236,8 @@ test_direct_policy_contract() {
   assert_policy direct-watch-not-blessed $'deny\twatcher-direct' 'bin/fm-watch.sh'
   assert_policy direct-watch-expanded $'deny\twatcher-direct' '$FM_HOME/bin/fm-watch.sh'
   assert_policy direct-watch-safe-shape $'deny\twatcher-direct' 'cd /tmp; bin/fm-watch.sh'
+  assert_policy direct-watch-syntax-read allow 'bash -n bin/fm-watch.sh'
+  assert_policy direct-watch-script-wrapper $'deny\twatcher-nested' 'bash bin/fm-watch.sh'
   heredoc_data=$'cat <<\'EOF\'\nbin/fm-watch-arm.sh &\nEOF'
   heredoc_watcher=$'bin/fm-watch-arm.sh <<\'EOF\'\ndata only\nEOF'
   assert_policy direct-heredoc-data allow "$heredoc_data"

--- a/tests/fm-backend.test.sh
+++ b/tests/fm-backend.test.sh
@@ -689,12 +689,15 @@ strip_send_preflight() {  # <log>
 }
 
 test_send_conformance_old_vs_new() {
-  local old_bin fb log_old log_new home rc_old rc_new filtered_old filtered_new
+  local old_bin fb log_old log_new home rc_old rc_new filtered_old filtered_new guarded_new expected_cursor expected_capture
   old_bin=$(build_old_bin send-old)
   fb=$(make_send_fakebin "$TMP_ROOT/send-fake")
   home="$TMP_ROOT/send-home"; mkdir -p "$home/state"
   log_old="$TMP_ROOT/send-old.log"; log_new="$TMP_ROOT/send-new.log"
   filtered_old="$TMP_ROOT/send-old.filtered.log"; filtered_new="$TMP_ROOT/send-new.filtered.log"
+  guarded_new="$TMP_ROOT/send-new.guarded.log"
+  expected_cursor=$'tmux\x1fdisplay-message\x1f-p\x1f-t\x1fsess:win\x1f#{cursor_y}'
+  expected_capture=$'tmux\x1fcapture-pane\x1f-e\x1f-p\x1f-t\x1fsess:win\x1f-S\x1f0\x1f-E\x1f-'
 
   # Case 1: --key path.
   run_send_case "$old_bin" "$fb" "$log_old" "$home" -- "sess:win" --key Escape
@@ -717,7 +720,12 @@ test_send_conformance_old_vs_new() {
   rc_new=$?
   expect_code "$rc_old" "$rc_new" "fm-send plain text: old vs new exit code"
   strip_send_preflight "$log_old" > "$filtered_old"
-  strip_send_preflight "$log_new" > "$filtered_new"
+  strip_send_preflight "$log_new" > "$guarded_new"
+  [ "$(sed -n '1p' "$guarded_new")" = "$expected_cursor" ] \
+    || fail "fm-send plain text: strict composer guard did not read cursor position before typing"
+  [ "$(sed -n '2p' "$guarded_new")" = "$expected_capture" ] \
+    || fail "fm-send plain text: strict composer guard did not capture the composer before typing"
+  sed '1,2d' "$guarded_new" > "$filtered_new"
   diff -u "$filtered_old" "$filtered_new" > "$TMP_ROOT/send-diff-plain.txt" 2>&1 \
     || fail "fm-send plain text: tmux command log differs old vs new"$'\n'"$(cat "$TMP_ROOT/send-diff-plain.txt")"
   assert_contains "$(cat "$log_new")" $'\x1f''send-keys'$'\x1f''-t'$'\x1f''sess:win'$'\x1f''-l'$'\x1f''hello captain' \
@@ -733,11 +741,16 @@ test_send_conformance_old_vs_new() {
   rc_new=$?
   expect_code "$rc_old" "$rc_new" "fm-send /skill: old vs new exit code"
   strip_send_preflight "$log_old" > "$filtered_old"
-  strip_send_preflight "$log_new" > "$filtered_new"
+  strip_send_preflight "$log_new" > "$guarded_new"
+  [ "$(sed -n '1p' "$guarded_new")" = "$expected_cursor" ] \
+    || fail "fm-send /skill: strict composer guard did not read cursor position before typing"
+  [ "$(sed -n '2p' "$guarded_new")" = "$expected_capture" ] \
+    || fail "fm-send /skill: strict composer guard did not capture the composer before typing"
+  sed '1,2d' "$guarded_new" > "$filtered_new"
   diff -u "$filtered_old" "$filtered_new" > "$TMP_ROOT/send-diff-slash.txt" 2>&1 \
     || fail "fm-send /skill: tmux command log differs old vs new"$'\n'"$(cat "$TMP_ROOT/send-diff-slash.txt")"
 
-  pass "fm-send.sh: explicit tmux targets are verified, while --key/plain/slash send command shape stays old-compatible"
+  pass "fm-send.sh: explicit targets and empty composers are verified before old-compatible key/plain/slash submission"
 }
 
 # --- old vs new: fm-peek.sh --------------------------------------------------

--- a/tests/fm-bearings-report.test.sh
+++ b/tests/fm-bearings-report.test.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Behavior tests for create-exclusive Bearings report versioning.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+TMP_ROOT=$(fm_test_tmproot fm-bearings-report)
+WRITER="$ROOT/bin/fm-bearings-report.sh"
+
+test_prior_report_is_versioned_before_replacement() {
+  local home draft target archived receipt old_digest old_bytes
+  home="$TMP_ROOT/home"
+  mkdir -p "$home/data"
+  target="$home/data/status-report-2026-07-31.md"
+  draft="$home/draft.md"
+  printf '# Prior Bearings\nEvidence cited elsewhere.\n' > "$target"
+  printf '# Current Bearings\nFresh fleet state.\n' > "$draft"
+  old_digest=$(shasum -a 256 "$target" | awk '{print $1}')
+  old_bytes=$(wc -c < "$target" | tr -d '[:space:]')
+
+  FM_HOME="$home" FM_BEARINGS_REPORT_DATE=2026-07-31 "$WRITER" "$draft" >/dev/null \
+    || fail "Bearings report writer refused a valid replacement"
+  cmp -s "$target" "$draft" || fail "dated report did not receive the fresh draft"
+
+  archived=$(find "$home/data/status-report-versions" -type f ! -name '*.receipt' | head -1)
+  receipt=$(find "$home/data/status-report-versions" -type f -name '*.receipt' | head -1)
+  assert_present "$archived" "prior Bearings report was destroyed without a version"
+  assert_present "$receipt" "prior Bearings report has no custody receipt"
+  printf '# Prior Bearings\nEvidence cited elsewhere.\n' > "$home/expected-prior"
+  cmp -s "$archived" "$home/expected-prior" || fail "versioned report bytes changed"
+  assert_grep "sha256=$old_digest" "$receipt" "receipt digest does not bind the prior report"
+  assert_grep "bytes=$old_bytes" "$receipt" "receipt byte count does not bind the prior report"
+  assert_grep 'source_ref=' "$receipt" "receipt omitted the source ref"
+  assert_grep 'custody_class=bearings-prior-snapshot' "$receipt" "receipt omitted custody class"
+  assert_grep 'timestamp_utc=' "$receipt" "receipt omitted its pre-transition timestamp"
+  assert_grep "archived_path=$archived" "$receipt" "receipt does not link the preserved bytes"
+  pass "Bearings versions a prior same-day report with a pre-transition custody receipt"
+}
+
+test_repeated_replacements_never_overwrite_versions() {
+  local home draft count
+  home="$TMP_ROOT/repeat"
+  mkdir -p "$home/data"
+  draft="$home/draft.md"
+  printf 'version zero\n' > "$home/data/status-report-2026-07-31.md"
+  printf 'version one\n' > "$draft"
+  FM_HOME="$home" FM_BEARINGS_REPORT_DATE=2026-07-31 "$WRITER" "$draft" >/dev/null \
+    || fail "first replacement failed"
+  printf 'version two\n' > "$draft"
+  FM_HOME="$home" FM_BEARINGS_REPORT_DATE=2026-07-31 "$WRITER" "$draft" >/dev/null \
+    || fail "second replacement failed"
+  count=$(find "$home/data/status-report-versions" -type f ! -name '*.receipt' | wc -l | tr -d '[:space:]')
+  [ "$count" -eq 2 ] || fail "expected two create-exclusive versions, got $count"
+  pass "repeated Bearings replacements create unique versions"
+}
+
+test_prior_report_is_versioned_before_replacement
+test_repeated_replacements_never_overwrite_versions

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -209,6 +209,8 @@ test_ship_modes_generate_clean_briefs() {
     assert_grep "{TASK}" "$brief" "$id: brief missing the {TASK} placeholder"
     assert_grep "mid-task \`working:\` line (including setup complete) is nonterminal" "$brief" \
       "$id: brief missing nonterminal working:/setup-complete gate protection"
+    assert_no_grep "# Spec-forging contract - HARD GATE" "$brief" \
+      "$id: ordinary brief rendered the opt-in spec-forging contract"
     assert_no_grep "EOF" "$brief" "$id: brief leaked a heredoc EOF marker (unterminated heredoc)"
   done
   pass "fm-brief.sh: no-mistakes/direct-PR/local-only briefs generate cleanly"
@@ -363,6 +365,65 @@ test_herdr_lab_omission_is_loud_for_ship_and_scout() {
   pass "fm-brief.sh: ship and scout scaffolds make omitted Herdr intent fail-visible"
 }
 
+test_spec_forging_authority_contract() {
+  local home id brief kind missing variable err status
+  home="$TMP_ROOT/spec-forging-authority-home"
+  mkdir -p "$home/data"
+
+  for kind in ship scout; do
+    id="brief-spec-forging-$kind"
+    set --
+    [ "$kind" = scout ] && set -- --scout
+    FM_SPEC_FORGING_PRD='docs/product.md plus Cesar signature receipt' \
+      FM_SPEC_FORGING_AGENTS='AGENTS.md' \
+      FM_SPEC_FORGING_REPO='coreldh/example at /work/example; verify origin/main; push fork/fm/spec' \
+      FM_SPEC_FORGING_FILES='.kiro/specs/example requirements.md design.md tasks.md' \
+      FM_SPEC_FORGING_SLICE='slice one; deployment excluded' \
+      FM_SPEC_FORGING_VISUAL_GATE='not applicable; no UI' \
+      FM_SPEC_FORGING_SURFACE='commissioned Faber worker' \
+      FM_SPEC_FORGING_VALIDATION_GATE='independent reviewer receives path and sha' \
+      FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" example "$@" --spec-forging >/dev/null 2>&1
+    brief="$home/data/$id/brief.md"
+    assert_present "$brief" "$kind spec-forging brief was not scaffolded"
+    assert_grep "# Spec-forging contract - HARD GATE" "$brief" \
+      "$kind spec-forging brief lost its hard gate"
+    assert_grep "Architecture or scope changes return to Marco Antonio; the forger never authorizes or resolves them." "$brief" \
+      "$kind spec-forging brief let the forger self-resolve architecture or scope"
+    assert_grep "The architect is the Marco Antonio station or role and may be an explicitly commissioned worker." "$brief" \
+      "$kind spec-forging brief lost the commissioned-architect definition"
+    assert_grep "That worker never self-appoints and never signs for Cesar." "$brief" \
+      "$kind spec-forging brief let a worker self-appoint or sign for Cesar"
+    assert_grep "Agrippa is not the architect." "$brief" \
+      "$kind spec-forging brief mislabeled Agrippa as architect"
+    assert_grep "After legitimate authorization, the correction returns to an independent gate." "$brief" \
+      "$kind spec-forging brief lost independent re-gating after authorization"
+  done
+
+  for variable in \
+    FM_SPEC_FORGING_PRD FM_SPEC_FORGING_AGENTS FM_SPEC_FORGING_REPO \
+    FM_SPEC_FORGING_FILES FM_SPEC_FORGING_SLICE FM_SPEC_FORGING_VISUAL_GATE \
+    FM_SPEC_FORGING_SURFACE FM_SPEC_FORGING_VALIDATION_GATE; do
+    id="brief-spec-missing-${variable#FM_SPEC_FORGING_}"
+    missing=$(printf '%s' "$variable" | tr '[:upper:]_' '[:lower:]-')
+    err="$home/$missing.err"
+    status=0
+    env \
+      FM_SPEC_FORGING_PRD='prd' FM_SPEC_FORGING_AGENTS='agents' FM_SPEC_FORGING_REPO='repo' \
+      FM_SPEC_FORGING_FILES='files' FM_SPEC_FORGING_SLICE='slice' \
+      FM_SPEC_FORGING_VISUAL_GATE='visual' FM_SPEC_FORGING_SURFACE='surface' \
+      FM_SPEC_FORGING_VALIDATION_GATE='gate' "$variable=" FM_HOME="$home" \
+      "$ROOT/bin/fm-brief.sh" "$id" example --spec-forging >/dev/null 2>"$err" || status=$?
+    expect_code 1 "$status" "missing $variable must refuse spec-forging scaffold"
+    assert_absent "$home/data/$id" "missing $variable created a partial task directory"
+  done
+
+  status=0
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" brief-spec-secondmate --secondmate --no-projects --spec-forging \
+    >/dev/null 2>"$home/secondmate.err" || status=$?
+  expect_code 1 "$status" "secondmate charter must reject --spec-forging"
+  pass "fm-brief.sh: producer scope authority is fail-closed and never self-appointed"
+}
+
 test_secondmate_no_projects_charter() {
   local home brief status
   home="$TMP_ROOT/no-projects-home"
@@ -430,7 +491,7 @@ test_secondmate_marked_request_reporting_contract() {
     "secondmate charter did not limit keyed phases to reportable material changes"
   assert_grep "If its first reportable event is \`working [key=<work-slug>]: {material phase}\`" "$brief" \
     "secondmate charter lost keyed working syntax for a reportable material phase"
-  assert_grep "use the same key on its later \`paused\`, \`done\`, \`failed\`, \`needs-decision\`, or \`blocked\` event" "$brief" \
+  assert_grep "use the same key on its later \`paused\`, \`awaiting-captain\`, \`done\`, \`failed\`, \`needs-decision\`, or \`blocked\` event" "$brief" \
     "secondmate charter lost same-key closure for a reportable material phase"
   assert_grep 'resolved [key=<work-slug>]' "$brief" \
     "secondmate charter lost resolved closure for a keyed material phase"
@@ -445,8 +506,10 @@ test_secondmate_marked_request_reporting_contract() {
     "secondmate charter lost declared external waits"
   assert_grep 'a captain decision, a real blocker, a failure, or work ready for review' "$brief" \
     "secondmate charter lost decisions, blockers, failures, or ready outcomes"
-  assert_grep 'States: working, needs-decision, blocked, paused, done, failed.' "$brief" \
+  assert_grep 'States: working, needs-decision, blocked, paused, awaiting-captain, done, failed.' "$brief" \
     "secondmate charter changed the preserved status vocabulary"
+  assert_grep 'awaiting-captain [key=<slug>]' "$brief" \
+    "secondmate charter omitted the durable unbounded captain-wait vocabulary"
   pass "fm-brief.sh: marked requests avoid generic acknowledgements and preserve material reporting"
 }
 
@@ -579,7 +642,7 @@ test_pause_verb_override_renders_all_brief_scaffolds() {
         ;;
     esac
     brief="$home/data/$id/brief.md"
-    assert_grep "States: working, needs-decision, blocked, awaiting, done, failed." "$brief" \
+    assert_grep "States: working, needs-decision, blocked, awaiting, awaiting-captain, done, failed." "$brief" \
       "$kind brief did not render the configured pause verb in its states list"
     # shellcheck disable=SC2016 # Literal backticks and braces must remain unexpanded.
     assert_grep 'Use `awaiting: {why}`' "$brief" \
@@ -642,6 +705,7 @@ test_ship_project_memory_wording
 test_herdr_lab_contract_is_explicit_and_complete
 test_herdr_lab_contract_quotes_foreign_firstmate_path
 test_herdr_lab_omission_is_loud_for_ship_and_scout
+test_spec_forging_authority_contract
 test_herdr_lab_contract_applies_to_scouts_but_not_secondmates
 test_secondmate_no_projects_charter
 test_secondmate_marked_request_reporting_contract

--- a/tests/fm-crew-state.test.sh
+++ b/tests/fm-crew-state.test.sh
@@ -71,6 +71,9 @@ case "${1:-}" in
         if [ "${1:-}" = --run ]; then printf '%s\n' "${FM_FAKE_AXI_STATUS_RUN:-}"
         else printf '%s\n' "${FM_FAKE_AXI_STATUS:-}"; fi ;;
       logs)
+        if [ "${FM_FAKE_WORKER_LOG_UNAVAILABLE:-0}" != 1 ]; then
+          printf 'codex started pid=4242\n'
+        fi
         printf '%s\n' "${FM_FAKE_CI_LOGS:-}" ;;
     esac
     ;;
@@ -180,10 +183,11 @@ reset_fakes() {
   FM_FAKE_HERDR_MISSING=0
   FM_FAKE_HERDR_AGENT_STATUS=""
   FM_FAKE_CI_LOGS=""
-  FM_FAKE_WORKER_PS_STATE=""
+  FM_FAKE_WORKER_PS_STATE='S+'
+  FM_FAKE_WORKER_LOG_UNAVAILABLE=0
   export FM_FAKE_AXI_STATUS FM_FAKE_AXI_STATUS_RUN FM_FAKE_RUNS_LIST FM_FAKE_BUSY FM_FAKE_BUSY_TEXT FM_FAKE_TMUX_MISSING
   export FM_FAKE_HERDR_BUSY FM_FAKE_HERDR_MISSING FM_FAKE_HERDR_AGENT_STATUS FM_FAKE_CI_LOGS
-  export FM_FAKE_WORKER_PS_STATE
+  export FM_FAKE_WORKER_PS_STATE FM_FAKE_WORKER_LOG_UNAVAILABLE
 }
 
 # --- run-object fixtures (TOON, as `no-mistakes axi status` emits) -----------
@@ -409,6 +413,24 @@ test_dead_or_suspended_pipeline_worker_is_not_recorded_working() {
   assert_contains "$out" 'headless pipeline worker suspended pid=4242' \
     "suspended step worker was not distinguished from a live worker"
   pass "dead and suspended headless workers never inherit a stale running verdict"
+}
+
+test_unbound_pipeline_worker_is_indeterminate() {
+  reset_fakes
+  local d out
+  d=$(new_case headless-unbound)
+  make_repo_on_branch "$d/wt" fm/headless-unbound
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/headless-unbound.meta" "window=fm:fm-headless-unbound" "worktree=$d/wt" "kind=ship" "harness=codex"
+  FM_FAKE_AXI_STATUS="$(run_running fm/headless-unbound)"
+  FM_FAKE_CI_LOGS='pipeline log shape without a native worker pid'
+  FM_FAKE_WORKER_LOG_UNAVAILABLE=1
+  out=$(run_crew_state "$d" headless-unbound)
+  assert_contains "$out" 'state: unknown' \
+    "PID-unbound run inherited a live verdict from the stale running ledger"
+  assert_contains "$out" 'headless worker identity unavailable' \
+    "PID-unbound run did not report its process-level evidence limit"
+  pass "PID-unbound pipeline workers remain indeterminate rather than guessed live or dead"
 }
 
 # (b) needs-decision log + a resumed (running/fixing) run = SUPERSEDED
@@ -1365,6 +1387,7 @@ test_missing_run_head_falls_back_to_current_state() {
 test_active_run_is_authoritative
 test_headless_pipeline_worker_liveness_overrides_pane_interruption
 test_dead_or_suspended_pipeline_worker_is_not_recorded_working
+test_unbound_pipeline_worker_is_indeterminate
 test_stale_needs_decision_superseded
 test_stale_blocked_superseded
 test_genuine_parked_not_superseded

--- a/tests/fm-crew-state.test.sh
+++ b/tests/fm-crew-state.test.sh
@@ -122,7 +122,17 @@ case "${1:-}" in
 esac
 exit 0
 SH
-  chmod +x "$fb/no-mistakes" "$fb/tmux" "$fb/herdr"
+  cat > "$fb/ps" <<'SH'
+#!/usr/bin/env bash
+set -u
+if printf '%s\n' "$*" | grep -F -- '-p 4242' >/dev/null; then
+  [ -n "${FM_FAKE_WORKER_PS_STATE:-}" ] || exit 1
+  printf '%s codex native worker\n' "$FM_FAKE_WORKER_PS_STATE"
+  exit 0
+fi
+exec /bin/ps "$@"
+SH
+  chmod +x "$fb/no-mistakes" "$fb/tmux" "$fb/herdr" "$fb/ps"
   printf '%s\n' "$fb"
 }
 
@@ -170,8 +180,10 @@ reset_fakes() {
   FM_FAKE_HERDR_MISSING=0
   FM_FAKE_HERDR_AGENT_STATUS=""
   FM_FAKE_CI_LOGS=""
+  FM_FAKE_WORKER_PS_STATE=""
   export FM_FAKE_AXI_STATUS FM_FAKE_AXI_STATUS_RUN FM_FAKE_RUNS_LIST FM_FAKE_BUSY FM_FAKE_BUSY_TEXT FM_FAKE_TMUX_MISSING
   export FM_FAKE_HERDR_BUSY FM_FAKE_HERDR_MISSING FM_FAKE_HERDR_AGENT_STATUS FM_FAKE_CI_LOGS
+  export FM_FAKE_WORKER_PS_STATE
 }
 
 # --- run-object fixtures (TOON, as `no-mistakes axi status` emits) -----------
@@ -356,6 +368,47 @@ test_active_run_is_authoritative() {
   assert_contains "$out" "source: run-step" "active run -> run-step source"
   assert_contains "$out" "validating (running)" "active run reports the step"
   pass "active run-step is authoritative"
+}
+
+test_headless_pipeline_worker_liveness_overrides_pane_interruption() {
+  reset_fakes
+  local d out
+  d=$(new_case headless-live)
+  make_repo_on_branch "$d/wt" fm/headless-live
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/headless-live.meta" "window=fm:fm-headless-live" "worktree=$d/wt" "kind=ship" "harness=codex"
+  FM_FAKE_AXI_STATUS="$(run_running fm/headless-live)"
+  FM_FAKE_CI_LOGS='codex started pid=4242'
+  FM_FAKE_WORKER_PS_STATE='S+'
+  FM_FAKE_TMUX_MISSING=1
+  out=$(run_crew_state "$d" headless-live)
+  assert_contains "$out" 'state: working' "live detached worker was recorded halted with its pane gone"
+  assert_contains "$out" 'headless pipeline worker live pid=4242' \
+    "run-step did not distinguish the detached worker from its interrupted pane"
+  pass "live headless pipeline worker remains working independently of pane interruption"
+}
+
+test_dead_or_suspended_pipeline_worker_is_not_recorded_working() {
+  reset_fakes
+  local d out
+  d=$(new_case headless-dead)
+  make_repo_on_branch "$d/wt" fm/headless-dead
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/headless-dead.meta" "window=fm:fm-headless-dead" "worktree=$d/wt" "kind=ship" "harness=codex"
+  FM_FAKE_AXI_STATUS="$(run_running fm/headless-dead)"
+  FM_FAKE_CI_LOGS='codex started pid=4242'
+  FM_FAKE_WORKER_PS_STATE=''
+  out=$(run_crew_state "$d" headless-dead)
+  assert_not_contains "$out" 'state: working' "dead step worker inherited the stale running row"
+  assert_contains "$out" 'headless pipeline worker dead pid=4242' \
+    "dead step worker was not distinguished from the run record"
+
+  FM_FAKE_WORKER_PS_STATE='T'
+  out=$(run_crew_state "$d" headless-dead)
+  assert_not_contains "$out" 'state: working' "suspended step worker inherited the stale running row"
+  assert_contains "$out" 'headless pipeline worker suspended pid=4242' \
+    "suspended step worker was not distinguished from a live worker"
+  pass "dead and suspended headless workers never inherit a stale running verdict"
 }
 
 # (b) needs-decision log + a resumed (running/fixing) run = SUPERSEDED
@@ -1310,6 +1363,8 @@ test_missing_run_head_falls_back_to_current_state() {
 }
 
 test_active_run_is_authoritative
+test_headless_pipeline_worker_liveness_overrides_pane_interruption
+test_dead_or_suspended_pipeline_worker_is_not_recorded_working
 test_stale_needs_decision_superseded
 test_stale_blocked_superseded
 test_genuine_parked_not_superseded

--- a/tests/fm-daemon.test.sh
+++ b/tests/fm-daemon.test.sh
@@ -1827,6 +1827,29 @@ test_inject_msg_defers_on_unrecognized_composer_state() {
   pass "inject_msg: unrecognized composer states defer by default"
 }
 
+test_inject_msg_defers_on_registered_model_capacity_hold() {
+  local dir state touched
+  dir=$(make_supercase inject-model-capacity-hold)
+  state="$dir/state"
+  touched="$dir/backend-called"
+  afk_enter "$state"
+  cat > "$state/.model-capacity-hold" <<'EOF'
+schema=fm-model-capacity-hold.v1
+hold_id=reserve-daemon
+reason=capacity reserved for another dispatch
+dispatch_ref=dispatch reserve-daemon
+registered_at=2026-07-31T00:00:00Z
+EOF
+  (
+    fm_backend_target_exists() { : > "$touched"; return 0; }
+    if FM_SUPERVISOR_BACKEND=herdr FM_SUPERVISOR_TARGET="default:w1:p2" inject_msg "hello" "$state"; then
+      fail "inject_msg should defer while a registered model-capacity hold is active"
+    fi
+  ) || fail "model-capacity-held inject_msg subshell failed"
+  assert_absent "$touched" "held injection reached the backend before refusing"
+  pass "inject_msg: registered model-capacity hold preserves the buffer before backend work"
+}
+
 test_afk_start_refuses_when_flag_cannot_be_written
 test_afk_start_ignores_stale_pidfile_without_lock
 test_afk_start_reclaims_stale_daemon_lock_reused_pid
@@ -1926,3 +1949,4 @@ test_inject_msg_herdr_pane_gone_defers
 test_inject_msg_herdr_submits_through_backend_dispatch
 test_inject_msg_defers_on_dead_shell_unknown
 test_inject_msg_defers_on_unrecognized_composer_state
+test_inject_msg_defers_on_registered_model_capacity_hold

--- a/tests/fm-decision-hold-lifecycle.test.sh
+++ b/tests/fm-decision-hold-lifecycle.test.sh
@@ -111,6 +111,7 @@ write_origin_meta() {  # <home> <id> [kind]
   local home=$1 id=$2 kind=${3:-scout}
   fm_write_meta "$home/state/$id.meta" \
     "window=firstmate:fm-$id" \
+    "endpoint_task_id=$id" \
     "worktree=$home/projects/missing-$id" \
     "project=$home/projects/sample" \
     "harness=codex" \
@@ -119,7 +120,7 @@ write_origin_meta() {  # <home> <id> [kind]
 }
 
 test_structured_holds_survive_teardown_and_route_resolution() {
-  local home id route_hold access_hold before after json open show
+  local home id route_hold access_hold before after json open show hold_receipt resolved_receipt decision_object saved_receipt invisible_bearings
   home=$(make_home durable-lifecycle)
   id=sample-systems-review
   mkdir -p "$home/data/$id"
@@ -167,6 +168,21 @@ EOF
     || fail "shared investigation completion gate failed"
   assert_grep "decisions_reviewed=1" "$home/state/$id.meta" "completion attestation missing"
   assert_grep "decision_keys=access,route" "$home/state/$id.meta" "decision inventory was not deterministic"
+  hold_receipt="$home/data/decision-hold-receipts/$route_hold.hold"
+  assert_present "$hold_receipt" "completion did not create a durable cleanup receipt"
+  assert_grep "schema=fm-decision-hold-receipt.v1" "$hold_receipt" \
+    "cleanup receipt lost its schema"
+  assert_grep "origin_id=$id" "$hold_receipt" "cleanup receipt lost task identity"
+  assert_grep "dispatch_id=$id" "$hold_receipt" "cleanup receipt lost dispatch identity"
+  assert_grep "hold_id=$route_hold" "$hold_receipt" "cleanup receipt lost hold identity"
+  grep -Eq '^object_sha256=[0-9a-f]{64}$' "$hold_receipt" \
+    || fail "cleanup receipt object digest is absent, zero, or malformed"
+  assert_no_grep "object_sha256=0000000000000000000000000000000000000000000000000000000000000000" "$hold_receipt" \
+    "cleanup receipt object digest is all zeroes"
+  grep -Eq '^bearings_sha256=[0-9a-f]{64}$' "$hold_receipt" \
+    || fail "cleanup receipt Bearings digest is absent, zero, or malformed"
+  assert_no_grep "bearings_sha256=0000000000000000000000000000000000000000000000000000000000000000" "$hold_receipt" \
+    "cleanup receipt Bearings digest is all zeroes"
   open=$(bash -c '. "$1"; status_open_decisions "$2"' _ \
     "$ROOT/bin/fm-classify-lib.sh" "$home/state/$id.status")
   [ -z "$open" ] || fail "captain-held transfer did not close duplicate live status decisions: $open"
@@ -180,6 +196,36 @@ EOF
       and (.decisions_open | any(.id == $access and .verb == "captain-hold" and .owner == "(main)"))
       and (.gates | any(.id == $route or .id == $access) | not)
   ' >/dev/null || fail "Bearings did not surface structured captain holds: $json"
+
+  saved_receipt=$(cat "$hold_receipt")
+  sed 's/^dispatch_id=.*/dispatch_id=other-dispatch/' "$hold_receipt" > "$hold_receipt.tmp"
+  mv "$hold_receipt.tmp" "$hold_receipt"
+  if run_teardown "$home" "$id" >"$home/unresolved-wrong-dispatch.out" 2>"$home/unresolved-wrong-dispatch.err"; then
+    fail "unresolved cleanup receipt with a wrong dispatch identity allowed teardown"
+  fi
+  assert_present "$home/state/$id.meta" "wrong-dispatch refusal removed scout metadata"
+  printf '%s\n' "$saved_receipt" > "$hold_receipt"
+
+  sed 's/^object_sha256=.*/object_sha256=0000000000000000000000000000000000000000000000000000000000000000/' \
+    "$hold_receipt" > "$hold_receipt.tmp"
+  mv "$hold_receipt.tmp" "$hold_receipt"
+  if run_teardown "$home" "$id" >"$home/unresolved-zero-digest.out" 2>"$home/unresolved-zero-digest.err"; then
+    fail "unresolved cleanup receipt with an all-zero digest allowed teardown"
+  fi
+  assert_present "$home/state/$id.meta" "zero-digest refusal removed scout metadata"
+  printf '%s\n' "$saved_receipt" > "$hold_receipt"
+
+  invisible_bearings="$home/invisible-bearings"
+  cat > "$invisible_bearings" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' '{"schema":"fm-bearings.v1","decisions_open":[]}'
+EOF
+  chmod +x "$invisible_bearings"
+  if FM_DECISION_HOLD_BEARINGS="$invisible_bearings" run_teardown "$home" "$id" \
+    >"$home/unresolved-invisible.out" 2>"$home/unresolved-invisible.err"; then
+    fail "unresolved hold absent from fresh Bearings still allowed teardown"
+  fi
+  assert_present "$home/state/$id.meta" "Bearings-invisible refusal removed scout metadata"
 
   run_teardown "$home" "$id" >/dev/null 2> "$home/teardown.err" \
     || fail "reviewed investigation teardown failed: $(cat "$home/teardown.err")"
@@ -248,6 +294,34 @@ EOF
   run_decisions "$home" resolve "$id" route --decision-file "$home/route-decision.txt" \
     --routed-to sample-route-implementation --routed-to sample-route-followup >/dev/null \
     || fail "could not resume and complete partial decision routing"
+  resolved_receipt="$home/data/decision-hold-receipts/$route_hold.resolved"
+  decision_object="$home/data/decision-hold-receipts/$route_hold.decision.md"
+  assert_present "$resolved_receipt" "resolved hold did not create its trusted receipt"
+  assert_present "$decision_object" "resolved hold did not retain the digest-bound decision object"
+  assert_grep "origin_id=$id" "$resolved_receipt" "resolution receipt lost task identity"
+  assert_grep "dispatch_id=$id" "$resolved_receipt" "resolution receipt lost dispatch identity"
+  assert_grep "routed_ids=sample-route-followup,sample-route-implementation" "$resolved_receipt" \
+    "resolution receipt lost its routed task identities"
+  grep -Eq '^decision_sha256=[0-9a-f]{64}$' "$resolved_receipt" \
+    || fail "resolution receipt decision digest is absent, zero, or malformed"
+  assert_no_grep "decision_sha256=0000000000000000000000000000000000000000000000000000000000000000" "$resolved_receipt" \
+    "resolution receipt decision digest is all zeroes"
+  run_decisions "$home" verify-resolution "$id" route >/dev/null \
+    || fail "fresh trusted resolution receipt did not verify"
+  saved_receipt=$(cat "$resolved_receipt")
+  sed 's/^dispatch_id=.*/dispatch_id=some-other-dispatch/' "$resolved_receipt" > "$resolved_receipt.tmp"
+  mv "$resolved_receipt.tmp" "$resolved_receipt"
+  if run_decisions "$home" verify-resolution "$id" route >"$home/wrong-dispatch.out" 2>"$home/wrong-dispatch.err"; then
+    fail "resolution receipt with the wrong dispatch identity verified"
+  fi
+  printf '%s\n' "$saved_receipt" > "$resolved_receipt"
+  mv "$decision_object" "$decision_object.missing"
+  if run_decisions "$home" verify-resolution "$id" route >"$home/missing-object.out" 2>"$home/missing-object.err"; then
+    fail "resolution receipt verified while its decision object path was absent"
+  fi
+  mv "$decision_object.missing" "$decision_object"
+  run_decisions "$home" verify-resolution "$id" route >/dev/null \
+    || fail "restored trusted resolution receipt did not verify"
   run_decisions "$home" resolve "$id" route --decision-file "$home/route-decision.txt" \
     --routed-to sample-route-implementation --routed-to sample-route-followup >/dev/null \
     || fail "identical resolution retry was not idempotent"
@@ -274,6 +348,102 @@ EOF
       and (.decisions_open | any(.id == "sample-systems-review") | not)
   ' >/dev/null || fail "resolved or decision-like report prose produced a false hold: $json"
   pass "captain holds are idempotent, distinct, teardown-safe, Bearings-visible, and durably routed before close"
+}
+
+write_done_resolution_row() {  # <home> <hold-id> <digest> <routed-id> [body-marker]
+  local home=$1 hold=$2 digest=$3 routed=$4 marker=${5:-Routed work:}
+  cat >> "$home/data/backlog.md" <<EOF
+- [x] $hold - Historical route choice (repo: sample) (kind: captain) (done 2026-07-31)
+  Resolution recorded by fm-decision-hold.
+  Decision digest: $digest
+  Routed identities: $routed
+
+  Captain decision:
+  Use the historical route.
+
+  $marker
+  - $routed
+EOF
+}
+
+test_resolution_receipt_attack_constructions_refuse() {
+  local home origin hold digest case_name duplicate_row
+  digest=123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0
+  for case_name in absent malformed duplicate wrong-origin faithful zero-digest; do
+    home=$(make_home "receipt-attack-$case_name")
+    origin="sample-$case_name-review"
+    hold="$origin-decision-route"
+    mkdir -p "$home/data/$origin"
+    write_origin_meta "$home" "$origin"
+    printf '# Historical review\n' > "$home/data/$origin/report.md"
+    tasks_in "$home" add routed-task "Routed task" --kind ship --repo sample >/dev/null
+    case "$case_name" in
+      absent) : ;;
+      malformed) write_done_resolution_row "$home" "$hold" "$digest" routed-task "Routed identities only:" ;;
+      duplicate)
+        write_done_resolution_row "$home" "$hold" "$digest" routed-task
+        duplicate_row=$(awk -v prefix="- [x] $hold - " '
+          index($0, prefix) == 1 {capture=1}
+          capture {print}
+        ' "$home/data/backlog.md")
+        printf '%s\n' "$duplicate_row" >> "$home/data/done-archive.md"
+        ;;
+      wrong-origin) write_done_resolution_row "$home" "different-review-decision-route" "$digest" routed-task ;;
+      faithful) write_done_resolution_row "$home" "$hold" "$digest" routed-task ;;
+      zero-digest) write_done_resolution_row "$home" "$hold" \
+        0000000000000000000000000000000000000000000000000000000000000000 routed-task ;;
+    esac
+    if run_decisions "$home" verify-resolution "$origin" route \
+      >"$home/$case_name.out" 2>"$home/$case_name.err"; then
+      fail "$case_name hand-written or indeterminate resolution construction verified"
+    fi
+  done
+  assert_grep "trusted cleanup receipt" "$TMP_ROOT/receipt-attack-faithful/faithful.err" \
+    "faithful hand-written historical row did not refuse for missing authority receipt"
+  assert_grep "preserve the origin and row" "$TMP_ROOT/receipt-attack-faithful/faithful.err" \
+    "historical resolved-row refusal did not name the non-destructive operator remedy"
+  assert_grep "no safe automatic migration is shipped" "$TMP_ROOT/receipt-attack-faithful/faithful.err" \
+    "historical resolved-row refusal promised an unavailable migration"
+  assert_grep "nonzero" "$TMP_ROOT/receipt-attack-zero-digest/zero-digest.err" \
+    "all-zero historical decision digest did not fail explicitly"
+  pass "absent, malformed, duplicate, wrong-origin, hand-written, and zero-digest resolution rows refuse"
+}
+
+test_historical_open_inventory_diagnostics_name_safe_remedies() {
+  local home origin hold receipt meta_tmp
+  home=$(make_home historical-open-remedy)
+  origin=sample-historical-open-review
+  mkdir -p "$home/data/$origin"
+  write_origin_meta "$home" "$origin"
+  printf '# Historical open review\n' > "$home/data/$origin/report.md"
+  hold=$(run_decisions "$home" hold "$origin" route \
+    --title "Choose the historical route" --reason "captain route choice pending" --repo sample) \
+    || fail "could not register historical-open hold fixture"
+  run_decisions "$home" complete "$origin" route >/dev/null \
+    || fail "could not complete historical-open inventory fixture"
+  receipt="$home/data/decision-hold-receipts/$hold.hold"
+  assert_present "$receipt" "historical-open fixture did not establish its cleanup receipt"
+  rm "$receipt"
+
+  if run_decisions "$home" verify "$origin" >"$home/open.out" 2>"$home/open.err"; then
+    fail "historical open inventory without a receipt unexpectedly verified"
+  fi
+  assert_grep "re-run complete $origin with its full recorded decision inventory" "$home/open.err" \
+    "repairable historical open inventory did not name the safe complete retry"
+  assert_grep "only while the hold remains open and the exact dispatch binding survives" "$home/open.err" \
+    "historical open remedy overstated when receipt reconstruction is safe"
+
+  meta_tmp="$home/state/$origin.meta.next"
+  grep -v '^endpoint_task_id=' "$home/state/$origin.meta" > "$meta_tmp"
+  mv "$meta_tmp" "$home/state/$origin.meta"
+  if run_decisions "$home" verify "$origin" >"$home/bindingless.out" 2>"$home/bindingless.err"; then
+    fail "binding-less historical inventory unexpectedly verified"
+  fi
+  assert_grep "preserve origin metadata and holds" "$home/bindingless.err" \
+    "binding-less historical refusal did not preserve the only authoritative evidence"
+  assert_grep "no safe automatic migration is shipped" "$home/bindingless.err" \
+    "binding-less historical refusal promised an unavailable migration"
+  pass "historical open and binding-less refusals name only safe operator remedies"
 }
 
 test_scout_teardown_always_requires_inventory_verification() {
@@ -324,7 +494,7 @@ test_origin_slug_validation_precedes_path_construction() {
 }
 
 test_visual_review_uses_shared_completion_owner() {
-  local home id hold json
+  local home id hold json origin_receipt hold_receipt saved_origin routed decision
   home=$(make_home visual-review)
   id=sample-board-review
   mkdir -p "$home/data/$id"
@@ -334,6 +504,13 @@ test_visual_review_uses_shared_completion_owner() {
   printf '# Sample board investigation\n\nThe initial findings need no captain choice.\n' > "$home/data/$id/report.md"
   run_decisions "$home" complete "$id" --none >/dev/null \
     || fail "initial investigation could not pass the shared completion owner"
+  origin_receipt="$home/data/decision-hold-receipts/$id.origin"
+  assert_present "$origin_receipt" "empty initial inventory did not preserve its dispatch carrier"
+  assert_grep "origin_id=$id" "$origin_receipt" "dispatch carrier lost its task identity"
+  assert_grep "dispatch_id=$id" "$origin_receipt" "dispatch carrier lost its endpoint identity"
+  assert_grep "origin_path=$home/data/$id/report.md" "$origin_receipt" "dispatch carrier lost its exact report path"
+  grep -Eq '^origin_sha256=[0-9a-f]{64}$' "$origin_receipt" \
+    || fail "dispatch carrier source digest is absent, zero, or malformed"
   run_teardown "$home" "$id" >/dev/null 2> "$home/visual-teardown.err" \
     || fail "completed investigation teardown failed: $(cat "$home/visual-teardown.err")"
   tasks_in "$home" "done" "$id" --report "data/$id/report.md" --keep 0 >/dev/null
@@ -343,8 +520,17 @@ test_visual_review_uses_shared_completion_owner() {
   hold=$(run_decisions "$home" hold "$id" layout \
     --title "Choose the sample layout" --reason "captain layout choice pending" --repo sample) \
     || fail "post-teardown visual review could not use the shared hold owner"
+  saved_origin=$(cat "$origin_receipt")
+  sed 's#^origin_path=.*#origin_path=/tmp/forged-report.md#' "$origin_receipt" > "$origin_receipt.tmp"
+  mv "$origin_receipt.tmp" "$origin_receipt"
+  if run_decisions "$home" complete "$id" layout >"$home/forged-origin.out" 2>"$home/forged-origin.err"; then
+    fail "post-teardown completion accepted a forged report path"
+  fi
+  printf '%s\n' "$saved_origin" > "$origin_receipt"
   run_decisions "$home" complete "$id" layout >/dev/null \
     || fail "post-teardown visual review could not use the shared completion owner"
+  hold_receipt="$home/data/decision-hold-receipts/$hold.hold"
+  assert_present "$hold_receipt" "post-teardown completion did not create a cleanup receipt"
   [ "$hold" = "$id-decision-layout" ] || fail "visual review used a separate identity policy"
   json=$(run_bearings "$home") || fail "Bearings failed after the ended visual review"
   printf '%s' "$json" | jq -e --arg hold "$hold" '
@@ -352,7 +538,40 @@ test_visual_review_uses_shared_completion_owner() {
   ' >/dev/null || fail "ended visual review did not leave its durable Captain Call: $json"
   [ ! -e "$home/data/visual-review-decisions.json" ] \
     || fail "visual review created a second decision database"
+  routed=sample-layout-implementation
+  tasks_in "$home" add "$routed" "Apply the selected sample layout" --kind ship --repo sample >/dev/null
+  tasks_in "$home" block "$routed" --by "$hold" >/dev/null
+  decision="$home/layout-decision.txt"
+  printf 'Use the compact sample layout.\n' > "$decision"
+  run_decisions "$home" resolve "$id" layout --decision-file "$decision" --routed-to "$routed" >/dev/null \
+    || fail "post-teardown hold could not route its trusted resolution"
+  run_decisions "$home" verify-resolution "$id" layout >/dev/null \
+    || fail "post-teardown resolution receipt did not verify"
   pass "ended visual review follows the same decision-hold completion owner"
+}
+
+test_post_teardown_handwritten_resolution_refuses_completion() {
+  local home origin hold digest
+  home=$(make_home post-teardown-handwritten)
+  origin=sample-post-teardown-review
+  hold="$origin-decision-route"
+  digest=123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0
+  mkdir -p "$home/data/$origin"
+  tasks_in "$home" add "$origin" "Review the historical route" --kind scout --repo sample --start >/dev/null
+  write_origin_meta "$home" "$origin"
+  printf 'done: report complete\n' > "$home/state/$origin.status"
+  printf '# Historical route review\n\nNo initial captain choice.\n' > "$home/data/$origin/report.md"
+  run_decisions "$home" complete "$origin" --none >/dev/null
+  run_teardown "$home" "$origin" >/dev/null 2>"$home/teardown.err"
+  tasks_in "$home" "done" "$origin" --report "data/$origin/report.md" --keep 0 >/dev/null
+  tasks_in "$home" add routed-task "Routed task" --kind ship --repo sample >/dev/null
+  write_done_resolution_row "$home" "$hold" "$digest" routed-task
+  if run_decisions "$home" complete "$origin" route >"$home/complete.out" 2>"$home/complete.err"; then
+    fail "post-teardown completion trusted a hand-written resolved row"
+  fi
+  assert_grep "trusted cleanup receipt" "$home/complete.err" \
+    "post-teardown hand-written row did not refuse for missing script authority"
+  pass "post-teardown completion rejects hand-written resolved rows"
 }
 
 test_none_inventory_and_resolved_prose_do_not_create_holds() {
@@ -481,6 +700,8 @@ test_resolve_matches_quoted_blocked_by_edges() {
   hold_absent=$(run_decisions "$home" hold "$origin" edge-absent \
     --title "Absent edge decision" --reason "captain absent pending" --repo sample) \
     || fail "could not register absent-edge hold"
+  run_decisions "$home" complete "$origin" edge-first edge-mid edge-last edge-absent >/dev/null \
+    || fail "could not record dispatch-bound cleanup receipts for quote-edge holds"
 
   tasks_in "$home" add pad-a "Pad A" --kind ship --repo sample >/dev/null \
     || fail "could not create pad-a blocker"
@@ -556,7 +777,10 @@ test_scout_teardown_always_requires_inventory_verification
 test_structured_holds_survive_teardown_and_route_resolution
 test_origin_slug_validation_precedes_path_construction
 test_visual_review_uses_shared_completion_owner
+test_post_teardown_handwritten_resolution_refuses_completion
 test_none_inventory_and_resolved_prose_do_not_create_holds
 test_terminal_single_owner_status_decision_does_not_block_empty_inventory
 test_secondmate_hold_stays_in_authoritative_home
 test_resolve_matches_quoted_blocked_by_edges
+test_historical_open_inventory_diagnostics_name_safe_remedies
+test_resolution_receipt_attack_constructions_refuse

--- a/tests/fm-model-capacity-hold.test.sh
+++ b/tests/fm-model-capacity-hold.test.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# Behavior tests for durable model-capacity holds on Firstmate-controlled paths.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+TMP_ROOT=$(fm_test_tmproot fm-model-capacity-hold)
+HOLD="$ROOT/bin/fm-model-capacity-hold.sh"
+SEND="$ROOT/bin/fm-send.sh"
+SPAWN="$ROOT/bin/fm-spawn.sh"
+
+make_home() {
+  local home=$1
+  mkdir -p "$home/state" "$home/data" "$home/fakebin"
+  fm_write_meta "$home/state/lane.meta" 'window=test:fm-lane' 'kind=ship' 'harness=codex'
+  cat > "$home/fakebin/tmux" <<'SH'
+#!/usr/bin/env bash
+case "${1:-}" in
+  display-message) printf '1\n' ;;
+  capture-pane) printf '╭────╮\n│    │\n╰────╯\n' ;;
+  send-keys) printf '%s\n' "$*" >> "$FM_HOLD_SEND_LOG" ;;
+esac
+SH
+  fm_fake_exit0 "$home/fakebin" sleep
+  chmod +x "$home/fakebin/tmux"
+}
+
+test_registered_hold_blocks_send_until_digest_bound_release() {
+  local home log err authority rc
+  home="$TMP_ROOT/home"
+  make_home "$home"
+  log="$home/send.log"
+  err="$home/send.err"
+  authority="$home/release-authority.txt"
+  : > "$log"
+
+  FM_HOME="$home" "$HOLD" register reserve-night \
+    --reason 'captain reserved model capacity' --dispatch-ref 'cm31r2 dispatch 2026-07-31' >/dev/null \
+    || fail "could not register a model-capacity hold"
+  rc=0
+  PATH="$home/fakebin:$PATH" FM_HOME="$home" FM_ROOT_OVERRIDE="$home" \
+    FM_HOLD_SEND_LOG="$log" FM_SEND_SETTLE=0 "$SEND" lane 'new model work' \
+    >/dev/null 2>"$err" || rc=$?
+  [ "$rc" -ne 0 ] || fail "registered model-capacity hold allowed a text steer"
+  [ ! -s "$log" ] || fail "held text steer reached the backend"
+  assert_grep 'model-capacity hold reserve-night is active' "$err" \
+    "held send did not identify the active durable hold"
+
+  printf 'Captain released reserve-night after the protected dispatch ended.\n' > "$authority"
+  FM_HOME="$home" "$HOLD" release reserve-night --authority-file "$authority" >/dev/null \
+    || fail "could not release the registered hold"
+  PATH="$home/fakebin:$PATH" FM_HOME="$home" FM_ROOT_OVERRIDE="$home" \
+    FM_HOLD_SEND_LOG="$log" FM_SEND_SETTLE=0 "$SEND" lane 'new model work' \
+    >/dev/null 2>"$err" || fail "released hold still blocked text delivery"
+  [ -s "$log" ] || fail "released send never reached the backend"
+  find "$home/data/model-capacity-holds" -name 'reserve-night.registered' -type f | grep . >/dev/null \
+    || fail "registration receipt disappeared on release"
+  release_receipt=$(find "$home/data/model-capacity-holds" -name 'reserve-night.released' -type f | head -1)
+  assert_present "$release_receipt" "release has no durable receipt"
+  authority_digest=$(shasum -a 256 "$authority" | awk '{print $1}')
+  assert_grep "authority_sha256=$authority_digest" "$release_receipt" \
+    "release receipt is not bound to its authority object"
+  pass "registered model-capacity hold blocks sends until a digest-bound release"
+}
+
+test_registered_hold_blocks_spawn_before_fleet_mutation() {
+  local home err rc
+  home="$TMP_ROOT/spawn-home"
+  make_home "$home"
+  err="$home/spawn.err"
+  FM_HOME="$home" "$HOLD" register reserve-spawn \
+    --reason 'capacity reserved for another dispatch' --dispatch-ref 'dispatch reserve-spawn' >/dev/null \
+    || fail "could not register the spawn hold"
+
+  rc=0
+  FM_HOME="$home" FM_ROOT_OVERRIDE="$ROOT" "$SPAWN" new-lane sample \
+    >/dev/null 2>"$err" || rc=$?
+  [ "$rc" -ne 0 ] || fail "registered model-capacity hold allowed a spawn"
+  assert_grep 'model-capacity hold reserve-spawn is active' "$err" \
+    "held spawn did not identify the active durable hold"
+  assert_absent "$home/state/new-lane.meta" "held spawn mutated fleet metadata before refusing"
+  assert_absent "$home/data/new-lane" "held spawn created task data before refusing"
+  pass "registered model-capacity hold blocks spawn before fleet mutation"
+}
+
+test_registered_hold_blocks_send_until_digest_bound_release
+test_registered_hold_blocks_spawn_before_fleet_mutation

--- a/tests/fm-record-reconcile.test.sh
+++ b/tests/fm-record-reconcile.test.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# Behavior tests for non-destructive fleet-record reconciliation.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+TMP_ROOT=$(fm_test_tmproot fm-record-reconcile)
+RECONCILE="$ROOT/bin/fm-record-reconcile.sh"
+
+test_terminal_row_reconciles_while_unlanded_work_remains() {
+  local home wt dirty_wt receipt head
+  home="$TMP_ROOT/home"
+  wt="$home/projects/sample-terminal"
+  mkdir -p "$home/data" "$home/state" "$home/projects" "$wt"
+  cp "$ROOT/.tasks.toml" "$home/.tasks.toml"
+  cat > "$home/data/backlog.md" <<'EOF'
+## In flight
+- [ ] sample-terminal - Completed producer awaiting an independent gate (repo: sample) (kind: ship) (since 2026-07-31)
+- [ ] captain-wait - Completed producer awaiting the captain (repo: sample) (kind: ship) (since 2026-07-31)
+- [ ] dirty-terminal - Terminal event with uncommitted work (repo: sample) (kind: ship) (since 2026-07-31)
+- [ ] missing-meta - Preserve a row whose endpoint metadata is missing (repo: sample) (kind: ship) (since 2026-07-31)
+
+## Queued
+
+## Done
+EOF
+  git -C "$wt" init -q
+  git -C "$wt" config user.email test@example.com
+  git -C "$wt" config user.name Test
+  git -C "$wt" commit -q --allow-empty -m base
+  git -C "$wt" checkout -q -b fm/sample-terminal
+  git -C "$wt" commit -q --allow-empty -m 'unlanded completed work'
+  head=$(git -C "$wt" rev-parse HEAD)
+  fm_write_meta "$home/state/sample-terminal.meta" \
+    'window=test:fm-sample-terminal' "worktree=$wt" 'project=sample' 'kind=ship' 'endpoint_task_id=sample-terminal'
+  printf 'done: ready in branch fm/sample-terminal at %s\n' "$head" > "$home/state/sample-terminal.status"
+  fm_write_meta "$home/state/captain-wait.meta" \
+    'window=test:fm-captain-wait' "worktree=$wt" 'project=sample' 'kind=ship' 'endpoint_task_id=captain-wait'
+  printf 'awaiting-captain [key=gate]: approve the independent gate result\n' > "$home/state/captain-wait.status"
+  dirty_wt="$home/projects/dirty-terminal"
+  mkdir -p "$dirty_wt"
+  git -C "$dirty_wt" init -q
+  git -C "$dirty_wt" config user.email test@example.com
+  git -C "$dirty_wt" config user.name Test
+  git -C "$dirty_wt" commit -q --allow-empty -m base
+  printf 'uncommitted evidence\n' > "$dirty_wt/uncommitted.txt"
+  fm_write_meta "$home/state/dirty-terminal.meta" \
+    'window=test:fm-dirty-terminal' "worktree=$dirty_wt" 'project=sample' 'kind=ship' 'endpoint_task_id=dirty-terminal'
+  printf 'done: reported too early\n' > "$home/state/dirty-terminal.status"
+  fm_write_meta "$home/state/orphan-meta.meta" \
+    'window=test:fm-orphan-meta' "worktree=$home/projects/orphan" 'project=sample' 'kind=ship'
+  printf 'done: historical status with no metadata row\n' > "$home/state/orphan-status.status"
+
+  FM_HOME="$home" "$RECONCILE" >/dev/null || fail "record reconciliation failed"
+  ! sed -n '/^## In flight/,/^## /p' "$home/data/backlog.md" | grep -F -- '- [ ] sample-terminal -' >/dev/null \
+    || fail "terminal report still reads in flight"
+  sed -n '/^## Done/,$p' "$home/data/backlog.md" | grep -F -- '- [x] sample-terminal -' >/dev/null \
+    || fail "terminal report was not reconciled into Done"
+  sed -n '/^## Done/,$p' "$home/data/backlog.md" | grep -F -- '- [x] captain-wait -' >/dev/null \
+    || fail "complete awaiting-captain report was not reconciled into Done"
+  grep -F -- '- [ ] dirty-terminal -' "$home/data/backlog.md" >/dev/null \
+    || fail "dirty terminal row was retired despite uncommitted evidence"
+  assert_present "$dirty_wt/uncommitted.txt" "reconciliation erased uncommitted evidence"
+  assert_present "$home/state/sample-terminal.meta" "reconciliation erased retained task metadata"
+  [ "$(git -C "$wt" rev-parse HEAD)" = "$head" ] || fail "reconciliation changed unlanded work"
+  assert_absent "$wt/.git/refs/remotes/origin" "fixture unexpectedly gained a landing remote"
+  grep -F -- '- [ ] missing-meta -' "$home/data/backlog.md" >/dev/null \
+    || fail "reconciliation erased a row that proves missing metadata"
+  assert_present "$home/state/orphan-meta.meta" "reconciliation erased orphan metadata evidence"
+  receipt=$(find "$home/data/record-reconciliation" -type f -name '*.receipt' | head -1)
+  assert_present "$receipt" "reconciliation wrote no durable inventory receipt"
+  assert_grep $'terminal-retained\tsample-terminal' "$receipt" "receipt omitted the reconciled terminal row"
+  assert_grep $'terminal-retained\tcaptain-wait' "$receipt" "receipt omitted the reconciled captain-wait row"
+  assert_grep $'terminal-unreconciled\tdirty-terminal' "$receipt" "receipt omitted the dirty terminal refusal"
+  assert_grep $'missing-meta\tmissing-meta' "$receipt" "receipt omitted metadata-count drift"
+  assert_grep $'orphan-meta\torphan-meta' "$receipt" "receipt omitted the orphan metadata"
+  assert_grep $'orphan-status\torphan-status' "$receipt" "receipt omitted the orphan status record"
+  assert_grep 'in_flight_count=2' "$receipt" "receipt omitted the reconciled in-flight count"
+  assert_grep 'metadata_count=4' "$receipt" "receipt omitted the retained metadata count"
+  assert_grep 'metadata_minus_in_flight=2' "$receipt" "receipt omitted explicit metadata-count drift"
+  pass "terminal row reconciles without cleaning unlanded work or erasing drift evidence"
+}
+
+test_terminal_row_reconciles_while_unlanded_work_remains

--- a/tests/fm-record-reconcile.test.sh
+++ b/tests/fm-record-reconcile.test.sh
@@ -6,10 +6,17 @@ set -u
 . "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
 
 TMP_ROOT=$(fm_test_tmproot fm-record-reconcile)
-RECONCILE="$ROOT/bin/fm-record-reconcile.sh"
+DRAIN="$ROOT/bin/fm-wake-drain.sh"
+
+append_status_wake() {  # <state-dir> <task-id>
+  FM_STATE_OVERRIDE="$1" bash -c '
+    . "$1"
+    fm_wake_append signal "$2.status" "signal: $3/$2.status"
+  ' _ "$ROOT/bin/fm-wake-lib.sh" "$2" "$1"
+}
 
 test_terminal_row_reconciles_while_unlanded_work_remains() {
-  local home wt dirty_wt receipt head
+  local home wt dirty_wt receipt head guard_root drain_out
   home="$TMP_ROOT/home"
   wt="$home/projects/sample-terminal"
   mkdir -p "$home/data" "$home/state" "$home/projects" "$wt"
@@ -52,7 +59,15 @@ EOF
     'window=test:fm-orphan-meta' "worktree=$home/projects/orphan" 'project=sample' 'kind=ship'
   printf 'done: historical status with no metadata row\n' > "$home/state/orphan-status.status"
 
-  FM_HOME="$home" "$RECONCILE" >/dev/null || fail "record reconciliation failed"
+  guard_root="$home/guard-root"
+  drain_out="$home/drain.out"
+  mkdir -p "$guard_root"
+  touch "$home/state/.last-watcher-beat"
+  append_status_wake "$home/state" sample-terminal || fail "could not queue terminal status wake"
+  FM_HOME="$home" FM_ROOT_OVERRIDE="$guard_root" "$DRAIN" > "$drain_out" \
+    || fail "terminal wake drain and record reconciliation failed"
+  grep "$(printf '\tsignal\tsample-terminal.status\t')" "$drain_out" >/dev/null \
+    || fail "terminal wake did not traverse the ordinary drain path"
   ! sed -n '/^## In flight/,/^## /p' "$home/data/backlog.md" | grep -F -- '- [ ] sample-terminal -' >/dev/null \
     || fail "terminal report still reads in flight"
   sed -n '/^## Done/,$p' "$home/data/backlog.md" | grep -F -- '- [x] sample-terminal -' >/dev/null \

--- a/tests/fm-send-strict.test.sh
+++ b/tests/fm-send-strict.test.sh
@@ -50,7 +50,11 @@ case "${1:-}" in
     printf '%%1\n'
     exit 0 ;;
   capture-pane)
-    printf '╭────╮\n│    │\n╰────╯\n'
+    if [ -n "${FM_TMUX_CAPTURE_FILE:-}" ]; then
+      cat "$FM_TMUX_CAPTURE_FILE"
+    else
+      printf '╭────╮\n│    │\n╰────╯\n'
+    fi
     exit 0 ;;
   list-windows)
     printf 'foreign:%s\n' "${FM_FAKE_TMUX_WINDOW:-fm-lost}"
@@ -163,9 +167,33 @@ test_healthy_fm_id_send_still_works() {
   pass "fm-send strict: healthy fm-<id> sends still type once and submit"
 }
 
+test_stale_composer_refuses_before_typing() {
+  local dir fb home err log capture rc got
+  dir="$TMP_ROOT/stale-composer"; mkdir -p "$dir"
+  fb=$(make_stubs "$dir"); home=$(setup_home stalecomposer); err="$dir/send.err"; log="$dir/tmux.log"; : > "$log"
+  capture="$dir/capture.txt"
+  printf '╭────────────────────╮\n│ stale prior order  │\n╰────────────────────╯\n' > "$capture"
+  fm_write_meta "$home/state/stale.meta" "window=sess:fm-stale" "kind=ship" "harness=codex"
+
+  rc=0
+  PATH="$fb:$PATH" FM_HOME="$home" FM_ROOT_OVERRIDE="$home" FM_TMUX_LOG="$log" \
+    FM_TMUX_CAPTURE_FILE="$capture" FM_SEND_SETTLE=0 \
+    "$SEND" stale "fresh order" >/dev/null 2>"$err" || rc=$?
+  [ "$rc" -ne 0 ] || fail "stale composer accepted a second instruction"
+  got=$(cat "$log")
+  assert_not_contains "$got" 'literal=1 arg=fresh order' \
+    "fm-send typed the fresh order into a composer that already contained stale text"
+  assert_not_contains "$got" 'literal=0 arg=Enter' \
+    "fm-send submitted the stale composer while attempting the fresh order"
+  assert_contains "$(cat "$err")" 'composer is not affirmatively empty' \
+    "stale-composer refusal did not explain the delivery gap"
+  pass "fm-send strict: stale composer text refuses before any typing or Enter"
+}
+
 test_exact_lane_id_send_still_works
 test_unset_fm_home_fails
 test_unresolvable_target_does_not_tmux_fallback
 test_prefixless_herdr_pane_id_fails
 test_unmatched_single_colon_target_must_exist
 test_healthy_fm_id_send_still_works
+test_stale_composer_refuses_before_typing

--- a/tests/fm-session-start.test.sh
+++ b/tests/fm-session-start.test.sh
@@ -729,7 +729,9 @@ SH
   i=1
   while [ "$i" -le 40 ]; do
     (
-      harness_pid=$BASHPID
+      # Bash 3.2 keeps $$ fixed across subshells and has no BASHPID. A child
+      # shell's PPID is the portable actual PID of this concurrent subshell.
+      harness_pid=$(sh -c 'printf "%s\n" "$PPID"')
       : > "$home/state/harness-$harness_pid"
       : > "$ready/$i"
       while [ "$(find "$ready" -type f | wc -l | tr -d ' ')" -lt 40 ]; do

--- a/tests/fm-wake-queue.test.sh
+++ b/tests/fm-wake-queue.test.sh
@@ -212,6 +212,33 @@ test_drain_dedupes_obvious_duplicates() {
   pass "drain collapses obvious duplicate heartbeat and signal records"
 }
 
+test_drain_preserves_consumed_queue_evidence() {
+  local dir state data out archived receipt digest bytes
+  dir=$(make_case custody)
+  state="$dir/state"
+  data="$dir/data"
+  out="$dir/drain.out"
+  mkdir -p "$data"
+  append_wake "$state" signal task.status "signal: $state/task.status" || fail "signal append failed"
+  append_wake "$state" heartbeat heartbeat heartbeat || fail "heartbeat append failed"
+  digest=$(shasum -a 256 "$state/.wake-queue" | awk '{print $1}')
+  bytes=$(wc -c < "$state/.wake-queue" | tr -d '[:space:]')
+
+  FM_STATE_OVERRIDE="$state" FM_DATA_OVERRIDE="$data" "$DRAIN" > "$out" \
+    || fail "custody-preserving drain failed"
+  archived=$(find "$data/wake-receipts" -type f ! -name '*.receipt' | head -1)
+  receipt=$(find "$data/wake-receipts" -type f -name '*.receipt' | head -1)
+  assert_present "$archived" "drain erased the consumed queue without preserving its bytes"
+  assert_present "$receipt" "drain erased the consumed queue without a custody receipt"
+  [ "$(shasum -a 256 "$archived" | awk '{print $1}')" = "$digest" ] \
+    || fail "archived queue digest differs from the consumed queue"
+  assert_grep "sha256=$digest" "$receipt" "queue receipt digest does not bind the consumed bytes"
+  assert_grep "bytes=$bytes" "$receipt" "queue receipt byte count does not bind the consumed bytes"
+  assert_grep 'custody_class=consumed-wake-queue' "$receipt" "queue receipt omitted custody class"
+  [ ! -s "$state/.wake-queue" ] || fail "drain left consumed rows in the live queue"
+  pass "drain preserves consumed wake evidence before retiring live queue rows"
+}
+
 # The drain runs at the top of every wake-handling turn, so it also asserts
 # watcher liveness via fm-guard.sh: a lapsed re-arm chain then surfaces even on a
 # plain drain-and-handle turn that runs no other supervision script. It must warn
@@ -386,9 +413,12 @@ test_slow_annotation_does_not_block_append_and_deleted_file_fails_open() {
 }
 
 test_interruption_before_and_after_raw_commit() {
-  local dir state before_out after_out replay_out empty_out pid rc count i
+  local dir state pre_data post_data before_out after_out replay_out empty_out pid rc count i
   dir=$(make_case interruption)
   state="$dir/state"
+  pre_data="$dir/pre-data"
+  post_data="$dir/post-data"
+  mkdir -p "$pre_data" "$post_data"
   before_out="$dir/before.out"
   after_out="$dir/after.out"
   replay_out="$dir/replay.out"
@@ -396,7 +426,7 @@ test_interruption_before_and_after_raw_commit() {
   printf 'done: interruption fixture\n' > "$state/task.status"
   append_wake "$state" signal task.status "signal: task" || fail "pre-commit interruption wake append failed"
 
-  FM_STATE_OVERRIDE="$state" FM_WAKE_DRAIN_TEST_DELAY_BEFORE_COMMIT=5 "$DRAIN" > "$before_out" &
+  FM_STATE_OVERRIDE="$state" FM_DATA_OVERRIDE="$pre_data" FM_WAKE_DRAIN_TEST_DELAY_BEFORE_COMMIT=5 "$DRAIN" > "$before_out" &
   pid=$!
   i=0
   while [ "$i" -lt 100 ] && ! compgen -G "$state/.wake-queue.drain.*" >/dev/null; do
@@ -410,23 +440,37 @@ test_interruption_before_and_after_raw_commit() {
   rc=$?
   set -e
   [ "$rc" -ne 0 ] || fail "pre-commit interruption unexpectedly succeeded"
-  FM_STATE_OVERRIDE="$state" "$DRAIN" > "$replay_out" || fail "restored pre-commit wake did not drain"
+  FM_STATE_OVERRIDE="$state" FM_DATA_OVERRIDE="$pre_data" "$DRAIN" > "$replay_out" || fail "restored pre-commit wake did not drain"
   count=$(awk -F '\t' 'NF == 5 { count++ } END { print count + 0 }' "$replay_out")
   [ "$count" -eq 1 ] || fail "pre-commit interruption lost or duplicated the restored row"
 
   append_wake "$state" signal task.status "signal: task after commit" || fail "post-commit interruption wake append failed"
-  FM_STATE_OVERRIDE="$state" FM_WAKE_ENRICH_TEST_DELAY=5 "$DRAIN" > "$after_out" &
+  FM_STATE_OVERRIDE="$state" FM_DATA_OVERRIDE="$post_data" FM_WAKE_ENRICH_TEST_DELAY=5 "$DRAIN" > "$after_out" &
   pid=$!
   wait_for_file_text "$after_out" "$(printf '\tsignal\ttask.status\t')" \
     || { kill "$pid" 2>/dev/null || true; fail "post-commit drain did not print its raw row"; }
+  i=0
+  while [ "$i" -lt 100 ] && ! compgen -G "$post_data/wake-receipts/.*.receipt" >/dev/null; do
+    sleep 0.05
+    i=$((i + 1))
+  done
+  compgen -G "$post_data/wake-receipts/.*.receipt" >/dev/null \
+    || { kill "$pid" 2>/dev/null || true; fail "post-commit drain did not custody-receipt consumed bytes"; }
+  i=0
+  while [ "$i" -lt 100 ] && [ -e "$state/.wake-queue.lock" ]; do
+    sleep 0.05
+    i=$((i + 1))
+  done
+  [ ! -e "$state/.wake-queue.lock" ] \
+    || { kill "$pid" 2>/dev/null || true; fail "post-commit drain had not released queue ownership"; }
   kill -TERM "$pid" 2>/dev/null || fail "could not interrupt drain after raw commitment"
   set +e
   wait "$pid"
   set -e
-  FM_STATE_OVERRIDE="$state" "$DRAIN" > "$empty_out" || fail "drain after post-commit interruption failed"
+  FM_STATE_OVERRIDE="$state" FM_DATA_OVERRIDE="$post_data" "$DRAIN" > "$empty_out" || fail "drain after post-commit interruption failed"
   count=$(awk -F '\t' 'NF == 5 { count++ } END { print count + 0 }' "$after_out" "$empty_out")
   [ "$count" -eq 1 ] || fail "post-commit interruption restored or duplicated the consumed row"
-  pass "interruptions restore before commitment and never replay after raw commitment"
+  pass "interruptions restore before custody commitment and never replay after receipt-bound retirement"
 }
 
 test_concurrent_append_and_drain
@@ -436,6 +480,7 @@ test_not_working_stale_enqueue_before_suppressor
 test_check_output_is_queued
 test_atomic_double_drain
 test_drain_dedupes_obvious_duplicates
+test_drain_preserves_consumed_queue_evidence
 test_drain_asserts_watcher_liveness
 test_structural_signal_enrichment_preserves_raw_rows
 test_enrichment_caps_and_status_file_failures

--- a/tests/fm-wake-queue.test.sh
+++ b/tests/fm-wake-queue.test.sh
@@ -320,7 +320,7 @@ SH
 }
 
 test_enrichment_caps_and_status_file_failures() {
-  local dir state out fake_perl_log perl_bin i raw_count annotation_bytes annotation_count oversized_lines perl_reads
+  local dir state out fake_perl_log perl_bin i raw_count annotation_bytes annotation_count oversized_lines perl_reads terminal_reads
   dir=$(make_case caps)
   state="$dir/state"
   out="$dir/drain.out"
@@ -329,7 +329,13 @@ test_enrichment_caps_and_status_file_failures() {
   cat > "$dir/fakebin/perl" <<'SH'
 #!/usr/bin/env bash
 if [ "${1:-}" = -MFcntl=:DEFAULT ]; then
-  printf 'read\n' >> "$FM_WAKE_ENRICH_PERL_LOG"
+  previous=
+  current=
+  for arg in "$@"; do
+    previous=$current
+    current=$arg
+  done
+  printf 'read\t%s\n' "$previous" >> "$FM_WAKE_ENRICH_PERL_LOG"
 fi
 exec "$FM_WAKE_ENRICH_REAL_PERL" "$@"
 SH
@@ -366,7 +372,11 @@ SH
   annotation_count=$(grep -c '^wake annotation: latest' "$out" || true)
   [ "$annotation_count" -lt 9 ] || fail "global cap did not omit any of the nine readable status annotations"
   perl_reads=$(wc -l < "$fake_perl_log" | tr -d ' ')
-  [ "$perl_reads" -eq 8 ] || fail "enrichment read cap allowed $perl_reads safe reads instead of 8"
+  [ "$perl_reads" -eq 9 ] \
+    || fail "terminal detection plus capped enrichment used $perl_reads safe reads instead of exactly 9"
+  terminal_reads=$(awk -F '\t' -v path="$state/huge.status" '$2 == path { count++ } END { print count + 0 }' "$fake_perl_log")
+  [ "$terminal_reads" -eq 2 ] \
+    || fail "terminal status was not read exactly once for reconciliation and once inside the eight-read annotation cap"
   grep -E '^wake annotation: [1-9][0-9]* annotations omitted \(enrichment read cap\)$' "$out" >/dev/null \
     || fail "enrichment read-cap omission marker was not emitted"
   if grep -E ': (empty|missing|malformed|unreadable)\.status:' "$out" >/dev/null; then

--- a/tests/fm-watch-arm-ownership.test.sh
+++ b/tests/fm-watch-arm-ownership.test.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Regression for manual arm racing a Claude Stop-hook-owned arm cycle.
+set -u
+
+# shellcheck source=tests/wake-helpers.sh
+. "$(dirname "${BASH_SOURCE[0]}")/wake-helpers.sh"
+
+TMP_ROOT=$(fm_test_tmproot fm-watch-arm-ownership)
+WATCH="$ROOT/bin/fm-watch.sh"
+ARM="$ROOT/bin/fm-watch-arm.sh"
+LIB="$ROOT/bin/fm-wake-lib.sh"
+
+test_manual_arm_does_not_attach_to_autoarm_owned_cycle() {
+  local dir state fakebin holder watcher arm out i
+  dir=$(make_case owner-race)
+  state="$dir/state"
+  fakebin="$dir/fakebin"
+  out="$dir/arm.out"
+  printf '%s\n' fm-pr-check-migration-scan-v1 > "$state/.pr-check-migration-scan-v1"
+  printf '%s\n' fm-pr-check-migration-v1 > "$state/.pr-check-migration-v1"
+  chmod 0600 "$state/.pr-check-migration-scan-v1" "$state/.pr-check-migration-v1"
+
+  FM_STATE_OVERRIDE="$state" bash -c '
+    . "$1"
+    fm_lock_try_acquire "$2" || exit 7
+    sleep 20
+  ' _ "$LIB" "$state/.claude-autoarm.lock" &
+  holder=$!
+  i=0
+  while [ "$i" -lt 50 ] && [ ! -e "$state/.claude-autoarm.lock/pid" ]; do sleep 0.05; i=$((i + 1)); done
+  assert_present "$state/.claude-autoarm.lock/pid" "fixture autoarm owner lock was not published"
+
+  PATH="$fakebin:$PATH" FM_STATE_OVERRIDE="$state" FM_POLL=5 FM_SIGNAL_GRACE=1 \
+    FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" >/dev/null 2>&1 &
+  watcher=$!
+  i=0
+  while [ "$i" -lt 80 ] && [ ! -e "$state/.watch.lock/pid" ]; do sleep 0.05; i=$((i + 1)); done
+  assert_present "$state/.watch.lock/pid" "fixture watcher did not become live"
+
+  PATH="$fakebin:$PATH" FM_STATE_OVERRIDE="$state" FM_ARM_CONFIRM_TIMEOUT=1 "$ARM" > "$out" 2>&1 &
+  arm=$!
+  if ! wait_for_exit "$arm" 30; then
+    kill "$arm" 2>/dev/null || true
+    wait "$arm" 2>/dev/null || true
+    kill "$watcher" "$holder" 2>/dev/null || true
+    wait "$watcher" "$holder" 2>/dev/null || true
+    fail "manual arm attached to the Stop-hook-owned cycle instead of deferring: $(cat "$out")"
+  fi
+  grep -F 'watcher: delegated to Claude auto-arm owner' "$out" >/dev/null \
+    || fail "manual arm did not identify delegated cycle ownership: $(cat "$out")"
+  kill -0 "$watcher" 2>/dev/null || fail "ownership reconciliation stopped the live watcher"
+  kill "$watcher" "$holder" 2>/dev/null || true
+  wait "$watcher" "$holder" 2>/dev/null || true
+  pass "manual arm never attaches to a Claude auto-arm-owned watcher cycle"
+}
+
+test_manual_arm_does_not_attach_to_autoarm_owned_cycle

--- a/tests/fm-watch-triage.test.sh
+++ b/tests/fm-watch-triage.test.sh
@@ -111,6 +111,15 @@ record_pi_busy() {  # <state-dir> <id>
 
 reap() { kill "$1" 2>/dev/null || true; wait "$1" 2>/dev/null || true; }
 
+make_clean_retained_worktree() {  # <path>
+  local path=$1
+  mkdir -p "$path"
+  git -C "$path" init -q
+  git -C "$path" config user.email test@example.com
+  git -C "$path" config user.name Test
+  git -C "$path" commit -q --allow-empty -m base
+}
+
 # --- pure classifier predicates (fm-classify-lib.sh) ------------------------
 
 test_signal_reason_is_actionable_classifier() {
@@ -456,6 +465,95 @@ test_terminal_stale_surfaced() {
   pass "a stale pane sitting on a terminal status is surfaced (queue + exit)"
 }
 
+test_surfaced_done_lane_retires_from_future_stale_escalation() {
+  local dir state fakebin out capture_file window key sig pid terminal worktree head
+  dir=$(make_case terminal-retained); state="$dir/state"; fakebin="$dir/fakebin"
+  out="$dir/watch.out"; capture_file="$dir/pane.txt"
+  window="test:fm-complete"
+  terminal='done: ready in branch fm/complete at cf68fd9'
+  worktree="$dir/worktree"
+  make_clean_retained_worktree "$worktree"
+  head=$(git -C "$worktree" rev-parse HEAD)
+  printf 'idle composer after completion' > "$capture_file"
+  printf 'window=%s\nkind=ship\nworktree=%s\n' "$window" "$worktree" > "$state/complete.meta"
+  printf '%s\n' "$terminal" > "$state/complete.status"
+  sig=$(seen_sig "$state/complete.status"); printf '%s' "$sig" > "$state/.seen-complete_status"
+  printf '%s' "$terminal" > "$state/.hb-surfaced-complete"
+  key=$(printf '%s' "$window" | tr ':/.' '___')
+
+  watch_bg "$state" "$fakebin" "$out" env FM_FAKE_TMUX_WINDOW="$window" \
+    FM_FAKE_TMUX_CAPTURE="$capture_file" FM_STALE_ESCALATE_SECS=1
+  pid=$!
+  if ! wait_live "$pid" 35; then
+    reap "$pid"
+    fail "surfaced done lane re-escalated as stale: $(cat "$out")"
+  fi
+  [ ! -s "$state/.wake-queue" ] || fail "surfaced done lane queued another stale wake"
+  assert_present "$state/.terminal-retained-$key" \
+    "watcher did not record that the complete lane remains intentionally retained"
+  assert_grep "head=$head" "$state/.terminal-retained-$key" \
+    "terminal retirement was not bound to the retained HEAD"
+  assert_grep 'tree_state=clean' "$state/.terminal-retained-$key" \
+    "terminal retirement did not verify a clean worktree"
+  assert_present "$state/complete.meta" "terminal retirement erased task metadata"
+  reap "$pid"
+
+  # A retained terminal lane is trusted only while the mechanically checked
+  # terminal/clean-tree/HEAD triple is unchanged.
+  printf 'new unreported work\n' > "$worktree/changed.txt"
+  : > "$out"
+  watch_bg "$state" "$fakebin" "$out" env FM_FAKE_TMUX_WINDOW="$window" \
+    FM_FAKE_TMUX_CAPTURE="$capture_file" FM_STALE_ESCALATE_SECS=1
+  pid=$!
+  wait_for_exit "$pid" 40 || fail "changed retained lane stayed hidden after its tree became dirty"
+  grep -F 'retained evidence changed' "$out" >/dev/null \
+    || fail "retained lane change did not surface an actionable reason: $(cat "$out")"
+  pass "surfaced done lane retires from stale escalation while its worktree metadata remains"
+}
+
+test_awaiting_captain_is_durable_but_resumed_work_still_wedges() {
+  local dir state fakebin out capture_file window key sig pid line worktree
+  dir=$(make_case awaiting-captain); state="$dir/state"; fakebin="$dir/fakebin"
+  out="$dir/watch.out"; capture_file="$dir/pane.txt"
+  window="test:fm-awaiting"
+  line='awaiting-captain [key=gate]: approve the independent gate result'
+  worktree="$dir/worktree"
+  make_clean_retained_worktree "$worktree"
+  printf 'idle complete worker' > "$capture_file"
+  printf 'window=%s\nkind=ship\nworktree=%s\n' "$window" "$worktree" > "$state/awaiting.meta"
+  printf '%s\n' "$line" > "$state/awaiting.status"
+  sig=$(seen_sig "$state/awaiting.status"); printf '%s' "$sig" > "$state/.seen-awaiting_status"
+  printf '%s' "$line" > "$state/.hb-surfaced-awaiting"
+  key=$(printf '%s' "$window" | tr ':/.' '___')
+  export FM_FAKE_CREW_STATE='state: awaiting-captain · source: status-log · approve the independent gate result'
+
+  watch_bg "$state" "$fakebin" "$out" env FM_FAKE_TMUX_WINDOW="$window" \
+    FM_FAKE_TMUX_CAPTURE="$capture_file" FM_STALE_ESCALATE_SECS=1 FM_PAUSE_RESURFACE_SECS=1
+  pid=$!
+  if ! wait_live "$pid" 35; then
+    reap "$pid"
+    fail "awaiting-captain state resurfaced on a bounded stale cadence: $(cat "$out")"
+  fi
+  [ ! -s "$state/.wake-queue" ] || fail "awaiting-captain state queued a repeated stale wake"
+  assert_present "$state/.awaiting-captain-$key" "durable captain-wait marker was not recorded"
+  reap "$pid"
+
+  # A stale awaiting-captain line cannot hide work that has resumed. Once the
+  # authoritative run-step says working, the normal wedge timer applies again.
+  export FM_FAKE_CREW_STATE='state: working · source: run-step · validating (running)'
+  echo $(( $(date +%s) - 500 )) > "$state/.stale-since-$key"
+  printf 'identity-1\t100\n' > "$state/.progress-$key"
+  : > "$out"
+  watch_bg "$state" "$fakebin" "$out" env FM_FAKE_TMUX_WINDOW="$window" \
+    FM_FAKE_TMUX_CAPTURE="$capture_file" FM_STALE_ESCALATE_SECS=1 \
+    FM_PROCESS_PROGRESS_BIN="$fakebin/fm-no-progress"
+  pid=$!
+  wait_for_exit "$pid" 50 || fail "resumed worker hid forever behind awaiting-captain"
+  grep -F 'possible wedge' "$out" >/dev/null \
+    || fail "resumed worker did not return to normal wedge supervision: $(cat "$out")"
+  pass "awaiting-captain stays quiet indefinitely but cannot hide resumed wedged work"
+}
+
 # --- stale pane, STALE terminal status overridden by an active run: absorbed ---
 # Regression for the 2026-07 herdr false-surface incidents: a crew's own status
 # log gets no new entry once firstmate hands it to a no-mistakes validation
@@ -567,6 +665,49 @@ test_nonterminal_stale_provably_working_absorbed_then_escalated() {
   FM_STATE_OVERRIDE="$state" "$DRAIN" > "$drain_out" 2>/dev/null || fail "drain after the wedge escalation failed"
   grep "$(printf '\tstale\t')" "$drain_out" | grep -F "$window" >/dev/null || fail "wedge escalation was not queued"
   pass "provably-working non-terminal stale is absorbed on first sight, then wedge-escalated past the threshold"
+}
+
+test_cumulative_cpu_delta_suppresses_false_wedge() {
+  local dir state fakebin out capture_file window key pane_hash sig pid progress counter
+  dir=$(make_case cumulative-progress); state="$dir/state"; fakebin="$dir/fakebin"
+  out="$dir/watch.out"; capture_file="$dir/pane.txt"; progress="$fakebin/progress-sample"
+  counter="$fakebin/progress-counter"
+  window="test:fm-progress"
+  printf 'unchanged terminal surface while tool runs' > "$capture_file"
+  printf 'window=%s\nkind=ship\n' "$window" > "$state/progress.meta"
+  printf 'working: long test run\n' > "$state/progress.status"
+  sig=$(seen_sig "$state/progress.status"); printf '%s' "$sig" > "$state/.seen-progress_status"
+  key=$(printf '%s' "$window" | tr ':/.' '___')
+  pane_hash=$(hash_text 'unchanged terminal surface while tool runs')
+  printf '%s' "$pane_hash" > "$state/.hash-$key"
+  printf '2\n' > "$state/.count-$key"
+  printf '%s' "$pane_hash" > "$state/.stale-$key"
+  echo $(( $(date +%s) - 500 )) > "$state/.stale-since-$key"
+  printf 'identity-1\t100\n' > "$state/.progress-$key"
+  printf '100\n' > "$counter"
+  cat > "$progress" <<SH
+#!/usr/bin/env bash
+value=\$(cat '$counter')
+value=\$((value + 20))
+printf '%s\n' "\$value" > '$counter'
+printf 'identity-1\t%s\n' "\$value"
+SH
+  chmod +x "$progress"
+  export FM_FAKE_CREW_STATE='state: working · source: run-step · validating (running)'
+
+  watch_bg "$state" "$fakebin" "$out" env FM_FAKE_TMUX_WINDOW="$window" \
+    FM_FAKE_TMUX_CAPTURE="$capture_file" FM_PROCESS_PROGRESS_BIN="$progress" \
+    FM_STALE_ESCALATE_SECS=1
+  pid=$!
+  if ! wait_live "$pid" 30; then
+    reap "$pid"
+    fail "cumulative CPU delta was ignored and the progressing worker wedged: $(cat "$out")"
+  fi
+  [ ! -s "$state/.wake-queue" ] || fail "progressing worker queued a false stale wake"
+  grep -E '^identity-1[[:space:]][0-9]+$' "$state/.progress-$key" >/dev/null \
+    || fail "watcher did not retain the new cumulative progress sample"
+  reap "$pid"
+  pass "cumulative CPU delta resets stale escalation for a demonstrably progressing worker"
 }
 
 # --- non-terminal stale, crew NOT provably working: surfaced immediately ------
@@ -1566,8 +1707,11 @@ test_turn_ended_not_working_surfaced
 test_working_note_not_working_surfaced
 test_actionable_signal_surfaced
 test_terminal_stale_surfaced
+test_surfaced_done_lane_retires_from_future_stale_escalation
+test_awaiting_captain_is_durable_but_resumed_work_still_wedges
 test_stale_terminal_status_overridden_by_active_run
 test_nonterminal_stale_provably_working_absorbed_then_escalated
+test_cumulative_cpu_delta_suppresses_false_wedge
 test_wedge_escalation_marks_demand_deep_inspection_after_threshold
 test_wedge_escalation_resets_when_pane_becomes_active
 test_busy_pane_below_turn_age_bound_is_absorbed


### PR DESCRIPTION
> **Correction (by the author, before review):** this PR was opened with a title and description
> that named only the arm-guard change. That was wrong — it understated the scope by a wide margin.
> The description below is the corrected, measured one. Nothing in the branch changed; only this
> text did.

## Summary

Firstmate supervision and record integrity, plus a hardening of the watcher arm guard.
**43 files, +2658/−104**, in four commits. This is not a small change and should not be reviewed as one.

## What is actually in here

**1. `fix: reconcile retained supervision state` — 43 files, +2522/−104.** The bulk of the PR. Adds
six new scripts and their suites:

| new | purpose |
|---|---|
| `bin/fm-record-reconcile.sh` | reconcile durable records against live state |
| `bin/fm-custody-lib.sh` | custody checks for retained work |
| `bin/fm-model-capacity-hold.sh` + `-lib.sh` | capacity-based dispatch holds |
| `bin/fm-bearings-report.sh` | bearings generation |
| `bin/fm-process-progress.sh` | progress accounting |

and touches ~20 existing `bin/` scripts, largest being `bin/fm-decision-hold.sh` (+473/−25) and
`bin/fm-watch.sh` (+166/−1).

**2. `fix: reconcile terminal wakes immediately` — 7 files, +94/−16.**

**3. `fix: fail closed on watcher syntax checks` — 3 files, +78/−24.** The arm-guard allow-list.

**4. `docs: disclose bash -s watcher guard gap` — 1 file, +5/−1.**

## The load-bearing design choice (commit 3)

The watcher syntax-check exception is an **allow-list**, not patterns bolted onto a deny-list. Three
holes have been found in this guard — `--rcfile`, `--init-file`, `-s` — all argument-consuming or
payload-hiding invocation forms. The class is demonstrably not exhausted, so the structure must fail
closed on the fourth form nobody has found yet. A deny-list would not.

## One pre-existing gap is deliberately NOT closed

`bash -s` with an operand hides a heredoc/here-string payload from shell-invocation analysis and can
execute `bin/fm-watch.sh` end to end. It is **pre-existing on `main`**, not introduced here. Tracked
as #1489; `docs/arm-pretool-check.md` now names it and limits the coverage claim to statically
recognized shell invocations rather than overstating what the guard catches.

## Verification

Rebased onto `8c21b10`; `origin/main` is an ancestor, so this fast-forwards. `git range-diff`
accounts for all four commits — none squashed or dropped; three patch-identical, one
integration-adjusted where an `AGENTS.md` conflict retained both this branch's correction and new
main's process-event clause.

Thirteen-case arm-guard matrix across Codex, Claude, Grok, OpenCode and Pi transports: **12/13.**
**A13 is expected red and is not this branch's defect** — attribution was controlled by running it
against `origin/main` at `8c21b10`, which returns the identical `deny watcher-bundled`. Tracked
separately.

Security-property matrix: `bash -n` / `bash --noexec` allowed; nested execution, `--rcfile`,
`--init-file` and all three redirection forms denied.

Suites green: `fm-arm-pretool-check`, `fm-procevent`, `fm-turnend-guard`, `fm-supervision-events`,
`fm-watch-triage`; `fm-lint` with pinned ShellCheck 0.11.0; documentation-audience check; `git diff --check`.

**Not independently verified:** the guard matrix was produced by the authoring agent. It could not be
re-run by the supervising agent, because commands naming the watcher script are themselves denied by
the guard under test.

## Review note

Opened for @kunchenguid. Merge authority is not ours.
