### PR TITLE
feat(secure-credentials): add opt-in TUI credential collector

### DIFF
--- a/.pi/opt-in-extensions/secure-credentials/README
+++ b/.pi/opt-in-extensions/secure-credentials/README
@@ -1,0 +1,75 @@
+# secure-credentials-tui
+
+Esta extensão coleta credenciais somente em uma sessão especialista TUI iniciada de propósito.
+
+Pi não descobre este diretório automaticamente.
+
+Use `pi -e ./.pi/opt-in-extensions/secure-credentials/index.ts` para carregá-lo.
+
+A sessão precisa definir `WAYFINDER_SECURE_CREDENTIALS_MANIFEST` para um arquivo JSON local do operador.
+
+O arquivo do manifest precisa ser regular, não ser symlink, ter um link e não ser gravável por grupo ou outros usuários.
+
+O diretório pai de cada destino precisa ser regular, não ser symlinkado, ser privado e pertencer ao operador atual.
+
+O formato do manifest é:
+
+```json
+{
+  "version": 1,
+  "destinations": [
+    {
+      "id": "specialist-env",
+      "path": "/private/operator/path/credentials.env",
+      "keys": ["EXAMPLE_API_KEY", "EXAMPLE_MODEL_KEY"]
+    }
+  ]
+}
+```
+
+Use nomes de chave no formato de variável de ambiente.
+
+O mesmo nome de chave não pode aparecer duas vezes no manifest.
+
+O modelo envia somente a lista de nomes allowlisted.
+
+O modelo não envia caminho, comando, sink ou valor secreto.
+
+Exemplo de inicialização:
+
+```sh
+chmod 700 /private/operator/path
+chmod 600 /private/operator/path/secure-credentials.json
+WAYFINDER_SECURE_CREDENTIALS_MANIFEST=/private/operator/path/secure-credentials.json \
+  pi -e ./.pi/opt-in-extensions/secure-credentials/index.ts
+```
+
+O arquivo de destino novo recebe modo `0600`.
+
+Uma atualização usa arquivo temporário privado, `fsync` quando suportado e rename atômico.
+
+Cada destino usa fila no processo e lock de diretório durante toda a janela de leitura, confirmação e escrita.
+
+Um lock existente faz a chamada pular sem coletar valor.
+
+Após uma falha do processo, remova o diretório `<destino>.lock` somente depois de confirmar que nenhuma sessão especialista ainda está ativa.
+
+Uma chave já existente permanece intacta por padrão.
+
+A substituição exige uma escolha explícita na tela TUI.
+
+Escape, Ctrl+C, abort e reload encerram a página sem aplicar a transação pendente.
+
+A tela usa uma máscara de largura fixa e nunca mostra prefixo, sufixo, tamanho exato ou fragmento do valor.
+
+O editor mantém o marcador `CURSOR_MARKER` quando recebe foco para posicionamento de IME.
+
+O valor não entra em `process.env`, argv, comandos shell, URLs, logs, stderr, resultado da ferramenta, renderer ou sessão JSONL.
+
+A implementação não promete zeroização de strings JavaScript.
+
+Ela reduz cópias e mantém o valor somente durante a coleta e a escrita.
+
+RPC, print e JSON recusam antes de abrir qualquer página ou ler um destino.
+
+Este primeiro corte não implementa Vercel, Convex, keychain, login de provider, rotação automática ou instalação automática.

--- a/.pi/opt-in-extensions/secure-credentials/index.ts
+++ b/.pi/opt-in-extensions/secure-credentials/index.ts
@@ -1,0 +1,500 @@
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { Text } from "@earendil-works/pi-tui";
+import { Type } from "typebox";
+
+import {
+	readSecureCredentialsManifest,
+	resolveSecureCredentialsManifestPath,
+	isSecureCredentialKeyName,
+	SecureCredentialsManifestError,
+} from "./secure-credentials-manifest.ts";
+import {
+	buildSecureCredentialsFileContent,
+	readSecureCredentialsFile,
+	removeSecureCredentialsFileIfUnchanged,
+	SecureCredentialsFileError,
+	withSecureCredentialsDestinationLock,
+	withSecureCredentialsFileQueue,
+	writeSecureCredentialsFileAtomically,
+	type SecureCredentialsFileSnapshot,
+} from "./secure-credentials-file.ts";
+import type {
+	SecureCredentialInputOutcome,
+	SecureCredentialOverwriteOutcome,
+	SecureCredentialResult,
+	SecureCredentialsDestination,
+	SecureCredentialsManifest,
+	SecureCredentialsRequest,
+	SecureCredentialsToolDetails,
+} from "./secure-credentials-contract.ts";
+import { SecureCredentialInputPage, SecureCredentialOverwritePage } from "./secure-credentials-ui.ts";
+
+const SecureCredentialsRequestSchema = Type.Object({
+	keys: Type.Array(Type.String({ description: "Allowlisted credential key names only" }), {
+		minItems: 1,
+		description: "Key names from the operator-owned manifest",
+	}),
+});
+
+type SecureCredentialsToolCallbacks = {
+	setActiveDialog: (cancel: () => void) => void;
+	clearActiveDialog: (cancel: () => void) => void;
+};
+
+type ResolvedCredentialRequest = {
+	key: string;
+	destination: SecureCredentialsDestination;
+};
+
+/** Register the secure credential collector with the supplied TUI-only lifecycle callbacks. */
+export function createSecureCredentialsTool(callbacks: SecureCredentialsToolCallbacks) {
+	return {
+		name: "secure_credentials_collect",
+		label: "Secure Credentials",
+		description:
+			"Collect values for allowlisted credential key names in the specialist TUI and write only operator-manifest destinations.",
+		promptSnippet: "Collect allowlisted credential values without returning secret text",
+		promptGuidelines: [
+			"Use secure_credentials_collect only with key names from the operator-owned manifest.",
+			"Never place paths, commands, sinks, or credential values in secure_credentials_collect arguments.",
+		],
+		parameters: SecureCredentialsRequestSchema,
+		executionMode: "sequential" as const,
+
+		async execute(
+			_toolCallId: string,
+			params: SecureCredentialsRequest,
+			signal: AbortSignal | undefined,
+			_onUpdate: unknown,
+			ctx: ExtensionContext,
+		) {
+			if (ctx.mode !== "tui") {
+				throw new Error("Secure credentials collection requires TUI mode.");
+			}
+
+			const cancellation = createCancellationSignal(signal, ctx.signal);
+			const removeActiveCollection = installActiveDialog(callbacks, cancellation.cancel);
+			let resolvedRequests: ResolvedCredentialRequest[] | undefined;
+			try {
+				const manifestPath = resolveSecureCredentialsManifestPath(ctx.cwd);
+				const manifest = await readSecureCredentialsManifest(manifestPath);
+				resolvedRequests = resolveSecureCredentialRequests(params.keys, manifest);
+				if (cancellation.signal.aborted) {
+					return buildSecureCredentialsToolResult(buildCancelledDetails(resolvedRequests, new Map()));
+				}
+				const requests = resolvedRequests;
+				const destinations = uniqueDestinations(requests);
+
+				const execution = await withCredentialDestinationQueues(
+					destinations,
+					0,
+					() =>
+						withCredentialDestinationLocks(
+							destinations,
+							requests,
+							0,
+							() =>
+								collectAndApplyCredentialChanges(
+									requests,
+									cancellation.signal,
+									ctx,
+									callbacks,
+								),
+						),
+				);
+
+				return buildSecureCredentialsToolResult(execution);
+			} catch (error) {
+				if (cancellation.signal.aborted && resolvedRequests) {
+					return buildSecureCredentialsToolResult(buildCancelledDetails(resolvedRequests, new Map()));
+				}
+				if (error instanceof SecureCredentialsManifestError || error instanceof SecureCredentialsFileError) {
+					throw error;
+				}
+				throw new Error("Secure credentials collection failed.");
+			} finally {
+				removeActiveCollection();
+				cancellation.dispose();
+			}
+		},
+
+		renderCall(args: SecureCredentialsRequest, theme: { fg: (color: string, text: string) => string; bold: (text: string) => string }) {
+			const keys = Array.isArray(args?.keys) ? args.keys.filter((key): key is string => typeof key === "string") : [];
+			const label = theme.fg("toolTitle", theme.bold("secure_credentials_collect"));
+			const requested = keys.length > 0 ? theme.fg("muted", ` ${keys.join(", ")}`) : "";
+			return new Text(label + requested, 0, 0);
+		},
+
+		renderResult(
+			result: { details?: unknown },
+			_options: unknown,
+			theme: { fg: (color: string, text: string) => string },
+		) {
+			const details = result.details as SecureCredentialsToolDetails | undefined;
+			if (!details || !Array.isArray(details.results)) {
+				return new Text(theme.fg("error", "Secure credentials collection failed."), 0, 0);
+			}
+			const lines = details.results.map((item) => {
+				const color = item.status === "applied" ? "success" : item.status === "cancelled" ? "warning" : "muted";
+				return theme.fg(color, `${item.key} ${item.destination} ${item.status}`);
+			});
+			return new Text(lines.join("\n"), 0, 0);
+		},
+	};
+}
+
+/** Load and register the collector only after a TUI session has started. */
+export default function secureCredentialsExtension(pi: ExtensionAPI): void {
+	const activeDialog = createActiveDialogController();
+	let registered = false;
+
+	pi.on("session_start", async (_event, ctx) => {
+		if (ctx.mode !== "tui" || registered) return;
+		pi.registerTool(
+			createSecureCredentialsTool({
+				setActiveDialog: activeDialog.set,
+				clearActiveDialog: activeDialog.clear,
+			}),
+		);
+		registered = true;
+	});
+
+	pi.on("session_shutdown", async () => {
+		activeDialog.cancel();
+	});
+}
+
+async function collectAndApplyCredentialChanges(
+	requests: ResolvedCredentialRequest[],
+	signal: AbortSignal,
+	ctx: ExtensionContext,
+	callbacks: SecureCredentialsToolCallbacks,
+): Promise<SecureCredentialsToolDetails> {
+	const snapshots = new Map<string, SecureCredentialsFileSnapshot>();
+	for (const destination of uniqueDestinations(requests)) {
+		const snapshot = await readSecureCredentialsFile(destination.path);
+		for (const request of requestsForDestination(requests, destination)) {
+			if ((snapshot.keyOccurrences.get(request.key) ?? 0) > 1) {
+				throw new SecureCredentialsFileError("duplicate key assignments must be resolved before collection");
+			}
+		}
+		snapshots.set(destination.id, snapshot);
+	}
+
+	const statuses = new Map<string, SecureCredentialResult["status"]>();
+	const values = new Map<string, string>();
+	try {
+		for (const request of requests) {
+			if (signal.aborted) {
+				return buildCancelledDetails(requests, statuses);
+			}
+			const snapshot = snapshots.get(request.destination.id);
+			if (!snapshot) throw new SecureCredentialsFileError("destination snapshot is missing");
+			const alreadyExists = (snapshot.keyOccurrences.get(request.key) ?? 0) === 1;
+
+			if (alreadyExists) {
+				const overwrite = await showOverwritePage(request, signal, ctx, callbacks);
+				if (overwrite.kind === "cancelled") {
+					return buildCancelledDetails(requests, statuses);
+				}
+				if (overwrite.kind === "skip") {
+					statuses.set(request.key, "skipped");
+					continue;
+				}
+			}
+
+			const input = await showCredentialInputPage(request, signal, ctx, callbacks);
+			if (input.kind === "cancelled") {
+				return buildCancelledDetails(requests, statuses);
+			}
+			values.set(request.key, input.value);
+			statuses.set(request.key, "applied");
+		}
+
+		if (signal.aborted) {
+			return buildCancelledDetails(requests, statuses);
+		}
+		const writes = buildCredentialWrites(requests, snapshots, values);
+		if (writes.length > 0) await commitCredentialWrites(writes);
+		return buildSecureCredentialDetails(requests, statuses);
+	} finally {
+		values.clear();
+	}
+}
+
+async function showCredentialInputPage(
+	request: ResolvedCredentialRequest,
+	signal: AbortSignal,
+	ctx: ExtensionContext,
+	callbacks: SecureCredentialsToolCallbacks,
+): Promise<SecureCredentialInputOutcome> {
+	if (signal.aborted) return { kind: "cancelled" };
+	let finish: ((outcome: SecureCredentialInputOutcome) => void) | undefined;
+	const cancel = () => finish?.({ kind: "cancelled" });
+	const removeActive = installActiveDialog(callbacks, cancel);
+	const abort = () => cancel();
+	signal.addEventListener("abort", abort, { once: true });
+	try {
+		const result = await ctx.ui.custom<SecureCredentialInputOutcome>((tui, theme, _keybindings, done) => {
+			finish = done;
+			return new SecureCredentialInputPage(
+				request.key,
+				request.destination.id,
+				theme,
+				() => tui.requestRender(),
+				done,
+			);
+		});
+		return result ?? { kind: "cancelled" };
+	} finally {
+		signal.removeEventListener("abort", abort);
+		removeActive();
+	}
+}
+
+async function showOverwritePage(
+	request: ResolvedCredentialRequest,
+	signal: AbortSignal,
+	ctx: ExtensionContext,
+	callbacks: SecureCredentialsToolCallbacks,
+): Promise<SecureCredentialOverwriteOutcome> {
+	if (signal.aborted) return { kind: "cancelled" };
+	let finish: ((outcome: SecureCredentialOverwriteOutcome) => void) | undefined;
+	const cancel = () => finish?.({ kind: "cancelled" });
+	const removeActive = installActiveDialog(callbacks, cancel);
+	const abort = () => cancel();
+	signal.addEventListener("abort", abort, { once: true });
+	try {
+		const result = await ctx.ui.custom<SecureCredentialOverwriteOutcome>((tui, theme, _keybindings, done) => {
+			finish = done;
+			return new SecureCredentialOverwritePage(
+				request.key,
+				request.destination.id,
+				theme,
+				() => tui.requestRender(),
+				done,
+			);
+		});
+		return result ?? { kind: "cancelled" };
+	} finally {
+		signal.removeEventListener("abort", abort);
+		removeActive();
+	}
+}
+
+function buildCredentialWrites(
+	requests: ResolvedCredentialRequest[],
+	snapshots: Map<string, SecureCredentialsFileSnapshot>,
+	values: Map<string, string>,
+): CredentialWrite[] {
+	const writes: CredentialWrite[] = [];
+	for (const destination of uniqueDestinations(requests)) {
+		const snapshot = snapshots.get(destination.id);
+		if (!snapshot) throw new SecureCredentialsFileError("destination snapshot is missing");
+		const changes = new Map<string, string>();
+		for (const request of requestsForDestination(requests, destination)) {
+			const value = values.get(request.key);
+			if (value !== undefined) changes.set(request.key, value);
+		}
+		if (changes.size === 0) continue;
+		writes.push({
+			destination,
+			snapshot,
+			nextBytes: buildSecureCredentialsFileContent(snapshot, changes),
+		});
+	}
+	return writes;
+}
+
+interface CredentialWrite {
+	destination: SecureCredentialsDestination;
+	snapshot: SecureCredentialsFileSnapshot;
+	nextBytes: Buffer;
+}
+
+async function commitCredentialWrites(writes: CredentialWrite[]): Promise<void> {
+	const committed: CredentialWrite[] = [];
+	try {
+		for (const write of writes) {
+			await writeSecureCredentialsFileAtomically(write.destination.path, write.snapshot, write.nextBytes);
+			committed.push(write);
+		}
+	} catch {
+		for (const write of committed.reverse()) {
+			try {
+				if (write.snapshot.exists) {
+					const current = await readSecureCredentialsFile(write.destination.path);
+					await writeSecureCredentialsFileAtomically(write.destination.path, current, write.snapshot.bytes);
+				} else {
+					await removeSecureCredentialsFileIfUnchanged(
+						write.destination.path,
+						write.snapshot,
+						write.nextBytes,
+					);
+				}
+			} catch {
+				continue;
+			}
+		}
+		throw new SecureCredentialsFileError("the credential transaction was rolled back");
+	}
+}
+
+async function withCredentialDestinationQueues<T>(
+	destinations: SecureCredentialsDestination[],
+	index: number,
+	callback: () => Promise<T>,
+): Promise<T> {
+	if (index >= destinations.length) return callback();
+	return withSecureCredentialsFileQueue(destinations[index]!.path, () =>
+		withCredentialDestinationQueues(destinations, index + 1, callback),
+	);
+}
+
+async function withCredentialDestinationLocks(
+	destinations: SecureCredentialsDestination[],
+	requests: ResolvedCredentialRequest[],
+	index: number,
+	callback: () => Promise<SecureCredentialsToolDetails>,
+): Promise<SecureCredentialsToolDetails> {
+	if (index >= destinations.length) return callback();
+	const lock = await withSecureCredentialsDestinationLock(destinations[index]!.path, () =>
+		withCredentialDestinationLocks(destinations, requests, index + 1, callback),
+	);
+	if (!lock.locked) {
+		return buildSkippedDetailsForRequests(requests);
+	}
+	return lock.value!;
+}
+
+function resolveSecureCredentialRequests(
+	keys: string[],
+	manifest: SecureCredentialsManifest,
+): ResolvedCredentialRequest[] {
+	if (!Array.isArray(keys) || keys.length === 0) {
+		throw new SecureCredentialsManifestError("the request must contain at least one key name");
+	}
+	const byKey = new Map<string, SecureCredentialsDestination>();
+	for (const destination of manifest.destinations) {
+		for (const key of destination.keys) byKey.set(key, destination);
+	}
+	const seen = new Set<string>();
+	return keys.map((key) => {
+		if (typeof key !== "string" || !isSecureCredentialKeyName(key)) {
+			throw new SecureCredentialsManifestError("the request contains an invalid key name");
+		}
+		if (seen.has(key)) throw new SecureCredentialsManifestError("the request contains a duplicate key name");
+		seen.add(key);
+		const destination = byKey.get(key);
+		if (!destination) throw new SecureCredentialsManifestError(`key ${key} is not allowlisted`);
+		return { key, destination };
+	});
+}
+
+function uniqueDestinations(requests: ResolvedCredentialRequest[]): SecureCredentialsDestination[] {
+	const byId = new Map<string, SecureCredentialsDestination>();
+	for (const request of requests) byId.set(request.destination.id, request.destination);
+	return [...byId.values()].sort((left, right) => left.path.localeCompare(right.path));
+}
+
+function requestsForDestination(
+	requests: ResolvedCredentialRequest[],
+	destination: SecureCredentialsDestination,
+): ResolvedCredentialRequest[] {
+	return requests.filter((request) => request.destination.id === destination.id);
+}
+
+function buildSecureCredentialsToolResult(details: SecureCredentialsToolDetails): {
+	content: [{ type: "text"; text: string }];
+	details: SecureCredentialsToolDetails;
+} {
+	const text = details.results
+		.map((result) => `${result.key} ${result.destination} ${result.status}`)
+		.join("\n");
+	return { content: [{ type: "text", text }], details };
+}
+
+function buildSecureCredentialDetails(
+	requests: ResolvedCredentialRequest[],
+	statuses: Map<string, SecureCredentialResult["status"]>,
+): SecureCredentialsToolDetails {
+	return {
+		results: requests.map((request) => ({
+			key: request.key,
+			destination: request.destination.id,
+			status: statuses.get(request.key) ?? "skipped",
+		})),
+	};
+}
+
+function buildCancelledDetails(
+	requests: ResolvedCredentialRequest[],
+	statuses: Map<string, SecureCredentialResult["status"]>,
+): SecureCredentialsToolDetails {
+	return {
+		results: requests.map((request) => ({
+			key: request.key,
+			destination: request.destination.id,
+			status: statuses.get(request.key) === "skipped" ? "skipped" : "cancelled",
+		})),
+	};
+}
+
+function buildSkippedDetailsForRequests(requests: ResolvedCredentialRequest[]): SecureCredentialsToolDetails {
+	return {
+		results: requests.map((request) => ({
+			key: request.key,
+			destination: request.destination.id,
+			status: "skipped" as const,
+		})),
+	};
+}
+
+function installActiveDialog(
+	callbacks: SecureCredentialsToolCallbacks,
+	cancel: () => void,
+): () => void {
+	callbacks.setActiveDialog(cancel);
+	return () => callbacks.clearActiveDialog(cancel);
+}
+
+function createActiveDialogController(): {
+	set: (cancel: () => void) => void;
+	clear: (cancel: () => void) => void;
+	cancel: () => void;
+} {
+	const activeCancels = new Set<() => void>();
+	return {
+		set(cancel) {
+			activeCancels.add(cancel);
+		},
+		clear(cancel) {
+			activeCancels.delete(cancel);
+		},
+		cancel() {
+			for (const cancel of [...activeCancels]) cancel();
+		},
+	};
+}
+
+function createCancellationSignal(
+	toolSignal: AbortSignal | undefined,
+	contextSignal: AbortSignal | undefined,
+): { signal: AbortSignal; cancel: () => void; dispose: () => void } {
+	const controller = new AbortController();
+	const relays: Array<() => void> = [];
+	for (const source of [toolSignal, contextSignal]) {
+		if (!source) continue;
+		const relay = () => controller.abort();
+		if (source.aborted) controller.abort();
+		else {
+			source.addEventListener("abort", relay, { once: true });
+			relays.push(() => source.removeEventListener("abort", relay));
+		}
+	}
+	return {
+		signal: controller.signal,
+		cancel: () => controller.abort(),
+		dispose: () => relays.forEach((remove) => remove()),
+	};
+}

