### PR TITLE
Fix Orca composite worktree endpoint validation

### DIFF
--- a/bin/backends/orca.sh
+++ b/bin/backends/orca.sh
@@ -128,6 +128,13 @@ fm_backend_orca_repo_ensure() {  # <project-path>
   printf '%s' "$repo_id"
 }
 
+fm_backend_orca_worktree_id_for_cli() {  # <id-or-id-and-path>
+  case "$1" in
+    *::*) printf '%s' "${1%%::*}" ;;
+    *) printf '%s' "$1" ;;
+  esac
+}
+
 fm_backend_orca_worktree_create() {  # <project-path> <name>
   local project=$1 name=$2 repo_id out wt_id wt_path terminal
   repo_id=$(fm_backend_orca_repo_ensure "$project") || return 1

--- a/bin/backends/orca.sh
+++ b/bin/backends/orca.sh
@@ -155,7 +155,8 @@ fm_backend_orca_worktree_create() {  # <project-path> <name>
 }
 
 fm_backend_orca_terminal_create() {  # <worktree-id> <title>
-  local worktree_id=$1 title=$2 out terminal
+  local worktree_id title=$2 out terminal
+  worktree_id=$(fm_backend_orca_worktree_id_for_cli "${1:-}")
   fm_backend_orca_tool_check || return 1
   out=$(orca terminal create --worktree "id:$worktree_id" --title "$title" --json) || return 1
   terminal=$(printf '%s' "$out" | fm_backend_orca_json_get terminal-handle) || {
@@ -178,14 +179,16 @@ fm_backend_orca_send_literal() {  # <terminal-id> <text>
 }
 
 fm_backend_orca_remove_worktree() {  # <worktree-id>
-  local worktree_id=${1:-}
+  local worktree_id
+  worktree_id=$(fm_backend_orca_worktree_id_for_cli "${1:-}")
   [ -n "$worktree_id" ] || { echo "error: missing Orca worktree id; cannot remove worktree" >&2; return 1; }
   fm_backend_orca_tool_check || return 1
   fm_backend_orca_run_json orca worktree rm --worktree "id:$worktree_id" --force --json
 }
 
 fm_backend_orca_worktree_path() {
-  local worktree_id=${1:-} out path
+  local worktree_id out path
+  worktree_id=$(fm_backend_orca_worktree_id_for_cli "${1:-}")
   [ -n "$worktree_id" ] || { echo "error: missing Orca worktree id; cannot resolve worktree path" >&2; return 1; }
   fm_backend_orca_tool_check || return 1
   out=$(orca worktree show --worktree "id:$worktree_id" --json) || return 1

--- a/bin/fm-backend.sh
+++ b/bin/fm-backend.sh
@@ -383,6 +383,38 @@ fm_backend_endpoint_atom_valid() {  # <value>
   esac
 }
 
+# Orca worktree metadata is currently recorded as <id>::<absolute-path> so
+# cleanup can retain the creation-time path binding while older records carry
+# only the id. Validate both forms without allowing path or shell metacharacters.
+fm_backend_orca_worktree_id_valid() {  # <value>
+  local value=$1 id path
+  case "$value" in
+    *::*::*|::*|*::) return 1 ;;
+    *::*)
+      id=${value%%::*}
+      path=${value#*::}
+      fm_backend_endpoint_atom_valid "$id" || return 1
+      case "$path" in
+        /*) ;;
+        *) return 1 ;;
+      esac
+      case "$path" in
+        ''|*[!A-Za-z0-9._/@%+-]*|*/../*|*/..|*/./*|*/.) return 1 ;;
+      esac
+      ;;
+    *)
+      fm_backend_endpoint_atom_valid "$value" || return 1
+      ;;
+  esac
+}
+
+fm_backend_orca_worktree_id_for_cli() {  # <id-or-id-and-path>
+  case "$1" in
+    *::*) printf '%s' "${1%%::*}" ;;
+    *) printf '%s' "$1" ;;
+  esac
+}
+
 fm_backend_validate_task_endpoint() {  # <meta-file> <task-id>
   local meta=$1 id=$2 backend_count backend window worktree project binding_count binding
   local session pane recorded_session workspace tab terminal worktree_id surface
@@ -503,7 +535,7 @@ fm_backend_validate_task_endpoint() {  # <meta-file> <task-id>
       }
       if [ "$window" != "fm-$id" ] \
         || ! fm_backend_endpoint_atom_valid "$terminal" \
-        || ! fm_backend_endpoint_atom_valid "$worktree_id"; then
+        || ! fm_backend_orca_worktree_id_valid "$worktree_id"; then
         echo "REFUSED: Orca endpoint metadata for task $id is malformed or inconsistent; preserving task state." >&2
         return 1
       fi
@@ -761,7 +793,7 @@ fm_backend_remove_worktree() {  # <backend> <worktree-id>
   shift
   fm_backend_source "$backend" || return 1
   case "$backend" in
-    orca) fm_backend_orca_remove_worktree "$@" ;;
+    orca) set -- "$(fm_backend_orca_worktree_id_for_cli "${1:-}")"; fm_backend_orca_remove_worktree "$@" ;;
     *) echo "error: backend '$backend' does not own task worktrees" >&2; return 1 ;;
   esac
 }
