### PR TITLE
fix(bin): deliver requested spawn effort or refuse launch, never silently omit it

### DIFF
--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -109,7 +109,7 @@ Never replace an effort value supplied by either higher-precedence source.
 Use the fallback only when neither the captain nor applicable standing configuration specifies effort.
 Use `low` for well-understood work with an explicit bounded path and `xhigh` for ambiguous investigation or design.
 Choose intermediate levels proportionally as complexity, uncertainty, blast radius, or open-ended reasoning increases.
-When a verified adapter lacks `xhigh`, cap the choice at its highest supported non-`max` level rather than omitting the intended effort silently.
+When a verified adapter lacks `xhigh`, cap the choice at its highest supported non-`max` level rather than requesting an effort `fm-spawn` will refuse.
 Never select `max` from this fallback; use it only when the captain has explicitly expressed that per-task or standing preference.
 
 The supported launch-profile flags below are verified locally; each row records its evidence.
@@ -302,7 +302,7 @@ When a secondmate is launched on Pi or pi-signed, `fm-spawn.sh --secondmate` lau
 
 Grok Build TUI (`grok`), a Claude-Code-compatible CLI from xAI.
 Launch with a positional prompt: `grok --always-approve "$(cat <brief>)"`.
-For Grok's supported reasoning-effort values and omission behavior, see the [launch-profile-axes table](#launch-profile-axes).
+For Grok's supported reasoning-effort values and refusal behavior, see the [launch-profile-axes table](#launch-profile-axes).
 
 | Fact | Value |
 |---|---|

--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -117,7 +117,7 @@ The supported launch-profile flags below are verified locally; each row records 
 | Harness | Model flag | Effort flag | Notes |
 |---|---|---|---|
 | claude | `--model <model>` | `--effort <low\|medium\|high\|xhigh\|max>` | Verified on Claude Code 2.1.196. |
-| codex | `--model <model>` | `-c 'model_reasoning_effort="<low\|medium\|high\|xhigh>"'` | Verified on codex-cli 0.142.1. The installed binary schema contains `model_reasoning_effort`, the active config uses it, and the bundled model catalog advertises only low/medium/high/xhigh. `max` is omitted. |
+| codex | `--model <model>` | `-c 'model_reasoning_effort="<catalog-supported effort>"'` | Verified on codex-cli 0.144.4 (2026-08-02). The live per-model catalog in `${CODEX_HOME:-$HOME/.codex}/models_cache.json` owns the accepted range; the observed catalog advertises `max` for the 5.6 family and `ultra` for Sol and Terra. |
 | grok | `--model <model>` | `--reasoning-effort <low\|medium\|high>` | Verified on grok 0.2.99 (2026-07-13). `--effort` is an alias, but firstmate's profile axis is reasoning effort. As of 0.2.99 the ceiling is `high`; both `xhigh` and `max` are rejected with `use one of: high, medium, low`, so firstmate omits them. |
 | pi / pi-signed | `--model <model>` | `--thinking <low\|medium\|high\|xhigh\|max>` | Verified 2026-07-27 on Pi and pi-signed 0.82.0. Both expose the same accepted thinking levels and completed the same model-qualified max-thinking smoke. |
 | opencode | `--model <provider/model>` | none for firstmate's interactive launch | Verified on opencode 1.17.6. `opencode run` has `--variant`, but firstmate launches the interactive `opencode --prompt` path, which has no verified effort flag. |
@@ -145,8 +145,9 @@ For an unfamiliar harness or model namespace, establish support and provider ide
 A listing that reaches the account and does not contain the model is concrete evidence the model is unsupported: block that candidate and quote the result.
 A discovery surface you could not reach establishes nothing; report that as uncertainty rather than turning it into a supported or unsupported verdict.
 
-When a requested effort value is outside the harness-specific accepted set, `fm-spawn` records the requested `effort=` in meta but emits no effort flag for that harness.
-This preserves launch success instead of passing a known-bad value.
+`ultra` does not join firstmate's shared profile axis: the observed Codex catalog describes it as reasoning with automatic task delegation, so it changes execution topology rather than only reasoning depth, and it is not supported even by every Codex 5.6 model.
+When concrete adapter or per-model catalog evidence proves a requested effort cannot be delivered, `fm-spawn` refuses before creating an endpoint or metadata instead of launching at an unreported default.
+When the Codex catalog or exact model is unavailable, `fm-spawn` warns and passes the requested value through for Codex to validate, because uncertainty alone must not block a potentially valid dispatch and the request must never be silently discarded.
 
 ## no-mistakes skill invocation
 

--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -118,7 +118,7 @@ The supported launch-profile flags below are verified locally; each row records 
 |---|---|---|---|
 | claude | `--model <model>` | `--effort <low\|medium\|high\|xhigh\|max>` | Verified on Claude Code 2.1.196. |
 | codex | `--model <model>` | `-c 'model_reasoning_effort="<catalog-supported effort>"'` | Verified on codex-cli 0.144.4 (2026-08-02). The live per-model catalog in `${CODEX_HOME:-$HOME/.codex}/models_cache.json` owns the accepted range; the observed catalog advertises `max` for the 5.6 family and `ultra` for Sol and Terra. |
-| grok | `--model <model>` | `--reasoning-effort <low\|medium\|high>` | Verified on grok 0.2.99 (2026-07-13). `--effort` is an alias, but firstmate's profile axis is reasoning effort. As of 0.2.99 the ceiling is `high`; both `xhigh` and `max` are rejected with `use one of: high, medium, low`, so firstmate omits them. |
+| grok | `--model <model>` | `--reasoning-effort <low\|medium\|high>` | Verified on grok 0.2.99 (2026-07-13). `--effort` is an alias, but firstmate's profile axis is reasoning effort. As of 0.2.99 the ceiling is `high`; both `xhigh` and `max` are rejected with `use one of: high, medium, low`, so firstmate refuses those requests before launch. |
 | pi / pi-signed | `--model <model>` | `--thinking <low\|medium\|high\|xhigh\|max>` | Verified 2026-07-27 on Pi and pi-signed 0.82.0. Both expose the same accepted thinking levels and completed the same model-qualified max-thinking smoke. |
 | opencode | `--model <provider/model>` | none for firstmate's interactive launch | Verified on opencode 1.17.6. `opencode run` has `--variant`, but firstmate launches the interactive `opencode --prompt` path, which has no verified effort flag. |
 | kimi | `--model <model>` | none | Verified 2026-07-25 on Kimi Code CLI 0.29.1. |
@@ -372,7 +372,7 @@ Kimi Code CLI launches from the absolute path resolved from `PATH`, falling back
 | Slash submission | One Enter submits, with no popup swallow or settle hazard. |
 | Environment marker | None; detection relies on process ancestry command name `kimi`. |
 | Composer | Bordered box with a bare `>` prompt glyph and no observed ghost or placeholder text. |
