### PR TITLE
fix(tests): portable contender pid under Bash 3.2

### DIFF
--- a/tests/fm-session-start.test.sh
+++ b/tests/fm-session-start.test.sh
@@ -771,7 +771,9 @@ SH
   i=1
   while [ "$i" -le 40 ]; do
     (
-      harness_pid=$(sh -c 'printf "%s\n" "$PPID"')
+      # Prefer BASHPID when present; Bash 3.2 lacks it and $$ is identical
+      # across subshells, so fall back to nested shell PPID as contender pid.
+      harness_pid=${BASHPID:-$(sh -c 'echo $PPID')}
       : > "$home/state/harness-$harness_pid"
       : > "$ready/$i"
       while [ "$(find "$ready" -type f | wc -l | tr -d ' ')" -lt 40 ]; do


### PR DESCRIPTION
## Intent

Rebase portable BASHPID contender pid test fix onto latest main after merge conflicts

## What Changed

08c56ef fix(tests): portable contender pid under Bash 3.2

## Testing

- ⏭️ **Test** - skipped

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⏭️ **Review** - skipped</summary>

Step was skipped.

</details>

<details>
<summary>⏭️ **Test** - skipped</summary>

Step was skipped.

</details>

<details>
<summary>⏭️ **Document** - skipped</summary>

Step was skipped.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