@@ -771,7 +803,7 @@ fm_backend_worktree_path() {  # <backend> <worktree-id>
   shift
   fm_backend_source "$backend" || return 1
   case "$backend" in
-    orca) fm_backend_orca_worktree_path "$@" ;;
+    orca) set -- "$(fm_backend_orca_worktree_id_for_cli "${1:-}")"; fm_backend_orca_worktree_path "$@" ;;
     *) echo "error: backend '$backend' does not own task worktrees" >&2; return 1 ;;
   esac
 }

--- a/bin/fm-backend.sh
+++ b/bin/fm-backend.sh
@@ -408,13 +408,6 @@ fm_backend_orca_worktree_id_valid() {  # <value>
   esac
 }
 
-fm_backend_orca_worktree_id_for_cli() {  # <id-or-id-and-path>
-  case "$1" in
-    *::*) printf '%s' "${1%%::*}" ;;
-    *) printf '%s' "$1" ;;
-  esac
-}
-
 fm_backend_validate_task_endpoint() {  # <meta-file> <task-id>
   local meta=$1 id=$2 backend_count backend window worktree project binding_count binding
   local session pane recorded_session workspace tab terminal worktree_id surface

--- a/bin/fm-backend.sh
+++ b/bin/fm-backend.sh
@@ -793,7 +793,7 @@ fm_backend_remove_worktree() {  # <backend> <worktree-id>
   shift
   fm_backend_source "$backend" || return 1
   case "$backend" in
-    orca) set -- "$(fm_backend_orca_worktree_id_for_cli "${1:-}")"; fm_backend_orca_remove_worktree "$@" ;;
+    orca) fm_backend_orca_remove_worktree "$@" ;;
     *) echo "error: backend '$backend' does not own task worktrees" >&2; return 1 ;;
   esac
 }
@@ -803,7 +803,7 @@ fm_backend_worktree_path() {  # <backend> <worktree-id>
   shift
   fm_backend_source "$backend" || return 1
   case "$backend" in
-    orca) set -- "$(fm_backend_orca_worktree_id_for_cli "${1:-}")"; fm_backend_orca_worktree_path "$@" ;;
+    orca) fm_backend_orca_worktree_path "$@" ;;
     *) echo "error: backend '$backend' does not own task worktrees" >&2; return 1 ;;
   esac
 }

--- a/docs/orca-backend.md
+++ b/docs/orca-backend.md
@@ -36,12 +36,14 @@ The normal isolation and unlanded-work refusal rules still apply.
 backend=orca
 window=fm-<id>
 terminal=<orca terminal handle>
