### PR TITLE
feat(herdr): auto-set human-readable agent/tab names on spawn

### DIFF
--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -52,9 +52,10 @@
 #
 # Authoritative task recovery/orphan discovery (ids may not deterministically match live state
 # after a server restart in a differently-configured session; see the
-# verification doc) uses LABEL matching (fm-<id> tab labels), never trusts a
-# stored pane id blindly: fm_backend_herdr_list_live. The presentation journal
-# is deliberately excluded from that path.
+# verification doc) uses LABEL matching (fm-<id> create labels and post-spawn
+# scout-/ship- display names), never trusts a stored pane id blindly:
+# fm_backend_herdr_list_live. The presentation journal is deliberately excluded
+# from that path.
 #
 # Requires: herdr (CLI + socket), jq (JSON parsing). Bootstrap detects these
 # through fm_backend_required_tools only when herdr is the resolved backend;
@@ -639,6 +640,129 @@ fm_backend_herdr_projection_concise_task_label() {  # <task-id>
     fm-*) task=${task#fm-} ;;
   esac
   printf '%s' "$task"
+}
+
+# fm_backend_herdr_display_name: pure map of (task_id, kind) to a valid Herdr
+# agent/tab display name matching ^[a-z][a-z0-9_-]{0,31}$.
+# kind=scout -> scout-<slug>; any other kind -> ship-<slug>.
+# Strips redundant fm-/scout-/ship- prefixes from the id before composing,
+# lowercases, replaces invalid characters with '-', collapses runs of '-',
+# truncates to 32 characters, and never leaves a trailing '-' or '_'.
+# Pure: no I/O. Display names are never ownership authority (recorded pane/tab
+# ids in meta remain authoritative; see docs/herdr-backend.md).
+fm_backend_herdr_display_name() {  # <task-id> <kind>
+  local id=$1 kind=$2 prefix slug out
+  case "$kind" in
+    scout) prefix=scout ;;
+    *) prefix=ship ;;
+  esac
+  id=$(printf '%s' "$id" | tr '[:upper:]' '[:lower:]')
+  while :; do
+    case "$id" in
+      fm-*) id=${id#fm-} ;;
+      scout-*) id=${id#scout-} ;;
+      ship-*) id=${id#ship-} ;;
+      *) break ;;
+    esac
+  done
+  # tr -c replaces every non-allowed char with '-'; tr -s collapses runs.
+  slug=$(printf '%s' "$id" | tr -c 'a-z0-9_-' '-' | tr -s '-')
+  while [ -n "$slug" ]; do
+    case "$slug" in
+      -*|_* ) slug=${slug#?} ;;
+      *-|*_ ) slug=${slug%?} ;;
+      *) break ;;
+    esac
+  done
+  if [ -n "$slug" ]; then
+    out="${prefix}-${slug}"
+  else
+    out=$prefix
+  fi
+  if [ "${#out}" -gt 32 ]; then
+    out=${out:0:32}
+    while [ -n "$out" ]; do
+      case "$out" in
+        *-|*_ ) out=${out%?} ;;
+        *) break ;;
+      esac
+    done
+  fi
+  case "$out" in
+    [a-z]|[a-z][a-z0-9_-]*) ;;
+    *) out=$prefix ;;
+  esac
+  if [ "${#out}" -gt 32 ] || [ -z "$out" ]; then
+    out=$prefix
+  fi
+  printf '%s' "$out"
+}
+
+# fm_backend_herdr_task_label_candidates: labels that may identify a prior
+# instance of the same task tab for husk close-and-replace. Always includes
+# the create label fm-<id> plus both role display names (scout- and ship-)
+# derived from that id, so a post-spawn tab rename does not strand husks.
+# Accepts either a bare task id or an fm-<id> create label. Prints one label
+# per line; pure aside from the display-name helper.
+fm_backend_herdr_task_label_candidates() {  # <task-id-or-fm-label>
+  local raw=$1 id scout_name ship_name
+  id=$raw
+  case "$id" in
+    fm-*) id=${id#fm-} ;;
+  esac
+  [ -n "$id" ] || return 0
+  scout_name=$(fm_backend_herdr_display_name "$id" scout)
+  ship_name=$(fm_backend_herdr_display_name "$id" ship)
+  printf 'fm-%s\n' "$id"
+  printf '%s\n' "$scout_name"
+  [ "$ship_name" = "$scout_name" ] || printf '%s\n' "$ship_name"
+}
+
+# fm_backend_herdr_apply_display_name: best-effort wait until <pane> reports a
+# registered agent, then rename the agent and tab to <name>.
+# Failures warn on stderr and never fail the spawn (exit 0 always).
+# Does not touch the primary seed tab labeled "1" (callers never pass it).
+# Polls/sleep are overridable for tests via FM_BACKEND_HERDR_DISPLAY_NAME_POLLS
+# and FM_BACKEND_HERDR_DISPLAY_NAME_SLEEP.
+fm_backend_herdr_apply_display_name() {  # <session> <pane_id> <tab_id> <name>
+  local session=$1 pane=$2 tab=$3 name=$4 state i
+  local polls=${FM_BACKEND_HERDR_DISPLAY_NAME_POLLS:-20}
+  local sleep_s=${FM_BACKEND_HERDR_DISPLAY_NAME_SLEEP:-0.25}
+  case "$name" in
+    [a-z]|[a-z][a-z0-9_-]*)
+      if [ "${#name}" -gt 32 ]; then
+        echo "warning: herdr display name '$name' exceeds 32 chars; skipping rename" >&2
+        return 0
+      fi
+      ;;
+    *)
+      echo "warning: herdr display name '$name' is invalid; skipping rename" >&2
+      return 0
+      ;;
+  esac
+  [ -n "$session" ] && [ -n "$pane" ] || {
+    echo "warning: herdr display rename missing session or pane; skipping" >&2
+    return 0
+  }
+  state=no-agent
+  for ((i = 0; i < polls; i++)); do
+    state=$(fm_backend_herdr_pane_agent_state "$session" "$pane")
+    [ "$state" = live ] && break
+    sleep "$sleep_s"
+  done
+  if [ "$state" != live ]; then
+    echo "warning: herdr agent not registered in time to rename to $name; leaving default names" >&2
+    return 0
+  fi
+  if ! fm_backend_herdr_cli "$session" agent rename "$pane" "$name" >/dev/null 2>&1; then
+    echo "warning: herdr agent rename to $name failed" >&2
+  fi
+  if [ -n "$tab" ] && [ "$tab" != 1 ]; then
+    if ! fm_backend_herdr_cli "$session" tab rename "$tab" "$name" >/dev/null 2>&1; then
+      echo "warning: herdr tab rename to $name failed" >&2
+    fi
+  fi
+  return 0
 }
 
 # fm_backend_herdr_projection_workspace_label: presentation-only child label.
