### PR TITLE
Add verified agy worker adapter

### DIFF
--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: harness-adapters
-description: Agent-only reference for firstmate harness operations. Use before spawning or recovering a crewmate or secondmate, handling a trust dialog, sending a harness-specific skill invocation, interrupting or exiting an agent, resuming an exited agent, or verifying a new harness adapter. Contains verified facts for claude, codex, opencode, pi, pi-signed, grok, and kimi.
+description: Agent-only reference for firstmate harness operations. Use before spawning or recovering a crewmate or secondmate, handling a trust dialog, sending a harness-specific skill invocation, interrupting or exiting an agent, resuming an exited agent, or verifying a new harness adapter. Contains verified facts for claude, codex, opencode, pi, pi-signed, grok, kimi, and agy.
 user-invocable: false
 metadata:
   internal: true
@@ -58,6 +58,7 @@ The primary integrations for `claude`, `codex`, `opencode`, `pi`, `pi-signed`, a
 `opencode`, `pi`, and `pi-signed` expose passive lifecycle callbacks and force one bounded follow-up when the shared predicate blocks.
 Grok selects native blocking or its pre-native bounded resume fallback from the exact running Stop payload; [`docs/turnend-guard.md`](../../../docs/turnend-guard.md) owns that contract.
 Kimi is outside the primary turn-end guard scope, while `docs/turnend-guard.md` owns its separate guarded global hook for crew wake signals.
+agy is outside the primary turn-end guard scope and has no verified crew turn-end signal.
 The exact hook files, commands, scoping rules, and fail-open tradeoffs are owned by `docs/turnend-guard.md`.
 `docs/verification/supervision.md` "Turn-end guard" owns active validation evidence.
 When changing any primary turn-end hook, validate the real harness behavior in a scratch project or throwaway home before trusting it, then update that doc and the relevant concise fact below.
@@ -127,6 +128,7 @@ The supported launch-profile flags below are verified locally; each row records 
 | pi / pi-signed | `--model <model>` | `--thinking <low\|medium\|high\|xhigh\|max>` | Verified 2026-07-27 on Pi and pi-signed 0.82.0. Both expose the same accepted thinking levels and completed the same model-qualified max-thinking smoke. |
 | opencode | `--model <provider/model>` | none for firstmate's interactive launch | Verified on opencode 1.17.6. `opencode run` has `--variant`, but firstmate launches the interactive `opencode --prompt` path, which has no verified effort flag. |
 | kimi | `--model <model>` | none | Verified 2026-07-25 on Kimi Code CLI 0.29.1. |
+| agy | `--model <model>` | none | Verified 2026-08-02 on Antigravity CLI 1.1.9. Reasoning effort is part of the model name, so firstmate omits the separate `--effort` flag. |
 
 The concrete `harness` field owns adapter identity independently of the model provider: `harness=pi` with `model=xai/grok-*` is Pi using xAI, not `harness=grok`, and does not require Grok CLI login; `harness=grok` remains the standalone Grok Build CLI adapter.
 No script resolves that split for you: establish which credential store a tuple reads from the discovery surfaces below plus `quota-axi auth --json`'s per-provider sources, and show that reasoning rather than inferring it from a harness, model, or source name.
@@ -144,6 +146,7 @@ Use the discovery surface in the current authenticated environment because suppo
 | pi / pi-signed | Run the selected executable as `<executable> --list-models [search]`; Pi's installed `docs/models.md` owns how built-in, extension-registered, and custom provider/model entries reach that list. |
 | grok | Run `grok models`, which lists the models available to the current Grok installation and account. |
 | kimi | Run `kimi provider list --json`, which lists the current provider and model configuration. |
+| agy | Run `agy models`, which lists the models available to the current Antigravity CLI installation and account. |
 
 For an unfamiliar harness or model namespace, establish support and provider identity from that harness's authoritative CLI help, model listing, or current documentation rather than guessing from a name or prefix.
 A listing that reaches the account and does not contain the model is concrete evidence the model is unsupported: block that candidate and quote the result.
