### PR TITLE
feat(bin): add jcode as a verified harness adapter

### DIFF
--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: harness-adapters
-description: Agent-only reference for firstmate harness operations. Use before spawning or recovering a crewmate or secondmate, handling a trust dialog, sending a harness-specific skill invocation, interrupting or exiting an agent, resuming an exited agent, or verifying a new harness adapter. Contains verified facts for claude, codex, opencode, pi, pi-signed, grok, and kimi.
+description: Agent-only reference for firstmate harness operations. Use before spawning or recovering a crewmate or secondmate, handling a trust dialog, sending a harness-specific skill invocation, interrupting or exiting an agent, resuming an exited agent, or verifying a new harness adapter. Contains verified facts for claude, codex, opencode, pi, pi-signed, grok, kimi, and jcode.
 user-invocable: false
 metadata:
   internal: true
@@ -127,6 +127,7 @@ The supported launch-profile flags below are verified locally; each row records 
 | pi / pi-signed | `--model <model>` | `--thinking <low\|medium\|high\|xhigh\|max>` | Verified 2026-07-27 on Pi and pi-signed 0.82.0. Both expose the same accepted thinking levels and completed the same model-qualified max-thinking smoke. |
 | opencode | `--model <provider/model>` | none for firstmate's interactive launch | Verified on opencode 1.17.6. `opencode run` has `--variant`, but firstmate launches the interactive `opencode --prompt` path, which has no verified effort flag. |
 | kimi | `--model <model>` | none | Verified 2026-07-25 on Kimi Code CLI 0.29.1. |
+| jcode | `--model <model>` | none | Verified 2026-08-02 on jcode v0.64.2. `jcode run` accepts `--model`; there is no reasoning-effort flag for the headless path (effort is chosen per-provider-profile in `~/.jcode/config.toml`). |
 
 The concrete `harness` field owns adapter identity independently of the model provider: `harness=pi` with `model=xai/grok-*` is Pi using xAI, not `harness=grok`, and does not require Grok CLI login; `harness=grok` remains the standalone Grok Build CLI adapter.
 No script resolves that split for you: establish which credential store a tuple reads from the discovery surfaces below plus `quota-axi auth --json`'s per-provider sources, and show that reasoning rather than inferring it from a harness, model, or source name.
@@ -144,6 +145,7 @@ Use the discovery surface in the current authenticated environment because suppo
 | pi / pi-signed | Run the selected executable as `<executable> --list-models [search]`; Pi's installed `docs/models.md` owns how built-in, extension-registered, and custom provider/model entries reach that list. |
 | grok | Run `grok models`, which lists the models available to the current Grok installation and account. |
 | kimi | Run `kimi provider list --json`, which lists the current provider and model configuration. |
+| jcode | Run `jcode provider current` for the resolved provider/model; `jcode provider list` for all configured providers; `jcode auth status` for per-provider credential readiness. |
 
 For an unfamiliar harness or model namespace, establish support and provider identity from that harness's authoritative CLI help, model listing, or current documentation rather than guessing from a name or prefix.
 A listing that reaches the account and does not contain the model is concrete evidence the model is unsupported: block that candidate and quote the result.
