### PR TITLE
test(turnend-guard): cover Codex checkpoint foreground-only health boundary

### DIFF
--- a/docs/supervision-protocols/codex.md
+++ b/docs/supervision-protocols/codex.md
@@ -5,7 +5,7 @@ When this session owns supervision and away mode is not active:
 2. Source `__FM_X_MODE_ENV__` first when X mode is active.
 3. First cycle: run one foreground watcher checkpoint with `bin/fm-watch-checkpoint.sh --seconds "${FM_CODEX_WATCH_CHECKPOINT:-180}"`.
 4. Ordinary wake: if the command prints `signal:`, `stale:`, `check:`, or `heartbeat`, drain queued wakes, handle that wake, then start the next checkpoint.
-5. If the command prints `checkpoint:` or exits 124 with no wake, drain queued wakes anyway, process any queued user message now visible to Codex, then start the next checkpoint.
+5. If the command prints `checkpoint:` or exits 124 with no wake, drain queued wakes anyway, process any queued user message now visible to Codex, then start the next checkpoint. A checkpoint proves watcher health only while its foreground command still owns the watcher lock; after it returns, the Stop guard correctly blocks an in-flight primary from ending blind until the next checkpoint is running.
 6. Never use shell `&` or Codex background tasks for firstmate watcher supervision.
 7. Do not run `bin/fm-watch-arm.sh` as Codex's normal supervision command.
    If it is ever shelled anyway, a backgrounded, piped, or bundled anti-pattern is denied automatically by the PreToolUse seatbelt (`bin/fm-arm-pretool-check.sh`) registered in `.codex/hooks.json`.

--- a/docs/turnend-guard.md
+++ b/docs/turnend-guard.md
@@ -90,7 +90,7 @@ That warning uses `bin/fm-supervision-instructions.sh --repair-line`, so it alwa
 
 ## Regression coverage
 
-`tests/fm-turnend-guard.test.sh` covers the predicate, main and secondmate primary scope, child-worktree exclusion, `FM_HOME` and `FM_STATE_OVERRIDE` precedence, the cooperative `--claude` claim wait, epoch allow, re-block budget, Pi logical-run latching, missing-`jq` behavior, all five primary registrations, Grok native and legacy selection, typed field precedence, malformed input, and exactly-one-path safety.
+`tests/fm-turnend-guard.test.sh` covers the predicate, main and secondmate primary scope, child-worktree exclusion, `FM_HOME` and `FM_STATE_OVERRIDE` precedence, the cooperative `--claude` claim wait, epoch allow, re-block budget, Pi logical-run latching, missing-`jq` behavior, all five primary registrations, the Codex checkpoint's foreground-only health boundary, Grok native and legacy selection, typed field precedence, malformed input, and exactly-one-path safety.
 `tests/fm-kimi-harness.test.sh` covers the separate Kimi crew hook's format preservation, idempotence, refusal cases, token guard, spawn registration, and teardown cleanup.
 `tests/fm-supervision-instructions.test.sh` covers recovery-line ownership and pi-signed's identity-preserving reuse of Pi's protocol.
 `FM_PI_LIVE_E2E=1 tests/fm-pi-primary-live-e2e.test.sh` is the opt-in isolated Pi path.

