### PR TITLE
fix(herdr): bind server ensure and all send/read operations to server identity

### DIFF
--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -1355,8 +1355,12 @@ fm_backend_herdr_workspace_find() {  # <session>
 # FM_BACKEND_HERDR_OWN_SOCKET_REASON, so each call site's message stays
 # specific to what it was trying to do (place a worker vs. bind a server).
 #
-# Sets, only on a 0 return, FM_BACKEND_HERDR_OWN_SOCKET to the canonical
-# claimed socket. Always sets FM_BACKEND_HERDR_OWN_SOCKET_REASON.
+# Sets FM_BACKEND_HERDR_OWN_SOCKET (the canonical claimed socket) and
+# FM_BACKEND_HERDR_OWN_SESSION_SOCKET (<session>'s resolved socket) as soon
+# as each is known - so BOTH are also populated on a socket-mismatch refusal,
+# which callers' mismatch error messages rely on; a set value is therefore
+# not by itself proof of a match. Always sets
+# FM_BACKEND_HERDR_OWN_SOCKET_REASON.
 #
 # Returns:
 #   0 - this process's own pane's session and socket both match <session>.

--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -1208,14 +1208,96 @@ fm_backend_herdr_projection_order_best_effort() {  # <session> <created-workspac
 # has-session || tmux new-session -d`. Verified: a bare socket CLI call does
 # NOT auto-start the server, so this must run before any workspace/tab/pane
 # call. Bounded poll for the server to report running.
+#
+# 2026-08-01 incident: this used to trust a single `status --json` probe and
+# unconditionally launch another `herdr ... server` whenever that one probe
+# read anything but exactly "true" - including a transient miss against a
+# session that was already alive. Reproduced in the isolated lab: forcing
+# just the FIRST such probe to misreport made this function invoke `herdr
+# server` again against an already-running named session, and the session
+# was unreachable for the remainder of the 10s poll before recovering - a
+# real, disruptive restart of a server nothing was ever wrong with, entirely
+# from this function's own lack of tolerance for one bad read. Two
+# independent hardenings close that:
+#
+#   1. If THIS process is itself running inside a herdr pane that verifiably
+#      belongs to <session> right now (fm_backend_herdr_own_pane_socket_check),
+#      that is proof positive a server for <session> is live - no RPC probe
+#      is trusted over it, and none is ever attempted. A pane that proves a
+#      DIFFERENT session refuses loudly rather than guessing which server to
+#      address or start.
+#   2. Otherwise (no herdr ancestry to check), before concluding "not running"
+#      from one probe, the authoritative session registry is consulted by
+#      NAME: zero matches means nothing owns it yet (safe to start), exactly
+#      one match reports its own running state directly, and MORE than one
+#      match is refused loudly rather than guessed at - never autostarting a
+#      server when any registration already claims this exact name. The same
+#      registry is re-checked once the new server reports running, so a
+#      start that collided with a concurrent one is caught rather than
+#      silently accepted.
 fm_backend_herdr_server_ensure() {  # <session>
-  local session=$1 running out i
+  local session=$1 running out i own_status sessions_json count pane=${HERDR_PANE_ID:-}
+
+  fm_backend_herdr_own_pane_socket_check "$session"
+  own_status=$?
+  case "$own_status" in
+    0) return 0 ;;
+    1)
+      case "$FM_BACKEND_HERDR_OWN_SOCKET_REASON" in
+        cross-session)
+          echo "error: this process's own herdr pane '$pane' reports session '$(fm_backend_herdr_session)' but '$session' was requested; refusing to start or address a server other than the one this process is actually running in" >&2
+          ;;
+        no-socket)
+          echo "error: this process's own herdr pane '$pane' has no injected socket identity; refusing to guess whether it belongs to session '$session'" >&2
+          ;;
+        bad-socket)
+          echo "error: this process's own herdr pane '$pane' reports an unusable socket path; refusing to guess whether it belongs to session '$session'" >&2
+          ;;
+        unresolvable-session)
+          echo "error: herdr session '$session' has no unambiguous socket to match against this process's own pane; refusing to guess server ownership" >&2
+          ;;
+        socket-mismatch)
+          echo "error: this process's own herdr pane '$pane' belongs to the server at '$FM_BACKEND_HERDR_OWN_SOCKET', not session '$session' at '$FM_BACKEND_HERDR_OWN_SESSION_SOCKET'; refusing to start or address a server other than the one this process is actually running in" >&2
+          ;;
+      esac
+      return 1
+      ;;
+    *) ;;  # 2: no herdr ancestry at all - fall through to the name-based path
+  esac
+
   running=$(fm_backend_herdr_cli "$session" status --json 2>/dev/null | jq -r '.server.running // false' 2>/dev/null)
   [ "$running" = "true" ] && return 0
+
+  sessions_json=$(fm_backend_herdr_cli "$session" session list --json 2>/dev/null) || {
+    echo "error: could not list herdr sessions to confirm no server already owns '$session' before starting one" >&2
+    return 1
+  }
+  count=$(printf '%s' "$sessions_json" | jq -r --arg n "$session" '[.sessions[]? | select(.name == $n)] | length' 2>/dev/null)
+  case "$count" in
+    ''|*[!0-9]*)
+      echo "error: herdr session list returned an unreadable result for '$session'; refusing to guess whether a server already owns it" >&2
+      return 1
+      ;;
+  esac
+  if [ "$count" -gt 1 ]; then
+    echo "error: ${count} herdr sessions are already registered under the name '$session'; refusing to guess which one owns it or to start another" >&2
+    return 1
+  fi
+  if [ "$count" -eq 1 ]; then
+    running=$(printf '%s' "$sessions_json" | jq -r --arg n "$session" '[.sessions[]? | select(.name == $n)][0].running // false' 2>/dev/null)
+    [ "$running" = "true" ] && return 0
+  fi
+
   ( fm_backend_herdr_cli "$session" server >/dev/null 2>&1 & ) || return 1
   for i in $(seq 1 20); do
     running=$(fm_backend_herdr_cli "$session" status --json 2>/dev/null | jq -r '.server.running // false' 2>/dev/null)
-    [ "$running" = "true" ] && return 0
+    if [ "$running" = "true" ]; then
+      sessions_json=$(fm_backend_herdr_cli "$session" session list --json 2>/dev/null) || sessions_json=
+      count=$(printf '%s' "$sessions_json" | jq -r --arg n "$session" '[.sessions[]? | select(.name == $n)] | length' 2>/dev/null)
+      [ "$count" = 1 ] && return 0
+      echo "error: starting a herdr server for session '$session' produced ${count:-an unreadable number of} registrations under that name; refusing to proceed with an ambiguous server" >&2
+      return 1
+    fi
     sleep 0.5
   done
   echo "error: herdr server for session '$session' did not report running within 10s" >&2
@@ -1259,6 +1341,69 @@ fm_backend_herdr_workspace_find() {  # <session>
   fm_backend_herdr_workspace_find_all "$1" | head -1
 }
 
+# fm_backend_herdr_own_pane_socket_check: does THIS process's own injected
+# herdr pane identity verifiably belong to the exact live server behind
+# <session> right now? Single owner of the "same-session, same-socket" proof
+# shared by worker placement (fm_backend_herdr_launcher_identity) and
+# server-level binding (fm_backend_herdr_server_ensure,
+# fm_backend_herdr_target_ready): a process's own pane is proof positive that
+# a server for its exact session is live, which is stronger and cheaper than
+# any single RPC liveness probe, and a mismatch here is proof the caller is
+# about to address a DIFFERENT server than the one it is actually running in.
+#
+# Never prints anything - callers own their own wording, keyed off
+# FM_BACKEND_HERDR_OWN_SOCKET_REASON, so each call site's message stays
+# specific to what it was trying to do (place a worker vs. bind a server).
+#
+# Sets, only on a 0 return, FM_BACKEND_HERDR_OWN_SOCKET to the canonical
+# claimed socket. Always sets FM_BACKEND_HERDR_OWN_SOCKET_REASON.
+#
+# Returns:
+#   0 - this process's own pane's session and socket both match <session>.
+#   2 - this process is NOT running in a herdr pane (no HERDR_PANE_ID at all);
+#       reason "no-pane". Not a failure - there is simply no identity to bind.
+#   1 - a launcher pane IS claimed but its binding is missing, stale, or
+#       belongs to another herdr session/server. Reason is one of:
+#       cross-session, no-socket, bad-socket, unresolvable-session,
+#       socket-mismatch.
+fm_backend_herdr_own_pane_socket_check() {  # <session>
+  local session=$1 pane=${HERDR_PANE_ID:-} claimed_session claimed_socket session_socket
+  FM_BACKEND_HERDR_OWN_SOCKET_REASON=""
+  FM_BACKEND_HERDR_OWN_SOCKET=""
+  FM_BACKEND_HERDR_OWN_SESSION_SOCKET=""
+  if [ -z "$pane" ]; then
+    FM_BACKEND_HERDR_OWN_SOCKET_REASON="no-pane"
+    return 2
+  fi
+  claimed_session=$(fm_backend_herdr_session)
+  if [ "$claimed_session" != "$session" ]; then
+    FM_BACKEND_HERDR_OWN_SOCKET_REASON="cross-session"
+    return 1
+  fi
+  claimed_socket=${HERDR_SOCKET_PATH:-}
+  if [ -z "$claimed_socket" ]; then
+    FM_BACKEND_HERDR_OWN_SOCKET_REASON="no-socket"
+    return 1
+  fi
+  claimed_socket=$(fm_backend_herdr_canonical_socket_path "$claimed_socket") || {
+    FM_BACKEND_HERDR_OWN_SOCKET_REASON="bad-socket"
+    return 1
+  }
+  # shellcheck disable=SC2034  # callers format their own message on refusal
+  FM_BACKEND_HERDR_OWN_SOCKET=$claimed_socket
+  session_socket=$(fm_backend_herdr_presentation_session_socket_path "$session") || {
+    FM_BACKEND_HERDR_OWN_SOCKET_REASON="unresolvable-session"
+    return 1
+  }
+  # shellcheck disable=SC2034  # callers format their own message on refusal
+  FM_BACKEND_HERDR_OWN_SESSION_SOCKET=$session_socket
+  if [ "$claimed_socket" != "$session_socket" ]; then
+    FM_BACKEND_HERDR_OWN_SOCKET_REASON="socket-mismatch"
+    return 1
+  fi
+  return 0
+}
+
 # fm_backend_herdr_launcher_identity: the EXACT herdr workspace that the
 # process making this spawn is itself running in.
 #
