### PR TITLE
feat(skills): add parallel-ideation skill for multi-skill ideation runs

### DIFF
--- a/.agents/skills/parallel-ideation/SKILL.md
+++ b/.agents/skills/parallel-ideation/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: parallel-ideation
+description: >-
+  Run several ideation or brainstorming skills in parallel on one subject and turn their outputs into a single synthesis.
+  Use when the captain invokes /parallel-ideation or asks to run multiple ideation, brainstorming, or design-thinking skills in parallel on the same subject and synthesize the results.
+user-invocable: true
+metadata:
+  internal: true
+---
+
+# parallel-ideation
+
+Coordinate several different ideation or brainstorming skills against one subject so their disagreement, not only their overlap, becomes the deliverable.
+This skill is generic over the roster: the captain supplies which skills run at intake, and nothing here hard-codes a particular ideation skill, plugin, or harness.
+The procedure has five stages.
+Follow them in order; do not improvise a parallel loop while a client is waiting.
+
+## Why this exists
+
+One ideation skill yields one question set.
+Several different skills on the same raw subject yield several different question sets, and the resolution comes from the friction between them.
+The cost is coordination, and this skill is that coordination written down.
+
+## 1. Intake
+
+1. Capture the subject in one paragraph, in the source's own words.
+   Do not summarize, rephrase, or normalize it before the crews see it, because each rostered skill is supposed to interrogate the raw statement.
+2. Confirm the roster with the captain: which ideation or brainstorming skills run, with one crewmate per skill.
+   The roster is captain-supplied and may change between runs; never invent a default roster.
+3. Resolve the harness per crew from what actually provides that skill.
+   A skill delivered as a harness-specific plugin can only run on that harness, so the roster can force a harness pin that differs from this home's usual crewmate default.
+   Perform that check against the skill's real delivery surface before spawn; do not assume a fixed harness name here.
+   Load `harness-adapters` before any spawn so the pin is applied through the ordinary dispatch path.
+4. Resolve the repository the crews will be spawned into before dispatch.
+   A spawn allocates a worktree, so a subject with no repository yet must go through the `project-management` skill first rather than mid-run.
+5. Assign a durable run id for this parallel run (the id that will own the shared premise note and the synthesis).
+   Prefer a single backlog or task identity that groups the crew scouts so cleanup and history stay legible.
+
+## 2. Shared premise note
+
+1. Create `data/<run-id>/facts.md` yourself and remain its only writer.
+   Crews never edit this file.
+2. Seed it with the raw subject paragraph from intake, plus any fact the captain has already confirmed at that moment.
+3. Every crew brief must instruct the crew to read this note before starting and again after each relayed answer.
+4. The note's purpose is to stop the crews drifting into incompatible premises, which would make their reports impossible to compare at synthesis.
+5. Append only captain-confirmed facts.
+   Do not write firstmate guesses, unconfirmed crew assumptions, or product choices firstmate invents on its own authority.
+
+## 3. Dispatch
+
+1. Spawn one crewmate per rostered skill as a scout: the deliverable is a report, never a PR.
+   Ordinary scout lifecycle, briefs, and isolation rules in `AGENTS.md` section 7 still apply; this skill only owns the parallel coordination on top of them.
+2. Each crew brief must:
+   - name exactly one skill from the roster for that crew to run;
+   - point at the shared premise note path and require the re-read rule above;
+   - carry the raw subject paragraph without firstmate rewriting it;
+   - restate that crewmates never address the captain and that all captain communication flows through firstmate;
+   - tell the crew how to raise a question: append a keyed `blocked:` line and stop, rather than guessing a product answer.
+3. Apply any harness pin resolved at intake for that crew when spawning.
+4. Record the run as under way and supervise under the ordinary supervision contract.
+
+## 4. Question loop
+
+1. Collect questions rather than relaying them one at a time as they arrive.
+   Wait for a natural batch boundary (for example every crew has either blocked or finished a first pass, or a bounded wait has elapsed with open questions) before showing the captain anything.
+2. Deduplicate across crews before the captain sees them.
+   Near-identical questions merge into one item that records which crews asked it.
+   The same question arriving three times is signal about importance, not three separate questions.
+3. Send the captain one batch at a time in plain chat, or a structured surface when the batch is large enough that reading it as prose is worse.
+   Phrase each item as a decision or clarification in captain-facing language, with the asking crews attributed when that attribution helps.
+4. When the captain answers, relay each answer only to the crews that asked that question.
+   Append every confirmed fact to the shared premise note.
+   Tell every crew in the run, including those that did not ask, to re-read the premise note so premises stay aligned.
+5. Firstmate does not answer a crew's question on its own authority when the question is a product choice that belongs to the captain, regardless of the project's autonomy posture.
+   Only captain-confirmed facts enter the premise note and the relay.
+6. Repeat the loop until every crew has written its report or a genuine blocker requires captain or firstmate action outside this skill.
+
+## 5. Synthesis and close
+
+1. Each crew must write its report before its scratch worktree can be discarded.
+   Do not clean up a crew that has not left a self-contained report.
+2. Read every report completely.
+3. Produce one synthesis document for the run.
+   Recommended path: `data/<run-id>/synthesis.md`, or another durable captain-facing path the captain requested at intake.
+   The synthesis must include, at minimum:
+   - the raw subject statement used for the run;
+   - a short map of which rostered skill each crew ran;
+   - the shared findings where the crews agreed, attributed only when attribution still matters;
+   - an explicit contradictions section for every material point where the crews disagreed, with each position attributed to the crew that held it.
+4. Do not average, blend, or silently drop a minority position.
+   Preserving the contradiction is the deliverable's main value, because agreement between the crews was already cheap to obtain.
+5. Any decision the run surfaced but did not resolve follows `decision-hold-lifecycle` before the run is treated as complete.
+6. Cleanup happens only after every report exists and the synthesis is written.
+   Tear down scout worktrees only through the ordinary landed-report and unresolved-decision completion path; never force discard without explicit authority.
+
+## Out of scope
+
+- Choosing the roster for the captain.
+- Answering product questions in place of the captain.
+- Turning the synthesis into implementation without a separate ship authorization.
+- Hard-coding which ideation skills, plugins, or harnesses participate.
+
+## Cross-references
+
+- Spawn, scout briefs, and cleanup: `AGENTS.md` section 7 and section 11; `bin/fm-brief.sh` and `bin/fm-spawn.sh` own mechanics.
+- Harness pins and skill-invocation: `harness-adapters`.
+- Missing repository at intake: `project-management`.
+- Unresolved captain decisions at close: `decision-hold-lifecycle`.
+- Captain-facing outcome language: `AGENTS.md` section 9.

--- a/.agents/skills/parallel-ideation/SKILL.md
+++ b/.agents/skills/parallel-ideation/SKILL.md
@@ -30,7 +30,7 @@ The cost is coordination, and this skill is that coordination written down.
 3. Resolve the harness per crew from what actually provides that skill.
    A skill delivered as a harness-specific plugin can only run on that harness, so the roster can force a harness pin that differs from this home's usual crewmate default.
    Perform that check against the skill's real delivery surface before spawn; do not assume a fixed harness name here.
