### PR TITLE
feat(dispatch): reapply Antigravity quota preflight before spawn

### DIFF
--- a/.agents/skills/project-management/SKILL.md
+++ b/.agents/skills/project-management/SKILL.md
@@ -37,17 +37,18 @@ Do not overwrite or repurpose an existing path.
 
 Choose the delivery mode when adding or creating the project:
 
-- `no-mistakes` runs the full validation pipeline before a PR and is the default when the captain does not specify a mode.
 - `direct-PR` pushes and opens a PR without the no-mistakes pipeline.
+- `no-mistakes` runs the full validation pipeline before a PR.
 - `local-only` has no required remote or PR and lands only through the approved local fast-forward path.
 
-The optional `+yolo` posture changes routine approval authority but does not change the delivery mode.
-Default it off, and enable it only on the captain's explicit instruction.
+When the captain omits the mode, default to `direct-PR +yolo`.
+An explicit mode without `+yolo` keeps routine approval authority off; an explicit `+yolo` enables it without changing delivery mode.
 `AGENTS.md` section 7 owns the complete authority boundary and exceptions when it is on.
 
 ## Add or clone an existing project
 
 Confirm the source URL, local project name, delivery mode, and autonomy posture.
+If the captain omits delivery mode, use `direct-PR +yolo`.
 Clone into `projects/<name>` and add the registry entry only after the destination is known to be unused.
 A `no-mistakes` project must have an `origin` remote and must complete the initialization procedure below.
 A `direct-PR` project needs an `origin` remote but skips no-mistakes initialization.
@@ -56,7 +57,7 @@ A `local-only` project may have no remote and skips no-mistakes initialization.
 ## Create a project
 
 Creating a GitHub repository is outward-facing.
-Before making that remote change, propose the repository name, owner or organization, visibility, and delivery mode, defaulting visibility to private and delivery mode to `no-mistakes`, then obtain the captain's explicit consent for those values.
+Before making that remote change, propose the repository name, owner or organization, visibility, and delivery mode, defaulting visibility to private and delivery mode to `direct-PR +yolo`, then obtain the captain's explicit consent for those values.
 Use `gh-axi` for the approved GitHub operation and consult its current help rather than relying on remembered flags.
 After remote creation succeeds, clone it locally, add the registry entry, and initialize it according to its delivery mode.
 

