### PR TITLE
feat(bin): add /watch video evidence capability

### DIFF
--- a/.agents/skills/watch/SKILL.md
+++ b/.agents/skills/watch/SKILL.md
@@ -39,7 +39,7 @@ Do not run an installer, ask for an API key, inspect `~/.config/watch/.env`, use
 The script works transcript-first where public captions are feasible.
 It gathers safe metadata and captions before downloading media, selects transcript windows and ranges from the question when possible, combines scene or slide changes with bounded periodic coverage, and emits a manifest with frame paths, timestamps, reasons, transcript provenance, warnings, token estimates, and cleanup receipt.
 It fetches the captain's public URL exactly as supplied, so providers that encode the video identity in query parameters keep working; do not rewrite, shorten, or strip the URL before passing it.
-Transient media is bounded by a byte ceiling, and a focused run asks the provider for just that section when it can.
+Transient media is bounded by a byte ceiling, and a focused run asks the provider for just that section when that is the cheaper bounded route; a focus range covering most of the source takes the whole media instead, which never narrows the evidence.
 Remote transcription is disabled in v1; if public captions are absent or the local file has no transcript, answer from visual evidence only and say that audio transcript evidence was unavailable.
 
 ## Evidence reading

--- a/.agents/skills/watch/SKILL.md
+++ b/.agents/skills/watch/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: watch
+description: >-
+  Analyze public video URLs or explicitly supplied local video files from bounded evidence.
+  Use when the captain invokes /watch, provides a public video URL with an analysis request, or names a local video file path and asks what is shown or said.
+user-invocable: true
+metadata:
+  internal: true
+---
+
+# watch
+
+Analyze a public video URL or an explicitly supplied local video file with sparse, evidence-grounded sampling.
+This skill is cross-harness: it uses `bin/fm-video-watch.sh` and the ordinary file `Read` tool rather than any Claude-only plugin directory.
+The script's `--help` output owns exact flags, limits, manifest fields, cleanup receipt behavior, and exit codes.
+
+## Intake
+
+1. Identify one source and one analysis request.
+   Accept exactly one public `http` or `https` video URL, or one explicit local video file path supplied by the captain.
+   Do not expand playlists, feeds, channels, search pages, browser tabs, private pages, or inferred local paths.
+2. If the captain names a precise range or moment, pass absolute timestamps with `--start` and `--end`.
+   Use focused mode for questions like "around 2:30", "the first 10 seconds", "the intro", or "zoom into 0:45-1:00".
+3. Use higher resolution only when the question needs readable on-screen text.
+   Prefer the default resolution and frame cap for ordinary summaries or content analysis.
+
+## Preparation workflow
+
+Run:
+
+```sh
+bin/fm-video-watch.sh prepare "<source>" --question "<captain request>"
+```
+
+Add `--start`, `--end`, `--max-frames`, `--resolution`, or `--caption-lang` only when the request justifies them.
+If the script refuses, report the concrete safe outcome: missing local dependency, unsupported public source, rejected playlist or live stream, unsafe local file, no captions, or failed preparation.
+Do not run an installer, ask for an API key, inspect `~/.config/watch/.env`, use browser profiles, attach a browser, pass cookies, or retry with authenticated state.
+
+The script works transcript-first where public captions are feasible.
+It gathers safe metadata and captions before downloading media, selects transcript windows and ranges from the question when possible, combines scene or slide changes with bounded periodic coverage, and emits a manifest with frame paths, timestamps, reasons, transcript provenance, warnings, token estimates, and cleanup receipt.
+Remote transcription is disabled in v1; if public captions are absent or the local file has no transcript, answer from visual evidence only and say that audio transcript evidence was unavailable.
+
+## Evidence reading
+
+1. Read the manifest JSON from stdout as the source of truth.
+   Treat `warnings`, `selected_ranges`, `frames[].reason`, and `token_budget` as mandatory context for the answer.
+2. Read only the listed frame paths, preferably in batches of 10-20 frames.
+   Do not read media files, audio files, raw downloads, or unrelated paths.
+3. Use the transcript segments embedded in the manifest as audio evidence.
+   Do not claim unsupported transcript coverage, language, or speaker identity.
+4. Cite timestamps for important claims.
+   Be explicit that visual analysis is based on sampled frames and selected transcript windows, not every frame, unless the requested focused range and frame count genuinely make that level of coverage evident.
+5. If the evidence is too sparse for the question, recommend one focused re-run with concrete `--start` and `--end` values instead of guessing.
+
+## Cleanup
+
+After answering, run:
+
+```sh
+bin/fm-video-watch.sh cleanup "<cleanup_receipt>"
+```
+
+Use exactly the opaque receipt from the manifest.
+Do not delete paths by hand.
+If the captain is likely to ask an immediate follow-up that needs the same frames, keep the receipt in visible context and clean up after the follow-up.
+
+## Attribution
+
+Firstmate's implementation preserves and adapts useful MIT-licensed mechanics from `bradautomates/claude-video`, installed locally at git revision `755c157466738dda102c939158a0116b972925a3`.
+It is not a copy of the Claude-only plugin packaging and has no runtime dependency on `~/.claude/skills/watch`.

--- a/.agents/skills/watch/SKILL.md
+++ b/.agents/skills/watch/SKILL.md
@@ -12,7 +12,7 @@ metadata:
 
 Analyze a public video URL or an explicitly supplied local video file with sparse, evidence-grounded sampling.
 This skill is cross-harness: it uses `bin/fm-video-watch.sh` and the ordinary file `Read` tool rather than any Claude-only plugin directory.
-The script's `--help` output owns exact flags, limits, manifest fields, cleanup receipt behavior, and exit codes.
+`bin/fm-video-watch.sh --help` owns the exact subcommands, flags, defaults, and limits, that script's header comment owns the media, coverage, cleanup receipt, and exit-code contract, and the emitted manifest carries its own field set.
 
 ## Intake
 

--- a/.agents/skills/watch/SKILL.md
+++ b/.agents/skills/watch/SKILL.md
@@ -32,18 +32,22 @@ Run:
 bin/fm-video-watch.sh prepare "<source>" --question "<captain request>"
 ```
 
-Add `--start`, `--end`, `--max-frames`, `--resolution`, or `--caption-lang` only when the request justifies them.
+Add `--start`, `--end`, `--max-frames`, `--resolution`, `--caption-lang`, or `--max-media-bytes` only when the request justifies them.
 If the script refuses, report the concrete safe outcome: missing local dependency, unsupported public source, rejected playlist or live stream, unsafe local file, no captions, or failed preparation.
 Do not run an installer, ask for an API key, inspect `~/.config/watch/.env`, use browser profiles, attach a browser, pass cookies, or retry with authenticated state.
 
 The script works transcript-first where public captions are feasible.
 It gathers safe metadata and captions before downloading media, selects transcript windows and ranges from the question when possible, combines scene or slide changes with bounded periodic coverage, and emits a manifest with frame paths, timestamps, reasons, transcript provenance, warnings, token estimates, and cleanup receipt.
+It fetches the captain's public URL exactly as supplied, so providers that encode the video identity in query parameters keep working; do not rewrite, shorten, or strip the URL before passing it.
+Transient media is bounded by a byte ceiling, and a focused run asks the provider for just that section when it can.
 Remote transcription is disabled in v1; if public captions are absent or the local file has no transcript, answer from visual evidence only and say that audio transcript evidence was unavailable.
 
 ## Evidence reading
 
 1. Read the manifest JSON from stdout as the source of truth.
-   Treat `warnings`, `selected_ranges`, `frames[].reason`, and `token_budget` as mandatory context for the answer.
+   Treat `warnings`, `selected_ranges`, `media`, `frames[].reason`, and `token_budget` as mandatory context for the answer.
+   `media.visual_coverage` is binding: `full` means frames were sampled across the whole selection, `section` means only `media.acquired_range` was acquired, and `none` means there is no visual evidence at all.
+   When it is `section` or `none`, say so plainly and pass on `media.focused_pass_recommendation` instead of implying the whole video was seen.
 2. Read only the listed frame paths, preferably in batches of 10-20 frames.
    Do not read media files, audio files, raw downloads, or unrelated paths.
 3. Use the transcript segments embedded in the manifest as audio evidence.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -229,6 +229,7 @@ Firstmate never writes a project's `AGENTS.md` directly.
 A crewmate creates or updates it lazily through the project's selected delivery path, using `bin/fm-ensure-agents-md.sh` and preferring pointers to authoritative sources over copied detail.
 Keep fleet delivery posture and captain-private strategy out of project memory.
 When the captain invokes `/stow`, load the `stow` skill for the complete knowledge-routing and unfinished-work sweep.
+When the captain invokes `/watch`, supplies a public video URL with an analysis request, or explicitly names a local video file to analyze, load the `watch` skill.
 
 ## 7. Task lifecycle
 

--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ Claude and grok use the slash form shown here; codex uses the same names with `$
 | `/bearings`        | Generate a concise four-section chat digest from bounded local fleet and registered-secondmate state; use `/bearings file` to also replace today's dated report in `data/`, and add `include PRs` when live PR enrichment is wanted |
 | `/updatefirstmate` | Self-update the running firstmate and its secondmates to the latest from origin with fast-forward-only pulls, then re-read instructions and nudge secondmates |
 | `/stow`            | Sweep the session for uncaptured durable knowledge, route each finding to its disk home per AGENTS.md, file undone next steps to the backlog, and report what is now safe to reset |
+| `/watch`           | Analyze one public video URL or one explicitly supplied local video file from a bounded, sanitized evidence manifest of transcript windows and sampled frames, then clean the transient evidence up by exact receipt |
 
 Bearings invocation examples:
 

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -900,6 +900,9 @@ families_for_changed_path() {
     bin/fm-bearings-snapshot.sh|bin/fm-fleet-snapshot.sh|bin/fm-fleet-view.sh)
       printf '%s\n' snapshot-bearings
       ;;
+    bin/fm-video-watch*)
+      printf '%s\n' __script__:fm-video-watch.test.sh
+      ;;
     bin/fm-install-herdr.sh|bin/fm-install-treehouse.sh|bin/fm-herdr-ci-cleanup.sh)
       printf '%s\n' pure-contract-unit
       # Pin or cleanup changes also select the real-Herdr family so the required

--- a/bin/fm-video-watch-impl.py
+++ b/bin/fm-video-watch-impl.py
@@ -41,6 +41,8 @@ FREE_SPACE_MARGIN_BYTES = 512 * 1024 * 1024
 MAX_TRANSCRIPT_CHARS = 16_000
 MAX_COMMAND_SECONDS = 180
 SCENE_THRESHOLD = 0.28