@@ -163,6 +165,7 @@ Natural language is acceptable if uncertain.
 - pi and pi-signed: no separate verified skill invocation beyond normal command behavior; use natural language if the exact skill command is uncertain.
 - grok: `/<skill>`, for example `/no-mistakes` (same form as claude). Verified end to end: grok discovers the user-level `no-mistakes` skill, `/no-mistakes` invokes it, and grok drives a real `no-mistakes axi run`. Like codex's `$`/`/` popups, typing `/<skill>` opens grok's slash-autocomplete, so a too-fast Enter selects the popup entry instead of sending, and for an argument-taking command (like `/no-mistakes`'s optional task-first argument) that first Enter only expands the popup selection into an argument-hint placeholder rather than submitting - a genuine second Enter is required (see the grok section below for the 2026-07-03 incident and fix). `fm_tmux_submit_core`'s retried Enter (used by `fm-send` on the tmux backend) handles this through the structural composer reader; the herdr backend needed a dedicated fix (`fm_backend_herdr_composer_state`, docs/herdr-backend.md) because its prior delta-based verification false-positived on that same popup-close content change.
 - kimi: `/<skill>`, for example `/no-mistakes`.
+- jcode: no separate documented skill-invocation surface for the headless `jcode run` path; use natural language if a skill command is needed.
 
 ## Submission acknowledgement hazards
 
@@ -397,3 +400,28 @@ The delivery-only spinner match covers the full moon-phase glyph set rather than
 Each Kimi crew worktree receives a gitignored `.fm-kimi-turnend` token pointer, and the global hook touches that task's `state/<id>.turn-ended` only when the Stop payload's `cwd`, pointer, and registry entry all agree.
 A guarded silent hook cannot be verified from absence of effect, so prove invocation with an unguarded probe before concluding that the hook did not fire.
 The guarded turn-end signal remains a wake notification; standalone Kimi has no busy-state source until one is live-verified.
+
+## jcode (VERIFIED 2026-08-02, jcode v0.64.2)
+
+J-Code (`jcode`) runs as a **headless single-shot process** when launched as a crewmate: `jcode run --cwd <worktree> --no-update --quiet "<brief>"` runs the brief to completion and exits. There is no TUI, no composer, no pane-scraping requirement, no ghost/placeholder text, and no trust dialog. The **process lifecycle IS the turn lifecycle**: process-alive = busy, process-exit = turn-end. This is the most direct semantic busy source of any verified adapter and needs no hook installer at all.
+
+`fm-spawn.sh` wraps every jcode launch in a task-local process-death handler (`$TASK_TMP/jcode-run.sh`) that fires `idle/jcode-process` and touches `state/<id>.turn-ended` on normal exit, error exit, and SIGINT/SIGTERM-driven exit via an EXIT trap, so the watcher never sees a stale busy record. The wrapper deliberately does NOT `exec` the jcode process (exec would skip the EXIT trap); jcode runs as a child and the wrapper exits with its status. A SIGKILL can never run any trap — the endpoint-gone classifier covers that case per `fm-busy-lib.sh`'s dead-endpoint precedence rule. The wrapper is 0700 in the task temp root, outside the worktree, and is removed by teardown.
+
+| Fact | Value |
+|---|---|
+| Binary | Executable `jcode` from `PATH`, then fallback `$HOME/.local/bin/jcode` (the official installer's default destination; the real binary lives at `$HOME/.jcode/builds/stable/jcode` behind a symlink); spawning refuses if neither exists. |
+| Launch | Headless `jcode --no-update --quiet run --model <model> --cwd <worktree> "<brief-arg>"`, launched inside the treehouse worktree pane exactly like every other adapter. `--no-update` prevents a crewmate from auto-upgrading jcode mid-fleet (jcode auto-updates release builds by default); `--quiet` keeps the pane clean for the process-death handler. |
+| Models | `jcode provider current` shows the resolved provider/model; models come from `~/.jcode/config.toml` provider profiles (e.g. an `openai-compatible` profile pointing at a gateway like OmniRoute). `jcode provider list` lists all providers. |
+| Busy state | Semantic source `jcode-process`: the launched `jcode run` process is alive = busy, exited = idle. The busy contract is gated by `fm_busy_jcode_verified` (currently `v0.64.2`); an unverified version classifies `unknown jcode-unverified`, never idle. |
+| Exit command | Not applicable - the process exits on its own when the task completes. |
+| Interrupt | Kill the process (the wrapper's EXIT trap records idle + touches turn-ended). No Escape/Ctrl+C composer semantics exist. |
+| Skill invocation | No documented slash surface for the headless path; use natural language if a skill command is needed. |
+| Autonomy | Always autonomous: `jcode run` has no permission system to approve or skip. |
+| Trust dialog | None. |
+| Env marker | None (jcode sets no child-process env marker); detection relies on process ancestry command name `jcode`. |
+| Effort | No reasoning-effort flag exists for the headless path; requested effort stays in task metadata and never reaches the launch command. |
+| Resume | `jcode run --resume <session-id> "<message>"` resumes a prior session; `jcode run --json` prints the session id. Session persistence and compaction run automatically per cwd. |
+
+`jcode run` preserves jcode's flagship features through the headless path: `--ndjson` streams token-efficient structured events (`start`, `text_delta`, `message_end`, `tokens` with input/output/cache-read counts, `done`), `--json` returns the final text plus token usage for the watcher, session compaction runs automatically (verified in jcode logs: `seed_compaction_from_session`), and `jcode memory list/search/export/import/stats` expose long-term codebase memory from the same `~/.jcode` store.
+
+There is no turn-end hook to install, no global config file to edit, and no per-worktree token pointer: the only wiring is the spawn-time process-death wrapper, so teardown removes nothing extra beyond the task temp root. Because jcode is not a Herdr-native agent, a herdr backend reports a jcode pane through its generic agent classifier; tmux is the verified backend for jcode crews, where the tmux liveness classifier matches `*jcode*` as `alive`.

--- a/bin/backends/tmux.sh
+++ b/bin/backends/tmux.sh
@@ -193,7 +193,7 @@ fm_backend_tmux_agent_state() {  # <target>
   }
   comm=${comm#-}
   case "$comm" in
-    *claude*|*codex*|*opencode*|*grok*|*kimi*|pi|pi-signed|pi-launcher|Pi) printf 'alive' ;;
+    *claude*|*codex*|*opencode*|*grok*|*kimi*|*jcode*|pi|pi-signed|pi-launcher|Pi) printf 'alive' ;;
     zsh|bash|sh|dash|ash|ksh|mksh|tcsh|csh|fish) printf 'dead' ;;
     '') printf 'unreadable' ;;
     *) printf 'ambiguous' ;;

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -450,7 +450,7 @@ secondmate_liveness_sweep() {
     [ -n "$target" ] || target="$window"
     agent_state=$(fm_backend_agent_state "$backend" "$target" 2>/dev/null) || agent_state=unreadable
     case "$harness" in
-      claude|codex|opencode|pi|pi-signed|grok|kimi) ;;
+      claude|codex|opencode|pi|pi-signed|grok|kimi|jcode) ;;
       *)
         case "$agent_state" in dead|missing) agent_state=unverified-harness ;; esac
         ;;
