### PR TITLE
feat(bin): add opt-in visual-evidence contract to generated ship briefs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -473,6 +473,7 @@ If a ship task touches firstmate's shared tracked material, explicitly require `
 If a task will drive Herdr lifecycle behavior, scaffold with `--herdr-lab`; if that need appears after an unguarded scaffold, stop and regenerate rather than adding commands by hand.
 The generated Herdr contract must use a named non-`default` isolated lab and its guarded helper for every lifecycle action.
 If a ship task changes a user-visible surface - browser, terminal, or generated output alike - scaffold with `--visual-evidence` so the brief requires captured before-and-after artifacts instead of prose.
+Those captures land on a sibling orphan `fm/<task-id>-evidence` ref that never merges, so delete that ref once the task's pull request or ready branch lands.
 
 Load `secondmate-provisioning` before creating or using a charter brief and preserve its idle-by-default and marked-return-channel contracts.
 Status appends are sparse supervisor-actionable events, not routine progress; `bin/fm-classify-lib.sh` owns keyed open and resolved semantics.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -472,7 +472,7 @@ Every ship brief must retain the worktree-isolation assertion and stop if launch
 If a ship task touches firstmate's shared tracked material, explicitly require `firstmate-coding-guidelines` before editing.
 If a task will drive Herdr lifecycle behavior, scaffold with `--herdr-lab`; if that need appears after an unguarded scaffold, stop and regenerate rather than adding commands by hand.
 The generated Herdr contract must use a named non-`default` isolated lab and its guarded helper for every lifecycle action.
-If a ship task changes a user-visible surface, scaffold with `--visual-evidence` so the brief requires before-and-after visual artifacts instead of prose.
+If a ship task changes a user-visible surface - browser, terminal, or generated output alike - scaffold with `--visual-evidence` so the brief requires captured before-and-after artifacts instead of prose.
 
 Load `secondmate-provisioning` before creating or using a charter brief and preserve its idle-by-default and marked-return-channel contracts.
 Status appends are sparse supervisor-actionable events, not routine progress; `bin/fm-classify-lib.sh` owns keyed open and resolved semantics.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -473,7 +473,6 @@ If a ship task touches firstmate's shared tracked material, explicitly require `
 If a task will drive Herdr lifecycle behavior, scaffold with `--herdr-lab`; if that need appears after an unguarded scaffold, stop and regenerate rather than adding commands by hand.
 The generated Herdr contract must use a named non-`default` isolated lab and its guarded helper for every lifecycle action.
 If a ship task changes a user-visible surface - browser, terminal, or generated output alike - scaffold with `--visual-evidence` so the brief requires captured before-and-after artifacts instead of prose.
-Those captures land on a sibling orphan `fm/<task-id>-evidence` ref that never merges, so delete that ref once the task's pull request or ready branch lands.
 
 Load `secondmate-provisioning` before creating or using a charter brief and preserve its idle-by-default and marked-return-channel contracts.
 Status appends are sparse supervisor-actionable events, not routine progress; `bin/fm-classify-lib.sh` owns keyed open and resolved semantics.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,6 +84,7 @@ data/                personal fleet records; LOCAL, gitignored as a whole
   secondmates.md      secondmate routing table; firstmate-private, maintained by fm-home-seed.sh (section 6)
   <id>/brief.md      per-task crewmate brief, or per-secondmate charter brief when kind=secondmate
   <id>/report.md     scout task deliverable, written by the crewmate; survives teardown
+  <id>/evidence/     visual-evidence artifacts for a `--visual-evidence` ship task, written by the crewmate; survives teardown
 projects/            cloned repos; gitignored; read-only except under hard rule 1's concrete captain-approved project operation exception
 state/               volatile runtime signals; gitignored
   <id>.status        appended by crewmates: "<state>: <note>" wake-event lines, not current-state truth

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -472,6 +472,7 @@ Every ship brief must retain the worktree-isolation assertion and stop if launch
 If a ship task touches firstmate's shared tracked material, explicitly require `firstmate-coding-guidelines` before editing.
 If a task will drive Herdr lifecycle behavior, scaffold with `--herdr-lab`; if that need appears after an unguarded scaffold, stop and regenerate rather than adding commands by hand.
 The generated Herdr contract must use a named non-`default` isolated lab and its guarded helper for every lifecycle action.
+If a ship task changes a user-visible surface, scaffold with `--visual-evidence` so the brief requires before-and-after visual artifacts instead of prose.
 
 Load `secondmate-provisioning` before creating or using a charter brief and preserve its idle-by-default and marked-return-channel contracts.
 Status appends are sparse supervisor-actionable events, not routine progress; `bin/fm-classify-lib.sh` owns keyed open and resolved semantics.

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -28,14 +28,19 @@
 #   without it carry a loud declaration so an omitted contract cannot be silent.
 #   --visual-evidence adds the visual-evidence contract to a ship brief, for work
 #   that changes a user-visible surface. The generated contract requires: a
-#   "before" that is a screenshot of the real page at the real route; an "after"
-#   that is always an artifact, preferring a screenshot of the change running in a
-#   throwaway prototype, then a mock rendered in the project's own design system,
-#   then a diagram; one tight screenshot per claim placed beside that claim;
-#   cropping and annotation down to the region that changed; and prose reserved
-#   for rationale, trade-offs, and open questions. Prototyping the after costs
-#   budget when the worker chooses and only repays a review round later, so the
-#   brief has to require it or no worker spends it.
+#   "before" that is a capture of the real surface as it stands today, unless the
+#   surface does not exist yet; an "after" that is always an artifact, preferring
+#   a capture of the change running in a throwaway prototype, then a mock rendered
+#   in the project's own design system, then a diagram; one tight capture per
+#   claim placed beside that claim; cropping and annotation down to the region
+#   that changed; and prose reserved for rationale, trade-offs, and open
+#   questions. The medium follows the surface - a browser view is a screenshot of
+#   the real route, CLI output is the real transcript of the real command, a
+#   generated file is its real content - so the contract fits non-browser
+#   surfaces too. Artifacts go in the PR description when the project opens a PR
+#   and in data/<task-id>/ otherwise, which outlives the worktree.
+#   Prototyping the after costs budget when the worker chooses and only repays a
+#   review round later, so the brief has to require it or no worker spends it.
 #   The flag is explicit because {TASK} is filled in after scaffolding, so the
 #   scaffold cannot tell whether the work is visual. It is ship-only, and omitting
 #   it emits nothing at all: unlike Herdr lifecycle isolation, a missing visual
@@ -386,18 +391,20 @@ DOD=${DOD%$'\n'}
 # surrounding brief byte-identical to a brief scaffolded without the flag.
 VISUAL_EVIDENCE_SECTION=""
 if [ "$VISUAL_EVIDENCE" -eq 1 ]; then
-IFS= read -r -d '' VISUAL_EVIDENCE_SECTION <<'EOF' || true
+IFS= read -r -d '' VISUAL_EVIDENCE_SECTION <<EOF || true
 # Visual evidence - show the change, do not describe it
