### PR TITLE
feat(bin): add omp (Oh My Pi) as a verified crewmate/secondmate harness

### DIFF
--- a/.agents/skills/afk/SKILL.md
+++ b/.agents/skills/afk/SKILL.md
@@ -84,7 +84,7 @@ The daemon constructs every current injection as the `away-supervisor` kind owne
 The bare `FM_INJECT_MARK` form remains accepted for legacy daemon escalations during rollout.
 U+2063 has no normal keyboard keystroke and survives terminal transport as UTF-8 text.
 This is how firstmate tells a daemon escalation apart from a real message in the same pane.
-The operational prefix travels with the message text; it does not rely on harness-level typed-vs-injected detection, which is not portable across claude, codex, opencode, pi, pi-signed, grok, and kimi.
+The operational prefix travels with the message text; it does not rely on harness-level typed-vs-injected detection, which is not portable across claude, codex, opencode, pi, pi-signed, grok, kimi, and omp.
 
 ## Busy-guard and composer guard
 

--- a/.agents/skills/firstmate-orca/SKILL.md
+++ b/.agents/skills/firstmate-orca/SKILL.md
@@ -13,7 +13,7 @@ It does not replace `AGENTS.md`, `docs/orca-backend.md`, or `harness-adapters`.
 
 Orca is a runtime backend, not an agent harness.
 The runtime backend owns the task endpoint and, for Orca, the task worktree.
-The harness is the agent process launched inside that endpoint, such as `claude`, `codex`, `opencode`, `pi`, `pi-signed`, `grok`, or `kimi`.
+The harness is the agent process launched inside that endpoint, such as `claude`, `codex`, `opencode`, `pi`, `pi-signed`, `grok`, `kimi`, or `omp`.
 Load `harness-adapters` for harness-specific launch, interrupt, resume, trust-dialog, and skill-invocation facts.
 
 Implementation details, metadata fields, teardown guarantees, and limitations live in `docs/orca-backend.md`.

--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: harness-adapters
-description: Agent-only reference for firstmate harness operations. Use before spawning or recovering a crewmate or secondmate, handling a trust dialog, sending a harness-specific skill invocation, interrupting or exiting an agent, resuming an exited agent, or verifying a new harness adapter. Contains verified facts for claude, codex, opencode, pi, pi-signed, grok, and kimi.
+description: Agent-only reference for firstmate harness operations. Use before spawning or recovering a crewmate or secondmate, handling a trust dialog, sending a harness-specific skill invocation, interrupting or exiting an agent, resuming an exited agent, or verifying a new harness adapter. Contains verified facts for claude, codex, opencode, pi, pi-signed, grok, kimi, and omp.
 user-invocable: false
 metadata:
   internal: true
@@ -127,6 +127,7 @@ The supported launch-profile flags below are verified locally; each row records 
 | pi / pi-signed | `--model <model>` | `--thinking <low\|medium\|high\|xhigh\|max>` | Verified 2026-07-27 on Pi and pi-signed 0.82.0. Both expose the same accepted thinking levels and completed the same model-qualified max-thinking smoke. |
 | opencode | `--model <provider/model>` | none for firstmate's interactive launch | Verified on opencode 1.17.6. `opencode run` has `--variant`, but firstmate launches the interactive `opencode --prompt` path, which has no verified effort flag. |
 | kimi | `--model <model>` | none | Verified 2026-07-25 on Kimi Code CLI 0.29.1. |
+| omp | `--model <value>` (fuzzy match) | `--thinking <low\|medium\|high\|xhigh\|max>` | Verified 2026-08-03 on omp 17.2.5. `--thinking` also accepts `off\|minimal\|auto`, a superset of the shared vocabulary; all five firstmate levels ran with no error. An unmatched `--model` value fails with a clear error rather than silently falling back. |
 
 The concrete `harness` field owns adapter identity independently of the model provider: `harness=pi` with `model=xai/grok-*` is Pi using xAI, not `harness=grok`, and does not require Grok CLI login; `harness=grok` remains the standalone Grok Build CLI adapter.
 No script resolves that split for you: establish which credential store a tuple reads from the discovery surfaces below plus `quota-axi auth --json`'s per-provider sources, and show that reasoning rather than inferring it from a harness, model, or source name.
@@ -144,6 +145,7 @@ Use the discovery surface in the current authenticated environment because suppo
 | pi / pi-signed | Run the selected executable as `<executable> --list-models [search]`; Pi's installed `docs/models.md` owns how built-in, extension-registered, and custom provider/model entries reach that list. |
 | grok | Run `grok models`, which lists the models available to the current Grok installation and account. |
 | kimi | Run `kimi provider list --json`, which lists the current provider and model configuration. |
+| omp | Run `omp models`, which lists, searches, and refreshes available models. |
 
 For an unfamiliar harness or model namespace, establish support and provider identity from that harness's authoritative CLI help, model listing, or current documentation rather than guessing from a name or prefix.
 A listing that reaches the account and does not contain the model is concrete evidence the model is unsupported: block that candidate and quote the result.