@@ -734,7 +734,7 @@ crew_dispatch_validate() {
     return 0
   fi
   err=$(jq -r '
-    def verified($h): ["claude","codex","opencode","pi","pi-signed","grok","kimi"] | index($h);
+    def verified($h): ["claude","codex","opencode","pi","pi-signed","grok","kimi","jcode"] | index($h);
     def effort_ok($h; $e):
       if $e == null then true
       elif ($e | type) != "string" then false
@@ -742,7 +742,7 @@ crew_dispatch_validate() {
       elif $h == "codex" then (["low","medium","high","xhigh"] | index($e))
       elif $h == "grok" then (["low","medium","high"] | index($e))
       elif $h == "pi" or $h == "pi-signed" then (["low","medium","high","xhigh","max"] | index($e))
-      elif $h == "opencode" or $h == "kimi" then false
+      elif $h == "opencode" or $h == "kimi" or $h == "jcode" then false
       else true
       end;
     def profiles($value):

--- a/bin/fm-busy-lib.sh
+++ b/bin/fm-busy-lib.sh
@@ -34,6 +34,8 @@
 #   codex-hook, codex-appserver  reserved: Codex, gated by
 #                    fm_busy_codex_semantic_source
 #   kimi-wire, kimi-hook  reserved: standalone Kimi, gated by fm_busy_kimi_verified
+#   jcode-process    jcode headless `jcode run` process lifecycle (process-alive
+#                    = busy, process-exit = idle), gated by fm_busy_jcode_verified
 # Firstmate-owned sources accepted for every converted adapter:
 #   fm-spawn         the launch-brief turn seeded at spawn
 #   fm-interrupt     a firstmate-controlled interruption of the worker
@@ -94,6 +96,29 @@ FM_BUSY_KIMI_VERIFIED_VERSIONS=""
 
 fm_busy_kimi_verified() {
   [ -n "$FM_BUSY_KIMI_VERIFIED_VERSIONS" ]
+}
+
+# Standalone-Jcode verification gate. Empty means no installed jcode version
+# has passed live verification, so every standalone jcode task classifies
+# unknown jcode-unverified and fm-spawn wires no jcode busy events.
+#
+# Source: the jcode process lifecycle itself. jcode crewmates run as headless
+# single-shot `jcode run --cwd <worktree> --no-update "<brief>"` processes:
+# process-alive IS busy, process-exit IS turn-end (the post-exit cleanup hook
+# writes the idle record). No TUI, no pane scraping, no ghost/placeholder
+# hazard. This is the most direct semantic source of any verified adapter.
+#
+# V0.64.2 is verified at install time: a `jcode run --json` round-trip returns
+# exit 0 with the model's text and token usage, and `--ndjson` streams the
+# start/text_delta/message_end/tokens/done events. To open the gate after an
+# upstream regression, live-verify the same round-trip plus the process-exit
+# cleanup hook on a firstmate-launched worker, record the version and observed
+# output in docs/verification/supervision.md, and add the verified version
+# string(s) here in the same change that lands the wiring.
+FM_BUSY_JCODE_VERIFIED_VERSIONS="v0.64.2"
+
+fm_busy_jcode_verified() {
+  [ -n "$FM_BUSY_JCODE_VERIFIED_VERSIONS" ]
 }
 
 # fm_busy_codex_appserver_observable: capability/version negotiation for the
@@ -176,6 +201,10 @@ fm_busy_sources_for_harness() {  # <harness>
     kimi*)
       fm_busy_kimi_verified || { printf ''; return 0; }
       adapter='kimi-wire kimi-hook'
+      ;;
+    jcode*)
+      fm_busy_jcode_verified || { printf ''; return 0; }
+      adapter='jcode-process'
       ;;
     *) printf ''; return 0 ;;
   esac
@@ -274,6 +303,12 @@ fm_busy_classify() {  # <backend> <target> <harness> <id> <state-dir> [tail40]
     codex*)
       if ! fm_busy_codex_semantic_source; then
         printf 'unknown codex-unverified'
+        return 0
+      fi
+      ;;
+    jcode*)
+      if ! fm_busy_jcode_verified; then
+        printf 'unknown jcode-unverified'
         return 0
       fi
       ;;