--- a/tests/fm-turnend-guard.test.sh
+++ b/tests/fm-turnend-guard.test.sh
@@ -288,7 +288,7 @@ test_hook_silent_with_live_lock_and_fresh_beacon() {
 # while the checkpoint holds its lock, then block after the bounded checkpoint
 # exits. A recently completed checkpoint is deliberately not health evidence.
 test_codex_checkpoint_health_ends_when_foreground_command_returns() {
-  local dir checkpoint_pid attempt live_out live_status after_out after_status checkpoint_status
+  local dir checkpoint_pid live_out live_status after_out after_status checkpoint_status
   dir="$TMP_ROOT/hook-codex-checkpoint"
   git clone -q "$ROOT" "$dir" || fail "could not create isolated Codex checkpoint fixture"
   dir=$(cd "$dir" && pwd -P)
@@ -298,7 +298,7 @@ test_codex_checkpoint_health_ends_when_foreground_command_returns() {
   FM_HOME="$dir" FM_POLL=1 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=999999 \
     "$dir/bin/fm-watch-checkpoint.sh" --seconds 3 >"$dir/checkpoint.out" 2>"$dir/checkpoint.err" &
   checkpoint_pid=$!
-  for attempt in $(seq 1 30); do
+  for _ in $(seq 1 30); do
     [ -s "$dir/state/.watch.lock/pid" ] && [ -e "$dir/state/.last-watcher-beat" ] && break
     sleep 0.1
   done

--- a/tests/fm-turnend-guard.test.sh
+++ b/tests/fm-turnend-guard.test.sh
@@ -283,6 +283,45 @@ test_hook_silent_with_live_lock_and_fresh_beacon() {
   pass "fm-turnend-guard: silent no-op with a live watcher lock and fresh beacon"
 }
 
+# A Codex checkpoint owns the watcher only for the lifetime of its foreground
+# command. This is the real lifecycle boundary: the guard must allow a Stop
+# while the checkpoint holds its lock, then block after the bounded checkpoint
+# exits. A recently completed checkpoint is deliberately not health evidence.
+test_codex_checkpoint_health_ends_when_foreground_command_returns() {
+  local dir checkpoint_pid attempt live_out live_status after_out after_status checkpoint_status
+  dir="$TMP_ROOT/hook-codex-checkpoint"
+  git clone -q "$ROOT" "$dir" || fail "could not create isolated Codex checkpoint fixture"
+  dir=$(cd "$dir" && pwd -P)
+  mkdir -p "$dir/state" "$dir/config"
+  : > "$dir/state/task1.meta"
+
+  FM_HOME="$dir" FM_POLL=1 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=999999 \
+    "$dir/bin/fm-watch-checkpoint.sh" --seconds 3 >"$dir/checkpoint.out" 2>"$dir/checkpoint.err" &
+  checkpoint_pid=$!
+  for attempt in $(seq 1 30); do
+    [ -s "$dir/state/.watch.lock/pid" ] && [ -e "$dir/state/.last-watcher-beat" ] && break
+    sleep 0.1
+  done
+  [ -s "$dir/state/.watch.lock/pid" ] && [ -e "$dir/state/.last-watcher-beat" ] || {
+    kill "$checkpoint_pid" 2>/dev/null || true
+    wait "$checkpoint_pid" 2>/dev/null || true
+    fail "foreground checkpoint never became watcher-healthy"
+  }
+
+  live_out=$(run_hook "$dir" false); live_status=$?
+  expect_code 0 "$live_status" "active Codex checkpoint must make the guard allow Stop"
+  [ -z "$live_out" ] || fail "active Codex checkpoint produced guard output: $live_out"
+
+  wait "$checkpoint_pid"; checkpoint_status=$?
+  expect_code 124 "$checkpoint_status" "quiet Codex checkpoint must reach its bounded timeout"
+  assert_absent "$dir/state/.watch.lock/pid" "checkpoint timeout left a watcher lock behind"
+
+  after_out=$(run_hook "$dir" false); after_status=$?
+  expect_code 2 "$after_status" "completed checkpoint must not let an in-flight primary Stop blind"
+  assert_contains "$after_out" "TURN WOULD END BLIND" "post-checkpoint guard must explain the missing live watcher"
+  pass "fm-turnend-guard: Codex checkpoint is healthy only while its foreground command is live"
+}
+
 test_hook_blocks_with_live_lock_and_stale_beacon() {
   local dir pid identity out status
   dir=$(make_primary_dir "$TMP_ROOT/hook-live-lock-stale")
@@ -1135,6 +1174,7 @@ test_hook_blocks_when_fresh_beacon_has_no_live_lock
 test_hook_blocks_source_only_home
 test_hook_blocks_when_dead_lock_has_fresh_beacon
 test_hook_silent_with_live_lock_and_fresh_beacon
+test_codex_checkpoint_health_ends_when_foreground_command_returns
 test_hook_blocks_with_live_lock_and_stale_beacon
 test_hook_blocks_when_unhealthy_in_primary
 test_hook_blocks_from_fm_home_state


### PR DESCRIPTION
## Intent

Prevent Codex Stop hooks from falsely reporting blind supervision while a foreground checkpoint is actually active, without weakening the guard after a checkpoint ends or when work is truly unsupervised. The committed change adds an isolated lifecycle regression that proves an active healthy checkpoint permits the Stop hook and a timed-out checkpoint re-blocks an in-flight primary, plus protocol documentation that makes the boundary explicit. Validate, push, open a PR, and stop when CI is green; do not merge.

## What Changed

- Added `test_codex_checkpoint_health_ends_when_foreground_command_returns` to `tests/fm-turnend-guard.test.sh`, an isolated-clone regression proving `fm-watch-checkpoint.sh` makes the Stop guard permissive while its foreground command holds the watcher lock, and that the guard re-blocks an in-flight primary once the checkpoint times out and the lock is released.
- Updated `docs/turnend-guard.md`'s regression coverage list to mention the new Codex checkpoint foreground-only health boundary test.
- Clarified `docs/supervision-protocols/codex.md` step 5 to state explicitly that a checkpoint only proves watcher health while its foreground command owns the watcher lock, and that the Stop guard correctly blocks an in-flight primary once it returns, until the next checkpoint starts.

## Risk Assessment

✅ Low: The change is test-and-docs-only (no changes to bin/fm-turnend-guard.sh, bin/fm-watch.sh, or bin/fm-watch-checkpoint.sh); it adds a regression test that exercises real, already-correct lock/beacon lifecycle behavior confirmed by reading the guard and watcher source, and follows an established real-process test pattern already used in tests/fm-watch-checkpoint.test.sh.

## Testing

Ran the targeted test file tests/fm-turnend-guard.test.sh (the only file touched besides docs), which exercises bin/fm-turnend-guard.sh and bin/fm-watch-checkpoint.sh end-to-end via real subprocesses and a live watcher lock/beacon in an isolated git clone; the new test explicitly demonstrates a foreground Codex checkpoint making the Stop hook allow (exit 0, silent) while its lock is live, then re-block (exit 2, 'TURN WOULD END BLIND') once the checkpoint times out and the lock is gone — matching the required intent. All 53 tests passed with no failures, and the worktree remained clean after the run.

<details>
<summary>Evidence: Full test run output for tests/fm-turnend-guard.test.sh</summary>

```text
ok - fm-turnend-guard: Codex checkpoint is healthy only while its foreground command is live
... (53 total, all 'ok')
bash tests/fm-turnend-guard.test.sh 2.83s user 3.60s system 33% cpu 19.194 total
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bash tests/fm-turnend-guard.test.sh (all 53 cases, including the new test_codex_checkpoint_health_ends_when_foreground_command_returns lifecycle regression)`
- `git status --porcelain to confirm no leftover artifacts from the test's isolated clone fixture`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Lint** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ linter found issues (exit code 1)

🔧 Fix: {&#34;summary&#34;: &#34;fix(tests): drop unused loop var in turnend-guard test&#34;}
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