@@ -163,6 +165,7 @@ Natural language is acceptable if uncertain.
 - pi and pi-signed: no separate verified skill invocation beyond normal command behavior; use natural language if the exact skill command is uncertain.
 - grok: `/<skill>`, for example `/no-mistakes` (same form as claude). Verified end to end: grok discovers the user-level `no-mistakes` skill, `/no-mistakes` invokes it, and grok drives a real `no-mistakes axi run`. Like codex's `$`/`/` popups, typing `/<skill>` opens grok's slash-autocomplete, so a too-fast Enter selects the popup entry instead of sending, and for an argument-taking command (like `/no-mistakes`'s optional task-first argument) that first Enter only expands the popup selection into an argument-hint placeholder rather than submitting - a genuine second Enter is required (see the grok section below for the 2026-07-03 incident and fix). `fm_tmux_submit_core`'s retried Enter (used by `fm-send` on the tmux backend) handles this through the structural composer reader; the herdr backend needed a dedicated fix (`fm_backend_herdr_composer_state`, docs/herdr-backend.md) because its prior delta-based verification false-positived on that same popup-close content change.
 - kimi: `/<skill>`, for example `/no-mistakes`.
+- omp: `/<skill>`, for example `/no-mistakes`; firstmate skills are discovered (verified live: typing `/` surfaced `skill:no-mistakes` in the autocomplete popup). A no-argument command (`/exit`) submitted cleanly on the first Enter in testing, but an argument-taking skill invocation was not separately verified against the same popup-swallow hazard every other slash-popup adapter has, so treat it as exposed to that hazard until proven otherwise and let the retried-Enter submit core absorb it.
 
 ## Submission acknowledgement hazards
 
@@ -397,3 +400,66 @@ The delivery-only spinner match covers the full moon-phase glyph set rather than
 Each Kimi crew worktree receives a gitignored `.fm-kimi-turnend` token pointer, and the global hook touches that task's `state/<id>.turn-ended` only when the Stop payload's `cwd`, pointer, and registry entry all agree.
 A guarded silent hook cannot be verified from absence of effect, so prove invocation with an unguarded probe before concluding that the hook did not fire.
 The guarded turn-end signal remains a wake notification; standalone Kimi has no busy-state source until one is live-verified.
+
+## omp (VERIFIED 2026-08-03, omp 17.2.5)
+
+omp ("Oh My Pi", binary `omp`, bun-installed) is literally the `@oh-my-pi/pi-coding-agent` npm package under a different bin name and CLI identity - the installed `omp` binary resolves (`readlink -f`) to `.../node_modules/@oh-my-pi/pi-coding-agent/dist/cli.js`, and its `--help` env-var list documents `PI_CODING_AGENT_DIR`, `PI_SMOL_MODEL`, `PI_SLOW_MODEL`, `PI_PLAN_MODEL`, `PI_PACKAGE_DIR`.
+It is nonetheless empirically distinct from `pi`/`pi-signed`: a different executable name, different environment markers, and a genuinely different extension-lifecycle API (no `agent_settled` event exists in this version).
+Every fact below was established empirically for this task rather than assumed from that shared ancestry.
+
+| Fact | Value |
+|---|---|
+| Busy state | The Firstmate-owned extension's `agent_start` (busy) and `agent_end` confirmed `!willContinue` plus a deferred `ctx.setTimeout(fn, 0)` + `ctx.isIdle()` reconfirmation (idle). |
+| Exit command | `/exit` |
+| Interrupt | single Escape |
+| Skill invocation | `/<skill>` (e.g. `/no-mistakes`); firstmate skills are discovered |
+
+### Environment markers and detection precedence
+
+omp sets **both** `OMPCODE=1` and `CLAUDECODE=1` for its own child processes - verified with `CLAUDECODE` explicitly unset before invoking omp, confirming omp itself sets it rather than merely inheriting it, presumably for Claude-ecosystem tool compatibility.
+It does **not** set `PI_CODING_AGENT` (Pi's own marker) or `GROK_AGENT`.
+`bin/fm-harness.sh` therefore checks `OMPCODE` before `CLAUDECODE` in `detect_own`, or every omp session would misidentify as claude.
+Process-ancestry fallback matches the exact `omp` comm (a live `ps` read sees the renamed comm directly), plus a bare-interpreter args check for `bun`/`node`/`python` ancestors naming an `/omp` script path, mirroring the existing node/python bare-interpreter pattern.
+
+### Extension API differs from Pi
+
+omp exposes `-e`/`--extension=<file>` with the same flag shape as Pi, and the loaded extension receives an `ExtensionAPI` with `pi.on(event, handler)` - but the event set is not Pi's.
+There is no `agent_settled` event in this version.
+The closest analogues, live-verified with a logging probe extension in both `omp -p` print mode and an interactive TUI (tmux and Herdr), across ordinary completed turns, multi-tool-call turns, and a manual Escape interrupt:
+
+- `agent_start` - fires once per user prompt; used as the busy signal, same as Pi.
+- `agent_end` - fires when an agent loop ends, carrying an optional `willContinue: true` when an automatic continuation (auto-retry, empty/unexpected-stop retry) is already scheduled; subscribers must not treat a `willContinue` end as a terminal settle.
+- `session_stop` - fires when a main-agent turn is about to settle, letting a handler request one continuation turn (`SessionStopEventResult.continue`); this is the closer analogue of Claude's/Codex's Stop hooks and is the natural integration point for a future omp primary turn-end guard, but it is **not** used by the crewmate busy-state wiring below and is not otherwise built or verified in this change (see `docs/verification/supervision.md` "Turn-end guard").
+- `turn_end` - fires at every inner turn boundary; used for the turn-end NOTIFICATION touch, same as Pi.
+- `ctx.isIdle()` - present on `ExtensionContext`, but reads `false` at the exact synchronous instant `agent_end` fires (verified repeatedly) and only flips `true` within the same event-loop tick. Checking it synchronously inside the `agent_end` handler would permanently misclassify idle as busy; `bin/fm-spawn.sh`'s extension defers the check one tick via `ctx.setTimeout(fn, 0)` before reconfirming, the same "don't trust a settle that might race a fresh run" guard Pi's synchronous `ctx.isIdle()` check encodes, adapted for omp's event-vs-flag ordering.
+
+A manual Escape interrupt during a running tool call fired `turn_end` then `agent_end` (`willContinue` unset) with no `session_stop`, so - unlike Claude, which fires no hook on a manual interrupt - omp's own `agent_end` handling covers the interrupt path with no separate firstmate-controlled clear needed.
+`fm-spawn` keeps the extension file in `state/`, outside the worktree, matching Pi's pattern; omp shows no project-trust dialog to dodge (see below), so this is precautionary rather than required.
+
+### Trust dialog
+
+No trust or confirmation dialog was observed on the first launch in any of four distinct, genuinely fresh git repositories (never previously touched by omp), each with `--auto-approve`.
+Whether some untested condition (no `--auto-approve`, a different filesystem shape) can still trigger one was not established either way.
+
+### Composer shape (tmux and Herdr)
+
+omp's composer collapses its top and bottom border into dual-purpose rows instead of the top-border/`│ content │`/bottom-border shape every other verified adapter uses, identical under both backends (same underlying TUI): the top row embeds the model/thinking/dir/branch/context/cost status bar and the standing `▶` prompt/run marker inside its own border (`╭── π > ... ▶───...───╮`), and the bottom row embeds the actual typed text between its own border glyphs (`╰─ <text> ─╯`) with no intervening `│...│` row when the text fits on one line; wrapped text adds genuine `│ text │` rows and moves the final line's overflow into the bottom row the same way.
+This structurally fails the generic tmux/Herdr multi-row box scan (both require at least one `│...│` content row between top and bottom), so `fm_tmux_omp_composer_find` (`bin/fm-tmux-lib.sh`) and `fm_backend_herdr_omp_composer_find` (`bin/backends/herdr.sh`) locate this shape independently, each keeping the bottom-most match like Pi's separator-pair scan; Herdr's additionally gates on the native `omp` identity, mirroring Pi's `separated`-shape gate.
+The rendered busy indicator is `Working…` with a single horizontal-ellipsis glyph (U+2026), not three literal dots like Pi's `Working...` - confirmed byte-for-byte, so Pi's busy-footer regex does not match it; `FM_TMUX_OMP_BUSY_REGEX_DEFAULT` owns the correct pattern.
+No ghost or placeholder text was observed in an empty composer.
+
+### Herdr native identity
+
+Herdr natively recognizes omp and reports `"agent":"omp"` from `agent get`, with an ordinary `agent_status` (`idle`/`working`/etc.) - the same shape every other native-identified harness gets.
+`fm_backend_herdr_pane_agent_state` (liveness/husk classification) needed no change: it already accepts any registered `agent_status` regardless of the agent name.
+
+### Tmux liveness quirk
+
+Under tmux, `#{pane_current_command}` reports **`bun`**, not `omp`, for a running omp process - stable across resamples, a resize, and `refresh-client`, even though `/proc/<pid>/comm` for the same live process reads `omp` (bun renames its own process title after tmux's window/pane bookkeeping already captured the pre-rename identity, and tmux never resamples again while the same process keeps running).
+Exiting correctly reverts the reported command to the shell, so the alive-to-dead transition liveness recovery depends on remains correct; only the "still alive" display name is stale.
+Bare `bun` is too generic to trust fleet-wide (any bun-run script would match it), so `fm_backend_tmux_agent_state` treats a `bun` comm as provisional and confirms it by reading the pane's live child process args for a script path ending in `/omp` before classifying `alive`; otherwise it classifies `ambiguous`, never a guessed `alive` or `dead`.
+
+### Secondmate
+
+omp survives idling (confirmed a real 25-second idle gap, then a fresh message processed correctly with no restart) and exits with a `/exit` + `--resume <session-id>` mechanism, so it is spawned as a secondmate the same as every other verified harness.
+A secondmate launches bare (`--auto-approve` plus model/effort flags, no `-e` extension): busy-state wiring is not armed for secondmates fleet-wide (AGENTS.md - a secondmate's idle endpoint is healthy, and parent supervision relies on routed status), and building omp's own primary-role turn-end-guard/watcher extension pair (the equivalent of `.pi/extensions/fm-primary-turnend-guard.ts`/`fm-primary-pi-watch.ts`) was out of scope for this change and is not built - see `docs/verification/supervision.md` "Turn-end guard".

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -164,7 +164,7 @@ A silent bootstrap section needs no action; for any printed actionable diagnosti
 ## 4. Harness and runtime dispatch
 
 Load `harness-adapters` before every spawn or recovery and before trust handling, skill invocation, interrupt, exit, resume, or adapter verification.
-The verified harnesses are `claude`, `codex`, `opencode`, `pi`, `pi-signed`, `grok`, and `kimi`; never dispatch on an unverified adapter.
+The verified harnesses are `claude`, `codex`, `opencode`, `pi`, `pi-signed`, `grok`, `kimi`, and `omp`; never dispatch on an unverified adapter.
 If static `config/crew-harness` or `config/secondmate-harness` names an unverified adapter, report it and fall back only to a verified adapter rather than launching it.
 
 `docs/configuration.md` owns dispatch-profile and runtime-backend schemas, `bin/fm-harness.sh` owns static resolution, and `bin/fm-spawn.sh` owns launch flags and fail-closed validation.

--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -2516,6 +2516,117 @@ $cap
 EOF
 }
 
+# omp's composer collapses its top and bottom border into dual-purpose rows
+# (verified live, omp 17.2.5, both idle and busy, identical shape under tmux -
+# see bin/fm-tmux-lib.sh's fm_tmux_omp_composer_find for the full structural
+# rationale): the TOP row embeds the model/thinking/dir/branch/context/cost
+# status bar AND the standing "▶" prompt/run marker inside its own border
+# ("╭── π > ... ▶───...───╮"), and the BOTTOM row embeds the actual typed
+# text between its own border glyphs ("╰─ <text> ─╯") with no intervening
+# │...│ row when the text fits on one line; wrapped text adds genuine
+# │ text │ rows and moves the final line's overflow into the bottom row the
+# same way. Bound the structural candidate like the Pi separator scan.
+FM_BACKEND_HERDR_OMP_COMPOSER_MAX_LINES=${FM_BACKEND_HERDR_OMP_COMPOSER_MAX_LINES:-8}
+
+fm_backend_herdr_omp_top_row() {  # <plain-row>
+  case "$1" in
+    '╭'*'▶'*'╮'|'┌'*'▶'*'┐'|'╔'*'▶'*'╗'|'┏'*'▶'*'┓') return 0 ;;
+  esac
+  return 1
+}
+
+fm_backend_herdr_omp_bottom_row() {  # <plain-row>
+  case "$1" in
+    '╰'*'╯'|'└'*'┘'|'╚'*'╝'|'┗'*'┛') return 0 ;;
+  esac
+  return 1
+}
+
+# fm_backend_herdr_omp_border_content: strip one omp box border row's own
+# edge glyphs, leaving the (possibly empty) inner text with its dash padding
+# collapsed to spaces - the same trick fm_tmux_omp_border_content uses,
+# safe here for the same reason (real typed content never contains a raw
+# "─"/"-" run). Ghost-strips first so ANSI de-emphasis never counts as text.
+fm_backend_herdr_omp_border_content() {  # <raw-row>
+  local stripped
+  stripped=$(printf '%s\n' "$1" | fm_composer_strip_ghost)
+  case "$stripped" in
+    '╭'*'╮') stripped=${stripped#╭}; stripped=${stripped%╮} ;;
+    '┌'*'┐') stripped=${stripped#┌}; stripped=${stripped%┐} ;;
+    '╔'*'╗') stripped=${stripped#╔}; stripped=${stripped%╗} ;;
+    '┏'*'┓') stripped=${stripped#┏}; stripped=${stripped%┓} ;;
+    '╰'*'╯') stripped=${stripped#╰}; stripped=${stripped%╯} ;;
+    '└'*'┘') stripped=${stripped#└}; stripped=${stripped%┘} ;;
+    '╚'*'╝') stripped=${stripped#╚}; stripped=${stripped%╝} ;;
+    '┗'*'┛') stripped=${stripped#┗}; stripped=${stripped%┛} ;;
+    '│'*'│') stripped=${stripped#│}; stripped=${stripped%│} ;;
+    '┃'*'┃') stripped=${stripped#┃}; stripped=${stripped%┃} ;;
+    '║'*'║') stripped=${stripped#║}; stripped=${stripped%║} ;;
+    '|'*'|') stripped=${stripped#|}; stripped=${stripped%|} ;;
+  esac
+  stripped=${stripped//─/ }
+  stripped=${stripped//-/ }
+  printf '%s' "$stripped"
+}
+
+# Locate the bottom-most complete omp composer box: a top row carrying "▶"
+# inside its own border, followed by zero or more │ content │ rows, closed
+# by a bottom row whose own inner text is itself the final content chunk.
+# Sets globals so the caller can compare this shape's screen position
+# against the generic bordered/bare candidates, exactly like the Pi
+# separator-pair scan. FM_BACKEND_HERDR_OMP_CONTENT joins every content row
+# (middle │ rows plus the bottom row) with a space, already border-stripped
+# and dash-collapsed; empty when the composer is genuinely empty.
+fm_backend_herdr_omp_composer_find() {  # <ansi-capture>
+  local cap=$1 line plain top=-1 lines=0 max row=0 chunk candidate=""
+  max=$FM_BACKEND_HERDR_OMP_COMPOSER_MAX_LINES
+  case "$max" in ''|*[!0-9]*|0) max=8 ;; esac
+  FM_BACKEND_HERDR_OMP_PAIR_FOUND=0
+  FM_BACKEND_HERDR_OMP_PAIR_VALID=0
+  FM_BACKEND_HERDR_OMP_PAIR_OPEN_LINE=0
+  FM_BACKEND_HERDR_OMP_PAIR_LINE=0
+  FM_BACKEND_HERDR_OMP_CONTENT=""
+  while IFS= read -r line; do
+    row=$((row + 1))
+    plain=$(fm_backend_herdr_strip_ansi "$line")
+    plain="${plain#"${plain%%[![:space:]]*}"}"
+    plain="${plain%"${plain##*[![:space:]]}"}"
+    if fm_backend_herdr_omp_top_row "$plain"; then
+      top=$row
+      lines=0
+      candidate=""
+    elif [ "$top" -ge 0 ] && fm_backend_herdr_omp_bottom_row "$plain"; then
+      FM_BACKEND_HERDR_OMP_PAIR_FOUND=1
+      FM_BACKEND_HERDR_OMP_PAIR_OPEN_LINE=$top
+      FM_BACKEND_HERDR_OMP_PAIR_LINE=$row
+      if [ "$lines" -le "$max" ]; then
+        chunk=$(fm_backend_herdr_omp_border_content "$line")
+        chunk="${chunk#"${chunk%%[![:space:]]*}"}"
+        chunk="${chunk%"${chunk##*[![:space:]]}"}"
+        FM_BACKEND_HERDR_OMP_PAIR_VALID=1
+        FM_BACKEND_HERDR_OMP_CONTENT="${candidate:+$candidate }$chunk"
+      else
+        FM_BACKEND_HERDR_OMP_PAIR_VALID=0
+        FM_BACKEND_HERDR_OMP_CONTENT=""
+      fi
+      top=-1
+    elif [ "$top" -ge 0 ]; then
+      case "$plain" in
+        '│'*'│'|'┃'*'┃'|'║'*'║'|'|'*'|')
+          lines=$((lines + 1))
+          chunk=$(fm_backend_herdr_omp_border_content "$line")
+          chunk="${chunk#"${chunk%%[![:space:]]*}"}"
+          chunk="${chunk%"${chunk##*[![:space:]]}"}"
+          [ -z "$chunk" ] || candidate="${candidate:+$candidate }$chunk"
+          ;;
+        *) top=-1 ;;
+      esac
+    fi
+  done <<EOF
+$cap
+EOF
+}
+
 fm_backend_herdr_agent_identity_raw() {  # <session> <pane> -> <agent>\t<status>
   local out
   out=$(fm_backend_herdr_cli "$1" agent get "$2" 2>/dev/null) || return 1
@@ -2592,6 +2703,38 @@ EOF
     # not provide the complete Pi composer structure required for injection.
     found=0
   fi
+  # omp's composer neither has side borders (the generic bordered scan above
+  # never matches its ╭/╰ corners) nor Pi's separator shape, so it needs its
+  # own bottom-anchored pair scan, gated on native identity like Pi's. Compare
+  # against whichever candidate line is currently authoritative (the generic
+  # match, possibly already overridden by the Pi branch above) so an earlier
+  # row of either other shape can never outrank the live omp composer.
+  fm_backend_herdr_omp_composer_find "$cap"
+  if [ "$FM_BACKEND_HERDR_OMP_PAIR_FOUND" -eq 1 ] \
+     && [ "$FM_BACKEND_HERDR_OMP_PAIR_LINE" -gt "$generic_line" ] \
+     && [ "$generic_line" -lt "$FM_BACKEND_HERDR_OMP_PAIR_OPEN_LINE" ]; then
+    identity=$(fm_backend_herdr_agent_identity_raw "$session" "$pane" 2>/dev/null || true)
+    IFS=$'\t' read -r agent agent_status <<EOF
+$identity
+EOF
+    case "$agent:$agent_status" in
+      omp:idle|omp:done|omp:blocked)
+        if [ "$FM_BACKEND_HERDR_OMP_PAIR_VALID" -eq 1 ]; then
+          shape=omp
+          raw_match=$FM_BACKEND_HERDR_OMP_CONTENT
+          found=1
+        else
+          found=0
+        fi
+        ;;
+      omp:*|:*)
+        # A working omp or unreadable identity cannot authorize injection,
+        # and the lower pair proves any generic row above is not current.
+        found=0
+        ;;
+      *) : ;; # A known non-omp agent keeps its established generic verdict.
+    esac
+  fi
   [ "$found" -eq 1 ] || { printf 'unknown'; return 0; }
   # Content: extract the real typed text from the raw row with the shared,
   # fleet-wide ghost stripper (bin/fm-composer-lib.sh), which drops dim/faint AND
@@ -2615,6 +2758,13 @@ EOF
     # The native Pi identity plus the complete separator pair is the genuine
     # composer container, equivalent to a bordered box for shared content
     # classification. ANSI stripping keeps real text and drops only styling.
+    bordered=1
+  elif [ "$shape" = omp ]; then
+    # FM_BACKEND_HERDR_OMP_CONTENT is already border-stripped, ghost-stripped,
+    # and dash-collapsed per row by fm_backend_herdr_omp_composer_find; the
+    # re-application of fm_composer_strip_ghost above is a harmless no-op on
+    # already-plain text. The native omp identity plus the complete top/bottom
+    # pair is the genuine composer container, equivalent to a bordered box.
     bordered=1
   fi
   # Delegate the empty/pending/unknown decision to the shared owner. The bare

--- a/bin/backends/tmux.sh
+++ b/bin/backends/tmux.sh
@@ -345,13 +345,18 @@ EOF
 # script path ending in "/omp" (mirrors fm-harness.sh's own node/python/bun
 # bare-interpreter args check). Fails closed (false) on any read failure.
 fm_backend_tmux_bun_child_is_omp() {  # <target>
-  local target=$1 pane_pid args
+  local target=$1 pane_pid child_pid args
   pane_pid=$(tmux display-message -p -t "$target" '#{pane_pid}' 2>/dev/null) || return 1
   case "$pane_pid" in ''|*[!0-9]*) return 1 ;; esac
-  args=$(ps -o args= --ppid "$pane_pid" 2>/dev/null) || return 1
-  case "$args" in
-    *' '*/omp|*' '*/omp' '*) return 0 ;;
-  esac
+  # `ps --ppid` is a GNU/procps-ng long option unsupported by BSD/macOS ps;
+  # `pgrep -P` (child-pid lookup) plus the portable `ps -o args= -p <pid>`
+  # form works on both, matching fm-harness.sh's own ancestry-walk idiom.
+  for child_pid in $(pgrep -P "$pane_pid" 2>/dev/null); do
+    args=$(ps -o args= -p "$child_pid" 2>/dev/null) || continue
+    case "$args" in
+      *' '*/omp|*' '*/omp' '*) return 0 ;;
+    esac
+  done
   return 1
 }
 