-   Inside the routing precedence `AGENTS.md` section 4 owns, an explicit per-task captain override still wins, but a pin that delivery makes mandatory outranks a matching crew-dispatch profile's harness, because a profile harness that cannot run the assigned skill silently defeats the dispatch.
+   Resolve the pin through the routing precedence `AGENTS.md` section 4 owns, and when delivery makes a harness mandatory, confirm it with the captain and carry it as the explicit per-task captain override that precedence already ranks first.
    Load `harness-adapters` before any spawn so the pin is applied through the ordinary dispatch path.
 4. Resolve the repository the crews will be spawned into before dispatch.
    A spawn allocates a worktree, so a subject with no repository yet must go through the `project-management` skill first rather than mid-run.

--- a/.agents/skills/parallel-ideation/SKILL.md
+++ b/.agents/skills/parallel-ideation/SKILL.md
@@ -30,6 +30,7 @@ The cost is coordination, and this skill is that coordination written down.
 3. Resolve the harness per crew from what actually provides that skill.
    A skill delivered as a harness-specific plugin can only run on that harness, so the roster can force a harness pin that differs from this home's usual crewmate default.
    Perform that check against the skill's real delivery surface before spawn; do not assume a fixed harness name here.
+   Inside the routing precedence `AGENTS.md` section 4 owns, an explicit per-task captain override still wins, but a pin that delivery makes mandatory outranks a matching crew-dispatch profile's harness, because a profile harness that cannot run the assigned skill silently defeats the dispatch.
    Load `harness-adapters` before any spawn so the pin is applied through the ordinary dispatch path.
 4. Resolve the repository the crews will be spawned into before dispatch.
    A spawn allocates a worktree, so a subject with no repository yet must go through the `project-management` skill first rather than mid-run.
@@ -38,7 +39,7 @@ The cost is coordination, and this skill is that coordination written down.
 
 ## 2. Shared premise note
 
-1. Create `data/<run-id>/facts.md` yourself and remain its only writer.
+1. Create `data/<run-id>/facts.md` in the firstmate home yourself and remain its only writer.
    Crews never edit this file.
 2. Seed it with the raw subject paragraph from intake, plus any fact the captain has already confirmed at that moment.
 3. Every crew brief must instruct the crew to read this note before starting and again after each relayed answer.
@@ -52,7 +53,7 @@ The cost is coordination, and this skill is that coordination written down.
    Ordinary scout lifecycle, briefs, and isolation rules in `AGENTS.md` section 7 still apply; this skill only owns the parallel coordination on top of them.
 2. Each crew brief must:
    - name exactly one skill from the roster for that crew to run;
-   - point at the shared premise note path and require the re-read rule above;
+   - carry the absolute firstmate-home path to the shared premise note, never the relative `data/<run-id>/facts.md` form, because a crew reads it from an isolated project worktree where that relative path resolves to nothing or to an unrelated file, and require the re-read rule above;
    - carry the raw subject paragraph without firstmate rewriting it;
    - restate that crewmates never address the captain and that all captain communication flows through firstmate;
    - tell the crew how to raise a question: append a keyed `blocked:` line and stop, rather than guessing a product answer.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -257,6 +257,7 @@ If established evidence already answers an informational question, relay it with
 Never both present a likely-enough solution and launch a parallel design exercise that is not expected to change it.
 A diagnostic request, report, recommendation, or implementation-ready finding is evidence, not authorization to change code.
 Load `diagnostic-reasoning` before scoping a reported bug and before acting on a diagnostic report.
+Load `parallel-ideation` when the captain asks to run several ideation or brainstorming skills in parallel on one subject and synthesize their outputs.
 
 Treat file or subsystem overlap as a risk signal rather than an automatic reason to wait, and dispatch isolated work immediately with no concurrency cap when each change can be independently implemented and validated and the selected delivery path can reconcile ordinary rebases or conflicts.
 Serialize only for a true semantic dependency, shared mutable external state, incompatible concurrent migration, or another concrete condition that makes independent progress or reconciliation unsafe; same-file editing alone is insufficient, and genuine blockers remain durable.

--- a/README.md
+++ b/README.md
@@ -167,13 +167,14 @@ Full architecture - the supervision engine, worktree isolation, secondmates, dis
 Firstmate ships these user-invocable built-in skills.
 Claude and grok use the slash form shown here; codex uses the same names with `$`, such as `$afk`.
 
-| Skill              | What it does                                                                                                                                  |
-| ------------------ | -------------------------------------------------------------------------------------------------------------------------------------------- |
-| `/afk`             | Enter away-mode supervision: the sub-supervisor self-handles routine notifications in bash, escalates captain-relevant events and bounded declared-external-wait rechecks as batched digests, and actively alerts if delivery gets stuck while you step away |
-| `/ahoy`            | Recap visible session events since the prior real captain message plus visibly unanswered captain decisions, falling back to Bearings when invoked as the session's first real captain message |
-| `/bearings`        | Generate a concise four-section chat digest from bounded local fleet and registered-secondmate state; use `/bearings file` to also replace today's dated report in `data/`, and add `include PRs` when live PR enrichment is wanted |
-| `/updatefirstmate` | Self-update the running firstmate and its secondmates to the latest from origin with fast-forward-only pulls, then re-read instructions and nudge secondmates |
-| `/stow`            | Sweep the session for uncaptured durable knowledge, route each finding to its disk home per AGENTS.md, file undone next steps to the backlog, and report what is now safe to reset |
+| Skill                | What it does                                                                                                                                  |
+| -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| `/afk`               | Enter away-mode supervision: the sub-supervisor self-handles routine notifications in bash, escalates captain-relevant events and bounded declared-external-wait rechecks as batched digests, and actively alerts if delivery gets stuck while you step away |
+| `/ahoy`              | Recap visible session events since the prior real captain message plus visibly unanswered captain decisions, falling back to Bearings when invoked as the session's first real captain message |
+| `/bearings`          | Generate a concise four-section chat digest from bounded local fleet and registered-secondmate state; use `/bearings file` to also replace today's dated report in `data/`, and add `include PRs` when live PR enrichment is wanted |
+| `/parallel-ideation` | Run several captain-supplied ideation or brainstorming skills in parallel on one subject and synthesize their reports into one document |
+| `/updatefirstmate`   | Self-update the running firstmate and its secondmates to the latest from origin with fast-forward-only pulls, then re-read instructions and nudge secondmates |
+| `/stow`              | Sweep the session for uncaptured durable knowledge, route each finding to its disk home per AGENTS.md, file undone next steps to the backlog, and report what is now safe to reset |
 
 Bearings invocation examples:
 

--- a/docs/documentation-audiences.json
+++ b/docs/documentation-audiences.json
@@ -152,6 +152,10 @@
       "audience": "agent-runtime"
     },
     {
+      "path": ".agents/skills/parallel-ideation/SKILL.md",
+      "audience": "agent-runtime"
+    },
+    {
       "path": ".agents/skills/process-event-sources/SKILL.md",
       "audience": "agent-runtime"
     },


### PR DESCRIPTION
## Intent

