### PR TITLE
fix(herdr): recover unreachable task cleanup safely

### DIFF
--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -52,10 +52,14 @@
 # leased home releases its durable treehouse lease so the pool slot is freed,
 # never left leased forever. If the treehouse return fails, teardown leaves the
 # leased home and state in place instead of hiding a still-held lease.
-# Usage: fm-teardown.sh <task-id> [--force]
+# Usage: fm-teardown.sh <task-id> [--force|--discard-approved-by-captain]
 #   --force skips ordinary-task dirty and landed-work checks, skips scout report
 #   checks, and discards secondmate child work for kind=secondmate. Only use it
 #   when the captain has explicitly said to discard the work.
+#   --discard-approved-by-captain enables one narrower recovery for an ordinary
+#   Herdr task whose exact recorded endpoint cannot be inspected. It still
+#   refuses dirty, shared, mismatched, detached, or otherwise unprovable git
+#   worktrees and does not authorize any other task or cleanup path.
 #
 # Transient / stale worktree git lock recovery (teardown-lock-race): a crew process
 # killed mid-git-operation can leave a .git/worktrees/<wt>/index.lock (or, for a
@@ -115,7 +119,15 @@ if [ "$#" -lt 1 ] || ! fm_task_id_path_safe "$1"; then
   exit 2
 fi
 ID=$1
-FORCE=${2:-}
+[ "$#" -le 2 ] || { echo "error: invalid teardown request" >&2; exit 2; }
+FORCE=
+DISCARD_APPROVED_BY_CAPTAIN=0
+case "${2:-}" in
+  '') ;;
+  --force) FORCE=--force ;;
+  --discard-approved-by-captain) DISCARD_APPROVED_BY_CAPTAIN=1 ;;
+  *) echo "error: invalid teardown approval flag" >&2; exit 2 ;;
+esac
 # Fail closed before any fleet mutation: a no-mistakes gate agent must never tear
 # down a worktree (see bin/fm-gate-refuse-lib.sh).
 fm_refuse_if_gate_agent
