### PR TITLE
fix(bin): make generated ship briefs self-drive delivery

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -301,7 +301,7 @@ After an autonomous merge, give the captain a one-line full-URL or local-main ou
 ### Validate
 
 For a no-mistakes ship, trigger validation on the same worker after its implementation commit, using the harness invocation owned by `harness-adapters`.
-The task worker that starts a no-mistakes run drives the pipeline and owns every `no-mistakes axi run` and `no-mistakes axi respond` call through the next gate or outcome.
+The task worker that starts a no-mistakes run drives the pipeline and owns every `no-mistakes axi run` and `no-mistakes axi respond` call until a gate requires firstmate or the run reaches a terminal outcome.
 Firstmate never invokes `no-mistakes axi respond` for a crew-owned run.
 Once validation starts, prefer routing new requirements to follow-up work rather than expanding the current task, unless a new requirement completely invalidates the work being validated; however, the smallest downstream changes needed to keep already accepted product or engineering behavior correct, add behavioral tests where an executable contract exists, or keep documentation accurate remain within the current task even when they touch files not named at intake, and corrections required to satisfy already accepted intent are not new requirements.
 

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -311,6 +311,7 @@ case "$MODE" in
 This project ships **direct-PR**: you raise the PR yourself, without the no-mistakes pipeline.
 The task is complete only when committed on your branch.
 When it is implemented and committed, push your branch and open a PR with \`gh-axi\`, then append \`done: PR {url}\` to the status file and stop.
+Do not end your turn waiting for firstmate to tell you to push or open the PR - those delivery steps are yours.
 Do NOT run /no-mistakes. The configured merge authority decides whether to merge the PR; firstmate relays the outcome.
 EOF
     ;;
@@ -323,6 +324,7 @@ This project ships **local-only**: no remote, no PR, no pipeline.
 The task is complete only when committed on your branch \`fm/$ID\`. Do NOT push, do NOT open a PR, do NOT merge.
 Keep your branch a clean fast-forward onto the current default branch - if \`main\` has advanced, rebase onto it so the eventual merge stays a fast-forward.
 When it is implemented and committed, append \`done: ready in branch fm/$ID\` to the status file and stop.
+Do not end your turn waiting for firstmate to tell you to rebase or report the ready branch - those delivery steps are yours.
 The configured merge authority approves the ready branch, then firstmate merges it into local \`main\` through the guarded fast-forward path.
 EOF
     ;;
@@ -333,8 +335,10 @@ EOF
     IFS= read -r -d '' DOD <<EOF || true
 # Definition of done
 The task is complete only when committed on your branch.
-When you believe it is complete, append \`done: {summary}\` to the status file and stop.
-Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.
+After committing the implementation, invoke /no-mistakes yourself to validate and ship the PR.
+Do not append \`done:\` or end your turn merely because the pipeline is running.
+Poll the run's own status and keep driving it until it reaches a gate that requires firstmate or a terminal outcome.
+"Waiting for the next decision point" is not a valid resting state while the run is active.
 
 You drive no-mistakes by responding to its gates, not by implementing fixes.
 Follow the guidance no-mistakes itself provides for the mechanics: it loads when you invoke /no-mistakes, and \`no-mistakes axi run --help\` plus the \`help\` lines in each \`axi\` response are authoritative and version-matched to the installed binary.

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -269,6 +269,14 @@ test_no_mistakes_dod_wording() {
     "no-mistakes DOD must keep direct requirements and exclude generic scaffold boilerplate from --intent"
   assert_grep "exclude generic operational, status, delivery, and other scaffold boilerplate unless it is task-specific" "$brief" \
     "no-mistakes DOD must exclude non-task-specific scaffold boilerplate from --intent"
+  assert_grep "After committing the implementation, invoke /no-mistakes yourself to validate and ship the PR." "$brief" \
+    "no-mistakes DOD must require the worker to start its own validation run"
+  assert_grep "Do not append \`done:\` or end your turn merely because the pipeline is running." "$brief" \
+    "no-mistakes DOD must forbid ending the turn while the pipeline is active"
+  assert_grep "Poll the run's own status and keep driving it until it reaches a gate that requires firstmate or a terminal outcome." "$brief" \
+    "no-mistakes DOD must require polling through a gate or terminal outcome"
+  assert_grep '"Waiting for the next decision point" is not a valid resting state while the run is active.' "$brief" \
+    "no-mistakes DOD must reject waiting for a decision while the pipeline runs"
   # The apostrophe in "firstmate's authority check" is now structurally safe
   # (no `$(...)` wrapper around the heredoc), so it renders verbatim instead of
   # being reworded or escaped away. test_no_heredoc_in_command_substitution
@@ -276,6 +284,26 @@ test_no_mistakes_dod_wording() {
   assert_grep "firstmate's authority check" "$brief" \
     "no-mistakes DOD lost the apostrophe prose that the structural fix makes parse-safe"
   pass "fm-brief.sh: no-mistakes DOD keeps its apostrophe prose, now parse-safe"
+}
+
+test_faster_delivery_modes_do_not_wait_for_firstmate() {
+  local home id brief
+  home="$TMP_ROOT/faster-delivery-self-drive-home"
+  write_registry "$home"
+
+  id="brief-direct-self-drive-b2"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" direct-proj >/dev/null 2>&1
+  brief="$home/data/$id/brief.md"
+  assert_grep "Do not end your turn waiting for firstmate to tell you to push or open the PR - those delivery steps are yours." "$brief" \
+    "direct-PR brief must make the worker drive its own push and PR creation"
+
+  id="brief-local-self-drive-b2"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" local-proj >/dev/null 2>&1
+  brief="$home/data/$id/brief.md"
+  assert_grep "Do not end your turn waiting for firstmate to tell you to rebase or report the ready branch - those delivery steps are yours." "$brief" \
+    "local-only brief must make the worker drive its own rebase and ready report"
+
+  pass "fm-brief.sh: each faster delivery mode owns its steps without waiting for firstmate"
 }
 
 test_ship_project_memory_wording() {
@@ -638,6 +666,7 @@ test_help_includes_entire_header
 test_ship_modes_generate_clean_briefs
 test_faster_paths_use_configured_authority_without_stacked_review
 test_no_mistakes_dod_wording
+test_faster_delivery_modes_do_not_wait_for_firstmate
 test_ship_project_memory_wording
 test_herdr_lab_contract_is_explicit_and_complete
 test_herdr_lab_contract_quotes_foreign_firstmate_path


### PR DESCRIPTION
## Intent

Make generated ship briefs require workers to run validation end to end after committing rather than stopping for firstmate. In no-mistakes mode, require the worker to invoke the pipeline, poll and drive it until a firstmate-required gate or terminal outcome, and explicitly reject waiting for the next decision point while active. Preserve the existing authority, daemon, active-run, ask-user, --yes, CI-ready, and legitimate stop-state protections. Check direct-PR and local-only for equivalent wait-to-be-told wording and correct them if present. Add colocated behavioral tests, generate and read every delivery mode, and keep bin/fm-brief.sh shellcheck-clean.

## What Changed

- Make generated no-mistakes ship briefs require workers to start and drive validation through a firstmate-required gate or terminal outcome.
- Prevent direct-PR and local-only workers from waiting for firstmate before completing their delivery steps, and align validation ownership documentation.
- Add behavioral coverage for self-driven delivery wording across all ship modes.

## Risk Assessment

✅ Low: The change is narrowly scoped and consistently makes workers own delivery progression while preserving authority escalation, daemon safety, active-run restrictions, ask-user handling, --yes avoidance, CI-ready completion, and legitimate stop states.

## Testing

Inspected the targeted diff, ran the colocated behavioral test, then generated and read all three delivery-mode briefs end to end; the worker self-drive wording and existing safety/authority protections were present, all focused tests passed, and reviewer-visible transcripts and complete generated briefs were captured.

<details>
<summary>Evidence: Delivery-mode definitions of done</summary>

```text
===== no-mistakes =====
# Definition of done
The task is complete only when committed on your branch.
After committing the implementation, invoke /no-mistakes yourself to validate and ship the PR.
Do not append `done:` or end your turn merely because the pipeline is running.
Poll the run's own status and keep driving it until it reaches a gate that requires firstmate or a terminal outcome.
"Waiting for the next decision point" is not a valid resting state while the run is active.

