### PR TITLE
feat(bin): add durable dispatch log for crewmate/scout/secondmate spawns

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,6 +80,7 @@ data/                personal fleet records; LOCAL, gitignored as a whole
   captain.md         this home's domain-local captain preferences and working style; LOCAL, gitignored, canonical even if harness memory mirrors it, and updated with inspect-then-update
   captain-shared.md  main-authoritative shared captain preferences propagated read-only to secondmate homes; LOCAL, gitignored, owned by secondmate-provisioning
   learnings.md       fleet-local operational facts and gotchas; LOCAL, gitignored; dated, evidence-backed, curated, and updated with inspect-then-update - rewrite and prune rather than append forever, the same contract as captain.md; created lazily, absent until this home has a learning to store
+  dispatch-log.jsonl append-only per-spawn/teardown dispatch record (harness/model/effort/kind/repo); query via bin/fm-dispatch-log.sh
   projects.md        thin fleet navigation registry; firstmate-private, parsed by fm-project-mode.sh (section 6)
   secondmates.md      secondmate routing table; firstmate-private, maintained by fm-home-seed.sh (section 6)
   <id>/brief.md      per-task crewmate brief, or per-secondmate charter brief when kind=secondmate

--- a/bin/fm-dispatch-log.sh
+++ b/bin/fm-dispatch-log.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+# fm-dispatch-log.sh - durable log of firstmate's own crewmate/scout/secondmate
+# dispatches, and a query CLI over it.
+#
+# Why this exists: state/<id>.meta records harness=/model=/effort=/kind=/mode=/
+# backend=/yolo= per task, but that file is deleted at teardown
+# (bin/fm-teardown.sh), so nothing survives a task's cleanup to compare dispatch
+# patterns - which harness/model got used, how often - across stretches of time
+# or across dispatch-policy changes. This is that durable record.
+#
+# Log format: data/dispatch-log.jsonl (JSON Lines - one JSON object per line, no
+# wrapping array). This is the single owner of that format; nowhere else
+# restates it. Two event types, each appended best-effort/non-fatal by its
+# owning script so a logging failure never fails a spawn or teardown:
+#   spawn:    {"event":"spawn","ts":"<ISO8601 UTC>","id":"<task id>",
+#              "harness":"...","model":"...","effort":"...","kind":"...",
+#              "repo":"...","mode":"...","backend":"...","yolo":"..."}
+#             Appended by bin/fm-spawn.sh right after it writes state/<id>.meta,
+#             reusing that same already-resolved variables (never recomputed).
+#   teardown: {"event":"teardown","ts":"<ISO8601 UTC>","id":"<task id>"}
+#             Appended by bin/fm-teardown.sh right before it deletes
+#             state/<id>.meta. Deliberately minimal: id is the join key back to
+#             the task's own spawn line; richer outcome detail (done/failed, PR
+#             url) already lives in tasks-axi's own Done record keyed by the
+#             same task id, so it is not duplicated here.
+# The log is personal fleet data (data/ is gitignored as a whole; AGENTS.md
+# section 2), never committed, and never pruned by this script.
+#
+# A missing data/dispatch-log.jsonl is a valid "no dispatches yet" state, not an
+# error: a brand-new fleet has appended nothing. An EXISTING but unreadable log
+# (e.g. bad permissions) is a real problem and errors loudly instead of quietly
+# reporting zero.
+#
+# Usage: fm-dispatch-log.sh summary [--since YYYY-MM-DD] [--until YYYY-MM-DD]
+#                                    [--group-by model|harness|kind|repo|effort]
+#   Filters spawn events (teardown events are join-only and never counted) by
+#   ts date (UTC) when --since/--until are given (inclusive on both ends),
+#   groups by the chosen field (default: model), and prints one
+#   "<value>: <count>" line per group - sorted by count descending, then value
+#   ascending - followed by a "total: <N>" line. A malformed JSON line is
+#   skipped rather than aborting the read. Exit 2 on a bad subcommand, flag, or
+#   value; exit 1 if the log exists but cannot be read, or jq is missing;
+#   exit 0 otherwise, including the empty-log and no-match cases.
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
+DATA="${FM_DATA_OVERRIDE:-$FM_HOME/data}"
+LOG="$DATA/dispatch-log.jsonl"
+
+usage() {
+  sed -n '2,36p' "$0" | sed 's/^# \{0,1\}//'
+}
+
+case "${1:-}" in
+  -h|--help) usage; exit 0 ;;
+esac
+
+SUB=${1:-}
+if [ -z "$SUB" ]; then
+  echo "error: missing subcommand; usage: fm-dispatch-log.sh summary [--since YYYY-MM-DD] [--until YYYY-MM-DD] [--group-by model|harness|kind|repo|effort]" >&2
+  exit 2
+fi
+case "$SUB" in
+  summary) ;;
+  *) echo "error: unknown subcommand '$SUB' (only 'summary' is supported)" >&2; exit 2 ;;
+esac
+shift
+
+SINCE=
+UNTIL=
+GROUP_BY=model
+want_value=
+for a in "$@"; do
+  if [ -n "$want_value" ]; then
+    case "$a" in
+      --*) echo "error: --$want_value requires a value" >&2; exit 2 ;;
+    esac
+    case "$want_value" in
+      since) SINCE=$a ;;
+      until) UNTIL=$a ;;
+      group-by) GROUP_BY=$a ;;
+    esac
+    want_value=
+    continue
+  fi
+  case "$a" in
+    --since) want_value=since ;;
+    --since=*) SINCE=${a#--since=} ;;
+    --until) want_value=until ;;
+    --until=*) UNTIL=${a#--until=} ;;
+    --group-by) want_value=group-by ;;
+    --group-by=*) GROUP_BY=${a#--group-by=} ;;
+    *) echo "error: unknown flag '$a'" >&2; exit 2 ;;
+  esac
+done
+[ -z "$want_value" ] || { echo "error: --$want_value requires a value" >&2; exit 2; }
+
+validate_date() {
+  local label=$1 value=$2
+  [ -n "$value" ] || return 0
+  case "$value" in
+    [0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]) return 0 ;;
+  esac
+  echo "error: --$label must be YYYY-MM-DD, got '$value'" >&2
+  exit 2
+}
+validate_date since "$SINCE"
+validate_date until "$UNTIL"
+
+case "$GROUP_BY" in
+  model|harness|kind|repo|effort) ;;
+  *) echo "error: --group-by must be one of model, harness, kind, repo, effort; got '$GROUP_BY'" >&2; exit 2 ;;
+esac
+
+if [ ! -e "$LOG" ]; then
+  echo "total: 0"
+  echo "note: no dispatch log yet ($LOG not found) - no dispatches recorded so far"
+  exit 0
+fi
+
+command -v jq >/dev/null 2>&1 || { echo "error: jq is required but not found on PATH" >&2; exit 1; }
+
+if [ ! -r "$LOG" ]; then
+  echo "error: dispatch log exists but is not readable: $LOG" >&2
+  exit 1
+fi
+
+RESULT=$(jq -R -s \
+  --arg since "$SINCE" --arg until "$UNTIL" --arg group "$GROUP_BY" '
+  split("\n")
+  | map(select(length > 0))
+  | map(try fromjson catch empty)
+  | map(select(type == "object" and .event == "spawn"))
+  | map(select(
+      ($since == "" or ((.ts // "")[0:10] >= $since))
+      and ($until == "" or ((.ts // "")[0:10] <= $until))
+    ))
+  | (group_by(.[$group] // "unknown")
+     | map({key: (.[0][$group] // "unknown"), count: length})
+     | sort_by(-.count, .key)) as $groups
+  | {groups: $groups, total: ($groups | map(.count) | add // 0)}
+' "$LOG") || { echo "error: failed to parse dispatch log $LOG" >&2; exit 1; }
+
+printf '%s' "$RESULT" | jq -r '.groups[] | "\(.key): \(.count)"'
+printf 'total: %s\n' "$(printf '%s' "$RESULT" | jq -r '.total')"

--- a/bin/fm-dispatch-log.sh
+++ b/bin/fm-dispatch-log.sh
@@ -17,6 +17,9 @@
 #              "repo":"...","mode":"...","backend":"...","yolo":"..."}
 #             Appended by bin/fm-spawn.sh right after it writes state/<id>.meta,
 #             reusing that same already-resolved variables (never recomputed).
+#             repo is blank for a kind=secondmate spawn: its resolved path is
+#             the secondmate's firstmate home, not a project repo, so it is
+#             left empty rather than mislabeled - grouped as "unknown" below.
 #   teardown: {"event":"teardown","ts":"<ISO8601 UTC>","id":"<task id>"}
 #             Appended by bin/fm-teardown.sh right before it deletes
 #             state/<id>.meta. Deliberately minimal: id is the join key back to
@@ -35,12 +38,13 @@
 #                                    [--group-by model|harness|kind|repo|effort]
 #   Filters spawn events (teardown events are join-only and never counted) by
 #   ts date (UTC) when --since/--until are given (inclusive on both ends),
-#   groups by the chosen field (default: model), and prints one
-#   "<value>: <count>" line per group - sorted by count descending, then value
-#   ascending - followed by a "total: <N>" line. A malformed JSON line is
-#   skipped rather than aborting the read. Exit 2 on a bad subcommand, flag, or
-#   value; exit 1 if the log exists but cannot be read, or jq is missing;
-#   exit 0 otherwise, including the empty-log and no-match cases.
+#   groups by the chosen field (default: model; a blank or missing value on
+#   that field buckets as "unknown"), and prints one "<value>: <count>" line
+#   per group - sorted by count descending, then value ascending - followed by
+#   a "total: <N>" line. A malformed JSON line is skipped rather than aborting
+#   the read. Exit 2 on a bad subcommand, flag, or value; exit 1 if the log
+#   exists but cannot be read, or jq is missing; exit 0 otherwise, including
+#   the empty-log and no-match cases.
 set -eu
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -50,7 +54,7 @@ DATA="${FM_DATA_OVERRIDE:-$FM_HOME/data}"
 LOG="$DATA/dispatch-log.jsonl"
 
 usage() {
-  sed -n '2,36p' "$0" | sed 's/^# \{0,1\}//'
+  sed -n '2,47p' "$0" | sed 's/^# \{0,1\}//'
 }
 
 case "${1:-}" in
@@ -129,6 +133,7 @@ fi
 
 RESULT=$(jq -R -s \
   --arg since "$SINCE" --arg until "$UNTIL" --arg group "$GROUP_BY" '
+  def bucket: if ((.[$group] // "") == "") then "unknown" else .[$group] end;
   split("\n")
   | map(select(length > 0))
   | map(try fromjson catch empty)
@@ -137,8 +142,8 @@ RESULT=$(jq -R -s \
       ($since == "" or ((.ts // "")[0:10] >= $since))
       and ($until == "" or ((.ts // "")[0:10] <= $until))
     ))
-  | (group_by(.[$group] // "unknown")
-     | map({key: (.[0][$group] // "unknown"), count: length})
+  | (group_by(bucket)
+     | map({key: (.[0] | bucket), count: length})
      | sort_by(-.count, .key)) as $groups
   | {groups: $groups, total: ($groups | map(.count) | add // 0)}
 ' "$LOG") || { echo "error: failed to parse dispatch log $LOG" >&2; exit 1; }

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1653,6 +1653,13 @@ META_WINDOW=$T
 # data/, full disk, ...) must never fail an otherwise-successful spawn.
 {
   mkdir -p "$DATA" 2>/dev/null
+  # A secondmate dispatch's PROJ_ABS is its firstmate home, not a project
+  # repo (see meta's own home= vs project= split above); leave repo blank
+  # rather than mislabeling a home path as a repo.
+  DISPATCH_LOG_REPO=$PROJ_ABS
+  if [ "$KIND" = secondmate ]; then
+    DISPATCH_LOG_REPO=
+  fi
   printf '{"event":"spawn","ts":"%s","id":"%s","harness":"%s","model":"%s","effort":"%s","kind":"%s","repo":"%s","mode":"%s","backend":"%s","yolo":"%s"}\n' \
     "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
     "$(json_escape "$ID")" \
@@ -1660,7 +1667,7 @@ META_WINDOW=$T
     "$(json_escape "${MODEL:-default}")" \
     "$(json_escape "${EFFORT:-default}")" \
     "$(json_escape "$KIND")" \
-    "$(json_escape "$PROJ_ABS")" \
+    "$(json_escape "$DISPATCH_LOG_REPO")" \
     "$(json_escape "$MODE")" \
     "$(json_escape "$BACKEND")" \
     "$(json_escape "$YOLO")" \

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -121,6 +121,9 @@
 # On success prints: spawned <id> harness=<name> kind=<ship|scout|secondmate> mode=<mode> yolo=<on|off> window=<backend-target> worktree=<path>
 # mode/yolo are resolved per-project from data/projects.md for ship/scout tasks;
 # secondmate spawns record mode=secondmate, yolo=off, home=, and projects=.
+# After a successful state/<id>.meta write, this script also appends a durable
+# "spawn" record to data/dispatch-log.jsonl; bin/fm-dispatch-log.sh's header
+# owns that log's format and query CLI.
 set -eu
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -1643,6 +1646,27 @@ META_WINDOW=$T
     echo "projects=$SECONDMATE_PROJECTS"
   fi
 } > "$STATE/$ID.meta"
+
+# Durable dispatch record (bin/fm-dispatch-log.sh header owns the log format).
+# Best-effort and non-fatal: reuses the variables already resolved above for
+# meta, never recomputes anything, and a logging failure (missing/unwritable
+# data/, full disk, ...) must never fail an otherwise-successful spawn.
+{
+  mkdir -p "$DATA" 2>/dev/null
+  printf '{"event":"spawn","ts":"%s","id":"%s","harness":"%s","model":"%s","effort":"%s","kind":"%s","repo":"%s","mode":"%s","backend":"%s","yolo":"%s"}\n' \
+    "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+    "$(json_escape "$ID")" \
+    "$(json_escape "$HARNESS")" \
+    "$(json_escape "${MODEL:-default}")" \
+    "$(json_escape "${EFFORT:-default}")" \
+    "$(json_escape "$KIND")" \
+    "$(json_escape "$PROJ_ABS")" \
+    "$(json_escape "$MODE")" \
+    "$(json_escape "$BACKEND")" \
+    "$(json_escape "$YOLO")" \
+    >> "$DATA/dispatch-log.jsonl"
+} 2>/dev/null || true
+
 [ "$BACKEND" = orca ] && ORCA_ABORT_CLEANUP=0
 
 sq_brief=$(shell_quote "$BRIEF")

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -57,6 +57,10 @@
 #   checks, and discards secondmate child work for kind=secondmate. Only use it
 #   when the captain has explicitly said to discard the work.
 #
+# Before deleting state/<id>.meta, this script also appends a durable
+# "teardown" record to data/dispatch-log.jsonl; bin/fm-dispatch-log.sh's header
+# owns that log's format and query CLI.
+#
 # Transient / stale worktree git lock recovery (teardown-lock-race): a crew process
 # killed mid-git-operation can leave a .git/worktrees/<wt>/index.lock (or, for a
 # non-linked worktree, .git/index.lock) that makes `treehouse return --force` fail
@@ -1685,6 +1689,16 @@ fm_backend_clear_transition "$BACKEND" "$STATE" "$T" || true
 [ -n "$TASK_TMP" ] && rm -rf "$TASK_TMP"
 remove_pr_poll_artifacts "$STATE" "$ID" || exit 1
 retire_busy_state "$STATE" "$ID" "$BUSY_GEN" || exit 1
+# Durable dispatch record (bin/fm-dispatch-log.sh header owns the log format).
+# Best-effort and non-fatal, appended while META still exists so the read above
+# stays the single source for this task's fields; a logging failure must never
+# block teardown. Deliberately minimal (id only) - see the header cross-reference.
+{
+  mkdir -p "$DATA" 2>/dev/null
+  printf '{"event":"teardown","ts":"%s","id":"%s"}\n' \
+    "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$ID" \
+    >> "$DATA/dispatch-log.jsonl"
+} 2>/dev/null || true
 rm -f "$STATE/$ID.status" "$STATE/$ID.turn-ended" "$STATE/$ID.meta" \
   "$STATE/$ID.pi-ext.ts" "$STATE/$ID.grok-turnend-token" \
   "$STATE/$ID.kimi-turnend-token"

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -89,6 +89,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-pr-merge.sh`         | Record PR metadata, then merge a task's canonical full GitHub URL                    |
 | `fm-promote.sh`          | Promote a scout task in place to a protected ship task                               |
 | `fm-teardown.sh`         | Fail-closed teardown: return landed ship worktrees, require completed scout deliverables, retire secondmate homes |
+| `fm-dispatch-log.sh`     | Durable per-spawn/teardown dispatch log and its `summary` query CLI                  |
 | `fm-harness.sh`          | Detect the running harness and resolve crew or secondmate harness, model, and effort |
 | `fm-lock.sh`             | Per-home firstmate session lock                                                      |
 | `fm-x-lib.sh`            | Shared X-mode config, relay, and reply-threading helpers                             |

--- a/tests/fm-dispatch-log.test.sh
+++ b/tests/fm-dispatch-log.test.sh
@@ -1,0 +1,327 @@
+#!/usr/bin/env bash
+# tests/fm-dispatch-log.test.sh - behavior tests for the durable dispatch log
+# query CLI (bin/fm-dispatch-log.sh: summary grouping/counting, --since/--until
+# filtering, empty/missing-log handling, malformed-line tolerance, and usage
+# errors), plus targeted tests on the real non-fatal append blocks documented in
+# bin/fm-spawn.sh and bin/fm-teardown.sh.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+command -v jq >/dev/null 2>&1 || { echo "skip: jq not found"; exit 0; }
+
+CLI="$ROOT/bin/fm-dispatch-log.sh"
+
+make_home() {  # <name>
+  local home
+  home=$(fm_test_tmproot "fm-dispatch-log-$1")
+  mkdir -p "$home/data"
+  printf '%s\n' "$home"
+}
+
+write_log() {  # <home> <line>...
+  local home=$1
+  shift
+  local line
+  for line in "$@"; do
+    printf '%s\n' "$line" >> "$home/data/dispatch-log.jsonl"
+  done
+}
+
+spawn_line() {  # <id> <ts> <harness> <model> <effort> <kind> <repo> <mode> <backend> <yolo>
+  printf '{"event":"spawn","ts":"%s","id":"%s","harness":"%s","model":"%s","effort":"%s","kind":"%s","repo":"%s","mode":"%s","backend":"%s","yolo":"%s"}' \
+    "$2" "$1" "$3" "$4" "$5" "$6" "$7" "$8" "$9" "${10}"
+}
+
+run() {  # <home> <args...>
+  local home=$1
+  shift
+  FM_HOME="$home" "$CLI" "$@"
+}
+
+# --- summary grouping and counting -------------------------------------------
+
+test_summary_groups_by_model_default_and_prints_total() {
+  local home out
+  home=$(make_home grouping)
+  write_log "$home" \
+    "$(spawn_line a1 2026-07-01T10:00:00Z claude sonnet high ship /x/foo no-mistakes tmux off)" \
+    "$(spawn_line a2 2026-07-02T10:00:00Z claude opus xhigh scout /x/foo no-mistakes tmux off)" \
+    "$(spawn_line a3 2026-07-03T10:00:00Z codex gpt medium ship /x/bar no-mistakes tmux on)" \
+    "$(spawn_line a4 2026-07-04T10:00:00Z claude sonnet high ship /x/foo no-mistakes tmux off)"
+  out=$(run "$home" summary)
+  assert_contains "$out" "sonnet: 2" "sonnet must be counted twice"
+  assert_contains "$out" "opus: 1" "opus must be counted once"
+  assert_contains "$out" "gpt: 1" "gpt must be counted once"
+  assert_contains "$out" "total: 4" "total must sum every spawn event"
+  pass "summary groups by model by default and prints a pre-computed total"
+}
+
+test_summary_group_by_other_fields() {
+  local home out
+  home=$(make_home other-fields)
+  write_log "$home" \
+    "$(spawn_line a1 2026-07-01T10:00:00Z claude sonnet high ship /x/foo no-mistakes tmux off)" \
+    "$(spawn_line a2 2026-07-02T10:00:00Z codex gpt medium scout /x/bar no-mistakes tmux on)"
+  out=$(run "$home" summary --group-by harness)
+  assert_contains "$out" "claude: 1" "harness group-by must count claude"
+  assert_contains "$out" "codex: 1" "harness group-by must count codex"
+  out=$(run "$home" summary --group-by kind)
+  assert_contains "$out" "ship: 1" "kind group-by must count ship"
+  assert_contains "$out" "scout: 1" "kind group-by must count scout"
+  out=$(run "$home" summary --group-by repo)
+  assert_contains "$out" "/x/foo: 1" "repo group-by must count /x/foo"
+  assert_contains "$out" "/x/bar: 1" "repo group-by must count /x/bar"
+  out=$(run "$home" summary --group-by effort)
+  assert_contains "$out" "high: 1" "effort group-by must count high"
+  assert_contains "$out" "medium: 1" "effort group-by must count medium"
+  pass "summary --group-by supports harness, kind, repo, and effort"
+}
+
+test_teardown_events_are_join_only_and_never_counted() {
+  local home out
+  home=$(make_home teardown-events)
+  write_log "$home" \
+    "$(spawn_line a1 2026-07-01T10:00:00Z claude sonnet high ship /x/foo no-mistakes tmux off)" \
+    '{"event":"teardown","ts":"2026-07-01T11:00:00Z","id":"a1"}'
+  out=$(run "$home" summary)
+  assert_contains "$out" "total: 1" "a teardown event must never be counted toward the total"
+  pass "teardown events are join-only and never counted in the summary"
+}
+
+# --- date filtering -----------------------------------------------------------
+
+test_since_until_date_filtering_is_inclusive() {
+  local home out
+  home=$(make_home date-filter)
+  write_log "$home" \
+    "$(spawn_line a1 2026-06-30T23:59:59Z claude sonnet high ship /x/foo no-mistakes tmux off)" \
+    "$(spawn_line a2 2026-07-01T00:00:00Z claude sonnet high ship /x/foo no-mistakes tmux off)" \
+    "$(spawn_line a3 2026-07-15T12:00:00Z claude sonnet high ship /x/foo no-mistakes tmux off)" \
+    "$(spawn_line a4 2026-07-31T23:59:59Z claude sonnet high ship /x/foo no-mistakes tmux off)" \
+    "$(spawn_line a5 2026-08-01T00:00:00Z claude sonnet high ship /x/foo no-mistakes tmux off)"
+  out=$(run "$home" summary --since 2026-07-01 --until 2026-07-31)
+  assert_contains "$out" "total: 3" "since/until bounds must be inclusive on both ends"
+  pass "--since/--until date filtering is inclusive on both boundary dates"
+}
+
+test_date_filter_with_no_matches_is_a_definitive_zero_not_blank() {
+  local home out
+  home=$(make_home no-match)
+  write_log "$home" \
+    "$(spawn_line a1 2026-07-01T10:00:00Z claude sonnet high ship /x/foo no-mistakes tmux off)"
+  out=$(run "$home" summary --since 2030-01-01)
+  assert_contains "$out" "total: 0" "a filter matching nothing must print a definitive total: 0"
+  pass "a date filter matching nothing prints a definitive total: 0, not blank output"
+}
+
+# --- empty / missing log ------------------------------------------------------
+
+test_missing_log_file_is_a_valid_empty_state_not_an_error() {
+  local home out rc
+  home=$(fm_test_tmproot fm-dispatch-log-missing)
+  out=$(run "$home" summary)
+  rc=$?
+  expect_code 0 "$rc" "a missing dispatch log must not be an error"
+  assert_contains "$out" "total: 0" "a missing log must still print a definitive total: 0"
+  assert_contains "$out" "no dispatch log yet" "a missing log must explain itself, not just print zero silently"
+  pass "a missing dispatch-log.jsonl is a valid empty-fleet state, not an error"
+}
+
+test_empty_log_file_present_is_also_zero() {
+  local home out
+  home=$(make_home empty-file)
+  : > "$home/data/dispatch-log.jsonl"
+  out=$(run "$home" summary)
+  assert_contains "$out" "total: 0" "a present-but-empty log must summarize to zero"
+  pass "an existing empty log summarizes to a definitive zero"
+}
+
+test_unreadable_log_errors_loudly_instead_of_silent_zero() {
+  local home rc err
+  home=$(make_home unreadable)
+  write_log "$home" "$(spawn_line a1 2026-07-01T10:00:00Z claude sonnet high ship /x/foo no-mistakes tmux off)"
+  if [ "$(id -u)" = 0 ]; then
+    echo "skip: running as root, permission bits do not restrict reads"
+    return 0
+  fi
+  chmod 000 "$home/data/dispatch-log.jsonl"
+  err=$(run "$home" summary 2>&1)
+  rc=$?
+  chmod 644 "$home/data/dispatch-log.jsonl"
+  [ "$rc" -ne 0 ] || fail "an unreadable log must not silently report success"
+  assert_contains "$err" "not readable" "an unreadable log must report a structured error, not a silent zero"
+  pass "an existing but unreadable log errors loudly instead of silently reporting zero"
+}
+
+test_malformed_json_line_is_skipped_not_fatal() {
+  local home out
+  home=$(make_home malformed)
+  write_log "$home" \
+    "$(spawn_line a1 2026-07-01T10:00:00Z claude sonnet high ship /x/foo no-mistakes tmux off)" \
+    'not valid json at all' \
+    '{"event":"spawn","harness":"codex"' \
+    "$(spawn_line a2 2026-07-02T10:00:00Z claude sonnet high ship /x/foo no-mistakes tmux off)"
+  out=$(run "$home" summary)
+  assert_contains "$out" "sonnet: 2" "malformed lines must be skipped, not counted or fatal"
+  assert_contains "$out" "total: 2" "the total must reflect only the well-formed spawn lines"
+  pass "a malformed JSON line is skipped rather than aborting the read"
+}
+
+# --- usage / bad input ---------------------------------------------------------
+
+test_unknown_subcommand_errors() {
+  local home rc
+  home=$(make_home bad-subcommand)
+  run "$home" bogus >/dev/null 2>&1
+  rc=$?
+  expect_code 2 "$rc" "an unknown subcommand must be a loud usage error"
+  pass "an unknown subcommand is a loud usage error"
+}
+
+test_unknown_flag_errors() {
+  local home rc
+  home=$(make_home bad-flag)
+  run "$home" summary --nope >/dev/null 2>&1
+  rc=$?
+  expect_code 2 "$rc" "an unknown flag must be a loud usage error"
+  pass "an unknown flag is a loud usage error"
+}
+
+test_bad_group_by_value_errors() {
+  local home rc
+  home=$(make_home bad-groupby)
+  run "$home" summary --group-by nonsense >/dev/null 2>&1
+  rc=$?
+  expect_code 2 "$rc" "an invalid --group-by value must be a loud usage error"
+  pass "an invalid --group-by value is a loud usage error"
+}
+
+test_bad_date_format_errors() {
+  local home rc
+  home=$(make_home bad-date)
+  run "$home" summary --since 07/01/2026 >/dev/null 2>&1
+  rc=$?
+  expect_code 2 "$rc" "a malformed --since date must be a loud usage error"
+  pass "a malformed --since/--until date is a loud usage error"
+}
+
+# --- the real append blocks in fm-spawn.sh / fm-teardown.sh --------------------
+#
+# A full spawn/teardown integration test is out of scope (would require mocking
+# the whole backend/worktree pipeline); these instead eval the LITERAL append
+# block from each script (extracted, not reimplemented) against stubbed
+# variables, so a regression in the actual shipped code is caught.
+
+extract_block() {  # <file>
+  awk '
+    /# Durable dispatch record \(bin\/fm-dispatch-log\.sh header owns the log format\)\./ {flag=1}
+    flag {print}
+    flag && /^} 2>\/dev\/null \|\| true$/ {exit}
+  ' "$1"
+}
+
+test_spawn_append_block_produces_the_documented_json_shape() {
+  local home block out
+  home=$(make_home spawn-append)
+  block=$(extract_block "$ROOT/bin/fm-spawn.sh")
+  [ -n "$block" ] || fail "could not locate the dispatch-log append block in bin/fm-spawn.sh"
+  # The variables and function below are consumed by the eval'd extracted
+  # block, invisibly to shellcheck's static analysis.
+  # shellcheck disable=SC2034,SC2329
+  out=$(
+    set -eu
+    json_escape() { printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g'; }
+    DATA="$home/data"
+    ID="spawn-shape"
+    HARNESS="claude"
+    MODEL="sonnet"
+    EFFORT="high"
+    KIND="ship"
+    PROJ_ABS="/x/foo"
+    MODE="no-mistakes"
+    BACKEND="tmux"
+    YOLO="off"
+    eval "$block"
+    cat "$DATA/dispatch-log.jsonl"
+  )
+  printf '%s' "$out" | jq -e '
+    .event == "spawn" and .id == "spawn-shape" and .harness == "claude"
+      and .model == "sonnet" and .effort == "high" and .kind == "ship"
+      and .repo == "/x/foo" and .mode == "no-mistakes" and .backend == "tmux"
+      and .yolo == "off" and (.ts | test("^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$"))
+  ' >/dev/null || fail "the real fm-spawn.sh append block did not produce the documented JSON shape: $out"
+  pass "the real fm-spawn.sh append block produces the documented spawn JSON shape"
+}
+
+test_spawn_append_block_is_non_fatal_when_data_is_unwritable() {
+  local home block rc parent out_file
+  home=$(make_home spawn-nonfatal)
+  parent="$home/readonly-parent"
+  mkdir -p "$parent"
+  if [ "$(id -u)" = 0 ]; then
+    echo "skip: running as root, permission bits do not restrict writes"
+    return 0
+  fi
+  chmod 555 "$parent"
+  block=$(extract_block "$ROOT/bin/fm-spawn.sh")
+  out_file=$(mktemp)
+  bash -c '
+    set -eu
+    json_escape() { printf "%s" "$1" | sed "s/\\\\/\\\\\\\\/g; s/\"/\\\\\"/g"; }
+    DATA="'"$parent"'/data"
+    ID="x"; HARNESS="claude"; MODEL="sonnet"; EFFORT="high"; KIND="ship"
+    PROJ_ABS="/x/foo"; MODE="no-mistakes"; BACKEND="tmux"; YOLO="off"
+    '"$block"'
+    echo survived
+  ' > "$out_file" 2>&1
+  rc=$?
+  chmod 755 "$parent"
+  expect_code 0 "$rc" "a non-fatal append must never abort the caller under set -eu"
+  assert_contains "$(cat "$out_file")" "survived" \
+    "the script must reach the line after the append block even when data/ cannot be created"
+  rm -f "$out_file"
+  pass "the spawn append block is non-fatal under set -eu when data/ is unwritable"
+}
+
+test_teardown_append_block_produces_the_documented_json_shape() {
+  local home block out
+  home=$(make_home teardown-append)
+  block=$(extract_block "$ROOT/bin/fm-teardown.sh")
+  [ -n "$block" ] || fail "could not locate the dispatch-log append block in bin/fm-teardown.sh"
+  # ID is consumed by the eval'd extracted block, invisibly to shellcheck.
+  # shellcheck disable=SC2034
+  out=$(
+    set -eu
+    DATA="$home/data"
+    ID="teardown-shape"
+    eval "$block"
+    cat "$DATA/dispatch-log.jsonl"
+  )
+  printf '%s' "$out" | jq -e '
+    .event == "teardown" and .id == "teardown-shape"
+      and (.ts | test("^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$"))
+      and (keys | length) == 3
+  ' >/dev/null || fail "the real fm-teardown.sh append block did not produce the documented minimal JSON shape: $out"
+  pass "the real fm-teardown.sh append block produces the documented minimal teardown JSON shape"
+}
+
+test_summary_groups_by_model_default_and_prints_total
+test_summary_group_by_other_fields
+test_teardown_events_are_join_only_and_never_counted
+test_since_until_date_filtering_is_inclusive
+test_date_filter_with_no_matches_is_a_definitive_zero_not_blank
+test_missing_log_file_is_a_valid_empty_state_not_an_error
+test_empty_log_file_present_is_also_zero
+test_unreadable_log_errors_loudly_instead_of_silent_zero
+test_malformed_json_line_is_skipped_not_fatal
+test_unknown_subcommand_errors
+test_unknown_flag_errors
+test_bad_group_by_value_errors
+test_bad_date_format_errors
+test_spawn_append_block_produces_the_documented_json_shape
+test_spawn_append_block_is_non_fatal_when_data_is_unwritable
+test_teardown_append_block_produces_the_documented_json_shape
+
+echo "# fm-dispatch-log.test.sh: all assertions passed"

--- a/tests/fm-dispatch-log.test.sh
+++ b/tests/fm-dispatch-log.test.sh
@@ -79,6 +79,18 @@ test_summary_group_by_other_fields() {
   pass "summary --group-by supports harness, kind, repo, and effort"
 }
 
+test_group_by_repo_buckets_blank_value_as_unknown() {
+  local home out
+  home=$(make_home blank-repo)
+  write_log "$home" \
+    "$(spawn_line a1 2026-07-01T10:00:00Z claude sonnet high ship /x/foo no-mistakes tmux off)" \
+    "$(spawn_line a2 2026-07-02T10:00:00Z claude sonnet high secondmate "" no-mistakes tmux off)"
+  out=$(run "$home" summary --group-by repo)
+  assert_contains "$out" "/x/foo: 1" "a real repo path must still be counted under its own key"
+  assert_contains "$out" "unknown: 1" "a blank repo (e.g. a secondmate spawn) must bucket as unknown"
+  pass "summary --group-by repo buckets a blank value as unknown rather than a literal empty key"
+}
+
 test_teardown_events_are_join_only_and_never_counted() {
   local home out
   home=$(make_home teardown-events)
@@ -255,6 +267,35 @@ test_spawn_append_block_produces_the_documented_json_shape() {
   pass "the real fm-spawn.sh append block produces the documented spawn JSON shape"
 }
 
+test_spawn_append_block_blanks_repo_for_secondmate_kind() {
+  local home block out
+  home=$(make_home spawn-append-secondmate)
+  block=$(extract_block "$ROOT/bin/fm-spawn.sh")
+  [ -n "$block" ] || fail "could not locate the dispatch-log append block in bin/fm-spawn.sh"
+  # PROJ_ABS is a secondmate's firstmate home for kind=secondmate, not a repo;
+  # the append block must leave repo blank rather than logging the home path.
+  # shellcheck disable=SC2034,SC2329
+  out=$(
+    set -eu
+    json_escape() { printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g'; }
+    DATA="$home/data"
+    ID="spawn-secondmate-shape"
+    HARNESS="claude"
+    MODEL="default"
+    EFFORT="default"
+    KIND="secondmate"
+    PROJ_ABS="/home/sctru/.claude/secondmates/some-secondmate"
+    MODE="secondmate"
+    BACKEND="tmux"
+    YOLO="off"
+    eval "$block"
+    cat "$DATA/dispatch-log.jsonl"
+  )
+  printf '%s' "$out" | jq -e '.repo == ""' >/dev/null \
+    || fail "a kind=secondmate spawn must record a blank repo, not its firstmate home path: $out"
+  pass "the real fm-spawn.sh append block blanks repo for a kind=secondmate spawn"
+}
+
 test_spawn_append_block_is_non_fatal_when_data_is_unwritable() {
   local home block rc parent out_file
   home=$(make_home spawn-nonfatal)
@@ -309,6 +350,7 @@ test_teardown_append_block_produces_the_documented_json_shape() {
 
 test_summary_groups_by_model_default_and_prints_total
 test_summary_group_by_other_fields
+test_group_by_repo_buckets_blank_value_as_unknown
 test_teardown_events_are_join_only_and_never_counted
 test_since_until_date_filtering_is_inclusive
 test_date_filter_with_no_matches_is_a_definitive_zero_not_blank
@@ -321,6 +363,7 @@ test_unknown_flag_errors
 test_bad_group_by_value_errors
 test_bad_date_format_errors
 test_spawn_append_block_produces_the_documented_json_shape
+test_spawn_append_block_blanks_repo_for_secondmate_kind
 test_spawn_append_block_is_non_fatal_when_data_is_unwritable
 test_teardown_append_block_produces_the_documented_json_shape
 


### PR DESCRIPTION
## Intent

Land the parked fm-dispatch-log-k4 feature: a durable append-only JSONL log of firstmate's own crewmate/scout/secondmate dispatches (data/dispatch-log.jsonl), with best-effort non-fatal append hooks in bin/fm-spawn.sh and bin/fm-teardown.sh, and a bin/fm-dispatch-log.sh summary query CLI (group-by model/harness/kind/repo/effort, --since/--until date filtering). This resolves a design decision that parked the pipeline on 2026-07-29: review flagged that for kind=secondmate spawns, PROJ_ABS (the value logged under the repo field) is the secondmate's firstmate home path, not a project repo, so --group-by repo mixed home directories into repo counts. Chose to blank the repo field for kind=secondmate spawns (over renaming it to project) and bucket blank/missing group-by values as unknown; also fixed fm-dispatch-log.sh's --help range which truncated its header. Review, test, document, and lint already passed clean on this commit lineage in a prior run (only the push step failed, on a missing fork-url/no push access to origin - now fixed via 'no-mistakes init --fork-url git@github.com:sctru/firstmate.git' and a fresh fork at github.com/sctru/firstmate); fast-forwarded local branch to include the prior run's document-step auto-fix commit (docs/scripts.md toolbelt entry) and skipping the already-verified steps to retry push/PR/CI.

## What Changed

- Add `bin/fm-dispatch-log.sh`, a summary query CLI over a new append-only `data/dispatch-log.jsonl` log, supporting `--group-by` (model/harness/kind/repo/effort) and `--since`/`--until` date filtering.
- Wire best-effort, non-fatal append hooks into `bin/fm-spawn.sh` and `bin/fm-teardown.sh` so every spawn and teardown is recorded to the log; blank the repo field for `kind=secondmate` spawns (its `PROJ_ABS` is a secondmate's firstmate home path, not a project repo) and bucket blank/missing group-by values as `unknown`.
- Fix `fm-dispatch-log.sh`'s `--help` output range, which was truncating its header, add `tests/fm-dispatch-log.test.sh` coverage, and list the script in the bin toolbelt table in `AGENTS.md` and `docs/scripts.md`.

## Testing

- ⏭️ **Test** - skipped

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>⏭️ **intent** - skipped</summary>

Step was skipped.

</details>

<details>
<summary>⏭️ **Rebase** - skipped</summary>

Step was skipped.

</details>

<details>
<summary>⏭️ **Review** - skipped</summary>

Step was skipped.

</details>

<details>
<summary>⏭️ **Test** - skipped</summary>

Step was skipped.

</details>

<details>
<summary>⏭️ **Document** - skipped</summary>

Step was skipped.

</details>

<details>
<summary>⏭️ **Lint** - skipped</summary>

Step was skipped.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