--- a/bin/backends/tmux.sh
+++ b/bin/backends/tmux.sh
@@ -317,11 +317,42 @@ EOF
 
   case "$comm" in
     '') printf 'unreadable'; return 0 ;;
+    bun)
+      # omp ships as a bun-run script; tmux's #{pane_current_command} keeps
+      # reporting the bun interpreter's own pre-launch name rather than the
+      # renamed "omp" comm the running process actually reports to /proc
+      # (verified empirically and stable across resamples, resize, and
+      # refresh-client - not a transient race). Bare "bun" is too generic to
+      # trust on its own (any bun-run script would match), so confirm via the
+      # pane's live child process args, mirroring fm-harness.sh's own
+      # bare-interpreter args check for node/python/bun ancestry.
+      if fm_backend_tmux_bun_child_is_omp "$target"; then
+        printf 'alive'
+      else
+        printf 'ambiguous'
+      fi
+      return 0
+      ;;
   esac
   case "$(fm_backend_tmux_classify_process_name "$comm")" in
     shell) printf 'dead' ;;
     *) printf 'ambiguous' ;;
   esac
+}
+
+# fm_backend_tmux_bun_child_is_omp: confirm a "bun" pane_current_command is
+# genuinely omp by inspecting the pane shell's live child process args for a
+# script path ending in "/omp" (mirrors fm-harness.sh's own node/python/bun
+# bare-interpreter args check). Fails closed (false) on any read failure.
+fm_backend_tmux_bun_child_is_omp() {  # <target>
+  local target=$1 pane_pid args
+  pane_pid=$(tmux display-message -p -t "$target" '#{pane_pid}' 2>/dev/null) || return 1
+  case "$pane_pid" in ''|*[!0-9]*) return 1 ;; esac
+  args=$(ps -o args= --ppid "$pane_pid" 2>/dev/null) || return 1
+  case "$args" in
+    *' '*/omp|*' '*/omp' '*) return 0 ;;
+  esac
+  return 1
 }
 
 # Backward-compatible three-state view for callers that only need a yes/no

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -583,7 +583,7 @@ secondmate_liveness_sweep() {
     [ -n "$target" ] || target="$window"
     agent_state=$(fm_backend_agent_state "$backend" "$target" 2>/dev/null) || agent_state=unreadable
     case "$harness" in
-      claude|codex|opencode|pi|pi-signed|grok|kimi) ;;
+      claude|codex|opencode|pi|pi-signed|grok|kimi|omp) ;;
       *)
         case "$agent_state" in dead|missing) agent_state=unverified-harness ;; esac
         ;;
@@ -888,14 +888,14 @@ crew_dispatch_validate() {
     return 0
   fi
   err=$(jq -r '
-    def verified($h): ["claude","codex","opencode","pi","pi-signed","grok","kimi"] | index($h);
+    def verified($h): ["claude","codex","opencode","pi","pi-signed","grok","kimi","omp"] | index($h);
     def effort_ok($h; $e):
       if $e == null then true
       elif ($e | type) != "string" then false
       elif $h == "claude" then (["low","medium","high","xhigh","max"] | index($e))
       elif $h == "codex" then (["low","medium","high","xhigh"] | index($e))
       elif $h == "grok" then (["low","medium","high"] | index($e))
-      elif $h == "pi" or $h == "pi-signed" then (["low","medium","high","xhigh","max"] | index($e))
+      elif $h == "pi" or $h == "pi-signed" or $h == "omp" then (["low","medium","high","xhigh","max"] | index($e))
       elif $h == "opencode" or $h == "kimi" then false
       else true
       end;

--- a/bin/fm-busy-lib.sh
+++ b/bin/fm-busy-lib.sh
@@ -29,6 +29,8 @@
 # task's recorded harness classifies unknown, so one adapter's writer can
 # never classify another adapter):
 #   pi-ext           Pi/pi-signed per-task extension (agent_start/agent_settled)
+#   omp-ext          omp per-task extension (agent_start/agent_end, deferred
+#                    ctx.isIdle() reconfirmation - see bin/fm-spawn.sh)
 #   opencode-plugin  OpenCode per-task plugin (session.status)
 #   claude-hook      Claude lifecycle hooks (UserPromptSubmit/Stop/StopFailure/SessionEnd)
 #   codex-hook, codex-appserver  reserved: Codex, gated by
@@ -173,6 +175,7 @@ fm_busy_sources_for_harness() {  # <harness>
       ;;
     opencode*) adapter=opencode-plugin ;;
     pi|pi-signed) adapter=pi-ext ;;
+    omp) adapter=omp-ext ;;
     kimi*)
       fm_busy_kimi_verified || { printf ''; return 0; }
       adapter='kimi-wire kimi-hook'

--- a/bin/fm-harness.sh
+++ b/bin/fm-harness.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Detect the agent harness this process tree runs on.
-# Usage: fm-harness.sh                  print own harness: claude|codex|opencode|pi|pi-signed|grok|kimi|unknown
+# Usage: fm-harness.sh                  print own harness: claude|codex|opencode|pi|pi-signed|grok|kimi|omp|unknown
 #        fm-harness.sh crew             print the effective CREWMATE harness
 #                                        (config/crew-harness; "default" resolves to own)
 #        fm-harness.sh secondmate       print the harness the PRIMARY uses to launch
@@ -30,11 +30,20 @@ CONFIG="${FM_CONFIG_OVERRIDE:-$FM_HOME/config}"
 detect_own() {
   # Layer 1: environment markers for verified harnesses.
   # Keep marker detection before ancestry detection as an explicit precedence rule.
-  # Only claude, pi, and grok set verified markers of their own; codex, opencode,
-  # and kimi are markerless, so a foreign marker retained in a terminal
-  # multiplexer's stored environment can silently misidentify one of them before
-  # ancestry is consulted. This is a precedence hazard, not evidence that
-  # CLAUDECODE inheritance into a kimi child was observed; it was not observed.
+  # omp (Oh My Pi) sets BOTH OMPCODE=1 and CLAUDECODE=1 for its own child
+  # processes (verified empirically: launching omp with CLAUDECODE explicitly
+  # unset beforehand still yields CLAUDECODE=1 in its bash-tool children),
+  # presumably for Claude-ecosystem tool compatibility. OMPCODE must therefore
+  # be checked BEFORE CLAUDECODE, or every omp session would misidentify as
+  # claude. omp does NOT set PI_CODING_AGENT despite being built on the same
+  # underlying @oh-my-pi/pi-coding-agent package as pi/pi-signed.
+  [ "${OMPCODE:-}" = "1" ] && { echo omp; return; }
+  # Only claude, pi, grok, and omp set verified markers of their own; codex,
+  # opencode, and kimi are markerless, so a foreign marker retained in a
+  # terminal multiplexer's stored environment can silently misidentify one of
+  # them before ancestry is consulted. This is a precedence hazard, not
+  # evidence that CLAUDECODE inheritance into a kimi child was observed; it
+  # was not observed.
   [ "${CLAUDECODE:-}" = "1" ] && { echo claude; return; }
   if [ "${PI_CODING_AGENT:-}" = "true" ]; then
     if [ "${FM_PI_HARNESS:-}" = pi-signed ]; then echo pi-signed; else echo pi; fi
@@ -56,8 +65,13 @@ detect_own() {
       kimi) echo kimi; return ;;
       pi-signed) echo pi; return ;;
       pi) echo pi; return ;;
-      node*|python*)
-        # Bare interpreter: match the harness name in its script path.
+      omp) echo omp; return ;;
+      node*|python*|bun*)
+        # Bare interpreter: match the harness name in its script path. bun is
+        # here because omp ships as a bun-run script whose comm gets renamed
+        # to "omp" at runtime (a live ps read sees "omp" directly, matched
+        # above), but a caller that only sees the pre-rename "bun" comm - or a
+        # snapshot taken before the rename lands - still needs this fallback.
         args=$(ps -o args= -p "$pid" 2>/dev/null)
         case "$args" in
           *claude*) echo claude; return ;;
@@ -65,6 +79,7 @@ detect_own() {
           *opencode*) echo opencode; return ;;
           *grok*) echo grok; return ;;
           *" pi "*|*/pi) echo pi; return ;;
+          *" omp "*|*/omp) echo omp; return ;;
         esac ;;
     esac
     pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' ')

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1003,17 +1003,11 @@ effort_flag_for_harness() {
         low|medium|high) printf -- '--reasoning-effort %s ' "$(shell_quote "$effort")" ;;
       esac
       ;;
-    pi|pi-signed)
+    pi|pi-signed|omp)
       # Pi 0.80.6 accepts the full shared effort vocabulary, including max, through
-      # its --thinking flag.
-      case "$effort" in
-        low|medium|high|xhigh|max) printf -- '--thinking %s ' "$(shell_quote "$effort")" ;;
-      esac
-      ;;
-    omp)
-      # omp 17.2.5's --thinking accepts off|minimal|low|medium|high|xhigh|max|auto,
-      # a superset of the shared vocabulary; all five firstmate levels verified
-      # working with no error.
+      # its --thinking flag. omp 17.2.5's --thinking accepts
+      # off|minimal|low|medium|high|xhigh|max|auto, a superset of the shared
+      # vocabulary; all five firstmate levels verified working with no error.
       case "$effort" in
         low|medium|high|xhigh|max) printf -- '--thinking %s ' "$(shell_quote "$effort")" ;;
       esac

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -83,7 +83,7 @@
 #   profile consultation. A --secondmate spawn is exempt and resolves the SECONDMATE
 #   harness (config/secondmate-harness -> config/crew-harness -> own), so the
 #   secondmate-vs-crewmate split is DURABLE across every respawn (recovery,
-#   /updatefirstmate, restart). A bare adapter name (claude|codex|opencode|pi|pi-signed|grok|kimi)
+#   /updatefirstmate, restart). A bare adapter name (claude|codex|opencode|pi|pi-signed|grok|kimi|omp)
 #   overrides it for this spawn (either kind). A non-flag string containing
 #   whitespace is treated as a RAW launch command - the escape hatch for verifying
 #   new adapters. pi-signed launches that exact executable name from PATH and
@@ -125,6 +125,8 @@
 #                  turn-end signal rides the launch command, e.g. codex -c notify=[...])
 #     __PIEXT__    absolute path to state/<task-id>.pi-ext.ts (pi turn-end extension,
 #                  written by this script; outside the worktree to avoid pi's trust gate)
+#     __OMPEXT__   absolute path to state/<task-id>.omp-ext.ts (omp busy-state extension,
+#                  written by this script; kept outside the worktree like __PIEXT__)
 #     __PITURNEND__ absolute path to .pi/extensions/fm-primary-turnend-guard.ts in a pi secondmate home
 #     __PIWATCH__   absolute path to .pi/extensions/fm-primary-pi-watch.ts in a pi secondmate home
 #     __OPINPUT__   absolute path to the canonical operational-input encoder
@@ -774,7 +776,7 @@ FIRSTMATE_HOME=
 
 if [ "$KIND" = secondmate ]; then
   case "${POS[1]:-}" in
-    ''|claude|codex|opencode|pi|pi-signed|grok|kimi)
+    ''|claude|codex|opencode|pi|pi-signed|grok|kimi|omp)
       ARG3=${POS[1]:-}
       ;;
     *' '*)
@@ -840,6 +842,23 @@ launch_template() {
     # Its turn-end signal is a globally configured Stop hook plus a guarded
     # per-task worktree token, so no launch placeholder belongs here.
     kimi) printf '%s' '__KIMIBIN__ __MODELFLAG__--auto' ;;
+    # omp (Oh My Pi): --auto-approve auto-approves every tool call (verified:
+    # fully unattended, no permission dialogs, no first-run trust dialog
+    # observed across four distinct fresh worktrees). Accepts one positional
+    # prompt exactly like claude/grok. Ship/scout load the busy-state
+    # extension kept outside the worktree, same rationale as pi/pi-signed
+    # (project-local extension files pollute the project); omp shows no
+    # project-trust gate to dodge, but keeping the file out of git's view is
+    # still correct. A secondmate launches bare: omp's deeper primary-role
+    # turn-end-guard/watcher extension pair is not built or verified here
+    # (see the harness-adapters skill), only its plain interactive session.
+    omp)
+      if [ "$kind" = secondmate ]; then
+        printf '%s' 'omp --auto-approve __MODELFLAG____EFFORTFLAG__"$(__OPINPUT__ encode launch-brief < __BRIEF__)"'
+      else
+        printf '%s' 'omp --auto-approve __MODELFLAG____EFFORTFLAG__-e __OMPEXT__ "$(__OPINPUT__ encode launch-brief < __BRIEF__)"'
+      fi
+      ;;
     *) return 1 ;;
   esac
 }