You drive no-mistakes by responding to its gates, not by implementing fixes.
Follow the guidance no-mistakes itself provides for the mechanics: it loads when you invoke /no-mistakes, and `no-mistakes axi run --help` plus the `help` lines in each `axi` response are authoritative and version-matched to the installed binary.
When starting no-mistakes, make `--intent` preserve all relevant content from this brief's `# Task` section plus every later accepted Firstmate requirement, clarification, constraint, exclusion, and supersession, carrying only each requirement's current accepted form; retain direct requirements instead of substituting a diff summary, and exclude generic operational, status, delivery, and other scaffold boilerplate unless it is task-specific.
Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix.

Two firstmate-specific rules layer on top of that guidance:
- ask-user findings are never yours to answer: escalate to firstmate (rule 6) and stop.
  Firstmate applies the authority contract in its `AGENTS.md` and obtains any required captain decision.
  When the decision comes back, feed it to the gate with `no-mistakes axi respond` and let the pipeline apply it - do not route the question to "the user" or implement the fix yourself.
- Avoid `--yes`: it would silently bypass firstmate's authority check and any required captain escalation.

===== direct-pr =====
# Definition of done
This project ships **direct-PR**: you raise the PR yourself, without the no-mistakes pipeline.
The task is complete only when committed on your branch.
When it is implemented and committed, push your branch and open a PR with `gh-axi`, then append `done: PR {url}` to the status file and stop.
Do not end your turn waiting for firstmate to tell you to push or open the PR - those delivery steps are yours.
===== local-only =====
# Definition of done
This project ships **local-only**: no remote, no PR, no pipeline.
The task is complete only when committed on your branch `fm/evidence-local-only`. Do NOT push, do NOT open a PR, do NOT merge.
Keep your branch a clean fast-forward onto the current default branch - if `main` has advanced, rebase onto it so the eventual merge stays a fast-forward.
When it is implemented and committed, append `done: ready in branch fm/evidence-local-only` to the status file and stop.
Do not end your turn waiting for firstmate to tell you to rebase or report the ready branch - those delivery steps are yours.
```
</details>
<details>
<summary>Evidence: Preserved protections and self-drive wording</summary>

```text
/tmp/no-mistakes-evidence/01KZ2XW840WP21RQ8EV7PRDKW4/no-mistakes-brief.md:39:6. If a decision belongs above the implementation worker (product choices, destructive actions, ask-user findings),
/tmp/no-mistakes-evidence/01KZ2XW840WP21RQ8EV7PRDKW4/no-mistakes-brief.md:42:7. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving
/tmp/no-mistakes-evidence/01KZ2XW840WP21RQ8EV7PRDKW4/no-mistakes-brief.md:43:   every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
/tmp/no-mistakes-evidence/01KZ2XW840WP21RQ8EV7PRDKW4/no-mistakes-brief.md:57:Poll the run's own status and keep driving it until it reaches a gate that requires firstmate or a terminal outcome.
/tmp/no-mistakes-evidence/01KZ2XW840WP21RQ8EV7PRDKW4/no-mistakes-brief.md:58:"Waiting for the next decision point" is not a valid resting state while the run is active.
/tmp/no-mistakes-evidence/01KZ2XW840WP21RQ8EV7PRDKW4/no-mistakes-brief.md:63:Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix.
/tmp/no-mistakes-evidence/01KZ2XW840WP21RQ8EV7PRDKW4/no-mistakes-brief.md:66:- ask-user findings are never yours to answer: escalate to firstmate (rule 6) and stop.
/tmp/no-mistakes-evidence/01KZ2XW840WP21RQ8EV7PRDKW4/no-mistakes-brief.md:69:- Avoid `--yes`: it would silently bypass firstmate's authority check and any required captain escalation.
/tmp/no-mistakes-evidence/01KZ2XW840WP21RQ8EV7PRDKW4/no-mistakes-brief.md:71:After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append `done: PR {url} checks green` and stop. You are finished.
/tmp/no-mistakes-evidence/01KZ2XW840WP21RQ8EV7PRDKW4/local-only-brief.md:38:6. If a decision belongs above the implementation worker (product choices, destructive actions, ask-user findings),
/tmp/no-mistakes-evidence/01KZ2XW840WP21RQ8EV7PRDKW4/local-only-brief.md:41:7. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving
/tmp/no-mistakes-evidence/01KZ2XW840WP21RQ8EV7PRDKW4/local-only-brief.md:42:   every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
/tmp/no-mistakes-evidence/01KZ2XW840WP21RQ8EV7PRDKW4/local-only-brief.md:57:Do not end your turn waiting for firstmate to tell you to rebase or report the ready branch - those delivery steps are yours.
/tmp/no-mistakes-evidence/01KZ2XW840WP21RQ8EV7PRDKW4/local-only-brief.md:58:The configured merge authority approves the ready branch, then firstmate merges it into local `main` through the guarded fast-forward path.
/tmp/no-mistakes-evidence/01KZ2XW840WP21RQ8EV7PRDKW4/direct-pr-brief.md:38:6. If a decision belongs above the implementation worker (product choices, destructive actions, ask-user findings),
/tmp/no-mistakes-evidence/01KZ2XW840WP21RQ8EV7PRDKW4/direct-pr-brief.md:41:7. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving
/tmp/no-mistakes-evidence/01KZ2XW840WP21RQ8EV7PRDKW4/direct-pr-brief.md:42:   every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
/tmp/no-mistakes-evidence/01KZ2XW840WP21RQ8EV7PRDKW4/direct-pr-brief.md:56:Do not end your turn waiting for firstmate to tell you to push or open the PR - those delivery steps are yours.
/tmp/no-mistakes-evidence/01KZ2XW840WP21RQ8EV7PRDKW4/direct-pr-brief.md:57:Do NOT run /no-mistakes. The configured merge authority decides whether to merge the PR; firstmate relays the outcome.
```
</details>
<details>
<summary>Evidence: Generated no-mistakes brief</summary>

```text
You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.

