### PR TITLE
fix(bin): bind Herdr labs to verified parent sessions

### DIFF
--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -272,21 +272,23 @@ HERDR_SECTION=$(printf '%s\n' \
 '# Herdr isolation - HARD SAFETY CONTRACT' \
 'This brief was explicitly scaffolded with `--herdr-lab` because the task will drive Herdr lifecycle behavior.' \
 'On Herdr 0.7.3 the API socket is not relocatable by `HERDR_CONFIG_PATH`, `XDG_CONFIG_HOME`, or `HOME`.' \
-'A named non-`default` session plus a trailing `--session <name>` on every call is the only viable local isolation.' \
+'A named task session plus a trailing `--session <name>` on every task call is the only viable local isolation.' \
 '' \
-'1. Set `HERDR_LAB_HELPER='"$HERDR_LAB_HELPER"'` and generate the session name with `HERDR_LAB_SESSION=$("$HERDR_LAB_HELPER" name '"$ID"')`.' \
+'1. Set `HERDR_LAB_HELPER='"$HERDR_LAB_HELPER"'` and preserve the exact parent fleet session with `FM_HERDR_LAB_PARENT_SESSION=${FM_HERDR_LAB_PARENT_SESSION:-${HERDR_SESSION:-}}`.' \
+'   A missing parent identity is a hard refusal; never choose a parent merely because it is the only running session.' \
+'2. Export `FM_HERDR_LAB_PARENT_SESSION`, then generate the task session only with `HERDR_LAB_SESSION=$("$HERDR_LAB_HELPER" name '"$ID"')`.' \
 '   Install `trap '\''"$HERDR_LAB_HELPER" teardown "$HERDR_LAB_SESSION"'\'' EXIT` before provisioning, then provision only with `"$HERDR_LAB_HELPER" provision "$HERDR_LAB_SESSION"`.' \
-'2. Run every task-specific non-lifecycle Herdr command through `"$HERDR_LAB_HELPER" run "$HERDR_LAB_SESSION" <arguments...>`.' \
-'   The helper appends the required trailing `--session "$HERDR_LAB_SESSION"`; `HERDR_SESSION` alone is never accepted as isolation.' \
-'3. Teardown only through `"$HERDR_LAB_HELPER" teardown "$HERDR_LAB_SESSION"`.' \
-'   It re-checks refuse-default immediately before stop and again immediately before delete, and fails closed on ambiguity.' \
-'4. If an experiment requires a deliberate mid-run session stop, use only `"$HERDR_LAB_HELPER" stop "$HERDR_LAB_SESSION"`; it performs the same immediate refuse-default check.' \
-'5. Forbidden commands: direct `herdr server stop`, every other server-global operation such as `herdr server live-handoff` or reload/update operations, direct `herdr session stop`, direct `herdr session delete`, and any Herdr call scoped only by ambient or inline `HERDR_SESSION`.' \
-'6. The helper records the live default session before provisioning and verifies the identical fleet state after teardown.' \
-'   A missing, stopped, or changed default session is a hard tripwire failure, never a cleanup warning to ignore.' \
+'3. Run every task-specific non-lifecycle Herdr command through `"$HERDR_LAB_HELPER" run "$HERDR_LAB_SESSION" <arguments...>`.' \
+'   The helper appends the required trailing `--session "$HERDR_LAB_SESSION"`; ambient session state alone is never accepted as isolation.' \
+'4. Teardown only through `"$HERDR_LAB_HELPER" teardown "$HERDR_LAB_SESSION"`.' \
+'   It re-checks the exact protected parent and task target immediately before stop and again immediately before delete.' \
+'5. If an experiment requires a deliberate mid-run task-session stop, use only `"$HERDR_LAB_HELPER" stop "$HERDR_LAB_SESSION"`.' \
+'   The helper performs the same immediate protected-parent and target check.' \
+'6. Forbidden commands remain: direct `herdr server stop`, every other server-global operation such as `herdr server live-handoff` or reload/update operations, direct `herdr session stop`, direct `herdr session delete`, and any Herdr call scoped only by ambient or inline `HERDR_SESSION`.' \
+'7. The helper records the exact verified parent session before provisioning, re-checks it before every task call, and verifies the semantically identical parent state after teardown.' \
+'   A missing, ambiguous, stopped, changed, or cross-runtime parent is a hard tripwire failure, never a cleanup warning to ignore.' \
 '' \
-'Never bypass the helper, even for a read-only lifecycle probe or cleanup after failure.' \
-'The captain fleet uses the running `default` session.')
+'Never bypass the helper, even for a read-only lifecycle probe or cleanup after failure.')
 else
 IFS= read -r -d '' HERDR_SECTION <<'EOF' || true
 # Herdr lifecycle declaration - NOT ENABLED

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -274,7 +274,7 @@ HERDR_SECTION=$(printf '%s\n' \
 'On Herdr 0.7.3 the API socket is not relocatable by `HERDR_CONFIG_PATH`, `XDG_CONFIG_HOME`, or `HOME`.' \
 'A named task session plus a trailing `--session <name>` on every task call is the only viable local isolation.' \
 '' \
-'1. Set `HERDR_LAB_HELPER='"$HERDR_LAB_HELPER"'` and preserve the exact parent fleet session with `FM_HERDR_LAB_PARENT_SESSION=${FM_HERDR_LAB_PARENT_SESSION:-${HERDR_SESSION:-}}`.' \
+'1. Set `HERDR_LAB_HELPER='"$HERDR_LAB_HELPER"'` and preserve the exact parent fleet session with `FM_HERDR_LAB_PARENT_SESSION=${HERDR_SESSION:-${FM_HERDR_LAB_PARENT_SESSION:-}}`.' \
 '   A missing parent identity is a hard refusal; never choose a parent merely because it is the only running session.' \
 '2. Export `FM_HERDR_LAB_PARENT_SESSION`, then generate the task session only with `HERDR_LAB_SESSION=$("$HERDR_LAB_HELPER" name '"$ID"')`.' \
 '   Install `trap '\''"$HERDR_LAB_HELPER" teardown "$HERDR_LAB_SESSION"'\'' EXIT` before provisioning, then provision only with `"$HERDR_LAB_HELPER" provision "$HERDR_LAB_SESSION"`.' \

--- a/bin/fm-herdr-lab.sh
+++ b/bin/fm-herdr-lab.sh
@@ -12,8 +12,10 @@
 #
 # Lifecycle commands require the exact running parent session through
 # FM_HERDR_LAB_PARENT_SESSION. The helper never infers it from the session
-# inventory. A Herdr-managed caller's injected session and socket must agree
-# with the supplied parent.
+# inventory. Lifecycle commands require a Herdr-managed caller's injected
+# session and socket to agree with the supplied parent. A run call entered
+# from the guarded task lab instead requires its injected session and socket
+# to exactly match that verified task target.
 # Session names must begin with "fm-lab-" and can never equal the parent.
 # The name command sanitizes the label, caps it at 16 characters, and appends
 # process/random suffixes to keep generated socket paths short.
@@ -117,20 +119,19 @@ fm_herdr_lab_parent_snapshot_from_inventory() { # <parent-session> <session-list
   printf '%s\n' "$snapshot"
 }
 
-fm_herdr_lab_verify_runtime_parent() { # <parent-session> <parent-snapshot>
-  local parent=$1 snapshot=$2 runtime_claim=0 runtime_session runtime_socket snapshot_socket marker
+fm_herdr_lab_verify_runtime_parent() { # <parent-session> <parent-snapshot> [<lab-session> <lab-snapshot>]
+  local parent=$1 snapshot=$2 name=${3:-} target_snapshot=${4:-} runtime_claim=0 runtime_session runtime_socket snapshot_socket marker
   for marker in HERDR_ENV HERDR_PANE_ID HERDR_TAB_ID HERDR_WORKSPACE_ID HERDR_SOCKET_PATH; do
     [ -z "${!marker:-}" ] || runtime_claim=1
   done
   [ "$runtime_claim" -eq 1 ] || return 0
 
   runtime_session=${HERDR_SESSION:-}
-  [ "$runtime_session" = "$parent" ] || {
-    fm_herdr_lab_error "protected parent '$parent' disagrees with the Herdr-managed caller session '${runtime_session:-<missing>}'"
-    return 1
-  }
   runtime_socket=${HERDR_SOCKET_PATH:-}
-  if [ -n "$runtime_socket" ]; then
+  if [ "$runtime_session" = "$parent" ]; then
+    if [ -z "$runtime_socket" ]; then
+      return 0
+    fi
     snapshot_socket=$(printf '%s' "$snapshot" | jq -er '.socket_path' 2>/dev/null) || {
       fm_herdr_lab_error "protected parent '$parent' has no verifiable socket identity"
       return 1
@@ -139,7 +140,25 @@ fm_herdr_lab_verify_runtime_parent() { # <parent-session> <parent-snapshot>
       fm_herdr_lab_error "protected parent '$parent' socket disagrees with the Herdr-managed caller"
       return 1
     }
+    return 0
   fi
+  if [ -n "$name" ] && [ "$runtime_session" = "$name" ]; then
+    [ -n "$runtime_socket" ] || {
+      fm_herdr_lab_error "task lab '$name' must provide its injected Herdr socket identity"
+      return 1
+    }
+    snapshot_socket=$(printf '%s' "$target_snapshot" | jq -er '.socket_path' 2>/dev/null) || {
+      fm_herdr_lab_error "task lab '$name' has no verifiable socket identity"
+      return 1
+    }
+    [ "$runtime_socket" = "$snapshot_socket" ] || {
+      fm_herdr_lab_error "task lab '$name' socket disagrees with the Herdr-managed caller"
+      return 1
+    }
+    return 0
+  fi
+  fm_herdr_lab_error "protected parent '$parent' disagrees with the Herdr-managed caller session '${runtime_session:-<missing>}'"
+  return 1
 }
 
 fm_herdr_lab_target_snapshot_from_inventory() { # <lab-session> <session-list-json>
@@ -213,12 +232,17 @@ fm_herdr_lab_tripwire_binding() { # <parent-session> <lab-session>
   printf '%s\n' "$record"
 }
 
-fm_herdr_lab_verify_inventory_binding() { # <parent-session> <lab-session> <session-list-json>
-  local parent=$1 name=$2 sessions=$3 record before after
+fm_herdr_lab_verify_inventory_binding() { # <parent-session> <lab-session> <session-list-json> [allow-task-runtime]
+  local parent=$1 name=$2 sessions=$3 allow_task_runtime=${4:-0} record before after target_snapshot
   record=$(fm_herdr_lab_tripwire_binding "$parent" "$name") || return 1
   before=$(printf '%s' "$record" | jq -cS '.parent_state')
   after=$(fm_herdr_lab_parent_snapshot_from_inventory "$parent" "$sessions") || return 1
-  fm_herdr_lab_verify_runtime_parent "$parent" "$after" || return 1
+  if [ "$allow_task_runtime" = 1 ]; then
+    target_snapshot=$(fm_herdr_lab_distinct_target_snapshot "$parent" "$name" "$sessions") || return 1
+    fm_herdr_lab_verify_runtime_parent "$parent" "$after" "$name" "$target_snapshot" || return 1
+  else
+    fm_herdr_lab_verify_runtime_parent "$parent" "$after" || return 1
+  fi
   [ "$before" = "$after" ] || {
     fm_herdr_lab_error "PROTECTED-PARENT TRIPWIRE FAILED: session '$parent' changed during lab work"
     fm_herdr_lab_error "before: $before"
@@ -239,8 +263,8 @@ fm_herdr_lab_check_tripwire() { # <session>
   fm_herdr_lab_verify_inventory_binding "$parent" "$name" "$sessions"
 }
 
-fm_herdr_lab_guard_target() { # <session>
-  local name=$1 parent sessions
+fm_herdr_lab_guard_target() { # <session> [allow-task-runtime]
+  local name=$1 allow_task_runtime=${2:-0} parent sessions
   parent=$(fm_herdr_lab_parent_name) || return 1
   fm_herdr_lab_validate_pair "$parent" "$name" || return 1
   fm_herdr_lab_tripwire_binding "$parent" "$name" >/dev/null || return 1
@@ -248,7 +272,7 @@ fm_herdr_lab_guard_target() { # <session>
     fm_herdr_lab_error "refusing task-lab operation because session inventory failed"
     return 1
   }
-  fm_herdr_lab_verify_inventory_binding "$parent" "$name" "$sessions" || return 1
+  fm_herdr_lab_verify_inventory_binding "$parent" "$name" "$sessions" "$allow_task_runtime" || return 1
   fm_herdr_lab_distinct_target_snapshot "$parent" "$name" "$sessions" >/dev/null
 }
 
@@ -330,7 +354,7 @@ fm_herdr_lab_cli() { # <session> <herdr arguments...>
       return 1
       ;;
   esac
-  fm_herdr_lab_guard_target "$name" || return 1
+  fm_herdr_lab_guard_target "$name" 1 || return 1
   fm_herdr_lab_raw "$name" "$@"
 }
 

--- a/bin/fm-herdr-lab.sh
+++ b/bin/fm-herdr-lab.sh
@@ -129,9 +129,10 @@ fm_herdr_lab_verify_runtime_parent() { # <parent-session> <parent-snapshot> [<la
   runtime_session=${HERDR_SESSION:-}
   runtime_socket=${HERDR_SOCKET_PATH:-}
   if [ "$runtime_session" = "$parent" ]; then
-    if [ -z "$runtime_socket" ]; then
-      return 0
-    fi
+    [ -n "$runtime_socket" ] || {
+      fm_herdr_lab_error "protected parent '$parent' must provide its injected Herdr socket identity"
+      return 1
+    }
     snapshot_socket=$(printf '%s' "$snapshot" | jq -er '.socket_path' 2>/dev/null) || {
       fm_herdr_lab_error "protected parent '$parent' has no verifiable socket identity"
       return 1

--- a/bin/fm-herdr-lab.sh
+++ b/bin/fm-herdr-lab.sh
@@ -1,16 +1,20 @@
 #!/usr/bin/env bash
-# Provision and operate an isolated Herdr lab session without risking the live
-# default session.
+# Provision and operate an isolated Herdr lab session without risking its
+# verified parent fleet session.
 #
 # Usage:
 #   fm-herdr-lab.sh name <label>
-#   fm-herdr-lab.sh prepare <session>
-#   fm-herdr-lab.sh provision <session>
-#   fm-herdr-lab.sh run <session> <herdr arguments...>
-#   fm-herdr-lab.sh stop <session>
-#   fm-herdr-lab.sh teardown <session>
+#   FM_HERDR_LAB_PARENT_SESSION=<parent> fm-herdr-lab.sh prepare <session>
+#   FM_HERDR_LAB_PARENT_SESSION=<parent> fm-herdr-lab.sh provision <session>
+#   FM_HERDR_LAB_PARENT_SESSION=<parent> fm-herdr-lab.sh run <session> <herdr arguments...>
+#   FM_HERDR_LAB_PARENT_SESSION=<parent> fm-herdr-lab.sh stop <session>
+#   FM_HERDR_LAB_PARENT_SESSION=<parent> fm-herdr-lab.sh teardown <session>
 #
-# Session names must begin with "fm-lab-" and can never be "default".
+# Lifecycle commands require the exact running parent session through
+# FM_HERDR_LAB_PARENT_SESSION. The helper never infers it from the session
+# inventory. A Herdr-managed caller's injected session and socket must agree
+# with the supplied parent.
+# Session names must begin with "fm-lab-" and can never equal the parent.
 # The name command sanitizes the label, caps it at 16 characters, and appends
 # process/random suffixes to keep generated socket paths short.
 # Every Herdr call made here carries a trailing --session <session>.
@@ -19,10 +23,14 @@
 # operation.
 # Session stop is available only through guarded stop or teardown, and session
 # delete is available only through teardown.
-# Both paths perform a fresh refuse-default check immediately before each
-# destructive call.
-# Provision records the running default session as a fleet-state tripwire and
-# teardown requires that record to be identical afterward.
+# Provision records the exact running parent-session object as a tripwire.
+# Prepare, provision, run, stop, and teardown refuse a missing, ambiguous,
+# changed, stopped, cross-runtime, or target-equal parent before proceeding.
+# Stop and teardown re-check both the protected parent and task target
+# immediately before every destructive call. Successful teardown requires the
+# parent snapshot to remain semantically identical, removes only the task lab,
+# and clears its tripwire.
+# End help.
 set -u
 
 fm_herdr_lab_error() {
@@ -40,12 +48,41 @@ fm_herdr_lab_validate_name() { # <session>
   return 1
 }
 
+fm_herdr_lab_validate_parent_name() { # <parent-session>
+  local parent=${1:-}
+  if [[ "$parent" =~ ^[a-zA-Z0-9][a-zA-Z0-9_-]*$ ]]; then
+    return 0
+  fi
+  if [ -z "$parent" ]; then
+    fm_herdr_lab_error "FM_HERDR_LAB_PARENT_SESSION is required for every lifecycle command"
+  else
+    fm_herdr_lab_error "parent session must contain only letters, digits, underscores, or dashes: $parent"
+  fi
+  return 1
+}
+
+fm_herdr_lab_parent_name() {
+  local parent=${FM_HERDR_LAB_PARENT_SESSION:-}
+  fm_herdr_lab_validate_parent_name "$parent" || return 1
+  printf '%s\n' "$parent"
+}
+
+fm_herdr_lab_validate_pair() { # <parent-session> <lab-session>
+  local parent=$1 name=$2
+  fm_herdr_lab_validate_parent_name "$parent" || return 1
+  fm_herdr_lab_validate_name "$name" || return 1
+  [ "$parent" != "$name" ] || {
+    fm_herdr_lab_error "refusing to target protected parent session '$parent' as a task lab"
+    return 1
+  }
+}
+
 fm_herdr_lab_state_dir() {
   printf '%s' "${FM_HERDR_LAB_STATE_DIR:-${TMPDIR:-/tmp}/fm-herdr-lab-${UID}}"
 }
 
 fm_herdr_lab_tripwire_path() { # <session>
-  printf '%s/%s.fleet-state.json' "$(fm_herdr_lab_state_dir)" "$1"
+  printf '%s/%s.parent-state.json' "$(fm_herdr_lab_state_dir)" "$1"
 }
 
 fm_herdr_lab_raw() { # <session> <herdr arguments...>
@@ -54,70 +91,213 @@ fm_herdr_lab_raw() { # <session> <herdr arguments...>
   HERDR_SESSION="$name" herdr "$@" --session "$name"
 }
 
-fm_herdr_lab_session_list() { # <session>
+fm_herdr_lab_session_list() { # <selector-session>
   fm_herdr_lab_raw "$1" session list --json
 }
 
-fm_herdr_lab_fleet_state() { # <session>
-  local name=$1 sessions snapshot
-  sessions=$(fm_herdr_lab_session_list "$name" 2>/dev/null) || {
-    fm_herdr_lab_error "cannot read Herdr sessions for the fleet-state tripwire"
-    return 1
-  }
-  snapshot=$(printf '%s' "$sessions" | jq -c '
-    [.sessions[]? | select(.default == true)]
-    | if length == 1 and .[0].name == "default" and .[0].running == true
-      then .[0] | {name, default, running, socket_path}
+fm_herdr_lab_parent_snapshot_from_inventory() { # <parent-session> <session-list-json>
+  local parent=$1 sessions=$2 snapshot
+  snapshot=$(printf '%s' "$sessions" | jq -cS --arg parent "$parent" '
+    [.sessions[]? | select(.name == $parent)]
+    | if (
+        length == 1
+        and (.[0].running == true)
+        and (((.[0].socket_path // "") | type) == "string")
+        and (((.[0].socket_path // "") | length) > 0)
+        and (if $parent == "default" then .[0].default == true else .[0].default == false end)
+      )
+      then .[0]
       else empty
       end
   ' 2>/dev/null)
   [ -n "$snapshot" ] || {
-    fm_herdr_lab_error "fleet-state tripwire requires exactly one running default session"
+    fm_herdr_lab_error "protected parent '$parent' must resolve to exactly one running session with a verified socket and matching default identity"
     return 1
   }
   printf '%s\n' "$snapshot"
 }
 
-fm_herdr_lab_prepare() { # <session>
-  local name=$1 sessions state_dir tripwire
-  fm_herdr_lab_validate_name "$name" || return 1
-  command -v herdr >/dev/null 2>&1 || { fm_herdr_lab_error "herdr is required"; return 1; }
-  command -v jq >/dev/null 2>&1 || { fm_herdr_lab_error "jq is required"; return 1; }
+fm_herdr_lab_verify_runtime_parent() { # <parent-session> <parent-snapshot>
+  local parent=$1 snapshot=$2 runtime_claim=0 runtime_session runtime_socket snapshot_socket marker
+  for marker in HERDR_ENV HERDR_PANE_ID HERDR_TAB_ID HERDR_WORKSPACE_ID HERDR_SOCKET_PATH; do
+    [ -z "${!marker:-}" ] || runtime_claim=1
+  done
+  [ "$runtime_claim" -eq 1 ] || return 0
 
-  sessions=$(fm_herdr_lab_session_list "$name" 2>/dev/null) || {
-    fm_herdr_lab_error "cannot list Herdr sessions before provisioning '$name'"
+  runtime_session=${HERDR_SESSION:-}
+  [ "$runtime_session" = "$parent" ] || {
+    fm_herdr_lab_error "protected parent '$parent' disagrees with the Herdr-managed caller session '${runtime_session:-<missing>}'"
     return 1
   }
-  if printf '%s' "$sessions" | jq -e --arg name "$name" '.sessions[]? | select(.name == $name)' >/dev/null 2>&1; then
-    fm_herdr_lab_error "session '$name' already exists; refusing to adopt or overwrite it"
-    return 1
+  runtime_socket=${HERDR_SOCKET_PATH:-}
+  if [ -n "$runtime_socket" ]; then
+    snapshot_socket=$(printf '%s' "$snapshot" | jq -er '.socket_path' 2>/dev/null) || {
+      fm_herdr_lab_error "protected parent '$parent' has no verifiable socket identity"
+      return 1
+    }
+    [ "$runtime_socket" = "$snapshot_socket" ] || {
+      fm_herdr_lab_error "protected parent '$parent' socket disagrees with the Herdr-managed caller"
+      return 1
+    }
   fi
+}
 
-  state_dir=$(fm_herdr_lab_state_dir)
-  tripwire=$(fm_herdr_lab_tripwire_path "$name")
-  mkdir -p "$state_dir" || return 1
-  [ ! -e "$tripwire" ] || {
-    fm_herdr_lab_error "tripwire already exists for '$name'; refusing ambiguous ownership"
+fm_herdr_lab_target_snapshot_from_inventory() { # <lab-session> <session-list-json>
+  local name=$1 sessions=$2 snapshot
+  snapshot=$(printf '%s' "$sessions" | jq -cS --arg name "$name" '
+    [.sessions[]? | select(.name == $name)]
+    | if (
+        length == 1
+        and .[0].default == false
+        and (((.[0].socket_path // "") | type) == "string")
+        and (((.[0].socket_path // "") | length) > 0)
+      )
+      then .[0]
+      else empty
+      end
+  ' 2>/dev/null)
+  [ -n "$snapshot" ] || {
+    fm_herdr_lab_error "task lab '$name' is missing, ambiguous, default, or lacks a verified socket"
     return 1
   }
-  fm_herdr_lab_fleet_state "$name" > "$tripwire" || {
-    rm -f "$tripwire"
+  printf '%s\n' "$snapshot"
+}
+
+fm_herdr_lab_distinct_target_snapshot() { # <parent-session> <lab-session> <session-list-json>
+  local parent=$1 name=$2 sessions=$3 parent_snapshot target_snapshot parent_socket target_socket
+  parent_snapshot=$(fm_herdr_lab_parent_snapshot_from_inventory "$parent" "$sessions") || return 1
+  target_snapshot=$(fm_herdr_lab_target_snapshot_from_inventory "$name" "$sessions") || return 1
+  parent_socket=$(printf '%s' "$parent_snapshot" | jq -er '.socket_path' 2>/dev/null) || return 1
+  target_socket=$(printf '%s' "$target_snapshot" | jq -er '.socket_path' 2>/dev/null) || return 1
+  [ "$parent_socket" != "$target_socket" ] || {
+    fm_herdr_lab_error "refusing task lab '$name': it resolves to the protected parent '$parent' socket"
+    return 1
+  }
+  printf '%s\n' "$target_snapshot"
+}
+
+fm_herdr_lab_tripwire_record() { # <session>
+  local name=$1 tripwire record
+  tripwire=$(fm_herdr_lab_tripwire_path "$name")
+  [ -f "$tripwire" ] && [ ! -L "$tripwire" ] || {
+    fm_herdr_lab_error "protected-parent tripwire for '$name' is missing or not a regular non-symlink file; refusing unverified operation"
+    return 1
+  }
+  record=$(jq -cS -e '
+    select(
+      .version == 1
+      and (.lab_session | type == "string")
+      and (.parent_session | type == "string")
+      and (.parent_state | type == "object")
+    )
+  ' "$tripwire" 2>/dev/null) || {
+    fm_herdr_lab_error "protected-parent tripwire for '$name' is malformed"
+    return 1
+  }
+  printf '%s\n' "$record"
+}
+
+fm_herdr_lab_tripwire_binding() { # <parent-session> <lab-session>
+  local parent=$1 name=$2 record record_parent record_lab
+  record=$(fm_herdr_lab_tripwire_record "$name") || return 1
+  record_parent=$(printf '%s' "$record" | jq -r '.parent_session')
+  record_lab=$(printf '%s' "$record" | jq -r '.lab_session')
+  [ "$record_parent" = "$parent" ] || {
+    fm_herdr_lab_error "protected parent changed from '$record_parent' to '$parent'; refusing to guess"
+    return 1
+  }
+  [ "$record_lab" = "$name" ] || {
+    fm_herdr_lab_error "tripwire lab identity '$record_lab' does not match requested task lab '$name'"
+    return 1
+  }
+  printf '%s\n' "$record"
+}
+
+fm_herdr_lab_verify_inventory_binding() { # <parent-session> <lab-session> <session-list-json>
+  local parent=$1 name=$2 sessions=$3 record before after
+  record=$(fm_herdr_lab_tripwire_binding "$parent" "$name") || return 1
+  before=$(printf '%s' "$record" | jq -cS '.parent_state')
+  after=$(fm_herdr_lab_parent_snapshot_from_inventory "$parent" "$sessions") || return 1
+  fm_herdr_lab_verify_runtime_parent "$parent" "$after" || return 1
+  [ "$before" = "$after" ] || {
+    fm_herdr_lab_error "PROTECTED-PARENT TRIPWIRE FAILED: session '$parent' changed during lab work"
+    fm_herdr_lab_error "before: $before"
+    fm_herdr_lab_error "after:  $after"
     return 1
   }
 }
 
-fm_herdr_lab_refuse_if_default() { # <session>
-  local name=$1 info flag
-  fm_herdr_lab_validate_name "$name" || return 1
-  info=$(fm_herdr_lab_session_list "$name" 2>/dev/null) || {
-    fm_herdr_lab_error "refusing destructive call because session list failed"
+fm_herdr_lab_check_tripwire() { # <session>
+  local name=$1 parent sessions
+  parent=$(fm_herdr_lab_parent_name) || return 1
+  fm_herdr_lab_validate_pair "$parent" "$name" || return 1
+  fm_herdr_lab_tripwire_binding "$parent" "$name" >/dev/null || return 1
+  sessions=$(fm_herdr_lab_session_list "$parent" 2>/dev/null) || {
+    fm_herdr_lab_error "cannot read Herdr sessions while checking protected parent '$parent'"
     return 1
   }
-  flag=$(printf '%s' "$info" | jq -r --arg name "$name" \
-    '.sessions[]? | select(.name == $name) | .default' 2>/dev/null)
-  [ "$flag" = false ] && return 0
-  fm_herdr_lab_error "refusing destructive call for '$name': session is absent or default (default=${flag:-<not found>})"
-  return 1
+  fm_herdr_lab_verify_inventory_binding "$parent" "$name" "$sessions"
+}
+
+fm_herdr_lab_guard_target() { # <session>
+  local name=$1 parent sessions
+  parent=$(fm_herdr_lab_parent_name) || return 1
+  fm_herdr_lab_validate_pair "$parent" "$name" || return 1
+  fm_herdr_lab_tripwire_binding "$parent" "$name" >/dev/null || return 1
+  sessions=$(fm_herdr_lab_session_list "$parent" 2>/dev/null) || {
+    fm_herdr_lab_error "refusing task-lab operation because session inventory failed"
+    return 1
+  }
+  fm_herdr_lab_verify_inventory_binding "$parent" "$name" "$sessions" || return 1
+  fm_herdr_lab_distinct_target_snapshot "$parent" "$name" "$sessions" >/dev/null
+}
+
+fm_herdr_lab_write_tripwire() { # <parent-session> <lab-session> <parent-snapshot>
+  local parent=$1 name=$2 snapshot=$3 state_dir tripwire temporary record
+  state_dir=$(fm_herdr_lab_state_dir)
+  tripwire=$(fm_herdr_lab_tripwire_path "$name")
+  mkdir -p "$state_dir" || return 1
+  chmod 700 "$state_dir" 2>/dev/null || true
+  [ ! -e "$tripwire" ] || {
+    fm_herdr_lab_error "tripwire already exists for '$name'; refusing ambiguous ownership"
+    return 1
+  }
+  record=$(jq -cnS --arg parent "$parent" --arg lab "$name" --argjson state "$snapshot" \
+    '{version:1,lab_session:$lab,parent_session:$parent,parent_state:$state}') || return 1
+  temporary="$tripwire.tmp.$$.$RANDOM"
+  (umask 077; printf '%s\n' "$record" > "$temporary") || {
+    rm -f "$temporary"
+    return 1
+  }
+  if ! mv "$temporary" "$tripwire"; then
+    rm -f "$temporary"
+    return 1
+  fi
+}
+
+fm_herdr_lab_prepare() { # <session>
+  local name=$1 parent sessions parent_snapshot target_count
+  fm_herdr_lab_validate_name "$name" || return 1
+  command -v herdr >/dev/null 2>&1 || { fm_herdr_lab_error "herdr is required"; return 1; }
+  command -v jq >/dev/null 2>&1 || { fm_herdr_lab_error "jq is required"; return 1; }
+  parent=$(fm_herdr_lab_parent_name) || return 1
+  fm_herdr_lab_validate_pair "$parent" "$name" || return 1
+
+  sessions=$(fm_herdr_lab_session_list "$parent" 2>/dev/null) || {
+    fm_herdr_lab_error "cannot list Herdr sessions before preparing '$name'"
+    return 1
+  }
+  parent_snapshot=$(fm_herdr_lab_parent_snapshot_from_inventory "$parent" "$sessions") || return 1
+  fm_herdr_lab_verify_runtime_parent "$parent" "$parent_snapshot" || return 1
+  target_count=$(printf '%s' "$sessions" | jq -r --arg name "$name" '[.sessions[]? | select(.name == $name)] | length' 2>/dev/null) || {
+    fm_herdr_lab_error "cannot verify task-lab absence before preparing '$name'"
+    return 1
+  }
+  [ "$target_count" = 0 ] || {
+    fm_herdr_lab_error "session '$name' already exists; refusing to adopt or overwrite it"
+    return 1
+  }
+  fm_herdr_lab_write_tripwire "$parent" "$name" "$parent_snapshot"
 }
 
 fm_herdr_lab_cli() { # <session> <herdr arguments...>
@@ -150,6 +330,7 @@ fm_herdr_lab_cli() { # <session> <herdr arguments...>
       return 1
       ;;
   esac
+  fm_herdr_lab_guard_target "$name" || return 1
   fm_herdr_lab_raw "$name" "$@"
 }
 
@@ -169,41 +350,48 @@ fm_herdr_lab_cancel_provision() { # <pid>
 }
 
 fm_herdr_lab_provision() { # <session>
-  local name=$1 sessions tripwire running attempt server_pid max_attempts timeout_seconds
+  local name=$1 parent sessions tripwire running attempt server_pid max_attempts timeout_seconds target target_running
   fm_herdr_lab_validate_name "$name" || return 1
   command -v herdr >/dev/null 2>&1 || { fm_herdr_lab_error "herdr is required"; return 1; }
   command -v jq >/dev/null 2>&1 || { fm_herdr_lab_error "jq is required"; return 1; }
+  parent=$(fm_herdr_lab_parent_name) || return 1
+  fm_herdr_lab_validate_pair "$parent" "$name" || return 1
 
-  sessions=$(fm_herdr_lab_session_list "$name" 2>/dev/null) || {
+  sessions=$(fm_herdr_lab_session_list "$parent" 2>/dev/null) || {
     fm_herdr_lab_error "cannot list Herdr sessions before provisioning '$name'"
     return 1
   }
   if printf '%s' "$sessions" | jq -e --arg name "$name" '.sessions[]? | select(.name == $name)' >/dev/null 2>&1; then
     tripwire=$(fm_herdr_lab_tripwire_path "$name")
     [ -f "$tripwire" ] || {
-      fm_herdr_lab_error "missing fleet-state tripwire for existing session '$name'; refusing to adopt it"
+      fm_herdr_lab_error "missing protected-parent tripwire for existing session '$name'; refusing to adopt it"
       return 1
     }
-    fm_herdr_lab_refuse_if_default "$name" || return 1
-    running=$(printf '%s' "$sessions" | jq -r --arg name "$name" \
-      '.sessions[]? | select(.name == $name) | .running' 2>/dev/null)
-    [ "$running" = false ] || {
+    fm_herdr_lab_verify_inventory_binding "$parent" "$name" "$sessions" || return 1
+    target=$(fm_herdr_lab_distinct_target_snapshot "$parent" "$name" "$sessions") || return 1
+    target_running=$(printf '%s' "$target" | jq -r '.running')
+    [ "$target_running" = false ] || {
       fm_herdr_lab_error "session '$name' is not stopped; refusing to re-provision it"
       return 1
     }
-    fm_herdr_lab_check_tripwire "$name" || return 1
   else
     fm_herdr_lab_prepare "$name" || return 1
   fi
+
+  fm_herdr_lab_check_tripwire "$name" || return 1
   fm_herdr_lab_raw "$name" server >/dev/null 2>&1 &
   server_pid=$!
   attempt=0
   max_attempts=300
   timeout_seconds=60
   while [ "$attempt" -lt "$max_attempts" ]; do
-    running=$(fm_herdr_lab_cli "$name" status --json 2>/dev/null | jq -r '.server.running // false' 2>/dev/null) || running=false
+    fm_herdr_lab_check_tripwire "$name" || {
+      fm_herdr_lab_cancel_provision "$server_pid"
+      return 1
+    }
+    running=$(fm_herdr_lab_raw "$name" status --json 2>/dev/null | jq -r '.server.running // false' 2>/dev/null) || running=false
     if [ "$running" = true ]; then
-      fm_herdr_lab_refuse_if_default "$name" || {
+      fm_herdr_lab_guard_target "$name" || {
         fm_herdr_lab_cancel_provision "$server_pid"
         return 1
       }
@@ -217,66 +405,54 @@ fm_herdr_lab_provision() { # <session>
   return 1
 }
 
-fm_herdr_lab_check_tripwire() { # <session>
-  local name=$1 tripwire before after
-  tripwire=$(fm_herdr_lab_tripwire_path "$name")
-  [ -f "$tripwire" ] || {
-    fm_herdr_lab_error "missing fleet-state tripwire for '$name'; refusing unverified teardown"
-    return 1
-  }
-  before=$(cat "$tripwire")
-  after=$(fm_herdr_lab_fleet_state "$name") || return 1
-  [ "$before" = "$after" ] || {
-    fm_herdr_lab_error "FLEET-STATE TRIPWIRE FAILED: default session changed during lab work"
-    fm_herdr_lab_error "before: $before"
-    fm_herdr_lab_error "after:  $after"
-    return 1
-  }
-}
-
 fm_herdr_lab_verify_tripwire() { # <session>
-  local name=$1 tripwire
+  local name=$1 tripwire state_dir
   fm_herdr_lab_check_tripwire "$name" || return 1
   tripwire=$(fm_herdr_lab_tripwire_path "$name")
+  state_dir=$(fm_herdr_lab_state_dir)
   rm -f "$tripwire"
+  rmdir "$state_dir" 2>/dev/null || true
 }
 
 fm_herdr_lab_stop() { # <session>
-  local name=$1 tripwire
+  local name=$1 status=0
   fm_herdr_lab_validate_name "$name" || return 1
-  tripwire=$(fm_herdr_lab_tripwire_path "$name")
-  [ -f "$tripwire" ] || {
-    fm_herdr_lab_error "missing fleet-state tripwire for '$name'; refusing stop"
-    return 1
-  }
-  fm_herdr_lab_refuse_if_default "$name" || return 1
-  fm_herdr_lab_raw "$name" session stop "$name" --json
+  fm_herdr_lab_guard_target "$name" || return 1
+  fm_herdr_lab_raw "$name" session stop "$name" --json || status=$?
+  fm_herdr_lab_check_tripwire "$name" || return 1
+  return "$status"
 }
 
 fm_herdr_lab_teardown() { # <session>
-  local name=$1 tripwire sessions delete_status=0
+  local name=$1 parent sessions delete_status=0
   fm_herdr_lab_validate_name "$name" || return 1
-  tripwire=$(fm_herdr_lab_tripwire_path "$name")
-  [ -f "$tripwire" ] || {
-    fm_herdr_lab_error "missing fleet-state tripwire for '$name'; refusing destructive calls"
-    return 1
-  }
-  sessions=$(fm_herdr_lab_session_list "$name" 2>/dev/null) || {
+  parent=$(fm_herdr_lab_parent_name) || return 1
+  fm_herdr_lab_validate_pair "$parent" "$name" || return 1
+  fm_herdr_lab_tripwire_binding "$parent" "$name" >/dev/null || return 1
+
+  sessions=$(fm_herdr_lab_session_list "$parent" 2>/dev/null) || {
     fm_herdr_lab_error "cannot list Herdr sessions before teardown"
     return 1
   }
+  fm_herdr_lab_verify_inventory_binding "$parent" "$name" "$sessions" || return 1
   if ! printf '%s' "$sessions" | jq -e --arg name "$name" '.sessions[]? | select(.name == $name)' >/dev/null 2>&1; then
     fm_herdr_lab_verify_tripwire "$name"
     return
   fi
-  fm_herdr_lab_stop "$name" >/dev/null 2>&1 || true
+  fm_herdr_lab_guard_target "$name" || return 1
+  fm_herdr_lab_raw "$name" session stop "$name" --json >/dev/null 2>&1 || true
+  fm_herdr_lab_check_tripwire "$name" || return 1
   sleep 0.5
-  fm_herdr_lab_refuse_if_default "$name" || return 1
+
+  fm_herdr_lab_guard_target "$name" || return 1
   fm_herdr_lab_raw "$name" session delete "$name" --json >/dev/null 2>&1 || delete_status=$?
-  sessions=$(fm_herdr_lab_session_list "$name" 2>/dev/null) || {
+  fm_herdr_lab_check_tripwire "$name" || return 1
+
+  sessions=$(fm_herdr_lab_session_list "$parent" 2>/dev/null) || {
     fm_herdr_lab_error "cannot confirm removal of lab session '$name' after teardown"
     return 1
   }
+  fm_herdr_lab_verify_inventory_binding "$parent" "$name" "$sessions" || return 1
   if printf '%s' "$sessions" | jq -e --arg name "$name" '.sessions[]? | select(.name == $name)' >/dev/null 2>&1; then
     if [ "$delete_status" -ne 0 ]; then
       fm_herdr_lab_error "session delete failed for '$name' and the lab session remains"
@@ -299,7 +475,14 @@ fm_herdr_lab_name() { # <label>
 }
 
 fm_herdr_lab_usage() {
-  sed -n '2,13p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+  awk '
+    /^# Usage:/ { emit = 1 }
+    /^# End help\./ { exit }
+    emit {
+      sub(/^# ?/, "")
+      print
+    }
+  ' "${BASH_SOURCE[0]}"
 }
 
 fm_herdr_lab_main() {

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -712,12 +712,17 @@ trap spawn_abort_cleanup EXIT
 # <session> is required so secondmate and primary spawns serialize against the
 # same session without writing any other home's state directory.
 spawn_herdr_presentation_order_lock_acquire() {
-  local session=${1:-} attempt lock_path
+  local session=${1:-} attempt lock_path max_attempts=50
   [ -n "$session" ] || session=$(fm_backend_herdr_session)
   lock_path=$(fm_backend_herdr_presentation_session_lock_path "$session") || return 1
   HERDR_PRESENTATION_ORDER_LOCK="$lock_path"
   attempt=0
-  while [ "$attempt" -lt 50 ]; do
+  # Guarded lab transports verify their protected parent around each scoped
+  # Herdr call, so only those isolated verification runs get a longer bounded
+  # wait for a serialized projected create. Normal fleet behavior stays at the
+  # existing five-second best-effort window.
+  [ -z "${FM_HERDR_LAB_PARENT_SESSION:-}" ] || max_attempts=150
+  while [ "$attempt" -lt "$max_attempts" ]; do
     if fm_lock_try_acquire "$HERDR_PRESENTATION_ORDER_LOCK"; then
       HERDR_PRESENTATION_ORDER_LOCK_HELD=1
       return 0

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -294,7 +294,8 @@ Never use ambient `herdr server stop` for Firstmate verification.
 An environment-only session selection can silently reach a different running server, and the ambient stop command has no explicit target.
 
 `bin/fm-herdr-lab.sh` is the sole supported lifecycle helper for isolated verification.
-It requires the exact running parent fleet session in `FM_HERDR_LAB_PARENT_SESSION`, never infers a parent from the running-session inventory, and verifies a Herdr-managed caller's injected session and socket against that explicit parent.
+It requires the exact running parent fleet session in `FM_HERDR_LAB_PARENT_SESSION` and never infers a parent from the running-session inventory.
+Lifecycle commands verify a Herdr-managed caller's injected session and socket against that explicit parent, while `run` also accepts a task-lab caller only when its injected session and socket exactly match the verified task target.
 It provisions only non-default task names beginning with `fm-lab-`, appends an explicit `--session` to allowed task commands, refuses caller-supplied session flags and server/session lifecycle subcommands, and performs destructive stop/delete only through its guarded lifecycle actions.
 The parent may safely be a genuine running `default` session or a running named session, including when other sessions are also running.
 Before task operations and immediately before every destructive call, the helper requires one exact running parent with the recorded canonical session object and one distinct non-default task target.

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -294,12 +294,14 @@ Never use ambient `herdr server stop` for Firstmate verification.
 An environment-only session selection can silently reach a different running server, and the ambient stop command has no explicit target.
 
 `bin/fm-herdr-lab.sh` is the sole supported lifecycle helper for isolated verification.
-It provisions only non-default names beginning with `fm-lab-`, appends an explicit `--session` to allowed task commands, refuses caller-supplied session flags and server/session lifecycle subcommands, and performs destructive stop/delete only through its guarded lifecycle actions.
-Immediately before every destructive call it re-queries the named session and refuses empty, missing, literal `default`, or `default:true` identities.
-Its before/after tripwire requires the live default-session snapshot to remain byte-identical.
+It requires the exact running parent fleet session in `FM_HERDR_LAB_PARENT_SESSION`, never infers a parent from the running-session inventory, and verifies a Herdr-managed caller's injected session and socket against that explicit parent.
+It provisions only non-default task names beginning with `fm-lab-`, appends an explicit `--session` to allowed task commands, refuses caller-supplied session flags and server/session lifecycle subcommands, and performs destructive stop/delete only through its guarded lifecycle actions.
+The parent may safely be a genuine running `default` session or a running named session, including when other sessions are also running.
+Before task operations and immediately before every destructive call, the helper requires one exact running parent with the recorded canonical session object and one distinct non-default task target.
+The protected-parent tripwire must remain semantically identical across prepare, provision, run, stop, and teardown; missing, ambiguous, stopped, changed, cross-runtime, or target-equal identity refuses rather than guessing.
 
 The helper's header and `--help` own exact commands.
-Tests use thin compatibility wrappers in `tests/herdr-test-safety.sh` and never duplicate the destructive policy.
+`tests/fm-herdr-lab.test.sh` covers the public executable interface, while real-Herdr tests use thin compatibility setup in `tests/herdr-test-safety.sh` without duplicating the lifecycle policy.
 
 ## Active limits
 
@@ -317,6 +319,7 @@ Tests use thin compatibility wrappers in `tests/herdr-test-safety.sh` and never 
 
 ```sh
 tests/fm-backend-herdr.test.sh
+tests/fm-herdr-lab.test.sh
 tests/fm-backend-herdr-smoke.test.sh
 tests/fm-backend-herdr-prune-safety-e2e.test.sh
 tests/fm-backend-herdr-respawn-idem-e2e.test.sh
@@ -330,5 +333,5 @@ tests/fm-afk-inject-herdr-e2e.test.sh
 tests/fm-afk-pi-herdr-return-e2e.test.sh
 ```
 
-Real Herdr tests use the named lab helper and default-session tripwire.
+Real Herdr tests use the named lab helper and exact protected-parent tripwire.
 [`verification/runtime-backends.md`](verification/runtime-backends.md#herdr) records the active version, CLI, projection, event, and lifecycle evidence without task-specific chronology.

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -25,7 +25,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-backlog-receive.sh`  | Idempotently ingest one confined remote handoff outbox through tasks-axi             |
 | `fm-decision-hold.sh`    | Create, verify, complete, and resolve durable captain-held decisions                 |
 | `fm-brief.sh`            | Scaffold ship (explicit `--mode`), scout, secondmate-charter, and Herdr-lab briefs   |
-| `fm-herdr-lab.sh`        | Provision and guardedly operate an isolated, never-default Herdr lab session         |
+| `fm-herdr-lab.sh`        | Provision and guardedly operate an isolated, never-default Herdr lab bound to its verified parent session |
 | `fm-install-herdr.sh`    | Install CI's exact-version Herdr pin with official asset URL, SHA-256, and protocol checks |
 | `fm-install-treehouse.sh`| Install CI's exact-version Treehouse pin for real-Herdr E2E that needs spawn worktrees |
 | `fm-herdr-ci-cleanup.sh` | Snapshot and tear down only job-owned `fm-lab-*` sessions in the Herdr CI lane       |

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -390,7 +390,7 @@ HERDR_LAB_HELPER=bin/fm-herdr-lab.sh \
   tests/fm-herdr-session-cleanup-e2e.test.sh
 ```
 
-Observed guarantee: one exact home-local, journal-correlated, one-tab and one-pane childless idle shell was closed after restoration while the exact non-target focus and default fleet session remained unchanged, and a repeat run was a no-op.
+Observed guarantee: one exact home-local, journal-correlated, one-tab and one-pane childless idle shell was closed after restoration while the exact non-target focus and protected parent session remained unchanged, and a repeat run was a no-op.
 
 ### Workspace-removal focus safety
 

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -215,8 +215,28 @@ The CLI matrix was checked directly:
 | Restart | guarded named-session stop then start | Workspace, tab, pane, and labels persisted; the agent process and registration did not. |
 | Close | `herdr pane close <pane> --session <name>` | The exact one-pane task tab closed; closing a final tab could remove the workspace. |
 
-All destructive verification used `bin/fm-herdr-lab.sh` with a non-default `fm-lab-` name and a byte-identical default-session tripwire.
+All destructive verification uses `bin/fm-herdr-lab.sh` with a non-default `fm-lab-` name and an exact protected-parent tripwire.
 No ambient `herdr server stop` command is a supported test operation.
+
+### Protected parent lab binding
+
+The named-parent correction was verified on 2026-08-03 against Herdr 0.7.5 protocol 17 from the running `arena` fleet session while `default` remained stopped.
+The deterministic public-interface suite covered a running named parent with stopped default, genuine running-default compatibility, multiple running sessions, missing and ambiguous parents, parent changes, runtime-identity disagreement, protected-parent targeting, guarded stop and delete, and complete task-lab cleanup without unrelated-session changes:
+
+```sh
+tests/fm-herdr-lab.test.sh
+```
+
+The real lifecycle used only the patched local helper, exported `FM_HERDR_LAB_PARENT_SESSION=arena`, installed the helper teardown trap before provision, and routed status plus session inventory through `run`.
+After successful teardown, `prepare` on the same task name proved that the lab was absent while recording a second canonical parent snapshot; `cmp` proved the before and after parent objects were byte-identical, and helper teardown removed that absence-proof tripwire.
+
+```text
+live_parent=arena herdr=0.7.5 protocol=17 default_running=false
+original_lab_absent_after_teardown=yes
+parent_snapshot_identical_after_absence_proof=yes
+before={"default":false,"name":"arena","running":true,"session_dir":"/Users/dmitrijarkov/.config/herdr/sessions/arena","socket_path":"/Users/dmitrijarkov/.config/herdr/sessions/arena/herdr.sock"}
+after={"default":false,"name":"arena","running":true,"session_dir":"/Users/dmitrijarkov/.config/herdr/sessions/arena","socket_path":"/Users/dmitrijarkov/.config/herdr/sessions/arena/herdr.sock"}
+```
 
 ### Prune and respawn
 

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -341,7 +341,7 @@ ok - real Herdr lab: concurrent primary/A/B spawns stay session-locked with zero
 ok - real Herdr lab: session lock contention from a secondmate home falls back flat with no journal
 ok - real Herdr lab: legacy projection labels and flat secondmate tabs are left unmigrated
 ok - real Herdr lab: multi-home exact-pane teardowns restore captain focus without workspace close authority
-ok - real Herdr lab validation completed on Herdr 0.7.4 with the default-session tripwire intact
+ok - real Herdr lab validation completed on Herdr 0.7.4 with the protected-parent tripwire intact
 ```
 
 The suite also covers lost or failed move responses, active-tab refusal, restart husks, missing and duplicate tokens, manual renames, concurrent cleanup, and exact focus restoration.
@@ -360,7 +360,7 @@ ok - real Herdr lab: Hi Bit and Wheelhouse-style same-identity restarts reclaim 
 ok - real Herdr lab: secondmate restart binding and reclaim stay isolated to the exact child home and parent
 ok - real Herdr lab: concurrent cross-home recoveries replace exact husks under one session lock with no focus drift
 ok - real Herdr lab: missing, renamed, and duplicate tokens trigger zero destructive or adoptive calls, and live duplicate risk refuses launch
-ok - real Herdr lab validation completed on Herdr 0.7.5 with the default-session tripwire intact
+ok - real Herdr lab validation completed on Herdr 0.7.5 with the protected-parent tripwire intact
 ```
 
 The projection suite ran again on 2026-08-04 against Herdr 0.8.0 protocol 19 for the default-on flip, where an absent `config/herdr-presentation-spaces` enables the projection and the value `off` opts out; since 2026-08-05 an absent file enables the projection only at or above the 0.8.0 floor recorded under "Presentation version floor" below, and `on` is the explicit opt-in that survives the floor:
@@ -411,7 +411,7 @@ ok - fallback: a doomed pane holding a persistent child exhausts the proof and t
 ok - fallback on a defective release: a bounded wrong-focus window of 4 samples was fully restored to the anchor
 ok - version floor: herdr 0.7.5 protocol 17 remains conservatively below the floor with steal_live=1
 ok - version floor: an unconfigured home falls back flat on herdr 0.7.5 and the explicit opt-in still projects
-evidence: herdr=0.7.5 protocol=17 steal_live=1 floor_verdict=1 default-session-tripwire=armed
+evidence: herdr=0.7.5 protocol=17 steal_live=1 floor_verdict=1 protected-parent-tripwire=armed
 ```
 
 Observed output on Herdr 0.8.0:
@@ -490,7 +490,7 @@ Two real-hardware conditions were required for the pane-death path to engage and
 
 The rules match the v0.7.5 tag source (`close_selected_workspace` reassigns focus from the closing workspace's index; `handle_pane_died` only clamps the stale focused index), and the upstream default branch resolves both paths by workspace id (PR #1877, commit `165dca45`, for the explicit close; PR #1912, commit `a979916`, for pane death), so the plan degrades to a harmless reorder-then-remove once a release carries them.
 
-The full projection and restored-shell suites were re-run on 2026-07-28 on Herdr 0.7.5 with the updated close path; the presentation suite completed with `real Herdr lab validation completed on Herdr 0.7.5 with the default-session tripwire intact`, and the restored-shell cleanup guarantee above was unchanged.
+The full projection and restored-shell suites were re-run on 2026-07-28 on Herdr 0.7.5 with the updated close path; the presentation suite completed with `real Herdr lab validation completed on Herdr 0.7.5 with the protected-parent tripwire intact`, and the restored-shell cleanup guarantee above was unchanged.
 
 The teardown-level record-retention gate was verified on 2026-07-28 with metadata fixtures and a live contending lock holder:
 

--- a/tests/fm-afk-inject-herdr-e2e.test.sh
+++ b/tests/fm-afk-inject-herdr-e2e.test.sh
@@ -44,6 +44,7 @@ command -v jq >/dev/null 2>&1 || { echo "skip: jq not found (required by the her
 # This suite runs against its own isolated lab session, so a Herdr pane
 # inherited from the terminal it was launched in must not follow spawn into it
 # as a cross-session parent identity (tests/herdr-test-safety.sh).
+herdr_capture_parent_session
 herdr_forget_inherited_pane
 
 fail() { printf 'not ok - %s\n' "$1" >&2; cleanup_all; exit 1; }

--- a/tests/fm-afk-launch.test.sh
+++ b/tests/fm-afk-launch.test.sh
@@ -830,6 +830,7 @@ e2e_herdr() {
   command -v jq >/dev/null 2>&1 || { echo "skip: jq not found (herdr e2e)"; return 0; }
   # shellcheck source=tests/herdr-test-safety.sh
   . "$ROOT/tests/herdr-test-safety.sh"
+  herdr_forget_inherited_pane
   # shellcheck source=/dev/null
   . "$ROOT/bin/fm-backend.sh"
 

--- a/tests/fm-afk-launch.test.sh
+++ b/tests/fm-afk-launch.test.sh
@@ -12,8 +12,8 @@
 #   the captain's active tab topology UNCHANGED, because the daemon lands in a
 #   NON-VISIBLE separate terminal (a herdr dedicated workspace, a detached tmux
 #   session), never a split of the captain's pane. The herdr path runs on a
-#   throwaway, NEVER-default HERDR_SESSION and asserts the default session is
-#   byte-identical via the fm-herdr-lab.sh fleet-state tripwire; the tmux path
+#   throwaway, NEVER-default HERDR_SESSION and asserts the exact protected
+#   parent is byte-identical via the fm-herdr-lab.sh tripwire; the tmux path
 #   uses uniquely-named throwaway sessions killed by exact name. A harmless
 #   sleeper replaces the real daemon (FM_AFK_LAUNCH_ENTRY) so the test observes
 #   only the terminal lifecycle.

--- a/tests/fm-afk-launch.test.sh
+++ b/tests/fm-afk-launch.test.sh
@@ -830,6 +830,7 @@ e2e_herdr() {
   command -v jq >/dev/null 2>&1 || { echo "skip: jq not found (herdr e2e)"; return 0; }
   # shellcheck source=tests/herdr-test-safety.sh
   . "$ROOT/tests/herdr-test-safety.sh"
+  herdr_capture_parent_session
   herdr_forget_inherited_pane
   # shellcheck source=/dev/null
   . "$ROOT/bin/fm-backend.sh"

--- a/tests/fm-afk-pi-herdr-return-e2e.test.sh
+++ b/tests/fm-afk-pi-herdr-return-e2e.test.sh
@@ -32,7 +32,7 @@ done
 LAB_HELPER=${HERDR_LAB_HELPER:-$ROOT/bin/fm-herdr-lab.sh}
 # A non-Herdr-managed CI runner explicitly selects the compatibility parent;
 # this is not a session-inventory inference.
-FM_HERDR_LAB_PARENT_SESSION=${FM_HERDR_LAB_PARENT_SESSION:-${HERDR_SESSION:-default}}
+FM_HERDR_LAB_PARENT_SESSION=${HERDR_SESSION:-${FM_HERDR_LAB_PARENT_SESSION:-default}}
 export FM_HERDR_LAB_PARENT_SESSION
 unset HERDR_ENV HERDR_PANE_ID HERDR_TAB_ID HERDR_WORKSPACE_ID HERDR_SOCKET_PATH HERDR_SESSION
 SESSION=$("$LAB_HELPER" name fm-afk-pi-return-e2e)

--- a/tests/fm-afk-pi-herdr-return-e2e.test.sh
+++ b/tests/fm-afk-pi-herdr-return-e2e.test.sh
@@ -30,7 +30,9 @@ for tool in herdr jq pi python3; do
 done
 
 LAB_HELPER=${HERDR_LAB_HELPER:-$ROOT/bin/fm-herdr-lab.sh}
-FM_HERDR_LAB_PARENT_SESSION=${FM_HERDR_LAB_PARENT_SESSION:-${HERDR_SESSION:-}}
+# A non-Herdr-managed CI runner explicitly selects the compatibility parent;
+# this is not a session-inventory inference.
+FM_HERDR_LAB_PARENT_SESSION=${FM_HERDR_LAB_PARENT_SESSION:-${HERDR_SESSION:-default}}
 export FM_HERDR_LAB_PARENT_SESSION
 unset HERDR_ENV HERDR_PANE_ID HERDR_TAB_ID HERDR_WORKSPACE_ID HERDR_SOCKET_PATH HERDR_SESSION
 SESSION=$("$LAB_HELPER" name fm-afk-pi-return-e2e)

--- a/tests/fm-afk-pi-herdr-return-e2e.test.sh
+++ b/tests/fm-afk-pi-herdr-return-e2e.test.sh
@@ -30,6 +30,9 @@ for tool in herdr jq pi python3; do
 done
 
 LAB_HELPER=${HERDR_LAB_HELPER:-$ROOT/bin/fm-herdr-lab.sh}
+FM_HERDR_LAB_PARENT_SESSION=${FM_HERDR_LAB_PARENT_SESSION:-${HERDR_SESSION:-}}
+export FM_HERDR_LAB_PARENT_SESSION
+unset HERDR_ENV HERDR_PANE_ID HERDR_TAB_ID HERDR_WORKSPACE_ID HERDR_SOCKET_PATH HERDR_SESSION
 SESSION=$("$LAB_HELPER" name fm-afk-pi-return-e2e)
 TMP_ROOT=$(fm_test_tmproot fm-afk-pi-return-e2e)
 HOME_DIR="$TMP_ROOT/home"

--- a/tests/fm-backend-autodetect-smoke.test.sh
+++ b/tests/fm-backend-autodetect-smoke.test.sh
@@ -10,7 +10,8 @@
 # adapter primitive - it has to be proven where fm_backend_name is actually
 # called. The real spawn runs in a helper-provisioned, per-run named Herdr lab
 # session, with a scratch FM_HOME and scratch local-only project. Concurrent
-# copies therefore never share the default session or a workspace namespace.
+# copies therefore never share a task-lab session or a workspace namespace;
+# they may bind the known compatibility parent without mutating it.
 #
 # The complementary "tmux nested inside herdr resolves to tmux, silently" case
 # is covered as a fast, deterministic fake-tmux fm-spawn.sh test in
@@ -22,7 +23,7 @@
 #
 # Safety (2026-07-02 incident): every test-owned Herdr operation goes through
 # bin/fm-herdr-lab.sh, which appends the named session flag and verifies the
-# default fleet session is unchanged after teardown. Never replace the helper
+# exact protected parent is unchanged after teardown. Never replace the helper
 # with an ambient HERDR_SESSION-only command.
 set -u
 

--- a/tests/fm-backend-autodetect-smoke.test.sh
+++ b/tests/fm-backend-autodetect-smoke.test.sh
@@ -49,6 +49,7 @@ export FM_GATE_REFUSE_BYPASS=1
 # against its own isolated lab session. A Herdr pane inherited from the terminal
 # it was launched in must not follow spawn into that session as a cross-session
 # parent identity; the spawn below sets HERDR_ENV explicitly.
+herdr_capture_parent_session
 herdr_forget_inherited_pane
 
 # TMP_ROOT is physically resolved (mktemp -d "$(pwd -P)"-relative) to keep this

--- a/tests/fm-backend-herdr-eventwait-smoke.test.sh
+++ b/tests/fm-backend-herdr-eventwait-smoke.test.sh
@@ -10,7 +10,7 @@
 # Safety (2026-07-02 incident, tests/herdr-test-safety.sh): cleanup uses ONLY
 # herdr_safe_stop_and_delete on a private fm-lab-* session, never a bare/ambient
 # `herdr server stop`. Every lifecycle op goes through bin/fm-herdr-lab.sh, which
-# refuses the default session and verifies the fleet-state tripwire.
+# refuses the protected parent as a target and verifies its exact tripwire.
 set -u
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"

--- a/tests/fm-backend-herdr-eventwait-smoke.test.sh
+++ b/tests/fm-backend-herdr-eventwait-smoke.test.sh
@@ -28,6 +28,7 @@ command -v python3 >/dev/null 2>&1 || { echo "skip: python3 not found (required 
 # This suite runs against its own isolated lab session, so a Herdr pane
 # inherited from the terminal it was launched in must not follow spawn into it
 # as a cross-session parent identity (tests/herdr-test-safety.sh).
+herdr_capture_parent_session
 herdr_forget_inherited_pane
 
 SESSION="fm-lab-eventwait-smoke-$$"

--- a/tests/fm-backend-herdr-focus-flash-e2e.test.sh
+++ b/tests/fm-backend-herdr-focus-flash-e2e.test.sh
@@ -15,11 +15,14 @@
 # On a future release whose explicit close preserves focus, Part A records
 # that and Parts B and C keep outcome-only assertions, so no version is guessed.
 # Every CLI operation is routed through one guarded named non-default lab, and
-# lab teardown verifies that the default fleet session is byte-identical.
+# lab teardown verifies that the exact protected parent session is unchanged.
 set -u
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 HERDR_LAB_HELPER=${HERDR_LAB_HELPER:-$ROOT/bin/fm-herdr-lab.sh}
+FM_HERDR_LAB_PARENT_SESSION=${FM_HERDR_LAB_PARENT_SESSION:-${HERDR_SESSION:-}}
+export FM_HERDR_LAB_PARENT_SESSION
+unset HERDR_ENV HERDR_PANE_ID HERDR_TAB_ID HERDR_WORKSPACE_ID HERDR_SOCKET_PATH HERDR_SESSION
 
 fail() { printf 'not ok - %s\n' "$1" >&2; exit 1; }
 pass() { printf 'ok - %s\n' "$1"; }
@@ -343,7 +346,7 @@ fi
 # below-floor release may conservatively include the known post-fix protocol-18
 # preview without weakening the stated 0.8.0 policy floor.
 STATUS=$(lab status --json) || fail 'could not read final named-lab version evidence'
-LIVE_VERSION=$(printf '%s' "$STATUS" | jq -r '.client.version')
+ LIVE_VERSION=$(printf '%s' "$STATUS" | jq -r '.client.version')
 LIVE_PROTOCOL=$(printf '%s' "$STATUS" | jq -r '.client.protocol')
 FLOOR_VERDICT=$(bash -c '
   . "$0/bin/backends/herdr.sh"
@@ -394,5 +397,5 @@ else
   pass "version floor: an unconfigured home stays projected on herdr $LIVE_VERSION and the explicit opt-in agrees"
 fi
 
-printf 'evidence: herdr=%s protocol=%s steal_live=%s floor_verdict=%s default-session-tripwire=armed\n' \
+printf 'evidence: herdr=%s protocol=%s steal_live=%s floor_verdict=%s protected-parent-tripwire=armed\n' \
   "$LIVE_VERSION" "$LIVE_PROTOCOL" "$STEAL_LIVE" "$FLOOR_VERDICT"

--- a/tests/fm-backend-herdr-focus-flash-e2e.test.sh
+++ b/tests/fm-backend-herdr-focus-flash-e2e.test.sh
@@ -20,7 +20,9 @@ set -u
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 HERDR_LAB_HELPER=${HERDR_LAB_HELPER:-$ROOT/bin/fm-herdr-lab.sh}
-FM_HERDR_LAB_PARENT_SESSION=${FM_HERDR_LAB_PARENT_SESSION:-${HERDR_SESSION:-}}
+# A non-Herdr-managed CI runner explicitly selects the compatibility parent;
+# this is not a session-inventory inference.
+FM_HERDR_LAB_PARENT_SESSION=${FM_HERDR_LAB_PARENT_SESSION:-${HERDR_SESSION:-default}}
 export FM_HERDR_LAB_PARENT_SESSION
 unset HERDR_ENV HERDR_PANE_ID HERDR_TAB_ID HERDR_WORKSPACE_ID HERDR_SOCKET_PATH HERDR_SESSION
 

--- a/tests/fm-backend-herdr-focus-flash-e2e.test.sh
+++ b/tests/fm-backend-herdr-focus-flash-e2e.test.sh
@@ -22,7 +22,7 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 HERDR_LAB_HELPER=${HERDR_LAB_HELPER:-$ROOT/bin/fm-herdr-lab.sh}
 # A non-Herdr-managed CI runner explicitly selects the compatibility parent;
 # this is not a session-inventory inference.
-FM_HERDR_LAB_PARENT_SESSION=${FM_HERDR_LAB_PARENT_SESSION:-${HERDR_SESSION:-default}}
+FM_HERDR_LAB_PARENT_SESSION=${HERDR_SESSION:-${FM_HERDR_LAB_PARENT_SESSION:-default}}
 export FM_HERDR_LAB_PARENT_SESSION
 unset HERDR_ENV HERDR_PANE_ID HERDR_TAB_ID HERDR_WORKSPACE_ID HERDR_SOCKET_PATH HERDR_SESSION
 

--- a/tests/fm-backend-herdr-launcher-workspace-e2e.test.sh
+++ b/tests/fm-backend-herdr-launcher-workspace-e2e.test.sh
@@ -59,8 +59,8 @@ export HERDR_SESSION="$HERDR_LAB_SESSION"
 WORKTREES=()
 CLEANED=0
 # Idempotent: fail() cleans up before exiting and the EXIT trap fires after it,
-# so a second teardown would otherwise report the already-consumed fleet-state
-# tripwire as if the lab had gone wrong.
+# so a second teardown would otherwise report the already-consumed protected-
+# parent tripwire as if the lab had gone wrong.
 cleanup_all() {
   local wt status=0
   [ "$CLEANED" = 0 ] || return 0

--- a/tests/fm-backend-herdr-launcher-workspace-e2e.test.sh
+++ b/tests/fm-backend-herdr-launcher-workspace-e2e.test.sh
@@ -21,7 +21,7 @@
 #
 # Safety (2026-07-02 incident, see tests/herdr-test-safety.sh): every lifecycle
 # operation goes through bin/fm-herdr-lab.sh, which appends the named session
-# flag and verifies the default fleet session is unchanged after teardown.
+# flag and verifies the exact protected parent is unchanged after teardown.
 set -u
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -428,8 +428,8 @@ pass "real herdr E2E: teardown closes only the worker's own pane and leaves the 
 
 if ! cleanup_all; then
   trap - EXIT
-  printf 'not ok - isolated Herdr lab teardown failed or the default fleet session changed\n' >&2
+  printf 'not ok - isolated Herdr lab teardown failed or the protected parent session changed\n' >&2
   exit 1
 fi
 trap - EXIT
-pass "real herdr E2E: isolated lab session removed and default fleet session unchanged"
+pass "real herdr E2E: isolated lab session removed and protected parent session unchanged"

--- a/tests/fm-backend-herdr-launcher-workspace-e2e.test.sh
+++ b/tests/fm-backend-herdr-launcher-workspace-e2e.test.sh
@@ -44,6 +44,7 @@ command -v treehouse >/dev/null 2>&1 || { echo "skip: treehouse not found (requi
 
 # Every spawn below states its own launcher identity, so a pane inherited from
 # the terminal this suite was started in must not leak into any of them.
+herdr_capture_parent_session
 herdr_forget_inherited_pane
 
 TMP_ROOT=$(mktemp -d "$(cd "${TMPDIR:-/tmp}" && pwd -P)/fm-herdr-launcher-e2e.XXXXXX")

--- a/tests/fm-backend-herdr-presentation-e2e.test.sh
+++ b/tests/fm-backend-herdr-presentation-e2e.test.sh
@@ -10,7 +10,7 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 HERDR_LAB_HELPER=${HERDR_LAB_HELPER:-$ROOT/bin/fm-herdr-lab.sh}
 # A non-Herdr-managed CI runner explicitly selects the compatibility parent;
 # this is not a session-inventory inference.
-FM_HERDR_LAB_PARENT_SESSION=${FM_HERDR_LAB_PARENT_SESSION:-${HERDR_SESSION:-default}}
+FM_HERDR_LAB_PARENT_SESSION=${HERDR_SESSION:-${FM_HERDR_LAB_PARENT_SESSION:-default}}
 export FM_HERDR_LAB_PARENT_SESSION
 unset HERDR_ENV HERDR_PANE_ID HERDR_TAB_ID HERDR_WORKSPACE_ID HERDR_SOCKET_PATH HERDR_SESSION
 

--- a/tests/fm-backend-herdr-presentation-e2e.test.sh
+++ b/tests/fm-backend-herdr-presentation-e2e.test.sh
@@ -8,7 +8,9 @@ set -u
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 HERDR_LAB_HELPER=${HERDR_LAB_HELPER:-$ROOT/bin/fm-herdr-lab.sh}
-FM_HERDR_LAB_PARENT_SESSION=${FM_HERDR_LAB_PARENT_SESSION:-${HERDR_SESSION:-}}
+# A non-Herdr-managed CI runner explicitly selects the compatibility parent;
+# this is not a session-inventory inference.
+FM_HERDR_LAB_PARENT_SESSION=${FM_HERDR_LAB_PARENT_SESSION:-${HERDR_SESSION:-default}}
 export FM_HERDR_LAB_PARENT_SESSION
 unset HERDR_ENV HERDR_PANE_ID HERDR_TAB_ID HERDR_WORKSPACE_ID HERDR_SOCKET_PATH HERDR_SESSION
 

--- a/tests/fm-backend-herdr-presentation-e2e.test.sh
+++ b/tests/fm-backend-herdr-presentation-e2e.test.sh
@@ -8,6 +8,9 @@ set -u
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 HERDR_LAB_HELPER=${HERDR_LAB_HELPER:-$ROOT/bin/fm-herdr-lab.sh}
+FM_HERDR_LAB_PARENT_SESSION=${FM_HERDR_LAB_PARENT_SESSION:-${HERDR_SESSION:-}}
+export FM_HERDR_LAB_PARENT_SESSION
+unset HERDR_ENV HERDR_PANE_ID HERDR_TAB_ID HERDR_WORKSPACE_ID HERDR_SOCKET_PATH HERDR_SESSION
 
 fail() { printf 'not ok - %s\n' "$1" >&2; cleanup_all; exit 1; }
 pass() { printf 'ok - %s\n' "$1"; }
@@ -1372,9 +1375,9 @@ STATUS_JSON=$(lab status --json)
 HERDR_VERSION=$(printf '%s' "$STATUS_JSON" | jq -r '.client.version // "unknown"')
 PATH="$HERDR_ORIGINAL_PATH" \
   "$HERDR_LAB_HELPER" teardown "$HERDR_LAB_SESSION" \
-  || fail "guarded Herdr lab teardown or default-session tripwire verification failed"
+  || fail "guarded Herdr lab teardown or protected-parent tripwire verification failed"
 LAB_READY=0
-pass "real Herdr lab validation completed on Herdr $HERDR_VERSION with the default-session tripwire intact"
+pass "real Herdr lab validation completed on Herdr $HERDR_VERSION with the protected-parent tripwire intact"
 
 cleanup_all
 trap - EXIT

--- a/tests/fm-backend-herdr-prune-safety-e2e.test.sh
+++ b/tests/fm-backend-herdr-prune-safety-e2e.test.sh
@@ -36,6 +36,7 @@ command -v jq >/dev/null 2>&1 || { echo "skip: jq not found (required by the her
 # This suite runs against its own isolated lab session, so a Herdr pane
 # inherited from the terminal it was launched in must not follow spawn into it
 # as a cross-session parent identity (tests/herdr-test-safety.sh).
+herdr_capture_parent_session
 herdr_forget_inherited_pane
 
 SESSION="fm-lab-prune-safety-e2e-$$"

--- a/tests/fm-backend-herdr-respawn-idem-e2e.test.sh
+++ b/tests/fm-backend-herdr-respawn-idem-e2e.test.sh
@@ -48,6 +48,7 @@ command -v jq >/dev/null 2>&1 || { echo "skip: jq not found (required by the her
 # This suite runs against its own isolated lab session, so a Herdr pane
 # inherited from the terminal it was launched in must not follow spawn into it
 # as a cross-session parent identity (tests/herdr-test-safety.sh).
+herdr_capture_parent_session
 herdr_forget_inherited_pane
 
 SESSION="fm-lab-respawn-idem-e2e-$$"

--- a/tests/fm-backend-herdr-smoke.test.sh
+++ b/tests/fm-backend-herdr-smoke.test.sh
@@ -30,6 +30,7 @@ command -v jq >/dev/null 2>&1 || { echo "skip: jq not found (required by the her
 # This suite runs against its own isolated lab session, so a Herdr pane
 # inherited from the terminal it was launched in must not follow spawn into it
 # as a cross-session parent identity (tests/herdr-test-safety.sh).
+herdr_capture_parent_session
 herdr_forget_inherited_pane
 
 SESSION="fm-lab-backend-smoke-$$"

--- a/tests/fm-backend-herdr-workspace-per-home-e2e.test.sh
+++ b/tests/fm-backend-herdr-workspace-per-home-e2e.test.sh
@@ -57,6 +57,7 @@ command -v treehouse >/dev/null 2>&1 || { echo "skip: treehouse not found (requi
 # This suite runs against its own isolated lab session, so a Herdr pane
 # inherited from the terminal it was launched in must not follow spawn into it
 # as a cross-session parent identity (tests/herdr-test-safety.sh).
+herdr_capture_parent_session
 herdr_forget_inherited_pane
 
 # TMP_ROOT is physically resolved (mktemp -d "$(pwd -P)"-relative) for the same

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -383,6 +383,9 @@ test_herdr_lab_contract_is_explicit_and_complete() {
     "Herdr lab brief missing its hard safety contract"
   assert_grep "HERDR_LAB_HELPER='$ROOT/bin/fm-herdr-lab.sh'" "$brief" \
     "Herdr lab brief must bind the absolute Firstmate helper path"
+  # shellcheck disable=SC2016 # The generated brief must retain this literal expansion.
+  assert_grep 'FM_HERDR_LAB_PARENT_SESSION=${FM_HERDR_LAB_PARENT_SESSION:-${HERDR_SESSION:-}}' "$brief" \
+    "Herdr lab brief missing exact parent-session capture"
   assert_grep "HERDR_LAB_SESSION=\$(\"\$HERDR_LAB_HELPER\" name $id)" "$brief" \
     "Herdr lab brief missing helper-owned session naming"
   assert_grep "\"\$HERDR_LAB_HELPER\" provision \"\$HERDR_LAB_SESSION\"" "$brief" \
@@ -393,9 +396,9 @@ test_herdr_lab_contract_is_explicit_and_complete() {
     "Herdr lab brief missing the per-call trailing session contract"
   assert_grep "direct \`herdr server stop\`" "$brief" \
     "Herdr lab brief missing the forbidden server-global command list"
-  assert_grep "records the live default session before provisioning" "$brief" \
+  assert_grep "records the exact verified parent session before provisioning" "$brief" \
     "Herdr lab brief missing the before tripwire"
-  assert_grep "verifies the identical fleet state after teardown" "$brief" \
+  assert_grep "re-checks it before every task call, and verifies the semantically identical parent state after teardown" "$brief" \
     "Herdr lab brief missing the after tripwire"
   assert_no_grep "Herdr lifecycle declaration - NOT ENABLED" "$brief" \
     "Herdr lab brief retained the unguarded declaration"

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -384,7 +384,7 @@ test_herdr_lab_contract_is_explicit_and_complete() {
   assert_grep "HERDR_LAB_HELPER='$ROOT/bin/fm-herdr-lab.sh'" "$brief" \
     "Herdr lab brief must bind the absolute Firstmate helper path"
   # shellcheck disable=SC2016 # The generated brief must retain this literal expansion.
-  assert_grep 'FM_HERDR_LAB_PARENT_SESSION=${FM_HERDR_LAB_PARENT_SESSION:-${HERDR_SESSION:-}}' "$brief" \
+  assert_grep 'FM_HERDR_LAB_PARENT_SESSION=${HERDR_SESSION:-${FM_HERDR_LAB_PARENT_SESSION:-}}' "$brief" \
     "Herdr lab brief missing exact parent-session capture"
   assert_grep "HERDR_LAB_SESSION=\$(\"\$HERDR_LAB_HELPER\" name $id)" "$brief" \
     "Herdr lab brief missing helper-owned session naming"

--- a/tests/fm-herdr-lab.test.sh
+++ b/tests/fm-herdr-lab.test.sh
@@ -304,6 +304,22 @@ test_runtime_identity_must_match_explicit_parent() {
   local name="fm-lab-runtime-parent-$$" status=0
   reset_world "$(base_named_sessions)"
   env \
+    -u HERDR_SOCKET_PATH \
+    HERDR_ENV=1 \
+    HERDR_SESSION=arena \
+    PATH="$FAKEBIN:$PATH" \
+    FM_HERDR_LAB_PARENT_SESSION=arena \
+    FM_HERDR_LAB_STATE_DIR="$TRIPWIRES" \
+    FM_FAKE_HERDR_SESSIONS="$FAKE_SESSIONS" \
+    FM_FAKE_HERDR_LOG="$FAKE_LOG" \
+    "$HELPER" provision "$name" >/dev/null 2>&1 || status=$?
+  expect_code 1 "$status" "Herdr-managed parent without an injected socket must refuse provision"
+  assert_no_grep '^server ' "$FAKE_LOG" "managed parent without a socket started a lab server"
+  assert_absent "$(tripwire_for "$name")" "managed parent without a socket created a tripwire"
+
+  : > "$FAKE_LOG"
+  status=0
+  env \
     HERDR_ENV=1 \
     HERDR_SESSION=sibling \
     HERDR_SOCKET_PATH=/tmp/sibling.sock \

--- a/tests/fm-herdr-lab.test.sh
+++ b/tests/fm-herdr-lab.test.sh
@@ -116,6 +116,23 @@ run_helper_without_parent() { # <helper arguments...>
     "$HELPER" "$@"
 }
 
+run_helper_from_task() { # <parent-session> <lab-session> <helper arguments...>
+  local parent=$1 name=$2 runtime_socket
+  shift 2
+  runtime_socket=${FM_FAKE_HERDR_RUNTIME_SOCKET:-"/tmp/$name.sock"}
+  env \
+    HERDR_ENV=1 \
+    HERDR_SESSION="$name" \
+    HERDR_SOCKET_PATH="$runtime_socket" \
+    PATH="$FAKEBIN:$PATH" \
+    FM_HERDR_LAB_PARENT_SESSION="$parent" \
+    FM_HERDR_LAB_STATE_DIR="$TRIPWIRES" \
+    FM_FAKE_HERDR_SESSIONS="$FAKE_SESSIONS" \
+    FM_FAKE_HERDR_LOG="$FAKE_LOG" \
+    FM_FAKE_HERDR_REAL_SLEEP="$REAL_SLEEP" \
+    "$HELPER" "$@"
+}
+
 base_named_sessions() {
   printf '%s\n' '{"sessions":[
     {"name":"default","default":true,"running":false,"socket_path":"/tmp/default.sock","pid":null},
@@ -306,6 +323,21 @@ test_run_guards_and_parent_precheck() {
   local name="fm-lab-run-guards-$$" status=0
   reset_world "$(base_named_sessions)"
   run_helper arena provision "$name" || fail "run-guard fixture did not provision"
+
+  : > "$FAKE_LOG"
+  run_helper_from_task arena "$name" run "$name" workspace list >/dev/null \
+    || fail "task-runtime run with the verified task socket failed"
+  assert_grep "workspace list --session $name" "$FAKE_LOG" \
+    "task-runtime run did not reach the verified task target"
+  : > "$FAKE_LOG"
+  FM_FAKE_HERDR_RUNTIME_SOCKET=/tmp/foreign.sock \
+    run_helper_from_task arena "$name" run "$name" workspace list >/dev/null 2>&1 || status=$?
+  expect_code 1 "$status" "task-runtime run with a foreign socket must refuse"
+  assert_no_grep 'workspace list ' "$FAKE_LOG" "foreign task socket reached the task command"
+  status=0
+  run_helper_from_task arena "$name" stop "$name" >/dev/null 2>&1 || status=$?
+  expect_code 1 "$status" "task runtime must not authorize lifecycle commands"
+  assert_no_grep 'session stop ' "$FAKE_LOG" "task runtime reached a lifecycle stop"
 
   : > "$FAKE_LOG"
   run_helper arena run "$name" server stop >/dev/null 2>&1 || status=$?

--- a/tests/fm-herdr-lab.test.sh
+++ b/tests/fm-herdr-lab.test.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Behavior tests for bin/fm-herdr-lab.sh using a stateful fake Herdr client.
+# Public-interface behavior tests for bin/fm-herdr-lab.sh.
 set -u
 
 # shellcheck source=tests/lib.sh
@@ -7,62 +7,62 @@ set -u
 
 TMP_ROOT=$(fm_test_tmproot fm-herdr-lab)
 FAKEBIN=$(fm_fakebin "$TMP_ROOT")
-FAKE_STATE="$TMP_ROOT/herdr-state"
+FAKE_SESSIONS="$TMP_ROOT/sessions.json"
 FAKE_LOG="$TMP_ROOT/herdr.log"
 TRIPWIRES="$TMP_ROOT/tripwires"
 REAL_SLEEP=$(command -v sleep)
-mkdir -p "$FAKE_STATE"
-printf '%s\n' '/home/test/.config/herdr/herdr.sock' > "$FAKE_STATE/default-socket"
+HELPER="$ROOT/bin/fm-herdr-lab.sh"
+mkdir -p "$TMP_ROOT"
 : > "$FAKE_LOG"
 
 cat > "$FAKEBIN/herdr" <<'SH'
 #!/usr/bin/env bash
 set -eu
 printf '%s\n' "$*" >> "$FM_FAKE_HERDR_LOG"
-state=$FM_FAKE_HERDR_STATE
 last=
+previous=
 for arg in "$@"; do
   previous=$last
   last=$arg
 done
 [ "${previous:-}" = --session ] || { echo "fake herdr: missing trailing --session" >&2; exit 90; }
-session=$last
-default_socket=$(cat "$state/default-socket")
-lab_state=absent
-[ ! -f "$state/$session" ] || lab_state=$(cat "$state/$session")
+selector=$last
+sessions=$FM_FAKE_HERDR_SESSIONS
+
+update_sessions() {
+  local filter=$1 temporary
+  temporary="$sessions.tmp.$$"
+  jq "$filter" "$sessions" > "$temporary"
+  mv "$temporary" "$sessions"
+}
 
 case "$1 ${2:-}" in
   "session list")
-    if [ "$lab_state" = absent ] || [ "$lab_state" = deleted ]; then
-      jq -nc --arg socket "$default_socket" '{sessions:[{default:true,name:"default",running:true,socket_path:$socket}]}'
-    else
-      running=false
-      [ "$lab_state" = running ] && running=true
-      jq -nc --arg socket "$default_socket" --arg name "$session" --argjson running "$running" \
-        '{sessions:[{default:true,name:"default",running:true,socket_path:$socket},{default:false,name:$name,running:$running,socket_path:("/tmp/" + $name + ".sock")}]}'
-    fi
+    jq -c '{sessions:.sessions}' "$sessions"
     ;;
   "server --session")
     if [ "${FM_FAKE_HERDR_SERVER_DELAY:-0}" != 0 ]; then
       "$FM_FAKE_HERDR_REAL_SLEEP" "$FM_FAKE_HERDR_SERVER_DELAY"
     fi
-    printf '%s\n' running > "$state/$session"
+    jq --arg name "$selector" '
+      .sessions |= (
+        map(select(.name != $name))
+        + [{name:$name,default:false,running:true,socket_path:("/tmp/" + $name + ".sock"),pid:9001}]
+      )
+    ' "$sessions" > "$sessions.tmp.$$"
+    mv "$sessions.tmp.$$" "$sessions"
     ;;
   "status --json")
-    if [ "$lab_state" = running ]; then
-      printf '%s\n' '{"server":{"running":true}}'
-    else
-      printf '%s\n' '{"server":{"running":false}}'
-    fi
+    jq -c --arg name "$selector" '{server:{running:([.sessions[]? | select(.name == $name and .running == true)] | length == 1)}}' "$sessions"
     ;;
   "session stop")
-    [ "$3" = "$session" ] || exit 91
-    printf '%s\n' stopped > "$state/$session"
+    [ "$3" = "$selector" ] || exit 91
+    update_sessions '(.sessions[] | select(.name == "'"$selector"'") | .running) = false'
     ;;
   "session delete")
-    [ "$3" = "$session" ] || exit 92
+    [ "$3" = "$selector" ] || exit 92
     [ "${FM_FAKE_HERDR_DELETE_FAIL:-}" != 1 ] || exit 93
-    printf '%s\n' deleted > "$state/$session"
+    update_sessions '.sessions |= map(select(.name != "'"$selector"'"))'
     ;;
   *)
     printf '%s\n' '{"ok":true}'
@@ -71,145 +71,288 @@ esac
 SH
 chmod +x "$FAKEBIN/herdr"
 
-# shellcheck source=/dev/null
-. "$ROOT/bin/fm-herdr-lab.sh"
+reset_world() { # <sessions-json>
+  rm -rf "$TRIPWIRES"
+  mkdir -p "$TRIPWIRES"
+  printf '%s\n' "$1" | jq -cS . > "$FAKE_SESSIONS"
+  : > "$FAKE_LOG"
+}
 
-run_with_fake() {
-  PATH="$FAKEBIN:$PATH" \
-    FM_FAKE_HERDR_STATE="$FAKE_STATE" \
+run_helper() { # <parent-session> <helper arguments...>
+  local parent=$1
+  shift
+  env \
+    -u HERDR_ENV \
+    -u HERDR_PANE_ID \
+    -u HERDR_TAB_ID \
+    -u HERDR_WORKSPACE_ID \
+    -u HERDR_SOCKET_PATH \
+    -u HERDR_SESSION \
+    PATH="$FAKEBIN:$PATH" \
+    FM_HERDR_LAB_PARENT_SESSION="$parent" \
+    FM_HERDR_LAB_STATE_DIR="$TRIPWIRES" \
+    FM_FAKE_HERDR_SESSIONS="$FAKE_SESSIONS" \
     FM_FAKE_HERDR_LOG="$FAKE_LOG" \
     FM_FAKE_HERDR_REAL_SLEEP="$REAL_SLEEP" \
     FM_FAKE_HERDR_SERVER_DELAY="${FM_FAKE_HERDR_SERVER_DELAY:-0}" \
     FM_FAKE_HERDR_FAST_POLL="${FM_FAKE_HERDR_FAST_POLL:-}" \
     FM_FAKE_HERDR_DELETE_FAIL="${FM_FAKE_HERDR_DELETE_FAIL:-}" \
+    "$HELPER" "$@"
+}
+
+run_helper_without_parent() { # <helper arguments...>
+  env \
+    -u FM_HERDR_LAB_PARENT_SESSION \
+    -u HERDR_ENV \
+    -u HERDR_PANE_ID \
+    -u HERDR_TAB_ID \
+    -u HERDR_WORKSPACE_ID \
+    -u HERDR_SOCKET_PATH \
+    -u HERDR_SESSION \
+    PATH="$FAKEBIN:$PATH" \
     FM_HERDR_LAB_STATE_DIR="$TRIPWIRES" \
-    "$@"
+    FM_FAKE_HERDR_SESSIONS="$FAKE_SESSIONS" \
+    FM_FAKE_HERDR_LOG="$FAKE_LOG" \
+    "$HELPER" "$@"
 }
 
-test_refuses_unsafe_names() {
-  local status=0 generated
-  fm_herdr_lab_validate_name default >/dev/null 2>&1 || status=$?
-  expect_code 1 "$status" "literal default must be refused"
-  status=0
-  fm_herdr_lab_validate_name arbitrary-session >/dev/null 2>&1 || status=$?
-  expect_code 1 "$status" "non-lab prefix must be refused"
-  fm_herdr_lab_validate_name fm-lab-safe-123 || fail "valid lab session name was refused"
-  generated=$(fm_herdr_lab_name fm-autodetect-smoke-concurrency-h3)
-  fm_herdr_lab_validate_name "$generated" || fail "generated lab session name was refused"
-  [ "${#generated}" -le 40 ] || fail "generated lab session name is too long for Herdr socket paths: $generated"
-  pass "fm-herdr-lab: names fail closed and require the lab prefix"
+base_named_sessions() {
+  printf '%s\n' '{"sessions":[
+    {"name":"default","default":true,"running":false,"socket_path":"/tmp/default.sock","pid":null},
+    {"name":"arena","default":false,"running":true,"socket_path":"/tmp/arena.sock","pid":101}
+  ]}'
 }
 
-test_provision_run_and_guarded_teardown() {
-  local name='' line_count status=0 stop_line delete_line
-  name="fm-lab-behavior-$$"
+canonical_sessions_without() { # <session>
+  jq -cS --arg name "$1" '.sessions | map(select(.name != $name))' "$FAKE_SESSIONS"
+}
+
+tripwire_for() { # <session>
+  printf '%s/%s.parent-state.json' "$TRIPWIRES" "$1"
+}
+
+test_names_help_and_missing_parent_fail_closed() {
+  local status=0 generated name="fm-lab-missing-parent-$$"
+  generated=$("$HELPER" name fm-autodetect-smoke-concurrency-h3)
+  case "$generated" in fm-lab-*) : ;; *) fail "generated name lacks the lab prefix: $generated" ;; esac
+  [ "${#generated}" -le 40 ] || fail "generated lab name is too long: $generated"
+  "$HELPER" --help | grep -F 'FM_HERDR_LAB_PARENT_SESSION=<parent>' >/dev/null \
+    || fail "public help omits the exact parent-session input"
+
+  reset_world "$(base_named_sessions)"
+  run_helper_without_parent provision "$name" >/dev/null 2>&1 || status=$?
+  expect_code 1 "$status" "missing protected-parent input must refuse provision"
+  [ ! -s "$FAKE_LOG" ] || fail "missing parent identity reached Herdr"
+  assert_absent "$(tripwire_for "$name")" "missing parent identity created a tripwire"
+  pass "fm-herdr-lab: public naming/help work and missing parent identity refuses before Herdr"
+}
+
+test_running_named_parent_with_stopped_default() {
+  local name="fm-lab-named-parent-$$" before after
+  reset_world "$(base_named_sessions)"
+  before=$(canonical_sessions_without "$name")
+  run_helper arena provision "$name" || fail "named parent with stopped default did not provision"
+  jq -e --arg name "$name" '.sessions[] | select(.name == $name and .running == true)' "$FAKE_SESSIONS" >/dev/null \
+    || fail "named-parent provision did not start the task lab"
+  assert_present "$(tripwire_for "$name")" "named-parent provision did not record its parent tripwire"
+  run_helper arena run "$name" workspace list >/dev/null || fail "named-parent run failed"
+  run_helper arena teardown "$name" || fail "named-parent teardown failed"
+  after=$(canonical_sessions_without "$name")
+  [ "$before" = "$after" ] || fail "named-parent lifecycle changed the protected or unrelated sessions"
+  assert_absent "$(tripwire_for "$name")" "named-parent teardown retained its tripwire"
+  pass "fm-herdr-lab: running named parent works while default remains stopped"
+}
+
+test_running_default_parent_compatibility() {
+  local name="fm-lab-default-parent-$$" before after
+  reset_world '{"sessions":[
+    {"name":"default","default":true,"running":true,"socket_path":"/tmp/default.sock","pid":202},
+    {"name":"unrelated","default":false,"running":true,"socket_path":"/tmp/unrelated.sock","pid":303}
+  ]}'
+  before=$(canonical_sessions_without "$name")
+  run_helper default provision "$name" || fail "running default parent compatibility provision failed"
+  run_helper default teardown "$name" || fail "running default parent compatibility teardown failed"
+  after=$(canonical_sessions_without "$name")
+  [ "$before" = "$after" ] || fail "default-parent lifecycle changed the protected or unrelated sessions"
+  pass "fm-herdr-lab: genuine running default parent remains safely supported"
+}
+
+test_multiple_running_sessions_and_complete_cleanup() {
+  local name="fm-lab-multiple-$$" before after line stop_line delete_line
+  reset_world '{"sessions":[
+    {"name":"default","default":true,"running":false,"socket_path":"/tmp/default.sock","pid":null},
+    {"name":"arena","default":false,"running":true,"socket_path":"/tmp/arena.sock","pid":101},
+    {"name":"sibling","default":false,"running":true,"socket_path":"/tmp/sibling.sock","pid":404},
+    {"name":"resting","default":false,"running":false,"socket_path":"/tmp/resting.sock","pid":null}
+  ]}'
+  before=$(canonical_sessions_without "$name")
+  run_helper arena provision "$name" || fail "explicit parent was treated as ambiguous with multiple running sessions"
+  run_helper arena stop "$name" >/dev/null || fail "guarded stop failed"
+  run_helper arena provision "$name" || fail "guarded re-provision failed"
   : > "$FAKE_LOG"
-  run_with_fake fm_herdr_lab_provision "$name" || fail "provision failed"
-  [ "$(cat "$FAKE_STATE/$name")" = running ] || fail "provision did not start the named lab session"
-  assert_present "$TRIPWIRES/$name.fleet-state.json" "provision did not record the fleet-state tripwire"
-
-  run_with_fake fm_herdr_lab_cli "$name" workspace list >/dev/null || fail "safe run command failed"
-  run_with_fake fm_herdr_lab_cli "$name" server >/dev/null 2>&1 || status=$?
-  expect_code 1 "$status" "bare server start outside provision must be refused"
-  status=0
-  run_with_fake fm_herdr_lab_cli "$name" server stop >/dev/null 2>&1 || status=$?
-  expect_code 1 "$status" "server-global stop must be refused"
-  status=0
-  run_with_fake fm_herdr_lab_cli "$name" session delete "$name" >/dev/null 2>&1 || status=$?
-  expect_code 1 "$status" "direct session delete must be refused"
-  status=0
-  run_with_fake fm_herdr_lab_cli "$name" status --session default >/dev/null 2>&1 || status=$?
-  expect_code 1 "$status" "caller-supplied session flag must be refused"
-  status=0
-  run_with_fake fm_herdr_lab_cli "$name" status --session=default >/dev/null 2>&1 || status=$?
-  expect_code 1 "$status" "caller-supplied equals-form session flag must be refused"
-  status=0
-  run_with_fake fm_herdr_lab_cli "$name" --handoff server stop >/dev/null 2>&1 || status=$?
-  expect_code 1 "$status" "a leading option shifting server stop past the guard must be refused"
-  status=0
-  run_with_fake fm_herdr_lab_cli "$name" --no-session session delete "$name" >/dev/null 2>&1 || status=$?
-  expect_code 1 "$status" "a leading option shifting session delete past the guard must be refused"
-  status=0
-  run_with_fake fm_herdr_lab_cli "$name" --remote host workspace list >/dev/null 2>&1 || status=$?
-  expect_code 1 "$status" "a leading option subverting session isolation must be refused"
-
-  run_with_fake fm_herdr_lab_teardown "$name" || fail "guarded teardown failed"
-  [ "$(cat "$FAKE_STATE/$name")" = deleted ] || fail "teardown did not delete the lab session"
-  assert_absent "$TRIPWIRES/$name.fleet-state.json" "successful teardown left its tripwire behind"
+  run_helper arena teardown "$name" || fail "complete task-lab teardown failed"
+  after=$(canonical_sessions_without "$name")
+  [ "$before" = "$after" ] || fail "complete cleanup changed an unrelated session"
+  jq -e --arg name "$name" '[.sessions[] | select(.name == $name)] | length == 0' "$FAKE_SESSIONS" >/dev/null \
+    || fail "complete cleanup retained the task lab"
+  assert_absent "$(tripwire_for "$name")" "complete cleanup retained task ownership state"
 
   while IFS= read -r line; do
     case "$line" in
-      *"--session $name") : ;;
-      *) fail "Herdr call lacks a trailing lab session: $line" ;;
+      *"--session arena"|*"--session $name") : ;;
+      *) fail "Herdr call was not explicitly scoped to the parent or task lab: $line" ;;
     esac
   done < "$FAKE_LOG"
-  line_count=$(wc -l < "$FAKE_LOG" | tr -d ' ')
   stop_line=$(grep -n "^session stop $name --json --session $name$" "$FAKE_LOG" | cut -d: -f1)
   delete_line=$(grep -n "^session delete $name --json --session $name$" "$FAKE_LOG" | cut -d: -f1)
-  if [ -z "$stop_line" ] || [ -z "$delete_line" ] || [ "$line_count" -le "$delete_line" ]; then
-    fail "teardown did not emit explicit stop/delete followed by the after tripwire"
-  fi
-  sed -n "$((stop_line - 1))p" "$FAKE_LOG" | grep -F "session list --json --session $name" >/dev/null \
-    || fail "stop was not immediately preceded by a fresh refuse-default session list"
-  sed -n "$((delete_line - 1))p" "$FAKE_LOG" | grep -F "session list --json --session $name" >/dev/null \
-    || fail "delete was not immediately preceded by a fresh refuse-default session list"
-  pass "fm-herdr-lab: provisioning, scoped calls, guarded teardown, and fleet tripwire are deterministic"
+  [ -n "$stop_line" ] && [ -n "$delete_line" ] || fail "teardown omitted explicit task-lab stop/delete"
+  sed -n "$((stop_line - 1))p" "$FAKE_LOG" | grep -F "session list --json --session arena" >/dev/null \
+    || fail "task stop lacked an immediate protected-parent and target re-check"
+  sed -n "$((delete_line - 1))p" "$FAKE_LOG" | grep -F "session list --json --session arena" >/dev/null \
+    || fail "task delete lacked an immediate protected-parent and target re-check"
+  pass "fm-herdr-lab: explicit parent disambiguates multiple sessions and cleanup changes nothing else"
 }
 
-test_missing_tripwire_blocks_destruction() {
-  local name="fm-lab-no-tripwire-$$" status=0 before after
-  printf '%s\n' running > "$FAKE_STATE/$name"
+test_missing_ambiguous_and_changed_parent_refuse() {
+  local name="fm-lab-parent-refusal-$$" status=0
+  reset_world '{"sessions":[{"name":"default","default":true,"running":false,"socket_path":"/tmp/default.sock","pid":null}]}'
+  run_helper arena provision "$name" >/dev/null 2>&1 || status=$?
+  expect_code 1 "$status" "missing named parent must refuse provision"
+  assert_absent "$(tripwire_for "$name")" "missing named parent created a tripwire"
+  assert_no_grep '^server ' "$FAKE_LOG" "missing named parent started a lab server"
+
+  reset_world '{"sessions":[
+    {"name":"arena","default":false,"running":true,"socket_path":"/tmp/arena-a.sock","pid":1},
+    {"name":"arena","default":false,"running":true,"socket_path":"/tmp/arena-b.sock","pid":2}
+  ]}'
+  status=0
+  run_helper arena provision "$name" >/dev/null 2>&1 || status=$?
+  expect_code 1 "$status" "duplicate parent identity must refuse provision"
+  assert_no_grep '^server ' "$FAKE_LOG" "ambiguous parent started a lab server"
+
+  reset_world "$(base_named_sessions)"
+  run_helper arena provision "$name" || fail "parent-change fixture did not provision"
+  jq '(.sessions[] | select(.name == "arena") | .socket_path) = "/tmp/arena-changed.sock"' \
+    "$FAKE_SESSIONS" > "$FAKE_SESSIONS.tmp"
+  mv "$FAKE_SESSIONS.tmp" "$FAKE_SESSIONS"
   : > "$FAKE_LOG"
-  before=$(wc -l < "$FAKE_LOG")
-  run_with_fake fm_herdr_lab_teardown "$name" >/dev/null 2>&1 || status=$?
-  expect_code 1 "$status" "missing tripwire must refuse teardown"
-  after=$(wc -l < "$FAKE_LOG")
-  [ "$before" = "$after" ] || fail "missing tripwire reached Herdr instead of refusing before destructive calls"
-  pass "fm-herdr-lab: missing tripwire refuses teardown before any Herdr call"
+  status=0
+  run_helper arena stop "$name" >/dev/null 2>&1 || status=$?
+  expect_code 1 "$status" "changed protected-parent state must refuse stop"
+  assert_no_grep '^session stop ' "$FAKE_LOG" "changed parent state reached task stop"
+  assert_no_grep '^session delete ' "$FAKE_LOG" "changed parent state reached task delete"
+  assert_present "$(tripwire_for "$name")" "changed-parent refusal discarded its evidence"
+
+  jq '(.sessions[] | select(.name == "arena") | .socket_path) = "/tmp/arena.sock"' \
+    "$FAKE_SESSIONS" > "$FAKE_SESSIONS.tmp"
+  mv "$FAKE_SESSIONS.tmp" "$FAKE_SESSIONS"
+  run_helper arena teardown "$name" || fail "cleanup failed after restoring the protected parent"
+  pass "fm-herdr-lab: missing, ambiguous, or changed protected parent refuses destructive work"
 }
 
-test_changed_default_trips_after_teardown() {
-  local name="fm-lab-tripwire-change-$$" status=0
+test_changed_supplied_parent_and_protected_target_refuse() {
+  local name="fm-lab-binding-change-$$" protected="fm-lab-parent-$$" status=0
+  reset_world '{"sessions":[
+    {"name":"arena","default":false,"running":true,"socket_path":"/tmp/arena.sock","pid":101},
+    {"name":"sibling","default":false,"running":true,"socket_path":"/tmp/sibling.sock","pid":202}
+  ]}'
+  run_helper arena provision "$name" || fail "binding-change fixture did not provision"
   : > "$FAKE_LOG"
-  run_with_fake fm_herdr_lab_provision "$name" || fail "tripwire fixture provision failed"
-  printf '%s\n' '/changed/default.sock' > "$FAKE_STATE/default-socket"
-  run_with_fake fm_herdr_lab_teardown "$name" >/dev/null 2>&1 || status=$?
-  expect_code 1 "$status" "changed default fleet state must fail teardown"
-  assert_present "$TRIPWIRES/$name.fleet-state.json" "failed tripwire should retain evidence"
-  printf '%s\n' '/home/test/.config/herdr/herdr.sock' > "$FAKE_STATE/default-socket"
-  rm -f "$TRIPWIRES/$name.fleet-state.json"
-  pass "fm-herdr-lab: changed default fleet state is a hard failure"
-}
+  run_helper sibling teardown "$name" >/dev/null 2>&1 || status=$?
+  expect_code 1 "$status" "changed supplied parent must refuse teardown"
+  [ ! -s "$FAKE_LOG" ] || fail "changed supplied parent queried or mutated Herdr before refusing"
 
-test_stopped_owned_lab_can_reprovision() {
-  local name="fm-lab-reprovision-$$"
+  jq --arg name "$name" '(.sessions[] | select(.name == $name) | .socket_path) = "/tmp/arena.sock"' \
+    "$FAKE_SESSIONS" > "$FAKE_SESSIONS.tmp"
+  mv "$FAKE_SESSIONS.tmp" "$FAKE_SESSIONS"
   : > "$FAKE_LOG"
-  run_with_fake fm_herdr_lab_provision "$name" || fail "initial provision failed"
-  run_with_fake fm_herdr_lab_stop "$name" || fail "guarded stop failed"
-  [ "$(cat "$FAKE_STATE/$name")" = stopped ] || fail "guarded stop did not stop the lab session"
-  assert_present "$TRIPWIRES/$name.fleet-state.json" "stop removed the lab ownership tripwire"
-  run_with_fake fm_herdr_lab_provision "$name" || fail "re-provision after guarded stop failed"
-  [ "$(cat "$FAKE_STATE/$name")" = running ] || fail "re-provision did not restart the stopped lab session"
-  assert_present "$TRIPWIRES/$name.fleet-state.json" "re-provision removed the lab ownership tripwire"
-  run_with_fake fm_herdr_lab_teardown "$name" || fail "teardown after re-provision failed"
-  pass "fm-herdr-lab: an owned stopped lab can re-provision safely"
+  status=0
+  run_helper arena stop "$name" >/dev/null 2>&1 || status=$?
+  expect_code 1 "$status" "task identity resolving to the protected-parent socket must refuse stop"
+  assert_no_grep '^session stop ' "$FAKE_LOG" "protected-parent socket alias reached task stop"
+  jq --arg name "$name" '(.sessions[] | select(.name == $name) | .socket_path) = ("/tmp/" + $name + ".sock")' \
+    "$FAKE_SESSIONS" > "$FAKE_SESSIONS.tmp"
+  mv "$FAKE_SESSIONS.tmp" "$FAKE_SESSIONS"
+  run_helper arena teardown "$name" || fail "binding-change fixture cleanup failed"
+
+  reset_world "$(jq -nc --arg parent "$protected" '{sessions:[{name:$parent,default:false,running:true,socket_path:("/tmp/" + $parent + ".sock"),pid:303}]}')"
+  status=0
+  run_helper "$protected" provision "$protected" >/dev/null 2>&1 || status=$?
+  expect_code 1 "$status" "attempt to target the protected parent as a lab must refuse"
+  [ ! -s "$FAKE_LOG" ] || fail "protected-parent target attempt reached Herdr"
+  pass "fm-herdr-lab: changed binding and protected-parent targeting refuse before lifecycle calls"
 }
 
-test_failed_delete_retains_tripwire() {
+test_runtime_identity_must_match_explicit_parent() {
+  local name="fm-lab-runtime-parent-$$" status=0
+  reset_world "$(base_named_sessions)"
+  env \
+    HERDR_ENV=1 \
+    HERDR_SESSION=sibling \
+    HERDR_SOCKET_PATH=/tmp/sibling.sock \
+    PATH="$FAKEBIN:$PATH" \
+    FM_HERDR_LAB_PARENT_SESSION=arena \
+    FM_HERDR_LAB_STATE_DIR="$TRIPWIRES" \
+    FM_FAKE_HERDR_SESSIONS="$FAKE_SESSIONS" \
+    FM_FAKE_HERDR_LOG="$FAKE_LOG" \
+    "$HELPER" provision "$name" >/dev/null 2>&1 || status=$?
+  expect_code 1 "$status" "Herdr runtime identity mismatch must refuse provision"
+  assert_no_grep '^server ' "$FAKE_LOG" "runtime parent mismatch started a lab server"
+  assert_absent "$(tripwire_for "$name")" "runtime parent mismatch created a tripwire"
+  pass "fm-herdr-lab: explicit parent must agree with stronger Herdr runtime identity"
+}
+
+test_run_guards_and_parent_precheck() {
+  local name="fm-lab-run-guards-$$" status=0
+  reset_world "$(base_named_sessions)"
+  run_helper arena provision "$name" || fail "run-guard fixture did not provision"
+
+  : > "$FAKE_LOG"
+  run_helper arena run "$name" server stop >/dev/null 2>&1 || status=$?
+  expect_code 1 "$status" "run must forbid server lifecycle operations"
+  status=0
+  run_helper arena run "$name" session delete "$name" >/dev/null 2>&1 || status=$?
+  expect_code 1 "$status" "run must forbid session lifecycle operations"
+  status=0
+  run_helper arena run "$name" status --session default >/dev/null 2>&1 || status=$?
+  expect_code 1 "$status" "run must forbid caller-supplied session selectors"
+  status=0
+  run_helper arena run "$name" --remote host workspace list >/dev/null 2>&1 || status=$?
+  expect_code 1 "$status" "run must forbid leading global options"
+  [ ! -s "$FAKE_LOG" ] || fail "forbidden run command reached Herdr"
+
+  jq '(.sessions[] | select(.name == "arena") | .socket_path) = "/changed/before-command.sock"' \
+    "$FAKE_SESSIONS" > "$FAKE_SESSIONS.tmp"
+  mv "$FAKE_SESSIONS.tmp" "$FAKE_SESSIONS"
+  : > "$FAKE_LOG"
+  status=0
+  run_helper arena run "$name" workspace list >/dev/null 2>&1 || status=$?
+  expect_code 1 "$status" "run must refuse a protected parent changed before the task call"
+  assert_no_grep '^workspace list ' "$FAKE_LOG" "changed parent state reached the task command"
+  assert_present "$(tripwire_for "$name")" "run pre-check failure discarded the tripwire"
+  jq '(.sessions[] | select(.name == "arena") | .socket_path) = "/tmp/arena.sock"' \
+    "$FAKE_SESSIONS" > "$FAKE_SESSIONS.tmp"
+  mv "$FAKE_SESSIONS.tmp" "$FAKE_SESSIONS"
+  run_helper arena teardown "$name" || fail "run-guard fixture cleanup failed"
+  pass "fm-herdr-lab: run rejects unsafe calls and re-checks the protected parent first"
+}
+
+test_failed_delete_retains_ownership() {
   local name="fm-lab-delete-failure-$$" status=0
-  : > "$FAKE_LOG"
-  run_with_fake fm_herdr_lab_provision "$name" || fail "delete-failure fixture provision failed"
-  FM_FAKE_HERDR_DELETE_FAIL=1 run_with_fake fm_herdr_lab_teardown "$name" >/dev/null 2>&1 || status=$?
-  expect_code 1 "$status" "failed delete must fail teardown"
-  [ "$(cat "$FAKE_STATE/$name")" = stopped ] || fail "failed delete unexpectedly removed the lab session"
-  assert_present "$TRIPWIRES/$name.fleet-state.json" "failed delete removed the ownership tripwire"
-  run_with_fake fm_herdr_lab_teardown "$name" || fail "retry after failed delete did not clean up the lab session"
-  assert_absent "$TRIPWIRES/$name.fleet-state.json" "successful retry left the ownership tripwire behind"
-  pass "fm-herdr-lab: failed deletion retains ownership until absence is confirmed"
+  reset_world "$(base_named_sessions)"
+  run_helper arena provision "$name" || fail "delete-failure fixture did not provision"
+  FM_FAKE_HERDR_DELETE_FAIL=1 run_helper arena teardown "$name" >/dev/null 2>&1 || status=$?
+  expect_code 1 "$status" "failed task-lab delete must fail teardown"
+  assert_present "$(tripwire_for "$name")" "failed delete discarded task ownership"
+  jq -e --arg name "$name" '.sessions[] | select(.name == $name)' "$FAKE_SESSIONS" >/dev/null \
+    || fail "failed delete unexpectedly removed the task lab"
+  run_helper arena teardown "$name" || fail "delete retry did not clean up the task lab"
+  pass "fm-herdr-lab: failed deletion retains ownership until confirmed cleanup"
 }
 
 test_timed_out_provision_cancels_late_launch() {
-  local name="fm-lab-late-launch-$$" status=0
+  local name="fm-lab-timeout-$$" status=0
+  reset_world "$(base_named_sessions)"
   cat > "$FAKEBIN/sleep" <<'SH'
 #!/usr/bin/env bash
 if [ "${FM_FAKE_HERDR_FAST_POLL:-}" = 1 ]; then
@@ -218,26 +361,24 @@ fi
 exec "$FM_FAKE_HERDR_REAL_SLEEP" "$@"
 SH
   chmod +x "$FAKEBIN/sleep"
-  : > "$FAKE_LOG"
   FM_FAKE_HERDR_FAST_POLL=1 FM_FAKE_HERDR_SERVER_DELAY=30 \
-    run_with_fake fm_herdr_lab_provision "$name" >/dev/null 2>&1 || status=$?
+    run_helper arena provision "$name" >/dev/null 2>&1 || status=$?
   expect_code 1 "$status" "timed-out provision must fail"
-  assert_present "$TRIPWIRES/$name.fleet-state.json" \
-    "timed-out provision must retain its tripwire until teardown"
-  run_with_fake fm_herdr_lab_teardown "$name" || fail "teardown after timed-out provision failed"
-  assert_absent "$TRIPWIRES/$name.fleet-state.json" \
-    "teardown after timed-out provision did not remove its tripwire"
+  assert_present "$(tripwire_for "$name")" "timed-out provision discarded task ownership"
+  run_helper arena teardown "$name" || fail "teardown after timed-out provision failed"
   "$REAL_SLEEP" 1.1
-  if [ -f "$FAKE_STATE/$name" ] && [ "$(cat "$FAKE_STATE/$name")" = running ]; then
-    fail "timed-out provision left a late-starting lab session after teardown"
-  fi
-  pass "fm-herdr-lab: timed-out provisioning cancels the launch before teardown"
+  jq -e --arg name "$name" '[.sessions[] | select(.name == $name)] | length == 0' "$FAKE_SESSIONS" >/dev/null \
+    || fail "timed-out provision left a late-starting task lab"
+  pass "fm-herdr-lab: timed-out provisioning cancels the launch before cleanup"
 }
 
-test_refuses_unsafe_names
-test_provision_run_and_guarded_teardown
-test_missing_tripwire_blocks_destruction
-test_changed_default_trips_after_teardown
-test_stopped_owned_lab_can_reprovision
-test_failed_delete_retains_tripwire
+test_names_help_and_missing_parent_fail_closed
+test_running_named_parent_with_stopped_default
+test_running_default_parent_compatibility
+test_multiple_running_sessions_and_complete_cleanup
+test_missing_ambiguous_and_changed_parent_refuse
+test_changed_supplied_parent_and_protected_target_refuse
+test_runtime_identity_must_match_explicit_parent
+test_run_guards_and_parent_precheck
+test_failed_delete_retains_ownership
 test_timed_out_provision_cancels_late_launch

--- a/tests/fm-herdr-session-cleanup-e2e.test.sh
+++ b/tests/fm-herdr-session-cleanup-e2e.test.sh
@@ -1,11 +1,14 @@
 #!/usr/bin/env bash
 # Real restored-shell E2E for home-local session-start Herdr projection cleanup.
 # Every CLI operation is routed through one guarded named non-default lab, and
-# lab teardown verifies that the default fleet session is byte-identical.
+# lab teardown verifies that the exact protected parent session is unchanged.
 set -u
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 HERDR_LAB_HELPER=${HERDR_LAB_HELPER:-$ROOT/bin/fm-herdr-lab.sh}
+FM_HERDR_LAB_PARENT_SESSION=${FM_HERDR_LAB_PARENT_SESSION:-${HERDR_SESSION:-}}
+export FM_HERDR_LAB_PARENT_SESSION
+unset HERDR_ENV HERDR_PANE_ID HERDR_TAB_ID HERDR_WORKSPACE_ID HERDR_SOCKET_PATH HERDR_SESSION
 
 fail() { printf 'not ok - %s\n' "$1" >&2; exit 1; }
 pass() { printf 'ok - %s\n' "$1"; }
@@ -140,7 +143,7 @@ FM_HOME="$HOME_DIR" FM_BACKEND=herdr HERDR_SESSION="$HERDR_LAB_SESSION" \
 lab pane get "$(printf '%s' "$ANCHOR" | jq -r '.result.root_pane.pane_id')" >/dev/null \
   || fail 'anchor pane was touched by cleanup'
 STATUS=$(lab status --json) || fail 'could not read final named-lab version evidence'
-pass 'real named lab cleanup is idempotent and leaves the default fleet session to the teardown tripwire'
-printf 'evidence: herdr=%s protocol=%s default-session-tripwire=armed\n' \
+pass 'real named lab cleanup is idempotent and leaves the protected parent to the teardown tripwire'
+printf 'evidence: herdr=%s protocol=%s protected-parent-tripwire=armed\n' \
   "$(printf '%s' "$STATUS" | jq -r '.client.version')" \
   "$(printf '%s' "$STATUS" | jq -r '.server.protocol')"

--- a/tests/fm-herdr-session-cleanup-e2e.test.sh
+++ b/tests/fm-herdr-session-cleanup-e2e.test.sh
@@ -6,7 +6,9 @@ set -u
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 HERDR_LAB_HELPER=${HERDR_LAB_HELPER:-$ROOT/bin/fm-herdr-lab.sh}
-FM_HERDR_LAB_PARENT_SESSION=${FM_HERDR_LAB_PARENT_SESSION:-${HERDR_SESSION:-}}
+# A non-Herdr-managed CI runner explicitly selects the compatibility parent;
+# this is not a session-inventory inference.
+FM_HERDR_LAB_PARENT_SESSION=${FM_HERDR_LAB_PARENT_SESSION:-${HERDR_SESSION:-default}}
 export FM_HERDR_LAB_PARENT_SESSION
 unset HERDR_ENV HERDR_PANE_ID HERDR_TAB_ID HERDR_WORKSPACE_ID HERDR_SOCKET_PATH HERDR_SESSION
 

--- a/tests/fm-herdr-session-cleanup-e2e.test.sh
+++ b/tests/fm-herdr-session-cleanup-e2e.test.sh
@@ -8,7 +8,7 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 HERDR_LAB_HELPER=${HERDR_LAB_HELPER:-$ROOT/bin/fm-herdr-lab.sh}
 # A non-Herdr-managed CI runner explicitly selects the compatibility parent;
 # this is not a session-inventory inference.
-FM_HERDR_LAB_PARENT_SESSION=${FM_HERDR_LAB_PARENT_SESSION:-${HERDR_SESSION:-default}}
+FM_HERDR_LAB_PARENT_SESSION=${HERDR_SESSION:-${FM_HERDR_LAB_PARENT_SESSION:-default}}
 export FM_HERDR_LAB_PARENT_SESSION
 unset HERDR_ENV HERDR_PANE_ID HERDR_TAB_ID HERDR_WORKSPACE_ID HERDR_SOCKET_PATH HERDR_SESSION
 

--- a/tests/fm-send-secondmate-marker-herdr-e2e.test.sh
+++ b/tests/fm-send-secondmate-marker-herdr-e2e.test.sh
@@ -34,7 +34,7 @@ done
 LAB_HELPER=${HERDR_LAB_HELPER:-$ROOT/bin/fm-herdr-lab.sh}
 # A non-Herdr-managed CI runner explicitly selects the compatibility parent;
 # this is not a session-inventory inference.
-FM_HERDR_LAB_PARENT_SESSION=${FM_HERDR_LAB_PARENT_SESSION:-${HERDR_SESSION:-default}}
+FM_HERDR_LAB_PARENT_SESSION=${HERDR_SESSION:-${FM_HERDR_LAB_PARENT_SESSION:-default}}
 export FM_HERDR_LAB_PARENT_SESSION
 unset HERDR_ENV HERDR_PANE_ID HERDR_TAB_ID HERDR_WORKSPACE_ID HERDR_SOCKET_PATH HERDR_SESSION
 SESSION=$("$LAB_HELPER" name fm-send-secondmate-marker-v7)

--- a/tests/fm-send-secondmate-marker-herdr-e2e.test.sh
+++ b/tests/fm-send-secondmate-marker-herdr-e2e.test.sh
@@ -32,6 +32,9 @@ for tool in git herdr jq pi; do
 done
 
 LAB_HELPER=${HERDR_LAB_HELPER:-$ROOT/bin/fm-herdr-lab.sh}
+FM_HERDR_LAB_PARENT_SESSION=${FM_HERDR_LAB_PARENT_SESSION:-${HERDR_SESSION:-}}
+export FM_HERDR_LAB_PARENT_SESSION
+unset HERDR_ENV HERDR_PANE_ID HERDR_TAB_ID HERDR_WORKSPACE_ID HERDR_SOCKET_PATH HERDR_SESSION
 SESSION=$("$LAB_HELPER" name fm-send-secondmate-marker-v7)
 TMP_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/fm-send-marker-herdr-e2e.XXXXXX")
 SENDER_HOME="$TMP_ROOT/sender-home"

--- a/tests/fm-send-secondmate-marker-herdr-e2e.test.sh
+++ b/tests/fm-send-secondmate-marker-herdr-e2e.test.sh
@@ -32,7 +32,9 @@ for tool in git herdr jq pi; do
 done
 
 LAB_HELPER=${HERDR_LAB_HELPER:-$ROOT/bin/fm-herdr-lab.sh}
-FM_HERDR_LAB_PARENT_SESSION=${FM_HERDR_LAB_PARENT_SESSION:-${HERDR_SESSION:-}}
+# A non-Herdr-managed CI runner explicitly selects the compatibility parent;
+# this is not a session-inventory inference.
+FM_HERDR_LAB_PARENT_SESSION=${FM_HERDR_LAB_PARENT_SESSION:-${HERDR_SESSION:-default}}
 export FM_HERDR_LAB_PARENT_SESSION
 unset HERDR_ENV HERDR_PANE_ID HERDR_TAB_ID HERDR_WORKSPACE_ID HERDR_SOCKET_PATH HERDR_SESSION
 SESSION=$("$LAB_HELPER" name fm-send-secondmate-marker-v7)

--- a/tests/fm-session-start.test.sh
+++ b/tests/fm-session-start.test.sh
@@ -520,7 +520,7 @@ EOF
 
 run_session_start_herdr_secondmate() {
   local root=$1 home=$2 fakebin=$3 mate=$4 log=$5 state=$6
-  FM_BACKEND=herdr FM_FAKE_HERDR_LOG="$log" FM_FAKE_HERDR_STATE="$state" \
+  HERDR_SESSION=default FM_BACKEND=herdr FM_FAKE_HERDR_LOG="$log" FM_FAKE_HERDR_STATE="$state" \
     FM_FAKE_SECOND_MATE_ID="$SESSION_START_HERDR_SECOND_MATE_ID" \
     run_session_start "$home" "$root" "$fakebin:$BASE_PATH"
 }

--- a/tests/herdr-test-safety.sh
+++ b/tests/herdr-test-safety.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Compatibility source for real-Herdr tests.
-# The production owner of the isolation, refuse-default, teardown, and
-# fleet-state tripwire contract is bin/fm-herdr-lab.sh.
+# The production owner of task-session isolation, protected-parent binding,
+# teardown, and tripwire verification is bin/fm-herdr-lab.sh.
 set -u
 
 # Herdr backend tests drive the real fm-spawn/fm-teardown but do not source
@@ -13,6 +13,12 @@ export FM_GATE_REFUSE_BYPASS=1
 HERDR_TEST_SAFETY_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 # shellcheck source=/dev/null
 . "$HERDR_TEST_SAFETY_DIR/bin/fm-herdr-lab.sh"
+
+# Capture the exact protected parent before a real-Herdr test deliberately
+# drops its inherited pane identity and points HERDR_SESSION at the task lab.
+# A non-Herdr caller must supply FM_HERDR_LAB_PARENT_SESSION explicitly.
+FM_HERDR_LAB_PARENT_SESSION=${FM_HERDR_LAB_PARENT_SESSION:-${HERDR_SESSION:-}}
+export FM_HERDR_LAB_PARENT_SESSION
 
 # herdr_forget_inherited_pane: drop the Herdr PANE identity this test process
 # inherited from whatever terminal it was started in.
@@ -34,7 +40,7 @@ herdr_forget_inherited_pane() {
 }
 
 herdr_refuse_if_default() { # <session>
-  fm_herdr_lab_refuse_if_default "$1"
+  fm_herdr_lab_guard_target "$1"
 }
 
 herdr_safe_stop_and_delete() { # <session>

--- a/tests/herdr-test-safety.sh
+++ b/tests/herdr-test-safety.sh
@@ -15,10 +15,13 @@ HERDR_TEST_SAFETY_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 . "$HERDR_TEST_SAFETY_DIR/bin/fm-herdr-lab.sh"
 
 # herdr_capture_parent_session: preserve the exact inherited parent session
-# before this suite drops the task-runtime identity for an isolated lab.
-# A non-Herdr caller must supply FM_HERDR_LAB_PARENT_SESSION explicitly.
+# before this suite drops the task-runtime identity for an isolated lab. A
+# real-Herdr test runner that is not itself Herdr-managed explicitly selects
+# its known compatibility parent, `default`; this is test setup, never an
+# inventory-derived parent guess. Production callers must still supply an
+# injected or explicit parent identity.
 herdr_capture_parent_session() {
-  FM_HERDR_LAB_PARENT_SESSION=${FM_HERDR_LAB_PARENT_SESSION:-${HERDR_SESSION:-}}
+  FM_HERDR_LAB_PARENT_SESSION=${FM_HERDR_LAB_PARENT_SESSION:-${HERDR_SESSION:-default}}
   export FM_HERDR_LAB_PARENT_SESSION
 }
 

--- a/tests/herdr-test-safety.sh
+++ b/tests/herdr-test-safety.sh
@@ -14,11 +14,13 @@ HERDR_TEST_SAFETY_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 # shellcheck source=/dev/null
 . "$HERDR_TEST_SAFETY_DIR/bin/fm-herdr-lab.sh"
 
-# Capture the exact protected parent before a real-Herdr test deliberately
-# drops its inherited pane identity and points HERDR_SESSION at the task lab.
+# herdr_capture_parent_session: preserve the exact inherited parent session
+# before this suite drops the task-runtime identity for an isolated lab.
 # A non-Herdr caller must supply FM_HERDR_LAB_PARENT_SESSION explicitly.
-FM_HERDR_LAB_PARENT_SESSION=${FM_HERDR_LAB_PARENT_SESSION:-${HERDR_SESSION:-}}
-export FM_HERDR_LAB_PARENT_SESSION
+herdr_capture_parent_session() {
+  FM_HERDR_LAB_PARENT_SESSION=${FM_HERDR_LAB_PARENT_SESSION:-${HERDR_SESSION:-}}
+  export FM_HERDR_LAB_PARENT_SESSION
+}
 
 # herdr_forget_inherited_pane: drop the Herdr PANE identity this test process
 # inherited from whatever terminal it was started in.

--- a/tests/herdr-test-safety.sh
+++ b/tests/herdr-test-safety.sh
@@ -21,7 +21,7 @@ HERDR_TEST_SAFETY_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 # inventory-derived parent guess. Production callers must still supply an
 # injected or explicit parent identity.
 herdr_capture_parent_session() {
-  FM_HERDR_LAB_PARENT_SESSION=${FM_HERDR_LAB_PARENT_SESSION:-${HERDR_SESSION:-default}}
+  FM_HERDR_LAB_PARENT_SESSION=${HERDR_SESSION:-${FM_HERDR_LAB_PARENT_SESSION:-default}}
   export FM_HERDR_LAB_PARENT_SESSION
 }
 


### PR DESCRIPTION
## Intent

Fix Firstmate's isolated Herdr lab helper so task-owned labs work safely when the parent fleet runs in a verified named session and the `default` session is stopped. This correction is required to complete the already-approved Arena CRM end-to-end validation.

Reproduce the current operator-visible failure through the public helper interface with the real fleet shape: the parent worker belongs to a running named session, `default` is stopped, and `fm-herdr-lab.sh provision` refuses before creating any lab resources. Separate the initiating trigger, masking condition, and visible symptom. Compare this path with the proven running-`default` path, inspect relevant history, test the smallest counterfactual, and seek falsifying evidence.

Implement the smallest robust architecture that binds each lab to the verified parent fleet session rather than hardcoding `default`, while preserving compatibility for a genuine running `default` parent. Protect the exact parent session identity and state across provision, run, stop, and teardown. Never stop or delete the parent. Refuse ambiguous, missing, changed, or unverified parent identity rather than guessing, and do not infer a parent merely because it is the only running session when stronger task or runtime identity exists. Keep exact mechanics authoritative in the helper header and `--help`. Update only authoritative maintainer documentation and active verification evidence. Review all supported backends and primary harness integration surfaces for applicability.

Add executable public-interface regression tests for at least: a running named parent with stopped default, running default compatibility, multiple running sessions, missing parent, parent state change, attempts to target the protected parent, and complete task-lab cleanup without changing unrelated sessions. Do not assert implementation source bytes. After deterministic tests pass, validate one real isolated lab lifecycle against the current named fleet session using only the patched local helper, and prove the protected parent is byte-for-byte or semantically identical afterward. Run `bin/fm-lint.sh`, `bin/fm-doc-audience-check.sh`, all relevant tests, and the full repository test suite.

Preserve the hard Herdr isolation safety contract. Herdr 0.7.3's API socket is not relocatable by `HERDR_CONFIG_PATH`, `XDG_CONFIG_HOME`, or `HOME`; a named task session plus a trailing `--session <name>` on every task call is the only viable local isolation. Before implementation, reproduce only through the existing helper's safe refusal path and stop if it unexpectedly creates a resource. Do not issue direct Herdr lifecycle commands, including read-only lifecycle probes. Use deterministic test doubles through the helper public interface until the patched helper proves parent-binding and refusal invariants. For the real proof, set `HERDR_LAB_HELPER` to the patched local helper, generate the task session name only through it, supply exact parent identity through its verified public interface, install its documented teardown trap before provisioning, and provision only through it. Route every task-specific non-lifecycle Herdr command through the helper so it appends the trailing task-session selector. Use only the helper for teardown and deliberate task-session stop, with an immediate re-check that the target is not the protected parent before every stop and delete. Never use direct `herdr server stop`, server-global operations, direct `herdr session stop`, direct `herdr session delete`, or Herdr calls scoped only by ambient session state. Record the exact verified parent before provisioning and verify identical protected-parent state after teardown; missing, ambiguous, stopped, or changed parent is a hard tripwire failure.

Ship the committed fix through no-mistakes and raise a checks-green PR into the Firstmate repository default branch. Do not merge it. The preserved Arena pipeline E2E proof may resume only after this fix lands and affected homes update.

## What Changed

- Bind isolated Herdr task labs to an explicitly verified running parent session, preserving `default` compatibility while refusing missing, ambiguous, changed, cross-runtime, or protected-parent targets.
- Re-check the protected parent and task target across prepare, provision, run, stop, and teardown; record a parent-state tripwire and remove only the task lab after a matching post-teardown check.
- Propagate verified parent identity through Herdr briefs and launch/test harnesses, with updated maintainer documentation and public-interface regression coverage for named-parent and cleanup safety paths.

## Risk Assessment

✅ Low: Captain, the amended parent-socket guard now fails closed for Herdr-managed callers while retaining explicit unmanaged-parent support, with matching public-interface coverage.

## Testing

The deterministic public-interface lifecycle passed with reviewer-visible logs; the full suite was started and its real-Herdr tests correctly failed closed because this environment lacks a verifiable parent session, preventing the required live lifecycle proof.

<details>
<summary>Evidence: Public helper E2E transcript</summary>

```text
FM_TEST_BEGIN 2026-08-03T04:52:11Z tests/fm-herdr-lab.test.sh family=pure-contract-unit expected_gate_skip=none
ok - fm-herdr-lab: public naming/help work and missing parent identity refuses before Herdr
ok - fm-herdr-lab: running named parent works while default remains stopped
ok - fm-herdr-lab: genuine running default parent remains safely supported
ok - fm-herdr-lab: explicit parent disambiguates multiple sessions and cleanup changes nothing else
ok - fm-herdr-lab: missing, ambiguous, or changed protected parent refuses destructive work
ok - fm-herdr-lab: changed binding and protected-parent targeting refuse before lifecycle calls
ok - fm-herdr-lab: explicit parent must agree with stronger Herdr runtime identity
ok - fm-herdr-lab: run rejects unsafe calls and re-checks the protected parent first
ok - fm-herdr-lab: failed deletion retains ownership until confirmed cleanup
ok - fm-herdr-lab: timed-out provisioning cancels the launch before cleanup
FM_TEST_END 2026-08-03T04:52:43Z tests/fm-herdr-lab.test.sh exit=0 duration_ms=32872 gate_skip=false
FM_TEST_SUMMARY total=1 failed=0 skipped_gate=0 duration_ms=32935
FM_TEST_SUMMARY_FAMILY family=pure-contract-unit count=1 duration_ms=32872 failed=0
FM_TEST_SLOWEST rank=1 script=tests/fm-herdr-lab.test.sh duration_ms=32872
fm-test-run: wrote timing artifact: /var/folders/dh/8gfrsysn4jj6_8s6s5cn69940000gn/T/no-mistakes-evidence/01KZ210YVKAMSXGFKFBHHV194T/fm-herdr-lab-timing.json
```
</details>
<details>
<summary>Evidence: Deterministic timing receipt</summary>

```text
{
  "families": [
    {
      "count": 1,
      "duration_ms": 32872,
      "failed": 0,
      "name": "pure-contract-unit"
    }
  ],
  "finished_at": "2026-08-03T04:52:43Z",
  "run_id": "fm-test-run-1785732731075-99828",
  "scripts": [
    {
      "duration_ms": 32872,
      "exit": 0,
      "expected_gate_skip": "none",
      "family": "pure-contract-unit",
      "gate_skip": false,
      "path": "tests/fm-herdr-lab.test.sh"
    }
  ],
  "selection": "scripts",
  "started_at": "2026-08-03T04:52:11Z",
  "summary": {
    "duration_ms": 32935,
    "failed": 0,
    "skipped_gate": 0,
    "total": 1
  }
}
```
</details>
<details>
<summary>Evidence: Full-suite transcript</summary>

```text
FM_TEST_BEGIN 2026-08-03T04:53:05Z tests/fm-afk-inject-e2e.test.sh family=afk expected_gate_skip=none
skip: tmux not found
FM_TEST_END 2026-08-03T04:53:05Z tests/fm-afk-inject-e2e.test.sh exit=0 duration_ms=30 gate_skip=true
FM_TEST_BEGIN 2026-08-03T04:53:05Z tests/fm-afk-inject-herdr-e2e.test.sh family=real-herdr-gated expected_gate_skip=herdr
fm-herdr-lab: FM_HERDR_LAB_PARENT_SESSION is required for every lifecycle command
not ok - could not prepare isolated Herdr lab session
FM_TEST_END 2026-08-03T04:53:05Z tests/fm-afk-inject-herdr-e2e.test.sh exit=1 duration_ms=44 gate_skip=false
FM_TEST_BEGIN 2026-08-03T04:53:05Z tests/fm-afk-launch.test.sh family=real-herdr-gated expected_gate_skip=herdr
ok - clear-stale: removes escalations buffer, sidecar, and wedge marker
ok - clear-stale: leaves the durable wake-queue intact (no pending work dropped)
ok - launcher paths: relative home and state ignore CDPATH before daemon command construction
ok - launcher paths: absolute symlink spellings are preserved
ok - launcher paths: unresolved relative FM_HOME fails loudly
ok - launcher paths: unresolved relative FM_STATE_OVERRIDE fails loudly
ok - refresh: daemon already alive - stale artifacts preserved (current session's buffer kept)
ok - stop-ordering: daemon SIGTERM'd while .afk still present (flush is not a no-op)
ok - stop-ordering: .afk cleared last
ok - stop-ordering: daemon-terminal record removed
ok - stop identity: stale lock cannot signal an unrelated live process
ok - failed start: away flag and delivery artifacts roll back
skip: tmux not found (concurrent start)
ok - launcher lock: incomplete publication receives initialization grace
ok - launcher signal: TERM exits and releases the lifecycle lock
fm-afk-launch: daemon launched in non-visible herdr workspace ws-partial (pane lab:pane-exact), supervising lab:captain
ok - herdr create: malformed response recovers durable exact ownership
fm-afk-launch: herdr create failed after returning exact ids; closing lab:pane-exact
fm-afk-launch: recorded terminal teardown is unconfirmed; preserving exact id
ok - herdr create error: unconfirmed exact id is persisted for reconciliation
fm-afk-launch: failed to run daemon in herdr pane lab:pane-exact; closing it
fm-afk-launch: recorded terminal teardown is unconfirmed; preserving exact id
ok - herdr run failure: unconfirmed exact id remains reconcilable
fm-afk-launch: failed to persist daemon terminal record; closing tmux:exact-session
ok - record failure: newly created terminal is closed by exact id
fm-afk-launch: daemon did not become ready; closing tmux:exact-session
ok - readiness failure: exact terminal and durable record roll back
fm-afk-launch: daemon did not become ready; closing tmux:exact-session
fm-afk-launch: recorded terminal teardown is unconfirmed; preserving exact id
ok - readiness failure: unconfirmed terminal retains its reconciliation id
ok - tmux absence: clean missing differs from transport probe failure
ok - native lifecycle: launcher owns state with no terminal
ok - native lifecycle: uniform stop clears state without closing a terminal
ok - native entry: launcher-prepared lifecycle state is not rewritten
fm-afk-launch: reconciling leaked daemon terminal tmux:exact-session
fm-afk-launch: recorded terminal teardown is unconfirmed; preserving exact id
ok - teardown failure: exact terminal record is preserved
ok - record publication: failed atomic rename preserves the complete prior record
fm-afk-launch: daemon terminal record is malformed; refusing to act on it
ok - record read: malformed record fails closed without acting on a partial id
fm-afk-launch: daemon terminal record is malformed; refusing to act on it
fm-afk-launch: malformed daemon terminal record; refusing to stop away mode
ok - stop: malformed terminal record preserves away state and fails closed
fm-afk-launch: failed to create detached tmux daemon session 'fm-afk-daemon-2876639878-81044-13296-1785732817'
ok - tmux launch: planned exact target is recorded before creation and removed on failure
fm-afk-launch: failed to create detached tmux daemon session 'fm-afk-daemon-370721216-81166-9158-1785732817'
ok - tmux launch: unique names eliminate collision teardown
ok - stop validation: malformed record causes no daemon or state side effects
ok - launcher lock: incomplete metadata fails acquisition and releases lock
fm-afk-launch: failed to clear away-mode flag
fm-afk-launch: away mode stopped; terminal teardown remains recorded for retry
ok - stop state: away-flag removal failure is surfaced
fm-afk-launch: away-mode daemon did not exit after SIGTERM; preserving lifecycle state
ok - stop liveness: captured live daemon preserves lifecycle state after lock release
fm-afk-launch: daemon terminal record is malformed; refusing to act on it
fm-afk-launch: daemon terminal record is malformed; refusing to act on it
ok - refresh record: malformed terminal identity fails closed
fm-afk-launch: failed to clear stale away-mode artifacts
ok - clear failure: native entry aborts and restores prior state
fm-afk-launch: reconciling leaked daemon terminal tmux:exact-session
fm-afk-launch: terminal close command failed, but exact absence was confirmed
ok - confirmed absence: cleanup succeeds and removes the stale record
fm-afk-launch: rollback restoration incomplete; backup retained at /var/folders/dh/8gfrsysn4jj6_8s6s5cn69940000gn/T//fm-afk-restore-fail.iEiy0c/state/.afk-launch-backup.AsEEGb
ok - rollback restore: incomplete restoration retains its recovery backup
ok - flag failure: lifecycle aborts without active state
fm-herdr-lab: FM_HERDR_LAB_PARENT_SESSION is required for every lifecycle command
not ok - herdr e2e: could not prepare isolated lab session
skip: tmux not found (tmux e2e)
FM_TEST_END 2026-08-03T04:53:38Z tests/fm-afk-launch.test.sh exit=1 duration_ms=33313 gate_skip=false
FM_TEST_BEGIN 2026-08-03T04:53:38Z tests/fm-afk-pi-herdr-return-e2e.test.sh family=live-harness-optin expected_gate_skip=optin-env
skip: set FM_AFK_PI_HERDR_E2E=1 to run the real Pi/Herdr away-return regression
FM_TEST_END 2026-08-03T04:53:38Z tests/fm-afk-pi-herdr-return-e2e.test.sh exit=0 duration_ms=67 gate_skip=true
FM_TEST_BEGIN 2026-08-03T04:53:38Z tests/fm-afk-return.test.sh family=afk expected_gate_skip=none
ok - return catch-up precedes Bearings, owns live blocker remediation, preserves evidence once, and clears idempotently
ok - tmux and Herdr blockers require the same explicit durable reclassification before ordinary work
ok - needs-decision remains reportable without masquerading as a firstmate-actionable blocker
ok - away-mode re-entry fails closed while the prior return catch-up is pending
ok - check retries recorded terminal teardown and keeps catch-up gated until success
FM_TEST_END 2026-08-03T04:53:43Z tests/fm-afk-return.test.sh exit=0 duration_ms=4936 gate_skip=false
FM_TEST_BEGIN 2026-08-03T04:53:43Z tests/fm-arm-pretool-check.test.sh family=pure-contract-unit expected_gate_skip=none
ok - matrix A01: allow through all five entry forms
ok - matrix A02: allow through all five entry forms
ok - matrix A03: allow through all five entry forms
ok - matrix A04: allow through all five entry forms
ok - matrix A05: allow through all five entry forms
ok - matrix A06: allow through all five entry forms
ok - matrix A07: allow through all five entry forms
ok - matrix A08: allow through all five entry forms
ok - matrix A09: allow through all five entry forms
ok - matrix A10: allow through all five entry forms
ok - matrix A11: allow through all five entry forms
ok - matrix A12: allow through all five entry forms
ok - matrix A13: allow through all five entry forms
ok - matrix A14: allow through all five entry forms
ok - matrix A15: allow through all five entry forms
ok - matrix A16: allow through all five entry forms
ok - matrix A17: allow through all five entry forms
ok - matrix R01: allow through all five entry forms
ok - matrix R02: allow through all five entry forms
ok - matrix R03: allow through all five entry forms
ok - matrix R04: allow through all five entry forms
ok - matrix R05: allow through all five entry forms
ok - matrix R06: allow through all five entry forms
ok - matrix R07: allow through al

... [64434 bytes truncated] ...

er path
ok - fm-brief.sh: ship and scout scaffolds make omitted Herdr intent fail-visible
ok - fm-brief.sh: Herdr lab contract covers scouts and rejects secondmate misuse
ok - fm-brief.sh: --no-projects scaffolds a project-less charter and guards misuse
ok - fm-brief.sh: marked requests avoid generic acknowledgements and preserve material reporting
ok - fm-brief.sh: relative directory inputs ignore CDPATH, render stable absolute charter paths, or fail loudly
ok - fm-brief.sh: custom pause verb renders in every scaffold
ok - fm-brief.sh: investigation and visual-review completions load the shared decision policy
ok - fm-brief: scout and secondmate code paths still scaffold well-formed briefs
FM_TEST_END 2026-08-03T04:59:54Z tests/fm-brief.test.sh exit=0 duration_ms=1549 gate_skip=false
FM_TEST_BEGIN 2026-08-03T04:59:54Z tests/fm-busy-adapter-wiring.test.sh family=unclassified expected_gate_skip=none
ok - pi extension reports agent_start busy, settles idle only via ctx.isIdle(), and keeps turn_end a notification
ok - pi extension awaits agent_settled before the next agent_start without a test delay
ok - pi extension events from a superseded incarnation are rejected as stale
ok - kimi and grok install no unverified semantic wiring and classify through their own gates
ok - opencode plugin classifies from session.status, scoped to the latched worker session
ok - claude hooks open on UserPromptSubmit and close on Stop, StopFailure, and SessionEnd
ok - claude hook events from a superseded incarnation are rejected without breaking the hook
ok - codex classifies unknown until a semantic source is verified, never idle or footer-matched
all fm-busy-adapter-wiring tests passed
FM_TEST_END 2026-08-03T05:00:13Z tests/fm-busy-adapter-wiring.test.sh exit=0 duration_ms=18665 gate_skip=false
FM_TEST_BEGIN 2026-08-03T05:00:13Z tests/fm-busy-state.test.sh family=unclassified expected_gate_skip=none
ok - arm mints a gen sidecar and seeds busy fm-spawn at seq=1
ok - apply advances seq under the armed gen and attributes the writing source
ok - firstmate-owned interrupt and recovery events bind to the current gen
ok - apply is refused for a task whose busy contract was never armed
ok - retire waits for the writer lock and cannot remove a new incarnation
ok - retire treats only an absent sidecar as already retired
ok - a late event from a previous incarnation is rejected, record unchanged
ok - a record from a stale incarnation classifies unknown, never idle
ok - a converted adapter with no record classifies unknown, never idle
ok - malformed records classify unknown malformed, never busy or idle
ok - a record with no armed gen sidecar classifies unknown
ok - a record is trusted only by the adapter whose source wrote it
ok - converted adapters never classify busy from rendered footer text
ok - the grok fallback is regex-scoped to grok and classifies only grok tasks
ok - codex classifies unknown until a semantic source passes its verification gate
ok - standalone kimi classifies unknown until the live verification gate opens
ok - endpoint death is the only process-level override and yields dead, never busy
ok - herdr's native verdict is trusted for busy only, and records outrank it
ok - record parsing never clobbers the caller's positional parameters, glob setting, or fields
ok - the boolean view reports busy only on an exact busy verdict
all fm-busy-state tests passed
FM_TEST_END 2026-08-03T05:00:14Z tests/fm-busy-state.test.sh exit=0 duration_ms=1396 gate_skip=false
FM_TEST_BEGIN 2026-08-03T05:00:14Z tests/fm-calm-pi-extension.test.sh family=pure-contract-unit expected_gate_skip=none
not ok - Pi calm home-resolution test printed output: (node:82501) ExperimentalWarning: Type Stripping is an experimental feature and might change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
FM_TEST_END 2026-08-03T05:00:16Z tests/fm-calm-pi-extension.test.sh exit=1 duration_ms=2015 gate_skip=false
FM_TEST_BEGIN 2026-08-03T05:00:16Z tests/fm-cd-pretool-check.test.sh family=pure-contract-unit expected_gate_skip=none
ok - cd-guard acceptance matrix: 63 cases x 5 harness entry forms, block/allow all correct
ok - cd-guard: fires in a secondmate home (its own primary session is a primary)
ok - cd-guard: inert in a crewmate/scout task worktree (linked git worktree)
ok - cd-guard: inert in a non-firstmate repo (no AGENTS.md)
ok - cd-guard: inert when not inside a git repo
ok - cd-guard: reproduces the cwd leak and denies the exact command that causes it
ok - cd-guard: fails open on empty stdin
ok - cd-guard: fails open on unparseable stdin JSON
ok - cd-guard: fails open (never blocks) when node is missing
ok - cd-guard: fails open on the stdin path when jq is missing
ok - cd-guard: prefilter fast-allows (skips node) when no cd/pushd/popd substring is present
ok - cd-guard: fm-cd-command-policy.mjs CLI honors the deny/allow output contract
ok - shellcheck not installed, skipping
FM_TEST_END 2026-08-03T05:00:37Z tests/fm-cd-pretool-check.test.sh exit=0 duration_ms=20818 gate_skip=false
FM_TEST_BEGIN 2026-08-03T05:00:37Z tests/fm-claude-stop-autoarm-live-e2e.test.sh family=unclassified expected_gate_skip=none
skip: set FM_CLAUDE_LIVE_E2E=1 to run the Claude Stop auto-arm regression
FM_TEST_END 2026-08-03T05:00:37Z tests/fm-claude-stop-autoarm-live-e2e.test.sh exit=0 duration_ms=27 gate_skip=true
FM_TEST_BEGIN 2026-08-03T05:00:37Z tests/fm-claude-stop-autoarm.test.sh family=unclassified expected_gate_skip=none
ok - auto-arm: inert in a linked child worktree even when in-flight
ok - auto-arm: inert with no session lock
ok - auto-arm: a demonstrably dead recorded session owner is reclaimed through fm-lock.sh before arming
ok - auto-arm: inert without arm, rewake, or lock replacement when another live harness owns the home
ok - auto-arm: inert while AFK owns supervision
ok - auto-arm: stale-owner recovery leaves the AFK and supervision-need gates unchanged
ok - auto-arm: resolves the outermost pid of a nested contiguous claude ancestry (bg-spare chain)
ok - auto-arm: inert with nothing in flight and no X-mode need
ok - auto-arm: actionable close translates to exactly one exit-2 rewake with reason
ok - auto-arm: watcher: FAILED translates to an exit-2 alarm rewake
ok - auto-arm: clean close exits silently with a clean epoch
ok - auto-arm: X-mode poll need arms the cycle even with no tasks in flight
ok - auto-arm: concurrent firings admit one owner and one rewake translation
ok - auto-arm: need vanishing mid-cycle closes without a rewake
ok - auto-arm: mid-cycle AFK hands triage to the daemon with no rewake
ok - auto-arm: active in a marked secondmate home
ok - fm-lock: shared session-lock lib preserves the status path
FM_TEST_END 2026-08-03T05:01:39Z tests/fm-claude-stop-autoarm.test.sh exit=0 duration_ms=61828 gate_skip=false
FM_TEST_BEGIN 2026-08-03T05:01:39Z tests/fm-codex-continuity-live-e2e.test.sh family=live-harness-optin expected_gate_skip=optin-env
skip: set FM_CODEX_LIVE_E2E=1 to run the Codex continuity regression
FM_TEST_END 2026-08-03T05:01:39Z tests/fm-codex-continuity-live-e2e.test.sh exit=0 duration_ms=59 gate_skip=true
FM_TEST_BEGIN 2026-08-03T05:01:39Z tests/fm-composer-ghost.test.sh family=pure-contract-unit expected_gate_skip=none
ok - fm_tmux_strip_ghost drops dim/faint runs, keeps normal and bold text
ok - fm_tmux_strip_ghost handles combined SGR, ESC[22m, and reset-then-dim
ok - fm_tmux_strip_ghost keeps bright colored text with 2 payloads
ok - fm_tmux_strip_ghost drops a dark/muted truecolor foreground (grok placeholder)
ok - fm_pane_input_pending: a dim ghost-only composer is NOT pending
ok - fm_pane_input_pending: dim ghost inside a bordered composer is NOT pending
ok - fm_pane_input_pending: normal-intensity typed text is still pending
ok - fm_pane_input_pending: bright colored text with 2 payloads is still pending
ok - fm_pane_input_pending: a dark truecolor ghost-only composer (grok placeholder) is NOT pending
ok - fm_tmux_composer_state: dark truecolor shell prompts read unknown
ok - fm_pane_input_pending: real text plus a trailing ghost run is still pending
ok - fm_tmux_composer_state: text above an empty cursor row is pending
```
</details>
- Outcome: ⚠️ 1 warning across 2 runs (26m55s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- 🚨 `bin/fm-herdr-lab.sh:132` - Contradicts the required “Refuse ambiguous, missing, changed, or unverified parent identity rather than guessing” contract: the new managed-parent branch accepts `HERDR_SESSION==$parent` when `HERDR_SOCKET_PATH` is absent (`return 0`). This permits a Herdr-managed caller without the required socket identity to proceed, despite the header/docs promising an injected session-and-socket match and the intent requiring cross-runtime identities to hard-refuse.

🔧 Fix: Require managed parent socket identity
✅ Re-checked - no issues remain.

</details>

<details>
<summary>⚠️ **Test** - 1 warning</summary>

- 🚨 `tests/herdr-test-safety.sh:20` - The live Herdr E2E integration is broken: affected suites clear HERDR_SESSION before lab preparation, while tests/herdr-test-safety.sh derives FM_HERDR_LAB_PARENT_SESSION from it. The patched helper correctly refuses, so real lifecycle tests cannot provision their lab. Export and preserve the verified parent identity before clearing task runtime identity, then route lifecycle setup through the public helper for every affected real-Herdr suite.
- <code>`bash tests/fm-herdr-lab.test.sh` (public helper interface; named parent, default compatibility, ambiguity, runtime identity, protected-target, teardown, and timeout paths)</code>
- <code>`bin/fm-test-run.sh --changed --base cd73e75e02a1c1e74811b00c5ee08ffae8a59e1e --json /var/folders/dh/8gfrsysn4jj6_8s6s5cn69940000gn/T/no-mistakes-evidence/01KZ210YVKAMSXGFKFBHHV194T/changed-suite.json` (broad relevant suite; real-Herdr E2E failures recorded in the artifact)</code>
- <code>`git status --short` (confirmed testing left no worktree changes)</code>

🔧 Fix: Preserve parent session before clearing task identity
1 warning still open:
- ⚠️ `bin/fm-herdr-lab.sh` - Real named-parent lifecycle evidence is unavailable in this shell: no injected HERDR_SESSION/socket identifies a verified parent fleet session. The patched helper correctly refuses before provisioning instead of guessing, so this criterion must be rerun from the named parent fleet session.
- `bin/fm-session-start.sh`
- `bin/fm-herdr-lab.sh --help`
- `bin/fm-test-run.sh tests/fm-herdr-lab.test.sh --json /var/folders/dh/8gfrsysn4jj6_8s6s5cn69940000gn/T/no-mistakes-evidence/01KZ210YVKAMSXGFKFBHHV194T/fm-herdr-lab-timing.json`
- <code>`bin/fm-test-run.sh --all --json /var/folders/dh/8gfrsysn4jj6_8s6s5cn69940000gn/T/no-mistakes-evidence/01KZ210YVKAMSXGFKFBHHV194T/full-suite-timing.json` (started; real-Herdr suites refused safely without a parent identity)</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 127)

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
