### PR TITLE
feat(bin): add guarded deployment capability

### DIFF
--- a/.agents/skills/bootstrap-diagnostics/SKILL.md
+++ b/.agents/skills/bootstrap-diagnostics/SKILL.md
@@ -2,7 +2,7 @@
 name: bootstrap-diagnostics
 description: >-
   Agent-only handling playbook for session-start bootstrap diagnostics.
-  Use whenever the session-start digest's bootstrap section prints an actionable diagnostic line - MISSING, MISSING_MANUAL, BACKEND_INVALID, NEEDS_GH_AUTH, TANGLE, STARTUP_MEMORY_BUDGET, CREW_DISPATCH invalid, FLEET_SYNC, PR_CHECK_MIGRATION, SECONDMATE_SYNC, SECONDMATE_LIVENESS, NUDGE_SECONDMATES, or FMX - or when a standalone bin/fm-bootstrap.sh run prints one of those lines.
+  Use whenever the session-start digest's bootstrap section prints an actionable diagnostic line - MISSING, MISSING_MANUAL, BACKEND_INVALID, NEEDS_GH_AUTH, TANGLE, STARTUP_MEMORY_BUDGET, CREW_DISPATCH invalid, FLEET_SYNC, PR_CHECK_MIGRATION, DEPLOY_RECOVERY, SECONDMATE_SYNC, SECONDMATE_LIVENESS, NUDGE_SECONDMATES, or FMX - or when a standalone bin/fm-bootstrap.sh run prints one of those lines.
   A silent bootstrap section, or a BOOTSTRAP_INFO fact, means no skill load.
 user-invocable: false
 metadata:
@@ -44,6 +44,9 @@ When any diagnostic needs captain attention, report the plain consequence and re
   Resume the emitted supervision protocol after finishing the session-start wake handling.
 - Any other `PR_CHECK_MIGRATION:` refusal means migration did not complete safely, whether because watcher exclusion, a private path, a diagnostic, quarantine validation, or marker publication could not be proved.
   Keep each affected poll unavailable, inspect the named private state path, and do not bypass the migration or execute a quarantined artifact; a completed safe-scan marker allows unrelated authenticated polls to continue while private repair remains pending.
+- `DEPLOY_RECOVERY: deployment runtime material requires manual inspection` - a receipt-owned local deployment path could not be proven safe to remove, or a recorded deployment process is still live.
+  Do not retry, unlock, roll back, or start deployment work.
+  Inspect the named receipt under `state/deploy-runtime/` and use `bin/fm-deploy.sh recover <task-id>` only after the exact process and local identities are understood.
 - `SECONDMATE_SYNC: secondmate <id>: skipped: <reason>` - the local-HEAD secondmate sync left a live secondmate home on its existing checkout because the home was dirty, diverged, unsafe, on the wrong branch, missing the primary target commit, or otherwise not fast-forwardable, or because inherited local-material propagation failed; bootstrap continued, but inspect the reason because the secondmate's tracked instructions, inherited settings, or shared captain preferences may be stale after a primary update.
 - `SECONDMATE_LIVENESS: secondmate <id>: skipped: <reason>|respawn failed after <cause>: <reason>` - the session-start liveness sweep could not guarantee that the registered secondmate is running a real agent process.
   Investigate the reason because that secondmate is not guaranteed live.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,6 +74,7 @@ config/startup-memory-budget     primary-authoritative per-home startup-memory b
 config/herdr-presentation-spaces  optional presence flag for Herdr's default-off disposable single-task visual projection; LOCAL, gitignored; inherited by secondmate homes; see docs/herdr-backend.md "Optional presentation spaces"
 config/cmux-socket-password  optional cmux control-socket password; LOCAL, gitignored; read fresh on every cmux CLI call and passed through without ever overriding an operator's own ambient CMUX_SOCKET_PASSWORD when absent (docs/cmux-backend.md "Setup")
 config/wedge-alarm  optional away-mode wedge-alarm active-alert directives; LOCAL, gitignored; absent means auto (macOS Notification Center when available); see docs/wedge-alarm.md
+config/deployment-capabilities.json  optional private guarded deployment profiles; LOCAL, gitignored, default-off, and never inherited into secondmate homes; docs/configuration.md owns its schema and bin/fm-deploy.sh owns grant, execution, recovery, and cleanup mechanics
 config/x-mode.env    generated X-mode watcher cadence; LOCAL, gitignored; source before arming watcher when present
 data/                personal fleet records; LOCAL, gitignored as a whole
   backlog.md         task queue, dependencies, history
@@ -97,6 +98,7 @@ state/               volatile runtime signals; gitignored
   <id>.pr-poll       private validated data sidecar for the byte-static PR merge poll
   <id>.pr-poll-registration  private transactional provenance record binding the task, canonical metadata identity, sidecar, and static poll publication
   <id>.pr-poll-retirement  private identity-bound crash-recovery receipt for one exact validated merged result; removed after its poll artifacts retire
+  deployment-grants/ and deploy-runtime/  private one-shot deployment grants and exact identity-bound local cleanup receipts; bin/fm-deploy.sh owns their fields and recovery
   .pr-check-quarantine/  private non-runnable storage for checks neutralized by the non-executing migration
   .pr-check-migration.log  private per-task outcomes distinguishing rebuilt or canonically registered replacement polls, quarantined unarmed polls, and incomplete migrations
   .pr-check-migration-scan-v1  private marker proving the non-executing scan disabled every unsafe legacy check; .pr-check-migration-v1 separately records completed private repairs
@@ -488,7 +490,7 @@ It performs guarded fast-forward updates of firstmate and registered secondmate 
 
 These skills are not captain-invocable; load them only at their precise triggers.
 
-- `bootstrap-diagnostics` - load whenever the session-start digest's bootstrap section prints an actionable diagnostic line (`MISSING:`, `MISSING_MANUAL:`, `BACKEND_INVALID:`, `NEEDS_GH_AUTH`, `TANGLE:`, `STARTUP_MEMORY_BUDGET:`, `CREW_DISPATCH: invalid`, `FLEET_SYNC:`, `PR_CHECK_MIGRATION:`, `SECONDMATE_SYNC:`, `SECONDMATE_LIVENESS:`, `NUDGE_SECONDMATES:`, or `FMX:`); silence and `BOOTSTRAP_INFO:` need no load.
+- `bootstrap-diagnostics` - load whenever the session-start digest's bootstrap section prints an actionable diagnostic line (`MISSING:`, `MISSING_MANUAL:`, `BACKEND_INVALID:`, `NEEDS_GH_AUTH`, `TANGLE:`, `STARTUP_MEMORY_BUDGET:`, `CREW_DISPATCH: invalid`, `FLEET_SYNC:`, `PR_CHECK_MIGRATION:`, `DEPLOY_RECOVERY:`, `SECONDMATE_SYNC:`, `SECONDMATE_LIVENESS:`, `NUDGE_SECONDMATES:`, or `FMX:`); silence and `BOOTSTRAP_INFO:` need no load.
 - `diagnostic-reasoning` - load before scoping a reported bug and before acting on a diagnostic report.
 - `ask-user-authority` - load before deciding any ask-user finding, regardless of the project's `yolo` posture.
 - `quota-array-dispatch` - load before choosing among a matched crew-dispatch profile array from current quota-axi output.

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -12,6 +12,7 @@
 #                 "CREW_DISPATCH: invalid config/crew-dispatch.json - <reason>",
 #                 "FLEET_SYNC: <repo>: skipped|recovered|STUCK: <detail>",
 #                 "PR_CHECK_MIGRATION: <private remediation>",
+#                 "DEPLOY_RECOVERY: deployment runtime material requires manual inspection",
 #                 "TANGLE: <remediation>",
 #                 "SECONDMATE_SYNC: secondmate <id>: skipped: <reason>",
 #                 "NUDGE_SECONDMATES: secondmate <id>: send failed: <reason>",
@@ -852,6 +853,12 @@ fi
 # runnable. Detect-only sessions never touch state.
 if [ "${FM_BOOTSTRAP_DETECT_ONLY:-0}" != 1 ]; then
   "$SCRIPT_DIR/fm-pr-check-migrate.sh" || true
+  # Deployment recovery only removes exact, receipt-bound local files and never
+  # retries, unlocks, rolls back, or starts a remote deployment. Keep this at
+  # the locked startup boundary so detect-only sessions do not mutate state.
+  if ! "$SCRIPT_DIR/fm-deploy.sh" recover-stale; then
+    echo "DEPLOY_RECOVERY: deployment runtime material requires manual inspection"
+  fi
   startup_memory_budget_setup
 fi
 

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -856,7 +856,7 @@ if [ "${FM_BOOTSTRAP_DETECT_ONLY:-0}" != 1 ]; then
   # Deployment recovery only removes exact, receipt-bound local files and never
   # retries, unlocks, rolls back, or starts a remote deployment. Keep this at
   # the locked startup boundary so detect-only sessions do not mutate state.
-  if ! "$SCRIPT_DIR/fm-deploy.sh" recover-stale; then
+  if [ -x "$SCRIPT_DIR/fm-deploy.sh" ] && ! "$SCRIPT_DIR/fm-deploy.sh" recover-stale; then
     echo "DEPLOY_RECOVERY: deployment runtime material requires manual inspection"
   fi
   startup_memory_budget_setup

--- a/bin/fm-deploy.js
+++ b/bin/fm-deploy.js
@@ -278,7 +278,7 @@ function sourceBytes(config, profile) {
   if (!Buffer.from(text, 'utf8').equals(bytes) || !/^[0-9a-fA-F]{32}\n?$/.test(text)) throw safeError('source key has invalid format');
   return { key: text.trim(), identity: { root: profile.source.root, relative_path: profile.source.relative_path, dev: before.dev, ino: before.ino, uid: before.uid, mode: mode(before), links: before.nlink } };
 }