Add a new captain-invocable firstmate skill, parallel-ideation, that encodes the procedure for running several ideation or brainstorming skills in parallel on one subject and turning their output into a single synthesis.

This changes firstmate's shared tracked material, so firstmate-coding-guidelines bind (knowledge placement, one-owner, size discipline, trigger hygiene, repo style).

Why: one ideation skill gives one question set; several different skills in parallel on the same subject give several different question sets; the value is the disagreement between them, not the overlap. The skill is the coordination so it is not improvised while a client is waiting.

Deliverable:
- Create .agents/skills/parallel-ideation/SKILL.md matching internal firstmate skill conventions (English, one full sentence per line, plain dash only).
- Skill must be generic over the roster: do not hard-code any particular ideation skill, plugin, or harness; roster is captain-supplied at intake.
- Procedure owns five stages: (1) Intake - raw subject paragraph, confirm roster, resolve harness per crew from what provides that skill as a check not a fixed name, resolve repository via project-management before dispatch if none; (2) Shared premise note data/<run-id>/facts.md firstmate-only writer; (3) Dispatch one scout per skill with briefs that name one skill, point at premise note, crews never address captain, blocked: for questions; (4) Question loop - batch/dedupe questions, relay answers only to askers, append confirmed facts, re-read note for all, firstmate does not answer product choices for captain; (5) Synthesis with explicit contradictions section attributing positions, decision-hold-lifecycle for unresolved decisions, cleanup only after every report exists.
- Declare load trigger as exactly one line in AGENTS.md section 7 intake material (captain-invocable, not section 13); procedure stays entirely in the skill.
- No other owner restates the procedure; cross-references only.
- Do not add tests that assert on documentation bytes; do not touch projects/, data/, state/, or config/; no agent name as commit co-author.
- bin/fm-doc-audience-check.sh must pass; bin/fm-lint.sh only if bin/ changed.

## What Changed

- Adds `.agents/skills/parallel-ideation/SKILL.md`, a captain-invocable (`/parallel-ideation`) skill that owns a five-stage procedure: intake (raw subject, captain-supplied roster, per-crew harness pin resolved through the `AGENTS.md` section 4 precedence, repository resolved before dispatch), a firstmate-only shared premise note at `data/<run-id>/facts.md`, one scout per rostered skill with briefs carrying the absolute home path to that note, a batched and deduplicated question loop that relays answers only to the asking crews, and a synthesis that keeps an explicit attributed contradictions section. The skill is generic over the roster and hard-codes no ideation skill, plugin, or harness.
- Declares the load trigger as a single line in `AGENTS.md` section 7 intake material, with the procedure staying entirely in the skill and other owners carrying cross-references only.
- Lists `/parallel-ideation` in the README built-in-skills table and classifies the new SKILL.md as `agent-runtime` in `docs/documentation-audiences.json`, so `bin/fm-doc-audience-check.sh` and `tests/fm-documentation-audiences.test.sh` pass with the new tracked prose surface.

## Risk Assessment

✅ Low: The change is documentation-only, conforms to every source-verifiable acceptance criterion, and the one gate-breaking omission from the previous round is now fixed and statically confirmed complete.

## Testing

<code>Ran the intent-required repo checks (bin/fm-doc-audience-check.sh ok, tests/fm-documentation-audiences.test.sh fully green, fm-lint.sh correctly skipped since bin/ is unchanged), then demonstrated the skill as a captain actually experiences it by running Claude Code headlessly in a sandbox home wired through the same `.claude/skills -&gt; .agents/skills` discovery path: `/parallel-ideation` loaded and produced the complete five-stage run with the raw subject preserved, the captain-supplied roster, harness resolved from the skill&#39;s real delivery surface, the missing repository escalated through project-management before dispatch, the firstmate-only premise note, absolute-path briefs with the `blocked:` protocol, the deduped question batch, and a synthesis carrying an attributed contradictions section plus decision-hold-lifecycle and cleanup-last; a second run with no slash command confirmed the AGENTS.md section 7 trigger fires and is not in section 13. Also captured a rendered screenshot of the README skills table showing the new `/parallel-ideation` row. All checks passed, no test or product failures, sandbox removed and the worktree left clean.</code>

- Evidence: Rendered README built-in-skills table showing /parallel-ideation (local file: <code>/var/folders/1t/12j9b68s5tj28wbq7wd_6fm80000gn/T/no-mistakes-evidence/01KZ09S6G9TQBP27VYTWMMC1HJ/readme-skills-table.png</code>)
<details>
<summary>Evidence: Rendered README skills-table HTML (source of the screenshot)</summary>

```text
<!DOCTYPE html>
<html xmlns="http://www.w3.org/1999/xhtml">
<head>
  <meta charset="utf-8" />
  <meta name="generator" content="pandoc 3.10" />
  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes" />
  <title>firstmate README - built-in skills</title>
  <style>

span.smallcaps{font-variant: small-caps;}
div.columns{display: flex; gap: 1.5em;}
div.column{flex: auto;}
@media screen {
div.columns{gap: min(4vw, 1.5em);}
div.column{overflow-x: auto;}
}
div.hanging-indent{margin-left: 1.5em; text-indent: -1.5em;}

ul.task-list[class]{list-style: none;}
ul.task-list li input[type="checkbox"] {
font-size: inherit;
width: 0.8em;
margin: 0 0.8em 0.2em -1.6em;
vertical-align: middle;
}
.display.math{display: block; text-align: center; margin: 0.5rem auto;}
</style>
  <style type="text/css">body { font-family: -apple-system, "Segoe UI", Helvetica, Arial, sans-serif; font-size: 15px; line-height: 1.6; color: #1f2328; margin: 32px; max-width: 1100px; }
table { border-collapse: collapse; display: block; overflow: auto; }
th, td { border: 1px solid #d1d9e0; padding: 8px 13px; vertical-align: top; }
tr:nth-child(2n) { background: #f6f8fa; }
code { background: #eff1f3; padding: 2px 5px; border-radius: 6px; font-size: 90%; }
</style>
</head>
<body>
<header id="title-block-header">
<h1 class="title">firstmate README - built-in skills</h1>
</header>
<p>Full architecture - the supervision engine, worktree isolation,
secondmates, dispatch profiles, project modes, optional X mode, fleet
sync, and self-update - is in <a href="docs/architecture.md">docs/architecture.md</a>.</p>
<h2 id="built-in-skills">Built-in skills</h2>
<p>Firstmate ships these user-invocable built-in skills. Claude and grok
use the slash form shown here; codex uses the same names with
<code>$</code>, such as <code>$afk</code>.</p>
<table>
<thead>
<tr>
<th>Skill</th>
<th>What it does</th>
</tr>
</thead>
<tbody>
<tr>
<td><code>/afk</code></td>
<td>Enter away-mode supervision: the sub-supervisor self-handles routine
notifications in bash, escalates captain-relevant events and bounded
declared-external-wait rechecks as batched digests, and actively alerts
if delivery gets stuck while you step away</td>
</tr>
<tr>
<td><code>/ahoy</code></td>
<td>Recap visible session events since the prior real captain message
plus visibly unanswered captain decisions, falling back to Bearings when
invoked as the session&#39;s first real captain message</td>
</tr>
<tr>
<td><code>/bearings</code></td>
<td>Generate a concise four-section chat digest from bounded local fleet
and registered-secondmate state; use <code>/bearings file</code> to also
replace today&#39;s dated report in <code>data/</code>, and add
<code>include PRs</code> when live PR enrichment is wanted</td>
</tr>
<tr>
<td><code>/parallel-ideation</code></td>
<td>Run several captain-supplied ideation or brainstorming skills in
parallel on one subject and synthesize their reports into one
document</td>
</tr>
<tr>
<td><code>/updatefirstmate</code></td>
<td>Self-update the running firstmate and its secondmates to the latest
from origin with fast-forward-only pulls, then re-read instructions and
nudge secondmates</td>
</tr>
<tr>
<td><code>/stow</code></td>
<td>Sweep the session for uncaptured durable knowledge, route each
finding to its disk home per AGENTS.md, file undone next steps to the
backlog, and report what is now safe to reset</td>
</tr>
</tbody>
</table>
<p>Bearings invocation examples:</p>
</body>
</html>
```
</details>
<details>
<summary>Evidence: Captain transcript: /parallel-ideation drives all five stages</summary>

