### PR TITLE
perf: shard portable serial tests across CI runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,8 @@ jobs:
       - run: bin/fm-lint.sh
 
   # Deterministic proof that portable parallel shards + portable serial + Herdr
-  # equal the complete tests/*.test.sh inventory with no missing or duplicates.
+  # equal the complete tests/*.test.sh inventory with no missing or duplicates,
+  # and that the portable serial CI shards partition that serial lane exactly.
   test-coverage:
     name: Test coverage guard
     runs-on: ubuntu-latest
@@ -104,13 +105,22 @@ jobs:
 
   # Required portable serial remainder: watcher, lock, AFK, tmux, daemon,
   # ambiguous, and other stateful tests. Real Herdr stays in tests-herdr.
+  # Split across separate runners so no two of these stateful scripts ever share
+  # a machine: each shard is still strictly serial in itself. Shard membership
+  # and the shard count both belong to bin/fm-test-run.sh, which refuses a lane
+  # whose "ofN" disagrees with it (docs/fm-test-portable-shards.md).
   tests-portable-serial:
-    name: Behavior portable serial
+    name: Behavior portable serial ${{ matrix.shard }}
     runs-on: ubuntu-latest
-    # Measured serial remainder is ~13 min wall without Herdr. Cap is a hang
-    # tripwire above observed p99 script cost and suite wall, not the expected
-    # healthy end (interim 25m full-suite slack reduced after sharding).
-    timeout-minutes: 20
+    # Measured whole remainder is ~19 min of serial work; the balanced shards
+    # are ~4.8 min each. Cap is a hang tripwire with roughly 3x margin, not the
+    # expected healthy end of the lane.
+    timeout-minutes: 15
+    strategy:
+      # Every shard reports so one failure never hides another shard's result.
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4]
     steps:
       - uses: actions/checkout@v6
         with:
@@ -133,18 +143,24 @@ jobs:
           set -eu
           npm install -g tasks-axi
           tasks-axi --version
-      - name: Run portable serial remainder
+      - name: Run portable serial shard ${{ matrix.shard }}
+        env:
+          # job-total rather than a literal, so shrinking or growing the matrix
+          # without matching bin/fm-test-run.sh is refused instead of quietly
+          # leaving a shard of the required lane unrun.
+          FM_SERIAL_LANE: portable-serial-${{ matrix.shard }}of${{ strategy.job-total }}
+          FM_SERIAL_SHARD: ${{ matrix.shard }}
         run: |
           set -eu
           mkdir -p "$RUNNER_TEMP/fm-test"
-          bin/fm-test-run.sh --lane portable-serial \
-            --json "$RUNNER_TEMP/fm-test/fm-test-timing-portable-serial.json"
-      - name: Upload portable serial timing artifact
+          bin/fm-test-run.sh --lane "$FM_SERIAL_LANE" \
+            --json "$RUNNER_TEMP/fm-test/fm-test-timing-portable-serial-${FM_SERIAL_SHARD}.json"
+      - name: Upload portable serial shard ${{ matrix.shard }} timing artifact
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: fm-test-timing-portable-serial
-          path: ${{ runner.temp }}/fm-test/fm-test-timing-portable-serial.json
+          name: fm-test-timing-portable-serial-${{ matrix.shard }}
+          path: ${{ runner.temp }}/fm-test/fm-test-timing-portable-serial-${{ matrix.shard }}.json
           if-no-files-found: warn
 
   # Required real-Herdr lane: pinned install, serial real-herdr-gated family,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,7 +78,8 @@ bin/fm-test-run.sh --family pure-contract-unit   # ordinary family-scoped local 
 bin/fm-test-run.sh --changed   # conservative changed-file-informed set (never silent full suite)
 bin/fm-test-run.sh --proven-isolated --jobs 4   # explicit local parallel of the proven set only (default is serial)
 bin/fm-test-run.sh --lane portable-serial   # portable serial remainder (watcher/AFK/tmux/stateful)
-bin/fm-test-run.sh --check-coverage   # prove portable shards + serial + Herdr equal the full inventory
+bin/fm-test-run.sh --lane portable-serial-1of4   # reproduce one CI serial shard (see --list-lanes for the current count)
+bin/fm-test-run.sh --check-coverage   # prove portable shards + serial + serial shards + Herdr equal the full inventory
 bin/fm-test-run.sh --all   # deliberate complete regression (optional local full walk; not no-mistakes Test)
 bin/fm-test-isolation-proof.sh --list   # proven parallel candidate set (Phase 2 owner)
 bin/fm-test-isolation-proof.sh --jobs 4 --json /tmp/fm-isolation-proof.json   # re-run concurrent isolation proof only
@@ -93,7 +94,7 @@ Its header and `--help` own the flags, family labels, lanes, and changed-file ma
 Portable shard balance evidence lives in `docs/fm-test-portable-shards.md`.
 Local no-mistakes Test stays intent-targeted and must not wire `commands.test` to `--all` or a `tests/*.test.sh` walk.
 Family selection is the ordinary local path; `--all` is deliberate full regression only.
-CI owns broad regression across required portable parallel shards, the portable serial lane, the Herdr lane, lint, invariants, the coverage guard, and stock macOS Bash compatibility in [`.github/workflows/ci.yml`](.github/workflows/ci.yml).
+CI owns broad regression across required portable parallel shards, the portable serial lane's separate-runner shards, the Herdr lane, lint, invariants, the coverage guard, and stock macOS Bash compatibility in [`.github/workflows/ci.yml`](.github/workflows/ci.yml).
 Use `bin/fm-test-run.sh --help` for lane names, `--jobs` rules, and required gate-skip flags when reproducing a lane locally.
 Discover tests by listing `tests/*.test.sh`: each is a self-contained bash script named `<subject>.test.sh`, and its header comment describes what it covers, so pass one to `bin/fm-test-run.sh` to focus on a subject with canonical timing output.
 Tests that need a real optional backend or an explicit opt-in (real herdr/zellij/cmux smoke tests, the live Pi regression) skip themselves and print the tool or environment gate needed to enable them, so the portable suite remains safe on machines without those tools.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,7 +78,7 @@ bin/fm-test-run.sh --family pure-contract-unit   # ordinary family-scoped local 
 bin/fm-test-run.sh --changed   # conservative changed-file-informed set (never silent full suite)
 bin/fm-test-run.sh --proven-isolated --jobs 4   # explicit local parallel of the proven set only (default is serial)
 bin/fm-test-run.sh --lane portable-serial   # portable serial remainder (watcher/AFK/tmux/stateful)