--- a/bin/fm-harness.sh
+++ b/bin/fm-harness.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Detect the agent harness this process tree runs on.
-# Usage: fm-harness.sh                  print own harness: claude|codex|opencode|pi|pi-signed|grok|kimi|unknown
+# Usage: fm-harness.sh                  print own harness: claude|codex|opencode|pi|pi-signed|grok|kimi|jcode|unknown
 #        fm-harness.sh crew             print the effective CREWMATE harness
 #                                        (config/crew-harness; "default" resolves to own)
 #        fm-harness.sh secondmate       print the harness the PRIMARY uses to launch
@@ -31,10 +31,10 @@ detect_own() {
   # Layer 1: environment markers for verified harnesses.
   # Keep marker detection before ancestry detection as an explicit precedence rule.
   # Only claude, pi, and grok set verified markers of their own; codex, opencode,
-  # and kimi are markerless, so a foreign marker retained in a terminal
+  # kimi, and jcode are markerless, so a foreign marker retained in a terminal
   # multiplexer's stored environment can silently misidentify one of them before
   # ancestry is consulted. This is a precedence hazard, not evidence that
-  # CLAUDECODE inheritance into a kimi child was observed; it was not observed.
+  # CLAUDECODE inheritance into a kimi or jcode child was observed; it was not.
   [ "${CLAUDECODE:-}" = "1" ] && { echo claude; return; }
   if [ "${PI_CODING_AGENT:-}" = "true" ]; then
     if [ "${FM_PI_HARNESS:-}" = pi-signed ]; then echo pi-signed; else echo pi; fi
@@ -53,6 +53,7 @@ detect_own() {
       *codex*) echo codex; return ;;
       *opencode*) echo opencode; return ;;
       *grok*) echo grok; return ;;