```text
# Captain transcript: /parallel-ideation in a firstmate home
Command:
  cd <sandbox home with .claude/skills -> repo .agents/skills>
  claude -p "/parallel-ideation <subject paragraph + roster + no repo yet>" \
    --setting-sources project --permission-mode plan --tools "Read,Glob,Grep"

Firstmate reply (verbatim):

The plan-file and question tools aren't available in this session, so I'll give you the full dry run directly here instead.

## Stage 1 — Intake (result)

**Subject paragraph** (verbatim, not rephrased for the crews):
> "Our CLI's first-run onboarding is too slow; new users take about 40 minutes to get their first successful command and half of them drop out before that."

**Roster** (captain-supplied, one crewmate each):

| Crew | Skill | Deliverable |
|---|---|---|
| A | `superpowers:brainstorming` | report |
| B | `bmad-analysis:bmad-brainstorming` | report |
| C | `agent-skills:idea-refine` | report |

**Harness resolution — not yet cleared.** All three names use the `plugin:skill` colon form, a plugin-marketplace invocation shape rather than a home-local skill. Per `harness-adapters`, a plugin-delivered skill can force a harness pin for that crew even if it overrides the usual crew-dispatch default, and that has to be checked "against the skill's real delivery surface," not guessed from the name. Before any real spawn I'd verify, per crew, which harness actually has that plugin installed and verified — likely all three pin to `claude` if they're Claude Code marketplace plugins, but I won't assert that without checking. This is my job at dispatch time, not a question for you, unless verification comes back empty for a crew — then I'd stop and report that concretely instead of substituting a guess.

**Repository — blocking, needs your call.** You flagged this yourself: nothing's registered yet. Intake step 4 requires resolving it *before* dispatch, routed through `project-management` rather than mid-run, and it needs one of:
- **Add/clone an existing repo** — source URL, local project name, delivery mode, autonomy posture.
- **Create a new repo** — proposed name, owner/org, visibility (defaults private), delivery mode (defaults `no-mistakes`) — outward-facing, needs your explicit consent on those values.
- **Local-only** — local git repo under `projects/<name>`, no remote, registry entry only. Plausible here since the three crews only produce reports plus a synthesis doc, no PR.

I'm not assuming local-only, since "our CLI" implies an existing product that may already live elsewhere. **This is the question I need answered before real dispatch: which of the three applies, and if it's add/create, what's the repo name/URL?**

**Run id (proposed):** `cli-onboarding-speed` — groups the three scouts under one backlog identity for cleanup and history. Say if you want a different id.

## Stage 2 — Shared premise note (plan)

- Path: `data/cli-onboarding-speed/facts.md` in the firstmate home — created and owned solely by me; crews never write to it.
- Seed content: the raw subject paragraph, plus the two numbers already confirmed in it (~40 min to first success, ~50% drop-out before that). Nothing else — no assumptions about platform, what counts as a "successful command," or the current flow, even though a crew will likely ask.
- Every brief tells the crew to read this note before starting and again after each relayed answer, so the three don't drift onto incompatible premises about what "the CLI" or "success" means.

## Stage 3 — Dispatch (plan)

One scout per roster skill. Each brief:
- Names exactly one skill for that crew to run.
- Carries the **absolute** path to `facts.md` (never the relative form — a crew reads it from an isolated worktree where the relative path resolves to nothing).
- Carries the raw subject paragraph unedited.
- States crewmates never address you directly — all captain communication routes through me.
- Tells the crew to raise a question by appending a keyed `blocked:` line and stopping, rather than guessing a product answer.
- Gets the harness pin resolved in Stage 1 applied at spawn.

Deliverable for every crew is a report, never a PR.

## Stage 4 — Question loop (plan)

- Wait for a natural batch boundary (every crew blocked or done a first pass, or a bounded wait elapses with open questions) before bringing anything to you — no relaying one at a time.
- Deduplicate near-identical questions across the three crews into one item, noting which crews asked it; three crews asking the same thing is a signal about importance, not three separate questions.
- Present each batch as a decision or clarification in plain language.
- On your answer: relay only to the crews that asked it, append the confirmed fact to `facts.md`, and tell every crew (asked or not) to re-read the note.
- I never answer a product-choice question on my own authority — only your confirmed facts enter the note or get relayed.
- Repeat until every crew has a report or a genuine blocker needs action outside this skill.

## Stage 5 — Synthesis and close (plan)

- Every crew lands a self-contained report before its scratch worktree is discarded.
- I read all three completely, then write one synthesis to `data/cli-onboarding-speed/synthesis.md` (or wherever you'd rather), containing at minimum: the raw subject statement, a map of which crew ran which skill, shared findings, and an explicit **contradictions** section for every point of disagreement, attributed by crew — never averaged, blended, or dropped.
- Any decision the run surfaces but doesn't resolve goes through `decision-hold-lifecycle` as a structured captain-held backlog item before the run counts as complete.
- Cleanup (tearing down the three scout worktrees) happens only after all three reports exist and the synthesis is written.

**The one thing I need from you before this can become a real dispatch:** how do you want the repository resolved — add an existing one (with URL/name), create a new one, or local-only?
```
</details>
<details>
<summary>Evidence: Raw stream-json of the /parallel-ideation session</summary>