# Task
{TASK}

# Herdr lifecycle declaration - NOT ENABLED
**HARD SAFETY GATE:** this scaffold cannot inspect the task text that replaces `{TASK}` later.
If the task will start, stop, delete, restart, profile, or otherwise drive Herdr lifecycle behavior, stop and regenerate the brief with `--herdr-lab` before dispatch.
Do not add Herdr lifecycle commands to this unguarded brief by hand.

# Setup
You are in a disposable git worktree of default-proj, at a detached HEAD on a clean default branch.

**Verify isolation before anything else.** Run `pwd -P` and `git rev-parse --show-toplevel`; both must resolve to the disposable task worktree you were launched in, such as a treehouse pool path or an Orca-managed worktree, not the primary checkout firstmate operates from.
The path check is authoritative: `git rev-parse --git-dir` and `git rev-parse --git-common-dir` can help inspect the repo, but they do not prove you are outside the primary checkout.
If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not branch or commit here - append `blocked: launched in primary checkout, not an isolated worktree` to the status file and stop.

1. First action: create your branch: `git checkout -b fm/evidence-no-mistakes`
2. Run `no-mistakes doctor`; if it reports the repo is not initialized here, run `no-mistakes init`.

# Rules
1. Never push to the default branch. Never merge a PR.
2. Stay inside this worktree; modify nothing outside it.
3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
4. Report status by appending one line:
   `echo "{state}: {one short line}" >> '/tmp/no-mistakes-evidence/01KZ2XW840WP21RQ8EV7PRDKW4/generated-home/state/evidence-no-mistakes.status'`
   States: working, needs-decision, blocked, paused, done, failed.
   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
   would act on (setup done, bug reproduced, fix implemented, validation passed) and the
   needs-decision/blocked/paused/done/failed states. No step-by-step FYI progress lines;
   firstmate reads your pane for that.
   A mid-task `working:` line (including setup complete) is nonterminal: do not end the
   turn after it; continue the same stage until a defined `done:` gate under Definition of done.
   Use `paused: {why}` - distinct from `blocked:` - ONLY when you are deliberately idling on a
   known external wait you expect to clear on its own (an upstream release, a rate-limit reset,
   a scheduled window): firstmate then leaves your idle pane alone and rechecks it on a long
   cadence instead of treating it as a possible wedge. Use `blocked:` when you are stuck and need help.