@@ -1278,6 +1423,11 @@ fm_backend_herdr_workspace_find() {  # <session>
 # rewrite a running process's environment. Only a live read is the CURRENT
 # parent, which is what placement has to bind to.
 #
+# The same-session/same-socket proof itself is owned by
+# fm_backend_herdr_own_pane_socket_check; this function translates its reason
+# codes to the exact wording this call site has always used, then continues
+# with the pane/tab/workspace resolution that check does not cover.
+#
 # Sets, only on a 0 return:
 #   FM_BACKEND_HERDR_LAUNCHER_PANE_ID
 #   FM_BACKEND_HERDR_LAUNCHER_TAB_ID
@@ -1295,40 +1445,44 @@ fm_backend_herdr_workspace_find() {  # <session>
 #       refuse before creating or publishing any worker endpoint rather than
 #       degrading to a label search.
 fm_backend_herdr_launcher_identity() {  # <session>
-  local session=$1 pane=${HERDR_PANE_ID:-} claimed_session claimed_socket session_socket
+  local session=$1 pane=${HERDR_PANE_ID:-} status
   local pane_out tab_out list tab workspace
   FM_BACKEND_HERDR_LAUNCHER_PANE_ID=""
   FM_BACKEND_HERDR_LAUNCHER_TAB_ID=""
   FM_BACKEND_HERDR_LAUNCHER_WORKSPACE_ID=""
   [ -n "$pane" ] || return 2
 
-  # Same-session proof, before the pane id is trusted at all: herdr pane ids
-  # ("w2:p1") restart at the same low numbers in every session, so a pane id
-  # borrowed from another session can silently resolve to a real but unrelated
-  # workspace here. The injected socket path is the server identity herdr
-  # exposes, and the session name independently binds the named session.
-  claimed_session=$(fm_backend_herdr_session)
-  if [ "$claimed_session" != "$session" ]; then
-    echo "error: herdr launcher pane '$pane' reports session '$claimed_session' but this spawn targets session '$session'; refusing to place a worker from a cross-session parent identity" >&2
-    return 1
-  fi
-  claimed_socket=${HERDR_SOCKET_PATH:-}
-  if [ -z "$claimed_socket" ]; then
-    echo "error: herdr launcher pane '$pane' has no injected socket identity; refusing to place a worker from an unverifiable parent identity" >&2
-    return 1
-  fi
-  claimed_socket=$(fm_backend_herdr_canonical_socket_path "$claimed_socket") || {
-    echo "error: herdr launcher pane '$pane' reports an unusable socket path; refusing to place a worker from an unverifiable parent identity" >&2
-    return 1
-  }
-  session_socket=$(fm_backend_herdr_presentation_session_socket_path "$session") || {
-    echo "error: herdr session '$session' has no unambiguous socket to match against the launcher pane's own; refusing to place a worker from an unverifiable parent identity" >&2
-    return 1
-  }
-  if [ "$claimed_socket" != "$session_socket" ]; then
-    echo "error: herdr launcher pane '$pane' belongs to the server at '$claimed_socket', not session '$session' at '$session_socket'; refusing to place a worker from a cross-session parent identity" >&2
-    return 1
-  fi
+  # Same-session/same-socket proof, before the pane id is trusted at all:
+  # herdr pane ids ("w2:p1") restart at the same low numbers in every
+  # session, so a pane id borrowed from another session can silently resolve
+  # to a real but unrelated workspace here. Owned by
+  # fm_backend_herdr_own_pane_socket_check; this call site keeps its own
+  # historical wording per reason.
+  fm_backend_herdr_own_pane_socket_check "$session"
+  status=$?
+  case "$status" in
+    2) return 2 ;;
+    1)
+      case "$FM_BACKEND_HERDR_OWN_SOCKET_REASON" in
+        cross-session)
+          echo "error: herdr launcher pane '$pane' reports session '$(fm_backend_herdr_session)' but this spawn targets session '$session'; refusing to place a worker from a cross-session parent identity" >&2
+          ;;
+        no-socket)
+          echo "error: herdr launcher pane '$pane' has no injected socket identity; refusing to place a worker from an unverifiable parent identity" >&2
+          ;;
+        bad-socket)
+          echo "error: herdr launcher pane '$pane' reports an unusable socket path; refusing to place a worker from an unverifiable parent identity" >&2
+          ;;
+        unresolvable-session)
+          echo "error: herdr session '$session' has no unambiguous socket to match against the launcher pane's own; refusing to place a worker from an unverifiable parent identity" >&2
+          ;;
+        socket-mismatch)
+          echo "error: herdr launcher pane '$pane' belongs to the server at '$FM_BACKEND_HERDR_OWN_SOCKET', not session '$session' at '$FM_BACKEND_HERDR_OWN_SESSION_SOCKET'; refusing to place a worker from a cross-session parent identity" >&2
+          ;;
+      esac
+      return 1
+      ;;
+  esac
 
   pane_out=$(fm_backend_herdr_cli "$session" pane get "$pane" 2>/dev/null) || {
     echo "error: herdr launcher pane '$pane' could not be read in session '$session'; refusing to place a worker without its exact parent workspace" >&2
@@ -2268,6 +2422,12 @@ fm_backend_herdr_parse_target() {  # <target>
   [ -n "$FM_BACKEND_HERDR_SESSION" ] && [ -n "$FM_BACKEND_HERDR_PANE" ] && [ "$FM_BACKEND_HERDR_PANE" != "$target" ]
 }
 
+# fm_backend_herdr_target_ready: the single choke point for every ordinary
+# send and read (capture, capture_ansi, send_text_line, send_literal,
+# send_key, current_path). fm_backend_herdr_server_ensure owns binding this
+# call to the exact server identity of firstmate's own pane when it has one,
+# so every one of those operations refuses rather than silently addressing a
+# different server than the one this process is actually running in.
 fm_backend_herdr_target_ready() {  # <target>
   fm_backend_herdr_parse_target "$1" || return 1
   fm_backend_herdr_server_ensure "$FM_BACKEND_HERDR_SESSION" || return 1

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1040,13 +1040,19 @@ case "$BACKEND" in
           case "$HERDR_RECLAIM_STATUS" in
             0)
               HERDR_PROJECTED=1
-              HERDR_WORKSPACE_ID=$HERDR_RECOVERY_WORKSPACE_ID
+              # HERDR_TASK_* name the WORKER pane this spawn creates. Never
+              # store them in HERDR_WORKSPACE_ID/HERDR_TAB_ID/HERDR_PANE_ID:
+              # those are herdr's injected own-process identity, and the
+              # sourced backend reads them as "the pane THIS process runs in"
+              # (fm_backend_herdr_own_pane_socket_check), so shadowing them
+              # makes every later send/read refuse as an unverifiable pane.
+              HERDR_TASK_WORKSPACE_ID=$HERDR_RECOVERY_WORKSPACE_ID
               HERDR_SEEDED_DEFAULT_TAB_ID=""
-              HERDR_TAB_ID=$FM_BACKEND_HERDR_PROJECTION_TAB_ID
-              HERDR_PANE_ID=$FM_BACKEND_HERDR_PROJECTION_PANE_ID
+              HERDR_TASK_TAB_ID=$FM_BACKEND_HERDR_PROJECTION_TAB_ID
+              HERDR_TASK_PANE_ID=$FM_BACKEND_HERDR_PROJECTION_PANE_ID
               HERDR_PROJECTION_ABORT_CLEANUP=1
               HERDR_PROJECTION_ABORT_SESSION=$HERDR_SES
-              HERDR_PROJECTION_ABORT_TASK_PANE=$HERDR_PANE_ID
+              HERDR_PROJECTION_ABORT_TASK_PANE=$HERDR_TASK_PANE_ID
               HERDR_PROJECTION_ABORT_SEEDED_PANE=""
               ;;
             2)
@@ -1096,25 +1102,25 @@ case "$BACKEND" in
             fi
             HERDR_PROJECTED=1
             HERDR_SES=$FM_BACKEND_HERDR_PROJECTION_SESSION
-            HERDR_WORKSPACE_ID=$FM_BACKEND_HERDR_PROJECTION_WORKSPACE_ID
+            HERDR_TASK_WORKSPACE_ID=$FM_BACKEND_HERDR_PROJECTION_WORKSPACE_ID
             HERDR_SEEDED_DEFAULT_TAB_ID=$FM_BACKEND_HERDR_PROJECTION_SEEDED_TAB_ID
-            HERDR_TAB_ID=$FM_BACKEND_HERDR_PROJECTION_TAB_ID
-            HERDR_PANE_ID=$FM_BACKEND_HERDR_PROJECTION_PANE_ID
+            HERDR_TASK_TAB_ID=$FM_BACKEND_HERDR_PROJECTION_TAB_ID
+            HERDR_TASK_PANE_ID=$FM_BACKEND_HERDR_PROJECTION_PANE_ID
             HERDR_PROJECTION_ABORT_CLEANUP=1
             HERDR_PROJECTION_ABORT_SESSION=$HERDR_SES
-            HERDR_PROJECTION_ABORT_TASK_PANE=$HERDR_PANE_ID
+            HERDR_PROJECTION_ABORT_TASK_PANE=$HERDR_TASK_PANE_ID
             HERDR_PROJECTION_ABORT_SEEDED_PANE=$FM_BACKEND_HERDR_PROJECTION_SEEDED_PANE_ID
             fm_backend_herdr_projection_order_best_effort \
-              "$HERDR_SES" "$HERDR_WORKSPACE_ID" "$HERDR_PARENT_LABEL" "$HERDR_PARENT_WORKSPACE_ID"
+              "$HERDR_SES" "$HERDR_TASK_WORKSPACE_ID" "$HERDR_PARENT_LABEL" "$HERDR_PARENT_WORKSPACE_ID"
             HERDR_HOME_ID=$(fm_backend_herdr_projection_home_identity "$HERDR_LABEL_HOME" 2>/dev/null || true)
             if [ -n "$HERDR_HOME_ID" ] \
                && fm_backend_herdr_projection_live_binding_matches \