-This task changes a user-visible surface, so every claim about how it looks must arrive as an artifact, not as prose.
-Produce the artifacts below as you work and put them where this change is reviewed: the PR description when this project opens a PR, otherwise the summary you hand back.
+This task changes a user-visible surface, so every claim about how it looks must arrive as a capture of the real thing, not as prose.
+The medium follows the surface: a browser view is captured as a screenshot of the real page at the real route, terminal or CLI output as the real transcript of the real command, a generated file or payload as its real content.
+Produce the artifacts below as you work and put them where this change is reviewed: the PR description when this project opens a PR, and in every non-PR mode the directory \`$DATA/$ID/\` beside this brief, which outlives your worktree the way a scout report does.
+Those artifacts and the status file are the only things you write outside the worktree.
 
-1. **Before is a screenshot of the real page at the real route.** Run the project, navigate to the affected view, and capture what is there today. A written description of the current look is not a before.
-2. **After is always an artifact, never prose alone.** In order of preference: a screenshot of the change running in a throwaway prototype; a mock rendered in the project's own design system; a diagram. If prototyping the after looks too expensive, that is evidence the change is under-specified - settle what it should be first. It is not an exemption.
-3. **One tight screenshot per claim, placed beside the claim it evidences.** Do not dump a single full-page image at the top and leave the reader to map it back onto the text.
-4. **Crop and annotate down to the region that changed.** A full-page image offered as proof that one element moved makes the reviewer do the diffing.
+1. **Before is a capture of the real surface as it stands today.** Run the project, reach the affected surface, and capture it: the real page at the real route, the real command with its real output, the real generated content. A written description of the current look is never a before. The one exception is a surface that does not exist yet - say so in a line and go straight to the after.
+2. **After is always an artifact, never prose alone.** In order of preference: a capture of the change running in a throwaway prototype; a mock rendered in the project's own design system; a diagram. If prototyping the after looks too expensive, that is evidence the change is under-specified - settle what it should be first. It is not an exemption.
+3. **One tight capture per claim, placed beside the claim it evidences.** Do not dump a single full-page image or an entire transcript at the top and leave the reader to map it back onto the text.
+4. **Crop and annotate down to the region that changed.** A full-page image offered as proof that one element moved, or a whole log offered as proof of one changed line, makes the reviewer do the diffing.
 5. **Prose is reserved for what cannot be shown** - rationale, trade-offs, and open questions.
 
-Capture screenshots with `chrome-devtools-axi`.
+Capture browser surfaces with \`chrome-devtools-axi\`.
 EOF
 # The leading newline opens the blank line before the heading, and the trailing
 # newline read -r -d '' preserved closes the blank line before "# Project memory".

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -46,11 +46,13 @@
 #   data/<task-id>/evidence/, which the flag also names as the single exception to
 #   the brief's stay-inside-the-worktree rule 2 - the same class of write as the
 #   status file, scoped to this task and nothing else.
-#   Each artifact is linked by its path beside the claim it evidences, and the
-#   prose must carry that claim on its own, because a reviewer who is not on this
-#   machine cannot open the file: for upstream-facing work the artifacts are the
-#   captain's verification rather than the upstream reviewer's, which is an
-#   accepted limitation and the reason captures go to no other host.
+#   Each artifact is linked by its path beside the claim it evidences - in the
+#   pull request body as soon as it exists, whoever opened it, or in the hand-back
+#   when the mode opens none - and the prose must carry that claim on its own,
+#   because a reviewer who is not on this machine cannot open the file: for
+#   upstream-facing work the artifacts are the captain's verification rather than
+#   the upstream reviewer's, which is an accepted limitation and the reason
+#   captures go to no other host.
 #   Prototyping the after costs budget when the worker chooses and only repays a
 #   review round later, so the brief has to require it or no worker spends it.
 #   The flag is explicit because {TASK} is filled in after scaffolding, so the
@@ -433,6 +435,8 @@ If you conclude an artifact cannot be produced without writing outside this work
 ## Delivering the artifacts
 Copy every artifact you present out of \`.fm-scratch/\` into this task's own evidence directory, which outlives this worktree: run \`mkdir -p $EVIDENCE_DIR\` and copy them there, keeping the layout flat with one file per claim.
 Link each artifact by its path beside the claim it evidences - in the pull request body when this project opens one, in the summary you hand back when it does not - never as a block at the bottom.
+When the pull request is opened for you, add those links to its body with \`gh-axi\` as soon as it exists; when you open it yourself, write them into the body you author; when there is no pull request, name this directory in the hand-back you return.
+Adding those links is not a code edit and not a findings fix, so it is not the hand-editing that an active validation run forbids.
 Write each claim so the prose carries it on its own: a path is opaque to a reader who cannot open the file, so the sentence states what changed and the artifact confirms it. That is not prose standing in for an after; the artifact stays mandatory.
 Accept the one limitation rather than working around it: a reviewer who is not on this machine cannot open these files, so for work whose pull request goes to a public upstream the artifacts are the captain's verification rather than the upstream reviewer's, and the self-carrying prose above is what keeps that pull request readable for both.
 That is also why the artifacts go nowhere else, not to a gist and not to any other host: a secret gist is unlisted rather than access-controlled, so anyone holding the link could read captures of a private product.

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -42,10 +42,15 @@
 #   is its real content), so the contract fits non-browser surfaces too.
 #   Prototypes and captures are built inside the task worktree under a
 #   self-ignoring .fm-scratch/ and are never committed to the code branch; the
-#   captures are delivered on a sibling orphan ref fm/<task-id>-evidence, pushed
-#   to the code branch's remote and linked from the pull request body in the PR
-#   modes, kept local and named in the hand-back for local-only, never a gist,
-#   and deleted once the work lands because that ref never merges.
+#   artifacts that are presented are copied to this task's own record directory,
+#   data/<task-id>/evidence/, which the flag also names as the single exception to
+#   the brief's stay-inside-the-worktree rule 2 - the same class of write as the
+#   status file, scoped to this task and nothing else.
+#   Each artifact is linked by its path beside the claim it evidences, and the
+#   prose must carry that claim on its own, because a reviewer who is not on this
+#   machine cannot open the file: for upstream-facing work the artifacts are the
+#   captain's verification rather than the upstream reviewer's, which is an
+#   accepted limitation and the reason captures go to no other host.
 #   Prototyping the after costs budget when the worker chooses and only repays a
 #   review round later, so the brief has to require it or no worker spends it.
 #   The flag is explicit because {TASK} is filled in after scaffolding, so the
@@ -163,6 +168,7 @@ shell_quote() {
 }
 
 STATUS_FILE=$(shell_quote "$STATE/$ID.status")
+EVIDENCE_DIR=$(shell_quote "$DATA/$ID/evidence")
 
 if [ "$KIND" = secondmate ]; then
 SECONDMATE_PROJECTS=""
@@ -396,24 +402,16 @@ DOD=${DOD%$'\n'}
 # Opt-in visual-evidence contract. It stays empty unless --visual-evidence was
 # passed, and it carries its own leading newline so an omitted section leaves the
 # surrounding brief byte-identical to a brief scaffolded without the flag.
+RULE2='2. Stay inside this worktree; modify nothing outside it.'
 VISUAL_EVIDENCE_SECTION=""
 if [ "$VISUAL_EVIDENCE" -eq 1 ]; then
-case "$MODE" in
-  local-only)
-    IFS= read -r -d '' VISUAL_EVIDENCE_DELIVERY <<EOF || true
-This project ships local-only, so \`fm/$ID-evidence\` stays local: never push it, and name the ref and the capture filenames in your \`ready in branch\` hand-back so the reviewer can check it out.
-The evidence ref never merges, so no branch cleanup removes it: say in that hand-back that \`fm/$ID-evidence\` must be deleted once the work lands, and delete it yourself if you are still working then.
+IFS= read -r -d '' RULE2 <<EOF || true
+2. Stay inside this worktree; modify nothing outside it.
+   The single exception is this task's own visual-evidence directory \`$EVIDENCE_DIR\` in the firstmate home, described under Visual evidence below.
+   That is the same class of write, to the same home, as the status file you append to in rule 4: every brief already writes that one file outside its worktree.
+   It authorizes nothing else - not another task's record directory, not that home's shared files, not any other path.
 EOF
-    ;;
-  *)
-    IFS= read -r -d '' VISUAL_EVIDENCE_DELIVERY <<EOF || true
-Push \`fm/$ID-evidence\` to the same remote your code branch goes to, so it inherits that repository's access control; it is the only other ref you push, a sibling of your own branch and never the default branch.
-Reference each capture in the pull request body by its URL on that ref, and when the pull request is opened for you, add those links to its body with \`gh-axi\` as soon as it exists.
-The evidence ref never merges, so no branch cleanup removes it: state in the pull request body that \`fm/$ID-evidence\` must be deleted once the pull request lands, and delete it yourself if you are still working then.
-EOF
-    ;;
-esac
-VISUAL_EVIDENCE_DELIVERY=${VISUAL_EVIDENCE_DELIVERY%$'\n'}
+RULE2=${RULE2%$'\n'}
 IFS= read -r -d '' VISUAL_EVIDENCE_SECTION <<EOF || true
 # Visual evidence - show the change, do not describe it
 This task changes a user-visible surface, so every claim about how it looks must arrive as a capture of the real thing, not as prose.
@@ -430,14 +428,14 @@ The medium follows the surface: a browser view is captured as a screenshot of th
 Build every prototype and capture inside this worktree, under \`.fm-scratch/\`: create the directory and write a single \`*\` line into \`.fm-scratch/.gitignore\`, which hides the whole directory from git without touching the project's own ignore file.
 A prototype is scratch: never commit it to your \`fm/$ID\` branch, and expect it to die with this worktree.
 Capture browser surfaces with \`chrome-devtools-axi\`.
-If you conclude an artifact cannot be produced without writing outside this worktree, append \`blocked: {why}\` and stop; that is an escalation, not a licence to write outside it.
+If you conclude an artifact cannot be produced without writing outside this worktree and its evidence directory, append \`blocked: {why}\` and stop; that is an escalation, not a licence to write anywhere else.
 
-## Delivering the captures
-The captures are delivered on a sibling orphan ref, \`fm/$ID-evidence\` - never on your code branch, and never in a gist, because a secret gist is unlisted rather than access-controlled and anyone holding the link can read it.
-Commit your code work first, then run \`git switch --orphan fm/$ID-evidence\`: your tracked files clear while \`.fm-scratch/\` survives, so copy the captures out of it to the ref root.
-Keep that root flat - one capture per claim with \`before\` or \`after\` in each filename, a \`README.md\` indexing them, and any script you wrote to produce them committed alongside.
-Commit with a message prefixed \`evidence:\`, then run \`git switch fm/$ID\` and carry on with the code work.
-$VISUAL_EVIDENCE_DELIVERY
+## Delivering the artifacts
+Copy every artifact you present out of \`.fm-scratch/\` into this task's own evidence directory, which outlives this worktree: run \`mkdir -p $EVIDENCE_DIR\` and copy them there, keeping the layout flat with one file per claim.
+Link each artifact by its path beside the claim it evidences - in the pull request body when this project opens one, in the summary you hand back when it does not - never as a block at the bottom.
+Write each claim so the prose carries it on its own: a path is opaque to a reader who cannot open the file, so the sentence states what changed and the artifact confirms it. That is not prose standing in for an after; the artifact stays mandatory.
+Accept the one limitation rather than working around it: a reviewer who is not on this machine cannot open these files, so for work whose pull request goes to a public upstream the artifacts are the captain's verification rather than the upstream reviewer's, and the self-carrying prose above is what keeps that pull request readable for both.
+That is also why the artifacts go nowhere else, not to a gist and not to any other host: a secret gist is unlisted rather than access-controlled, so anyone holding the link could read captures of a private product.
 EOF
 # The leading newline opens the blank line before the heading, and the trailing
 # newline read -r -d '' preserved closes the blank line before "# Project memory".
@@ -463,7 +461,7 @@ If the top-level path is the primary checkout or not the worktree you were launc
 
 # Rules
 $RULE1
-2. Stay inside this worktree; modify nothing outside it.
+$RULE2
 3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
 4. Report status by appending one line:
    \`echo "{state}: {one short line}" >> $STATUS_FILE\`

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -34,11 +34,18 @@
 #   in the project's own design system, then a diagram; one tight capture per
 #   claim placed beside that claim; cropping and annotation down to the region
 #   that changed; and prose reserved for rationale, trade-offs, and open
-#   questions. The medium follows the surface - a browser view is a screenshot of
-#   the real route, CLI output is the real transcript of the real command, a
-#   generated file is its real content - so the contract fits non-browser
-#   surfaces too. Artifacts go in the PR description when the project opens a PR
-#   and in data/<task-id>/ otherwise, which outlives the worktree.
+#   questions. The after has one carve-out, for motion, timing, or a measurement
+#   no still capture can hold, which the worker must name and justify; an
+#   unattached "I could not show it" stays a missing after.
+#   The medium follows the surface (a browser view is a screenshot of the real
+#   route, CLI output is the real transcript of the real command, a generated file
+#   is its real content), so the contract fits non-browser surfaces too.
+#   Prototypes and captures are built inside the task worktree under a
+#   self-ignoring .fm-scratch/ and are never committed to the code branch; the
+#   captures are delivered on a sibling orphan ref fm/<task-id>-evidence, pushed
+#   to the code branch's remote and linked from the pull request body in the PR
+#   modes, kept local and named in the hand-back for local-only, never a gist,
+#   and deleted once the work lands because that ref never merges.
 #   Prototyping the after costs budget when the worker chooses and only repays a
 #   review round later, so the brief has to require it or no worker spends it.
 #   The flag is explicit because {TASK} is filled in after scaffolding, so the
@@ -391,20 +398,46 @@ DOD=${DOD%$'\n'}
 # surrounding brief byte-identical to a brief scaffolded without the flag.
 VISUAL_EVIDENCE_SECTION=""
 if [ "$VISUAL_EVIDENCE" -eq 1 ]; then
+case "$MODE" in
+  local-only)
+    IFS= read -r -d '' VISUAL_EVIDENCE_DELIVERY <<EOF || true
+This project ships local-only, so \`fm/$ID-evidence\` stays local: never push it, and name the ref and the capture filenames in your \`ready in branch\` hand-back so the reviewer can check it out.
+The evidence ref never merges, so no branch cleanup removes it: say in that hand-back that \`fm/$ID-evidence\` must be deleted once the work lands, and delete it yourself if you are still working then.
+EOF
+    ;;
+  *)
+    IFS= read -r -d '' VISUAL_EVIDENCE_DELIVERY <<EOF || true
+Push \`fm/$ID-evidence\` to the same remote your code branch goes to, so it inherits that repository's access control; it is the only other ref you push, a sibling of your own branch and never the default branch.
+Reference each capture in the pull request body by its URL on that ref, and when the pull request is opened for you, add those links to its body with \`gh-axi\` as soon as it exists.
+The evidence ref never merges, so no branch cleanup removes it: state in the pull request body that \`fm/$ID-evidence\` must be deleted once the pull request lands, and delete it yourself if you are still working then.
+EOF
+    ;;
+esac
+VISUAL_EVIDENCE_DELIVERY=${VISUAL_EVIDENCE_DELIVERY%$'\n'}
 IFS= read -r -d '' VISUAL_EVIDENCE_SECTION <<EOF || true
 # Visual evidence - show the change, do not describe it
 This task changes a user-visible surface, so every claim about how it looks must arrive as a capture of the real thing, not as prose.
 The medium follows the surface: a browser view is captured as a screenshot of the real page at the real route, terminal or CLI output as the real transcript of the real command, a generated file or payload as its real content.
-Produce the artifacts below as you work and put them where this change is reviewed: the PR description when this project opens a PR, and in every non-PR mode the directory \`$DATA/$ID/\` beside this brief, which outlives your worktree the way a scout report does.
-Those artifacts and the status file are the only things you write outside the worktree.
 
 1. **Before is a capture of the real surface as it stands today.** Run the project, reach the affected surface, and capture it: the real page at the real route, the real command with its real output, the real generated content. A written description of the current look is never a before. The one exception is a surface that does not exist yet - say so in a line and go straight to the after.
 2. **After is always an artifact, never prose alone.** In order of preference: a capture of the change running in a throwaway prototype; a mock rendered in the project's own design system; a diagram. If prototyping the after looks too expensive, that is evidence the change is under-specified - settle what it should be first. It is not an exemption.
+   The single carve-out is a change no still capture can hold, meaning motion, timing, or a measurement, and then a recording or the measured result is the artifact. Name the form you used and why a still could not carry the claim. "I could not show it" with nothing attached is not a carve-out; it is a missing after.
 3. **One tight capture per claim, placed beside the claim it evidences.** Do not dump a single full-page image or an entire transcript at the top and leave the reader to map it back onto the text.
 4. **Crop and annotate down to the region that changed.** A full-page image offered as proof that one element moved, or a whole log offered as proof of one changed line, makes the reviewer do the diffing.
 5. **Prose is reserved for what cannot be shown** - rationale, trade-offs, and open questions.
 
+## Producing the artifacts
+Build every prototype and capture inside this worktree, under \`.fm-scratch/\`: create the directory and write a single \`*\` line into \`.fm-scratch/.gitignore\`, which hides the whole directory from git without touching the project's own ignore file.
+A prototype is scratch: never commit it to your \`fm/$ID\` branch, and expect it to die with this worktree.
 Capture browser surfaces with \`chrome-devtools-axi\`.
+If you conclude an artifact cannot be produced without writing outside this worktree, append \`blocked: {why}\` and stop; that is an escalation, not a licence to write outside it.
+
+## Delivering the captures
+The captures are delivered on a sibling orphan ref, \`fm/$ID-evidence\` - never on your code branch, and never in a gist, because a secret gist is unlisted rather than access-controlled and anyone holding the link can read it.
+Commit your code work first, then run \`git switch --orphan fm/$ID-evidence\`: your tracked files clear while \`.fm-scratch/\` survives, so copy the captures out of it to the ref root.
+Keep that root flat - one capture per claim with \`before\` or \`after\` in each filename, a \`README.md\` indexing them, and any script you wrote to produce them committed alongside.
+Commit with a message prefixed \`evidence:\`, then run \`git switch fm/$ID\` and carry on with the code work.
+$VISUAL_EVIDENCE_DELIVERY
 EOF
 # The leading newline opens the blank line before the heading, and the trailing
 # newline read -r -d '' preserved closes the blank line before "# Project memory".

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -6,7 +6,7 @@
 # description, acceptance criteria, and context, and may adjust other sections
 # when the task genuinely deviates (e.g. working an existing external PR instead
 # of shipping a new one).
-# Usage: fm-brief.sh <task-id> <repo-name> [--scout] [--herdr-lab]
+# Usage: fm-brief.sh <task-id> <repo-name> [--scout] [--herdr-lab] [--visual-evidence]
 #        fm-brief.sh <task-id> --secondmate {<project>...|--no-projects}
 #   --scout writes the scout contract instead: the deliverable is a report at
 #   data/<task-id>/report.md (no branch, no push, no PR) and the worktree is scratch.
@@ -26,6 +26,21 @@
 #   The flag must be explicit because {TASK} is filled after scaffolding and the
 #   caller-supplied repo string cannot reliably identify this repo. Briefs made
 #   without it carry a loud declaration so an omitted contract cannot be silent.
+#   --visual-evidence adds the visual-evidence contract to a ship brief, for work
+#   that changes a user-visible surface. The generated contract requires: a
+#   "before" that is a screenshot of the real page at the real route; an "after"
+#   that is always an artifact, preferring a screenshot of the change running in a
+#   throwaway prototype, then a mock rendered in the project's own design system,
+#   then a diagram; one tight screenshot per claim placed beside that claim;
+#   cropping and annotation down to the region that changed; and prose reserved
+#   for rationale, trade-offs, and open questions. Prototyping the after costs
+#   budget when the worker chooses and only repays a review round later, so the
+#   brief has to require it or no worker spends it.
+#   The flag is explicit because {TASK} is filled in after scaffolding, so the
+#   scaffold cannot tell whether the work is visual. It is ship-only, and omitting
+#   it emits nothing at all: unlike Herdr lifecycle isolation, a missing visual
+#   contract costs a review round, not safety, so briefs for work with no
+#   user-visible surface must not carry a declaration.
 # For ship tasks, the definition of done is shaped by the project's delivery mode
 # (data/projects.md via fm-project-mode.sh; see the project-management skill
 # and AGENTS.md task lifecycle):
@@ -93,6 +108,7 @@ else
 fi
 KIND=ship
 HERDR_LAB=0
+VISUAL_EVIDENCE=0
 NO_PROJECTS=0
 POS=()
 for a in "$@"; do
@@ -100,6 +116,7 @@ for a in "$@"; do
     --scout) KIND=scout ;;
     --secondmate) KIND=secondmate ;;
     --herdr-lab) HERDR_LAB=1 ;;
+    --visual-evidence) VISUAL_EVIDENCE=1 ;;
     --no-projects) NO_PROJECTS=1 ;;
     *) POS+=("$a") ;;
   esac
@@ -108,6 +125,13 @@ ID=${POS[0]}
 
 if [ "$KIND" = secondmate ] && [ "$HERDR_LAB" -eq 1 ]; then
   echo "error: --herdr-lab applies only to crewmate ship or scout briefs" >&2
+  exit 1
+fi
+
+# Ship-only: the contract is about how a change is shown for review, and only a
+# ship brief delivers a change. A scout already owes evidence through its report.
+if [ "$VISUAL_EVIDENCE" -eq 1 ] && [ "$KIND" != ship ]; then
+  echo "error: --visual-evidence applies only to crewmate ship briefs" >&2
   exit 1
 fi
 
@@ -357,6 +381,29 @@ esac
 # briefs stay byte-identical to the historical Bash 5 output.
 DOD=${DOD%$'\n'}
 
+# Opt-in visual-evidence contract. It stays empty unless --visual-evidence was
+# passed, and it carries its own leading newline so an omitted section leaves the
+# surrounding brief byte-identical to a brief scaffolded without the flag.
+VISUAL_EVIDENCE_SECTION=""
+if [ "$VISUAL_EVIDENCE" -eq 1 ]; then
+IFS= read -r -d '' VISUAL_EVIDENCE_SECTION <<'EOF' || true
+# Visual evidence - show the change, do not describe it
+This task changes a user-visible surface, so every claim about how it looks must arrive as an artifact, not as prose.
+Produce the artifacts below as you work and put them where this change is reviewed: the PR description when this project opens a PR, otherwise the summary you hand back.
+
+1. **Before is a screenshot of the real page at the real route.** Run the project, navigate to the affected view, and capture what is there today. A written description of the current look is not a before.
+2. **After is always an artifact, never prose alone.** In order of preference: a screenshot of the change running in a throwaway prototype; a mock rendered in the project's own design system; a diagram. If prototyping the after looks too expensive, that is evidence the change is under-specified - settle what it should be first. It is not an exemption.
+3. **One tight screenshot per claim, placed beside the claim it evidences.** Do not dump a single full-page image at the top and leave the reader to map it back onto the text.
+4. **Crop and annotate down to the region that changed.** A full-page image offered as proof that one element moved makes the reviewer do the diffing.
+5. **Prose is reserved for what cannot be shown** - rationale, trade-offs, and open questions.
+
+Capture screenshots with `chrome-devtools-axi`.
+EOF
+# The leading newline opens the blank line before the heading, and the trailing
+# newline read -r -d '' preserved closes the blank line before "# Project memory".
+VISUAL_EVIDENCE_SECTION=$'\n'${VISUAL_EVIDENCE_SECTION}
+fi
+
 cat > "$BRIEF" <<EOF
 You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.
 
@@ -398,7 +445,7 @@ $RULE1
 7. Never stop, restart, or update the shared \`no-mistakes\` daemon - it is one instance serving
    every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
    daemon error, append \`blocked: {the daemon error}\` and stop; only firstmate manages the daemon.
-
+$VISUAL_EVIDENCE_SECTION
 # Project memory
 If \`AGENTS.md\` or \`CLAUDE.md\` already exists, or if this task produced durable project-intrinsic knowledge, run \`$FM_ROOT/bin/fm-ensure-agents-md.sh .\` in the worktree.
 Record only project knowledge useful to almost every future session.

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -18,7 +18,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-update.sh`           | Fast-forward-only self-update of firstmate and secondmate homes from origin          |
 | `fm-backlog-handoff.sh`  | Validate and delegate queued backlog-item moves into a secondmate home               |
 | `fm-decision-hold.sh`    | Create, verify, complete, and resolve durable captain-held decisions                 |