5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
6. If a decision belongs above the implementation worker (product choices, destructive actions, ask-user findings),
   append `needs-decision: {summary of options}` and stop. Firstmate will apply the configured authority and reply with the decision.
   When firstmate replies or a blocker clears and you resume, append `resolved: {how it was decided or unblocked}` (add the same `[key=<slug>]` if you opened it with one) so the decision or blocker is durably closed and does not keep resurfacing.
7. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving
   every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
   daemon error, append `blocked: {the daemon error}` and stop; only firstmate manages the daemon.

# Project memory
If `AGENTS.md` or `CLAUDE.md` already exists, or if this task produced durable project-intrinsic knowledge, run `/home/tommy/.no-mistakes/worktrees/ac9dcfd85b73/01KZ2XW840WP21RQ8EV7PRDKW4/bin/fm-ensure-agents-md.sh .` in the worktree.
Record only project knowledge useful to almost every future session.
For anything the codebase already shows, prefer a pointer to the authoritative file, command, or doc over copying the detail.
If you touch a project `AGENTS.md` that lacks `## Maintaining this file`, add that short self-governance section from `/home/tommy/.no-mistakes/worktrees/ac9dcfd85b73/01KZ2XW840WP21RQ8EV7PRDKW4/bin/fm-ensure-agents-md.sh` in the same pass.
Keep it proportionate: skip `AGENTS.md` edits for trivial tasks that produced no durable project knowledge.

