### PR TITLE
feat(bin): support Luna xhigh and explicit max profiles

### DIFF
--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -122,7 +122,7 @@ The supported launch-profile flags below are verified locally; each row records 
 | Harness | Model flag | Effort flag | Notes |
 |---|---|---|---|
 | claude | `--model <model>` | `--effort <low\|medium\|high\|xhigh\|max>` | Verified on Claude Code 2.1.196. |
-| codex | `--model <model>` | `-c 'model_reasoning_effort="<low\|medium\|high\|xhigh\|max>"'` | Verified on codex-cli 0.146.0 against the live Luna catalog. See [`docs/verification/dispatch-auth.md`](../../../docs/verification/dispatch-auth.md#codex-luna-launch-profile). |
+| codex | `--model <model>` | `-c 'model_reasoning_effort="<low\|medium\|high\|xhigh\|max>"'` | Verified on codex-cli 0.146.0 against the live Luna catalog; `max` is supported only with model `gpt-5.6-luna`. See [`docs/verification/dispatch-auth.md`](../../../docs/verification/dispatch-auth.md#codex-luna-launch-profile). |
 | grok | `--model <model>` | `--reasoning-effort <low\|medium\|high>` | Verified on grok 0.2.99 (2026-07-13). `--effort` is an alias, but firstmate's profile axis is reasoning effort. As of 0.2.99 the ceiling is `high`; both `xhigh` and `max` are rejected with `use one of: high, medium, low`, so firstmate omits them. |
 | pi / pi-signed | `--model <model>` | `--thinking <low\|medium\|high\|xhigh\|max>` | Verified 2026-07-27 on Pi and pi-signed 0.82.0. Both expose the same accepted thinking levels and completed the same model-qualified max-thinking smoke. |
 | opencode | `--model <provider/model>` | none for firstmate's interactive launch | Verified on opencode 1.17.6. `opencode run` has `--variant`, but firstmate launches the interactive `opencode --prompt` path, which has no verified effort flag. |

--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -122,7 +122,7 @@ The supported launch-profile flags below are verified locally; each row records 
 | Harness | Model flag | Effort flag | Notes |
 |---|---|---|---|
 | claude | `--model <model>` | `--effort <low\|medium\|high\|xhigh\|max>` | Verified on Claude Code 2.1.196. |
-| codex | `--model <model>` | `-c 'model_reasoning_effort="<low\|medium\|high\|xhigh\|max>"'` | Verified on codex-cli 0.146.0 against the live Luna catalog; `max` is supported only with model `gpt-5.6-luna`. See [`docs/verification/dispatch-auth.md`](../../../docs/verification/dispatch-auth.md#codex-luna-launch-profile). |
+| codex | `--model <model>` | `-c 'model_reasoning_effort="<low\|medium\|high\|xhigh\|max>"'` | Verified on codex-cli 0.146.0 against the live Luna catalog; Firstmate's verified `max` support is limited to model `gpt-5.6-luna`. See [`docs/verification/dispatch-auth.md`](../../../docs/verification/dispatch-auth.md#codex-luna-launch-profile). |
 | grok | `--model <model>` | `--reasoning-effort <low\|medium\|high>` | Verified on grok 0.2.99 (2026-07-13). `--effort` is an alias, but firstmate's profile axis is reasoning effort. As of 0.2.99 the ceiling is `high`; both `xhigh` and `max` are rejected with `use one of: high, medium, low`, so firstmate omits them. |
 | pi / pi-signed | `--model <model>` | `--thinking <low\|medium\|high\|xhigh\|max>` | Verified 2026-07-27 on Pi and pi-signed 0.82.0. Both expose the same accepted thinking levels and completed the same model-qualified max-thinking smoke. |
 | opencode | `--model <provider/model>` | none for firstmate's interactive launch | Verified on opencode 1.17.6. `opencode run` has `--variant`, but firstmate launches the interactive `opencode --prompt` path, which has no verified effort flag. |
@@ -149,8 +149,7 @@ For an unfamiliar harness or model namespace, establish support and provider ide
 A listing that reaches the account and does not contain the model is concrete evidence the model is unsupported: block that candidate and quote the result.
 A discovery surface you could not reach establishes nothing; report that as uncertainty rather than turning it into a supported or unsupported verdict.
 
-When a requested effort value is outside the harness-specific accepted set, `fm-spawn` records the requested `effort=` in meta but emits no effort flag for that harness.
-This preserves launch success instead of passing a known-bad value.
+[`docs/configuration.md`](../../../docs/configuration.md#crew-dispatch-profiles-configcrew-dispatchjson) owns harness-specific effort compatibility, metadata handling, and the fail-closed Codex model/effort exception.
 
 ## no-mistakes skill invocation
 

--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -122,7 +122,7 @@ The supported launch-profile flags below are verified locally; each row records 
 | Harness | Model flag | Effort flag | Notes |
 |---|---|---|---|
 | claude | `--model <model>` | `--effort <low\|medium\|high\|xhigh\|max>` | Verified on Claude Code 2.1.196. |
-| codex | `--model <model>` | `-c 'model_reasoning_effort="<low\|medium\|high\|xhigh>"'` | Verified on codex-cli 0.142.1. The installed binary schema contains `model_reasoning_effort`, the active config uses it, and the bundled model catalog advertises only low/medium/high/xhigh. `max` is omitted. |
+| codex | `--model <model>` | `-c 'model_reasoning_effort="<low\|medium\|high\|xhigh\|max>"'` | Verified on codex-cli 0.146.0 against the live Luna catalog. See [`docs/verification/dispatch-auth.md`](../../../docs/verification/dispatch-auth.md#codex-luna-launch-profile). |
 | grok | `--model <model>` | `--reasoning-effort <low\|medium\|high>` | Verified on grok 0.2.99 (2026-07-13). `--effort` is an alias, but firstmate's profile axis is reasoning effort. As of 0.2.99 the ceiling is `high`; both `xhigh` and `max` are rejected with `use one of: high, medium, low`, so firstmate omits them. |
 | pi / pi-signed | `--model <model>` | `--thinking <low\|medium\|high\|xhigh\|max>` | Verified 2026-07-27 on Pi and pi-signed 0.82.0. Both expose the same accepted thinking levels and completed the same model-qualified max-thinking smoke. |
 | opencode | `--model <provider/model>` | none for firstmate's interactive launch | Verified on opencode 1.17.6. `opencode run` has `--variant`, but firstmate launches the interactive `opencode --prompt` path, which has no verified effort flag. |
@@ -139,7 +139,7 @@ Use the discovery surface in the current authenticated environment because suppo
 | Harness | Authoritative discovery surface |
 |---|---|
 | claude | Open the current interactive session's `/model` picker; `claude --help` documents the accepted alias or full-model-name input shape. |
-| codex | Open the current interactive session's `/model` picker. |
+| codex | Run `codex debug models` for the live catalog, then inspect the requested model's `supported_reasoning_levels`; the interactive `/model` picker is a useful account-visible cross-check. |
 | opencode | Run `opencode models [provider]`, which lists available provider/model identifiers. |
 | pi / pi-signed | Run the selected executable as `<executable> --list-models [search]`; Pi's installed `docs/models.md` owns how built-in, extension-registered, and custom provider/model entries reach that list. |
 | grok | Run `grok models`, which lists the models available to the current Grok installation and account. |

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -739,7 +739,7 @@ crew_dispatch_validate() {
       if $e == null then true
       elif ($e | type) != "string" then false
       elif $h == "claude" then (["low","medium","high","xhigh","max"] | index($e))
-      elif $h == "codex" then (["low","medium","high","xhigh"] | index($e))
+      elif $h == "codex" then (["low","medium","high","xhigh","max"] | index($e))
       elif $h == "grok" then (["low","medium","high"] | index($e))
       elif $h == "pi" or $h == "pi-signed" then (["low","medium","high","xhigh","max"] | index($e))
       elif $h == "opencode" or $h == "kimi" then false

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -735,12 +735,12 @@ crew_dispatch_validate() {
   fi
   err=$(jq -r '
     def verified($h): ["claude","codex","opencode","pi","pi-signed","grok","kimi"] | index($h);
-    def effort_ok($h; $m; $e):
+    def effort_ok($is_default; $h; $m; $e):
       if $e == null then true
       elif ($e | type) != "string" then false
       elif $h == "claude" then (["low","medium","high","xhigh","max"] | index($e))
       elif $h == "codex" then
-        if $e == "max" then $m == "gpt-5.6-luna"
+        if $e == "max" then ($is_default | not) and $m == "gpt-5.6-luna"
         else (["low","medium","high","xhigh"] | index($e))
         end
       elif $h == "grok" then (["low","medium","high"] | index($e))
@@ -754,17 +754,17 @@ crew_dispatch_validate() {
       else []
       end;
     def configured_profiles:
-      ([(.rules // [])[]? | profiles(.use?)[]?]
-        + (if has("default") then [profiles(.default)[]?] else [] end));
+      ([(.rules // [])[]? | profiles(.use?)[]? | {profile: ., is_default: false}]
+        + (if has("default") then [profiles(.default)[]? | {profile: ., is_default: true}] else [] end));
     def malformed_optional_fields($items):
       ($items | any(has("model") and (((.model | type) != "string") or (.model | length) == 0)))
       or ($items | any(has("effort") and (((.effort | type) != "string") or (.effort | length) == 0)));
     def bad_efforts:
       configured_profiles
-      | map({h: .harness, m: .model, e: .effort})
+      | map({h: .profile.harness, m: .profile.model, e: .profile.effort, is_default: .is_default})
       | map(select(.e != null))
       | map(select((.h | type) == "string" and verified(.h)))
-      | map(select(. as $p | effort_ok($p.h; $p.m; $p.e) | not))
+      | map(select(. as $p | effort_ok($p.is_default; $p.h; $p.m; $p.e) | not))
       | map("\(.h):\(.e)")
       | unique;
     if type != "object" then "top-level value must be an object"
@@ -786,7 +786,7 @@ crew_dispatch_validate() {
     elif has("default") and malformed_optional_fields([profiles(.default)[]?]) then "default profile model and effort must be non-empty strings when present"
     else
       (configured_profiles
-        | map(.harness)
+        | map(.profile.harness)
         | map(select(. != null))
         | map(select(. as $h | verified($h) | not))
         | unique) as $bad_harnesses

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -735,11 +735,14 @@ crew_dispatch_validate() {
   fi
   err=$(jq -r '
     def verified($h): ["claude","codex","opencode","pi","pi-signed","grok","kimi"] | index($h);
-    def effort_ok($h; $e):
+    def effort_ok($h; $m; $e):
       if $e == null then true
       elif ($e | type) != "string" then false
       elif $h == "claude" then (["low","medium","high","xhigh","max"] | index($e))
-      elif $h == "codex" then (["low","medium","high","xhigh","max"] | index($e))
+      elif $h == "codex" then
+        if $e == "max" then $m == "gpt-5.6-luna"
+        else (["low","medium","high","xhigh"] | index($e))
+        end
       elif $h == "grok" then (["low","medium","high"] | index($e))
       elif $h == "pi" or $h == "pi-signed" then (["low","medium","high","xhigh","max"] | index($e))
       elif $h == "opencode" or $h == "kimi" then false
@@ -758,10 +761,10 @@ crew_dispatch_validate() {
       or ($items | any(has("effort") and (((.effort | type) != "string") or (.effort | length) == 0)));
     def bad_efforts:
       configured_profiles
-      | map({h: .harness, e: .effort})
+      | map({h: .harness, m: .model, e: .effort})
       | map(select(.e != null))
       | map(select((.h | type) == "string" and verified(.h)))
-      | map(select(. as $p | effort_ok($p.h; $p.e) | not))
+      | map(select(. as $p | effort_ok($p.h; $p.m; $p.e) | not))
       | map("\(.h):\(.e)")
       | unique;
     if type != "object" then "top-level value must be an object"

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -22,8 +22,8 @@
 #   axes chosen by firstmate at intake. They are only threaded into harnesses whose
 #   installed CLIs were verified to support that axis; unsupported axes are omitted
 #   from that harness's launch rather than guessed.
-#   For codex, every accepted effort maps to
-#   -c 'model_reasoning_effort="<low|medium|high|xhigh|max>"'.
+#   For codex, low through xhigh map to model_reasoning_effort, and max is accepted
+#   only with model gpt-5.6-luna.
 #   --backend <name> is the explicit runtime session-provider backend for this
 #   exact task only (docs/configuration.md "Runtime backend" owns when that flag
 #   is authorized). Without it, the script resolves FM_BACKEND, then
@@ -635,6 +635,21 @@ if [ "$KIND" = secondmate ] && [ -z "$ARG3" ]; then
   fi
 fi
 
+codex_effort_supported() {
+  local model=$1 effort=$2
+  case "$effort" in
+    low|medium|high|xhigh) return 0 ;;
+    max) [ "$model" = gpt-5.6-luna ] ;;
+    *) return 1 ;;
+  esac
+}
+
+if [ "$HARNESS" = codex ] && [ -n "$EFFORT" ] && [ "$EFFORT" != default ] \
+  && ! codex_effort_supported "$MODEL" "$EFFORT"; then
+  echo "error: codex effort '$EFFORT' requires model 'gpt-5.6-luna'" >&2
+  exit 1
+fi
+
 secondmate_registry_value() {
   secondmate_registry_field "$DATA/secondmates.md" "$1" "$2"
 }
@@ -680,7 +695,7 @@ model_flag_for_harness() {
 }
 
 effort_flag_for_harness() {
-  local harness=$1 effort=$2
+  local harness=$1 model=$2 effort=$3
   [ -n "$effort" ] && [ "$effort" != default ] || return 0
   case "$harness" in
     claude)
@@ -689,10 +704,14 @@ effort_flag_for_harness() {
       esac
       ;;
     codex)
-      # The installed codex config schema uses model_reasoning_effort, and the
-      # live model catalog advertises low|medium|high|xhigh|max for Luna.
       case "$effort" in
-        low|medium|high|xhigh|max) printf -- '-c %s ' "$(shell_quote "model_reasoning_effort=\"$effort\"")" ;;
+        low|medium|high|xhigh)
+          printf -- '-c %s ' "$(shell_quote "model_reasoning_effort=\"$effort\"")"
+          ;;
+        max)
+          codex_effort_supported "$model" "$effort" \
+            && printf -- '-c %s ' "$(shell_quote "model_reasoning_effort=\"$effort\"")"
+          ;;
       esac
       ;;
     grok)
@@ -1756,7 +1775,7 @@ sq_piturnend=$(shell_quote "$PROJ_ABS/.pi/extensions/fm-primary-turnend-guard.ts
 sq_piwatch=$(shell_quote "$PROJ_ABS/.pi/extensions/fm-primary-pi-watch.ts")
 sq_opinput=$(shell_quote "$FM_ROOT/bin/fm-operational-input.sh")
 MODELFLAG=$(model_flag_for_harness "$HARNESS" "$MODEL")
-EFFORTFLAG=$(effort_flag_for_harness "$HARNESS" "$EFFORT")
+EFFORTFLAG=$(effort_flag_for_harness "$HARNESS" "$MODEL" "$EFFORT")
 LAUNCH=${LAUNCH//__MODELFLAG__/$MODELFLAG}
 LAUNCH=${LAUNCH//__EFFORTFLAG__/$EFFORTFLAG}
 LAUNCH=${LAUNCH//__BRIEF__/$sq_brief}

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -22,6 +22,7 @@
 #   axes chosen by firstmate at intake. They are only threaded into harnesses whose
 #   installed CLIs were verified to support that axis; unsupported axes are omitted
 #   from that harness's launch rather than guessed.
+#   Model-qualified incompatibilities are rejected before launch and metadata.
 #   For codex, low through xhigh map to model_reasoning_effort, and max is accepted
 #   only with model gpt-5.6-luna.
 #   --backend <name> is the explicit runtime session-provider backend for this

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -22,6 +22,8 @@
 #   axes chosen by firstmate at intake. They are only threaded into harnesses whose
 #   installed CLIs were verified to support that axis; unsupported axes are omitted
 #   from that harness's launch rather than guessed.
+#   For codex, every accepted effort maps to
+#   -c 'model_reasoning_effort="<low|medium|high|xhigh|max>"'.
 #   --backend <name> is the explicit runtime session-provider backend for this
 #   exact task only (docs/configuration.md "Runtime backend" owns when that flag
 #   is authorized). Without it, the script resolves FM_BACKEND, then
@@ -688,10 +690,9 @@ effort_flag_for_harness() {
       ;;
     codex)
       # The installed codex config schema uses model_reasoning_effort, and the
-      # bundled model catalog advertises low|medium|high|xhigh. Omit max rather
-      # than passing an unsupported value.
+      # live model catalog advertises low|medium|high|xhigh|max for Luna.
       case "$effort" in
-        low|medium|high|xhigh) printf -- '-c %s ' "$(shell_quote "model_reasoning_effort=\"$effort\"")" ;;
+        low|medium|high|xhigh|max) printf -- '-c %s ' "$(shell_quote "model_reasoning_effort=\"$effort\"")" ;;
       esac
       ;;
     grok)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -167,8 +167,7 @@ The shell scripts validate the JSON shape and verified harness/effort combinatio
 The session-start bootstrap step keeps valid dispatch configuration silent unless verbose facts are enabled and surfaces a concise invalid-config line when validation fails.
 When the file exists, `fm-spawn.sh` refuses crewmate and scout launches without an explicit harness, so `config/crew-harness` is only automatic when no dispatch profile file is active.
 Secondmate launches are exempt because they resolve the secondmate harness and any optional secondmate model or effort tokens instead.
-Unsupported effort values are still recorded in task meta when passed to `fm-spawn.sh`, but the launch template omits any effort flag that the selected harness does not accept.
-That keeps spawn launch compatible across claude, codex, grok, pi, opencode, and kimi while preserving the requested profile for later audit.
+[`docs/configuration.md`](configuration.md#crew-dispatch-profiles-configcrew-dispatchjson) owns effort compatibility, metadata handling, and fail-closed exceptions; `fm-spawn.sh` enforces that operator contract before launch.
 
 ## Optional secondmates
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -255,6 +255,7 @@ Both `use` and the optional top-level `default` accept either one profile object
 The single-object form stays fully backward-compatible, and every profile needs `harness`.
 Profile `model` and `effort` fields and rule `why` are optional.
 An omitted model or effort means the selected harness uses its own default for that axis.
+For Codex, `max` is supported only with model `gpt-5.6-luna`; lower effort levels remain model-independent in the dispatch validator.
 Every profile array is an implicit quota-aware choice resolved through `quota-array-dispatch`.
 If no dispatch rule fits, firstmate resolves `default` through the same object-or-array path before falling back to `config/crew-harness`.
 If a selected profile carries an effort value the chosen harness does not accept, `fm-spawn.sh` records the requested `effort=` in task meta for traceability but omits the launch flag, and bootstrap reports the invalid harness/effort pair as a `CREW_DISPATCH` diagnostic when it is visible in the file.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -255,10 +255,11 @@ Both `use` and the optional top-level `default` accept either one profile object
 The single-object form stays fully backward-compatible, and every profile needs `harness`.
 Profile `model` and `effort` fields and rule `why` are optional.
 An omitted model or effort means the selected harness uses its own default for that axis.
-For Codex, `max` is supported only with model `gpt-5.6-luna`; lower effort levels remain model-independent in the dispatch validator.
+For Codex, `max` is supported only in rule profiles and explicit per-task overrides with model `gpt-5.6-luna`; the top-level `default` cannot select `max`, and lower effort levels remain model-independent in the dispatch validator.
 Every profile array is an implicit quota-aware choice resolved through `quota-array-dispatch`.
 If no dispatch rule fits, firstmate resolves `default` through the same object-or-array path before falling back to `config/crew-harness`.
-If a selected profile carries an effort value the chosen harness does not accept, `fm-spawn.sh` records the requested `effort=` in task meta for traceability but omits the launch flag, and bootstrap reports the invalid harness/effort pair as a `CREW_DISPATCH` diagnostic when it is visible in the file.
+Except for model-qualified Codex incompatibilities, if a selected profile carries an effort value the chosen harness does not accept, `fm-spawn.sh` records the requested `effort=` in task meta for traceability but omits the launch flag, and bootstrap reports the invalid harness/effort pair as a `CREW_DISPATCH` diagnostic when it is visible in the file.
+Model-qualified Codex incompatibilities fail before task metadata or launch instead of using that omission behavior.
 See [`docs/examples/crew-dispatch.json`](examples/crew-dispatch.json) for a starting point to copy into local `config/crew-dispatch.json`.
 When the file exists, bootstrap validates it with `jq`.
 Valid files stay silent by default; with `FM_BOOTSTRAP_VERBOSE_FACTS=1`, bootstrap emits `BOOTSTRAP_INFO: crew dispatch active config/crew-dispatch.json`, one `BOOTSTRAP_INFO:` fact per rule, and one fact for the optional default profile set.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -255,7 +255,7 @@ Both `use` and the optional top-level `default` accept either one profile object
 The single-object form stays fully backward-compatible, and every profile needs `harness`.
 Profile `model` and `effort` fields and rule `why` are optional.
 An omitted model or effort means the selected harness uses its own default for that axis.
-Codex `max` requires model `gpt-5.6-luna` at launch; in crew dispatch configuration, bootstrap accepts that pair only in rule profiles, while the top-level `default` cannot select `max` and lower effort levels remain model-independent in the validator.
+Codex `max` requires model `gpt-5.6-luna` at launch; bootstrap accepts that pair only in a rule profile representing an explicit captain preference, while the top-level `default` cannot select `max` and lower effort levels remain model-independent in the validator.
 Every profile array is an implicit quota-aware choice resolved through `quota-array-dispatch`.
 If no dispatch rule fits, firstmate resolves `default` through the same object-or-array path before falling back to `config/crew-harness`.
 Except for model-qualified Codex incompatibilities, if a selected profile carries an effort value the chosen harness does not accept, `fm-spawn.sh` records the requested `effort=` in task meta for traceability but omits the launch flag, and bootstrap reports the invalid harness/effort pair as a `CREW_DISPATCH` diagnostic when it is visible in the file.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -255,7 +255,7 @@ Both `use` and the optional top-level `default` accept either one profile object
 The single-object form stays fully backward-compatible, and every profile needs `harness`.
 Profile `model` and `effort` fields and rule `why` are optional.
 An omitted model or effort means the selected harness uses its own default for that axis.
-For Codex, `max` is supported only in rule profiles and explicit per-task overrides with model `gpt-5.6-luna`; the top-level `default` cannot select `max`, and lower effort levels remain model-independent in the dispatch validator.
+Codex `max` requires model `gpt-5.6-luna` at launch; in crew dispatch configuration, bootstrap accepts that pair only in rule profiles, while the top-level `default` cannot select `max` and lower effort levels remain model-independent in the validator.
 Every profile array is an implicit quota-aware choice resolved through `quota-array-dispatch`.
 If no dispatch rule fits, firstmate resolves `default` through the same object-or-array path before falling back to `config/crew-harness`.
 Except for model-qualified Codex incompatibilities, if a selected profile carries an effort value the chosen harness does not accept, `fm-spawn.sh` records the requested `effort=` in task meta for traceability but omits the launch flag, and bootstrap reports the invalid harness/effort pair as a `CREW_DISPATCH` diagnostic when it is visible in the file.

--- a/docs/examples/crew-dispatch.json
+++ b/docs/examples/crew-dispatch.json
@@ -19,8 +19,5 @@
       "why": "Use a strong coding profile for big, ambiguous work; resolve the alternatives through quota-array-dispatch."
     }
   ],
-  "default": [
-    { "harness": "codex", "model": "gpt-5.5", "effort": "medium" },
-    { "harness": "pi", "model": "anthropic/claude-sonnet-5", "effort": "medium" }
-  ]
+  "default": { "harness": "codex", "model": "gpt-5.6-luna", "effort": "xhigh" }
 }

--- a/docs/verification/dispatch-auth.md
+++ b/docs/verification/dispatch-auth.md
@@ -114,6 +114,37 @@ No models matching "gpt-9.9-nonexistent"
 
 A listing that reaches the account and returns no row is the authoritative negative that does block a candidate.
 
+## Codex Luna launch profile
+
+Verified 2026-08-02 against codex-cli 0.146.0.
+The live Codex catalog is authoritative for the installed CLI's model and reasoning-effort surface, so no model-qualified execution smoke was necessary.
+
+```sh
+codex --version
+codex debug models | jq '.models[] | select(.slug == "gpt-5.6-luna") | {slug, description, default_reasoning_level, supported_reasoning_levels: [.supported_reasoning_levels[].effort], default_verbosity, context_window}'
+```
+
+```text
+codex-cli 0.146.0
+{
+  "slug": "gpt-5.6-luna",
+  "description": "Fast and affordable agentic coding model.",
+  "default_reasoning_level": "medium",
+  "supported_reasoning_levels": [
+    "low",
+    "medium",
+    "high",
+    "xhigh",
+    "max"
+  ],
+  "default_verbosity": "low",
+  "context_window": 272000
+}
+```
+
+This establishes that a concrete `harness=codex`, `model=gpt-5.6-luna`, `effort=max` dispatch tuple is supported by the current installed Codex surface.
+`bin/fm-spawn.sh` owns the exact conversion from that concrete profile to Codex launch arguments, and `tests/fm-spawn-dispatch-profile.test.sh` owns executable regression coverage for the emitted setting.
+
 ## Credential sources are independent per provider
 
 Verified 2026-07-30 against quota-axi 0.1.16.

--- a/docs/verification/dispatch-auth.md
+++ b/docs/verification/dispatch-auth.md
@@ -143,6 +143,7 @@ codex-cli 0.146.0
 ```
 
 This establishes that a concrete `harness=codex`, `model=gpt-5.6-luna`, `effort=max` dispatch tuple is supported by the current installed Codex surface.
+Firstmate therefore accepts Codex `max` only with this model, while the generic effort fallback never selects `max` on its own.
 `bin/fm-spawn.sh` owns the exact conversion from that concrete profile to Codex launch arguments, and `tests/fm-spawn-dispatch-profile.test.sh` owns executable regression coverage for the emitted setting.
 
 ## Credential sources are independent per provider

--- a/docs/verification/dispatch-auth.md
+++ b/docs/verification/dispatch-auth.md
@@ -143,7 +143,7 @@ codex-cli 0.146.0
 ```
 
 This establishes that a concrete `harness=codex`, `model=gpt-5.6-luna`, `effort=max` dispatch tuple is supported by the current installed Codex surface.
-Firstmate therefore accepts Codex `max` only with this model, while the generic effort fallback never selects `max` on its own.
+[`docs/configuration.md`](../configuration.md#crew-dispatch-profiles-configcrew-dispatchjson) owns the operator acceptance constraints for that tuple, including the standing-default prohibition.
 `bin/fm-spawn.sh` owns the exact conversion from that concrete profile to Codex launch arguments, and `tests/fm-spawn-dispatch-profile.test.sh` owns executable regression coverage for the emitted setting.
 
 ## Credential sources are independent per provider

--- a/tests/fm-bootstrap.test.sh
+++ b/tests/fm-bootstrap.test.sh
@@ -807,6 +807,8 @@ test_crew_dispatch_validation() {
 malformed dispatch config is flagged^{"rules":[^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - malformed JSON
 unverified dispatch harness is flagged^{"rules":[{"when":"anything","use":{"harness":"spaceship"}}],"default":{"harness":"codex"}}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - unverified harness: spaceship
 codex luna xhigh single-object default is accepted^{"default":{"harness":"codex","model":"gpt-5.6-luna","effort":"xhigh"}}^empty^
+unsupported codex max for gpt-5.5 is flagged^{"rules":[{"when":"big feature","use":{"harness":"codex","model":"gpt-5.5","effort":"max"}}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - invalid effort: codex:max
+unsupported codex max without model is flagged^{"rules":[{"when":"big feature","use":{"harness":"codex","effort":"max"}}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - invalid effort: codex:max
 unsupported codex ultra effort is flagged^{"rules":[{"when":"big feature","use":{"harness":"codex","model":"gpt-5.6-luna","effort":"ultra"}}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - invalid effort: codex:ultra
 unsupported grok max effort is flagged^{"rules":[{"when":"deep current work","use":{"harness":"grok","model":"grok-4","effort":"max"}}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - invalid effort: grok:max
 unsupported grok xhigh effort is flagged^{"rules":[{"when":"deep current work","use":{"harness":"grok","model":"grok-4","effort":"xhigh"}}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - invalid effort: grok:xhigh

--- a/tests/fm-bootstrap.test.sh
+++ b/tests/fm-bootstrap.test.sh
@@ -806,7 +806,8 @@ test_crew_dispatch_validation() {
   done <<'ROWS'
 malformed dispatch config is flagged^{"rules":[^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - malformed JSON
 unverified dispatch harness is flagged^{"rules":[{"when":"anything","use":{"harness":"spaceship"}}],"default":{"harness":"codex"}}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - unverified harness: spaceship
-unsupported codex max effort is flagged^{"rules":[{"when":"big feature","use":{"harness":"codex","model":"gpt-5","effort":"max"}}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - invalid effort: codex:max
+codex luna max single-object default is accepted^{"default":{"harness":"codex","model":"gpt-5.6-luna","effort":"max"}}^empty^
+unsupported codex ultra effort is flagged^{"rules":[{"when":"big feature","use":{"harness":"codex","model":"gpt-5.6-luna","effort":"ultra"}}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - invalid effort: codex:ultra
 unsupported grok max effort is flagged^{"rules":[{"when":"deep current work","use":{"harness":"grok","model":"grok-4","effort":"max"}}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - invalid effort: grok:max
 unsupported grok xhigh effort is flagged^{"rules":[{"when":"deep current work","use":{"harness":"grok","model":"grok-4","effort":"xhigh"}}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - invalid effort: grok:xhigh
 pi max effort is accepted^{"rules":[{"when":"deep coding","use":{"harness":"pi","model":"openai-codex/gpt-5.6-sol","effort":"max"}}]}^empty^
@@ -823,7 +824,7 @@ empty array use is flagged^{"rules":[{"when":"big feature","use":[]}]}^exact^CRE
 array profile without harness is flagged^{"rules":[{"when":"big feature","use":[{"model":"gpt-5.5"}]}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - each use profile needs harness
 array profile with malformed model is flagged^{"rules":[{"when":"big feature","use":[{"harness":"codex","model":5}]}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - use profile model and effort must be non-empty strings when present
 unknown select is flagged^{"rules":[{"when":"big feature","use":[{"harness":"claude"},{"harness":"codex"}],"select":"mystery"}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - unknown select: mystery
-array profile unsupported effort is flagged^{"rules":[{"when":"big feature","use":[{"harness":"codex","effort":"max"}]}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - invalid effort: codex:max
+array profile codex max effort is accepted^{"rules":[{"when":"big feature","use":[{"harness":"codex","model":"gpt-5.6-luna","effort":"max"}]}]}^empty^
 empty default array is flagged^{"default":[]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - default needs at least one profile
 non-object default array entry is flagged^{"default":["codex"]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - each default profile must be an object
 default array profile without harness is flagged^{"default":[{"model":"gpt-5.5"}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - each default profile needs harness

--- a/tests/fm-bootstrap.test.sh
+++ b/tests/fm-bootstrap.test.sh
@@ -806,7 +806,7 @@ test_crew_dispatch_validation() {
   done <<'ROWS'
 malformed dispatch config is flagged^{"rules":[^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - malformed JSON
 unverified dispatch harness is flagged^{"rules":[{"when":"anything","use":{"harness":"spaceship"}}],"default":{"harness":"codex"}}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - unverified harness: spaceship
-codex luna max single-object default is accepted^{"default":{"harness":"codex","model":"gpt-5.6-luna","effort":"max"}}^empty^
+codex luna xhigh single-object default is accepted^{"default":{"harness":"codex","model":"gpt-5.6-luna","effort":"xhigh"}}^empty^
 unsupported codex ultra effort is flagged^{"rules":[{"when":"big feature","use":{"harness":"codex","model":"gpt-5.6-luna","effort":"ultra"}}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - invalid effort: codex:ultra
 unsupported grok max effort is flagged^{"rules":[{"when":"deep current work","use":{"harness":"grok","model":"grok-4","effort":"max"}}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - invalid effort: grok:max
 unsupported grok xhigh effort is flagged^{"rules":[{"when":"deep current work","use":{"harness":"grok","model":"grok-4","effort":"xhigh"}}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - invalid effort: grok:xhigh

--- a/tests/fm-bootstrap.test.sh
+++ b/tests/fm-bootstrap.test.sh
@@ -807,6 +807,8 @@ test_crew_dispatch_validation() {
 malformed dispatch config is flagged^{"rules":[^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - malformed JSON
 unverified dispatch harness is flagged^{"rules":[{"when":"anything","use":{"harness":"spaceship"}}],"default":{"harness":"codex"}}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - unverified harness: spaceship
 codex luna xhigh single-object default is accepted^{"default":{"harness":"codex","model":"gpt-5.6-luna","effort":"xhigh"}}^empty^
+codex luna max single-object default is flagged^{"default":{"harness":"codex","model":"gpt-5.6-luna","effort":"max"}}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - invalid effort: codex:max
+codex luna max default array entry is flagged^{"default":[{"harness":"claude","effort":"high"},{"harness":"codex","model":"gpt-5.6-luna","effort":"max"}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - invalid effort: codex:max
 unsupported codex max for gpt-5.5 is flagged^{"rules":[{"when":"big feature","use":{"harness":"codex","model":"gpt-5.5","effort":"max"}}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - invalid effort: codex:max
 unsupported codex max without model is flagged^{"rules":[{"when":"big feature","use":{"harness":"codex","effort":"max"}}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - invalid effort: codex:max
 unsupported codex ultra effort is flagged^{"rules":[{"when":"big feature","use":{"harness":"codex","model":"gpt-5.6-luna","effort":"ultra"}}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - invalid effort: codex:ultra

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -414,6 +414,22 @@ test_codex_threads_luna_max_effort() {
   pass "codex receives the Luna model and model_reasoning_effort max profile flags"
 }
 
+test_codex_rejects_max_for_unsupported_model() {
+  local rec id out status
+  id=profile-codex-max-unsupported-z4b
+  rec=$(make_spawn_case profile-codex-max-unsupported codex "$id")
+  read_case_record "$rec"
+
+  out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR" \
+    --model gpt-5.5 --effort max)
+  status=$?
+  expect_code 1 "$status" "codex spawn should reject max for gpt-5.5"
+  assert_contains "$out" "codex effort 'max' requires model 'gpt-5.6-luna'" \
+    "codex spawn did not explain the model-qualified max requirement"
+  assert_absent "$HOME_DIR/state/$id.meta" "unsupported Codex max should be rejected before meta is written"
+  pass "codex rejects max when the selected model does not support it"
+}
+
 test_spawn_rejects_unverified_ultra_effort() {
   local rec id out status
   id=profile-ultra-z4b
@@ -701,6 +717,7 @@ test_active_dispatch_profile_allows_raw_launch_command
 test_claude_threads_model_and_effort
 test_codex_threads_luna_xhigh_effort
 test_codex_threads_luna_max_effort
+test_codex_rejects_max_for_unsupported_model
 test_spawn_rejects_unverified_ultra_effort
 test_grok_threads_model_and_reasoning_effort
 test_grok_omits_invalid_max_reasoning_effort

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -68,7 +68,7 @@ make_spawn_case() {
 
 enable_dispatch_profile() {
   local home=$1
-  printf '%s\n' '{"rules":[{"when":"current events","use":{"harness":"grok","model":"grok-4","effort":"high"}}],"default":{"harness":"codex","model":"gpt-5","effort":"medium"}}' \
+  printf '%s\n' '{"rules":[{"when":"current events","use":{"harness":"grok","model":"grok-4","effort":"high"}}],"default":{"harness":"codex","model":"gpt-5.6-luna","effort":"max"}}' \
     > "$home/config/crew-dispatch.json"
 }
 
@@ -321,15 +321,15 @@ test_active_dispatch_profile_allows_explicit_harness() {
   enable_dispatch_profile "$HOME_DIR"
 
   out=$(run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" \
-    "$id" "$PROJ_DIR" --harness codex --model gpt-5 --effort high)
+    "$id" "$PROJ_DIR" --harness codex --model gpt-5.6-luna --effort max)
   status=$?
   expect_code 0 "$status" "explicit harness should satisfy active dispatch-profile requirement"
   assert_contains "$out" "spawned $id harness=codex" "spawn did not report explicit codex harness"
-  assert_meta_profile "$HOME_DIR/state/$id.meta" codex gpt-5 high
+  assert_meta_profile "$HOME_DIR/state/$id.meta" codex gpt-5.6-luna max
   launch=$(cat "$LAUNCH_LOG")
-  assert_contains "$launch" "codex --model 'gpt-5' -c 'model_reasoning_effort=\"high\"' --dangerously-bypass-approvals-and-sandbox" \
-    "explicit harness launch did not thread model and effort"
-  pass "active crew-dispatch profile allows an explicit resolved harness"
+  assert_contains "$launch" "codex --model 'gpt-5.6-luna' -c 'model_reasoning_effort=\"max\"' --dangerously-bypass-approvals-and-sandbox" \
+    "explicit harness launch did not override the static harness with the resolved Luna max profile"
+  pass "active crew-dispatch profile allows explicit Luna max to override the static harness"
 }
 
 test_active_dispatch_profile_allows_positional_harness() {
@@ -398,21 +398,36 @@ test_codex_threads_model_and_effort() {
   pass "codex receives --model and model_reasoning_effort profile flags"
 }
 
-test_codex_omits_invalid_max_effort() {
+test_codex_threads_luna_max_effort() {
   local rec id out status launch
   id=profile-codex-max-z4
   rec=$(make_spawn_case profile-codex-max codex "$id")
   read_case_record "$rec"
 
-  out=$(run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR" --model gpt-5 --effort max)
+  out=$(run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR" --model gpt-5.6-luna --effort max)
   status=$?
-  expect_code 0 "$status" "codex spawn with unsupported max effort should omit the effort flag"
-  assert_meta_profile "$HOME_DIR/state/$id.meta" codex gpt-5 max
+  expect_code 0 "$status" "codex Luna spawn with max effort should succeed"
+  assert_meta_profile "$HOME_DIR/state/$id.meta" codex gpt-5.6-luna max
   launch=$(cat "$LAUNCH_LOG")
-  assert_contains "$launch" "codex --model 'gpt-5' --dangerously-bypass-approvals-and-sandbox" \
-    "codex launch did not preserve the model flag when max effort was omitted"
-  assert_not_contains "$launch" "model_reasoning_effort" "codex launch must omit unsupported max reasoning effort"
-  pass "codex omits unsupported max effort instead of passing a bad config value"
+  assert_contains "$launch" "codex --model 'gpt-5.6-luna' -c 'model_reasoning_effort=\"max\"' --dangerously-bypass-approvals-and-sandbox" \
+    "codex Luna launch did not thread max reasoning effort config"
+  pass "codex receives the Luna model and model_reasoning_effort max profile flags"
+}
+
+test_spawn_rejects_unverified_ultra_effort() {
+  local rec id out status
+  id=profile-ultra-z4b
+  rec=$(make_spawn_case profile-ultra codex "$id")
+  read_case_record "$rec"
+
+  out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR" \
+    --model gpt-5.6-luna --effort ultra)
+  status=$?
+  expect_code 1 "$status" "spawn should reject effort outside the shared verified vocabulary"
+  assert_contains "$out" "--effort must be one of low, medium, high, xhigh, max" \
+    "spawn did not explain the rejected ultra effort"
+  assert_absent "$HOME_DIR/state/$id.meta" "invalid effort refusal should happen before meta is written"
+  pass "spawn continues to reject unverified ultra effort"
 }
 
 test_grok_threads_model_and_reasoning_effort() {
@@ -685,7 +700,8 @@ test_active_dispatch_profile_allows_positional_harness
 test_active_dispatch_profile_allows_raw_launch_command
 test_claude_threads_model_and_effort
 test_codex_threads_model_and_effort
-test_codex_omits_invalid_max_effort
+test_codex_threads_luna_max_effort
+test_spawn_rejects_unverified_ultra_effort
 test_grok_threads_model_and_reasoning_effort
 test_grok_omits_invalid_max_reasoning_effort
 test_grok_omits_invalid_xhigh_reasoning_effort

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -68,7 +68,7 @@ make_spawn_case() {
 
 enable_dispatch_profile() {
   local home=$1
-  printf '%s\n' '{"rules":[{"when":"current events","use":{"harness":"grok","model":"grok-4","effort":"high"}}],"default":{"harness":"codex","model":"gpt-5.6-luna","effort":"max"}}' \
+  printf '%s\n' '{"rules":[{"when":"current events","use":{"harness":"grok","model":"grok-4","effort":"high"}}],"default":{"harness":"codex","model":"gpt-5.6-luna","effort":"xhigh"}}' \
     > "$home/config/crew-dispatch.json"
 }
 
@@ -329,7 +329,7 @@ test_active_dispatch_profile_allows_explicit_harness() {
   launch=$(cat "$LAUNCH_LOG")
   assert_contains "$launch" "codex --model 'gpt-5.6-luna' -c 'model_reasoning_effort=\"max\"' --dangerously-bypass-approvals-and-sandbox" \
     "explicit harness launch did not override the static harness with the resolved Luna max profile"
-  pass "active crew-dispatch profile allows explicit Luna max to override the static harness"
+  pass "active crew-dispatch profile allows explicit Luna max to override the standing Luna xhigh default"
 }
 
 test_active_dispatch_profile_allows_positional_harness() {
@@ -382,20 +382,20 @@ test_claude_threads_model_and_effort() {
   pass "claude receives --model and --effort profile flags"
 }
 
-test_codex_threads_model_and_effort() {
+test_codex_threads_luna_xhigh_effort() {
   local rec id out status launch
   id=profile-codex-z3
   rec=$(make_spawn_case profile-codex codex "$id")
   read_case_record "$rec"
 
-  out=$(run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR" --model gpt-5 --effort high)
+  out=$(run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR" --model gpt-5.6-luna --effort xhigh)
   status=$?
   expect_code 0 "$status" "codex spawn with profile flags should succeed"
-  assert_meta_profile "$HOME_DIR/state/$id.meta" codex gpt-5 high
+  assert_meta_profile "$HOME_DIR/state/$id.meta" codex gpt-5.6-luna xhigh
   launch=$(cat "$LAUNCH_LOG")
-  assert_contains "$launch" "codex --model 'gpt-5' -c 'model_reasoning_effort=\"high\"' --dangerously-bypass-approvals-and-sandbox" \
-    "codex launch did not thread model and reasoning effort config"
-  pass "codex receives --model and model_reasoning_effort profile flags"
+  assert_contains "$launch" "codex --model 'gpt-5.6-luna' -c 'model_reasoning_effort=\"xhigh\"' --dangerously-bypass-approvals-and-sandbox" \
+    "codex Luna launch did not thread the standing xhigh reasoning effort config"
+  pass "codex receives the Luna model and standing model_reasoning_effort xhigh profile flags"
 }
 
 test_codex_threads_luna_max_effort() {
@@ -699,7 +699,7 @@ test_active_dispatch_profile_allows_explicit_harness
 test_active_dispatch_profile_allows_positional_harness
 test_active_dispatch_profile_allows_raw_launch_command
 test_claude_threads_model_and_effort
-test_codex_threads_model_and_effort
+test_codex_threads_luna_xhigh_effort
 test_codex_threads_luna_max_effort
 test_spawn_rejects_unverified_ultra_effort
 test_grok_threads_model_and_reasoning_effort


### PR DESCRIPTION
## Intent

Update Firstmate’s verified Codex launch-profile support so ordinary Firstmate-spawned workers can use gpt-5.6-luna as the future standing default with xhigh reasoning effort through config/crew-dispatch.json. Keep Codex max support only for explicit per-task or captain overrides when supported: permit max only for explicitly supported gpt-5.6-luna overrides, reject unsupported model/effort pairs such as gpt-5.5/max, and reject max in every standing top-level default profile. Do not make max the standing default and do not add ultra. Ensure the Codex adapter emits model_reasoning_effort for supported efforts, dispatch validation accepts Luna xhigh and preserves explicit Luna max support, the generic fallback never chooses max on its own, and regression coverage protects launch emission, accepted and rejected dispatch configuration, malformed/unsupported effort behavior on other adapters, explicit-harness/profile precedence, supported harness/backend integrations, documentation audience checks, lint, and tests. Use installed Codex 0.146.0 live catalog evidence for gpt-5.6-luna. Do not modify captain-private config/crew-dispatch.json, primary Codex or native agent settings, config/secondmate-harness, or project configuration. The captain authorizes validation fixes, fork push, and draft PR creation; do not merge the PR.

## What Changed

- Emit Codex `model_reasoning_effort` for Luna `xhigh` and `max` profiles, rejecting `max` for unsupported models before launch or metadata creation.
- Allow Luna `xhigh` in standing dispatch defaults while restricting Luna `max` to explicit rule profiles and rejecting `max` in every top-level default.
- Update dispatch documentation, live Codex 0.146.0 catalog evidence, examples, and regression coverage for accepted and rejected profile combinations.

## Risk Assessment

✅ Low: The change is well-bounded and conforms to the intent: Luna xhigh is the documented standing default, Codex max is restricted to explicit Luna profiles and rejected in top-level defaults, and launch validation fails before endpoint or metadata creation for unsupported pairs.

## Testing

No pre-supplied baseline test output was present; focused spawn, bootstrap, and documentation tests passed, live Codex 0.146.0 catalog evidence confirmed Luna’s supported efforts, end-to-end CLI transcripts demonstrated accepted and rejected dispatch behavior, and the worktree finished clean.

<details>
<summary>Evidence: Installed Codex Luna live catalog</summary>

`codex-cli 0.146.0; live gpt-5.6-luna catalog lists low, medium, high, xhigh, and max reasoning levels.`

```text
codex-cli 0.146.0
{
  "slug": "gpt-5.6-luna",
  "description": "Fast and affordable agentic coding model.",
  "default_reasoning_level": "medium",
  "supported_reasoning_levels": [
    "low",
    "medium",
    "high",
    "xhigh",
    "max"
  ],
  "default_verbosity": "low",
  "context_window": 272000
}
```
</details>
<details>
<summary>Evidence: Firstmate Luna dispatch end-to-end transcript</summary>

`Demonstrates Luna/xhigh and explicit Luna/max launches, emitted model_reasoning_effort, persisted metadata, and rejection of default max, gpt-5.5/max, and ultra.`

```text
PROFILE xhigh
spawn exit: 0
spawn output: warn: no registry at /var/folders/_5/tb9gc96s2yn91g4jx4tmy2rw0000gn/T//fm-luna-evidence.am0xxw/standing-xhigh/home/data/projects.md; defaulting project to no-mistakes off
spawned evidence-luna-xhigh harness=codex kind=ship mode=no-mistakes yolo=off window=firstmate:fm-evidence-luna-xhigh worktree=/var/folders/_5/tb9gc96s2yn91g4jx4tmy2rw0000gn/T//fm-luna-evidence.am0xxw/standing-xhigh/wt
launch command: codex --model 'gpt-5.6-luna' -c 'model_reasoning_effort="xhigh"' --dangerously-bypass-approvals-and-sandbox -c "notify=[\"bash\",\"-c\",\"touch '/private/var/folders/_5/tb9gc96s2yn91g4jx4tmy2rw0000gn/T/fm-luna-evidence.am0xxw/standing-xhigh/home/state/evidence-luna-xhigh.turn-ended'\"]" "$('/Users/kalyanmadanapalli/.no-mistakes/worktrees/2031ab99032e/01KZ22CFGFYWVAJZ147W6Z5RKZ/bin/fm-operational-input.sh' encode launch-brief < '/var/folders/_5/tb9gc96s2yn91g4jx4tmy2rw0000gn/T//fm-luna-evidence.am0xxw/standing-xhigh/home/data/evidence-luna-xhigh/brief.md')"
persisted profile:
harness=codex
model=gpt-5.6-luna
effort=xhigh

PROFILE max
spawn exit: 0
spawn output: warn: no registry at /var/folders/_5/tb9gc96s2yn91g4jx4tmy2rw0000gn/T//fm-luna-evidence.am0xxw/explicit-max/home/data/projects.md; defaulting project to no-mistakes off
spawned evidence-luna-max harness=codex kind=ship mode=no-mistakes yolo=off window=firstmate:fm-evidence-luna-max worktree=/var/folders/_5/tb9gc96s2yn91g4jx4tmy2rw0000gn/T//fm-luna-evidence.am0xxw/explicit-max/wt
launch command: codex --model 'gpt-5.6-luna' -c 'model_reasoning_effort="max"' --dangerously-bypass-approvals-and-sandbox -c "notify=[\"bash\",\"-c\",\"touch '/private/var/folders/_5/tb9gc96s2yn91g4jx4tmy2rw0000gn/T/fm-luna-evidence.am0xxw/explicit-max/home/state/evidence-luna-max.turn-ended'\"]" "$('/Users/kalyanmadanapalli/.no-mistakes/worktrees/2031ab99032e/01KZ22CFGFYWVAJZ147W6Z5RKZ/bin/fm-operational-input.sh' encode launch-brief < '/var/folders/_5/tb9gc96s2yn91g4jx4tmy2rw0000gn/T//fm-luna-evidence.am0xxw/explicit-max/home/data/evidence-luna-max/brief.md')"
persisted profile:
harness=codex
model=gpt-5.6-luna
effort=max

UNSUPPORTED PROFILE gpt-5.5/max
spawn exit: 1
spawn output: error: codex effort 'max' requires model 'gpt-5.6-luna'
metadata written: no

DEFAULT Luna/xhigh
BOOTSTRAP_INFO: crew dispatch active config/crew-dispatch.json
BOOTSTRAP_INFO: crew dispatch default: codex/gpt-5.6-luna/xhigh

DEFAULT Luna/max
CREW_DISPATCH: invalid config/crew-dispatch.json - invalid effort: codex:max

RULE Luna/max explicit override
BOOTSTRAP_INFO: crew dispatch active config/crew-dispatch.json
BOOTSTRAP_INFO: crew dispatch rule: captain requests maximum effort -> codex/gpt-5.6-luna/max

RULE gpt-5.5/max unsupported
CREW_DISPATCH: invalid config/crew-dispatch.json - invalid effort: codex:max

RULE Luna/ultra unsupported
CREW_DISPATCH: invalid config/crew-dispatch.json - invalid effort: codex:ultra
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bash tests/fm-spawn-dispatch-profile.test.sh`
- `bash tests/fm-bootstrap.test.sh`
- `bash tests/fm-documentation-audiences.test.sh`
- `codex --version`
- `codex debug models | jq '.models[] | select(.slug == "gpt-5.6-luna") | …'`
- <code>Isolated fake-tmux `bin/fm-spawn.sh` E2E for Luna/xhigh, explicit Luna/max, and rejected gpt-5.5/max</code>
- <code>Detect-only verbose `bin/fm-bootstrap.sh` checks for Luna/xhigh default, Luna/max default/rule, gpt-5.5/max, and Luna/ultra</code>
- <code>`git status --short` final cleanliness check</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 127)

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