--- a/.agents/skills/secondmate-provisioning/SKILL.md
+++ b/.agents/skills/secondmate-provisioning/SKILL.md
@@ -24,6 +24,7 @@ Keep the always-inline routing rules in `AGENTS.md` authoritative: route by natu
 ```
 
 Each registry entry stays concise and single-line: the summary is one sentence naming the durable charter, `scope:` is the natural-language intake responsibility, `projects:` is the non-exclusive clone list, and any extra prose is limited to genuinely domain-specific hard rules that change routing or safety for that secondmate.
+Natural-language summary and `scope:` text may contain parentheses and semicolons; keep the generated `(home: ...; scope: ...; projects: ...; added ...)` suffix intact so operational consumers resolve its explicit field markers.
 The `home:` path points to the seeded home containing `data/charter.md`; no extra registry pointer field is needed.
 The home-seeded `data/charter.md` is the sole owner of boilerplate idle-by-default behavior, the normal delegation lifecycle, and standard escalation contracts, so point to that charter rather than restating those contracts in the registry entry.
 The `scope:` field is used during intake.
@@ -116,7 +117,7 @@ It uses the same live-home discovery and propagation helper as bootstrap, report
 `bin/fm-home-seed.sh` refuses to copy a missing or placeholder charter.
 
 Direct seed without a preexisting brief requires `FM_SECONDMATE_CHARTER`.
-Run `bin/fm-home-seed.sh validate` when checking registry integrity; it refuses duplicate ids, duplicate homes, and nested or overlapping homes.
+Run `bin/fm-home-seed.sh validate` when checking registry integrity; its header owns the complete validation and refusal mechanics.
 
 Seeding is transactional.
 If validation, cloning, no-mistakes initialization, or registry update fails, generated briefs, new homes, new project clones, and registry edits are rolled back.

--- a/bin/fm-backlog-handoff.sh
+++ b/bin/fm-backlog-handoff.sh
@@ -53,21 +53,19 @@ REG="$DATA/secondmates.md"
 MAIN_BACKLOG="$DATA/backlog.md"
 # shellcheck source=bin/fm-tasks-axi-lib.sh disable=SC1091
 . "$SCRIPT_DIR/fm-tasks-axi-lib.sh"
+# shellcheck source=bin/fm-secondmate-registry-lib.sh
+. "$SCRIPT_DIR/fm-secondmate-registry-lib.sh"
 
 [ $# -ge 2 ] || { echo "usage: fm-backlog-handoff.sh <secondmate-id> <item-key>..." >&2; exit 1; }
 ID=$1
 shift
 
 secondmate_home() {
-  local id=$1 line
+  local id=$1 home
   [ -f "$REG" ] || { echo "error: no secondmate registry at $REG" >&2; return 1; }
-  line=$(grep -E "^- $id( |$)" "$REG" | tail -1 || true)
-  [ -n "$line" ] || { echo "error: secondmate $id is not registered in $REG" >&2; return 1; }
-  # Match the (home: ...) field itself; do not require zero parentheses before it.
-  # Summary/scope prose often contains parentheticals (e.g. "(id is legacy)"), and
-  # ^[^(]* would leave those entries looking like "has no home". Greedy prefix so the
-  # last (home: ...) on the line wins. Empty when the field is absent.
-  printf '%s\n' "$line" | sed -n 's/.*(home:[[:space:]]*\([^;)]*\);.*/\1/p' | sed 's/[[:space:]]*$//'
+  home=$(secondmate_registry_field "$REG" "$id" home || true)
+  [ -n "$home" ] || { echo "error: secondmate $id has no home in $REG" >&2; return 1; }
+  printf '%s\n' "$home"
 }
 
 path_is_ancestor_of() {

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -29,8 +29,8 @@
 # For ship tasks, the definition of done is shaped by the project's delivery mode
 # (data/projects.md via fm-project-mode.sh; see the project-management skill
 # and AGENTS.md task lifecycle):
-#   no-mistakes  implement -> /no-mistakes pipeline -> PR -> captain merge (default)
-#   direct-PR    implement -> push + open PR via gh-axi (no pipeline) -> captain merge
+#   direct-PR    implement -> push + open PR via gh-axi (no pipeline) -> captain merge (omitted mode defaults to direct-PR +yolo)
+#   no-mistakes  implement -> /no-mistakes pipeline -> PR -> captain merge
 #   local-only   implement on branch, stop and report "ready in branch" (no push/PR);
 #                captain approves, firstmate merges to local main
 # Ship briefs begin with a worktree-isolation assertion before the branch step.
@@ -248,6 +248,15 @@ HERDR_SECTION=${HERDR_SECTION%$'\n'}
 fi
 
 if [ "$KIND" = scout ]; then
+  SPECIALIST_RESULT="your findings and evidence"
+else
+  SPECIALIST_RESULT="implementation, evidence, and any required PR"
+fi
+SPECIALIST_RULE="8. Standard implementation uses one \`antigravity/gemini-3.6-flash\` crewmate at high effort unless Firstmate explicitly overrides dispatch. You own narrow supporting calls to installed specialists: use \`@fixer\` for targeted implementation, \`@explorer\` for repository mapping and search, \`@plan\` for architecture or implementation planning, \`@designer\` for frontend, UI, and visual work, and \`@oracle\` for independent correctness and risk review when authorized. Inspect and incorporate returned findings yourself, then return $SPECIALIST_RESULT to Firstmate while preserving this brief's isolation, approval, and delivery rules."
+WEB_RESEARCH_RULE="9. For web research, use Firecrawl MCP first: call \`firecrawl_search\`, call \`firecrawl_search_feedback\` after using its results, and use \`firecrawl_scrape\` for known pages. If Firecrawl is unavailable, use another tool only as a fallback and disclose that fallback in your findings."
+REVIEW_PATH_RULE="10. Before pre-commit review, record the base and HEAD SHAs, then have the reviewer inspect the exact committed range with \`git diff <base>...<HEAD>\` and use \`git show <base>..<HEAD>\` for commit details; if the review tool cannot access those commits or shows an empty range, report the mismatch instead of reviewing it."
+
+if [ "$KIND" = scout ]; then
 cat > "$BRIEF" <<EOF
 You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.
 
@@ -283,6 +292,9 @@ The report is the only thing that survives, so anything worth keeping must be in
 7. Never stop, restart, or update the shared \`no-mistakes\` daemon - it is one instance serving
    every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
    daemon error, append \`blocked: {the daemon error}\` and stop; only firstmate manages the daemon.
+$SPECIALIST_RULE
+$WEB_RESEARCH_RULE
+$REVIEW_PATH_RULE
 
 # Definition of done
 Write your findings to \`$DATA/$ID/report.md\`.
@@ -310,7 +322,9 @@ case "$MODE" in
 # Definition of done
 This project ships **direct-PR**: you raise the PR yourself, without the no-mistakes pipeline.
 The task is complete only when committed on your branch.
-When it is implemented and committed, push your branch and open a PR with \`gh-axi\`, then append \`done: PR {url}\` to the status file and stop.
+Before pushing or requesting a PR, you must ask \`@oracle\` for a fresh read-only review of the complete committed range and verification evidence, using rule 10's exact base/HEAD commands.
+Resolve every finding and rerun affected checks; if \`@oracle\` is unavailable, append \`blocked: {why}\` and stop without requesting a PR.
+When it is implemented, reviewed, and committed, push your branch and open a PR with \`gh-axi\`, then append \`done: PR {url}\` to the status file and stop.
 Do NOT run /no-mistakes. The configured merge authority decides whether to merge the PR; firstmate relays the outcome.
 EOF
     ;;
@@ -326,7 +340,7 @@ When it is implemented and committed, append \`done: ready in branch fm/$ID\` to
 The configured merge authority approves the ready branch, then firstmate merges it into local \`main\` through the guarded fast-forward path.
 EOF
     ;;
-  *)  # no-mistakes (default)
+  *)  # no-mistakes fallback
     SETUP2="
 2. Run \`no-mistakes doctor\`; if it reports the repo is not initialized here, run \`no-mistakes init\`."
     RULE1='1. Never push to the default branch. Never merge a PR.'
@@ -338,6 +352,7 @@ Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.
 
 You drive no-mistakes by responding to its gates, not by implementing fixes.
 Follow the guidance no-mistakes itself provides for the mechanics: it loads when you invoke /no-mistakes, and \`no-mistakes axi run --help\` plus the \`help\` lines in each \`axi\` response are authoritative and version-matched to the installed binary.
+When starting no-mistakes, make \`--intent\` preserve all relevant content from this brief's \`# Task\` section plus every later accepted Firstmate requirement, clarification, constraint, exclusion, and supersession, carrying only each requirement's current accepted form; retain direct requirements instead of substituting a diff summary, and exclude generic operational, status, delivery, and other scaffold boilerplate unless it is task-specific.
 Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix.
 
 Two firstmate-specific rules layer on top of that guidance:
@@ -397,6 +412,9 @@ $RULE1
 7. Never stop, restart, or update the shared \`no-mistakes\` daemon - it is one instance serving
    every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
    daemon error, append \`blocked: {the daemon error}\` and stop; only firstmate manages the daemon.
+$SPECIALIST_RULE
+$WEB_RESEARCH_RULE
+$REVIEW_PATH_RULE
 
 # Project memory
 If \`AGENTS.md\` or \`CLAUDE.md\` already exists, or if this task produced durable project-intrinsic knowledge, run \`$FM_ROOT/bin/fm-ensure-agents-md.sh .\` in the worktree.

--- a/bin/fm-ff-lib.sh
+++ b/bin/fm-ff-lib.sh
@@ -25,6 +25,8 @@
 # shared default branch or any other worktree's checkout.
 
 SUB_HOME_MARKER="${SUB_HOME_MARKER:-.fm-secondmate-home}"
+# shellcheck source=bin/fm-secondmate-registry-lib.sh
+. "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/fm-secondmate-registry-lib.sh"
 
 # --- helpers ---------------------------------------------------------------
 
@@ -229,20 +231,6 @@ dirty_status() {
   else
     git -C "$dir" status --porcelain 2>/dev/null | head -1
   fi
-}
-
-secondmate_registry_field() {
-  local reg=$1 id=$2 key=$3 line value
-  [ -f "$reg" ] || return 1
-  line=$(grep -E "^- $id( |$)" "$reg" | tail -1 || true)
-  [ -n "$line" ] || return 1
-  case "$key" in
-    home) value=$(printf '%s\n' "$line" | sed -n 's/.*(home:[[:space:]]*\([^;)]*\);.*/\1/p' | sed 's/[[:space:]]*$//') ;;
-    projects) value=$(printf '%s\n' "$line" | sed -n 's/.*; projects:[[:space:]]*\([^;)]*\); added .*/\1/p' | sed 's/[[:space:]]*$//') ;;
-    *) return 1 ;;
-  esac
-  [ -n "$value" ] || return 1
-  printf '%s\n' "$value"
 }
 
 # List this home's LIVE secondmate direct reports from state/<id>.meta records.

--- a/bin/fm-fleet-snapshot.sh
+++ b/bin/fm-fleet-snapshot.sh
@@ -839,7 +839,7 @@ BASH
         | select(startswith("- "))
         | (capture("^- (?<id>[^[:space:]]+)")?) as $id
         | select($id != null)
-        | (capture("\\(home:[[:space:]]*(?<home>[^;)]*);")?) as $home
+        | (capture("^.*\\(home:[[:space:]]*(?<home>[^;)]*);[[:space:]]*scope:[[:space:]]*.*;[[:space:]]*projects:[[:space:]]*[^;)]*;[[:space:]]*added[[:space:]]+[0-9]{4}-[0-9]{2}-[0-9]{2}\\)[[:space:]]*$")?) as $home
         | {id:$id.id,home:($home.home // null),registered:true,
            registry_error:(if $home == null or ($home.home | length) == 0 then "registry entry has no home" else null end)} ]
       | group_by(.id)

--- a/bin/fm-home-seed.sh
+++ b/bin/fm-home-seed.sh
@@ -27,8 +27,9 @@
 #       to override the registry routing scope. Otherwise the registry summary
 #       and scope are derived from the filled charter brief.
 #   fm-home-seed.sh validate
-#       Refuse duplicate ids, duplicate homes, and nested or overlapping homes in
-#       data/secondmates.md.
+#       Refuse records that operational consumers cannot parse, unavailable or
+#       unsafe registry files when present, non-absolute or unresolvable homes,
+#       duplicate ids or homes, and nested or overlapping homes.
 set -eu
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -38,14 +39,12 @@ DATA="${FM_DATA_OVERRIDE:-$FM_HOME/data}"
 PROJECTS="${FM_PROJECTS_OVERRIDE:-$FM_HOME/projects}"
 REG="$DATA/secondmates.md"
 SUB_HOME_MARKER=".fm-secondmate-home"
+# shellcheck source=bin/fm-secondmate-registry-lib.sh
+. "$SCRIPT_DIR/fm-secondmate-registry-lib.sh"
 
 usage() {
   echo "usage: fm-home-seed.sh <id> <home|-> {<project>...|--no-projects}" >&2
   echo "       fm-home-seed.sh validate" >&2
-}
-
-registry_home_for_line() {
-  sed -n 's/^[^(]*(home: \([^;)]*\);.*/\1/p'
 }
 
 normalize_registry_text() {
@@ -179,13 +178,15 @@ registry_home_conflict_for_assignment() {
   local id=$1 home=$2 target line registered_id registered_home registered_key
   [ -f "$REG" ] || return 1
   target=$(resolved_path "$home")
-  while IFS= read -r line; do
+  while IFS= read -r line || [ -n "$line" ]; do
     case "$line" in
       "- "*)
-        registered_id=${line#- }
-        registered_id=${registered_id%% *}
-        registered_home=$(printf '%s\n' "$line" | registry_home_for_line)
-        [ -n "$registered_home" ] || continue
+        if ! secondmate_registry_parse_line "$line"; then
+          echo "error: malformed secondmate registry entry: $line" >&2
+          return 1
+        fi
+        registered_id=$SECONDMATE_REGISTRY_ID
+        registered_home=$SECONDMATE_REGISTRY_HOME
         registered_key=$(resolved_path "$registered_home")
         if [ "$registered_key" = "$target" ]; then
           [ "$registered_id" = "$id" ] && continue
@@ -206,14 +207,16 @@ registry_id_conflict_for_assignment() {
   local id=$1 home=$2 target line registered_id registered_home registered_key
   [ -f "$REG" ] || return 1
   target=$(resolved_path "$home")
-  while IFS= read -r line; do
+  while IFS= read -r line || [ -n "$line" ]; do
     case "$line" in
       "- "*)
-        registered_id=${line#- }
-        registered_id=${registered_id%% *}
+        secondmate_registry_parse_line "$line" || {
+          echo "error: malformed secondmate registry entry: $line" >&2
+          return 1
+        }
+        registered_id=$SECONDMATE_REGISTRY_ID
         [ "$registered_id" = "$id" ] || continue
-        registered_home=$(printf '%s\n' "$line" | registry_home_for_line)
-        [ -n "$registered_home" ] || continue
+        registered_home=$SECONDMATE_REGISTRY_HOME
         registered_key=$(resolved_path "$registered_home")
         [ "$registered_key" = "$target" ] && continue
         printf '%s\n' "$registered_key"
@@ -225,76 +228,11 @@ registry_id_conflict_for_assignment() {
 }
 
 validate_registry() {
-  local tmp line id registered_home home_key duplicate_homes duplicate_ids overlaps
-  tmp=$(mktemp "${TMPDIR:-/tmp}/fm-firstmates.XXXXXX")
-  if [ -f "$REG" ]; then
-    while IFS= read -r line; do
-      case "$line" in
-        "- "*)
-          id=${line#- }
-          id=${id%% *}
-          registered_home=$(printf '%s\n' "$line" | registry_home_for_line)
-          [ -n "$registered_home" ] || continue
-          home_key=$(resolved_path "$registered_home")
-          printf '%s\t%s\n' "$home_key" "$id" >> "$tmp"
-          ;;
-      esac
-    done < "$REG"
-  fi
-  duplicate_homes=$(awk -F '\t' '
-    {
-      if (($1 in owner) && owner[$1] != $2) {
-        print $1 ": " owner[$1] ", " $2
-        bad=1
-      } else {
-        owner[$1]=$2
-      }
-    }
-    END { exit bad ? 1 : 0 }
-  ' "$tmp" 2>/dev/null) || {
-    rm -f "$tmp"
-    printf 'error: duplicate secondmate home assignment:\n%s\n' "$duplicate_homes" >&2
+  [ -e "$REG" ] || [ -L "$REG" ] || return 0
+  secondmate_registry_validate_bindings "$REG" resolved_path || {
+    printf 'error: %s\n' "$SECONDMATE_REGISTRY_ERROR" >&2
     return 1
   }
-  duplicate_ids=$(awk -F '\t' '
-    {
-      if ($2 in home) {
-        print $2 ": " home[$2] ", " $1
-        bad=1
-      } else {
-        home[$2]=$1
-      }
-    }
-    END { exit bad ? 1 : 0 }
-  ' "$tmp" 2>/dev/null) || {
-    rm -f "$tmp"
-    printf 'error: duplicate secondmate id assignment:\n%s\n' "$duplicate_ids" >&2
-    return 1
-  }
-  overlaps=$(awk -F '\t' '
-    function ancestor(a, b) { return a != b && index(b, a "/") == 1 }
-    {
-      for (i = 1; i <= count; i++) {
-        if (ancestor($1, path[i])) {
-          print $1 " (" $2 ") contains " path[i] " (" id[i] ")"
-          bad=1
-        } else if (ancestor(path[i], $1)) {
-          print path[i] " (" id[i] ") contains " $1 " (" $2 ")"
-          bad=1
-        }
-      }
-      count++
-      path[count]=$1
-      id[count]=$2
-    }
-    END { exit bad ? 1 : 0 }
-  ' "$tmp" 2>/dev/null) || {
-    rm -f "$tmp"
-    printf 'error: overlapping secondmate home assignment:\n%s\n' "$overlaps" >&2
-    return 1
-  }
-  rm -f "$tmp"
-  return 0
 }
 
 join_projects() {

--- a/bin/fm-project-mode.sh
+++ b/bin/fm-project-mode.sh
@@ -4,20 +4,20 @@
 # no-mistakes|direct-PR|local-only and yolo is on|off.
 #
 # Registry line format (data/projects.md):
-#   - <name> - <desc> (added <date>)                  -> no-mistakes off  (legacy default)
+#   - <name> - <desc> (added <date>)                  -> direct-PR on  (omitted mode default)
 #   - <name> [<mode>] - <desc> (added <date>)          -> <mode> off
 #   - <name> [<mode> +yolo] - <desc> (added <date>)    -> <mode> on
 #
 # mode = how a finished change reaches main:
-#   no-mistakes  full pipeline -> PR -> captain merge (default)
+#   no-mistakes  full pipeline -> PR -> captain merge
 #   direct-PR    push + PR via gh-axi, no pipeline -> captain merge
 #   local-only   local branch, no remote/PR -> captain approve -> guarded local merge
 # yolo (orthogonal) = when on, firstmate may make routine approval decisions itself.
 #   AGENTS.md section 7 is the single owner of authority exceptions, including
 #   ask-user contract expansion and stronger captain boundaries.
 #
-# An unknown/missing project or unknown mode falls back to "no-mistakes off" and warns
-# to stderr, so a typo never silently drops the gate.
+# An unknown/missing project or malformed explicit mode falls back to
+# "no-mistakes off" and warns to stderr, so uncertainty never drops the gate.
 # Usage: fm-project-mode.sh <project-name>
 set -eu
 
@@ -37,14 +37,26 @@ fi
 # awk emits "<mode> <yolo>" (one line) or nothing if the project is absent.
 parsed=$(awk -v n="$NAME" '
   $1=="-" && $2==n {
-    mode="no-mistakes"; yolo="off";
+    mode="direct-PR"; yolo="on";
+    if ($3 != "-" && $3 !~ /^\[/) { print "invalid"; exit }
     if ($3 ~ /^\[/) {
-      s="";
-      for (i=3; i<=NF; i++) { s = s (s==""?"":" ") $i; if ($i ~ /\]$/) break }
-      gsub(/^\[|\]$/, "", s);           # strip the surrounding brackets
-      k = split(s, a, " ");
-      if (a[1] != "" && a[1] != "+yolo") mode = a[1];
-      for (j=1; j<=k; j++) if (a[j]=="+yolo") yolo="on";
+      s=""; closed=0;
+      for (i=3; i<=NF; i++) {
+        s = s (s==""?"":" ") $i;
+        if ($i ~ /\]$/) { closed=1; break }
+      }
+      if (!closed || i >= NF || $(i+1) != "-") { print "invalid"; exit }
+      gsub(/^\[/, "", s); gsub(/\]$/, "", s);
+      k = split(s, a, " "); valid=1;
+      if (k < 1 || a[1] == "") valid=0;
+      if (a[1] !~ /^(no-mistakes|direct-PR|local-only)$/) valid=0;
+      else mode=a[1];
+      yolo="off";
+      for (j=2; j<=k; j++) {
+        if (a[j] == "+yolo" && yolo == "off") yolo="on";
+        else valid=0;
+      }
+      if (!valid) { print "invalid"; exit }
     }
     print mode, yolo; exit
   }
@@ -52,6 +64,12 @@ parsed=$(awk -v n="$NAME" '
 
 if [ -z "$parsed" ]; then
   echo "warn: project \"$NAME\" not in registry; defaulting to no-mistakes off" >&2
+  echo "no-mistakes off"
+  exit 0
+fi
+
+if [ "$parsed" = invalid ]; then
+  echo "warn: malformed mode for $NAME; defaulting to no-mistakes off" >&2
   echo "no-mistakes off"
   exit 0
 fi

--- a/bin/fm-public-followup.sh
+++ b/bin/fm-public-followup.sh
@@ -103,6 +103,8 @@ DATA="${FM_DATA_OVERRIDE:-$FM_HOME/data}"
 
 # shellcheck source=bin/fm-public-followup-lib.sh
 . "$SCRIPT_DIR/fm-public-followup-lib.sh"
+# shellcheck source=bin/fm-secondmate-registry-lib.sh
+. "$SCRIPT_DIR/fm-secondmate-registry-lib.sh"
 
 RETRY_BACKOFF=${FM_PF_RETRY_BACKOFF_SECS:-900}
 case "$RETRY_BACKOFF" in ''|*[!0-9]*) RETRY_BACKOFF=900 ;; esac
@@ -521,8 +523,7 @@ public_followup_secondmate_home() {
   meta="$STATE/$id.meta"
   home=$(fmx_meta_get "$meta" home)
   if [ -z "$home" ] && [ -f "$DATA/secondmates.md" ] && [ ! -L "$DATA/secondmates.md" ]; then
-    home=$(awk -v id="$id" '$1 == "-" && $2 == id { line=$0 } END { print line }' "$DATA/secondmates.md" 2>/dev/null \
-      | sed -n 's/.*(home:[[:space:]]*\([^;)]*\);.*/\1/p' | sed 's/[[:space:]]*$//')
+    home=$(secondmate_registry_field "$DATA/secondmates.md" "$id" home || true)
   fi
   [ -n "$home" ] || return 1
   case "$home" in /*) ;; *) return 1 ;; esac

--- a/bin/fm-secondmate-registry-lib.sh
+++ b/bin/fm-secondmate-registry-lib.sh
@@ -1,0 +1,211 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2034 # parsed fields are output globals for sourcing callers.
+# Shared parser for data/secondmates.md records.
+#
+# A generated record ends with an explicit structured suffix:
+#   (home: ...; scope: ...; projects: ...; added YYYY-MM-DD)
+# Summary text and scope text are natural language and may contain parentheses
+# and semicolons, so field boundaries are anchored to the suffix markers rather
+# than to the first incidental punctuation.
+
+SECONDMATE_REGISTRY_ID=
+SECONDMATE_REGISTRY_SUMMARY=
+SECONDMATE_REGISTRY_HOME=
+SECONDMATE_REGISTRY_SCOPE=
+SECONDMATE_REGISTRY_PROJECTS=
+SECONDMATE_REGISTRY_ADDED=
+SECONDMATE_REGISTRY_LINE=
+SECONDMATE_REGISTRY_MATCH_HOME=
+SECONDMATE_REGISTRY_MATCH_HOME_KEY=
+SECONDMATE_REGISTRY_MATCH_PROJECTS=
+SECONDMATE_REGISTRY_ERROR=
+
+secondmate_registry_parse_line() {
+  local line=$1
+  local record_re='^- ([A-Za-z0-9._-]+) - (.+) \(home:[[:space:]]*([^;)]*);[[:space:]]*scope:[[:space:]]*(.*);[[:space:]]*projects:[[:space:]]*([^;)]*);[[:space:]]*added[[:space:]]+([0-9]{4}-[0-9]{2}-[0-9]{2})\)[[:space:]]*$'
+  SECONDMATE_REGISTRY_ID=
+  SECONDMATE_REGISTRY_SUMMARY=
+  SECONDMATE_REGISTRY_HOME=
+  SECONDMATE_REGISTRY_SCOPE=
+  SECONDMATE_REGISTRY_PROJECTS=
+  SECONDMATE_REGISTRY_ADDED=
+  if [[ "$line" =~ $record_re ]]; then
+    SECONDMATE_REGISTRY_ID=${BASH_REMATCH[1]}
+    SECONDMATE_REGISTRY_SUMMARY=${BASH_REMATCH[2]}
+    SECONDMATE_REGISTRY_HOME=${BASH_REMATCH[3]}
+    SECONDMATE_REGISTRY_SCOPE=${BASH_REMATCH[4]}
+    SECONDMATE_REGISTRY_PROJECTS=${BASH_REMATCH[5]}
+    SECONDMATE_REGISTRY_ADDED=${BASH_REMATCH[6]}
+  else
+    return 1
+  fi
+  [ -n "$SECONDMATE_REGISTRY_HOME" ] || return 1
+  [ -n "$SECONDMATE_REGISTRY_SCOPE" ] || return 1
+  return 0
+}
+
+secondmate_registry_line_for_id() {
+  local reg=$1 id=$2 line count=0
+  case "$id" in ''|*[!A-Za-z0-9._-]*) return 1 ;; esac
+  [ -f "$reg" ] && [ ! -L "$reg" ] || return 1
+  while IFS= read -r line || [ -n "$line" ]; do
+    [ "$line" = "- $id" ] || case "$line" in "- $id "*) ;; *) continue ;; esac
+    count=$((count + 1))
+    [ "$count" -eq 1 ] || return 1
+    SECONDMATE_REGISTRY_LINE=$line
+  done < "$reg"
+  [ "$count" -eq 1 ] || return 1
+  secondmate_registry_parse_line "$SECONDMATE_REGISTRY_LINE"
+}
+
+secondmate_registry_field() {
+  local reg=$1 id=$2 key=$3
+  secondmate_registry_line_for_id "$reg" "$id" || return 1
+  case "$key" in
+    home) printf '%s\n' "$SECONDMATE_REGISTRY_HOME" ;;
+    projects) printf '%s\n' "$SECONDMATE_REGISTRY_PROJECTS" ;;
+    *) return 1 ;;
+  esac
+}
+
+secondmate_registry_path_key() {
+  local path=$1 parent base
+  case "$path" in /*) ;; *) return 1 ;; esac
+  if [ -d "$path" ]; then
+    cd "$path" && pwd -P
+  else
+    parent=$(dirname "$path")
+    base=$(basename "$path")
+    cd "$parent" && printf '%s/%s\n' "$(pwd -P)" "$base"
+  fi
+}
+
+secondmate_registry_validate_bindings() {
+  local reg=$1 resolver=$2 expected_id=${3:-} expected_home=${4:-}
+  local tmp snapshot bindings line id home home_key duplicate_homes duplicate_ids overlaps expected_home_key
+  SECONDMATE_REGISTRY_MATCH_HOME=
+  SECONDMATE_REGISTRY_MATCH_HOME_KEY=
+  SECONDMATE_REGISTRY_MATCH_PROJECTS=
+  SECONDMATE_REGISTRY_ERROR=
+  case "$expected_id" in *[!A-Za-z0-9._-]*) SECONDMATE_REGISTRY_ERROR="invalid secondmate id: $expected_id"; return 1 ;; esac
+  if [ ! -f "$reg" ] || [ -L "$reg" ]; then
+    SECONDMATE_REGISTRY_ERROR="secondmate registry is unavailable or unsafe: $reg"
+    return 1
+  fi
+  tmp=$(mktemp -d "${TMPDIR:-/tmp}/fm-secondmate-registry.XXXXXX") || {
+    SECONDMATE_REGISTRY_ERROR="could not create secondmate registry validation state"
+    return 1
+  }
+  snapshot="$tmp/registry"
+  bindings="$tmp/bindings"
+  if ! cat "$reg" > "$snapshot" 2>/dev/null || ! : > "$bindings"; then
+    rm -rf -- "$tmp"
+    SECONDMATE_REGISTRY_ERROR="secondmate registry is unavailable or unsafe: $reg"
+    return 1
+  fi
+  while IFS= read -r line || [ -n "$line" ]; do
+    case "$line" in
+      "- "*)
+        if ! secondmate_registry_parse_line "$line"; then
+          rm -rf -- "$tmp"
+          SECONDMATE_REGISTRY_ERROR="malformed secondmate registry entry: $line"
+          return 1
+        fi
+        id=$SECONDMATE_REGISTRY_ID
+        home=$SECONDMATE_REGISTRY_HOME
+        case "$home" in
+          /*) ;;
+          *)
+            rm -rf -- "$tmp"
+            SECONDMATE_REGISTRY_ERROR="unsafe non-absolute secondmate home for $id: $home"
+            return 1
+            ;;
+        esac
+        case "$home" in
+          *$'\t'*)
+            rm -rf -- "$tmp"
+            SECONDMATE_REGISTRY_ERROR="unsafe secondmate home for $id"
+            return 1
+            ;;
+        esac
+        home_key=$("$resolver" "$home" 2>/dev/null || true)
+        if [ -z "$home_key" ]; then
+          rm -rf -- "$tmp"
+          SECONDMATE_REGISTRY_ERROR="unresolvable secondmate home for $id: $home"
+          return 1
+        fi
+        printf '%s\t%s\n' "$home_key" "$id" >> "$bindings"
+        if [ -n "$expected_id" ] && [ "$id" = "$expected_id" ]; then
+          SECONDMATE_REGISTRY_MATCH_HOME=$home
+          SECONDMATE_REGISTRY_MATCH_HOME_KEY=$home_key
+          SECONDMATE_REGISTRY_MATCH_PROJECTS=$SECONDMATE_REGISTRY_PROJECTS
+        fi
+        ;;
+    esac
+  done < "$snapshot"
+  duplicate_homes=$(awk -F '\t' '
+    {
+      if ($1 in owner) {
+        print $1 ": " owner[$1] ", " $2
+        bad=1
+      } else {
+        owner[$1]=$2
+      }
+    }
+    END { exit bad ? 1 : 0 }
+  ' "$bindings" 2>/dev/null) || {
+    rm -rf -- "$tmp"
+    SECONDMATE_REGISTRY_ERROR="duplicate secondmate home assignment: $duplicate_homes"
+    return 1
+  }
+  duplicate_ids=$(awk -F '\t' '
+    {
+      if ($2 in home) {
+        print $2 ": " home[$2] ", " $1
+        bad=1
+      } else {
+        home[$2]=$1
+      }
+    }
+    END { exit bad ? 1 : 0 }
+  ' "$bindings" 2>/dev/null) || {
+    rm -rf -- "$tmp"
+    SECONDMATE_REGISTRY_ERROR="duplicate secondmate id assignment: $duplicate_ids"
+    return 1
+  }
+  overlaps=$(awk -F '\t' '
+    function ancestor(a, b) { return a != b && index(b, a "/") == 1 }
+    {
+      for (i = 1; i <= count; i++) {
+        if (ancestor($1, path[i])) {
+          print $1 " (" $2 ") contains " path[i] " (" id[i] ")"
+          bad=1
+        } else if (ancestor(path[i], $1)) {
+          print path[i] " (" id[i] ") contains " $1 " (" $2 ")"
+          bad=1
+        }
+      }
+      count++
+      path[count]=$1
+      id[count]=$2
+    }
+    END { exit bad ? 1 : 0 }
+  ' "$bindings" 2>/dev/null) || {
+    rm -rf -- "$tmp"
+    SECONDMATE_REGISTRY_ERROR="overlapping secondmate home assignment: $overlaps"
+    return 1
+  }
+  rm -rf -- "$tmp"
+  if [ -n "$expected_id" ] && [ -z "$SECONDMATE_REGISTRY_MATCH_HOME" ]; then
+    SECONDMATE_REGISTRY_ERROR="no registry binding for secondmate $expected_id"
+    return 1
+  fi
+  if [ -n "$expected_home" ]; then
+    expected_home_key=$("$resolver" "$expected_home" 2>/dev/null || true)
+    if [ -z "$expected_home_key" ] || [ "$expected_home_key" != "$SECONDMATE_REGISTRY_MATCH_HOME_KEY" ]; then
+      SECONDMATE_REGISTRY_ERROR="secondmate $expected_id is registered at $SECONDMATE_REGISTRY_MATCH_HOME, not $expected_home"
+      return 1
+    fi
+  fi
+  return 0
+}

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -566,18 +566,7 @@ if [ "$KIND" = secondmate ] && [ -z "$ARG3" ]; then
 fi
 
 secondmate_registry_value() {
-  local id=$1 key=$2 reg line value
-  reg="$DATA/secondmates.md"
-  [ -f "$reg" ] || return 1
-  line=$(grep -E "^- $id( |$)" "$reg" | tail -1 || true)
-  [ -n "$line" ] || return 1
-  case "$key" in
-    home) value=$(printf '%s\n' "$line" | sed -n 's/^[^(]*(home: \([^;)]*\);.*/\1/p') ;;
-    projects) value=$(printf '%s\n' "$line" | sed -n 's/^[^(]*(home: [^;)]*; scope: [^;)]*; projects: \([^;)]*\); added .*/\1/p') ;;
-    *) return 1 ;;
-  esac
-  [ -n "$value" ] || return 1
-  printf '%s\n' "$value"
+  secondmate_registry_field "$DATA/secondmates.md" "$1" "$2"
 }
 
 shell_quote() {
@@ -800,6 +789,13 @@ fi
 if [ "$KIND" = secondmate ]; then
   [ -n "$FIRSTMATE_HOME" ] || { echo "error: no firstmate home supplied or registered for $ID" >&2; exit 1; }
   PROJ_ABS=$(validate_firstmate_home_for_spawn "$ID" "$FIRSTMATE_HOME")
+  if [ -e "$DATA/secondmates.md" ] || [ -L "$DATA/secondmates.md" ]; then
+    if ! secondmate_registry_validate_bindings "$DATA/secondmates.md" resolve_path "$ID" "$FIRSTMATE_HOME"; then
+      echo "error: $SECONDMATE_REGISTRY_ERROR" >&2
+      exit 1
+    fi
+    SECONDMATE_PROJECTS=$SECONDMATE_REGISTRY_MATCH_PROJECTS
+  fi
   WT="$PROJ_ABS"
   # Local-HEAD sync: before launch, fast-forward this secondmate's worktree to the
   # PRIMARY checkout's current default-branch commit, so a freshly spawned or
@@ -1593,11 +1589,10 @@ fi
 # Recorded in meta so fm-teardown's safety check and the validate/merge stages can
 # branch on them. Mode governs ship tasks; a scout's deliverable is a report, not a
 # merge, so scout teardown ignores mode.
-SECONDMATE_PROJECTS=
 if [ "$KIND" = secondmate ]; then
   MODE=secondmate
   YOLO=off
-  SECONDMATE_PROJECTS=$(secondmate_registry_value "$ID" projects || true)
+  : "${SECONDMATE_PROJECTS:=}"
 else
   PROJ_NAME=$(basename "$PROJ_ABS")
   read -r MODE YOLO <<EOF

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -89,6 +89,14 @@
 #   secondmate receives the primary's read-only shared captain-preference file
 #   (fm-config-inherit-lib.sh). A successful launch clears pending inherited
 #   config reread generations because the new agent reads the converged files.
+#   Before any worktree, backend endpoint, agent process, or task metadata is
+#   created, every final model beginning with antigravity/ runs the installed
+#   deterministic quota checker with `check`. FM_ANTIGRAVITY_PREFLIGHT_BIN is
+#   the test override; otherwise the checker is resolved under
+#   ${PI_CODING_AGENT_DIR:-$HOME/.pi/agent}/extensions/antigravity-account-switcher/.
+#   The checker runs with a bounded timeout and output stream. Exit 0 preserves
+#   the requested model and effort; documented exit 1 changes them to
+#   cockpit/gpt-5.6-luna and high; every other result refuses the spawn.
 #   --scout records kind=scout in the task's meta (report deliverable, scratch worktree;
 #   see AGENTS.md task lifecycle); --secondmate records kind=secondmate and launches in a
 #   provisioned firstmate home; the default is kind=ship.
@@ -422,6 +430,7 @@ SPAWN_TASK_LOCK_HELD=1
 PROJ=
 ARG3=
 FIRSTMATE_HOME=
+RAW_LAUNCH=0
 
 if [ "$KIND" = secondmate ]; then
   case "${POS[1]:-}" in
@@ -498,6 +507,7 @@ launch_template() {
 case "$ARG3" in
   *' '*)  # raw launch command (unverified-adapter escape hatch)
     LAUNCH=$ARG3
+    RAW_LAUNCH=1
     HARNESS=""
     for word in $LAUNCH; do
       case "$word" in [A-Za-z_]*=*) continue ;; *) HARNESS=$(basename "$word"); break ;; esac
@@ -563,6 +573,156 @@ if [ "$KIND" = secondmate ] && [ -z "$ARG3" ]; then
       esac
     fi
   fi
+fi
+
+antigravity_preflight() {
+  if [ "$RAW_LAUNCH" -eq 1 ] && [ -z "$MODEL" ]; then
+    local cleaned_word
+    for word in $LAUNCH; do
+      cleaned_word=$(printf '%s' "$word" | tr -d "\"'")
+      case "$cleaned_word" in
+        --model=antigravity/*) MODEL=${cleaned_word#--model=} ;;
+        antigravity/*) MODEL=$cleaned_word ;;
+      esac
+    done
+  fi
+
+  case "$MODEL" in
+    antigravity/*) ;;
+    *) return 0 ;;
+  esac
+
+  local checker agent_dir timeout_seconds output_bytes tmp_out rc
+  checker=${FM_ANTIGRAVITY_PREFLIGHT_BIN:-}
+  if [ -z "$checker" ]; then
+    agent_dir=${PI_CODING_AGENT_DIR:-${HOME:-}/.pi/agent}
+    checker="$agent_dir/extensions/antigravity-account-switcher/bin/antigravity-account-check.js"
+    if [ ! -f "$checker" ] || [ ! -x "$checker" ]; then
+      checker="$agent_dir/extensions/pi-antigravity-account-switcher/bin/antigravity-account-check.js"
+    fi
+  fi
+  if [ ! -f "$checker" ] || [ ! -x "$checker" ]; then
+    echo "error: Antigravity quota preflight checker is missing or not executable: $checker" >&2
+    return 1
+  fi
+
+  timeout_seconds=${FM_ANTIGRAVITY_PREFLIGHT_TIMEOUT_SECONDS:-30}
+  output_bytes=${FM_ANTIGRAVITY_PREFLIGHT_OUTPUT_BYTES:-8192}
+  case "$timeout_seconds" in
+    ''|*[!0-9]*)
+      echo "error: Antigravity quota preflight timeout is not a positive integer" >&2
+      return 1
+      ;;
+  esac
+  case "$output_bytes" in
+    ''|*[!0-9]*)
+      echo "error: Antigravity quota preflight output limit is not a positive integer" >&2
+      return 1
+      ;;
+  esac
+  [ "$timeout_seconds" -gt 0 ] || {
+    echo "error: Antigravity quota preflight timeout must be positive" >&2
+    return 1
+  }
+  [ "$output_bytes" -gt 0 ] || {
+    echo "error: Antigravity quota preflight output limit must be positive" >&2
+    return 1
+  }
+
+  if ! command -v perl >/dev/null 2>&1; then
+    echo "error: Antigravity quota preflight requires perl" >&2
+    return 1
+  fi
+
+  tmp_out=$(mktemp "${STATE}/.preflight-${ID}.XXXXXXXX" 2>/dev/null || mktemp "/tmp/.preflight-${ID}.XXXXXXXX")
+
+  set +e
+  perl -e '
+    my $t = shift; my $file = shift; my $limit = shift;
+    pipe(my $r, my $w) or die;
+    my $pid = fork; die "fork failed" unless defined $pid;
+    if (!$pid) {
+      close $r;
+      setpgrp(0, 0);
+      open(STDOUT, ">&", $w) or die;
+      open(STDERR, ">&", $w) or die;
+      close $w;
+      exec @ARGV;
+    }
+    close $w;
+    local $SIG{ALRM} = sub {
+      kill "TERM", -$pid;
+      select undef, undef, undef, 0.2;
+      kill "KILL", -$pid;
+      exit 124;
+    };
+    alarm $t;
+    open(my $out_fh, ">", $file) or die;
+    my $bytes_read = 0;
+    my $buf;
+    while (sysread($r, $buf, 4096)) {
+      if ($bytes_read < $limit) {
+        my $to_write = length($buf);
+        if ($bytes_read + $to_write > $limit) {
+          $to_write = $limit - $bytes_read;
+        }
+        syswrite($out_fh, substr($buf, 0, $to_write));
+        $bytes_read += $to_write;
+      }
+    }
+    close $out_fh;
+    close $r;
+    waitpid($pid, 0);
+    alarm 0;
+    my $sig = $? & 127;
+    my $rc = $sig ? 255 : ($? >> 8);
+    kill "TERM", -$pid;
+    select undef, undef, undef, 0.1;
+    kill "KILL", -$pid;
+    exit $rc;
+  ' "$timeout_seconds" "$tmp_out" "$output_bytes" "$checker" check >/dev/null 2>&1
+  rc=$?
+  set -e
+  rm -f "$tmp_out"
+
+  case "$rc" in
+    0) return 0 ;;
+    1)
+      MODEL=cockpit/gpt-5.6-luna
+      EFFORT=high
+      ANTIGRAVITY_FALLBACK=1
+      return 0
+      ;;
+    124)
+      echo "error: Antigravity quota preflight timed out" >&2
+      return 1
+      ;;
+    *)
+      echo "error: Antigravity quota preflight failed with unrecognized result (exit $rc)" >&2
+      return 1
+      ;;
+  esac
+}
+
+ANTIGRAVITY_FALLBACK=0
+antigravity_preflight || exit 1
+if [ "$ANTIGRAVITY_FALLBACK" -eq 1 ] && [ "$RAW_LAUNCH" -eq 1 ]; then
+  case "$LAUNCH" in
+    *'antigravity/'*)
+      LAUNCH=$(printf '%s' "$LAUNCH" | sed -E "s/['\"]?antigravity\/[^'\" ]+['\"]?/'cockpit\/gpt-5.6-luna'/g")
+      case "$LAUNCH" in
+        *--effort*)
+          LAUNCH=$(printf '%s' "$LAUNCH" | sed -E "s/--effort[ =]['\"]?[^'\" ]+['\"]?/--effort 'high'/g")
+          ;;
+        *)
+          LAUNCH="$LAUNCH --effort 'high'"
+          ;;
+      esac
+      ;;
+    *)
+      LAUNCH="$LAUNCH --model 'cockpit/gpt-5.6-luna' --effort 'high'"
+      ;;
+  esac
 fi
 
 secondmate_registry_value() {

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -108,6 +108,8 @@ SUB_HOME_MARKER=".fm-secondmate-home"
 . "$SCRIPT_DIR/fm-pr-lib.sh"
 # shellcheck source=bin/fm-public-followup-lib.sh
 . "$SCRIPT_DIR/fm-public-followup-lib.sh"
+# shellcheck source=bin/fm-secondmate-registry-lib.sh
+. "$SCRIPT_DIR/fm-secondmate-registry-lib.sh"
 if [ "$#" -lt 1 ] || ! fm_task_id_path_safe "$1"; then
   echo "error: invalid teardown request" >&2
   exit 2
@@ -155,7 +157,7 @@ PUBLIC_FOLLOWUP_PARENT_UNRESOLVED=0
 PUBLIC_FOLLOWUP_PARENT_RELAY_ACTIVE=0
 PUBLIC_FOLLOWUP_RELAY_ACTIVE=0
 public_followup_resolve_primary_home() {
-  local parent=$1 child=$2 id=$3 parent_meta registry lines line_count meta_home registry_home
+  local parent=$1 child=$2 id=$3 parent_meta registry meta_home
   fm_pf_home_id_valid "secondmate:$id" || return 1
   case "$parent" in /*) ;; *) return 1 ;; esac
   parent=$(CDPATH='' cd -- "$parent" 2>/dev/null && pwd -P) || return 1
@@ -168,14 +170,7 @@ public_followup_resolve_primary_home() {
   meta_home=$(CDPATH='' cd -- "$meta_home" 2>/dev/null && pwd -P) || return 1
   [ "$meta_home" = "$child" ] || return 1
   registry="$parent/data/secondmates.md"
-  [ -f "$registry" ] && [ ! -L "$registry" ] || return 1
-  lines=$(awk -v wanted="$id" '$1 == "-" && $2 == wanted { print }' "$registry" 2>/dev/null || true)
-  line_count=$(printf '%s\n' "$lines" | grep -c . || true)
-  [ "$line_count" -eq 1 ] || return 1
-  line=$(printf '%s\n' "$lines")
-  registry_home=$(printf '%s\n' "$line" | sed -n 's/^[^(]*(home: \([^;)]*\);.*/\1/p')
-  registry_home=$(CDPATH='' cd -- "$registry_home" 2>/dev/null && pwd -P) || return 1
-  [ "$registry_home" = "$child" ] || return 1
+  secondmate_registry_validate_bindings "$registry" secondmate_registry_path_key "$id" "$child" || return 1
   printf '%s\n' "$parent"
 }
 if [ -f "$FM_HOME/$SUB_HOME_MARKER" ]; then
@@ -535,10 +530,6 @@ backlog_refresh_reminder() {
   fi
 }
 
-registry_home_for_line() {
-  sed -n 's/^[^(]*(home: \([^;)]*\);.*/\1/p'
-}
-
 path_is_ancestor_of() {
   local ancestor=$1 path=$2
   [ -n "$ancestor" ] || return 1
@@ -894,13 +885,19 @@ validate_removal_target() {
 registered_descendant_home_for_removal() {
   local reg=$1 target=$2 line id registered_home registered_abs
   [ -f "$reg" ] || return 1
-  while IFS= read -r line; do
+  if ! secondmate_registry_validate_bindings "$reg" secondmate_registry_path_key; then
+    echo "REFUSED: $SECONDMATE_REGISTRY_ERROR" >&2
+    return 2
+  fi
+  while IFS= read -r line || [ -n "$line" ]; do
     case "$line" in
       "- "*)
-        id=${line#- }
-        id=${id%% *}
-        registered_home=$(printf '%s\n' "$line" | registry_home_for_line)
-        [ -n "$registered_home" ] || continue
+        secondmate_registry_parse_line "$line" || {
+          echo "REFUSED: malformed secondmate registry entry: $line" >&2
+          return 2
+        }
+        id=$SECONDMATE_REGISTRY_ID
+        registered_home=$SECONDMATE_REGISTRY_HOME
         registered_abs=$(removal_target_abs_path "$registered_home" 2>/dev/null || true)
         [ -n "$registered_abs" ] || continue
         [ "$registered_abs" = "$target" ] && continue
@@ -989,11 +986,33 @@ validate_firstmate_home_for_removal() {
       echo "REFUSED: unsafe $label removal target $home is marked for secondmate ${marker_id:-unknown}, expected $expected_id" >&2
       return 1
     fi
+    if [ -e "$SECONDMATE_REG" ] || [ -L "$SECONDMATE_REG" ]; then
+      if ! secondmate_registry_validate_bindings "$SECONDMATE_REG" secondmate_registry_path_key "$expected_id" "$abs_home_path"; then
+        case "$SECONDMATE_REGISTRY_ERROR" in
+          overlapping\ secondmate\ home\ assignment:*)
+            echo "REFUSED: unsafe $label removal target $home contains registered secondmate home; $SECONDMATE_REGISTRY_ERROR" >&2
+            ;;
+          *) echo "REFUSED: $SECONDMATE_REGISTRY_ERROR" >&2 ;;
+        esac
+        return 1
+      fi
+    fi
   fi
   validate_firstmate_operational_dirs_for_removal "$abs_home_path" "$label" || return 1
-  conflict=$(registered_descendant_home_for_removal "$SECONDMATE_REG" "$abs_home_path" || true)
+  conflict=
+  if conflict=$(registered_descendant_home_for_removal "$SECONDMATE_REG" "$abs_home_path"); then
+    :
+  else
+    conflict_rc=$?
+    [ "$conflict_rc" -eq 1 ] || return 1
+  fi
   if [ -z "$conflict" ]; then
-    conflict=$(registered_descendant_home_for_removal "$abs_home_path/data/secondmates.md" "$abs_home_path" || true)
+    if conflict=$(registered_descendant_home_for_removal "$abs_home_path/data/secondmates.md" "$abs_home_path"); then
+      :
+    else
+      conflict_rc=$?
+      [ "$conflict_rc" -eq 1 ] || return 1
+    fi
   fi
   if [ -n "$conflict" ]; then
     IFS=$'\t' read -r child_id child_home <<EOF

--- a/bin/fm-update.sh
+++ b/bin/fm-update.sh
@@ -70,13 +70,17 @@ sweep_live_secondmate_metas "$STATE" origin no
 # Registry backstop: a secondmate registered in data/secondmates.md but without
 # a live meta (e.g. between restarts) is still its persistent on-disk home.
 if [ -f "$SECONDMATES_MD" ]; then
-  while IFS= read -r line; do
+  while IFS= read -r line || [ -n "$line" ]; do
     case "$line" in
       "- "*) ;;
       *) continue ;;
     esac
-    id=$(printf '%s\n' "$line" | sed -n 's/^- \([^ ][^ ]*\) - .*/\1/p')
-    home=$(printf '%s\n' "$line" | sed -n 's/.*(home:[[:space:]]*\([^;]*\);.*/\1/p' | sed 's/[[:space:]]*$//')
+    if ! secondmate_registry_parse_line "$line"; then
+      echo "secondmate registry: skipped malformed entry: $line" >&2
+      continue
+    fi
+    id=$SECONDMATE_REGISTRY_ID
+    home=$SECONDMATE_REGISTRY_HOME
     process_secondmate "$id" "$home" "" origin no
   done < "$SECONDMATES_MD"
 fi

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -168,6 +168,7 @@ When the file exists, `fm-spawn.sh` refuses crewmate and scout launches without 
 Secondmate launches are exempt because they resolve the secondmate harness and any optional secondmate model or effort tokens instead.
 Unsupported effort values are still recorded in task meta when passed to `fm-spawn.sh`, but the launch template omits any effort flag that the selected harness does not accept.
 That keeps spawn launch compatible across claude, codex, grok, pi, opencode, and kimi while preserving the requested profile for later audit.
+The final model also passes through the Antigravity quota preflight owned by [configuration.md](configuration.md#antigravity-quota-preflight) before spawn side effects begin.
 
 ## Optional secondmates
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -155,7 +155,7 @@ The helper's header owns exact parsing, publication, and report output mechanics
 
 Persistent secondmate routes live locally in `data/secondmates.md`.
 The concise single-line route contract is owned by the [`secondmate-provisioning` skill](../.agents/skills/secondmate-provisioning/SKILL.md#routing-table), including the parser-compatible fields, one-sentence summary requirement, `home:` pointer to the seeded charter, and limit on extra registry prose.
-`fm-home-seed.sh validate` refuses duplicate ids, duplicate homes, and nested or overlapping homes.
+Use `fm-home-seed.sh validate` to check the complete operational registry contract documented by the command itself.
 The main first mate routes by reading those scopes with judgment; the project list is provisioning data, not exclusive ownership.
 Use `fm-home-seed.sh <id> - {<project>...|--no-projects}` to lease a fresh firstmate worktree for the secondmate home.
 Use the deliberate `--no-projects` signal only for a firstmate-repo domain that needs no separate project clones.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -265,6 +265,16 @@ Malformed JSON, an empty or malformed rule/default array, an unverified harness,
 While the file remains present, no crewmate or scout spawn may proceed without an explicit resolved harness; malformed configuration must be reported and corrected rather than selected around.
 Secondmate homes inherit this file from the primary, so a secondmate's own crewmates apply the same dispatch profile behavior.
 
+## Antigravity quota preflight
+
+Before `fm-spawn.sh` creates a worktree, backend endpoint, agent process, or task metadata, every final model whose name begins with `antigravity/` must pass the Antigravity quota preflight.
+The checker is the executable `antigravity-account-check.js` under `${PI_CODING_AGENT_DIR:-$HOME/.pi/agent}/extensions/antigravity-account-switcher/bin/` (falling back to `${PI_CODING_AGENT_DIR:-$HOME/.pi/agent}/extensions/pi-antigravity-account-switcher/bin/antigravity-account-check.js`), unless the test-only `FM_ANTIGRAVITY_PREFLIGHT_BIN` override is set.
+The preflight invokes that checker with `check`, bounds its runtime with `FM_ANTIGRAVITY_PREFLIGHT_TIMEOUT_SECONDS` (default `30` seconds) using `timeout`, `gtimeout`, or `perl`, and discards output after the bounded `FM_ANTIGRAVITY_PREFLIGHT_OUTPUT_BYTES` limit (default `8192` bytes) so checker output cannot be surfaced as a secret-bearing diagnostic.
+Exit `0` preserves the requested model and effort.
+The checker's documented exit `1` means all configured accounts are unusable and changes the final profile to `cockpit/gpt-5.6-luna` at `high` effort.
+Missing or non-executable checkers, invalid limits, missing timeout support (`timeout`, `gtimeout`, or `perl`), timeouts, crashes, errors, and unknown exit results refuse the spawn before those side effects occur.
+The same boundary applies to explicit models, dispatch-profile models, scouts, secondmates, and raw launch commands, while non-Antigravity models bypass it.
+
 ## Toolchain
 
 On session start the first mate detects what its required toolchain is missing or too old and lists each problem with either an exact install command or manual instructions.

--- a/tests/fm-backend.test.sh
+++ b/tests/fm-backend.test.sh
@@ -141,7 +141,7 @@ resolve_permissive_tmux_kill_ref() {
 # hence the dispatcher is a copied sibling, while the tmux adapter is extracted
 # from BASE_REF so conformance tests retain the exact historical behavior even
 # when this branch changes tmux dispatch semantics.
-OLD_BIN_UNCHANGED_SIBLINGS="fm-gate-refuse-lib.sh fm-guard.sh fm-lock-lib.sh fm-tasks-axi-lib.sh fm-pr-lib.sh fm-tangle-lib.sh fm-tmux-lib.sh fm-composer-lib.sh fm-wake-lib.sh fm-classify-lib.sh fm-supervision-lib.sh fm-ff-lib.sh fm-config-inherit-lib.sh fm-project-mode.sh fm-harness.sh fm-crew-state.sh fm-decision-hold.sh fm-backend.sh fm-operational-input.sh fm-public-followup-lib.sh fm-x-lib.sh"
+OLD_BIN_UNCHANGED_SIBLINGS="fm-gate-refuse-lib.sh fm-guard.sh fm-lock-lib.sh fm-tasks-axi-lib.sh fm-pr-lib.sh fm-tangle-lib.sh fm-tmux-lib.sh fm-composer-lib.sh fm-wake-lib.sh fm-classify-lib.sh fm-supervision-lib.sh fm-ff-lib.sh fm-config-inherit-lib.sh fm-project-mode.sh fm-harness.sh fm-crew-state.sh fm-decision-hold.sh fm-backend.sh fm-operational-input.sh fm-public-followup-lib.sh fm-secondmate-registry-lib.sh fm-x-lib.sh"
 # A pull-request merge may add a new main-only dependency that the branch's older baseline does not have yet.
 OLD_BIN_OPTIONAL_SIBLINGS="fm-pending-reply-lib.sh"
 OLD_BIN_REFACTORED="fm-send.sh fm-peek.sh fm-watch.sh fm-spawn.sh fm-teardown.sh fm-marker-lib.sh"

--- a/tests/fm-backlog-handoff.test.sh
+++ b/tests/fm-backlog-handoff.test.sh
@@ -482,9 +482,11 @@ test_registry_home_with_pre_home_parentheses() {
   setup_homes "$home" "$sub" "$id"
   local sub_abs
   sub_abs=$(cd "$sub" && pwd -P)
-  # Prose parentheses before (home: ...), matching live registry shape.
-  printf -- '- %s - issue triage (id is legacy) (home: %s; scope: issue triage; projects: alpha; added 2026-07-09)\n' \
+  # Prose parentheses before (home: ...) and punctuation inside scope match the live registry shape.
+  printf -- '- %s - issue triage (id is legacy) (home: %s; scope: issue triage (child); semicolon is meaningful; projects: alpha; added 2026-07-09)\n' \
     "$id" "$sub_abs" > "$home/data/secondmates.md"
+  FM_HOME="$home" "$ROOT/bin/fm-home-seed.sh" validate >/dev/null \
+    || fail "home-seed validation rejected punctuation-bearing registry fields"
 
   cat > "$home/data/backlog.md" <<'EOF'
 ## Queued

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -188,6 +188,77 @@ write_registry() {
 EOF
 }
 
+assert_specialist_rule() {
+  local brief=$1 context=$2 expected_return
+  if [ "$context" = scout ]; then
+    expected_return="your findings and evidence"
+  else
+    expected_return="implementation, evidence, and any required PR"
+  fi
+  assert_grep "Standard implementation uses one \`antigravity/gemini-3.6-flash\` crewmate at high effort unless Firstmate explicitly overrides dispatch." "$brief" \
+    "$context brief missing standard crewmate dispatch"
+  assert_grep "You own narrow supporting calls to installed specialists: use \`@fixer\` for targeted implementation, \`@explorer\` for repository mapping and search, \`@plan\` for architecture or implementation planning, \`@designer\` for frontend, UI, and visual work, and \`@oracle\` for independent correctness and risk review when authorized." "$brief" \
+    "$context brief missing worker-owned specialist routing"
+  assert_grep "Inspect and incorporate returned findings yourself, then return $expected_return to Firstmate while preserving this brief's isolation, approval, and delivery rules." "$brief" \
+    "$context brief missing delegation boundary guidance"
+  assert_no_grep "lelouch" "$brief" "$context brief must not add an automatic Lelouch review"
+}
+
+assert_web_research_rule() {
+  local brief=$1 context=$2
+  assert_grep "For web research, use Firecrawl MCP first: call \`firecrawl_search\`, call \`firecrawl_search_feedback\` after using its results, and use \`firecrawl_scrape\` for known pages." "$brief" \
+    "$context brief missing Firecrawl MCP routing rule"
+  assert_grep "If Firecrawl is unavailable, use another tool only as a fallback and disclose that fallback in your findings." "$brief" \
+    "$context brief missing Firecrawl fallback disclosure"
+}
+
+assert_review_path_rule() {
+  local brief=$1 context=$2
+  assert_grep "Before pre-commit review, record the base and HEAD SHAs, then have the reviewer inspect the exact committed range with \`git diff <base>...<HEAD>\` and use \`git show <base>..<HEAD>\` for commit details" "$brief" \
+    "$context brief missing committed-range review verification"
+  assert_grep "if the review tool cannot access those commits or shows an empty range, report the mismatch instead of reviewing it." "$brief" \
+    "$context brief missing committed-range mismatch handling"
+}
+
+test_project_mode_defaults_and_rejects_malformed() {
+  local home out brief err
+  home="$TMP_ROOT/project-mode-home"
+  mkdir -p "$home/data"
+  cat > "$home/data/projects.md" <<'EOF'
+- omitted-proj - omitted mode (added 2026-07-01)
+- explicit-proj [direct-PR] - explicit mode (added 2026-07-01)
+- malformed-proj [bogus +yolo] - malformed mode (added 2026-07-01)
+- malformed-yolo-proj [+yolo] - missing explicit mode (added 2026-07-01)
+- malformed-extra-proj [direct-PR +yolo unexpected] - malformed option (added 2026-07-01)
+- malformed-trailing-proj [direct-PR +yolo] unexpected - malformed trailing token (added 2026-07-01)
+- malformed-third-proj unexpected - malformed third token (added 2026-07-01)
+EOF
+  out=$(FM_HOME="$home" "$ROOT/bin/fm-project-mode.sh" omitted-proj)
+  [ "$out" = "direct-PR on" ] || fail "omitted delivery mode did not default to direct-PR on"
+  out=$(FM_HOME="$home" "$ROOT/bin/fm-project-mode.sh" explicit-proj)
+  [ "$out" = "direct-PR off" ] || fail "explicit delivery mode did not preserve yolo off"
+  out=$(FM_HOME="$home" "$ROOT/bin/fm-project-mode.sh" malformed-proj 2>/dev/null)
+  [ "$out" = "no-mistakes off" ] || fail "malformed explicit mode did not fall back to no-mistakes off"
+  out=$(FM_HOME="$home" "$ROOT/bin/fm-project-mode.sh" malformed-yolo-proj 2>/dev/null)
+  [ "$out" = "no-mistakes off" ] || fail "malformed [+yolo] mode did not fall back to no-mistakes off"
+  out=$(FM_HOME="$home" "$ROOT/bin/fm-project-mode.sh" malformed-extra-proj 2>/dev/null)
+  [ "$out" = "no-mistakes off" ] || fail "malformed explicit option did not fall back to no-mistakes off"
+  out=$(FM_HOME="$home" "$ROOT/bin/fm-project-mode.sh" malformed-trailing-proj 2>/dev/null)
+  [ "$out" = "no-mistakes off" ] || fail "malformed trailing token did not fall back to no-mistakes off"
+  err="$home/malformed-third.err"
+  out=$(FM_HOME="$home" "$ROOT/bin/fm-project-mode.sh" malformed-third-proj 2>"$err")
+  [ "$out" = "no-mistakes off" ] || fail "malformed third token did not fall back to no-mistakes off"
+  grep -F 'malformed mode' "$err" >/dev/null \
+    || fail "malformed third token did not emit a warning"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" omitted-brief omitted-proj >/dev/null
+  brief="$home/data/omitted-brief/brief.md"
+  assert_grep "This project ships **direct-PR**" "$brief" \
+    "omitted mode brief did not use direct-PR delivery"
+  assert_no_grep "This project ships **no-mistakes**" "$brief" \
+    "omitted mode brief used no-mistakes delivery"
+  pass "fm-project-mode: omitted mode defaults to direct-PR on and malformed modes fall back safely"
+}
+
 # fm-brief.sh must exit 0 and produce a brief with no unreplaced shell
 # metacharacter corruption for every ship delivery mode. This also guards
 # against any *new* unescaped apostrophe or unbalanced quote later added to
@@ -209,6 +280,9 @@ test_ship_modes_generate_clean_briefs() {
     assert_grep "{TASK}" "$brief" "$id: brief missing the {TASK} placeholder"
     assert_grep "mid-task \`working:\` line (including setup complete) is nonterminal" "$brief" \
       "$id: brief missing nonterminal working:/setup-complete gate protection"
+    assert_specialist_rule "$brief" "$id"
+    assert_web_research_rule "$brief" "$id"
+    assert_review_path_rule "$brief" "$id"
     assert_no_grep "EOF" "$brief" "$id: brief leaked a heredoc EOF marker (unterminated heredoc)"
   done
   pass "fm-brief.sh: no-mistakes/direct-PR/local-only briefs generate cleanly"
@@ -223,6 +297,8 @@ test_faster_paths_use_configured_authority_without_stacked_review() {
   brief="$home/data/$id/brief.md"
   assert_grep "The configured merge authority decides whether to merge the PR; firstmate relays the outcome." "$brief" \
     "direct-PR brief lost configured merge authority"
+  assert_grep "Before pushing or requesting a PR, you must ask \`@oracle\` for a fresh read-only review of the complete committed range and verification evidence, using rule 10's exact base/HEAD commands." "$brief" \
+    "direct-PR brief lost its mandatory exact-range Oracle review"
   assert_no_grep "The captain reviews and merges the PR" "$brief" \
     "direct-PR brief hard-coded captain-only authority"
   id="brief-local-authority-a4"
@@ -234,6 +310,12 @@ test_faster_paths_use_configured_authority_without_stacked_review() {
     "local-only brief hard-coded captain-only authority"
   assert_no_grep "Firstmate then reviews your branch diff" "$brief" \
     "local-only brief retained a personal review stacked on the selected delivery path"
+  assert_no_grep "make \`--intent\` preserve all relevant content from this brief" "$home/data/$id/brief.md" \
+    "local-only brief must not include the no-mistakes --intent contract"
+  id="brief-direct-intent-a4"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" direct-proj >/dev/null 2>&1
+  assert_no_grep "make \`--intent\` preserve all relevant content from this brief" "$home/data/$id/brief.md" \
+    "direct-PR brief must not include the no-mistakes --intent contract"
   pass "fm-brief.sh: faster paths use configured authority without stacked review"
 }
 
@@ -255,13 +337,23 @@ test_no_mistakes_dod_wording() {
   # shellcheck disable=SC2016  # single quotes are deliberate: the backticks must stay literal
   assert_grep '`help`' "$brief" \
     "no-mistakes DOD must render literal backticks around help"
+  assert_grep "make \`--intent\` preserve all relevant content from this brief" "$brief" \
+    "no-mistakes DOD must require --intent to retain the accepted task contract"
+  assert_grep "carrying only each requirement's current accepted form" "$brief" \
+    "no-mistakes DOD must replace superseded requirements with their current accepted form"
+  assert_grep "retain direct requirements instead of substituting a diff summary" "$brief" \
+    "no-mistakes DOD must keep direct requirements and exclude generic scaffold boilerplate from --intent"
+  assert_grep "exclude generic operational, status, delivery, and other scaffold boilerplate unless it is task-specific" "$brief" \
+    "no-mistakes DOD must exclude non-task-specific scaffold boilerplate from --intent"
   # The apostrophe in "firstmate's authority check" is now structurally safe
   # (no `$(...)` wrapper around the heredoc), so it renders verbatim instead of
   # being reworded or escaped away. test_no_heredoc_in_command_substitution
   # guards the structure that makes it safe.
   assert_grep "firstmate's authority check" "$brief" \
     "no-mistakes DOD lost the apostrophe prose that the structural fix makes parse-safe"
-  pass "fm-brief.sh: no-mistakes DOD keeps its apostrophe prose, now parse-safe"
+  assert_no_grep "Before pushing or requesting a PR" "$brief" \
+    "no-mistakes brief must not add the direct-PR Oracle review gate"
+  pass "fm-brief.sh: no-mistakes DOD keeps its apostrophe prose without a direct-PR Oracle gate"
 }
 
 test_ship_project_memory_wording() {
@@ -607,6 +699,9 @@ test_scout_and_secondmate_scaffold() {
   assert_present "$brief" "scout brief was not scaffolded"
   assert_grep "SCOUT task" "$brief" "scout brief must declare itself a scout task"
   assert_grep "report.md" "$brief" "scout brief must point at the report deliverable"
+  assert_specialist_rule "$brief" "scout"
+  assert_web_research_rule "$brief" "scout"
+  assert_review_path_rule "$brief" "scout"
 
   FM_SECONDMATE_CHARTER='Supervise the alpha domain.' \
     FM_HOME="$BRIEF_HOME" "$ROOT/bin/fm-brief.sh" brief-sm-q6 --secondmate alpha >/dev/null 2>&1 \
@@ -619,6 +714,7 @@ test_scout_and_secondmate_scaffold() {
 }
 
 test_script_parses
+test_project_mode_defaults_and_rejects_malformed
 test_no_heredoc_in_command_substitution
 test_help_includes_entire_header
 test_ship_modes_generate_clean_briefs

--- a/tests/fm-gotmp.test.sh
+++ b/tests/fm-gotmp.test.sh
@@ -70,6 +70,7 @@ make_fake_root() {
   # teardown now requires.
   ln -s "$ROOT/bin/fm-public-followup-lib.sh" "$fake/bin/fm-public-followup-lib.sh"
   ln -s "$ROOT/bin/fm-x-lib.sh" "$fake/bin/fm-x-lib.sh"
+  ln -s "$ROOT/bin/fm-secondmate-registry-lib.sh" "$fake/bin/fm-secondmate-registry-lib.sh"
   # fm-guard.sh: stub (teardown calls it with `|| true`).
   cat > "$fake/bin/fm-guard.sh" <<'SH'
 #!/usr/bin/env bash
@@ -142,6 +143,7 @@ test_teardown_skips_gracefully_without_tasktmp() {
   # teardown now requires.
   ln -s "$ROOT/bin/fm-public-followup-lib.sh" "$fake/bin/fm-public-followup-lib.sh"
   ln -s "$ROOT/bin/fm-x-lib.sh" "$fake/bin/fm-x-lib.sh"
+  ln -s "$ROOT/bin/fm-secondmate-registry-lib.sh" "$fake/bin/fm-secondmate-registry-lib.sh"
   cat > "$fake/bin/fm-guard.sh" <<'SH'
 #!/usr/bin/env bash
 exit 0

--- a/tests/fm-public-followup.test.sh
+++ b/tests/fm-public-followup.test.sh
@@ -585,7 +585,7 @@ test_delivery_requires_registration_before_posting() {
 }
 
 test_secondmate_teardown_requires_parent_binding() {
-  local parent child
+  local parent child registry_before marker_before
   parent=$(make_home teardown-parent)
   child=$(make_home teardown-child)
   printf '%s\n' mate > "$child/.fm-secondmate-home"
@@ -607,8 +607,12 @@ test_secondmate_teardown_requires_parent_binding() {
   parent=$(make_home teardown-valid-parent)
   child=$(make_home teardown-valid-child)
   printf '%s\n' mate > "$child/.fm-secondmate-home"
-  printf -- '- mate - synthetic (home: %s; scope: synthetic; projects: ; added 2026-07-30)\n' \
+  printf -- '- mate - synthetic (id is legacy); preserve this (home: %s; scope: synthetic (child); semicolon remains meaningful; projects: ; added 2026-07-30)\n' \
     "$child" > "$parent/data/secondmates.md"
+  FM_HOME="$parent" "$ROOT/bin/fm-home-seed.sh" validate >/dev/null \
+    || fail "home-seed validation rejected a punctuation-bearing operational registry record"
+  registry_before=$(cat "$parent/data/secondmates.md")
+  marker_before=$(cat "$child/.fm-secondmate-home")
   seed_commitment "$parent" pf-teardown-valid req-teardown-valid x secondmate:mate work-child
   fm_write_meta "$parent/state/mate.meta" "kind=secondmate" "home=$child"
   fm_write_meta "$child/state/work-child.meta" \
@@ -627,6 +631,10 @@ test_secondmate_teardown_requires_parent_binding() {
   esac
   assert_present "$child/state/work-child.meta" \
     "an owed parent commitment must preserve the child work metadata"
+  [ "$registry_before" = "$(cat "$parent/data/secondmates.md")" ] \
+    || fail "guarded cleanup refusal changed the parent registry"
+  [ "$marker_before" = "$(cat "$child/.fm-secondmate-home")" ] \
+    || fail "guarded cleanup refusal changed the child identity marker"
   pass "marked secondmate teardown resolves its parent and fails closed when unavailable"
 }
 

--- a/tests/fm-secondmate-lifecycle-e2e.test.sh
+++ b/tests/fm-secondmate-lifecycle-e2e.test.sh
@@ -51,7 +51,7 @@ setup_world() {
   cat > "$HOME_DIR/data/projects.md" <<EOF
 - alpha [direct-PR +yolo] - alpha project (added 2026-06-22)
 - beta [direct-PR] - beta project (added 2026-06-22)
-- gamma - gamma project (added 2026-06-22)
+- gamma [no-mistakes] - gamma project (added 2026-06-22)
 EOF
   ALPHA_ORIGIN=$(git -C "$HOME_DIR/projects/alpha" remote get-url origin)
   BETA_ORIGIN=$(git -C "$HOME_DIR/projects/beta" remote get-url origin)

--- a/tests/fm-secondmate-safety.test.sh
+++ b/tests/fm-secondmate-safety.test.sh
@@ -109,6 +109,72 @@ EOF
   pass "seed allows overlapping project clone lists and drops the owns/owner routing"
 }
 
+test_home_seed_validate_rejects_unparseable_registry_entry() {
+  local home err
+  home="$TMP_ROOT/unparseable-registry-home"
+  err="$TMP_ROOT/unparseable-registry.err"
+  mkdir -p "$home/data"
+  printf '%s\n' '- broken - prose (home: /tmp/child; scope: missing projects and date)' > "$home/data/secondmates.md"
+  if FM_HOME="$home" "$ROOT/bin/fm-home-seed.sh" validate >/dev/null 2>"$err"; then
+    fail "home-seed validation accepted an operationally unparseable registry record"
+  fi
+  grep -F 'malformed secondmate registry entry' "$err" >/dev/null \
+    || fail "home-seed validation did not explain the malformed registry record"
+  pass "home-seed validation rejects registry records no operational parser can consume"
+}
+
+test_home_seed_refuses_broken_registry_symlink() {
+  local home sub err target
+  home="$TMP_ROOT/broken-registry-symlink-home"
+  sub="$TMP_ROOT/broken-registry-symlink-subhome"
+  err="$TMP_ROOT/broken-registry-symlink.err"
+  target="$home/data/missing-secondmates.md"
+  mkdir -p "$home/data" "$home/state" "$home/projects"
+  ln -s "$target" "$home/data/secondmates.md"
+  if FM_HOME="$home" "$ROOT/bin/fm-home-seed.sh" validate >/dev/null 2>"$err"; then
+    fail "home-seed validation accepted a broken registry symlink"
+  fi
+  grep -F 'secondmate registry is unavailable or unsafe' "$err" >/dev/null \
+    || fail "home-seed validation did not explain the broken registry symlink"
+  if FM_HOME="$home" FM_SECONDMATE_CHARTER='design domain' \
+    "$ROOT/bin/fm-home-seed.sh" design "$sub" alpha >/dev/null 2>"$err"; then
+    fail "home seeding accepted a broken registry symlink"
+  fi
+  [ -L "$home/data/secondmates.md" ] || fail "home seeding replaced the broken registry symlink"
+  [ ! -e "$target" ] || fail "home seeding wrote through the broken registry symlink"
+  [ ! -e "$sub" ] || fail "home seeding provisioned a home before broken registry refusal"
+  [ ! -e "$home/data/design" ] || fail "home seeding created a brief before broken registry refusal"
+  pass "home seeding refuses broken registry symlinks before provisioning"
+}
+
+test_home_seed_refuses_unreadable_registry() {
+  local home sub err registry
+  home="$TMP_ROOT/unreadable-registry-home"
+  sub="$TMP_ROOT/unreadable-registry-subhome"
+  err="$TMP_ROOT/unreadable-registry.err"
+  registry="$home/data/secondmates.md"
+  mkdir -p "$home/data" "$home/state" "$home/projects"
+  printf '%s\n' '- design - design domain (home: /tmp/design; scope: design; projects: alpha; added 2026-07-30)' > "$registry"
+  chmod 000 "$registry"
+  if FM_HOME="$home" "$ROOT/bin/fm-home-seed.sh" validate >/dev/null 2>"$err"; then
+    chmod 600 "$registry"
+    fail "home-seed validation accepted an unreadable registry"
+  fi
+  grep -F 'secondmate registry is unavailable or unsafe' "$err" >/dev/null || {
+    chmod 600 "$registry"
+    fail "home-seed validation did not explain the unreadable registry"
+  }
+  if FM_HOME="$home" FM_SECONDMATE_CHARTER='design domain' \
+    "$ROOT/bin/fm-home-seed.sh" design "$sub" alpha >/dev/null 2>"$err"; then
+    chmod 600 "$registry"
+    fail "home seeding accepted an unreadable registry"
+  fi
+  chmod 600 "$registry"
+  [ ! -e "$sub" ] || fail "home seeding provisioned a home before unreadable registry refusal"
+  [ ! -e "$home/data/design" ] || fail "home seeding created a brief before unreadable registry refusal"
+  pass "home seeding refuses unreadable registries before provisioning"
+}
+
 test_home_seed_validate_rejects_duplicate_homes() {
   local home subhome subhome_abs err
   home="$TMP_ROOT/duplicate-home"
@@ -442,6 +508,94 @@ test_home_seed_no_projects_end_to_end() {
   proj_val=$(grep '^projects=' "$meta" | head -1 | cut -d= -f2-)
   [ -z "$proj_val" ] || fail "project-less spawn recorded a non-empty projects meta: '$proj_val'"
   pass "home seeding scaffolds, registers, and spawns a project-less home end to end"
+}
+
+test_secondmate_spawn_resolves_punctuated_registry_projects() {
+  local home sub sub_abs fakebin log meta projects
+  home="$TMP_ROOT/punctuated-spawn-home"
+  sub="$TMP_ROOT/punctuated-spawn-subhome"
+  mkdir -p "$home/data" "$home/state" "$home/config" "$home/projects"
+  mkdir -p "$sub/data" "$sub/state" "$sub/config" "$sub/projects"
+  mark_firstmate_home "$sub"
+  printf 'punctuated\n' > "$sub/.fm-secondmate-home"
+  printf '# Charter\n\nHandled work.\n' > "$sub/data/charter.md"
+  sub_abs=$(cd "$sub" && pwd -P)
+  printf -- '- punctuated - launch notes (parenthetical) (home: %s; scope: launch (child); semicolon is valid; projects: alpha, beta; added 2026-07-30)' \
+    "$sub_abs" > "$home/data/secondmates.md"
+  FM_HOME="$home" "$ROOT/bin/fm-home-seed.sh" validate >/dev/null \
+    || fail "home-seed validation rejected punctuated registry fields before spawn"
+  fakebin=$(make_fake_tmux "$TMP_ROOT/punctuated-spawn-fake")
+  log="$TMP_ROOT/punctuated-spawn-fake/tmux.log"
+  PATH="$fakebin:$PATH" FM_HOME="$home" FM_FAKE_TMUX_LOG="$log" \
+    FM_FAKE_TMUX_CAPTURE="$TMP_ROOT/punctuated-spawn-fake/pane.txt" \
+    "$ROOT/bin/fm-spawn.sh" punctuated codex --secondmate >/dev/null 2>&1 \
+    || fail "secondmate spawn failed for punctuated registry fields"
+  meta="$home/state/punctuated.meta"
+  projects=$(grep '^projects=' "$meta" | cut -d= -f2-)
+  [ "$projects" = 'alpha, beta' ] \
+    || fail "secondmate spawn resolved the wrong projects field: '$projects'"
+  pass "secondmate spawn resolves home validation and projects from punctuated registry fields"
+}
+
+test_secondmate_spawn_refuses_ambiguous_and_mismatched_registry_bindings() {
+  local row case_name home sub other fakebin log err meta_before
+  for row in duplicate-id unterminated-duplicate-id duplicate-home supplied-mismatch metadata-mismatch; do
+    case_name=${row%%|*}
+    home="$TMP_ROOT/spawn-binding-$case_name-home"
+    sub="$TMP_ROOT/spawn-binding-$case_name-sub"
+    other="$TMP_ROOT/spawn-binding-$case_name-other"
+    mkdir -p "$home/data" "$home/state" "$home/config" "$home/projects"
+    mark_firstmate_home "$sub"
+    mark_firstmate_home "$other"
+    printf 'domain\n' > "$sub/.fm-secondmate-home"
+    printf 'domain\n' > "$other/.fm-secondmate-home"
+    case "$case_name" in
+      duplicate-id)
+        cat > "$home/data/secondmates.md" <<EOF
+- domain - primary route (home: $sub; scope: valid (scope); punctuation; projects: alpha; added 2026-07-30)
+- domain - duplicate route (home: $other; scope: duplicate; projects: beta; added 2026-07-30)
+EOF
+        ;;
+      unterminated-duplicate-id)
+        printf -- '- domain - primary route (home: %s; scope: valid (scope); punctuation; projects: alpha; added 2026-07-30)\n- domain - duplicate route (home: %s; scope: duplicate; projects: beta; added 2026-07-30)' \
+          "$sub" "$other" > "$home/data/secondmates.md"
+        ;;
+      duplicate-home)
+        cat > "$home/data/secondmates.md" <<EOF
+- domain - primary route (home: $sub; scope: valid (scope); punctuation; projects: alpha; added 2026-07-30)
+- other - duplicate home route (home: $sub; scope: duplicate; projects: beta; added 2026-07-30)
+EOF
+        ;;
+      supplied-mismatch|metadata-mismatch)
+        printf -- '- domain - mismatched route (home: %s; scope: valid (scope); punctuation; projects: alpha; added 2026-07-30)\n' \
+          "$other" > "$home/data/secondmates.md"
+        ;;
+    esac
+    fakebin=$(make_fake_tmux "$TMP_ROOT/spawn-binding-$case_name-fake")
+    log="$TMP_ROOT/spawn-binding-$case_name-fake/tmux.log"
+    err="$TMP_ROOT/spawn-binding-$case_name.err"
+    if [ "$case_name" = metadata-mismatch ]; then
+      fm_write_secondmate_meta "$home/state/domain.meta" "$sub"
+      meta_before="$TMP_ROOT/spawn-binding-$case_name.meta.before"
+      cp "$home/state/domain.meta" "$meta_before"
+      if PATH="$fakebin:$PATH" FM_HOME="$home" FM_FAKE_TMUX_LOG="$log" \
+        FM_FAKE_TMUX_CAPTURE="$TMP_ROOT/spawn-binding-$case_name-fake/pane.txt" \
+        "$ROOT/bin/fm-spawn.sh" domain codex --secondmate >/dev/null 2>"$err"; then
+        fail "secondmate spawn accepted $case_name registry binding"
+      fi
+      cmp -s "$meta_before" "$home/state/domain.meta" || fail "secondmate spawn changed metadata after $case_name refusal"
+    else
+      if PATH="$fakebin:$PATH" FM_HOME="$home" FM_FAKE_TMUX_LOG="$log" \
+        FM_FAKE_TMUX_CAPTURE="$TMP_ROOT/spawn-binding-$case_name-fake/pane.txt" \
+        "$ROOT/bin/fm-spawn.sh" domain "$sub" codex --secondmate >/dev/null 2>"$err"; then
+        fail "secondmate spawn accepted $case_name registry binding"
+      fi
+      [ ! -e "$home/state/domain.meta" ] || fail "secondmate spawn wrote metadata after $case_name refusal"
+    fi
+    [ ! -e "$home/state/.spawn-domain.lock" ] || fail "secondmate spawn left a lock after $case_name refusal"
+    grep -F 'new-window' "$log" >/dev/null && fail "secondmate spawn created an endpoint before $case_name refusal"
+  done
+  pass "secondmate spawn refuses ambiguous, supplied-home, and metadata-home registry bindings"
 }
 
 test_home_seed_refuses_projectful_reused_charter_for_projectless_home() {
@@ -978,7 +1132,7 @@ test_home_seed_skips_initialized_existing_no_mistakes_projects() {
   origin=$(git -C "$home/projects/alpha" remote get-url origin)
   git clone --quiet "$origin" "$subhome/projects/alpha"
   git -C "$subhome/projects/alpha" remote add no-mistakes "$TMP_ROOT/no-mistakes-alpha.git"
-  printf '%s\n' '- alpha - alpha project (added 2026-06-22)' '- beta - beta project (added 2026-06-22)' > "$home/data/projects.md"
+  printf '%s\n' '- alpha [no-mistakes] - alpha project (added 2026-06-22)' '- beta [no-mistakes] - beta project (added 2026-06-22)' > "$home/data/projects.md"
   fakebin=$(make_recording_no_mistakes "$TMP_ROOT/existing-initialized-fake")
   : > "$log"
 
@@ -1010,7 +1164,7 @@ test_home_seed_refuses_uninitialized_existing_no_mistakes_project() {
   mkdir -p "$subhome/projects"
   origin=$(git -C "$home/projects/alpha" remote get-url origin)
   git clone --quiet "$origin" "$subhome/projects/alpha"
-  printf '%s\n' '- alpha - alpha project (added 2026-06-22)' > "$home/data/projects.md"
+  printf '%s\n' '- alpha [no-mistakes] - alpha project (added 2026-06-22)' > "$home/data/projects.md"
   fakebin=$(make_recording_no_mistakes "$TMP_ROOT/existing-uninitialized-fake")
   : > "$log"
 
@@ -1314,6 +1468,53 @@ EOF
   [ ! -e "$home/state/domain.meta" ] || fail "teardown did not clear parent meta"
   grep -F -- '- domain ' "$home/data/secondmates.md" >/dev/null && fail "teardown did not remove secondmate registry route"
   pass "secondmate teardown retires empty homes and releases routing"
+}
+
+test_secondmate_teardown_refuses_ambiguous_and_mismatched_registry_bindings() {
+  local case_name home sub other fakebin log err meta_before registry_before
+  for case_name in duplicate-id duplicate-home home-mismatch; do
+    home="$TMP_ROOT/teardown-binding-$case_name-home"
+    sub="$TMP_ROOT/teardown-binding-$case_name-sub"
+    other="$TMP_ROOT/teardown-binding-$case_name-other"
+    mkdir -p "$home/state" "$home/data" "$sub/state" "$sub/data" "$sub/config" "$sub/projects" "$other"
+    printf 'domain\n' > "$sub/.fm-secondmate-home"
+    fm_write_secondmate_meta "$home/state/domain.meta" "$sub"
+    case "$case_name" in
+      duplicate-id)
+        cat > "$home/data/secondmates.md" <<EOF
+- domain - primary route (home: $sub; scope: valid (scope); punctuation; projects: alpha; added 2026-07-30)
+- domain - duplicate route (home: $other; scope: duplicate; projects: beta; added 2026-07-30)
+EOF
+        ;;
+      duplicate-home)
+        cat > "$home/data/secondmates.md" <<EOF
+- domain - primary route (home: $sub; scope: valid (scope); punctuation; projects: alpha; added 2026-07-30)
+- other - duplicate home route (home: $sub; scope: duplicate; projects: beta; added 2026-07-30)
+EOF
+        ;;
+      home-mismatch)
+        printf -- '- domain - mismatched route (home: %s; scope: valid (scope); punctuation; projects: alpha; added 2026-07-30)\n' \
+          "$other" > "$home/data/secondmates.md"
+        ;;
+    esac
+    meta_before="$TMP_ROOT/teardown-binding-$case_name.meta.before"
+    registry_before="$TMP_ROOT/teardown-binding-$case_name.registry.before"
+    cp "$home/state/domain.meta" "$meta_before"
+    cp "$home/data/secondmates.md" "$registry_before"
+    fakebin=$(make_fake_tmux "$TMP_ROOT/teardown-binding-$case_name-fake")
+    log="$TMP_ROOT/teardown-binding-$case_name-fake/tmux.log"
+    err="$TMP_ROOT/teardown-binding-$case_name.err"
+    if PATH="$fakebin:$PATH" FM_HOME="$home" FM_FAKE_TMUX_LOG="$log" \
+      FM_FAKE_TMUX_CAPTURE="$TMP_ROOT/teardown-binding-$case_name-fake/pane.txt" \
+      "$ROOT/bin/fm-teardown.sh" domain --force >/dev/null 2>"$err"; then
+      fail "secondmate teardown accepted $case_name registry binding"
+    fi
+    [ -d "$sub" ] || fail "secondmate teardown removed the home after $case_name refusal"
+    cmp -s "$meta_before" "$home/state/domain.meta" || fail "secondmate teardown changed metadata after $case_name refusal"
+    cmp -s "$registry_before" "$home/data/secondmates.md" || fail "secondmate teardown changed registry after $case_name refusal"
+    grep -F 'kill-window' "$log" >/dev/null && fail "secondmate teardown killed an endpoint before $case_name refusal"
+  done
+  pass "secondmate teardown refuses ambiguous and identity-mismatched registry bindings"
 }
 
 test_secondmate_teardown_refuses_failed_leased_home_return() {
@@ -2167,6 +2368,9 @@ EOF
 test_fm_home_parameterization
 test_lock_status_is_per_home
 test_seed_allows_overlapping_clones_and_drops_owner
+test_home_seed_validate_rejects_unparseable_registry_entry
+test_home_seed_refuses_broken_registry_symlink
+test_home_seed_refuses_unreadable_registry
 test_home_seed_validate_rejects_duplicate_homes
 test_home_seed_validate_rejects_duplicate_ids
 test_home_seed_validate_rejects_nested_homes
@@ -2179,6 +2383,8 @@ test_home_seed_refuses_missing_filled_charter
 test_home_seed_refuses_placeholder_charter
 test_home_seed_refuses_empty_charter_fields
 test_home_seed_no_projects_end_to_end
+test_secondmate_spawn_resolves_punctuated_registry_projects
+test_secondmate_spawn_refuses_ambiguous_and_mismatched_registry_bindings
 test_home_seed_refuses_projectful_reused_charter_for_projectless_home
 test_home_seed_refuses_projectless_conversion_of_populated_home
 test_home_seed_refuses_projectless_home_with_uninspectable_projects
@@ -2205,6 +2411,7 @@ test_secondmate_spawn_requires_seeded_matching_home
 test_secondmate_spawn_refuses_operational_dirs_outside_subhome
 test_fm_send_refuses_bare_window_without_home_meta
 test_secondmate_teardown_retires_empty_home
+test_secondmate_teardown_refuses_ambiguous_and_mismatched_registry_bindings
 test_secondmate_teardown_refuses_failed_leased_home_return
 test_secondmate_teardown_removes_plain_clone_home_without_treehouse_return
 test_secondmate_force_teardown_discards_child_work

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -72,6 +72,12 @@ enable_dispatch_profile() {
     > "$home/config/crew-dispatch.json"
 }
 
+enable_antigravity_dispatch_profile() {
+  local home=$1
+  printf '%s\n' '{"rules":[{"when":"current events","use":{"harness":"pi","model":"antigravity/gemini-3.6-flash","effort":"high"}}],"default":{"harness":"pi","model":"antigravity/gemini-3.6-flash","effort":"high"}}' \
+    > "$home/config/crew-dispatch.json"
+}
+
 make_seeded_secondmate_home() {
   local home=$1 id=$2
   mkdir -p "$home/bin" "$home/data"
@@ -93,8 +99,59 @@ run_spawn() {
     FM_PROJECTS_OVERRIDE="$home/projects" FM_CONFIG_OVERRIDE="$home/config" \
     FM_SPAWN_NO_GUARD=1 FM_FAKE_PANE_PATH="$wt" TMUX="fake,1,0" \
     CLAUDE_CONFIG_DIR="${FM_TEST_CLAUDE_CONFIG_DIR:-}" \
-    FM_FAKE_LAUNCH_LOG="$launchlog" GROK_HOME="$home/grok-home" PATH="$fakebin:$PATH" \
+    FM_FAKE_LAUNCH_LOG="$launchlog" \
+    FM_ANTIGRAVITY_PREFLIGHT_BIN="${PREFLIGHT_BIN:-}" \
+    FM_ANTIGRAVITY_PREFLIGHT_TIMEOUT_SECONDS="${PREFLIGHT_TIMEOUT:-30}" \
+    FM_PREFLIGHT_LOG="${PREFLIGHT_LOG:-}" FM_PREFLIGHT_RESULT="${PREFLIGHT_RESULT:-ok}" \
+    GROK_HOME="$home/grok-home" PATH="$fakebin:$PATH" \
     "$SPAWN" "$@" 2>&1
+}
+
+make_preflight_checker() {
+  local path=$1
+  cat > "$path" <<'SH'
+#!/usr/bin/env bash
+set -u
+[ -z "${FM_PREFLIGHT_LOG:-}" ] || printf '%s\n' "$*" >> "$FM_PREFLIGHT_LOG"
+case "${FM_PREFLIGHT_RESULT:-ok}" in
+  ok) printf '%s\n' 'OK: active re***@example.invalid is usable (rotated: false)'; exit 0 ;;
+  exhausted) printf '%s\n' 'EXHAUSTED: all configured accounts are exhausted or unavailable'; exit 1 ;;
+  secret-error) printf '%s\n' 'ERROR: refresh_token=super-secret-value leaked@example.invalid'; exit 2 ;;
+  timeout) sleep 5; exit 0 ;;
+  signal-kill) kill -9 $$ ;;
+  *) exit 23 ;;
+esac
+SH
+  chmod +x "$path"
+}
+
+make_forked_preflight_checker() {
+  local path=$1
+  cat > "$path" <<'SH'
+#!/usr/bin/env bash
+set -u
+[ -z "${FM_PREFLIGHT_LOG:-}" ] || printf '%s\n' "$*" >> "$FM_PREFLIGHT_LOG"
+( sleep 10 >/dev/null 2>&1 & )
+printf '%s\n' 'OK: active re***@example.invalid is usable'
+exit 0
+SH
+  chmod +x "$path"
+}
+
+make_large_preflight_checker() {
+  local path=$1 result=${2:-ok}
+  cat > "$path" <<SH
+#!/usr/bin/env bash
+set -u
+[ -z "\${FM_PREFLIGHT_LOG:-}" ] || printf '%s\n' "\$*" >> "\$FM_PREFLIGHT_LOG"
+python3 -c 'print("X" * 50000)'
+case "$result" in
+  ok) exit 0 ;;
+  exhausted) exit 1 ;;
+  *) exit 2 ;;
+esac
+SH
+  chmod +x "$path"
 }
 
 read_case_record() {
@@ -667,6 +724,389 @@ test_active_dispatch_profile_does_not_block_secondmate_launch() {
   pass "active crew-dispatch profile does not block secondmate launches"
 }
 
+test_antigravity_preflight_exit_zero_preserves_profile() {
+  local rec id out status
+  id=preflight-ok-z17
+  rec=$(make_spawn_case preflight-ok pi "$id")
+  read_case_record "$rec"
+  PREFLIGHT_BIN="$CASE_DIR/checker"
+  PREFLIGHT_LOG="$CASE_DIR/checker.log"
+  PREFLIGHT_RESULT=ok
+  make_preflight_checker "$PREFLIGHT_BIN"
+
+  out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR" \
+    --model antigravity/gemini-3.6-flash --effort high)
+  status=$?
+  expect_code 0 "$status" "usable Antigravity quota should permit the spawn"
+  assert_meta_profile "$HOME_DIR/state/$id.meta" pi antigravity/gemini-3.6-flash high
+  assert_grep "check" "$PREFLIGHT_LOG" "preflight checker was not invoked with check"
+  pass "exit 0 keeps the requested Antigravity model and effort"
+}
+
+test_antigravity_preflight_configured_profile_covers_scouts() {
+  local rec id out status
+  id=preflight-profile-scout-z17b
+  rec=$(make_spawn_case preflight-profile-scout pi "$id")
+  read_case_record "$rec"
+  enable_antigravity_dispatch_profile "$HOME_DIR"
+  PREFLIGHT_BIN="$CASE_DIR/checker"
+  PREFLIGHT_LOG="$CASE_DIR/checker.log"
+  PREFLIGHT_RESULT=ok
+  make_preflight_checker "$PREFLIGHT_BIN"
+
+  out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR" \
+    --harness pi --model antigravity/gemini-3.6-flash --effort high --scout)
+  status=$?
+  expect_code 0 "$status" "configured Antigravity scout profile should permit the spawn"
+  assert_grep "kind=scout" "$HOME_DIR/state/$id.meta" "configured Antigravity scout did not record kind=scout"
+  assert_meta_profile "$HOME_DIR/state/$id.meta" pi antigravity/gemini-3.6-flash high
+  assert_grep "check" "$PREFLIGHT_LOG" "configured Antigravity scout did not invoke preflight"
+  pass "configured Antigravity profiles use the shared scout boundary"
+}
+
+test_antigravity_preflight_all_unusable_falls_back_before_metadata() {
+  local rec id out status launch
+  id=preflight-exhausted-z18
+  rec=$(make_spawn_case preflight-exhausted pi "$id")
+  read_case_record "$rec"
+  PREFLIGHT_BIN="$CASE_DIR/checker"
+  PREFLIGHT_LOG="$CASE_DIR/checker.log"
+  PREFLIGHT_RESULT=exhausted
+  make_preflight_checker "$PREFLIGHT_BIN"
+
+  out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR" \
+    --model antigravity/gemini-3.6-flash --effort xhigh)
+  status=$?
+  expect_code 0 "$status" "exhausted Antigravity accounts should fall back to Luna high"
+  assert_meta_profile "$HOME_DIR/state/$id.meta" pi cockpit/gpt-5.6-luna high
+  launch=$(cat "$LAUNCH_LOG")
+  assert_contains "$launch" "--model 'cockpit/gpt-5.6-luna' --thinking 'high'" \
+    "launch command did not receive the Luna high fallback profile"
+  assert_grep "check" "$PREFLIGHT_LOG" "exhausted accounts test did not run the quota checker"
+  pass "exit 1 falls back to Luna high before endpoint and metadata publication"
+}
+
+test_antigravity_preflight_raw_launch_uses_fallback() {
+  local rec id out status launch
+  id=preflight-raw-fallback-z18b
+  rec=$(make_spawn_case preflight-raw-fallback pi "$id")
+  read_case_record "$rec"
+  PREFLIGHT_BIN="$CASE_DIR/checker"
+  PREFLIGHT_LOG="$CASE_DIR/checker.log"
+  PREFLIGHT_RESULT=exhausted
+  make_preflight_checker "$PREFLIGHT_BIN"
+
+  out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR" \
+    "custom-agent --flag" --model antigravity/gemini-3.6-flash --effort xhigh)
+  status=$?
+  expect_code 0 "$status" "raw launch should use the documented Luna fallback"
+  assert_meta_profile "$HOME_DIR/state/$id.meta" custom-agent cockpit/gpt-5.6-luna high
+  launch=$(cat "$LAUNCH_LOG")
+  assert_contains "$launch" "custom-agent --flag --model 'cockpit/gpt-5.6-luna' --effort 'high'" \
+    "raw launch did not receive the Luna fallback"
+  pass "exit 1 applies the Luna fallback to raw launch commands"
+}
+
+test_antigravity_preflight_error_is_secret_safe_and_refuses() {
+  local rec id out status
+  id=preflight-error-z19
+  rec=$(make_spawn_case preflight-error pi "$id")
+  read_case_record "$rec"
+  PREFLIGHT_BIN="$CASE_DIR/checker"
+  PREFLIGHT_LOG="$CASE_DIR/checker.log"
+  PREFLIGHT_RESULT=secret-error
+  make_preflight_checker "$PREFLIGHT_BIN"
+
+  out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR" \
+    --model antigravity/gemini-3.6-flash --effort high)
+  status=$?
+  expect_code 1 "$status" "checker error exit code must refuse Antigravity launch"
+  assert_contains "$out" "unrecognized result (exit 2)" "preflight error refusal was not concrete"
+  assert_not_contains "$out" "super-secret-value" "preflight error leaked secret diagnostic text"
+  assert_absent "$HOME_DIR/state/$id.meta" "checker error wrote task metadata"
+  pass "checker error exit code refuses without leaking checker stdout"
+}
+
+test_antigravity_preflight_missing_and_non_executable_refuse() {
+  local rec id out status
+  id=preflight-missing-z20
+  rec=$(make_spawn_case preflight-missing pi "$id")
+  read_case_record "$rec"
+  PREFLIGHT_BIN="$CASE_DIR/missing-checker"
+
+  out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR" \
+    --model antigravity/gemini-3.6-flash --effort high)
+  status=$?
+  expect_code 1 "$status" "missing checker must refuse Antigravity launch"
+  assert_contains "$out" "missing or not executable" "missing checker refusal was not concrete"
+  assert_absent "$HOME_DIR/state/$id.meta" "missing checker wrote task metadata"
+
+  touch "$PREFLIGHT_BIN"
+  chmod -x "$PREFLIGHT_BIN"
+  out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR" \
+    --model antigravity/gemini-3.6-flash --effort high)
+  status=$?
+  expect_code 1 "$status" "non-executable checker must refuse Antigravity launch"
+  assert_contains "$out" "missing or not executable" "non-executable refusal was not concrete"
+  assert_absent "$HOME_DIR/state/$id.meta" "non-executable checker wrote task metadata"
+  pass "missing or non-executable checker refuses before endpoint creation"
+}
+
+test_antigravity_preflight_timeout_refuses() {
+  local rec id out status
+  id=preflight-timeout-z21
+  rec=$(make_spawn_case preflight-timeout pi "$id")
+  read_case_record "$rec"
+  PREFLIGHT_BIN="$CASE_DIR/checker"
+  PREFLIGHT_LOG="$CASE_DIR/checker.log"
+  PREFLIGHT_RESULT=timeout
+  make_preflight_checker "$PREFLIGHT_BIN"
+
+  out=$(PREFLIGHT_TIMEOUT=1 \
+    run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR" \
+    --model antigravity/gemini-3.6-flash --effort high)
+  status=$?
+  expect_code 1 "$status" "preflight timeout must refuse Antigravity launch"
+  assert_contains "$out" "timed out" "timeout refusal was not concrete"
+  assert_absent "$HOME_DIR/state/$id.meta" "timeout wrote task metadata"
+  pass "preflight timeout refuses before endpoint creation"
+}
+
+test_antigravity_preflight_skips_non_antigravity_models() {
+  local rec id out status
+  id=preflight-luna-z23
+  rec=$(make_spawn_case preflight-luna pi "$id")
+  read_case_record "$rec"
+  PREFLIGHT_BIN="$CASE_DIR/missing-checker"
+  PREFLIGHT_LOG="$CASE_DIR/checker.log"
+  PREFLIGHT_RESULT=ok
+
+  out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR" \
+    --model cockpit/gpt-5.6-luna --effort high)
+  status=$?
+  expect_code 0 "$status" "Luna must not require Antigravity preflight"
+  assert_meta_profile "$HOME_DIR/state/$id.meta" pi cockpit/gpt-5.6-luna high
+  assert_absent "$PREFLIGHT_LOG" "Luna launch unexpectedly invoked Antigravity preflight"
+  pass "Luna and other non-Antigravity models bypass the checker"
+}
+
+test_antigravity_preflight_applies_to_configured_secondmate_model() {
+  local rec id sm out status
+  id=preflight-secondmate-z24
+  rec=$(make_spawn_case preflight-secondmate codex "$id")
+  read_case_record "$rec"
+  sm="$CASE_DIR/secondmate-home"
+  make_seeded_secondmate_home "$sm" "$id"
+  mkdir -p "$sm/state" "$sm/config" "$sm/projects"
+  printf '%s\n' 'pi antigravity/gemini-3.6-flash medium' > "$HOME_DIR/config/secondmate-harness"
+  PREFLIGHT_BIN="$CASE_DIR/checker"
+  PREFLIGHT_LOG="$CASE_DIR/checker.log"
+  PREFLIGHT_RESULT=exhausted
+  make_preflight_checker "$PREFLIGHT_BIN"
+
+  out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$sm" --secondmate)
+  status=$?
+  expect_code 0 "$status" "secondmate Antigravity model should use the shared preflight boundary"
+  assert_meta_profile "$HOME_DIR/state/$id.meta" pi cockpit/gpt-5.6-luna high
+  assert_grep "check" "$PREFLIGHT_LOG" "secondmate did not invoke the quota checker"
+  pass "secondmate config models use the same preflight and accurate fallback metadata"
+}
+
+test_antigravity_preflight_forked_checker_does_not_hang() {
+  local rec id out status
+  id=preflight-forked-z25
+  rec=$(make_spawn_case preflight-forked pi "$id")
+  read_case_record "$rec"
+  PREFLIGHT_BIN="$CASE_DIR/checker"
+  PREFLIGHT_LOG="$CASE_DIR/checker.log"
+  make_forked_preflight_checker "$PREFLIGHT_BIN"
+
+  out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR" \
+    --model antigravity/gemini-3.6-flash --effort high)
+  status=$?
+  expect_code 0 "$status" "forked checker should return promptly and permit spawn"
+  assert_meta_profile "$HOME_DIR/state/$id.meta" pi antigravity/gemini-3.6-flash high
+  assert_grep "check" "$PREFLIGHT_LOG" "forked checker was not invoked"
+  pass "forked checker process does not hang the preflight"
+}
+
+test_antigravity_preflight_invalid_limits_refuse() {
+  local rec id out status
+  id=preflight-invalid-limits-z26
+  rec=$(make_spawn_case preflight-invalid-limits pi "$id")
+  read_case_record "$rec"
+  PREFLIGHT_BIN="$CASE_DIR/checker"
+  PREFLIGHT_LOG="$CASE_DIR/checker.log"
+  PREFLIGHT_RESULT=ok
+  make_preflight_checker "$PREFLIGHT_BIN"
+
+  out=$(PREFLIGHT_TIMEOUT=invalid \
+    run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR" \
+    --model antigravity/gemini-3.6-flash --effort high)
+  status=$?
+  expect_code 1 "$status" "non-integer timeout must refuse spawn"
+  assert_contains "$out" "timeout is not a positive integer" "invalid timeout refusal missing diagnostic"
+  assert_absent "$HOME_DIR/state/$id.meta" "invalid timeout written metadata"
+
+  out=$(FM_ANTIGRAVITY_PREFLIGHT_OUTPUT_BYTES=0 \
+    run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR" \
+    --model antigravity/gemini-3.6-flash --effort high)
+  status=$?
+  expect_code 1 "$status" "zero output limit must refuse spawn"
+  assert_contains "$out" "output limit must be positive" "invalid output limit refusal missing diagnostic"
+  assert_absent "$HOME_DIR/state/$id.meta" "invalid output limit written metadata"
+  pass "invalid timeout and output limit settings refuse before endpoint creation"
+}
+
+test_antigravity_preflight_uses_default_checker_path() {
+  local rec id out status agent_dir checker_path
+  id=preflight-default-path-z27
+  rec=$(make_spawn_case preflight-default-path pi "$id")
+  read_case_record "$rec"
+  agent_dir="$CASE_DIR/pi-agent"
+  checker_path="$agent_dir/extensions/antigravity-account-switcher/bin/antigravity-account-check.js"
+  mkdir -p "$(dirname "$checker_path")"
+  PREFLIGHT_LOG="$CASE_DIR/checker.log"
+  PREFLIGHT_RESULT=ok
+  make_preflight_checker "$checker_path"
+
+  out=$(PI_CODING_AGENT_DIR="$agent_dir" PREFLIGHT_BIN="" \
+    run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR" \
+    --model antigravity/gemini-3.6-flash --effort high)
+  status=$?
+  expect_code 0 "$status" "default checker path under PI_CODING_AGENT_DIR should succeed"
+  assert_meta_profile "$HOME_DIR/state/$id.meta" pi antigravity/gemini-3.6-flash high
+  assert_grep "check" "$PREFLIGHT_LOG" "default checker path was not invoked"
+  pass "default checker path under PI_CODING_AGENT_DIR is resolved and executed"
+}
+
+test_antigravity_preflight_uses_secondary_fallback_checker_path() {
+  local rec id out status agent_dir secondary_checker_path
+  id=preflight-secondary-path-z33
+  rec=$(make_spawn_case preflight-secondary-path pi "$id")
+  read_case_record "$rec"
+  agent_dir="$CASE_DIR/pi-agent"
+  secondary_checker_path="$agent_dir/extensions/pi-antigravity-account-switcher/bin/antigravity-account-check.js"
+  mkdir -p "$(dirname "$secondary_checker_path")"
+  PREFLIGHT_LOG="$CASE_DIR/checker.log"
+  PREFLIGHT_RESULT=ok
+  make_preflight_checker "$secondary_checker_path"
+
+  out=$(PI_CODING_AGENT_DIR="$agent_dir" PREFLIGHT_BIN="" \
+    run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR" \
+    --model antigravity/gemini-3.6-flash --effort high)
+  status=$?
+  expect_code 0 "$status" "secondary checker path under PI_CODING_AGENT_DIR should succeed when primary is missing"
+  assert_meta_profile "$HOME_DIR/state/$id.meta" pi antigravity/gemini-3.6-flash high
+  assert_grep "check" "$PREFLIGHT_LOG" "secondary checker path was not invoked"
+  pass "secondary checker path under PI_CODING_AGENT_DIR is resolved and executed when primary path is missing"
+}
+
+test_antigravity_preflight_embedded_raw_launch_model_uses_fallback() {
+  local rec id out status launch
+  id=preflight-raw-embedded-z28
+  rec=$(make_spawn_case preflight-raw-embedded pi "$id")
+  read_case_record "$rec"
+  PREFLIGHT_BIN="$CASE_DIR/checker"
+  PREFLIGHT_LOG="$CASE_DIR/checker.log"
+  PREFLIGHT_RESULT=exhausted
+  make_preflight_checker "$PREFLIGHT_BIN"
+
+  out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR" \
+    "custom-agent --model=antigravity/gemini-3.6-flash --effort xhigh")
+  status=$?
+  expect_code 0 "$status" "raw launch with embedded antigravity model flag should trigger preflight fallback"
+  assert_meta_profile "$HOME_DIR/state/$id.meta" custom-agent cockpit/gpt-5.6-luna high
+  launch=$(cat "$LAUNCH_LOG")
+  assert_contains "$launch" "--model='cockpit/gpt-5.6-luna'" \
+    "embedded raw launch model did not receive Luna fallback"
+  assert_grep "check" "$PREFLIGHT_LOG" "embedded raw launch model did not invoke checker"
+  pass "raw launch commands with embedded model flag trigger preflight and Luna fallback"
+}
+
+test_antigravity_preflight_large_output_does_not_fail() {
+  local rec id out status
+  id=preflight-large-out-z29
+  rec=$(make_spawn_case preflight-large-out pi "$id")
+  read_case_record "$rec"
+  PREFLIGHT_BIN="$CASE_DIR/checker"
+  PREFLIGHT_LOG="$CASE_DIR/checker.log"
+  make_large_preflight_checker "$PREFLIGHT_BIN" ok
+
+  out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR" \
+    --model antigravity/gemini-3.6-flash --effort high)
+  status=$?
+  expect_code 0 "$status" "checker writing large output with exit 0 should succeed"
+  assert_meta_profile "$HOME_DIR/state/$id.meta" pi antigravity/gemini-3.6-flash high
+  pass "checker writing >8KB output with exit 0 does not receive SIGPIPE or fail"
+}
+
+test_antigravity_preflight_space_in_home_path_succeeds() {
+  local rec id out status home_space
+  id=preflight-space-z30
+  rec=$(make_spawn_case preflight-space pi "$id")
+  read_case_record "$rec"
+  home_space="$CASE_DIR/home with spaces"
+  mkdir -p "$home_space/data/$id" "$home_space/projects" "$home_space/state" "$home_space/config"
+  touch "$home_space/state/.last-watcher-beat"
+  printf 'brief for %s\n' "$id" > "$home_space/data/$id/brief.md"
+  PREFLIGHT_BIN="$CASE_DIR/checker"
+  PREFLIGHT_LOG="$CASE_DIR/checker.log"
+  PREFLIGHT_RESULT=ok
+  make_preflight_checker "$PREFLIGHT_BIN"
+
+  out=$(run_spawn "$home_space" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR" \
+    --model antigravity/gemini-3.6-flash --effort high)
+  status=$?
+  expect_code 0 "$status" "preflight with space in home path should succeed"
+  assert_meta_profile "$home_space/state/$id.meta" pi antigravity/gemini-3.6-flash high
+  pass "state path containing spaces is handled safely"
+}
+
+test_antigravity_preflight_quoted_embedded_raw_launch_model_uses_fallback() {
+  local rec id out status launch
+  id=preflight-raw-quoted-z31
+  rec=$(make_spawn_case preflight-raw-quoted pi "$id")
+  read_case_record "$rec"
+  PREFLIGHT_BIN="$CASE_DIR/checker"
+  PREFLIGHT_LOG="$CASE_DIR/checker.log"
+  PREFLIGHT_RESULT=exhausted
+  make_preflight_checker "$PREFLIGHT_BIN"
+
+  out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR" \
+    "custom-agent --model 'antigravity/gemini-3.6-flash' --effort xhigh")
+  status=$?
+  expect_code 0 "$status" "raw launch with single-quoted antigravity model should trigger fallback and replace flag"
+  assert_meta_profile "$HOME_DIR/state/$id.meta" custom-agent cockpit/gpt-5.6-luna high
+  launch=$(cat "$LAUNCH_LOG")
+  assert_contains "$launch" "custom-agent --model 'cockpit/gpt-5.6-luna' --effort 'high'" \
+    "quoted raw launch model and effort were not cleanly replaced"
+  assert_not_contains "$launch" "antigravity" \
+    "quoted raw launch model still contains old antigravity string"
+  assert_not_contains "$launch" "xhigh" \
+    "quoted raw launch effort still contains old xhigh string"
+  pass "single-quoted raw launch model and effort flags are parsed and cleanly replaced on fallback"
+}
+
+test_antigravity_preflight_signal_killed_checker_refuses() {
+  local rec id out status
+  id=preflight-sigkill-z32
+  rec=$(make_spawn_case preflight-sigkill pi "$id")
+  read_case_record "$rec"
+  PREFLIGHT_BIN="$CASE_DIR/checker"
+  PREFLIGHT_LOG="$CASE_DIR/checker.log"
+  PREFLIGHT_RESULT=signal-kill
+  make_preflight_checker "$PREFLIGHT_BIN"
+
+  out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR" \
+    --model antigravity/gemini-3.6-flash --effort high)
+  status=$?
+  expect_code 1 "$status" "signal-killed checker must refuse Antigravity launch"
+  assert_contains "$out" "unrecognized result (exit 255)" "signal-killed refusal did not report exit 255"
+  assert_absent "$HOME_DIR/state/$id.meta" "signal-killed checker wrote task metadata"
+  pass "checker killed by signal refuses spawn and reports unrecognized result"
+}
+
 test_no_profile_keeps_claude_profile_defaults
 test_relative_home_overrides_launch_with_absolute_cross_process_paths
 test_home_defaults_preserve_absolute_or_resolve_relative_paths
@@ -693,5 +1133,23 @@ test_claude_forwards_firstmate_config_dir_when_set
 test_claude_omits_config_dir_prefix_when_unset
 test_non_claude_harness_ignores_config_dir
 test_active_dispatch_profile_does_not_block_secondmate_launch
+test_antigravity_preflight_exit_zero_preserves_profile
+test_antigravity_preflight_configured_profile_covers_scouts
+test_antigravity_preflight_all_unusable_falls_back_before_metadata
+test_antigravity_preflight_raw_launch_uses_fallback
+test_antigravity_preflight_error_is_secret_safe_and_refuses
+test_antigravity_preflight_missing_and_non_executable_refuse
+test_antigravity_preflight_timeout_refuses
+test_antigravity_preflight_skips_non_antigravity_models
+test_antigravity_preflight_applies_to_configured_secondmate_model
+test_antigravity_preflight_forked_checker_does_not_hang
+test_antigravity_preflight_invalid_limits_refuse
+test_antigravity_preflight_uses_default_checker_path
+test_antigravity_preflight_uses_secondary_fallback_checker_path
+test_antigravity_preflight_embedded_raw_launch_model_uses_fallback
+test_antigravity_preflight_large_output_does_not_fail
+test_antigravity_preflight_space_in_home_path_succeeds
+test_antigravity_preflight_quoted_embedded_raw_launch_model_uses_fallback
+test_antigravity_preflight_signal_killed_checker_refuses
 
 echo "# all fm-spawn-dispatch-profile tests passed"


### PR DESCRIPTION
## Summary
Re-applies the Antigravity quota preflight check in `bin/fm-spawn.sh` before creating worktrees, endpoints, agent processes, or task metadata.

- Every final model beginning with `antigravity/` invokes `antigravity-account-check.js check` (resolving under `~/.pi/agent/extensions/antigravity-account-switcher/bin/` or falling back to `~/.pi/agent/extensions/pi-antigravity-account-switcher/bin/`).
- If all accounts are exhausted (exit 1), seamlessly falls back to `cockpit/gpt-5.6-luna` at `high` effort so workers can proceed safely.
- Non-Antigravity models bypass the check.
- Comprehensive test coverage in `tests/fm-spawn-dispatch-profile.test.sh` (43 tests passing).