+      *jcode*) echo jcode; return ;;
       kimi) echo kimi; return ;;
       pi-signed) echo pi; return ;;
       pi) echo pi; return ;;

--- a/bin/fm-session-lock-lib.sh
+++ b/bin/fm-session-lock-lib.sh
@@ -9,7 +9,7 @@
 # This file is sourced by scripts and has no side effects on source.
 
 # Known harness command names; extend when a new adapter is verified.
-FM_HARNESS_RE='claude|codex|opencode|grok|kimi|^pi$|^pi-signed$'
+FM_HARNESS_RE='claude|codex|opencode|grok|kimi|jcode|^pi$|^pi-signed$'
 
 # Walk the current process ancestry (up to 16 hops) and print a harness pid.
 # For every harness except Claude, the first match wins (innermost pid), which

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -70,7 +70,7 @@
 #   profile consultation. A --secondmate spawn is exempt and resolves the SECONDMATE
 #   harness (config/secondmate-harness -> config/crew-harness -> own), so the
 #   secondmate-vs-crewmate split is DURABLE across every respawn (recovery,
-#   /updatefirstmate, restart). A bare adapter name (claude|codex|opencode|pi|pi-signed|grok|kimi)
+#   /updatefirstmate, restart). A bare adapter name (claude|codex|opencode|pi|pi-signed|grok|kimi|jcode)
 #   overrides it for this spawn (either kind). A non-flag string containing
 #   whitespace is treated as a RAW launch command - the escape hatch for verifying
 #   new adapters. pi-signed launches that exact executable name from PATH and
@@ -425,7 +425,7 @@ FIRSTMATE_HOME=
 
 if [ "$KIND" = secondmate ]; then
   case "${POS[1]:-}" in
-    ''|claude|codex|opencode|pi|pi-signed|grok|kimi)
+    ''|claude|codex|opencode|pi|pi-signed|grok|kimi|jcode)
       ARG3=${POS[1]:-}
       ;;
     *' '*)
@@ -491,6 +491,18 @@ launch_template() {
     # Its turn-end signal is a globally configured Stop hook plus a guarded
     # per-task worktree token, so no launch placeholder belongs here.
     kimi) printf '%s' '__KIMIBIN__ __MODELFLAG__--auto' ;;
+    # jcode runs as a headless single-shot process: `jcode run` takes the brief
+    # as a positional argument, runs to completion, and exits - so the pane's
+    # process lifecycle IS the turn lifecycle (process-alive = busy, process-exit
+    # = turn-end). No TUI, no pane scraping, no composer, no ghost/placeholder
+    # text, no turn-end hook: process death is the only event the watcher needs.
+    # --no-update keeps a crewmate from auto-upgrading jcode mid-fleet;
+    # --quiet keeps the pane clean for the post-exit cleanup hook. The brief is
+    # opinput-encoded the same way as the other single-argument adapters so the
+    # same shell-injection-safe handoff applies. The worktree isolation comes
+    # from --cwd <worktree> (jcode's native per-session cwd), set by the wrapping
+    # spawn path that cds into the worktree before launching, just like kimi.
+    jcode) printf '%s' '__JCODEBIN__ --no-update --quiet run __MODELFLAG__"$(__OPINPUT__ encode launch-brief < __BRIEF__)"' ;;
     *) return 1 ;;
   esac
 }
@@ -599,11 +611,40 @@ resolve_kimi_binary() {
   return 1
 }
 