# Definition of done
The task is complete only when committed on your branch.
After committing the implementation, invoke /no-mistakes yourself to validate and ship the PR.
Do not append `done:` or end your turn merely because the pipeline is running.
Poll the run's own status and keep driving it until it reaches a gate that requires firstmate or a terminal outcome.
"Waiting for the next decision point" is not a valid resting state while the run is active.

You drive no-mistakes by responding to its gates, not by implementing fixes.
Follow the guidance no-mistakes itself provides for the mechanics: it loads when you invoke /no-mistakes, and `no-mistakes axi run --help` plus the `help` lines in each `axi` response are authoritative and version-matched to the installed binary.
When starting no-mistakes, make `--intent` preserve all relevant content from this brief's `# Task` section plus every later accepted Firstmate requirement, clarification, constraint, exclusion, and supersession, carrying only each requirement's current accepted form; retain direct requirements instead of substituting a diff summary, and exclude generic operational, status, delivery, and other scaffold boilerplate unless it is task-specific.
Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix.

Two firstmate-specific rules layer on top of that guidance:
- ask-user findings are never yours to answer: escalate to firstmate (rule 6) and stop.
  Firstmate applies the authority contract in its `AGENTS.md` and obtains any required captain decision.
  When the decision comes back, feed it to the gate with `no-mistakes axi respond` and let the pipeline apply it - do not route the question to "the user" or implement the fix yourself.
- Avoid `--yes`: it would silently bypass firstmate's authority check and any required captain escalation.

After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append `done: PR {url} checks green` and stop. You are finished.
```
</details>
<details>
<summary>Evidence: Generated direct-PR brief</summary>

```text
You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.

# Task
{TASK}

# Herdr lifecycle declaration - NOT ENABLED
**HARD SAFETY GATE:** this scaffold cannot inspect the task text that replaces `{TASK}` later.
If the task will start, stop, delete, restart, profile, or otherwise drive Herdr lifecycle behavior, stop and regenerate the brief with `--herdr-lab` before dispatch.
Do not add Herdr lifecycle commands to this unguarded brief by hand.

# Setup
You are in a disposable git worktree of direct-proj, at a detached HEAD on a clean default branch.

**Verify isolation before anything else.** Run `pwd -P` and `git rev-parse --show-toplevel`; both must resolve to the disposable task worktree you were launched in, such as a treehouse pool path or an Orca-managed worktree, not the primary checkout firstmate operates from.
The path check is authoritative: `git rev-parse --git-dir` and `git rev-parse --git-common-dir` can help inspect the repo, but they do not prove you are outside the primary checkout.
If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not branch or commit here - append `blocked: launched in primary checkout, not an isolated worktree` to the status file and stop.