--- a/.pi/opt-in-extensions/secure-credentials/secure-credentials-contract.ts
+++ b/.pi/opt-in-extensions/secure-credentials/secure-credentials-contract.ts
@@ -1,0 +1,53 @@
+/** The status returned for one requested credential. */
+export type SecureCredentialStatus = "applied" | "skipped" | "cancelled";
+
+/** The safe result returned for one requested credential. */
+export interface SecureCredentialResult {
+	/** The allowlisted environment-style key name. */
+	key: string;
+	/** The operator-defined logical destination name. */
+	destination: string;
+	/** The outcome without a credential value. */
+	status: SecureCredentialStatus;
+}
+
+/** The tool details that are safe to persist in a Pi session. */
+export interface SecureCredentialsToolDetails {
+	/** Results contain names and statuses only. */
+	results: SecureCredentialResult[];
+}
+
+/** One operator-defined local file destination. */
+export interface SecureCredentialsDestination {
+	/** The logical destination name shown to the operator. */
+	id: string;
+	/** The resolved local file path controlled by the manifest. */
+	path: string;
+	/** The allowlisted key names accepted by this destination. */
+	keys: string[];
+}
+
+/** The versioned operator-owned allowlist manifest. */
+export interface SecureCredentialsManifest {
+	/** The manifest schema version. */
+	version: 1;
+	/** The local destinations and their allowlisted keys. */
+	destinations: SecureCredentialsDestination[];
+}
+
+/** The only tool arguments accepted from the model. */
+export interface SecureCredentialsRequest {
+	/** Allowlisted key names requested by the model. */
+	keys: string[];
+}
+
+/** The outcome of a masked TUI value page. */
+export type SecureCredentialInputOutcome =
+	| { kind: "submitted"; value: string }
+	| { kind: "cancelled" };
+
+/** The outcome of a TUI overwrite page. */
+export type SecureCredentialOverwriteOutcome =
+	| { kind: "replace" }
+	| { kind: "skip" }
+	| { kind: "cancelled" };

--- a/.pi/opt-in-extensions/secure-credentials/secure-credentials-file.ts
+++ b/.pi/opt-in-extensions/secure-credentials/secure-credentials-file.ts
@@ -1,5 +1,5 @@
 import { constants } from "node:fs";
-import { chmod, lstat, mkdtemp, open, rename, rmdir, unlink } from "node:fs/promises";
+import { chmod, lstat, mkdir, mkdtemp, open, rename, rmdir, unlink } from "node:fs/promises";
 import { basename, dirname, parse, resolve } from "node:path";
 
 import { withFileMutationQueue } from "@earendil-works/pi-coding-agent";
