### PR TITLE
fix: resolve project-local skills deterministically

### DIFF
--- a/.agents/skills/project-skill-discovery/SKILL.md
+++ b/.agents/skills/project-skill-discovery/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: project-skill-discovery
+description: >-
+  Discover a captain-named skill local to a resolved project before global or plugin fallback.
+  Load when the active catalog does not unequivocally identify a named project skill, or before declaring it absent.
+user-invocable: false
+metadata:
+  internal: true
+---
+
+# Project skill discovery
+
+Use this procedure when the captain names a skill for project work and its project-local identity is not already certain.
+
+1. Resolve the project first under `AGENTS.md` section 7.
+   Continue only when one canonical project root is selected.
+2. Run `bin/fm-project-skill-resolve.sh <project-root> <captain-supplied-skill-name>` and process its documented exit code.
+   The resolver's header and `--help` own search roots, normalization, matching, precedence, output, and path safety.
+3. On success, use the returned project-local skill for this project even when the active global or plugin catalog has a homonym.
+   Read the complete `SKILL.md` and every reference its instructions require before acting.
+4. On ambiguity or an unsafe path, stop and relay the resolver's diagnostic.
+   Resolution is complete only after one local file is unique and safe.
+5. On absence, consult the active global and plugin catalog next.
+   Declare the named skill absent only after both the local resolver and that catalog have no match.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -504,6 +504,7 @@ These skills are not captain-invocable; load them only at their precise triggers
 - `fmx-respond` - load on an `x-mention <request_id>` `check:` wake to handle the mention, on an `x-mode-error ...` `check:` wake to report the X-mode configuration blocker, on a `public-followup ...` `check:` wake or a startup-surfaced public commitment, and on any milestone or terminal wake for an X-mode-linked task before posting its completion follow-up; relevant only when X mode is on.
 - `firstmate-codexapp` - load before coordinating a visible Codex Desktop thread, evaluating a Codex App backend request, or reconciling Codex Desktop host-tool smoke evidence for Firstmate work.
 - `firstmate-coding-guidelines` - load before changing firstmate's shared, tracked material, as defined by section 1's list, whether editing directly or briefing a crewmate for a firstmate-repo task.
+- `project-skill-discovery` - load when the captain names a project skill that the active catalog does not resolve unequivocally, and before declaring any named project skill absent.
 
 ## 14. X mode
 

