### PR TITLE
docs: scope ambiguous multi-session planning to existing owners

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -246,6 +246,8 @@ Send in-scope work to the fitting secondmate unless it is blocked or the captain
 If no secondmate scope fits, use the main home or discuss creating an appropriate persistent secondmate.
 For one-off or infrequent operational work, start with the simplest direct end-to-end path.
 Do not build wrappers, control planes, policy layers, custom verifiers, or automation unless the direct path exposes a concrete blocker or repeated need that justifies the added machinery.
+When the global ambiguous multi-session planning rule applies, create backlog work only for decisions that can be stated precisely now; keep the rest in the scout report or parent backlog body as `Not yet specified` until prerequisite decisions resolve.
+Use only the existing backlog, scout, dependency, and decision-hold owners; do not create a parallel map or ticket lifecycle, and planning completion never authorizes a Ship.
 
 Before commissioning an investigation, consult existing reports and established evidence.
 Classify the deliverable:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -246,7 +246,8 @@ Send in-scope work to the fitting secondmate unless it is blocked or the captain
 If no secondmate scope fits, use the main home or discuss creating an appropriate persistent secondmate.
 For one-off or infrequent operational work, start with the simplest direct end-to-end path.
 Do not build wrappers, control planes, policy layers, custom verifiers, or automation unless the direct path exposes a concrete blocker or repeated need that justifies the added machinery.
-When the global ambiguous multi-session planning rule applies, create backlog work only for decisions that can be stated precisely now; keep the rest in the scout report or parent backlog body as `Not yet specified` until prerequisite decisions resolve.
+When planning work that is both ambiguous and likely to span multiple sessions, create backlog work only for decisions that can be stated precisely now; keep the rest in the scout report or parent backlog body as `Not yet specified` until prerequisite decisions resolve.
+`Not yet specified` covers only downstream scope that is not yet a captain choice; an unresolved captain decision still registers as a hold under `decision-hold-lifecycle`, which keeps precedence.
 Use only the existing backlog, scout, dependency, and decision-hold owners; do not create a parallel map or ticket lifecycle, and planning completion never authorizes a Ship.
 
 Before commissioning an investigation, consult existing reports and established evidence.


### PR DESCRIPTION
## Intent

Add the approved narrow Wayfinder-derived ambiguity heuristic to both ordinary Claude/Pi mode and Firstmate without installing Wayfinder or introducing a new map, tracker taxonomy, or lifecycle. This Firstmate repository change must specialize the shared rule through the existing scout, backlog, dependency, and decision-hold owners: create backlog work only for decisions precise enough to state now, keep remaining uncertainty as Not yet specified until prerequisites resolve, and ensure planning completion never authorizes a Ship. Keep the change concise and documentation-only.

## What Changed

- Added a planning rule to `AGENTS.md`: when work is both ambiguous and likely to span multiple sessions, create backlog work only for decisions that can be stated precisely now, and keep the rest in the scout report or parent backlog body as `Not yet specified` until prerequisite decisions resolve.
- Clarified precedence so `Not yet specified` covers only downstream scope that is not yet a captain choice — an unresolved captain decision still registers as a hold under `decision-hold-lifecycle`.
- Constrained the rule to the existing backlog, scout, dependency, and decision-hold owners: no parallel map or ticket lifecycle, and planning completion never authorizes a Ship.

## Risk Assessment

✅ Low: A three-line documentation-only addition to AGENTS.md that reuses existing owners and explicitly defers to decision-hold-lifecycle precedence, satisfying every stated intent constraint with no code or behavior surface touched.

## Testing

I treated the agent-loaded AGENTS.md/CLAUDE.md text as the end-user surface and captured it as a rendered transcript, showing the new planning rule sitting inside the existing Intake and authority section rather than in any new structure; alongside that I verified the four cited owners (backlog, scout, dependency, decision-hold-lifecycle) all pre-exist, that decision-hold precedence and the never-authorizes-a-Ship constraint are stated and consistent with the existing skill policy, and that no Wayfinder artifact was introduced. Targeted automated tests for the touched surfaces — documentation-audience classification, AGENTS.md file conventions, and the decision-hold lifecycle owner — all passed, and the worktree is clean. No screenshot applies: this is an agent-instruction markdown file with no rendered UI surface, so the reviewer-visible artifact is the section as an agent reads it.

<details>
<summary>Evidence: Agent-loaded AGENTS.md planning rule (as read via CLAUDE.md) + owner/constraint checks</summary>