1. First action: create your branch: `git checkout -b fm/evidence-direct-pr`

# Rules
1. Never push to the default branch (push only your `fm/evidence-direct-pr` branch). Never merge a PR.
2. Stay inside this worktree; modify nothing outside it.
3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
4. Report status by appending one line:
   `echo "{state}: {one short line}" >> '/tmp/no-mistakes-evidence/01KZ2XW840WP21RQ8EV7PRDKW4/generated-home/state/evidence-direct-pr.status'`
   States: working, needs-decision, blocked, paused, done, failed.
   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
   would act on (setup done, bug reproduced, fix implemented, validation passed) and the
   needs-decision/blocked/paused/done/failed states. No step-by-step FYI progress lines;
   firstmate reads your pane for that.
   A mid-task `working:` line (including setup complete) is nonterminal: do not end the
   turn after it; continue the same stage until a defined `done:` gate under Definition of done.
   Use `paused: {why}` - distinct from `blocked:` - ONLY when you are deliberately idling on a
   known external wait you expect to clear on its own (an upstream release, a rate-limit reset,
   a scheduled window): firstmate then leaves your idle pane alone and rechecks it on a long
   cadence instead of treating it as a possible wedge. Use `blocked:` when you are stuck and need help.
5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
6. If a decision belongs above the implementation worker (product choices, destructive actions, ask-user findings),
   append `needs-decision: {summary of options}` and stop. Firstmate will apply the configured authority and reply with the decision.
   When firstmate replies or a blocker clears and you resume, append `resolved: {how it was decided or unblocked}` (add the same `[key=<slug>]` if you opened it with one) so the decision or blocker is durably closed and does not keep resurfacing.
7. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving
   every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
   daemon error, append `blocked: {the daemon error}` and stop; only firstmate manages the daemon.

# Project memory
If `AGENTS.md` or `CLAUDE.md` already exists, or if this task produced durable project-intrinsic knowledge, run `/home/tommy/.no-mistakes/worktrees/ac9dcfd85b73/01KZ2XW840WP21RQ8EV7PRDKW4/bin/fm-ensure-agents-md.sh .` in the worktree.
Record only project knowledge useful to almost every future session.
For anything the codebase already shows, prefer a pointer to the authoritative file, command, or doc over copying the detail.
If you touch a project `AGENTS.md` that lacks `## Maintaining this file`, add that short self-governance section from `/home/tommy/.no-mistakes/worktrees/ac9dcfd85b73/01KZ2XW840WP21RQ8EV7PRDKW4/bin/fm-ensure-agents-md.sh` in the same pass.
Keep it proportionate: skip `AGENTS.md` edits for trivial tasks that produced no durable project knowledge.

# Definition of done
This project ships **direct-PR**: you raise the PR yourself, without the no-mistakes pipeline.
The task is complete only when committed on your branch.
When it is implemented and committed, push your branch and open a PR with `gh-axi`, then append `done: PR {url}` to the status file and stop.
Do not end your turn waiting for firstmate to tell you to push or open the PR - those delivery steps are yours.
Do NOT run /no-mistakes. The configured merge authority decides whether to merge the PR; firstmate relays the outcome.
```
</details>
<details>
<summary>Evidence: Generated local-only brief</summary>

```text
You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.

# Task
{TASK}

# Herdr lifecycle declaration - NOT ENABLED
**HARD SAFETY GATE:** this scaffold cannot inspect the task text that replaces `{TASK}` later.
If the task will start, stop, delete, restart, profile, or otherwise drive Herdr lifecycle behavior, stop and regenerate the brief with `--herdr-lab` before dispatch.
Do not add Herdr lifecycle commands to this unguarded brief by hand.

# Setup
You are in a disposable git worktree of local-proj, at a detached HEAD on a clean default branch.

**Verify isolation before anything else.** Run `pwd -P` and `git rev-parse --show-toplevel`; both must resolve to the disposable task worktree you were launched in, such as a treehouse pool path or an Orca-managed worktree, not the primary checkout firstmate operates from.
The path check is authoritative: `git rev-parse --git-dir` and `git rev-parse --git-common-dir` can help inspect the repo, but they do not prove you are outside the primary checkout.
If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not branch or commit here - append `blocked: launched in primary checkout, not an isolated worktree` to the status file and stop.