--- a/bin/fm-project-skill-resolve.sh
+++ b/bin/fm-project-skill-resolve.sh
@@ -1,0 +1,192 @@
+#!/usr/bin/env bash
+# Resolve one named skill inside one already-resolved project.
+#
+# Usage:
+#   fm-project-skill-resolve.sh <project-root> <skill-name>
+#   fm-project-skill-resolve.sh -- <project-root> <skill-name>
+#   fm-project-skill-resolve.sh -h | --help
+#
+# Search roots are direct children of <project-root>/.agents/skills,
+# <project-root>/.codex/skills, and <project-root>/skills when that directory
+# contains project skills.
+# Hidden directories are searched normally.
+#
+# A candidate matches when its directory basename normalized to lowercase
+# ASCII hyphen form equals the normalized query, or when its SKILL.md front
+# matter has a name value exactly equal to the original query.
+# Normalization lowercases ASCII, replaces each non-alphanumeric run with one
+# hyphen, and trims leading or trailing hyphens.
+# Partial matches are never accepted.
+#
+# All local roots have equal rank.
+# One unique local match succeeds, duplicate evidence for the same file is
+# deduplicated, and multiple matching files are ambiguous.
+# Global and plugin catalogs are outside this resolver; its caller gives a
+# unique local match precedence before consulting them.
+#
+# The project and every returned file are canonicalized.
+# Symlinked search roots and matching symlink candidates are unsafe and stop
+# resolution rather than allowing discovery outside the project.
+#
+# Success prints the canonical absolute SKILL.md path and nothing else.
+# Diagnostics go to stderr.
+# Exit codes: 0 resolved, 1 absent, 2 invalid input, 3 ambiguous, 4 unsafe path.
+set -eu
+
+usage() {
+  awk '
+    NR == 1 { next }
+    /^#/ { sub(/^# ?/, ""); print; next }
+    { exit }
+  ' "$0"
+}
+
+diagnose() {
+  printf 'fm-project-skill-resolve: %s\n' "$*" >&2
+}
+
+normalize_slug() {
+  LC_ALL=C printf '%s' "$1" \
+    | tr '[:upper:]' '[:lower:]' \
+    | sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//'
+}
+
+frontmatter_name() {
+  awk '
+    NR == 1 {
+      sub(/\r$/, "")
+      if ($0 != "---") exit
+      inside = 1
+      next
+    }
+    inside {
+      sub(/\r$/, "")
+      if ($0 == "---") exit
+      if ($0 ~ /^[[:space:]]*name[[:space:]]*:/) {
+        sub(/^[[:space:]]*name[[:space:]]*:[[:space:]]*/, "")
+        sub(/[[:space:]]+$/, "")
+        if (($0 ~ /^".*"$/) || ($0 ~ /^\047.*\047$/)) {
+          print substr($0, 2, length($0) - 2)
+        } else {
+          print
+        }
+        exit
+      }
+    }
+  ' "$1"
+}
+
+inside_project() {
+  case "$1" in
+    "$PROJECT"/*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+append_match() {
+  local existing
+  for existing in "${MATCHES[@]-}"; do
+    [ "$existing" = "$1" ] && return 0
+  done
+  MATCHES+=("$1")
+}
+
+case "${1:-}" in
+  -h|--help)
+    usage
+    exit 0
+    ;;
+  --)
+    shift
+    ;;
+esac
+
+if [ "$#" -ne 2 ]; then
+  usage >&2
+  exit 2
+fi
+
+PROJECT_INPUT=$1
+QUERY=$2
+
+if [ -z "$QUERY" ]; then
+  diagnose "invalid empty skill name"
+  exit 2
+fi
+
+PROJECT=$(realpath -e -- "$PROJECT_INPUT" 2>/dev/null) || {
+  diagnose "invalid project root: $PROJECT_INPUT"
+  exit 2
+}
+if [ ! -d "$PROJECT" ]; then
+  diagnose "project root is not a directory: $PROJECT_INPUT"
+  exit 2
+fi
+
+QUERY_SLUG=$(normalize_slug "$QUERY")
+if [ -z "$QUERY_SLUG" ]; then
+  diagnose "skill name has no normalizable slug: $QUERY"
+  exit 2
+fi
+
+MATCHES=()
+for relative_root in .agents/skills .codex/skills skills; do
+  search_root="$PROJECT/$relative_root"
+  if [ -L "$search_root" ]; then
+    diagnose "unsafe symlinked search root: $search_root"
+    exit 4
+  fi
+  [ -d "$search_root" ] || continue
+
+  while IFS= read -r -d '' entry; do
+    entry_slug=$(normalize_slug "$(basename "$entry")")
+    [ "$entry_slug" = "$QUERY_SLUG" ] || continue
+    diagnose "unsafe matching symlink candidate: $entry"
+    exit 4
+  done < <(find -P "$search_root" -mindepth 1 -maxdepth 1 -type l -print0)
+
+  while IFS= read -r -d '' skill_dir; do
+    candidate="$skill_dir/SKILL.md"
+    [ -e "$candidate" ] || [ -L "$candidate" ] || continue
+    dir_slug=$(normalize_slug "$(basename "$skill_dir")")
+
+    if [ -L "$candidate" ]; then
+      if [ "$dir_slug" = "$QUERY_SLUG" ]; then
+        diagnose "unsafe matching symlink candidate: $candidate"
+        exit 4
+      fi
+      continue
+    fi
+    [ -f "$candidate" ] || continue
+
+    canonical=$(realpath -e -- "$candidate" 2>/dev/null) || {
+      diagnose "unsafe unreadable candidate: $candidate"
+      exit 4
+    }
+    inside_project "$canonical" || {
+      diagnose "unsafe candidate outside project: $candidate"
+      exit 4
+    }
+
+    declared_name=$(frontmatter_name "$canonical")
+    if [ "$dir_slug" = "$QUERY_SLUG" ] || [ "$declared_name" = "$QUERY" ]; then
+      append_match "$canonical"
+    fi
+  done < <(find -P "$search_root" -mindepth 1 -maxdepth 1 -type d -print0)
+done
+
+case "${#MATCHES[@]}" in
+  0)
+    diagnose "absent project skill '$QUERY' under $PROJECT"
+    exit 1
+    ;;
+  1)
+    printf '%s\n' "${MATCHES[0]}"
+    exit 0
+    ;;
+  *)
+    diagnose "ambiguous project skill '$QUERY' under $PROJECT"
+    printf '%s\n' "${MATCHES[@]}" | LC_ALL=C sort | sed 's/^/  /' >&2
+    exit 3
+    ;;
+esac

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -125,6 +125,7 @@ family_for_basename() {
     fm-documentation-audiences.test.sh|fm-ensure-agents-md.test.sh|fm-grok-harness.test.sh|\
     fm-kimi-harness.test.sh|fm-herdr-lab.test.sh|fm-lint.test.sh|\
     fm-operational-input.test.sh|fm-pi-primary-types.test.sh|\
+    fm-project-skill-resolve.test.sh|\
     fm-send-popup-settle.test.sh|fm-send-settle.test.sh|\
     fm-subagent-pretool-check.test.sh|\
     fm-supervision-instructions.test.sh|fm-tmux-submit-busy.test.sh|fm-transition-lib.test.sh|\

--- a/tests/fm-project-skill-resolve.test.sh
+++ b/tests/fm-project-skill-resolve.test.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+# Behavioral tests for project-local skill discovery through the executable
+# resolver interface.
+set -u
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+RESOLVER="$ROOT/bin/fm-project-skill-resolve.sh"
+TMP_ROOT=$(mktemp -d)
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+fail() {
+  printf 'not ok - %s\n' "$1" >&2
+  exit 1
+}
+
+pass() {
+  printf 'ok - %s\n' "$1"
+}
+
+make_skill() {
+  local path=$1 name=$2
+  mkdir -p "$(dirname "$path")"
+  printf '%s\n' '---' "name: $name" '---' '' '# Fixture' >"$path"
+}
+
+run_resolver() {
+  local project=$1 query=$2
+  set +e
+  OUTPUT=$($RESOLVER "$project" "$query" 2>"$TMP_ROOT/stderr")
+  STATUS=$?
+  set -e
+  ERROR=$(<"$TMP_ROOT/stderr")
+}
+
+assert_success_path() {
+  local expected=$1 label=$2
+  [ "$STATUS" -eq 0 ] || fail "$label: exit $STATUS: $ERROR"
+  [ "$OUTPUT" = "$(realpath "$expected")" ] || fail "$label: unexpected output: $OUTPUT"
+  pass "$label"
+}
+
+test_hidden_agents_root() {
+  local project="$TMP_ROOT/hidden-project"
+  local skill="$project/.agents/skills/writing-great-skills/SKILL.md"
+  make_skill "$skill" writing-great-skills
+  run_resolver "$project" writing-great-skills
+  assert_success_path "$skill" "discovers a skill under hidden .agents"
+}
+
+test_codex_root() {
+  local project="$TMP_ROOT/codex-project"
+  local skill="$project/.codex/skills/release-notes/SKILL.md"
+  make_skill "$skill" release-notes
+  run_resolver "$project" release-notes
+  assert_success_path "$skill" "discovers a skill under .codex"
+}
+
+test_project_skills_root() {
+  local project="$TMP_ROOT/public-project"
+  local skill="$project/skills/repo-guide/SKILL.md"
+  make_skill "$skill" repo-guide
+  run_resolver "$project" repo-guide
+  assert_success_path "$skill" "discovers a project skills surface"
+}
+
+test_slug_normalization_without_partial_match() {
+  local project="$TMP_ROOT/normalized-project"
+  local skill="$project/.agents/skills/Writing_Great Skills/SKILL.md"
+  make_skill "$skill" unrelated-name
+  run_resolver "$project" "Writing Great Skills"
+  assert_success_path "$skill" "normalizes human names and slugs"
+
+  run_resolver "$project" "Writing Great"
+  [ "$STATUS" -eq 1 ] || fail "partial slug match returned exit $STATUS"
+  [ -z "$OUTPUT" ] || fail "partial slug match returned a path"
+  pass "rejects partial slug matches"
+}
+
+test_exact_frontmatter_name() {
+  local project="$TMP_ROOT/name-project"
+  local skill="$project/.agents/skills/opaque-directory/SKILL.md"
+  make_skill "$skill" "writing-great-skills"
+  run_resolver "$project" writing-great-skills
+  assert_success_path "$skill" "resolves an exact frontmatter name"
+
+  run_resolver "$project" Writing-Great-Skills
+  [ "$STATUS" -eq 1 ] || fail "non-exact frontmatter name returned exit $STATUS"
+  pass "frontmatter name matching is exact"
+}
+
+test_local_scope_excludes_global_homonym() {
+  local project="$TMP_ROOT/local-project"
+  local local_skill="$project/.agents/skills/writing-great-skills/SKILL.md"
+  local global_skill="$TMP_ROOT/global/.agents/skills/writing-great-skills/SKILL.md"
+  make_skill "$local_skill" writing-great-skills
+  make_skill "$global_skill" writing-great-skills
+  run_resolver "$project" writing-great-skills
+  assert_success_path "$local_skill" "keeps resolution inside the selected project"
+}
+
+test_ambiguity() {
+  local project="$TMP_ROOT/ambiguous-project"
+  make_skill "$project/.agents/skills/shared/SKILL.md" shared
+  make_skill "$project/.codex/skills/shared/SKILL.md" shared
+  run_resolver "$project" shared
+  [ "$STATUS" -eq 3 ] || fail "ambiguity returned exit $STATUS: $ERROR"
+  case "$ERROR" in *"ambiguous project skill"*) ;; *) fail "ambiguity diagnostic missing" ;; esac
+  pass "rejects ambiguous local matches"
+}
+
+test_absence() {
+  local project="$TMP_ROOT/absent-project"
+  mkdir -p "$project/.agents/skills"
+  run_resolver "$project" missing-skill
+  [ "$STATUS" -eq 1 ] || fail "absence returned exit $STATUS: $ERROR"
+  case "$ERROR" in *"absent project skill"*) ;; *) fail "absence diagnostic missing" ;; esac
+  pass "reports absence with a non-zero exit"
+}
+
+test_unsafe_symlink() {
+  local project="$TMP_ROOT/unsafe-project"
+  local outside="$TMP_ROOT/outside/escape"
+  make_skill "$outside/SKILL.md" escape
+  mkdir -p "$project/.agents/skills"
+  ln -s "$outside" "$project/.agents/skills/escape"
+  run_resolver "$project" escape
+  [ "$STATUS" -eq 4 ] || fail "unsafe symlink returned exit $STATUS: $ERROR"
+  [ -z "$OUTPUT" ] || fail "unsafe symlink returned a path"
+  case "$ERROR" in *"unsafe matching symlink candidate"*) ;; *) fail "unsafe path diagnostic missing" ;; esac
+  pass "refuses a matching skill symlink outside the project"
+}
+
+test_help() {
+  "$RESOLVER" --help >/dev/null || fail "--help failed"
+  pass "help is available from the executable interface"
+}
+
+test_hidden_agents_root
+test_codex_root
+test_project_skills_root
+test_slug_normalization_without_partial_match
+test_exact_frontmatter_name
+test_local_scope_excludes_global_homonym
+test_ambiguity
+test_absence
+test_unsafe_symlink
+test_help


### PR DESCRIPTION
## Summary
- resolve named project-local skills before global or plugin fallback
- search .agents/skills, .codex/skills, and project skills safely
- add the internal discovery procedure and one-line AGENTS trigger
- reject ambiguous, partial, absent, and unsafe matches

## Validation
- RED contract test against the pre-change baseline
- bin/fm-test-run.sh tests/fm-project-skill-resolve.test.sh
- bin/fm-lint.sh with pinned ShellCheck 0.11.0
- bin/fm-doc-audience-check.sh
- complete diff review against firstmate-coding-guidelines and writing-great-skills