### PR TITLE
fix(bin): open exactly one decision per status line

### DIFF
--- a/.agents/skills/decision-hold-lifecycle/SKILL.md
+++ b/.agents/skills/decision-hold-lifecycle/SKILL.md
@@ -31,6 +31,7 @@ Bearings reads the resulting structured state and must never compensate by scrap
 2. Inventory only genuine unresolved choices that require the captain.
 3. For each choice, choose a stable key and use the script's `hold` command with a concise title, reason, and repository.
 4. Run the script's `complete` command with the full unresolved-key inventory for that review pass.
+   When the gate reports an open decision outside the reviewed inventory, read the status line that opened it before adding the key: a `[key=<slug>]` token written after the colon is summary prose, so that decision is filed under `default`, and a `!unresolved-key-<line>` entry means the named line resolves to no single key at all.
 5. Relay the choices to the captain as decisions from Bearings' Captain's Call section under `AGENTS.md` section 9; do not use the word hold in captain chat.
 6. After the captain decides, record dependent work with normal tasks-axi commands and block it by the hold identity.
 7. Put the captain's exact durable decision in a file and use the script's `resolve` command with every routed task.

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -278,8 +278,10 @@ The report is the only thing that survives, so anything worth keeping must be in
    treating it as a possible wedge. Use \`blocked:\` when you are stuck and need help.
 5. If you hit the same obstacle twice, append \`blocked: {why}\` and stop; firstmate will help.
 6. If a decision belongs to a human (product choices, destructive actions),
-   append \`needs-decision: {summary of options}\` and stop. Firstmate will reply with the decision.
-   When firstmate replies or a blocker clears and you resume, append \`resolved: {how it was decided or unblocked}\` (add the same \`[key=<slug>]\` if you opened it with one) so the decision or blocker is durably closed and does not keep resurfacing.
+   append \`needs-decision [key=<slug>]: {summary of options}\` and stop. Firstmate will reply with the decision.
+   The \`[key=<slug>]\` token must sit before the colon: anywhere after it is read as summary prose, the
+   decision is filed under \`default\` instead, and your later keyed \`resolved:\` line will not close it.
+   When firstmate replies or a blocker clears and you resume, append \`resolved [key=<slug>]: {how it was decided or unblocked}\` with that same key so the decision or blocker is durably closed and does not keep resurfacing.
 7. Never stop, restart, or update the shared \`no-mistakes\` daemon - it is one instance serving
    every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
    daemon error, append \`blocked: {the daemon error}\` and stop; only firstmate manages the daemon.
@@ -393,8 +395,10 @@ $RULE1
    cadence instead of treating it as a possible wedge. Use \`blocked:\` when you are stuck and need help.
 5. If you hit the same obstacle twice, append \`blocked: {why}\` and stop; firstmate will help.
 6. If a decision belongs above the implementation worker (product choices, destructive actions, ask-user findings),
-   append \`needs-decision: {summary of options}\` and stop. Firstmate will apply the configured authority and reply with the decision.
-   When firstmate replies or a blocker clears and you resume, append \`resolved: {how it was decided or unblocked}\` (add the same \`[key=<slug>]\` if you opened it with one) so the decision or blocker is durably closed and does not keep resurfacing.
+   append \`needs-decision [key=<slug>]: {summary of options}\` and stop. Firstmate will apply the configured authority and reply with the decision.
+   The \`[key=<slug>]\` token must sit before the colon: anywhere after it is read as summary prose, the
+   decision is filed under \`default\` instead, and your later keyed \`resolved:\` line will not close it.
+   When firstmate replies or a blocker clears and you resume, append \`resolved [key=<slug>]: {how it was decided or unblocked}\` with that same key so the decision or blocker is durably closed and does not keep resurfacing.
 7. Never stop, restart, or update the shared \`no-mistakes\` daemon - it is one instance serving
    every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
    daemon error, append \`blocked: {the daemon error}\` and stop; only firstmate manages the daemon.

--- a/bin/fm-classify-lib.sh
+++ b/bin/fm-classify-lib.sh
@@ -157,6 +157,13 @@ status_is_paused_or_captain_held() {  # <status-line>
 #   resolved       [key=api-shape]: <how it was decided>
 # A line with no token uses the key "default", preserving the historical
 # one-open-decision-per-task behavior (a bare "resolved:" closes "default").
+# The token's POSITION is part of the grammar, not a formatting preference: only
+# the prefix before the first colon is parsed for a key. A summary may legitimately
+# mention "[key=...]" as prose ("should docs mention [key=prose]?") and nothing in
+# the line distinguishes that from intent, so a token after the colon is always
+# note text. The fold below is what makes that rule safe to enforce - a line whose
+# key cannot be resolved to exactly one slug still opens exactly one decision,
+# under a reserved key, instead of silently folding into "default".
 # The three parsers are pure reads of a single line; the verb parser strips any
 # key token before the colon so the leading word is recovered cleanly.
 status_line_verb() {  # <status-line> -> leading verb word
@@ -172,20 +179,39 @@ status_line_note() {  # <status-line> -> text after the first colon, trimmed
     *) printf '%s' "$1" ;;
   esac
 }
-_fm_decision_key() {  # <status-line> -> key slug, or "default" when no token
-  local prefix=${1%%:*} k
+_fm_decision_key() {  # <status-line> -> key slug, "default" when no token, or 1
+  local prefix=${1%%:*} k rest
+  # No token at all in the prefix: the historical single-decision default.
   case "$prefix" in
-    *\[key=*\]*)
-      k=${prefix#*\[key=}
-      k=${k%%\]*}
-      case "$k" in
-        ''|*[!A-Za-z0-9._-]*) return 1 ;;
-        *) printf '%s' "$k" ;;
-      esac
-      ;;
-    *) printf 'default' ;;
+    *\[key=*) ;;
+    *) printf 'default'; return 0 ;;
+  esac
+  # A token was intended but the parser cannot resolve it to exactly one slug.
+  # Return 1 in all three cases (unterminated, not a slug, more than one token)
+  # rather than guessing: picking the first token binds the decision to whichever
+  # one happened to come first, and falling back to "default" reopens whatever an
+  # earlier bare "resolved:" line had closed. Callers refuse instead.
+  case "$prefix" in
+    *\[key=*\]*) ;;
+    *) return 1 ;;
+  esac
+  rest=${prefix#*\[key=}
+  k=${rest%%\]*}
+  case "${rest#*\]}" in *\[key=*\]*) return 1 ;; esac
+  case "$k" in
+    ''|*[!A-Za-z0-9._-]*) return 1 ;;
+    *) printf '%s' "$k" ;;
   esac
 }
+# Reserved key for a line whose own key could not be resolved. "!" can never
+# appear in a valid slug, so such a record collides with no real decision and no
+# captain-held inventory entry, which is what makes the gate in
+# bin/fm-decision-hold.sh reject it by name instead of absorbing it. The offending
+# line number is appended so two unresolvable lines in one file stay distinct
+# rather than overwriting each other, and the status log is append-only so the
+# number is stable across folds. Deliberately not overridable: a home that could
+# retune this could make the reserved key collide with a real slug again.
+FM_CLASSIFY_UNRESOLVED_KEY_PREFIX='!unresolved-key-'
 # Drop the record for <key> from a newline-terminated "<key>\t<verb>\t<note>" set.
 # Portable (no associative arrays) so the fold runs on bash 3.2 as well as 4+.
 _fm_decision_drop() {  # <open-set> <key>
@@ -204,19 +230,31 @@ EOF
 # Fold the WHOLE status stream into the set of decisions still open. Prints one
 # TAB-separated "<key>\t<verb>\t<summary>" line per still-open decision, in
 # most-recently-opened-last order; prints nothing when none are open. Pure read of
-# the file, no globals beyond the optional FM_CLASSIFY_RESOLVE_VERB override. This
-# is the durable open-set the fleet snapshot and any point-in-time consumer must use
+# the file, no globals beyond the optional FM_CLASSIFY_RESOLVE_VERB override, and
+# the only write is a stderr diagnostic for a line whose key cannot be resolved.
+# Every non-blank needs-decision/blocked line yields exactly one record, so the set
+# can never quietly gain or lose a decision the log does not name. This is the
+# durable open-set the fleet snapshot and any point-in-time consumer must use
 # instead of trusting the last status line.
 status_open_decisions() {  # <status-file>
-  local f=$1 line verb key note resolve held open='' stripped
+  local f=$1 line verb key note resolve held open='' stripped lineno=0
   [ -f "$f" ] || return 0
   resolve=${FM_CLASSIFY_RESOLVE_VERB:-$FM_CLASSIFY_RESOLVE_VERB_DEFAULT}
   held=${FM_CLASSIFY_CAPTAIN_HELD_VERB:-$FM_CLASSIFY_CAPTAIN_HELD_VERB_DEFAULT}
   while IFS= read -r line || [ -n "$line" ]; do
+    lineno=$((lineno + 1))
     stripped=${line//[[:space:]]/}
     [ -n "$stripped" ] || continue
     verb=$(status_line_verb "$line")
-    key=$(_fm_decision_key "$line") || continue
+    # An unresolvable key must never drop the line. Dropping a needs-decision
+    # loses a captain decision outright, and dropping a resolved leaves its
+    # decision open with no trace of the attempt to close it. Record it under the
+    # reserved key and say so on stderr so the offending line is fixable.
+    if ! key=$(_fm_decision_key "$line"); then
+      key="${FM_CLASSIFY_UNRESOLVED_KEY_PREFIX}${lineno}"
+      printf 'fm-classify: %s line %s names no single decision key, recorded as %s: %s\n' \
+        "$f" "$lineno" "$key" "$line" >&2
+    fi
     case "$verb" in
       needs-decision|blocked)
         note=$(status_line_note "$line")
@@ -251,6 +289,12 @@ _fm_status_open_activities_stream() {
     stripped=${line//[[:space:]]/}
     [ -n "$stripped" ] || continue
     verb=$(status_line_verb "$line")
+    # Unlike the decision fold above, an unresolvable key drops the line here.
+    # These records are supersession EVIDENCE, never authoritative crew state, so
+    # both directions of a dropped line are conservative: no open phase claims no
+    # supersession, and a dropped terminal event leaves the older phase open.
+    # Reserving a per-line key instead would strand a phase no later event could
+    # ever close.
     key=$(_fm_decision_key "$line") || continue
     case "$verb" in
       working|"$pause")

--- a/docs/decision-hold-lifecycle.md
+++ b/docs/decision-hold-lifecycle.md
@@ -19,6 +19,8 @@ It accepts `--none` as an explicit semantic inventory result, not as inferred ab
 It verifies every listed identity against tasks-axi before recording completion.
 For an open keyed status decision, it appends a `captain-held [key=<key>]: ...` transfer event only after the matching backlog hold is durable.
 `bin/fm-classify-lib.sh` recognizes that transfer as closing the live status copy without claiming that the captain has answered it.
+That library also owns which key each status line opens, and its fold guarantees the gate sees exactly one record per line.
+A line whose key cannot be resolved to a single slug opens a reserved `!unresolved-key-<line>` record rather than a guessed or defaulted one, so `complete` and `verify` reject it by name instead of absorbing it into an unrelated decision.
 
 Scout teardown calls the script's read-only `verify` subcommand after checking for the report and before removing any source state.
 The `--force` path remains the explicit captain-approved discard escape hatch.
@@ -43,11 +45,13 @@ The projection remains read-only and does not inspect historical prose.
 Verification date: 2026-07-14.
 Additional quoted `blocked_by` regression verification date: 2026-07-17.
 Plural blocker-readiness and mixed-home projection verification date: 2026-07-22.
+Decision key grammar verification date: 2026-08-02.
 
 The focused end-to-end regression uses only synthetic `sample` identities and decision text.
 It begins with a completed investigation and visual review whose genuine unresolved choice exists only in the report.
 The initial Bearings snapshot correctly has no open decision, and the new teardown gate refuses to erase the source.
 A later regression covers tasks-axi's quoted multi-entry `blocked_by` output so `resolve` matches the first, middle, and last ids and rejects a genuinely absent id.
+The key-grammar regression covers what the gate sees: a keyed, unkeyed, two-key, or malformed status line each opens exactly one decision, and a keyed line opens no `default` record beside it.
 
 The final verification commands and their exact summarized outputs follow.
 
@@ -62,6 +66,9 @@ ok - resolved findings and decision-like prose do not create false holds
 ok - terminal single-owner stale status decisions do not block empty inventory
 ok - main-home and secondmate-home captain holds remain correctly routed
 ok - resolve matches first/middle/last in quoted blocked_by and rejects a genuinely absent id
+
+$ bash tests/fm-watch-triage.test.sh | grep 'decision key grammar'
+ok - decision key grammar: one line opens exactly one decision, keyed, unkeyed, or refused
 
 $ bash tests/fm-fleet-snapshot-view.test.sh
 ok - backlog normalization preserves strict roles and resolves every blocker compatibly

--- a/tests/fm-watch-triage.test.sh
+++ b/tests/fm-watch-triage.test.sh
@@ -192,7 +192,9 @@ test_classifier_primitives() {
   FM_CAPTAIN_RE='custom-verb:' status_is_captain_relevant "custom-verb: x" \
     || fail "nonterminal suppression weakened custom bare-line behavior"
   printf 'needs-decision: should docs mention [key=prose]?\nneeds-decision [key=q1]: real choice\nresolved: docs still mention [key=q1]\nneeds-decision [key=bad key]: malformed\n' > "$state/keys.status"
-  open=$(status_open_decisions "$state/keys.status")
+  # The malformed fourth line is deliberate here and its stderr diagnostic is
+  # asserted by test_decision_key_grammar; drop it so the suite output stays clean.
+  open=$(status_open_decisions "$state/keys.status" 2>/dev/null)
   printf '%s' "$open" | grep -F $'q1\t' >/dev/null \
     || fail "a key token in resolved note prose closed the keyed decision"
   printf '%s' "$open" | grep -F $'prose\t' >/dev/null \
@@ -222,6 +224,90 @@ EOF
   [ -z "$(status_open_activities "$state/legacy-activity.status")" ] \
     || fail "a legacy terminal event did not supersede the default working phase"
   pass "classifier primitives: keyed decisions and activity phases, captain relevance, window-to-task, and overrides"
+}
+
+# The decision-key grammar of status_open_decisions, one case per shape a status
+# line can carry. The invariant every case asserts is the same: ONE
+# needs-decision line opens exactly ONE record. Incident regression - a scout
+# escalating twice ended up with a phantom "default" record beside its two real
+# keys, which put an entry outside the reviewed inventory and failed
+# bin/fm-decision-hold.sh verify at teardown four times in one session. The
+# phantom was never a duplicate of a keyed line; it was a THIRD line whose key
+# token sat after the colon, where the grammar reads it as summary prose.
+test_decision_key_grammar() {
+  local dir state open err count
+  dir=$(make_case decision-key-grammar); state="$dir/state"
+
+  # Keyed: exactly one record, under that key, and NO default record beside it.
+  printf 'working: started\nneeds-decision [key=api-shape]: A or B\n' > "$state/keyed.status"
+  open=$(status_open_decisions "$state/keyed.status" 2>/dev/null)
+  count=$(printf '%s' "$open" | grep -c . || true)
+  [ "$count" = 1 ] || fail "a keyed needs-decision opened $count decisions, expected 1"
+  printf '%s' "$open" | grep -qF $'api-shape\tneeds-decision\tA or B' \
+    || fail "a keyed needs-decision did not open its own key"
+  printf '%s' "$open" | grep -qF $'default\t' \
+    && fail "a keyed needs-decision also opened a default-keyed record"
+
+  # Unkeyed: exactly one record, under default. The historical shape.
+  printf 'working: started\nneeds-decision: A or B\n' > "$state/unkeyed.status"
+  open=$(status_open_decisions "$state/unkeyed.status" 2>/dev/null)
+  count=$(printf '%s' "$open" | grep -c . || true)
+  [ "$count" = 1 ] || fail "an unkeyed needs-decision opened $count decisions, expected 1"
+  printf '%s' "$open" | grep -qF $'default\tneeds-decision\tA or B' \
+    || fail "an unkeyed needs-decision did not open the default key"
+
+  # Two key tokens: the line names two decisions, so the fold refuses to pick one.
+  # Binding it to the first token misattributes the decision and falling back to
+  # default reopens whatever an earlier bare resolved: line closed; both are
+  # silent. The reserved key is loud instead - no captain-held inventory entry can
+  # ever match it, so fm-decision-hold.sh verify rejects it by name.
+  printf 'needs-decision [key=one] [key=two]: A or B\n' > "$state/twokey.status"
+  open=$(status_open_decisions "$state/twokey.status" 2>/dev/null)
+  count=$(printf '%s' "$open" | grep -c . || true)
+  [ "$count" = 1 ] || fail "a two-key needs-decision opened $count decisions, expected 1"
+  printf '%s' "$open" | grep -qE $'^(one|two|default)\t' \
+    && fail "a two-key needs-decision silently picked a key"
+  printf '%s' "$open" | grep -qF $'!unresolved-key-1\tneeds-decision\tA or B' \
+    || fail "a two-key needs-decision was not recorded under the reserved key"
+  err=$(status_open_decisions "$state/twokey.status" 2>&1 >/dev/null)
+  case "$err" in
+    *"$state/twokey.status"*"line 1"*'!unresolved-key-1'*) ;;
+    *) fail "a two-key needs-decision produced no diagnostic naming the file and line" ;;
+  esac
+
+  # An unresolvable key must never DROP the line: losing a needs-decision loses a
+  # captain decision outright, which is worse than the phantom it replaces.
+  printf 'needs-decision [key=bad key]: malformed\n' > "$state/badkey.status"
+  open=$(status_open_decisions "$state/badkey.status" 2>/dev/null)
+  count=$(printf '%s' "$open" | grep -c . || true)
+  [ "$count" = 1 ] || fail "an invalid key slug opened $count decisions, expected 1"
+  printf '%s' "$open" | grep -qF $'!unresolved-key-1\tneeds-decision\tmalformed' \
+    || fail "an invalid key slug did not open a reserved-key decision"
+
+  # Two unresolvable lines stay distinct instead of overwriting each other, and an
+  # unresolvable resolved: closes neither of them nor any real decision.
+  printf 'needs-decision [key=real]: keep me\nneeds-decision [key=bad key]: first\nneeds-decision [key=]: second\nresolved [key=a/b]: closes nothing\n' \
+    > "$state/multibad.status"
+  open=$(status_open_decisions "$state/multibad.status" 2>/dev/null)
+  count=$(printf '%s' "$open" | grep -c . || true)
+  [ "$count" = 3 ] || fail "unresolvable lines collapsed into $count decisions, expected 3"
+  printf '%s' "$open" | grep -qF $'real\tneeds-decision\tkeep me' \
+    || fail "an unresolvable resolved: line closed an unrelated real decision"
+
+  # The end-user reproduction. Two real escalations, the second written with its
+  # key after the colon: the default record belongs to THAT line, and the first
+  # line's keyed record is untouched by it.
+  printf 'needs-decision [key=label-direction]: A, B or E\nresolved [key=label-direction]: E\nneeds-decision: half or full framing [key=phone-framing]\n' \
+    > "$state/misplaced.status"
+  open=$(status_open_decisions "$state/misplaced.status" 2>/dev/null)
+  count=$(printf '%s' "$open" | grep -c . || true)
+  [ "$count" = 1 ] || fail "a misplaced key token opened $count decisions, expected 1"
+  printf '%s' "$open" | grep -qF $'default\tneeds-decision\thalf or full framing [key=phone-framing]' \
+    || fail "a key token after the colon was not left as summary prose under default"
+  printf '%s' "$open" | grep -qF $'label-direction\t' \
+    && fail "a keyed resolved: line failed to close its own decision"
+
+  pass "decision key grammar: one line opens exactly one decision, keyed, unkeyed, or refused"
 }
 
 # crew_is_provably_working: the absorb-only-when-provably-working predicate. It is
@@ -1803,6 +1889,7 @@ test_signal_reason_is_actionable_classifier
 test_stale_is_terminal_classifier
 test_scan_captain_relevant_statuses_classifier
 test_classifier_primitives
+test_decision_key_grammar
 test_crew_is_provably_working_classifier
 test_status_is_paused_classifier
 test_crew_absorb_class_classifier


### PR DESCRIPTION
## The defect

`status_open_decisions` in `bin/fm-classify-lib.sh` folds a task's append-only status log into the set of decisions still open. A `needs-decision:` or `blocked:` line opens a keyed decision, and only a `resolved:` or `captain-held:` line carrying that same key closes it. `bin/fm-decision-hold.sh` then refuses to complete or verify while any open key sits outside the reviewed inventory.

Two line shapes broke that fold, both silently.

**1. An unresolvable key dropped the entire line.** `_fm_decision_key` returned non-zero when a `[key=...]` token could not be parsed as a slug, and both folds did `continue`. So this:

```
needs-decision [key=bad key]: which storage backend?
```

opened no decision at all. The escalation disappeared from the durable set and the completion gate passed as though nothing were pending. A malformed `resolved:` line likewise closed nothing, leaving no trace of the attempt. Losing a decision outright is the worse of the two failures here.

**2. Two key tokens bound the decision to whichever came first.**

```
needs-decision [key=one] [key=two]: pick a rollout order
```

folded to `one`, with nothing to tell the author that the second key had been ignored.

### The rule that is working as designed

Only the prefix before the first colon is parsed for a key. A `[key=...]` token after the colon is summary prose, so this opens a decision under `default`:

```
needs-decision: half or full framing [key=phone-framing]
```

That is deliberate and stays unchanged. A summary may legitimately read `should docs mention [key=prose]?`, and nothing in the line distinguishes prose from intent once past the colon. There is an existing test asserting exactly this.

It was, however, completely silent, and it is the shape that motivated this change. An author who writes one correctly keyed line and later writes a second line with the token after the colon ends up with a `default` record sitting beside their real keys. The gate then rejects `default` as outside the reviewed inventory, and nothing explains why. The only remedy was to know, by folklore, to append a bare unkeyed `resolved:` after every escalation. This PR keeps the parsing rule and removes the silence.

## Reproduction

```console
$ . bin/fm-classify-lib.sh
$ printf 'needs-decision [key=bad key]: which storage backend?\n' > /tmp/t.status
$ status_open_decisions /tmp/t.status
$ # before: no output at all, the decision is gone and the gate passes
```

```console
$ printf 'needs-decision [key=one] [key=two]: pick a rollout order\n' > /tmp/t.status
$ status_open_decisions /tmp/t.status
one	needs-decision	pick a rollout order
$ # before: silently bound to the first token
```

## The fix

The invariant is now explicit: **every non-blank `needs-decision:` or `blocked:` line opens exactly one record.**

- A resolvable key opens one decision under that key. Unchanged.
- No key token opens one decision under `default`. Unchanged.
- A line the parser cannot resolve to exactly one slug (two `[key=...]` tokens, an unterminated token, or a value that is not a slug) opens one decision under a reserved `!unresolved-key-<line>` key, and reports the file and line on stderr.

Refusing beats guessing for the ambiguous cases. Taking the first token binds the decision to whichever one happened to be typed first. Falling back to `default` reopens whatever an earlier bare `resolved:` had closed. Both are silent, and neither is recoverable by an author who is never told.

`!` can never appear in a valid slug, so `validate_slug` in `bin/fm-decision-hold.sh` rejects it. The reserved record therefore can never acquire an inventory entry, and `complete` and `verify` reject it by name until the offending status line is fixed. The line number is part of the key so that two malformed lines in one file stay distinct instead of overwriting each other; the status log is append-only, so the number is stable across folds.

The activity fold (`_fm_status_open_activities_stream`) deliberately keeps dropping such lines. Those records are supersession evidence rather than authoritative state, so both directions of a drop are conservative, and a reserved per-line key would strand a phase that no later event could ever close. The reasoning is recorded inline at both call sites.

`bin/fm-brief.sh` now states the token position rule in the generated status protocol, and `.agents/skills/decision-hold-lifecycle/SKILL.md` points at it from the gate failure, so the rule is discoverable at both the moment of writing and the moment of failing.

## Tests

`test_decision_key_grammar` in `tests/fm-watch-triage.test.sh`, alongside the existing key-grammar assertions:

- a keyed line opens exactly one record, under its own key
- a keyed line opens no `default` record beside it
- an unkeyed line opens exactly one record, under `default`
- a two-key line opens exactly one record, under neither key nor `default`, and emits a diagnostic naming the file and line
- a malformed key opens exactly one record instead of vanishing
- two malformed lines stay distinct, and a malformed `resolved:` closes neither them nor an unrelated real decision
- the end-to-end shape: a token after the colon stays prose under `default`, and the earlier keyed decision is untouched by it

Every case asserts the exact record count, not just the presence of a key, so a regression that adds or loses a record fails rather than passing on a substring match.

## Compatibility note

A status log that already contains a line with an unparsable key will now fail the completion gate where it previously passed. That is the intended correction, since such a log does contain an unaccounted decision, but it is a behaviour change on existing data rather than a pure bug fix.

## Verification

`bin/fm-lint.sh` and `bin/fm-doc-audience-check.sh` are clean. The full suite passes apart from three suites that fail identically with this branch's tree removed (`fm-bootstrap`, `fm-pi-watch-extension`, `fm-test-run`), so none of them is caused by this change; the first looks environment dependent, and the second reproduces on elapsed wall time alone rather than test ordering.