@@ -952,7 +971,7 @@ model_flag_for_harness() {
   local harness=$1 model=$2
   [ -n "$model" ] && [ "$model" != default ] || return 0
   case "$harness" in
-    claude|codex|opencode|pi|pi-signed|grok|kimi)
+    claude|codex|opencode|pi|pi-signed|grok|kimi|omp)
       printf -- '--model %s ' "$(shell_quote "$model")"
       ;;
   esac
@@ -987,6 +1006,14 @@ effort_flag_for_harness() {
     pi|pi-signed)
       # Pi 0.80.6 accepts the full shared effort vocabulary, including max, through
       # its --thinking flag.
+      case "$effort" in
+        low|medium|high|xhigh|max) printf -- '--thinking %s ' "$(shell_quote "$effort")" ;;
+      esac
+      ;;
+    omp)
+      # omp 17.2.5's --thinking accepts off|minimal|low|medium|high|xhigh|max|auto,
+      # a superset of the shared vocabulary; all five firstmate levels verified
+      # working with no error.
       case "$effort" in
         low|medium|high|xhigh|max) printf -- '--thinking %s ' "$(shell_quote "$effort")" ;;
       esac
@@ -1774,7 +1801,7 @@ if [ "$KIND" != secondmate ]; then
       ;;
   esac
   case "$HARNESS" in
-    claude*|opencode*|pi|pi-signed)
+    claude*|opencode*|pi|pi-signed|omp)
       BUSY_GEN=$("$FM_ROOT/bin/fm-busy-event.sh" arm "$STATE_REAL" "$ID") || {
         echo "error: failed to arm the busy-state contract for $ID" >&2
         exit 1
@@ -1895,6 +1922,56 @@ export default function (pi: any) {
   pi.on("agent_settled", (_event: any, ctx: any) => {
     if (ctx && typeof ctx.isIdle === "function" && !ctx.isIdle()) return;
     return busyEvent("idle", "agent-settled");
+  });
+  pi.on("turn_end", () => execFile("touch", ["$TURNEND"]));
+}
+EOF
+      ;;
+    omp)
+      # Written OUTSIDE the worktree like pi's extension, for consistency
+      # (omp shows no project-trust dialog to dodge, verified across four
+      # fresh worktrees, so this is precautionary rather than required).
+      # Semantic state, verified live on omp 17.2.5's extension API, which
+      # differs from pi's: there is no "agent_settled" event here.
+      # "agent_start" -> busy, once per user prompt.
+      # "agent_end" -> idle, UNLESS event.willContinue is set (an automatic
+      # continuation - auto-retry, empty/unexpected-stop retry - is already
+      # scheduled, so this is not a user-visible terminal settle). ctx.isIdle()
+      # reads false at the exact synchronous moment agent_end fires (verified
+      # empirically, twice) but flips true within the same event-loop tick, so
+      # the idle write is deferred one tick via ctx.setTimeout(fn, 0) and
+      # reconfirmed with ctx.isIdle() there - the same "don't trust a settle
+      # that might race a fresh run" guard pi's ctx.isIdle() check encodes,
+      # adapted for omp's event-vs-flag ordering. Verified live: a manual
+      # Escape interrupt also fires agent_end (unlike claude, which fires no
+      # hook on manual interrupt), so no separate firstmate-interrupt handling
+      # is needed here.
+      # "turn_end" fires at every inner turn boundary and stays a wake
+      # NOTIFICATION touch for the watcher, never current-state truth.
+      cat > "$STATE/$ID.omp-ext.ts" <<EOF
+// Firstmate semantic busy-state events + turn-end notification; written by
+// fm-spawn under the contract owned by bin/fm-busy-lib.sh.
+import { execFile } from "node:child_process";
+const busyEvent = (state: string, event: string) =>
+  new Promise<void>((resolve) => {
+    execFile("$FM_ROOT/bin/fm-busy-event.sh", [
+      "apply", "$STATE_REAL", "$ID", state,
+      "--gen", "$BUSY_GEN", "--source", "omp-ext", "--event", event,
+    ], () => resolve());
+  });
+export default function (pi: any) {
+  pi.on("agent_start", () => busyEvent("busy", "agent-start"));
+  pi.on("agent_end", (event: any, ctx: any) => {
+    if (event && event.willContinue) return;
+    if (ctx && typeof ctx.setTimeout === "function") {
+      ctx.setTimeout(() => {
+        if (typeof ctx.isIdle !== "function" || ctx.isIdle()) {
+          busyEvent("idle", "agent-end");
+        }
+      }, 0);
+    } else {
+      busyEvent("idle", "agent-end");
+    }
   });
   pi.on("turn_end", () => execFile("touch", ["$TURNEND"]));
 }
@@ -2070,6 +2147,7 @@ META_WINDOW=$T
 sq_brief=$(shell_quote "$BRIEF")
 sq_turnend=$(shell_quote "$TURNEND")
 sq_piext=$(shell_quote "$STATE/$ID.pi-ext.ts")
+sq_ompext=$(shell_quote "$STATE/$ID.omp-ext.ts")
 sq_piturnend=$(shell_quote "$PROJ_ABS/.pi/extensions/fm-primary-turnend-guard.ts")
 sq_piwatch=$(shell_quote "$PROJ_ABS/.pi/extensions/fm-primary-pi-watch.ts")
 sq_opinput=$(shell_quote "$FM_ROOT/bin/fm-operational-input.sh")