@@ -568,6 +580,152 @@ worktree_registered_for_project() {
 $listed
 EOF
   return 1
+}
+
+canonical_git_dir() {  # <repo-or-worktree> <git-rev-parse-key>
+  local repo=$1 key=$2 path
+  path=$(git -C "$repo" rev-parse --path-format=absolute "$key" 2>/dev/null) || return 1
+  [ -d "$path" ] || return 1
+  (cd "$path" 2>/dev/null && pwd -P)
+}
+
+herdr_discard_meta_is_unambiguous() {  # <canonical-worktree>
+  local expected=$1 other other_id recorded canonical
+  for other in "$STATE"/*.meta; do
+    [ -e "$other" ] || [ -L "$other" ] || continue
+    [ "$other" != "$META" ] || continue
+    if [ ! -f "$other" ] || [ -L "$other" ]; then
+      if grep -Fqx "worktree=$WT" "$other" 2>/dev/null; then
+        echo "REFUSED: another task record ambiguously claims Herdr worktree $WT; preserving task state." >&2
+        return 1
+      fi
+      continue
+    fi
+    other_id=$(basename "$other" .meta)
+    recorded=$(fm_backend_meta_exact_value "$other" worktree 2>/dev/null || true)
+    [ -n "$recorded" ] || continue
+    if [ "$recorded" = "$WT" ]; then
+      echo "REFUSED: Herdr worktree $WT is also recorded for task $other_id; preserving both task records." >&2
+      return 1
+    fi
+    [ -d "$recorded" ] || continue
+    canonical=$(canonical_existing_dir "$recorded" 2>/dev/null || true)
+    if [ -n "$canonical" ] && [ "$canonical" = "$expected" ]; then
+      echo "REFUSED: Herdr worktree $WT is canonically shared with task $other_id; preserving both task records." >&2
+      return 1
+    fi
+  done
+}
+
+validate_herdr_unreachable_discard_worktree() {
+  local project_abs worktree_abs project_top worktree_top project_common worktree_common
+  local expected_branch branch head branch_head listed line listed_abs
+  local record_path record_head record_branch path_matches=0 branch_matches=0 dirty_raw dirty
+  [ "$DISCARD_APPROVED_BY_CAPTAIN" = 1 ] || return 1
+  [ "$KIND" != secondmate ] || {
+    echo "REFUSED: endpoint-independent Herdr discard is not supported for secondmates." >&2
+    return 1
+  }
+  case "$PROJ:$WT" in
+    /*:/*) ;;
+    *) echo "REFUSED: Herdr discard requires absolute recorded project and worktree paths." >&2; return 1 ;;
+  esac
+  project_abs=$(canonical_existing_dir "$PROJ") || {
+    echo "REFUSED: recorded project $PROJ is unavailable; cannot prove repository identity." >&2
+    return 1
+  }
+  worktree_abs=$(canonical_existing_dir "$WT") || {
+    echo "REFUSED: recorded Herdr worktree $WT is unavailable; cannot prove checkout identity." >&2
+    return 1
+  }
+  [ "$project_abs" = "$PROJ" ] && [ "$worktree_abs" = "$WT" ] || {
+    echo "REFUSED: recorded Herdr project or worktree path is not canonical; preserving task state." >&2
+    return 1
+  }
+  [ "$project_abs" != "$worktree_abs" ] || {
+    echo "REFUSED: recorded Herdr worktree is the project checkout itself; preserving it." >&2
+    return 1
+  }
+  project_top=$(git -C "$project_abs" rev-parse --show-toplevel 2>/dev/null) || return 1
+  worktree_top=$(git -C "$worktree_abs" rev-parse --show-toplevel 2>/dev/null) || return 1
+  project_top=$(canonical_existing_dir "$project_top") || return 1
+  worktree_top=$(canonical_existing_dir "$worktree_top") || return 1
+  if [ "$project_top" != "$project_abs" ] || [ "$worktree_top" != "$worktree_abs" ]; then
+    echo "REFUSED: recorded Herdr repository/worktree roots do not match their canonical git roots." >&2
+    return 1
+  fi
+  project_common=$(canonical_git_dir "$project_abs" --git-common-dir) || return 1
+  worktree_common=$(canonical_git_dir "$worktree_abs" --git-common-dir) || return 1
+  if [ "$project_common" != "$worktree_common" ]; then
+    echo "REFUSED: recorded Herdr worktree does not belong to the recorded project repository." >&2
+    return 1
+  fi
+  expected_branch="fm/$ID"
+  branch=$(git -C "$worktree_abs" symbolic-ref --quiet --short HEAD 2>/dev/null) || {
+    echo "REFUSED: recorded Herdr worktree is detached; task branch ownership is unprovable." >&2
+    return 1
+  }
+  [ "$branch" = "$expected_branch" ] || {
+    echo "REFUSED: recorded Herdr worktree is on branch $branch, expected $expected_branch for task $ID." >&2
+    return 1
+  }
+  head=$(git -C "$worktree_abs" rev-parse --verify 'HEAD^{commit}' 2>/dev/null) || return 1
+  branch_head=$(git -C "$worktree_abs" rev-parse --verify "refs/heads/$expected_branch^{commit}" 2>/dev/null) || return 1
+  [ "$head" = "$branch_head" ] || {
+    echo "REFUSED: recorded Herdr task branch does not resolve to the inspected worktree HEAD." >&2
+    return 1
+  }
+  listed=$(git -C "$project_abs" -c core.quotePath=false worktree list --porcelain 2>/dev/null) || return 1
+  record_path=
+  record_head=
+  record_branch=
+  while IFS= read -r line || [ -n "$line" ]; do
+    case "$line" in
+      worktree\ *)
+        record_path=${line#worktree }
+        record_head=
+        record_branch=
+        ;;
+      HEAD\ *) record_head=${line#HEAD } ;;
+      branch\ *) record_branch=${line#branch } ;;
+      '')
+        if [ -n "$record_path" ]; then
+          listed_abs=$(canonical_existing_dir "$record_path" 2>/dev/null || true)
+          if [ "$listed_abs" = "$worktree_abs" ]; then
+            path_matches=$((path_matches + 1))
+            [ "$record_head" = "$head" ] && [ "$record_branch" = "refs/heads/$expected_branch" ] || {
+              echo "REFUSED: git worktree registration does not match the recorded Herdr branch and HEAD." >&2
+              return 1
+            }
+          fi
+          [ "$record_branch" != "refs/heads/$expected_branch" ] || branch_matches=$((branch_matches + 1))
+        fi
+        record_path=
+        ;;
+    esac
+  done <<FMEOF
+$listed
+
+FMEOF
+  if [ "$path_matches" -ne 1 ] || [ "$branch_matches" -ne 1 ]; then
+    echo "REFUSED: recorded Herdr checkout ownership is missing, duplicated, or ambiguous in git worktree registration." >&2
+    return 1
+  fi
+  herdr_discard_meta_is_unambiguous "$worktree_abs" || return 1
+  dirty_raw=$(git -C "$worktree_abs" status --porcelain 2>/dev/null) || {
+    echo "REFUSED: cannot inspect the recorded Herdr worktree for uncommitted changes." >&2
+    return 1
+  }
+  dirty=$(printf '%s\n' "$dirty_raw" | grep -vE '^\?\? (\.claude/|\.fm-(grok|kimi)-turnend$)' | head -1 || true)
+  [ -z "$dirty" ] || {
+    echo "REFUSED: recorded Herdr worktree $WT is dirty; explicit discard approval does not authorize an unproved dirty checkout." >&2
+    return 1
+  }
+  if [ -e "$STATE/$ID.herdr-presentation" ] || [ -L "$STATE/$ID.herdr-presentation" ]; then
+    echo "REFUSED: task $ID has a Herdr presentation journal whose endpoint-independent ownership cannot be proved." >&2
+    return 1
+  fi
+  return 0
 }
 
 inspectable_git_worktree() {
@@ -1533,7 +1691,25 @@ if [ "$BACKEND" = orca ] && [ "$KIND" != scout ] && [ "$KIND" != secondmate ] &&
   ORCA_PATH_MATCH_VERIFIED=1
 fi
 
-if [ -d "$WT" ] && [ "$FORCE" != "--force" ]; then
+HERDR_UNREACHABLE_DISCARD=0
+if [ "$BACKEND" = herdr ] && [ "$DISCARD_APPROVED_BY_CAPTAIN" = 1 ]; then
+  teardown_herdr_require_prerequisites "$ID" || exit 1
+  fm_backend_herdr_parse_target "$T" || exit 1
+  herdr_presence=$(fm_backend_herdr_pane_presence_state "$FM_BACKEND_HERDR_SESSION" "$FM_BACKEND_HERDR_PANE")
+  case "$herdr_presence" in
+    unknown)
+      validate_herdr_unreachable_discard_worktree || exit 1
+      HERDR_UNREACHABLE_DISCARD=1
+      ;;
+    dead|present) ;;
+    *)
+      echo "REFUSED: Herdr endpoint inspection returned an unsupported state; preserving task state." >&2
+      exit 1
+      ;;
+  esac
+fi
+
+if [ -d "$WT" ] && [ "$FORCE" != "--force" ] && [ "$HERDR_UNREACHABLE_DISCARD" != 1 ]; then
   if validate_worktree_teardown_safety; then
     :
   else
@@ -1556,7 +1732,7 @@ fi
 # refuses before any destructive step.
 TEARDOWN_HERDR_SESSION=
 TEARDOWN_HERDR_PANE=
-if [ "$BACKEND" = herdr ]; then
+if [ "$BACKEND" = herdr ] && [ "$HERDR_UNREACHABLE_DISCARD" != 1 ]; then
   teardown_herdr_preflight_target "$T" "$ID" || exit 1
   fm_backend_herdr_parse_target "$T" || exit 1
   TEARDOWN_HERDR_SESSION=$FM_BACKEND_HERDR_SESSION
@@ -1636,7 +1812,7 @@ if [ "$HERDR_PRESENTATION_RETIRE_CANDIDATE" = 1 ]; then
   else
     echo "warning: herdr presentation focus lock unavailable; refusing a concurrent focus-unsafe pane close" >&2
   fi
-elif [ "$BACKEND" = herdr ]; then
+elif [ "$BACKEND" = herdr ] && [ "$HERDR_UNREACHABLE_DISCARD" != 1 ]; then
   if teardown_herdr_session_lock_held "$TEARDOWN_HERDR_SESSION"; then
     fm_backend_herdr_kill_serialized "$TEARDOWN_HERDR_SESSION" "$TEARDOWN_HERDR_PANE" 2>/dev/null || true
   else
@@ -1661,7 +1837,7 @@ fi
 # the locked close. Only a structured not-found proves the pane gone; unknown
 # presence, missing or malformed endpoint identity, and missing confirmation
 # machinery all refuse.
-if [ "$BACKEND" = herdr ]; then
+if [ "$BACKEND" = herdr ] && [ "$HERDR_UNREACHABLE_DISCARD" != 1 ]; then
   fm_backend_source herdr || true
   if ! declare -F fm_backend_herdr_endpoint_confirmed_gone >/dev/null 2>&1; then
     echo "error: herdr endpoint confirmation is unavailable for $ID; retaining every durable task record" >&2

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -163,9 +163,9 @@ family_for_basename() {
       printf '%s\n' live-harness-optin
       ;;
     fm-backend-herdr.test.sh|fm-backend-tmux-smoke.test.sh|fm-backend.test.sh|\
-    fm-herdr-session-cleanup.test.sh|fm-send-strict.test.sh|fm-spawn-batch.test.sh|\
-    fm-spawn-dispatch-profile.test.sh|fm-spawn-worktree-settle.test.sh|\
-    fm-teardown-endpoint-safety.test.sh)
+    fm-herdr-session-cleanup.test.sh|fm-herdr-unreachable-teardown.test.sh|\
+    fm-send-strict.test.sh|fm-spawn-batch.test.sh|fm-spawn-dispatch-profile.test.sh|\
+    fm-spawn-worktree-settle.test.sh|fm-teardown-endpoint-safety.test.sh)
       printf '%s\n' backend-dispatch
       ;;
     fm-pr-check-security.test.sh|fm-pr-merge.test.sh|fm-review-diff.test.sh|\
@@ -381,8 +381,8 @@ run_coverage_guard() {
     return 1
   fi
   cat "$tmp/s1" "$tmp/s2" | LC_ALL=C sort -u >"$tmp/shards_union"
-  missing=$(comm -23 "$tmp/proven" "$tmp/shards_union" || true)
-  extra=$(comm -13 "$tmp/proven" "$tmp/shards_union" || true)
+  missing=$(LC_ALL=C comm -23 "$tmp/proven" "$tmp/shards_union" || true)
+  extra=$(LC_ALL=C comm -13 "$tmp/proven" "$tmp/shards_union" || true)
   if [ -n "$missing" ] || [ -n "$extra" ]; then
     log "coverage guard: portable shards must equal the proven-isolated set"
     [ -z "$missing" ] || { log "missing from shards:"; printf '%s\n' "$missing" >&2; }
@@ -404,7 +404,7 @@ run_coverage_guard() {
   for pair in "shards_union:serial" "shards_union:herdr" "serial:herdr"; do
     a=${pair%%:*}
     b=${pair#*:}
-    comm -12 "$tmp/$a" "$tmp/$b" >"$tmp/overlap"
+    LC_ALL=C comm -12 "$tmp/$a" "$tmp/$b" >"$tmp/overlap"
     if [ -s "$tmp/overlap" ]; then
       log "coverage guard: overlap between $a and $b:"
       cat "$tmp/overlap" >&2
@@ -422,8 +422,8 @@ run_coverage_guard() {
     return 1
   fi
   LC_ALL=C sort -u "$tmp/union_raw" >"$tmp/union"
-  missing=$(comm -23 "$tmp/all" "$tmp/union" || true)
-  extra=$(comm -13 "$tmp/all" "$tmp/union" || true)
+  missing=$(LC_ALL=C comm -23 "$tmp/all" "$tmp/union" || true)
+  extra=$(LC_ALL=C comm -13 "$tmp/all" "$tmp/union" || true)
   if [ -n "$missing" ] || [ -n "$extra" ]; then
     log "coverage guard: union of portable shards + portable serial + Herdr must equal tests/*.test.sh"
     [ -z "$missing" ] || { log "missing from union:"; printf '%s\n' "$missing" >&2; }
@@ -436,7 +436,7 @@ run_coverage_guard() {
     "$ROOT/bin/fm-test-isolation-proof.sh" --list | LC_ALL=C sort -u >"$tmp/proof_list"
     if ! cmp -s "$tmp/proven" "$tmp/proof_list"; then
       log "coverage guard: embedded proven-isolated set diverges from bin/fm-test-isolation-proof.sh --list"
-      comm -3 "$tmp/proven" "$tmp/proof_list" >&2 || true
+      LC_ALL=C comm -3 "$tmp/proven" "$tmp/proof_list" >&2 || true
       rm -rf "$tmp"
       return 1
     fi

--- a/tests/fm-herdr-unreachable-teardown.test.sh
+++ b/tests/fm-herdr-unreachable-teardown.test.sh
@@ -1,0 +1,217 @@
+#!/usr/bin/env bash
+# Regression tests for captain-approved cleanup of an unreachable Herdr endpoint.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+fm_git_identity fmtest fmtest@example.invalid
+
+TEARDOWN="$ROOT/bin/fm-teardown.sh"
+TMP_ROOT=$(fm_test_tmproot fm-teardown-herdr-unreachable)
+
+make_fakebin() {  # <case-dir> <mode>
+  local case_dir=$1 mode=$2
+  mkdir -p "$case_dir/fakebin"
+  cat > "$case_dir/fakebin/treehouse" <<'SH'
+#!/usr/bin/env bash
+set -eu
+printf 'treehouse' >> "${FM_RUNTIME_LOG:?}"
+printf ' <%s>' "$@" >> "${FM_RUNTIME_LOG:?}"
+printf '\n' >> "${FM_RUNTIME_LOG:?}"
+[ "${1:-}" = return ] || exit 1
+shift
+wt=
+for arg in "$@"; do
+  case "$arg" in --force) ;; *) wt=$arg ;; esac
+done
+[ -n "$wt" ] || exit 1
+git -C "$PWD" worktree remove --force "$wt"
+SH
+  if [ "$mode" = unreachable ]; then
+    cat > "$case_dir/fakebin/herdr" <<'SH'
+#!/usr/bin/env bash
+printf 'herdr' >> "${FM_RUNTIME_LOG:?}"
+printf ' <%s>' "$@" >> "${FM_RUNTIME_LOG:?}"
+printf '\n' >> "${FM_RUNTIME_LOG:?}"
+printf '%s\n' '{"error":{"code":"invalid_endpoint","message":"recorded endpoint is unavailable"}}'
+exit 1
+SH
+  else
+    cat > "$case_dir/fakebin/herdr" <<'SH'
+#!/usr/bin/env bash
+set -u
+printf 'herdr' >> "${FM_RUNTIME_LOG:?}"
+printf ' <%s>' "$@" >> "${FM_RUNTIME_LOG:?}"
+printf '\n' >> "${FM_RUNTIME_LOG:?}"
+closed=${FM_HERDR_CLOSED:?}
+case "${1:-} ${2:-}" in
+  "session list")
+    printf '%s\n' "{\"sessions\":[{\"name\":\"lab\",\"running\":true,\"socket_path\":\"${FM_HERDR_SOCKET:?}\"}]}"
+    ;;
+  "pane get")
+    if [ -f "$closed" ]; then
+      printf '%s\n' '{"error":{"code":"pane_not_found"}}'
+      exit 1
+    fi
+    printf '%s\n' '{"result":{"pane":{"pane_id":"w1:p1","tab_id":"w1:t1","workspace_id":"w1"}}}'
+    ;;
+  "pane close")
+    : > "$closed"
+    printf '%s\n' '{"result":{"closed":true}}'
+    ;;
+  "workspace list")
+    printf '%s\n' '{"error":{"code":"not_available"}}'
+    exit 1
+    ;;
+  *)
+    printf '%s\n' '{}'
+    ;;
+esac
+SH
+  fi
+  chmod +x "$case_dir/fakebin/treehouse" "$case_dir/fakebin/herdr"
+}
+
+make_case() {  # <name> <herdr-mode>
+  local name=$1 mode=$2 case_dir
+  case_dir="$TMP_ROOT/$name"
+  mkdir -p "$case_dir/state" "$case_dir/data" "$case_dir/config"
+  git init -q "$case_dir/project"
+  git -C "$case_dir/project" checkout -q -b main
+  printf '%s\n' base > "$case_dir/project/file.txt"
+  git -C "$case_dir/project" add file.txt
+  git -C "$case_dir/project" commit -q -m base
+  git -C "$case_dir/project" worktree add -q -b "fm/$name" "$case_dir/wt" main
+  : > "$case_dir/runtime.log"
+  : > "$case_dir/herdr.sock"
+  make_fakebin "$case_dir" "$mode"
+  fm_write_meta "$case_dir/state/$name.meta" \
+    "window=lab:w1:p1" "endpoint_task_id=$name" \
+    "worktree=$case_dir/wt" "project=$case_dir/project" \
+    "backend=herdr" "herdr_session=lab" "herdr_workspace_id=w1" \
+    "herdr_tab_id=w1:t1" "herdr_pane_id=w1:p1" \
+    "kind=ship" "mode=local-only"
+  printf '%s\n' "$case_dir"
+}
+
+run_teardown() {  # <case-dir> <id> [flag]
+  local case_dir=$1 id=$2 flag=${3:-}
+  if [ -n "$flag" ]; then
+    FM_ROOT_OVERRIDE="$ROOT" FM_STATE_OVERRIDE="$case_dir/state" \
+    FM_DATA_OVERRIDE="$case_dir/data" FM_CONFIG_OVERRIDE="$case_dir/config" \
+    FM_RUNTIME_LOG="$case_dir/runtime.log" FM_HERDR_CLOSED="$case_dir/closed" \
+    FM_HERDR_SOCKET="$case_dir/herdr.sock" PATH="$case_dir/fakebin:$PATH" \
+      "$TEARDOWN" "$id" "$flag"
+  else
+    FM_ROOT_OVERRIDE="$ROOT" FM_STATE_OVERRIDE="$case_dir/state" \
+    FM_DATA_OVERRIDE="$case_dir/data" FM_CONFIG_OVERRIDE="$case_dir/config" \
+    FM_RUNTIME_LOG="$case_dir/runtime.log" FM_HERDR_CLOSED="$case_dir/closed" \
+    FM_HERDR_SOCKET="$case_dir/herdr.sock" PATH="$case_dir/fakebin:$PATH" \
+      "$TEARDOWN" "$id"
+  fi
+}
+
+assert_refused_intact() {  # <case-dir> <id> <description> [flag]
+  local case_dir=$1 id=$2 description=$3 flag=${4:-} rc
+  set +e
+  run_teardown "$case_dir" "$id" "$flag" > "$case_dir/out" 2> "$case_dir/err"
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "$description: teardown unexpectedly succeeded"
+  assert_present "$case_dir/state/$id.meta" "$description: task metadata was removed"
+  assert_present "$case_dir/wt" "$description: worktree was removed"
+  assert_absent "$case_dir/closed" "$description: runtime pane was closed"
+  ! grep -F 'treehouse <return>' "$case_dir/runtime.log" >/dev/null \
+    || fail "$description: worktree return ran before refusal"
+}
+
+test_unreachable_requires_exact_approval() {
+  local case_dir id=normal-refusal
+  case_dir=$(make_case "$id" unreachable)
+  assert_refused_intact "$case_dir" "$id" "unreachable endpoint without discard approval"
+  assert_grep "ambiguous structured presence" "$case_dir/err" \
+    "normal cleanup did not report the unreachable endpoint"
+  pass "unreachable Herdr endpoint remains intact without the exact captain discard flag"
+}
+
+test_unreachable_approved_clean_checkout_succeeds() {
+  local case_dir id=approved-clean
+  case_dir=$(make_case "$id" unreachable)
+  printf '%s\n' \
+    'pr=https://github.com/example/repo/pull/4' \
+    'pr_head=5644454b8f40dcebf5c75835cdeb98978c4873e5' \
+    >> "$case_dir/state/$id.meta"
+  run_teardown "$case_dir" "$id" --discard-approved-by-captain \
+    > "$case_dir/out" 2> "$case_dir/err" \
+    || fail "approved unreachable cleanup failed: $(cat "$case_dir/err")"
+  assert_absent "$case_dir/state/$id.meta" "approved cleanup retained task metadata"
+  assert_absent "$case_dir/wt" "approved cleanup retained the exact worktree"
+  grep -F 'treehouse <return> <--force>' "$case_dir/runtime.log" >/dev/null \
+    || fail "approved cleanup did not return the verified worktree"
+  pass "exact captain approval removes a clean, uniquely owned worktree when the Herdr endpoint is unreachable"
+}
+
+test_unreachable_refuses_identity_mismatches() {
+  local case_dir id other
+
+  id='repo-mismatch'
+  case_dir=$(make_case "$id" unreachable)
+  git init -q "$case_dir/other-project"
+  other="$case_dir/other-project"
+  perl -0pi -e "s{^project=.*$}{project=$other}m" "$case_dir/state/$id.meta"
+  assert_refused_intact "$case_dir" "$id" "repository mismatch" --discard-approved-by-captain
+
+  id='worktree-mismatch'
+  case_dir=$(make_case "$id" unreachable)
+  git init -q "$case_dir/other-worktree"
+  other="$case_dir/other-worktree"
+  perl -0pi -e "s{^worktree=.*$}{worktree=$other}m" "$case_dir/state/$id.meta"
+  assert_refused_intact "$case_dir" "$id" "worktree mismatch" --discard-approved-by-captain
+
+  id='branch-mismatch'
+  case_dir=$(make_case "$id" unreachable)
+  git -C "$case_dir/wt" branch -m fm/not-the-task
+  assert_refused_intact "$case_dir" "$id" "branch mismatch" --discard-approved-by-captain
+
+  pass "approved unreachable cleanup refuses mismatched repository, worktree, and branch identity"
+}
+
+test_unreachable_refuses_ambiguous_or_dirty_checkout() {
+  local case_dir id
+
+  id=ambiguous-owner
+  case_dir=$(make_case "$id" unreachable)
+  fm_write_meta "$case_dir/state/other-task.meta" \
+    "window=lab:w9:p9" "endpoint_task_id=other-task" \
+    "worktree=$case_dir/wt" "project=$case_dir/project" \
+    "backend=herdr" "herdr_session=lab" "herdr_workspace_id=w9" \
+    "herdr_tab_id=w9:t9" "herdr_pane_id=w9:p9"
+  assert_refused_intact "$case_dir" "$id" "ambiguous checkout ownership" --discard-approved-by-captain
+
+  id=dirty-checkout
+  case_dir=$(make_case "$id" unreachable)
+  printf '%s\n' dirty >> "$case_dir/wt/file.txt"
+  assert_refused_intact "$case_dir" "$id" "dirty checkout" --discard-approved-by-captain
+
+  pass "approved unreachable cleanup refuses shared and dirty checkouts"
+}
+
+test_healthy_endpoint_uses_normal_close_path() {
+  local case_dir id=healthy-endpoint
+  case_dir=$(make_case "$id" healthy)
+  run_teardown "$case_dir" "$id" --discard-approved-by-captain \
+    > "$case_dir/out" 2> "$case_dir/err" \
+    || fail "healthy endpoint cleanup failed: $(cat "$case_dir/err")"
+  assert_present "$case_dir/closed" "healthy endpoint was not closed"
+  assert_absent "$case_dir/state/$id.meta" "healthy endpoint cleanup retained metadata"
+  assert_absent "$case_dir/wt" "healthy endpoint cleanup retained worktree"
+  grep -F 'herdr <pane> <close> <w1:p1>' "$case_dir/runtime.log" >/dev/null \
+    || fail "healthy endpoint did not use the normal exact-pane close path"
+  pass "healthy Herdr endpoint still uses the normal locked close and confirmation path"
+}
+
+test_unreachable_requires_exact_approval
+test_unreachable_approved_clean_checkout_succeeds
+test_unreachable_refuses_identity_mismatches
+test_unreachable_refuses_ambiguous_or_dirty_checkout
+test_healthy_endpoint_uses_normal_close_path


### PR DESCRIPTION
## Summary
- add an exact `--discard-approved-by-captain` recovery path for ordinary Herdr tasks whose recorded pane cannot be inspected
- prove task metadata, canonical repository/worktree identity, unique git-worktree ownership, exact `fm/<task>` branch and HEAD, clean status, and absence of ambiguous task ownership before returning the worktree
- preserve the normal locked pane-close path for reachable endpoints and keep `--force`, landed-work, dirty-worktree, secondmate, and merge-authority behavior unchanged
- register executable regressions in the test runner and make its C-sorted coverage comparisons locale-stable

## Diagnosis
- initiating trigger: cleanup is requested after the task has finished
- masking condition: the recorded named Herdr session/pane is still reachable, allowing the normal lock and structured close-confirmation path
- visible symptom: when the endpoint is unavailable or reports `invalid_endpoint`, teardown refuses before returning the otherwise preserved task worktree, even with explicit discard approval
- smallest counterfactual: stopping only the isolated named Herdr lab session changes the same valid task record from successful live-endpoint cleanup to an ambiguous-presence refusal

## Validation
- real isolated Herdr lab: reproduced the stopped-session refusal, then confirmed the new exact approval flag removes only the verified clean worktree while the default Herdr session tripwire remains unchanged
- `tests/fm-herdr-unreachable-teardown.test.sh`
- `tests/fm-teardown-endpoint-safety.test.sh`
- `tests/fm-teardown.test.sh`
- `tests/fm-test-run.test.sh`
- `bin/fm-lint.sh` with pinned ShellCheck 0.11.0
- `bash -n` and `git diff --check`

Direct PR delivery was requested; no no-mistakes command was run.