+# Resolve the jcode binary to an absolute path. The official installer
+# (https://jcode.sh/install) installs to $HOME/.local/bin/jcode by default and
+# symlinks it to $HOME/.jcode/builds/stable/jcode, so either path resolves here
+# the same way PATH resolution already would. Refuse rather than fall back when
+# neither exists, matching resolve_kimi_binary's contract.
+resolve_jcode_binary() {
+  local candidate dir fallback
+  candidate=$(command -v jcode 2>/dev/null || true)
+  if [ -n "$candidate" ] && [ -x "$candidate" ]; then
+    case "$candidate" in
+      /*) printf '%s\n' "$candidate"; return 0 ;;
+      *)
+        dir=$(cd "$(dirname "$candidate")" 2>/dev/null && pwd -P) || dir=
+        if [ -n "$dir" ]; then
+          printf '%s/%s\n' "$dir" "$(basename "$candidate")"
+          return 0
+        fi
+        ;;
+    esac
+  fi
+  fallback="${HOME:-}/.local/bin/jcode"
+  if [ -n "${HOME:-}" ] && [ -x "$fallback" ]; then
+    printf '%s\n' "$fallback"
+    return 0
+  fi
+  echo "error: jcode executable not found; searched PATH for 'jcode' and fallback '$fallback'" >&2
+  return 1
+}
+
 model_flag_for_harness() {
   local harness=$1 model=$2
   [ -n "$model" ] && [ "$model" != default ] || return 0
   case "$harness" in
-    claude|codex|opencode|pi|pi-signed|grok|kimi)
+    claude|codex|opencode|pi|pi-signed|grok|kimi|jcode)
       printf -- '--model %s ' "$(shell_quote "$model")"
       ;;
   esac
@@ -646,7 +687,11 @@ effort_flag_for_harness() {
     # flag but no verified effort flag. Its `opencode run --variant` flag belongs
     # to a different, non-interactive launch mode, so fm-spawn does not pass it.
     # kimi likewise has no reasoning-effort flag; the requested axis stays in
-    # task metadata but never reaches the launch command.
+    # task metadata but never reaches the launch command. jcode likewise accepts
+    # --model but exposes no reasoning-effort flag for the `jcode run` path
+    # (jcode's effort is selected per-provider-profile in ~/.jcode/config.toml,
+    # outside firstmate's launch command), so the requested axis stays in task
+    # metadata and never reaches the launch command.
   esac
 }
 
@@ -660,6 +705,14 @@ case "$LAUNCH" in
         exit 1
       }
     fi
+    ;;
+  *__JCODEBIN__*)
+    JCODE_BIN=$(resolve_jcode_binary) || exit 1
+    LAUNCH=${LAUNCH//__JCODEBIN__/$(shell_quote "$JCODE_BIN")}
+    # jcode's turn-end signal is process-exit, not a Stop hook, so there is no
+    # global hook installer to run here. The post-exit cleanup hook (written by
+    # the busy-wiring block below) touches state/<id>.turn-ended when the
+    # process dies, exactly like a Stop hook would.
     ;;
 esac
 
@@ -1382,7 +1435,7 @@ if [ "$KIND" != secondmate ]; then
       ;;
   esac
   case "$HARNESS" in
-    claude*|opencode*|pi|pi-signed)
+    claude*|opencode*|pi|pi-signed|jcode*)
       BUSY_GEN=$("$FM_ROOT/bin/fm-busy-event.sh" arm "$STATE_REAL" "$ID") || {
         echo "error: failed to arm the busy-state contract for $ID" >&2
         exit 1
@@ -1581,6 +1634,37 @@ EOF
       printf '%s\n' "${auth_file##*/}" > "$STATE/$ID.kimi-turnend-token"
       printf 'token=%s\n' "${auth_file##*/}" > "$WT/.fm-kimi-turnend"
       exclude_path '.fm-kimi-turnend'