@@ -2080,6 +2158,7 @@ LAUNCH=${LAUNCH//__EFFORTFLAG__/$EFFORTFLAG}
 LAUNCH=${LAUNCH//__BRIEF__/$sq_brief}
 LAUNCH=${LAUNCH//__TURNEND__/$sq_turnend}
 LAUNCH=${LAUNCH//__PIEXT__/$sq_piext}
+LAUNCH=${LAUNCH//__OMPEXT__/$sq_ompext}
 LAUNCH=${LAUNCH//__PITURNEND__/$sq_piturnend}
 LAUNCH=${LAUNCH//__PIWATCH__/$sq_piwatch}
 LAUNCH=${LAUNCH//__OPINPUT__/$sq_opinput}

--- a/bin/fm-tmux-lib.sh
+++ b/bin/fm-tmux-lib.sh
@@ -82,13 +82,17 @@
 # busy signals on their own.
 # The full moon-phase set remains locale- and emoji-font-sensitive because Kimi
 # exposes no stable ASCII busy token.
-FM_TMUX_BUSY_REGEX_DEFAULT='esc (to )?interrupt|Working\.\.\.|Ctrl\+c:cancel'
+FM_TMUX_BUSY_REGEX_DEFAULT='esc (to )?interrupt|Working\.\.\.|Working…|Ctrl\+c:cancel'
 FM_TMUX_CLAUDE_BUSY_REGEX_DEFAULT='esc to interrupt|…[[:space:]]+\([0-9]+[smh]'
 FM_TMUX_CODEX_BUSY_REGEX_DEFAULT='esc to interrupt'
 FM_TMUX_OPENCODE_BUSY_REGEX_DEFAULT='esc interrupt'
 FM_TMUX_PI_BUSY_REGEX_DEFAULT='Working\.\.\.'
 FM_TMUX_GROK_BUSY_REGEX_DEFAULT='Ctrl\+c:cancel'
 FM_TMUX_KIMI_BUSY_REGEX_DEFAULT='^[[:space:]]*(🌑|🌒|🌓|🌔|🌕|🌖|🌗|🌘)[[:space:]]+·[[:space:]]+'
+# omp renders "Working" followed by a single horizontal-ellipsis glyph (U+2026),
+# NOT three literal dots like Pi's "Working..." - verified byte-for-byte live
+# on omp 17.2.5, so Pi's regex does not match it.
+FM_TMUX_OMP_BUSY_REGEX_DEFAULT='Working…'
 
 fm_busy_lines_match() {  # [harness]
   local harness=${1:-} lines regex
@@ -103,6 +107,7 @@ fm_busy_lines_match() {  # [harness]
       pi|pi-signed) regex=$FM_TMUX_PI_BUSY_REGEX_DEFAULT ;;
       grok) regex=$FM_TMUX_GROK_BUSY_REGEX_DEFAULT ;;
       kimi) regex=$FM_TMUX_KIMI_BUSY_REGEX_DEFAULT ;;
+      omp) regex=$FM_TMUX_OMP_BUSY_REGEX_DEFAULT ;;
       '') regex=$FM_TMUX_BUSY_REGEX_DEFAULT ;;
       *)
         # A supplied harness must never borrow another harness's signature.
@@ -302,6 +307,117 @@ EOF
   return 1
 }
 
+# omp's composer collapses its top and bottom border into dual-purpose rows
+# instead of the three-plus-row shape (top border / │ content │ / bottom
+# border) every other verified adapter uses (verified live, omp 17.2.5, both
+# idle and busy): the TOP row embeds the model/thinking/dir/branch/context/
+# cost status bar AND the standing "▶" prompt/run marker inside its own
+# border ("╭── π > ... ▶───...───╮"), and the BOTTOM row embeds the actual
+# typed text between its own border glyphs ("╰─ <text> ─╯") with NO
+# intervening │...│ row when the text fits on one line. Wrapped text adds
+# genuine │ text │ rows in between and moves the final line's overflow into
+# the bottom row exactly the same way. This shape structurally fails
+# fm_tmux_find_composer_box's generic scan (it requires at least one │...│
+# content row between top and bottom), so omp needs its own finder, tried
+# first and bounded like Pi's herdr separator-pair scan.
+FM_TMUX_OMP_COMPOSER_MAX_LINES=${FM_TMUX_OMP_COMPOSER_MAX_LINES:-8}
+
+# fm_tmux_omp_composer_find: locate the bottom-most instance of omp's own
+# composer shape in <plain-pane>. Prints "<top_row> <bottom_row>" (0-based)
+# on a match; both indices are needed by the caller to re-read the RAW
+# (styled) rows for ghost-aware content extraction. Keeping the LAST match
+# (scanning forward, always overwriting) means an earlier decorative box
+# (e.g. a tool-result box, which never contains "▶") can never outrank the
+# live bottom composer.
+fm_tmux_omp_composer_find() {  # <plain-pane>
+  local pane=$1 line trimmed row=0 top=-1 lines=0 max=$FM_TMUX_OMP_COMPOSER_MAX_LINES
+  local found_top=-1 found_bottom=-1
+  case "$max" in ''|*[!0-9]*|0) max=8 ;; esac
+  while IFS= read -r line; do
+    trimmed="${line#"${line%%[![:space:]]*}"}"
+    trimmed="${trimmed%"${trimmed##*[![:space:]]}"}"
+    case "$trimmed" in
+      '╭'*'▶'*'╮'|'┌'*'▶'*'┐'|'╔'*'▶'*'╗'|'┏'*'▶'*'┓'|'+'*'▶'*'+')
+        top=$row
+        lines=0
+        ;;
+      '╰'*'╯'|'└'*'┘'|'╚'*'╝'|'┗'*'┛')
+        if [ "$top" -ge 0 ] && [ "$lines" -le "$max" ]; then
+          found_top=$top
+          found_bottom=$row
+        fi
+        top=-1
+        ;;
+      '│'*'│'|'┃'*'┃'|'║'*'║'|'|'*'|')
+        [ "$top" -ge 0 ] && lines=$((lines + 1))
+        ;;
+      *)
+        [ "$top" -ge 0 ] && top=-1
+        ;;
+    esac
+    row=$((row + 1))
+  done <<EOF
+$pane
+EOF
+  [ "$found_top" -ge 0 ] || return 1
+  printf '%s %s' "$found_top" "$found_bottom"
+}
+
+# fm_tmux_omp_border_content: strip one omp box border row's own edge glyphs,
+# leaving the (possibly empty) inner text with its dash padding collapsed to
+# spaces - the same trick fm_tmux_find_composer_box uses for top_spaces,
+# safe here because real typed content never contains a raw "─"/"-" run.
+# Ghost-strips first, so this handles both the top border (never actually
+# fed real composer text, but harmless) and the content-bearing bottom
+# border/│ rows alike.
+fm_tmux_omp_border_content() {  # <raw-row>
+  local stripped
+  stripped=$(printf '%s\n' "$1" | fm_composer_strip_ghost)
+  case "$stripped" in
+    '╭'*'╮') stripped=${stripped#╭}; stripped=${stripped%╮} ;;
+    '┌'*'┐') stripped=${stripped#┌}; stripped=${stripped%┐} ;;
+    '╔'*'╗') stripped=${stripped#╔}; stripped=${stripped%╗} ;;
+    '┏'*'┓') stripped=${stripped#┏}; stripped=${stripped%┓} ;;
+    '╰'*'╯') stripped=${stripped#╰}; stripped=${stripped%╯} ;;
+    '└'*'┘') stripped=${stripped#└}; stripped=${stripped%┘} ;;
+    '╚'*'╝') stripped=${stripped#╚}; stripped=${stripped%╝} ;;
+    '┗'*'┛') stripped=${stripped#┗}; stripped=${stripped%┛} ;;
+    '│'*'│') stripped=${stripped#│}; stripped=${stripped%│} ;;
+    '┃'*'┃') stripped=${stripped#┃}; stripped=${stripped%┃} ;;
+    '║'*'║') stripped=${stripped#║}; stripped=${stripped%║} ;;
+    '|'*'|') stripped=${stripped#|}; stripped=${stripped%|} ;;
+  esac
+  stripped=${stripped//─/ }
+  stripped=${stripped//-/ }
+  printf '%s' "$stripped"
+}
+
+# fm_tmux_omp_composer_state: classify omp's own composer shape as
+# empty|pending|unknown|no-match, given an already-captured <styled-pane>
+# (caller's fm_tmux_composer_state already captured it once; this avoids a
+# second tmux capture-pane round trip on every check). Only the BOTTOM row's
+# own content counts as composer text - the top row's embedded status bar is
+# never composer input, so it is read purely for the structural "▶" match,
+# never for content. A middle │ text │ row (present only while wrapping)
+# also counts.
+fm_tmux_omp_composer_state() {  # <styled-pane> <plain-pane>
+  local pane=$1 plain=$2 box top bottom row row_raw content joined=""
+  box=$(fm_tmux_omp_composer_find "$plain") || { printf 'no-match'; return 0; }
+  top=${box%% *}
+  bottom=${box#* }
+  row=$((top + 1))
+  while [ "$row" -le "$bottom" ]; do
+    row_raw=$(printf '%s\n' "$pane" | sed -n "$((row + 1))p")
+    content=$(fm_tmux_omp_border_content "$row_raw")
+    content="${content#"${content%%[![:space:]]*}"}"
+    content="${content%"${content##*[![:space:]]}"}"
+    [ -n "$content" ] || { row=$((row + 1)); continue; }
+    joined="${joined:+$joined }$content"
+    row=$((row + 1))
+  done
+  fm_composer_classify_content 1 "$joined" "${FM_COMPOSER_IDLE_RE:-}" insensitive "$joined"
+}
+
 # fm_tmux_composer_state classification contract:
 # A row is structural only when its first or last non-whitespace character is a
 # composer edge. A complete box has matching border families and bounded top and
@@ -320,6 +436,11 @@ fm_tmux_composer_state() {  # <target> -> empty|pending|pending-unproven|unknown
   case "$cy" in ''|*[!0-9]*) printf 'unknown'; return 0 ;; esac
   pane=$(tmux capture-pane -e -p -t "$target" -S 0 -E - 2>/dev/null) || { printf 'unknown'; return 0; }
   plain=$(printf '%s\n' "$pane" | fm_composer_strip_ansi)
+  state=$(fm_tmux_omp_composer_state "$pane" "$plain")
+  if [ "$state" != no-match ]; then
+    printf '%s' "$state"
+    return 0
+  fi
   if box=$(fm_tmux_find_composer_box "$cy" "$plain"); then
     top=${box%% *}
     box=${box#* }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -92,7 +92,7 @@ On an unmarked return, `bin/fm-afk-return.sh` owns ordered shutdown, durable cat
 `bin/fm-busy-lib.sh` is the single owner of what "this worker is busy" means, and `bin/fm-busy-event.sh` is the only writer of the per-task records it reads.
 Every classification returns a verdict of busy, idle, unknown, or dead together with the source that produced it, so a consumer or a diagnostic can never confuse semantic state with a fallback.
 
-Each converted adapter reports its own turn lifecycle through a machine-readable contract the vendor already exposes, rather than through rendered footer text: Pi and pi-signed through the Firstmate-owned extension's `agent_start` and `agent_settled` confirmed by `ctx.isIdle()`, OpenCode through its plugin's semantic `session.status`, and Claude through owned `UserPromptSubmit`, `Stop`, `StopFailure`, and `SessionEnd` hooks.
+Each converted adapter reports its own turn lifecycle through a machine-readable contract the vendor already exposes, rather than through rendered footer text: Pi and pi-signed through the Firstmate-owned extension's `agent_start` and `agent_settled` confirmed by `ctx.isIdle()`, omp through its own distinct extension API's `agent_start` and `agent_end` (idle only once no `willContinue` continuation is scheduled, confirmed by a deferred `ctx.isIdle()` recheck) since this version of omp has no `agent_settled` event, OpenCode through its plugin's semantic `session.status`, and Claude through owned `UserPromptSubmit`, `Stop`, `StopFailure`, and `SessionEnd` hooks.
 Kimi behind Pi inherits Pi's lifecycle.
 Codex and standalone Kimi classify unknown behind explicit probes until a semantic source is live-verified for them, and Grok keeps one clearly isolated rendered-tail fallback that can only ever classify a Grok task.
 
@@ -168,7 +168,7 @@ The session-start bootstrap step keeps valid dispatch configuration silent unles
 When the file exists, `fm-spawn.sh` refuses crewmate and scout launches without an explicit harness, so `config/crew-harness` is only automatic when no dispatch profile file is active.
 Secondmate launches are exempt because they resolve the secondmate harness and any optional secondmate model or effort tokens instead.
 Unsupported effort values are still recorded in task meta when passed to `fm-spawn.sh`, but the launch template omits any effort flag that the selected harness does not accept.
-That keeps spawn launch compatible across claude, codex, grok, pi, opencode, and kimi while preserving the requested profile for later audit.
+That keeps spawn launch compatible across every verified harness ([Harness support](configuration.md#harness-support)) while preserving the requested profile for later audit.
 
 ## Optional secondmates
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -206,7 +206,7 @@ The full cmux home label also includes a short hash of the resolved `FM_ROOT` pa
 
 ## Harness support
 
-claude, codex, opencode, pi, pi-signed, grok, and kimi are empirically verified for crewmate and secondmate launches; [README requirements](../README.md#requirements) own the set supported for the primary session.
+claude, codex, opencode, pi, pi-signed, grok, kimi, and omp are empirically verified for crewmate and secondmate launches; [README requirements](../README.md#requirements) own the set supported for the primary session.
 New harnesses get verified through a supervised trial task before joining the set.
 The verified adapter knowledge - each harness's busy-state source, interrupt and exit commands, skill-invocation syntax, and per-harness quirks - lives in [`.agents/skills/harness-adapters/SKILL.md`](../.agents/skills/harness-adapters/SKILL.md).
 Launch mechanics, including the verified command templates, live in [`bin/fm-spawn.sh`](../bin/fm-spawn.sh).

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -210,8 +210,9 @@ A human-blocked permission dialog has no busy banner and still surfaces.
 ## Composer and injection safety
 
 Herdr has no direct cursor-row primitive.
-The adapter locates the bottom-most recognized bordered row, Claude `❯` row, Codex `›` row, or a Pi separator region admitted only when native identity is exactly Pi and state is idle, done, or blocked.
-A working Pi, pending middle row, missing identity, incomplete separator pair, or over-tall candidate remains pending or unknown.
+The adapter locates the bottom-most recognized bordered row, Claude `❯` row, Codex `›` row, a Pi separator region admitted only when native identity is exactly Pi and state is idle, done, or blocked, or omp's own collapsed top/bottom-border pair admitted only when native identity is exactly omp and state is idle, done, or blocked.
+A working Pi or omp, pending middle row, missing identity, incomplete separator or border pair, or over-tall candidate remains pending or unknown.
+[`harness-adapters`](../.agents/skills/harness-adapters/SKILL.md) owns omp's collapsed-border composer shape and its native-identity gate.
 
 ANSI capture preserves de-emphasized placeholder style.
 `bin/fm-composer-lib.sh` is the fleet-wide owner that strips dim or faint runs and dark truecolor placeholders while retaining bright typed input.
@@ -310,6 +311,7 @@ tests/fm-herdr-session-cleanup.test.sh
 tests/fm-herdr-session-cleanup-e2e.test.sh
 tests/fm-afk-inject-herdr-e2e.test.sh
 tests/fm-afk-pi-herdr-return-e2e.test.sh
+tests/fm-omp-harness.test.sh
 ```
 
 Real Herdr tests use the named lab helper and default-session tripwire.

--- a/docs/tmux-backend.md
+++ b/docs/tmux-backend.md
@@ -60,6 +60,8 @@ Scoping the second source to the foreground process group rather than to the pan
 The same scoping covers multi-process launchers without a special case, so the Pi Launcher path is attributed through its `pi-signed` wrapper and `pi` engine even though its title is the exact foreground command `pi-launcher`.
 Direct executable identities `pi`, `pi-signed`, and `Pi` remain accepted exactly, and similar or prefixed process names are not accepted through those exact Pi-family entries.
 
+A bare `bun` comm (omp's own process; bun renames its title only after tmux's window bookkeeping already captured the pre-rename name) is provisional, never `alive` on its own: it is confirmed by reading the pane's live child-process args for a script path ending in `/omp` before classifying `alive`, otherwise `ambiguous`, never a guessed `alive` or `dead`. [`harness-adapters`](../.agents/skills/harness-adapters/SKILL.md) owns the full quirk.
+
 The CI-enforced portable regression and opt-in real-harness drift guard follow the split owned by `.agents/skills/firstmate-coding-guidelines/SKILL.md`.
 Run the real-harness guard after any harness upgrade and before trusting refreshed evidence.
 
@@ -101,6 +103,7 @@ tests/fm-tmux-agent-liveness.test.sh
 tests/fm-harness-liveness-drift-live-e2e.test.sh
 tests/fm-composer-ghost.test.sh
 tests/fm-kimi-harness.test.sh
+tests/fm-omp-harness.test.sh
 tests/fm-tmux-submit-busy.test.sh
 tests/fm-bootstrap.test.sh
 ```

--- a/docs/turnend-guard.md
+++ b/docs/turnend-guard.md
@@ -100,6 +100,7 @@ That warning uses `bin/fm-supervision-instructions.sh --repair-line`, so it alwa
 - If `jq` is removed after installation, the hook remains silent and exits 0, turn-end wakes stop, and Kimi crews fall back to idle detection.
 - Unreadable hook input remains fail-open.
 - No harness adapter uses a shell ampersand to manufacture supervision.
+- omp remains outside the primary guard integrations above; its `session_stop` event is the natural integration point, but building and verifying that guard was out of scope for the change that added omp as a crewmate/secondmate adapter. [`harness-adapters`](../.agents/skills/harness-adapters/SKILL.md) owns the omp facts, and [`verification/supervision.md`](verification/supervision.md#turn-end-guard) records why.
 
 ## Regression coverage
 

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -124,6 +124,28 @@ Tmux needs the exact `pi-launcher`, `pi-signed`, `pi`, and `Pi` process identiti
 Herdr uses native registered-agent state and needs no process-name branch.
 Zellij has no verified recovery-grade agent process probe, while Orca and cmux do not support secondmate spawns, so those three retain their existing generic ordinary-launch semantics without a new liveness matcher.
 
+omp 17.2.5 (the `@oh-my-pi/pi-coding-agent` bun package under the `omp` bin name) was checked the same way on 2026-08-03, with a real interactive launch in a plain tmux window (automatic-rename left on, unlike a real `fm-spawn` window, to let tmux's own renaming reveal the raw comm value):
+
+```sh
+tmux new-session -d -s ompcomm -c "$scratch_repo"
+tmux send-keys -t ompcomm 'omp --auto-approve' Enter
+tmux display-message -p -t ompcomm '#{pane_current_command}'
+pane_pid=$(tmux list-panes -t ompcomm -F '#{pane_pid}')
+ps -o pid,comm,args -p "$(pgrep -P "$pane_pid" | head -1)"
+```
+
+Observed output:
+
+```text
+bun
+94100 omp             bun /home/srouwen/.bun/bin/omp --auto-approve
+```
+
+`#{pane_current_command}` reported `bun` continuously - stable across six 1-second resamples, a resize, and `refresh-client` while the process stayed the same, and while busy running a tool call - even though `/proc/<pid>/comm` for the exact same live process read `omp` (bun renames its own process title after tmux's window/pane bookkeeping has already captured its pre-rename identity, and tmux never resamples again while the same process keeps running).
+Exiting with `/exit` correctly reverted `#{pane_current_command}` to `bash`, so the alive-to-dead transition tmux liveness recovery depends on remains correct; only the "still alive" display name is stale.
+Because bare `bun` is too generic to trust fleet-wide (any bun-run script would match), `fm_backend_tmux_agent_state` treats a `bun` comm as provisional and confirms it by reading the pane's live child process args for a script path ending in `/omp`, mirroring `fm-harness.sh`'s own node/python/bun bare-interpreter ancestry check; a `bun` pane whose child args do not end in `/omp` classifies `ambiguous`, never `alive`.
+Herdr needed no equivalent branch: `herdr agent get` reported `"agent":"omp"` natively for the same process (see the Herdr section below), so its liveness classifier - which already accepts any registered `agent_status` regardless of the agent name - required no change.
+
 The structural multi-row composer reader, Kimi pointer-delivery path, and OpenCode 1.18.4 busy-queue behavior are pinned by:
 
 ```sh
@@ -402,6 +424,40 @@ The U+2063 operational and routed-request separators were exercised through a re
 FM_SEND_MARKER_HERDR_E2E=1 \
   tests/fm-send-secondmate-marker-herdr-e2e.test.sh
 ```
+
+### omp native identity and composer shape
+
+omp 17.2.5 was checked live on 2026-08-03 inside a guarded lab pane:
+
+```sh
+HERDR_LAB_HELPER=bin/fm-herdr-lab.sh
+"$HERDR_LAB_HELPER" run "$LAB" pane run "$PANE" "omp --auto-approve"
+"$HERDR_LAB_HELPER" run "$LAB" agent get "$PANE"
+```
+
+Observed `agent get` result: `"agent":"omp"` with an ordinary `agent_status` (`idle`/`working`), the same registered-agent shape every other native-identified harness gets - Herdr needed no version gate or new liveness branch for omp, only the composer classifier below.
+
+omp's own composer collapses its top and bottom border into dual-purpose rows instead of the top-border/`│ content │`/bottom-border shape every other verified adapter (including Pi's own separator-pair shape) uses: the top row embeds the model/thinking/dir/branch/context/cost status bar and the standing `▶` prompt/run marker inside its own border (`╭── π > ... ▶───...───╮`), and the bottom row embeds the actual typed text between its own border glyphs (`╰─ <text> ─╯`) with no intervening `│...│` row when the text fits on one line; wrapped text adds genuine `│ text │` rows and moves the final line's overflow into the bottom row the same way.
+This shape is identical under tmux and Herdr (same underlying TUI), reproduced with:
+
+```sh
+tmux send-keys -t "$w" 'omp --auto-approve' Enter
+tmux send-keys -t "$w" 'hello unsent text'
+tmux capture-pane -p -t "$w"
+```
+
+Observed idle/pending/busy captures (abbreviated):
+
+```text
+╭── π  > ⬢ Sonnet 5 · ◒ high > 🗑 .../omp-test1 > ⑂ main ?2 > ◫ 2.8%/1M ⟲ > $0.01 (sub) ▶──...──╮
+╰─                                                                                    ─╯
+
+╭── ... ▶──...──╮
+╰─ hello unsent text                                                                  ─╯
+```
+
+`fm_backend_herdr_omp_composer_find` (`bin/backends/herdr.sh`) and `fm_tmux_omp_composer_find` (`bin/fm-tmux-lib.sh`) both locate this bottom-anchored pair independently (Herdr additionally gates on the native `omp` identity, mirroring the Pi separator-pair gate); a live idle-to-pending-to-cleared cycle and a wrapped multi-line composer were confirmed through both backends' `..._composer_state` entry points during this same session.
+The rendered busy indicator is `Working…` with a single horizontal-ellipsis glyph (U+2026), not three literal dots like Pi's `Working...`, confirmed byte-for-byte with `od -c`; `bin/fm-tmux-lib.sh`'s `FM_TMUX_OMP_BUSY_REGEX_DEFAULT` matches the ellipsis form.
 
 ### Native blocked event
 

--- a/docs/verification/supervision.md
+++ b/docs/verification/supervision.md
@@ -73,6 +73,13 @@ Each pass polled `state/<id>.busy-state` while a real turn ran.
 | Codex | codex-cli 0.145.0 | None usable | See below; classifies `unknown codex-unverified`. |
 | Kimi (standalone) | not installed | None usable | No binary on `PATH`, so the gate stays closed and it classifies `unknown kimi-unverified`. |
 | Grok | 0.2.112 | Isolated rendered-tail fallback | Retained unconverted; the approved audit could not credit a live structured-lifecycle run. |
+| omp | 17.2.5 | Extension `agent_start` / `agent_end` (`willContinue`) with a deferred `ctx.setTimeout(fn, 0)` + `ctx.isIdle()` reconfirmation | See below; the event names and `isIdle()` timing differ from Pi even though omp ships the same underlying `@oh-my-pi/pi-coding-agent` package. |
+
+omp's extension API was probed live on 2026-08-03 with a logging-only probe extension loaded via `-e`, both in `omp -p` print mode and in an interactive TUI pane (tmux and Herdr), against real turns including a tool call, a multi-tool-call turn, and a manual Escape interrupt.
+There is no `agent_settled` event in this version; the closest analogues are `agent_end` (fires once an agent loop ends, carrying an optional `willContinue: true` when an automatic continuation - auto-retry, empty/unexpected-stop retry - is already scheduled) and a new `session_stop` event (fires when a main-agent turn is about to settle, letting a handler request one continuation turn; not used for the busy-state wiring here, closer to the primary-turn-end-guard shape other adapters get through their own hook systems).
+Observed sequence for an ordinary completed turn: `session_start`, `agent_start` (`ctx.isIdle()` reads `false`), one `turn_start`/`turn_end` pair per inner turn, `session_stop`, then `agent_end` (`willContinue=undefined`).
+`ctx.isIdle()` read `false` at the exact synchronous instant `agent_end` fired in every completed-turn observation, then flipped to `true` within the same event-loop tick (`ctx.setTimeout(fn, 0)` observed the flip; `+50ms` and `+500ms` checks stayed `true`) - reading it synchronously inside the `agent_end` handler would permanently misclassify idle as busy, so the busy-state extension defers the check exactly as `bin/fm-spawn.sh` writes it.
+A manual Escape interrupt during a running bash tool call fired `turn_end` then `agent_end` (`willContinue=undefined`, `ctx.isIdle()` reading `true` synchronously that time) with no `session_stop`, so - unlike Claude, which fires no hook on a manual interrupt - omp's own `agent_end` handling covers the interrupt path without a separate firstmate-controlled clear.
 
 Codex was probed two ways, both refused:
 
@@ -122,6 +129,9 @@ ok - grok 0.2.112 (9bbd559437aa) [stable] native Stop kept one session across fa
 ok - grok 0.2.73 (9ff14c43bbe5) [stable] legacy Stop omitted capability, resumed exactly once, and stopped normally
 ok - Grok adaptive Stop real-process matrix passed with exact target cleanup and control-window survival
 ```
+
+**omp is not in this table.** Building and verifying a primary-role turn-end guard plus watcher-arm integration for a firstmate instance running natively on omp - installing the guard, proving `session_stop`'s continuation-request result actually forces one blocking follow-up the way Claude's/Codex's exit-2 `Stop` hooks or Pi's `agent_settled` callback do, and wiring the equivalent of `.pi/extensions/fm-primary-turnend-guard.ts`/`fm-primary-pi-watch.ts` for a secondmate running on omp - was out of scope for the crewmate/scout busy-state work above and was not attempted.
+Only omp's per-task crewmate busy-state extension (the row in the Semantic busy state table) is verified; a secondmate spawned on omp launches bare, with no primary-role extension pair, until this gap is closed.
 
 The same run proved the Claude-compatible Stop entries stay inert under `GROK_AGENT`, the legacy resume carries `GROK_TURNEND_GUARD_ACTIVE=1`, and every replacement root is removed after exact target cleanup while its control window survives.
 

--- a/tests/fm-omp-harness.test.sh
+++ b/tests/fm-omp-harness.test.sh
@@ -1,0 +1,482 @@
+#!/usr/bin/env bash
+# Behavior tests for the verified omp ("Oh My Pi") crewmate/secondmate adapter:
+# harness detection precedence, the semantic busy-state extension's real
+# lifecycle behavior, spawn-time launch flags, the busy-lib trust registration,
+# and the bespoke composer/liveness detection omp's collapsed box shape needs
+# on both the tmux and Herdr backends.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+# shellcheck source=/dev/null
+. "$ROOT/bin/fm-composer-lib.sh"
+# shellcheck source=/dev/null
+. "$ROOT/bin/fm-tmux-lib.sh"
+# shellcheck source=/dev/null
+. "$ROOT/bin/fm-busy-lib.sh"
+
+HARNESS="$ROOT/bin/fm-harness.sh"
+SPAWN="$ROOT/bin/fm-spawn.sh"
+TMP_ROOT=$(fm_test_tmproot fm-omp-harness)
+NODE_BIN=$(command -v node) || fail "test needs node"
+
+# --- detection precedence ----------------------------------------------------
+
+test_omp_detection_precedence_over_claudecode() {
+  local out
+  out=$(OMPCODE=1 CLAUDECODE=1 FM_ROOT_OVERRIDE="$ROOT" "$HARNESS")
+  [ "$out" = omp ] || fail "OMPCODE=1 with CLAUDECODE=1 must detect omp, got '$out'"
+  out=$(CLAUDECODE=1 FM_ROOT_OVERRIDE="$ROOT" "$HARNESS")
+  [ "$out" = claude ] || fail "CLAUDECODE=1 alone (no OMPCODE) must still detect claude, got '$out'"
+  out=$(OMPCODE=1 FM_ROOT_OVERRIDE="$ROOT" "$HARNESS")
+  [ "$out" = omp ] || fail "OMPCODE=1 alone must detect omp, got '$out'"
+  pass "fm-harness.sh checks OMPCODE before CLAUDECODE, so omp never misidentifies as claude"
+}
+
+test_omp_detection_precedence_over_claudecode
+
+# --- busy-lib trust registration --------------------------------------------
+
+test_omp_busy_source_trusted() {
+  local sources
+  sources=$(fm_busy_sources_for_harness omp)
+  case " $sources " in
+    *' omp-ext '*) : ;;
+    *) fail "omp must trust its own omp-ext semantic source, got '$sources'" ;;
+  esac
+  case " $sources " in
+    *' fm-spawn '*) : ;;
+    *) fail "omp must trust the firstmate-owned fm-spawn seed source, got '$sources'" ;;
+  esac
+  fm_busy_source_trusted omp omp-ext || fail "omp-ext must be trusted for harness=omp"
+  fm_busy_source_trusted omp pi-ext && fail "omp must never trust pi's semantic source"
+  fm_busy_source_trusted pi omp-ext && fail "pi must never trust omp's semantic source"
+  pass "omp trusts only its own semantic source, never another adapter's"
+}
+
+test_omp_busy_source_trusted
+
+# --- fm-spawn: launch flags and extension wiring ----------------------------
+
+make_spawn_fakebin() {
+  local dir=$1 fakebin
+  fakebin=$(fm_fakebin "$dir")
+  cat > "$fakebin/tmux" <<'SH'
+#!/usr/bin/env bash
+set -u
+case "$*" in
+  *"#{pane_current_path}"*) printf '%s\n' "${FM_FAKE_PANE_PATH:-}"; exit 0 ;;
+esac
+case "${1:-}" in
+  display-message) printf 'firstmate\n'; exit 0 ;;
+  list-windows) exit 0 ;;
+  has-session|new-session|new-window|kill-window) exit 0 ;;
+  send-keys)
+    prev=
+    literal=
+    for arg in "$@"; do
+      if [ "$prev" = -l ]; then literal=$arg; break; fi
+      prev=$arg
+    done
+    if [ -n "$literal" ]; then
+      case "$literal" in
+        *omp*) printf '%s\n' "$literal" >> "${FM_FAKE_LAUNCH_LOG:?}" ;;
+      esac
+    fi
+    exit 0
+    ;;
+esac
+exit 0
+SH
+  chmod +x "$fakebin/tmux"
+  fm_fake_exit0 "$fakebin" treehouse gh-axi gh
+  printf '%s\n' "$fakebin"
+}
+
+make_omp_spawn_case() {  # <name> <id>
+  local name=$1 id=$2 case_dir home proj wt fakebin
+  case_dir="$TMP_ROOT/$name"
+  home="$case_dir/home"
+  proj="$case_dir/project"
+  wt="$case_dir/wt"
+  fakebin=$(make_spawn_fakebin "$case_dir/fake")
+  mkdir -p "$home/data/$id" "$home/projects" "$home/state" "$home/config"
+  printf 'brief\n' > "$home/data/$id/brief.md"
+  fm_git_worktree "$proj" "$wt" "wt-$name"
+  touch "$home/state/.last-watcher-beat"
+  printf '%s\n' "$case_dir|$home|$proj|$wt|$fakebin"
+}
+
+run_omp_spawn() {  # <home> <proj> <wt> <fakebin> <id> [extra spawn args...]
+  local home=$1 proj=$2 wt=$3 fakebin=$4 id=$5
+  shift 5
+  FM_ROOT_OVERRIDE='' FM_HOME="$home" \
+    FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
+    FM_PROJECTS_OVERRIDE="$home/projects" FM_CONFIG_OVERRIDE="$home/config" \
+    FM_SPAWN_NO_GUARD=1 FM_FAKE_PANE_PATH="$wt" TMUX="fake,1,0" \
+    FM_FAKE_LAUNCH_LOG="$home/launch.log" PATH="$fakebin:$PATH" \
+    "$SPAWN" "$id" "$proj" omp --mode no-mistakes --yolo off "$@" 2>&1
+}
+
+test_omp_spawn_launch_flags_and_extension() {
+  local rec case_dir home proj wt fakebin id out ext launch
+  id=omp-flags-1
+  rec=$(make_omp_spawn_case flags "$id")
+  IFS='|' read -r case_dir home proj wt fakebin <<EOF
+$rec
+EOF
+  out=$(run_omp_spawn "$home" "$proj" "$wt" "$fakebin" "$id" --model sonnet --effort high)
+  expect_code 0 $? "omp spawn should succeed: $out"
+  assert_contains "$out" "spawned $id harness=omp" "omp spawn did not report success"
+  assert_grep "harness=omp" "$home/state/$id.meta" "meta did not record harness=omp"
+
+  launch="$home/launch.log"
+  assert_present "$launch" "omp launch command was never sent to the pane"
+  assert_grep '--auto-approve' "$launch" "omp launch is missing --auto-approve"
+  assert_grep "--model 'sonnet'" "$launch" "omp launch is missing --model"
+  assert_grep "--thinking 'high'" "$launch" "omp launch is missing --thinking"
+  assert_grep '-e ' "$launch" "ship omp launch is missing the -e busy-state extension flag"
+
+  ext="$home/state/$id.omp-ext.ts"
+  assert_present "$ext" "omp spawn did not write the per-task busy-state extension"
+  assert_grep 'agent_start' "$ext" "omp extension does not subscribe to agent_start"
+  assert_grep 'agent_end' "$ext" "omp extension does not subscribe to agent_end"
+  assert_grep 'willContinue' "$ext" "omp extension does not check willContinue"
+  assert_grep 'setTimeout' "$ext" "omp extension does not defer its isIdle() reconfirmation"
+  assert_grep 'turn_end' "$ext" "omp extension does not subscribe to turn_end"
+  assert_no_grep 'agent_settled' "$ext" "omp extension must not reuse Pi's nonexistent agent_settled event"
+  pass "omp ship spawn sends --auto-approve/--model/--thinking/-e and writes the busy-state extension"
+}
+
+test_omp_spawn_secondmate_launches_bare() {
+  local rec case_dir home proj wt fakebin id out launch ext
+  id=omp-secondmate-1
+  rec=$(make_omp_spawn_case secondmate "$id")
+  IFS='|' read -r case_dir home proj wt fakebin <<EOF
+$rec
+EOF
+  mkdir -p "$wt/bin"
+  : > "$wt/.fm-secondmate-home"
+  printf '%s\n' "$id" > "$wt/.fm-secondmate-home"
+  cp "$ROOT/AGENTS.md" "$wt/AGENTS.md" 2>/dev/null || printf 'agents\n' > "$wt/AGENTS.md"
+  out=$(FM_ROOT_OVERRIDE='' FM_HOME="$home" \
+    FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
+    FM_PROJECTS_OVERRIDE="$home/projects" FM_CONFIG_OVERRIDE="$home/config" \
+    FM_SPAWN_NO_GUARD=1 FM_FAKE_PANE_PATH="$wt" TMUX="fake,1,0" \
+    FM_FAKE_LAUNCH_LOG="$home/launch.log" PATH="$fakebin:$PATH" \
+    "$SPAWN" "$id" "$wt" omp --secondmate 2>&1)
+  expect_code 0 $? "omp secondmate spawn should succeed: $out"
+  launch="$home/launch.log"
+  assert_present "$launch" "omp secondmate launch command was never sent to the pane"
+  assert_grep '--auto-approve' "$launch" "omp secondmate launch is missing --auto-approve"
+  assert_no_grep '-e ' "$launch" "omp secondmate must launch bare (no primary-role extension pair is built yet)"
+  ext="$home/state/$id.omp-ext.ts"
+  assert_absent "$ext" "a secondmate spawn must not arm the crewmate busy-state extension"
+  pass "omp secondmate launches bare, with no busy-state extension armed"
+}
+
+test_omp_spawn_launch_flags_and_extension
+test_omp_spawn_secondmate_launches_bare
+
+# --- driving the real generated extension through a plain Node host --------
+#
+# Mirrors tests/fm-busy-adapter-wiring.test.sh's drive_pi_ext: load the actual
+# generated .ts file (type-stripped by Node directly, same as the real omp
+# runtime would resolve it) in a plain Node host, wire a fake ExtensionAPI,
+# and fire real lifecycle handlers, so the artifact, the real
+# bin/fm-busy-event.sh writer, and the real classifier are exercised together
+# with no live omp binary.
+drive_omp_ext() {  # <ext-path> <mode>
+  EXT_PATH="$1" MODE="$2" "$NODE_BIN" --input-type=module 2>&1 <<'EOF'
+import { pathToFileURL } from "node:url";
+const mod = await import(pathToFileURL(process.env.EXT_PATH).href);
+const handlers = {};
+mod.default({ on: (name, fn) => { handlers[name] = fn; } });
+const idle = process.env.MODE !== "end-not-idle";
+const ctx = {
+  isIdle: () => idle,
+  setTimeout: (fn, ms) => setTimeout(fn, ms),
+};
+switch (process.env.MODE) {
+  case "agent-start": await handlers["agent_start"]({}, ctx); break;
+  case "end-idle": await handlers["agent_end"]({}, ctx); break;
+  case "end-not-idle": await handlers["agent_end"]({}, ctx); break;
+  case "end-continuing": await handlers["agent_end"]({ willContinue: true }, ctx); break;
+  case "turn-end": await handlers["turn_end"]({}, ctx); break;
+  default: throw new Error("unknown mode " + process.env.MODE);
+}
+// agent_end defers its idle write one event-loop tick via ctx.setTimeout;
+// give every mode enough real wall-clock time for that deferred write (and
+// the async fm-busy-event.sh execFile call inside it) to land before exit.
+await new Promise((resolve) => setTimeout(resolve, 200));
+EOF
+}
+
+classify_omp() {  # <id> <state-dir>
+  fm_busy_classify tmux fake:w omp "$1" "$2"
+}
+
+test_omp_extension_semantic_lifecycle() {
+  local rec case_dir home proj wt fakebin id out state ext
+  id=omp-lifecycle-1
+  rec=$(make_omp_spawn_case lifecycle "$id")
+  IFS='|' read -r case_dir home proj wt fakebin <<EOF
+$rec
+EOF
+  out=$(run_omp_spawn "$home" "$proj" "$wt" "$fakebin" "$id")
+  expect_code 0 $? "omp spawn should succeed: $out"
+  state="$home/state"
+  ext="$state/$id.omp-ext.ts"
+  assert_present "$ext" "omp spawn did not write the per-task extension"
+
+  out=$(classify_omp "$id" "$state")
+  [ "$out" = "busy fm-spawn" ] || fail "seed after spawn must be 'busy fm-spawn', got '$out'"
+
+  rm -f "$state/$id.turn-ended"
+  out=$(drive_omp_ext "$ext" turn-end) || fail "turn_end drive failed: $out"
+  [ -f "$state/$id.turn-ended" ] || fail "turn_end no longer touches the notification marker"
+  out=$(classify_omp "$id" "$state")
+  [ "$out" = "busy fm-spawn" ] || fail "turn_end must stay a notification, not a state edge, got '$out'"
+
+  out=$(drive_omp_ext "$ext" end-idle) || fail "agent_end (idle) drive failed: $out"
+  out=$(classify_omp "$id" "$state")
+  [ "$out" = "idle omp-ext" ] || fail "agent_end with a confirmed isIdle() must classify 'idle omp-ext', got '$out'"
+
+  out=$(drive_omp_ext "$ext" agent-start) || fail "agent_start drive failed: $out"
+  out=$(classify_omp "$id" "$state")
+  [ "$out" = "busy omp-ext" ] || fail "agent_start must classify 'busy omp-ext', got '$out'"
+
+  out=$(drive_omp_ext "$ext" end-continuing) || fail "agent_end (willContinue) drive failed: $out"
+  out=$(classify_omp "$id" "$state")
+  [ "$out" = "busy omp-ext" ] || fail "agent_end carrying willContinue must never settle idle, got '$out'"
+
+  out=$(drive_omp_ext "$ext" end-not-idle) || fail "agent_end (not yet idle) drive failed: $out"
+  out=$(classify_omp "$id" "$state")
+  [ "$out" = "busy omp-ext" ] || fail "agent_end whose deferred isIdle() reads false must stay busy, got '$out'"
+
+  out=$(drive_omp_ext "$ext" end-idle) || fail "final agent_end drive failed: $out"
+  out=$(classify_omp "$id" "$state")
+  [ "$out" = "idle omp-ext" ] || fail "the final confirmed settle must classify idle, got '$out'"
+  pass "omp extension reports agent_start busy, settles idle only via a deferred confirmed isIdle(), never on willContinue, and keeps turn_end a notification"
+}
+
+test_omp_extension_stale_incarnation_rejected() {
+  local rec case_dir home proj wt fakebin id out state ext
+  id=omp-stale-1
+  rec=$(make_omp_spawn_case stale "$id")
+  IFS='|' read -r case_dir home proj wt fakebin <<EOF
+$rec
+EOF
+  out=$(run_omp_spawn "$home" "$proj" "$wt" "$fakebin" "$id")
+  expect_code 0 $? "omp spawn should succeed: $out"
+  state="$home/state"
+  ext="$state/$id.omp-ext.ts"
+  "$ROOT/bin/fm-busy-event.sh" arm "$state" "$id" >/dev/null
+  out=$(drive_omp_ext "$ext" end-idle) || fail "stale drive failed: $out"
+  out=$(classify_omp "$id" "$state")
+  [ "$out" = "busy fm-spawn" ] || fail "a stale extension event must not change state, got '$out'"
+  pass "omp extension events from a superseded incarnation are rejected as stale"
+}
+
+test_omp_extension_semantic_lifecycle
+test_omp_extension_stale_incarnation_rejected
+
+# --- tmux composer detection: omp's collapsed top/bottom-border box ---------
+#
+# omp's composer has no │ side-border content row in the common (unwrapped)
+# case, so the generic multi-row box scanner never finds it; these pin the
+# bespoke fm_tmux_omp_composer_find/fm_tmux_omp_composer_state path this task
+# added, fed fixed pane fixtures through a fake tmux exactly like
+# tests/fm-composer-ghost.test.sh does for every other adapter's shape.
+make_fake_tmux_composer() {  # <dir> -> fakebin dir
+  local dir=$1 fb
+  fb=$(fm_fakebin "$dir")
+  cat > "$fb/tmux" <<'SH'
+#!/usr/bin/env bash
+set -u
+case "${1:-}" in
+  display-message) printf '0\n'; exit 0 ;;
+  capture-pane) printf '%b' "${FM_FAKE_OMP_PANE:-}"; exit 0 ;;
+esac
+exit 0
+SH
+  chmod +x "$fb/tmux"
+  printf '%s\n' "$fb"
+}
+
+# ANSI-C quoted constants (bash $'...' hex escapes), built once so no test
+# body needs a variable-as-format-string printf (SC2059): omp's own box
+# corners (╭ ╮ ╰ ╯), its "▶" prompt/run marker, and a plain content-row side
+# border (│), concatenated directly into fixed pane fixtures below.
+OMP_BOX_TL=$'\xe2\x95\xad'    # ╭
+OMP_BOX_TR=$'\xe2\x95\xae'    # ╮
+OMP_BOX_BL=$'\xe2\x95\xb0'    # ╰
+OMP_BOX_BR=$'\xe2\x95\xaf'    # ╯
+OMP_BOX_H=$'\xe2\x94\x80'     # ─
+OMP_BOX_V=$'\xe2\x94\x82'     # │
+OMP_MARKER=$'\xe2\x96\xb6'    # ▶
+OMP_TOP_ROW="$OMP_BOX_TL$OMP_BOX_H$OMP_BOX_H $OMP_MARKER$OMP_BOX_H$OMP_BOX_H$OMP_BOX_H$OMP_BOX_TR"
+
+test_omp_tmux_composer_empty() {
+  local fb pane out
+  fb=$(make_fake_tmux_composer "$TMP_ROOT/tmux-empty")
+  pane="$OMP_TOP_ROW"$'\n'"$OMP_BOX_BL$OMP_BOX_H                                                 $OMP_BOX_H$OMP_BOX_BR"$'\n'
+  out=$(FM_FAKE_OMP_PANE="$pane" PATH="$fb:$PATH" fm_tmux_composer_state fakepane)
+  [ "$out" = empty ] || fail "an all-blank omp composer must classify empty, got '$out'"
+  pass "omp's collapsed idle composer classifies empty structurally"
+}
+
+test_omp_tmux_composer_pending() {
+  local fb pane out
+  fb=$(make_fake_tmux_composer "$TMP_ROOT/tmux-pending")
+  pane="$OMP_TOP_ROW"$'\n'"$OMP_BOX_BL$OMP_BOX_H hello unsent text                               $OMP_BOX_H$OMP_BOX_BR"$'\n'
+  out=$(FM_FAKE_OMP_PANE="$pane" PATH="$fb:$PATH" fm_tmux_composer_state fakepane)
+  [ "$out" = pending ] || fail "real typed text embedded in omp's bottom border must classify pending, got '$out'"
+  pass "omp's bottom-border-embedded text classifies pending structurally"
+}
+
+test_omp_tmux_composer_wrapped_pending() {
+  local fb pane out
+  fb=$(make_fake_tmux_composer "$TMP_ROOT/tmux-wrapped")
+  pane="$OMP_TOP_ROW"$'\n'"$OMP_BOX_V first line of a wrapped message                $OMP_BOX_V"$'\n'"$OMP_BOX_BL$OMP_BOX_H second line overflow                            $OMP_BOX_H$OMP_BOX_BR"$'\n'
+  out=$(FM_FAKE_OMP_PANE="$pane" PATH="$fb:$PATH" fm_tmux_composer_state fakepane)
+  [ "$out" = pending ] || fail "a wrapped omp composer (top / │ / bottom) must classify pending, got '$out'"
+  pass "omp's wrapped multi-row composer is still located and classified pending"
+}
+
+test_omp_tmux_composer_ignores_unrelated_box() {
+  local fb pane plain out
+  fb=$(make_fake_tmux_composer "$TMP_ROOT/tmux-unrelated")
+  pane="$OMP_BOX_TL$OMP_BOX_H$OMP_BOX_H$OMP_BOX_H$OMP_BOX_TR"$'\n''$ echo hi'$'\n'"$OMP_BOX_BL$OMP_BOX_H$OMP_BOX_H$OMP_BOX_H$OMP_BOX_BR"$'\n'
+  plain=$(printf '%s' "$pane" | fm_composer_strip_ansi)
+  out=$(FM_FAKE_OMP_PANE="$pane" PATH="$fb:$PATH" fm_tmux_omp_composer_state "$pane" "$plain")
+  [ "$out" = no-match ] || fail "a box with no omp prompt marker in its top row must never be mistaken for omp's composer, got '$out'"
+  pass "a decorative box with no omp prompt marker is never mistaken for the composer"
+}
+
+test_omp_tmux_composer_empty
+test_omp_tmux_composer_pending
+test_omp_tmux_composer_wrapped_pending
+test_omp_tmux_composer_ignores_unrelated_box
+
+# --- Herdr composer detection: native identity + the same collapsed shape --
+
+JQ_BIN=$(command -v jq) || fail "test needs jq"
+
+# shellcheck source=/dev/null
+. "$ROOT/bin/backends/herdr.sh"
+
+make_fake_herdr() {  # <dir> -> fakebin dir
+  local dir=$1 fb
+  fb=$(fm_fakebin "$dir")
+  cat > "$fb/herdr" <<'SH'
+#!/usr/bin/env bash
+set -u
+case "${1:-} ${2:-}" in
+  "status --json") printf '{"server":{"running":true},"client":{"protocol":17}}\n'; exit 0 ;;
+  "agent get") printf '{"result":{"agent":{"agent":"%s","agent_status":"%s"}}}\n' "${FM_FAKE_HERDR_AGENT:-omp}" "${FM_FAKE_HERDR_STATUS:-idle}"; exit 0 ;;
+  "pane read") printf '%b' "${FM_FAKE_OMP_PANE:-}"; exit 0 ;;
+esac
+exit 0
+SH
+  chmod +x "$fb/herdr"
+  # jq must be real (used to parse status/agent JSON); put its real directory
+  # first so it resolves ahead of anything else on the caller's PATH.
+  printf '%s\n' "$JQ_BIN_DIR:$fb"
+}
+JQ_BIN_DIR=$(dirname "$JQ_BIN")
+
+test_omp_herdr_composer_empty_with_native_identity() {
+  local fb pane out
+  fb=$(make_fake_herdr "$TMP_ROOT/herdr-empty")
+  pane="$OMP_TOP_ROW"$'\n'"$OMP_BOX_BL$OMP_BOX_H                                                 $OMP_BOX_H$OMP_BOX_BR"$'\n'
+  out=$(FM_FAKE_OMP_PANE="$pane" FM_FAKE_HERDR_AGENT=omp FM_FAKE_HERDR_STATUS=idle \
+    PATH="$fb:$PATH" fm_backend_herdr_composer_state 'fmtest:w1:p1')
+  [ "$out" = empty ] || fail "an all-blank omp composer under Herdr must classify empty, got '$out'"
+  pass "Herdr: omp's collapsed idle composer classifies empty with native identity confirmed"
+}
+
+test_omp_herdr_composer_pending_with_native_identity() {
+  local fb pane out
+  fb=$(make_fake_herdr "$TMP_ROOT/herdr-pending")
+  pane="$OMP_TOP_ROW"$'\n'"$OMP_BOX_BL$OMP_BOX_H hello unsent text                               $OMP_BOX_H$OMP_BOX_BR"$'\n'
+  out=$(FM_FAKE_OMP_PANE="$pane" FM_FAKE_HERDR_AGENT=omp FM_FAKE_HERDR_STATUS=idle \
+    PATH="$fb:$PATH" fm_backend_herdr_composer_state 'fmtest:w1:p1')
+  [ "$out" = pending ] || fail "real typed text under Herdr must classify pending, got '$out'"
+  pass "Herdr: omp's bottom-border-embedded text classifies pending"
+}
+
+test_omp_herdr_composer_refuses_without_native_identity() {
+  local fb pane out
+  fb=$(make_fake_herdr "$TMP_ROOT/herdr-refuse")
+  pane="$OMP_TOP_ROW"$'\n'"$OMP_BOX_BL$OMP_BOX_H                                                 $OMP_BOX_H$OMP_BOX_BR"$'\n'
+  out=$(FM_FAKE_OMP_PANE="$pane" FM_FAKE_HERDR_AGENT=claude FM_FAKE_HERDR_STATUS=idle \
+    PATH="$fb:$PATH" fm_backend_herdr_composer_state 'fmtest:w1:p1')
+  [ "$out" = unknown ] || fail "the omp composer shape must never authorize injection without the native omp identity, got '$out'"
+  pass "Herdr: an omp-shaped box with a non-omp native identity never classifies empty/pending"
+}
+
+test_omp_herdr_composer_empty_with_native_identity
+test_omp_herdr_composer_pending_with_native_identity
+test_omp_herdr_composer_refuses_without_native_identity
+
+# --- tmux liveness: the "bun" comm quirk ------------------------------------
+#
+# omp ships as a bun-run script; tmux's #{pane_current_command} reports "bun"
+# for a running omp process, not "omp" (verified live, see
+# docs/verification/runtime-backends.md). Bare "bun" is too generic to trust
+# fleet-wide, so fm_backend_tmux_agent_state confirms it via the pane's live
+# child process args before classifying alive.
+
+# shellcheck disable=SC2034 # read by the sourced backends/tmux.sh itself
+FM_BACKEND_LIB_DIR="$ROOT/bin"
+# shellcheck source=/dev/null
+. "$ROOT/bin/backends/tmux.sh"
+
+make_fake_tmux_liveness() {  # <dir> <comm> <child-args> -> fakebin dir
+  local dir=$1 comm=$2 args=$3 fb
+  fb=$(fm_fakebin "$dir")
+  cat > "$fb/tmux" <<SH
+#!/usr/bin/env bash
+set -u
+case "\${1:-}" in
+  list-windows) printf 'testwin\n'; exit 0 ;;
+  display-message)
+    for a in "\$@"; do case "\$a" in *pane_current_command*) printf '%s\n' "$comm"; exit 0 ;; esac; done
+    for a in "\$@"; do case "\$a" in *pane_pid*) printf '4242\n'; exit 0 ;; esac; done
+    printf '\n'; exit 0
+    ;;
+esac
+exit 0
+SH
+  chmod +x "$fb/tmux"
+  cat > "$fb/ps" <<SH
+#!/usr/bin/env bash
+case "\$*" in
+  *--ppid*4242*) printf '%s\n' "$args" ;;
+esac
+exit 0
+SH
+  chmod +x "$fb/ps"
+  printf '%s\n' "$fb"
+}
+
+test_omp_tmux_liveness_confirms_bun_omp_child() {
+  local fb out
+  fb=$(make_fake_tmux_liveness "$TMP_ROOT/liveness-omp" bun 'bun /home/user/.bun/bin/omp --auto-approve')
+  out=$(PATH="$fb:$PATH" fm_backend_tmux_agent_state "sess:testwin")
+  [ "$out" = alive ] || fail "a bun comm whose child args end in /omp must classify alive, got '$out'"
+  pass "tmux liveness confirms a bun-reported omp process via its child args"
+}
+
+test_omp_tmux_liveness_refuses_unconfirmed_bun() {
+  local fb out
+  fb=$(make_fake_tmux_liveness "$TMP_ROOT/liveness-other" bun 'bun /home/user/some/other/tool.js')
+  out=$(PATH="$fb:$PATH" fm_backend_tmux_agent_state "sess:testwin")
+  [ "$out" = ambiguous ] || fail "a bun comm whose child args do NOT name omp must never be guessed alive, got '$out'"
+  pass "tmux liveness never guesses alive for an unconfirmed bun process"
+}
+
+test_omp_tmux_liveness_confirms_bun_omp_child
+test_omp_tmux_liveness_refuses_unconfirmed_bun

--- a/tests/fm-omp-harness.test.sh
+++ b/tests/fm-omp-harness.test.sh
@@ -451,10 +451,18 @@ esac
 exit 0
 SH
   chmod +x "$fb/tmux"
+  cat > "$fb/pgrep" <<'SH'
+#!/usr/bin/env bash
+case "$*" in
+  *-P*4242*) printf '4343\n' ;;
+esac
+exit 0
+SH
+  chmod +x "$fb/pgrep"
   cat > "$fb/ps" <<SH
 #!/usr/bin/env bash
 case "\$*" in
-  *--ppid*4242*) printf '%s\n' "$args" ;;
+  *4343*) printf '%s\n' "$args" ;;
 esac
 exit 0
 SH


### PR DESCRIPTION
## Summary

Adds `omp` ("Oh My Pi", binary `omp`, bun-installed via `@oh-my-pi/pi-coding-agent`) as a fully verified crewmate/secondmate harness adapter, to the same bar as `claude`, `codex`, `opencode`, `pi`/`pi-signed`, `grok`, and `kimi`. Every fact below was established empirically (per `CONTRIBUTING.md`'s harness-adapter rule), never assumed from `omp`'s shared ancestry with Pi.

- `bin/fm-harness.sh`: detects `omp` from its own `OMPCODE=1` env marker, checked **before** `CLAUDECODE` — omp sets both, verified by unsetting `CLAUDECODE` first and observing omp itself re-set it.
- `bin/fm-spawn.sh`: ship/scout launch template (`--auto-approve` + the busy-state extension via `-e`), bare secondmate launch, `--model`/`--thinking` flag wiring, and the per-task busy-state extension file.
- `bin/fm-busy-lib.sh`: registers omp's own trusted semantic busy source (`omp-ext`).
- `bin/fm-tmux-lib.sh` / `bin/backends/herdr.sh` / `bin/backends/tmux.sh`: bespoke composer detection for omp's collapsed top/bottom-border box shape (fails the existing generic multi-row scanner), plus a confirmed-not-guessed tmux liveness check for the `bun` comm quirk.
- `.agents/skills/harness-adapters/SKILL.md`, `AGENTS.md` §4, `docs/verification/{supervision,runtime-backends}.md`: fact-table documentation and dated empirical evidence.
- `tests/fm-omp-harness.test.sh`: drives the real generated extension through a plain Node host and exercises every script through real behavior, never asserting on implementation bytes.

Key empirical findings that shaped the implementation:
- omp's extension API has **no `agent_settled` event** (unlike Pi in this version). The verified idle signal is `agent_end` with no `willContinue`, reconfirmed via a deferred `ctx.setTimeout(fn, 0)` + `ctx.isIdle()` check — `isIdle()` reads `false` synchronously at the exact instant `agent_end` fires but flips `true` within the same tick.
- A manual Escape interrupt fires `agent_end` naturally (unlike Claude), so no separate firstmate-controlled interrupt-clear path was needed.
- Herdr natively recognizes `omp` (`agent:"omp"` from `agent get`), so its liveness classifier needed no change; tmux's `#{pane_current_command}` reports `bun` (a stable rendering quirk, not a race), confirmed via child-process args before classifying `alive`.
- No trust dialog was observed across four fresh git repositories.

**Known gap, flagged explicitly rather than guessed at:** omp's own primary-role turn-end-guard/watcher-arm integration (the equivalent of Pi's `fm-primary-turnend-guard.ts`/`fm-primary-pi-watch.ts`) is out of scope and not built. A secondmate spawned on omp launches bare, with no primary-role extension pair. See the `harness-adapters` SKILL.md `omp` section and `docs/verification/supervision.md`'s "Turn-end guard" note.

## Test plan

- [x] `bin/fm-lint.sh` passes clean
- [x] `bin/fm-doc-audience-check.sh` passes clean
- [x] `tests/fm-omp-harness.test.sh` (15 cases) passes, covering harness detection precedence, the real generated busy-state extension's lifecycle behavior, spawn launch flags, tmux/Herdr composer detection, and tmux liveness confirmation
- [x] Full related regression suite re-run with no regressions (composer, busy-adapter-wiring, secondmate-harness, daemon, teardown, bootstrap, dispatch-profile tests)
- [x] Validated through the `no-mistakes` pipeline: intent, rebase, review, test, and document steps all passed clean (0 findings); lint passed clean after installing ShellCheck 0.11.0 in this environment

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>
</details>
<details>
<summary>✅ **Rebase** - passed</summary>
</details>
<details>
<summary>✅ **Review** - completed</summary>
</details>
<details>
<summary>✅ **Test** - passed</summary>
</details>
<details>
<summary>✅ **Document** - passed</summary>
</details>
<details>
<summary>✅ **Lint** - passed</summary>
</details>
<details>
<summary>✅ **Push** - passed</summary>
</details>