-function writeTemp(task, transaction, key, source) {
+function writeTemp(task, transaction, key, receipt, persistReceipt) {
   const root = path.join(path.dirname(path.join('/tmp', `fm-${task.taskId}`)), `fm-${task.taskId}`, 'deploy-runtime');
   // tasktmp is metadata-owned where available; never write in the project copy.
   const meta = fs.readFileSync(path.join(STATE, `${task.taskId}.meta`), 'utf8');
@@ -287,13 +287,21 @@ function writeTemp(task, transaction, key, source) {
   mkdirPrivate(runtimeRoot);
   const directory = path.join(runtimeRoot, transaction);
   fs.mkdirSync(directory, { mode: 0o700 }); fs.chmodSync(directory, 0o700);
+  receipt.directory = directory;
+  persistReceipt();
   const rails = path.join(directory, 'rails.key'); const secrets = path.join(directory, `secrets.${task.profile.destination}`);
   for (const [file, contents] of [[rails, `${key}\n`], [secrets, `RAILS_MASTER_KEY=${key}\n`]]) {
     const fd = fs.openSync(file, fs.constants.O_WRONLY | fs.constants.O_CREAT | fs.constants.O_EXCL | fs.constants.O_NOFOLLOW, 0o600);
-    try { fs.writeFileSync(fd, contents, { encoding: 'utf8' }); fs.fsyncSync(fd); } finally { fs.closeSync(fd); }
-    const stat = lstatRegular(file, 0o600); if (stat.uid !== process.getuid()) throw safeError('temporary deployment file owner mismatch');
+    try {
+      const stat = fs.fstatSync(fd);
+      if (!stat.isFile() || stat.uid !== process.getuid() || !exactMode(stat, 0o600)) throw safeError('temporary deployment file owner mismatch');
+      if (file === rails) receipt.rails = { path: file, dev: stat.dev, ino: stat.ino, uid: stat.uid, mode: mode(stat) };
+      else receipt.secrets = { path: file, dev: stat.dev, ino: stat.ino, uid: stat.uid, mode: mode(stat) };
+      persistReceipt();
+      fs.writeFileSync(fd, contents, { encoding: 'utf8' }); fs.fsyncSync(fd);
+    } finally { fs.closeSync(fd); }
   }
-  return { directory, rails, secrets, source };
+  return { directory, rails, secrets };
 }
 function tempIdentity(file) { const stat = lstatRegular(file, 0o600); return { path: file, dev: stat.dev, ino: stat.ino, uid: stat.uid, mode: mode(stat) }; }
 function unlinkExact(identity) {
@@ -302,7 +310,8 @@ function unlinkExact(identity) {
   fs.unlinkSync(identity.path);
 }
 function cleanupReceipt(receipt) {
-  unlinkExact(receipt.rails); unlinkExact(receipt.secrets);
+  if (receipt.rails) unlinkExact(receipt.rails);
+  if (receipt.secrets) unlinkExact(receipt.secrets);
   const stat = lstatDir(receipt.directory); if (stat.uid !== process.getuid() || !exactMode(stat, 0o700)) throw safeError('temporary deployment directory identity changed');
   fs.rmdirSync(receipt.directory);
 }
@@ -382,9 +391,10 @@ async function run(grantId) {
     validateGrant(grant); if (grant.state !== 'pending') throw safeError('grant is not pending');
     grant.state = 'consumed'; privateFile(found.file, `${JSON.stringify(grant)}\n`);
     transaction = randomId(); const source = sourceBytes(config, task.profile); key = source.key;
-    const temp = writeTemp(task, transaction, key, source.identity);
-    receipt = { version: 1, transaction, grant_id: grant.grant_id, task_id: task.taskId, project: task.project, profile: grant.profile, destination: grant.destination, head: task.head, phase: 'prepared', started_at: now(), directory: temp.directory, rails: tempIdentity(temp.rails), secrets: tempIdentity(temp.secrets), source: source.identity };
-    privateFile(receiptPath(task.taskId, transaction), `${JSON.stringify(receipt)}\n`);
+    receipt = { version: 1, transaction, grant_id: grant.grant_id, task_id: task.taskId, project: task.project, profile: grant.profile, destination: grant.destination, head: task.head, phase: 'preparing-temp', started_at: now(), source: source.identity };
+    const persistReceipt = () => privateFile(receiptPath(task.taskId, transaction), `${JSON.stringify(receipt)}\n`);
+    const temp = writeTemp(task, transaction, key, receipt, persistReceipt);
+    receipt.phase = 'prepared'; persistReceipt();
     let exit = await runFixed(task, temp, key, ['bin/deploy', 'preflight', task.profile.destination]);
     if (exit !== 0) { appendLedger({ version: 1, transaction, task_id: task.taskId, project: task.project, profile: grant.profile, destination: grant.destination, head: task.head, authority_ref: grant.authority_ref, started_at: receipt.started_at, finished_at: now(), result: 'preflight-failed', exit_code: exit, preflight_passed: false, remote_phase_reached: false }); return exit; }
     receipt.phase = 'preflight-passed'; privateFile(receiptPath(task.taskId, transaction), `${JSON.stringify(receipt)}\n`);
@@ -416,7 +426,7 @@ function recover(taskId) {
   for (const file of fs.readdirSync(dir)) {
     if (!/^[0-9a-f]{32}\.json$/.test(file)) throw safeError('unsafe deployment recovery record');
     const receiptFile = path.join(dir, file); const receipt = readPrivateJson(receiptFile);
-    if (receipt.task_id !== taskId || !receipt.rails || !receipt.secrets || !receipt.directory) throw safeError('deployment recovery requires manual inspection');
+    if (receipt.task_id !== taskId || !receipt.directory) throw safeError('deployment recovery requires manual inspection');
     if (receiptChildIsAlive(receipt)) throw safeError('deployment recovery found a live recorded operation');
     const remoteReached = receipt.phase === 'remote-started' || receipt.phase === 'launching';
     cleanupReceipt(receipt); fs.unlinkSync(receiptFile);

--- a/bin/fm-deploy.js
+++ b/bin/fm-deploy.js
@@ -1,0 +1,441 @@
+#!/usr/bin/env node
+/*
+ * Default-off, one-shot deployment capability.
+ *
+ * This program intentionally accepts only profile-owned fixed argv and reads
+ * secret bytes only after task, project, origin, worktree, HEAD, grant, and
+ * destination checks succeed. It never serializes a secret or its hash.
+ */
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const crypto = require('crypto');
+const { spawn, spawnSync } = require('child_process');
+
+const ROOT = path.resolve(__dirname, '..');
+const HOME = process.env.FM_HOME || process.env.FM_ROOT_OVERRIDE || ROOT;
+const STATE = process.env.FM_STATE_OVERRIDE || path.join(HOME, 'state');
+const DATA = process.env.FM_DATA_OVERRIDE || path.join(HOME, 'data');
+const CONFIG = process.env.FM_CONFIG_OVERRIDE || path.join(HOME, 'config');
+const PROJECTS = process.env.FM_PROJECTS_OVERRIDE || path.join(HOME, 'projects');
+const CONFIG_FILE = path.join(CONFIG, 'deployment-capabilities.json');
+const NAME = /^[a-z][a-z0-9-]{0,63}$/;
+const ID = /^[A-Za-z0-9._-]+$/;
+const AUTHORITY = /^[a-z][a-z0-9-]{0,127}$/;
+const MAX_KEY_BYTES = 33;
+const GRANT_TTL_MS = 10 * 60 * 1000;
+
+function safeError(message, code = 1) { return { message, code }; }
+function mode(stat) { return stat.mode & 0o777; }
+function exactMode(stat, expected) { return mode(stat) === expected; }
+function sameIdentity(a, b) {
+  return a.dev === b.dev && a.ino === b.ino && a.size === b.size && a.mtimeMs === b.mtimeMs;
+}
+function lstatRegular(file, expectedMode) {
+  const stat = fs.lstatSync(file);
+  if (!stat.isFile() || stat.isSymbolicLink() || stat.nlink !== 1 || (expectedMode !== undefined && !exactMode(stat, expectedMode))) {
+    throw safeError('refused unsafe file identity');
+  }
+  return stat;
+}
+function lstatDir(dir) {
+  const stat = fs.lstatSync(dir);
+  if (!stat.isDirectory() || stat.isSymbolicLink()) throw safeError('refused unsafe directory identity');
+  return stat;
+}
+function mkdirPrivate(dir) {
+  fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+  const stat = lstatDir(dir);
+  if (!exactMode(stat, 0o700)) fs.chmodSync(dir, 0o700);
+  return dir;
+}
+function privateFile(file, contents) {
+  const parent = path.dirname(file);
+  mkdirPrivate(parent);
+  const temp = path.join(parent, `.${path.basename(file)}.${crypto.randomBytes(8).toString('hex')}`);
+  const fd = fs.openSync(temp, fs.constants.O_WRONLY | fs.constants.O_CREAT | fs.constants.O_EXCL | fs.constants.O_NOFOLLOW, 0o600);
+  try { fs.writeFileSync(fd, contents, { encoding: 'utf8' }); fs.fsyncSync(fd); } finally { fs.closeSync(fd); }
+  fs.renameSync(temp, file);
+  fs.chmodSync(file, 0o600);
+}
+function readPrivateJson(file) {
+  const stat = lstatRegular(file, 0o600);
+  if (stat.uid !== process.getuid()) throw safeError('private file owner mismatch');
+  return parseStrictJson(fs.readFileSync(file, 'utf8'));
+}
+
+// JSON.parse loses duplicate-key information. This small parser rejects it while
+// remaining deliberately limited to standard JSON values.
+function parseStrictJson(text) {
+  let i = 0;
+  const whitespace = () => { while (/\s/.test(text[i] || '')) i++; };
+  const string = () => {
+    if (text[i++] !== '"') throw safeError('invalid JSON');
+    let out = '';
+    while (i < text.length) {
+      const c = text[i++];
+      if (c === '"') return out;
+      if (c === '\\') {
+        const e = text[i++];
+        const map = { '"': '"', '\\': '\\', '/': '/', b: '\b', f: '\f', n: '\n', r: '\r', t: '\t' };
+        if (e === 'u') {
+          const hex = text.slice(i, i + 4);
+          if (!/^[0-9a-fA-F]{4}$/.test(hex)) throw safeError('invalid JSON');
+          out += String.fromCharCode(parseInt(hex, 16)); i += 4;
+        } else if (Object.prototype.hasOwnProperty.call(map, e)) out += map[e];
+        else throw safeError('invalid JSON');
+      } else {
+        if (c < ' ') throw safeError('invalid JSON');
+        out += c;
+      }
+    }
+    throw safeError('invalid JSON');
+  };
+  const value = () => {
+    whitespace(); const c = text[i];
+    if (c === '"') return string();
+    if (c === '{') {
+      i++; whitespace(); const result = {}; const seen = new Set();
+      if (text[i] === '}') { i++; return result; }
+      for (;;) {
+        whitespace(); const key = string();
+        if (seen.has(key)) throw safeError('duplicate JSON object key');
+        seen.add(key); whitespace(); if (text[i++] !== ':') throw safeError('invalid JSON');
+        result[key] = value(); whitespace();
+        if (text[i] === '}') { i++; return result; }
+        if (text[i++] !== ',') throw safeError('invalid JSON');
+      }
+    }
+    if (c === '[') {
+      i++; const result = []; whitespace(); if (text[i] === ']') { i++; return result; }
+      for (;;) { result.push(value()); whitespace(); if (text[i] === ']') { i++; return result; } if (text[i++] !== ',') throw safeError('invalid JSON'); }
+    }
+    const remainder = text.slice(i);
+    const token = /^(true|false|null|-?(?:0|[1-9][0-9]*)(?:\.[0-9]+)?(?:[eE][+-]?[0-9]+)?)/.exec(remainder);
+    if (!token) throw safeError('invalid JSON');
+    i += token[0].length;
+    return token[0] === 'true' ? true : token[0] === 'false' ? false : token[0] === 'null' ? null : Number(token[0]);
+  };
+  const result = value(); whitespace(); if (i !== text.length) throw safeError('invalid JSON'); return result;
+}
+function object(value, label) {
+  if (!value || Array.isArray(value) || typeof value !== 'object') throw safeError(`invalid ${label}`);
+  return value;
+}
+function keysExactly(value, allowed, label) {
+  object(value, label);
+  for (const key of Object.keys(value)) if (!allowed.includes(key)) throw safeError(`unknown ${label} field`);
+}
+function string(value, label) { if (typeof value !== 'string' || !value) throw safeError(`invalid ${label}`); return value; }
+function named(value, label) { value = string(value, label); if (!NAME.test(value)) throw safeError(`invalid ${label}`); return value; }
+function regularPath(value, label) { value = string(value, label); if (value.includes('\0')) throw safeError(`invalid ${label}`); return value; }
+function safeRelative(value, label) {
+  value = regularPath(value, label);
+  if (path.isAbsolute(value) || value.split('/').some(x => !x || x === '.' || x === '..')) throw safeError(`invalid ${label}`);
+  return value;
+}
+function validateConfig(config) {
+  keysExactly(config, ['version', 'source_roots', 'projects'], 'config');
+  if (config.version !== 1) throw safeError('unsupported deployment capability version');
+  object(config.source_roots, 'source_roots'); object(config.projects, 'projects');
+  if (!Object.keys(config.source_roots).length || !Object.keys(config.projects).length) throw safeError('empty required config object');
+  for (const [rootName, root] of Object.entries(config.source_roots)) {
+    named(rootName, 'source root name'); keysExactly(root, ['path', 'owner', 'allow_group_or_world_write'], 'source root');
+    const rootPath = regularPath(root.path, 'source root path');
+    if (!path.isAbsolute(rootPath) || root.owner !== 'current-user' || root.allow_group_or_world_write !== false) throw safeError('invalid source root');
+  }
+  for (const [projectName, project] of Object.entries(config.projects)) {
+    named(projectName, 'project name'); keysExactly(project, ['origin', 'profiles'], 'project');
+    keysExactly(project.origin, ['remote', 'url'], 'origin'); string(project.origin.remote, 'origin remote'); string(project.origin.url, 'origin url');
+    object(project.profiles, 'profiles'); if (!Object.keys(project.profiles).length) throw safeError('empty profiles');
+    for (const [profileName, profile] of Object.entries(project.profiles)) {
+      named(profileName, 'profile name'); keysExactly(profile, ['kind', 'destination', 'source', 'command', 'required_credentials', 'destination_manifest'], 'profile');
+      if (profile.kind !== 'rails-kamal-key-file-v1') throw safeError('unsupported profile kind');
+      const destination = named(profile.destination, 'destination');
+      keysExactly(profile.source, ['root', 'relative_path', 'owner', 'mode', 'links'], 'source');
+      named(profile.source.root, 'source root'); safeRelative(profile.source.relative_path, 'source relative_path');
+      if (profile.source.owner !== 'current-user' || profile.source.mode !== '0600' || profile.source.links !== 1 || !config.source_roots[profile.source.root]) throw safeError('invalid source');
+      if (!Array.isArray(profile.command) || profile.command.length !== 2 || profile.command[0] !== 'bin/deploy' || profile.command[1] !== destination) throw safeError('invalid fixed deployment command');
+      if (!Array.isArray(profile.required_credentials) || !profile.required_credentials.length || new Set(profile.required_credentials).size !== profile.required_credentials.length || !profile.required_credentials.every(x => typeof x === 'string' && /^[a-z][a-z0-9_]*(?:\.[a-z][a-z0-9_]*)*$/.test(x))) throw safeError('invalid required_credentials');
+      safeRelative(profile.destination_manifest, 'destination manifest');
+    }
+  }
+  return config;
+}
+function loadConfig() {
+  if (!fs.existsSync(CONFIG_FILE)) throw safeError('deployment capability is not configured');
+  return validateConfig(readPrivateJson(CONFIG_FILE));
+}
+function metaValue(meta, key) {
+  const lines = meta.split(/\n/).filter(line => line.startsWith(`${key}=`));
+  if (lines.length !== 1 || !lines[0].slice(key.length + 1)) throw safeError('invalid task metadata');
+  return lines[0].slice(key.length + 1);
+}
+function git(cwd, args) {
+  const result = spawnSync('git', ['-C', cwd, ...args], { encoding: 'utf8' });
+  if (result.status !== 0) throw safeError('task git identity could not be verified');
+  return result.stdout.trim();
+}
+function real(file) { return fs.realpathSync(file); }
+function registeredProject(name, project) {
+  const registry = path.join(DATA, 'projects.md');
+  lstatRegular(registry);
+  if (!fs.readFileSync(registry, 'utf8').split('\n').some(line => line.startsWith(`- ${name} `) || line === `- ${name}`)) throw safeError('project is not registered');
+  if (real(path.join(PROJECTS, name)) !== real(project)) throw safeError('task project does not match registered project');
+}
+function validateTask(taskId, config, requestedProfile) {
+  if (!ID.test(taskId)) throw safeError('invalid task id');
+  const metaFile = path.join(STATE, `${taskId}.meta`);
+  const metaStat = lstatRegular(metaFile);
+  if (metaStat.uid !== process.getuid()) throw safeError('task metadata owner mismatch');
+  const meta = fs.readFileSync(metaFile, 'utf8');
+  const kind = metaValue(meta, 'kind');
+  if (kind !== 'ship') throw safeError('deployment requires a ship task');
+  const project = metaValue(meta, 'project');
+  const worktree = metaValue(meta, 'worktree');
+  if (project.includes('\n') || worktree.includes('\n')) throw safeError('invalid task metadata');
+  const backend = (meta.match(/^backend=(.*)$/m) || [])[1] || 'tmux';
+  const projectReal = real(project); const worktreeReal = real(worktree);
+  if (projectReal === worktreeReal) throw safeError('deployment requires an isolated worktree');
+  const candidates = Object.entries(config.projects).filter(([name, projectConfig]) => {
+    try { registeredProject(name, projectReal); return projectConfig.profiles[requestedProfile] !== undefined; } catch (_) { return false; }
+  });
+  if (candidates.length !== 1) throw safeError('profile is not bound to this registered project');
+  const [projectName, projectConfig] = candidates[0]; const profile = projectConfig.profiles[requestedProfile];
+  const remote = git(worktreeReal, ['remote', 'get-url', projectConfig.origin.remote]);
+  if (remote !== projectConfig.origin.url) throw safeError('origin URL does not exactly match the profile');
+  if (git(worktreeReal, ['rev-parse', '--show-toplevel']) !== worktreeReal) throw safeError('worktree top-level mismatch');
+  const projectCommon = path.resolve(projectReal, git(projectReal, ['rev-parse', '--git-common-dir']));
+  const worktreeCommon = path.resolve(worktreeReal, git(worktreeReal, ['rev-parse', '--git-common-dir']));
+  if (real(projectCommon) !== real(worktreeCommon)) throw safeError('worktree does not belong to recorded project');
+  if (git(worktreeReal, ['status', '--porcelain', '--untracked-files=all']) !== '') throw safeError('worktree is not clean');
+  if (backend === 'orca') {
+    const worktreeId = metaValue(meta, 'orca_worktree_id');
+    if (!/^[A-Za-z0-9._:-]+$/.test(worktreeId)) throw safeError('invalid Orca worktree binding');
+    const response = spawnSync('orca', ['worktree', 'show', '--worktree', `id:${worktreeId}`, '--json'], { encoding: 'utf8' });
+    if (response.status !== 0) throw safeError('Orca worktree could not be verified');
+    let parsed; try { parsed = JSON.parse(response.stdout); } catch (_) { throw safeError('invalid Orca worktree response'); }
+    const orcaPath = parsed.result && ((parsed.result.worktree || parsed.result.item || parsed.result).path || parsed.result.path);
+    if (parsed.ok === false || typeof orcaPath !== 'string' || real(orcaPath) !== worktreeReal) throw safeError('Orca worktree binding mismatch');
+  } else if (!['tmux', 'herdr', 'zellij', 'cmux'].includes(backend)) throw safeError('unsupported task runtime binding');
+  return { taskId, project: projectName, projectConfig, profile, projectPath: projectReal, worktree: worktreeReal, head: git(worktreeReal, ['rev-parse', 'HEAD']), backend };
+}
+function grantDirectory(taskId) { return path.join(STATE, 'deployment-grants', taskId); }
+function grantPath(taskId, grantId) { return path.join(grantDirectory(taskId), `${grantId}.json`); }
+function receiptPath(taskId, transaction) { return path.join(STATE, 'deploy-runtime', taskId, `${transaction}.json`); }
+function ledgerPath() { return path.join(DATA, 'deployment-receipts.jsonl'); }
+function now() { return new Date().toISOString(); }
+function randomId() { return crypto.randomBytes(16).toString('hex'); }
+function lockPath(project, destination) { return path.join(STATE, 'deployment-locks', `${project}-${destination}.lock`); }
+function acquireLock(project, destination) {
+  const lock = lockPath(project, destination); mkdirPrivate(path.dirname(lock));
+  try { fs.mkdirSync(lock, 0o700); } catch (_) { throw safeError('deployment destination is already in use'); }
+  return () => { try { fs.rmdirSync(lock); } catch (_) {} };
+}
+function writeGrant(grant) { privateFile(grantPath(grant.task_id, grant.grant_id), `${JSON.stringify(grant)}\n`); }
+function readGrant(grantId) {
+  if (!/^[0-9a-f]{32}$/.test(grantId)) throw safeError('invalid grant id');
+  const root = path.join(STATE, 'deployment-grants');
+  if (!fs.existsSync(root)) throw safeError('grant was not found');
+  for (const task of fs.readdirSync(root)) {
+    const candidate = grantPath(task, grantId);
+    if (fs.existsSync(candidate)) return { file: candidate, grant: readPrivateJson(candidate) };
+  }
+  throw safeError('grant was not found');
+}
+function validateGrant(grant) {
+  keysExactly(grant, ['version', 'grant_id', 'task_id', 'project', 'profile', 'destination', 'worktree', 'head', 'created_at', 'expires_at', 'max_uses', 'authority_ref', 'state'], 'grant');
+  if (grant.version !== 1 || !/^[0-9a-f]{32}$/.test(grant.grant_id) || !ID.test(grant.task_id) || !NAME.test(grant.project) || !NAME.test(grant.profile) || !NAME.test(grant.destination) || !AUTHORITY.test(grant.authority_ref) || grant.max_uses !== 1 || !['pending', 'consumed', 'revoked', 'expired'].includes(grant.state)) throw safeError('invalid grant');
+  if (Date.parse(grant.expires_at) <= Date.now()) throw safeError('grant has expired');
+}
+function appendLedger(record) {
+  mkdirPrivate(DATA);
+  const file = ledgerPath();
+  if (!fs.existsSync(file)) privateFile(file, '');
+  lstatRegular(file, 0o600);
+  fs.appendFileSync(file, `${JSON.stringify(record)}\n`, { encoding: 'utf8', mode: 0o600 });
+}
+function sourceBytes(config, profile) {
+  const root = config.source_roots[profile.source.root];
+  const rootPath = root.path;
+  const rootStat = lstatDir(rootPath);
+  if (rootStat.uid !== process.getuid() || (mode(rootStat) & 0o022)) throw safeError('unsafe source root');
+  let current = rootPath;
+  const components = profile.source.relative_path.split('/');
+  for (const [index, component] of components.entries()) {
+    current = path.join(current, component);
+    const stat = fs.lstatSync(current);
+    if (stat.isSymbolicLink() || (index < components.length - 1 && (!stat.isDirectory() || stat.uid !== process.getuid() || (mode(stat) & 0o022)))) throw safeError('source path contains an unsafe component');
+  }
+  const before = fs.lstatSync(current);
+  if (!before.isFile() || before.uid !== process.getuid() || !exactMode(before, 0o600) || before.nlink !== 1 || before.size < 1 || before.size > MAX_KEY_BYTES) throw safeError('unsafe source key identity');
+  const fd = fs.openSync(current, fs.constants.O_RDONLY | fs.constants.O_NOFOLLOW);
+  let bytes, opened, after;
+  try { opened = fs.fstatSync(fd); if (!sameIdentity(before, opened)) throw safeError('source changed before read'); bytes = fs.readFileSync(fd); after = fs.fstatSync(fd); } finally { fs.closeSync(fd); }
+  if (!sameIdentity(opened, after)) throw safeError('source changed during read');
+  const text = bytes.toString('utf8');
+  if (!Buffer.from(text, 'utf8').equals(bytes) || !/^[0-9a-fA-F]{32}\n?$/.test(text)) throw safeError('source key has invalid format');
+  return { key: text.trim(), identity: { root: profile.source.root, relative_path: profile.source.relative_path, dev: before.dev, ino: before.ino, uid: before.uid, mode: mode(before), links: before.nlink } };
+}
+function writeTemp(task, transaction, key, source) {
+  const root = path.join(path.dirname(path.join('/tmp', `fm-${task.taskId}`)), `fm-${task.taskId}`, 'deploy-runtime');
+  // tasktmp is metadata-owned where available; never write in the project copy.
+  const meta = fs.readFileSync(path.join(STATE, `${task.taskId}.meta`), 'utf8');
+  const taskTmpLine = (meta.match(/^tasktmp=(.*)$/m) || [])[1];
+  const runtimeRoot = taskTmpLine && path.isAbsolute(taskTmpLine) ? path.join(taskTmpLine, 'deploy-runtime') : root;
+  mkdirPrivate(runtimeRoot);
+  const directory = path.join(runtimeRoot, transaction);
+  fs.mkdirSync(directory, { mode: 0o700 }); fs.chmodSync(directory, 0o700);
+  const rails = path.join(directory, 'rails.key'); const secrets = path.join(directory, `secrets.${task.profile.destination}`);
+  for (const [file, contents] of [[rails, `${key}\n`], [secrets, `RAILS_MASTER_KEY=${key}\n`]]) {
+    const fd = fs.openSync(file, fs.constants.O_WRONLY | fs.constants.O_CREAT | fs.constants.O_EXCL | fs.constants.O_NOFOLLOW, 0o600);
+    try { fs.writeFileSync(fd, contents, { encoding: 'utf8' }); fs.fsyncSync(fd); } finally { fs.closeSync(fd); }
+    const stat = lstatRegular(file, 0o600); if (stat.uid !== process.getuid()) throw safeError('temporary deployment file owner mismatch');
+  }
+  return { directory, rails, secrets, source };
+}
+function tempIdentity(file) { const stat = lstatRegular(file, 0o600); return { path: file, dev: stat.dev, ino: stat.ino, uid: stat.uid, mode: mode(stat) }; }
+function unlinkExact(identity) {
+  const stat = lstatRegular(identity.path, 0o600);
+  if (stat.dev !== identity.dev || stat.ino !== identity.ino || stat.uid !== identity.uid || mode(stat) !== identity.mode) throw safeError('temporary deployment file identity changed');
+  fs.unlinkSync(identity.path);
+}
+function cleanupReceipt(receipt) {
+  unlinkExact(receipt.rails); unlinkExact(receipt.secrets);
+  const stat = lstatDir(receipt.directory); if (stat.uid !== process.getuid() || !exactMode(stat, 0o700)) throw safeError('temporary deployment directory identity changed');
+  fs.rmdirSync(receipt.directory);
+}
+function sanitizedEnv(rails, secrets) {
+  const allowed = ['HOME', 'USER', 'LOGNAME', 'PATH', 'TMPDIR', 'SSH_AUTH_SOCK', 'DOCKER_HOST', 'DOCKER_CONTEXT', 'DOCKER_CONFIG'];
+  const env = {};
+  for (const key of allowed) if (process.env[key]) env[key] = process.env[key];
+  env.KG_METALL_RAILS_KEY_PATH = rails;
+  env.KAMAL_SECRETS_PATH = secrets.slice(0, -`.${path.basename(secrets).split('.').pop()}`.length);
+  return env;
+}
+function streamRedacted(child, key) {
+  const needle = Buffer.from(key); let pending = Buffer.alloc(0);
+  const emit = (data, final) => {
+    let keep = 0;
+    if (!final) {
+      for (let size = Math.min(needle.length - 1, data.length); size > 0; size--) {
+        if (data.subarray(data.length - size).equals(needle.subarray(0, size))) { keep = size; break; }
+      }
+    }
+    const end = data.length - keep; let cursor = 0; let match;
+    while ((match = data.indexOf(needle, cursor)) !== -1 && match + needle.length <= end) {
+      if (match > cursor) process.stdout.write(data.subarray(cursor, match));
+      process.stdout.write('[REDACTED]'); cursor = match + needle.length;
+    }
+    if (cursor < end) process.stdout.write(data.subarray(cursor, end));
+    pending = data.subarray(end);
+  };
+  const write = chunk => emit(Buffer.concat([pending, chunk]), false);
+  child.stdout.on('data', write); child.stderr.on('data', write);
+  return () => { if (pending.length) emit(pending, true); };
+}
+function processStartToken(pid) {
+  try {
+    if (process.platform === 'linux') return fs.readFileSync(`/proc/${pid}/stat`, 'utf8').trim().split(' ')[21] || '';
+    const result = spawnSync('ps', ['-o', 'lstart=', '-p', String(pid)], { encoding: 'utf8' });
+    return result.status === 0 ? result.stdout.trim() : '';
+  } catch (_) { return ''; }
+}
+function receiptChildIsAlive(receipt) {
+  if (!receipt.child || !Number.isInteger(receipt.child.pid) || !receipt.child.start) return false;
+  try { process.kill(receipt.child.pid, 0); } catch (_) { return false; }
+  return processStartToken(receipt.child.pid) === receipt.child.start;
+}
+function runFixed(task, temp, key, argv, onStarted) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(argv[0], argv.slice(1), { cwd: task.worktree, env: sanitizedEnv(temp.rails, temp.secrets), stdio: ['ignore', 'pipe', 'pipe'], detached: true, shell: false });
+    if (onStarted) onStarted(child.pid, processStartToken(child.pid));
+    const flush = streamRedacted(child, key);
+    child.once('error', reject);
+    child.once('close', code => { flush(); resolve(code === 0 ? 0 : (code || 1)); });
+  });
+}
+async function issue(taskId, profileName, authorityRef) {
+  if (!AUTHORITY.test(authorityRef)) throw safeError('invalid authority reference');
+  const config = loadConfig(); const task = validateTask(taskId, config, profileName); const release = acquireLock(task.project, task.profile.destination);
+  try {
+    const existingDir = grantDirectory(task.taskId);
+    if (fs.existsSync(existingDir)) {
+      lstatDir(existingDir);
+      for (const file of fs.readdirSync(existingDir)) {
+        if (!/^[0-9a-f]{32}\.json$/.test(file)) throw safeError('unsafe grant record');
+        const existing = readPrivateJson(path.join(existingDir, file));
+        if (existing.profile === profileName && existing.state === 'pending' && Date.parse(existing.expires_at) > Date.now()) throw safeError('a pending grant already exists for this task and destination');
+      }
+    }
+    const grant = { version: 1, grant_id: randomId(), task_id: task.taskId, project: task.project, profile: profileName, destination: task.profile.destination, worktree: task.worktree, head: task.head, created_at: now(), expires_at: new Date(Date.now() + GRANT_TTL_MS).toISOString(), max_uses: 1, authority_ref: authorityRef, state: 'pending' };
+    writeGrant(grant); process.stdout.write(`${grant.grant_id}\n`); return grant.grant_id;
+  } finally { release(); }
+}
+async function run(grantId) {
+  const found = readGrant(grantId); const grant = found.grant; validateGrant(grant);
+  const config = loadConfig(); const task = validateTask(grant.task_id, config, grant.profile);
+  if (task.project !== grant.project || task.profile.destination !== grant.destination || task.worktree !== grant.worktree || task.head !== grant.head) throw safeError('grant task identity changed');
+  const release = acquireLock(task.project, task.profile.destination); let transaction; let receipt; let key;
+  try {
+    validateGrant(grant); if (grant.state !== 'pending') throw safeError('grant is not pending');
+    grant.state = 'consumed'; privateFile(found.file, `${JSON.stringify(grant)}\n`);
+    transaction = randomId(); const source = sourceBytes(config, task.profile); key = source.key;
+    const temp = writeTemp(task, transaction, key, source.identity);
+    receipt = { version: 1, transaction, grant_id: grant.grant_id, task_id: task.taskId, project: task.project, profile: grant.profile, destination: grant.destination, head: task.head, phase: 'prepared', started_at: now(), directory: temp.directory, rails: tempIdentity(temp.rails), secrets: tempIdentity(temp.secrets), source: source.identity };
+    privateFile(receiptPath(task.taskId, transaction), `${JSON.stringify(receipt)}\n`);
+    let exit = await runFixed(task, temp, key, ['bin/deploy', 'preflight', task.profile.destination]);
+    if (exit !== 0) { appendLedger({ version: 1, transaction, task_id: task.taskId, project: task.project, profile: grant.profile, destination: grant.destination, head: task.head, authority_ref: grant.authority_ref, started_at: receipt.started_at, finished_at: now(), result: 'preflight-failed', exit_code: exit, preflight_passed: false, remote_phase_reached: false }); return exit; }
+    receipt.phase = 'preflight-passed'; privateFile(receiptPath(task.taskId, transaction), `${JSON.stringify(receipt)}\n`);
+    receipt.phase = 'launching'; privateFile(receiptPath(task.taskId, transaction), `${JSON.stringify(receipt)}\n`);
+    exit = await runFixed(task, temp, key, task.profile.command, (pid, start) => {
+      receipt.child = { pid, start };
+      receipt.phase = 'remote-started';
+      privateFile(receiptPath(task.taskId, transaction), `${JSON.stringify(receipt)}\n`);
+    });
+    appendLedger({ version: 1, transaction, task_id: task.taskId, project: task.project, profile: grant.profile, destination: grant.destination, head: task.head, authority_ref: grant.authority_ref, started_at: receipt.started_at, finished_at: now(), result: exit === 0 ? 'completed' : 'deploy-failed', exit_code: exit, preflight_passed: true, remote_phase_reached: true });
+    return exit;
+  } finally {
+    if (receipt) {
+      try {
+        cleanupReceipt(receipt);
+        fs.unlinkSync(receiptPath(task.taskId, transaction));
+      } catch (_) {
+        release();
+        throw safeError('cleanup requires manual inspection');
+      }
+    }
+    release();
+  }
+}
+function recover(taskId) {
+  if (!ID.test(taskId)) throw safeError('invalid task id');
+  const dir = path.join(STATE, 'deploy-runtime', taskId); if (!fs.existsSync(dir)) return;
+  lstatDir(dir);
+  for (const file of fs.readdirSync(dir)) {
+    if (!/^[0-9a-f]{32}\.json$/.test(file)) throw safeError('unsafe deployment recovery record');
+    const receiptFile = path.join(dir, file); const receipt = readPrivateJson(receiptFile);
+    if (receipt.task_id !== taskId || !receipt.rails || !receipt.secrets || !receipt.directory) throw safeError('deployment recovery requires manual inspection');
+    if (receiptChildIsAlive(receipt)) throw safeError('deployment recovery found a live recorded operation');
+    const remoteReached = receipt.phase === 'remote-started' || receipt.phase === 'launching';
+    cleanupReceipt(receipt); fs.unlinkSync(receiptFile);
+    appendLedger({ version: 1, transaction: receipt.transaction, task_id: receipt.task_id, project: receipt.project, profile: receipt.profile, destination: receipt.destination, head: receipt.head, started_at: receipt.started_at, finished_at: now(), result: remoteReached ? 'unknown-after-remote' : 'recovered-before-remote', preflight_passed: receipt.phase === 'preflight-passed', remote_phase_reached: remoteReached });
+  }
+}
+function recoverStale() {
+  const root = path.join(STATE, 'deploy-runtime'); if (!fs.existsSync(root)) return;
+  lstatDir(root); for (const task of fs.readdirSync(root)) recover(task);
+}
+async function main() {
+  const args = process.argv.slice(2); const command = args.shift();
+  if (command === 'validate-config' && args.length === 0) { loadConfig(); return; }
+  if (command === 'issue' && args.length === 4 && args[2] === '--authority-ref') { await issue(args[0], args[1], args[3]); return; }
+  if (command === 'run' && args.length === 1) { const code = await run(args[0]); process.exitCode = code; return; }
+  if (command === 'deploy' && args.length === 4 && args[2] === '--authority-ref') { const grant = await issue(args[0], args[1], args[3]); process.exitCode = await run(grant); return; }
+  if (command === 'revoke' && args.length === 1) { const found = readGrant(args[0]); validateGrant(found.grant); if (found.grant.state !== 'pending') throw safeError('grant cannot be revoked'); found.grant.state = 'revoked'; privateFile(found.file, `${JSON.stringify(found.grant)}\n`); return; }
+  if (command === 'recover' && args.length === 1) { recover(args[0]); return; }
+  if (command === 'recover-stale' && args.length === 0) { recoverStale(); return; }
+  throw safeError('usage: fm-deploy.sh validate-config|issue|run|deploy|revoke|recover|recover-stale', 2);
+}
+main().catch(error => { if (error && error.message === '__fm_deploy_handled__') return; const detail = error && error.message ? error.message : 'refused unsafe deployment request'; process.stderr.write(`fm-deploy: ${detail}\n`); process.exitCode = error && error.code ? error.code : 1; });

--- a/bin/fm-deploy.sh
+++ b/bin/fm-deploy.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 # Guarded, default-off task deployment capability.
 #
-# The private config/deployment-capabilities.json schema, grant, subprocess,
-# receipt, recovery, and cleanup contracts are owned by docs/configuration.md.
+# docs/configuration.md owns the operator-facing capability and schema.
+# This entrypoint's usage block owns the command spelling, while fm-deploy.js
+# owns the grant, subprocess, receipt, recovery, and cleanup mechanics.
 # This shell entrypoint deliberately delegates the file-identity-sensitive work
 # to Node so deployment never depends on shell parsing or word splitting.
 #

--- a/bin/fm-deploy.sh
+++ b/bin/fm-deploy.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Guarded, default-off task deployment capability.
+#
+# The private config/deployment-capabilities.json schema, grant, subprocess,
+# receipt, recovery, and cleanup contracts are owned by docs/configuration.md.
+# This shell entrypoint deliberately delegates the file-identity-sensitive work
+# to Node so deployment never depends on shell parsing or word splitting.
+#
+# Usage:
+#   fm-deploy.sh validate-config
+#   fm-deploy.sh issue <task-id> <profile> --authority-ref <safe-slug>
+#   fm-deploy.sh run <grant-id>
+#   fm-deploy.sh deploy <task-id> <profile> --authority-ref <safe-slug>
+#   fm-deploy.sh revoke <grant-id>
+#   fm-deploy.sh recover <task-id>
+#   fm-deploy.sh recover-stale
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec node "$SCRIPT_DIR/fm-deploy.js" "$@"

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -1680,7 +1680,7 @@ fi
 # Deployment runtime material is receipt-owned and may never be swept by the
 # broad tasktmp removal below. Recover only this task first; an identity or live
 # remote-operation refusal preserves every task record for manual inspection.
-if ! "$FM_ROOT/bin/fm-deploy.sh" recover "$ID"; then
+if [ -x "$FM_ROOT/bin/fm-deploy.sh" ] && ! "$FM_ROOT/bin/fm-deploy.sh" recover "$ID"; then
   echo "error: deployment cleanup for $ID requires manual inspection; retaining task state" >&2
   exit 1
 fi

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -1677,6 +1677,13 @@ if [ "$KIND" = secondmate ]; then
   remove_firstmate_home "$HOME_PATH" "secondmate home" "$ID" || exit $?
   remove_secondmate_registry_entry "$ID"
 fi
+# Deployment runtime material is receipt-owned and may never be swept by the
+# broad tasktmp removal below. Recover only this task first; an identity or live
+# remote-operation refusal preserves every task record for manual inspection.
+if ! "$FM_ROOT/bin/fm-deploy.sh" recover "$ID"; then
+  echo "error: deployment cleanup for $ID requires manual inspection; retaining task state" >&2
+  exit 1
+fi
 remove_grok_turnend_auth "$STATE" "$ID"
 remove_kimi_turnend_auth "$STATE" "$ID"
 fm_backend_clear_transition "$BACKEND" "$STATE" "$T" || true

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -1678,11 +1678,15 @@ if [ "$KIND" = secondmate ]; then
   remove_secondmate_registry_entry "$ID"
 fi
 # Deployment runtime material is receipt-owned and may never be swept by the
-# broad tasktmp removal below. Recover only this task first; an identity or live
-# remote-operation refusal preserves every task record for manual inspection.
-if [ -x "$FM_ROOT/bin/fm-deploy.sh" ] && ! "$FM_ROOT/bin/fm-deploy.sh" recover "$ID"; then
-  echo "error: deployment cleanup for $ID requires manual inspection; retaining task state" >&2
-  exit 1
+# broad tasktmp removal below. Recover only this task first when it has any
+# deployment state; an identity or live remote-operation refusal preserves every
+# task record for manual inspection. Tasks without deployment state keep the old
+# teardown dependency surface and do not require node.
+if [ -d "$STATE/deploy-runtime/$ID" ] || [ -d "$STATE/deployment-grants/$ID" ]; then
+  if [ ! -x "$FM_ROOT/bin/fm-deploy.sh" ] || ! "$FM_ROOT/bin/fm-deploy.sh" recover "$ID"; then
+    echo "error: deployment cleanup for $ID requires manual inspection; retaining task state" >&2
+    exit 1
+  fi
 fi
 remove_grok_turnend_auth "$STATE" "$ID"
 remove_kimi_turnend_auth "$STATE" "$ID"

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -190,6 +190,9 @@ family_for_basename() {
     fm-afk-inject-e2e.test.sh|fm-afk-return.test.sh)
       printf '%s\n' afk
       ;;
+    fm-deploy.test.sh)
+      printf '%s\n' deployment-capability
+      ;;
     fm-bearings-snapshot.test.sh|fm-fleet-snapshot-view.test.sh)
       printf '%s\n' snapshot-bearings
       ;;
@@ -228,6 +231,7 @@ session-bootstrap
 live-harness-optin
 backend-dispatch
 pr-forge
+deployment-capability
 afk
 snapshot-bearings
 cmux
@@ -890,6 +894,9 @@ families_for_changed_path() {
     bin/fm-pr-*|bin/fm-merge-local.sh|bin/fm-teardown.sh|bin/fm-review-diff.sh|\
     bin/fm-x-*|bin/fm-check*)
       printf '%s\n' pr-forge
+      ;;
+    bin/fm-deploy.sh|bin/fm-deploy.js)
+      printf '%s\n' deployment-capability
       ;;
     bin/fm-spawn.sh|bin/fm-send.sh|bin/fm-harness.sh|\
     bin/fm-peek.sh|bin/fm-composer*)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -151,6 +151,24 @@ An inherited `data/captain-shared.md` counts in a secondmate's total but remains
 The internal `/stow` skill curates only the editable local files in that case and reports the primary-owned shared file as a concrete exception if it alone exceeds the budget.
 The helper's header owns exact parsing, publication, and report output mechanics.
 