-| `fm-brief.sh`            | Scaffold ship, scout, secondmate-charter, and Herdr-lab briefs                       |
+| `fm-brief.sh`            | Scaffold ship, scout, secondmate-charter, Herdr-lab, and visual-evidence briefs      |
 | `fm-herdr-lab.sh`        | Provision and guardedly operate an isolated, never-default Herdr lab session         |
 | `fm-install-herdr.sh`    | Install CI's exact-version Herdr pin with official asset URL, SHA-256, and protocol checks |
 | `fm-install-treehouse.sh`| Install CI's exact-version Treehouse pin for real-Herdr E2E that needs spawn worktrees |

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -18,7 +18,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-update.sh`           | Fast-forward-only self-update of firstmate and secondmate homes from origin          |
 | `fm-backlog-handoff.sh`  | Validate and delegate queued backlog-item moves into a secondmate home               |
 | `fm-decision-hold.sh`    | Create, verify, complete, and resolve durable captain-held decisions                 |
-| `fm-brief.sh`            | Scaffold ship, scout, secondmate-charter, Herdr-lab, and visual-evidence briefs      |
+| `fm-brief.sh`            | Scaffold ship, scout, secondmate-charter, Herdr-lab, and visual-evidence briefs, whose captures land on a sibling `fm/<task-id>-evidence` ref |
 | `fm-herdr-lab.sh`        | Provision and guardedly operate an isolated, never-default Herdr lab session         |
 | `fm-install-herdr.sh`    | Install CI's exact-version Herdr pin with official asset URL, SHA-256, and protocol checks |
 | `fm-install-treehouse.sh`| Install CI's exact-version Treehouse pin for real-Herdr E2E that needs spawn worktrees |

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -18,7 +18,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-update.sh`           | Fast-forward-only self-update of firstmate and secondmate homes from origin          |
 | `fm-backlog-handoff.sh`  | Validate and delegate queued backlog-item moves into a secondmate home               |
 | `fm-decision-hold.sh`    | Create, verify, complete, and resolve durable captain-held decisions                 |