@@ -59,7 +59,7 @@ export async function withSecureCredentialsDestinationLock<T>(
 	const lockPath = `${absolutePath}.lock`;
 
 	try {
-		await mkdirPrivateLockDirectory(lockPath);
+		await mkdir(lockPath, { mode: 0o700 });
 	} catch (error) {
 		if (isErrorCode(error, "EEXIST")) return { locked: false };
 		throw new SecureCredentialsFileError("the destination lock could not be created");
@@ -304,11 +304,6 @@ function countSecureCredentialKeys(text: string): Map<string, number> {
 
 function findSecureCredentialsLineEnding(lines: SecureCredentialsLine[]): string {
 	return lines.find((line) => line.ending.length > 0)?.ending ?? "\n";
-}
-
-async function mkdirPrivateLockDirectory(lockPath: string): Promise<void> {
-	const { mkdir } = await import("node:fs/promises");
-	await mkdir(lockPath, { mode: 0o700 });
 }
 
 async function syncSecureCredentialsDirectory(directoryPath: string): Promise<void> {

--- a/.pi/opt-in-extensions/secure-credentials/secure-credentials-file.ts
+++ b/.pi/opt-in-extensions/secure-credentials/secure-credentials-file.ts
@@ -1,0 +1,341 @@
+import { constants } from "node:fs";
+import { chmod, lstat, mkdtemp, open, rename, rmdir, unlink } from "node:fs/promises";
+import { basename, dirname, parse, resolve } from "node:path";
+
+import { withFileMutationQueue } from "@earendil-works/pi-coding-agent";
+
+/** A safe filesystem error that never includes file contents or secret values. */
+export class SecureCredentialsFileError extends Error {
+	constructor(message: string) {
+		super(`Secure credentials file error: ${message}`);
+		this.name = "SecureCredentialsFileError";
+	}
+}
+
+/** A non-blocking lock result for one destination file. */
+export interface SecureCredentialsLockResult<T> {
+	/** True when this operation acquired and released the destination lock. */
+	locked: boolean;
+	/** The callback result when the lock was acquired. */
+	value?: T;
+}
+
+/** The safe snapshot used for compare-before-write and rollback. */
+export interface SecureCredentialsFileSnapshot {
+	/** Whether the destination existed when it was read. */
+	exists: boolean;
+	/** The original bytes, kept only for the active transaction. */
+	bytes: Buffer;
+	/** The original private mode when the destination existed. */
+	mode?: number;
+	/** The number of assignments for each environment-style key. */
+	keyOccurrences: Map<string, number>;
+}
+
+/** Serialize a key change without shell interpolation or a multiline value. */
+export function serializeSecureCredentialValue(value: string): string {
+	if (value.includes("\n") || value.includes("\r")) {
+		throw new SecureCredentialsFileError("credential values must be single-line");
+	}
+	return JSON.stringify(value);
+}
+
+/** Queue the complete destination mutation window for this local file. */
+export function withSecureCredentialsFileQueue<T>(
+	filePath: string,
+	callback: () => Promise<T>,
+): Promise<T> {
+	return withFileMutationQueue(resolve(filePath), callback);
+}
+
+/** Acquire a private non-blocking lock directory for a destination file. */
+export async function withSecureCredentialsDestinationLock<T>(
+	filePath: string,
+	callback: () => Promise<T>,
+): Promise<SecureCredentialsLockResult<T>> {
+	const absolutePath = resolve(filePath);
+	const parentDirectory = dirname(absolutePath);
+	await validateSecureCredentialsParentDirectory(parentDirectory);
+	const lockPath = `${absolutePath}.lock`;
+
+	try {
+		await mkdirPrivateLockDirectory(lockPath);
+	} catch (error) {
+		if (isErrorCode(error, "EEXIST")) return { locked: false };
+		throw new SecureCredentialsFileError("the destination lock could not be created");
+	}
+
+	try {
+		return { locked: true, value: await callback() };
+	} finally {
+		await rmdir(lockPath);
+	}
+}
+
+/** Read and validate one private destination without returning its value to callers. */
+export async function readSecureCredentialsFile(filePath: string): Promise<SecureCredentialsFileSnapshot> {
+	const absolutePath = resolve(filePath);
+	await validateSecureCredentialsParentDirectory(dirname(absolutePath));
+
+	let handle: Awaited<ReturnType<typeof open>> | undefined;
+	try {
+		const noFollow = (constants as { O_NOFOLLOW?: number }).O_NOFOLLOW ?? 0;
+		handle = await open(absolutePath, constants.O_RDONLY | noFollow);
+		const metadata = await handle.stat();
+		validatePrivateCredentialFileMetadata(metadata);
+		const bytes = await handle.readFile();
+		const text = decodeCredentialFile(bytes);
+		return {
+			exists: true,
+			bytes,
+			mode: metadata.mode & 0o777,
+			keyOccurrences: countSecureCredentialKeys(text),
+		};
+	} catch (error) {
+		if (isErrorCode(error, "ENOENT")) {
+			return { exists: false, bytes: Buffer.alloc(0), keyOccurrences: new Map() };
+		}
+		if (error instanceof SecureCredentialsFileError) throw error;
+		throw new SecureCredentialsFileError("the destination could not be read");
+	} finally {
+		await handle?.close().catch(() => undefined);
+	}
+}
+
+/** Build the next destination bytes while preserving unrelated lines byte-for-byte. */
+export function buildSecureCredentialsFileContent(
+	snapshot: SecureCredentialsFileSnapshot,
+	changes: ReadonlyMap<string, string>,
+): Buffer {
+	const text = decodeCredentialFile(snapshot.bytes);
+	const lines = splitSecureCredentialsLines(text);
+	const serialized = new Map<string, string>();
+	for (const [key, value] of changes) {
+		serialized.set(key, serializeSecureCredentialValue(value));
+	}
+
+	const replaced = new Set<string>();
+	const output: string[] = [];
+	for (const line of lines) {
+		const assignment = parseSecureCredentialsAssignment(line.body);
+		if (!assignment || !serialized.has(assignment.key)) {
+			output.push(line.body + line.ending);
+			continue;
+		}
+		if ((snapshot.keyOccurrences.get(assignment.key) ?? 0) !== 1) {
+			throw new SecureCredentialsFileError("duplicate key assignments must be resolved before writing");
+		}
+		output.push(
+			`${assignment.prefix}${assignment.key}${assignment.separator}${serialized.get(assignment.key)}${line.ending}`,
+		);
+		replaced.add(assignment.key);
+	}
+
+	const lineEnding = findSecureCredentialsLineEnding(lines);
+	for (const [key, value] of serialized) {
+		if (replaced.has(key)) continue;
+		const current = output.join("");
+		if (current.length > 0 && !current.endsWith("\n") && !current.endsWith("\r")) {
+			output.push(lineEnding);
+		}
+		output.push(`${key}=${value}${lineEnding}`);
+		replaced.add(key);
+	}
+
+	return Buffer.from(output.join(""), "utf8");
+}
+
+/** Write destination bytes through a private temporary file and atomic rename. */
+export async function writeSecureCredentialsFileAtomically(
+	filePath: string,
+	expected: SecureCredentialsFileSnapshot,
+	nextBytes: Buffer,
+): Promise<void> {
+	const absolutePath = resolve(filePath);
+	await validateSecureCredentialsParentDirectory(dirname(absolutePath));
+	const current = await readSecureCredentialsFile(absolutePath);
+	if (current.exists !== expected.exists || !current.bytes.equals(expected.bytes)) {
+		throw new SecureCredentialsFileError("the destination changed during collection");
+	}
+
+	let temporaryDirectory: string | undefined;
+	let temporaryPath: string | undefined;
+	let handle: Awaited<ReturnType<typeof open>> | undefined;
+	try {
+		temporaryDirectory = await mkdtemp(`${dirname(absolutePath)}/.secure-credentials-`);
+		await chmod(temporaryDirectory, 0o700);
+		temporaryPath = `${temporaryDirectory}/${basename(absolutePath)}`;
+		handle = await open(
+			temporaryPath,
+			constants.O_WRONLY | constants.O_CREAT | constants.O_EXCL,
+			0o600,
+		);
+		await handle.writeFile(nextBytes);
+		await handle.sync();
+		await handle.close();
+		handle = undefined;
+		await rename(temporaryPath, absolutePath);
+		temporaryPath = undefined;
+		await syncSecureCredentialsDirectory(dirname(absolutePath));
+
+		const written = await readSecureCredentialsFile(absolutePath);
+		if (!written.exists || written.mode !== 0o600 || !written.bytes.equals(nextBytes)) {
+			throw new SecureCredentialsFileError("the atomic destination write did not verify");
+		}
+	} catch (error) {
+		if (error instanceof SecureCredentialsFileError) throw error;
+		throw new SecureCredentialsFileError("the atomic destination write failed");
+	} finally {
+		await handle?.close().catch(() => undefined);
+		if (temporaryPath) await unlink(temporaryPath).catch(() => undefined);
+		if (temporaryDirectory) await rmdir(temporaryDirectory).catch(() => undefined);
+	}
+}
+
+/** Remove a newly created destination during a failed multi-file transaction. */
+export async function removeSecureCredentialsFileIfUnchanged(
+	filePath: string,
+	expected: SecureCredentialsFileSnapshot,
+	createdBytes: Buffer,
+): Promise<void> {
+	if (expected.exists) {
+		throw new SecureCredentialsFileError("rollback expected a newly created destination");
+	}
+	const absolutePath = resolve(filePath);
+	const current = await readSecureCredentialsFile(absolutePath);
+	if (!current.exists) return;
+	if (!current.bytes.equals(createdBytes)) {
+		throw new SecureCredentialsFileError("the newly created destination changed before rollback");
+	}
+	await unlink(absolutePath);
+	await syncSecureCredentialsDirectory(dirname(absolutePath));
+}
+
+async function validateSecureCredentialsParentDirectory(directoryPath: string): Promise<void> {
+	const absoluteDirectory = resolve(directoryPath);
+	const root = parse(absoluteDirectory).root;
+	let current = root;
+	const parts = absoluteDirectory.slice(root.length).split(/[\\/]/u).filter(Boolean);
+	for (const part of parts) {
+		current = `${current}${current.endsWith("/") || current.endsWith("\\") ? "" : "/"}${part}`;
+		let metadata;
+		try {
+			metadata = await lstat(current);
+		} catch {
+			throw new SecureCredentialsFileError("the destination directory does not exist");
+		}
+		if (metadata.isSymbolicLink() || !metadata.isDirectory()) {
+			throw new SecureCredentialsFileError("destination path components must be ordinary directories");
+		}
+	}
+
+	const metadata = await lstat(absoluteDirectory).catch(() => undefined);
+	if (!metadata || metadata.isSymbolicLink() || !metadata.isDirectory()) {
+		throw new SecureCredentialsFileError("the destination parent must be an ordinary directory");
+	}
+	if ((metadata.mode & 0o077) !== 0) {
+		throw new SecureCredentialsFileError("the destination parent must be private");
+	}
+	assertCurrentOwner(metadata.uid, "the destination parent");
+}
+
+function validatePrivateCredentialFileMetadata(metadata: Awaited<ReturnType<typeof lstat>>): void {
+	if (metadata.isSymbolicLink() || !metadata.isFile() || metadata.nlink !== 1) {
+		throw new SecureCredentialsFileError("the destination must be one ordinary file with one link");
+	}
+	if ((metadata.mode & 0o077) !== 0 || (metadata.mode & 0o200) === 0) {
+		throw new SecureCredentialsFileError("the destination file must be private and owner-writable");
+	}
+	assertCurrentOwner(metadata.uid, "the destination file");
+}
+
+function decodeCredentialFile(bytes: Buffer): string {
+	try {
+		return new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+	} catch {
+		throw new SecureCredentialsFileError("the destination is not valid UTF-8 text");
+	}
+}
+
+interface SecureCredentialsLine {
+	body: string;
+	ending: string;
+}
+
+interface SecureCredentialsAssignment {
+	prefix: string;
+	key: string;
+	separator: string;
+}
+
+function splitSecureCredentialsLines(text: string): SecureCredentialsLine[] {
+	const lines: SecureCredentialsLine[] = [];
+	let start = 0;
+	for (let index = 0; index < text.length; index += 1) {
+		const char = text[index];
+		if (char !== "\n" && char !== "\r") continue;
+		const ending = char === "\r" && text[index + 1] === "\n" ? "\r\n" : char;
+		const end = ending === "\r\n" ? index + 2 : index + 1;
+		lines.push({ body: text.slice(start, index), ending });
+		start = end;
+		if (ending === "\r\n") index += 1;
+	}
+	if (start < text.length || lines.length === 0) {
+		lines.push({ body: text.slice(start), ending: "" });
+	}
+	return lines;
+}
+
+function parseSecureCredentialsAssignment(line: string): SecureCredentialsAssignment & { key: string } | undefined {
+	const match = /^([ \t]*(?:export[ \t]+)?)([A-Za-z_][A-Za-z0-9_]*)([ \t]*=[ \t]*)(.*)$/u.exec(line);
+	if (!match) return undefined;
+	return { prefix: match[1] ?? "", key: match[2] ?? "", separator: match[3] ?? "" };
+}
+
+function countSecureCredentialKeys(text: string): Map<string, number> {
+	const occurrences = new Map<string, number>();
+	for (const line of splitSecureCredentialsLines(text)) {
+		const assignment = parseSecureCredentialsAssignment(line.body);
+		if (!assignment) continue;
+		occurrences.set(assignment.key, (occurrences.get(assignment.key) ?? 0) + 1);
+	}
+	return occurrences;
+}
+
+function findSecureCredentialsLineEnding(lines: SecureCredentialsLine[]): string {
+	return lines.find((line) => line.ending.length > 0)?.ending ?? "\n";
+}
+
+async function mkdirPrivateLockDirectory(lockPath: string): Promise<void> {
+	const { mkdir } = await import("node:fs/promises");
+	await mkdir(lockPath, { mode: 0o700 });
+}
+
+async function syncSecureCredentialsDirectory(directoryPath: string): Promise<void> {
+	let handle: Awaited<ReturnType<typeof open>> | undefined;
+	try {
+		handle = await open(directoryPath, constants.O_RDONLY);
+		await handle.sync();
+	} catch (error) {
+		if (!isIgnorableDirectorySyncError(error)) {
+			throw new SecureCredentialsFileError("the destination directory could not be synchronized");
+		}
+	} finally {
+		await handle?.close().catch(() => undefined);
+	}
+}
+
+function isIgnorableDirectorySyncError(error: unknown): boolean {
+	return ["EBADF", "EISDIR", "EINVAL", "ENOTSUP", "EPERM"].some((code) => isErrorCode(error, code));
+}
+
+function isErrorCode(error: unknown, code: string): boolean {
+	return typeof error === "object" && error !== null && "code" in error && error.code === code;
+}
+
+function assertCurrentOwner(uid: number | undefined, subject: string): void {
+	if (typeof process.getuid !== "function" || uid === undefined) return;
+	if (uid !== process.getuid()) {
+		throw new SecureCredentialsFileError(`${subject} must belong to the current operator`);
+	}
+}

--- a/.pi/opt-in-extensions/secure-credentials/secure-credentials-manifest.ts
+++ b/.pi/opt-in-extensions/secure-credentials/secure-credentials-manifest.ts
@@ -1,0 +1,209 @@
+import { constants } from "node:fs";
+import { lstat, open } from "node:fs/promises";
+import { dirname, isAbsolute, parse, relative, resolve, sep } from "node:path";
+
+import type {
+	SecureCredentialsDestination,
+	SecureCredentialsManifest,
+} from "./secure-credentials-contract.ts";
+
+/** The operator environment variable that selects the manifest file. */
+export const SECURE_CREDENTIALS_MANIFEST_ENV = "WAYFINDER_SECURE_CREDENTIALS_MANIFEST";
+
+const SECURE_CREDENTIAL_KEY_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/u;
+const SECURE_CREDENTIAL_DESTINATION_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]*$/u;
+const SECURE_CREDENTIAL_MANIFEST_MODE_MASK = 0o022;
+
+/** A safe configuration error that never includes file contents or secret values. */
+export class SecureCredentialsManifestError extends Error {
+	constructor(message: string) {
+		super(`Secure credentials manifest error: ${message}`);
+		this.name = "SecureCredentialsManifestError";
+	}
+}
+
+/** Check whether a string is a valid environment-style credential key name. */
+export function isSecureCredentialKeyName(value: string): boolean {
+	return SECURE_CREDENTIAL_KEY_PATTERN.test(value);
+}
+
+/** Check whether a string is a safe operator-defined logical destination name. */
+export function isSecureCredentialDestinationId(value: string): boolean {
+	return SECURE_CREDENTIAL_DESTINATION_ID_PATTERN.test(value);
+}
+
+/** Resolve the operator-selected manifest without accepting a model-supplied path. */
+export function resolveSecureCredentialsManifestPath(
+	cwd: string,
+	environment: Readonly<Record<string, string | undefined>> = process.env,
+): string {
+	const configuredPath = environment[SECURE_CREDENTIALS_MANIFEST_ENV];
+	if (!configuredPath) {
+		throw new SecureCredentialsManifestError(
+			`set ${SECURE_CREDENTIALS_MANIFEST_ENV} before starting the specialist TUI session`,
+		);
+	}
+	if (configuredPath.includes("\0")) {
+		throw new SecureCredentialsManifestError("the configured manifest path contains a NUL byte");
+	}
+	return resolve(cwd, configuredPath);
+}
+
+/** Read and validate the private operator-owned allowlist manifest. */
+export async function readSecureCredentialsManifest(
+	manifestPath: string,
+): Promise<SecureCredentialsManifest> {
+	const absolutePath = resolve(manifestPath);
+	let handle: Awaited<ReturnType<typeof open>> | undefined;
+	try {
+		await validateSecureCredentialsManifestParent(dirname(absolutePath));
+		const metadata = await lstat(absolutePath);
+		if (metadata.isSymbolicLink()) {
+			throw new SecureCredentialsManifestError("the manifest must not be a symlink");
+		}
+		if (!metadata.isFile() || metadata.nlink !== 1) {
+			throw new SecureCredentialsManifestError("the manifest must be one ordinary file with one link");
+		}
+		if ((metadata.mode & SECURE_CREDENTIAL_MANIFEST_MODE_MASK) !== 0) {
+			throw new SecureCredentialsManifestError("the manifest must not be group or world writable");
+		}
+		assertCurrentOwner(metadata.uid, "the manifest");
+
+		const noFollow = (constants as { O_NOFOLLOW?: number }).O_NOFOLLOW ?? 0;
+		handle = await open(absolutePath, constants.O_RDONLY | noFollow);
+		const openedMetadata = await handle.stat();
+		if (openedMetadata.isSymbolicLink() || !openedMetadata.isFile() || openedMetadata.nlink !== 1) {
+			throw new SecureCredentialsManifestError("the manifest changed to a non-ordinary file");
+		}
+		assertCurrentOwner(openedMetadata.uid, "the manifest");
+		const bytes = await handle.readFile();
+		const text = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+		return parseSecureCredentialsManifest(text, absolutePath);
+	} catch (error) {
+		if (error instanceof SecureCredentialsManifestError) throw error;
+		throw new SecureCredentialsManifestError("the manifest could not be read");
+	} finally {
+		await handle?.close().catch(() => undefined);
+	}
+}
+
+/** Parse a manifest string and resolve every destination relative to its manifest file. */
+export function parseSecureCredentialsManifest(
+	text: string,
+	manifestPath: string,
+): SecureCredentialsManifest {
+	let value: unknown;
+	try {
+		value = JSON.parse(text) as unknown;
+	} catch {
+		throw new SecureCredentialsManifestError("the manifest is not valid JSON");
+	}
+
+	if (!isRecord(value) || value.version !== 1 || !Array.isArray(value.destinations)) {
+		throw new SecureCredentialsManifestError("the manifest must contain version 1 and destinations");
+	}
+
+	const manifestDirectory = dirname(resolve(manifestPath));
+	const destinations: SecureCredentialsDestination[] = [];
+	const seenIds = new Set<string>();
+	const seenPaths = new Set<string>();
+	const seenKeys = new Set<string>();
+
+	for (const candidate of value.destinations) {
+		if (!isRecord(candidate)) {
+			throw new SecureCredentialsManifestError("each destination must be an object");
+		}
+		const id = candidate.id;
+		const rawPath = candidate.path;
+		const keys = candidate.keys;
+		if (
+			typeof id !== "string" ||
+			!isSecureCredentialDestinationId(id) ||
+			typeof rawPath !== "string" ||
+			rawPath.length === 0 ||
+			rawPath.includes("\0") ||
+			!Array.isArray(keys) ||
+			keys.length === 0 ||
+			!keys.every((key): key is string => typeof key === "string")
+		) {
+			throw new SecureCredentialsManifestError("each destination needs a safe id, path, and key list");
+		}
+		if (seenIds.has(id)) {
+			throw new SecureCredentialsManifestError("destination ids must be unique");
+		}
+		seenIds.add(id);
+
+		const destinationPath = resolveManifestDestinationPath(manifestDirectory, rawPath);
+		if (seenPaths.has(destinationPath)) {
+			throw new SecureCredentialsManifestError("destination paths must be unique");
+		}
+		seenPaths.add(destinationPath);
+		if (destinationPath === resolve(manifestPath)) {
+			throw new SecureCredentialsManifestError("the manifest cannot also be a credential destination");
+		}
+
+		const uniqueKeys = new Set<string>();
+		for (const key of keys) {
+			if (!isSecureCredentialKeyName(key)) {
+				throw new SecureCredentialsManifestError("credential key names must use environment-style characters");
+			}
+			if (uniqueKeys.has(key) || seenKeys.has(key)) {
+				throw new SecureCredentialsManifestError("credential key names must be unique across destinations");
+			}
+			uniqueKeys.add(key);
+			seenKeys.add(key);
+		}
+
+		destinations.push({ id, path: destinationPath, keys: [...uniqueKeys] });
+	}
+
+	if (destinations.length === 0) {
+		throw new SecureCredentialsManifestError("the manifest must allow at least one destination");
+	}
+
+	return { version: 1, destinations };
+}
+
+/** Resolve only operator-manifest paths and reject relative traversal outside the manifest directory. */
+function resolveManifestDestinationPath(manifestDirectory: string, rawPath: string): string {
+	if (isAbsolute(rawPath)) return resolve(rawPath);
+	const destinationPath = resolve(manifestDirectory, rawPath);
+	const escaped = relative(manifestDirectory, destinationPath);
+	if (escaped === ".." || escaped.startsWith(`..${sep}`) || isAbsolute(escaped)) {
+		throw new SecureCredentialsManifestError("relative destination paths must stay under the manifest directory");
+	}
+	return destinationPath;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+async function validateSecureCredentialsManifestParent(directoryPath: string): Promise<void> {
+	const absoluteDirectory = resolve(directoryPath);
+	const root = parse(absoluteDirectory).root;
+	let current = root;
+	const parts = absoluteDirectory.slice(root.length).split(/[\\/]/u).filter(Boolean);
+	for (const part of parts) {
+		current = `${current}${current.endsWith("/") || current.endsWith("\\") ? "" : "/"}${part}`;
+		const metadata = await lstat(current).catch(() => undefined);
+		if (!metadata || metadata.isSymbolicLink() || !metadata.isDirectory()) {
+			throw new SecureCredentialsManifestError("manifest path components must be ordinary directories");
+		}
+	}
+	const metadata = await lstat(absoluteDirectory).catch(() => undefined);
+	if (!metadata || metadata.isSymbolicLink() || !metadata.isDirectory()) {
+		throw new SecureCredentialsManifestError("the manifest parent must be an ordinary directory");
+	}
+	if ((metadata.mode & 0o077) !== 0) {
+		throw new SecureCredentialsManifestError("the manifest parent must be private");
+	}
+	assertCurrentOwner(metadata.uid, "the manifest parent");
+}
+
+function assertCurrentOwner(uid: number | undefined, subject: string): void {
+	if (typeof process.getuid !== "function" || uid === undefined) return;
+	if (uid !== process.getuid()) {
+		throw new SecureCredentialsManifestError(`${subject} must belong to the current operator`);
+	}
+}

--- a/.pi/opt-in-extensions/secure-credentials/secure-credentials-ui.ts
+++ b/.pi/opt-in-extensions/secure-credentials/secure-credentials-ui.ts
@@ -1,0 +1,334 @@
+import type { Theme } from "@earendil-works/pi-coding-agent";
+import {
+	CURSOR_MARKER,
+	Key,
+	matchesKey,
+	truncateToWidth,
+	wrapTextWithAnsi,
+	type Component,
+	type Focusable,
+} from "@earendil-works/pi-tui";
+
+import type {
+	SecureCredentialInputOutcome,
+	SecureCredentialOverwriteOutcome,
+} from "./secure-credentials-contract.ts";
+
+const MASKED_CREDENTIAL_PLACEHOLDER = "••••••••";
+const BRACKETED_PASTE_START = "\x1b[200~";
+const BRACKETED_PASTE_END = "\x1b[201~";
+
+/** A single-line masked editor that keeps the IME cursor marker visible. */
+export class MaskedCredentialEditor implements Component, Focusable {
+	/** TUI sets this property when the editor owns focus. */
+	focused = false;
+
+	/** Called after a non-empty value is submitted and cleared from the editor. */
+	onSubmit?: (value: string) => void;
+	/** Called when Escape or Ctrl+C cancels the page. */
+	onCancel?: () => void;
+	/** Called when Enter is pressed with no value. */
+	onEmptySubmit?: () => void;
+
+	private value = "";
+	private cursor = 0;
+	private pasteBuffer = "";
+
+	/** Clear the in-memory editor value and its pending paste buffer. */
+	clear(): void {
+		this.value = "";
+		this.cursor = 0;
+		this.pasteBuffer = "";
+	}
+
+	handleInput(data: string): void {
+		if (matchesKey(data, Key.escape) || matchesKey(data, Key.ctrl("c"))) {
+			this.clear();
+			this.onCancel?.();
+			return;
+		}
+		if (matchesKey(data, Key.enter)) {
+			const submitted = this.value;
+			this.clear();
+			if (submitted.length === 0) {
+				this.onEmptySubmit?.();
+			} else {
+				this.onSubmit?.(submitted);
+			}
+			return;
+		}
+		if (matchesKey(data, Key.backspace)) {
+			this.deleteBackward();
+			return;
+		}
+		if (matchesKey(data, Key.delete)) {
+			this.deleteForward();
+			return;
+		}
+		if (matchesKey(data, Key.left)) {
+			this.moveLeft();
+			return;
+		}
+		if (matchesKey(data, Key.right)) {
+			this.moveRight();
+			return;
+		}
+		if (matchesKey(data, Key.home)) {
+			this.cursor = 0;
+			return;
+		}
+		if (matchesKey(data, Key.end)) {
+			this.cursor = this.value.length;
+			return;
+		}
+		this.handleTextOrPaste(data);
+	}
+
+	render(width: number): string[] {
+		const safeWidth = Math.max(1, width);
+		const mask = Array.from(MASKED_CREDENTIAL_PLACEHOLDER);
+		let content = mask.join("");
+		if (this.focused) {
+			const cursorIndex = Math.min(this.graphemeCountBeforeCursor(), mask.length - 1);
+			const before = mask.slice(0, cursorIndex).join("");
+			const atCursor = mask[cursorIndex] ?? " ";
+			const after = mask.slice(cursorIndex + 1).join("");
+			content = `${before}${CURSOR_MARKER}\x1b[7m${atCursor}\x1b[0m${after}`;
+		}
+
+		const line = truncateToWidth(content, safeWidth, "", true);
+		if (this.focused && !line.includes(CURSOR_MARKER)) {
+			return [`${CURSOR_MARKER}\x1b[7m \x1b[0m`];
+		}
+		return [line];
+	}
+
+	invalidate(): void {}
+
+	private handleTextOrPaste(data: string): void {
+		if (this.pasteBuffer.length > 0) {
+			const combined = this.pasteBuffer + data;
+			this.pasteBuffer = "";
+			const end = combined.indexOf(BRACKETED_PASTE_END);
+			if (end < 0) {
+				this.pasteBuffer = combined;
+				return;
+			}
+			this.insertPrintableText(combined.slice(0, end));
+			this.handleTextOrPaste(combined.slice(end + BRACKETED_PASTE_END.length));
+			return;
+		}
+
+		const start = data.indexOf(BRACKETED_PASTE_START);
+		if (start >= 0) {
+			this.insertPrintableText(data.slice(0, start));
+			const pasted = data.slice(start + BRACKETED_PASTE_START.length);
+			const end = pasted.indexOf(BRACKETED_PASTE_END);
+			if (end < 0) {
+				this.pasteBuffer = pasted;
+				return;
+			}
+			this.insertPrintableText(pasted.slice(0, end));
+			this.handleTextOrPaste(pasted.slice(end + BRACKETED_PASTE_END.length));
+			return;
+		}
+
+		this.insertPrintableText(data);
+	}
+
+	private insertPrintableText(text: string): void {
+		if (text.length === 0 || /[\u0000-\u001f\u007f]/u.test(text)) return;
+		this.value = `${this.value.slice(0, this.cursor)}${text}${this.value.slice(this.cursor)}`;
+		this.cursor += text.length;
+	}
+
+	private deleteBackward(): void {
+		if (this.cursor === 0) return;
+		const before = this.value.slice(0, this.cursor);
+		const graphemes = Array.from(before);
+		const previous = graphemes[graphemes.length - 1] ?? "";
+		this.cursor -= previous.length;
+		this.value = `${this.value.slice(0, this.cursor)}${this.value.slice(this.cursor + previous.length)}`;
+	}
+
+	private deleteForward(): void {
+		if (this.cursor >= this.value.length) return;
+		const after = Array.from(this.value.slice(this.cursor));
+		const next = after[0] ?? "";
+		this.value = `${this.value.slice(0, this.cursor)}${this.value.slice(this.cursor + next.length)}`;
+	}
+
+	private moveLeft(): void {
+		if (this.cursor === 0) return;
+		const before = Array.from(this.value.slice(0, this.cursor));
+		this.cursor -= (before[before.length - 1] ?? "").length;
+	}
+
+	private moveRight(): void {
+		if (this.cursor >= this.value.length) return;
+		const after = Array.from(this.value.slice(this.cursor));
+		this.cursor += (after[0] ?? "").length;
+	}
+
+	private graphemeCountBeforeCursor(): number {
+		return Array.from(this.value.slice(0, this.cursor)).length;
+	}
+}
+
+/** A TUI page that collects one credential without rendering its value. */
+export class SecureCredentialInputPage implements Component, Focusable {
+	private readonly editor: MaskedCredentialEditor;
+	private _focused = false;
+	private finished = false;
+	private errorText = "";
+	private readonly key: string;
+	private readonly destination: string;
+	private readonly theme: Theme;
+	private readonly requestRender: () => void;
+	private readonly done: (outcome: SecureCredentialInputOutcome) => void;
+
+	constructor(
+		key: string,
+		destination: string,
+		theme: Theme,
+		requestRender: () => void,
+		done: (outcome: SecureCredentialInputOutcome) => void,
+	) {
+		this.key = key;
+		this.destination = destination;
+		this.theme = theme;
+		this.requestRender = requestRender;
+		this.done = done;
+		this.editor = new MaskedCredentialEditor();
+		this.editor.onSubmit = (value) => this.finish({ kind: "submitted", value });
+		this.editor.onCancel = () => this.finish({ kind: "cancelled" });
+		this.editor.onEmptySubmit = () => {
+			this.errorText = "A non-empty value is required.";
+			this.requestRender();
+		};
+	}
+
+	get focused(): boolean {
+		return this._focused;
+	}
+
+	set focused(value: boolean) {
+		this._focused = value;
+		this.editor.focused = value;
+	}
+
+	handleInput(data: string): void {
+		if (matchesKey(data, Key.escape) || matchesKey(data, Key.ctrl("c"))) {
+			this.finish({ kind: "cancelled" });
+			return;
+		}
+		this.editor.handleInput(data);
+		this.requestRender();
+	}
+
+	render(width: number): string[] {
+		const safeWidth = Math.max(1, width);
+		const lines: string[] = [];
+		const addWrapped = (text: string) => {
+			lines.push(...wrapTextWithAnsi(text, safeWidth));
+		};
+
+		lines.push(this.theme.fg("borderAccent", "─".repeat(safeWidth)));
+		addWrapped(this.theme.fg("accent", `Credential key: ${this.key}`));
+		addWrapped(this.theme.fg("muted", `Destination: ${this.destination}`));
+		lines.push("");
+		lines.push(...this.editor.render(safeWidth));
+		lines.push("");
+		if (this.errorText) addWrapped(this.theme.fg("warning", this.errorText));
+		addWrapped(this.theme.fg("dim", "Enter saves this value. Escape cancels."));
+		lines.push(this.theme.fg("borderAccent", "─".repeat(safeWidth)));
+		return lines.map((line) => truncateToWidth(line, safeWidth, "", true));
+	}
+
+	invalidate(): void {
+		this.editor.invalidate();
+	}
+
+	dispose(): void {
+		this.editor.clear();
+	}
+
+	private finish(outcome: SecureCredentialInputOutcome): void {
+		if (this.finished) return;
+		this.finished = true;
+		this.editor.clear();
+		this.done(outcome);
+	}
+}
+
+/** A TUI page that requires an explicit choice before replacing an existing value. */
+export class SecureCredentialOverwritePage implements Component {
+	private selected: "replace" | "skip" = "skip";
+	private finished = false;
+	private readonly key: string;
+	private readonly destination: string;
+	private readonly theme: Theme;
+	private readonly requestRender: () => void;
+	private readonly done: (outcome: SecureCredentialOverwriteOutcome) => void;
+
+	constructor(
+		key: string,
+		destination: string,
+		theme: Theme,
+		requestRender: () => void,
+		done: (outcome: SecureCredentialOverwriteOutcome) => void,
+	) {
+		this.key = key;
+		this.destination = destination;
+		this.theme = theme;
+		this.requestRender = requestRender;
+		this.done = done;
+	}
+
+	handleInput(data: string): void {
+		if (matchesKey(data, Key.escape) || matchesKey(data, Key.ctrl("c"))) {
+			this.finish({ kind: "cancelled" });
+			return;
+		}
+		if (matchesKey(data, Key.left) || matchesKey(data, Key.right) || matchesKey(data, Key.tab)) {
+			this.selected = this.selected === "skip" ? "replace" : "skip";
+			this.requestRender();
+			return;
+		}
+		if (matchesKey(data, Key.enter)) {
+			this.finish({ kind: this.selected });
+		}
+	}
+
+	render(width: number): string[] {
+		const safeWidth = Math.max(1, width);
+		const lines: string[] = [];
+		const addWrapped = (text: string) => {
+			lines.push(...wrapTextWithAnsi(text, safeWidth));
+		};
+		const option = (kind: "replace" | "skip", label: string) => {
+			const marker = this.selected === kind ? ">" : " ";
+			const color = this.selected === kind ? "accent" : "muted";
+			return this.theme.fg(color, `${marker} ${label}`);
+		};
+
+		lines.push(this.theme.fg("borderAccent", "─".repeat(safeWidth)));
+		addWrapped(this.theme.fg("warning", `Credential key already exists: ${this.key}`));
+		addWrapped(this.theme.fg("muted", `Destination: ${this.destination}`));
+		lines.push("");
+		lines.push(option("skip", "Keep the existing value"));
+		lines.push(option("replace", "Replace it"));
+		lines.push("");
+		addWrapped(this.theme.fg("dim", "Left/Right or Tab chooses. Enter confirms. Escape cancels."));
+		lines.push(this.theme.fg("borderAccent", "─".repeat(safeWidth)));
+		return lines.map((line) => truncateToWidth(line, safeWidth, "", true));
+	}
+
+	invalidate(): void {}
+
+	private finish(outcome: SecureCredentialOverwriteOutcome): void {
+		if (this.finished) return;
+		this.finished = true;
+		this.done(outcome);
+	}
+}

--- a/.pi/opt-in-extensions/secure-credentials/secure-credentials.test.mjs
+++ b/.pi/opt-in-extensions/secure-credentials/secure-credentials.test.mjs
@@ -1,0 +1,605 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { chmod, cp, mkdir, mkdtemp, readFile, readdir, symlink, writeFile, link, stat } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const sourceDirectory = fileURLToPath(new URL("./", import.meta.url));
+const piPackageRoot = join(spawnSync("npm", ["root", "-g"], { encoding: "utf8" }).stdout.trim(), "@earendil-works", "pi-coding-agent");
+const { visibleWidth } = await import(pathToFileURL(join(piPackageRoot, "node_modules/@earendil-works/pi-tui/dist/index.js")).href);
+const manifestEnvironmentName = "WAYFINDER_SECURE_CREDENTIALS_MANIFEST";
+const canarySecret = "CANARY_SECRET_VALUE_SHOULD_NOT_ESCAPE";
+
+let testCount = 0;
+
+function pass(message) {
+	testCount += 1;
+	console.log(`ok - ${message}`);
+}
+
+function assertNoSecret(value, label) {
+	const serialized = typeof value === "string" ? value : JSON.stringify(value);
+	assert.equal(serialized.includes(canarySecret), false, `${label} exposed the canary`);
+}
+
+async function createFixture(name) {
+	const root = await mkdtemp(join(tmpdir(), `secure-credentials-${name}-`));
+	await mkdir(join(root, "node_modules/@earendil-works"), { recursive: true });
+	await writeFile(join(root, "package.json"), '{"type":"module"}\n');
+	await symlink(piPackageRoot, join(root, "node_modules/@earendil-works/pi-coding-agent"));
+	await symlink(join(piPackageRoot, "node_modules/@earendil-works/pi-tui"), join(root, "node_modules/@earendil-works/pi-tui"));
+	await symlink(join(piPackageRoot, "node_modules/@earendil-works/pi-ai"), join(root, "node_modules/@earendil-works/pi-ai"));
+	await symlink(join(piPackageRoot, "node_modules/typebox"), join(root, "node_modules/typebox"));
+	await cp(sourceDirectory, join(root, "secure-credentials"), { recursive: true });
+	return root;
+}
+
+async function createWorkspace(name, destinations, options = {}) {
+	const root = await createFixture(name);
+	const privateDirectory = join(root, "private");
+	await mkdir(privateDirectory, { recursive: true });
+	await chmod(privateDirectory, options.privateMode ?? 0o700);
+	const manifestPath = join(privateDirectory, "manifest.json");
+	const manifest = {
+		version: 1,
+		destinations: destinations.map((destination) => ({
+			id: destination.id,
+			path: destination.path ?? `${destination.id}.env`,
+			keys: destination.keys,
+		})),
+	};
+	await writeFile(manifestPath, JSON.stringify(manifest, null, 2) + "\n");
+	await chmod(manifestPath, 0o600);
+	return { root, privateDirectory, manifestPath };
+}
+
+async function createHarness(workspace, actionSets = [], options = {}) {
+	const extensionPath = join(workspace.root, "secure-credentials/index.ts");
+	const module = await import(`${pathToFileURL(extensionPath).href}?test=${Date.now()}-${Math.random()}`);
+	const handlers = new Map();
+	let tool;
+	let customCalls = 0;
+	let lastComponent;
+	const renderWidths = options.renderWidths ?? [];
+	const theme = {
+		fg: (_color, text) => text,
+		bold: (text) => text,
+	};
+	const tui = { requestRender() {} };
+	const pi = {
+		on(name, handler) {
+			handlers.set(name, handler);
+		},
+		registerTool(candidate) {
+			tool = candidate;
+		},
+	};
+	module.default(pi);
+	const sessionStart = handlers.get("session_start");
+	assert.equal(typeof sessionStart, "function", "extension did not register session_start");
+	const mode = options.mode ?? "tui";
+	await sessionStart({ reason: "startup" }, { mode });
+
+	const previousManifest = process.env[manifestEnvironmentName];
+	process.env[manifestEnvironmentName] = workspace.manifestPath;
+	const ui = {
+		async custom(factory) {
+			customCalls += 1;
+			let resolveDialog;
+			let settled = false;
+			const resultPromise = new Promise((resolve) => {
+				resolveDialog = resolve;
+			});
+			const done = (value) => {
+				if (settled) return;
+				settled = true;
+				resolveDialog(value);
+			};
+			lastComponent = factory(tui, theme, {}, done);
+			if (typeof lastComponent.focused === "boolean") lastComponent.focused = true;
+			const width = renderWidths[customCalls - 1];
+			if (width !== undefined) {
+				const lines = lastComponent.render(width);
+				for (const line of lines) {
+					assert.ok(visibleWidth(line) <= width, `TUI line exceeded width ${width}`);
+				}
+				options.onRender?.(lines, lastComponent, customCalls);
+			}
+			const actions = actionSets.shift();
+			if (typeof actions === "function") await actions(lastComponent, done);
+			else for (const action of actions ?? []) lastComponent.handleInput(action);
+			const result = await resultPromise;
+			lastComponent.dispose?.();
+			return result;
+		},
+	};
+	const context = {
+		mode,
+		cwd: workspace.root,
+		signal: options.signal,
+		ui,
+	};
+	return {
+		tool,
+		handlers,
+		context,
+		get customCalls() {
+			return customCalls;
+		},
+		get lastComponent() {
+			return lastComponent;
+		},
+		async finish() {
+			if (previousManifest === undefined) delete process.env[manifestEnvironmentName];
+			else process.env[manifestEnvironmentName] = previousManifest;
+		},
+	};
+}
+
+async function executeCollection(workspace, actionSets, options = {}) {
+	const harness = await createHarness(workspace, actionSets, options);
+	try {
+		const result = await harness.tool.execute("test-call", { keys: options.keys ?? [workspace.key] }, undefined, undefined, harness.context);
+		return { result, harness };
+	} finally {
+		await harness.finish();
+	}
+}
+
+async function assertRejectsCollection(workspace, options = {}) {
+	const harness = await createHarness(workspace, options.actionSets ?? [], options);
+	try {
+		await assert.rejects(
+			() => harness.tool.execute("test-call", { keys: options.keys ?? [workspace.key] }, undefined, undefined, harness.context),
+			/secure credentials/i,
+		);
+	} finally {
+		await harness.finish();
+	}
+}
+
+async function testTuiRegistrationAndModeRefusal() {
+	const workspace = await createWorkspace("registration", [{ id: "local", keys: ["REGISTRATION_KEY"] }]);
+	workspace.key = "REGISTRATION_KEY";
+	const tuiHarness = await createHarness(workspace, [["\r"]]);
+	assert.equal(tuiHarness.tool.name, "secure_credentials_collect");
+	assert.equal(tuiHarness.tool.executionMode, "sequential");
+	assert.deepEqual(Object.keys(tuiHarness.tool.parameters.properties), ["keys"]);
+	assert.equal(tuiHarness.tool.promptSnippet.includes("secret text"), true);
+	await tuiHarness.finish();
+
+	for (const mode of ["rpc", "print", "json"]) {
+		const harness = await createHarness(workspace, [], { mode });
+		assert.equal(harness.tool, undefined, `tool registered in ${mode} mode`);
+		await harness.finish();
+	}
+	pass("registration is discoverable only in TUI mode and the schema accepts key names only");
+}
+
+async function testNewFileAndSecretBoundaries() {
+	const workspace = await createWorkspace("new-file", [{ id: "local", keys: ["NEW_FILE_KEY"] }]);
+	workspace.key = "NEW_FILE_KEY";
+	const destination = join(workspace.privateDirectory, "local.env");
+	const logs = [];
+	const errors = [];
+	const oldLog = console.log;
+	const oldError = console.error;
+	const oldWrite = process.stderr.write;
+	console.log = (...args) => logs.push(args.join(" "));
+	console.error = (...args) => errors.push(args.join(" "));
+	process.stderr.write = (...args) => {
+		errors.push(String(args[0]));
+		return true;
+	};
+	const oldEnvironment = process.env.NEW_FILE_KEY;
+	delete process.env.NEW_FILE_KEY;
+	try {
+		const { result, harness } = await executeCollection(workspace, [[canarySecret, "\r"]], {
+			keys: ["NEW_FILE_KEY"],
+			renderWidths: [18],
+			onRender(lines, component) {
+				assert.equal(lines.join("\n").includes("\x1b_pi:c\x07"), true, "focused page omitted the IME marker");
+				assert.equal(lines.join("\n").includes(canarySecret), false, "focused page rendered the canary");
+				component.handleInput("\x1b[C");
+			},
+		});
+		assert.deepEqual(result, {
+			content: [{ type: "text", text: "NEW_FILE_KEY local applied" }],
+			details: { results: [{ key: "NEW_FILE_KEY", destination: "local", status: "applied" }] },
+		});
+		assert.equal(harness.customCalls, 1);
+		const content = await readFile(destination, "utf8");
+		assert.equal(content.includes(canarySecret), true);
+		assert.equal((await stat(destination)).mode & 0o777, 0o600);
+		assert.equal(process.env.NEW_FILE_KEY, undefined);
+		const sessionJsonl = JSON.stringify({ type: "message", message: { role: "toolResult", ...result } });
+		assertNoSecret(sessionJsonl, "session JSONL");
+		assertNoSecret(result, "tool result");
+		const rendered = harness.tool.renderResult(result, {}, { fg: (_color, text) => text }, {});
+		assertNoSecret(rendered.render(120).join("\n"), "renderer");
+		assertNoSecret(process.argv.join(" "), "argv");
+		assertNoSecret(logs, "logs");
+		assertNoSecret(errors, "stderr");
+	} finally {
+		if (oldEnvironment === undefined) delete process.env.NEW_FILE_KEY;
+		else process.env.NEW_FILE_KEY = oldEnvironment;
+		console.log = oldLog;
+		console.error = oldError;
+		process.stderr.write = oldWrite;
+	}
+	pass("new files use mode 0600 and the canary stays out of every returned or rendered artifact");
+}
+
+async function testExistingValueAndAtomicReplacement() {
+	const workspace = await createWorkspace("overwrite", [{ id: "local", keys: ["OVERWRITE_KEY"] }]);
+	workspace.key = "OVERWRITE_KEY";
+	const destination = join(workspace.privateDirectory, "local.env");
+	const original = "KEEP=one\r\nOVERWRITE_KEY=old\r\nTAIL=three\r\n";
+	await writeFile(destination, original);
+	await chmod(destination, 0o600);
+	const first = await executeCollection(workspace, [["\r"]], { keys: ["OVERWRITE_KEY"] });
+	assert.deepEqual(first.result.details.results[0], { key: "OVERWRITE_KEY", destination: "local", status: "skipped" });
+	assert.equal(await readFile(destination, "utf8"), original);
+	const second = await executeCollection(workspace, [["\x1b[C", "\r"], [canarySecret, "\r"]], { keys: ["OVERWRITE_KEY"] });
+	assert.deepEqual(second.result.details.results[0], { key: "OVERWRITE_KEY", destination: "local", status: "applied" });
+	const updated = await readFile(destination, "utf8");
+	assert.equal(updated.includes(canarySecret), true);
+	assert.equal(updated.includes("KEEP=one\r\n"), true);
+	assert.equal(updated.includes("TAIL=three\r\n"), true);
+	assert.equal(updated.includes("OVERWRITE_KEY=old"), false);
+	assert.equal((await stat(destination)).mode & 0o777, 0o600);
+	assert.equal((await readdir(workspace.privateDirectory)).some((entry) => entry.startsWith(".secure-credentials-")), false);
+	pass("existing values stay unchanged by default and replacement preserves unrelated bytes atomically");
+}
+
+async function testAllowlistsAndManifestTraversal() {
+	const workspace = await createWorkspace("allowlist", [{ id: "local", keys: ["ALLOWED_KEY"] }]);
+	workspace.key = "ALLOWED_KEY";
+	const harness = await createHarness(workspace, []);
+	try {
+		await assert.rejects(
+			() => harness.tool.execute("test-call", { keys: ["NOT_ALLOWED"] }, undefined, undefined, harness.context),
+			/allowlisted/i,
+		);
+		assert.equal(harness.customCalls, 0);
+	} finally {
+		await harness.finish();
+	}
+	const duplicateRequestHarness = await createHarness(workspace, []);
+	try {
+		await assert.rejects(
+			() => duplicateRequestHarness.tool.execute("test-call", { keys: ["ALLOWED_KEY", "ALLOWED_KEY"] }, undefined, undefined, duplicateRequestHarness.context),
+			/duplicate/i,
+		);
+	} finally {
+		await duplicateRequestHarness.finish();
+	}
+	const traversal = await createWorkspace("traversal", [{ id: "escape", path: "../escape.env", keys: ["TRAVERSAL_KEY"] }]);
+	traversal.key = "TRAVERSAL_KEY";
+	await assertRejectsCollection(traversal, { keys: ["TRAVERSAL_KEY"] });
+	const absolute = await createWorkspace("absolute", [{ id: "local", keys: ["ABSOLUTE_KEY"] }]);
+	absolute.key = "ABSOLUTE_KEY";
+	const absoluteDestination = join(absolute.privateDirectory, "absolute.env");
+	const absoluteManifest = JSON.parse(await readFile(absolute.manifestPath, "utf8"));
+	absoluteManifest.destinations[0].path = absoluteDestination;
+	await writeFile(absolute.manifestPath, JSON.stringify(absoluteManifest, null, 2) + "\n");
+	await chmod(absolute.manifestPath, 0o600);
+	const absoluteResult = await executeCollection(absolute, [["ABSOLUTE_VALUE", "\r"]], { keys: ["ABSOLUTE_KEY"] });
+	assert.deepEqual(absoluteResult.result.details.results, [{ key: "ABSOLUTE_KEY", destination: "local", status: "applied" }]);
+	const duplicateManifest = await createWorkspace("manifest-duplicate", [
+		{ id: "one", keys: ["DUPLICATE_MANIFEST_KEY"] },
+		{ id: "two", keys: ["DUPLICATE_MANIFEST_KEY"] },
+	]);
+	duplicateManifest.key = "DUPLICATE_MANIFEST_KEY";
+	await assertRejectsCollection(duplicateManifest, { keys: ["DUPLICATE_MANIFEST_KEY"] });
+	pass("unknown keys, duplicate requests, manifest duplicates, traversal, and unambiguous absolute paths are covered");
+}
+
+async function testSymlinkHardlinkModesAndReadFailures() {
+	const symlinkWorkspace = await createWorkspace("symlink", [{ id: "local", path: "link.env", keys: ["SYMLINK_KEY"] }]);
+	symlinkWorkspace.key = "SYMLINK_KEY";
+	const realFile = join(symlinkWorkspace.privateDirectory, "real.env");
+	await writeFile(realFile, "SYMLINK_KEY=old\n");
+	await chmod(realFile, 0o600);
+	await symlink(realFile, join(symlinkWorkspace.privateDirectory, "link.env"));
+	await assertRejectsCollection(symlinkWorkspace, { keys: ["SYMLINK_KEY"] });
+
+	const hardlinkWorkspace = await createWorkspace("hardlink", [{ id: "local", path: "linked.env", keys: ["HARDLINK_KEY"] }]);
+	hardlinkWorkspace.key = "HARDLINK_KEY";
+	const source = join(hardlinkWorkspace.privateDirectory, "source.env");
+	await writeFile(source, "HARDLINK_KEY=old\n");
+	await chmod(source, 0o600);
+	await link(source, join(hardlinkWorkspace.privateDirectory, "linked.env"));
+	await assertRejectsCollection(hardlinkWorkspace, { keys: ["HARDLINK_KEY"] });
+
+	const modeWorkspace = await createWorkspace("mode", [{ id: "local", path: "permissive.env", keys: ["MODE_KEY"] }]);
+	modeWorkspace.key = "MODE_KEY";
+	const permissive = join(modeWorkspace.privateDirectory, "permissive.env");
+	await writeFile(permissive, "MODE_KEY=old\n");
+	await chmod(permissive, 0o644);
+	await assertRejectsCollection(modeWorkspace, { keys: ["MODE_KEY"] });
+
+	const parentWorkspace = await createWorkspace("parent-symlink", [{ id: "local", path: "linked-dir/secret.env", keys: ["PARENT_KEY"] }]);
+	parentWorkspace.key = "PARENT_KEY";
+	const safeParent = join(parentWorkspace.root, "safe-parent");
+	await mkdir(safeParent);
+	await chmod(safeParent, 0o700);
+	await symlink(safeParent, join(parentWorkspace.privateDirectory, "linked-dir"));
+	await assertRejectsCollection(parentWorkspace, { keys: ["PARENT_KEY"] });
+
+	const readFailureWorkspace = await createWorkspace("read-failure", [{ id: "local", path: "directory.env", keys: ["READ_FAILURE_KEY"] }]);
+	readFailureWorkspace.key = "READ_FAILURE_KEY";
+	await mkdir(join(readFailureWorkspace.privateDirectory, "directory.env"));
+	await chmod(join(readFailureWorkspace.privateDirectory, "directory.env"), 0o700);
+	await assertRejectsCollection(readFailureWorkspace, { keys: ["READ_FAILURE_KEY"] });
+	pass("symlinks, hardlinks, permissive files, symlinked parents, and read failures stop before collection");
+}
+
+async function testDuplicateKeysAndLockContention() {
+	const duplicateWorkspace = await createWorkspace("duplicate", [{ id: "local", keys: ["DUPLICATE_KEY"] }]);
+	duplicateWorkspace.key = "DUPLICATE_KEY";
+	const duplicateFile = join(duplicateWorkspace.privateDirectory, "local.env");
+	const duplicateBytes = "DUPLICATE_KEY=one\nDUPLICATE_KEY=two\n";
+	await writeFile(duplicateFile, duplicateBytes);
+	await chmod(duplicateFile, 0o600);
+	await assertRejectsCollection(duplicateWorkspace, { keys: ["DUPLICATE_KEY"] });
+	assert.equal(await readFile(duplicateFile, "utf8"), duplicateBytes);
+
+	const lockWorkspace = await createWorkspace("lock", [{ id: "local", keys: ["LOCK_KEY"] }]);
+	lockWorkspace.key = "LOCK_KEY";
+	const lockPath = join(lockWorkspace.privateDirectory, "local.env.lock");
+	await mkdir(lockPath);
+	await chmod(lockPath, 0o700);
+	const locked = await executeCollection(lockWorkspace, [[canarySecret, "\r"]], { keys: ["LOCK_KEY"] });
+	assert.deepEqual(locked.result.details.results, [{ key: "LOCK_KEY", destination: "local", status: "skipped" }]);
+	assert.equal(locked.harness.customCalls, 0);
+	assert.equal(await stat(join(lockWorkspace.privateDirectory, "local.env")).then(() => true).catch(() => false), false);
+	pass("duplicate assignments fail safely and lock contention skips without collecting input");
+}
+
+async function testCancellationAbortAndMultiplePages() {
+	const cancellationWorkspace = await createWorkspace("cancel", [
+		{ id: "local", keys: ["FIRST_KEY", "SECOND_KEY"] },
+	]);
+	cancellationWorkspace.key = "FIRST_KEY";
+	const cancelResult = await executeCollection(cancellationWorkspace, [[canarySecret, "\r"], ["\x1b"]], {
+		keys: ["FIRST_KEY", "SECOND_KEY"],
+		renderWidths: [9, 9],
+	});
+	assert.deepEqual(cancelResult.result.details.results, [
+		{ key: "FIRST_KEY", destination: "local", status: "cancelled" },
+		{ key: "SECOND_KEY", destination: "local", status: "cancelled" },
+	]);
+	assert.equal(await stat(join(cancellationWorkspace.privateDirectory, "local.env")).then(() => true).catch(() => false), false);
+	assert.equal(cancelResult.harness.customCalls, 2);
+
+	const abortWorkspace = await createWorkspace("abort", [{ id: "local", keys: ["ABORT_KEY"] }]);
+	abortWorkspace.key = "ABORT_KEY";
+	const controller = new AbortController();
+	const abortResult = await executeCollection(
+		abortWorkspace,
+		[(component) => {
+			assert.equal(component.render(12).join("\n").includes("\x1b_pi:c\x07"), true);
+			controller.abort();
+		}],
+		{ keys: ["ABORT_KEY"], signal: controller.signal },
+	);
+	assert.deepEqual(abortResult.result.details.results, [{ key: "ABORT_KEY", destination: "local", status: "cancelled" }]);
+	assert.equal(await stat(join(abortWorkspace.privateDirectory, "local.env")).then(() => true).catch(() => false), false);
+	pass("multiple pages, Escape, narrow widths, and AbortSignal cancellation leave no partial file");
+}
+
+async function testReloadCleanup() {
+	const workspace = await createWorkspace("reload", [{ id: "local", keys: ["RELOAD_KEY"] }]);
+	workspace.key = "RELOAD_KEY";
+	const harness = await createHarness(workspace, [() => undefined], { keys: ["RELOAD_KEY"] });
+	const pending = harness.tool.execute("test-call", { keys: ["RELOAD_KEY"] }, undefined, undefined, harness.context);
+	await new Promise((resolve) => setImmediate(resolve));
+	await harness.handlers.get("session_shutdown")({ reason: "reload" }, harness.context);
+	const result = await pending;
+	assert.deepEqual(result.details.results, [{ key: "RELOAD_KEY", destination: "local", status: "cancelled" }]);
+	assert.equal(await stat(join(workspace.privateDirectory, "local.env")).then(() => true).catch(() => false), false);
+	await harness.finish();
+	pass("session shutdown cleanup cancels an active page without leaving a destination file");
+}
+
+async function findJsonlWithText(directory, text) {
+	for (const entry of await readdir(directory, { withFileTypes: true })) {
+		const entryPath = join(directory, entry.name);
+		if (entry.isDirectory()) {
+			const nested = await findJsonlWithText(entryPath, text);
+			if (nested) return nested;
+		} else if (entry.name.endsWith(".jsonl") && (await readFile(entryPath, "utf8")).includes(text)) {
+			return entryPath;
+		}
+	}
+	return undefined;
+}
+
+function shellQuote(value) {
+	return `'${value.replaceAll("'", "'\\''")}'`;
+}
+
+async function testRealPiTuiSecretBoundary() {
+	const workspace = await createWorkspace("real-tui", [{ id: "local", keys: ["E2E_KEY"] }]);
+	const sessionsDirectory = join(workspace.root, "sessions");
+	await mkdir(sessionsDirectory, { recursive: true });
+	const destination = join(workspace.privateDirectory, "local.env");
+	const driverPath = join(workspace.root, "driver.ts");
+	const environmentObservation = join(workspace.root, "environment-observation.txt");
+	const argvObservation = join(workspace.root, "argv-observation.txt");
+	const tuiLog = join(workspace.root, "tui.log");
+	await writeFile(
+		driverPath,
+		'import { createAssistantMessageEventStream } from "@earendil-works/pi-ai";\n' +
+			'import { writeFileSync } from "node:fs";\n' +
+			'export default function (pi) {\n' +
+			'  pi.registerProvider("secure-e2e", {\n' +
+			'    baseUrl: "http://127.0.0.1",\n' +
+			'    apiKey: "test-only",\n' +
+			'    api: "openai-completions",\n' +
+			'    models: [{ id: "deterministic", name: "deterministic", reasoning: false, input: ["text"], cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 }, contextWindow: 4096, maxTokens: 128 }],\n' +
+			'    streamSimple(model, context) {\n' +
+			'      const stream = createAssistantMessageEventStream();\n' +
+			'      const hasToolResult = context.messages.some((message) => message.role === "toolResult");\n' +
+			'      const output = { role: "assistant", content: [], api: model.api, provider: model.provider, model: model.id, usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, totalTokens: 0, cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 } }, stopReason: "pending", timestamp: Date.now() };\n' +
+			'      queueMicrotask(() => {\n' +
+			'        stream.push({ type: "start", partial: output });\n' +
+			'        if (!hasToolResult) {\n' +
+			'          const call = { type: "toolCall", id: "secure-e2e-call", name: "secure_credentials_collect", arguments: { keys: ["E2E_KEY"] } };\n' +
+			'          output.content.push(call);\n' +
+			'          output.stopReason = "toolUse";\n' +
+			'          stream.push({ type: "toolcall_start", contentIndex: 0, partial: output });\n' +
+			'          stream.push({ type: "toolcall_end", contentIndex: 0, toolCall: call, partial: output });\n' +
+			'          stream.push({ type: "done", reason: "toolUse", message: output });\n' +
+			'        } else {\n' +
+			'          const text = "E2E_COMPLETE";\n' +
+			'          output.content.push({ type: "text", text });\n' +
+			'          output.stopReason = "stop";\n' +
+			'          stream.push({ type: "text_start", contentIndex: 0, partial: output });\n' +
+			'          stream.push({ type: "text_delta", contentIndex: 0, delta: text, partial: output });\n' +
+			'          stream.push({ type: "text_end", contentIndex: 0, content: text, partial: output });\n' +
+			'          stream.push({ type: "done", reason: "stop", message: output });\n' +
+			'        }\n' +
+			'        stream.end();\n' +
+			'      });\n' +
+			'      return stream;\n' +
+			'    },\n' +
+			'  });\n' +
+			'  pi.on("session_shutdown", () => {\n' +
+			'    writeFileSync(process.env.E2E_ENV_OBSERVATION, process.env.E2E_KEY ?? "<unset>");\n' +
+			'    writeFileSync(process.env.E2E_ARGV_OBSERVATION, process.argv.join("\\u0000"));\n' +
+			'  });\n' +
+			'}\n',
+	);
+
+	const socket = `secure-credentials-e2e-${process.pid}`;
+	const sessionName = `secure-credentials-${process.pid}`;
+	const piCommand = [
+		"env",
+		`E2E_ENV_OBSERVATION=${shellQuote(environmentObservation)}`,
+		`E2E_ARGV_OBSERVATION=${shellQuote(argvObservation)}`,
+		`WAYFINDER_SECURE_CREDENTIALS_MANIFEST=${shellQuote(workspace.manifestPath)}`,
+		`PI_TUI_WRITE_LOG=${shellQuote(tuiLog)}`,
+		"PI_OFFLINE=1",
+		"pi",
+		"--session-dir",
+		shellQuote(sessionsDirectory),
+		"--no-context-files",
+		"--no-skills",
+		"--no-prompt-templates",
+		"--no-extensions",
+		"--approve",
+		"-e",
+		shellQuote(join(workspace.root, "secure-credentials/index.ts")),
+		"-e",
+		shellQuote(driverPath),
+		"--provider",
+		"secure-e2e",
+		"--model",
+		"deterministic",
+		"begin",
+	].join(" ");
+	try {
+		const started = spawnSync("tmux", ["-L", socket, "new-session", "-d", "-s", sessionName, "-x", "80", "-y", "24", `cd ${shellQuote(workspace.root)} && ${piCommand}`], {
+			encoding: "utf8",
+		});
+		assert.equal(started.status, 0, started.stderr);
+		let pane = "";
+		for (let attempt = 0; attempt < 200; attempt += 1) {
+			pane = spawnSync("tmux", ["-L", socket, "capture-pane", "-p", "-t", sessionName, "-S", "-200"], { encoding: "utf8" }).stdout;
+			if (pane.includes("Credential key: E2E_KEY")) break;
+			await new Promise((resolve) => setTimeout(resolve, 50));
+		}
+		assert.equal(pane.includes("Credential key: E2E_KEY"), true, pane);
+		spawnSync("tmux", ["-L", socket, "send-keys", "-t", sessionName, "-l", canarySecret], { encoding: "utf8" });
+		spawnSync("tmux", ["-L", socket, "send-keys", "-t", sessionName, "Enter"], { encoding: "utf8" });
+		const sessionFilePromise = (async () => {
+			for (let attempt = 0; attempt < 240; attempt += 1) {
+				const sessionFile = await findJsonlWithText(sessionsDirectory, "E2E_COMPLETE");
+				if (sessionFile) return sessionFile;
+				await new Promise((resolve) => setTimeout(resolve, 50));
+			}
+			return undefined;
+		})();
+		const sessionFile = await sessionFilePromise;
+		assert.ok(sessionFile, "Pi did not finish the deterministic TUI session");
+		pane = spawnSync("tmux", ["-L", socket, "capture-pane", "-p", "-t", sessionName, "-S", "-300"], { encoding: "utf8" }).stdout;
+		assertNoSecret(pane, "Pi TUI pane");
+		assertNoSecret(await readFile(sessionFile, "utf8"), "real Pi session JSONL");
+		assert.equal((await stat(destination)).mode & 0o777, 0o600);
+		assert.equal((await readFile(destination, "utf8")).includes(canarySecret), true);
+		spawnSync("tmux", ["-L", socket, "send-keys", "-t", sessionName, "C-d"], { encoding: "utf8" });
+		let observedEnvironment;
+		for (let attempt = 0; attempt < 200; attempt += 1) {
+			try {
+				observedEnvironment = await readFile(environmentObservation, "utf8");
+				break;
+			} catch {
+				await new Promise((resolve) => setTimeout(resolve, 50));
+			}
+		}
+		assert.ok(observedEnvironment !== undefined, "Pi did not emit the shutdown environment observation");
+		assertNoSecret(observedEnvironment, "Pi process environment");
+		assertNoSecret(await readFile(argvObservation, "utf8"), "Pi argv");
+		assertNoSecret(await readFile(tuiLog, "utf8"), "Pi TUI write log");
+		pass("real Pi TUI collection keeps the canary out of the pane, session JSONL, environment, argv, and TUI log");
+	} finally {
+		spawnSync("tmux", ["-L", socket, "kill-session", "-t", sessionName], { encoding: "utf8" });
+	}
+}
+
+async function testPlainPiDoesNotDiscoverExtension() {
+	const root = await createFixture("plain-launch");
+	const probePath = join(root, "probe.ts");
+	const outputPath = join(root, "tool-names.json");
+	await writeFile(
+		probePath,
+		'import { writeFileSync } from "node:fs";\n' +
+			'export default function (pi) {\n' +
+			'  pi.on("session_start", (_event, ctx) => {\n' +
+			'    writeFileSync(process.env.PROBE_OUTPUT, JSON.stringify(pi.getAllTools().map((tool) => tool.name)));\n' +
+			'    ctx.shutdown();\n' +
+			'  });\n' +
+			'}\n',
+	);
+	const child = spawnSync(
+		"pi",
+		[
+			"--mode",
+			"rpc",
+			"--no-session",
+			"--no-context-files",
+			"--no-skills",
+			"--no-prompt-templates",
+			"--approve",
+			"--offline",
+			"-e",
+			probePath,
+		],
+		{
+			cwd: root,
+			encoding: "utf8",
+			timeout: 30000,
+			env: { ...process.env, PROBE_OUTPUT: outputPath },
+		},
+	);
+	assert.equal(child.error, undefined, child.error?.message);
+	assert.equal(child.status, 0, child.stderr);
+	const names = JSON.parse(await readFile(outputPath, "utf8"));
+	assert.equal(names.includes("secure_credentials_collect"), false);
+	pass("an ordinary Pi launch does not auto-discover the opt-in extension outside .pi/extensions");
+}
+
+await testTuiRegistrationAndModeRefusal();
+await testNewFileAndSecretBoundaries();
+await testExistingValueAndAtomicReplacement();
+await testAllowlistsAndManifestTraversal();
+await testSymlinkHardlinkModesAndReadFailures();
+await testDuplicateKeysAndLockContention();
+await testCancellationAbortAndMultiplePages();
+await testReloadCleanup();
+await testRealPiTuiSecretBoundary();
+await testPlainPiDoesNotDiscoverExtension();
+console.log(`secure-credentials tests: ${testCount} passed`);


### PR DESCRIPTION
## Intent

COMPLETE ORIGINAL TASK BRIEF:
You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.

# Task
Implement Wayfinder ticket PX05, the opt-in TUI credential collector, without installing or copying the GSD Pi extension raw.

Authoritative plan:
- `data/wayfinder/pi-workflow-extensions/MAP.md`
- `data/wayfinder/pi-workflow-extensions/tickets/PX02.md`
- `data/wayfinder/pi-workflow-extensions/tickets/PX03.md`
- `data/wayfinder/pi-workflow-extensions/tickets/PX05.md`
- Evidence: `data/gsd-pi-pi-extensions-scout/report.md`

Before editing:
- Read and follow `/home/shiv/tec-workspace/.agents/skills/firstmate-coding-guidelines/SKILL.md`.
- Read and apply `/home/shiv/.pi/agent/skills/write-discoverable-code/SKILL.md` and `/home/shiv/.pi/agent/skills/codebase-design/SKILL.md`.
- Read the installed Pi `docs/extensions.md`, `docs/tui.md`, `docs/packages.md`, `docs/security.md`, `docs/rpc.md`, `docs/session-format.md`, and `docs/environment-variables.md` completely.
- Follow relevant Markdown cross-references and inspect the installed extension examples before implementing.
- Run `no-mistakes doctor` after creating the branch and stop if the repository is not ready.

Scope ownership:
- Own only `.pi/opt-in-extensions/secure-credentials/**`, its focused tests, and documentation colocated with that extension.
- Do not edit the ask-user extension, shared Firstmate instructions, README, or unrelated integration docs.
- PX07 owns cross-extension integration and shared documentation.

Required behavior:
- Keep the extension outside `.pi/extensions/` so Pi never auto-discovers it.
- Load only through explicit `pi -e <entrypoint>` in a specialist TUI session.
- Register a discoverable tool such as `secure_credentials_collect` only in TUI mode.
- Accept an operator-owned allowlisted manifest; tool arguments may request allowed key names but never provide paths, commands, sinks, or secret values.
- Collect values through `ctx.ui.custom()` with an IME-safe masked editor.
- Show no prefix, suffix, raw length, or secret fragment.
- Validate private directories, ordinary files, link counts, symlinks, and allowlisted paths before reading or writing.
- Create new files with mode `0600` and update through a private temporary file plus atomic rename.
- Serialize each full read-modify-write window per destination.
- Preserve an existing value by default; replacement requires explicit TUI confirmation.
- Never copy the secret into `process.env`, argv, shell commands, URLs, logs, stderr, tool results, renderer details, or Pi session entries.
- Abort and cancellation must leave no partial write.
- RPC, print, and JSON modes must refuse before collecting input.
- Return only key name, logical destination, and applied, skipped, or cancelled status.
- Do not claim JavaScript string zeroization; minimize copies and lifetime instead.

First-cut exclusions:
- No Vercel, Convex, keychain, remote channel, provider login, automatic rotation, existing-value preview, arbitrary `.env` path, or auto-installation.
- Do not create the main-home enablement marker.
- Do not change merge, send, discard, credential, or security authority.

Verification:
- Exercise the public extension surface, not source-byte assertions.
- Cover allowlists, traversal, absolute paths, symlinks, hardlinks, modes, lock contention, atomic replacement, duplicate keys, read failures, cancellation, and overwrite choice.
- Use canary secrets to prove absence from result content, details, renderer, session JSONL, environment, argv, and logs.
- Cover TUI focus, IME marker, narrow width, multiple pages, Escape, abort, and reload cleanup.
- Prove the extension remains undiscovered in an ordinary plain Pi launch.
- Run focused tests, `bin/fm-doc-audience-check.sh` for maintained prose, and `bin/fm-lint.sh` when applicable.
- Before reporting implementation complete, load `/home/shiv/.agents/skills/but-for-real/SKILL.md` and challenge every acceptance claim.

# Herdr lifecycle declaration - NOT ENABLED
**HARD SAFETY GATE:** this scaffold cannot inspect the task text that replaces `{TASK}` later.
If the task will start, stop, delete, restart, profile, or otherwise drive Herdr lifecycle behavior, stop and regenerate the brief with `--herdr-lab` before dispatch.
Do not add Herdr lifecycle commands to this unguarded brief by hand.

# Setup
You are in a disposable git worktree of tec-workspace, at a detached HEAD on a clean default branch.

**Verify isolation before anything else.** Run `pwd -P` and `git rev-parse --show-toplevel`; both must resolve to the disposable task worktree you were launched in, such as a treehouse pool path or an Orca-managed worktree, not the primary checkout firstmate operates from.
The path check is authoritative: `git rev-parse --git-dir` and `git rev-parse --git-common-dir` can help inspect the repo, but they do not prove you are outside the primary checkout.
If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not branch or commit here - append `blocked: launched in primary checkout, not an isolated worktree` to the status file and stop.

1. First action: create your branch: `git checkout -b fm/px05-secure-credentials-tui`

# Rules
1. Never push to the default branch. Never merge a PR. Work only on your `fm/px05-secure-credentials-tui` branch.
2. Stay inside this worktree; modify nothing outside it.
3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
4. Report status by appending one line:
`echo "{state}: {one short line}" >> '/home/shiv/tec-workspace/state/px05-secure-credentials-tui.status'`
States: working, needs-decision, blocked, paused, done, failed.
Each append wakes firstmate, so report sparingly: only phase changes a supervisor
would act on (setup done, bug reproduced, fix implemented, validation passed) and the
needs-decision/blocked/paused/done/failed states. No step-by-step FYI progress lines;
firstmate reads your pane for that.
A mid-task `working:` line (including setup complete) is nonterminal: do not end the
turn after it; continue the same stage until a defined `done:` gate under Definition of done.
Use `paused: {why}` - distinct from `blocked:` - ONLY when you are deliberately idling on a
known external wait you expect to clear on its own (an upstream release, a rate-limit reset,
a scheduled window): firstmate then leaves your idle pane alone and rechecks it on a long
cadence instead of treating it as a possible wedge. Use `blocked:` when you are stuck and need help.
5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
6. If a decision belongs above the implementation worker (product choices, destructive actions, ask-user findings),
append `needs-decision: {summary of options}` and stop. Firstmate will apply the configured authority and reply with the decision.
When firstmate replies or a blocker clears and you resume, append `resolved: {how it was decided or unblocked}` (add the same `[key=<slug>]` if you opened it with one) so the decision or blocker is durably closed and does not keep resurfacing.
7. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving
every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
daemon error, append `blocked: {the daemon error}` and stop; only firstmate manages the daemon.

# Project memory
If `AGENTS.md` or `CLAUDE.md` already exists, or if this task produced durable project-intrinsic knowledge, run `/home/shiv/tec-workspace/bin/fm-ensure-agents-md.sh .` in the worktree.
Record only project knowledge useful to almost every future session.
For anything the codebase already shows, prefer a pointer to the authoritative file, command, or doc over copying the detail.
If you touch a project `AGENTS.md` that lacks `## Maintaining this file`, add that short self-governance section from `/home/shiv/tec-workspace/bin/fm-ensure-agents-md.sh` in the same pass.
Keep it proportionate: skip `AGENTS.md` edits for trivial tasks that produced no durable project knowledge.

# Definition of done
The task is complete only when committed on your branch.
When you believe it is complete, append `done: {summary}` to the status file and stop.
Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.

You drive no-mistakes by responding to its gates, not by implementing fixes.
Follow the guidance no-mistakes provides, `no-mistakes axi run --help`, and every returned `help` line.
The run intent must preserve this Task section and every later accepted clarification.
Do not hand-edit, commit, abort, restart, or answer findings yourself while a run is active.
Ask-user findings return to firstmate under rule 6.
Avoid `--yes`, because it would bypass firstmate's authority check.

After /no-mistakes reports CI green, append `done: PR {url} checks green` and stop.
Do not merge.
PX08 owns the captain's required visual acceptance before landing or activation.


ACCEPTED WAYFINDER MAP:
# Map: Extensões TUI para o workflow Pi

**Destination:** Integrar duas extensões TUI independentes ao workflow Pi: perguntas estruturadas na sessão principal e coleta segura de credenciais em sessão especialista explícita, sem instalar código upstream cru, sem criar outra autoridade e sem expor segredos na conversa ou na sessão.

## Notes

- Idioma: pt-BR.
- Evidência GSD Pi: `data/gsd-pi-pi-extensions-scout/report.md`.
- Evidência Oh My Pi: `data/oh-my-pi-pi-extensions-scout/report.md`.
- Baseline local: Pi `0.83.0`, docs `extensions.md`, `tui.md`, `packages.md` e `session-format.md` da instalação atual.
- Este mapa planeja duas extensões separadas. Não existe pacote monolítico obrigatório.
- O caminho comum é somente o contrato de compatibilidade, carregamento e autoridade. Cada ramo pode ser implementado e validado separadamente.
- O mapa não autoriza implementação por si só. Os tickets de task começam somente após despacho explícito.

## Grafo

- Tronco: PX01 -> PX02.
- Ramo credenciais: PX02 -> PX03 -> PX05.
- Ramo perguntas: PX02 -> PX04 -> PX06.
- Cruzamento de integração: PX05 + PX06 -> PX07 -> PX08.

## Frontier

- PX05 - Implementar coletor TUI seguro de credenciais (task, em andamento como `px05-secure-credentials-tui`)
- PX06 - Implementar perguntas TUI estruturadas (task, em andamento como `px06-ask-user-tui`)
- PX07 - Provar isolamento, lifecycle, reload e empacotamento (task, bloqueado por PX05 e PX06)
- PX08 - Aceite visual e operacional do captain (visual-review, bloqueado por PX07)

PX05 e PX06 são independentes e podem começar em paralelo quando autorizados.

## Decisions so far

- PX01 - As fontes foram fixadas e comparadas contra a API pública do Pi instalado.
- PX02 - As extensões ficam separadas. Nenhum pacote upstream será instalado cru.
- `ask-user-tui` registra o tool somente quando a sessão TUI roda na home principal e encontra o marker privado `config/ask-user-tui`; o marker não é herdado.
- `secure-credentials-tui` carrega somente por `-e` em uma sessão especialista explícita.
- Workers normais e secondmates não recebem nenhuma das duas por padrão.
- Perguntas estruturadas não substituem `decision-hold-lifecycle`, backlog, autoridade do captain ou contratos de worker.
- O coletor não recebe caminho ou valor secreto do modelo, não hidrata `process.env` e não possui sinks Vercel ou Convex no primeiro corte.
- Nenhum limite numérico de perguntas, caracteres, timeout ou páginas será copiado sem medição local.

## Not yet specified

- Nenhuma escolha funcional bloqueia os dois ramos.
- Limites de UI e tripwires serão medidos nas provas TUI de PX07 antes de virarem configuração.
- A ordem de implementação será escolhida no despacho. Ela não altera o grafo.

## Out of scope

- Instalação direta de `get-secrets-from-user.ts` ou `ask-user-questions.ts`.
- Perguntas remotas por Slack, Discord, Telegram, X ou outro canal.
- Coleta de segredo em RPC, print, JSON ou chat.
- Vercel, Convex, rotação automática, descoberta automática de arquivos ou escrita arbitrária em `.env`.
- Outro dispatcher, watcher, worktree manager, permission system ou backlog.
- Alteração de merge authority, segurança, descarte ou aprovação por resposta TUI.
- Swarm, subagent, bg-shell, GSD engine e qualquer runtime paralelo.


ACCEPTED WAYFINDER PX02 CONSTRAINTS:
# PX02 - Topologia, carregamento e autoridade

**Type:** grilling
**Status:** resolved
**Blocked by:** PX01

## Question

Definir se as duas capacidades viram uma extensão única ou separada, onde carregam e quais sessões podem usá-las.

## Decision

Serão duas extensões independentes.

### Perguntas TUI

- Entrada planejada: `.pi/extensions/fm-ask-user-tui.ts` ou diretório equivalente.
- Auto-discovery somente no projeto Firstmate.
- A factory registra a superfície apenas em TUI, quando o cwd canônico contém um marker privado, regular e não symlinkado em `config/ask-user-tui`, e não existe `.fm-secondmate-home`.
- O marker pertence somente à home principal, não entra na allowlist de herança e só será criado após PX08.
- Não confiar apenas em `FM_HOME`: workers comuns podem iniciar sem essa variável explícita.
- Em worktree de worker, secondmate, sessão sem marker ou sessão sem TUI, a extensão não registra o tool.

### Credenciais TUI

- Entrada planejada: `.pi/opt-in-extensions/secure-credentials/index.ts` ou diretório equivalente fora de `.pi/extensions/`.
- Nunca auto-discovered.
- Carregamento somente por `pi -e <entrypoint>` em sessão especialista iniciada de propósito.
- A sessão especialista não herda autoridade de merge, envio, descarte ou segurança.

### Autoridade

- `ask-user-tui` apresenta e retorna respostas. Não decide por conta própria.
- Decisões duráveis continuam sob `decision-hold-lifecycle`, `tasks-axi` e o firstmate.
- Workers continuam reportando `needs-decision`; nunca abrem TUI para falar com o captain.
- `secure-credentials-tui` recebe apenas manifests locais allowlisted e nunca caminhos arbitrários do modelo.


ACCEPTED WAYFINDER PX03 CONSTRAINTS:
# PX03 - Contrato do coletor TUI seguro

**Type:** specification
**Status:** resolved
**Blocked by:** PX02

## Question

Definir o comportamento seguro mínimo do coletor de credenciais antes da implementação.

## Decision

### Entrada

- TUI obrigatório: `ctx.mode === "tui"`.
- Um manifest local, comum ao operador e ao código, define nomes de chaves e destinos permitidos.
- O modelo pode pedir uma chave allowlisted, mas não fornece caminho, comando, sink ou valor.
- Cada segredo é digitado em componente `ctx.ui.custom()` com `Editor` mascarado.
- A tela não mostra prefixo, sufixo ou tamanho exato do valor.

### Escrita

- Diretório privado validado, não symlinkado e com permissão restrita.
- Arquivo regular, single-link e allowlisted.
- Arquivo novo com modo `0600`.
- Atualização por arquivo temporário privado, validação, fsync quando disponível e rename atômico.
- Lock por destino durante toda a janela read-modify-write.
- Segredo existente é preservado por padrão. Substituição exige escolha TUI explícita.
- Nenhum valor entra em `process.env`, argv, shell, URL, log, stderr, tool result, renderer ou session entry.

### Lifecycle

- Cancelamento ou abort encerra a página e não aplica writes parciais.
- Resultado contém somente nome da chave, destino lógico e estado aplicado, pulado ou cancelado.
- A implementação não promete zeroização de strings JavaScript. Ela minimiza cópias e escopo de vida.
- RPC, print e JSON recusam com erro claro antes da coleta.

### Primeiro corte

- Somente destino local allowlisted.
- Sem Vercel, Convex, keychain, provider login, rotação automática ou leitura de valor existente.


ACCEPTED WAYFINDER PX05 TASK RECORD:
# PX05 - Implementar coletor TUI seguro de credenciais

**Type:** task
**Status:** in_progress
**Blocked by:** PX02, PX03
**Backlog:** `px05-secure-credentials-tui`

## Goal

Implementar a extensão opt-in `secure-credentials-tui` conforme PX03, sem copiar o código GSD cru.

## Required work

- Carregar `firstmate-coding-guidelines` antes de tocar material rastreado.
- Usar apenas APIs públicas do Pi instalado e `typebox`.
- Implementar manifest allowlisted, resolução segura de caminho e escrita atômica privada.
- Implementar componente TUI mascarado com foco IME, largura correta, cancelamento e invalidação.
- Garantir ausência do segredo em result, details, renderer, session JSONL, env, argv e logs.
- Fornecer launcher ou comando documentado que usa `pi -e` sem auto-discovery.

## Verification

- Testes unitários de path, symlink, hardlink, mode, lock, rename, duplicata e overwrite.
- Testes TUI de máscara, cancelamento, largura estreita e múltiplas páginas.
- Teste real de arquivo novo e atualização preservando bytes não relacionados.
- Teste de busca por canário secreto em todos os artefatos observáveis.
- Teste de recusa em RPC, print e JSON.
- no-mistakes obrigatório por tocar credenciais e segurança.

## Done

Código validado, documentação de uso explícito, nenhuma instalação automática e evidência visual aceita pelo captain em PX08.


ACCEPTED IMPLEMENTATION CLARIFICATIONS:
- Keep the extension in .pi/opt-in-extensions/secure-credentials and never add it to .pi/extensions.
- Load the extension only with explicit pi -e in a specialist TUI session.
- Use the operator environment variable WAYFINDER_SECURE_CREDENTIALS_MANIFEST to select a private version-1 JSON manifest with destination ids, allowlisted key names, and operator-owned paths.
- Use only secure_credentials_collect keys arguments; never accept paths, commands, sinks, or values from the model.
- Use fixed-width masked TUI pages with CURSOR_MARKER, no existing-value preview, explicit overwrite choice, serialized destination locks, private temporary files, atomic rename, and safe status-only results.
- Preserve every first-cut exclusion: no Vercel, Convex, keychain, remote channel, provider login, rotation, arbitrary .env discovery, auto-installation, main-home marker, or authority change.
- The committed PX05 branch is ready for the no-mistakes pipeline. The pipeline must preserve this intent, never use --yes, never merge, and stop at checks-passed with the full PR URL for PX08 visual acceptance.

## What Changed

- Adds a new opt-in `secure-credentials` extension under `.pi/opt-in-extensions/` (outside `.pi/extensions/`, so Pi never auto-discovers it), loaded only via explicit `pi -e` in a specialist TUI session; it registers `secure_credentials_collect` in TUI mode and refuses up front under RPC, print, and JSON.
- Drives collection from an operator-owned version-1 JSON manifest (selected by `WAYFINDER_SECURE_CREDENTIALS_MANIFEST`) whose key names and destination paths form the allowlist; tool arguments carry only allowlisted key names, never paths, commands, sinks, or values, and secrets are typed into a fixed-width masked `ctx.ui.custom` editor that exposes no prefix, suffix, length, or fragment.
- Validates destinations (private directory, regular single-link file, no symlinks/hardlinks, permissive-mode rejection) before writing new files at mode `0600` via a private temp file plus atomic rename, serializes each read-modify-write window with a per-destination lock, preserves existing values unless explicitly overwritten, keeps status-only results, and ships a 605-line focused test suite covering allowlist/traversal/symlink/lock/atomic-replacement cases plus canary-absence checks and a real Pi TUI end-to-end run.

## Risk Assessment

✅ Low: A unica mudanca desde a rodada anterior e a simplificacao aprovada (import estatico de mkdir), sem alteracao de comportamento e com todas as invariantes de seguranca preservadas.

## Testing

Rodei a suíte focada da extensão (10 testes, todos passam), que exercita a superfície pública real: allowlist, traversal, symlink, hardlink, modo, lock, rename atômico, duplicatas, cancelamento, reload e recusa em RPC/print/JSON, além de um teste que sobe o Pi 0.83.0 real por tmux e busca o canário em pane, session JSONL, env, argv e log. Para evidência visual do usuário final, capturei em um Pi real a página de entrada mascarada mostrando somente `••••••••` de largura fixa antes e durante a digitação de um segredo de 37 caracteres, e um relatório de fronteira confirmando canário ausente de pane/JSONL/log, arquivo com modo 600 e valor de fato gravado. A tela é textual (TUI em terminal), então a evidência reviewer-visível é o pane ANSI capturado, não um screenshot de navegador. Nenhuma falha; worktree limpo após remover o script transitório de captura.

<details>
<summary>Evidence: Real Pi TUI masked input page (empty field)</summary>

```text
REAL Pi 0.83.0 TUI (tmux 100x30) - secure_credentials_collect masked input page
The model requested key OPENAI_API_KEY. No path/value came from the model.
The value field shows only a fixed-width mask, never a prefix/suffix/length.

Warning: No models match pattern "ollama-cloud/deepseek-v4-flash"
Warning: No models match pattern "ollama-cloud/glm-5.2"
Model scope: claude-opus-5, gpt-5.6-sol, claude-opus-4-8-nm, claude-opus-4-8-nm2, gpt-5.6-luna, gpt-
5.6-terra (Ctrl+P to cycle)

 pi v0.83.0
 escape interrupt · ctrl+c/ctrl+d clear/exit · / commands · ! bash · ctrl+o more
 Press ctrl+o to show full startup help and loaded resources.

 Pi can explain its own features and look up its docs. Ask it how to use or extend Pi.

[Extensions]
  driver.ts, secure-credentials

[Themes]
  dank, piolium-srcery


 begin



 secure_credentials_collect OPENAI_API_KEY


 Warning: tmux extended-keys is off. Modified Enter keys may not work. Add `set -g extended-keys
 on` to ~/.tmux.conf and restart tmux.

 ⠙ Working...

────────────────────────────────────────────────────────────────────────────────────────────────────
Credential key: OPENAI_API_KEY
Destination: specialist-env

••••••••

Enter saves this value. Escape cancels.
────────────────────────────────────────────────────────────────────────────────────────────────────
/tmp/secure-credentials-evidence-6UI1ND
0.4%/4.1k (auto)                                                          (secure-e2e) deterministic
```
</details>
<details>
<summary>Evidence: Real Pi TUI masked field while typing a 37-char secret</summary>

```text
REAL Pi TUI after typing a 37-char secret into the field
The mask stays fixed-width; the pane never shows the typed characters or length.

Warning: No models match pattern "ollama-cloud/deepseek-v4-flash"
Warning: No models match pattern "ollama-cloud/glm-5.2"
Model scope: claude-opus-5, gpt-5.6-sol, claude-opus-4-8-nm, claude-opus-4-8-nm2, gpt-5.6-luna, gpt-
5.6-terra (Ctrl+P to cycle)

 pi v0.83.0
 escape interrupt · ctrl+c/ctrl+d clear/exit · / commands · ! bash · ctrl+o more
 Press ctrl+o to show full startup help and loaded resources.

 Pi can explain its own features and look up its docs. Ask it how to use or extend Pi.

[Extensions]
  driver.ts, secure-credentials

[Themes]
  dank, piolium-srcery


 begin



 secure_credentials_collect OPENAI_API_KEY


 Warning: tmux extended-keys is off. Modified Enter keys may not work. Add `set -g extended-keys
 on` to ~/.tmux.conf and restart tmux.

 ⠸ Working...

────────────────────────────────────────────────────────────────────────────────────────────────────
Credential key: OPENAI_API_KEY
Destination: specialist-env

••••••••

Enter saves this value. Escape cancels.
────────────────────────────────────────────────────────────────────────────────────────────────────
/tmp/secure-credentials-evidence-6UI1ND
0.4%/4.1k (auto)                                                          (secure-e2e) deterministic
```
</details>
<details>
<summary>Evidence: End-to-end secret boundary report (pane/JSONL/log clean, file mode 600)</summary>

<code>canary present in TUI pane : false (must be false)&#10;canary present in session JSONL : false (must be false)&#10;canary present in TUI write log : false (must be false)&#10;destination file mode : 600 (must be 600)&#10;canary actually written to dest file: true (must be true)&#10;Persisted destination file (secret redacted):&#10;OPENAI_API_KEY=&#34;&lt;SECRET-REDACTED-BY-EVIDENCE-CAPTURE&gt;&#34;</code>

```text
SECURE CREDENTIALS - END-TO-END SECRET BOUNDARY EVIDENCE (real Pi 0.83.0 TUI)
===========================================================================

Canary secret typed into the masked field: CANARY_SECRET_VALUE_SHOULD_NOT_ESCAPE

Final TUI pane after the collection completed:
----------------------------------------------
Warning: No models match pattern "ollama-cloud/deepseek-v4-flash"
Warning: No models match pattern "ollama-cloud/glm-5.2"
Model scope: claude-opus-5, gpt-5.6-sol, claude-opus-4-8-nm, claude-opus-4-8-nm2, gpt-5.6-luna, gpt-
5.6-terra (Ctrl+P to cycle)

 pi v0.83.0
 escape interrupt · ctrl+c/ctrl+d clear/exit · / commands · ! bash · ctrl+o more
 Press ctrl+o to show full startup help and loaded resources.

 Pi can explain its own features and look up its docs. Ask it how to use or extend Pi.

[Extensions]
  driver.ts, secure-credentials

[Themes]
  dank, piolium-srcery


 begin



 secure_credentials_collect OPENAI_API_KEY
 OPENAI_API_KEY specialist-env applied


 Warning: tmux extended-keys is off. Modified Enter keys may not work. Add `set -g extended-keys
 on` to ~/.tmux.conf and restart tmux.

 E2E_COMPLETE

────────────────────────────────────────────────────────────────────────────────────────────────────

────────────────────────────────────────────────────────────────────────────────────────────────────
/tmp/secure-credentials-evidence-6UI1ND
0.7%/4.1k (auto)                                                          (secure-e2e) deterministic





Secret boundary checks:
-----------------------
  canary present in TUI pane          : false  (must be false)
  canary present in session JSONL     : false  (must be false)
  canary present in TUI write log     : false  (must be false)
  destination file mode               : 600  (must be 600)
  canary actually written to dest file: true  (must be true)

Persisted destination file (secret redacted for this evidence artifact only):
----------------------------------------------------------------------------
OPENAI_API_KEY="<SECRET-REDACTED-BY-EVIDENCE-CAPTURE>"
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- ℹ️ `.pi/opt-in-extensions/secure-credentials/secure-credentials-file.ts:310` - Em secure-credentials-file.ts, mkdirPrivateLockDirectory usa import dinamico (await import(&#34;node:fs/promises&#34;)) so para obter mkdir, mas o modulo ja importa deste mesmo pacote no topo. Adicionar mkdir ao import estatico existente elimina o import assincrono por aquisicao de lock. Simplificacao, sem mudanca de comportamento.

🔧 Fix: use static mkdir import for lock directory creation
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`node .pi/opt-in-extensions/secure-credentials/secure-credentials.test.mjs` (10 focused tests, all pass): TUI-only registration and RPC/print/JSON refusal, key-name-only schema, allowlist + duplicate-request + manifest-duplicate + traversal + absolute-path handling, symlink/hardlink/permissive-mode/symlinked-parent/read-failure rejections, lock contention skip, new-file mode 0600, atomic replacement preserving unrelated bytes, existing-value preserve-by-default + explicit overwrite, cancellation/abort/multi-page with no partial write, reload cleanup, canary absence from result/details/renderer/session JSONL/env/argv/logs, real Pi TUI end-to-end via tmux, and plain-Pi non-discovery of the opt-in extension</code>
- <code>Manual evidence capture: real Pi 0.83.0 TUI driven over tmux (100x30), model requested only `keys:[&#39;OPENAI_API_KEY&#39;]`, typed the 37-char canary into the masked `ctx.ui.custom` editor, verified the pane shows only a fixed-width `••••••••` mask before and while typing, then confirmed the canary is absent from the TUI pane, session JSONL, and TUI write log while the destination file lands with mode 600 containing the value</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
