### PR TITLE
feat(pi): add primary-only structured questions TUI

### DIFF
--- a/.pi/extensions/fm-ask-user-tui.ts
+++ b/.pi/extensions/fm-ask-user-tui.ts
@@ -1,0 +1,1021 @@
+// Firstmate's primary-only structured questions tool.
+//
+// This extension owns only local presentation and answer collection.
+// Durable decisions, authority, backlog records, and worker escalation remain outside this file.
+// The tool is registered from session_start only after Pi proves TUI mode and the primary scope.
+// The private marker is intentionally read from the canonical project root and is never created here.
+// PX08 can use the focused test's deterministic payload in a disposable primary checkout.
+// That demo creates its marker only in temporary test state and never enables this repository.
+
+import { lstatSync, realpathSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import {
+  getMarkdownTheme,
+  type ExtensionAPI,
+  type ExtensionMode,
+  type Theme,
+  type ToolDefinition,
+} from "@earendil-works/pi-coding-agent";
+import {
+  Editor,
+  Key,
+  Markdown,
+  matchesKey,
+  type Component,
+  type EditorTheme,
+  type Focusable,
+  type TUI,
+  truncateToWidth,
+  visibleWidth,
+  wrapTextWithAnsi,
+} from "@earendil-works/pi-tui";
+import { Type, type Static } from "typebox";
+
+const ASK_USER_MARKER_NAME = "ask-user-tui";
+const SECOND_MATE_MARKER_NAME = ".fm-secondmate-home";
+const COLUMN_DIVIDER = " │ ";
+const FREE_TEXT_OPTION_ID = "__free_text__";
+
+const AskUserOptionSchema = Type.Object({
+  id: Type.String({
+    description: "Stable option identifier returned in selectedOptionIds.",
+  }),
+  label: Type.String({
+    description: "Short user-facing option label.",
+  }),
+  description: Type.Optional(
+    Type.String({
+      description: "Optional explanation of the consequence or tradeoff.",
+    }),
+  ),
+  preview: Type.Optional(
+    Type.String({
+      description: "Optional Markdown preview shown when this option is focused.",
+    }),
+  ),
+  recommended: Type.Optional(
+    Type.Boolean({
+      description: "Marks this option as recommended without selecting it.",
+    }),
+  ),
+});
+
+const AskUserQuestionSchema = Type.Object({
+  id: Type.String({
+    description: "Stable question identifier returned in questionId.",
+  }),
+  header: Type.Optional(
+    Type.String({
+      description: "Optional short heading shown on the question page.",
+    }),
+  ),
+  question: Type.String({
+    description: "Question text shown to the captain.",
+  }),
+  options: Type.Optional(
+    Type.Array(AskUserOptionSchema, {
+      description: "Optional choices. Omit this field for a free-text-only question.",
+    }),
+  ),
+  allowMultiple: Type.Optional(
+    Type.Boolean({
+      description: "Allow several option IDs to be selected with Space before Enter.",
+    }),
+  ),
+  allowFreeText: Type.Optional(
+    Type.Boolean({
+      description: "Add a free-text answer path. Defaults to true.",
+    }),
+  ),
+});
+
+const AskUserQuestionsParamsSchema = Type.Object({
+  questions: Type.Array(AskUserQuestionSchema, {
+    description: "Questions to show one page at a time in the primary TUI.",
+  }),
+});
+
+export type AskUserOption = Static<typeof AskUserOptionSchema>;
+export type AskUserQuestion = Static<typeof AskUserQuestionSchema>;
+export type AskUserQuestionsParams = Static<typeof AskUserQuestionsParamsSchema>;
+
+/** One structured answer containing stable IDs and optional captain-entered free text. */
+export interface AskUserQuestionAnswer {
+  questionId: string;
+  selectedOptionIds: string[];
+  freeText?: string;
+}
+
+/** The answer payload returned by ask_user_questions when the TUI is submitted. */
+export interface AskUserQuestionsResponse {
+  answers: AskUserQuestionAnswer[];
+}
+
+/** Tool details distinguish deliberate cancellation, external abort, and submission. */
+export interface AskUserQuestionsDetails {
+  response: AskUserQuestionsResponse | null;
+  cancelled: boolean;
+  aborted: boolean;
+  error?: string;
+}
+
+type NormalizedOption = {
+  id: string;
+  label: string;
+  description?: string;
+  preview?: string;
+  recommended: boolean;
+};
+
+type NormalizedQuestion = {
+  id: string;
+  header: string;
+  prompt: string;
+  options: NormalizedOption[];
+  allowMultiple: boolean;
+  allowFreeText: boolean;
+};
+
+type QuestionState = {
+  cursorIndex: number;
+  selectedOptionIds: Set<string>;
+  freeText: string;
+  freeTextError?: string;
+};
+
+type OptionItem = NormalizedOption & { kind: "option" };
+
+type FreeTextItem = {
+  kind: "free-text";
+  id: typeof FREE_TEXT_OPTION_ID;
+  label: string;
+  description: string;
+};
+
+type QuestionItem = OptionItem | FreeTextItem;
+
+type AskUserQuestionsUiOutcome =
+  | { kind: "submitted"; response: AskUserQuestionsResponse }
+  | { kind: "cancelled"; aborted: boolean };
+
+type NormalizationResult =
+  | { questions: NormalizedQuestion[] }
+  | { error: string };
+
+const extensionRoot = canonicalPath(resolve(dirname(fileURLToPath(import.meta.url)), "../.."));
+
+function canonicalPath(path: string): string {
+  try {
+    return realpathSync(path);
+  } catch {
+    return resolve(path);
+  }
+}
+
+function hasPathEntry(path: string): boolean {
+  try {
+    lstatSync(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function isRegularNonSymlinkFile(path: string): boolean {
+  try {
+    const stat = lstatSync(path);
+    return stat.isFile() && !stat.isSymbolicLink();
+  } catch {
+    return false;
+  }
+}
+
+function isDirectory(path: string): boolean {
+  try {
+    return lstatSync(path).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+function hasSecondmateHomeMarker(root: string): boolean {
+  return hasPathEntry(join(root, SECOND_MATE_MARKER_NAME));
+}
+
+function isPlainGitCheckout(root: string): boolean {
+  const gitDir = spawnSync("git", ["-C", root, "rev-parse", "--git-dir"], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "ignore"],
+  });
+  const commonDir = spawnSync("git", ["-C", root, "rev-parse", "--git-common-dir"], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "ignore"],
+  });
+  if (gitDir.status !== 0 || commonDir.status !== 0) return false;
+  return gitDir.stdout.trim() === commonDir.stdout.trim();
+}
+
+/**
+ * Checks the primary TUI activation contract without trusting FM_HOME or other environment values.
+ */
+export function isAskUserTuiEligible(cwd: string, mode: ExtensionMode = "tui"): boolean {
+  if (mode !== "tui") return false;
+
+  const canonicalCwd = canonicalPath(cwd);
+  if (canonicalCwd !== extensionRoot) return false;
+  if (hasSecondmateHomeMarker(canonicalCwd)) return false;
+  if (!isRegularNonSymlinkFile(join(canonicalCwd, "AGENTS.md"))) return false;
+  if (!isDirectory(join(canonicalCwd, "bin"))) return false;
+  if (!isRegularNonSymlinkFile(join(canonicalCwd, "bin", "fm-session-start.sh"))) return false;
+  if (!isPlainGitCheckout(canonicalCwd)) return false;
+  if (!isDirectory(join(canonicalCwd, "config"))) return false;
+
+  const markerPath = join(canonicalCwd, "config", ASK_USER_MARKER_NAME);
+  return isRegularNonSymlinkFile(markerPath);
+}
+
+function normalizeQuestions(params: AskUserQuestionsParams): NormalizationResult {
+  if (!params || !Array.isArray(params.questions) || params.questions.length === 0) {
+    return { error: "ask_user_questions requires at least one question" };
+  }
+
+  const questionIds = new Set<string>();
+  const questions: NormalizedQuestion[] = [];
+
+  for (const question of params.questions) {
+    if (!question || typeof question !== "object") {
+      return { error: "ask_user_questions received a malformed question" };
+    }
+    if (typeof question.id !== "string" || question.id.length === 0) {
+      return { error: "ask_user_questions requires a non-empty question id" };
+    }
+    if (questionIds.has(question.id)) {
+      return { error: `ask_user_questions received duplicate question id: ${question.id}` };
+    }
+    questionIds.add(question.id);
+
+    if (typeof question.question !== "string" || question.question.trim().length === 0) {
+      return { error: `ask_user_questions received empty question text: ${question.id}` };
+    }
+
+    const allowFreeText = question.allowFreeText !== false;
+    const rawOptions = question.options;
+    if (rawOptions !== undefined && !Array.isArray(rawOptions)) {
+      return { error: `ask_user_questions received malformed options: ${question.id}` };
+    }
+    if (rawOptions !== undefined && rawOptions.length === 0 && !allowFreeText) {
+      return { error: `ask_user_questions received empty options: ${question.id}` };
+    }
+    if (rawOptions === undefined && !allowFreeText) {
+      return { error: `ask_user_questions needs options or free text: ${question.id}` };
+    }
+
+    const optionIds = new Set<string>();
+    const options: NormalizedOption[] = [];
+    for (const option of rawOptions ?? []) {
+      if (!option || typeof option !== "object") {
+        return { error: `ask_user_questions received malformed option: ${question.id}` };
+      }
+      if (typeof option.id !== "string" || option.id.length === 0) {
+        return { error: `ask_user_questions requires a non-empty option id: ${question.id}` };
+      }
+      if (option.id === FREE_TEXT_OPTION_ID) {
+        return { error: `ask_user_questions reserves the free-text option id: ${option.id}` };
+      }
+      if (optionIds.has(option.id)) {
+        return { error: `ask_user_questions received duplicate option id: ${option.id}` };
+      }
+      optionIds.add(option.id);
+      if (typeof option.label !== "string" || option.label.trim().length === 0) {
+        return { error: `ask_user_questions received empty option label: ${option.id}` };
+      }
+      if (option.description !== undefined && typeof option.description !== "string") {
+        return { error: `ask_user_questions received malformed option description: ${option.id}` };
+      }
+      if (option.preview !== undefined && typeof option.preview !== "string") {
+        return { error: `ask_user_questions received malformed Markdown preview: ${option.id}` };
+      }
+      if (option.recommended !== undefined && typeof option.recommended !== "boolean") {
+        return { error: `ask_user_questions received malformed recommendation: ${option.id}` };
+      }
+      options.push({
+        id: option.id,
+        label: option.label,
+        description: option.description,
+        preview: option.preview,
+        recommended: option.recommended === true,
+      });
+    }
+
+    questions.push({
+      id: question.id,
+      header:
+        typeof question.header === "string" && question.header.trim().length > 0
+          ? question.header
+          : question.id,
+      prompt: question.question,
+      options,
+      allowMultiple: question.allowMultiple === true,
+      allowFreeText,
+    });
+  }
+
+  return { questions };
+}
+
+function cancelledResult(aborted: boolean, error?: string): {
+  content: [{ type: "text"; text: string }];
+  details: AskUserQuestionsDetails;
+} {
+  const text = error
+    ? error
+    : aborted
+      ? "ask_user_questions was interrupted before receiving a response"
+      : "ask_user_questions was cancelled before receiving a response";
+  return {
+    content: [{ type: "text", text }],
+    details: { response: null, cancelled: true, aborted, ...(error ? { error } : {}) },
+  };
+}
+
+function submittedResult(response: AskUserQuestionsResponse): {
+  content: [{ type: "text"; text: string }];
+  details: AskUserQuestionsDetails;
+} {
+  return {
+    content: [{ type: "text", text: JSON.stringify(response) }],
+    details: { response, cancelled: false, aborted: false },
+  };
+}
+
+function isRecommendedOption(option: NormalizedOption): boolean {
+  return option.recommended || /\(\s*recommended\s*\)\s*$/i.test(option.label);
+}
+
+function padLine(line: string, width: number): string {
+  return line + " ".repeat(Math.max(0, width - visibleWidth(line)));
+}
+
+function wrapToWidth(text: string, width: number): string[] {
+  const safeWidth = Math.max(1, width);
+  return wrapTextWithAnsi(text, safeWidth).map((line) => truncateToWidth(line, safeWidth, ""));
+}
+
+class AskUserQuestionsScreen implements Component, Focusable {
+  private readonly tui: TUI;
+  private readonly theme: Theme;
+  private readonly questions: NormalizedQuestion[];
+  private readonly states: QuestionState[];
+  private readonly done: (result: AskUserQuestionsUiOutcome) => void;
+  private readonly editor: Editor;
+  private readonly removeAbortListener: (() => void) | undefined;
+  private _focused = false;
+  private currentPage = 0;
+  private showingReview = false;
+  private freeTextMode = false;
+  private pageScroll = 0;
+  private lastViewport = 1;
+  private lastMaxScroll = 0;
+  private cachedWidth: number | undefined;
+  private cachedLines: string[] | undefined;
+  private finished = false;
+  private disposed = false;
+
+  constructor(
+    tui: TUI,
+    theme: Theme,
+    questions: NormalizedQuestion[],
+    signal: AbortSignal | undefined,
+    done: (result: AskUserQuestionsUiOutcome) => void,
+  ) {
+    this.tui = tui;
+    this.theme = theme;
+    this.questions = questions;
+    this.done = done;
+    this.states = questions.map(() => ({ cursorIndex: 0, selectedOptionIds: new Set(), freeText: "" }));
+
+    const editorTheme: EditorTheme = {
+      borderColor: (text: string) => theme.fg("accent", text),
+      selectList: {
+        selectedPrefix: (text: string) => theme.fg("accent", text),
+        selectedText: (text: string) => theme.fg("accent", text),
+        description: (text: string) => theme.fg("muted", text),
+        scrollInfo: (text: string) => theme.fg("dim", text),
+        noMatch: (text: string) => theme.fg("warning", text),
+      },
+    };
+    this.editor = new Editor(tui, editorTheme);
+    this.editor.onChange = (text) => {
+      const state = this.states[this.currentPage];
+      if (!state) return;
+      state.freeText = text;
+      state.freeTextError = undefined;
+      this.refresh();
+    };
+    this.editor.onSubmit = (text) => {
+      this.submitFreeText(text);
+    };
+
+    if (signal) {
+      const onAbort = () => {
+        this.finish({ kind: "cancelled", aborted: true });
+      };
+      if (signal.aborted) {
+        onAbort();
+      } else {
+        signal.addEventListener("abort", onAbort, { once: true });
+        this.removeAbortListener = () => signal.removeEventListener("abort", onAbort);
+      }
+    }
+
+    const currentQuestion = this.questions[0];
+    if (currentQuestion && currentQuestion.options.length === 0 && currentQuestion.allowFreeText) {
+      this.enterFreeText();
+    }
+  }
+
+  get focused(): boolean {
+    return this._focused;
+  }
+
+  set focused(value: boolean) {
+    this._focused = value;
+    this.syncEditorFocus();
+  }
+
+  handleInput(data: string): void {
+    if (this.finished || this.disposed) return;
+
+    if (this.freeTextMode) {
+      if (matchesKey(data, Key.escape) || matchesKey(data, Key.ctrl("c"))) {
+        this.finish({ kind: "cancelled", aborted: false });
+        return;
+      }
+      this.editor.handleInput(data);
+      this.refresh();
+      return;
+    }
+
+    if (this.showingReview) {
+      this.handleReviewInput(data);
+      return;
+    }
+
+    if (matchesKey(data, Key.escape) || matchesKey(data, Key.ctrl("c"))) {
+      this.finish({ kind: "cancelled", aborted: false });
+      return;
+    }
+    if (matchesKey(data, Key.left) || matchesKey(data, Key.shift("tab"))) {
+      this.movePage(-1);
+      return;
+    }
+    if (matchesKey(data, Key.right) || matchesKey(data, Key.tab)) {
+      this.movePage(1);
+      return;
+    }
+    if (matchesKey(data, Key.pageUp)) {
+      this.pageScroll = Math.max(0, this.pageScroll - this.lastViewport);
+      this.refresh();
+      return;
+    }
+    if (matchesKey(data, Key.pageDown)) {
+      this.pageScroll = Math.min(this.lastMaxScroll, this.pageScroll + this.lastViewport);
+      this.refresh();
+      return;
+    }
+    if (matchesKey(data, Key.home)) {
+      this.pageScroll = 0;
+      this.refresh();
+      return;
+    }
+    if (matchesKey(data, Key.end)) {
+      this.pageScroll = this.lastMaxScroll;
+      this.refresh();
+      return;
+    }
+
+    const question = this.currentQuestion();
+    if (!question) return;
+    const items = this.questionItems(question);
+    const state = this.states[this.currentPage]!;
+
+    if (matchesKey(data, Key.up)) {
+      state.cursorIndex = (state.cursorIndex - 1 + items.length) % items.length;
+      state.freeTextError = undefined;
+      this.pageScroll = 0;
+      this.refresh();
+      return;
+    }
+    if (matchesKey(data, Key.down)) {
+      state.cursorIndex = (state.cursorIndex + 1) % items.length;
+      state.freeTextError = undefined;
+      this.pageScroll = 0;
+      this.refresh();
+      return;
+    }
+    if (question.allowMultiple && matchesKey(data, Key.space)) {
+      const item = items[state.cursorIndex];
+      if (item && item.kind !== "free-text") {
+        if (state.selectedOptionIds.has(item.id)) state.selectedOptionIds.delete(item.id);
+        else state.selectedOptionIds.add(item.id);
+        state.freeTextError = undefined;
+        this.refresh();
+      }
+      return;
+    }
+    if (matchesKey(data, Key.enter)) {
+      this.commitCurrentItem();
+    }
+  }
+
+  render(width: number): string[] {
+    const renderWidth = Math.max(1, width);
+    if (this.cachedLines && this.cachedWidth === renderWidth) return this.cachedLines;
+
+    const header = this.renderHeader(renderWidth);
+    const footer = this.renderFooter(renderWidth);
+    const body = this.showingReview ? this.renderReviewBody(renderWidth) : this.renderQuestionBody(renderWidth);
+    const terminalRows = this.tui.terminal?.rows;
+    const stdoutRows = process.stdout.rows;
+    const rows =
+      typeof terminalRows === "number" && terminalRows > 0
+        ? terminalRows
+        : typeof stdoutRows === "number" && stdoutRows > 0
+          ? stdoutRows
+          : header.length + body.length + footer.length;
+    const viewport = Math.max(1, rows - header.length - footer.length);
+    this.lastViewport = viewport;
+    this.lastMaxScroll = Math.max(0, body.length - viewport);
+    this.pageScroll = Math.min(this.pageScroll, this.lastMaxScroll);
+
+    const visibleBody = body.slice(this.pageScroll, this.pageScroll + viewport);
+    if (this.lastMaxScroll > 0 && visibleBody.length > 0) {
+      if (this.pageScroll > 0) {
+        visibleBody[0] = truncateToWidth(
+          this.theme.fg("dim", `↑ ${this.pageScroll} more`),
+          renderWidth,
+          "",
+        );
+      }
+      const hiddenBelow = body.length - (this.pageScroll + visibleBody.length);
+      if (hiddenBelow > 0) {
+        visibleBody[visibleBody.length - 1] = truncateToWidth(
+          this.theme.fg("dim", `↓ ${hiddenBelow} more · PgUp/PgDn`),
+          renderWidth,
+          "",
+        );
+      }
+    }
+
+    const lines = [...header, ...visibleBody, ...footer].map((line) => truncateToWidth(line, renderWidth, ""));
+    this.cachedWidth = renderWidth;
+    this.cachedLines = lines;
+    return lines;
+  }
+
+  invalidate(): void {
+    this.cachedWidth = undefined;
+    this.cachedLines = undefined;
+    this.editor.invalidate();
+  }
+
+  dispose(): void {
+    if (this.disposed) return;
+    this.disposed = true;
+    this.removeAbortListener?.();
+    this.editor.onChange = undefined;
+    this.editor.onSubmit = undefined;
+  }
+
+  private currentQuestion(): NormalizedQuestion | undefined {
+    return this.questions[this.currentPage];
+  }
+
+  private questionItems(question: NormalizedQuestion): QuestionItem[] {
+    const items: QuestionItem[] = question.options.map((option) => ({ ...option, kind: "option" as const }));
+    if (question.allowFreeText) {
+      items.push({
+        kind: "free-text",
+        id: FREE_TEXT_OPTION_ID,
+        label: "Write a free-text answer",
+        description: "Type an answer in your own words.",
+      });
+    }
+    return items;
+  }
+
+  private currentState(): QuestionState {
+    return this.states[this.currentPage]!;
+  }
+
+  private currentItem(): QuestionItem | undefined {
+    const question = this.currentQuestion();
+    if (!question) return undefined;
+    return this.questionItems(question)[this.currentState().cursorIndex];
+  }
+
+  private isAnswered(state: QuestionState): boolean {
+    return state.selectedOptionIds.size > 0 || state.freeText.trim().length > 0;
+  }
+
+  private allAnswered(): boolean {
+    return this.states.every((state) => this.isAnswered(state));
+  }
+
+  private movePage(direction: -1 | 1): void {
+    if (this.questions.length === 0) return;
+    this.freeTextMode = false;
+    this.syncEditorFocus();
+    this.currentPage = (this.currentPage + direction + this.questions.length) % this.questions.length;
+    const question = this.currentQuestion();
+    const items = question ? this.questionItems(question) : [];
+    const state = this.currentState();
+    state.cursorIndex = Math.min(state.cursorIndex, Math.max(0, items.length - 1));
+    this.pageScroll = 0;
+    this.refresh();
+  }
+
+  private commitCurrentItem(): void {
+    const question = this.currentQuestion();
+    const state = this.currentState();
+    const item = this.currentItem();
+    if (!question || !item) return;
+
+    if (item.kind === "free-text") {
+      this.enterFreeText();
+      return;
+    }
+
+    if (question.allowMultiple) {
+      if (!this.isAnswered(state)) {
+        state.freeTextError = "Select at least one option or write a free-text answer.";
+        this.refresh();
+        return;
+      }
+      this.advanceAfterAnswer();
+      return;
+    }
+
+    state.selectedOptionIds = new Set([item.id]);
+    state.freeText = "";
+    state.freeTextError = undefined;
+    this.advanceAfterAnswer();
+  }
+
+  private enterFreeText(): void {
+    const state = this.currentState();
+    this.freeTextMode = true;
+    state.freeTextError = undefined;
+    this.editor.setText(state.freeText);
+    this.syncEditorFocus();
+    this.refresh();
+  }
+
+  private submitFreeText(text: string): void {
+    const state = this.currentState();
+    const trimmed = text.trim();
+    if (trimmed.length === 0) {
+      state.freeTextError = "Free-text answers cannot be empty.";
+      this.refresh();
+      return;
+    }
+    state.freeText = trimmed;
+    state.selectedOptionIds = this.currentQuestion()?.allowMultiple ? state.selectedOptionIds : new Set();
+    state.freeTextError = undefined;
+    this.freeTextMode = false;
+    this.syncEditorFocus();
+    this.advanceAfterAnswer();
+  }
+
+  private advanceAfterAnswer(): void {
+    this.pageScroll = 0;
+    if (this.currentPage < this.questions.length - 1) {
+      this.currentPage += 1;
+      this.freeTextMode = false;
+      const question = this.currentQuestion();
+      const items = question ? this.questionItems(question) : [];
+      this.currentState().cursorIndex = Math.min(this.currentState().cursorIndex, Math.max(0, items.length - 1));
+      this.syncEditorFocus();
+      this.refresh();
+      return;
+    }
+    if (this.allAnswered()) {
+      this.showingReview = true;
+      this.freeTextMode = false;
+      this.syncEditorFocus();
+      this.refresh();
+      return;
+    }
+    this.refresh();
+  }
+
+  private handleReviewInput(data: string): void {
+    if (matchesKey(data, Key.escape) || matchesKey(data, Key.ctrl("c"))) {
+      this.finish({ kind: "cancelled", aborted: false });
+      return;
+    }
+    if (matchesKey(data, Key.left)) {
+      this.showingReview = false;
+      this.currentPage = this.questions.length - 1;
+      this.pageScroll = 0;
+      this.refresh();
+      return;
+    }
+    if (matchesKey(data, Key.pageUp)) {
+      this.pageScroll = Math.max(0, this.pageScroll - this.lastViewport);
+      this.refresh();
+      return;
+    }
+    if (matchesKey(data, Key.pageDown)) {
+      this.pageScroll = Math.min(this.lastMaxScroll, this.pageScroll + this.lastViewport);
+      this.refresh();
+      return;
+    }
+    if ((matchesKey(data, Key.enter) || matchesKey(data, Key.right)) && this.allAnswered()) {
+      this.finish({ kind: "submitted", response: this.buildResponse() });
+    }
+  }
+
+  private buildResponse(): AskUserQuestionsResponse {
+    const answers: AskUserQuestionAnswer[] = [];
+    for (let index = 0; index < this.questions.length; index += 1) {
+      const question = this.questions[index]!;
+      const state = this.states[index]!;
+      const selectedOptionIds = question.options
+        .filter((option) => state.selectedOptionIds.has(option.id))
+        .map((option) => option.id);
+      const freeText = state.freeText.trim();
+      answers.push({
+        questionId: question.id,
+        selectedOptionIds,
+        ...(freeText.length > 0 ? { freeText } : {}),
+      });
+    }
+    return { answers };
+  }
+
+  private finish(outcome: AskUserQuestionsUiOutcome): void {
+    if (this.finished || this.disposed) return;
+    this.finished = true;
+    this.removeAbortListener?.();
+    this.done(outcome);
+  }
+
+  private syncEditorFocus(): void {
+    this.editor.focused = this._focused && this.freeTextMode;
+  }
+
+  private refresh(): void {
+    this.cachedWidth = undefined;
+    this.cachedLines = undefined;
+    this.tui.requestRender();
+  }
+
+  private renderHeader(width: number): string[] {
+    const question = this.currentQuestion();
+    const title = this.showingReview
+      ? "Review answers"
+      : `${question?.header ?? "Question"}  ${this.currentPage + 1}/${this.questions.length}`;
+    const pageStates = this.questions.map((item, index) => {
+      const state = this.states[index]!;
+      const marker = this.isAnswered(state) ? "●" : "○";
+      const color = this.isAnswered(state) ? "success" : "muted";
+      return index === this.currentPage && !this.showingReview
+        ? this.theme.fg("accent", `[${marker} ${item.header}]`)
+        : this.theme.fg(color, `${marker} ${item.header}`);
+    });
+    const rows = [
+      this.theme.fg("borderAccent", "─".repeat(width)),
+      truncateToWidth(`${this.theme.fg("accent", this.theme.bold(title))}  ${pageStates.join("  ")}`, width, ""),
+      "",
+    ];
+    return rows;
+  }
+
+  private renderFooter(width: number): string[] {
+    const hint = this.showingReview
+      ? "Enter submit · Left edit · Esc cancel · PgUp/PgDn scroll"
+      : this.freeTextMode
+        ? "Enter confirm text · Esc cancel · PgUp/PgDn scroll"
+        : this.currentQuestion()?.allowMultiple
+          ? "↑↓ focus · Space toggle · Enter next · Tab page · Esc cancel"
+          : "↑↓ focus · Enter choose · Tab page · Esc cancel";
+    return ["", ...wrapToWidth(this.theme.fg("dim", hint), width), this.theme.fg("borderAccent", "─".repeat(width))];
+  }
+
+  private renderQuestionBody(width: number): string[] {
+    const question = this.currentQuestion();
+    if (!question) return [this.theme.fg("error", "No question is available.")];
+    const state = this.currentState();
+    const items = this.questionItems(question);
+    const currentItem = items[state.cursorIndex];
+    const preview = currentItem && currentItem.kind !== "free-text" ? currentItem.preview?.trim() : undefined;
+    const dividerWidth = visibleWidth(COLUMN_DIVIDER);
+    const leftWidth = Math.max(1, Math.floor((width - dividerWidth) / 2));
+    const rightWidth = Math.max(1, width - dividerWidth - leftWidth);
+
+    const left = this.renderQuestionColumn(question, state, items, leftWidth);
+    if (!preview || leftWidth <= 1 || rightWidth <= 1) {
+      const stacked = [...this.renderQuestionColumn(question, state, items, width)];
+      if (preview) {
+        stacked.push("");
+        stacked.push(this.theme.fg("accent", "Preview"));
+        stacked.push(...this.renderMarkdown(preview, width));
+      }
+      return stacked;
+    }
+
+    const right = [this.theme.fg("accent", "Preview"), ...this.renderMarkdown(preview, rightWidth)];
+    const lineCount = Math.max(left.length, right.length);
+    const merged: string[] = [];
+    for (let index = 0; index < lineCount; index += 1) {
+      const leftLine = padLine(truncateToWidth(left[index] ?? "", leftWidth, ""), leftWidth);
+      const rightLine = truncateToWidth(right[index] ?? "", rightWidth, "");
+      merged.push(leftLine + this.theme.fg("dim", COLUMN_DIVIDER) + rightLine);
+    }
+    return merged;
+  }
+
+  private renderQuestionColumn(
+    question: NormalizedQuestion,
+    state: QuestionState,
+    items: QuestionItem[],
+    width: number,
+  ): string[] {
+    const lines: string[] = [];
+    lines.push(...wrapToWidth(this.theme.fg("text", question.prompt), width));
+    if (question.allowMultiple) lines.push(...wrapToWidth(this.theme.fg("muted", "Select all that apply."), width));
+    lines.push("");
+
+    for (let index = 0; index < items.length; index += 1) {
+      const item = items[index]!;
+      const focused = index === state.cursorIndex && !this.freeTextMode;
+      if (item.kind === "free-text") {
+        const entered = state.freeText.trim().length > 0;
+        const prefix = entered ? "✎ " : "✎ ";
+        const label = `${prefix}${item.label}`;
+        const styled = focused
+          ? this.theme.fg("accent", `> ${label}`)
+          : this.theme.fg(entered ? "success" : "text", `  ${label}`);
+        lines.push(...wrapToWidth(styled, width));
+        lines.push(...wrapToWidth(this.theme.fg("muted", `    ${item.description}`), width));
+        continue;
+      }
+
+      const checked = state.selectedOptionIds.has(item.id);
+      const marker = question.allowMultiple ? (checked ? "☑" : "☐") : (checked ? "●" : "○");
+      const recommendation = isRecommendedOption(item) ? this.theme.fg("success", " (recommended)") : "";
+      const label = `${marker} ${item.label}${recommendation}`;
+      const styled = focused
+        ? this.theme.fg("accent", `> ${label}`)
+        : this.theme.fg(checked ? "success" : "text", `  ${label}`);
+      lines.push(...wrapToWidth(styled, width));
+      if (item.description) lines.push(...wrapToWidth(this.theme.fg("muted", `    ${item.description}`), width));
+    }
+
+    if (this.freeTextMode) {
+      lines.push("");
+      lines.push(this.theme.fg("muted", "Your free-text answer:"));
+      lines.push(...this.editor.render(Math.max(1, width - 2)).map((line) => truncateToWidth(` ${line}`, width, "")));
+      if (state.freeTextError) lines.push(...wrapToWidth(this.theme.fg("warning", state.freeTextError), width));
+    } else if (state.freeText.trim().length > 0) {
+      lines.push("");
+      lines.push(...wrapToWidth(this.theme.fg("muted", `Free text: ${state.freeText.trim()}`), width));
+    } else if (state.freeTextError) {
+      lines.push("");
+      lines.push(...wrapToWidth(this.theme.fg("warning", state.freeTextError), width));
+    }
+
+    return lines;
+  }
+
+  private renderReviewBody(width: number): string[] {
+    const lines: string[] = [this.theme.fg("text", "Review the structured answers before submission."), ""];
+    for (let index = 0; index < this.questions.length; index += 1) {
+      const question = this.questions[index]!;
+      const state = this.states[index]!;
+      const selected = question.options
+        .filter((option) => state.selectedOptionIds.has(option.id))
+        .map((option) => `${option.id}: ${option.label}`);
+      if (selected.length === 0) selected.push("(none)");
+      lines.push(...wrapToWidth(this.theme.fg("accent", question.id), width));
+      lines.push(...wrapToWidth(this.theme.fg("muted", question.prompt), width));
+      for (const value of selected) lines.push(...wrapToWidth(`  ${value}`, width));
+      if (state.freeText.trim().length > 0) {
+        lines.push(...wrapToWidth(`  freeText: ${state.freeText.trim()}`, width));
+      }
+      lines.push("");
+    }
+    if (this.allAnswered()) lines.push(this.theme.fg("success", "All questions have answers."));
+    else lines.push(this.theme.fg("warning", "Some questions still need an answer."));
+    return lines;
+  }
+
+  private renderMarkdown(markdown: string, width: number): string[] {
+    const component = new Markdown(markdown, 0, 0, getMarkdownTheme());
+    return component.render(Math.max(1, width)).map((line) => truncateToWidth(line, Math.max(1, width), ""));
+  }
+}
+
+function createAskUserQuestionsTool(): ToolDefinition<typeof AskUserQuestionsParamsSchema, AskUserQuestionsDetails> {
+  return {
+    name: "ask_user_questions",
+    label: "Ask user questions",
+    description:
+      "Present structured questions to the captain in the primary TUI and return stable option IDs plus optional free text. This tool collects answers only and never approves or records a durable decision.",
+    promptSnippet: "Ask the captain structured local TUI questions before proceeding, without deciding or recording authority.",
+    promptGuidelines: [
+      "Use ask_user_questions only in the eligible primary TUI when a concrete choice needs captain input.",
+      "Use stable question and option IDs so the structured answer can be mapped without relying on labels.",
+      "Mark recommended options with recommended: true and explain the consequence or tradeoff in description. ask_user_questions never preselects recommendations.",
+      "Use allowMultiple: true when several option IDs can be selected. Use allowFreeText for a question that needs an answer in the captain's own words.",
+      "Use preview for concise Markdown that helps compare the focused option. The preview is local UI content and is not an approval or decision record.",
+      "Do not use ask_user_questions for merge, discard, security, credentials, messaging, or irreversible approval. Durable decisions remain with Firstmate authority and decision-hold-lifecycle.",
+    ],
+    parameters: AskUserQuestionsParamsSchema,
+    executionMode: "sequential",
+    async execute(_toolCallId, params, signal, _onUpdate, ctx) {
+      if (!isAskUserTuiEligible(ctx.cwd, ctx.mode)) {
+        return cancelledResult(false, "ask_user_questions is available only in the marked main-primary TUI");
+      }
+      if (signal?.aborted) return cancelledResult(true);
+
+      const normalized = normalizeQuestions(params);
+      if ("error" in normalized) return cancelledResult(false, normalized.error);
+
+      let screen: AskUserQuestionsScreen | undefined;
+      const outcome = await ctx.ui.custom<AskUserQuestionsUiOutcome>((tui, theme, _keybindings, done) => {
+        screen = new AskUserQuestionsScreen(tui, theme, normalized.questions, signal, done);
+        return screen;
+      });
+      screen?.dispose();
+
+      if (!outcome || outcome.kind === "cancelled") {
+        return cancelledResult(outcome?.kind === "cancelled" ? outcome.aborted : signal?.aborted === true);
+      }
+      return submittedResult(outcome.response);
+    },
+    renderCall(args, theme) {
+      const questionCount = Array.isArray(args.questions) ? args.questions.length : 0;
+      const headers = Array.isArray(args.questions)
+        ? args.questions
+            .map((question) => (typeof question.header === "string" && question.header ? question.header : question.id))
+            .join(", ")
+        : "";
+      let text = theme.fg("toolTitle", theme.bold("ask_user_questions "));
+      text += theme.fg("muted", `${questionCount} question${questionCount === 1 ? "" : "s"}`);
+      if (headers) text += theme.fg("dim", ` (${headers})`);
+      return new (class implements Component {
+        render(width: number): string[] {
+          return wrapToWidth(text, width);
+        }
+        invalidate(): void {}
+      })();
+    },
+    renderResult(result, _options, theme) {
+      const details = result.details;
+      if (details.cancelled) {
+        return new (class implements Component {
+          render(): string[] {
+            return [theme.fg("warning", details.aborted ? "Interrupted" : "Cancelled")];
+          }
+          invalidate(): void {}
+        })();
+      }
+
+      const response = details.response;
+      if (!response) {
+        return new (class implements Component {
+          render(): string[] {
+            return [theme.fg("error", "ask_user_questions returned no response")];
+          }
+          invalidate(): void {}
+        })();
+      }
+
+      const lines = response.answers.map((answer) => {
+        const selected = answer.selectedOptionIds.length > 0 ? answer.selectedOptionIds.join(", ") : "(free text)";
+        const freeText = answer.freeText ? ` ${theme.fg("muted", `freeText: ${answer.freeText}`)}` : "";
+        return `${theme.fg("success", "✓ ")}${theme.fg("accent", answer.questionId)}: ${selected}${freeText}`;
+      });
+      return new (class implements Component {
+        render(width: number): string[] {
+          return lines.flatMap((line) => wrapToWidth(line, width));
+        }
+        invalidate(): void {}
+      })();
+    },
+  };
+}
+
+export default function fmAskUserTui(pi: ExtensionAPI): void {
+  let registered = false;
+
+  pi.on("session_start", async (_event, ctx) => {
+    if (registered || !isAskUserTuiEligible(ctx.cwd, ctx.mode)) return;
+    pi.registerTool(createAskUserQuestionsTool());
+    registered = true;
+  });
+}

--- a/.pi/extensions/fm-ask-user-tui.ts
+++ b/.pi/extensions/fm-ask-user-tui.ts
@@ -378,6 +378,8 @@ class AskUserQuestionsScreen implements Component, Focusable {
   private pageScroll = 0;
   private lastViewport = 1;
   private lastMaxScroll = 0;
+  private scrollToCursor = false;
+  private focusedLineRange: { start: number; end: number } | undefined;
   private cachedWidth: number | undefined;
   private cachedLines: string[] | undefined;
   private finished = false;
@@ -504,14 +506,14 @@ class AskUserQuestionsScreen implements Component, Focusable {
     if (matchesKey(data, Key.up)) {
       state.cursorIndex = (state.cursorIndex - 1 + items.length) % items.length;
       state.freeTextError = undefined;
-      this.pageScroll = 0;
+      this.scrollToCursor = true;
       this.refresh();
       return;
     }
     if (matchesKey(data, Key.down)) {
       state.cursorIndex = (state.cursorIndex + 1) % items.length;
       state.freeTextError = undefined;
-      this.pageScroll = 0;
+      this.scrollToCursor = true;
       this.refresh();
       return;
     }
@@ -536,6 +538,7 @@ class AskUserQuestionsScreen implements Component, Focusable {
 
     const header = this.renderHeader(renderWidth);
     const footer = this.renderFooter(renderWidth);
+    this.focusedLineRange = undefined;
     const body = this.showingReview ? this.renderReviewBody(renderWidth) : this.renderQuestionBody(renderWidth);
     const terminalRows = this.tui.terminal?.rows;
     const stdoutRows = process.stdout.rows;
@@ -548,7 +551,13 @@ class AskUserQuestionsScreen implements Component, Focusable {
     const viewport = Math.max(1, rows - header.length - footer.length);
     this.lastViewport = viewport;
     this.lastMaxScroll = Math.max(0, body.length - viewport);
-    this.pageScroll = Math.min(this.pageScroll, this.lastMaxScroll);
+    if (this.scrollToCursor && this.focusedLineRange) {
+      const { start, end } = this.focusedLineRange;
+      if (start < this.pageScroll) this.pageScroll = start;
+      else if (end > this.pageScroll + viewport) this.pageScroll = end - viewport;
+    }
+    this.scrollToCursor = false;
+    this.pageScroll = Math.max(0, Math.min(this.pageScroll, this.lastMaxScroll));
 
     const visibleBody = body.slice(this.pageScroll, this.pageScroll + viewport);
     if (this.lastMaxScroll > 0 && visibleBody.length > 0) {
@@ -852,6 +861,7 @@ class AskUserQuestionsScreen implements Component, Focusable {
     for (let index = 0; index < items.length; index += 1) {
       const item = items[index]!;
       const focused = index === state.cursorIndex && !this.freeTextMode;
+      const itemStart = lines.length;
       if (item.kind === "free-text") {
         const entered = state.freeText.trim().length > 0;
         const prefix = entered ? "✎ " : "✎ ";
@@ -861,6 +871,7 @@ class AskUserQuestionsScreen implements Component, Focusable {
           : this.theme.fg(entered ? "success" : "text", `  ${label}`);
         lines.push(...wrapToWidth(styled, width));
         lines.push(...wrapToWidth(this.theme.fg("muted", `    ${item.description}`), width));
+        if (focused) this.focusedLineRange = { start: itemStart, end: lines.length };
         continue;
       }
 
@@ -873,6 +884,7 @@ class AskUserQuestionsScreen implements Component, Focusable {
         : this.theme.fg(checked ? "success" : "text", `  ${label}`);
       lines.push(...wrapToWidth(styled, width));
       if (item.description) lines.push(...wrapToWidth(this.theme.fg("muted", `    ${item.description}`), width));
+      if (focused) this.focusedLineRange = { start: itemStart, end: lines.length };
     }
 
     if (this.freeTextMode) {

--- a/.pi/extensions/fm-ask-user-tui.ts
+++ b/.pi/extensions/fm-ask-user-tui.ts
@@ -553,8 +553,12 @@ class AskUserQuestionsScreen implements Component, Focusable {
     this.lastMaxScroll = Math.max(0, body.length - viewport);
     if (this.scrollToCursor && this.focusedLineRange) {
       const { start, end } = this.focusedLineRange;
-      if (start < this.pageScroll) this.pageScroll = start;
-      else if (end > this.pageScroll + viewport) this.pageScroll = end - viewport;
+      const indicatorReserve = this.lastMaxScroll > 0 ? 1 : 0;
+      if (start - indicatorReserve < this.pageScroll) {
+        this.pageScroll = start - indicatorReserve;
+      } else if (end + indicatorReserve > this.pageScroll + viewport) {
+        this.pageScroll = end + indicatorReserve - viewport;
+      }
     }
     this.scrollToCursor = false;
     this.pageScroll = Math.max(0, Math.min(this.pageScroll, this.lastMaxScroll));

--- a/tests/fm-ask-user-tui.test.sh
+++ b/tests/fm-ask-user-tui.test.sh
@@ -1,0 +1,438 @@
+#!/usr/bin/env bash
+# Focused activation and public TUI behavior checks for ask_user_questions.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+TMP_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/fm-ask-user-tui.XXXXXX")
+trap 'rm -rf "$TMP_ROOT"' EXIT
+EXT="$ROOT/.pi/extensions/fm-ask-user-tui.ts"
+PI_PACKAGE_DIR=${FM_PI_PACKAGE_DIR:-"$(npm root -g 2>/dev/null)/@earendil-works/pi-coding-agent"}
+
+if ! command -v node >/dev/null 2>&1; then
+  echo "skip: node not found for ask_user_questions tests"
+  exit 0
+fi
+if [ ! -f "$PI_PACKAGE_DIR/package.json" ]; then
+  echo "skip: installed @earendil-works/pi-coding-agent package not found"
+  exit 0
+fi
+
+prepare_fixture() {
+  local name=$1 fixture=$TMP_ROOT/$1
+  git clone -q "$ROOT" "$fixture"
+  mkdir -p "$fixture/.pi/extensions" "$fixture/config" "$fixture/node_modules/@earendil-works"
+  cp "$EXT" "$fixture/.pi/extensions/fm-ask-user-tui.ts"
+  printf '%s\n' '{"type":"module"}' > "$fixture/package.json"
+  ln -s "$PI_PACKAGE_DIR" "$fixture/node_modules/@earendil-works/pi-coding-agent"
+  ln -s "$PI_PACKAGE_DIR/node_modules/@earendil-works/pi-tui" "$fixture/node_modules/@earendil-works/pi-tui"
+  ln -s "$PI_PACKAGE_DIR/node_modules/typebox" "$fixture/node_modules/typebox"
+  printf '%s\n' "$fixture"
+}
+
+run_node() {
+  local fixture=$1 script=$2
+  shift 2
+  (cd "$fixture" && env "$@" node --experimental-strip-types "$script")
+}
+
+typecheck_extension() {
+  if ! command -v tsc >/dev/null 2>&1; then
+    echo "skip: tsc not found for ask_user_questions typecheck"
+    return 0
+  fi
+
+  if [ ! -d "$PI_PACKAGE_DIR/node_modules/typebox" ] || \
+    [ ! -d "$PI_PACKAGE_DIR/node_modules/@earendil-works/pi-tui" ] || \
+    [ ! -d "$PI_PACKAGE_DIR/node_modules/@types/node" ]; then
+    echo "skip: installed Pi package is missing pi-tui, typebox, or Node declarations"
+    return 0
+  fi
+
+  local type_root="$TMP_ROOT/typecheck"
+  mkdir -p "$type_root/node_modules/@earendil-works" "$type_root/node_modules/@types"
+  cp "$EXT" "$type_root/fm-ask-user-tui.ts"
+  ln -s "$PI_PACKAGE_DIR" "$type_root/node_modules/@earendil-works/pi-coding-agent"
+  ln -s "$PI_PACKAGE_DIR/node_modules/@earendil-works/pi-tui" "$type_root/node_modules/@earendil-works/pi-tui"
+  ln -s "$PI_PACKAGE_DIR/node_modules/typebox" "$type_root/node_modules/typebox"
+  ln -s "$PI_PACKAGE_DIR/node_modules/@types/node" "$type_root/node_modules/@types/node"
+  printf '%s\n' '{"type":"module"}' > "$type_root/package.json"
+  cat > "$type_root/tsconfig.json" <<'JSON'
+{
+  "compilerOptions": {
+    "allowImportingTsExtensions": true,
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "noEmit": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "target": "ES2022",
+    "types": ["node"]
+  },
+  "include": ["fm-ask-user-tui.ts"]
+}
+JSON
+  (cd "$type_root" && tsc -p tsconfig.json) || fail "ask_user_questions failed strict Pi typecheck"
+  pass "ask_user_questions passes strict no-emit typecheck against installed Pi"
+}
+
+typecheck_extension
+
+cat > "$TMP_ROOT/activation-probe.mjs" <<'JS'
+import { pathToFileURL } from "node:url";
+
+const extension = await import(`${pathToFileURL(process.env.ASK_USER_EXTENSION).href}?case=${process.env.ASK_USER_CASE}`);
+const handlers = new Map();
+const tools = [];
+const pi = {
+  on(name, handler) {
+    handlers.set(name, handler);
+  },
+  registerTool(tool) {
+    tools.push(tool);
+  },
+};
+extension.default(pi);
+if (tools.length !== 0) throw new Error("the extension registered a tool before session_start");
+const sessionStart = handlers.get("session_start");
+if (!sessionStart) throw new Error("the extension did not register its lifecycle handler");
+await sessionStart({ reason: "startup" }, { cwd: process.cwd(), mode: process.env.ASK_USER_MODE });
+const expected = Number(process.env.ASK_USER_EXPECTED_TOOLS);
+if (tools.length !== expected) {
+  throw new Error(`expected ${expected} registered tools, received ${tools.length}`);
+}
+if (expected === 1) {
+  if (tools[0].name !== "ask_user_questions") throw new Error("unexpected tool name");
+  if (!tools[0].promptSnippet || !tools[0].promptGuidelines?.length) {
+    throw new Error("searchable tool metadata is incomplete");
+  }
+}
+process.stdout.write(`activation ${process.env.ASK_USER_CASE}: ${tools.length}\n`);
+JS
+
+run_activation_case() {
+  local name=$1 mode=$2 expected=$3 fixture output
+  fixture=$(prepare_fixture "$name")
+  if [ "$name" = marker-valid ]; then
+    : > "$fixture/config/ask-user-tui"
+  elif [ "$name" = marker-symlink ]; then
+    : > "$fixture/config/marker-target"
+    ln -s marker-target "$fixture/config/ask-user-tui"
+  elif [ "$name" = secondmate-home ]; then
+    : > "$fixture/config/ask-user-tui"
+    printf '%s\n' secondmate > "$fixture/.fm-secondmate-home"
+  elif [ "$name" = ambient-fm-home-only ]; then
+    mkdir -p "$TMP_ROOT/ambient-home/config"
+    : > "$TMP_ROOT/ambient-home/config/ask-user-tui"
+  fi
+
+  output=$(run_node "$fixture" "$TMP_ROOT/activation-probe.mjs" \
+    ASK_USER_EXTENSION="$fixture/.pi/extensions/fm-ask-user-tui.ts" \
+    ASK_USER_CASE="$name" \
+    ASK_USER_MODE="$mode" \
+    ASK_USER_EXPECTED_TOOLS="$expected" \
+    FM_HOME="$TMP_ROOT/ambient-home") || fail "activation case $name failed: $output"
+  assert_contains "$output" "activation $name: $expected" "activation case $name returned the wrong registration result"
+}
+
+run_activation_case marker-valid tui 1
+run_activation_case marker-absent tui 0
+run_activation_case marker-symlink tui 0
+run_activation_case secondmate-home tui 0
+run_activation_case rpc-mode rpc 0
+run_activation_case print-mode print 0
+run_activation_case json-mode json 0
+run_activation_case ambient-fm-home-only tui 0
+
+worker_root=$(prepare_fixture worker-root)
+: > "$worker_root/config/ask-user-tui"
+worker_worktree="$TMP_ROOT/worker-worktree"
+git -C "$worker_root" worktree add -q -b ask-user-worker "$worker_worktree"
+mkdir -p "$worker_worktree/.pi/extensions" "$worker_worktree/config" "$worker_worktree/node_modules/@earendil-works"
+cp "$EXT" "$worker_worktree/.pi/extensions/fm-ask-user-tui.ts"
+printf '%s\n' '{"type":"module"}' > "$worker_worktree/package.json"
+ln -s "$PI_PACKAGE_DIR" "$worker_worktree/node_modules/@earendil-works/pi-coding-agent"
+ln -s "$PI_PACKAGE_DIR/node_modules/@earendil-works/pi-tui" "$worker_worktree/node_modules/@earendil-works/pi-tui"
+ln -s "$PI_PACKAGE_DIR/node_modules/typebox" "$worker_worktree/node_modules/typebox"
+: > "$worker_worktree/config/ask-user-tui"
+worker_output=$(run_node "$worker_worktree" "$TMP_ROOT/activation-probe.mjs" \
+  ASK_USER_EXTENSION="$worker_worktree/.pi/extensions/fm-ask-user-tui.ts" \
+  ASK_USER_CASE=worker-worktree \
+  ASK_USER_MODE=tui \
+  ASK_USER_EXPECTED_TOOLS=0) || fail "worker worktree activation test failed: $worker_output"
+assert_contains "$worker_output" "activation worker-worktree: 0" "worker worktree registered the primary-only tool"
+
+git -C "$worker_root" worktree remove -f "$worker_worktree"
+pass "activation requires a regular marker in the plain primary checkout and rejects absence, symlink, secondmate, worker, RPC, print, JSON, and FM_HOME-only cases"
+
+cat > "$TMP_ROOT/behavior-probe.mjs" <<'JS'
+import { initTheme } from "@earendil-works/pi-coding-agent";
+import { CURSOR_MARKER, visibleWidth } from "@earendil-works/pi-tui";
+import extension from "./.pi/extensions/fm-ask-user-tui.ts";
+
+initTheme("dark");
+const handlers = new Map();
+const tools = [];
+const calls = [];
+const pi = {
+  on(name, handler) {
+    const current = handlers.get(name) ?? [];
+    current.push(handler);
+    handlers.set(name, current);
+  },
+  registerTool(tool) {
+    tools.push(tool);
+  },
+  appendEntry() {
+    throw new Error("ask_user_questions must not append session state");
+  },
+  registerCommand() {
+    throw new Error("ask_user_questions must not register a command");
+  },
+  registerShortcut() {
+    throw new Error("ask_user_questions must not register a shortcut");
+  },
+};
+extension(pi);
+if (tools.length !== 0) throw new Error("tool registered before the session start event");
+await handlers.get("session_start")[0]({ reason: "startup" }, { cwd: process.cwd(), mode: "tui" });
+if (tools.length !== 1) throw new Error("eligible TUI did not register one tool");
+const tool = tools[0];
+if (tool.name !== "ask_user_questions") throw new Error("wrong registered tool");
+for (const reason of ["reload", "new", "resume", "fork"]) {
+  await handlers.get("session_start")[0]({ reason }, { cwd: process.cwd(), mode: "tui" });
+}
+if (tools.length !== 1 || handlers.get("session_start").length !== 1) {
+  throw new Error("session lifecycle duplicated the tool or handler");
+}
+if (handlers.has("session_shutdown")) throw new Error("shutdown registered an unnecessary handler");
+
+const reloadHandlers = new Map();
+const reloadTools = [];
+const reloadPi = {
+  on(name, handler) {
+    reloadHandlers.set(name, handler);
+  },
+  registerTool(tool) {
+    reloadTools.push(tool);
+  },
+};
+extension(reloadPi);
+await reloadHandlers.get("session_start")({ reason: "reload" }, { cwd: process.cwd(), mode: "tui" });
+await reloadHandlers.get("session_start")({ reason: "new" }, { cwd: process.cwd(), mode: "tui" });
+if (reloadTools.length !== 1 || reloadHandlers.get("session_start") === undefined) {
+  throw new Error("reload created duplicate tools or lost the lifecycle handler");
+}
+
+let palette = "";
+const theme = {
+  fg(_color, text) {
+    return `${palette}${text}`;
+  },
+  bg(_color, text) {
+    return `${palette}${text}`;
+  },
+  bold(text) {
+    return `${palette}${text}`;
+  },
+};
+const tui = {
+  terminal: { rows: 28 },
+  requestRender() {
+    calls.push("render");
+  },
+};
+
+function assertWidth(lines, width, label) {
+  for (const line of lines) {
+    if (visibleWidth(line) > width) throw new Error(`${label} exceeded width ${width}: ${line}`);
+  }
+}
+
+async function runQuestions(params, keys, options = {}) {
+  let component;
+  let initialLines = [];
+  const ui = {
+    custom(factory) {
+      return new Promise((resolve) => {
+        component = factory(tui, theme, {}, resolve);
+        component.focused = true;
+        initialLines = component.render(options.initialWidth ?? 100);
+        assertWidth(initialLines, options.initialWidth ?? 100, "initial render");
+        if (options.onComponent) options.onComponent(component, initialLines);
+        if (options.abort) {
+          setTimeout(() => options.abort.abort(), 0);
+        }
+        for (const key of keys) component.handleInput?.(key);
+      });
+    },
+  };
+  const result = await tool.execute("probe", params, options.abort?.signal, undefined, {
+    cwd: process.cwd(),
+    mode: "tui",
+    ui,
+  });
+  return { result, initialLines, component };
+}
+
+const structured = await runQuestions(
+  {
+    questions: [
+      {
+        id: "choice-question",
+        header: "Choice",
+        question: "Choose one path.",
+        options: [
+          { id: "option-alpha", label: "Alpha", description: "Low migration cost.", recommended: true, preview: "# Alpha\n\nUse **Alpha**." },
+          { id: "option-beta", label: "Beta", description: "Higher migration cost." },
+        ],
+      },
+      {
+        id: "multi-question",
+        header: "Many",
+        question: "Choose several paths.",
+        allowMultiple: true,
+        allowFreeText: false,
+        options: [
+          { id: "option-x", label: "X" },
+          { id: "option-y", label: "Y" },
+        ],
+      },
+    ],
+  },
+  ["\r", " ", "\u001b[B", " ", "\r", "\r"],
+  {
+    initialWidth: 100,
+    onComponent(component, initialLines) {
+      const initial = initialLines.join("\n");
+      if (!initial.includes("Preview") || !initial.includes("Alpha")) throw new Error("Markdown preview or option missing");
+      if (!initial.includes("recommended") || !initial.includes("○")) throw new Error("recommendation was not visible without preselection");
+      palette = "THEME_CHANGED:";
+      component.invalidate();
+      const invalidated = component.render(100).join("\n");
+      if (!invalidated.includes("THEME_CHANGED:")) throw new Error("theme invalidation did not rebuild rendered content");
+      assertWidth(component.render(12), 12, "narrow render");
+    },
+  },
+);
+const structuredJson = JSON.stringify(structured.result);
+if (!structuredJson.includes("option-alpha") || !structuredJson.includes("option-x") || !structuredJson.includes("option-y")) {
+  throw new Error(`structured result lost stable IDs: ${structuredJson}`);
+}
+if (structured.result.details.cancelled) throw new Error("structured answer was marked cancelled");
+
+const freeText = await runQuestions(
+  { questions: [{ id: "free-question", question: "Write an answer.", options: [], allowFreeText: true }] },
+  ["h", "i", "\r", "\r"],
+  {
+    initialWidth: 80,
+    onComponent(_component, initialLines) {
+      if (!initialLines.some((line) => line.includes(CURSOR_MARKER))) throw new Error("focused free-text editor did not expose IME cursor marker");
+    },
+  },
+);
+if (freeText.result.details.response?.answers[0]?.freeText !== "hi") throw new Error("free text was not returned");
+if (!JSON.stringify(freeText.result).includes("free-question")) throw new Error("free-text result lost question id");
+
+const emptyFreeText = await runQuestions(
+  { questions: [{ id: "empty-question", question: "Write an answer.", options: [], allowFreeText: true }] },
+  ["\r", "\u001b"],
+);
+if (!emptyFreeText.result.details.cancelled || emptyFreeText.result.details.aborted) throw new Error("empty free text did not cancel explicitly");
+if (!emptyFreeText.result.content[0].text.includes("cancelled")) throw new Error("empty free text cancellation was not explicit");
+
+const cancelled = await runQuestions(
+  { questions: [{ id: "cancel-question", question: "Choose.", options: [{ id: "cancel-option", label: "Option" }] }] },
+  ["\u001b"],
+);
+if (!cancelled.result.details.cancelled || cancelled.result.details.response !== null) throw new Error("Escape invented or retained an answer");
+
+const abort = new AbortController();
+const interrupted = await runQuestions(
+  { questions: [{ id: "abort-question", question: "Choose.", options: [{ id: "abort-option", label: "Option" }] }] },
+  [],
+  { abort },
+);
+if (!interrupted.result.details.cancelled || !interrupted.result.details.aborted) throw new Error("Abort did not return explicit interruption");
+
+let customCalled = false;
+const malformed = await tool.execute(
+  "malformed",
+  { questions: [{ id: "bad", question: "Bad options", allowFreeText: false, options: [{ id: "dup", label: "One" }, { id: "dup", label: "Two" }] }] },
+  undefined,
+  undefined,
+  {
+    cwd: process.cwd(),
+    mode: "tui",
+    ui: { custom() { customCalled = true; throw new Error("malformed input opened the TUI"); } },
+  },
+);
+if (!malformed.details?.cancelled || !malformed.details.error) throw new Error("malformed options were not rejected");
+if (customCalled) throw new Error("malformed options opened the TUI");
+
+const emptyQuestions = await tool.execute(
+  "empty",
+  { questions: [] },
+  undefined,
+  undefined,
+  {
+    cwd: process.cwd(),
+    mode: "tui",
+    ui: { custom() { throw new Error("empty input opened the TUI"); } },
+  },
+);
+if (!emptyQuestions.details.cancelled || !emptyQuestions.details.error) throw new Error("empty question input was not rejected");
+
+const malformedPreview = await tool.execute(
+  "bad-preview",
+  { questions: [{ id: "bad-preview", question: "Bad preview", allowFreeText: false, options: [{ id: "bad", label: "Bad", preview: 42 }] }] },
+  undefined,
+  undefined,
+  {
+    cwd: process.cwd(),
+    mode: "tui",
+    ui: { custom() { throw new Error("malformed preview opened the TUI"); } },
+  },
+);
+if (!malformedPreview.details.cancelled || !malformedPreview.details.error) throw new Error("malformed preview was not rejected");
+
+const nonTui = await tool.execute(
+  "non-tui",
+  { questions: [{ id: "non-tui", question: "No UI", options: [{ id: "option", label: "Option" }] }] },
+  undefined,
+  undefined,
+  {
+    cwd: process.cwd(),
+    mode: "rpc",
+    ui: { custom() { throw new Error("non-TUI mode opened the TUI"); } },
+  },
+);
+if (!nonTui.details.cancelled || !nonTui.details.error) throw new Error("non-TUI execution was not rejected");
+
+const renderCall = tool.renderCall(
+  { questions: [{ id: "q", question: "Q", options: [{ id: "o", label: "O" }] }] },
+  theme,
+  {},
+);
+assertWidth(renderCall.render(8), 8, "renderCall");
+const renderResult = tool.renderResult(
+  structured.result,
+  { expanded: false, isPartial: false },
+  theme,
+  {},
+);
+assertWidth(renderResult.render(32), 32, "renderResult");
+
+if (calls.length === 0) throw new Error("TUI state changes never requested a render");
+process.stdout.write("behavior: structured, multi-select, free text, preview, cancellation, abort, IME, width, theme, reload, and malformed input passed\n");
+JS
+
+behavior_fixture=$(prepare_fixture behavior)
+: > "$behavior_fixture/config/ask-user-tui"
+cp "$TMP_ROOT/behavior-probe.mjs" "$behavior_fixture/behavior-probe.mjs"
+behavior_output=$(run_node "$behavior_fixture" "$behavior_fixture/behavior-probe.mjs" \
+  ASK_USER_EXTENSION="$behavior_fixture/.pi/extensions/fm-ask-user-tui.ts") || fail "behavior probe failed: $behavior_output"
+assert_contains "$behavior_output" "behavior: structured" "behavior probe did not complete"
+pass "public TUI behavior returns stable IDs and explicit cancellation without authority or session side effects"
+pass "deterministic disposable-primary demo path covers narrow and wide rendering for PX08"


### PR DESCRIPTION
## Intent

⁣FIRSTMATE_OP: v1 launch-brief: You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.

# Task
Implement Wayfinder ticket PX06, the primary-only structured questions TUI, without installing or copying the GSD Pi extension raw.

Authoritative plan:
- `data/wayfinder/pi-workflow-extensions/MAP.md`
- `data/wayfinder/pi-workflow-extensions/tickets/PX02.md`
- `data/wayfinder/pi-workflow-extensions/tickets/PX04.md`
- `data/wayfinder/pi-workflow-extensions/tickets/PX06.md`
- Evidence: `data/gsd-pi-pi-extensions-scout/report.md`

Before editing:
- Read and follow `/home/shiv/tec-workspace/.agents/skills/firstmate-coding-guidelines/SKILL.md`.
- Read and apply `/home/shiv/.pi/agent/skills/write-discoverable-code/SKILL.md` and `/home/shiv/.pi/agent/skills/codebase-design/SKILL.md`.
- Read the installed Pi `docs/extensions.md`, `docs/tui.md`, `docs/packages.md`, `docs/session-format.md`, `docs/keybindings.md`, and `docs/rpc.md` completely.
- Follow relevant Markdown cross-references and inspect `question.ts`, `questionnaire.ts`, `tools.ts`, and other matching installed examples.
- Run `no-mistakes doctor` after creating the branch and stop if the repository is not ready.

Scope ownership:
- Own only `.pi/extensions/fm-ask-user-tui.ts` or its same-named directory, its focused tests, and documentation colocated with that extension.
- Do not edit the secure credential extension, shared Firstmate instructions, README, or unrelated integration docs.
- PX07 owns cross-extension integration and shared documentation.

Required activation:
- Pi may auto-discover the source, but the extension must register no tool outside the eligible main-primary TUI.
- Require a main-private, ordinary, non-symlink marker at `config/ask-user-tui`.
- The marker is not inherited and must not be created by this task.
- Do not trust ambient `FM_HOME` alone.
- Reject or register nothing for marker absence, symlink, secondmate home, worker worktree, RPC, print, and JSON modes.
- Preserve current Firstmate supervision and every protected tool.

Required TUI behavior:
- Register a searchable tool named `ask_user_questions` with accurate prompt metadata.
- Show one question per page through `ctx.ui.custom()`.
- Support single select, multi-select, Markdown preview, and a free-text answer path.
- Keep recommended choices visually clear, but never preselect or auto-submit one.
- Preserve stable question and option IDs in the structured result.
- Escape and abort return explicit cancellation and never invent an answer.
- Respect terminal width, focus and IME cursor placement, theme invalidation, keyboard navigation, and reload lifecycle.
- Use no copied numeric caps for question count, preview length, timeout, or pages.
- If a defensive tripwire becomes necessary, measure the real TUI path and report the receipt before adding it.

Authority boundaries:
- The tool presents choices and returns answers only.
- It does not approve merge, discard, security, credentials, messaging, or irreversible action.
- A TUI answer does not close a durable decision by itself.
- `decision-hold-lifecycle`, `tasks-axi`, firstmate authority, and worker `needs-decision` remain the owners.
- No Slack, Discord, Telegram, X, browser, polling, remote questions, backlog, or hidden decision cache.
- Workers and secondmates never use this tool to address the captain.

Verification:
- Exercise public behavior, not source-byte assertions.
- Cover valid and invalid activation marker, symlink marker, worker worktree, secondmate home, and every non-TUI mode.
- Cover single selection, multiple selection, free text, Markdown preview, cancellation, abort, stable IDs, empty input, and malformed options.
- Cover narrow and wide terminals, keyboard-only navigation, IME focus, invalidate, theme change, reload, new, resume, fork, and shutdown.
- Prove no handler, widget, shortcut, or state duplicates after reload.
- Prove answers alone do not mutate backlog, decision records, state logs, or authority.
- Produce a deterministic TUI demo path for PX08, but do not enable the private marker.
- Run focused tests, `bin/fm-doc-audience-check.sh` for maintained prose, and `bin/fm-lint.sh` when applicable.
- Before reporting implementation complete, load `/home/shiv/.agents/skills/but-for-real/SKILL.md` and challenge every acceptance claim.

# Herdr lifecycle declaration - NOT ENABLED
**HARD SAFETY GATE:** this scaffold cannot inspect the task text that replaces `{TASK}` later.
If the task will start, stop, delete, restart, profile, or otherwise drive Herdr lifecycle behavior, stop and regenerate the brief with `--herdr-lab` before dispatch.
Do not add Herdr lifecycle commands to this unguarded brief by hand.

# Setup
You are in a disposable git worktree of tec-workspace, at a detached HEAD on a clean default branch.

**Verify isolation before anything else.** Run `pwd -P` and `git rev-parse --show-toplevel`; both must resolve to the disposable task worktree you were launched in, such as a treehouse pool path or an Orca-managed worktree, not the primary checkout firstmate operates from.
The path check is authoritative: `git rev-parse --git-dir` and `git rev-parse --git-common-dir` can help inspect the repo, but they do not prove you are outside the primary checkout.
If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not branch or commit here - append `blocked: launched in primary checkout, not an isolated worktree` to the status file and stop.

1. First action: create your branch: `git checkout -b fm/px06-ask-user-tui`

# Rules
1. Never push to the default branch. Never merge a PR. Work only on your `fm/px06-ask-user-tui` branch.
2. Stay inside this worktree; modify nothing outside it.
3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
4. Report status by appending one line:
`echo "{state}: {one short line}" >> '/home/shiv/tec-workspace/state/px06-ask-user-tui.status'`
States: working, needs-decision, blocked, paused, done, failed.
Each append wakes firstmate, so report sparingly: only phase changes a
supervisor would act on (setup done, bug reproduced, fix implemented,
validation passed) and the needs-decision/blocked/paused/done/failed states.
No step-by-step FYI progress lines; firstmate reads your pane for that.
A mid-task `working:` line (including setup complete) is nonterminal: do not end the turn after it; continue the same stage until a defined `done:` gate under Definition of done.
Use `paused: {why}` - distinct from `blocked:` - ONLY when you are deliberately idling on a known external wait you expect to clear on its own (an upstream release, a rate-limit reset, a scheduled window): firstmate then leaves your idle pane alone and rechecks it on a long cadence instead of treating it as a possible wedge.
Use `blocked:` when you are stuck and need help.
5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
6. If a decision belongs above the implementation worker (product choices, destructive actions, ask-user findings), append `needs-decision: {summary of options}` and stop. Firstmate will apply the configured authority and reply with the decision.
When firstmate replies or a blocker clears and you resume, append `resolved: {how it was decided or unblocked}` (add the same `[key=<slug>]` if you opened it with one) so the decision or blocker is durably closed and does not keep resurfacing.
7. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes daemon error, append `blocked: {the daemon error}` and stop; only firstmate manages the daemon.

# Project memory
If `AGENTS.md` or `CLAUDE.md` already exists, or if this task produced durable project-intrinsic knowledge, run `/home/shiv/tec-workspace/bin/fm-ensure-agents-md.sh .` in the worktree.
Record only project knowledge useful to almost every future session.
For anything the codebase already shows, prefer a pointer to the authoritative file, command, or doc over copying it.
If you touch a project `AGENTS.md` that lacks `## Maintaining this file`, add that short self-governance section from `/home/shiv/tec-workspace/bin/fm-ensure-agents-md.sh` in the same pass.
Keep it proportionate: skip `AGENTS.md` edits for trivial tasks that produced no durable project knowledge.

# Definition of done
The task is complete only when committed on your branch.
When you believe it is complete, append `done: {summary}` to the status file and stop.
Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.

You drive no-mistakes by responding to its gates, not by implementing fixes.
Follow the guidance no-mistakes provides, `no-mistakes axi run --help`, and every returned `help` line.
The run intent must preserve this Task section and every later accepted clarification.
Do not hand-edit, commit, abort, restart, or answer findings yourself while a run is active.
Ask-user findings return to firstmate under rule 6.
Avoid `--yes`, because it would bypass firstmate's authority check.

After /no-mistakes reports CI green, append `done: PR {url} checks green` and stop.
Do not merge.
PX08 owns the captain's required visual acceptance before landing or activation.

# Accepted Wayfinder constraints from MAP.md
**Destination:** Integrate two independent TUI extensions into the Pi workflow: structured questions in the primary session and secure credential collection in an explicitly specialist session, without installing raw upstream code, without creating another authority, and without exposing secrets in conversation or the session.

- Language: pt-BR.
- GSD Pi evidence is `data/gsd-pi-pi-extensions-scout/report.md`.
- Oh My Pi evidence is `data/oh-my-pi-pi-extensions-scout/report.md`.
- Local baseline is Pi `0.83.0` with the current installation's `extensions.md`, `tui.md`, `packages.md`, and `session-format.md`.
- This map plans two separate extensions. A monolithic package is not required.
- The common path is only the compatibility, loading, and authority contract. Each branch can be implemented and validated independently.
- The map does not authorize implementation by itself. Task tickets start only after explicit dispatch.

Graph:
- Trunk: PX01 -> PX02.
- Credential branch: PX02 -> PX03 -> PX05.
- Questions branch: PX02 -> PX04 -> PX06.
- Integration crossing: PX05 + PX06 -> PX07 -> PX08.

Accepted decisions:
- PX01 fixed and compared the sources against the installed Pi public API.
- PX02 keeps the extensions separate. No raw upstream package is installed.
- `ask-user-tui` registers the tool only when the primary session runs in the main home and finds the private marker `config/ask-user-tui`; the marker is not inherited.
- `secure-credentials-tui` loads only through `-e` in an explicitly specialist session.
- Normal workers and secondmates do not receive either extension by default.
- Structured questions do not replace `decision-hold-lifecycle`, backlog, captain authority, or worker contracts.
- The credential collector receives only local allowlisted manifests, never arbitrary model paths, does not hydrate `process.env`, and has no Vercel or Convex sinks in the first cut.
- No numeric limit for questions, characters, timeout, or pages is copied without local measurement.

Not yet specified:
- No functional choice blocks either branch.
- UI limits and tripwires will be measured in PX07 before becoming configuration.
- Implementation order is selected at dispatch and does not change the graph.

Out of scope:
- Direct installation of `get-secrets-from-user.ts` or `ask-user-questions.ts`.
- Remote questions through Slack, Discord, Telegram, X, or another channel.
- Credential collection in RPC, print, JSON, or chat.
- Vercel, Convex, automatic rotation, automatic file discovery, or arbitrary `.env` writes.
- Another dispatcher, watcher, worktree manager, permission system, or backlog.
- Changes to merge authority, security, discard, or approval through a TUI answer.
- Swarm, subagent, bg-shell, GSD engine, and any parallel runtime.

# Accepted PX02 constraints
**Question TUI entry and loading:** `.pi/extensions/fm-ask-user-tui.ts` or an equivalent directory is the planned entry. Auto-discovery is only in the Firstmate project. The factory exposes the surface only in TUI when the canonical cwd contains a private, regular, non-symlink marker at `config/ask-user-tui`, and no `.fm-secondmate-home` exists. The marker belongs only to the primary home, is not inherited, and is created only after PX08. Do not rely only on `FM_HOME`, because normal workers can start without that variable. In a worker worktree, secondmate, session without the marker, or session without TUI, the extension registers no tool.

**Credential TUI loading:** The credential entry is outside `.pi/extensions`, is never auto-discovered, and loads only through `pi -e <entrypoint>` in a deliberately specialist session. The specialist session does not inherit merge, send, discard, or security authority.

**Authority:** `ask-user-tui` presents and returns answers and does not decide independently. Durable decisions remain owned by `decision-hold-lifecycle`, `tasks-axi`, and Firstmate. Workers continue to report `needs-decision` and never open a TUI to address the captain. The credential extension accepts only allowlisted local manifests and never arbitrary model paths.

# Accepted PX04 constraints
**UX:** The TUI is mandatory through `ctx.ui.custom()`. Show one question per page. Support single choice, multiple choice, Markdown preview, and free-text response. A recommended option must explain consequence and tradeoff without being automatically selected. Escape cancels. Cancellation returns an explicit state and never invents an answer. Preserve stable question and option IDs in the result.

**Data:** Tool arguments contain question, options, descriptions, and previews. Tool result contains only selected IDs and typed free text. The result participates in normal session context because it is not secret. UI state is ephemeral. No parallel backlog or remote cache.

**Authority:** The tool does not approve merge, discard, security, send, or irreversible actions. A TUI response does not close a durable decision by itself. Firstmate records a decision through the current owner when context requires it. The extension does not load in workers or secondmates.

**Limits:** No numeric cap is fixed in the specification. PX07 measures viewport, pagination, and volume before creating tripwires. No Slack, Discord, Telegram, X, browser, or polling.

# Accepted PX06 constraints
**Goal:** Implement `ask-user-tui` according to PX04, using the installed Pi public API and without transporting GSD remote questions.

**Required work:** Load `firstmate-coding-guidelines` before touching tracked material. Register the tool and renderers only in the eligible primary session. Implement single-choice, multiple-choice, preview, and free-text pages. Preserve stable IDs and explicit cancellation. Integrate only by composition with current decision policy. Do not create backlog, hold, polling, remote channel, or automatic approval inside the extension.

**Verification:** Test the private marker activation rule, including valid marker, absent marker, symlink, worker worktree, secondmate, and non-TUI modes. Test single, multiple, free text, preview, cancellation, and structured return. Test TUI width, pagination, IME focus, invalidate, and render. Prove responses do not alter backlog or authority. The no-mistakes pipeline is required because this touches authority and a primary extension.

**Done:** The tool is available only in the correct scope, the UX is validated, and visual evidence is accepted by the captain in PX08.

# Accepted scout constraints used for PX06
- The GSD `ask-user-questions` UI is reference material only. Its remote question manager, Slack, Discord, Telegram, polling, dedup cache, notification bell, and GSD authority are not transported.
- The installed Pi public imports are `@earendil-works/pi-coding-agent`, `@earendil-works/pi-tui`, and `typebox`; upstream GSD aliases and private imports are not assumed.
- `ctx.ui.custom()` is TUI-only because it returns undefined in RPC. Do not use RPC fallback for this primary-only tool.
- The installed `ctx.ui.select()` contract has no multi-select option, so multi-select belongs in the custom TUI component.
- Pi extensions run with process permissions and have no in-process sandbox. Session and project scope are security boundaries.
- Do not add a second inference runtime, provider, dispatcher, worker, watcher, process manager, browser stack, web channel, or backlog.

## What Changed

- Add `.pi/extensions/fm-ask-user-tui.ts`, which registers a searchable `ask_user_questions` tool only in an eligible main-primary TUI session gated on a regular, non-symlink `config/ask-user-tui` marker (rejecting marker absence, symlink markers, secondmate homes, worker worktrees, and RPC/print/JSON modes).
- Drive one question per page through `ctx.ui.custom()` with single-select, multi-select, Markdown preview, and free-text paths, keeping recommended choices visible without preselecting, preserving stable question and option IDs, and returning explicit cancellation on Escape/abort; keyboard navigation now scrolls to keep the focused option visible and reserves rows for the `↑/↓ more` scroll indicators.
- Add `tests/fm-ask-user-tui.test.sh` covering activation rules and public behavior (selection modes, free text, preview, cancellation, stable IDs, empty/malformed input, terminal width, theme invalidation, and reload/new/resume/fork lifecycle with no handler duplication).

## Risk Assessment

✅ Low: The incremental change is a small, self-contained scroll-reserve adjustment that correctly keeps the focused option visible beside the indicator rows for realistic cases, behind a not-yet-enabled activation marker.

## Testing

O teste focado `tests/fm-ask-user-tui.test.sh` passou por inteiro (typecheck estrito pulou por falta de `tsc` no PATH, comportamento esperado do próprio teste), cobrindo a regra do marcador privado, todos os modos não-TUI, e o comportamento público do TUI sem efeitos de autoridade ou sessão. Para prova de nível de produto eu montei um fixture de checkout primário com o marcador `config/ask-user-tui`, dirigi o componente real `ctx.ui.custom()` de ponta a ponta e capturei 9 frames: pergunta única com opção recomendada visível sem preseleção e preview Markdown, navegação por teclado, terminal estreito respeitando a largura, multi-seleção com Space, página de texto livre com o marcador de cursor IME presente, revisão e o resultado estruturado com IDs estáveis (`opt-postgres`, `reg-us`, `reg-eu`, `freeText`), além do cancelamento por Escape retornando `response:null, cancelled:true` sem inventar resposta. Os frames foram renderizados em HTML e capturados em PNG para revisão visual. Nenhum problema encontrado.

- Evidence: Captura de tela dos 9 frames do TUI ask_user_questions (fluxo completo + resultado JSON) (local file: <code>/tmp/no-mistakes-evidence/01KZ18YKD6710736GKS9BFR1J4/px06-tui-demo.png</code>)
- Evidence: Demo TUI renderizado em HTML (frames ANSI com cores) (local file: <code>/tmp/no-mistakes-evidence/01KZ18YKD6710736GKS9BFR1J4/px06-tui-demo.html</code>)
<details>
<summary>Evidence: Resultado estruturado retornado ao modelo (IDs estáveis) e cancelamento explícito</summary>

```text
submit -> {"answers":[{"questionId":"storage-backend","selectedOptionIds":["opt-postgres"]},{"questionId":"regions","selectedOptionIds":["reg-us","reg-eu"]},{"questionId":"rollout-notes","selectedOptionIds":[],"freeText":"canary us-east-1 first"}]}
escape -> {"response":null,"cancelled":true,"aborted":false}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed (2) ✅</summary>

- ⚠️ `.pi/extensions/fm-ask-user-tui.ts:511` - Keyboard navigation can hide the focused option. In handleInput, Up/Down (lines 504-517) move cursorIndex through the full item list and reset pageScroll to 0, while render() slices the body at [pageScroll, pageScroll+viewport] and never scrolls to keep cursorIndex visible. With more options than fit the viewport (no numeric cap exists), pressing Down moves focus below the visible window with the view pinned at the top, so a keyboard-only captain cannot see which option is highlighted. Fix: after moving the cursor, adjust pageScroll so the focused item&#39;s line range stays within the viewport instead of forcing pageScroll = 0.

🔧 Fix: keep focused option visible during keyboard navigation
1 warning still open:
- ⚠️ `.pi/extensions/fm-ask-user-tui.ts:557` - The scroll-to-cursor fix aligns the focused item flush to the viewport edge (line 556 sets pageScroll = start; line 557 sets pageScroll = end - viewport), but render() then overwrites the first visible line with the &#39;↑ N more&#39; indicator (lines 564-569) and the last visible line with the &#39;↓ N more&#39; indicator (lines 571-578) whenever content is hidden above/below. So when keyboard navigation scrolls a focused option to the exact top or bottom of the viewport with more content beyond it, that option&#39;s edge line is replaced by the scroll indicator - for a single-line option this hides it entirely, the same &#39;focused option not visible&#39; symptom the round-1 fix targeted. This is reachable during normal Up/Down navigation through an option list longer than the viewport (no numeric cap exists). Fix: reserve the indicator rows when computing the scroll target, e.g. shrink the effective viewport by the indicator line(s) so the focused item&#39;s start/end stays inside the non-indicator region.

🔧 Fix: reserve scroll indicator rows when keeping focused option visible
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash tests/fm-ask-user-tui.test.sh` — ativação (marcador válido/ausente/symlink, secondmate, worker worktree, RPC/print/JSON, FM_HOME-só) e comportamento público (seleção única/múltipla, texto livre, preview Markdown, cancelamento, abort, IDs estáveis, entrada vazia/malformada, largura, tema, reload/new/resume/fork, sem duplicação de handler)</code>
- <code>Demo end-to-end `node demo.mjs` num fixture clonado com marcador presente e modo TUI: dirigiu o componente real de `ctx.ui.custom()` por seleção única (recomendado marcado, sem preseleção), multi-seleção, texto livre com marcador de cursor IME, revisão e submissão, mais cancelamento por Escape</code>
- `Renderização dos frames capturados para HTML e captura de tela PNG via chrome-devtools-axi`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