@@ -1992,10 +2116,17 @@ fm_backend_herdr_agent_alive() {  # <target>
 # case. Echoes "<tab_id> <pane_id>" on success.
 fm_backend_herdr_create_task() {  # <container> <label> <cwd> <seeded_default_tab_id>
   local container=$1 label=$2 cwd=$3 seeded_tab_id=${4:-} session wsid list dup_tabs dup dup_pane dup_tab_ids out tab_id pane_id remaining_dup_tabs
+  local want_json
   session=${container%%:*}
   wsid=${container#*:}
   list=$(fm_backend_herdr_cli "$session" tab list --workspace "$wsid" 2>/dev/null) || return 1
-  dup_tabs=$(printf '%s' "$list" | jq -r --arg want "$label" 'if (.result.tabs | type) == "array" then .result.tabs[] | select(.label == $want) | .tab_id else error("missing result.tabs") end' 2>/dev/null) || {
+  # Husk/dup match uses the create label (fm-<id>) plus post-spawn display
+  # names (scout-/ship-) so a renamed tab is still found on re-spawn.
+  want_json=$(fm_backend_herdr_task_label_candidates "$label" | jq -R . | jq -s -c .) || {
+    echo "error: could not build herdr tab label candidates for '$label'" >&2
+    return 1
+  }
+  dup_tabs=$(printf '%s' "$list" | jq -r --argjson want "$want_json" 'if (.result.tabs | type) == "array" then .result.tabs[] | select(.label as $l | ($want | index($l)) != null) | .tab_id else error("missing result.tabs") end' 2>/dev/null) || {
     echo "error: could not parse herdr tab list output for workspace $wsid (session $session)" >&2
     return 1
   }
@@ -2036,8 +2167,8 @@ EOF
       echo "error: could not parse herdr tab list output for workspace $wsid (session $session)" >&2
       return 1
     fi
-    remaining_dup_tabs=$(printf '%s' "$list" | jq -r --arg want "$label" --arg replacement "$tab_id" \
-      '.result.tabs[]? | select(.label == $want and .tab_id != $replacement) | .tab_id' 2>/dev/null)
+    remaining_dup_tabs=$(printf '%s' "$list" | jq -r --argjson want "$want_json" --arg replacement "$tab_id" \
+      '.result.tabs[]? | select((.label as $l | ($want | index($l)) != null) and .tab_id != $replacement) | .tab_id' 2>/dev/null)
     remaining_dup_tabs=${remaining_dup_tabs//$'\n'/ }
     if [ -n "$remaining_dup_tabs" ]; then
       echo "error: failed to remove preexisting herdr tab(s) $remaining_dup_tabs for label '$label' in workspace $wsid (session $session)" >&2
@@ -3220,15 +3351,16 @@ EOF
 }
 
 # fm_backend_herdr_list_live: recovery/orphan discovery. Lists every tab whose
-# label looks like a firstmate task window (fm-<id>) in <session>'s, THIS
-# HOME'S OWN workspace (fm_backend_herdr_workspace_label - never another
-# home's), by LABEL - never by trusting a stored pane id, since ids are not
-# guaranteed stable across every server lifecycle (see herdr-verification-p2.md
-# "ID stability"). A caller running as a given home (e.g. a secondmate
-# recovering its own in-flight work) naturally scopes to that home's own
-# workspace because FM_HOME already names it - no glue needed, unlike the
-# primary-spawns-a-secondmate path in fm-spawn.sh. Read-only: a session/
-# workspace that does not exist yet simply lists nothing. One
+# label looks like a firstmate task window in <session>'s, THIS HOME'S OWN
+# workspace (fm_backend_herdr_workspace_label - never another home's), by
+# LABEL - never by trusting a stored pane id, since ids are not guaranteed
+# stable across every server lifecycle (see herdr-verification-p2.md
+# "ID stability"). Matches create labels (fm-<id>) and post-spawn human
+# display names (scout-<slug>, ship-<slug>). A caller running as a given home
+# (e.g. a secondmate recovering its own in-flight work) naturally scopes to
+# that home's own workspace because FM_HOME already names it - no glue needed,
+# unlike the primary-spawns-a-secondmate path in fm-spawn.sh. Read-only: a
+# session/workspace that does not exist yet simply lists nothing. One
 # "<session>:<pane_id>\t<label>" line per live task tab.
 fm_backend_herdr_list_live() {  # <session>
   local session=$1 wsid tabs tab_id label pane_id
@@ -3240,7 +3372,7 @@ fm_backend_herdr_list_live() {  # <session>
     pane_id=$(fm_backend_herdr_pane_for_tab "$session" "$wsid" "$tab_id") || continue
     [ -n "$pane_id" ] || continue
     printf '%s:%s\t%s\n' "$session" "$pane_id" "$label"
-  done < <(printf '%s' "$tabs" | jq -r '.result.tabs[]? | select(.label | startswith("fm-")) | "\(.tab_id)\t\(.label)"' 2>/dev/null)
+  done < <(printf '%s' "$tabs" | jq -r '.result.tabs[]? | select((.label | type) == "string" and (.label | test("^(fm|scout|ship)-"))) | "\(.tab_id)\t\(.label)"' 2>/dev/null)
 }
 
 # --- native event push: pane.agent_status_changed subscriber -----------------

--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -52,10 +52,9 @@
 #
 # Authoritative task recovery/orphan discovery (ids may not deterministically match live state
 # after a server restart in a differently-configured session; see the
-# verification doc) uses LABEL matching (fm-<id> create labels and post-spawn
-# scout-/ship- display names), never trusts a stored pane id blindly:
-# fm_backend_herdr_list_live. The presentation journal is deliberately excluded
-# from that path.
+# verification doc) uses LABEL matching (fm-<id> tab labels), never trusts a
+# stored pane id blindly: fm_backend_herdr_list_live. The presentation journal
+# is deliberately excluded from that path.
 #
 # Requires: herdr (CLI + socket), jq (JSON parsing). Bootstrap detects these
 # through fm_backend_required_tools only when herdr is the resolved backend;
@@ -689,7 +688,8 @@ fm_backend_herdr_display_name() {  # <task-id> <kind>
     done
   fi
   case "$out" in
-    [a-z]|[a-z][a-z0-9_-]*) ;;
+    [a-z]*[!a-z0-9_-]*) out=$prefix ;;
+    [a-z]*) ;;
     *) out=$prefix ;;
   esac
   if [ "${#out}" -gt 32 ] || [ -z "$out" ]; then
@@ -698,48 +698,33 @@ fm_backend_herdr_display_name() {  # <task-id> <kind>
   printf '%s' "$out"
 }
 
-# fm_backend_herdr_task_label_candidates: labels that may identify a prior
-# instance of the same task tab for husk close-and-replace. Always includes
-# the create label fm-<id> plus both role display names (scout- and ship-)
-# derived from that id, so a post-spawn tab rename does not strand husks.
-# Accepts either a bare task id or an fm-<id> create label. Prints one label
-# per line; pure aside from the display-name helper.
-fm_backend_herdr_task_label_candidates() {  # <task-id-or-fm-label>
-  local raw=$1 id scout_name ship_name
-  id=$raw
-  case "$id" in
-    fm-*) id=${id#fm-} ;;
-  esac
-  [ -n "$id" ] || return 0
-  scout_name=$(fm_backend_herdr_display_name "$id" scout)
-  ship_name=$(fm_backend_herdr_display_name "$id" ship)
-  printf 'fm-%s\n' "$id"
-  printf '%s\n' "$scout_name"
-  [ "$ship_name" = "$scout_name" ] || printf '%s\n' "$ship_name"
-}
-
 # fm_backend_herdr_apply_display_name: best-effort wait until <pane> reports a
-# registered agent, then rename the agent and tab to <name>.
+# registered agent, then rename that AGENT (the agents-sidebar entry) to <name>.
+# Tabs are deliberately never renamed: the tab label fm-<id> is the injective
+# identity husk reclaim and fm_backend_herdr_list_live match on, and display
+# names are lossy (lowercased, sanitized, truncated to 32) so two distinct task
+# ids can share one. Renaming a tab to a display name would let one task's
+# reclaim match another task's tab.
 # Failures warn on stderr and never fail the spawn (exit 0 always).
-# Does not touch the primary seed tab labeled "1" (callers never pass it).
 # Polls/sleep are overridable for tests via FM_BACKEND_HERDR_DISPLAY_NAME_POLLS
 # and FM_BACKEND_HERDR_DISPLAY_NAME_SLEEP.
-fm_backend_herdr_apply_display_name() {  # <session> <pane_id> <tab_id> <name>
-  local session=$1 pane=$2 tab=$3 name=$4 state i
+fm_backend_herdr_apply_display_name() {  # <session> <pane_id> <name>
+  local session=$1 pane=$2 name=$3 state i
   local polls=${FM_BACKEND_HERDR_DISPLAY_NAME_POLLS:-20}
   local sleep_s=${FM_BACKEND_HERDR_DISPLAY_NAME_SLEEP:-0.25}
+  # Reject anything outside ^[a-z][a-z0-9_-]{0,31}$. A trailing bare * in a glob
+  # matches ANY characters, so the grammar is enforced as a rejection pattern
+  # (an invalid char anywhere) plus a first-character check, not as a repeat.
   case "$name" in
-    [a-z]|[a-z][a-z0-9_-]*)
-      if [ "${#name}" -gt 32 ]; then
-        echo "warning: herdr display name '$name' exceeds 32 chars; skipping rename" >&2
-        return 0
-      fi
-      ;;
-    *)
+    [a-z]*[!a-z0-9_-]*|[!a-z]*|"")
       echo "warning: herdr display name '$name' is invalid; skipping rename" >&2
       return 0
       ;;
   esac
+  if [ "${#name}" -gt 32 ]; then
+    echo "warning: herdr display name '$name' exceeds 32 chars; skipping rename" >&2
+    return 0
+  fi
   [ -n "$session" ] && [ -n "$pane" ] || {
     echo "warning: herdr display rename missing session or pane; skipping" >&2
     return 0
@@ -747,8 +732,13 @@ fm_backend_herdr_apply_display_name() {  # <session> <pane_id> <tab_id> <name>
   state=no-agent
   for ((i = 0; i < polls; i++)); do
     state=$(fm_backend_herdr_pane_agent_state "$session" "$pane")
-    [ "$state" = live ] && break
-    sleep "$sleep_s"
+    # dead is structural and terminal: no agent will ever register there.
+    if [ "$state" = live ] || [ "$state" = dead ]; then
+      break
+    fi
+    if [ "$((i + 1))" -lt "$polls" ]; then
+      sleep "$sleep_s"
+    fi
   done
   if [ "$state" != live ]; then
     echo "warning: herdr agent not registered in time to rename to $name; leaving default names" >&2
@@ -756,11 +746,6 @@ fm_backend_herdr_apply_display_name() {  # <session> <pane_id> <tab_id> <name>
   fi
   if ! fm_backend_herdr_cli "$session" agent rename "$pane" "$name" >/dev/null 2>&1; then
     echo "warning: herdr agent rename to $name failed" >&2
-  fi
-  if [ -n "$tab" ] && [ "$tab" != 1 ]; then
-    if ! fm_backend_herdr_cli "$session" tab rename "$tab" "$name" >/dev/null 2>&1; then
-      echo "warning: herdr tab rename to $name failed" >&2
-    fi
   fi
   return 0
 }
@@ -2116,17 +2101,14 @@ fm_backend_herdr_agent_alive() {  # <target>
 # case. Echoes "<tab_id> <pane_id>" on success.
 fm_backend_herdr_create_task() {  # <container> <label> <cwd> <seeded_default_tab_id>
   local container=$1 label=$2 cwd=$3 seeded_tab_id=${4:-} session wsid list dup_tabs dup dup_pane dup_tab_ids out tab_id pane_id remaining_dup_tabs
-  local want_json
   session=${container%%:*}
   wsid=${container#*:}
   list=$(fm_backend_herdr_cli "$session" tab list --workspace "$wsid" 2>/dev/null) || return 1
-  # Husk/dup match uses the create label (fm-<id>) plus post-spawn display
-  # names (scout-/ship-) so a renamed tab is still found on re-spawn.
-  want_json=$(fm_backend_herdr_task_label_candidates "$label" | jq -R . | jq -s -c .) || {
-    echo "error: could not build herdr tab label candidates for '$label'" >&2
-    return 1
-  }
-  dup_tabs=$(printf '%s' "$list" | jq -r --argjson want "$want_json" 'if (.result.tabs | type) == "array" then .result.tabs[] | select(.label as $l | ($want | index($l)) != null) | .tab_id else error("missing result.tabs") end' 2>/dev/null) || {
+  # Husk/dup match is exact equality on the create label fm-<id>. Tabs are never
+  # renamed post-spawn (only the agent is - see fm_backend_herdr_apply_display_name),
+  # so this label stays an injective task identity and can never match a
+  # different task's tab.
+  dup_tabs=$(printf '%s' "$list" | jq -r --arg want "$label" 'if (.result.tabs | type) == "array" then .result.tabs[] | select(.label == $want) | .tab_id else error("missing result.tabs") end' 2>/dev/null) || {
     echo "error: could not parse herdr tab list output for workspace $wsid (session $session)" >&2
     return 1
   }
@@ -2167,8 +2149,8 @@ EOF
       echo "error: could not parse herdr tab list output for workspace $wsid (session $session)" >&2
       return 1
     fi
-    remaining_dup_tabs=$(printf '%s' "$list" | jq -r --argjson want "$want_json" --arg replacement "$tab_id" \
-      '.result.tabs[]? | select((.label as $l | ($want | index($l)) != null) and .tab_id != $replacement) | .tab_id' 2>/dev/null)
+    remaining_dup_tabs=$(printf '%s' "$list" | jq -r --arg want "$label" --arg replacement "$tab_id" \
+      '.result.tabs[]? | select(.label == $want and .tab_id != $replacement) | .tab_id' 2>/dev/null)
     remaining_dup_tabs=${remaining_dup_tabs//$'\n'/ }
     if [ -n "$remaining_dup_tabs" ]; then
       echo "error: failed to remove preexisting herdr tab(s) $remaining_dup_tabs for label '$label' in workspace $wsid (session $session)" >&2
@@ -3351,15 +3333,16 @@ EOF
 }
 
 # fm_backend_herdr_list_live: recovery/orphan discovery. Lists every tab whose
-# label looks like a firstmate task window in <session>'s, THIS HOME'S OWN
-# workspace (fm_backend_herdr_workspace_label - never another home's), by
-# LABEL - never by trusting a stored pane id, since ids are not guaranteed
-# stable across every server lifecycle (see herdr-verification-p2.md
-# "ID stability"). Matches create labels (fm-<id>) and post-spawn human
-# display names (scout-<slug>, ship-<slug>). A caller running as a given home
-# (e.g. a secondmate recovering its own in-flight work) naturally scopes to
-# that home's own workspace because FM_HOME already names it - no glue needed,
-# unlike the primary-spawns-a-secondmate path in fm-spawn.sh. Read-only: a
+# label looks like a firstmate task window (fm-<id>) in <session>'s, THIS
+# HOME'S OWN workspace (fm_backend_herdr_workspace_label - never another
+# home's), by LABEL - never by trusting a stored pane id, since ids are not
+# guaranteed stable across every server lifecycle (see herdr-verification-p2.md
+# "ID stability"). Tabs keep their fm-<id> create label for life (only the
+# agent is renamed post-spawn), so the emitted label stays exactly reversible
+# to a task id. A caller running as a given home (e.g. a secondmate
+# recovering its own in-flight work) naturally scopes to that home's own
+# workspace because FM_HOME already names it - no glue needed, unlike the
+# primary-spawns-a-secondmate path in fm-spawn.sh. Read-only: a
 # session/workspace that does not exist yet simply lists nothing. One
 # "<session>:<pane_id>\t<label>" line per live task tab.
 fm_backend_herdr_list_live() {  # <session>
@@ -3372,7 +3355,7 @@ fm_backend_herdr_list_live() {  # <session>
     pane_id=$(fm_backend_herdr_pane_for_tab "$session" "$wsid" "$tab_id") || continue
     [ -n "$pane_id" ] || continue
     printf '%s:%s\t%s\n' "$session" "$pane_id" "$label"
-  done < <(printf '%s' "$tabs" | jq -r '.result.tabs[]? | select((.label | type) == "string" and (.label | test("^(fm|scout|ship)-"))) | "\(.tab_id)\t\(.label)"' 2>/dev/null)
+  done < <(printf '%s' "$tabs" | jq -r '.result.tabs[]? | select((.label | type) == "string" and (.label | startswith("fm-"))) | "\(.tab_id)\t\(.label)"' 2>/dev/null)
 }
 
 # --- native event push: pane.agent_status_changed subscriber -----------------

--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -698,6 +698,75 @@ fm_backend_herdr_display_name() {  # <task-id> <kind>
   printf '%s' "$out"
 }
 
+# fm_backend_herdr_display_name_digest: 6 lowercase hex characters derived
+# deterministically from the FULL (untruncated) task id, so two ids that share
+# a truncated display-name prefix still diverge. Pure apart from the hashing
+# binary; returns non-zero when no usable hasher is available.
+fm_backend_herdr_display_name_digest() {  # <task-id>
+  local id=$1 hash=
+  if command -v shasum >/dev/null 2>&1; then
+    hash=$(printf '%s' "$id" | shasum -a 256 2>/dev/null | awk '{print $1}')
+  elif command -v sha256sum >/dev/null 2>&1; then
+    hash=$(printf '%s' "$id" | sha256sum 2>/dev/null | awk '{print $1}')
+  elif command -v cksum >/dev/null 2>&1; then
+    hash=$(printf '%s' "$id" | cksum 2>/dev/null | awk '{printf "%08x", $1}')
+  fi
+  case "$hash" in
+    ''|*[!0-9a-f]*) return 1 ;;
+  esac
+  [ "${#hash}" -ge 6 ] || return 1
+  printf '%s' "${hash:0:6}"
+}
+
+# fm_backend_herdr_display_name_disambiguate: rewrite an already-valid display
+# <name> into a distinct one for <task-id> by trading the tail of the name for
+# a stable digest of the untruncated id, staying inside ^[a-z][a-z0-9_-]{0,31}$.
+# Deterministic: the same task id always yields the same disambiguated name, so
+# retries and relaunches never churn the sidebar entry.
+fm_backend_herdr_display_name_disambiguate() {  # <name> <task-id>
+  local name=$1 id=$2 digest base budget out
+  [ -n "$name" ] && [ -n "$id" ] || return 1
+  digest=$(fm_backend_herdr_display_name_digest "$id") || return 1
+  budget=$((32 - ${#digest} - 1))
+  [ "$budget" -gt 0 ] || return 1
+  base=$name
+  if [ "${#base}" -gt "$budget" ]; then
+    base=${base:0:budget}
+  fi
+  while [ -n "$base" ]; do
+    case "$base" in
+      *-|*_ ) base=${base%?} ;;
+      *) break ;;
+    esac
+  done
+  [ -n "$base" ] || return 1
+  out="${base}-${digest}"
+  case "$out" in
+    [a-z]*[!a-z0-9_-]*|[!a-z]*) return 1 ;;
+  esac
+  [ "${#out}" -le 32 ] || return 1
+  [ "$out" != "$name" ] || return 1
+  printf '%s' "$out"
+}
+
+# fm_backend_herdr_live_agent_names: one currently-registered agent display name
+# per line for <session>, skipping the agent in <self-pane-id> (our own pane, if
+# it already carries a name) so a re-run never collides with itself. Read-only.
+# Non-zero when herdr cannot be asked or the response cannot be parsed, which
+# callers treat as "cannot tell" rather than "no collision".
+fm_backend_herdr_live_agent_names() {  # <session> [<self-pane-id>]
+  local session=$1 self=${2:-} out
+  out=$(fm_backend_herdr_cli "$session" agent list 2>/dev/null) || return 1
+  printf '%s' "$out" | jq -r --arg self "$self" '
+    if (.result.agents | type) == "array" then
+      .result.agents[]
+      | select((.pane_id // "") != $self)
+      | .name
+      | select(type == "string" and . != "")
+    else error("missing result.agents") end
+  ' 2>/dev/null
+}
+
 # fm_backend_herdr_apply_display_name: best-effort wait until <pane> reports a
 # registered agent, then rename that AGENT (the agents-sidebar entry) to <name>.
 # Tabs are deliberately never renamed: the tab label fm-<id> is the injective
@@ -705,11 +774,16 @@ fm_backend_herdr_display_name() {  # <task-id> <kind>
 # names are lossy (lowercased, sanitized, truncated to 32) so two distinct task
 # ids can share one. Renaming a tab to a display name would let one task's
 # reclaim match another task's tab.
+# Herdr requires agent names be unique among live agents, and display names are
+# lossy, so <name> can already be taken by another live task. When <task-id> is
+# supplied the collision is detected against the live agent list first and the
+# name is deterministically disambiguated with a digest of the untruncated id
+# rather than sent to a rename herdr is certain to reject.
 # Failures warn on stderr and never fail the spawn (exit 0 always).
 # Polls/sleep are overridable for tests via FM_BACKEND_HERDR_DISPLAY_NAME_POLLS
 # and FM_BACKEND_HERDR_DISPLAY_NAME_SLEEP.
-fm_backend_herdr_apply_display_name() {  # <session> <pane_id> <name>
-  local session=$1 pane=$2 name=$3 state i
+fm_backend_herdr_apply_display_name() {  # <session> <pane_id> <name> [<task-id>]
+  local session=$1 pane=$2 name=$3 id=${4:-} state i names alt final
   local polls=${FM_BACKEND_HERDR_DISPLAY_NAME_POLLS:-20}
   local sleep_s=${FM_BACKEND_HERDR_DISPLAY_NAME_SLEEP:-0.25}
   # Reject anything outside ^[a-z][a-z0-9_-]{0,31}$. A trailing bare * in a glob
@@ -744,8 +818,20 @@ fm_backend_herdr_apply_display_name() {  # <session> <pane_id> <name>
     echo "warning: herdr agent not registered in time to rename to $name; leaving default names" >&2
     return 0
   fi
-  if ! fm_backend_herdr_cli "$session" agent rename "$pane" "$name" >/dev/null 2>&1; then
-    echo "warning: herdr agent rename to $name failed" >&2
+  final=$name
+  if names=$(fm_backend_herdr_live_agent_names "$session" "$pane"); then
+    if printf '%s\n' "$names" | grep -Fxq -- "$name"; then
+      if alt=$(fm_backend_herdr_display_name_disambiguate "$name" "$id") \
+        && ! printf '%s\n' "$names" | grep -Fxq -- "$alt"; then
+        final=$alt
+      else
+        echo "warning: herdr display name $name is already taken by a live agent and could not be disambiguated; leaving default names" >&2
+        return 0
+      fi
+    fi
+  fi
+  if ! fm_backend_herdr_cli "$session" agent rename "$pane" "$final" >/dev/null 2>&1; then
+    echo "warning: herdr agent rename to $final failed" >&2
   fi
   return 0
 }

--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -641,20 +641,58 @@ fm_backend_herdr_projection_concise_task_label() {  # <task-id>
   printf '%s' "$task"
 }
 
+# fm_backend_herdr_display_name_digest: 6 lowercase hex characters derived
+# deterministically from the FULL (untruncated, unsanitized) task id, so two ids
+# that share a truncated or sanitized display-name stem still diverge. Pure
+# apart from the hashing binary; returns non-zero when no hasher is available.
+fm_backend_herdr_display_name_digest() {  # <task-id>
+  local id=$1 hash=
+  if command -v shasum >/dev/null 2>&1; then
+    hash=$(printf '%s' "$id" | shasum -a 256 2>/dev/null | awk '{print $1}')
+  elif command -v sha256sum >/dev/null 2>&1; then
+    hash=$(printf '%s' "$id" | sha256sum 2>/dev/null | awk '{print $1}')
+  elif command -v cksum >/dev/null 2>&1; then
+    hash=$(printf '%s' "$id" | cksum 2>/dev/null | awk '{printf "%08x", $1}')
+  fi
+  case "$hash" in
+    ''|*[!0-9a-f]*) return 1 ;;
+  esac
+  [ "${#hash}" -ge 6 ] || return 1
+  printf '%s' "${hash:0:6}"
+}
+
 # fm_backend_herdr_display_name: pure map of (task_id, kind) to a valid Herdr
-# agent/tab display name matching ^[a-z][a-z0-9_-]{0,31}$.
-# kind=scout -> scout-<slug>; any other kind -> ship-<slug>.
+# agent display name matching ^[a-z][a-z0-9_-]{0,31}$.
+# kind=scout -> scout-<stem>-<digest>; any other kind -> ship-<stem>-<digest>.
 # Strips redundant fm-/scout-/ship- prefixes from the id before composing,
 # lowercases, replaces invalid characters with '-', collapses runs of '-',
-# truncates to 32 characters, and never leaves a trailing '-' or '_'.
-# Pure: no I/O. Display names are never ownership authority (recorded pane/tab
-# ids in meta remain authoritative; see docs/herdr-backend.md).
+# truncates the stem to leave room for the digest, and never leaves a trailing
+# '-' or '_'.
+# The digest is appended UNCONDITIONALLY, for every task, never only for ids
+# observed to collide. Herdr requires agent names be unique among live agents,
+# and the stem is a lossy many-to-one map of the id, so two tasks whose ids
+# differ only past the truncation point (or only in characters the sanitizer
+# folds) would otherwise land on one name and the second rename would be
+# rejected. Deciding that from a live agent-name query instead would be both
+# racy (two concurrent spawns each observe no collision) and environment-
+# dependent (the same id renames differently depending on who happens to be
+# live), so no such query exists: the name is a function of the task id alone
+# and a relaunch of the same task always reproduces it.
+# Pure: no I/O beyond hashing the id. Display names are never ownership
+# authority (recorded pane/tab ids in meta remain authoritative; see
+# docs/herdr-backend.md).
 fm_backend_herdr_display_name() {  # <task-id> <kind>
-  local id=$1 kind=$2 prefix slug out
+  local id=$1 kind=$2 prefix slug out digest budget
   case "$kind" in
     scout) prefix=scout ;;
     *) prefix=ship ;;
   esac
+  digest=$(fm_backend_herdr_display_name_digest "$1") || digest=
+  if [ -n "$digest" ]; then
+    budget=$((32 - ${#digest} - 1))
+  else
+    budget=32
+  fi
   id=$(printf '%s' "$id" | tr '[:upper:]' '[:lower:]')
   while :; do
     case "$id" in
@@ -678,8 +716,8 @@ fm_backend_herdr_display_name() {  # <task-id> <kind>
   else
     out=$prefix
   fi
-  if [ "${#out}" -gt 32 ]; then
-    out=${out:0:32}
+  if [ "${#out}" -gt "$budget" ]; then
+    out=${out:0:budget}
     while [ -n "$out" ]; do
       case "$out" in
         *-|*_ ) out=${out%?} ;;
@@ -687,6 +725,8 @@ fm_backend_herdr_display_name() {  # <task-id> <kind>
       esac
     done
   fi
+  [ -n "$out" ] || out=$prefix
+  [ -z "$digest" ] || out="${out}-${digest}"
   case "$out" in
     [a-z]*[!a-z0-9_-]*) out=$prefix ;;
     [a-z]*) ;;
@@ -698,75 +738,6 @@ fm_backend_herdr_display_name() {  # <task-id> <kind>
   printf '%s' "$out"
 }
 
-# fm_backend_herdr_display_name_digest: 6 lowercase hex characters derived
-# deterministically from the FULL (untruncated) task id, so two ids that share
-# a truncated display-name prefix still diverge. Pure apart from the hashing
-# binary; returns non-zero when no usable hasher is available.
-fm_backend_herdr_display_name_digest() {  # <task-id>
-  local id=$1 hash=
-  if command -v shasum >/dev/null 2>&1; then
-    hash=$(printf '%s' "$id" | shasum -a 256 2>/dev/null | awk '{print $1}')
-  elif command -v sha256sum >/dev/null 2>&1; then
-    hash=$(printf '%s' "$id" | sha256sum 2>/dev/null | awk '{print $1}')
-  elif command -v cksum >/dev/null 2>&1; then
-    hash=$(printf '%s' "$id" | cksum 2>/dev/null | awk '{printf "%08x", $1}')
-  fi
-  case "$hash" in
-    ''|*[!0-9a-f]*) return 1 ;;
-  esac
-  [ "${#hash}" -ge 6 ] || return 1
-  printf '%s' "${hash:0:6}"
-}
-
-# fm_backend_herdr_display_name_disambiguate: rewrite an already-valid display
-# <name> into a distinct one for <task-id> by trading the tail of the name for
-# a stable digest of the untruncated id, staying inside ^[a-z][a-z0-9_-]{0,31}$.
-# Deterministic: the same task id always yields the same disambiguated name, so
-# retries and relaunches never churn the sidebar entry.
-fm_backend_herdr_display_name_disambiguate() {  # <name> <task-id>
-  local name=$1 id=$2 digest base budget out
-  [ -n "$name" ] && [ -n "$id" ] || return 1
-  digest=$(fm_backend_herdr_display_name_digest "$id") || return 1
-  budget=$((32 - ${#digest} - 1))
-  [ "$budget" -gt 0 ] || return 1
-  base=$name
-  if [ "${#base}" -gt "$budget" ]; then
-    base=${base:0:budget}
-  fi
-  while [ -n "$base" ]; do
-    case "$base" in
-      *-|*_ ) base=${base%?} ;;
-      *) break ;;
-    esac
-  done
-  [ -n "$base" ] || return 1
-  out="${base}-${digest}"
-  case "$out" in
-    [a-z]*[!a-z0-9_-]*|[!a-z]*) return 1 ;;
-  esac
-  [ "${#out}" -le 32 ] || return 1
-  [ "$out" != "$name" ] || return 1
-  printf '%s' "$out"
-}
-
-# fm_backend_herdr_live_agent_names: one currently-registered agent display name
-# per line for <session>, skipping the agent in <self-pane-id> (our own pane, if
-# it already carries a name) so a re-run never collides with itself. Read-only.
-# Non-zero when herdr cannot be asked or the response cannot be parsed, which
-# callers treat as "cannot tell" rather than "no collision".
-fm_backend_herdr_live_agent_names() {  # <session> [<self-pane-id>]
-  local session=$1 self=${2:-} out
-  out=$(fm_backend_herdr_cli "$session" agent list 2>/dev/null) || return 1
-  printf '%s' "$out" | jq -r --arg self "$self" '
-    if (.result.agents | type) == "array" then
-      .result.agents[]
-      | select((.pane_id // "") != $self)
-      | .name
-      | select(type == "string" and . != "")
-    else error("missing result.agents") end
-  ' 2>/dev/null
-}
-
 # fm_backend_herdr_apply_display_name: best-effort wait until <pane> reports a
 # registered agent, then rename that AGENT (the agents-sidebar entry) to <name>.
 # Tabs are deliberately never renamed: the tab label fm-<id> is the injective
@@ -774,16 +745,14 @@ fm_backend_herdr_live_agent_names() {  # <session> [<self-pane-id>]
 # names are lossy (lowercased, sanitized, truncated to 32) so two distinct task
 # ids can share one. Renaming a tab to a display name would let one task's
 # reclaim match another task's tab.
-# Herdr requires agent names be unique among live agents, and display names are
-# lossy, so <name> can already be taken by another live task. When <task-id> is
-# supplied the collision is detected against the live agent list first and the
-# name is deterministically disambiguated with a digest of the untruncated id
-# rather than sent to a rename herdr is certain to reject.
+# Uniqueness among live agents is already carried by the name itself: every
+# display name ends in a digest of its own task id (fm_backend_herdr_display_name),
+# so no live agent-name query happens here and there is no check-then-act window.
 # Failures warn on stderr and never fail the spawn (exit 0 always).
 # Polls/sleep are overridable for tests via FM_BACKEND_HERDR_DISPLAY_NAME_POLLS
 # and FM_BACKEND_HERDR_DISPLAY_NAME_SLEEP.
-fm_backend_herdr_apply_display_name() {  # <session> <pane_id> <name> [<task-id>]
-  local session=$1 pane=$2 name=$3 id=${4:-} state i names alt final
+fm_backend_herdr_apply_display_name() {  # <session> <pane_id> <name>
+  local session=$1 pane=$2 name=$3 state i
   local polls=${FM_BACKEND_HERDR_DISPLAY_NAME_POLLS:-20}
   local sleep_s=${FM_BACKEND_HERDR_DISPLAY_NAME_SLEEP:-0.25}
   # Reject anything outside ^[a-z][a-z0-9_-]{0,31}$. A trailing bare * in a glob
@@ -818,20 +787,8 @@ fm_backend_herdr_apply_display_name() {  # <session> <pane_id> <name> [<task-id>
     echo "warning: herdr agent not registered in time to rename to $name; leaving default names" >&2
     return 0
   fi
-  final=$name
-  if names=$(fm_backend_herdr_live_agent_names "$session" "$pane"); then
-    if printf '%s\n' "$names" | grep -Fxq -- "$name"; then
-      if alt=$(fm_backend_herdr_display_name_disambiguate "$name" "$id") \
-        && ! printf '%s\n' "$names" | grep -Fxq -- "$alt"; then
-        final=$alt
-      else
-        echo "warning: herdr display name $name is already taken by a live agent and could not be disambiguated; leaving default names" >&2
-        return 0
-      fi
-    fi
-  fi
-  if ! fm_backend_herdr_cli "$session" agent rename "$pane" "$final" >/dev/null 2>&1; then
-    echo "warning: herdr agent rename to $final failed" >&2
+  if ! fm_backend_herdr_cli "$session" agent rename "$pane" "$name" >/dev/null 2>&1; then
+    echo "warning: herdr agent rename to $name failed" >&2
   fi
   return 0
 }

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -2476,7 +2476,7 @@ fi
 preserve_relaunch_meta() {
   awk -F= '
     BEGIN {
-      split("window endpoint_task_id worktree project harness kind mode yolo tasktmp model effort busy_gen traceparent backend herdr_session herdr_workspace_id herdr_tab_id herdr_pane_id zellij_session zellij_tab_id zellij_pane_id orca_worktree_id terminal cmux_workspace_id cmux_surface_id home projects control_relaunch_tx", keys, " ")
+      split("window endpoint_task_id worktree project harness kind mode yolo tasktmp model effort busy_gen traceparent backend herdr_session herdr_workspace_id herdr_tab_id herdr_pane_id herdr_display_name zellij_session zellij_tab_id zellij_pane_id orca_worktree_id terminal cmux_workspace_id cmux_surface_id home projects control_relaunch_tx", keys, " ")
       for (i in keys) owned[keys[i]] = 1
     }
     !($1 in owned)
@@ -2505,11 +2505,13 @@ preserve_relaunch_meta() {
     echo "herdr_workspace_id=$HERDR_WORKSPACE_ID"
     echo "herdr_tab_id=$HERDR_TAB_ID"
     echo "herdr_pane_id=$HERDR_PANE_ID"
-    # Human-readable agents-sidebar / tab display name (not ownership authority).
+    # Human-readable agents-sidebar display name (not ownership authority).
     # Computed for ship/scout only; secondmates keep the default Herdr names.
     if [ "$KIND" != secondmate ]; then
       HERDR_DISPLAY_NAME=$(fm_backend_herdr_display_name "$ID" "$KIND")
-      [ -n "$HERDR_DISPLAY_NAME" ] && echo "herdr_display_name=$HERDR_DISPLAY_NAME"
+      if [ -n "$HERDR_DISPLAY_NAME" ]; then
+        echo "herdr_display_name=$HERDR_DISPLAY_NAME"
+      fi
     fi
   fi
   if [ "$BACKEND" = zellij ]; then
@@ -2648,17 +2650,15 @@ if [ "${HERDR_PROJECTED:-0}" -eq 1 ]; then
   spawn_herdr_presentation_order_lock_release
 fi
 spawn_send_key "$T" Enter
-# Best-effort Herdr agents-sidebar (and tab) rename after the harness has been
-# launched. Wait until the pane registers an agent; rename failures never fail
-# the spawn. Secondmates are out of scope. Ownership stays on recorded pane/tab
-# ids in meta (docs/herdr-backend.md).
+# Best-effort Herdr agents-sidebar rename after the harness has been launched.
+# Wait until the pane registers an agent; rename failures never fail the spawn.
+# Secondmates are out of scope. The TAB is never renamed - its fm-<id> create
+# label is the identity husk reclaim and list_live match on, and display names
+# are lossy. Ownership stays on recorded pane/tab ids in meta
+# (docs/herdr-backend.md).
 if [ "$BACKEND" = herdr ] && [ "$KIND" != secondmate ] && [ -n "${HERDR_DISPLAY_NAME:-}" ]; then
-  HERDR_RENAME_TAB_ID=$HERDR_TAB_ID
-  if [ "${HERDR_PROJECTED:-0}" -eq 1 ]; then
-    HERDR_RENAME_TAB_ID=
-  fi
   fm_backend_herdr_apply_display_name \
-    "$HERDR_SES" "$HERDR_PANE_ID" "$HERDR_RENAME_TAB_ID" "$HERDR_DISPLAY_NAME" || true
+    "$HERDR_SES" "$HERDR_PANE_ID" "$HERDR_DISPLAY_NAME" || true
 fi
 if [ "$HARNESS" = kimi ]; then
   if ! kimi_wait_for_ready; then

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -2655,10 +2655,11 @@ spawn_send_key "$T" Enter
 # Secondmates are out of scope. The TAB is never renamed - its fm-<id> create
 # label is the identity husk reclaim and list_live match on, and display names
 # are lossy. Ownership stays on recorded pane/tab ids in meta
-# (docs/herdr-backend.md).
+# (docs/herdr-backend.md). The task id is passed so a name already taken by
+# another live agent can be deterministically disambiguated from it.
 if [ "$BACKEND" = herdr ] && [ "$KIND" != secondmate ] && [ -n "${HERDR_DISPLAY_NAME:-}" ]; then
   fm_backend_herdr_apply_display_name \
-    "$HERDR_SES" "$HERDR_PANE_ID" "$HERDR_DISPLAY_NAME" || true
+    "$HERDR_SES" "$HERDR_PANE_ID" "$HERDR_DISPLAY_NAME" "$ID" || true
 fi
 if [ "$HARNESS" = kimi ]; then
   if ! kimi_wait_for_ready; then

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -2655,11 +2655,10 @@ spawn_send_key "$T" Enter
 # Secondmates are out of scope. The TAB is never renamed - its fm-<id> create
 # label is the identity husk reclaim and list_live match on, and display names
 # are lossy. Ownership stays on recorded pane/tab ids in meta
-# (docs/herdr-backend.md). The task id is passed so a name already taken by
-# another live agent can be deterministically disambiguated from it.
+# (docs/herdr-backend.md).
 if [ "$BACKEND" = herdr ] && [ "$KIND" != secondmate ] && [ -n "${HERDR_DISPLAY_NAME:-}" ]; then
   fm_backend_herdr_apply_display_name \
-    "$HERDR_SES" "$HERDR_PANE_ID" "$HERDR_DISPLAY_NAME" "$ID" || true
+    "$HERDR_SES" "$HERDR_PANE_ID" "$HERDR_DISPLAY_NAME" || true
 fi
 if [ "$HARNESS" = kimi ]; then
   if ! kimi_wait_for_ready; then

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -2505,6 +2505,12 @@ preserve_relaunch_meta() {
     echo "herdr_workspace_id=$HERDR_WORKSPACE_ID"
     echo "herdr_tab_id=$HERDR_TAB_ID"
     echo "herdr_pane_id=$HERDR_PANE_ID"
+    # Human-readable agents-sidebar / tab display name (not ownership authority).
+    # Computed for ship/scout only; secondmates keep the default Herdr names.
+    if [ "$KIND" != secondmate ]; then
+      HERDR_DISPLAY_NAME=$(fm_backend_herdr_display_name "$ID" "$KIND")
+      [ -n "$HERDR_DISPLAY_NAME" ] && echo "herdr_display_name=$HERDR_DISPLAY_NAME"
+    fi
   fi
   if [ "$BACKEND" = zellij ]; then
     echo "zellij_session=$ZELLIJ_SES"
@@ -2642,6 +2648,14 @@ if [ "${HERDR_PROJECTED:-0}" -eq 1 ]; then
   spawn_herdr_presentation_order_lock_release
 fi
 spawn_send_key "$T" Enter
+# Best-effort Herdr agents-sidebar (and tab) rename after the harness has been
+# launched. Wait until the pane registers an agent; rename failures never fail
+# the spawn. Secondmates are out of scope. Ownership stays on recorded pane/tab
+# ids in meta (docs/herdr-backend.md).
+if [ "$BACKEND" = herdr ] && [ "$KIND" != secondmate ] && [ -n "${HERDR_DISPLAY_NAME:-}" ]; then
+  fm_backend_herdr_apply_display_name \
+    "$HERDR_SES" "$HERDR_PANE_ID" "$HERDR_TAB_ID" "$HERDR_DISPLAY_NAME" || true
+fi
 if [ "$HARNESS" = kimi ]; then
   if ! kimi_wait_for_ready; then
     kimi_spawn_fail "kimi did not show a verified ready signal before brief delivery"

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -2653,8 +2653,12 @@ spawn_send_key "$T" Enter
 # the spawn. Secondmates are out of scope. Ownership stays on recorded pane/tab
 # ids in meta (docs/herdr-backend.md).
 if [ "$BACKEND" = herdr ] && [ "$KIND" != secondmate ] && [ -n "${HERDR_DISPLAY_NAME:-}" ]; then
+  HERDR_RENAME_TAB_ID=$HERDR_TAB_ID
+  if [ "${HERDR_PROJECTED:-0}" -eq 1 ]; then
+    HERDR_RENAME_TAB_ID=
+  fi
   fm_backend_herdr_apply_display_name \
-    "$HERDR_SES" "$HERDR_PANE_ID" "$HERDR_TAB_ID" "$HERDR_DISPLAY_NAME" || true
+    "$HERDR_SES" "$HERDR_PANE_ID" "$HERDR_RENAME_TAB_ID" "$HERDR_DISPLAY_NAME" || true
 fi
 if [ "$HARNESS" = kimi ]; then
   if ! kimi_wait_for_ready; then

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -68,7 +68,7 @@ A cmux spawn additionally version-gates against the installed `cmux` binary's ve
 A backend spawn refusal from a missing dependency, version gate, or unauthenticated socket is terminal for that selected backend; firstmate surfaces it as a blocker instead of silently retrying another backend.
 Task meta records `backend=` only for a non-default backend; an absent `backend=` means `tmux`, preserving existing default-path meta files.
 Every new task records `endpoint_task_id=` as the cleanup binding between the metadata filename and its opaque runtime endpoint.
-A herdr task additionally records `herdr_session=`, `herdr_workspace_id=`, `herdr_tab_id=`, and `herdr_pane_id=`.
+A herdr task additionally records `herdr_session=`, `herdr_workspace_id=`, `herdr_tab_id=`, and `herdr_pane_id=`; a ship or scout task also records `herdr_display_name=` for the best-effort agent/tab rename (see [`herdr-backend.md`](herdr-backend.md#crewmate-display-names)).
 A zellij task additionally records `zellij_session=`, `zellij_tab_id=`, and `zellij_pane_id=`.
 An Orca task additionally records `orca_worktree_id=` and `terminal=`, with `window=fm-<id>` kept as the shared firstmate alias.
 A cmux task additionally records `cmux_workspace_id=` and `cmux_surface_id=`.
@@ -513,6 +513,8 @@ FM_BACKEND_HERDR_BARE_PROMPT_RE='^(❯|›)'  # herdr-only: verified agent glyph
 FM_BACKEND_HERDR_PI_COMPOSER_MAX_LINES=8  # herdr-only: maximum rows admitted between Pi's native-identity-corroborated separator pair; taller or ambiguous candidates stay unknown (docs/herdr-backend.md "Composer and injection safety")
 FM_BACKEND_HERDR_SUBMIT_POLLS=6  # herdr-only: agent-state samples spread across each Enter attempt's budget when confirming a submit (docs/herdr-backend.md "Current transport behavior")
 FM_BACKEND_HERDR_SUBMIT_MIN_SLEEP=0.6  # herdr-only: minimum per-Enter confirmation budget before polling agent-state after an idle baseline
+FM_BACKEND_HERDR_DISPLAY_NAME_POLLS=20  # herdr-only: samples waiting for a registered agent before the best-effort post-spawn display-name rename gives up (docs/herdr-backend.md "Crewmate display names")
+FM_BACKEND_HERDR_DISPLAY_NAME_SLEEP=0.25  # herdr-only: seconds between those polls
 FM_BACKEND_ORCA_COMPOSER_LINES=200  # orca-only: terminal-read lines scanned to locate the composer row for submit verification
 FM_BACKEND_ORCA_IDLE_RE='^Type a message\.\.\.$'  # orca-only: empty-composer placeholder regex after border/prompt stripping
 FM_ZELLIJ_SESSION=firstmate  # zellij-only: named session for normal backend ops and test isolation (docs/zellij-backend.md)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -68,7 +68,7 @@ A cmux spawn additionally version-gates against the installed `cmux` binary's ve
 A backend spawn refusal from a missing dependency, version gate, or unauthenticated socket is terminal for that selected backend; firstmate surfaces it as a blocker instead of silently retrying another backend.
 Task meta records `backend=` only for a non-default backend; an absent `backend=` means `tmux`, preserving existing default-path meta files.
 Every new task records `endpoint_task_id=` as the cleanup binding between the metadata filename and its opaque runtime endpoint.
-A herdr task additionally records `herdr_session=`, `herdr_workspace_id=`, `herdr_tab_id=`, and `herdr_pane_id=`; a ship or scout task also records `herdr_display_name=` for the best-effort agent/tab rename (see [`herdr-backend.md`](herdr-backend.md#crewmate-display-names)).
+A herdr task additionally records `herdr_session=`, `herdr_workspace_id=`, `herdr_tab_id=`, and `herdr_pane_id=`; a ship or scout task also records `herdr_display_name=` for the best-effort agent rename (see [`herdr-backend.md`](herdr-backend.md#crewmate-display-names)).
 A zellij task additionally records `zellij_session=`, `zellij_tab_id=`, and `zellij_pane_id=`.
 An Orca task additionally records `orca_worktree_id=` and `terminal=`, with `window=fm-<id>` kept as the shared firstmate alias.
 A cmux task additionally records `cmux_workspace_id=` and `cmux_surface_id=`.

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -69,15 +69,15 @@ Closing its last tab can remove the workspace, and the next spawn recreates it.
 
 ### Crewmate display names
 
-After a ship or scout harness launch on Herdr, Firstmate best-effort renames the registered agent and its tab to a short role-plus-topic name (`scout-<slug>` or `ship-<slug>`) so the agents sidebar is readable without a manual rename.
+After a ship or scout harness launch on Herdr, Firstmate best-effort renames the registered agent to a short role-plus-topic name (`scout-<slug>` or `ship-<slug>`) so the agents sidebar is readable without a manual rename.
 The name is pure-derived from the task id and kind (`fm_backend_herdr_display_name`), capped at 32 characters, and matches Herdr's agent-name grammar.
 It is also recorded as `herdr_display_name=` in task meta for recovery and debugging.
 Display names are never ownership authority: peeks, sends, teardown, and supervision keep using recorded pane and tab ids.
-Tabs are still created as `fm-<id>`; post-spawn rename is best-effort and must not fail the spawn.
-Husk re-spawn and list-live therefore match either the create label or the scout/ship display form so a renamed husk is not stranded.
-The primary seed tab labeled `1` is never renamed.
+Only the agent (the sidebar entry) is renamed, in both projected and non-projected modes; the TAB always keeps its `fm-<id>` create label for life.
+That is deliberate: the display name is a lossy many-to-one map (lowercased, sanitized, truncated to 32) while task ids run to 64 characters over `[A-Za-z0-9._-]`, so two distinct ids can collapse to one display name.
+Keeping tab labels at `fm-<id>` keeps them an injective task identity, so husk reclaim's exact-label match and `fm_backend_herdr_list_live` can never match, refuse, or close a different task's tab.
+The rename is best-effort and must not fail the spawn.
 Secondmate launches are out of scope for automatic display names.
-When presentation spaces are enabled and the task tab is a projected child, only the agent is renamed: the tab keeps its `fm-<id>` label so husk reclaim's exact-label match (see below) still finds it on re-spawn.
 
 ## Presentation spaces
 

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -67,6 +67,17 @@ Existing task operations use recorded endpoint ids and do not move a live task w
 The per-home workspace is reused while it has task tabs.
 Closing its last tab can remove the workspace, and the next spawn recreates it.
 
+### Crewmate display names
+
+After a ship or scout harness launch on Herdr, Firstmate best-effort renames the registered agent and its tab to a short role-plus-topic name (`scout-<slug>` or `ship-<slug>`) so the agents sidebar is readable without a manual rename.
+The name is pure-derived from the task id and kind (`fm_backend_herdr_display_name`), capped at 32 characters, and matches Herdr's agent-name grammar.
+It is also recorded as `herdr_display_name=` in task meta for recovery and debugging.
+Display names are never ownership authority: peeks, sends, teardown, and supervision keep using recorded pane and tab ids.
+Tabs are still created as `fm-<id>`; post-spawn rename is best-effort and must not fail the spawn.
+Husk re-spawn and list-live therefore match either the create label or the scout/ship display form so a renamed husk is not stranded.
+The primary seed tab labeled `1` is never renamed.
+Secondmate launches are out of scope for automatic display names.
+
 ## Presentation spaces
 
 Each new crewmate or scout is placed in a disposable one-task workspace by default, on Herdr 0.8.0 and newer.

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -76,6 +76,10 @@ Display names are never ownership authority: peeks, sends, teardown, and supervi
 Only the agent (the sidebar entry) is renamed, in both projected and non-projected modes; the TAB always keeps its `fm-<id>` create label for life.
 That is deliberate: the display name is a lossy many-to-one map (lowercased, sanitized, truncated to 32) while task ids run to 64 characters over `[A-Za-z0-9._-]`, so two distinct ids can collapse to one display name.
 Keeping tab labels at `fm-<id>` keeps them an injective task identity, so husk reclaim's exact-label match and `fm_backend_herdr_list_live` can never match, refuse, or close a different task's tab.
+Herdr requires agent names be unique among live agents, so before renaming, Firstmate checks the candidate against the live agent list (`herdr agent list`, ignoring its own pane).
+On a collision it trades the tail of the name for a six-hex-character digest of the untruncated task id (`fm_backend_herdr_display_name_disambiguate`), which is deterministic, so retries and relaunches of the same task always land on the same sidebar name.
+Meta records the undisambiguated `herdr_display_name=`; the applied name is recoverable from the same task id through that helper.
+When the live agent list cannot be read, or the disambiguated name is taken too, the rename is skipped with a warning naming the collision.
 The rename is best-effort and must not fail the spawn.
 Secondmate launches are out of scope for automatic display names.
 

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -77,6 +77,7 @@ Tabs are still created as `fm-<id>`; post-spawn rename is best-effort and must n
 Husk re-spawn and list-live therefore match either the create label or the scout/ship display form so a renamed husk is not stranded.
 The primary seed tab labeled `1` is never renamed.
 Secondmate launches are out of scope for automatic display names.
+When presentation spaces are enabled and the task tab is a projected child, only the agent is renamed: the tab keeps its `fm-<id>` label so husk reclaim's exact-label match (see below) still finds it on re-spawn.
 
 ## Presentation spaces
 

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -73,13 +73,14 @@ After a ship or scout harness launch on Herdr, Firstmate best-effort renames the
 The name is pure-derived from the task id and kind (`fm_backend_herdr_display_name`), capped at 32 characters, and matches Herdr's agent-name grammar.
 It is also recorded as `herdr_display_name=` in task meta for recovery and debugging.
 Display names are never ownership authority: peeks, sends, teardown, and supervision keep using recorded pane and tab ids.
-Only the agent (the sidebar entry) is renamed, in both projected and non-projected modes; the TAB always keeps its `fm-<id>` create label for life.
+Only the agent (the sidebar entry) is renamed, in both projected and non-projected modes; the tab always keeps its `fm-<id>` create label for life.
 That is deliberate: the stem is a lossy many-to-one map (lowercased, sanitized, truncated) while task ids run to 64 characters over `[A-Za-z0-9._-]`, so two distinct ids can produce one stem.
 Keeping tab labels at `fm-<id>` keeps them an injective task identity, so husk reclaim's exact-label match and `fm_backend_herdr_list_live` can never match, refuse, or close a different task's tab.
-Herdr requires agent names be unique among live agents, so the stem is truncated to leave room for a trailing six-hex-character digest of the full untruncated task id, and that digest is appended to EVERY name, not only to ids observed to collide.
+Herdr requires agent names be unique among live agents, so the stem is truncated to leave room for a trailing six-hex-character digest of the full untruncated task id, and that digest is appended to every name rather than only to ids observed to collide.
 Two tasks that share a stem still differ in the tail of their ids and therefore in their digest.
-Deciding to disambiguate from a live `herdr agent list` query instead was tried and rejected: it is racy (two concurrent spawns each read a list in which neither has renamed yet, so both send the same name) and environment-dependent (the same task id renames differently depending on which other agents happen to be live), which is exactly the sidebar churn the digest prevents.
-There is therefore no live-agent query on this path at all: the name is a function of the task id alone, so a relaunch of the same task always reproduces the name recorded in `herdr_display_name=`.
+A host with no usable hashing utility at all (`shasum`, `sha256sum`, `cksum`) falls back to the bare stem and loses that guarantee, which is the only case where two live tasks can contend for one agent name.
+Disambiguating from a live `herdr agent list` query instead is unsound on both counts: it is racy (two concurrent spawns each read a list in which neither has renamed yet, so both send the same name) and environment-dependent (the same task id renames differently depending on which other agents happen to be live), which is exactly the sidebar churn the digest prevents.
+No live-agent query happens on this path at all: the name is a function of the task id alone, so a relaunch of the same task always reproduces the name recorded in `herdr_display_name=`.
 The rename is best-effort and must not fail the spawn; a rejected rename warns and leaves Herdr's default names in place.
 Secondmate launches are out of scope for automatic display names.
 
@@ -210,11 +211,13 @@ herdr_session=<session>
 herdr_workspace_id=<workspace-id>
 herdr_tab_id=<tab-id>
 herdr_pane_id=<pane-id>
+herdr_display_name=<agent-display-name>   # ship and scout only
 ```
 
 A Herdr pane id contains a colon, so the adapter splits `window=` on the first colon only.
 The recorded pane is the operational fast path.
 Workspace and tab ids support verification and cleanup but are not inferred from mutable labels during normal operation.
+`herdr_display_name=` is a readability record only, never an endpoint (see [Crewmate display names](#crewmate-display-names)).
 
 ## Current transport behavior
 

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -69,18 +69,18 @@ Closing its last tab can remove the workspace, and the next spawn recreates it.
 
 ### Crewmate display names
 
-After a ship or scout harness launch on Herdr, Firstmate best-effort renames the registered agent to a short role-plus-topic name (`scout-<slug>` or `ship-<slug>`) so the agents sidebar is readable without a manual rename.
+After a ship or scout harness launch on Herdr, Firstmate best-effort renames the registered agent to a short role-plus-topic name (`scout-<stem>-<digest>` or `ship-<stem>-<digest>`) so the agents sidebar is readable without a manual rename.
 The name is pure-derived from the task id and kind (`fm_backend_herdr_display_name`), capped at 32 characters, and matches Herdr's agent-name grammar.
 It is also recorded as `herdr_display_name=` in task meta for recovery and debugging.
 Display names are never ownership authority: peeks, sends, teardown, and supervision keep using recorded pane and tab ids.
 Only the agent (the sidebar entry) is renamed, in both projected and non-projected modes; the TAB always keeps its `fm-<id>` create label for life.
-That is deliberate: the display name is a lossy many-to-one map (lowercased, sanitized, truncated to 32) while task ids run to 64 characters over `[A-Za-z0-9._-]`, so two distinct ids can collapse to one display name.
+That is deliberate: the stem is a lossy many-to-one map (lowercased, sanitized, truncated) while task ids run to 64 characters over `[A-Za-z0-9._-]`, so two distinct ids can produce one stem.
 Keeping tab labels at `fm-<id>` keeps them an injective task identity, so husk reclaim's exact-label match and `fm_backend_herdr_list_live` can never match, refuse, or close a different task's tab.
-Herdr requires agent names be unique among live agents, so before renaming, Firstmate checks the candidate against the live agent list (`herdr agent list`, ignoring its own pane).
-On a collision it trades the tail of the name for a six-hex-character digest of the untruncated task id (`fm_backend_herdr_display_name_disambiguate`), which is deterministic, so retries and relaunches of the same task always land on the same sidebar name.
-Meta records the undisambiguated `herdr_display_name=`; the applied name is recoverable from the same task id through that helper.
-When the live agent list cannot be read, or the disambiguated name is taken too, the rename is skipped with a warning naming the collision.
-The rename is best-effort and must not fail the spawn.
+Herdr requires agent names be unique among live agents, so the stem is truncated to leave room for a trailing six-hex-character digest of the full untruncated task id, and that digest is appended to EVERY name, not only to ids observed to collide.
+Two tasks that share a stem still differ in the tail of their ids and therefore in their digest.
+Deciding to disambiguate from a live `herdr agent list` query instead was tried and rejected: it is racy (two concurrent spawns each read a list in which neither has renamed yet, so both send the same name) and environment-dependent (the same task id renames differently depending on which other agents happen to be live), which is exactly the sidebar churn the digest prevents.
+There is therefore no live-agent query on this path at all: the name is a function of the task id alone, so a relaunch of the same task always reproduces the name recorded in `herdr_display_name=`.
+The rename is best-effort and must not fail the spawn; a rejected rename warns and leaves Herdr's default names in place.
 Secondmate launches are out of scope for automatic display names.
 
 ## Presentation spaces

--- a/tests/fm-backend-herdr.test.sh
+++ b/tests/fm-backend-herdr.test.sh
@@ -744,26 +744,28 @@ test_create_task_refuses_when_agent_state_ambiguous() {
 test_display_name_pure_helper_shapes() {
   (
     . "$ROOT/bin/backends/herdr.sh"
-    [ "$(fm_backend_herdr_display_name terse-oss-phase01 scout)" = scout-terse-oss-phase01 ] || {
-      echo "scout id: $(fm_backend_herdr_display_name terse-oss-phase01 scout)" >&2; exit 1
+    # Every name is <stem>-<6 hex digest of the full task id>.
+    assert_stem() {  # <actual> <expected-stem>
+      case "$1" in
+        "$2"-[0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f]) ;;
+        *) echo "expected $2-<6hex>, got $1" >&2; return 1 ;;
+      esac
     }
-    [ "$(fm_backend_herdr_display_name memberos-auth ship)" = ship-memberos-auth ] || exit 1
-    [ "$(fm_backend_herdr_display_name memberos-auth crew)" = ship-memberos-auth ] || exit 1
+    assert_stem "$(fm_backend_herdr_display_name terse-oss-phase01 scout)" scout-terse-oss-phase01 || exit 1
+    assert_stem "$(fm_backend_herdr_display_name memberos-auth ship)" ship-memberos-auth || exit 1
+    assert_stem "$(fm_backend_herdr_display_name memberos-auth crew)" ship-memberos-auth || exit 1
     # Already-prefixed ids do not double the role prefix.
-    [ "$(fm_backend_herdr_display_name scout-terse-phase01 scout)" = scout-terse-phase01 ] || exit 1
-    [ "$(fm_backend_herdr_display_name ship-memberos-auth ship)" = ship-memberos-auth ] || exit 1
-    [ "$(fm_backend_herdr_display_name fm-terse-oss-phase01 scout)" = scout-terse-oss-phase01 ] || exit 1
+    assert_stem "$(fm_backend_herdr_display_name scout-terse-phase01 scout)" scout-terse-phase01 || exit 1
+    assert_stem "$(fm_backend_herdr_display_name ship-memberos-auth ship)" ship-memberos-auth || exit 1
+    assert_stem "$(fm_backend_herdr_display_name fm-terse-oss-phase01 scout)" scout-terse-oss-phase01 || exit 1
     # Uppercase and invalid characters are sanitized.
-    [ "$(fm_backend_herdr_display_name 'Terse/OSS Phase01!' scout)" = scout-terse-oss-phase01 ] || {
-      echo "sanitized: $(fm_backend_herdr_display_name 'Terse/OSS Phase01!' scout)" >&2; exit 1
-    }
-    # Long ids truncate to 32 without trailing - or _.
+    assert_stem "$(fm_backend_herdr_display_name 'Terse/OSS Phase01!' scout)" scout-terse-oss-phase01 || exit 1
+    # Long ids truncate to fit the name AND its digest, without a trailing - or _.
     long=$(fm_backend_herdr_display_name very-long-task-id-that-exceeds-the-thirty-two-char-limit scout)
     [ "${#long}" -le 32 ] || { echo "too long: $long (${#long})" >&2; exit 1; }
     case "$long" in
-      *-|*_) echo "trailing separator: $long" >&2; exit 1 ;;
-      scout-*) ;;
-      *) echo "bad prefix: $long" >&2; exit 1 ;;
+      scout-*[!-_]-[0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f]) ;;
+      *) echo "truncated name lost its prefix or digest: $long" >&2; exit 1 ;;
     esac
     # Grammar: ^[a-z][a-z0-9_-]{0,31}$ (rejection form - a trailing bare * in a
     # glob matches ANY character, so it cannot express the repeat).
@@ -778,18 +780,57 @@ test_display_name_pure_helper_shapes() {
       [ "${#candidate}" -le 32 ] || { echo "too long: $candidate" >&2; exit 1; }
     done
   ) || fail "fm_backend_herdr_display_name pure helper failed an edge case"
-  pass "fm_backend_herdr_display_name: scout/ship prefixes, strip, sanitize, truncate to 32"
+  pass "fm_backend_herdr_display_name: scout/ship prefixes, strip, sanitize, truncate, always digest-suffixed"
+}
+
+test_display_name_diverges_for_ids_sharing_a_stem() {
+  # Herdr requires agent names be unique among live agents. Two ids that differ
+  # only past the truncation point - or only in characters the sanitizer folds -
+  # produce ONE stem, so the digest is what keeps the full names apart. Asserted
+  # as a pure function of the id: no live agent list is consulted anywhere.
+  local one two folded plain
+  one=$( . "$ROOT/bin/backends/herdr.sh"; fm_backend_herdr_display_name fm-alpha-service-refactor-phase-one scout )
+  two=$( . "$ROOT/bin/backends/herdr.sh"; fm_backend_herdr_display_name fm-alpha-service-refactor-phase-two scout )
+  [ "${one%-*}" = "${two%-*}" ] \
+    || fail "the collision premise is gone: stems '${one%-*}' and '${two%-*}' already differ"
+  [ "$one" != "$two" ] || fail "two ids sharing a stem must not share a display name, both got '$one'"
+  folded=$( . "$ROOT/bin/backends/herdr.sh"; fm_backend_herdr_display_name 'Terse/OSS' scout )
+  plain=$( . "$ROOT/bin/backends/herdr.sh"; fm_backend_herdr_display_name terse-oss scout )
+  [ "${folded%-*}" = "${plain%-*}" ] \
+    || fail "expected sanitizing to fold these ids onto one stem, got '${folded%-*}' and '${plain%-*}'"
+  [ "$folded" != "$plain" ] \
+    || fail "two ids folded onto one stem must not share a display name, both got '$folded'"
+  for candidate in "$one" "$two" "$folded" "$plain"; do
+    case "$candidate" in
+      [a-z]*[!a-z0-9_-]*|[!a-z]*|"") fail "display name breaks herdr's grammar: $candidate" ;;
+    esac
+    [ "${#candidate}" -le 32 ] || fail "display name exceeds 32 chars: $candidate"
+  done
+  pass "fm_backend_herdr_display_name: ids sharing a truncated or sanitized stem still get distinct names"
+}
+
+test_display_name_is_deterministic_across_processes() {
+  # The name must depend on the task id ALONE, so a relaunch reproduces exactly
+  # the name recorded in herdr_display_name= no matter what else is live.
+  local first second third
+  first=$( . "$ROOT/bin/backends/herdr.sh"; fm_backend_herdr_display_name fm-alpha-service-refactor-phase-two scout )
+  second=$( . "$ROOT/bin/backends/herdr.sh"; fm_backend_herdr_display_name fm-alpha-service-refactor-phase-two scout )
+  third=$( bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_display_name fm-alpha-service-refactor-phase-two scout' "$ROOT" )
+  [ -n "$first" ] || fail "display name must not be empty"
+  [ "$first" = "$second" ] || fail "repeated calls diverged: '$first' then '$second'"
+  [ "$first" = "$third" ] || fail "a fresh process diverged: '$first' then '$third'"
+  pass "fm_backend_herdr_display_name: the same task id reproduces the same name across processes"
 }
 
 test_create_task_ignores_colliding_display_name_tab() {
-  # Two distinct task ids can collapse to ONE display name (lowercase, sanitize,
-  # truncate at 32). Tabs therefore keep their exact fm-<id> label for life, and
-  # husk/dup matching stays exact: phase-two's spawn must NOT see phase-one's
-  # tab, whose display name would have collided.
+  # Two distinct task ids can collapse to ONE display-name stem (lowercase,
+  # sanitize, truncate). Tabs therefore keep their exact fm-<id> label for life,
+  # and husk/dup matching stays exact: phase-two's spawn must NOT see phase-one's
+  # tab, whose display-name stem is identical to its own.
   local dir log resp fb out tab pane
   dir="$TMP_ROOT/husk-display-collision"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
-  # Live (non-husk) tab for a DIFFERENT task whose scout display name is
-  # byte-identical to this spawn's: scout-alpha-service-refactor-pha.
+  # Live (non-husk) tab for a DIFFERENT task whose scout display-name stem is
+  # byte-identical to this spawn's: scout-alpha-service-refac.
   printf '{"result":{"tabs":[{"tab_id":"w1:t2","label":"fm-alpha-service-refactor-phase-one","workspace_id":"w1"}]}}\n' > "$resp/1.out"
   printf '{"result":{"tab":{"tab_id":"w1:t3"},"root_pane":{"pane_id":"w1:p3"}}}\n' > "$resp/2.out"
   fb=$(make_herdr_fakebin "$dir")
@@ -875,95 +916,6 @@ test_apply_display_name_gives_up_early_on_dead_pane() {
   fi
   assert_not_contains "$(cat "$log")" $'\x1f''agent'$'\x1f''rename' "must not rename a dead pane"
   pass "fm_backend_herdr_apply_display_name: breaks out of the poll loop on a dead pane"
-}
-
-# run_apply_display_name: drive one fm_backend_herdr_apply_display_name call
-# against a canned herdr whose agent list already holds <taken>, and echo the
-# name the agent was finally renamed to (empty when no rename was attempted).
-run_apply_display_name() {  # <dir> <name> <task-id> <taken-name>
-  local dir=$1 name=$2 id=$3 taken=$4 log resp fb
-  rm -rf "$dir"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
-  printf '{"result":{"pane":{"pane_id":"w1:p9"}}}\n' > "$resp/1.out"
-  printf '{"result":{"agent":{"agent_status":"working"}}}\n' > "$resp/2.out"
-  printf '{"result":{"agents":[{"pane_id":"w1:p1","name":"%s"},{"pane_id":"w1:p2","name":null}]}}\n' "$taken" > "$resp/3.out"
-  fb=$(make_herdr_fakebin "$dir")
-  PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
-    FM_BACKEND_HERDR_DISPLAY_NAME_POLLS=2 FM_BACKEND_HERDR_DISPLAY_NAME_SLEEP=0 \
-    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_apply_display_name "$1" "$2" "$3" "$4"' \
-    "$ROOT" fmtest w1:p9 "$name" "$id" >/dev/null 2>"$dir/err" \
-    || { echo "apply_display_name exited non-zero" >&2; return 1; }
-  awk -F$'\x1f' '{for (i = 1; i <= NF; i++) if ($i == "rename") { print $(i + 2); exit } }' "$log"
-}
-
-test_apply_display_name_disambiguates_live_name_collision() {
-  # fm-alpha-service-refactor-phase-one and ...-phase-two both truncate to the
-  # 32-char name scout-alpha-service-refactor-pha, and herdr rejects a rename to
-  # a name a live agent already holds. The second spawn must therefore land on a
-  # distinct name rather than lose its rename, and the two tasks must not
-  # collapse onto each other again.
-  local taken one two again
-  taken=$( . "$ROOT/bin/backends/herdr.sh"; fm_backend_herdr_display_name fm-alpha-service-refactor-phase-one scout )
-  [ "$taken" = scout-alpha-service-refactor-pha ] \
-    || fail "expected the truncated collision name, got '$taken'"
-  one=$(run_apply_display_name "$TMP_ROOT/apply-display-collide-one" "$taken" fm-alpha-service-refactor-phase-one "$taken") \
-    || fail "apply_display_name must return 0 on a live-name collision"
-  two=$(run_apply_display_name "$TMP_ROOT/apply-display-collide-two" "$taken" fm-alpha-service-refactor-phase-two "$taken") \
-    || fail "apply_display_name must return 0 on a live-name collision"
-  again=$(run_apply_display_name "$TMP_ROOT/apply-display-collide-again" "$taken" fm-alpha-service-refactor-phase-two "$taken") \
-    || fail "apply_display_name must return 0 on a live-name collision"
-  [ -n "$one" ] && [ -n "$two" ] || fail "a collision must still produce a rename, got '$one' / '$two'"
-  [ "$one" != "$taken" ] && [ "$two" != "$taken" ] \
-    || fail "apply_display_name must not send a name a live agent already holds"
-  [ "$one" != "$two" ] || fail "two colliding task ids must diverge, both got '$two'"
-  [ "$two" = "$again" ] || fail "the same task id must be deterministic, got '$two' then '$again'"
-  for candidate in "$one" "$two"; do
-    case "$candidate" in
-      [a-z]*[!a-z0-9_-]*|[!a-z]*) fail "disambiguated name breaks herdr's grammar: $candidate" ;;
-      scout-*) ;;
-      *) fail "disambiguated name lost its role prefix: $candidate" ;;
-    esac
-    [ "${#candidate}" -le 32 ] || fail "disambiguated name exceeds 32 chars: $candidate"
-  done
-  pass "fm_backend_herdr_apply_display_name: deterministically disambiguates a live agent-name collision"
-}
-
-test_apply_display_name_skips_collision_it_cannot_disambiguate() {
-  # Without a task id there is nothing stable to disambiguate from, so the
-  # rename herdr would reject is skipped with a warning that names the cause,
-  # never sent blind.
-  local dir log resp fb err
-  dir="$TMP_ROOT/apply-display-collide-blind"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
-  printf '{"result":{"pane":{"pane_id":"w1:p9"}}}\n' > "$resp/1.out"
-  printf '{"result":{"agent":{"agent_status":"working"}}}\n' > "$resp/2.out"
-  printf '{"result":{"agents":[{"pane_id":"w1:p1","name":"scout-x"}]}}\n' > "$resp/3.out"
-  fb=$(make_herdr_fakebin "$dir")
-  err=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
-    FM_BACKEND_HERDR_DISPLAY_NAME_POLLS=2 FM_BACKEND_HERDR_DISPLAY_NAME_SLEEP=0 \
-    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_apply_display_name fmtest w1:p9 scout-x' "$ROOT" 2>&1 ) \
-    || fail "apply_display_name must return 0 when a collision cannot be disambiguated"
-  assert_contains "$err" "already taken by a live agent" "expected a collision-specific warning"
-  assert_not_contains "$(cat "$log")" $'\x1f''agent'$'\x1f''rename' \
-    "apply_display_name must not send a rename herdr is certain to reject"
-  pass "fm_backend_herdr_apply_display_name: skips an undisambiguatable collision with a warning naming it"
-}
-
-test_apply_display_name_ignores_own_pane_when_checking_collisions() {
-  # A re-run over an already-renamed pane must not read its own name as another
-  # agent's and disambiguate away from it.
-  local dir log resp fb renamed
-  dir="$TMP_ROOT/apply-display-self"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
-  printf '{"result":{"pane":{"pane_id":"w1:p9"}}}\n' > "$resp/1.out"
-  printf '{"result":{"agent":{"agent_status":"working"}}}\n' > "$resp/2.out"
-  printf '{"result":{"agents":[{"pane_id":"w1:p9","name":"scout-terse-phase01"}]}}\n' > "$resp/3.out"
-  fb=$(make_herdr_fakebin "$dir")
-  PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
-    FM_BACKEND_HERDR_DISPLAY_NAME_POLLS=2 FM_BACKEND_HERDR_DISPLAY_NAME_SLEEP=0 \
-    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_apply_display_name fmtest w1:p9 scout-terse-phase01 fm-terse-phase01' "$ROOT" \
-    >/dev/null 2>&1 || fail "apply_display_name should return 0"
-  renamed=$(awk -F$'\x1f' '{for (i = 1; i <= NF; i++) if ($i == "rename") { print $(i + 2); exit } }' "$log")
-  [ "$renamed" = scout-terse-phase01 ] \
-    || fail "apply_display_name must keep its own name, renamed to '$renamed'"
-  pass "fm_backend_herdr_apply_display_name: its own pane's name is never a collision"
 }
 
 test_apply_display_name_skips_when_agent_never_registers() {
@@ -4548,14 +4500,13 @@ test_projection_recovery_is_read_only_and_refuses_live_duplicate_risk
 test_workspace_find_matches_only_this_homes_own_label
 test_list_live_scoped_to_this_homes_workspace_only
 test_display_name_pure_helper_shapes
+test_display_name_diverges_for_ids_sharing_a_stem
+test_display_name_is_deterministic_across_processes
 test_create_task_ignores_colliding_display_name_tab
 test_list_live_emits_only_reversible_fm_labels
 test_apply_display_name_renames_agent_only
 test_apply_display_name_rejects_invalid_grammar
 test_apply_display_name_gives_up_early_on_dead_pane
-test_apply_display_name_disambiguates_live_name_collision
-test_apply_display_name_skips_collision_it_cannot_disambiguate
-test_apply_display_name_ignores_own_pane_when_checking_collisions
 test_apply_display_name_skips_when_agent_never_registers
 test_parse_target
 test_normalize_key

--- a/tests/fm-backend-herdr.test.sh
+++ b/tests/fm-backend-herdr.test.sh
@@ -739,6 +739,134 @@ test_create_task_refuses_when_agent_state_ambiguous() {
   pass "fm_backend_herdr_create_task: refuses (fail-safe) rather than guessing when the duplicate's agent state cannot be classified confidently"
 }
 
+# --- display names (pure helper + husk safety for post-spawn rename) ---------
+
+test_display_name_pure_helper_shapes() {
+  (
+    . "$ROOT/bin/backends/herdr.sh"
+    [ "$(fm_backend_herdr_display_name terse-oss-phase01 scout)" = scout-terse-oss-phase01 ] || {
+      echo "scout id: $(fm_backend_herdr_display_name terse-oss-phase01 scout)" >&2; exit 1
+    }
+    [ "$(fm_backend_herdr_display_name memberos-auth ship)" = ship-memberos-auth ] || exit 1
+    [ "$(fm_backend_herdr_display_name memberos-auth crew)" = ship-memberos-auth ] || exit 1
+    # Already-prefixed ids do not double the role prefix.
+    [ "$(fm_backend_herdr_display_name scout-terse-phase01 scout)" = scout-terse-phase01 ] || exit 1
+    [ "$(fm_backend_herdr_display_name ship-memberos-auth ship)" = ship-memberos-auth ] || exit 1
+    [ "$(fm_backend_herdr_display_name fm-terse-oss-phase01 scout)" = scout-terse-oss-phase01 ] || exit 1
+    # Uppercase and invalid characters are sanitized.
+    [ "$(fm_backend_herdr_display_name 'Terse/OSS Phase01!' scout)" = scout-terse-oss-phase01 ] || {
+      echo "sanitized: $(fm_backend_herdr_display_name 'Terse/OSS Phase01!' scout)" >&2; exit 1
+    }
+    # Long ids truncate to 32 without trailing - or _.
+    long=$(fm_backend_herdr_display_name very-long-task-id-that-exceeds-the-thirty-two-char-limit scout)
+    [ "${#long}" -le 32 ] || { echo "too long: $long (${#long})" >&2; exit 1; }
+    case "$long" in
+      *-|*_) echo "trailing separator: $long" >&2; exit 1 ;;
+      scout-*) ;;
+      *) echo "bad prefix: $long" >&2; exit 1 ;;
+    esac
+    # Grammar: ^[a-z][a-z0-9_-]{0,31}$
+    case "$long" in
+      [a-z]|[a-z][a-z0-9_-]*) ;;
+      *) echo "grammar fail: $long" >&2; exit 1 ;;
+    esac
+  ) || fail "fm_backend_herdr_display_name pure helper failed an edge case"
+  pass "fm_backend_herdr_display_name: scout/ship prefixes, strip, sanitize, truncate to 32"
+}
+
+test_task_label_candidates_include_display_names() {
+  (
+    . "$ROOT/bin/backends/herdr.sh"
+    out=$(fm_backend_herdr_task_label_candidates fm-terse-oss-phase01)
+    printf '%s\n' "$out" | grep -Fxq 'fm-terse-oss-phase01' || exit 1
+    printf '%s\n' "$out" | grep -Fxq 'scout-terse-oss-phase01' || exit 1
+    printf '%s\n' "$out" | grep -Fxq 'ship-terse-oss-phase01' || exit 1
+  ) || fail "fm_backend_herdr_task_label_candidates missing expected labels"
+  pass "fm_backend_herdr_task_label_candidates: fm- plus scout- and ship- display forms"
+}
+
+test_create_task_closes_and_replaces_renamed_display_husk() {
+  # After a successful spawn the tab may have been renamed from fm-<id> to
+  # scout-<slug>. Re-spawn must still find that husk by display name.
+  local dir log resp fb out tab pane
+  dir="$TMP_ROOT/husk-display-name"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
+  printf '{"result":{"tabs":[{"tab_id":"w1:t2","label":"scout-terse-oss-phase01","workspace_id":"w1"}]}}\n' > "$resp/1.out"
+  printf '{"result":{"panes":[{"pane_id":"w1:p2","tab_id":"w1:t2"}]}}\n' > "$resp/2.out"
+  printf '{"result":{"pane":{"pane_id":"w1:p2"}}}\n' > "$resp/3.out"
+  printf '{"error":{"code":"agent_not_found","message":"agent target w1:p2 not found"}}\n' > "$resp/4.out"
+  printf '{"result":{"tab":{"tab_id":"w1:t3"},"root_pane":{"pane_id":"w1:p3"}}}\n' > "$resp/5.out"
+  printf '{"result":{"tabs":[{"tab_id":"w1:t3","label":"fm-terse-oss-phase01","workspace_id":"w1"}]}}\n' > "$resp/7.out"
+  fb=$(make_herdr_fakebin "$dir")
+  out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
+    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_create_task fmtest:w1 fm-terse-oss-phase01 /tmp/proj' "$ROOT" ) \
+    || fail "create_task should close-and-replace a display-renamed husk"
+  read -r tab pane <<EOF
+$out
+EOF
+  if [ "$tab" != "w1:t3" ] || [ "$pane" != "w1:p3" ]; then
+    fail "create_task should echo the NEW tab/pane ids, got '$out'"
+  fi
+  assert_contains "$(cat "$log")" $'\x1f''tab'$'\x1f''close'$'\x1f''w1:t2' \
+    "create_task did not close the display-renamed husk tab"
+  assert_contains "$(cat "$log")" $'\x1f''tab'$'\x1f''create' \
+    "create_task did not create a replacement for the display-renamed husk"
+  pass "fm_backend_herdr_create_task: replaces a husk whose tab was renamed to scout-<slug>"
+}
+
+test_list_live_includes_display_name_labels() {
+  local dir log resp fb out home
+  dir="$TMP_ROOT/list-live-display"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
+  home="$TMP_ROOT/list-live-display-home"; mkdir -p "$home"
+  printf '{"result":{"workspaces":[{"workspace_id":"w1","label":"firstmate"}]}}\n' > "$resp/1.out"
+  printf '{"result":{"tabs":[{"tab_id":"w1:t1","label":"scout-terse-phase01"},{"tab_id":"w1:t2","label":"1"},{"tab_id":"w1:t3","label":"ship-memberos-auth"}]}}\n' > "$resp/2.out"
+  printf '{"result":{"panes":[{"pane_id":"w1:p1","tab_id":"w1:t1"},{"pane_id":"w1:p2","tab_id":"w1:t2"},{"pane_id":"w1:p3","tab_id":"w1:t3"}]}}\n' > "$resp/3.out"
+  printf '{"result":{"panes":[{"pane_id":"w1:p1","tab_id":"w1:t1"},{"pane_id":"w1:p2","tab_id":"w1:t2"},{"pane_id":"w1:p3","tab_id":"w1:t3"}]}}\n' > "$resp/4.out"
+  fb=$(make_herdr_fakebin "$dir")
+  out=$( PATH="$fb:$PATH" FM_HOME="$home" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
+    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_list_live fmtest' "$ROOT" )
+  assert_contains "$out" $'fmtest:w1:p1\tscout-terse-phase01' "list_live missed scout- display label"
+  assert_contains "$out" $'fmtest:w1:p3\tship-memberos-auth' "list_live missed ship- display label"
+  assert_not_contains "$out" $'w1:p2' "list_live must not treat seed tab '1' as a task"
+  pass "fm_backend_herdr_list_live: includes scout-/ship- display labels, not seed tab 1"
+}
+
+test_apply_display_name_renames_agent_and_tab() {
+  local dir log resp fb
+  dir="$TMP_ROOT/apply-display"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
+  # apply polls pane_agent_state: pane get + agent get until live, then renames.
+  printf '{"result":{"pane":{"pane_id":"w1:p9"}}}\n' > "$resp/1.out"
+  printf '{"result":{"agent":{"agent_status":"working"}}}\n' > "$resp/2.out"
+  # 3: agent rename (empty success)
+  # 4: tab rename (empty success)
+  fb=$(make_herdr_fakebin "$dir")
+  PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
+    FM_BACKEND_HERDR_DISPLAY_NAME_POLLS=2 FM_BACKEND_HERDR_DISPLAY_NAME_SLEEP=0 \
+    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_apply_display_name fmtest w1:p9 w1:t9 scout-terse-phase01' "$ROOT" \
+    || fail "apply_display_name should return 0"
+  assert_contains "$(cat "$log")" $'\x1f''agent'$'\x1f''rename'$'\x1f''w1:p9'$'\x1f''scout-terse-phase01' \
+    "apply_display_name did not agent-rename"
+  assert_contains "$(cat "$log")" $'\x1f''tab'$'\x1f''rename'$'\x1f''w1:t9'$'\x1f''scout-terse-phase01' \
+    "apply_display_name did not tab-rename"
+  pass "fm_backend_herdr_apply_display_name: renames agent and tab after agent is live"
+}
+
+test_apply_display_name_skips_when_agent_never_registers() {
+  local dir log resp fb err
+  dir="$TMP_ROOT/apply-display-skip"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
+  printf '{"result":{"pane":{"pane_id":"w1:p9"}}}\n' > "$resp/1.out"
+  printf '{"error":{"code":"agent_not_found","message":"none"}}\n' > "$resp/2.out"
+  printf '{"result":{"pane":{"pane_id":"w1:p9"}}}\n' > "$resp/3.out"
+  printf '{"error":{"code":"agent_not_found","message":"none"}}\n' > "$resp/4.out"
+  fb=$(make_herdr_fakebin "$dir")
+  err=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
+    FM_BACKEND_HERDR_DISPLAY_NAME_POLLS=2 FM_BACKEND_HERDR_DISPLAY_NAME_SLEEP=0 \
+    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_apply_display_name fmtest w1:p9 w1:t9 scout-x' "$ROOT" 2>&1 ) \
+    || fail "apply_display_name must return 0 even when rename is skipped"
+  assert_contains "$err" "not registered in time" "expected skip warning when agent never appears"
+  assert_not_contains "$(cat "$log")" $'\x1f''agent'$'\x1f''rename' "must not rename without a live agent"
+  pass "fm_backend_herdr_apply_display_name: skips rename without failing when agent never registers"
+}
+
 test_create_task_husk_replacement_creates_before_closing() {
   # Safety-critical ordering: the replacement tab must be created BEFORE the
   # husk tab is closed, never the reverse - closing a workspace's LAST
@@ -4303,6 +4431,12 @@ test_projection_reclaim_replaces_only_exact_husk_and_advances_binding
 test_projection_recovery_is_read_only_and_refuses_live_duplicate_risk
 test_workspace_find_matches_only_this_homes_own_label
 test_list_live_scoped_to_this_homes_workspace_only
+test_display_name_pure_helper_shapes
+test_task_label_candidates_include_display_names
+test_create_task_closes_and_replaces_renamed_display_husk
+test_list_live_includes_display_name_labels
+test_apply_display_name_renames_agent_and_tab
+test_apply_display_name_skips_when_agent_never_registers
 test_parse_target
 test_normalize_key
 test_capture_calls_pane_read

--- a/tests/fm-backend-herdr.test.sh
+++ b/tests/fm-backend-herdr.test.sh
@@ -765,89 +765,116 @@ test_display_name_pure_helper_shapes() {
       scout-*) ;;
       *) echo "bad prefix: $long" >&2; exit 1 ;;
     esac
-    # Grammar: ^[a-z][a-z0-9_-]{0,31}$
-    case "$long" in
-      [a-z]|[a-z][a-z0-9_-]*) ;;
-      *) echo "grammar fail: $long" >&2; exit 1 ;;
-    esac
+    # Grammar: ^[a-z][a-z0-9_-]{0,31}$ (rejection form - a trailing bare * in a
+    # glob matches ANY character, so it cannot express the repeat).
+    for candidate in "$long" \
+      "$(fm_backend_herdr_display_name 'Terse/OSS Phase01!' scout)" \
+      "$(fm_backend_herdr_display_name '///' ship)" \
+      "$(fm_backend_herdr_display_name '' scout)" \
+      "$(fm_backend_herdr_display_name '9lead' ship)"; do
+      case "$candidate" in
+        [a-z]*[!a-z0-9_-]*|[!a-z]*|"") echo "grammar fail: $candidate" >&2; exit 1 ;;
+      esac
+      [ "${#candidate}" -le 32 ] || { echo "too long: $candidate" >&2; exit 1; }
+    done
   ) || fail "fm_backend_herdr_display_name pure helper failed an edge case"
   pass "fm_backend_herdr_display_name: scout/ship prefixes, strip, sanitize, truncate to 32"
 }
 
-test_task_label_candidates_include_display_names() {
-  (
-    . "$ROOT/bin/backends/herdr.sh"
-    out=$(fm_backend_herdr_task_label_candidates fm-terse-oss-phase01)
-    printf '%s\n' "$out" | grep -Fxq 'fm-terse-oss-phase01' || exit 1
-    printf '%s\n' "$out" | grep -Fxq 'scout-terse-oss-phase01' || exit 1
-    printf '%s\n' "$out" | grep -Fxq 'ship-terse-oss-phase01' || exit 1
-  ) || fail "fm_backend_herdr_task_label_candidates missing expected labels"
-  pass "fm_backend_herdr_task_label_candidates: fm- plus scout- and ship- display forms"
-}
-
-test_create_task_closes_and_replaces_renamed_display_husk() {
-  # After a successful spawn the tab may have been renamed from fm-<id> to
-  # scout-<slug>. Re-spawn must still find that husk by display name.
+test_create_task_refuses_colliding_display_name_tab() {
+  # Two distinct task ids can collapse to ONE display name (lowercase, sanitize,
+  # truncate at 32). Tabs therefore keep their exact fm-<id> label for life, and
+  # husk/dup matching stays exact: phase-two's spawn must NOT see phase-one's
+  # tab, whose display name would have collided.
   local dir log resp fb out tab pane
-  dir="$TMP_ROOT/husk-display-name"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
-  printf '{"result":{"tabs":[{"tab_id":"w1:t2","label":"scout-terse-oss-phase01","workspace_id":"w1"}]}}\n' > "$resp/1.out"
-  printf '{"result":{"panes":[{"pane_id":"w1:p2","tab_id":"w1:t2"}]}}\n' > "$resp/2.out"
-  printf '{"result":{"pane":{"pane_id":"w1:p2"}}}\n' > "$resp/3.out"
-  printf '{"error":{"code":"agent_not_found","message":"agent target w1:p2 not found"}}\n' > "$resp/4.out"
-  printf '{"result":{"tab":{"tab_id":"w1:t3"},"root_pane":{"pane_id":"w1:p3"}}}\n' > "$resp/5.out"
-  printf '{"result":{"tabs":[{"tab_id":"w1:t3","label":"fm-terse-oss-phase01","workspace_id":"w1"}]}}\n' > "$resp/7.out"
+  dir="$TMP_ROOT/husk-display-collision"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
+  # Live (non-husk) tab for a DIFFERENT task whose scout display name is
+  # byte-identical to this spawn's: scout-alpha-service-refactor-pha.
+  printf '{"result":{"tabs":[{"tab_id":"w1:t2","label":"fm-alpha-service-refactor-phase-one","workspace_id":"w1"}]}}\n' > "$resp/1.out"
+  printf '{"result":{"tab":{"tab_id":"w1:t3"},"root_pane":{"pane_id":"w1:p3"}}}\n' > "$resp/2.out"
   fb=$(make_herdr_fakebin "$dir")
   out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
-    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_create_task fmtest:w1 fm-terse-oss-phase01 /tmp/proj' "$ROOT" ) \
-    || fail "create_task should close-and-replace a display-renamed husk"
+    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_create_task fmtest:w1 fm-alpha-service-refactor-phase-two /tmp/proj' "$ROOT" ) \
+    || fail "create_task must not refuse a spawn whose display name collides with another live task"
   read -r tab pane <<EOF
 $out
 EOF
   if [ "$tab" != "w1:t3" ] || [ "$pane" != "w1:p3" ]; then
-    fail "create_task should echo the NEW tab/pane ids, got '$out'"
+    fail "create_task should echo the new tab/pane ids, got '$out'"
   fi
-  assert_contains "$(cat "$log")" $'\x1f''tab'$'\x1f''close'$'\x1f''w1:t2' \
-    "create_task did not close the display-renamed husk tab"
-  assert_contains "$(cat "$log")" $'\x1f''tab'$'\x1f''create' \
-    "create_task did not create a replacement for the display-renamed husk"
-  pass "fm_backend_herdr_create_task: replaces a husk whose tab was renamed to scout-<slug>"
+  assert_not_contains "$(cat "$log")" $'\x1f''tab'$'\x1f''close' \
+    "create_task must never close another task's tab on a display-name collision"
+  pass "fm_backend_herdr_create_task: display-name collisions never match another task's tab"
 }
 
-test_list_live_includes_display_name_labels() {
+test_list_live_emits_only_reversible_fm_labels() {
   local dir log resp fb out home
   dir="$TMP_ROOT/list-live-display"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
   home="$TMP_ROOT/list-live-display-home"; mkdir -p "$home"
   printf '{"result":{"workspaces":[{"workspace_id":"w1","label":"firstmate"}]}}\n' > "$resp/1.out"
-  printf '{"result":{"tabs":[{"tab_id":"w1:t1","label":"scout-terse-phase01"},{"tab_id":"w1:t2","label":"1"},{"tab_id":"w1:t3","label":"ship-memberos-auth"}]}}\n' > "$resp/2.out"
+  printf '{"result":{"tabs":[{"tab_id":"w1:t1","label":"fm-terse-phase01"},{"tab_id":"w1:t2","label":"1"},{"tab_id":"w1:t3","label":"scout-hand-made"}]}}\n' > "$resp/2.out"
   printf '{"result":{"panes":[{"pane_id":"w1:p1","tab_id":"w1:t1"},{"pane_id":"w1:p2","tab_id":"w1:t2"},{"pane_id":"w1:p3","tab_id":"w1:t3"}]}}\n' > "$resp/3.out"
   printf '{"result":{"panes":[{"pane_id":"w1:p1","tab_id":"w1:t1"},{"pane_id":"w1:p2","tab_id":"w1:t2"},{"pane_id":"w1:p3","tab_id":"w1:t3"}]}}\n' > "$resp/4.out"
   fb=$(make_herdr_fakebin "$dir")
   out=$( PATH="$fb:$PATH" FM_HOME="$home" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
     bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_list_live fmtest' "$ROOT" )
-  assert_contains "$out" $'fmtest:w1:p1\tscout-terse-phase01' "list_live missed scout- display label"
-  assert_contains "$out" $'fmtest:w1:p3\tship-memberos-auth' "list_live missed ship- display label"
+  assert_contains "$out" $'fmtest:w1:p1\tfm-terse-phase01' "list_live missed the fm-<id> task tab"
   assert_not_contains "$out" $'w1:p2' "list_live must not treat seed tab '1' as a task"
-  pass "fm_backend_herdr_list_live: includes scout-/ship- display labels, not seed tab 1"
+  assert_not_contains "$out" $'w1:p3' "list_live must not treat a human scout-* tab as a firstmate task"
+  pass "fm_backend_herdr_list_live: only exact fm-<id> tabs, never seed tab 1 or human scout-/ship- tabs"
 }
 
-test_apply_display_name_renames_agent_and_tab() {
+test_apply_display_name_renames_agent_only() {
   local dir log resp fb
   dir="$TMP_ROOT/apply-display"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
   # apply polls pane_agent_state: pane get + agent get until live, then renames.
   printf '{"result":{"pane":{"pane_id":"w1:p9"}}}\n' > "$resp/1.out"
   printf '{"result":{"agent":{"agent_status":"working"}}}\n' > "$resp/2.out"
-  # 3: agent rename (empty success)
-  # 4: tab rename (empty success)
+  # 3: agent rename (empty success); no tab rename call should ever be made.
   fb=$(make_herdr_fakebin "$dir")
   PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
     FM_BACKEND_HERDR_DISPLAY_NAME_POLLS=2 FM_BACKEND_HERDR_DISPLAY_NAME_SLEEP=0 \
-    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_apply_display_name fmtest w1:p9 w1:t9 scout-terse-phase01' "$ROOT" \
+    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_apply_display_name fmtest w1:p9 scout-terse-phase01' "$ROOT" \
     || fail "apply_display_name should return 0"
   assert_contains "$(cat "$log")" $'\x1f''agent'$'\x1f''rename'$'\x1f''w1:p9'$'\x1f''scout-terse-phase01' \
     "apply_display_name did not agent-rename"
-  assert_contains "$(cat "$log")" $'\x1f''tab'$'\x1f''rename'$'\x1f''w1:t9'$'\x1f''scout-terse-phase01' \
-    "apply_display_name did not tab-rename"
-  pass "fm_backend_herdr_apply_display_name: renames agent and tab after agent is live"
+  assert_not_contains "$(cat "$log")" $'\x1f''tab'$'\x1f''rename' \
+    "apply_display_name must never rename a tab away from its fm-<id> label"
+  pass "fm_backend_herdr_apply_display_name: renames the agent only, never the tab"
+}
+
+test_apply_display_name_rejects_invalid_grammar() {
+  local dir log resp fb err
+  dir="$TMP_ROOT/apply-display-grammar"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
+  fb=$(make_herdr_fakebin "$dir")
+  err=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
+    FM_BACKEND_HERDR_DISPLAY_NAME_POLLS=2 FM_BACKEND_HERDR_DISPLAY_NAME_SLEEP=0 \
+    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_apply_display_name fmtest w1:p9 "a/b c"' "$ROOT" 2>&1 ) \
+    || fail "apply_display_name must return 0 when the name is rejected"
+  assert_contains "$err" "is invalid" "expected an invalid-name warning for 'a/b c'"
+  assert_not_contains "$(cat "$log")" $'\x1f''agent'$'\x1f''rename' \
+    "apply_display_name must not send a name violating herdr's grammar"
+  pass "fm_backend_herdr_apply_display_name: rejects names with characters outside [a-z0-9_-]"
+}
+
+test_apply_display_name_gives_up_early_on_dead_pane() {
+  # A structurally gone pane will never register an agent, so the poll loop must
+  # stop at the first dead sample instead of burning the whole budget.
+  local dir log resp fb err calls
+  dir="$TMP_ROOT/apply-display-dead"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
+  printf '{"error":{"code":"pane_not_found","message":"gone"}}\n' > "$resp/1.out"
+  fb=$(make_herdr_fakebin "$dir")
+  err=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
+    FM_BACKEND_HERDR_DISPLAY_NAME_POLLS=8 FM_BACKEND_HERDR_DISPLAY_NAME_SLEEP=0 \
+    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_apply_display_name fmtest w1:p9 scout-x' "$ROOT" 2>&1 ) \
+    || fail "apply_display_name must return 0 when the pane is dead"
+  assert_contains "$err" "not registered in time" "expected the skip warning for a dead pane"
+  calls=$(grep -c $'\x1f''pane'$'\x1f''get' "$log" 2>/dev/null || true)
+  if [ "${calls:-0}" -ne 1 ]; then
+    fail "apply_display_name should stop after the first dead sample, made ${calls:-0} pane-get polls"
+  fi
+  assert_not_contains "$(cat "$log")" $'\x1f''agent'$'\x1f''rename' "must not rename a dead pane"
+  pass "fm_backend_herdr_apply_display_name: breaks out of the poll loop on a dead pane"
 }
 
 test_apply_display_name_skips_when_agent_never_registers() {
@@ -860,32 +887,11 @@ test_apply_display_name_skips_when_agent_never_registers() {
   fb=$(make_herdr_fakebin "$dir")
   err=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
     FM_BACKEND_HERDR_DISPLAY_NAME_POLLS=2 FM_BACKEND_HERDR_DISPLAY_NAME_SLEEP=0 \
-    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_apply_display_name fmtest w1:p9 w1:t9 scout-x' "$ROOT" 2>&1 ) \
+    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_apply_display_name fmtest w1:p9 scout-x' "$ROOT" 2>&1 ) \
     || fail "apply_display_name must return 0 even when rename is skipped"
   assert_contains "$err" "not registered in time" "expected skip warning when agent never appears"
   assert_not_contains "$(cat "$log")" $'\x1f''agent'$'\x1f''rename' "must not rename without a live agent"
   pass "fm_backend_herdr_apply_display_name: skips rename without failing when agent never registers"
-}
-
-test_apply_display_name_skips_tab_rename_when_projected() {
-  local dir log resp fb
-  dir="$TMP_ROOT/apply-display-projected"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
-  # presentation-projected spawns pass an empty tab id (fm-spawn.sh clears
-  # HERDR_RENAME_TAB_ID when HERDR_PROJECTED=1) so the task's real tab, which
-  # belongs to the presentation host, is never touched.
-  printf '{"result":{"pane":{"pane_id":"w1:p9"}}}\n' > "$resp/1.out"
-  printf '{"result":{"agent":{"agent_status":"working"}}}\n' > "$resp/2.out"
-  # 3: agent rename (empty success); no tab rename call should be made.
-  fb=$(make_herdr_fakebin "$dir")
-  PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
-    FM_BACKEND_HERDR_DISPLAY_NAME_POLLS=2 FM_BACKEND_HERDR_DISPLAY_NAME_SLEEP=0 \
-    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_apply_display_name fmtest w1:p9 "" scout-terse-phase01' "$ROOT" \
-    || fail "apply_display_name should return 0 for a projected (empty-tab-id) task"
-  assert_contains "$(cat "$log")" $'\x1f''agent'$'\x1f''rename'$'\x1f''w1:p9'$'\x1f''scout-terse-phase01' \
-    "apply_display_name did not agent-rename when tab id is empty"
-  assert_not_contains "$(cat "$log")" $'\x1f''tab'$'\x1f''rename' \
-    "apply_display_name must not tab-rename a presentation-projected (empty tab id) task"
-  pass "fm_backend_herdr_apply_display_name: skips tab rename but still agent-renames when tab id is empty (projected)"
 }
 
 test_create_task_husk_replacement_creates_before_closing() {
@@ -4453,12 +4459,12 @@ test_projection_recovery_is_read_only_and_refuses_live_duplicate_risk
 test_workspace_find_matches_only_this_homes_own_label
 test_list_live_scoped_to_this_homes_workspace_only
 test_display_name_pure_helper_shapes
-test_task_label_candidates_include_display_names
-test_create_task_closes_and_replaces_renamed_display_husk
-test_list_live_includes_display_name_labels
-test_apply_display_name_renames_agent_and_tab
+test_create_task_refuses_colliding_display_name_tab
+test_list_live_emits_only_reversible_fm_labels
+test_apply_display_name_renames_agent_only
+test_apply_display_name_rejects_invalid_grammar
+test_apply_display_name_gives_up_early_on_dead_pane
 test_apply_display_name_skips_when_agent_never_registers
-test_apply_display_name_skips_tab_rename_when_projected
 test_parse_target
 test_normalize_key
 test_capture_calls_pane_read

--- a/tests/fm-backend-herdr.test.sh
+++ b/tests/fm-backend-herdr.test.sh
@@ -781,7 +781,7 @@ test_display_name_pure_helper_shapes() {
   pass "fm_backend_herdr_display_name: scout/ship prefixes, strip, sanitize, truncate to 32"
 }
 
-test_create_task_refuses_colliding_display_name_tab() {
+test_create_task_ignores_colliding_display_name_tab() {
   # Two distinct task ids can collapse to ONE display name (lowercase, sanitize,
   # truncate at 32). Tabs therefore keep their exact fm-<id> label for life, and
   # husk/dup matching stays exact: phase-two's spawn must NOT see phase-one's
@@ -875,6 +875,95 @@ test_apply_display_name_gives_up_early_on_dead_pane() {
   fi
   assert_not_contains "$(cat "$log")" $'\x1f''agent'$'\x1f''rename' "must not rename a dead pane"
   pass "fm_backend_herdr_apply_display_name: breaks out of the poll loop on a dead pane"
+}
+
+# run_apply_display_name: drive one fm_backend_herdr_apply_display_name call
+# against a canned herdr whose agent list already holds <taken>, and echo the
+# name the agent was finally renamed to (empty when no rename was attempted).
+run_apply_display_name() {  # <dir> <name> <task-id> <taken-name>
+  local dir=$1 name=$2 id=$3 taken=$4 log resp fb
+  rm -rf "$dir"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
+  printf '{"result":{"pane":{"pane_id":"w1:p9"}}}\n' > "$resp/1.out"
+  printf '{"result":{"agent":{"agent_status":"working"}}}\n' > "$resp/2.out"
+  printf '{"result":{"agents":[{"pane_id":"w1:p1","name":"%s"},{"pane_id":"w1:p2","name":null}]}}\n' "$taken" > "$resp/3.out"
+  fb=$(make_herdr_fakebin "$dir")
+  PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
+    FM_BACKEND_HERDR_DISPLAY_NAME_POLLS=2 FM_BACKEND_HERDR_DISPLAY_NAME_SLEEP=0 \
+    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_apply_display_name "$1" "$2" "$3" "$4"' \
+    "$ROOT" fmtest w1:p9 "$name" "$id" >/dev/null 2>"$dir/err" \
+    || { echo "apply_display_name exited non-zero" >&2; return 1; }
+  awk -F$'\x1f' '{for (i = 1; i <= NF; i++) if ($i == "rename") { print $(i + 2); exit } }' "$log"
+}
+
+test_apply_display_name_disambiguates_live_name_collision() {
+  # fm-alpha-service-refactor-phase-one and ...-phase-two both truncate to the
+  # 32-char name scout-alpha-service-refactor-pha, and herdr rejects a rename to
+  # a name a live agent already holds. The second spawn must therefore land on a
+  # distinct name rather than lose its rename, and the two tasks must not
+  # collapse onto each other again.
+  local taken one two again
+  taken=$( . "$ROOT/bin/backends/herdr.sh"; fm_backend_herdr_display_name fm-alpha-service-refactor-phase-one scout )
+  [ "$taken" = scout-alpha-service-refactor-pha ] \
+    || fail "expected the truncated collision name, got '$taken'"
+  one=$(run_apply_display_name "$TMP_ROOT/apply-display-collide-one" "$taken" fm-alpha-service-refactor-phase-one "$taken") \
+    || fail "apply_display_name must return 0 on a live-name collision"
+  two=$(run_apply_display_name "$TMP_ROOT/apply-display-collide-two" "$taken" fm-alpha-service-refactor-phase-two "$taken") \
+    || fail "apply_display_name must return 0 on a live-name collision"
+  again=$(run_apply_display_name "$TMP_ROOT/apply-display-collide-again" "$taken" fm-alpha-service-refactor-phase-two "$taken") \
+    || fail "apply_display_name must return 0 on a live-name collision"
+  [ -n "$one" ] && [ -n "$two" ] || fail "a collision must still produce a rename, got '$one' / '$two'"
+  [ "$one" != "$taken" ] && [ "$two" != "$taken" ] \
+    || fail "apply_display_name must not send a name a live agent already holds"
+  [ "$one" != "$two" ] || fail "two colliding task ids must diverge, both got '$two'"
+  [ "$two" = "$again" ] || fail "the same task id must be deterministic, got '$two' then '$again'"
+  for candidate in "$one" "$two"; do
+    case "$candidate" in
+      [a-z]*[!a-z0-9_-]*|[!a-z]*) fail "disambiguated name breaks herdr's grammar: $candidate" ;;
+      scout-*) ;;
+      *) fail "disambiguated name lost its role prefix: $candidate" ;;
+    esac
+    [ "${#candidate}" -le 32 ] || fail "disambiguated name exceeds 32 chars: $candidate"
+  done
+  pass "fm_backend_herdr_apply_display_name: deterministically disambiguates a live agent-name collision"
+}
+
+test_apply_display_name_skips_collision_it_cannot_disambiguate() {
+  # Without a task id there is nothing stable to disambiguate from, so the
+  # rename herdr would reject is skipped with a warning that names the cause,
+  # never sent blind.
+  local dir log resp fb err
+  dir="$TMP_ROOT/apply-display-collide-blind"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
+  printf '{"result":{"pane":{"pane_id":"w1:p9"}}}\n' > "$resp/1.out"
+  printf '{"result":{"agent":{"agent_status":"working"}}}\n' > "$resp/2.out"
+  printf '{"result":{"agents":[{"pane_id":"w1:p1","name":"scout-x"}]}}\n' > "$resp/3.out"
+  fb=$(make_herdr_fakebin "$dir")
+  err=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
+    FM_BACKEND_HERDR_DISPLAY_NAME_POLLS=2 FM_BACKEND_HERDR_DISPLAY_NAME_SLEEP=0 \
+    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_apply_display_name fmtest w1:p9 scout-x' "$ROOT" 2>&1 ) \
+    || fail "apply_display_name must return 0 when a collision cannot be disambiguated"
+  assert_contains "$err" "already taken by a live agent" "expected a collision-specific warning"
+  assert_not_contains "$(cat "$log")" $'\x1f''agent'$'\x1f''rename' \
+    "apply_display_name must not send a rename herdr is certain to reject"
+  pass "fm_backend_herdr_apply_display_name: skips an undisambiguatable collision with a warning naming it"
+}
+
+test_apply_display_name_ignores_own_pane_when_checking_collisions() {
+  # A re-run over an already-renamed pane must not read its own name as another
+  # agent's and disambiguate away from it.
+  local dir log resp fb renamed
+  dir="$TMP_ROOT/apply-display-self"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
+  printf '{"result":{"pane":{"pane_id":"w1:p9"}}}\n' > "$resp/1.out"
+  printf '{"result":{"agent":{"agent_status":"working"}}}\n' > "$resp/2.out"
+  printf '{"result":{"agents":[{"pane_id":"w1:p9","name":"scout-terse-phase01"}]}}\n' > "$resp/3.out"
+  fb=$(make_herdr_fakebin "$dir")
+  PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
+    FM_BACKEND_HERDR_DISPLAY_NAME_POLLS=2 FM_BACKEND_HERDR_DISPLAY_NAME_SLEEP=0 \
+    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_apply_display_name fmtest w1:p9 scout-terse-phase01 fm-terse-phase01' "$ROOT" \
+    >/dev/null 2>&1 || fail "apply_display_name should return 0"
+  renamed=$(awk -F$'\x1f' '{for (i = 1; i <= NF; i++) if ($i == "rename") { print $(i + 2); exit } }' "$log")
+  [ "$renamed" = scout-terse-phase01 ] \
+    || fail "apply_display_name must keep its own name, renamed to '$renamed'"
+  pass "fm_backend_herdr_apply_display_name: its own pane's name is never a collision"
 }
 
 test_apply_display_name_skips_when_agent_never_registers() {
@@ -4459,11 +4548,14 @@ test_projection_recovery_is_read_only_and_refuses_live_duplicate_risk
 test_workspace_find_matches_only_this_homes_own_label
 test_list_live_scoped_to_this_homes_workspace_only
 test_display_name_pure_helper_shapes
-test_create_task_refuses_colliding_display_name_tab
+test_create_task_ignores_colliding_display_name_tab
 test_list_live_emits_only_reversible_fm_labels
 test_apply_display_name_renames_agent_only
 test_apply_display_name_rejects_invalid_grammar
 test_apply_display_name_gives_up_early_on_dead_pane
+test_apply_display_name_disambiguates_live_name_collision
+test_apply_display_name_skips_collision_it_cannot_disambiguate
+test_apply_display_name_ignores_own_pane_when_checking_collisions
 test_apply_display_name_skips_when_agent_never_registers
 test_parse_target
 test_normalize_key

--- a/tests/fm-backend-herdr.test.sh
+++ b/tests/fm-backend-herdr.test.sh
@@ -867,6 +867,27 @@ test_apply_display_name_skips_when_agent_never_registers() {
   pass "fm_backend_herdr_apply_display_name: skips rename without failing when agent never registers"
 }
 
+test_apply_display_name_skips_tab_rename_when_projected() {
+  local dir log resp fb
+  dir="$TMP_ROOT/apply-display-projected"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
+  # presentation-projected spawns pass an empty tab id (fm-spawn.sh clears
+  # HERDR_RENAME_TAB_ID when HERDR_PROJECTED=1) so the task's real tab, which
+  # belongs to the presentation host, is never touched.
+  printf '{"result":{"pane":{"pane_id":"w1:p9"}}}\n' > "$resp/1.out"
+  printf '{"result":{"agent":{"agent_status":"working"}}}\n' > "$resp/2.out"
+  # 3: agent rename (empty success); no tab rename call should be made.
+  fb=$(make_herdr_fakebin "$dir")
+  PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
+    FM_BACKEND_HERDR_DISPLAY_NAME_POLLS=2 FM_BACKEND_HERDR_DISPLAY_NAME_SLEEP=0 \
+    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_apply_display_name fmtest w1:p9 "" scout-terse-phase01' "$ROOT" \
+    || fail "apply_display_name should return 0 for a projected (empty-tab-id) task"
+  assert_contains "$(cat "$log")" $'\x1f''agent'$'\x1f''rename'$'\x1f''w1:p9'$'\x1f''scout-terse-phase01' \
+    "apply_display_name did not agent-rename when tab id is empty"
+  assert_not_contains "$(cat "$log")" $'\x1f''tab'$'\x1f''rename' \
+    "apply_display_name must not tab-rename a presentation-projected (empty tab id) task"
+  pass "fm_backend_herdr_apply_display_name: skips tab rename but still agent-renames when tab id is empty (projected)"
+}
+
 test_create_task_husk_replacement_creates_before_closing() {
   # Safety-critical ordering: the replacement tab must be created BEFORE the
   # husk tab is closed, never the reverse - closing a workspace's LAST
@@ -4437,6 +4458,7 @@ test_create_task_closes_and_replaces_renamed_display_husk
 test_list_live_includes_display_name_labels
 test_apply_display_name_renames_agent_and_tab
 test_apply_display_name_skips_when_agent_never_registers
+test_apply_display_name_skips_tab_rename_when_projected
 test_parse_target
 test_normalize_key
 test_capture_calls_pane_read


### PR DESCRIPTION
## Intent

Auto human-readable Herdr agent/tab names on spawn for firstmate's herdr backend.

When firstmate spawns a crewmate or scout on the herdr backend, automatically set a logical display name so the Herdr agents sidebar is readable without a manual post-spawn rename.

Captain preference (implement in code):
- Scout: scout-<topic-slug>
- Ship: ship-<topic-slug>
- ≤32 chars; must match Herdr agent rename grammar ^[a-z][a-z0-9_-]{0,31}$
- Do not rename the primary seed tab labeled 1
- Prefer task-id slug when it already reads well (terse-oss-phase01 → scout-terse-oss-phase01 after strip/sanitize)

Requirements (current accepted form):
1. Pure helper mapping (task_id, kind) → valid display name: kind=scout → scout-<sanitized-slug>; else ship/crew → ship-<slug>; strip redundant fm-/scout-/ship- prefixes; lowercase; replace invalid chars; truncate to 32 without trailing -/_
2. After Herdr spawn launches the harness (after launch Enter), best-effort wait until the pane reports an agent, then herdr agent rename and herdr tab rename with husk/list_live safety preserved
3. Record herdr_display_name=<name> in task meta for recovery and debugging
4. Rename failures must not fail the spawn (warn on stderr); spawn success remains about endpoint + launch
5. Unit tests for pure name helper (long ids, already-prefixed ids, uppercase, invalid chars) and husk/list_live/rename behavior
6. Update docs/herdr-backend.md briefly: display names are not ownership authority; recorded pane/tab ids remain authoritative
7. Husk re-spawn and list_live must match either fm-<id> create labels or scout-/ship- display forms so renamed tabs are not stranded
8. Existing peeks/sends/teardown continue via meta endpoint ids
9. Secondmate launches out of scope for automatic display names

Out of scope: Herdr UI bold/dim hierarchy; enabling config/herdr-presentation-spaces by default; renaming primary firstmate agent/tab 1.

Acceptance: spawning a herdr scout with id like terse-oss-phase01 yields agent (and safe tab) name scout-terse-oss-phase01 without manual rename; tests pass; no-mistakes PR green.

Note: first run failed only at push because origin was HTTPS to upstream with READ-only access; fork git@github.com:nbost130/firstmate.git is now configured via no-mistakes init --fork-url for push while PRs open against upstream.

## What Changed

- Added a pure helper that maps `(task_id, kind)` to a valid Herdr display name (`scout-<slug>` / `ship-<slug>`), stripping redundant prefixes, sanitizing invalid characters, lowercasing, and truncating to the 32-char rename grammar limit.
- After a Herdr spawn launches the harness, best-effort waits for the pane to report an agent, then renames the Herdr agent and tab (preserving husk/`list_live` matching against both `fm-<id>` and `scout-/ship-` label forms), records `herdr_display_name=<name>` in task meta, and skips the tab rename when the task tab is presentation-projected so the projection reclaim invariant stays intact; rename failures warn on stderr without failing the spawn.
- Updated `docs/configuration.md` and `docs/herdr-backend.md` to document the `herdr_display_name` meta field and rename-poll environment variables, and added unit tests covering the name-mapping helper and the projected-tab rename-skip branch.

## Risk Assessment

✅ Low: The prior finding (unconditional post-spawn tab rename clobbering the presentation-projection reclaim invariant) is fixed exactly as instructed: tab rename is now skipped when HERDR_PROJECTED=1 (empty tab id passed to fm_backend_herdr_apply_display_name, which already treats an empty tab id as "skip tab rename" per bin/backends/herdr.sh:541), while agent rename still fires unconditionally and the flat (non-projected) path is untouched; docs gained a one-sentence clarification and no other files changed.

## Testing

Ran the herdr backend's bash unit-test file directly (`bash tests/fm-backend-herdr.test.sh`), which is the smallest relevant test for this change: all 166 assertions passed cleanly with exit 0, including the newly added test_apply_display_name_skips_tab_rename_when_projected, which exercises exactly the projected-tab-rename-skip branch the round-1 finding flagged as untested — it confirms an agent rename fires and no tab rename call is made when the tab id is empty. Note: invoking the same test via the repo's bin/fm-test-run.sh wrapper produced identical 166/166 ok output but then hung past a 240s timeout after printing the final test result, apparently in the wrapper's post-run bookkeeping (tee/summary) rather than in the test itself — this looks like a pre-existing harness quirk unrelated to this diff, not a test failure, since the direct bash invocation completes and exits 0 immediately. Worktree is clean; no transient artifacts to remove.

<details>
<summary>Evidence: tests/fm-backend-herdr.test.sh full run (166/166 ok)</summary>

<code>ok - fm_backend_herdr_apply_display_name: skips tab rename but still agent-renames when tab id is empty (projected)&#10;... 166 ok lines total, 0 failures</code>

```text
ok - fm_backend_herdr_version_check: accepts the current protocol (14)
ok - fm_backend_herdr_version_check: refuses an old protocol loudly
ok - fm_backend_herdr_version_check: refuses loudly when herdr is not installed
ok - fm_backend_herdr_workspace_label: a primary home (no marker) resolves to 'firstmate'
ok - fm_backend_herdr_workspace_label: a secondmate home (.fm-secondmate-home) resolves to '2ndmate-<id>'
ok - fm_backend_herdr_workspace_label: trims whitespace around the marker's secondmate id
ok - fm_backend_herdr_workspace_label: an empty marker file falls back to the primary label 'firstmate'
ok - fm_backend_herdr_workspace_label: two different secondmate homes get two different, non-colliding labels
ok - fm_backend_herdr_cli: sets HERDR_SESSION AND appends a trailing --session flag on every call
ok - fm_backend_herdr_launcher_identity: a firstmate not running inside herdr has no launcher workspace to inherit
ok - fm_backend_herdr_launcher_identity: HERDR_ENV=1 without a pane id selects the backend but binds no parent
ok - fm_backend_herdr_launcher_identity: resolves the launcher's exact workspace even when a same-labeled workspace sorts first
ok - fm_backend_herdr_launcher_identity: refuses a launcher pane that names a different herdr session
ok - fm_backend_herdr_launcher_identity: refuses a claimed pane without exact server identity
ok - fm_backend_herdr_launcher_identity: refuses a launcher pane whose injected socket belongs to another herdr server
ok - fm_backend_herdr_launcher_identity: refuses when the launcher's own pane no longer resolves
ok - fm_backend_herdr_launcher_identity: refuses when the launcher's pane and tab disagree about their workspace
ok - fm_backend_herdr_launcher_identity: refuses when the launcher's workspace is gone from its own session
ok - fm_backend_herdr_workspace_ensure: places a worker in the launcher's exact workspace, not the first same-labeled one
ok - fm_backend_herdr_workspace_ensure: refuses to guess between two same-labeled home workspaces
ok - fm_backend_herdr_workspace_ensure: a --secondmate container resolves that home's own workspace, not the launcher's
ok - fm_backend_herdr_container_ensure: surfaces the exact ambiguous-placement refusal instead of a generic failure
ok - fm_backend_herdr_container_ensure: version-gates, starts the server, ensures the firstmate workspace, echoes session:workspace_id + the seeded default tab id
ok - fm_backend_herdr_container_ensure: reuses an existing firstmate workspace without recreating it, and reports no seeded default tab (adopted, not created)
ok - fm_backend_herdr_container_ensure: workspace create passes --no-focus
ok - fm_backend_herdr_container_ensure: creates the workspace under the SECONDMATE home's own label, not 'firstmate'
ok - fm_backend_herdr_create_task: prunes exactly the seeded default tab container_ensure identified, once the first real task tab exists
ok - herdr repeated spawn/teardown: one persistent firstmate workspace reused, zero orphans, default tab pruned, create ran once
ok - fm_backend_herdr_create_task: an ADOPTED workspace's pre-existing tab is never pruned (the created-vs-adopted gate)
ok - fm_backend_herdr_create_task: the label-collision startup-workspace scenario (2026-07-02 incident) leaves the captain's live tab untouched
ok - fm_backend_herdr_workspace_prune_seeded_default_tab: refuses to close the seeded default tab when its pane reports a working agent (defense in depth)
ok - fm_backend_herdr_create_task: refuses a duplicate tab label (herdr's own tab create has no uniqueness check)
ok - fm_backend_herdr_create_task: a same-labeled tab with a live (even idle) registered agent still refuses exactly as before
ok - fm_backend_herdr_create_task: scans every same-labeled tab and refuses if any duplicate is live
ok - fm_backend_herdr_create_task: closes and replaces a same-labeled tab whose pane is dead (pane_not_found)
ok - fm_backend_herdr_create_task: closes and replaces a same-labeled tab whose pane is alive but hosts no registered agent (a restored plain shell)
ok - fm_backend_herdr_create_task: closes every confirmed same-labeled husk only after creating the replacement
ok - fm_backend_herdr_create_task: refuses success when a preexisting husk tab remains after replacement
ok - fm_backend_herdr_create_task: refuses (fail-safe) rather than guessing when the duplicate's agent state cannot be classified confidently
ok - fm_backend_herdr_create_task: creates the replacement tab BEFORE closing the husk tab, never the reverse
ok - fm_backend_herdr_create_task: creates a tab and parses tab_id/pane_id from the JSON response, prunes nothing when no seeded tab id is given
ok - fm_backend_herdr_create_task: tab create passes --no-focus
ok - herdr presentation journal: atomically publishes one non-authoritative 128-bit correlator and refuses overwrite
ok - herdr presentation journal: version 2 binds exact home/endpoint/parent identities and advances atomically
ok - herdr presentation create: exact response IDs yield one normal task pane with no workspace-close authority
ok - herdr presentation create: concurrent same-label tabs are never prune targets
ok - herdr presentation focus: snapshot requires one exact active workspace and tab
ok - herdr presentation focus: exact pane close restores the exact prior workspace and tab
ok - herdr presentation focus: cleanup refuses rather than close the captain's active tab
ok - herdr presentation focus: pane close fails when exact focus restoration fails
ok - herdr presentation reclaim: live agent state at the close boundary refuses mutation
ok - herdr presentation cleanup: emptying close behind focus ends the exact shell without a move or focus change
ok - herdr presentation cleanup: emptying close before focus moves the doomed workspace to the end and ends its exact shell
ok - herdr presentation cleanup: emptying close with the focused workspace last skips the move
ok - herdr presentation cleanup: emptying close of the last workspace skips the move
ok - herdr presentation cleanup: a non-emptying close stays plain with no proof, move, or signal
ok - herdr presentation cleanup: no-move plain close requires structured pane removal
ok - herdr presentation cleanup: an ambiguous workspace layout falls back to the plain close
ok - herdr presentation cleanup: a failed repositioning move falls back to the plain close with a warning
ok - herdr presentation cleanup: a pane with a live foreground process falls back to the plain close
ok - herdr presentation cleanup: a transient prompt helper settles into the pane-death path instead of the plain close
ok - herdr presentation cleanup: a SIGHUP-surviving shell is escalated to SIGKILL before giving up
ok - herdr presentation cleanup: a failed pane-death close falls back to the plain close
ok - herdr presentation cleanup: the exact-tab restore remains the backstop behind the pane-death close
tests/fm-backend-herdr.test.sh: line 4072: 11064 Hangup: 1               sleep 300
ok - herdr presentation cleanup: SIGKILL never reaches a pid the exact pane no longer owns
ok - herdr presentation cleanup: every unconfirmed removal restores the exact original workspace order and reports failure
ok - fm_backend_herdr_kill: one session lock covers the focus-safe emptying removal
tests/fm-backend-herdr.test.sh: line 4075: 15336 Hangup: 1               sleep 300
ok - fm_backend_herdr_kill: killing the focused workspace's tab keeps the legitimate plain close
ok - endpoint confirmed-gone: only structured not-found permits record removal and ambiguous identity refuses
ok - fm_backend_herdr_kill: unavailable session locks defer every pane close
ok - herdr presentation focus: projected seeded pruning refuses the active tab
ok - herdr presentation labels: └ concise-task · p:<full-token> for primary and secondmate children
ok - herdr presentation ordering: exact new workspace appends to the primary block while focus and relative orders stay stable
ok - herdr presentation ordering: secondmate children append under their owning parent block
ok - herdr presentation ordering: a foreign legacy child is warning-only and read-only
ok - herdr presentation ordering: intervenin

... [1767 bytes truncated] ...

tize, truncate to 32
ok - fm_backend_herdr_task_label_candidates: fm- plus scout- and ship- display forms
ok - fm_backend_herdr_create_task: replaces a husk whose tab was renamed to scout-<slug>
ok - fm_backend_herdr_list_live: includes scout-/ship- display labels, not seed tab 1
ok - fm_backend_herdr_apply_display_name: renames agent and tab after agent is live
ok - fm_backend_herdr_apply_display_name: skips rename without failing when agent never registers
ok - fm_backend_herdr_apply_display_name: skips tab rename but still agent-renames when tab id is empty (projected)
ok - fm_backend_herdr_parse_target: splits '<session>:<pane_id>' on the FIRST colon (pane_id itself contains one)
ok - fm_backend_herdr_normalize_key: Enter/Escape/C-c map to herdr's verified enter/escape/ctrl+c
ok - fm_backend_herdr_capture: calls 'pane read <pane> --source recent --lines N' with the session set
ok - fm_backend_herdr_capture: works around the verified small-N '--lines' bug by over-fetching and trimming locally
ok - fm_backend_herdr_capture: ensures the session and preserves pane read failure
ok - fm_backend_herdr_send_key: normalizes the key and targets the right pane
ok - fm_backend_herdr_kill: calls pane close and stays best-effort on failure
ok - fm_backend_herdr_current_path: reads pane foreground_cwd (the live running process), not the frozen creation-time cwd
ok - fm_backend_herdr_busy_state: working -> busy
ok - fm_backend_herdr_busy_state: done -> idle, blocked -> idle (surfaced like a stale pane, not suppressed as busy)
ok - fm_backend_herdr_busy_state: unparseable/absent agent state reports unknown, the regex-fallback cue
ok - fm_backend_herdr_composer_state: a bare '❯' composer row reads empty
ok - fm_backend_herdr_composer_state: the ghost placeholder text reads empty, not pending
ok - fm_backend_herdr_composer_state: real composer text reads pending
ok - fm_backend_herdr_composer_state: a slash-command popup's argument-hint placeholder still reads pending (the incident fix)
ok - fm_backend_herdr_composer_state: reports unknown when the pane cannot be captured
ok - fm_backend_herdr_composer_state: reports unknown for bare shell prompts with no composer row
ok - fm_backend_herdr_composer_state: a native idle Pi separator composer reads empty
ok - fm_backend_herdr_composer_state: real Pi composer text remains pending
ok - fm_backend_herdr_composer_state: an incomplete lower Pi separator cannot inherit a stale empty row
ok - fm_backend_herdr_composer_state: Pi separators never authorize working, non-Pi, unreadable, or over-tall targets
ok - fm_backend_herdr_composer_state: a real-claude unbordered '❯' prompt row (no border box in view) reads empty
ok - fm_backend_herdr_composer_state: a real-claude unbordered '❯ <text>' prompt row reads pending
ok - fm_backend_herdr_composer_state: a live unbordered prompt row below a stale bordered decorative box still wins (not misread as the box's own row)
ok - fm_backend_herdr_composer_state: claude's dim prompt-suggestion ghost (the overnight wedge shape) reads empty
ok - fm_backend_herdr_composer_state: real typed text on the same claude prompt row still reads pending
ok - fm_backend_herdr_composer_state: grok's dark-truecolor placeholder (the TRUECOLOR gap) reads empty
ok - fm_backend_herdr_composer_state: grok's real bright typed input still reads pending
ok - fm_backend_herdr_composer_state: a real-codex unbordered '›' prompt row reads empty
ok - fm_backend_herdr_composer_state: a faint real-codex ghost suggestion reads empty
ok - fm_backend_herdr_composer_state: non-faint codex prompt text still reads pending
ok - fm_backend_herdr_wait_for_working: reports 'busy' immediately on the first poll, without spending the rest of the budget
ok - fm_backend_herdr_wait_for_working: a slow transition landing on a later sample within one window is still caught (robust against the 'slow transition' failure direction)
ok - fm_backend_herdr_wait_for_working: spreads six samples across the full budget endpoint without a final trailing sleep
ok - fm_backend_herdr_send_text_submit: applies the herdr minimum confirmation budget before polling agent-state
ok - fm_backend_herdr_wait_for_working: reports 'idle' (readable, genuinely not yet working) when 'busy' never appears
ok - fm_backend_herdr_wait_for_working: reports 'unknown' (a hard read failure, not a timing race) only when EVERY poll in the window fails
ok - fm_backend_herdr_wait_for_working: treats blocked as submit-active for confirmation without changing watcher busy-state semantics
ok - fm_backend_herdr_send_text_submit: reports 'empty' once agent_status reports working after one Enter, without ever reading the composer
ok - fm_backend_herdr_send_text_submit: reports 'pending' when agent_status never reports working after retried Enters (swallowed)
ok - fm_backend_herdr_send_text_submit: a slash-command popup's placeholder fill on Enter #1 never flips agent_status to working, so it does not short-circuit as submitted; Enter #2 is retried and lands it
ok - fm_backend_herdr_send_text_submit: a post-Enter blocked state confirms delivery without retrying into the prompt
ok - fm_backend_herdr_send_text_submit: preexisting working is not accepted as submit proof when the composer still holds the message
ok - fm_backend_herdr_send_text_submit: confirms submission via native agent-state alone, immune to a codex-style dynamic idle-tip composer that would have misread as 'pending' under the old composer-based confirmation
ok - fm_backend_herdr_composer_state: a faint real-codex dynamic idle-tip composer row reads empty
ok - fm_backend_composer_state (herdr): the pre-injection empty-box guard still refuses a genuinely non-empty composer, unaffected by the submit-confirmation change
ok - fm_backend_herdr_send_text_submit: a slow transition landing on a later sample within one Enter's budget is confirmed WITHOUT sending a needless extra Enter
ok - fm_backend_herdr_send_text_submit: reports 'send-failed' when the literal send-text call itself errors
ok - fm_backend_herdr_send_text_submit: reports 'unknown' when the post-Enter agent-get read fails (never retries past an unreadable target)
ok - fm_backend_validate: herdr is a known backend (P2)
ok - fm_backend_busy_state: tmux (no native primitive) always reports unknown, preserving the P1 regex-only path
error: unknown backend 'bogus' (known: tmux herdr zellij orca cmux)
ok - fm_backend_composer_state dispatches tmux/herdr/orca to their named classifiers, unknown for zellij/unrecognized backends
ok - fm-peek/fm-send: explicit stale targets matching metadata use the recorded backend
ok - fm_backend_herdr_normalize_event routes through the shared record with an empty from_status
ok - fm_backend_herdr_escalation_marker keys the dedupe marker exactly like the watcher's .stale-<key>
ok - fm_backend_herdr_apply_transition: blocked dedupe starts only after explicit commit
ok - fm_backend_herdr_apply_transition: a working edge clears the marker so the next ->blocked re-escalates
ok - fm_backend_herdr_clear_transition removes task-owned dedupe state
ok - fm_backend_herdr_apply_transition: idle/done (defer) and unknown/empty (fallback) take no fast action
ok - fm_backend_herdr_wait_transition: a home with no herdr panes falls back to polling (rc 2)
ok - fm_backend_herdr_wait_transition: below-capability protocol/schema falls back to polling (rc 2)
ok - fm_backend_herdr_wait_transition: reconnect level-reconcile returns an uncommitted blocked pane
ok - fm_backend_herdr_wait_transition: subscribes before reconnect level-reconcile
ok - fm_backend_herdr_wait_transition: a still-blocked, already-escalated pane is not re-delivered on reconnect
ok - fm_backend_herdr_wait_transition: a streamed ->blocked edge returns the record sub-poll
ok - fm_backend_herdr_wait_transition: streamed working clears the marker, idle/done are deferred (clean timeout)
ok - fm_backend_herdr_wait_transition: a reader/subscribe failure falls back to polling (rc 2)
ok - fm_backend_herdr_wait_transition: Bash 3.2-safe bad-ack path closes fd 9 and removes its FIFO
ok - fm_backend_herdr_wait_transition: stock macOS Bash clean timeout closes fd 9 and returns 1
```
</details>
- Outcome: 🔧 1 issue found → auto-fixed ✅ across 2 runs (38m6s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `bin/fm-spawn.sh:1701` - The new post-launch auto-rename fires unconditionally for any BACKEND=herdr non-secondmate spawn, including when `config/herdr-presentation-spaces` is enabled and the task tab is a projected child (`HERDR_PROJECTED=1`). In that mode `HERDR_TAB_ID`/`HERDR_PANE_ID` (bin/fm-spawn.sh:1045-1046, 1101-1102) refer to the presentation-projected task tab, which docs/herdr-backend.md:95 and bin/backends/herdr.sh:334 both fix as permanently labeled `fm-&lt;id&gt;` — that exact label is what `fm_backend_herdr_projection_live_binding_matches` (bin/backends/herdr.sh:2135-2140) requires on every later husk reclaim (`fm_backend_herdr_projection_reclaim_task`, invoked from fm-spawn.sh:1034-1039 on re-spawn). Because `fm_backend_herdr_apply_display_name` renames that tab to `scout-&lt;slug&gt;`/`ship-&lt;slug&gt;` right after launch, every subsequent re-spawn of a presentation-projected task will fail the exact-label check and hit the existing `warning: ... ambiguous, renamed, foreign, or non-nested live shape; spawning flat` path (bin/backends/herdr.sh:2198), permanently degrading the presentation-reclaim optimization for any task that goes through this new rename. This directly contradicts the codebase&#39;s own stated invariant that &#39;the presentation journal is deliberately excluded from that path&#39; (bin/backends/herdr.sh:50-53) and is untested — none of the new tests in tests/fm-backend-herdr.test.sh exercise the HERDR_PROJECTED interaction. It does not crash the spawn (reclaim failure gracefully falls back to a flat spawn), but it silently kills a working, documented feature path for any user who has opted into `config/herdr-presentation-spaces`. The earliest shared boundary to fix this is the call site itself: skip (or otherwise special-case) the `fm_backend_herdr_apply_display_name` call when `HERDR_PROJECTED` is 1, consistent with the existing philosophy that presentation-projected tabs are excluded from label-based matching.

🔧 Fix: Skip herdr tab rename when task tab is presentation-projected
✅ Re-checked - no issues remain.

</details>

<details>
<summary>🔧 **Test** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `tests/fm-backend-herdr.test.sh:833` - The follow-up review commit (33e8ddb) that skips the herdr tab rename when the task tab is presentation-projected (fm-spawn.sh: HERDR_RENAME_TAB_ID cleared when HERDR_PROJECTED=1, passed as an empty tab id into fm_backend_herdr_apply_display_name) has no automated test coverage anywhere in the diff. The two existing apply_display_name unit tests (tests/fm-backend-herdr.test.sh:833,853) both pass a non-empty tab id and only assert the tab-gets-renamed and never-registers-agent paths; neither exercises the empty-tab-id/projected-skip branch, and no presentation-e2e test references HERDR_DISPLAY_NAME/HERDR_PROJECTED together either. I manually verified the branch behaves correctly (agent rename fires, tab rename is skipped when tab id is empty), so this is a coverage gap rather than a functional bug, but the intent&#39;s stated safety property for projected tabs is only proven here by manual testing, not by the test suite.
- `./tests/fm-backend-herdr.test.sh (full run, 165/165 ok, exit 0)`
- `bash -c 'fm_backend_herdr_display_name terse-oss-phase01 scout' -> scout-terse-oss-phase01 (acceptance example)`
- `bash -c 'fm_backend_herdr_display_name memberos-auth ship' -> ship-memberos-auth`
- `bash -n bin/backends/herdr.sh && bash -n bin/fm-spawn.sh (syntax check)`
- `manual fake-herdr-CLI transcript: fm_backend_herdr_apply_display_name fmtest w1:p9 "" scout-terse-phase01 -> agent rename called, tab rename NOT called (verifies the untested presentation-projected skip branch)`

🔧 Fix: Add unit test for herdr projected-tab display-name skip branch
✅ Re-checked - no issues remain.
- <code>`bash tests/fm-backend-herdr.test.sh` (direct invocation, exit 0, 166/166 ok, including the new test_apply_display_name_skips_tab_rename_when_projected)</code>
- <code>`bin/fm-test-run.sh tests/fm-backend-herdr.test.sh` (same 166 ok assertions observed in output, but the wrapper hung post-completion past the outer timeout — see note in testing_summary)</code>
- <code>`git show 35fa659` to confirm the diff adds exactly the requested test and registers it in the bottom test-invocation list</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