-bin/fm-test-run.sh --lane portable-serial-1of4   # reproduce one CI serial shard (see --list-lanes for the current count)
+bin/fm-test-run.sh --list-lanes   # discover exact lane names, including the current CI serial shards
 bin/fm-test-run.sh --check-coverage   # prove portable shards + serial + serial shards + Herdr equal the full inventory
 bin/fm-test-run.sh --all   # deliberate complete regression (optional local full walk; not no-mistakes Test)
 bin/fm-test-isolation-proof.sh --list   # proven parallel candidate set (Phase 2 owner)
@@ -95,7 +95,7 @@ Portable shard balance evidence lives in `docs/fm-test-portable-shards.md`.
 Local no-mistakes Test stays intent-targeted and must not wire `commands.test` to `--all` or a `tests/*.test.sh` walk.
 Family selection is the ordinary local path; `--all` is deliberate full regression only.
 CI owns broad regression across required portable parallel shards, the portable serial lane's separate-runner shards, the Herdr lane, lint, invariants, the coverage guard, and stock macOS Bash compatibility in [`.github/workflows/ci.yml`](.github/workflows/ci.yml).
-Use `bin/fm-test-run.sh --help` for lane names, `--jobs` rules, and required gate-skip flags when reproducing a lane locally.
+Use `bin/fm-test-run.sh --list-lanes` for exact lane names and `--help` for `--jobs` rules and required gate-skip flags when reproducing a lane locally.
 Discover tests by listing `tests/*.test.sh`: each is a self-contained bash script named `<subject>.test.sh`, and its header comment describes what it covers, so pass one to `bin/fm-test-run.sh` to focus on a subject with canonical timing output.
 Tests that need a real optional backend or an explicit opt-in (real herdr/zellij/cmux smoke tests, the live Pi regression) skip themselves and print the tool or environment gate needed to enable them, so the portable suite remains safe on machines without those tools.
 The [Herdr backend guide](docs/herdr-backend.md#destructive-lab-safety) owns the lane's isolation boundary, while [runtime backend verification](docs/verification/runtime-backends.md#herdr) owns active empirical evidence; live harness credential tests remain opt-in.

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -9,6 +9,7 @@
 #   fm-test-run.sh --family <name>
 #   fm-test-run.sh --changed [--base <git-ref>]
 #   fm-test-run.sh --lane portable-parallel-1|portable-parallel-2|portable-serial
+#   fm-test-run.sh --lane portable-serial-<k>of<n>   (one CI serial shard)
 #   fm-test-run.sh --proven-isolated
 #   fm-test-run.sh tests/<name>.test.sh [more scripts...]
 #
@@ -60,6 +61,11 @@
 # live in this script only (one owner). The proven-isolated candidate set remains
 # owned by bin/fm-test-isolation-proof.sh; portable parallel shards are a
 # duration-balanced partition of that exact set (see docs/fm-test-portable-shards.md).
+#
+# portable-serial stays strictly serial. Its CI shards (portable-serial-<k>of<n>)
+# split it across separate runners, so two of its stateful scripts still never
+# share a machine. This script owns <n>: a lane whose <n> disagrees with the
+# configured shard count is refused, so a CI matrix cannot silently drop a shard.
 # --changed is conservative: it over-selects related families rather than
 # under-selecting, and never expands to the complete suite unless --all.
 set -eu
@@ -82,6 +88,15 @@ EXCLUDE_FAMILIES=()
 FAIL_ON_GATE_SKIP=
 JOBS=1
 JOBS_MAX=8
+
+# How many separate-runner shards the portable serial remainder splits into.
+# One owner: CI lane names carry this count and are refused when they disagree.
+PORTABLE_SERIAL_SHARDS=4
+
+# Balance hint for a portable-serial script with no measured duration, close to
+# the measured per-script mean so a newly added test neither starves nor
+# overloads the shard it lands in.
+PORTABLE_SERIAL_DEFAULT_WEIGHT_MS=20000
 
 usage() {
   awk '
@@ -223,12 +238,16 @@ EOF
 }
 
 list_known_lanes() {
-  cat <<'EOF'
-portable-parallel-1
-portable-parallel-2
-portable-serial
-real-herdr-gated
-EOF
+  local i
+  printf '%s\n' portable-parallel-1
+  printf '%s\n' portable-parallel-2
+  printf '%s\n' portable-serial
+  i=1
+  while [ "$i" -le "$PORTABLE_SERIAL_SHARDS" ]; do
+    printf 'portable-serial-%sof%s\n' "$i" "$PORTABLE_SERIAL_SHARDS"
+    i=$((i + 1))
+  done
+  printf '%s\n' real-herdr-gated
 }
 
 # Exact proven-isolated candidate set (same paths as
@@ -309,6 +328,178 @@ is_proven_isolated_script() {
   return 1
 }
 
+# The portable serial remainder: every tests/*.test.sh that is neither
+# proven-isolated nor real-herdr-gated. Watcher, lock, AFK, real tmux, daemon,
+# secondmate lifecycle, bootstrap, live-harness opt-in, GUI-backend, and other
+# unproven work stays here. Derived rather than enumerated so a newly added test
+# lands here by default instead of falling out of every lane.
+list_portable_serial() {
+  local s base fam
+  while IFS= read -r s; do
+    [ -n "$s" ] || continue
+    base=$(basename "$s")
+    fam=$(family_for_basename "$base")
+    if [ "$fam" = "real-herdr-gated" ]; then
+      continue
+    fi
+    if is_proven_isolated_script "$s"; then
+      continue
+    fi
+    printf '%s\n' "$s"
+  done < <(all_repo_tests)
+}
+
+# Measured portable-serial script durations in milliseconds, from the CI timing
+# artifact recorded in docs/fm-test-portable-shards.md. These are balance hints
+# only: the shard partition stays complete and disjoint whatever they say, so a
+# stale hint costs balance rather than coverage. That doc owns the refresh
+# procedure.
+portable_serial_weight_hints() {
+  cat <<'EOF'
+tests/fm-afk-inject-e2e.test.sh 34019
+tests/fm-afk-pi-herdr-return-e2e.test.sh 42
+tests/fm-afk-return.test.sh 1105
+tests/fm-ask-user-authority.test.sh 68
+tests/fm-backend-cmux-smoke.test.sh 29
+tests/fm-backend-cmux.test.sh 2349
+tests/fm-backend-herdr-focus-flash-e2e.test.sh 21
+tests/fm-backend-orca.test.sh 12041
+tests/fm-backend-tmux-smoke.test.sh 314
+tests/fm-backend-zellij-smoke.test.sh 21
+tests/fm-backend-zellij.test.sh 4225
+tests/fm-backend.test.sh 16370
+tests/fm-backlog-handoff.test.sh 2786
+tests/fm-bearings-snapshot.test.sh 60103
+tests/fm-bootstrap.test.sh 21912
+tests/fm-busy-adapter-wiring.test.sh 13962
+tests/fm-busy-state.test.sh 607
+tests/fm-calm-pi-extension.test.sh 203
+tests/fm-claude-stop-autoarm-live-e2e.test.sh 19
+tests/fm-claude-stop-autoarm.test.sh 60521
+tests/fm-codex-continuity-live-e2e.test.sh 19
+tests/fm-daemon.test.sh 15140
+tests/fm-documentation-audiences.test.sh 572
+tests/fm-fleet-snapshot-view.test.sh 5902
+tests/fm-fleet-sync.test.sh 16417
+tests/fm-gate-refuse.test.sh 2839
+tests/fm-gitignore-config.test.sh 28
+tests/fm-gotmp.test.sh 308
+tests/fm-grok-continuity-live-e2e.test.sh 19
+tests/fm-grok-stop-live-e2e.test.sh 19
+tests/fm-guard-stale-banner.test.sh 2917
+tests/fm-herdr-session-cleanup.test.sh 4802
+tests/fm-kimi-harness.test.sh 12590
+tests/fm-opencode-primary-live-e2e.test.sh 18
+tests/fm-operational-input.test.sh 184
+tests/fm-pending-reply.test.sh 7328
+tests/fm-pi-primary-live-e2e.test.sh 19
+tests/fm-pi-watch-extension.test.sh 16386
+tests/fm-pr-check-security.test.sh 199573
+tests/fm-procevent.test.sh 42789
+tests/fm-public-followup.test.sh 23365
+tests/fm-quota-array-dispatch-live-e2e.test.sh 19
+tests/fm-secondmate-harness.test.sh 87895
+tests/fm-secondmate-lifecycle-e2e.test.sh 4929
+tests/fm-secondmate-liveness.test.sh 12553
+tests/fm-secondmate-safety.test.sh 24432
+tests/fm-secondmate-sync.test.sh 12289
+tests/fm-send-secondmate-marker-herdr-e2e.test.sh 27
+tests/fm-send-secondmate-marker.test.sh 2136
+tests/fm-session-start.test.sh 37289
+tests/fm-sessionstart-nudge.test.sh 264
+tests/fm-shared-captain-inheritance.test.sh 3506
+tests/fm-spawn-dispatch-profile.test.sh 41351
+tests/fm-spawn-worktree-settle.test.sh 4598
+tests/fm-startup-memory-budget.test.sh 4260
+tests/fm-subagent-pretool-check.test.sh 901
+tests/fm-supervision-events.test.sh 413
+tests/fm-tangle-guard.test.sh 7230
+tests/fm-teardown-endpoint-safety.test.sh 1073
+tests/fm-teardown.test.sh 23237
+tests/fm-test-isolation-proof.test.sh 326
+tests/fm-turnend-guard.test.sh 5986
+tests/fm-update.test.sh 1894
+tests/fm-vendor-auth-probe.test.sh 42796
+tests/fm-wake-daemon-lifecycle-e2e.test.sh 4284
+tests/fm-wake-queue.test.sh 22787
+tests/fm-watch-checkpoint.test.sh 3943
+tests/fm-watch-triage.test.sh 113051
+tests/fm-watcher-lock.test.sh 98342
+EOF
+}
+
+portable_serial_weight_for() {
+  local want=$1 path ms
+  while read -r path ms; do
+    if [ "$path" = "$want" ]; then
+      printf '%s\n' "$ms"
+      return 0
+    fi
+  done < <(portable_serial_weight_hints)
+  printf '%s\n' "$PORTABLE_SERIAL_DEFAULT_WEIGHT_MS"
+}
+
+# Longest-processing-time assignment of the serial remainder to
+# PORTABLE_SERIAL_SHARDS bins, printing "<shard>\t<script>" for every script.
+# Deterministic: candidates are ordered by hint descending then path, and ties
+# between equally loaded bins always take the lowest bin index.
+portable_serial_assignments() {
+  local ms script i best best_load
+  local -a loads=()
+  i=1
+  while [ "$i" -le "$PORTABLE_SERIAL_SHARDS" ]; do
+    loads[i]=0
+    i=$((i + 1))
+  done
+  while IFS=$'\t' read -r ms script; do
+    [ -n "$script" ] || continue
+    best=1
+    best_load=${loads[1]}
+    i=2
+    while [ "$i" -le "$PORTABLE_SERIAL_SHARDS" ]; do
+      if [ "${loads[i]}" -lt "$best_load" ]; then
+        best_load=${loads[i]}
+        best=$i
+      fi
+      i=$((i + 1))
+    done
+    loads[best]=$((best_load + ms))
+    printf '%s\t%s\n' "$best" "$script"
+  done < <(
+    while IFS= read -r script; do
+      [ -n "$script" ] || continue
+      printf '%s\t%s\n' "$(portable_serial_weight_for "$script")" "$script"
+    done < <(list_portable_serial) | LC_ALL=C sort -t$'\t' -k1,1nr -k2,2
+  )
+}
+
+# Parse "<k>of<n>" from a portable-serial shard lane and echo <k>, refusing when
+# <n> disagrees with this script's configured count so a CI matrix built for a
+# different shard count fails loudly instead of dropping tests.
+portable_serial_shard_index() {
+  local lane=$1 spec index count
+  spec=${lane#portable-serial-}
+  index=${spec%%of*}
+  count=${spec#*of}
+  case "$spec" in
+    *of*) ;;
+    *) die "unknown lane '$lane' (see --list-lanes)" ;;
+  esac
+  case "$index" in
+    ''|*[!0-9]*) die "unknown lane '$lane' (see --list-lanes)" ;;
+  esac
+  case "$count" in
+    ''|*[!0-9]*) die "unknown lane '$lane' (see --list-lanes)" ;;
+  esac
+  if [ "$count" -ne "$PORTABLE_SERIAL_SHARDS" ]; then
+    die "lane '$lane' asks for $count portable serial shards but this runner is configured for $PORTABLE_SERIAL_SHARDS (see --list-lanes)"
+  fi
+  if [ "$index" -lt 1 ] || [ "$index" -gt "$PORTABLE_SERIAL_SHARDS" ]; then
+    die "lane '$lane' shard index is outside 1..$PORTABLE_SERIAL_SHARDS (see --list-lanes)"
+  fi
+  printf '%s\n' "$index"
+}
+
 select_proven_isolated() {
   local s
   while IFS= read -r s; do
@@ -318,7 +509,7 @@ select_proven_isolated() {
 }
 
 select_lane() {
-  local want=$1 s base fam found=0
+  local want=$1 s shard idx found=0
   case "$want" in
     portable-parallel-1)
       while IFS= read -r s; do
@@ -335,22 +526,22 @@ select_lane() {
       done < <(list_portable_parallel_2)
       ;;
     portable-serial)
-      # Everything in the complete suite that is not proven-isolated and not
-      # real-herdr-gated. Watcher/lock/AFK/tmux/daemon/ambiguous/stateful work
-      # stays here, serial only.
       while IFS= read -r s; do
         [ -n "$s" ] || continue
-        base=$(basename "$s")
-        fam=$(family_for_basename "$base")
-        if [ "$fam" = "real-herdr-gated" ]; then
-          continue
-        fi
-        if is_proven_isolated_script "$s"; then
-          continue
-        fi
         add_script "$s"
         found=1
-      done < <(all_repo_tests)
+      done < <(list_portable_serial)
+      ;;
+    portable-serial-*)
+      # One separate-runner shard of the same remainder, still serial in itself.
+      shard=$(portable_serial_shard_index "$want")
+      while IFS=$'\t' read -r idx s; do
+        [ -n "$s" ] || continue
+        if [ "$idx" = "$shard" ]; then
+          add_script "$s"
+          found=1
+        fi
+      done < <(portable_serial_assignments)
       ;;
     real-herdr-gated)
       select_family real-herdr-gated