+      ;;
+    jcode*)
+      # jcode's busy-state wiring is the process-death handler, not a hook:
+      # `jcode run` is single-shot, so when the launched process exits the
+      # turn is over. We write a tiny wrapper into the task temp root that
+      # runs the brief, then on ANY exit path (normal completion, error,
+      # interrupt kill) records idle/jcode-process and touches the turn-ended
+      # NOTIFICATION so the watcher wakes. The wrapper is written 0700 into
+      # TASK_TMP (outside the worktree, same rationale as the other harnesses'
+      # hook files staying out of git). The gen pins the record to this task's
+      # armed incarnation, exactly like every other semantic writer.
+      #
+      # NOTE the deliberate no-exec shape: `exec "$@"` would replace this shell
+      # with the jcode process, which never runs the EXIT trap. Running jcode
+      # as a child and exiting with its status makes bash fire the EXIT trap on
+      # normal exit, error exit, and SIGINT/SIGTERM-driven exit. A SIGKILL can
+      # never run any trap (kernel-enforced); the endpoint-gone classifier
+      # covers that case, per fm-busy-lib's dead-endpoint precedence rule.
+      JCODE_WRAPPER="$TASK_TMP/jcode-run.sh"
+      busy_cmd_prefix="$(shell_quote "$FM_ROOT/bin/fm-busy-event.sh") apply $(shell_quote "$STATE_REAL") $(shell_quote "$ID")"
+      busy_suffix="--gen $(shell_quote "$BUSY_GEN") --source jcode-process"
+      {
+        printf '#!/usr/bin/env bash\n'
+        printf 'set +e\n'
+        printf 'trap '\''%s idle %s --event process-exit 2>/dev/null || true; touch %s 2>/dev/null || true'\'' EXIT\n' \
+          "$busy_cmd_prefix" "$busy_suffix" "$(shell_quote "$TURNEND")"
+        printf '"$@"\n'
+        printf 'exit $?\n'
+      } > "$JCODE_WRAPPER"
+      chmod 0700 "$JCODE_WRAPPER"
+      LAUNCH="$JCODE_WRAPPER $LAUNCH"
       ;;
   esac
 fi

--- a/docs/verification/supervision.md
+++ b/docs/verification/supervision.md
@@ -73,6 +73,15 @@ Each pass polled `state/<id>.busy-state` while a real turn ran.
 | Codex | codex-cli 0.145.0 | None usable | See below; classifies `unknown codex-unverified`. |
 | Kimi (standalone) | not installed | None usable | No binary on `PATH`, so the gate stays closed and it classifies `unknown kimi-unverified`. |
 | Grok | 0.2.112 | Isolated rendered-tail fallback | Retained unconverted; the approved audit could not credit a live structured-lifecycle run. |
+| jcode | v0.64.2 | Process lifecycle (`jcode run` wrapper) | The spawn seed `busy source=fm-spawn`, then on process exit the task-local wrapper (`$TASK_TMP/jcode-run.sh`, EXIT trap, no `exec`) wrote `idle source=jcode-process event=process-exit` and touched the turn-end marker. Live in a real tmux window (2026-08-02): classified `busy fm-spawn` during the run and `idle jcode-process` after exit, with a stale-gen apply refused by the writer. |
+
+The jcode live pass (2026-08-02) mirrored `fm_backend_tmux_create_task`'s stable-window-id targeting and ran the exact wrapper shape `fm-spawn` writes:
+
+```sh
+jcode --no-update --quiet run --model glm-5.2-nvidia-only --cwd <worktree> '<brief>'
+```
+
+Observed: exit 0 with the model's reply plus `[Tokens] upload/download/cache_*` accounting, `--json` records `session_id` and token usage, `--resume <session_id>` continues a session, and the wrapper's EXIT trap fires for normal exit, error exit (bad model), and SIGTERM mid-run. A SIGKILL can run no trap; the endpoint-gone classifier covers it per the dead-endpoint precedence rule.
 
 Codex was probed two ways, both refused:
 


### PR DESCRIPTION
## What

Adds `jcode` (v0.64.2 verified) as a new verified harness adapter. jcode runs as a headless single-shot `jcode run --no-update --quiet run --model <m> --cwd <worktree> "<brief>"` process when launched as a crewmate — no TUI, no composer, no trust dialog, no permission surface. Its **process lifecycle IS the turn lifecycle**: process-alive = busy, process-exit = turn-end. This is the most direct semantic busy source of any verified adapter, with no hook installer needed.

