### PR TITLE
fix: pass backlog JSON via slurpfile in fleet snapshot

### DIFF
--- a/bin/fm-fleet-snapshot.sh
+++ b/bin/fm-fleet-snapshot.sh
@@ -566,7 +566,8 @@ task_json_lines() {
 main_inventory_json() {  # <backlog-json> <tasks-json>
   jq -n \
     --slurpfile backlog <(printf '%s' "$1") \
-    --argjson tasks "$2" '
+    --slurpfile tasks <(printf '%s' "$2") '
+    ($tasks[0]) as $tasks |
     ($backlog[0]) as $backlog |
     ([ $backlog.records[]?
        | select((.state == "in_flight" or .state == "queued") and (.structured | not)) ]) as $unstructured_current
@@ -601,7 +602,8 @@ secondmate_home_summary_json() {  # <backlog-json> <tasks-json>
     --argjson decisions_n "$FM_SNAPSHOT_SECONDMATE_DECISIONS" \
     --argjson landed_n "$FM_SNAPSHOT_SECONDMATE_LANDED_PER_HOME" \
     --slurpfile backlog <(printf '%s' "$1") \
-    --argjson tasks "$2" '
+    --slurpfile tasks <(printf '%s' "$2") '
+    ($tasks[0]) as $tasks |
     def trunc($n):
       tostring | gsub("\\s+"; " ")
       | if length > $n then .[:$n] + "…" else . end;
@@ -1078,7 +1080,8 @@ secondmate_current_json() {  # <parent-tasks-json>
   local activity_scan activities decisions reconciliation provenance freshness reason summary summary_rc summary_bytes summary_valid summary_reason summary_invalidity state current_reason terminal terminal_contradiction contradiction
   local records='[]' seen_homes=''
   registry=$(registry_secondmates_json) || return 1
-  union=$(jq -n --argjson registry "$registry" --argjson tasks "$tasks" '
+  union=$(jq -n --argjson registry "$registry" --slurpfile tasks <(printf '%s' "$tasks") '
+    ($tasks[0]) as $tasks |
     ($registry.records // []) as $registered
     | (($registered | map(.id)) // []) as $registered_ids
     | ([ $registered[] as $r
@@ -1318,12 +1321,13 @@ jq -n \
   --arg config "$CONFIG" \
   --arg projects "$PROJECTS" \
   --slurpfile backlog <(printf '%s' "$BACKLOG_JSON") \
-  --argjson tasks "$TASKS_JSON" \
+  --slurpfile tasks <(printf '%s' "$TASKS_JSON") \
   --argjson main_inventory "$MAIN_INVENTORY_JSON" \
   --argjson scout_reports "$SCOUT_REPORTS_JSON" \
   --argjson secondmate_current "$SECONDMATE_CURRENT_JSON" \
   --argjson secondmate_landed "$SECONDMATE_LANDED_JSON" \
-  '($backlog[0]) as $backlog |
+  '($tasks[0]) as $tasks |
+   ($backlog[0]) as $backlog |
    def backlog_by_id($id): ($backlog.records[]? | select(.structured == true and .id == $id) | .) // null;
    def task_by_id($id): ($tasks[]? | select(.id == $id) | .) // null;
    def report_kind($id): (task_by_id($id).kind // backlog_by_id($id).kind // "scout");

--- a/bin/fm-fleet-snapshot.sh
+++ b/bin/fm-fleet-snapshot.sh
@@ -565,8 +565,9 @@ task_json_lines() {
 # discloses backlog↔task inconsistency for renderers (Bearings omitted/gates).
 main_inventory_json() {  # <backlog-json> <tasks-json>
   jq -n \
-    --argjson backlog "$1" \
+    --slurpfile backlog <(printf '%s' "$1") \
     --argjson tasks "$2" '
+    ($backlog[0]) as $backlog |
     ([ $backlog.records[]?
        | select((.state == "in_flight" or .state == "queued") and (.structured | not)) ]) as $unstructured_current
     | ([ $backlog.records[]?
@@ -599,11 +600,12 @@ secondmate_home_summary_json() {  # <backlog-json> <tasks-json>
     --argjson queued_n "$FM_SNAPSHOT_SECONDMATE_QUEUED" \
     --argjson decisions_n "$FM_SNAPSHOT_SECONDMATE_DECISIONS" \
     --argjson landed_n "$FM_SNAPSHOT_SECONDMATE_LANDED_PER_HOME" \
-    --argjson backlog "$1" \
+    --slurpfile backlog <(printf '%s' "$1") \
     --argjson tasks "$2" '
     def trunc($n):
       tostring | gsub("\\s+"; " ")
       | if length > $n then .[:$n] + "…" else . end;
+    ($backlog[0]) as $backlog |
     ([ $backlog.records[]?
        | select((.state == "in_flight" or .state == "queued") and (.structured | not)) ]) as $unstructured_current
     | ([ $backlog.records[]? | select(.state == "in_flight" and .structured) ]) as $owned_in_flight
@@ -1315,13 +1317,14 @@ jq -n \
   --arg data "$DATA" \
   --arg config "$CONFIG" \
   --arg projects "$PROJECTS" \
-  --argjson backlog "$BACKLOG_JSON" \
+  --slurpfile backlog <(printf '%s' "$BACKLOG_JSON") \
   --argjson tasks "$TASKS_JSON" \
   --argjson main_inventory "$MAIN_INVENTORY_JSON" \
   --argjson scout_reports "$SCOUT_REPORTS_JSON" \
   --argjson secondmate_current "$SECONDMATE_CURRENT_JSON" \
   --argjson secondmate_landed "$SECONDMATE_LANDED_JSON" \
-  'def backlog_by_id($id): ($backlog.records[]? | select(.structured == true and .id == $id) | .) // null;
+  '($backlog[0]) as $backlog |
+   def backlog_by_id($id): ($backlog.records[]? | select(.structured == true and .id == $id) | .) // null;
    def task_by_id($id): ($tasks[]? | select(.id == $id) | .) // null;
    def report_kind($id): (task_by_id($id).kind // backlog_by_id($id).kind // "scout");
    {


### PR DESCRIPTION
Fixes https://github.com/kunchenguid/firstmate/issues/1558

**Problem:** the fleet snapshot dies when the backlog grows large.

**Root cause:** `backlog_json` output exceeds jq's 128KB per-argument limit — `--argjson backlog` fails with `Argument list too long`, so the snapshot aborts before producing output (observed with a 161KB backlog JSON).

**Steps to reproduce:**
1. Grow `data/backlog.md` so its JSON serialization exceeds ~128KB (161KB reproduces it).
2. Run the fleet snapshot command that binds the backlog via `--argjson backlog`.
3. Observe the snapshot abort with `Argument list too long` and no output.

**Fix:** switch the three call sites from `--argjson` to `--slurpfile` with process substitution — passes a short file path and keeps the rebinding inside the jq program.