-| Effort | No reasoning-effort flag exists, so requested effort is recorded in task metadata but omitted from launch. |
+| Effort | No reasoning-effort flag exists, so a requested effort is refused before launch. |
 
 `fm-spawn.sh` launches Kimi bare, waits for the composer box or `Welcome to Kimi Code!`, sends only `Read the brief at <absolute-path> and follow it exactly.`, and requires a cleared composer plus either the echoed `✨` submission or nonzero context before accepting delivery.
 This launch-then-send shape is mandatory because Kimi rejects a positional brief as an unknown command.

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -909,7 +909,7 @@ crew_dispatch_validate() {
       if $e == null then true
       elif ($e | type) != "string" then false
       elif $h == "claude" then (["low","medium","high","xhigh","max"] | index($e))
-      elif $h == "codex" then (["low","medium","high","xhigh"] | index($e))
+      elif $h == "codex" then (["low","medium","high","xhigh","max"] | index($e))
       elif $h == "grok" then (["low","medium","high"] | index($e))
       elif $h == "pi" or $h == "pi-signed" then (["low","medium","high","xhigh","max"] | index($e))
       elif $h == "muse" then (["low","medium","high","xhigh","max"] | index($e))

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -905,14 +905,14 @@ crew_dispatch_validate() {
   fi
   err=$(jq -r '
     def verified($h): ["claude","codex","opencode","pi","pi-signed","grok","kimi","muse"] | index($h);
+    def shared_effort($e): (["low","medium","high","xhigh","max"] | index($e));
     def effort_ok($h; $e):
       if $e == null then true
       elif ($e | type) != "string" then false
-      elif $h == "claude" then (["low","medium","high","xhigh","max"] | index($e))
-      elif $h == "codex" then (["low","medium","high","xhigh","max"] | index($e))
+      elif $h == "claude" or $h == "codex" then shared_effort($e)
       elif $h == "grok" then (["low","medium","high"] | index($e))
-      elif $h == "pi" or $h == "pi-signed" then (["low","medium","high","xhigh","max"] | index($e))
-      elif $h == "muse" then (["low","medium","high","xhigh","max"] | index($e))
+      elif $h == "pi" or $h == "pi-signed" then shared_effort($e)
+      elif $h == "muse" then shared_effort($e)
       elif $h == "opencode" or $h == "kimi" then false
       else true
       end;

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -19,9 +19,11 @@
 #   --harness <name> is the explicit per-spawn harness/profile adapter. The old
 #   positional harness arg still works for back-compat.
 #   --model <name> and --effort <low|medium|high|xhigh|max> are concrete profile
-#   axes chosen by firstmate at intake. They are only threaded into harnesses whose
-#   installed CLIs were verified to support that axis; unsupported axes are omitted
-#   from that harness's launch rather than guessed.
+#   axes chosen by firstmate at intake. A requested effort is either delivered to
+#   the selected harness or refused before launch; it is never silently omitted.
+#   Codex checks an explicit model against its live models_cache.json catalog.
+#   Missing or inconclusive catalog evidence warns and passes the value through so
+#   uncertainty does not block a potentially valid launch or erase the request.
 #   --backend <name> is the explicit runtime session-provider backend for this
 #   exact task only (docs/configuration.md "Runtime backend" owns when that flag
 #   is authorized). Without it, the script resolves FM_BACKEND, then
@@ -1052,8 +1054,55 @@ model_flag_for_harness() {
   esac
 }
 
+codex_effort_catalog_result() {  # <model> <effort>
+  local model=$1 effort=$2 codex_home cache result
+  if [ -z "$model" ] || [ "$model" = default ]; then
+    printf '%s\n' unresolved-model
+    return 0
+  fi
+  if [ -n "${CODEX_HOME:-}" ]; then
+    codex_home=$CODEX_HOME
+  elif [ -n "${HOME:-}" ]; then
+    codex_home="$HOME/.codex"
+  else
+    printf '%s\n' unavailable-home
+    return 0
+  fi
+  cache="$codex_home/models_cache.json"
+  if [ ! -r "$cache" ]; then
+    printf 'unavailable-cache\t%s\n' "$cache"
+    return 0
+  fi
+  if ! command -v jq >/dev/null 2>&1; then
+    printf 'unavailable-jq\t%s\n' "$cache"
+    return 0
+  fi
+  result=$(jq -er --arg model "$model" --arg effort "$effort" '
+    [.models[]? | select(.slug == $model)] as $matches
+    | if ($matches | length) != 1 then
+        "absent-model\t\($model)"
+      else
+        [$matches[0].supported_reasoning_levels[]?.effort] as $levels
+        | if ($levels | index($effort)) != null then
+            "supported"
+          else
+            "unsupported\t" + ($levels | join(", "))
+          end
+      end
+  ' "$cache" 2>/dev/null) || {
+    printf 'invalid-cache\t%s\n' "$cache"
+    return 0
+  }
+  printf '%s\n' "$result"
+}
+
+refuse_undeliverable_effort() {  # <harness> <effort> <detail>
+  echo "error: refusing $1 spawn because requested effort '$2' cannot be delivered: $3" >&2
+  return 1
+}
+
 effort_flag_for_harness() {
-  local harness=$1 effort=$2
+  local harness=$1 effort=$2 model=${3:-} catalog_result catalog_detail cache
   [ -n "$effort" ] && [ "$effort" != default ] || return 0
   case "$harness" in
     claude)
@@ -1062,20 +1111,54 @@ effort_flag_for_harness() {
       esac
       ;;
     codex)
-      # The installed codex config schema uses model_reasoning_effort, and the
-      # bundled model catalog advertises low|medium|high|xhigh. Omit max rather
-      # than passing an unsupported value.
-      case "$effort" in
-        low|medium|high|xhigh) printf -- '-c %s ' "$(shell_quote "model_reasoning_effort=\"$effort\"")" ;;
+      # Codex effort support is model-specific and changes independently of this
+      # script. The live cache is authoritative when it has one exact model row.
+      # Unknown evidence is not a contradiction: pass the requested config through
+      # with a warning so Codex can accept a newly added level instead of fm-spawn
+      # silently replacing it with the model default.
+      catalog_result=$(codex_effort_catalog_result "$model" "$effort")
+      catalog_detail=${catalog_result#*$'\t'}
+      case "$catalog_result" in
+        supported) ;;
+        unsupported$'\t'*)
+          cache="${CODEX_HOME:-${HOME:+$HOME/.codex}}/models_cache.json"
+          refuse_undeliverable_effort codex "$effort" \
+            "model '$model' advertises only ${catalog_detail:-no reasoning levels} in $cache"
+          return 1
+          ;;
+        unresolved-model)
+          echo "warning: Codex effort '$effort' cannot be preflighted without an explicit model; passing model_reasoning_effort through for Codex to validate" >&2
+          ;;
+        absent-model$'\t'*)
+          echo "warning: Codex model '$model' is absent from the live model catalog; passing requested effort '$effort' through for Codex to validate" >&2
+          ;;
+        unavailable-cache$'\t'*)
+          echo "warning: Codex model catalog is unavailable at '$catalog_detail'; passing requested effort '$effort' through for Codex to validate" >&2
+          ;;
+        unavailable-jq$'\t'*)
+          echo "warning: jq is unavailable, so Codex model '$model' cannot be checked against '$catalog_detail'; passing requested effort '$effort' through for Codex to validate" >&2
+          ;;
+        invalid-cache$'\t'*)
+          echo "warning: Codex model catalog at '$catalog_detail' is invalid; passing requested effort '$effort' through for Codex to validate" >&2
+          ;;
+        unavailable-home)
+          echo "warning: neither CODEX_HOME nor HOME identifies the Codex model catalog; passing requested effort '$effort' through for Codex to validate" >&2
+          ;;
+        *)
+          echo "error: refusing codex spawn because its model-catalog result was not understood: $catalog_result" >&2
+          return 1
+          ;;
       esac
+      printf -- '-c %s ' "$(shell_quote "model_reasoning_effort=\"$effort\"")"
       ;;
     grok)
       # grok exposes both --effort and --reasoning-effort; firstmate's profile
       # axis is the reasoning knob. As of grok 0.2.99, --reasoning-effort accepts
-      # only low|medium|high and rejects both xhigh and max, so omit those rather
-      # than passing a known-bad value.
+      # only low|medium|high and rejects both xhigh and max, so refuse those before
+      # endpoint creation rather than launching at Grok's default.
       case "$effort" in
         low|medium|high) printf -- '--reasoning-effort %s ' "$(shell_quote "$effort")" ;;
+        *) refuse_undeliverable_effort grok "$effort" "the verified reasoning-effort ceiling is high"; return 1 ;;
       esac
       ;;
     pi|pi-signed)
@@ -1099,13 +1182,28 @@ effort_flag_for_harness() {
         max) printf -- '--reasoning-effort %s ' "$(shell_quote ultra)" ;;
       esac
       ;;
-    # opencode's interactive `opencode --prompt` launch has a verified --model
-    # flag but no verified effort flag. Its `opencode run --variant` flag belongs
-    # to a different, non-interactive launch mode, so fm-spawn does not pass it.
-    # kimi likewise has no reasoning-effort flag; the requested axis stays in
-    # task metadata but never reaches the launch command.
+    opencode)
+      refuse_undeliverable_effort opencode "$effort" \
+        "its interactive launch has no verified effort flag"
+      return 1
+      ;;
+    kimi)
+      refuse_undeliverable_effort kimi "$effort" "it has no reasoning-effort flag"
+      return 1
+      ;;
+    *)
+      refuse_undeliverable_effort "${harness:-unknown harness}" "$effort" \
+        "no verified effort flag exists for this launch path"
+      return 1
+      ;;
   esac
 }
+
+# Resolve profile flags before binary-specific setup, project allocation, endpoint
+# creation, or metadata publication. A known-undeliverable effort therefore refuses
+# without leaving side effects or a durable record that falsely claims it launched.
+MODELFLAG=$(model_flag_for_harness "$HARNESS" "$MODEL")
+EFFORTFLAG=$(effort_flag_for_harness "$HARNESS" "$EFFORT" "$MODEL") || exit 1
 
 case "$LAUNCH" in
   *__MUSEBIN__*)
@@ -2229,8 +2327,6 @@ sq_piext=$(shell_quote "$STATE/$ID.pi-ext.ts")
 sq_piturnend=$(shell_quote "$PROJ_ABS/.pi/extensions/fm-primary-turnend-guard.ts")
 sq_piwatch=$(shell_quote "$PROJ_ABS/.pi/extensions/fm-primary-pi-watch.ts")
 sq_opinput=$(shell_quote "$FM_ROOT/bin/fm-operational-input.sh")