<code>== Section as an agent reads it (CLAUDE.md, Intake and authority) ==&#10;...&#10;Do not build wrappers, control planes, policy layers, custom verifiers, or automation unless the direct path exposes a concrete blocker or repeated need that justifies the added machinery.&#10;When planning work that is both ambiguous and likely to span multiple sessions, create backlog work only for decisions that can be stated precisely now; keep the rest in the scout report or parent backlog body as `Not yet specified` until prerequisite decisions resolve.&#10;`Not yet specified` covers only downstream scope that is not yet a captain choice; an unresolved captain decision still registers as a hold under `decision-hold-lifecycle`, which keeps precedence.&#10;Use only the existing backlog, scout, dependency, and decision-hold owners; do not create a parallel map or ticket lifecycle, and planning completion never authorizes a Ship.&#10;&#10;== Referenced owners all pre-exist (no new map/tracker/lifecycle introduced) ==&#10;bin/fm-decision-hold.sh&#10;.agents/skills/decision-hold-lifecycle/SKILL.md&#10;changed files: AGENTS.md</code>

```text
== Change surface (documentation-only) ==
 AGENTS.md | 3 +++
 1 file changed, 3 insertions(+)

== Agent-loaded surface: CLAUDE.md -> AGENTS.md ==
lrwxrwxrwx - trantor  3 Aug 10:36 CLAUDE.md -> AGENTS.md

== Section as an agent reads it (CLAUDE.md, Intake and authority) ==
### Intake and authority

Resolve the project independently for every request.
An explicit project wins, a clear follow-up inherits its referent, and otherwise match the request against the registry, work under way, and project code or README.
Proceed on one confident match while naming the project in plain language; ask one concise question when multiple or no projects plausibly match.

Route by the nature of the work against each registered secondmate scope, not by a non-exclusive clone list.
Keep `local-only` work in the main home.
Send in-scope work to the fitting secondmate unless it is blocked or the captain explicitly redirects it; do not read the secondmate's chat because marked routed replies return through its status or referenced document.
If no secondmate scope fits, use the main home or discuss creating an appropriate persistent secondmate.
For one-off or infrequent operational work, start with the simplest direct end-to-end path.
Do not build wrappers, control planes, policy layers, custom verifiers, or automation unless the direct path exposes a concrete blocker or repeated need that justifies the added machinery.
When planning work that is both ambiguous and likely to span multiple sessions, create backlog work only for decisions that can be stated precisely now; keep the rest in the scout report or parent backlog body as `Not yet specified` until prerequisite decisions resolve.
`Not yet specified` covers only downstream scope that is not yet a captain choice; an unresolved captain decision still registers as a hold under `decision-hold-lifecycle`, which keeps precedence.
Use only the existing backlog, scout, dependency, and decision-hold owners; do not create a parallel map or ticket lifecycle, and planning completion never authorizes a Ship.

Before commissioning an investigation, consult existing reports and established evidence.

== Referenced owners all pre-exist (no new map/tracker/lifecycle introduced) ==
bin/fm-decision-hold.sh
.agents/skills/decision-hold-lifecycle/SKILL.md
AGENTS.md

== Ship is never authorized by planning completion ==
251:Use only the existing backlog, scout, dependency, and decision-hold owners; do not create a parallel map or ticket lifecycle, and planning completion never authorizes a Ship.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`git diff --stat 4ee4a0a..409d00a` and `git diff --name-only` — confirmed the change touches only AGENTS.md (3 added lines)</code>
- <code>Rendered the agent-loaded surface: `awk &#39;/^### Intake and authority/{f=1} f{print} ...&#39; CLAUDE.md` (CLAUDE.md is a symlink to AGENTS.md) to see the rule exactly as an agent reads it at intake</code>
- <code>`grep -rin wayfinder .` — no Wayfinder text or install anywhere in the repo</code>
- <code>`ls .agents/skills/decision-hold-lifecycle/SKILL.md bin/fm-decision-hold.sh` plus reading the skill policy — confirmed every referenced owner pre-exists and the new `Not yet specified` scoping does not contradict decision-hold precedence</code>
- <code>`grep -n &#34;never authorizes a Ship&#34; CLAUDE.md` and `grep -n &#39;\bShip\b&#39; AGENTS.md` — Ship-authorization constraint present and consistent with the existing Ship deliverable term</code>
- `bash tests/fm-documentation-audiences.test.sh`
- `bash tests/fm-ensure-agents-md.test.sh`
- `bash tests/fm-decision-hold-lifecycle.test.sh`
- <code>`git status --porcelain` — worktree clean, no transient artifacts left behind</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