```text
{"type":"system","subtype":"init","cwd":"/private/tmp/pi-sandbox.ivCsI3","session_id":"7d3b34fc-bbfc-45ef-a9b0-b09610d12066","tools":["Glob","Grep","Read"],"mcp_servers":[],"model":"claude-sonnet-5","permissionMode":"plan","slash_commands":["afk","ahoy","bearings","parallel-ideation","stow","updatefirstmate","deep-research","design-sync","dataviz","update-config","verify","debug","code-review","simplify","batch","fewer-permission-prompts","doctor","loop","schedule","claude-api","run","run-skill-generator","agents","clear","color","compact","config","context","effort","fast","heapdump","init","mcp","model","__remote-workflow","workflow-launch-exec","reload-skills","rename","review","ultrareview","security-review","usage-credits","extra-usage","usage","insights","recap","goal","design","design-consent","design-revoke","team-onboarding"],"apiKeySource":"none","claude_code_version":"2.1.220","output_style":"default","agents":["claude","Explore","general-purpose","Plan","statusline-setup"],"skills":["afk","ahoy","bearings","parallel-ideation","stow","updatefirstmate","deep-research","design-sync","dataviz","update-config","verify","debug","code-review","simplify","batch","fewer-permission-prompts","doctor","loop","schedule","claude-api","run","run-skill-generator"],"plugins":[],"capabilities":["interrupt_receipt_v1","interrupt_cancel_queued_v1","msg_lifecycle_v1"],"analytics_disabled":false,"product_feedback_disabled":false,"uuid":"cd3907b3-56f0-4ad3-942a-c9fea5109d20","memory_paths":{"auto":"/Users/ivymee/.claude/projects/-private-tmp-pi-sandbox-ivCsI3/memory/"},"fast_mode_state":"off","fast_mode_disabled_reason":"sdk_opt_in_required"}
{"type":"system","subtype":"thinking_tokens","estimated_tokens":50,"estimated_tokens_delta":50,"uuid":"b10858a3-3402-44ff-b4a4-8c3b51cc9f59","session_id":"7d3b34fc-bbfc-45ef-a9b0-b09610d12066"}
{"type":"system","subtype":"thinking_tokens","estimated_tokens":150,"estimated_tokens_delta":100,"uuid":"0bb33f92-049f-4570-92dd-8f45dd7c958d","session_id":"7d3b34fc-bbfc-45ef-a9b0-b09610d12066"}
{"type":"system","subtype":"thinking_tokens","estimated_tokens":250,"estimated_tokens_delta":100,"uuid":"e3dc86fc-1008-4bb5-8e2d-4425d6738883","session_id":"7d3b34fc-bbfc-45ef-a9b0-b09610d12066"}
{"type":"system","subtype":"thinking_tokens","estimated_tokens":400,"estimated_tokens_delta":150,"uuid":"0b5d4852-1279-4fad-a719-9e96c5ec6c57","session_id":"7d3b34fc-bbfc-45ef-a9b0-b09610d12066"}
{"type":"system","subtype":"thinking_tokens","estimated_tokens":550,"estimated_tokens_delta":150,"uuid":"6c0b9300-34ea-4c6d-8d81-a280e05a196c","session_id":"7d3b34fc-bbfc-45ef-a9b0-b09610d12066"}
{"type":"system","subtype":"thinking_tokens","estimated_tokens":650,"estimated_tokens_delta":100,"uuid":"7b942d7c-76db-4836-8247-49c22b07f4a9","session_id":"7d3b34fc-bbfc-45ef-a9b0-b09610d12066"}
{"type":"system","subtype":"thinking_tokens","estimated_tokens":800,"estimated_tokens_delta":150,"uuid":"17ffb86d-84ac-4e32-876f-4ba15c26a824","session_id":"7d3b34fc-bbfc-45ef-a9b0-b09610d12066"}
{"type":"system","subtype":"thinking_tokens","estimated_tokens":950,"estimated_tokens_delta":150,"uuid":"59126b7c-6a46-4371-a9f9-b6d9b067b47f","session_id":"7d3b34fc-bbfc-45ef-a9b0-b09610d12066"}
{"type":"assistant","message":{"model":"claude-sonnet-5","id":"msg_011CddGKVfEuQSvnupLcgJuh","type":"message","role":"assistant","content":[{"type":"thinking","thinking":"","signature":"EpQZCokBCBAYAipAI41F9uN0ZlkaEUbt5RrKxxn4M7wZ9To1Tq1ADyf8+dpy+9z3sXFoYeyxuxEwUBB/Iy7RtiW3Y0V0lZByx8RZbTIPY2xhdWRlLXNvbm5ldC01OABCCHRoaW5raW5nWiRiYTZlY2E1YS1iYmZmLTQ0YTMtYWNiMy1kN2I0MzIxMWFhYTYSDGb/QPozHaUTeTqivhoMiL4uiiLjWsLONxIvIjDn/UqlfpCE06nkRFgn530RQJEdl64esQRitYmJ+1qa4/+bBRa9hC5QEamhRkg31tsqtxedwjNEMz8zBuC96XhK733dRGC6TR8QJeq97AM+PEWEPNKOG8pTNG6WAsd8ntTMsvvs9DVgep8kCG05NrDUIp/5AQYCw1zpKmN5uynEbZUPg2GptK076pCIP1mVqcH0aGJbE48gM5WHJgNiwCNHISHZclXH+wPnbgoGDtMGROeLsIOWMzkR1cs222IZY1MDEB/GDbY2QxWgcnXMYlWgk1CDahunLd/asUMhgRtNhGh8g6c8CyoZJSMBKp0gq8pARP67xuNwpfx7XyfX4ow6/J2o3CnDWTGl+8TMxijHyYt1I5A0BXH4CtXIU1/U/0SsDSByrZs4GMstA3e6p4pwlTLtxt98heXqOgn4FliQuxYfFvriOyJ4kTwPpuhGKPzMN1S/piTyFzD+0ivo7Rl6NOPgro0PAqFzc9vudg0ndnzAC+jLr0tmQHjxVzGbix8fEh2uQDLM79O3hs/VwlscH878/Sq4VJPFvu2bnRXnVoCzTFqwsB384BJvTUvb0lQQKYoCH+JqvP7W3ubkrPDtAhds7JavfF/IHFKv71t7oCJCqjt+WcNtfq61cSREWzKOghnXgOnMa59KF+7vzg4jEuFwsB1YJGYk77C5D1rdk3JD/C8U0JZA0D5m5+sBQXaJzlidIU085t614gJersnljqFh3Yh9fPVjiIcQNYTcBDB3hQWs76B8JZDPcAgYNyXS4QxRUpnP/sNbxzoJ+ntP/xEz89RcWpJJDnM1MIbtWWhso0PsBPIasTWrW8Sc6UqByx1OEm7aQMAYBWrMNS5hkpsJANQRQwz++3fjO865UIqjtN3DnvBPEJmx0Dzx0BPo7n39uHgg60k6f1phem2gPiMYrdCLyIP5acFaGfuguGsCLCsntqgzL3ceEjXWcG2pGH6b3I1mrvQJhlDTr74EBtg7ePTG0RZMHcmbMT5QTsZcpGJrpCAaNv6N6hcIWqOPa1Wth8+cDGKXgzyYwhiaJ36EdJhOtZKW57JtEXjRUJUs5Dh0/Ff1iW3vg0IYu+2s55t7QN6kIWflyITGVPAd5WYXcDPRQd6TZPG3CiRFzi4aq6IHdWUanZY4VJjTn8+IpSRVtoF1BW19Ye0wWxyB+brjbgo6Q/aCF9KdjARm9evLijRAm9+wmquE6GPN36qBel+7PwNkbZ3YpVodZ6K8iJQ+zA+RqnqobO1elOzb3fWe5rRHKjmRHaOJs/pywrgyTTTcS3vtGdXm8z06K4tHdRpgK9dfoJAAUSr7wBMyaT9JGN7NJ4yIc4Wu8T1URi2Mkb/iUJYsYgSfC862fGh5CFiICGRBigyWo4Je0X8mhGu9UmwucX0HmM8qDvwMYFg+WmEZ82U4FSOpDIZ1XSDc4bsRNPtRvZIsGoP2G/UesIZ7ZlIkM91c7eOt/xy9H7UfiKJE65LaT8ZK+dZp019S8bB3ax39gYZZUMQi6nH5MGsiPEXD/WTViCdBufQhW9w/AAxhu84xld9wxp/bt+ZWO102qBReMwfaCsjKo1yzh6q/t2eH89rt4zgM1+26HKdqU2S1/8zNBv9xNyhT7o2XpNTYnUn9Hbxi4xVpmmxJ4IHb4M4jEDiH4LKFbJMeAqOv24Q/5O+LcQV5JDKKBko48AVn7EB42TF6rruKemfJc9ca1zvRWCairVsOyyZYNe1KWwoIqthw7TYgmCpxnKsRgT/4UJNsURqgDQzNXNWSz9VRQOm3iEXuboBTVjp9e5btf/bhbfFRFhqMZX45pqAs+MPmmaMkYuei8j51IaZU+mFStW8VeBttNF5A+LlUv2NMo+q3WO7fk70T9279j6E9MJ5c7BNFi140rhNih/IXAucD4FAKmot23IGiF3gi6NeuFUHxTN7GjK/ucE4m6UgS4ZG0J3hd8SeSs+joFwnNeDyZz8+PaKcfU7gZVTy1QoXsdP8G0ZcXdFjoRV64mN0ohnPHus/AUaXnDKY3WKJbvfcfTig64AeZPOtJb2osYtmSPL8pfE2loLtFMxvZ0/sDe1+N2zRC9rGgjgR2i+8NIB9ZrC3mt4vebcCTnFf/CabrS21ZkOIqPkxDCXxC+gzz8YDynSAcUd7xb431cPBBF7t1EZe74xZ5+zM95wbrytNczyS7+tQUK+yfjFPgEFCVvIsZu0upvETzo6EVwqOCgM3oiJOU4tedu/OhAUPRf2HG/IsWj4n+L/f4MccR6odcygi/ftoWWN/SJfO5vuONI6Jh0BsNovxZ0wmOb9gRx5NUH9SyKzJsjgQo8B1dZAOk72PkcPgeJRHq1LdozQCT3CnTC49c/SOszzRL1PL4cQHaKbkddrNcc08y1GSeXIUR7reK8KeBjzgsHapQX2VVE8XO+4jlXEu0hUFpcPCRqVb9cQrxqF/TRhgVsDY5RYKS7+MEuVNBDareKuXnJMa6DqjtP4cvqdGlJt54JAsGGmMAgxSLOquG4SOxEQ2e7c76iURfpVnHAj6wgTfBzZJE9C8Qvf0XdGZNLSQX6wo2SP/9DEWInV7A4vx3F6hOYeAPAK95AqwUXKXZiRZrsvI7sQWrG73R3zVFjhJwrkI+iNl0t77ZR0+t2E4Eevpb1VsypeUD3jTQLdNKzZC0MwypF8Y2Zo+k78ksE2irw7E4/aC6qdYzwSPXzf32NHRd7vPkp9fhXguLWSyDyFseau5lIBtrdbP/EkzZsL3qrgweiwX8pMFKgXlEc9vKs8cbD1qRhQt+4gSFS9Eb108oOxnvA+Lu7BpYSUthMGuKcU4aoCN21jy4Dp3WEhf7skVWSoOoBOijQ1H5pf1pWspYCSvKZEGcbHI5yxVKvo9exj2nTaOIFuv3p0qY99oKWstGMtKIJLrqcQw5YmlqCQFvKbz2BX981i5nni5sjplFGTFXKeLbndcHvUOqmXMNI3vddnwJ7AKXcOiw+qEBlh3wDDW5ThlZhijCpdASrQYHnNSHuVryBOKXvJr2rYjdQVjQfSYZJXzkHXKunEedy1GhhdUR0uyc2hZMW5RCHTFAvR6uJCV2qOFdW2b33d8BJfM/sZaX55ODTR8fA9uvQmNzwl6rzt227yeEKOGXBjBFEv5GlmvAFBd1tsrfqZr5SukGAV9wLQCPXWP2wWE4JXz02xqMzreg8SVPJRDi55bAG3GoWm3ZE9k2qniC7+Ch25ijl+etgATluCkvDJnfQXndvgemVH4Kx7r6v53kJjABDebONZI7T0n9KS+U+AuLW9b9N6hJPKlqgvUdiRUoBwJ9e1n7XrXNCC0I+SwjluzABFmqkD6fXX5cmiHsU88IjJ6FgeCskd8t1gzQ0vPp6cOY+ALgx1UKNEicGq/vzSzcxTGKGYeMOVesp69TZnX9rGQS/L3T9dTRXHkCl3rwFBTGaaKKghbWBjYW6NRGaSyMN3Hul0pU6LgIJL3u8CsxpsBX7zcF/arLgbKKbm6sryU4W79+G8L5sn7nFx8JwMnDuzwkZCc6UtMlPmpJeKGdOCXCcJSVtyBqq5/dy85xn3Qa1fhJ+j/pY1ca4VyHSDeQd8l/CCldghYAMfPVdMH9QicKtwtK+RVVDycQWKJefNE3G++iGwRv7wZGyWjilZlKPExAq48oj0+dl69NtmrB4qUAsF1i4kdUFT0pTmH88X2yYBD58B8wESwARJNvxnW3gfHDgQI9uqT9UofOcC65agzUW8PcOnqw3IPwhKgZ9EVJdlCkAruazlgjQDwQ3hqqhly2vrVt7T6pmbrvkcyRRPN6sQAV+WtN5TOa/Uo1nLLM0COfX/5zLr+YiO+fAG1N9sbSjBapjF2McYeTXtxg1amIAMBQLou2J+xUhMUrn4QCDX8UajuocYHD+tqkWh1x/D9KN6jyPK9nOOV0031JhYrCwVF2L/AqWyapIeBuL/sYvwcUtBbM/WVb5XhCJms6ImqYQiBHw1XZ95j/oNed8z11NSQWQY2dQKPbaUVxf6ZLbZI+M78dbJWRM6Cn33F1zZ6aqLTHX4tDiAQ++u+QAM1a5dZVoOi7CZhsK3JpvRgB"}],"stop_reason":null,"stop_sequence":null,"stop_details":null,"usage":{"input_tokens":2,"cache_creation_input_tokens":10262,"cache_read_input_tokens":6271,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":10262},"output_tokens":2,"service_tier":"standard","inference_geo":"not_available"},"diagnostics":null,"context_management":null},"parent_tool_use_id":null,"session_id":"7d3b34fc-bbfc-45ef-a9b0-b09610d12066","uuid":"423c841d-7fa3-4f32-a183-7c76c3f

... [297186 bytes truncated] ...

Any decision the run surfaces but doesn't resolve goes through `decision-hold-lifecycle` as a structured captain-held backlog item before the run counts as complete.\n- Cleanup (tearing down the three scout worktrees) happens only after all three reports exist and the synthesis is written.\n\n**The one thing I need from you before this can become a real dispatch:** how do you want the repository resolved — add an existing one (with URL/name), create a new one, or local-only?"}],"stop_reason":null,"stop_sequence":null,"stop_details":null,"usage":{"input_tokens":2,"cache_creation_input_tokens":2774,"cache_read_input_tokens":62671,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":2774},"output_tokens":9,"service_tier":"standard","inference_geo":"not_available"},"diagnostics":null,"context_management":null},"parent_tool_use_id":null,"session_id":"7d3b34fc-bbfc-45ef-a9b0-b09610d12066","uuid":"cede46dd-d852-48b3-ae9e-3a2e1cd37afb","timestamp":"2026-08-02T04:11:35.621Z","request_id":"req_011CddGWGWHC2K53gwMSdcxK"}
{"is_error":false,"duration_api_ms":170344,"num_turns":25,"stop_reason":"end_turn","session_id":"7d3b34fc-bbfc-45ef-a9b0-b09610d12066","total_cost_usd":0.7179545999999999,"usage":{"input_tokens":24,"cache_creation_input_tokens":59174,"cache_read_input_tokens":488712,"output_tokens":14415,"server_tool_use":{"web_search_requests":0,"web_fetch_requests":0},"service_tier":"standard","cache_creation":{"ephemeral_1h_input_tokens":59174,"ephemeral_5m_input_tokens":0},"inference_geo":"not_available","iterations":[{"input_tokens":2,"output_tokens":2282,"cache_read_input_tokens":62671,"cache_creation_input_tokens":2774,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":2774},"type":"message"}],"speed":"standard"},"modelUsage":{"claude-sonnet-5":{"inputTokens":24,"outputTokens":14415,"cacheReadInputTokens":488712,"cacheCreationInputTokens":59174,"webSearchRequests":0,"costUSD":0.7179545999999999,"contextWindow":1000000,"maxOutputTokens":64000,"canonicalModel":"claude-sonnet-5","provider":"firstParty"}},"permission_denials":[],"terminal_reason":"completed","fast_mode_state":"off","fast_mode_disabled_reason":"sdk_opt_in_required","subtype":"success","api_error_status":null,"result":"The plan-file and question tools aren't available in this session, so I'll give you the full dry run directly here instead.\n\n## Stage 1 — Intake (result)\n\n**Subject paragraph** (verbatim, not rephrased for the crews):\n> \"Our CLI's first-run onboarding is too slow; new users take about 40 minutes to get their first successful command and half of them drop out before that.\"\n\n**Roster** (captain-supplied, one crewmate each):\n\n| Crew | Skill | Deliverable |\n|---|---|---|\n| A | `superpowers:brainstorming` | report |\n| B | `bmad-analysis:bmad-brainstorming` | report |\n| C | `agent-skills:idea-refine` | report |\n\n**Harness resolution — not yet cleared.** All three names use the `plugin:skill` colon form, a plugin-marketplace invocation shape rather than a home-local skill. Per `harness-adapters`, a plugin-delivered skill can force a harness pin for that crew even if it overrides the usual crew-dispatch default, and that has to be checked \"against the skill's real delivery surface,\" not guessed from the name. Before any real spawn I'd verify, per crew, which harness actually has that plugin installed and verified — likely all three pin to `claude` if they're Claude Code marketplace plugins, but I won't assert that without checking. This is my job at dispatch time, not a question for you, unless verification comes back empty for a crew — then I'd stop and report that concretely instead of substituting a guess.\n\n**Repository — blocking, needs your call.** You flagged this yourself: nothing's registered yet. Intake step 4 requires resolving it *before* dispatch, routed through `project-management` rather than mid-run, and it needs one of:\n- **Add/clone an existing repo** — source URL, local project name, delivery mode, autonomy posture.\n- **Create a new repo** — proposed name, owner/org, visibility (defaults private), delivery mode (defaults `no-mistakes`) — outward-facing, needs your explicit consent on those values.\n- **Local-only** — local git repo under `projects/<name>`, no remote, registry entry only. Plausible here since the three crews only produce reports plus a synthesis doc, no PR.\n\nI'm not assuming local-only, since \"our CLI\" implies an existing product that may already live elsewhere. **This is the question I need answered before real dispatch: which of the three applies, and if it's add/create, what's the repo name/URL?**\n\n**Run id (proposed):** `cli-onboarding-speed` — groups the three scouts under one backlog identity for cleanup and history. Say if you want a different id.\n\n## Stage 2 — Shared premise note (plan)\n\n- Path: `data/cli-onboarding-speed/facts.md` in the firstmate home — created and owned solely by me; crews never write to it.\n- Seed content: the raw subject paragraph, plus the two numbers already confirmed in it (~40 min to first success, ~50% drop-out before that). Nothing else — no assumptions about platform, what counts as a \"successful command,\" or the current flow, even though a crew will likely ask.\n- Every brief tells the crew to read this note before starting and again after each relayed answer, so the three don't drift onto incompatible premises about what \"the CLI\" or \"success\" means.\n\n## Stage 3 — Dispatch (plan)\n\nOne scout per roster skill. Each brief:\n- Names exactly one skill for that crew to run.\n- Carries the **absolute** path to `facts.md` (never the relative form — a crew reads it from an isolated worktree where the relative path resolves to nothing).\n- Carries the raw subject paragraph unedited.\n- States crewmates never address you directly — all captain communication routes through me.\n- Tells the crew to raise a question by appending a keyed `blocked:` line and stopping, rather than guessing a product answer.\n- Gets the harness pin resolved in Stage 1 applied at spawn.\n\nDeliverable for every crew is a report, never a PR.\n\n## Stage 4 — Question loop (plan)\n\n- Wait for a natural batch boundary (every crew blocked or done a first pass, or a bounded wait elapses with open questions) before bringing anything to you — no relaying one at a time.\n- Deduplicate near-identical questions across the three crews into one item, noting which crews asked it; three crews asking the same thing is a signal about importance, not three separate questions.\n- Present each batch as a decision or clarification in plain language.\n- On your answer: relay only to the crews that asked it, append the confirmed fact to `facts.md`, and tell every crew (asked or not) to re-read the note.\n- I never answer a product-choice question on my own authority — only your confirmed facts enter the note or get relayed.\n- Repeat until every crew has a report or a genuine blocker needs action outside this skill.\n\n## Stage 5 — Synthesis and close (plan)\n\n- Every crew lands a self-contained report before its scratch worktree is discarded.\n- I read all three completely, then write one synthesis to `data/cli-onboarding-speed/synthesis.md` (or wherever you'd rather), containing at minimum: the raw subject statement, a map of which crew ran which skill, shared findings, and an explicit **contradictions** section for every point of disagreement, attributed by crew — never averaged, blended, or dropped.\n- Any decision the run surfaces but doesn't resolve goes through `decision-hold-lifecycle` as a structured captain-held backlog item before the run counts as complete.\n- Cleanup (tearing down the three scout worktrees) happens only after all three reports exist and the synthesis is written.\n\n**The one thing I need from you before this can become a real dispatch:** how do you want the repository resolved — add an existing one (with URL/name), create a new one, or local-only?","ttft_ms":14917,"ttft_stream_ms":3850,"time_to_request_ms":49,"type":"result","duration_ms":170498,"uuid":"0e195474-6f64-40e6-8082-f08a5d3841b1"}
```
</details>
<details>
<summary>Evidence: AGENTS.md section 7 trigger fires on a natural-language ask</summary>