-| `fm-brief.sh`            | Scaffold ship, scout, secondmate-charter, Herdr-lab, and visual-evidence briefs, whose captures land on a sibling `fm/<task-id>-evidence` ref |
+| `fm-brief.sh`            | Scaffold ship, scout, secondmate-charter, Herdr-lab, and visual-evidence briefs, whose artifacts land in the task's own `data/<task-id>/evidence/` |
 | `fm-herdr-lab.sh`        | Provision and guardedly operate an isolated, never-default Herdr lab session         |
 | `fm-install-herdr.sh`    | Install CI's exact-version Herdr pin with official asset URL, SHA-256, and protocol checks |
 | `fm-install-treehouse.sh`| Install CI's exact-version Treehouse pin for real-Herdr E2E that needs spawn worktrees |

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -18,7 +18,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-update.sh`           | Fast-forward-only self-update of firstmate and secondmate homes from origin          |
 | `fm-backlog-handoff.sh`  | Validate and delegate queued backlog-item moves into a secondmate home               |
 | `fm-decision-hold.sh`    | Create, verify, complete, and resolve durable captain-held decisions                 |
-| `fm-brief.sh`            | Scaffold ship, scout, secondmate-charter, Herdr-lab, and visual-evidence briefs, whose artifacts land in the task's own `data/<task-id>/evidence/` |
+| `fm-brief.sh`            | Scaffold ship, scout, secondmate-charter, Herdr-lab, and visual-evidence briefs      |
 | `fm-herdr-lab.sh`        | Provision and guardedly operate an isolated, never-default Herdr lab session         |
 | `fm-install-herdr.sh`    | Install CI's exact-version Herdr pin with official asset URL, SHA-256, and protocol checks |
 | `fm-install-treehouse.sh`| Install CI's exact-version Treehouse pin for real-Herdr E2E that needs spawn worktrees |

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -367,6 +367,7 @@ test_visual_evidence_contract_is_opt_in_and_complete() {
   local home id brief
   home="$TMP_ROOT/visual-evidence-home"
   write_registry "$home"
+  home=$(cd "$home" && pwd -P)
 
   # The contract renders for every ship delivery mode, since a change needs the
   # same evidence whether it lands through the pipeline, a direct PR, or locally.
@@ -377,26 +378,41 @@ test_visual_evidence_contract_is_opt_in_and_complete() {
     assert_present "$brief" "$id: --visual-evidence brief was not scaffolded"
     assert_grep "# Visual evidence - show the change, do not describe it" "$brief" \
       "$id: visual-evidence brief missing its section heading"
-    assert_grep "Before is a screenshot of the real page at the real route" "$brief" \
-      "$id: visual-evidence contract lost the real-page before requirement"
-    assert_grep "A written description of the current look is not a before." "$brief" \
+    assert_grep "Before is a capture of the real surface as it stands today" "$brief" \
+      "$id: visual-evidence contract lost the real-surface before requirement"
+    assert_grep "the real page at the real route, the real command with its real output, the real generated content" "$brief" \
+      "$id: visual-evidence contract lost the per-surface before media"
+    assert_grep "A written description of the current look is never a before." "$brief" \
       "$id: visual-evidence contract allowed a prose before"
+    assert_grep "The one exception is a surface that does not exist yet" "$brief" \
+      "$id: visual-evidence contract demanded a before for a surface that cannot be captured"
     assert_grep "After is always an artifact, never prose alone" "$brief" \
       "$id: visual-evidence contract lost the artifact-after requirement"
-    assert_grep "a screenshot of the change running in a throwaway prototype; a mock rendered in the project's own design system; a diagram" "$brief" \
+    assert_grep "a capture of the change running in a throwaway prototype; a mock rendered in the project's own design system; a diagram" "$brief" \
       "$id: visual-evidence contract lost the ordered after-artifact preference"
     assert_grep "that is evidence the change is under-specified" "$brief" \
       "$id: visual-evidence contract lost the under-specified consequence"
     assert_grep "It is not an exemption." "$brief" \
       "$id: visual-evidence contract offered a cost-based exemption"
-    assert_grep "One tight screenshot per claim, placed beside the claim it evidences" "$brief" \
+    assert_grep "One tight capture per claim, placed beside the claim it evidences" "$brief" \
       "$id: visual-evidence contract lost per-claim colocation"
-    assert_grep "Do not dump a single full-page image at the top" "$brief" \
+    assert_grep "Do not dump a single full-page image or an entire transcript at the top" "$brief" \
       "$id: visual-evidence contract allowed a page dump at the top"
     assert_grep "Crop and annotate down to the region that changed" "$brief" \
       "$id: visual-evidence contract lost the crop-and-annotate requirement"
     assert_grep "Prose is reserved for what cannot be shown" "$brief" \
       "$id: visual-evidence contract lost the prose-is-for-the-unshowable rule"
+    # The medium follows the surface, so a CLI or file surface is capturable too.
+    assert_grep "terminal or CLI output as the real transcript of the real command" "$brief" \
+      "$id: visual-evidence contract is browser-only and unsatisfiable for a CLI surface"
+    assert_grep "a generated file or payload as its real content" "$brief" \
+      "$id: visual-evidence contract lost the generated-content medium"
+    assert_grep "Capture browser surfaces with \`chrome-devtools-axi\`." "$brief" \
+      "$id: visual-evidence contract lost the browser capture tool as a browser-scoped example"
+    # Non-PR modes need a durable home for the artifacts: the worktree is torn
+    # down, so the brief must name the data dir that outlives it.
+    assert_grep "in every non-PR mode the directory \`$home/data/$id/\` beside this brief" "$brief" \
+      "$id: visual-evidence contract left non-PR artifacts without a durable absolute location"
     assert_no_grep "EOF" "$brief" \
       "$id: visual-evidence brief leaked a heredoc EOF marker"
   done
@@ -424,6 +440,10 @@ test_visual_evidence_contract_is_opt_in_and_complete() {
   help=$("$ROOT/bin/fm-brief.sh" --help)
   assert_contains "$help" "--visual-evidence adds the visual-evidence contract" \
     "fm-brief.sh --help does not document --visual-evidence"
+  assert_contains "$help" "The medium follows the surface" \
+    "fm-brief.sh --help still documents the contract as browser-only"
+  assert_contains "$help" "data/<task-id>/ otherwise" \
+    "fm-brief.sh --help does not document where non-PR artifacts go"
   pass "fm-brief.sh: --visual-evidence emits the full contract and is absent otherwise"
 }
 

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -363,6 +363,86 @@ test_herdr_lab_omission_is_loud_for_ship_and_scout() {
   pass "fm-brief.sh: ship and scout scaffolds make omitted Herdr intent fail-visible"
 }
 
+test_visual_evidence_contract_is_opt_in_and_complete() {
+  local home id brief
+  home="$TMP_ROOT/visual-evidence-home"
+  write_registry "$home"
+
+  # The contract renders for every ship delivery mode, since a change needs the
+  # same evidence whether it lands through the pipeline, a direct PR, or locally.
+  for id_proj in "brief-visual-nm-e1:no-registry-proj" "brief-visual-dpr-e2:direct-proj" "brief-visual-lo-e3:local-proj"; do
+    id=${id_proj%%:*}
+    FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" "${id_proj##*:}" --visual-evidence >/dev/null 2>&1
+    brief="$home/data/$id/brief.md"
+    assert_present "$brief" "$id: --visual-evidence brief was not scaffolded"
+    assert_grep "# Visual evidence - show the change, do not describe it" "$brief" \
+      "$id: visual-evidence brief missing its section heading"
+    assert_grep "Before is a screenshot of the real page at the real route" "$brief" \
+      "$id: visual-evidence contract lost the real-page before requirement"
+    assert_grep "A written description of the current look is not a before." "$brief" \
+      "$id: visual-evidence contract allowed a prose before"
+    assert_grep "After is always an artifact, never prose alone" "$brief" \
+      "$id: visual-evidence contract lost the artifact-after requirement"
+    assert_grep "a screenshot of the change running in a throwaway prototype; a mock rendered in the project's own design system; a diagram" "$brief" \
+      "$id: visual-evidence contract lost the ordered after-artifact preference"
+    assert_grep "that is evidence the change is under-specified" "$brief" \
+      "$id: visual-evidence contract lost the under-specified consequence"
+    assert_grep "It is not an exemption." "$brief" \
+      "$id: visual-evidence contract offered a cost-based exemption"
+    assert_grep "One tight screenshot per claim, placed beside the claim it evidences" "$brief" \
+      "$id: visual-evidence contract lost per-claim colocation"
+    assert_grep "Do not dump a single full-page image at the top" "$brief" \
+      "$id: visual-evidence contract allowed a page dump at the top"
+    assert_grep "Crop and annotate down to the region that changed" "$brief" \
+      "$id: visual-evidence contract lost the crop-and-annotate requirement"
+    assert_grep "Prose is reserved for what cannot be shown" "$brief" \
+      "$id: visual-evidence contract lost the prose-is-for-the-unshowable rule"
+    assert_no_grep "EOF" "$brief" \
+      "$id: visual-evidence brief leaked a heredoc EOF marker"
+  done
+
+  # Absent by default: a brief for work with no user-visible surface must not
+  # carry the contract, and unlike --herdr-lab it leaves no declaration behind.
+  # This case gets its own home and an id free of the searched-for words, so the
+  # negative assertions cannot match a rendered fixture path or branch name.
+  local plain_home
+  plain_home="$TMP_ROOT/no-contract-home"
+  write_registry "$plain_home"
+  id="brief-default-ship-e4"
+  FM_HOME="$plain_home" "$ROOT/bin/fm-brief.sh" "$id" no-registry-proj >/dev/null 2>&1
+  brief="$plain_home/data/$id/brief.md"
+  assert_present "$brief" "$id: default ship brief was not scaffolded"
+  assert_no_grep "Visual evidence" "$brief" \
+    "$id: default ship brief carried the visual-evidence contract"
+  assert_no_grep "visual-evidence" "$brief" \
+    "$id: default ship brief carried a visual-evidence declaration or regeneration notice"
+  assert_no_grep "screenshot" "$brief" \
+    "$id: default ship brief bloated with screenshot instructions"
+
+  # Every scaffold still documents the flag through --help.
+  local help
+  help=$("$ROOT/bin/fm-brief.sh" --help)
+  assert_contains "$help" "--visual-evidence adds the visual-evidence contract" \
+    "fm-brief.sh --help does not document --visual-evidence"
+  pass "fm-brief.sh: --visual-evidence emits the full contract and is absent otherwise"
+}
+
+test_visual_evidence_is_ship_only() {
+  local home status
+  home="$TMP_ROOT/visual-evidence-misuse-home"
+  mkdir -p "$home/data"
+
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" visual-scout someproj --scout --visual-evidence >/dev/null 2>&1; status=$?
+  expect_code 1 "$status" "--visual-evidence on a scout brief must fail"
+  assert_absent "$home/data/visual-scout/brief.md" "rejected scout --visual-evidence still wrote a brief"
+
+  FM_HOME="$home" FM_SECONDMATE_CHARTER=ops \
+    "$ROOT/bin/fm-brief.sh" visual-mate --secondmate --no-projects --visual-evidence >/dev/null 2>&1; status=$?
+  expect_code 1 "$status" "--visual-evidence on a secondmate charter must fail"
+  assert_absent "$home/data/visual-mate/brief.md" "rejected secondmate --visual-evidence still wrote a brief"
+  pass "fm-brief.sh: --visual-evidence is ship-only and rejects misuse without writing a brief"
+}
+
 test_secondmate_no_projects_charter() {
   local home brief status
   home="$TMP_ROOT/no-projects-home"
@@ -643,6 +723,8 @@ test_herdr_lab_contract_is_explicit_and_complete
 test_herdr_lab_contract_quotes_foreign_firstmate_path
 test_herdr_lab_omission_is_loud_for_ship_and_scout
 test_herdr_lab_contract_applies_to_scouts_but_not_secondmates
+test_visual_evidence_contract_is_opt_in_and_complete
+test_visual_evidence_is_ship_only
 test_secondmate_no_projects_charter
 test_secondmate_marked_request_reporting_contract
 test_secondmate_directory_paths_are_absolute_and_output_is_stable

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -438,6 +438,14 @@ test_visual_evidence_contract_is_opt_in_and_complete() {
       "$id: visual-evidence contract lost per-claim colocation of the artifact paths"
     assert_grep "never as a block at the bottom" "$brief" \
       "$id: visual-evidence contract allowed an artifact block at the bottom"
+    # Who authors the pull request body, and when the links go in, for a mode
+    # whose pipeline opens the pull request on the worker's behalf.
+    assert_grep "When the pull request is opened for you, add those links to its body with \`gh-axi\` as soon as it exists" "$brief" \
+      "$id: visual-evidence contract gave no owner or timing for a pull request body opened for the worker"
+    assert_grep "when you open it yourself, write them into the body you author; when there is no pull request, name this directory in the hand-back you return" "$brief" \
+      "$id: visual-evidence contract left the self-opened and no-pull-request cases unstated"
+    assert_grep "Adding those links is not a code edit and not a findings fix, so it is not the hand-editing that an active validation run forbids." "$brief" \
+      "$id: visual-evidence contract reads as licence to hand-edit during an active validation run"
     assert_grep "Write each claim so the prose carries it on its own" "$brief" \
       "$id: visual-evidence contract left the prose unreadable to anyone who cannot open the files"
     assert_grep "That is not prose standing in for an after; the artifact stays mandatory." "$brief" \
@@ -496,6 +504,8 @@ test_visual_evidence_contract_is_opt_in_and_complete() {
     "$id: default ship brief lost ship rule 2"
   assert_no_grep "The single exception is this task's own" "$brief" \
     "$id: default ship brief carried the rule 2 carve-out without the flag"
+  assert_no_grep "add those links to its body" "$brief" \
+    "$id: default ship brief carried the visual-evidence pull-request-body clause"
 
   # Every scaffold still documents the flag through --help.
   local help
@@ -510,6 +520,8 @@ test_visual_evidence_contract_is_opt_in_and_complete() {
     "fm-brief.sh --help does not document where the artifacts are delivered"
   assert_contains "$help" "single exception to" \
     "fm-brief.sh --help does not document the rule 2 carve-out the flag adds"
+  assert_contains "$help" "pull request body as soon as it exists, whoever opened it" \
+    "fm-brief.sh --help does not document when the per-claim links reach the pull request body"
   assert_not_contains "$help" "-evidence ref" \
     "fm-brief.sh --help still documents the withdrawn evidence ref"
   pass "fm-brief.sh: --visual-evidence emits the full contract and is absent otherwise"

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -424,51 +424,51 @@ test_visual_evidence_contract_is_opt_in_and_complete() {
       "$id: visual-evidence contract lost the self-ignoring scratch directory mechanism"
     assert_grep "never commit it to your \`fm/$id\` branch" "$brief" \
       "$id: visual-evidence contract let a scratch prototype land on the code branch"
-    assert_grep "append \`blocked: {why}\` and stop; that is an escalation, not a licence to write outside it" "$brief" \
-      "$id: visual-evidence contract turned an impossible capture into licence to write outside the worktree"
+    assert_grep "append \`blocked: {why}\` and stop; that is an escalation, not a licence to write anywhere else" "$brief" \
+      "$id: visual-evidence contract turned an impossible capture into licence to write anywhere else"
     assert_no_grep "Those artifacts and the status file are the only things you write outside the worktree." "$brief" \
-      "$id: visual-evidence contract still carves an exception out of ship rule 2"
-    # Captures are delivered on a sibling orphan evidence ref, never on the code
-    # branch and never in a gist, and the ref is deleted when the work lands.
-    assert_grep "sibling orphan ref, \`fm/$id-evidence\`" "$brief" \
-      "$id: visual-evidence contract lost the sibling orphan evidence ref"
-    assert_grep "never in a gist, because a secret gist is unlisted rather than access-controlled" "$brief" \
-      "$id: visual-evidence contract lost the gist prohibition and its reason"
-    assert_grep "git switch --orphan fm/$id-evidence" "$brief" \
-      "$id: visual-evidence contract lost the orphan-ref mechanics"
-    assert_grep "one capture per claim with \`before\` or \`after\` in each filename, a \`README.md\` indexing them, and any script you wrote to produce them committed alongside" "$brief" \
-      "$id: visual-evidence contract lost the flat evidence-ref layout convention"
-    assert_grep "Commit with a message prefixed \`evidence:\`" "$brief" \
-      "$id: visual-evidence contract lost the evidence: commit prefix"
-    assert_grep "must be deleted once the" "$brief" \
-      "$id: visual-evidence contract left the evidence ref behind as a stale branch"
+      "$id: visual-evidence contract still carves an unnamed exception out of ship rule 2"
+    # The artifacts presented go to this task's own record directory, which
+    # outlives the worktree, and nowhere else.
+    assert_grep "Copy every artifact you present out of \`.fm-scratch/\` into this task's own evidence directory" "$brief" \
+      "$id: visual-evidence contract lost the record-directory delivery destination"
+    assert_grep "run \`mkdir -p '$home/data/$id/evidence'\` and copy them there" "$brief" \
+      "$id: visual-evidence contract did not name the task's own absolute evidence directory"
+    assert_grep "Link each artifact by its path beside the claim it evidences" "$brief" \
+      "$id: visual-evidence contract lost per-claim colocation of the artifact paths"
+    assert_grep "never as a block at the bottom" "$brief" \
+      "$id: visual-evidence contract allowed an artifact block at the bottom"
+    assert_grep "Write each claim so the prose carries it on its own" "$brief" \
+      "$id: visual-evidence contract left the prose unreadable to anyone who cannot open the files"
+    assert_grep "That is not prose standing in for an after; the artifact stays mandatory." "$brief" \
+      "$id: visual-evidence contract let self-carrying prose weaken the artifact requirement"
+    assert_grep "a reviewer who is not on this machine cannot open these files" "$brief" \
+      "$id: visual-evidence contract papered over the accepted limitation of a local artifact home"
+    assert_grep "not to a gist and not to any other host" "$brief" \
+      "$id: visual-evidence contract lost the no-other-host prohibition"
+    assert_grep "a secret gist is unlisted rather than access-controlled" "$brief" \
+      "$id: visual-evidence contract lost the reason a gist is not an artifact home"
+    # The withdrawn evidence-ref mechanism must not come back in any form.
+    assert_no_grep "fm/$id-evidence" "$brief" \
+      "$id: visual-evidence contract still carries the withdrawn sibling evidence ref"
+    assert_no_grep "git switch --orphan" "$brief" \
+      "$id: visual-evidence contract still carries the withdrawn orphan-ref mechanics"
+    assert_no_grep "evidence:" "$brief" \
+      "$id: visual-evidence contract still carries the withdrawn evidence commit prefix"
+    assert_no_grep "must be deleted" "$brief" \
+      "$id: visual-evidence contract still carries the withdrawn ref-deletion requirement"
+    # Rule 2 keeps its absolute opening and gains exactly one named exception.
+    assert_grep "2. Stay inside this worktree; modify nothing outside it." "$brief" \
+      "$id: visual-evidence brief weakened the opening of ship rule 2"
+    assert_grep "The single exception is this task's own visual-evidence directory \`'$home/data/$id/evidence'\`" "$brief" \
+      "$id: ship rule 2 did not name the one authorized write outside the worktree"
+    assert_grep "the same class of write, to the same home, as the status file you append to in rule 4" "$brief" \
+      "$id: ship rule 2 carve-out lost the status-file precedent that bounds it"
+    assert_grep "It authorizes nothing else - not another task's record directory, not that home's shared files, not any other path." "$brief" \
+      "$id: ship rule 2 carve-out did not bound its own scope"
     assert_no_grep "EOF" "$brief" \
       "$id: visual-evidence brief leaked a heredoc EOF marker"
   done
-
-  # Delivery of the captures follows the project's delivery mode: the PR modes
-  # push the evidence ref and link it from the PR body, while local-only is
-  # defined by not pushing, so its evidence ref stays local.
-  for id in brief-visual-nm-e1 brief-visual-dpr-e2; do
-    brief="$home/data/$id/brief.md"
-    assert_grep "Push \`fm/$id-evidence\` to the same remote your code branch goes to" "$brief" \
-      "$id: visual-evidence contract did not push the evidence ref to the code branch's remote"
-    assert_grep "it is the only other ref you push, a sibling of your own branch and never the default branch" "$brief" \
-      "$id: visual-evidence contract left the evidence push at odds with the never-push-the-default-branch rule"
-    assert_grep "Reference each capture in the pull request body by its URL on that ref" "$brief" \
-      "$id: visual-evidence contract did not land the captures in the pull request body"
-    assert_grep "add those links to its body with \`gh-axi\` as soon as it exists" "$brief" \
-      "$id: visual-evidence contract gave no timing for a pull request opened by the pipeline"
-  done
-
-  id="brief-visual-lo-e3"
-  brief="$home/data/$id/brief.md"
-  assert_grep "This project ships local-only, so \`fm/$id-evidence\` stays local: never push it" "$brief" \
-    "$id: local-only visual-evidence contract did not keep the evidence ref local"
-  assert_grep "name the ref and the capture filenames in your \`ready in branch\` hand-back" "$brief" \
-    "$id: local-only visual-evidence contract did not point the hand-back at the evidence ref"
-  assert_no_grep "Push \`fm/$id-evidence\`" "$brief" \
-    "$id: local-only visual-evidence contract told the worker to push"
 
   # Absent by default: a brief for work with no user-visible surface must not
   # carry the contract, and unlike --herdr-lab it leaves no declaration behind.
@@ -489,8 +489,13 @@ test_visual_evidence_contract_is_opt_in_and_complete() {
     "$id: default ship brief bloated with screenshot instructions"
   assert_no_grep ".fm-scratch" "$brief" \
     "$id: default ship brief carried the visual-evidence scratch convention"
-  assert_no_grep "-evidence" "$brief" \
+  assert_no_grep "evidence" "$brief" \
     "$id: default ship brief carried the visual-evidence delivery convention"
+  # Rule 2 is byte-identical to the unflagged shape: the carve-out is opt-in too.
+  assert_grep "2. Stay inside this worktree; modify nothing outside it." "$brief" \
+    "$id: default ship brief lost ship rule 2"
+  assert_no_grep "The single exception is this task's own" "$brief" \
+    "$id: default ship brief carried the rule 2 carve-out without the flag"
 
   # Every scaffold still documents the flag through --help.
   local help
@@ -501,10 +506,12 @@ test_visual_evidence_contract_is_opt_in_and_complete() {
     "fm-brief.sh --help still documents the contract as browser-only"
   assert_contains "$help" "self-ignoring .fm-scratch/ and are never committed to the code branch" \
     "fm-brief.sh --help does not document where the artifacts are produced"
-  assert_contains "$help" "sibling orphan ref fm/<task-id>-evidence" \
-    "fm-brief.sh --help does not document where the captures are delivered"
-  assert_contains "$help" "deleted once the work lands because that ref never merges" \
-    "fm-brief.sh --help does not document the evidence-ref deletion requirement"
+  assert_contains "$help" "data/<task-id>/evidence/" \
+    "fm-brief.sh --help does not document where the artifacts are delivered"
+  assert_contains "$help" "single exception to" \
+    "fm-brief.sh --help does not document the rule 2 carve-out the flag adds"
+  assert_not_contains "$help" "-evidence ref" \
+    "fm-brief.sh --help still documents the withdrawn evidence ref"
   pass "fm-brief.sh: --visual-evidence emits the full contract and is absent otherwise"
 }
 

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -367,7 +367,6 @@ test_visual_evidence_contract_is_opt_in_and_complete() {
   local home id brief
   home="$TMP_ROOT/visual-evidence-home"
   write_registry "$home"
-  home=$(cd "$home" && pwd -P)
 
   # The contract renders for every ship delivery mode, since a change needs the
   # same evidence whether it lands through the pipeline, a direct PR, or locally.
@@ -409,13 +408,67 @@ test_visual_evidence_contract_is_opt_in_and_complete() {
       "$id: visual-evidence contract lost the generated-content medium"
     assert_grep "Capture browser surfaces with \`chrome-devtools-axi\`." "$brief" \
       "$id: visual-evidence contract lost the browser capture tool as a browser-scoped example"
-    # Non-PR modes need a durable home for the artifacts: the worktree is torn
-    # down, so the brief must name the data dir that outlives it.
-    assert_grep "in every non-PR mode the directory \`$home/data/$id/\` beside this brief" "$brief" \
-      "$id: visual-evidence contract left non-PR artifacts without a durable absolute location"
+    # The after carve-out is narrow and conditional: a still that cannot hold the
+    # change is not a licence to fall back to prose.
+    assert_grep "The single carve-out is a change no still capture can hold, meaning motion, timing, or a measurement" "$brief" \
+      "$id: visual-evidence contract lost the narrow motion/timing/measurement carve-out"
+    assert_grep "Name the form you used and why a still could not carry the claim." "$brief" \
+      "$id: visual-evidence carve-out did not require naming the artifact form and its justification"
+    assert_grep "\"I could not show it\" with nothing attached is not a carve-out; it is a missing after." "$brief" \
+      "$id: visual-evidence carve-out allowed an unattached claim to pass as an after"
+    # Rule 2 stands: prototypes and captures are built inside the worktree in one
+    # conventional self-ignoring scratch dir, never committed to the code branch.
+    assert_grep "Build every prototype and capture inside this worktree, under \`.fm-scratch/\`" "$brief" \
+      "$id: visual-evidence contract did not confine artifact production to the worktree"
+    assert_grep "write a single \`*\` line into \`.fm-scratch/.gitignore\`" "$brief" \
+      "$id: visual-evidence contract lost the self-ignoring scratch directory mechanism"
+    assert_grep "never commit it to your \`fm/$id\` branch" "$brief" \
+      "$id: visual-evidence contract let a scratch prototype land on the code branch"
+    assert_grep "append \`blocked: {why}\` and stop; that is an escalation, not a licence to write outside it" "$brief" \
+      "$id: visual-evidence contract turned an impossible capture into licence to write outside the worktree"
+    assert_no_grep "Those artifacts and the status file are the only things you write outside the worktree." "$brief" \
+      "$id: visual-evidence contract still carves an exception out of ship rule 2"
+    # Captures are delivered on a sibling orphan evidence ref, never on the code
+    # branch and never in a gist, and the ref is deleted when the work lands.
+    assert_grep "sibling orphan ref, \`fm/$id-evidence\`" "$brief" \
+      "$id: visual-evidence contract lost the sibling orphan evidence ref"
+    assert_grep "never in a gist, because a secret gist is unlisted rather than access-controlled" "$brief" \
+      "$id: visual-evidence contract lost the gist prohibition and its reason"
+    assert_grep "git switch --orphan fm/$id-evidence" "$brief" \
+      "$id: visual-evidence contract lost the orphan-ref mechanics"
+    assert_grep "one capture per claim with \`before\` or \`after\` in each filename, a \`README.md\` indexing them, and any script you wrote to produce them committed alongside" "$brief" \
+      "$id: visual-evidence contract lost the flat evidence-ref layout convention"
+    assert_grep "Commit with a message prefixed \`evidence:\`" "$brief" \
+      "$id: visual-evidence contract lost the evidence: commit prefix"
+    assert_grep "must be deleted once the" "$brief" \
+      "$id: visual-evidence contract left the evidence ref behind as a stale branch"
     assert_no_grep "EOF" "$brief" \
       "$id: visual-evidence brief leaked a heredoc EOF marker"
   done
+
+  # Delivery of the captures follows the project's delivery mode: the PR modes
+  # push the evidence ref and link it from the PR body, while local-only is
+  # defined by not pushing, so its evidence ref stays local.
+  for id in brief-visual-nm-e1 brief-visual-dpr-e2; do
+    brief="$home/data/$id/brief.md"
+    assert_grep "Push \`fm/$id-evidence\` to the same remote your code branch goes to" "$brief" \
+      "$id: visual-evidence contract did not push the evidence ref to the code branch's remote"
+    assert_grep "it is the only other ref you push, a sibling of your own branch and never the default branch" "$brief" \
+      "$id: visual-evidence contract left the evidence push at odds with the never-push-the-default-branch rule"
+    assert_grep "Reference each capture in the pull request body by its URL on that ref" "$brief" \
+      "$id: visual-evidence contract did not land the captures in the pull request body"
+    assert_grep "add those links to its body with \`gh-axi\` as soon as it exists" "$brief" \
+      "$id: visual-evidence contract gave no timing for a pull request opened by the pipeline"
+  done
+
+  id="brief-visual-lo-e3"
+  brief="$home/data/$id/brief.md"
+  assert_grep "This project ships local-only, so \`fm/$id-evidence\` stays local: never push it" "$brief" \
+    "$id: local-only visual-evidence contract did not keep the evidence ref local"
+  assert_grep "name the ref and the capture filenames in your \`ready in branch\` hand-back" "$brief" \
+    "$id: local-only visual-evidence contract did not point the hand-back at the evidence ref"
+  assert_no_grep "Push \`fm/$id-evidence\`" "$brief" \
+    "$id: local-only visual-evidence contract told the worker to push"
 
   # Absent by default: a brief for work with no user-visible surface must not
   # carry the contract, and unlike --herdr-lab it leaves no declaration behind.
@@ -434,6 +487,10 @@ test_visual_evidence_contract_is_opt_in_and_complete() {
     "$id: default ship brief carried a visual-evidence declaration or regeneration notice"
   assert_no_grep "screenshot" "$brief" \
     "$id: default ship brief bloated with screenshot instructions"
+  assert_no_grep ".fm-scratch" "$brief" \
+    "$id: default ship brief carried the visual-evidence scratch convention"
+  assert_no_grep "-evidence" "$brief" \
+    "$id: default ship brief carried the visual-evidence delivery convention"
 
   # Every scaffold still documents the flag through --help.
   local help
@@ -442,8 +499,12 @@ test_visual_evidence_contract_is_opt_in_and_complete() {
     "fm-brief.sh --help does not document --visual-evidence"
   assert_contains "$help" "The medium follows the surface" \
     "fm-brief.sh --help still documents the contract as browser-only"
-  assert_contains "$help" "data/<task-id>/ otherwise" \
-    "fm-brief.sh --help does not document where non-PR artifacts go"
+  assert_contains "$help" "self-ignoring .fm-scratch/ and are never committed to the code branch" \
+    "fm-brief.sh --help does not document where the artifacts are produced"
+  assert_contains "$help" "sibling orphan ref fm/<task-id>-evidence" \
+    "fm-brief.sh --help does not document where the captures are delivered"
+  assert_contains "$help" "deleted once the work lands because that ref never merges" \
+    "fm-brief.sh --help does not document the evidence-ref deletion requirement"
   pass "fm-brief.sh: --visual-evidence emits the full contract and is absent otherwise"
 }
 


### PR DESCRIPTION
## Intent

Make firstmate's brief scaffold (bin/fm-brief.sh) generate a visual-evidence contract for frontend ship tasks.

WHY: Firstmate briefs currently say nothing about how a change should be *shown*. Observed repeatedly: workers describe a UI change in prose, screenshot the 'before' only when pushed, dump one full-page image at the top instead of evidence beside each claim, and never produce an 'after' artifact at all. Every review then costs a round of the captain asking for what should have arrived the first time. Root cause: prototyping costs budget at the moment of choosing and only repays a round later, so no worker spends it unprompted. The brief has to require it.

THE CONTRACT THE GENERATED BRIEF MUST REQUIRE (five points, specified by the requester):
1. Before is a screenshot of the real page at the real route - never a description of the current look.
2. After is always an artifact. In order of preference: a screenshot of the change running in a throwaway prototype; a rendered mock in the project's own design system; a diagram. Prose alone is not an acceptable 'after'. If prototyping the after looks too expensive, that is evidence the change is under-specified - not an exemption.
3. One tight screenshot per claim, placed beside the claim it evidences - not a page dump at the top that the reader must map back onto the text.
4. Crop and annotate to the region that changed. A full-page image proving a button moved makes the reviewer do the diffing.
5. Prose is reserved for what cannot be shown - rationale, trade-offs, open questions.

ACCEPTANCE CRITERIA: fm-brief.sh emits this section for frontend ship tasks and does not bloat briefs where it is irrelevant. How 'frontend' is determined was explicitly left to the implementer's design, with an explicit flag called acceptable and probably better than inference, since the scaffold cannot see the task text. The generated wording must be self-contained so a worker reading only the brief knows what to produce. Colocated tests must cover that the section appears when requested and is absent otherwise. --help and any doc that already owns the scaffold's contract must be updated, and NO new doc may be added.

DECISIONS MADE WHILE IMPLEMENTING (deliberate, not accidents):
- Chose an explicit opt-in --visual-evidence flag over inference, as the requester suggested: {TASK} is filled in after scaffolding, so the scaffold cannot see whether the work is visual.
- Ship-only. --scout and --secondmate are rejected with an error and no file written. Rationale: the contract is about how a delivered change is shown for review, and a scout already owes evidence through its report.
- Deliberately asymmetric with --herdr-lab: omitting --visual-evidence emits NOTHING - no 'NOT ENABLED' declaration - because a missing visual contract costs a review round, not safety, and the acceptance criteria forbid bloating briefs where it is irrelevant. This asymmetry is intentional and should not be 'fixed' into a declaration.
- Verified and preserved byte-identical output for briefs scaffolded without the flag (ship, scout, and secondmate), by giving the section variable its own leading newline and keeping the trailing one.
- Built the section with 'IFS= read -r -d ... <<EOF' rather than a heredoc wrapped in a command substitution, matching the existing Bash 3.2 parse-safety contract that tests/fm-brief.test.sh guards structurally.
- Docs updated where existing owners already live: the script header (which IS --help output), a one-line dispatch trigger in AGENTS.md section 11 next to the --herdr-lab trigger (without it nothing would ever pass the new flag - trigger hygiene per the firstmate-coding-guidelines skill), and the one-line fm-brief.sh row in docs/scripts.md. No new doc, per the acceptance criteria.

ONE OPEN DESIGN QUESTION, RAISED BY THE REQUESTER: these five points are one captain's standard, and upstream may reasonably want the contract configurable rather than hardcoded for every firstmate user. The instruction was to implement the five points as the generated default, and to raise configurability as an ask-user finding ONLY if it turns out to be load-bearing for the change to be acceptable upstream - explicitly NOT to expand scope into a configuration system on the implementer's own initiative. Judgment applied: configurability is not load-bearing, because every other generated section (Herdr contract, project-memory bar, status protocol, delivery-mode definitions of done) is a hardcoded opinionated contract, the only customization precedent in this scaffold is the pause verb, and the flag itself is already the opt-in. So no configuration system was built. That was a deliberate scope decision, not an oversight.

CONSTRAINTS: Nothing from any private project may appear in this work - no product names, routes, schemas, business detail, or examples drawn from the captain's repos, in code, tests, comments, commit messages, or docs. Generic examples only, because this lands in a public upstream repository. Branches push to the configured fork and the PR opens against upstream; do not push to origin directly. This repo's own style rules apply: one sentence per line in tracked Markdown, plain dash instead of em dash, no agent name as commit co-author, shellcheck-clean bin scripts via bin/fm-lint.sh, and tests colocated in tests/ extending the existing runner rather than a new one.

## What Changed

- `bin/fm-brief.sh` gains a `--visual-evidence` flag that appends a "Visual evidence" section to ship briefs: a before that is a capture of the real surface (with an explicit carve-out when the surface does not exist yet), an after that is always an artifact in preference order (throwaway-prototype capture, design-system mock, diagram), one tight capture per claim placed beside that claim, cropping and annotation to the changed region, and prose reserved for rationale, trade-offs, and open questions. The medium follows the surface, so a browser view, a CLI transcript, and generated file content are all covered. The flag is ship-only - `--scout` and `--secondmate` exit 1 with no file written - and omitting it emits nothing, keeping unflagged ship, scout, and secondmate briefs byte-identical.
- The generated contract routes prototypes and captures through a self-ignoring `.fm-scratch/` inside the task worktree (never committed to the code branch) and copies presented artifacts to the task's own `data/<task-id>/evidence/`, which the flag also renders into the brief's rule 2 as the single stay-inside-the-worktree exception, in the same class as the status-file append. Artifact links are required beside each claim in the PR body as soon as it exists or in the hand-back when no PR is opened, with prose that carries the claim on its own.
- Docs updated in their existing owners with no new file: the script header (which is `--help`), an AGENTS.md section 11 dispatch trigger beside the `--herdr-lab` trigger plus a home-layout entry for `<id>/evidence/`, and the one-line `fm-brief.sh` row in `docs/scripts.md`. `tests/fm-brief.test.sh` adds colocated cases covering that the section renders in full when requested, is absent otherwise, and that the flag is rejected for scout and secondmate briefs.

## Risk Assessment

✅ Low: Round 5 adds two sentences to the opt-in section plus one documentation-inventory line, both previously identified fixes; byte-identity for all seven unflagged variants still holds including Rule 2, every positive and negative assertion matches real generated output, and no acceptance criterion is left unmet.

## Testing

Exercised the change as an end user of the scaffold: ran the full colocated tests/fm-brief.test.sh (19 cases, all pass, including the two new visual-evidence cases), then generated real briefs with and without --visual-evidence and rendered them side by side as screenshots showing the five-point contract present in the flagged brief and completely absent - with no "NOT ENABLED" declaration - in the unflagged one. Verified the deliberate no-bloat guarantee by regenerating six unflagged scaffolds (ship across all three delivery modes, scout, secondmate, --herdr-lab) from both the base and target commits into an identical home path and confirming byte-for-byte identical output; verified the ship-only guard rejects --scout and --secondmate with exit 1 and no file written; verified macOS stock Bash 3.2 both parses the script and produces a brief identical to the Bash 5 output with no leaked heredoc marker; verified --help and the doc-inventory test after the AGENTS.md and docs/scripts.md edits, and that no new file was added. A mutation check against the pre-change script confirmed both new tests actually fail without the feature. Everything passed and no issues surfaced; transient temp homes were removed and the worktree is clean.

- Evidence: Rendered generated briefs, side by side: without the flag (left) vs --visual-evidence (right) (local file: <code>/var/folders/40/vfb2wp5n78d1nbkbdk7sv6f40000gn/T/no-mistakes-evidence/01KZ0S73WYZREZE8F9ZB0SH1C9/brief-flag-vs-no-flag.png</code>)
- Evidence: Cropped: the visual-evidence section the flag adds to the generated brief (local file: <code>/var/folders/40/vfb2wp5n78d1nbkbdk7sv6f40000gn/T/no-mistakes-evidence/01KZ0S73WYZREZE8F9ZB0SH1C9/visual-evidence-section-crop.png</code>)
<details>
<summary>Evidence: Generated ship brief with --visual-evidence (raw markdown a crewmate reads)</summary>

```text
You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.