-                 "$HERDR_SES" "$HERDR_PROJECTION_ID" "$HERDR_WORKSPACE_ID" \
-                 "$HERDR_TAB_ID" "$HERDR_PANE_ID" "$HERDR_PARENT_WORKSPACE_ID" \
+                 "$HERDR_SES" "$HERDR_PROJECTION_ID" "$HERDR_TASK_WORKSPACE_ID" \
+                 "$HERDR_TASK_TAB_ID" "$HERDR_TASK_PANE_ID" "$HERDR_PARENT_WORKSPACE_ID" \
                  "$HERDR_PARENT_LABEL" "$HERDR_PROJECTION_LABEL" "$W" \
                && fm_backend_herdr_projection_journal_bind \
                  "$HERDR_PRESENTATION_JOURNAL" "$ID" "$HERDR_HOME_ID" "$HERDR_SES" \
-                 "$HERDR_WORKSPACE_ID" "$HERDR_TAB_ID" "$HERDR_PANE_ID" \
+                 "$HERDR_TASK_WORKSPACE_ID" "$HERDR_TASK_TAB_ID" "$HERDR_TASK_PANE_ID" \
                  "$HERDR_PARENT_WORKSPACE_ID" "$HERDR_PARENT_LABEL" "$HERDR_PROJECTION_LABEL" "$W"; then
               :
             else
@@ -1137,17 +1143,17 @@ case "$BACKEND" in
       CONTAINER=${HERDR_CONTAINER_RAW%%$'\t'*}
       HERDR_SEEDED_DEFAULT_TAB_ID=${HERDR_CONTAINER_RAW#*$'\t'}
       HERDR_SES=${CONTAINER%%:*}
-      HERDR_WORKSPACE_ID=${CONTAINER#*:}
+      HERDR_TASK_WORKSPACE_ID=${CONTAINER#*:}
       HERDR_TASK_IDS=$(FM_HOME="$HERDR_LABEL_HOME" fm_backend_herdr_create_task "$CONTAINER" "$W" "$PROJ_ABS" "$HERDR_SEEDED_DEFAULT_TAB_ID") || exit 1
-      read -r HERDR_TAB_ID HERDR_PANE_ID <<EOF
+      read -r HERDR_TASK_TAB_ID HERDR_TASK_PANE_ID <<EOF
 $HERDR_TASK_IDS
 EOF
     fi
-    if [ -z "$HERDR_TAB_ID" ] || [ -z "$HERDR_PANE_ID" ]; then
+    if [ -z "$HERDR_TASK_TAB_ID" ] || [ -z "$HERDR_TASK_PANE_ID" ]; then
       echo "error: herdr did not return a tab/pane id for $W" >&2
       exit 1
     fi
-    T="$HERDR_SES:$HERDR_PANE_ID"
+    T="$HERDR_SES:$HERDR_TASK_PANE_ID"
     ;;
   zellij)
     ZELLIJ_SES=$(fm_backend_zellij_container_ensure) || exit 1
@@ -1621,9 +1627,9 @@ META_WINDOW=$T
   [ "$BACKEND" = tmux ] || echo "backend=$BACKEND"
   if [ "$BACKEND" = herdr ]; then
     echo "herdr_session=$HERDR_SES"
-    echo "herdr_workspace_id=$HERDR_WORKSPACE_ID"
-    echo "herdr_tab_id=$HERDR_TAB_ID"
-    echo "herdr_pane_id=$HERDR_PANE_ID"
+    echo "herdr_workspace_id=$HERDR_TASK_WORKSPACE_ID"
+    echo "herdr_tab_id=$HERDR_TASK_TAB_ID"
+    echo "herdr_pane_id=$HERDR_TASK_PANE_ID"
   fi
   if [ "$BACKEND" = zellij ]; then
     echo "zellij_session=$ZELLIJ_SES"

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -183,7 +183,7 @@ Workspace and tab ids support verification and cleanup but are not inferred from
 
 ## Current transport behavior
 
-The adapter starts and polls a named server before workspace, tab, pane, or agent calls.
+The adapter ensures a named server is running before workspace, tab, pane, or agent calls, starting and polling one only when nothing already proves the session alive.
 Every Herdr invocation goes through `fm_backend_herdr_cli`, which sets the environment and passes an explicit trailing `--session <name>`.
 An environment variable alone is not reliable when another Herdr server is running.
 

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -187,6 +187,13 @@ The adapter starts and polls a named server before workspace, tab, pane, or agen
 Every Herdr invocation goes through `fm_backend_herdr_cli`, which sets the environment and passes an explicit trailing `--session <name>`.
 An environment variable alone is not reliable when another Herdr server is running.
 
+A session name is not by itself proof of which physical server owns it: Herdr's own session registry can carry more than one registration under the same name, and a single liveness probe can transiently misreport.
+`fm_backend_herdr_server_ensure` never autostarts a server on the strength of one probe alone.
+When this process is itself running inside a Herdr pane, its own injected pane/session/socket identity (the same live proof `fm_backend_herdr_launcher_identity` uses for placement) is checked first: a verified match is proof positive that a server for that session is already running, so no probe is even attempted and no restart is ever risked; a verified mismatch refuses loudly rather than guessing which server to address.
+With no such identity to check, before concluding a server is missing the adapter consults the session registry by name rather than trusting the probe alone: zero registrations means it is safe to start one, exactly one reports its own running state directly, and more than one refuses loudly instead of guessing or starting another.
+The registry is re-checked once a freshly started server reports running, so a start that collided with a concurrent one is caught rather than accepted silently.
+Ordinary send and read operations (`fm_backend_herdr_target_ready`, used by every capture, send, and current-path call) apply the same own-pane identity check before addressing a session, so they refuse rather than silently reading or writing a different server than the one this process is actually running in.
+
 Literal text and Enter are separate operations for ordinary steers.
 Spawn-time fixed commands may use Herdr's atomic run primitive.
 Enter, Escape, and Ctrl-C are supported.
@@ -303,6 +310,7 @@ tests/fm-backend-herdr-prune-safety-e2e.test.sh
 tests/fm-backend-herdr-respawn-idem-e2e.test.sh
 tests/fm-backend-herdr-workspace-per-home-e2e.test.sh
 tests/fm-backend-herdr-launcher-workspace-e2e.test.sh
+tests/fm-backend-herdr-server-identity-e2e.test.sh
 tests/fm-backend-herdr-presentation-e2e.test.sh
 tests/fm-backend-herdr-eventwait-smoke.test.sh
 tests/fm-herdr-session-cleanup.test.sh

--- a/tests/fm-backend-herdr-server-identity-e2e.test.sh
+++ b/tests/fm-backend-herdr-server-identity-e2e.test.sh
@@ -1,0 +1,204 @@
+#!/usr/bin/env bash
+# tests/fm-backend-herdr-server-identity-e2e.test.sh - real-herdr regression
+# test for the 2026-08-01 incident: fm_backend_herdr_server_ensure addressed a
+# server purely by SESSION NAME, and a single misreported liveness probe was
+# enough to make it invoke `herdr ... server` again against an ALREADY-alive
+# session - reproduced against the real binary by forcing exactly one
+# `status --json` probe to misreport: the session was unreachable for the
+# remainder of server_ensure's 10s poll before recovering, a real disruptive
+# restart of a server nothing was wrong with. fm-spawn.sh's own workspace
+# PLACEMENT was already fixed by commit f0d7cbe ("place workers in the
+# launching workspace"); this suite covers what that commit did not touch:
+# server_ensure's own autostart decision, and ordinary send/read binding.
+#
+# Every scenario below drives the REAL bin/backends/herdr.sh functions
+# in-process (never a rewritten copy) against an isolated, non-default lab
+# session. Only fm_backend_herdr_cli itself is wrapped, to (a) log every call
+# so a scenario can assert "server" was never invoked, and (b) inject one
+# controlled fault at a time (a misreported liveness probe, or an ambiguous
+# session-list result) - never a bypass of bin/fm-herdr-lab.sh's safety net,
+# since every call still carries the lab's own explicit --session.
+set -u
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+fail() { printf 'not ok - %s\n' "$1" >&2; cleanup_all; exit 1; }
+pass() { printf 'ok - %s\n' "$1"; }
+assert_contains_local() {  # <haystack> <needle> <msg>
+  case "$1" in
+    *"$2"*) : ;;
+    *) fail "$3"$'\n'"--- got ---"$'\n'"$1" ;;
+  esac
+}
+assert_not_contains_local() {  # <haystack> <needle> <msg>
+  case "$1" in
+    *"$2"*) fail "$3"$'\n'"--- got ---"$'\n'"$1" ;;
+  esac
+}
+
+command -v herdr >/dev/null 2>&1 || { echo "skip: herdr not found"; exit 0; }
+command -v jq >/dev/null 2>&1 || { echo "skip: jq not found (required by the herdr adapter)"; exit 0; }
+
+# shellcheck source=tests/herdr-test-safety.sh
+. "$ROOT/tests/herdr-test-safety.sh"
+
+herdr_forget_inherited_pane
+
+SESSION="fm-lab-server-identity-$$"
+export HERDR_SESSION="$SESSION"
+CLEANED=0
+# Idempotent: fail() cleans up before exiting and the EXIT trap fires after
+# it, so a second teardown would otherwise report the already-consumed
+# fleet-state tripwire as if the lab had gone wrong.
+cleanup_all() {
+  [ "$CLEANED" = 0 ] || return 0
+  CLEANED=1
+  herdr_safe_stop_and_delete "$SESSION"
+}
+trap cleanup_all EXIT
+fm_herdr_lab_prepare "$SESSION" || fail "could not prepare isolated Herdr lab session"
+
+# shellcheck source=/dev/null
+. "$ROOT/bin/fm-backend.sh"
+fm_backend_source herdr || fail "fm_backend_source herdr failed"
+
+# container_ensure both starts this isolated session's real server and gives
+# us a real workspace to hang a "launcher pane" off of.
+CONTAINER_RAW=$(fm_backend_herdr_container_ensure /tmp) || fail "container_ensure failed"
+CONTAINER=${CONTAINER_RAW%%$'\t'*}
+WSID=${CONTAINER#*:}
+
+LAB_SOCKET=$(herdr session list --json --session "$SESSION" 2>/dev/null \
+  | jq -r --arg s "$SESSION" '.sessions[]? | select(.name == $s) | .socket_path')
+[ -n "$LAB_SOCKET" ] || fail "could not read the isolated lab session's real socket path"
+
+# A real pane inside the primary workspace, standing in for "the captain's own
+# pane" / firstmate's own launcher identity.
+LAUNCH_OUT=$(herdr tab create --workspace "$WSID" --cwd /tmp --label captain-shell --no-focus --session "$SESSION" 2>/dev/null) \
+  || fail "could not create the launcher pane"
+LAUNCH_PANE=$(printf '%s' "$LAUNCH_OUT" | jq -r '.result.root_pane.pane_id // empty')
+[ -n "$LAUNCH_PANE" ] || fail "launcher pane creation did not return a pane id"
+
+CALL_LOG=$(mktemp "${TMPDIR:-/tmp}/fm-herdr-server-identity-log.XXXXXX")
+POISON_MODE_FILE=$(mktemp "${TMPDIR:-/tmp}/fm-herdr-server-identity-mode.XXXXXX")
+POISON_USED_FILE=$(mktemp "${TMPDIR:-/tmp}/fm-herdr-server-identity-used.XXXXXX")
+
+eval "$(declare -f fm_backend_herdr_cli | sed '1s/fm_backend_herdr_cli/fm_backend_herdr_cli_real/')"
+
+set_poison_mode() { printf '%s' "$1" > "$POISON_MODE_FILE"; : > "$POISON_USED_FILE"; }
+poison_was_used() { [ -s "$POISON_USED_FILE" ]; }
+
+# fm_backend_herdr_cli (test double): logs every call unit-separated, then
+# injects at most one controlled fault per the current poison mode before
+# falling through to the REAL implementation for everything else. State
+# lives in files, not shell variables: fm_backend_herdr_server_ensure calls
+# this through command substitution ($( )), which forks a subshell, so a
+# plain variable write here would never be visible to the caller afterward.
+fm_backend_herdr_cli() {  # <session> <herdr-subcommand-and-args...>
+  local sess=$1 mode
+  shift
+  { printf '%s' "$sess"; for a in "$@"; do printf '\x1f%s' "$a"; done; printf '\n'; } >> "$CALL_LOG"
+  mode=$(cat "$POISON_MODE_FILE" 2>/dev/null || true)
+  case "$mode" in
+    status-once)
+      if [ ! -s "$POISON_USED_FILE" ] && [ "${1:-}" = status ] && [ "${2:-}" = --json ]; then
+        printf 'used\n' > "$POISON_USED_FILE"
+        printf '{"server":{"running":false}}'
+        return 0
+      fi
+      ;;
+    sessionlist-ambiguous)
+      # The real session IS genuinely healthy, so the plain status probe
+      # must also be forced false here (every time, not just once) or it
+      # would short-circuit before the ambiguity check is ever reached.
+      if [ "${1:-}" = status ] && [ "${2:-}" = --json ]; then
+        printf '{"server":{"running":false}}'
+        return 0
+      fi
+      if [ "${1:-}" = session ] && [ "${2:-}" = list ] && [ "${3:-}" = --json ]; then
+        printf '{"sessions":[{"name":"%s","running":true,"socket_path":"/fake/a.sock"},{"name":"%s","running":true,"socket_path":"/fake/b.sock"}]}' "$sess" "$sess"
+        return 0
+      fi
+      ;;
+  esac
+  fm_backend_herdr_cli_real "$sess" "$@"
+}
+
+# --- 1. own-pane identity short-circuit: never restart a session firstmate's
+#        own pane already proves is live, even when the liveness probe misses -
+
+export HERDR_ENV=1 HERDR_PANE_ID="$LAUNCH_PANE" HERDR_SOCKET_PATH="$LAB_SOCKET"
+: > "$CALL_LOG"
+set_poison_mode status-once
+fm_backend_herdr_server_ensure "$SESSION"
+status=$?
+[ "$status" -eq 0 ] || fail "server_ensure must succeed when firstmate's own pane already proves the session is live"
+! poison_was_used || fail "the own-pane short-circuit must never even reach the liveness probe it would otherwise be misled by"
+assert_not_contains_local "$(cat "$CALL_LOG")" $'\x1f''server'$'\n' \
+  "the own-pane short-circuit must never invoke 'herdr ... server' - that is the disruptive restart from the 2026-08-01 incident"
+pass "real herdr: server_ensure's own-pane identity proof skips the liveness probe entirely and never restarts an already-live session"
+
+# --- 2. no ancestry: a misreported probe must not restart an already-alive
+#        session either - the authoritative session registry catches it -----
+
+unset HERDR_ENV HERDR_PANE_ID HERDR_SOCKET_PATH
+: > "$CALL_LOG"
+set_poison_mode status-once
+fm_backend_herdr_server_ensure "$SESSION"
+status=$?
+[ "$status" -eq 0 ] || fail "server_ensure must still succeed via the session registry when the probe alone misreports"
+poison_was_used || fail "sanity: the liveness probe should have been consulted (and poisoned) with no own-pane identity to short-circuit on"
+assert_contains_local "$(cat "$CALL_LOG")" $'\x1f''session'$'\x1f''list'$'\x1f''--json' \
+  "server_ensure did not consult the authoritative session registry before concluding it was safe to start a server"
+assert_not_contains_local "$(cat "$CALL_LOG")" $'\x1f''server'$'\n' \
+  "a misreported liveness probe must never cause a second server to be started against an already-registered, already-running session"
+pass "real herdr: even with no launcher identity to bind to, a misreported liveness probe does not restart a session the registry shows is already running"
+
+# --- 3. ambiguous ownership refuses loudly and never starts anything -------
+
+: > "$CALL_LOG"
+set_poison_mode sessionlist-ambiguous
+err=$(fm_backend_herdr_server_ensure "$SESSION" 2>&1)
+status=$?
+[ "$status" -ne 0 ] || fail "server_ensure must refuse, not guess, when the session registry shows more than one registration under this name"
+assert_contains_local "$err" "2 herdr sessions are already registered" "the ambiguity refusal did not explain itself"
+assert_not_contains_local "$(cat "$CALL_LOG")" $'\x1f''server'$'\n' \
+  "an ambiguous registration must never be resolved by starting yet another server"
+pass "real herdr: server_ensure refuses loudly on an ambiguous session registry instead of guessing or starting another server"
+
+set_poison_mode none
+
+# --- 4. ordinary send/read binds to firstmate's own pane identity: a claimed
+#        pane in a DIFFERENT session must refuse to touch this session's real
+#        task pane, not silently read/write it -------------------------------
+
+TASK_IDS=$(fm_backend_herdr_create_task "$CONTAINER" fm-identity-e2e /tmp) || fail "create_task failed"
+read -r _TASK_TAB TASK_PANE <<EOF
+$TASK_IDS
+EOF
+[ -n "$TASK_PANE" ] || fail "create_task did not return a pane id"
+TARGET="$SESSION:$TASK_PANE"
+
+export HERDR_ENV=1 HERDR_PANE_ID="$LAUNCH_PANE" HERDR_SESSION=someother-session HERDR_SOCKET_PATH="$LAB_SOCKET"
+if fm_backend_herdr_capture "$TARGET" 20 >/dev/null 2>"$CALL_LOG.err"; then
+  fail "capture must refuse when firstmate's own pane claims a different session than the target"
+fi
+assert_contains_local "$(cat "$CALL_LOG.err")" "someother-session" \
+  "the cross-session send/read refusal did not name the mismatched session"
+pass "real herdr: capture refuses to address a target session that firstmate's own pane does not verifiably belong to"
+
+export HERDR_SESSION="$SESSION"
+fm_backend_herdr_send_text_line "$TARGET" "echo identity-e2e-ok" || fail "send_text_line failed with a genuinely matching launcher identity"
+sleep 0.5
+out=$(fm_backend_herdr_capture "$TARGET" 20) || fail "capture failed with a genuinely matching launcher identity"
+case "$out" in
+  *identity-e2e-ok*) : ;;
+  *) fail "real herdr: send/capture did not work with a genuinely matching launcher identity"$'\n'"$out" ;;
+esac
+pass "real herdr: send/capture still work normally once firstmate's own pane verifiably matches the target session"
+
+unset HERDR_ENV HERDR_PANE_ID HERDR_SOCKET_PATH
+rm -f "$CALL_LOG" "$CALL_LOG.err" "$POISON_MODE_FILE" "$POISON_USED_FILE"
+cleanup_all
+trap - EXIT
+pass "real herdr: isolated lab session removed and default fleet session unchanged"