@@ -364,7 +555,7 @@ select_lane() {
 }
 
 run_coverage_guard() {
-  local tmp missing extra a b
+  local tmp missing extra a b shard
   local -a saved_scripts=()
   tmp=$(mktemp -d "${TMPDIR:-/tmp}/fm-test-coverage.XXXXXX")
 
@@ -391,15 +582,50 @@ run_coverage_guard() {
     return 1
   fi
 
-  # Serial + Herdr lane listings without disturbing a caller's selection.
+  # Serial (whole lane and each CI shard) + Herdr lane listings without
+  # disturbing a caller's selection.
   saved_scripts=("${SCRIPTS[@]+"${SCRIPTS[@]}"}")
   SCRIPTS=()
   select_lane portable-serial
   printf '%s\n' "${SCRIPTS[@]+"${SCRIPTS[@]}"}" | LC_ALL=C sort -u >"$tmp/serial"
+  : >"$tmp/serial_shards_raw"
+  shard=1
+  while [ "$shard" -le "$PORTABLE_SERIAL_SHARDS" ]; do
+    SCRIPTS=()
+    select_lane "portable-serial-${shard}of${PORTABLE_SERIAL_SHARDS}"
+    if [ "${#SCRIPTS[@]}" -eq 0 ]; then
+      log "coverage guard: portable serial shard $shard of $PORTABLE_SERIAL_SHARDS is empty"
+      SCRIPTS=("${saved_scripts[@]+"${saved_scripts[@]}"}")
+      rm -rf "$tmp"
+      return 1
+    fi
+    printf '%s\n' "${SCRIPTS[@]}" >>"$tmp/serial_shards_raw"
+    shard=$((shard + 1))
+  done
   SCRIPTS=()
   select_family real-herdr-gated
   printf '%s\n' "${SCRIPTS[@]+"${SCRIPTS[@]}"}" | LC_ALL=C sort -u >"$tmp/herdr"
   SCRIPTS=("${saved_scripts[@]+"${saved_scripts[@]}"}")
+
+  # Every serial script runs in exactly one CI shard: no duplicate work across
+  # runners, and no script silently left out of the required lane.
+  LC_ALL=C sort "$tmp/serial_shards_raw" | uniq -d >"$tmp/serial_shard_dups"
+  if [ -s "$tmp/serial_shard_dups" ]; then
+    log "coverage guard: portable serial shards share scripts:"
+    cat "$tmp/serial_shard_dups" >&2
+    rm -rf "$tmp"
+    return 1
+  fi
+  LC_ALL=C sort -u "$tmp/serial_shards_raw" >"$tmp/serial_shards"
+  missing=$(comm -23 "$tmp/serial" "$tmp/serial_shards" || true)
+  extra=$(comm -13 "$tmp/serial" "$tmp/serial_shards" || true)
+  if [ -n "$missing" ] || [ -n "$extra" ]; then
+    log "coverage guard: portable serial shards must equal the portable serial lane"
+    [ -z "$missing" ] || { log "missing from serial shards:"; printf '%s\n' "$missing" >&2; }
+    [ -z "$extra" ] || { log "extra beyond serial lane:"; printf '%s\n' "$extra" >&2; }
+    rm -rf "$tmp"
+    return 1
+  fi
 
   for pair in "shards_union:serial" "shards_union:herdr" "serial:herdr"; do
     a=${pair%%:*}
@@ -442,10 +668,11 @@ run_coverage_guard() {
     fi
   fi
 
-  printf 'FM_TEST_COVERAGE ok total=%s parallel=%s serial=%s herdr=%s\n' \
+  printf 'FM_TEST_COVERAGE ok total=%s parallel=%s serial=%s serial_shards=%s herdr=%s\n' \
     "$(wc -l <"$tmp/all" | tr -d ' ')" \
     "$(wc -l <"$tmp/shards_union" | tr -d ' ')" \
     "$(wc -l <"$tmp/serial" | tr -d ' ')" \
+    "$PORTABLE_SERIAL_SHARDS" \
     "$(wc -l <"$tmp/herdr" | tr -d ' ')"
   rm -rf "$tmp"
   return 0

--- a/docs/fm-test-portable-shards.md
+++ b/docs/fm-test-portable-shards.md
@@ -51,15 +51,49 @@ The two parallel lanes use longest-processing-time assignment from those measure
 
 `portable-serial` includes every `tests/*.test.sh` that is neither proven-isolated nor `real-herdr-gated`.
 It keeps watcher, lock, AFK, real tmux, daemon, secondmate lifecycle, bootstrap, live-harness opt-in, GUI-backend, and other unproven work serial.
+Membership is derived rather than enumerated, so a newly added test lands here by default.
+
+## Portable serial CI shards
+
+Running that remainder as one serial job took about 19 minutes and repeatedly ended at the job timeout.
+`portable-serial-<k>of<n>` splits it across `n` separate CI runners.
+Each shard is still strictly serial in itself, and separate runners mean no two of these stateful scripts ever share a machine, so the split needs no concurrency isolation proof.
+
+`bin/fm-test-run.sh` owns `n` and refuses any lane whose `of<n>` disagrees with it.
+`.github/workflows/ci.yml` derives the same `n` from `strategy.job-total` rather than a literal, so changing the shard count in either file without the other fails the lane loudly instead of leaving part of the required suite unrun.
+
+Assignment is longest-processing-time bin packing over per-script duration hints embedded in `bin/fm-test-run.sh`.
+The hints came from the `fm-test-timing-portable-serial` artifact of CI run [30725985757](https://github.com/kunchenguid/firstmate/actions/runs/30725985757) on 2026-08-02, where the lane ran 69 scripts in 1143762 ms of serial work.
+A script with no hint gets the conservative `PORTABLE_SERIAL_DEFAULT_WEIGHT_MS` default.
+Hints only affect balance: the coverage guard keeps the partition complete and disjoint whatever they say, so a stale hint costs a slower shard rather than lost coverage.
+
+| Lane | Script count | Estimated duration |
+|---|---:|---:|
+| `portable-serial-1of4` | 15 | 285941 ms (~285.9 s) |
+| `portable-serial-2of4` | 18 | 285940 ms (~285.9 s) |
+| `portable-serial-3of4` | 17 | 285941 ms (~285.9 s) |
+| `portable-serial-4of4` | 19 | 285940 ms (~285.9 s) |
+| imbalance | | 1 ms |
+
+The single longest script, `tests/fm-pr-check-security.test.sh` at 199573 ms, is the floor for any shard count.
+
+Refresh the hints by downloading the per-shard timing artifacts from a green CI run, replacing the `portable_serial_weight_hints` table in `bin/fm-test-run.sh` with the measured `path`/`duration_ms` pairs, and updating the table above:
+
+```sh
+gh run download <run-id> -R kunchenguid/firstmate --pattern 'fm-test-timing-portable-serial-*' -D /tmp/fm-serial
+jq -r '.scripts[] | [.path, .duration_ms] | @tsv' /tmp/fm-serial/*.json | LC_ALL=C sort
+bin/fm-test-run.sh --check-coverage
+```
 
 ## Coverage guard
 
 `bin/fm-test-run.sh --check-coverage` verifies that both parallel lanes partition the proven-isolated set.
 It also verifies that the parallel lanes, portable serial lane, and real-Herdr family are disjoint and cover every `tests/*.test.sh` script.
+It separately verifies that the portable serial CI shards are non-empty, disjoint, and together equal the portable serial lane.
 
 ## Timing artifacts
 
-Portable shards, the portable serial lane, and the Herdr lane upload runner-generated timing JSON.
+Portable shards, each portable serial shard, and the Herdr lane upload runner-generated timing JSON.
 `bin/fm-test-run.sh --aggregate-json` creates the combined summary artifact.
 `.github/workflows/ci.yml` owns the exact artifact names and aggregation wiring.
 
@@ -73,7 +107,7 @@ Portable shards, the portable serial lane, and the Herdr lane upload runner-gene
 | Job | timeout-minutes | Rationale |
 |---|---:|---|
 | portable parallel 1/2 | 10 | The measured shard sums are about three minutes and the timeout is a hang tripwire. |
-| portable serial | 20 | The serial remainder needs a larger hang tripwire. |
+| portable serial 1-4 | 15 | Each balanced shard is about five minutes, leaving roughly 3x hang-tripwire margin. |
 | Herdr | 40 | The real-Herdr lane keeps its dedicated timeout. |
 
 Timeouts are hang tripwires rather than expected healthy durations.

--- a/docs/fm-test-portable-shards.md
+++ b/docs/fm-test-portable-shards.md
@@ -69,11 +69,11 @@ Hints only affect balance: the coverage guard keeps the partition complete and d
 
 | Lane | Script count | Estimated duration |
 |---|---:|---:|
-| `portable-serial-1of4` | 15 | 285941 ms (~285.9 s) |
-| `portable-serial-2of4` | 18 | 285940 ms (~285.9 s) |
-| `portable-serial-3of4` | 17 | 285941 ms (~285.9 s) |
-| `portable-serial-4of4` | 19 | 285940 ms (~285.9 s) |
-| imbalance | | 1 ms |
+| `portable-serial-1of4` | 15 | 285945 ms (~285.9 s) |
+| `portable-serial-2of4` | 18 | 285944 ms (~285.9 s) |
+| `portable-serial-3of4` | 17 | 285929 ms (~285.9 s) |
+| `portable-serial-4of4` | 19 | 285944 ms (~285.9 s) |
+| imbalance | | 16 ms |
 
 The single longest script, `tests/fm-pr-check-security.test.sh` at 199573 ms, is the floor for any shard count.
 

--- a/docs/fm-test-portable-shards.md
+++ b/docs/fm-test-portable-shards.md
@@ -55,7 +55,8 @@ Membership is derived rather than enumerated, so a newly added test lands here b
 
 ## Portable serial CI shards
 
-Running that remainder as one serial job took about 19 minutes and repeatedly ended at the job timeout.
+On green CI run [30725985757](https://github.com/kunchenguid/firstmate/actions/runs/30725985757), that remainder accumulated 19m04s of script time against a 20-minute job timeout.
+On [PR 1495](https://github.com/kunchenguid/firstmate/pull/1495), its main step ran about 19m51s before the job was cancelled at that boundary.
 `portable-serial-<k>of<n>` splits it across `n` separate CI runners.
 Each shard is still strictly serial in itself, and separate runners mean no two of these stateful scripts ever share a machine, so the split needs no concurrency isolation proof.
 
@@ -63,7 +64,7 @@ Each shard is still strictly serial in itself, and separate runners mean no two 
 `.github/workflows/ci.yml` derives the same `n` from `strategy.job-total` rather than a literal, so changing the shard count in either file without the other fails the lane loudly instead of leaving part of the required suite unrun.
 
 Assignment is longest-processing-time bin packing over per-script duration hints embedded in `bin/fm-test-run.sh`.
-The hints came from the `fm-test-timing-portable-serial` artifact of CI run [30725985757](https://github.com/kunchenguid/firstmate/actions/runs/30725985757) on 2026-08-02, where the lane ran 69 scripts in 1143762 ms of serial work.
+The hints came from that run's `fm-test-timing-portable-serial` artifact on 2026-08-02, where the lane ran 69 scripts in 1143762 ms of serial work.
 A script with no hint gets the conservative `PORTABLE_SERIAL_DEFAULT_WEIGHT_MS` default.
 Hints only affect balance: the coverage guard keeps the partition complete and disjoint whatever they say, so a stale hint costs a slower shard rather than lost coverage.
 

--- a/tests/fm-test-run.test.sh
+++ b/tests/fm-test-run.test.sh
@@ -386,8 +386,88 @@ test_portable_shard_union_and_coverage_guard() {
   pass "portable shard union, disjointness, and coverage guard hold"
 }
 
+test_portable_serial_shards_partition_the_serial_lane() {
+  local lanes count serial shard listed union dups shard_lane total cap
+  lanes=$("$RUNNER" --list-lanes)
+  count=$(printf '%s\n' "$lanes" | grep -c '^portable-serial-[0-9]*of[0-9]*$')
+  [ "$count" -ge 2 ] || fail "expected at least two portable serial shard lanes, got $count"
+  printf '%s\n' "$lanes" | grep -q "^portable-serial-1of${count}\$" \
+    || fail "shard lane names must carry the shard count ${count}: $lanes"
+
+  serial=$("$RUNNER" --list --lane portable-serial | LC_ALL=C sort)
+  union=""
+  shard=1
+  while [ "$shard" -le "$count" ]; do
+    shard_lane="portable-serial-${shard}of${count}"
+    listed=$("$RUNNER" --list --lane "$shard_lane")
+    [ -n "$listed" ] || fail "$shard_lane selected no tests"
+    union=$(printf '%s\n%s' "$union" "$listed")
+    shard=$((shard + 1))
+  done
+  union=$(printf '%s\n' "$union" | grep -v '^$' || true)
+
+  dups=$(printf '%s\n' "$union" | LC_ALL=C sort | uniq -d || true)
+  [ -z "$dups" ] || fail "portable serial shards run the same script twice: $dups"
+  [ "$(printf '%s\n' "$union" | LC_ALL=C sort)" = "$serial" ] \
+    || fail "portable serial shards must exactly cover the portable serial lane"
+
+  # Every shard carries a real share of the lane, so no degenerate partition
+  # leaves one runner doing nearly all of the work the split exists to spread.
+  total=$(printf '%s\n' "$serial" | wc -l | tr -d ' ')
+  cap=$((total * 6 / 10))
+  shard=1
+  while [ "$shard" -le "$count" ]; do
+    listed=$("$RUNNER" --list --lane "portable-serial-${shard}of${count}" | wc -l | tr -d ' ')
+    [ "$listed" -ge 2 ] \
+      || fail "portable-serial-${shard}of${count} holds only $listed script(s)"
+    [ "$listed" -le "$cap" ] \
+      || fail "portable-serial-${shard}of${count} holds $listed of $total scripts"
+    shard=$((shard + 1))
+  done
+
+  # Assignment is deterministic across invocations.
+  [ "$("$RUNNER" --list --lane "portable-serial-1of${count}")" = \
+    "$("$RUNNER" --list --lane "portable-serial-1of${count}")" ] \
+    || fail "portable serial shard membership must be deterministic"
+  pass "portable serial shards are a deterministic disjoint cover of the serial lane"
+}
+
+test_portable_serial_shard_lane_refusals() {
+  local tmp count rc other
+  tmp=$(mktemp -d "${TMPDIR:-/tmp}/fm-test-run-shard-lane.XXXXXX")
+  count=$("$RUNNER" --list-lanes | grep -c '^portable-serial-[0-9]*of[0-9]*$')
+  other=$((count + 1))
+
+  # A lane built for a different shard count must refuse rather than run a
+  # partial suite: this is what keeps a CI matrix from silently dropping tests.
+  set +e
+  "$RUNNER" --list --lane "portable-serial-1of${other}" >"$tmp/out" 2>"$tmp/err"
+  rc=$?
+  set -e
+  [ "$rc" -eq 2 ] || fail "mismatched shard count must refuse (exit 2), got $rc"
+  [ ! -s "$tmp/out" ] || fail "mismatched shard count must not list tests"
+  grep -Fq "configured for $count" "$tmp/err" \
+    || fail "mismatch refusal must name the configured count: $(cat "$tmp/err")"
+
+  set +e
+  "$RUNNER" --list --lane "portable-serial-$((count + 1))of${count}" >"$tmp/out2" 2>"$tmp/err2"
+  rc=$?
+  set -e
+  [ "$rc" -eq 2 ] || fail "out-of-range shard index must refuse (exit 2), got $rc"
+  grep -Fq "outside 1..$count" "$tmp/err2" \
+    || fail "range refusal message missing: $(cat "$tmp/err2")"
+
+  set +e
+  "$RUNNER" --list --lane portable-serial-1 >"$tmp/out3" 2>"$tmp/err3"
+  rc=$?
+  set -e
+  [ "$rc" -eq 2 ] || fail "shard lane without a count must refuse (exit 2), got $rc"
+  rm -rf "$tmp"
+  pass "portable serial shard lanes refuse mismatched, out-of-range, and countless names"
+}
+
 test_jobs_requires_proven_isolated() {
-  local tmp rc
+  local tmp rc shard_lane
   tmp=$(mktemp -d "${TMPDIR:-/tmp}/fm-test-run-jobs.XXXXXX")
   set +e
   "$RUNNER" --jobs 2 --lane portable-serial >"$tmp/out" 2>"$tmp/err"
@@ -401,6 +481,15 @@ test_jobs_requires_proven_isolated() {
   rc=$?
   set -e
   [ "$rc" -eq 2 ] || fail "--jobs on watcher-lock must refuse, got $rc"
+  # Sharding across runners never relaxes the serial rule inside one shard.
+  shard_lane=$("$RUNNER" --list-lanes | grep -m1 '^portable-serial-[0-9]*of[0-9]*$')
+  set +e
+  "$RUNNER" --jobs 2 --lane "$shard_lane" >"$tmp/out3" 2>"$tmp/err3"
+  rc=$?
+  set -e
+  [ "$rc" -eq 2 ] || fail "--jobs with a portable serial shard must refuse, got $rc"
+  grep -Fq 'not in the proven-isolated set' "$tmp/err3" \
+    || fail "shard --jobs refusal message missing: $(cat "$tmp/err3")"
   rm -rf "$tmp"
   pass "--jobs refuses non-proven / stateful selections"
 }
@@ -430,28 +519,42 @@ if [ "$1" = "-f" ] && [ "$2" = "%Lp" ]; then
 fi
 exit 1
 SH
+  # The slow fixture blocks on the replacement fixture's own signal rather than
+  # a wall-clock sleep, so a loaded machine cannot let it finish first and turn
+  # a correct scheduler into a failure. The bounded deadline is only there so a
+  # scheduler that really does wait for the oldest worker still reports instead
+  # of hanging.
   cat >"$repo/$a" <<'SH'
 #!/usr/bin/env bash
-sleep 0.5
+if [ -n "${SCHED_WAIT_FOR_REPLACEMENT:-}" ]; then
+  waited=0
+  while [ ! -e "$SCHED_EVIDENCE/replacement-started" ] && [ "$waited" -lt 600 ]; do
+    sleep 0.05
+    waited=$((waited + 1))
+  done
+fi
 touch "$SCHED_EVIDENCE/slow-done"
 echo "ok - slow fixture"
 SH
   cat >"$repo/$b" <<'SH'
 #!/usr/bin/env bash
-sleep 0.05
 echo "ok - fast fixture"
 SH
   cat >"$repo/$c" <<'SH'
 #!/usr/bin/env bash
+# Read the evidence before releasing the slow fixture, so the release can never
+# race ahead of the check it is being used to make.
 if [ -e "$SCHED_EVIDENCE/slow-done" ]; then
+  touch "$SCHED_EVIDENCE/replacement-started"
   echo "not ok - scheduler waited for oldest worker"
   exit 1
 fi
+touch "$SCHED_EVIDENCE/replacement-started"
 echo "ok - replacement fixture started before slow fixture finished"
 SH
   chmod +x "$runner" "$repo/$a" "$repo/$b" "$repo/$c" "$fake_bin/stat"
   set +e
-  PATH="$fake_bin:$PATH" SCHED_EVIDENCE="$evidence" \
+  PATH="$fake_bin:$PATH" SCHED_EVIDENCE="$evidence" SCHED_WAIT_FOR_REPLACEMENT=1 \
     "$runner" --jobs 2 --json "$tmp/timing.json" \
     "$a" "$b" "$c" >"$tmp/out" 2>"$tmp/err"
   rc=$?
@@ -579,6 +682,8 @@ test_gate_skip_accounting
 test_fail_on_gate_skip_token
 test_exclude_family
 test_portable_shard_union_and_coverage_guard
+test_portable_serial_shards_partition_the_serial_lane
+test_portable_serial_shard_lane_refusals
 test_jobs_requires_proven_isolated
 test_jobs_parallel_scheduler_and_failure_propagation
 test_aggregate_json


### PR DESCRIPTION
## Intent

Speed up the 'Behavior portable serial' CI job so it completes with a comfortable buffer below its timeout-minutes limit.

Problem: on firstmate PR 1495 the 'Behavior portable serial' CI job was cancelled - not because tests failed (every step passed), but because its main step ('Run portable serial remainder') ran ~19m51s and the job hit its ~20-minute timeout-minutes at the exact boundary. It runs the behavior suite serially, which is too slow, so it intermittently times out and cancels. Same class of issue as the recently merged windows CI slowness fix (no-mistakes PR 645 - branchsync serial floor).

Goal: reduce the serial job's wall time SIGNIFICANTLY so it finishes with a comfortable margin - well under half the timeout, not a few seconds under. Approaches in preference order: parallelize the serial remainder where safe (shard/concurrent execution); keep only genuinely serial-only tests (shared mutable state, ports, global fixtures) in the serial set and move the parallel-safe majority to parallel; speed up the slowest individual tests; trim redundant setup. Preserve full behavioral coverage - never weaken or delete tests to gain speed. Provide concrete before/after wall-time evidence versus the timeout. Widening timeout-minutes is acceptable only as belt-and-suspenders on top of a real speedup, never as the primary fix.

Measured evidence gathered before implementing: on green CI run 30725985757 the lane's 69 scripts summed to 1143762 ms (19m04s) against the 20-minute cap; job setup (checkout, ShellCheck, tmux check, tasks-axi install) is only about 7s, so the cost is entirely test wall time and there is nothing meaningful to trim in setup. The single longest script, tests/fm-pr-check-security.test.sh at 199573 ms, is the hard floor for any shard count.

Chosen approach and the reasoning behind it: shard the portable serial lane across four SEPARATE CI runners rather than introducing concurrency inside one runner. Each shard stays strictly serial in itself. Because separate GitHub jobs get separate machines, no two of these stateful scripts (watcher, lock, AFK, real tmux, daemon, secondmate lifecycle, bootstrap, live-harness opt-in, GUI-backend) ever share a machine, so this split deliberately needs NO concurrency isolation proof - unlike the existing portable parallel lanes, which are restricted to the proven-isolated set owned by bin/fm-test-isolation-proof.sh. Moving serial tests into the proven-isolated parallel set was deliberately NOT done, because that would require a new concurrent isolation proof archive and is the riskier path. Individual test internals were deliberately left untouched to avoid weakening coverage or introducing flakiness; sharding alone reaches the target.

Deliberate design decisions a reviewer would not infer from the diff alone:
- Serial-lane membership stays DERIVED (everything neither proven-isolated nor real-herdr-gated) rather than enumerated, so a newly added test lands in the lane by default instead of falling out of every lane. Shard assignment is computed at runtime by longest-processing-time bin packing, so new tests need no manual shard placement.
- The per-script duration table embedded in bin/fm-test-run.sh is intentionally a BALANCE HINT ONLY, not a correctness input. The coverage guard keeps the partition complete and disjoint whatever the hints say, so a stale hint costs a slower shard rather than lost coverage. Unmeasured scripts get a conservative default near the measured per-script mean. docs/fm-test-portable-shards.md owns the refresh procedure.
- Lane names deliberately carry the shard count (portable-serial-<k>of<n>) and bin/fm-test-run.sh refuses any lane whose ofN disagrees with its configured count. ci.yml deliberately derives the same N from strategy.job-total rather than a literal. This is fail-closed on purpose: changing the shard count in either file alone makes the lane fail loudly instead of silently leaving part of the required suite unrun. The plain-<k> naming was rejected precisely because it has that silent coverage hole.
- timeout-minutes was TIGHTENED from 20 to 15, not widened. Expected work per shard is 285941 ms (~4m46s), about a third of the cap, leaving roughly 3x hang-tripwire margin. Timeouts in this repo are hang tripwires, not expected healthy durations.
- fail-fast: false on the matrix is deliberate so one shard's failure never hides another shard's result.
- --check-coverage was extended to additionally prove the serial shards are non-empty, pairwise disjoint, and exactly equal to the serial lane. No test is weakened, skipped, or removed anywhere in this change.

Also included deliberately, as an engineering-excellence fix for flakiness encountered while validating: tests/fm-test-run.test.sh's --jobs scheduler fixture proved slot-refill behavior with a 0.5s-versus-0.05s wall-clock sleep race, which failed on a loaded machine during this work. It is replaced with an explicit signal handshake between the fixtures (the slow fixture blocks until the replacement fixture signals, and the replacement reads the evidence before signalling), with a bounded deadline so a genuinely wait-for-oldest scheduler still reports instead of hanging. Verified 3/3 under sustained ~20x CPU saturation where the old shape had already flaked.

Local verification already performed: bin/fm-lint.sh clean; bin/fm-doc-audience-check.sh ok; --check-coverage reports FM_TEST_COVERAGE ok total=104 parallel=24 serial=69 serial_shards=4 herdr=11; all four shards balance to 285.9s with 1 ms imbalance; tests/fm-test-run.test.sh, tests/fm-lint.test.sh and tests/fm-documentation-audiences.test.sh pass; portable-serial-1of4 executed end to end with 15/15 green (FM_TEST_SUMMARY total=15 failed=0 skipped_gate=2, exit 0); bin/fm-test-run.sh parses under stock macOS Bash 3.2.

This is firstmate's own shared tracked material (.github/workflows/, bin/, docs/, CONTRIBUTING.md, tests/), so the firstmate-coding-guidelines skill applies: one sentence per line in tracked Markdown, plain dash never em dash, no agent commit co-author, shellcheck-clean bin scripts via bin/fm-lint.sh, tests colocated in tests/ extending the existing runner, tests must exercise executable interfaces rather than assert implementation source text, and every contract stated in full exactly once with cross-references elsewhere. The authoritative before/after wall time will come from this PR's own CI run.

## What Changed

- Split the portable serial behavior lane into four duration-balanced CI jobs that remain serial per runner, disable matrix fail-fast, and tighten the timeout from 20 to 15 minutes.
- Add deterministic longest-processing-time shard assignment, fail-closed shard-count validation, lane discovery, and coverage checks proving the serial shards are non-empty, disjoint, and complete.
- Document shard timing and refresh procedures, and replace the scheduler test's timing race with a bounded signal handshake.

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>
</details>
<details>
<summary>✅ **Rebase** - passed</summary>
</details>
<details>
<summary>✅ **Review** - completed</summary>
</details>
<details>
<summary>✅ **Test** - passed</summary>
</details>
<details>
<summary>✅ **Document** - passed</summary>
</details>
<details>
<summary>✅ **Lint** - passed</summary>
</details>
<details>
<summary>✅ **Push** - passed</summary>
</details>