# Task
{TASK}

# Herdr lifecycle declaration - NOT ENABLED
**HARD SAFETY GATE:** this scaffold cannot inspect the task text that replaces `{TASK}` later.
If the task will start, stop, delete, restart, profile, or otherwise drive Herdr lifecycle behavior, stop and regenerate the brief with `--herdr-lab` before dispatch.
Do not add Herdr lifecycle commands to this unguarded brief by hand.

# Setup
You are in a disposable git worktree of example-web-app, at a detached HEAD on a clean default branch.

**Verify isolation before anything else.** Run `pwd -P` and `git rev-parse --show-toplevel`; both must resolve to the disposable task worktree you were launched in, such as a treehouse pool path or an Orca-managed worktree, not the primary checkout firstmate operates from.
The path check is authoritative: `git rev-parse --git-dir` and `git rev-parse --git-common-dir` can help inspect the repo, but they do not prove you are outside the primary checkout.
If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not branch or commit here - append `blocked: launched in primary checkout, not an isolated worktree` to the status file and stop.

1. First action: create your branch: `git checkout -b fm/redesign-settings-page`

# Rules
1. Never push to the default branch (push only your `fm/redesign-settings-page` branch). Never merge a PR.
2. Stay inside this worktree; modify nothing outside it.
   The single exception is this task's own visual-evidence directory `'/tmp/firstmate-demo-home/data/redesign-settings-page/evidence'` in the firstmate home, described under Visual evidence below.
   That is the same class of write, to the same home, as the status file you append to in rule 4: every brief already writes that one file outside its worktree.
   It authorizes nothing else - not another task's record directory, not that home's shared files, not any other path.