+SCENE_TIMEOUT_FLOOR = 300
+SCENE_TIMEOUT_CEILING = 900
 SECRET_QUERY_KEYS = {
     "access_token",
     "api_key",
@@ -845,6 +847,14 @@ def confirm_section_media(media: Media, probed_duration: float, warnings: list[s
     return media
 
 
+def scene_timestamp_timeout(span: float) -> int:
+    return int(min(SCENE_TIMEOUT_CEILING, max(SCENE_TIMEOUT_FLOOR, span + 120)))
+
+
+def scene_timeout(selected: Range) -> int:
+    return scene_timestamp_timeout(max(0.0, selected.end - selected.start))
+
+
 def scene_timestamps(video: Path, ranges: list[Range], offset: float = 0.0) -> tuple[list[float], list[str]]:
     warnings: list[str] = []
     timestamps: list[float] = []
@@ -867,7 +877,11 @@ def scene_timestamps(video: Path, ranges: list[Range], offset: float = 0.0) -> t
             "null",
             "-",
         ]
-        result = run_quiet(cmd, timeout=300)
+        try:
+            result = run_quiet(cmd, timeout=scene_timeout(selected))
+        except WatchError:
+            warnings.append("scene-change detection did not finish for at least one selected range; periodic coverage was still used")
+            continue
         if result.returncode != 0:
             warnings.append("scene-change detection failed for at least one selected range; periodic coverage was still used")
             continue

--- a/bin/fm-video-watch-impl.py
+++ b/bin/fm-video-watch-impl.py
@@ -515,7 +515,7 @@ def choose_caption(metadata: dict[str, Any], requested: str | None) -> tuple[str
     return None, None, None
 
 
-def retrieve_captions(url: str, work: Path, lang: str) -> Path | None:
+def retrieve_captions(url: str, work: Path, lang: str, warnings: list[str]) -> Path | None:
     out_dir = work / "captions"
     out_dir.mkdir(parents=True, exist_ok=True)
     template = str(out_dir / "caption.%(ext)s")
@@ -536,9 +536,15 @@ def retrieve_captions(url: str, work: Path, lang: str) -> Path | None:
         template,
         url,
     ]
-    result = run_quiet(cmd)
+    try:
+        returncode = run_quiet(cmd).returncode
+    except WatchError:
+        returncode = 1
+        warnings.append(
+            "caption retrieval did not finish; the run continued without caption evidence"
+        )
     candidates = sorted(out_dir.glob("*.vtt"))
-    if result.returncode != 0 and not candidates:
+    if returncode != 0 and not candidates:
         return None
     return candidates[0] if candidates else None
 
@@ -711,6 +717,16 @@ def resolve_media_ceiling(requested: int | None, work: Path, warnings: list[str]
     if ceiling <= 0:
         raise WatchError("no usable local free space remains for transient media", 5)
     return ceiling
+
+
+def require_free_space(work: Path, needed_bytes: int) -> None:
+    usable = max(0, shutil.disk_usage(work).free - FREE_SPACE_MARGIN_BYTES)
+    if needed_bytes > usable:
+        raise WatchError(
+            "no usable local free space remains for the transient copy of this video; "
+            f"{needed_bytes} bytes are needed and only {usable} usable bytes are available",
+            5,
+        )
 
 
 def declared_media_bytes(metadata: dict[str, Any]) -> int | None:
@@ -1110,7 +1126,7 @@ def build_manifest(args: argparse.Namespace, smoke_mode: bool = False) -> dict[s
             metadata = load_ytdlp_metadata(fetch_source)
             transcript_language, caption_kind, caption_lang = choose_caption(metadata, args.caption_lang)
             if caption_lang:
-                caption_path = retrieve_captions(fetch_source, work, caption_lang)
+                caption_path = retrieve_captions(fetch_source, work, caption_lang, warnings)
                 if caption_path:
                     transcript_segments = parse_vtt(caption_path)
                     transcript_provenance = f"captions:{caption_kind}"
@@ -1131,6 +1147,7 @@ def build_manifest(args: argparse.Namespace, smoke_mode: bool = False) -> dict[s
             media.acquisition_reason = acquisition_reason
         else:
             local_path = validate_local(fetch_source, args.max_local_bytes)
+            require_free_space(work, local_path.stat().st_size)
             media_dir = work / "media"
             media_dir.mkdir(parents=True, exist_ok=True)
             local_copy = media_dir / f"local{local_path.suffix.lower()}"
@@ -1149,12 +1166,19 @@ def build_manifest(args: argparse.Namespace, smoke_mode: bool = False) -> dict[s
             media = confirm_section_media(media, float(probed["duration_seconds"]), warnings)
         else:
             probed = {}
-        duration = safe_float(metadata.get("duration"), 0.0) or float(probed.get("duration_seconds", 0.0))
+        probed_duration = float(probed.get("duration_seconds", 0.0))
+        duration = safe_float(metadata.get("duration"), 0.0)
+        if duration <= 0 and probed_duration > 0:
+            duration = media.offset_seconds + probed_duration if media.coverage == "section" else probed_duration
+            if media.coverage == "section":
+                warnings.append(
+                    "the source advertised no duration, so the reported duration is a lower bound "
+                    "derived from the bounded section that was acquired"
+                )
         if duration <= 0:
             raise WatchError("video duration could not be determined", 5)
         chapters = normalize_chapters(metadata.get("chapters"), duration)
         ranges = select_ranges(duration, transcript_segments, chapters, args.question, start, end)
-        max_frames, resolution = clamp_requested_limits(args, ranges[0].reason == "focused_range", warnings)
         selected_transcript, transcript_truncated = transcript_excerpt(transcript_segments, ranges)
         if transcript_truncated:
             warnings.append("transcript evidence was truncated to the bounded manifest budget")
@@ -1172,7 +1196,7 @@ def build_manifest(args: argparse.Namespace, smoke_mode: bool = False) -> dict[s
                 plan,
                 resolution,
                 media.offset_seconds,
-                tail_seek_limit(float(probed["duration_seconds"]), float(probed.get("frame_rate") or 0.0)),
+                tail_seek_limit(probed_duration, float(probed.get("frame_rate") or 0.0)),
             )
         else:
             recommendation = focused_pass_recommendation(ranges, duration)
@@ -1324,6 +1348,9 @@ def main(argv: list[str] | None = None) -> int:
     except WatchError as exc:
         eprint(f"fm-video-watch: {exc}")
         return exc.code
+    except Exception as exc:
+        eprint(f"fm-video-watch: unexpected {type(exc).__name__} while preparing video evidence")
+        return 5
 
 
 if __name__ == "__main__":

--- a/bin/fm-video-watch-impl.py
+++ b/bin/fm-video-watch-impl.py
@@ -43,6 +43,9 @@ MAX_COMMAND_SECONDS = 180
 SCENE_THRESHOLD = 0.28
 SCENE_TIMEOUT_FLOOR = 300
 SCENE_TIMEOUT_CEILING = 900
+MEDIA_FORMAT_SELECTOR = "bv*[height<=720]+ba/b[height<=720]/bv+ba/b"
+SECTION_REENCODE_BYTE_OVERHEAD = 1.7
+SECTION_MIN_SAVING = 0.75
 SECRET_QUERY_KEYS = {
     "access_token",
     "api_key",
@@ -375,15 +378,16 @@ def cmd_doctor(_args: argparse.Namespace) -> int:
 
 
 def load_ytdlp_metadata(url: str) -> dict[str, Any]:
-    cmd = [
+    base = [
         "yt-dlp",
         "--dump-single-json",
         "--skip-download",
         "--no-playlist",
         "--no-warnings",
-        url,
     ]
-    result = run_quiet(cmd)
+    result = run_quiet(base + ["-f", MEDIA_FORMAT_SELECTOR, url])
+    if result.returncode != 0:
+        result = run_quiet(base + [url])
     if result.returncode != 0:
         raise WatchError("public video metadata was unavailable without login or was unsupported", 4)
     try:
@@ -680,6 +684,7 @@ class Media:
     section: tuple[float, float] | None = None
     offset_seconds: float = 0.0
     refusal: str | None = None
+    acquisition_reason: str = "no_focus_range_requested"
 
 
 def resolve_media_ceiling(requested: int | None, work: Path, warnings: list[str]) -> int:
@@ -716,6 +721,36 @@ def declared_media_bytes(metadata: dict[str, Any]) -> int | None:
     return None
 
 
+def projected_section_share(span: float, duration: float) -> float | None:
+    """Fraction of the full download a forced-keyframe section is projected to cost.
+
+    A bounded section is re-encoded rather than stream-copied, so it costs more
+    than its share of the timeline. The overhead constant is the measured ratio
+    from the acceptance record in docs/verification/video-watch.md.
+    """
+    if duration <= 0:
+        return None
+    return min(1.0, max(0.0, span) / duration) * SECTION_REENCODE_BYTE_OVERHEAD
+
+
+def choose_acquisition(
+    section: tuple[float, float] | None,
+    duration: float,
+    declared: int | None,
+    ceiling: int,
+) -> tuple[tuple[float, float] | None, str]:
+    if section is None:
+        return None, "no_focus_range_requested"
+    if declared is not None and declared > ceiling:
+        return section, "a_bounded_section_is_the_only_route_under_the_transient_byte_ceiling"
+    share = projected_section_share(section[1] - section[0], duration)
+    if share is None:
+        return section, "source_duration_unknown_so_the_focus_range_bounds_acquisition"
+    if share <= SECTION_MIN_SAVING:
+        return section, "a_bounded_section_is_projected_cheaper_than_the_full_media"
+    return None, "the_full_media_is_projected_cheaper_than_a_re_encoded_section"
+
+
 def purge_media(out_dir: Path) -> None:
     if out_dir.exists():
         shutil.rmtree(out_dir, ignore_errors=True)
@@ -728,7 +763,7 @@ def run_ytdlp_download(
     cmd = [
         "yt-dlp",
         "-f",
-        "bv*[height<=720]+ba/b[height<=720]/bv+ba/b",
+        MEDIA_FORMAT_SELECTOR,
         "--merge-output-format",
         "mp4",
         "--no-playlist",
@@ -1083,14 +1118,17 @@ def build_manifest(args: argparse.Namespace, smoke_mode: bool = False) -> dict[s
                     warnings.append("caption metadata existed but caption retrieval produced no VTT file")
             else:
                 warnings.append("no compatible public captions were advertised; remote transcription is disabled in v1")
-            media = acquire_media(
-                fetch_source,
-                work,
-                ceiling,
-                declared_media_bytes(metadata),
-                requested_section(start, end, safe_float(metadata.get("duration"), 0.0)),
-                warnings,
-            )
+            meta_duration = safe_float(metadata.get("duration"), 0.0)
+            declared = declared_media_bytes(metadata)
+            wanted = requested_section(start, end, meta_duration)
+            section, acquisition_reason = choose_acquisition(wanted, meta_duration, declared, ceiling)
+            if wanted is not None and section is None:
+                warnings.append(
+                    "the requested focus range covers enough of the source that downloading the whole media "
+                    "is cheaper than a re-encoded provider section; the selected evidence range is unchanged"
+                )
+            media = acquire_media(fetch_source, work, ceiling, declared, section, warnings)
+            media.acquisition_reason = acquisition_reason
         else:
             local_path = validate_local(fetch_source, args.max_local_bytes)
             media_dir = work / "media"
@@ -1176,6 +1214,7 @@ def build_manifest(args: argparse.Namespace, smoke_mode: bool = False) -> dict[s
                 "byte_ceiling": media.byte_ceiling,
                 "declared_bytes": media.declared_bytes,
                 "downloaded_bytes": media.downloaded_bytes,
+                "acquisition_reason": media.acquisition_reason,
                 "acquired_range": (
                     {"start_seconds": round(media.section[0], 2), "end_seconds": round(media.section[1], 2)}
                     if media.coverage == "section" and media.section is not None
@@ -1254,8 +1293,9 @@ def parser() -> argparse.ArgumentParser:
             "URL is fetched exactly as given; only the manifest description redacts query values, and "
             "credential, signature, session, or token query fields are refused outright. Public media "
             "is bounded by a transient byte ceiling both before download and after acquisition, focused "
-            "runs request a bounded section when the provider supports one, and media.visual_coverage "
-            "reports whether the evidence is full, section-only, or absent. Missing dependencies "
+            "runs take whichever bounded route is projected cheaper because a provider section is "
+            "re-encoded rather than stream-copied, and media.visual_coverage plus media.acquisition_reason "
+            "report whether the evidence is full, section-only, or absent and why. Missing dependencies "
             "are reported; no installer is run. Remote transcription is disabled in v1."
         ),
     )

--- a/bin/fm-video-watch-impl.py
+++ b/bin/fm-video-watch-impl.py
@@ -20,7 +20,7 @@ import uuid
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
-from urllib.parse import parse_qs, urlencode, urlsplit, urlunsplit
+from urllib.parse import parse_qs, quote, urlsplit, urlunsplit
 
 SCHEMA = "fm.video-watch.manifest.v1"
 OWNED_MARKER = ".fm-video-watch-owned.json"
@@ -35,9 +35,71 @@ DEFAULT_RESOLUTION = 512
 MAX_FULL_RESOLUTION = 768
 MAX_FOCUS_RESOLUTION = 1280
 DEFAULT_MAX_LOCAL_BYTES = 2 * 1024 * 1024 * 1024
+DEFAULT_MAX_MEDIA_BYTES = 4 * 1024 * 1024 * 1024
+HARD_MAX_MEDIA_BYTES = 16 * 1024 * 1024 * 1024
+FREE_SPACE_MARGIN_BYTES = 512 * 1024 * 1024
 MAX_TRANSCRIPT_CHARS = 16_000
 MAX_COMMAND_SECONDS = 180
 SCENE_THRESHOLD = 0.28
+SECRET_QUERY_KEYS = {
+    "access_token",
+    "api_key",
+    "apikey",
+    "auth",
+    "authorization",
+    "client_secret",
+    "credential",
+    "hmac",
+    "key-pair-id",
+    "password",
+    "passwd",
+    "policy",
+    "pwd",
+    "secret",
+    "session",
+    "session_id",
+    "sessionid",
+    "sig",
+    "sign",
+    "signature",
+    "token",
+}
+SECRET_QUERY_PREFIXES = ("x-amz-", "__hdn", "__token")
+TRACKING_QUERY_KEYS = {
+    "ab_channel",
+    "embeds_referring_euri",
+    "embeds_referring_origin",
+    "fbclid",
+    "feature",
+    "gclid",
+    "msclkid",
+    "ncid",
+    "pp",
+    "ref",
+    "ref_src",
+    "referrer",
+    "si",
+    "source_ve_path",
+    "spm",
+    "utm_campaign",
+    "utm_content",
+    "utm_id",
+    "utm_medium",
+    "utm_source",
+    "utm_term",
+}
+IDENTITY_QUERY_KEYS = {
+    "clip",
+    "clip_id",
+    "id",
+    "media_id",
+    "v",
+    "vid",
+    "video",
+    "video_id",
+    "videoid",
+}
+REDACTED_VALUE = "redacted"
 
 
 class WatchError(Exception):
@@ -134,6 +196,39 @@ def is_public_url(source: str) -> bool:
     return urlsplit(source).scheme.lower() in {"http", "https"}
 
 
+def is_secret_query_key(key: str) -> bool:
+    lowered = key.lower()
+    return lowered in SECRET_QUERY_KEYS or lowered.startswith(SECRET_QUERY_PREFIXES)
+
+
+def describe_url(raw: str) -> dict[str, Any]:
+    """Build the display-only identity for a URL that already passed the source policy.
+
+    The fetch target stays byte-for-byte the supplied URL; only this description is
+    reduced, and it never reproduces a query value that is not a known public
+    resource identifier.
+    """
+    split = urlsplit(raw)
+    query = parse_qs(split.query, keep_blank_values=True)
+    display_pairs: list[tuple[str, str]] = []
+    for key, values in query.items():
+        lowered = key.lower()
+        if lowered in TRACKING_QUERY_KEYS:
+            continue
+        value = values[0] if values else ""
+        display_pairs.append((key, value if lowered in IDENTITY_QUERY_KEYS else REDACTED_VALUE))
+    display_query = "&".join(f"{quote(k, safe='')}={quote(v, safe='')}" for k, v in display_pairs)
+    host = (split.hostname or "").lower()
+    sanitized = urlunsplit((split.scheme.lower(), split.netloc.lower(), split.path, display_query, ""))
+    return {
+        "kind": "public_url",
+        "sanitized": sanitized,
+        "host": host,
+        "path": split.path or "/",
+        "query_keys": sorted({key for key, _ in display_pairs}),
+    }
+
+
 def sanitize_url(raw: str) -> tuple[str, dict[str, Any]]:
     split = urlsplit(raw)
     scheme = split.scheme.lower()
@@ -143,21 +238,16 @@ def sanitize_url(raw: str) -> tuple[str, dict[str, Any]]:
         raise WatchError("URL userinfo is not accepted", 4)
     if not split.netloc:
         raise WatchError("URL host is required", 4)
-    query = parse_qs(split.query, keep_blank_values=False)
+    query = parse_qs(split.query, keep_blank_values=True)
     if "list" in query or "playlist" in query:
         raise WatchError("playlist URLs are rejected; provide exactly one public video URL", 4)
-    safe_query: dict[str, list[str]] = {}
-    host = split.hostname or ""
-    if host.endswith("youtube.com") and split.path == "/watch" and query.get("v"):
-        safe_query["v"] = [query["v"][0]]
-    sanitized = urlunsplit((scheme, split.netloc.lower(), split.path, urlencode(safe_query, doseq=True), ""))
-    identity = {
-        "kind": "public_url",
-        "sanitized": sanitized,
-        "host": host.lower(),
-        "path": split.path or "/",
-    }
-    return sanitized, identity
+    if any(is_secret_query_key(key) for key in query):
+        raise WatchError(
+            "URL carries credential, signature, session, or token query fields; "
+            "supply the plain public video URL instead of a signed or authenticated one",
+            4,
+        )
+    return raw, describe_url(raw)
 
 
 def reject_unsafe_source(source: str) -> tuple[str, dict[str, Any], bool]:
@@ -165,8 +255,8 @@ def reject_unsafe_source(source: str) -> tuple[str, dict[str, Any], bool]:
     if split.scheme and split.scheme.lower() not in {"http", "https"}:
         raise WatchError("unsupported source scheme; use a public http(s) URL or an explicit local file path", 4)
     if is_public_url(source):
-        sanitized, identity = sanitize_url(source)
-        return sanitized, identity, True
+        fetch_url, identity = sanitize_url(source)
+        return fetch_url, identity, True
     return source, {"kind": "local_file", "sanitized": Path(source).name}, False
 
 
@@ -343,6 +433,29 @@ def safe_float(value: Any, default: float = 0.0) -> float:
         return default
 
 
+def parse_frame_rate(stream: dict[str, Any]) -> float:
+    for key in ("avg_frame_rate", "r_frame_rate"):
+        raw = str(stream.get(key) or "")
+        if "/" not in raw:
+            continue
+        num, _, den = raw.partition("/")
+        numerator = safe_float(num, 0.0)
+        denominator = safe_float(den, 0.0)
+        if numerator > 0 and denominator > 0:
+            return numerator / denominator
+    return 0.0
+
+
+def tail_seek_limit(duration: float, frame_rate: float) -> float:
+    """Last timestamp that ffmpeg can still decode a frame at.
+
+    Seeking at or past the final frame's presentation time makes ffmpeg exit
+    non-zero without writing a file, so keep one safe frame of slack.
+    """
+    frame_gap = 1.0 / frame_rate if frame_rate > 0 else 0.5
+    return max(0.0, duration - max(2 * frame_gap, 0.5))
+
+
 def probe_video(path: Path) -> dict[str, Any]:
     result = run_quiet([
         "ffprobe",
@@ -370,6 +483,7 @@ def probe_video(path: Path) -> dict[str, Any]:
         raise WatchError("video duration could not be determined", 5)
     return {
         "duration_seconds": duration,
+        "frame_rate": parse_frame_rate(video_stream),
         "width": video_stream.get("width"),
         "height": video_stream.get("height"),
         "codec": video_stream.get("codec_name"),
@@ -554,10 +668,61 @@ def transcript_excerpt(segments: list[Segment], ranges: list[Range]) -> tuple[li
     return selected, truncated
 
 
-def download_video(url: str, work: Path) -> Path:
-    out_dir = work / "media"
+@dataclass
+class Media:
+    path: Path | None
+    coverage: str
+    byte_ceiling: int
+    declared_bytes: int | None = None
+    downloaded_bytes: int | None = None
+    section: tuple[float, float] | None = None
+    offset_seconds: float = 0.0
+    refusal: str | None = None
+
+
+def resolve_media_ceiling(requested: int | None, work: Path, warnings: list[str]) -> int:
+    ceiling = DEFAULT_MAX_MEDIA_BYTES if requested is None else requested
+    if ceiling <= 0:
+        raise WatchError("--max-media-bytes must be positive", 2)
+    if ceiling > HARD_MAX_MEDIA_BYTES:
+        raise WatchError(
+            f"--max-media-bytes cannot exceed the {HARD_MAX_MEDIA_BYTES} byte hard cap for transient public media",
+            2,
+        )
+    usable = max(0, shutil.disk_usage(work).free - FREE_SPACE_MARGIN_BYTES)
+    if ceiling > DEFAULT_MAX_MEDIA_BYTES and ceiling > usable:
+        raise WatchError(
+            "a transient media ceiling above the 4 GiB default requires proven local free space; "
+            f"only {usable} usable bytes are available",
+            2,
+        )
+    if ceiling > usable:
+        warnings.append(
+            f"transient media ceiling reduced to {usable} bytes because local free space is the binding limit"
+        )
+        ceiling = usable
+    if ceiling <= 0:
+        raise WatchError("no usable local free space remains for transient media", 5)
+    return ceiling
+
+
+def declared_media_bytes(metadata: dict[str, Any]) -> int | None:
+    for key in ("filesize", "filesize_approx"):
+        value = safe_float(metadata.get(key), 0.0)
+        if value > 0:
+            return int(value)
+    return None
+
+
+def purge_media(out_dir: Path) -> None:
+    if out_dir.exists():
+        shutil.rmtree(out_dir, ignore_errors=True)
+
+
+def run_ytdlp_download(
+    url: str, out_dir: Path, max_bytes: int, section: tuple[float, float] | None
+) -> tuple[Path | None, bool, int]:
     out_dir.mkdir(parents=True, exist_ok=True)
-    template = str(out_dir / "video.%(ext)s")
     cmd = [
         "yt-dlp",
         "-f",
@@ -566,20 +731,121 @@ def download_video(url: str, work: Path) -> Path:
         "mp4",
         "--no-playlist",
         "--no-warnings",
-        "-o",
-        template,
-        url,
+        "--max-filesize",
+        str(max_bytes),
     ]
+    if section is not None:
+        cmd += [
+            "--download-sections",
+            f"*{section[0]:.3f}-{section[1]:.3f}",
+            "--force-keyframes-at-cuts",
+        ]
+    cmd += ["-o", str(out_dir / "video.%(ext)s"), url]
     result = run_quiet(cmd, timeout=600)
     videos = sorted([p for p in out_dir.glob("video.*") if p.suffix.lower() in VIDEO_EXTS])
-    if result.returncode != 0 and not videos:
-        raise WatchError("public video download failed without safe public access", 4)
-    if not videos:
+    hit_ceiling = "max-filesize" in (result.stderr or "").lower() or "max-filesize" in (result.stdout or "").lower()
+    return (videos[0] if videos else None), hit_ceiling, result.returncode
+
+
+def acquire_media(
+    url: str,
+    work: Path,
+    ceiling: int,
+    declared: int | None,
+    section: tuple[float, float] | None,
+    warnings: list[str],
+) -> Media:
+    out_dir = work / "media"
+    if section is not None:
+        path, hit_ceiling, _ = run_ytdlp_download(url, out_dir, ceiling, section)
+        if path is not None:
+            return bound_downloaded_media(
+                Media(path, "section", ceiling, declared, section=section, offset_seconds=section[0]),
+                out_dir,
+                warnings,
+            )
+        purge_media(out_dir)
+        if hit_ceiling:
+            return Media(
+                None,
+                "none",
+                ceiling,
+                declared,
+                refusal=(
+                    "the provider could not deliver a bounded section and the full media exceeds the "
+                    "transient byte ceiling, so no video was downloaded"
+                ),
+            )
+        warnings.append(
+            "the provider could not deliver a bounded section download; a full media pass was attempted "
+            "within the transient byte ceiling"
+        )
+    if declared is not None and declared > ceiling:
+        purge_media(out_dir)
+        return Media(
+            None,
+            "none",
+            ceiling,
+            declared,
+            refusal="the declared public media size exceeds the transient byte ceiling, so no video was downloaded",
+        )
+    path, hit_ceiling, returncode = run_ytdlp_download(url, out_dir, ceiling, None)
+    if path is None:
+        purge_media(out_dir)
+        if hit_ceiling:
+            return Media(
+                None,
+                "none",
+                ceiling,
+                declared,
+                refusal="the public media size exceeds the transient byte ceiling, so no video was downloaded",
+            )
+        if returncode != 0:
+            raise WatchError("public video download failed without safe public access", 4)
         raise WatchError("public video download produced no video file", 5)
-    return videos[0]
+    return bound_downloaded_media(Media(path, "full", ceiling, declared), out_dir, warnings)
 
 
-def scene_timestamps(video: Path, ranges: list[Range]) -> tuple[list[float], list[str]]:
+def bound_downloaded_media(media: Media, out_dir: Path, warnings: list[str]) -> Media:
+    if media.path is None:
+        return media
+    downloaded = media.path.stat().st_size
+    if downloaded <= 0:
+        purge_media(out_dir)
+        raise WatchError("public video download produced no usable media", 5)
+    if downloaded > media.byte_ceiling:
+        purge_media(out_dir)
+        warnings.append(
+            "the acquired public media exceeded the transient byte ceiling and its partial artifacts were removed"
+        )
+        return Media(
+            None,
+            "none",
+            media.byte_ceiling,
+            media.declared_bytes,
+            refusal="the acquired public media exceeded the transient byte ceiling, so no video evidence was kept",
+        )
+    media.downloaded_bytes = downloaded
+    return media
+
+
+def confirm_section_media(media: Media, probed_duration: float, warnings: list[str]) -> Media:
+    if media.coverage != "section" or media.section is None:
+        return media
+    span = media.section[1] - media.section[0]
+    if probed_duration <= span + max(5.0, 0.25 * span):
+        return media
+    warnings.append(
+        "the provider ignored the bounded section request and returned full media; "
+        "frame timestamps remain absolute"
+    )
+    media.coverage = "full"
+    media.section = None
+    media.offset_seconds = 0.0
+    return media
+
+
+def scene_timestamps(video: Path, ranges: list[Range], offset: float = 0.0) -> tuple[list[float], list[str]]:
     warnings: list[str] = []
     timestamps: list[float] = []
     for selected in ranges:
@@ -589,9 +855,9 @@ def scene_timestamps(video: Path, ranges: list[Range]) -> tuple[list[float], lis
             "-loglevel",
             "info",
             "-ss",
-            f"{selected.start:.3f}",
+            f"{max(0.0, selected.start - offset):.3f}",
             "-to",
-            f"{selected.end:.3f}",
+            f"{max(0.0, selected.end - offset):.3f}",
             "-i",
             str(video),
             "-vf",
@@ -691,18 +957,33 @@ def extract_frame(video: Path, out_path: Path, timestamp: float, resolution: int
         raise WatchError("frame extraction failed", 5)
 
 
-def extract_frames(video: Path, work: Path, plan: list[dict[str, Any]], resolution: int) -> list[dict[str, Any]]:
+def extract_frames(
+    video: Path,
+    work: Path,
+    plan: list[dict[str, Any]],
+    resolution: int,
+    offset: float = 0.0,
+    last_decodable: float | None = None,
+) -> list[dict[str, Any]]:
     frames: list[dict[str, Any]] = []
     frame_dir = work / "frames"
     frame_dir.mkdir(parents=True, exist_ok=True)
-    for idx, item in enumerate(plan, start=1):
-        out_path = frame_dir / f"frame_{idx:04d}.jpg"
+    seen: set[float] = set()
+    for item in plan:
         timestamp = float(item["timestamp_seconds"])
-        extract_frame(video, out_path, timestamp, resolution)
+        if last_decodable is not None:
+            timestamp = min(timestamp, offset + last_decodable)
+        timestamp = round(max(offset, timestamp), 2)
+        if timestamp in seen:
+            continue
+        seen.add(timestamp)
+        idx = len(frames) + 1
+        out_path = frame_dir / f"frame_{idx:04d}.jpg"
+        extract_frame(video, out_path, max(0.0, timestamp - offset), resolution)
         frames.append({
             "index": idx,
             "path": str(out_path),
-            "timestamp_seconds": round(timestamp, 2),
+            "timestamp_seconds": timestamp,
             "timestamp": fmt_time(timestamp),
             "reason": item["reason"],
         })
@@ -734,8 +1015,30 @@ def source_title(metadata: dict[str, Any], local_path: Path | None) -> str | Non
     return str(title)[:200] if title else None
 
 
+def requested_section(
+    start: float | None, end: float | None, duration: float
+) -> tuple[float, float] | None:
+    if start is None and end is None:
+        return None
+    lo = start if start is not None else 0.0
+    hi = end if end is not None else (duration if duration > 0 else None)
+    if hi is None or hi <= lo:
+        return None
+    return (lo, hi)
+
+
+def focused_pass_recommendation(ranges: list[Range], duration: float) -> str:
+    anchor = ranges[0] if ranges else Range(0.0, duration, "full_video")
+    lo = anchor.start
+    hi = min(duration, lo + 300.0) if duration > 0 else lo + 300.0
+    return (
+        "no visual frames were acquired within the transient media ceiling; re-run one focused pass with "
+        f"--start {fmt_time(lo)} --end {fmt_time(hi)}, or raise --max-media-bytes if the local disk allows it"
+    )
+
+
 def build_manifest(args: argparse.Namespace, smoke_mode: bool = False) -> dict[str, Any]:
-    source_for_validation, source_identity, url_mode = reject_unsafe_source(args.source)
+    fetch_source, source_identity, url_mode = reject_unsafe_source(args.source)
     require_deps(url_mode)
     warnings: list[str] = []
     start = parse_time(args.start)
@@ -750,14 +1053,15 @@ def build_manifest(args: argparse.Namespace, smoke_mode: bool = False) -> dict[s
     transcript_segments: list[Segment] = []
     transcript_language: str | None = None
     transcript_provenance = "none"
-    video_path: Path | None = None
     local_path: Path | None = None
+    media = Media(None, "none", 0)
     try:
         if url_mode:
-            metadata = load_ytdlp_metadata(source_for_validation)
+            ceiling = resolve_media_ceiling(args.max_media_bytes, work, warnings)
+            metadata = load_ytdlp_metadata(fetch_source)
             transcript_language, caption_kind, caption_lang = choose_caption(metadata, args.caption_lang)
             if caption_lang:
-                caption_path = retrieve_captions(source_for_validation, work, caption_lang)
+                caption_path = retrieve_captions(fetch_source, work, caption_lang)
                 if caption_path:
                     transcript_segments = parse_vtt(caption_path)
                     transcript_provenance = f"captions:{caption_kind}"
@@ -765,29 +1069,71 @@ def build_manifest(args: argparse.Namespace, smoke_mode: bool = False) -> dict[s
                     warnings.append("caption metadata existed but caption retrieval produced no VTT file")
             else:
                 warnings.append("no compatible public captions were advertised; remote transcription is disabled in v1")
-            video_path = download_video(source_for_validation, work)
+            media = acquire_media(
+                fetch_source,
+                work,
+                ceiling,
+                declared_media_bytes(metadata),
+                requested_section(start, end, safe_float(metadata.get("duration"), 0.0)),
+                warnings,
+            )
         else:
-            local_path = validate_local(source_for_validation, args.max_local_bytes)
+            local_path = validate_local(fetch_source, args.max_local_bytes)
             media_dir = work / "media"
             media_dir.mkdir(parents=True, exist_ok=True)
-            video_path = media_dir / f"local{local_path.suffix.lower()}"
-            shutil.copy2(local_path, video_path)
+            local_copy = media_dir / f"local{local_path.suffix.lower()}"
+            shutil.copy2(local_path, local_copy)
+            media = Media(
+                local_copy,
+                "full",
+                args.max_local_bytes,
+                declared_bytes=local_copy.stat().st_size,
+                downloaded_bytes=local_copy.stat().st_size,
+            )
             warnings.append("local-file transcription is not enabled in v1 unless captions are separately supported later")
-        probed = probe_video(video_path)
-        duration = safe_float(metadata.get("duration"), 0.0) or float(probed["duration_seconds"])
+        video_path = media.path
+        if video_path is not None:
+            probed = probe_video(video_path)
+            media = confirm_section_media(media, float(probed["duration_seconds"]), warnings)
+        else:
+            probed = {}
+        duration = safe_float(metadata.get("duration"), 0.0) or float(probed.get("duration_seconds", 0.0))
+        if duration <= 0:
+            raise WatchError("video duration could not be determined", 5)
         chapters = normalize_chapters(metadata.get("chapters"), duration)
         ranges = select_ranges(duration, transcript_segments, chapters, args.question, start, end)
         max_frames, resolution = clamp_requested_limits(args, ranges[0].reason == "focused_range", warnings)
         selected_transcript, transcript_truncated = transcript_excerpt(transcript_segments, ranges)
         if transcript_truncated:
             warnings.append("transcript evidence was truncated to the bounded manifest budget")
-        scenes, scene_warnings = scene_timestamps(video_path, ranges)
-        warnings.extend(scene_warnings)
-        plan = combine_frame_plan(ranges, scenes, max_frames)
-        if not plan:
-            raise WatchError("frame planning produced no evidence frames", 5)
-        frames = extract_frames(video_path, work, plan, resolution)
-        if duration > 600 and not focused:
+        frames: list[dict[str, Any]] = []
+        recommendation: str | None = None
+        if video_path is not None:
+            scenes, scene_warnings = scene_timestamps(video_path, ranges, media.offset_seconds)
+            warnings.extend(scene_warnings)
+            plan = combine_frame_plan(ranges, scenes, max_frames)
+            if not plan:
+                raise WatchError("frame planning produced no evidence frames", 5)
+            frames = extract_frames(
+                video_path,
+                work,
+                plan,
+                resolution,
+                media.offset_seconds,
+                tail_seek_limit(float(probed["duration_seconds"]), float(probed.get("frame_rate") or 0.0)),
+            )
+        else:
+            recommendation = focused_pass_recommendation(ranges, duration)
+            warnings.append(media.refusal or "no visual evidence was acquired for this source")
+            warnings.append(
+                "this manifest carries transcript and chapter evidence only; do not claim any visual coverage"
+            )
+        if media.coverage == "section" and media.section is not None:
+            warnings.append(
+                "visual evidence covers only the requested section "
+                f"{fmt_time(media.section[0])}-{fmt_time(media.section[1])}, not the whole video"
+            )
+        if duration > 600 and not focused and frames:
             warnings.append("video is over 10 minutes; this is sparse sampled evidence, not every frame")
         frame_token_estimate = int(len(frames) * 1200 * (resolution / 512) ** 2)
         transcript_chars = sum(len(seg["text"]) for seg in selected_transcript)
@@ -809,6 +1155,19 @@ def build_manifest(args: argparse.Namespace, smoke_mode: bool = False) -> dict[s
                 "selected_segment_count": len(selected_transcript),
                 "segments": selected_transcript,
                 "remote_transcription": "disabled",
+            },
+            "media": {
+                "acquired": video_path is not None,
+                "visual_coverage": media.coverage,
+                "byte_ceiling": media.byte_ceiling,
+                "declared_bytes": media.declared_bytes,
+                "downloaded_bytes": media.downloaded_bytes,
+                "acquired_range": (
+                    {"start_seconds": round(media.section[0], 2), "end_seconds": round(media.section[1], 2)}
+                    if media.coverage == "section" and media.section is not None
+                    else None
+                ),
+                "focused_pass_recommendation": recommendation,
             },
             "frames": frames,
             "token_budget": {
@@ -858,6 +1217,16 @@ def add_prepare_options(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--resolution", type=int, default=DEFAULT_RESOLUTION, help="Frame width in pixels. Default 512; hard cap 768 full or 1280 focused.")
     parser.add_argument("--caption-lang", default=None, help="Preferred caption language, default en with compatible fallbacks")
     parser.add_argument("--max-local-bytes", type=int, default=DEFAULT_MAX_LOCAL_BYTES, help="Safety limit for explicit local video files")
+    parser.add_argument(
+        "--max-media-bytes",
+        type=int,
+        default=None,
+        help=(
+            "Transient public-media byte ceiling. Default 4 GiB; explicit values up to 16 GiB are honored "
+            "only when local free space proves sufficient. Sources declared above the ceiling are refused "
+            "before download and return transcript and chapter evidence with a focused-pass recommendation."
+        ),
+    )
 
 
 def parser() -> argparse.ArgumentParser:
@@ -867,7 +1236,12 @@ def parser() -> argparse.ArgumentParser:
         epilog=(
             "The manifest is sparse evidence: it reports sampled frames and transcript windows, "
             "not a claim that every frame was watched. Public URL mode uses yt-dlp only, with "
-            "no browser profiles, cookies, login state, headers, or extensions. Missing dependencies "
+            "no browser profiles, cookies, login state, headers, or extensions. The supplied public "
+            "URL is fetched exactly as given; only the manifest description redacts query values, and "
+            "credential, signature, session, or token query fields are refused outright. Public media "
+            "is bounded by a transient byte ceiling both before download and after acquisition, focused "
+            "runs request a bounded section when the provider supports one, and media.visual_coverage "
+            "reports whether the evidence is full, section-only, or absent. Missing dependencies "
             "are reported; no installer is run. Remote transcription is disabled in v1."
         ),
     )

--- a/bin/fm-video-watch-impl.py
+++ b/bin/fm-video-watch-impl.py
@@ -1,0 +1,902 @@
+#!/usr/bin/env python3
+"""Private implementation for bin/fm-video-watch.sh.
+
+The public contract lives in fm-video-watch.sh's header and this program's help
+text as reached through that wrapper.
+"""
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import math
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+from urllib.parse import parse_qs, urlencode, urlsplit, urlunsplit
+
+SCHEMA = "fm.video-watch.manifest.v1"
+OWNED_MARKER = ".fm-video-watch-owned.json"
+RECEIPT_PREFIX = "fmvw1."
+REQUIRED_COMMON = ("ffmpeg", "ffprobe")
+REQUIRED_URL = ("yt-dlp",)
+VIDEO_EXTS = {".mp4", ".mkv", ".webm", ".mov", ".m4v", ".avi", ".flv", ".wmv"}
+DEFAULT_MAX_FRAMES = 36
+FULL_HARD_MAX_FRAMES = 60
+FOCUS_HARD_MAX_FRAMES = 80
+DEFAULT_RESOLUTION = 512
+MAX_FULL_RESOLUTION = 768
+MAX_FOCUS_RESOLUTION = 1280
+DEFAULT_MAX_LOCAL_BYTES = 2 * 1024 * 1024 * 1024
+MAX_TRANSCRIPT_CHARS = 16_000
+MAX_COMMAND_SECONDS = 180
+SCENE_THRESHOLD = 0.28
+
+
+class WatchError(Exception):
+    def __init__(self, message: str, code: int = 5, warnings: list[str] | None = None):
+        super().__init__(message)
+        self.code = code
+        self.warnings = warnings or []
+
+
+@dataclass(frozen=True)
+class Segment:
+    start: float
+    end: float
+    text: str
+
+
+@dataclass(frozen=True)
+class Range:
+    start: float
+    end: float
+    reason: str
+
+
+def _json_dumps(data: Any) -> str:
+    return json.dumps(data, indent=2, sort_keys=True, ensure_ascii=False)
+
+
+def eprint(message: str) -> None:
+    print(message, file=sys.stderr)
+
+
+def run_quiet(cmd: list[str], timeout: int = MAX_COMMAND_SECONDS) -> subprocess.CompletedProcess[str]:
+    try:
+        return subprocess.run(cmd, capture_output=True, text=True, timeout=timeout, check=False)
+    except subprocess.TimeoutExpired as exc:
+        raise WatchError(f"command timed out after {timeout}s: {Path(cmd[0]).name}", 5) from exc
+    except OSError as exc:
+        raise WatchError(f"could not run required command {Path(cmd[0]).name}: {exc}", 5) from exc
+
+
+def which_missing(names: tuple[str, ...] | list[str]) -> list[str]:
+    return [name for name in names if shutil.which(name) is None]
+
+
+def require_deps(url_mode: bool) -> None:
+    missing = which_missing(list(REQUIRED_COMMON) + (list(REQUIRED_URL) if url_mode else []))
+    if missing:
+        hints = []
+        if any(name in missing for name in ("ffmpeg", "ffprobe")):
+            hints.append("install ffmpeg, which provides ffmpeg and ffprobe")
+        if "yt-dlp" in missing:
+            hints.append("install yt-dlp")
+        raise WatchError(
+            "missing required dependencies: " + ", ".join(missing) + ". " + "; ".join(hints),
+            3,
+        )
+
+
+def parse_time(value: str | None) -> float | None:
+    if value is None:
+        return None
+    s = value.strip()
+    if not s:
+        return None
+    if s.startswith("-"):
+        raise WatchError("timestamps must be non-negative absolute times", 2)
+    parts = s.split(":")
+    try:
+        if len(parts) == 1:
+            seconds = float(parts[0])
+        elif len(parts) == 2:
+            seconds = int(parts[0]) * 60 + float(parts[1])
+        elif len(parts) == 3:
+            seconds = int(parts[0]) * 3600 + int(parts[1]) * 60 + float(parts[2])
+        else:
+            raise ValueError
+    except ValueError as exc:
+        raise WatchError(f"cannot parse timestamp {value!r}; use SS, MM:SS, or HH:MM:SS", 2) from exc
+    if seconds < 0:
+        raise WatchError("timestamps must be non-negative absolute times", 2)
+    return seconds
+
+
+def fmt_time(seconds: float) -> str:
+    total = int(round(max(0.0, seconds)))
+    hours, rem = divmod(total, 3600)
+    minutes, sec = divmod(rem, 60)
+    if hours:
+        return f"{hours}:{minutes:02d}:{sec:02d}"
+    return f"{minutes:02d}:{sec:02d}"
+
+
+def is_public_url(source: str) -> bool:
+    return urlsplit(source).scheme.lower() in {"http", "https"}
+
+
+def sanitize_url(raw: str) -> tuple[str, dict[str, Any]]:
+    split = urlsplit(raw)
+    scheme = split.scheme.lower()
+    if scheme not in {"http", "https"}:
+        raise WatchError("unsupported URL scheme; only public http and https video URLs are accepted", 4)
+    if split.username or split.password:
+        raise WatchError("URL userinfo is not accepted", 4)
+    if not split.netloc:
+        raise WatchError("URL host is required", 4)
+    query = parse_qs(split.query, keep_blank_values=False)
+    if "list" in query or "playlist" in query:
+        raise WatchError("playlist URLs are rejected; provide exactly one public video URL", 4)
+    safe_query: dict[str, list[str]] = {}
+    host = split.hostname or ""
+    if host.endswith("youtube.com") and split.path == "/watch" and query.get("v"):
+        safe_query["v"] = [query["v"][0]]
+    sanitized = urlunsplit((scheme, split.netloc.lower(), split.path, urlencode(safe_query, doseq=True), ""))
+    identity = {
+        "kind": "public_url",
+        "sanitized": sanitized,
+        "host": host.lower(),
+        "path": split.path or "/",
+    }
+    return sanitized, identity
+
+
+def reject_unsafe_source(source: str) -> tuple[str, dict[str, Any], bool]:
+    split = urlsplit(source)
+    if split.scheme and split.scheme.lower() not in {"http", "https"}:
+        raise WatchError("unsupported source scheme; use a public http(s) URL or an explicit local file path", 4)
+    if is_public_url(source):
+        sanitized, identity = sanitize_url(source)
+        return sanitized, identity, True
+    return source, {"kind": "local_file", "sanitized": Path(source).name}, False
+
+
+def validate_local(source: str, max_local_bytes: int) -> Path:
+    path = Path(source).expanduser()
+    try:
+        st = path.lstat()
+    except FileNotFoundError as exc:
+        raise WatchError("local video file was not found", 2) from exc
+    if path.is_symlink():
+        raise WatchError("local video file must be an explicit regular file, not a symlink", 4)
+    if not path.is_file():
+        raise WatchError("local video source must be an explicit regular file", 4)
+    if st.st_size <= 0:
+        raise WatchError("local video file is empty", 4)
+    if st.st_size > max_local_bytes:
+        raise WatchError(
+            f"local video file is larger than the configured safety limit ({max_local_bytes} bytes)",
+            4,
+        )
+    if path.suffix.lower() not in VIDEO_EXTS:
+        raise WatchError("local file extension is not a supported video type", 4)
+    return path.resolve(strict=True)
+
+
+def make_workdir() -> tuple[Path, str]:
+    root = Path(tempfile.mkdtemp(prefix="fm-video-watch-")).resolve(strict=True)
+    nonce = uuid.uuid4().hex
+    marker = {"schema": "fm.video-watch.owned.v1", "nonce": nonce}
+    marker_path = root / OWNED_MARKER
+    marker_path.write_text(_json_dumps(marker) + "\n", encoding="utf-8")
+    marker_path.chmod(0o600)
+    return root, nonce
+
+
+def b64url(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).decode("ascii").rstrip("=")
+
+
+def b64url_decode(data: str) -> bytes:
+    pad = "=" * (-len(data) % 4)
+    return base64.urlsafe_b64decode(data + pad)
+
+
+def make_receipt(root: Path, nonce: str) -> str:
+    payload = {"schema": "fm.video-watch.receipt.v1", "root": str(root), "nonce": nonce}
+    return RECEIPT_PREFIX + b64url(json.dumps(payload, separators=(",", ":")).encode("utf-8"))
+
+
+def decode_receipt(receipt: str) -> tuple[Path, str]:
+    if not receipt.startswith(RECEIPT_PREFIX):
+        raise WatchError("cleanup receipt is not a Firstmate video-watch receipt", 2)
+    try:
+        payload = json.loads(b64url_decode(receipt[len(RECEIPT_PREFIX):]).decode("utf-8"))
+    except Exception as exc:
+        raise WatchError("cleanup receipt is malformed", 2) from exc
+    if payload.get("schema") != "fm.video-watch.receipt.v1":
+        raise WatchError("cleanup receipt schema is unsupported", 2)
+    root = Path(str(payload.get("root") or ""))
+    nonce = str(payload.get("nonce") or "")
+    if not root.is_absolute() or not nonce:
+        raise WatchError("cleanup receipt is incomplete", 2)
+    return root, nonce
+
+
+def verify_owned_root(root: Path, nonce: str) -> None:
+    try:
+        resolved = root.resolve(strict=True)
+    except FileNotFoundError as exc:
+        raise WatchError("cleanup target no longer exists", 5) from exc
+    if resolved != root:
+        raise WatchError("cleanup target must be the exact owned temporary directory", 4)
+    temp_root = Path(tempfile.gettempdir()).resolve(strict=True)
+    try:
+        resolved.relative_to(temp_root)
+    except ValueError as exc:
+        raise WatchError("cleanup target is outside the system temporary directory", 4) from exc
+    if not root.name.startswith("fm-video-watch-"):
+        raise WatchError("cleanup target is not a Firstmate video-watch directory", 4)
+    if root.is_symlink() or not root.is_dir():
+        raise WatchError("cleanup target is not an ordinary owned directory", 4)
+    marker = root / OWNED_MARKER
+    if marker.is_symlink() or not marker.is_file():
+        raise WatchError("cleanup ownership marker is missing or unsafe", 4)
+    try:
+        data = json.loads(marker.read_text(encoding="utf-8"))
+    except Exception as exc:
+        raise WatchError("cleanup ownership marker is unreadable", 4) from exc
+    if data.get("schema") != "fm.video-watch.owned.v1" or data.get("nonce") != nonce:
+        raise WatchError("cleanup receipt does not match the owned evidence directory", 4)
+
+
+def cmd_cleanup(args: argparse.Namespace) -> int:
+    root, nonce = decode_receipt(args.receipt)
+    verify_owned_root(root, nonce)
+    shutil.rmtree(root)
+    if root.exists():
+        raise WatchError("cleanup could not prove the evidence directory was removed", 5)
+    print(_json_dumps({"schema": "fm.video-watch.cleanup.v1", "removed": True, "receipt": args.receipt}))
+    return 0
+
+
+def cmd_doctor(_args: argparse.Namespace) -> int:
+    missing = which_missing(list(REQUIRED_COMMON) + list(REQUIRED_URL))
+    status = {
+        "schema": "fm.video-watch.doctor.v1",
+        "ready": not missing,
+        "missing_dependencies": missing,
+        "install_hint": "Install ffmpeg (for ffmpeg and ffprobe) and yt-dlp. Firstmate never auto-installs them.",
+        "auto_install_attempted": False,
+    }
+    print(_json_dumps(status))
+    return 0 if not missing else 3
+
+
+def load_ytdlp_metadata(url: str) -> dict[str, Any]:
+    cmd = [
+        "yt-dlp",
+        "--dump-single-json",
+        "--skip-download",
+        "--no-playlist",
+        "--no-warnings",
+        url,
+    ]
+    result = run_quiet(cmd)
+    if result.returncode != 0:
+        raise WatchError("public video metadata was unavailable without login or was unsupported", 4)
+    try:
+        data = json.loads(result.stdout or "{}")
+    except json.JSONDecodeError as exc:
+        raise WatchError("public video metadata was malformed", 5) from exc
+    if not isinstance(data, dict):
+        raise WatchError("public video metadata was malformed", 5)
+    reject_metadata(data)
+    return data
+
+
+def reject_metadata(data: dict[str, Any]) -> None:
+    if data.get("_type") in {"playlist", "multi_video"} or data.get("playlist_count") or data.get("entries"):
+        raise WatchError("source expanded to more than one video; playlists are rejected", 4)
+    if data.get("is_live") or str(data.get("live_status") or "").lower() in {"is_live", "is_upcoming", "post_live"}:
+        raise WatchError("live or upcoming streams are rejected", 4)
+    availability = str(data.get("availability") or "").lower()
+    if availability and availability not in {"public", "unlisted"}:
+        raise WatchError("authenticated, private, subscriber-only, or DRM video sources are rejected", 4)
+    if data.get("drm") or data.get("has_drm"):
+        raise WatchError("DRM-protected video sources are rejected", 4)
+
+
+def normalize_chapters(raw: Any, duration: float) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    if isinstance(raw, list):
+        for chapter in raw[:80]:
+            if not isinstance(chapter, dict):
+                continue
+            start = safe_float(chapter.get("start_time"), 0.0)
+            end = safe_float(chapter.get("end_time"), duration)
+            title = str(chapter.get("title") or "").strip()[:120]
+            if end <= start:
+                continue
+            out.append({"start_seconds": round(start, 2), "end_seconds": round(end, 2), "title": title})
+    return out
+
+
+def safe_float(value: Any, default: float = 0.0) -> float:
+    try:
+        if value is None or value == "":
+            return default
+        value = float(value)
+        if math.isnan(value) or math.isinf(value):
+            return default
+        return value
+    except (TypeError, ValueError):
+        return default
+
+
+def probe_video(path: Path) -> dict[str, Any]:
+    result = run_quiet([
+        "ffprobe",
+        "-v",
+        "quiet",
+        "-print_format",
+        "json",
+        "-show_format",
+        "-show_streams",
+        str(path),
+    ])
+    if result.returncode != 0:
+        raise WatchError("video probing failed", 5)
+    try:
+        data = json.loads(result.stdout or "{}")
+    except json.JSONDecodeError as exc:
+        raise WatchError("video metadata was malformed", 5) from exc
+    streams = data.get("streams") if isinstance(data.get("streams"), list) else []
+    fmt = data.get("format") if isinstance(data.get("format"), dict) else {}
+    video_stream = next((s for s in streams if isinstance(s, dict) and s.get("codec_type") == "video"), {})
+    if not video_stream:
+        raise WatchError("video file has no video stream", 4)
+    duration = safe_float(fmt.get("duration") or video_stream.get("duration"), 0.0)
+    if duration <= 0:
+        raise WatchError("video duration could not be determined", 5)
+    return {
+        "duration_seconds": duration,
+        "width": video_stream.get("width"),
+        "height": video_stream.get("height"),
+        "codec": video_stream.get("codec_name"),
+        "size_bytes": int(safe_float(fmt.get("size"), 0.0)),
+        "has_audio": any(isinstance(s, dict) and s.get("codec_type") == "audio" for s in streams),
+    }
+
+
+def choose_caption(metadata: dict[str, Any], requested: str | None) -> tuple[str | None, str | None, str | None]:
+    requested = requested or "en"
+    subtitles = metadata.get("subtitles") if isinstance(metadata.get("subtitles"), dict) else {}
+    automatic = metadata.get("automatic_captions") if isinstance(metadata.get("automatic_captions"), dict) else {}
+    preference = [requested, "en", "en-US", "en-GB", "en-orig"]
+    seen: set[str] = set()
+    for lang in preference + sorted(subtitles) + sorted(automatic):
+        if lang in seen:
+            continue
+        seen.add(lang)
+        if lang in subtitles:
+            return lang, "manual", lang
+        if lang in automatic:
+            return lang, "automatic", lang
+    return None, None, None
+
+
+def retrieve_captions(url: str, work: Path, lang: str) -> Path | None:
+    out_dir = work / "captions"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    template = str(out_dir / "caption.%(ext)s")
+    cmd = [
+        "yt-dlp",
+        "--skip-download",
+        "--write-subs",
+        "--write-auto-subs",
+        "--sub-langs",
+        lang,
+        "--sub-format",
+        "vtt",
+        "--convert-subs",
+        "vtt",
+        "--no-playlist",
+        "--no-warnings",
+        "-o",
+        template,
+        url,
+    ]
+    result = run_quiet(cmd)
+    candidates = sorted(out_dir.glob("*.vtt"))
+    if result.returncode != 0 and not candidates:
+        return None
+    return candidates[0] if candidates else None
+
+
+TS_RE = re.compile(r"(\d{2}):(\d{2}):(\d{2})[.,](\d{3})\s+-->\s+(\d{2}):(\d{2}):(\d{2})[.,](\d{3})")
+TAG_RE = re.compile(r"<[^>]+>")
+
+
+def _to_seconds(parts: tuple[str, str, str, str]) -> float:
+    h, m, s, ms = parts
+    return int(h) * 3600 + int(m) * 60 + int(s) + int(ms) / 1000.0
+
+
+def parse_vtt(path: Path) -> list[Segment]:
+    text = path.read_text(encoding="utf-8", errors="ignore")
+    lines = text.splitlines()
+    segments: list[Segment] = []
+    i = 0
+    while i < len(lines):
+        match = TS_RE.match(lines[i])
+        if not match:
+            i += 1
+            continue
+        start = _to_seconds(match.groups()[:4])
+        end = _to_seconds(match.groups()[4:])
+        i += 1
+        cue_lines: list[str] = []
+        while i < len(lines) and lines[i].strip():
+            cleaned = TAG_RE.sub("", lines[i]).strip()
+            if cleaned:
+                cue_lines.append(cleaned)
+            i += 1
+        cue = " ".join(cue_lines).strip()
+        if cue:
+            segments.append(Segment(round(start, 2), round(end, 2), cue))
+        i += 1
+    return dedupe_segments(segments)
+
+
+def dedupe_segments(segments: list[Segment]) -> list[Segment]:
+    out: list[Segment] = []
+    for seg in segments:
+        if out and seg.text == out[-1].text:
+            prev = out[-1]
+            out[-1] = Segment(prev.start, seg.end, prev.text)
+            continue
+        if out and seg.text.startswith(out[-1].text + " "):
+            prev = out[-1]
+            out[-1] = Segment(prev.start, seg.end, seg.text)
+            continue
+        out.append(seg)
+    return out
+
+
+def query_terms(question: str | None) -> set[str]:
+    if not question:
+        return set()
+    stop = {"about", "what", "when", "where", "which", "there", "their", "this", "that", "does", "with", "from", "the", "how", "why", "who", "can", "summarize", "summary", "video"}
+    return {token for token in re.findall(r"[a-z0-9]{3,}", question.lower()) if token not in stop}
+
+
+def clip_range(start: float, end: float, duration: float) -> Range | None:
+    start = max(0.0, min(duration, start))
+    end = max(0.0, min(duration, end))
+    if end <= start:
+        return None
+    return Range(round(start, 2), round(end, 2), "transcript_match")
+
+
+def merge_ranges(ranges: list[Range], duration: float, max_ranges: int = 5) -> list[Range]:
+    normalized = sorted([r for r in ranges if r.end > r.start], key=lambda r: r.start)
+    merged: list[Range] = []
+    for r in normalized:
+        if not merged or r.start > merged[-1].end + 5:
+            merged.append(r)
+        else:
+            prev = merged[-1]
+            reason = prev.reason if prev.reason == r.reason else f"{prev.reason}+{r.reason}"
+            merged[-1] = Range(prev.start, max(prev.end, r.end), reason)
+    if not merged:
+        return [Range(0.0, duration, "full_video")]
+    return merged[:max_ranges]
+
+
+def select_ranges(
+    duration: float,
+    segments: list[Segment],
+    chapters: list[dict[str, Any]],
+    question: str | None,
+    start: float | None,
+    end: float | None,
+) -> list[Range]:
+    if start is not None or end is not None:
+        lo = start if start is not None else 0.0
+        hi = end if end is not None else duration
+        if lo >= duration:
+            raise WatchError("--start is at or after the end of the video", 2)
+        if hi <= lo:
+            raise WatchError("--end must be greater than --start", 2)
+        return [Range(round(lo, 2), round(min(hi, duration), 2), "focused_range")]
+    terms = query_terms(question)
+    ranges: list[Range] = []
+    if terms and segments:
+        for seg in segments:
+            lower = seg.text.lower()
+            if any(term in lower for term in terms):
+                clipped = clip_range(seg.start - 20, seg.end + 20, duration)
+                if clipped:
+                    ranges.append(clipped)
+    if terms and chapters:
+        for chapter in chapters:
+            title = str(chapter.get("title") or "").lower()
+            if any(term in title for term in terms):
+                ranges.append(Range(float(chapter["start_seconds"]), float(chapter["end_seconds"]), "chapter_match"))
+    if ranges:
+        return merge_ranges(ranges, duration)
+    return [Range(0.0, duration, "full_video")]
+
+
+def transcript_excerpt(segments: list[Segment], ranges: list[Range]) -> tuple[list[dict[str, Any]], bool]:
+    selected: list[dict[str, Any]] = []
+    chars = 0
+    truncated = False
+    for seg in segments:
+        if not any(seg.end >= r.start and seg.start <= r.end for r in ranges):
+            continue
+        text = seg.text.strip()
+        chars += len(text)
+        if chars > MAX_TRANSCRIPT_CHARS:
+            truncated = True
+            break
+        selected.append({"start_seconds": seg.start, "end_seconds": seg.end, "text": text})
+    return selected, truncated
+
+
+def download_video(url: str, work: Path) -> Path:
+    out_dir = work / "media"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    template = str(out_dir / "video.%(ext)s")
+    cmd = [
+        "yt-dlp",
+        "-f",
+        "bv*[height<=720]+ba/b[height<=720]/bv+ba/b",
+        "--merge-output-format",
+        "mp4",
+        "--no-playlist",
+        "--no-warnings",
+        "-o",
+        template,
+        url,
+    ]
+    result = run_quiet(cmd, timeout=600)
+    videos = sorted([p for p in out_dir.glob("video.*") if p.suffix.lower() in VIDEO_EXTS])
+    if result.returncode != 0 and not videos:
+        raise WatchError("public video download failed without safe public access", 4)
+    if not videos:
+        raise WatchError("public video download produced no video file", 5)
+    return videos[0]
+
+
+def scene_timestamps(video: Path, ranges: list[Range]) -> tuple[list[float], list[str]]:
+    warnings: list[str] = []
+    timestamps: list[float] = []
+    for selected in ranges:
+        cmd = [
+            "ffmpeg",
+            "-hide_banner",
+            "-loglevel",
+            "info",
+            "-ss",
+            f"{selected.start:.3f}",
+            "-to",
+            f"{selected.end:.3f}",
+            "-i",
+            str(video),
+            "-vf",
+            f"select='gt(scene,{SCENE_THRESHOLD})',showinfo",
+            "-an",
+            "-f",
+            "null",
+            "-",
+        ]
+        result = run_quiet(cmd, timeout=300)
+        if result.returncode != 0:
+            warnings.append("scene-change detection failed for at least one selected range; periodic coverage was still used")
+            continue
+        for match in re.finditer(r"pts_time:([0-9]+(?:\.[0-9]+)?)", result.stderr):
+            timestamps.append(round(selected.start + float(match.group(1)), 2))
+    return sorted(set(timestamps)), warnings
+
+
+def periodic_timestamps(ranges: list[Range], budget: int) -> list[float]:
+    total_duration = sum(max(0.0, r.end - r.start) for r in ranges)
+    if total_duration <= 0:
+        return []
+    points: list[float] = []
+    periodic_budget = max(1, budget)
+    for r in ranges:
+        share = max(1, round(periodic_budget * ((r.end - r.start) / total_duration)))
+        if share == 1:
+            points.append(round((r.start + r.end) / 2, 2))
+            continue
+        step = (r.end - r.start) / (share - 1)
+        for i in range(share):
+            points.append(round(min(r.end, r.start + i * step), 2))
+    return sorted(set(points))
+
+
+def combine_frame_plan(ranges: list[Range], scenes: list[float], max_frames: int) -> list[dict[str, Any]]:
+    periodic = periodic_timestamps(ranges, max(1, max_frames // 2))
+    candidates: list[dict[str, Any]] = []
+    for t in periodic:
+        candidates.append({"timestamp_seconds": t, "reason": "periodic_coverage"})
+    min_gap = max(1.0, sum(r.end - r.start for r in ranges) / max(max_frames, 1) / 2)
+    last_scene = -9999.0
+    for t in scenes:
+        if not any(r.start <= t <= r.end for r in ranges):
+            continue
+        if t - last_scene < min_gap:
+            continue
+        candidates.append({"timestamp_seconds": t, "reason": "scene_or_slide_change"})
+        last_scene = t
+    focused = ranges and ranges[0].reason == "focused_range"
+    if focused:
+        for r in ranges:
+            candidates.append({"timestamp_seconds": r.start, "reason": "focused_range_start"})
+            candidates.append({"timestamp_seconds": max(r.start, r.end - 0.01), "reason": "focused_range_end"})
+    by_time: dict[float, str] = {}
+    for item in sorted(candidates, key=lambda x: (x["timestamp_seconds"], x["reason"])):
+        t = round(float(item["timestamp_seconds"]), 2)
+        reason = str(item["reason"])
+        if t in by_time:
+            if reason not in by_time[t]:
+                by_time[t] = by_time[t] + "+" + reason
+        else:
+            by_time[t] = reason
+    items = [{"timestamp_seconds": t, "reason": reason} for t, reason in sorted(by_time.items())]
+    if len(items) <= max_frames:
+        return items
+    # Keep a stable spread across the selected evidence instead of the first N frames.
+    chosen: list[dict[str, Any]] = []
+    for i in range(max_frames):
+        idx = round(i * (len(items) - 1) / max(max_frames - 1, 1))
+        chosen.append(items[idx])
+    dedup: dict[float, dict[str, Any]] = {item["timestamp_seconds"]: item for item in chosen}
+    return [dedup[t] for t in sorted(dedup)]
+
+
+def extract_frame(video: Path, out_path: Path, timestamp: float, resolution: int) -> None:
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    result = run_quiet([
+        "ffmpeg",
+        "-hide_banner",
+        "-loglevel",
+        "error",
+        "-y",
+        "-ss",
+        f"{timestamp:.3f}",
+        "-i",
+        str(video),
+        "-frames:v",
+        "1",
+        "-vf",
+        f"scale={resolution}:-2",
+        "-q:v",
+        "4",
+        str(out_path),
+    ])
+    if result.returncode != 0 or not out_path.exists() or out_path.stat().st_size <= 0:
+        raise WatchError("frame extraction failed", 5)
+
+
+def extract_frames(video: Path, work: Path, plan: list[dict[str, Any]], resolution: int) -> list[dict[str, Any]]:
+    frames: list[dict[str, Any]] = []
+    frame_dir = work / "frames"
+    frame_dir.mkdir(parents=True, exist_ok=True)
+    for idx, item in enumerate(plan, start=1):
+        out_path = frame_dir / f"frame_{idx:04d}.jpg"
+        timestamp = float(item["timestamp_seconds"])
+        extract_frame(video, out_path, timestamp, resolution)
+        frames.append({
+            "index": idx,
+            "path": str(out_path),
+            "timestamp_seconds": round(timestamp, 2),
+            "timestamp": fmt_time(timestamp),
+            "reason": item["reason"],
+        })
+    return frames
+
+
+def clamp_requested_limits(args: argparse.Namespace, focused: bool, warnings: list[str]) -> tuple[int, int]:
+    hard_max = FOCUS_HARD_MAX_FRAMES if focused else FULL_HARD_MAX_FRAMES
+    max_frames = args.max_frames if args.max_frames is not None else DEFAULT_MAX_FRAMES
+    if max_frames <= 0:
+        raise WatchError("--max-frames must be positive", 2)
+    if max_frames > hard_max:
+        warnings.append(f"requested frame cap exceeded the hard cap; using {hard_max} frames")
+        max_frames = hard_max
+    res_hard = MAX_FOCUS_RESOLUTION if focused else MAX_FULL_RESOLUTION
+    resolution = args.resolution
+    if resolution <= 0:
+        raise WatchError("--resolution must be positive", 2)
+    if resolution > res_hard:
+        warnings.append(f"requested resolution exceeded the hard cap; using {res_hard}px wide")
+        resolution = res_hard
+    return max_frames, resolution
+
+
+def source_title(metadata: dict[str, Any], local_path: Path | None) -> str | None:
+    if local_path is not None:
+        return local_path.name
+    title = metadata.get("title")
+    return str(title)[:200] if title else None
+
+
+def build_manifest(args: argparse.Namespace, smoke_mode: bool = False) -> dict[str, Any]:
+    source_for_validation, source_identity, url_mode = reject_unsafe_source(args.source)
+    require_deps(url_mode)
+    warnings: list[str] = []
+    start = parse_time(args.start)
+    end = parse_time(args.end)
+    if start is not None and end is not None and end <= start:
+        raise WatchError("--end must be greater than --start", 2)
+    focused = start is not None or end is not None
+    max_frames, resolution = clamp_requested_limits(args, focused, warnings)
+    work, nonce = make_workdir()
+    receipt = make_receipt(work, nonce)
+    metadata: dict[str, Any] = {}
+    transcript_segments: list[Segment] = []
+    transcript_language: str | None = None
+    transcript_provenance = "none"
+    video_path: Path | None = None
+    local_path: Path | None = None
+    try:
+        if url_mode:
+            metadata = load_ytdlp_metadata(source_for_validation)
+            transcript_language, caption_kind, caption_lang = choose_caption(metadata, args.caption_lang)
+            if caption_lang:
+                caption_path = retrieve_captions(source_for_validation, work, caption_lang)
+                if caption_path:
+                    transcript_segments = parse_vtt(caption_path)
+                    transcript_provenance = f"captions:{caption_kind}"
+                else:
+                    warnings.append("caption metadata existed but caption retrieval produced no VTT file")
+            else:
+                warnings.append("no compatible public captions were advertised; remote transcription is disabled in v1")
+            video_path = download_video(source_for_validation, work)
+        else:
+            local_path = validate_local(source_for_validation, args.max_local_bytes)
+            media_dir = work / "media"
+            media_dir.mkdir(parents=True, exist_ok=True)
+            video_path = media_dir / f"local{local_path.suffix.lower()}"
+            shutil.copy2(local_path, video_path)
+            warnings.append("local-file transcription is not enabled in v1 unless captions are separately supported later")
+        probed = probe_video(video_path)
+        duration = safe_float(metadata.get("duration"), 0.0) or float(probed["duration_seconds"])
+        chapters = normalize_chapters(metadata.get("chapters"), duration)
+        ranges = select_ranges(duration, transcript_segments, chapters, args.question, start, end)
+        max_frames, resolution = clamp_requested_limits(args, ranges[0].reason == "focused_range", warnings)
+        selected_transcript, transcript_truncated = transcript_excerpt(transcript_segments, ranges)
+        if transcript_truncated:
+            warnings.append("transcript evidence was truncated to the bounded manifest budget")
+        scenes, scene_warnings = scene_timestamps(video_path, ranges)
+        warnings.extend(scene_warnings)
+        plan = combine_frame_plan(ranges, scenes, max_frames)
+        if not plan:
+            raise WatchError("frame planning produced no evidence frames", 5)
+        frames = extract_frames(video_path, work, plan, resolution)
+        if duration > 600 and not focused:
+            warnings.append("video is over 10 minutes; this is sparse sampled evidence, not every frame")
+        frame_token_estimate = int(len(frames) * 1200 * (resolution / 512) ** 2)
+        transcript_chars = sum(len(seg["text"]) for seg in selected_transcript)
+        manifest = {
+            "schema": SCHEMA,
+            "mode": "real_public_smoke" if smoke_mode else "prepare",
+            "source": source_identity,
+            "title": source_title(metadata, local_path),
+            "duration_seconds": round(duration, 2),
+            "duration": fmt_time(duration),
+            "chapters": chapters,
+            "selected_ranges": [
+                {"start_seconds": r.start, "end_seconds": r.end, "reason": r.reason} for r in ranges
+            ],
+            "transcript": {
+                "available": bool(transcript_segments),
+                "provenance": transcript_provenance,
+                "language": transcript_language,
+                "selected_segment_count": len(selected_transcript),
+                "segments": selected_transcript,
+                "remote_transcription": "disabled",
+            },
+            "frames": frames,
+            "token_budget": {
+                "estimated_frame_tokens": frame_token_estimate,
+                "estimated_transcript_tokens": math.ceil(transcript_chars / 4),
+                "estimated_total_tokens": frame_token_estimate + math.ceil(transcript_chars / 4),
+                "max_frames": max_frames,
+                "resolution_px_wide": resolution,
+                "batching_guidance": "Read frames in batches of 10-20 and cite timestamps; re-run focused with --start/--end if a sampled range is insufficient.",
+            },
+            "warnings": sorted(set(warnings)),
+            "cleanup_receipt": receipt,
+        }
+        (work / "manifest.json").write_text(_json_dumps(manifest) + "\n", encoding="utf-8")
+        return manifest
+    except Exception:
+        # Keep the quarantined evidence directory for diagnosis but never print raw source details.
+        if work.exists():
+            eprint(f"fm-video-watch: evidence retained for cleanup with receipt {receipt}")
+        raise
+
+
+def cmd_prepare(args: argparse.Namespace) -> int:
+    manifest = build_manifest(args)
+    print(_json_dumps(manifest))
+    return 0
+
+
+def cmd_smoke(args: argparse.Namespace) -> int:
+    if os.environ.get("FM_VIDEO_WATCH_REAL_SMOKE") != "1" or not args.i_understand_this_uses_network:
+        raise WatchError(
+            "real public smoke is opt-in only; set FM_VIDEO_WATCH_REAL_SMOKE=1 and pass --i-understand-this-uses-network",
+            2,
+        )
+    args.source = args.url
+    manifest = build_manifest(args, smoke_mode=True)
+    print(_json_dumps(manifest))
+    return 0
+
+
+def add_prepare_options(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("source", nargs="?", help="One public video URL or one explicit local video file path")
+    parser.add_argument("--question", default=None, help="Analysis request used to select transcript windows and evidence ranges")
+    parser.add_argument("--start", default=None, help="Absolute focus start timestamp: SS, MM:SS, or HH:MM:SS")
+    parser.add_argument("--end", default=None, help="Absolute focus end timestamp: SS, MM:SS, or HH:MM:SS")
+    parser.add_argument("--max-frames", type=int, default=None, help="Frame cap. Default 36; hard cap 60 full video or 80 focused.")
+    parser.add_argument("--resolution", type=int, default=DEFAULT_RESOLUTION, help="Frame width in pixels. Default 512; hard cap 768 full or 1280 focused.")
+    parser.add_argument("--caption-lang", default=None, help="Preferred caption language, default en with compatible fallbacks")
+    parser.add_argument("--max-local-bytes", type=int, default=DEFAULT_MAX_LOCAL_BYTES, help="Safety limit for explicit local video files")
+
+
+def parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="fm-video-watch.sh",
+        description="Prepare safe, bounded video evidence manifests for Firstmate /watch.",
+        epilog=(
+            "The manifest is sparse evidence: it reports sampled frames and transcript windows, "
+            "not a claim that every frame was watched. Public URL mode uses yt-dlp only, with "
+            "no browser profiles, cookies, login state, headers, or extensions. Missing dependencies "
+            "are reported; no installer is run. Remote transcription is disabled in v1."
+        ),
+    )
+    sub = p.add_subparsers(dest="command", required=True)
+    sub.add_parser("doctor", help="Detect dependencies only; never install anything").set_defaults(func=cmd_doctor)
+    prepare = sub.add_parser("prepare", help="Create one value-safe manifest and evidence directory")
+    add_prepare_options(prepare)
+    prepare.set_defaults(func=cmd_prepare)
+    cleanup = sub.add_parser("cleanup", help="Remove exactly one owned evidence directory using its opaque receipt")
+    cleanup.add_argument("receipt")
+    cleanup.set_defaults(func=cmd_cleanup)
+    smoke = sub.add_parser("smoke", help="Opt-in real public smoke; impossible to run accidentally")
+    smoke.add_argument("--url", required=True, help="Public URL to test")
+    smoke.add_argument("--i-understand-this-uses-network", action="store_true")
+    add_prepare_options(smoke)
+    smoke.set_defaults(func=cmd_smoke)
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parser().parse_args(argv)
+    try:
+        if getattr(args, "command", None) == "prepare" and not args.source:
+            raise WatchError("prepare requires one source", 2)
+        return int(args.func(args))
+    except WatchError as exc:
+        eprint(f"fm-video-watch: {exc}")
+        return exc.code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/bin/fm-video-watch.sh
+++ b/bin/fm-video-watch.sh
@@ -33,7 +33,8 @@
 #   2 command-line usage or invalid input
 #   3 missing required local dependency
 #   4 unsupported, unsafe, authenticated, DRM, playlist, or live source
-#   5 media probing, caption retrieval, download, frame extraction, or cleanup failed
+#   5 media probing, download, frame extraction, or cleanup failed, insufficient local
+#     free space for the transient copy, or an unexpected internal failure
 #
 # Use --help for the full operator contract.
 set -euo pipefail

--- a/bin/fm-video-watch.sh
+++ b/bin/fm-video-watch.sh
@@ -9,6 +9,16 @@
 #
 # This script owns the user-visible mechanics, limits, manifest contract, cleanup
 # receipt, and exit-code classes for the Firstmate watch skill.
+# A public URL is fetched exactly as supplied, so providers that carry the video
+# identity in query parameters keep working; URLs bearing credential, signature,
+# session, or token query fields are refused, and the manifest description prints
+# query values only for known public identifier keys.
+# Transient public media is bounded by --max-media-bytes: 4 GiB by default, up to
+# 16 GiB when local free space proves sufficient, enforced before download and
+# again after acquisition. Focused runs request a bounded provider section when
+# one is available; manifest field media.visual_coverage reports full, section, or
+# none, and a refused acquisition still returns transcript and chapter evidence
+# plus a focused-pass recommendation.
 # Its private Python implementation preserves and adapts useful MIT mechanics from
 # bradautomates/claude-video at git revision 755c157466738dda102c939158a0116b972925a3.
 # It does not depend on ~/.claude/skills/watch, does not install dependencies,

--- a/bin/fm-video-watch.sh
+++ b/bin/fm-video-watch.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# fm-video-watch.sh - prepare bounded video evidence manifests for Firstmate /watch.
+#
+# Public interface:
+#   fm-video-watch.sh doctor
+#   fm-video-watch.sh prepare <public-url-or-local-video> [options]
+#   fm-video-watch.sh cleanup <opaque-receipt>
+#   fm-video-watch.sh smoke --url <public-url> --i-understand-this-uses-network [prepare options]
+#
+# This script owns the user-visible mechanics, limits, manifest contract, cleanup
+# receipt, and exit-code classes for the Firstmate watch skill.
+# Its private Python implementation preserves and adapts useful MIT mechanics from
+# bradautomates/claude-video at git revision 755c157466738dda102c939158a0116b972925a3.
+# It does not depend on ~/.claude/skills/watch, does not install dependencies,
+# does not use browser profiles or cookies, and does not read or write
+# ~/.config/watch/.env.
+#
+# Exit codes:
+#   0 success
+#   2 command-line usage or invalid input
+#   3 missing required local dependency
+#   4 unsupported, unsafe, authenticated, DRM, playlist, or live source
+#   5 media probing, caption retrieval, download, frame extraction, or cleanup failed
+#
+# Use --help for the full operator contract.
+set -euo pipefail
+
+SELF_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+IMPL="$SELF_DIR/fm-video-watch-impl.py"
+
+exec python3 "$IMPL" "$@"

--- a/bin/fm-video-watch.sh
+++ b/bin/fm-video-watch.sh
@@ -7,8 +7,8 @@
 #   fm-video-watch.sh cleanup <opaque-receipt>
 #   fm-video-watch.sh smoke --url <public-url> --i-understand-this-uses-network [prepare options]
 #
-# This script owns the user-visible mechanics, limits, manifest contract, cleanup
-# receipt, and exit-code classes for the Firstmate watch skill.
+# This script owns the user-visible mechanics, limits, media and coverage contract,
+# cleanup receipt handling, and exit-code classes for the Firstmate watch skill.
 # A public URL is fetched exactly as supplied, so providers that carry the video
 # identity in query parameters keep working; URLs bearing credential, signature,
 # session, or token query fields are refused, and the manifest description prints
@@ -36,7 +36,9 @@
 #   5 media probing, download, frame extraction, or cleanup failed, insufficient local
 #     free space for the transient copy, or an unexpected internal failure
 #
-# Use --help for the full operator contract.
+# This header and the exit classes above are the prose contract; use --help for the
+# exact subcommands, flags, defaults, and limits, and read the emitted manifest for
+# its own field set.
 set -euo pipefail
 
 SELF_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/bin/fm-video-watch.sh
+++ b/bin/fm-video-watch.sh
@@ -15,10 +15,13 @@
 # query values only for known public identifier keys.
 # Transient public media is bounded by --max-media-bytes: 4 GiB by default, up to
 # 16 GiB when local free space proves sufficient, enforced before download and
-# again after acquisition. Focused runs request a bounded provider section when
-# one is available; manifest field media.visual_coverage reports full, section, or
-# none, and a refused acquisition still returns transcript and chapter evidence
-# plus a focused-pass recommendation.
+# again after acquisition. A focused run takes whichever bounded route is
+# projected cheaper: a provider section when the requested span is a small share
+# of the source, otherwise the whole media when it already fits the ceiling,
+# because a section is re-encoded rather than stream-copied. Manifest field
+# media.visual_coverage reports full, section, or none, media.acquisition_reason
+# records why that route was taken, and a refused acquisition still returns
+# transcript and chapter evidence plus a focused-pass recommendation.
 # Its private Python implementation preserves and adapts useful MIT mechanics from
 # bradautomates/claude-video at git revision 755c157466738dda102c939158a0116b972925a3.
 # It does not depend on ~/.claude/skills/watch, does not install dependencies,

--- a/docs/documentation-audiences.json
+++ b/docs/documentation-audiences.json
@@ -180,6 +180,10 @@
       "audience": "agent-runtime"
     },
     {
+      "path": ".agents/skills/watch/SKILL.md",
+      "audience": "agent-runtime"
+    },
+    {
       "path": "AGENTS.md",
       "audience": "agent-runtime"
     },
@@ -329,6 +333,10 @@
     },
     {
       "path": "docs/verification/supervision.md",
+      "audience": "maintainer-verification"
+    },
+    {
+      "path": "docs/verification/video-watch.md",
       "audience": "maintainer-verification"
     },
     {

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -15,6 +15,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-fleet-snapshot.sh`   | Print the read-only structured fleet snapshot JSON (schema `fm-fleet-snapshot.v1`)   |
 | `fm-fleet-view.sh`       | Render the fleet snapshot as a human Markdown view                                   |
 | `fm-bearings-snapshot.sh` | Project the fleet snapshot to the compact TOON bearings view; local-only unless `--include-prs` |
+| `fm-video-watch.sh`     | Prepare safe bounded video evidence manifests for `/watch` and clean them up by receipt |
 | `fm-update.sh`           | Fast-forward-only self-update of firstmate and secondmate homes from origin          |
 | `fm-backlog-handoff.sh`  | Validate and delegate queued backlog-item moves into a secondmate home               |
 | `fm-decision-hold.sh`    | Create, verify, complete, and resolve durable captain-held decisions                 |

--- a/docs/verification/video-watch.md
+++ b/docs/verification/video-watch.md
@@ -1,0 +1,80 @@
+# Video watch verification
+
+Audience: maintainer verification.
+
+This record holds reusable evidence for Firstmate's `/watch` safety and manifest guarantees.
+The user-facing workflow is owned by `.agents/skills/watch/SKILL.md`, and the exact mechanics, flags, limits, manifest schema, cleanup receipt, and exit codes are owned by `bin/fm-video-watch.sh --help`.
+
+## Upstream provenance
+
+Firstmate's implementation preserves and adapts useful mechanics from the MIT-licensed upstream skill `bradautomates/claude-video`.
+The audited local installation was:
+
+```text
+repository: https://github.com/bradautomates/claude-video.git
+installed revision: 755c157466738dda102c939158a0116b972925a3
+commit author: bradautomates <bradley_bonanno@outlook.com>
+commit date: 2026-04-24T17:22:51+10:00
+commit subject: Fix Windows compatibility: encoding, installer hints, interpreter name
+license: MIT, Copyright (c) 2026 Bradley Bonanno
+```
+
+Firstmate does not depend on that installed path or a floating branch at runtime.
+It also does not copy the Claude plugin, Codex plugin, hook, release, installer, or Whisper-key management surfaces.
+
+## Offline contract coverage
+
+`tests/fm-video-watch.test.sh` exercises the public wrapper with fake `yt-dlp`, `ffprobe`, and `ffmpeg` commands.
+The suite does not use network access and does not assert implementation-source bytes.
+
+Covered guarantees include:
+
+| Guarantee | Coverage |
+| --- | --- |
+| dependency checks are detect-only | `doctor` reports missing tools and the fake command log proves no installer command ran |
+| URL value safety | signed query strings, cookies, and redaction canaries are absent from manifests and diagnostics |
+| public-source rejection | unsafe schemes, playlist URLs, metadata-expanded playlists, live streams, authenticated/private videos, and DRM metadata are refused |
+| local-file boundary | local mode accepts only an explicit ordinary video file and refuses symlinks, non-video extensions, empty files, and oversized files |
+| transcript-first planning | caption metadata causes caption retrieval before media download, and matching transcript terms narrow selected ranges before frame extraction |
+| caption choice | requested language, manual captions, automatic captions, and English fallback are selected deterministically |
+| frame and token budgets | default caps prefer a compact frame set, hard caps clamp excessive requests, and manifest token estimates expose the resulting cost |
+| scene-plus-periodic evidence | fake scene-change output is combined with bounded periodic coverage and every selected frame records a timestamp and reason |
+| focused ranges | `--start` and `--end` produce absolute focused ranges, denser allowed caps, and focused start/end frame reasons |
+| manifest schema | schema, sanitized source identity, duration, chapters, transcript provenance, frames, warnings, token budget, and cleanup receipt are present |
+| malformed metadata | invalid JSON from `yt-dlp` or `ffprobe` is refused without leaking raw command output |
+| failure cleanup contract | extraction failures retain a quarantined owned directory only behind an opaque receipt |
+| exact cleanup | cleanup requires the matching receipt, rejects receipt mismatch, refuses unsafe targets, removes only an owned temp directory, and proves absence |
+| symlink/race resistance | symlinked cleanup roots and replaced ownership markers are refused |
+
+## Real public smoke
+
+The opt-in real smoke is intentionally impossible to trigger accidentally.
+It requires both `FM_VIDEO_WATCH_REAL_SMOKE=1` and `--i-understand-this-uses-network`:
+
+```sh
+FM_VIDEO_WATCH_REAL_SMOKE=1 bin/fm-video-watch.sh smoke \
+  --url 'https://www.youtube.com/watch?v=8ZgpAXe5V5w' \
+  --question 'Summarize the public acceptance case with compact evidence.' \
+  --max-frames 24 \
+  --i-understand-this-uses-network
+```
+
+The acceptance record must retain only sanitized facts: schema, sanitized source identity, transcript provenance and language, selected range count, frame count, timestamp-alignment spot checks, warnings, and successful cleanup proof.
+Downloaded media, captions, frames, signed URLs, raw command output, and local temp paths must not be committed.
+
+Verified on 2026-08-02 on macOS with `yt-dlp` 2026.06.09 and FFmpeg/ffprobe 8.0.1:
+
+```text
+schema: fm.video-watch.manifest.v1
+source: https://www.youtube.com/watch?v=8ZgpAXe5V5w
+duration_seconds: 3709.0
+transcript: captions:automatic, language en, selected_segment_count 116
+selected_ranges: 5
+frames: 24
+first frame timestamp: 05:25, reason periodic_coverage
+second frame timestamp: 05:27, reason scene_or_slide_change
+last frame timestamp: 25:58, reason periodic_coverage
+token estimate: frame 28800, transcript 2155, total 30955
+warnings: video is over 10 minutes; this is sparse sampled evidence, not every frame
+cleanup proof: owned evidence directory existed before cleanup, cleanup reported removed=true, and the owned directory was absent afterward
+```

--- a/docs/verification/video-watch.md
+++ b/docs/verification/video-watch.md
@@ -33,7 +33,11 @@ Covered guarantees include:
 | --- | --- |
 | dependency checks are detect-only | `doctor` reports missing tools and the fake command log proves no installer command ran |
 | URL value safety | signed query strings, cookies, and redaction canaries are absent from manifests and diagnostics |
-| public-source rejection | unsafe schemes, playlist URLs, metadata-expanded playlists, live streams, authenticated/private videos, and DRM metadata are refused |
+| public-source rejection | unsafe schemes, playlist URLs, credential- or signature-bearing query fields, metadata-expanded playlists, live streams, authenticated/private videos, and DRM metadata are refused |
+| fetch-target fidelity | the exact supplied public URL reaches `yt-dlp`, including identity-bearing query parameters, while the manifest description drops tracking fields and redacts every value that is not a known public identifier |
+| transient media bounds | a declared size above the byte ceiling is refused before any download command runs, the default ceiling clamps to free space instead of failing, raising it above the default requires proven free space, and values above 16 GiB are refused |
+| honest visual coverage | `media.visual_coverage` reports full, section, or none; focused runs request a bounded provider section, a section that the provider ignores is downgraded to full with a warning, and a refused acquisition still returns transcript, chapters, and a focused-pass recommendation |
+| section timestamp fidelity | frames extracted from a bounded section are seeked relative to the acquired media while manifest timestamps stay absolute |
 | local-file boundary | local mode accepts only an explicit ordinary video file and refuses symlinks, non-video extensions, empty files, and oversized files |
 | transcript-first planning | caption metadata causes caption retrieval before media download, and matching transcript terms narrow selected ranges before frame extraction |
 | caption choice | requested language, manual captions, automatic captions, and English fallback are selected deterministically |
@@ -62,7 +66,8 @@ FM_VIDEO_WATCH_REAL_SMOKE=1 bin/fm-video-watch.sh smoke \
 The acceptance record must retain only sanitized facts: schema, sanitized source identity, transcript provenance and language, selected range count, frame count, timestamp-alignment spot checks, warnings, and successful cleanup proof.
 Downloaded media, captions, frames, signed URLs, raw command output, and local temp paths must not be committed.
 
-Verified on 2026-08-02 on macOS with `yt-dlp` 2026.06.09 and FFmpeg/ffprobe 8.0.1:
+Verified on 2026-08-02 on macOS with `yt-dlp` 2026.06.09 and FFmpeg/ffprobe 8.0.1.
+This record predates the URL-identity and transient-media-ceiling change, so its `source:` line reflects the earlier display form and it carries no `media:` block; re-run the smoke to refresh it.
 
 ```text
 schema: fm.video-watch.manifest.v1

--- a/docs/verification/video-watch.md
+++ b/docs/verification/video-watch.md
@@ -36,7 +36,9 @@ Covered guarantees include:
 | public-source rejection | unsafe schemes, playlist URLs, credential- or signature-bearing query fields, metadata-expanded playlists, live streams, authenticated/private videos, and DRM metadata are refused |
 | fetch-target fidelity | the exact supplied public URL reaches `yt-dlp`, including identity-bearing query parameters, while the manifest description drops tracking fields and redacts every value that is not a known public identifier |
 | transient media bounds | a declared size above the byte ceiling is refused before any download command runs, the default ceiling clamps to free space instead of failing, raising it above the default requires proven free space, and values above 16 GiB are refused |
-| honest visual coverage | `media.visual_coverage` reports full, section, or none; focused runs request a bounded provider section, a section that the provider ignores is downgraded to full with a warning, and a refused acquisition still returns transcript, chapters, and a focused-pass recommendation |
+| honest visual coverage | `media.visual_coverage` reports full, section, or none; a section that the provider ignores is downgraded to full with a warning, and a refused acquisition still returns transcript, chapters, and a focused-pass recommendation |
+| cheaper bounded acquisition route | a focus range spanning most of the source takes the full download and says so in `media.acquisition_reason` and a warning, a small focus range still takes the bounded provider section, a declared size above the ceiling still forces the section as the only route, and the selected evidence range is identical either way |
+| trustworthy size estimates | the metadata call is scoped to the same format selector the download uses, so `media.declared_bytes` describes the bytes actually fetched; measured 0.34% and 0.17% off on the two acceptance sources |
 | section timestamp fidelity | frames extracted from a bounded section are seeked relative to the acquired media while manifest timestamps stay absolute |
 | local-file boundary | local mode accepts only an explicit ordinary video file and refuses symlinks, non-video extensions, empty files, and oversized files |
 | transcript-first planning | caption metadata causes caption retrieval before media download, and matching transcript terms narrow selected ranges before frame extraction |
@@ -67,7 +69,7 @@ FM_VIDEO_WATCH_REAL_SMOKE=1 bin/fm-video-watch.sh smoke \
 The acceptance record must retain only sanitized facts: schema, sanitized source identity, transcript provenance and language, selected range count, frame count, timestamp-alignment spot checks, warnings, and successful cleanup proof.
 Downloaded media, captions, frames, signed URLs, raw command output, and local temp paths must not be committed.
 
-Re-verified on 2026-08-02 on macOS with `yt-dlp` 2026.06.09 and FFmpeg/ffprobe 8.0.1, after the URL-identity, transient-media-ceiling, and whole-video extraction changes.
+Re-verified on 2026-08-02 on macOS with `yt-dlp` 2026.06.09 and FFmpeg/ffprobe 8.0.1, after the URL-identity, transient-media-ceiling, whole-video extraction, and acquisition-route changes.
 This record was produced by the exact `smoke` invocation above, so it reports `mode: real_public_smoke` and carries the `media:` block.
 
 ```text
@@ -79,20 +81,22 @@ title: L8 Principal's Agentic Engineering Setup (just copy him)
 duration_seconds: 3709.0 (1:01:49)
 transcript: captions:automatic, language en, selected_segment_count 214
 selected_ranges: 1, reason full_video, 0.0-3709.0
-media: acquired true, visual_coverage full, byte_ceiling 4294967296, declared_bytes 246117398, downloaded_bytes 164332937, acquired_range none
+media: acquired true, visual_coverage full, acquisition_reason no_focus_range_requested,
+       byte_ceiling 4294967296, declared_bytes 164619367, downloaded_bytes 164332937, acquired_range none
+declared-size accuracy: 164619367 estimated against 164332937 actual, 0.17% high
 frames: 36, reasons periodic_coverage and scene_or_slide_change
 first frame timestamp: 00:00
 last frame timestamp: 1:01:49 (3708.94s, inside the last decodable frame)
 token estimate: frame 43200, transcript 3996, total 47196
 warnings: transcript evidence was truncated to the bounded manifest budget; video is over 10 minutes, this is sparse sampled evidence, not every frame
-wall clock: 7m32s including download, caption retrieval, scene detection, and 36 extractions
+wall clock: 70s including download, caption retrieval, scene detection, and 36 extractions
 cleanup proof: cleanup by exact receipt reported removed=true and the owned directory was absent afterward
 ```
 
 ## Whole-video versus focused acceptance
 
-This pair is ordinary `prepare` evidence, not the opt-in smoke path.
-Both runs used `bin/fm-video-watch.sh prepare '<url>' --question 'Summarize the video'`, the second adding `--start 00:00 --end 09:19`.
+These three runs are ordinary `prepare` evidence, not the opt-in smoke path.
+All used `bin/fm-video-watch.sh prepare '<url>' --question 'Summarize the video'`, the second and third adding a focus range.
 
 ```text
 schema: fm.video-watch.manifest.v1
@@ -100,25 +104,37 @@ mode: prepare
 source: https://www.youtube.com/watch?v=9WOpQqSO5aA
 title: Real AI Agent Stack: Harness -> Loop -> Graph
 duration_seconds: 559.0 (09:19), chapters 8
-transcript: captions:automatic, language en, selected_segment_count 218 (both runs)
+transcript: captions:automatic, language en, selected_segment_count 218
+declared-size accuracy: 19939872 estimated against 20008710 actual, 0.34% low
 
 default whole-video run, no focus range:
   selected_ranges: 1, reason full_video, 0.0-559.0
-  media: acquired true, visual_coverage full, declared_bytes 31304766, downloaded_bytes 20008710
+  media: visual_coverage full, acquisition_reason no_focus_range_requested, downloaded_bytes 20008710
   frames: 20, first 00:00, last 09:18
   warnings: transcript evidence was truncated to the bounded manifest budget
-  wall clock: 26s
+  wall clock: 18s
   result: completed, this is the path that previously failed
 
-focused run, --start 00:00 --end 09:19 over the same source:
+wide focus range, --start 00:00 --end 09:19, the whole source:
   selected_ranges: 1, reason focused_range, 0.0-559.0
-  media: acquired true, visual_coverage section, acquired_range 0.0-559.0, downloaded_bytes 32510301
-  frames: 20, first 00:00, last 09:10, reasons include focused_range_start and focused_range_end
-  warnings: visual evidence covers only the requested section 00:00-09:19, not the whole video
-  wall clock: 5m22s, the provider section is re-encoded because cuts are forced to keyframes
-  result: completed, and its frame count and coverage match the whole-video run
+  media: visual_coverage full, acquisition_reason the_full_media_is_projected_cheaper_than_a_re_encoded_section,
+         downloaded_bytes 20008710, acquired_range none
+  frames: 20, first 00:00, last 09:18
+  warnings: the requested focus range covers enough of the source that downloading the whole media is
+            cheaper than a re-encoded provider section, the selected evidence range is unchanged
+  wall clock: 18s
+  result: completed; the same request cost 5m22s and 32510301 bytes before the route choice landed
 
-cleanup proof: both runs were removed by their exact receipts, each reporting removed=true
+narrow focus range, --start 02:00 --end 03:00, 11% of the source:
+  selected_ranges: 1, reason focused_range, 120.0-180.0
+  media: visual_coverage section, acquisition_reason a_bounded_section_is_projected_cheaper_than_the_full_media,
+         downloaded_bytes 3603554, acquired_range 120.0-180.0
+  frames: 18, first 02:00, last 03:00
+  warnings: visual evidence covers only the requested section 02:00-03:00, not the whole video
+  wall clock: 16s
+  result: completed; the bounded section still runs where it actually saves, 18% of the full download
+
+cleanup proof: every run was removed by its exact receipt, each reporting removed=true
 ```
 
 ## Whole-video extraction defect and correction
@@ -146,5 +162,20 @@ mocked suite with the strengthened stub ffmpeg, 120s fixture
 ```
 
 The correction is `tail_seek_limit`, which derives the last safely seekable timestamp from the probed duration and `avg_frame_rate` rather than from a fixed margin, so a low-frame-rate source is handled too. Whole-video coverage, the duration-aware frame budget, and truthful sampling language are unchanged. `tests/fm-video-watch.test.sh` now covers this two ways: the stub `ffmpeg` refuses a seek at or past the last frame, and a real-`ffmpeg` regression test runs the default whole-video path end to end over a synthesized clip.
+
+## Acquisition route choice
+
+A bounded provider section is re-encoded rather than stream-copied, because `--force-keyframes-at-cuts` is required for the cut to land where the caller asked.
+The earlier acceptance record measured that cost on a 559-second source: a section spanning the whole video cost 32510301 bytes and 5m22s against 20008710 bytes and 26s for the same video downloaded whole, so the mechanism meant to bound resources was inflating them.
+
+The route is now chosen from the projected byte cost rather than taken unconditionally:
+
+- the projected section cost is `span / duration * 1.7` of the full download, where `1.7` is the measured re-encode overhead above;
+- a section is requested when that projection lands at or under 75% of the full download, which works out to spans below roughly 44% of the source;
+- a declared size above the transient byte ceiling still forces the section, because it is then the only route to any visual evidence;
+- an unknown duration still honors the focus range, because nothing can be projected.
+
+The estimate is trustworthy because the metadata call now uses the same format selector as the download, so `declared_bytes` describes the bytes actually fetched instead of the best-quality formats.
+The focus range itself is never altered by this choice: `selected_ranges` is identical on both routes, and taking the full media only ever widens what was acquired, which `media.visual_coverage` and `media.acquisition_reason` both state.
 
 resolved: [key=01KZ1NPWRMTEZXYFDDXT1XT9N4] captain approved refreshed public proof and whole-video extraction correction

--- a/docs/verification/video-watch.md
+++ b/docs/verification/video-watch.md
@@ -46,7 +46,9 @@ Covered guarantees include:
 | frame and token budgets | default caps prefer a compact frame set, hard caps clamp excessive requests, and manifest token estimates expose the resulting cost |
 | scene-plus-periodic evidence | fake scene-change output is combined with bounded periodic coverage and every selected frame records a timestamp and reason |
 | whole-video extraction | the stub `ffmpeg` refuses a seek at or past the last frame, so the mocked suite can no longer hide this class; additionally, when real `ffmpeg` and `ffprobe` are present the default no-focus-range path runs end to end over a synthesized clip, every planned frame lands on disk, the final frame stays inside the last decodable frame, and cleanup proves absence, and that one case is skipped when those tools are absent |
-| optional enrichment stays optional | scene-change detection that fails or does not finish degrades to periodic coverage with a warning instead of aborting the manifest |
+| optional enrichment stays optional | scene-change detection that fails or does not finish degrades to periodic coverage with a warning, and caption retrieval that fails or does not finish degrades to a warning, instead of aborting the manifest |
+| source-timeline range fidelity | a source that advertises no duration still honors `--start`/`--end` after a bounded section download: the focus range, the acquisition reason, and a duration disclosed as a lower bound all stay in source coordinates |
+| documented exit classes | a local copy that would exhaust usable free space is refused before it starts, and any unexpected failure is reported as exit 5 by exception class alone rather than escaping as a traceback that names local paths |
 | focused ranges | `--start` and `--end` produce absolute focused ranges, denser allowed caps, and focused start/end frame reasons |
 | manifest schema | schema, sanitized source identity, duration, chapters, transcript provenance, frames, warnings, token budget, and cleanup receipt are present |
 | malformed metadata | invalid JSON from `yt-dlp` or `ffprobe` is refused without leaking raw command output |

--- a/docs/verification/video-watch.md
+++ b/docs/verification/video-watch.md
@@ -43,10 +43,12 @@ Covered guarantees include:
 | caption choice | requested language, manual captions, automatic captions, and English fallback are selected deterministically |
 | frame and token budgets | default caps prefer a compact frame set, hard caps clamp excessive requests, and manifest token estimates expose the resulting cost |
 | scene-plus-periodic evidence | fake scene-change output is combined with bounded periodic coverage and every selected frame records a timestamp and reason |
+| whole-video extraction | the stub `ffmpeg` refuses a seek at or past the last frame, so the mocked suite can no longer hide this class; additionally, when real `ffmpeg` and `ffprobe` are present the default no-focus-range path runs end to end over a synthesized clip, every planned frame lands on disk, the final frame stays inside the last decodable frame, and cleanup proves absence, and that one case is skipped when those tools are absent |
+| optional enrichment stays optional | scene-change detection that fails or does not finish degrades to periodic coverage with a warning instead of aborting the manifest |
 | focused ranges | `--start` and `--end` produce absolute focused ranges, denser allowed caps, and focused start/end frame reasons |
 | manifest schema | schema, sanitized source identity, duration, chapters, transcript provenance, frames, warnings, token budget, and cleanup receipt are present |
 | malformed metadata | invalid JSON from `yt-dlp` or `ffprobe` is refused without leaking raw command output |
-| failure cleanup contract | extraction failures retain a quarantined owned directory only behind an opaque receipt |
+| failure cleanup contract | extraction failures retain a quarantined owned directory only behind an opaque receipt, and that receipt is proven to remove it; every refusal path in the suite hands its receipt back so a run leaves no owned directory in the system temp directory |
 | exact cleanup | cleanup requires the matching receipt, rejects receipt mismatch, refuses unsafe targets, removes only an owned temp directory, and proves absence |
 | symlink/race resistance | symlinked cleanup roots and replaced ownership markers are refused |
 
@@ -58,28 +60,91 @@ It requires both `FM_VIDEO_WATCH_REAL_SMOKE=1` and `--i-understand-this-uses-net
 ```sh
 FM_VIDEO_WATCH_REAL_SMOKE=1 bin/fm-video-watch.sh smoke \
   --url 'https://www.youtube.com/watch?v=8ZgpAXe5V5w' \
-  --question 'Summarize the public acceptance case with compact evidence.' \
-  --max-frames 24 \
+  --question 'Summarize the video' \
   --i-understand-this-uses-network
 ```
 
 The acceptance record must retain only sanitized facts: schema, sanitized source identity, transcript provenance and language, selected range count, frame count, timestamp-alignment spot checks, warnings, and successful cleanup proof.
 Downloaded media, captions, frames, signed URLs, raw command output, and local temp paths must not be committed.
 
-Verified on 2026-08-02 on macOS with `yt-dlp` 2026.06.09 and FFmpeg/ffprobe 8.0.1.
-This record predates the URL-identity and transient-media-ceiling change, so its `source:` line reflects the earlier display form and it carries no `media:` block; re-run the smoke to refresh it.
+Re-verified on 2026-08-02 on macOS with `yt-dlp` 2026.06.09 and FFmpeg/ffprobe 8.0.1, after the URL-identity, transient-media-ceiling, and whole-video extraction changes.
+This record was produced by the exact `smoke` invocation above, so it reports `mode: real_public_smoke` and carries the `media:` block.
 
 ```text
 schema: fm.video-watch.manifest.v1
+mode: real_public_smoke
 source: https://www.youtube.com/watch?v=8ZgpAXe5V5w
-duration_seconds: 3709.0
-transcript: captions:automatic, language en, selected_segment_count 116
-selected_ranges: 5
-frames: 24
-first frame timestamp: 05:25, reason periodic_coverage
-second frame timestamp: 05:27, reason scene_or_slide_change
-last frame timestamp: 25:58, reason periodic_coverage
-token estimate: frame 28800, transcript 2155, total 30955
-warnings: video is over 10 minutes; this is sparse sampled evidence, not every frame
-cleanup proof: owned evidence directory existed before cleanup, cleanup reported removed=true, and the owned directory was absent afterward
+source identity: host www.youtube.com, path /watch, query_keys [v]
+title: L8 Principal's Agentic Engineering Setup (just copy him)
+duration_seconds: 3709.0 (1:01:49)
+transcript: captions:automatic, language en, selected_segment_count 214
+selected_ranges: 1, reason full_video, 0.0-3709.0
+media: acquired true, visual_coverage full, byte_ceiling 4294967296, declared_bytes 246117398, downloaded_bytes 164332937, acquired_range none
+frames: 36, reasons periodic_coverage and scene_or_slide_change
+first frame timestamp: 00:00
+last frame timestamp: 1:01:49 (3708.94s, inside the last decodable frame)
+token estimate: frame 43200, transcript 3996, total 47196
+warnings: transcript evidence was truncated to the bounded manifest budget; video is over 10 minutes, this is sparse sampled evidence, not every frame
+wall clock: 7m32s including download, caption retrieval, scene detection, and 36 extractions
+cleanup proof: cleanup by exact receipt reported removed=true and the owned directory was absent afterward
 ```
+
+## Whole-video versus focused acceptance
+
+This pair is ordinary `prepare` evidence, not the opt-in smoke path.
+Both runs used `bin/fm-video-watch.sh prepare '<url>' --question 'Summarize the video'`, the second adding `--start 00:00 --end 09:19`.
+
+```text
+schema: fm.video-watch.manifest.v1
+mode: prepare
+source: https://www.youtube.com/watch?v=9WOpQqSO5aA
+title: Real AI Agent Stack: Harness -> Loop -> Graph
+duration_seconds: 559.0 (09:19), chapters 8
+transcript: captions:automatic, language en, selected_segment_count 218 (both runs)
+
+default whole-video run, no focus range:
+  selected_ranges: 1, reason full_video, 0.0-559.0
+  media: acquired true, visual_coverage full, declared_bytes 31304766, downloaded_bytes 20008710
+  frames: 20, first 00:00, last 09:18
+  warnings: transcript evidence was truncated to the bounded manifest budget
+  wall clock: 26s
+  result: completed, this is the path that previously failed
+
+focused run, --start 00:00 --end 09:19 over the same source:
+  selected_ranges: 1, reason focused_range, 0.0-559.0
+  media: acquired true, visual_coverage section, acquired_range 0.0-559.0, downloaded_bytes 32510301
+  frames: 20, first 00:00, last 09:10, reasons include focused_range_start and focused_range_end
+  warnings: visual evidence covers only the requested section 00:00-09:19, not the whole video
+  wall clock: 5m22s, the provider section is re-encoded because cuts are forced to keyframes
+  result: completed, and its frame count and coverage match the whole-video run
+
+cleanup proof: both runs were removed by their exact receipts, each reporting removed=true
+```
+
+## Whole-video extraction defect and correction
+
+The captain reported that the default no-focus-range preparation failed during frame extraction on `https://www.youtube.com/watch?v=9WOpQqSO5aA` while twelve explicit focused ranges over the same timeline succeeded.
+
+- Trigger: `periodic_timestamps` emits a sample at exactly the range end, and on the default `full_video` path that end is the video duration.
+- Masking condition: a focused range usually ends before the media does, so its samples stay inside the last decodable frame; only a range that reaches the end of the media hits the failure.
+- Symptom: `ffmpeg -ss <duration>` exits non-zero and writes no file, and `extract_frame` treated that as fatal, so `prepare` exited 5 after the download had already completed.
+
+Counterfactuals, run through the local-file path on synthesized clips so no network is involved:
+
+```text
+12s at 25fps, default frame budget
+  implementation at ad44376 (before the correction): exit 5, "frame extraction failed"
+  implementation at b52f31c (with tail_seek_limit): exit 0, 18 frames, last frame 11.5s of 12.0s
+
+6s at 10fps with --max-frames 8 --resolution 128, the shape the regression test ships
+  implementation at ad44376: exit 5, "frame extraction failed"
+  current implementation: exit 0, every planned frame on disk, final frame inside the media
+
+mocked suite with the strengthened stub ffmpeg, 120s fixture
+  implementation at ad44376: exit 5
+  current implementation: exit 0, 21 frames, last frame 119.0
+```
+
+The correction is `tail_seek_limit`, which derives the last safely seekable timestamp from the probed duration and `avg_frame_rate` rather than from a fixed margin, so a low-frame-rate source is handled too. Whole-video coverage, the duration-aware frame budget, and truthful sampling language are unchanged. `tests/fm-video-watch.test.sh` now covers this two ways: the stub `ffmpeg` refuses a seek at or past the last frame, and a real-`ffmpeg` regression test runs the default whole-video path end to end over a synthesized clip.
+
+resolved: [key=01KZ1NPWRMTEZXYFDDXT1XT9N4] captain approved refreshed public proof and whole-video extraction correction

--- a/docs/verification/video-watch.md
+++ b/docs/verification/video-watch.md
@@ -3,7 +3,7 @@
 Audience: maintainer verification.
 
 This record holds reusable evidence for Firstmate's `/watch` safety and manifest guarantees.
-The user-facing workflow is owned by `.agents/skills/watch/SKILL.md`, and the exact mechanics, flags, limits, manifest schema, cleanup receipt, and exit codes are owned by `bin/fm-video-watch.sh --help`.
+The user-facing workflow is owned by `.agents/skills/watch/SKILL.md`, the exact subcommands, flags, and limits are owned by `bin/fm-video-watch.sh --help`, and the media, coverage, cleanup receipt, and exit-code contract is owned by that script's header comment.
 
 ## Upstream provenance
 
@@ -151,15 +151,15 @@ Counterfactuals, run through the local-file path on synthesized clips so no netw
 
 ```text
 12s at 25fps, default frame budget
-  implementation at ad44376 (before the correction): exit 5, "frame extraction failed"
-  implementation at b52f31c (with tail_seek_limit): exit 0, 18 frames, last frame 11.5s of 12.0s
+  before the correction: exit 5, "frame extraction failed"
+  with tail_seek_limit: exit 0, 18 frames, last frame 11.5s of 12.0s
 
 6s at 10fps with --max-frames 8 --resolution 128, the shape the regression test ships
-  implementation at ad44376: exit 5, "frame extraction failed"
+  before the correction: exit 5, "frame extraction failed"
   current implementation: exit 0, every planned frame on disk, final frame inside the media
 
 mocked suite with the strengthened stub ffmpeg, 120s fixture
-  implementation at ad44376: exit 5
+  before the correction: exit 5
   current implementation: exit 0, 21 frames, last frame 119.0
 ```
 
@@ -179,5 +179,3 @@ The route is now chosen from the projected byte cost rather than taken unconditi
 
 The estimate is trustworthy because the metadata call now uses the same format selector as the download, so `declared_bytes` describes the bytes actually fetched instead of the best-quality formats.
 The focus range itself is never altered by this choice: `selected_ranges` is identical on both routes, and taking the full media only ever widens what was acquired, which `media.visual_coverage` and `media.acquisition_reason` both state.
-
-resolved: [key=01KZ1NPWRMTEZXYFDDXT1XT9N4] captain approved refreshed public proof and whole-video extraction correction

--- a/tests/fm-video-watch.test.sh
+++ b/tests/fm-video-watch.test.sh
@@ -352,6 +352,94 @@ test_section_download_keeps_absolute_timestamps() {
   pass "bounded section downloads keep manifest timestamps absolute and coverage honest"
 }
 
+test_section_download_without_advertised_duration_keeps_the_focus_range() {
+  local dir="$TMP_ROOT/section-no-duration" out err fakebin metadata receipt rc
+  mkdir -p "$dir"
+  out="$dir/out.json"
+  err="$dir/err"
+  metadata='{"id":"abc","title":"No duration","availability":"public"}'
+  fakebin=$(make_fakebin "$dir")
+  : > "$dir/commands.log"
+  set +e
+  FM_FAKE_COMMAND_LOG="$dir/commands.log" FM_FAKE_YTDLP_METADATA="$metadata" FM_FAKE_MEDIA_DURATION=10 \
+    FM_FAKE_FFPROBE_JSON='{"format":{"duration":"10.0","size":"1000"},"streams":[{"codec_type":"video","width":1280,"height":720,"codec_name":"h264"}]}' \
+    PATH="$fakebin:$BASE_PATH" "$WATCH" prepare 'https://video.example/watch/one' \
+    --start 00:10 --end 00:20 --max-frames 6 > "$out" 2> "$err"
+  rc=$?
+  set +e
+  expect_code 0 "$rc" "a bounded section download of a source with no advertised duration was rejected"
+  [ "$(json_get "$out" "data['media']['acquisition_reason']")" = 'source_duration_unknown_so_the_focus_range_bounds_acquisition' ] \
+    || fail "the unknown-duration acquisition route was not recorded"
+  [ "$(json_get "$out" "data['selected_ranges'][0]['reason']")" = 'focused_range' ] || fail "the focus range was lost"
+  [ "$(json_get "$out" "data['selected_ranges'][0]['start_seconds']")" = '10.0' ] || fail "the focus range start moved"
+  [ "$(json_get "$out" "data['selected_ranges'][0]['end_seconds']")" = '20.0' ] || fail "the focus range end moved"
+  [ "$(json_get "$out" "data['duration_seconds']")" = '20.0' ] \
+    || fail "duration was reported in acquired-media coordinates instead of source coordinates"
+  assert_contains "$(json_get "$out" "' '.join(data['warnings'])")" 'lower bound' \
+    "the derived source duration was not disclosed as a lower bound"
+  receipt=$(json_get "$out" "data['cleanup_receipt']")
+  PATH="$(dirname "$REAL_PYTHON"):$BASE_PATH" "$WATCH" cleanup "$receipt" >/dev/null
+  pass "a section download of a source with no advertised duration keeps source-timeline focus ranges"
+}
+
+test_optional_enrichment_and_unexpected_failures_stay_in_contract() {
+  "$REAL_PYTHON" - "$ROOT/bin/fm-video-watch-impl.py" <<'PY' || fail "optional caption, free-space, and exit-class contracts regressed"
+import contextlib, importlib.util, io, sys, tempfile
+from collections import namedtuple
+from pathlib import Path
+
+spec = importlib.util.spec_from_file_location("fmvw", sys.argv[1])
+mod = importlib.util.module_from_spec(spec)
+sys.modules["fmvw"] = mod
+spec.loader.exec_module(mod)
+
+work = Path(tempfile.mkdtemp(prefix="fm-video-watch-unit-"))
+
+
+def _timeout(*_a, **_k):
+    raise mod.WatchError("command timed out after 180s: yt-dlp", 5)
+
+
+mod.run_quiet = _timeout
+warnings = []
+assert mod.retrieve_captions("https://video.example/watch/one", work, "en", warnings) is None
+assert warnings and "caption retrieval did not finish" in warnings[0], warnings
+
+usage = namedtuple("usage", "total used free")
+mod.shutil.disk_usage = lambda _path: usage(0, 0, mod.FREE_SPACE_MARGIN_BYTES + 1000)
+mod.require_free_space(work, 1000)
+try:
+    mod.require_free_space(work, 1001)
+except mod.WatchError as exc:
+    assert exc.code == 5, exc.code
+    assert "no usable local free space" in str(exc), str(exc)
+else:
+    raise AssertionError("a local copy larger than the usable free space must be refused")
+
+
+def _boom(_args):
+    raise OSError(28, "No space left on device", "/private/captain/secret-holiday.mp4")
+
+
+mod.cmd_doctor = _boom
+sys.modules["fmvw"].cmd_doctor = _boom
+parser = mod.parser()
+args = parser.parse_args(["doctor"])
+args.func = _boom
+mod.parser = lambda: type("P", (), {"parse_args": staticmethod(lambda _argv=None: args)})()
+captured = io.StringIO()
+with contextlib.redirect_stderr(captured):
+    code = mod.main([])
+assert code == 5, code
+assert "secret-holiday" not in captured.getvalue(), captured.getvalue()
+assert "OSError" in captured.getvalue(), captured.getvalue()
+
+mod.shutil.rmtree(work, ignore_errors=True)
+assert not work.exists(), work
+PY
+  pass "optional caption failure degrades and unexpected failures map onto the documented exit classes"
+}
+
 test_wide_focus_range_takes_the_cheaper_full_download() {
   local dir="$TMP_ROOT/wide-focus" out err fakebin metadata commands receipt
   mkdir -p "$dir"
@@ -661,6 +749,8 @@ test_metadata_rejections
 test_prepare_transcript_first_and_manifest_contract
 test_focused_range_caps_and_language_choice
 test_section_download_keeps_absolute_timestamps
+test_section_download_without_advertised_duration_keeps_the_focus_range
+test_optional_enrichment_and_unexpected_failures_stay_in_contract
 test_wide_focus_range_takes_the_cheaper_full_download
 test_media_ceiling_refuses_before_download
 test_media_ceiling_override_requires_free_space

--- a/tests/fm-video-watch.test.sh
+++ b/tests/fm-video-watch.test.sh
@@ -352,6 +352,33 @@ test_section_download_keeps_absolute_timestamps() {
   pass "bounded section downloads keep manifest timestamps absolute and coverage honest"
 }
 
+test_wide_focus_range_takes_the_cheaper_full_download() {
+  local dir="$TMP_ROOT/wide-focus" out err fakebin metadata commands receipt
+  mkdir -p "$dir"
+  out="$dir/out.json"
+  err="$dir/err"
+  metadata='{"id":"abc","title":"Wide focus","duration":120,"availability":"public","filesize_approx":20000000,"subtitles":{"en":[{"ext":"vtt"}]}}'
+  fakebin=$(make_fakebin "$dir")
+  : > "$dir/commands.log"
+  FM_FAKE_COMMAND_LOG="$dir/commands.log" FM_FAKE_YTDLP_METADATA="$metadata" PATH="$fakebin:$BASE_PATH" \
+    "$WATCH" prepare 'https://video.example/watch/one' --question 'read the text' \
+    --start 00:00 --end 02:00 > "$out" 2> "$err"
+  commands=$(cat "$dir/commands.log")
+  assert_not_contains "$commands" '--download-sections' "a whole-span focus range still paid for a re-encoded section"
+  [ "$(json_get "$out" "data['media']['visual_coverage']")" = 'full' ] || fail "the cheaper full route did not report full coverage"
+  [ "$(json_get "$out" "data['media']['acquisition_reason']")" = 'the_full_media_is_projected_cheaper_than_a_re_encoded_section' ] \
+    || fail "the acquisition route reason was not recorded"
+  [ "$(json_get "$out" "data['selected_ranges'][0]['reason']")" = 'focused_range' ] || fail "the focus range was lost by the full route"
+  [ "$(json_get "$out" "data['selected_ranges'][0]['end_seconds']")" = '120.0' ] || fail "the focus range span changed"
+  assert_contains "$(json_get "$out" "' '.join(data['warnings'])")" 'cheaper than a re-encoded provider section' \
+    "the route choice was not disclosed"
+  assert_contains "$(cat "$dir/commands.log")" '--dump-single-json' "metadata was not gathered before acquisition"
+  assert_contains "$commands" 'bv*[height<=720]' "the declared size was not scoped to the format actually downloaded"
+  receipt=$(json_get "$out" "data['cleanup_receipt']")
+  PATH="$(dirname "$REAL_PYTHON"):$BASE_PATH" "$WATCH" cleanup "$receipt" >/dev/null
+  pass "a focus range that covers most of the source takes the cheaper full download without losing the range"
+}
+
 test_media_ceiling_refuses_before_download() {
   local dir="$TMP_ROOT/ceiling" out err fakebin metadata receipt commands
   mkdir -p "$dir"
@@ -417,6 +444,16 @@ assert mod.tail_seek_limit(10.0, 25.0) == 9.5, mod.tail_seek_limit(10.0, 25.0)
 assert mod.tail_seek_limit(10.0, 1.0) == 8.0, mod.tail_seek_limit(10.0, 1.0)
 assert mod.tail_seek_limit(10.0, 0.0) == 9.0, mod.tail_seek_limit(10.0, 0.0)
 assert mod.tail_seek_limit(0.2, 25.0) == 0.0, mod.tail_seek_limit(0.2, 25.0)
+
+GiB = 1024 ** 3
+assert mod.choose_acquisition(None, 120.0, 1000, 4 * GiB)[0] is None
+assert mod.choose_acquisition((0.0, 10.0), 120.0, 20_000_000, 4 * GiB)[0] == (0.0, 10.0)
+assert mod.choose_acquisition((0.0, 120.0), 120.0, 20_000_000, 4 * GiB)[0] is None
+assert mod.choose_acquisition((0.0, 60.0), 120.0, 20_000_000, 4 * GiB)[0] is None
+assert mod.choose_acquisition((0.0, 30.0), 120.0, None, 4 * GiB)[0] == (0.0, 30.0)
+assert mod.choose_acquisition((0.0, 120.0), 0.0, None, 4 * GiB)[0] == (0.0, 120.0)
+assert mod.choose_acquisition((0.0, 120.0), 120.0, 9 * GiB, 4 * GiB)[0] == (0.0, 120.0)
+assert mod.projected_section_share(10.0, 0.0) is None
 
 assert mod.scene_timestamp_timeout(60.0) == 300, mod.scene_timestamp_timeout(60.0)
 assert mod.scene_timestamp_timeout(3709.0) == 900, mod.scene_timestamp_timeout(3709.0)
@@ -624,6 +661,7 @@ test_metadata_rejections
 test_prepare_transcript_first_and_manifest_contract
 test_focused_range_caps_and_language_choice
 test_section_download_keeps_absolute_timestamps
+test_wide_focus_range_takes_the_cheaper_full_download
 test_media_ceiling_refuses_before_download
 test_media_ceiling_override_requires_free_space
 test_local_file_refusals

--- a/tests/fm-video-watch.test.sh
+++ b/tests/fm-video-watch.test.sh
@@ -92,6 +92,22 @@ if [ "${FM_FAKE_FFMPEG_EXTRACT_FAIL:-0}" = 1 ]; then
   printf 'extract failed with secret %s\n' "${FM_FAKE_SECRET:-SECRET_SHOULD_NOT_LEAK}" >&2
   exit 1
 fi
+# Real ffmpeg exits non-zero and writes nothing when -ss lands at or past the
+# last decodable frame, so the stub must refuse it too.
+seek=
+prev=
+for arg in "$@"; do
+  if [ "$prev" = -ss ]; then
+    seek=$arg
+  fi
+  prev=$arg
+done
+if [ -n "$seek" ]; then
+  awk -v ss="$seek" -v dur="${FM_FAKE_MEDIA_DURATION:-120}" 'BEGIN { exit (ss > dur - 0.04) ? 0 : 1 }' && {
+    printf 'Output file does not contain any stream\n' >&2
+    exit 234
+  }
+fi
 out=${@: -1}
 mkdir -p "$(dirname "$out")"
 printf 'jpg\n' > "$out"
@@ -120,6 +136,18 @@ payload = receipt.split('.', 1)[1]
 payload += '=' * (-len(payload) % 4)
 print(json.loads(base64.urlsafe_b64decode(payload))['root'])
 PY
+}
+
+# A refused or failed prepare deliberately retains its owned evidence directory
+# behind the receipt it prints on stderr. Tests must hand that receipt back so a
+# suite run leaves nothing in the system temp directory.
+cleanup_retained() {
+  local err=$1 receipt
+  [ -f "$err" ] || return 0
+  receipt=$(grep -o 'fmvw1\.[A-Za-z0-9_-]*' "$err" | head -1)
+  [ -n "$receipt" ] || return 0
+  PATH="$(dirname "$REAL_PYTHON"):$BASE_PATH" "$WATCH" cleanup "$receipt" >/dev/null 2>&1
+  printf '%s\n' "$receipt"
 }
 
 mutate_receipt_nonce() {
@@ -235,6 +263,7 @@ test_metadata_rejections() {
     rc=$?
     set +e
     expect_code 4 "$rc" "metadata rejection for $case"
+    cleanup_retained "$dir/err" >/dev/null
   done
   pass "playlist, live, authenticated, and DRM metadata are rejected"
 }
@@ -304,7 +333,7 @@ test_section_download_keeps_absolute_timestamps() {
   err="$dir/err"
   fakebin=$(make_fakebin "$dir")
   : > "$dir/commands.log"
-  FM_FAKE_COMMAND_LOG="$dir/commands.log" \
+  FM_FAKE_COMMAND_LOG="$dir/commands.log" FM_FAKE_MEDIA_DURATION=10 \
     FM_FAKE_FFPROBE_JSON='{"format":{"duration":"10.0","size":"1000"},"streams":[{"codec_type":"video","width":1280,"height":720,"codec_name":"h264"}]}' \
     PATH="$fakebin:$BASE_PATH" "$WATCH" prepare 'https://video.example/watch/one' --question 'read the text' \
     --start 00:10 --end 00:20 --max-frames 6 > "$out" 2> "$err"
@@ -363,6 +392,7 @@ test_media_ceiling_override_requires_free_space() {
   expect_code 2 "$rc" "a media ceiling above the 16 GiB hard cap is refused"
   output=$(cat "$dir/out" "$dir/err")
   assert_contains "$output" 'hard cap for transient public media' "hard-cap refusal did not name the bound"
+  cleanup_retained "$dir/err" >/dev/null
 
   "$REAL_PYTHON" - "$ROOT/bin/fm-video-watch-impl.py" <<'PY' || fail "free-space preflight does not gate only the override"
 import importlib.util, shutil, sys, tempfile
@@ -387,6 +417,19 @@ assert mod.tail_seek_limit(10.0, 25.0) == 9.5, mod.tail_seek_limit(10.0, 25.0)
 assert mod.tail_seek_limit(10.0, 1.0) == 8.0, mod.tail_seek_limit(10.0, 1.0)
 assert mod.tail_seek_limit(10.0, 0.0) == 9.0, mod.tail_seek_limit(10.0, 0.0)
 assert mod.tail_seek_limit(0.2, 25.0) == 0.0, mod.tail_seek_limit(0.2, 25.0)
+
+assert mod.scene_timestamp_timeout(60.0) == 300, mod.scene_timestamp_timeout(60.0)
+assert mod.scene_timestamp_timeout(3709.0) == 900, mod.scene_timestamp_timeout(3709.0)
+
+
+def _refuse(*_a, **_k):
+    raise mod.WatchError("command timed out after 300s: ffmpeg", 5)
+
+
+mod.run_quiet = _refuse
+scenes, scene_warnings = mod.scene_timestamps(Path("missing.mp4"), [mod.Range(0.0, 3709.0, "full_video")])
+assert scenes == [], scenes
+assert scene_warnings and "periodic coverage was still used" in scene_warnings[0], scene_warnings
 
 try:
     mod.resolve_media_ceiling(8 * 1024 * 1024 * 1024, work, [])
@@ -413,17 +456,20 @@ test_local_file_refusals() {
   rc=$?
   set +e
   expect_code 4 "$rc" "local symlink is refused"
+  cleanup_retained "$dir/link.err" >/dev/null
   set +e
   FM_FAKE_COMMAND_LOG="$dir/commands.log" PATH="$fakebin:$BASE_PATH" "$WATCH" prepare "$file" --max-local-bytes 2 --question 'what happens?' > "$dir/size.out" 2> "$dir/size.err"
   rc=$?
   set +e
   expect_code 4 "$rc" "oversized local file is refused"
+  cleanup_retained "$dir/size.err" >/dev/null
   printf 'video\n' > "$dir/video.txt"
   set +e
   FM_FAKE_COMMAND_LOG="$dir/commands.log" PATH="$fakebin:$BASE_PATH" "$WATCH" prepare "$dir/video.txt" --question 'what happens?' > "$dir/type.out" 2> "$dir/type.err"
   rc=$?
   set +e
   expect_code 4 "$rc" "unsupported local extension is refused"
+  cleanup_retained "$dir/type.err" >/dev/null
   out="$dir/local-success.json"
   FM_FAKE_COMMAND_LOG="$dir/commands.log" PATH="$fakebin:$BASE_PATH" "$WATCH" prepare "$file" --question 'what happens?' > "$out" 2> "$dir/local-success.err"
   [ "$(json_get "$out" "data['source']['kind']")" = 'local_file' ] || fail "local success did not record local source kind"
@@ -436,7 +482,7 @@ test_local_file_refusals() {
 }
 
 test_malformed_metadata_and_failure_receipt_are_safe() {
-  local dir="$TMP_ROOT/malformed" fakebin rc output
+  local dir="$TMP_ROOT/malformed" fakebin rc output receipt
   mkdir -p "$dir"
   fakebin=$(make_fakebin "$dir")
   : > "$dir/commands.log"
@@ -448,6 +494,7 @@ test_malformed_metadata_and_failure_receipt_are_safe() {
   expect_code 5 "$rc" "malformed yt-dlp metadata is refused"
   output=$(cat "$dir/out" "$dir/err")
   assert_not_contains "$output" 'SECRET_SHOULD_NOT_LEAK' "malformed metadata diagnostic leaked URL canary"
+  cleanup_retained "$dir/err" >/dev/null
 
   dir="$TMP_ROOT/extract-fail"
   mkdir -p "$dir"
@@ -462,7 +509,10 @@ test_malformed_metadata_and_failure_receipt_are_safe() {
   output=$(cat "$dir/out" "$dir/err")
   assert_contains "$output" 'evidence retained for cleanup with receipt fmvw1.' "failure did not provide cleanup receipt"
   assert_not_contains "$output" 'SECRET_SHOULD_NOT_LEAK' "failure diagnostic leaked raw command canary"
-  pass "malformed metadata and extraction failures stay value-safe"
+  receipt=$(cleanup_retained "$dir/err")
+  [ -n "$receipt" ] || fail "the retained failure directory exposed no usable receipt"
+  [ ! -e "$(receipt_root "$receipt")" ] || fail "the retained failure directory survived its own receipt"
+  pass "malformed metadata and extraction failures stay value-safe and clean up by their retained receipt"
 }
 
 test_cleanup_receipt_mismatch_and_symlink_marker_resistance() {
@@ -505,6 +555,53 @@ test_cleanup_receipt_mismatch_and_symlink_marker_resistance() {
   pass "cleanup requires matching receipt and resists symlink marker replacement"
 }
 
+test_default_whole_video_completes_on_real_media() {
+  local dir="$TMP_ROOT/whole-video" bin out err rc receipt root duration
+  local real_ffmpeg real_ffprobe
+  real_ffmpeg=$(command -v ffmpeg 2>/dev/null)
+  real_ffprobe=$(command -v ffprobe 2>/dev/null)
+  if [ -z "$real_ffmpeg" ] || [ -z "$real_ffprobe" ]; then
+    pass "default whole-video extraction on real media (skipped: ffmpeg and ffprobe are not installed)"
+    return 0
+  fi
+  mkdir -p "$dir"
+  bin="$dir/realbin"
+  mkdir -p "$bin"
+  ln -sf "$real_ffmpeg" "$bin/ffmpeg"
+  ln -sf "$real_ffprobe" "$bin/ffprobe"
+  ln -sf "$REAL_PYTHON" "$bin/python3"
+  duration=6
+  PATH="$bin:$BASE_PATH" ffmpeg -hide_banner -loglevel error \
+    -f lavfi -i "testsrc=duration=$duration:size=160x120:rate=10" \
+    -c:v libx264 -preset ultrafast -pix_fmt yuv420p "$dir/clip.mp4" 2> "$dir/gen.err" \
+    || fail "could not synthesize the regression clip"
+  out="$dir/out.json"
+  err="$dir/err"
+  set +e
+  PATH="$bin:$BASE_PATH" "$WATCH" prepare "$dir/clip.mp4" --question 'what is shown' \
+    --max-frames 8 --resolution 128 > "$out" 2> "$err"
+  rc=$?
+  set +e
+  expect_code 0 "$rc" "the default whole-video path completes without a focus range"
+  receipt=$("$REAL_PYTHON" - "$out" "$duration" <<'PY'
+import json, os, sys
+data = json.load(open(sys.argv[1], encoding='utf-8'))
+duration = float(sys.argv[2])
+assert data['selected_ranges'][0]['reason'] == 'full_video', data['selected_ranges']
+assert data['media']['visual_coverage'] == 'full', data['media']
+assert len(data['frames']) >= 3, len(data['frames'])
+assert data['frames'][-1]['timestamp_seconds'] < duration, data['frames'][-1]
+for frame in data['frames']:
+    assert os.path.getsize(frame['path']) > 0, frame['path']
+print(data['cleanup_receipt'])
+PY
+  ) || fail "the whole-video manifest did not extract every planned frame inside the media"
+  root=$(receipt_root "$receipt")
+  PATH="$bin:$BASE_PATH" "$WATCH" cleanup "$receipt" >/dev/null
+  [ ! -e "$root" ] || fail "whole-video cleanup did not remove the owned directory"
+  pass "the default whole-video path extracts every planned frame from real media and cleans up exactly"
+}
+
 test_real_smoke_requires_two_opt_ins() {
   local dir="$TMP_ROOT/smoke" fakebin rc
   mkdir -p "$dir"
@@ -532,4 +629,5 @@ test_media_ceiling_override_requires_free_space
 test_local_file_refusals
 test_malformed_metadata_and_failure_receipt_are_safe
 test_cleanup_receipt_mismatch_and_symlink_marker_resistance
+test_default_whole_video_completes_on_real_media
 test_real_smoke_requires_two_opt_ins

--- a/tests/fm-video-watch.test.sh
+++ b/tests/fm-video-watch.test.sh
@@ -1,0 +1,391 @@
+#!/usr/bin/env bash
+# Contract tests for Firstmate's public video-watch evidence preparer.
+set -u
+
+# shellcheck source=tests/lib.sh disable=SC1091
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+WATCH="$ROOT/bin/fm-video-watch.sh"
+TMP_ROOT=$(fm_test_tmproot fm-video-watch-tests)
+BASE_PATH=${FM_TEST_BASE_PATH:-/usr/bin:/bin:/usr/sbin:/sbin}
+REAL_PYTHON=$(command -v python3)
+REAL_BASH=$(command -v bash)
+
+make_fakebin() {
+  local dir=$1 fakebin
+  fakebin=$(fm_fakebin "$dir")
+  ln -s "$REAL_PYTHON" "$fakebin/python3"
+  cat > "$fakebin/yt-dlp" <<'SH'
+#!/usr/bin/env bash
+printf 'yt-dlp %s\n' "$*" >> "$FM_FAKE_COMMAND_LOG"
+if [ "${FM_FAKE_YTDLP_FAIL:-0}" = 1 ]; then
+  printf 'raw secret noise %s\n' "${FM_FAKE_SECRET:-SECRET_SHOULD_NOT_LEAK}" >&2
+  exit 1
+fi
+out_template=
+prev=
+for arg in "$@"; do
+  if [ "$prev" = -o ]; then
+    out_template=$arg
+  fi
+  prev=$arg
+done
+case " $* " in
+  *" --dump-single-json "*)
+    if [ -n "${FM_FAKE_YTDLP_METADATA:-}" ]; then
+      printf '%s\n' "$FM_FAKE_YTDLP_METADATA"
+    else
+      cat <<'JSON'
+{"id":"abc123","title":"Fixture video","duration":120,"availability":"public","subtitles":{"en":[{"ext":"vtt"}]},"chapters":[{"start_time":0,"end_time":60,"title":"Pricing hook"},{"start_time":60,"end_time":120,"title":"Demo"}]}
+JSON
+    fi
+    exit 0
+    ;;
+  *" --skip-download "*)
+    [ "${FM_FAKE_NO_CAPTION_FILE:-0}" = 1 ] && exit 0
+    out=${out_template/'%(ext)s'/en.vtt}
+    mkdir -p "$(dirname "$out")"
+    cat > "$out" <<'VTT'
+WEBVTT
+
+00:00:05.000 --> 00:00:08.000
+Opening setup.
+
+00:00:20.000 --> 00:00:25.000
+The pricing hook appears on screen.
+
+00:01:05.000 --> 00:01:09.000
+The demo shows the dashboard.
+VTT
+    exit 0
+    ;;
+  *)
+    out=${out_template/'%(ext)s'/mp4}
+    mkdir -p "$(dirname "$out")"
+    printf 'video\n' > "$out"
+    exit 0
+    ;;
+esac
+SH
+  cat > "$fakebin/ffprobe" <<'SH'
+#!/usr/bin/env bash
+printf 'ffprobe %s\n' "$*" >> "$FM_FAKE_COMMAND_LOG"
+if [ -n "${FM_FAKE_FFPROBE_JSON:-}" ]; then
+  printf '%s\n' "$FM_FAKE_FFPROBE_JSON"
+else
+  cat <<'JSON'
+{"format":{"duration":"120.0","size":"1000"},"streams":[{"codec_type":"video","width":1280,"height":720,"codec_name":"h264"},{"codec_type":"audio"}]}
+JSON
+fi
+SH
+  cat > "$fakebin/ffmpeg" <<'SH'
+#!/usr/bin/env bash
+printf 'ffmpeg %s\n' "$*" >> "$FM_FAKE_COMMAND_LOG"
+case " $* " in
+  *showinfo*)
+    [ "${FM_FAKE_SCENE_FAIL:-0}" = 1 ] && exit 1
+    printf 'showinfo pts_time:2.5\nshowinfo pts_time:21.0\nshowinfo pts_time:67.0\n' >&2
+    exit 0
+    ;;
+esac
+if [ "${FM_FAKE_FFMPEG_EXTRACT_FAIL:-0}" = 1 ]; then
+  printf 'extract failed with secret %s\n' "${FM_FAKE_SECRET:-SECRET_SHOULD_NOT_LEAK}" >&2
+  exit 1
+fi
+out=${@: -1}
+mkdir -p "$(dirname "$out")"
+printf 'jpg\n' > "$out"
+exit 0
+SH
+  chmod +x "$fakebin/yt-dlp" "$fakebin/ffprobe" "$fakebin/ffmpeg"
+  printf '%s\n' "$fakebin"
+}
+
+json_get() {
+  local file=$1 expr=$2
+  "$REAL_PYTHON" - "$file" "$expr" <<'PY'
+import json, sys
+with open(sys.argv[1], encoding='utf-8') as f:
+    data = json.load(f)
+print(eval(sys.argv[2], {}, {'data': data}))
+PY
+}
+
+receipt_root() {
+  local receipt=$1
+  "$REAL_PYTHON" - "$receipt" <<'PY'
+import base64, json, sys
+receipt = sys.argv[1]
+payload = receipt.split('.', 1)[1]
+payload += '=' * (-len(payload) % 4)
+print(json.loads(base64.urlsafe_b64decode(payload))['root'])
+PY
+}
+
+mutate_receipt_nonce() {
+  local receipt=$1
+  "$REAL_PYTHON" - "$receipt" <<'PY'
+import base64, json, sys
+prefix, payload = sys.argv[1].split('.', 1)
+payload += '=' * (-len(payload) % 4)
+data = json.loads(base64.urlsafe_b64decode(payload))
+data['nonce'] = '0' * 32
+raw = json.dumps(data, separators=(',', ':')).encode()
+print(prefix + '.' + base64.urlsafe_b64encode(raw).decode().rstrip('='))
+PY
+}
+
+run_prepare() {
+  local dir=$1 out=$2 err=$3
+  shift 3
+  local fakebin
+  fakebin=$(make_fakebin "$dir")
+  : > "$dir/commands.log"
+  FM_FAKE_COMMAND_LOG="$dir/commands.log" PATH="$fakebin:$BASE_PATH" "$WATCH" prepare "$@" > "$out" 2> "$err"
+}
+
+test_doctor_missing_is_detect_only() {
+  local dir="$TMP_ROOT/doctor" fakebin out err rc
+  mkdir -p "$dir/fakebin"
+  ln -s "$REAL_PYTHON" "$dir/fakebin/python3"
+  ln -s "$REAL_BASH" "$dir/fakebin/bash"
+  cat > "$dir/fakebin/brew" <<'SH'
+#!/usr/bin/env bash
+echo brew-called >> "$FM_FAKE_COMMAND_LOG"
+exit 99
+SH
+  chmod +x "$dir/fakebin/brew"
+  : > "$dir/commands.log"
+  set +e
+  FM_FAKE_COMMAND_LOG="$dir/commands.log" PATH="$dir/fakebin:$BASE_PATH" "$WATCH" doctor > "$dir/out.json" 2> "$dir/err"
+  rc=$?
+  set +e
+  expect_code 3 "$rc" "doctor reports missing dependencies"
+  assert_contains "$(cat "$dir/out.json")" '"auto_install_attempted": false' "doctor records detect-only behavior"
+  [ ! -s "$dir/commands.log" ] || fail "doctor attempted an installer"
+  pass "doctor is detect-only when dependencies are missing"
+}
+
+test_url_rejections_are_sanitized() {
+  local dir="$TMP_ROOT/reject-url" fakebin out err rc output
+  mkdir -p "$dir"
+  fakebin=$(make_fakebin "$dir")
+  : > "$dir/commands.log"
+  set +e
+  FM_FAKE_COMMAND_LOG="$dir/commands.log" PATH="$fakebin:$BASE_PATH" "$WATCH" prepare \
+    'https://www.youtube.com/watch?v=abc&signature=SECRET_SHOULD_NOT_LEAK&list=PL123' \
+    --question 'summarize' > "$dir/out" 2> "$dir/err"
+  rc=$?
+  set +e
+  expect_code 4 "$rc" "playlist URL is rejected"
+  output=$(cat "$dir/out" "$dir/err")
+  assert_not_contains "$output" 'SECRET_SHOULD_NOT_LEAK' "rejected URL does not leak signed query values"
+  assert_not_contains "$output" 'signature=' "rejected URL does not echo signed query names"
+  pass "playlist and signed-query rejection is value-safe"
+}
+
+test_metadata_rejections() {
+  local case dir fakebin rc metadata
+  for case in playlist live auth drm; do
+    dir="$TMP_ROOT/meta-$case"
+    mkdir -p "$dir"
+    fakebin=$(make_fakebin "$dir")
+    : > "$dir/commands.log"
+    case "$case" in
+      playlist) metadata='{"_type":"playlist","entries":[{}]}' ;;
+      live) metadata='{"id":"x","title":"Live","duration":0,"availability":"public","is_live":true}' ;;
+      auth) metadata='{"id":"x","title":"Private","duration":10,"availability":"private"}' ;;
+      drm) metadata='{"id":"x","title":"DRM","duration":10,"availability":"public","drm":true}' ;;
+    esac
+    set +e
+    FM_FAKE_COMMAND_LOG="$dir/commands.log" FM_FAKE_YTDLP_METADATA="$metadata" PATH="$fakebin:$BASE_PATH" \
+      "$WATCH" prepare 'https://video.example/watch/one' --question 'summarize' > "$dir/out" 2> "$dir/err"
+    rc=$?
+    set +e
+    expect_code 4 "$rc" "metadata rejection for $case"
+  done
+  pass "playlist, live, authenticated, and DRM metadata are rejected"
+}
+
+test_prepare_transcript_first_and_manifest_contract() {
+  local dir="$TMP_ROOT/prepare" out err commands receipt root cleanup
+  mkdir -p "$dir"
+  out="$dir/out.json"
+  err="$dir/err"
+  run_prepare "$dir" "$out" "$err" 'https://www.youtube.com/watch?v=abc123&signature=SECRET_SHOULD_NOT_LEAK' --question 'Where is the dashboard demo?'
+  [ "$(json_get "$out" "data['schema']")" = 'fm.video-watch.manifest.v1' ] || fail "manifest schema mismatch"
+  [ "$(json_get "$out" "data['source']['sanitized']")" = 'https://www.youtube.com/watch?v=abc123' ] || fail "sanitized YouTube URL mismatch"
+  assert_not_contains "$(cat "$out" "$err")" 'SECRET_SHOULD_NOT_LEAK' "manifest does not leak signed query canary"
+  [ "$(json_get "$out" "data['transcript']['provenance']")" = 'captions:manual' ] || fail "manual caption provenance missing"
+  [ "$(json_get "$out" "len(data['selected_ranges'])")" -ge 1 ] || fail "selected range missing"
+  [ "$(json_get "$out" "data['selected_ranges'][0]['start_seconds']")" != '0.0' ] || fail "question terms did not narrow transcript range"
+  [ "$(json_get "$out" "len(data['frames'])")" -le 36 ] || fail "default frame budget exceeded"
+  assert_contains "$(json_get "$out" "','.join(sorted({f['reason'] for f in data['frames']}))")" 'periodic_coverage' "periodic evidence missing"
+  assert_contains "$(json_get "$out" "','.join(sorted({f['reason'] for f in data['frames']}))")" 'scene_or_slide_change' "scene evidence missing"
+  [ "$(json_get "$out" "data['token_budget']['estimated_total_tokens'] > 0")" = True ] || fail "token estimate missing"
+  commands=$(cat "$dir/commands.log")
+  [[ "$commands" == *"--dump-single-json"*"--skip-download --write-subs"*"--merge-output-format"* ]] \
+    || fail "yt-dlp was not called metadata/captions before media download"
+  receipt=$(json_get "$out" "data['cleanup_receipt']")
+  root=$(receipt_root "$receipt")
+  [ -d "$root/frames" ] || fail "frame directory missing before cleanup"
+  cleanup="$dir/cleanup.json"
+  PATH="$(dirname "$REAL_PYTHON"):$BASE_PATH" "$WATCH" cleanup "$receipt" > "$cleanup"
+  [ "$(json_get "$cleanup" "data['removed']")" = True ] || fail "cleanup did not report removal"
+  [ ! -e "$root" ] || fail "cleanup did not prove absence"
+  pass "transcript-first planning emits a bounded value-safe manifest and cleans up exactly"
+}
+
+test_focused_range_caps_and_language_choice() {
+  local dir="$TMP_ROOT/focus" out err metadata warnings
+  mkdir -p "$dir"
+  out="$dir/out.json"
+  err="$dir/err"
+  metadata='{"id":"abc","title":"Auto caps","duration":120,"availability":"public","automatic_captions":{"fr":[{"ext":"vtt"}],"en":[{"ext":"vtt"}]}}'
+  fakebin=$(make_fakebin "$dir")
+  : > "$dir/commands.log"
+  FM_FAKE_COMMAND_LOG="$dir/commands.log" FM_FAKE_YTDLP_METADATA="$metadata" PATH="$fakebin:$BASE_PATH" \
+    "$WATCH" prepare 'https://video.example/watch/one' --question 'read the text' --start 00:10 --end 00:20 \
+    --caption-lang fr --max-frames 999 --resolution 9999 > "$out" 2> "$err"
+  [ "$(json_get "$out" "data['selected_ranges'][0]['reason']")" = 'focused_range' ] || fail "focused range not recorded"
+  [ "$(json_get "$out" "data['transcript']['language']")" = 'fr' ] || fail "requested caption language not selected"
+  [ "$(json_get "$out" "data['token_budget']['max_frames']")" = 80 ] || fail "focused frame hard cap not applied"
+  [ "$(json_get "$out" "data['token_budget']['resolution_px_wide']")" = 1280 ] || fail "focused resolution hard cap not applied"
+  warnings=$(json_get "$out" "' '.join(data['warnings'])")
+  assert_contains "$warnings" 'hard cap' "cap warning missing"
+  assert_contains "$(json_get "$out" "','.join(f['reason'] for f in data['frames'])")" 'focused_range_start' "focused start frame missing"
+  receipt=$(json_get "$out" "data['cleanup_receipt']")
+  PATH="$(dirname "$REAL_PYTHON"):$BASE_PATH" "$WATCH" cleanup "$receipt" >/dev/null
+  pass "focused ranges use absolute timestamps, denser caps, and requested captions"
+}
+
+test_local_file_refusals() {
+  local dir="$TMP_ROOT/local" fakebin rc file link out receipt root
+  mkdir -p "$dir"
+  file="$dir/video.mp4"
+  printf 'video\n' > "$file"
+  link="$dir/link.mp4"
+  ln -s "$file" "$link"
+  fakebin=$(make_fakebin "$dir")
+  : > "$dir/commands.log"
+  set +e
+  FM_FAKE_COMMAND_LOG="$dir/commands.log" PATH="$fakebin:$BASE_PATH" "$WATCH" prepare "$link" --question 'what happens?' > "$dir/link.out" 2> "$dir/link.err"
+  rc=$?
+  set +e
+  expect_code 4 "$rc" "local symlink is refused"
+  set +e
+  FM_FAKE_COMMAND_LOG="$dir/commands.log" PATH="$fakebin:$BASE_PATH" "$WATCH" prepare "$file" --max-local-bytes 2 --question 'what happens?' > "$dir/size.out" 2> "$dir/size.err"
+  rc=$?
+  set +e
+  expect_code 4 "$rc" "oversized local file is refused"
+  printf 'video\n' > "$dir/video.txt"
+  set +e
+  FM_FAKE_COMMAND_LOG="$dir/commands.log" PATH="$fakebin:$BASE_PATH" "$WATCH" prepare "$dir/video.txt" --question 'what happens?' > "$dir/type.out" 2> "$dir/type.err"
+  rc=$?
+  set +e
+  expect_code 4 "$rc" "unsupported local extension is refused"
+  out="$dir/local-success.json"
+  FM_FAKE_COMMAND_LOG="$dir/commands.log" PATH="$fakebin:$BASE_PATH" "$WATCH" prepare "$file" --question 'what happens?' > "$out" 2> "$dir/local-success.err"
+  [ "$(json_get "$out" "data['source']['kind']")" = 'local_file' ] || fail "local success did not record local source kind"
+  receipt=$(json_get "$out" "data['cleanup_receipt']")
+  root=$(receipt_root "$receipt")
+  [ -f "$root/media/local.mp4" ] || fail "local media was not copied into the owned temp directory"
+  PATH="$(dirname "$REAL_PYTHON"):$BASE_PATH" "$WATCH" cleanup "$receipt" >/dev/null
+  [ ! -e "$root" ] || fail "local success cleanup did not remove owned temp directory"
+  pass "local file mode refuses unsafe files and copies accepted media into owned temp storage"
+}
+
+test_malformed_metadata_and_failure_receipt_are_safe() {
+  local dir="$TMP_ROOT/malformed" fakebin rc output
+  mkdir -p "$dir"
+  fakebin=$(make_fakebin "$dir")
+  : > "$dir/commands.log"
+  set +e
+  FM_FAKE_COMMAND_LOG="$dir/commands.log" FM_FAKE_YTDLP_METADATA='{' PATH="$fakebin:$BASE_PATH" \
+    "$WATCH" prepare 'https://video.example/watch/one?token=SECRET_SHOULD_NOT_LEAK' --question 'summarize' > "$dir/out" 2> "$dir/err"
+  rc=$?
+  set +e
+  expect_code 5 "$rc" "malformed yt-dlp metadata is refused"
+  output=$(cat "$dir/out" "$dir/err")
+  assert_not_contains "$output" 'SECRET_SHOULD_NOT_LEAK' "malformed metadata diagnostic leaked URL canary"
+
+  dir="$TMP_ROOT/extract-fail"
+  mkdir -p "$dir"
+  fakebin=$(make_fakebin "$dir")
+  : > "$dir/commands.log"
+  set +e
+  FM_FAKE_COMMAND_LOG="$dir/commands.log" FM_FAKE_FFMPEG_EXTRACT_FAIL=1 FM_FAKE_SECRET=SECRET_SHOULD_NOT_LEAK PATH="$fakebin:$BASE_PATH" \
+    "$WATCH" prepare 'https://video.example/watch/one?token=SECRET_SHOULD_NOT_LEAK' --question 'pricing' > "$dir/out" 2> "$dir/err"
+  rc=$?
+  set +e
+  expect_code 5 "$rc" "frame extraction failure is reported"
+  output=$(cat "$dir/out" "$dir/err")
+  assert_contains "$output" 'evidence retained for cleanup with receipt fmvw1.' "failure did not provide cleanup receipt"
+  assert_not_contains "$output" 'SECRET_SHOULD_NOT_LEAK' "failure diagnostic leaked raw command canary"
+  pass "malformed metadata and extraction failures stay value-safe"
+}
+
+test_cleanup_receipt_mismatch_and_symlink_marker_resistance() {
+  local dir="$TMP_ROOT/cleanup" out err receipt bad root fakebin outside rc
+  mkdir -p "$dir"
+  out="$dir/out.json"
+  err="$dir/err"
+  run_prepare "$dir" "$out" "$err" 'https://video.example/watch/one' --question 'pricing'
+  receipt=$(json_get "$out" "data['cleanup_receipt']")
+  bad=$(mutate_receipt_nonce "$receipt")
+  root=$(receipt_root "$receipt")
+  set +e
+  PATH="$(dirname "$REAL_PYTHON"):$BASE_PATH" "$WATCH" cleanup "$bad" > "$dir/bad.out" 2> "$dir/bad.err"
+  rc=$?
+  set +e
+  expect_code 4 "$rc" "mismatched cleanup receipt is refused"
+  [ -d "$root" ] || fail "receipt mismatch removed evidence directory"
+  PATH="$(dirname "$REAL_PYTHON"):$BASE_PATH" "$WATCH" cleanup "$receipt" >/dev/null
+  [ ! -e "$root" ] || fail "valid cleanup did not remove directory after mismatch"
+
+  dir="$TMP_ROOT/cleanup-symlink"
+  mkdir -p "$dir"
+  out="$dir/out.json"
+  err="$dir/err"
+  run_prepare "$dir" "$out" "$err" 'https://video.example/watch/one' --question 'pricing'
+  receipt=$(json_get "$out" "data['cleanup_receipt']")
+  root=$(receipt_root "$receipt")
+  outside="$TMP_ROOT/outside-marker"
+  printf 'outside\n' > "$outside"
+  rm -f "$root/.fm-video-watch-owned.json"
+  ln -s "$outside" "$root/.fm-video-watch-owned.json"
+  set +e
+  PATH="$(dirname "$REAL_PYTHON"):$BASE_PATH" "$WATCH" cleanup "$receipt" > "$dir/sym.out" 2> "$dir/sym.err"
+  rc=$?
+  set +e
+  expect_code 4 "$rc" "symlinked ownership marker is refused"
+  [ -e "$outside" ] || fail "cleanup followed symlinked ownership marker"
+  rm -f "$root/.fm-video-watch-owned.json"
+  rm -rf "$root"
+  pass "cleanup requires matching receipt and resists symlink marker replacement"
+}
+
+test_real_smoke_requires_two_opt_ins() {
+  local dir="$TMP_ROOT/smoke" fakebin rc
+  mkdir -p "$dir"
+  fakebin=$(make_fakebin "$dir")
+  : > "$dir/commands.log"
+  set +e
+  FM_FAKE_COMMAND_LOG="$dir/commands.log" PATH="$fakebin:$BASE_PATH" "$WATCH" smoke --url 'https://www.youtube.com/watch?v=8ZgpAXe5V5w' \
+    --question 'summarize' --i-understand-this-uses-network > "$dir/out" 2> "$dir/err"
+  rc=$?
+  set +e
+  expect_code 2 "$rc" "real smoke requires environment opt-in"
+  [ ! -s "$dir/commands.log" ] || fail "real smoke ran tools without env opt-in"
+  pass "real public smoke cannot run accidentally"
+}
+
+test_doctor_missing_is_detect_only
+test_url_rejections_are_sanitized
+test_metadata_rejections
+test_prepare_transcript_first_and_manifest_contract
+test_focused_range_caps_and_language_choice
+test_local_file_refusals
+test_malformed_metadata_and_failure_receipt_are_safe
+test_cleanup_receipt_mismatch_and_symlink_marker_resistance
+test_real_smoke_requires_two_opt_ins

--- a/tests/fm-video-watch.test.sh
+++ b/tests/fm-video-watch.test.sh
@@ -181,7 +181,39 @@ test_url_rejections_are_sanitized() {
   output=$(cat "$dir/out" "$dir/err")
   assert_not_contains "$output" 'SECRET_SHOULD_NOT_LEAK' "rejected URL does not leak signed query values"
   assert_not_contains "$output" 'signature=' "rejected URL does not echo signed query names"
-  pass "playlist and signed-query rejection is value-safe"
+
+  : > "$dir/commands.log"
+  set +e
+  FM_FAKE_COMMAND_LOG="$dir/commands.log" PATH="$fakebin:$BASE_PATH" "$WATCH" prepare \
+    'https://video.example/watch/one?id=42&Signature=SECRET_SHOULD_NOT_LEAK' \
+    --question 'summarize' > "$dir/signed.out" 2> "$dir/signed.err"
+  rc=$?
+  set +e
+  expect_code 4 "$rc" "signed URL is rejected before any fetch"
+  output=$(cat "$dir/signed.out" "$dir/signed.err")
+  assert_not_contains "$output" 'SECRET_SHOULD_NOT_LEAK' "signed rejection does not leak the signature value"
+  [ ! -s "$dir/commands.log" ] || fail "signed URL reached yt-dlp before rejection"
+  pass "playlist and credential-bearing query rejection is value-safe"
+}
+
+test_supplied_url_is_fetched_exactly() {
+  local dir="$TMP_ROOT/exact-url" out err commands receipt
+  mkdir -p "$dir"
+  out="$dir/out.json"
+  err="$dir/err"
+  run_prepare "$dir" "$out" "$err" 'https://player.vimeo.com/video/76979871?h=8272103f6e&utm_source=SECRET_SHOULD_NOT_LEAK' \
+    --question 'summarize'
+  commands=$(cat "$dir/commands.log")
+  assert_contains "$commands" 'https://player.vimeo.com/video/76979871?h=8272103f6e&utm_source=SECRET_SHOULD_NOT_LEAK' \
+    "yt-dlp did not receive the exact supplied URL"
+  [ "$(json_get "$out" "data['source']['sanitized']")" = 'https://player.vimeo.com/video/76979871?h=redacted' ] \
+    || fail "identity-bearing query parameter was not retained and redacted for display"
+  [ "$(json_get "$out" "data['source']['query_keys']")" = "['h']" ] || fail "retained query key names missing"
+  assert_not_contains "$(cat "$out" "$err")" 'SECRET_SHOULD_NOT_LEAK' "manifest leaked a tracking query value"
+  assert_not_contains "$(cat "$out" "$err")" '8272103f6e' "manifest printed a non-identifier query value"
+  receipt=$(json_get "$out" "data['cleanup_receipt']")
+  PATH="$(dirname "$REAL_PYTHON"):$BASE_PATH" "$WATCH" cleanup "$receipt" >/dev/null
+  pass "the exact supplied public URL is fetched while the manifest stays value-safe"
 }
 
 test_metadata_rejections() {
@@ -212,10 +244,13 @@ test_prepare_transcript_first_and_manifest_contract() {
   mkdir -p "$dir"
   out="$dir/out.json"
   err="$dir/err"
-  run_prepare "$dir" "$out" "$err" 'https://www.youtube.com/watch?v=abc123&signature=SECRET_SHOULD_NOT_LEAK' --question 'Where is the dashboard demo?'
+  run_prepare "$dir" "$out" "$err" 'https://www.youtube.com/watch?v=abc123&si=SECRET_SHOULD_NOT_LEAK' --question 'Where is the dashboard demo?'
   [ "$(json_get "$out" "data['schema']")" = 'fm.video-watch.manifest.v1' ] || fail "manifest schema mismatch"
   [ "$(json_get "$out" "data['source']['sanitized']")" = 'https://www.youtube.com/watch?v=abc123' ] || fail "sanitized YouTube URL mismatch"
-  assert_not_contains "$(cat "$out" "$err")" 'SECRET_SHOULD_NOT_LEAK' "manifest does not leak signed query canary"
+  assert_not_contains "$(cat "$out" "$err")" 'SECRET_SHOULD_NOT_LEAK' "manifest does not leak tracking query canary"
+  [ "$(json_get "$out" "data['media']['acquired']")" = True ] || fail "media acquisition not recorded"
+  [ "$(json_get "$out" "data['media']['visual_coverage']")" = 'full' ] || fail "full visual coverage not recorded"
+  [ "$(json_get "$out" "data['media']['byte_ceiling'] > 0")" = True ] || fail "transient media ceiling missing"
   [ "$(json_get "$out" "data['transcript']['provenance']")" = 'captions:manual' ] || fail "manual caption provenance missing"
   [ "$(json_get "$out" "len(data['selected_ranges'])")" -ge 1 ] || fail "selected range missing"
   [ "$(json_get "$out" "data['selected_ranges'][0]['start_seconds']")" != '0.0' ] || fail "question terms did not narrow transcript range"
@@ -254,9 +289,114 @@ test_focused_range_caps_and_language_choice() {
   warnings=$(json_get "$out" "' '.join(data['warnings'])")
   assert_contains "$warnings" 'hard cap' "cap warning missing"
   assert_contains "$(json_get "$out" "','.join(f['reason'] for f in data['frames'])")" 'focused_range_start' "focused start frame missing"
+  assert_contains "$(cat "$dir/commands.log")" '--download-sections *10.000-20.000' "focused run did not request a bounded provider section"
+  assert_contains "$warnings" 'ignored the bounded section request' "unbounded section fallback was not disclosed"
+  [ "$(json_get "$out" "data['media']['visual_coverage']")" = 'full' ] || fail "full media fallback coverage not recorded"
   receipt=$(json_get "$out" "data['cleanup_receipt']")
   PATH="$(dirname "$REAL_PYTHON"):$BASE_PATH" "$WATCH" cleanup "$receipt" >/dev/null
   pass "focused ranges use absolute timestamps, denser caps, and requested captions"
+}
+
+test_section_download_keeps_absolute_timestamps() {
+  local dir="$TMP_ROOT/section" out err fakebin receipt commands
+  mkdir -p "$dir"
+  out="$dir/out.json"
+  err="$dir/err"
+  fakebin=$(make_fakebin "$dir")
+  : > "$dir/commands.log"
+  FM_FAKE_COMMAND_LOG="$dir/commands.log" \
+    FM_FAKE_FFPROBE_JSON='{"format":{"duration":"10.0","size":"1000"},"streams":[{"codec_type":"video","width":1280,"height":720,"codec_name":"h264"}]}' \
+    PATH="$fakebin:$BASE_PATH" "$WATCH" prepare 'https://video.example/watch/one' --question 'read the text' \
+    --start 00:10 --end 00:20 --max-frames 6 > "$out" 2> "$err"
+  [ "$(json_get "$out" "data['media']['visual_coverage']")" = 'section' ] || fail "section coverage not recorded"
+  [ "$(json_get "$out" "data['media']['acquired_range']['start_seconds']")" = '10.0' ] || fail "acquired section range missing"
+  [ "$(json_get "$out" "min(f['timestamp_seconds'] for f in data['frames']) >= 10.0")" = True ] \
+    || fail "section frames did not keep absolute timestamps"
+  [ "$(json_get "$out" "max(f['timestamp_seconds'] for f in data['frames']) <= 19.5")" = True ] \
+    || fail "section frames were planned past the last decodable frame of the acquired media"
+  assert_contains "$(json_get "$out" "' '.join(data['warnings'])")" 'covers only the requested section' \
+    "section-only coverage was not disclosed"
+  commands=$(cat "$dir/commands.log")
+  assert_contains "$commands" '-ss 0.000' "section media was not seeked relative to the acquired section"
+  receipt=$(json_get "$out" "data['cleanup_receipt']")
+  PATH="$(dirname "$REAL_PYTHON"):$BASE_PATH" "$WATCH" cleanup "$receipt" >/dev/null
+  pass "bounded section downloads keep manifest timestamps absolute and coverage honest"
+}
+
+test_media_ceiling_refuses_before_download() {
+  local dir="$TMP_ROOT/ceiling" out err fakebin metadata receipt commands
+  mkdir -p "$dir"
+  out="$dir/out.json"
+  err="$dir/err"
+  metadata='{"id":"big","title":"Huge","duration":1200,"availability":"public","filesize_approx":9000000000,"subtitles":{"en":[{"ext":"vtt"}]},"chapters":[{"start_time":0,"end_time":600,"title":"Pricing hook"}]}'
+  fakebin=$(make_fakebin "$dir")
+  : > "$dir/commands.log"
+  FM_FAKE_COMMAND_LOG="$dir/commands.log" FM_FAKE_YTDLP_METADATA="$metadata" PATH="$fakebin:$BASE_PATH" \
+    "$WATCH" prepare 'https://video.example/watch/one' --question 'pricing' --max-media-bytes 1000000 > "$out" 2> "$err"
+  [ "$(json_get "$out" "data['media']['acquired']")" = False ] || fail "oversized media was still acquired"
+  [ "$(json_get "$out" "data['media']['visual_coverage']")" = 'none' ] || fail "absent visual coverage not recorded"
+  [ "$(json_get "$out" "len(data['frames'])")" = 0 ] || fail "frames were emitted without acquired media"
+  [ "$(json_get "$out" "data['transcript']['available']")" = True ] || fail "transcript evidence was not returned"
+  [ "$(json_get "$out" "len(data['chapters']) > 0")" = True ] || fail "chapter evidence was not returned"
+  assert_contains "$(json_get "$out" "data['media']['focused_pass_recommendation']")" '--start' \
+    "focused-pass recommendation missing"
+  assert_contains "$(json_get "$out" "' '.join(data['warnings'])")" 'do not claim any visual coverage' \
+    "manifest did not warn against claiming visual coverage"
+  commands=$(cat "$dir/commands.log")
+  assert_not_contains "$commands" '--merge-output-format' "media download ran despite exceeding the byte ceiling"
+  receipt=$(json_get "$out" "data['cleanup_receipt']")
+  PATH="$(dirname "$REAL_PYTHON"):$BASE_PATH" "$WATCH" cleanup "$receipt" >/dev/null
+  pass "declared media above the transient ceiling is refused before download with transcript evidence returned"
+}
+
+test_media_ceiling_override_requires_free_space() {
+  local dir="$TMP_ROOT/ceiling-override" fakebin rc output
+  mkdir -p "$dir"
+  fakebin=$(make_fakebin "$dir")
+  : > "$dir/commands.log"
+  set +e
+  FM_FAKE_COMMAND_LOG="$dir/commands.log" PATH="$fakebin:$BASE_PATH" \
+    "$WATCH" prepare 'https://video.example/watch/one' --question 'pricing' \
+    --max-media-bytes 99999999999999 > "$dir/out" 2> "$dir/err"
+  rc=$?
+  set +e
+  expect_code 2 "$rc" "a media ceiling above the 16 GiB hard cap is refused"
+  output=$(cat "$dir/out" "$dir/err")
+  assert_contains "$output" 'hard cap for transient public media' "hard-cap refusal did not name the bound"
+
+  "$REAL_PYTHON" - "$ROOT/bin/fm-video-watch-impl.py" <<'PY' || fail "free-space preflight does not gate only the override"
+import importlib.util, shutil, sys, tempfile
+from collections import namedtuple
+from pathlib import Path
+
+spec = importlib.util.spec_from_file_location("fmvw", sys.argv[1])
+mod = importlib.util.module_from_spec(spec)
+sys.modules["fmvw"] = mod
+spec.loader.exec_module(mod)
+
+usage = namedtuple("usage", "total used free")
+mod.shutil.disk_usage = lambda _path: usage(0, 0, 3 * 1024 * 1024 * 1024)
+work = Path(tempfile.gettempdir())
+
+warnings = []
+ceiling = mod.resolve_media_ceiling(None, work, warnings)
+assert ceiling < mod.DEFAULT_MAX_MEDIA_BYTES, "default ceiling must clamp to free space, not refuse"
+assert any("free space is the binding limit" in w for w in warnings), warnings
+
+assert mod.tail_seek_limit(10.0, 25.0) == 9.5, mod.tail_seek_limit(10.0, 25.0)
+assert mod.tail_seek_limit(10.0, 1.0) == 8.0, mod.tail_seek_limit(10.0, 1.0)
+assert mod.tail_seek_limit(10.0, 0.0) == 9.0, mod.tail_seek_limit(10.0, 0.0)
+assert mod.tail_seek_limit(0.2, 25.0) == 0.0, mod.tail_seek_limit(0.2, 25.0)
+
+try:
+    mod.resolve_media_ceiling(8 * 1024 * 1024 * 1024, work, [])
+except mod.WatchError as exc:
+    assert exc.code == 2, exc.code
+    assert "proven local free space" in str(exc), str(exc)
+else:
+    raise AssertionError("override above the default must require proven free space")
+PY
+  pass "the transient media ceiling clamps by default, keeps seeks inside the media, and requires proven free space only when raised"
 }
 
 test_local_file_refusals() {
@@ -302,7 +442,7 @@ test_malformed_metadata_and_failure_receipt_are_safe() {
   : > "$dir/commands.log"
   set +e
   FM_FAKE_COMMAND_LOG="$dir/commands.log" FM_FAKE_YTDLP_METADATA='{' PATH="$fakebin:$BASE_PATH" \
-    "$WATCH" prepare 'https://video.example/watch/one?token=SECRET_SHOULD_NOT_LEAK' --question 'summarize' > "$dir/out" 2> "$dir/err"
+    "$WATCH" prepare 'https://video.example/watch/one?h=SECRET_SHOULD_NOT_LEAK' --question 'summarize' > "$dir/out" 2> "$dir/err"
   rc=$?
   set +e
   expect_code 5 "$rc" "malformed yt-dlp metadata is refused"
@@ -315,7 +455,7 @@ test_malformed_metadata_and_failure_receipt_are_safe() {
   : > "$dir/commands.log"
   set +e
   FM_FAKE_COMMAND_LOG="$dir/commands.log" FM_FAKE_FFMPEG_EXTRACT_FAIL=1 FM_FAKE_SECRET=SECRET_SHOULD_NOT_LEAK PATH="$fakebin:$BASE_PATH" \
-    "$WATCH" prepare 'https://video.example/watch/one?token=SECRET_SHOULD_NOT_LEAK' --question 'pricing' > "$dir/out" 2> "$dir/err"
+    "$WATCH" prepare 'https://video.example/watch/one?h=SECRET_SHOULD_NOT_LEAK' --question 'pricing' > "$dir/out" 2> "$dir/err"
   rc=$?
   set +e
   expect_code 5 "$rc" "frame extraction failure is reported"
@@ -382,9 +522,13 @@ test_real_smoke_requires_two_opt_ins() {
 
 test_doctor_missing_is_detect_only
 test_url_rejections_are_sanitized
+test_supplied_url_is_fetched_exactly
 test_metadata_rejections
 test_prepare_transcript_first_and_manifest_contract
 test_focused_range_caps_and_language_choice
+test_section_download_keeps_absolute_timestamps
+test_media_ceiling_refuses_before_download
+test_media_ceiling_override_requires_free_space
 test_local_file_refusals
 test_malformed_metadata_and_failure_receipt_are_safe
 test_cleanup_receipt_mismatch_and_symlink_marker_resistance


### PR DESCRIPTION
## Intent

Build a permanent, cross-harness Firstmate /watch capability for sophisticated, low-token, evidence-grounded analysis of public video URLs and explicitly supplied local video files, incorporating and attributing useful MIT mechanics from the installed bradautomates/claude-video watch skill without depending on ~/.claude/skills/watch or copying Claude-only plugin packaging. Add a user-invocable internal Firstmate watch skill, a single public mechanics owner preferably bin/fm-video-watch.sh with --help, transcript-first public URL preparation, safe sanitized manifests with bounded frames/transcript/token estimates and opaque cleanup receipts, focused --start/--end passes, detect-only dependency diagnostics, strict public URL rejection for playlists/live/auth/DRM/unsafe schemes, strict local-file validation, no browser/cookie/login/profile use, no API-key prompting or remote transcription in v1 unless securely preconfigured, all artifacts under an owned private temporary directory cleaned only by exact receipt, and no resident services or broad control plane. Preserve the full useful behavior of the original bradautomates/claude-video skill as approved by the captain: public URLs across yt-dlp-supported sites, explicit local files, native captions, timestamped transcript, Groq/OpenAI Whisper fallback only from already configured protected local provider settings without exposing or asking for keys, duration-aware frames, focused --start/--end ranges, frame-budget and resolution controls, transcript-plus-frame synthesis, follow-up reuse, exact cleanup, full original URL fetching when public-source policy permits, safe query-value redaction without changing resource identity, resource bounds using metadata/captions first, selected section/range downloads when supported, adaptive format choice, a default transient public-media ceiling of 4 GiB, and explicit bounded override up to 16 GiB only with local free-space preflight. Also refresh real public proof and fix the accepted whole-video path defect for https://www.youtube.com/watch?v=9WOpQqSO5aA, preserving full-video default behavior rather than hidden range looping, recording sanitized title/duration/caption/frame/timestamp/cleanup evidence, and refreshing https://www.youtube.com/watch?v=8ZgpAXe5V5w for final URL identity and media-ceiling behavior. Provide mocked unit/contract tests for URL sanitation, source rejection, local-file symlink/size/type refusal, budgets, transcript-first planning, scene-plus-periodic frame selection, focused ranges, captions/language choice, safe Whisper behavior, manifest schema, redaction canaries, malformed metadata, failure cleanup, receipt mismatch, symlink/race resistance, exact cleanup, download ceilings, whole-video frame extraction, and detect-only missing dependencies. Add opt-in real public smoke that records only sanitized verification evidence, and run applicable lint, doc audience, focused tests, changed-file tests, and relevant suite checks.

## What Changed

- New `bin/fm-video-watch.sh` wrapper over a private Python implementation, owning the whole `/watch` mechanics contract: `doctor` (detect-only dependency diagnostics), `prepare`, `cleanup`, and opt-in `smoke`. Preparation is transcript-first from native captions, selects frames by scene change plus bounded periodic coverage, supports focused `--start`/`--end` passes with frame-budget and resolution controls, and emits a sanitized manifest with frame paths, timestamps, reasons, transcript provenance, warnings, token estimates, and an opaque cleanup receipt. Public URLs are fetched exactly as supplied with query values redacted for unknown keys, playlist/live/authenticated/DRM/unsafe sources and unsafe local files are refused, transient media is bounded at 4 GiB by default (up to 16 GiB with a local free-space preflight), `media.visual_coverage` reports `full`/`section`/`none`, and exit classes 0/2/3/4/5 are documented in the script header. Remote transcription is disabled in v1, so absent captions degrade to visual-only evidence rather than prompting for keys.
- New user-invocable `.agents/skills/watch/SKILL.md` describing intake, preparation, and evidence-reading discipline through `bin/fm-video-watch.sh` and the ordinary file `Read` tool, with no dependency on `~/.claude/skills/watch`. Registered in the AGENTS.md skill-loading rules, the README built-in skills table, `docs/scripts.md`, `docs/documentation-audiences.json`, and the `bin/fm-test-run.sh` changed-path family map.
- New `tests/fm-video-watch.test.sh` mocked unit and contract suite covering URL sanitation, source and local-file rejection, budgets and download ceilings, transcript-first planning, frame selection, focused ranges, caption language choice, manifest schema, redaction canaries, malformed metadata, failure cleanup, receipt mismatch, symlink and race resistance, whole-video extraction, and missing dependencies. New `docs/verification/video-watch.md` records the sanitized public-source verification evidence and upstream MIT attribution to `bradautomates/claude-video` at revision `755c157466738dda102c939158a0116b972925a3`.

## Risk Assessment

✅ Low: All five previously accepted findings are fixed correctly at the boundaries recommended, each with a targeted new test and matching wrapper/verification-doc updates, sibling paths were re-checked for regressions, and the only remaining issue is an informational warning-text inconsistency in a narrow timeout sub-case.

## Testing

Ran the targeted mocked contract suite and the documentation-audience suite through the repo runner (all pass, no gate skips, so the real-ffmpeg whole-video regression genuinely executed), then drove the actual CLI end to end: the default whole-video path on the defect URL, a focused 02:00-03:00 section, a media-ceiling refusal and the two-opt-in real public smoke on the second URL, an explicitly supplied local clip, the full refusal matrix, and receipt-exact cleanup after every run. The whole-video fix is confirmed by frame-level proof rather than exit status alone (every manifest frame present on disk, on-disk count matching, tail frames at 558.34s and 3708.94s decoding into real images), and the smoke run independently reproduced the recorded acceptance figures. Visual evidence is a contact sheet of all 18 frames from a synthesized local clip whose burned-in timestamps match the manifest one for one; real-source frames were verified on disk and read inline but deliberately not exported, since this repo's verification policy keeps public-media evidence sanitized. Lint and the broader suite belong to other phases and were not run here. All checks passed and no product defects surfaced; one pre-existing test-harness temp-root hygiene note is reported for information only.

- Evidence: Contact sheet: all 18 frames from the local-file run over a synthesized 20s clip, burned-in timestamps matching the manifest (local file: <code>/var/folders/0d/jhgr3px15y17yxr3ykhr9bdc0000gn/T/no-mistakes-evidence/01KZ2E3V1XX35866KAH3ANE8Q9/local-clip-contact-sheet.png</code>)
<details>
<summary>Evidence: Sanitized evidence record for all six exercised paths</summary>

```text
# Firstmate /watch - test-phase evidence (sanitized)

Run on 2026-08-02, macOS, yt-dlp 2026.06.09, ffmpeg/ffprobe 8.0.1, from the worktree at
target commit b2c8406. Only sanitized facts are recorded: no media, captions, frames,
signed URLs, raw command output, or local temp paths.

## 1. Whole-video default path, the accepted defect (https://www.youtube.com/watch?v=9WOpQqSO5aA)

`bin/fm-video-watch.sh prepare '<url>' --question 'Summarize the video'` -> exit 0 in 20s.

`` `text
schema fm.video-watch.manifest.v1, mode prepare
source identity: host www.youtube.com, path /watch, query_keys [v], exact URL preserved
title: Real AI Agent Stack: Harness -> Loop -> Graph
duration 559.0 (09:19), chapters 8
selected_ranges: exactly 1 entry, reason full_video, 0.0-559.0   (no hidden range looping)
media: acquired true, visual_coverage full, acquisition_reason no_focus_range_requested,
       byte_ceiling 4294967296, declared 19939872 vs downloaded 20008710 (0.34%)
transcript: captions:automatic, en, 218 segments, remote_transcription disabled
frames: 20 in manifest, 20 present on disk with nonzero size, 20 image files in the frame dir
first frame 00:00 (0.0), last frame 09:18 (558.34 < 559.0 duration)
warnings: transcript evidence was truncated to the bounded manifest budget
token_budget: frame 24000, transcript 3997, total 27997
cleanup: exact receipt -> removed=true, owned directory absent afterward
`` `

Frames were opened with the ordinary Read tool the way the skill directs an agent to consume
them: frame 1 at 00:00 is a fully black image, frame 10 is real mid-video content (a test-report
UI), and frame 20 at 09:18 is a readable end card. The tail frame decodes, which is exactly the
class that used to fail with exit 5.

## 2. Focused range takes the bounded section (same URL, --start 02:00 --end 03:00)

`` `text
selected_ranges: 1, reason focused_range, 120.0-180.0
media: visual_coverage section, acquisition_reason a_bounded_section_is_projected_cheaper_than_the_full_media,
       acquired_range 120.0-180.0, downloaded 3603554 bytes (18% of the full download)
frames: 18, all on disk, first 02:00 (120.0), last 03:00 (179.5) - absolute source timestamps
reasons: focused_range_start+periodic_coverage, periodic_coverage, focused_range_end
warnings: visual evidence covers only the requested section 02:00-03:00, not the whole video
cleanup: exact receipt -> removed=true, directory absent
`` `

## 3. Media ceiling and URL identity (https://www.youtube.com/watch?v=8ZgpAXe5V5w)

`prepare '<url>' --question 'Summarize the video' --max-media-bytes 10000000` -> exit 0 in 5s,
refused before any download:

`` `text
source identity: host www.youtube.com, path /watch, query_keys [v], exact URL preserved
title: L8 Principal's Agentic Engineering Setup (just copy him), duration 3709.0 (1:01:49)
media: acquired false, downloaded_bytes null, visual_coverage none,
       byte_ceiling 10000000, declared_bytes 164619367
       focused_pass_recommendation: re-run one focused pass with --start 00:00 --end 05:00,
       or raise --max-media-bytes if the local disk allows it
transcript still returned: captions:automatic, en, 214 segments
warnings: declared public media size exceeds the transient byte ceiling, so no video was downloaded;
          this manifest carries transcript and chapter evidence only, do not claim any visual coverage
frames: 0, token_budget frame 0 / transcript 3996
cleanup: exact receipt -> removed=true, directory absent
`` `

## 4. Opt-in real public smoke, both opt-ins (same URL)

`FM_VIDEO_WATCH_REAL_SMOKE=1 bin/fm-video-watch.sh smoke --url '<url>' --question 'Summarize the video' --i-understand-this-uses-network`
-> exit 0 in 63s wall clock.

`` `text
mode real_public_smoke, source identity host www.youtube.com, path /watch, query_keys [v]
selected_ranges: 1, full_video, 0.0-3709.0
media: visual_coverage full, acquisition_reason no_focus_range_requested,
       declared 164619367 vs downloaded 164332937 (0.17% high, matches the recorded acceptance figure)
transcript: captions:automatic, en, 214 segments
frames: 36 in manifest, 36 present on disk with nonzero size
first 00:00 (0.0), last 1:01:49 (3708.94 < 3709.0); the last frame decodes to real content
warnings: transcript truncated to the bounded budget; video is over 10 minutes, sparse sampled evidence
token_budget: frame 43200, transcript 3996, total 47196
leak scan over the whole manifest for signature / token= / cookie / /Users/ / googlevideo: no hits
cleanup: 158M owned directory removed by exact receipt, absent afterward
`` `

## 5. Explicit local file (synthesized 20s clip, no network)

`` `text
source: kind local_file, sanitized "demo-clip.mp4" (basename only, no local path in the manifest)
duration 20.0, selected_ranges 1 full_video 0.0-20.0, visual_coverage full
frames: 18, all on disk, first 00:00 (0.0), last 00:20 (19.5 < 20.0)
transcript: none, remote_transcription disabled
warnings: local-file transcription is not enabled in v1
cleanup: exact receipt -> removed=true, directory absent
`` `

Visual artifact `local-clip-contact-sheet.png` tiles all 18 extracted frames. The burned-in
clip timestamps (00:00:00.000 ... 00:00:19.520) match the manifest timestamps one for one and
cover all four synthesized scenes, so whole-video coverage and timestamp mapping are visible
rather than asserted.

## 6. Safety refusals and exit classes

`` `text
playlist URL              exit 4  playlist URLs are rejected; provide exactly one public video URL
channel /live URL         exit 4  public video metadata was unavailable without login or was unsupported
file:// scheme            exit 4  unsupported source scheme; use a public http(s) URL or a local file path
token/Signature query     exit 4  URL carries credential, signature, session, or token query fields
local symlink             exit 4  local video file must be an explicit regular file, not a symlink
non-video extension       exit 4  local file extension is not a supported video type
missing local file        exit 2  local video file was not found
smoke, one opt-in only    exit 2  real public smoke is opt-in only; needs env var AND the flag
smoke, no opt-in          exit 2  same refusal
cleanup, wrong receipt    exit 2  cleanup receipt is malformed
`` `

Every refusal that retained an owned directory printed its opaque receipt, and each of those
receipts removed the directory (removed=true, absent afterward).

`doctor` reported `ready: true`, `auto_install_attempted: false`, and an install hint only.
`bin/fm-video-watch.sh --help` exits 0 and prints the full operator contract (`help.txt`).

## 7. Hygiene

Every owned directory created by these runs was removed by its exact receipt or, for the
synthesized clip and the test harness root, by direct removal of my own transient paths.
No `fm-video-watch-*` directory created during this phase remains in the system temp dir, and
`git status --porcelain` is empty.
```
</details>
<details>
<summary>Evidence: Whole-video default path on the defect URL (sanitized manifest fields)</summary>

<code>selected_ranges: [{&#34;end_seconds&#34;: 559.0, &#34;reason&#34;: &#34;full_video&#34;, &#34;start_seconds&#34;: 0.0}]&#10;media: acquired true, visual_coverage full, acquisition_reason no_focus_range_requested, declared_bytes 19939872, downloaded_bytes 20008710&#10;transcript: captions:automatic, en, 218 segments, remote_transcription disabled&#10;frame count in manifest: 20&#10;frames present on disk with nonzero size: 20 | missing/empty: 0&#10;image files on disk in frame dir: 20&#10;first ts: 0.0 last ts: 558.34 | last &lt; duration: True&#10;warnings: [&#34;transcript evidence was truncated to the bounded manifest budget&#34;]&#10;cleanup by exact receipt: removed=true, owned directory absent afterward</code>

```text
schema: fm.video-watch.manifest.v1 | mode: prepare
source: {"host": "www.youtube.com", "kind": "public_url", "path": "/watch", "query_keys": ["v"], "sanitized": "https://www.youtube.com/watch?v=9WOpQqSO5aA"}
title: Real AI Agent Stack: Harness → Loop → Graph
top-level keys: ['chapters', 'cleanup_receipt', 'duration', 'duration_seconds', 'frames', 'media', 'mode', 'schema', 'selected_ranges', 'source', 'title', 'token_budget', 'transcript', 'warnings']
duration_seconds: 559.0
selected_ranges: [{"end_seconds": 559.0, "reason": "full_video", "start_seconds": 0.0}]
media: {"acquired": true, "acquired_range": null, "acquisition_reason": "no_focus_range_requested", "byte_ceiling": 4294967296, "declared_bytes": 19939872, "downloaded_bytes": 20008710, "focused_pass_recommendation": null, "visual_coverage": "full"}
transcript provenance: None lang: en segments: 218
frame count in manifest: 20
frames present on disk with nonzero size: 20 | missing/empty: 0
image files on disk in frame dir(s): 20
first ts: 0.0 last ts: 558.34 | last < duration: True
reasons: ['periodic_coverage', 'scene_or_slide_change']
warnings: ["transcript evidence was truncated to the bounded manifest budget"]
token_budget: {"batching_guidance": "Read frames in batches of 10-20 and cite timestamps; re-run focused with --start/--end if a sampled range is insufficient.", "estimated_frame_tokens": 24000, "estimated_total_tokens": 27997, "estimated_transcript_tokens": 3997, "max_frames": 36, "resolution_px_wide": 512}
cleanup_receipt present: True
```
</details>
<details>
<summary>Evidence: Opt-in real public smoke on the second URL (sanitized manifest fields)</summary>

<code>schema: fm.video-watch.manifest.v1 | mode: real_public_smoke&#10;source identity: host www.youtube.com, path /watch, query_keys [v], exact URL preserved&#10;duration 1:01:49 (3709.0); selected_ranges: 1 full_video 0.0-3709.0&#10;media: visual_coverage full, declared 164619367 vs downloaded 164332937 (0.17% high)&#10;frames: 36 in manifest, 36 on disk nonzero; first 00:00, last 1:01:49 (3708.94 &lt; 3709.0)&#10;token_budget: frame 43200, transcript 3996, total 47196&#10;leak canary scan (signature / token= / cookie / /Users/ / googlevideo): no hits&#10;cleanup: 158M owned directory removed by exact receipt, absent afterward</code>

```text
schema: fm.video-watch.manifest.v1 | mode: real_public_smoke
source: {"host": "www.youtube.com", "kind": "public_url", "path": "/watch", "query_keys": ["v"], "sanitized": "https://www.youtube.com/watch?v=8ZgpAXe5V5w"}
title: L8 Principal's Agentic Engineering Setup (just copy him)
duration: 1:01:49 3709.0
selected_ranges: [{"end_seconds": 3709.0, "reason": "full_video", "start_seconds": 0.0}]
media: {"acquired": true, "acquired_range": null, "acquisition_reason": "no_focus_range_requested", "byte_ceiling": 4294967296, "declared_bytes": 164619367, "downloaded_bytes": 164332937, "focused_pass_recommendation": null, "visual_coverage": "full"}
transcript: captions:automatic lang en segments 214 remote_transcription disabled
frames: 36
frames on disk nonzero: 36 missing: 0
first/last ts: 00:00 1:01:49 | 0.0 3708.94
reasons: ['periodic_coverage', 'scene_or_slide_change']
warnings: ["transcript evidence was truncated to the bounded manifest budget", "video is over 10 minutes; this is sparse sampled evidence, not every frame"]
token_budget: {"batching_guidance": "Read frames in batches of 10-20 and cite timestamps; re-run focused with --start/--end if a sampled range is insufficient.", "estimated_frame_tokens": 43200, "estimated_total_tokens": 47196, "estimated_transcript_tokens": 3996, "max_frames": 36, "resolution_px_wide": 512}
receipt present: True
```
</details>
<details>
<summary>Evidence: Media-ceiling refusal before download, transcript-only evidence returned</summary>

<code>media: acquired false, downloaded_bytes null, visual_coverage none, byte_ceiling 10000000, declared_bytes 164619367&#10;focused_pass_recommendation: no visual frames were acquired within the transient media ceiling; re-run one focused pass with --start 00:00 --end 05:00, or raise --max-media-bytes if the local disk allows it&#10;transcript still returned: captions:automatic, en, 214 segments | frames: 0&#10;warnings: declared public media size exceeds the transient byte ceiling, so no video was downloaded; this manifest carries transcript and chapter evidence only, do not claim any visual coverage</code>

```text
schema: fm.video-watch.manifest.v1 | mode: prepare
source: {"host": "www.youtube.com", "kind": "public_url", "path": "/watch", "query_keys": ["v"], "sanitized": "https://www.youtube.com/watch?v=8ZgpAXe5V5w"}
title: L8 Principal's Agentic Engineering Setup (just copy him)
duration: 1:01:49 3709.0
selected_ranges: [{"end_seconds": 3709.0, "reason": "full_video", "start_seconds": 0.0}]
media: {"acquired": false, "acquired_range": null, "acquisition_reason": "no_focus_range_requested", "byte_ceiling": 10000000, "declared_bytes": 164619367, "downloaded_bytes": null, "focused_pass_recommendation": "no visual frames were acquired within the transient media ceiling; re-run one focused pass with --start 00:00 --end 05:00, or raise --max-media-bytes if the local disk allows it", "visual_coverage": "none"}
transcript: captions:automatic lang en segments 214 remote_transcription disabled
frames: 0
warnings: ["the declared public media size exceeds the transient byte ceiling, so no video was downloaded", "this manifest carries transcript and chapter evidence only; do not claim any visual coverage", "transcript evidence was truncated to the bounded manifest budget"]
token_budget: {"batching_guidance": "Read frames in batches of 10-20 and cite timestamps; re-run focused with --start/--end if a sampled range is insufficient.", "estimated_frame_tokens": 0, "estimated_total_tokens": 3996, "estimated_transcript_tokens": 3996, "max_frames": 36, "resolution_px_wide": 512}
receipt present: True
```
</details>
<details>
<summary>Evidence: Focused-range run takes the bounded provider section</summary>

<code>selected_ranges: 1, focused_range, 120.0-180.0&#10;media: visual_coverage section, acquisition_reason a_bounded_section_is_projected_cheaper_than_the_full_media, acquired_range 120.0-180.0, downloaded 3603554 bytes&#10;frames: 18, all on disk; first 02:00 (120.0), last 03:00 (179.5) in absolute source coordinates&#10;warnings: visual evidence covers only the requested section 02:00-03:00, not the whole video</code>

```text
schema: fm.video-watch.manifest.v1 | mode: prepare
source: {"host": "www.youtube.com", "kind": "public_url", "path": "/watch", "query_keys": ["v"], "sanitized": "https://www.youtube.com/watch?v=9WOpQqSO5aA"}
title: Real AI Agent Stack: Harness → Loop → Graph
duration: 09:19 559.0
selected_ranges: [{"end_seconds": 180.0, "reason": "focused_range", "start_seconds": 120.0}]
media: {"acquired": true, "acquired_range": {"end_seconds": 180.0, "start_seconds": 120.0}, "acquisition_reason": "a_bounded_section_is_projected_cheaper_than_the_full_media", "byte_ceiling": 4294967296, "declared_bytes": 19939872, "downloaded_bytes": 3603554, "focused_pass_recommendation": null, "visual_coverage": "section"}
transcript: captions:automatic lang en segments 28 remote_transcription disabled
frames: 18
frames on disk nonzero: 18 missing: 0
first/last ts: 02:00 03:00 | 120.0 179.5
reasons: ['focused_range_end', 'focused_range_start+periodic_coverage', 'periodic_coverage']
warnings: ["visual evidence covers only the requested section 02:00-03:00, not the whole video"]
token_budget: {"batching_guidance": "Read frames in batches of 10-20 and cite timestamps; re-run focused with --start/--end if a sampled range is insufficient.", "estimated_frame_tokens": 21600, "estimated_total_tokens": 22120, "estimated_transcript_tokens": 520, "max_frames": 36, "resolution_px_wide": 512}
receipt present: True
```
</details>
<details>
<summary>Evidence: Local-file path over an explicitly supplied clip</summary>

<code>source: kind local_file, sanitized &#34;demo-clip.mp4&#34; (basename only, no local path in the manifest)&#10;duration 20.0; selected_ranges 1 full_video 0.0-20.0; visual_coverage full&#10;frames: 18, all on disk; first 00:00 (0.0), last 00:20 (19.5 &lt; 20.0)&#10;transcript: none, remote_transcription disabled&#10;warnings: local-file transcription is not enabled in v1</code>

```text
schema: fm.video-watch.manifest.v1 | mode: prepare
source: {"kind": "local_file", "sanitized": "demo-clip.mp4"}
title: demo-clip.mp4
duration: 00:20 20.0
selected_ranges: [{"end_seconds": 20.0, "reason": "full_video", "start_seconds": 0.0}]
media: {"acquired": true, "acquired_range": null, "acquisition_reason": "no_focus_range_requested", "byte_ceiling": 2147483648, "declared_bytes": 2089593, "downloaded_bytes": 2089593, "focused_pass_recommendation": null, "visual_coverage": "full"}
transcript: none lang None segments 0 remote_transcription disabled
frames: 18
frames on disk nonzero: 18 missing: 0
first/last ts: 00:00 00:20 | 0.0 19.5
reasons: ['periodic_coverage']
warnings: ["local-file transcription is not enabled in v1 unless captions are separately supported later"]
token_budget: {"batching_guidance": "Read frames in batches of 10-20 and cite timestamps; re-run focused with --start/--end if a sampled range is insufficient.", "estimated_frame_tokens": 21600, "estimated_total_tokens": 21600, "estimated_transcript_tokens": 0, "max_frames": 36, "resolution_px_wide": 512}
receipt present: True
```
</details>
<details>
<summary>Evidence: Safety refusals with documented exit classes and receipt-proven cleanup</summary>

<code>playlist URL exit 4 playlist URLs are rejected; provide exactly one public video URL&#10;channel /live URL exit 4 public video metadata was unavailable without login or was unsupported&#10;file:// scheme exit 4 unsupported source scheme; use a public http(s) URL or an explicit local file path&#10;token/Signature query exit 4 URL carries credential, signature, session, or token query fields&#10;local symlink exit 4 local video file must be an explicit regular file, not a symlink&#10;non-video extension exit 4 local file extension is not a supported video type&#10;missing local file exit 2 local video file was not found&#10;smoke, one or zero opt-ins exit 2 real public smoke is opt-in only; needs FM_VIDEO_WATCH_REAL_SMOKE=1 AND --i-understand-this-uses-network&#10;cleanup, wrong receipt exit 2 cleanup receipt is malformed&#10;every retained receipt -&gt; cleanup removed=true, directory absent</code>

```text
channel/live URL           exit=4  fm-video-watch: public video metadata was unavailable without login or was unsupported
                             retained receipt -> cleanup removed=True, dir absent=yes
local symlink              exit=4  fm-video-watch: local video file must be an explicit regular file, not a symlink
                             retained receipt -> cleanup removed=True, dir absent=yes
non-video extension        exit=4  fm-video-watch: local file extension is not a supported video type
                             retained receipt -> cleanup removed=True, dir absent=yes
missing local file         exit=2  fm-video-watch: local video file was not found
                             retained receipt -> cleanup removed=True, dir absent=yes
```
</details>
<details>
<summary>Evidence: Targeted test run log (video-watch contract suite + documentation audiences)</summary>

<code>FM_TEST_SUMMARY total=2 failed=0 skipped_gate=0 duration_ms=17294&#10;ok - the default whole-video path extracts every planned frame from real media and cleans up exactly&#10;ok - real public smoke cannot run accidentally</code>

```text
FM_TEST_BEGIN 2026-08-03T00:14:55Z tests/fm-video-watch.test.sh family=unclassified expected_gate_skip=none
ok - doctor is detect-only when dependencies are missing
ok - playlist and credential-bearing query rejection is value-safe
ok - the exact supplied public URL is fetched while the manifest stays value-safe
ok - playlist, live, authenticated, and DRM metadata are rejected
ok - transcript-first planning emits a bounded value-safe manifest and cleans up exactly
ok - focused ranges use absolute timestamps, denser caps, and requested captions
ok - bounded section downloads keep manifest timestamps absolute and coverage honest
ok - a section download of a source with no advertised duration keeps source-timeline focus ranges
ok - optional caption failure degrades and unexpected failures map onto the documented exit classes
ok - a focus range that covers most of the source takes the cheaper full download without losing the range
ok - declared media above the transient ceiling is refused before download with transcript evidence returned
ok - the transient media ceiling clamps by default, keeps seeks inside the media, and requires proven free space only when raised
ok - local file mode refuses unsafe files and copies accepted media into owned temp storage
ok - malformed metadata and extraction failures stay value-safe and clean up by their retained receipt
ok - cleanup requires matching receipt and resists symlink marker replacement
ok - the default whole-video path extracts every planned frame from real media and cleans up exactly
ok - real public smoke cannot run accidentally
FM_TEST_END 2026-08-03T00:15:11Z tests/fm-video-watch.test.sh exit=0 duration_ms=15705 gate_skip=false
FM_TEST_BEGIN 2026-08-03T00:15:11Z tests/fm-documentation-audiences.test.sh family=pure-contract-unit expected_gate_skip=none
ok - documentation inventory classifies every maintained prose surface exactly once
ok - classification, setup routing, and maintained-prose scope fail safely
ok - required documentation owner pointers cannot silently disappear
ok - local links resolve while dates, versions, commands, and incident prose remain semantically reviewed
FM_TEST_END 2026-08-03T00:15:12Z tests/fm-documentation-audiences.test.sh exit=0 duration_ms=1450 gate_skip=false
FM_TEST_SUMMARY total=2 failed=0 skipped_gate=0 duration_ms=17294
FM_TEST_SUMMARY_FAMILY family=pure-contract-unit count=1 duration_ms=1450 failed=0
FM_TEST_SUMMARY_FAMILY family=unclassified count=1 duration_ms=15705 failed=0
FM_TEST_SLOWEST rank=1 script=tests/fm-video-watch.test.sh duration_ms=15705
FM_TEST_SLOWEST rank=2 script=tests/fm-documentation-audiences.test.sh duration_ms=1450
```
</details>
<details>
<summary>Evidence: fm-video-watch.sh --help operator contract</summary>

```text
usage: fm-video-watch.sh [-h] {doctor,prepare,cleanup,smoke} ...

Prepare safe, bounded video evidence manifests for Firstmate /watch.

positional arguments:
  {doctor,prepare,cleanup,smoke}
    doctor              Detect dependencies only; never install anything
    prepare             Create one value-safe manifest and evidence directory
    cleanup             Remove exactly one owned evidence directory using its
                        opaque receipt
    smoke               Opt-in real public smoke; impossible to run
                        accidentally

options:
  -h, --help            show this help message and exit

The manifest is sparse evidence: it reports sampled frames and transcript
windows, not a claim that every frame was watched. Public URL mode uses yt-dlp
only, with no browser profiles, cookies, login state, headers, or extensions.
The supplied public URL is fetched exactly as given; only the manifest
description redacts query values, and credential, signature, session, or token
query fields are refused outright. Public media is bounded by a transient byte
ceiling both before download and after acquisition, focused runs take
whichever bounded route is projected cheaper because a provider section is re-
encoded rather than stream-copied, and media.visual_coverage plus
media.acquisition_reason report whether the evidence is full, section-only, or
absent and why. Missing dependencies are reported; no installer is run. Remote
transcription is disabled in v1.
```
</details>
- Outcome: ⚠️ 1 info across 1 run (15m19s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ⚠️ `bin/fm-video-watch-impl.py:1209` - Intent conformance: the criteria require preserving &#34;Groq/OpenAI Whisper fallback only from already configured protected local provider settings without exposing or asking for keys&#34; and forbid remote transcription &#34;in v1 unless securely preconfigured&#34;. The change removes that capability entirely rather than gating it on a preconfigured provider: the manifest hardcodes `&#34;remote_transcription&#34;: &#34;disabled&#34;` (impl.py:1209), the manifest emits the warning &#34;no compatible public captions were advertised; remote transcription is disabled in v1&#34; (impl.py:1120) and &#34;local-file transcription is not enabled in v1&#34; (impl.py:1145), the skill states &#34;Remote transcription is disabled in v1&#34; (.agents/skills/watch/SKILL.md:43), and the wrapper header asserts it &#34;does not read or write ~/.config/watch/.env&#34; (bin/fm-video-watch.sh:29). Consequence: a public video with no captions, and every local file, yields zero transcript evidence even when the captain already has a protected provider configured. This is honest and clearly disclosed, but it drops a behavior the intent marks as preserved, so it needs the author&#39;s call rather than a reviewer fix.
- ⚠️ `bin/fm-video-watch-impl.py:1152` - `duration` falls back to the *acquired media&#39;s* probed duration while `--start`/`--end` remain in *source* timeline coordinates, so a bounded section download poisons range validation. Failing sequence: a yt-dlp extractor that returns no `duration` (generic/direct-file extractors do this) plus `prepare &lt;url&gt; --end 00:20 --start 00:10`. `requested_section(10, 20, 0.0)` returns `(10, 20)`; `choose_acquisition` hits `projected_section_share(10, 0.0) -&gt; None` and returns the section with reason `source_duration_unknown_so_the_focus_range_bounds_acquisition`; the 10 s section downloads successfully; `probe_video` reports `duration_seconds == 10`; line 1152 sets `duration = 10` because metadata duration is 0; then `select_ranges(10, ..., start=10, end=20)` hits `if lo &gt;= duration` and raises WatchError code 2 &#34;--start is at or after the end of the video&#34;. The run therefore pays for a successful download and then exits 2 with a message that contradicts the request. Fix at the boundary that introduced the coordinate mix: keep the source-timeline duration separate from the probed-media duration and feed only the source-timeline value to `select_ranges`/`requested_section`, falling back to `media.offset_seconds + probed_duration` when the media is a section.
- ⚠️ `bin/fm-video-watch-impl.py:1324` - `main()` catches only `WatchError`, so any other exception escapes as a Python traceback with exit code 1, which is outside the exit-code contract the wrapper documents (bin/fm-video-watch.sh:31-36 declares 0/2/3/4/5). Concrete reachable trigger: `shutil.copy2(local_path, local_copy)` at impl.py:1137 raises `OSError: [Errno 28] No space left on device` when the owned temp directory&#39;s filesystem is full. Local mode has no free-space preflight at all, unlike URL mode which calls `resolve_media_ceiling` (impl.py:1109), so copying a file up to the 2 GiB `--max-local-bytes` default can exhaust temp space. The `except Exception` at impl.py:1239 prints the retention receipt and re-raises, so the caller gets receipt line + traceback + exit 1, and any shell wrapping this on exit-code classes mis-handles it. Wrap the `args.func(args)` call in a broad handler that maps unexpected exceptions to code 5 with a value-safe message, and add a free-space check before the local copy.
- ⚠️ `bin/fm-video-watch-impl.py:539` - Caption retrieval is treated as optional everywhere except on timeout, where it becomes fatal. `retrieve_captions` calls `run_quiet(cmd)` with the 180 s `MAX_COMMAND_SECONDS` default; `run_quiet` converts `subprocess.TimeoutExpired` (and `OSError`) into `WatchError(code 5)`, which propagates straight out of `build_manifest` and aborts the whole run. Every sibling optional path degrades instead: a non-zero yt-dlp return with no VTT returns `None` and only adds a warning (impl.py:541-543, 1118), and `scene_timestamps` explicitly catches `WatchError` and falls back to periodic coverage (impl.py:917-919). Failing sequence: a long source whose auto-caption fetch takes over 180 s on a slow link exits 5 with &#34;command timed out after 180s: yt-dlp&#34;, discarding a run that could have returned full visual evidence with a &#34;captions unavailable&#34; warning. This also contradicts the guarantee recorded in docs/verification/video-watch.md:49 (&#34;optional enrichment stays optional&#34;). Catch `WatchError` around the caption `run_quiet` and degrade to a warning.
- ⚠️ `bin/fm-video-watch-impl.py:841` - The transient byte ceiling does not bound peak on-disk usage, and the resulting local failure is reported as a remote-access refusal. `MEDIA_FORMAT_SELECTOR` is `bv*[height&lt;=720]+ba/...` with `--merge-output-format mp4`, and yt-dlp applies `--max-filesize` per downloaded format, so a ceiling of N permits roughly 2N on disk at merge time (separate video file + audio file + merged output). Meanwhile `resolve_media_ceiling` only reserves `FREE_SPACE_MARGIN_BYTES` (512 MiB) beyond the ceiling itself (impl.py:699-710). Failing sequence: 5 GiB free, default 4 GiB ceiling (unclamped because 4 GiB &lt; 4.5 GiB usable), a ~3 GiB source; the merge fills the disk, yt-dlp exits non-zero writing no `video.*`, so `run_ytdlp_download` returns `(None, hit_ceiling=False, returncode!=0)` and line 841 raises code 4 &#34;public video download failed without safe public access&#34; - the exit class reserved for unsupported/authenticated/DRM sources - for what is purely a local disk-space failure. That misroutes the operator and contradicts the wrapper header&#39;s claim that transient media is &#34;bounded by --max-media-bytes ... enforced before download and again after acquisition&#34; (bin/fm-video-watch.sh:16-19). Deciding whether the ceiling should mean peak bytes (halve the per-format limit or widen the free-space margin) or stay a final-artifact bound with a distinct disk-space exit class is the author&#39;s call.
- ⚠️ `README.md:176` - The new skill declares `user-invocable: true` (.agents/skills/watch/SKILL.md:6) but is not added to README.md&#39;s &#34;Built-in skills&#34; table, whose stated scope is &#34;Firstmate ships these user-invocable built-in skills&#34;. All five other `user-invocable: true` skills under .agents/skills/ (afk, ahoy, bearings, updatefirstmate, stow) have a row there. The change updates every other registry it touches - AGENTS.md:232, docs/documentation-audiences.json, docs/scripts.md, and the bin/fm-test-run.sh changed-path family map - so this is the one missed one, and no test enforces it, which is why it will not be caught downstream. Add a `/watch` row.
- ℹ️ `bin/fm-video-watch-impl.py:1098` - Simplification: `clamp_requested_limits` is called twice with provably identical arguments and its first result is discarded. At line 1098 `focused = start is not None or end is not None`; at line 1157 the same call passes `ranges[0].reason == &#39;focused_range&#39;`, which `select_ranges` sets exactly when `start is not None or end is not None` (impl.py:634-641). The two `focused` values can never differ, so the second call recomputes the same caps and re-appends the same warnings (deduped only by `sorted(set(warnings))` at line 1234). If the first call is there to validate `--max-frames`/`--resolution` positivity before the workdir and download, split that validation out and keep a single clamp; otherwise drop the second call.

🔧 Fix: fix video-watch duration coordinates, exit classes, caption degradation
1 info still open:
- ℹ️ `bin/fm-video-watch-impl.py:543` - The new caption-timeout degradation appends its warning unconditionally, before the code knows whether a VTT is still going to be used. Failing sequence: `run_quiet` times out and SIGKILLs yt-dlp after it has already written `captions/caption.&lt;lang&gt;.vtt` (partially or fully). The `except WatchError` branch appends &#34;caption retrieval did not finish; the run continued without caption evidence&#34; (line 543-545), then line 546 globs and finds the file, so line 549 returns it; the caller at impl.py:1130-1132 parses it and sets `transcript.available: true` with `provenance: captions:manual`. The manifest then carries transcript segments while simultaneously warning that the run continued *without* caption evidence, and a truncated VTT is presented as complete caption coverage with no incompleteness signal - directly against the honest-coverage discipline the rest of this manifest enforces (`media.visual_coverage`, the section-only warning, the sparse-sampling warning). Move the warning after the candidate check: emit &#34;the run continued without caption evidence&#34; only when `None` is returned, and emit a distinct &#34;caption retrieval did not finish; the transcript may be incomplete&#34; when a candidate is used anyway.

</details>

<details>
<summary>⚠️ **Test** - 1 info</summary>

- ℹ️ `tests/lib.sh:71` - Shared test-harness hygiene, pre-existing and not introduced by this change: tests/lib.sh:71 registers the temp root and installs its EXIT trap inside a command-substitution subshell (TMP_ROOT=$(fm_test_tmproot ...)), so the parent shell never removes it. One run of tests/fm-video-watch.test.sh left a root behind with 206 entries / 540 KB, and 46 such roots have accumulated for this suite alone (about 10 other suites show the same pattern at lower volume). I removed my own root. No action needed for this change; noted so a reviewer can decide whether the harness is worth fixing separately.
- <code>`bin/fm-test-run.sh tests/fm-video-watch.test.sh tests/fm-documentation-audiences.test.sh` (0 failures, gate_skip=false so the real-ffmpeg whole-video regression actually ran)</code>
- <code>`bin/fm-video-watch.sh doctor` (detect-only: ready=true, auto_install_attempted=false, install hint only)</code>
- <code>`bin/fm-video-watch.sh --help` (exit 0, full operator contract printed)</code>
- <code>`bin/fm-video-watch.sh prepare &#39;https://www.youtube.com/watch?v=9WOpQqSO5aA&#39; --question &#39;Summarize the video&#39;` plus a manifest invariant check: single full_video range 0.0-559.0, visual_coverage full, 20/20 frames on disk nonzero, on-disk image count equal to len(frames), last ts 558.34 &lt; 559.0</code>
- `Read frames 1, 10 and 20 of that run with the ordinary Read tool, the way the skill directs an agent to consume the evidence`
- <code>`bin/fm-video-watch.sh prepare &#39;&lt;9WOpQqSO5aA&gt;&#39; --start 02:00 --end 03:00` (section route, acquired_range 120.0-180.0, 3603554 bytes vs 20008710 full, 18 frames at absolute 120.0-179.5)</code>
- <code>`bin/fm-video-watch.sh prepare &#39;https://www.youtube.com/watch?v=8ZgpAXe5V5w&#39; --question &#39;Summarize the video&#39; --max-media-bytes 10000000` (refused before download, transcript and chapters still returned, exact URL preserved)</code>
- <code>`FM_VIDEO_WATCH_REAL_SMOKE=1 bin/fm-video-watch.sh smoke --url &#39;https://www.youtube.com/watch?v=8ZgpAXe5V5w&#39; --question &#39;Summarize the video&#39; --i-understand-this-uses-network` (63s, 36/36 frames on disk, 0.17% size accuracy, last frame 3708.94 read back and decodes)</code>
- `Leak-canary scan over the full smoke manifest for signature / token= / cookie / /Users/ / googlevideo: no hits`
- <code>`bin/fm-video-watch.sh prepare &lt;synthesized 20s local clip&gt;` plus an ffmpeg contact sheet of all 18 extracted frames</code>
- `CLI refusal matrix: playlist URL, channel/live URL, file:// scheme, token/Signature query, local symlink, non-video extension, missing local file, smoke with one or zero opt-ins, malformed cleanup receipt (exit classes 4/4/4/4/4/4/2/2/2)`
- <code>`bin/fm-video-watch.sh cleanup &#39;&lt;receipt&gt;&#39;` on all five prepare/smoke runs and on every refusal that retained a receipt (removed=true, directory absent afterward, including the 158M smoke directory)</code>
- <code>`git status --porcelain` and a system-temp sweep for fm-video-watch-* directories created during this phase (both empty after cleanup)</code>

</details>

<details>
<summary>⚠️ **Document** - 2 infos</summary>

- ℹ️ `docs/verification/video-watch.md:181` - Removed the trailing `resolved: [key=01KZ1NPWRMTEZXYFDDXT1XT9N4] captain approved refreshed public proof and whole-video extraction correction` line, a one-off process identifier that the placement policy keeps out of tracked docs and that matches no convention found in .no-mistakes.yaml, CLAUDE.md, or the decision-hold docs. Its substance is already carried by the whole-video defect section and the refreshed smoke block. Surfacing it as a judgment call: if the gate expects that ack inside the diff rather than in `no-mistakes respond` output, restore the line.
- ℹ️ `.agents/skills/watch/SKILL.md:71` - Follow-up, out of scope here: the upstream revision 755c157466738dda102c939158a0116b972925a3 is stated in three places (this skill&#39;s Attribution, the verification doc&#39;s Upstream provenance block, and the bin/fm-video-watch.sh header). docs/verification/video-watch.md holds the full record and is the owner; the other two could keep short MIT attribution and point there, so a future re-baseline updates one string instead of three. Left as is because all three are currently correct and attribution belongs near the derived work.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