@@ -163,6 +166,7 @@ Natural language is acceptable if uncertain.
 - pi and pi-signed: no separate verified skill invocation beyond normal command behavior; use natural language if the exact skill command is uncertain.
 - grok: `/<skill>`, for example `/no-mistakes` (same form as claude). Verified end to end: grok discovers the user-level `no-mistakes` skill, `/no-mistakes` invokes it, and grok drives a real `no-mistakes axi run`. Like codex's `$`/`/` popups, typing `/<skill>` opens grok's slash-autocomplete, so a too-fast Enter selects the popup entry instead of sending, and for an argument-taking command (like `/no-mistakes`'s optional task-first argument) that first Enter only expands the popup selection into an argument-hint placeholder rather than submitting - a genuine second Enter is required (see the grok section below for the 2026-07-03 incident and fix). `fm_tmux_submit_core`'s retried Enter (used by `fm-send` on the tmux backend) handles this through the structural composer reader; the herdr backend needed a dedicated fix (`fm_backend_herdr_composer_state`, docs/herdr-backend.md) because its prior delta-based verification false-positived on that same popup-close content change.
 - kimi: `/<skill>`, for example `/no-mistakes`.
+- agy: no separate verified skill invocation beyond normal command behavior; use natural language if the exact skill command is uncertain.
 
 ## Submission acknowledgement hazards
 
@@ -397,3 +401,32 @@ The delivery-only spinner match covers the full moon-phase glyph set rather than
 Each Kimi crew worktree receives a gitignored `.fm-kimi-turnend` token pointer, and the global hook touches that task's `state/<id>.turn-ended` only when the Stop payload's `cwd`, pointer, and registry entry all agree.
 A guarded silent hook cannot be verified from absence of effect, so prove invocation with an unguarded probe before concluding that the hook did not fire.
 The guarded turn-end signal remains a wake notification; standalone Kimi has no busy-state source until one is live-verified.
+
+## agy (VERIFIED 2026-08-02, Antigravity CLI 1.1.9)
+
+Antigravity CLI (`agy`) launches as a supervised interactive TUI with `-i` / `--prompt-interactive`.
+Launch with `agy --dangerously-skip-permissions --model <model> -i "$(__OPINPUT__ encode launch-brief < __BRIEF__)"`.
+Do not use `--print`, `--prompt`, or `-p` for crewmate launch because those are one-shot surfaces and exit.
+
+| Fact | Value |
+|---|---|
+| Binary | Executable `agy` from `PATH`; spawning refuses before launch when absent. |
+| Busy state | Rendered pane-state fallback isolated to `harness=agy`: the footer shows `esc to cancel` while a turn runs. Idle shows a bare `>` composer with no `esc to cancel`. |
+| Exit command | `Ctrl+D` once asks for confirmation with `press ctrl+d again to exit`; a second `Ctrl+D` exits cleanly back to the shell and prints `Resume with -c (or command below): agy --conversation=<id>`. |
+| Interrupt | Single Escape is the visible cancel affordance while a turn runs. |
+| Skill invocation | No separate verified skill invocation beyond normal command behavior; use natural language if uncertain. |
+| Autonomy | `--dangerously-skip-permissions`, observed to bypass tool permission prompts for unattended work. |
+| Trust dialog | First launch per worktree may ask "Do you trust the contents of this project?" and defaults to "Yes, I trust this folder"; Enter accepts it. |
+| Environment marker | `ANTIGRAVITY_AGENT=1`, observed in child/tool process environments. |
+| Composer | Idle is an unbordered bare `>` row. Firstmate treats that as empty only when the recorded target harness is `agy`; a generic bare shell `>` remains unknown. |
+| Models | `gemini-3.6-flash-{high,medium,low}`, `gemini-3.5-flash-{high,medium,low}`, `gemini-3.1-pro-{high,low}`, `claude-sonnet-4-6`, `claude-opus-4-6-thinking`, and `gpt-oss-120b-medium`. |
+| Effort | Reasoning effort is baked into the model name, so firstmate records any requested effort in task metadata but emits no separate `--effort` flag. |
+
+### Limits
+
+agy emits no verified Firstmate turn-end signal.
+There is no verified hook surface equivalent to the claude, codex, grok, or kimi turn-end paths, so supervision is pane state plus status appends only.
+
+Account quota is a real operational ceiling.
+On 2026-08-02 the Gemini model group hit `Individual quota reached` with a roughly 168 hour reset after a single afternoon fan-out, while the Claude and GPT group still worked.
+`fm-spawn.sh` scans the launch pane for that quota refusal and fails the spawn loudly instead of reporting success on a wedged pane.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -163,7 +163,7 @@ A silent bootstrap section needs no action; for any printed actionable diagnosti
 ## 4. Harness and runtime dispatch
 
 Load `harness-adapters` before every spawn or recovery and before trust handling, skill invocation, interrupt, exit, resume, or adapter verification.
-The verified harnesses are `claude`, `codex`, `opencode`, `pi`, `pi-signed`, `grok`, and `kimi`; never dispatch on an unverified adapter.
+The verified harnesses are `claude`, `codex`, `opencode`, `pi`, `pi-signed`, `grok`, `kimi`, and `agy`; never dispatch on an unverified adapter.
 If static `config/crew-harness` or `config/secondmate-harness` names an unverified adapter, report it and fall back only to a verified adapter rather than launching it.
 
 `docs/configuration.md` owns dispatch-profile and runtime-backend schemas, `bin/fm-harness.sh` owns static resolution, and `bin/fm-spawn.sh` owns launch flags and fail-closed validation.

--- a/bin/backends/tmux.sh
+++ b/bin/backends/tmux.sh
@@ -193,7 +193,7 @@ fm_backend_tmux_agent_state() {  # <target>
   }
   comm=${comm#-}
   case "$comm" in
-    *claude*|*codex*|*opencode*|*grok*|*kimi*|pi|pi-signed|pi-launcher|Pi) printf 'alive' ;;
+    *claude*|*codex*|*opencode*|*grok*|*kimi*|agy|*antigravity*|pi|pi-signed|pi-launcher|Pi) printf 'alive' ;;
     zsh|bash|sh|dash|ash|ksh|mksh|tcsh|csh|fish) printf 'dead' ;;
     '') printf 'unreadable' ;;
     *) printf 'ambiguous' ;;

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -450,7 +450,7 @@ secondmate_liveness_sweep() {
     [ -n "$target" ] || target="$window"
     agent_state=$(fm_backend_agent_state "$backend" "$target" 2>/dev/null) || agent_state=unreadable
     case "$harness" in
-      claude|codex|opencode|pi|pi-signed|grok|kimi) ;;
+      claude|codex|opencode|pi|pi-signed|grok|kimi|agy) ;;
       *)
         case "$agent_state" in dead|missing) agent_state=unverified-harness ;; esac
         ;;