1. First action: create your branch: `git checkout -b fm/evidence-local-only`

# Rules
1. Never push to any remote and never open a PR. Work only on your `fm/evidence-local-only` branch; firstmate handles the merge into local `main`.
2. Stay inside this worktree; modify nothing outside it.
3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
4. Report status by appending one line:
   `echo "{state}: {one short line}" >> '/tmp/no-mistakes-evidence/01KZ2XW840WP21RQ8EV7PRDKW4/generated-home/state/evidence-local-only.status'`
   States: working, needs-decision, blocked, paused, done, failed.
   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
   would act on (setup done, bug reproduced, fix implemented, validation passed) and the
   needs-decision/blocked/paused/done/failed states. No step-by-step FYI progress lines;
   firstmate reads your pane for that.
   A mid-task `working:` line (including setup complete) is nonterminal: do not end the
   turn after it; continue the same stage until a defined `done:` gate under Definition of done.
   Use `paused: {why}` - distinct from `blocked:` - ONLY when you are deliberately idling on a
   known external wait you expect to clear on its own (an upstream release, a rate-limit reset,
   a scheduled window): firstmate then leaves your idle pane alone and rechecks it on a long
   cadence instead of treating it as a possible wedge. Use `blocked:` when you are stuck and need help.
5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
6. If a decision belongs above the implementation worker (product choices, destructive actions, ask-user findings),
   append `needs-decision: {summary of options}` and stop. Firstmate will apply the configured authority and reply with the decision.
   When firstmate replies or a blocker clears and you resume, append `resolved: {how it was decided or unblocked}` (add the same `[key=<slug>]` if you opened it with one) so the decision or blocker is durably closed and does not keep resurfacing.
7. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving
   every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
   daemon error, append `blocked: {the daemon error}` and stop; only firstmate manages the daemon.

# Project memory
If `AGENTS.md` or `CLAUDE.md` already exists, or if this task produced durable project-intrinsic knowledge, run `/home/tommy/.no-mistakes/worktrees/ac9dcfd85b73/01KZ2XW840WP21RQ8EV7PRDKW4/bin/fm-ensure-agents-md.sh .` in the worktree.
Record only project knowledge useful to almost every future session.
For anything the codebase already shows, prefer a pointer to the authoritative file, command, or doc over copying the detail.
If you touch a project `AGENTS.md` that lacks `## Maintaining this file`, add that short self-governance section from `/home/tommy/.no-mistakes/worktrees/ac9dcfd85b73/01KZ2XW840WP21RQ8EV7PRDKW4/bin/fm-ensure-agents-md.sh` in the same pass.
Keep it proportionate: skip `AGENTS.md` edits for trivial tasks that produced no durable project knowledge.

# Definition of done
This project ships **local-only**: no remote, no PR, no pipeline.
The task is complete only when committed on your branch `fm/evidence-local-only`. Do NOT push, do NOT open a PR, do NOT merge.
Keep your branch a clean fast-forward onto the current default branch - if `main` has advanced, rebase onto it so the eventual merge stays a fast-forward.
When it is implemented and committed, append `done: ready in branch fm/evidence-local-only` to the status file and stop.
Do not end your turn waiting for firstmate to tell you to rebase or report the ready branch - those delivery steps are yours.
The configured merge authority approves the ready branch, then firstmate merges it into local `main` through the guarded fast-forward path.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `git diff 33a428773059aa9bbe55865ce73ae51e4334bccc..b2f983688db04aa31f035b9b1bbc601b9246ff63 -- bin/fm-brief.sh tests/fm-brief.test.sh AGENTS.md`
- `bash tests/fm-brief.test.sh`
- <code>Generated and read no-mistakes, direct-PR, and local-only briefs using `FM_HOME=&lt;evidence-home&gt; bin/fm-brief.sh &lt;id&gt; &lt;project&gt;`</code>
- <code>Extracted each generated `# Definition of done` and inspected self-drive, authority, daemon, active-run, ask-user, `--yes`, CI-ready, and legitimate stop-state wording</code>
- `git status --short`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 127)

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