<code>Captain, the skill is `parallel-ideation`.&#10;&#10;Exact instruction line: &#34;Load `parallel-ideation` when the captain asks to run several ideation or brainstorming skills in parallel on one subject and synthesize their outputs.&#34;&#10;&#10;That line lives in Section 7 (Task lifecycle), under the &#34;Intake and authority&#34; subsection.</code>

```text
Captain, the skill is **`parallel-ideation`**.

Exact instruction line: "Load `parallel-ideation` when the captain asks to run several ideation or brainstorming skills in parallel on one subject and synthesize their outputs."

That line lives in **Section 7** (Task lifecycle), under the "Intake and authority" subsection.
```
</details>
<details>
<summary>Evidence: Required repo checks</summary>

```text
$ bin/fm-doc-audience-check.sh
fm-doc-audience-check: ok surfaces=62 local_links=170

$ bash tests/fm-documentation-audiences.test.sh
ok - documentation inventory classifies every maintained prose surface exactly once
ok - classification, setup routing, and maintained-prose scope fail safely
ok - required documentation owner pointers cannot silently disappear
ok - local links resolve while dates, versions, commands, and incident prose remain semantically reviewed
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 4 issues found → auto-fixed ✅</summary>

- 🚨 `.agents/skills/parallel-ideation/SKILL.md:1` - The new tracked prose surface is not classified in docs/documentation-audiences.json, so the intent&#39;s required criterion &#34;bin/fm-doc-audience-check.sh must pass&#34; is not met. The check collects every tracked *.md via git ls-files and fails with &#34;unclassified: .agents/skills/parallel-ideation/SKILL.md&#34; (bin/fm-doc-audience-check.sh:174-185); tests/fm-documentation-audiences.test.sh:55 runs that same check against the repo root, so CI breaks too. Every sibling skill has an entry; the fix is one object {&#34;path&#34;: &#34;.agents/skills/parallel-ideation/SKILL.md&#34;, &#34;audience&#34;: &#34;agent-runtime&#34;} inserted between the harness-adapters entry (docs/documentation-audiences.json:151) and the process-event-sources entry (line 155).
- ⚠️ `README.md:176` - The skill declares user-invocable: true and a /parallel-ideation invocation, but README.md&#39;s &#34;Built-in skills&#34; table - introduced by &#34;Firstmate ships these user-invocable built-in skills&#34; (README.md:167) and referenced by the two-tier layout section as the set of user-invocable skills - was not extended. All five existing user-invocable skills (/afk, /ahoy, /bearings, /updatefirstmate, /stow) are listed there, so a captain reading the README cannot discover the new command and the table now understates what ships. Adding one row is a cross-reference, not a restatement of the procedure, so it does not conflict with the one-owner constraint in the intent.
- ⚠️ `.agents/skills/parallel-ideation/SKILL.md:55` - The brief requirement says only &#34;point at the shared premise note path&#34; while the path is written relatively as data/&lt;run-id&gt;/facts.md (line 41). Crews run inside an isolated project worktree, not the firstmate home, so a relative data/&lt;run-id&gt;/facts.md resolves against the project repo and either does not exist or names an unrelated file; the crew then starts without the premise it was told to read, or blocks. bin/fm-brief.sh avoids this by interpolating absolute home paths ($DATA/$ID/report.md at bin/fm-brief.sh:288, $FM_ROOT/.agents/skills/... at line 290). State that the brief must carry the absolute firstmate-home path to the note.
- ℹ️ `.agents/skills/parallel-ideation/SKILL.md:30` - Intake introduces a per-crew harness pin derived from what delivers the rostered skill, but does not say how it ranks against the routing precedence AGENTS.md section 4 owns (explicit per-task captain override, then best-fit configured rule, then configured default, then static crewmate harness). When config/crew-dispatch.json has a matching rule, firstmate has no stated tiebreak between the profile&#39;s harness and a plugin-only skill&#39;s required harness, and picking the profile silently makes the crew unable to run its assigned skill. One clause naming where the pin sits in that precedence would close it without restating section 4.

🔧 Fix: Classify parallel-ideation skill, list it, harden brief paths
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bin/fm-doc-audience-check.sh` (required by intent) - ok surfaces=62 local_links=170</code>
- <code>`bash tests/fm-documentation-audiences.test.sh` - 4/4 ok, confirms the new SKILL.md is classified exactly once in docs/documentation-audiences.json</code>
- <code>Manual end-user run: `claude -p &#34;/parallel-ideation &lt;subject + roster + no repo yet&gt;&#34; --setting-sources project --permission-mode plan --tools &#34;Read,Glob,Grep&#34;` in a sandbox home whose `.claude/skills` symlinks this worktree&#39;s `.agents/skills` (same discovery path the repo itself uses)</code>
- <code>Manual trigger check: natural-language ask with no slash command, asking which skill loads first and from which numbered AGENTS.md section - answered `parallel-ideation`, quoted the exact line, section 7 Intake and authority</code>
- <code>Rendered `README.md` built-in-skills table via `pandoc -f gfm` and screenshotted headless Chrome to verify the `/parallel-ideation` row renders in the captain-facing table</code>
- <code>Constraint spot checks: `git diff --name-only 8c21b101..HEAD -- projects data state config` (empty), co-author trailer scan on both commits (none), ASCII/em-dash scan of SKILL.md (clean), cross-reference scan showing no other owner restates the procedure</code>
- <code>`bin/fm-lint.sh` deliberately not run - `git diff --name-only 8c21b101..HEAD` shows no bin/ changes</code>

</details>

<details>
<summary>🔧 **Document** - 1 issue found → auto-fixed ✅</summary>

- ℹ️ `.agents/skills/parallel-ideation/SKILL.md:33` - Harness-precedence refinement lives only in the new skill, not in its owner. `.agents/skills/parallel-ideation/SKILL.md:33` states that a harness pin made mandatory by a skill&#39;s delivery surface outranks a matching crew-dispatch profile&#39;s harness. `AGENTS.md:172` (section 4) is the authoritative owner of routing precedence and states it flatly as &#34;an explicit per-task captain override, then the best-fit configured rule, then the configured default, then the static crewmate harness&#34;, with no delivery-mandatory tier; `harness-adapters` does not cover it either. A reader of section 4 alone would not learn the refinement. I did not edit section 4 because the author&#39;s intent constrains this change to exactly one AGENTS.md line and because it is arguable the skill is only applying section 4 (a profile harness that cannot run the assigned skill is not a &#34;best fit&#34;) rather than adding a tier. Follow-up: either the owner absorbs one clause, or the skill is reworded as an application of the existing chain.

🔧 Fix: Reword parallel-ideation harness pin to section 4 precedence
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