-MODELFLAG=$(model_flag_for_harness "$HARNESS" "$MODEL")
-EFFORTFLAG=$(effort_flag_for_harness "$HARNESS" "$EFFORT")
 LAUNCH=${LAUNCH//__MODELFLAG__/$MODELFLAG}
 LAUNCH=${LAUNCH//__EFFORTFLAG__/$EFFORTFLAG}
 LAUNCH=${LAUNCH//__BRIEF__/$sq_brief}

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -121,7 +121,11 @@
 #   and scout batches. The loop lives here, in bash, so callers never hand-write a
 #   multi-task shell loop (the tool shell is zsh, which does not word-split unquoted
 #   $vars and silently breaks ad-hoc `for ... in $pairs` loops).
-#   Launch templates live in launch_template() below; placeholders replaced before launch:
+#   Launch templates live in launch_template() below; placeholders replaced before launch
+#   (raw launch commands receive the same substitution):
+#     __MODELFLAG__ the harness-specific model flag resolved from --model (empty when unset)
+#     __EFFORTFLAG__ the harness-specific effort flag resolved from --effort; a requested
+#                  effort is refused when the launch command lacks this placeholder
 #     __BRIEF__    absolute path to data/<task-id>/brief.md
 #     __TURNEND__  absolute path to state/<task-id>.turn-ended (for harnesses whose
 #                  turn-end signal rides the launch command, e.g. codex -c notify=[...])

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1204,6 +1204,16 @@ effort_flag_for_harness() {
 # without leaving side effects or a durable record that falsely claims it launched.
 MODELFLAG=$(model_flag_for_harness "$HARNESS" "$MODEL")
 EFFORTFLAG=$(effort_flag_for_harness "$HARNESS" "$EFFORT" "$MODEL") || exit 1
+if [ -n "$EFFORTFLAG" ]; then
+  case "$LAUNCH" in
+    *__EFFORTFLAG__*) ;;
+    *)
+      refuse_undeliverable_effort "$HARNESS" "$EFFORT" \
+        "this launch command has no __EFFORTFLAG__ placeholder to receive it"
+      exit 1
+      ;;
+  esac
+fi
 
 case "$LAUNCH" in
   *__MUSEBIN__*)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -168,8 +168,8 @@ The shell scripts validate the JSON shape and verified harness/effort combinatio
 The session-start bootstrap step keeps valid dispatch configuration silent unless verbose facts are enabled and surfaces a concise invalid-config line when validation fails.
 When the file exists, `fm-spawn.sh` refuses crewmate and scout launches without an explicit harness, so `config/crew-harness` is only automatic when no dispatch profile file is active.
 Secondmate launches are exempt because they resolve the secondmate harness and any optional secondmate model or effort tokens instead.
-Unsupported effort values are still recorded in task meta when passed to `fm-spawn.sh`, but the launch template omits any effort flag that the selected harness does not accept.
-That keeps spawn launch compatible across claude, codex, opencode, pi, pi-signed, grok, kimi, and muse while preserving the requested profile for later audit.
+A requested effort is either delivered to the selected harness's launch or refused by `fm-spawn.sh` before endpoint creation and task metadata; it is never silently omitted from the launch while meta claims it applied.
+Codex effort support is model-specific and resolved from its live model catalog at spawn time; when the catalog or exact model cannot be verified, `fm-spawn.sh` warns and passes the requested value through for Codex itself to validate.
 
 ## Optional secondmates
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -277,7 +277,7 @@ Bootstrap reports statically invalid harness/effort pairs as a `CREW_DISPATCH` d
 See [`docs/examples/crew-dispatch.json`](examples/crew-dispatch.json) for a starting point to copy into local `config/crew-dispatch.json`.
 When the file exists, bootstrap validates it with `jq`.
 Valid files stay silent by default; with `FM_BOOTSTRAP_VERBOSE_FACTS=1`, bootstrap emits `BOOTSTRAP_INFO: crew dispatch active config/crew-dispatch.json`, one `BOOTSTRAP_INFO:` fact per rule, and one fact for the optional default profile set.
-Malformed JSON, an empty or malformed rule/default array, an unverified harness, or an effort value unsupported by that harness is reported as `CREW_DISPATCH: invalid config/crew-dispatch.json - ...`; missing `jq` is reported through the normal `MISSING: jq` install-consent flow.
+Malformed JSON, an empty or malformed rule/default array, an unverified harness, or a statically invalid harness/effort pair is reported as `CREW_DISPATCH: invalid config/crew-dispatch.json - ...`; missing `jq` is reported through the normal `MISSING: jq` install-consent flow.
 While the file remains present, no crewmate or scout spawn may proceed without an explicit resolved harness; malformed configuration must be reported and corrected rather than selected around.
 Secondmate homes inherit this file from the primary, so a secondmate's own crewmates apply the same dispatch profile behavior.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -272,7 +272,8 @@ Profile `model` and `effort` fields and rule `why` are optional.
 An omitted model or effort means the selected harness uses its own default for that axis.
 Every profile array is an implicit quota-aware choice resolved through `quota-array-dispatch`.
 If no dispatch rule fits, firstmate resolves `default` through the same object-or-array path before falling back to `config/crew-harness`.
-If a selected profile carries an effort value the chosen harness does not accept, `fm-spawn.sh` records the requested `effort=` in task meta for traceability but omits the launch flag, and bootstrap reports the invalid harness/effort pair as a `CREW_DISPATCH` diagnostic when it is visible in the file.
+If concrete adapter or per-model catalog evidence proves that the chosen harness cannot deliver a selected effort, `fm-spawn.sh` refuses before creating an endpoint or task metadata.
+Bootstrap reports statically invalid harness/effort pairs as a `CREW_DISPATCH` diagnostic when they are visible in the file, while Codex model-specific compatibility is resolved from its live model catalog at spawn time.
 See [`docs/examples/crew-dispatch.json`](examples/crew-dispatch.json) for a starting point to copy into local `config/crew-dispatch.json`.
 When the file exists, bootstrap validates it with `jq`.
 Valid files stay silent by default; with `FM_BOOTSTRAP_VERBOSE_FACTS=1`, bootstrap emits `BOOTSTRAP_INFO: crew dispatch active config/crew-dispatch.json`, one `BOOTSTRAP_INFO:` fact per rule, and one fact for the optional default profile set.

--- a/tests/fm-bootstrap.test.sh
+++ b/tests/fm-bootstrap.test.sh
@@ -923,7 +923,7 @@ test_crew_dispatch_validation() {
   done <<'ROWS'
 malformed dispatch config is flagged^{"rules":[^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - malformed JSON
 unverified dispatch harness is flagged^{"rules":[{"when":"anything","use":{"harness":"spaceship"}}],"default":{"harness":"codex"}}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - unverified harness: spaceship
-unsupported codex max effort is flagged^{"rules":[{"when":"big feature","use":{"harness":"codex","model":"gpt-5","effort":"max"}}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - invalid effort: codex:max
+codex max effort is accepted for live per-model validation at spawn^{"rules":[{"when":"big feature","use":{"harness":"codex","model":"gpt-5.6-sol","effort":"max"}}]}^empty^
 unsupported grok max effort is flagged^{"rules":[{"when":"deep current work","use":{"harness":"grok","model":"grok-4","effort":"max"}}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - invalid effort: grok:max
 unsupported grok xhigh effort is flagged^{"rules":[{"when":"deep current work","use":{"harness":"grok","model":"grok-4","effort":"xhigh"}}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - invalid effort: grok:xhigh
 pi max effort is accepted^{"rules":[{"when":"deep coding","use":{"harness":"pi","model":"openai-codex/gpt-5.6-sol","effort":"max"}}]}^empty^
@@ -942,7 +942,7 @@ empty array use is flagged^{"rules":[{"when":"big feature","use":[]}]}^exact^CRE
 array profile without harness is flagged^{"rules":[{"when":"big feature","use":[{"model":"gpt-5.5"}]}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - each use profile needs harness
 array profile with malformed model is flagged^{"rules":[{"when":"big feature","use":[{"harness":"codex","model":5}]}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - use profile model and effort must be non-empty strings when present
 unknown select is flagged^{"rules":[{"when":"big feature","use":[{"harness":"claude"},{"harness":"codex"}],"select":"mystery"}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - unknown select: mystery
-array profile unsupported effort is flagged^{"rules":[{"when":"big feature","use":[{"harness":"codex","effort":"max"}]}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - invalid effort: codex:max
+array profile codex max effort is accepted for live validation at spawn^{"rules":[{"when":"big feature","use":[{"harness":"codex","effort":"max"}]}]}^empty^
 empty default array is flagged^{"default":[]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - default needs at least one profile
 non-object default array entry is flagged^{"default":["codex"]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - each default profile must be an object
 default array profile without harness is flagged^{"default":[{"model":"gpt-5.5"}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - each default profile needs harness

--- a/tests/fm-kimi-harness.test.sh
+++ b/tests/fm-kimi-harness.test.sh
@@ -186,7 +186,7 @@ test_kimi_launch_then_send_is_verified() {
   read_spawn_record "$rec"
   out=$(FM_FAKE_KIMI_SWALLOW_FIRST=yes run_spawn \
     "$CASE_DIR" "$HOME_DIR" "$PROJ_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$id" \
-    --model kimi-code/k3 --effort high)
+    --model kimi-code/k3)
   rc=$?
   expect_code 0 "$rc" "verified kimi launch-then-send should succeed"
   assert_contains "$out" "spawned $id harness=kimi" "kimi spawn did not report success"
@@ -194,7 +194,6 @@ test_kimi_launch_then_send_is_verified() {
   launch=$(cat "$CASE_DIR/launch.log")
   [ "$launch" = "'$FAKEBIN_DIR/kimi' --model 'kimi-code/k3' --auto" ] \
     || fail "kimi launch did not use the absolute binary, model, and --auto only: $launch"
-  assert_not_contains "$launch" "--effort" "kimi launch emitted a nonexistent effort flag"
   assert_not_contains "$launch" "turn-ended" "kimi launch embedded a turn-end path"
   assert_not_contains "$launch" "__TURNEND__" "kimi launch retained a turn-end placeholder"
 
@@ -204,7 +203,7 @@ test_kimi_launch_then_send_is_verified() {
     || fail "kimi pointer was not the exact absolute-path-only instruction: $pointer"
   meta="$HOME_DIR/state/$id.meta"
   assert_grep 'model=kimi-code/k3' "$meta" "kimi meta lost the requested model"
-  assert_grep 'effort=high' "$meta" "kimi meta did not retain the unsupported effort axis"
+  assert_grep 'effort=default' "$meta" "kimi meta invented an effort no launch received"
   assert_grep "tasktmp=$task_tmp" "$meta" "kimi meta did not record its task temp root"
   assert_present "$task_tmp/gotmp" "kimi spawn did not create its Go temp directory"
   assert_grep "export GOTMPDIR=$task_tmp/gotmp" "$CASE_DIR/tmux-calls.log" \
@@ -214,6 +213,24 @@ test_kimi_launch_then_send_is_verified() {
   assert_grep 'token=' "$WT_DIR/.fm-kimi-turnend" "kimi spawn did not write its token pointer"
   assert_present "$HOME_DIR/state/$id.kimi-turnend-token" "kimi spawn did not record its token"
   pass "fm-spawn: kimi launches, delivers its brief, and registers a guarded turn-end token"
+}
+
+test_kimi_refuses_undeliverable_effort_axis() {
+  local id rec out rc
+  id="kimi-effort-refusal-z2-$$"
+  rec=$(make_spawn_case effort-refusal "$id")
+  read_spawn_record "$rec"
+  out=$(run_spawn "$CASE_DIR" "$HOME_DIR" "$PROJ_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$id" \
+    --model kimi-code/k3 --effort high)
+  rc=$?
+  expect_code 1 "$rc" "kimi spawn with an undeliverable effort should refuse"
+  assert_contains "$out" "requested effort 'high' cannot be delivered" \
+    "kimi refusal did not name the undeliverable request"
+  assert_contains "$out" "it has no reasoning-effort flag" \
+    "kimi refusal did not explain why the axis is undeliverable"
+  assert_absent "$HOME_DIR/state/$id.meta" "kimi refusal wrote misleading task metadata"
+  [ ! -s "$CASE_DIR/launch.log" ] || fail "kimi refusal typed a launch command"
+  pass "kimi refuses an effort its launch cannot deliver"
 }
 
 test_kimi_hook_install_is_surgical_idempotent_and_removable() {
@@ -662,6 +679,7 @@ test_kimi_hook_remove_preserves_owned_newline_boundary
 test_kimi_hook_fails_closed_on_missing_malformed_or_partial_config
 test_kimi_hook_install_refuses_without_jq
 test_kimi_launch_then_send_is_verified
+test_kimi_refuses_undeliverable_effort_axis
 test_kimi_hook_is_silent_and_requires_registered_workspace_token
 test_kimi_spawn_refuses_unsafe_global_config_before_pane_creation
 test_kimi_teardown_removes_pointer_and_registry_token

--- a/tests/fm-secondmate-harness.test.sh
+++ b/tests/fm-secondmate-harness.test.sh
@@ -606,6 +606,32 @@ SH
   printf '%s\n' "$fakebin"
 }
 
+# A hermetic Codex model catalog, mirroring fm-spawn-dispatch-profile.test.sh's
+# write_codex_catalog: fm-spawn's codex effort preflight reads
+# ${CODEX_HOME:-$HOME/.codex}/models_cache.json, and without a pinned CODEX_HOME
+# every codex+effort spawn here would depend on the invoking machine's live
+# Codex state.
+write_codex_catalog() {
+  local codex_home=$1
+  mkdir -p "$codex_home"
+  cat > "$codex_home/models_cache.json" <<'JSON'
+{
+  "client_version": "test",
+  "models": [
+    {
+      "slug": "gpt-5.5",
+      "supported_reasoning_levels": [
+        {"effort": "low"},
+        {"effort": "medium"},
+        {"effort": "high"},
+        {"effort": "xhigh"}
+      ]
+    }
+  ]
+}
+JSON
+}
+
 # spawn_secondmate_capture <world> <id> <home> <launchlog> [extra fm-spawn.sh args...]
 # Same shape as spawn_secondmate but captures the launch command into <launchlog>
 # and does not discard stderr, so callers can assert on both.
@@ -614,12 +640,14 @@ spawn_secondmate_capture() {
   shift 4
   mkdir -p "$world/home/state" "$world/home/data"
   fakebin=$(make_launch_capturing_tmux "$world/tmux-$id")
+  write_codex_catalog "$world/codex-home"
   : > "$launchlog"
   PATH="$fakebin:$BASE_PATH" TMUX='' CLAUDECODE=1 \
     FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$world/home" \
     FM_STATE_OVERRIDE="$world/home/state" FM_DATA_OVERRIDE="$world/home/data" \
     FM_PROJECTS_OVERRIDE="$world/home/projects" FM_CONFIG_OVERRIDE="$world/home/config" \
     FM_SPAWN_NO_GUARD=1 FM_FAKE_LAUNCH_LOG="$launchlog" \
+    CODEX_HOME="$world/codex-home" \
     "$ROOT/bin/fm-spawn.sh" "$id" "$home" "$@" --secondmate
 }
 

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -46,6 +46,39 @@ SH
   printf '%s\n' "$fakebin"
 }
 
+write_codex_catalog() {
+  local home=$1
+  mkdir -p "$home/codex-home"
+  cat > "$home/codex-home/models_cache.json" <<'JSON'
+{
+  "client_version": "test",
+  "fetched_at": "2026-08-02T00:00:00Z",
+  "models": [
+    {
+      "slug": "gpt-5",
+      "supported_reasoning_levels": [
+        {"effort": "low"},
+        {"effort": "medium"},
+        {"effort": "high"},
+        {"effort": "xhigh"}
+      ]
+    },
+    {
+      "slug": "gpt-5.6-sol",
+      "supported_reasoning_levels": [
+        {"effort": "low"},
+        {"effort": "medium"},
+        {"effort": "high"},
+        {"effort": "xhigh"},
+        {"effort": "max"},
+        {"effort": "ultra"}
+      ]
+    }
+  ]
+}
+JSON
+}
+
 make_spawn_case() {
   local name=$1 harness=$2 case_dir home proj wt fakebin launchlog id
   shift 2
@@ -56,6 +89,7 @@ make_spawn_case() {
   launchlog="$case_dir/launch.log"
   fakebin=$(make_spawn_fakebin "$case_dir/fake")
   mkdir -p "$home/data" "$home/projects" "$home/state" "$home/config"
+  write_codex_catalog "$home"
   printf '%s\n' "$harness" > "$home/config/crew-harness"
   fm_git_worktree "$proj" "$wt" "wt-$name"
   touch "$home/state/.last-watcher-beat"
@@ -93,6 +127,7 @@ run_spawn() {
     FM_PROJECTS_OVERRIDE="$home/projects" FM_CONFIG_OVERRIDE="$home/config" \
     FM_SPAWN_NO_GUARD=1 FM_FAKE_PANE_PATH="$wt" TMUX="fake,1,0" \
     CLAUDE_CONFIG_DIR="${FM_TEST_CLAUDE_CONFIG_DIR:-}" \
+    CODEX_HOME="${FM_TEST_CODEX_HOME:-$home/codex-home}" \
     FM_FAKE_LAUNCH_LOG="$launchlog" GROK_HOME="$home/grok-home" PATH="$fakebin:$PATH" \
     "$SPAWN" "$@" 2>&1
 }
@@ -398,21 +433,71 @@ test_codex_threads_model_and_effort() {
   pass "codex receives --model and model_reasoning_effort profile flags"
 }
 
-test_codex_omits_invalid_max_effort() {
+test_codex_threads_catalog_supported_max_effort() {
   local rec id out status launch
   id=profile-codex-max-z4
   rec=$(make_spawn_case profile-codex-max codex "$id")
   read_case_record "$rec"
 
+  out=$(run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR" --model gpt-5.6-sol --effort max)
+  status=$?
+  expect_code 0 "$status" "codex spawn with catalog-supported max effort should succeed"
+  assert_meta_profile "$HOME_DIR/state/$id.meta" codex gpt-5.6-sol max
+  launch=$(cat "$LAUNCH_LOG")
+  assert_contains "$launch" "codex --model 'gpt-5.6-sol' -c 'model_reasoning_effort=\"max\"' --dangerously-bypass-approvals-and-sandbox" \
+    "codex launch did not thread catalog-supported max reasoning effort"
+  pass "codex receives a max effort advertised by the selected live-catalog model"
+}
+
+test_codex_refuses_catalog_unsupported_effort() {
+  local rec id out status
+  id=profile-codex-unsupported-z4b
+  rec=$(make_spawn_case profile-codex-unsupported codex "$id")
+  read_case_record "$rec"
+
   out=$(run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR" --model gpt-5 --effort max)
   status=$?
-  expect_code 0 "$status" "codex spawn with unsupported max effort should omit the effort flag"
-  assert_meta_profile "$HOME_DIR/state/$id.meta" codex gpt-5 max
+  expect_code 1 "$status" "codex spawn with catalog-unsupported max effort should refuse"
+  assert_contains "$out" "requested effort 'max' cannot be delivered" \
+    "codex refusal did not identify the undeliverable effort"
+  assert_contains "$out" "model 'gpt-5' advertises only low, medium, high, xhigh" \
+    "codex refusal did not report the selected model's catalog range"
+  assert_absent "$HOME_DIR/state/$id.meta" "codex refusal wrote misleading task metadata"
+  [ ! -s "$LAUNCH_LOG" ] || fail "codex refusal typed a launch command"
+  pass "codex refuses before launch when its live per-model catalog contradicts the requested effort"
+}
+
+test_codex_passes_effort_through_when_model_is_absent_from_catalog() {
+  local rec id out status launch
+  id=profile-codex-future-z4c
+  rec=$(make_spawn_case profile-codex-future codex "$id")
+  read_case_record "$rec"
+
+  out=$(run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR" --model future-model --effort max)
+  status=$?
+  expect_code 0 "$status" "codex spawn with a catalog-absent model should pass the effort through"
+  assert_contains "$out" "model 'future-model' is absent from the live model catalog" \
+    "catalog uncertainty did not produce a visible warning"
   launch=$(cat "$LAUNCH_LOG")
-  assert_contains "$launch" "codex --model 'gpt-5' --dangerously-bypass-approvals-and-sandbox" \
-    "codex launch did not preserve the model flag when max effort was omitted"
-  assert_not_contains "$launch" "model_reasoning_effort" "codex launch must omit unsupported max reasoning effort"
-  pass "codex omits unsupported max effort instead of passing a bad config value"
+  assert_contains "$launch" "--model 'future-model' -c 'model_reasoning_effort=\"max\"'" \
+    "catalog uncertainty silently discarded the requested effort"
+  pass "codex warns but passes through an effort when catalog evidence is inconclusive"
+}
+
+test_ultra_stays_outside_shared_effort_axis() {
+  local rec id out status
+  id=profile-codex-ultra-z4d
+  rec=$(make_spawn_case profile-codex-ultra codex "$id")
+  read_case_record "$rec"
+
+  out=$(run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR" --model gpt-5.6-sol --effort ultra)
+  status=$?
+  expect_code 1 "$status" "ultra should remain outside firstmate's shared effort axis"
+  assert_contains "$out" "--effort must be one of low, medium, high, xhigh, max" \
+    "ultra refusal did not report the supported profile axis"
+  assert_absent "$HOME_DIR/state/$id.meta" "ultra parser refusal wrote task metadata"
+  [ ! -s "$LAUNCH_LOG" ] || fail "ultra parser refusal typed a launch command"
+  pass "ultra remains outside the shared profile axis and refuses before launch"
 }
 
 test_grok_threads_model_and_reasoning_effort() {
@@ -432,7 +517,7 @@ test_grok_threads_model_and_reasoning_effort() {
   pass "grok receives --model and --reasoning-effort profile flags"
 }
 
-test_grok_omits_invalid_max_reasoning_effort() {
+test_grok_refuses_invalid_max_reasoning_effort() {
   local rec id out status launch
   id=profile-grok-max-z6
   rec=$(make_spawn_case profile-grok-max grok "$id")
@@ -440,17 +525,15 @@ test_grok_omits_invalid_max_reasoning_effort() {
 
   out=$(run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR" --model grok-4 --effort max)
   status=$?
-  expect_code 0 "$status" "grok spawn with unsupported max reasoning effort should omit the effort flag"
-  assert_meta_profile "$HOME_DIR/state/$id.meta" grok grok-4 max
-  launch=$(cat "$LAUNCH_LOG")
-  assert_contains "$launch" "grok --always-approve --model 'grok-4' \"\$('${ROOT}/bin/fm-operational-input.sh' encode launch-brief < " \
-    "grok launch did not preserve the model flag and typed brief when max effort was omitted"
-  assert_not_contains "$launch" "--reasoning-effort" "grok launch must omit unsupported max reasoning effort"
-  assert_not_contains "$launch" "--effort" "grok launch must not fall back to --effort for reasoning effort"
-  pass "grok omits unsupported max reasoning effort"
+  expect_code 1 "$status" "grok spawn with unsupported max reasoning effort should refuse"
+  assert_contains "$out" "requested effort 'max' cannot be delivered" \
+    "grok max refusal did not name the undeliverable request"
+  assert_absent "$HOME_DIR/state/$id.meta" "grok max refusal wrote misleading task metadata"
+  [ ! -s "$LAUNCH_LOG" ] || fail "grok max refusal typed a launch command"
+  pass "grok refuses an unsupported max effort before launch"
 }
 
-test_grok_omits_invalid_xhigh_reasoning_effort() {
+test_grok_refuses_invalid_xhigh_reasoning_effort() {
   local rec id out status launch
   id=profile-grok-xhigh-z6b
   rec=$(make_spawn_case profile-grok-xhigh grok "$id")
@@ -459,33 +542,28 @@ test_grok_omits_invalid_xhigh_reasoning_effort() {
   # grok 0.2.99 rejects xhigh (accepted set is only low|medium|high).
   out=$(run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR" --model grok-4 --effort xhigh)
   status=$?
-  expect_code 0 "$status" "grok spawn with unsupported xhigh reasoning effort should omit the effort flag"
-  assert_meta_profile "$HOME_DIR/state/$id.meta" grok grok-4 xhigh
-  launch=$(cat "$LAUNCH_LOG")
-  assert_contains "$launch" "grok --always-approve --model 'grok-4' \"\$('${ROOT}/bin/fm-operational-input.sh' encode launch-brief < " \
-    "grok launch did not preserve the model flag and typed brief when xhigh effort was omitted"
-  assert_not_contains "$launch" "--reasoning-effort" "grok launch must omit unsupported xhigh reasoning effort"
-  assert_not_contains "$launch" "--effort" "grok launch must not fall back to --effort for reasoning effort"
-  pass "grok omits unsupported xhigh reasoning effort"
+  expect_code 1 "$status" "grok spawn with unsupported xhigh reasoning effort should refuse"
+  assert_contains "$out" "requested effort 'xhigh' cannot be delivered" \
+    "grok xhigh refusal did not name the undeliverable request"
+  assert_absent "$HOME_DIR/state/$id.meta" "grok xhigh refusal wrote misleading task metadata"
+  [ ! -s "$LAUNCH_LOG" ] || fail "grok xhigh refusal typed a launch command"
+  pass "grok refuses an unsupported xhigh effort before launch"
 }
 
-test_opencode_threads_model_and_ignores_effort_axis() {
-  local rec id out status launch
+test_opencode_refuses_undeliverable_effort_axis() {
+  local rec id out status
   id=profile-opencode-z7
   rec=$(make_spawn_case profile-opencode opencode "$id")
   read_case_record "$rec"
 
   out=$(run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR" --model anthropic/claude-sonnet-4-5 --effort high)
   status=$?
-  expect_code 0 "$status" "opencode spawn with model and ignored effort should succeed"
-  assert_meta_profile "$HOME_DIR/state/$id.meta" opencode anthropic/claude-sonnet-4-5 high
-  launch=$(cat "$LAUNCH_LOG")
-  assert_contains "$launch" "opencode --model 'anthropic/claude-sonnet-4-5' --prompt" \
-    "opencode launch did not thread model"
-  assert_not_contains "$launch" "--effort" "opencode launch must not pass unsupported --effort"
-  assert_not_contains "$launch" "--variant" "opencode launch must not pass run-only --variant"
-  assert_not_contains "$launch" "--thinking" "opencode launch must not pass pi thinking flag"
-  pass "opencode receives --model and omits the unsupported effort axis"
+  expect_code 1 "$status" "opencode spawn with an undeliverable effort should refuse"
+  assert_contains "$out" "requested effort 'high' cannot be delivered" \
+    "opencode refusal did not name the undeliverable request"
+  assert_absent "$HOME_DIR/state/$id.meta" "opencode refusal wrote misleading task metadata"
+  [ ! -s "$LAUNCH_LOG" ] || fail "opencode refusal typed a launch command"
+  pass "opencode refuses an effort its interactive launch cannot deliver"
 }
 
 test_pi_threads_model_and_max_effort() {
@@ -685,11 +763,14 @@ test_active_dispatch_profile_allows_positional_harness
 test_active_dispatch_profile_allows_raw_launch_command
 test_claude_threads_model_and_effort
 test_codex_threads_model_and_effort
-test_codex_omits_invalid_max_effort
+test_codex_threads_catalog_supported_max_effort
+test_codex_refuses_catalog_unsupported_effort
+test_codex_passes_effort_through_when_model_is_absent_from_catalog
+test_ultra_stays_outside_shared_effort_axis
 test_grok_threads_model_and_reasoning_effort
-test_grok_omits_invalid_max_reasoning_effort
-test_grok_omits_invalid_xhigh_reasoning_effort
-test_opencode_threads_model_and_ignores_effort_axis
+test_grok_refuses_invalid_max_reasoning_effort
+test_grok_refuses_invalid_xhigh_reasoning_effort
+test_opencode_refuses_undeliverable_effort_axis
 test_pi_threads_model_and_max_effort
 test_pi_signed_threads_shared_pi_profile_and_preserves_identity
 test_pi_signed_missing_binary_refuses_before_endpoint_or_metadata

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -566,6 +566,27 @@ test_opencode_refuses_undeliverable_effort_axis() {
   pass "opencode refuses an effort its interactive launch cannot deliver"
 }
 
+test_raw_launch_refuses_undeliverable_effort() {
+  local rec id out status
+  id=profile-raw-effort-z7b
+  rec=$(make_spawn_case profile-raw-effort codex "$id")
+  read_case_record "$rec"
+
+  # A raw launch command (unverified-adapter escape hatch) has no __EFFORTFLAG__
+  # placeholder, so even a catalog-supported effort has nowhere to land.
+  out=$(run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR" \
+    'codex --dangerously-bypass-approvals-and-sandbox go' --model gpt-5.6-sol --effort max)
+  status=$?
+  expect_code 1 "$status" "raw launch spawn with a requested effort should refuse"
+  assert_contains "$out" "requested effort 'max' cannot be delivered" \
+    "raw-launch refusal did not name the undeliverable request"
+  assert_contains "$out" "no __EFFORTFLAG__ placeholder" \
+    "raw-launch refusal did not explain the missing placeholder"
+  assert_absent "$HOME_DIR/state/$id.meta" "raw-launch refusal wrote misleading task metadata"
+  [ ! -s "$LAUNCH_LOG" ] || fail "raw-launch refusal typed a launch command"
+  pass "a raw launch command refuses a requested effort it has no placeholder to receive"
+}
+
 test_pi_threads_model_and_max_effort() {
   local rec id out status launch
   id=profile-pi-z8
@@ -771,6 +792,7 @@ test_grok_threads_model_and_reasoning_effort
 test_grok_refuses_invalid_max_reasoning_effort
 test_grok_refuses_invalid_xhigh_reasoning_effort
 test_opencode_refuses_undeliverable_effort_axis
+test_raw_launch_refuses_undeliverable_effort
 test_pi_threads_model_and_max_effort
 test_pi_signed_threads_shared_pi_profile_and_preserves_identity
 test_pi_signed_missing_binary_refuses_before_endpoint_or_metadata


### PR DESCRIPTION
## What Changed

- `bin/fm-spawn.sh` now validates a requested Codex effort against the live `models_cache.json` catalog: supported levels (including `max` on models that advertise it) are delivered via `model_reasoning_effort`, unsupported levels refuse the spawn with the model's advertised range, and missing or inconclusive catalog evidence warns and passes the requested value through for Codex to validate.
- Effort requests that can never reach the launch command now refuse before any side effects (project allocation, endpoint creation, metadata publication) instead of silently launching at the harness default while task metadata records the requested effort: grok `xhigh`/`max`, opencode, kimi, unknown harnesses, and any launch command lacking an `__EFFORTFLAG__` placeholder. `bin/fm-bootstrap.sh` crew-dispatch validation now shares one effort list for claude/codex/pi so `codex:max` passes through to spawn-time live validation.
- Docs and the harness-adapters skill (`docs/architecture.md`, `docs/configuration.md`, `.agents/skills/harness-adapters/SKILL.md`, the fm-spawn header) drop the stale "effort is omitted" claims and document the deliver-or-refuse behavior and launch placeholders; test suites were extended accordingly (dispatch-profile catalog delivery/refusal/pass-through cases, hermetic `CODEX_HOME` wiring in the kimi and secondmate suites, updated bootstrap validation), all passing in the pipeline's Test phase including a watch-it-fail run against the base commit.

## Risk Assessment

✅ Low: A deliberate, well-documented behavior change (loud refusal of undeliverable efforts plus live-catalog Codex validation) whose refusal ordering, lock cleanup on the new exit paths, set -eu interactions, and test hermeticity all verify cleanly in source; the single finding is a pre-existing sibling gap on the model axis suitable for follow-up.

## Testing

Ran the four touched suites (dispatch-profile, kimi, secondmate, bootstrap) with verified exit codes — all green; proved the new codex-catalog test detects the old behavior by watching it fail against the base-commit fm-spawn.sh; and captured before/after CLI transcripts of the real fm-spawn.sh showing max-effort delivery from the live catalog, loud pre-launch refusals with no metadata side effects, and warn-and-pass-through on catalog uncertainty, versus the base commit's silent effort omission with misleading metadata.

<details>
<summary>Evidence: fm-spawn effort demo transcript (target commit): catalog-supported max delivered, unsupported refused, uncertainty passed through</summary>

```text
### fm-spawn effort delivery demo — Spawn a direct report: a crewmate in a treehouse or Orca worktree, or a ###

================================================================
$ fm-spawn.sh demo-codex-max <project> --model gpt-5.6-sol --effort max
  (harness=codex; hermetic CODEX_HOME catalog: gpt-5 tops out at xhigh,
   gpt-5.6-sol advertises low..max plus ultra)
----------------------------------------------------------------
warn: no registry at /var/folders/pq/43bb80gj31x7009tmpvfjcy40000gn/T//fm-spawn-effort-demo.VCnzdR/codex-max-supported/home/data/projects.md; defaulting project to no-mistakes off
spawned demo-codex-max harness=codex kind=ship mode=no-mistakes yolo=off window=firstmate:fm-demo-codex-max worktree=/var/folders/pq/43bb80gj31x7009tmpvfjcy40000gn/T//fm-spawn-effort-demo.VCnzdR/codex-max-supported/wt
exit code: 0
launch command typed into the pane:
  | codex --model 'gpt-5.6-sol' -c 'model_reasoning_effort="max"' --dangerously-bypass-approvals-and-sandbox -c "notify=[\"bash\",\"-c\",\"touch '/private/var/folders/pq/43bb80gj31x7009tmpvfjcy40000gn/T/fm-spawn-effort-demo.VCnzdR/codex-max-supported/home/state/demo-codex-max.turn-ended'\"]" "$('/Users/ivannovak/.no-mistakes/worktrees/e7be5960b363/01KZ29B0B9CX2K7EXXTN165XSC/bin/fm-operational-input.sh' encode launch-brief < '/var/folders/pq/43bb80gj31x7009tmpvfjcy40000gn/T//fm-spawn-effort-demo.VCnzdR/codex-max-supported/home/data/demo-codex-max/brief.md')"
task metadata written (demo-codex-max.meta):
  | harness=codex
  | model=gpt-5.6-sol
  | effort=max

================================================================
$ fm-spawn.sh demo-codex-refuse <project> --model gpt-5 --effort max
  (harness=codex; hermetic CODEX_HOME catalog: gpt-5 tops out at xhigh,
   gpt-5.6-sol advertises low..max plus ultra)
----------------------------------------------------------------
error: refusing codex spawn because requested effort 'max' cannot be delivered: model 'gpt-5' advertises only low, medium, high, xhigh in /var/folders/pq/43bb80gj31x7009tmpvfjcy40000gn/T//fm-spawn-effort-demo.VCnzdR/codex-max-unsupported/home/codex-home/models_cache.json
exit code: 1
launch command typed into the pane: (none - nothing was launched)
task metadata written: (none)

================================================================
$ fm-spawn.sh demo-codex-future <project> --model future-model --effort max
  (harness=codex; hermetic CODEX_HOME catalog: gpt-5 tops out at xhigh,
   gpt-5.6-sol advertises low..max plus ultra)
----------------------------------------------------------------
warning: Codex model 'future-model' is absent from the live model catalog; passing requested effort 'max' through for Codex to validate
warn: no registry at /var/folders/pq/43bb80gj31x7009tmpvfjcy40000gn/T//fm-spawn-effort-demo.VCnzdR/codex-model-absent/home/data/projects.md; defaulting project to no-mistakes off
spawned demo-codex-future harness=codex kind=ship mode=no-mistakes yolo=off window=firstmate:fm-demo-codex-future worktree=/var/folders/pq/43bb80gj31x7009tmpvfjcy40000gn/T//fm-spawn-effort-demo.VCnzdR/codex-model-absent/wt
exit code: 0
launch command typed into the pane:
  | codex --model 'future-model' -c 'model_reasoning_effort="max"' --dangerously-bypass-approvals-and-sandbox -c "notify=[\"bash\",\"-c\",\"touch '/private/var/folders/pq/43bb80gj31x7009tmpvfjcy40000gn/T/fm-spawn-effort-demo.VCnzdR/codex-model-absent/home/state/demo-codex-future.turn-ended'\"]" "$('/Users/ivannovak/.no-mistakes/worktrees/e7be5960b363/01KZ29B0B9CX2K7EXXTN165XSC/bin/fm-operational-input.sh' encode launch-brief < '/var/folders/pq/43bb80gj31x7009tmpvfjcy40000gn/T//fm-spawn-effort-demo.VCnzdR/codex-model-absent/home/data/demo-codex-future/brief.md')"
task metadata written (demo-codex-future.meta):
  | harness=codex
  | model=future-model
  | effort=max

================================================================
$ fm-spawn.sh demo-grok-xhigh <project> --model grok-4 --effort xhigh
  (harness=grok; hermetic CODEX_HOME catalog: gpt-5 tops out at xhigh,
   gpt-5.6-sol advertises low..max plus ultra)
----------------------------------------------------------------
error: refusing grok spawn because requested effort 'xhigh' cannot be delivered: the verified reasoning-effort ceiling is high
exit code: 1
launch command typed into the pane: (none - nothing was launched)
task metadata written: (none)

================================================================
$ fm-spawn.sh demo-opencode <project> --model anthropic/claude-sonnet-4-5 --effort high
  (harness=opencode; hermetic CODEX_HOME catalog: gpt-5 tops out at xhigh,
   gpt-5.6-sol advertises low..max plus ultra)
----------------------------------------------------------------
error: refusing opencode spawn because requested effort 'high' cannot be delivered: its interactive launch has no verified effort flag
exit code: 1
launch command typed into the pane: (none - nothing was launched)
task metadata written: (none)
```
</details>
<details>
<summary>Evidence: fm-spawn effort demo transcript (base commit): same commands silently omit effort while metadata claims it applied</summary>

```text
### fm-spawn effort delivery demo — Spawn a direct report: a crewmate in a treehouse or Orca worktree, or a ###

================================================================
$ fm-spawn.sh demo-codex-max <project> --model gpt-5.6-sol --effort max
  (harness=codex; hermetic CODEX_HOME catalog: gpt-5 tops out at xhigh,
   gpt-5.6-sol advertises low..max plus ultra)
----------------------------------------------------------------
warn: no registry at /var/folders/pq/43bb80gj31x7009tmpvfjcy40000gn/T//fm-spawn-effort-demo.m5qjld/codex-max-supported/home/data/projects.md; defaulting project to no-mistakes off
spawned demo-codex-max harness=codex kind=ship mode=no-mistakes yolo=off window=firstmate:fm-demo-codex-max worktree=/var/folders/pq/43bb80gj31x7009tmpvfjcy40000gn/T//fm-spawn-effort-demo.m5qjld/codex-max-supported/wt
exit code: 0
launch command typed into the pane:
  | codex --model 'gpt-5.6-sol' --dangerously-bypass-approvals-and-sandbox -c "notify=[\"bash\",\"-c\",\"touch '/private/var/folders/pq/43bb80gj31x7009tmpvfjcy40000gn/T/fm-spawn-effort-demo.m5qjld/codex-max-supported/home/state/demo-codex-max.turn-ended'\"]" "$('/Users/ivannovak/.no-mistakes/worktrees/e7be5960b363/01KZ29B0B9CX2K7EXXTN165XSC/bin/fm-operational-input.sh' encode launch-brief < '/var/folders/pq/43bb80gj31x7009tmpvfjcy40000gn/T//fm-spawn-effort-demo.m5qjld/codex-max-supported/home/data/demo-codex-max/brief.md')"
task metadata written (demo-codex-max.meta):
  | harness=codex
  | model=gpt-5.6-sol
  | effort=max

================================================================
$ fm-spawn.sh demo-codex-refuse <project> --model gpt-5 --effort max
  (harness=codex; hermetic CODEX_HOME catalog: gpt-5 tops out at xhigh,
   gpt-5.6-sol advertises low..max plus ultra)
----------------------------------------------------------------
warn: no registry at /var/folders/pq/43bb80gj31x7009tmpvfjcy40000gn/T//fm-spawn-effort-demo.m5qjld/codex-max-unsupported/home/data/projects.md; defaulting project to no-mistakes off
spawned demo-codex-refuse harness=codex kind=ship mode=no-mistakes yolo=off window=firstmate:fm-demo-codex-refuse worktree=/var/folders/pq/43bb80gj31x7009tmpvfjcy40000gn/T//fm-spawn-effort-demo.m5qjld/codex-max-unsupported/wt
exit code: 0
launch command typed into the pane:
  | codex --model 'gpt-5' --dangerously-bypass-approvals-and-sandbox -c "notify=[\"bash\",\"-c\",\"touch '/private/var/folders/pq/43bb80gj31x7009tmpvfjcy40000gn/T/fm-spawn-effort-demo.m5qjld/codex-max-unsupported/home/state/demo-codex-refuse.turn-ended'\"]" "$('/Users/ivannovak/.no-mistakes/worktrees/e7be5960b363/01KZ29B0B9CX2K7EXXTN165XSC/bin/fm-operational-input.sh' encode launch-brief < '/var/folders/pq/43bb80gj31x7009tmpvfjcy40000gn/T//fm-spawn-effort-demo.m5qjld/codex-max-unsupported/home/data/demo-codex-refuse/brief.md')"
task metadata written (demo-codex-refuse.meta):
  | harness=codex
  | model=gpt-5
  | effort=max

================================================================
$ fm-spawn.sh demo-codex-future <project> --model future-model --effort max
  (harness=codex; hermetic CODEX_HOME catalog: gpt-5 tops out at xhigh,
   gpt-5.6-sol advertises low..max plus ultra)
----------------------------------------------------------------
warn: no registry at /var/folders/pq/43bb80gj31x7009tmpvfjcy40000gn/T//fm-spawn-effort-demo.m5qjld/codex-model-absent/home/data/projects.md; defaulting project to no-mistakes off
spawned demo-codex-future harness=codex kind=ship mode=no-mistakes yolo=off window=firstmate:fm-demo-codex-future worktree=/var/folders/pq/43bb80gj31x7009tmpvfjcy40000gn/T//fm-spawn-effort-demo.m5qjld/codex-model-absent/wt
exit code: 0
launch command typed into the pane:
  | codex --model 'future-model' --dangerously-bypass-approvals-and-sandbox -c "notify=[\"bash\",\"-c\",\"touch '/private/var/folders/pq/43bb80gj31x7009tmpvfjcy40000gn/T/fm-spawn-effort-demo.m5qjld/codex-model-absent/home/state/demo-codex-future.turn-ended'\"]" "$('/Users/ivannovak/.no-mistakes/worktrees/e7be5960b363/01KZ29B0B9CX2K7EXXTN165XSC/bin/fm-operational-input.sh' encode launch-brief < '/var/folders/pq/43bb80gj31x7009tmpvfjcy40000gn/T//fm-spawn-effort-demo.m5qjld/codex-model-absent/home/data/demo-codex-future/brief.md')"
task metadata written (demo-codex-future.meta):
  | harness=codex
  | model=future-model
  | effort=max

================================================================
$ fm-spawn.sh demo-grok-xhigh <project> --model grok-4 --effort xhigh
  (harness=grok; hermetic CODEX_HOME catalog: gpt-5 tops out at xhigh,
   gpt-5.6-sol advertises low..max plus ultra)
----------------------------------------------------------------
warn: no registry at /var/folders/pq/43bb80gj31x7009tmpvfjcy40000gn/T//fm-spawn-effort-demo.m5qjld/grok-xhigh/home/data/projects.md; defaulting project to no-mistakes off
spawned demo-grok-xhigh harness=grok kind=ship mode=no-mistakes yolo=off window=firstmate:fm-demo-grok-xhigh worktree=/var/folders/pq/43bb80gj31x7009tmpvfjcy40000gn/T//fm-spawn-effort-demo.m5qjld/grok-xhigh/wt
exit code: 0
launch command typed into the pane:
  | grok --always-approve --model 'grok-4' "$('/Users/ivannovak/.no-mistakes/worktrees/e7be5960b363/01KZ29B0B9CX2K7EXXTN165XSC/bin/fm-operational-input.sh' encode launch-brief < '/var/folders/pq/43bb80gj31x7009tmpvfjcy40000gn/T//fm-spawn-effort-demo.m5qjld/grok-xhigh/home/data/demo-grok-xhigh/brief.md')"
task metadata written (demo-grok-xhigh.meta):
  | harness=grok
  | model=grok-4
  | effort=xhigh

================================================================
$ fm-spawn.sh demo-opencode <project> --model anthropic/claude-sonnet-4-5 --effort high
  (harness=opencode; hermetic CODEX_HOME catalog: gpt-5 tops out at xhigh,
   gpt-5.6-sol advertises low..max plus ultra)
----------------------------------------------------------------
warn: no registry at /var/folders/pq/43bb80gj31x7009tmpvfjcy40000gn/T//fm-spawn-effort-demo.m5qjld/opencode-effort/home/data/projects.md; defaulting project to no-mistakes off
spawned demo-opencode harness=opencode kind=ship mode=no-mistakes yolo=off window=firstmate:fm-demo-opencode worktree=/var/folders/pq/43bb80gj31x7009tmpvfjcy40000gn/T//fm-spawn-effort-demo.m5qjld/opencode-effort/wt
exit code: 0
launch command typed into the pane:
  | OPENCODE_CONFIG_CONTENT='{"permission":{"*":"allow"}}' opencode --model 'anthropic/claude-sonnet-4-5' --prompt "$('/Users/ivannovak/.no-mistakes/worktrees/e7be5960b363/01KZ29B0B9CX2K7EXXTN165XSC/bin/fm-operational-input.sh' encode launch-brief < '/var/folders/pq/43bb80gj31x7009tmpvfjcy40000gn/T//fm-spawn-effort-demo.m5qjld/opencode-effort/home/data/demo-opencode/brief.md')"
task metadata written (demo-opencode.meta):
  | harness=opencode
  | model=anthropic/claude-sonnet-4-5
  | effort=high
```
</details>
<details>
<summary>Evidence: Reproducible demo script used to generate both transcripts</summary>

```text
#!/usr/bin/env bash
# Manual end-to-end demo of fm-spawn.sh effort delivery/refusal behavior.
# Reuses the repo's test lib for hermetic fixtures (fake tmux pane, isolated
# git worktree, pinned CODEX_HOME catalog) but drives the real bin/fm-spawn.sh
# exactly as firstmate would, and prints the literal launch command that would
# have been typed into the crewmate pane.
set -u
REPO=${1:?usage: demo-codex-effort.sh <repo-root>}
. "$REPO/tests/lib.sh"

SPAWN="$ROOT/bin/fm-spawn.sh"
TMP_ROOT=$(fm_test_tmproot fm-spawn-effort-demo)

make_fakebin() {
  local dir=$1 fakebin
  fakebin=$(fm_fakebin "$dir")
  cat > "$fakebin/tmux" <<'SH'
#!/usr/bin/env bash
set -u
case "$*" in
  *"#{pane_current_path}"*) printf '%s\n' "${FM_FAKE_PANE_PATH:-}"; exit 0 ;;
esac
case "${1:-}" in
  display-message) printf 'firstmate\n'; exit 0 ;;
  list-windows) exit 0 ;;
  has-session|new-session|new-window|kill-window) exit 0 ;;
  send-keys)
    if [ -n "${FM_FAKE_LAUNCH_LOG:-}" ]; then
      prev=
      for a in "$@"; do
        if [ "$prev" = "-l" ]; then
          printf '%s\n' "$a" >> "$FM_FAKE_LAUNCH_LOG"
        fi
        prev=$a
      done
    fi
    exit 0
    ;;
esac
exit 0
SH
  chmod +x "$fakebin/tmux"
  fm_fake_exit0 "$fakebin" treehouse pi-signed
  printf '%s\n' "$fakebin"
}

write_catalog() {
  local home=$1
  mkdir -p "$home/codex-home"
  cat > "$home/codex-home/models_cache.json" <<'JSON'
{
  "client_version": "demo",
  "models": [
    {"slug": "gpt-5",
     "supported_reasoning_levels": [
       {"effort": "low"}, {"effort": "medium"}, {"effort": "high"}, {"effort": "xhigh"}]},
    {"slug": "gpt-5.6-sol",
     "supported_reasoning_levels": [
       {"effort": "low"}, {"effort": "medium"}, {"effort": "high"},
       {"effort": "xhigh"}, {"effort": "max"}, {"effort": "ultra"}]}
  ]
}
JSON
}

scenario() {  # <name> <harness> <id> [fm-spawn args...]
  local name=$1 harness=$2 id=$3 case_dir home proj wt fakebin launchlog out rc
  shift 3
  case_dir="$TMP_ROOT/$name"; home="$case_dir/home"
  proj="$case_dir/project"; wt="$case_dir/wt"
  launchlog="$case_dir/launch.log"
  fakebin=$(make_fakebin "$case_dir/fake")
  mkdir -p "$home/data" "$home/projects" "$home/state" "$home/config" "$home/data/$id"
  write_catalog "$home"
  printf '%s\n' "$harness" > "$home/config/crew-harness"
  fm_git_worktree "$proj" "$wt" "wt-$name" >/dev/null 2>&1
  touch "$home/state/.last-watcher-beat"
  printf 'brief for %s\n' "$id" > "$home/data/$id/brief.md"
  : > "$launchlog"

  echo "================================================================"
  echo "\$ fm-spawn.sh $id <project> $*"
  echo "  (harness=$harness; hermetic CODEX_HOME catalog: gpt-5 tops out at xhigh,"
  echo "   gpt-5.6-sol advertises low..max plus ultra)"
  echo "----------------------------------------------------------------"
  out=$(FM_ROOT_OVERRIDE='' FM_HOME="$home" \
    FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
    FM_PROJECTS_OVERRIDE="$home/projects" FM_CONFIG_OVERRIDE="$home/config" \
    FM_SPAWN_NO_GUARD=1 FM_FAKE_PANE_PATH="$wt" TMUX="fake,1,0" \
    CLAUDE_CONFIG_DIR='' CODEX_HOME="$home/codex-home" \
    FM_FAKE_LAUNCH_LOG="$launchlog" GROK_HOME="$home/grok-home" \
    PATH="$fakebin:$PATH" \
    "$SPAWN" "$id" "$proj" "$@" 2>&1)
  rc=$?
  printf '%s\n' "$out"
  echo "exit code: $rc"
  if [ -s "$launchlog" ]; then
    echo "launch command typed into the pane:"
    sed 's/^/  | /' "$launchlog"
  else
    echo "launch command typed into the pane: (none - nothing was launched)"
  fi
  if [ -f "$home/state/$id.meta" ]; then
    echo "task metadata written ($id.meta):"
    grep -E '^(harness|model|effort)=' "$home/state/$id.meta" | sed 's/^/  | /'
  else
    echo "task metadata written: (none)"
  fi
  echo
}

echo "### fm-spawn effort delivery demo — $($SPAWN --help 2>/dev/null | head -1 || echo bin/fm-spawn.sh) ###"
echo

scenario codex-max-supported codex demo-codex-max \
  --model gpt-5.6-sol --effort max
scenario codex-max-unsupported codex demo-codex-refuse \
  --model gpt-5 --effort max
scenario codex-model-absent codex demo-codex-future \
  --model future-model --effort max
scenario grok-xhigh grok demo-grok-xhigh \
  --model grok-4 --effort xhigh
scenario opencode-effort opencode demo-opencode \
  --model anthropic/claude-sonnet-4-5 --effort high
```
</details>
<details>
<summary>Evidence: Before/after launch command for `--model gpt-5.6-sol --effort max`</summary>

```text
BASE (f5ab708): codex --model 'gpt-5.6-sol' --dangerously-bypass-approvals-and-sandbox ... [effort silently dropped; meta still records effort=max]
TARGET (9f12a3a): codex --model 'gpt-5.6-sol' -c 'model_reasoning_effort="max"' --dangerously-bypass-approvals-and-sandbox ...

TARGET refusal (gpt-5 tops out at xhigh in catalog):
error: refusing codex spawn because requested effort 'max' cannot be delivered: model 'gpt-5' advertises only low, medium, high, xhigh in .../models_cache.json
exit code: 1; no launch typed, no task metadata written
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>⏭️ **intent** - skipped</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 warning</summary>

- ⚠️ `bin/fm-spawn.sh:750` - The invariant this branch enforces for effort (a requested profile axis is delivered to the launch or refused, never silently omitted while meta records it) remains violated for the model axis on raw launch commands. A spawn like `fm-spawn.sh &lt;id&gt; &lt;repo&gt; &#39;codex --dangerously-bypass-approvals-and-sandbox go&#39; --model gpt-5.6-sol` computes MODELFLAG, but the raw command has no __MODELFLAG__ placeholder, so the substitution at line 1762 is a no-op and the launch runs the harness&#39;s default model while state/&lt;id&gt;.meta durably records model=gpt-5.6-sol. The new placeholder guard at line 750 covers only EFFORTFLAG. Consider extending the same guard to a non-empty MODELFLAG (refuse a raw launch that has no __MODELFLAG__ placeholder to receive a requested model), or explicitly documenting the asymmetry. Pre-existing behavior, not introduced by this branch, and outside its stated effort scope — follow-up material.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash tests/fm-spawn-dispatch-profile.test.sh` (30 tests: codex catalog max delivery, catalog refusal, absent-model pass-through, ultra exclusion, grok/opencode/raw-launch refusals) — all pass, exit 0</code>
- <code>`bash tests/fm-kimi-harness.test.sh` (18 tests incl. new kimi effort-refusal) — all pass, exit 0 (verified real exit code, not the tail pipeline&#39;s)</code>
- <code>`bash tests/fm-secondmate-harness.test.sh` (hermetic CODEX_HOME catalog wiring for secondmate spawns) — all pass</code>
- <code>`bash tests/fm-bootstrap.test.sh` (updated crew-dispatch validation: codex:max accepted for spawn-time live validation, grok:max/xhigh still flagged) — all pass, exit 0</code>
- <code>Watch-it-fail: restored base-commit `bin/fm-spawn.sh` via `git checkout f5ab708 -- bin/fm-spawn.sh`, reran dispatch-profile suite — exit 1 with `test_codex_threads_catalog_supported_max_effort` red, launch log showing `model_reasoning_effort` omitted; then restored target version and confirmed clean worktree</code>
- <code>Manual end-to-end demo driving the real `bin/fm-spawn.sh` with a hermetic fake-tmux + pinned CODEX_HOME catalog: gpt-5.6-sol+max delivered, gpt-5+max refused with catalog range and no metadata/launch, catalog-absent model warned and passed through, grok xhigh and opencode high refused — captured for both target and base commits</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