3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
4. Report status by appending one line:
   `echo "{state}: {one short line}" >> '/tmp/firstmate-demo-home/state/redesign-settings-page.status'`
   States: working, needs-decision, blocked, paused, done, failed.
   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
   would act on (setup done, bug reproduced, fix implemented, validation passed) and the
   needs-decision/blocked/paused/done/failed states. No step-by-step FYI progress lines;
   firstmate reads your pane for that.
   A mid-task `working:` line (including setup complete) is nonterminal: do not end the
   turn after it; continue the same stage until a defined `done:` gate under Definition of done.
   Use `paused: {why}` - distinct from `blocked:` - ONLY when you are deliberately idling on a
   known external wait you expect to clear on its own (an upstream release, a rate-limit reset,
   a scheduled window): firstmate then leaves your idle pane alone and rechecks it on a long
   cadence instead of treating it as a possible wedge. Use `blocked:` when you are stuck and need help.
5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
6. If a decision belongs above the implementation worker (product choices, destructive actions, ask-user findings),
   append `needs-decision: {summary of options}` and stop. Firstmate will apply the configured authority and reply with the decision.
   When firstmate replies or a blocker clears and you resume, append `resolved: {how it was decided or unblocked}` (add the same `[key=<slug>]` if you opened it with one) so the decision or blocker is durably closed and does not keep resurfacing.
7. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving
   every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
   daemon error, append `blocked: {the daemon error}` and stop; only firstmate manages the daemon.

# Visual evidence - show the change, do not describe it
This task changes a user-visible surface, so every claim about how it looks must arrive as a capture of the real thing, not as prose.
The medium follows the surface: a browser view is captured as a screenshot of the real page at the real route, terminal or CLI output as the real transcript of the real command, a generated file or payload as its real content.

1. **Before is a capture of the real surface as it stands today.** Run the project, reach the affected surface, and capture it: the real page at the real route, the real command with its real output, the real generated content. A written description of the current look is never a before. The one exception is a surface that does not exist yet - say so in a line and go straight to the after.
2. **After is always an artifact, never prose alone.** In order of preference: a capture of the change running in a throwaway prototype; a mock rendered in the project's own design system; a diagram. If prototyping the after looks too expensive, that is evidence the change is under-specified - settle what it should be first. It is not an exemption.
   The single carve-out is a change no still capture can hold, meaning motion, timing, or a measurement, and then a recording or the measured result is the artifact. Name the form you used and why a still could not carry the claim. "I could not show it" with nothing attached is not a carve-out; it is a missing after.
3. **One tight capture per claim, placed beside the claim it evidences.** Do not dump a single full-page image or an entire transcript at the top and leave the reader to map it back onto the text.
4. **Crop and annotate down to the region that changed.** A full-page image offered as proof that one element moved, or a whole log offered as proof of one changed line, makes the reviewer do the diffing.
5. **Prose is reserved for what cannot be shown** - rationale, trade-offs, and open questions.

## Producing the artifacts
Build every prototype and capture inside this worktree, under `.fm-scratch/`: create the directory and write a single `*` line into `.fm-scratch/.gitignore`, which hides the whole directory from git without touching the project's own ignore file.
A prototype is scratch: never commit it to your `fm/redesign-settings-page` branch, and expect it to die with this worktree.
Capture browser surfaces with `chrome-devtools-axi`.
If you conclude an artifact cannot be produced without writing outside this worktree and its evidence directory, append `blocked: {why}` and stop; that is an escalation, not a licence to write anywhere else.

## Delivering the artifacts
Copy every artifact you present out of `.fm-scratch/` into this task's own evidence directory, which outlives this worktree: run `mkdir -p '/tmp/firstmate-demo-home/data/redesign-settings-page/evidence'` and copy them there, keeping the layout flat with one file per claim.
Link each artifact by its path beside the claim it evidences - in the pull request body when this project opens one, in the summary you hand back when it does not - never as a block at the bottom.
When the pull request is opened for you, add those links to its body with `gh-axi` as soon as it exists; when you open it yourself, write them into the body you author; when there is no pull request, name this directory in the hand-back you return.
Adding those links is not a code edit and not a findings fix, so it is not the hand-editing that an active validation run forbids.
Write each claim so the prose carries it on its own: a path is opaque to a reader who cannot open the file, so the sentence states what changed and the artifact confirms it. That is not prose standing in for an after; the artifact stays mandatory.
Accept the one limitation rather than working around it: a reviewer who is not on this machine cannot open these files, so for work whose pull request goes to a public upstream the artifacts are the captain's verification rather than the upstream reviewer's, and the self-carrying prose above is what keeps that pull request readable for both.
That is also why the artifacts go nowhere else, not to a gist and not to any other host: a secret gist is unlisted rather than access-controlled, so anyone holding the link could read captures of a private product.

# Project memory
If `AGENTS.md` or `CLAUDE.md` already exists, or if this task produced durable project-intrinsic knowledge, run `/Users/axvon/.no-mistakes/worktrees/74bf7f97ec45/01KZ0S73WYZREZE8F9ZB0SH1C9/bin/fm-ensure-agents-md.sh .` in the worktree.
Record only project knowledge useful to almost every future session.
For anything the codebase already shows, prefer a pointer to the authoritative file, command, or doc over copying the detail.
If you touch a project `AGENTS.md` that lacks `## Maintaining this file`, add that short self-governance section from `/Users/axvon/.no-mistakes/worktrees/74bf7f97ec45/01KZ0S73WYZREZE8F9ZB0SH1C9/bin/fm-ensure-agents-md.sh` in the same pass.
Keep it proportionate: skip `AGENTS.md` edits for trivial tasks that produced no durable project knowledge.

# Definition of done
This project ships **direct-PR**: you raise the PR yourself, without the no-mistakes pipeline.
The task is complete only when committed on your branch.
When it is implemented and committed, push your branch and open a PR with `gh-axi`, then append `done: PR {url}` to the status file and stop.
Do NOT run /no-mistakes. The configured merge authority decides whether to merge the PR; firstmate relays the outcome.
```
</details>
<details>
<summary>Evidence: Generated ship brief without the flag (no section, no declaration)</summary>

```text
You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.

# Task
{TASK}

# Herdr lifecycle declaration - NOT ENABLED
**HARD SAFETY GATE:** this scaffold cannot inspect the task text that replaces `{TASK}` later.
If the task will start, stop, delete, restart, profile, or otherwise drive Herdr lifecycle behavior, stop and regenerate the brief with `--herdr-lab` before dispatch.
Do not add Herdr lifecycle commands to this unguarded brief by hand.

# Setup
You are in a disposable git worktree of example-web-app, at a detached HEAD on a clean default branch.

**Verify isolation before anything else.** Run `pwd -P` and `git rev-parse --show-toplevel`; both must resolve to the disposable task worktree you were launched in, such as a treehouse pool path or an Orca-managed worktree, not the primary checkout firstmate operates from.
The path check is authoritative: `git rev-parse --git-dir` and `git rev-parse --git-common-dir` can help inspect the repo, but they do not prove you are outside the primary checkout.
If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not branch or commit here - append `blocked: launched in primary checkout, not an isolated worktree` to the status file and stop.

1. First action: create your branch: `git checkout -b fm/tune-retry-backoff`

# Rules
1. Never push to the default branch (push only your `fm/tune-retry-backoff` branch). Never merge a PR.
2. Stay inside this worktree; modify nothing outside it.
3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
4. Report status by appending one line:
   `echo "{state}: {one short line}" >> '/tmp/firstmate-demo-home/state/tune-retry-backoff.status'`
   States: working, needs-decision, blocked, paused, done, failed.
   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
   would act on (setup done, bug reproduced, fix implemented, validation passed) and the
   needs-decision/blocked/paused/done/failed states. No step-by-step FYI progress lines;
   firstmate reads your pane for that.
   A mid-task `working:` line (including setup complete) is nonterminal: do not end the
   turn after it; continue the same stage until a defined `done:` gate under Definition of done.
   Use `paused: {why}` - distinct from `blocked:` - ONLY when you are deliberately idling on a
   known external wait you expect to clear on its own (an upstream release, a rate-limit reset,
   a scheduled window): firstmate then leaves your idle pane alone and rechecks it on a long
   cadence instead of treating it as a possible wedge. Use `blocked:` when you are stuck and need help.
5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
6. If a decision belongs above the implementation worker (product choices, destructive actions, ask-user findings),
   append `needs-decision: {summary of options}` and stop. Firstmate will apply the configured authority and reply with the decision.
   When firstmate replies or a blocker clears and you resume, append `resolved: {how it was decided or unblocked}` (add the same `[key=<slug>]` if you opened it with one) so the decision or blocker is durably closed and does not keep resurfacing.
7. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving
   every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
   daemon error, append `blocked: {the daemon error}` and stop; only firstmate manages the daemon.

