### PR TITLE
feat(bin): add deterministic agent lifecycle control

### DIFF
--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -173,7 +173,7 @@ The shared symptom is a healthy-looking pane with no work in progress, so each a
 
 | Fact | Value |
 |---|---|
-| Busy state | Owned lifecycle hooks: `UserPromptSubmit` opens a turn, `Stop`, `StopFailure`, and `SessionEnd` close it. Claude fires no hook for a manual interrupt, so a firstmate-initiated interrupt must record the clear itself. |
+| Busy state | Owned lifecycle hooks: `UserPromptSubmit` opens a turn, while `Stop`, `StopFailure`, and `SessionEnd` close it; because Claude fires no hook for a manual interrupt, `bin/fm-control.sh interrupt` reports only delivered keys and the verified endpoint or live agent, publishes no idle event, makes no cancellation claim, and leaves adapter-observed state unchanged, so a mid-turn worker typically remains busy via `claude-hook`. |
 | Exit command | `/exit` |
 | Interrupt | single Escape |
 | Skill invocation | `/<skill>` (e.g. `/no-mistakes`) |

--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -204,7 +204,7 @@ Claude Code's primary watcher protocol is Stop-owned: the auto-arm hook fires on
 | Fact | Value |
 |---|---|
 | Busy state | Unknown until a semantic source is live-verified: the app-server turn lifecycle is unreachable for a pane worker, and project lifecycle hooks did not fire for a firstmate-launched worker. |
-| Exit command | `/quit` (slash popup needs about 1 second between text and Enter; `fm-send` handles it) |
+| Exit command | `/quit` (slash popup needs about 1 second between text and Enter; the shared submit path used by `fm-control` handles it) |
 | Interrupt | single Escape |
 | Skill invocation | `$<skill>` (e.g. `$no-mistakes`); `/<skill>` is claude-only and codex rejects it as "Unrecognized command" |
 
@@ -236,7 +236,7 @@ The checkpoint is deliberately foreground and bounded so Codex regains control r
 |---|---|
 | Busy state | The Firstmate-owned plugin's semantic `session.status`: `busy` and `retry` are active, `idle` is inactive, latched to the worker's own session. |
 | Exit command | `/exit` |
-| Interrupt | double Escape; known flaky while a long shell command runs, so a wedged pane may need `/exit` and relaunch |
+| Interrupt | double Escape; known flaky while a long shell command runs, so use `bin/fm-control.sh <task-id> relaunch` for a wedged pane |
 
 No trust dialog.
 Opencode can auto-upgrade itself in the background and the running TUI can exit mid-task, observed live from 1.15.7 to 1.17.3.
@@ -409,7 +409,7 @@ Muse Code is a CREWMATE and SCOUT adapter only.
 | Models | `--model <model>`; the only provider is `meta`. |
 | Busy state | Its own durable session event log, folded on demand by `bin/fm-busy-lib.sh`. There is no hook or plugin writer, so nothing is armed and no busy record is ever seeded. |
 | Exit command | `/exit` (the popup shows `/exit  Quit when idle`); one Enter submits it, and the pane prints `To continue this session, run muse resume <session-uuid>`. |
-| Interrupt | Single Escape. It closes the run with `terminal: cancelled` AND restores the interrupted prompt into the composer as real bright text, so `fm-send.sh` follows Escape with `C-u` to clear it. |
+| Interrupt | Single Escape, which closes the run with `terminal: cancelled` AND restores the interrupted prompt into the composer as real bright text, so `fm-control` follows Escape with `C-u` to clear it; `fm-send`'s legacy key path reads the same composer-clear table. |
 | Skill invocation | `/<skill>`, the claude/grok form. |
 | Autonomy | `--yolo`, which disables approval, disables the sandbox, and trusts the workspace for the run. |
 | Trust dialog | `Do you trust this workspace?` with `1 Trust and continue` preselected, accepted by Enter. `--yolo` suppresses it entirely, which is what firstmate relies on because every task gets a fresh worktree path. |

--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -27,6 +27,9 @@ Inheritance also copies the literal `config/crew-dispatch.json` file, so secondm
 
 Each adapter splits into mechanics and knowledge.
 The per-task mechanics, including launch command, autonomy flag, and any enabled crewmate turn-end hook, live in `bin/fm-spawn.sh`.
+Agent lifecycle mechanics - which key interrupts a turn, how many times it must be sent, whether the composer needs clearing afterwards, which command exits the agent, and which task kinds the adapter can run - are owned by the executable control plane in `bin/fm-control-lib.sh` and delivered by `bin/fm-control.sh <task-id> interrupt|exit|relaunch`.
+Never hand-type an interrupt key or exit command through `fm-send`: a routing-marked lifecycle command becomes chat the agent reasons about instead of executing, which is the defect the control plane exists to remove ([`docs/agent-control.md`](../../../docs/agent-control.md)).
+The per-adapter `Exit command` and `Interrupt` rows below remain the verification record for those values; the executable owner is what firstmate actually runs, so a newly verified adapter is not reachable by the control plane until its rows land in that owner.
 The primary-session "no turn ends blind" guard contract and harness hook installation paths live in `docs/turnend-guard.md`.
 The primary-session watcher wake protocols are rendered from `docs/supervision-protocols/` by `bin/fm-supervision-instructions.sh`.
 The supervision knowledge lives here: busy state, exit command, interrupt, dialogs, resume behavior, skill invocation, and quirks.

--- a/.agents/skills/secondmate-provisioning/SKILL.md
+++ b/.agents/skills/secondmate-provisioning/SKILL.md
@@ -215,6 +215,8 @@ For a remote route, the same command probes and relaunches only on the configure
 An SSH transport failure or unreadable remote endpoint remains unknown and must be reconciled on that host; never launch a local replacement.
 Respawn re-resolves the secondmate harness from current config, uses the same guarded pre-launch sync, and re-propagates inherited local material, so recovered secondmates converge inherited config items and shared captain preferences whenever their home validates; tracked-file sync remains guarded separately.
 If the secondmate is already running and only inherited local material changed, prefer `bin/fm-config-push.sh` over respawning.
+To move a live LOCAL secondmate onto a newly pinned harness, model, or effort without a full recovery, set `config/secondmate-harness` and then relaunch it with `bin/fm-control.sh <id> relaunch`, which re-resolves that pin, stops the agent, and launches the replacement in the same home ([`docs/agent-control.md`](../../../docs/agent-control.md)).
+That plane refuses a remotely placed secondmate by name, because its agent runs on another host where none of the plane's postconditions can be read; use the remote route's own relaunch path for those.
 
 Do not reconstruct a secondmate's whole tree from the main home.
 The main firstmate reconciles only direct reports.

--- a/.agents/skills/secondmate-provisioning/SKILL.md
+++ b/.agents/skills/secondmate-provisioning/SKILL.md
@@ -244,4 +244,6 @@ Raw deletion is unsupported because a blocking process-event child can outlive i
 
 With `--force`, teardown is the explicit discard path.
 It kills child windows, discards child work and state inside the secondmate home, removes the route, releases the lease, and removes the retired secondmate home.
+If forced teardown contends with a fresh task publication in any affected home, one command refuses without publishing or removing task state; treat that refusal as terminal and inspect the other operation before retrying.
+Relaunch and non-forced teardown remain outside that serialization.
 Never use `--force` unless the captain explicitly said to discard the work.

--- a/.agents/skills/stuck-crewmate-recovery/SKILL.md
+++ b/.agents/skills/stuck-crewmate-recovery/SKILL.md
@@ -13,7 +13,9 @@ metadata:
 
 Use this playbook when the session-start digest reports an ordinary direct report's endpoint dead or its metadata has no window, or when a direct report is stale, looping, repeatedly confused, asking a question its brief already answers, unresponsive, or when a steer failed to land.
 
-Load `harness-adapters` before sending an interrupt, exit command, resume command, or harness-specific skill invocation.
+Interrupt, stop, and relaunch a worker through `bin/fm-control.sh <task-id> interrupt|exit|relaunch`, which resolves the recorded runtime itself, verifies each action, and never tears down or discards anything ([`docs/agent-control.md`](../../../docs/agent-control.md)).
+That plane covers workers running in this home; a remotely placed secondmate is refused by name and reconciled through `secondmate-provisioning` instead.
+Load `harness-adapters` before a resume command or a harness-specific skill invocation, and whenever the adapter's own quirks matter.
 The target window's harness is recorded as `harness=` in `state/<id>.meta`.
 
 ## Session-start reconciliation for a dead ordinary direct report
@@ -40,9 +42,9 @@ Escalate in order:
 
 1. Peek the pane.
 2. If the crewmate is waiting on a question its brief already answers, answer in one line via `FM_HOME=<this-firstmate-home> bin/fm-send.sh` from an active firstmate session unless `FM_HOME` is already set to the active firstmate home.
-3. If the crewmate is confused or looping, interrupt with the adapter's interrupt key, then redirect with one corrective line.
-   For example, for a single-Escape adapter: `FM_HOME=<this-firstmate-home> bin/fm-send.sh <window> --key Escape`.
-4. If the crewmate is genuinely wedged after redirection, exit the agent with the adapter's exit command and relaunch with the same brief plus a `progress so far` note appended to it.
+3. If the crewmate is confused or looping, interrupt with `FM_HOME=<this-firstmate-home> bin/fm-control.sh <task-id> interrupt`, then redirect with one corrective line through `fm-send`.
+4. If the crewmate is genuinely wedged after redirection, relaunch it with `FM_HOME=<this-firstmate-home> bin/fm-control.sh <task-id> relaunch --note '<progress so far>'`, which stops the agent, carries the brief plus that note into a replacement in the same local copy, and restores the prior record if the replacement cannot start.
+   Pass `--harness`, `--model`, or `--effort` on that same command when the worker should come back on a different runtime.
    Genuine wedging means looping, unresponsive, repeating the same obstacle, or truly dead.
    A low context reading is not wedging; modern harnesses auto-compact and keep going.
    The worktree and commits persist, so relaunch is cheap.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -289,6 +289,8 @@ A persistent secondmate is recorded in the secondmate registry and runtime state
 
 Steer a worker with short single-line messages through fail-closed `fm-send`; put long instructions in a file.
 When a steer answers an open keyed decision or blocker, pass `fm-send`'s `--resolve-key` so the answer itself closes that decision record at answer time, identically for local and remote workers (contract: `bin/fm-send.sh` header).
+`fm-send` is the data plane for text the worker should read; never use its key or text paths for interrupt, exit, or other lifecycle control, because routing-marked lifecycle text becomes chat the worker reasons about instead of executing.
+Drive a worker's lifecycle through `bin/fm-control.sh <task-id> interrupt|exit|relaunch`, which owns the per-runtime mechanics, verifies each action, and never tears down or discards anything ([`docs/agent-control.md`](docs/agent-control.md)).
 A secondmate's routed reply returns through status or a document pointer, not by firstmate peeking into its chat.
 For the parent-owned correlation, recovery, and escalation contract on marked secondmate requests, see `bin/fm-pending-reply-lib.sh`.
 Supervise all live work under section 8.

--- a/bin/fm-busy-event.sh
+++ b/bin/fm-busy-event.sh
@@ -18,9 +18,10 @@
 #       Append one lifecycle event: validate the gen against the armed
 #       sidecar, advance seq under the lock, atomically replace the record.
 #       Adapter wiring passes the exact --gen embedded at arm time, so a
-#       hook that outlives its incarnation fails closed here. Firstmate-owned
-#       paths (fm-interrupt, fm-recovery) may pass --current-gen to bind to
-#       whatever incarnation is armed right now.
+#       hook that outlives its incarnation fails closed here. The legacy
+#       Claude fm-send --key Escape path (fm-interrupt) and firstmate recovery
+#       paths (fm-recovery) may pass --current-gen to bind to the incarnation
+#       armed right now.
 #
 #   retire <state-dir> <id> (--gen G | --current-gen)
 #       Remove one incarnation's sidecar and record while holding the same

--- a/bin/fm-busy-lib.sh
+++ b/bin/fm-busy-lib.sh
@@ -36,7 +36,7 @@
 #   kimi-wire, kimi-hook  reserved: standalone Kimi, gated by fm_busy_kimi_verified
 # Firstmate-owned sources accepted for every converted adapter:
 #   fm-spawn         the launch-brief turn seeded at spawn
-#   fm-interrupt     a firstmate-controlled interruption of the worker
+#   fm-interrupt     the legacy Claude fm-send --key Escape idle event
 #   fm-recovery      a documented recovery reset after relaunch
 # Classifier-only sources (never written into a record):
 #   endpoint-gone, herdr-native, grok-regex, muse-session-log, missing,

--- a/bin/fm-busy-lib.sh
+++ b/bin/fm-busy-lib.sh
@@ -513,18 +513,10 @@ EOF
   printf '%s' "$selected"
 }
 
-# fm_busy_muse_run_state: fold one session log to busy|settled|none.
-#   busy     at least one run started with no matching terminal
-#   settled  every started run reached a terminal
-#   none     the log holds no run lifecycle records at all
-# The match is anchored on the exact structural prefix rather than a bare
-# "kind":"terminal" search, because muse also emits nested "record":{"kind":
-# "terminal"} cleanup-effect payloads that are NOT run terminals and would
-# otherwise close a run that is still in flight.
-fm_busy_muse_run_state() {  # <session-log>
+fm_busy_muse_run_events() {  # <session-log>
   [ -f "$1" ] || return 1
   LC_ALL=C awk '
-    BEGIN { pre = "\"payload\":{\"kind\":\"run\",\"run_id\":\"" }
+    BEGIN { OFS = "\t"; pre = "\"payload\":{\"kind\":\"run\",\"run_id\":\"" }
     {
       p = index($0, pre)
       if (p == 0) next
@@ -539,15 +531,68 @@ fm_busy_muse_run_state() {  # <session-log>
       q = index(rest, "\"")
       if (q == 0) next
       ev = substr(rest, 1, q - 1)
-      if (ev == "started") { open[rid] = 1; seen = 1 }
-      else if (ev == "terminal") { open[rid] = 0 }
-    }
-    END {
-      if (!seen) { print "none"; exit }
-      for (r in open) if (open[r] == 1) { print "busy"; exit }
-      print "settled"
+      terminal = ""
+      if (ev == "terminal") {
+        marker = "\"terminal\":\""
+        p = index(rest, marker)
+        if (p != 0) {
+          value = substr(rest, p + length(marker))
+          q = index(value, "\"")
+          if (q != 0) terminal = substr(value, 1, q - 1)
+        }
+      }
+      if (ev == "started" || ev == "terminal") print rid, ev, terminal
     }
   ' "$1"
+}
+
+# fm_busy_muse_run_state: fold one session log to busy|settled|none.
+#   busy     at least one run started with no matching terminal
+#   settled  every started run reached a terminal
+#   none     the log holds no run lifecycle records at all
+# The match is anchored on the exact structural prefix rather than a bare
+# "kind":"terminal" search, because muse also emits nested "record":{"kind":
+# "terminal"} cleanup-effect payloads that are NOT run terminals and would
+# otherwise close a run that is still in flight.
+fm_busy_muse_run_state() {  # <session-log>
+  [ -f "$1" ] || return 1
+  fm_busy_muse_run_events "$1" | LC_ALL=C awk -F '\t' '
+    $2 == "started" { open[$1] = 1; seen = 1 }
+    $2 == "terminal" { open[$1] = 0 }
+    END {
+      if (!seen) { print "none"; exit }
+      for (rid in open) if (open[rid] == 1) { print "busy"; exit }
+      print "settled"
+    }
+  '
+}
+
+fm_busy_muse_active_run_id() {  # <session-log>
+  [ -f "$1" ] || return 1
+  fm_busy_muse_run_events "$1" | LC_ALL=C awk -F '\t' '
+    $2 == "started" { open[$1] = 1 }
+    $2 == "terminal" { open[$1] = 0 }
+    END {
+      for (rid in open) {
+        if (open[rid] != 1) continue
+        active = rid
+        count++
+      }
+      if (count != 1) exit 1
+      print active
+    }
+  '
+}
+
+fm_busy_muse_run_terminal() {  # <session-log> <run-id>
+  [ -f "$1" ] && [ -n "${2:-}" ] || return 1
+  fm_busy_muse_run_events "$1" | LC_ALL=C awk -F '\t' -v wanted="$2" '
+    $1 == wanted && $2 == "terminal" && $3 != "" { terminal = $3 }
+    END {
+      if (terminal == "") exit 1
+      print terminal
+    }
+  '
 }
 
 # fm_busy_grok_tail_busy: the Grok-only temporary rendered-tail fallback.

--- a/bin/fm-control-lib.sh
+++ b/bin/fm-control-lib.sh
@@ -21,8 +21,9 @@
 #      is refused.
 #   2. Per-harness control mechanics: which key interrupts a running turn, how
 #      many times it must be sent, whether the composer needs clearing after
-#      that key, which command exits the agent, and which task kinds the adapter
-#      is verified to run. These are the empirically verified facts previously
+#      that key, which adapter-owned cancellation acknowledgement is observable,
+#      which command exits the agent, and which task kinds the adapter is
+#      verified to run. These are the empirically verified facts previously
 #      carried only in the harness-adapters skill's per-adapter tables; that
 #      skill now points here so one executable owner holds them, and
 #      bin/fm-send.sh's --key path reads the same table rather than a second
@@ -134,6 +135,14 @@ fm_control_interrupt_clear_key() {  # <harness>
   case "${1-}" in
     muse) printf 'C-u' ;;
     claude|codex|opencode|pi|pi-signed|grok|kimi) ;;
+    *) return 1 ;;
+  esac
+}
+
+fm_control_interrupt_ack_source() {  # <harness>
+  case "${1-}" in
+    muse) printf 'muse-session-terminal' ;;
+    claude|codex|opencode|pi|pi-signed|grok|kimi) printf 'none' ;;
     *) return 1 ;;
   esac
 }

--- a/bin/fm-control-lib.sh
+++ b/bin/fm-control-lib.sh
@@ -1,0 +1,232 @@
+#!/usr/bin/env bash
+# fm-control-lib.sh - the ONE executable owner of firstmate's agent lifecycle
+# CONTROL-PLANE mechanics.
+#
+# Data plane vs control plane (captain-approved root architecture, 2026-07-13).
+# bin/fm-send.sh is the DATA plane: conversational text for the agent to read,
+# always routing-marked for a kind=secondmate target so the reply comes back
+# through the status path. That marking is exactly right for a message and
+# exactly wrong for a lifecycle command: a marked "/quit" arrives as ordinary
+# chat ("[fm-from-firstmate] /quit") that the agent reasons ABOUT instead of
+# executing. bin/fm-control.sh is the CONTROL plane: allowlisted lifecycle
+# verbs addressed to an exact task id, with the per-harness mechanics owned
+# here rather than improvised per harness in agent prose.
+#
+# This file owns three capability tables plus their pure artifact-path tables
+# and nothing else. It has no side effects, runs no backend command, and reads
+# no state, so it can be sourced by a test as a pure contract:
+#
+#   1. Verb allowlist. There is no arbitrary-text and no generic raw-key entry
+#      point on the control plane; a caller either names an allowlisted verb or
+#      is refused.
+#   2. Per-harness control mechanics: which key interrupts a running turn, how
+#      many times it must be sent, whether the composer needs clearing after
+#      that key, which command exits the agent, and which task kinds the adapter
+#      is verified to run. These are the empirically verified facts previously
+#      carried only in the harness-adapters skill's per-adapter tables; that
+#      skill now points here so one executable owner holds them, and
+#      bin/fm-send.sh's --key path reads the same table rather than a second
+#      copy of it.
+#   3. Per-backend capability: which named keys a runtime backend can deliver,
+#      and whether the backend has a recovery-grade agent-state classifier
+#      (bin/fm-backend.sh's fm_backend_agent_state) able to PROVE that an agent
+#      stopped. A verb whose postcondition cannot be proven on the recorded
+#      backend is refused rather than performed blind.
+#
+# `resume` is deliberately NOT a verb. It is not deterministic across the
+# verified adapters: codex and grok resume only from a session id printed at
+# exit, opencode resumes the most recent session for the cwd with --continue,
+# and claude, pi, pi-signed, and kimi have no verified pane-resume contract at
+# all. `relaunch` covers the same need deterministically for every adapter,
+# because the brief on disk - not a harness-private session - is the durable
+# instruction.
+
+# The complete control-plane verb allowlist, one per line.
+fm_control_verbs() {
+  cat <<'EOF'
+interrupt
+exit
+relaunch
+EOF
+}
+
+fm_control_verb_allowed() {  # <verb>
+  case "${1-}" in
+    interrupt|exit|relaunch) return 0 ;;
+  esac
+  return 1
+}
+
+# The harnesses whose control mechanics are verified. Mirrors AGENTS.md
+# section 4's verified-adapter list; an unverified adapter is refused rather
+# than guessed at, exactly as a spawn on it would be.
+fm_control_harness_supported() {  # <harness>
+  case "${1-}" in
+    claude|codex|opencode|pi|pi-signed|grok|kimi|muse) return 0 ;;
+  esac
+  return 1
+}
+
+# The verified adapter a RECORDED harness value belongs to. Every table below
+# is keyed by the exact verified adapter name, but a task launched from a raw
+# command records the command's basename instead (bin/fm-spawn.sh derives
+# harness= that way), which is why the spawn adapters match `claude*`, `muse*`,
+# and friends. This is the one place that prefix rule is stated. `pi` and
+# `pi-signed` are exact because a `pi*` prefix would swallow the signed adapter,
+# and an unrecognized value returns nonzero rather than being guessed into a
+# family.
+fm_control_harness_family() {  # <recorded-harness>
+  case "${1-}" in
+    pi) printf 'pi' ;;
+    pi-signed) printf 'pi-signed' ;;
+    claude*) printf 'claude' ;;
+    codex*) printf 'codex' ;;
+    opencode*) printf 'opencode' ;;
+    grok*) printf 'grok' ;;
+    kimi*) printf 'kimi' ;;
+    muse*) printf 'muse' ;;
+    *) return 1 ;;
+  esac
+}
+
+# Which task kinds an adapter is verified to run. muse is a crewmate/scout
+# adapter only: it has no primary supervision protocol, and bin/fm-spawn.sh
+# refuses a --secondmate launch on it. The control plane asks this BEFORE it
+# stops anything, so an incompatible relaunch target is refused while the
+# current agent is still running rather than after it has been stopped.
+fm_control_harness_supports_kind() {  # <harness> <kind>
+  local harness=${1-} kind=${2-}
+  fm_control_harness_supported "$harness" || return 1
+  case "$harness" in
+    muse) [ "$kind" != secondmate ] || return 1 ;;
+  esac
+  return 0
+}
+
+# The key that cancels a running turn. Escape for every adapter except grok,
+# whose Esc only moves focus to the scrollback; grok cancels on Ctrl+C.
+fm_control_interrupt_key() {  # <harness>
+  case "${1-}" in
+    claude|codex|opencode|pi|pi-signed|kimi|muse) printf 'Escape' ;;
+    grok) printf 'C-c' ;;
+    *) return 1 ;;
+  esac
+}
+
+# How many times the interrupt key must be delivered. OpenCode needs a double
+# Escape; every other verified adapter interrupts on a single press.
+fm_control_interrupt_repeat() {  # <harness>
+  case "${1-}" in
+    opencode) printf '2' ;;
+    claude|codex|pi|pi-signed|grok|kimi|muse) printf '1' ;;
+    *) return 1 ;;
+  esac
+}
+
+# The key that must follow the interrupt key to leave the composer empty, or
+# nothing when the adapter needs none. muse is the one verified adapter that
+# RESTORES the cancelled prompt into its composer as real bright text, so an
+# interrupt is not complete until Ctrl+U has cleared it; leaving it there would
+# make the next submitted line - a steer, or this plane's own exit command -
+# concatenate onto it. Prints the key or nothing; a harness with no verified
+# mechanics returns nonzero, matching the tables above.
+fm_control_interrupt_clear_key() {  # <harness>
+  case "${1-}" in
+    muse) printf 'C-u' ;;
+    claude|codex|opencode|pi|pi-signed|grok|kimi) ;;
+    *) return 1 ;;
+  esac
+}
+
+# The command that exits the agent from its own composer.
+fm_control_exit_command() {  # <harness>
+  case "${1-}" in
+    claude|opencode|grok|kimi|muse) printf '/exit' ;;
+    codex|pi|pi-signed) printf '/quit' ;;
+    *) return 1 ;;
+  esac
+}
+
+# Which named keys a backend adapter can deliver. Every session provider
+# normalizes Enter, Ctrl+C, and the Ctrl+U composer clear; Orca's terminal API
+# exposes only an interrupt and an Enter, so it can deliver neither Escape nor
+# Ctrl+U (bin/backends/orca.sh's fm_backend_orca_send_key).
+fm_control_backend_supports_key() {  # <backend> <key>
+  local backend=${1-} key=${2-}
+  case "$backend" in
+    tmux|herdr|zellij|cmux)
+      case "$key" in Escape|Enter|C-c|C-u) return 0 ;; esac
+      ;;
+    orca)
+      case "$key" in Enter|C-c) return 0 ;; esac
+      ;;
+  esac
+  return 1
+}
+
+# Whether <backend> has a recovery-grade agent-state classifier. Only tmux and
+# herdr implement fm_backend_agent_state; zellij, orca, and cmux report
+# `unverified`, so no reading of theirs can prove an agent stopped. The control
+# plane refuses a stop-proving verb there instead of reporting an unprovable
+# transition as success.
+fm_control_backend_state_verified() {  # <backend>
+  case "${1-}" in
+    tmux|herdr) return 0 ;;
+  esac
+  return 1
+}
+
+# The per-task wiring artifacts a harness leaves behind, so a relaunch that
+# changes harness (or re-arms the same one with a fresh busy generation) can
+# clear the previous incarnation's wiring instead of leaving a stale hook
+# pointing at a retired generation. Prints zero or more absolute paths, one per
+# line: worktree-resident hook files and firstmate-owned state tokens only,
+# never a harness's own managed config.
+fm_control_harness_wiring_paths() {  # <harness> <worktree> <state-dir> <id>
+  local harness=${1-} wt=${2-} state=${3-} id=${4-}
+  [ -n "$wt" ] && [ -n "$state" ] && [ -n "$id" ] || return 1
+  case "$harness" in
+    claude) printf '%s\n' "$wt/.claude/settings.local.json" ;;
+    opencode) printf '%s\n' "$wt/.opencode/plugins/fm-busy-state.js" ;;
+    pi|pi-signed) printf '%s\n' "$state/$id.pi-ext.ts" ;;
+    grok)
+      printf '%s\n' "$wt/.fm-grok-turnend"
+      printf '%s\n' "$state/$id.grok-turnend-token"
+      ;;
+    kimi)
+      printf '%s\n' "$wt/.fm-kimi-turnend"
+      printf '%s\n' "$state/$id.kimi-turnend-token"
+      ;;
+    muse)
+      # muse installs no hook: its busy source is its own session event log,
+      # bound to the pane by these two firstmate-owned sidecars. A relaunch
+      # ONTO muse rewrites them, but a relaunch AWAY from muse must retire them
+      # so no retired incarnation's session binding outlives the agent.
+      printf '%s\n' "$state/$id.muse-session"
+      printf '%s\n' "$state/$id.muse-session-current"
+      ;;
+  esac
+}
+
+# The firstmate-owned global turn-end registry entry a harness mints per task.
+# grok and kimi are the two adapters whose turn-end hook is global and gated by
+# a private token file; every other adapter's wiring is fully covered by
+# fm_control_harness_wiring_paths. Prints the registry path or nothing.
+fm_control_harness_turnend_token_path() {  # <harness> <state-dir> <id>
+  local harness=${1-} state=${2-} id=${3-}
+  [ -n "$state" ] && [ -n "$id" ] || return 1
+  case "$harness" in
+    grok) printf '%s\n' "$state/$id.grok-turnend-token" ;;
+    kimi) printf '%s\n' "$state/$id.kimi-turnend-token" ;;
+  esac
+}
+
+fm_control_harness_turnend_auth_path() {  # <harness> <token>
+  local harness=${1-} token=${2-}
+  case "$token" in ''|*[!A-Za-z0-9._-]*) return 0 ;; esac
+  case "$harness" in
+    grok) printf '%s\n' "${GROK_HOME:-$HOME/.grok}/hooks/fm-turn-end.d/$token" ;;
+    kimi) printf '%s\n' "$HOME/.kimi-code/fm-turn-end.d/$token" ;;
+    *) return 0 ;;
+  esac
+}

--- a/bin/fm-control.sh
+++ b/bin/fm-control.sh
@@ -1,0 +1,831 @@
+#!/usr/bin/env bash
+# fm-control.sh - the CONTROL PLANE for a firstmate-owned agent: allowlisted
+# lifecycle verbs addressed to an exact task id.
+#
+# Usage: fm-control.sh <task-id> interrupt
+#        fm-control.sh <task-id> exit
+#        fm-control.sh <task-id> relaunch [--harness <name>] [--model <name>]
+#                                         [--effort <level>]
+#                                         (--note <text> | --note-file <path>)
+#
+# Why this exists, and how it differs from fm-send.sh. bin/fm-send.sh is the
+# DATA plane: conversational text for the agent to read, always routing-marked
+# for a kind=secondmate target so the reply returns through the status path.
+# That marking is right for a message and wrong for a lifecycle command - a
+# marked "/quit" arrives as ordinary chat the agent reasons ABOUT instead of
+# executing. This script is the control plane: semantic process control with a
+# closed verb list, per-harness mechanics owned by an executable adapter
+# (bin/fm-control-lib.sh) rather than improvised in agent prose, and a verified
+# postcondition for every action. There is deliberately NO arbitrary-text and
+# NO generic raw-key entry point here; fm-send remains the only way to send an
+# agent something to read.
+#
+#   interrupt  Cancel the running turn with the harness's verified interrupt
+#              key. The agent keeps running. Postcondition: the endpoint still
+#              exists, the agent is still alive where the backend can classify
+#              that, and no stale busy record survives - firstmate records
+#              idle/fm-interrupt against the armed busy generation itself,
+#              because a manual interrupt is not something every harness
+#              reports (Claude fires no hook for one).
+#   exit       Stop the agent, preserving its terminal endpoint, worktree, and
+#              every uncommitted change. Interrupts first when the task reads
+#              busy, then submits the harness's exit command. Postcondition:
+#              the backend's recovery-grade classifier reports the agent gone.
+#              Already-stopped is success (idempotent).
+#   relaunch   Transactionally replace the running agent with a new one, in the
+#              SAME endpoint and SAME worktree, on the same or a newly chosen
+#              harness/model/effort - so switching harness is one ordinary use
+#              of this verb. With no explicit axis, a secondmate re-resolves its
+#              durable config/secondmate-harness pin (harness plus its optional
+#              model and effort tokens) exactly as any other respawn does, while
+#              a ship or scout keeps the harness already recorded for it.
+#              --note is required for a ship or scout, whose replacement
+#              inherits the local copy but none of the conversation; a
+#              secondmate reconciles its own home's records at startup, so its
+#              standing charter is never rewritten.
+#              Records a durable checkpoint and that note, exits the old agent,
+#              then delegates the launch to its single owner,
+#              bin/fm-spawn.sh --relaunch. A failure before publication keeps
+#              the prior durable record in place and reports the concrete
+#              state; it never leaves a half-transitioned task claiming to be
+#              running.
+#
+# Teardown and discard are NOT verbs here and never will be. `exit` stops an
+# agent and preserves everything else; removing a worktree, killing an
+# endpoint, or discarding work stays with bin/fm-teardown.sh, which owns the
+# landed-work test.
+#
+# `resume` is not a verb: it is not deterministic across the verified adapters
+# (bin/fm-control-lib.sh's header owns that reasoning). `relaunch` covers the
+# same need for every adapter because the brief on disk, not a harness-private
+# session, is the durable instruction.
+#
+# Targeting is EXACT: only a bare task id with a state/<id>.meta record in
+# THIS home is accepted, and the record must pass the shared endpoint-identity
+# validation (bin/fm-backend.sh's fm_backend_validate_task_endpoint). A legacy
+# fm-<id> label, an explicit session:window endpoint, and a bare window name
+# are all refused - a lifecycle command delivered to the wrong endpoint is far
+# worse than a loud refusal.
+#
+# A remotely placed secondmate is refused by name: its agent runs on another
+# host, so no postcondition this plane verifies could be read for it here.
+#
+# Fail-closed boundaries:
+#   - An unverified harness, or a harness whose control mechanics are unknown,
+#     is refused rather than guessed at.
+#   - A backend that cannot deliver the harness's interrupt key is refused
+#     (Orca's terminal API has no Escape).
+#   - `exit` and `relaunch` require a backend with a recovery-grade agent-state
+#     classifier (tmux, herdr), because without one the "the agent stopped"
+#     postcondition cannot be proven. zellij, orca, and cmux are refused rather
+#     than reported as successful blind.
+#   - An ambiguous or unreadable endpoint state refuses; only a positively
+#     classified state acts.
+#
+# Environment knobs (all bounded waits, seconds):
+#   FM_CONTROL_POLL              poll interval for postcondition waits (0.5)
+#   FM_CONTROL_SETTLE_WAIT       busy->not-busy settle after an interrupt (5)
+#   FM_CONTROL_EXIT_WAIT         alive->dead wait after the exit command (30)
+#   FM_CONTROL_LAUNCH_WAIT       dead->alive wait after a relaunch (90)
+#   FM_CONTROL_EXIT_RETRIES      Enter retries for the exit command (3)
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+
+usage() {
+  # The whole leading comment block, ending at the first non-comment line.
+  sed -n '2,${/^#/!q;p;}' "$0" | sed 's/^# \{0,1\}//'
+}
+
+case "${1:-}" in
+  -h|--help) usage; exit 0 ;;
+esac
+
+# shellcheck source=bin/fm-gate-refuse-lib.sh
+. "$SCRIPT_DIR/fm-gate-refuse-lib.sh"
+# Fail closed before any fleet mutation: a no-mistakes gate agent must never
+# drive a crewmate's lifecycle (see bin/fm-gate-refuse-lib.sh).
+fm_refuse_if_gate_agent
+
+if [ -z "${FM_HOME+x}" ] || [ -z "${FM_HOME:-}" ]; then
+  echo "error: FM_HOME is not set; fm-control refuses to resolve a task without an explicit firstmate home" >&2
+  exit 1
+fi
+[ -d "$FM_HOME" ] || {
+  echo "error: FM_HOME '$FM_HOME' is not a directory" >&2
+  exit 1
+}
+STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
+DATA="${FM_DATA_OVERRIDE:-$FM_HOME/data}"
+[ -d "$STATE" ] || {
+  echo "error: state dir '$STATE' is missing; fm-control cannot resolve tasks for FM_HOME '$FM_HOME'" >&2
+  exit 1
+}
+
+# shellcheck source=bin/fm-backend.sh
+. "$SCRIPT_DIR/fm-backend.sh"
+# shellcheck source=bin/fm-busy-lib.sh
+. "$SCRIPT_DIR/fm-busy-lib.sh"
+# shellcheck source=bin/fm-control-lib.sh
+. "$SCRIPT_DIR/fm-control-lib.sh"
+# shellcheck source=bin/fm-pr-lib.sh
+. "$SCRIPT_DIR/fm-pr-lib.sh"
+# shellcheck source=bin/fm-wake-lib.sh
+. "$SCRIPT_DIR/fm-wake-lib.sh"
+
+POLL=${FM_CONTROL_POLL:-0.5}
+SETTLE_WAIT=${FM_CONTROL_SETTLE_WAIT:-5}
+EXIT_WAIT=${FM_CONTROL_EXIT_WAIT:-30}
+LAUNCH_WAIT=${FM_CONTROL_LAUNCH_WAIT:-90}
+EXIT_RETRIES=${FM_CONTROL_EXIT_RETRIES:-3}
+
+die() {  # <message>
+  echo "error: $1" >&2
+  exit 1
+}
+
+CONTROL_LOCK=
+CONTROL_LOCK_HELD=0
+RELAUNCH_ACTIVE=0
+RELAUNCH_PHASE=start
+
+control_cleanup() {
+  local status=$?
+  if [ "$RELAUNCH_ACTIVE" = 1 ] \
+     && declare -F relaunch_rollback >/dev/null 2>&1; then
+    relaunch_rollback || true
+  fi
+  if [ "$CONTROL_LOCK_HELD" = 1 ]; then
+    CONTROL_LOCK_HELD=0
+    fm_lock_release "$CONTROL_LOCK" || true
+  fi
+  return "$status"
+}
+
+# --- argument parsing -------------------------------------------------------
+
+RAW_ID=${1:-}
+VERB=${2:-}
+[ -n "$RAW_ID" ] && [ -n "$VERB" ] || { usage >&2; exit 2; }
+shift 2
+
+if ! fm_control_verb_allowed "$VERB"; then
+  {
+    if [ "$VERB" = resume ]; then
+      echo "error: 'resume' is not a control verb: resuming an exited agent is not deterministic across the verified adapters (codex and grok need a session id printed at exit, opencode continues the most recent session for the cwd, and claude, pi, pi-signed, and kimi have no verified pane-resume contract). Use 'relaunch', which carries the brief plus a progress note into a fresh agent on any adapter."
+    else
+      echo "error: '$VERB' is not a control verb"
+    fi
+    echo "allowed verbs:"
+    fm_control_verbs | sed 's/^/  /'
+  } >&2
+  exit 2
+fi
+
+NEW_HARNESS=
+NEW_MODEL=
+NEW_EFFORT=
+HARNESS_SET=0
+MODEL_SET=0
+EFFORT_SET=0
+NOTE=
+NOTE_SET=0
+want_value=
+for a in "$@"; do
+  if [ -n "$want_value" ]; then
+    case "$a" in
+      --*) die "--$want_value requires a value" ;;
+    esac
+    case "$want_value" in
+      harness) NEW_HARNESS=$a; HARNESS_SET=1 ;;
+      model) NEW_MODEL=$a; MODEL_SET=1 ;;
+      effort) NEW_EFFORT=$a; EFFORT_SET=1 ;;
+      note) NOTE=$a; NOTE_SET=1 ;;
+      note-file)
+        [ -f "$a" ] || die "--note-file '$a' is not a readable file"
+        NOTE=$(cat "$a")
+        NOTE_SET=1
+        ;;
+    esac
+    want_value=
+    continue
+  fi
+  case "$a" in
+    --harness) want_value=harness ;;
+    --harness=*) NEW_HARNESS=${a#--harness=}; HARNESS_SET=1 ;;
+    --model) want_value=model ;;
+    --model=*) NEW_MODEL=${a#--model=}; MODEL_SET=1 ;;
+    --effort) want_value=effort ;;
+    --effort=*) NEW_EFFORT=${a#--effort=}; EFFORT_SET=1 ;;
+    --note) want_value=note ;;
+    --note=*) NOTE=${a#--note=}; NOTE_SET=1 ;;
+    --note-file) want_value=note-file ;;
+    --note-file=*)
+      [ -f "${a#--note-file=}" ] || die "--note-file '${a#--note-file=}' is not a readable file"
+      NOTE=$(cat "${a#--note-file=}")
+      NOTE_SET=1
+      ;;
+    *) die "unexpected argument '$a'" ;;
+  esac
+done
+[ -z "$want_value" ] || die "--$want_value requires a value"
+
+if [ "$VERB" != relaunch ]; then
+  [ "$HARNESS_SET" = 0 ] && [ "$MODEL_SET" = 0 ] && [ "$EFFORT_SET" = 0 ] && [ "$NOTE_SET" = 0 ] \
+    || die "--harness, --model, --effort, and --note apply to 'relaunch' only"
+fi
+[ "$HARNESS_SET" = 0 ] || [ -n "$NEW_HARNESS" ] || die "--harness requires a non-empty value"
+[ "$MODEL_SET" = 0 ] || [ -n "$NEW_MODEL" ] || die "--model requires a non-empty value"
+[ "$EFFORT_SET" = 0 ] || [ -n "$NEW_EFFORT" ] || die "--effort requires a non-empty value"
+case "$NEW_EFFORT" in
+  ''|low|medium|high|xhigh|max) ;;
+  *) die "--effort must be one of low, medium, high, xhigh, max" ;;
+esac
+
+# --- exact task-id resolution ----------------------------------------------
+
+case "$RAW_ID" in
+  *:*) die "'$RAW_ID' is an explicit backend endpoint; fm-control accepts an exact task id only, so a lifecycle command can never land on an endpoint this home does not own" ;;
+esac
+if ! fm_task_id_creation_valid "$RAW_ID"; then
+  die "'$RAW_ID' is not a valid task id"
+fi
+ID=$RAW_ID
+CONTROL_LOCK="$STATE/.control-$ID.lock"
+trap control_cleanup EXIT
+fm_lock_try_acquire "$CONTROL_LOCK" \
+  || die "another lifecycle action is already running for task $ID"
+CONTROL_LOCK_HELD=1
+META="$STATE/$ID.meta"
+if [ ! -f "$META" ]; then
+  case "$RAW_ID" in
+    fm-*)
+      if [ -f "$STATE/${RAW_ID#fm-}.meta" ]; then
+        die "'$RAW_ID' is a window label, not a task id; pass the exact task id '${RAW_ID#fm-}'"
+      fi
+      ;;
+  esac
+  die "no task '$ID' in $STATE (fm-control resolves an exact task id only)"
+fi
+
+# A remotely placed secondmate records its endpoint on ANOTHER host, so every
+# postcondition this plane verifies - the agent-state classification, the busy
+# verdict, the endpoint's existence - would be read here for an endpoint that
+# does not live here. Endpoint validation already refuses such a record, since
+# `window=remote:<id>` can never match a local backend's required shape, so
+# nothing can be delivered to a wrong endpoint either way. What that refusal
+# cannot say is WHY, and "malformed metadata" is the wrong thing to tell an
+# operator about a correctly configured remote route. Name the placement
+# instead, using the same `remote_host` signal bin/fm-send.sh routes on.
+if [ -n "$(fm_meta_get "$META" remote_host)" ]; then
+  die "task $ID is a remotely placed secondmate on $(fm_meta_get "$META" remote_host); its agent runs outside this home, so no lifecycle action here could verify that it interrupted, stopped, or came back. Drive its lifecycle on that host, and reconcile it through the secondmate recovery path rather than this plane"
+fi
+
+fm_backend_validate_task_endpoint "$META" "$ID" || exit 1
+BACKEND=$FM_BACKEND_VALIDATED_BACKEND
+T=$FM_BACKEND_VALIDATED_TARGET
+LABEL="fm-$ID"
+HARNESS=$(fm_meta_get "$META" harness)
+KIND=$(fm_meta_get "$META" kind)
+WT=$(fm_meta_get "$META" worktree)
+[ -n "$KIND" ] || KIND=ship
+
+fm_control_harness_supported "$HARNESS" \
+  || die "task $ID records harness '${HARNESS:-none}', which has no verified control mechanics; fm-control refuses to guess an interrupt key or exit command"
+
+fm_backend_validate "$BACKEND" || exit 1
+
+# --- shared helpers ---------------------------------------------------------
+
+agent_state() {
+  fm_backend_agent_state "$BACKEND" "$T"
+}
+
+busy_verdict() {
+  fm_busy_classify_meta "$META" "$ID" "$STATE"
+}
+
+# wait_agent_state <wanted...> <timeout>: poll until agent_state prints one of
+# the wanted values. Prints the final observed state; returns 0 on a match.
+wait_agent_state() {  # <timeout> <wanted>...
+  local timeout=$1 state want elapsed=0
+  shift
+  while :; do
+    state=$(agent_state)
+    for want in "$@"; do
+      if [ "$state" = "$want" ]; then
+        printf '%s' "$state"
+        return 0
+      fi
+    done
+    awk -v e="$elapsed" -v t="$timeout" 'BEGIN{exit !(e < t)}' || break
+    sleep "$POLL"
+    elapsed=$(awk -v e="$elapsed" -v p="$POLL" 'BEGIN{printf "%.3f", e + p}')
+  done
+  printf '%s' "$state"
+  return 1
+}
+
+require_state_verified_backend() {  # <verb>
+  fm_control_backend_state_verified "$BACKEND" && return 0
+  die "task $ID runs on the $BACKEND backend, which has no recovery-grade agent-state classifier, so '$1' cannot prove the agent actually stopped; refusing rather than reporting an unproven transition as done"
+}
+
+# send_interrupt_keys: deliver the harness's interrupt key the verified number
+# of times, then the composer-clear key when the adapter needs one. Refuses
+# before sending anything when the backend cannot deliver either key, because
+# an interrupt that cancels the turn but leaves the restored prompt in the
+# composer would make the next submitted line concatenate onto it.
+send_interrupt_keys() {
+  local key repeat clear i=0
+  key=$(fm_control_interrupt_key "$HARNESS")
+  repeat=$(fm_control_interrupt_repeat "$HARNESS")
+  clear=$(fm_control_interrupt_clear_key "$HARNESS")
+  fm_control_backend_supports_key "$BACKEND" "$key" \
+    || die "harness $HARNESS interrupts with $key, which the $BACKEND backend cannot deliver; refusing to send a different key"
+  [ -z "$clear" ] || fm_control_backend_supports_key "$BACKEND" "$clear" \
+    || die "harness $HARNESS needs $clear to clear its composer after an interrupt, which the $BACKEND backend cannot deliver; refusing to leave the cancelled prompt where the next submitted line would concatenate onto it"
+  while [ "$i" -lt "$repeat" ]; do
+    fm_backend_send_key "$BACKEND" "$T" "$key" "$LABEL" \
+      || die "interrupt key $key was not delivered to task $ID on $BACKEND"
+    i=$((i + 1))
+    [ "$i" -ge "$repeat" ] || sleep 0.2
+  done
+  [ -z "$clear" ] || fm_backend_send_key "$BACKEND" "$T" "$clear" "$LABEL" \
+    || die "interrupt key $key reached task $ID, but $clear did not, so its composer still holds the cancelled prompt; clear it before the next lifecycle action"
+}
+
+record_interrupt_idle() {
+  # Only a task with an armed busy generation has a record to update. A manual
+  # interrupt is not something every harness reports: Claude fires no lifecycle
+  # hook for one at all, so waiting for an adapter to clear its own busy record
+  # would hang forever on exactly the adapter that needs this most. Firstmate
+  # therefore owns the transition itself through the fm-interrupt source every
+  # converted adapter trusts.
+  [ -f "$STATE/$ID.busy-gen" ] || return 0
+  "$SCRIPT_DIR/fm-busy-event.sh" apply "$STATE" "$ID" idle \
+    --current-gen --source fm-interrupt --event interrupt >/dev/null 2>&1
+}
+
+# do_interrupt: the shared interrupt action, used by the `interrupt` verb and
+# as `exit`'s busy precondition. Prints the proof it obtained: `agent-alive`
+# when the backend could confirm the agent survived the interrupt, `endpoint`
+# when only the endpoint's existence could be confirmed.
+do_interrupt() {
+  local proof after elapsed
+  send_interrupt_keys
+  fm_backend_target_exists "$BACKEND" "$T" "$LABEL" \
+    || die "task $ID's endpoint disappeared while interrupting it; no further control action is safe"
+  proof=endpoint
+  if fm_control_backend_state_verified "$BACKEND"; then
+    # An interrupt cancels a turn; it must never have stopped the agent. This
+    # is the postcondition that separates a landed interrupt from an accident.
+    after=$(agent_state)
+    [ "$after" = alive ] \
+      || die "task $ID's agent is '$after' after its interrupt key; an interrupt must leave the agent running"
+    proof=agent-alive
+  fi
+  record_interrupt_idle \
+    || die "task $ID's interrupt landed, but its armed busy generation could not be recorded idle; refusing to claim the stale record was cleared"
+  # No stale busy record may survive the interrupted turn. After the
+  # firstmate-owned idle event above this is immediate for every adapter with a
+  # semantic source. Grok is the exception: it has no semantic writer yet, so
+  # its verdict comes from a rendered footer that needs a beat to repaint after
+  # the cancel. Give any still-busy verdict that bounded settle rather than
+  # calling a landed interrupt a failure - but keep the failure, because a
+  # verdict that never settles means the interrupt did not take.
+  after=$(busy_verdict)
+  elapsed=0
+  while [ "${after%% *}" = busy ]; do
+    awk -v e="$elapsed" -v t="$SETTLE_WAIT" 'BEGIN{exit !(e < t)}' || break
+    sleep "$POLL"
+    elapsed=$(awk -v e="$elapsed" -v p="$POLL" 'BEGIN{printf "%.3f", e + p}')
+    after=$(busy_verdict)
+  done
+  case "$after" in
+    idle\ *) ;;
+    unknown\ *)
+      [ ! -e "$STATE/$ID.busy-gen" ] && [ ! -e "$STATE/$ID.busy-state" ] \
+        || die "task $ID's busy state is unresolved after its interrupt (${after}); refusing to claim the stale record was cleared"
+      ;;
+    busy\ *) die "task $ID still reads busy ${SETTLE_WAIT}s after its interrupt (${after}); the interrupt did not take" ;;
+    *) die "task $ID's busy state is unresolved after its interrupt (${after}); refusing to claim the stale record was cleared" ;;
+  esac
+  printf '%s' "$proof"
+}
+
+# do_exit: stop the running agent, preserving endpoint and worktree. Prints
+# `already-stopped` or `stopped`.
+do_exit() {
+  local state cmd verdict
+  require_state_verified_backend exit
+  state=$(agent_state)
+  case "$state" in
+    dead)
+      printf 'already-stopped'
+      return 0
+      ;;
+    alive) ;;
+    missing) die "task $ID's recorded endpoint is gone, so there is no agent to stop; reconcile the task before any further control action" ;;
+    *) die "task $ID's endpoint reads '$state' rather than a positively classified state; refusing to send a lifecycle command into an unattributed endpoint" ;;
+  esac
+  # A busy agent is interrupted first so the exit command reaches an idle
+  # composer instead of being queued behind the running turn.
+  case "$(busy_verdict)" in
+    busy*) do_interrupt >/dev/null ;;
+  esac
+  cmd=$(fm_control_exit_command "$HARNESS")
+  # The submit verdict is NOT the postcondition here: a successful exit command
+  # destroys the composer the verdict is read from, so a post-exit read can
+  # legitimately report anything. Only a hard transport failure aborts; the
+  # authoritative proof is the agent-state wait below. The retried Enter still
+  # matters, because a slash command opens a completion popup on some TUIs that
+  # swallows the first Enter.
+  verdict=$(fm_backend_send_text_submit "$BACKEND" "$T" "$cmd" "$EXIT_RETRIES" "$POLL" 1.2 "$LABEL") \
+    || die "the exit command could not be sent to task $ID on $BACKEND"
+  [ "$verdict" != send-failed ] \
+    || die "the exit command could not be sent to task $ID on $BACKEND"
+  state=$(wait_agent_state "$EXIT_WAIT" dead) || {
+    die "task $ID's agent was still '$state' ${EXIT_WAIT}s after its exit command; the agent did not stop and nothing was changed"
+  }
+  # The incarnation is over: retire its busy wiring so no stale record or
+  # orphaned generation survives the agent that produced it.
+  if [ -f "$STATE/$ID.busy-gen" ]; then
+    "$SCRIPT_DIR/fm-busy-event.sh" retire "$STATE" "$ID" --current-gen >/dev/null 2>&1 || true
+  fi
+  printf 'stopped'
+}
+
+# --- transactional relaunch -------------------------------------------------
+#
+# The transaction's durable record is state/<id>.control-relaunch, with the
+# prior metadata and brief preserved beside it. Every failure path runs through
+# relaunch_rollback (an EXIT trap, so a refusal raised deep inside a shared
+# helper is covered too) and leaves either the pre-relaunch durable record or a
+# concrete, named partial state - never a task whose record claims an agent
+# that is not running.
+
+JOURNAL="$STATE/$ID.control-relaunch"
+META_PRIOR="$JOURNAL.meta-prior"
+BRIEF_PRIOR="$JOURNAL.brief-prior"
+NOTE_FILE="$JOURNAL.note"
+RELAUNCH_META_PUBLISHED=0
+RELAUNCH_AGENT_CONFIRMED=0
+RELAUNCH_TX=
+RELAUNCH_BRIEF=
+PRIOR_HARNESS=$HARNESS
+CONFIG_HARNESS=
+CONFIG_MODEL=
+CONFIG_EFFORT=
+PRIOR_MODEL=
+PRIOR_EFFORT=
+TARGET_HARNESS=$HARNESS
+TARGET_MODEL=
+TARGET_EFFORT=
+
+journal_write() {  # <phase> [extra-line]...
+  local phase=$1
+  shift
+  if {
+    echo "v1"
+    echo "task=$ID"
+    echo "phase=$phase"
+    echo "ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    echo "backend=$BACKEND"
+    echo "endpoint=$T"
+    echo "worktree=$WT"
+    echo "kind=$KIND"
+    echo "from_harness=$PRIOR_HARNESS"
+    echo "from_model=$PRIOR_MODEL"
+    echo "from_effort=$PRIOR_EFFORT"
+    echo "to_harness=$TARGET_HARNESS"
+    echo "to_model=$TARGET_MODEL"
+    echo "to_effort=$TARGET_EFFORT"
+    local line
+    for line in "$@"; do
+      echo "$line"
+    done
+  } > "$JOURNAL.tmp" && mv -f "$JOURNAL.tmp" "$JOURNAL"; then
+    RELAUNCH_PHASE=$phase
+    return 0
+  fi
+  return 1
+}
+
+relaunch_rollback() {
+  local state
+  [ "$RELAUNCH_ACTIVE" = 1 ] || return 0
+  [ "$RELAUNCH_PHASE" != complete ] || return 0
+  RELAUNCH_ACTIVE=0
+  case "$RELAUNCH_PHASE" in
+    checkpoint|noted)
+      # The old agent was never touched. Restore the instructions byte-exact so
+      # a refused relaunch leaves nothing behind.
+      if [ -n "$RELAUNCH_BRIEF" ] && [ -f "$BRIEF_PRIOR" ]; then
+        cp -p "$BRIEF_PRIOR" "$RELAUNCH_BRIEF" 2>/dev/null || true
+      fi
+      journal_write "failed:$RELAUNCH_PHASE" "rollback=instructions-restored" || true
+      echo "error: relaunch of $ID was refused before its agent was touched; nothing changed" >&2
+      ;;
+    stopping)
+      state=$(agent_state 2>/dev/null || printf unknown)
+      case "$state" in
+        alive)
+          if [ -n "$RELAUNCH_BRIEF" ] && [ -f "$BRIEF_PRIOR" ]; then
+            cp -p "$BRIEF_PRIOR" "$RELAUNCH_BRIEF" 2>/dev/null || true
+          fi
+          journal_write "failed:$RELAUNCH_PHASE" "rollback=instructions-restored-agent-alive" || true
+          echo "error: relaunch of $ID failed while stopping the old agent, which is still running; its original instructions were restored" >&2
+          ;;
+        dead)
+          journal_write "failed:$RELAUNCH_PHASE" "rollback=prior-record-kept-agent-dead" || true
+          echo "error: $ID's agent stopped but relaunch did not reach replacement launch; no agent is running, and its work plus progress note are preserved at $WT" >&2
+          ;;
+        *)
+          journal_write "failed:$RELAUNCH_PHASE" "rollback=none-agent-state-$state" || true
+          echo "error: relaunch of $ID failed while stopping the old agent and its state is '$state'; the durable record and progress note were retained for recovery" >&2
+          ;;
+      esac
+      ;;
+    exited|launching)
+      if [ "$RELAUNCH_AGENT_CONFIRMED" = 1 ]; then
+        journal_write "failed:$RELAUNCH_PHASE" "rollback=none-new-agent-confirmed" || true
+        echo "error: $ID's replacement is running on $TARGET_HARNESS, but transaction completion could not be persisted; its published record was retained for reconciliation" >&2
+      elif [ "$RELAUNCH_META_PUBLISHED" = 1 ] \
+         || { [ -n "$RELAUNCH_TX" ] \
+              && [ "$(fm_meta_get "$META" control_relaunch_tx)" = "$RELAUNCH_TX" ]; }; then
+        # The launch owner published the new incarnation's record. Leaving it
+        # in place is the honest state: the task is now recorded on the new
+        # harness with no agent confirmed, which is exactly what recovery
+        # reconciles. Rewriting it back to the old harness would be a second,
+        # worse inaccuracy.
+        journal_write "failed:$RELAUNCH_PHASE" "rollback=none-new-record-kept" || true
+        echo "error: $ID was relaunched on $TARGET_HARNESS but no running agent could be confirmed; its work is preserved at $WT" >&2
+      else
+        journal_write "failed:$RELAUNCH_PHASE" "rollback=prior-record-kept" || true
+        echo "error: $ID's agent was stopped but the replacement did not launch; no agent is running, and its work plus the recorded progress note are preserved at $WT" >&2
+      fi
+      ;;
+  esac
+  return 0
+}
+
+resolve_relaunch_profile() {
+  PRIOR_HARNESS=$HARNESS
+  PRIOR_MODEL=$(fm_meta_get "$META" model)
+  PRIOR_EFFORT=$(fm_meta_get "$META" effort)
+  [ -n "$PRIOR_MODEL" ] || PRIOR_MODEL=default
+  [ -n "$PRIOR_EFFORT" ] || PRIOR_EFFORT=default
+  CONFIG_HARNESS=
+  CONFIG_MODEL=
+  CONFIG_EFFORT=
+  if [ "$KIND" = secondmate ]; then
+    # A secondmate's harness, model, and effort are a durable configured pin
+    # that every respawn re-resolves (the secondmate-provisioning contract), so
+    # a relaunch with no explicit harness picks up a newly configured one
+    # instead of freezing whatever this incarnation happens to run. Crewmates
+    # and scouts deliberately do NOT resolve config here: their harness comes
+    # from firstmate's own dispatch-profile judgment at intake, and silently
+    # re-resolving it would bypass that consultation.
+    CONFIG_HARNESS=$("$SCRIPT_DIR/fm-harness.sh" secondmate 2>/dev/null || true)
+    CONFIG_MODEL=$("$SCRIPT_DIR/fm-harness.sh" secondmate-model 2>/dev/null || true)
+    CONFIG_EFFORT=$("$SCRIPT_DIR/fm-harness.sh" secondmate-effort 2>/dev/null || true)
+    case "$CONFIG_EFFORT" in
+      ''|low|medium|high|xhigh|max) ;;
+      *)
+        echo "warning: config/secondmate-harness effort token '$CONFIG_EFFORT' is not one of low, medium, high, xhigh, max; ignoring" >&2
+        CONFIG_EFFORT=
+        ;;
+    esac
+  fi
+  if [ "$HARNESS_SET" = 1 ]; then
+    fm_control_harness_supported "$NEW_HARNESS" \
+      || die "'$NEW_HARNESS' is not a verified harness; fm-control refuses to relaunch onto an adapter with no verified control or launch mechanics"
+    TARGET_HARNESS=$NEW_HARNESS
+  elif [ "$HARNESS_SET" = 0 ] && [ -n "$CONFIG_HARNESS" ]; then
+    fm_control_harness_supported "$CONFIG_HARNESS" \
+      || die "the configured secondmate harness '$CONFIG_HARNESS' is not verified; fm-control refuses to relaunch onto an adapter with no verified control or launch mechanics"
+    TARGET_HARNESS=$CONFIG_HARNESS
+  else
+    TARGET_HARNESS=$PRIOR_HARNESS
+  fi
+  # The launch owner refuses an adapter that cannot run this task's kind, but it
+  # is only reached after the old agent has been stopped. Asking the same
+  # capability table here keeps that refusal on the pre-stop side of the
+  # transaction, where nothing has changed yet.
+  fm_control_harness_supports_kind "$TARGET_HARNESS" "$KIND" \
+    || die "'$TARGET_HARNESS' is not verified to run a $KIND task, so relaunching $ID onto it would stop the running agent for a launch that must be refused; choose an adapter verified for this kind"
+  # A model or effort chosen for the previous harness does not transfer to a
+  # different one, so an explicit harness change resets both axes unless the
+  # caller names them too.
+  if [ "$MODEL_SET" = 1 ]; then
+    TARGET_MODEL=$NEW_MODEL
+  elif [ "$HARNESS_SET" = 0 ] && [ -n "$CONFIG_HARNESS" ]; then
+    TARGET_MODEL=${CONFIG_MODEL:-default}
+  elif [ "$TARGET_HARNESS" = "$PRIOR_HARNESS" ]; then
+    TARGET_MODEL=$PRIOR_MODEL
+  else
+    TARGET_MODEL=default
+  fi
+  if [ "$EFFORT_SET" = 1 ]; then
+    TARGET_EFFORT=$NEW_EFFORT
+  elif [ "$HARNESS_SET" = 0 ] && [ -n "$CONFIG_HARNESS" ]; then
+    TARGET_EFFORT=${CONFIG_EFFORT:-default}
+  elif [ "$TARGET_HARNESS" = "$PRIOR_HARNESS" ]; then
+    TARGET_EFFORT=$PRIOR_EFFORT
+  else
+    TARGET_EFFORT=default
+  fi
+}
+
+# safe_checkpoint: prove, before anything is stopped, that the work a relaunch
+# must preserve is actually there and recoverable afterwards. Fills
+# CHECKPOINT_LINES with the journal lines describing what it proved, and
+# refuses outright when any of it cannot be established.
+CHECKPOINT_LINES=()
+safe_checkpoint() {
+  local wt_real wt_top wt_top_real head head_ref head_ref_status status_output dirty children marker child_meta
+  CHECKPOINT_LINES=()
+  [ -n "$WT" ] || die "task $ID has no recorded worktree; refusing to relaunch without a recorded local copy to preserve"
+  [ -d "$WT" ] || die "task $ID's recorded worktree $WT is missing; refusing to relaunch and lose track of its work"
+  wt_real=$(cd "$WT" 2>/dev/null && pwd -P) || die "task $ID's recorded worktree $WT cannot be resolved"
+  wt_top=$(git -C "$WT" rev-parse --show-toplevel 2>/dev/null) \
+    || die "task $ID's recorded worktree $WT is not a git worktree; refusing to relaunch without a checkout whose unlanded work can be accounted for"
+  wt_top_real=$(cd "$wt_top" 2>/dev/null && pwd -P) || wt_top_real=$wt_top
+  [ "$wt_real" = "$wt_top_real" ] \
+    || die "task $ID's recorded worktree $WT is not a worktree root (root is $wt_top); refusing to relaunch against an ambiguous checkout"
+  if head=$(git -C "$WT" rev-parse --verify HEAD 2>/dev/null); then
+    :
+  elif head_ref=$(git -C "$WT" symbolic-ref -q HEAD 2>/dev/null); then
+    if git -C "$WT" show-ref --verify --quiet "$head_ref" 2>/dev/null; then
+      die "task $ID's worktree HEAD exists but cannot be resolved; refusing to relaunch from an unreadable checkout"
+    else
+      head_ref_status=$?
+      [ "$head_ref_status" -eq 1 ] \
+        || die "task $ID's worktree HEAD cannot be inspected; refusing to relaunch from an unreadable checkout"
+      head=unborn
+    fi
+  else
+    die "task $ID's worktree HEAD cannot be inspected; refusing to relaunch from an unreadable checkout"
+  fi
+  status_output=$(git -C "$WT" status --porcelain 2>/dev/null) \
+    || die "task $ID's worktree status cannot be inspected; refusing to relaunch without accounting for local changes"
+  if [ -n "$status_output" ]; then
+    dirty=yes
+  else
+    dirty=no
+  fi
+  CHECKPOINT_LINES+=("worktree_head=$head" "worktree_dirty=$dirty")
+  if [ "$KIND" = secondmate ]; then
+    # A secondmate's own crewmates outlive its relaunch: they run in their own
+    # endpoints, and the relaunched secondmate reconciles them from its home's
+    # durable records at startup. The checkpoint proves those records are
+    # readable BEFORE the agent stops, so a relaunch can never strand child
+    # work behind an unreadable home.
+    marker=$(cat "$WT/.fm-secondmate-home" 2>/dev/null || true)
+    [ "$marker" = "$ID" ] \
+      || die "task $ID's home $WT is not marked as its own seeded secondmate home (marker: ${marker:-none}); refusing to relaunch"
+    [ -d "$WT/state" ] \
+      || die "secondmate $ID's home has no readable state directory, so its child work cannot be accounted for; refusing to relaunch"
+    find "$WT/state" -mindepth 1 -maxdepth 1 -print >/dev/null 2>&1 \
+      || die "secondmate $ID's child records cannot be traversed; refusing to relaunch"
+    children=0
+    for child_meta in "$WT/state"/*.meta; do
+      if [ ! -e "$child_meta" ] && [ ! -L "$child_meta" ]; then
+        continue
+      fi
+      if [ ! -f "$child_meta" ] || [ -L "$child_meta" ] \
+         || ! cat "$child_meta" >/dev/null 2>&1; then
+        die "secondmate $ID's child record $child_meta is not a readable regular file; refusing to relaunch"
+      fi
+      children=$((children + 1))
+    done
+    CHECKPOINT_LINES+=("children=$children")
+  fi
+}
+
+# record_note: put the required progress note somewhere durable, and - for a
+# ship or scout, whose only record of the interrupted reasoning is the
+# conversation about to be discarded - into the instructions the replacement
+# actually reads. A secondmate's charter is a durable standing document and is
+# never rewritten: a secondmate reconciles its own home's records at startup,
+# so the note stays parent-side audit evidence.
+record_note() {
+  local stamp
+  [ -n "$NOTE" ] || return 0
+  stamp=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+  printf '%s\n' "$NOTE" > "$NOTE_FILE"
+  case "$KIND" in
+    ship|scout)
+      cp -p "$RELAUNCH_BRIEF" "$BRIEF_PRIOR" \
+        || die "could not preserve task $ID's instructions before recording the progress note"
+      {
+        echo
+        echo "## Progress note ($stamp)"
+        echo
+        echo "This task was relaunched. Continue from here; the local copy and every"
+        echo "uncommitted change are exactly as the previous worker left them."
+        echo
+        printf '%s\n' "$NOTE"
+      } >> "$RELAUNCH_BRIEF" \
+        || die "could not append the progress note to task $ID's instructions"
+      ;;
+  esac
+}
+
+do_relaunch() {
+  local exit_result state note_line
+  local -a spawn_args
+
+  require_state_verified_backend relaunch
+  resolve_relaunch_profile
+
+  case "$KIND" in
+    ship|scout)
+      RELAUNCH_BRIEF="$DATA/$ID/brief.md"
+      [ -f "$RELAUNCH_BRIEF" ] \
+        || die "task $ID has no instructions at $RELAUNCH_BRIEF; refusing to relaunch a worker with nothing to work from"
+      [ "$NOTE_SET" = 1 ] && [ -n "$NOTE" ] \
+        || die "relaunch of a $KIND task requires --note (or --note-file): the replacement worker inherits the local copy but none of the conversation, so it must be told what happened"
+      ;;
+    secondmate)
+      # The charter in the secondmate's own home is its instruction source and
+      # stays untouched.
+      RELAUNCH_BRIEF=
+      ;;
+    *)
+      die "task $ID records kind '$KIND', which has no defined relaunch shape"
+      ;;
+  esac
+
+  if [ -n "$NOTE" ]; then
+    note_line="note_file=$NOTE_FILE"
+  else
+    note_line="note=none"
+  fi
+  safe_checkpoint
+  cp -p "$META" "$META_PRIOR" || die "could not preserve task $ID's durable record before relaunching"
+  RELAUNCH_ACTIVE=1
+  journal_write checkpoint "${CHECKPOINT_LINES[@]}" "$note_line"
+
+  record_note
+  journal_write noted "${CHECKPOINT_LINES[@]}" "$note_line"
+
+  journal_write stopping "${CHECKPOINT_LINES[@]}" "$note_line"
+  exit_result=$(do_exit)
+  journal_write exited "${CHECKPOINT_LINES[@]}" "$note_line" "exit_result=$exit_result"
+
+  # The launch owner (fm-spawn --relaunch) clears the previous incarnation's
+  # per-task harness wiring before arming the new one, so nothing to do here.
+  RELAUNCH_TX="${BASHPID:-$$}.$(date -u +%Y%m%dT%H%M%SZ).$RANDOM"
+  journal_write launching "${CHECKPOINT_LINES[@]}" "$note_line" "relaunch_tx=$RELAUNCH_TX"
+  spawn_args=("$ID" --relaunch --harness "$TARGET_HARNESS")
+  [ "$TARGET_MODEL" = default ] || spawn_args+=(--model "$TARGET_MODEL")
+  [ "$TARGET_EFFORT" = default ] || spawn_args+=(--effort "$TARGET_EFFORT")
+  if FM_CONTROL_RELAUNCH_TX="$RELAUNCH_TX" \
+      "$SCRIPT_DIR/fm-spawn.sh" "${spawn_args[@]}" >/dev/null; then
+    RELAUNCH_META_PUBLISHED=1
+  else
+    [ "$(fm_meta_get "$META" control_relaunch_tx)" != "$RELAUNCH_TX" ] \
+      || RELAUNCH_META_PUBLISHED=1
+    die "the replacement agent for $ID could not be launched on $TARGET_HARNESS"
+  fi
+
+  state=$(wait_agent_state "$LAUNCH_WAIT" alive) || {
+    die "the replacement agent for $ID did not come up within ${LAUNCH_WAIT}s (endpoint reads '$state')"
+  }
+  RELAUNCH_AGENT_CONFIRMED=1
+
+  journal_write complete "${CHECKPOINT_LINES[@]}" "$note_line" "exit_result=$exit_result"
+  RELAUNCH_ACTIVE=0
+  echo "relaunched $ID harness=$TARGET_HARNESS from=$PRIOR_HARNESS model=$TARGET_MODEL effort=$TARGET_EFFORT backend=$BACKEND endpoint=$T worktree=$WT"
+}
+
+# --- verbs ------------------------------------------------------------------
+
+case "$VERB" in
+  interrupt)
+    state=$(agent_state)
+    case "$state" in
+      alive) ;;
+      unverified)
+        # No recovery-grade classifier on this backend. Interrupt is
+        # non-destructive and its endpoint-existence postcondition is still
+        # real, so it proceeds - the printed proof names exactly what was
+        # verified rather than implying more.
+        ;;
+      dead|missing) die "no agent is running at task $ID's recorded endpoint (state: $state); there is nothing to interrupt" ;;
+      *) die "task $ID's endpoint reads '$state' rather than a positively classified state; refusing to send a lifecycle key into an unattributed endpoint" ;;
+    esac
+    proof=$(do_interrupt)
+    echo "interrupted $ID harness=$HARNESS backend=$BACKEND verified=$proof"
+    ;;
+  exit)
+    result=$(do_exit)
+    echo "$result $ID harness=$HARNESS backend=$BACKEND endpoint=$T worktree=$WT"
+    ;;
+  relaunch)
+    do_relaunch
+    ;;
+esac

--- a/bin/fm-control.sh
+++ b/bin/fm-control.sh
@@ -20,13 +20,12 @@
 # NO generic raw-key entry point here; fm-send remains the only way to send an
 # agent something to read.
 #
-#   interrupt  Cancel the running turn with the harness's verified interrupt
-#              key. The agent keeps running. Postcondition: the endpoint still
-#              exists, the agent is still alive where the backend can classify
-#              that, and no stale busy record survives - firstmate records
-#              idle/fm-interrupt against the armed busy generation itself,
-#              because a manual interrupt is not something every harness
-#              reports (Claude fires no hook for one).
+#   interrupt  Deliver the harness's verified interrupt sequence. The agent
+#              keeps running. Postcondition: delivery succeeded, the endpoint
+#              still exists, and the agent is still alive where the backend can
+#              classify that. Cancellation is confirmed only from an adapter-
+#              owned acknowledgement and otherwise reported unconfirmed. Busy
+#              state is never rewritten as proof of the action.
 #   exit       Stop the agent, preserving its terminal endpoint, worktree, and
 #              every uncommitted change. Interrupts first when the task reads
 #              busy, then submits the harness's exit command. Postcondition:
@@ -84,7 +83,7 @@
 #
 # Environment knobs (all bounded waits, seconds):
 #   FM_CONTROL_POLL              poll interval for postcondition waits (0.5)
-#   FM_CONTROL_SETTLE_WAIT       busy->not-busy settle after an interrupt (5)
+#   FM_CONTROL_SETTLE_WAIT       adapter acknowledgement wait after interrupt (5)
 #   FM_CONTROL_EXIT_WAIT         alive->dead wait after the exit command (30)
 #   FM_CONTROL_LAUNCH_WAIT       dead->alive wait after a relaunch (90)
 #   FM_CONTROL_EXIT_RETRIES      Enter retries for the exit command (3)
@@ -358,24 +357,44 @@ send_interrupt_keys() {
     || die "interrupt key $key reached task $ID, but $clear did not, so its composer still holds the cancelled prompt; clear it before the next lifecycle action"
 }
 
-record_interrupt_idle() {
-  # Only a task with an armed busy generation has a record to update. A manual
-  # interrupt is not something every harness reports: Claude fires no lifecycle
-  # hook for one at all, so waiting for an adapter to clear its own busy record
-  # would hang forever on exactly the adapter that needs this most. Firstmate
-  # therefore owns the transition itself through the fm-interrupt source every
-  # converted adapter trusts.
-  [ -f "$STATE/$ID.busy-gen" ] || return 0
-  "$SCRIPT_DIR/fm-busy-event.sh" apply "$STATE" "$ID" idle \
-    --current-gen --source fm-interrupt --event interrupt >/dev/null 2>&1
+prepare_interrupt_ack() {
+  INTERRUPT_ACK_SOURCE=$(fm_control_interrupt_ack_source "$HARNESS")
+  INTERRUPT_ACK_LOG=
+  INTERRUPT_ACK_RUN=
+  case "$INTERRUPT_ACK_SOURCE" in
+    muse-session-terminal)
+      INTERRUPT_ACK_LOG=$(fm_busy_muse_session_log "$STATE" "$ID" 2>/dev/null || true)
+      [ -n "$INTERRUPT_ACK_LOG" ] || return 0
+      INTERRUPT_ACK_RUN=$(fm_busy_muse_active_run_id "$INTERRUPT_ACK_LOG" 2>/dev/null || true)
+      ;;
+  esac
+}
+
+interrupt_cancel_claim() {
+  local elapsed=0 terminal=
+  case "$INTERRUPT_ACK_SOURCE:$INTERRUPT_ACK_RUN" in
+    muse-session-terminal:?*) ;;
+    *) printf 'unconfirmed'; return 0 ;;
+  esac
+  while :; do
+    terminal=$(fm_busy_muse_run_terminal "$INTERRUPT_ACK_LOG" "$INTERRUPT_ACK_RUN" 2>/dev/null || true)
+    case "$terminal" in
+      cancelled) printf 'confirmed'; return 0 ;;
+      ?*) printf 'unconfirmed'; return 0 ;;
+    esac
+    awk -v e="$elapsed" -v t="$SETTLE_WAIT" 'BEGIN{exit !(e < t)}' || break
+    sleep "$POLL"
+    elapsed=$(awk -v e="$elapsed" -v p="$POLL" 'BEGIN{printf "%.3f", e + p}')
+  done
+  printf 'unconfirmed'
 }
 
 # do_interrupt: the shared interrupt action, used by the `interrupt` verb and
-# as `exit`'s busy precondition. Prints the proof it obtained: `agent-alive`
-# when the backend could confirm the agent survived the interrupt, `endpoint`
-# when only the endpoint's existence could be confirmed.
+# as `exit`'s busy precondition. Prints the delivery postcondition followed by
+# the independently observed cancellation claim.
 do_interrupt() {
-  local proof after elapsed
+  local proof after cancel
+  prepare_interrupt_ack
   send_interrupt_keys
   fm_backend_target_exists "$BACKEND" "$T" "$LABEL" \
     || die "task $ID's endpoint disappeared while interrupting it; no further control action is safe"
@@ -388,33 +407,8 @@ do_interrupt() {
       || die "task $ID's agent is '$after' after its interrupt key; an interrupt must leave the agent running"
     proof=agent-alive
   fi
-  record_interrupt_idle \
-    || die "task $ID's interrupt landed, but its armed busy generation could not be recorded idle; refusing to claim the stale record was cleared"
-  # No stale busy record may survive the interrupted turn. After the
-  # firstmate-owned idle event above this is immediate for every adapter with a
-  # semantic source. Grok is the exception: it has no semantic writer yet, so
-  # its verdict comes from a rendered footer that needs a beat to repaint after
-  # the cancel. Give any still-busy verdict that bounded settle rather than
-  # calling a landed interrupt a failure - but keep the failure, because a
-  # verdict that never settles means the interrupt did not take.
-  after=$(busy_verdict)
-  elapsed=0
-  while [ "${after%% *}" = busy ]; do
-    awk -v e="$elapsed" -v t="$SETTLE_WAIT" 'BEGIN{exit !(e < t)}' || break
-    sleep "$POLL"
-    elapsed=$(awk -v e="$elapsed" -v p="$POLL" 'BEGIN{printf "%.3f", e + p}')
-    after=$(busy_verdict)
-  done
-  case "$after" in
-    idle\ *) ;;
-    unknown\ *)
-      [ ! -e "$STATE/$ID.busy-gen" ] && [ ! -e "$STATE/$ID.busy-state" ] \
-        || die "task $ID's busy state is unresolved after its interrupt (${after}); refusing to claim the stale record was cleared"
-      ;;
-    busy\ *) die "task $ID still reads busy ${SETTLE_WAIT}s after its interrupt (${after}); the interrupt did not take" ;;
-    *) die "task $ID's busy state is unresolved after its interrupt (${after}); refusing to claim the stale record was cleared" ;;
-  esac
-  printf '%s' "$proof"
+  cancel=$(interrupt_cancel_claim)
+  printf '%s cancel=%s' "$proof" "$cancel"
 }
 
 # do_exit: stop the running agent, preserving endpoint and worktree. Prints
@@ -432,8 +426,7 @@ do_exit() {
     missing) die "task $ID's recorded endpoint is gone, so there is no agent to stop; reconcile the task before any further control action" ;;
     *) die "task $ID's endpoint reads '$state' rather than a positively classified state; refusing to send a lifecycle command into an unattributed endpoint" ;;
   esac
-  # A busy agent is interrupted first so the exit command reaches an idle
-  # composer instead of being queued behind the running turn.
+  # A busy agent is interrupted first before the exit command is submitted.
   case "$(busy_verdict)" in
     busy*) do_interrupt >/dev/null ;;
   esac
@@ -823,7 +816,7 @@ case "$VERB" in
       *) die "task $ID's endpoint reads '$state' rather than a positively classified state; refusing to send a lifecycle key into an unattributed endpoint" ;;
     esac
     proof=$(do_interrupt)
-    echo "interrupted $ID harness=$HARNESS backend=$BACKEND verified=$proof"
+    echo "interrupt-delivered $ID harness=$HARNESS backend=$BACKEND verified=$proof"
     ;;
   exit)
     result=$(do_exit)

--- a/bin/fm-control.sh
+++ b/bin/fm-control.sh
@@ -37,7 +37,9 @@
 #              of this verb. With no explicit axis, a secondmate re-resolves its
 #              durable config/secondmate-harness pin (harness plus its optional
 #              model and effort tokens) exactly as any other respawn does, while
-#              a ship or scout keeps the harness already recorded for it.
+#              a ship or scout keeps the exact adapter already recorded for it.
+#              A prefixed raw-command basename cannot reconstruct its launch
+#              command, so relaunch requires an explicit --harness for it.
 #              --note is required for a ship or scout, whose replacement
 #              inherits the local copy but none of the conversation; a
 #              secondmate reconciles its own home's records at startup, so its
@@ -414,7 +416,7 @@ do_interrupt() {
 # do_exit: stop the running agent, preserving endpoint and worktree. Prints
 # `already-stopped` or `stopped`.
 do_exit() {
-  local state cmd verdict
+  local state cmd verdict interrupt_result=not-needed
   require_state_verified_backend exit
   state=$(agent_state)
   case "$state" in
@@ -428,7 +430,7 @@ do_exit() {
   esac
   # A busy agent is interrupted first before the exit command is submitted.
   case "$(busy_verdict)" in
-    busy*) do_interrupt >/dev/null ;;
+    busy*) interrupt_result="delivered verified=$(do_interrupt)" ;;
   esac
   cmd=$(fm_control_exit_command "$HARNESS")
   # The submit verdict is NOT the postcondition here: a successful exit command
@@ -442,7 +444,7 @@ do_exit() {
   [ "$verdict" != send-failed ] \
     || die "the exit command could not be sent to task $ID on $BACKEND"
   state=$(wait_agent_state "$EXIT_WAIT" dead) || {
-    die "task $ID's agent was still '$state' ${EXIT_WAIT}s after its exit command; the agent did not stop and nothing was changed"
+    die "exit-delivered $ID interrupt=$interrupt_result exit-command=delivered agent-state=$state exit=unconfirmed; the agent did not stop within ${EXIT_WAIT}s"
   }
   # The incarnation is over: retire its busy wiring so no stale record or
   # orphaned generation survives the agent that produced it.
@@ -574,6 +576,10 @@ resolve_relaunch_profile() {
   PRIOR_EFFORT=$(fm_meta_get "$META" effort)
   [ -n "$PRIOR_MODEL" ] || PRIOR_MODEL=default
   [ -n "$PRIOR_EFFORT" ] || PRIOR_EFFORT=default
+  if [ "$HARNESS_SET" = 0 ] \
+     && [ "$PRIOR_RECORDED_HARNESS" != "$PRIOR_HARNESS" ]; then
+    die "task $ID records harness '$PRIOR_RECORDED_HARNESS', whose original launch command cannot be reconstructed from its recorded basename; relaunching without --harness would substitute the canonical adapter '$PRIOR_HARNESS' for the command actually running. Pass an explicit --harness to choose the replacement runtime deliberately"
+  fi
   CONFIG_HARNESS=
   CONFIG_MODEL=
   CONFIG_EFFORT=

--- a/bin/fm-control.sh
+++ b/bin/fm-control.sh
@@ -286,13 +286,15 @@ fm_backend_validate_task_endpoint "$META" "$ID" || exit 1
 BACKEND=$FM_BACKEND_VALIDATED_BACKEND
 T=$FM_BACKEND_VALIDATED_TARGET
 LABEL="fm-$ID"
-HARNESS=$(fm_meta_get "$META" harness)
+RECORDED_HARNESS=$(fm_meta_get "$META" harness)
 KIND=$(fm_meta_get "$META" kind)
 WT=$(fm_meta_get "$META" worktree)
 [ -n "$KIND" ] || KIND=ship
 
+HARNESS=$(fm_control_harness_family "$RECORDED_HARNESS") \
+  || die "task $ID records harness '${RECORDED_HARNESS:-none}', which has no verified control mechanics; fm-control refuses to guess an interrupt key or exit command"
 fm_control_harness_supported "$HARNESS" \
-  || die "task $ID records harness '${HARNESS:-none}', which has no verified control mechanics; fm-control refuses to guess an interrupt key or exit command"
+  || die "task $ID records harness '${RECORDED_HARNESS:-none}', which has no verified control mechanics; fm-control refuses to guess an interrupt key or exit command"
 
 fm_backend_validate "$BACKEND" || exit 1
 
@@ -475,6 +477,7 @@ RELAUNCH_AGENT_CONFIRMED=0
 RELAUNCH_TX=
 RELAUNCH_BRIEF=
 PRIOR_HARNESS=$HARNESS
+PRIOR_RECORDED_HARNESS=$RECORDED_HARNESS
 CONFIG_HARNESS=
 CONFIG_MODEL=
 CONFIG_EFFORT=
@@ -496,7 +499,7 @@ journal_write() {  # <phase> [extra-line]...
     echo "endpoint=$T"
     echo "worktree=$WT"
     echo "kind=$KIND"
-    echo "from_harness=$PRIOR_HARNESS"
+    echo "from_harness=$PRIOR_RECORDED_HARNESS"
     echo "from_model=$PRIOR_MODEL"
     echo "from_effort=$PRIOR_EFFORT"
     echo "to_harness=$TARGET_HARNESS"
@@ -573,6 +576,7 @@ relaunch_rollback() {
 
 resolve_relaunch_profile() {
   PRIOR_HARNESS=$HARNESS
+  PRIOR_RECORDED_HARNESS=$RECORDED_HARNESS
   PRIOR_MODEL=$(fm_meta_get "$META" model)
   PRIOR_EFFORT=$(fm_meta_get "$META" effort)
   [ -n "$PRIOR_MODEL" ] || PRIOR_MODEL=default
@@ -799,7 +803,7 @@ do_relaunch() {
 
   journal_write complete "${CHECKPOINT_LINES[@]}" "$note_line" "exit_result=$exit_result"
   RELAUNCH_ACTIVE=0
-  echo "relaunched $ID harness=$TARGET_HARNESS from=$PRIOR_HARNESS model=$TARGET_MODEL effort=$TARGET_EFFORT backend=$BACKEND endpoint=$T worktree=$WT"
+  echo "relaunched $ID harness=$TARGET_HARNESS from=$PRIOR_RECORDED_HARNESS model=$TARGET_MODEL effort=$TARGET_EFFORT backend=$BACKEND endpoint=$T worktree=$WT"
 }
 
 # --- verbs ------------------------------------------------------------------

--- a/bin/fm-control.sh
+++ b/bin/fm-control.sh
@@ -391,13 +391,18 @@ interrupt_cancel_claim() {
   printf 'unconfirmed'
 }
 
-# do_interrupt: the shared interrupt action, used by the `interrupt` verb and
-# as `exit`'s busy precondition. Prints the delivery postcondition followed by
-# the independently observed cancellation claim.
-do_interrupt() {
-  local proof after cancel
+# deliver_interrupt: deliver and observe the strongest adapter-owned
+# cancellation claim available after delivery.
+deliver_interrupt() {
+  local cancel
   prepare_interrupt_ack
   send_interrupt_keys
+  cancel=$(interrupt_cancel_claim)
+  printf '%s' "$cancel"
+}
+
+verify_interrupt_running() {
+  local proof after
   fm_backend_target_exists "$BACKEND" "$T" "$LABEL" \
     || die "task $ID's endpoint disappeared while interrupting it; no further control action is safe"
   proof=endpoint
@@ -409,14 +414,26 @@ do_interrupt() {
       || die "task $ID's agent is '$after' after its interrupt key; an interrupt must leave the agent running"
     proof=agent-alive
   fi
-  cancel=$(interrupt_cancel_claim)
+  printf '%s' "$proof"
+}
+
+do_interrupt() {
+  local proof cancel
+  cancel=$(deliver_interrupt) || return $?
+  proof=$(verify_interrupt_running) || return $?
   printf '%s cancel=%s' "$proof" "$cancel"
+}
+
+retire_busy_incarnation() {
+  if [ -f "$STATE/$ID.busy-gen" ]; then
+    "$SCRIPT_DIR/fm-busy-event.sh" retire "$STATE" "$ID" --current-gen >/dev/null 2>&1 || true
+  fi
 }
 
 # do_exit: stop the running agent, preserving endpoint and worktree. Prints
 # `already-stopped` or `stopped`.
 do_exit() {
-  local state cmd verdict interrupt_result=not-needed
+  local state cmd verdict cancel interrupt_result=not-needed
   require_state_verified_backend exit
   state=$(agent_state)
   case "$state" in
@@ -430,7 +447,20 @@ do_exit() {
   esac
   # A busy agent is interrupted first before the exit command is submitted.
   case "$(busy_verdict)" in
-    busy*) interrupt_result="delivered verified=$(do_interrupt)" ;;
+    busy*)
+      cancel=$(deliver_interrupt) || return $?
+      state=$(agent_state)
+      case "$state" in
+        dead)
+          retire_busy_incarnation
+          printf 'stopped'
+          return 0
+          ;;
+        alive) interrupt_result="delivered verified=agent-alive cancel=$cancel" ;;
+        missing) die "task $ID's recorded endpoint disappeared after interrupt delivery, so exit cannot prove whether the agent stopped" ;;
+        *) die "task $ID's endpoint reads '$state' after interrupt delivery rather than a positively classified state; exit cannot prove whether the agent stopped" ;;
+      esac
+      ;;
   esac
   cmd=$(fm_control_exit_command "$HARNESS")
   # The submit verdict is NOT the postcondition here: a successful exit command
@@ -448,9 +478,7 @@ do_exit() {
   }
   # The incarnation is over: retire its busy wiring so no stale record or
   # orphaned generation survives the agent that produced it.
-  if [ -f "$STATE/$ID.busy-gen" ]; then
-    "$SCRIPT_DIR/fm-busy-event.sh" retire "$STATE" "$ID" --current-gen >/dev/null 2>&1 || true
-  fi
+  retire_busy_incarnation
   printf 'stopped'
 }
 

--- a/bin/fm-decision-hold.sh
+++ b/bin/fm-decision-hold.sh
@@ -51,6 +51,19 @@ DATA="${FM_DATA_OVERRIDE:-$FM_HOME/data}"
 # shellcheck source=bin/fm-tasks-axi-lib.sh
 # shellcheck disable=SC1091
 . "$SCRIPT_DIR/fm-tasks-axi-lib.sh"
+# shellcheck source=bin/fm-wake-lib.sh
+# shellcheck disable=SC1091
+. "$SCRIPT_DIR/fm-wake-lib.sh"
+
+DECISION_META_LOCK=
+DECISION_META_LOCK_HELD=0
+decision_hold_cleanup() {
+  if [ "$DECISION_META_LOCK_HELD" = 1 ]; then
+    fm_lock_release "$DECISION_META_LOCK" || true
+    DECISION_META_LOCK_HELD=0
+  fi
+}
+trap decision_hold_cleanup EXIT
 
 usage() {
   awk '
@@ -281,6 +294,12 @@ command_complete() {
   shift
   meta="$STATE/$origin.meta"
   [ -f "$meta" ] && has_meta=1
+  if [ "$has_meta" = 1 ]; then
+    DECISION_META_LOCK=$(fm_meta_lock_path "$meta") || fail "could not resolve task metadata lock"
+    fm_lock_acquire_wait "$DECISION_META_LOCK"
+    DECISION_META_LOCK_HELD=1
+    [ -f "$meta" ] || fail "task metadata disappeared while recording completion"
+  fi
   require_tasks_axi
   origin_exists_here "$origin" || fail "origin $origin is not owned by the active home $FM_HOME"
   if [ "$#" -eq 1 ] && [ "$1" = --none ]; then
@@ -321,6 +340,8 @@ EOF
     if [ "$(meta_value "$meta" decisions_reviewed)" != 1 ] || [ "$previous" != "$keys" ]; then
       printf 'decisions_reviewed=1\ndecision_keys=%s\n' "$keys" >> "$meta"
     fi
+    fm_lock_release "$DECISION_META_LOCK"
+    DECISION_META_LOCK_HELD=0
 
     # Transfer any still-open status decision to its durable backlog owner so the
     # live status fold does not duplicate the same Captain's Call item.

--- a/bin/fm-pr-check.sh
+++ b/bin/fm-pr-check.sh
@@ -15,6 +15,8 @@ STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
 
 # shellcheck source=bin/fm-pr-lib.sh
 . "$SCRIPT_DIR/fm-pr-lib.sh"
+# shellcheck source=bin/fm-wake-lib.sh
+. "$SCRIPT_DIR/fm-wake-lib.sh"
 
 if [ "$#" -ne 2 ]; then
   echo "error: invalid PR check request" >&2
@@ -79,15 +81,26 @@ if [ "$PROVIDER" = github ] && [ -n "$WT" ] && [ -d "$WT" ] && command -v gh >/d
 fi
 
 META_TMP=
+META_LOCK=
+META_LOCK_HELD=0
 pr_check_cleanup() {
   fm_pr_poll_cleanup
   [ -z "$META_TMP" ] || rm -f -- "$META_TMP"
+  if [ "$META_LOCK_HELD" = 1 ]; then
+    fm_lock_release "$META_LOCK" || true
+    META_LOCK_HELD=0
+  fi
 }
 trap pr_check_cleanup EXIT
 trap 'exit 1' HUP INT TERM
 fm_pr_poll_prepare "$STATE" "$ID" "$PROVIDER" "$URL" "$HOST" "$PROJECT_PATH" "$NUMBER" "$SCRIPT_DIR/fm-pr-poll.sh" \
   || { echo "error: could not prepare PR poll" >&2; exit 1; }
 
+META_LOCK=$(fm_meta_lock_path "$META") || exit 1
+fm_lock_acquire_wait "$META_LOCK"
+META_LOCK_HELD=1
+[ -f "$META" ] && [ ! -L "$META" ] && [ "$(fm_pr_file_link_count "$META")" = 1 ] \
+  || { echo "error: task metadata is unavailable" >&2; exit 1; }
 META_DEVICE=$(fm_pr_file_device "$META") || exit 1
 STATE_DEVICE=$(fm_pr_file_device "$STATE") || exit 1
 [ "$META_DEVICE" = "$STATE_DEVICE" ] || { echo "error: task metadata is unavailable" >&2; exit 1; }
@@ -114,6 +127,8 @@ fm_pr_metadata_identity_parse "$META" || exit 1
 [ "$FM_PR_META_PROVIDER" = "$PROVIDER" ] && [ "$FM_PR_META_URL" = "$URL" ] \
   && [ "$FM_PR_META_HOST" = "$HOST" ] && [ "$FM_PR_META_PATH" = "$PROJECT_PATH" ] \
   && [ "$FM_PR_META_NUMBER" = "$NUMBER" ] || exit 1
+fm_lock_release "$META_LOCK"
+META_LOCK_HELD=0
 
 fm_pr_poll_publish_prepared || {
   echo "error: could not publish PR poll" >&2

--- a/bin/fm-promote.sh
+++ b/bin/fm-promote.sh
@@ -20,6 +20,11 @@ FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
 FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
 STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
 
+# shellcheck source=bin/fm-pr-lib.sh
+. "$SCRIPT_DIR/fm-pr-lib.sh"
+# shellcheck source=bin/fm-wake-lib.sh
+. "$SCRIPT_DIR/fm-wake-lib.sh"
+
 MODE=
 YOLO=
 MODE_SET=0
@@ -68,13 +73,42 @@ case "$YOLO" in
   *) echo "error: --yolo must be on or off (got '$YOLO')" >&2; exit 1 ;;
 esac
 
-"$FM_ROOT/bin/fm-guard.sh" || true
 ID=${POS[0]}
+fm_task_id_creation_valid "$ID" || { echo "error: invalid task id" >&2; exit 2; }
+CONTROL_LOCK="$STATE/.control-$ID.lock"
+CONTROL_LOCK_HELD=0
+META_LOCK=
+META_LOCK_HELD=0
+TMP=
+promote_cleanup() {
+  local status=$?
+  [ -z "$TMP" ] || rm -f -- "$TMP" 2>/dev/null || true
+  if [ "$META_LOCK_HELD" = 1 ]; then
+    META_LOCK_HELD=0
+    fm_lock_release "$META_LOCK" || true
+  fi
+  if [ "$CONTROL_LOCK_HELD" = 1 ]; then
+    CONTROL_LOCK_HELD=0
+    fm_lock_release "$CONTROL_LOCK" || true
+  fi
+  return "$status"
+}
+trap promote_cleanup EXIT
+fm_lock_try_acquire "$CONTROL_LOCK" || {
+  echo "error: another lifecycle action is already running for task $ID; nothing was changed" >&2
+  exit 1
+}
+CONTROL_LOCK_HELD=1
+"$FM_ROOT/bin/fm-guard.sh" || true
 META="$STATE/$ID.meta"
+[ -d "$STATE" ] || { echo "error: state dir not found: $STATE" >&2; exit 1; }
+META_LOCK=$(fm_meta_lock_path "$META") || exit 1
+fm_lock_acquire_wait "$META_LOCK"
+META_LOCK_HELD=1
 [ -f "$META" ] || { echo "error: no meta for task $ID at $META" >&2; exit 1; }
 grep -qx 'kind=scout' "$META" || { echo "error: task $ID is not a scout task (kind=scout not in meta)" >&2; exit 1; }
 
-TMP="$META.tmp"
+TMP="$STATE/.$ID.meta.promote.${BASHPID:-$$}"
 grep -v -e '^kind=' -e '^mode=' -e '^yolo=' "$META" > "$TMP"
 {
   echo "kind=ship"
@@ -82,6 +116,9 @@ grep -v -e '^kind=' -e '^mode=' -e '^yolo=' "$META" > "$TMP"
   echo "yolo=$YOLO"
 } >> "$TMP"
 mv "$TMP" "$META"
+TMP=
+fm_lock_release "$META_LOCK"
+META_LOCK_HELD=0
 
 HOME_Q=$(printf '%q' "$FM_HOME")
 echo "promoted $ID to ship mode=$MODE yolo=$YOLO (teardown protection restored)"

--- a/bin/fm-remote-job-lib.sh
+++ b/bin/fm-remote-job-lib.sh
@@ -742,25 +742,36 @@ fm_remote_job_worker_process_group() { # <pid>
 
 # Stop a worker and every descendant it leaked, TERM first and KILL only for a
 # survivor. Signals the isolated worker group when one is provable and the lone
-# process otherwise. Returns non-zero when the worker is still alive afterwards.
+# process otherwise. Returns non-zero when any verified worker-group member is
+# still alive afterwards.
 fm_remote_job_stop_worker_tree() { # <pid>
   local pid=$1 pgid i=0
   case "$pid" in ''|*[!0-9]*) return 1 ;; esac
   [ "$pid" -gt 1 ] || return 1
   pgid=$(fm_remote_job_worker_process_group "$pid" 2>/dev/null || true)
   if [ -n "$pgid" ]; then kill -TERM -- "-$pgid" 2>/dev/null || true; else kill -TERM "$pid" 2>/dev/null || true; fi
-  while kill -0 "$pid" 2>/dev/null && [ "$i" -lt 50 ]; do
+  while { [ -n "$pgid" ] && kill -0 -- "-$pgid" 2>/dev/null || [ -z "$pgid" ] && kill -0 "$pid" 2>/dev/null; } \
+    && [ "$i" -lt 50 ]; do
     i=$((i + 1))
     sleep 0.1
   done
-  kill -0 "$pid" 2>/dev/null || return 0
+  if [ -n "$pgid" ]; then
+    kill -0 -- "-$pgid" 2>/dev/null || return 0
+  else
+    kill -0 "$pid" 2>/dev/null || return 0
+  fi
   if [ -n "$pgid" ]; then kill -KILL -- "-$pgid" 2>/dev/null || true; else kill -KILL "$pid" 2>/dev/null || true; fi
   i=0
-  while kill -0 "$pid" 2>/dev/null && [ "$i" -lt 50 ]; do
+  while { [ -n "$pgid" ] && kill -0 -- "-$pgid" 2>/dev/null || [ -z "$pgid" ] && kill -0 "$pid" 2>/dev/null; } \
+    && [ "$i" -lt 50 ]; do
     i=$((i + 1))
     sleep 0.1
   done
-  ! kill -0 "$pid" 2>/dev/null
+  if [ -n "$pgid" ]; then
+    ! kill -0 -- "-$pgid" 2>/dev/null
+  else
+    ! kill -0 "$pid" 2>/dev/null
+  fi
 }
 
 fm_remote_job_read_single_line() {

--- a/bin/fm-send.sh
+++ b/bin/fm-send.sh
@@ -93,6 +93,8 @@ fi
 
 # shellcheck source=bin/fm-backend.sh
 . "$SCRIPT_DIR/fm-backend.sh"
+# shellcheck source=bin/fm-control-lib.sh
+. "$SCRIPT_DIR/fm-control-lib.sh"
 # shellcheck source=bin/fm-marker-lib.sh
 . "$SCRIPT_DIR/fm-marker-lib.sh"
 # shellcheck source=bin/fm-pending-reply-lib.sh
@@ -118,13 +120,18 @@ fm_send_id_from_meta() {  # <meta-file>
 # it and submits both as one garbled message. Ctrl-U clears the composer
 # (verified), so the interrupt is not complete until it has been sent. A failed
 # clear is loud rather than silent, because the alternative is a corrupted steer.
+# WHICH adapters need that clear, and which key clears them, comes from the one
+# control-plane capability table (bin/fm-control-lib.sh) rather than a second
+# copy here - the same table bin/fm-control.sh's interrupt verb reads.
 fm_send_clear_after_interrupt() {  # <key>
-  local key=$1
+  local key=$1 family clear
   [ "$key" = Escape ] || return 0
-  case "$TARGET_HARNESS" in muse*) : ;; *) return 0 ;; esac
+  family=$(fm_control_harness_family "$TARGET_HARNESS") || return 0
+  clear=$(fm_control_interrupt_clear_key "$family") || return 0
+  [ -n "$clear" ] || return 0
   [ "$TARGET_BACKEND" != remote ] || return 0
-  if ! fm_backend_send_key "$TARGET_BACKEND" "$T" C-u "$EXPECTED_LABEL"; then
-    echo "error: Escape reached $T, but the muse composer could not be cleared; it still holds the restored prompt. Clear it before sending the next message." >&2
+  if ! fm_backend_send_key "$TARGET_BACKEND" "$T" "$clear" "$EXPECTED_LABEL"; then
+    echo "error: Escape reached $T, but the $TARGET_HARNESS composer could not be cleared; it still holds the restored prompt. Clear it before sending the next message." >&2
     return 1
   fi
 }

--- a/bin/fm-send.sh
+++ b/bin/fm-send.sh
@@ -143,26 +143,6 @@ fm_send_normalize_key() {  # <key>
   esac
 }
 
-fm_send_record_interrupt() {  # <key>
-  local key=$1 id gen
-  [ "$key" = Escape ] || return 0
-  case "$TARGET_HARNESS" in claude*) : ;; *) return 0 ;; esac
-  [ -n "$TARGET_META" ] || return 0
-  id=$(fm_send_id_from_meta "$TARGET_META")
-  [ -f "$STATE/$id.busy-gen" ] || return 0
-  gen=$(fm_meta_get "$TARGET_META" busy_gen)
-  if [ -n "$gen" ]; then
-    "$FM_ROOT/bin/fm-busy-event.sh" apply "$STATE" "$id" idle \
-      --gen "$gen" --source fm-interrupt --event interrupt
-  else
-    "$FM_ROOT/bin/fm-busy-event.sh" apply "$STATE" "$id" idle \
-      --current-gen --source fm-interrupt --event interrupt
-  fi || {
-    echo "error: key '$key' reached $T, but the Claude interrupt state could not be recorded for $id" >&2
-    return 1
-  }
-}
-
 fm_send_meta_for_key_value() {  # <state-dir> <key> <value>
   local state=$1 key=$2 value=$3 meta got
   for meta in "$state"/*.meta; do
@@ -422,7 +402,6 @@ if [ "${1:-}" = "--key" ]; then
     exit 1
   fi
   fm_send_clear_after_interrupt "$semantic_key" || exit 1
-  fm_send_record_interrupt "$semantic_key" || exit 1
 else
   MESSAGE=$*
   # The pre-marker answer text, kept for the closing resolved note so the

--- a/bin/fm-send.sh
+++ b/bin/fm-send.sh
@@ -143,6 +143,26 @@ fm_send_normalize_key() {  # <key>
   esac
 }
 
+fm_send_record_interrupt() {  # <key>
+  local key=$1 id gen
+  [ "$key" = Escape ] || return 0
+  case "$TARGET_HARNESS" in claude*) : ;; *) return 0 ;; esac
+  [ -n "$TARGET_META" ] || return 0
+  id=$(fm_send_id_from_meta "$TARGET_META")
+  [ -f "$STATE/$id.busy-gen" ] || return 0
+  gen=$(fm_meta_get "$TARGET_META" busy_gen)
+  if [ -n "$gen" ]; then
+    "$FM_ROOT/bin/fm-busy-event.sh" apply "$STATE" "$id" idle \
+      --gen "$gen" --source fm-interrupt --event interrupt
+  else
+    "$FM_ROOT/bin/fm-busy-event.sh" apply "$STATE" "$id" idle \
+      --current-gen --source fm-interrupt --event interrupt
+  fi || {
+    echo "error: key '$key' reached $T, but the Claude interrupt state could not be recorded for $id" >&2
+    return 1
+  }
+}
+
 fm_send_meta_for_key_value() {  # <state-dir> <key> <value>
   local state=$1 key=$2 value=$3 meta got
   for meta in "$state"/*.meta; do
@@ -402,6 +422,7 @@ if [ "${1:-}" = "--key" ]; then
     exit 1
   fi
   fm_send_clear_after_interrupt "$semantic_key" || exit 1
+  fm_send_record_interrupt "$semantic_key" || exit 1
 else
   MESSAGE=$*
   # The pre-marker answer text, kept for the closing resolved note so the

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -810,6 +810,14 @@ spawn_herdr_presentation_order_lock_acquire() {
 
 clear_relaunch_harness_wiring() {
   local harness=$1 wt=$2 state=$3 id=$4 token_path token auth_path path
+  # The wiring arms above match on harness PREFIXES, because a task launched
+  # from a raw command records that command's basename rather than the exact
+  # adapter name. The retirement tables are keyed by the exact adapter, so the
+  # recorded value is resolved to its adapter first; otherwise a task recorded
+  # as, say, `grok-2` would have wiring armed and never retired. An
+  # unrecognized value resolves to no adapter, which is also the case in which
+  # no wiring was armed to begin with.
+  harness=$(fm_control_harness_family "$harness") || harness=
   token_path=$(fm_control_harness_turnend_token_path "$harness" "$state" "$id") || return 1
   token=
   if [ -n "$token_path" ] && [ -f "$token_path" ]; then

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -2434,7 +2434,7 @@ fi
 preserve_relaunch_meta() {
   awk -F= '
     BEGIN {
-      split("window endpoint_task_id worktree project harness kind mode yolo tasktmp model effort busy_gen backend herdr_session herdr_workspace_id herdr_tab_id herdr_pane_id zellij_session zellij_tab_id zellij_pane_id orca_worktree_id terminal cmux_workspace_id cmux_surface_id home projects control_relaunch_tx", keys, " ")
+      split("window endpoint_task_id worktree project harness kind mode yolo tasktmp model effort busy_gen traceparent backend herdr_session herdr_workspace_id herdr_tab_id herdr_pane_id zellij_session zellij_tab_id zellij_pane_id orca_worktree_id terminal cmux_workspace_id cmux_surface_id home projects control_relaunch_tx", keys, " ")
       for (i in keys) owned[keys[i]] = 1
     }
     !($1 in owned)
@@ -2453,7 +2453,7 @@ preserve_relaunch_meta() {
   echo "model=${MODEL:-default}"
   echo "effort=${EFFORT:-default}"
   [ -z "${BUSY_GEN:-}" ] || echo "busy_gen=$BUSY_GEN"
-  # Default-off writes no traceparent= line (meta stays byte-identical).
+  # Default-off writes no traceparent= line.
   # backend= is written only for a non-default (non-tmux) backend, so the
   # default path's meta stays byte-identical (absent backend= means tmux;
   # data/fm-backend-design-d7's P1 compatibility contract).
@@ -2541,6 +2541,29 @@ if [ "$KIND" = secondmate ]; then
   # injected carrier and this on/off snapshot are guaranteed to agree.
   LAUNCH="FM_ROOT_OVERRIDE= FM_STATE_OVERRIDE= FM_DATA_OVERRIDE= FM_PROJECTS_OVERRIDE= FM_CONFIG_OVERRIDE= FM_PUBLIC_FOLLOWUP_PRIMARY_HOME=$sq_primary_home FM_HOME=$sq_home FM_TRACE_CONTEXT=$SPAWN_TRACE_EFFECTIVE FM_SUPERVISION_MODEL=$supervision_model $LAUNCH"
 fi
+if [ -z "$SPAWN_TRACEPARENT" ] && [ "$RELAUNCH" -eq 1 ]; then
+  LAUNCH="unset TRACEPARENT; $LAUNCH"
+fi
+
+spawn_record_traceparent() {
+  local meta="$STATE/$ID.meta" tmp status=0
+  SPAWN_META_LOCK=$(fm_meta_lock_path "$meta") || return 1
+  fm_lock_acquire_wait "$SPAWN_META_LOCK"
+  SPAWN_META_LOCK_HELD=1
+  SPAWN_META_TMP="$STATE/.$ID.meta.trace.${BASHPID:-$$}"
+  if [ ! -f "$meta" ] || [ ! -w "$meta" ] \
+     || ! awk -F= '$1 != "traceparent"' "$meta" > "$SPAWN_META_TMP" \
+     || ! printf 'traceparent=%s\n' "$SPAWN_TRACEPARENT" >> "$SPAWN_META_TMP" \
+     || ! mv -f "$SPAWN_META_TMP" "$meta"; then
+    status=1
+    rm -f "$SPAWN_META_TMP" 2>/dev/null || true
+  fi
+  SPAWN_META_TMP=
+  fm_lock_release "$SPAWN_META_LOCK" || status=1
+  SPAWN_META_LOCK_HELD=0
+  return "$status"
+}
+
 # Export GOTMPDIR into the crewmate's pane shell so the agent and every child
 # process (go build, go test, ...) inherit it. Sent before the launch command so
 # the env is set when the agent starts; the brief sleep lets the export land.
@@ -2550,7 +2573,7 @@ spawn_send_text_line "$T" "export GOTMPDIR=$TASK_TMP/gotmp"
 # entirely when trace context is off.
 if [ -n "$SPAWN_TRACEPARENT" ]; then
   if spawn_send_text_line "$T" "export TRACEPARENT=$SPAWN_TRACEPARENT"; then
-    if ! echo "traceparent=$SPAWN_TRACEPARENT" >> "$STATE/$ID.meta"; then
+    if ! spawn_record_traceparent; then
       LAUNCH="unset TRACEPARENT; $LAUNCH"
     fi
   else
@@ -2559,6 +2582,7 @@ if [ -n "$SPAWN_TRACEPARENT" ]; then
       echo "error: trace-context input could not be cleared for $W; refusing to append the launch command" >&2
       exit 1
     fi
+    LAUNCH="unset TRACEPARENT; $LAUNCH"
   fi
 fi
 sleep 0.3

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -2170,8 +2170,9 @@ if [ "$KIND" != secondmate ]; then
       # a turn; Stop (normal completion), StopFailure (API-error turn end),
       # and SessionEnd (process shutdown) all close it, so an abnormal end can
       # never leave a stale busy record. Claude fires no hook for a manual
-      # interrupt, so its last adapter-owned busy state remains as observed.
-      # Stop keeps the turn-ended NOTIFICATION touch for the watcher. Every
+      # interrupt: fm-control preserves the adapter-owned state, while the
+      # legacy fm-send --key Escape path records idle/fm-interrupt. Stop keeps
+      # the turn-ended NOTIFICATION touch for the watcher. Every
       # hook command tolerates a refused event (|| true) so a stale-gen writer
       # can never break Claude's own lifecycle.
       mkdir -p "$WT/.claude"

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -95,7 +95,9 @@
 #   focus-sensitive presentation mutation.
 #   Every single-task invocation holds one task-id-scoped lock across backend
 #   creation through metadata publication, so concurrent same-id spawns serialize
-#   even when they select different backends.
+#   even when they select different backends. A fresh spawn first takes the
+#   per-home task-set lock and refuses rather than waits when forced teardown owns
+#   it; relaunch is exempt because the existing task's control lock covers it.
 #   With no harness arg, a crewmate/scout spawn resolves the CREW harness only when
 #   config/crew-dispatch.json is absent. When that file exists, crewmate/scout
 #   spawns require an explicit harness so firstmate cannot silently skip dispatch

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -2170,11 +2170,10 @@ if [ "$KIND" != secondmate ]; then
       # a turn; Stop (normal completion), StopFailure (API-error turn end),
       # and SessionEnd (process shutdown) all close it, so an abnormal end can
       # never leave a stale busy record. Claude fires no hook for a manual
-      # interrupt, so the firstmate-controlled interruption procedure
-      # (harness-adapters) records idle/fm-interrupt itself. Stop keeps the
-      # turn-ended NOTIFICATION touch for the watcher. Every hook command
-      # tolerates a refused event (|| true) so a stale-gen writer can never
-      # break Claude's own lifecycle.
+      # interrupt, so its last adapter-owned busy state remains as observed.
+      # Stop keeps the turn-ended NOTIFICATION touch for the watcher. Every
+      # hook command tolerates a refused event (|| true) so a stale-gen writer
+      # can never break Claude's own lifecycle.
       mkdir -p "$WT/.claude"
       busy_cmd_prefix="$(shell_quote "$FM_ROOT/bin/fm-busy-event.sh") apply $(shell_quote "$STATE_REAL") $(shell_quote "$ID")"
       busy_suffix="--gen $(shell_quote "$BUSY_GEN") --source claude-hook"

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -619,34 +619,7 @@ spawn_remote_secondmate() {
   return 0
 }
 
-# Backend selection (data/fm-backend-design-d7): explicit --backend, else
-# FM_BACKEND env, else config/backend, else runtime auto-detection, else
-# default tmux (fm_backend_name). fm_backend_validate_spawn refuses unknown or
-# non-spawn-capable backends. The resolved value is
-# recorded in meta only when it is NOT tmux (fm-teardown.sh and fm-watch.sh's
-# window_backend/fm_backend_of_meta already treat an absent backend= as tmux),
-# so the default path's meta stays byte-identical.
 BACKEND=
-if [ "$RELAUNCH" -eq 0 ]; then
-  if [ "$BACKEND_SET" -eq 1 ]; then
-    BACKEND=$BACKEND_ARG
-  else
-    BACKEND=$(fm_backend_name)
-  fi
-  fm_backend_validate_spawn "$BACKEND" || exit 1
-  fm_backend_source "$BACKEND" || exit 1
-  if [ "$BACKEND" = orca ] && [ "$KIND" = secondmate ]; then
-    echo "error: backend=orca does not support --secondmate spawns yet" >&2
-    exit 1
-  fi
-  if [ "$BACKEND" = cmux ] && [ "$KIND" = secondmate ]; then
-    echo "error: backend=cmux does not support --secondmate spawns yet" >&2
-    exit 1
-  fi
-  if [ "$BACKEND" = orca ]; then
-    fm_backend_orca_runtime_check || exit 1
-  fi
-fi
 ORCA_ABORT_CLEANUP=0
 ORCA_WORKTREE_ID=
 ORCA_TERMINAL=
@@ -902,6 +875,10 @@ if [ "$RELAUNCH" -eq 1 ]; then
   fi
 fi
 if [ "$RELAUNCH" -eq 0 ]; then
+  mkdir -p "$STATE" || {
+    echo "error: could not create parent state directory" >&2
+    exit 1
+  }
   # A FRESH spawn changes which tasks this home has, so it must not interleave
   # with a forced teardown that has already enumerated that set: a record
   # published inside the enumerate-then-remove window is invisible to the
@@ -934,6 +911,33 @@ if [ "$KIND" = secondmate ]; then
     remote_spawn_rc=$?
   fi
   [ "$remote_spawn_rc" -eq 3 ] || exit "$remote_spawn_rc"
+fi
+# Backend selection (data/fm-backend-design-d7): explicit --backend, else
+# FM_BACKEND env, else config/backend, else runtime auto-detection, else
+# default tmux (fm_backend_name). fm_backend_validate_spawn refuses unknown or
+# non-spawn-capable backends. The resolved value is
+# recorded in meta only when it is NOT tmux (fm-teardown.sh and fm-watch.sh's
+# window_backend/fm_backend_of_meta already treat an absent backend= as tmux),
+# so the default path's meta stays byte-identical.
+if [ "$RELAUNCH" -eq 0 ]; then
+  if [ "$BACKEND_SET" -eq 1 ]; then
+    BACKEND=$BACKEND_ARG
+  else
+    BACKEND=$(fm_backend_name)
+  fi
+  fm_backend_validate_spawn "$BACKEND" || exit 1
+  fm_backend_source "$BACKEND" || exit 1
+  if [ "$BACKEND" = orca ] && [ "$KIND" = secondmate ]; then
+    echo "error: backend=orca does not support --secondmate spawns yet" >&2
+    exit 1
+  fi
+  if [ "$BACKEND" = cmux ] && [ "$KIND" = secondmate ]; then
+    echo "error: backend=cmux does not support --secondmate spawns yet" >&2
+    exit 1
+  fi
+  if [ "$BACKEND" = orca ]; then
+    fm_backend_orca_runtime_check || exit 1
+  fi
 fi
 SPAWN_TASK_LOCK="$STATE/.spawn-$ID.lock"
 if ! fm_lock_try_acquire "$SPAWN_TASK_LOCK"; then

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -670,6 +670,8 @@ SPAWN_META_TMP=
 SPAWN_META_LOCK=
 SPAWN_META_LOCK_HELD=0
 SPAWN_META_PUBLISH_STARTED=0
+SPAWN_TASK_SET_LOCK=
+SPAWN_TASK_SET_LOCK_HELD=0
 RELAUNCH_REPLACEMENT_PENDING=0
 RELAUNCH_REPLACEMENT_BUSY_GEN=
 RELAUNCH_REPLACEMENT_HARNESS=
@@ -774,6 +776,10 @@ spawn_abort_cleanup() {
   if [ "$SPAWN_META_LOCK_HELD" = 1 ]; then
     SPAWN_META_LOCK_HELD=0
     fm_lock_release "$SPAWN_META_LOCK" || true
+  fi
+  if [ "$SPAWN_TASK_SET_LOCK_HELD" = 1 ]; then
+    SPAWN_TASK_SET_LOCK_HELD=0
+    fm_lock_release "$SPAWN_TASK_SET_LOCK" || true
   fi
   if [ "$SPAWN_CONTROL_LOCK_HELD" = 1 ]; then
     SPAWN_CONTROL_LOCK_HELD=0
@@ -899,6 +905,32 @@ if [ "$RELAUNCH" -eq 1 ]; then
     echo "error: another lifecycle action is already running for task $ID" >&2
     exit 1
   fi
+fi
+if [ "$RELAUNCH" -eq 0 ]; then
+  # A FRESH spawn changes which tasks this home has, so it must not interleave
+  # with a forced teardown that has already enumerated that set: a record
+  # published inside the enumerate-then-remove window is invisible to the
+  # teardown's per-task preflight but visible to its cleanup, and gets mutated
+  # while never lifecycle-locked (bin/fm-wake-lib.sh's fm_task_set_lock_path
+  # owns the evidence; bin/fm-teardown.sh holds the same lock from enumeration
+  # through cleanup). Taken before this task's own locks, matching the
+  # acquisition order documented there, and held through publication.
+  #
+  # A relaunch is exempt: it republishes a task that already exists, so it is
+  # already covered by that task's control lock, which the teardown preflight
+  # tests.
+  #
+  # Refusing rather than waiting is the fail-closed direction: the home may be
+  # moments from removal, so there is nothing worth waiting for.
+  SPAWN_TASK_SET_LOCK=$(fm_task_set_lock_path "$STATE") || {
+    echo "error: could not resolve the task-set lock for $STATE" >&2
+    exit 1
+  }
+  if ! fm_lock_try_acquire "$SPAWN_TASK_SET_LOCK"; then
+    echo "error: this home's task set is locked by another operation (a forced teardown is enumerating or removing its tasks); refusing to create task $ID rather than racing it" >&2
+    exit 1
+  fi
+  SPAWN_TASK_SET_LOCK_HELD=1
 fi
 SPAWN_TASK_LOCK="$STATE/.spawn-$ID.lock"
 if ! fm_lock_try_acquire "$SPAWN_TASK_LOCK"; then
@@ -2497,6 +2529,13 @@ if [ "$RELAUNCH" -eq 1 ]; then
   SPAWN_META_TMP=
   fm_lock_release "$SPAWN_META_LOCK"
   SPAWN_META_LOCK_HELD=0
+fi
+if [ "$SPAWN_TASK_SET_LOCK_HELD" = 1 ]; then
+  # The record is published, so this task is now part of the set a teardown
+  # enumerates and locks per task. The set lock is only needed across that
+  # publication.
+  SPAWN_TASK_SET_LOCK_HELD=0
+  fm_lock_release "$SPAWN_TASK_SET_LOCK"
 fi
 [ "$BACKEND" = orca ] && ORCA_ABORT_CLEANUP=0
 

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -16,6 +16,22 @@
 #   loud one-line deviation notice is printed and the spawn continues.
 #   no-mistakes-prod-only is a registry policy rather than a task mode and is
 #   refused as a flag value.
+#        fm-spawn.sh <task-id> --relaunch [--harness <name>] [--model <name>] [--effort <level>]
+#   --relaunch launches a replacement agent for an EXISTING task into that
+#   task's own recorded endpoint and worktree instead of creating either. It is
+#   the launch half of the control plane (bin/fm-control.sh relaunch), which
+#   owns the checkpoint, the progress note, stopping the previous agent, and the
+#   transaction; call fm-control rather than this flag directly unless you are
+#   deliberately re-launching an already-stopped task. Every identity axis -
+#   backend, kind, project or home, worktree, endpoint - comes from the task's
+#   validated state/<id>.meta, so --backend, --scout, --secondmate, a project
+#   positional, and batch pairs are all refused alongside it; only harness,
+#   model, and effort may change, which is what makes a harness switch one
+#   ordinary relaunch. It refuses unless the recorded endpoint is positively
+#   agent-free on a backend with a recovery-grade agent-state classifier (tmux
+#   or herdr), refuses unless the endpoint's shell is sitting in the recorded
+#   worktree, and clears the previous harness's per-task wiring before arming
+#   the new incarnation.
 #   --harness <name> is the explicit per-spawn harness/profile adapter. The old
 #   positional harness arg still works for back-compat.
 #   --model <name> and --effort <low|medium|high|xhigh|max> are concrete profile
@@ -207,6 +223,8 @@ SUB_HOME_MARKER=".fm-secondmate-home"
 . "$SCRIPT_DIR/fm-config-inherit-lib.sh"
 # shellcheck source=bin/fm-backend.sh
 . "$SCRIPT_DIR/fm-backend.sh"
+# shellcheck source=bin/fm-control-lib.sh
+. "$SCRIPT_DIR/fm-control-lib.sh"
 # shellcheck source=bin/fm-gate-refuse-lib.sh
 . "$SCRIPT_DIR/fm-gate-refuse-lib.sh"
 # shellcheck source=bin/fm-busy-lib.sh
@@ -224,6 +242,7 @@ fm_refuse_if_gate_agent
 # set by the batch loop below), so the guard runs once for the batch, not once per pair.
 [ -n "${FM_SPAWN_NO_GUARD:-}" ] || "$FM_ROOT/bin/fm-guard.sh" || true
 KIND=ship
+KIND_SET=0
 HARNESS_ARG=
 MODEL=
 EFFORT=
@@ -238,6 +257,7 @@ BACKEND_SET=0
 MODE_SET=0
 YOLO_SET=0
 TRACEPARENT_SET=0
+RELAUNCH=0
 POS=()
 want_value=
 for a in "$@"; do
@@ -259,8 +279,9 @@ for a in "$@"; do
     continue
   fi
   case "$a" in
-    --scout) KIND=scout ;;
-    --secondmate) KIND=secondmate ;;
+    --scout) KIND=scout; KIND_SET=1 ;;
+    --secondmate) KIND=secondmate; KIND_SET=1 ;;
+    --relaunch) RELAUNCH=1 ;;
     --harness) want_value=harness ;;
     --harness=*) HARNESS_ARG=${a#--harness=}; HARNESS_SET=1 ;;
     --model) want_value=model ;;
@@ -304,39 +325,50 @@ case "$EFFORT" in
   *) echo "error: --effort must be one of low, medium, high, xhigh, max" >&2; exit 1 ;;
 esac
 
-# Delivery contract (AGENTS.md section 7). A ship task's mode and yolo are
-# firstmate's per-task decision, so they are required and closed-set validated
-# here rather than resolved from the project registry. Scouts deliver a report
-# and record no delivery posture; secondmate spawns hardcode theirs.
-if [ "$KIND" = ship ]; then
-  [ "$MODE_SET" -eq 1 ] || {
-    echo "error: ship spawns require --mode <no-mistakes|direct-PR|local-only>; resolve it at intake from the captain's instruction and the project's registered posture in data/projects.md" >&2
-    exit 1
-  }
-  [ "$YOLO_SET" -eq 1 ] || {
-    echo "error: ship spawns require --yolo <on|off>; it is this task's routine approval authority, not a project lookup" >&2
-    exit 1
-  }
-  case "$MODE" in
-    no-mistakes|direct-PR|local-only) ;;
-    no-mistakes-prod-only)
-      echo "error: no-mistakes-prod-only is a registry policy, not a task mode; classify this task's surface and resolve it to no-mistakes or direct-PR at intake" >&2
-      exit 1 ;;
-    *) echo "error: --mode must be one of no-mistakes, direct-PR, local-only (got '$MODE')" >&2; exit 1 ;;
-  esac
-  case "$YOLO" in
-    on|off) ;;
-    *) echo "error: --yolo must be on or off (got '$YOLO')" >&2; exit 1 ;;
-  esac
+# --relaunch reuses an existing task's endpoint, worktree, project, and kind,
+# so every axis this block resolves for a fresh spawn instead comes from that
+# task's own durable record below. Contradicting it on the command line is a
+# refusal rather than a silently-ignored flag.
+if [ "$RELAUNCH" -eq 1 ]; then
+  [ "$BACKEND_SET" -eq 0 ] || { echo "error: --relaunch reuses the task's recorded backend; --backend cannot override it" >&2; exit 1; }
+  [ "$KIND_SET" -eq 0 ] || { echo "error: --relaunch reuses the task's recorded kind; --scout/--secondmate cannot override it" >&2; exit 1; }
+  [ "$MODE_SET" -eq 0 ] || { echo "error: --relaunch reuses the task's recorded delivery mode; --mode cannot override it" >&2; exit 1; }
+  [ "$YOLO_SET" -eq 0 ] || { echo "error: --relaunch reuses the task's recorded yolo posture; --yolo cannot override it" >&2; exit 1; }
 else
-  [ "$MODE_SET" -eq 0 ] || {
-    echo "error: --mode applies only to ship spawns; a scout delivers a report and a secondmate records its own fixed posture" >&2
-    exit 1
-  }
-  [ "$YOLO_SET" -eq 0 ] || {
-    echo "error: --yolo applies only to ship spawns; a scout delivers a report and a secondmate records its own fixed posture" >&2
-    exit 1
-  }
+  # Delivery contract (AGENTS.md section 7). A ship task's mode and yolo are
+  # firstmate's per-task decision, so they are required and closed-set validated
+  # here rather than resolved from the project registry. Scouts deliver a report
+  # and record no delivery posture; secondmate spawns hardcode theirs.
+  if [ "$KIND" = ship ]; then
+    [ "$MODE_SET" -eq 1 ] || {
+      echo "error: ship spawns require --mode <no-mistakes|direct-PR|local-only>; resolve it at intake from the captain's instruction and the project's registered posture in data/projects.md" >&2
+      exit 1
+    }
+    [ "$YOLO_SET" -eq 1 ] || {
+      echo "error: ship spawns require --yolo <on|off>; it is this task's routine approval authority, not a project lookup" >&2
+      exit 1
+    }
+    case "$MODE" in
+      no-mistakes|direct-PR|local-only) ;;
+      no-mistakes-prod-only)
+        echo "error: no-mistakes-prod-only is a registry policy, not a task mode; classify this task's surface and resolve it to no-mistakes or direct-PR at intake" >&2
+        exit 1 ;;
+      *) echo "error: --mode must be one of no-mistakes, direct-PR, local-only (got '$MODE')" >&2; exit 1 ;;
+    esac
+    case "$YOLO" in
+      on|off) ;;
+      *) echo "error: --yolo must be on or off (got '$YOLO')" >&2; exit 1 ;;
+    esac
+  else
+    [ "$MODE_SET" -eq 0 ] || {
+      echo "error: --mode applies only to ship spawns; a scout delivers a report and a secondmate records its own fixed posture" >&2
+      exit 1
+    }
+    [ "$YOLO_SET" -eq 0 ] || {
+      echo "error: --yolo applies only to ship spawns; a scout delivers a report and a secondmate records its own fixed posture" >&2
+      exit 1
+    }
+  fi
 fi
 
 spawn_remote_secondmate() {
@@ -599,23 +631,26 @@ fi
 # recorded in meta only when it is NOT tmux (fm-teardown.sh and fm-watch.sh's
 # window_backend/fm_backend_of_meta already treat an absent backend= as tmux),
 # so the default path's meta stays byte-identical.
-if [ "$BACKEND_SET" -eq 1 ]; then
-  BACKEND=$BACKEND_ARG
-else
-  BACKEND=$(fm_backend_name)
-fi
-fm_backend_validate_spawn "$BACKEND" || exit 1
-fm_backend_source "$BACKEND" || exit 1
-if [ "$BACKEND" = orca ] && [ "$KIND" = secondmate ]; then
-  echo "error: backend=orca does not support --secondmate spawns yet" >&2
-  exit 1
-fi
-if [ "$BACKEND" = cmux ] && [ "$KIND" = secondmate ]; then
-  echo "error: backend=cmux does not support --secondmate spawns yet" >&2
-  exit 1
-fi
-if [ "$BACKEND" = orca ]; then
-  fm_backend_orca_runtime_check || exit 1
+BACKEND=
+if [ "$RELAUNCH" -eq 0 ]; then
+  if [ "$BACKEND_SET" -eq 1 ]; then
+    BACKEND=$BACKEND_ARG
+  else
+    BACKEND=$(fm_backend_name)
+  fi
+  fm_backend_validate_spawn "$BACKEND" || exit 1
+  fm_backend_source "$BACKEND" || exit 1
+  if [ "$BACKEND" = orca ] && [ "$KIND" = secondmate ]; then
+    echo "error: backend=orca does not support --secondmate spawns yet" >&2
+    exit 1
+  fi
+  if [ "$BACKEND" = cmux ] && [ "$KIND" = secondmate ]; then
+    echo "error: backend=cmux does not support --secondmate spawns yet" >&2
+    exit 1
+  fi
+  if [ "$BACKEND" = orca ]; then
+    fm_backend_orca_runtime_check || exit 1
+  fi
 fi
 ORCA_ABORT_CLEANUP=0
 ORCA_WORKTREE_ID=
@@ -628,6 +663,18 @@ HERDR_PRESENTATION_ORDER_LOCK=
 HERDR_PRESENTATION_ORDER_LOCK_HELD=0
 SPAWN_TASK_LOCK=
 SPAWN_TASK_LOCK_HELD=0
+SPAWN_CONTROL_LOCK=
+SPAWN_CONTROL_LOCK_HELD=0
+SPAWN_CONTROL_PARENT=0
+SPAWN_META_TMP=
+SPAWN_META_LOCK=
+SPAWN_META_LOCK_HELD=0
+SPAWN_META_PUBLISH_STARTED=0
+RELAUNCH_REPLACEMENT_PENDING=0
+RELAUNCH_REPLACEMENT_BUSY_GEN=
+RELAUNCH_REPLACEMENT_HARNESS=
+RELAUNCH_REPLACEMENT_STATE=
+RELAUNCH_REPLACEMENT_WT=
 CONFIG_INHERIT_LOCK=
 CONFIG_INHERIT_LOCK_HELD=0
 
@@ -650,6 +697,30 @@ parse_orca_worktree_result() {
 
 spawn_abort_cleanup() {
   local status=$?
+  if [ "$RELAUNCH_REPLACEMENT_PENDING" = 1 ] \
+     && [ "$SPAWN_META_PUBLISH_STARTED" = 1 ] \
+     && [ -n "$SPAWN_META_TMP" ] \
+     && [ ! -e "$SPAWN_META_TMP" ] \
+     && [ ! -L "$SPAWN_META_TMP" ]; then
+    RELAUNCH_REPLACEMENT_PENDING=0
+  fi
+  if [ "$RELAUNCH_REPLACEMENT_PENDING" = 1 ]; then
+    RELAUNCH_REPLACEMENT_PENDING=0
+    if ! clear_relaunch_harness_wiring \
+        "$RELAUNCH_REPLACEMENT_HARNESS" \
+        "$RELAUNCH_REPLACEMENT_WT" \
+        "$RELAUNCH_REPLACEMENT_STATE" \
+        "$ID"; then
+      echo "warning: could not remove replacement wiring after aborted relaunch of $ID" >&2
+    fi
+    if [ -n "$RELAUNCH_REPLACEMENT_BUSY_GEN" ]; then
+      if ! "$FM_ROOT/bin/fm-busy-event.sh" retire \
+          "$RELAUNCH_REPLACEMENT_STATE" "$ID" \
+          --gen "$RELAUNCH_REPLACEMENT_BUSY_GEN"; then
+        echo "warning: could not retire replacement busy generation after aborted relaunch of $ID" >&2
+      fi
+    fi
+  fi
   if [ "$HERDR_PROJECTION_ABORT_CLEANUP" = 1 ] \
      && [ "$HERDR_PRESENTATION_ORDER_LOCK_HELD" != 1 ]; then
     if ! spawn_herdr_presentation_order_lock_acquire "${HERDR_PROJECTION_ABORT_SESSION:-}"; then
@@ -700,6 +771,15 @@ spawn_abort_cleanup() {
     SPAWN_TASK_LOCK_HELD=0
     fm_lock_release "$SPAWN_TASK_LOCK" || true
   fi
+  if [ "$SPAWN_META_LOCK_HELD" = 1 ]; then
+    SPAWN_META_LOCK_HELD=0
+    fm_lock_release "$SPAWN_META_LOCK" || true
+  fi
+  if [ "$SPAWN_CONTROL_LOCK_HELD" = 1 ]; then
+    SPAWN_CONTROL_LOCK_HELD=0
+    fm_lock_release "$SPAWN_CONTROL_LOCK" || true
+  fi
+  [ -z "$SPAWN_META_TMP" ] || rm -f "$SPAWN_META_TMP" 2>/dev/null || true
   if [ "$CONFIG_INHERIT_LOCK_HELD" = 1 ]; then
     CONFIG_INHERIT_LOCK_HELD=0
     fm_lock_release "$CONFIG_INHERIT_LOCK" || true
@@ -728,6 +808,25 @@ spawn_herdr_presentation_order_lock_acquire() {
   return 1
 }
 
+clear_relaunch_harness_wiring() {
+  local harness=$1 wt=$2 state=$3 id=$4 token_path token auth_path path
+  token_path=$(fm_control_harness_turnend_token_path "$harness" "$state" "$id") || return 1
+  token=
+  if [ -n "$token_path" ] && [ -f "$token_path" ]; then
+    IFS= read -r token < "$token_path" || [ -n "$token" ] || return 1
+  fi
+  auth_path=$(fm_control_harness_turnend_auth_path "$harness" "$token") || return 1
+  if [ -n "$auth_path" ]; then
+    rm -f -- "$auth_path" || return 1
+  fi
+  while IFS= read -r path; do
+    [ -n "$path" ] || continue
+    rm -f -- "$path" || return 1
+  done <<EOF
+$(fm_control_harness_wiring_paths "$harness" "$wt" "$state" "$id")
+EOF
+}
+
 spawn_herdr_presentation_order_lock_release() {
   [ "$HERDR_PRESENTATION_ORDER_LOCK_HELD" = 1 ] || return 0
   HERDR_PRESENTATION_ORDER_LOCK_HELD=0
@@ -742,6 +841,10 @@ spawn_herdr_presentation_order_lock_release() {
 # one (task ids are bare slugs), so they fall straight through to the logic below.
 idpart=${POS[0]:-}
 idpart=${idpart%%=*}
+if [ "$RELAUNCH" -eq 1 ] && [ "${#POS[@]}" -gt 0 ] && [ "${POS[0]}" != "$idpart" ]; then
+  echo "error: --relaunch is single-task only; relaunch each task explicitly" >&2
+  exit 1
+fi
 if [ "${#POS[@]}" -gt 0 ] && [ "${POS[0]}" != "$idpart" ] && case "$idpart" in */*) false ;; *) true ;; esac; then
   if [ "$KIND" != secondmate ] && [ -z "$HARNESS_ARG" ] && [ -f "$CONFIG/crew-dispatch.json" ]; then
     echo "error: config/crew-dispatch.json is active - pass an explicit harness resolved from the dispatch rules (the consultation backstop, so the rules are never silently skipped)." >&2
@@ -777,6 +880,18 @@ if [ "${#POS[@]}" -gt 0 ] && [ "${POS[0]}" != "$idpart" ] && case "$idpart" in *
 fi
 ID=${POS[0]}
 fm_task_id_creation_valid "$ID" || { echo "error: invalid task id" >&2; exit 2; }
+if [ "$RELAUNCH" -eq 1 ]; then
+  SPAWN_CONTROL_LOCK="$STATE/.control-$ID.lock"
+  control_owner=$(cat "$SPAWN_CONTROL_LOCK/pid" 2>/dev/null || true)
+  if [ "$control_owner" = "$PPID" ] && fm_pid_alive "$control_owner"; then
+    SPAWN_CONTROL_PARENT=1
+  elif fm_lock_try_acquire "$SPAWN_CONTROL_LOCK"; then
+    SPAWN_CONTROL_LOCK_HELD=1
+  else
+    echo "error: another lifecycle action is already running for task $ID" >&2
+    exit 1
+  fi
+fi
 SPAWN_TASK_LOCK="$STATE/.spawn-$ID.lock"
 if ! fm_lock_try_acquire "$SPAWN_TASK_LOCK"; then
   echo "error: another spawn is already creating task $ID" >&2
@@ -787,7 +902,77 @@ PROJ=
 ARG3=
 FIRSTMATE_HOME=
 
-if [ "$KIND" = secondmate ]; then
+# --relaunch adoption: every identity axis comes from the task's own validated
+# durable record, never from the command line, so a relaunch can only ever
+# re-launch the task it names. The endpoint identity check is the same shared
+# validation teardown uses, so a malformed, ambiguous, or foreign record
+# refuses here exactly as it refuses there.
+RELAUNCH_PRIOR_HARNESS=
+if [ "$RELAUNCH" -eq 1 ]; then
+  [ "${#POS[@]}" -eq 1 ] || {
+    echo "error: --relaunch takes the task id only; its project or home comes from the task's own record" >&2
+    exit 1
+  }
+  RELAUNCH_META="$STATE/$ID.meta"
+  [ -f "$RELAUNCH_META" ] || {
+    echo "error: --relaunch needs an existing task record; no $RELAUNCH_META" >&2
+    exit 1
+  }
+  fm_backend_validate_task_endpoint "$RELAUNCH_META" "$ID" || exit 1
+  BACKEND=$FM_BACKEND_VALIDATED_BACKEND
+  RELAUNCH_TARGET=$FM_BACKEND_VALIDATED_TARGET
+  fm_backend_validate_spawn "$BACKEND" || exit 1
+  fm_backend_source "$BACKEND" || exit 1
+  # A relaunch must PROVE the previous agent is gone before it launches another
+  # one into the same endpoint, and only tmux and herdr have a recovery-grade
+  # classifier that can (bin/fm-control-lib.sh owns that capability table).
+  fm_control_backend_state_verified "$BACKEND" || {
+    echo "error: backend '$BACKEND' has no recovery-grade agent-state classifier, so a relaunch cannot prove the previous agent exited; refusing rather than risking two agents in one endpoint" >&2
+    exit 1
+  }
+  RELAUNCH_STATE=$(fm_backend_agent_state "$BACKEND" "$RELAUNCH_TARGET")
+  [ "$RELAUNCH_STATE" = dead ] || {
+    echo "error: task $ID's endpoint reads '$RELAUNCH_STATE'; a relaunch requires a positively agent-free endpoint (stop the agent first with bin/fm-control.sh $ID exit)" >&2
+    exit 1
+  }
+  RELAUNCH_PRIOR_HARNESS=$(fm_meta_get "$RELAUNCH_META" harness)
+  KIND=$(fm_meta_get "$RELAUNCH_META" kind)
+  [ -n "$KIND" ] || KIND=ship
+  MODE=$(fm_meta_get "$RELAUNCH_META" mode)
+  YOLO=$(fm_meta_get "$RELAUNCH_META" yolo)
+  RELAUNCH_WT=$(fm_meta_get "$RELAUNCH_META" worktree)
+  [ -n "$RELAUNCH_WT" ] && [ -d "$RELAUNCH_WT" ] || {
+    echo "error: task $ID's recorded worktree '${RELAUNCH_WT:-none}' is missing; refusing to relaunch without the local copy its work lives in" >&2
+    exit 1
+  }
+  if [ "$KIND" = secondmate ]; then
+    FIRSTMATE_HOME=$(fm_meta_get "$RELAUNCH_META" home)
+    [ -n "$FIRSTMATE_HOME" ] || FIRSTMATE_HOME=$RELAUNCH_WT
+  else
+    PROJ=$(fm_meta_get "$RELAUNCH_META" project)
+    [ -n "$PROJ" ] || {
+      echo "error: task $ID has no recorded project; refusing to relaunch" >&2
+      exit 1
+    }
+  fi
+  if [ "$BACKEND" = herdr ]; then
+    HERDR_SES=$(fm_meta_get "$RELAUNCH_META" herdr_session)
+    HERDR_WORKSPACE_ID=$(fm_meta_get "$RELAUNCH_META" herdr_workspace_id)
+    HERDR_TAB_ID=$(fm_meta_get "$RELAUNCH_META" herdr_tab_id)
+    HERDR_PANE_ID=$(fm_meta_get "$RELAUNCH_META" herdr_pane_id)
+  fi
+  # With no explicit harness, a relaunch reuses the harness already recorded
+  # for this task. It must NOT fall through to the fresh-spawn config
+  # resolution, which would silently move an existing task onto whatever the
+  # crew or secondmate default currently says. Choosing a different harness is
+  # the caller's explicit decision, made with --harness (bin/fm-control.sh
+  # resolves that decision, including a secondmate's durable pin).
+  ARG3=${HARNESS_ARG:-$RELAUNCH_PRIOR_HARNESS}
+  [ -n "$ARG3" ] || {
+    echo "error: task $ID has no recorded harness; pass --harness to relaunch it" >&2
+    exit 1
+  }
+elif [ "$KIND" = secondmate ]; then
   case "${POS[1]:-}" in
     ''|claude|codex|opencode|pi|pi-signed|grok|kimi|muse)
       ARG3=${POS[1]:-}
@@ -1490,6 +1675,18 @@ herdr_projection_existing_meta_allows_flat() {  # <meta>
 }
 
 W="fm-$ID"
+if [ "$RELAUNCH" -eq 1 ]; then
+  # Adopt the recorded endpoint instead of creating one. This is what keeps a
+  # relaunch a REPLACEMENT rather than a second copy of the task: no new
+  # terminal, no second worktree, and every uncommitted change left exactly
+  # where the previous agent left it.
+  T=$RELAUNCH_TARGET
+  # A secondmate's home already resolved WT above through the same validation a
+  # fresh secondmate spawn uses; every other kind takes the recorded worktree.
+  [ "$KIND" = secondmate ] || WT=$RELAUNCH_WT
+  WT_TARGET=$T
+  SES=${T%%:*}
+else
 case "$BACKEND" in
   tmux)
     SES=$(fm_backend_tmux_container_ensure)
@@ -1720,6 +1917,7 @@ EOF
     T="$ORCA_TERMINAL"
     ;;
 esac
+fi
 if [ "$KIND" = secondmate ]; then
   FM_INHERITABLE_CONFIG=trace-context \
     propagate_inheritable_config "$CONFIG" "$PROJ_ABS/config" \
@@ -1818,7 +2016,24 @@ kimi_spawn_fail() {  # <detail>
   echo "error: $1; inspect window $T" >&2
 }
 
-if [ "$KIND" != secondmate ] && [ "$BACKEND" != orca ]; then
+if [ "$RELAUNCH" -eq 1 ]; then
+  # No worktree is acquired: the recorded one is reused as-is. What must be
+  # proven instead is that the adopted endpoint's shell is actually sitting in
+  # that worktree, so the replacement agent starts where the work is rather
+  # than wherever the pane happened to drift.
+  relaunch_wt_real=$(real_path_or_raw "$WT")
+  relaunch_seen=
+  for _ in $(seq 1 10); do
+    relaunch_seen=$(spawn_current_path "$WT_TARGET" || true)
+    [ -z "$relaunch_seen" ] || [ "$(real_path_or_raw "$relaunch_seen")" != "$relaunch_wt_real" ] || break
+    sleep 0.5
+  done
+  if [ -z "$relaunch_seen" ] || [ "$(real_path_or_raw "$relaunch_seen")" != "$relaunch_wt_real" ]; then
+    echo "error: task $ID's endpoint is in '${relaunch_seen:-unknown}', not its recorded worktree '$WT'; refusing to relaunch an agent outside the copy holding its work" >&2
+    exit 1
+  fi
+  [ "$KIND" = secondmate ] || validate_spawn_worktree "relaunch" "$T"
+elif [ "$KIND" != secondmate ] && [ "$BACKEND" != orca ]; then
   spawn_send_text_line "$WT_TARGET" 'treehouse get'
 
   # Wait for the treehouse subshell: the pane's cwd moves from the project to the worktree.
@@ -1890,6 +2105,21 @@ exclude_path() {
   mkdir -p "$(dirname "$EXCL")"
   grep -qxF "$rel" "$EXCL" 2>/dev/null || echo "$rel" >> "$EXCL"
 }
+if [ "$RELAUNCH" -eq 1 ]; then
+  # Retire the previous incarnation's per-task harness wiring before arming the
+  # new one. Without this, a harness switch would leave the old adapter's hook
+  # files and turn-end token registry entries behind, and even a same-harness
+  # relaunch would orphan the retired busy generation's token
+  # (bin/fm-control-lib.sh owns where those artifacts live).
+  clear_relaunch_harness_wiring "$RELAUNCH_PRIOR_HARNESS" "$WT" "$STATE_REAL" "$ID" || {
+    echo "error: could not retire $RELAUNCH_PRIOR_HARNESS wiring for task $ID; refusing to arm the replacement" >&2
+    exit 1
+  }
+  RELAUNCH_REPLACEMENT_PENDING=1
+  RELAUNCH_REPLACEMENT_HARNESS=$HARNESS
+  RELAUNCH_REPLACEMENT_STATE=$STATE_REAL
+  RELAUNCH_REPLACEMENT_WT=$WT
+fi
 if [ "$KIND" != secondmate ]; then
   # Arm the semantic busy-state contract (bin/fm-busy-lib.sh) for every
   # adapter with a verified semantic source. The launch brief sent below IS a
@@ -1913,6 +2143,7 @@ if [ "$KIND" != secondmate ]; then
         echo "error: failed to arm the busy-state contract for $ID" >&2
         exit 1
       }
+      [ "$RELAUNCH" -ne 1 ] || RELAUNCH_REPLACEMENT_BUSY_GEN=$BUSY_GEN
       ;;
     kimi*)
       # Standalone Kimi stays unknown until fm_busy_kimi_verified opens on a
@@ -2185,6 +2416,23 @@ fi
 
 META_WINDOW=$T
 [ "$BACKEND" = orca ] && META_WINDOW=$W
+SPAWN_META_PATH="$STATE/$ID.meta"
+if [ "$RELAUNCH" -eq 1 ]; then
+  SPAWN_META_LOCK=$(fm_meta_lock_path "$STATE/$ID.meta") || exit 1
+  fm_lock_acquire_wait "$SPAWN_META_LOCK"
+  SPAWN_META_LOCK_HELD=1
+  SPAWN_META_TMP="$STATE/.$ID.meta.relaunch.${BASHPID:-$$}"
+  SPAWN_META_PATH=$SPAWN_META_TMP
+fi
+preserve_relaunch_meta() {
+  awk -F= '
+    BEGIN {
+      split("window endpoint_task_id worktree project harness kind mode yolo tasktmp model effort busy_gen backend herdr_session herdr_workspace_id herdr_tab_id herdr_pane_id zellij_session zellij_tab_id zellij_pane_id orca_worktree_id terminal cmux_workspace_id cmux_surface_id home projects control_relaunch_tx", keys, " ")
+      for (i in keys) owned[keys[i]] = 1
+    }
+    !($1 in owned)
+  ' "$RELAUNCH_META"
+}
 {
   echo "window=$META_WINDOW"
   echo "endpoint_task_id=$ID"
@@ -2226,7 +2474,22 @@ META_WINDOW=$T
     echo "home=$PROJ_ABS"
     echo "projects=$SECONDMATE_PROJECTS"
   fi
-} > "$STATE/$ID.meta"
+  if [ "$RELAUNCH" -eq 1 ]; then
+    preserve_relaunch_meta
+  fi
+  if [ "$SPAWN_CONTROL_PARENT" = 1 ] && [ -n "${FM_CONTROL_RELAUNCH_TX:-}" ]; then
+    echo "control_relaunch_tx=$FM_CONTROL_RELAUNCH_TX"
+  fi
+} > "$SPAWN_META_PATH"
+if [ "$RELAUNCH" -eq 1 ]; then
+  SPAWN_META_PUBLISH_STARTED=1
+  mv -f "$SPAWN_META_TMP" "$STATE/$ID.meta"
+  RELAUNCH_REPLACEMENT_PENDING=0
+  SPAWN_META_PUBLISH_STARTED=0
+  SPAWN_META_TMP=
+  fm_lock_release "$SPAWN_META_LOCK"
+  SPAWN_META_LOCK_HELD=0
+fi
 [ "$BACKEND" = orca ] && ORCA_ABORT_CLEANUP=0
 
 sq_brief=$(shell_quote "$BRIEF")

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -604,6 +604,10 @@ spawn_remote_secondmate() {
     [ -z "$remote_recorded_traceparent" ] || echo "traceparent=$remote_recorded_traceparent"
   } > "$tmp"
   mv -f -- "$tmp" "$meta"
+  if [ "$SPAWN_TASK_SET_LOCK_HELD" = 1 ]; then
+    SPAWN_TASK_SET_LOCK_HELD=0
+    fm_lock_release "$SPAWN_TASK_SET_LOCK"
+  fi
   fm_lock_release "$remote_lock" || true
   fm_lock_release "$registry_lock" || true
   fm_lock_release "$SPAWN_TASK_LOCK" || true
@@ -614,15 +618,6 @@ spawn_remote_secondmate() {
   echo "spawned $id harness=$harness kind=secondmate mode=secondmate yolo=off window=remote:$id worktree=$home remote=$host backend=$remote_backend"
   return 0
 }
-
-if [ "$KIND" = secondmate ]; then
-  if spawn_remote_secondmate "${POS[0]:-}"; then
-    exit 0
-  else
-    remote_spawn_rc=$?
-  fi
-  [ "$remote_spawn_rc" -eq 3 ] || exit "$remote_spawn_rc"
-fi
 
 # Backend selection (data/fm-backend-design-d7): explicit --backend, else
 # FM_BACKEND env, else config/backend, else runtime auto-detection, else
@@ -931,6 +926,14 @@ if [ "$RELAUNCH" -eq 0 ]; then
     exit 1
   fi
   SPAWN_TASK_SET_LOCK_HELD=1
+fi
+if [ "$KIND" = secondmate ]; then
+  if spawn_remote_secondmate "$ID"; then
+    exit 0
+  else
+    remote_spawn_rc=$?
+  fi
+  [ "$remote_spawn_rc" -eq 3 ] || exit "$remote_spawn_rc"
 fi
 SPAWN_TASK_LOCK="$STATE/.spawn-$ID.lock"
 if ! fm_lock_try_acquire "$SPAWN_TASK_LOCK"; then

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -1890,7 +1890,22 @@ collect_descendant_task_locks() {
   local home=$1 sub_state child_meta child_id child_kind child_wt child_home task_set_lock
   local -a child_ids
   sub_state="$home/state"
-  [ -d "$sub_state" ] || return 0
+  if [ -L "$sub_state" ]; then
+    echo "REFUSED: secondmate home $home has a symbolic-link state path at $sub_state; forced teardown changed nothing" >&2
+    return 1
+  fi
+  if [ -e "$sub_state" ] && [ ! -d "$sub_state" ]; then
+    echo "REFUSED: secondmate home $home has a non-directory state path at $sub_state; forced teardown changed nothing" >&2
+    return 1
+  fi
+  if ! mkdir -p -- "$sub_state"; then
+    echo "REFUSED: secondmate home $home state directory could not be established at $sub_state; forced teardown changed nothing" >&2
+    return 1
+  fi
+  if [ -L "$sub_state" ] || [ ! -d "$sub_state" ]; then
+    echo "REFUSED: secondmate home $home state path is not a safe directory at $sub_state; forced teardown changed nothing" >&2
+    return 1
+  fi
   # Freeze this home's task SET before reading it. Everything below locks the
   # tasks that exist right now, but the later cleanup re-enumerates, so without
   # this a fresh spawn could publish a record into the gap and be mutated

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -176,11 +176,20 @@ CONTROL_LOCK="$STATE/.control-$ID.lock"
 CONTROL_LOCK_HELD=0
 META_LOCK=
 META_LOCK_HELD=0
+DESCENDANT_LOCK_PATHS=()
+DESCENDANT_TASK_STATES=()
+DESCENDANT_TASK_IDS=()
+DESCENDANT_TASK_KINDS=()
+DESCENDANT_TASK_HOMES=()
 teardown_release_locks() {
-  local status=$?
+  local status=$? i
   if declare -F teardown_release_herdr_locks >/dev/null 2>&1; then
     teardown_release_herdr_locks || true
   fi
+  for ((i=${#DESCENDANT_LOCK_PATHS[@]} - 1; i >= 0; i--)); do
+    fm_lock_release "${DESCENDANT_LOCK_PATHS[$i]}" || true
+  done
+  DESCENDANT_LOCK_PATHS=()
   if [ "$META_LOCK_HELD" = 1 ]; then
     fm_lock_release "$META_LOCK" || true
     META_LOCK_HELD=0
@@ -1877,6 +1886,88 @@ preflight_firstmate_home_process_event_tree() {
   preflight_firstmate_home_process_events "$home" "$label"
 }
 
+collect_descendant_task_locks() {
+  local home=$1 sub_state child_meta child_id child_kind child_wt child_home
+  local -a child_ids
+  sub_state="$home/state"
+  [ -d "$sub_state" ] || return 0
+  child_ids=()
+  for child_meta in "$sub_state"/*.meta; do
+    [ -e "$child_meta" ] || continue
+    child_ids+=("$(basename "$child_meta" .meta)")
+  done
+  [ "${#child_ids[@]}" -gt 0 ] || return 0
+  while IFS= read -r child_id; do
+    child_meta="$sub_state/$child_id.meta"
+    child_kind=$(meta_value "$child_meta" kind)
+    [ -n "$child_kind" ] || child_kind=ship
+    child_home=
+    if [ "$child_kind" = secondmate ]; then
+      child_wt=$(meta_value "$child_meta" worktree)
+      child_home=$(meta_value "$child_meta" home)
+      [ -n "$child_home" ] || child_home=$child_wt
+    fi
+    DESCENDANT_TASK_STATES+=("$sub_state")
+    DESCENDANT_TASK_IDS+=("$child_id")
+    DESCENDANT_TASK_KINDS+=("$child_kind")
+    DESCENDANT_TASK_HOMES+=("$child_home")
+    [ "$child_kind" != secondmate ] \
+      || collect_descendant_task_locks "$child_home" \
+      || return 1
+  done < <(printf '%s\n' "${child_ids[@]}" | LC_ALL=C sort)
+}
+
+preflight_descendant_task_locks() {
+  local home=$1 i state task_id meta control_lock meta_lock kind child_wt child_home
+  DESCENDANT_TASK_STATES=()
+  DESCENDANT_TASK_IDS=()
+  DESCENDANT_TASK_KINDS=()
+  DESCENDANT_TASK_HOMES=()
+  collect_descendant_task_locks "$home" || return 1
+  # Tasks are acquired in parent-before-child preorder, sorted by id within
+  # each home. Each control lock precedes its matching metadata lock, and no
+  # child lock holder reaches back for a parent lock, so acquisition cannot cycle.
+  for ((i=0; i < ${#DESCENDANT_TASK_IDS[@]}; i++)); do
+    state=${DESCENDANT_TASK_STATES[$i]}
+    task_id=${DESCENDANT_TASK_IDS[$i]}
+    meta="$state/$task_id.meta"
+    control_lock="$state/.control-$task_id.lock"
+    meta_lock=$(fm_meta_lock_path "$meta") || {
+      echo "REFUSED: descendant task $task_id has an invalid metadata lock path; forced teardown changed nothing" >&2
+      return 1
+    }
+    if ! fm_lock_try_acquire "$control_lock"; then
+      echo "REFUSED: descendant task $task_id has a lifecycle action in flight (control lock is held); forced teardown changed nothing" >&2
+      return 1
+    fi
+    DESCENDANT_LOCK_PATHS+=("$control_lock")
+    if ! fm_lock_try_acquire "$meta_lock"; then
+      echo "REFUSED: descendant task $task_id has a metadata update in flight (metadata lock is held); forced teardown changed nothing" >&2
+      return 1
+    fi
+    DESCENDANT_LOCK_PATHS+=("$meta_lock")
+    [ -f "$meta" ] || {
+      echo "REFUSED: descendant task $task_id changed while forced teardown acquired its locks; forced teardown changed nothing" >&2
+      return 1
+    }
+    kind=$(meta_value "$meta" kind)
+    [ -n "$kind" ] || kind=ship
+    [ "$kind" = "${DESCENDANT_TASK_KINDS[$i]}" ] || {
+      echo "REFUSED: descendant task $task_id changed kind while forced teardown acquired its locks; forced teardown changed nothing" >&2
+      return 1
+    }
+    if [ "$kind" = secondmate ]; then
+      child_wt=$(meta_value "$meta" worktree)
+      child_home=$(meta_value "$meta" home)
+      [ -n "$child_home" ] || child_home=$child_wt
+      [ "$child_home" = "${DESCENDANT_TASK_HOMES[$i]}" ] || {
+        echo "REFUSED: descendant task $task_id changed home while forced teardown acquired its locks; forced teardown changed nothing" >&2
+        return 1
+      }
+    fi
+  done
+}
+
 validate_firstmate_home_children_removal() {
   local home=$1 sub_state child_meta child_id child_wt child_proj child_kind child_home child_backend child_orca_worktree_id
   sub_state="$home/state"
@@ -2153,6 +2244,8 @@ if [ "$KIND" = secondmate ]; then
   [ -n "$HOME_PATH" ] || HOME_PATH=$WT
   validate_firstmate_home_for_removal "$HOME_PATH" "secondmate home" "$ID" >/dev/null || exit 1
   if [ "$FORCE" = "--force" ]; then
+    validate_firstmate_home_children_removal "$HOME_PATH" || exit 1
+    preflight_descendant_task_locks "$HOME_PATH" || exit 1
     validate_firstmate_home_children_removal "$HOME_PATH" || exit 1
     if [ "$BACKEND" = herdr ]; then
       teardown_herdr_preflight_target "$T" "$ID" || exit 1

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -1887,10 +1887,25 @@ preflight_firstmate_home_process_event_tree() {
 }
 
 collect_descendant_task_locks() {
-  local home=$1 sub_state child_meta child_id child_kind child_wt child_home
+  local home=$1 sub_state child_meta child_id child_kind child_wt child_home task_set_lock
   local -a child_ids
   sub_state="$home/state"
   [ -d "$sub_state" ] || return 0
+  # Freeze this home's task SET before reading it. Everything below locks the
+  # tasks that exist right now, but the later cleanup re-enumerates, so without
+  # this a fresh spawn could publish a record into the gap and be mutated
+  # without ever having been lifecycle-locked (bin/fm-wake-lib.sh's
+  # fm_task_set_lock_path owns why). Taken per home, parent before child, and
+  # held until this teardown exits.
+  task_set_lock=$(fm_task_set_lock_path "$sub_state") || {
+    echo "REFUSED: secondmate home $home has an invalid task-set lock path; forced teardown changed nothing" >&2
+    return 1
+  }
+  if ! fm_lock_try_acquire "$task_set_lock"; then
+    echo "REFUSED: secondmate home $home is publishing a task right now (task-set lock is held); forced teardown changed nothing" >&2
+    return 1
+  fi
+  DESCENDANT_LOCK_PATHS+=("$task_set_lock")
   child_ids=()
   for child_meta in "$sub_state"/*.meta; do
     [ -e "$child_meta" ] || continue
@@ -1924,9 +1939,13 @@ preflight_descendant_task_locks() {
   DESCENDANT_TASK_KINDS=()
   DESCENDANT_TASK_HOMES=()
   collect_descendant_task_locks "$home" || return 1
-  # Tasks are acquired in parent-before-child preorder, sorted by id within
-  # each home. Each control lock precedes its matching metadata lock, and no
-  # child lock holder reaches back for a parent lock, so acquisition cannot cycle.
+  # Acquisition order, which every other holder of these locks must match so
+  # they cannot cycle: each home's task-set lock first (parent home before child
+  # home, during collection above), then per-task locks in that same
+  # parent-before-child preorder, sorted by id within each home, each control
+  # lock before its matching metadata lock. No child lock holder ever reaches
+  # back for a parent lock. bin/fm-spawn.sh takes the same task-set lock before
+  # its own per-task locks when it publishes a fresh record.
   for ((i=0; i < ${#DESCENDANT_TASK_IDS[@]}; i++)); do
     state=${DESCENDANT_TASK_STATES[$i]}
     task_id=${DESCENDANT_TASK_IDS[$i]}

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -146,6 +146,8 @@ SUB_HOME_PARENT_MARKER=".fm-secondmate-parent"
 . "$SCRIPT_DIR/fm-tasks-axi-lib.sh"
 # shellcheck source=bin/fm-backend.sh
 . "$SCRIPT_DIR/fm-backend.sh"
+# shellcheck source=bin/fm-control-lib.sh
+. "$SCRIPT_DIR/fm-control-lib.sh"
 # shellcheck source=bin/fm-lock-lib.sh
 . "$SCRIPT_DIR/fm-lock-lib.sh"
 # shellcheck source=bin/fm-gate-refuse-lib.sh
@@ -168,12 +170,43 @@ if [ "$#" -lt 1 ] || ! fm_task_id_path_safe "$1"; then
 fi
 ID=$1
 FORCE=${2:-}
+# shellcheck source=bin/fm-wake-lib.sh
+. "$SCRIPT_DIR/fm-wake-lib.sh"
+CONTROL_LOCK="$STATE/.control-$ID.lock"
+CONTROL_LOCK_HELD=0
+META_LOCK=
+META_LOCK_HELD=0
+teardown_release_locks() {
+  local status=$?
+  if declare -F teardown_release_herdr_locks >/dev/null 2>&1; then
+    teardown_release_herdr_locks || true
+  fi
+  if [ "$META_LOCK_HELD" = 1 ]; then
+    fm_lock_release "$META_LOCK" || true
+    META_LOCK_HELD=0
+  fi
+  if [ "$CONTROL_LOCK_HELD" = 1 ]; then
+    fm_lock_release "$CONTROL_LOCK" || true
+    CONTROL_LOCK_HELD=0
+  fi
+  return "$status"
+}
+trap teardown_release_locks EXIT
+fm_lock_try_acquire "$CONTROL_LOCK" || {
+  echo "error: another lifecycle action is already running for task $ID; nothing was changed" >&2
+  exit 1
+}
+CONTROL_LOCK_HELD=1
 # Fail closed before any fleet mutation: a no-mistakes gate agent must never tear
 # down a worktree (see bin/fm-gate-refuse-lib.sh).
 fm_refuse_if_gate_agent
 FM_LOCK_LOG_PREFIX=teardown
 
 META="$STATE/$ID.meta"
+[ -f "$META" ] || { echo "error: no meta for task $ID at $META" >&2; exit 1; }
+META_LOCK=$(fm_meta_lock_path "$META") || exit 1
+fm_lock_acquire_wait "$META_LOCK"
+META_LOCK_HELD=1
 [ -f "$META" ] || { echo "error: no meta for task $ID at $META" >&2; exit 1; }
 
 REMOTE_HANDOFF_DIR_PRESENT=0
@@ -597,20 +630,29 @@ if [ "$BACKEND" = orca ] && [ "$KIND" != secondmate ]; then
   [ -z "$T_ORCA" ] || T=$T_ORCA
 fi
 
+# Where a harness's firstmate-owned global turn-end registry entry lives is
+# owned by bin/fm-control-lib.sh, so teardown and the control plane's relaunch
+# retire the same artifact rather than each carrying its own copy of the path.
 remove_grok_turnend_auth() {
-  local state_dir=$1 id=$2 token hooks_dir
-  token=$(cat "$state_dir/$id.grok-turnend-token" 2>/dev/null || true)
-  case "$token" in ''|*[!A-Za-z0-9._-]*) return 0 ;; esac
-  hooks_dir="${GROK_HOME:-$HOME/.grok}/hooks/fm-turn-end.d"
-  rm -f "$hooks_dir/$token"
+  local state_dir=$1 id=$2 token_path token='' path
+  token_path=$(fm_control_harness_turnend_token_path grok "$state_dir" "$id") || return 1
+  if [ -n "$token_path" ] && [ -f "$token_path" ]; then
+    IFS= read -r token < "$token_path" || [ -n "$token" ] || return 1
+  fi
+  path=$(fm_control_harness_turnend_auth_path grok "$token") || return 1
+  [ -n "$path" ] || return 0
+  rm -f -- "$path"
 }
 
 remove_kimi_turnend_auth() {
-  local state_dir=$1 id=$2 token hooks_dir
-  token=$(cat "$state_dir/$id.kimi-turnend-token" 2>/dev/null || true)
-  case "$token" in ''|*[!A-Za-z0-9._-]*) return 0 ;; esac
-  hooks_dir="$HOME/.kimi-code/fm-turn-end.d"
-  rm -f "$hooks_dir/$token"
+  local state_dir=$1 id=$2 token_path token='' path
+  token_path=$(fm_control_harness_turnend_token_path kimi "$state_dir" "$id") || return 1
+  if [ -n "$token_path" ] && [ -f "$token_path" ]; then
+    IFS= read -r token < "$token_path" || [ -n "$token" ] || return 1
+  fi
+  path=$(fm_control_harness_turnend_auth_path kimi "$token") || return 1
+  [ -n "$path" ] || return 0
+  rm -f -- "$path"
 }
 
 retire_busy_state() {
@@ -1969,7 +2011,6 @@ $session	$lock_path"
       else
         TEARDOWN_HERDR_LOCK_RECORDS="$session	$lock_path"
       fi
-      trap teardown_release_herdr_locks EXIT
       return 0
     fi
     sleep 0.1
@@ -2079,8 +2120,8 @@ cleanup_firstmate_home_children() {
         safe_rm_rf_child_worktree "$child_wt" "$child_proj"
       fi
     fi
-    remove_grok_turnend_auth "$sub_state" "$child_id"
-    remove_kimi_turnend_auth "$sub_state" "$child_id"
+    remove_grok_turnend_auth "$sub_state" "$child_id" || return 1
+    remove_kimi_turnend_auth "$sub_state" "$child_id" || return 1
     remove_pr_poll_artifacts "$sub_state" "$child_id" || return 1
     child_busy_gen=$(meta_value "$child_meta" busy_gen)
     if [ -z "$child_busy_gen" ]; then
@@ -2355,8 +2396,8 @@ if [ "$KIND" = secondmate ]; then
   remove_firstmate_home "$HOME_PATH" "secondmate home" "$ID" || exit $?
   remove_secondmate_registry_entry "$ID"
 fi
-remove_grok_turnend_auth "$STATE" "$ID"
-remove_kimi_turnend_auth "$STATE" "$ID"
+remove_grok_turnend_auth "$STATE" "$ID" || exit 1
+remove_kimi_turnend_auth "$STATE" "$ID" || exit 1
 fm_backend_clear_transition "$BACKEND" "$STATE" "$T" || true
 # Remove the per-task temp root (/tmp/fm-<id>/, incl. its gotmp/) recorded by spawn.
 # Read before the state-file rm below; empty (pre-fix tasks without tasktmp=) is a no-op.
@@ -2367,7 +2408,11 @@ rm -f "$STATE/$ID.status" "$STATE/$ID.turn-ended" "$STATE/$ID.meta" \
   "$STATE/$ID.pi-ext.ts" "$STATE/$ID.grok-turnend-token" \
   "$STATE/$ID.kimi-turnend-token" "$STATE/$ID.muse-session" \
   "$STATE/$ID.muse-session-current" \
-  "$STATE/.$ID.open-decisions-cursor"
+  "$STATE/.$ID.open-decisions-cursor" \
+  "$STATE/$ID.control-relaunch" "$STATE/$ID.control-relaunch.meta-prior" \
+  "$STATE/$ID.control-relaunch.brief-prior" "$STATE/$ID.control-relaunch.note"
+fm_lock_release "$META_LOCK"
+META_LOCK_HELD=0
 if [ "$KIND" != scout ] && [ "$KIND" != secondmate ] && [ "$MODE" != local-only ]; then
   "$FM_ROOT/bin/fm-fleet-sync.sh" "$PROJ" || true
 fi

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -47,9 +47,11 @@
 # if Herdr's last-pane cleanup focuses an unrelated neighboring workspace.
 # Secondmates (kind=secondmate in meta) are retired explicitly. Normal
 # teardown refuses while their home has in-flight crewmate meta files; --force
-# is the approved discard path that prevalidates child removal targets, discards
-# child work, kills child runtime endpoints, and removes the retired home. Removing a
-# leased home releases its durable treehouse lease so the pool slot is freed,
+# is the approved discard path that prevalidates child removal targets, locks each
+# descendant home's task set before enumeration, and holds those locks through
+# child cleanup. Contention refuses the complete forced teardown before child
+# mutation. It then discards child work, kills child runtime endpoints, and removes
+# the retired home. Removing a leased home releases its durable treehouse lease so the pool slot is freed,
 # never left leased forever. If the treehouse return fails, teardown leaves the
 # leased home and state in place instead of hiding a still-held lease.
 # Usage: fm-teardown.sh <task-id> [--force]

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -160,7 +160,8 @@ family_for_basename() {
     fm-backend-herdr-launcher-workspace-e2e.test.sh|\
     fm-backend-herdr-prune-safety-e2e.test.sh|fm-backend-herdr-respawn-idem-e2e.test.sh|\
     fm-herdr-session-cleanup-e2e.test.sh|\
-    fm-backend-herdr-smoke.test.sh|fm-backend-herdr-workspace-per-home-e2e.test.sh)
+    fm-backend-herdr-smoke.test.sh|fm-backend-herdr-workspace-per-home-e2e.test.sh|\
+    fm-control-herdr-smoke.test.sh)
       printf '%s\n' real-herdr-gated
       ;;
     fm-backlog-handoff.test.sh|fm-on.test.sh|fm-remote-backlog-handoff.test.sh|\
@@ -190,6 +191,7 @@ family_for_basename() {
       ;;
     fm-backend-herdr.test.sh|fm-backend-tmux-smoke.test.sh|fm-backend.test.sh|\
     fm-tmux-agent-liveness.test.sh|\
+    fm-control.test.sh|fm-control-relaunch.test.sh|\
     fm-herdr-session-cleanup.test.sh|fm-send-resolve-key.test.sh|fm-send-strict.test.sh|fm-spawn-batch.test.sh|\
     fm-spawn-dispatch-profile.test.sh|\
     fm-trace-context-spawn.test.sh|fm-spawn-worktree-settle.test.sh|\

--- a/bin/fm-wake-lib.sh
+++ b/bin/fm-wake-lib.sh
@@ -478,6 +478,21 @@ fm_lock_release() {
   rmdir "$lockdir" 2>/dev/null || true
 }
 
+fm_meta_lock_path() {
+  local meta=$1 dir base id
+  dir=${meta%/*}
+  base=${meta##*/}
+  [ "$dir" != "$meta" ] || dir=.
+  case "$base" in
+    *.meta) id=${base%.meta} ;;
+    *) return 1 ;;
+  esac
+  case "$id" in
+    ''|*[!A-Za-z0-9._-]*) return 1 ;;
+  esac
+  printf '%s/.meta-%s.lock\n' "$dir" "$id"
+}
+
 fm_failure_episode_reset() {
   local state=$1 mode=${2:-acquire} lock current pid acquired=0 path
   lock="$state/.turnend-claude-blocks.lock"

--- a/bin/fm-wake-lib.sh
+++ b/bin/fm-wake-lib.sh
@@ -493,6 +493,27 @@ fm_meta_lock_path() {
   printf '%s/.meta-%s.lock\n' "$dir" "$id"
 }
 
+# fm_task_set_lock_path: the per-home lock guarding WHICH tasks exist in a home,
+# as opposed to fm_meta_lock_path, which guards one task's record.
+#
+# A per-task lock cannot protect a task that does not exist yet. Forced
+# secondmate teardown enumerates a home's task set, locks what it found, and
+# then re-enumerates while removing; a fresh spawn publishing a record inside
+# that window is invisible to the first enumeration and visible to the second,
+# so it gets destructively processed while never lifecycle-locked (reproduced
+# with real agents: a record published 0.249s after teardown began was removed
+# and its worktree returned to the pool, with both commands reporting success).
+# Holding this lock from enumeration through cleanup makes the two operations
+# serialize: either the spawn publishes first and the teardown's preflight
+# covers it, or the teardown owns the set and the spawn refuses. Both directions
+# fail closed.
+fm_task_set_lock_path() {  # <state-dir>
+  local state=$1
+  [ -n "$state" ] || return 1
+  case "$state" in *[$'\n\r\t']*) return 1 ;; esac
+  printf '%s/.task-set.lock\n' "$state"
+}
+
 fm_failure_episode_reset() {
   local state=$1 mode=${2:-acquire} lock current pid acquired=0 path
   lock="$state/.turnend-claude-blocks.lock"

--- a/bin/fm-x-followup.sh
+++ b/bin/fm-x-followup.sh
@@ -68,6 +68,8 @@ FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
 STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
 # shellcheck source=bin/fm-x-lib.sh
 . "$SCRIPT_DIR/fm-x-lib.sh"
+# shellcheck source=bin/fm-wake-lib.sh
+. "$SCRIPT_DIR/fm-wake-lib.sh"
 
 usage() {
   echo "usage: fm-x-followup.sh --check <task-id> | --clear <task-id> | <task-id> [--image <path>] [--final] --text-file <path> | <task-id> [--image <path>] [--final] -" >&2

--- a/bin/fm-x-lib.sh
+++ b/bin/fm-x-lib.sh
@@ -936,37 +936,45 @@ fmx_meta_tmp() {
 # budget against a binding the relay already knows about. Returns non-zero if
 # <meta> is missing or the rewrite fails.
 fmx_meta_link_set() {
-  local meta=$1 rid=$2 ts=$3 followups=${4:-0} platform=${5:-} reply_max=${6:-} tmp
+  local meta=$1 rid=$2 ts=$3 followups=${4:-0} platform=${5:-} reply_max=${6:-} tmp lock
   [ -f "$meta" ] || return 1
-  tmp=$(fmx_meta_tmp "$meta") || return 1
+  lock=$(fm_meta_lock_path "$meta") || return 1
+  fm_lock_acquire_wait "$lock"
+  [ -f "$meta" ] || { fm_lock_release "$lock"; return 1; }
+  tmp=$(fmx_meta_tmp "$meta") || { fm_lock_release "$lock"; return 1; }
   if ! { grep -vE '^x_request=|^x_request_ts=|^x_followups=|^x_platform=|^x_reply_max_chars=' "$meta" || true; } > "$tmp"; then
-    rm -f "$tmp"; return 1
+    rm -f "$tmp"; fm_lock_release "$lock"; return 1
   fi
-  printf 'x_request=%s\n' "$rid" >> "$tmp" || { rm -f "$tmp"; return 1; }
-  printf 'x_request_ts=%s\n' "$ts" >> "$tmp" || { rm -f "$tmp"; return 1; }
-  printf 'x_followups=%s\n' "$followups" >> "$tmp" || { rm -f "$tmp"; return 1; }
+  printf 'x_request=%s\n' "$rid" >> "$tmp" || { rm -f "$tmp"; fm_lock_release "$lock"; return 1; }
+  printf 'x_request_ts=%s\n' "$ts" >> "$tmp" || { rm -f "$tmp"; fm_lock_release "$lock"; return 1; }
+  printf 'x_followups=%s\n' "$followups" >> "$tmp" || { rm -f "$tmp"; fm_lock_release "$lock"; return 1; }
   if [ -n "$platform" ]; then
-    printf 'x_platform=%s\n' "$platform" >> "$tmp" || { rm -f "$tmp"; return 1; }
+    printf 'x_platform=%s\n' "$platform" >> "$tmp" || { rm -f "$tmp"; fm_lock_release "$lock"; return 1; }
   fi
   case "$reply_max" in
     ''|*[!0-9]*) ;;
-    *) printf 'x_reply_max_chars=%s\n' "$reply_max" >> "$tmp" || { rm -f "$tmp"; return 1; } ;;
+    *) printf 'x_reply_max_chars=%s\n' "$reply_max" >> "$tmp" || { rm -f "$tmp"; fm_lock_release "$lock"; return 1; } ;;
   esac
-  mv -f "$tmp" "$meta" || { rm -f "$tmp"; return 1; }
+  mv -f "$tmp" "$meta" || { rm -f "$tmp"; fm_lock_release "$lock"; return 1; }
+  fm_lock_release "$lock"
 }
 
 # fmx_meta_followups_set <meta> <n>: atomically rewrite just the x_followups
 # line, preserving every other meta line including link and reply context.
 # Returns non-zero if <meta> is missing or the rewrite fails.
 fmx_meta_followups_set() {
-  local meta=$1 n=$2 tmp
+  local meta=$1 n=$2 tmp lock
   [ -f "$meta" ] || return 1
-  tmp=$(fmx_meta_tmp "$meta") || return 1
+  lock=$(fm_meta_lock_path "$meta") || return 1
+  fm_lock_acquire_wait "$lock"
+  [ -f "$meta" ] || { fm_lock_release "$lock"; return 1; }
+  tmp=$(fmx_meta_tmp "$meta") || { fm_lock_release "$lock"; return 1; }
   if ! { grep -vE '^x_followups=' "$meta" || true; } > "$tmp"; then
-    rm -f "$tmp"; return 1
+    rm -f "$tmp"; fm_lock_release "$lock"; return 1
   fi
-  printf 'x_followups=%s\n' "$n" >> "$tmp" || { rm -f "$tmp"; return 1; }
-  mv -f "$tmp" "$meta" || { rm -f "$tmp"; return 1; }
+  printf 'x_followups=%s\n' "$n" >> "$tmp" || { rm -f "$tmp"; fm_lock_release "$lock"; return 1; }
+  mv -f "$tmp" "$meta" || { rm -f "$tmp"; fm_lock_release "$lock"; return 1; }
+  fm_lock_release "$lock"
 }
 
 # fmx_meta_link_clear <meta>: atomically remove the x_request/x_request_ts/
@@ -974,11 +982,15 @@ fmx_meta_followups_set() {
 # succeeds whether or not a link is present, and is a no-op when <meta> is
 # missing.
 fmx_meta_link_clear() {
-  local meta=$1 tmp
+  local meta=$1 tmp lock
   [ -f "$meta" ] || return 0
-  tmp=$(fmx_meta_tmp "$meta") || return 1
+  lock=$(fm_meta_lock_path "$meta") || return 1
+  fm_lock_acquire_wait "$lock"
+  [ -f "$meta" ] || { fm_lock_release "$lock"; return 0; }
+  tmp=$(fmx_meta_tmp "$meta") || { fm_lock_release "$lock"; return 1; }
   if ! { grep -vE '^x_request=|^x_request_ts=|^x_followups=|^x_platform=|^x_reply_max_chars=' "$meta" || true; } > "$tmp"; then
-    rm -f "$tmp"; return 1
+    rm -f "$tmp"; fm_lock_release "$lock"; return 1
   fi
-  mv -f "$tmp" "$meta" || { rm -f "$tmp"; return 1; }
+  mv -f "$tmp" "$meta" || { rm -f "$tmp"; fm_lock_release "$lock"; return 1; }
+  fm_lock_release "$lock"
 }

--- a/bin/fm-x-link.sh
+++ b/bin/fm-x-link.sh
@@ -43,6 +43,8 @@ FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
 STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
 # shellcheck source=bin/fm-x-lib.sh
 . "$SCRIPT_DIR/fm-x-lib.sh"
+# shellcheck source=bin/fm-wake-lib.sh
+. "$SCRIPT_DIR/fm-wake-lib.sh"
 # shellcheck source=bin/fm-pr-lib.sh
 . "$SCRIPT_DIR/fm-pr-lib.sh"
 

--- a/docs/agent-control.md
+++ b/docs/agent-control.md
@@ -32,8 +32,9 @@ A recorded `harness=` is not always an exact adapter name: a task launched from 
 | --- | --- | --- |
 | `interrupt` | Deliver the harness's verified interrupt sequence while leaving the agent running. | Delivery succeeds while the endpoint still exists and the agent is still alive where the backend can classify that; cancellation is confirmed only from an adapter-owned acknowledgement and otherwise reports `cancel=unconfirmed`. |
 | `exit` | Stop the agent, preserving the endpoint, the worktree, and every uncommitted change. | The backend's recovery-grade classifier reports the agent gone. Already-stopped is idempotent success. |
-| `relaunch` | Replace the running agent with a new one in the same endpoint and worktree, on the same or a newly chosen harness, model, and effort. | The new agent is alive on the recorded endpoint, and the durable record names the harness that is actually running. |
+| `relaunch` | Replace the running agent with a new one in the same endpoint and worktree, on the exact recorded adapter or an explicitly chosen harness, model, and effort. | The new agent is alive on the recorded endpoint, and the durable record names the harness that is actually running. |
 
+An exit that delivers lifecycle input but cannot prove the agent stopped fails with `exit=unconfirmed`, reports the observed agent state and any interrupt cancellation claim, and never claims that nothing changed.
 Interrupt never rewrites busy state as proof of its own success.
 Claude exposes no lifecycle acknowledgement for a manual interrupt, so delivery succeeds with `cancel=unconfirmed` and its adapter-owned busy state remains as observed.
 muse's session log records `terminal=cancelled` for the interrupted run, so the control plane reports `cancel=confirmed` only after observing that exact acknowledgement.
@@ -58,6 +59,7 @@ It is not deterministic across the verified adapters: codex and grok resume only
    An explicit `--harness`, `--model`, or `--effort` wins.
    Otherwise a `kind=secondmate` task re-resolves its durable `config/secondmate-harness` pin, including that file's optional model and effort tokens, exactly as every other respawn does - so setting the pin and relaunching is the ordinary way to move a secondmate's runtime.
    A ship or scout keeps the harness already recorded for it, because that harness comes from firstmate's dispatch-profile judgment at intake and must not be silently re-read from configuration.
+   A recorded raw-command basename that differs from its resolved adapter cannot reproduce the command actually running, so relaunch refuses before the checkpoint unless the caller passes an explicit `--harness` to choose the replacement runtime deliberately.
    A harness change resets model and effort unless they are named too, because a model chosen for one adapter does not transfer to another.
 2. **Safe checkpoint.**
    The recorded worktree must exist and be a worktree root; its head and dirty state are recorded.
@@ -87,6 +89,7 @@ Switching harness is therefore one ordinary relaunch rather than a separate mech
   Its agent runs on another host, so none of the postconditions this plane verifies could be read for it here; local endpoint validation would refuse the record regardless, because `window=remote:<id>` can never match a local backend's required shape.
   Drive that lifecycle on its own host and reconcile it through the secondmate recovery path.
 - An unverified harness is refused rather than guessed at.
+- An implicit relaunch from a prefixed raw-command basename is refused before the agent or durable state is touched because its original launch command cannot be reconstructed.
 - An adapter that is not verified for this task's kind is refused **before** the running agent is stopped, not after.
   muse is a crewmate and scout adapter only, so relaunching a secondmate onto it refuses while its agent is still up rather than leaving that secondmate with no agent when the launch owner refuses.
 - A backend that cannot deliver the harness's interrupt key, or the composer clear that key needs, is refused rather than sent a different key.

--- a/docs/agent-control.md
+++ b/docs/agent-control.md
@@ -30,11 +30,13 @@ A recorded `harness=` is not always an exact adapter name: a task launched from 
 
 | Verb | Effect | Postcondition |
 | --- | --- | --- |
-| `interrupt` | Cancel the running turn. The agent keeps running. | The endpoint still exists, the agent is still alive where the backend can classify that, and no stale busy record survives. |
+| `interrupt` | Deliver the harness's verified interrupt sequence while leaving the agent running. | Delivery succeeds while the endpoint still exists and the agent is still alive where the backend can classify that; cancellation is confirmed only from an adapter-owned acknowledgement and otherwise reports `cancel=unconfirmed`. |
 | `exit` | Stop the agent, preserving the endpoint, the worktree, and every uncommitted change. | The backend's recovery-grade classifier reports the agent gone. Already-stopped is idempotent success. |
 | `relaunch` | Replace the running agent with a new one in the same endpoint and worktree, on the same or a newly chosen harness, model, and effort. | The new agent is alive on the recorded endpoint, and the durable record names the harness that is actually running. |
 
-Firstmate records the interrupt's `idle`/`fm-interrupt` busy event itself rather than waiting for the harness to report one, because a manual interrupt is not something every harness reports: Claude fires no lifecycle hook for one at all, so waiting would hang forever on exactly the adapter that needs the control plane most.
+Interrupt never rewrites busy state as proof of its own success.
+Claude exposes no lifecycle acknowledgement for a manual interrupt, so delivery succeeds with `cancel=unconfirmed` and its adapter-owned busy state remains as observed.
+muse's session log records `terminal=cancelled` for the interrupted run, so the control plane reports `cancel=confirmed` only after observing that exact acknowledgement.
 
 An interrupt is not complete until the composer is empty.
 muse is the one verified adapter that restores the cancelled prompt back into its composer as real text, so its interrupt key is followed by a Ctrl+U clear; without it the next submitted line - including this plane's own exit command - would concatenate onto the restored prompt and submit both as one line.

--- a/docs/agent-control.md
+++ b/docs/agent-control.md
@@ -1,0 +1,117 @@
+# Agent lifecycle control plane
+
+Firstmate talks to a running agent two ways, and they are not the same channel.
+
+The **data plane** is [`bin/fm-send.sh`](../bin/fm-send.sh): conversational text for the agent to read.
+For a `kind=secondmate` target it always prepends the from-firstmate routing marker, because a secondmate is itself a firstmate and its reply must come back through the status path rather than a chat nobody reads.
+
+The **control plane** is [`bin/fm-control.sh`](../bin/fm-control.sh): allowlisted lifecycle verbs addressed to an exact task id.
+
+The split exists because the data plane's marking is exactly right for a message and exactly wrong for a lifecycle command.
+A routing-marked `/quit` arrives as ordinary chat - `[fm-from-firstmate] /quit` - which the agent reasons about instead of executing.
+The failure repeated across harnesses and homes, and the workaround (remember to use an unmarked send for agent-control commands, and improvise the right key or command per harness) lived only in agent prose, so it failed again every time a session did not happen to recall it.
+
+## What the control plane owns
+
+`bin/fm-control-lib.sh` is the single executable owner of three capability tables, with no side effects, so it can be read as a contract:
+
+- The **verb allowlist**: `interrupt`, `exit`, `relaunch`.
+  There is no arbitrary-text and no generic raw-key entry point.
+  A caller either names an allowlisted verb or is refused.
+- **Per-harness mechanics**: the key that cancels a running turn, how many times it must be delivered, whether the composer needs clearing afterwards, the command that exits the agent, and which task kinds the adapter is verified to run.
+  These were previously carried only in the [`harness-adapters`](../.agents/skills/harness-adapters/SKILL.md) skill's per-adapter tables, which now point here.
+  `bin/fm-send.sh`'s `--key` path reads the composer-clear table from this owner too, rather than keeping a second copy of it.
+- **Per-backend capability**: which named keys a runtime backend can deliver, and whether it has a recovery-grade agent-state classifier able to prove an agent stopped.
+
+A recorded `harness=` is not always an exact adapter name: a task launched from a raw command records that command's basename instead.
+`fm_control_harness_family` is the one place that prefix rule is stated, and an unrecognized value resolves to no adapter rather than being guessed into one.
+
+## Verbs
+
+| Verb | Effect | Postcondition |
+| --- | --- | --- |
+| `interrupt` | Cancel the running turn. The agent keeps running. | The endpoint still exists, the agent is still alive where the backend can classify that, and no stale busy record survives. |
+| `exit` | Stop the agent, preserving the endpoint, the worktree, and every uncommitted change. | The backend's recovery-grade classifier reports the agent gone. Already-stopped is idempotent success. |
+| `relaunch` | Replace the running agent with a new one in the same endpoint and worktree, on the same or a newly chosen harness, model, and effort. | The new agent is alive on the recorded endpoint, and the durable record names the harness that is actually running. |
+
+Firstmate records the interrupt's `idle`/`fm-interrupt` busy event itself rather than waiting for the harness to report one, because a manual interrupt is not something every harness reports: Claude fires no lifecycle hook for one at all, so waiting would hang forever on exactly the adapter that needs the control plane most.
+
+An interrupt is not complete until the composer is empty.
+muse is the one verified adapter that restores the cancelled prompt back into its composer as real text, so its interrupt key is followed by a Ctrl+U clear; without it the next submitted line - including this plane's own exit command - would concatenate onto the restored prompt and submit both as one line.
+The clear is refused before anything is sent when the recorded backend cannot deliver it.
+
+**Teardown and discard are not verbs and will not become verbs.**
+`exit` stops an agent and preserves everything else.
+Removing a worktree, closing an endpoint, or discarding work stays with [`bin/fm-teardown.sh`](../bin/fm-teardown.sh), which owns the landed-work test.
+
+**`resume` is not a verb.**
+It is not deterministic across the verified adapters: codex and grok resume only from a session id printed at exit, opencode continues the most recent session for the cwd, and claude, pi, pi-signed, and kimi have no verified pane-resume contract.
+`relaunch` covers the same need on every adapter, because the brief on disk - not a harness-private session - is the durable instruction.
+
+## Transactional relaunch
+
+`relaunch` is the only verb that changes durable records, so it runs as a transaction with a journal at `state/<id>.control-relaunch`, the prior record preserved beside it, and a ship or scout's prior instructions preserved when a progress note is appended.
+
+1. **Resolve the profile.**
+   An explicit `--harness`, `--model`, or `--effort` wins.
+   Otherwise a `kind=secondmate` task re-resolves its durable `config/secondmate-harness` pin, including that file's optional model and effort tokens, exactly as every other respawn does - so setting the pin and relaunching is the ordinary way to move a secondmate's runtime.
+   A ship or scout keeps the harness already recorded for it, because that harness comes from firstmate's dispatch-profile judgment at intake and must not be silently re-read from configuration.
+   A harness change resets model and effort unless they are named too, because a model chosen for one adapter does not transfer to another.
+2. **Safe checkpoint.**
+   The recorded worktree must exist and be a worktree root; its head and dirty state are recorded.
+   For a `kind=secondmate` task, the home's identity marker must match and its child records must be readable, so a relaunch can never strand child work behind an unreadable home.
+   A secondmate's own crewmates run in their own endpoints and outlive its relaunch; the relaunched secondmate reconciles them from its home's durable records at startup.
+3. **Record the note.**
+   A ship or scout relaunch requires `--note`, because the replacement inherits the local copy but none of the conversation; the note is appended to the instructions it reads.
+   A secondmate relaunch does not require one and never rewrites its standing charter.
+4. **Stop the old agent** through the `exit` verb, with its postcondition.
+5. **Launch the replacement** through its single owner, `bin/fm-spawn.sh --relaunch`, which adopts the recorded endpoint and worktree instead of creating either, clears the previous harness's per-task wiring, and arms a fresh busy generation.
+
+Switching harness is therefore one ordinary relaunch rather than a separate mechanism.
+
+### Failure and rollback
+
+- A refusal **before** the agent is stopped leaves the durable record and the instructions byte-identical.
+- A launch failure **after** the agent is stopped restores the prior durable record, keeps the progress note so a later recovery still has it, marks the journal `failed:launching`, and reports plainly that no agent is running and where the work is preserved.
+- If the launch owner already published the new record but no running agent can be confirmed, the new record is kept: the task is recorded on the new harness with no agent confirmed, which is exactly what recovery reconciles.
+  Rewriting it back to the old harness would be a second, worse inaccuracy.
+
+## Fail-closed boundaries
+
+- Targeting is exact.
+  Only a bare task id with a `state/<id>.meta` record in this home is accepted, and that record must pass the shared endpoint-identity validation.
+  A legacy `fm-<id>` window label, an explicit `session:window` endpoint, and a record whose `endpoint_task_id` names another task are all refused.
+- A remotely placed secondmate is refused by name.
+  Its agent runs on another host, so none of the postconditions this plane verifies could be read for it here; local endpoint validation would refuse the record regardless, because `window=remote:<id>` can never match a local backend's required shape.
+  Drive that lifecycle on its own host and reconcile it through the secondmate recovery path.
+- An unverified harness is refused rather than guessed at.
+- An adapter that is not verified for this task's kind is refused **before** the running agent is stopped, not after.
+  muse is a crewmate and scout adapter only, so relaunching a secondmate onto it refuses while its agent is still up rather than leaving that secondmate with no agent when the launch owner refuses.
+- A backend that cannot deliver the harness's interrupt key, or the composer clear that key needs, is refused rather than sent a different key.
+  Orca's terminal API exposes only an interrupt and an Enter, so it can deliver neither Escape nor Ctrl+U.
+- `exit` and `relaunch` require a backend with a recovery-grade agent-state classifier - tmux and herdr - because without one the "the agent stopped" postcondition cannot be proven.
+  zellij, orca, and cmux are refused rather than reported as successful blind.
+- An ambiguous or unreadable endpoint state refuses.
+  Only a positively classified state acts.
+- `fm-spawn --relaunch` independently refuses unless the recorded endpoint is positively agent-free and its shell is sitting in the recorded worktree, so a replacement can never join a live agent or start outside the copy holding the work.
+
+## Capability matrix
+
+Backend capability comes from each adapter's real surface, not from a policy choice.
+
+| Backend | Escape | Enter | Ctrl+C | Ctrl+U | Recovery-grade agent state |
+| --- | --- | --- | --- | --- | --- |
+| tmux | yes | yes | yes | yes | yes |
+| herdr | yes | yes | yes | yes | yes |
+| zellij | yes | yes | yes | yes | no |
+| cmux | yes | yes | yes | yes | no |
+| orca | no | yes | yes | no | no |
+
+Per-harness interrupt keys, repeat counts, composer clears, exit commands, and supported task kinds live in `bin/fm-control-lib.sh` and are exercised for every verified harness by `tests/fm-control.test.sh`.
+The empirical basis for each adapter's value is the `harness-adapters` skill's verification record for that adapter.
+
+## Verification
+
+- `tests/fm-control.test.sh` - the adapter contract for every verified harness, the backend capability matrix, exact-id scoping, the closed verb list, the busy, idle, dead, and idempotent lifecycle cases, and marker non-regression, all against a stubbed session provider.
+- `tests/fm-control-relaunch.test.sh` - the relaunch transaction: identity preservation, harness switching, the progress note, checkpoint refusals, and rollback after a failed launch.
+- `tests/fm-control-herdr-smoke.test.sh` - the second state-verified backend against the real herdr binary, on an isolated throwaway lab session.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -89,6 +89,11 @@ Stalled escalation delivery writes `state/.subsuper-inject-wedged` and attempts 
 On an unmarked return, `bin/fm-afk-return.sh` owns ordered shutdown, durable catch-up evidence, and the fail-closed gate that keeps ordinary work behind every live firstmate-actionable blocker.
 `fm-send.sh` selects a pre-Enter popup-settle for slash commands and for codex `$...` skill invocations using metadata-routed target `harness=` values, then adds its own `FM_SEND_SETTLE` pause after successful text sends so immediate peeks catch the receiving turn starting; the sub-supervisor uses only the shared submit core and does not pay that post-submit pause.
 
+Text for a worker to read and commands that drive a worker's process are separate planes.
+`fm-send.sh` is the data plane and always routing-marks a `kind=secondmate` target, which is right for a message and wrong for a lifecycle command, because a marked exit command arrives as chat the agent reasons about instead of executing.
+`bin/fm-control.sh` is the control plane: an allowlisted `interrupt`, `exit`, and transactional `relaunch` addressed to an exact task id, with per-harness mechanics owned by `bin/fm-control-lib.sh`, a verified postcondition per verb, and no arbitrary-text or raw-key entry point.
+[`docs/agent-control.md`](agent-control.md) owns the verb contract, the capability matrix, the relaunch transaction, and the fail-closed boundaries.
+
 ## Busy state is semantic, per adapter
 
 `bin/fm-busy-lib.sh` is the single owner of what "this worker is busy" means, and `bin/fm-busy-event.sh` is the only writer of the per-task records it reads.
@@ -152,7 +157,7 @@ Ship briefs also tell the crewmate to verify `pwd -P` and `git rev-parse --show-
 
 Firstmate's own no-mistakes gate runs agents inside a checkout that also contains the fleet-captain identity in `AGENTS.md`, so gate execution needs an authority boundary separate from ordinary crewmate worktree isolation.
 The tracked `.no-mistakes.yaml` sets `disable_project_settings: true`; no-mistakes honors that setting only from the trusted default-branch copy, so a pushed branch cannot enable its own project instructions during validation.
-Independently, `fm-spawn.sh`, `fm-send.sh`, and `fm-teardown.sh` source `bin/fm-gate-refuse-lib.sh` and exit with status 3 before fleet mutation when the gate environment marker is present or the current checkout matches the default no-mistakes gate-repository topology.
+Independently, `fm-spawn.sh`, `fm-send.sh`, `fm-control.sh`, and `fm-teardown.sh` source `bin/fm-gate-refuse-lib.sh` and exit with status 3 before fleet mutation when the gate environment marker is present or the current checkout matches the default no-mistakes gate-repository topology.
 A normal primary checkout or crewmate worktree has neither signal and remains unaffected.
 The helper's header owns the exact signal detection, relocated-home limitation, test-harness bypass, and relationship to no-mistakes' HEAD-continuity guard.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -210,7 +210,8 @@ claude, codex, opencode, pi, pi-signed, grok, and kimi are empirically verified 
 muse is verified for crewmate and scout launches ONLY, and `fm-spawn.sh` refuses it for a secondmate, because muse ships no usable hook surface for a primary session's turn-end supervision; [`docs/verification/muse.md`](verification/muse.md) owns that evidence.
 muse also needs a worker-reachable credential before spawning, and the portable fleet path is the `<config>/muse/auth.json` credential stored by `muse login`, because a caller-only `META_API_KEY` does not cross a long-lived backend daemon.
 New harnesses get verified through a supervised trial task before joining the set.
-The verified adapter knowledge - each harness's busy-state source, interrupt and exit commands, skill-invocation syntax, and per-harness quirks - lives in [`.agents/skills/harness-adapters/SKILL.md`](../.agents/skills/harness-adapters/SKILL.md).
+The verified adapter evidence - each harness's busy-state source, interrupt and exit behavior, skill-invocation syntax, and per-harness quirks - lives in [`.agents/skills/harness-adapters/SKILL.md`](../.agents/skills/harness-adapters/SKILL.md).
+The executable interrupt and exit mechanics live in [`bin/fm-control-lib.sh`](../bin/fm-control-lib.sh), and [`docs/agent-control.md`](agent-control.md) owns their lifecycle-control architecture.
 Launch mechanics, including the verified command templates, live in [`bin/fm-spawn.sh`](../bin/fm-spawn.sh).
 Enabled primary-session turn-end guard integrations are tracked as repo-level hook files and documented in [`docs/turnend-guard.md`](turnend-guard.md).
 Kimi remains outside the primary turn-end guard integrations; [`docs/turnend-guard.md`](turnend-guard.md#compatibility-limits) owns its separate captain-approved crew wake hook.
@@ -225,6 +226,7 @@ The first non-empty, non-comment line is parsed as `<harness> [<model>] [<effort
 A bare `<harness>` preserves the previous behavior: harness only, with no model or effort launch flag.
 When the harness token is absent or `default`, secondmate launch falls back through `config/crew-harness` and then the primary's own harness, and no model or effort is read from that file.
 `fm-harness.sh secondmate-model` and `fm-harness.sh secondmate-effort` expose only the optional tokens from `config/secondmate-harness`; `config/crew-harness` remains a bare adapter-name file.
+Changing this pin affects the next secondmate spawn or `fm-control relaunch`; the relaunch profile rules are owned by [`docs/agent-control.md`](agent-control.md#transactional-relaunch).
 An explicit harness argument to `fm-spawn.sh` still overrides either config file for that spawn only.
 An explicit `--model` or `--effort` overrides the matching token from `config/secondmate-harness`; for a local route, an explicit harness or raw launch command starts with clean model and effort defaults unless those flags are also passed.
 Remote secondmate routes accept verified harness adapters only and reject raw launch commands.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -226,7 +226,7 @@ The first non-empty, non-comment line is parsed as `<harness> [<model>] [<effort
 A bare `<harness>` preserves the previous behavior: harness only, with no model or effort launch flag.
 When the harness token is absent or `default`, secondmate launch falls back through `config/crew-harness` and then the primary's own harness, and no model or effort is read from that file.
 `fm-harness.sh secondmate-model` and `fm-harness.sh secondmate-effort` expose only the optional tokens from `config/secondmate-harness`; `config/crew-harness` remains a bare adapter-name file.
-Changing this pin affects the next secondmate spawn or `fm-control relaunch`; the relaunch profile rules are owned by [`docs/agent-control.md`](agent-control.md#transactional-relaunch).
+Changing this pin affects the next secondmate spawn or control-plane relaunch; the relaunch profile rules are owned by [`docs/agent-control.md`](agent-control.md#transactional-relaunch).
 An explicit harness argument to `fm-spawn.sh` still overrides either config file for that spawn only.
 An explicit `--model` or `--effort` overrides the matching token from `config/secondmate-harness`; for a local route, an explicit harness or raw launch command starts with clean model and effort defaults unless those flags are also passed.
 Remote secondmate routes accept verified harness adapters only and reject raw launch commands.

--- a/docs/documentation-audiences.json
+++ b/docs/documentation-audiences.json
@@ -201,6 +201,10 @@
       "audience": "public-product"
     },
     {
+      "path": "docs/agent-control.md",
+      "audience": "maintainer-architecture"
+    },
+    {
       "path": "docs/architecture.md",
       "audience": "maintainer-architecture"
     },

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -91,6 +91,8 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-wake-lib.sh`         | Shared durable wake queue, portable locks, and watcher identity/health helpers       |
 | `fm-classify-lib.sh`     | Shared wake-classification vocabulary and durable keyed-decision folds and scans     |
 | `fm-send.sh`             | Send one verified literal line or supported key through the target's recorded backend |
+| `fm-control.sh`          | Agent lifecycle control plane: allowlisted `interrupt`, `exit`, and transactional `relaunch` verbs for an exact task id ([agent-control.md](agent-control.md)) |
+| `fm-control-lib.sh`      | One executable owner of the control-plane verb allowlist, per-harness interrupt/exit mechanics, and per-backend capability |
 | `fm-busy-lib.sh`         | Single owner of the semantic busy-state contract: verdicts, source attribution, and per-harness sources |
 | `fm-busy-event.sh`       | The only writer of a task's semantic busy-state record; arms an incarnation and applies lifecycle events |
 | `fm-tmux-lib.sh`         | Shared tmux pane primitives for composer capture, verified submit, and the submit-time busy check |

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -530,6 +530,27 @@ ok - real herdr: the watcher fast-path enqueues a stale wake naming the task win
 
 Polling remained active and is covered as the fallback for capability, connect, subscribe, and repeated reader failure.
 
+### Agent lifecycle control
+
+Herdr is one of the two backends whose recovery-grade agent-state classifier the control plane may trust ([agent-control.md](../agent-control.md)), so its lifecycle gating is measured against the real binary; reverified 2026-08-08 on Herdr 0.8.0, and first measured 2026-08-02 on Herdr 0.7.5 with identical results:
+
+```sh
+tests/fm-control-herdr-smoke.test.sh
+```
+
+Observed output:
+
+```text
+ok - real herdr: exit on a pane with no registered agent is idempotent success
+ok - real herdr: interrupt refuses when herdr's own agent registry reports no agent
+ok - real herdr: interrupt delivers the harness's key and proves the agent survived it
+ok - real herdr: no control verb removed the endpoint or the task's local copy
+ok - real herdr: an agent that does not stop fails closed instead of being reported as stopped
+```
+
+The registry read through `herdr pane report-agent` is the same source `fm_backend_herdr_agent_state` classifies, so registering and not registering an agent on a plain shell pane exercises exactly the gate every lifecycle verb depends on, with no real agent launched.
+That command is the guard that refreshes this record; run it after every Herdr upgrade rather than trusting the version above.
+
 ### Away-mode transport
 
 The Pi/Herdr return and injection path was reverified on Herdr 0.7.3 and Pi 0.80.7:

--- a/tests/fm-backend-herdr-presentation-e2e.test.sh
+++ b/tests/fm-backend-herdr-presentation-e2e.test.sh
@@ -386,6 +386,25 @@ spawn_task() {  # <id> <home> <project>
     "$ROOT/bin/fm-spawn.sh" "$id" "$project" "sh -c 'sleep 120'" --mode no-mistakes --yolo off --backend herdr
 }
 
+finish_concurrent_spawn() {  # <id> <status> <stdout> <stderr>
+  local id=$1 status=$2 out=$3 err=$4
+  [ "$status" -ne 0 ] || return 0
+  grep -F "task set is locked" "$err" >/dev/null 2>&1 \
+    || fail "concurrent projected spawn $id failed unexpectedly: $(cat "$err")"
+  spawn_task "$id" "$HOME_DIR" "$PROJECT_DIR" > "$out" 2> "$err" \
+    || fail "projected spawn $id retry failed after task-set publication completed: $(cat "$err")"
+}
+
+finish_concurrent_expected_abort() {  # <id> <status> <stdout> <stderr>
+  local id=$1 status=$2 out=$3 err=$4
+  [ "$status" -ne 0 ] || fail "post-create abort fixture $id unexpectedly succeeded"
+  if grep -F "task set is locked" "$err" >/dev/null 2>&1; then
+    if spawn_task "$id" "$HOME_DIR" "$PROJECT_DIR" > "$out" 2> "$err"; then
+      fail "post-create abort fixture $id unexpectedly succeeded after task-set publication completed"
+    fi
+  fi
+}
+
 spawn_secondmate_task() {
   local id=$1 home=$2
   FM_GATE_REFUSE_BYPASS=1 FM_SPAWN_NO_GUARD=1 FM_HOME="$HOME_DIR" FM_ROOT_OVERRIDE="$ROOT" \
@@ -718,7 +737,9 @@ normalize_meta "$ON_META" > "$TMP_ROOT/on.meta.normalized"
 cmp -s "$TMP_ROOT/off.meta.normalized" "$TMP_ROOT/on.meta.normalized" \
   || fail "metadata changed beyond Herdr container IDs between opted-out and projected paths"
 
-# Two real concurrent primary spawns share the bounded presentation-order lock.
+# Two real primary spawns begin concurrently.
+# The fresh-spawn task-set lock may fail closed for one while the other
+# publishes, in which case retry it only after the lock owner has completed.
 # Their final relative order must match Herdr's actual serialized create order,
 # rather than a task-name or priority guess.
 CONCURRENT_FOCUS_AUDIT_START=$(focus_audit_line_count)
@@ -726,8 +747,10 @@ spawn_task order-a "$HOME_DIR" "$PROJECT_DIR" > "$TMP_ROOT/order-a.out" 2> "$TMP
 ORDER_A_PID=$!
 spawn_task order-b "$HOME_DIR" "$PROJECT_DIR" > "$TMP_ROOT/order-b.out" 2> "$TMP_ROOT/order-b.err" &
 ORDER_B_PID=$!
-wait "$ORDER_A_PID" || fail "concurrent projected spawn A failed: $(cat "$TMP_ROOT/order-a.err")"
-wait "$ORDER_B_PID" || fail "concurrent projected spawn B failed: $(cat "$TMP_ROOT/order-b.err")"
+if wait "$ORDER_A_PID"; then ORDER_A_STATUS=0; else ORDER_A_STATUS=$?; fi
+if wait "$ORDER_B_PID"; then ORDER_B_STATUS=0; else ORDER_B_STATUS=$?; fi
+finish_concurrent_spawn order-a "$ORDER_A_STATUS" "$TMP_ROOT/order-a.out" "$TMP_ROOT/order-a.err"
+finish_concurrent_spawn order-b "$ORDER_B_STATUS" "$TMP_ROOT/order-b.out" "$TMP_ROOT/order-b.err"
 assert_focus_is "$CAPTAIN_FOCUS" "concurrent projected spawns"
 assert_raw_presentation_mutations_preserved_since "$CONCURRENT_FOCUS_AUDIT_START" "concurrent projected spawns"
 ORDER_A_META="$HOME_DIR/state/order-a.meta"
@@ -801,8 +824,10 @@ spawn_task abort-a "$HOME_DIR" "$PROJECT_DIR" > "$TMP_ROOT/abort-a.out" 2> "$TMP
 ABORT_A_PID=$!
 spawn_task abort-b "$HOME_DIR" "$PROJECT_DIR" > "$TMP_ROOT/abort-b.out" 2> "$TMP_ROOT/abort-b.err" &
 ABORT_B_PID=$!
-if wait "$ABORT_A_PID"; then fail "post-create abort fixture A unexpectedly succeeded"; fi
-if wait "$ABORT_B_PID"; then fail "post-create abort fixture B unexpectedly succeeded"; fi
+if wait "$ABORT_A_PID"; then ABORT_A_STATUS=0; else ABORT_A_STATUS=$?; fi
+if wait "$ABORT_B_PID"; then ABORT_B_STATUS=0; else ABORT_B_STATUS=$?; fi
+finish_concurrent_expected_abort abort-a "$ABORT_A_STATUS" "$TMP_ROOT/abort-a.out" "$TMP_ROOT/abort-a.err"
+finish_concurrent_expected_abort abort-b "$ABORT_B_STATUS" "$TMP_ROOT/abort-b.out" "$TMP_ROOT/abort-b.err"
 grep -F "did not yield an isolated worktree" "$TMP_ROOT/abort-a.err" >/dev/null 2>&1 \
   || fail "post-create abort fixture A did not reach the armed validation failure"
 grep -F "did not yield an isolated worktree" "$TMP_ROOT/abort-b.err" >/dev/null 2>&1 \
@@ -878,8 +903,10 @@ for ROUND in 1 2 3; do
   WAVE_A_PID=$!
   spawn_task "focus-$ROUND-b" "$HOME_DIR" "$PROJECT_DIR" > "$TMP_ROOT/focus-$ROUND-b.out" 2> "$TMP_ROOT/focus-$ROUND-b.err" &
   WAVE_B_PID=$!
-  wait "$WAVE_A_PID" || fail "focus wave $ROUND spawn A failed: $(cat "$TMP_ROOT/focus-$ROUND-a.err")"
-  wait "$WAVE_B_PID" || fail "focus wave $ROUND spawn B failed: $(cat "$TMP_ROOT/focus-$ROUND-b.err")"
+  if wait "$WAVE_A_PID"; then WAVE_A_STATUS=0; else WAVE_A_STATUS=$?; fi
+  if wait "$WAVE_B_PID"; then WAVE_B_STATUS=0; else WAVE_B_STATUS=$?; fi
+  finish_concurrent_spawn "focus-$ROUND-a" "$WAVE_A_STATUS" "$TMP_ROOT/focus-$ROUND-a.out" "$TMP_ROOT/focus-$ROUND-a.err"
+  finish_concurrent_spawn "focus-$ROUND-b" "$WAVE_B_STATUS" "$TMP_ROOT/focus-$ROUND-b.out" "$TMP_ROOT/focus-$ROUND-b.err"
   remember_meta_worktree "$HOME_DIR/state/focus-$ROUND-a.meta" >/dev/null
   remember_meta_worktree "$HOME_DIR/state/focus-$ROUND-b.meta" >/dev/null
   assert_focus_is "$CAPTAIN_FOCUS" "focus wave $ROUND concurrent spawns"

--- a/tests/fm-backend-orca.test.sh
+++ b/tests/fm-backend-orca.test.sh
@@ -1168,6 +1168,9 @@ test_secondmate_force_teardown_removes_orca_child_via_orca() {
     "backend=orca" "orca_worktree_id=wt-child-cleanup"
   orca_case secondmate-child-cleanup
   printf '{"ok":true,"result":{"worktree":{"id":"wt-child-cleanup","path":"%s"}}}\n' "$childwt" > "$RESP/1.out"
+  printf '{"ok":true,"result":{"worktree":{"id":"wt-child-cleanup","path":"%s"}}}\n' "$childwt" > "$RESP/2.out"
+  printf '{"ok":true,"result":{}}\n' > "$RESP/3.out"
+  printf '{"ok":true,"result":{}}\n' > "$RESP/4.out"
   add_tmux_fake "$FB"
   neutral=$(neutral_fm_root "$CASE_DIR/neutral")
   set +e

--- a/tests/fm-control-herdr-smoke.test.sh
+++ b/tests/fm-control-herdr-smoke.test.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+# tests/fm-control-herdr-smoke.test.sh - real-herdr smoke test for the agent
+# lifecycle control plane (bin/fm-control.sh).
+#
+# tmux is the control plane's reference backend and is covered hermetically in
+# tests/fm-control.test.sh. herdr is the OTHER backend whose recovery-grade
+# agent-state classifier the control plane is allowed to trust, so its
+# behavior is pinned here against the REAL binary rather than a stub: whether
+# an agent is running, and therefore whether a lifecycle verb may act at all,
+# comes from herdr's own agent registry.
+#
+# No real agent is launched. herdr's `pane report-agent` is the same registry
+# the adapter reads, so registering and not registering an agent on a plain
+# shell pane exercises exactly the classification the control plane gates on.
+#
+# Always runs on a private, named, throwaway lab session, never the default
+# one (tests/herdr-test-safety.sh; the 2026-07-02 incident). Skips cleanly
+# when herdr or jq is missing.
+set -u
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+fail() { printf 'not ok - %s\n' "$1" >&2; cleanup_all; exit 1; }
+pass() { printf 'ok - %s\n' "$1"; }
+
+command -v herdr >/dev/null 2>&1 || { echo "skip: herdr not found"; exit 0; }
+command -v jq >/dev/null 2>&1 || { echo "skip: jq not found (required by the herdr adapter)"; exit 0; }
+
+# shellcheck source=tests/herdr-test-safety.sh
+. "$ROOT/tests/herdr-test-safety.sh"
+herdr_forget_inherited_pane
+
+SESSION="fm-lab-control-smoke-$$"
+export HERDR_SESSION="$SESSION"
+SCRATCH=
+cleanup_all() {
+  [ -n "$SCRATCH" ] && rm -rf "$SCRATCH"
+  herdr_safe_stop_and_delete "$SESSION"
+}
+trap cleanup_all EXIT
+fm_herdr_lab_prepare "$SESSION" || fail "could not prepare isolated Herdr lab session"
+
+SCRATCH=$(mktemp -d "${TMPDIR:-/tmp}/fm-control-herdr.XXXXXX")
+SCRATCH=$(cd "$SCRATCH" && pwd)
+HOME_DIR="$SCRATCH/home"
+mkdir -p "$HOME_DIR/state" "$HOME_DIR/data/hsmoke"
+printf '# brief\n' > "$HOME_DIR/data/hsmoke/brief.md"
+
+# A real git worktree so the control plane's checkpoint has a real local copy.
+PROJ="$SCRATCH/proj"
+WT="$SCRATCH/wt"
+mkdir -p "$PROJ"
+git -C "$PROJ" init -q
+printf '# proj\n' > "$PROJ/README.md"
+git -C "$PROJ" add README.md
+git -C "$PROJ" -c user.name='Firstmate Tests' -c user.email='tests@example.invalid' commit -qm initial
+git -C "$PROJ" worktree add --quiet -b hsmoke "$WT"
+
+# shellcheck source=/dev/null
+. "$ROOT/bin/fm-backend.sh"
+fm_backend_source herdr || fail "fm_backend_source herdr failed"
+
+CONTAINER_RAW=$(fm_backend_herdr_container_ensure "$WT") || fail "container_ensure failed"
+CONTAINER=${CONTAINER_RAW%%$'\t'*}
+SEEDED_TAB_ID=${CONTAINER_RAW#*$'\t'}
+WORKSPACE_ID=${CONTAINER#*:}
+TASK_IDS=$(fm_backend_herdr_create_task "$CONTAINER" "fm-hsmoke" "$WT" "$SEEDED_TAB_ID") \
+  || fail "create_task failed"
+read -r TAB_ID PANE_ID <<EOF
+$TASK_IDS
+EOF
+[ -n "$TAB_ID" ] && [ -n "$PANE_ID" ] || fail "create_task did not return tab/pane ids"
+
+{
+  echo "window=$SESSION:$PANE_ID"
+  echo "endpoint_task_id=hsmoke"
+  echo "worktree=$WT"
+  echo "project=$PROJ"
+  echo "harness=claude"
+  echo "kind=ship"
+  echo "mode=no-mistakes"
+  echo "yolo=off"
+  echo "model=default"
+  echo "effort=default"
+  echo "backend=herdr"
+  echo "herdr_session=$SESSION"
+  echo "herdr_workspace_id=$WORKSPACE_ID"
+  echo "herdr_tab_id=$TAB_ID"
+  echo "herdr_pane_id=$PANE_ID"
+} > "$HOME_DIR/state/hsmoke.meta"
+
+run_control() {
+  env FM_HOME="$HOME_DIR" HERDR_SESSION="$SESSION" \
+    FM_CONTROL_POLL=0.2 FM_CONTROL_EXIT_WAIT=2 \
+    "$ROOT/bin/fm-control.sh" "$@" 2>&1
+}
+
+# --- no registered agent: the endpoint exists but hosts no agent ------------
+
+OUT=$(run_control hsmoke exit) || fail "exit against an agent-free herdr pane should be idempotent success: $OUT"
+case "$OUT" in
+  "already-stopped hsmoke"*) : ;;
+  *) fail "an agent-free herdr pane should report already-stopped, got: $OUT" ;;
+esac
+pass "real herdr: exit on a pane with no registered agent is idempotent success"
+
+if OUT=$(run_control hsmoke interrupt 2>&1); then
+  fail "interrupt should refuse when herdr reports no agent on the pane: $OUT"
+fi
+case "$OUT" in
+  *"nothing to interrupt"*) : ;;
+  *) fail "the interrupt refusal should say there is no agent, got: $OUT" ;;
+esac
+pass "real herdr: interrupt refuses when herdr's own agent registry reports no agent"
+
+# --- a registered agent: classification flips, and the verbs follow ---------
+
+herdr pane report-agent "$PANE_ID" --source fm-control-smoke --agent fm-control-smoke-agent \
+  --state idle --session "$SESSION" >/dev/null 2>&1 \
+  || fail "could not register a live agent on the task pane"
+
+STATE=$(fm_backend_agent_state herdr "$SESSION:$PANE_ID")
+[ "$STATE" = alive ] || fail "herdr should classify a registered agent as alive, got '$STATE'"
+
+OUT=$(run_control hsmoke interrupt) || fail "interrupt against a registered agent should succeed: $OUT"
+case "$OUT" in
+  *"interrupted hsmoke harness=claude backend=herdr verified=agent-alive"*) : ;;
+  *) fail "interrupt should report the agent-alive proof on herdr, got: $OUT" ;;
+esac
+pass "real herdr: interrupt delivers the harness's key and proves the agent survived it"
+
+herdr pane get "$PANE_ID" --session "$SESSION" >/dev/null 2>&1 \
+  || fail "the control plane must never remove the endpoint it was operating on"
+[ -d "$WT" ] || fail "the control plane must never remove the task's local copy"
+pass "real herdr: no control verb removed the endpoint or the task's local copy"
+
+# Last, because it deliberately types a harness command into a pane that hosts
+# a plain shell: the registered agent cannot actually be stopped that way, and
+# the control plane must say so rather than report a stop it did not achieve.
+if OUT=$(run_control hsmoke exit 2>&1); then
+  fail "exit should fail closed when the agent does not stop: $OUT"
+fi
+case "$OUT" in
+  *"did not stop"*) : ;;
+  *) fail "the exit failure should say the agent did not stop, got: $OUT" ;;
+esac
+pass "real herdr: an agent that does not stop fails closed instead of being reported as stopped"
+
+fm_backend_herdr_kill "$SESSION:$PANE_ID" 2>/dev/null || true

--- a/tests/fm-control-herdr-smoke.test.sh
+++ b/tests/fm-control-herdr-smoke.test.sh
@@ -124,7 +124,7 @@ STATE=$(fm_backend_agent_state herdr "$SESSION:$PANE_ID")
 
 OUT=$(run_control hsmoke interrupt) || fail "interrupt against a registered agent should succeed: $OUT"
 case "$OUT" in
-  *"interrupted hsmoke harness=claude backend=herdr verified=agent-alive"*) : ;;
+  *"interrupt-delivered hsmoke harness=claude backend=herdr verified=agent-alive cancel=unconfirmed"*) : ;;
   *) fail "interrupt should report the agent-alive proof on herdr, got: $OUT" ;;
 esac
 pass "real herdr: interrupt delivers the harness's key and proves the agent survived it"

--- a/tests/fm-control-relaunch.test.sh
+++ b/tests/fm-control-relaunch.test.sh
@@ -666,6 +666,31 @@ test_spawn_relaunch_without_a_harness_reuses_the_recorded_one() {
   pass "fm-spawn --relaunch: with no explicit harness it reuses the task's recorded one, never the crew default"
 }
 
+# fm-spawn arms per-task wiring on harness PREFIXES, because a task launched
+# from a raw command records that command's basename rather than the exact
+# adapter name. Retirement must resolve the same way, or a task recorded as
+# `grok-2` would have its turn-end token and hook pointer armed and never
+# retired - leaving a registry entry that outlives the agent that owned it.
+test_prefixed_prior_harness_wiring_is_still_retired() {
+  local dir auth
+  dir=$(new_case prefixwiring rl30)
+  add_ship_task "$dir" rl30 grok-2
+  mkdir -p "$dir/grokhome/hooks/fm-turn-end.d"
+  printf 'fm.abcdefabcdef\n' > "$dir/home/state/rl30.grok-turnend-token"
+  auth="$dir/grokhome/hooks/fm-turn-end.d/fm.abcdefabcdef"
+  printf '%s\n' "$dir/home/state/rl30.turn-ended" > "$auth"
+  printf 'token=fm.abcdefabcdef\n' > "$dir/wt/.fm-grok-turnend"
+  printf 'zsh' > "$dir/fake/command"
+  run_spawn "$dir" rl30 --relaunch --harness claude >/dev/null
+  [ ! -e "$auth" ] \
+    || fail "a prefixed prior harness must still have its turn-end registry entry revoked"
+  [ ! -e "$dir/home/state/rl30.grok-turnend-token" ] \
+    || fail "a prefixed prior harness must still have its private token retired"
+  [ ! -e "$dir/wt/.fm-grok-turnend" ] \
+    || fail "a prefixed prior harness must still have its worktree hook pointer removed"
+  pass "fm-spawn --relaunch: wiring armed under a prefixed harness name is still retired"
+}
+
 # --- 3 and 4. refusals before the agent is touched ---------------------------
 
 test_missing_worktree_refuses_before_stopping_anything() {
@@ -1154,6 +1179,7 @@ test_secondmate_relaunch_onto_a_crewmate_only_adapter_refuses_before_stop
 test_explicit_secondmate_harness_ignores_configured_profile_axes
 test_ship_relaunch_ignores_the_crew_harness_config
 test_spawn_relaunch_without_a_harness_reuses_the_recorded_one
+test_prefixed_prior_harness_wiring_is_still_retired
 test_missing_worktree_refuses_before_stopping_anything
 test_missing_instructions_refuse_before_stopping_anything
 test_checkpoint_refusal_leaves_the_record_byte_identical

--- a/tests/fm-control-relaunch.test.sh
+++ b/tests/fm-control-relaunch.test.sh
@@ -386,6 +386,33 @@ test_harness_switch_does_not_carry_the_old_profile_axes() {
   pass "fm-control relaunch: a harness switch resets model and effort unless they are named too"
 }
 
+test_harness_switch_resolves_a_prefixed_recorded_harness() {
+  local dir out rc auth
+  dir=$(new_case prefixcontrol rl32)
+  add_ship_task "$dir" rl32 grok-2
+  printf 'grok-2' > "$dir/fake/command"
+  mkdir -p "$dir/grokhome/hooks/fm-turn-end.d"
+  printf 'fm.abcdefabcdef\n' > "$dir/home/state/rl32.grok-turnend-token"
+  auth="$dir/grokhome/hooks/fm-turn-end.d/fm.abcdefabcdef"
+  printf '%s\n' "$dir/home/state/rl32.turn-ended" > "$auth"
+  printf 'token=fm.abcdefabcdef\n' > "$dir/wt/.fm-grok-turnend"
+
+  out=$(run_control "$dir" rl32 relaunch --harness claude --note "switching runtime"); rc=$?
+  expect_code 0 "$rc" "relaunch should resolve a prefixed recorded harness"$'\n'"$out"
+  [ "$(sed -n '1p' "$dir/fake/literal")" = /exit ] \
+    || fail "relaunch should stop a grok-prefixed task with grok's exit command"
+  [ "$(meta_field "$dir" rl32 harness)" = claude ] \
+    || fail "relaunch should publish the explicitly selected replacement harness"
+  [ "$(journal_field "$dir" rl32 from_harness)" = grok-2 ] \
+    || fail "relaunch should retain the recorded harness basename in its provenance"
+  assert_contains "$out" "harness=claude from=grok-2" \
+    "relaunch should report the recorded-to-selected harness transition"
+  [ ! -e "$auth" ] && [ ! -e "$dir/home/state/rl32.grok-turnend-token" ] \
+    && [ ! -e "$dir/wt/.fm-grok-turnend" ] \
+    || fail "relaunch should retire wiring owned by the prefixed prior harness"
+  pass "fm-control relaunch: a prefixed recorded harness can switch adapters transactionally"
+}
+
 test_same_harness_relaunch_keeps_the_profile_axes() {
   local dir out rc
   dir=$(new_case keepprofile rl6)
@@ -1187,6 +1214,7 @@ test_relaunch_appends_the_progress_note_to_the_instructions
 test_relaunch_requires_a_note_for_a_ship_task
 test_harness_switch_moves_the_record_and_clears_prior_wiring
 test_harness_switch_does_not_carry_the_old_profile_axes
+test_harness_switch_resolves_a_prefixed_recorded_harness
 test_same_harness_relaunch_keeps_the_profile_axes
 test_explicit_model_wins_over_the_recorded_one
 test_relaunch_onto_an_unverified_harness_is_refused

--- a/tests/fm-control-relaunch.test.sh
+++ b/tests/fm-control-relaunch.test.sh
@@ -474,6 +474,37 @@ test_harness_switch_resolves_a_prefixed_recorded_harness() {
   pass "fm-control relaunch: a prefixed recorded harness can switch adapters transactionally"
 }
 
+test_prefixed_recorded_harness_requires_explicit_replacement() {
+  local dir out rc meta brief
+  dir=$(new_case prefixrefuse rl34)
+  add_ship_task "$dir" rl34 grok-2
+  printf 'grok-2' > "$dir/fake/command"
+  meta="$dir/home/state/rl34.meta"
+  brief="$dir/home/data/rl34/brief.md"
+  cp "$meta" "$dir/meta.before"
+  cp "$brief" "$dir/brief.before"
+
+  out=$(run_control "$dir" rl34 relaunch --note "continue safely"); rc=$?
+  expect_code 1 "$rc" "implicit relaunch from a prefixed command should refuse"
+  assert_contains "$out" "original launch command cannot be reconstructed from its recorded basename" \
+    "the refusal should name the missing launch identity"
+  assert_contains "$out" "would substitute the canonical adapter 'grok'" \
+    "the refusal should name the unsafe substitution"
+  assert_contains "$out" "Pass an explicit --harness" \
+    "the refusal should name the deliberate replacement path"
+  cmp -s "$meta" "$dir/meta.before" \
+    || fail "a refused prefixed relaunch must leave metadata byte-identical"
+  cmp -s "$brief" "$dir/brief.before" \
+    || fail "a refused prefixed relaunch must leave instructions byte-identical"
+  [ "$(cat "$dir/fake/command")" = grok-2 ] \
+    || fail "a refused prefixed relaunch must leave the original agent alive"
+  [ -z "$(cat "$dir/fake/literal")" ] && [ -z "$(cat "$dir/fake/keys")" ] \
+    || fail "a refused prefixed relaunch must deliver no lifecycle input"
+  [ ! -e "$dir/home/state/rl34.control-relaunch" ] \
+    || fail "a refused prefixed relaunch must not create a durable journal"
+  pass "fm-control relaunch: a prefixed command requires an explicit replacement harness"
+}
+
 test_same_harness_relaunch_keeps_the_profile_axes() {
   local dir out rc
   dir=$(new_case keepprofile rl6)
@@ -1277,6 +1308,7 @@ test_relaunch_requires_a_note_for_a_ship_task
 test_harness_switch_moves_the_record_and_clears_prior_wiring
 test_harness_switch_does_not_carry_the_old_profile_axes
 test_harness_switch_resolves_a_prefixed_recorded_harness
+test_prefixed_recorded_harness_requires_explicit_replacement
 test_same_harness_relaunch_keeps_the_profile_axes
 test_explicit_model_wins_over_the_recorded_one
 test_relaunch_onto_an_unverified_harness_is_refused

--- a/tests/fm-control-relaunch.test.sh
+++ b/tests/fm-control-relaunch.test.sh
@@ -1,0 +1,1177 @@
+#!/usr/bin/env bash
+# fm-control.sh relaunch: the transactional replace-the-agent verb.
+#
+# Relaunch is the only control verb that changes durable records, so these
+# tests pin the transaction itself, hermetically (stubbed session provider, no
+# real agent):
+#   1. A same-harness relaunch keeps every identity axis and reuses the SAME
+#      endpoint and worktree - it replaces an agent, it never forks a task.
+#   2. A harness switch is one ordinary relaunch: the record follows, the
+#      previous harness's per-task wiring is cleared, and profile axes chosen
+#      for the old harness do not silently carry to the new one.
+#   3. The progress note is required where the replacement needs it, lands in
+#      the instructions the replacement reads, and never rewrites a charter.
+#   4. A refusal before the agent is stopped changes nothing.
+#   5. A launch failure after the agent is stopped keeps the prior record,
+#      reports the concrete state, and preserves the work.
+#   6. fm-spawn --relaunch refuses on its own: a live agent, a contradicting
+#      flag, an extra positional, or a backend that cannot prove the previous
+#      agent exited.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+# shellcheck source=/dev/null
+. "$ROOT/bin/fm-control-lib.sh"
+
+CONTROL="$ROOT/bin/fm-control.sh"
+SPAWN="$ROOT/bin/fm-spawn.sh"
+PROMOTE="$ROOT/bin/fm-promote.sh"
+X_LINK="$ROOT/bin/fm-x-link.sh"
+# fm_test_tmproot's own cleanup trap fires when its command substitution exits,
+# so recreate the root before resolving it and clean it up from this file's trap.
+TMP_ROOT=$(fm_test_tmproot fm-control-relaunch)
+mkdir -p "$TMP_ROOT"
+TMP_ROOT=$(cd "$TMP_ROOT" && pwd)
+TASK_TMPS=()
+
+relaunch_cleanup() {
+  local d
+  for d in "${TASK_TMPS[@]:-}"; do
+    [ -n "$d" ] && rm -rf "$d"
+  done
+  rm -rf "$TMP_ROOT"
+}
+trap relaunch_cleanup EXIT
+
+# The same lifecycle-modelling tmux stub as tests/fm-control.test.sh: the
+# harness's exit command stops the agent, and a launch-brief literal starts the
+# harness named in `becomes`.
+make_tmux_stub() {  # <dir>
+  local fb="$1/fakebin"
+  mkdir -p "$fb"
+  cat > "$fb/tmux" <<'SH'
+#!/usr/bin/env bash
+set -u
+D=$FM_FAKE_DIR
+case "${1:-}" in
+  send-keys)
+    shift
+    literal=0
+    while [ $# -gt 0 ]; do
+      case "$1" in
+        -t) shift 2 ;;
+        -l) literal=1; shift ;;
+        *) break ;;
+      esac
+    done
+    payload=${1:-}
+    if [ "$literal" = 1 ]; then
+      printf '%s\n' "$payload" >> "$D/literal"
+      case "$payload" in
+        /exit|/quit)
+          printf 'zsh' > "$D/command"
+          [ -z "${FM_FAKE_EXIT_TRANSPORT_FAIL_AFTER_STOP:-}" ] || exit 1
+          ;;
+        *'encode launch-brief'*)
+          cat "$D/becomes" > "$D/command"
+          [ -z "${FM_FAKE_LAUNCH_TRANSPORT_FAIL_AFTER_START:-}" ] || exit 1
+          ;;
+      esac
+    else
+      printf '%s\n' "$payload" >> "$D/keys"
+    fi
+    exit 0 ;;
+  display-message)
+    for a in "$@"; do
+      case "$a" in
+        *cursor_y*) printf '1\n'; exit 0 ;;
+        *pane_current_command*) cat "$D/command"; printf '\n'; exit 0 ;;
+        *pane_current_path*)
+          if [ -n "${FM_FAKE_CWD_RACE_READY:-}" ]; then
+            : > "$FM_FAKE_CWD_RACE_READY"
+            /bin/sleep 1
+          fi
+          cat "$D/cwd"; printf '\n'; exit 0 ;;
+      esac
+    done
+    printf 'fakepane\n'; exit 0 ;;
+  capture-pane) printf '╭────╮\n│    │\n╰────╯\n'; exit 0 ;;
+  list-windows) [ -f "$D/windows" ] && cat "$D/windows"; exit 0 ;;
+esac
+exit 0
+SH
+  chmod +x "$fb/tmux"
+  cat > "$fb/sleep" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+  chmod +x "$fb/sleep"
+}
+
+# new_case <name> [id] -> echoes a case dir with a live claude ship task.
+new_case() {
+  local id=${2:-t1} dir="$TMP_ROOT/$1-$RANDOM"
+  mkdir -p "$dir/home/state" "$dir/home/data" "$dir/fake"
+  : > "$dir/fake/literal"
+  : > "$dir/fake/keys"
+  printf 'claude' > "$dir/fake/command"
+  printf 'claude' > "$dir/fake/becomes"
+  printf '%s\n' "fm-$id" > "$dir/fake/windows"
+  make_tmux_stub "$dir"
+  printf '%s\n' "$dir"
+}
+
+# add_ship_task <case-dir> <id> [harness]
+add_ship_task() {
+  local dir=$1 id=$2 harness=${3:-claude}
+  local home="$dir/home" proj="$dir/proj" wt="$dir/wt"
+  fm_git_worktree "$proj" "$wt" "task-$id"
+  mkdir -p "$home/data/$id"
+  printf '# brief for %s\n\nDo the thing.\n' "$id" > "$home/data/$id/brief.md"
+  {
+    echo "window=fmses:fm-$id"
+    echo "endpoint_task_id=$id"
+    echo "worktree=$wt"
+    echo "project=$proj"
+    echo "harness=$harness"
+    echo "kind=ship"
+    echo "mode=no-mistakes"
+    echo "yolo=off"
+    echo "tasktmp=/tmp/fm-$id"
+    echo "model=default"
+    echo "effort=default"
+  } > "$home/state/$id.meta"
+  printf '%s\n' "fm-$id" > "$dir/fake/windows"
+  printf '%s' "$wt" > "$dir/fake/cwd"
+  TASK_TMPS+=("/tmp/fm-$id")
+}
+
+run_control() {  # <case-dir> <args...>
+  local dir=$1; shift
+  env PATH="$dir/fakebin:$PATH" FM_HOME="$dir/home" FM_FAKE_DIR="$dir/fake" \
+    FM_SPAWN_NO_GUARD=1 GROK_HOME="$dir/grokhome" \
+    FM_CONTROL_POLL=0.01 FM_CONTROL_EXIT_WAIT=0.05 FM_CONTROL_LAUNCH_WAIT=0.05 \
+    FM_REAL_GIT="${FM_REAL_GIT:-}" FM_FAKE_GIT_FAILURE="${FM_FAKE_GIT_FAILURE:-}" \
+    FM_REAL_MV="${FM_REAL_MV:-}" FM_FAKE_COMPLETE_JOURNAL_MV_FAIL="${FM_FAKE_COMPLETE_JOURNAL_MV_FAIL:-}" \
+    FM_FAKE_META_PUBLISH_MV_FAIL="${FM_FAKE_META_PUBLISH_MV_FAIL:-}" \
+    "$CONTROL" "$@" 2>&1
+}
+
+run_spawn() {  # <case-dir> <args...>
+  local dir=$1; shift
+  env PATH="$dir/fakebin:$PATH" FM_HOME="$dir/home" FM_FAKE_DIR="$dir/fake" \
+    FM_SPAWN_NO_GUARD=1 GROK_HOME="$dir/grokhome" \
+    "$SPAWN" "$@" 2>&1
+}
+
+meta_field() {  # <case-dir> <id> <key>
+  grep "^$3=" "$1/home/state/$2.meta" | tail -1 | cut -d= -f2-
+}
+
+journal_field() {  # <case-dir> <id> <key>
+  grep "^$3=" "$1/home/state/$2.control-relaunch" | tail -1 | cut -d= -f2-
+}
+
+make_git_failure_stub() {  # <case-dir>
+  cat > "$1/fakebin/git" <<'SH'
+#!/usr/bin/env bash
+case "${FM_FAKE_GIT_FAILURE:-}:$*" in
+  head:*' rev-parse --verify HEAD'|head:*' symbolic-ref -q HEAD') exit 128 ;;
+  status:*' status --porcelain') exit 128 ;;
+esac
+exec "$FM_REAL_GIT" "$@"
+SH
+  chmod +x "$1/fakebin/git"
+}
+
+make_mv_failure_stub() {  # <case-dir>
+  cat > "$1/fakebin/mv" <<'SH'
+#!/usr/bin/env bash
+if [ -n "${FM_FAKE_COMPLETE_JOURNAL_MV_FAIL:-}" ]; then
+  for path in "$@"; do
+    if [ -f "$path" ] && grep -Fqx 'phase=complete' "$path"; then
+      exit 1
+    fi
+  done
+fi
+if [ -n "${FM_FAKE_META_PUBLISH_MV_FAIL:-}" ]; then
+  for path in "$@"; do
+    [ "$path" != "$FM_FAKE_META_PUBLISH_MV_FAIL" ] || exit 1
+  done
+fi
+exec "$FM_REAL_MV" "$@"
+SH
+  chmod +x "$1/fakebin/mv"
+}
+
+make_meta_race_awk_stub() {  # <case-dir>
+  cat > "$1/fakebin/awk" <<'SH'
+#!/usr/bin/env bash
+for arg in "$@"; do
+  if [ -n "${FM_FAKE_META_RACE_PATH:-}" ] && [ "$arg" = "$FM_FAKE_META_RACE_PATH" ]; then
+    : > "$FM_FAKE_META_RACE_READY"
+    /bin/sleep 1
+    break
+  fi
+done
+exec "$FM_REAL_AWK" "$@"
+SH
+  chmod +x "$1/fakebin/awk"
+}
+
+make_rm_failure_stub() {  # <case-dir>
+  cat > "$1/fakebin/rm" <<'SH'
+#!/usr/bin/env bash
+for arg in "$@"; do
+  if [ -n "${FM_FAKE_RM_FAIL_PATH:-}" ] && [ "$arg" = "$FM_FAKE_RM_FAIL_PATH" ]; then
+    exit 1
+  fi
+done
+exec "$FM_REAL_RM" "$@"
+SH
+  chmod +x "$1/fakebin/rm"
+}
+
+# --- 1. same-harness relaunch -----------------------------------------------
+
+test_same_harness_relaunch_keeps_identity_and_reuses_the_endpoint() {
+  local dir out rc gen_before gen_after
+  dir=$(new_case same rl1)
+  add_ship_task "$dir" rl1 claude
+  gen_before=$("$ROOT/bin/fm-busy-event.sh" arm "$dir/home/state" rl1)
+  printf 'busy_gen=%s\n' "$gen_before" >> "$dir/home/state/rl1.meta"
+  out=$(run_control "$dir" rl1 relaunch --note "stopped mid-refactor"); rc=$?
+  expect_code 0 "$rc" "a same-harness relaunch should succeed"$'\n'"$out"
+  assert_contains "$out" "relaunched rl1 harness=claude from=claude" "the outcome should name the transition"
+  [ "$(meta_field "$dir" rl1 window)" = "fmses:fm-rl1" ] \
+    || fail "the endpoint must be reused, not recreated"
+  [ "$(meta_field "$dir" rl1 worktree)" = "$dir/wt" ] \
+    || fail "the worktree must be reused, not reallocated"
+  [ "$(meta_field "$dir" rl1 kind)" = ship ] || fail "kind must survive the relaunch"
+  [ "$(meta_field "$dir" rl1 project)" = "$dir/proj" ] || fail "project must survive the relaunch"
+  gen_after=$(meta_field "$dir" rl1 busy_gen)
+  [ -n "$gen_after" ] && [ "$gen_after" != "$gen_before" ] \
+    || fail "a relaunch must arm a fresh busy generation, got '$gen_after'"
+  [ "$(journal_field "$dir" rl1 phase)" = complete ] \
+    || fail "the transaction journal should end complete"
+  assert_grep "/exit" "$dir/fake/literal" "the previous agent should have been exited"
+  assert_grep "encode launch-brief" "$dir/fake/literal" "the replacement should have been launched"
+  pass "fm-control relaunch: a same-harness relaunch replaces the agent in the same endpoint and worktree"
+}
+
+test_relaunch_preserves_durable_task_metadata() {
+  local dir out rc
+  dir=$(new_case durable-meta rl19)
+  add_ship_task "$dir" rl19 claude
+  {
+    printf '%s\n' 'pr=https://github.com/example/repo/pull/19'
+    printf '%s\n' 'pr_head=feature/relaunch'
+    printf '%s\n' 'x_request=request-19'
+    printf '%s\n' 'decisions_reviewed=1'
+  } >> "$dir/home/state/rl19.meta"
+
+  out=$(run_control "$dir" rl19 relaunch --note "continuing review work"); rc=$?
+  expect_code 0 "$rc" "relaunch should preserve durable metadata"$'\n'"$out"
+  [ "$(meta_field "$dir" rl19 pr)" = "https://github.com/example/repo/pull/19" ] \
+    || fail "the task PR must survive relaunch"
+  [ "$(meta_field "$dir" rl19 pr_head)" = "feature/relaunch" ] \
+    || fail "the task PR head must survive relaunch"
+  [ "$(meta_field "$dir" rl19 x_request)" = "request-19" ] \
+    || fail "the task X request must survive relaunch"
+  [ "$(meta_field "$dir" rl19 decisions_reviewed)" = 1 ] \
+    || fail "the task decision state must survive relaunch"
+  pass "fm-control relaunch: durable task metadata survives replacement launch publication"
+}
+
+test_relaunch_serializes_concurrent_durable_metadata_publication() {
+  local dir control_pid link_out rc i=0
+  dir=$(new_case metadata-race rl28)
+  add_ship_task "$dir" rl28 claude
+  make_meta_race_awk_stub "$dir"
+  FM_REAL_AWK=$(command -v awk) \
+    FM_FAKE_META_RACE_PATH="$dir/home/state/rl28.meta" \
+    FM_FAKE_META_RACE_READY="$dir/meta-race-ready" \
+    run_control "$dir" rl28 relaunch --note "continue after publication" > "$dir/control.out" &
+  control_pid=$!
+  while [ ! -e "$dir/meta-race-ready" ] && [ "$i" -lt 200 ]; do
+    /bin/sleep 0.01
+    i=$((i + 1))
+  done
+  [ -e "$dir/meta-race-ready" ] || {
+    kill "$control_pid" 2>/dev/null || true
+    wait "$control_pid" 2>/dev/null || true
+    fail "relaunch did not reach metadata publication"
+  }
+  link_out=$(env PATH="$dir/fakebin:$PATH" FM_HOME="$dir/home" FM_ROOT_OVERRIDE="$ROOT" \
+    FM_REAL_AWK="$(command -v awk)" \
+    "$X_LINK" rl28 request-28 --carry-count 1 --carry-ts 1700000000 \
+      --carry-platform x --carry-max 280 2>&1); rc=$?
+  expect_code 0 "$rc" "concurrent X metadata publication should serialize"$'\n'"$link_out"
+  wait "$control_pid"; rc=$?
+  expect_code 0 "$rc" "relaunch should complete after serialized metadata publication"$'\n'"$(cat "$dir/control.out")"
+  [ "$(meta_field "$dir" rl28 x_request)" = request-28 ] \
+    || fail "relaunch erased metadata published concurrently through the X interface"
+  [ "$(meta_field "$dir" rl28 x_followups)" = 1 ] \
+    || fail "relaunch erased the concurrent follow-up count"
+  pass "fm-control relaunch: concurrent task metadata publications serialize"
+}
+
+test_relaunch_appends_the_progress_note_to_the_instructions() {
+  local dir out rc brief
+  dir=$(new_case note rl2)
+  add_ship_task "$dir" rl2 claude
+  out=$(run_control "$dir" rl2 relaunch --note "reproduced the crash in parser.go"); rc=$?
+  expect_code 0 "$rc" "relaunch should succeed"$'\n'"$out"
+  brief="$dir/home/data/rl2/brief.md"
+  assert_grep "Do the thing." "$brief" "the original instructions must survive"
+  assert_grep "## Progress note" "$brief" "the note should be a dated section in the instructions"
+  assert_grep "reproduced the crash in parser.go" "$brief" "the note text should reach the replacement"
+  assert_grep "reproduced the crash in parser.go" "$dir/home/state/rl2.control-relaunch.note" \
+    "the note should also be preserved beside the transaction record"
+  pass "fm-control relaunch: the progress note lands in the instructions the replacement reads"
+}
+
+test_relaunch_requires_a_note_for_a_ship_task() {
+  local dir out rc before
+  dir=$(new_case nonote rl3)
+  add_ship_task "$dir" rl3 claude
+  before=$(cat "$dir/home/data/rl3/brief.md")
+  out=$(run_control "$dir" rl3 relaunch); rc=$?
+  expect_code 1 "$rc" "a ship relaunch without a note should refuse"
+  assert_contains "$out" "requires --note" "the refusal should name the missing note"
+  [ "$(cat "$dir/home/data/rl3/brief.md")" = "$before" ] \
+    || fail "a refused relaunch must not touch the instructions"
+  [ -z "$(cat "$dir/fake/literal")" ] || fail "a refused relaunch must send nothing"
+  [ "$(cat "$dir/fake/command")" = claude ] || fail "a refused relaunch must not stop the agent"
+  pass "fm-control relaunch: a ship task refuses without the progress note its replacement needs"
+}
+
+# --- 2. harness switch -------------------------------------------------------
+
+test_harness_switch_moves_the_record_and_clears_prior_wiring() {
+  local dir out rc
+  dir=$(new_case switch rl4)
+  add_ship_task "$dir" rl4 claude
+  # Wiring the previous claude incarnation left in the worktree.
+  mkdir -p "$dir/wt/.claude"
+  printf '{"hooks":{}}\n' > "$dir/wt/.claude/settings.local.json"
+  printf 'codex' > "$dir/fake/becomes"
+  out=$(run_control "$dir" rl4 relaunch --harness codex --note "switching runtime"); rc=$?
+  expect_code 0 "$rc" "a harness switch should succeed"$'\n'"$out"
+  assert_contains "$out" "harness=codex from=claude" "the outcome should name both harnesses"
+  [ "$(meta_field "$dir" rl4 harness)" = codex ] || fail "the record should follow the switch"
+  [ ! -e "$dir/wt/.claude/settings.local.json" ] \
+    || fail "the previous harness's per-task wiring must be cleared on a switch"
+  assert_grep "codex" "$dir/fake/literal" "the replacement launch should be the new harness"
+  [ "$(journal_field "$dir" rl4 from_harness)" = claude ] || fail "the journal should record the origin harness"
+  [ "$(journal_field "$dir" rl4 to_harness)" = codex ] || fail "the journal should record the target harness"
+  pass "fm-control relaunch: switching harness is one ordinary relaunch, and the old wiring goes with the old agent"
+}
+
+test_harness_switch_does_not_carry_the_old_profile_axes() {
+  local dir out rc
+  dir=$(new_case profile rl5)
+  add_ship_task "$dir" rl5 claude
+  sed 's/^model=default$/model=opus/; s/^effort=default$/effort=xhigh/' \
+    "$dir/home/state/rl5.meta" > "$dir/home/state/rl5.meta.tmp"
+  mv "$dir/home/state/rl5.meta.tmp" "$dir/home/state/rl5.meta"
+  printf 'codex' > "$dir/fake/becomes"
+  out=$(run_control "$dir" rl5 relaunch --harness codex --note "switching runtime"); rc=$?
+  expect_code 0 "$rc" "a harness switch should succeed"$'\n'"$out"
+  [ "$(meta_field "$dir" rl5 model)" = default ] \
+    || fail "a model chosen for the old harness must not carry to a different one"
+  [ "$(meta_field "$dir" rl5 effort)" = default ] \
+    || fail "an effort chosen for the old harness must not carry to a different one"
+  pass "fm-control relaunch: a harness switch resets model and effort unless they are named too"
+}
+
+test_same_harness_relaunch_keeps_the_profile_axes() {
+  local dir out rc
+  dir=$(new_case keepprofile rl6)
+  add_ship_task "$dir" rl6 claude
+  sed 's/^model=default$/model=opus/; s/^effort=default$/effort=high/' \
+    "$dir/home/state/rl6.meta" > "$dir/home/state/rl6.meta.tmp"
+  mv "$dir/home/state/rl6.meta.tmp" "$dir/home/state/rl6.meta"
+  out=$(run_control "$dir" rl6 relaunch --note "same runtime"); rc=$?
+  expect_code 0 "$rc" "a same-harness relaunch should succeed"$'\n'"$out"
+  [ "$(meta_field "$dir" rl6 model)" = opus ] || fail "the model should carry across a same-harness relaunch"
+  [ "$(meta_field "$dir" rl6 effort)" = high ] || fail "the effort should carry across a same-harness relaunch"
+  pass "fm-control relaunch: a same-harness relaunch keeps the profile axes it was running with"
+}
+
+test_explicit_model_wins_over_the_recorded_one() {
+  local dir out rc
+  dir=$(new_case explicit rl7)
+  add_ship_task "$dir" rl7 claude
+  out=$(run_control "$dir" rl7 relaunch --model sonnet --effort low --note "dialling down"); rc=$?
+  expect_code 0 "$rc" "relaunch with explicit axes should succeed"$'\n'"$out"
+  [ "$(meta_field "$dir" rl7 model)" = sonnet ] || fail "an explicit model should be recorded"
+  [ "$(meta_field "$dir" rl7 effort)" = low ] || fail "an explicit effort should be recorded"
+  pass "fm-control relaunch: explicit model and effort win over the recorded ones"
+}
+
+test_relaunch_onto_an_unverified_harness_is_refused() {
+  local dir out rc
+  dir=$(new_case badharness rl8)
+  add_ship_task "$dir" rl8 claude
+  out=$(run_control "$dir" rl8 relaunch --harness someagent --note "x"); rc=$?
+  expect_code 1 "$rc" "an unverified target harness should refuse"
+  assert_contains "$out" "not a verified harness" "the refusal should name the unverified adapter"
+  [ "$(cat "$dir/fake/command")" = claude ] || fail "a refused relaunch must not stop the agent"
+  pass "fm-control relaunch: refuses to relaunch onto an adapter with no verified mechanics"
+}
+
+test_prior_harness_turnend_registry_entry_is_cleared() {
+  local dir auth
+  dir=$(new_case grokauth rl9)
+  add_ship_task "$dir" rl9 grok
+  mkdir -p "$dir/grokhome/hooks/fm-turn-end.d"
+  printf 'fm.abcdefabcdef\n' > "$dir/home/state/rl9.grok-turnend-token"
+  auth="$dir/grokhome/hooks/fm-turn-end.d/fm.abcdefabcdef"
+  printf '%s\n' "$dir/home/state/rl9.turn-ended" > "$auth"
+  printf 'grok' > "$dir/fake/command"
+  printf 'grok' > "$dir/fake/becomes"
+  run_control "$dir" rl9 relaunch --note "restart on the same runtime" >/dev/null
+  [ ! -e "$auth" ] \
+    || fail "the previous incarnation's turn-end registry entry must not outlive it"
+  pass "fm-control relaunch: the retired incarnation's global turn-end token is revoked"
+}
+
+test_wiring_removal_failure_refuses_before_replacement_arm() {
+  local dir hook out rc real_rm
+  dir=$(new_case wiring-failure rl29)
+  add_ship_task "$dir" rl29 claude
+  hook="$dir/wt/.claude/settings.local.json"
+  mkdir -p "${hook%/*}"
+  printf '{}\n' > "$hook"
+  real_rm=$(command -v rm)
+  make_rm_failure_stub "$dir"
+  out=$(FM_REAL_RM="$real_rm" FM_FAKE_RM_FAIL_PATH="$hook" \
+    run_control "$dir" rl29 relaunch --note "retry after wiring cleanup"); rc=$?
+  expect_code 1 "$rc" "an undeletable prior hook must fail closed"$'\n'"$out"
+  assert_contains "$out" "could not retire claude wiring" \
+    "the failure should identify prior wiring cleanup"
+  [ -e "$hook" ] || fail "the fixture should retain the undeletable prior hook"
+  assert_no_grep "encode launch-brief" "$dir/fake/literal" \
+    "replacement launch must not be armed after wiring cleanup fails"
+  [ "$(journal_field "$dir" rl29 phase)" = failed:launching ] \
+    || fail "the transaction should record the partial launch failure"
+  [ "$(journal_field "$dir" rl29 rollback)" = prior-record-kept ] \
+    || fail "unpublished rollback should retain the live durable record"
+  pass "fm-control relaunch: wiring cleanup failure refuses replacement arming"
+}
+
+test_turnend_auth_paths_are_owned_by_the_control_adapter() {
+  local dir state grok_path kimi_path token_path
+  dir=$(fm_test_tmproot fm-control-auth)
+  state="$dir/state"
+  mkdir -p "$state"
+  printf 'fm.111111111111\n' > "$state/x.grok-turnend-token"
+  printf 'fm.222222222222\n' > "$state/x.kimi-turnend-token"
+  token_path=$(fm_control_harness_turnend_token_path grok "$state" x)
+  [ "$token_path" = "$state/x.grok-turnend-token" ] \
+    || fail "the grok token path should be computed without reading it"
+  grok_path=$(GROK_HOME="$dir/gh" fm_control_harness_turnend_auth_path grok fm.111111111111)
+  [ "$grok_path" = "$dir/gh/hooks/fm-turn-end.d/fm.111111111111" ] \
+    || fail "grok's registry path should resolve under GROK_HOME, got '$grok_path'"
+  kimi_path=$(HOME="$dir/kh" fm_control_harness_turnend_auth_path kimi fm.222222222222)
+  [ "$kimi_path" = "$dir/kh/.kimi-code/fm-turn-end.d/fm.222222222222" ] \
+    || fail "kimi's registry path should resolve under the home store, got '$kimi_path'"
+  grok_path=$(GROK_HOME="$dir/gh" fm_control_harness_turnend_auth_path grok 'not a token/../..')
+  [ -z "$grok_path" ] || fail "a malformed token must resolve to no path, got '$grok_path'"
+  pass "fm-control-lib: one owner resolves each harness's turn-end registry entry, and refuses a malformed token"
+}
+
+test_secondmate_relaunch_picks_up_the_configured_harness_pin() {
+  local dir home out rc
+  dir=$(new_case smpin sm3)
+  home="$dir/home"
+  mkdir -p "$home/config"
+  printf 'codex some-model high\n' > "$home/config/secondmate-harness"
+  mkdir -p "$home/data/sm3"
+  printf '# secondmate brief\n' > "$home/data/sm3/brief.md"
+  fm_git_worktree "$dir/proj" "$dir/smhome" sm-branch
+  mkdir -p "$dir/smhome/state" "$dir/smhome/data" "$dir/smhome/bin"
+  printf 'sm3\n' > "$dir/smhome/.fm-secondmate-home"
+  printf '# agents\n' > "$dir/smhome/AGENTS.md"
+  {
+    echo "window=fmses:fm-sm3"
+    echo "endpoint_task_id=sm3"
+    echo "worktree=$dir/smhome"
+    echo "project=$dir/smhome"
+    echo "harness=claude"
+    echo "kind=secondmate"
+    echo "mode=secondmate"
+    echo "yolo=off"
+    echo "model=default"
+    echo "effort=default"
+    echo "home=$dir/smhome"
+  } > "$home/state/sm3.meta"
+  printf '%s\n' "fm-sm3" > "$dir/fake/windows"
+  printf '%s' "$dir/smhome" > "$dir/fake/cwd"
+  printf 'codex' > "$dir/fake/becomes"
+  out=$(run_control "$dir" sm3 relaunch); rc=$?
+  expect_code 0 "$rc" "a configured secondmate harness should relaunch"$'\n'"$out"
+  [ "$(journal_field "$dir" sm3 to_harness)" = codex ] \
+    || fail "a secondmate relaunch should pick up the configured harness pin, got '$(journal_field "$dir" sm3 to_harness)'"
+  [ "$(journal_field "$dir" sm3 to_model)" = some-model ] \
+    || fail "the configured model token should come with the pin"
+  [ "$(journal_field "$dir" sm3 to_effort)" = high ] \
+    || fail "the configured effort token should come with the pin"
+  assert_not_contains "$out" "not a verified harness" "codex is a verified harness"
+  pass "fm-control relaunch: a secondmate relaunch re-resolves its durable configured harness pin"
+}
+
+test_secondmate_relaunch_ignores_invalid_configured_effort_before_stop() {
+  local dir home out rc
+  dir=$(new_case invalid-effort sm6)
+  home="$dir/home"
+  mkdir -p "$home/config" "$home/data/sm6"
+  printf 'codex some-model impossible\n' > "$home/config/secondmate-harness"
+  printf '# secondmate brief\n' > "$home/data/sm6/brief.md"
+  fm_git_worktree "$dir/proj" "$dir/smhome" sm-branch
+  mkdir -p "$dir/smhome/state" "$dir/smhome/data" "$dir/smhome/bin"
+  printf 'sm6\n' > "$dir/smhome/.fm-secondmate-home"
+  printf '# agents\n' > "$dir/smhome/AGENTS.md"
+  {
+    echo "window=fmses:fm-sm6"
+    echo "endpoint_task_id=sm6"
+    echo "worktree=$dir/smhome"
+    echo "project=$dir/smhome"
+    echo "harness=claude"
+    echo "kind=secondmate"
+    echo "mode=secondmate"
+    echo "yolo=off"
+    echo "model=default"
+    echo "effort=default"
+    echo "home=$dir/smhome"
+  } > "$home/state/sm6.meta"
+  printf '%s\n' "fm-sm6" > "$dir/fake/windows"
+  printf '%s' "$dir/smhome" > "$dir/fake/cwd"
+  printf 'codex' > "$dir/fake/becomes"
+  out=$(run_control "$dir" sm6 relaunch); rc=$?
+  expect_code 0 "$rc" "an invalid configured effort should be ignored before stop"$'\n'"$out"
+  assert_contains "$out" "effort token 'impossible'" \
+    "relaunch should surface the same warning as a normal secondmate spawn"
+  [ "$(journal_field "$dir" sm6 to_effort)" = default ] \
+    || fail "invalid configured effort should normalize to default"
+  pass "fm-control relaunch: invalid configured effort is ignored before stop"
+}
+
+# muse is a verified adapter, but only for crewmates and scouts: it has no
+# primary supervision protocol, so bin/fm-spawn.sh refuses it for a secondmate.
+# That refusal alone is not enough here, because the launch owner is reached
+# only AFTER the running agent has been stopped - a secondmate would be left
+# with no agent at all. The control plane asks the same capability question
+# before it touches anything, so the refusal lands while the agent is still up.
+test_secondmate_relaunch_onto_a_crewmate_only_adapter_refuses_before_stop() {
+  local dir home out rc
+  dir=$(new_case smkind sm7)
+  home="$dir/home"
+  mkdir -p "$home/config" "$home/data/sm7"
+  printf '# secondmate brief\n' > "$home/data/sm7/brief.md"
+  fm_git_worktree "$dir/proj" "$dir/smhome" sm-branch
+  mkdir -p "$dir/smhome/state" "$dir/smhome/data" "$dir/smhome/bin"
+  printf 'sm7\n' > "$dir/smhome/.fm-secondmate-home"
+  printf '# agents\n' > "$dir/smhome/AGENTS.md"
+  {
+    echo "window=fmses:fm-sm7"
+    echo "endpoint_task_id=sm7"
+    echo "worktree=$dir/smhome"
+    echo "project=$dir/smhome"
+    echo "harness=claude"
+    echo "kind=secondmate"
+    echo "mode=secondmate"
+    echo "yolo=off"
+    echo "model=default"
+    echo "effort=default"
+    echo "home=$dir/smhome"
+  } > "$home/state/sm7.meta"
+  printf '%s\n' "fm-sm7" > "$dir/fake/windows"
+  printf '%s' "$dir/smhome" > "$dir/fake/cwd"
+  out=$(run_control "$dir" sm7 relaunch --harness muse); rc=$?
+  expect_code 1 "$rc" "a crewmate-only adapter should refuse a secondmate relaunch"
+  assert_contains "$out" "not verified to run a secondmate task" \
+    "the refusal should name the kind the adapter cannot run"
+  [ "$(cat "$dir/fake/command")" = claude ] \
+    || fail "the refusal must land before the running agent is stopped"
+  [ "$(meta_field "$dir" sm7 harness)" = claude ] \
+    || fail "a refused relaunch must leave the durable record on the recorded harness"
+  pass "fm-control relaunch: an adapter unverified for this task kind refuses before the agent is stopped"
+}
+
+test_explicit_secondmate_harness_ignores_configured_profile_axes() {
+  local dir home out rc
+  dir=$(new_case smexplicit sm4)
+  home="$dir/home"
+  mkdir -p "$home/config"
+  printf 'claude opus high\n' > "$home/config/secondmate-harness"
+  mkdir -p "$home/data/sm4"
+  printf '# secondmate brief\n' > "$home/data/sm4/brief.md"
+  fm_git_worktree "$dir/proj" "$dir/smhome" sm-branch
+  mkdir -p "$dir/smhome/state" "$dir/smhome/data" "$dir/smhome/bin"
+  printf 'sm4\n' > "$dir/smhome/.fm-secondmate-home"
+  printf '# agents\n' > "$dir/smhome/AGENTS.md"
+  {
+    echo "window=fmses:fm-sm4"
+    echo "endpoint_task_id=sm4"
+    echo "worktree=$dir/smhome"
+    echo "project=$dir/smhome"
+    echo "harness=claude"
+    echo "kind=secondmate"
+    echo "mode=secondmate"
+    echo "yolo=off"
+    echo "model=opus"
+    echo "effort=high"
+    echo "home=$dir/smhome"
+  } > "$home/state/sm4.meta"
+  printf '%s\n' "fm-sm4" > "$dir/fake/windows"
+  printf '%s' "$dir/smhome" > "$dir/fake/cwd"
+  printf 'codex' > "$dir/fake/becomes"
+  out=$(run_control "$dir" sm4 relaunch --harness codex); rc=$?
+  expect_code 0 "$rc" "an explicit secondmate harness should relaunch"$'\n'"$out"
+  [ "$(meta_field "$dir" sm4 model)" = default ] \
+    || fail "an explicit secondmate harness must not inherit the configured model"
+  [ "$(meta_field "$dir" sm4 effort)" = default ] \
+    || fail "an explicit secondmate harness must not inherit the configured effort"
+  pass "fm-control relaunch: explicit secondmate harness resets unnamed profile axes"
+}
+
+test_ship_relaunch_ignores_the_crew_harness_config() {
+  local dir out
+  dir=$(new_case crewcfg rl20)
+  add_ship_task "$dir" rl20 claude
+  mkdir -p "$dir/home/config"
+  printf 'codex\n' > "$dir/home/config/crew-harness"
+  out=$(run_control "$dir" rl20 relaunch --note "same worker, same runtime")
+  assert_contains "$out" "harness=claude from=claude" \
+    "a ship relaunch must keep its recorded harness rather than re-reading crew config"
+  [ "$(meta_field "$dir" rl20 harness)" = claude ] \
+    || fail "a ship relaunch must not silently move onto the configured crew harness"
+  pass "fm-control relaunch: a ship task keeps its recorded harness instead of re-reading crew config"
+}
+
+test_spawn_relaunch_without_a_harness_reuses_the_recorded_one() {
+  local dir out
+  dir=$(new_case spawnharness rl21)
+  add_ship_task "$dir" rl21 claude
+  mkdir -p "$dir/home/config"
+  printf 'codex\n' > "$dir/home/config/crew-harness"
+  printf 'zsh' > "$dir/fake/command"
+  out=$(run_spawn "$dir" rl21 --relaunch)
+  [ "$(meta_field "$dir" rl21 harness)" = claude ] \
+    || fail "fm-spawn --relaunch without --harness must reuse the recorded harness, got '$(meta_field "$dir" rl21 harness)'"
+  assert_contains "$out" "spawned rl21 harness=claude" "the launch should report the recorded harness"
+  pass "fm-spawn --relaunch: with no explicit harness it reuses the task's recorded one, never the crew default"
+}
+
+# --- 3 and 4. refusals before the agent is touched ---------------------------
+
+test_missing_worktree_refuses_before_stopping_anything() {
+  local dir out rc
+  dir=$(new_case nowt rl10)
+  add_ship_task "$dir" rl10 claude
+  rm -rf "$dir/wt"
+  out=$(run_control "$dir" rl10 relaunch --note "x"); rc=$?
+  expect_code 1 "$rc" "a missing worktree should refuse"
+  assert_contains "$out" "recorded worktree" "the refusal should name the missing local copy"
+  [ "$(cat "$dir/fake/command")" = claude ] || fail "a refused relaunch must not stop the agent"
+  [ -z "$(cat "$dir/fake/literal")" ] || fail "a refused relaunch must send nothing"
+  pass "fm-control relaunch: an unaccountable local copy refuses before the agent is touched"
+}
+
+test_missing_instructions_refuse_before_stopping_anything() {
+  local dir out rc
+  dir=$(new_case nobrief rl11)
+  add_ship_task "$dir" rl11 claude
+  rm -f "$dir/home/data/rl11/brief.md"
+  out=$(run_control "$dir" rl11 relaunch --note "x"); rc=$?
+  expect_code 1 "$rc" "missing instructions should refuse"
+  assert_contains "$out" "no instructions" "the refusal should name the missing instructions"
+  [ "$(cat "$dir/fake/command")" = claude ] || fail "a refused relaunch must not stop the agent"
+  pass "fm-control relaunch: a worker with nothing to work from is never launched"
+}
+
+test_checkpoint_refusal_leaves_the_record_byte_identical() {
+  local dir before after
+  dir=$(new_case bytes rl12)
+  add_ship_task "$dir" rl12 claude
+  before=$(cat "$dir/home/state/rl12.meta")
+  rm -rf "$dir/wt/.git"
+  run_control "$dir" rl12 relaunch --note "x" >/dev/null 2>&1
+  after=$(cat "$dir/home/state/rl12.meta")
+  [ "$before" = "$after" ] || fail "a refused relaunch must leave the durable record byte-identical"
+  pass "fm-control relaunch: a refusal before the agent is stopped leaves the durable record untouched"
+}
+
+test_checkpoint_refuses_uninspectable_head_and_status() {
+  local dir out rc real_git
+  real_git=$(command -v git)
+
+  dir=$(new_case badhead rl22)
+  add_ship_task "$dir" rl22 claude
+  make_git_failure_stub "$dir"
+  out=$(FM_REAL_GIT="$real_git" FM_FAKE_GIT_FAILURE=head \
+    run_control "$dir" rl22 relaunch --note "x"); rc=$?
+  expect_code 1 "$rc" "an uninspectable HEAD should refuse"
+  assert_contains "$out" "HEAD cannot be inspected" "the refusal should name the failed HEAD proof"
+  [ "$(cat "$dir/fake/command")" = claude ] || fail "HEAD inspection failure must not stop the agent"
+
+  dir=$(new_case badstatus rl23)
+  add_ship_task "$dir" rl23 claude
+  make_git_failure_stub "$dir"
+  out=$(FM_REAL_GIT="$real_git" FM_FAKE_GIT_FAILURE=status \
+    run_control "$dir" rl23 relaunch --note "x"); rc=$?
+  expect_code 1 "$rc" "an uninspectable worktree status should refuse"
+  assert_contains "$out" "status cannot be inspected" "the refusal should name the failed dirty-state proof"
+  [ "$(cat "$dir/fake/command")" = claude ] || fail "status inspection failure must not stop the agent"
+  pass "fm-control relaunch: checkpoint inspection failures refuse before stopping"
+}
+
+# --- 5. failure after the agent is stopped -----------------------------------
+
+test_launch_failure_keeps_the_prior_record_and_reports_it() {
+  local dir out rc before
+  dir=$(new_case rollback rl13)
+  add_ship_task "$dir" rl13 claude
+  before=$(cat "$dir/home/state/rl13.meta")
+  # The endpoint's shell is not in the recorded worktree, so the launch owner
+  # refuses AFTER the previous agent has already been stopped.
+  printf '%s' "$dir/proj" > "$dir/fake/cwd"
+  out=$(run_control "$dir" rl13 relaunch --harness codex --note "carry this forward"); rc=$?
+  expect_code 1 "$rc" "a failed launch should fail closed"$'\n'"$out"
+  assert_contains "$out" "no agent is running" "the failure should say no agent is running"
+  assert_contains "$out" "$dir/wt" "the failure should say where the work is preserved"
+  [ "$(cat "$dir/home/state/rl13.meta")" = "$before" ] \
+    || fail "a failed launch must keep the prior durable record"
+  [ "$(journal_field "$dir" rl13 phase)" = "failed:launching" ] \
+    || fail "the journal should record the failed phase, got '$(journal_field "$dir" rl13 phase)'"
+  [ "$(journal_field "$dir" rl13 rollback)" = "prior-record-kept" ] \
+    || fail "the journal should record what the rollback did"
+  assert_grep "carry this forward" "$dir/home/data/rl13/brief.md" \
+    "the progress note must survive so a later recovery still has it"
+  pass "fm-control relaunch: a launch failure after the stop keeps the prior record and reports the real state"
+}
+
+test_prepublication_failure_keeps_concurrent_durable_metadata() {
+  local dir control_pid link_out rc i=0
+  dir=$(new_case rollback-race rl30)
+  add_ship_task "$dir" rl30 claude
+  printf '%s' "$dir/proj" > "$dir/fake/cwd"
+  FM_FAKE_CWD_RACE_READY="$dir/cwd-race-ready" \
+    run_control "$dir" rl30 relaunch --harness codex --note "preserve concurrent metadata" \
+      > "$dir/control.out" &
+  control_pid=$!
+  while [ ! -e "$dir/cwd-race-ready" ] && [ "$i" -lt 200 ]; do
+    /bin/sleep 0.01
+    i=$((i + 1))
+  done
+  [ -e "$dir/cwd-race-ready" ] || {
+    kill "$control_pid" 2>/dev/null || true
+    wait "$control_pid" 2>/dev/null || true
+    fail "relaunch did not reach its pre-publication endpoint check"
+  }
+  link_out=$(env PATH="$dir/fakebin:$PATH" FM_HOME="$dir/home" FM_ROOT_OVERRIDE="$ROOT" \
+    "$X_LINK" rl30 request-30 --carry-count 2 --carry-ts 1700000000 \
+      --carry-platform x --carry-max 280 2>&1); rc=$?
+  expect_code 0 "$rc" "concurrent durable metadata publication should succeed"$'\n'"$link_out"
+  wait "$control_pid"; rc=$?
+  expect_code 1 "$rc" "the staged pre-publication launch failure should fail closed"
+  [ "$(meta_field "$dir" rl30 x_request)" = request-30 ] \
+    || fail "rollback erased the concurrent X request"
+  [ "$(meta_field "$dir" rl30 x_followups)" = 2 ] \
+    || fail "rollback erased the concurrent follow-up count"
+  [ "$(journal_field "$dir" rl30 rollback)" = prior-record-kept ] \
+    || fail "pre-publication rollback should leave the live record untouched"
+  pass "fm-control relaunch: unpublished rollback keeps concurrent durable metadata"
+}
+
+test_post_publication_launch_failure_keeps_the_new_record() {
+  local dir out rc
+  dir=$(new_case published rl24)
+  add_ship_task "$dir" rl24 claude
+  printf 'codex' > "$dir/fake/becomes"
+  out=$(FM_FAKE_LAUNCH_TRANSPORT_FAIL_AFTER_START=1 \
+    run_control "$dir" rl24 relaunch --harness codex --note "keep the published record"); rc=$?
+  expect_code 1 "$rc" "a post-publication launch failure should fail closed"$'\n'"$out"
+  [ "$(meta_field "$dir" rl24 harness)" = codex ] \
+    || fail "a published replacement record must not be rewritten to the prior harness"
+  [ -n "$(meta_field "$dir" rl24 control_relaunch_tx)" ] \
+    || fail "the published replacement record should identify its relaunch transaction"
+  [ "$(journal_field "$dir" rl24 rollback)" = none-new-record-kept ] \
+    || fail "the journal should record that the published replacement record was kept"
+  pass "fm-control relaunch: post-publication failure keeps the new durable record"
+}
+
+test_stop_transport_failure_reconciles_a_dead_agent() {
+  local dir out rc
+  dir=$(new_case stopfail rl25)
+  add_ship_task "$dir" rl25 claude
+  out=$(FM_FAKE_EXIT_TRANSPORT_FAIL_AFTER_STOP=1 \
+    run_control "$dir" rl25 relaunch --note "preserve this after stop"); rc=$?
+  expect_code 1 "$rc" "a stop transport failure should fail closed"$'\n'"$out"
+  [ "$(cat "$dir/fake/command")" = zsh ] || fail "the fixture should stop the old agent before reporting transport failure"
+  [ "$(journal_field "$dir" rl25 phase)" = failed:stopping ] \
+    || fail "the journal should retain the pre-stop phase on a partial stop"
+  [ "$(journal_field "$dir" rl25 rollback)" = prior-record-kept-agent-dead ] \
+    || fail "rollback should reconcile the observed dead agent"
+  assert_contains "$out" "no agent is running" "the failure should report the reconciled dead state"
+  assert_grep "preserve this after stop" "$dir/home/data/rl25/brief.md" \
+    "the progress note should survive once the old agent has stopped"
+  pass "fm-control relaunch: partial stop reconciles actual agent state"
+}
+
+test_complete_journal_failure_rolls_back_from_durable_phase() {
+  local dir out rc real_mv
+  dir=$(new_case completejournal rl27)
+  add_ship_task "$dir" rl27 claude
+  printf 'codex' > "$dir/fake/becomes"
+  real_mv=$(command -v mv)
+  make_mv_failure_stub "$dir"
+  out=$(FM_REAL_MV="$real_mv" FM_FAKE_COMPLETE_JOURNAL_MV_FAIL=1 \
+    run_control "$dir" rl27 relaunch --harness codex --note "keep durable phase honest"); rc=$?
+  expect_code 1 "$rc" "a failed complete journal replacement should fail closed"$'\n'"$out"
+  [ "$(journal_field "$dir" rl27 phase)" = failed:launching ] \
+    || fail "rollback should start from the last durable launching phase"
+  [ "$(journal_field "$dir" rl27 rollback)" = none-new-agent-confirmed ] \
+    || fail "rollback should retain the confirmed-running replacement"
+  [ "$(meta_field "$dir" rl27 harness)" = codex ] \
+    || fail "journal failure must not rewrite the published replacement record"
+  assert_contains "$out" "replacement is running" \
+    "journal failure should report the confirmed-running replacement"
+  assert_not_contains "$out" "no running agent could be confirmed" \
+    "journal failure should not contradict the confirmed agent state"
+  pass "fm-control relaunch: failed journal replacement preserves durable phase"
+}
+
+test_prepublication_abort_retires_replacement_wiring_and_busy_state() {
+  local dir out rc real_mv meta
+  dir=$(new_case prepublishcleanup rl28)
+  add_ship_task "$dir" rl28 claude
+  meta="$dir/home/state/rl28.meta"
+  real_mv=$(command -v mv)
+  make_mv_failure_stub "$dir"
+  out=$(FM_REAL_MV="$real_mv" FM_FAKE_META_PUBLISH_MV_FAIL="$meta" \
+    run_control "$dir" rl28 relaunch --note "clean partial replacement state"); rc=$?
+  expect_code 1 "$rc" "a failed metadata publication should fail closed"$'\n'"$out"
+  [ "$(meta_field "$dir" rl28 harness)" = claude ] \
+    || fail "a failed publication should retain the prior durable record"
+  [ ! -e "$dir/wt/.claude/settings.local.json" ] \
+    || fail "an aborted replacement should remove its harness wiring"
+  [ ! -e "$dir/home/state/rl28.busy-gen" ] \
+    || fail "an aborted replacement should retire its busy generation"
+  [ ! -e "$dir/home/state/rl28.busy-state" ] \
+    || fail "an aborted replacement should remove its seeded busy record"
+  [ "$(journal_field "$dir" rl28 rollback)" = prior-record-kept ] \
+    || fail "the journal should record the unpublished replacement rollback"
+  pass "fm-spawn relaunch: prepublication abort removes replacement state"
+}
+
+test_journal_records_the_checkpoint_it_proved() {
+  local dir head
+  dir=$(new_case journal rl14)
+  add_ship_task "$dir" rl14 claude
+  printf 'scratch\n' > "$dir/wt/uncommitted.txt"
+  head=$(git -C "$dir/wt" rev-parse HEAD)
+  run_control "$dir" rl14 relaunch --note "keeping the scratch file" >/dev/null
+  [ "$(journal_field "$dir" rl14 worktree_head)" = "$head" ] \
+    || fail "the checkpoint should record the head it preserved"
+  [ "$(journal_field "$dir" rl14 worktree_dirty)" = yes ] \
+    || fail "the checkpoint should record that uncommitted work was present"
+  [ -f "$dir/wt/uncommitted.txt" ] || fail "uncommitted work must survive a relaunch"
+  pass "fm-control relaunch: the checkpoint records the exact unlanded work it preserved"
+}
+
+# --- secondmate child-work safety -------------------------------------------
+
+test_secondmate_relaunch_checkpoints_child_work_and_spares_the_charter() {
+  local dir home out rc
+  dir=$(new_case sm sm1)
+  home="$dir/home"
+  mkdir -p "$home/config"
+  printf 'claude\n' > "$home/config/secondmate-harness"
+  fm_git_worktree "$dir/proj" "$dir/smhome" sm-branch
+  mkdir -p "$dir/smhome/state" "$dir/smhome/data" "$dir/smhome/bin"
+  printf 'sm1\n' > "$dir/smhome/.fm-secondmate-home"
+  printf '# charter\n' > "$dir/smhome/data/charter.md"
+  printf '# agents\n' > "$dir/smhome/AGENTS.md"
+  printf 'window=x:fm-c1\n' > "$dir/smhome/state/c1.meta"
+  printf 'window=x:fm-c2\n' > "$dir/smhome/state/c2.meta"
+  {
+    echo "window=fmses:fm-sm1"
+    echo "endpoint_task_id=sm1"
+    echo "worktree=$dir/smhome"
+    echo "project=$dir/smhome"
+    echo "harness=claude"
+    echo "kind=secondmate"
+    echo "mode=secondmate"
+    echo "yolo=off"
+    echo "model=default"
+    echo "effort=default"
+    echo "home=$dir/smhome"
+    echo "projects="
+  } > "$home/state/sm1.meta"
+  printf '%s\n' "fm-sm1" > "$dir/fake/windows"
+  printf '%s' "$dir/smhome" > "$dir/fake/cwd"
+  # No --note: a secondmate reconciles its own home's records at startup, so
+  # the note is optional there.
+  out=$(run_control "$dir" sm1 relaunch); rc=$?
+  expect_code 0 "$rc" "a checkpointed secondmate should relaunch"$'\n'"$out"
+  [ "$(journal_field "$dir" sm1 children)" = 2 ] \
+    || fail "the checkpoint must account for the secondmate's child work, got '$(journal_field "$dir" sm1 children)'"
+  assert_not_contains "$out" "requires --note" "a secondmate relaunch must not demand a progress note"
+  [ "$(cat "$dir/smhome/data/charter.md")" = "# charter" ] \
+    || fail "a secondmate's standing charter must never be rewritten by a relaunch"
+  assert_present "$dir/smhome/state/c1.meta" "child records must survive the relaunch"
+  assert_present "$dir/smhome/state/c2.meta" "child records must survive the relaunch"
+  pass "fm-control relaunch: a secondmate's child work is accounted for and its charter is left alone"
+}
+
+test_secondmate_relaunch_refuses_an_unmarked_home() {
+  local dir home out rc
+  dir=$(new_case smbad sm2)
+  home="$dir/home"
+  mkdir -p "$home/config"
+  printf 'claude\n' > "$home/config/secondmate-harness"
+  fm_git_worktree "$dir/proj" "$dir/smhome" sm-branch
+  mkdir -p "$dir/smhome/state"
+  printf 'someone-else\n' > "$dir/smhome/.fm-secondmate-home"
+  {
+    echo "window=fmses:fm-sm2"
+    echo "endpoint_task_id=sm2"
+    echo "worktree=$dir/smhome"
+    echo "project=$dir/smhome"
+    echo "harness=claude"
+    echo "kind=secondmate"
+    echo "mode=secondmate"
+    echo "yolo=off"
+  } > "$home/state/sm2.meta"
+  printf '%s\n' "fm-sm2" > "$dir/fake/windows"
+  out=$(run_control "$dir" sm2 relaunch); rc=$?
+  expect_code 1 "$rc" "a home marked for another secondmate should refuse"
+  assert_contains "$out" "not marked as its own seeded secondmate home" \
+    "the refusal should name the identity mismatch"
+  [ "$(cat "$dir/fake/command")" = claude ] || fail "a refused relaunch must not stop the agent"
+  pass "fm-control relaunch: a secondmate home that is not this secondmate's is refused"
+}
+
+test_secondmate_checkpoint_refuses_unreadable_child_state() {
+  local dir home out rc
+  dir=$(new_case smchildren sm5)
+  home="$dir/home"
+  mkdir -p "$home/config"
+  printf 'claude\n' > "$home/config/secondmate-harness"
+  fm_git_worktree "$dir/proj" "$dir/smhome" sm-branch
+  mkdir -p "$dir/smhome/state/bad.meta"
+  printf 'sm5\n' > "$dir/smhome/.fm-secondmate-home"
+  {
+    echo "window=fmses:fm-sm5"
+    echo "endpoint_task_id=sm5"
+    echo "worktree=$dir/smhome"
+    echo "project=$dir/smhome"
+    echo "harness=claude"
+    echo "kind=secondmate"
+    echo "mode=secondmate"
+    echo "yolo=off"
+    echo "home=$dir/smhome"
+  } > "$home/state/sm5.meta"
+  printf '%s\n' "fm-sm5" > "$dir/fake/windows"
+  printf '%s' "$dir/smhome" > "$dir/fake/cwd"
+  out=$(run_control "$dir" sm5 relaunch); rc=$?
+  expect_code 1 "$rc" "a non-readable child record should refuse"
+  assert_contains "$out" "not a readable regular file" "the refusal should name the unreadable child record"
+  [ "$(cat "$dir/fake/command")" = claude ] || fail "child record failure must not stop the secondmate"
+  rmdir "$dir/smhome/state/bad.meta"
+  cat > "$dir/fakebin/find" <<'SH'
+#!/usr/bin/env bash
+exit 1
+SH
+  chmod +x "$dir/fakebin/find"
+  out=$(run_control "$dir" sm5 relaunch); rc=$?
+  expect_code 1 "$rc" "failed child-state traversal should refuse"
+  assert_contains "$out" "child records cannot be traversed" \
+    "the refusal should preserve a find traversal failure"
+  [ "$(cat "$dir/fake/command")" = claude ] || fail "child traversal failure must not stop the secondmate"
+  pass "fm-control relaunch: unreadable and untraversable child state fails checkpoint"
+}
+
+test_concurrent_relaunch_is_refused() {
+  local dir out rc lock holder i
+  dir=$(new_case lock rl19)
+  add_ship_task "$dir" rl19 claude
+  lock="$dir/home/state/.control-rl19.lock"
+  # A live holder of this task's control lock, taken through the same lock
+  # library fm-control uses.
+  (
+    # shellcheck source=/dev/null
+    . "$ROOT/bin/fm-wake-lib.sh"
+    fm_lock_try_acquire "$lock" || exit 1
+    sleep 30
+  ) &
+  holder=$!
+  i=0
+  while [ ! -e "$lock" ] && [ "$i" -lt 100 ]; do
+    sleep 0.1
+    i=$((i + 1))
+  done
+  [ -e "$lock" ] || { kill "$holder" 2>/dev/null; fail "could not stage a held control lock"; }
+  out=$(run_control "$dir" rl19 relaunch --note "concurrent"); rc=$?
+  kill "$holder" 2>/dev/null || true
+  wait "$holder" 2>/dev/null || true
+  expect_code 1 "$rc" "a second concurrent control action should refuse"
+  assert_contains "$out" "another lifecycle action is already running" \
+    "the refusal should name the concurrent action"
+  [ "$(cat "$dir/fake/command")" = claude ] \
+    || fail "a refused concurrent relaunch must not stop the agent"
+  pass "fm-control relaunch: two control actions on one task serialize instead of interleaving"
+}
+
+# shellcheck disable=SC2031
+test_direct_spawn_relaunch_participates_in_the_lifecycle_lock() {
+  local dir out rc lock holder i=0
+  dir=$(new_case spawnlock rl26)
+  add_ship_task "$dir" rl26 claude
+  printf 'zsh' > "$dir/fake/command"
+  lock="$dir/home/state/.control-rl26.lock"
+  (
+    . "$ROOT/bin/fm-wake-lib.sh"
+    fm_lock_try_acquire "$lock" || exit 1
+    sleep 30
+  ) &
+  holder=$!
+  while [ ! -e "$lock" ] && [ "$i" -lt 100 ]; do
+    sleep 0.1
+    i=$((i + 1))
+  done
+  [ -e "$lock" ] || fail "could not stage the lifecycle lock"
+  out=$(run_spawn "$dir" rl26 --relaunch --harness claude); rc=$?
+  kill "$holder" 2>/dev/null || true
+  wait "$holder" 2>/dev/null || true
+  expect_code 1 "$rc" "direct relaunch spawn should refuse a held lifecycle lock"
+  assert_contains "$out" "another lifecycle action is already running" \
+    "direct relaunch spawn should name lifecycle contention"
+  [ -z "$(cat "$dir/fake/literal")" ] || fail "contended direct relaunch spawn must deliver no launch bytes"
+  pass "fm-spawn relaunch: direct entry participates in lifecycle serialization"
+}
+
+# shellcheck disable=SC2031
+test_promotion_participates_in_the_lifecycle_lock_before_metadata_resolution() {
+  local dir out rc lock holder i=0
+  dir=$(new_case promotelock rl29)
+  add_ship_task "$dir" rl29 claude
+  lock="$dir/home/state/.control-rl29.lock"
+  (
+    . "$ROOT/bin/fm-wake-lib.sh"
+    fm_lock_try_acquire "$lock" || exit 1
+    sleep 30
+  ) &
+  holder=$!
+  while [ ! -e "$lock" ] && [ "$i" -lt 100 ]; do
+    sleep 0.1
+    i=$((i + 1))
+  done
+  [ -e "$lock" ] || fail "could not stage the promotion lifecycle lock"
+  out=$(FM_HOME="$dir/home" "$PROMOTE" rl29 --mode direct-PR --yolo on 2>&1); rc=$?
+  kill "$holder" 2>/dev/null || true
+  wait "$holder" 2>/dev/null || true
+  expect_code 1 "$rc" "promotion should refuse a concurrent lifecycle action"
+  assert_contains "$out" "another lifecycle action is already running" \
+    "promotion should lock before interpreting the task metadata"
+  [ "$(meta_field "$dir" rl29 kind)" = ship ] \
+    || fail "a contended promotion must leave task metadata unchanged"
+  pass "fm-promote: promotion participates in lifecycle serialization"
+}
+
+# --- 6. fm-spawn --relaunch's own refusals -----------------------------------
+
+test_spawn_relaunch_refuses_a_live_agent() {
+  local dir out rc
+  dir=$(new_case live rl15)
+  add_ship_task "$dir" rl15 claude
+  out=$(run_spawn "$dir" rl15 --relaunch --harness claude); rc=$?
+  expect_code 1 "$rc" "relaunching into a live endpoint should refuse"
+  assert_contains "$out" "positively agent-free endpoint" "the refusal should demand an agent-free endpoint"
+  assert_contains "$out" "fm-control.sh rl15 exit" "the refusal should point at the way to stop it"
+  pass "fm-spawn --relaunch: refuses to launch a second agent into a live endpoint"
+}
+
+test_spawn_relaunch_refuses_contradicting_flags() {
+  local dir out rc
+  dir=$(new_case flags rl16)
+  add_ship_task "$dir" rl16 claude
+  printf 'zsh' > "$dir/fake/command"
+  out=$(run_spawn "$dir" rl16 --relaunch --backend herdr); rc=$?
+  expect_code 1 "$rc" "--backend should be refused alongside --relaunch"
+  assert_contains "$out" "recorded backend" "the refusal should name the recorded backend rule"
+  out=$(run_spawn "$dir" rl16 --relaunch --scout); rc=$?
+  expect_code 1 "$rc" "--scout should be refused alongside --relaunch"
+  assert_contains "$out" "recorded kind" "the refusal should name the recorded kind rule"
+  out=$(run_spawn "$dir" rl16 "$dir/proj" --relaunch); rc=$?
+  expect_code 1 "$rc" "a project positional should be refused alongside --relaunch"
+  assert_contains "$out" "takes the task id only" "the refusal should name the positional rule"
+  pass "fm-spawn --relaunch: every identity axis comes from the record, and a contradicting flag refuses"
+}
+
+test_spawn_relaunch_refuses_an_unrecorded_task() {
+  local dir out rc
+  dir=$(new_case norecord rl17)
+  add_ship_task "$dir" rl17 claude
+  out=$(run_spawn "$dir" nosuchtask --relaunch); rc=$?
+  expect_code 1 "$rc" "an unrecorded task should refuse"
+  assert_contains "$out" "needs an existing task record" "the refusal should name the missing record"
+  pass "fm-spawn --relaunch: an unrecorded task is refused"
+}
+
+test_spawn_relaunch_refuses_a_pane_outside_the_worktree() {
+  local dir out rc
+  dir=$(new_case wrongcwd rl18)
+  add_ship_task "$dir" rl18 claude
+  printf 'zsh' > "$dir/fake/command"
+  printf '%s' "$dir/proj" > "$dir/fake/cwd"
+  out=$(run_spawn "$dir" rl18 --relaunch --harness claude); rc=$?
+  expect_code 1 "$rc" "a pane outside the worktree should refuse"
+  assert_contains "$out" "not its recorded worktree" "the refusal should name the wrong location"
+  pass "fm-spawn --relaunch: refuses to start a replacement outside the copy holding the work"
+}
+
+test_same_harness_relaunch_keeps_identity_and_reuses_the_endpoint
+test_relaunch_preserves_durable_task_metadata
+test_relaunch_serializes_concurrent_durable_metadata_publication
+test_relaunch_appends_the_progress_note_to_the_instructions
+test_relaunch_requires_a_note_for_a_ship_task
+test_harness_switch_moves_the_record_and_clears_prior_wiring
+test_harness_switch_does_not_carry_the_old_profile_axes
+test_same_harness_relaunch_keeps_the_profile_axes
+test_explicit_model_wins_over_the_recorded_one
+test_relaunch_onto_an_unverified_harness_is_refused
+test_prior_harness_turnend_registry_entry_is_cleared
+test_wiring_removal_failure_refuses_before_replacement_arm
+test_turnend_auth_paths_are_owned_by_the_control_adapter
+test_secondmate_relaunch_picks_up_the_configured_harness_pin
+test_secondmate_relaunch_ignores_invalid_configured_effort_before_stop
+test_secondmate_relaunch_onto_a_crewmate_only_adapter_refuses_before_stop
+test_explicit_secondmate_harness_ignores_configured_profile_axes
+test_ship_relaunch_ignores_the_crew_harness_config
+test_spawn_relaunch_without_a_harness_reuses_the_recorded_one
+test_missing_worktree_refuses_before_stopping_anything
+test_missing_instructions_refuse_before_stopping_anything
+test_checkpoint_refusal_leaves_the_record_byte_identical
+test_checkpoint_refuses_uninspectable_head_and_status
+test_launch_failure_keeps_the_prior_record_and_reports_it
+test_prepublication_failure_keeps_concurrent_durable_metadata
+test_post_publication_launch_failure_keeps_the_new_record
+test_stop_transport_failure_reconciles_a_dead_agent
+test_complete_journal_failure_rolls_back_from_durable_phase
+test_prepublication_abort_retires_replacement_wiring_and_busy_state
+test_journal_records_the_checkpoint_it_proved
+test_secondmate_relaunch_checkpoints_child_work_and_spares_the_charter
+test_secondmate_relaunch_refuses_an_unmarked_home
+test_secondmate_checkpoint_refuses_unreadable_child_state
+test_concurrent_relaunch_is_refused
+test_direct_spawn_relaunch_participates_in_the_lifecycle_lock
+test_promotion_participates_in_the_lifecycle_lock_before_metadata_resolution
+test_spawn_relaunch_refuses_a_live_agent
+test_spawn_relaunch_refuses_contradicting_flags
+test_spawn_relaunch_refuses_an_unrecorded_task
+test_spawn_relaunch_refuses_a_pane_outside_the_worktree

--- a/tests/fm-control-relaunch.test.sh
+++ b/tests/fm-control-relaunch.test.sh
@@ -691,6 +691,26 @@ test_prefixed_prior_harness_wiring_is_still_retired() {
   pass "fm-spawn --relaunch: wiring armed under a prefixed harness name is still retired"
 }
 
+# muse installs no hook; its busy source is its own session event log, bound to
+# the pane by two firstmate-owned sidecars. Relaunching AWAY from muse must
+# retire that binding, or a retired incarnation's session pin outlives the agent
+# that produced it.
+test_muse_session_binding_is_retired_on_a_harness_switch() {
+  local dir
+  dir=$(new_case musewiring rl31)
+  add_ship_task "$dir" rl31 muse
+  printf 'sessions_root=/nonexistent\nworkspace_root=%s\nbinding_id=1.2.3\n' "$dir/wt" \
+    > "$dir/home/state/rl31.muse-session"
+  printf '/nonexistent/session.jsonl\n' > "$dir/home/state/rl31.muse-session-current"
+  printf 'zsh' > "$dir/fake/command"
+  run_spawn "$dir" rl31 --relaunch --harness claude >/dev/null
+  [ ! -e "$dir/home/state/rl31.muse-session" ] \
+    || fail "the retired muse incarnation's session binding must not outlive it"
+  [ ! -e "$dir/home/state/rl31.muse-session-current" ] \
+    || fail "the retired muse incarnation's resolved session pin must not outlive it"
+  pass "fm-spawn --relaunch: switching away from muse retires its session binding"
+}
+
 # --- 3 and 4. refusals before the agent is touched ---------------------------
 
 test_missing_worktree_refuses_before_stopping_anything() {
@@ -1180,6 +1200,7 @@ test_explicit_secondmate_harness_ignores_configured_profile_axes
 test_ship_relaunch_ignores_the_crew_harness_config
 test_spawn_relaunch_without_a_harness_reuses_the_recorded_one
 test_prefixed_prior_harness_wiring_is_still_retired
+test_muse_session_binding_is_retired_on_a_harness_switch
 test_missing_worktree_refuses_before_stopping_anything
 test_missing_instructions_refuse_before_stopping_anything
 test_checkpoint_refusal_leaves_the_record_byte_identical

--- a/tests/fm-control-relaunch.test.sh
+++ b/tests/fm-control-relaunch.test.sh
@@ -23,6 +23,8 @@ set -u
 . "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
 # shellcheck source=/dev/null
 . "$ROOT/bin/fm-control-lib.sh"
+# shellcheck source=/dev/null
+. "$ROOT/bin/fm-trace-context-lib.sh"
 
 CONTROL="$ROOT/bin/fm-control.sh"
 SPAWN="$ROOT/bin/fm-spawn.sh"
@@ -80,6 +82,17 @@ case "${1:-}" in
       esac
     else
       printf '%s\n' "$payload" >> "$D/keys"
+      case "$payload" in
+        'export GOTMPDIR='*)
+          if [ -n "${FM_FAKE_TRACE_PREPARE:-}" ]; then
+            : > "$FM_FAKE_TRACE_PREPARE"
+            while [ ! -e "$FM_FAKE_META_WRITER_READY" ]; do /bin/sleep 0.01; done
+          fi
+          ;;
+        'export TRACEPARENT='*)
+          [ -z "${FM_FAKE_TRACE_EXPORTED:-}" ] || : > "$FM_FAKE_TRACE_EXPORTED"
+          ;;
+      esac
     fi
     exit 0 ;;
   display-message)
@@ -155,6 +168,9 @@ run_control() {  # <case-dir> <args...>
     FM_REAL_GIT="${FM_REAL_GIT:-}" FM_FAKE_GIT_FAILURE="${FM_FAKE_GIT_FAILURE:-}" \
     FM_REAL_MV="${FM_REAL_MV:-}" FM_FAKE_COMPLETE_JOURNAL_MV_FAIL="${FM_FAKE_COMPLETE_JOURNAL_MV_FAIL:-}" \
     FM_FAKE_META_PUBLISH_MV_FAIL="${FM_FAKE_META_PUBLISH_MV_FAIL:-}" \
+    FM_FAKE_TRACE_PREPARE="${FM_FAKE_TRACE_PREPARE:-}" \
+    FM_FAKE_META_WRITER_READY="${FM_FAKE_META_WRITER_READY:-}" \
+    FM_FAKE_TRACE_EXPORTED="${FM_FAKE_TRACE_EXPORTED:-}" \
     "$CONTROL" "$@" 2>&1
 }
 
@@ -200,24 +216,21 @@ if [ -n "${FM_FAKE_META_PUBLISH_MV_FAIL:-}" ]; then
     [ "$path" != "$FM_FAKE_META_PUBLISH_MV_FAIL" ] || exit 1
   done
 fi
+source_path=
+target_path=
+for path in "$@"; do
+  source_path=$target_path
+  target_path=$path
+done
+if [ -n "${FM_FAKE_META_WRITER_TARGET:-}" ] \
+   && [ "$target_path" = "$FM_FAKE_META_WRITER_TARGET" ] \
+   && grep -q '^x_request=' "$source_path" 2>/dev/null; then
+  : > "$FM_FAKE_META_WRITER_READY"
+  while [ ! -e "$FM_FAKE_META_WRITER_RELEASE" ]; do /bin/sleep 0.01; done
+fi
 exec "$FM_REAL_MV" "$@"
 SH
   chmod +x "$1/fakebin/mv"
-}
-
-make_meta_race_awk_stub() {  # <case-dir>
-  cat > "$1/fakebin/awk" <<'SH'
-#!/usr/bin/env bash
-for arg in "$@"; do
-  if [ -n "${FM_FAKE_META_RACE_PATH:-}" ] && [ "$arg" = "$FM_FAKE_META_RACE_PATH" ]; then
-    : > "$FM_FAKE_META_RACE_READY"
-    /bin/sleep 1
-    break
-  fi
-done
-exec "$FM_REAL_AWK" "$@"
-SH
-  chmod +x "$1/fakebin/awk"
 }
 
 make_rm_failure_stub() {  # <case-dir>
@@ -285,36 +298,84 @@ test_relaunch_preserves_durable_task_metadata() {
 }
 
 test_relaunch_serializes_concurrent_durable_metadata_publication() {
-  local dir control_pid link_out rc i=0
+  local dir control_pid link_pid rc i=0 traceparent prepare ready exported release
   dir=$(new_case metadata-race rl28)
   add_ship_task "$dir" rl28 claude
-  make_meta_race_awk_stub "$dir"
-  FM_REAL_AWK=$(command -v awk) \
-    FM_FAKE_META_RACE_PATH="$dir/home/state/rl28.meta" \
-    FM_FAKE_META_RACE_READY="$dir/meta-race-ready" \
+  printf '%s\n' "$$" > "$dir/home/state/.lock"
+  printf '%s on\n' "$$" > "$dir/home/state/.trace-context-effective"
+  make_mv_failure_stub "$dir"
+  prepare="$dir/trace-prepare"
+  ready="$dir/meta-writer-ready"
+  exported="$dir/trace-exported"
+  release="$dir/meta-writer-release"
+  FM_REAL_MV=$(command -v mv) \
+    FM_FAKE_TRACE_PREPARE="$prepare" \
+    FM_FAKE_META_WRITER_READY="$ready" \
+    FM_FAKE_TRACE_EXPORTED="$exported" \
     run_control "$dir" rl28 relaunch --note "continue after publication" > "$dir/control.out" &
   control_pid=$!
-  while [ ! -e "$dir/meta-race-ready" ] && [ "$i" -lt 200 ]; do
+  while [ ! -e "$prepare" ] && [ "$i" -lt 200 ]; do
     /bin/sleep 0.01
     i=$((i + 1))
   done
-  [ -e "$dir/meta-race-ready" ] || {
+  [ -e "$prepare" ] || {
     kill "$control_pid" 2>/dev/null || true
     wait "$control_pid" 2>/dev/null || true
-    fail "relaunch did not reach metadata publication"
+    fail "relaunch did not reach trace delivery"
   }
-  link_out=$(env PATH="$dir/fakebin:$PATH" FM_HOME="$dir/home" FM_ROOT_OVERRIDE="$ROOT" \
-    FM_REAL_AWK="$(command -v awk)" \
+  env PATH="$dir/fakebin:$PATH" FM_HOME="$dir/home" FM_ROOT_OVERRIDE="$ROOT" \
+    FM_REAL_MV="$(command -v mv)" \
+    FM_FAKE_META_WRITER_TARGET="$dir/home/state/rl28.meta" \
+    FM_FAKE_META_WRITER_READY="$ready" \
+    FM_FAKE_META_WRITER_RELEASE="$release" \
     "$X_LINK" rl28 request-28 --carry-count 1 --carry-ts 1700000000 \
-      --carry-platform x --carry-max 280 2>&1); rc=$?
-  expect_code 0 "$rc" "concurrent X metadata publication should serialize"$'\n'"$link_out"
+      --carry-platform x --carry-max 280 > "$dir/link.out" 2>&1 &
+  link_pid=$!
+  i=0
+  while { [ ! -e "$ready" ] || [ ! -e "$exported" ]; } && [ "$i" -lt 200 ]; do
+    /bin/sleep 0.01
+    i=$((i + 1))
+  done
+  [ -e "$ready" ] && [ -e "$exported" ] || {
+    : > "$release"
+    kill "$link_pid" "$control_pid" 2>/dev/null || true
+    wait "$link_pid" 2>/dev/null || true
+    wait "$control_pid" 2>/dev/null || true
+    fail "trace publication did not overlap the concurrent metadata writer"
+  }
+  : > "$release"
+  wait "$link_pid"; rc=$?
+  expect_code 0 "$rc" "concurrent X metadata publication should serialize"$'\n'"$(cat "$dir/link.out")"
   wait "$control_pid"; rc=$?
   expect_code 0 "$rc" "relaunch should complete after serialized metadata publication"$'\n'"$(cat "$dir/control.out")"
   [ "$(meta_field "$dir" rl28 x_request)" = request-28 ] \
     || fail "relaunch erased metadata published concurrently through the X interface"
   [ "$(meta_field "$dir" rl28 x_followups)" = 1 ] \
     || fail "relaunch erased the concurrent follow-up count"
-  pass "fm-control relaunch: concurrent task metadata publications serialize"
+  traceparent=$(meta_field "$dir" rl28 traceparent)
+  fm_trace_context_valid "$traceparent" \
+    || fail "concurrent metadata publication erased the replacement's trace carrier"
+  pass "fm-control relaunch: trace and concurrent task metadata publications serialize"
+}
+
+test_disabled_relaunch_clears_prior_trace_context() {
+  local dir out rc
+  dir=$(new_case trace-off rl33)
+  add_ship_task "$dir" rl33 claude
+  printf '%s\n' 'traceparent=00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-01' \
+    >> "$dir/home/state/rl33.meta"
+  printf '%s\n' "$$" > "$dir/home/state/.lock"
+  printf '%s off\n' "$$" > "$dir/home/state/.trace-context-effective"
+
+  out=$(run_control "$dir" rl33 relaunch --note "crossing trace boundary"); rc=$?
+  expect_code 0 "$rc" "disabled relaunch should succeed"$'\n'"$out"
+  [ -z "$(meta_field "$dir" rl33 traceparent)" ] \
+    || fail "disabled relaunch must remove the prior trace carrier from metadata"
+  grep -q '^unset TRACEPARENT; .*claude' "$dir/fake/literal" \
+    || fail "disabled relaunch must clear the pane carrier before replacement launch"
+  ! grep -q '^export TRACEPARENT=' "$dir/fake/literal" \
+    || fail "disabled relaunch must not export a replacement trace carrier"
+  pass "fm-control relaunch: disabling tracing clears metadata and pane context"
 }
 
 test_relaunch_appends_the_progress_note_to_the_instructions() {
@@ -1210,6 +1271,7 @@ test_spawn_relaunch_refuses_a_pane_outside_the_worktree() {
 test_same_harness_relaunch_keeps_identity_and_reuses_the_endpoint
 test_relaunch_preserves_durable_task_metadata
 test_relaunch_serializes_concurrent_durable_metadata_publication
+test_disabled_relaunch_clears_prior_trace_context
 test_relaunch_appends_the_progress_note_to_the_instructions
 test_relaunch_requires_a_note_for_a_ship_task
 test_harness_switch_moves_the_record_and_clears_prior_wiring

--- a/tests/fm-control.test.sh
+++ b/tests/fm-control.test.sh
@@ -572,11 +572,13 @@ test_verb_allowlist_is_closed() {
   assert_contains "$out" "interrupt" "the refusal should list the allowed verbs"
   out=$(run_control "$dir" t1 --key); rc=$?
   expect_code 2 "$rc" "a raw key is not a control verb"
+  out=$(run_control "$dir" t1 clear); rc=$?
+  expect_code 2 "$rc" "clear is not a control verb"
   out=$(run_control "$dir" t1 "please stop what you are doing"); rc=$?
   expect_code 2 "$rc" "arbitrary text is not a control verb"
   [ -z "$(literals "$dir")" ] || fail "a refused verb must send nothing"
   [ -z "$(keys_sent "$dir")" ] || fail "a refused verb must send no keys"
-  pass "fm-control: the verb list is closed - no raw keys, no arbitrary text"
+  pass "fm-control: the verb list is closed - no raw keys, arbitrary text, or clear verb"
 }
 
 test_resume_is_refused_with_its_reason() {

--- a/tests/fm-control.test.sh
+++ b/tests/fm-control.test.sh
@@ -254,6 +254,30 @@ test_harness_family_resolution() {
   pass "fm-control-lib: a recorded harness resolves to its verified adapter without guessing"
 }
 
+test_prefixed_recorded_harness_reaches_each_control_verb() {
+  local dir out rc
+  dir=$(new_case prefixed-interrupt)
+  add_task "$dir" t1 grok-2
+  alive_as "$dir" grok-2
+  out=$(run_control "$dir" t1 interrupt); rc=$?
+  expect_code 0 "$rc" "interrupt should resolve a prefixed recorded harness"$'\n'"$out"
+  [ "$(keys_sent "$dir")" = C-c ] \
+    || fail "a grok-prefixed task should receive grok's interrupt key"
+  assert_contains "$out" "harness=grok" \
+    "interrupt should report the verified adapter that supplied its mechanics"
+
+  dir=$(new_case prefixed-exit)
+  add_task "$dir" t1 grok-2
+  alive_as "$dir" grok-2
+  out=$(run_control "$dir" t1 exit); rc=$?
+  expect_code 0 "$rc" "exit should resolve a prefixed recorded harness"$'\n'"$out"
+  [ "$(literals "$dir")" = /exit ] \
+    || fail "a grok-prefixed task should receive grok's exit command"
+  assert_contains "$out" "stopped t1 harness=grok" \
+    "exit should report the verified adapter that supplied its mechanics"
+  pass "fm-control: prefixed recorded harnesses reach interrupt and exit mechanics"
+}
+
 test_opencode_interrupts_twice_and_others_once() {
   # The one adapter that differs, asserted through the delivered keys rather
   # than the table, so a regression in either shows up here.
@@ -763,6 +787,7 @@ test_interrupt_sends_each_harness_verified_key
 test_opencode_interrupts_twice_and_others_once
 test_unverified_harness_is_refused
 test_harness_family_resolution
+test_prefixed_recorded_harness_reaches_each_control_verb
 test_backend_key_capability_matrix
 test_harness_kind_capability
 test_orca_refuses_an_escape_harness_interrupt

--- a/tests/fm-control.test.sh
+++ b/tests/fm-control.test.sh
@@ -707,17 +707,26 @@ test_muse_interrupt_confirms_adapter_acknowledgement() {
 }
 
 test_agent_that_does_not_stop_fails_closed() {
-  local dir out rc
+  local dir out rc gen
   dir=$(new_case stubborn)
   add_task "$dir" t1 claude
   alive_as "$dir" claude
+  gen=$("$ROOT/bin/fm-busy-event.sh" arm "$dir/home/state" t1)
+  printf 'busy_gen=%s\n' "$gen" >> "$dir/home/state/t1.meta"
   out=$(env FM_FAKE_NEVER_DIES=1 PATH="$dir/fakebin:$PATH" FM_HOME="$dir/home" \
     FM_FAKE_DIR="$dir/fake" FM_CONTROL_POLL=0.01 FM_CONTROL_EXIT_WAIT=0.05 \
     "$CONTROL" t1 exit 2>&1); rc=$?
   expect_code 1 "$rc" "an agent that ignores its exit command should fail closed"
   assert_contains "$out" "did not stop" "the failure should say the agent did not stop"
-  assert_contains "$out" "nothing was changed" "the failure should say nothing was changed"
-  pass "fm-control exit: an agent that ignores its exit command fails closed instead of claiming success"
+  assert_contains "$out" "exit-delivered t1 interrupt=delivered verified=agent-alive cancel=unconfirmed exit-command=delivered agent-state=alive exit=unconfirmed" \
+    "the failure should distinguish delivered lifecycle input from the unconfirmed exit"
+  assert_not_contains "$out" "nothing was changed" \
+    "the failure must not deny the lifecycle input that was delivered"
+  [ "$(keys_sent "$dir")" = Escape ] \
+    || fail "a stubborn busy agent should receive its interrupt sequence"
+  [ "$(literals "$dir")" = /exit ] \
+    || fail "a stubborn busy agent should receive its exit command"
+  pass "fm-control exit: a stubborn agent reports delivered input and an unconfirmed exit"
 }
 
 test_grok_interrupt_without_acknowledgement_reports_unconfirmed() {

--- a/tests/fm-control.test.sh
+++ b/tests/fm-control.test.sh
@@ -1,0 +1,792 @@
+#!/usr/bin/env bash
+# fm-control.sh: the agent lifecycle CONTROL plane.
+#
+# These tests pin the control plane's observable behavior hermetically - a
+# stubbed session provider, no real agent - through the executable interface
+# firstmate actually calls:
+#   1. Adapter contract: every verified harness gets its own verified exit
+#      command and interrupt key, delivered as bytes to the endpoint.
+#   2. Backend capability: a backend that cannot deliver the harness's
+#      interrupt key, and a backend with no recovery-grade agent-state
+#      classifier, both refuse instead of acting blind.
+#   3. Exact-id scoping: a window label, an explicit endpoint, an unknown id,
+#      and a record bound to another task are all refused.
+#   4. Verb allowlist: no arbitrary text, no raw keys, no resume.
+#   5. Lifecycle states: busy interrupts first, idle does not, already-stopped
+#      is idempotent success, and an agent that does not stop fails closed.
+#   6. Marker non-regression: a control command to a kind=secondmate task
+#      carries NO from-firstmate marker and opens no pending-reply expectation,
+#      while fm-send's marking of the same task is untouched.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+# shellcheck source=/dev/null
+. "$ROOT/bin/fm-control-lib.sh"
+# shellcheck source=/dev/null
+. "$ROOT/bin/fm-marker-lib.sh"
+
+CONTROL="$ROOT/bin/fm-control.sh"
+SEND="$ROOT/bin/fm-send.sh"
+# fm_test_tmproot's own cleanup trap fires when its command substitution exits,
+# so recreate the root before resolving it and clean it up from this file's trap.
+TMP_ROOT=$(fm_test_tmproot fm-control)
+mkdir -p "$TMP_ROOT"
+TMP_ROOT=$(cd "$TMP_ROOT" && pwd)
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+VERIFIED_HARNESSES="claude codex opencode pi pi-signed grok kimi muse"
+
+# The expectation table, written out independently of the implementation so a
+# silent change to either side shows up here. The fourth field is the composer
+# clear that must FOLLOW the interrupt key, empty for every adapter that leaves
+# its composer empty on cancel.
+verified_adapter_contract() {  # <harness> -> exit command, interrupt key, repeat, clear key
+  case "$1" in
+    claude) printf '/exit\tEscape\t1\t\n' ;;
+    codex) printf '/quit\tEscape\t1\t\n' ;;
+    opencode) printf '/exit\tEscape\t2\t\n' ;;
+    pi) printf '/quit\tEscape\t1\t\n' ;;
+    pi-signed) printf '/quit\tEscape\t1\t\n' ;;
+    grok) printf '/exit\tC-c\t1\t\n' ;;
+    kimi) printf '/exit\tEscape\t1\t\n' ;;
+    muse) printf '/exit\tEscape\t1\tC-u\n' ;;
+    *) return 1 ;;
+  esac
+}
+
+# --- fake session provider --------------------------------------------------
+#
+# A tmux stub whose whole model is four files under $FM_FAKE_DIR:
+#   command  the pane's foreground process name, which IS the agent-state
+#            classifier's input (bin/backends/tmux.sh).
+#   cwd      the pane's current path.
+#   literal  every `send-keys -l` payload, one per line - exactly what was
+#            typed into the composer.
+#   keys     every named key send, one per line.
+#   pane     optional capture-pane override, for an adapter whose busy verdict
+#            is read from the rendered tail.
+# Two transitions make it a lifecycle model rather than a recorder: a literal
+# that is the harness's exit command flips `command` to a shell (the agent
+# stopped), and a literal carrying a launch brief flips it to the value in
+# `becomes` (a new agent came up). FM_FAKE_NEVER_DIES suppresses the first, so
+# a stubborn agent can be tested too.
+make_tmux_stub() {  # <dir> -> echoes fakebin dir
+  local dir=$1 fb="$1/fakebin"
+  mkdir -p "$fb"
+  cat > "$fb/tmux" <<'SH'
+#!/usr/bin/env bash
+set -u
+D=$FM_FAKE_DIR
+case "${1:-}" in
+  send-keys)
+    shift
+    literal=0
+    while [ $# -gt 0 ]; do
+      case "$1" in
+        -t) shift 2 ;;
+        -l) literal=1; shift ;;
+        *) break ;;
+      esac
+    done
+    payload=${1:-}
+    if [ "$literal" = 1 ]; then
+      printf '%s\n' "$payload" >> "$D/literal"
+      if [ -z "${FM_FAKE_NEVER_DIES:-}" ] \
+         && { [ "$payload" = /exit ] || [ "$payload" = /quit ]; }; then
+        printf 'zsh' > "$D/command"
+      fi
+      case "$payload" in
+        *'encode launch-brief'*) cat "$D/becomes" > "$D/command" ;;
+      esac
+    else
+      printf '%s\n' "$payload" >> "$D/keys"
+    fi
+    exit 0 ;;
+  display-message)
+    for a in "$@"; do
+      case "$a" in
+        *cursor_y*) printf '1\n'; exit 0 ;;
+        *pane_current_command*) cat "$D/command"; printf '\n'; exit 0 ;;
+        *pane_current_path*) cat "$D/cwd"; printf '\n'; exit 0 ;;
+      esac
+    done
+    printf 'fakepane\n'; exit 0 ;;
+  capture-pane)
+    if [ -f "$D/pane" ]; then cat "$D/pane"; else printf '╭────╮\n│    │\n╰────╯\n'; fi
+    exit 0 ;;
+  list-windows)
+    if [ -f "$D/windows" ]; then cat "$D/windows"; fi
+    exit 0 ;;
+esac
+exit 0
+SH
+  chmod +x "$fb/tmux"
+  cat > "$fb/sleep" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+  chmod +x "$fb/sleep"
+  printf '%s\n' "$fb"
+}
+
+# new_case <name> -> echoes a case dir holding home/, fake/, and fakebin.
+new_case() {
+  local dir="$TMP_ROOT/$1-$RANDOM"
+  mkdir -p "$dir/home/state" "$dir/home/data" "$dir/fake"
+  : > "$dir/fake/literal"
+  : > "$dir/fake/keys"
+  printf 'zsh' > "$dir/fake/command"
+  printf 'claude' > "$dir/fake/becomes"
+  make_tmux_stub "$dir" >/dev/null
+  printf '%s\n' "$dir"
+}
+
+# add_task <case-dir> <id> <harness> [kind] [backend] [window]
+# Builds the task's worktree (a real git worktree so the relaunch checkpoint
+# has something to account for), its brief, and its state/<id>.meta.
+add_task() {
+  local dir=$1 id=$2 harness=$3 kind=${4:-ship} backend=${5:-tmux}
+  local window=${6:-fmses:fm-$id}
+  local home="$dir/home" proj="$dir/proj-$id" wt="$dir/wt-$id"
+  fm_git_worktree "$proj" "$wt" "task-$id"
+  mkdir -p "$home/data/$id"
+  printf '# brief for %s\n' "$id" > "$home/data/$id/brief.md"
+  {
+    echo "window=$window"
+    echo "endpoint_task_id=$id"
+    echo "worktree=$wt"
+    echo "project=$proj"
+    echo "harness=$harness"
+    echo "kind=$kind"
+    echo "mode=no-mistakes"
+    echo "yolo=off"
+    echo "model=default"
+    echo "effort=default"
+    [ "$backend" = tmux ] || echo "backend=$backend"
+  } > "$home/state/$id.meta"
+  printf '%s\n' "fm-$id" > "$dir/fake/windows"
+  printf '%s' "$wt" > "$dir/fake/cwd"
+}
+
+# run_control <case-dir> <args...>: run fm-control against the case's home with
+# the stubbed provider on PATH. Echoes combined output; returns its exit code.
+run_control() {
+  local dir=$1; shift
+  env PATH="$dir/fakebin:$PATH" FM_HOME="$dir/home" FM_FAKE_DIR="$dir/fake" \
+    FM_CONTROL_POLL=0.01 FM_CONTROL_SETTLE_WAIT=0.05 \
+    FM_CONTROL_EXIT_WAIT=0.05 FM_CONTROL_LAUNCH_WAIT=0.05 \
+    "$CONTROL" "$@" 2>&1
+}
+
+alive_as() {  # <case-dir> <command-name>
+  printf '%s' "$2" > "$1/fake/command"
+}
+
+literals() {  # <case-dir>
+  cat "$1/fake/literal"
+}
+
+# Every named key EXCEPT Enter, which is submission mechanics shared with every
+# text send rather than a control-plane key.
+keys_sent() {  # <case-dir>
+  grep -v '^Enter$' "$1/fake/keys" || true
+}
+
+# --- 1. adapter contract across every verified harness -----------------------
+
+test_exit_types_each_harness_verified_command() {
+  local dir out rc harness expected key repeat clear
+  for harness in $VERIFIED_HARNESSES; do
+    dir=$(new_case "exit-$harness")
+    add_task "$dir" t1 "$harness"
+    alive_as "$dir" "$harness"
+    out=$(run_control "$dir" t1 exit); rc=$?
+    expect_code 0 "$rc" "exit on $harness should succeed"$'\n'"$out"
+    IFS=$'\t' read -r expected key repeat clear <<< "$(verified_adapter_contract "$harness")"
+    [ "$(literals "$dir")" = "$expected" ] \
+      || fail "exit on $harness should type exactly '$expected', got: $(literals "$dir")"
+    assert_contains "$out" "stopped t1 harness=$harness" "exit should report the stop for $harness"
+  done
+  pass "fm-control exit: every verified harness gets its own verified exit command"
+}
+
+test_interrupt_sends_each_harness_verified_key() {
+  local dir out rc harness expected key repeat clear got want
+  for harness in $VERIFIED_HARNESSES; do
+    dir=$(new_case "int-$harness")
+    add_task "$dir" t1 "$harness"
+    alive_as "$dir" "$harness"
+    out=$(run_control "$dir" t1 interrupt); rc=$?
+    expect_code 0 "$rc" "interrupt on $harness should succeed"$'\n'"$out"
+    IFS=$'\t' read -r expected key repeat clear <<< "$(verified_adapter_contract "$harness")"
+    want=$(for _ in $(seq 1 "$repeat"); do printf '%s\n' "$key"; done)
+    [ -z "$clear" ] || want="$want"$'\n'"$clear"
+    got=$(keys_sent "$dir")
+    [ "$got" = "$want" ] \
+      || fail "interrupt on $harness should send $repeat x $key${clear:+ then $clear}, got: $got"
+    [ -z "$(literals "$dir")" ] \
+      || fail "interrupt on $harness must type no text, got: $(literals "$dir")"
+  done
+  pass "fm-control interrupt: every verified harness gets its own verified key and repeat count"
+}
+
+# A recorded harness can carry a raw launch command's basename, so the tables
+# are reached through one prefix rule rather than an exact string match.
+test_harness_family_resolution() {
+  local pair recorded want got
+  for pair in claude:claude claude-latest:claude codex:codex codex-cli:codex \
+      opencode:opencode grok:grok grok-2:grok kimi:kimi muse:muse \
+      muse-bin-0.1.0:muse pi:pi pi-signed:pi-signed; do
+    recorded=${pair%%:*}
+    want=${pair#*:}
+    got=$(fm_control_harness_family "$recorded") \
+      || fail "'$recorded' should resolve to the $want adapter"
+    [ "$got" = "$want" ] || fail "'$recorded' should resolve to $want, got '$got'"
+  done
+  fm_control_harness_family someagent \
+    && fail "an unrecognized launch command must not be guessed into an adapter family"
+  fm_control_harness_family '' \
+    && fail "an empty harness must not resolve to an adapter family"
+  # The signed adapter is a distinct launch profile, not a pi variant.
+  [ "$(fm_control_harness_family pi-signed)" != "$(fm_control_harness_family pi)" ] \
+    || fail "pi-signed must not collapse into pi"
+  pass "fm-control-lib: a recorded harness resolves to its verified adapter without guessing"
+}
+
+test_opencode_interrupts_twice_and_others_once() {
+  # The one adapter that differs, asserted through the delivered keys rather
+  # than the table, so a regression in either shows up here.
+  local dir
+  dir=$(new_case int-double)
+  add_task "$dir" t1 opencode
+  alive_as "$dir" opencode
+  run_control "$dir" t1 interrupt >/dev/null
+  [ "$(keys_sent "$dir" | wc -l | tr -d ' ')" = 2 ] \
+    || fail "opencode should receive a double Escape"
+  dir=$(new_case int-single)
+  add_task "$dir" t1 claude
+  alive_as "$dir" claude
+  run_control "$dir" t1 interrupt >/dev/null
+  [ "$(keys_sent "$dir" | wc -l | tr -d ' ')" = 1 ] \
+    || fail "claude should receive a single Escape"
+  pass "fm-control interrupt: opencode needs a double Escape, claude a single one"
+}
+
+test_unverified_harness_is_refused() {
+  local dir out rc
+  dir=$(new_case unverified)
+  add_task "$dir" t1 someagent
+  alive_as "$dir" someagent
+  out=$(run_control "$dir" t1 exit); rc=$?
+  expect_code 1 "$rc" "an unverified harness should refuse"
+  assert_contains "$out" "no verified control mechanics" "refusal should name the missing verification"
+  [ -z "$(literals "$dir")" ] || fail "an unverified harness must receive no bytes"
+  pass "fm-control: a harness with no verified control mechanics is refused, not guessed at"
+}
+
+# --- 2. backend capability matrix -------------------------------------------
+
+test_backend_key_capability_matrix() {
+  local backend key
+  for backend in tmux herdr zellij cmux; do
+    # C-u is the composer clear muse's interrupt needs; every session provider
+    # but Orca normalizes it (bin/backends/*.sh).
+    for key in Escape Enter C-c C-u; do
+      fm_control_backend_supports_key "$backend" "$key" \
+        || fail "$backend should be able to deliver $key"
+    done
+  done
+  fm_control_backend_supports_key orca Escape \
+    && fail "orca's terminal API has no Escape and must not claim it"
+  fm_control_backend_supports_key orca C-u \
+    && fail "orca's terminal API has no composer clear and must not claim one"
+  fm_control_backend_supports_key orca C-c || fail "orca should deliver C-c"
+  fm_control_backend_supports_key orca Enter || fail "orca should deliver Enter"
+  pass "fm-control-lib: the backend key matrix matches each adapter's real send-key surface"
+}
+
+# A verified adapter is not automatically verified for every task kind, and the
+# check has to sit on the pre-stop side of a relaunch: muse has no primary
+# supervision protocol, so bin/fm-spawn.sh refuses it for a secondmate, and
+# discovering that only after the running agent was stopped would strand the
+# secondmate with no agent at all.
+test_harness_kind_capability() {
+  local harness
+  for harness in $VERIFIED_HARNESSES; do
+    fm_control_harness_supports_kind "$harness" ship \
+      || fail "$harness should be able to run a ship task"
+    fm_control_harness_supports_kind "$harness" scout \
+      || fail "$harness should be able to run a scout task"
+  done
+  fm_control_harness_supports_kind muse secondmate \
+    && fail "muse has no primary supervision protocol and must not claim a secondmate"
+  for harness in claude codex opencode pi pi-signed grok kimi; do
+    fm_control_harness_supports_kind "$harness" secondmate \
+      || fail "$harness should be able to run a secondmate"
+  done
+  fm_control_harness_supports_kind someagent ship \
+    && fail "an unverified harness must not claim any kind"
+  pass "fm-control-lib: adapter capability is per task kind, not per adapter alone"
+}
+
+test_orca_refuses_an_escape_harness_interrupt() {
+  local dir out rc
+  dir=$(new_case orca-escape)
+  add_task "$dir" t1 claude ship orca "term-1"
+  # Orca records its endpoint as terminal=, which endpoint validation requires.
+  {
+    cat "$dir/home/state/t1.meta"
+    echo "terminal=term-1"
+    echo "orca_worktree_id=wt-1"
+  } > "$dir/home/state/t1.meta.new"
+  sed 's|^window=.*|window=fm-t1|' "$dir/home/state/t1.meta.new" > "$dir/home/state/t1.meta"
+  out=$(run_control "$dir" t1 interrupt); rc=$?
+  expect_code 1 "$rc" "an Escape harness on orca should refuse"
+  assert_contains "$out" "cannot deliver" "refusal should name the undeliverable key"
+  pass "fm-control interrupt: a backend that cannot deliver the harness's key refuses instead of sending another"
+}
+
+test_unverified_state_backends_refuse_stop_verbs() {
+  local dir out rc backend
+  for backend in zellij cmux; do
+    dir=$(new_case "nostate-$backend")
+    if [ "$backend" = zellij ]; then
+      add_task "$dir" t1 claude ship zellij "sess:7"
+      {
+        echo "zellij_session=sess"
+        echo "zellij_tab_id=1"
+        echo "zellij_pane_id=7"
+      } >> "$dir/home/state/t1.meta"
+    else
+      add_task "$dir" t1 claude ship cmux "ws1:surface1"
+      {
+        echo "cmux_workspace_id=ws1"
+        echo "cmux_surface_id=surface1"
+      } >> "$dir/home/state/t1.meta"
+    fi
+    out=$(run_control "$dir" t1 exit); rc=$?
+    expect_code 1 "$rc" "exit on $backend should refuse"$'\n'"$out"
+    assert_contains "$out" "no recovery-grade agent-state classifier" \
+      "the $backend refusal should name the missing stop proof"
+    [ -z "$(literals "$dir")" ] || fail "$backend must receive no exit command"
+    out=$(run_control "$dir" t1 relaunch --note x); rc=$?
+    expect_code 1 "$rc" "relaunch on $backend should refuse"$'\n'"$out"
+    assert_contains "$out" "no recovery-grade agent-state classifier" \
+      "the $backend relaunch refusal should name the missing stop proof"
+  done
+  pass "fm-control: a backend that cannot prove an agent stopped refuses exit and relaunch"
+}
+
+test_state_verified_backends_are_exactly_tmux_and_herdr() {
+  fm_control_backend_state_verified tmux || fail "tmux has a recovery-grade classifier"
+  fm_control_backend_state_verified herdr || fail "herdr has a recovery-grade classifier"
+  local backend
+  for backend in zellij orca cmux; do
+    fm_control_backend_state_verified "$backend" \
+      && fail "$backend has no recovery-grade classifier and must not claim one"
+  done
+  pass "fm-control-lib: stop-proving verbs are gated on the backends that really classify agent state"
+}
+
+# --- 3. exact-id scoping ----------------------------------------------------
+
+test_window_label_is_refused_with_the_exact_id() {
+  local dir out rc
+  dir=$(new_case label)
+  add_task "$dir" t1 claude
+  alive_as "$dir" claude
+  out=$(run_control "$dir" fm-t1 exit); rc=$?
+  expect_code 1 "$rc" "a window label should refuse"
+  assert_contains "$out" "pass the exact task id 't1'" "the refusal should name the exact id"
+  [ -z "$(literals "$dir")" ] || fail "a refused target must receive no bytes"
+  pass "fm-control: a legacy window label is refused and the exact task id is named"
+}
+
+test_explicit_endpoint_is_refused() {
+  local dir out rc
+  dir=$(new_case endpoint)
+  add_task "$dir" t1 claude
+  alive_as "$dir" claude
+  out=$(run_control "$dir" "fmses:fm-t1" exit); rc=$?
+  expect_code 1 "$rc" "an explicit endpoint should refuse"
+  assert_contains "$out" "exact task id only" "the refusal should name the exact-id rule"
+  [ -z "$(literals "$dir")" ] || fail "a refused target must receive no bytes"
+  pass "fm-control: an explicit backend endpoint is never a control target"
+}
+
+test_unknown_task_is_refused() {
+  local dir out rc
+  dir=$(new_case unknown)
+  add_task "$dir" t1 claude
+  out=$(run_control "$dir" t2 exit); rc=$?
+  expect_code 1 "$rc" "an unknown task should refuse"
+  assert_contains "$out" "no task 't2'" "the refusal should name the missing task"
+  pass "fm-control: an unrecorded task id is refused"
+}
+
+test_record_bound_to_another_task_is_refused() {
+  local dir out rc
+  dir=$(new_case foreign)
+  add_task "$dir" t1 claude
+  alive_as "$dir" claude
+  sed 's/^endpoint_task_id=t1$/endpoint_task_id=other/' "$dir/home/state/t1.meta" \
+    > "$dir/home/state/t1.meta.tmp"
+  mv "$dir/home/state/t1.meta.tmp" "$dir/home/state/t1.meta"
+  out=$(run_control "$dir" t1 exit); rc=$?
+  expect_code 1 "$rc" "a record bound to another task should refuse"
+  assert_contains "$out" "belongs to task other" "the refusal should name the conflicting binding"
+  [ -z "$(literals "$dir")" ] || fail "a foreign record must receive no bytes"
+  pass "fm-control: a record whose endpoint identity names another task is refused"
+}
+
+# A remotely placed secondmate's agent runs on another host, so none of the
+# postconditions this plane verifies could be read for it here. Endpoint
+# validation would refuse the record anyway - `window=remote:<id>` can never
+# match a local backend's shape - but it would blame malformed metadata for a
+# correctly configured route, so the placement is named instead. Every verb
+# refuses, and none of them reaches a local endpoint.
+test_remote_secondmate_is_refused_by_placement() {
+  local dir out rc verb
+  for verb in interrupt exit relaunch; do
+    dir=$(new_case "remote-$verb")
+    add_task "$dir" t1 claude secondmate
+    alive_as "$dir" claude
+    {
+      grep -v '^window=' "$dir/home/state/t1.meta"
+      echo "window=remote:t1"
+      echo "home=$dir/wt-t1"
+      echo "remote_host=example.invalid"
+      echo "remote_root=/srv/fm"
+      echo "remote_backend=herdr"
+      echo "remote_target=fm:pane-1"
+    } > "$dir/home/state/t1.meta.tmp"
+    mv "$dir/home/state/t1.meta.tmp" "$dir/home/state/t1.meta"
+    if [ "$verb" = relaunch ]; then
+      out=$(run_control "$dir" t1 "$verb" --note "x"); rc=$?
+    else
+      out=$(run_control "$dir" t1 "$verb"); rc=$?
+    fi
+    expect_code 1 "$rc" "$verb on a remotely placed secondmate should refuse"
+    assert_contains "$out" "remotely placed secondmate on example.invalid" \
+      "the $verb refusal should name the remote placement, not blame the record"
+    assert_not_contains "$out" "malformed" \
+      "a correctly configured remote route must not be reported as malformed"
+    [ -z "$(literals "$dir")" ] && [ -z "$(keys_sent "$dir")" ] \
+      || fail "$verb on a remote secondmate must reach no local endpoint"
+  done
+  pass "fm-control: a remotely placed secondmate is refused by placement, not by a metadata complaint"
+}
+
+hold_lifecycle_lock() {  # <lock-path>
+  local lifecycle_lock_path=$1
+  . "$ROOT/bin/fm-wake-lib.sh"
+  fm_lock_try_acquire "$lifecycle_lock_path" || return 1
+  sleep 30
+}
+
+test_interrupt_and_exit_lock_before_task_state_resolution() {
+  local case_dir out rc verb lifecycle_lock_path holder i
+  for verb in interrupt exit; do
+    case_dir=$(new_case "locked-$verb")
+    add_task "$case_dir" t1 claude
+    alive_as "$case_dir" claude
+    lifecycle_lock_path="$case_dir/home/state/.control-t1.lock"
+    hold_lifecycle_lock "$lifecycle_lock_path" &
+    holder=$!
+    i=0
+    while [ ! -e "$lifecycle_lock_path" ] && [ "$i" -lt 100 ]; do
+      sleep 0.1
+      i=$((i + 1))
+    done
+    [ -e "$lifecycle_lock_path" ] || fail "could not stage the lifecycle lock for $verb"
+    sed 's/^endpoint_task_id=t1$/endpoint_task_id=other/' "$case_dir/home/state/t1.meta" \
+      > "$case_dir/home/state/t1.meta.tmp"
+    mv "$case_dir/home/state/t1.meta.tmp" "$case_dir/home/state/t1.meta"
+    out=$(run_control "$case_dir" t1 "$verb"); rc=$?
+    kill "$holder" 2>/dev/null || true
+    wait "$holder" 2>/dev/null || true
+    expect_code 1 "$rc" "$verb should refuse a held lifecycle lock"
+    assert_contains "$out" "another lifecycle action is already running" \
+      "$verb should serialize before reading mutable task state"
+    [ -z "$(literals "$case_dir")" ] || fail "contended $verb must type no command"
+    [ -z "$(keys_sent "$case_dir")" ] || fail "contended $verb must send no control key"
+  done
+  pass "fm-control: interrupt and exit lock before task-state resolution"
+}
+
+# --- 4. verb allowlist ------------------------------------------------------
+
+test_verb_allowlist_is_closed() {
+  local dir out rc
+  dir=$(new_case verbs)
+  add_task "$dir" t1 claude
+  alive_as "$dir" claude
+  out=$(run_control "$dir" t1 restart); rc=$?
+  expect_code 2 "$rc" "an unknown verb should be a usage error"
+  assert_contains "$out" "is not a control verb" "the refusal should say so"
+  assert_contains "$out" "interrupt" "the refusal should list the allowed verbs"
+  out=$(run_control "$dir" t1 --key); rc=$?
+  expect_code 2 "$rc" "a raw key is not a control verb"
+  out=$(run_control "$dir" t1 "please stop what you are doing"); rc=$?
+  expect_code 2 "$rc" "arbitrary text is not a control verb"
+  [ -z "$(literals "$dir")" ] || fail "a refused verb must send nothing"
+  [ -z "$(keys_sent "$dir")" ] || fail "a refused verb must send no keys"
+  pass "fm-control: the verb list is closed - no raw keys, no arbitrary text"
+}
+
+test_resume_is_refused_with_its_reason() {
+  local dir out rc
+  dir=$(new_case resume)
+  add_task "$dir" t1 claude
+  out=$(run_control "$dir" t1 resume); rc=$?
+  expect_code 2 "$rc" "resume should be refused"
+  assert_contains "$out" "not deterministic across the verified adapters" \
+    "the refusal should explain why resume is excluded"
+  assert_contains "$out" "relaunch" "the refusal should point at the deterministic alternative"
+  pass "fm-control: resume is refused with the determinism reason and the alternative"
+}
+
+test_relaunch_only_flags_are_rejected_on_other_verbs() {
+  local dir out rc
+  dir=$(new_case flags)
+  add_task "$dir" t1 claude
+  alive_as "$dir" claude
+  out=$(run_control "$dir" t1 exit --harness codex); rc=$?
+  expect_code 1 "$rc" "--harness should not apply to exit"
+  assert_contains "$out" "apply to 'relaunch' only" "the refusal should scope the flags"
+  pass "fm-control: profile and note flags belong to relaunch only"
+}
+
+# --- 5. lifecycle states ----------------------------------------------------
+
+test_already_stopped_exit_is_idempotent() {
+  local dir out rc
+  dir=$(new_case idempotent)
+  add_task "$dir" t1 claude
+  alive_as "$dir" zsh
+  out=$(run_control "$dir" t1 exit); rc=$?
+  expect_code 0 "$rc" "exiting an already-stopped agent should succeed"
+  assert_contains "$out" "already-stopped t1" "the outcome should say it was already stopped"
+  [ -z "$(literals "$dir")" ] || fail "an already-stopped agent must not be sent an exit command"
+  pass "fm-control exit: an already-stopped agent is idempotent success with no bytes sent"
+}
+
+test_missing_endpoint_refuses() {
+  local dir out rc
+  dir=$(new_case gone)
+  add_task "$dir" t1 claude
+  : > "$dir/fake/windows"
+  out=$(run_control "$dir" t1 exit); rc=$?
+  expect_code 1 "$rc" "a missing endpoint should refuse"
+  assert_contains "$out" "recorded endpoint is gone" "the refusal should name the missing endpoint"
+  pass "fm-control exit: a vanished endpoint refuses instead of silently succeeding"
+}
+
+test_interrupt_refuses_when_no_agent_runs() {
+  local dir out rc
+  dir=$(new_case nointerrupt)
+  add_task "$dir" t1 claude
+  alive_as "$dir" zsh
+  out=$(run_control "$dir" t1 interrupt); rc=$?
+  expect_code 1 "$rc" "interrupting a stopped agent should refuse"
+  assert_contains "$out" "nothing to interrupt" "the refusal should say there is no agent"
+  [ -z "$(keys_sent "$dir")" ] || fail "no key should reach a stopped agent"
+  pass "fm-control interrupt: refuses when no agent is running rather than keying a shell"
+}
+
+test_ambiguous_endpoint_refuses() {
+  local dir out rc
+  dir=$(new_case ambiguous)
+  add_task "$dir" t1 claude
+  alive_as "$dir" some-unrelated-process
+  out=$(run_control "$dir" t1 exit); rc=$?
+  expect_code 1 "$rc" "an unattributed endpoint should refuse"
+  assert_contains "$out" "positively classified" "the refusal should name the missing attribution"
+  [ -z "$(literals "$dir")" ] || fail "an unattributed endpoint must receive no bytes"
+  pass "fm-control exit: an endpoint whose process cannot be attributed refuses"
+}
+
+test_busy_agent_is_interrupted_before_the_exit_command() {
+  local dir out rc
+  dir=$(new_case busy)
+  add_task "$dir" t1 claude
+  alive_as "$dir" claude
+  # Arm the semantic busy contract and record a busy turn, exactly as the
+  # harness's own lifecycle hook would.
+  gen=$("$ROOT/bin/fm-busy-event.sh" arm "$dir/home/state" t1)
+  printf 'busy_gen=%s\n' "$gen" >> "$dir/home/state/t1.meta"
+  out=$(run_control "$dir" t1 exit); rc=$?
+  expect_code 0 "$rc" "exiting a busy agent should succeed"$'\n'"$out"
+  [ "$(keys_sent "$dir")" = "Escape" ] \
+    || fail "a busy agent should be interrupted once before its exit command, got: $(keys_sent "$dir")"
+  [ "$(literals "$dir")" = "/exit" ] || fail "the exit command should follow the interrupt"
+  pass "fm-control exit: a busy agent is interrupted first so the exit command reaches an idle composer"
+}
+
+test_idle_agent_is_not_interrupted() {
+  local dir out rc gen
+  dir=$(new_case idle)
+  add_task "$dir" t1 claude
+  alive_as "$dir" claude
+  gen=$("$ROOT/bin/fm-busy-event.sh" arm "$dir/home/state" t1 --state idle --source fm-spawn --event seed)
+  printf 'busy_gen=%s\n' "$gen" >> "$dir/home/state/t1.meta"
+  out=$(run_control "$dir" t1 exit); rc=$?
+  expect_code 0 "$rc" "exiting an idle agent should succeed"$'\n'"$out"
+  [ -z "$(keys_sent "$dir")" ] \
+    || fail "an idle agent needs no interrupt, got keys: $(keys_sent "$dir")"
+  [ "$(literals "$dir")" = "/exit" ] || fail "the exit command should still be sent"
+  pass "fm-control exit: an idle agent goes straight to its exit command"
+}
+
+test_interrupt_records_idle_against_the_armed_generation() {
+  local dir gen record
+  dir=$(new_case record)
+  add_task "$dir" t1 claude
+  alive_as "$dir" claude
+  gen=$("$ROOT/bin/fm-busy-event.sh" arm "$dir/home/state" t1)
+  printf 'busy_gen=%s\n' "$gen" >> "$dir/home/state/t1.meta"
+  run_control "$dir" t1 interrupt >/dev/null
+  record=$(cat "$dir/home/state/t1.busy-state")
+  assert_contains "$record" "state=idle" "a proven interrupt should record idle"
+  assert_contains "$record" "source=fm-interrupt" "the record should attribute the interrupt to firstmate"
+  assert_contains "$record" "gen=$gen" "the record should bind the armed generation"
+  pass "fm-control interrupt: a proven interrupt records idle/fm-interrupt on the armed generation"
+}
+
+test_interrupt_refuses_when_armed_idle_transition_cannot_publish() {
+  local dir gen out rc
+  dir=$(new_case stale-record)
+  add_task "$dir" t1 claude
+  alive_as "$dir" claude
+  gen=$("$ROOT/bin/fm-busy-event.sh" arm "$dir/home/state" t1)
+  printf 'busy_gen=%s\n' "$gen" >> "$dir/home/state/t1.meta"
+  printf '%s\n' 'not-a-busy-record' > "$dir/home/state/t1.busy-state"
+  mkdir "$dir/home/state/t1.busy-state.lock"
+  out=$(FM_BUSY_LOCK_STALE_SECS=999999 run_control "$dir" t1 interrupt); rc=$?
+  expect_code 1 "$rc" "an interrupt must refuse when its idle event cannot publish"
+  assert_contains "$out" "could not be recorded idle" \
+    "the refusal should name the failed idle transition"
+  [ "$(cat "$dir/home/state/t1.busy-state")" = 'not-a-busy-record' ] \
+    || fail "the fixture should retain the malformed stale record"
+  pass "fm-control interrupt: an armed generation must publish verified idle state"
+}
+
+test_agent_that_does_not_stop_fails_closed() {
+  local dir out rc
+  dir=$(new_case stubborn)
+  add_task "$dir" t1 claude
+  alive_as "$dir" claude
+  out=$(env FM_FAKE_NEVER_DIES=1 PATH="$dir/fakebin:$PATH" FM_HOME="$dir/home" \
+    FM_FAKE_DIR="$dir/fake" FM_CONTROL_POLL=0.01 FM_CONTROL_EXIT_WAIT=0.05 \
+    "$CONTROL" t1 exit 2>&1); rc=$?
+  expect_code 1 "$rc" "an agent that ignores its exit command should fail closed"
+  assert_contains "$out" "did not stop" "the failure should say the agent did not stop"
+  assert_contains "$out" "nothing was changed" "the failure should say nothing was changed"
+  pass "fm-control exit: an agent that ignores its exit command fails closed instead of claiming success"
+}
+
+test_interrupt_that_does_not_settle_fails_closed() {
+  local dir out rc
+  dir=$(new_case nosettle)
+  add_task "$dir" t1 grok
+  alive_as "$dir" grok
+  # Grok has no semantic busy writer yet, so its verdict comes from the
+  # rendered cancel hint. A footer that never clears means the cancel did not
+  # take, and the control plane must say so instead of reporting a landed
+  # interrupt.
+  printf '╭────╮\n│    │\n╰────╯\n Ctrl+c:cancel\n' > "$dir/fake/pane"
+  out=$(run_control "$dir" t1 interrupt); rc=$?
+  expect_code 1 "$rc" "an interrupt whose busy verdict never settles should fail closed"
+  assert_contains "$out" "the interrupt did not take" "the failure should say the interrupt did not take"
+  pass "fm-control interrupt: a busy verdict that never settles fails closed rather than claiming success"
+}
+
+test_interrupt_settles_once_the_rendered_footer_clears() {
+  local dir out rc
+  dir=$(new_case settles)
+  add_task "$dir" t1 grok
+  alive_as "$dir" grok
+  printf '╭────╮\n│    │\n╰────╯\n Shift+Tab:mode │ Ctrl+.:shortcuts\n' > "$dir/fake/pane"
+  out=$(run_control "$dir" t1 interrupt); rc=$?
+  expect_code 0 "$rc" "an interrupt whose verdict reads idle should succeed"$'\n'"$out"
+  assert_contains "$out" "verified=agent-alive" "the proof should name the surviving agent"
+  [ "$(keys_sent "$dir")" = "C-c" ] || fail "grok should be cancelled with C-c, got: $(keys_sent "$dir")"
+  pass "fm-control interrupt: grok's cancel lands and its idle footer settles the verdict"
+}
+
+# --- 6. marker non-regression -----------------------------------------------
+
+test_secondmate_control_command_carries_no_marker() {
+  local dir out rc typed home
+  dir=$(new_case sm-marker)
+  home="$dir/home"
+  add_task "$dir" domain claude secondmate
+  # A secondmate's worktree IS its home; give it the marker its records need.
+  printf '%s\n' domain > "$dir/wt-domain/.fm-secondmate-home"
+  alive_as "$dir" claude
+  out=$(run_control "$dir" domain exit); rc=$?
+  expect_code 0 "$rc" "exiting a secondmate's agent should succeed"$'\n'"$out"
+  typed=$(literals "$dir")
+  [ "$typed" = "/exit" ] \
+    || fail "a secondmate control command must be the bare exit command, got: $typed"
+  case "$typed" in
+    *"$FM_FROMFIRST_MARK"*) fail "a control command must never carry the from-firstmate marker" ;;
+  esac
+  case "$typed" in
+    *corr=*) fail "a control command must never carry a pending-reply correlation id" ;;
+  esac
+  [ -z "$(find "$home/state/pending-replies" -type f 2>/dev/null | head -n 1)" ] \
+    || fail "a control command must not open a pending-reply expectation"
+  pass "fm-control: a lifecycle command to a secondmate is unmarked and opens no reply expectation"
+}
+
+test_fm_send_still_marks_the_same_secondmate_task() {
+  local dir log out rc
+  dir=$(new_case sm-send)
+  add_task "$dir" domain claude secondmate
+  log="$dir/fake/sendlog"
+  : > "$log"
+  out=$(env PATH="$dir/fakebin:$PATH" FM_HOME="$dir/home" FM_FAKE_DIR="$dir/fake" \
+    FM_SEND_SETTLE=0 FM_ROOT_OVERRIDE="$dir/home" \
+    "$SEND" domain "audit the build" 2>&1); rc=$?
+  expect_code 0 "$rc" "fm-send to a secondmate should still succeed"$'\n'"$out"
+  case "$(literals "$dir")" in
+    "$FM_FROMFIRST_MARK"*) : ;;
+    *) fail "fm-send must still mark a kind=secondmate target: $(literals "$dir")" ;;
+  esac
+  pass "fm-control's arrival leaves fm-send's from-firstmate marking untouched"
+}
+
+test_exit_types_each_harness_verified_command
+test_interrupt_sends_each_harness_verified_key
+test_opencode_interrupts_twice_and_others_once
+test_unverified_harness_is_refused
+test_harness_family_resolution
+test_backend_key_capability_matrix
+test_harness_kind_capability
+test_orca_refuses_an_escape_harness_interrupt
+test_unverified_state_backends_refuse_stop_verbs
+test_state_verified_backends_are_exactly_tmux_and_herdr
+test_window_label_is_refused_with_the_exact_id
+test_explicit_endpoint_is_refused
+test_unknown_task_is_refused
+test_record_bound_to_another_task_is_refused
+test_remote_secondmate_is_refused_by_placement
+test_interrupt_and_exit_lock_before_task_state_resolution
+test_verb_allowlist_is_closed
+test_resume_is_refused_with_its_reason
+test_relaunch_only_flags_are_rejected_on_other_verbs
+test_already_stopped_exit_is_idempotent
+test_missing_endpoint_refuses
+test_interrupt_refuses_when_no_agent_runs
+test_ambiguous_endpoint_refuses
+test_busy_agent_is_interrupted_before_the_exit_command
+test_idle_agent_is_not_interrupted
+test_interrupt_records_idle_against_the_armed_generation
+test_interrupt_refuses_when_armed_idle_transition_cannot_publish
+test_agent_that_does_not_stop_fails_closed
+test_interrupt_that_does_not_settle_fails_closed
+test_interrupt_settles_once_the_rendered_footer_clears
+test_secondmate_control_command_carries_no_marker
+test_fm_send_still_marks_the_same_secondmate_task

--- a/tests/fm-control.test.sh
+++ b/tests/fm-control.test.sh
@@ -101,6 +101,9 @@ case "${1:-}" in
       esac
     else
       printf '%s\n' "$payload" >> "$D/keys"
+      if [ "$payload" = Escape ] && [ -n "${FM_FAKE_MUSE_LOG:-}" ]; then
+        printf '%s\n' '{"schema_version":1,"payload_type":"runtime.session","payload":{"kind":"run","run_id":"run-1","event":{"kind":"terminal","terminal":"cancelled","reason":null}}}' >> "$FM_FAKE_MUSE_LOG"
+      fi
     fi
     exit 0 ;;
   display-message)
@@ -176,6 +179,7 @@ run_control() {
   env PATH="$dir/fakebin:$PATH" FM_HOME="$dir/home" FM_FAKE_DIR="$dir/fake" \
     FM_CONTROL_POLL=0.01 FM_CONTROL_SETTLE_WAIT=0.05 \
     FM_CONTROL_EXIT_WAIT=0.05 FM_CONTROL_LAUNCH_WAIT=0.05 \
+    FM_FAKE_MUSE_LOG="${FM_FAKE_MUSE_LOG:-}" \
     "$CONTROL" "$@" 2>&1
 }
 
@@ -645,7 +649,7 @@ test_busy_agent_is_interrupted_before_the_exit_command() {
   [ "$(keys_sent "$dir")" = "Escape" ] \
     || fail "a busy agent should be interrupted once before its exit command, got: $(keys_sent "$dir")"
   [ "$(literals "$dir")" = "/exit" ] || fail "the exit command should follow the interrupt"
-  pass "fm-control exit: a busy agent is interrupted first so the exit command reaches an idle composer"
+  pass "fm-control exit: a busy agent receives interrupt delivery before the exit command"
 }
 
 test_idle_agent_is_not_interrupted() {
@@ -663,37 +667,43 @@ test_idle_agent_is_not_interrupted() {
   pass "fm-control exit: an idle agent goes straight to its exit command"
 }
 
-test_interrupt_records_idle_against_the_armed_generation() {
-  local dir gen record
-  dir=$(new_case record)
+test_interrupt_without_acknowledgement_preserves_busy_state() {
+  local dir gen before after out rc
+  dir=$(new_case unconfirmed)
   add_task "$dir" t1 claude
   alive_as "$dir" claude
   gen=$("$ROOT/bin/fm-busy-event.sh" arm "$dir/home/state" t1)
   printf 'busy_gen=%s\n' "$gen" >> "$dir/home/state/t1.meta"
-  run_control "$dir" t1 interrupt >/dev/null
-  record=$(cat "$dir/home/state/t1.busy-state")
-  assert_contains "$record" "state=idle" "a proven interrupt should record idle"
-  assert_contains "$record" "source=fm-interrupt" "the record should attribute the interrupt to firstmate"
-  assert_contains "$record" "gen=$gen" "the record should bind the armed generation"
-  pass "fm-control interrupt: a proven interrupt records idle/fm-interrupt on the armed generation"
+  before=$(cat "$dir/home/state/t1.busy-state")
+  out=$(run_control "$dir" t1 interrupt); rc=$?
+  expect_code 0 "$rc" "an interrupt without acknowledgement should still deliver"$'\n'"$out"
+  after=$(cat "$dir/home/state/t1.busy-state")
+  [ "$after" = "$before" ] || fail "an unconfirmed interrupt must preserve adapter-owned busy state"
+  assert_contains "$out" "verified=agent-alive cancel=unconfirmed" \
+    "the result should distinguish delivery proof from unconfirmed cancellation"
+  assert_not_contains "$out" "cancel=confirmed" \
+    "an adapter without acknowledgement must not report cancellation"
+  pass "fm-control interrupt: unconfirmed delivery preserves observed busy state"
 }
 
-test_interrupt_refuses_when_armed_idle_transition_cannot_publish() {
-  local dir gen out rc
-  dir=$(new_case stale-record)
-  add_task "$dir" t1 claude
-  alive_as "$dir" claude
-  gen=$("$ROOT/bin/fm-busy-event.sh" arm "$dir/home/state" t1)
-  printf 'busy_gen=%s\n' "$gen" >> "$dir/home/state/t1.meta"
-  printf '%s\n' 'not-a-busy-record' > "$dir/home/state/t1.busy-state"
-  mkdir "$dir/home/state/t1.busy-state.lock"
-  out=$(FM_BUSY_LOCK_STALE_SECS=999999 run_control "$dir" t1 interrupt); rc=$?
-  expect_code 1 "$rc" "an interrupt must refuse when its idle event cannot publish"
-  assert_contains "$out" "could not be recorded idle" \
-    "the refusal should name the failed idle transition"
-  [ "$(cat "$dir/home/state/t1.busy-state")" = 'not-a-busy-record' ] \
-    || fail "the fixture should retain the malformed stale record"
-  pass "fm-control interrupt: an armed generation must publish verified idle state"
+test_muse_interrupt_confirms_adapter_acknowledgement() {
+  local dir root log out rc
+  dir=$(new_case confirmed)
+  add_task "$dir" t1 muse
+  alive_as "$dir" muse
+  root="$dir/muse-sessions"
+  log="$root/2026/08/08/session-1/session.jsonl"
+  mkdir -p "$(dirname "$log")"
+  printf '%s\n' \
+    "{\"schema_version\":1,\"payload_type\":\"runtime.session.metadata\",\"payload\":{\"kind\":\"metadata\",\"record\":{\"workspace_root\":\"$dir/wt-t1\"}}}" \
+    '{"schema_version":1,"payload_type":"runtime.session","payload":{"kind":"run","run_id":"run-1","event":{"kind":"started","prompt":"work"}}}' > "$log"
+  printf 'sessions_root=%s\nworkspace_root=%s\nbinding_id=test\n' \
+    "$root" "$dir/wt-t1" > "$dir/home/state/t1.muse-session"
+  out=$(FM_FAKE_MUSE_LOG="$log" run_control "$dir" t1 interrupt); rc=$?
+  expect_code 0 "$rc" "muse interrupt should observe its adapter acknowledgement"$'\n'"$out"
+  assert_contains "$out" "verified=agent-alive cancel=confirmed" \
+    "the result should report muse's cancelled terminal acknowledgement"
+  pass "fm-control interrupt: muse confirms cancellation from its session log"
 }
 
 test_agent_that_does_not_stop_fails_closed() {
@@ -710,33 +720,31 @@ test_agent_that_does_not_stop_fails_closed() {
   pass "fm-control exit: an agent that ignores its exit command fails closed instead of claiming success"
 }
 
-test_interrupt_that_does_not_settle_fails_closed() {
+test_grok_interrupt_without_acknowledgement_reports_unconfirmed() {
   local dir out rc
   dir=$(new_case nosettle)
   add_task "$dir" t1 grok
   alive_as "$dir" grok
-  # Grok has no semantic busy writer yet, so its verdict comes from the
-  # rendered cancel hint. A footer that never clears means the cancel did not
-  # take, and the control plane must say so instead of reporting a landed
-  # interrupt.
   printf '╭────╮\n│    │\n╰────╯\n Ctrl+c:cancel\n' > "$dir/fake/pane"
   out=$(run_control "$dir" t1 interrupt); rc=$?
-  expect_code 1 "$rc" "an interrupt whose busy verdict never settles should fail closed"
-  assert_contains "$out" "the interrupt did not take" "the failure should say the interrupt did not take"
-  pass "fm-control interrupt: a busy verdict that never settles fails closed rather than claiming success"
+  expect_code 0 "$rc" "grok interrupt delivery should not depend on inferred cancellation"$'\n'"$out"
+  assert_contains "$out" "verified=agent-alive cancel=unconfirmed" \
+    "a rendered busy hint is not a cancellation acknowledgement"
+  pass "fm-control interrupt: grok reports delivery without claiming cancellation"
 }
 
-test_interrupt_settles_once_the_rendered_footer_clears() {
+test_grok_idle_footer_does_not_confirm_cancellation() {
   local dir out rc
   dir=$(new_case settles)
   add_task "$dir" t1 grok
   alive_as "$dir" grok
   printf '╭────╮\n│    │\n╰────╯\n Shift+Tab:mode │ Ctrl+.:shortcuts\n' > "$dir/fake/pane"
   out=$(run_control "$dir" t1 interrupt); rc=$?
-  expect_code 0 "$rc" "an interrupt whose verdict reads idle should succeed"$'\n'"$out"
-  assert_contains "$out" "verified=agent-alive" "the proof should name the surviving agent"
-  [ "$(keys_sent "$dir")" = "C-c" ] || fail "grok should be cancelled with C-c, got: $(keys_sent "$dir")"
-  pass "fm-control interrupt: grok's cancel lands and its idle footer settles the verdict"
+  expect_code 0 "$rc" "grok interrupt delivery should succeed"$'\n'"$out"
+  assert_contains "$out" "verified=agent-alive cancel=unconfirmed" \
+    "an idle footer is not an explicit cancellation acknowledgement"
+  [ "$(keys_sent "$dir")" = "C-c" ] || fail "grok should receive C-c, got: $(keys_sent "$dir")"
+  pass "fm-control interrupt: grok's idle footer does not confirm cancellation"
 }
 
 # --- 6. marker non-regression -----------------------------------------------
@@ -808,10 +816,10 @@ test_interrupt_refuses_when_no_agent_runs
 test_ambiguous_endpoint_refuses
 test_busy_agent_is_interrupted_before_the_exit_command
 test_idle_agent_is_not_interrupted
-test_interrupt_records_idle_against_the_armed_generation
-test_interrupt_refuses_when_armed_idle_transition_cannot_publish
+test_interrupt_without_acknowledgement_preserves_busy_state
+test_muse_interrupt_confirms_adapter_acknowledgement
 test_agent_that_does_not_stop_fails_closed
-test_interrupt_that_does_not_settle_fails_closed
-test_interrupt_settles_once_the_rendered_footer_clears
+test_grok_interrupt_without_acknowledgement_reports_unconfirmed
+test_grok_idle_footer_does_not_confirm_cancellation
 test_secondmate_control_command_carries_no_marker
 test_fm_send_still_marks_the_same_secondmate_task

--- a/tests/fm-control.test.sh
+++ b/tests/fm-control.test.sh
@@ -101,8 +101,16 @@ case "${1:-}" in
       esac
     else
       printf '%s\n' "$payload" >> "$D/keys"
+      if [ -n "${FM_FAKE_INTERRUPT_STOPS_AGENT:-}" ] \
+         && { [ "$payload" = Escape ] || [ "$payload" = C-c ]; }; then
+        printf 'zsh' > "$D/command"
+      fi
       if [ "$payload" = Escape ] && [ -n "${FM_FAKE_MUSE_LOG:-}" ]; then
-        printf '%s\n' '{"schema_version":1,"payload_type":"runtime.session","payload":{"kind":"run","run_id":"run-1","event":{"kind":"terminal","terminal":"cancelled","reason":null}}}' >> "$FM_FAKE_MUSE_LOG"
+        if [ -n "${FM_FAKE_MUSE_DISAPPEAR_BEFORE_ACK:-}" ]; then
+          : > "$D/muse-ack-pending"
+        else
+          printf '%s\n' '{"schema_version":1,"payload_type":"runtime.session","payload":{"kind":"run","run_id":"run-1","event":{"kind":"terminal","terminal":"cancelled","reason":null}}}' >> "$FM_FAKE_MUSE_LOG"
+        fi
       fi
     fi
     exit 0 ;;
@@ -127,6 +135,12 @@ SH
   chmod +x "$fb/tmux"
   cat > "$fb/sleep" <<'SH'
 #!/usr/bin/env bash
+if [ -n "${FM_FAKE_MUSE_DISAPPEAR_BEFORE_ACK:-}" ] \
+   && [ -e "$FM_FAKE_DIR/muse-ack-pending" ]; then
+  rm -f "$FM_FAKE_DIR/muse-ack-pending"
+  printf 'zsh' > "$FM_FAKE_DIR/command"
+  printf '%s\n' '{"schema_version":1,"payload_type":"runtime.session","payload":{"kind":"run","run_id":"run-1","event":{"kind":"terminal","terminal":"cancelled","reason":null}}}' >> "$FM_FAKE_MUSE_LOG"
+fi
 exit 0
 SH
   chmod +x "$fb/sleep"
@@ -180,6 +194,8 @@ run_control() {
     FM_CONTROL_POLL=0.01 FM_CONTROL_SETTLE_WAIT=0.05 \
     FM_CONTROL_EXIT_WAIT=0.05 FM_CONTROL_LAUNCH_WAIT=0.05 \
     FM_FAKE_MUSE_LOG="${FM_FAKE_MUSE_LOG:-}" \
+    FM_FAKE_MUSE_DISAPPEAR_BEFORE_ACK="${FM_FAKE_MUSE_DISAPPEAR_BEFORE_ACK:-}" \
+    FM_FAKE_INTERRUPT_STOPS_AGENT="${FM_FAKE_INTERRUPT_STOPS_AGENT:-}" \
     "$CONTROL" "$@" 2>&1
 }
 
@@ -706,6 +722,49 @@ test_muse_interrupt_confirms_adapter_acknowledgement() {
   pass "fm-control interrupt: muse confirms cancellation from its session log"
 }
 
+test_interrupt_revalidates_agent_after_acknowledgement_wait() {
+  local dir root log out rc
+  dir=$(new_case ack-race)
+  add_task "$dir" t1 muse
+  alive_as "$dir" muse
+  root="$dir/muse-sessions"
+  log="$root/2026/08/08/session-1/session.jsonl"
+  mkdir -p "$(dirname "$log")"
+  printf '%s\n' \
+    "{\"schema_version\":1,\"payload_type\":\"runtime.session.metadata\",\"payload\":{\"kind\":\"metadata\",\"record\":{\"workspace_root\":\"$dir/wt-t1\"}}}" \
+    '{"schema_version":1,"payload_type":"runtime.session","payload":{"kind":"run","run_id":"run-1","event":{"kind":"started","prompt":"work"}}}' > "$log"
+  printf 'sessions_root=%s\nworkspace_root=%s\nbinding_id=test\n' \
+    "$root" "$dir/wt-t1" > "$dir/home/state/t1.muse-session"
+  out=$(FM_FAKE_MUSE_LOG="$log" FM_FAKE_MUSE_DISAPPEAR_BEFORE_ACK=1 \
+    run_control "$dir" t1 interrupt); rc=$?
+  expect_code 1 "$rc" "interrupt should fail when the agent stops during acknowledgement polling"
+  assert_contains "$out" "agent is 'dead' after its interrupt key" \
+    "the final postcondition should observe the agent after acknowledgement polling"
+  assert_not_contains "$out" "interrupt-delivered" \
+    "a stale pre-wait liveness proof must not be published"
+  pass "fm-control interrupt: postconditions are revalidated after acknowledgement polling"
+}
+
+test_exit_accepts_agent_stopped_by_busy_interrupt() {
+  local dir out rc gen
+  dir=$(new_case interrupt-stops)
+  add_task "$dir" t1 claude
+  alive_as "$dir" claude
+  gen=$("$ROOT/bin/fm-busy-event.sh" arm "$dir/home/state" t1)
+  printf 'busy_gen=%s\n' "$gen" >> "$dir/home/state/t1.meta"
+  out=$(FM_FAKE_INTERRUPT_STOPS_AGENT=1 run_control "$dir" t1 exit); rc=$?
+  expect_code 0 "$rc" "exit should accept a busy agent stopped by interrupt"$'\n'"$out"
+  assert_contains "$out" "stopped t1 harness=claude" \
+    "the authoritative gone-state should complete exit successfully"
+  [ "$(keys_sent "$dir")" = Escape ] \
+    || fail "exit should deliver the busy agent's interrupt sequence"
+  [ -z "$(literals "$dir")" ] \
+    || fail "exit should not type a command after interrupt already stopped the agent"
+  [ ! -e "$dir/home/state/t1.busy-gen" ] && [ ! -e "$dir/home/state/t1.busy-state" ] \
+    || fail "exit should retire busy wiring for an agent stopped by interrupt"
+  pass "fm-control exit: an interrupt-stopped agent satisfies the gone-state postcondition"
+}
+
 test_agent_that_does_not_stop_fails_closed() {
   local dir out rc gen
   dir=$(new_case stubborn)
@@ -827,6 +886,8 @@ test_busy_agent_is_interrupted_before_the_exit_command
 test_idle_agent_is_not_interrupted
 test_interrupt_without_acknowledgement_preserves_busy_state
 test_muse_interrupt_confirms_adapter_acknowledgement
+test_interrupt_revalidates_agent_after_acknowledgement_wait
+test_exit_accepts_agent_stopped_by_busy_interrupt
 test_agent_that_does_not_stop_fails_closed
 test_grok_interrupt_without_acknowledgement_reports_unconfirmed
 test_grok_idle_footer_does_not_confirm_cancellation

--- a/tests/fm-gotmp.test.sh
+++ b/tests/fm-gotmp.test.sh
@@ -61,6 +61,9 @@ make_fake_root() {
   ln -s "$ROOT/bin/fm-nm-run-lib.sh" "$fake/bin/fm-nm-run-lib.sh"
   # fm-lock-lib.sh: teardown sources it for the shared lock-staleness proof.
   ln -s "$ROOT/bin/fm-lock-lib.sh" "$fake/bin/fm-lock-lib.sh"
+  # Lifecycle serialization and shared adapter ownership are sourced by teardown.
+  ln -s "$ROOT/bin/fm-control-lib.sh" "$fake/bin/fm-control-lib.sh"
+  ln -s "$ROOT/bin/fm-wake-lib.sh" "$fake/bin/fm-wake-lib.sh"
   # fm-gate-refuse-lib.sh: teardown sources it before any fleet mutation.
   ln -s "$ROOT/bin/fm-gate-refuse-lib.sh" "$fake/bin/fm-gate-refuse-lib.sh"
   # fm-pr-lib.sh: teardown uses its canonical task-ID validator for poll cleanup.
@@ -138,6 +141,8 @@ test_teardown_skips_gracefully_without_tasktmp() {
   ln -s "$ROOT/bin/fm-composer-lib.sh" "$fake/bin/fm-composer-lib.sh"
   ln -s "$ROOT/bin/fm-nm-run-lib.sh" "$fake/bin/fm-nm-run-lib.sh"
   ln -s "$ROOT/bin/fm-lock-lib.sh" "$fake/bin/fm-lock-lib.sh"
+  ln -s "$ROOT/bin/fm-control-lib.sh" "$fake/bin/fm-control-lib.sh"
+  ln -s "$ROOT/bin/fm-wake-lib.sh" "$fake/bin/fm-wake-lib.sh"
   # fm-gate-refuse-lib.sh: teardown sources it before any fleet mutation.
   ln -s "$ROOT/bin/fm-gate-refuse-lib.sh" "$fake/bin/fm-gate-refuse-lib.sh"
   # fm-pr-lib.sh: teardown uses its canonical task-ID validator for poll cleanup.

--- a/tests/fm-remote-job-orphan-reap.test.sh
+++ b/tests/fm-remote-job-orphan-reap.test.sh
@@ -114,12 +114,14 @@ pass "the Linux start path puts the whole worker tree in its own process group"
   fail "the fixture worker is not orphaned to init, so this case does not reproduce the leak"
 
 # The exact teardown shape that leaked in production: a fixture cleanup removes
-# the worker's state root and then TERMs the single recorded worker pid - which
-# is the serving child, not the supervisor. The supervisor respawns, so the tree
-# survives a teardown that looks complete.
+# the worker's state root and then stops only the single recorded worker pid -
+# which is the serving child, not the supervisor. KILL makes that obsolete
+# teardown reproduction independent of the graceful handler's missing-state
+# refusal. The supervisor respawns, so the tree survives a teardown that looks
+# complete.
 rm -rf "$CASE1/remote-jobs"
-kill -TERM "$SERVE" 2>/dev/null || true
-wait_gone "$SERVE" 10 || fail "the serving child ignored TERM"
+kill -KILL "$SERVE" 2>/dev/null || true
+wait_gone "$SERVE" 10 || fail "the recorded serving child did not stop"
 alive "$WORKER" || fail "the fixture supervisor did not survive a lone child kill, so this case no longer covers the leak"
 wait_child "$WORKER" 15 || fail "the supervisor did not respawn after its recorded child pid was killed"
 pass "removing the state root and killing the recorded worker pid leaves the tree running at ppid 1"

--- a/tests/fm-remote-job.test.sh
+++ b/tests/fm-remote-job.test.sh
@@ -247,10 +247,14 @@ pass "ensure replaces a live worker after its code changes"
 RELOCATED_ROOT="$TMP_ROOT/relocated-root"
 cp -R "$REMOTE_ROOT" "$RELOCATED_ROOT"
 OLD_WORKER_PID=$NEW_WORKER_PID
+OLD_WORKER_PGID=$(fm_remote_job_process_pgid "$OLD_WORKER_PID") \
+  || fail "the worker replacement fixture could not resolve its process group"
 fm_remote_job_ensure_worker "$RELOCATED_ROOT" "$ACCOUNT_HOME" \
   || fail "$FM_REMOTE_JOB_ERROR"
 NEW_WORKER_PID=$(cat "$STATE_ROOT/worker.pid")
 [ "$NEW_WORKER_PID" != "$OLD_WORKER_PID" ] || fail "ensure retained a worker bound to a different code root"
+! kill -0 -- "-$OLD_WORKER_PGID" 2>/dev/null \
+  || fail "ensure left the replaced worker supervisor group alive"
 fm_remote_job_stage "$ACCOUNT_HOME" "$RELOCATED_ROOT" "$REMOTE_HOME" fm-probe-job.sh < /dev/null > /dev/null
 JOB_ID=$FM_REMOTE_JOB_ID
 fm_remote_job_wait "$ACCOUNT_HOME" "$JOB_ID" || fail "$FM_REMOTE_JOB_ERROR"

--- a/tests/fm-secondmate-safety.test.sh
+++ b/tests/fm-secondmate-safety.test.sh
@@ -2387,12 +2387,17 @@ EOF
   printf '%s|%s\n' "$home" "$subhome"
 }
 
+task_set_lock_path() {  # <state-dir>
+  local state=$1
+  ( . "$ROOT/bin/fm-wake-lib.sh"; fm_task_set_lock_path "$state" )
+}
+
 # The holder must stay ALIVE: fm_lock_try_acquire reclaims a lock whose owning
 # pid is gone, so a lock taken in a subshell that then exits would be stolen and
 # the contention under test would never happen.
 hold_task_set_lock() {  # <state-dir> -> echoes "<holder-pid> <lock-path>"
   local state=$1 lock holder i=0
-  lock=$( . "$ROOT/bin/fm-wake-lib.sh"; fm_task_set_lock_path "$state" ) || return 1
+  lock=$(task_set_lock_path "$state") || return 1
   [ -n "$lock" ] || return 1
   # stdout/stderr are redirected so the long-lived holder does not inherit this
   # function's command-substitution pipe; leaving it open would block the caller
@@ -2528,7 +2533,7 @@ SH
     wait "$pid" 2>/dev/null || true
     fail "forced teardown did not reach the post-lock preflight: $(cat "$err")"
   }
-  lock=$( . "$ROOT/bin/fm-wake-lib.sh"; fm_task_set_lock_path "$subhome/state" ) \
+  lock=$(task_set_lock_path "$subhome/state") \
     || fail "could not resolve the established descendant task-set lock"
   [ -d "$subhome/state" ] || fail "forced teardown did not establish the absent state directory"
   [ -e "$lock" ] || fail "forced teardown did not own the descendant task-set lock during preflight"

--- a/tests/fm-secondmate-safety.test.sh
+++ b/tests/fm-secondmate-safety.test.sh
@@ -2080,9 +2080,9 @@ SH
   pass "secondmate force teardown preserves child worktree after unproven lock refusal"
 }
 
-test_secondmate_force_teardown_allows_operational_dir_symlinks_inside_home() {
+test_secondmate_force_teardown_allows_non_state_operational_dir_symlinks_inside_home() {
   local opdir home subhome target fakebin err log
-  for opdir in data state config projects; do
+  for opdir in data config projects; do
     home="$TMP_ROOT/symlink-inside-teardown-home-$opdir"
     subhome="$TMP_ROOT/symlink-inside-teardown-subhome-$opdir"
     target="$subhome/internal-$opdir"
@@ -2112,7 +2112,7 @@ EOF
     [ ! -e "$home/state/domain.meta" ] || fail "force teardown did not clear parent meta for inside $opdir symlink"
     grep -F 'kill-window -t =firstmate:=fm-domain' "$log" >/dev/null || fail "force teardown did not kill parent window for inside $opdir symlink"
   done
-  pass "force teardown allows operational directory symlinks inside the subhome"
+  pass "force teardown allows non-state operational directory symlinks inside the subhome"
 }
 
 test_secondmate_force_teardown_refuses_operational_dir_symlink_outside_home() {
@@ -2415,6 +2415,107 @@ hold_task_set_lock() {  # <state-dir> -> echoes "<holder-pid> <lock-path>"
     return 1
   }
   printf '%s %s\n' "$holder" "$lock"
+}
+
+seed_empty_task_set_home() {  # <tag> -> echoes "<home>|<subhome>"
+  local tag=$1 home subhome
+  home="$TMP_ROOT/$tag-home"
+  subhome="$TMP_ROOT/$tag-subhome"
+  mkdir -p "$home/state" "$home/data" "$subhome/data"
+  printf '%s\n' domain > "$subhome/.fm-secondmate-home"
+  cat > "$home/state/domain.meta" <<EOF
+window=firstmate:fm-domain
+worktree=$subhome
+project=$subhome
+harness=echo
+kind=secondmate
+mode=secondmate
+yolo=off
+home=$subhome
+projects=alpha
+EOF
+  printf '%s\n' '- domain - design domain (home: '"$subhome"'; scope: design domain; projects: alpha; added 2026-06-22)' > "$home/data/secondmates.md"
+  printf '%s|%s\n' "$home" "$subhome"
+}
+
+test_force_teardown_refuses_non_directory_descendant_state() {
+  local home subhome fakebin err log rec
+  rec=$(seed_empty_task_set_home taskset-state-file)
+  IFS='|' read -r home subhome <<EOF
+$rec
+EOF
+  printf '%s\n' 'not a state directory' > "$subhome/state"
+  err="$TMP_ROOT/taskset-state-file.err"
+  fakebin=$(make_fake_tmux "$TMP_ROOT/taskset-state-file-fake")
+  log="$TMP_ROOT/taskset-state-file-fake/tmux.log"
+  if PATH="$fakebin:$PATH" FM_HOME="$home" FM_FAKE_TMUX_LOG="$log" \
+    FM_FAKE_TMUX_CAPTURE="$TMP_ROOT/taskset-state-file-fake/pane.txt" \
+    "$ROOT/bin/fm-teardown.sh" domain --force >/dev/null 2>"$err"; then
+    fail "forced teardown accepted a non-directory descendant state path"
+  fi
+  [ -d "$subhome" ] || fail "state-path refusal removed the descendant home"
+  [ -f "$subhome/state" ] || fail "state-path refusal changed the non-directory state path"
+  [ -e "$home/state/domain.meta" ] || fail "state-path refusal removed parent metadata"
+  grep -F 'kill-window' "$log" >/dev/null && fail "state-path refusal killed a window"
+  grep -F "$(basename "$subhome")" "$err" >/dev/null || fail "state-path refusal did not name the descendant home: $(cat "$err")"
+  grep -F 'not a directory' "$err" >/dev/null || fail "state-path refusal did not explain the concrete problem: $(cat "$err")"
+  pass "forced teardown refuses a non-directory descendant state path"
+}
+
+test_force_teardown_locks_descendant_with_absent_state() {
+  local home subhome fakebin err log rec claim_root ready release lock pid i=0
+  rec=$(seed_empty_task_set_home taskset-state-absent)
+  IFS='|' read -r home subhome <<EOF
+$rec
+EOF
+  claim_root="$TMP_ROOT/taskset-state-absent-xdg/firstmate/procevent-claims"
+  ready="$TMP_ROOT/taskset-state-absent.ready"
+  release="$TMP_ROOT/taskset-state-absent.release"
+  mkdir -p "$claim_root" "$subhome/bin"
+  printf '%s\n' "$subhome" > "$claim_root/held.claim"
+  cat > "$subhome/bin/fm-procevent.sh" <<'SH'
+#!/usr/bin/env bash
+set -u
+if [ "${1:-}" = sweep-home ] && [ "${2:-}" = --preflight ]; then
+  : > "$FM_TASK_SET_TEST_READY"
+  while [ ! -e "$FM_TASK_SET_TEST_RELEASE" ]; do sleep 0.05; done
+  exit 1
+fi
+exit 1
+SH
+  chmod +x "$subhome/bin/fm-procevent.sh"
+  err="$TMP_ROOT/taskset-state-absent.err"
+  fakebin=$(make_fake_tmux "$TMP_ROOT/taskset-state-absent-fake")
+  log="$TMP_ROOT/taskset-state-absent-fake/tmux.log"
+  PATH="$fakebin:$PATH" FM_HOME="$home" FM_FAKE_TMUX_LOG="$log" \
+    FM_FAKE_TMUX_CAPTURE="$TMP_ROOT/taskset-state-absent-fake/pane.txt" \
+    XDG_STATE_HOME="$TMP_ROOT/taskset-state-absent-xdg" \
+    FM_TASK_SET_TEST_READY="$ready" FM_TASK_SET_TEST_RELEASE="$release" \
+    "$ROOT/bin/fm-teardown.sh" domain --force >/dev/null 2>"$err" &
+  pid=$!
+  while [ ! -e "$ready" ] && kill -0 "$pid" 2>/dev/null && [ "$i" -lt 200 ]; do
+    sleep 0.05
+    i=$((i + 1))
+  done
+  [ -e "$ready" ] || {
+    : > "$release"
+    wait "$pid" 2>/dev/null || true
+    fail "forced teardown did not reach the post-lock preflight: $(cat "$err")"
+  }
+  lock=$( . "$ROOT/bin/fm-wake-lib.sh"; fm_task_set_lock_path "$subhome/state" ) \
+    || fail "could not resolve the established descendant task-set lock"
+  [ -d "$subhome/state" ] || fail "forced teardown did not establish the absent state directory"
+  [ -e "$lock" ] || fail "forced teardown did not own the descendant task-set lock during preflight"
+  kill -0 "$pid" 2>/dev/null || fail "forced teardown exited before task-set ownership was observed"
+  : > "$release"
+  if wait "$pid"; then
+    fail "forced teardown ignored the staged process-event preflight refusal"
+  fi
+  [ -d "$subhome" ] || fail "post-lock refusal removed the descendant home"
+  [ -e "$home/state/domain.meta" ] || fail "post-lock refusal removed parent metadata"
+  [ ! -e "$lock" ] || fail "refused teardown left the descendant task-set lock behind"
+  grep -F 'kill-window' "$log" >/dev/null && fail "post-lock refusal killed a window"
+  pass "forced teardown locks a descendant whose state directory was absent"
 }
 
 test_force_teardown_refuses_while_a_task_is_being_published() {
@@ -2879,11 +2980,13 @@ test_secondmate_teardown_removes_plain_clone_home_without_treehouse_return
 test_secondmate_force_teardown_discards_child_work
 test_secondmate_force_teardown_refuses_child_quarantine_symlink
 test_secondmate_force_teardown_preserves_child_on_unproven_lock
-test_secondmate_force_teardown_allows_operational_dir_symlinks_inside_home
+test_secondmate_force_teardown_allows_non_state_operational_dir_symlinks_inside_home
 test_secondmate_force_teardown_refuses_operational_dir_symlink_outside_home
 test_secondmate_teardown_refuses_registered_nested_home
 test_secondmate_teardown_refuses_child_registry_nested_home
 test_secondmate_force_teardown_prevalidates_before_child_cleanup
+test_force_teardown_refuses_non_directory_descendant_state
+test_force_teardown_locks_descendant_with_absent_state
 test_force_teardown_refuses_while_a_task_is_being_published
 test_fresh_spawn_refuses_while_a_forced_teardown_owns_the_task_set
 test_fresh_remote_secondmate_spawn_refuses_while_task_set_is_owned

--- a/tests/fm-secondmate-safety.test.sh
+++ b/tests/fm-secondmate-safety.test.sh
@@ -2462,6 +2462,32 @@ EOF
   pass "forced teardown refuses a non-directory descendant state path"
 }
 
+test_force_teardown_refuses_symlinked_descendant_state() {
+  local home subhome fakebin err log rec
+  rec=$(seed_empty_task_set_home taskset-state-symlink)
+  IFS='|' read -r home subhome <<EOF
+$rec
+EOF
+  mkdir -p "$subhome/state-target"
+  ln -s state-target "$subhome/state"
+  err="$TMP_ROOT/taskset-state-symlink.err"
+  fakebin=$(make_fake_tmux "$TMP_ROOT/taskset-state-symlink-fake")
+  log="$TMP_ROOT/taskset-state-symlink-fake/tmux.log"
+  if PATH="$fakebin:$PATH" FM_HOME="$home" FM_FAKE_TMUX_LOG="$log" \
+    FM_FAKE_TMUX_CAPTURE="$TMP_ROOT/taskset-state-symlink-fake/pane.txt" \
+    "$ROOT/bin/fm-teardown.sh" domain --force >/dev/null 2>"$err"; then
+    fail "forced teardown accepted a symlinked descendant state path"
+  fi
+  [ -d "$subhome" ] || fail "symlinked state-path refusal removed the descendant home"
+  [ -L "$subhome/state" ] || fail "symlinked state-path refusal changed the state symlink"
+  [ -d "$subhome/state-target" ] || fail "symlinked state-path refusal changed the state target"
+  [ -e "$home/state/domain.meta" ] || fail "symlinked state-path refusal removed parent metadata"
+  grep -F 'kill-window' "$log" >/dev/null && fail "symlinked state-path refusal killed a window"
+  grep -F "$(basename "$subhome")" "$err" >/dev/null || fail "symlinked state-path refusal did not name the descendant home: $(cat "$err")"
+  grep -F 'symbolic-link state path' "$err" >/dev/null || fail "symlinked state-path refusal did not explain the concrete problem: $(cat "$err")"
+  pass "forced teardown refuses a symlinked descendant state path"
+}
+
 test_force_teardown_locks_descendant_with_absent_state() {
   local home subhome fakebin err log rec claim_root ready release lock pid i=0
   rec=$(seed_empty_task_set_home taskset-state-absent)
@@ -2986,6 +3012,7 @@ test_secondmate_teardown_refuses_registered_nested_home
 test_secondmate_teardown_refuses_child_registry_nested_home
 test_secondmate_force_teardown_prevalidates_before_child_cleanup
 test_force_teardown_refuses_non_directory_descendant_state
+test_force_teardown_refuses_symlinked_descendant_state
 test_force_teardown_locks_descendant_with_absent_state
 test_force_teardown_refuses_while_a_task_is_being_published
 test_fresh_spawn_refuses_while_a_forced_teardown_owns_the_task_set

--- a/tests/fm-secondmate-safety.test.sh
+++ b/tests/fm-secondmate-safety.test.sh
@@ -2477,6 +2477,34 @@ EOF
   pass "a fresh spawn refuses to publish while a forced teardown owns the task set"
 }
 
+test_fresh_remote_secondmate_spawn_refuses_while_task_set_is_owned() {
+  local home err held holder lock
+  home="$TMP_ROOT/taskset-remote-spawn-home"
+  err="$TMP_ROOT/taskset-remote-spawn.err"
+  mkdir -p "$home/state" "$home/data"
+  printf '%s\n' '- remote-new - remote domain (host: remote-mac; root: /remote/root; home: /remote/home; scope: remote work; projects: alpha; added 2026-08-02)' \
+    > "$home/data/secondmates.md"
+  held=$(hold_task_set_lock "$home/state") \
+    || fail "could not stage a held remote-spawn task-set lock"
+  holder=${held%% *}
+  lock=${held#* }
+  if FM_HOME="$home" FM_SPAWN_NO_GUARD=1 \
+    "$ROOT/bin/fm-spawn.sh" remote-new --secondmate >/dev/null 2>"$err"; then
+    kill "$holder" 2>/dev/null || true
+    fail "a fresh remote secondmate spawn published while the task set was owned"
+  fi
+  [ ! -e "$home/state/remote-new.meta" ] \
+    || fail "a refused remote secondmate spawn still published a durable record"
+  [ -e "$lock" ] || fail "a refused remote secondmate spawn removed the owner's task-set lock"
+  grep -F "task set is locked" "$err" >/dev/null \
+    || fail "the remote spawn refusal did not name task-set contention: $(cat "$err")"
+  [ ! -e "$home/state/.spawn-remote-new.lock" ] \
+    || fail "a refused remote secondmate spawn left its own task lock behind"
+  kill "$holder" 2>/dev/null || true
+  wait "$holder" 2>/dev/null || true
+  pass "a fresh remote secondmate spawn refuses while the task set is owned"
+}
+
 test_secondmate_force_teardown_refuses_child_active_home_descendant() {
   local home subhome childproj childwt fakebin err log
   home="$TMP_ROOT/child-active-descendant-home"
@@ -2858,6 +2886,7 @@ test_secondmate_teardown_refuses_child_registry_nested_home
 test_secondmate_force_teardown_prevalidates_before_child_cleanup
 test_force_teardown_refuses_while_a_task_is_being_published
 test_fresh_spawn_refuses_while_a_forced_teardown_owns_the_task_set
+test_fresh_remote_secondmate_spawn_refuses_while_task_set_is_owned
 test_secondmate_force_teardown_refuses_child_active_home_descendant
 test_secondmate_force_teardown_refuses_child_repo_descendant
 test_secondmate_force_teardown_refuses_unregistered_child_worktree

--- a/tests/fm-secondmate-safety.test.sh
+++ b/tests/fm-secondmate-safety.test.sh
@@ -2344,6 +2344,139 @@ EOF
   pass "force teardown validates subhome before child cleanup"
 }
 
+# A per-task lock cannot protect a task that does not exist yet. Forced teardown
+# enumerates a home's task set, locks what it found, then re-enumerates while
+# removing - so a fresh spawn publishing inside that window was destructively
+# processed while never lifecycle-locked (reproduced with real agents). The
+# per-home task-set lock serializes the two. Both directions are asserted here,
+# by HOLDING the lock rather than racing on timing, so neither case can go
+# quietly vacuous.
+seed_task_set_lock_home() {  # <tag> -> echoes "<home>|<subhome>"
+  local tag=$1 home subhome childproj childwt
+  home="$TMP_ROOT/$tag-home"
+  subhome="$TMP_ROOT/$tag-subhome"
+  childproj="$subhome/projects/alpha"
+  childwt="$TMP_ROOT/$tag-child-worktree"
+  mkdir -p "$home/state" "$home/data" "$subhome/state" "$subhome/data"
+  # A real worktree pair: child-removal validation runs before the task-set
+  # preflight and refuses a child whose worktree is not a genuine worktree of
+  # its project, which would mask the refusal under test.
+  fm_git_worktree "$childproj" "$childwt" "child-$tag"
+  printf '%s\n' domain > "$subhome/.fm-secondmate-home"
+  cat > "$home/state/domain.meta" <<EOF
+window=firstmate:fm-domain
+worktree=$subhome
+project=$subhome
+harness=echo
+kind=secondmate
+mode=secondmate
+yolo=off
+home=$subhome
+projects=alpha
+EOF
+  printf '%s\n' '- domain - design domain (home: '"$subhome"'; scope: design domain; projects: alpha; added 2026-06-22)' > "$home/data/secondmates.md"
+  cat > "$subhome/state/child.meta" <<EOF
+window=firstmate:fm-child
+worktree=$childwt
+project=$childproj
+harness=echo
+kind=ship
+mode=no-mistakes
+yolo=off
+EOF
+  printf '%s|%s\n' "$home" "$subhome"
+}
+
+# The holder must stay ALIVE: fm_lock_try_acquire reclaims a lock whose owning
+# pid is gone, so a lock taken in a subshell that then exits would be stolen and
+# the contention under test would never happen.
+hold_task_set_lock() {  # <state-dir> -> echoes "<holder-pid> <lock-path>"
+  local state=$1 lock holder i=0
+  lock=$( . "$ROOT/bin/fm-wake-lib.sh"; fm_task_set_lock_path "$state" ) || return 1
+  [ -n "$lock" ] || return 1
+  # stdout/stderr are redirected so the long-lived holder does not inherit this
+  # function's command-substitution pipe; leaving it open would block the caller
+  # until the holder exited, by which point the lock would be stale and the
+  # contention under test could not happen.
+  (
+    # shellcheck source=/dev/null
+    . "$ROOT/bin/fm-wake-lib.sh"
+    fm_lock_try_acquire "$lock" || exit 1
+    sleep 30
+  ) >/dev/null 2>&1 &
+  holder=$!
+  while [ ! -e "$lock" ] && [ "$i" -lt 100 ]; do
+    sleep 0.1
+    i=$((i + 1))
+  done
+  [ -e "$lock" ] || {
+    kill "$holder" 2>/dev/null || true
+    wait "$holder" 2>/dev/null || true
+    return 1
+  }
+  printf '%s %s\n' "$holder" "$lock"
+}
+
+test_force_teardown_refuses_while_a_task_is_being_published() {
+  local home subhome fakebin err log lock rec held holder
+  rec=$(seed_task_set_lock_home taskset-teardown)
+  IFS='|' read -r home subhome <<EOF
+$rec
+EOF
+  err="$TMP_ROOT/taskset-teardown.err"
+  # Stand in for a fresh spawn that is mid-publication in the secondmate's home.
+  held=$(hold_task_set_lock "$subhome/state") \
+    || fail "could not stage a held task-set lock"
+  holder=${held%% *}
+  lock=${held#* }
+  fakebin=$(make_fake_tmux "$TMP_ROOT/taskset-teardown-fake")
+  log="$TMP_ROOT/taskset-teardown-fake/tmux.log"
+  if PATH="$fakebin:$PATH" FM_HOME="$home" FM_FAKE_TMUX_LOG="$log" \
+    FM_FAKE_TMUX_CAPTURE="$TMP_ROOT/taskset-teardown-fake/pane.txt" \
+    "$ROOT/bin/fm-teardown.sh" domain --force >/dev/null 2>"$err"; then
+    fail "forced teardown proceeded while a task was being published"
+  fi
+  [ -d "$subhome" ] || fail "forced teardown removed the home despite refusing"
+  [ -e "$subhome/state/child.meta" ] || fail "forced teardown removed child metadata despite refusing"
+  [ -e "$home/state/domain.meta" ] || fail "forced teardown cleared parent metadata despite refusing"
+  grep -F 'kill-window' "$log" >/dev/null && fail "forced teardown killed a window despite refusing"
+  [ -e "$lock" ] || fail "forced teardown removed the publisher's task-set lock"
+  grep -F 'task-set lock is held' "$err" >/dev/null \
+    || fail "the refusal did not name the task-set contention: $(cat "$err")"
+  kill "$holder" 2>/dev/null || true
+  wait "$holder" 2>/dev/null || true
+  pass "forced teardown refuses while a fresh task is being published in the home"
+}
+
+test_fresh_spawn_refuses_while_a_forced_teardown_owns_the_task_set() {
+  local home subhome err rec held holder lock
+  rec=$(seed_task_set_lock_home taskset-spawn)
+  IFS='|' read -r home subhome <<EOF
+$rec
+EOF
+  err="$TMP_ROOT/taskset-spawn.err"
+  # Stand in for a forced teardown that already enumerated this home's task set.
+  held=$(hold_task_set_lock "$subhome/state") \
+    || fail "could not stage a held task-set lock"
+  holder=${held%% *}
+  lock=${held#* }
+  if FM_HOME="$subhome" FM_SPAWN_NO_GUARD=1 \
+    "$ROOT/bin/fm-spawn.sh" newtask "$subhome/projects/alpha" --scout >/dev/null 2>"$err"; then
+    kill "$holder" 2>/dev/null || true
+    fail "a fresh spawn published a task while a forced teardown owned the set"
+  fi
+  [ ! -e "$subhome/state/newtask.meta" ] \
+    || fail "a refused spawn still published a durable record"
+  [ -e "$lock" ] || fail "a refused spawn removed the teardown's task-set lock"
+  grep -F "task set is locked" "$err" >/dev/null \
+    || fail "the spawn refusal did not name the task-set contention: $(cat "$err")"
+  [ ! -e "$subhome/state/.spawn-newtask.lock" ] \
+    || fail "a refused spawn left its own task lock behind"
+  kill "$holder" 2>/dev/null || true
+  wait "$holder" 2>/dev/null || true
+  pass "a fresh spawn refuses to publish while a forced teardown owns the task set"
+}
+
 test_secondmate_force_teardown_refuses_child_active_home_descendant() {
   local home subhome childproj childwt fakebin err log
   home="$TMP_ROOT/child-active-descendant-home"
@@ -2723,6 +2856,8 @@ test_secondmate_force_teardown_refuses_operational_dir_symlink_outside_home
 test_secondmate_teardown_refuses_registered_nested_home
 test_secondmate_teardown_refuses_child_registry_nested_home
 test_secondmate_force_teardown_prevalidates_before_child_cleanup
+test_force_teardown_refuses_while_a_task_is_being_published
+test_fresh_spawn_refuses_while_a_forced_teardown_owns_the_task_set
 test_secondmate_force_teardown_refuses_child_active_home_descendant
 test_secondmate_force_teardown_refuses_child_repo_descendant
 test_secondmate_force_teardown_refuses_unregistered_child_worktree

--- a/tests/fm-send-settle.test.sh
+++ b/tests/fm-send-settle.test.sh
@@ -118,8 +118,8 @@ test_key_path_never_pauses() {
   pass "fm-send: the --key path never pauses (settle scoped to text submit)"
 }
 
-test_claude_escape_preserves_adapter_busy_state() {
-  local dir fb log rc home gen before after
+test_claude_escape_records_interrupt_idle() {
+  local dir fb log rc home gen out
   dir="$TMP_ROOT/claude-interrupt"; mkdir -p "$dir"
   fb=$(make_stubs "$dir"); log="$dir/sleep.log"
   home="$dir/home"; mkdir -p "$home/state"
@@ -129,19 +129,18 @@ test_claude_escape_preserves_adapter_busy_state() {
   gen=$("$ROOT/bin/fm-busy-event.sh" arm "$home/state" task)
   printf 'busy_gen=%s\n' "$gen" >> "$home/state/task.meta"
   : > "$log"
-  before=$(cat "$home/state/task.busy-state")
 
   env PATH="$fb:$PATH" FM_HOME="$home" FM_SLEEP_LOG="$log" \
     "$SEND" task --key Escape 2>/dev/null; rc=$?
   expect_code 0 "$rc" "Claude Escape send should succeed"
-  after=$(cat "$home/state/task.busy-state")
-  [ "$after" = "$before" ] \
-    || fail "Claude Escape must preserve the last adapter-owned busy state"
-  pass "fm-send: Claude Escape preserves adapter-owned busy state"
+  out=$(fm_busy_classify tmux sess:win claude task "$home/state")
+  [ "$out" = "idle fm-interrupt" ] \
+    || fail "Claude Escape must classify idle/fm-interrupt, got '$out'"
+  pass "fm-send: a successful Claude Escape records the interrupt lifecycle edge"
 }
 
 test_default_send_pauses_one_second
 test_zero_disables_pause
 test_pause_is_tunable
 test_key_path_never_pauses
-test_claude_escape_preserves_adapter_busy_state
+test_claude_escape_records_interrupt_idle

--- a/tests/fm-send-settle.test.sh
+++ b/tests/fm-send-settle.test.sh
@@ -118,8 +118,8 @@ test_key_path_never_pauses() {
   pass "fm-send: the --key path never pauses (settle scoped to text submit)"
 }
 
-test_claude_escape_records_interrupt_idle() {
-  local dir fb log rc home gen out
+test_claude_escape_preserves_adapter_busy_state() {
+  local dir fb log rc home gen before after
   dir="$TMP_ROOT/claude-interrupt"; mkdir -p "$dir"
   fb=$(make_stubs "$dir"); log="$dir/sleep.log"
   home="$dir/home"; mkdir -p "$home/state"
@@ -129,18 +129,19 @@ test_claude_escape_records_interrupt_idle() {
   gen=$("$ROOT/bin/fm-busy-event.sh" arm "$home/state" task)
   printf 'busy_gen=%s\n' "$gen" >> "$home/state/task.meta"
   : > "$log"
+  before=$(cat "$home/state/task.busy-state")
 
   env PATH="$fb:$PATH" FM_HOME="$home" FM_SLEEP_LOG="$log" \
     "$SEND" task --key Escape 2>/dev/null; rc=$?
   expect_code 0 "$rc" "Claude Escape send should succeed"
-  out=$(fm_busy_classify tmux sess:win claude task "$home/state")
-  [ "$out" = "idle fm-interrupt" ] \
-    || fail "Claude Escape must classify idle/fm-interrupt, got '$out'"
-  pass "fm-send: a successful Claude Escape records the interrupt lifecycle edge"
+  after=$(cat "$home/state/task.busy-state")
+  [ "$after" = "$before" ] \
+    || fail "Claude Escape must preserve the last adapter-owned busy state"
+  pass "fm-send: Claude Escape preserves adapter-owned busy state"
 }
 
 test_default_send_pauses_one_second
 test_zero_disables_pause
 test_pause_is_tunable
 test_key_path_never_pauses
-test_claude_escape_records_interrupt_idle
+test_claude_escape_preserves_adapter_busy_state

--- a/tests/fm-teardown-endpoint-safety.test.sh
+++ b/tests/fm-teardown-endpoint-safety.test.sh
@@ -93,6 +93,103 @@ test_invalid_endpoint_records_refuse_before_mutation() {
   pass "fm-teardown: missing, empty, malformed, ambiguous, and task-mismatched endpoints refuse before every mutation or runtime call"
 }
 
+test_control_lock_contention_refuses_before_mutation() {
+  local dir id=locked-task lock holder i=0 rc
+  dir=$(make_case control-lock)
+  fm_write_meta "$dir/home/state/$id.meta" \
+    "window=isolated:fm-$id" "endpoint_task_id=$id" \
+    "worktree=$dir/worktree" "project=$dir/project" "kind=scout"
+  lock="$dir/home/state/.control-$id.lock"
+  (
+    # shellcheck source=/dev/null
+    . "$ROOT/bin/fm-wake-lib.sh"
+    fm_lock_try_acquire "$lock" || exit 1
+    sleep 30
+  ) &
+  holder=$!
+  while [ ! -e "$lock" ] && [ "$i" -lt 100 ]; do
+    sleep 0.1
+    i=$((i + 1))
+  done
+  [ -e "$lock" ] || {
+    kill "$holder" 2>/dev/null || true
+    wait "$holder" 2>/dev/null || true
+    fail "could not stage a held lifecycle lock"
+  }
+  fm_write_meta "$dir/home/state/$id.meta" \
+    "window=isolated:fm-$id" "endpoint_task_id=other-task" \
+    "worktree=$dir/worktree" "project=$dir/project" "kind=scout"
+
+  set +e
+  run_case "$dir" "$id" > "$dir/stdout" 2> "$dir/stderr"
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "teardown unexpectedly succeeded under lifecycle lock contention"
+  assert_present "$dir/home/state/$id.meta" "contended teardown removed task metadata"
+  assert_present "$dir/worktree/sentinel" "contended teardown changed the worktree"
+  assert_present "$lock" "contended teardown removed another action's lock"
+  [ ! -s "$dir/runtime.log" ] \
+    || fail "contended teardown reached the runtime: $(cat "$dir/runtime.log")"
+  assert_contains "$(cat "$dir/stderr")" "another lifecycle action is already running" \
+    "contended teardown should serialize before reading mutable task metadata"
+  kill "$holder" 2>/dev/null || true
+  wait "$holder" 2>/dev/null || true
+  pass "fm-teardown: a concurrent lifecycle action refuses before mutation"
+}
+
+test_metadata_lock_serializes_destructive_cleanup() {
+  local dir id=metadata-locked-task lock ready release holder teardown_pid i=0 rc
+  dir=$(make_case metadata-lock)
+  fm_write_meta "$dir/home/state/$id.meta" \
+    "window=isolated:fm-$id" "endpoint_task_id=$id" \
+    "worktree=$dir/worktree" "project=$dir/project" "kind=scout"
+  lock="$dir/home/state/.meta-$id.lock"
+  ready="$dir/meta-lock-ready"
+  release="$dir/meta-lock-release"
+  (
+    # shellcheck source=/dev/null
+    . "$ROOT/bin/fm-wake-lib.sh"
+    fm_lock_try_acquire "$lock" || exit 1
+    trap 'fm_lock_release "$lock"' EXIT
+    : > "$ready"
+    while [ ! -e "$release" ]; do
+      sleep 0.01
+    done
+  ) &
+  holder=$!
+  while [ ! -e "$ready" ] && [ "$i" -lt 100 ]; do
+    sleep 0.1
+    i=$((i + 1))
+  done
+  [ -e "$ready" ] || {
+    kill "$holder" 2>/dev/null || true
+    wait "$holder" 2>/dev/null || true
+    fail "could not stage a held metadata lock"
+  }
+
+  run_case "$dir" "$id" > "$dir/stdout" 2> "$dir/stderr" &
+  teardown_pid=$!
+  sleep 0.2
+  if ! kill -0 "$teardown_pid" 2>/dev/null; then
+    : > "$release"
+    wait "$holder" 2>/dev/null || true
+    wait "$teardown_pid" 2>/dev/null || true
+    fail "teardown did not wait for the shared metadata writer lock"
+  fi
+  assert_present "$dir/home/state/$id.meta" "metadata-lock contention removed task metadata"
+  assert_present "$dir/worktree/sentinel" "metadata-lock contention changed the worktree"
+  [ ! -s "$dir/runtime.log" ] \
+    || fail "metadata-lock contention reached the runtime: $(cat "$dir/runtime.log")"
+
+  : > "$release"
+  wait "$holder" || fail "metadata lock holder failed"
+  wait "$teardown_pid"; rc=$?
+  expect_code 0 "$rc" "teardown should complete after the metadata writer releases"
+  assert_absent "$dir/home/state/$id.meta" \
+    "serialized teardown left a task record that a completed writer could resurrect"
+  pass "fm-teardown: destructive cleanup serializes with metadata writers"
+}
+
 test_supported_backend_endpoint_records_validate() {
   local dir id backend target
   dir=$(make_case valid-backends)
@@ -269,6 +366,8 @@ SH
 }
 
 test_invalid_endpoint_records_refuse_before_mutation
+test_control_lock_contention_refuses_before_mutation
+test_metadata_lock_serializes_destructive_cleanup
 test_supported_backend_endpoint_records_validate
 test_tmux_empty_target_refuses_without_invocation
 test_recorded_process_identity_cleanup_is_exact

--- a/tests/fm-teardown.test.sh
+++ b/tests/fm-teardown.test.sh
@@ -1667,6 +1667,99 @@ SH
   pass "forced secondmate teardown preflights every Herdr child before cleanup mutation"
 }
 
+configure_secondmate_with_tmux_children() {  # <case-dir>
+  local case_dir=$1 home="$1/secondmate-home" child child_wt
+  mkdir -p "$home/state" "$home/data" "$home/config" "$home/projects"
+  printf '%s\n' task-x1 > "$home/.fm-secondmate-home"
+  printf '%s\n' "home=$home" >> "$case_dir/state/task-x1.meta"
+  for child in child-a child-b; do
+    child_wt="$case_dir/$child-wt"
+    git -C "$case_dir/project" worktree add -q -b "fm/$child" "$child_wt" main
+    fm_write_meta "$home/state/$child.meta" \
+      "window=firstmate:fm-$child" \
+      "endpoint_task_id=$child" \
+      "worktree=$child_wt" \
+      "project=$case_dir/project" \
+      "kind=ship" \
+      "mode=local-only"
+    : > "$home/state/$child.status"
+  done
+}
+
+test_forced_secondmate_teardown_holds_descendant_lifecycle_locks() {
+  local case_dir home lock ready release holder_pid rc waited=0 child
+  case_dir=$(make_case descendant-locks)
+  write_meta "$case_dir" local-only secondmate
+  configure_secondmate_with_tmux_children "$case_dir"
+  home="$case_dir/secondmate-home"
+  : > "$case_dir/kill.log"
+  : > "$case_dir/treehouse.log"
+  cat > "$case_dir/fakebin/tmux" <<SH
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> "$case_dir/kill.log"
+exit 0
+SH
+  cat > "$case_dir/fakebin/treehouse" <<SH
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> "$case_dir/treehouse.log"
+exit 0
+SH
+  chmod +x "$case_dir/fakebin/tmux" "$case_dir/fakebin/treehouse"
+
+  lock="$home/state/.control-child-b.lock"
+  ready="$case_dir/lock-ready"
+  release="$case_dir/lock-release"
+  ROOT="$ROOT" LOCK="$lock" READY="$ready" RELEASE="$release" \
+    HOME_STATE="$home/state" OWNER_PID="$$" bash -c '
+    export FM_STATE_OVERRIDE="$HOME_STATE"
+    . "$ROOT/bin/fm-wake-lib.sh"
+    fm_lock_try_acquire "$LOCK" || exit 1
+    : > "$READY"
+    while [ ! -e "$RELEASE" ] && kill -0 "$OWNER_PID" 2>/dev/null; do sleep 0.1; done
+    fm_lock_release "$LOCK"
+  ' &
+  holder_pid=$!
+  while [ ! -e "$ready" ] && [ "$waited" -lt 50 ]; do
+    sleep 0.1
+    waited=$((waited + 1))
+  done
+  [ -e "$ready" ] || fail "descendant-locks: the contending lifecycle action never acquired its lock"
+
+  rc=0
+  run_teardown "$case_dir" --force > "$case_dir/stdout" 2> "$case_dir/stderr" || rc=$?
+  if [ "$rc" -eq 0 ]; then
+    : > "$release"
+    wait "$holder_pid" 2>/dev/null || true
+    fail "descendant-locks: forced teardown ignored a descendant lifecycle lock"
+  fi
+  assert_grep "descendant task child-b has a lifecycle action in flight" "$case_dir/stderr" \
+    "descendant-locks: refusal did not name the contended descendant"
+  [ ! -e "$home/state/.control-child-a.lock" ] \
+    && [ ! -e "$home/state/.meta-child-a.lock" ] \
+    || { : > "$release"; wait "$holder_pid" 2>/dev/null || true; fail "descendant-locks: refusal leaked earlier descendant locks"; }
+  [ ! -s "$case_dir/kill.log" ] \
+    || { : > "$release"; wait "$holder_pid" 2>/dev/null || true; fail "descendant-locks: refusal killed an endpoint"; }
+  [ ! -s "$case_dir/treehouse.log" ] \
+    || { : > "$release"; wait "$holder_pid" 2>/dev/null || true; fail "descendant-locks: refusal returned a worktree"; }
+  [ -e "$case_dir/state/task-x1.meta" ] && [ -d "$home" ] \
+    || { : > "$release"; wait "$holder_pid" 2>/dev/null || true; fail "descendant-locks: refusal removed parent state"; }
+  for child in child-a child-b; do
+    [ -e "$home/state/$child.meta" ] && [ -d "$case_dir/$child-wt" ] \
+      || { : > "$release"; wait "$holder_pid" 2>/dev/null || true; fail "descendant-locks: refusal removed $child state or worktree"; }
+  done
+
+  : > "$release"
+  wait "$holder_pid" 2>/dev/null || true
+  rc=0
+  run_teardown "$case_dir" --force > "$case_dir/retry.stdout" 2> "$case_dir/retry.stderr" || rc=$?
+  expect_code 0 "$rc" "descendant-locks: uncontended retry should complete"
+  [ ! -e "$case_dir/state/task-x1.meta" ] && [ ! -d "$home" ] \
+    || fail "descendant-locks: uncontended retry retained retired task state"
+  [ -s "$case_dir/kill.log" ] && [ -s "$case_dir/treehouse.log" ] \
+    || fail "descendant-locks: uncontended retry did not perform endpoint and worktree cleanup"
+  pass "forced secondmate teardown holds every descendant lifecycle and metadata lock"
+}
+
 test_forced_secondmate_herdr_child_retains_records_when_close_unconfirmed() {
   local case_dir home log closed rc
   case_dir=$(make_case herdr-child-unconfirmed-close)
@@ -2512,6 +2605,7 @@ test_herdr_flat_teardown_refuses_orphaning_records_then_retry_completes
 test_herdr_flat_teardown_refuses_records_on_unparseable_presence
 test_herdr_flat_teardown_preflight_refuses_before_changes
 test_forced_secondmate_herdr_child_preflight_refuses_before_changes
+test_forced_secondmate_teardown_holds_descendant_lifecycle_locks
 test_forced_secondmate_herdr_child_retains_records_when_close_unconfirmed
 test_forced_teardown_retains_nested_secondmate_home_when_grandchild_close_unconfirmed
 test_herdr_projection_teardown_retires_journal_only_after_confirmed_close

--- a/tests/fm-trace-context-lib.test.sh
+++ b/tests/fm-trace-context-lib.test.sh
@@ -240,35 +240,6 @@ for tok in brief prompt report status ; do
 done
 pass "the lib code never reads a brief, prompt, report, or status - it cannot leak content"
 
-# --- structural wiring in bin/fm-spawn.sh ------------------------------------
-
-SPAWN="$ROOT/bin/fm-spawn.sh"
-# Patterns deliberately start after any leading '$' so the fixed-string grep needs
-# no shell metacharacters while still pinning the exact wiring.
-assert_grep 'fm-trace-context-lib.sh' "$SPAWN" "fm-spawn.sh must source the trace-context lib"
-assert_grep 'SPAWN_TRACEPARENT=' "$SPAWN" "fm-spawn.sh must assign the resolved carrier"
-assert_grep 'fm_trace_context_resolve' "$SPAWN" "fm-spawn.sh must resolve the carrier through the lib entry point"
-# shellcheck disable=SC2016 # Dollar signs are literal source text in this fixed-string assertion.
-assert_grep 'if spawn_send_text_line "$T" "export TRACEPARENT=$SPAWN_TRACEPARENT"; then' "$SPAWN" \
-  "fm-spawn.sh must condition metadata publication on successful carrier delivery"
-# shellcheck disable=SC2016 # Dollar signs are literal source text in this fixed-string assertion.
-assert_grep 'echo "traceparent=$SPAWN_TRACEPARENT" >> "$STATE/$ID.meta"' "$SPAWN" \
-  "fm-spawn.sh must record the delivered carrier in metadata"
-assert_grep 'export TRACEPARENT=' "$SPAWN" "fm-spawn.sh must inject the W3C TRACEPARENT env var"
-pass "fm-spawn.sh sources the lib and records one shared SPAWN_TRACEPARENT only after successful injection"
-
-# The injection must ride the same channel and site as GOTMPDIR (before launch,
-# unconditional across kinds): the TRACEPARENT export follows the GOTMPDIR export.
-gotmp_line=$(grep -n 'export GOTMPDIR=' "$SPAWN" | tail -1 | cut -d: -f1)
-tp_line=$(grep -n 'export TRACEPARENT=' "$SPAWN" | tail -1 | cut -d: -f1)
-# shellcheck disable=SC2016 # Dollar signs are literal source text in this grep pattern.
-meta_line=$(grep -n 'echo "traceparent=$SPAWN_TRACEPARENT" >>' "$SPAWN" | tail -1 | cut -d: -f1)
-[ -n "$gotmp_line" ] && [ -n "$tp_line" ] && [ -n "$meta_line" ] \
-  && [ "$tp_line" -gt "$gotmp_line" ] && [ "$((tp_line - gotmp_line))" -le 5 ] \
-  && [ "$meta_line" -gt "$tp_line" ] \
-  || fail "TRACEPARENT must be exported before metadata publication at the pre-launch GOTMPDIR site (gotmp=$gotmp_line tp=$tp_line meta=$meta_line)"
-pass "TRACEPARENT is injected at the unconditional pre-launch GOTMPDIR site and recorded only after successful delivery"
-
 # --- secondmate inheritance wires the nested chain ---------------------------
 
 # shellcheck source=/dev/null


### PR DESCRIPTION
## Intent

Fix the CONFIRMED, reproduced spawn/teardown race on PR #1568's branch. This is a scoped addition to an otherwise complete and previously green PR - add ONLY this fix.

THE DEFECT (reproduced with real agents, not theoretical):
Forced secondmate teardown enumerates a home's task set, acquires per-task control and metadata locks for exactly that snapshot, and then RE-ENUMERATES the same directory while removing. A fresh (non-relaunch) fm-spawn takes only its own per-task .spawn-<id>.lock, so a task id that did not exist at snapshot time is invisible to the preflight but visible to the cleanup. Measured: a record published 0.249s after teardown began was destructively processed - metadata removed, tmux window closed, worktree returned to the pool - while BOTH commands reported success and nothing refused. A per-task lock cannot protect a task that does not exist yet.

THE FIX (exactly the mechanism the reproduction report prescribes, nothing more):
Serialize fresh task publication and forced teardown through a shared per-home TASK-SET lock, held from enumeration through cleanup.
- New fm_task_set_lock_path in bin/fm-wake-lib.sh: <home>/state/.task-set.lock, guarding WHICH tasks a home has, as opposed to fm_meta_lock_path which guards one task's record. One owner for the path and the rationale.
- bin/fm-teardown.sh acquires it per home inside collect_descendant_task_locks, BEFORE enumerating that home, parent home before child home, and holds it through cleanup_firstmate_home_children via the existing descendant lock-release path. Refuses the whole forced teardown on contention, changing nothing.
- bin/fm-spawn.sh acquires the same lock on the FRESH path only, before its own per-task locks, and releases it after publication. A relaunch is exempt because it republishes a task that already exists and is therefore already covered by that task's control lock, which the teardown preflight tests. The spawn REFUSES rather than waits, because the home may be moments from removal.

Either the spawn publishes first and the teardown's preflight covers it, or the teardown owns the set and the spawn refuses. Both directions fail closed.

ACQUISITION ORDER (stated in bin/fm-teardown.sh so it cannot drift): each home's task-set lock first, parent home before child home; then per-task locks in that same preorder, sorted by id within a home, each control lock before its matching metadata lock. No child lock holder reaches back for a parent lock, so acquisition cannot cycle. bin/fm-spawn.sh follows the same order.

TESTS: two behavioral tests in tests/fm-secondmate-safety.test.sh pin both directions by HOLDING the lock with a live process rather than racing on timing, so neither can go quietly vacuous: a forced teardown refuses while a task is being published (naming the contention, removing nothing, killing no window), and a fresh spawn refuses to publish while a forced teardown owns the set (publishing no record and leaving no lock behind).

SCOPE LIMITS - this PR is otherwise finished and was already green; do NOT expand:
- Do NOT change bin/fm-send.sh's --key interrupt behavior; that divergence is separately filed as fm-send-key-interrupt-postcondition-r1.
- Do NOT rewrite bin/fm-busy-lib.sh or bin/fm-busy-event.sh to force the control-plane interrupt contract onto fm-send.
- Do NOT add a `clear` verb or expand the control-plane verb allowlist.
- Do NOT add durable launch-specification state for prefixed raw-command harnesses.
- Do NOT extend this serialization to the NON-forced teardown path, which refuses on any existing child and is already fail-closed.
- Keep every fix from the earlier rounds of this branch intact: prefixed-harness family resolution across the lifecycle verbs, the captain's interrupt contract (delivery proven, cancellation unconfirmed, busy never force-cleared), the honest failed-exit message, the pre-stop kind-capability and ambiguous-relaunch refusals, and the descendant lifecycle-lock preflight.

REQUIREMENTS: bin/fm-lint.sh clean; behavioral tests through the executable interface, never asserting implementation source text; deterministic and idempotent enforcement; one-owner rule for the lock path and its rationale; one sentence per line in tracked Markdown; plain dash; genuine full-matrix green CI. This is firstmate's shared tracked supervision-adjacent infrastructure, so hold the highest bar.

## What Changed

- Add exact-task `interrupt`, `exit`, and transactional `relaunch` lifecycle commands with verified harness and backend capabilities.
- Serialize fresh task publication and forced recursive teardown with per-home task-set locks, alongside descendant lifecycle-lock preflight.
- Document the control plane and add behavioral coverage for control, relaunch, Herdr, and secondmate teardown safety.

## Risk Assessment

🚨 High: The confirmed destructive spawn/teardown race remains reachable when cleanup deletes the directory containing the newly introduced lock.

## Testing

After correcting an initial test-selection harness issue, focused executable-interface tests and two end-to-end contention checks confirmed both race directions fail closed, preserve existing state, avoid window teardown or task publication, and leave no unintended lock residue; reviewer-visible CLI/state evidence was captured and the worktree remained clean.

<details>
<summary>Evidence: End-to-end task-set lock contention transcript for forced teardown and fresh spawn</summary>

```text
=== Direction 1: publisher owns task-set lock; forced teardown ===
$ FM_HOME=<parent> fm-teardown.sh domain --force
exit=1
●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
●  WATCHER DOWN - SUPERVISION IS OFF
●  1 task(s) in flight, but no watcher has a fresh beacon (last beat: never, grace 300s).
●  Trust the emitted supervision protocol for this harness; do not use shell & for watcher repair.
●  This is a supervision warning only; the guarded operation WILL still run.
●  repair a missing or failed watcher cycle with the Pi tool fm_watch_arm_pi, or restart Pi with -e /Users/kunchen/.no-mistakes/worktrees/016d88035d58/01KZHR9GCYD6J6QBH838MKX9TY/.pi/extensions/fm-primary-turnend-guard.ts -e /Users/kunchen/.no-mistakes/worktrees/016d88035d58/01KZHR9GCYD6J6QBH838MKX9TY/.pi/extensions/fm-primary-pi-watch.ts if the extensions are not loaded.
●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
REFUSED: secondmate home /var/folders/0k/bf8mwt2n5qddzk24r20gfk0c0000gn/T//fm-secondmate-safety.oJDUG2/evidence-teardown-subhome is publishing a task right now (task-set lock is held); forced teardown changed nothing
child_home_exists=yes
child_metadata_exists=yes
parent_metadata_exists=yes
tmux_kill_window_calls=0
publisher_lock_still_owned=yes

=== Direction 2: teardown owns task-set lock; fresh spawn ===
$ FM_HOME=<child> fm-spawn.sh newtask <project> --scout
exit=1
error: this home's task set is locked by another operation (a forced teardown is enumerating or removing its tasks); refusing to create task newtask rather than racing it
new_task_metadata_exists=no
spawn_task_lock_left_behind=no
teardown_lock_still_owned=yes
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"24253994535d4604be74144ec2c1f59319118437","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 error</summary>

- 🚨 `bin/fm-spawn.sh:909` - The required criterion says “bin/fm-spawn.sh acquires the same lock on the FRESH path only, before its own per-task locks,” but the added lock hunk is reached only after `spawn_remote_secondmate` at line 619. A fresh remote-secondmate spawn acquires `.spawn-&lt;id&gt;.lock`, publishes `&lt;id&gt;.meta`, and exits without the task-set lock, so forced teardown can still snapshot first and then remove that newly published record/home while both operations succeed. Move task-set serialization to the earliest shared fresh-spawn boundary, including the remote publication path.

🔧 Fix: Serialize remote secondmate publication with forced teardown
2 errors still open:
- 🚨 `bin/fm-spawn.sh:930` - Moving remote-secondmate dispatch below ordinary backend selection makes remote spawns inherit parent backend failures. For example, with FM_BACKEND/config backend set to orca or cmux, lines 643-651 reject --secondmate before spawn_remote_secondmate runs, although that path explicitly hardcodes Herdr and previously ignored ambient backend selection. Dispatch remote secondmates after acquiring the task-set lock but before ordinary backend resolution; resolve the ordinary backend only after return code 3 selects the local path.
- 🚨 `bin/fm-spawn.sh:924` - A remote secondmate spawn no longer supports a missing parent state directory. The task-set acquisition requires $STATE to exist because fm_lock_abs_path must cd into it, but the existing mkdir -p &#34;$STATE&#34; is now inside spawn_remote_secondmate and therefore unreachable. Such a spawn falsely reports task-set contention and publishes nothing. Establish the state directory before acquiring the shared lock, retaining the function&#39;s fail-closed error handling.

🔧 Fix: Preserve remote spawn routing and state initialization
1 error still open:
- 🚨 `bin/fm-teardown.sh:1893` - The required per-home serialization is skipped when `&lt;home&gt;/state` is absent. That state is accepted by teardown validation, while a supported concurrent fresh spawn creates the directory, acquires its new lock, and publishes after this early return; forced cleanup can therefore remove the newly published task/home without ever owning the same task-set lock. This leaves the confirmed race reachable. Refuse forced teardown when a descendant home&#39;s state directory is absent, or otherwise establish a stable state-directory boundary before enumeration without violating the requirement that a refusal changes nothing.

🔧 Fix: Serialize teardown when descendant state is absent
1 error still open:
- 🚨 `tests/fm-secondmate-safety.test.sh:2447` - This test does not exercise the new fail-closed branch in collect_descendant_task_locks as required. Because the regular file exists before teardown starts, validate_firstmate_home_children_removal at bin/fm-teardown.sh:2281 rejects it first via operational-directory validation; deleting lines 1897-1899 would still leave this test passing. Add an executable-interface case that reaches collection, such as an in-home state-directory symlink that passes the earlier containment validation but must be refused by the new -L check.

🔧 Fix: Cover symlinked descendant state refusal
1 error still open:
- 🚨 `bin/fm-teardown.sh:1923` - The task-set lock is stored inside the home that forced cleanup later deletes (lines 2220 and 2523). Once `rm -rf` or `treehouse return` unlinks `&lt;home&gt;/state/.task-set.lock`, a concurrent fresh spawn can recreate `state`, acquire the same textual lock path, and publish while teardown still owns its now-unreachable lock; cleanup can then delete that new record or leave an orphaned task. This violates the required invariant that teardown holds serialization through cleanup. Establish retirement/exclusion at a stable shared boundary that home removal cannot unlink, and make fresh spawn validate it before creating state or publishing.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>Inspected the target diff and task-set lock implementation paths in `bin/fm-wake-lib.sh`, `bin/fm-spawn.sh`, and `bin/fm-teardown.sh`.</code>
- <code>Ran focused functions from `tests/fm-secondmate-safety.test.sh`: `test_force_teardown_refuses_non_directory_descendant_state`, `test_force_teardown_refuses_symlinked_descendant_state`, `test_force_teardown_locks_descendant_with_absent_state`, `test_force_teardown_refuses_while_a_task_is_being_published`, `test_fresh_spawn_refuses_while_a_forced_teardown_owns_the_task_set`, and `test_fresh_remote_secondmate_spawn_refuses_while_task_set_is_owned`.</code>
- <code>Manually held the live per-home task-set lock and invoked `fm-teardown.sh domain --force`, verifying refusal, preserved metadata/home, zero tmux window kills, and preserved owner lock.</code>
- <code>Manually held the live per-home task-set lock and invoked `fm-spawn.sh newtask &lt;project&gt; --scout`, verifying refusal, no metadata publication, no per-task lock residue, and preserved owner lock.</code>
- <code>Checked `git status --short` after testing to confirm no transient working-tree artifacts remained.</code>

</details>

<details>
<summary>⚠️ **Document** - 1 error</summary>

- 🚨 `tests/fm-secondmate-safety.test.sh:2535` - bin/fm-lint.sh fails with SC2031 at lines 2535, 2537, and 2541; executable test changes are outside this documentation phase.

</details>

<details>
<summary>🔧 **Lint** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ linter found issues (exit code 1)

🔧 Fix: Isolate task-set lock path resolution
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
