### PR TITLE
docs: add instruction-ablation doctrine to maintenance guidance

### DIFF
--- a/.no-mistakes.yaml
+++ b/.no-mistakes.yaml
@@ -40,7 +40,3 @@ commands:
 test:
   evidence:
     store_in_repo: false
-
-# Configure push target to use fork instead of upstream.
-push:
-  target: fork

--- a/.no-mistakes.yaml
+++ b/.no-mistakes.yaml
@@ -40,3 +40,7 @@ commands:
 test:
   evidence:
     store_in_repo: false
+
+# Configure push target to use fork instead of upstream.
+push:
+  target: fork

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -534,3 +534,4 @@ Keep this file for knowledge useful to almost every future agent session in this
 Do not repeat what the codebase already shows; point to the authoritative file, skill, command, or doc.
 Prefer rewriting or pruning existing entries over appending new ones.
 When updating this file, preserve every safety boundary and keep the always-loaded contract concise.
+After a material model upgrade or evidence that instructions are stale, test removals in a bounded isolated run and restore only instructions whose absence causes repeated failures.


### PR DESCRIPTION
After a material model upgrade or evidence that instructions are stale, test removals in a bounded isolated run and restore only instructions whose absence causes repeated failures.

This single-sentence addition to AGENTS.md's 'Maintaining this file' section documents the instruction-ablation practice for keeping the always-loaded contract concise and fit.