# Project memory
If `AGENTS.md` or `CLAUDE.md` already exists, or if this task produced durable project-intrinsic knowledge, run `/Users/axvon/.no-mistakes/worktrees/74bf7f97ec45/01KZ0S73WYZREZE8F9ZB0SH1C9/bin/fm-ensure-agents-md.sh .` in the worktree.
Record only project knowledge useful to almost every future session.
For anything the codebase already shows, prefer a pointer to the authoritative file, command, or doc over copying the detail.
If you touch a project `AGENTS.md` that lacks `## Maintaining this file`, add that short self-governance section from `/Users/axvon/.no-mistakes/worktrees/74bf7f97ec45/01KZ0S73WYZREZE8F9ZB0SH1C9/bin/fm-ensure-agents-md.sh` in the same pass.
Keep it proportionate: skip `AGENTS.md` edits for trivial tasks that produced no durable project knowledge.

# Definition of done
This project ships **direct-PR**: you raise the PR yourself, without the no-mistakes pipeline.
The task is complete only when committed on your branch.
When it is implemented and committed, push your branch and open a PR with `gh-axi`, then append `done: PR {url}` to the status file and stop.
Do NOT run /no-mistakes. The configured merge authority decides whether to merge the PR; firstmate relays the outcome.
```
</details>
<details>
<summary>Evidence: Diff of the two generated briefs - the flag&#39;s entire footprint</summary>

```text
--- /var/folders/40/vfb2wp5n78d1nbkbdk7sv6f40000gn/T/no-mistakes-evidence/01KZ0S73WYZREZE8F9ZB0SH1C9/brief-without-flag.md	2026-08-02 12:08:15
+++ /var/folders/40/vfb2wp5n78d1nbkbdk7sv6f40000gn/T/no-mistakes-evidence/01KZ0S73WYZREZE8F9ZB0SH1C9/brief-with-visual-evidence.md	2026-08-02 12:08:15
@@ -15,14 +15,17 @@
 The path check is authoritative: `git rev-parse --git-dir` and `git rev-parse --git-common-dir` can help inspect the repo, but they do not prove you are outside the primary checkout.
 If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not branch or commit here - append `blocked: launched in primary checkout, not an isolated worktree` to the status file and stop.
 
-1. First action: create your branch: `git checkout -b fm/tune-retry-backoff`
+1. First action: create your branch: `git checkout -b fm/redesign-settings-page`
 
 # Rules
-1. Never push to the default branch (push only your `fm/tune-retry-backoff` branch). Never merge a PR.
+1. Never push to the default branch (push only your `fm/redesign-settings-page` branch). Never merge a PR.
 2. Stay inside this worktree; modify nothing outside it.
+   The single exception is this task's own visual-evidence directory `'/tmp/firstmate-demo-home/data/redesign-settings-page/evidence'` in the firstmate home, described under Visual evidence below.
+   That is the same class of write, to the same home, as the status file you append to in rule 4: every brief already writes that one file outside its worktree.
+   It authorizes nothing else - not another task's record directory, not that home's shared files, not any other path.
 3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
 4. Report status by appending one line:
-   `echo "{state}: {one short line}" >> '/tmp/firstmate-demo-home/state/tune-retry-backoff.status'`
+   `echo "{state}: {one short line}" >> '/tmp/firstmate-demo-home/state/redesign-settings-page.status'`
    States: working, needs-decision, blocked, paused, done, failed.
    Each append wakes firstmate, so report sparingly: only phase changes a supervisor
    would act on (setup done, bug reproduced, fix implemented, validation passed) and the
@@ -42,6 +45,32 @@
    every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
    daemon error, append `blocked: {the daemon error}` and stop; only firstmate manages the daemon.
 
+# Visual evidence - show the change, do not describe it
+This task changes a user-visible surface, so every claim about how it looks must arrive as a capture of the real thing, not as prose.
+The medium follows the surface: a browser view is captured as a screenshot of the real page at the real route, terminal or CLI output as the real transcript of the real command, a generated file or payload as its real content.
+
+1. **Before is a capture of the real surface as it stands today.** Run the project, reach the affected surface, and capture it: the real page at the real route, the real command with its real output, the real generated content. A written description of the current look is never a before. The one exception is a surface that does not exist yet - say so in a line and go straight to the after.
+2. **After is always an artifact, never prose alone.** In order of preference: a capture of the change running in a throwaway prototype; a mock rendered in the project's own design system; a diagram. If prototyping the after looks too expensive, that is evidence the change is under-specified - settle what it should be first. It is not an exemption.
+   The single carve-out is a change no still capture can hold, meaning motion, timing, or a measurement, and then a recording or the measured result is the artifact. Name the form you used and why a still could not carry the claim. "I could not show it" with nothing attached is not a carve-out; it is a missing after.
+3. **One tight capture per claim, placed beside the claim it evidences.** Do not dump a single full-page image or an entire transcript at the top and leave the reader to map it back onto the text.
+4. **Crop and annotate down to the region that changed.** A full-page image offered as proof that one element moved, or a whole log offered as proof of one changed line, makes the reviewer do the diffing.
+5. **Prose is reserved for what cannot be shown** - rationale, trade-offs, and open questions.
+
+## Producing the artifacts
+Build every prototype and capture inside this worktree, under `.fm-scratch/`: create the directory and write a single `*` line into `.fm-scratch/.gitignore`, which hides the whole directory from git without touching the project's own ignore file.
+A prototype is scratch: never commit it to your `fm/redesign-settings-page` branch, and expect it to die with this worktree.
+Capture browser surfaces with `chrome-devtools-axi`.
+If you conclude an artifact cannot be produced without writing outside this worktree and its evidence directory, append `blocked: {why}` and stop; that is an escalation, not a licence to write anywhere else.
+
+## Delivering the artifacts
+Copy every artifact you present out of `.fm-scratch/` into this task's own evidence directory, which outlives this worktree: run `mkdir -p '/tmp/firstmate-demo-home/data/redesign-settings-page/evidence'` and copy them there, keeping the layout flat with one file per claim.
+Link each artifact by its path beside the claim it evidences - in the pull request body when this project opens one, in the summary you hand back when it does not - never as a block at the bottom.
+When the pull request is opened for you, add those links to its body with `gh-axi` as soon as it exists; when you open it yourself, write them into the body you author; when there is no pull request, name this directory in the hand-back you return.
+Adding those links is not a code edit and not a findings fix, so it is not the hand-editing that an active validation run forbids.
+Write each claim so the prose carries it on its own: a path is opaque to a reader who cannot open the file, so the sentence states what changed and the artifact confirms it. That is not prose standing in for an after; the artifact stays mandatory.
+Accept the one limitation rather than working around it: a reviewer who is not on this machine cannot open these files, so for work whose pull request goes to a public upstream the artifacts are the captain's verification rather than the upstream reviewer's, and the self-carrying prose above is what keeps that pull request readable for both.
+That is also why the artifacts go nowhere else, not to a gist and not to any other host: a secret gist is unlisted rather than access-controlled, so anyone holding the link could read captures of a private product.
+
 # Project memory
 If `AGENTS.md` or `CLAUDE.md` already exists, or if this task produced durable project-intrinsic knowledge, run `/Users/axvon/.no-mistakes/worktrees/74bf7f97ec45/01KZ0S73WYZREZE8F9ZB0SH1C9/bin/fm-ensure-agents-md.sh .` in the worktree.
 Record only project knowledge useful to almost every future session.
```
</details>
<details>
<summary>Evidence: Ship-only guard: scout and secondmate rejected, no brief written</summary>

<code>$ bin/fm-brief.sh vis-scout someproj --scout --visual-evidence&#10;error: --visual-evidence applies only to crewmate ship briefs&#10;exit=1&#10;&#10;$ FM_SECONDMATE_CHARTER=ops bin/fm-brief.sh vis-mate --secondmate --no-projects --visual-evidence&#10;error: --visual-evidence applies only to crewmate ship briefs&#10;exit=1&#10;&#10;$ ls $FM_HOME/data # no brief written for either rejected scaffold&#10;demo-plain-02&#10;demo-visual-01&#10;projects.md</code>

```text
$ bin/fm-brief.sh vis-scout someproj --scout --visual-evidence
error: --visual-evidence applies only to crewmate ship briefs
exit=1

$ FM_SECONDMATE_CHARTER=ops bin/fm-brief.sh vis-mate --secondmate --no-projects --visual-evidence
error: --visual-evidence applies only to crewmate ship briefs
exit=1

$ ls $FM_HOME/data   # no brief written for either rejected scaffold
demo-plain-02
demo-visual-01
projects.md
```
</details>
<details>
<summary>Evidence: Unflagged briefs unchanged across the change (base cd73e75 vs target edf2187)</summary>

```text
=== unflagged parity: base(cd73e75) vs target(edf2187) ===
IDENTICAL: all 6 unflagged scaffolds byte-for-byte unchanged
bbdb0dd24b3ec2fc0f4e69c03aecea9203662795 out-base/t-mate.md
e974c7588ad5971c3a3f7d59a57c0e622b48d7a7 out-base/t-scout.md
c861ae6c40403a30d1bb2e2d5109df85105af047 out-base/t-ship-dpr.md
43b5aa55a015b5546a7273360929071eee809249 out-base/t-ship-herdr.md
04715de4104edfbdfe83bfff29f10244288b1cc9 out-base/t-ship-local.md
2d9bab4c240610332de86610ae2283f8ecabfca5 out-base/t-ship-nm.md
bbdb0dd24b3ec2fc0f4e69c03aecea9203662795 out-target/t-mate.md
e974c7588ad5971c3a3f7d59a57c0e622b48d7a7 out-target/t-scout.md
c861ae6c40403a30d1bb2e2d5109df85105af047 out-target/t-ship-dpr.md
43b5aa55a015b5546a7273360929071eee809249 out-target/t-ship-herdr.md
04715de4104edfbdfe83bfff29f10244288b1cc9 out-target/t-ship-local.md
2d9bab4c240610332de86610ae2283f8ecabfca5 out-target/t-ship-nm.md
```
</details>
<details>
<summary>Evidence: macOS stock Bash 3.2 parse and generation parity</summary>

```text
GNU bash, version 3.2.57(1)-release (arm64-apple-darwin25)
bash 3.2 parse: OK
bash 5 vs macOS bash 3.2 generated brief: IDENTICAL
EOF markers leaked in 3.2 brief: 0

=== combined --visual-evidence --herdr-lab ===
3:# Task
6:# Herdr isolation - HARD SAFETY CONTRACT
25:# Setup
34:# Rules
62:# Visual evidence - show the change, do not describe it
88:# Project memory
95:# Definition of done
```
</details>
<details>
<summary>Evidence: fm-brief.sh --help documenting the new flag</summary>

```text
Scaffold a crewmate brief or persistent secondmate charter at
data/<task-id>/brief.md under the active firstmate home.
For ordinary tasks, the standard Setup/Rules/Definition-of-done contract is
filled in. Firstmate then replaces the {TASK} placeholder with the task
description, acceptance criteria, and context, and may adjust other sections
when the task genuinely deviates (e.g. working an existing external PR instead
of shipping a new one).
Usage: fm-brief.sh <task-id> <repo-name> [--scout] [--herdr-lab] [--visual-evidence]
       fm-brief.sh <task-id> --secondmate {<project>...|--no-projects}
  --scout writes the scout contract instead: the deliverable is a report at
  data/<task-id>/report.md (no branch, no push, no PR) and the worktree is scratch.
  --secondmate writes a persistent secondmate charter. The project list
  is cloned into the secondmate home, while the natural-language scope
  tells the main firstmate when to route work there; routine churn stays in its own home;
  captain-relevant escalations and marked from-firstmate replies append to this
  home's status file.
  --no-projects writes a project-less charter for a domain whose subject is the
  firstmate repo itself (its home is a firstmate worktree, its crews take pooled
  worktrees of the same repo). It is mutually exclusive with a project list, and
  omitting both still fails loudly so an accidental omission is never silent.
  Set FM_SECONDMATE_CHARTER='<charter>' to fill the charter text.
  Set FM_SECONDMATE_SCOPE='<scope>' to write a routing scope distinct from the charter text.
  --herdr-lab is mandatory when the task will issue Herdr lifecycle commands.
  It adds the hard isolation contract backed by bin/fm-herdr-lab.sh.
  The flag must be explicit because {TASK} is filled after scaffolding and the
  caller-supplied repo string cannot reliably identify this repo. Briefs made
  without it carry a loud declaration so an omitted contract cannot be silent.
  --visual-evidence adds the visual-evidence contract to a ship brief, for work
  that changes a user-visible surface. The generated contract requires: a
  "before" that is a capture of the real surface as it stands today, unless the
  surface does not exist yet; an "after" that is always an artifact, preferring
  a capture of the change running in a throwaway prototype, then a mock rendered
  in the project's own design system, then a diagram; one tight capture per
  claim placed beside that claim; cropping and annotation down to the region
  that changed; and prose reserved for rationale, trade-offs, and open
  questions. The after has one carve-out, for motion, timing, or a measurement
  no still capture can hold, which the worker must name and justify; an
  unattached "I could not show it" stays a missing after.
  The medium follows the surface (a browser view is a screenshot of the real
  route, CLI output is the real transcript of the real command, a generated file
  is its real content), so the contract fits non-browser surfaces too.
  Prototypes and captures are built inside the task worktree under a
  self-ignoring .fm-scratch/ and are never committed to the code branch; the
  artifacts that are presented are copied to this task's own record directory,
  data/<task-id>/evidence/, which the flag also names as the single exception to
  the brief's stay-inside-the-worktree rule 2 - the same class of write as the
  status file, scoped to this task and nothing else.
  Each artifact is linked by its path beside the claim it evidences - in the
  pull request body as soon as it exists, whoever opened it, or in the hand-back
  when the mode opens none - and the prose must carry that claim on its own,
  because a reviewer who is not on this machine cannot open the file: for
  upstream-facing work the artifacts are the captain's verification rather than
  the upstream reviewer's, which is an accepted limitation and the reason
  captures go to no other host.
  Prototyping the after costs budget when the worker chooses and only repays a
  review round later, so the brief has to require it or no worker spends it.
  The flag is explicit because {TASK} is filled in after scaffolding, so the
  scaffold cannot tell whether the work is visual. It is ship-only, and omitting
  it emits nothing at all: unlike Herdr lifecycle isolation, a missing visual
  contract costs a review round, not safety, so briefs for work with no
  user-visible surface must not carry a declaration.