-orca_worktree_id=<orca worktree id>
+orca_worktree_id=<orca worktree id>::<absolute Orca worktree path>
 worktree=<absolute Orca worktree path>
 ```
 
 `window=` remains the caller-facing Firstmate alias.
 `terminal=` and `orca_worktree_id=` are the backend authority used by operation and cleanup paths.
+The composite worktree value keeps the Orca id and creation-time absolute path together for cleanup identity checks.
+Cleanup also accepts older id-only values for compatibility.
 
 ## Current lifecycle and safety
 

--- a/docs/orca-backend.md
+++ b/docs/orca-backend.md
@@ -79,6 +79,7 @@ It never raw-deletes an Orca worktree.
 tests/fm-backend-orca.test.sh
 tests/fm-backend.test.sh
 tests/fm-bootstrap.test.sh
+tests/fm-teardown-endpoint-safety.test.sh
 ```
 
 [`verification/runtime-backends.md`](verification/runtime-backends.md#orca) records the real readiness and response-shape smoke.

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -92,6 +92,7 @@ Expected submit matrix: proven pending plus busy is accepted as queued; proven p
 ### Cleanup endpoint identity
 
 The cleanup identity boundary was validated on 2026-07-28 with tmux 3.6a and metadata fixtures for every supported backend.
+On 2026-08-03 the Orca fixture matrix was extended to the composite `orca_worktree_id=<id>::<absolute path>` records written by `fm-spawn.sh`, with path-traversal, whitespace, semicolon, and quote composites refusing.
 
 ```sh
 tests/fm-teardown-endpoint-safety.test.sh

--- a/tests/fm-teardown-endpoint-safety.test.sh
+++ b/tests/fm-teardown-endpoint-safety.test.sh
@@ -143,7 +143,8 @@ test_supported_backend_endpoint_records_validate() {
   for garbage in \
     "284dc4d4-dd13-4a07-9406-b5cd59a55aeb::$dir/worktree/../escape" \
     "284dc4d4-dd13-4a07-9406-b5cd59a55aeb::$dir/worktree with-space" \
-    "284dc4d4-dd13-4a07-9406-b5cd59a55aeb::$dir/worktree;touch"; do
+    "284dc4d4-dd13-4a07-9406-b5cd59a55aeb::$dir/worktree;touch" \
+    "284dc4d4-dd13-4a07-9406-b5cd59a55aeb::$dir/worktree\"x"; do
     fm_write_meta "$dir/home/state/orca-garbage-task.meta" \
       "window=fm-orca-garbage-task" "endpoint_task_id=orca-garbage-task" \
       "terminal=term_garbage" "worktree=$dir/worktree" "project=$dir/project" \

--- a/tests/fm-teardown-endpoint-safety.test.sh
+++ b/tests/fm-teardown-endpoint-safety.test.sh
@@ -130,6 +130,29 @@ test_supported_backend_endpoint_records_validate() {
   fm_backend_validate_task_endpoint "$dir/home/state/$id.meta" "$id" || fail "valid Orca endpoint refused"
   [ "$FM_BACKEND_VALIDATED_TARGET" = term-7 ] || fail "Orca validation did not select its terminal"
 
+  id=orca-composite-task
+  fm_write_meta "$dir/home/state/$id.meta" \
+    "window=fm-$id" "endpoint_task_id=$id" "terminal=term_7f3e" \
+    "worktree=$dir/worktree" "project=$dir/project" "backend=orca" \
+    "orca_worktree_id=284dc4d4-dd13-4a07-9406-b5cd59a55aeb::$dir/worktree"
+  fm_backend_validate_task_endpoint "$dir/home/state/$id.meta" "$id" \
+    || fail "fm-spawn-written composite Orca endpoint refused"
+  [ "$FM_BACKEND_VALIDATED_TARGET" = term_7f3e ] \
+    || fail "composite Orca validation did not select its terminal"
+
+  for garbage in \
+    "284dc4d4-dd13-4a07-9406-b5cd59a55aeb::$dir/worktree/../escape" \
+    "284dc4d4-dd13-4a07-9406-b5cd59a55aeb::$dir/worktree with-space" \
+    "284dc4d4-dd13-4a07-9406-b5cd59a55aeb::$dir/worktree;touch"; do
+    fm_write_meta "$dir/home/state/orca-garbage-task.meta" \
+      "window=fm-orca-garbage-task" "endpoint_task_id=orca-garbage-task" \
+      "terminal=term_garbage" "worktree=$dir/worktree" "project=$dir/project" \
+      "backend=orca" "orca_worktree_id=$garbage"
+    if fm_backend_validate_task_endpoint "$dir/home/state/orca-garbage-task.meta" orca-garbage-task; then
+      fail "malformed composite Orca endpoint unexpectedly validated: $garbage"
+    fi
+  done
+
   id=cmux-task
   fm_write_meta "$dir/home/state/$id.meta" \
     "window=workspace-1:surface-2" "endpoint_task_id=$id" "worktree=$dir/worktree" "project=$dir/project" \


### PR DESCRIPTION
## Summary
- Accept and strictly validate Orca `<id>::<absolute-path>` worktree metadata while preserving id-only compatibility.
- Normalize composite IDs at the Orca adapter boundary before CLI operations.
- Add regression coverage for healthy metadata and malformed traversal/injection variants.

## Validation
- no-mistakes review, tests, documentation, and lint completed.
- Existing unrelated Orca metadata-publication test failure was identified as pre-existing.