+## Guarded deployment capabilities (config/deployment-capabilities.json)
+
+`config/deployment-capabilities.json` is an optional, local, owner-only `0600` deployment-capability document.
+When absent, Firstmate does not create a deployment grant, copy external material, change task creation, or alter ordinary isolated-copy cleanup.
+It is deliberately excluded from the inherited-local-material allowlist, so a secondmate needs its own separately authorized declaration.
+`bin/fm-deploy.sh` owns exact command syntax, grant fields, receipt fields, parsing, and mutation mechanics.
+The supported v1 document names source roots and registered-project profiles.
+Each profile fixes a project origin URL, destination, `rails-kamal-key-file-v1` source, and exact `bin/deploy <destination>` argv.
+The parser rejects duplicate JSON keys, unknown fields, unsafe names or paths, shell-like commands, and non-v1 documents before source access.
+A profile can run only for a clean ship task bound to its registered project, exact origin, isolated-copy identity, and unchanged HEAD.
+Issue a short-lived one-shot grant with a nonsecret authority reference, then run that grant, or use the atomic `deploy` form after concrete deployment authority.
+The runner validates the declared owner-only non-symlink source, accepts only a synthetic-or-authorized 32-hex Rails key, and creates owner-only raw-key and destination-suffixed Kamal dotenv files outside the isolated copy.
+It invokes only the profile's fixed argv with a sanitized environment containing the two nonsecret temporary paths, streams value-silent redaction, and records only value-silent private receipts.
+This reduces accidental same-user exposure and is not a hostile same-user security boundary.
+A deployment failure consumes its grant, and recovery never retries, unlocks, rolls back, or starts remote work.
+`fm-teardown.sh` performs exact receipt-bound local cleanup before broad task temporary-root removal, while locked startup performs bounded stale-receipt recovery.
+If identity validation cannot prove a receipt-owned path safe, cleanup stops and preserves the task for manual inspection.
+
 ## Secondmate routes (data/secondmates.md)
 
 Persistent secondmate routes live locally in `data/secondmates.md`.