@@ -734,7 +734,7 @@ crew_dispatch_validate() {
     return 0
   fi
   err=$(jq -r '
-    def verified($h): ["claude","codex","opencode","pi","pi-signed","grok","kimi"] | index($h);
+    def verified($h): ["claude","codex","opencode","pi","pi-signed","grok","kimi","agy"] | index($h);
     def effort_ok($h; $e):
       if $e == null then true
       elif ($e | type) != "string" then false
@@ -742,7 +742,7 @@ crew_dispatch_validate() {
       elif $h == "codex" then (["low","medium","high","xhigh"] | index($e))
       elif $h == "grok" then (["low","medium","high"] | index($e))
       elif $h == "pi" or $h == "pi-signed" then (["low","medium","high","xhigh","max"] | index($e))
-      elif $h == "opencode" or $h == "kimi" then false
+      elif $h == "opencode" or $h == "kimi" or $h == "agy" then false
       else true
       end;
     def profiles($value):

--- a/bin/fm-busy-lib.sh
+++ b/bin/fm-busy-lib.sh
@@ -39,7 +39,7 @@
 #   fm-interrupt     a firstmate-controlled interruption of the worker
 #   fm-recovery      a documented recovery reset after relaunch
 # Classifier-only sources (never written into a record):
-#   endpoint-gone, herdr-native, grok-regex, missing, malformed,
+#   endpoint-gone, herdr-native, grok-regex, agy-regex, missing, malformed,
 #   gen-mismatch, source-mismatch, kimi-unverified, codex-unverified,
 #   capture-failed, no-target
 #
@@ -50,15 +50,14 @@
 #   3. a valid, gen-matching, source-trusted record -> its state and source
 #   4. no record at all: herdr's native busy verdict is trusted as busy
 #      (generation state is sufficient for busy, not for idle), then the
-#      Grok-only temporary regex fallback classifies a grok task from its
-#      rendered tail, then unknown missing
+#      Grok-only and agy-only temporary regex fallbacks classify their task
+#      from the rendered tail, then unknown missing
 #   5. malformed, stale, or untrusted records -> unknown, never a fallback
-# The Grok arm is the ONLY rendered-text classification that survives the
-# redesign, because Grok's structured lifecycle was not credited-live-verified
-# in the approved audit; it is scoped to harness=grok and can never classify
+# The Grok and agy arms are the ONLY rendered-text classifications that survive
+# the redesign, because neither has a credited-live-verified structured
+# lifecycle source; each is scoped to its own harness and can never classify
 # another adapter. The delivery guards in bin/fm-tmux-lib.sh match rendered
-# footers for submit acknowledgement and away-mode supervisor injection only;
-# neither is a recorded worker state source.
+# footers for submit acknowledgement and away-mode supervisor injection too.
 #
 # Codex negotiation (fm_busy_codex_appserver_observable,
 # fm_busy_codex_hooks_verified): the approved contract prefers Codex's
@@ -255,6 +254,11 @@ fm_busy_grok_tail_busy() {
     | grep -qiE "${FM_BUSY_REGEX:-${FM_TMUX_GROK_BUSY_REGEX_DEFAULT:-Ctrl\\+c:cancel}}"
 }
 
+fm_busy_agy_tail_busy() {
+  grep -v '^[[:space:]]*$' | tail -12 \
+    | grep -qiE "${FM_BUSY_REGEX:-${FM_TMUX_AGY_BUSY_REGEX_DEFAULT:-esc to cancel}}"
+}
+
 # fm_busy_classify: semantic classification for a task whose endpoint the
 # caller has already established as present. Prints "<verdict> <source>":
 # busy|idle|unknown plus the producing source (see header). Never probes
@@ -324,6 +328,25 @@ fm_busy_classify() {  # <backend> <target> <harness> <id> <state-dir> [tail40]
         printf 'busy grok-regex'
       else
         printf 'idle grok-regex'
+      fi
+      return 0
+      ;;
+    agy*)
+      if [ -z "$tail40" ]; then
+        if command -v fm_backend_capture >/dev/null 2>&1; then
+          tail40=$(fm_backend_capture "$backend" "$target" 40 2>/dev/null) || {
+            printf 'unknown capture-failed'
+            return 0
+          }
+        else
+          printf 'unknown capture-failed'
+          return 0
+        fi
+      fi
+      if printf '%s' "$tail40" | fm_busy_agy_tail_busy; then
+        printf 'busy agy-regex'
+      else
+        printf 'idle agy-regex'
       fi
       return 0
       ;;

--- a/bin/fm-composer-lib.sh
+++ b/bin/fm-composer-lib.sh
@@ -197,7 +197,14 @@ fm_composer_classify_content() {  # <bordered> <content> [idle_re] [idle_case] [
     '>'|'$'|'%'|'#')
       # Shell prompt glyph: empty ONLY inside a composer box (the harness's own
       # prompt). Bare, it is a dead-shell prompt - never a safe injection target.
-      if [ "$bordered" = 1 ]; then printf 'empty'; else printf 'unknown'; fi
+      # agy is the verified exception: its live idle composer is an unbordered
+      # bare `>` row. Callers must opt in with FM_COMPOSER_BARE_PROMPT_OK=agy
+      # from recorded harness metadata; never enable this globally.
+      if [ "$bordered" = 1 ] || { [ "$content" = '>' ] && [ "${FM_COMPOSER_BARE_PROMPT_OK:-}" = agy ]; }; then
+        printf 'empty'
+      else
+        printf 'unknown'
+      fi
       return 0 ;;
   esac
   # Nothing on the row = empty composer.

--- a/bin/fm-crew-state.sh
+++ b/bin/fm-crew-state.sh
@@ -153,7 +153,7 @@ pane_readable() {  # <target>
 }
 # crew_busy_verdict: the crew's semantic busy state from the one contract
 # owner (bin/fm-busy-lib.sh), as "<busy|idle|unknown> <source>". A converted
-# adapter answers from its own lifecycle record; Grok answers from its
+# adapter answers from its own lifecycle record; Grok and agy answer from their
 # isolated rendered-tail fallback; a herdr crew's native `busy` is accepted
 # when no record exists, but its native `idle` is NOT, because agent.get
 # reports generation state (idle while a crew blocks on its own long-running
@@ -161,7 +161,7 @@ pane_readable() {  # <target>
 crew_busy_verdict() {  # <target>
   local tail40=''
   case "$HARNESS" in
-    grok*) tail40=$(fm_backend_capture "$TASK_BACKEND" "$1" 40 "$EXPECTED_LABEL" 2>/dev/null) || tail40='' ;;
+    grok*|agy*) tail40=$(fm_backend_capture "$TASK_BACKEND" "$1" 40 "$EXPECTED_LABEL" 2>/dev/null) || tail40='' ;;
   esac
   fm_busy_classify "$TASK_BACKEND" "$1" "$HARNESS" "$ID" "$STATE" "$tail40"
 }

--- a/bin/fm-harness.sh
+++ b/bin/fm-harness.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Detect the agent harness this process tree runs on.
-# Usage: fm-harness.sh                  print own harness: claude|codex|opencode|pi|pi-signed|grok|kimi|unknown
+# Usage: fm-harness.sh                  print own harness: claude|codex|opencode|pi|pi-signed|grok|kimi|agy|unknown
 #        fm-harness.sh crew             print the effective CREWMATE harness
 #                                        (config/crew-harness; "default" resolves to own)
 #        fm-harness.sh secondmate       print the harness the PRIMARY uses to launch
@@ -30,8 +30,8 @@ CONFIG="${FM_CONFIG_OVERRIDE:-$FM_HOME/config}"
 detect_own() {
   # Layer 1: environment markers for verified harnesses.
   # Keep marker detection before ancestry detection as an explicit precedence rule.
-  # Only claude, pi, and grok set verified markers of their own; codex, opencode,
-  # and kimi are markerless, so a foreign marker retained in a terminal
+  # Only claude, pi, grok, and agy set verified markers of their own; codex,
+  # opencode, and kimi are markerless, so a foreign marker retained in a terminal
   # multiplexer's stored environment can silently misidentify one of them before
   # ancestry is consulted. This is a precedence hazard, not evidence that
   # CLAUDECODE inheritance into a kimi child was observed; it was not observed.
@@ -44,6 +44,9 @@ detect_own() {
   # It does NOT set CLAUDECODE despite being Claude-Code-compatible, so this marker
   # is unambiguous when firstmate runs natively on grok.
   [ "${GROK_AGENT:-}" = "1" ] && { echo grok; return; }
+  # Antigravity CLI sets ANTIGRAVITY_AGENT=1 for its child/tool processes
+  # (verified, agy 1.1.9).
+  [ "${ANTIGRAVITY_AGENT:-}" = "1" ] && { echo agy; return; }
   # Layer 2: walk the parent chain and match the command name.
   local pid=$$ comm args
   for _ in 1 2 3 4 5 6 7 8; do
@@ -54,6 +57,8 @@ detect_own() {
       *opencode*) echo opencode; return ;;
       *grok*) echo grok; return ;;
       kimi) echo kimi; return ;;
+      agy) echo agy; return ;;
+      *antigravity*) echo agy; return ;;
       pi-signed) echo pi; return ;;
       pi) echo pi; return ;;
       node*|python*)
