### PR TITLE
feat(bin): add implementation habits to ship briefs

### DIFF
--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -399,6 +399,11 @@ $RULE1
    every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
    daemon error, append \`blocked: {the daemon error}\` and stop; only firstmate manages the daemon.
 
+# Implementation habits
+- Before editing source, if \`graphify-out/graph.json\` exists, consult it for callers, importers, and blast radius; do not rebuild or refresh it unless explicitly asked.
+- Never claim unverified success: preserve failure evidence and stop, and treat the project's delivery mode - not passing local tests - as the definition of done.
+- When work is test-shaped, retain failing-test-first evidence: the failing test, smallest passing change, behaviour-preserving cleanup, and final passing command.
+
 # Project memory
 If \`AGENTS.md\` or \`CLAUDE.md\` already exists, or if this task produced durable project-intrinsic knowledge, run \`$FM_ROOT/bin/fm-ensure-agents-md.sh .\` in the worktree.
 Record only project knowledge useful to almost every future session.

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -295,6 +295,47 @@ test_ship_project_memory_wording() {
   pass "fm-brief.sh: ship project-memory wording carries the AGENTS.md authoring bar"
 }
 
+test_ship_implementation_habits_are_scoped_and_preserve_safety_contracts() {
+  local home ship scout secondmate herdr_ship herdr_scout habit
+  home="$TMP_ROOT/implementation-habits-home"
+  mkdir -p "$home/data"
+
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" habits-ship sample >/dev/null 2>&1
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" habits-scout sample --scout >/dev/null 2>&1
+  FM_HOME="$home" FM_SECONDMATE_CHARTER=sample \
+    "$ROOT/bin/fm-brief.sh" habits-secondmate --secondmate --no-projects >/dev/null 2>&1
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" habits-herdr-ship sample --herdr-lab >/dev/null 2>&1
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" habits-herdr-scout sample --scout --herdr-lab >/dev/null 2>&1
+
+  ship="$home/data/habits-ship/brief.md"
+  scout="$home/data/habits-scout/brief.md"
+  secondmate="$home/data/habits-secondmate/brief.md"
+  herdr_ship="$home/data/habits-herdr-ship/brief.md"
+  herdr_scout="$home/data/habits-herdr-scout/brief.md"
+
+  # shellcheck disable=SC2016 # Backticks in the generated brief must remain literal.
+  for habit in \
+    'if `graphify-out/graph.json` exists, consult it for callers, importers, and blast radius' \
+    "treat the project's delivery mode - not passing local tests - as the definition of done" \
+    'When work is test-shaped, retain failing-test-first evidence'; do
+    assert_grep "$habit" "$ship" "ship brief missing implementation habit: $habit"
+    assert_grep "$habit" "$herdr_ship" "Herdr ship brief missing implementation habit: $habit"
+    assert_no_grep "$habit" "$scout" "scout brief received a ship-only implementation habit: $habit"
+    assert_no_grep "$habit" "$secondmate" "secondmate charter received a crewmate implementation habit: $habit"
+    assert_no_grep "$habit" "$herdr_scout" "Herdr scout brief received a ship-only implementation habit: $habit"
+  done
+
+  assert_grep '**Verify isolation before anything else.**' "$ship" \
+    "ship implementation habits changed the worktree-isolation assertion"
+  assert_grep 'States: working, needs-decision, blocked, paused, done, failed.' "$ship" \
+    "ship implementation habits changed the status protocol"
+  assert_grep 'The task is complete only when committed on your branch.' "$ship" \
+    "ship implementation habits changed the delivery-mode commit gate"
+  assert_grep 'done: PR {url} checks green' "$ship" \
+    "ship implementation habits changed the delivery-mode completion gate"
+  pass "fm-brief.sh: ship habits are scoped and preserve existing safety contracts"
+}
+
 test_herdr_lab_contract_is_explicit_and_complete() {
   local home id brief
   home="$TMP_ROOT/herdr-lab-home"
@@ -639,6 +680,7 @@ test_ship_modes_generate_clean_briefs
 test_faster_paths_use_configured_authority_without_stacked_review
 test_no_mistakes_dod_wording
 test_ship_project_memory_wording
+test_ship_implementation_habits_are_scoped_and_preserve_safety_contracts
 test_herdr_lab_contract_is_explicit_and_complete
 test_herdr_lab_contract_quotes_foreign_firstmate_path
 test_herdr_lab_omission_is_loud_for_ship_and_scout


### PR DESCRIPTION
## Summary

Add three concise implementation habits to ship briefs generated by `bin/fm-brief.sh`:

1. Consult an existing `graphify-out/graph.json` for callers, importers, and blast radius before editing source, without rebuilding or refreshing the graph. This uses existing structural knowledge instead of spending tokens rediscovering repository relationships.
2. Preserve failure evidence and never claim success without satisfying the project delivery mode. This exists because two workers on this fleet declared themselves done today, 2026-08-02, after local tests passed even though they never ran their delivery pipeline, pushed their work, or opened a PR.
3. For genuinely test-shaped work, retain failing-test-first evidence, the smallest passing change, behavior-preserving cleanup, and the final passing command. This keeps implementation claims tied to observable proof without imposing the workflow on investigations or documentation.

## Scope and safety

The habits appear in normal ship briefs and `--herdr-lab` ship briefs. They remain absent from scout, `--herdr-lab --scout`, and secondmate scaffolds where they do not apply.

The existing worktree-isolation assertion, status protocol, and delivery-mode definitions of done are unchanged. Behavioral coverage pins those safety sections while checking every scaffold variant.

## Validation

- `bash tests/fm-brief.test.sh`
- `bin/fm-lint.sh` with ShellCheck 0.11.0