### PR TITLE
feat(bin): publish the Captain's Log machine projection for Engineering

### DIFF
--- a/.agents/skills/decision-hold-lifecycle/SKILL.md
+++ b/.agents/skills/decision-hold-lifecycle/SKILL.md
@@ -22,6 +22,8 @@ A completed investigation and an ended visual review use this same owner and com
 Run the command in the originating work's authoritative `FM_HOME`; main-home work creates main-home holds, and secondmate-owned work creates holds in that secondmate home's backlog rather than copying them into the main backlog.
 Do not close a hold merely because the originating investigation completed, its report was archived, its visual review ended, or its task was torn down.
 The hold remains the authoritative Captain's Call item until the captain's answer is durably recorded, dependent work is created in the same backlog and blocked by that hold, and `bin/fm-decision-hold.sh resolve` routes the answer by clearing those dependency edges before closing the hold.
+A Captain Call that `bin/fm-report.sh` raises from an accepted Engineering mission is the one exception: it lives in this same backlog and closes through this same `resolve` owner, but only the `resolveCondition` intent of `bin/fm-captains-log-projection.sh` may drive it.
+A bare `resolve` would close that hold without the durable outcome the projection derives resolution from, leaving the captain's answer unprojected.
 Resolved findings, recommendations that need no captain choice, and prose that merely sounds decision-like do not create holds.
 Bearings reads the resulting structured state and must never compensate by scraping historical reports, visual-review artifacts, terminal output, chat, or other prose.
 

--- a/bin/fm-captains-log-projection.sh
+++ b/bin/fm-captains-log-projection.sh
@@ -449,10 +449,12 @@ intent_response() {  # <intent-json>
     2) return 2 ;;
   esac
   lock_dir="$STATE/fm-projection-intent-locks/$intent_id"
-  fm_eng_lock_acquire "$lock_dir" "${FM_PROJECTION_INTENT_LOCK_STALE_MINUTES:-}" "$NOW" || {
-    fail_json intent_busy "The intent is already being processed"
-    return 2
-  }
+  fm_eng_lock_acquire "$lock_dir" "${FM_PROJECTION_INTENT_LOCK_STALE_MINUTES:-}" "$NOW"
+  case $? in
+    0) ;;
+    1) fail_json intent_busy "The intent is already being processed"; return 2 ;;
+    *) fail_json intent_lock_unavailable "The intent mutex could not be created, so the intent was not applied"; return 2 ;;
+  esac
   trap fm_eng_lock_release_all RETURN
   replay_prior_outcome "$record" "$digest_value"
   case $? in

--- a/bin/fm-captains-log-projection.sh
+++ b/bin/fm-captains-log-projection.sh
@@ -1,0 +1,679 @@
+#!/usr/bin/env bash
+# fm-captains-log-projection.sh - bounded machine projection for Captain's Log.
+#
+# Reads one JSON request from stdin and prints one JSON response.
+# The stable request schema is fm-captains-log-projection.v1.
+#
+# Supported operations:
+#   {"schemaVersion":"fm-captains-log-projection.v1","operation":"capabilities"}
+#   {"schemaVersion":"fm-captains-log-projection.v1","operation":"snapshot"}
+#   {"schemaVersion":"fm-captains-log-projection.v1","operation":"intent","intent":{...}}
+#
+# Core projection data is stored below data/engineering as closed JSON records.
+# Invalid records remain visible in snapshot.invalidRecords and are never used
+# to derive executable conditions, review packets, or command outcomes.
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
+DATA="${FM_DATA_OVERRIDE:-$FM_HOME/data}"
+STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
+ENGINEERING="$DATA/engineering"
+MISSIONS="$ENGINEERING/missions"
+REPORTS="$ENGINEERING/reports"
+OUTCOMES="$ENGINEERING/outcomes"
+SHAPEUP_OUTCOMES="$ENGINEERING/shapeup-outcomes"
+NOW="${FM_PROJECTION_NOW:-$(date -u +%Y-%m-%dT%H:%M:%SZ)}"
+SCHEMA=fm-captains-log-projection.v1
+
+# shellcheck source=bin/fm-engineering-lib.sh
+# shellcheck disable=SC1091
+. "$SCRIPT_DIR/fm-engineering-lib.sh"
+
+command -v jq >/dev/null 2>&1 || {
+  echo "fm-captains-log-projection: jq not found" >&2
+  exit 1
+}
+
+digest() {
+  if command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 | awk '{print $1}'
+  else
+    sha256sum | awk '{print $1}'
+  fi
+}
+
+fail_json() {  # <code> <message>
+  jq -n --arg schemaVersion "$SCHEMA" --arg code "$1" --arg message "$2" \
+    '{accepted:false,schemaVersion:$schemaVersion,error:{code:$code,message:$message}}'
+}
+
+valid_identity() {  # <value>
+  case "$1" in
+    ''|*[!A-Za-z0-9._-]*) return 1 ;;
+  esac
+  [ "${#1}" -le 128 ]
+}
+
+INTENT_LOCK_DIR=''
+INTENT_LOCK_HOST=${HOSTNAME:-$(hostname 2>/dev/null || printf 'unknown-host')}
+INTENT_LOCK_STALE_MINUTES=5
+case "${FM_PROJECTION_INTENT_LOCK_STALE_MINUTES:-}" in
+  ''|*[!0-9]*) ;;
+  *)
+    if [ "${#FM_PROJECTION_INTENT_LOCK_STALE_MINUTES}" -le 9 ] \
+      && [ "$FM_PROJECTION_INTENT_LOCK_STALE_MINUTES" -ge 1 ]; then
+      INTENT_LOCK_STALE_MINUTES=$FM_PROJECTION_INTENT_LOCK_STALE_MINUTES
+    fi
+    ;;
+esac
+
+remove_intent_lock() {  # <lock-dir>
+  rm -f "$1/owner" 2>/dev/null || true
+  rmdir "$1" 2>/dev/null || true
+}
+
+release_intent_lock() {
+  [ -n "$INTENT_LOCK_DIR" ] || return 0
+  remove_intent_lock "$INTENT_LOCK_DIR"
+  INTENT_LOCK_DIR=''
+}
+
+PROCESS_START_METHOD=lstart
+
+# The signature is rendered in a fixed locale and timezone so the same process
+# always yields the same identity whatever environment observes it. It carries
+# its method so a signature produced a different way is never mistaken for a
+# different process.
+process_start_signature() {  # <pid>
+  local value
+  value=$(LC_ALL=C TZ=UTC ps -o lstart= -p "$1" 2>/dev/null | tr -d '[:space:]')
+  [ -n "$value" ] || return 1
+  printf '%s:%s' "$PROCESS_START_METHOD" "$value"
+}
+
+# A lock whose recorded owner is provably gone - exited, or its pid recycled by a
+# process that started later - is reclaimed at once. An owner that cannot be
+# compared, including one recorded by another identity method, falls back to the
+# bounded age window, so no lock can wedge forever and none is reclaimed merely
+# because its identity is presented differently. A confirmed live owner is never
+# reclaimed, however long it runs and whoever owns it.
+intent_lock_owner_state() {  # <lock-dir>
+  local dir=$1 owner_host owner_pid owner_started current_started
+  if [ ! -f "$dir/owner" ]; then
+    printf 'unknown'
+    return 0
+  fi
+  owner_host=$(sed -n 's/^host=//p' "$dir/owner" 2>/dev/null | head -1)
+  owner_pid=$(sed -n 's/^pid=//p' "$dir/owner" 2>/dev/null | head -1)
+  owner_started=$(sed -n 's/^started=//p' "$dir/owner" 2>/dev/null | head -1)
+  if [ "$owner_host" != "$INTENT_LOCK_HOST" ]; then
+    printf 'unknown'
+    return 0
+  fi
+  case "$owner_pid" in
+    ''|*[!0-9]*) printf 'unknown'; return 0 ;;
+  esac
+  current_started=$(process_start_signature "$owner_pid") || current_started=''
+  if [ -z "$current_started" ]; then
+    if kill -0 "$owner_pid" 2>/dev/null; then
+      printf 'unknown'
+    else
+      printf 'dead'
+    fi
+    return 0
+  fi
+  case "$owner_started" in
+    "$PROCESS_START_METHOD":?*) ;;
+    *) printf 'unknown'; return 0 ;;
+  esac
+  if [ "$owner_started" = "$current_started" ]; then
+    printf 'alive'
+  else
+    printf 'dead'
+  fi
+}
+
+reclaim_stale_intent_lock() {  # <lock-dir>
+  local dir=$1
+  [ -d "$dir" ] || return 0
+  case "$(intent_lock_owner_state "$dir")" in
+    alive) return 0 ;;
+    dead) ;;
+    *)
+      [ -n "$(find "$dir" -maxdepth 0 -mmin "+$INTENT_LOCK_STALE_MINUTES" -print 2>/dev/null)" ] || return 0
+      ;;
+  esac
+  remove_intent_lock "$dir"
+}
+
+trap release_intent_lock EXIT
+trap 'release_intent_lock; exit 130' INT
+trap 'release_intent_lock; exit 143' TERM
+trap 'release_intent_lock; exit 129' HUP
+
+collect_records() {  # <dir> <kind>
+  local dir=$1 kind=$2 file records invalid
+  local -a files=() valid=() malformed=()
+  if [ -d "$dir" ]; then
+    while IFS= read -r file; do
+      [ -n "$file" ] || continue
+      files[${#files[@]}]=$file
+    done < <(find "$dir" -type f -name '*.json' -print 2>/dev/null | LC_ALL=C sort)
+  fi
+  if [ "${#files[@]}" -eq 0 ]; then
+    printf '{"records":[],"invalid":[]}'
+    return 0
+  fi
+  if records=$(printf '%s\0' "${files[@]}" | xargs -0 cat 2>/dev/null | jq -cn '[inputs]' 2>/dev/null) \
+    && [ "$(printf '%s' "$records" | jq -r 'length')" = "${#files[@]}" ] \
+    && [ "$(printf '%s' "$records" | jq -r 'all(type == "object")')" = true ]; then
+    jq -cn --argjson records "$records" '{records:$records,invalid:[]}'
+    return 0
+  fi
+  for file in "${files[@]}"; do
+    if jq -e 'type == "object"' "$file" >/dev/null 2>&1; then
+      valid[${#valid[@]}]=$file
+    else
+      malformed[${#malformed[@]}]=$(basename "$file" .json)
+    fi
+  done
+  records='[]'
+  if [ "${#valid[@]}" -gt 0 ]; then
+    records=$(printf '%s\0' "${valid[@]}" | xargs -0 cat 2>/dev/null \
+      | jq -cn '[inputs | select(type == "object")]') || return 1
+    [ -n "$records" ] || return 1
+    [ "$(printf '%s' "$records" | jq -r 'length')" = "${#valid[@]}" ] || return 1
+  fi
+  invalid='[]'
+  if [ "${#malformed[@]}" -gt 0 ]; then
+    invalid=$(jq -cn --arg kind "$kind" '
+      [ $ARGS.positional[]
+        | {kind:$kind,recordId:.,error:{code:"malformed_record",message:"Record is not a valid JSON object"}} ]
+    ' --args "${malformed[@]}") || return 1
+  fi
+  jq -cn --argjson records "$records" --argjson invalid "$invalid" '{records:$records,invalid:$invalid}'
+}
+
+condition_projection() {  # <reports-json> <outcomes-json>
+  jq -cn --argjson reports "$1" --argjson outcomes "$2" '
+    [ $reports[]
+      | select(.condition? and (.condition | type == "object"))
+      | select(.status? == "accepted")
+      | {
+          reportId:.reportId,
+          missionId:.missionId,
+          conditionId:.condition.conditionId,
+          holdId:(.condition.holdId // null),
+          packetRevision:(.condition.packetRevision // .sourceRevision),
+          lifecycle:(.condition.lifecycle // "raised"),
+          affectedObjects:(.condition.affectedObjects // []),
+          explanation:(.condition.explanation // ""),
+          recommendation:(.condition.recommendation // ""),
+          choices:(.condition.choices // []),
+          consequenceOfDelay:(.condition.consequenceOfDelay // ""),
+          evidence:(.condition.evidence // []),
+          boundRevisions:(.condition.boundRevisions // {}),
+          creationSequence:(.condition.creationSequence // 0),
+          projection:(.condition.projection // null),
+          cycleRef:(.correlation.shapeUp.cycleRef // ""),
+          buildRef:(.correlation.shapeUp.buildRef // ""),
+          scopeRef:(.correlation.shapeUp.scopeRef // null),
+          capturedAt:(.capturedAt // ""),
+          acceptedAt:(.acceptedAt // "")
+        }
+    ]
+    | sort_by(.missionId,.conditionId,.acceptedAt,.capturedAt,.reportId)
+    | group_by([.missionId,.conditionId])
+    | map(last)
+    | map(. as $condition
+      | .lifecycle = (
+          [ $outcomes[]
+            | select(.intent.action == "resolveCondition")
+            | select(.intent.missionId == $condition.missionId)
+            | select(.intent.conditionId == $condition.conditionId)
+            | select(.outcome.status == "resolved")
+          ]
+          | if length > 0 then "resolved" else $condition.lifecycle end))
+    | sort_by(.cycleRef,.buildRef,(.scopeRef // ""),.creationSequence,.missionId,.conditionId)
+  '
+}
+
+build_reviews() {  # <missions-json> <reports-json> <outcomes-json>
+  local missions=$1 reports=$2 outcomes=$3
+  jq -cn --argjson missions "$missions" --argjson reports "$reports" --argjson outcomes "$outcomes" '
+    def authoritative: sort_by(.acceptedAt // "",.capturedAt // "",.reportId) | last // null;
+    def terminal($missionId):
+      ([ $reports[]
+        | select(.status == "accepted" and .missionId == $missionId)
+        | select(.kind == "scope_discovery" or .kind == "scope_revision" or .kind == "hill_judgment" or .kind == "blocker" or .kind == "outcome")
+      ] | authoritative) as $latest
+      | ($latest != null
+        and $latest.kind == "outcome"
+        and ($latest.outcome.state == "completed" or $latest.outcome.state == "failed" or $latest.outcome.state == "cancelled"));
+    def required_evidence_verified($mission):
+      (($mission.evidenceRequirements // []) | all(. as $requirement |
+        ([ $reports[]
+          | select(.status == "accepted")
+          | select(.missionId == $mission.missionId and .kind == "evidence")
+          | select(.evidence.contract == $requirement)
+        ] | authoritative) as $latest
+        | ($latest != null and $latest.evidence.verification.status == "verified")));
+    [ $missions[]
+      | select((.state // "accepted") == "accepted")
+      | select(.correlation.shapeUp.buildRef? != null)
+    ]
+    | sort_by(.correlation.shapeUp.cycleRef,.correlation.shapeUp.buildRef,.missionId)
+    | group_by([.correlation.shapeUp.cycleRef,.correlation.shapeUp.buildRef])
+    | map(
+        . as $group
+        | ($group[0].correlation.shapeUp) as $shape
+        | ($group | map(.correlation.shapeUp.buildRevision // "") | unique) as $buildRevisions
+        | (($buildRevisions | length) > 1) as $revisionConflict
+        | ($group | map(. as $mission | {
+            missionId:$mission.missionId,
+            missionRevision:($mission.sourceRevision // ""),
+            buildRevision:($mission.correlation.shapeUp.buildRevision // ""),
+            terminal:terminal($mission.missionId),
+            evidenceVerified:required_evidence_verified($mission),
+            reportRevisions:([ $reports[]
+              | select(.status == "accepted" and .missionId == $mission.missionId)
+              | .sourceRevision ] | sort),
+            evidenceRevisions:([ $reports[]
+              | select(.status == "accepted" and .missionId == $mission.missionId and .kind == "evidence")
+              | .sourceRevision ] | sort)
+          })) as $missionSet
+        | {
+            cycleRef:$shape.cycleRef,
+            buildRef:$shape.buildRef,
+            buildRevision:(if $revisionConflict then null else ($buildRevisions[0] // "") end),
+            buildRevisions:$buildRevisions,
+            revisionConflict:$revisionConflict,
+            missionSet:$missionSet,
+            ready:(($revisionConflict | not) and ($missionSet | all(.terminal and .evidenceVerified))),
+            packetMaterial:({
+              cycleRef:$shape.cycleRef,
+              buildRef:$shape.buildRef,
+              buildRevisions:$buildRevisions,
+              revisionConflict:$revisionConflict,
+              missionSet:$missionSet
+            } | @json)
+          }
+      )
+  '
+}
+
+review_revisions() {  # <reviews-json>
+  local reviews=$1 count index material revision result='[]'
+  count=$(printf '%s' "$reviews" | jq -r 'if type == "array" then length else "invalid" end') || return 1
+  case "$count" in
+    ''|*[!0-9]*) return 1 ;;
+  esac
+  index=0
+  while [ "$index" -lt "$count" ]; do
+    material=$(printf '%s' "$reviews" | jq -r --argjson index "$index" '.[$index].packetMaterial') || return 1
+    revision=$(printf '%s' "$material" | digest) || return 1
+    [ -n "$revision" ] || return 1
+    result=$(jq -cn --argjson result "$result" --argjson reviews "$reviews" \
+      --argjson index "$index" --arg revision "$revision" '
+      $result + [$reviews[$index] | del(.packetMaterial) | . + {packetRevision:$revision}]') || return 1
+    index=$((index + 1))
+  done
+  printf '%s' "$result"
+}
+
+snapshot_json() {
+  local mission_bundle report_bundle outcome_bundle shapeup_bundle missions reports outcomes shapeup_outcomes invalid conditions material source_revision reviews
+  mission_bundle=$(collect_records "$MISSIONS" mission) || return 1
+  report_bundle=$(collect_records "$REPORTS" report) || return 1
+  outcome_bundle=$(collect_records "$OUTCOMES" outcome) || return 1
+  shapeup_bundle=$(collect_records "$SHAPEUP_OUTCOMES" shapeup-outcome) || return 1
+  missions=$(printf '%s' "$mission_bundle" | jq -c '.records | sort_by(.missionId // "")') || return 1
+  reports=$(printf '%s' "$report_bundle" | jq -c '.records | sort_by(.capturedAt // "",.reportId // "")') || return 1
+  outcomes=$(printf '%s' "$outcome_bundle" | jq -c '.records | sort_by(.recordedAt // "",.intentId // "")') || return 1
+  shapeup_outcomes=$(printf '%s' "$shapeup_bundle" | jq -c '.records | sort_by(.outcome.recordedAt // "",.outcome.reportId // "")') || return 1
+  invalid=$(jq -cn \
+    --argjson a "$(printf '%s' "$mission_bundle" | jq -c '.invalid')" \
+    --argjson b "$(printf '%s' "$report_bundle" | jq -c '.invalid')" \
+    --argjson c "$(printf '%s' "$outcome_bundle" | jq -c '.invalid')" \
+    --argjson d "$(printf '%s' "$shapeup_bundle" | jq -c '.invalid')" \
+    '$a + $b + $c + $d') || return 1
+  conditions=$(condition_projection "$reports" "$outcomes") || return 1
+  [ -n "$conditions" ] || return 1
+  material=$(jq -cS -n --argjson missions "$missions" --argjson reports "$reports" \
+    --argjson outcomes "$outcomes" --argjson shapeUpOutcomes "$shapeup_outcomes" --argjson invalid "$invalid" \
+    '{missions:$missions,reports:$reports,outcomes:$outcomes,shapeUpOutcomes:$shapeUpOutcomes,invalidRecords:$invalid}') || return 1
+  source_revision=$(printf '%s' "$material" | digest) || return 1
+  [ -n "$source_revision" ] || return 1
+  reviews=$(build_reviews "$missions" "$reports" "$outcomes") || return 1
+  [ -n "$reviews" ] || return 1
+  reviews=$(review_revisions "$reviews") || return 1
+  reviews=$(jq -cn --argjson reviews "$reviews" --argjson outcomes "$outcomes" '
+    $reviews
+    | map(. as $review
+      | .acceptance = (
+          [ $outcomes[]
+            | select(.intent.action == "acceptBuildReview")
+            | select(.intent.cycleRef == $review.cycleRef)
+            | select(.intent.buildRef == $review.buildRef)
+            | select(.intent.packetRevision == $review.packetRevision)
+            | .outcome
+          ] | last // null))
+  ') || return 1
+  jq -cn --arg capturedAt "$NOW" --arg sourceRevision "$source_revision" \
+    --argjson missions "$missions" --argjson reports "$reports" \
+    --argjson conditions "$conditions" --argjson outcomes "$outcomes" \
+    --argjson shapeUpOutcomes "$shapeup_outcomes" \
+    --argjson buildReviews "$reviews" --argjson invalidRecords "$invalid" '
+    {
+      schemaVersion:"fm-captains-log-snapshot.v1",
+      sourceRevision:$sourceRevision,
+      capturedAt:$capturedAt,
+      freshness:"fresh",
+      missions:$missions,
+      reports:$reports,
+      evidence:[$reports[]
+        | select(.status == "accepted" and .kind == "evidence")
+        | {reportId,sourceRevision,capturedAt,missionId,taskId,crewmateId,correlation,evidence}],
+      conditions:$conditions,
+      buildReviews:$buildReviews,
+      outcomes:$outcomes,
+      shapeUpOutcomes:$shapeUpOutcomes,
+      invalidRecords:$invalidRecords
+    }
+  '
+}
+
+capabilities_response() {
+  jq -n --arg schemaVersion "$SCHEMA" --arg capturedAt "$NOW" '
+    {
+      accepted:true,
+      schemaVersion:$schemaVersion,
+      sourceRevision:"capabilities-v1",
+      capturedAt:$capturedAt,
+      operations:["capabilities","snapshot","intent","inspectSession"],
+      capabilities:{
+        core:"available",
+        shapeUp:{status:"negotiated",required:false},
+        sessionInspection:{status:"negotiated",required:false,mode:"bounded-read-only",preferredBackend:"herdr"}
+      },
+      acceptedIntents:["acknowledgeCondition","acceptBuildReview","resolveCondition"]
+    }
+  '
+}
+
+replay_prior_outcome() {  # <record-path> <request-digest>
+  local record=$1 digest_value=$2 prior prior_digest
+  [ -f "$record" ] || return 1
+  prior=$(jq -c . "$record" 2>/dev/null) || {
+    fail_json malformed_record "The prior intent outcome is unreadable"
+    return 2
+  }
+  prior_digest=$(printf '%s' "$prior" | jq -r '.requestDigest // empty')
+  [ "$prior_digest" = "$digest_value" ] || {
+    fail_json identity_conflict "intentId was already used with different content"
+    return 2
+  }
+  printf '%s' "$prior" | jq -c --arg schemaVersion "$SCHEMA" '
+    {accepted:true,schemaVersion:$schemaVersion,outcome:(.outcome + {replayed:true})}'
+  return 0
+}
+
+intent_response() {  # <intent-json>
+  local intent=$1 intent_id action digest_value record outcome tmp snapshot review build_ref packet_revision
+  local cycle_ref condition_id condition mission_id report_id decision decision_file route resolution_status lock_dir lock_started
+  local -a route_args=()
+  intent_id=$(printf '%s' "$intent" | jq -r '.intentId // empty')
+  action=$(printf '%s' "$intent" | jq -r '.action // empty')
+  valid_identity "$intent_id" || {
+    fail_json malformed_intent "intentId must be a privacy-safe identity"
+    return 2
+  }
+  case "$action" in
+    acknowledgeCondition|acceptBuildReview|resolveCondition) ;;
+    *) fail_json unsupported_intent "The requested intent is not advertised"; return 2 ;;
+  esac
+  fm_eng_contains_credentials "$intent" && {
+    fail_json credential_material "Credentials must never enter Captain intents"
+    return 2
+  }
+  mkdir -p "$OUTCOMES" "$STATE/fm-projection-intent-locks"
+  record="$OUTCOMES/$intent_id.json"
+  digest_value=$(printf '%s' "$intent" | jq -cS . | digest)
+  replay_prior_outcome "$record" "$digest_value"
+  case $? in
+    0) return 0 ;;
+    2) return 2 ;;
+  esac
+  lock_dir="$STATE/fm-projection-intent-locks/$intent_id"
+  if ! mkdir "$lock_dir" 2>/dev/null; then
+    reclaim_stale_intent_lock "$lock_dir"
+    if ! mkdir "$lock_dir" 2>/dev/null; then
+      fail_json intent_busy "The intent is already being processed"
+      return 2
+    fi
+  fi
+  INTENT_LOCK_DIR="$lock_dir"
+  lock_started=$(process_start_signature "$$") || lock_started=unknown
+  printf 'host=%s\npid=%s\nstarted=%s\nacquiredAt=%s\n' \
+    "$INTENT_LOCK_HOST" "$$" "$lock_started" "$NOW" > "$lock_dir/owner" 2>/dev/null || true
+  trap release_intent_lock RETURN
+  replay_prior_outcome "$record" "$digest_value"
+  case $? in
+    0) return 0 ;;
+    2) return 2 ;;
+  esac
+  if [ "$action" = acceptBuildReview ]; then
+    cycle_ref=$(printf '%s' "$intent" | jq -r '.cycleRef // empty')
+    build_ref=$(printf '%s' "$intent" | jq -r '.buildRef // empty')
+    packet_revision=$(printf '%s' "$intent" | jq -r '.packetRevision // empty')
+    [ -n "$cycle_ref" ] && [ -n "$build_ref" ] && [ -n "$packet_revision" ] || {
+      fail_json malformed_intent "Build Review acceptance requires cycleRef, buildRef, and packetRevision"
+      return 2
+    }
+    snapshot=$(snapshot_json) || {
+      fail_json projection_unavailable "The projection record store could not be read"
+      return 2
+    }
+    review=$(printf '%s' "$snapshot" | jq -c --arg cycleRef "$cycle_ref" --arg buildRef "$build_ref" \
+      '[.buildReviews[] | select(.cycleRef == $cycleRef and .buildRef == $buildRef)] | first // empty')
+    [ -n "$review" ] || { fail_json review_not_found "Build Review packet is unavailable"; return 2; }
+    [ "$(printf '%s' "$review" | jq -r '.packetRevision')" = "$packet_revision" ] || {
+      fail_json stale_packet "Build Review packet changed before Captain acceptance"
+      return 2
+    }
+    [ "$(printf '%s' "$review" | jq -r '.revisionConflict')" = false ] || {
+      fail_json review_revision_conflict "Active missions in this Build are bound to conflicting Build revisions"
+      return 2
+    }
+    [ "$(printf '%s' "$review" | jq -r '.ready')" = true ] || {
+      fail_json review_not_ready "Every active mission and required evidence revision must be ready"
+      return 2
+    }
+  fi
+  if [ "$action" = acknowledgeCondition ] || [ "$action" = resolveCondition ]; then
+    mission_id=$(printf '%s' "$intent" | jq -r '.missionId // empty')
+    condition_id=$(printf '%s' "$intent" | jq -r '.conditionId // empty')
+    packet_revision=$(printf '%s' "$intent" | jq -r '.packetRevision // empty')
+    valid_identity "$mission_id" && valid_identity "$condition_id" && [ -n "$packet_revision" ] || {
+      fail_json malformed_intent "Condition intent requires missionId, conditionId, and packetRevision"
+      return 2
+    }
+    snapshot=$(snapshot_json) || {
+      fail_json projection_unavailable "The projection record store could not be read"
+      return 2
+    }
+    condition=$(printf '%s' "$snapshot" | jq -c --arg missionId "$mission_id" --arg conditionId "$condition_id" \
+      '.conditions[] | select(.missionId == $missionId and .conditionId == $conditionId)')
+    [ -n "$condition" ] || { fail_json condition_not_found "Captain Call condition is unavailable"; return 2; }
+    [ "$(printf '%s' "$condition" | jq -r '.packetRevision')" = "$packet_revision" ] || {
+      fail_json stale_packet "Captain Call packet changed before the intent was applied"
+      return 2
+    }
+  fi
+  resolution_status=accepted
+  if [ "$action" = resolveCondition ]; then
+    decision=$(printf '%s' "$intent" | jq -r '.decision // empty')
+    printf '%s' "$intent" | jq -e '
+      (.decision | type == "string" and length > 0 and length <= 8192)
+      and (.routedTo | type == "array" and length > 0)
+      and all(.routedTo[]; type == "string")
+    ' >/dev/null 2>&1 || {
+      fail_json malformed_intent "Resolution requires a bounded decision and routedTo identities"
+      return 2
+    }
+    while IFS= read -r route; do
+      valid_identity "$route" || {
+        fail_json malformed_identity "routedTo identities must be privacy-safe"
+        return 2
+      }
+      route_args+=(--routed-to "$route")
+    done < <(printf '%s' "$intent" | jq -r '.routedTo[]' | LC_ALL=C sort -u)
+    report_id=$(printf '%s' "$condition" | jq -r '.reportId')
+    "$SCRIPT_DIR/fm-decision-hold.sh" project "$mission_id" "$condition_id" \
+      --packet-file "$REPORTS/$report_id.json" --lifecycle resolving >/dev/null || {
+      fail_json decision_resolution_failed "Captain Call could not enter resolving state"
+      return 2
+    }
+    mkdir -p "$ENGINEERING/decisions"
+    decision_file="$ENGINEERING/decisions/$intent_id.txt"
+    tmp="$decision_file.$$"
+    printf '%s\n' "$decision" > "$tmp" && mv "$tmp" "$decision_file"
+    "$SCRIPT_DIR/fm-decision-hold.sh" resolve "$mission_id" "$condition_id" \
+      --decision-file "$decision_file" "${route_args[@]}" >/dev/null || {
+      fail_json decision_resolution_failed "Captain decision could not be routed durably"
+      return 2
+    }
+    resolution_status=resolved
+  fi
+  outcome=$(jq -cn --arg intentId "$intent_id" --arg action "$action" --arg recordedAt "$NOW" \
+    --arg resolutionStatus "$resolution_status" '
+    {
+      intentId:$intentId,
+      action:$action,
+      status:(
+        if $action == "acknowledgeCondition" then "acknowledged"
+        elif $action == "acceptBuildReview" then "captainAccepted"
+        else $resolutionStatus end),
+      recordedAt:$recordedAt,
+      replayed:false,
+      implications:{delivery:false,buildCloseout:false,cycleClose:false}
+    }
+  ')
+  tmp="$record.$$"
+  jq -cn --arg requestDigest "$digest_value" --argjson intent "$intent" --argjson outcome "$outcome" \
+    '{requestDigest:$requestDigest,intent:$intent,outcome:$outcome}' > "$tmp" && mv "$tmp" "$record"
+  jq -cn --arg schemaVersion "$SCHEMA" --argjson outcome "$outcome" \
+    '{accepted:true,schemaVersion:$schemaVersion,outcome:$outcome}'
+}
+
+inspect_session_response() {  # <request-json>
+  local value=$1 mission_id task_id expected lines mission session inspection status
+  mission_id=$(printf '%s' "$value" | jq -r '.missionId // empty')
+  task_id=$(printf '%s' "$value" | jq -r '.taskId // empty')
+  expected=$(printf '%s' "$value" | jq -r '.expectedMissionRevision // empty')
+  lines=$(printf '%s' "$value" | jq -r 'if (.lines // null) == null then "40" else (.lines | tostring) end')
+  case "$lines" in
+    ''|*[!0-9]*) fail_json malformed_request "lines must be a positive integer of at most 200"; return 2 ;;
+  esac
+  [ "${#lines}" -le 18 ] || {
+    fail_json malformed_request "lines must be a positive integer of at most 200"
+    return 2
+  }
+  lines=$((10#$lines))
+  [ "$lines" -ge 1 ] && [ "$lines" -le 200 ] || {
+    fail_json malformed_request "lines must be a positive integer of at most 200"
+    return 2
+  }
+  if ! valid_identity "$mission_id" || ! valid_identity "$task_id"; then
+    fail_json malformed_identity "missionId and taskId must be privacy-safe identities"
+    return 2
+  fi
+  [ -f "$MISSIONS/$mission_id.json" ] || {
+    fail_json mission_not_found "Mission is not present in the projection"
+    return 2
+  }
+  mission=$(jq -c . "$MISSIONS/$mission_id.json" 2>/dev/null) || {
+    fail_json malformed_record "Mission record is unreadable"
+    return 2
+  }
+  [ "$(printf '%s' "$mission" | jq -r '.taskId')" = "$task_id" ] || {
+    fail_json identity_drift "Task identity does not match the mission"
+    return 2
+  }
+  [ "$(printf '%s' "$mission" | jq -r '.sourceRevision')" = "$expected" ] || {
+    fail_json stale_revision "Mission revision changed before session inspection"
+    return 2
+  }
+  session=$(printf '%s' "$mission" | jq -c '.correlation.firstMate.session // null')
+  [ "$session" != null ] || {
+    fail_json capability_unavailable "Mission has no negotiated session descriptor"
+    return 2
+  }
+  inspection=$(FM_HOME="$FM_HOME" FM_DATA_OVERRIDE="$DATA" FM_STATE_OVERRIDE="$STATE" \
+    "$SCRIPT_DIR/fm-peek.sh" --json "$task_id" "$lines" 2>/dev/null)
+  status=$?
+  printf '%s' "$inspection" | jq -e 'type == "object"' >/dev/null 2>&1 || {
+    fail_json inspection_unavailable "Session inspection produced no structured result"
+    return 2
+  }
+  if [ "$status" -ne 0 ]; then
+    printf '%s' "$inspection" | jq -c --arg schemaVersion "$SCHEMA" '
+      {
+        accepted:false,
+        schemaVersion:$schemaVersion,
+        error:(.error // {code:"inspection_unavailable",message:"Session inspection failed without a typed error"})
+      }'
+    return 2
+  fi
+  printf '%s' "$inspection" | jq -e --argjson session "$session" '
+    .descriptor.backend == $session.backend and .descriptor.targetId == $session.targetId
+  ' >/dev/null 2>&1 || {
+    fail_json session_identity_drift "Live session descriptor differs from the mission correlation"
+    return 2
+  }
+  printf '%s' "$inspection" | jq -c --arg schemaVersion "$SCHEMA" '
+    {accepted:true,schemaVersion:$schemaVersion,inspection:.}'
+}
+
+request=$(head -c 262145)
+[ "${#request}" -le 262144 ] || {
+  fail_json request_too_large "Projection requests are limited to 256 KiB"
+  exit 2
+}
+printf '%s' "$request" | jq -e 'type == "object"' >/dev/null 2>&1 || {
+  fail_json malformed_request "Request must be a JSON object"
+  exit 2
+}
+version=$(printf '%s' "$request" | jq -r '.schemaVersion // empty')
+[ "$version" = "$SCHEMA" ] || {
+  fail_json unsupported_schema "Only fm-captains-log-projection.v1 is supported"
+  exit 2
+}
+operation=$(printf '%s' "$request" | jq -r '.operation // empty')
+case "$operation" in
+  capabilities)
+    capabilities_response
+    ;;
+  snapshot)
+    snapshot=$(snapshot_json) || {
+      fail_json projection_unavailable "The projection record store could not be read"
+      exit 2
+    }
+    jq -cn --arg schemaVersion "$SCHEMA" --argjson snapshot "$snapshot" \
+      '{accepted:true,schemaVersion:$schemaVersion,snapshot:$snapshot}'
+    ;;
+  intent)
+    intent=$(printf '%s' "$request" | jq -c '.intent // empty')
+    [ -n "$intent" ] || { fail_json malformed_intent "intent is required"; exit 2; }
+    intent_response "$intent"
+    ;;
+  inspectSession)
+    inspect_session_response "$request"
+    ;;
+  *)
+    fail_json unsupported_operation "The requested operation is not advertised"
+    exit 2
+    ;;
+esac

--- a/bin/fm-captains-log-projection.sh
+++ b/bin/fm-captains-log-projection.sh
@@ -153,9 +153,59 @@ trap 'release_intent_lock; exit 130' INT
 trap 'release_intent_lock; exit 143' TERM
 trap 'release_intent_lock; exit 129' HUP
 
+# A record that parses but violates the shape this projection derives from it is
+# isolated exactly like an unparseable one. Otherwise a single hand-edited record
+# raises a jq type error inside a downstream computation and blanks every
+# unrelated projection operation, including the fleet snapshot's embedded copy.
+# Only the fields a record actually participates through are constrained, and
+# only while it participates: a rejected report or a superseded mission is never
+# read as execution truth, so its stored shape is not held to that bar.
+partition_records() {  # <records-json> <kind> <malformed-json> <record-id>...
+  local records=$1 kind=$2 malformed=$3
+  shift 3
+  jq -cn --argjson records "$records" --arg kind "$kind" --argjson malformed "$malformed" '
+    def optional($value; $expected): ($value | type) as $actual | $actual == "null" or $actual == $expected;
+    def member($value; $key): if ($value | type) == "object" then $value[$key] else null end;
+    def shaped:
+      if $kind == "mission" then
+        ((.state // "accepted") != "accepted")
+        or (optional(.correlation; "object")
+          and optional(member(.correlation; "shapeUp"); "object")
+          and optional(.evidenceRequirements; "array"))
+      elif $kind == "report" then
+        (.status != "accepted")
+        or (optional(.correlation; "object")
+          and optional(member(.correlation; "shapeUp"); "object")
+          and optional(.condition; "object")
+          and optional(.evidence; "object")
+          and optional(member(.evidence; "verification"); "object")
+          and optional(.outcome; "object"))
+      elif $kind == "outcome" then
+        optional(.intent; "object") and optional(.outcome; "object")
+      else
+        optional(.outcome; "object")
+      end;
+    [ range($records | length) as $index
+      | {recordId:($ARGS.positional[$index] // ""), record:$records[$index]} ]
+    | {
+        records:[ .[] | select(.record | shaped) | .record ],
+        invalid:($malformed + [ .[]
+          | select(.record | shaped | not)
+          | {
+              kind:$kind,
+              recordId:.recordId,
+              error:{
+                code:"schema_invalid_record",
+                message:"Record does not match the projection record shape"
+              }
+            } ])
+      }
+  ' --args "$@"
+}
+
 collect_records() {  # <dir> <kind>
-  local dir=$1 kind=$2 file records invalid
-  local -a files=() valid=() malformed=()
+  local dir=$1 kind=$2 file records malformed_json='[]'
+  local -a files=() valid=() names=() malformed=()
   if [ -d "$dir" ]; then
     while IFS= read -r file; do
       [ -n "$file" ] || continue
@@ -169,31 +219,37 @@ collect_records() {  # <dir> <kind>
   if records=$(printf '%s\0' "${files[@]}" | xargs -0 cat 2>/dev/null | jq -cn '[inputs]' 2>/dev/null) \
     && [ "$(printf '%s' "$records" | jq -r 'length')" = "${#files[@]}" ] \
     && [ "$(printf '%s' "$records" | jq -r 'all(type == "object")')" = true ]; then
-    jq -cn --argjson records "$records" '{records:$records,invalid:[]}'
+    valid=("${files[@]}")
+  else
+    for file in "${files[@]}"; do
+      if jq -e 'type == "object"' "$file" >/dev/null 2>&1; then
+        valid[${#valid[@]}]=$file
+      else
+        malformed[${#malformed[@]}]=$(basename "$file" .json)
+      fi
+    done
+    records='[]'
+    if [ "${#valid[@]}" -gt 0 ]; then
+      records=$(printf '%s\0' "${valid[@]}" | xargs -0 cat 2>/dev/null \
+        | jq -cn '[inputs | select(type == "object")]') || return 1
+      [ -n "$records" ] || return 1
+      [ "$(printf '%s' "$records" | jq -r 'length')" = "${#valid[@]}" ] || return 1
+    fi
+    if [ "${#malformed[@]}" -gt 0 ]; then
+      malformed_json=$(jq -cn --arg kind "$kind" '
+        [ $ARGS.positional[]
+          | {kind:$kind,recordId:.,error:{code:"malformed_record",message:"Record is not a valid JSON object"}} ]
+      ' --args "${malformed[@]}") || return 1
+    fi
+  fi
+  if [ "${#valid[@]}" -eq 0 ]; then
+    jq -cn --argjson invalid "$malformed_json" '{records:[],invalid:$invalid}'
     return 0
   fi
-  for file in "${files[@]}"; do
-    if jq -e 'type == "object"' "$file" >/dev/null 2>&1; then
-      valid[${#valid[@]}]=$file
-    else
-      malformed[${#malformed[@]}]=$(basename "$file" .json)
-    fi
+  for file in "${valid[@]}"; do
+    names[${#names[@]}]=$(basename "$file" .json)
   done
-  records='[]'
-  if [ "${#valid[@]}" -gt 0 ]; then
-    records=$(printf '%s\0' "${valid[@]}" | xargs -0 cat 2>/dev/null \
-      | jq -cn '[inputs | select(type == "object")]') || return 1
-    [ -n "$records" ] || return 1
-    [ "$(printf '%s' "$records" | jq -r 'length')" = "${#valid[@]}" ] || return 1
-  fi
-  invalid='[]'
-  if [ "${#malformed[@]}" -gt 0 ]; then
-    invalid=$(jq -cn --arg kind "$kind" '
-      [ $ARGS.positional[]
-        | {kind:$kind,recordId:.,error:{code:"malformed_record",message:"Record is not a valid JSON object"}} ]
-    ' --args "${malformed[@]}") || return 1
-  fi
-  jq -cn --argjson records "$records" --argjson invalid "$invalid" '{records:$records,invalid:$invalid}'
+  partition_records "$records" "$kind" "$malformed_json" "${names[@]}"
 }
 
 condition_projection() {  # <reports-json> <outcomes-json>
@@ -201,7 +257,12 @@ condition_projection() {  # <reports-json> <outcomes-json>
     [ $reports[]
       | select(.condition? and (.condition | type == "object"))
       | select(.status? == "accepted")
-      | {
+    ]
+    | sort_by(.missionId,.condition.conditionId,.acceptedAt // "",.acceptanceSequence // 0,.reportId)
+    | group_by([.missionId,.condition.conditionId])
+    | map(last)
+    | map(
+        {
           reportId:.reportId,
           missionId:.missionId,
           conditionId:.condition.conditionId,
@@ -222,11 +283,7 @@ condition_projection() {  # <reports-json> <outcomes-json>
           scopeRef:(.correlation.shapeUp.scopeRef // null),
           capturedAt:(.capturedAt // ""),
           acceptedAt:(.acceptedAt // "")
-        }
-    ]
-    | sort_by(.missionId,.conditionId,.acceptedAt,.capturedAt,.reportId)
-    | group_by([.missionId,.conditionId])
-    | map(last)
+        })
     | map(. as $condition
       | .lifecycle = (
           [ $outcomes[]
@@ -243,7 +300,7 @@ condition_projection() {  # <reports-json> <outcomes-json>
 build_reviews() {  # <missions-json> <reports-json> <outcomes-json>
   local missions=$1 reports=$2 outcomes=$3
   jq -cn --argjson missions "$missions" --argjson reports "$reports" --argjson outcomes "$outcomes" '
-    def authoritative: sort_by(.acceptedAt // "",.capturedAt // "",.reportId) | last // null;
+    def authoritative: sort_by(.acceptedAt // "",.acceptanceSequence // 0,.reportId) | last // null;
     def terminal($missionId):
       ([ $reports[]
         | select(.status == "accepted" and .missionId == $missionId)
@@ -304,23 +361,30 @@ build_reviews() {  # <missions-json> <reports-json> <outcomes-json>
   '
 }
 
+# Packet material is emitted once, hashed once per packet, and reattached in a
+# single pass, so attaching n revisions costs O(n) work rather than reserializing
+# the whole Review set on every packet.
 review_revisions() {  # <reviews-json>
-  local reviews=$1 count index material revision result='[]'
+  local reviews=$1 count material revision
+  local -a revisions=()
   count=$(printf '%s' "$reviews" | jq -r 'if type == "array" then length else "invalid" end') || return 1
   case "$count" in
     ''|*[!0-9]*) return 1 ;;
   esac
-  index=0
-  while [ "$index" -lt "$count" ]; do
-    material=$(printf '%s' "$reviews" | jq -r --argjson index "$index" '.[$index].packetMaterial') || return 1
+  if [ "$count" -eq 0 ]; then
+    printf '[]'
+    return 0
+  fi
+  while IFS= read -r material; do
     revision=$(printf '%s' "$material" | digest) || return 1
     [ -n "$revision" ] || return 1
-    result=$(jq -cn --argjson result "$result" --argjson reviews "$reviews" \
-      --argjson index "$index" --arg revision "$revision" '
-      $result + [$reviews[$index] | del(.packetMaterial) | . + {packetRevision:$revision}]') || return 1
-    index=$((index + 1))
-  done
-  printf '%s' "$result"
+    revisions[${#revisions[@]}]=$revision
+  done < <(printf '%s' "$reviews" | jq -r '.[].packetMaterial')
+  [ "${#revisions[@]}" -eq "$count" ] || return 1
+  jq -cn --argjson reviews "$reviews" '
+    [ range($reviews | length) as $index
+      | $reviews[$index] | del(.packetMaterial) | . + {packetRevision:$ARGS.positional[$index]} ]
+  ' --args "${revisions[@]}"
 }
 
 snapshot_json() {
@@ -539,7 +603,11 @@ intent_response() {  # <intent-json>
     mkdir -p "$ENGINEERING/decisions"
     decision_file="$ENGINEERING/decisions/$intent_id.txt"
     tmp="$decision_file.$$"
-    printf '%s\n' "$decision" > "$tmp" && mv "$tmp" "$decision_file"
+    if ! { printf '%s\n' "$decision" > "$tmp" 2>/dev/null && mv "$tmp" "$decision_file" 2>/dev/null; }; then
+      rm -f "$tmp" 2>/dev/null || true
+      fail_json decision_resolution_failed "The Captain decision could not be stored durably"
+      return 2
+    fi
     "$SCRIPT_DIR/fm-decision-hold.sh" resolve "$mission_id" "$condition_id" \
       --decision-file "$decision_file" "${route_args[@]}" >/dev/null || {
       fail_json decision_resolution_failed "Captain decision could not be routed durably"
@@ -561,9 +629,14 @@ intent_response() {  # <intent-json>
       implications:{delivery:false,buildCloseout:false,cycleClose:false}
     }
   ')
-  tmp="$record.$$"
-  jq -cn --arg requestDigest "$digest_value" --argjson intent "$intent" --argjson outcome "$outcome" \
-    '{requestDigest:$requestDigest,intent:$intent,outcome:$outcome}' > "$tmp" && mv "$tmp" "$record"
+  # The outcome store is what makes an intent durable and replayable, so an
+  # outcome that did not land is never reported as accepted.
+  fm_eng_atomic_write "$record" "$(jq -cn --arg requestDigest "$digest_value" \
+    --argjson intent "$intent" --argjson outcome "$outcome" \
+    '{requestDigest:$requestDigest,intent:$intent,outcome:$outcome}')" || {
+    fail_json outcome_not_durable "The intent outcome could not be recorded durably"
+    return 2
+  }
   jq -cn --arg schemaVersion "$SCHEMA" --argjson outcome "$outcome" \
     '{accepted:true,schemaVersion:$schemaVersion,outcome:$outcome}'
 }

--- a/bin/fm-captains-log-projection.sh
+++ b/bin/fm-captains-log-projection.sh
@@ -56,102 +56,12 @@ valid_identity() {  # <value>
   [ "${#1}" -le 128 ]
 }
 
-INTENT_LOCK_DIR=''
-INTENT_LOCK_HOST=${HOSTNAME:-$(hostname 2>/dev/null || printf 'unknown-host')}
-INTENT_LOCK_STALE_MINUTES=5
-case "${FM_PROJECTION_INTENT_LOCK_STALE_MINUTES:-}" in
-  ''|*[!0-9]*) ;;
-  *)
-    if [ "${#FM_PROJECTION_INTENT_LOCK_STALE_MINUTES}" -le 9 ] \
-      && [ "$FM_PROJECTION_INTENT_LOCK_STALE_MINUTES" -ge 1 ]; then
-      INTENT_LOCK_STALE_MINUTES=$FM_PROJECTION_INTENT_LOCK_STALE_MINUTES
-    fi
-    ;;
-esac
-
-remove_intent_lock() {  # <lock-dir>
-  rm -f "$1/owner" 2>/dev/null || true
-  rmdir "$1" 2>/dev/null || true
-}
-
-release_intent_lock() {
-  [ -n "$INTENT_LOCK_DIR" ] || return 0
-  remove_intent_lock "$INTENT_LOCK_DIR"
-  INTENT_LOCK_DIR=''
-}
-
-PROCESS_START_METHOD=lstart
-
-# The signature is rendered in a fixed locale and timezone so the same process
-# always yields the same identity whatever environment observes it. It carries
-# its method so a signature produced a different way is never mistaken for a
-# different process.
-process_start_signature() {  # <pid>
-  local value
-  value=$(LC_ALL=C TZ=UTC ps -o lstart= -p "$1" 2>/dev/null | tr -d '[:space:]')
-  [ -n "$value" ] || return 1
-  printf '%s:%s' "$PROCESS_START_METHOD" "$value"
-}
-
-# A lock whose recorded owner is provably gone - exited, or its pid recycled by a
-# process that started later - is reclaimed at once. An owner that cannot be
-# compared, including one recorded by another identity method, falls back to the
-# bounded age window, so no lock can wedge forever and none is reclaimed merely
-# because its identity is presented differently. A confirmed live owner is never
-# reclaimed, however long it runs and whoever owns it.
-intent_lock_owner_state() {  # <lock-dir>
-  local dir=$1 owner_host owner_pid owner_started current_started
-  if [ ! -f "$dir/owner" ]; then
-    printf 'unknown'
-    return 0
-  fi
-  owner_host=$(sed -n 's/^host=//p' "$dir/owner" 2>/dev/null | head -1)
-  owner_pid=$(sed -n 's/^pid=//p' "$dir/owner" 2>/dev/null | head -1)
-  owner_started=$(sed -n 's/^started=//p' "$dir/owner" 2>/dev/null | head -1)
-  if [ "$owner_host" != "$INTENT_LOCK_HOST" ]; then
-    printf 'unknown'
-    return 0
-  fi
-  case "$owner_pid" in
-    ''|*[!0-9]*) printf 'unknown'; return 0 ;;
-  esac
-  current_started=$(process_start_signature "$owner_pid") || current_started=''
-  if [ -z "$current_started" ]; then
-    if kill -0 "$owner_pid" 2>/dev/null; then
-      printf 'unknown'
-    else
-      printf 'dead'
-    fi
-    return 0
-  fi
-  case "$owner_started" in
-    "$PROCESS_START_METHOD":?*) ;;
-    *) printf 'unknown'; return 0 ;;
-  esac
-  if [ "$owner_started" = "$current_started" ]; then
-    printf 'alive'
-  else
-    printf 'dead'
-  fi
-}
-
-reclaim_stale_intent_lock() {  # <lock-dir>
-  local dir=$1
-  [ -d "$dir" ] || return 0
-  case "$(intent_lock_owner_state "$dir")" in
-    alive) return 0 ;;
-    dead) ;;
-    *)
-      [ -n "$(find "$dir" -maxdepth 0 -mmin "+$INTENT_LOCK_STALE_MINUTES" -print 2>/dev/null)" ] || return 0
-      ;;
-  esac
-  remove_intent_lock "$dir"
-}
-
-trap release_intent_lock EXIT
-trap 'release_intent_lock; exit 130' INT
-trap 'release_intent_lock; exit 143' TERM
-trap 'release_intent_lock; exit 129' HUP
+# The liveness-safe mutex is owned once by bin/fm-engineering-lib.sh so the
+# report and intent paths cannot drift into two different reclaim policies.
+trap fm_eng_lock_release_all EXIT
+trap 'fm_eng_lock_release_all; exit 130' INT
+trap 'fm_eng_lock_release_all; exit 143' TERM
+trap 'fm_eng_lock_release_all; exit 129' HUP
 
 # A record that parses but violates the shape this projection derives from it is
 # isolated exactly like an unparseable one. Otherwise a single hand-edited record
@@ -185,15 +95,19 @@ partition_records() {  # <records-json> <kind> <malformed-json> <record-id>...
       else
         optional(.outcome; "object")
       end;
+    def readable($value): if ($value | type) == "string" then $value else null end;
     [ range($records | length) as $index
       | {recordId:($ARGS.positional[$index] // ""), record:$records[$index]} ]
     | {
         records:[ .[] | select(.record | shaped) | .record ],
         invalid:($malformed + [ .[]
           | select(.record | shaped | not)
+          | (member(member(.record; "correlation"); "shapeUp")) as $shape
           | {
               kind:$kind,
               recordId:.recordId,
+              cycleRef:readable(member($shape; "cycleRef")),
+              buildRef:readable(member($shape; "buildRef")),
               error:{
                 code:"schema_invalid_record",
                 message:"Record does not match the projection record shape"
@@ -238,7 +152,13 @@ collect_records() {  # <dir> <kind>
     if [ "${#malformed[@]}" -gt 0 ]; then
       malformed_json=$(jq -cn --arg kind "$kind" '
         [ $ARGS.positional[]
-          | {kind:$kind,recordId:.,error:{code:"malformed_record",message:"Record is not a valid JSON object"}} ]
+          | {
+              kind:$kind,
+              recordId:.,
+              cycleRef:null,
+              buildRef:null,
+              error:{code:"malformed_record",message:"Record is not a valid JSON object"}
+            } ]
       ' --args "${malformed[@]}") || return 1
     fi
   fi
@@ -297,9 +217,17 @@ condition_projection() {  # <reports-json> <outcomes-json>
   '
 }
 
-build_reviews() {  # <missions-json> <reports-json> <outcomes-json>
-  local missions=$1 reports=$2 outcomes=$3
-  jq -cn --argjson missions "$missions" --argjson reports "$reports" --argjson outcomes "$outcomes" '
+# An isolated mission or report record cannot participate in readiness, so a
+# packet that might be missing one is never reported ready: the mission set would
+# silently shrink and the Captain could accept a Build Review that does not cover
+# every active mission. A record whose own correlation is unreadable could belong
+# to any Build, so it suppresses readiness across the Review set until the
+# operator repairs it. Isolation is part of the packet material, so newly
+# isolating a record invalidates a pending acceptance like any other change.
+build_reviews() {  # <missions-json> <reports-json> <outcomes-json> <invalid-json>
+  local missions=$1 reports=$2 outcomes=$3 invalid=$4
+  jq -cn --argjson missions "$missions" --argjson reports "$reports" --argjson outcomes "$outcomes" \
+    --argjson invalid "$invalid" '
     def authoritative: sort_by(.acceptedAt // "",.acceptanceSequence // 0,.reportId) | last // null;
     def terminal($missionId):
       ([ $reports[]
@@ -328,6 +256,12 @@ build_reviews() {  # <missions-json> <reports-json> <outcomes-json>
         | ($group[0].correlation.shapeUp) as $shape
         | ($group | map(.correlation.shapeUp.buildRevision // "") | unique) as $buildRevisions
         | (($buildRevisions | length) > 1) as $revisionConflict
+        | ([ $invalid[]
+            | select(.kind == "mission" or .kind == "report")
+            | select((.cycleRef == null or .buildRef == null)
+              or (.cycleRef == $shape.cycleRef and .buildRef == $shape.buildRef))
+            | {kind,recordId,error:.error.code}
+          ] | sort_by(.kind,.recordId)) as $isolatedRecords
         | ($group | map(. as $mission | {
             missionId:$mission.missionId,
             missionRevision:($mission.sourceRevision // ""),
@@ -348,13 +282,17 @@ build_reviews() {  # <missions-json> <reports-json> <outcomes-json>
             buildRevisions:$buildRevisions,
             revisionConflict:$revisionConflict,
             missionSet:$missionSet,
-            ready:(($revisionConflict | not) and ($missionSet | all(.terminal and .evidenceVerified))),
+            isolatedRecords:$isolatedRecords,
+            ready:(($revisionConflict | not)
+              and (($isolatedRecords | length) == 0)
+              and ($missionSet | all(.terminal and .evidenceVerified))),
             packetMaterial:({
               cycleRef:$shape.cycleRef,
               buildRef:$shape.buildRef,
               buildRevisions:$buildRevisions,
               revisionConflict:$revisionConflict,
-              missionSet:$missionSet
+              missionSet:$missionSet,
+              isolatedRecords:$isolatedRecords
             } | @json)
           }
       )
@@ -410,7 +348,7 @@ snapshot_json() {
     '{missions:$missions,reports:$reports,outcomes:$outcomes,shapeUpOutcomes:$shapeUpOutcomes,invalidRecords:$invalid}') || return 1
   source_revision=$(printf '%s' "$material" | digest) || return 1
   [ -n "$source_revision" ] || return 1
-  reviews=$(build_reviews "$missions" "$reports" "$outcomes") || return 1
+  reviews=$(build_reviews "$missions" "$reports" "$outcomes" "$invalid") || return 1
   [ -n "$reviews" ] || return 1
   reviews=$(review_revisions "$reviews") || return 1
   reviews=$(jq -cn --argjson reviews "$reviews" --argjson outcomes "$outcomes" '
@@ -486,7 +424,7 @@ replay_prior_outcome() {  # <record-path> <request-digest>
 
 intent_response() {  # <intent-json>
   local intent=$1 intent_id action digest_value record outcome tmp snapshot review build_ref packet_revision
-  local cycle_ref condition_id condition mission_id report_id decision decision_file route resolution_status lock_dir lock_started
+  local cycle_ref condition_id condition mission_id report_id decision decision_file route resolution_status lock_dir
   local -a route_args=()
   intent_id=$(printf '%s' "$intent" | jq -r '.intentId // empty')
   action=$(printf '%s' "$intent" | jq -r '.action // empty')
@@ -511,18 +449,11 @@ intent_response() {  # <intent-json>
     2) return 2 ;;
   esac
   lock_dir="$STATE/fm-projection-intent-locks/$intent_id"
-  if ! mkdir "$lock_dir" 2>/dev/null; then
-    reclaim_stale_intent_lock "$lock_dir"
-    if ! mkdir "$lock_dir" 2>/dev/null; then
-      fail_json intent_busy "The intent is already being processed"
-      return 2
-    fi
-  fi
-  INTENT_LOCK_DIR="$lock_dir"
-  lock_started=$(process_start_signature "$$") || lock_started=unknown
-  printf 'host=%s\npid=%s\nstarted=%s\nacquiredAt=%s\n' \
-    "$INTENT_LOCK_HOST" "$$" "$lock_started" "$NOW" > "$lock_dir/owner" 2>/dev/null || true
-  trap release_intent_lock RETURN
+  fm_eng_lock_acquire "$lock_dir" "${FM_PROJECTION_INTENT_LOCK_STALE_MINUTES:-}" "$NOW" || {
+    fail_json intent_busy "The intent is already being processed"
+    return 2
+  }
+  trap fm_eng_lock_release_all RETURN
   replay_prior_outcome "$record" "$digest_value"
   case $? in
     0) return 0 ;;
@@ -545,6 +476,10 @@ intent_response() {  # <intent-json>
     [ -n "$review" ] || { fail_json review_not_found "Build Review packet is unavailable"; return 2; }
     [ "$(printf '%s' "$review" | jq -r '.packetRevision')" = "$packet_revision" ] || {
       fail_json stale_packet "Build Review packet changed before Captain acceptance"
+      return 2
+    }
+    [ "$(printf '%s' "$review" | jq -r '.isolatedRecords | length')" = 0 ] || {
+      fail_json review_records_isolated "A stored mission or report record for this Build is invalid, so the packet cannot prove it covers every active mission"
       return 2
     }
     [ "$(printf '%s' "$review" | jq -r '.revisionConflict')" = false ] || {

--- a/bin/fm-decision-hold.sh
+++ b/bin/fm-decision-hold.sh
@@ -372,7 +372,7 @@ EOF
 }
 
 command_project() {
-  local origin=${1:-} key=${2:-} packet_file='' lifecycle='' id packet packet_revision packet_record body
+  local origin=${1:-} key=${2:-} packet_file='' lifecycle='' id packet packet_revision packet_record body hold_body
   [ "$#" -ge 2 ] || { usage >&2; exit 2; }
   shift 2
   while [ "$#" -gt 0 ]; do
@@ -397,6 +397,17 @@ command_project() {
   id=$(hold_id "$origin" "$key")
   require_tasks_axi
   verify_hold_active "$id"
+  # A hold that already carries a resolution record is mid-resolution: that
+  # record is the retry identity `resolve` needs to finish a partially completed
+  # routing operation, so projecting a packet over it would make the hold
+  # permanently unresolvable.
+  hold_body=$(show_field "$(task_show "$id")" body)
+  case "$hold_body" in
+    *"Resolution recorded by fm-decision-hold."*)
+      printf 'retained: %s %s resolution-record\n' "$id" "$lifecycle"
+      return 0
+      ;;
+  esac
   body=$(printf 'Origin: %s\nDecision key: %s\nState: awaiting captain decision.\n\nFirstMate Captain Call packet.\nLifecycle: %s\nPacket record: %s\nPacket revision: %s' \
     "$origin" "$key" "$lifecycle" "$packet_record" "$packet_revision")
   tasks_axi update "$id" --body "$body" >/dev/null \

--- a/bin/fm-decision-hold.sh
+++ b/bin/fm-decision-hold.sh
@@ -22,6 +22,9 @@
 #     --title <title> --reason <reason> [--repo <repo>]
 #   fm-decision-hold.sh complete <origin-id> (--none | <decision-key>...)
 #   fm-decision-hold.sh verify <origin-id>
+#   fm-decision-hold.sh project <origin-id> <decision-key> \
+#     --packet-file <path> --lifecycle <raised|updated|resolving>
+#   fm-decision-hold.sh status <origin-id> <decision-key> --json
 #   fm-decision-hold.sh resolve <origin-id> <decision-key> \
 #     --decision-file <path> --routed-to <task-id> [--routed-to <task-id>...]
 #
@@ -118,6 +121,7 @@ show_field() {  # <show-output> <field>
 origin_exists_here() {  # <origin-id>
   [ -f "$STATE/$1.meta" ] && return 0
   [ -f "$DATA/$1/report.md" ] && return 0
+  [ -f "$DATA/engineering/missions/$1.json" ] && return 0
   task_show "$1" >/dev/null 2>&1
 }
 
@@ -367,6 +371,86 @@ EOF
   printf 'verified: %s unresolved-decision inventory\n' "$origin"
 }
 
+command_project() {
+  local origin=${1:-} key=${2:-} packet_file='' lifecycle='' id packet packet_revision packet_record body
+  [ "$#" -ge 2 ] || { usage >&2; exit 2; }
+  shift 2
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --packet-file) shift; packet_file=${1:-} ;;
+      --lifecycle) shift; lifecycle=${1:-} ;;
+      *) usage >&2; exit 2 ;;
+    esac
+    shift
+  done
+  validate_slug origin-id "$origin"
+  validate_slug decision-key "$key"
+  case "$lifecycle" in raised|updated|resolving) ;; *) fail "lifecycle must be raised, updated, or resolving" ;; esac
+  [ -f "$packet_file" ] || fail "packet file does not exist: $packet_file"
+  packet=$(jq -ce 'select(type == "object" and (.condition | type == "object"))' "$packet_file" 2>/dev/null) \
+    || fail "packet file must contain one structured condition"
+  packet_revision=$(printf '%s' "$packet" | jq -r '.condition.packetRevision // empty')
+  [ -n "$packet_revision" ] || fail "packet revision is missing"
+  packet_record=$(printf '%s' "$packet" | jq -r '.reportId // empty')
+  [ -n "$packet_record" ] || fail "packet record identity is missing"
+  validate_slug packet-record "$packet_record"
+  id=$(hold_id "$origin" "$key")
+  require_tasks_axi
+  verify_hold_active "$id"
+  body=$(printf 'Origin: %s\nDecision key: %s\nState: awaiting captain decision.\n\nFirstMate Captain Call packet.\nLifecycle: %s\nPacket record: %s\nPacket revision: %s' \
+    "$origin" "$key" "$lifecycle" "$packet_record" "$packet_revision")
+  tasks_axi update "$id" --body "$body" >/dev/null \
+    || fail "could not project Captain Call packet on $id"
+  printf 'projected: %s %s\n' "$id" "$lifecycle"
+}
+
+command_status() {
+  local origin=${1:-} key=${2:-} id show state held body lifecycle packet_revision packet_record packet_file
+  [ "$#" -eq 3 ] && [ "$3" = --json ] || { usage >&2; exit 2; }
+  validate_slug origin-id "$origin"
+  validate_slug decision-key "$key"
+  require_tasks_axi
+  id=$(hold_id "$origin" "$key")
+  show=$(task_show "$id") || fail "captain hold $id is absent"
+  state=$(show_field "$show" state)
+  held=$(show_field "$show" held)
+  body=$(show_field "$show" body)
+  packet_revision=$(printf '%s\n' "$body" | sed -n 's/.*Packet revision: \([^\\"]*\).*/\1/p' | head -1)
+  packet_record=$(printf '%s\n' "$body" | sed -n 's/.*Packet record: \([^\\"]*\).*/\1/p' | head -1)
+  packet_file=''
+  case "$packet_record" in
+    ''|*[!A-Za-z0-9._-]*) ;;
+    *) packet_file="$DATA/engineering/reports/$packet_record.json" ;;
+  esac
+  if [ "$state" = "done" ]; then
+    lifecycle=resolved
+  else
+    lifecycle=$(printf '%s\n' "$body" | sed -n 's/.*Lifecycle: \([^\\"]*\).*/\1/p' | head -1)
+    case "$lifecycle" in
+      raised|updated|resolving) ;;
+      *)
+        if [ -f "$packet_file" ]; then
+          lifecycle=$(jq -r '.condition.lifecycle // "raised"' "$packet_file" 2>/dev/null || printf raised)
+        else
+          lifecycle=raised
+        fi
+        ;;
+    esac
+  fi
+  jq -n --arg conditionId "$key" --arg holdId "$id" --arg lifecycle "$lifecycle" \
+    --arg packetRevision "$packet_revision" \
+    --arg state "$state" --arg held "$held" '
+    {
+      schemaVersion:"fm-captain-call-status.v1",
+      conditionId:$conditionId,
+      holdId:$holdId,
+      lifecycle:$lifecycle,
+      packetRevision:(if $packetRevision == "" then null else $packetRevision end),
+      durableState:{state:$state,held:($held == "yes")}
+    }
+  '
+}
+
 command_resolve() {
   local origin=${1:-} key=${2:-} decision_file='' id='' decision='' decision_digest='' body='' routed='' routed_csv='' dep show blocked state hold_show hold_body resolution_recorded=0
   [ "$#" -ge 2 ] || { usage >&2; exit 2; }
@@ -458,6 +542,8 @@ case "${1:-}" in
   hold) shift; command_hold "$@" ;;
   complete) shift; command_complete "$@" ;;
   verify) shift; command_verify "$@" ;;
+  project) shift; command_project "$@" ;;
+  status) shift; command_status "$@" ;;
   resolve) shift; command_resolve "$@" ;;
   -h|--help) usage ;;
   *) usage >&2; exit 2 ;;

--- a/bin/fm-engineering-lib.sh
+++ b/bin/fm-engineering-lib.sh
@@ -73,6 +73,19 @@ fm_eng_credential_name_regex() {
   printf '%s' "$FM_ENG_CREDENTIAL_NAMES" | LC_ALL=C tr 'A-Z ' 'a-z|'
 }
 
+# A colon is both the credential-header separator and ordinary prose punctuation,
+# so the colon form matches a narrower label: the vocabulary word must be a whole
+# separator-delimited component of the name rather than merely a substring of one.
+# `SERVICE_TOKEN`, `X-Api-Key`, and `AWS_ACCESS_KEY_ID` qualify; the inert plural
+# telemetry label `tokens` does not, because its word is glued to a trailing run.
+fm_eng_credential_label_ere() {
+  local names word
+  names=$(fm_eng_credential_name_ere)
+  word=${names#'[A-Za-z0-9_]*('}
+  word=${word%')[A-Za-z0-9_]*'}
+  printf '([A-Za-z0-9]+[-_])*(%s)([-_][A-Za-z0-9]+)*' "$word"
+}
+
 # Stored records are scanned for credential-named keys, known secret value
 # shapes, and assignment-shaped values. The assignment shape is deliberately
 # narrower than pane redaction's: prose that merely names a credential after a
@@ -107,6 +120,145 @@ fm_eng_atomic_write() {  # <path> <json>
     return 0
   fi
   rm -f "$tmp" 2>/dev/null || true
+  return 1
+}
+
+FM_ENG_LOCK_HOST=${HOSTNAME:-$(hostname 2>/dev/null || printf 'unknown-host')}
+FM_ENG_LOCK_HELD=''
+FM_ENG_PROCESS_START_METHOD=lstart
+
+fm_eng_lock_stale_minutes() {  # <requested>
+  case "$1" in
+    ''|*[!0-9]*) printf '5'; return 0 ;;
+  esac
+  if [ "${#1}" -le 9 ] && [ "$1" -ge 1 ]; then
+    printf '%s' "$1"
+  else
+    printf '5'
+  fi
+}
+
+# The signature is rendered in a fixed locale and timezone so the same process
+# always yields the same identity whatever environment observes it. It carries
+# its method so a signature produced a different way is never mistaken for a
+# different process.
+fm_eng_process_start_signature() {  # <pid>
+  local value
+  value=$(LC_ALL=C TZ=UTC ps -o lstart= -p "$1" 2>/dev/null | tr -d '[:space:]')
+  [ -n "$value" ] || return 1
+  printf '%s:%s' "$FM_ENG_PROCESS_START_METHOD" "$value"
+}
+
+fm_eng_lock_remove() {  # <lock-dir>
+  rm -f "$1/owner" 2>/dev/null || true
+  rmdir "$1" 2>/dev/null || true
+}
+
+# A lock whose recorded owner is provably gone - exited, or its pid recycled by a
+# process that started later - is reclaimed at once. An owner that cannot be
+# compared, including one recorded by another identity method, falls back to the
+# bounded age window, so no lock can wedge forever and none is reclaimed merely
+# because its identity is presented differently. A confirmed live owner is never
+# reclaimed, however long it runs and whoever owns it.
+fm_eng_lock_owner_state() {  # <lock-dir>
+  local dir=$1 owner_host owner_pid owner_started current_started
+  if [ ! -f "$dir/owner" ]; then
+    printf 'unknown'
+    return 0
+  fi
+  owner_host=$(sed -n 's/^host=//p' "$dir/owner" 2>/dev/null | head -1)
+  owner_pid=$(sed -n 's/^pid=//p' "$dir/owner" 2>/dev/null | head -1)
+  owner_started=$(sed -n 's/^started=//p' "$dir/owner" 2>/dev/null | head -1)
+  if [ "$owner_host" != "$FM_ENG_LOCK_HOST" ]; then
+    printf 'unknown'
+    return 0
+  fi
+  case "$owner_pid" in
+    ''|*[!0-9]*) printf 'unknown'; return 0 ;;
+  esac
+  current_started=$(fm_eng_process_start_signature "$owner_pid") || current_started=''
+  if [ -z "$current_started" ]; then
+    if kill -0 "$owner_pid" 2>/dev/null; then
+      printf 'unknown'
+    else
+      printf 'dead'
+    fi
+    return 0
+  fi
+  case "$owner_started" in
+    "$FM_ENG_PROCESS_START_METHOD":?*) ;;
+    *) printf 'unknown'; return 0 ;;
+  esac
+  if [ "$owner_started" = "$current_started" ]; then
+    printf 'alive'
+  else
+    printf 'dead'
+  fi
+}
+
+fm_eng_lock_reclaim() {  # <lock-dir> <stale-minutes>
+  local dir=$1 stale=$2
+  [ -d "$dir" ] || return 0
+  case "$(fm_eng_lock_owner_state "$dir")" in
+    alive) return 0 ;;
+    dead) ;;
+    *)
+      [ -n "$(find "$dir" -maxdepth 0 -mmin "+$stale" -print 2>/dev/null)" ] || return 0
+      ;;
+  esac
+  fm_eng_lock_remove "$dir"
+}
+
+fm_eng_lock_release_all() {
+  local dir
+  [ -n "$FM_ENG_LOCK_HELD" ] || return 0
+  for dir in $FM_ENG_LOCK_HELD; do
+    fm_eng_lock_remove "$dir"
+  done
+  FM_ENG_LOCK_HELD=''
+}
+
+fm_eng_lock_release() {  # <lock-dir>
+  local dir kept=''
+  for dir in ${FM_ENG_LOCK_HELD:-}; do
+    [ "$dir" = "$1" ] || kept="${kept}${kept:+ }$dir"
+  done
+  FM_ENG_LOCK_HELD=$kept
+  fm_eng_lock_remove "$1"
+}
+
+# The mutex is a mkdir the filesystem serializes, and the owner record is what
+# makes reclaiming it safe rather than a blind timeout.
+fm_eng_lock_acquire() {  # <lock-dir> <stale-minutes> <recorded-at>
+  local dir=$1 stale started
+  stale=$(fm_eng_lock_stale_minutes "${2:-}")
+  mkdir -p "$(dirname "$dir")" 2>/dev/null || return 1
+  if ! mkdir "$dir" 2>/dev/null; then
+    fm_eng_lock_reclaim "$dir" "$stale"
+    mkdir "$dir" 2>/dev/null || return 1
+  fi
+  FM_ENG_LOCK_HELD="${FM_ENG_LOCK_HELD}${FM_ENG_LOCK_HELD:+ }$dir"
+  started=$(fm_eng_process_start_signature "$$") || started=unknown
+  printf 'host=%s\npid=%s\nstarted=%s\nacquiredAt=%s\n' \
+    "$FM_ENG_LOCK_HOST" "$$" "$started" "${3:-}" > "$dir/owner" 2>/dev/null || true
+}
+
+# Contending for a shared counter is normal rather than an error, so this waits a
+# bounded time instead of refusing. Every attempt goes through the reclaim path,
+# so a holder that crashed cannot wedge the wait, and an expired wait is a typed
+# refusal rather than an unbounded block.
+fm_eng_lock_acquire_wait() {  # <lock-dir> <stale-minutes> <recorded-at> [attempts]
+  local attempts=${4:-100} index=0
+  case "$attempts" in
+    ''|*[!0-9]*|0) attempts=100 ;;
+  esac
+  while [ "$index" -lt "$attempts" ]; do
+    if fm_eng_lock_acquire "$1" "${2:-}" "${3:-}"; then
+      return 0
+    fi
+    index=$((index + 1))
+    sleep 0.05 2>/dev/null || sleep 1
+  done
   return 1
 }
 

--- a/bin/fm-engineering-lib.sh
+++ b/bin/fm-engineering-lib.sh
@@ -295,6 +295,10 @@ fm_eng_lock_pause_unit() {
 # serializes, and the owner probe that reclaims a crashed holder runs about once a
 # second instead of on every retry. A store that can never hold the lock is not
 # contention and is refused at once rather than after the whole wait.
+# The clock this reads counts whole seconds, so the deadline carries one extra
+# second: the requested interval is a grace period the caller is owed in full
+# rather than a ceiling a partly elapsed second can cut short, and the overshoot
+# that buys stays under one second.
 fm_eng_lock_acquire_wait() {  # <lock-dir> <stale-minutes> <recorded-at> [seconds]
   local dir=$1 stale=${2:-} at=${3:-} seconds=${4:-5} deadline probes=0 reclaim_every status
   case "$seconds" in
@@ -311,7 +315,7 @@ fm_eng_lock_acquire_wait() {  # <lock-dir> <stale-minutes> <recorded-at> [second
   else
     reclaim_every=20
   fi
-  deadline=$(( $(date +%s) + seconds ))
+  deadline=$(( $(date +%s) + seconds + 1 ))
   while [ "$(date +%s)" -lt "$deadline" ]; do
     sleep "$FM_ENG_LOCK_PAUSE_UNIT"
     if mkdir "$dir" 2>/dev/null; then

--- a/bin/fm-engineering-lib.sh
+++ b/bin/fm-engineering-lib.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# Shared validation and storage helpers for FirstMate Engineering records.
+
+fm_eng_digest() {
+  if command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 | awk '{print $1}'
+  else
+    sha256sum | awk '{print $1}'
+  fi
+}
+
+fm_eng_fail() {  # <schema> <code> <message> [record-json]
+  local schema=$1 code=$2 message=$3 record=${4:-null}
+  jq -cn --arg schemaVersion "$schema" --arg code "$code" --arg message "$message" \
+    --argjson record "$record" '
+    {accepted:false,schemaVersion:$schemaVersion,error:{code:$code,message:$message}}
+    + (if $record == null then {} else {report:$record} end)
+  '
+}
+
+fm_eng_valid_identity() {  # <value>
+  case "$1" in
+    ''|*[!A-Za-z0-9._-]*) return 1 ;;
+  esac
+  [ "${#1}" -le 128 ]
+}
+
+fm_eng_read_json() {  # <path-or-dash> [max-bytes]
+  local source=$1 max=${2:-262144} value
+  if [ "$source" = - ]; then
+    value=$(head -c $((max + 1)))
+  else
+    [ -f "$source" ] || return 1
+    value=$(head -c $((max + 1)) "$source")
+  fi
+  [ "${#value}" -le "$max" ] || return 2
+  printf '%s' "$value" | jq -ce 'select(type == "object")'
+}
+
+fm_eng_contains_credentials() {  # <json>
+  printf '%s' "$1" | jq -e '
+    . as $root
+    | any(paths(scalars);
+        . as $path
+        | ($root | getpath($path)) as $value
+        | ($value | type == "string")
+          and (
+            (($path[-1] | tostring | ascii_downcase) | test("token|secret|credential|password"))
+            or ($value | test("gh[pousr]_[A-Za-z0-9]|Bearer[[:space:]]+|BEGIN[[:space:]]+(RSA[[:space:]]+)?PRIVATE[[:space:]]+KEY"; "i"))
+          ))
+  ' >/dev/null 2>&1
+}
+
+fm_eng_canonical() {  # <json>
+  printf '%s' "$1" | jq -cS .
+}
+
+fm_eng_atomic_write() {  # <path> <json>
+  local path=$1 value=$2 tmp="$1.$$"
+  mkdir -p "$(dirname "$path")"
+  printf '%s\n' "$value" > "$tmp" && mv "$tmp" "$path"
+}
+
+fm_eng_validate_correlation() {  # <json> <mission> <task> <crewmate>
+  local value=$1 mission=$2 task=$3 crewmate=$4
+  printf '%s' "$value" | jq -e \
+    --arg mission "$mission" --arg task "$task" --arg crewmate "$crewmate" '
+    .schemaVersion == "shapeup-correlation.v1"
+    and (.sourceRevision | type == "string" and length > 0)
+    and (.capturedAt | type == "string" and length > 0)
+    and (.identity.kind == "command" or .identity.kind == "event")
+    and (.identity.id | type == "string" and length > 0)
+    and (.shapeUp.cycleRef | type == "string" and length > 0)
+    and (.shapeUp.buildRef | type == "string" and length > 0)
+    and (.shapeUp.scopeRef == null or (.shapeUp.scopeRef | type == "string" and length > 0))
+    and (.firstMate.missionId == $mission)
+    and (.firstMate.taskId == $task)
+    and (.firstMate.crewmateId == $crewmate)
+    and (
+      .firstMate.session == null
+      or (
+        (.firstMate.session | keys - ["backend","targetId","lifecycle"] | length) == 0
+        and (.firstMate.session.backend | IN("tmux","herdr","zellij","orca","cmux"))
+        and (.firstMate.session.targetId | type == "string" and length > 0 and length <= 512)
+        and ((.firstMate.session.targetId | test("[[:cntrl:]]")) | not)
+        and (.firstMate.session.lifecycle | IN("starting","running","detached","reconnecting","ended","crashed"))
+      )
+    )
+  ' >/dev/null 2>&1
+}
+
+fm_eng_relative_to() {  # <path> <root>
+  case "$1/" in
+    "$2/"*) return 0 ;;
+  esac
+  return 1
+}

--- a/bin/fm-engineering-lib.sh
+++ b/bin/fm-engineering-lib.sh
@@ -245,12 +245,22 @@ fm_eng_lock_release() {  # <lock-dir>
   fm_eng_lock_remove "$1"
 }
 
+# Taking the lock and recording who holds it are one step, so the cheap retry path
+# registers ownership exactly the way the first attempt does.
+fm_eng_lock_record() {  # <lock-dir> <recorded-at>
+  local started
+  FM_ENG_LOCK_HELD_DIRS[${#FM_ENG_LOCK_HELD_DIRS[@]}]=$1
+  started=$(fm_eng_process_start_signature "$$") || started=unknown
+  printf 'host=%s\npid=%s\nstarted=%s\nacquiredAt=%s\n' \
+    "$FM_ENG_LOCK_HOST" "$$" "$started" "${2:-}" > "$1/owner" 2>/dev/null || true
+}
+
 # The mutex is a mkdir the filesystem serializes, and the owner record is what
 # makes reclaiming it safe rather than a blind timeout. Contention and a store that
 # cannot hold a lock at all are separate answers: status 1 means another owner has
 # it and waiting can help, status 2 means it can never be taken here.
 fm_eng_lock_acquire() {  # <lock-dir> <stale-minutes> <recorded-at>
-  local dir=$1 stale started
+  local dir=$1 stale
   stale=$(fm_eng_lock_stale_minutes "${2:-}")
   mkdir -p "$(dirname "$dir")" 2>/dev/null || return 2
   if ! mkdir "$dir" 2>/dev/null; then
@@ -260,52 +270,61 @@ fm_eng_lock_acquire() {  # <lock-dir> <stale-minutes> <recorded-at>
       return 1
     fi
   fi
-  FM_ENG_LOCK_HELD_DIRS[${#FM_ENG_LOCK_HELD_DIRS[@]}]=$dir
-  started=$(fm_eng_process_start_signature "$$") || started=unknown
-  printf 'host=%s\npid=%s\nstarted=%s\nacquiredAt=%s\n' \
-    "$FM_ENG_LOCK_HOST" "$$" "$started" "${3:-}" > "$dir/owner" 2>/dev/null || true
+  fm_eng_lock_record "$dir" "${3:-}"
 }
 
 FM_ENG_LOCK_PAUSE_UNIT=''
 
-# The wait is expressed in seconds, so the bound a caller asks for is the bound it
-# gets whether or not this host's sleep accepts a fraction.
+# The probe costs a real sleep, so it assigns the shared answer directly rather
+# than being read back through a command substitution that would discard it, and
+# it is only ever reached once a wait is already going to pause.
 fm_eng_lock_pause_unit() {
-  if [ -z "$FM_ENG_LOCK_PAUSE_UNIT" ]; then
-    if sleep 0.05 2>/dev/null; then
-      FM_ENG_LOCK_PAUSE_UNIT=0.05
-    else
-      FM_ENG_LOCK_PAUSE_UNIT=1
-    fi
+  [ -z "$FM_ENG_LOCK_PAUSE_UNIT" ] || return 0
+  if sleep 0.05 2>/dev/null; then
+    FM_ENG_LOCK_PAUSE_UNIT=0.05
+  else
+    FM_ENG_LOCK_PAUSE_UNIT=1
   fi
-  printf '%s' "$FM_ENG_LOCK_PAUSE_UNIT"
 }
 
 # Contending for a shared counter is normal rather than an error, so this waits a
-# bounded time instead of refusing. Every attempt goes through the reclaim path, so
-# a holder that crashed cannot wedge the wait. A store that can never hold the lock
-# is not contention and is refused at once rather than after the whole wait.
+# bounded time instead of refusing. The bound is a wall-clock deadline, so probe,
+# reclaim, and process-spawn cost all come out of the caller's budget rather than
+# extending it. An uncontended acquisition never pauses, never probes, and never
+# reads the clock. Once contended, retries are the bare mkdir the filesystem
+# serializes, and the owner probe that reclaims a crashed holder runs about once a
+# second instead of on every retry. A store that can never hold the lock is not
+# contention and is refused at once rather than after the whole wait.
 fm_eng_lock_acquire_wait() {  # <lock-dir> <stale-minutes> <recorded-at> [seconds]
-  local seconds=${4:-5} unit attempts index=0 status
+  local dir=$1 stale=${2:-} at=${3:-} seconds=${4:-5} deadline probes=0 reclaim_every status
   case "$seconds" in
     ''|*[!0-9]*|0) seconds=5 ;;
   esac
   [ "${#seconds}" -le 4 ] || seconds=5
-  unit=$(fm_eng_lock_pause_unit)
-  if [ "$unit" = 1 ]; then
-    attempts=$seconds
+  fm_eng_lock_acquire "$dir" "$stale" "$at"
+  status=$?
+  [ "$status" -eq 1 ] || return "$status"
+  stale=$(fm_eng_lock_stale_minutes "$stale")
+  fm_eng_lock_pause_unit
+  if [ "$FM_ENG_LOCK_PAUSE_UNIT" = 1 ]; then
+    reclaim_every=1
   else
-    attempts=$((seconds * 20))
+    reclaim_every=20
   fi
-  while :; do
-    fm_eng_lock_acquire "$1" "${2:-}" "${3:-}"
-    status=$?
-    [ "$status" -eq 0 ] && return 0
-    [ "$status" -eq 1 ] || return "$status"
-    index=$((index + 1))
-    [ "$index" -lt "$attempts" ] || return 1
-    sleep "$unit"
+  deadline=$(( $(date +%s) + seconds ))
+  while [ "$(date +%s)" -lt "$deadline" ]; do
+    sleep "$FM_ENG_LOCK_PAUSE_UNIT"
+    if mkdir "$dir" 2>/dev/null; then
+      fm_eng_lock_record "$dir" "$at"
+      return 0
+    fi
+    probes=$((probes + 1))
+    if [ "$probes" -ge "$reclaim_every" ]; then
+      probes=0
+      fm_eng_lock_reclaim "$dir" "$stale"
+    fi
   done
+  return 1
 }
 
 fm_eng_validate_correlation() {  # <json> <mission> <task> <crewmate>

--- a/bin/fm-engineering-lib.sh
+++ b/bin/fm-engineering-lib.sh
@@ -37,16 +37,59 @@ fm_eng_read_json() {  # <path-or-dash> [max-bytes]
   printf '%s' "$value" | jq -ce 'select(type == "object")'
 }
 
+# The credential-name vocabulary is owned once here so record scanning and pane
+# redaction recognize the same names. Each entry is an ERE fragment whose letters
+# are matched without regard to case.
+FM_ENG_CREDENTIAL_NAMES='TOKEN SECRET PASSWORD PASSWD CREDENTIAL API[-_]?KEY ACCESS[-_]?KEY PRIVATE[-_]?KEY'
+
+# The ERE form spells every letter as an explicit two-case bracket instead of
+# relying on a case-insensitivity flag, which awk has no portable form of and
+# sed only carries as an extension.
+fm_eng_credential_name_ere() {
+  local word rest letter pair out alt=''
+  for word in $FM_ENG_CREDENTIAL_NAMES; do
+    out=''
+    rest=$word
+    while [ -n "$rest" ]; do
+      letter=${rest%"${rest#?}"}
+      rest=${rest#?}
+      case "$letter" in
+        [A-Za-z])
+          for pair in Aa Bb Cc Dd Ee Ff Gg Hh Ii Jj Kk Ll Mm Nn Oo Pp Qq Rr Ss Tt Uu Vv Ww Xx Yy Zz; do
+            case "$pair" in
+              *"$letter"*) out="${out}[$pair]"; break ;;
+            esac
+          done
+          ;;
+        *) out="$out$letter" ;;
+      esac
+    done
+    alt="${alt}${alt:+|}$out"
+  done
+  printf '[A-Za-z0-9_]*(%s)[A-Za-z0-9_]*' "$alt"
+}
+
+fm_eng_credential_name_regex() {
+  printf '%s' "$FM_ENG_CREDENTIAL_NAMES" | LC_ALL=C tr 'A-Z ' 'a-z|'
+}
+
+# Stored records are scanned for credential-named keys, known secret value
+# shapes, and assignment-shaped values. The assignment shape is deliberately
+# narrower than pane redaction's: prose that merely names a credential after a
+# colon is ordinary Captain and crewmate language and must stay storable.
 fm_eng_contains_credentials() {  # <json>
-  printf '%s' "$1" | jq -e '
+  local names
+  names=$(fm_eng_credential_name_regex)
+  printf '%s' "$1" | jq -e --arg names "$names" '
     . as $root
     | any(paths(scalars);
         . as $path
         | ($root | getpath($path)) as $value
         | ($value | type == "string")
           and (
-            (($path[-1] | tostring | ascii_downcase) | test("token|secret|credential|password"))
+            (($path[-1] | tostring | ascii_downcase) | test($names))
             or ($value | test("gh[pousr]_[A-Za-z0-9]|Bearer[[:space:]]+|BEGIN[[:space:]]+(RSA[[:space:]]+)?PRIVATE[[:space:]]+KEY"; "i"))
+            or ($value | test("[A-Za-z0-9_]*(" + $names + ")[A-Za-z0-9_]*=[^[:space:]]"; "i"))
           ))
   ' >/dev/null 2>&1
 }
@@ -55,10 +98,16 @@ fm_eng_canonical() {  # <json>
   printf '%s' "$1" | jq -cS .
 }
 
+# A durable record either lands whole or reports failure; callers must never
+# publish an outcome the store did not accept.
 fm_eng_atomic_write() {  # <path> <json>
   local path=$1 value=$2 tmp="$1.$$"
-  mkdir -p "$(dirname "$path")"
-  printf '%s\n' "$value" > "$tmp" && mv "$tmp" "$path"
+  mkdir -p "$(dirname "$path")" 2>/dev/null || return 1
+  if printf '%s\n' "$value" > "$tmp" 2>/dev/null && mv "$tmp" "$path" 2>/dev/null; then
+    return 0
+  fi
+  rm -f "$tmp" 2>/dev/null || true
+  return 1
 }
 
 fm_eng_validate_correlation() {  # <json> <mission> <task> <crewmate>

--- a/bin/fm-engineering-lib.sh
+++ b/bin/fm-engineering-lib.sh
@@ -42,10 +42,11 @@ fm_eng_read_json() {  # <path-or-dash> [max-bytes]
 # are matched without regard to case.
 FM_ENG_CREDENTIAL_NAMES='TOKEN SECRET PASSWORD PASSWD CREDENTIAL API[-_]?KEY ACCESS[-_]?KEY PRIVATE[-_]?KEY'
 
-# The ERE form spells every letter as an explicit two-case bracket instead of
-# relying on a case-insensitivity flag, which awk has no portable form of and
-# sed only carries as an extension.
-fm_eng_credential_name_ere() {
+# The alternation is built once here and wrapped by each consumer, so no form has
+# to parse another form's output to recover it. Every letter is spelled as an
+# explicit two-case bracket instead of relying on a case-insensitivity flag, which
+# awk has no portable form of and sed only carries as an extension.
+fm_eng_credential_alternation() {
   local word rest letter pair out alt=''
   for word in $FM_ENG_CREDENTIAL_NAMES; do
     out=''
@@ -66,7 +67,11 @@ fm_eng_credential_name_ere() {
     done
     alt="${alt}${alt:+|}$out"
   done
-  printf '[A-Za-z0-9_]*(%s)[A-Za-z0-9_]*' "$alt"
+  printf '%s' "$alt"
+}
+
+fm_eng_credential_name_ere() {
+  printf '[A-Za-z0-9_]*(%s)[A-Za-z0-9_]*' "$(fm_eng_credential_alternation)"
 }
 
 fm_eng_credential_name_regex() {
@@ -74,16 +79,20 @@ fm_eng_credential_name_regex() {
 }
 
 # A colon is both the credential-header separator and ordinary prose punctuation,
-# so the colon form matches a narrower label: the vocabulary word must be a whole
-# separator-delimited component of the name rather than merely a substring of one.
-# `SERVICE_TOKEN`, `X-Api-Key`, and `AWS_ACCESS_KEY_ID` qualify; the inert plural
-# telemetry label `tokens` does not, because its word is glued to a trailing run.
+# so the colon form requires the credential word to end the label: anything may be
+# glued in front of it and only separator-delimited components may follow it.
+# `apitoken`, `dbpassword`, `SERVICE_TOKEN`, `X-Api-Key`, and `aws_access_key_id`
+# all qualify, while the inert plural telemetry label `tokens` does not, because a
+# trailing run is glued to its word rather than separated from it.
 fm_eng_credential_label_ere() {
-  local names word
-  names=$(fm_eng_credential_name_ere)
-  word=${names#'[A-Za-z0-9_]*('}
-  word=${word%')[A-Za-z0-9_]*'}
-  printf '([A-Za-z0-9]+[-_])*(%s)([-_][A-Za-z0-9]+)*' "$word"
+  printf '[A-Za-z0-9_-]*(%s)([-_][A-Za-z0-9]+)*' "$(fm_eng_credential_alternation)"
+}
+
+# A credential header may be quoted or bracketed by the surrounding config or JSON
+# a pane echoes, so the label boundary admits those delimiters as well as
+# whitespace and the start of the line.
+fm_eng_credential_label_anchor() {
+  printf '%s' "[]\"',{}()[[:space:]]"
 }
 
 # Stored records are scanned for credential-named keys, known secret value
@@ -124,7 +133,9 @@ fm_eng_atomic_write() {  # <path> <json>
 }
 
 FM_ENG_LOCK_HOST=${HOSTNAME:-$(hostname 2>/dev/null || printf 'unknown-host')}
-FM_ENG_LOCK_HELD=''
+# Held locks are tracked as array elements rather than a joined string so a home
+# whose path contains a space still releases the directory it actually holds.
+FM_ENG_LOCK_HELD_DIRS=()
 FM_ENG_PROCESS_START_METHOD=lstart
 
 fm_eng_lock_stale_minutes() {  # <requested>
@@ -211,55 +222,90 @@ fm_eng_lock_reclaim() {  # <lock-dir> <stale-minutes>
 
 fm_eng_lock_release_all() {
   local dir
-  [ -n "$FM_ENG_LOCK_HELD" ] || return 0
-  for dir in $FM_ENG_LOCK_HELD; do
+  [ "${#FM_ENG_LOCK_HELD_DIRS[@]}" -gt 0 ] || return 0
+  for dir in "${FM_ENG_LOCK_HELD_DIRS[@]}"; do
     fm_eng_lock_remove "$dir"
   done
-  FM_ENG_LOCK_HELD=''
+  FM_ENG_LOCK_HELD_DIRS=()
 }
 
 fm_eng_lock_release() {  # <lock-dir>
-  local dir kept=''
-  for dir in ${FM_ENG_LOCK_HELD:-}; do
-    [ "$dir" = "$1" ] || kept="${kept}${kept:+ }$dir"
-  done
-  FM_ENG_LOCK_HELD=$kept
+  local dir
+  local -a kept=()
+  if [ "${#FM_ENG_LOCK_HELD_DIRS[@]}" -gt 0 ]; then
+    for dir in "${FM_ENG_LOCK_HELD_DIRS[@]}"; do
+      [ "$dir" = "$1" ] || kept[${#kept[@]}]=$dir
+    done
+  fi
+  if [ "${#kept[@]}" -gt 0 ]; then
+    FM_ENG_LOCK_HELD_DIRS=("${kept[@]}")
+  else
+    FM_ENG_LOCK_HELD_DIRS=()
+  fi
   fm_eng_lock_remove "$1"
 }
 
 # The mutex is a mkdir the filesystem serializes, and the owner record is what
-# makes reclaiming it safe rather than a blind timeout.
+# makes reclaiming it safe rather than a blind timeout. Contention and a store that
+# cannot hold a lock at all are separate answers: status 1 means another owner has
+# it and waiting can help, status 2 means it can never be taken here.
 fm_eng_lock_acquire() {  # <lock-dir> <stale-minutes> <recorded-at>
   local dir=$1 stale started
   stale=$(fm_eng_lock_stale_minutes "${2:-}")
-  mkdir -p "$(dirname "$dir")" 2>/dev/null || return 1
+  mkdir -p "$(dirname "$dir")" 2>/dev/null || return 2
   if ! mkdir "$dir" 2>/dev/null; then
     fm_eng_lock_reclaim "$dir" "$stale"
-    mkdir "$dir" 2>/dev/null || return 1
+    if ! mkdir "$dir" 2>/dev/null; then
+      [ -d "$dir" ] || return 2
+      return 1
+    fi
   fi
-  FM_ENG_LOCK_HELD="${FM_ENG_LOCK_HELD}${FM_ENG_LOCK_HELD:+ }$dir"
+  FM_ENG_LOCK_HELD_DIRS[${#FM_ENG_LOCK_HELD_DIRS[@]}]=$dir
   started=$(fm_eng_process_start_signature "$$") || started=unknown
   printf 'host=%s\npid=%s\nstarted=%s\nacquiredAt=%s\n' \
     "$FM_ENG_LOCK_HOST" "$$" "$started" "${3:-}" > "$dir/owner" 2>/dev/null || true
 }
 
-# Contending for a shared counter is normal rather than an error, so this waits a
-# bounded time instead of refusing. Every attempt goes through the reclaim path,
-# so a holder that crashed cannot wedge the wait, and an expired wait is a typed
-# refusal rather than an unbounded block.
-fm_eng_lock_acquire_wait() {  # <lock-dir> <stale-minutes> <recorded-at> [attempts]
-  local attempts=${4:-100} index=0
-  case "$attempts" in
-    ''|*[!0-9]*|0) attempts=100 ;;
-  esac
-  while [ "$index" -lt "$attempts" ]; do
-    if fm_eng_lock_acquire "$1" "${2:-}" "${3:-}"; then
-      return 0
+FM_ENG_LOCK_PAUSE_UNIT=''
+
+# The wait is expressed in seconds, so the bound a caller asks for is the bound it
+# gets whether or not this host's sleep accepts a fraction.
+fm_eng_lock_pause_unit() {
+  if [ -z "$FM_ENG_LOCK_PAUSE_UNIT" ]; then
+    if sleep 0.05 2>/dev/null; then
+      FM_ENG_LOCK_PAUSE_UNIT=0.05
+    else
+      FM_ENG_LOCK_PAUSE_UNIT=1
     fi
+  fi
+  printf '%s' "$FM_ENG_LOCK_PAUSE_UNIT"
+}
+
+# Contending for a shared counter is normal rather than an error, so this waits a
+# bounded time instead of refusing. Every attempt goes through the reclaim path, so
+# a holder that crashed cannot wedge the wait. A store that can never hold the lock
+# is not contention and is refused at once rather than after the whole wait.
+fm_eng_lock_acquire_wait() {  # <lock-dir> <stale-minutes> <recorded-at> [seconds]
+  local seconds=${4:-5} unit attempts index=0 status
+  case "$seconds" in
+    ''|*[!0-9]*|0) seconds=5 ;;
+  esac
+  [ "${#seconds}" -le 4 ] || seconds=5
+  unit=$(fm_eng_lock_pause_unit)
+  if [ "$unit" = 1 ]; then
+    attempts=$seconds
+  else
+    attempts=$((seconds * 20))
+  fi
+  while :; do
+    fm_eng_lock_acquire "$1" "${2:-}" "${3:-}"
+    status=$?
+    [ "$status" -eq 0 ] && return 0
+    [ "$status" -eq 1 ] || return "$status"
     index=$((index + 1))
-    sleep 0.05 2>/dev/null || sleep 1
+    [ "$index" -lt "$attempts" ] || return 1
+    sleep "$unit"
   done
-  return 1
 }
 
 fm_eng_validate_correlation() {  # <json> <mission> <task> <crewmate>

--- a/bin/fm-fleet-snapshot.sh
+++ b/bin/fm-fleet-snapshot.sh
@@ -51,6 +51,14 @@
 #     compatibility landed-work roll-up derived from secondmate_current. Readable
 #     structured homes with an unknown current classification are partial, not
 #     unreadable, and retain independently trustworthy structured surfaces.
+#   captains_log_projection: the embedded `fm-captains-log-snapshot.v1` document
+#     produced by bin/fm-captains-log-projection.sh, carrying missions, reports,
+#     evidence, conditions, buildReviews, outcomes, shapeUpOutcomes, and
+#     invalidRecords. freshness is "fresh" with a sourceRevision and capturedAt
+#     when the projection answered; a projection that is absent, failing, or
+#     rejecting the request degrades to freshness "unavailable" with null
+#     sourceRevision, null capturedAt, and empty collections rather than failing
+#     this read-only snapshot.
 #   secondmate_guidance: return-channel action note for renderers and bearings.
 #
 # Compatibility: JSON is the primary machine-readable surface.
@@ -1372,6 +1380,16 @@ SECONDMATE_CURRENT_JSON=$(secondmate_current_json "$TASKS_JSON") \
   || { echo "fm-fleet-snapshot: registered secondmate aggregation failed" >&2; exit 1; }
 SECONDMATE_LANDED_JSON=$(secondmate_landed_from_current_json "$SECONDMATE_CURRENT_JSON") \
   || { echo "fm-fleet-snapshot: secondmate landed projection failed" >&2; exit 1; }
+if ENGINEERING_PROJECTION_RESPONSE=$(printf '%s' \
+  '{"schemaVersion":"fm-captains-log-projection.v1","operation":"snapshot"}' \
+  | FM_HOME="$FM_HOME" FM_DATA_OVERRIDE="$DATA" FM_STATE_OVERRIDE="$STATE" \
+    FM_PROJECTION_NOW="$SNAPSHOT_NOW" "$SCRIPT_DIR/fm-captains-log-projection.sh" 2>/dev/null) \
+  && printf '%s' "$ENGINEERING_PROJECTION_RESPONSE" | jq -e '.accepted == true' >/dev/null 2>&1; then
+  ENGINEERING_PROJECTION_JSON=$(printf '%s' "$ENGINEERING_PROJECTION_RESPONSE" | jq -c '.snapshot')
+else
+  ENGINEERING_PROJECTION_JSON=$(jq -n \
+    '{schemaVersion:"fm-captains-log-snapshot.v1",freshness:"unavailable",sourceRevision:null,capturedAt:null,missions:[],reports:[],evidence:[],conditions:[],buildReviews:[],outcomes:[],shapeUpOutcomes:[],invalidRecords:[]}')
+fi
 
 jq -n \
   --arg generated "$SNAPSHOT_NOW" \
@@ -1387,6 +1405,7 @@ jq -n \
   --argjson scout_reports "$SCOUT_REPORTS_JSON" \
   --argjson secondmate_current "$SECONDMATE_CURRENT_JSON" \
   --argjson secondmate_landed "$SECONDMATE_LANDED_JSON" \
+  --argjson captains_log_projection "$ENGINEERING_PROJECTION_JSON" \
   'def backlog_by_id($id): ($backlog.records[]? | select(.structured == true and .id == $id) | .) // null;
    def task_by_id($id): ($tasks[]? | select(.id == $id) | .) // null;
    def report_kind($id): (task_by_id($id).kind // backlog_by_id($id).kind // "scout");
@@ -1401,6 +1420,7 @@ jq -n \
      scout_reports:($scout_reports | map(. + {kind:report_kind(.id)})),
      secondmate_current:$secondmate_current,
      secondmate_landed:$secondmate_landed,
+     captains_log_projection:$captains_log_projection,
      secondmate_guidance:{
        note:"For kind=secondmate, bearings selects validated structured state from that registered home; parent events and bounded terminal evidence are fallback-only supplements and never current-state authority."
      }

--- a/bin/fm-mission.sh
+++ b/bin/fm-mission.sh
@@ -101,21 +101,33 @@ accept_mission() {  # <path-or-dash>
       }
     }
   ')
-  fm_eng_atomic_write "$path" "$stored"
+  fm_eng_atomic_write "$path" "$stored" || {
+    fm_eng_fail "$SCHEMA" record_not_durable "The accepted mission could not be stored durably"
+    return 2
+  }
   jq -cn --arg schemaVersion "$SCHEMA" --argjson mission "$stored" \
     '{accepted:true,schemaVersion:$schemaVersion,replayed:false,mission:$mission}'
 }
 
-change_state() {  # <state> <mission-id> <flag> <value> <field>
+# Every identity this surface stores stays a privacy-safe slug, including the
+# replacement mission and deferring decision a state change binds itself to.
+change_state() {  # <state> <mission-id> <flag> <value> <field> <expected-flag>
   local state=$1 mission_id=$2 flag=$3 value=$4 field=$5 path current updated
   fm_eng_valid_identity "$mission_id" || { fm_eng_fail "$SCHEMA" malformed_identity "Invalid missionId"; return 2; }
   [ "$flag" = "$6" ] || { usage >&2; return 2; }
+  fm_eng_valid_identity "$value" || {
+    fm_eng_fail "$SCHEMA" malformed_identity "$flag must be a privacy-safe identity"
+    return 2
+  }
   path="$MISSIONS/$mission_id.json"
   [ -f "$path" ] || { fm_eng_fail "$SCHEMA" mission_not_found "Mission is not accepted"; return 2; }
   current=$(jq -c . "$path") || { fm_eng_fail "$SCHEMA" malformed_record "Mission record is unreadable"; return 2; }
   updated=$(printf '%s' "$current" | jq -c --arg state "$state" --arg field "$field" --arg value "$value" --arg at "$NOW" \
     '.state=$state | .[$field]=$value | .stateChangedAt=$at')
-  fm_eng_atomic_write "$path" "$updated"
+  fm_eng_atomic_write "$path" "$updated" || {
+    fm_eng_fail "$SCHEMA" record_not_durable "The mission state change could not be stored durably"
+    return 2
+  }
   jq -cn --arg schemaVersion "$SCHEMA" --argjson mission "$updated" \
     '{accepted:true,schemaVersion:$schemaVersion,mission:$mission}'
 }

--- a/bin/fm-mission.sh
+++ b/bin/fm-mission.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+# fm-mission.sh - accept and manage revision-bound Engineering missions.
+#
+# Usage:
+#   fm-mission.sh accept <mission-json-file|->
+#   fm-mission.sh supersede <mission-id> --replacement <mission-id>
+#   fm-mission.sh defer <mission-id> --decision-id <intent-id> --build-revision <revision>
+#
+# Accepted missions always carry reporting instructions that require initial
+# Scope discovery when possible and continuous observations until terminal.
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
+DATA="${FM_DATA_OVERRIDE:-$FM_HOME/data}"
+ENGINEERING="$DATA/engineering"
+MISSIONS="$ENGINEERING/missions"
+NOW="${FM_ENGINEERING_NOW:-$(date -u +%Y-%m-%dT%H:%M:%SZ)}"
+SCHEMA=fm-engineering-mission.v1
+
+# shellcheck source=bin/fm-engineering-lib.sh
+# shellcheck disable=SC1091
+. "$SCRIPT_DIR/fm-engineering-lib.sh"
+
+command -v jq >/dev/null 2>&1 || { echo "fm-mission: jq not found" >&2; exit 1; }
+
+usage() {
+  awk 'NR == 1 { next } /^#/ { sub(/^# ?/, ""); print; next } { exit }' "$0"
+}
+
+accept_mission() {  # <path-or-dash>
+  local input mission_id task_id crewmate correlation canonical revision path prior prior_revision stored
+  input=$(fm_eng_read_json "$1") || {
+    case $? in
+      2) fm_eng_fail "$SCHEMA" request_too_large "Mission records are limited to 256 KiB" ;;
+      *) fm_eng_fail "$SCHEMA" malformed_mission "Mission input must be a readable JSON object" ;;
+    esac
+    return 2
+  }
+  fm_eng_contains_credentials "$input" && {
+    fm_eng_fail "$SCHEMA" credential_material "Credentials must never enter mission data"
+    return 2
+  }
+  mission_id=$(printf '%s' "$input" | jq -r '.missionId // empty')
+  task_id=$(printf '%s' "$input" | jq -r '.taskId // empty')
+  crewmate=$(printf '%s' "$input" | jq -r '.crewmateId // empty')
+  if ! fm_eng_valid_identity "$mission_id" \
+    || ! fm_eng_valid_identity "$task_id" \
+    || ! fm_eng_valid_identity "$crewmate"; then
+    fm_eng_fail "$SCHEMA" malformed_identity "missionId, taskId, and crewmateId must be privacy-safe identities"
+    return 2
+  fi
+  printf '%s' "$input" | jq -e '
+    .schemaVersion == "fm-engineering-mission.v1"
+    and (.acceptedBuildRevision | type == "string" and length > 0)
+    and ((.evidenceRequirements // []) | type == "array")
+    and ((.allowedEvidenceRoots // []) | type == "array")
+  ' >/dev/null 2>&1 || {
+    fm_eng_fail "$SCHEMA" malformed_mission "Mission schema, Build revision, or evidence contract is invalid"
+    return 2
+  }
+  correlation=$(printf '%s' "$input" | jq -c '.correlation // null')
+  fm_eng_validate_correlation "$correlation" "$mission_id" "$task_id" "$crewmate" || {
+    fm_eng_fail "$SCHEMA" malformed_correlation "Mission correlation is malformed or identity-drifted"
+    return 2
+  }
+  printf '%s' "$correlation" | jq -e --arg revision "$(printf '%s' "$input" | jq -r '.acceptedBuildRevision')" \
+    '.shapeUp.buildRevision == $revision' >/dev/null 2>&1 || {
+    fm_eng_fail "$SCHEMA" stale_build "acceptedBuildRevision must match the correlation Build revision"
+    return 2
+  }
+  canonical=$(fm_eng_canonical "$input")
+  revision=$(printf '%s' "$canonical" | fm_eng_digest)
+  path="$MISSIONS/$mission_id.json"
+  if [ -f "$path" ]; then
+    prior=$(jq -c . "$path" 2>/dev/null) || {
+      fm_eng_fail "$SCHEMA" malformed_record "The existing mission record is unreadable"
+      return 2
+    }
+    prior_revision=$(printf '%s' "$prior" | jq -r '.requestRevision // empty')
+    [ "$prior_revision" = "$revision" ] || {
+      fm_eng_fail "$SCHEMA" identity_conflict "missionId was already used with different content"
+      return 2
+    }
+    jq -cn --arg schemaVersion "$SCHEMA" --argjson mission "$prior" \
+      '{accepted:true,schemaVersion:$schemaVersion,replayed:true,mission:$mission}'
+    return 0
+  fi
+  stored=$(printf '%s' "$input" | jq -c \
+    --arg sourceRevision "$revision" --arg requestRevision "$revision" --arg acceptedAt "$NOW" '
+    . + {
+      sourceRevision:$sourceRevision,
+      requestRevision:$requestRevision,
+      state:"accepted",
+      acceptedAt:$acceptedAt,
+      reporting:{
+        establishInitialScopes:true,
+        continueUntilTerminal:true,
+        acceptedKinds:["scope_discovery","scope_revision","hill_judgment","blocker","evidence","verification_instructions","outcome"]
+      }
+    }
+  ')
+  fm_eng_atomic_write "$path" "$stored"
+  jq -cn --arg schemaVersion "$SCHEMA" --argjson mission "$stored" \
+    '{accepted:true,schemaVersion:$schemaVersion,replayed:false,mission:$mission}'
+}
+
+change_state() {  # <state> <mission-id> <flag> <value> <field>
+  local state=$1 mission_id=$2 flag=$3 value=$4 field=$5 path current updated
+  fm_eng_valid_identity "$mission_id" || { fm_eng_fail "$SCHEMA" malformed_identity "Invalid missionId"; return 2; }
+  [ "$flag" = "$6" ] || { usage >&2; return 2; }
+  path="$MISSIONS/$mission_id.json"
+  [ -f "$path" ] || { fm_eng_fail "$SCHEMA" mission_not_found "Mission is not accepted"; return 2; }
+  current=$(jq -c . "$path") || { fm_eng_fail "$SCHEMA" malformed_record "Mission record is unreadable"; return 2; }
+  updated=$(printf '%s' "$current" | jq -c --arg state "$state" --arg field "$field" --arg value "$value" --arg at "$NOW" \
+    '.state=$state | .[$field]=$value | .stateChangedAt=$at')
+  fm_eng_atomic_write "$path" "$updated"
+  jq -cn --arg schemaVersion "$SCHEMA" --argjson mission "$updated" \
+    '{accepted:true,schemaVersion:$schemaVersion,mission:$mission}'
+}
+
+case "${1:-}" in
+  accept)
+    [ "$#" -eq 2 ] || { usage >&2; exit 2; }
+    accept_mission "$2"
+    ;;
+  supersede)
+    [ "$#" -eq 4 ] || { usage >&2; exit 2; }
+    change_state superseded "$2" "$3" "$4" replacementMissionId --replacement
+    ;;
+  defer)
+    [ "$#" -eq 6 ] || { usage >&2; exit 2; }
+    [ "$3" = --decision-id ] && [ "$5" = --build-revision ] || { usage >&2; exit 2; }
+    fm_eng_valid_identity "$2" || { fm_eng_fail "$SCHEMA" malformed_identity "Invalid missionId"; exit 2; }
+    path="$MISSIONS/$2.json"
+    [ -f "$path" ] || { fm_eng_fail "$SCHEMA" mission_not_found "Mission is not accepted"; exit 2; }
+    current_revision=$(jq -r '.acceptedBuildRevision // empty' "$path")
+    [ "$current_revision" = "$6" ] || { fm_eng_fail "$SCHEMA" stale_build "Deferred decision is bound to another Build revision"; exit 2; }
+    change_state deferred "$2" "$3" "$4" deferredDecisionId --decision-id
+    ;;
+  -h|--help)
+    usage
+    ;;
+  *)
+    usage >&2
+    exit 2
+    ;;
+esac

--- a/bin/fm-peek.sh
+++ b/bin/fm-peek.sh
@@ -65,13 +65,16 @@ valid_target_id() {
 # columns - reach the widest row's guaranteed width, itself a lower bound on the
 # pane width because each non-ASCII codepoint may instead occupy none. Both
 # bounds err toward stitching, so a wide glyph cannot hide the wrap.
-# Stitching is speculative, so every logical line is offered to the rules twice:
-# once joined and once as the rows the pane actually printed. When redacting the
-# rows one at a time produces exactly what redacting the joined line produced, no
-# redaction depended on the stitch and the rows are handed back with their own
-# boundaries; only a redaction that straddles a wrap keeps the joined line. That
-# way a row which merely fills the pane keeps its own line and its own event even
-# when the row beside it carries a credential of its own.
+# Stitching is speculative, so the rules run over the rows the pane actually
+# printed first, and the joined candidate is then built from those already-redacted
+# rows and offered to the rules again. The joined candidate therefore carries every
+# redaction the rows carry plus any that only a rejoined wrap reveals, so choosing
+# it can never release a value the rows had already masked. When the rows rejoin to
+# exactly the joined candidate nothing depended on the stitch and the rows are
+# handed back with their own boundaries, so a row which merely fills the pane keeps
+# its own line and its own event even when the row beside it carries a credential
+# of its own; only a redaction that a wrap hid from the per-row pass costs the
+# boundary.
 redact_capture() {
   local names labels anchor quotes
   names=$(fm_eng_credential_name_ere)
@@ -97,7 +100,7 @@ redact_capture() {
       if (cells - wide > floor) floor = cells - wide
     }
     END {
-      logical = ""; rows = 0; open = 0
+      rows = 0; open = 0
       for (i = 1; i <= NR; i++) {
         row = line[i]
         if (!open) { carried = pending; pending = 0; open = 1 }
@@ -106,16 +109,12 @@ redact_capture() {
         dangling = (separated || contiguous)
         stitch = (i < NR && floor > 0 && reach[i] >= floor)
         if (stitch && separated) row = row " "
-        logical = logical row
         row_text[++rows] = row
         if (stitch) continue
-        if (carried) {
-          logical = claim(logical)
-          row_text[1] = claim(row_text[1])
-        }
-        print "J\t" logical
+        if (carried) row_text[1] = claim(row_text[1])
+        print "G\t" (carried ? 1 : 0)
         for (r = 1; r <= rows; r++) print "R\t" row_text[r]
-        logical = ""; rows = 0; open = 0
+        rows = 0; open = 0
         pending = dangling
       }
     }
@@ -127,9 +126,49 @@ redact_capture() {
     -e "s/(^|$anchor)($labels$quotes)[[:space:]]*:[[:space:]]*${quotes}[^[:space:]]+\$/\\1\\2: [REDACTED]/" \
     -e 's/(-----BEGIN ([A-Z ]+)?PRIVATE KEY-----)/[REDACTED PRIVATE KEY]/g' \
   | LC_ALL=C awk '
-    # Each logical line arrives as its joined form followed by the rows the pane
-    # printed, both already redacted. The rules cannot match across the one-letter
-    # tag, so the two forms agreeing means no redaction needed the stitch.
+    # The redacted rows of each logical line rejoin into the joined candidate, so
+    # that candidate starts from every redaction the per-row pass already made and
+    # the rules only have to add what a rejoined wrap reveals. The rules cannot
+    # match across the one-letter tag, so the tag is safe to carry through them.
+    function claim(text,   indent) {
+      indent = ""
+      if (match(text, /^[ \t]+/)) { indent = substr(text, 1, RLENGTH); text = substr(text, RLENGTH + 1) }
+      sub(/^[^ \t]+/, "[REDACTED]", text)
+      return indent text
+    }
+    function emit(   r, joined) {
+      if (!open) return
+      joined = ""
+      for (r = 1; r <= rows; r++) joined = joined row_text[r]
+      if (carried) joined = claim(joined)
+      print "J\t" joined
+      for (r = 1; r <= rows; r++) print "R\t" row_text[r]
+      open = 0; rows = 0
+    }
+    {
+      cut = index($0, "\t")
+      text = substr($0, cut + 1)
+      if (substr($0, 1, cut - 1) == "G") {
+        emit()
+        carried = (text == "1")
+        open = 1
+      } else {
+        row_text[++rows] = text
+      }
+    }
+    END { emit() }
+  ' | LC_ALL=C sed -E \
+    -e 's/(Bearer)[[:space:]]+[^[:space:]]+/\1 [REDACTED]/g' \
+    -e 's/(gh[pousr]_)[A-Za-z0-9_]+/\1[REDACTED]/g' \
+    -e "s/($names)=[^[:space:]]+/\\1=[REDACTED]/g" \
+    -e "s/(^|$anchor)($labels$quotes)[[:space:]]*:[[:space:]]*${quotes}[^[:space:]]{6,}/\\1\\2: [REDACTED]/g" \
+    -e "s/(^|$anchor)($labels$quotes)[[:space:]]*:[[:space:]]*${quotes}[^[:space:]]+\$/\\1\\2: [REDACTED]/" \
+    -e 's/(-----BEGIN ([A-Z ]+)?PRIVATE KEY-----)/[REDACTED PRIVATE KEY]/g' \
+  | LC_ALL=C awk '
+    # The joined candidate is a superset of the rows it was built from, so when the
+    # rows rejoin to something else the difference is a redaction only the rejoined
+    # wrap revealed and the joined form is the safe answer. Otherwise nothing
+    # depended on the stitch and the pane rows keep their own boundaries.
     function settle(   r, joined_rows) {
       if (!open) return
       joined_rows = ""

--- a/bin/fm-peek.sh
+++ b/bin/fm-peek.sh
@@ -64,9 +64,14 @@ valid_target_id() {
 # its codepoints plus its non-ASCII codepoints - each of which may occupy two
 # columns - reach the widest row's guaranteed width, itself a lower bound on the
 # pane width because each non-ASCII codepoint may instead occupy none. Both
-# bounds err toward stitching, so a wide glyph cannot hide the wrap. Stitched
-# rows are split apart again unless the rules actually redacted something, so an
-# unrelated row that merely fills the pane keeps its own line and its own event.
+# bounds err toward stitching, so a wide glyph cannot hide the wrap.
+# Stitching is speculative, so every logical line is offered to the rules twice:
+# once joined and once as the rows the pane actually printed. When redacting the
+# rows one at a time produces exactly what redacting the joined line produced, no
+# redaction depended on the stitch and the rows are handed back with their own
+# boundaries; only a redaction that straddles a wrap keeps the joined line. That
+# way a row which merely fills the pane keeps its own line and its own event even
+# when the row beside it carries a credential of its own.
 redact_capture() {
   local names labels anchor quotes
   names=$(fm_eng_credential_name_ere)
@@ -76,6 +81,14 @@ redact_capture() {
   LC_ALL=C awk -v names="$names" -v labels="$labels" -v anchor="$anchor" -v quotes="$quotes" '
     function codepoints(text,   rest) { rest = text; return length(text) - gsub(/[\200-\277]/, "", rest) }
     function multibyte(text,    rest) { rest = text; return gsub(/[\300-\377]/, "", rest) }
+    # A dangling introducer from the previous logical line claims the first token
+    # of this one, which is the wrapped value in full.
+    function claim(text,   indent) {
+      indent = ""
+      if (match(text, /^[ \t]+/)) { indent = substr(text, 1, RLENGTH); text = substr(text, RLENGTH + 1) }
+      sub(/^[^ \t]+/, "[REDACTED]", text)
+      return indent text
+    }
     {
       line[NR] = $0
       cells = codepoints($0)
@@ -84,7 +97,7 @@ redact_capture() {
       if (cells - wide > floor) floor = cells - wide
     }
     END {
-      logical = ""; spans = ""; open = 0
+      logical = ""; rows = 0; open = 0
       for (i = 1; i <= NR; i++) {
         row = line[i]
         if (!open) { carried = pending; pending = 0; open = 1 }
@@ -94,18 +107,15 @@ redact_capture() {
         stitch = (i < NR && floor > 0 && reach[i] >= floor)
         if (stitch && separated) row = row " "
         logical = logical row
-        spans = spans (spans == "" ? "" : ",") length(row)
+        row_text[++rows] = row
         if (stitch) continue
-        # A dangling introducer from the previous logical line claims the first
-        # token of this one, which is the wrapped value in full.
         if (carried) {
-          indent = ""
-          if (match(logical, /^[ \t]+/)) { indent = substr(logical, 1, RLENGTH); logical = substr(logical, RLENGTH + 1) }
-          sub(/^[^ \t]+/, "[REDACTED]", logical)
-          logical = indent logical
+          logical = claim(logical)
+          row_text[1] = claim(row_text[1])
         }
-        print spans "\t" logical
-        logical = ""; spans = ""; open = 0
+        print "J\t" logical
+        for (r = 1; r <= rows; r++) print "R\t" row_text[r]
+        logical = ""; rows = 0; open = 0
         pending = dangling
       }
     }
@@ -117,19 +127,32 @@ redact_capture() {
     -e "s/(^|$anchor)($labels$quotes)[[:space:]]*:[[:space:]]*${quotes}[^[:space:]]+\$/\\1\\2: [REDACTED]/" \
     -e 's/(-----BEGIN ([A-Z ]+)?PRIVATE KEY-----)/[REDACTED PRIVATE KEY]/g' \
   | LC_ALL=C awk '
-    # The leading span list records each stitched row width; the rules cannot
-    # match inside it, so a logical line the rules left byte-for-byte alone is
-    # handed back as the rows the pane actually printed.
+    # Each logical line arrives as its joined form followed by the rows the pane
+    # printed, both already redacted. The rules cannot match across the one-letter
+    # tag, so the two forms agreeing means no redaction needed the stitch.
+    function settle(   r, joined_rows) {
+      if (!open) return
+      joined_rows = ""
+      for (r = 1; r <= rows; r++) joined_rows = joined_rows row_text[r]
+      if (joined_rows == logical) {
+        for (r = 1; r <= rows; r++) print row_text[r]
+      } else {
+        print logical
+      }
+      open = 0; rows = 0
+    }
     {
       cut = index($0, "\t")
-      count = split(substr($0, 1, cut - 1), span, ",")
       text = substr($0, cut + 1)
-      total = 0
-      for (i = 1; i <= count; i++) total += span[i]
-      if (length(text) != total || index(text, "[REDACTED]") > 0) { print text; next }
-      at = 1
-      for (i = 1; i <= count; i++) { print substr(text, at, span[i]); at += span[i] }
+      if (substr($0, 1, cut - 1) == "J") {
+        settle()
+        logical = text
+        open = 1
+      } else {
+        row_text[++rows] = text
+      }
     }
+    END { settle() }
   '
 }
 

--- a/bin/fm-peek.sh
+++ b/bin/fm-peek.sh
@@ -50,6 +50,12 @@ valid_target_id() {
 # would break the very value rule that has to consume the rejoined token. An
 # unstitched row of either shape fails closed onto the next row's first token
 # regardless of the whitespace in front of it.
+# The two separators carry different amounts of evidence, so they are recognized
+# differently. `=` is an assignment and is unambiguous, so any credential-named
+# operand qualifies. `:` is also ordinary prose punctuation, so it needs a whole
+# separator-delimited credential label and an operand long enough to be a secret;
+# otherwise inert telemetry such as `Total tokens: 4821` would be treated as a
+# credential, and a pane-wide inert label would stitch away the next row's event.
 # Stitching never trusts a measured display width. A mid-token wrap leaves the
 # row exactly as wide as the pane, so a row counts as possibly pane-wide when
 # its codepoints plus its non-ASCII codepoints - each of which may occupy two
@@ -59,9 +65,10 @@ valid_target_id() {
 # rows are split apart again unless the rules actually redacted something, so an
 # unrelated row that merely fills the pane keeps its own line and its own event.
 redact_capture() {
-  local names
+  local names labels
   names=$(fm_eng_credential_name_ere)
-  LC_ALL=C awk -v names="$names" '
+  labels=$(fm_eng_credential_label_ere)
+  LC_ALL=C awk -v names="$names" -v labels="$labels" '
     function codepoints(text,   rest) { rest = text; return length(text) - gsub(/[\200-\277]/, "", rest) }
     function multibyte(text,    rest) { rest = text; return gsub(/[\300-\377]/, "", rest) }
     {
@@ -77,7 +84,7 @@ redact_capture() {
         row = line[i]
         if (!open) { carried = pending; pending = 0; open = 1 }
         separated = (row ~ /Bearer$/)
-        contiguous = (row ~ /gh[pousr]_$/ || row ~ ("(" names ")[[:space:]]*[=:]$"))
+        contiguous = (row ~ /gh[pousr]_$/ || row ~ ("(" names ")=$") || row ~ ("(^|[[:space:]])(" labels ")[[:space:]]*:$"))
         dangling = (separated || contiguous)
         stitch = (i < NR && floor > 0 && reach[i] >= floor)
         if (stitch && separated) row = row " "
@@ -101,7 +108,7 @@ redact_capture() {
     -e 's/(Bearer)[[:space:]]+[^[:space:]]+/\1 [REDACTED]/g' \
     -e 's/(gh[pousr]_)[A-Za-z0-9_]+/\1[REDACTED]/g' \
     -e "s/($names)=[^[:space:]]+/\\1=[REDACTED]/g" \
-    -e "s/($names)[[:space:]]*:[[:space:]]*[^[:space:]]+/\\1: [REDACTED]/g" \
+    -e "s/(^|[[:space:]])($labels)[[:space:]]*:[[:space:]]*[^[:space:]]{6,}/\\1\\2: [REDACTED]/g" \
     -e 's/(-----BEGIN ([A-Z ]+)?PRIVATE KEY-----)/[REDACTED PRIVATE KEY]/g' \
   | LC_ALL=C awk '
     # The leading span list records each stitched row width; the rules cannot

--- a/bin/fm-peek.sh
+++ b/bin/fm-peek.sh
@@ -52,10 +52,13 @@ valid_target_id() {
 # regardless of the whitespace in front of it.
 # The two separators carry different amounts of evidence, so they are recognized
 # differently. `=` is an assignment and is unambiguous, so any credential-named
-# operand qualifies. `:` is also ordinary prose punctuation, so it needs a whole
-# separator-delimited credential label and an operand long enough to be a secret;
-# otherwise inert telemetry such as `Total tokens: 4821` would be treated as a
-# credential, and a pane-wide inert label would stitch away the next row's event.
+# operand qualifies. `:` is also ordinary prose punctuation, so it asks for a label
+# whose credential word ends it and for one of two independent signals from the
+# operand: it either closes the line, the way a credential header's value does, or
+# it is long enough to be a secret wherever it sits. Inert telemetry such as
+# `Total tokens: 4821 in this run` gives neither signal - its label is a glued
+# plural and its operand is short and mid-sentence - so it renders as the pane
+# printed it, and a pane-wide inert label never stitches away the next row's event.
 # Stitching never trusts a measured display width. A mid-token wrap leaves the
 # row exactly as wide as the pane, so a row counts as possibly pane-wide when
 # its codepoints plus its non-ASCII codepoints - each of which may occupy two
@@ -65,10 +68,12 @@ valid_target_id() {
 # rows are split apart again unless the rules actually redacted something, so an
 # unrelated row that merely fills the pane keeps its own line and its own event.
 redact_capture() {
-  local names labels
+  local names labels anchor quotes
   names=$(fm_eng_credential_name_ere)
   labels=$(fm_eng_credential_label_ere)
-  LC_ALL=C awk -v names="$names" -v labels="$labels" '
+  anchor=$(fm_eng_credential_label_anchor)
+  quotes="[\"']*"
+  LC_ALL=C awk -v names="$names" -v labels="$labels" -v anchor="$anchor" -v quotes="$quotes" '
     function codepoints(text,   rest) { rest = text; return length(text) - gsub(/[\200-\277]/, "", rest) }
     function multibyte(text,    rest) { rest = text; return gsub(/[\300-\377]/, "", rest) }
     {
@@ -84,7 +89,7 @@ redact_capture() {
         row = line[i]
         if (!open) { carried = pending; pending = 0; open = 1 }
         separated = (row ~ /Bearer$/)
-        contiguous = (row ~ /gh[pousr]_$/ || row ~ ("(" names ")=$") || row ~ ("(^|[[:space:]])(" labels ")[[:space:]]*:$"))
+        contiguous = (row ~ /gh[pousr]_$/ || row ~ ("(" names ")=$") || row ~ ("(^|" anchor ")(" labels ")" quotes "[[:space:]]*:$"))
         dangling = (separated || contiguous)
         stitch = (i < NR && floor > 0 && reach[i] >= floor)
         if (stitch && separated) row = row " "
@@ -108,7 +113,8 @@ redact_capture() {
     -e 's/(Bearer)[[:space:]]+[^[:space:]]+/\1 [REDACTED]/g' \
     -e 's/(gh[pousr]_)[A-Za-z0-9_]+/\1[REDACTED]/g' \
     -e "s/($names)=[^[:space:]]+/\\1=[REDACTED]/g" \
-    -e "s/(^|[[:space:]])($labels)[[:space:]]*:[[:space:]]*[^[:space:]]{6,}/\\1\\2: [REDACTED]/g" \
+    -e "s/(^|$anchor)($labels$quotes)[[:space:]]*:[[:space:]]*${quotes}[^[:space:]]{6,}/\\1\\2: [REDACTED]/g" \
+    -e "s/(^|$anchor)($labels$quotes)[[:space:]]*:[[:space:]]*${quotes}[^[:space:]]+\$/\\1\\2: [REDACTED]/" \
     -e 's/(-----BEGIN ([A-Z ]+)?PRIVATE KEY-----)/[REDACTED PRIVATE KEY]/g' \
   | LC_ALL=C awk '
     # The leading span list records each stitched row width; the rules cannot

--- a/bin/fm-peek.sh
+++ b/bin/fm-peek.sh
@@ -1,8 +1,12 @@
 #!/usr/bin/env bash
 # Print the tail of a crewmate endpoint (bounded, for cheap diagnosis).
 # Usage: fm-peek.sh <target> [lines=40]
+#        fm-peek.sh --json <exact-task-id> [lines=40]
 #   <target> may be an exact task id, a legacy fm-<id> task label resolved
 #   through this home's state/<id>.meta, or an explicit backend target.
+#   --json accepts only an exact task id with one metadata record and returns a
+#   closed descriptor plus bounded redacted capture. It never resolves a bare
+#   or ambiguous live target and never exposes commands or environment values.
 set -eu
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -12,6 +16,150 @@ STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
 
 # shellcheck source=bin/fm-backend.sh
 . "$SCRIPT_DIR/fm-backend.sh"
+
+machine_error() {  # <code> <message>
+  jq -n --arg code "$1" --arg message "$2" \
+    '{available:false,schemaVersion:"fm-session-inspection.v1",error:{code:$code,message:$message}}'
+}
+
+valid_task_id() {
+  case "$1" in ''|*[!A-Za-z0-9._-]*) return 1 ;; esac
+  [ "${#1}" -le 128 ]
+}
+
+valid_target_id() {
+  [ -n "$1" ] && [ "${#1}" -le 512 ] || return 1
+  ! printf '%s' "$1" | LC_ALL=C grep -q '[[:cntrl:]]'
+}
+
+# redact_capture: credential redaction over one bounded pane capture on stdin.
+# A pane inserts a real newline at its width, so a credential wider than the
+# pane arrives split across capture lines and per-line rules would only match
+# the fragment on one of them. Rows the pane may have wrapped are therefore
+# stitched into one logical line before the single-line rules run, so a value -
+# or the introducer itself - split across the wrap is matched whole, and a
+# multi-row value stays a single token the value rules consume entirely.
+# A pane that wrapped on the space separating an introducer from its value
+# leaves no split token to stitch, and the space itself lands either at the end
+# of one row (where the pane strips it) or at the start of the next. Both shapes
+# leave a bare introducer at a row end: a stitched row gets the separating space
+# back, and an unstitched one fails closed onto the next row's first token
+# regardless of the whitespace in front of it.
+# Stitching never trusts a measured display width. A mid-token wrap leaves the
+# row exactly as wide as the pane, so a row counts as possibly pane-wide when
+# its codepoints plus its non-ASCII codepoints - each of which may occupy two
+# columns - reach the widest row's guaranteed width, itself a lower bound on the
+# pane width because each non-ASCII codepoint may instead occupy none. Both
+# bounds err toward stitching, so a wide glyph cannot hide the wrap. Stitched
+# rows are split apart again unless the rules actually redacted something, so an
+# unrelated row that merely fills the pane keeps its own line and its own event.
+redact_capture() {
+  LC_ALL=C awk '
+    function codepoints(text,   rest) { rest = text; return length(text) - gsub(/[\200-\277]/, "", rest) }
+    function multibyte(text,    rest) { rest = text; return gsub(/[\300-\377]/, "", rest) }
+    {
+      line[NR] = $0
+      cells = codepoints($0)
+      wide = multibyte($0)
+      reach[NR] = cells + wide
+      if (cells - wide > floor) floor = cells - wide
+    }
+    END {
+      logical = ""; spans = ""; open = 0
+      for (i = 1; i <= NR; i++) {
+        row = line[i]
+        if (!open) { carried = pending; pending = 0; open = 1 }
+        dangling = (row ~ /(Bearer|gh[pousr]_|[A-Za-z0-9_]*(TOKEN|SECRET|PASSWORD|CREDENTIAL)[A-Za-z0-9_]*=)$/)
+        stitch = (i < NR && floor > 0 && reach[i] >= floor)
+        if (stitch && dangling) row = row " "
+        logical = logical row
+        spans = spans (spans == "" ? "" : ",") length(row)
+        if (stitch) continue
+        # A dangling introducer from the previous logical line claims the first
+        # token of this one, which is the wrapped value in full.
+        if (carried) {
+          indent = ""
+          if (match(logical, /^[ \t]+/)) { indent = substr(logical, 1, RLENGTH); logical = substr(logical, RLENGTH + 1) }
+          sub(/^[^ \t]+/, "[REDACTED]", logical)
+          logical = indent logical
+        }
+        print spans "\t" logical
+        logical = ""; spans = ""; open = 0
+        pending = dangling
+      }
+    }
+  ' | LC_ALL=C sed -E \
+    -e 's/(Bearer)[[:space:]]+[^[:space:]]+/\1 [REDACTED]/g' \
+    -e 's/(gh[pousr]_)[A-Za-z0-9_]+/\1[REDACTED]/g' \
+    -e 's/([A-Za-z0-9_]*(TOKEN|SECRET|PASSWORD|CREDENTIAL)[A-Za-z0-9_]*)=[^[:space:]]+/\1=[REDACTED]/g' \
+    -e 's/(-----BEGIN ([A-Z ]+)?PRIVATE KEY-----)/[REDACTED PRIVATE KEY]/g' \
+  | LC_ALL=C awk '
+    # The leading span list records each stitched row width; the rules cannot
+    # match inside it, so a logical line the rules left byte-for-byte alone is
+    # handed back as the rows the pane actually printed.
+    {
+      cut = index($0, "\t")
+      count = split(substr($0, 1, cut - 1), span, ",")
+      text = substr($0, cut + 1)
+      total = 0
+      for (i = 1; i <= count; i++) total += span[i]
+      if (length(text) != total || index(text, "[REDACTED]") > 0) { print text; next }
+      at = 1
+      for (i = 1; i <= count; i++) { print substr(text, at, span[i]); at += span[i] }
+    }
+  '
+}
+
+machine_peek() {  # <task-id> <lines>
+  # A wrapped credential's introducer can sit just above the requested window,
+  # so the capture reads a bounded number of extra rows for redaction context
+  # and the answer is trimmed back to the requested bound afterwards.
+  local task_id=$1 lines=$2 lookback=8 meta backend target expected capture bytes truncated=false lifecycle=running
+  command -v jq >/dev/null 2>&1 || { echo "fm-peek: jq not found" >&2; return 1; }
+  valid_task_id "$task_id" || { machine_error malformed_task "Task identity is invalid"; return 2; }
+  case "$lines" in ''|*[!0-9]*|0) machine_error invalid_bound "Capture lines must be a positive integer"; return 2 ;; esac
+  [ "$lines" -le 200 ] || { machine_error invalid_bound "Capture lines are limited to 200"; return 2; }
+  meta="$STATE/$task_id.meta"
+  [ -f "$meta" ] || { machine_error session_not_found "No exact session descriptor exists for the task"; return 2; }
+  backend=$(fm_backend_of_meta "$meta")
+  target=$(fm_backend_target_of_meta "$meta")
+  valid_target_id "$target" || { machine_error session_unavailable "The task has no valid backend target"; return 2; }
+  expected="fm-$task_id"
+  if ! fm_backend_target_exists "$backend" "$target" "$expected"; then
+    lifecycle=ended
+    machine_error session_ended "The recorded session endpoint is no longer available"
+    return 2
+  fi
+  capture=$(fm_backend_capture "$backend" "$target" "$((lines + lookback))" "$expected" 2>/dev/null) || {
+    machine_error session_unavailable "The recorded session could not be captured"
+    return 2
+  }
+  capture=$(printf '%s\n' "$capture" | redact_capture | tail -n "$lines")
+  bytes=$(printf '%s' "$capture" | LC_ALL=C wc -c | tr -d '[:space:]')
+  if [ "$bytes" -gt 32768 ]; then
+    capture=$(printf '%s' "$capture" | head -c 32768)
+    bytes=32768
+    truncated=true
+  fi
+  jq -n --arg taskId "$task_id" --arg backend "$backend" --arg targetId "$target" \
+    --arg lifecycle "$lifecycle" --arg text "$capture" --argjson lines "$lines" \
+    --argjson bytes "$bytes" --argjson truncated "$truncated" '
+    {
+      available:true,
+      schemaVersion:"fm-session-inspection.v1",
+      descriptor:{taskId:$taskId,backend:$backend,targetId:$targetId,lifecycle:$lifecycle},
+      capture:{text:$text,lines:$lines,bytes:$bytes,truncated:$truncated},
+      mode:"bounded-read-only",
+      authoritative:false
+    }
+  '
+}
+
+if [ "${1:-}" = --json ]; then
+  [ "$#" -ge 2 ] && [ "$#" -le 3 ] || { machine_error malformed_request "Usage: fm-peek.sh --json <task-id> [lines]"; exit 2; }
+  machine_peek "$2" "${3:-40}"
+  exit $?
+fi
 
 "$SCRIPT_DIR/fm-guard.sh" || true
 

--- a/bin/fm-peek.sh
+++ b/bin/fm-peek.sh
@@ -16,6 +16,9 @@ STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
 
 # shellcheck source=bin/fm-backend.sh
 . "$SCRIPT_DIR/fm-backend.sh"
+# shellcheck source=bin/fm-engineering-lib.sh
+# shellcheck disable=SC1091
+. "$SCRIPT_DIR/fm-engineering-lib.sh"
 
 machine_error() {  # <code> <message>
   jq -n --arg code "$1" --arg message "$2" \
@@ -39,11 +42,13 @@ valid_target_id() {
 # stitched into one logical line before the single-line rules run, so a value -
 # or the introducer itself - split across the wrap is matched whole, and a
 # multi-row value stays a single token the value rules consume entirely.
-# A pane that wrapped on the space separating an introducer from its value
-# leaves no split token to stitch, and the space itself lands either at the end
-# of one row (where the pane strips it) or at the start of the next. Both shapes
-# leave a bare introducer at a row end: a stitched row gets the separating space
-# back, and an unstitched one fails closed onto the next row's first token
+# An introducer left bare at a row end is one of two shapes, and only one of them
+# lost a separator to the wrap. A space-separated introducer such as `Bearer` did
+# lose the space, so a stitched row gets it back. An assignment introducer such as
+# `SERVICE_TOKEN=` or `X-Api-Key:` is contiguous with its value, so the wrap landed
+# mid-token and the rows rejoin with nothing between them; inserting a space there
+# would break the very value rule that has to consume the rejoined token. An
+# unstitched row of either shape fails closed onto the next row's first token
 # regardless of the whitespace in front of it.
 # Stitching never trusts a measured display width. A mid-token wrap leaves the
 # row exactly as wide as the pane, so a row counts as possibly pane-wide when
@@ -54,7 +59,9 @@ valid_target_id() {
 # rows are split apart again unless the rules actually redacted something, so an
 # unrelated row that merely fills the pane keeps its own line and its own event.
 redact_capture() {
-  LC_ALL=C awk '
+  local names
+  names=$(fm_eng_credential_name_ere)
+  LC_ALL=C awk -v names="$names" '
     function codepoints(text,   rest) { rest = text; return length(text) - gsub(/[\200-\277]/, "", rest) }
     function multibyte(text,    rest) { rest = text; return gsub(/[\300-\377]/, "", rest) }
     {
@@ -69,9 +76,11 @@ redact_capture() {
       for (i = 1; i <= NR; i++) {
         row = line[i]
         if (!open) { carried = pending; pending = 0; open = 1 }
-        dangling = (row ~ /(Bearer|gh[pousr]_|[A-Za-z0-9_]*(TOKEN|SECRET|PASSWORD|CREDENTIAL)[A-Za-z0-9_]*=)$/)
+        separated = (row ~ /Bearer$/)
+        contiguous = (row ~ /gh[pousr]_$/ || row ~ ("(" names ")[[:space:]]*[=:]$"))
+        dangling = (separated || contiguous)
         stitch = (i < NR && floor > 0 && reach[i] >= floor)
-        if (stitch && dangling) row = row " "
+        if (stitch && separated) row = row " "
         logical = logical row
         spans = spans (spans == "" ? "" : ",") length(row)
         if (stitch) continue
@@ -91,7 +100,8 @@ redact_capture() {
   ' | LC_ALL=C sed -E \
     -e 's/(Bearer)[[:space:]]+[^[:space:]]+/\1 [REDACTED]/g' \
     -e 's/(gh[pousr]_)[A-Za-z0-9_]+/\1[REDACTED]/g' \
-    -e 's/([A-Za-z0-9_]*(TOKEN|SECRET|PASSWORD|CREDENTIAL)[A-Za-z0-9_]*)=[^[:space:]]+/\1=[REDACTED]/g' \
+    -e "s/($names)=[^[:space:]]+/\\1=[REDACTED]/g" \
+    -e "s/($names)[[:space:]]*:[[:space:]]*[^[:space:]]+/\\1: [REDACTED]/g" \
     -e 's/(-----BEGIN ([A-Z ]+)?PRIVATE KEY-----)/[REDACTED PRIVATE KEY]/g' \
   | LC_ALL=C awk '
     # The leading span list records each stitched row width; the rules cannot

--- a/bin/fm-report.sh
+++ b/bin/fm-report.sh
@@ -121,7 +121,7 @@ EOF
 next_acceptance_sequence() {
   local current='' next
   fm_eng_lock_acquire_wait "$SEQUENCE_LOCK" "${FM_REPORT_SEQUENCE_LOCK_STALE_MINUTES:-}" "$NOW" \
-    "${FM_REPORT_SEQUENCE_LOCK_ATTEMPTS:-}" || return 1
+    "${FM_REPORT_SEQUENCE_LOCK_WAIT_SECONDS:-}" || return 1
   if [ -f "$SEQUENCE_FILE" ]; then
     IFS= read -r current < "$SEQUENCE_FILE" || true
     current=${current%%[!0-9]*}

--- a/bin/fm-report.sh
+++ b/bin/fm-report.sh
@@ -1,0 +1,462 @@
+#!/usr/bin/env bash
+# fm-report.sh - validate and append continuous Engineering observations.
+#
+# Usage:
+#   fm-report.sh append <report-json-file|->
+#
+# Reports are immutable and idempotent by reportId.
+# Invalid correlated reports are retained with status=rejected and a typed
+# error so Captain's Log can show them without making them executable.
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
+DATA="${FM_DATA_OVERRIDE:-$FM_HOME/data}"
+ENGINEERING="$DATA/engineering"
+MISSIONS="$ENGINEERING/missions"
+REPORTS="$ENGINEERING/reports"
+NOW="${FM_ENGINEERING_NOW:-$(date -u +%Y-%m-%dT%H:%M:%SZ)}"
+SCHEMA=fm-engineering-report.v1
+MAX_EVIDENCE_BYTES=${FM_EVIDENCE_MAX_BYTES:-10485760}
+
+# shellcheck source=bin/fm-engineering-lib.sh
+# shellcheck disable=SC1091
+. "$SCRIPT_DIR/fm-engineering-lib.sh"
+
+command -v jq >/dev/null 2>&1 || { echo "fm-report: jq not found" >&2; exit 1; }
+
+usage() {
+  awk 'NR == 1 { next } /^#/ { sub(/^# ?/, ""); print; next } { exit }' "$0"
+}
+
+report_error() {  # <code> <message> <input> <digest> <report-id>
+  local code=$1 message=$2 input=$3 request_digest=$4 report_id=$5 rejected
+  rejected=$(printf '%s' "$input" | jq -c --arg code "$code" --arg message "$message" \
+    --arg sourceRevision "$request_digest" --arg rejectedAt "$NOW" '
+    . + {
+      sourceRevision:$sourceRevision,
+      requestDigest:$sourceRevision,
+      status:"rejected",
+      rejectedAt:$rejectedAt,
+      error:{code:$code,message:$message}
+    }
+  ')
+  if fm_eng_valid_identity "$report_id"; then
+    fm_eng_atomic_write "$REPORTS/$report_id.json" "$rejected"
+  fi
+  fm_eng_fail "$SCHEMA" "$code" "$message" "$rejected"
+  return 2
+}
+
+canonical_file() {  # <path>
+  local path=$1 dir base
+  [ -f "$path" ] || return 1
+  dir=$(cd "$(dirname "$path")" 2>/dev/null && pwd -P) || return 1
+  base=$(basename "$path")
+  printf '%s/%s\n' "$dir" "$base"
+}
+
+evidence_root_allows() {  # <file> <mission-json>
+  local file=$1 mission=$2 root canonical_root
+  while IFS= read -r root; do
+    [ -n "$root" ] || continue
+    canonical_root=$(cd "$root" 2>/dev/null && pwd -P) || continue
+    fm_eng_relative_to "$file" "$canonical_root" && return 0
+  done < <(printf '%s' "$mission" | jq -r '.allowedEvidenceRoots[]?')
+  return 1
+}
+
+CONDITION_SCAN_EMPTY='{"latest":null,"nextSequence":1}'
+
+condition_scan_filter() {  # <mission-id> <condition-id> <file>...
+  local mission_id=$1 condition_id=$2
+  shift 2
+  printf '%s\0' "$@" | xargs -0 cat 2>/dev/null \
+    | jq -cn --arg missionId "$mission_id" --arg conditionId "$condition_id" '
+    [inputs] as $read
+    | ($read | map(select(type == "object"))) as $records
+    | {
+        latest:([ $records[]
+          | select(.status == "accepted" and .missionId == $missionId
+            and .condition.conditionId == $conditionId) ]
+          | sort_by(.acceptedAt // "",.capturedAt // "",.reportId) | last // null),
+        nextSequence:(([ $records[] | .condition.creationSequence? | numbers ] | max // 0) + 1),
+        readCount:($read | length)
+      }
+  '
+}
+
+condition_scan_complete() {  # <scan-json> <expected-count>
+  [ -n "$1" ] || return 1
+  [ "$(printf '%s' "$1" | jq -r '.readCount // "invalid"')" = "$2" ]
+}
+
+# One pass over stored reports yields both the authoritative prior packet for a
+# condition and the next unused creation sequence. Every expected record must be
+# read: a store that cannot be read in full is a typed failure, never a silently
+# truncated history that would re-raise an existing condition and collide its
+# creation sequence.
+condition_scan() {  # <mission-id> <condition-id>
+  local mission_id=$1 condition_id=$2 file result
+  local -a files=() valid=()
+  if [ -d "$REPORTS" ]; then
+    while IFS= read -r file; do
+      [ -n "$file" ] || continue
+      files[${#files[@]}]=$file
+    done < <(find "$REPORTS" -maxdepth 1 -type f -name '*.json' -print 2>/dev/null | LC_ALL=C sort)
+  fi
+  if [ "${#files[@]}" -eq 0 ]; then
+    printf '%s' "$CONDITION_SCAN_EMPTY"
+    return 0
+  fi
+  if result=$(condition_scan_filter "$mission_id" "$condition_id" "${files[@]}" 2>/dev/null) \
+    && condition_scan_complete "$result" "${#files[@]}"; then
+    printf '%s' "$result"
+    return 0
+  fi
+  for file in "${files[@]}"; do
+    [ -r "$file" ] || return 1
+    jq -e 'type == "object"' "$file" >/dev/null 2>&1 && valid[${#valid[@]}]=$file
+  done
+  if [ "${#valid[@]}" -eq 0 ]; then
+    printf '%s' "$CONDITION_SCAN_EMPTY"
+    return 0
+  fi
+  result=$(condition_scan_filter "$mission_id" "$condition_id" "${valid[@]}") || return 1
+  condition_scan_complete "$result" "${#valid[@]}" || return 1
+  printf '%s' "$result"
+}
+
+validate_evidence() {  # <input> <mission>
+  local input=$1 mission=$2 kind value canonical size
+  printf '%s' "$input" | jq -e '
+    .evidence.producer == .crewmateId
+    and .evidence.verifier == "firstmate"
+    and (.evidence.contract | type == "string" and length > 0)
+    and (.evidence.executionRevision | type == "string" and length > 0)
+    and (.evidence.verification.status | IN("missing","present","failed","stale","unavailable","not-applicable","verified"))
+    and (.evidence.verification.instructions | type == "string" and length > 0)
+    and (.evidence.reference.kind | IN("file","url"))
+    and (.evidence.reference.value | type == "string" and length > 0)
+    and (.evidence.reference.mediaType | IN("text/plain","application/json","image/png","image/jpeg","application/pdf"))
+  ' >/dev/null 2>&1 || return 3
+  kind=$(printf '%s' "$input" | jq -r '.evidence.reference.kind')
+  value=$(printf '%s' "$input" | jq -r '.evidence.reference.value')
+  case "$kind" in
+    file)
+      canonical=$(canonical_file "$value") || return 4
+      evidence_root_allows "$canonical" "$mission" || return 5
+      size=$(wc -c < "$canonical" | tr -d '[:space:]')
+      case "$size" in ''|*[!0-9]*) return 3 ;; esac
+      [ "$size" -le "$MAX_EVIDENCE_BYTES" ] || return 6
+      ;;
+    url)
+      case "$value" in https://*) ;; *) return 7 ;; esac
+      printf '%s' "$input" | jq -e '.evidence.reference.requiresConfirmation == true' >/dev/null 2>&1 || return 8
+      ;;
+  esac
+  return 0
+}
+
+# Projection is a separate durable step from acceptance: an accepted report keeps
+# a typed projection state so an exact replay can retry and heal it. A retry that
+# fails again leaves the existing state untouched so replay stays free of writes.
+project_condition_packet() {  # <report-path> <mission-id> <condition-id> <lifecycle> <report-json>
+  local path=$1 mission_id=$2 condition_id=$3 lifecycle=$4 report=$5 updated
+  if "$SCRIPT_DIR/fm-decision-hold.sh" project "$mission_id" "$condition_id" \
+    --packet-file "$path" --lifecycle "$lifecycle" >/dev/null; then
+    updated=$(printf '%s' "$report" | jq -c --arg at "$NOW" \
+      '.condition.projection={status:"projected",projectedAt:$at}')
+  else
+    updated=$(printf '%s' "$report" | jq -c --arg at "$NOW" '
+      if (.condition.projection.status? // "") == "degraded" then .
+      else
+        .condition.projection={
+          status:"degraded",
+          attemptedAt:$at,
+          error:{
+            code:"captain_call_projection_failed",
+            message:"Captain Call is held durably but its packet could not be projected"
+          }
+        }
+      end')
+  fi
+  [ "$updated" = "$report" ] || fm_eng_atomic_write "$path" "$updated"
+  printf '%s' "$updated"
+}
+
+condition_hold_state() {  # <mission-id> <condition-id>
+  local status
+  status=$("$SCRIPT_DIR/fm-decision-hold.sh" status "$1" "$2" --json 2>/dev/null) || {
+    printf 'unknown'
+    return 0
+  }
+  printf '%s' "$status" | jq -e 'type == "object"' >/dev/null 2>&1 || {
+    printf 'unknown'
+    return 0
+  }
+  if printf '%s' "$status" | jq -e '.durableState.held == true and .durableState.state == "queued"' >/dev/null 2>&1; then
+    printf 'active'
+  else
+    printf 'inactive'
+  fi
+}
+
+# Healing only makes sense while the Captain Call is still held. Once the durable
+# hold is closed the packet can never land, so the record records that terminally
+# instead of retrying and rewriting itself on every replay.
+heal_condition_projection() {  # <report-path> <report-json>
+  local path=$1 report=$2 mission_id condition_id lifecycle updated
+  mission_id=$(printf '%s' "$report" | jq -r '.missionId // empty')
+  condition_id=$(printf '%s' "$report" | jq -r '.condition.conditionId // empty')
+  lifecycle=$(printf '%s' "$report" | jq -r '.condition.lifecycle // "raised"')
+  if [ "$(condition_hold_state "$mission_id" "$condition_id")" = inactive ]; then
+    updated=$(printf '%s' "$report" | jq -c --arg at "$NOW" '
+      .condition.projection={
+        status:"abandoned",
+        abandonedAt:$at,
+        error:{
+          code:"captain_call_not_active",
+          message:"The Captain Call is no longer actively held, so its packet can no longer be projected"
+        }
+      }')
+    [ "$updated" = "$report" ] || fm_eng_atomic_write "$path" "$updated"
+    printf '%s' "$updated"
+    return 0
+  fi
+  project_condition_packet "$path" "$mission_id" "$condition_id" "$lifecycle" "$report"
+}
+
+accepted_report_response() {  # <report-json> <replayed>
+  printf '%s' "$1" | jq -c --arg schemaVersion "$SCHEMA" --argjson replayed "$2" '
+    . as $report
+    | ($report.condition.projection? // null) as $projection
+    | {accepted:true,schemaVersion:$schemaVersion,replayed:$replayed,report:$report}
+    | if ($projection != null and $projection.status != "projected")
+      then . + {captainCall:{projection:$projection.status,error:$projection.error}}
+      else . end'
+}
+
+append_report() {  # <path-or-dash>
+  local input report_id kind mission_id task_id crewmate request_digest path prior prior_digest mission correlation validation stored
+  local shapeup_submission condition_scan_result
+  local condition_id condition_title condition_packet condition_revision condition_previous condition_sequence condition_lifecycle hold_id
+  input=$(fm_eng_read_json "$1") || {
+    case $? in
+      2) fm_eng_fail "$SCHEMA" request_too_large "Report records are limited to 256 KiB" ;;
+      *) fm_eng_fail "$SCHEMA" malformed_report "Report input must be a readable JSON object" ;;
+    esac
+    return 2
+  }
+  fm_eng_contains_credentials "$input" && {
+    fm_eng_fail "$SCHEMA" credential_material "Credentials must never enter reports or evidence"
+    return 2
+  }
+  report_id=$(printf '%s' "$input" | jq -r '.reportId // empty')
+  kind=$(printf '%s' "$input" | jq -r '.kind // empty')
+  mission_id=$(printf '%s' "$input" | jq -r '.missionId // empty')
+  task_id=$(printf '%s' "$input" | jq -r '.taskId // empty')
+  crewmate=$(printf '%s' "$input" | jq -r '.crewmateId // empty')
+  if ! fm_eng_valid_identity "$report_id" \
+    || ! fm_eng_valid_identity "$mission_id" \
+    || ! fm_eng_valid_identity "$task_id" \
+    || ! fm_eng_valid_identity "$crewmate"; then
+    fm_eng_fail "$SCHEMA" malformed_identity "Report and FirstMate identities must be privacy-safe"
+    return 2
+  fi
+  request_digest=$(fm_eng_canonical "$input" | fm_eng_digest)
+  path="$REPORTS/$report_id.json"
+  if [ -f "$path" ]; then
+    prior=$(jq -c . "$path" 2>/dev/null) || { fm_eng_fail "$SCHEMA" malformed_record "Existing report is unreadable"; return 2; }
+    prior_digest=$(printf '%s' "$prior" | jq -r '.requestDigest // empty')
+    [ "$prior_digest" = "$request_digest" ] || {
+      fm_eng_fail "$SCHEMA" identity_conflict "reportId was already used with different content"
+      return 2
+    }
+    if [ "$(printf '%s' "$prior" | jq -r '.status')" = rejected ]; then
+      fm_eng_fail "$SCHEMA" "$(printf '%s' "$prior" | jq -r '.error.code')" \
+        "$(printf '%s' "$prior" | jq -r '.error.message')" "$prior"
+      return 2
+    fi
+    if [ "$(printf '%s' "$prior" | jq -r '.condition.projection.status? // empty')" = degraded ]; then
+      prior=$(heal_condition_projection "$path" "$prior")
+    fi
+    accepted_report_response "$prior" true
+    return 0
+  fi
+  printf '%s' "$input" | jq -e '
+    .schemaVersion == "fm-engineering-report.v1"
+    and (.capturedAt | type == "string" and length > 0)
+  ' >/dev/null 2>&1 || {
+    report_error malformed_report "Report schema or capture time is invalid" "$input" "$request_digest" "$report_id"
+    return 2
+  }
+  case "$kind" in
+    scope_discovery|scope_revision|hill_judgment|blocker|evidence|verification_instructions|outcome) ;;
+    *) report_error unsupported_report_kind "Report kind is not accepted" "$input" "$request_digest" "$report_id"; return 2 ;;
+  esac
+  [ -f "$MISSIONS/$mission_id.json" ] || {
+    report_error mission_not_found "Report mission is not accepted" "$input" "$request_digest" "$report_id"
+    return 2
+  }
+  mission=$(jq -c . "$MISSIONS/$mission_id.json" 2>/dev/null) || {
+    report_error malformed_record "Mission record is unreadable" "$input" "$request_digest" "$report_id"
+    return 2
+  }
+  [ "$(printf '%s' "$mission" | jq -r '.taskId')" = "$task_id" ] \
+    && [ "$(printf '%s' "$mission" | jq -r '.crewmateId')" = "$crewmate" ] || {
+      report_error identity_drift "Report task or crewmate differs from the accepted mission" "$input" "$request_digest" "$report_id"
+      return 2
+    }
+  correlation=$(printf '%s' "$input" | jq -c '.correlation // null')
+  fm_eng_validate_correlation "$correlation" "$mission_id" "$task_id" "$crewmate" || {
+    report_error malformed_correlation "Report correlation is malformed or identity-drifted" "$input" "$request_digest" "$report_id"
+    return 2
+  }
+  printf '%s' "$correlation" | jq -e --argjson mission "$mission" '
+    .shapeUp.cycleRef == $mission.correlation.shapeUp.cycleRef
+    and .shapeUp.buildRef == $mission.correlation.shapeUp.buildRef
+    and .shapeUp.buildRevision == $mission.correlation.shapeUp.buildRevision
+  ' >/dev/null 2>&1 || {
+    report_error cross_build "Report correlation does not match the accepted Build" "$input" "$request_digest" "$report_id"
+    return 2
+  }
+  case "$kind" in
+    hill_judgment)
+      printf '%s' "$input" | jq -e '
+        (.hill.phase | IN("uphill","crest","downhill"))
+        and (.hill.judgment | type == "string" and length > 0)
+        and ((.hill.movement // "unchanged") | IN("forward","backward","unchanged"))
+        and (.hill | has("value") | not)
+        and (.hill | has("progress") | not)
+      ' >/dev/null 2>&1 || {
+        report_error invalid_hill "Hill reports must be qualitative judgments and may move backward" "$input" "$request_digest" "$report_id"
+        return 2
+      }
+      ;;
+    evidence)
+      validate_evidence "$input" "$mission"
+      validation=$?
+      case "$validation" in
+        0) ;;
+        4) report_error evidence_missing "Evidence file is missing" "$input" "$request_digest" "$report_id"; return 2 ;;
+        5) report_error evidence_outside_roots "Evidence file is outside approved roots" "$input" "$request_digest" "$report_id"; return 2 ;;
+        6) report_error evidence_too_large "Evidence exceeds the configured size bound" "$input" "$request_digest" "$report_id"; return 2 ;;
+        7) report_error evidence_scheme "Hosted evidence must use https" "$input" "$request_digest" "$report_id"; return 2 ;;
+        8) report_error evidence_confirmation "Hosted evidence requires explicit navigation confirmation" "$input" "$request_digest" "$report_id"; return 2 ;;
+        *) report_error invalid_evidence "Evidence contract, media type, or verification is invalid" "$input" "$request_digest" "$report_id"; return 2 ;;
+      esac
+      ;;
+    outcome)
+      printf '%s' "$input" | jq -e '.outcome.state | IN("completed","failed","cancelled")' >/dev/null 2>&1 || {
+        report_error invalid_outcome "Outcome state must be completed, failed, or cancelled" "$input" "$request_digest" "$report_id"
+        return 2
+      }
+      ;;
+  esac
+  if printf '%s' "$input" | jq -e '.condition? | type == "object"' >/dev/null 2>&1; then
+    printf '%s' "$input" | jq -e '
+      (.condition.conditionId | type == "string" and length > 0)
+      and (.condition.title | type == "string" and length > 0)
+      and (.condition.explanation | type == "string" and length > 0)
+      and (.condition.recommendation | type == "string" and length > 0)
+      and (.condition.choices | type == "array" and length > 0)
+      and (.condition.consequenceOfDelay | type == "string" and length > 0)
+      and (.condition.affectedObjects | type == "array")
+      and (.condition.evidence | type == "array")
+      and (.condition.boundRevisions | type == "object")
+    ' >/dev/null 2>&1 || {
+      report_error malformed_condition "Consequential reports require a complete Captain Call packet" "$input" "$request_digest" "$report_id"
+      return 2
+    }
+    condition_id=$(printf '%s' "$input" | jq -r '.condition.conditionId')
+    condition_title=$(printf '%s' "$input" | jq -r '.condition.title')
+    fm_eng_valid_identity "$condition_id" || {
+      report_error malformed_condition "conditionId must be a privacy-safe identity" "$input" "$request_digest" "$report_id"
+      return 2
+    }
+    condition_scan_result=$(condition_scan "$mission_id" "$condition_id") || {
+      fm_eng_fail "$SCHEMA" condition_history_unavailable \
+        "Stored condition history could not be read, so the Captain Call was not raised"
+      return 2
+    }
+    condition_previous=$(printf '%s' "$condition_scan_result" | jq -c '.latest')
+    if [ "$condition_previous" != null ]; then
+      condition_lifecycle=updated
+      condition_sequence=$(printf '%s' "$condition_previous" | jq -r '.condition.creationSequence')
+    else
+      condition_lifecycle=raised
+      condition_sequence=$(printf '%s' "$condition_scan_result" | jq -r '.nextSequence')
+    fi
+    condition_packet=$(printf '%s' "$input" | jq -cS \
+      --arg reportRevision "$request_digest" --arg missionRevision "$(printf '%s' "$mission" | jq -r '.sourceRevision')" '
+      {condition:.condition,correlation:.correlation,reportRevision:$reportRevision,missionRevision:$missionRevision}
+    ')
+    condition_revision=$(printf '%s' "$condition_packet" | fm_eng_digest)
+    hold_id="$mission_id-decision-$condition_id"
+    stored=$(printf '%s' "$input" | jq -c \
+      --arg sourceRevision "$request_digest" --arg acceptedAt "$NOW" \
+      --arg holdId "$hold_id" --arg packetRevision "$condition_revision" \
+      --arg lifecycle "$condition_lifecycle" --argjson creationSequence "$condition_sequence" '
+      . + {sourceRevision:$sourceRevision,requestDigest:$sourceRevision,status:"accepted",acceptedAt:$acceptedAt}
+      | .condition += {
+          holdId:$holdId,
+          packetRevision:$packetRevision,
+          lifecycle:$lifecycle,
+          creationSequence:$creationSequence
+        }
+    ')
+    if ! "$SCRIPT_DIR/fm-decision-hold.sh" hold "$mission_id" "$condition_id" \
+      --title "$condition_title" --reason "captain decision pending for $condition_id" >/dev/null; then
+      report_error captain_call_unavailable "Consequential report could not enter the durable Captain Call lifecycle" \
+        "$input" "$request_digest" "$report_id"
+      return 2
+    fi
+    fm_eng_atomic_write "$path" "$stored"
+    stored=$(project_condition_packet "$path" "$mission_id" "$condition_id" "$condition_lifecycle" "$stored")
+    accepted_report_response "$stored" false
+    return 0
+  fi
+  stored=$(printf '%s' "$input" | jq -c --arg sourceRevision "$request_digest" --arg acceptedAt "$NOW" '
+    . + {sourceRevision:$sourceRevision,requestDigest:$sourceRevision,status:"accepted",acceptedAt:$acceptedAt}
+  ')
+  fm_eng_atomic_write "$path" "$stored"
+  shapeup_submission=null
+  if [ -f "${FM_CONFIG_OVERRIDE:-$FM_HOME/config}/shapeup-client.json" ]; then
+    case "$kind" in
+      scope_discovery|scope_revision|hill_judgment)
+        shapeup_submission=$("$SCRIPT_DIR/fm-shapeup-client.sh" submit "$report_id") || true
+        printf '%s' "$shapeup_submission" | jq -e 'type == "object"' >/dev/null 2>&1 || {
+          shapeup_submission=$(jq -cn '{
+            accepted:false,
+            schemaVersion:"fm-shapeup-client.v1",
+            error:{
+              code:"shapeup_unavailable",
+              message:"The ShapeUp client produced no structured submission result"
+            }
+          }')
+        }
+        ;;
+    esac
+  fi
+  jq -cn --arg schemaVersion "$SCHEMA" --argjson report "$stored" \
+    --argjson shapeUpSubmission "$shapeup_submission" '
+    {accepted:true,schemaVersion:$schemaVersion,replayed:false,report:$report}
+    | if $shapeUpSubmission == null then . else .shapeUpSubmission=$shapeUpSubmission end
+  '
+}
+
+case "${1:-}" in
+  append)
+    [ "$#" -eq 2 ] || { usage >&2; exit 2; }
+    append_report "$2"
+    ;;
+  -h|--help)
+    usage
+    ;;
+  *)
+    usage >&2
+    exit 2
+    ;;
+esac

--- a/bin/fm-report.sh
+++ b/bin/fm-report.sh
@@ -67,6 +67,50 @@ evidence_root_allows() {  # <file> <mission-json>
   return 1
 }
 
+SEQUENCE_FILE="$ENGINEERING/reports.sequence"
+
+# Acceptance order is FirstMate's own, not the crewmate's. Wall-clock acceptance
+# time is only second-resolution and is pinnable, so a monotonic sequence
+# FirstMate assigns at acceptance decides which of two reports accepted in the
+# same second is the later one. The counter is advanced before the record lands,
+# so an interrupted append can only skip a number, never reuse one.
+acceptance_sequence_floor() {
+  local file max
+  local -a files=()
+  if [ -d "$REPORTS" ]; then
+    while IFS= read -r file; do
+      [ -n "$file" ] || continue
+      files[${#files[@]}]=$file
+    done < <(find "$REPORTS" -maxdepth 1 -type f -name '*.json' -print 2>/dev/null)
+  fi
+  if [ "${#files[@]}" -eq 0 ]; then
+    printf '0'
+    return 0
+  fi
+  max=$(printf '%s\0' "${files[@]}" | xargs -0 cat 2>/dev/null \
+    | jq -rn '[inputs | select(type == "object") | .acceptanceSequence? | numbers] | max // 0' 2>/dev/null) || max=''
+  case "$max" in
+    ''|*[!0-9]*) max=0 ;;
+  esac
+  [ "${#max}" -le 15 ] || max=0
+  printf '%s' "$max"
+}
+
+next_acceptance_sequence() {
+  local current='' next
+  if [ -f "$SEQUENCE_FILE" ]; then
+    IFS= read -r current < "$SEQUENCE_FILE" || true
+    current=${current%%[!0-9]*}
+  fi
+  case "$current" in
+    ''|*[!0-9]*) current=$(acceptance_sequence_floor) ;;
+  esac
+  [ "${#current}" -le 15 ] || current=$(acceptance_sequence_floor)
+  next=$((current + 1))
+  fm_eng_atomic_write "$SEQUENCE_FILE" "$next" || return 1
+  printf '%s' "$next"
+}
+
 CONDITION_SCAN_EMPTY='{"latest":null,"nextSequence":1}'
 
 condition_scan_filter() {  # <mission-id> <condition-id> <file>...
@@ -80,7 +124,7 @@ condition_scan_filter() {  # <mission-id> <condition-id> <file>...
         latest:([ $records[]
           | select(.status == "accepted" and .missionId == $missionId
             and .condition.conditionId == $conditionId) ]
-          | sort_by(.acceptedAt // "",.capturedAt // "",.reportId) | last // null),
+          | sort_by(.acceptedAt // "",.acceptanceSequence // 0,.reportId) | last // null),
         nextSequence:(([ $records[] | .condition.creationSequence? | numbers ] | max // 0) + 1),
         readCount:($read | length)
       }
@@ -182,7 +226,9 @@ project_condition_packet() {  # <report-path> <mission-id> <condition-id> <lifec
         }
       end')
   fi
-  [ "$updated" = "$report" ] || fm_eng_atomic_write "$path" "$updated"
+  if [ "$updated" != "$report" ]; then
+    fm_eng_atomic_write "$path" "$updated" || updated=$report
+  fi
   printf '%s' "$updated"
 }
 
@@ -221,7 +267,9 @@ heal_condition_projection() {  # <report-path> <report-json>
           message:"The Captain Call is no longer actively held, so its packet can no longer be projected"
         }
       }')
-    [ "$updated" = "$report" ] || fm_eng_atomic_write "$path" "$updated"
+    if [ "$updated" != "$report" ]; then
+      fm_eng_atomic_write "$path" "$updated" || updated=$report
+    fi
     printf '%s' "$updated"
     return 0
   fi
@@ -240,7 +288,7 @@ accepted_report_response() {  # <report-json> <replayed>
 
 append_report() {  # <path-or-dash>
   local input report_id kind mission_id task_id crewmate request_digest path prior prior_digest mission correlation validation stored
-  local shapeup_submission condition_scan_result
+  local shapeup_submission condition_scan_result acceptance_sequence
   local condition_id condition_title condition_packet condition_revision condition_previous condition_sequence condition_lifecycle hold_id
   input=$(fm_eng_read_json "$1") || {
     case $? in
@@ -394,12 +442,32 @@ append_report() {  # <path-or-dash>
       {condition:.condition,correlation:.correlation,reportRevision:$reportRevision,missionRevision:$missionRevision}
     ')
     condition_revision=$(printf '%s' "$condition_packet" | fm_eng_digest)
-    hold_id="$mission_id-decision-$condition_id"
+    # fm-decision-hold.sh owns the <origin>-decision-<key> identity and returns
+    # the identity it actually held, so the stored holdId can never name a hold
+    # this home does not have.
+    if ! hold_id=$("$SCRIPT_DIR/fm-decision-hold.sh" hold "$mission_id" "$condition_id" \
+      --title "$condition_title" --reason "captain decision pending for $condition_id") \
+      || ! fm_eng_valid_identity "$hold_id"; then
+      report_error captain_call_unavailable "Consequential report could not enter the durable Captain Call lifecycle" \
+        "$input" "$request_digest" "$report_id"
+      return 2
+    fi
+    acceptance_sequence=$(next_acceptance_sequence) || {
+      fm_eng_fail "$SCHEMA" record_not_durable "The report acceptance order could not be recorded durably"
+      return 2
+    }
     stored=$(printf '%s' "$input" | jq -c \
       --arg sourceRevision "$request_digest" --arg acceptedAt "$NOW" \
       --arg holdId "$hold_id" --arg packetRevision "$condition_revision" \
-      --arg lifecycle "$condition_lifecycle" --argjson creationSequence "$condition_sequence" '
-      . + {sourceRevision:$sourceRevision,requestDigest:$sourceRevision,status:"accepted",acceptedAt:$acceptedAt}
+      --arg lifecycle "$condition_lifecycle" --argjson creationSequence "$condition_sequence" \
+      --argjson acceptanceSequence "$acceptance_sequence" '
+      . + {
+        sourceRevision:$sourceRevision,
+        requestDigest:$sourceRevision,
+        status:"accepted",
+        acceptedAt:$acceptedAt,
+        acceptanceSequence:$acceptanceSequence
+      }
       | .condition += {
           holdId:$holdId,
           packetRevision:$packetRevision,
@@ -407,21 +475,32 @@ append_report() {  # <path-or-dash>
           creationSequence:$creationSequence
         }
     ')
-    if ! "$SCRIPT_DIR/fm-decision-hold.sh" hold "$mission_id" "$condition_id" \
-      --title "$condition_title" --reason "captain decision pending for $condition_id" >/dev/null; then
-      report_error captain_call_unavailable "Consequential report could not enter the durable Captain Call lifecycle" \
-        "$input" "$request_digest" "$report_id"
+    fm_eng_atomic_write "$path" "$stored" || {
+      fm_eng_fail "$SCHEMA" record_not_durable "The accepted report could not be stored durably"
       return 2
-    fi
-    fm_eng_atomic_write "$path" "$stored"
+    }
     stored=$(project_condition_packet "$path" "$mission_id" "$condition_id" "$condition_lifecycle" "$stored")
     accepted_report_response "$stored" false
     return 0
   fi
-  stored=$(printf '%s' "$input" | jq -c --arg sourceRevision "$request_digest" --arg acceptedAt "$NOW" '
-    . + {sourceRevision:$sourceRevision,requestDigest:$sourceRevision,status:"accepted",acceptedAt:$acceptedAt}
+  acceptance_sequence=$(next_acceptance_sequence) || {
+    fm_eng_fail "$SCHEMA" record_not_durable "The report acceptance order could not be recorded durably"
+    return 2
+  }
+  stored=$(printf '%s' "$input" | jq -c --arg sourceRevision "$request_digest" --arg acceptedAt "$NOW" \
+    --argjson acceptanceSequence "$acceptance_sequence" '
+    . + {
+      sourceRevision:$sourceRevision,
+      requestDigest:$sourceRevision,
+      status:"accepted",
+      acceptedAt:$acceptedAt,
+      acceptanceSequence:$acceptanceSequence
+    }
   ')
-  fm_eng_atomic_write "$path" "$stored"
+  fm_eng_atomic_write "$path" "$stored" || {
+    fm_eng_fail "$SCHEMA" record_not_durable "The accepted report could not be stored durably"
+    return 2
+  }
   shapeup_submission=null
   if [ -f "${FM_CONFIG_OVERRIDE:-$FM_HOME/config}/shapeup-client.json" ]; then
     case "$kind" in

--- a/bin/fm-report.sh
+++ b/bin/fm-report.sh
@@ -13,6 +13,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
 FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
 DATA="${FM_DATA_OVERRIDE:-$FM_HOME/data}"
+STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
 ENGINEERING="$DATA/engineering"
 MISSIONS="$ENGINEERING/missions"
 REPORTS="$ENGINEERING/reports"
@@ -68,14 +69,19 @@ evidence_root_allows() {  # <file> <mission-json>
 }
 
 SEQUENCE_FILE="$ENGINEERING/reports.sequence"
+SEQUENCE_LOCK="$STATE/fm-report-sequence-lock"
 
-# Acceptance order is FirstMate's own, not the crewmate's. Wall-clock acceptance
-# time is only second-resolution and is pinnable, so a monotonic sequence
-# FirstMate assigns at acceptance decides which of two reports accepted in the
-# same second is the later one. The counter is advanced before the record lands,
-# so an interrupted append can only skip a number, never reuse one.
+trap fm_eng_lock_release_all EXIT
+trap 'fm_eng_lock_release_all; exit 130' INT
+trap 'fm_eng_lock_release_all; exit 143' TERM
+trap 'fm_eng_lock_release_all; exit 129' HUP
+
+# Rebuilding the floor from stored records has to prove it read every expected
+# record: a report the store would not hand over could be the one holding the
+# highest sequence, and a floor below the true maximum reuses a number that two
+# records then share.
 acceptance_sequence_floor() {
-  local file max
+  local file scanned count max
   local -a files=()
   if [ -d "$REPORTS" ]; then
     while IFS= read -r file; do
@@ -87,27 +93,48 @@ acceptance_sequence_floor() {
     printf '0'
     return 0
   fi
-  max=$(printf '%s\0' "${files[@]}" | xargs -0 cat 2>/dev/null \
-    | jq -rn '[inputs | select(type == "object") | .acceptanceSequence? | numbers] | max // 0' 2>/dev/null) || max=''
+  for file in "${files[@]}"; do
+    [ -r "$file" ] || return 1
+  done
+  scanned=$(printf '%s\0' "${files[@]}" | xargs -0 cat 2>/dev/null \
+    | jq -rn '[inputs] as $read
+      | (($read | map(select(type == "object") | .acceptanceSequence? | numbers) | max) // 0) as $max
+      | "\($read | length) \($max)"' 2>/dev/null) || return 1
+  IFS=' ' read -r count max <<EOF
+$scanned
+EOF
+  [ "$count" = "${#files[@]}" ] || return 1
   case "$max" in
-    ''|*[!0-9]*) max=0 ;;
+    ''|*[!0-9]*) return 1 ;;
   esac
-  [ "${#max}" -le 15 ] || max=0
+  [ "${#max}" -le 15 ] || return 1
   printf '%s' "$max"
 }
 
+# Acceptance order is FirstMate's own, not the crewmate's. Wall-clock acceptance
+# time is only second-resolution and is pinnable, so a monotonic sequence
+# FirstMate assigns at acceptance decides which of two reports accepted in the
+# same second is the later one. Allocation runs under the same liveness-safe
+# mutex the Captain intent path uses, so two concurrent appends cannot read the
+# same counter and stamp the same number; the counter is advanced before the
+# record lands, so an interrupted append can only skip a number, never reuse one.
 next_acceptance_sequence() {
   local current='' next
+  fm_eng_lock_acquire_wait "$SEQUENCE_LOCK" "${FM_REPORT_SEQUENCE_LOCK_STALE_MINUTES:-}" "$NOW" \
+    "${FM_REPORT_SEQUENCE_LOCK_ATTEMPTS:-}" || return 1
   if [ -f "$SEQUENCE_FILE" ]; then
     IFS= read -r current < "$SEQUENCE_FILE" || true
     current=${current%%[!0-9]*}
   fi
   case "$current" in
-    ''|*[!0-9]*) current=$(acceptance_sequence_floor) ;;
+    ''|*[!0-9]*) current=$(acceptance_sequence_floor) || { fm_eng_lock_release "$SEQUENCE_LOCK"; return 1; } ;;
   esac
-  [ "${#current}" -le 15 ] || current=$(acceptance_sequence_floor)
+  if [ "${#current}" -gt 15 ]; then
+    current=$(acceptance_sequence_floor) || { fm_eng_lock_release "$SEQUENCE_LOCK"; return 1; }
+  fi
   next=$((current + 1))
-  fm_eng_atomic_write "$SEQUENCE_FILE" "$next" || return 1
+  fm_eng_atomic_write "$SEQUENCE_FILE" "$next" || { fm_eng_lock_release "$SEQUENCE_LOCK"; return 1; }
+  fm_eng_lock_release "$SEQUENCE_LOCK"
   printf '%s' "$next"
 }
 
@@ -206,12 +233,32 @@ validate_evidence() {  # <input> <mission>
 # Projection is a separate durable step from acceptance: an accepted report keeps
 # a typed projection state so an exact replay can retry and heal it. A retry that
 # fails again leaves the existing state untouched so replay stays free of writes.
+# The durable owner reports whether it actually wrote the packet or retained an
+# in-flight resolution record, and only the former is recorded as projected.
 project_condition_packet() {  # <report-path> <mission-id> <condition-id> <lifecycle> <report-json>
-  local path=$1 mission_id=$2 condition_id=$3 lifecycle=$4 report=$5 updated
-  if "$SCRIPT_DIR/fm-decision-hold.sh" project "$mission_id" "$condition_id" \
-    --packet-file "$path" --lifecycle "$lifecycle" >/dev/null; then
-    updated=$(printf '%s' "$report" | jq -c --arg at "$NOW" \
-      '.condition.projection={status:"projected",projectedAt:$at}')
+  local path=$1 mission_id=$2 condition_id=$3 lifecycle=$4 report=$5 updated outcome
+  if outcome=$("$SCRIPT_DIR/fm-decision-hold.sh" project "$mission_id" "$condition_id" \
+    --packet-file "$path" --lifecycle "$lifecycle"); then
+    case "$outcome" in
+      retained:*)
+        updated=$(printf '%s' "$report" | jq -c --arg at "$NOW" '
+          if (.condition.projection.status? // "") == "retained" then .
+          else
+            .condition.projection={
+              status:"retained",
+              attemptedAt:$at,
+              error:{
+                code:"captain_call_resolution_in_flight",
+                message:"The Captain Call carries an in-flight resolution record, so this packet revision was not projected"
+              }
+            }
+          end')
+        ;;
+      *)
+        updated=$(printf '%s' "$report" | jq -c --arg at "$NOW" \
+          '.condition.projection={status:"projected",projectedAt:$at}')
+        ;;
+    esac
   else
     updated=$(printf '%s' "$report" | jq -c --arg at "$NOW" '
       if (.condition.projection.status? // "") == "degraded" then .
@@ -327,9 +374,9 @@ append_report() {  # <path-or-dash>
         "$(printf '%s' "$prior" | jq -r '.error.message')" "$prior"
       return 2
     fi
-    if [ "$(printf '%s' "$prior" | jq -r '.condition.projection.status? // empty')" = degraded ]; then
-      prior=$(heal_condition_projection "$path" "$prior")
-    fi
+    case "$(printf '%s' "$prior" | jq -r '.condition.projection.status? // empty')" in
+      degraded|retained) prior=$(heal_condition_projection "$path" "$prior") ;;
+    esac
     accepted_report_response "$prior" true
     return 0
   fi

--- a/bin/fm-shapeup-client.sh
+++ b/bin/fm-shapeup-client.sh
@@ -42,8 +42,16 @@ client_fail() {  # <code> <message> [detail-code]
   '
 }
 
+# GNU stat reads -f as a filesystem report that takes no format operand, so a
+# BSD-first `stat -f || stat -c` fallback prints a filesystem block on stdout
+# before failing over and pollutes the mode with it. Select the platform syntax,
+# exactly as bin/fm-pr-lib.sh and bin/fm-fleet-snapshot.sh already do.
 file_mode() {  # <path>
-  stat -f '%Lp' "$1" 2>/dev/null || stat -c '%a' "$1" 2>/dev/null
+  if [ "$(uname)" = Darwin ]; then
+    stat -f '%Lp' "$1" 2>/dev/null
+  else
+    stat -c '%a' "$1" 2>/dev/null
+  fi
 }
 
 load_config() {

--- a/bin/fm-shapeup-client.sh
+++ b/bin/fm-shapeup-client.sh
@@ -1,0 +1,233 @@
+#!/usr/bin/env bash
+# fm-shapeup-client.sh - supervisor-owned ShapeUp Engineering client boundary.
+#
+# Usage:
+#   fm-shapeup-client.sh capabilities
+#   fm-shapeup-client.sh submit <report-id>
+#
+# Configuration is read from config/shapeup-client.json.
+# The first release supports one closed executable transport that receives a
+# JSON request on stdin with no arguments.
+# A workspace credential is read fresh from the configured owner-only file and
+# supplied only through SHAPEUP_WORKSPACE_TOKEN in the child environment.
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
+DATA="${FM_DATA_OVERRIDE:-$FM_HOME/data}"
+CONFIG="${FM_CONFIG_OVERRIDE:-$FM_HOME/config}"
+ENGINEERING="$DATA/engineering"
+REPORTS="$ENGINEERING/reports"
+OUTCOMES="$ENGINEERING/shapeup-outcomes"
+CONFIG_FILE="$CONFIG/shapeup-client.json"
+NOW="${FM_ENGINEERING_NOW:-$(date -u +%Y-%m-%dT%H:%M:%SZ)}"
+SCHEMA=fm-shapeup-client.v1
+
+# shellcheck source=bin/fm-engineering-lib.sh
+# shellcheck disable=SC1091
+. "$SCRIPT_DIR/fm-engineering-lib.sh"
+
+command -v jq >/dev/null 2>&1 || { echo "fm-shapeup-client: jq not found" >&2; exit 1; }
+
+usage() {
+  awk 'NR == 1 { next } /^#/ { sub(/^# ?/, ""); print; next } { exit }' "$0"
+}
+
+client_fail() {  # <code> <message> [detail-code]
+  local detail=${3:-}
+  jq -cn --arg schemaVersion "$SCHEMA" --arg code "$1" --arg message "$2" --arg detail "$detail" '
+    {accepted:false,schemaVersion:$schemaVersion,error:{code:$code,message:$message}}
+    | if $detail == "" then . else .error.detailCode=$detail end
+  '
+}
+
+file_mode() {  # <path>
+  stat -f '%Lp' "$1" 2>/dev/null || stat -c '%a' "$1" 2>/dev/null
+}
+
+load_config() {
+  [ -f "$CONFIG_FILE" ] || return 1
+  jq -ce '
+    select(
+      .schemaVersion == "fm-shapeup-client.v1"
+      and (.workspaceId | type == "string" and length > 0)
+      and .transport.kind == "executable"
+      and (.transport.path | type == "string" and startswith("/"))
+      and (.credentialFile | type == "string" and test("^[A-Za-z0-9._-]+$"))
+    )
+  ' "$CONFIG_FILE" 2>/dev/null
+}
+
+load_credential() {  # <config-json>
+  local config=$1 credential_file mode token
+  credential_file="$CONFIG/$(printf '%s' "$config" | jq -r '.credentialFile')"
+  [ -f "$credential_file" ] || return 1
+  mode=$(file_mode "$credential_file") || return 1
+  case "$mode" in 400|600) ;; *) return 2 ;; esac
+  IFS= read -r token < "$credential_file" || true
+  [ -n "$token" ] || return 1
+  printf '%s' "$token"
+}
+
+transport_call() {  # <config-json> <credential> <request-json>
+  local config=$1 credential=$2 request=$3 transport response value
+  transport=$(printf '%s' "$config" | jq -r '.transport.path')
+  [ -f "$transport" ] && [ -x "$transport" ] || return 3
+  response=$(printf '%s' "$request" | SHAPEUP_WORKSPACE_TOKEN="$credential" "$transport" 2>/dev/null) || return 4
+  value=$(printf '%s' "$response" | jq -ce 'select(type == "object")' 2>/dev/null) || return 5
+  [ -n "$value" ] || return 5
+  fm_eng_contains_credentials "$value" && return 6
+  printf '%s' "$value"
+}
+
+transport_fail() {  # <status> <unavailable-message>
+  case "$1" in
+    6) client_fail credential_material "The ShapeUp transport response carried credential material" ;;
+    *) client_fail shapeup_unavailable "$2" ;;
+  esac
+}
+
+report_capability() {  # <kind>
+  case "$1" in
+    scope_discovery|scope_revision) printf 'scope.write' ;;
+    hill_judgment) printf 'hill.write' ;;
+    *) printf 'report.observe' ;;
+  esac
+}
+
+capabilities() {
+  local config credential response request status detail
+  config=$(load_config) || { client_fail shapeup_unavailable "ShapeUp client configuration is unavailable"; return 2; }
+  credential=$(load_credential "$config")
+  case $? in
+    0) ;;
+    2) client_fail credential_permissions "ShapeUp credential file must be owner-only"; return 2 ;;
+    *) client_fail shapeup_unavailable "ShapeUp workspace credential is unavailable"; return 2 ;;
+  esac
+  request=$(jq -cn --arg workspaceId "$(printf '%s' "$config" | jq -r '.workspaceId')" \
+    '{contractVersion:"shapeup-engineering.v1",operation:"capabilities",workspaceId:$workspaceId}')
+  response=$(transport_call "$config" "$credential" "$request")
+  status=$?
+  [ "$status" -eq 0 ] || {
+    transport_fail "$status" "ShapeUp capability negotiation is unavailable"
+    return 2
+  }
+  printf '%s' "$response" | jq -e '.accepted == true and (.capabilities | type == "array")' >/dev/null 2>&1 || {
+    detail=$(printf '%s' "$response" | jq -r '.error.code // "incompatible"')
+    client_fail shapeup_unavailable "ShapeUp rejected capability negotiation" "$detail"
+    return 2
+  }
+  jq -cn --arg schemaVersion "$SCHEMA" --argjson capabilities "$response" \
+    '{accepted:true,schemaVersion:$schemaVersion,capabilities:$capabilities}'
+}
+
+submit() {  # <report-id>
+  local report_id=$1 report report_digest record prior prior_digest config credential capability caps request response outcome tmp detail status
+  fm_eng_valid_identity "$report_id" || { client_fail malformed_identity "Invalid reportId"; return 2; }
+  [ -f "$REPORTS/$report_id.json" ] || { client_fail report_not_found "Validated report is absent"; return 2; }
+  report=$(jq -c . "$REPORTS/$report_id.json" 2>/dev/null) || { client_fail malformed_record "Report record is unreadable"; return 2; }
+  [ "$(printf '%s' "$report" | jq -r '.status')" = accepted ] || {
+    client_fail report_rejected "Rejected reports cannot be submitted"
+    return 2
+  }
+  report_digest=$(printf '%s' "$report" | jq -r '.sourceRevision')
+  record="$OUTCOMES/$report_id.json"
+  if [ -f "$record" ]; then
+    prior=$(jq -c . "$record" 2>/dev/null) || { client_fail malformed_record "Prior ShapeUp outcome is unreadable"; return 2; }
+    prior_digest=$(printf '%s' "$prior" | jq -r '.requestDigest // empty')
+    [ "$prior_digest" = "$report_digest" ] || {
+      client_fail identity_conflict "Report revision changed after ShapeUp submission"
+      return 2
+    }
+    printf '%s' "$prior" | jq -c --arg schemaVersion "$SCHEMA" '
+      {accepted:true,schemaVersion:$schemaVersion,outcome:(.outcome + {replayed:true})}'
+    return 0
+  fi
+  config=$(load_config) || { client_fail shapeup_unavailable "ShapeUp client configuration is unavailable"; return 2; }
+  credential=$(load_credential "$config")
+  case $? in
+    0) ;;
+    2) client_fail credential_permissions "ShapeUp credential file must be owner-only"; return 2 ;;
+    *) client_fail shapeup_unavailable "ShapeUp workspace credential is unavailable"; return 2 ;;
+  esac
+  caps=$(transport_call "$config" "$credential" "$(jq -cn \
+    --arg workspaceId "$(printf '%s' "$config" | jq -r '.workspaceId')" \
+    '{contractVersion:"shapeup-engineering.v1",operation:"capabilities",workspaceId:$workspaceId}')")
+  status=$?
+  [ "$status" -eq 0 ] || {
+    transport_fail "$status" "ShapeUp capability negotiation is unavailable"
+    return 2
+  }
+  printf '%s' "$caps" | jq -e '.accepted == true and (.capabilities | type == "array")' >/dev/null 2>&1 || {
+    detail=$(printf '%s' "$caps" | jq -r '.error.code // "incompatible"')
+    client_fail shapeup_unavailable "ShapeUp rejected capability negotiation" "$detail"
+    return 2
+  }
+  capability=$(report_capability "$(printf '%s' "$report" | jq -r '.kind')")
+  printf '%s' "$caps" | jq -e --arg capability "$capability" '.capabilities | index($capability) != null' >/dev/null || {
+    client_fail capability_unavailable "ShapeUp does not advertise the capability required for this report" "$capability"
+    return 2
+  }
+  request=$(jq -cn \
+    --arg workspaceId "$(printf '%s' "$config" | jq -r '.workspaceId')" \
+    --arg idempotencyKey "fm-report:$report_id:$report_digest" \
+    --arg expectedBuildRevision "$(printf '%s' "$report" | jq -r '.correlation.shapeUp.buildRevision')" \
+    --argjson report "$report" '
+    {
+      contractVersion:"shapeup-engineering.v1",
+      operation:"submit",
+      workspaceId:$workspaceId,
+      idempotencyKey:$idempotencyKey,
+      guard:{
+        cycleRef:$report.correlation.shapeUp.cycleRef,
+        buildRef:$report.correlation.shapeUp.buildRef,
+        expectedBuildRevision:$expectedBuildRevision
+      },
+      intent:{
+        kind:$report.kind,
+        scopeRef:$report.correlation.shapeUp.scopeRef,
+        observation:($report | del(.requestDigest,.status,.acceptedAt))
+      }
+    }
+  ')
+  response=$(transport_call "$config" "$credential" "$request")
+  status=$?
+  [ "$status" -eq 0 ] || {
+    transport_fail "$status" "ShapeUp submission is unavailable"
+    return 2
+  }
+  printf '%s' "$response" | jq -e '.accepted == true and (.outcome | type == "object")' >/dev/null 2>&1 || {
+    detail=$(printf '%s' "$response" | jq -r '.error.code // "unknown"')
+    case "$detail" in stale_revision) code=shapeup_stale ;; proposal_required) code=proposal_required ;; *) code=shapeup_unavailable ;; esac
+    client_fail "$code" "ShapeUp did not accept the guarded report intent" "$detail"
+    return 2
+  }
+  outcome=$(printf '%s' "$response" | jq -c --arg reportId "$report_id" --arg reportRevision "$report_digest" --arg recordedAt "$NOW" '
+    .outcome + {reportId:$reportId,reportRevision:$reportRevision,recordedAt:$recordedAt,replayed:false}
+  ')
+  mkdir -p "$OUTCOMES"
+  tmp="$record.$$"
+  jq -cn --arg requestDigest "$report_digest" --argjson outcome "$outcome" \
+    '{requestDigest:$requestDigest,outcome:$outcome}' > "$tmp" && mv "$tmp" "$record"
+  jq -cn --arg schemaVersion "$SCHEMA" --argjson outcome "$outcome" \
+    '{accepted:true,schemaVersion:$schemaVersion,outcome:$outcome}'
+}
+
+case "${1:-}" in
+  capabilities)
+    [ "$#" -eq 1 ] || { usage >&2; exit 2; }
+    capabilities
+    ;;
+  submit)
+    [ "$#" -eq 2 ] || { usage >&2; exit 2; }
+    submit "$2"
+    ;;
+  -h|--help)
+    usage
+    ;;
+  *)
+    usage >&2
+    exit 2
+    ;;
+esac

--- a/bin/fm-shapeup-client.sh
+++ b/bin/fm-shapeup-client.sh
@@ -89,13 +89,16 @@ transport_call() {  # <config-json> <credential> <request-json>
   local -a runner=()
   transport=$(printf '%s' "$config" | jq -r '.transport.path')
   [ -f "$transport" ] && [ -x "$transport" ] || return 3
-  if command -v timeout >/dev/null 2>&1; then
+  if [ "${FM_SHAPEUP_FORCE_TIMEOUT_FALLBACK:-0}" != 1 ] && command -v timeout >/dev/null 2>&1; then
     runner=(timeout "$TRANSPORT_TIMEOUT")
-  elif command -v gtimeout >/dev/null 2>&1; then
+  elif [ "${FM_SHAPEUP_FORCE_TIMEOUT_FALLBACK:-0}" != 1 ] && command -v gtimeout >/dev/null 2>&1; then
     runner=(gtimeout "$TRANSPORT_TIMEOUT")
   elif command -v perl >/dev/null 2>&1; then
+    # A failed exec must not fall through into the parent's wait path, and a
+    # transport killed by a signal must not report the success status of the
+    # partial output it already wrote.
     # shellcheck disable=SC2016  # Perl source, not shell: its sigils are literal.
-    runner=(perl -e 'my $t = shift; my $pid = fork; die "fork failed" unless defined $pid; if (!$pid) { setpgrp(0, 0); exec @ARGV } local $SIG{ALRM} = sub { kill "TERM", -$pid; select undef, undef, undef, 0.2; kill "KILL", -$pid; exit 124 }; alarm $t; waitpid $pid, 0; exit($? >> 8)' "$TRANSPORT_TIMEOUT")
+    runner=(perl -e 'my $t = shift; my $pid = fork; die "fork failed" unless defined $pid; if (!$pid) { setpgrp(0, 0); exec @ARGV; exit 127 } local $SIG{ALRM} = sub { kill "TERM", -$pid; select undef, undef, undef, 0.2; kill "KILL", -$pid; exit 124 }; alarm $t; waitpid $pid, 0; exit(($? & 127) ? 126 : ($? >> 8))' "$TRANSPORT_TIMEOUT")
   else
     return 8
   fi

--- a/bin/fm-shapeup-client.sh
+++ b/bin/fm-shapeup-client.sh
@@ -70,11 +70,40 @@ load_credential() {  # <config-json>
   printf '%s' "$token"
 }
 
+# A non-positive bound is not a bound, so an unusable override falls back to the
+# default rather than disabling the deadline.
+TRANSPORT_TIMEOUT=${FM_SHAPEUP_TRANSPORT_TIMEOUT:-30}
+case "$TRANSPORT_TIMEOUT" in
+  ''|*[!0-9]*|0*) TRANSPORT_TIMEOUT=30 ;;
+esac
+
+# The transport is an operator-configured foreign process, so it runs under a
+# hard wall-clock bound: a wedged endpoint must become a typed unavailable
+# submission instead of holding the reporting crewmate open indefinitely. The
+# bound mirrors bin/fm-fleet-snapshot.sh's run_timed selection so a macOS host
+# without coreutils still gets one, and it is assembled as argv rather than
+# wrapped in a shell function so the credential assignment prefixes an external
+# command and can never outlive the transport call.
 transport_call() {  # <config-json> <credential> <request-json>
-  local config=$1 credential=$2 request=$3 transport response value
+  local config=$1 credential=$2 request=$3 transport response value status
+  local -a runner=()
   transport=$(printf '%s' "$config" | jq -r '.transport.path')
   [ -f "$transport" ] && [ -x "$transport" ] || return 3
-  response=$(printf '%s' "$request" | SHAPEUP_WORKSPACE_TOKEN="$credential" "$transport" 2>/dev/null) || return 4
+  if command -v timeout >/dev/null 2>&1; then
+    runner=(timeout "$TRANSPORT_TIMEOUT")
+  elif command -v gtimeout >/dev/null 2>&1; then
+    runner=(gtimeout "$TRANSPORT_TIMEOUT")
+  elif command -v perl >/dev/null 2>&1; then
+    # shellcheck disable=SC2016  # Perl source, not shell: its sigils are literal.
+    runner=(perl -e 'my $t = shift; my $pid = fork; die "fork failed" unless defined $pid; if (!$pid) { setpgrp(0, 0); exec @ARGV } local $SIG{ALRM} = sub { kill "TERM", -$pid; select undef, undef, undef, 0.2; kill "KILL", -$pid; exit 124 }; alarm $t; waitpid $pid, 0; exit($? >> 8)' "$TRANSPORT_TIMEOUT")
+  else
+    return 8
+  fi
+  response=$(printf '%s' "$request" \
+    | SHAPEUP_WORKSPACE_TOKEN="$credential" "${runner[@]}" "$transport" 2>/dev/null)
+  status=$?
+  [ "$status" -ne 124 ] || return 7
+  [ "$status" -eq 0 ] || return 4
   value=$(printf '%s' "$response" | jq -ce 'select(type == "object")' 2>/dev/null) || return 5
   [ -n "$value" ] || return 5
   fm_eng_contains_credentials "$value" && return 6
@@ -84,6 +113,8 @@ transport_call() {  # <config-json> <credential> <request-json>
 transport_fail() {  # <status> <unavailable-message>
   case "$1" in
     6) client_fail credential_material "The ShapeUp transport response carried credential material" ;;
+    7) client_fail shapeup_unavailable "$2" transport_timeout ;;
+    8) client_fail shapeup_unavailable "$2" transport_unbounded ;;
     *) client_fail shapeup_unavailable "$2" ;;
   esac
 }
@@ -123,7 +154,7 @@ capabilities() {
 }
 
 submit() {  # <report-id>
-  local report_id=$1 report report_digest record prior prior_digest config credential capability caps request response outcome tmp detail status
+  local report_id=$1 report report_digest record prior prior_digest config credential capability caps request response outcome detail status
   fm_eng_valid_identity "$report_id" || { client_fail malformed_identity "Invalid reportId"; return 2; }
   [ -f "$REPORTS/$report_id.json" ] || { client_fail report_not_found "Validated report is absent"; return 2; }
   report=$(jq -c . "$REPORTS/$report_id.json" 2>/dev/null) || { client_fail malformed_record "Report record is unreadable"; return 2; }
@@ -206,10 +237,11 @@ submit() {  # <report-id>
   outcome=$(printf '%s' "$response" | jq -c --arg reportId "$report_id" --arg reportRevision "$report_digest" --arg recordedAt "$NOW" '
     .outcome + {reportId:$reportId,reportRevision:$reportRevision,recordedAt:$recordedAt,replayed:false}
   ')
-  mkdir -p "$OUTCOMES"
-  tmp="$record.$$"
-  jq -cn --arg requestDigest "$report_digest" --argjson outcome "$outcome" \
-    '{requestDigest:$requestDigest,outcome:$outcome}' > "$tmp" && mv "$tmp" "$record"
+  fm_eng_atomic_write "$record" "$(jq -cn --arg requestDigest "$report_digest" --argjson outcome "$outcome" \
+    '{requestDigest:$requestDigest,outcome:$outcome}')" || {
+    client_fail outcome_not_durable "The authoritative ShapeUp outcome could not be journalled durably"
+    return 2
+  }
   jq -cn --arg schemaVersion "$SCHEMA" --argjson outcome "$outcome" \
     '{accepted:true,schemaVersion:$schemaVersion,outcome:$outcome}'
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -37,9 +37,10 @@ Only when no matching run exists does it consult semantic busy state; exact busy
 Decision-only events such as `resolved` never become current state or leak their prose into the current-state detail.
 In that status-log fallback, a declared external wait reports the distinct `paused` state with its reason.
 The semantic branch reports working only on an exact busy verdict and names the source that produced it; an unknown verdict never becomes working, never permits the status-log fallback, and never becomes a silent idle.
-For whole-fleet read-only review, `bin/fm-fleet-snapshot.sh --json` emits schema `fm-fleet-snapshot.v1` from the backlog, task metadata, current crew state, endpoint probes, PR/report pointers, scout reports, bounded current summaries from registered secondmate homes, and secondmate return-channel guidance.
+For whole-fleet read-only review, `bin/fm-fleet-snapshot.sh --json` emits schema `fm-fleet-snapshot.v1` from the backlog, task metadata, current crew state, endpoint probes, PR/report pointers, scout reports, bounded current summaries from registered secondmate homes, the embedded Captain's Log machine projection, and secondmate return-channel guidance.
 `bin/fm-fleet-view.sh` renders that snapshot as Markdown for humans, while `bin/fm-bearings-snapshot.sh` provides the bounded bearings projection, so both views consume one structured contract instead of reparsing raw fleet files.
 The script header owns the exact JSON schema.
+[captains-log-machine-projection.md](captains-log-machine-projection.md) owns the embedded projection's versioned interface, Engineering records, and Captain intents, which `bin/fm-captains-log-projection.sh` publishes independently of this snapshot.
 
 ### Registered secondmate current state
 

--- a/docs/captains-log-machine-projection.md
+++ b/docs/captains-log-machine-projection.md
@@ -150,6 +150,7 @@ Run the focused portable suites with the following commands.
 
 ```text
 bash tests/fm-captains-log-projection.test.sh
+bash tests/fm-engineering-lib.test.sh
 bash tests/fm-mission-shapeup.test.sh
 bash tests/fm-report.test.sh
 bash tests/fm-shapeup-client.test.sh

--- a/docs/captains-log-machine-projection.md
+++ b/docs/captains-log-machine-projection.md
@@ -1,0 +1,133 @@
+# Captain's Log machine projection
+
+`bin/fm-captains-log-projection.sh` publishes FirstMate execution truth through one versioned JSON interface without exposing private logs, command text, terminal control, or backend processes.
+
+The interface reads one JSON object of at most 256 KiB from standard input and writes one JSON result to standard output.
+
+The request schema is `fm-captains-log-projection.v1`.
+
+## Authority and correlation
+
+FirstMate remains authoritative for missions, reports, evidence verification, durable Captain Calls, Captain outcomes, and exact session correlation.
+
+ShapeUp remains authoritative for Cycle, Build, Scope, and Hill facts.
+
+The shared `shapeup-correlation.v1` envelope carries opaque Cycle, Build, optional Scope, mission, task, crewmate, command or event, and optional session identities.
+
+Those identities provide correlation only and do not transfer authority between systems.
+
+The canonical envelope and compatibility cases live in `tests/fixtures/captains-log/correlation-envelope-v1.json` and `tests/fixtures/captains-log/compatibility-matrix-v1.json`.
+
+## Operations
+
+The `capabilities` operation advertises the core contract, accepted intents, and independently negotiated ShapeUp and session-inspection capabilities.
+
+```json
+{"schemaVersion":"fm-captains-log-projection.v1","operation":"capabilities"}
+```
+
+The `snapshot` operation returns deterministic missions, accepted and rejected reports, evidence, independently addressable conditions, Build Review packets, Captain outcomes, authoritative ShapeUp outcomes, and malformed-record diagnostics.
+
+```json
+{"schemaVersion":"fm-captains-log-projection.v1","operation":"snapshot"}
+```
+
+Every snapshot carries a source revision and capture time.
+
+Malformed stored records remain visible in `invalidRecords` and never participate in conditions, Review readiness, or executable outcomes.
+
+## Captain intents
+
+The `intent` operation accepts `acknowledgeCondition`, `resolveCondition`, and `acceptBuildReview` only when the capability document advertises them.
+
+Every intent requires a privacy-safe `intentId` that provides durable idempotency.
+
+An exact replay returns the prior semantic outcome even when the live packet has since changed.
+
+Reusing an `intentId` with different content returns `identity_conflict`.
+
+Condition acknowledgement requires `missionId`, `conditionId`, and `packetRevision`, records an acknowledgement outcome, and never resolves the underlying hold.
+
+Condition resolution additionally requires a bounded `decision` and one or more `routedTo` task identities.
+
+Resolution marks the existing Captain Call as resolving, records and routes the decision through `fm-decision-hold.sh`, closes that same durable hold, and then projects the condition as resolved.
+
+Build Review acceptance requires `cycleRef`, `buildRef`, and the current ready `packetRevision`.
+
+Captain acceptance records `captainAccepted` and explicitly leaves delivery, ShapeUp Build closeout, and Cycle close false.
+
+Unknown conditions, unavailable Review packets, changed packet revisions, unsupported actions, and identity conflicts return distinct typed errors.
+
+## Reports, evidence, and Review
+
+`bin/fm-mission.sh accept` binds an Engineering mission to one Build revision and adds instructions to establish initial Scopes when possible and continue reporting until the mission is terminal.
+
+`bin/fm-report.sh append` accepts Scope discovery, Scope revision, qualitative Hill judgment, blocker, evidence, verification-instruction, and outcome records.
+
+Report identity reuse is idempotent only for identical content.
+
+Cross-Build, malformed, or identity-drifted reports are retained with `status: rejected` and are never submitted or used as execution truth.
+
+A consequential report stays accepted when its durable hold cannot receive the packet; the record keeps a typed degraded projection state that an exact replay retries and heals.
+
+A degraded packet whose Captain Call is no longer actively held becomes `abandoned` once, so replay stops retrying a projection that can never land.
+
+Every projected condition carries its `projection` state, so a held condition that never received its packet is visible to the Captain.
+
+A record store that cannot be read in full, or a Build Review set that cannot be computed, is a typed `projection_unavailable` result, and a condition history that cannot be read in full is a typed `condition_history_unavailable` result; neither is ever reported as a fresh but empty projection.
+
+Every scan proves it read each expected record, so a partially readable store is a typed failure rather than a silently truncated history.
+
+Hill judgments are qualitative and may move backward as learning changes the execution picture.
+
+Numeric progress fields are rejected because task count, elapsed time, evidence count, terminal output, and process activity cannot determine Hill position.
+
+Projected evidence retains its report revision, producer, verifier, mission, task, Build, optional Scope, contract, execution revision, proof reference, verification status, and human verification instructions.
+
+Evidence references are limited to canonical files under mission-approved roots or HTTPS URLs that require explicit navigation confirmation.
+
+Evidence media types and sizes are bounded, active content is rejected, credential material is rejected, and verification distinguishes missing, present, failed, stale, unavailable, not-applicable, and verified.
+
+One Build Review packet covers every active accepted mission of a Cycle and Build, and it records the distinct Build revisions those missions are bound to.
+
+The packet becomes ready only when each mission is terminal, every required evidence contract is verified, and every active mission is bound to the same Build revision.
+
+Conflicting bound Build revisions keep the packet not ready and return the typed `review_revision_conflict` error on acceptance.
+
+The authoritative latest report for terminal state and evidence verification is the one FirstMate accepted last, so a crewmate-supplied capture time cannot pin readiness to a stale record.
+
+Superseded missions retain history outside the active set, and deferred missions require a revision-bound Captain decision.
+
+Any mission-set, report, evidence, execution, or Build-revision change produces a new packet revision and invalidates pending acceptance.
+
+## Optional session inspection
+
+The `inspectSession` operation is optional and cannot block the core projection.
+
+It requires the exact mission, task, and expected mission revision and refuses missing, stale, ambiguous, or identity-drifted correlation.
+
+The result contains a closed descriptor and bounded redacted output from `fm-peek.sh --json`.
+
+Redaction runs on the capture's reconstructed logical lines, so a credential the pane wrapped across capture lines is redacted whole instead of releasing the fragment on either side of the wrap.
+Reconstruction fails closed rather than trusting a measured display width, covers a wrap that lands on the space between an introducer and its value, and reads a bounded number of rows above the requested window so a value wrapped across the window edge is redacted too.
+A row that merely fills the pane without wrapping keeps its own line, so unrelated events are never merged into one.
+
+The operation never attaches an input-capable terminal client and never returns command text, arbitrary arguments, or unrestricted environment values.
+
+Session content and process state are explicitly non-authoritative for Hill movement, evidence verification, condition resolution, and progress.
+
+Inspection reads the task's own recorded backend, so every supported backend reports its actual descriptor and failure state without guessing a target; [configuration.md](configuration.md#runtime-backend-configbackend--fm_backend) owns which backend a task is launched on.
+
+## Verification
+
+Run the focused portable suites with the following commands.
+
+```text
+bash tests/fm-captains-log-projection.test.sh
+bash tests/fm-mission-shapeup.test.sh
+bash tests/fm-report.test.sh
+bash tests/fm-shapeup-client.test.sh
+bash tests/fm-decision-hold.test.sh
+bash tests/fm-build-review.test.sh
+bash tests/fm-peek.test.sh
+```

--- a/docs/captains-log-machine-projection.md
+++ b/docs/captains-log-machine-projection.md
@@ -36,6 +36,8 @@ Every snapshot carries a source revision and capture time.
 
 Malformed stored records remain visible in `invalidRecords` and never participate in conditions, Review readiness, or executable outcomes.
 
+A record that parses but violates the shape this projection derives from it is isolated the same way, as `schema_invalid_record` naming the offending record, so one hand-edited record cannot blank unrelated projection operations or the fleet snapshot's embedded copy.
+
 ## Captain intents
 
 The `intent` operation accepts `acknowledgeCondition`, `resolveCondition`, and `acceptBuildReview` only when the capability document advertises them.
@@ -58,6 +60,8 @@ Captain acceptance records `captainAccepted` and explicitly leaves delivery, Sha
 
 Unknown conditions, unavailable Review packets, changed packet revisions, unsupported actions, and identity conflicts return distinct typed errors.
 
+An outcome the store could not accept returns the typed `outcome_not_durable` error, because an intent is only accepted once its durable outcome has landed.
+
 ## Reports, evidence, and Review
 
 `bin/fm-mission.sh accept` binds an Engineering mission to one Build revision and adds instructions to establish initial Scopes when possible and continue reporting until the mission is terminal.
@@ -78,6 +82,8 @@ A record store that cannot be read in full, or a Build Review set that cannot be
 
 Every scan proves it read each expected record, so a partially readable store is a typed failure rather than a silently truncated history.
 
+Every durable write is checked, so a mission, report, or outcome the store could not accept returns the typed `record_not_durable` or `outcome_not_durable` error instead of an accepted result the store does not hold.
+
 Hill judgments are qualitative and may move backward as learning changes the execution picture.
 
 Numeric progress fields are rejected because task count, elapsed time, evidence count, terminal output, and process activity cannot determine Hill position.
@@ -96,6 +102,8 @@ Conflicting bound Build revisions keep the packet not ready and return the typed
 
 The authoritative latest report for terminal state and evidence verification is the one FirstMate accepted last, so a crewmate-supplied capture time cannot pin readiness to a stale record.
 
+Acceptance order is a monotonic `acceptanceSequence` FirstMate assigns as it accepts each report, so two reports accepted inside the same wall-clock second are still ordered by FirstMate rather than by anything the crewmate supplied.
+
 Superseded missions retain history outside the active set, and deferred missions require a revision-bound Captain decision.
 
 Any mission-set, report, evidence, execution, or Build-revision change produces a new packet revision and invalidates pending acceptance.
@@ -110,6 +118,8 @@ The result contains a closed descriptor and bounded redacted output from `fm-pee
 
 Redaction runs on the capture's reconstructed logical lines, so a credential the pane wrapped across capture lines is redacted whole instead of releasing the fragment on either side of the wrap.
 Reconstruction fails closed rather than trusting a measured display width, covers a wrap that lands on the space between an introducer and its value, and reads a bounded number of rows above the requested window so a value wrapped across the window edge is redacted too.
+A separator is restored only for an introducer that is genuinely space-separated from its value; an assignment introducer such as `SERVICE_TOKEN=`, `X-Api-Key:`, or `ghp_` rejoins its wrapped value with nothing between the rows, so the value rules still consume the rejoined token whole.
+Redaction recognizes the credential-name vocabulary `bin/fm-engineering-lib.sh` owns for the whole subsystem - token, secret, password, passwd, credential, API key, access key, and private key, in any case - in both assignment and colon-separated form, plus bearer headers, GitHub token prefixes, and PEM private-key headers.
 A row that merely fills the pane without wrapping keeps its own line, so unrelated events are never merged into one.
 
 The operation never attaches an input-capable terminal client and never returns command text, arbitrary arguments, or unrestricted environment values.

--- a/docs/captains-log-machine-projection.md
+++ b/docs/captains-log-machine-projection.md
@@ -112,6 +112,7 @@ Acceptance order is a monotonic `acceptanceSequence` FirstMate assigns as it acc
 The sequence is allocated under the same liveness-safe mutex the Captain intent path uses, so concurrent appends into one home cannot be handed the same number, and a store that cannot be read in full is a typed `record_not_durable` refusal rather than an order that repeats.
 That mutex distinguishes contention from a store that can never hold a lock: contention is waited out against a wall-clock deadline, while an un-creatable lock directory is refused at once rather than after the whole wait, and the Captain intent path reports the two as `intent_busy` and `intent_lock_unavailable`.
 The deadline is the caller's whole budget, so the probe, reclaim, and process-spawn cost of retrying comes out of it rather than extending it, and an uncontended acquisition neither pauses nor probes.
+The requested interval is a grace period the caller is owed in full rather than a ceiling, so a wait carries the request plus at most one second of the whole-second clock it reads, and the default is five seconds.
 
 Superseded missions retain history outside the active set, and deferred missions require a revision-bound Captain decision.
 
@@ -133,8 +134,9 @@ The two separators carry different evidence, so they are matched differently: `=
 A colon label must be one the credential word ends - anything may be glued in front of it, so `apitoken` and `dbpassword` qualify, and only separator-delimited components may follow it, so the inert plural `tokens` does not - and it may be quoted or bracketed the way a pane echoing JSON or a config fragment writes it.
 Its operand must then give one of two independent signals: it closes the line, the way a credential header's value does, or it is long enough to be a secret wherever it sits.
 That redacts a short value such as `Password: hunt3` and a mid-line one such as `api_key: sk_live_… (rotated)`, while inert telemetry such as `Total tokens: 4821 in this run` gives neither signal and renders as the pane printed it, and a pane-wide inert label is never read as a dangling introducer that would stitch away the next row's event.
-Because stitching is speculative, every logical line is redacted twice - once joined and once as the rows the pane printed - and the rows are handed back with their own boundaries whenever redacting them separately produces exactly what redacting the joined line produced.
-A row that merely fills the pane without wrapping therefore keeps its own line even when the row beside it carries a credential of its own, so unrelated events are never merged into one; only a redaction that straddles a wrap keeps the joined line.
+Because stitching is speculative, the rules run over the rows the pane printed first, and the joined candidate is then built from those already-redacted rows and offered to the rules again.
+The joined candidate therefore carries every redaction the rows carry plus any that only a rejoined wrap reveals, so whichever candidate is published can never release a value the other had already masked.
+The rows are handed back with their own boundaries whenever they rejoin to exactly the joined candidate, so a row that merely fills the pane without wrapping keeps its own line even when the row beside it carries a credential of its own and unrelated events are never merged into one; only a redaction that a wrap hid from the per-row pass costs the boundary.
 
 The operation never attaches an input-capable terminal client and never returns command text, arbitrary arguments, or unrestricted environment values.
 

--- a/docs/captains-log-machine-projection.md
+++ b/docs/captains-log-machine-projection.md
@@ -110,6 +110,7 @@ The authoritative latest report for terminal state and evidence verification is 
 
 Acceptance order is a monotonic `acceptanceSequence` FirstMate assigns as it accepts each report, so two reports accepted inside the same wall-clock second are still ordered by FirstMate rather than by anything the crewmate supplied.
 The sequence is allocated under the same liveness-safe mutex the Captain intent path uses, so concurrent appends into one home cannot be handed the same number, and a store that cannot be read in full is a typed `record_not_durable` refusal rather than an order that repeats.
+That mutex distinguishes contention from a store that can never hold a lock: contention is waited out for a bound expressed in seconds, while an un-creatable lock directory is refused at once rather than after the whole wait, and the Captain intent path reports the two as `intent_busy` and `intent_lock_unavailable`.
 
 Superseded missions retain history outside the active set, and deferred missions require a revision-bound Captain decision.
 
@@ -127,8 +128,10 @@ Redaction runs on the capture's reconstructed logical lines, so a credential the
 Reconstruction fails closed rather than trusting a measured display width, covers a wrap that lands on the space between an introducer and its value, and reads a bounded number of rows above the requested window so a value wrapped across the window edge is redacted too.
 A separator is restored only for an introducer that is genuinely space-separated from its value; an assignment introducer such as `SERVICE_TOKEN=`, `X-Api-Key:`, or `ghp_` rejoins its wrapped value with nothing between the rows, so the value rules still consume the rejoined token whole.
 Redaction recognizes the credential-name vocabulary `bin/fm-engineering-lib.sh` owns for the whole subsystem - token, secret, password, passwd, credential, API key, access key, and private key, in any case - plus bearer headers, GitHub token prefixes, and PEM private-key headers.
-The two separators carry different evidence, so they are matched differently: `=` is an assignment and accepts any credential-named operand, while `:` is also ordinary prose punctuation and additionally requires a whole separator-delimited credential label and an operand long enough to be a secret.
-That keeps inert telemetry such as `Total tokens: 4821` rendered as the pane printed it, and keeps a pane-wide inert label from being read as a dangling introducer that would stitch away the next row's event.
+The two separators carry different evidence, so they are matched differently: `=` is an assignment and accepts any credential-named operand, while `:` is also ordinary prose punctuation and asks for more.
+A colon label must be one the credential word ends - anything may be glued in front of it, so `apitoken` and `dbpassword` qualify, and only separator-delimited components may follow it, so the inert plural `tokens` does not - and it may be quoted or bracketed the way a pane echoing JSON or a config fragment writes it.
+Its operand must then give one of two independent signals: it closes the line, the way a credential header's value does, or it is long enough to be a secret wherever it sits.
+That redacts a short value such as `Password: hunt3` and a mid-line one such as `api_key: sk_live_… (rotated)`, while inert telemetry such as `Total tokens: 4821 in this run` gives neither signal and renders as the pane printed it, and a pane-wide inert label is never read as a dangling introducer that would stitch away the next row's event.
 A row that merely fills the pane without wrapping keeps its own line, so unrelated events are never merged into one.
 
 The operation never attaches an input-capable terminal client and never returns command text, arbitrary arguments, or unrestricted environment values.

--- a/docs/captains-log-machine-projection.md
+++ b/docs/captains-log-machine-projection.md
@@ -38,6 +38,10 @@ Malformed stored records remain visible in `invalidRecords` and never participat
 
 A record that parses but violates the shape this projection derives from it is isolated the same way, as `schema_invalid_record` naming the offending record, so one hand-edited record cannot blank unrelated projection operations or the fleet snapshot's embedded copy.
 
+Isolation keeps the record visible and non-executable, and Build Review then fails closed rather than open: a packet lists the isolated mission and report records that bear on it as `isolatedRecords`, never reports ready while any remain, and refuses acceptance with the typed `review_records_isolated` error, because a shrunken mission set cannot prove it covers every active mission.
+An isolated record whose own correlation is unreadable could belong to any Build, so it withholds readiness across the Review set until the operator repairs it; every other operation stays available throughout.
+Isolation is reported ahead of a Build-revision conflict, because a conflict verdict derived from a mission set that is known to be incomplete is not yet trustworthy.
+
 ## Captain intents
 
 The `intent` operation accepts `acknowledgeCondition`, `resolveCondition`, and `acceptBuildReview` only when the capability document advertises them.
@@ -76,6 +80,8 @@ A consequential report stays accepted when its durable hold cannot receive the p
 
 A degraded packet whose Captain Call is no longer actively held becomes `abandoned` once, so replay stops retrying a projection that can never land.
 
+A packet the durable owner withheld because its Captain Call carries an in-flight resolution record is recorded as the typed `retained` state, never as projected, and an exact replay retries it exactly like a degraded one.
+
 Every projected condition carries its `projection` state, so a held condition that never received its packet is visible to the Captain.
 
 A record store that cannot be read in full, or a Build Review set that cannot be computed, is a typed `projection_unavailable` result, and a condition history that cannot be read in full is a typed `condition_history_unavailable` result; neither is ever reported as a fresh but empty projection.
@@ -103,6 +109,7 @@ Conflicting bound Build revisions keep the packet not ready and return the typed
 The authoritative latest report for terminal state and evidence verification is the one FirstMate accepted last, so a crewmate-supplied capture time cannot pin readiness to a stale record.
 
 Acceptance order is a monotonic `acceptanceSequence` FirstMate assigns as it accepts each report, so two reports accepted inside the same wall-clock second are still ordered by FirstMate rather than by anything the crewmate supplied.
+The sequence is allocated under the same liveness-safe mutex the Captain intent path uses, so concurrent appends into one home cannot be handed the same number, and a store that cannot be read in full is a typed `record_not_durable` refusal rather than an order that repeats.
 
 Superseded missions retain history outside the active set, and deferred missions require a revision-bound Captain decision.
 
@@ -119,7 +126,9 @@ The result contains a closed descriptor and bounded redacted output from `fm-pee
 Redaction runs on the capture's reconstructed logical lines, so a credential the pane wrapped across capture lines is redacted whole instead of releasing the fragment on either side of the wrap.
 Reconstruction fails closed rather than trusting a measured display width, covers a wrap that lands on the space between an introducer and its value, and reads a bounded number of rows above the requested window so a value wrapped across the window edge is redacted too.
 A separator is restored only for an introducer that is genuinely space-separated from its value; an assignment introducer such as `SERVICE_TOKEN=`, `X-Api-Key:`, or `ghp_` rejoins its wrapped value with nothing between the rows, so the value rules still consume the rejoined token whole.
-Redaction recognizes the credential-name vocabulary `bin/fm-engineering-lib.sh` owns for the whole subsystem - token, secret, password, passwd, credential, API key, access key, and private key, in any case - in both assignment and colon-separated form, plus bearer headers, GitHub token prefixes, and PEM private-key headers.
+Redaction recognizes the credential-name vocabulary `bin/fm-engineering-lib.sh` owns for the whole subsystem - token, secret, password, passwd, credential, API key, access key, and private key, in any case - plus bearer headers, GitHub token prefixes, and PEM private-key headers.
+The two separators carry different evidence, so they are matched differently: `=` is an assignment and accepts any credential-named operand, while `:` is also ordinary prose punctuation and additionally requires a whole separator-delimited credential label and an operand long enough to be a secret.
+That keeps inert telemetry such as `Total tokens: 4821` rendered as the pane printed it, and keeps a pane-wide inert label from being read as a dangling introducer that would stitch away the next row's event.
 A row that merely fills the pane without wrapping keeps its own line, so unrelated events are never merged into one.
 
 The operation never attaches an input-capable terminal client and never returns command text, arbitrary arguments, or unrestricted environment values.

--- a/docs/captains-log-machine-projection.md
+++ b/docs/captains-log-machine-projection.md
@@ -110,7 +110,8 @@ The authoritative latest report for terminal state and evidence verification is 
 
 Acceptance order is a monotonic `acceptanceSequence` FirstMate assigns as it accepts each report, so two reports accepted inside the same wall-clock second are still ordered by FirstMate rather than by anything the crewmate supplied.
 The sequence is allocated under the same liveness-safe mutex the Captain intent path uses, so concurrent appends into one home cannot be handed the same number, and a store that cannot be read in full is a typed `record_not_durable` refusal rather than an order that repeats.
-That mutex distinguishes contention from a store that can never hold a lock: contention is waited out for a bound expressed in seconds, while an un-creatable lock directory is refused at once rather than after the whole wait, and the Captain intent path reports the two as `intent_busy` and `intent_lock_unavailable`.
+That mutex distinguishes contention from a store that can never hold a lock: contention is waited out against a wall-clock deadline, while an un-creatable lock directory is refused at once rather than after the whole wait, and the Captain intent path reports the two as `intent_busy` and `intent_lock_unavailable`.
+The deadline is the caller's whole budget, so the probe, reclaim, and process-spawn cost of retrying comes out of it rather than extending it, and an uncontended acquisition neither pauses nor probes.
 
 Superseded missions retain history outside the active set, and deferred missions require a revision-bound Captain decision.
 
@@ -132,7 +133,8 @@ The two separators carry different evidence, so they are matched differently: `=
 A colon label must be one the credential word ends - anything may be glued in front of it, so `apitoken` and `dbpassword` qualify, and only separator-delimited components may follow it, so the inert plural `tokens` does not - and it may be quoted or bracketed the way a pane echoing JSON or a config fragment writes it.
 Its operand must then give one of two independent signals: it closes the line, the way a credential header's value does, or it is long enough to be a secret wherever it sits.
 That redacts a short value such as `Password: hunt3` and a mid-line one such as `api_key: sk_live_… (rotated)`, while inert telemetry such as `Total tokens: 4821 in this run` gives neither signal and renders as the pane printed it, and a pane-wide inert label is never read as a dangling introducer that would stitch away the next row's event.
-A row that merely fills the pane without wrapping keeps its own line, so unrelated events are never merged into one.
+Because stitching is speculative, every logical line is redacted twice - once joined and once as the rows the pane printed - and the rows are handed back with their own boundaries whenever redacting them separately produces exactly what redacting the joined line produced.
+A row that merely fills the pane without wrapping therefore keeps its own line even when the row beside it carries a credential of its own, so unrelated events are never merged into one; only a redaction that straddles a wrap keeps the joined line.
 
 The operation never attaches an input-capable terminal client and never returns command text, arbitrary arguments, or unrestricted environment values.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -10,7 +10,7 @@ The shared orchestrator behavior lives in [`AGENTS.md`](../AGENTS.md) - edit it 
 
 This section is the single owner of the top-level operational-home layout; producer script headers and their help own exact child-file fields and mutation contracts.
 The tracked code root contains the shared instruction, skill, documentation, workflow, and `bin/` surfaces, while each effective `FM_HOME` contains private operational directories.
-`data/` holds durable private fleet records such as the project and secondmate registries, captain preferences, optional shared captain preferences, learnings, backlog, briefs, and scout reports.
+`data/` holds durable private fleet records such as the project and secondmate registries, captain preferences, optional shared captain preferences, learnings, backlog, briefs, scout reports, and the Engineering mission, report, and outcome records under `data/engineering/` published by the [Captain's Log machine projection](captains-log-machine-projection.md).
 `state/` holds volatile runtime records such as task metadata, append-only status events, endpoint signals, watcher and wake-queue coordination, away-mode state, generated X-mode artifacts, private secondmate config-reread generations with their retry and quarantine state, and parent-owned secondmate pending-reply records under `state/pending-replies/` (`bin/fm-pending-reply-lib.sh`).
 `config/` holds local gitignored operating choices, and `projects/` holds the local project clones that Firstmate reads but changes only through the narrow guarded and concrete captain-approved exceptions in `AGENTS.md`.
 
@@ -150,6 +150,11 @@ The stable local estimate is `ceil(UTF-8 bytes / 3)` per file, a conservative po
 An inherited `data/captain-shared.md` counts in a secondmate's total but remains primary-owned and read-only there.
 The internal `/stow` skill curates only the editable local files in that case and reports the primary-owned shared file as a concrete exception if it alone exceeds the budget.
 The helper's header owns exact parsing, publication, and report output mechanics.
+
+## ShapeUp Engineering client (config/shapeup-client.json)
+
+The optional local, gitignored `config/shapeup-client.json` enables supervisor-owned ShapeUp submission for accepted Engineering reports; without it, reports stay durable in this home and nothing is submitted.
+[`shapeup-client.md`](shapeup-client.md) owns its schema, protected credential file, transport contract, and typed failure outcomes.
 
 ## Secondmate routes (data/secondmates.md)
 

--- a/docs/decision-hold-lifecycle.md
+++ b/docs/decision-hold-lifecycle.md
@@ -33,6 +33,7 @@ The `project` subcommand extends that same hold with a structured Captain Call p
 It requires an active hold and a packet file containing one condition, so projection cannot create a second attention store or completion owner.
 It keeps the human decision context first in the hold body and appends only the durable record identity and packet revision, never the private packet path.
 A hold that already carries a resolution record is mid-resolution, so `project` retains that record and reports `retained` instead of overwriting the retry identity an exact `resolve` retry needs to finish a partial routing operation.
+That `retained` line is the machine-readable outcome: `bin/fm-report.sh` records the withheld packet as a typed `retained` projection state rather than claiming the hold received a revision it never got.
 
 The `status --json` subcommand returns the condition identity, hold identity, packet revision, typed lifecycle, and durable held state without projecting its private packet path.
 The Captain's Log projection uses the existing `resolve` subcommand for supported `resolveCondition` intent and records resolved lifecycle only after the durable completion owner succeeds.
@@ -83,11 +84,12 @@ ok - resolve matches first/middle/last in quoted blocked_by and rejects a genuin
 $ bash tests/fm-decision-hold.test.sh
 ok - Captain Call packets update independently and resolve through one durable completion owner
 ok - projecting a packet never erases a hold's in-flight resolution record
+ok - a packet withheld by an in-flight resolution is typed retained, not projected
 
 $ bash tests/fm-report.test.sh
 ok - a Captain Call packet that cannot be projected stays accepted, typed, and heals on exact replay
 ok - packet healing terminates once its durable Captain Call is closed
-(7 ok cases total; the two packet-projection lines are quoted, the rest elided)
+(9 ok cases total; the two packet-projection lines are quoted, the rest elided)
 
 $ bash tests/fm-captains-log-projection.test.sh
 ok - projection journals exact replay and rejects changed identity reuse
@@ -97,6 +99,7 @@ ok - the intent mutex recovers from crashes without ever reclaiming a live owner
 $ bash tests/fm-build-review.test.sh
 ok - Build Review binds the active mission/evidence revision and acceptance is not closeout
 ok - one Build Review packet spans every active mission and refuses conflicting revisions
+ok - an isolated active mission or report record makes Build Review fail closed with a typed refusal
 ok - a schema-invalid stored record stays visible and non-executable without blanking the projection
 ok - Review readiness follows FirstMate acceptance order, not crewmate capture time
 

--- a/docs/decision-hold-lifecycle.md
+++ b/docs/decision-hold-lifecycle.md
@@ -32,6 +32,7 @@ A failed intermediate step leaves the hold open.
 The `project` subcommand extends that same hold with a structured Captain Call packet revision and a raised, updated, or resolving lifecycle.
 It requires an active hold and a packet file containing one condition, so projection cannot create a second attention store or completion owner.
 It keeps the human decision context first in the hold body and appends only the durable record identity and packet revision, never the private packet path.
+A hold that already carries a resolution record is mid-resolution, so `project` retains that record and reports `retained` instead of overwriting the retry identity an exact `resolve` retry needs to finish a partial routing operation.
 
 The `status --json` subcommand returns the condition identity, hold identity, packet revision, typed lifecycle, and durable held state without projecting its private packet path.
 The Captain's Log projection uses the existing `resolve` subcommand for supported `resolveCondition` intent and records resolved lifecycle only after the durable completion owner succeeds.
@@ -81,6 +82,7 @@ ok - resolve matches first/middle/last in quoted blocked_by and rejects a genuin
 
 $ bash tests/fm-decision-hold.test.sh
 ok - Captain Call packets update independently and resolve through one durable completion owner
+ok - projecting a packet never erases a hold's in-flight resolution record
 
 $ bash tests/fm-report.test.sh
 ok - a Captain Call packet that cannot be projected stays accepted, typed, and heals on exact replay
@@ -95,7 +97,8 @@ ok - the intent mutex recovers from crashes without ever reclaiming a live owner
 $ bash tests/fm-build-review.test.sh
 ok - Build Review binds the active mission/evidence revision and acceptance is not closeout
 ok - one Build Review packet spans every active mission and refuses conflicting revisions
-ok - a Build Review set that cannot be computed degrades to a typed unavailable projection
+ok - a schema-invalid stored record stays visible and non-executable without blanking the projection
+ok - Review readiness follows FirstMate acceptance order, not crewmate capture time
 
 $ bash tests/fm-fleet-snapshot-view.test.sh
 ok - backlog normalization preserves strict roles and resolves every blocker compatibly

--- a/docs/decision-hold-lifecycle.md
+++ b/docs/decision-hold-lifecycle.md
@@ -5,13 +5,14 @@ This document records the deterministic mechanism, structured surfaces, and priv
 
 ## Mechanism
 
-`bin/fm-decision-hold.sh` is the only lifecycle command for an investigation or visual review's unresolved captain decisions.
+`bin/fm-decision-hold.sh` is the only lifecycle command for an investigation or visual review's unresolved captain decisions and for the Captain Calls a consequential Engineering report raises.
 The command runs tasks-axi in the active `FM_HOME`, so the existing backlog remains the only durable work database and a secondmate-owned decision stays in the secondmate home.
 It never reads report bodies, review artifacts, terminal output, or chat.
 
 The `hold` subcommand maps an originating work id and stable decision key to `<origin-id>-decision-<decision-key>`.
 It creates a kind `captain` backlog item when absent and invokes `tasks-axi hold <id> --reason <reason> --kind captain` on every retry.
 It rejects an identity collision, a changed title, and attempts to reopen an already resolved identity.
+An accepted Engineering mission record is also a valid origin, so `bin/fm-report.sh` raises a consequential report's Captain Call through this same subcommand instead of a second attention store.
 
 The `complete` subcommand unions the reviewed keys into `decision_keys=` and appends `decisions_reviewed=1` while originating task metadata is live.
 A post-teardown visual review can complete against the surviving report and durable holds without recreating volatile task metadata.
@@ -28,6 +29,14 @@ It records the decision digest and routed task identities as a retry identity in
 An exact retry can finish a partial routing operation, while a changed decision or routed-task set is rejected.
 A failed intermediate step leaves the hold open.
 
+The `project` subcommand extends that same hold with a structured Captain Call packet revision and a raised, updated, or resolving lifecycle.
+It requires an active hold and a packet file containing one condition, so projection cannot create a second attention store or completion owner.
+It keeps the human decision context first in the hold body and appends only the durable record identity and packet revision, never the private packet path.
+
+The `status --json` subcommand returns the condition identity, hold identity, packet revision, typed lifecycle, and durable held state without projecting its private packet path.
+The Captain's Log projection uses the existing `resolve` subcommand for supported `resolveCondition` intent and records resolved lifecycle only after the durable completion owner succeeds.
+Acknowledgement remains a separate semantic outcome and never calls `resolve`.
+
 ## Structured read surfaces
 
 `bin/fm-fleet-snapshot.sh` parses canonical tasks-axi `(hold: ...)` and `(hold-kind: captain)` metadata alongside existing backlog fields.
@@ -40,16 +49,23 @@ The projection remains read-only and does not inspect historical prose.
 
 ## Verification record
 
-Verification date: 2026-07-14.
-Additional quoted `blocked_by` regression verification date: 2026-07-17.
-Plural blocker-readiness and mixed-home projection verification date: 2026-07-22.
+Verification date: 2026-08-02.
+Earlier focused regression dates remain part of this record: 2026-07-14 for the end-to-end lifecycle, 2026-07-17 for quoted multi-entry `blocked_by` matching, and 2026-07-22 for plural blocker readiness and mixed-home projection.
 
 The focused end-to-end regression uses only synthetic `sample` identities and decision text.
 It begins with a completed investigation and visual review whose genuine unresolved choice exists only in the report.
-The initial Bearings snapshot correctly has no open decision, and the new teardown gate refuses to erase the source.
+The initial Bearings snapshot correctly has no open decision, and the teardown gate refuses to erase the source.
 A later regression covers tasks-axi's quoted multi-entry `blocked_by` output so `resolve` matches the first, middle, and last ids and rejects a genuinely absent id.
 
-The final verification commands and their exact summarized outputs follow.
+`tests/fm-decision-hold.test.sh` covers the Captain Call packet subcommands end to end: `project` raises and then independently updates one condition over the same durable hold, `status --json` reports that lifecycle and held state without exposing the private packet path, acknowledgement leaves the hold open, and resolution closes it through the existing `resolve` owner.
+That suite skips itself when `jq` or tasks-axi is absent, so a recorded `ok` line is the only proof it actually ran.
+The projection and Build Review suites are recorded alongside it because the projection is the only caller that closes one of these holds, and because Captain acceptance of a Build Review must not create a second attention store.
+
+The commands below were re-run on this tree on 2026-08-02, and their real outcomes follow.
+Long suites are quoted only for their decision-relevant cases; every elision states the suite's true case count.
+This evidence is scoped to exactly these commands.
+Repository-wide shell lint is owned by `bin/fm-lint.sh` and is recorded below as an exact command.
+The complete local suite is environment-sensitive on a developer machine, so it is not claimed green by this record.
 
 ```text
 $ bash tests/fm-decision-hold-lifecycle.test.sh
@@ -63,29 +79,51 @@ ok - terminal single-owner stale status decisions do not block empty inventory
 ok - main-home and secondmate-home captain holds remain correctly routed
 ok - resolve matches first/middle/last in quoted blocked_by and rejects a genuinely absent id
 
+$ bash tests/fm-decision-hold.test.sh
+ok - Captain Call packets update independently and resolve through one durable completion owner
+
+$ bash tests/fm-report.test.sh
+ok - a Captain Call packet that cannot be projected stays accepted, typed, and heals on exact replay
+ok - packet healing terminates once its durable Captain Call is closed
+(7 ok cases total; the two packet-projection lines are quoted, the rest elided)
+
+$ bash tests/fm-captains-log-projection.test.sh
+ok - projection journals exact replay and rejects changed identity reuse
+ok - the intent mutex recovers from crashes without ever reclaiming a live owner
+(6 ok cases total; the two intent-durability lines are quoted, the rest elided)
+
+$ bash tests/fm-build-review.test.sh
+ok - Build Review binds the active mission/evidence revision and acceptance is not closeout
+ok - one Build Review packet spans every active mission and refuses conflicting revisions
+ok - a Build Review set that cannot be computed degrades to a typed unavailable projection
+
 $ bash tests/fm-fleet-snapshot-view.test.sh
 ok - backlog normalization preserves strict roles and resolves every blocker compatibly
 ok - durable captain-held transfer closes the duplicate live status decision
 ok - snapshot parses tasks-axi rows and respects operational overrides
+(15 ok cases total; the three decision-relevant lines are quoted, the rest elided)
 
 $ bash tests/fm-bearings-snapshot.test.sh
 ok - a completed scout with decision-like report prose is a pointer, not pending
 ok - action-free items (working/done/queued/landed) do not leak into Captain's Call
 ok - mixed secondmate roles, partial state, and captain readiness project independently
 ok - main and secondmate captain actionability use the same blocker readiness
+(41 ok cases total; the four decision-relevant lines are quoted, the rest elided)
 
 $ bash tests/fm-brief.test.sh
 ok - fm-brief.sh: investigation and visual-review completions load the shared decision policy
+(17 ok cases total; the decision-policy line is quoted, the rest elided)
 
 $ bash tests/fm-teardown.test.sh
-all teardown safety cases passed
+ok - herdr flat teardown never erases records when pane presence is unparseable
+not ok - herdr-preflight-missing-adapter: the retryable pre-return refusal was not explained visibly
+(12 ok cases precede the failure, which aborts the suite)
 
-$ bin/fm-lint.sh
+$ bash bin/fm-lint.sh
 fm-lint.sh: ShellCheck 0.11.0 (pinned 0.11.0)
-
-$ git diff --check
-(no output)
-
-$ for test_script in tests/*.test.sh; do bash "$test_script"; done
-ALL 71 TEST SCRIPTS PASSED
+(exit 0; no diagnostics)
 ```
+
+The teardown suite is the one command above that does not pass on this tree.
+Its failing case removes the Herdr adapter from a copied `bin/` tree and expects a retryable refusal, but under the recording machine's bash 3.2 the failed `.` of that deleted adapter in `bin/fm-backend.sh` ends the `set -e` shell before the refusal is printed.
+Neither that case nor any file it exercises belongs to this mechanism, and the decision-hold teardown gate itself is proven above by `tests/fm-decision-hold-lifecycle.test.sh`.

--- a/docs/documentation-audiences.json
+++ b/docs/documentation-audiences.json
@@ -213,6 +213,10 @@
       "audience": "operator-current"
     },
     {
+      "path": "docs/captains-log-machine-projection.md",
+      "audience": "maintainer-architecture"
+    },
+    {
       "path": "docs/cd-guard.md",
       "audience": "maintainer-architecture"
     },
@@ -274,6 +278,10 @@
     },
     {
       "path": "docs/sessionstart-nudge.md",
+      "audience": "operator-current"
+    },
+    {
+      "path": "docs/shapeup-client.md",
       "audience": "operator-current"
     },
     {

--- a/docs/fm-test-portable-shards.md
+++ b/docs/fm-test-portable-shards.md
@@ -66,15 +66,15 @@ Each shard is still strictly serial in itself, and separate runners mean no two 
 Assignment is longest-processing-time bin packing over per-script duration hints embedded in `bin/fm-test-run.sh`.
 The hints came from that run's `fm-test-timing-portable-serial` artifact on 2026-08-02, where the lane ran 69 scripts in 1143762 ms of serial work.
 A script with no hint gets the conservative `PORTABLE_SERIAL_DEFAULT_WEIGHT_MS` default.
-The lane holds 80 scripts today, so the eleven added since that artifact are estimated at that default until the next refresh.
+The lane holds 84 scripts today, so the fifteen added since that artifact are estimated at that default until the next refresh.
 Hints only affect balance: the coverage guard keeps the partition complete and disjoint whatever they say, so a stale hint costs a slower shard rather than lost coverage.
 
 | Lane | Script count | Estimated duration |
 |---|---:|---:|
-| `portable-serial-1of4` | 19 | 340930 ms (~340.9 s) |
-| `portable-serial-2of4` | 20 | 340946 ms (~340.9 s) |
-| `portable-serial-3of4` | 18 | 340940 ms (~340.9 s) |
-| `portable-serial-4of4` | 23 | 340946 ms (~340.9 s) |
+| `portable-serial-1of4` | 20 | 360930 ms (~360.9 s) |
+| `portable-serial-2of4` | 21 | 360946 ms (~360.9 s) |
+| `portable-serial-3of4` | 19 | 360940 ms (~360.9 s) |
+| `portable-serial-4of4` | 24 | 360946 ms (~360.9 s) |
 | imbalance | | 16 ms |
 
 The single longest script, `tests/fm-pr-check-security.test.sh` at 199573 ms, is the floor for any shard count.

--- a/docs/fm-test-portable-shards.md
+++ b/docs/fm-test-portable-shards.md
@@ -66,14 +66,15 @@ Each shard is still strictly serial in itself, and separate runners mean no two 
 Assignment is longest-processing-time bin packing over per-script duration hints embedded in `bin/fm-test-run.sh`.
 The hints came from that run's `fm-test-timing-portable-serial` artifact on 2026-08-02, where the lane ran 69 scripts in 1143762 ms of serial work.
 A script with no hint gets the conservative `PORTABLE_SERIAL_DEFAULT_WEIGHT_MS` default.
+The lane holds 80 scripts today, so the eleven added since that artifact are estimated at that default until the next refresh.
 Hints only affect balance: the coverage guard keeps the partition complete and disjoint whatever they say, so a stale hint costs a slower shard rather than lost coverage.
 
 | Lane | Script count | Estimated duration |
 |---|---:|---:|
-| `portable-serial-1of4` | 15 | 285945 ms (~285.9 s) |
-| `portable-serial-2of4` | 18 | 285944 ms (~285.9 s) |
-| `portable-serial-3of4` | 17 | 285929 ms (~285.9 s) |
-| `portable-serial-4of4` | 19 | 285944 ms (~285.9 s) |
+| `portable-serial-1of4` | 19 | 340930 ms (~340.9 s) |
+| `portable-serial-2of4` | 20 | 340946 ms (~340.9 s) |
+| `portable-serial-3of4` | 18 | 340940 ms (~340.9 s) |
+| `portable-serial-4of4` | 23 | 340946 ms (~340.9 s) |
 | imbalance | | 16 ms |
 
 The single longest script, `tests/fm-pr-check-security.test.sh` at 199573 ms, is the floor for any shard count.

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -42,6 +42,8 @@ A secondmate launched by the primary receives a narrowly scoped home override du
 Attach to the selected named Herdr session and switch to the relevant home workspace to watch its task tabs.
 Routine supervision uses `bin/fm-peek.sh <id>` and `FM_HOME=<home> bin/fm-send.sh <id> '<text>'` without attaching.
 
+`bin/fm-peek.sh --json <id> [lines]` adds a backend-neutral, read-only, non-authoritative capture whose contract is owned by [captains-log-machine-projection.md](captains-log-machine-projection.md) "Optional session inspection"; the script header owns its exact flags and bounds.
+
 Workspace and tab creation use `--no-focus`.
 The first workspace in a completely empty Herdr session must become focused because no prior target exists, but later task creation does not intentionally steal focus.
 

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -13,13 +13,18 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-bootstrap.sh`        | Detect toolchain and fleet problems, run the locked session-start sweeps, and install approved tools |
 | `fm-fleet-sync.sh`       | Refresh project clones with safe fast-forwards, self-heals, `STUCK:` reports, branch pruning, and bounded recovery from an orphaned `.git/packed-refs.lock` |
 | `fm-fleet-snapshot.sh`   | Print the read-only structured fleet snapshot JSON (schema `fm-fleet-snapshot.v1`)   |
+| `fm-captains-log-projection.sh` | Publish the versioned bounded Captain's Log machine projection and accepted intents |
 | `fm-fleet-view.sh`       | Render the fleet snapshot as a human Markdown view                                   |
 | `fm-bearings-snapshot.sh` | Project the fleet snapshot to the compact TOON bearings view; local-only unless `--include-prs` |
 | `fm-update.sh`           | Fast-forward-only self-update of firstmate and local or remote secondmate homes       |
 | `fm-on.sh`               | Execute one tracked Firstmate command in a configured remote secondmate home          |
 | `fm-backlog-handoff.sh`  | Validate and delegate queued backlog-item moves into a secondmate home               |
 | `fm-backlog-receive.sh`  | Idempotently ingest one confined remote handoff outbox through tasks-axi             |
-| `fm-decision-hold.sh`    | Create, verify, complete, and resolve durable captain-held decisions                 |
+| `fm-decision-hold.sh`    | Create, project, verify, complete, and resolve durable captain-held decisions        |
+| `fm-mission.sh`          | Accept and manage revision-bound Engineering missions                               |
+| `fm-report.sh`           | Validate and append continuous Engineering observations and evidence                 |
+| `fm-shapeup-client.sh`   | Submit guarded Engineering intent through the supervisor-owned ShapeUp boundary      |
+| `fm-engineering-lib.sh`  | Shared Engineering record validation, correlation-envelope checks, and atomic storage helpers |
 | `fm-brief.sh`            | Scaffold ship (explicit `--mode`), scout, secondmate-charter, and Herdr-lab briefs   |
 | `fm-herdr-lab.sh`        | Provision and guardedly operate an isolated, never-default Herdr lab session         |
 | `fm-install-herdr.sh`    | Install CI's exact-version Herdr pin with official asset URL, SHA-256, and protocol checks |
@@ -83,7 +88,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-busy-lib.sh`         | Single owner of the semantic busy-state contract: verdicts, source attribution, and per-harness sources |
 | `fm-busy-event.sh`       | The only writer of a task's semantic busy-state record; arms an incarnation and applies lifecycle events |
 | `fm-tmux-lib.sh`         | Shared tmux pane primitives for composer capture, verified submit, and the submit-time busy check |
-| `fm-peek.sh`             | Print a bounded tail of a crewmate endpoint                                          |
+| `fm-peek.sh`             | Print a bounded tail or closed read-only JSON capture of a correlated endpoint       |
 | `fm-check-register.sh`   | Bind an intentional custom watcher check to its current bytes                       |
 | `fm-check-lib.sh`        | Validate custom-check registrations and prepare private execution snapshots          |
 | `fm-pr-lib.sh`           | Own canonical task and PR validation plus private atomic PR-poll publication and identity-bound retirement |

--- a/docs/shapeup-client.md
+++ b/docs/shapeup-client.md
@@ -1,0 +1,75 @@
+# ShapeUp Engineering client
+
+`bin/fm-shapeup-client.sh` is the supervisor-owned boundary for guarded Engineering intent submitted to ShapeUp.
+
+Crewmates, mission records, report records, evidence, and session processes never receive the workspace credential.
+
+## Configuration
+
+The client reads `config/shapeup-client.json` from the active FirstMate home.
+
+```json
+{
+  "schemaVersion": "fm-shapeup-client.v1",
+  "workspaceId": "workspace-1",
+  "transport": {
+    "kind": "executable",
+    "path": "/absolute/path/to/shapeup-transport"
+  },
+  "credentialFile": "shapeup-token"
+}
+```
+
+The transport path must be absolute and executable.
+
+The credential filename must be a simple filename under the active home's `config` directory.
+
+The credential file must have mode `0400` or `0600` and should be provisioned by platform-protected secret storage.
+
+The client reads the credential fresh for every operation, so replacing or removing the file rotates or revokes access without changing mission data.
+
+## Transport contract
+
+The transport receives one `shapeup-engineering.v1` JSON request on standard input and receives no command-line arguments.
+
+The workspace credential is present only as `SHAPEUP_WORKSPACE_TOKEN` in the transport environment.
+
+Capability negotiation sends `operation: capabilities` and requires an accepted response containing a capability array.
+
+Submission sends `operation: submit`, a durable idempotency key, opaque Cycle and Build correlation, the expected Build revision guard, optional Scope correlation, and the validated observation.
+
+The first release maps Scope discovery and Scope revision to `scope.write` and qualitative Hill judgment to `hill.write`.
+
+When the configuration exists, accepted ordinary Scope and Hill reports invoke this boundary automatically after FirstMate durably stores the report.
+
+A missing, revoked, incompatible, or partially capable ShapeUp endpoint leaves the FirstMate report accepted and returns only the affected submission as typed unavailable.
+
+Consequential reports enter the durable Captain Call lifecycle and are not submitted as ordinary ShapeUp updates.
+
+## Idempotency and failures
+
+The durable request identity is `fm-report:<report-id>:<report-revision>`.
+
+An exact retry returns the stored semantic outcome with `replayed: true`.
+
+Successful authoritative outcomes are retained in `data/engineering/shapeup-outcomes` and published as `shapeUpOutcomes` by the Captain's Log snapshot.
+
+Reusing a report identity after its accepted revision changes returns `identity_conflict`.
+
+Capability absence returns `capability_unavailable`, a changed ShapeUp guard returns `shapeup_stale`, and an action requiring a proposal returns `proposal_required`.
+
+Transport, credential, negotiation, and unknown remote failures return `shapeup_unavailable` without exposing the credential or deleting the source report.
+
+The client suppresses transport standard error and never includes the credential in requests, arguments, stored reports, outcomes, or diagnostics.
+
+Every transport response is scanned for credential material before it is trusted, and a response carrying any returns `credential_material` instead of being persisted or published.
+
+The scan matches credential-named string values and known secret patterns, so benign non-string fields such as `credentialRotationRequired: false` do not fail a submission.
+
+## Commands
+
+Use `bin/fm-shapeup-client.sh capabilities` to negotiate the current workspace capability document.
+
+Use `bin/fm-shapeup-client.sh submit <report-id>` to submit one already accepted report.
+
+Run `bash tests/fm-shapeup-client.test.sh` for the fixture transport, replay, revocation, and secret-boundary checks.

--- a/docs/shapeup-client.md
+++ b/docs/shapeup-client.md
@@ -46,6 +46,7 @@ A missing, revoked, incompatible, or partially capable ShapeUp endpoint leaves t
 
 Every transport invocation runs under a hard wall-clock bound, so a wedged endpoint expires into the same typed unavailable submission instead of holding the reporting crewmate open.
 The bound defaults to 30 seconds and is overridden by `FM_SHAPEUP_TRANSPORT_TIMEOUT`; an unusable override falls back to the default rather than disabling the bound, and a host with no way to bound a child process refuses the call instead of running it unbounded.
+A transport that cannot be executed at all, and one killed by a signal after writing partial output, both return typed unavailable rather than a success the journal would keep: the bound reports the child's own failure instead of the status of the bytes it managed to emit.
 
 Consequential reports enter the durable Captain Call lifecycle and are not submitted as ordinary ShapeUp updates.
 

--- a/docs/shapeup-client.md
+++ b/docs/shapeup-client.md
@@ -44,6 +44,9 @@ When the configuration exists, accepted ordinary Scope and Hill reports invoke t
 
 A missing, revoked, incompatible, or partially capable ShapeUp endpoint leaves the FirstMate report accepted and returns only the affected submission as typed unavailable.
 
+Every transport invocation runs under a hard wall-clock bound, so a wedged endpoint expires into the same typed unavailable submission instead of holding the reporting crewmate open.
+The bound defaults to 30 seconds and is overridden by `FM_SHAPEUP_TRANSPORT_TIMEOUT`; an unusable override falls back to the default rather than disabling the bound, and a host with no way to bound a child process refuses the call instead of running it unbounded.
+
 Consequential reports enter the durable Captain Call lifecycle and are not submitted as ordinary ShapeUp updates.
 
 ## Idempotency and failures
@@ -58,7 +61,9 @@ Reusing a report identity after its accepted revision changes returns `identity_
 
 Capability absence returns `capability_unavailable`, a changed ShapeUp guard returns `shapeup_stale`, and an action requiring a proposal returns `proposal_required`.
 
-Transport, credential, negotiation, and unknown remote failures return `shapeup_unavailable` without exposing the credential or deleting the source report.
+Transport, credential, negotiation, expiry, and unknown remote failures return `shapeup_unavailable` without exposing the credential or deleting the source report, and expiry carries the `transport_timeout` detail code.
+
+An authoritative outcome the store could not accept returns the typed `outcome_not_durable` error rather than a success the journal cannot replay.
 
 The client suppresses transport standard error and never includes the credential in requests, arguments, stored reports, outcomes, or diagnostics.
 

--- a/tests/fixtures/captains-log/compatibility-matrix-v1.json
+++ b/tests/fixtures/captains-log/compatibility-matrix-v1.json
@@ -1,0 +1,11 @@
+{
+  "schemaVersion": "fm-captains-log-compatibility.v1",
+  "projectionVersion": "fm-captains-log-projection.v1",
+  "correlationVersion": "shapeup-correlation.v1",
+  "cases": [
+    { "name": "complete", "core": "available", "shapeUp": "available", "sessionInspection": "available" },
+    { "name": "core-only", "core": "available", "shapeUp": "unavailable", "sessionInspection": "unavailable" },
+    { "name": "shapeup-partial", "core": "available", "shapeUp": "partial", "sessionInspection": "unavailable" },
+    { "name": "unsupported", "core": "unavailable", "shapeUp": "unavailable", "sessionInspection": "unavailable" }
+  ]
+}

--- a/tests/fixtures/captains-log/correlation-envelope-v1.json
+++ b/tests/fixtures/captains-log/correlation-envelope-v1.json
@@ -1,0 +1,24 @@
+{
+  "schemaVersion": "shapeup-correlation.v1",
+  "sourceRevision": "fm:mission-42:r7",
+  "capturedAt": "2026-08-01T12:00:00Z",
+  "identity": {
+    "kind": "event",
+    "id": "event-42"
+  },
+  "shapeUp": {
+    "cycleRef": "cycle-13",
+    "buildRef": "build-8",
+    "scopeRef": "scope-context"
+  },
+  "firstMate": {
+    "missionId": "mission-42",
+    "taskId": "task-42",
+    "crewmateId": "keiko",
+    "session": {
+      "backend": "herdr",
+      "targetId": "pane-42",
+      "lifecycle": "running"
+    }
+  }
+}

--- a/tests/fm-bearings-snapshot.test.sh
+++ b/tests/fm-bearings-snapshot.test.sh
@@ -1690,8 +1690,9 @@ EOF
         and (.reason | contains("unreadable-child"))))
   ' >/dev/null || fail "end-to-end mixed-domain projection was wrong: $json"
 
-  sed '/unreadable-child/a\
-- [ ] ordinary-orphan - Unowned release task (repo: sshhip) (kind: ship)' \
+  # Append with awk, not `sed a\`: BSD sed emits appended text without a trailing
+  # newline, which silently joins the fixture's next line and corrupts the backlog.
+  awk '{print} /unreadable-child/{print "- [ ] ordinary-orphan - Unowned release task (repo: sshhip) (kind: ship)"}' \
     "$sshhip/data/backlog.md" > "$sshhip/data/backlog.next"
   mv "$sshhip/data/backlog.next" "$sshhip/data/backlog.md"
   canonical=$(PATH="$fakebin:$PATH" FM_HOME="$home" FM_SNAPSHOT_NOW=2026-07-11T18:00:00Z \
@@ -1729,8 +1730,7 @@ EOF
       and .landed == []
       and .endpoints == []
   ' >/dev/null || fail "an unowned unknown child received partial structured projection: $canonical"
-  sed '/## In flight/a\
-- [ ] unreadable-child - Submit App Store build (repo: sshhip) (kind: ship)' \
+  awk '{print} /## In flight/{print "- [ ] unreadable-child - Submit App Store build (repo: sshhip) (kind: ship)"}' \
     "$sshhip/data/backlog.md" > "$sshhip/data/backlog.next"
   mv "$sshhip/data/backlog.next" "$sshhip/data/backlog.md"
 

--- a/tests/fm-build-review.test.sh
+++ b/tests/fm-build-review.test.sh
@@ -139,25 +139,102 @@ printf '%s' "$conflict_accept" | jq -e '.error.code == "review_revision_conflict
   || fail "conflicting Build revisions must be typed, not a misleading stale packet: $conflict_accept"
 pass "one Build Review packet spans every active mission and refuses conflicting revisions"
 
+# A record that parses but violates the shape the projection derives from it is
+# isolated exactly like an unparseable one, so one hand-edited record cannot blank
+# every unrelated projection operation.
 jq -n '{
   schemaVersion:"fm-engineering-mission.v1",missionId:"mission-44",taskId:"task-44",crewmateId:"malcolm",
   state:"accepted",sourceRevision:"hand-edited",acceptedBuildRevision:"build-8:r7",
   evidenceRequirements:"automated-tests",allowedEvidenceRoots:[],
   correlation:{shapeUp:{cycleRef:"cycle-13",buildRef:"build-8",buildRevision:"build-8:r7",scopeRef:null}}
 }' > "$HOME_DIR/data/engineering/missions/mission-44.json"
-set +e
-uncomputable=$(printf '%s' '{"schemaVersion":"fm-captains-log-projection.v1","operation":"snapshot"}' |
-  FM_HOME="$HOME_DIR" "$PROJECTION" 2>/dev/null)
-status=$?
-set -e
-[ "$status" -ne 0 ] || fail "an uncomputable Build Review set must not look like a fresh snapshot"
-printf '%s' "$uncomputable" | jq -e '.accepted == false and .error.code == "projection_unavailable"' >/dev/null \
-  || fail "a failed Build Review computation must be typed unavailable, not an empty review set: $uncomputable"
-rm -f "$HOME_DIR/data/engineering/missions/mission-44.json"
-set +e
+jq -n '{
+  schemaVersion:"fm-engineering-report.v1",reportId:"report-shape-invalid",status:"accepted",
+  sourceRevision:"hand-edited",missionId:"mission-42",kind:"evidence",capturedAt:"2026-08-01T12:20:00Z",
+  correlation:"not-an-envelope",evidence:"not-an-object"
+}' > "$HOME_DIR/data/engineering/reports/report-shape-invalid.json"
+isolated=$(printf '%s' '{"schemaVersion":"fm-captains-log-projection.v1","operation":"snapshot"}' |
+  FM_HOME="$HOME_DIR" "$PROJECTION")
+printf '%s' "$isolated" | jq -e '
+  .accepted == true
+  and .snapshot.freshness == "fresh"
+  and ([.snapshot.invalidRecords[] | select(.error.code == "schema_invalid_record") | .recordId] | sort)
+    == ["mission-44","report-shape-invalid"]
+  and ([.snapshot.invalidRecords[] | select(.recordId == "mission-44") | .kind] | first) == "mission"
+  and ([.snapshot.missions[].missionId] | index("mission-44")) == null
+  and ([.snapshot.reports[].reportId] | index("report-shape-invalid")) == null
+  and ([.snapshot.buildReviews[0].missionSet[].missionId] | sort) == ["mission-42","mission-43"]
+' >/dev/null || fail "a schema-invalid record must be isolated in invalidRecords, not blank the projection: $isolated"
+rm -f "$HOME_DIR/data/engineering/missions/mission-44.json" \
+  "$HOME_DIR/data/engineering/reports/report-shape-invalid.json"
 recovered=$(printf '%s' '{"schemaVersion":"fm-captains-log-projection.v1","operation":"snapshot"}' |
   FM_HOME="$HOME_DIR" "$PROJECTION")
-set -e
-printf '%s' "$recovered" | jq -e '.accepted == true and (.snapshot.buildReviews | length) == 1' >/dev/null \
-  || fail "the projection must recover once the uncomputable record is gone: $recovered"
-pass "a Build Review set that cannot be computed degrades to a typed unavailable projection"
+printf '%s' "$recovered" | jq -e '
+  .accepted == true and (.snapshot.buildReviews | length) == 1 and (.snapshot.invalidRecords | length) == 0
+' >/dev/null || fail "the projection must return to a clean invalid set once the record is gone: $recovered"
+pass "a schema-invalid stored record stays visible and non-executable without blanking the projection"
+
+# Acceptance order is FirstMate's, so two reports accepted inside the same second
+# must be ordered by FirstMate's own sequence and never by a crewmate's capture
+# time, however far in the future that capture time is dated.
+TIE_HOME="$TMP_ROOT/tie-home"
+TIE_WORKTREE="$TIE_HOME/projects/task-45"
+mkdir -p "$TIE_HOME/data" "$TIE_HOME/state" "$TIE_HOME/config" "$TIE_WORKTREE/evidence"
+printf 'verified\n' > "$TIE_WORKTREE/evidence/tests.txt"
+jq -n --arg root "$TIE_WORKTREE" '{
+  schemaVersion:"fm-engineering-mission.v1",missionId:"mission-45",taskId:"task-45",crewmateId:"nyota",
+  acceptedBuildRevision:"build-9:r1",evidenceRequirements:["automated-tests"],allowedEvidenceRoots:[$root],
+  correlation:{schemaVersion:"shapeup-correlation.v1",sourceRevision:"dispatch:r9",capturedAt:"2026-08-01T13:00:00Z",
+    identity:{kind:"command",id:"dispatch-45"},shapeUp:{cycleRef:"cycle-14",buildRef:"build-9",buildRevision:"build-9:r1",scopeRef:null},
+    firstMate:{missionId:"mission-45",taskId:"task-45",crewmateId:"nyota",session:null}}
+}' | FM_HOME="$TIE_HOME" "$MISSION" accept - >/dev/null
+
+tie_report() {  # <report-id> <kind> <captured-at>
+  jq -n --arg id "$1" --arg kind "$2" --arg at "$3" '{
+    schemaVersion:"fm-engineering-report.v1",reportId:$id,kind:$kind,capturedAt:$at,
+    missionId:"mission-45",taskId:"task-45",crewmateId:"nyota",
+    correlation:{schemaVersion:"shapeup-correlation.v1",sourceRevision:("event:"+$id),capturedAt:$at,
+      identity:{kind:"event",id:$id},shapeUp:{cycleRef:"cycle-14",buildRef:"build-9",buildRevision:"build-9:r1",scopeRef:null},
+      firstMate:{missionId:"mission-45",taskId:"task-45",crewmateId:"nyota",session:null}}
+  }'
+}
+
+tie_append() {  # <report-json>
+  printf '%s' "$1" | FM_HOME="$TIE_HOME" FM_ENGINEERING_NOW="2026-08-01T13:05:00Z" "$REPORT" append - >/dev/null
+}
+
+tie_evidence() {  # <report-id> <captured-at> <status>
+  tie_report "$1" evidence "$2" | jq --arg path "$TIE_WORKTREE/evidence/tests.txt" --arg status "$3" '
+    .evidence={producer:"nyota",verifier:"firstmate",contract:"automated-tests",executionRevision:("exec:"+$status),
+      reference:{kind:"file",value:$path,mediaType:"text/plain"},verification:{status:$status,instructions:"Run the suite."}}
+  '
+}
+
+tie_append "$(tie_evidence report-tie-evidence-future "2099-01-01T00:00:00Z" verified)"
+tie_append "$(tie_evidence report-tie-evidence-stale "2026-08-01T13:04:00Z" stale)"
+tie_append "$(tie_report report-tie-outcome outcome "2099-01-01T00:00:00Z" |
+  jq '.outcome={state:"completed",summary:"A forward-dated capture time must not pin readiness."}')"
+tie_append "$(tie_report report-tie-hill hill_judgment "2026-08-01T13:04:00Z" |
+  jq '.hill={phase:"uphill",judgment:"Execution reopened after the outcome was recorded.",movement:"backward"}')"
+
+tied=$(printf '%s' '{"schemaVersion":"fm-captains-log-projection.v1","operation":"snapshot"}' |
+  FM_HOME="$TIE_HOME" "$PROJECTION")
+printf '%s' "$tied" | jq -e '
+  (.snapshot.buildReviews | length) == 1
+  and .snapshot.buildReviews[0].missionSet[0].terminal == false
+  and .snapshot.buildReviews[0].missionSet[0].evidenceVerified == false
+  and .snapshot.buildReviews[0].ready == false
+  and ([.snapshot.reports[].acceptanceSequence] | unique | length) == 4
+' >/dev/null || fail "a crewmate capture time must not outrank FirstMate acceptance order: $tied"
+
+tie_append "$(tie_evidence report-tie-evidence-reverified "2026-08-01T13:04:00Z" verified)"
+tie_append "$(tie_report report-tie-outcome-final outcome "2026-08-01T13:04:00Z" |
+  jq '.outcome={state:"completed",summary:"The reopened execution finished."}')"
+settled=$(printf '%s' '{"schemaVersion":"fm-captains-log-projection.v1","operation":"snapshot"}' |
+  FM_HOME="$TIE_HOME" "$PROJECTION")
+printf '%s' "$settled" | jq -e '
+  .snapshot.buildReviews[0].missionSet[0].terminal == true
+  and .snapshot.buildReviews[0].missionSet[0].evidenceVerified == true
+  and .snapshot.buildReviews[0].ready == true
+' >/dev/null || fail "the last-accepted terminal outcome and verified evidence must decide readiness: $settled"
+pass "Review readiness follows FirstMate acceptance order, not crewmate capture time"

--- a/tests/fm-build-review.test.sh
+++ b/tests/fm-build-review.test.sh
@@ -165,6 +165,32 @@ printf '%s' "$isolated" | jq -e '
   and ([.snapshot.reports[].reportId] | index("report-shape-invalid")) == null
   and ([.snapshot.buildReviews[0].missionSet[].missionId] | sort) == ["mission-42","mission-43"]
 ' >/dev/null || fail "a schema-invalid record must be isolated in invalidRecords, not blank the projection: $isolated"
+
+# Isolation keeps unrelated projection surfaces available, but the Build Review
+# packet can no longer prove it covers every active mission, so it must fail closed
+# and name the records that are holding it back.
+printf '%s' "$isolated" | jq -e '
+  .snapshot.buildReviews[0].ready == false
+  and ([.snapshot.buildReviews[0].isolatedRecords[] | .recordId] | sort)
+    == ["mission-44","report-shape-invalid"]
+  and (.snapshot.conditions | type) == "array"
+' >/dev/null || fail "an isolated active record must keep the Build Review from reporting ready: $isolated"
+isolated_packet=$(printf '%s' "$isolated" | jq -r '.snapshot.buildReviews[0].packetRevision')
+set +e
+isolated_accept=$(jq -n --arg packet "$isolated_packet" '{schemaVersion:"fm-captains-log-projection.v1",operation:"intent",
+  intent:{intentId:"review-accept-isolated",action:"acceptBuildReview",cycleRef:"cycle-13",buildRef:"build-8",packetRevision:$packet}}' |
+  FM_HOME="$HOME_DIR" "$PROJECTION")
+status=$?
+set -e
+[ "$status" -ne 0 ] || fail "acceptance must be refused while an active record is isolated"
+printf '%s' "$isolated_accept" | jq -e '.error.code == "review_records_isolated"' >/dev/null \
+  || fail "an isolated active record must produce its own typed refusal: $isolated_accept"
+acknowledged=$(printf '%s' '{"schemaVersion":"fm-captains-log-projection.v1","operation":"capabilities"}' |
+  FM_HOME="$HOME_DIR" "$PROJECTION")
+printf '%s' "$acknowledged" | jq -e '.accepted == true and .capabilities.core == "available"' >/dev/null \
+  || fail "unrelated projection capabilities must stay available while a record is isolated: $acknowledged"
+pass "an isolated active mission or report record makes Build Review fail closed with a typed refusal"
+
 rm -f "$HOME_DIR/data/engineering/missions/mission-44.json" \
   "$HOME_DIR/data/engineering/reports/report-shape-invalid.json"
 recovered=$(printf '%s' '{"schemaVersion":"fm-captains-log-projection.v1","operation":"snapshot"}' |

--- a/tests/fm-build-review.test.sh
+++ b/tests/fm-build-review.test.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+# Behavior tests for Build-level Review readiness and revision-bound acceptance.
+set -u
+
+# shellcheck source=tests/lib.sh
+# shellcheck disable=SC1091
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+MISSION="$ROOT/bin/fm-mission.sh"
+REPORT="$ROOT/bin/fm-report.sh"
+PROJECTION="$ROOT/bin/fm-captains-log-projection.sh"
+TMP_ROOT=$(fm_test_tmproot fm-build-review)
+HOME_DIR="$TMP_ROOT/home"
+WORKTREE="$HOME_DIR/projects/task-42"
+mkdir -p "$HOME_DIR/data" "$HOME_DIR/state" "$HOME_DIR/config" "$WORKTREE/evidence"
+printf 'verified\n' > "$WORKTREE/evidence/tests.txt"
+
+command -v jq >/dev/null 2>&1 || { echo "skip: jq not found"; exit 0; }
+
+mission=$(jq -n --arg root "$WORKTREE" '{
+  schemaVersion:"fm-engineering-mission.v1",missionId:"mission-42",taskId:"task-42",crewmateId:"keiko",
+  acceptedBuildRevision:"build-8:r7",evidenceRequirements:["automated-tests"],allowedEvidenceRoots:[$root],
+  correlation:{schemaVersion:"shapeup-correlation.v1",sourceRevision:"dispatch:r1",capturedAt:"2026-08-01T12:00:00Z",
+    identity:{kind:"command",id:"dispatch-42"},shapeUp:{cycleRef:"cycle-13",buildRef:"build-8",buildRevision:"build-8:r7",scopeRef:"scope-context"},
+    firstMate:{missionId:"mission-42",taskId:"task-42",crewmateId:"keiko",session:null}}
+}')
+printf '%s' "$mission" | FM_HOME="$HOME_DIR" "$MISSION" accept - >/dev/null
+
+base_report() {
+  jq -n --arg id "$1" --arg kind "$2" --arg at "$3" '{
+    schemaVersion:"fm-engineering-report.v1",reportId:$id,kind:$kind,capturedAt:$at,
+    missionId:"mission-42",taskId:"task-42",crewmateId:"keiko",
+    correlation:{schemaVersion:"shapeup-correlation.v1",sourceRevision:("event:"+$id),capturedAt:$at,
+      identity:{kind:"event",id:$id},shapeUp:{cycleRef:"cycle-13",buildRef:"build-8",buildRevision:"build-8:r7",scopeRef:"scope-context"},
+      firstMate:{missionId:"mission-42",taskId:"task-42",crewmateId:"keiko",session:null}}
+  }'
+}
+
+evidence=$(base_report report-evidence evidence "2026-08-01T12:05:00Z" | jq --arg path "$WORKTREE/evidence/tests.txt" '
+  .evidence={producer:"keiko",verifier:"firstmate",contract:"automated-tests",executionRevision:"exec:r1",
+    reference:{kind:"file",value:$path,mediaType:"text/plain"},verification:{status:"verified",instructions:"Run the suite."}}
+')
+printf '%s' "$evidence" | FM_HOME="$HOME_DIR" "$REPORT" append - >/dev/null
+outcome=$(base_report report-outcome outcome "2026-08-01T12:06:00Z" | jq '.outcome={state:"completed",summary:"Accepted mission outcome is ready for Review."}')
+printf '%s' "$outcome" | FM_HOME="$HOME_DIR" "$REPORT" append - >/dev/null
+
+snapshot=$(printf '%s' '{"schemaVersion":"fm-captains-log-projection.v1","operation":"snapshot"}' |
+  FM_HOME="$HOME_DIR" "$PROJECTION")
+printf '%s' "$snapshot" | jq -e '
+  (.snapshot.buildReviews | length) == 1
+  and .snapshot.buildReviews[0].ready == true
+  and .snapshot.buildReviews[0].missionSet[0].terminal == true
+  and .snapshot.buildReviews[0].missionSet[0].evidenceVerified == true
+' >/dev/null || fail "Build Review should be ready only after terminal outcome and verified evidence: $snapshot"
+packet=$(printf '%s' "$snapshot" | jq -r '.snapshot.buildReviews[0].packetRevision')
+
+accept=$(jq -n --arg packet "$packet" '{schemaVersion:"fm-captains-log-projection.v1",operation:"intent",
+  intent:{intentId:"review-accept-1",action:"acceptBuildReview",cycleRef:"cycle-13",buildRef:"build-8",packetRevision:$packet}}' |
+  FM_HOME="$HOME_DIR" "$PROJECTION")
+printf '%s' "$accept" | jq -e '.accepted == true and .outcome.status == "captainAccepted"' >/dev/null \
+  || fail "revision-bound Build Review acceptance failed: $accept"
+
+stale_evidence=$(base_report report-evidence-stale evidence "2026-08-01T12:07:00Z" | jq --arg path "$WORKTREE/evidence/tests.txt" '
+  .evidence={producer:"keiko",verifier:"firstmate",contract:"automated-tests",executionRevision:"exec:r2",
+    reference:{kind:"file",value:$path,mediaType:"text/plain"},verification:{status:"stale",instructions:"Re-run the suite."}}
+')
+printf '%s' "$stale_evidence" | FM_HOME="$HOME_DIR" "$REPORT" append - >/dev/null
+evidence_changed=$(printf '%s' '{"schemaVersion":"fm-captains-log-projection.v1","operation":"snapshot"}' |
+  FM_HOME="$HOME_DIR" "$PROJECTION")
+printf '%s' "$evidence_changed" | jq -e '
+  .snapshot.buildReviews[0].ready == false
+  and .snapshot.buildReviews[0].missionSet[0].evidenceVerified == false
+' >/dev/null || fail "latest stale evidence did not invalidate Review readiness: $evidence_changed"
+
+reverified=$(base_report report-evidence-reverified evidence "2026-08-01T12:08:00Z" | jq --arg path "$WORKTREE/evidence/tests.txt" '
+  .evidence={producer:"keiko",verifier:"firstmate",contract:"automated-tests",executionRevision:"exec:r3",
+    reference:{kind:"file",value:$path,mediaType:"text/plain"},verification:{status:"verified",instructions:"Run the suite."}}
+')
+printf '%s' "$reverified" | FM_HOME="$HOME_DIR" "$REPORT" append - >/dev/null
+
+new_execution=$(base_report report-new-execution scope_discovery "2026-08-01T12:09:00Z" |
+  jq '.scope={title:"A new Scope",judgment:"Execution discovered more work."}')
+printf '%s' "$new_execution" | FM_HOME="$HOME_DIR" "$REPORT" append - >/dev/null
+changed=$(printf '%s' '{"schemaVersion":"fm-captains-log-projection.v1","operation":"snapshot"}' |
+  FM_HOME="$HOME_DIR" "$PROJECTION")
+new_packet=$(printf '%s' "$changed" | jq -r '.snapshot.buildReviews[0].packetRevision')
+[ "$new_packet" != "$packet" ] || fail "new execution did not invalidate the pending Review packet"
+printf '%s' "$changed" | jq -e '.snapshot.buildReviews[0].ready == false and .snapshot.buildReviews[0].missionSet[0].terminal == false' >/dev/null \
+  || fail "new execution after a terminal outcome must reopen mission readiness: $changed"
+
+replay=$(jq -n --arg packet "$packet" '{schemaVersion:"fm-captains-log-projection.v1",operation:"intent",
+  intent:{intentId:"review-accept-1",action:"acceptBuildReview",cycleRef:"cycle-13",buildRef:"build-8",packetRevision:$packet}}' |
+  FM_HOME="$HOME_DIR" "$PROJECTION")
+printf '%s' "$replay" | jq -e '.accepted == true and .outcome.status == "captainAccepted" and .outcome.replayed == true' >/dev/null \
+  || fail "exact Build Review replay must return the prior outcome after packet drift: $replay"
+
+set +e
+stale=$(jq -n --arg packet "$packet" '{schemaVersion:"fm-captains-log-projection.v1",operation:"intent",
+  intent:{intentId:"review-accept-2",action:"acceptBuildReview",cycleRef:"cycle-13",buildRef:"build-8",packetRevision:$packet}}' |
+  FM_HOME="$HOME_DIR" "$PROJECTION")
+status=$?
+set -e
+[ "$status" -ne 0 ] || fail "stale Build Review packet must fail"
+printf '%s' "$stale" | jq -e '.error.code == "stale_packet"' >/dev/null \
+  || fail "stale Build Review must return a typed error: $stale"
+pass "Build Review binds the active mission/evidence revision and acceptance is not closeout"
+
+mkdir -p "$HOME_DIR/projects/task-43"
+second_mission=$(jq -n --arg root "$HOME_DIR/projects/task-43" '{
+  schemaVersion:"fm-engineering-mission.v1",missionId:"mission-43",taskId:"task-43",crewmateId:"hoshi",
+  acceptedBuildRevision:"build-8:r8",evidenceRequirements:[],allowedEvidenceRoots:[$root],
+  correlation:{schemaVersion:"shapeup-correlation.v1",sourceRevision:"dispatch:r2",capturedAt:"2026-08-01T12:10:00Z",
+    identity:{kind:"command",id:"dispatch-43"},shapeUp:{cycleRef:"cycle-13",buildRef:"build-8",buildRevision:"build-8:r8",scopeRef:"scope-context"},
+    firstMate:{missionId:"mission-43",taskId:"task-43",crewmateId:"hoshi",session:null}}
+}')
+printf '%s' "$second_mission" | FM_HOME="$HOME_DIR" "$MISSION" accept - >/dev/null
+
+conflicted=$(printf '%s' '{"schemaVersion":"fm-captains-log-projection.v1","operation":"snapshot"}' |
+  FM_HOME="$HOME_DIR" "$PROJECTION")
+printf '%s' "$conflicted" | jq -e '
+  (.snapshot.buildReviews | length) == 1
+  and .snapshot.buildReviews[0].revisionConflict == true
+  and .snapshot.buildReviews[0].buildRevision == null
+  and .snapshot.buildReviews[0].buildRevisions == ["build-8:r7","build-8:r8"]
+  and ([.snapshot.buildReviews[0].missionSet[].missionId] | sort) == ["mission-42","mission-43"]
+  and .snapshot.buildReviews[0].ready == false
+' >/dev/null || fail "one Build packet must span every active mission and mark revision conflict: $conflicted"
+
+conflict_packet=$(printf '%s' "$conflicted" | jq -r '.snapshot.buildReviews[0].packetRevision')
+[ "${#conflict_packet}" -eq 64 ] || fail "Build Review packet revision must be a digest: $conflict_packet"
+set +e
+conflict_accept=$(jq -n --arg packet "$conflict_packet" '{schemaVersion:"fm-captains-log-projection.v1",operation:"intent",
+  intent:{intentId:"review-accept-conflict",action:"acceptBuildReview",cycleRef:"cycle-13",buildRef:"build-8",packetRevision:$packet}}' |
+  FM_HOME="$HOME_DIR" "$PROJECTION")
+status=$?
+set -e
+[ "$status" -ne 0 ] || fail "conflicting Build revisions must refuse acceptance"
+printf '%s' "$conflict_accept" | jq -e '.error.code == "review_revision_conflict"' >/dev/null \
+  || fail "conflicting Build revisions must be typed, not a misleading stale packet: $conflict_accept"
+pass "one Build Review packet spans every active mission and refuses conflicting revisions"
+
+jq -n '{
+  schemaVersion:"fm-engineering-mission.v1",missionId:"mission-44",taskId:"task-44",crewmateId:"malcolm",
+  state:"accepted",sourceRevision:"hand-edited",acceptedBuildRevision:"build-8:r7",
+  evidenceRequirements:"automated-tests",allowedEvidenceRoots:[],
+  correlation:{shapeUp:{cycleRef:"cycle-13",buildRef:"build-8",buildRevision:"build-8:r7",scopeRef:null}}
+}' > "$HOME_DIR/data/engineering/missions/mission-44.json"
+set +e
+uncomputable=$(printf '%s' '{"schemaVersion":"fm-captains-log-projection.v1","operation":"snapshot"}' |
+  FM_HOME="$HOME_DIR" "$PROJECTION" 2>/dev/null)
+status=$?
+set -e
+[ "$status" -ne 0 ] || fail "an uncomputable Build Review set must not look like a fresh snapshot"
+printf '%s' "$uncomputable" | jq -e '.accepted == false and .error.code == "projection_unavailable"' >/dev/null \
+  || fail "a failed Build Review computation must be typed unavailable, not an empty review set: $uncomputable"
+rm -f "$HOME_DIR/data/engineering/missions/mission-44.json"
+set +e
+recovered=$(printf '%s' '{"schemaVersion":"fm-captains-log-projection.v1","operation":"snapshot"}' |
+  FM_HOME="$HOME_DIR" "$PROJECTION")
+set -e
+printf '%s' "$recovered" | jq -e '.accepted == true and (.snapshot.buildReviews | length) == 1' >/dev/null \
+  || fail "the projection must recover once the uncomputable record is gone: $recovered"
+pass "a Build Review set that cannot be computed degrades to a typed unavailable projection"

--- a/tests/fm-captains-log-projection.test.sh
+++ b/tests/fm-captains-log-projection.test.sh
@@ -1,0 +1,191 @@
+#!/usr/bin/env bash
+# Behavior tests for the versioned Captain's Log machine projection.
+set -u
+
+# shellcheck source=tests/lib.sh
+# shellcheck disable=SC1091
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+PROJECTION="$ROOT/bin/fm-captains-log-projection.sh"
+TMP_ROOT=$(fm_test_tmproot fm-captains-log-projection)
+HOME_DIR="$TMP_ROOT/home"
+mkdir -p "$HOME_DIR/data/engineering/missions" "$HOME_DIR/data/engineering/reports" \
+  "$HOME_DIR/data/engineering/outcomes" "$HOME_DIR/state" "$HOME_DIR/config" "$HOME_DIR/projects"
+
+command -v jq >/dev/null 2>&1 || { echo "skip: jq not found"; exit 0; }
+
+request() {
+  printf '%s' "$1" | FM_HOME="$HOME_DIR" FM_PROJECTION_NOW="2026-08-01T12:00:00Z" "$PROJECTION"
+}
+
+capabilities=$(request '{"schemaVersion":"fm-captains-log-projection.v1","operation":"capabilities"}')
+printf '%s' "$capabilities" | jq -e '
+  .accepted == true
+  and .schemaVersion == "fm-captains-log-projection.v1"
+  and .capabilities.core == "available"
+  and .capabilities.sessionInspection.required == false
+  and (.operations | index("snapshot") != null)
+' >/dev/null || fail "projection capabilities are invalid: $capabilities"
+pass "projection publishes versioned independently negotiated capabilities"
+
+snapshot=$(request '{"schemaVersion":"fm-captains-log-projection.v1","operation":"snapshot"}')
+printf '%s' "$snapshot" | jq -e '
+  .accepted == true
+  and .snapshot.schemaVersion == "fm-captains-log-snapshot.v1"
+  and .snapshot.capturedAt == "2026-08-01T12:00:00Z"
+  and (.snapshot.sourceRevision | length == 64)
+  and (.snapshot.missions | length == 0)
+  and (.snapshot.reports | length == 0)
+  and (.snapshot.conditions | length == 0)
+  and (.snapshot.shapeUpOutcomes | length == 0)
+' >/dev/null || fail "empty projection snapshot is invalid: $snapshot"
+pass "projection emits a deterministic empty snapshot"
+
+set +e
+bad=$(request '{"schemaVersion":"future","operation":"snapshot"}')
+status=$?
+set -e
+[ "$status" -ne 0 ] || fail "unsupported schema must fail"
+printf '%s' "$bad" | jq -e '.error.code == "unsupported_schema" and .accepted == false' >/dev/null \
+  || fail "unsupported schema must return a typed error: $bad"
+pass "projection rejects unsupported schemas with a typed error"
+
+jq -n '{
+  schemaVersion:"fm-engineering-report.v1",reportId:"report-condition-1",sourceRevision:"report:r1",status:"accepted",
+  missionId:"mission-1",capturedAt:"2026-08-01T12:00:00Z",
+  correlation:{shapeUp:{buildRef:"build-1",scopeRef:null}},
+  condition:{conditionId:"condition-1",packetRevision:"packet-1",lifecycle:"raised",creationSequence:1}
+}' > "$HOME_DIR/data/engineering/reports/report-condition-1.json"
+intent='{"schemaVersion":"fm-captains-log-projection.v1","operation":"intent","intent":{"intentId":"intent-1","action":"acknowledgeCondition","missionId":"mission-1","conditionId":"condition-1","packetRevision":"packet-1"}}'
+first=$(request "$intent")
+second=$(request "$intent")
+printf '%s' "$first" | jq -e '.accepted == true and .outcome.replayed == false' >/dev/null \
+  || fail "first acknowledgement must be accepted: $first"
+printf '%s' "$second" | jq -e '.accepted == true and .outcome.replayed == true' >/dev/null \
+  || fail "exact replay must return the prior outcome: $second"
+
+set +e
+conflict=$(request "$(printf '%s' "$intent" | jq -c '.intent.packetRevision="packet-2"')")
+status=$?
+set -e
+[ "$status" -ne 0 ] || fail "changed intent reuse must fail"
+printf '%s' "$conflict" | jq -e '.error.code == "identity_conflict"' >/dev/null \
+  || fail "changed intent reuse must return identity_conflict: $conflict"
+pass "projection journals exact replay and rejects changed identity reuse"
+
+LOCKS="$HOME_DIR/state/fm-projection-intent-locks"
+lock_intent() {  # <intent-id> [stale-minutes] [tz]
+  jq -n --arg id "$1" '{schemaVersion:"fm-captains-log-projection.v1",operation:"intent",
+    intent:{intentId:$id,action:"acknowledgeCondition",missionId:"mission-1",conditionId:"condition-1",packetRevision:"packet-1"}}' |
+    TZ="${3:-UTC}" FM_HOME="$HOME_DIR" FM_PROJECTION_NOW="2026-08-01T12:00:00Z" \
+      FM_PROJECTION_INTENT_LOCK_STALE_MINUTES="${2:-5}" "$PROJECTION"
+}
+
+write_lock_owner() {  # <lock-dir> <pid> <started>
+  mkdir -p "$1"
+  printf 'host=%s\npid=%s\nstarted=%s\n' "${HOSTNAME:-$(hostname)}" "$2" "$3" > "$1/owner"
+}
+
+start_signature() {  # <pid>
+  local value
+  value=$(LC_ALL=C TZ=UTC ps -o lstart= -p "$1" 2>/dev/null | tr -d '[:space:]')
+  [ -n "$value" ] || return 1
+  printf 'lstart:%s' "$value"
+}
+
+# Capture output and status together so a regression reports its assertion
+# instead of aborting the suite under errexit.
+lock_attempt() {  # <intent-id> [stale-minutes] [tz]
+  set +e
+  lock_output=$(lock_intent "$1" "${2:-5}" "${3:-UTC}")
+  lock_status=$?
+  set -e
+}
+
+if ! own_started=$(start_signature "$$"); then
+  echo "skip: ps -o lstart= is unavailable, so intent-lock ownership is untestable"
+else
+  write_lock_owner "$LOCKS/live-owner" "$$" "$own_started"
+  touch -t 200001010000 "$LOCKS/live-owner"
+  lock_attempt live-owner
+  [ "$lock_status" -ne 0 ] || fail "a lock held by a live owner must not be reclaimed: $lock_output"
+  printf '%s' "$lock_output" | jq -e '.error.code == "intent_busy"' >/dev/null \
+    || fail "a live intent owner keeps the mutex however long it runs: $lock_output"
+  [ -d "$LOCKS/live-owner" ] || fail "the live owner's lock was removed"
+
+  write_lock_owner "$LOCKS/tz-owner" "$$" "$own_started"
+  touch -t 200001010000 "$LOCKS/tz-owner"
+  lock_attempt tz-owner 5 Asia/Tokyo
+  [ "$lock_status" -ne 0 ] \
+    || fail "a live owner must not be reclaimed just because the reader's timezone differs: $lock_output"
+  printf '%s' "$lock_output" | jq -e '.error.code == "intent_busy"' >/dev/null \
+    || fail "owner identity must not depend on the observing timezone: $lock_output"
+  [ -d "$LOCKS/tz-owner" ] || fail "a differing reader timezone reclaimed a live owner's lock"
+
+  if [ -n "$(start_signature 1)" ] && ! kill -0 1 2>/dev/null; then
+    write_lock_owner "$LOCKS/foreign-owner" 1 "$(start_signature 1)"
+    touch -t 200001010000 "$LOCKS/foreign-owner"
+    lock_attempt foreign-owner
+    [ "$lock_status" -ne 0 ] \
+      || fail "a live owner owned by another user must not be reclaimed: $lock_output"
+    printf '%s' "$lock_output" | jq -e '.error.code == "intent_busy"' >/dev/null \
+      || fail "an unsignalable but live owner must keep the mutex: $lock_output"
+  fi
+
+  write_lock_owner "$LOCKS/recycled-pid" "$$" "lstart:ThuJan100:00:001970"
+  lock_attempt recycled-pid
+  printf '%s' "$lock_output" | jq -e '.accepted == true and .outcome.status == "acknowledged"' >/dev/null \
+    || fail "a lock whose pid was recycled by a later process must be reclaimed: $lock_output"
+  [ ! -d "$LOCKS/recycled-pid" ] || fail "the recycled-pid lock was not released after the intent completed"
+
+  sh -c 'exit 0' &
+  dead_pid=$!
+  wait "$dead_pid" 2>/dev/null || true
+  write_lock_owner "$LOCKS/dead-owner" "$dead_pid" "$own_started"
+  lock_attempt dead-owner
+  printf '%s' "$lock_output" | jq -e '.accepted == true and .outcome.status == "acknowledged"' >/dev/null \
+    || fail "a lock whose owner is gone must be reclaimed at once: $lock_output"
+  [ ! -d "$LOCKS/dead-owner" ] || fail "the reclaimed lock was not released after the intent completed"
+
+  mkdir -p "$LOCKS/unowned"
+  lock_attempt unowned
+  [ "$lock_status" -ne 0 ] || fail "a fresh ownerless lock must still be honoured: $lock_output"
+  printf '%s' "$lock_output" | jq -e '.error.code == "intent_busy"' >/dev/null \
+    || fail "an ownerless lock inside its age window stays busy: $lock_output"
+
+  write_lock_owner "$LOCKS/foreign-method" "$$" "epoch:1754000000"
+  touch -t 200001010000 "$LOCKS/foreign-method"
+  lock_attempt foreign-method
+  printf '%s' "$lock_output" | jq -e '.accepted == true' >/dev/null \
+    || fail "an owner recorded by another identity method must age out, not be trusted forever: $lock_output"
+
+  write_lock_owner "$LOCKS/legacy-owner" "$$" ""
+  touch -t 200001010000 "$LOCKS/legacy-owner"
+  lock_attempt legacy-owner
+  printf '%s' "$lock_output" | jq -e '.accepted == true' >/dev/null \
+    || fail "an owner that cannot be verified must still age out instead of wedging: $lock_output"
+
+  mkdir -p "$LOCKS/aged-window"
+  touch -t 200001010000 "$LOCKS/aged-window"
+  lock_attempt aged-window 999999999
+  [ "$lock_status" -ne 0 ] || fail "a valid wide stale window must still honour an old lock: $lock_output"
+  printf '%s' "$lock_output" | jq -e '.error.code == "intent_busy"' >/dev/null \
+    || fail "a valid stale-window override must be honoured: $lock_output"
+  lock_attempt aged-window 0
+  printf '%s' "$lock_output" | jq -e '.accepted == true' >/dev/null \
+    || fail "an out-of-range stale window must fall back to the bounded default: $lock_output"
+  pass "the intent mutex recovers from crashes without ever reclaiming a live owner"
+fi
+
+jq -e '
+  .schemaVersion == "shapeup-correlation.v1"
+  and .shapeUp.cycleRef == "cycle-13"
+  and .shapeUp.buildRef == "build-8"
+  and .firstMate.missionId == "mission-42"
+  and .firstMate.session.backend == "herdr"
+' "$ROOT/tests/fixtures/captains-log/correlation-envelope-v1.json" >/dev/null \
+  || fail "correlation fixture is invalid"
+jq -e '.cases | map(.name) == ["complete","core-only","shapeup-partial","unsupported"]' \
+  "$ROOT/tests/fixtures/captains-log/compatibility-matrix-v1.json" >/dev/null \
+  || fail "compatibility fixture is invalid"
+pass "portable fixtures freeze the correlation and compatibility contract"

--- a/tests/fm-decision-hold.test.sh
+++ b/tests/fm-decision-hold.test.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# Behavior tests for Engineering Captain Call packets over durable holds.
+set -u
+
+# shellcheck source=tests/lib.sh
+# shellcheck disable=SC1091
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+MISSION="$ROOT/bin/fm-mission.sh"
+REPORT="$ROOT/bin/fm-report.sh"
+DECISIONS="$ROOT/bin/fm-decision-hold.sh"
+PROJECTION="$ROOT/bin/fm-captains-log-projection.sh"
+TMP_ROOT=$(fm_test_tmproot fm-engineering-decisions)
+HOME_DIR="$TMP_ROOT/home"
+mkdir -p "$HOME_DIR/data" "$HOME_DIR/state" "$HOME_DIR/config" "$HOME_DIR/projects/task-42"
+cp "$ROOT/.tasks.toml" "$HOME_DIR/.tasks.toml"
+cat > "$HOME_DIR/data/backlog.md" <<'EOF'
+## In flight
+
+## Queued
+
+## Done
+EOF
+
+command -v jq >/dev/null 2>&1 || { echo "skip: jq not found"; exit 0; }
+command -v tasks-axi >/dev/null 2>&1 || { echo "skip: tasks-axi not found"; exit 0; }
+
+mission=$(jq -n --arg root "$HOME_DIR/projects/task-42" '{
+  schemaVersion:"fm-engineering-mission.v1",missionId:"mission-42",taskId:"task-42",crewmateId:"keiko",
+  acceptedBuildRevision:"build-8:r7",evidenceRequirements:[],allowedEvidenceRoots:[$root],
+  correlation:{schemaVersion:"shapeup-correlation.v1",sourceRevision:"dispatch:r1",capturedAt:"2026-08-01T12:00:00Z",
+    identity:{kind:"command",id:"dispatch-42"},shapeUp:{cycleRef:"cycle-13",buildRef:"build-8",buildRevision:"build-8:r7",scopeRef:"scope-context"},
+    firstMate:{missionId:"mission-42",taskId:"task-42",crewmateId:"keiko",session:null}}
+}')
+printf '%s' "$mission" | FM_HOME="$HOME_DIR" "$MISSION" accept - >/dev/null
+
+condition_report() {
+  jq -n --arg id "$1" --arg condition "$2" --arg at "$3" '{
+    schemaVersion:"fm-engineering-report.v1",reportId:$id,kind:"scope_revision",capturedAt:$at,
+    missionId:"mission-42",taskId:"task-42",crewmateId:"keiko",scope:{change:"drop",reason:"The accepted Build no longer fits the appetite."},
+    correlation:{schemaVersion:"shapeup-correlation.v1",sourceRevision:("event:"+$id),capturedAt:$at,
+      identity:{kind:"event",id:$id},shapeUp:{cycleRef:"cycle-13",buildRef:"build-8",buildRevision:"build-8:r7",scopeRef:"scope-context"},
+      firstMate:{missionId:"mission-42",taskId:"task-42",crewmateId:"keiko",session:null}},
+    condition:{conditionId:$condition,title:("Choose "+$condition),explanation:"Dropping the Scope changes the accepted Build outcome.",
+      recommendation:"Defer the Scope explicitly.",choices:["defer","retain"],consequenceOfDelay:"Execution remains blocked.",
+      affectedObjects:["build-8","scope-context"],evidence:[],boundRevisions:{build:"build-8:r7"}}
+  }'
+}
+
+first=$(condition_report report-condition-1 scope-drop "2026-08-01T12:05:00Z" |
+  FM_HOME="$HOME_DIR" "$REPORT" append -)
+printf '%s' "$first" | jq -e '
+  .accepted == true
+  and .report.condition.lifecycle == "raised"
+  and .report.condition.holdId == "mission-42-decision-scope-drop"
+  and (.report.condition.packetRevision | length == 64)
+' >/dev/null || fail "consequential report did not raise a durable packet: $first"
+
+status=$(FM_HOME="$HOME_DIR" "$DECISIONS" status mission-42 scope-drop --json)
+printf '%s' "$status" | jq -e '.lifecycle == "raised" and .durableState.held == true' >/dev/null \
+  || fail "durable hold status is invalid: $status"
+
+updated=$(condition_report report-condition-2 scope-drop "2026-08-01T12:06:00Z" |
+  jq '.condition.explanation="New evidence sharpens the same condition."' |
+  FM_HOME="$HOME_DIR" "$REPORT" append -)
+printf '%s' "$updated" | jq -e '.accepted == true and .report.condition.lifecycle == "updated"' >/dev/null \
+  || fail "same condition did not update independently: $updated"
+
+snapshot=$(printf '%s' '{"schemaVersion":"fm-captains-log-projection.v1","operation":"snapshot"}' |
+  FM_HOME="$HOME_DIR" "$PROJECTION")
+printf '%s' "$snapshot" | jq -e '
+  (.snapshot.conditions | length) == 1
+  and .snapshot.conditions[0].conditionId == "scope-drop"
+  and .snapshot.conditions[0].lifecycle == "updated"
+' >/dev/null || fail "projection did not select the newest condition packet: $snapshot"
+
+packet=$(printf '%s' "$snapshot" | jq -r '.snapshot.conditions[0].packetRevision')
+ack=$(jq -n --arg packet "$packet" '{schemaVersion:"fm-captains-log-projection.v1",operation:"intent",
+  intent:{intentId:"ack-1",action:"acknowledgeCondition",missionId:"mission-42",conditionId:"scope-drop",packetRevision:$packet}}' |
+  FM_HOME="$HOME_DIR" "$PROJECTION")
+printf '%s' "$ack" | jq -e '.accepted == true and .outcome.status == "acknowledged"' >/dev/null \
+  || fail "acknowledgement failed: $ack"
+status=$(FM_HOME="$HOME_DIR" "$DECISIONS" status mission-42 scope-drop --json)
+printf '%s' "$status" | jq -e '.lifecycle == "updated" and .durableState.held == true' >/dev/null \
+  || fail "viewing or acknowledgement resolved the hold"
+
+(cd "$HOME_DIR" && tasks-axi add routed-scope-work "Route the chosen Scope" --kind ship --repo firstmate >/dev/null)
+(cd "$HOME_DIR" && tasks-axi block routed-scope-work --by mission-42-decision-scope-drop >/dev/null)
+resolved=$(jq -n --arg packet "$packet" '{schemaVersion:"fm-captains-log-projection.v1",operation:"intent",
+  intent:{intentId:"resolve-1",action:"resolveCondition",missionId:"mission-42",conditionId:"scope-drop",packetRevision:$packet,
+    decision:"Defer the Scope from this accepted Build outcome.",routedTo:["routed-scope-work"]}}' |
+  FM_HOME="$HOME_DIR" "$PROJECTION")
+printf '%s' "$resolved" | jq -e '.accepted == true and .outcome.status == "resolved"' >/dev/null \
+  || fail "Captain Call resolution was not routed through the durable completion owner: $resolved"
+snapshot=$(printf '%s' '{"schemaVersion":"fm-captains-log-projection.v1","operation":"snapshot"}' |
+  FM_HOME="$HOME_DIR" "$PROJECTION")
+printf '%s' "$snapshot" | jq -e '.snapshot.conditions[0].lifecycle == "resolved"' >/dev/null \
+  || fail "resolved Captain Call lifecycle was not projected: $snapshot"
+pass "Captain Call packets update independently and resolve through one durable completion owner"

--- a/tests/fm-decision-hold.test.sh
+++ b/tests/fm-decision-hold.test.sh
@@ -121,3 +121,27 @@ case "$retained_body" in
   *) fail "re-projection erased the retry identity a partial resolution depends on: $retained_body" ;;
 esac
 pass "projecting a packet never erases a hold's in-flight resolution record"
+
+# Retaining the resolution record is not the same as projecting the packet, so the
+# durable report must not claim a revision the hold never received.
+retained=$(condition_report report-condition-4 scope-widen "2026-08-01T12:08:00Z" |
+  jq '.condition.explanation="A newer packet revision arrives mid-resolution."' |
+  FM_HOME="$HOME_DIR" "$REPORT" append -)
+printf '%s' "$retained" | jq -e '
+  .accepted == true
+  and .report.condition.projection.status == "retained"
+  and .captainCall.projection == "retained"
+  and .captainCall.error.code == "captain_call_resolution_in_flight"
+' >/dev/null || fail "a packet held back by an in-flight resolution must not be recorded as projected: $retained"
+jq -e '.condition.projection.status == "retained"' \
+  "$HOME_DIR/data/engineering/reports/report-condition-4.json" >/dev/null \
+  || fail "the retained projection state must be durable"
+settled=$(cat "$HOME_DIR/data/engineering/reports/report-condition-4.json")
+again=$(condition_report report-condition-4 scope-widen "2026-08-01T12:08:00Z" |
+  jq '.condition.explanation="A newer packet revision arrives mid-resolution."' |
+  FM_HOME="$HOME_DIR" "$REPORT" append -)
+printf '%s' "$again" | jq -e '.accepted == true and .replayed == true and .captainCall.projection == "retained"' >/dev/null \
+  || fail "an exact replay must retry the retained packet and report it: $again"
+[ "$settled" = "$(cat "$HOME_DIR/data/engineering/reports/report-condition-4.json")" ] \
+  || fail "a retry that still cannot project must not rewrite the durable record"
+pass "a packet withheld by an in-flight resolution is typed retained, not projected"

--- a/tests/fm-decision-hold.test.sh
+++ b/tests/fm-decision-hold.test.sh
@@ -97,3 +97,27 @@ snapshot=$(printf '%s' '{"schemaVersion":"fm-captains-log-projection.v1","operat
 printf '%s' "$snapshot" | jq -e '.snapshot.conditions[0].lifecycle == "resolved"' >/dev/null \
   || fail "resolved Captain Call lifecycle was not projected: $snapshot"
 pass "Captain Call packets update independently and resolve through one durable completion owner"
+
+# A resolution that fails after recording the decision leaves the retry identity
+# in the hold body. Re-projecting a packet over it would erase the record an exact
+# retry needs, leaving the hold permanently unresolvable.
+widen=$(condition_report report-condition-3 scope-widen "2026-08-01T12:07:00Z" |
+  FM_HOME="$HOME_DIR" "$REPORT" append -)
+printf '%s' "$widen" | jq -e '.accepted == true and .report.condition.holdId == "mission-42-decision-scope-widen"' >/dev/null \
+  || fail "the widening Captain Call did not raise its own hold: $widen"
+partial=$(printf 'Resolution recorded by fm-decision-hold.\nDecision digest: %s\nRouted identities: routed-widen-work\n\nCaptain decision:\nWiden the Scope.\n\nRouted work:\n- routed-widen-work\n' \
+  "0000000000000000000000000000000000000000000000000000000000000000")
+(cd "$HOME_DIR" && tasks-axi update mission-42-decision-scope-widen --body "$partial" >/dev/null)
+projected=$(FM_HOME="$HOME_DIR" "$DECISIONS" project mission-42 scope-widen \
+  --packet-file "$HOME_DIR/data/engineering/reports/report-condition-3.json" --lifecycle resolving)
+case "$projected" in
+  retained:*) ;;
+  *) fail "projecting over a partial resolution must report the retained record: $projected" ;;
+esac
+retained_body=$(cd "$HOME_DIR" && tasks-axi show mission-42-decision-scope-widen --full |
+  sed -n 's/^  body: //p' | head -1)
+case "$retained_body" in
+  *"Resolution recorded by fm-decision-hold."*"routed-widen-work"*) ;;
+  *) fail "re-projection erased the retry identity a partial resolution depends on: $retained_body" ;;
+esac
+pass "projecting a packet never erases a hold's in-flight resolution record"

--- a/tests/fm-engineering-lib.test.sh
+++ b/tests/fm-engineering-lib.test.sh
@@ -224,8 +224,60 @@ test_lock_wait_fails_fast_on_permanent_failure() {
   fm_eng_lock_release_all
   [ "$status" -ne 0 ] || fail "a lock held by a live owner must not be handed to a waiter"
   [ "$elapsed" -ge 1 ] || fail "contention must actually be waited out, not refused at once"
-  [ "$elapsed" -le 6 ] || fail "the contention wait ran ${elapsed}s past its 2s bound"
+  # The bound is a wall-clock deadline, so per-attempt probe and spawn cost has to
+  # come out of the requested budget rather than multiplying it. The ceiling leaves
+  # room for a loaded runner without tolerating a bound that scales with fork cost.
+  [ "$elapsed" -le 4 ] || fail "the contention wait ran ${elapsed}s past its 2s deadline"
   pass "fm_eng_lock_acquire_wait waits out contention and refuses a permanent failure at once"
+}
+
+test_lock_wait_deadline_scales_with_request() {
+  local held="$TMP_ROOT/deadline/lock" short long
+  fm_eng_lock_acquire "$held" 5 "2026-08-02T00:00:00Z" || fail "the deadline fixture could not be set up"
+  short=$(date +%s)
+  set +e
+  ( fm_eng_lock_acquire_wait "$held" 5 "2026-08-02T00:00:00Z" 1 ) >/dev/null 2>&1
+  set -e
+  short=$(( $(date +%s) - short ))
+  long=$(date +%s)
+  set +e
+  ( fm_eng_lock_acquire_wait "$held" 5 "2026-08-02T00:00:00Z" 6 ) >/dev/null 2>&1
+  set -e
+  long=$(( $(date +%s) - long ))
+  fm_eng_lock_release_all
+  # A budget that is actually enforced tracks the request instead of a fixed
+  # multiple of it: a 6s wait must not finish inside a 1s wait's own ceiling.
+  [ "$short" -le 3 ] || fail "a 1s contention bound took ${short}s"
+  [ "$long" -ge 5 ] || fail "a 6s contention bound gave up after ${long}s"
+  [ "$long" -le 9 ] || fail "a 6s contention bound ran ${long}s"
+  pass "the contention bound tracks the requested seconds rather than a multiple of them"
+}
+
+test_pause_probe_is_memoized_and_deferred() {
+  local free="$TMP_ROOT/deferred/lock" held="$TMP_ROOT/deferred/held"
+  FM_ENG_LOCK_PAUSE_UNIT=''
+  # An uncontended acquisition must never reach the probe: its cost is a real
+  # sleep, and paying it would tax every report append for an answer that only
+  # matters once a wait actually has to pause.
+  fm_eng_lock_acquire_wait "$free" 5 "2026-08-02T00:00:00Z" 5 \
+    || fail "an uncontended wait must acquire the lock"
+  [ -z "$FM_ENG_LOCK_PAUSE_UNIT" ] \
+    || fail "an uncontended wait probed the pause unit: $FM_ENG_LOCK_PAUSE_UNIT"
+  fm_eng_lock_release "$free"
+
+  fm_eng_lock_acquire "$held" 5 "2026-08-02T00:00:00Z" || fail "the probe fixture could not be set up"
+  set +e
+  ( fm_eng_lock_acquire_wait "$held" 5 "2026-08-02T00:00:00Z" 1 ) >/dev/null 2>&1
+  set -e
+  fm_eng_lock_release_all
+  # The probe answer has to land in the caller's own shell, or it is re-paid on
+  # every wait for a capability that cannot change.
+  fm_eng_lock_pause_unit
+  case "$FM_ENG_LOCK_PAUSE_UNIT" in
+    0.05|1) ;;
+    *) fail "the pause probe did not memoize a usable unit: $FM_ENG_LOCK_PAUSE_UNIT" ;;
+  esac
+  pass "the pause probe memoizes in the caller's shell and never runs for an uncontended wait"
 }
 
 test_reads_are_bounded_and_closed() {
@@ -370,6 +422,8 @@ test_credential_label_anchor_admits_delimiters
 test_locks_are_liveness_safe
 test_locks_survive_paths_with_spaces
 test_lock_wait_fails_fast_on_permanent_failure
+test_lock_wait_deadline_scales_with_request
+test_pause_probe_is_memoized_and_deferred
 test_reads_are_bounded_and_closed
 test_canonical_form_is_revision_stable
 test_writes_are_atomic_and_leave_no_residue

--- a/tests/fm-engineering-lib.test.sh
+++ b/tests/fm-engineering-lib.test.sh
@@ -101,6 +101,53 @@ test_credential_vocabulary_is_shared() {
   pass "fm_eng_credential_name_ere and fm_eng_credential_name_regex share one vocabulary"
 }
 
+test_credential_label_form_is_whole_token() {
+  local labels name
+  labels=$(fm_eng_credential_label_ere)
+  # The colon form has to accept a real credential label whatever vendor prefix or
+  # suffix surrounds the credential word.
+  for name in SERVICE_TOKEN X-Api-Key aws_access_key_id AWS_SECRET_ACCESS_KEY Password access-key api_key; do
+    printf '%s:x\n' "$name" | LC_ALL=C grep -Eq "^($labels):" \
+      || fail "the credential label vocabulary does not match $name: $labels"
+  done
+  # A credential word glued to a trailing run is an inert telemetry label, not a
+  # credential name, and must not become a colon-form introducer.
+  for name in tokens secrets passwords credentials keys tokenized; do
+    ! printf '%s:x\n' "$name" | LC_ALL=C grep -Eq "^($labels):" \
+      || fail "the credential label vocabulary matched the inert plural label $name"
+  done
+  pass "fm_eng_credential_label_ere matches whole credential labels, not inert plurals"
+}
+
+test_locks_are_liveness_safe() {
+  local dir="$TMP_ROOT/locks/alpha" other="$TMP_ROOT/locks/beta" status
+  fm_eng_lock_acquire "$dir" 5 "2026-08-02T00:00:00Z" || fail "a free lock must be acquirable"
+  [ -d "$dir" ] || fail "acquiring the lock did not create its directory"
+  grep -q "^pid=$$\$" "$dir/owner" || fail "the lock owner record does not identify this process"
+
+  set +e
+  ( fm_eng_lock_acquire "$dir" 5 "2026-08-02T00:00:00Z" )
+  status=$?
+  set -e
+  [ "$status" -ne 0 ] || fail "a lock held by a live owner must not be re-acquirable"
+
+  fm_eng_lock_acquire "$other" 5 "2026-08-02T00:00:00Z" || fail "an unrelated lock must stay acquirable"
+  fm_eng_lock_release "$dir"
+  [ ! -d "$dir" ] || fail "releasing the lock did not remove its directory"
+  [ -d "$other" ] || fail "releasing one lock must not release another"
+  fm_eng_lock_release_all
+  [ ! -d "$other" ] || fail "releasing all locks left one behind"
+
+  # An owner that is provably gone is reclaimed at once rather than waiting out
+  # the age window, so a crash cannot wedge the mutex.
+  mkdir -p "$dir"
+  printf 'host=%s\npid=%s\nstarted=%s\n' "${HOSTNAME:-$(hostname)}" 999999 "lstart:ThuJan100:00:001970" > "$dir/owner"
+  fm_eng_lock_acquire "$dir" 5 "2026-08-02T00:00:00Z" \
+    || fail "a lock whose owner is provably gone must be reclaimed"
+  fm_eng_lock_release_all
+  pass "fm_eng_lock_acquire serializes live owners and reclaims provably dead ones"
+}
+
 test_reads_are_bounded_and_closed() {
   local file="$TMP_ROOT/record.json" big value status
   printf '{"missionId":"mission-42"}\n' > "$file"
@@ -238,6 +285,8 @@ test_failures_are_typed_json() {
 test_identities_stay_privacy_safe
 test_credential_material_is_detected
 test_credential_vocabulary_is_shared
+test_credential_label_form_is_whole_token
+test_locks_are_liveness_safe
 test_reads_are_bounded_and_closed
 test_canonical_form_is_revision_stable
 test_writes_are_atomic_and_leave_no_residue

--- a/tests/fm-engineering-lib.test.sh
+++ b/tests/fm-engineering-lib.test.sh
@@ -247,10 +247,29 @@ test_lock_wait_deadline_scales_with_request() {
   fm_eng_lock_release_all
   # A budget that is actually enforced tracks the request instead of a fixed
   # multiple of it: a 6s wait must not finish inside a 1s wait's own ceiling.
+  # The requested interval is also a grace period the caller is owed in full, so a
+  # partly elapsed second of the whole-second clock must not cut it short.
+  [ "$short" -ge 1 ] || fail "a 1s contention bound gave up inside its own grace period"
   [ "$short" -le 3 ] || fail "a 1s contention bound took ${short}s"
-  [ "$long" -ge 5 ] || fail "a 6s contention bound gave up after ${long}s"
+  [ "$long" -ge 6 ] || fail "a 6s contention bound gave up after ${long}s"
   [ "$long" -le 9 ] || fail "a 6s contention bound ran ${long}s"
   pass "the contention bound tracks the requested seconds rather than a multiple of them"
+}
+
+test_lock_wait_default_bound_is_honoured() {
+  local held="$TMP_ROOT/default-deadline/lock" elapsed
+  fm_eng_lock_acquire "$held" 5 "2026-08-02T00:00:00Z" || fail "the default-wait fixture could not be set up"
+  elapsed=$(date +%s)
+  set +e
+  ( fm_eng_lock_acquire_wait "$held" 5 "2026-08-02T00:00:00Z" ) >/dev/null 2>&1
+  set -e
+  elapsed=$(( $(date +%s) - elapsed ))
+  fm_eng_lock_release_all
+  # The documented default is five seconds, and a caller that names no bound is
+  # owed the same grace period as one that does.
+  [ "$elapsed" -ge 5 ] || fail "the default contention bound gave up after ${elapsed}s"
+  [ "$elapsed" -le 8 ] || fail "the default contention bound ran ${elapsed}s"
+  pass "an unspecified contention bound honours the documented five-second default"
 }
 
 test_pause_probe_is_memoized_and_deferred() {
@@ -423,6 +442,7 @@ test_locks_are_liveness_safe
 test_locks_survive_paths_with_spaces
 test_lock_wait_fails_fast_on_permanent_failure
 test_lock_wait_deadline_scales_with_request
+test_lock_wait_default_bound_is_honoured
 test_pause_probe_is_memoized_and_deferred
 test_reads_are_bounded_and_closed
 test_canonical_form_is_revision_stable

--- a/tests/fm-engineering-lib.test.sh
+++ b/tests/fm-engineering-lib.test.sh
@@ -1,0 +1,203 @@
+#!/usr/bin/env bash
+# Behavior tests for bin/fm-engineering-lib.sh, the shared validation and
+# storage helpers every Engineering surface (fm-mission.sh, fm-report.sh,
+# fm-shapeup-client.sh, fm-captains-log-projection.sh) depends on. The suite
+# surfaces exercise these through their own contracts; this file pins the
+# helper boundaries themselves so a shared-helper change cannot quietly widen
+# identity, credential, confinement, or size limits under all four of them.
+set -u
+
+# shellcheck source=tests/lib.sh
+# shellcheck disable=SC1091
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+command -v jq >/dev/null 2>&1 || { echo "skip: jq not found"; exit 0; }
+
+# shellcheck source=bin/fm-engineering-lib.sh
+# shellcheck disable=SC1091
+. "$ROOT/bin/fm-engineering-lib.sh"
+
+TMP_ROOT=$(fm_test_tmproot fm-engineering-lib)
+# Every suite materializes its own subdirectories under the temp root before
+# using it; this one writes directly into the root, so create it explicitly.
+mkdir -p "$TMP_ROOT"
+
+test_identities_stay_privacy_safe() {
+  local value
+  for value in mission-42 task_9 build.8 A-b_c.9; do
+    fm_eng_valid_identity "$value" || fail "'$value' should be a valid identity"
+  done
+  # Empty, whitespace, path traversal, shell metacharacters, and prose all carry
+  # content that must never reach a record path or a hold identity. These stay
+  # refused in every locale. Non-ASCII letters do not: the pattern's A-Za-z
+  # ranges are collation-based, so 'ünïcode' is refused under LC_ALL=C and
+  # accepted under a UTF-8 locale. Asserting either way here would pin a
+  # locale, so this suite covers only the locale-stable boundary.
+  # shellcheck disable=SC2016  # Literal command substitution is inert identity test data.
+  for value in '' ' ' 'mission 42' '../escape' 'mission/42' 'mission;rm' 'mission$(id)' 'mission*'; do
+    ! fm_eng_valid_identity "$value" || fail "'$value' should be refused as an identity"
+  done
+  fm_eng_valid_identity "$(head -c 128 /dev/zero | tr '\0' 'a')" \
+    || fail "a 128-character identity is within the bound"
+  ! fm_eng_valid_identity "$(head -c 129 /dev/zero | tr '\0' 'a')" \
+    || fail "a 129-character identity exceeds the bound"
+  pass "fm_eng_valid_identity accepts only bounded privacy-safe slugs"
+}
+
+test_credential_material_is_detected() {
+  local case
+  for case in \
+    '{"token":"anything at all"}' \
+    '{"nested":{"apiSecret":"value"}}' \
+    '{"a":{"b":[{"Password":"hunter2"}]}}' \
+    '{"note":"pushed with ghp_AAAAAAAAAAAAAAAAAAAA today"}' \
+    '{"header":"Bearer abc.def"}' \
+    '{"key":"-----BEGIN RSA PRIVATE KEY-----"}'
+  do
+    fm_eng_contains_credentials "$case" || fail "credential material was not detected: $case"
+  done
+  # Benign records must survive, including non-string values under names that
+  # merely read like credentials and prose that only mentions the words.
+  for case in \
+    '{"summary":"The suite passed."}' \
+    '{"tokenCount":42,"secretsScanned":true,"credentials":null}' \
+    '{"judgment":"We removed the password prompt from the flow."}' \
+    '{"reference":{"value":"https://example.test/report.json"}}'
+  do
+    ! fm_eng_contains_credentials "$case" || fail "benign record was rejected as credential material: $case"
+  done
+  pass "fm_eng_contains_credentials keys on credential-shaped names and values only"
+}
+
+test_reads_are_bounded_and_closed() {
+  local file="$TMP_ROOT/record.json" big value status
+  printf '{"missionId":"mission-42"}\n' > "$file"
+  value=$(fm_eng_read_json "$file") || fail "a readable JSON object must be accepted"
+  printf '%s' "$value" | jq -e '.missionId == "mission-42"' >/dev/null \
+    || fail "the read record lost its content: $value"
+
+  set +e
+  fm_eng_read_json "$TMP_ROOT/absent.json" >/dev/null 2>&1
+  status=$?
+  set -e
+  [ "$status" -eq 1 ] || fail "a missing file must report status 1, got $status"
+
+  printf '[1,2,3]\n' > "$file"
+  set +e
+  fm_eng_read_json "$file" >/dev/null 2>&1
+  status=$?
+  set -e
+  [ "$status" -ne 0 ] || fail "a non-object document must be refused"
+
+  big=$(head -c 300000 /dev/zero | tr '\0' 'a')
+  set +e
+  printf '{"blob":"%s"}' "$big" | fm_eng_read_json - >/dev/null 2>&1
+  status=$?
+  set -e
+  [ "$status" -eq 2 ] || fail "an oversized record must report the distinct status 2, got $status"
+
+  set +e
+  printf '{"blob":"%s"}' "$big" | fm_eng_read_json - 500000 >/dev/null 2>&1
+  status=$?
+  set -e
+  [ "$status" -eq 0 ] || fail "an explicit larger bound must admit the same record, got $status"
+  pass "fm_eng_read_json admits only bounded JSON objects and types its refusals"
+}
+
+test_canonical_form_is_revision_stable() {
+  local a b
+  a=$(fm_eng_canonical '{"b":1,"a":{"d":2,"c":3}}')
+  b=$(fm_eng_canonical '{"a":{"c":3,"d":2},"b":1}')
+  [ "$a" = "$b" ] || fail "canonical form is not key-order stable: '$a' vs '$b'"
+  [ "$(printf '%s' "$a" | fm_eng_digest)" = "$(printf '%s' "$b" | fm_eng_digest)" ] \
+    || fail "reordered identical content produced different revisions"
+  [ "$(printf '%s' "$a" | fm_eng_digest)" != "$(fm_eng_canonical '{"b":2,"a":{"d":2,"c":3}}' | fm_eng_digest)" ] \
+    || fail "different content produced the same revision"
+  [ "${#a}" -gt 0 ] && [ "$(printf '%s' "$a" | fm_eng_digest | wc -c | tr -d '[:space:]')" = 65 ] \
+    || fail "revision digest is not a 64-character hex digest"
+  pass "fm_eng_canonical and fm_eng_digest give content-addressed revisions"
+}
+
+test_writes_are_atomic_and_leave_no_residue() {
+  local path="$TMP_ROOT/nested/deeper/record.json"
+  fm_eng_atomic_write "$path" '{"state":"accepted"}'
+  jq -e '.state == "accepted"' "$path" >/dev/null || fail "atomic write did not store the record"
+  [ "$(find "$TMP_ROOT/nested/deeper" -type f | wc -l | tr -d '[:space:]')" = 1 ] \
+    || fail "atomic write left a temporary file behind: $(find "$TMP_ROOT/nested/deeper" -type f)"
+  fm_eng_atomic_write "$path" '{"state":"superseded"}'
+  jq -e '.state == "superseded"' "$path" >/dev/null || fail "atomic rewrite did not replace the record"
+  pass "fm_eng_atomic_write creates its parent and replaces records without residue"
+}
+
+test_confinement_rejects_sibling_prefixes() {
+  fm_eng_relative_to /approved/root/file.txt /approved/root || fail "a file under the root must be allowed"
+  fm_eng_relative_to /approved/root /approved/root || fail "the root itself must be allowed"
+  # The classic prefix trap: /approved/root-evil shares a string prefix with
+  # /approved/root but is a different directory.
+  ! fm_eng_relative_to /approved/root-evil/file.txt /approved/root \
+    || fail "a sibling directory sharing the root's prefix must be refused"
+  ! fm_eng_relative_to /etc/hosts /approved/root || fail "an unrelated path must be refused"
+  pass "fm_eng_relative_to confines paths without falling for sibling prefixes"
+}
+
+test_correlation_envelope_is_closed() {
+  local envelope
+  envelope=$(jq -cn '{schemaVersion:"shapeup-correlation.v1",sourceRevision:"dispatch:r1",
+    capturedAt:"2026-08-01T12:00:00Z",identity:{kind:"command",id:"dispatch-42"},
+    shapeUp:{cycleRef:"cycle-13",buildRef:"build-8",buildRevision:"build-8:r7",scopeRef:null},
+    firstMate:{missionId:"mission-42",taskId:"task-42",crewmateId:"keiko",session:null}}')
+  fm_eng_validate_correlation "$envelope" mission-42 task-42 keiko \
+    || fail "the canonical correlation envelope must validate"
+
+  fm_eng_validate_correlation "$(printf '%s' "$envelope" | jq -c '
+    .firstMate.session={backend:"herdr",targetId:"fm-task-42",lifecycle:"running"}')" \
+    mission-42 task-42 keiko || fail "a closed session descriptor must validate"
+
+  local case
+  # Each case drifts exactly one thing that must not be tolerated.
+  for case in \
+    '.schemaVersion="shapeup-correlation.v2"' \
+    '.identity.kind="prose"' \
+    '.identity.id=""' \
+    '.shapeUp.cycleRef=""' \
+    '.shapeUp.buildRef=null' \
+    '.firstMate.session={backend:"screen",targetId:"x",lifecycle:"running"}' \
+    '.firstMate.session={backend:"herdr",targetId:"x",lifecycle:"thinking"}' \
+    '.firstMate.session={backend:"herdr",targetId:"x",lifecycle:"running",command:"claude --dangerously"}'
+  do
+    ! fm_eng_validate_correlation "$(printf '%s' "$envelope" | jq -c "$case")" mission-42 task-42 keiko \
+      || fail "correlation drift was tolerated: $case"
+  done
+
+  ! fm_eng_validate_correlation "$envelope" mission-43 task-42 keiko \
+    || fail "a mission identity mismatch must be refused"
+  ! fm_eng_validate_correlation "$envelope" mission-42 task-43 keiko \
+    || fail "a task identity mismatch must be refused"
+  ! fm_eng_validate_correlation "$envelope" mission-42 task-42 hoshi \
+    || fail "a crewmate identity mismatch must be refused"
+  pass "fm_eng_validate_correlation keeps the envelope closed and identity-bound"
+}
+
+test_failures_are_typed_json() {
+  local out
+  out=$(fm_eng_fail fm-engineering-report.v1 cross_build "Report correlation does not match the accepted Build")
+  printf '%s' "$out" | jq -e '
+    .accepted == false
+    and .schemaVersion == "fm-engineering-report.v1"
+    and .error.code == "cross_build"
+    and (. | has("report") | not)
+  ' >/dev/null || fail "typed failure shape is invalid: $out"
+  out=$(fm_eng_fail fm-engineering-report.v1 cross_build "message" '{"reportId":"report-1","status":"rejected"}')
+  printf '%s' "$out" | jq -e '.report.reportId == "report-1" and .report.status == "rejected"' >/dev/null \
+    || fail "a rejected record must ride along with its typed failure: $out"
+  pass "fm_eng_fail emits one typed JSON refusal, with the rejected record when given"
+}
+
+test_identities_stay_privacy_safe
+test_credential_material_is_detected
+test_reads_are_bounded_and_closed
+test_canonical_form_is_revision_stable
+test_writes_are_atomic_and_leave_no_residue
+test_confinement_rejects_sibling_prefixes
+test_correlation_envelope_is_closed
+test_failures_are_typed_json

--- a/tests/fm-engineering-lib.test.sh
+++ b/tests/fm-engineering-lib.test.sh
@@ -106,17 +106,41 @@ test_credential_label_form_is_whole_token() {
   labels=$(fm_eng_credential_label_ere)
   # The colon form has to accept a real credential label whatever vendor prefix or
   # suffix surrounds the credential word.
-  for name in SERVICE_TOKEN X-Api-Key aws_access_key_id AWS_SECRET_ACCESS_KEY Password access-key api_key; do
+  # The colon form has to accept a real credential label whatever vendor prefix or
+  # suffix surrounds the credential word, including a glued lowercase prefix of the
+  # kind YAML, .env, and config dumps echo.
+  for name in SERVICE_TOKEN X-Api-Key aws_access_key_id AWS_SECRET_ACCESS_KEY Password access-key api_key \
+    apitoken dbpassword myapikey clientsecret; do
     printf '%s:x\n' "$name" | LC_ALL=C grep -Eq "^($labels):" \
       || fail "the credential label vocabulary does not match $name: $labels"
   done
   # A credential word glued to a trailing run is an inert telemetry label, not a
   # credential name, and must not become a colon-form introducer.
-  for name in tokens secrets passwords credentials keys tokenized; do
+  for name in tokens secrets passwords credentials keys tokenized secretive; do
     ! printf '%s:x\n' "$name" | LC_ALL=C grep -Eq "^($labels):" \
       || fail "the credential label vocabulary matched the inert plural label $name"
   done
   pass "fm_eng_credential_label_ere matches whole credential labels, not inert plurals"
+}
+
+test_credential_label_anchor_admits_delimiters() {
+  local anchor labels
+  anchor=$(fm_eng_credential_label_anchor)
+  labels=$(fm_eng_credential_label_ere)
+  # A pane echoing JSON or a config fragment quotes and brackets its labels, so the
+  # boundary has to admit those delimiters rather than only whitespace.
+  local case quotes='["'"'"']*'
+  for case in '{"api_key": "x"}' " \"password\": \"x\"" '[access-key: x]' '(dbpassword: x)'; do
+    printf '%s\n' "$case" | LC_ALL=C grep -Eq "(^|$anchor)($labels$quotes)[[:space:]]*:" \
+      || fail "the label boundary does not admit the delimiter in: $case"
+  done
+  # The boundary must not turn an inert plural into a label just because a
+  # delimiter sits in front of it.
+  for case in '{"tokens": 4821}' '(secrets: none)'; do
+    ! printf '%s\n' "$case" | LC_ALL=C grep -Eq "(^|$anchor)($labels$quotes)[[:space:]]*:" \
+      || fail "the label boundary admitted an inert plural in: $case"
+  done
+  pass "fm_eng_credential_label_anchor admits quoted and bracketed credential labels"
 }
 
 test_locks_are_liveness_safe() {
@@ -146,6 +170,62 @@ test_locks_are_liveness_safe() {
     || fail "a lock whose owner is provably gone must be reclaimed"
   fm_eng_lock_release_all
   pass "fm_eng_lock_acquire serializes live owners and reclaims provably dead ones"
+}
+
+test_locks_survive_paths_with_spaces() {
+  local base="$TMP_ROOT/My Locks/state" one two
+  one="$base/first lock"
+  two="$base/second lock"
+  mkdir -p "$base"
+  # A home whose path contains a space must still release the directory it holds,
+  # or every run leaks one lock per identity under state/.
+  fm_eng_lock_acquire "$one" 5 "2026-08-02T00:00:00Z" || fail "a spaced lock path must be acquirable"
+  fm_eng_lock_release_all
+  [ ! -d "$one" ] || fail "release_all left a lock whose path contains a space behind"
+
+  fm_eng_lock_acquire "$one" 5 "2026-08-02T00:00:00Z" || fail "a spaced lock path must be re-acquirable"
+  fm_eng_lock_acquire "$two" 5 "2026-08-02T00:00:00Z" || fail "a second spaced lock path must be acquirable"
+  fm_eng_lock_release "$one"
+  [ ! -d "$one" ] || fail "release did not remove the spaced lock it was given"
+  [ -d "$two" ] || fail "releasing one spaced lock must not release another"
+  fm_eng_lock_release_all
+  [ ! -d "$two" ] || fail "release_all left a second spaced lock behind"
+  pass "held-lock bookkeeping releases every lock whose path contains a space"
+}
+
+test_lock_wait_fails_fast_on_permanent_failure() {
+  local sealed="$TMP_ROOT/sealed" status started elapsed
+  if [ "$(id -u)" -eq 0 ]; then
+    echo "skip: permanent lock-failure coverage needs a non-root user"
+    return 0
+  fi
+  mkdir -p "$sealed"
+  chmod 500 "$sealed"
+  # A store that can never hold the lock is not contention, so the wait must refuse
+  # at once instead of burning its whole bound on a condition that cannot change.
+  started=$(date +%s)
+  set +e
+  fm_eng_lock_acquire_wait "$sealed/nested/lock" 5 "2026-08-02T00:00:00Z" 5
+  status=$?
+  set -e
+  elapsed=$(( $(date +%s) - started ))
+  chmod 700 "$sealed"
+  [ "$status" -ne 0 ] || fail "an un-creatable lock parent must not report success"
+  [ "$elapsed" -le 2 ] || fail "a permanent lock failure waited ${elapsed}s instead of refusing at once"
+
+  local contended="$TMP_ROOT/contended/lock"
+  fm_eng_lock_acquire "$contended" 5 "2026-08-02T00:00:00Z" || fail "the contention fixture could not be set up"
+  started=$(date +%s)
+  set +e
+  ( fm_eng_lock_acquire_wait "$contended" 5 "2026-08-02T00:00:00Z" 2 )
+  status=$?
+  set -e
+  elapsed=$(( $(date +%s) - started ))
+  fm_eng_lock_release_all
+  [ "$status" -ne 0 ] || fail "a lock held by a live owner must not be handed to a waiter"
+  [ "$elapsed" -ge 1 ] || fail "contention must actually be waited out, not refused at once"
+  [ "$elapsed" -le 6 ] || fail "the contention wait ran ${elapsed}s past its 2s bound"
+  pass "fm_eng_lock_acquire_wait waits out contention and refuses a permanent failure at once"
 }
 
 test_reads_are_bounded_and_closed() {
@@ -286,7 +366,10 @@ test_identities_stay_privacy_safe
 test_credential_material_is_detected
 test_credential_vocabulary_is_shared
 test_credential_label_form_is_whole_token
+test_credential_label_anchor_admits_delimiters
 test_locks_are_liveness_safe
+test_locks_survive_paths_with_spaces
+test_lock_wait_fails_fast_on_permanent_failure
 test_reads_are_bounded_and_closed
 test_canonical_form_is_revision_stable
 test_writes_are_atomic_and_leave_no_residue

--- a/tests/fm-engineering-lib.test.sh
+++ b/tests/fm-engineering-lib.test.sh
@@ -52,7 +52,14 @@ test_credential_material_is_detected() {
     '{"a":{"b":[{"Password":"hunter2"}]}}' \
     '{"note":"pushed with ghp_AAAAAAAAAAAAAAAAAAAA today"}' \
     '{"header":"Bearer abc.def"}' \
-    '{"key":"-----BEGIN RSA PRIVATE KEY-----"}'
+    '{"key":"-----BEGIN RSA PRIVATE KEY-----"}' \
+    '{"awsAccessKeyId":"AKIAEXAMPLEONLY"}' \
+    '{"apiKey":"value"}' \
+    '{"api_key":"value"}' \
+    '{"passwd":"value"}' \
+    '{"privateKey":"value"}' \
+    '{"summary":"the run exported SERVICE_TOKEN=fm_fake_value before failing"}' \
+    '{"summary":"the run exported api_key=fm_fake_value before failing"}'
   do
     fm_eng_contains_credentials "$case" || fail "credential material was not detected: $case"
   done
@@ -62,11 +69,36 @@ test_credential_material_is_detected() {
     '{"summary":"The suite passed."}' \
     '{"tokenCount":42,"secretsScanned":true,"credentials":null}' \
     '{"judgment":"We removed the password prompt from the flow."}' \
-    '{"reference":{"value":"https://example.test/report.json"}}'
+    '{"reference":{"value":"https://example.test/report.json"}}' \
+    '{"judgment":"Total tokens: 4821 in this run, so we split the Scope."}' \
+    '{"judgment":"We rotated the API key: ops will hand over the new one."}'
   do
     ! fm_eng_contains_credentials "$case" || fail "benign record was rejected as credential material: $case"
   done
   pass "fm_eng_contains_credentials keys on credential-shaped names and values only"
+}
+
+test_credential_vocabulary_is_shared() {
+  local ere regex name
+  ere=$(fm_eng_credential_name_ere)
+  regex=$(fm_eng_credential_name_regex)
+  # One vocabulary owns both forms, so pane redaction and record scanning cannot
+  # drift apart on which names carry secrets.
+  for name in token secret password passwd credential api key access private; do
+    case "$regex" in
+      *"$name"*) ;;
+      *) fail "the jq credential vocabulary lost $name: $regex" ;;
+    esac
+  done
+  for name in SERVICE_TOKEN aws_secret_access_key API-KEY passwd MyPassword; do
+    printf '%s=x\n' "$name" | LC_ALL=C grep -Eq "^($ere)=" \
+      || fail "the ERE credential vocabulary does not match $name: $ere"
+  done
+  for name in Authorization progress lifecycle; do
+    ! printf '%s=x\n' "$name" | LC_ALL=C grep -Eq "^($ere)=" \
+      || fail "the ERE credential vocabulary matched the benign name $name"
+  done
+  pass "fm_eng_credential_name_ere and fm_eng_credential_name_regex share one vocabulary"
 }
 
 test_reads_are_bounded_and_closed() {
@@ -126,7 +158,17 @@ test_writes_are_atomic_and_leave_no_residue() {
     || fail "atomic write left a temporary file behind: $(find "$TMP_ROOT/nested/deeper" -type f)"
   fm_eng_atomic_write "$path" '{"state":"superseded"}'
   jq -e '.state == "superseded"' "$path" >/dev/null || fail "atomic rewrite did not replace the record"
-  pass "fm_eng_atomic_write creates its parent and replaces records without residue"
+  # A store that cannot accept the record must say so: every caller publishes an
+  # outcome only after this returns success.
+  local status
+  set +e
+  fm_eng_atomic_write "$path/child.json" '{"state":"accepted"}' 2>/dev/null
+  status=$?
+  set -e
+  [ "$status" -ne 0 ] || fail "a write that cannot land must report failure"
+  [ "$(find "$TMP_ROOT/nested/deeper" -type f | wc -l | tr -d '[:space:]')" = 1 ] \
+    || fail "a failed atomic write left residue behind: $(find "$TMP_ROOT/nested/deeper" -type f)"
+  pass "fm_eng_atomic_write creates its parent, replaces records, and types its failures"
 }
 
 test_confinement_rejects_sibling_prefixes() {
@@ -195,6 +237,7 @@ test_failures_are_typed_json() {
 
 test_identities_stay_privacy_safe
 test_credential_material_is_detected
+test_credential_vocabulary_is_shared
 test_reads_are_bounded_and_closed
 test_canonical_form_is_revision_stable
 test_writes_are_atomic_and_leave_no_residue

--- a/tests/fm-mission-shapeup.test.sh
+++ b/tests/fm-mission-shapeup.test.sh
@@ -64,3 +64,34 @@ set -e
 printf '%s' "$secret" | jq -e '.error.code == "credential_material"' >/dev/null \
   || fail "credential rejection must be typed: $secret"
 pass "mission data rejects credential material"
+
+# A state change stores an identity, so free-form prose must never reach the
+# durable mission record the projection republishes verbatim.
+mission_path="$HOME_DIR/data/engineering/missions/mission-42.json"
+for bad in 'customer@example.test wants this dropped' '' 'mission 43' '../escape'; do
+  set +e
+  refused=$(FM_HOME="$HOME_DIR" "$MISSION" supersede mission-42 --replacement "$bad" 2>/dev/null)
+  status=$?
+  set -e
+  [ "$status" -ne 0 ] || fail "supersede must refuse the non-identity replacement '$bad'"
+  printf '%s' "$refused" | jq -e '.accepted == false and .error.code == "malformed_identity"' >/dev/null \
+    || fail "a non-identity replacement must be typed: $refused"
+done
+jq -e '.state == "accepted" and (has("replacementMissionId") | not)' "$mission_path" >/dev/null \
+  || fail "a refused state change must not touch the durable mission record"
+
+for bad in 'ask ops which decision' 'decision;rm -rf'; do
+  set +e
+  refused=$(FM_HOME="$HOME_DIR" "$MISSION" defer mission-42 --decision-id "$bad" --build-revision "build-8:r7" 2>/dev/null)
+  status=$?
+  set -e
+  [ "$status" -ne 0 ] || fail "defer must refuse the non-identity decision '$bad'"
+  printf '%s' "$refused" | jq -e '.accepted == false and .error.code == "malformed_identity"' >/dev/null \
+    || fail "a non-identity deferring decision must be typed: $refused"
+done
+
+superseded=$(FM_HOME="$HOME_DIR" "$MISSION" supersede mission-42 --replacement mission-43)
+printf '%s' "$superseded" | jq -e '
+  .accepted == true and .mission.state == "superseded" and .mission.replacementMissionId == "mission-43"
+' >/dev/null || fail "a privacy-safe replacement identity must still be accepted: $superseded"
+pass "mission state changes only store privacy-safe identities"

--- a/tests/fm-mission-shapeup.test.sh
+++ b/tests/fm-mission-shapeup.test.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Behavior tests for Engineering mission acceptance and correlation binding.
+set -u
+
+# shellcheck source=tests/lib.sh
+# shellcheck disable=SC1091
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+MISSION="$ROOT/bin/fm-mission.sh"
+TMP_ROOT=$(fm_test_tmproot fm-mission-shapeup)
+HOME_DIR="$TMP_ROOT/home"
+mkdir -p "$HOME_DIR/data" "$HOME_DIR/state" "$HOME_DIR/config" "$HOME_DIR/projects/task-42"
+
+command -v jq >/dev/null 2>&1 || { echo "skip: jq not found"; exit 0; }
+
+mission_file="$TMP_ROOT/mission.json"
+jq -n --arg root "$HOME_DIR/projects/task-42" '{
+  schemaVersion:"fm-engineering-mission.v1",
+  missionId:"mission-42",
+  taskId:"task-42",
+  crewmateId:"keiko",
+  acceptedBuildRevision:"build-8:r7",
+  evidenceRequirements:["automated-tests"],
+  allowedEvidenceRoots:[$root],
+  correlation:{
+    schemaVersion:"shapeup-correlation.v1",
+    sourceRevision:"dispatch:r1",
+    capturedAt:"2026-08-01T12:00:00Z",
+    identity:{kind:"command",id:"dispatch-42"},
+    shapeUp:{cycleRef:"cycle-13",buildRef:"build-8",buildRevision:"build-8:r7",scopeRef:null},
+    firstMate:{missionId:"mission-42",taskId:"task-42",crewmateId:"keiko",session:null}
+  }
+}' > "$mission_file"
+
+accepted=$(FM_HOME="$HOME_DIR" FM_ENGINEERING_NOW="2026-08-01T12:01:00Z" "$MISSION" accept "$mission_file")
+printf '%s' "$accepted" | jq -e '
+  .accepted == true
+  and .mission.state == "accepted"
+  and .mission.reporting.establishInitialScopes == true
+  and .mission.reporting.continueUntilTerminal == true
+  and (.mission.sourceRevision | length == 64)
+' >/dev/null || fail "mission acceptance contract is invalid: $accepted"
+
+replayed=$(FM_HOME="$HOME_DIR" "$MISSION" accept "$mission_file")
+printf '%s' "$replayed" | jq -e '.accepted == true and .replayed == true' >/dev/null \
+  || fail "exact mission replay must return the original mission"
+pass "Engineering missions bind correlation and continuous reporting instructions"
+
+set +e
+conflict=$(jq '.correlation.shapeUp.buildRef="build-9"' "$mission_file" | FM_HOME="$HOME_DIR" "$MISSION" accept -)
+status=$?
+set -e
+[ "$status" -ne 0 ] || fail "mission identity drift must fail"
+printf '%s' "$conflict" | jq -e '.error.code == "identity_conflict"' >/dev/null \
+  || fail "mission drift must return identity_conflict: $conflict"
+pass "mission identity reuse cannot drift across Builds"
+
+set +e
+secret=$(jq '.shapeUpToken="ghp_not_allowed" | .missionId="mission-secret" | .correlation.firstMate.missionId="mission-secret"' "$mission_file" |
+  FM_HOME="$HOME_DIR" "$MISSION" accept -)
+status=$?
+set -e
+[ "$status" -ne 0 ] || fail "credentials in mission data must fail"
+printf '%s' "$secret" | jq -e '.error.code == "credential_material"' >/dev/null \
+  || fail "credential rejection must be typed: $secret"
+pass "mission data rejects credential material"

--- a/tests/fm-peek.test.sh
+++ b/tests/fm-peek.test.sh
@@ -289,6 +289,34 @@ case "$(printf '%s' "$glued" | jq -r '.capture.text')" in
 esac
 pass "glued credential labels, short values, and quoted labels are all redacted"
 
+# Redacting one row must not cost the row above it its own event. A pane-wide inert
+# row followed by a credential-looking row is two events, whether the operand is a
+# short inert word or a genuine secret, because neither redaction depends on the
+# speculative stitch between them.
+BOUNDARY_CAPTURE="$TMP_ROOT/boundary-capture.txt"
+: > "$BOUNDARY_CAPTURE"
+pane_row "$BOUNDARY_CAPTURE" 39 'checking configuration values and other'
+pane_row "$BOUNDARY_CAPTURE" 15 'password: unset'
+boundary=$(peek_capture "$BOUNDARY_CAPTURE" 20)
+printf '%s' "$boundary" | jq -e '
+  .available == true
+  and .capture.text == "checking configuration values and other\npassword: [REDACTED]"
+' >/dev/null || fail "a short line-final operand must not merge the inert row above it: $boundary"
+
+SECRET_BOUNDARY_CAPTURE="$TMP_ROOT/boundary-secret-capture.txt"
+: > "$SECRET_BOUNDARY_CAPTURE"
+BOUNDARY_SECRET='fm_fake_realsecret1'
+pane_row "$SECRET_BOUNDARY_CAPTURE" 39 'checking configuration values and other'
+pane_row "$SECRET_BOUNDARY_CAPTURE" 29 "password: $BOUNDARY_SECRET"
+secret_boundary=$(peek_capture "$SECRET_BOUNDARY_CAPTURE" 20)
+secret_boundary_inspection=$(inspect_capture "$SECRET_BOUNDARY_CAPTURE" 20)
+printf '%s' "$secret_boundary" | jq -e '
+  .capture.text == "checking configuration values and other\npassword: [REDACTED]"
+' >/dev/null || fail "a genuine secret must be redacted in place without merging its neighbour: $secret_boundary"
+refute_fragments "machine peek" "$secret_boundary" "$BOUNDARY_SECRET"
+refute_fragments "session inspection" "$secret_boundary_inspection" "$BOUNDARY_SECRET"
+pass "redacting one row keeps the unrelated pane-wide row above it on its own line"
+
 # A two-column glyph makes a row occupy the whole pane while counting fewer
 # codepoints than a plain row beside it, so the wrap must not be recognized by
 # a measured width that a wide glyph can hide.

--- a/tests/fm-peek.test.sh
+++ b/tests/fm-peek.test.sh
@@ -251,6 +251,44 @@ for secret in "$HEADER_VALUE" "$PREFIXED_VALUE" "$SUFFIXED_VALUE" "$BARE_VALUE";
 done
 pass "colon-separated credential headers are redacted whatever surrounds the credential word"
 
+# A credential label is often a glued lowercase key, its value is sometimes short,
+# and a pane echoing JSON or a config fragment quotes both. None of those may
+# escape the colon form, and a value that does not end its line must still be
+# caught when it is long enough to be a secret on its own.
+GLUED_CAPTURE="$TMP_ROOT/glued-colon-capture.txt"
+: > "$GLUED_CAPTURE"
+GLUED_TOKEN_VALUE='fm_fake_glued123'
+GLUED_PASSWORD_VALUE='fm_fake_glued456'
+SHORT_VALUE='hunt3'
+QUOTED_VALUE='sk_fm_fake_quoted1'
+QUOTED_SECRET_VALUE='fm_fake_quoted2'
+MIDLINE_VALUE='fm_fake_mid1'
+# Widths ascend so only the last row can be pane-wide.
+pane_row "$GLUED_CAPTURE" 15 "Password: $SHORT_VALUE"
+pane_row "$GLUED_CAPTURE" 26 "apitoken: $GLUED_TOKEN_VALUE"
+pane_row "$GLUED_CAPTURE" 28 "dbpassword: $GLUED_PASSWORD_VALUE"
+pane_row "$GLUED_CAPTURE" 31 "api_key: $MIDLINE_VALUE (rotated)"
+pane_row "$GLUED_CAPTURE" 33 "{\"api_key\": \"$QUOTED_VALUE\"}"
+pane_row "$GLUED_CAPTURE" 35 "  \"clientsecret\": \"$QUOTED_SECRET_VALUE\""
+glued=$(peek_capture "$GLUED_CAPTURE" 20)
+glued_inspection=$(inspect_capture "$GLUED_CAPTURE" 20)
+printf '%s' "$glued" | jq -e '
+  .available == true
+  and (.capture.text | contains("Password: [REDACTED]"))
+  and (.capture.text | contains("apitoken: [REDACTED]"))
+  and (.capture.text | contains("dbpassword: [REDACTED]"))
+  and (.capture.text | contains("api_key: [REDACTED]"))
+  and (.capture.text | contains("clientsecret\": [REDACTED]"))
+' >/dev/null || fail "glued, short, quoted, and mid-line colon secrets must all be redacted: $glued"
+for secret in "$GLUED_TOKEN_VALUE" "$GLUED_PASSWORD_VALUE" "$QUOTED_VALUE" "$QUOTED_SECRET_VALUE" "$MIDLINE_VALUE"; do
+  refute_fragments "machine peek" "$glued" "$secret"
+  refute_fragments "session inspection" "$glued_inspection" "$secret"
+done
+case "$(printf '%s' "$glued" | jq -r '.capture.text')" in
+  *"$SHORT_VALUE"*) fail "a short colon-form secret was released in the clear: $glued" ;;
+esac
+pass "glued credential labels, short values, and quoted labels are all redacted"
+
 # A two-column glyph makes a row occupy the whole pane while counting fewer
 # codepoints than a plain row beside it, so the wrap must not be recognized by
 # a measured width that a wide glyph can hide.

--- a/tests/fm-peek.test.sh
+++ b/tests/fm-peek.test.sh
@@ -317,6 +317,40 @@ refute_fragments "machine peek" "$secret_boundary" "$BOUNDARY_SECRET"
 refute_fragments "session inspection" "$secret_boundary_inspection" "$BOUNDARY_SECRET"
 pass "redacting one row keeps the unrelated pane-wide row above it on its own line"
 
+# The joined and per-row candidates can disagree because the per-row pass saw a
+# credential the rejoined line hides, not only the other way round. Whichever
+# candidate is published must never expose a value the other masked, so the same
+# rows must redact in either order.
+CANDIDATE_SECRET='hunt3'
+candidate_capture() {  # <file> <credential-row-position>
+  : > "$1"
+  if [ "$2" = middle ]; then
+    pane_row "$1" 39 'checking configuration values and other'
+    pane_row "$1" 39 "step 4 of 9 note now    password: $CANDIDATE_SECRET"
+    pane_row "$1" 18 ' more context here'
+  else
+    pane_row "$1" 39 'checking configuration values and other'
+    pane_row "$1" 18 ' more context here'
+    pane_row "$1" 39 "step 4 of 9 note now    password: $CANDIDATE_SECRET"
+  fi
+}
+
+for position in middle last; do
+  CANDIDATE_CAPTURE="$TMP_ROOT/candidate-$position-capture.txt"
+  candidate_capture "$CANDIDATE_CAPTURE" "$position"
+  candidate=$(peek_capture "$CANDIDATE_CAPTURE" 20)
+  candidate_inspection=$(inspect_capture "$CANDIDATE_CAPTURE" 20)
+  printf '%s' "$candidate" | jq -e '
+    .available == true and (.capture.text | contains("password: [REDACTED]"))
+  ' >/dev/null || fail "a short operand must be redacted with the credential row $position: $candidate"
+  case "$(printf '%s' "$candidate" | jq -r '.capture.text')" in
+    *"$CANDIDATE_SECRET"*) fail "the published candidate released a value the other candidate masked: $candidate" ;;
+  esac
+  refute_fragments "machine peek" "$candidate" "$CANDIDATE_SECRET"
+  refute_fragments "session inspection" "$candidate_inspection" "$CANDIDATE_SECRET"
+done
+pass "a value either candidate masks is never released by the one that gets published"
+
 # A two-column glyph makes a row occupy the whole pane while counting fewer
 # codepoints than a plain row beside it, so the wrap must not be recognized by
 # a measured width that a wide glyph can hide.

--- a/tests/fm-peek.test.sh
+++ b/tests/fm-peek.test.sh
@@ -205,6 +205,52 @@ for secret in "$ASSIGN_VALUE" "$COLON_VALUE" "$GH_WRAP_VALUE" "$PASSWD_VALUE" "$
 done
 pass "a credential wrapped straight after its assignment separator is redacted, not released"
 
+# A colon is also ordinary prose punctuation. Inert telemetry that merely mentions
+# a credential word must keep its own line and its own value: a pane-wide inert
+# label must not be read as a dangling introducer that stitches away the next
+# row's event, and a short prose operand must not be mistaken for a secret.
+INERT_CAPTURE="$TMP_ROOT/inert-colon-capture.txt"
+: > "$INERT_CAPTURE"
+pane_row "$INERT_CAPTURE" 40 'ok 12 usage summary for this run tokens:'
+pane_row "$INERT_CAPTURE" 38 'ok 13 unrelated assertion on next line'
+pane_row "$INERT_CAPTURE" 30 'Total tokens: 4821 in this run'
+pane_row "$INERT_CAPTURE" 37 'Retrieved access-key: none configured'
+pane_row "$INERT_CAPTURE" 36 'Password: not required for this step'
+inert=$(peek_capture "$INERT_CAPTURE" 20)
+printf '%s' "$inert" | jq -e '
+  .available == true
+  and .capture.text == "ok 12 usage summary for this run tokens:\nok 13 unrelated assertion on next line\nTotal tokens: 4821 in this run\nRetrieved access-key: none configured\nPassword: not required for this step"
+' >/dev/null || fail "inert colon-separated telemetry must render unchanged and keep its row boundaries: $inert"
+pass "inert telemetry naming a credential word keeps its own line and its own value"
+
+# The colon form still has to catch a genuine credential header, including one
+# whose label carries a vendor prefix or suffix around the credential word.
+COLON_CAPTURE="$TMP_ROOT/colon-capture.txt"
+: > "$COLON_CAPTURE"
+HEADER_VALUE='fm_fake_12Cheader'
+PREFIXED_VALUE='fm_fake_13Cpref'
+SUFFIXED_VALUE='fm_fake_14Csuffi'
+BARE_VALUE='fm_fake_15Cbarepwd'
+# Widths ascend so only the last row can be pane-wide: every header here fits on
+# one row, and this case is about the rules rather than the wrap.
+pane_row "$COLON_CAPTURE" 28 "X-Api-Key: $HEADER_VALUE"
+pane_row "$COLON_CAPTURE" 28 "Password: $BARE_VALUE"
+pane_row "$COLON_CAPTURE" 37 "  aws_access_key_id: $SUFFIXED_VALUE"
+pane_row "$COLON_CAPTURE" 38 "AWS_SECRET_ACCESS_KEY: $PREFIXED_VALUE"
+colon=$(peek_capture "$COLON_CAPTURE" 20)
+colon_inspection=$(inspect_capture "$COLON_CAPTURE" 20)
+printf '%s' "$colon" | jq -e '
+  (.capture.text | contains("X-Api-Key: [REDACTED]"))
+  and (.capture.text | contains("AWS_SECRET_ACCESS_KEY: [REDACTED]"))
+  and (.capture.text | contains("aws_access_key_id: [REDACTED]"))
+  and (.capture.text | contains("Password: [REDACTED]"))
+' >/dev/null || fail "genuine colon-separated credential headers must stay redacted: $colon"
+for secret in "$HEADER_VALUE" "$PREFIXED_VALUE" "$SUFFIXED_VALUE" "$BARE_VALUE"; do
+  refute_fragments "machine peek" "$colon" "$secret"
+  refute_fragments "session inspection" "$colon_inspection" "$secret"
+done
+pass "colon-separated credential headers are redacted whatever surrounds the credential word"
+
 # A two-column glyph makes a row occupy the whole pane while counting fewer
 # codepoints than a plain row beside it, so the wrap must not be recognized by
 # a measured width that a wide glyph can hide.

--- a/tests/fm-peek.test.sh
+++ b/tests/fm-peek.test.sh
@@ -161,6 +161,50 @@ for secret in "$SPLIT_VALUE" "$BOUNDARY_VALUE" "$STRIPPED_VALUE" "$ONELINE_VALUE
 done
 pass "a credential wrapped at the pane width is redacted across the capture line boundary"
 
+# An assignment introducer is contiguous with its value, so a wrap right after
+# the `=` or `:` must rejoin with nothing between the rows. Reinserting a
+# separator there would leave the value on the far side of a space the value rule
+# cannot cross, releasing it in the clear.
+ASSIGN_CAPTURE="$TMP_ROOT/assign-capture.txt"
+: > "$ASSIGN_CAPTURE"
+ASSIGN_VALUE='fm_fake_31TassignWrappedValueQQQQQ'
+COLON_VALUE='fm_fake_44CcolonWrappedValueWWWWW'
+GH_WRAP_VALUE='fmfake55TokenWrappedAcrossTheRow'
+PASSWD_VALUE='fm_fake_66pwdvalue'
+AWS_KEY_VALUE='fm_fake_77akid'
+LOWER_KEY_VALUE='fm_fake_88lowercase'
+pane_row "$ASSIGN_CAPTURE" 12 'tests passed'
+pane_row "$ASSIGN_CAPTURE" 40 'deploy step 4 of 9        SERVICE_TOKEN='
+pane_row "$ASSIGN_CAPTURE" 34 "$ASSIGN_VALUE"
+pane_row "$ASSIGN_CAPTURE" 40 'deploy step 4 of 9            X-Api-Key:'
+pane_row "$ASSIGN_CAPTURE" 33 "$COLON_VALUE"
+pane_row "$ASSIGN_CAPTURE" 40 'deploy step 4 of 9                  ghp_'
+pane_row "$ASSIGN_CAPTURE" 32 "$GH_WRAP_VALUE"
+# The same credential vocabulary on rows the pane never wrapped.
+pane_row "$ASSIGN_CAPTURE" 25 "PASSWD=$PASSWD_VALUE"
+pane_row "$ASSIGN_CAPTURE" 32 "AWS_ACCESS_KEY_ID=$AWS_KEY_VALUE"
+pane_row "$ASSIGN_CAPTURE" 27 "api_key=$LOWER_KEY_VALUE"
+pane_row "$ASSIGN_CAPTURE" 27 'no lifecycle authority here'
+
+assigned=$(peek_capture "$ASSIGN_CAPTURE" 20)
+assigned_inspection=$(inspect_capture "$ASSIGN_CAPTURE" 20)
+printf '%s' "$assigned" | jq -e '
+  .available == true
+  and (.capture.text | contains("SERVICE_TOKEN=[REDACTED]"))
+  and (.capture.text | contains("X-Api-Key: [REDACTED]"))
+  and (.capture.text | contains("ghp_[REDACTED]"))
+  and (.capture.text | contains("PASSWD=[REDACTED]"))
+  and (.capture.text | contains("AWS_ACCESS_KEY_ID=[REDACTED]"))
+  and (.capture.text | contains("api_key=[REDACTED]"))
+  and (.capture.text | contains("tests passed"))
+  and (.capture.text | contains("no lifecycle authority here"))
+' >/dev/null || fail "assignment-shaped credentials must be redacted across the wrap: $assigned"
+for secret in "$ASSIGN_VALUE" "$COLON_VALUE" "$GH_WRAP_VALUE" "$PASSWD_VALUE" "$AWS_KEY_VALUE" "$LOWER_KEY_VALUE"; do
+  refute_fragments "machine peek" "$assigned" "$secret"
+  refute_fragments "session inspection" "$assigned_inspection" "$secret"
+done
+pass "a credential wrapped straight after its assignment separator is redacted, not released"
+
 # A two-column glyph makes a row occupy the whole pane while counting fewer
 # codepoints than a plain row beside it, so the wrap must not be recognized by
 # a measured width that a wide glyph can hide.

--- a/tests/fm-peek.test.sh
+++ b/tests/fm-peek.test.sh
@@ -1,0 +1,257 @@
+#!/usr/bin/env bash
+# Behavior tests for bounded read-only machine session inspection.
+set -u
+
+# shellcheck source=tests/lib.sh
+# shellcheck disable=SC1091
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+PEEK="$ROOT/bin/fm-peek.sh"
+PROJECTION="$ROOT/bin/fm-captains-log-projection.sh"
+MISSION="$ROOT/bin/fm-mission.sh"
+TMP_ROOT=$(fm_test_tmproot fm-peek-machine)
+HOME_DIR="$TMP_ROOT/home"
+mkdir -p "$HOME_DIR/data" "$HOME_DIR/state" "$HOME_DIR/config" "$HOME_DIR/projects/task-42"
+
+command -v jq >/dev/null 2>&1 || { echo "skip: jq not found"; exit 0; }
+
+fakebin=$(fm_fakebin "$HOME_DIR")
+DEFAULT_CAPTURE="$TMP_ROOT/default-capture.txt"
+printf 'tests passed\nBearer should-redact\nno lifecycle authority here\n' > "$DEFAULT_CAPTURE"
+# The fake honours the requested row count so a bounded window really is a
+# window: a capture that asks for fewer rows than the pane holds must not see
+# the rows above it unless fm-peek.sh deliberately reads further back.
+cat > "$fakebin/tmux" <<SH
+#!/usr/bin/env bash
+case "\${1:-}" in
+  list-windows) printf 'fm-task-42\n' ;;
+  display-message) printf '%%1\n' ;;
+  capture-pane)
+    rows=40
+    for arg in "\$@"; do
+      case "\$arg" in -[0-9]*) rows=\${arg#-} ;; esac
+    done
+    tail -n "\$rows" "\${FM_PEEK_TEST_CAPTURE:-$DEFAULT_CAPTURE}"
+    ;;
+esac
+SH
+chmod +x "$fakebin/tmux"
+
+fm_write_meta "$HOME_DIR/state/task-42.meta" \
+  "window=firstmate:fm-task-42" \
+  "worktree=$HOME_DIR/projects/task-42" \
+  "project=sample" \
+  "harness=codex" \
+  "kind=ship" \
+  "mode=ship"
+
+machine=$(PATH="$fakebin:$PATH" FM_HOME="$HOME_DIR" "$PEEK" --json task-42 20)
+printf '%s' "$machine" | jq -e '
+  .available == true
+  and .descriptor.backend == "tmux"
+  and .descriptor.taskId == "task-42"
+  and .descriptor.targetId == "firstmate:fm-task-42"
+  and .descriptor.lifecycle == "running"
+  and (.capture.text | contains("tests passed"))
+  and (.capture.text | contains("[REDACTED]"))
+  and (.descriptor | has("command") | not)
+' >/dev/null || fail "machine peek descriptor is invalid: $machine"
+pass "machine peek returns bounded redacted output with a closed descriptor"
+
+mission=$(jq -n --arg root "$HOME_DIR/projects/task-42" '{
+  schemaVersion:"fm-engineering-mission.v1",missionId:"mission-42",taskId:"task-42",crewmateId:"keiko",
+  acceptedBuildRevision:"build-8:r7",evidenceRequirements:[],allowedEvidenceRoots:[$root],
+  correlation:{schemaVersion:"shapeup-correlation.v1",sourceRevision:"dispatch:r1",capturedAt:"2026-08-01T12:00:00Z",
+    identity:{kind:"command",id:"dispatch-42"},shapeUp:{cycleRef:"cycle-13",buildRef:"build-8",buildRevision:"build-8:r7",scopeRef:null},
+    firstMate:{missionId:"mission-42",taskId:"task-42",crewmateId:"keiko",
+      session:{backend:"tmux",targetId:"firstmate:fm-task-42",lifecycle:"running"}}}
+}')
+accepted=$(printf '%s' "$mission" | FM_HOME="$HOME_DIR" "$MISSION" accept -)
+revision=$(printf '%s' "$accepted" | jq -r '.mission.sourceRevision')
+inspection=$(jq -n --arg revision "$revision" '{
+  schemaVersion:"fm-captains-log-projection.v1",operation:"inspectSession",
+  missionId:"mission-42",taskId:"task-42",expectedMissionRevision:$revision,lines:20
+}' | PATH="$fakebin:$PATH" FM_HOME="$HOME_DIR" "$PROJECTION")
+printf '%s' "$inspection" | jq -e '
+  .accepted == true
+  and .inspection.available == true
+  and .inspection.authoritative == false
+  and .inspection.mode == "bounded-read-only"
+' >/dev/null || fail "projection inspection is invalid: $inspection"
+pass "session inspection is optional, exact, and explicitly non-authoritative"
+
+# A pane inserts a real newline at its width, so a credential wider than the
+# pane arrives split across capture lines. The fixtures below are exact pane
+# geometry rather than folded text, because the shape of the wrap is what
+# decides the boundary: pane_row refuses a row that does not occupy the columns
+# it claims, so every wrap here stays the one a live endpoint produces.
+PANE_COLUMNS=40
+
+pane_row() {  # <file> <columns> <text>
+  # Display columns, not bytes: the fixtures pair each non-ASCII codepoint with
+  # a second column, which is what a pane gives a CJK or emoji glyph.
+  local file=$1 want=$2 text=$3 got
+  got=$(printf '%s' "$text" | LC_ALL=C awk '{
+    bytes = length($0); rest = $0
+    lead = gsub(/[\300-\377]/, "", rest); rest = $0
+    cont = gsub(/[\200-\277]/, "", rest)
+    print bytes - cont + lead
+  }')
+  [ "$got" = "$want" ] || fail "pane fixture row occupies $got columns, not $want: $text"
+  [ "$want" -le "$PANE_COLUMNS" ] || fail "pane fixture row is wider than the pane: $text"
+  printf '%s\n' "$text" >> "$file"
+}
+
+refute_fragments() {  # <label> <text> <secret>
+  local label=$1 text=$2 secret=$3 i window=8
+  for ((i = 0; i + window <= ${#secret}; i++)); do
+    case "$text" in
+      *"${secret:i:window}"*) fail "$label released a credential fragment across the wrap: ${secret:i:window}" ;;
+    esac
+  done
+}
+
+WRAP_CAPTURE="$TMP_ROOT/wrapped-capture.txt"
+: > "$WRAP_CAPTURE"
+SPLIT_VALUE='fm_fake_51QsecretPAYLOADabcdefghijklmnop'
+BOUNDARY_VALUE='fm_fake_92RwrappedAtIntroducerSpace'
+STRIPPED_VALUE='fm_fake_66StrippedSpaceValueZZZZZZZZZZZZYYYY'
+ONELINE_VALUE='fm_fake_unwrappedONELINE'
+pane_row "$WRAP_CAPTURE" 12 'tests passed'
+# The pane wrapped inside the value itself.
+pane_row "$WRAP_CAPTURE" 40 'Authorization: Bearer fm_fake_51QsecretP'
+pane_row "$WRAP_CAPTURE" 22 'AYLOADabcdefghijklmnop'
+# The pane wrapped on the space separating introducer from value, leaving that
+# space at the start of the next row.
+pane_row "$WRAP_CAPTURE" 40 'request auth note                 Bearer'
+pane_row "$WRAP_CAPTURE" 36 ' fm_fake_92RwrappedAtIntroducerSpace'
+# The same wrap, with the pane stripping the separating space off this row and
+# the value then running on across a second wrap.
+pane_row "$WRAP_CAPTURE" 39 'upload step 3 of 9 auth header   Bearer'
+pane_row "$WRAP_CAPTURE" 40 'fm_fake_66StrippedSpaceValueZZZZZZZZZZZZ'
+pane_row "$WRAP_CAPTURE" 4 'YYYY'
+# A credential that fits on one row, and inert output that must survive.
+pane_row "$WRAP_CAPTURE" 31 'Bearer fm_fake_unwrappedONELINE'
+pane_row "$WRAP_CAPTURE" 27 'no lifecycle authority here'
+
+peek_capture() {  # <capture-file> <lines>
+  FM_PEEK_TEST_CAPTURE="$1" PATH="$fakebin:$PATH" FM_HOME="$HOME_DIR" "$PEEK" --json task-42 "$2"
+}
+
+inspect_capture() {  # <capture-file> <lines>
+  jq -n --arg revision "$revision" --argjson lines "$2" '{
+    schemaVersion:"fm-captains-log-projection.v1",operation:"inspectSession",
+    missionId:"mission-42",taskId:"task-42",expectedMissionRevision:$revision,lines:$lines
+  }' | FM_PEEK_TEST_CAPTURE="$1" PATH="$fakebin:$PATH" FM_HOME="$HOME_DIR" "$PROJECTION"
+}
+
+wrapped=$(peek_capture "$WRAP_CAPTURE" 20)
+printf '%s' "$wrapped" | jq -e '
+  .available == true
+  and (.capture.text | contains("Bearer [REDACTED]"))
+  and (.capture.text | contains("tests passed"))
+  and (.capture.text | contains("no lifecycle authority here"))
+' >/dev/null || fail "a wrapped credential must still return redacted inert output: $wrapped"
+wrapped_inspection=$(inspect_capture "$WRAP_CAPTURE" 20)
+printf '%s' "$wrapped_inspection" | jq -e '.accepted == true and .inspection.available == true' >/dev/null \
+  || fail "session inspection must stay available for a wrapped capture: $wrapped_inspection"
+for secret in "$SPLIT_VALUE" "$BOUNDARY_VALUE" "$STRIPPED_VALUE" "$ONELINE_VALUE"; do
+  refute_fragments "machine peek" "$wrapped" "$secret"
+  refute_fragments "session inspection" "$wrapped_inspection" "$secret"
+done
+pass "a credential wrapped at the pane width is redacted across the capture line boundary"
+
+# A two-column glyph makes a row occupy the whole pane while counting fewer
+# codepoints than a plain row beside it, so the wrap must not be recognized by
+# a measured width that a wide glyph can hide.
+GLYPH_CAPTURE="$TMP_ROOT/glyph-capture.txt"
+: > "$GLYPH_CAPTURE"
+GLYPH_VALUE='fm_fake_77QwideGlyphAheadOfSecretXYZ012'
+pane_row "$GLYPH_CAPTURE" 40 '✅ Authorization: Bearer fm_fake_77Qwide'
+pane_row "$GLYPH_CAPTURE" 24 'GlyphAheadOfSecretXYZ012'
+pane_row "$GLYPH_CAPTURE" 22 '世界 progress 12 of 30'
+pane_row "$GLYPH_CAPTURE" 40 'plain ascii progress line that is long o'
+glyph=$(peek_capture "$GLYPH_CAPTURE" 20)
+glyph_inspection=$(inspect_capture "$GLYPH_CAPTURE" 20)
+printf '%s' "$glyph" | jq -e '
+  (.capture.text | contains("Bearer [REDACTED]"))
+  and (.capture.text | contains("世界 progress 12 of 30"))
+  and (.capture.text | contains("plain ascii progress line that is long o"))
+' >/dev/null || fail "a wide glyph must not hide the wrap or redact unrelated output: $glyph"
+refute_fragments "machine peek" "$glyph" "$GLYPH_VALUE"
+refute_fragments "session inspection" "$glyph_inspection" "$GLYPH_VALUE"
+pass "a credential wrapped behind a two-column glyph is redacted with the wrap"
+
+# Filling the pane is not the same as wrapping: two unrelated events must not
+# be handed to the machine consumer as one line.
+FIDELITY_CAPTURE="$TMP_ROOT/fidelity-capture.txt"
+: > "$FIDELITY_CAPTURE"
+pane_row "$FIDELITY_CAPTURE" 39 'ok 12 fixture rows rebuilt and verified'
+pane_row "$FIDELITY_CAPTURE" 38 'ok 13 unrelated assertion on next line'
+fidelity=$(peek_capture "$FIDELITY_CAPTURE" 20)
+printf '%s' "$fidelity" | jq -e '
+  .capture.text == "ok 12 fixture rows rebuilt and verified\nok 13 unrelated assertion on next line"
+' >/dev/null || fail "an exactly full-width unrelated row must keep its own line: $fidelity"
+pass "capture rows that merely fill the pane keep their own event boundary"
+
+# The bound is a window over the pane, so it can open on a continuation row
+# whose introducer scrolled above it.
+window=$(peek_capture "$WRAP_CAPTURE" 8)
+window_inspection=$(inspect_capture "$WRAP_CAPTURE" 8)
+printf '%s' "$window" | jq -e '
+  .capture.lines == 8
+  and (.capture.text | contains("no lifecycle authority here"))
+' >/dev/null || fail "a bounded window must stay bounded and inert: $window"
+refute_fragments "machine peek" "$window" "$SPLIT_VALUE"
+refute_fragments "session inspection" "$window_inspection" "$SPLIT_VALUE"
+pass "a bounded capture opening on a continuation row still redacts the value above it"
+
+set +e
+unknown=$(PATH="$fakebin:$PATH" FM_HOME="$HOME_DIR" "$PEEK" --json unknown-task 20)
+status=$?
+set -e
+[ "$status" -ne 0 ] || fail "unknown task must not select a guessed endpoint"
+printf '%s' "$unknown" | jq -e '.error.code == "session_not_found"' >/dev/null \
+  || fail "unknown task must return a typed unavailable result: $unknown"
+pass "machine peek never guesses an ambiguous or missing target"
+
+inspect_with_lines() {  # <lines-json>
+  jq -n --arg revision "$revision" --argjson lines "$1" '{
+    schemaVersion:"fm-captains-log-projection.v1",operation:"inspectSession",
+    missionId:"mission-42",taskId:"task-42",expectedMissionRevision:$revision,lines:$lines
+  }' | PATH="$fakebin:$PATH" FM_HOME="$HOME_DIR" "$PROJECTION"
+}
+
+for bad_lines in '0' '201' '"abc"' 'true' '99999999999999999999999'; do
+  set +e
+  bounded=$(inspect_with_lines "$bad_lines")
+  status=$?
+  set -e
+  [ "$status" -ne 0 ] || fail "lines=$bad_lines must be refused"
+  printf '%s' "$bounded" | jq -e '.accepted == false and .error.code == "malformed_request"' >/dev/null \
+    || fail "lines=$bad_lines must return one typed JSON result: $bounded"
+done
+padded=$(inspect_with_lines '"007"')
+printf '%s' "$padded" | jq -e '.accepted == true and .inspection.capture.lines == 7' >/dev/null \
+  || fail "a zero-padded bound must normalize instead of breaking the contract: $padded"
+pass "session inspection bounds its capture size and always answers with one typed result"
+
+INSPECT_BIN="$TMP_ROOT/inspect-bin"
+mkdir -p "$INSPECT_BIN"
+for script in "$ROOT"/bin/*; do
+  ln -s "$script" "$INSPECT_BIN/$(basename "$script")"
+done
+rm -f "$INSPECT_BIN/fm-peek.sh"
+printf '#!/usr/bin/env bash\nexit 127\n' > "$INSPECT_BIN/fm-peek.sh"
+chmod +x "$INSPECT_BIN/fm-peek.sh"
+set +e
+silent=$(jq -n --arg revision "$revision" '{
+  schemaVersion:"fm-captains-log-projection.v1",operation:"inspectSession",
+  missionId:"mission-42",taskId:"task-42",expectedMissionRevision:$revision,lines:20
+}' | PATH="$fakebin:$PATH" FM_HOME="$HOME_DIR" "$INSPECT_BIN/fm-captains-log-projection.sh")
+status=$?
+set -e
+[ "$status" -ne 0 ] || fail "a silent inspection subprocess must not look successful"
+printf '%s' "$silent" | jq -e '.accepted == false and .error.code == "inspection_unavailable"' >/dev/null \
+  || fail "an inspection producing no JSON must return a typed result, not empty output: $silent"
+pass "session inspection failure is typed rather than an empty response"

--- a/tests/fm-report.test.sh
+++ b/tests/fm-report.test.sh
@@ -220,3 +220,66 @@ else
   ' >/dev/null || fail "a retry once the history is readable must resume with an uncolliding sequence: $retried"
   pass "a condition history that cannot be read in full is typed, never silently truncated"
 fi
+
+# Acceptance order is FirstMate's, so concurrent appends into one home must never
+# be handed the same sequence: the tie would fall through to the crewmate-supplied
+# reportId and hand ordering back to the crewmate.
+CONCURRENT_HOME="$TMP_ROOT/concurrent-home"
+CONCURRENT_WORKTREE="$CONCURRENT_HOME/projects/task-50"
+mkdir -p "$CONCURRENT_HOME/data" "$CONCURRENT_HOME/state" "$CONCURRENT_HOME/config" "$CONCURRENT_WORKTREE"
+jq -n --arg root "$CONCURRENT_WORKTREE" '{
+  schemaVersion:"fm-engineering-mission.v1",missionId:"mission-50",taskId:"task-50",crewmateId:"travis",
+  acceptedBuildRevision:"build-11:r1",evidenceRequirements:[],allowedEvidenceRoots:[$root],
+  correlation:{schemaVersion:"shapeup-correlation.v1",sourceRevision:"dispatch:r11",capturedAt:"2026-08-01T14:00:00Z",
+    identity:{kind:"command",id:"dispatch-50"},shapeUp:{cycleRef:"cycle-16",buildRef:"build-11",buildRevision:"build-11:r1",scopeRef:null},
+    firstMate:{missionId:"mission-50",taskId:"task-50",crewmateId:"travis",session:null}}
+}' | FM_HOME="$CONCURRENT_HOME" "$MISSION" accept - >/dev/null
+
+concurrent_report() {  # <report-id>
+  jq -n --arg id "$1" '{
+    schemaVersion:"fm-engineering-report.v1",reportId:$id,kind:"hill_judgment",capturedAt:"2026-08-01T14:01:00Z",
+    missionId:"mission-50",taskId:"task-50",crewmateId:"travis",
+    hill:{phase:"uphill",judgment:"Concurrent crewmates report into one home.",movement:"unchanged"},
+    correlation:{schemaVersion:"shapeup-correlation.v1",sourceRevision:("event:"+$id),capturedAt:"2026-08-01T14:01:00Z",
+      identity:{kind:"event",id:$id},shapeUp:{cycleRef:"cycle-16",buildRef:"build-11",buildRevision:"build-11:r1",scopeRef:null},
+      firstMate:{missionId:"mission-50",taskId:"task-50",crewmateId:"travis",session:null}}
+  }'
+}
+
+for index in 1 2 3 4 5 6; do
+  concurrent_report "report-concurrent-$index" > "$TMP_ROOT/concurrent-$index.json"
+done
+for index in 1 2 3 4 5 6; do
+  FM_HOME="$CONCURRENT_HOME" FM_ENGINEERING_NOW="2026-08-01T14:02:00Z" \
+    "$REPORT" append "$TMP_ROOT/concurrent-$index.json" >/dev/null 2>&1 &
+done
+wait
+sequences=$(jq -s -r '[.[] | select(.status == "accepted") | .acceptanceSequence] | sort | @csv' \
+  "$CONCURRENT_HOME"/data/engineering/reports/*.json)
+[ "$sequences" = "1,2,3,4,5,6" ] || fail "concurrent appends did not each get their own acceptance sequence: $sequences"
+pass "concurrent appends allocate distinct FirstMate acceptance sequences"
+
+# A store that cannot hand over every report must not yield a floor below the true
+# maximum, because that reuses a sequence two records then share.
+if [ "$(id -u)" -eq 0 ]; then
+  echo "skip: unreadable-record sequence coverage needs a non-root user"
+else
+  rm -f "$CONCURRENT_HOME/data/engineering/reports.sequence"
+  chmod 000 "$CONCURRENT_HOME/data/engineering/reports/report-concurrent-1.json"
+  set +e
+  unreadable=$(concurrent_report report-concurrent-7 |
+    FM_HOME="$CONCURRENT_HOME" FM_ENGINEERING_NOW="2026-08-01T14:03:00Z" "$REPORT" append -)
+  status=$?
+  set -e
+  chmod 644 "$CONCURRENT_HOME/data/engineering/reports/report-concurrent-1.json"
+  [ "$status" -ne 0 ] || fail "a partially readable store must not silently rebuild the acceptance floor"
+  printf '%s' "$unreadable" | jq -e '.accepted == false and .error.code == "record_not_durable"' >/dev/null \
+    || fail "an unrebuildable acceptance floor must be typed: $unreadable"
+  assert_absent "$CONCURRENT_HOME/data/engineering/reports/report-concurrent-7.json" \
+    "a report whose acceptance order is unknown must not be stored"
+  recovered=$(concurrent_report report-concurrent-7 |
+    FM_HOME="$CONCURRENT_HOME" FM_ENGINEERING_NOW="2026-08-01T14:04:00Z" "$REPORT" append -)
+  printf '%s' "$recovered" | jq -e '.accepted == true and .report.acceptanceSequence == 7' >/dev/null \
+    || fail "a retry once the store is readable must resume above the true maximum: $recovered"
+  pass "an acceptance floor that cannot be rebuilt in full is typed, never an order that repeats"
+fi

--- a/tests/fm-report.test.sh
+++ b/tests/fm-report.test.sh
@@ -1,0 +1,222 @@
+#!/usr/bin/env bash
+# Behavior tests for continuous Engineering reports and evidence safety.
+set -u
+
+# shellcheck source=tests/lib.sh
+# shellcheck disable=SC1091
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+MISSION="$ROOT/bin/fm-mission.sh"
+REPORT="$ROOT/bin/fm-report.sh"
+TMP_ROOT=$(fm_test_tmproot fm-report)
+HOME_DIR="$TMP_ROOT/home"
+WORKTREE="$HOME_DIR/projects/task-42"
+mkdir -p "$HOME_DIR/data" "$HOME_DIR/state" "$HOME_DIR/config" "$WORKTREE/evidence"
+printf 'passing tests\n' > "$WORKTREE/evidence/tests.txt"
+
+command -v jq >/dev/null 2>&1 || { echo "skip: jq not found"; exit 0; }
+
+mission_file="$TMP_ROOT/mission.json"
+jq -n --arg root "$WORKTREE" '{
+  schemaVersion:"fm-engineering-mission.v1",missionId:"mission-42",taskId:"task-42",crewmateId:"keiko",
+  acceptedBuildRevision:"build-8:r7",evidenceRequirements:["automated-tests"],allowedEvidenceRoots:[$root],
+  correlation:{schemaVersion:"shapeup-correlation.v1",sourceRevision:"dispatch:r1",capturedAt:"2026-08-01T12:00:00Z",
+    identity:{kind:"command",id:"dispatch-42"},shapeUp:{cycleRef:"cycle-13",buildRef:"build-8",buildRevision:"build-8:r7",scopeRef:null},
+    firstMate:{missionId:"mission-42",taskId:"task-42",crewmateId:"keiko",session:null}}
+}' > "$mission_file"
+FM_HOME="$HOME_DIR" "$MISSION" accept "$mission_file" >/dev/null
+
+base_report() {
+  jq -n --arg kind "$1" --arg id "$2" '{
+    schemaVersion:"fm-engineering-report.v1",reportId:$id,kind:$kind,capturedAt:"2026-08-01T12:05:00Z",
+    missionId:"mission-42",taskId:"task-42",crewmateId:"keiko",
+    correlation:{schemaVersion:"shapeup-correlation.v1",sourceRevision:"report:r1",capturedAt:"2026-08-01T12:05:00Z",
+      identity:{kind:"event",id:$id},shapeUp:{cycleRef:"cycle-13",buildRef:"build-8",buildRevision:"build-8:r7",scopeRef:"scope-context"},
+      firstMate:{missionId:"mission-42",taskId:"task-42",crewmateId:"keiko",session:null}}
+  }'
+}
+
+hill=$(base_report hill_judgment report-hill-1 | jq '.hill={phase:"uphill",judgment:"A newly discovered integration seam moved this Scope backward.",movement:"backward"}')
+first=$(printf '%s' "$hill" | FM_HOME="$HOME_DIR" "$REPORT" append -)
+second=$(printf '%s' "$hill" | FM_HOME="$HOME_DIR" "$REPORT" append -)
+printf '%s' "$first" | jq -e '.accepted == true and .report.hill.movement == "backward"' >/dev/null \
+  || fail "backward Hill judgment must be accepted: $first"
+printf '%s' "$second" | jq -e '.accepted == true and .replayed == true' >/dev/null \
+  || fail "duplicate report must replay"
+pass "reports preserve qualitative backward Hill learning and deduplicate exact replay"
+
+set +e
+cross=$(printf '%s' "$hill" | jq '.reportId="report-cross" | .correlation.identity.id="report-cross" | .correlation.shapeUp.buildRef="build-9"' |
+  FM_HOME="$HOME_DIR" "$REPORT" append -)
+status=$?
+set -e
+[ "$status" -ne 0 ] || fail "cross-Build report must fail"
+printf '%s' "$cross" | jq -e '.error.code == "cross_build" and .report.status == "rejected"' >/dev/null \
+  || fail "cross-Build rejection must remain visible and typed: $cross"
+pass "cross-Build reports remain visible but non-executable"
+
+evidence=$(base_report evidence report-evidence-1 | jq --arg path "$WORKTREE/evidence/tests.txt" '
+  .evidence={producer:"keiko",verifier:"firstmate",contract:"automated-tests",executionRevision:"exec:r4",
+    reference:{kind:"file",value:$path,mediaType:"text/plain"},verification:{status:"verified",instructions:"Run the focused suite."}}
+')
+verified=$(printf '%s' "$evidence" | FM_HOME="$HOME_DIR" "$REPORT" append -)
+printf '%s' "$verified" | jq -e '.accepted == true and .report.evidence.verification.status == "verified"' >/dev/null \
+  || fail "confined verified evidence must be accepted: $verified"
+
+set +e
+outside=$(printf '%s' "$evidence" | jq '.reportId="report-evidence-outside" | .correlation.identity.id="report-evidence-outside" | .evidence.reference.value="/etc/hosts"' |
+  FM_HOME="$HOME_DIR" "$REPORT" append -)
+status=$?
+set -e
+[ "$status" -ne 0 ] || fail "outside evidence must fail"
+printf '%s' "$outside" | jq -e '.error.code == "evidence_outside_roots"' >/dev/null \
+  || fail "outside evidence rejection must be typed: $outside"
+pass "evidence references are confined and verified explicitly"
+
+snapshot=$(printf '%s' '{"schemaVersion":"fm-captains-log-projection.v1","operation":"snapshot"}' |
+  FM_HOME="$HOME_DIR" FM_PROJECTION_NOW="2026-08-01T12:10:00Z" "$ROOT/bin/fm-captains-log-projection.sh")
+printf '%s' "$snapshot" | jq -e '
+  (.snapshot.missions | length) == 1
+  and ([.snapshot.reports[] | select(.status == "accepted")] | length) == 2
+  and ([.snapshot.reports[] | select(.status == "rejected" and .error.code == "cross_build")] | length) == 1
+  and .snapshot.evidence[0].missionId == "mission-42"
+  and .snapshot.evidence[0].taskId == "task-42"
+  and .snapshot.evidence[0].correlation.shapeUp.buildRef == "build-8"
+' >/dev/null || fail "projection must retain accepted and rejected reports: $snapshot"
+pass "projection preserves accepted and rejected execution truth"
+
+# A stubbed decision-hold owner lets the degraded projection lifecycle be driven
+# deterministically without a live tasks-axi backlog.
+STUB_BIN="$TMP_ROOT/stub-bin"
+mkdir -p "$STUB_BIN"
+for script in "$ROOT"/bin/*; do
+  ln -s "$script" "$STUB_BIN/$(basename "$script")"
+done
+rm -f "$STUB_BIN/fm-decision-hold.sh"
+HOLD_STATE="$TMP_ROOT/hold-state"
+printf 'fail\n' > "$HOLD_STATE"
+cat > "$STUB_BIN/fm-decision-hold.sh" <<'SH'
+#!/usr/bin/env bash
+set -u
+state=$(cat "${FM_TEST_HOLD_STATE:?}")
+case "${1:-}" in
+  hold) printf '%s-decision-%s\n' "$2" "$3"; exit 0 ;;
+  project)
+    [ "$state" = project-ok ] || exit 1
+    printf 'projected\n'; exit 0 ;;
+  status)
+    case "$state" in
+      hold-gone) printf '{"schemaVersion":"fm-captain-call-status.v1","durableState":{"state":"done","held":false}}\n' ;;
+      *) printf '{"schemaVersion":"fm-captain-call-status.v1","durableState":{"state":"queued","held":true}}\n' ;;
+    esac
+    exit 0 ;;
+esac
+exit 2
+SH
+chmod +x "$STUB_BIN/fm-decision-hold.sh"
+
+condition_report=$(base_report scope_revision report-condition-1 | jq '
+  .condition={conditionId:"scope-drop",title:"Choose scope-drop",explanation:"Dropping the Scope changes the Build outcome.",
+    recommendation:"Defer the Scope explicitly.",choices:["defer","retain"],consequenceOfDelay:"Execution stays blocked.",
+    affectedObjects:["build-8"],evidence:[],boundRevisions:{build:"build-8:r7"}}
+  | .scope={change:"drop",reason:"The accepted Build no longer fits the appetite."}
+')
+report_path="$HOME_DIR/data/engineering/reports/report-condition-1.json"
+
+set +e
+degraded=$(printf '%s' "$condition_report" |
+  FM_HOME="$HOME_DIR" FM_TEST_HOLD_STATE="$HOLD_STATE" "$STUB_BIN/fm-report.sh" append -)
+status=$?
+set -e
+[ "$status" -eq 0 ] || fail "a report whose packet cannot be projected must still be accepted: $degraded"
+printf '%s' "$degraded" | jq -e '
+  .accepted == true
+  and .report.status == "accepted"
+  and .report.condition.projection.status == "degraded"
+  and .captainCall.projection == "degraded"
+  and .captainCall.error.code == "captain_call_projection_failed"
+' >/dev/null || fail "failed packet projection must stay accepted and typed degraded: $degraded"
+jq -e '.status == "accepted" and .condition.projection.status == "degraded"' "$report_path" >/dev/null \
+  || fail "the degraded projection state must be durable"
+
+before=$(cat "$report_path")
+retry=$(printf '%s' "$condition_report" |
+  FM_HOME="$HOME_DIR" FM_TEST_HOLD_STATE="$HOLD_STATE" "$STUB_BIN/fm-report.sh" append -)
+printf '%s' "$retry" | jq -e '.accepted == true and .replayed == true and .captainCall.projection == "degraded"' >/dev/null \
+  || fail "a still-degraded replay must report the degraded state: $retry"
+[ "$before" = "$(cat "$report_path")" ] || fail "a replay that cannot heal must not rewrite the durable record"
+
+printf 'project-ok\n' > "$HOLD_STATE"
+healed=$(printf '%s' "$condition_report" |
+  FM_HOME="$HOME_DIR" FM_TEST_HOLD_STATE="$HOLD_STATE" "$STUB_BIN/fm-report.sh" append -)
+printf '%s' "$healed" | jq -e '
+  .accepted == true and .replayed == true
+  and (.captainCall? // null) == null
+  and .report.condition.projection.status == "projected"
+' >/dev/null || fail "exact replay must heal a degraded packet projection: $healed"
+jq -e '.condition.projection.status == "projected"' "$report_path" >/dev/null \
+  || fail "the healed projection state must be durable"
+pass "a Captain Call packet that cannot be projected stays accepted, typed, and heals on exact replay"
+
+conditions=$(printf '%s' '{"schemaVersion":"fm-captains-log-projection.v1","operation":"snapshot"}' |
+  FM_HOME="$HOME_DIR" "$ROOT/bin/fm-captains-log-projection.sh")
+printf '%s' "$conditions" | jq -e '
+  (.snapshot.conditions | length) == 1
+  and .snapshot.conditions[0].projection.status == "projected"
+' >/dev/null || fail "the Captain surface must show whether a condition received its packet: $conditions"
+
+second_condition=$(printf '%s' "$condition_report" | jq '
+  .reportId="report-condition-2" | .correlation.identity.id="report-condition-2"
+  | .condition.conditionId="scope-hold" | .condition.title="Choose scope-hold"')
+printf 'fail\n' > "$HOLD_STATE"
+printf '%s' "$second_condition" |
+  FM_HOME="$HOME_DIR" FM_TEST_HOLD_STATE="$HOLD_STATE" "$STUB_BIN/fm-report.sh" append - >/dev/null
+second_path="$HOME_DIR/data/engineering/reports/report-condition-2.json"
+jq -e '.condition.projection.status == "degraded"' "$second_path" >/dev/null \
+  || fail "the second Captain Call must start degraded"
+
+printf 'hold-gone\n' > "$HOLD_STATE"
+abandoned=$(printf '%s' "$second_condition" |
+  FM_HOME="$HOME_DIR" FM_TEST_HOLD_STATE="$HOLD_STATE" "$STUB_BIN/fm-report.sh" append -)
+printf '%s' "$abandoned" | jq -e '
+  .accepted == true and .replayed == true
+  and .captainCall.projection == "abandoned"
+  and .captainCall.error.code == "captain_call_not_active"
+' >/dev/null || fail "healing must stop once the Captain Call is no longer held: $abandoned"
+settled=$(cat "$second_path")
+again=$(printf '%s' "$second_condition" |
+  FM_HOME="$HOME_DIR" FM_TEST_HOLD_STATE="$HOLD_STATE" "$STUB_BIN/fm-report.sh" append -)
+printf '%s' "$again" | jq -e '.accepted == true and .captainCall.projection == "abandoned"' >/dev/null \
+  || fail "an abandoned packet must stay abandoned: $again"
+[ "$settled" = "$(cat "$second_path")" ] || fail "an abandoned packet must not be rewritten on every replay"
+pass "packet healing terminates once its durable Captain Call is closed"
+
+if [ "$(id -u)" -eq 0 ]; then
+  echo "skip: unreadable-record coverage needs a non-root user"
+else
+  third_condition=$(printf '%s' "$condition_report" | jq '
+    .reportId="report-condition-3" | .correlation.identity.id="report-condition-3"
+    | .condition.conditionId="scope-widen" | .condition.title="Choose scope-widen"')
+  chmod 000 "$report_path"
+  set +e
+  truncated=$(printf '%s' "$third_condition" |
+    FM_HOME="$HOME_DIR" FM_TEST_HOLD_STATE="$HOLD_STATE" "$STUB_BIN/fm-report.sh" append -)
+  status=$?
+  set -e
+  chmod 644 "$report_path"
+  [ "$status" -ne 0 ] || fail "a partially readable condition history must not be treated as complete"
+  printf '%s' "$truncated" | jq -e '
+    .accepted == false and .error.code == "condition_history_unavailable"
+  ' >/dev/null || fail "an unreadable stored report must be typed, not a silently truncated history: $truncated"
+  assert_absent "$HOME_DIR/data/engineering/reports/report-condition-3.json" \
+    "an unreadable history must not durably reject the new report"
+  set +e
+  retried=$(printf '%s' "$third_condition" |
+    FM_HOME="$HOME_DIR" FM_TEST_HOLD_STATE="$HOLD_STATE" "$STUB_BIN/fm-report.sh" append -)
+  set -e
+  printf '%s' "$retried" | jq -e '
+    .accepted == true and .report.condition.lifecycle == "raised"
+    and .report.condition.creationSequence == 3
+  ' >/dev/null || fail "a retry once the history is readable must resume with an uncolliding sequence: $retried"
+  pass "a condition history that cannot be read in full is typed, never silently truncated"
+fi

--- a/tests/fm-shapeup-client.test.sh
+++ b/tests/fm-shapeup-client.test.sh
@@ -160,6 +160,60 @@ assert_absent "$HOME_DIR/data/engineering/shapeup-outcomes/report-scope-1.json" 
   "a wedged transport must not journal an outcome"
 pass "a transport that never answers expires into a typed unavailable submission"
 
+# The portable timeout fallback has to type the two ways a bounded child can fail
+# without ever answering: an interpreter that cannot start, and a death by signal
+# after partial output. Neither may be journalled as an authoritative outcome.
+if ! command -v perl >/dev/null 2>&1; then
+  echo "skip: perl is unavailable, so the portable timeout fallback is untestable"
+else
+  BROKEN_TRANSPORT="$TMP_ROOT/shapeup-transport-broken"
+  printf '#!/nonexistent/interpreter\ntrue\n' > "$BROKEN_TRANSPORT"
+  chmod +x "$BROKEN_TRANSPORT"
+  jq --arg t "$BROKEN_TRANSPORT" '.transport.path=$t' "$TMP_ROOT/config-partial.json" > "$HOME_DIR/config/shapeup-client.json"
+  set +e
+  broken=$(FM_HOME="$HOME_DIR" FM_SHAPEUP_FORCE_TIMEOUT_FALLBACK=1 "$CLIENT" submit report-scope-1)
+  status=$?
+  set -e
+  [ "$status" -ne 0 ] || fail "a transport that cannot be executed must not look like a submission"
+  printf '%s' "$broken" | jq -e '.accepted == false and .error.code == "shapeup_unavailable"' >/dev/null \
+    || fail "an unexecutable transport must be typed unavailable: $broken"
+  assert_absent "$HOME_DIR/data/engineering/shapeup-outcomes/report-scope-1.json" \
+    "an unexecutable transport must not journal an outcome"
+
+  SIGNAL_TRANSPORT="$TMP_ROOT/shapeup-transport-signal"
+  cat > "$SIGNAL_TRANSPORT" <<'SH'
+#!/usr/bin/env bash
+set -u
+request=$(cat)
+case "$(printf '%s' "$request" | jq -r '.operation')" in
+  capabilities) jq -n '{accepted:true,capabilities:["scope.write","hill.write"]}' ;;
+  submit)
+    jq -n '{accepted:true,outcome:{status:"applied",authoritativeRevision:"shapeup:r12"}}'
+    kill -KILL $$
+    ;;
+esac
+SH
+  chmod +x "$SIGNAL_TRANSPORT"
+  jq --arg t "$SIGNAL_TRANSPORT" '.transport.path=$t' "$TMP_ROOT/config-partial.json" > "$HOME_DIR/config/shapeup-client.json"
+  set +e
+  signalled=$(FM_HOME="$HOME_DIR" FM_SHAPEUP_FORCE_TIMEOUT_FALLBACK=1 "$CLIENT" submit report-scope-1)
+  status=$?
+  set -e
+  [ "$status" -ne 0 ] || fail "a transport killed by a signal must not look like a submission"
+  printf '%s' "$signalled" | jq -e '.accepted == false and .error.code == "shapeup_unavailable"' >/dev/null \
+    || fail "a signal-killed transport must be typed unavailable: $signalled"
+  assert_absent "$HOME_DIR/data/engineering/shapeup-outcomes/report-scope-1.json" \
+    "a signal-killed transport must not journal its partial output as authoritative"
+
+  jq --arg t "$TRANSPORT" '.transport.path=$t' "$TMP_ROOT/config-partial.json" > "$HOME_DIR/config/shapeup-client.json"
+  bounded=$(FM_HOME="$HOME_DIR" FM_SHAPEUP_FORCE_TIMEOUT_FALLBACK=1 \
+    SHAPEUP_TEST_ARGC="$ARGC_LOG" SHAPEUP_TEST_EXPECTED_TOKEN=token-one "$CLIENT" submit report-scope-1)
+  printf '%s' "$bounded" | jq -e '.accepted == true and .outcome.status == "applied"' >/dev/null \
+    || fail "the portable fallback must still carry a healthy submission through: $bounded"
+  rm -f "$HOME_DIR/data/engineering/shapeup-outcomes/report-scope-1.json"
+  pass "the portable timeout fallback types a failed exec and a signal death instead of claiming success"
+fi
+
 BENIGN_TRANSPORT="$TMP_ROOT/shapeup-transport-benign"
 cat > "$BENIGN_TRANSPORT" <<'SH'
 #!/usr/bin/env bash

--- a/tests/fm-shapeup-client.test.sh
+++ b/tests/fm-shapeup-client.test.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+# Behavior tests for the supervisor-owned ShapeUp client boundary.
+set -u
+
+# shellcheck source=tests/lib.sh
+# shellcheck disable=SC1091
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+MISSION="$ROOT/bin/fm-mission.sh"
+REPORT="$ROOT/bin/fm-report.sh"
+CLIENT="$ROOT/bin/fm-shapeup-client.sh"
+PROJECTION="$ROOT/bin/fm-captains-log-projection.sh"
+TMP_ROOT=$(fm_test_tmproot fm-shapeup-client)
+HOME_DIR="$TMP_ROOT/home"
+WORKTREE="$HOME_DIR/projects/task-42"
+mkdir -p "$HOME_DIR/data" "$HOME_DIR/state" "$HOME_DIR/config" "$WORKTREE"
+
+command -v jq >/dev/null 2>&1 || { echo "skip: jq not found"; exit 0; }
+
+TRANSPORT="$TMP_ROOT/shapeup-transport"
+cat > "$TRANSPORT" <<'SH'
+#!/usr/bin/env bash
+set -u
+request=$(cat)
+printf '%s\n' "$#" >> "${SHAPEUP_TEST_ARGC:?}"
+if [ "${SHAPEUP_WORKSPACE_TOKEN:-}" != "${SHAPEUP_TEST_EXPECTED_TOKEN:-}" ]; then
+  printf '{"accepted":false,"error":{"code":"unauthorized","message":"credential rejected"}}\n'
+  exit 0
+fi
+operation=$(printf '%s' "$request" | jq -r '.operation')
+case "$operation" in
+  capabilities)
+    jq -n '{accepted:true,contractVersion:"shapeup-engineering.v1",capabilities:["scope.write","hill.write"]}'
+    ;;
+  submit)
+    printf '%s' "$request" | jq '{accepted:true,outcome:{status:"applied",authoritativeRevision:"shapeup:r9",idempotencyKey:.idempotencyKey}}'
+    ;;
+esac
+SH
+chmod +x "$TRANSPORT"
+printf 'token-one\n' > "$HOME_DIR/config/shapeup-token"
+chmod 600 "$HOME_DIR/config/shapeup-token"
+jq -n --arg transport "$TRANSPORT" '{
+  schemaVersion:"fm-shapeup-client.v1",workspaceId:"workspace-1",
+  transport:{kind:"executable",path:$transport},credentialFile:"shapeup-token"
+}' > "$HOME_DIR/config/shapeup-client.json"
+
+mission=$(jq -n --arg root "$WORKTREE" '{
+  schemaVersion:"fm-engineering-mission.v1",missionId:"mission-42",taskId:"task-42",crewmateId:"keiko",
+  acceptedBuildRevision:"build-8:r7",evidenceRequirements:[],allowedEvidenceRoots:[$root],
+  correlation:{schemaVersion:"shapeup-correlation.v1",sourceRevision:"dispatch:r1",capturedAt:"2026-08-01T12:00:00Z",
+    identity:{kind:"command",id:"dispatch-42"},shapeUp:{cycleRef:"cycle-13",buildRef:"build-8",buildRevision:"build-8:r7",scopeRef:null},
+    firstMate:{missionId:"mission-42",taskId:"task-42",crewmateId:"keiko",session:null}}
+}')
+printf '%s' "$mission" | FM_HOME="$HOME_DIR" "$MISSION" accept - >/dev/null
+report=$(jq -n '{
+  schemaVersion:"fm-engineering-report.v1",reportId:"report-scope-1",kind:"scope_discovery",capturedAt:"2026-08-01T12:05:00Z",
+  missionId:"mission-42",taskId:"task-42",crewmateId:"keiko",scope:{title:"Context fencing",judgment:"A distinct integration risk emerged."},
+  correlation:{schemaVersion:"shapeup-correlation.v1",sourceRevision:"report:r1",capturedAt:"2026-08-01T12:05:00Z",
+    identity:{kind:"event",id:"report-scope-1"},shapeUp:{cycleRef:"cycle-13",buildRef:"build-8",buildRevision:"build-8:r7",scopeRef:null},
+    firstMate:{missionId:"mission-42",taskId:"task-42",crewmateId:"keiko",session:null}}
+}')
+printf '%s' "$report" | FM_HOME="$HOME_DIR" "$REPORT" append - >/dev/null
+
+ARGC_LOG="$TMP_ROOT/argc.log"
+: > "$ARGC_LOG"
+first=$(FM_HOME="$HOME_DIR" SHAPEUP_TEST_ARGC="$ARGC_LOG" SHAPEUP_TEST_EXPECTED_TOKEN=token-one "$CLIENT" submit report-scope-1)
+second=$(FM_HOME="$HOME_DIR" SHAPEUP_TEST_ARGC="$ARGC_LOG" SHAPEUP_TEST_EXPECTED_TOKEN=token-one "$CLIENT" submit report-scope-1)
+printf '%s' "$first" | jq -e '.accepted == true and .outcome.status == "applied" and .outcome.replayed == false' >/dev/null \
+  || fail "ShapeUp submission must be accepted: $first"
+printf '%s' "$second" | jq -e '.accepted == true and .outcome.replayed == true' >/dev/null \
+  || fail "ShapeUp submission must replay durably: $second"
+[ "$(tr -d '\n' < "$ARGC_LOG")" = "00" ] || fail "credential boundary must not add command arguments"
+assert_not_contains "$first" "token-one" "ShapeUp outcome leaked the credential"
+projection=$(printf '%s' '{"schemaVersion":"fm-captains-log-projection.v1","operation":"snapshot"}' |
+  FM_HOME="$HOME_DIR" "$PROJECTION")
+printf '%s' "$projection" | jq -e '
+  (.snapshot.shapeUpOutcomes | length) == 1
+  and .snapshot.shapeUpOutcomes[0].outcome.authoritativeRevision == "shapeup:r9"
+' >/dev/null || fail "projection did not retain the authoritative ShapeUp outcome: $projection"
+pass "ShapeUp client submits guarded idempotent intent without argv or output secrets"
+
+jq '.transport.path="/missing/transport"' "$HOME_DIR/config/shapeup-client.json" > "$TMP_ROOT/config-partial.json"
+cp "$TMP_ROOT/config-partial.json" "$HOME_DIR/config/shapeup-client.json"
+set +e
+unavailable=$(FM_HOME="$HOME_DIR" "$CLIENT" submit report-scope-1)
+status=$?
+set -e
+# A prior durable success must replay even when the transport is now absent.
+[ "$status" -eq 0 ] || fail "durable replay should survive transport loss"
+printf '%s' "$unavailable" | jq -e '.accepted == true and .outcome.replayed == true' >/dev/null \
+  || fail "transport loss must not erase the prior outcome: $unavailable"
+pass "lost-response recovery returns the durable semantic outcome"
+
+rm -f "$HOME_DIR/data/engineering/shapeup-outcomes/report-scope-1.json"
+set +e
+missing=$(FM_HOME="$HOME_DIR" "$CLIENT" submit report-scope-1)
+status=$?
+set -e
+[ "$status" -ne 0 ] || fail "missing transport without a journal must be unavailable"
+printf '%s' "$missing" | jq -e '.error.code == "shapeup_unavailable"' >/dev/null \
+  || fail "unavailable transport must be typed: $missing"
+[ -f "$HOME_DIR/data/engineering/reports/report-scope-1.json" ] || fail "ShapeUp unavailability lost the crewmate report"
+pass "ShapeUp unavailability preserves the validated report"
+
+LEAKY_TRANSPORT="$TMP_ROOT/shapeup-transport-leaky"
+cat > "$LEAKY_TRANSPORT" <<'SH'
+#!/usr/bin/env bash
+set -u
+request=$(cat)
+case "$(printf '%s' "$request" | jq -r '.operation')" in
+  capabilities) jq -n '{accepted:true,capabilities:["scope.write","hill.write"]}' ;;
+  submit) jq -n '{accepted:true,outcome:{status:"applied",authoritativeRevision:"shapeup:r10",workspaceToken:"ghp_leaked_from_upstream"}}' ;;
+esac
+SH
+chmod +x "$LEAKY_TRANSPORT"
+jq --arg t "$LEAKY_TRANSPORT" '.transport.path=$t' "$TMP_ROOT/config-partial.json" > "$HOME_DIR/config/shapeup-client.json"
+set +e
+leaked=$(FM_HOME="$HOME_DIR" "$CLIENT" submit report-scope-1)
+status=$?
+set -e
+[ "$status" -ne 0 ] || fail "a transport response carrying credential material must be refused"
+printf '%s' "$leaked" | jq -e '.accepted == false and .error.code == "credential_material"' >/dev/null \
+  || fail "leaked transport credentials must be typed: $leaked"
+assert_not_contains "$leaked" "ghp_leaked_from_upstream" "the refusal echoed the leaked credential"
+assert_absent "$HOME_DIR/data/engineering/shapeup-outcomes/report-scope-1.json" \
+  "a credential-bearing outcome must never be persisted"
+leak_projection=$(printf '%s' '{"schemaVersion":"fm-captains-log-projection.v1","operation":"snapshot"}' |
+  FM_HOME="$HOME_DIR" "$PROJECTION")
+assert_not_contains "$leak_projection" "ghp_leaked_from_upstream" "the projection republished the leaked credential"
+pass "transport responses carrying credential material never become durable projection state"
+
+BENIGN_TRANSPORT="$TMP_ROOT/shapeup-transport-benign"
+cat > "$BENIGN_TRANSPORT" <<'SH'
+#!/usr/bin/env bash
+set -u
+request=$(cat)
+case "$(printf '%s' "$request" | jq -r '.operation')" in
+  capabilities) jq -n '{accepted:true,capabilities:["scope.write","hill.write"]}' ;;
+  submit)
+    jq -n '{accepted:true,outcome:{status:"applied",authoritativeRevision:"shapeup:r11",
+      credentialRotationRequired:false,secretsScanned:0,passwordPolicyVersion:3}}' ;;
+esac
+SH
+chmod +x "$BENIGN_TRANSPORT"
+jq --arg t "$BENIGN_TRANSPORT" '.transport.path=$t' "$TMP_ROOT/config-partial.json" > "$HOME_DIR/config/shapeup-client.json"
+benign=$(FM_HOME="$HOME_DIR" "$CLIENT" submit report-scope-1)
+printf '%s' "$benign" | jq -e '
+  .accepted == true
+  and .outcome.status == "applied"
+  and .outcome.credentialRotationRequired == false
+  and .outcome.secretsScanned == 0
+' >/dev/null || fail "benign credential-named non-string fields must not fail a submission: $benign"
+pass "credential scanning of transport responses does not reject benign non-string fields"

--- a/tests/fm-shapeup-client.test.sh
+++ b/tests/fm-shapeup-client.test.sh
@@ -130,6 +130,36 @@ leak_projection=$(printf '%s' '{"schemaVersion":"fm-captains-log-projection.v1",
 assert_not_contains "$leak_projection" "ghp_leaked_from_upstream" "the projection republished the leaked credential"
 pass "transport responses carrying credential material never become durable projection state"
 
+# A wedged endpoint must not hold the reporting crewmate open: the transport runs
+# under a hard wall-clock bound and its expiry is the ordinary typed unavailable
+# submission, with the validated report left intact.
+HANGING_TRANSPORT="$TMP_ROOT/shapeup-transport-hanging"
+cat > "$HANGING_TRANSPORT" <<'SH'
+#!/usr/bin/env bash
+set -u
+cat >/dev/null
+exec sleep 120
+SH
+chmod +x "$HANGING_TRANSPORT"
+jq --arg t "$HANGING_TRANSPORT" '.transport.path=$t' "$TMP_ROOT/config-partial.json" > "$HOME_DIR/config/shapeup-client.json"
+started=$(date +%s)
+set +e
+hung=$(FM_HOME="$HOME_DIR" FM_SHAPEUP_TRANSPORT_TIMEOUT=2 "$CLIENT" submit report-scope-1)
+status=$?
+set -e
+elapsed=$(( $(date +%s) - started ))
+[ "$status" -ne 0 ] || fail "a transport that never answers must not look like a submission"
+printf '%s' "$hung" | jq -e '
+  .accepted == false
+  and .error.code == "shapeup_unavailable"
+  and (.error.detailCode | IN("transport_timeout","transport_unbounded"))
+' >/dev/null || fail "a wedged transport must be typed unavailable: $hung"
+[ "$elapsed" -lt 60 ] || fail "the transport call was not bounded; it ran for ${elapsed}s"
+[ -f "$HOME_DIR/data/engineering/reports/report-scope-1.json" ] || fail "a wedged transport lost the crewmate report"
+assert_absent "$HOME_DIR/data/engineering/shapeup-outcomes/report-scope-1.json" \
+  "a wedged transport must not journal an outcome"
+pass "a transport that never answers expires into a typed unavailable submission"
+
 BENIGN_TRANSPORT="$TMP_ROOT/shapeup-transport-benign"
 cat > "$BENIGN_TRANSPORT" <<'SH'
 #!/usr/bin/env bash


### PR DESCRIPTION
## Intent

Publish the implementation-ready FirstMate Engineering Machine Projection: a versioned backend-neutral Captain's Log interface with opaque Cycle/Build/Scope and FirstMate correlation; continuous Scope, qualitative Hill, blocker, evidence, verification, and outcome reports; supervisor-owned guarded ShapeUp submission with protected credentials and durable replay; existing decision holds as the sole Captain-attention lifecycle; revision-bound Build Review across every active mission and latest required evidence; and optional exact bounded read-only session inspection. Preserve rejected records, distinguish typed stale/unavailable/conflict outcomes, prevent credential leakage, keep session output non-authoritative, and ship all four implementation units with fixtures, documentation, and tests. Focused and affected regression suites pass and lint is clean. The full 111-script local suite passed 94 scripts; 11 real-Herdr gates lacked their required default session and six unrelated environment-sensitive baseline suites also failed, while every new feature suite passed.

## What Changed

- Added the versioned Captain's Log interface: `bin/fm-captains-log-projection.sh` (`capabilities`, `snapshot`, `intent`, optional `inspectSession` over a bounded JSON stdin contract), `bin/fm-mission.sh` for Build-revision-bound mission accept/supersede/defer, `bin/fm-report.sh` for immutable Scope, qualitative Hill, blocker, evidence, verification, and outcome records, and the shared `bin/fm-engineering-lib.sh` (privacy-safe identities, credential vocabulary, checked atomic writes, liveness-safe `mkdir` mutex). Rejected and schema-invalid records are retained and non-executable, partially readable stores and failed writes return typed `projection_unavailable` / `record_not_durable` / `outcome_not_durable` results, and acceptance order comes from a FirstMate-assigned `acceptanceSequence` allocated under the lock rather than from crewmate-supplied timestamps.
- Wired the surrounding surfaces: `bin/fm-shapeup-client.sh` submits Scope and Hill reports through one operator-configured closed transport under a bounded timeout, reading the workspace credential fresh from an owner-only file and passing it only via the child environment, with typed `shapeup_unavailable` outcomes and durable replay; `bin/fm-decision-hold.sh` gains `id`, `project`, and `status --json` so existing decision holds remain the sole Captain-attention lifecycle and a hold mid-resolution reports `retained` instead of overwriting the retry identity; Build Review acceptance is revision-bound across every active mission and fails closed while any bearing record is isolated.
- Added a bounded read-only `--json` capture mode to `bin/fm-peek.sh` that redacts credentials over reconstructed logical lines (wrap stitching, `=` vs `:` separator rules, row boundaries preserved unless a redaction straddled a wrap), embedded the projection snapshot in `bin/fm-fleet-snapshot.sh` with graceful `freshness: "unavailable"` degradation, and shipped the correlation-envelope and compatibility-matrix fixtures, `docs/captains-log-machine-projection.md`, `docs/shapeup-client.md`, updated architecture/configuration/scripts/decision-hold docs, and eight portable test suites (all passing, lint clean).

## Risk Assessment

✅ Low: This is the first round with no warning-or-above findings: every correctness, durability, and credential-leak defect from the five prior rounds is fixed and re-verified here by direct reproduction, the redaction candidate selection is now safe by construction rather than by comparison, and what remains is duplicated rule text and one vacuous test assertion.

## Testing

Ran the eight focused feature suites named in docs/captains-log-machine-projection.md plus the seven regression suites this change touches (fleet-snapshot embedding, decision-hold lifecycle, documentation inventory, and the fm-peek consumers) — all pass with no skips, since jq and tasks-axi are both available. Because passing suites alone do not show the interface an integrator uses, I also wrote and ran an end-to-end walkthrough that drives the real CLIs against a throwaway FM_HOME and captured the full request/response transcript: capability negotiation; a revision-bound mission with its evidence contract and reporting instructions; all seven report kinds including a backward Hill judgment; numeric progress refused as invalid_hill and a cross-Build report refused as cross_build, both retained on disk with status rejected; a Captain Call raised on a durable hold, acknowledged without resolving it, then resolved and closed through fm-decision-hold.sh, with identity_conflict on intentId reuse and condition_not_found for an unknown condition; a Build Review packet that becomes ready only once terminal and evidence-verified, accepts with delivery/buildCloseout/cycleClose all false, replays exactly, then returns review_revision_conflict and stale_packet once a second mission binds a different Build revision; guarded ShapeUp submission where the transport receives argc=0 and the token only via the environment, with credential_permissions on a non-owner-only file and shapeup_unavailable on a missing transport while the prior durable outcome still replays; bounded read-only session inspection returning authoritative false with a pane-wrapped Bearer value and an inline SERVICE_TOKEN both redacted (verified by a sliding-window fragment scan); an isolated hand-edited record failing Build Review closed with review_records_isolated while every other operation stays up; and the projection embedded in the fleet snapshot at freshness fresh. This change ships no UI, HTML, or rendered surface — its end-user surface is a stdin/stdout JSON CLI contract — so the reviewer-visible evidence is the CLI transcript and the persisted store state rather than screenshots. I did not run lint, since the task forbids linters, so the intent's "lint is clean" claim is unverified here; I also did not run the full 111-script suite, because .no-mistakes.yaml explicitly reserves broad regression for CI and scopes local Test to intent-targeted validation. Transient demo homes under /tmp were removed and the worktree is clean.

<details>
<summary>Evidence: End-to-end CLI transcript: all ten acts of the Captain&#39;s Log machine projection driven against a real FM_HOME</summary>

```text


═══ 1. Versioned backend-neutral interface: what does this build advertise? ═══

$ echo '{...capabilities}' | fm-captains-log-projection.sh
{
  "accepted": true,
  "acceptedIntents": [
    "acknowledgeCondition",
    "acceptBuildReview",
    "resolveCondition"
  ],
  "capabilities": {
    "core": "available",
    "sessionInspection": {
      "mode": "bounded-read-only",
      "preferredBackend": "herdr",
      "required": false,
      "status": "negotiated"
    },
    "shapeUp": {
      "required": false,
      "status": "negotiated"
    }
  },
  "capturedAt": "2026-08-01T12:00:00Z",
  "operations": [
    "capabilities",
    "snapshot",
    "intent",
    "inspectSession"
  ],
  "schemaVersion": "fm-captains-log-projection.v1",
  "sourceRevision": "capabilities-v1"
}


═══ 2. Revision-bound Engineering mission with a required evidence contract ═══

$ fm-mission.sh accept - <<< <mission-42 bound to build-8:r7>
{
  "accepted": true,
  "mission": {
    "acceptedBuildRevision": "build-8:r7",
    "evidenceRequirements": [
      "automated-tests"
    ],
    "missionId": "mission-42",
    "reporting": {
      "acceptedKinds": [
        "scope_discovery",
        "scope_revision",
        "hill_judgment",
        "blocker",
        "evidence",
        "verification_instructions",
        "outcome"
      ],
      "continueUntilTerminal": true,
      "establishInitialScopes": true
    },
    "sourceRevision": "fbe37ad57bc42906b4d737165da22a73b509eb8a76798987c7c54aaad03c4474",
    "state": "accepted"
  }
}


═══ 3. Continuous reporting: Scope, qualitative Hill, blocker, evidence, verification, outcome ═══

$ fm-report.sh append -  # scope_discovery
{
  "acceptanceSequence": 1,
  "accepted": true,
  "kind": "scope_discovery",
  "scope": {
    "judgment": "A distinct integration risk emerged.",
    "title": "Context fencing"
  }
}

$ fm-report.sh append -  # scope_revision (Scope is continuous)
{
  "acceptanceSequence": 2,
  "accepted": true,
  "kind": "scope_revision",
  "scope": {
    "change": "split",
    "reason": "Fencing separated from the transport rewrite."
  }
}

$ fm-report.sh append -  # hill_judgment, uphill/forward
{
  "accepted": true,
  "hill": {
    "judgment": "The unknowns are naming themselves.",
    "movement": "forward",
    "phase": "uphill"
  }
}

$ fm-report.sh append -  # hill_judgment may move BACKWARD as learning changes the picture
{
  "accepted": true,
  "hill": {
    "judgment": "A hidden coupling put the Scope back uphill.",
    "movement": "backward",
    "phase": "uphill"
  }
}

$ fm-report.sh append -  # numeric progress is REFUSED: no count can determine Hill position
{
  "accepted": false,
  "error": "invalid_hill",
  "message": "Hill reports must be qualitative judgments and may move backward",
  "storedStatus": "rejected"
}

$ fm-report.sh append -  # blocker
{
  "accepted": true,
  "kind": "blocker"
}

$ fm-report.sh append -  # evidence against the mission contract, verified
{
  "accepted": true,
  "evidence": {
    "contract": "automated-tests",
    "executionRevision": "exec:r1",
    "producer": "keiko",
    "reference": {
      "kind": "file",
      "mediaType": "text/plain",
      "value": "/tmp/fm-e2e.XHkqYw/projects/task-42/evidence/tests.txt"
    },
    "verification": {
      "instructions": "Run bash tests/fm-report.test.sh and read the summary.",
      "status": "verified"
    },
    "verifier": "firstmate"
  }
}

$ fm-report.sh append -  # verification_instructions for a human verifier
{
  "accepted": true,
  "kind": "verification_instructions"
}

$ fm-report.sh append -  # outcome
{
  "accepted": true,
  "kind": "outcome",
  "outcome": {
    "state": "completed",
    "summary": "Fencing landed with a verified suite."
  }
}


═══ 4. Rejected records are PRESERVED and typed, never silently dropped ═══

$ fm-report.sh append -  # a report correlated to a different Build
{
  "accepted": false,
  "error": "cross_build",
  "storedStatus": "rejected"
}

$ snapshot | .reports[] | {reportId, status, error}   # both rejects survive as history
[
  {
    "error": null,
    "reportId": "r-blocker-1",
    "status": "accepted"
  },
  {
    "error": "cross_build",
    "reportId": "r-cross",
    "status": "rejected"
  },
  {
    "error": null,
    "reportId": "r-evidence-1",
    "status": "accepted"
  },
  {
    "error": null,
    "reportId": "r-hill-1",
    "status": "accepted"
  },
  {
    "error": null,
    "reportId": "r-hill-2",
    "status": "accepted"
  },
  {
    "error": "invalid_hill",
    "reportId": "r-hill-bad",
    "status": "rejected"
  },
  {
    "error": null,
    "reportId": "r-outcome-1",
    "status": "accepted"
  },
  {
    "error": null,
    "reportId": "r-scope-1",
    "status": "accepted"
  },
  {
    "error": null,
    "reportId": "r-scope-2",
    "status": "accepted"
  },
  {
    "error": null,
    "reportId": "r-verify-1",
    "status": "accepted"
  }
]


═══ 5. Decision holds are the SOLE Captain-attention lifecycle ═══

$ fm-report.sh append -  # a consequential report raises one durable Captain Call
{
  "accepted": true,
  "condition": {
    "affectedObjects": [
      "build-8",
      "scope-context"
    ],
    "boundRevisions": {
      "build": "build-8:r7"
    },
    "choices": [
      "defer",
      "retain"
    ],
    "conditionId": "scope-drop",
    "consequenceOfDelay": "Execution stays blocked on an undecided Scope.",
    "creationSequence": 1,
    "evidence": [],
    "explanation": "Dropping the Scope changes the accepted Build outcome.",
    "holdId": "mission-42-decision-scope-drop",
    "lifecycle": "raised",
    "packetRevision": "627ced6aa9fc0283edf5932c9eb53be0674c2d758e157af6970d1f62ddbc17bb",
    "projection": {
      "projectedAt": "2026-08-01T12:00:00Z",
      "status": "projected"
    },
    "recommendation": "Defer the Scope explicitly.",
    "title": "Drop or retain the fencing Scope"
  }
}

$ fm-decision-hold.sh status mission-42 scope-drop --json
{
  "schemaVersion": "fm-captain-call-status.v1",
  "conditionId": "scope-drop",
  "holdId": "mission-42-decision-scope-drop",
  "lifecycle": "raised",
  "packetRevision": "627ced6aa9fc0283edf5932c9eb53be0674c2d758e157af6970d1f62ddbc17bb",
  "durableState": {
    "state": "queued",
    "held": true
  }
}

$ projection intent acknowledgeCondition  # attention only - never resolves the hold
{
  "accepted": true,
  "error": null,
  "outcome": {
    "action": "acknowledgeCondition",
    "implications": {
      "buildCloseout": false,
      "cycleClose": false,
      "delivery": false
    },
    "intentId": "ack-1",
    "recordedAt": "2026-08-01T12:00:00Z",
    "replayed": false,
    "status": "acknowledged"
  }
}

$ fm-decision-hold.sh status mission-42 scope-drop --json  # still held
{
  "schemaVersion": "fm-captain-call-status.v1",
  "conditionId": "scope-drop",
  "holdId": "mission-42-decision-scope-drop",
  "lifecycle": "raised",
  "packetRevision": "627ced6aa9fc0283edf5932c9eb53be0674c2d758e157af6970d1f62ddbc17bb",
  "durableState": {
    "state": "queued",
    "held": true
  }
}

$ tasks-axi add routed-scope-work ... && tasks-axi block routed-scope-work --by <holdId>
routed work is queued and blocked by the Captain Call

$ projection intent resolveCondition  # routes the decision and closes that same hold
{
  "accepted": true,
  "error": null,
  "outcome": {
    "action": "resolveCondition",
    "implications": {
      "buildCloseout": false,
      "cycleClose": false,
      "delivery": false
    },
    "intentId": "resolve-1",
    "recordedAt": "2026-08-01T12:00:00Z",
    "replayed": false,
    "status": "resolved"
  }
}

$ fm-decision-hold.sh status mission-42 scope-drop --json  # durably resolved
{
  "schemaVersion": "fm-captain-call-status.v1",
  "conditionId": "scope-drop",
  "holdId": "mission-42-decision-scope-drop",
  "lifecycle": "resolved",
  "packetRevision": null,
  "durableState": {
    "state": "done",
    "held": false
  }
}

$ snapshot | .conditions[0]
{
  "conditionId": "scope-drop",
  "holdId": "mission-42-decision-scope-drop",
  "lifecycle": "resolved",
  "packetRevision": "627ced6aa9fc0283edf5932c9eb53be0674c2d758e157af6970d1f62ddbc17bb",

... [1938 bytes truncated] ...

r": null,
  "outcome": {
    "action": "acceptBuildReview",
    "implications": {
      "buildCloseout": false,
      "cycleClose": false,
      "delivery": false
    },
    "intentId": "review-1",
    "recordedAt": "2026-08-01T12:00:00Z",
    "replayed": false,
    "status": "captainAccepted"
  }
}

$ projection intent acceptBuildReview  # exact replay returns the prior outcome
{
  "accepted": true,
  "replayed": true,
  "status": "captainAccepted"
}

$ fm-mission.sh accept -  # a second active mission bound to a DIFFERENT Build revision
{
  "accepted": true,
  "acceptedBuildRevision": "build-8:r8",
  "missionId": "mission-43"
}

$ snapshot | .buildReviews[0]  # one packet covers BOTH active missions
{
  "buildRevision": null,
  "buildRevisions": [
    "build-8:r7",
    "build-8:r8"
  ],
  "missionSet": [
    {
      "buildRevision": "build-8:r7",
      "missionId": "mission-42",
      "terminal": true
    },
    {
      "buildRevision": "build-8:r8",
      "missionId": "mission-43",
      "terminal": false
    }
  ],
  "ready": false,
  "revisionConflict": true
}

$ projection intent acceptBuildReview  # conflicting bound revisions are a typed refusal
{
  "accepted": false,
  "error": "review_revision_conflict",
  "message": "Active missions in this Build are bound to conflicting Build revisions"
}

$ projection intent acceptBuildReview  # the superseded packet is typed stale, not silently retried
{
  "accepted": false,
  "error": "stale_packet",
  "message": "Build Review packet changed before Captain acceptance"
}


═══ 7. Supervisor-owned guarded ShapeUp submission with protected credentials ═══

$ fm-shapeup-client.sh capabilities
{
  "accepted": true,
  "capabilities": {
    "accepted": true,
    "capabilities": [
      "scope.write",
      "hill.write"
    ],
    "contractVersion": "shapeup-engineering.v1"
  },
  "schemaVersion": "fm-shapeup-client.v1"
}

$ fm-shapeup-client.sh submit r-scope-1
{
  "accepted": true,
  "error": null,
  "outcome": {
    "authoritativeRevision": "shapeup:r9",
    "idempotencyKey": "fm-report:r-scope-1:612b3e0a6e83888a02a8dae686b9e798682eb5369f32cdd1fcba45a0b501c5cc",
    "recordedAt": "2026-08-01T12:00:00Z",
    "replayed": false,
    "reportId": "r-scope-1",
    "reportRevision": "612b3e0a6e83888a02a8dae686b9e798682eb5369f32cdd1fcba45a0b501c5cc",
    "status": "applied"
  }
}

$ fm-shapeup-client.sh submit r-scope-1   # durable replay, transport not re-invoked
{
  "accepted": true,
  "replayed": true,
  "status": "applied"
}

$ grep -c s3cr3t-workspace-token <(all client output)   # credential leakage check
clean: the workspace credential never appears in client output

$ cat transport-argv.log   # the credential reaches the child only through the environment
argc=0 argv=[] token_seen_in_env=yes
argc=0 argv=[] token_seen_in_env=yes
argc=0 argv=[] token_seen_in_env=yes

$ chmod 644 config/shapeup-token && fm-shapeup-client.sh submit r-hill-1
{
  "accepted": false,
  "error": {
    "code": "credential_permissions",
    "message": "ShapeUp credential file must be owner-only"
  }
}

$ <transport removed> fm-shapeup-client.sh submit r-hill-1   # typed unavailable, not a false success
{
  "accepted": false,
  "error": {
    "code": "shapeup_unavailable",
    "message": "ShapeUp capability negotiation is unavailable"
  }
}

$ <transport removed> fm-shapeup-client.sh submit r-scope-1   # prior durable outcome still replays
{
  "accepted": true,
  "replayed": true,
  "status": "applied"
}

$ snapshot | .shapeUpOutcomes   # ShapeUp stays authoritative for its own facts
[
  {
    "outcome": {
      "authoritativeRevision": "shapeup:r9",
      "idempotencyKey": "fm-report:r-scope-1:612b3e0a6e83888a02a8dae686b9e798682eb5369f32cdd1fcba45a0b501c5cc",
      "recordedAt": "2026-08-01T12:00:00Z",
      "replayed": false,
      "reportId": "r-scope-1",
      "reportRevision": "612b3e0a6e83888a02a8dae686b9e798682eb5369f32cdd1fcba45a0b501c5cc",
      "status": "applied"
    },
    "requestDigest": "612b3e0a6e83888a02a8dae686b9e798682eb5369f32cdd1fcba45a0b501c5cc"
  }
]


═══ 8. Optional, exact, bounded, non-authoritative session inspection ═══

$ cat pane.txt   # what the live 40-column pane actually holds
----------------------------------------| <- 40-column pane edge
running tests...                        |
Authorization: Bearer fm_fake_51QsecretP|
AYLOADabcdefghijklmnop                  |
SERVICE_TOKEN=another-live-secret       |
suite: 8 files, 0 failures              |

$ projection inspectSession (exact mission revision)
{
  "accepted": true,
  "error": null,
  "inspection": {
    "authoritative": false,
    "available": true,
    "capture": {
      "bytes": 101,
      "lines": 20,
      "text": "running tests...\nAuthorization: Bearer [REDACTED]\nSERVICE_TOKEN=[REDACTED]\nsuite: 8 files, 0 failures",
      "truncated": false
    },
    "descriptor": {
      "backend": "tmux",
      "lifecycle": "running",
      "targetId": "firstmate:fm-task-42",
      "taskId": "task-42"
    },
    "mode": "bounded-read-only"
  }
}

$ fragment check: does any 8-char window of the wrapped secret survive?
clean: no 8-character window of the pane-wrapped credential survives redaction

$ projection inspectSession with a STALE expected mission revision
{
  "accepted": false,
  "error": {
    "code": "stale_revision",
    "message": "Mission revision changed before session inspection"
  }
}


═══ 9. A hand-edited record is isolated: Build Review fails CLOSED, everything else stays up ═══

$ printf "{ not json" > data/engineering/reports/r-evidence-1.json

$ snapshot | .invalidRecords   # the broken record stays visible and non-executable
[
  {
    "buildRef": null,
    "cycleRef": null,
    "error": {
      "code": "malformed_record",
      "message": "Record is not a valid JSON object"
    },
    "kind": "report",
    "recordId": "r-evidence-1"
  }
]

$ snapshot | .buildReviews[0]  # never ready while an isolated record bears on it
{
  "isolatedRecords": [
    {
      "error": "malformed_record",
      "kind": "report",
      "recordId": "r-evidence-1"
    }
  ],
  "ready": false,
  "revisionConflict": true
}

$ projection intent acceptBuildReview <current packet>  # refuses with its own typed error,
                                              # ahead of the revision conflict verdict
{
  "accepted": false,
  "error": "review_records_isolated",
  "message": "A stored mission or report record for this Build is invalid, so the packet cannot prove it covers every active mission"
}

$ echo <capabilities> | fm-captains-log-projection.sh   # every other operation is unaffected
{
  "accepted": true,
  "core": "available"
}


═══ 10. The projection is embedded in the read-only fleet snapshot ═══

$ fm-fleet-snapshot.sh | .captains_log_projection
{
  "buildReviews": [
    {
      "buildRef": "build-8",
      "ready": false
    }
  ],
  "capturedAt": "2026-08-01T12:00:00Z",
  "conditions": [
    {
      "conditionId": "scope-drop",
      "lifecycle": "resolved",
      "projection": {
        "projectedAt": "2026-08-01T12:00:00Z",
        "status": "projected"
      }
    }
  ],
  "freshness": "fresh",
  "invalidRecords": [],
  "missions": [
    {
      "acceptedBuildRevision": "build-8:r7",
      "missionId": "mission-42",
      "state": "accepted"
    },
    {
      "acceptedBuildRevision": "build-8:r8",
      "missionId": "mission-43",
      "state": "accepted"
    }
  ],
  "outcomes": [
    {
      "action": "acknowledgeCondition",
      "implications": {
        "buildCloseout": false,
        "cycleClose": false,
        "delivery": false
      },
      "status": "acknowledged"
    },
    {
      "action": "resolveCondition",
      "implications": {
        "buildCloseout": false,
        "cycleClose": false,
        "delivery": false
      },
      "status": "resolved"
    },
    {
      "action": "acceptBuildReview",
      "implications": {
        "buildCloseout": false,
        "cycleClose": false,
        "delivery": false
      },
      "status": "captainAccepted"
    }
  ],
  "reportCount": 12,
  "schemaVersion": "fm-captains-log-snapshot.v1"
}


Demo FM_HOME: /tmp/fm-e2e.XHkqYw
```
</details>
- Evidence: Walkthrough script that produced the transcript (re-runnable: bash e2e-captains-log-walkthrough.sh &lt;repo-root&gt;) (local file: <code>/var/folders/2g/z6s_jsfx13b37_l46phgrnn00000gn/T/no-mistakes-evidence/01KZ296JNYPNXW5DBYWCEZG4PM/e2e-captains-log-walkthrough.sh</code>)
<details>
<summary>Evidence: Persisted store state after the walkthrough: retained rejected records, durable outcomes, closed Captain hold, no credential anywhere on disk</summary>

```text
$ find data/engineering -type f | sort   # durable record store the projection reads
data/engineering/decisions/resolve-1.txt
data/engineering/missions/mission-42.json
data/engineering/missions/mission-43.json
data/engineering/outcomes/ack-1.json
data/engineering/outcomes/resolve-1.json
data/engineering/outcomes/review-1.json
data/engineering/reports.sequence
data/engineering/reports/r-blocker-1.json
data/engineering/reports/r-condition-1.json
data/engineering/reports/r-cross.json
data/engineering/reports/r-evidence-1.json
data/engineering/reports/r-hill-1.json
data/engineering/reports/r-hill-2.json
data/engineering/reports/r-hill-bad.json
data/engineering/reports/r-outcome-1.json
data/engineering/reports/r-outcome-2.json
data/engineering/reports/r-scope-1.json
data/engineering/reports/r-scope-2.json
data/engineering/reports/r-verify-1.json
data/engineering/shapeup-outcomes/r-scope-1.json

$ jq '{reportId,kind,status,rejectedAt,error,hill}' data/engineering/reports/r-hill-bad.json
# a numeric-progress Hill report: refused, but retained verbatim and typed
{
  "error": {
    "code": "invalid_hill",
    "message": "Hill reports must be qualitative judgments and may move backward"
  },
  "hill": {
    "judgment": "Nearly there.",
    "phase": "downhill",
    "progress": 80
  },
  "kind": "hill_judgment",
  "rejectedAt": "2026-08-01T12:00:00Z",
  "reportId": "r-hill-bad",
  "status": "rejected"
}

$ jq '{reportId,kind,status,error,shapeUp:.correlation.shapeUp}' data/engineering/reports/r-cross.json
{
  "error": {
    "code": "cross_build",
    "message": "Report correlation does not match the accepted Build"
  },
  "kind": "scope_discovery",
  "reportId": "r-cross",
  "shapeUp": {
    "buildRef": "build-9",
    "buildRevision": "build-9:r1",
    "cycleRef": "cycle-13",
    "scopeRef": "scope-context"
  },
  "status": "rejected"
}

$ tasks-axi show mission-42-decision-scope-drop --full
# the sole Captain-attention lifecycle, durably closed by the resolveCondition intent
task:
  id: mission-42-decision-scope-drop
  title: Drop or retain the fencing Scope
  state: done
  blocked: no
  blocked_by: none
  held: no
  hold_reason: captain decision pending for scope-drop
  hold_kind: captain
  hold_until: "-"
  kind: captain
  repo: firstmate
  priority: "-"
  created: "-"
  closed: 2026-08-02
  deps: none
  links: none
  body: "Resolution recorded by fm-decision-hold.\nDecision digest: f78efc4e5028a8d184e1570c067e809e57c58365d8d79243fcd92adade3acf0a\nRouted identities: routed-scope-work\n\nCaptain decision:\nDefer the fencing Scope to the next Cycle.\n\nRouted work:- routed-scope-work"

$ grep -ri 's3cr3t-workspace-token' data/ state/ config/shapeup-client.json  # credential never persisted outside the owner-only file
(no matches)
```
</details>
<details>
<summary>Evidence: Captain-attention lifecycle and Build Review refusals (excerpt from the transcript)</summary>

```text
$ projection intent acknowledgeCondition # attention only - never resolves the hold
{"accepted": true, "outcome": {"action": "acknowledgeCondition", "status": "acknowledged",
"implications": {"buildCloseout": false, "cycleClose": false, "delivery": false}}}

$ fm-decision-hold.sh status mission-42 scope-drop --json # still held
{"lifecycle": "raised", "durableState": {"state": "queued", "held": true}}

$ projection intent resolveCondition # routes the decision and closes that same hold
{"accepted": true, "outcome": {"action": "resolveCondition", "status": "resolved"}}

$ fm-decision-hold.sh status mission-42 scope-drop --json # durably resolved
{"lifecycle": "resolved", "durableState": {"state": "done", "held": false}}

$ projection intent resolveCondition # reusing an intentId with different content
{"accepted": false, "error": "identity_conflict"}

$ projection intent acceptBuildReview # conflicting bound revisions
{"accepted": false, "error": "review_revision_conflict"}

$ projection intent acceptBuildReview # superseded packet
{"accepted": false, "error": "stale_packet"}

$ projection intent acceptBuildReview # a hand-edited record makes Review fail CLOSED
{"accepted": false, "error": "review_records_isolated"}
```
</details>
<details>
<summary>Evidence: Credential protection: ShapeUp argv boundary and pane-wrap redaction (excerpt from the transcript)</summary>

```text
$ cat transport-argv.log # the credential reaches the child only through the environment
argc=0 argv=[] token_seen_in_env=yes

$ grep s3cr3t-workspace-token <(all client output)
clean: the workspace credential never appears in client output

$ cat pane.txt # what the live 40-column pane actually holds
----------------------------------------| <- 40-column pane edge
running tests... |
Authorization: Bearer fm_fake_51QsecretP|
AYLOADabcdefghijklmnop |
SERVICE_TOKEN=another-live-secret |
suite: 8 files, 0 failures |

$ projection inspectSession (exact mission revision)
{"accepted": true, "inspection": {"available": true, "authoritative": false,
"mode": "bounded-read-only",
"capture": {"text": "running tests...\nAuthorization: Bearer [REDACTED]\nSERVICE_TOKEN=[REDACTED]\nsuite: 8 files, 0 failures"},
"descriptor": {"backend": "tmux", "lifecycle": "running", "targetId": "firstmate:fm-task-42", "taskId": "task-42"}}}

$ fragment check: does any 8-char window of the wrapped secret survive?
clean: no 8-character window of the pane-wrapped credential survives redaction
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

_... (3 earlier update rounds omitted to keep the PR body within GitHub's 65536-char limit; full history is in the run log.)_

<details>
<summary>⚠️ **Review** - 2 infos</summary>

🔧 Fix: fix(engineering): close redaction, replay, ordering, and durability gaps
6 issues (4 warnings, 2 infos) still open:
- ⚠️ `bin/fm-peek.sh:104` - The new colon rule `s/($names)[[:space:]]*:[[:space:]]*[^[:space:]]+/\1: [REDACTED]/g`, combined with the `contiguous` detection at line 80 (`row ~ (&#34;(&#34; names &#34;)[[:space:]]*[=:]$&#34;)`), fires on ordinary inert pane output because the vocabulary matches bare words like `tokens`, `password`, and `access-key`. Reproduced by running the current `redact_capture` over a synthetic pane: rows `ok 12 usage summary for this run    tokens:` (pane-wide, inert) and `ok 13 unrelated assertion on next line` come back as the single line `ok 12 usage summary for this run    tokens: [REDACTED] 13 unrelated assertion on next line` — the next row&#39;s `ok` is consumed as the credential value, the redaction suppresses the span re-split, and two unrelated pane events are merged into one. A standalone `Total tokens: 4821 in this run` becomes `Total tokens: [REDACTED] in this run`, and `Retrieved access-key: none configured` / `Password: not required for this step` merge into one mangled line. Two things this contradicts: docs/captains-log-machine-projection.md still states &#34;A row that merely fills the pane without wrapping keeps its own line, so unrelated events are never merged into one&#34;, and tests/fm-engineering-lib.test.sh:284 pins `&#34;Total tokens: 4821 in this run, so we split the Scope.&#34;` as benign for record scanning while the pane path now redacts exactly that string. This fails closed (over-redaction, not a leak), so it is not a security regression — but it degrades the readability that is the entire point of session inspection. Narrowing the colon form is a product tradeoff: require the matched name to be a whole token bounded by start/whitespace/`-`/`_` rather than allowing the `[A-Za-z0-9_]*` wrapper, restrict the colon form to compound names (`api-key:`, `x-auth-token:`) and drop bare `token:`/`key:`, or additionally require a secret-shaped value.
- ⚠️ `bin/fm-report.sh:99` - `next_acceptance_sequence` reads `$SEQUENCE_FILE`, computes `next=$((current + 1))`, and writes it back with no mutual exclusion, while `fm-report.sh append` has no lock at all (unlike the projection&#39;s intent path, which uses a `mkdir` mutex precisely because concurrency is expected). Two crewmates appending into the same FM_HOME concurrently both read N and both stamp `acceptanceSequence: N+1`. In `build_reviews`, `def authoritative: sort_by(.acceptedAt // &#34;&#34;,.acceptanceSequence // 0,.reportId) | last` then falls through to `.reportId`, which is crewmate-supplied — reopening the exact ordering hole this fix closes, just behind a concurrency window instead of a same-second window. The code comment at line 71 and docs/captains-log-machine-projection.md both assert the stronger property (&#34;two reports accepted inside the same wall-clock second are still ordered by FirstMate rather than by anything the crewmate supplied&#34;), which does not hold under a concurrent append. Secondary: the same comment claims &#34;an interrupted append can only skip a number, never reuse one&#34;, but if `$SEQUENCE_FILE` is missing or corrupt, `acceptance_sequence_floor` recomputes the max from `xargs -0 cat` over the report store, and an unreadable report file is silently skipped by `cat 2&gt;/dev/null`, yielding a floor below the true max and reusing a sequence. Guard the read-increment-write with the same `mkdir`-based mutex the projection uses.
- ⚠️ `bin/fm-captains-log-projection.sh:321` - `partition_records` now drops a schema-invalid mission from `records`, so `build_reviews`&#39; `select((.state // &#34;accepted&#34;) == &#34;accepted&#34;)` never sees it and the packet&#39;s `missionSet` silently shrinks. tests/fm-build-review.test.sh:147 pins this: with `mission-44` isolated, `missionSet` is asserted to be exactly `[&#34;mission-42&#34;,&#34;mission-43&#34;]`. Before this commit the projection refused outright (`projection_unavailable`); now it proceeds fail-open. `intent_response` gates `acceptBuildReview` only on `.revisionConflict`, `.packetRevision`, and `.ready` (line 554) and never consults `snapshot.invalidRecords`, so if the isolated record were the only mission still non-terminal, the packet reports `ready: true` and the Captain can accept a Build Review that does not cover every active mission — contradicting &#34;One Build Review packet covers every active accepted mission of a Cycle and Build&#34; and &#34;The packet becomes ready only when each mission is terminal&#34;. The same applies to an isolated accepted `evidence` or `outcome` report, whose exclusion lets an older record decide readiness. The isolation itself is what was asked for; what needs a decision is whether readiness/acceptance should be suppressed (or the packet should carry an `isolatedRecords` flag) while any mission- or report-kind record is in `invalidRecords`.
- ⚠️ `bin/fm-report.sh:214` - `command_project` now short-circuits with `printf &#39;retained: ...&#39;` and `return 0` when the hold already carries a resolution record (bin/fm-decision-hold.sh:407) — correct for the replay fix, but it is indistinguishable from success to its callers. `project_condition_packet` redirects stdout to /dev/null and branches only on exit status, so it stamps `.condition.projection={status:&#34;projected&#34;,projectedAt:...}` even though the hold body was never updated with the new packet revision. Failure scenario: a `resolveCondition` partially fails after `resolve` wrote the retry-identity body (hold still queued); a crewmate then appends an updated report for the same condition; `hold` succeeds, `project` returns `retained`, and the durable record claims the packet landed. docs/captains-log-machine-projection.md guarantees the opposite: &#34;Every projected condition carries its `projection` state, so a held condition that never received its packet is visible to the Captain.&#34; Either have `command_project` return a distinct status for the retained case so `project_condition_packet` can record `degraded` (which `heal_condition_projection` already retries), or add an explicit `retained` projection state — the choice is user-visible, so it needs your call.
- ℹ️ `bin/fm-shapeup-client.sh:98` - Two rough edges in the perl timeout fallback. (1) `if (!$pid) { setpgrp(0, 0); exec @ARGV }` has no `or exit` guard: a transport with a broken shebang makes `execve` fail with ENOENT, `exec` returns false, and the child falls through into the parent&#39;s code — installing an ALRM handler and calling `waitpid $pid, 0` with `$pid == 0`, which returns immediately and exits with an arbitrary `$? &gt;&gt; 8`. The `-f`/`-x` precheck at line 76 does not catch a bad interpreter line. Add `exec @ARGV or exit 127`. (2) `exit($? &gt;&gt; 8)` reports 0 when the transport is killed by a signal, so a transport that emitted a complete JSON object and was then SIGKILLed is treated as a successful submission and journalled. Map a signal death to a non-zero status (e.g. `exit($? &amp; 127 ? 126 : $? &gt;&gt; 8)`).
- ℹ️ `bin/fm-shapeup-client.sh:105` - With no `timeout`, `gtimeout`, or `perl` on PATH, `transport_call` now returns 8 and every submission fails with `shapeup_unavailable`/`transport_unbounded`, where it previously ran unbounded and worked. docs/shapeup-client.md documents this deliberately (&#34;a host with no way to bound a child process refuses the call instead of running it unbounded&#34;) and the fallback chain covers macOS and mainstream Linux, so this is a noted tradeoff rather than a defect — recording it so the new runtime dependency is visible if the client is ever run in a minimal container image.

🔧 Fix: fix(engineering): narrow colon redaction, lock sequence, fail-closed review
5 issues (2 warnings, 3 infos) still open:
- ⚠️ `bin/fm-peek.sh:111` - The narrowed colon rule `s/(^|[[:space:]])($labels)[[:space:]]*:[[:space:]]*[^[:space:]]{6,}/` correctly stops redacting inert telemetry, but it gives up two shapes the previous revision covered. Reproduced against the current `redact_capture`: `apitoken: fm_fake_gluedvalue123` and `dbpassword: fm_fake_gluedvalue456` come back unchanged, because `fm_eng_credential_label_ere` (bin/fm-engineering-lib.sh:82) requires the vocabulary word to be a whole separator-delimited component (`([A-Za-z0-9]+[-_])*(ALT)([-_][A-Za-z0-9]+)*`) and a glued lowercase name has no separator; the previous `($names)` form, which kept the `[A-Za-z0-9_]*` wrapper, matched them. `Password: hunt3` is also unchanged now, because the operand is below the `{6,}` bound. The `=` form still covers both (`apitoken=[REDACTED]` verified), so the gap is colon-specific. Lowercase glued keys are ordinary in YAML, `.env`, and config dumps a pane echoes. Separately worth noting while you are in this rule: a quoted label such as `{&#34;api_key&#34;: &#34;sk_fm_fake_live...&#34;}` or `  &#34;password&#34;: &#34;...&#34;` is matched by neither form, because `(^|[[:space:]])` requires the label to start immediately after whitespace and a leading quote blocks it — that one is pre-existing rather than new. Options if you want the coverage back without reintroducing the `tokens:` false positive: allow a leading quote/brace/dash in the anchor class, permit a glued prefix only when the credential word ends the label (`(^|[[:space:]&#34;&#39;{\[])[A-Za-z0-9]*(ALT)([-_][A-Za-z0-9]+)*`), or lower the operand bound and instead require the operand to look secret-shaped.
- ⚠️ `bin/fm-engineering-lib.sh:189` - `fm_eng_lock_release_all` iterates `for dir in $FM_ENG_LOCK_HELD`, an unquoted space-joined string built at line 214 (`FM_ENG_LOCK_HELD=&#34;${FM_ENG_LOCK_HELD}${FM_ENG_LOCK_HELD:+ }$dir&#34;`). A lock directory whose path contains a space is split into fragments, so `fm_eng_lock_remove` is called on paths that do not exist and the real directory is never removed. Reproduced with an FM_HOME of `.../My Home`: `fm_eng_lock_acquire` then `fm_eng_lock_release_all` leaves the lock directory behind (`fm_eng_lock_release` survives only because it calls `fm_eng_lock_remove &#34;$1&#34;` directly, ignoring its own broken bookkeeping). This matters most in `bin/fm-captains-log-projection.sh`, where `trap fm_eng_lock_release_all RETURN` (line 456) is the *only* release path for the intent mutex — every intent on such a home leaks a directory under `state/fm-projection-intent-locks/`, which then accumulates one per intentId. It self-heals (the next acquirer sees a dead owner and reclaims at once) rather than wedging, and it also defeats the INT/TERM/HUP traps in `bin/fm-report.sh`. `fm_eng_lock_release`&#39;s `kept` rebuild is corrupted the same way once more than one lock is held. Use a newline-delimited list read under `IFS=$&#39;\n&#39;`, or track held locks in a bash array.
- ℹ️ `bin/fm-engineering-lib.sh:232` - `fm_eng_lock_acquire` returns 1 both for contention (`mkdir &#34;$dir&#34;` failed after reclaim) and for a permanent condition (`mkdir -p &#34;$(dirname &#34;$dir&#34;)&#34;` failed — unwritable or missing `$STATE`). `fm_eng_lock_acquire_wait` cannot tell them apart and retries 100 times regardless, so `fm-report.sh append` on a home with a non-writable `state/` stalls the reporting crewmate for the full wait before returning `record_not_durable` — and it now takes that path on *every* append, since `next_acceptance_sequence` (bin/fm-report.sh:110) is unconditional. Return a distinct status for the un-creatable-parent case and fail fast on it. While there: `sleep 0.05 2&gt;/dev/null || sleep 1` means the wait is ~5s on hosts whose `sleep` accepts fractions and ~100s on one that does not, so the bound the retry count implies is not the bound a caller actually gets.
- ℹ️ `bin/fm-engineering-lib.sh:82` - `fm_eng_credential_label_ere` recovers the alternation by stripping the literal wrapper text off `fm_eng_credential_name_ere`&#39;s output (`word=${names#&#39;[A-Za-z0-9_]*(&#39;}` / `word=${word%&#39;)[A-Za-z0-9_]*&#39;}`). That couples the label form to the exact `printf &#39;[A-Za-z0-9_]*(%s)[A-Za-z0-9_]*&#39;` format string two functions away: change the wrapper and the strip silently no-ops, leaving `word` as the whole name ERE and producing a label regex that matches far more than intended, with no error. Extract the alternation into a `fm_eng_credential_alternation` helper that both `fm_eng_credential_name_ere` and `fm_eng_credential_label_ere` wrap, so neither has to parse the other&#39;s output.
- ℹ️ `bin/fm-captains-log-projection.sh:259` - The isolation filter `select((.cycleRef == null or .buildRef == null) or (.cycleRef == $shape.cycleRef and .buildRef == $shape.buildRef))` means any isolated mission or report whose own correlation is unreadable withholds readiness from *every* Build Review, not just the bound Build — and an unparseable JSON file always lands in that bucket, since `collect_records` stamps `cycleRef: null, buildRef: null` for `malformed_record`. That is the documented and requested fail-closed behavior (docs/captains-log-machine-projection.md: &#34;could belong to any Build, so it withholds readiness across the Review set&#34;), and the record is named in `invalidRecords` so the operator can find it. Recording the blast radius rather than proposing a change: one corrupt file in `data/engineering/reports/` blocks Captain acceptance of every Build until it is repaired or removed.

🔧 Fix: fix(engineering): restore colon secrets, path-safe locks, fast lock refusal
3 issues (1 warning, 2 infos) still open:
- ⚠️ `bin/fm-engineering-lib.sh:296` - `fm_eng_lock_acquire_wait` derives `attempts` from the requested seconds (`attempts=$((seconds * 20))` at line 296) and counts only the `sleep &#34;$unit&#34;` between attempts, but each attempt calls `fm_eng_lock_acquire` -&gt; `fm_eng_lock_reclaim` -&gt; `fm_eng_lock_owner_state`, which forks roughly ten processes (`dirname`, `mkdir`, three `sed`, three `head`, `ps`, `tr`). That overhead is unbudgeted, so the delivered bound is about 2.5x the requested one. Measured on an idle machine against a live-owner lock: requested 1s took 2551ms, 2s took 5390ms, and the default 5s took 12470ms. This contradicts the comment at line 276 (&#34;the bound a caller asks for is the bound it gets whether or not this host&#39;s sleep accepts a fraction&#34;) and the new docs/captains-log-machine-projection.md:113 claim that &#34;contention is waited out for a bound expressed in seconds&#34;. The practical cost is a ~12.5s stall on `fm-report.sh append` — the crewmate&#39;s reporting path — whenever two appends contend, plus ~1000 process spawns for that one wait. Two consequences to fix together: compute the deadline from a wall clock and stop when it passes rather than counting attempts, and stop re-running the full owner probe on every retry (probe once, then just retry `mkdir`, re-probing only occasionally). Note also that the new tests/fm-engineering-lib.test.sh:220 ceiling `[ &#34;$elapsed&#34; -le 6 ]` for a 2s bound leaves only ~0.6s of headroom over the 5.4s measured here, so it is likely to flake on a slower or loaded CI runner.
- ℹ️ `bin/fm-engineering-lib.sh:267` - `FM_ENG_LOCK_PAUSE_UNIT` is intended to memoize the fractional-sleep probe, but `fm_eng_lock_pause_unit` is invoked as `unit=$(fm_eng_lock_pause_unit)` (line 289), so the assignment happens in a command-substitution subshell and never reaches the parent. Verified: after three `fm_eng_lock_acquire_wait` calls the parent&#39;s `FM_ENG_LOCK_PAUSE_UNIT` is still empty. Because the probe body runs a real `sleep 0.05`, every `fm_eng_lock_acquire_wait` pays it — including the uncontended common path, since the probe is called before the first acquire attempt. Measured: an uncontended `fm_eng_lock_acquire_wait` costs 154ms against 26ms for a bare `fm_eng_lock_acquire`, so roughly 128ms is added to every `fm-report.sh append` for a capability check whose answer never changes. Have the function assign the global directly and return, rather than being consumed through `$(...)`; better still, defer the probe until the first retry is actually needed.
- ℹ️ `bin/fm-peek.sh:117` - The new line-final colon rule accepts an operand of any length, which makes the pre-existing &#34;redaction suppresses the span re-split&#34; mechanism fire on short, inert-looking values and merge unrelated pane rows again — a narrower instance of the round-2 class. Reproduced: rows `checking configuration values and other things` (pane-wide, inert) and `password: unset` come back as the single line `checking configuration values and other thingspassword: [REDACTED]`, while the same shape with a non-line-final operand (`password: unset for now`) correctly keeps both rows. docs/captains-log-machine-projection.md:134 still states &#34;A row that merely fills the pane without wrapping keeps its own line, so unrelated events are never merged into one.&#34; The redaction itself is defensible fail-closed behavior; the lost event boundary is not. Root cause is in the final awk stage, which prints the merged text whenever `index(text, &#34;[REDACTED]&#34;) &gt; 0` regardless of where the marker sits: re-split on the recorded spans when every `[REDACTED]` marker lies wholly inside one span, and only keep the merged line when a redaction actually straddles a span boundary.

🔧 Fix: fix(engineering): real lock deadline, deferred probe, row boundaries
2 issues (1 warning, 1 info) still open:
- ⚠️ `bin/fm-peek.sh:138` - `settle()` prints `logical` (the joined form) whenever `joined_rows != logical`, on the assumption that any disagreement means a redaction straddled a wrap. It can also mean the per-row pass redacted something the joined pass missed, and in that case the more-redacted result is discarded. Reproduced: a pane-wide row `...password: hunt3` followed by `  more context here` returns `checking configuration values and other  step 4 of 9 note now  password: hunt3  more context here` with the value in the clear, while the identical rows with the credential row last return `password: [REDACTED]`. Mechanism: the row pass matches rule 2 (line-final operand, any length) because `hunt3` ends row B, but in the joined line `hunt3` is followed by row C&#39;s leading space so it is neither line-final nor long enough for rule 1&#39;s `{6,}` bound; the forms disagree and the un-redacted joined form wins. Confirmed bounded to operands under six characters — `hunt36` and `fm_fake_longsecret1` are redacted correctly in the same geometry. This is not a regression (the previous revision leaked the same input through the single-form path), but this commit already computes the correct answer in the R pass. Fix: on disagreement prefer whichever form carries more `[REDACTED]` markers, falling back to the joined form only on a tie — that keeps the straddling-wrap case (joined has one marker, rows have none) and stops discarding a row-only redaction. The docs claim at docs/captains-log-machine-projection.md:137 (&#34;only a redaction that straddles a wrap keeps the joined line&#34;) describes the intended rule, not the implemented one.
- ℹ️ `bin/fm-engineering-lib.sh:313` - `deadline=$(( $(date +%s) + seconds ))` reads a whole-second clock, so the delivered wait is anywhere from `seconds - 1` to `seconds`. Measured: a 1s request completed in 403ms — under 60% of the requested grace period — while 2s/5s/6s came in at 2030ms/4849ms/6132ms. Only very short overrides of `FM_REPORT_SEQUENCE_LOCK_WAIT_SECONDS` or `fm_eng_lock_acquire_wait`&#39;s fourth argument are affected, and the default 5s is accurate enough, so this is polish rather than a defect. Add one second to the deadline (or derive it from the same sub-second source the pause unit already proves is available) so the requested bound is a floor rather than a ceiling.

🔧 Fix: fix(engineering): safe redaction candidate, lock deadline floor
2 infos still open:
- ℹ️ `bin/fm-peek.sh:160` - The six-expression sed rule block is now written out twice, verbatim, at lines 121-127 and 160-166, and the `claim` awk function is duplicated at lines 89-94 and 133-138. The safety invariant survives drift — both candidates pass through the second block, and the joined candidate is built from rows that already passed the first, so an expression present in only one block cannot release a value the other masked — but it does silently change behavior: a rule added only to the first block stops catching straddling wraps, and one added only to the second makes the two candidates disagree on inputs where nothing straddled, costing row boundaries for no reason. Neither failure produces an error. Collect the `-e` expressions into a shell array (`local -a rules=(-e &#39;...&#39; -e &#39;...&#39;)`) built once from `$names`/`$labels`/`$anchor`/`$quotes` and expand it at both call sites, and pass the shared `claim` body to both awk stages through a single here-doc or `-v` prologue.
- ℹ️ `tests/fm-peek.test.sh:350` - `refute_fragments &#34;session inspection&#34; &#34;$candidate_inspection&#34; &#34;$CANDIDATE_SECRET&#34;` never executes its body. `refute_fragments` (line 105) loops `for ((i = 0; i + window &lt;= ${#secret}; i++))` with `window=8`, and `CANDIDATE_SECRET=&#39;hunt3&#39;` is five characters, so `0 + 8 &lt;= 5` is false and zero comparisons run. The peek output is genuinely covered by the explicit `case` at line 347, but the projection&#39;s `inspectSession` path — which the new case&#39;s own comment says must never publish a value the other candidate masked — has no effective assertion at all. The same is true of the `refute_fragments` call for `SHORT_VALUE=&#39;hunt3&#39;` earlier in the file. Add a direct `case &#34;$(printf &#39;%s&#39; &#34;$candidate_inspection&#34; | jq -r &#39;.inspection.capture.text&#39;)&#34; in *&#34;$CANDIDATE_SECRET&#34;*) fail ...` check alongside the existing one, or have `refute_fragments` fall back to a whole-string containment check when the secret is shorter than its window.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bash tests/fm-captains-log-projection.test.sh`
- `bash tests/fm-mission-shapeup.test.sh`
- `bash tests/fm-report.test.sh`
- `bash tests/fm-shapeup-client.test.sh`
- `bash tests/fm-decision-hold.test.sh`
- `bash tests/fm-build-review.test.sh`
- `bash tests/fm-peek.test.sh`
- `bash tests/fm-engineering-lib.test.sh`
- <code>`bash tests/fm-bearings-snapshot.test.sh` (suite modified by this change)</code>
- `bash tests/fm-fleet-snapshot-view.test.sh`
- `bash tests/fm-decision-hold-lifecycle.test.sh`
- `bash tests/fm-documentation-audiences.test.sh`
- <code>`bash tests/fm-backend.test.sh`, `bash tests/fm-backend-tmux-smoke.test.sh`, `bash tests/fm-composer-ghost.test.sh` (fm-peek.sh consumers)</code>
- <code>Manual end-to-end walkthrough driving bin/fm-mission.sh, bin/fm-report.sh, bin/fm-captains-log-projection.sh, bin/fm-shapeup-client.sh, bin/fm-decision-hold.sh, bin/fm-peek.sh and bin/fm-fleet-snapshot.sh against a throwaway FM_HOME: `bash e2e-captains-log-walkthrough.sh &lt;repo-root&gt;`</code>
- <code>Manual credential-leakage checks: grep of client output and the whole persisted store for the workspace token, transport argv log showing `argc=0`, and an 8-character sliding-window fragment scan over the pane-wrapped secret in the inspectSession capture</code>
- <code>Manual durability inspection of the resulting record store (`find data/engineering -type f`, `jq` over the retained rejected records, `tasks-axi show mission-42-decision-scope-drop --full`)</code>

</details>

<details>
<summary>⚠️ **Document** - 2 infos</summary>

- ℹ️ `AGENTS.md:78` - AGENTS.md section 2&#39;s private-home tree enumerates every config/ file and the durable data/ records, but this change&#39;s config/shapeup-client.json, its credential file, and data/engineering/ are absent. I deliberately did not add them: docs/configuration.md is the stated owner of the operational-home layout and was updated with data/engineering/ and a ShapeUp client section, and AGENTS.md is reserved for knowledge almost every session needs (it is also under a 7,500-token startup budget). Flagging it as a judgment call in case the maintainer wants the always-loaded inventory to stay exhaustive for config/.
- ℹ️ `docs/documentation-audiences.json:35` - Out-of-scope hardening for a follow-up: docs/documentation-audiences.json&#39;s requiredOwnerPointers does not register the change&#39;s two new pointer edges (docs/configuration.md -&gt; docs/shapeup-client.md and docs/architecture.md -&gt; docs/captains-log-machine-projection.md). Those pointers are the only path from README-linked docs to the new surfaces, so registering them would let tests/fm-documentation-audiences.test.sh catch their silent removal the way it already guards the calm, supervision, and backend pointers. I left the inventory alone because nothing is currently stale and the check passes (surfaces=63, local_links=176).

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