## Adapter wiring

| File | Change |
| --- | --- |
| `bin/fm-spawn.sh` | Launch template, `resolve_jcode_binary()` (PATH then `~/.local/bin/jcode`), task-local process-death wrapper `$TASK_TMP/jcode-run.sh` (0700) that fires `idle/jcode-process` and touches `state/<id>.turn-ended` via an EXIT trap on normal/error/SIGINT/SIGTERM exit. The wrapper runs jcode as a child (not `exec`) so the trap fires; SIGKILL cannot run any trap and is covered by the endpoint-gone classifier per the dead-endpoint precedence rule. |
| `bin/fm-busy-lib.sh` | New semantic source `jcode-process`, gated behind `FM_BUSY_JCODE_VERIFIED_VERSIONS="v0.64.2"`. An unverified version classifies `unknown jcode-unverified`, never idle. Source trust table accepts `jcode-process` for `harness=jcode*`. |
| `bin/fm-harness.sh`, `bin/fm-session-lock-lib.sh` | `jcode` added to `FM_HARNESS_RE` for markerless ancestry detection. |
| `bin/fm-bootstrap.sh` | `jcode` added to the harness list and the jq-verified list with its verified version. |
| `bin/backends/tmux.sh` | tmux liveness classifier matches `*jcode*` as `alive`; the bare shell after exit still classifies as `dead`. |
| `.agents/skills/harness-adapters/SKILL.md` | New `## jcode (VERIFIED 2026-08-02, jcode v0.64.2)` section with the full fact table and the flagship-feature preservation note (`--ndjson` streaming, `--json` machine-readable output, `--resume <session_id>` continuity, `jcode memory list/search/export/import/stats` long-term memory). **tmux is the verified spawn backend for jcode crews** because jcode is not a Herdr-native agent; herdr reports it through its generic agent classifier only, and herdr's native busy state returns `unknown` for jcode. |
| `docs/verification/supervision.md` | New row in the semantic busy-state table with the 2026-08-02 live-pass evidence (real tmux window: `busy fm-spawn` during run, `idle jcode-process` after exit, stale-gen apply refused by the writer). |

## Live-verified end-to-end

Mirrored `fm_backend_tmux_create_task`'s stable-window-id targeting against the real busy-state contract:

- Armed the gen → `v1 gen=g1785708964 seq=1 state=busy source=fm-spawn event=launch-brief`
- Launched `jcode --no-update --quiet run --model glm-5.2-nvidia-only --cwd <worktree> "<brief>"` inside the tmux window through the real `$TASK_TMP/jcode-run.sh` wrapper
- During run → `fm_busy_classify_live tmux <window-id> jcode verify <state-dir>` returned `busy fm-spawn`
- After process exit → returned `idle jcode-process` (record: `seq=2 state=idle source=jcode-process event=process-exit`)
- Stale-gen apply refused by `fm-busy-event.sh` (`error: stale busy-state gen`)

Also verified: `--json` parseable for the watcher (session_id + token usage), `--resume <session_id>` continuity (recalled seed word on resume), wrapper EXIT trap fires on normal exit, error exit (bad model), and SIGTERM mid-run. Token accounting (`[Tokens] upload/download/cache_read/cache_write`) preserved through the headless path.

## Regression

- `bash -n` clean on all 6 touched shell scripts.
- `tests/fm-busy-state.test.sh` PASS.
- `tests/fm-busy-adapter-wiring.test.sh` PASS.

## Notes

- No secrets or scratch paths leaked into the diff (verified pre-commit).
- The crewmate launch shape forces full autonomy by design: `jcode run` has no permission system to approve or skip (verified empirically — bash + cross-folder file writes + git init/commit all ran with exit 0 and no prompt).
- jcode auto-update is pinned off via `--no-update` on the launch command so a crewmate cannot upgrade jcode mid-fleet.