--- a/tests/fm-backend-herdr.test.sh
+++ b/tests/fm-backend-herdr.test.sh
@@ -568,7 +568,7 @@ test_server_ensure_own_pane_identity_skips_probe_and_never_restarts() {
   expect_code 0 "$status" "server_ensure must succeed when firstmate's own pane already proves the session is live"
   assert_not_contains "$(cat "$log")" $'\x1f''status'$'\x1f''--json' \
     "the own-pane short-circuit must never even reach the liveness probe"
-  assert_not_contains "$(cat "$log")" $'\x1f''server'$'\n' \
+  assert_not_contains "$(cat "$log")" $'\x1f''server'$'\x1f' \
     "the own-pane short-circuit must never invoke 'herdr ... server' - the disruptive restart from the 2026-08-01 incident"
   pass "fm_backend_herdr_server_ensure: an own-pane identity match skips the liveness probe entirely and never restarts"
 }
@@ -599,7 +599,7 @@ test_server_ensure_no_ancestry_registry_confirms_already_running() {
   expect_code 0 "$status" "server_ensure must succeed when the session registry shows this name already running"
   assert_contains "$(cat "$log")" $'\x1f''session'$'\x1f''list'$'\x1f''--json' \
     "server_ensure did not consult the session registry before concluding it was safe to start a server"
-  assert_not_contains "$(cat "$log")" $'\x1f''server'$'\n' \
+  assert_not_contains "$(cat "$log")" $'\x1f''server'$'\x1f' \
     "a misreported liveness probe must never cause a server to be started against an already-registered, already-running session"
   pass "fm_backend_herdr_server_ensure: with no launcher identity, a misreported probe does not restart a session the registry shows is already running"
 }