For ship tasks, the definition of done is shaped by the project's delivery mode
(data/projects.md via fm-project-mode.sh; see the project-management skill
and AGENTS.md task lifecycle):
  no-mistakes  implement -> /no-mistakes pipeline -> PR -> captain merge (default)
  direct-PR    implement -> push + open PR via gh-axi (no pipeline) -> captain merge
  local-only   implement on branch, stop and report "ready in branch" (no push/PR);
               captain approves, firstmate merges to local main
Ship briefs begin with a worktree-isolation assertion before the branch step.
Scout tasks ignore mode - their deliverable is a report, not a merge.
Every scaffold's status protocol distinguishes the configured
declared-external-wait verb (FM_CLASSIFY_PAUSED_VERB, default "paused") from
"blocked:": pause for a known external wait expected to clear on its own,
blocked when firstmate must act.
Ship tasks include a project-memory section so durable project-intrinsic
learnings can be committed to AGENTS.md through the project's delivery path;
it carries the AGENTS.md authoring bar (widely useful knowledge only, pointers
over copied detail) and has the crewmate add the fm-ensure-agents-md.sh
self-governance section when a touched project AGENTS.md lacks it.
Refuses to overwrite an existing brief.
```
</details>
- Evidence: Rendered comparison page used for the screenshots (openable HTML) (local file: <code>/var/folders/40/vfb2wp5n78d1nbkbdk7sv6f40000gn/T/no-mistakes-evidence/01KZ0S73WYZREZE8F9ZB0SH1C9/brief-rendered-comparison.html</code>)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 3 issues found → auto-fixed (4) ✅</summary>

- ⚠️ `AGENTS.md:475` - The dispatch trigger fires on &#34;a user-visible surface&#34;, but the generated contract is browser-specific: bin/fm-brief.sh:394 demands &#34;a screenshot of the real page at the real route&#34; and &#34;navigate to the affected view&#34;, and line 400 says &#34;Capture screenshots with `chrome-devtools-axi`&#34;. Firstmate itself is a CLI/tmux tool and firstmate-repo ship briefs are routine (tests/fm-brief.test.sh:303 scaffolds with repo `firstmate`), so a ship task changing terminal or tmux output satisfies the trigger and receives a contract it cannot satisfy. The intent&#39;s acceptance criterion scopes this to &#34;frontend ship tasks&#34;; &#34;user-visible surface&#34; is wider. Narrowing the trigger to a browser-rendered surface (or widening the contract&#39;s point 1 to cover non-browser surfaces) would close the gap.
- ⚠️ `bin/fm-brief.sh:394` - Point 1 requires the &#34;before&#34; to be a screenshot of the real page at the real route and explicitly rejects a prose description, but gives no alternative when the surface does not exist yet. A ship task adding a new route or component has no page to capture, so a worker reading only the brief - which the acceptance criteria require to be self-contained - is told to produce something impossible and must either fabricate a substitute or spend a needs-decision round. A single clause (&#34;if the surface is new, say so and go straight to the after&#34;) would resolve it, but it changes the requester&#39;s verbatim point 1.
- ℹ️ `bin/fm-brief.sh:392` - The contract tells the worker to place artifacts in &#34;the PR description when this project opens a PR, otherwise the summary you hand back&#34;. In local-only mode the definition of done at bin/fm-brief.sh:349 is a single status append (`done: ready in branch fm/&lt;id&gt;`) with no PR and no report doc, and the worktree holding any captured images is torn down, so there is no durable place for screenshots. tests/fm-brief.test.sh:373 deliberately asserts the contract renders for local-only, so this mode is in scope by design. Naming a concrete location for the non-PR modes (for example a file committed on the branch) would make the wording self-contained across all three delivery modes.

🔧 Fix: broaden visual-evidence contract beyond browser and name artifact location
2 infos still open:
- ℹ️ `bin/fm-brief.sh:398` - The section adds &#34;Those artifacts and the status file are the only things you write outside the worktree.&#34;, which directly contradicts the ship brief&#39;s Rule 2 (bin/fm-brief.sh:426, rendered earlier in the same document as &#34;Stay inside this worktree; modify nothing outside it.&#34;) with no back-reference. The scout brief avoids this by enumerating the exceptions inside its own rule 2 (bin/fm-brief.sh:291), but amending the ship rule 2 unconditionally would break the byte-identity invariant the author deliberately preserved for unflagged briefs. A short back-reference in the section (&#34;as an exception to rule 2 above&#34;) would resolve it without touching the shared rules block.
- ℹ️ `bin/fm-brief.sh:398` - The non-PR half of the destination is now concrete (`$DATA/$ID/`), but the PR half is not. In the default no-mistakes mode the PR body is authored by the pipeline, not the worker (see the DOD at bin/fm-brief.sh:357-375, which never tells the worker to author or edit the PR description), so &#34;the PR description when this project opens a PR&#34; names a surface the worker does not own and gives no timing. Separately, GitHub has no API or CLI path to attach image files to a PR body, so a screenshot - the flagship artifact the contract requires - has no reachable landing place in either PR mode using the `gh-axi` the brief mandates. Pointing all modes at `$DATA/$ID/` as the file home and having the PR body reference them would close it; the captain&#39;s round-1 instruction addressed only the non-PR case, so this is the residual half rather than a departure from that decision.

🔧 Fix: keep visual-evidence artifacts in-worktree, deliver via evidence ref
4 warnings still open:
- ⚠️ `bin/fm-brief.sh:437` - `git switch --orphan` clears tracked files, and the project&#39;s root `.gitignore` is one of them. I verified in a scratch repo that on the orphan ref `git status --untracked-files=all` then lists `node_modules/`, `dist/`, and `.env` as untracked candidates - only `.fm-scratch/` stays hidden, because its ignore file is nested inside it. The contract then tells the worker to copy captures to that root, commit, and (in the PR modes, line 410) push the ref to a remote, but never says how to stage. A worker running `git add -A` there commits build output and secrets to a pushed branch, which defeats the access-control rationale the evidence-ref design exists to serve. One clause fixes it: stage the capture files, README.md, and capture scripts by name, and never `git add -A` on the evidence ref because the project&#39;s own ignore rules are not present there. Worth fixing in this change rather than as a follow-up, given the credential path.
- ⚠️ `bin/fm-brief.sh:410` - In direct-PR mode Rule 1 renders as &#34;Never push to the default branch (push only your `fm/&lt;id&gt;` branch). Never merge a PR.&#34; (built at bin/fm-brief.sh:344), but the delivery block tells the same worker to push `fm/&lt;id&gt;-evidence`. The mitigating clause &#34;it is the only other ref you push, a sibling of your own branch and never the default branch&#34; answers Rule 1&#39;s first sentence but not the parenthetical exclusivity. This is the same shape as the Rule 2 carve-out the captain ruled out last round, now on Rule 1, and the no-mistakes and local-only Rule 1 variants do not conflict - only direct-PR does. Because RULE1 is already built per-mode, widening just the direct-PR parenthetical when VISUAL_EVIDENCE is set would reconcile it without touching output for unflagged briefs.
- ⚠️ `bin/fm-brief.sh:412` - The deletion requirement says `fm/&lt;id&gt;-evidence` &#34;must be deleted once the pull request lands&#34; without distinguishing the local ref from the pushed one, and the AGENTS.md line added at AGENTS.md:476 says only &#34;delete that ref&#34;. I traced both cleanup paths: bin/fm-teardown.sh:1573 and :1589 delete only the branch checked out in the worktree, which is `fm/&lt;id&gt;`, and bin/fm-fleet-sync.sh `prune_gone_branches` only reclaims local branches whose upstream tracking ref is `[gone]` - the contract&#39;s push carries no `-u`, so the evidence ref has no upstream and is never pruned either. So after a PR merges both a local and a remote `fm/&lt;id&gt;-evidence` survive, which is exactly the stale-branch outcome the deletion requirement exists to prevent. Naming the remote explicitly fixes the wording; pushing with `-u` would additionally let the existing prune path reclaim the local copy once the remote is deleted.
- ⚠️ `bin/fm-brief.sh:410` - &#34;Push `fm/&lt;id&gt;-evidence` to the same remote your code branch goes to&#34; is not resolvable in the default no-mistakes mode. That mode&#39;s DOD (bin/fm-brief.sh:369-387) has the worker commit and then hand off to /no-mistakes, which owns the push; per the intent&#39;s own constraints the code branch goes to a configured fork while `origin` is upstream. At the point the contract has the worker push the evidence ref the code branch has not been pushed anywhere, so the worker has no way to read the target and a wrong guess sends private-product captures to upstream - the opposite of the access-control property the sentence claims. Either defer the evidence push until after the code branch has an upstream and read it (`git config branch.fm/&lt;id&gt;.remote`), or name the target explicitly.

🔧 Fix: deliver visual evidence to task record dir, drop evidence ref
2 warnings still open:
- ⚠️ `bin/fm-brief.sh:435` - &#34;Link each artifact by its path beside the claim it evidences - in the pull request body when this project opens one&#34; gives no owner and no timing for the default no-mistakes mode. That mode&#39;s DOD at bin/fm-brief.sh:375-393 has the worker commit, hand off to /no-mistakes, and then &#34;Do not hand-edit, commit, or fix findings yourself while a run is active&#34; - the pipeline authors the PR body, so the worker is never told when or how its per-claim links get into it. Round 3 covered this with &#34;when the pull request is opened for you, add those links to its body with `gh-axi` as soon as it exists&#34;, but that sentence lived inside the per-mode delivery block the captain ordered removed and nothing replaced it, so the round-2 finding pr-mode-artifact-destination-underspecified is reachable again. The intent makes this a criterion: &#34;The generated wording must be self-contained so a worker reading only the brief knows what to produce.&#34; Restoring a mode-agnostic version of that timing clause closes it without reintroducing anything from the withdrawn mechanism.
- ⚠️ `AGENTS.md:86` - The change adds a new durable, crewmate-written location `data/&lt;task-id&gt;/evidence/` but does not add it to AGENTS.md&#39;s home-layout inventory, which at line 86 already documents the exact sibling artifact from this same scaffold: &#34;`&lt;id&gt;/report.md`     scout task deliverable, written by the crewmate; survives teardown&#34;. I confirmed the parallel is real - bin/fm-teardown.sh:1688 removes only `$STATE/$ID.*`, so the evidence directory survives teardown just like the report. The intent requires that &#34;any doc that already owns the scaffold&#39;s contract must be updated&#34;, and this block is the existing owner of where crewmate deliverables live; adding one line beside the report entry satisfies it without a new doc.

🔧 Fix: restore PR-body link timing and document evidence dir
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash tests/fm-brief.test.sh` - full colocated suite, 19 cases pass including `test_visual_evidence_contract_is_opt_in_and_complete` and `test_visual_evidence_is_ship_only`</code>
- <code>`FM_HOME=&lt;tmp-home&gt; bin/fm-brief.sh redesign-settings-page example-web-app --visual-evidence` - real ship brief containing the contract; compared against `bin/fm-brief.sh tune-retry-backoff example-web-app` (no flag, no section, no declaration)</code>
- <code>Rendered both generated briefs with `markdown-it` and captured them side by side via `chrome-devtools-axi open file://... &amp;&amp; chrome-devtools-axi screenshot --full-page`, plus a crop of the added section</code>
- <code>Byte-parity check base cd73e75 vs target edf2187: generated ship (no-mistakes/direct-PR/local-only), scout, secondmate, and --herdr-lab briefs into an identical home path and `diff -r` - all six identical, matching SHAs</code>
- <code>`bin/fm-brief.sh vis-scout someproj --scout --visual-evidence` and `FM_SECONDMATE_CHARTER=ops bin/fm-brief.sh vis-mate --secondmate --no-projects --visual-evidence` - both exit 1, no brief written</code>
- <code>`/bin/bash -n bin/fm-brief.sh` (GNU bash 3.2.57) plus generating a flagged brief under `/bin/bash` and diffing against the Bash 5 output - identical, zero leaked `EOF` markers</code>
- <code>`bin/fm-brief.sh --help` - verified the flag, medium-follows-the-surface wording, .fm-scratch production, data/&lt;task-id&gt;/evidence delivery, and rule 2 carve-out are documented</code>
- <code>`bin/fm-brief.sh both example-web-app --visual-evidence --herdr-lab` - both contracts render, in order</code>
- <code>`bash tests/fm-documentation-audiences.test.sh` - structural doc inventory still passes after the AGENTS.md and docs/scripts.md edits</code>
- <code>`git diff --diff-filter=A --name-only cd73e75 edf2187` - confirms no new doc file was added</code>
- <code>Mutation check: ran `tests/fm-brief.test.sh` against a temp repo whose `bin/fm-brief.sh` is the pre-change version - the new test fails (`visual-evidence brief missing its section heading`), and the pre-change script silently accepted `--scout --visual-evidence` and wrote a scout brief</code>

</details>

<details>
<summary>⚠️ **Document** - 1 info</summary>

- ℹ️ `docs/scripts.md:21` - Judgment call worth surfacing: an earlier review commit (a99dd81/edf2187) named the artifact location in the docs/scripts.md fm-brief.sh row, and the final commit also documented data/&lt;task-id&gt;/evidence/ in the AGENTS.md home-layout inventory, leaving the path stated in three places (script header, AGENTS.md, scripts.md). I kept AGENTS.md as the owner for the path (it already owns data/&lt;id&gt;/brief.md and report.md) and the script header as the owner for flag mechanics, and reduced the scripts.md row back to its one purpose clause, per that file&#39;s own preamble and the one-owner rule in .agents/skills/firstmate-coding-guidelines/SKILL.md. If the intent of that review was specifically that scripts.md name the path, this consolidation reverses it.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