@@ -64,6 +69,7 @@ detect_own() {
           *codex*) echo codex; return ;;
           *opencode*) echo opencode; return ;;
           *grok*) echo grok; return ;;
+          *" agy "*|*/agy|*antigravity*) echo agy; return ;;
           *" pi "*|*/pi) echo pi; return ;;
         esac ;;
     esac

--- a/bin/fm-send.sh
+++ b/bin/fm-send.sh
@@ -291,7 +291,10 @@ else
   sleep_s=${FM_SEND_SLEEP:-0.4}
   # Type once, submit, verify. Only exact empty confirms delivery; every other
   # verdict preserves the loud refusal boundary.
-  if ! verdict=$(fm_backend_send_text_submit "$TARGET_BACKEND" "$T" "$MESSAGE" "$retries" "$sleep_s" "$settle" "$EXPECTED_LABEL"); then
+  composer_bare_prompt_ok=
+  [ "$TARGET_HARNESS" = agy ] && composer_bare_prompt_ok=agy
+  if ! verdict=$(FM_COMPOSER_BARE_PROMPT_OK="$composer_bare_prompt_ok" \
+    fm_backend_send_text_submit "$TARGET_BACKEND" "$T" "$MESSAGE" "$retries" "$sleep_s" "$settle" "$EXPECTED_LABEL"); then
     if [ "$PENDING_REPLY_CREATED" = 1 ] && [ -n "$PENDING_REPLY_CORR" ]; then
       fm_pending_reply_discard_undelivered "$STATE" "$PENDING_REPLY_CORR" || true
     fi

--- a/bin/fm-session-lock-lib.sh
+++ b/bin/fm-session-lock-lib.sh
@@ -9,7 +9,7 @@
 # This file is sourced by scripts and has no side effects on source.
 
 # Known harness command names; extend when a new adapter is verified.
-FM_HARNESS_RE='claude|codex|opencode|grok|kimi|^pi$|^pi-signed$'
+FM_HARNESS_RE='claude|codex|opencode|grok|kimi|^agy$|antigravity|^pi$|^pi-signed$'
 
 # Walk the current process ancestry (up to 16 hops) and print a harness pid.
 # For every harness except Claude, the first match wins (innermost pid), which

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -70,7 +70,7 @@
 #   profile consultation. A --secondmate spawn is exempt and resolves the SECONDMATE
 #   harness (config/secondmate-harness -> config/crew-harness -> own), so the
 #   secondmate-vs-crewmate split is DURABLE across every respawn (recovery,
-#   /updatefirstmate, restart). A bare adapter name (claude|codex|opencode|pi|pi-signed|grok|kimi)
+#   /updatefirstmate, restart). A bare adapter name (claude|codex|opencode|pi|pi-signed|grok|kimi|agy)
 #   overrides it for this spawn (either kind). A non-flag string containing
 #   whitespace is treated as a RAW launch command - the escape hatch for verifying
 #   new adapters. pi-signed launches that exact executable name from PATH and
@@ -425,7 +425,7 @@ FIRSTMATE_HOME=
 
 if [ "$KIND" = secondmate ]; then
   case "${POS[1]:-}" in
-    ''|claude|codex|opencode|pi|pi-signed|grok|kimi)
+    ''|claude|codex|opencode|pi|pi-signed|grok|kimi|agy)
       ARG3=${POS[1]:-}
       ;;
     *' '*)
@@ -491,6 +491,11 @@ launch_template() {
     # Its turn-end signal is a globally configured Stop hook plus a guarded
     # per-task worktree token, so no launch placeholder belongs here.
     kimi) printf '%s' '__KIMIBIN__ __MODELFLAG__--auto' ;;
+    # agy (Antigravity CLI): -i/--prompt-interactive delivers the launch brief
+    # and keeps the TUI session alive. --print/--prompt are one-shot and exit.
+    # Reasoning effort is part of the model name, so this template deliberately
+    # has no __EFFORTFLAG__ placeholder and no turn-end placeholder.
+    agy) printf '%s' 'agy --dangerously-skip-permissions __MODELFLAG__-i "$(__OPINPUT__ encode launch-brief < __BRIEF__)"' ;;
     *) return 1 ;;
   esac
 }
@@ -540,6 +545,10 @@ esac
 # retain the literal name in the launch command and task metadata.
 if [ "$HARNESS" = pi-signed ] && ! command -v pi-signed >/dev/null 2>&1; then
   echo "error: pi-signed executable not found on PATH; install the signed Pi wrapper or select a different verified harness" >&2
+  exit 1
+fi
+if [ "$HARNESS" = agy ] && ! command -v agy >/dev/null 2>&1; then
+  echo "error: agy executable not found on PATH; install Antigravity CLI or select a different verified harness" >&2
   exit 1
 fi
 
@@ -603,7 +612,7 @@ model_flag_for_harness() {
   local harness=$1 model=$2
   [ -n "$model" ] && [ "$model" != default ] || return 0
   case "$harness" in
-    claude|codex|opencode|pi|pi-signed|grok|kimi)
+    claude|codex|opencode|pi|pi-signed|grok|kimi|agy)
       printf -- '--model %s ' "$(shell_quote "$model")"
       ;;
   esac
@@ -647,6 +656,8 @@ effort_flag_for_harness() {
     # to a different, non-interactive launch mode, so fm-spawn does not pass it.
     # kimi likewise has no reasoning-effort flag; the requested axis stays in
     # task metadata but never reaches the launch command.
+    # agy's reasoning effort is baked into the selected model name, e.g.
+    # gemini-3.6-flash-high, so firstmate must not emit a separate --effort flag.
   esac
 }
 
@@ -1292,6 +1303,29 @@ kimi_spawn_fail() {  # <detail>
   echo "error: $1; inspect window $T" >&2
 }
 
+agy_capture() {
+  fm_backend_capture "$BACKEND" "$T" 120 "$W" 2>/dev/null || true
+}
+
+agy_spawn_fail() {  # <detail>
+  printf 'failed: %s\n' "$1" >> "$STATE/$ID.status"
+  echo "error: $1; inspect window $T" >&2
+}
+
+agy_wait_for_launch_refusal() {
+  local pane i=0 max=${FM_AGY_LAUNCH_POLLS:-20} interval=${FM_AGY_LAUNCH_INTERVAL:-0.5}
+  while [ "$i" -lt "$max" ]; do
+    pane=$(agy_capture)
+    if printf '%s\n' "$pane" | grep -qiE 'Individual quota reached|quota reached'; then
+      agy_spawn_fail "agy account quota reached during launch"
+      return 1
+    fi
+    i=$((i + 1))
+    [ "$i" -ge "$max" ] || sleep "$interval"
+  done
+  return 0
+}
+
 if [ "$KIND" != secondmate ] && [ "$BACKEND" != orca ]; then
   spawn_send_text_line "$WT_TARGET" 'treehouse get'
 