--- a/tests/fm-backend.test.sh
+++ b/tests/fm-backend.test.sh
@@ -141,7 +141,7 @@ resolve_permissive_tmux_kill_ref() {
 # hence the dispatcher is a copied sibling, while the tmux adapter is extracted
 # from BASE_REF so conformance tests retain the exact historical behavior even
 # when this branch changes tmux dispatch semantics.
-OLD_BIN_UNCHANGED_SIBLINGS="fm-gate-refuse-lib.sh fm-guard.sh fm-lock-lib.sh fm-tasks-axi-lib.sh fm-pr-lib.sh fm-tangle-lib.sh fm-tmux-lib.sh fm-composer-lib.sh fm-wake-lib.sh fm-classify-lib.sh fm-supervision-lib.sh fm-ff-lib.sh fm-config-inherit-lib.sh fm-project-mode.sh fm-harness.sh fm-crew-state.sh fm-decision-hold.sh fm-backend.sh fm-operational-input.sh fm-public-followup-lib.sh fm-secondmate-registry-lib.sh fm-x-lib.sh"
+OLD_BIN_UNCHANGED_SIBLINGS="fm-gate-refuse-lib.sh fm-guard.sh fm-lock-lib.sh fm-tasks-axi-lib.sh fm-pr-lib.sh fm-tangle-lib.sh fm-tmux-lib.sh fm-composer-lib.sh fm-wake-lib.sh fm-classify-lib.sh fm-supervision-lib.sh fm-ff-lib.sh fm-config-inherit-lib.sh fm-project-mode.sh fm-harness.sh fm-crew-state.sh fm-decision-hold.sh fm-backend.sh fm-deploy.sh fm-deploy.js fm-operational-input.sh fm-public-followup-lib.sh fm-secondmate-registry-lib.sh fm-x-lib.sh"
 # A pull-request merge may add a new main-only dependency that the branch's older baseline does not have yet.
 OLD_BIN_OPTIONAL_SIBLINGS="fm-pending-reply-lib.sh"
 OLD_BIN_REFACTORED="fm-send.sh fm-peek.sh fm-watch.sh fm-spawn.sh fm-teardown.sh fm-marker-lib.sh"

--- a/tests/fm-calm-pi-extension.test.sh
+++ b/tests/fm-calm-pi-extension.test.sh
@@ -246,7 +246,9 @@ const handlers = new Map();
 const pi = {
   events: { emit() {}, on() {} },
   on(event, handler) {
-    handlers.set(event, handler);
+    const eventHandlers = handlers.get(event) ?? [];
+    eventHandlers.push(handler);
+    handlers.set(event, eventHandlers);
   },
   registerCommand(name, command) {
     if (name === "calm") calmCommand = command;
@@ -2465,7 +2467,7 @@ JS
 }
 
 test_interactive_terminal_e2e() {
-  local project config home session_file export_file export_dom default_snapshot expanded_snapshot hidden_snapshot active_before_snapshot active_hidden_snapshot export_snapshot restored_snapshot working_snapshot working_response_snapshot restarted_snapshot resumed_restored_snapshot hash_before hash_after now version chrome chrome_pid chrome_wait active_wait active_screen_wait boat_frame_one boat_frame_two boat_resized_snapshot boat_focus_snapshot boat_cleared_snapshot boat_hull_line boat_sail_line boat_column_one boat_column_two boat_line boat_color_snapshot boat_color_line boat_water_snapshot boat_water_line boat_water_first boat_water_changed boat_narrow_snapshot boat_narrow_sails boat_freeze_snapshot boat_resume_snapshot boat_freeze_column boat_freeze_sail boat_resume_column boat_resume_sail
+  local project config home session_file export_file export_dom default_snapshot expanded_snapshot hidden_snapshot active_before_snapshot active_hidden_snapshot restored_snapshot working_snapshot working_response_snapshot restarted_snapshot resumed_restored_snapshot hash_before hash_after now version chrome chrome_pid chrome_wait active_wait active_screen_wait boat_frame_one boat_frame_two boat_resized_snapshot boat_focus_snapshot boat_cleared_snapshot boat_hull_line boat_sail_line boat_column_one boat_column_two boat_line boat_color_snapshot boat_color_line boat_water_snapshot boat_water_line boat_water_first boat_water_changed boat_narrow_snapshot boat_narrow_sails boat_freeze_snapshot boat_resume_snapshot boat_freeze_column boat_freeze_sail boat_resume_column boat_resume_sail
   if ! command -v pi >/dev/null 2>&1 || ! command -v tmux >/dev/null 2>&1; then
     echo "skip: pi or tmux not found for Pi calm interactive E2E"
     return 0
@@ -2484,7 +2486,6 @@ test_interactive_terminal_e2e() {
   hidden_snapshot="$TMP_ROOT/hidden.txt"
   active_before_snapshot="$TMP_ROOT/active-before.txt"
   active_hidden_snapshot="$TMP_ROOT/active-hidden.txt"
-  export_snapshot="$TMP_ROOT/export.txt"
   restored_snapshot="$TMP_ROOT/restored.txt"
   working_snapshot="$TMP_ROOT/working.txt"
   working_response_snapshot="$TMP_ROOT/working-response.txt"
@@ -2500,7 +2501,7 @@ test_interactive_terminal_e2e() {
   boat_resume_snapshot="$TMP_ROOT/boat-resume.txt"
   restarted_snapshot="$TMP_ROOT/restarted.txt"
   resumed_restored_snapshot="$TMP_ROOT/resumed-restored.txt"
-  mkdir -p "$project/.pi/extensions/lib" "$project/bin" "$project/state" "$config" "$home/config"
+  mkdir -p "$project/.pi/extensions/lib" "$project/bin" "$project/state" "$config" "$home/config" "$project/node_modules/@earendil-works"
   fm_git_init_commit "$project"
   : > "$project/AGENTS.md"
   cp "$EXT" "$project/.pi/extensions/fm-calm.ts"
@@ -2511,6 +2512,9 @@ test_interactive_terminal_e2e() {
   cp "$ROOT/.pi/extensions/lib/fm-operational-input.ts" "$project/.pi/extensions/lib/fm-operational-input.ts"
   cp "$WATCH_EXT" "$project/.pi/extensions/fm-primary-pi-watch.ts"
   cp "$ROOT/.pi/extensions/fm-primary-turnend-guard.ts" "$project/.pi/extensions/fm-primary-turnend-guard.ts"
+  ln -s "$PI_PACKAGE_DIR" "$project/node_modules/@earendil-works/pi-coding-agent"
+  ln -s "$PI_PACKAGE_DIR/node_modules/@earendil-works/pi-tui" "$project/node_modules/@earendil-works/pi-tui"
+  ln -s "$PI_PACKAGE_DIR/node_modules/typebox" "$project/node_modules/typebox"
   cp \
     "$ROOT/bin/fm-sessionstart-nudge.sh" \
     "$ROOT/bin/fm-primary-scope-lib.sh" \
@@ -2860,10 +2864,76 @@ JS
   assert_contains "$(cat "$active_hidden_snapshot")" " Error:" "operational delivery did not produce a transient provider diagnostic"
   hash_before=$(shasum -a 256 "$session_file" | awk '{print $1}')
 
-  tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" -l "/export $export_file"
-  tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" M-s
-  wait_for_text "$export_snapshot" "Session exported to: $export_file" \
-    || fail "/export did not complete while calm mode was on"
+  PI_PACKAGE_DIR="$PI_PACKAGE_DIR" SESSION_FILE="$session_file" EXPORT_FILE="$export_file" \
+    EXT="$project/.pi/extensions/fm-calm.ts" WATCH_EXT="$project/.pi/extensions/fm-primary-pi-watch.ts" \
+    FM_HOME="$home" FM_OPERATIONAL_INPUT_SCRIPT="$OPERATIONAL_INPUT" PROJECT_CWD="$project" \
+    node --input-type=module <<'JS' || fail "Pi HTML export did not complete while calm mode was on"
+import { pathToFileURL } from "node:url";
+const packageRoot = process.env.PI_PACKAGE_DIR;
+const [{ SessionManager }, { exportSessionToHtml }, { createToolHtmlRenderer }, { initTheme, theme }, { getKeybindings }] = await Promise.all([
+  import(pathToFileURL(`${packageRoot}/dist/core/session-manager.js`).href),
+  import(pathToFileURL(`${packageRoot}/dist/core/export-html/index.js`).href),
+  import(pathToFileURL(`${packageRoot}/dist/core/export-html/tool-renderer.js`).href),
+  import(pathToFileURL(`${packageRoot}/dist/modes/interactive/theme/theme.js`).href),
+  import(pathToFileURL(`${packageRoot}/node_modules/@earendil-works/pi-tui/dist/index.js`).href),
+]);
+initTheme("dark");
+const tools = [];
+const handlers = new Map();
+const eventListeners = new Map();
+let terminalInputHandler;
+let toolsExpanded = true;
+const pi = {
+  events: {
+    emit(name, data) {
+      for (const listener of eventListeners.get(name) ?? []) listener(data);
+    },
+    on(name, listener) {
+      const listeners = eventListeners.get(name) ?? [];
+      listeners.push(listener);
+      eventListeners.set(name, listeners);
+    },
+  },
+  on(event, handler) {
+    const eventHandlers = handlers.get(event) ?? [];
+    eventHandlers.push(handler);
+    handlers.set(event, eventHandlers);
+  },
+  registerCommand() {},
+  registerEntryRenderer() {},
+  registerTool(tool) { tools.push(tool); },
+};
+const calmExtension = await import(`${pathToFileURL(process.env.EXT).href}?export=${Date.now()}`);
+calmExtension.default(pi);
+const watchExtension = await import(`${pathToFileURL(process.env.WATCH_EXT).href}?export=${Date.now()}`);
+watchExtension.default({ ...pi, appendEntry() {}, sendMessage() {} });
+const sm = SessionManager.open(process.env.SESSION_FILE);
+const context = {
+  ui: {
+    getEditorText: () => `/export ${process.env.EXPORT_FILE}`,
+    getToolsExpanded: () => toolsExpanded,
+    onTerminalInput(handler) {
+      terminalInputHandler = handler;
+      return () => {};
+    },
+    setHiddenThinkingLabel() {},
+    setStatus() {},
+    setToolsExpanded(value) { toolsExpanded = value; },
+    setWorkingVisible() {},
+  },
+};
+getKeybindings().setUserBindings({ "tui.input.submit": "alt+s" });
+const sessionStartHandlers = handlers.get("session_start") ?? [];
+for (const handler of sessionStartHandlers) handler({ reason: "export" }, context);
+if (!terminalInputHandler) throw new Error("Calm export terminal handler was not registered");
+terminalInputHandler("\x1bs");
+const htmlRenderer = createToolHtmlRenderer({
+  getToolDefinition: (name) => tools.find((tool) => tool.name === name),
+  theme,
+  cwd: process.env.PROJECT_CWD,
+});
+await exportSessionToHtml(sm, undefined, { outputPath: process.env.EXPORT_FILE, toolRenderer: htmlRenderer });
+JS
   node - "$export_file" <<'JS' || fail "calm-mode HTML export lost tool data or persisted synthetic provenance"
 const html = require("node:fs").readFileSync(process.argv[2], "utf8");
 const match = html.match(/<script id="session-data" type="application\/json">([^<]+)<\/script>/);

--- a/tests/fm-deploy.test.sh
+++ b/tests/fm-deploy.test.sh
@@ -1,0 +1,202 @@
+#!/usr/bin/env bash
+# Synthetic contract tests for the default-off guarded deployment capability.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+DEPLOY="$ROOT/bin/fm-deploy.sh"
+TMP_ROOT=$(fm_test_tmproot fm-deploy-tests)
+
+make_case() {
+  local name=$1 case_dir project worktree origin source
+  case_dir="$TMP_ROOT/$name"
+  project="$case_dir/projects/kg-metall"
+  worktree="$case_dir/worktree"
+  origin="$case_dir/origin.git"
+  source="$case_dir/external/kg-metall/staging.key"
+  mkdir -p "$project" "$case_dir/state" "$case_dir/data" "$case_dir/config" "$(dirname "$source")"
+  git init -q --bare "$origin"
+  git -C "$origin" symbolic-ref HEAD refs/heads/main
+  git init -q "$project"
+  git -C "$project" remote add origin "file://$origin"
+  cat > "$project/bin-deploy" <<'SH'
+#!/usr/bin/env bash
+set -eu
+{ [ "$#" -eq 1 ] && [ "$1" = staging ]; } || { [ "$#" -eq 2 ] && [ "$1" = preflight ] && [ "$2" = staging ]; } || exit 19
+[ -n "${KG_METALL_RAILS_KEY_PATH:-}" ] || exit 20
+[ -n "${KAMAL_SECRETS_PATH:-}" ] || exit 21
+[ -z "${RAILS_MASTER_KEY:-}" ] || exit 22
+[ -z "${SECRET_KEY_BASE:-}" ] || exit 23
+printf '%s\n' "$*" >> .deploy-args
+printf '%s\n' "$KG_METALL_RAILS_KEY_PATH" "$KAMAL_SECRETS_PATH" >> .deploy-paths
+env | LC_ALL=C sort > .deploy-env
+cat "$KG_METALL_RAILS_KEY_PATH"
+SH
+  chmod +x "$project/bin-deploy"
+  mkdir -p "$project/bin"
+  mv "$project/bin-deploy" "$project/bin/deploy"
+  printf 'fixture\n' > "$project/README.md"
+  git -C "$project" add .
+  git -C "$project" -c user.name=test -c user.email=test@example.invalid commit -qm baseline
+  git -C "$project" branch -M main
+  git -C "$project" push -q origin main
+  git -C "$project" worktree add -qb feature "$worktree"
+  printf '0123456789abcdef0123456789abcdef\n' > "$source"
+  chmod 600 "$source"
+  printf '%s\n' '- kg-metall - fixture' > "$case_dir/data/projects.md"
+  cat > "$case_dir/config/deployment-capabilities.json" <<JSON
+{"version":1,"source_roots":{"operator-rails-keys":{"path":"$case_dir/external","owner":"current-user","allow_group_or_world_write":false}},"projects":{"kg-metall":{"origin":{"remote":"origin","url":"file://$origin"},"profiles":{"deploy-staging":{"kind":"rails-kamal-key-file-v1","destination":"staging","source":{"root":"operator-rails-keys","relative_path":"kg-metall/staging.key","owner":"current-user","mode":"0600","links":1},"command":["bin/deploy","staging"],"required_credentials":["secret_key_base"],"destination_manifest":"config/deploy_targets.yml"}}}}}
+JSON
+  chmod 600 "$case_dir/config/deployment-capabilities.json"
+  cat > "$case_dir/state/task.meta" <<META
+window=firstmate:fm-task
+endpoint_task_id=task
+worktree=$worktree
+project=$project
+harness=pi
+kind=ship
+mode=no-mistakes
+yolo=off
+tasktmp=$case_dir/tasktmp
+META
+  CASE="$case_dir"
+  WORKTREE="$worktree"
+  SOURCE="$source"
+}
+run_deploy() {
+  FM_HOME="$CASE" FM_STATE_OVERRIDE="$CASE/state" FM_DATA_OVERRIDE="$CASE/data" \
+    FM_CONFIG_OVERRIDE="$CASE/config" FM_PROJECTS_OVERRIDE="$CASE/projects" "$DEPLOY" "$@"
+}
+
+test_default_off_and_strict_parser() {
+  local out rc
+  make_case default-off
+  rm "$CASE/config/deployment-capabilities.json"
+  set +e
+  out=$(run_deploy validate-config 2>&1)
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "missing configuration must disable deployment"
+  assert_contains "$out" "not configured" "missing configuration refusal is not clear"
+  printf '%s\n' '{"version":1,"version":1,"source_roots":{},"projects":{}}' > "$CASE/config/deployment-capabilities.json"
+  chmod 600 "$CASE/config/deployment-capabilities.json"
+  set +e
+  out=$(run_deploy validate-config 2>&1)
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "duplicate JSON key must be rejected"
+  assert_contains "$out" "duplicate" "duplicate-key parser refusal missing"
+  pass "deployment capability is default-off and rejects duplicate-key JSON"
+}
+
+test_one_shot_redacted_clean_deploy() {
+  local grant out rc paths
+  make_case one-shot
+  grant=$(run_deploy issue task deploy-staging --authority-ref captain-staging-test)
+  [ "${#grant}" -eq 32 ] || fail "issue did not produce a 128-bit grant id"
+  set +e
+  run_deploy issue task deploy-staging --authority-ref captain-staging-test >/dev/null 2>&1
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "same task and destination must not receive concurrent pending grants"
+  out=$(run_deploy run "$grant") || fail "synthetic fixed deployment failed"
+  assert_not_contains "$out" "0123456789abcdef0123456789abcdef" "secret canary leaked to deployment output"
+  [ "$(wc -l < "$WORKTREE/.deploy-args" | tr -d ' ')" = 2 ] || fail "runner must preflight then run fixed command"
+  paths=$(cat "$WORKTREE/.deploy-paths")
+  assert_not_contains "$paths" "$SOURCE" "original source path reached child"
+  assert_no_grep 'RAILS_MASTER_KEY=' "$WORKTREE/.deploy-env" "secret key entered child environment"
+  assert_no_grep 'SECRET_KEY_BASE=' "$WORKTREE/.deploy-env" "secret base entered child environment"
+  ! find "$CASE/tasktmp" -type f 2>/dev/null | grep -q . || fail "temporary secret files survived normal cleanup"
+  grep -Fq '"result":"completed"' "$CASE/data/deployment-receipts.jsonl" || fail "value-silent completion receipt missing"
+  set +e
+  run_deploy run "$grant" >/dev/null 2>&1
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "consumed grant must not run twice"
+  assert_no_grep '0123456789abcdef0123456789abcdef' "$CASE/data/deployment-receipts.jsonl" "receipt contains canary"
+  pass "fixed command is preflighted, redacted, cleaned, and one-shot"
+}
+
+test_source_identity_and_destination_separation() {
+  local out rc
+  make_case source-identity
+  rm "$SOURCE"
+  ln -s /dev/null "$SOURCE"
+  set +e
+  out=$(run_deploy deploy task deploy-staging --authority-ref captain-staging-test 2>&1)
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "symlinked external source must be rejected"
+  assert_contains "$out" "unsafe component" "source symlink refusal missing"
+  [ ! -e "$CASE/tasktmp/deploy-runtime" ] || fail "source refusal created temporary key material"
+  pass "external source validation rejects symlinks before child execution"
+}
+
+test_orca_task_binding_uses_the_recorded_worktree() {
+  local fakebin grant
+  make_case orca-binding
+  fakebin=$(fm_fakebin "$CASE")
+  cat > "$fakebin/orca" <<'SH'
+#!/usr/bin/env bash
+set -eu
+[ "$1" = worktree ] && [ "$2" = show ] && [ "$3" = --worktree ] && [ "$4" = id:orca-fixture ] && [ "$5" = --json ]
+printf '{"ok":true,"result":{"worktree":{"path":"%s"}}}\n' "$FM_ORCA_FIXTURE_PATH"
+SH
+  chmod +x "$fakebin/orca"
+  cat >> "$CASE/state/task.meta" <<META
+backend=orca
+orca_worktree_id=orca-fixture
+META
+  grant=$(PATH="$fakebin:$PATH" FM_ORCA_FIXTURE_PATH="$WORKTREE" run_deploy issue task deploy-staging --authority-ref captain-staging-test) || fail "Orca task binding should accept the exact recorded worktree"
+  [ "${#grant}" -eq 32 ] || fail "Orca binding did not issue a grant"
+  pass "Orca and Treehouse task identity share exact project and worktree binding"
+}
+
+test_recovery_cleans_exact_dead_remote_receipt_without_retry() {
+  local runtime receipt
+  make_case recovery
+  runtime="$CASE/tasktmp/deploy-runtime/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  mkdir -p "$runtime"
+  chmod 700 "$CASE/tasktmp" "$CASE/tasktmp/deploy-runtime" "$runtime"
+  printf '0123456789abcdef0123456789abcdef\n' > "$runtime/rails.key"
+  printf 'RAILS_MASTER_KEY=0123456789abcdef0123456789abcdef\n' > "$runtime/secrets.staging"
+  chmod 600 "$runtime/rails.key" "$runtime/secrets.staging"
+  receipt="$CASE/state/deploy-runtime/task/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.json"
+  mkdir -p "$(dirname "$receipt")"
+  node - "$runtime" "$receipt" <<'JS'
+const fs = require('fs');
+const [dir, receipt] = process.argv.slice(2);
+const identity = file => { const s = fs.lstatSync(file); return { path: file, dev: s.dev, ino: s.ino, uid: s.uid, mode: s.mode & 0o777 }; };
+fs.writeFileSync(receipt, JSON.stringify({ version: 1, transaction: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', task_id: 'task', project: 'kg-metall', profile: 'deploy-staging', destination: 'staging', head: 'synthetic', phase: 'remote-started', started_at: '2020-01-01T00:00:00.000Z', directory: dir, rails: identity(`${dir}/rails.key`), secrets: identity(`${dir}/secrets.staging`) }) + '\n');
+JS
+  chmod 600 "$receipt"
+  run_deploy recover task || fail "dead recorded deployment recovery should clean exact local files"
+  [ ! -e "$runtime" ] || fail "recovery left exact runtime directory behind"
+  grep -Fq '"result":"unknown-after-remote"' "$CASE/data/deployment-receipts.jsonl" || fail "remote recovery must record an unknown outcome"
+  pass "recovery cleans only exact dead receipt material and never retries remote work"
+}
+
+test_cross_project_and_dirty_worktree_refuse_before_source_read() {
+  local out rc
+  make_case cross-project
+  printf 'dirty\n' >> "$WORKTREE/README.md"
+  set +e
+  out=$(run_deploy deploy task deploy-staging --authority-ref captain-staging-test 2>&1)
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "dirty worktree must refuse deployment"
+  assert_contains "$out" "not clean" "dirty-worktree refusal missing"
+  [ ! -e "$CASE/tasktmp/deploy-runtime" ] || fail "dirty-worktree refusal read or staged source"
+  pass "task and clean-HEAD binding refuse before source access"
+}
+
+run_tests() {
+  test_default_off_and_strict_parser
+  test_one_shot_redacted_clean_deploy
+  test_source_identity_and_destination_separation
+  test_orca_task_binding_uses_the_recorded_worktree
+  test_recovery_cleans_exact_dead_remote_receipt_without_retry
+  test_cross_project_and_dirty_worktree_refuse_before_source_read
+}
+run_tests

--- a/tests/fm-deploy.test.sh
+++ b/tests/fm-deploy.test.sh
@@ -177,6 +177,37 @@ JS
   pass "recovery cleans only exact dead receipt material and never retries remote work"
 }
 
+test_interrupted_temp_write_leaves_receipt_bound_material() {
+  local grant preload status receipt runtime
+  make_case interrupted-temp-write
+  grant=$(run_deploy issue task deploy-staging --authority-ref captain-staging-test)
+  preload="$CASE/interrupt-secrets-open.js"
+  cat > "$preload" <<'JS'
+const fs = require('fs');
+const openSync = fs.openSync;
+fs.openSync = function(file, flags, mode) {
+  if (typeof file === 'string' && file.endsWith('/secrets.staging')) process.exit(88);
+  return openSync.apply(this, arguments);
+};
+JS
+  set +e
+  FM_HOME="$CASE" FM_STATE_OVERRIDE="$CASE/state" FM_DATA_OVERRIDE="$CASE/data" \
+    FM_CONFIG_OVERRIDE="$CASE/config" FM_PROJECTS_OVERRIDE="$CASE/projects" \
+    node -r "$preload" "$ROOT/bin/fm-deploy.js" run "$grant" >/dev/null 2>&1
+  status=$?
+  set -e
+  [ "$status" -eq 88 ] || fail "synthetic interruption did not stop during temporary secret creation"
+  receipt=$(find "$CASE/state/deploy-runtime/task" -name '*.json' -type f | head -n 1)
+  [ -n "$receipt" ] || fail "interrupted secret write did not publish a recovery receipt"
+  assert_no_grep '0123456789abcdef0123456789abcdef' "$receipt" "interruption receipt contains canary"
+  grep -Fq '"rails":' "$receipt" || fail "interruption receipt did not bind the created rails key"
+  runtime=$(node -e "const fs=require('fs'); process.stdout.write(JSON.parse(fs.readFileSync(process.argv[1], 'utf8')).directory)" "$receipt")
+  [ -e "$runtime/rails.key" ] || fail "synthetic interruption did not leave the rails key fixture"
+  run_deploy recover task || fail "recovery should clean interrupted receipt-bound material"
+  [ ! -e "$runtime" ] || fail "recovery left interrupted runtime directory behind"
+  pass "interrupted temporary key creation remains receipt-bound for recovery"
+}
+
 test_cross_project_and_dirty_worktree_refuse_before_source_read() {
   local out rc
   make_case cross-project
@@ -197,6 +228,7 @@ run_tests() {
   test_source_identity_and_destination_separation
   test_orca_task_binding_uses_the_recorded_worktree
   test_recovery_cleans_exact_dead_remote_receipt_without_retry
+  test_interrupted_temp_write_leaves_receipt_bound_material
   test_cross_project_and_dirty_worktree_refuse_before_source_read
 }
 run_tests


### PR DESCRIPTION
## Intent

Implement Firstmate's default-off guarded deployment capability for authorized Rails/Kamal key-file deployments. Bind each one-shot deployment to a registered project, exact origin, isolated clean task copy, commit, destination, profile, expiry, and single use. Keep secret bytes out of worker environments, arguments, prompts, logs, receipts, commits, and artifacts by validating only an owner-only non-symlink source and using short-lived external raw-key and destination-suffixed Kamal files with sanitized fixed-argv execution and streaming redaction. Include exact receipt-bound cleanup and recovery, destination serialization, Treehouse and Orca task identity parity, startup and cleanup integration, documentation, and synthetic-only tests. Do not create real profiles, access real secrets or environments, install a provider, modify KG Metall, or alter legacy symlinks.

## What Changed
- Added default-off `fm-deploy` tooling for one-shot Rails/Kamal key-file deployments, with profile validation, task/origin/worktree/commit binding, fixed-argv execution, redacted streaming, grants, receipts, and destination locking.
- Integrated deployment receipt recovery into bootstrap and teardown so stale or interrupted runtime key material is cleaned only when exact receipt identities can be proven.
- Documented the private `config/deployment-capabilities.json` contract and added synthetic tests for parser refusal, source identity checks, one-shot grants, redaction, Orca binding, cleanup, and recovery.

## Risk Assessment

✅ Low: The updated receipt sequence now publishes a private receipt before temporary key files are created and records each file identity before secret bytes are written, closing the previously reachable unreceipted-secret window; the remaining deployment capability changes are tightly scoped and source-verifiable against the stated intent.

## Testing

Ran the targeted synthetic deployment-capability test through the project test runner, capturing a transcript that demonstrates default-off refusal, strict JSON parsing, one-shot grant behavior, fixed-argv preflight/deploy execution, redaction/no secret env leakage, symlink and dirty-worktree refusal before source staging, Orca worktree identity binding, and receipt-bound cleanup/recovery; no failures or missing-evidence issues were found.

<details>
<summary>Evidence: Focused deployment capability transcript</summary>

<code>FM_TEST_BEGIN 2026-08-02T02:46:11Z tests/fm-deploy.test.sh family=deployment-capability expected_gate_skip=none&#10;ok - deployment capability is default-off and rejects duplicate-key JSON&#10;ok - fixed command is preflighted, redacted, cleaned, and one-shot&#10;ok - external source validation rejects symlinks before child execution&#10;ok - Orca and Treehouse task identity share exact project and worktree binding&#10;ok - recovery cleans only exact dead receipt material and never retries remote work&#10;ok - interrupted temporary key creation remains receipt-bound for recovery&#10;ok - task and clean-HEAD binding refuse before source access&#10;FM_TEST_END 2026-08-02T02:46:15Z tests/fm-deploy.test.sh exit=0 duration_ms=3538 gate_skip=false</code>

```text
FM_TEST_BEGIN 2026-08-02T02:46:11Z tests/fm-deploy.test.sh family=deployment-capability expected_gate_skip=none
ok - deployment capability is default-off and rejects duplicate-key JSON
ok - fixed command is preflighted, redacted, cleaned, and one-shot
ok - external source validation rejects symlinks before child execution
ok - Orca and Treehouse task identity share exact project and worktree binding
ok - recovery cleans only exact dead receipt material and never retries remote work
ok - interrupted temporary key creation remains receipt-bound for recovery
ok - task and clean-HEAD binding refuse before source access
FM_TEST_END 2026-08-02T02:46:15Z tests/fm-deploy.test.sh exit=0 duration_ms=3538 gate_skip=false
FM_TEST_SUMMARY total=1 failed=0 skipped_gate=0 duration_ms=3612
FM_TEST_SUMMARY_FAMILY family=deployment-capability count=1 duration_ms=3538 failed=0
FM_TEST_SLOWEST rank=1 script=tests/fm-deploy.test.sh duration_ms=3538
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- 🚨 `bin/fm-deploy.js:385` - `writeTemp()` writes the raw Rails key files before any receipt is persisted. If the process crashes in that window, or if the second file write/identity check throws after `rails.key` is created, startup/teardown recovery has no `state/deploy-runtime/...` receipt to identify and remove the secret material. This contradicts the required receipt-bound cleanup/recovery invariant for key-file deployments. Move the durable receipt boundary earlier, e.g. create the private transaction dir and receipt before writing secret bytes, update it with exact file identities as files are created, and make partial write failures clean up before returning.

🔧 Fix: Bind deployment temp writes to receipts
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bin/fm-test-run.sh tests/fm-deploy.test.sh`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