@@ -615,7 +615,7 @@ test_server_ensure_no_ancestry_ambiguous_registry_refuses() {
   status=$?
   expect_code 1 "$status" "server_ensure must refuse, not guess, when the session registry shows more than one registration under this name"
   assert_contains "$out" "2 herdr sessions are already registered" "the ambiguity refusal did not explain itself"
-  assert_not_contains "$(cat "$log")" $'\x1f''server'$'\n' \
+  assert_not_contains "$(cat "$log")" $'\x1f''server'$'\x1f' \
     "an ambiguous registration must never be resolved by starting yet another server"
   pass "fm_backend_herdr_server_ensure: refuses loudly on an ambiguous session registry instead of guessing or starting another server"
 }

--- a/tests/fm-backend-herdr.test.sh
+++ b/tests/fm-backend-herdr.test.sh
@@ -506,14 +506,20 @@ test_container_ensure_starts_server_and_workspace() {
   printf '{"client":{"version":"0.7.1","protocol":14}}\n' > "$resp/1.out"
   # 2: server_ensure's status --json check -> not running
   printf '{"server":{"running":false}}\n' > "$resp/2.out"
-  # 3: `herdr server` backgrounded launch - no meaningful output
-  # 4: server_ensure poll -> now running
-  printf '{"server":{"running":true}}\n' > "$resp/4.out"
-  # 5: workspace list -> empty (no "firstmate" workspace yet)
-  printf '{"result":{"workspaces":[]}}\n' > "$resp/5.out"
-  # 6: workspace create -> w1, seeding default tab w1:t9 (real herdr returns
+  # 3: server_ensure's pre-start ambiguity check (session list by name) -> no
+  # existing registration, safe to start.
+  printf '{"sessions":[]}\n' > "$resp/3.out"
+  # 4: `herdr server` backgrounded launch - no meaningful output
+  # 5: server_ensure poll -> now running
+  printf '{"server":{"running":true}}\n' > "$resp/5.out"
+  # 6: server_ensure's post-start confirmation (session list by name) -> the
+  # new server is the only registration under this name.
+  printf '{"sessions":[{"name":"fmtest","running":true,"socket_path":"/fake/fmtest.sock"}]}\n' > "$resp/6.out"
+  # 7: workspace list -> empty (no "firstmate" workspace yet)
+  printf '{"result":{"workspaces":[]}}\n' > "$resp/7.out"
+  # 8: workspace create -> w1, seeding default tab w1:t9 (real herdr returns
   # the seeded tab/pane ids in the SAME response - verified empirically).
-  printf '{"result":{"workspace":{"workspace_id":"w1","label":"firstmate"},"tab":{"tab_id":"w1:t9"},"root_pane":{"pane_id":"w1:p9"}}}\n' > "$resp/6.out"
+  printf '{"result":{"workspace":{"workspace_id":"w1","label":"firstmate"},"tab":{"tab_id":"w1:t9"},"root_pane":{"pane_id":"w1:p9"}}}\n' > "$resp/8.out"
   fb=$(make_herdr_fakebin "$dir")
   out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" FM_HERDR_SCRIPT_STATUS=1 HERDR_SESSION=fmtest \
     bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_container_ensure /tmp' "$ROOT" )
@@ -536,6 +542,103 @@ test_container_ensure_reuses_existing_workspace() {
   [ "$out" = $'fmtest:w9\t' ] || fail "container_ensure should reuse the existing firstmate workspace id with an EMPTY seeded-tab field (an ADOPTED workspace is never a prune candidate), got '$out'"
   assert_not_contains "$(cat "$log")" $'\x1f''workspace'$'\x1f''create' "container_ensure should not create a workspace that already exists"
   pass "fm_backend_herdr_container_ensure: reuses an existing firstmate workspace without recreating it, and reports no seeded default tab (adopted, not created)"
+}
+
+# --- server_ensure hardening (2026-08-01 incident) ---------------------------
+#
+# fm_backend_herdr_server_ensure used to trust a single `status --json` probe
+# and unconditionally launch another `herdr ... server` whenever that probe
+# read anything but exactly "true" - including a transient miss against a
+# session that was already alive, which is exactly what caused a real,
+# disruptive restart of the captain's own already-running session. These
+# cases cover the two independent hardenings: an own-pane identity proof that
+# skips the probe entirely, and (when there is no such identity) an
+# authoritative session-registry check before ever concluding it is safe to
+# start a server, refusing loudly on ambiguity rather than guessing.
+
+test_server_ensure_own_pane_identity_skips_probe_and_never_restarts() {
+  local dir log resp fb status
+  dir="$TMP_ROOT/ensure-own-pane-ok"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
+  printf '{"sessions":[{"name":"fmtest","running":true,"socket_path":"/tmp/fm-herdr-unit/fmtest.sock"}]}\n' > "$resp/1.out"
+  fb=$(make_herdr_fakebin "$dir")
+  ( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" FM_HERDR_SCRIPT_STATUS=1 \
+    HERDR_ENV=1 HERDR_PANE_ID=w7:p3 HERDR_SESSION=fmtest HERDR_SOCKET_PATH=/tmp/fm-herdr-unit/fmtest.sock \
+    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_server_ensure fmtest' "$ROOT" )
+  status=$?
+  expect_code 0 "$status" "server_ensure must succeed when firstmate's own pane already proves the session is live"
+  assert_not_contains "$(cat "$log")" $'\x1f''status'$'\x1f''--json' \
+    "the own-pane short-circuit must never even reach the liveness probe"
+  assert_not_contains "$(cat "$log")" $'\x1f''server'$'\n' \
+    "the own-pane short-circuit must never invoke 'herdr ... server' - the disruptive restart from the 2026-08-01 incident"
+  pass "fm_backend_herdr_server_ensure: an own-pane identity match skips the liveness probe entirely and never restarts"
+}
+
+test_server_ensure_own_pane_mismatch_refuses() {
+  local dir log resp fb out status
+  dir="$TMP_ROOT/ensure-own-pane-xsession"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
+  fb=$(make_herdr_fakebin "$dir")
+  out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
+    HERDR_ENV=1 HERDR_PANE_ID=w7:p3 HERDR_SESSION=someother \
+    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_server_ensure fmtest' "$ROOT" 2>&1 )
+  status=$?
+  expect_code 1 "$status" "a launcher pane naming another herdr session must refuse rather than guess which server to address"
+  assert_contains "$out" "someother" "the cross-session refusal did not name the mismatched session"
+  [ ! -s "$log" ] || fail "a cross-session own-pane identity must be refused before any herdr call"
+  pass "fm_backend_herdr_server_ensure: refuses before any herdr call when firstmate's own pane names a different session"
+}
+
+test_server_ensure_no_ancestry_registry_confirms_already_running() {
+  local dir log resp fb status
+  dir="$TMP_ROOT/ensure-registry-running"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
+  printf '{"server":{"running":false}}\n' > "$resp/1.out"
+  printf '{"sessions":[{"name":"fmtest","running":true,"socket_path":"/tmp/fm-herdr-unit/fmtest.sock"}]}\n' > "$resp/2.out"
+  fb=$(make_herdr_fakebin "$dir")
+  ( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" FM_HERDR_SCRIPT_STATUS=1 \
+    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_server_ensure fmtest' "$ROOT" )
+  status=$?
+  expect_code 0 "$status" "server_ensure must succeed when the session registry shows this name already running"
+  assert_contains "$(cat "$log")" $'\x1f''session'$'\x1f''list'$'\x1f''--json' \
+    "server_ensure did not consult the session registry before concluding it was safe to start a server"
+  assert_not_contains "$(cat "$log")" $'\x1f''server'$'\n' \
+    "a misreported liveness probe must never cause a server to be started against an already-registered, already-running session"
+  pass "fm_backend_herdr_server_ensure: with no launcher identity, a misreported probe does not restart a session the registry shows is already running"
+}
+
+test_server_ensure_no_ancestry_ambiguous_registry_refuses() {
+  local dir log resp fb out status
+  dir="$TMP_ROOT/ensure-registry-ambiguous"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
+  printf '{"server":{"running":false}}\n' > "$resp/1.out"
+  printf '{"sessions":[{"name":"fmtest","running":true,"socket_path":"/fake/a.sock"},{"name":"fmtest","running":true,"socket_path":"/fake/b.sock"}]}\n' > "$resp/2.out"
+  fb=$(make_herdr_fakebin "$dir")
+  out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" FM_HERDR_SCRIPT_STATUS=1 \
+    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_server_ensure fmtest' "$ROOT" 2>&1 )
+  status=$?
+  expect_code 1 "$status" "server_ensure must refuse, not guess, when the session registry shows more than one registration under this name"
+  assert_contains "$out" "2 herdr sessions are already registered" "the ambiguity refusal did not explain itself"
+  assert_not_contains "$(cat "$log")" $'\x1f''server'$'\n' \
+    "an ambiguous registration must never be resolved by starting yet another server"
+  pass "fm_backend_herdr_server_ensure: refuses loudly on an ambiguous session registry instead of guessing or starting another server"
+}
+
+test_server_ensure_post_start_collision_refuses() {
+  local dir log resp fb out status
+  dir="$TMP_ROOT/ensure-post-start-collision"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
+  # 1: first status probe -> not running
+  printf '{"server":{"running":false}}\n' > "$resp/1.out"
+  # 2: pre-start registry check -> nothing owns it yet
+  printf '{"sessions":[]}\n' > "$resp/2.out"
+  # 3: `herdr server` backgrounded launch - no meaningful output
+  # 4: poll -> now running
+  printf '{"server":{"running":true}}\n' > "$resp/4.out"
+  # 5: post-start registry check -> a concurrent start collided
+  printf '{"sessions":[{"name":"fmtest","running":true,"socket_path":"/fake/a.sock"},{"name":"fmtest","running":true,"socket_path":"/fake/b.sock"}]}\n' > "$resp/5.out"
+  fb=$(make_herdr_fakebin "$dir")
+  out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" FM_HERDR_SCRIPT_STATUS=1 \
+    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_server_ensure fmtest' "$ROOT" 2>&1 )
+  status=$?
+  expect_code 1 "$status" "server_ensure must refuse when starting a server produced more than one registration under the same name"
+  assert_contains "$out" "registrations under that name" "the post-start collision refusal did not explain itself"
+  pass "fm_backend_herdr_server_ensure: refuses when a fresh start collides with a concurrent registration under the same name"
 }
 
 test_create_task_refuses_duplicate_label() {
@@ -3880,6 +3983,11 @@ test_workspace_ensure_other_home_ignores_the_launcher_identity
 test_container_ensure_refuses_an_ambiguous_home_label
 test_container_ensure_starts_server_and_workspace
 test_container_ensure_reuses_existing_workspace
+test_server_ensure_own_pane_identity_skips_probe_and_never_restarts
+test_server_ensure_own_pane_mismatch_refuses
+test_server_ensure_no_ancestry_registry_confirms_already_running
+test_server_ensure_no_ancestry_ambiguous_registry_refuses
+test_server_ensure_post_start_collision_refuses
 test_container_ensure_creates_with_no_focus_flag
 test_container_ensure_uses_secondmate_home_label
 test_workspace_ensure_prunes_default_tab


### PR DESCRIPTION
## Intent

Fix firstmate's Herdr backend adapter so workers always land in the captain's own visible Herdr server/session, never a parallel invisible one (2026-08-01 incident: captain's pane ran an unnamed/default session, fm_backend_herdr_server_ensure autostarted competing servers - 4 observed running concurrently, session panes wiped twice within an hour).

Diagnosis required checking prior work: upstream commit f0d7cbe (already on main) fixed worker WORKSPACE PLACEMENT at spawn time via fm_backend_herdr_launcher_identity's same-session/same-socket proof. I reproduced the fault end-to-end in an isolated Herdr lab (bin/fm-herdr-lab.sh) against the real herdr binary and confirmed f0d7cbe did NOT fix two remaining things: (1) fm_backend_herdr_server_ensure trusted a single 'status --json' liveness probe and would unconditionally invoke another 'herdr ... server' whenever that one probe misreported, even against an already-running session - forcing exactly one such probe to misreport (the disconfirming check) caused a real ~10s disruptive restart of a session nothing was wrong with, which is the actual mechanism behind the reported 'panes wiped' and 'competing servers' symptoms; (2) every ordinary send/read operation (capture, capture_ansi, send_text_line, send_literal, send_key, current_path, all via fm_backend_herdr_target_ready) addressed a herdr session purely by NAME with zero verification that the name still belongs to the same physical server, so a send/read could silently talk to a different server than the one a worker actually lives in.

Fix: extracted the existing same-session/same-socket identity proof out of fm_backend_herdr_launcher_identity into a new shared fm_backend_herdr_own_pane_socket_check (reason-coded, no user-facing wording of its own so launcher_identity's existing messages and tests are byte-for-byte unchanged). Reused it in two new places: fm_backend_herdr_server_ensure now short-circuits to 'definitely running, never autostart' whenever this process's own herdr pane already verifiably belongs to the target session (no RPC probe needed or trusted), and refuses loudly on a verified mismatch; when there is no such pane identity to check, it now consults the authoritative session registry (session list --json, filtered by name) before ever concluding a server is missing, refusing loudly when more than one registration already claims that name rather than guessing or starting another, and re-checks after a fresh start to catch a concurrent-start collision. fm_backend_herdr_target_ready (the single choke point for every send/read) gets the same own-pane binding, so ordinary operations also refuse rather than silently addressing a different server than the one this process is actually running in.

Deliberate scope decisions: did not add a cross-process file lock around server_ensure's check-and-start sequence - the own-pane short-circuit closes the primary, empirically-confirmed incident mechanism (a probe misfire against a session firstmate's own pane already proves is alive) without needing any lock, and the registry-based check plus post-start re-check meaningfully narrows the remaining no-ancestry race window; a full lock was judged disproportionate additional complexity for a residual race that the ambiguity-refusal already surfaces loudly rather than silently. Preserved fm_backend_herdr_launcher_identity's exact existing error wording and call sequence (verified via its full existing unit test suite) since that function is unrelated to this incident and already correctly tested.

Tests: new tests/fm-backend-herdr-server-identity-e2e.test.sh drives the real herdr binary in an isolated non-default lab session and reproduces (a) the own-pane short-circuit never invoking 'herdr ... server' even when a probe is forced to misreport, (b) the no-ancestry path also never restarting an already-alive session via the registry check, (c) ambiguous registry entries refusing loudly, (d) capture refusing when firstmate's own claimed pane belongs to a different session than the target, (e) normal send/capture still working once identity matches - this ran fully green against real herdr earlier in this task. Added 5 new unit tests (fake-CLI, deterministic) plus updated 1 existing unit test's canned response numbering in tests/fm-backend-herdr.test.sh for the new registry-check calls; full suite is 164/164 passing. docs/herdr-backend.md documents the new server-identity-binding and never-autostart-when-owned guarantees. bin/fm-lint.sh (shellcheck) is clean on the whole canonical file set.

Known environment caveat (not a code issue): this task's sandbox lost its ambient default Herdr session partway through work (confirmed as a pre-existing gap unrelated to these changes - three unmodified existing real-herdr e2e test files fail identically on the same 'requires exactly one running default session' precondition), so the new e2e file cannot be re-run to completion in this environment right now; it needs the same live default session CI's tests-herdr lane already bootstraps via its own dedicated setup step, and its logic/preconditions exactly mirror the already-accepted tests/fm-backend-herdr-smoke.test.sh and tests/fm-backend-herdr-launcher-workspace-e2e.test.sh that run in that same CI lane.

Note: an earlier run through this same pipeline already completed review (2 auto-fix + 2 info findings, fixed/acknowledged), test (0 findings), document (1 info/no-op), and lint cleanly on this exact code, then failed only at push due to a since-resolved credential gap (inactdev lacked write access to kunchenguid/firstmate; the captain has since stood up a fork at https://github.com/inactdev/firstmate and no-mistakes was re-initialized with --fork-url so this run pushes there while the PR opens against kunchenguid/firstmate).

## What Changed

- Extracted the same-session/same-socket identity proof from `fm_backend_herdr_launcher_identity` into a shared, reason-coded `fm_backend_herdr_own_pane_socket_check` (launcher_identity's messages and behavior are byte-for-byte unchanged). `fm_backend_herdr_server_ensure` now short-circuits to "running, never autostart" when this process's own herdr pane verifiably belongs to the target session; when no pane identity exists, it consults the session registry (`session list --json`) before concluding a server is missing, refuses loudly on ambiguous registrations or a verified mismatch, and re-checks after a fresh start to catch concurrent-start collisions. This closes the incident mechanism where a single misreported status probe triggered a disruptive restart of a healthy session.
- `fm_backend_herdr_target_ready`, the single choke point for every send/read operation (capture, capture_ansi, send_text_line, send_literal, send_key, current_path), applies the same own-pane binding, so ordinary operations refuse instead of silently addressing a different physical server than the one this process runs in.
- Added `tests/fm-backend-herdr-server-identity-e2e.test.sh` (6 scenarios against the real herdr binary in an isolated lab session, all passing) and 5 new deterministic unit tests in `tests/fm-backend-herdr.test.sh` (full suite 164/164); `docs/herdr-backend.md` documents the server-identity-binding and never-autostart-when-owned guarantees.

## Risk Assessment

✅ Low: The change implements every required intent behavior exactly (verified against the base diff, all call sites, and read-only probes of the real herdr registry confirming the new fail-closed paths cannot break cold-start), preserves launcher_identity's tested wording byte-for-byte, is covered by targeted unit and e2e regression tests, and the only residual (the no-ancestry concurrent-start race) is explicitly acknowledged and authorized in the intent.

## Testing

Ran the targeted deterministic unit suite (164/164 ok, including the 5 new server_ensure hardening tests), confirmed the new real-herdr e2e's default-session precondition gap is pre-existing by failing an unmodified sibling e2e identically, then safely replicated CI's default-session bootstrap on this machine and ran the new server-identity e2e fully green against the real herdr binary (6/6 scenarios, twice), capturing transcripts and before/after registry snapshots proving the machine was restored to its exact pre-test state.

<details>
<summary>Evidence: Real-herdr server-identity e2e transcript (all 6 scenarios ok)</summary>

<code>ok - real herdr: server_ensure&#39;s own-pane identity proof skips the liveness probe entirely and never restarts an already-live session&#10;ok - real herdr: even with no launcher identity to bind to, a misreported liveness probe does not restart a session the registry shows is already running&#10;ok - real herdr: server_ensure refuses loudly on an ambiguous session registry instead of guessing or starting another server&#10;ok - real herdr: capture refuses to address a target session that firstmate&#39;s own pane does not verifiably belong to&#10;ok - real herdr: send/capture still work normally once firstmate&#39;s own pane verifiably matches the target session&#10;ok - real herdr: isolated lab session removed and default fleet session unchanged</code>

```text
ok - real herdr: server_ensure's own-pane identity proof skips the liveness probe entirely and never restarts an already-live session
ok - real herdr: even with no launcher identity to bind to, a misreported liveness probe does not restart a session the registry shows is already running
ok - real herdr: server_ensure refuses loudly on an ambiguous session registry instead of guessing or starting another server
ok - real herdr: capture refuses to address a target session that firstmate's own pane does not verifiably belong to
ok - real herdr: send/capture still work normally once firstmate's own pane verifiably matches the target session
ok - real herdr: isolated lab session removed and default fleet session unchanged
```
</details>
<details>
<summary>Evidence: Unit suite full output (164/164 ok incl. 5 new server_ensure tests)</summary>

```text
ok - fm_backend_herdr_version_check: accepts the current protocol (14)
ok - fm_backend_herdr_version_check: refuses an old protocol loudly
ok - fm_backend_herdr_version_check: refuses loudly when herdr is not installed
ok - fm_backend_herdr_workspace_label: a primary home (no marker) resolves to 'firstmate'
ok - fm_backend_herdr_workspace_label: a secondmate home (.fm-secondmate-home) resolves to '2ndmate-<id>'
ok - fm_backend_herdr_workspace_label: trims whitespace around the marker's secondmate id
ok - fm_backend_herdr_workspace_label: an empty marker file falls back to the primary label 'firstmate'
ok - fm_backend_herdr_workspace_label: two different secondmate homes get two different, non-colliding labels
ok - fm_backend_herdr_cli: sets HERDR_SESSION AND appends a trailing --session flag on every call
ok - fm_backend_herdr_launcher_identity: a firstmate not running inside herdr has no launcher workspace to inherit
ok - fm_backend_herdr_launcher_identity: HERDR_ENV=1 without a pane id selects the backend but binds no parent
ok - fm_backend_herdr_launcher_identity: resolves the launcher's exact workspace even when a same-labeled workspace sorts first
ok - fm_backend_herdr_launcher_identity: refuses a launcher pane that names a different herdr session
ok - fm_backend_herdr_launcher_identity: refuses a claimed pane without exact server identity
ok - fm_backend_herdr_launcher_identity: refuses a launcher pane whose injected socket belongs to another herdr server
ok - fm_backend_herdr_launcher_identity: refuses when the launcher's own pane no longer resolves
ok - fm_backend_herdr_launcher_identity: refuses when the launcher's pane and tab disagree about their workspace
ok - fm_backend_herdr_launcher_identity: refuses when the launcher's workspace is gone from its own session
ok - fm_backend_herdr_workspace_ensure: places a worker in the launcher's exact workspace, not the first same-labeled one
ok - fm_backend_herdr_workspace_ensure: refuses to guess between two same-labeled home workspaces
ok - fm_backend_herdr_workspace_ensure: a --secondmate container resolves that home's own workspace, not the launcher's
ok - fm_backend_herdr_container_ensure: surfaces the exact ambiguous-placement refusal instead of a generic failure
ok - fm_backend_herdr_container_ensure: version-gates, starts the server, ensures the firstmate workspace, echoes session:workspace_id + the seeded default tab id
ok - fm_backend_herdr_container_ensure: reuses an existing firstmate workspace without recreating it, and reports no seeded default tab (adopted, not created)
ok - fm_backend_herdr_server_ensure: an own-pane identity match skips the liveness probe entirely and never restarts
ok - fm_backend_herdr_server_ensure: refuses before any herdr call when firstmate's own pane names a different session
ok - fm_backend_herdr_server_ensure: with no launcher identity, a misreported probe does not restart a session the registry shows is already running
ok - fm_backend_herdr_server_ensure: refuses loudly on an ambiguous session registry instead of guessing or starting another server
ok - fm_backend_herdr_server_ensure: refuses when a fresh start collides with a concurrent registration under the same name
ok - fm_backend_herdr_container_ensure: workspace create passes --no-focus
ok - fm_backend_herdr_container_ensure: creates the workspace under the SECONDMATE home's own label, not 'firstmate'
ok - fm_backend_herdr_create_task: prunes exactly the seeded default tab container_ensure identified, once the first real task tab exists
ok - herdr repeated spawn/teardown: one persistent firstmate workspace reused, zero orphans, default tab pruned, create ran once
ok - fm_backend_herdr_create_task: an ADOPTED workspace's pre-existing tab is never pruned (the created-vs-adopted gate)
ok - fm_backend_herdr_create_task: the label-collision startup-workspace scenario (2026-07-02 incident) leaves the captain's live tab untouched
ok - fm_backend_herdr_workspace_prune_seeded_default_tab: refuses to close the seeded default tab when its pane reports a working agent (defense in depth)
ok - fm_backend_herdr_create_task: refuses a duplicate tab label (herdr's own tab create has no uniqueness check)
ok - fm_backend_herdr_create_task: a same-labeled tab with a live (even idle) registered agent still refuses exactly as before
ok - fm_backend_herdr_create_task: scans every same-labeled tab and refuses if any duplicate is live
ok - fm_backend_herdr_create_task: closes and replaces a same-labeled tab whose pane is dead (pane_not_found)
ok - fm_backend_herdr_create_task: closes and replaces a same-labeled tab whose pane is alive but hosts no registered agent (a restored plain shell)
ok - fm_backend_herdr_create_task: closes every confirmed same-labeled husk only after creating the replacement
ok - fm_backend_herdr_create_task: refuses success when a preexisting husk tab remains after replacement
ok - fm_backend_herdr_create_task: refuses (fail-safe) rather than guessing when the duplicate's agent state cannot be classified confidently
ok - fm_backend_herdr_create_task: creates the replacement tab BEFORE closing the husk tab, never the reverse
ok - fm_backend_herdr_create_task: creates a tab and parses tab_id/pane_id from the JSON response, prunes nothing when no seeded tab id is given
ok - fm_backend_herdr_create_task: tab create passes --no-focus
ok - herdr presentation journal: atomically publishes one non-authoritative 128-bit correlator and refuses overwrite
ok - herdr presentation journal: version 2 binds exact home/endpoint/parent identities and advances atomically
ok - herdr presentation create: exact response IDs yield one normal task pane with no workspace-close authority
ok - herdr presentation create: concurrent same-label tabs are never prune targets
ok - herdr presentation focus: snapshot requires one exact active workspace and tab
ok - herdr presentation focus: exact pane close restores the exact prior workspace and tab
ok - herdr presentation focus: cleanup refuses rather than close the captain's active tab
ok - herdr presentation focus: pane close fails when exact focus restoration fails
ok - herdr presentation reclaim: live agent state at the close boundary refuses mutation
ok - herdr presentation cleanup: emptying close behind focus ends the exact shell without a move or focus change
ok - herdr presentation cleanup: emptying close before focus moves the doomed workspace to the end and ends its exact shell
ok - herdr presentation cleanup: emptying close with the focused workspace last skips the move
ok - herdr presentation cleanup: emptying close of the last workspace skips the move
ok - herdr presentation cleanup: a non-emptying close stays plain with no proof, move, or signal
ok - herdr presentation cleanup: no-move plain close requires structured pane removal
ok - herdr presentation cleanup: an ambiguous workspace layout falls back to the plain close
ok - herdr presentation cleanup: a failed repositioning move falls back to the plain close with a warning
ok - herdr presentation cleanup: a pane with a live foreground process falls back to the plain close
ok - herdr presentation cleanup: a transient prompt helper settles into the pane-death path instead of the plain close
tests/fm-backend-herdr.test.sh: line 1596:  7142 Killed: 9                  bash -c 'trap "" HUP; sleep 300'
ok - herdr presentation cleanup: a SIGHUP-surviving shell is escalated to SIGKILL before giving up
tests/fm-backend-herdr.test.sh: line 1634:  7437 Killed: 9                  bash -c 'trap "" HUP; sleep 300'
ok - herdr presentation cleanup: a failed pane-death close falls back to the plain close
tests/fm-backend-herdr.test.sh: line 1667:  7851 Hangup: 1                  sleep 300
ok - herdr presentation cleanup: the exact-tab restore remains the backstop behind the pane-death close
ok - herdr presentation cleanup: SIGKILL never reaches a pid the exact pane no longer owns
ok - herdr presentation cleanup: every unconfirmed removal restores the exact original workspace order and reports failure
tests/fm-backend-herdr.test.sh: line 1826:  9566 Hangup: 1                  sleep 300
ok - fm_backend_herdr_kill: one sess

... [1985 bytes truncated] ...

ays untouched
warning: 2 exact herdr presentation token matches for task-p3 are quarantined; inspecting only for duplicate-agent risk
warning: quarantined herdr presentation for task-p3 is dead or agent-free; exact bound reclaim may proceed, otherwise spawning flat
ok - herdr presentation recovery: duplicate-token inspection is read-only and live-agent risk refuses fallback
ok - fm_backend_herdr_workspace_find: matches only THIS home's own label among several coexisting workspaces
ok - fm_backend_herdr_list_live: scoped to this home's own workspace, never a sibling home's
ok - fm_backend_herdr_parse_target: splits '<session>:<pane_id>' on the FIRST colon (pane_id itself contains one)
ok - fm_backend_herdr_normalize_key: Enter/Escape/C-c map to herdr's verified enter/escape/ctrl+c
ok - fm_backend_herdr_capture: calls 'pane read <pane> --source recent --lines N' with the session set
ok - fm_backend_herdr_capture: works around the verified small-N '--lines' bug by over-fetching and trimming locally
ok - fm_backend_herdr_capture: ensures the session and preserves pane read failure
ok - fm_backend_herdr_send_key: normalizes the key and targets the right pane
ok - fm_backend_herdr_kill: calls pane close and stays best-effort on failure
ok - fm_backend_herdr_current_path: reads pane foreground_cwd (the live running process), not the frozen creation-time cwd
ok - fm_backend_herdr_busy_state: working -> busy
ok - fm_backend_herdr_busy_state: done -> idle, blocked -> idle (surfaced like a stale pane, not suppressed as busy)
ok - fm_backend_herdr_busy_state: unparseable/absent agent state reports unknown, the regex-fallback cue
ok - fm_backend_herdr_composer_state: a bare '❯' composer row reads empty
ok - fm_backend_herdr_composer_state: the ghost placeholder text reads empty, not pending
ok - fm_backend_herdr_composer_state: real composer text reads pending
ok - fm_backend_herdr_composer_state: a slash-command popup's argument-hint placeholder still reads pending (the incident fix)
ok - fm_backend_herdr_composer_state: reports unknown when the pane cannot be captured
ok - fm_backend_herdr_composer_state: reports unknown for bare shell prompts with no composer row
ok - fm_backend_herdr_composer_state: a native idle Pi separator composer reads empty
ok - fm_backend_herdr_composer_state: real Pi composer text remains pending
ok - fm_backend_herdr_composer_state: an incomplete lower Pi separator cannot inherit a stale empty row
ok - fm_backend_herdr_composer_state: Pi separators never authorize working, non-Pi, unreadable, or over-tall targets
ok - fm_backend_herdr_composer_state: a real-claude unbordered '❯' prompt row (no border box in view) reads empty
ok - fm_backend_herdr_composer_state: a real-claude unbordered '❯ <text>' prompt row reads pending
ok - fm_backend_herdr_composer_state: a live unbordered prompt row below a stale bordered decorative box still wins (not misread as the box's own row)
ok - fm_backend_herdr_composer_state: claude's dim prompt-suggestion ghost (the overnight wedge shape) reads empty
ok - fm_backend_herdr_composer_state: real typed text on the same claude prompt row still reads pending
ok - fm_backend_herdr_composer_state: grok's dark-truecolor placeholder (the TRUECOLOR gap) reads empty
ok - fm_backend_herdr_composer_state: grok's real bright typed input still reads pending
ok - fm_backend_herdr_composer_state: a real-codex unbordered '›' prompt row reads empty
ok - fm_backend_herdr_composer_state: a faint real-codex ghost suggestion reads empty
ok - fm_backend_herdr_composer_state: non-faint codex prompt text still reads pending
ok - fm_backend_herdr_wait_for_working: reports 'busy' immediately on the first poll, without spending the rest of the budget
ok - fm_backend_herdr_wait_for_working: a slow transition landing on a later sample within one window is still caught (robust against the 'slow transition' failure direction)
ok - fm_backend_herdr_wait_for_working: spreads six samples across the full budget endpoint without a final trailing sleep
ok - fm_backend_herdr_send_text_submit: applies the herdr minimum confirmation budget before polling agent-state
ok - fm_backend_herdr_wait_for_working: reports 'idle' (readable, genuinely not yet working) when 'busy' never appears
ok - fm_backend_herdr_wait_for_working: reports 'unknown' (a hard read failure, not a timing race) only when EVERY poll in the window fails
ok - fm_backend_herdr_wait_for_working: treats blocked as submit-active for confirmation without changing watcher busy-state semantics
ok - fm_backend_herdr_send_text_submit: reports 'empty' once agent_status reports working after one Enter, without ever reading the composer
ok - fm_backend_herdr_send_text_submit: reports 'pending' when agent_status never reports working after retried Enters (swallowed)
ok - fm_backend_herdr_send_text_submit: a slash-command popup's placeholder fill on Enter #1 never flips agent_status to working, so it does not short-circuit as submitted; Enter #2 is retried and lands it
ok - fm_backend_herdr_send_text_submit: a post-Enter blocked state confirms delivery without retrying into the prompt
ok - fm_backend_herdr_send_text_submit: preexisting working is not accepted as submit proof when the composer still holds the message
ok - fm_backend_herdr_send_text_submit: confirms submission via native agent-state alone, immune to a codex-style dynamic idle-tip composer that would have misread as 'pending' under the old composer-based confirmation
ok - fm_backend_herdr_composer_state: a faint real-codex dynamic idle-tip composer row reads empty
ok - fm_backend_composer_state (herdr): the pre-injection empty-box guard still refuses a genuinely non-empty composer, unaffected by the submit-confirmation change
ok - fm_backend_herdr_send_text_submit: a slow transition landing on a later sample within one Enter's budget is confirmed WITHOUT sending a needless extra Enter
ok - fm_backend_herdr_send_text_submit: reports 'send-failed' when the literal send-text call itself errors
ok - fm_backend_herdr_send_text_submit: reports 'unknown' when the post-Enter agent-get read fails (never retries past an unreadable target)
ok - fm_backend_validate: herdr is a known backend (P2)
ok - fm_backend_busy_state: tmux (no native primitive) always reports unknown, preserving the P1 regex-only path
error: unknown backend 'bogus' (known: tmux herdr zellij orca cmux)
ok - fm_backend_composer_state dispatches tmux/herdr/orca to their named classifiers, unknown for zellij/unrecognized backends
ok - fm-peek/fm-send: explicit stale targets matching metadata use the recorded backend
ok - fm_backend_herdr_normalize_event routes through the shared record with an empty from_status
ok - fm_backend_herdr_escalation_marker keys the dedupe marker exactly like the watcher's .stale-<key>
ok - fm_backend_herdr_apply_transition: blocked dedupe starts only after explicit commit
ok - fm_backend_herdr_apply_transition: a working edge clears the marker so the next ->blocked re-escalates
ok - fm_backend_herdr_clear_transition removes task-owned dedupe state
ok - fm_backend_herdr_apply_transition: idle/done (defer) and unknown/empty (fallback) take no fast action
ok - fm_backend_herdr_wait_transition: a home with no herdr panes falls back to polling (rc 2)
ok - fm_backend_herdr_wait_transition: below-capability protocol/schema falls back to polling (rc 2)
ok - fm_backend_herdr_wait_transition: reconnect level-reconcile returns an uncommitted blocked pane
ok - fm_backend_herdr_wait_transition: subscribes before reconnect level-reconcile
ok - fm_backend_herdr_wait_transition: a still-blocked, already-escalated pane is not re-delivered on reconnect
ok - fm_backend_herdr_wait_transition: a streamed ->blocked edge returns the record sub-poll
ok - fm_backend_herdr_wait_transition: streamed working clears the marker, idle/done are deferred (clean timeout)
ok - fm_backend_herdr_wait_transition: a reader/subscribe failure falls back to polling (rc 2)
ok - fm_backend_herdr_wait_transition: Bash 3.2-safe bad-ack path closes fd 9 and removes its FIFO
ok - fm_backend_herdr_wait_transition: stock macOS Bash clean timeout closes fd 9 and returns 1
```
</details>
<details>
<summary>Evidence: Precondition-gap comparison: new e2e vs unmodified pre-existing e2e fail identically without a default session</summary>

```text
=== NEW: tests/fm-backend-herdr-server-identity-e2e.test.sh ===
fm-herdr-lab: fleet-state tripwire requires exactly one running default session
not ok - could not prepare isolated Herdr lab session
fm-herdr-lab: missing fleet-state tripwire for 'fm-lab-server-identity-18709'; refusing destructive calls
exit: 1

=== PRE-EXISTING (unmodified): tests/fm-backend-herdr-smoke.test.sh ===
fm-herdr-lab: fleet-state tripwire requires exactly one running default session
not ok - could not prepare isolated Herdr lab session
fm-herdr-lab: missing fleet-state tripwire for 'fm-lab-backend-smoke-18731'; refusing destructive calls
fm-herdr-lab: missing fleet-state tripwire for 'fm-lab-backend-smoke-18731'; refusing destructive calls
exit: 1
```
</details>
<details>
<summary>Evidence: Herdr session registry before bootstrap (restored identically after)</summary>

```text
{"sessions":[{"default":true,"name":"default","running":false,"session_dir":"/Users/inactdev/.config/herdr","socket_path":"/Users/inactdev/.config/herdr/herdr.sock"}]}
```
</details>
<details>
<summary>Evidence: Herdr session registry after teardown (diff vs before: identical)</summary>

```text
{"sessions":[{"default":true,"name":"default","running":false,"session_dir":"/Users/inactdev/.config/herdr","socket_path":"/Users/inactdev/.config/herdr/herdr.sock"}]}
```
</details>
<details>
<summary>Evidence: Bootstrap default-server log</summary>

```text
herdr server running; you can use any herdr CLI command in another terminal.
api socket: /Users/inactdev/.config/herdr/herdr.sock
client socket: /Users/inactdev/.config/herdr/herdr-client.sock
logs: /Users/inactdev/.config/herdr/herdr-server.log
did you mean to open the Herdr TUI? run `herdr`; you do not need `herdr server`.
```
</details>
- Outcome: ⚠️ 1 info across 1 run (5m0s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 3 infos</summary>

- ℹ️ `bin/backends/herdr.sh:1262` - The reason-code case blocks translating FM_BACKEND_HERDR_OWN_SOCKET_REASON to messages (in fm_backend_herdr_server_ensure at lines 1246-1262 and the mirrored block in fm_backend_herdr_launcher_identity) have no default arm: if a future reason code is ever added to the shared fm_backend_herdr_own_pane_socket_check, both callers would return 1 silently with no stderr message, contradicting the adapter&#39;s refuse-loudly convention. Only reachable via future code drift, so informational; a `*)` arm echoing the raw reason would make it drift-proof.
- ℹ️ `bin/backends/herdr.sh:1275` - The pre-start registry consult (line 1275) is itself a single unretried read of `session list --json`: if that one read transiently misses the target session&#39;s registration while the status probe also misreports, server_ensure still autostarts against a live session; the post-start re-check (lines 1295-1299) then detects the collision only after the disruptive start has happened. This is exactly the residual no-ancestry race the user intent explicitly acknowledges and scopes out (no cross-process lock, registry deemed authoritative and file-backed rather than an RPC to the possibly-flaky server), so it is an accepted tradeoff, not a defect - noting it here so the acknowledged residual is on record.
- ℹ️ `tests/fm-backend-herdr.test.sh:630` - test_server_ensure_post_start_collision_refuses (and the renumbered test_container_ensure_starts_server_and_workspace) depend on the backgrounded `( herdr server &amp; )` invocation consuming its canned-response slot (3.out) before the first foreground poll consumes the next one; the fake bin&#39;s read-increment-write counter is not synchronized with the background fork, so a scheduling inversion would shift response numbering and fail the test. This ordering assumption is a pre-existing pattern inherited from the base version of test_container_ensure_starts_server_and_workspace (which has been stable in practice), so the new tests do not make anything worse - flagging only so a future flake here is recognized as this known race rather than a product regression.

</details>

<details>
<summary>⚠️ **Test** - 1 info</summary>

- ℹ️ Pre-existing herdr process residue on this machine, not created by this test phase and left untouched: an orphaned lab server `herdr server --session fm-lab-fm-herdr-session-15750-19915` (PID 22743, started ~1h22m before this phase, its session absent from the registry) and a day-old `/opt/homebrew/bin/herdr server` pair (PIDs 46271/46272) that `herdr status --json` does not report as the default server. Likely leftovers from the author&#39;s earlier lab reproduction work and the 2026-08-01 incident environment; worth a manual cleanup.
- <code>`bash tests/fm-backend-herdr.test.sh` - full fake-CLI unit suite, 164/164 ok, including the 5 new fm_backend_herdr_server_ensure hardening tests</code>
- <code>`bash tests/fm-backend-herdr-server-identity-e2e.test.sh` without a default session - confirmed it fails on the same &#39;fleet-state tripwire requires exactly one running default session&#39; precondition as the unmodified pre-existing `tests/fm-backend-herdr-smoke.test.sh`, proving the gap is environmental and pre-existing</code>
- <code>Manually replicated CI&#39;s tests-herdr bootstrap (headless `herdr server` for the default session, polled to running, exactly one running default registration) after snapshotting the registry</code>
- <code>`bash tests/fm-backend-herdr-server-identity-e2e.test.sh` against real herdr 0.7.5 with the bootstrap in place - all 6 scenarios ok, exit 0, verified on a second run; lab session removed and default fleet session unchanged per the test&#39;s own tripwire</code>
- <code>Stopped the bootstrap server and diffed `herdr session list --json` before/after - registry restored byte-identical (default registered, not running); confirmed no fm-lab sessions or test-created processes remain and `git status` is clean</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