@@ -1582,6 +1616,11 @@ EOF
       printf 'token=%s\n' "${auth_file##*/}" > "$WT/.fm-kimi-turnend"
       exclude_path '.fm-kimi-turnend'
       ;;
+    agy*)
+      # agy exposes no verified Firstmate turn-end hook surface. Do not arm a
+      # busy-state record that nothing can clear, and do not invent a hook.
+      # Supervision uses pane-state busy signatures and status appends only.
+      ;;
   esac
 fi
 
@@ -1688,6 +1727,9 @@ if [ "${HERDR_PROJECTED:-0}" -eq 1 ]; then
   spawn_herdr_presentation_order_lock_release
 fi
 spawn_send_key "$T" Enter
+if [ "$HARNESS" = agy ]; then
+  agy_wait_for_launch_refusal || exit 1
+fi
 if [ "$HARNESS" = kimi ]; then
   if ! kimi_wait_for_ready; then
     kimi_spawn_fail "kimi did not show a verified ready signal before brief delivery"

--- a/bin/fm-supervise-daemon.sh
+++ b/bin/fm-supervise-daemon.sh
@@ -596,8 +596,9 @@ pane_is_busy() {  # <target> [backend]
 # every verdict except exact empty as unsafe. inject_msg reads the full verdict
 # directly and applies the same positive-proof boundary.
 pane_input_pending() {  # <target> [backend]
-  local target=$1 backend=${2:-tmux}
-  [ "$(fm_backend_composer_state "$backend" "$target" 2>/dev/null)" != empty ]
+  local target=$1 backend=${2:-tmux} composer_bare_prompt_ok=
+  [ "$(fm_daemon_primary_harness)" = agy ] && composer_bare_prompt_ok=agy
+  [ "$(FM_COMPOSER_BARE_PROMPT_OK="$composer_bare_prompt_ok" fm_backend_composer_state "$backend" "$target" 2>/dev/null)" != empty ]
 }
 
 task_window_backend() {  # <window> <state>

--- a/bin/fm-tmux-lib.sh
+++ b/bin/fm-tmux-lib.sh
@@ -67,7 +67,8 @@
 . "$(dirname -- "${BASH_SOURCE[0]}")/fm-composer-lib.sh"
 
 # Delivery-only rendered busy footers per harness. claude/codex: "esc to
-# interrupt"; opencode: "esc interrupt"; pi: "Working..."; grok: "Ctrl+c:cancel".
+# interrupt"; opencode: "esc interrupt"; pi: "Working..."; grok: "Ctrl+c:cancel";
+# agy: "esc to cancel".
 # Claude's current spinner has a rotating glyph and word, but every active-turn
 # line has an ellipsis followed by a parenthesized elapsed duration. Keep this
 # signature separate from the shared default because that shape is not generic
@@ -82,13 +83,14 @@
 # busy signals on their own.
 # The full moon-phase set remains locale- and emoji-font-sensitive because Kimi
 # exposes no stable ASCII busy token.
-FM_TMUX_BUSY_REGEX_DEFAULT='esc (to )?interrupt|Working\.\.\.|Ctrl\+c:cancel'
+FM_TMUX_BUSY_REGEX_DEFAULT='esc (to )?interrupt|esc to cancel|Working\.\.\.|Ctrl\+c:cancel'
 FM_TMUX_CLAUDE_BUSY_REGEX_DEFAULT='esc to interrupt|…[[:space:]]+\([0-9]+[smh]'
 FM_TMUX_CODEX_BUSY_REGEX_DEFAULT='esc to interrupt'
 FM_TMUX_OPENCODE_BUSY_REGEX_DEFAULT='esc interrupt'
 FM_TMUX_PI_BUSY_REGEX_DEFAULT='Working\.\.\.'
 FM_TMUX_GROK_BUSY_REGEX_DEFAULT='Ctrl\+c:cancel'
 FM_TMUX_KIMI_BUSY_REGEX_DEFAULT='^[[:space:]]*(🌑|🌒|🌓|🌔|🌕|🌖|🌗|🌘)[[:space:]]+·[[:space:]]+'
+FM_TMUX_AGY_BUSY_REGEX_DEFAULT='esc to cancel'
 
 fm_busy_lines_match() {  # [harness]
   local harness=${1:-} lines regex
@@ -103,6 +105,7 @@ fm_busy_lines_match() {  # [harness]
       pi|pi-signed) regex=$FM_TMUX_PI_BUSY_REGEX_DEFAULT ;;
       grok) regex=$FM_TMUX_GROK_BUSY_REGEX_DEFAULT ;;
       kimi) regex=$FM_TMUX_KIMI_BUSY_REGEX_DEFAULT ;;
+      agy) regex=$FM_TMUX_AGY_BUSY_REGEX_DEFAULT ;;
       '') regex=$FM_TMUX_BUSY_REGEX_DEFAULT ;;
       *)
         # A supplied harness must never borrow another harness's signature.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -193,7 +193,7 @@ The full cmux home label also includes a short hash of the resolved `FM_ROOT` pa
 
 ## Harness support
 
-claude, codex, opencode, pi, pi-signed, grok, and kimi are empirically verified for crewmate and secondmate launches; [README requirements](../README.md#requirements) own the set supported for the primary session.
+claude, codex, opencode, pi, pi-signed, grok, kimi, and agy are empirically verified for crewmate and secondmate launches; [README requirements](../README.md#requirements) own the set supported for the primary session.
 New harnesses get verified through a supervised trial task before joining the set.
 The verified adapter knowledge - each harness's busy-state source, interrupt and exit commands, skill-invocation syntax, and per-harness quirks - lives in [`.agents/skills/harness-adapters/SKILL.md`](../.agents/skills/harness-adapters/SKILL.md).
 Launch mechanics, including the verified command templates, live in [`bin/fm-spawn.sh`](../bin/fm-spawn.sh).

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -28,7 +28,7 @@ zsh
 ```
 
 A persistent parent shell waiting for a child remained reported as the parent process, while a shell that directly execed a simple command changed identity with the process itself.
-Claude, Codex, OpenCode, and Grok were observed under their own process names.
+Claude, Codex, OpenCode, Grok, and agy were observed under their own process names.
 Kimi Code CLI 0.29.1 was observed under `kimi` on 2026-07-25.
 Pi and pi-signed 0.82.0 were reverified on 2026-07-27 through real isolated `fm-spawn.sh` launches.
 
@@ -72,6 +72,33 @@ The exact wrapper ancestry was `pi-signed` parent to Pi engine child, and the pl
 That shared plain-Pi path is retained as disconfirming evidence against using ancestry as runtime-selection authority.
 Firstmate therefore sets the exact `FM_PI_HARNESS` selection marker on both worker launch paths, while an unmarked Pi-family process remains `pi`.
 Both recorded runtime identities now classify the exact `pi-launcher` foreground command as `alive`.
+
+Antigravity CLI was verified on 2026-08-02 with `agy` 1.1.9.
+
+```sh
+agy --version
+agy --help
+agy models
+agy --dangerously-skip-permissions --model gpt-oss-120b-medium --print-timeout 2m --output-format text -p 'Run exactly this shell command and print its stdout only: env | sort | grep -E "^(AGY|ANTIGRAVITY|GOOGLE|GEMINI|AGENT|CODE|CLI|FM_|PWD=|SHELL=|PATH=)"'
+```
+
+Observed bounded output:
+
+```text
+1.1.9
+--prompt-interactive            Run an initial prompt interactively and continue the session
+gemini-3.6-flash-high
+gpt-oss-120b-medium
+ANTIGRAVITY_AGENT=1
+ANTIGRAVITY_AGENTAPI_EXE=/opt/homebrew/bin/agy
+ANTIGRAVITY_LS_VERSION=cli-1.1.9
+```
+
+The env-marker probe ran from a real agy tool process and establishes `ANTIGRAVITY_AGENT=1` as the harness marker.
+The same help/model-list evidence establishes the `--model` flag, `--prompt-interactive` / `-i` launch surface, model list, and the presence of a standalone `--effort` flag that Firstmate deliberately omits because the verified model names already encode effort.
+The first end-to-end Firstmate adapter proof used `bin/fm-spawn.sh agy-proof-v1 ... --harness agy --model gpt-oss-120b-medium` on 2026-08-02.
+It accepted the first-launch trust dialog with one Enter, delivered the launch brief, appended `working:` and `done:` to `state/agy-proof-v1.status`, and exited cleanly back to `zsh` after two `Ctrl+D` keypresses.
+The first `Ctrl+D` showed `press ctrl+d again to exit`, and the second printed `Resume with -c (or command below): agy --conversation=<id>`.
 
 Backend applicability was reviewed across every spawn adapter.
 Tmux needs the exact `pi-launcher`, `pi-signed`, `pi`, and `Pi` process identities for recovery-grade liveness.

--- a/tests/fm-busy-state.test.sh
+++ b/tests/fm-busy-state.test.sh
@@ -231,6 +231,20 @@ Ctrl+c:cancel'
   pass "converted adapters never classify busy from rendered footer text"
 }
 
+test_agy_rendered_tail_fallback_is_isolated() {
+  local state out
+  state=$(new_state_dir agy-regex)
+  out=$(fm_busy_classify tmux w1 agy t1 "$state" '⠋ Working... esc to cancel')
+  [ "$out" = "busy agy-regex" ] || fail "agy busy footer must classify busy agy-regex, got '$out'"
+  out=$(fm_busy_classify tmux w1 agy t1 "$state" 'ready'$'\n''> ')
+  [ "$out" = "idle agy-regex" ] || fail "agy idle pane must classify idle agy-regex, got '$out'"
+  out=$(fm_busy_classify tmux w1 grok t1 "$state" 'esc to cancel')
+  [ "$out" = "idle grok-regex" ] || fail "agy footer leaked into Grok fallback, got '$out'"
+  out=$(fm_busy_classify tmux w1 codex t1 "$state" 'esc to cancel')
+  [ "$out" = "unknown codex-unverified" ] || fail "agy footer leaked into Codex, got '$out'"
+  pass "agy rendered-tail fallback is scoped to harness=agy"
+}
+
 test_grok_regex_isolated() {
   local state out
   state=$(new_state_dir grok-arm)
@@ -368,6 +382,7 @@ test_missing_record_unknown_not_idle
 test_malformed_record_unknown
 test_record_without_sidecar_unknown
 test_source_mismatch_cross_adapter
+test_agy_rendered_tail_fallback_is_isolated
 test_converted_adapters_ignore_footer_text
 test_grok_regex_isolated
 test_codex_unverified_gate

--- a/tests/fm-composer-lib.test.sh
+++ b/tests/fm-composer-lib.test.sh
@@ -82,6 +82,17 @@ test_agent_glyphs_are_empty_bordered_and_bare() {
   pass "fm_composer_classify_content: agent prompt glyphs (❯ claude, › codex) read empty bordered or bare"
 }
 
+test_agy_bare_prompt_opt_in() {
+  local out
+  out=$(classify 0 '>')
+  [ "$out" = unknown ] || fail "bare > without agy opt-in must remain unknown, got '$out'"
+  out=$(FM_COMPOSER_BARE_PROMPT_OK=agy classify 0 '>')
+  [ "$out" = empty ] || fail "agy bare > opt-in should read empty, got '$out'"
+  out=$(FM_COMPOSER_BARE_PROMPT_OK=agy classify 0 '$')
+  [ "$out" = unknown ] || fail "agy opt-in must not bless another shell glyph, got '$out'"
+  pass "fm_composer_classify_content: agy's bare > composer is opt-in only"
+}
+
 # --- Empty content and idle placeholder -------------------------------------
 
 test_empty_content_is_empty() {
@@ -130,6 +141,7 @@ test_stripped_unbordered_content_uses_plain_content
 test_bare_shell_prompt_with_command_is_not_empty
 test_bordered_shell_glyph_is_empty
 test_agent_glyphs_are_empty_bordered_and_bare
+test_agy_bare_prompt_opt_in
 test_empty_content_is_empty
 test_idle_placeholder_is_empty
 test_idle_placeholder_case_mode_is_explicit

--- a/tests/fm-public-followup.test.sh
+++ b/tests/fm-public-followup.test.sh
@@ -25,6 +25,8 @@ TMP_ROOT=$(fm_test_tmproot fm-public-followup)
 
 command -v jq >/dev/null 2>&1 || { echo "skip: jq not found"; exit 0; }
 command -v tasks-axi >/dev/null 2>&1 || { echo "skip: tasks-axi not found"; exit 0; }
+tasks-axi public-followup --help >/dev/null 2>&1 \
+  || { echo "skip: tasks-axi public-followup not available"; exit 0; }
 
 # A fakebin `curl` standing in for the relay. It logs every call so a test can
 # prove exactly how many public posts happened, and honours FAKE_FOLLOWUP_CODE so

--- a/tests/fm-secondmate-harness.test.sh
+++ b/tests/fm-secondmate-harness.test.sh
@@ -52,7 +52,7 @@ set -u
 # ambient CLAUDECODE=1, the pi-signed ancestry case resolves "claude". Drop the
 # ambient markers so what this suite asserts does not depend on which harness it
 # was launched from; every case states the marker it means to test.
-unset CLAUDECODE PI_CODING_AGENT FM_PI_HARNESS GROK_AGENT
+unset CLAUDECODE PI_CODING_AGENT FM_PI_HARNESS GROK_AGENT ANTIGRAVITY_AGENT
 
 BASE_PATH=${FM_TEST_BASE_PATH:-/usr/bin:/bin:/usr/sbin:/sbin}
 fm_git_identity fmtest fmtest@example.com
@@ -196,6 +196,46 @@ SH
   fi
 
   pass "pi-signed identity: authoritative launch selection distinguishes shared wrapper ancestry"
+}
+
+test_agy_detection_and_session_lock_identity() {
+  local dir fakebin got
+  dir="$TMP_ROOT/agy-identity"
+  fakebin=$(fm_fakebin "$dir")
+  cat > "$fakebin/ps" <<'SH'
+#!/usr/bin/env bash
+set -u
+field= pid=
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -o) field=$2; shift 2 ;;
+    -p) pid=$2; shift 2 ;;
+    *) shift ;;
+  esac
+done
+case "$pid:$field" in
+  100:comm=) printf '%s\n' '/opt/homebrew/bin/agy' ;;
+  100:args=) printf '%s\n' 'agy --model gpt-oss-120b-medium' ;;
+  100:ppid=) printf '%s\n' 1 ;;
+  *:comm=) printf '%s\n' bash ;;
+  *:args=) printf '%s\n' bash ;;
+  *:ppid=) printf '%s\n' 100 ;;
+esac
+SH
+  chmod +x "$fakebin/ps"
+
+  got=$(env -u CLAUDECODE -u GROK_AGENT -u PI_CODING_AGENT ANTIGRAVITY_AGENT=1 PATH="$fakebin:$BASE_PATH" "$ROOT/bin/fm-harness.sh")
+  [ "$got" = agy ] || fail "Antigravity env marker resolved '$got', expected agy"
+  got=$(env -u CLAUDECODE -u GROK_AGENT -u PI_CODING_AGENT -u ANTIGRAVITY_AGENT PATH="$fakebin:$BASE_PATH" "$ROOT/bin/fm-harness.sh")
+  [ "$got" = agy ] || fail "agy ancestry resolved '$got', expected agy"
+  got=$(PATH="$fakebin:$BASE_PATH" bash -c \
+    '. "$0/bin/fm-session-lock-lib.sh"; fm_harness_ancestry_pid' "$ROOT")
+  [ "$got" = 100 ] || fail "session-lock ancestry selected '$got', expected agy pid 100"
+  PATH="$fakebin:$BASE_PATH" bash -c \
+    '. "$0/bin/fm-session-lock-lib.sh"; kill() { return 0; }; fm_harness_pid_alive 100' "$ROOT" \
+    || fail "session-lock liveness rejected agy holder"
+
+  pass "agy identity: env marker, process ancestry, and session-lock liveness classify Antigravity CLI"
 }
 
 test_dash_leading_process_names_are_basename_operands() {
@@ -2311,6 +2351,7 @@ SH
 test_harness_resolution
 test_secondmate_model_effort_tokens
 test_pi_signed_detection_and_session_lock_identity
+test_agy_detection_and_session_lock_identity
 test_dash_leading_process_names_are_basename_operands
 test_propagate_lib
 test_spawn_split_and_inherit

--- a/tests/fm-secondmate-liveness.test.sh
+++ b/tests/fm-secondmate-liveness.test.sh
@@ -97,7 +97,7 @@ SH
 test_tmux_agent_state_classifies() {
   local fb out
 
-  for harness in claude codex opencode grok kimi pi pi-signed pi-launcher Pi; do
+  for harness in claude codex opencode grok kimi agy pi pi-signed pi-launcher Pi; do
     fb=$(make_probe_tmux "$TMP_ROOT/tmux-$harness" "$harness")
     out=$(PATH="$fb:$BASE_PATH" bash -c '. "$0/bin/fm-backend.sh"; fm_backend_agent_state tmux sess:win' "$ROOT")
     [ "$out" = alive ] || fail "a live $harness foreground process should classify as alive, got '$out'"

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -26,6 +26,10 @@ case "${1:-}" in
   display-message) printf 'firstmate\n'; exit 0 ;;
   list-windows) exit 0 ;;
   has-session|new-session|new-window|kill-window) exit 0 ;;
+  capture-pane)
+    printf '%s\n' "${FM_FAKE_CAPTURE_TEXT:-}"
+    exit 0
+    ;;
   send-keys)
     if [ -n "${FM_FAKE_LAUNCH_LOG:-}" ]; then
       prev=
@@ -42,7 +46,7 @@ esac
 exit 0
 SH
   chmod +x "$fakebin/tmux"
-  fm_fake_exit0 "$fakebin" treehouse pi-signed
+  fm_fake_exit0 "$fakebin" treehouse pi-signed agy
   printf '%s\n' "$fakebin"
 }
 
@@ -92,6 +96,7 @@ run_spawn() {
     FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
     FM_PROJECTS_OVERRIDE="$home/projects" FM_CONFIG_OVERRIDE="$home/config" \
     FM_SPAWN_NO_GUARD=1 FM_FAKE_PANE_PATH="$wt" TMUX="fake,1,0" \
+    FM_AGY_LAUNCH_POLLS="${FM_TEST_AGY_LAUNCH_POLLS:-1}" \
     CLAUDE_CONFIG_DIR="${FM_TEST_CLAUDE_CONFIG_DIR:-}" \
     FM_FAKE_LAUNCH_LOG="$launchlog" GROK_HOME="$home/grok-home" PATH="$fakebin:$PATH" \
     "$SPAWN" "$@" 2>&1
@@ -482,6 +487,68 @@ test_opencode_threads_model_and_ignores_effort_axis() {
   pass "opencode receives --model and omits the unsupported effort axis"
 }
 
+test_agy_threads_model_and_ignores_effort_axis() {
+  local rec id out status launch
+  id=profile-agy-z7b
+  rec=$(make_spawn_case profile-agy agy "$id")
+  read_case_record "$rec"
+
+  out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR" \
+    --model gpt-oss-120b-medium --effort high)
+  status=$?
+  expect_code 0 "$status" "agy spawn with model and ignored effort should succeed"
+  assert_meta_profile "$HOME_DIR/state/$id.meta" agy gpt-oss-120b-medium high
+  launch=$(cat "$LAUNCH_LOG")
+  assert_contains "$launch" "agy --dangerously-skip-permissions --model 'gpt-oss-120b-medium' -i" \
+    "agy launch did not thread the model into the interactive prompt path"
+  assert_not_contains "$launch" "--effort" "agy launch must not pass a separate effort flag"
+  assert_not_contains "$launch" "__TURNEND__" "agy launch must not carry a turn-end placeholder"
+  assert_absent "$HOME_DIR/state/$id.busy-gen" "agy spawn must not arm a busy record with no hook to clear it"
+  pass "agy receives --model, uses -i, and omits the unsupported effort axis"
+}
+
+test_agy_missing_binary_refuses_before_endpoint_or_metadata() {
+  local rec id out status
+  id=profile-agy-missing-z7c
+  rec=$(make_spawn_case profile-agy-missing agy "$id")
+  read_case_record "$rec"
+  rm -f "$FAKEBIN_DIR/agy"
+  : > "$LAUNCH_LOG"
+
+  out=$(FM_ROOT_OVERRIDE='' FM_HOME="$HOME_DIR" \
+    FM_STATE_OVERRIDE="$HOME_DIR/state" FM_DATA_OVERRIDE="$HOME_DIR/data" \
+    FM_PROJECTS_OVERRIDE="$HOME_DIR/projects" FM_CONFIG_OVERRIDE="$HOME_DIR/config" \
+    FM_SPAWN_NO_GUARD=1 FM_FAKE_PANE_PATH="$WT_DIR" TMUX="fake,1,0" \
+    FM_FAKE_LAUNCH_LOG="$LAUNCH_LOG" PATH="$FAKEBIN_DIR:/usr/bin:/bin:/usr/sbin:/sbin" \
+    "$SPAWN" "$id" "$PROJ_DIR" 2>&1)
+  status=$?
+  expect_code 1 "$status" "a missing agy executable should refuse the spawn"
+  assert_contains "$out" "agy executable not found on PATH" \
+    "missing agy refusal did not name the actionable requirement"
+  assert_absent "$HOME_DIR/state/$id.meta" "missing agy refusal wrote task metadata"
+  [ ! -s "$LAUNCH_LOG" ] || fail "missing agy refusal typed a launch command"
+  pass "agy refuses safely and actionably when the selected executable is unavailable"
+}
+
+test_agy_quota_refusal_fails_loudly() {
+  local rec id out status
+  id=profile-agy-quota-z7d
+  rec=$(make_spawn_case profile-agy-quota agy "$id")
+  read_case_record "$rec"
+  export FM_TEST_AGY_LAUNCH_POLLS=1
+  export FM_FAKE_CAPTURE_TEXT='Individual quota reached. Try again in 168h.'
+  out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR" \
+    --model gemini-3.6-flash-high)
+  status=$?
+  unset FM_TEST_AGY_LAUNCH_POLLS FM_FAKE_CAPTURE_TEXT
+  expect_code 1 "$status" "agy quota exhaustion should fail the spawn"
+  assert_contains "$out" "agy account quota reached during launch" \
+    "agy quota refusal was not surfaced as an actionable spawn error"
+  assert_grep 'failed: agy account quota reached during launch' "$HOME_DIR/state/$id.status" \
+    "agy quota refusal did not append a failed status"
+  pass "agy launch quota errors are converted into loud spawn failure"
+}
+
 test_pi_threads_model_and_max_effort() {
   local rec id out status launch
   id=profile-pi-z8
@@ -684,6 +751,9 @@ test_grok_threads_model_and_reasoning_effort
 test_grok_omits_invalid_max_reasoning_effort
 test_grok_omits_invalid_xhigh_reasoning_effort
 test_opencode_threads_model_and_ignores_effort_axis
+test_agy_threads_model_and_ignores_effort_axis
+test_agy_missing_binary_refuses_before_endpoint_or_metadata
+test_agy_quota_refusal_fails_loudly
 test_pi_threads_model_and_max_effort
 test_pi_signed_threads_shared_pi_profile_and_preserves_identity
 test_pi_signed_missing_binary_refuses_before_endpoint_or_metadata

--- a/tests/fm-tmux-submit-busy.test.sh
+++ b/tests/fm-tmux-submit-busy.test.sh
@@ -254,6 +254,12 @@ test_claude_busy_signature_uses_real_capture_shapes() {
   pane_busy pi-signed pi-signed || fail "pi-signed should share Pi's exact Working footer"
   printf 'Ctrl+c:cancel\n' > "$composer"
   pane_busy grok grok || fail "Grok cancel footer should be busy"
+  printf '⠋ Working... esc to cancel\n' > "$composer"
+  pane_busy agy agy || fail "agy escape-to-cancel footer should be busy"
+  printf '⠋ Working... esc to cancel\n' > "$composer"
+  pane_busy cross codex && fail "agy footer must not classify a Codex pane busy"
+  printf 'esc to interrupt\n' > "$composer"
+  pane_busy cross agy && fail "agy must ignore Claude/Codex interrupt footers"
   pass "fm_pane_is_busy: Claude spinner is scoped, multi-frame, and backward-compatible"
 }
 


### PR DESCRIPTION
## Summary

- Add `agy` as a verified Firstmate worker adapter with harness detection, launch validation, model threading, busy-state supervision, and scoped bare-`>` composer handling.
- Record Antigravity CLI 1.1.9 evidence in `harness-adapters` and `docs/verification/runtime-backends.md`, including the no-turn-end-signal limit and quota ceiling.
- Add tests for agy identity, spawn flags, quota refusal, busy signatures, composer classification, and tmux liveness.

## Verification

- Real adapter proof: `bin/fm-spawn.sh agy-proof-v1 ... --harness agy --model gpt-oss-120b-medium`.
- Proof result: accepted the trust dialog with Enter, delivered the launch brief, appended `working:` and `done:` status lines, and exited cleanly back to `zsh` with two `Ctrl+D` keypresses.
- `bin/fm-test-run.sh --changed`: 95 scripts, 0 failed, 12 expected gate skips.
- `tests/fm-spawn-dispatch-profile.test.sh`.
- `tests/fm-public-followup.test.sh` skips cleanly when installed `tasks-axi` lacks the optional `public-followup` command.
- `bin/fm-doc-audience-check.sh`.
- `git diff --check`.
- `bash -n` on changed shell entry points.
- Full `bin/fm-lint.sh` was run with ShellCheck 0.11.0 from a temporary in-worktree install before cleanup.

## Notes

- `agy` is not added to `config/crew-dispatch.json`.
- Gemini quota remains documented as exhausted; the proof used `gpt-oss-120b-medium`.
