### PR TITLE
fix(bin): stop the captain decision queue compounding

### DIFF
--- a/.agents/skills/ask-user-authority/SKILL.md
+++ b/.agents/skills/ask-user-authority/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: ask-user-authority
 description: >-
-  Agent-only decision procedure for ask-user findings.
-  Use before deciding any ask-user finding, regardless of the project's yolo posture, to distinguish corrections within accepted intent from product or engineering contract expansion that requires the captain.
+  Agent-only decision procedure for ask-user findings and for any other question about to be escalated to the captain.
+  Use before deciding any ask-user finding, regardless of the project's yolo posture, and before registering a captain decision from an investigation or review, to distinguish corrections within accepted intent from product or engineering contract expansion that requires the captain.
 user-invocable: false
 metadata:
   internal: true
@@ -10,8 +10,41 @@ metadata:
 
 # ask-user-authority
 
-This skill is the single owner of the decision procedure for ask-user findings.
+This skill is the single owner of the escalate-or-decide boundary.
+It governs every question about to reach the captain, whether it arrived as an ask-user finding from a validation gate or as an unresolved choice found by an investigation or review, which `decision-hold-lifecycle` routes here before registering anything.
 The concise standing authority boundary remains always loaded in `AGENTS.md` section 7.
+
+## The bar for asking
+
+Escalation is expensive and the queue compounds, so the default is to decide.
+Ask only when the answer is genuinely not derivable from the accepted contract, the code, and the evidence in front of you.
+
+Apply this test before escalating anything:
+
+1. Is there a defensible answer a careful engineer would reach from the accepted contract and the evidence?
+   If yes, take it and record the reasoning; a difficult or debatable call is still yours.
+2. Would the two candidate answers commit the project to materially different products, costs, or accepted risks?
+   If yes, it is the captain's.
+3. Does answering it require preference the evidence cannot supply, such as which of two defensible products to build, how much risk or spend to accept, or what an external commitment should say?
+   If yes, it is the captain's.
+4. Is it destructive, irreversible, or genuinely security-sensitive?
+   If yes, it is the captain's under the stronger existing boundary.
+
+An engineering trade-off with a defensible answer is Firstmate's call even when the trade-off is real, the alternatives are close, or getting it wrong would cost rework.
+Difficulty, reviewer emphasis, and the presence of two options are not evidence that a question belongs to the captain.
+Uncertainty about which answer is best is the ordinary condition of engineering work, not grounds to escalate.
+
+Worked examples on both sides:
+
+- The order in which two related pull requests should land, where one order is clearly safer, is Firstmate's call: the evidence settles it and neither order changes what gets built.
+- Where a piece of infrastructure should live within an accepted architecture is Firstmate's call, even when two placements are defensible, because the choice does not change the product's behavior or its accepted risk.
+- Whether to fix a defect in place or split it across two pull requests is Firstmate's call when both routes deliver the same accepted behavior; it becomes the captain's only if splitting changes what ships or when.
+- Which of two documents is authoritative for a team's rules is the captain's: it is a standing policy choice about how the team works, and the evidence cannot rank the options.
+- Accepting a known risk in order to ship sooner is the captain's, because it trades product risk for time.
+- Anything that changes an outward-facing commitment, a cost, or a security posture is the captain's.
+
+When a question fails this bar, do not register it as a captain decision and do not park the work waiting for one.
+Decide it, record the reasoning where the work lives, and continue.
 
 ## Decide who has authority
 

--- a/.agents/skills/bearings/SKILL.md
+++ b/.agents/skills/bearings/SKILL.md
@@ -71,6 +71,7 @@ Every `/bearings` chat response renders EXACTLY these four sections, in THIS ord
 
 1. **Captain's Call** - ONLY items that need the captain's own action now: a decision to make, a PR to approve or merge, a credential or login to provide, or a blocker only the captain can clear.
    Empty-state: "Nothing needs your action right now."
+   A decision the snapshot marks `aging` leads this section and renders as still waiting since its date, for example "still waiting since 3 March"; it is never re-asked as though it were new.
 2. **Recently Landed** - the bounded current recent-completions baseline: merged PRs, completed scouts, and finished local-only merges across the main fleet and every registered secondmate home.
    Empty-state: "No recent completions are in the current baseline."
 3. **Underway** - live work progressing on its own, one line of current state per direct report.

--- a/.agents/skills/decision-hold-lifecycle/SKILL.md
+++ b/.agents/skills/decision-hold-lifecycle/SKILL.md
@@ -16,12 +16,24 @@ This skill is the single policy owner for unresolved captain decisions discovere
 
 Every unresolved decision that belongs to the captain and is discovered while producing, reading, presenting, or ending an investigation or visual review must become a structured captain-held work item in the authoritative backlog of the home that owns the originating work before that work or review may be treated as complete.
 The agent performs the semantic inventory because scripts must not infer decisions from report prose, visual-review artifacts, terminal output, or chat.
-Give each distinct unresolved decision a stable privacy-safe key, register it through `bin/fm-decision-hold.sh hold`, and use the same key on retry so registration is idempotent while different decisions retain different durable identities.
+Apply `ask-user-authority`'s bar for asking to every candidate first; a question that fails that bar is Firstmate's to decide and must not be registered here at all.
+Give each remaining distinct unresolved decision a stable privacy-safe key, register it through `bin/fm-decision-hold.sh hold`, and use the same key on retry so registration is idempotent while different decisions retain different durable identities.
+Before a new identity is created the script puts the home's open captain decisions in front of you and refuses, because a second key covering an already-open question is how this queue compounds.
+Read that listing and judge it semantically: an earlier review of the same pull request, subsystem, or policy question usually already owns the decision under a different key.
+When it does, use `bin/fm-decision-hold.sh fold` to add this pass's finding to the existing decision instead of opening a second one, then complete against that fold.
+Re-run with `--distinct` only when the question is genuinely different from every decision in that listing; the attestation is recorded in the new decision.
 After inventorying the whole report and review surface, run `bin/fm-decision-hold.sh complete` with every unresolved key, or with `--none` only when the reviewed surface contains no unresolved captain decision.
 A completed investigation and an ended visual review use this same owner and completion command; a visual tool, including Lavish, never owns a parallel completion policy.
 Run the command in the originating work's authoritative `FM_HOME`; main-home work creates main-home holds, and secondmate-owned work creates holds in that secondmate home's backlog rather than copying them into the main backlog.
 Do not close a hold merely because the originating investigation completed, its report was archived, its visual review ended, or its task was torn down.
-When the captain's answer authorizes follow-up work, the hold remains the authoritative Captain's Call item until that answer is durably recorded, dependent work is created in the same backlog and blocked by the hold, and `bin/fm-decision-hold.sh resolve` routes the answer by clearing those dependency edges before closing the hold.
+The hold remains the authoritative Captain's Call item until the captain's answer is durably recorded by `bin/fm-decision-hold.sh resolve`, which closes it.
+Record the answer in the same turn it arrives.
+An answer that lives only in a chat message is worse than no answer, because it acquires authority it cannot evidence: later work cites it as settled with nothing to point at, and the decision stays open and gets asked again.
+Recording is deliberately cheap so nothing stands between hearing the answer and writing it down - pass the captain's words to `resolve` with `--decision`, and use `--no-routed-work` when the answer spawns no dependent task.
+Two closures other than a fresh captain answer are equally first class: a question that turns out to be firstmate's own call under `ask-user-authority`'s bar closes with `--decided-by firstmate`, and one an earlier captain answer already settled closes with that answer and its source as the decision text.
+Neither is a shortcut around the captain; each is the honest record of who actually decided.
+A decision closed with a real record but not through this script still counts as durably resolved, so an earlier bulk close does not strand the investigation that found it.
+Where dependent work genuinely exists, create it in the same backlog, block it by the hold identity, and route it with `--routed-to`; the script refuses `--no-routed-work` while any task is blocked by the hold, so that requirement cannot be skipped.
 When the captain's answer routes no follow-up work at all, such as a declined proposal, `bin/fm-decision-hold.sh decline` records that answer and closes the hold; it never substitutes for routing work the captain did authorize.
 When the captain simply answers a hold that has no follow-up work routed behind it yet, `bin/fm-decision-hold.sh answer` records that answer and closes the hold, so answering is closing rather than a separate later act that can be forgotten.
 "A keyed answer closes its matching hold" is one capability with one owner, `bin/fm-decision-hold.sh answers`, and every channel that carries a captain answer feeds it the same `<decision-key>` and answer.
@@ -36,14 +48,17 @@ Bearings reads the resulting structured state and must never compensate by scrap
 ## Operating sequence
 
 1. Read the complete investigation result and complete the visual review before declaring either complete.
-2. Inventory only genuine unresolved choices that require the captain.
-3. For each choice, choose a stable key and use the script's `hold` command with a concise title, reason, and repository.
-4. Run the script's `complete` command with the full unresolved-key inventory for that review pass.
+2. Inventory only genuine unresolved choices that pass `ask-user-authority`'s bar for asking; decide the rest yourself.
+3. Read the open captain decisions the script prints, and for each surviving choice either `fold` it into the decision that already owns the question or register it with `hold` under a stable key, using `--distinct` only when it is genuinely a different question.
+4. Run the script's `complete` command with the full unresolved-key inventory for that review pass, or `--folded` when every finding went into an existing decision.
 5. Relay the choices to the captain as decisions from Bearings' Captain's Call section under `AGENTS.md` section 9; do not use the word hold in captain chat.
-6. If the captain authorizes dependent work, record it with normal tasks-axi commands and block it by the hold identity.
-7. Put the captain's exact durable decision in a file and close the hold with the script's `resolve` command and every routed task, its `answer` command when the captain answered a hold with no routed work behind it, its `decline` command when the answer routes no work at all, or its `repair` command when the hold was already closed outside the script.
+6. When the captain authorizes dependent work, record it with normal tasks-axi commands and block it by the hold identity.
+7. When the captain answers, run `resolve` in that same turn with `--decision` and either `--routed-to` for dependent work or `--no-routed-work` when none exists, creating and blocking dependent work first where it applies. When the answer routes no follow-up work at all, `decline` is the same one-turn recording without inventing a `--no-routed-work` resolve; `answer` records that same one-turn closure when the hold has no routed work behind it yet; when a hold was already closed outside this owner, `repair` records the decision it closed with.
    A hold that a channel already closed by feeding its keyed answer needs none of these; confirm it in step 8 instead.
 8. Confirm Bearings no longer shows the closed hold and that any routed work remains in structured backlog state.
+
+A decision the fleet view marks as ageing has already been asked.
+Resurface it as still waiting since its date, never as a new question, and never register a second decision for it.
 
 `bin/fm-decision-hold.sh --help` owns command syntax, identity construction, completion attestation, retry behavior, and close ordering.
 `docs/decision-hold-lifecycle.md` records the mechanism and regression evidence without restating this policy.

--- a/.agents/skills/decision-hold-lifecycle/SKILL.md
+++ b/.agents/skills/decision-hold-lifecycle/SKILL.md
@@ -20,9 +20,11 @@ Apply `ask-user-authority`'s bar for asking to every candidate first; a question
 Give each remaining distinct unresolved decision a stable privacy-safe key, register it through `bin/fm-decision-hold.sh hold`, and use the same key on retry so registration is idempotent while different decisions retain different durable identities.
 Before a new identity is created the script puts the home's open captain decisions in front of you and refuses, because a second key covering an already-open question is how this queue compounds.
 Read that listing and judge it semantically: an earlier review of the same pull request, subsystem, or policy question usually already owns the decision under a different key.
-When it does, use `bin/fm-decision-hold.sh fold` to add this pass's finding to the existing decision instead of opening a second one, naming the origin's open decision key with `--key` so the fold states which question it covers, then complete against that fold.
+When it does, use `bin/fm-decision-hold.sh fold` to add this pass's finding to the existing decision instead of opening a second one, then account for that fold at sign-off.
 Re-run with `--distinct` only when the question is genuinely different from every decision in that listing; the attestation is recorded in the new decision.
 After inventorying the whole report and review surface, run `bin/fm-decision-hold.sh complete` with every unresolved key, or with `--none` only when the reviewed surface contains no unresolved captain decision.
+Sign-off is where every structured decision still open in the originating work's status log is accounted for: supply its key when this work's own hold carries it, or name that exact key with `--folded-key` when a fold you recorded carries it.
+Say which entries a fold covers rather than leaving it to be inferred, because nothing else in the flow can state it and an entry nobody named is refused.
 A completed investigation and an ended visual review use this same owner and completion command; a visual tool, including Lavish, never owns a parallel completion policy.
 Run the command in the originating work's authoritative `FM_HOME`; main-home work creates main-home holds, and secondmate-owned work creates holds in that secondmate home's backlog rather than copying them into the main backlog.
 Do not close a hold merely because the originating investigation completed, its report was archived, its visual review ended, or its task was torn down.
@@ -49,8 +51,8 @@ Bearings reads the resulting structured state and must never compensate by scrap
 
 1. Read the complete investigation result and complete the visual review before declaring either complete.
 2. Inventory only genuine unresolved choices that pass `ask-user-authority`'s bar for asking; decide the rest yourself.
-3. Read the open captain decisions the script prints, and for each surviving choice either `fold` it into the decision that already owns the question, naming the covered decision key with `--key`, or register it with `hold` under a stable key, using `--distinct` only when it is genuinely a different question.
-4. Run the script's `complete` command with the full unresolved-key inventory for that review pass, or `--folded` when every finding went into an existing decision.
+3. Read the open captain decisions the script prints, and for each surviving choice either `fold` it into the decision that already owns the question or register it with `hold` under a stable key, using `--distinct` only when it is genuinely a different question.
+4. Run the script's `complete` command with the full unresolved-key inventory for that review pass, or `--folded` when every finding went into an existing decision, and name every open status entry a fold covers with `--folded-key` so nothing on the live surface is left unaccounted for.
 5. Relay the choices to the captain as decisions from Bearings' Captain's Call section under `AGENTS.md` section 9; do not use the word hold in captain chat.
 6. When the captain authorizes dependent work, record it with normal tasks-axi commands and block it by the hold identity.
 7. When the captain answers, run `resolve` in that same turn with `--decision` and either `--routed-to` for dependent work or `--no-routed-work` when none exists, creating and blocking dependent work first where it applies. When the answer routes no follow-up work at all, `decline` is the same one-turn recording without inventing a `--no-routed-work` resolve; `answer` records that same one-turn closure when the hold has no routed work behind it yet; when a hold was already closed outside this owner, `repair` records the decision it closed with.

--- a/.agents/skills/decision-hold-lifecycle/SKILL.md
+++ b/.agents/skills/decision-hold-lifecycle/SKILL.md
@@ -20,7 +20,7 @@ Apply `ask-user-authority`'s bar for asking to every candidate first; a question
 Give each remaining distinct unresolved decision a stable privacy-safe key, register it through `bin/fm-decision-hold.sh hold`, and use the same key on retry so registration is idempotent while different decisions retain different durable identities.
 Before a new identity is created the script puts the home's open captain decisions in front of you and refuses, because a second key covering an already-open question is how this queue compounds.
 Read that listing and judge it semantically: an earlier review of the same pull request, subsystem, or policy question usually already owns the decision under a different key.
-When it does, use `bin/fm-decision-hold.sh fold` to add this pass's finding to the existing decision instead of opening a second one, then complete against that fold.
+When it does, use `bin/fm-decision-hold.sh fold` to add this pass's finding to the existing decision instead of opening a second one, naming the origin's open decision key with `--key` so the fold states which question it covers, then complete against that fold.
 Re-run with `--distinct` only when the question is genuinely different from every decision in that listing; the attestation is recorded in the new decision.
 After inventorying the whole report and review surface, run `bin/fm-decision-hold.sh complete` with every unresolved key, or with `--none` only when the reviewed surface contains no unresolved captain decision.
 A completed investigation and an ended visual review use this same owner and completion command; a visual tool, including Lavish, never owns a parallel completion policy.
@@ -49,7 +49,7 @@ Bearings reads the resulting structured state and must never compensate by scrap
 
 1. Read the complete investigation result and complete the visual review before declaring either complete.
 2. Inventory only genuine unresolved choices that pass `ask-user-authority`'s bar for asking; decide the rest yourself.
-3. Read the open captain decisions the script prints, and for each surviving choice either `fold` it into the decision that already owns the question or register it with `hold` under a stable key, using `--distinct` only when it is genuinely a different question.
+3. Read the open captain decisions the script prints, and for each surviving choice either `fold` it into the decision that already owns the question, naming the covered decision key with `--key`, or register it with `hold` under a stable key, using `--distinct` only when it is genuinely a different question.
 4. Run the script's `complete` command with the full unresolved-key inventory for that review pass, or `--folded` when every finding went into an existing decision.
 5. Relay the choices to the captain as decisions from Bearings' Captain's Call section under `AGENTS.md` section 9; do not use the word hold in captain chat.
 6. When the captain authorizes dependent work, record it with normal tasks-axi commands and block it by the hold identity.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -363,8 +363,8 @@ jobs:
           bearings_output=$(/bin/bash tests/fm-bearings-snapshot.test.sh)
           printf '%s\n' "$bearings_output"
           bearings_count=$(printf '%s\n' "$bearings_output" | grep -c '^ok - ')
-          [ "$bearings_count" -eq 41 ] || {
-            echo "::error::expected 41 Bearings tests, got $bearings_count"
+          [ "$bearings_count" -eq 42 ] || {
+            echo "::error::expected 42 Bearings tests, got $bearings_count"
             exit 1
           }
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -399,6 +399,7 @@ Handle actionable wakes as follows:
 2. For `stale:`, inspect the recorded endpoint and load `stuck-crewmate-recovery` for a stopped, looping, confused, or unresponsive worker; a deep-inspection reason also requires current-state and validation-log inspection.
 3. For `check:`, act on the named poll result, including merges, Relay events, and process-to-event source results.
 4. For `heartbeat:`, review the whole fleet from the structured fleet view, reconcile suspicious tasks and PR state, update the backlog, and never report an unchanged fleet as progress.
+   Surface every decision that view marks as ageing, always as still waiting since its date rather than as a fresh question.
 
 When any wake reports a merged PR for a project cloned in this home, refresh that clone through the guarded fleet-sync path.
 When Relay-linked work reaches a milestone or terminal state, load `fmx-respond`; before terminal teardown, use its promised-final reconciliation when a typed public commitment exists, otherwise post the final completion follow-up so the link clears even if earlier follow-ups were spent.
@@ -522,7 +523,7 @@ These skills are not captain-invocable; load them only at their precise triggers
 
 - `bootstrap-diagnostics` - load whenever the session-start digest's bootstrap or network-checks section prints an actionable diagnostic line (`MISSING:`, `MISSING_MANUAL:`, `BACKEND_INVALID:`, `NEEDS_GH_AUTH`, `TANGLE:`, `STARTUP_MEMORY_BUDGET:`, `CREW_DISPATCH: invalid`, `FLEET_SYNC:`, `NETWORK_CHECKS:`, `PR_CHECK_MIGRATION:`, `SECONDMATE_SYNC:`, `SECONDMATE_LIVENESS:`, `SECONDMATE_HANDOFF:`, `NUDGE_SECONDMATES:`, or `FMX:`); silence and `BOOTSTRAP_INFO:` need no load.
 - `diagnostic-reasoning` - load before scoping a reported bug and before acting on a diagnostic report.
-- `ask-user-authority` - load before deciding any ask-user finding, regardless of the project's `yolo` posture.
+- `ask-user-authority` - load before deciding any ask-user finding, regardless of the project's `yolo` posture, and before registering any captain decision found by an investigation or review; it owns the bar for asking at all.
 - `quota-array-dispatch` - load before choosing among a matched crew-dispatch profile array from current quota-axi output.
 - `harness-adapters` - load before spawning or recovering a crewmate or secondmate, handling a trust dialog, sending a harness-specific skill invocation, interrupting or exiting an agent, resuming an exited agent, or verifying a new harness adapter.
 - `firstmate-orca` - load before switching to Orca, spawning or supervising Orca-backed work, smoke-testing Orca backend behavior, debugging Orca task state, or reconciling Orca-backed task metadata.

--- a/bin/fm-bearings-snapshot.sh
+++ b/bin/fm-bearings-snapshot.sh
@@ -22,6 +22,10 @@
 # This wrapper consumes canonical status decisions plus canonically normalized
 # backlog roles, unresolved blockers, and captain actionability. It never infers
 # decisions from report or visual-review prose or reimplements snapshot semantics.
+# Each open decision carries the date it was registered, how many days it has been
+# waiting, and the canonical snapshot's ageing flag, so a decision that has been
+# waiting cannot read as a fresh one. Ageing decisions sort first and therefore
+# survive the bounded decisions_open cap.
 #
 # Main-home inventory validity comes from the canonical snapshot's main_inventory
 # object (orphan structured in-flight without meta, unstructured current rows).
@@ -107,7 +111,8 @@ Default is LOCAL-ONLY (no network); --include-prs is the only path that fetches.
 
 Default fields: schema, home, generated, prs, in_flight{id,kind,state,doing},
   secondmates{id,state,doing,provenance,freshness,age_seconds,contradiction,reason},
-  decisions_open{id,key,verb,summary,owner}, landed{id,what,artifact,owner},
+  decisions_open{id,key,verb,summary,since,waiting_days,aging,owner} ordered ageing-first
+  then oldest-first, landed{id,what,artifact,owner},
   gates{id,title,blocked_by,reason,owner}, reports{id,path}, recorded_prs{id,url},
   unhealthy_endpoints{...} (only when non-empty), omitted{surface,reveal}.
 landed merges this home's Done with registered secondmate homes' Done, bounded by
@@ -382,11 +387,21 @@ MODEL=$(printf '%s' "$SNAP" | jq \
   | ([ .backlog.records[]
          | select(.structured and .captain_actionable == true)
          | {id,key:.id,verb:"captain-hold",
-            summary:((.title + ": " + .hold_reason) | trunc(90)),owner:"(main)"} ]
+            summary:((.title + ": " + .hold_reason) | trunc(90)),
+            since:(.since // null),
+            waiting_days:(.waiting_days // null),
+            aging:(.decision_aging // false),
+            owner:"(main)"} ]
      + [ (.secondmate_current.records // [])[] as $m | $m.decisions_open[]?
          | select(.source == "backlog" and .verb == "captain-hold")
          | {id:($m.id + "/" + .id),key,verb,
-            summary:(((.summary // .id) + ": " + (.reason // "captain decision pending")) | trunc(90)),owner:$m.id} ]) as $decisions_all
+            summary:(((.summary // .id) + ": " + (.reason // "captain decision pending")) | trunc(90)),
+            since:(.since // null),
+            waiting_days:(.waiting_days // null),
+            aging:(.aging // false),
+            owner:$m.id} ]) as $decisions_all
+  # Oldest first, so the decisions that have waited longest lead the section.
+  | ($decisions_all | sort_by([(if .aging then 0 else 1 end), (.since // "9999-99-99"), .id])) as $decisions_all
   | ((if (.main_inventory.valid == false) then
         [{id:"(main-inventory)",
           title:((.main_inventory.reason // "main inventory invalid") | trunc(60)),

--- a/bin/fm-decision-hold.sh
+++ b/bin/fm-decision-hold.sh
@@ -55,7 +55,9 @@
 # `fold` is the first-class alternative to a second decision: it appends this
 # pass's finding to an existing open hold's body and records the fold in the new
 # origin's metadata, so the origin still satisfies the completion gate without
-# creating a duplicate captain decision.
+# creating a duplicate captain decision. It refuses up front, before touching the
+# target, when the origin has no metadata to record the fold in, so a reported
+# fold always satisfies `complete --folded`.
 #
 # `complete` is the shared investigation and visual-review completion gate.
 # `--none` is an explicit semantic attestation that the just-reviewed surface has
@@ -151,14 +153,16 @@
 # from before either field existed remain valid and default to `captain`.
 #
 # The completion and teardown gates accept a decision as durably resolved when it
-# is closed and carries a decision record, whatever wrote that record, and when
-# Done retention has rotated it into data/done-archive.md. A decision closed with
-# no record at all is still refused, because that is the loss the gate exists to
-# prevent; the gate checks that an answer survives, not that this script formatted
-# it.
+# is closed and carries a decision record, whatever wrote that record, including
+# once Done retention has rotated it into data/done-archive.md. A decision closed
+# with no record at all is still refused, because that is the loss the gate exists
+# to prevent; the gate checks that an answer survives, not that this script
+# formatted it. The archived shape is held to the same record test as the live
+# one, so retention can never turn a refused closure into an accepted one.
 #
-# Environment: FM_DECISION_AGING_DAYS (default 3) sets the ageing threshold and
-# FM_DECISION_NOW (YYYY-MM-DD) pins today's date for tests.
+# Environment: FM_DECISION_AGING_DAYS (default 3) is the one ageing threshold,
+# shared with bin/fm-fleet-snapshot.sh so the CLI listing and the fleet view can
+# never disagree; FM_DECISION_NOW (YYYY-MM-DD) pins today's date for tests.
 set -eu
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -559,20 +563,58 @@ verify_hold_resolved() {  # <hold-id>
   body_has_resolution_record "$body"
 }
 
-# True when the backlog's Done retention has rotated <hold-id> into the archive.
-# The archived row is durable proof the decision was closed, so retention alone
-# must never make a reviewed inventory unverifiable.
-archived_done_record() {  # <hold-id>
+# The single record test every closed captain decision passes, whether its body
+# came from the live backlog or from the Done archive.
+#
+# A decision closed outside this script - because firstmate decided it, or
+# because an earlier captain answer already settled it - is durably resolved when
+# its body carries a decision record. The gate exists to stop a decision
+# vanishing unanswered, not to insist on this script's own formatting. A body
+# still carrying the untouched registration record says in its own words that no
+# answer was ever written, so that closure is refused.
+closed_body_has_record() {  # <body>
+  local body=$1
+  case "$body" in
+    *"Resolution recorded by fm-decision-hold."*"Routed work:"*) return 0 ;;
+  esac
+  case "$body" in
+    ''|'""'|'"-"') return 1 ;;
+    *"State: awaiting captain decision."*) return 1 ;;
+  esac
+  return 0
+}
+
+# The body of <hold-id>'s archived row, once the backlog's Done retention has
+# rotated it into data/done-archive.md; exit 1 when no such row exists. The
+# archive preserves the entry's indented body lines verbatim, so the archived
+# shape is held to the same record test as the live one and retention can neither
+# make a reviewed inventory unverifiable nor launder a recordless closure.
+archived_done_body() {  # <hold-id>
   local archive="$DATA/done-archive.md"
   [ -f "$archive" ] || return 1
-  grep -F -- "- [x] $1 - " "$archive" >/dev/null && return 0
-  grep -F -- "- [X] $1 - " "$archive" >/dev/null
+  awk -v id="$1" '
+    BEGIN { want = "- [x] " id " - "; wantu = "- [X] " id " - " }
+    index($0, want) == 1 || index($0, wantu) == 1 {
+      found = 1; inbody = 1; body = ""; pending = ""; next
+    }
+    inbody && /^  / {
+      body = body pending substr($0, 3) "\n"; pending = ""; next
+    }
+    inbody && /^[[:space:]]*$/ { pending = pending "\n"; next }
+    inbody { inbody = 0; pending = "" }
+    END { if (!found) exit 1; printf "%s", body }
+  ' "$archive"
 }
 
 verify_hold_durable() {  # <hold-id>
   local id=$1 show state held kind hold_kind body
   if ! show=$(task_show "$id"); then
-    archived_done_record "$id" && return 0
+    if body=$(archived_done_body "$id"); then
+      if closed_body_has_record "$body"; then
+        return 0
+      fi
+      fail "captain decision $id was archived with no decision record; record the answer in its body"
+    fi
     fail "captain decision $id is absent from $FM_HOME/data/backlog.md and its Done archive"
   fi
   state=$(show_field "$show" state)
@@ -584,20 +626,9 @@ verify_hold_durable() {  # <hold-id>
     return 0
   fi
   if [ "$state" = "done" ] && [ "$kind" = captain ]; then
-    case "$body" in
-      *"Resolution recorded by fm-decision-hold."*"Routed work:"*) return 0 ;;
-    esac
-    # A decision closed outside this script - because firstmate decided it, or
-    # because an earlier captain answer already settled it - is durably resolved
-    # when its body carries a decision record. The gate exists to stop a decision
-    # vanishing unanswered, not to insist on this script's own formatting.
-    # A body still carrying the untouched registration record says in its own
-    # words that no answer was ever written, so that closure is still refused.
-    case "$body" in
-      ''|'""'|'"-"') : ;;
-      *"State: awaiting captain decision."*) : ;;
-      *) return 0 ;;
-    esac
+    if closed_body_has_record "$body"; then
+      return 0
+    fi
     fail "captain decision $id was closed with no decision record; record the answer in its body"
   fi
   fail "captain decision $id is neither actively held nor durably resolved"
@@ -767,6 +798,12 @@ command_fold() {
   case "$into" in
     "$origin"-decision-*) fail "$into already belongs to $origin; use its own decision key instead" ;;
   esac
+  # A fold only means something once it is recorded in the origin's metadata,
+  # which is what lets `complete --folded` accept the origin. Without that file
+  # the fold cannot be recorded, so refuse before touching the target rather than
+  # reporting a success the completion gate will later reject.
+  meta="$STATE/$origin.meta"
+  [ -f "$meta" ] || fail "origin $origin has no runtime metadata at $meta, so the fold cannot be recorded; fold from the home that owns $origin"
   ( verify_hold_active "$into" ) >/dev/null 2>&1 \
     || fail "fold target $into is not an open captain decision; a resolved decision needs a new decision key"
 
@@ -783,12 +820,9 @@ command_fold() {
       ;;
   esac
 
-  meta="$STATE/$origin.meta"
-  if [ -f "$meta" ]; then
-    previous=$(meta_value "$meta" decision_folds)
-    folds=$(sorted_key_union "$previous" "$into")
-    [ "$previous" = "$folds" ] || printf 'decision_folds=%s\n' "$folds" >> "$meta"
-  fi
+  previous=$(meta_value "$meta" decision_folds)
+  folds=$(sorted_key_union "$previous" "$into")
+  [ "$previous" = "$folds" ] || printf 'decision_folds=%s\n' "$folds" >> "$meta"
   printf 'folded: %s -> %s\n' "$origin" "$into"
 }
 

--- a/bin/fm-decision-hold.sh
+++ b/bin/fm-decision-hold.sh
@@ -21,7 +21,8 @@
 #   fm-decision-hold.sh open [--origin <origin-id>] [--aging-only]
 #   fm-decision-hold.sh hold <origin-id> <decision-key> \
 #     --title <title> --reason <reason> [--repo <repo>] [--distinct]
-#   fm-decision-hold.sh fold <origin-id> --into <hold-id> --note <note>
+#   fm-decision-hold.sh fold <origin-id> --into <hold-id> --note <note> \
+#     [--key <decision-key>...]
 #   fm-decision-hold.sh complete <origin-id> (--none | --folded | <decision-key>...)
 #   fm-decision-hold.sh verify <origin-id>
 #   fm-decision-hold.sh resolve <origin-id> <decision-key> \
@@ -57,7 +58,12 @@
 # origin's metadata, so the origin still satisfies the completion gate without
 # creating a duplicate captain decision. It refuses up front, before touching the
 # target, when the origin has no metadata to record the fold in, so a reported
-# fold always satisfies `complete --folded`.
+# fold always satisfies `complete --folded`. It also transfers the origin's open
+# keyed status decision to the decision that now owns it, the same
+# `captain-held [key=...]` event `complete` writes, so a folded status decision is
+# not left open for a key this origin will never register. `--key` names which
+# open status decision this fold covers; it is required while several are open, so
+# one fold can never blanket-satisfy more than the question it folded.
 #
 # `complete` is the shared investigation and visual-review completion gate.
 # `--none` is an explicit semantic attestation that the just-reviewed surface has
@@ -292,8 +298,8 @@ today_utc() {
 }
 
 date_epoch() {  # <YYYY-MM-DD>
-  date -u -j -f '%Y-%m-%d' "$1" +%s 2>/dev/null \
-    || date -u -d "$1" +%s 2>/dev/null \
+  date -u -j -f '%Y-%m-%d %H:%M:%S' "$1 00:00:00" +%s 2>/dev/null \
+    || date -u -d "$1 00:00:00 UTC" +%s 2>/dev/null \
     || true
 }
 
@@ -335,13 +341,24 @@ TASKS_AXI_CSV_AWK='
 
 # Every open captain decision in the active home as
 # "<id>\t<since>\t<title>\t<reason>", ordered oldest first.
+#
+# The predicate is the same one bin/fm-fleet-snapshot.sh applies for
+# captain_actionable - queued, kind captain, held for the captain with a reason,
+# and carrying no unresolved blocker - so this listing and Bearings' Captain's
+# Call can never cite different decisions. tasks-axi drops a resolved blocker
+# from blocked_by and refuses an edge to a task that does not exist, so its
+# blocked_by is exactly the unresolved-blocker set the fleet view computes.
 list_open_captain_decisions() {
-  tasks_axi list --state held --kind captain --fields hold_reason,hold_kind,created 2>/dev/null \
+  tasks_axi list --state held --kind captain \
+      --fields hold_reason,hold_kind,created,blocked_by 2>/dev/null \
     | awk "
         function emit(line,   f, n) {
           n = parse_csv(line, f)
-          if (n < 8) return
+          if (n < 9) return
+          if (f[2] != \"queued\") return
+          if (f[6] == \"\") return
           if (f[7] != \"captain\") return
+          if (f[9] != \"\" && f[9] != \"none\") return
           printf \"%s\t%s\t%s\t%s\n\", f[1], f[8], clean(f[5]), clean(f[6])
         }
         $TASKS_AXI_CSV_AWK
@@ -397,6 +414,19 @@ origin_fold_ids() {  # <origin-id>
   local meta="$STATE/$1.meta"
   [ -f "$meta" ] || return 0
   meta_value "$meta" decision_folds
+}
+
+# The one fold check both the completion gate and the teardown gate apply, so the
+# two cannot drift apart.
+verify_folds() {  # <comma-separated-fold-ids>
+  local folds=$1 fold
+  [ -n "$folds" ] || return 0
+  while IFS= read -r fold; do
+    [ -n "$fold" ] || continue
+    verify_hold_durable "$fold"
+  done <<EOF
+$(printf '%s\n' "$folds" | tr ',' '\n')
+EOF
 }
 
 # The registration record a resolution must not erase. On a first resolution that
@@ -475,6 +505,44 @@ origin_open_decisions() {  # <origin-id>
     esac
   fi
   printf '%s' "$open"
+}
+
+status_transfer_line() {  # <key> <owner-hold-id>
+  printf 'captain-held [key=%s]: tracked by %s\n' "$1" "$2"
+}
+
+status_transfer_recorded() {  # <status-file> <key> <owner-hold-id>
+  [ -f "$1" ] || return 1
+  grep -Fxq -- "$(status_transfer_line "$2" "$3")" "$1"
+}
+
+# The origin's open structured decision keys this fold covers, one per line.
+# A fold closes the live status copy of the question it folded and nothing else,
+# so an explicit --key must name a decision that is open here, and an unqualified
+# fold covers a single open decision but refuses while several are open rather
+# than blanket-satisfying all of them. A key this fold already transferred to the
+# same owner is silently skipped, which keeps repeating a fold idempotent.
+fold_covered_keys() {  # <origin-id> <open-set> <requested-keys> <owner-hold-id>
+  local origin=$1 open=$2 requested=$3 into=$4 status_file="$STATE/$1.status" key open_keys count covered=''
+  open_keys=$(printf '%s' "$open" | awk -F'\t' 'NF { print $1 }')
+  if [ -n "$requested" ]; then
+    for key in $requested; do
+      if printf '%s\n' "$open_keys" | grep -Fxq -- "$key"; then
+        covered="${covered}${key}"$'\n'
+      elif status_transfer_recorded "$status_file" "$key" "$into"; then
+        :
+      else
+        fail "origin $origin has no open structured decision under key $key"
+      fi
+    done
+    printf '%s' "$covered"
+    return 0
+  fi
+  count=0
+  [ -z "$open_keys" ] || count=$(printf '%s\n' "$open_keys" | grep -c . || true)
+  [ "$count" -le 1 ] \
+    || fail "origin $origin has $count open structured decisions; name the one this fold covers with --key <decision-key>"
+  [ -z "$open_keys" ] || printf '%s\n' "$open_keys"
 }
 
 body_has_resolution_record() {  # <hold-body>
@@ -776,13 +844,14 @@ command_hold() {
 }
 
 command_fold() {
-  local origin=${1:-} into='' note='' meta previous folds body marker tmp
+  local origin=${1:-} into='' note='' requested='' meta previous folds body marker tmp status_file open covered key
   [ "$#" -ge 1 ] || { usage >&2; exit 2; }
   shift
   while [ "$#" -gt 0 ]; do
     case "$1" in
       --into) shift; into=${1:-} ;;
       --note) shift; note=${1:-} ;;
+      --key) shift; validate_slug decision-key "${1:-}"; requested="${requested}${requested:+ }${1:-}" ;;
       *) usage >&2; exit 2 ;;
     esac
     shift
@@ -806,6 +875,12 @@ command_fold() {
   [ -f "$meta" ] || fail "origin $origin has no runtime metadata at $meta, so the fold cannot be recorded; fold from the home that owns $origin"
   ( verify_hold_active "$into" ) >/dev/null 2>&1 \
     || fail "fold target $into is not an open captain decision; a resolved decision needs a new decision key"
+  # Which live status decisions this fold answers for is decided before anything is
+  # written, so a fold that cannot name its coverage refuses instead of leaving the
+  # target mutated and the origin still unable to complete.
+  status_file="$STATE/$origin.status"
+  open=$(origin_open_decisions "$origin")
+  covered=$(fold_covered_keys "$origin" "$open" "$requested" "$into")
 
   marker=$(printf 'Also raised by %s: %s' "$origin" "$note")
   body=$(read_body "$into")
@@ -823,11 +898,20 @@ command_fold() {
   previous=$(meta_value "$meta" decision_folds)
   folds=$(sorted_key_union "$previous" "$into")
   [ "$previous" = "$folds" ] || printf 'decision_folds=%s\n' "$folds" >> "$meta"
-  printf 'folded: %s -> %s\n' "$origin" "$into"
+
+  # The live status copy of a folded question is transferred to the decision that
+  # now owns it, exactly as `complete` transfers a question to its own hold, so
+  # `complete --folded` satisfies the per-key requirement instead of dead-ending
+  # on a status decision no key of this origin will ever cover.
+  for key in $covered; do
+    status_transfer_line "$key" "$into" >> "$status_file"
+  done
+  printf 'folded: %s -> %s%s\n' "$origin" "$into" \
+    "$(if [ -n "$covered" ]; then printf ' [keys=%s]' "$(printf '%s\n' "$covered" | sed '/^$/d' | paste -sd, -)"; fi)"
 }
 
 command_complete() {
-  local origin=${1:-} meta previous='' supplied='' keys='' key status_file open raw_open key_seen=0 has_meta=0 folds=''
+  local origin=${1:-} meta previous='' supplied='' keys='' key status_file open raw_open key_seen=0 has_meta=0 folds='' transfer_rc=0
   [ "$#" -ge 2 ] || { usage >&2; exit 2; }
   validate_slug origin-id "$origin"
   shift
@@ -859,14 +943,7 @@ command_complete() {
       shift
     done
   fi
-  if [ -n "$folds" ]; then
-    while IFS= read -r key; do
-      [ -n "$key" ] || continue
-      verify_hold_durable "$key"
-    done <<EOF
-$(printf '%s\n' "$folds" | tr ',' '\n')
-EOF
-  fi
+  verify_folds "$folds"
   if [ "$has_meta" = 1 ]; then
     previous=$(meta_value "$meta" decision_keys)
   fi
@@ -909,7 +986,7 @@ EOF
       list_has_key "$keys" "$key" || continue
       transfer_rc=0
       fm_wake_status_append_self_announced "$STATE" "$status_file" \
-        "captain-held [key=$key]: tracked by $(hold_id "$origin" "$key")" || transfer_rc=$?
+        "$(status_transfer_line "$key" "$(hold_id "$origin" "$key")")" || transfer_rc=$?
       [ "$transfer_rc" -ne 2 ] || fail "cannot append the captain-held transfer for $origin/$key"
       key_seen=1
     done <<EOF
@@ -922,7 +999,7 @@ EOF
 }
 
 command_verify() {
-  local origin=${1:-} meta reviewed keys key open folds
+  local origin=${1:-} meta reviewed keys key open
   [ "$#" -eq 1 ] || { usage >&2; exit 2; }
   validate_slug origin-id "$origin"
   meta="$STATE/$origin.meta"
@@ -930,15 +1007,7 @@ command_verify() {
   require_tasks_axi
   reviewed=$(meta_value "$meta" decisions_reviewed)
   [ "$reviewed" = 1 ] || fail "origin $origin has no completed unresolved-decision inventory"
-  folds=$(meta_value "$meta" decision_folds)
-  if [ -n "$folds" ]; then
-    while IFS= read -r key; do
-      [ -n "$key" ] || continue
-      verify_hold_durable "$key"
-    done <<EOF
-$(printf '%s\n' "$folds" | tr ',' '\n')
-EOF
-  fi
+  verify_folds "$(origin_fold_ids "$origin")"
   keys=$(meta_value "$meta" decision_keys)
   if [ -n "$keys" ]; then
     while IFS= read -r key; do

--- a/bin/fm-decision-hold.sh
+++ b/bin/fm-decision-hold.sh
@@ -62,8 +62,9 @@
 # keyed status decision to the decision that now owns it, the same
 # `captain-held [key=...]` event `complete` writes, so a folded status decision is
 # not left open for a key this origin will never register. `--key` names which
-# open status decision this fold covers; it is required while several are open, so
-# one fold can never blanket-satisfy more than the question it folded.
+# open status decision this fold covers and is required whenever the origin has
+# any open status decision, so a fold can never claim a question it was not told
+# about, nor blanket-satisfy more than the question it folded.
 #
 # `complete` is the shared investigation and visual-review completion gate.
 # `--none` is an explicit semantic attestation that the just-reviewed surface has
@@ -518,14 +519,18 @@ status_transfer_recorded() {  # <status-file> <key> <owner-hold-id>
 
 # The origin's open structured decision keys this fold covers, one per line.
 # A fold closes the live status copy of the question it folded and nothing else,
-# so an explicit --key must name a decision that is open here, and an unqualified
-# fold covers a single open decision but refuses while several are open rather
-# than blanket-satisfying all of them. A key this fold already transferred to the
-# same owner is silently skipped, which keeps repeating a fold idempotent.
+# so `--key` must name a decision that is open here, and it is required whenever
+# any decision is open at all. An unqualified fold has said nothing about which
+# question it covers, and a sole open decision is not evidence that it is the one
+# folded: silently transferring it would mark a question as owned by a decision
+# that never mentions it, which is the loss this gate exists to prevent. Repeated
+# keys collapse, and a key this fold already transferred to the same owner is
+# skipped, so neither a repeated key nor a repeated fold writes a second transfer.
 fold_covered_keys() {  # <origin-id> <open-set> <requested-keys> <owner-hold-id>
   local origin=$1 open=$2 requested=$3 into=$4 status_file="$STATE/$1.status" key open_keys count covered=''
   open_keys=$(printf '%s' "$open" | awk -F'\t' 'NF { print $1 }')
   if [ -n "$requested" ]; then
+    requested=$(sorted_key_union '' "$requested" | tr ',' ' ')
     for key in $requested; do
       if printf '%s\n' "$open_keys" | grep -Fxq -- "$key"; then
         covered="${covered}${key}"$'\n'
@@ -540,9 +545,8 @@ fold_covered_keys() {  # <origin-id> <open-set> <requested-keys> <owner-hold-id>
   fi
   count=0
   [ -z "$open_keys" ] || count=$(printf '%s\n' "$open_keys" | grep -c . || true)
-  [ "$count" -le 1 ] \
-    || fail "origin $origin has $count open structured decisions; name the one this fold covers with --key <decision-key>"
-  [ -z "$open_keys" ] || printf '%s\n' "$open_keys"
+  [ "$count" -eq 0 ] \
+    || fail "origin $origin has $count open structured decision$([ "$count" = 1 ] || printf s); name the one this fold covers with --key <decision-key>"
 }
 
 body_has_resolution_record() {  # <hold-body>

--- a/bin/fm-decision-hold.sh
+++ b/bin/fm-decision-hold.sh
@@ -21,9 +21,9 @@
 #   fm-decision-hold.sh open [--origin <origin-id>] [--aging-only]
 #   fm-decision-hold.sh hold <origin-id> <decision-key> \
 #     --title <title> --reason <reason> [--repo <repo>] [--distinct]
-#   fm-decision-hold.sh fold <origin-id> --into <hold-id> --note <note> \
-#     [--key <decision-key>...]
-#   fm-decision-hold.sh complete <origin-id> (--none | --folded | <decision-key>...)
+#   fm-decision-hold.sh fold <origin-id> --into <hold-id> --note <note>
+#   fm-decision-hold.sh complete <origin-id> \
+#     (--none | [<decision-key>...] [--folded] [--folded-key <decision-key>]...)
 #   fm-decision-hold.sh verify <origin-id>
 #   fm-decision-hold.sh resolve <origin-id> <decision-key> \
 #     (--decision <text> | --decision-file <path>) [--decided-by captain|firstmate] \
@@ -55,26 +55,30 @@
 #
 # `fold` is the first-class alternative to a second decision: it appends this
 # pass's finding to an existing open hold's body and records the fold in the new
-# origin's metadata, so the origin still satisfies the completion gate without
-# creating a duplicate captain decision. It refuses up front, before touching the
-# target, when the origin has no metadata to record the fold in, so a reported
-# fold always satisfies `complete --folded`. It also transfers the origin's open
-# keyed status decision to the decision that now owns it, the same
-# `captain-held [key=...]` event `complete` writes, so a folded status decision is
-# not left open for a key this origin will never register. `--key` names which
-# open status decision this fold covers and is required whenever the origin has
-# any open status decision, so a fold can never claim a question it was not told
-# about, nor blanket-satisfy more than the question it folded.
+# origin's metadata. It refuses up front, before touching the target, when the
+# origin has no metadata to record the fold in, so a reported fold is always one
+# sign-off can account for. `fold` never touches the origin's status log and takes
+# no decision key: which live question a fold answers for is a sign-off judgement,
+# not something a fold can be trusted to imply, so the two are decoupled.
 #
-# `complete` is the shared investigation and visual-review completion gate.
-# `--none` is an explicit semantic attestation that the just-reviewed surface has
-# no unresolved captain decision, and is refused when the origin recorded folds.
-# `--folded` attests that every unresolved decision found is already owned by a
-# hold this origin folded into. Later review passes may add keys; a live task's
-# metadata inventory is unioned idempotently. A post-teardown visual review can
-# complete against the surviving report and holds without recreating task state.
+# `complete` is the shared investigation and visual-review completion gate, and the
+# single owner of status accounting. Every structured decision still open in the
+# origin's status log must be explicitly accounted for, either by supplying its
+# decision key so it is carried by this origin's own captain hold, or by naming
+# that exact key with `--folded-key` so it is carried by a recorded fold. Nothing
+# is inferred from how many entries are open, and no path satisfies an entry the
+# caller did not name. `--none` is an explicit semantic attestation that the
+# just-reviewed surface has no unresolved captain decision, and is refused while
+# any fold is recorded or any status entry is open. `--folded` attests that every
+# unresolved decision this pass found is already owned by a hold the origin folded
+# into. Later review passes may add keys; a live task's metadata inventory is
+# unioned idempotently. A post-teardown visual review can complete against the
+# surviving report and holds without recreating task state. `complete` is the only
+# subcommand that writes the `captain-held [key=...]` transfer event that closes a
+# live status decision against its durable owner.
 # `verify` is read-only and is called by scout teardown so teardown cannot erase a
-# source before this gate has succeeded.
+# source before this gate has succeeded. It applies the accounting check through
+# the same helper `complete` uses, so the two gates cannot drift.
 #
 # `resolve`, `answer`, and `decline` close active holds; `repair` attests a hold
 # already closed outside this script. All four paths take the captain's answer as
@@ -512,41 +516,40 @@ status_transfer_line() {  # <key> <owner-hold-id>
   printf 'captain-held [key=%s]: tracked by %s\n' "$1" "$2"
 }
 
-status_transfer_recorded() {  # <status-file> <key> <owner-hold-id>
+status_transfer_recorded() {  # <status-file> <key>
   [ -f "$1" ] || return 1
-  grep -Fxq -- "$(status_transfer_line "$2" "$3")" "$1"
+  grep -Fq -- "captain-held [key=$2]: " "$1"
 }
 
-# The origin's open structured decision keys this fold covers, one per line.
-# A fold closes the live status copy of the question it folded and nothing else,
-# so `--key` must name a decision that is open here, and it is required whenever
-# any decision is open at all. An unqualified fold has said nothing about which
-# question it covers, and a sole open decision is not evidence that it is the one
-# folded: silently transferring it would mark a question as owned by a decision
-# that never mentions it, which is the loss this gate exists to prevent. Repeated
-# keys collapse, and a key this fold already transferred to the same owner is
-# skipped, so neither a repeated key nor a repeated fold writes a second transfer.
-fold_covered_keys() {  # <origin-id> <open-set> <requested-keys> <owner-hold-id>
-  local origin=$1 open=$2 requested=$3 into=$4 status_file="$STATE/$1.status" key open_keys count covered=''
-  open_keys=$(printf '%s' "$open" | awk -F'\t' 'NF { print $1 }')
-  if [ -n "$requested" ]; then
-    requested=$(sorted_key_union '' "$requested" | tr ',' ' ')
-    for key in $requested; do
-      if printf '%s\n' "$open_keys" | grep -Fxq -- "$key"; then
-        covered="${covered}${key}"$'\n'
-      elif status_transfer_recorded "$status_file" "$key" "$into"; then
-        :
-      else
-        fail "origin $origin has no open structured decision under key $key"
-      fi
-    done
-    printf '%s' "$covered"
-    return 0
-  fi
-  count=0
-  [ -z "$open_keys" ] || count=$(printf '%s\n' "$open_keys" | grep -c . || true)
-  [ "$count" -eq 0 ] \
-    || fail "origin $origin has $count open structured decision$([ "$count" = 1 ] || printf s); name the one this fold covers with --key <decision-key>"
+open_set_keys() {  # <open-set>
+  printf '%s' "$1" | awk -F'\t' 'NF { print $1 }'
+}
+
+open_set_has_key() {  # <open-set> <key>
+  open_set_keys "$1" | grep -Fxq -- "$2"
+}
+
+# The one accounting check the completion gate and the teardown gate both apply.
+# Every structured decision still open in the origin's status log must be named by
+# the caller: either its decision key was supplied, so this origin's own captain
+# hold carries it, or it was named with --folded-key, so a recorded fold carries
+# it. Nothing is inferred from how many entries are open, so an entry the caller
+# never mentioned is always refused.
+verify_status_accounting() {  # <origin-id> <keys-csv> <folded-keys-csv>
+  local origin=$1 keys=$2 folded_keys=$3 open key
+  open=$(origin_open_decisions "$origin")
+  while IFS=$'\t' read -r key _verb _summary; do
+    [ -n "$key" ] || continue
+    if list_has_key "$keys" "$key"; then
+      verify_hold_durable "$(hold_id "$origin" "$key")"
+    elif list_has_key "$folded_keys" "$key"; then
+      :
+    else
+      fail "open structured decision $origin/$key is unaccounted for; supply its decision key or name it with --folded-key"
+    fi
+  done <<EOF
+$open
+EOF
 }
 
 body_has_resolution_record() {  # <hold-body>
@@ -848,14 +851,13 @@ command_hold() {
 }
 
 command_fold() {
-  local origin=${1:-} into='' note='' requested='' meta previous folds body marker tmp status_file open covered key
+  local origin=${1:-} into='' note='' meta previous folds body marker tmp
   [ "$#" -ge 1 ] || { usage >&2; exit 2; }
   shift
   while [ "$#" -gt 0 ]; do
     case "$1" in
       --into) shift; into=${1:-} ;;
       --note) shift; note=${1:-} ;;
-      --key) shift; validate_slug decision-key "${1:-}"; requested="${requested}${requested:+ }${1:-}" ;;
       *) usage >&2; exit 2 ;;
     esac
     shift
@@ -872,19 +874,13 @@ command_fold() {
     "$origin"-decision-*) fail "$into already belongs to $origin; use its own decision key instead" ;;
   esac
   # A fold only means something once it is recorded in the origin's metadata,
-  # which is what lets `complete --folded` accept the origin. Without that file
-  # the fold cannot be recorded, so refuse before touching the target rather than
-  # reporting a success the completion gate will later reject.
+  # which is what lets sign-off account for it. Without that file the fold cannot
+  # be recorded, so refuse before touching the target rather than reporting a
+  # success the completion gate will later reject.
   meta="$STATE/$origin.meta"
   [ -f "$meta" ] || fail "origin $origin has no runtime metadata at $meta, so the fold cannot be recorded; fold from the home that owns $origin"
   ( verify_hold_active "$into" ) >/dev/null 2>&1 \
     || fail "fold target $into is not an open captain decision; a resolved decision needs a new decision key"
-  # Which live status decisions this fold answers for is decided before anything is
-  # written, so a fold that cannot name its coverage refuses instead of leaving the
-  # target mutated and the origin still unable to complete.
-  status_file="$STATE/$origin.status"
-  open=$(origin_open_decisions "$origin")
-  covered=$(fold_covered_keys "$origin" "$open" "$requested" "$into")
 
   marker=$(printf 'Also raised by %s: %s' "$origin" "$note")
   body=$(read_body "$into")
@@ -902,20 +898,11 @@ command_fold() {
   previous=$(meta_value "$meta" decision_folds)
   folds=$(sorted_key_union "$previous" "$into")
   [ "$previous" = "$folds" ] || printf 'decision_folds=%s\n' "$folds" >> "$meta"
-
-  # The live status copy of a folded question is transferred to the decision that
-  # now owns it, exactly as `complete` transfers a question to its own hold, so
-  # `complete --folded` satisfies the per-key requirement instead of dead-ending
-  # on a status decision no key of this origin will ever cover.
-  for key in $covered; do
-    status_transfer_line "$key" "$into" >> "$status_file"
-  done
-  printf 'folded: %s -> %s%s\n' "$origin" "$into" \
-    "$(if [ -n "$covered" ]; then printf ' [keys=%s]' "$(printf '%s\n' "$covered" | sed '/^$/d' | paste -sd, -)"; fi)"
+  printf 'folded: %s -> %s\n' "$origin" "$into"
 }
 
 command_complete() {
-  local origin=${1:-} meta previous='' supplied='' keys='' key status_file open raw_open key_seen=0 has_meta=0 folds='' transfer_rc=0
+  local origin=${1:-} meta previous='' previous_folded='' supplied='' folded_supplied='' keys='' folded_keys='' key none=0 folded_attest=0 status_file open raw_open has_meta=0 folds='' transfer_rc=0
   [ "$#" -ge 2 ] || { usage >&2; exit 2; }
   validate_slug origin-id "$origin"
   shift
@@ -930,28 +917,59 @@ command_complete() {
   require_tasks_axi
   origin_exists_here "$origin" || fail "origin $origin is not owned by the active home $FM_HOME"
   folds=$(origin_fold_ids "$origin")
-  if [ "$#" -eq 1 ] && [ "$1" = --none ]; then
+  status_file="$STATE/$origin.status"
+  raw_open=$(status_open_decisions "$status_file")
+  open=$(origin_open_decisions "$origin")
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --none) none=1 ;;
+      --folded) folded_attest=1 ;;
+      --folded-key)
+        shift
+        validate_slug decision-key "${1:-}"
+        folded_supplied="${folded_supplied}${folded_supplied:+ }${1:-}"
+        folded_attest=1
+        ;;
+      -*) usage >&2; exit 2 ;;
+      *)
+        validate_slug decision-key "$1"
+        supplied="${supplied}${supplied:+ }$1"
+        ;;
+    esac
+    shift
+  done
+  if [ "$none" = 1 ]; then
+    [ -z "$supplied" ] && [ "$folded_attest" = 0 ] \
+      || fail "--none cannot be combined with decision keys or a fold attestation"
     [ -z "$folds" ] \
-      || fail "--none contradicts the folds recorded for $origin ($folds); use --folded"
-    supplied=''
-  elif [ "$#" -eq 1 ] && [ "$1" = --folded ]; then
-    [ -n "$folds" ] \
-      || fail "--folded requires at least one recorded fold; run fm-decision-hold.sh fold first"
-    supplied=''
+      || fail "--none contradicts the folds recorded for $origin ($folds); account for what they cover with --folded-key"
+    [ -z "$open" ] \
+      || fail "--none contradicts the open structured decisions on $origin ($(open_set_keys "$open" | paste -sd, -)); account for each with its decision key or --folded-key"
   else
-    while [ "$#" -gt 0 ]; do
-      [ "$1" != --none ] || fail "--none cannot be combined with decision keys"
-      [ "$1" != --folded ] || fail "--folded cannot be combined with decision keys"
-      validate_slug decision-key "$1"
-      supplied="${supplied}${supplied:+ }$1"
-      shift
-    done
+    [ "$folded_attest" = 0 ] || [ -n "$folds" ] \
+      || fail "a fold attestation requires at least one recorded fold; run fm-decision-hold.sh fold first"
   fi
-  verify_folds "$folds"
   if [ "$has_meta" = 1 ]; then
     previous=$(meta_value "$meta" decision_keys)
+    previous_folded=$(meta_value "$meta" decision_folded_keys)
   fi
+  # A named key must be a live question, one an earlier sign-off already accounted
+  # for, or one already transferred to its owner, so re-running sign-off stays
+  # idempotent while a key that was never open cannot be attested away.
+  for key in $folded_supplied; do
+    if open_set_has_key "$open" "$key"; then
+      :
+    elif list_has_key "$previous_folded" "$key"; then
+      :
+    elif status_transfer_recorded "$status_file" "$key"; then
+      :
+    else
+      fail "origin $origin has no open structured decision under key $key to account for as folded"
+    fi
+  done
+  verify_folds "$folds"
   keys=$(sorted_key_union "$previous" "$supplied")
+  folded_keys=$(sorted_key_union "$previous_folded" "$folded_supplied")
   if [ -n "$keys" ]; then
     while IFS= read -r key; do
       [ -n "$key" ] || continue
@@ -960,50 +978,48 @@ command_complete() {
 $(printf '%s\n' "$keys" | tr ',' '\n')
 EOF
   fi
-
-  status_file="$STATE/$origin.status"
-  raw_open=$(status_open_decisions "$status_file")
-  open=$(origin_open_decisions "$origin")
-  while IFS=$'\t' read -r key _verb _summary; do
-    [ -n "$key" ] || continue
-    list_has_key "$keys" "$key" \
-      || fail "open structured decision $origin/$key has no captain-held inventory entry"
-  done <<EOF
-$open
-EOF
+  verify_status_accounting "$origin" "$keys" "$folded_keys"
 
   if [ "$has_meta" = 1 ]; then
-    if [ "$(meta_value "$meta" decisions_reviewed)" != 1 ] || [ "$previous" != "$keys" ]; then
-      printf 'decisions_reviewed=1\ndecision_keys=%s\n' "$keys" >> "$meta"
+    if [ "$(meta_value "$meta" decisions_reviewed)" != 1 ] \
+      || [ "$previous" != "$keys" ] || [ "$previous_folded" != "$folded_keys" ]; then
+      printf 'decisions_reviewed=1\ndecision_keys=%s\ndecision_folded_keys=%s\n' \
+        "$keys" "$folded_keys" >> "$meta"
     fi
     fm_lock_release "$DECISION_META_LOCK"
     DECISION_META_LOCK_HELD=0
 
-    # Transfer any still-open status decision to its durable backlog owner so the
-    # live status fold does not duplicate the same Captain's Call item.
-    # The transfer line is this home's own bookkeeping close, written by the
-    # turn that just reviewed the decision, so it uses the guarded
-    # self-announced append (bin/fm-wake-lib.sh) and does not wake this same
-    # session; an append failure still fails this command loudly.
+    # Transfer every accounted-for status decision to the durable owner that
+    # carries it, so the live status copy does not duplicate the same Captain's
+    # Call item. This is the only place that event is written. The transfer
+    # line is this home's own bookkeeping close, written by the turn that just
+    # reviewed the decision, so it uses the guarded self-announced append
+    # (bin/fm-wake-lib.sh) and does not wake this same session; an append
+    # failure still fails this command loudly.
     while IFS=$'\t' read -r key _verb _summary; do
       [ -n "$key" ] || continue
-      list_has_key "$keys" "$key" || continue
       transfer_rc=0
-      fm_wake_status_append_self_announced "$STATE" "$status_file" \
-        "$(status_transfer_line "$key" "$(hold_id "$origin" "$key")")" || transfer_rc=$?
+      if list_has_key "$keys" "$key"; then
+        fm_wake_status_append_self_announced "$STATE" "$status_file" \
+          "$(status_transfer_line "$key" "$(hold_id "$origin" "$key")")" || transfer_rc=$?
+      elif list_has_key "$folded_keys" "$key"; then
+        fm_wake_status_append_self_announced "$STATE" "$status_file" \
+          "$(status_transfer_line "$key" "$folds")" || transfer_rc=$?
+      else
+        continue
+      fi
       [ "$transfer_rc" -ne 2 ] || fail "cannot append the captain-held transfer for $origin/$key"
-      key_seen=1
     done <<EOF
 $raw_open
 EOF
   fi
-  : "$key_seen"
-  printf 'complete: %s decision inventory reviewed%s%s\n' \
-    "$origin" "${keys:+ ($keys)}" "${folds:+ [folded into $folds]}"
+  printf 'complete: %s decision inventory reviewed%s%s%s\n' \
+    "$origin" "${keys:+ ($keys)}" "${folds:+ [folded into $folds]}" \
+    "${folded_keys:+ [folded keys: $folded_keys]}"
 }
 
 command_verify() {
-  local origin=${1:-} meta reviewed keys key open
+  local origin=${1:-} meta reviewed keys key
   [ "$#" -eq 1 ] || { usage >&2; exit 2; }
   validate_slug origin-id "$origin"
   meta="$STATE/$origin.meta"
@@ -1021,15 +1037,7 @@ command_verify() {
 $(printf '%s\n' "$keys" | tr ',' '\n')
 EOF
   fi
-  open=$(origin_open_decisions "$origin")
-  while IFS=$'\t' read -r key _verb _summary; do
-    [ -n "$key" ] || continue
-    list_has_key "$keys" "$key" \
-      || fail "open structured decision $origin/$key is outside the reviewed inventory"
-    verify_hold_durable "$(hold_id "$origin" "$key")"
-  done <<EOF
-$open
-EOF
+  verify_status_accounting "$origin" "$keys" "$(meta_value "$meta" decision_folded_keys)"
   printf 'verified: %s unresolved-decision inventory\n' "$origin"
 }
 

--- a/bin/fm-decision-hold.sh
+++ b/bin/fm-decision-hold.sh
@@ -18,38 +18,69 @@
 #
 # Usage:
 #   fm-decision-hold.sh id <origin-id> <decision-key>
+#   fm-decision-hold.sh open [--origin <origin-id>] [--aging-only]
 #   fm-decision-hold.sh hold <origin-id> <decision-key> \
-#     --title <title> --reason <reason> [--repo <repo>]
-#   fm-decision-hold.sh complete <origin-id> (--none | <decision-key>...)
+#     --title <title> --reason <reason> [--repo <repo>] [--distinct]
+#   fm-decision-hold.sh fold <origin-id> --into <hold-id> --note <note>
+#   fm-decision-hold.sh complete <origin-id> (--none | --folded | <decision-key>...)
 #   fm-decision-hold.sh verify <origin-id>
 #   fm-decision-hold.sh resolve <origin-id> <decision-key> \
-#     --decision-file <path> --routed-to <task-id> [--routed-to <task-id>...]
-#   fm-decision-hold.sh answer <origin-id> <decision-key> --decision-file <path>
+#     (--decision <text> | --decision-file <path>) [--decided-by captain|firstmate] \
+#     (--routed-to <task-id>... | --no-routed-work)
+#   fm-decision-hold.sh answer <origin-id> <decision-key> \
+#     (--decision <text> | --decision-file <path>) [--decided-by captain|firstmate]
 #   fm-decision-hold.sh answers <origin-id> --source <provenance>   (keyed answers on stdin)
 #   fm-decision-hold.sh bind <source-id> <origin-id>
 #   fm-decision-hold.sh unbind <source-id>
 #   fm-decision-hold.sh binding <source-id>
-#   fm-decision-hold.sh decline <origin-id> <decision-key> --decision-file <path>
-#   fm-decision-hold.sh repair <origin-id> <decision-key> --decision-file <path>
+#   fm-decision-hold.sh decline <origin-id> <decision-key> \
+#     (--decision <text> | --decision-file <path>) [--decided-by captain|firstmate]
+#   fm-decision-hold.sh repair <origin-id> <decision-key> \
+#     (--decision <text> | --decision-file <path>) [--decided-by captain|firstmate]
+#
+# `open` lists every open captain decision in the active home with the date it was
+# registered and how many days it has been waiting. `--aging-only` keeps just the
+# decisions at or past FM_DECISION_AGING_DAYS (default 3). It is read-only.
+#
+# `hold` refuses to create a NEW backlog identity while the active home already
+# holds other open captain decisions, printing that open set and exiting 3. The
+# refusal exists because a second key covering an already-open question is the
+# common way this queue compounds, and the open set must be in front of the agent
+# before it registers another. Clear it either by folding the finding into the
+# decision it duplicates or, when the question is genuinely different, by passing
+# `--distinct`, which records the attestation in the new hold's body. Repeating
+# `hold` on an existing identity stays idempotent and is never gated, so retry and
+# recovery paths are unaffected.
+#
+# `fold` is the first-class alternative to a second decision: it appends this
+# pass's finding to an existing open hold's body and records the fold in the new
+# origin's metadata, so the origin still satisfies the completion gate without
+# creating a duplicate captain decision.
 #
 # `complete` is the shared investigation and visual-review completion gate.
 # `--none` is an explicit semantic attestation that the just-reviewed surface has
-# no unresolved captain decision. Later review passes may add keys; a live task's
+# no unresolved captain decision, and is refused when the origin recorded folds.
+# `--folded` attests that every unresolved decision found is already owned by a
+# hold this origin folded into. Later review passes may add keys; a live task's
 # metadata inventory is unioned idempotently. A post-teardown visual review can
 # complete against the surviving report and holds without recreating task state.
 # `verify` is read-only and is called by scout teardown so teardown cannot erase a
 # source before this gate has succeeded.
 #
 # `resolve`, `answer`, and `decline` close active holds; `repair` attests a hold
-# already closed outside this script. All four paths require a non-empty captain
-# decision file of at most 8192 bytes, record the same durable resolution block in
-# the hold body, and store the decision digest plus routed identities so an exact
-# retry is idempotent while a changed decision or, for `resolve`, routed set is
-# rejected. New records include a `Resolution mode:` naming their path; older
-# routed records remain valid.
+# already closed outside this script. All four paths take the captain's answer as
+# `--decision <text>` or `--decision-file <path>` of at most 8192 bytes, record the
+# same durable resolution block in the hold body, and store the decision digest
+# plus routed identities so an exact retry is idempotent while a changed decision
+# or, for `resolve`, routed set is rejected. `--decided-by` records who settled it:
+# `captain` by default, or `firstmate` when the question turned out to be
+# firstmate's own call. New records include a `Resolution mode:` naming their path
+# and a `Decided by:` naming the decider; older records remain valid.
 #
 # `resolve` is the routed path. It requires every --routed-to task to exist and to
-# be blocked by the hold. It writes the captain decision and routed identities into
+# be blocked by the hold, or declares no dependent work exists with
+# `--no-routed-work`, which is refused whenever any backlog task is actually
+# blocked by the hold. It writes the captain decision and routed identities into
 # the hold body, clears those dependency edges, and only then marks the hold Done.
 # A failure before the final step leaves the captain hold open.
 #
@@ -96,19 +127,38 @@
 # channel can be bound BEFORE it is armed and never produce an answer that has
 # nowhere to go.
 #
-# `decline` is the unrouted path for a decision the captain answered with no
-# follow-up work. It takes no --routed-to task, records `(none)` as the routed
-# identities, and closes an actively held hold. It refuses while any task is still
+# `decline` is the unrouted sibling of `resolve`, for a decision the captain
+# answered with no follow-up work. It takes the same `--decision`/`--decision-file`
+# and `--decided-by` inputs but no `--routed-to`; it records `(none)` as the routed
+# identities and closes an actively held hold. It refuses while any task is still
 # blocked by the hold, because releasing routed work without recording it is
 # `resolve`'s job.
 #
 # `repair` records the missing resolution block on a hold that was already closed
 # outside this script, so `verify` stops failing on an origin whose decision was
-# genuinely answered. It never reopens a hold, never clears a dependency edge, and
-# refuses a hold that is still actively held, so an unanswered decision keeps
-# blocking teardown until `resolve` or `decline` closes it with the captain's word.
-# It also refuses an identity that does not carry surviving captain-hold
-# provenance, so an ordinary captain-kind task cannot be repaired into a decision.
+# genuinely answered. It takes the same decision inputs as `resolve`/`decline`. It
+# never reopens a hold, never clears a dependency edge, and refuses a hold that is
+# still actively held, so an unanswered decision keeps blocking teardown until
+# `resolve` or `decline` closes it with the captain's word. It also refuses an
+# identity that does not carry surviving captain-hold provenance, so an ordinary
+# captain-kind task cannot be repaired into a decision.
+#
+# `resolve`, `decline`, and `repair` all record the same durable resolution block
+# in the hold body, storing the decision digest and routed identities (`(none)` for
+# decline/repair) so an exact retry is idempotent while a changed decision or, for
+# `resolve`, a changed routed set is rejected. Each record carries a `Resolution
+# mode:` naming its path and a `Decided by:` naming who settled it; older records
+# from before either field existed remain valid and default to `captain`.
+#
+# The completion and teardown gates accept a decision as durably resolved when it
+# is closed and carries a decision record, whatever wrote that record, and when
+# Done retention has rotated it into data/done-archive.md. A decision closed with
+# no record at all is still refused, because that is the loss the gate exists to
+# prevent; the gate checks that an answer survives, not that this script formatted
+# it.
+#
+# Environment: FM_DECISION_AGING_DAYS (default 3) sets the ageing threshold and
+# FM_DECISION_NOW (YYYY-MM-DD) pins today's date for tests.
 set -eu
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -187,17 +237,179 @@ ROUTED_NONE='(none)'
 
 DECISION_TEXT=''
 DECISION_DIGEST=''
+DECIDED_BY=''
 
-load_decision() {  # <path>; sets DECISION_TEXT and DECISION_DIGEST
-  local path=$1 decision
-  [ -n "$path" ] || fail "--decision-file is required"
-  [ -f "$path" ] || fail "decision file does not exist: $path"
-  decision=$(cat "$path")
-  [ -n "$decision" ] || fail "decision file must not be empty"
-  [ "$(printf '%s' "$decision" | LC_ALL=C wc -c | tr -d ' ')" -le 8192 ] \
-    || fail "decision file exceeds 8192 bytes"
-  DECISION_TEXT=$decision
-  DECISION_DIGEST=$(sha256_text "$decision")
+# Parses the --decision/--decision-file/--decided-by inputs shared by decline and
+# repair - the same shape resolve takes, minus routing - and loads the captain's
+# decision into DECISION_TEXT/DECISION_DIGEST and DECIDED_BY.
+parse_decision_answer() {  # "$@"
+  local decision_file='' decision_text=''
+  DECIDED_BY=captain
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --decision-file) shift; decision_file=${1:-} ;;
+      --decision) shift; decision_text=${1:-} ;;
+      --decided-by) shift; DECIDED_BY=${1:-} ;;
+      *) usage >&2; exit 2 ;;
+    esac
+    shift
+  done
+  case "$DECIDED_BY" in
+    captain|firstmate) : ;;
+    *) fail "--decided-by must be captain or firstmate" ;;
+  esac
+  [ -z "$decision_file" ] || [ -z "$decision_text" ] \
+    || fail "--decision and --decision-file are mutually exclusive"
+  if [ -n "$decision_file" ]; then
+    [ -f "$decision_file" ] || fail "decision file does not exist: $decision_file"
+    DECISION_TEXT=$(cat "$decision_file")
+    [ -n "$DECISION_TEXT" ] || fail "decision file must not be empty"
+  else
+    [ -n "$decision_text" ] || fail "--decision <text> or --decision-file <path> is required"
+    DECISION_TEXT=$decision_text
+  fi
+  [ "$(printf '%s' "$DECISION_TEXT" | LC_ALL=C wc -c | tr -d ' ')" -le 8192 ] \
+    || fail "the captain decision exceeds 8192 bytes"
+  DECISION_DIGEST=$(sha256_text "$DECISION_TEXT")
+}
+
+require_jq() {
+  command -v jq >/dev/null 2>&1 || fail "jq is required to read and rewrite a decision body"
+}
+
+aging_days() {
+  local days=${FM_DECISION_AGING_DAYS:-3}
+  case "$days" in ''|*[!0-9]*) days=3 ;; esac
+  printf '%s\n' "$days"
+}
+
+today_utc() {
+  printf '%s\n' "${FM_DECISION_NOW:-$(date -u +%Y-%m-%d)}"
+}
+
+date_epoch() {  # <YYYY-MM-DD>
+  date -u -j -f '%Y-%m-%d' "$1" +%s 2>/dev/null \
+    || date -u -d "$1" +%s 2>/dev/null \
+    || true
+}
+
+waiting_days() {  # <since-date>
+  local since=$1 now_epoch since_epoch days
+  now_epoch=$(date_epoch "$(today_utc)")
+  since_epoch=$(date_epoch "$since")
+  case "$now_epoch" in ''|*[!0-9]*) return 0 ;; esac
+  case "$since_epoch" in ''|*[!0-9]*) return 0 ;; esac
+  days=$(( (now_epoch - since_epoch) / 86400 ))
+  [ "$days" -ge 0 ] || days=0
+  printf '%s\n' "$days"
+}
+
+# tasks-axi renders rows as CSV that quotes any field containing a comma, so the
+# columns are parsed with quote awareness rather than a naive split.
+# shellcheck disable=SC2016  # awk source: $0 is awk's record, not a shell expansion.
+TASKS_AXI_CSV_AWK='
+  function parse_csv(s, out,   i, n, c, field, inq) {
+    n = 0; field = ""; inq = 0
+    for (i = 1; i <= length(s); i++) {
+      c = substr(s, i, 1)
+      if (inq) {
+        if (c == "\"") {
+          if (substr(s, i + 1, 1) == "\"") { field = field "\""; i++ } else { inq = 0 }
+        } else { field = field c }
+      } else if (c == "\"") { inq = 1 }
+      else if (c == ",") { out[++n] = field; field = "" }
+      else { field = field c }
+    }
+    out[++n] = field
+    return n
+  }
+  function clean(s) { gsub(/\t/, " ", s); return s }
+  /^tasks\[/ { rows = 1; next }
+  rows && !/^  / { rows = 0 }
+  rows && /^  / { line = $0; sub(/^  /, "", line); emit(line) }
+'
+
+# Every open captain decision in the active home as
+# "<id>\t<since>\t<title>\t<reason>", ordered oldest first.
+list_open_captain_decisions() {
+  tasks_axi list --state held --kind captain --fields hold_reason,hold_kind,created 2>/dev/null \
+    | awk "
+        function emit(line,   f, n) {
+          n = parse_csv(line, f)
+          if (n < 8) return
+          if (f[7] != \"captain\") return
+          printf \"%s\t%s\t%s\t%s\n\", f[1], f[8], clean(f[5]), clean(f[6])
+        }
+        $TASKS_AXI_CSV_AWK
+      " \
+    | LC_ALL=C sort -t"$(printf '\t')" -k2,2 -k1,1
+}
+
+# Backlog ids whose structured blocked-by edges name <hold-id>.
+list_tasks_blocked_by() {  # <hold-id>
+  tasks_axi list --blocked --fields blocked_by 2>/dev/null \
+    | awk -v want="$1" "
+        function emit(line,   f, n, i, parts) {
+          n = parse_csv(line, f)
+          if (n < 6) return
+          split(f[6], parts, \",\")
+          for (i in parts) { if (parts[i] == want) { print f[1]; return } }
+        }
+        $TASKS_AXI_CSV_AWK
+      "
+}
+
+render_open_decisions() {  # <tsv>
+  local tsv=$1 id since title reason days
+  [ -n "$tsv" ] || return 0
+  while IFS=$'\t' read -r id since title reason; do
+    [ -n "$id" ] || continue
+    days=$(waiting_days "$since")
+    if [ -n "$days" ]; then
+      printf -- '- %s (waiting %s day%s, since %s)\n' \
+        "$id" "$days" "$([ "$days" = 1 ] || printf s)" "$since"
+    else
+      printf -- '- %s (since %s)\n' "$id" "$since"
+    fi
+    printf '    question: %s\n' "$title"
+    [ -z "$reason" ] || printf '    reason: %s\n' "$reason"
+  done <<EOF
+$tsv
+EOF
+}
+
+read_body() {  # <hold-id>
+  local show body
+  require_jq
+  show=$(task_show "$1") || fail "captain decision $1 is absent from $FM_HOME/data/backlog.md"
+  body=$(show_field "$show" body)
+  [ -n "$body" ] || return 0
+  # tasks-axi renders the body as a JSON string literal on one line.
+  printf '%s' "$body" | jq -r 'if type == "string" then . else tostring end' 2>/dev/null \
+    || fail "could not read the current body of $1"
+}
+
+origin_fold_ids() {  # <origin-id>
+  local meta="$STATE/$1.meta"
+  [ -f "$meta" ] || return 0
+  meta_value "$meta" decision_folds
+}
+
+# The registration record a resolution must not erase. On a first resolution that
+# is the whole current body; on a retry it is the record the previous attempt
+# already carried forward, so retries stay idempotent instead of nesting.
+prior_registration() {  # <hold-id>
+  local body
+  body=$(read_body "$1")
+  case "$body" in
+    'Resolution recorded by fm-decision-hold.'*)
+      case "$body" in
+        *"$(printf '\nOrigin record:\n')"*) printf '%s' "${body#*$'\nOrigin record:\n'}" ;;
+        *) : ;;
+      esac
+      ;;
+    *) printf '%s' "$body" ;;
+  esac
 }
 
 tasks_axi() {
@@ -273,8 +485,8 @@ resolution_body() {  # <mode> <routed-csv> [routed-task-id...]
   shift 2
   # Command substitution strips the trailing newline, so restore it before the
   # routed-work list to keep each entry on its own durable backlog line.
-  body=$(printf 'Resolution recorded by fm-decision-hold.\nDecision digest: %s\nRouted identities: %s\nResolution mode: %s\n\nCaptain decision:\n%s\n\nRouted work:' \
-    "$DECISION_DIGEST" "$routed_csv" "$mode" "$DECISION_TEXT")
+  body=$(printf 'Resolution recorded by fm-decision-hold.\nDecision digest: %s\nRouted identities: %s\nDecided by: %s\nResolution mode: %s\n\nCaptain decision:\n%s\n\nRouted work:' \
+    "$DECISION_DIGEST" "$routed_csv" "$DECIDED_BY" "$mode" "$DECISION_TEXT")
   body="${body}"$'\n'
   if [ "$#" -eq 0 ]; then
     body="${body}${ROUTED_NONE}"$'\n'
@@ -347,9 +559,22 @@ verify_hold_resolved() {  # <hold-id>
   body_has_resolution_record "$body"
 }
 
+# True when the backlog's Done retention has rotated <hold-id> into the archive.
+# The archived row is durable proof the decision was closed, so retention alone
+# must never make a reviewed inventory unverifiable.
+archived_done_record() {  # <hold-id>
+  local archive="$DATA/done-archive.md"
+  [ -f "$archive" ] || return 1
+  grep -F -- "- [x] $1 - " "$archive" >/dev/null && return 0
+  grep -F -- "- [X] $1 - " "$archive" >/dev/null
+}
+
 verify_hold_durable() {  # <hold-id>
   local id=$1 show state held kind hold_kind body
-  show=$(task_show "$id") || fail "captain decision $id is absent from $FM_HOME/data/backlog.md"
+  if ! show=$(task_show "$id"); then
+    archived_done_record "$id" && return 0
+    fail "captain decision $id is absent from $FM_HOME/data/backlog.md and its Done archive"
+  fi
   state=$(show_field "$show" state)
   held=$(show_field "$show" held)
   kind=$(show_field "$show" kind)
@@ -358,14 +583,33 @@ verify_hold_durable() {  # <hold-id>
   if [ "$state" = queued ] && [ "$held" = yes ] && [ "$kind" = captain ] && [ "$hold_kind" = captain ]; then
     return 0
   fi
-  if [ "$state" = "done" ] && [ "$kind" = captain ] && body_has_resolution_record "$body"; then
-    return 0
+  if [ "$state" = "done" ] && [ "$kind" = captain ]; then
+    case "$body" in
+      *"Resolution recorded by fm-decision-hold."*"Routed work:"*) return 0 ;;
+    esac
+    # A decision closed outside this script - because firstmate decided it, or
+    # because an earlier captain answer already settled it - is durably resolved
+    # when its body carries a decision record. The gate exists to stop a decision
+    # vanishing unanswered, not to insist on this script's own formatting.
+    # A body still carrying the untouched registration record says in its own
+    # words that no answer was ever written, so that closure is still refused.
+    case "$body" in
+      ''|'""'|'"-"') : ;;
+      *"State: awaiting captain decision."*) : ;;
+      *) return 0 ;;
+    esac
+    fail "captain decision $id was closed with no decision record; record the answer in its body"
   fi
   fail "captain decision $id is neither actively held nor durably resolved"
 }
 
+# The retry identity is the decision digest, the routed identities, and the
+# recorded attributor. Attribution is part of the identity because a retry that
+# claims a different decider than the durable record would print success while the
+# record kept contradicting it. A record written before attribution existed reads
+# as `captain`, which is what it always meant.
 verify_resolution_identity() {
-  local id=$1 hold_body=$2 decision_digest=$3 routed_csv=$4 resolution_prefix resolution_fields recorded_digest recorded_routes
+  local id=$1 hold_body=$2 decision_digest=$3 routed_csv=$4 decided_by=$5 resolution_prefix resolution_fields recorded_digest recorded_routes recorded_decided_by tail
   resolution_prefix='"Resolution recorded by fm-decision-hold.\nDecision digest: '
   case "$hold_body" in
     "$resolution_prefix"*) resolution_fields=${hold_body#"$resolution_prefix"} ;;
@@ -376,12 +620,21 @@ verify_resolution_identity() {
     *) fail "captain hold $id has an invalid retry identity record" ;;
   esac
   recorded_digest=${resolution_fields%%\\n*}
-  resolution_fields=${resolution_fields#*\\nRouted identities: }
-  recorded_routes=${resolution_fields%%\\n*}
+  tail=${resolution_fields#*\\nRouted identities: }
+  recorded_routes=${tail%%\\n*}
+  case "$tail" in
+    *'\nDecided by: '*)
+      tail=${tail#*\\nDecided by: }
+      recorded_decided_by=${tail%%\\n*}
+      ;;
+    *) recorded_decided_by=captain ;;
+  esac
   [ "$recorded_digest" = "$decision_digest" ] \
     || fail "captain hold $id records a different captain decision"
   [ "$recorded_routes" = "$routed_csv" ] \
     || fail "captain hold $id records different routed work"
+  [ "$recorded_decided_by" = "$decided_by" ] \
+    || fail "captain hold $id records a different decider ($recorded_decided_by)"
 }
 
 command_id() {
@@ -389,8 +642,43 @@ command_id() {
   hold_id "$1" "$2"
 }
 
+command_open() {
+  local origin='' aging_only=0 tsv threshold count id since title reason days
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --origin) shift; validate_slug origin-id "${1:-}"; origin=${1:-} ;;
+      --aging-only) aging_only=1 ;;
+      *) usage >&2; exit 2 ;;
+    esac
+    shift
+  done
+  require_tasks_axi
+  tsv=$(list_open_captain_decisions)
+  if [ -n "$origin" ] && [ -n "$tsv" ]; then
+    tsv=$(printf '%s\n' "$tsv" | awk -F'\t' -v prefix="$origin-decision-" 'index($1, prefix) == 1')
+  fi
+  if [ "$aging_only" = 1 ] && [ -n "$tsv" ]; then
+    threshold=$(aging_days)
+    tsv=$(
+      while IFS=$'\t' read -r id since title reason; do
+        [ -n "$id" ] || continue
+        days=$(waiting_days "$since")
+        [ -n "$days" ] || continue
+        [ "$days" -ge "$threshold" ] || continue
+        printf '%s\t%s\t%s\t%s\n' "$id" "$since" "$title" "$reason"
+      done <<EOF
+$tsv
+EOF
+    )
+  fi
+  count=0
+  [ -z "$tsv" ] || count=$(printf '%s\n' "$tsv" | grep -c . || true)
+  printf 'open captain decisions in %s: %s\n' "$FM_HOME" "$count"
+  render_open_decisions "$tsv"
+}
+
 command_hold() {
-  local origin=${1:-} key=${2:-} title='' reason='' repo='' id show state kind existing_title body
+  local origin=${1:-} key=${2:-} title='' reason='' repo='' distinct=0 id show state kind existing_title body others attest=''
   [ "$#" -ge 2 ] || { usage >&2; exit 2; }
   shift 2
   while [ "$#" -gt 0 ]; do
@@ -398,6 +686,7 @@ command_hold() {
       --title) shift; title=${1:-} ;;
       --reason) shift; reason=${1:-} ;;
       --repo) shift; repo=${1:-} ;;
+      --distinct) distinct=1 ;;
       *) usage >&2; exit 2 ;;
     esac
     shift
@@ -418,6 +707,26 @@ command_hold() {
     [ "$kind" = captain ] || fail "existing backlog identity $id is not kind captain"
     [ "$existing_title" = "$title" ] || fail "existing captain hold $id has a different title"
   else
+    # A different key covering an already-open question is how this queue
+    # compounds, so the open set is placed in front of the caller before any new
+    # backlog identity is created. Exact-key retries never reach this branch.
+    others=$(list_open_captain_decisions | awk -F'\t' -v self="$id" '$1 != self')
+    if [ -n "$others" ] && [ "$distinct" != 1 ]; then
+      {
+        printf 'fm-decision-hold: refusing to open a new captain decision before the open set is reviewed.\n'
+        printf 'Open captain decisions in %s:\n' "$FM_HOME"
+        render_open_decisions "$others"
+        printf '\n'
+        printf 'If %s is the SAME question as one of these, fold this finding in instead:\n' "$key"
+        printf '  fm-decision-hold.sh fold %s --into <hold-id> --note <what this pass adds>\n' "$origin"
+        printf 'If it is a genuinely different question, re-run the same command with --distinct.\n'
+      } >&2
+      exit 3
+    fi
+    if [ -n "$others" ]; then
+      attest=$(printf '\nDistinct-from-open: attested %s against %s open captain decision(s).' \
+        "$(today_utc)" "$(printf '%s\n' "$others" | grep -c . || true)")
+    fi
     if [ -z "$repo" ] && [ -f "$STATE/$origin.meta" ]; then
       repo=$(meta_value "$STATE/$origin.meta" project)
       repo=${repo%/}
@@ -425,7 +734,7 @@ command_hold() {
     fi
     [ -n "$repo" ] || repo=firstmate
     validate_one_line repo "$repo"
-    body=$(printf 'Origin: %s\nDecision key: %s\nState: awaiting captain decision.' "$origin" "$key")
+    body=$(printf 'Origin: %s\nDecision key: %s\nState: awaiting captain decision.%s' "$origin" "$key" "$attest")
     tasks_axi add "$id" "$title" --kind captain --repo "$repo" --body "$body" >/dev/null \
       || fail "could not create captain decision item $id"
   fi
@@ -435,8 +744,56 @@ command_hold() {
   printf '%s\n' "$id"
 }
 
+command_fold() {
+  local origin=${1:-} into='' note='' meta previous folds body marker tmp
+  [ "$#" -ge 1 ] || { usage >&2; exit 2; }
+  shift
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --into) shift; into=${1:-} ;;
+      --note) shift; note=${1:-} ;;
+      *) usage >&2; exit 2 ;;
+    esac
+    shift
+  done
+  validate_slug origin-id "$origin"
+  [ -n "$into" ] || fail "--into <hold-id> is required"
+  validate_slug hold-id "$into"
+  validate_one_line note "$note"
+  require_tasks_axi
+  require_jq
+  origin_exists_here "$origin" || fail "origin $origin is not owned by the active home $FM_HOME"
+  [ "$into" != "$origin" ] || fail "an origin cannot fold into itself"
+  case "$into" in
+    "$origin"-decision-*) fail "$into already belongs to $origin; use its own decision key instead" ;;
+  esac
+  ( verify_hold_active "$into" ) >/dev/null 2>&1 \
+    || fail "fold target $into is not an open captain decision; a resolved decision needs a new decision key"
+
+  marker=$(printf 'Also raised by %s: %s' "$origin" "$note")
+  body=$(read_body "$into")
+  case "$body" in
+    *"$marker"*) : ;;
+    *)
+      tmp=$(mktemp) || fail "could not create a temporary file"
+      printf '%s\n%s\n' "$body" "$marker" > "$tmp"
+      tasks_axi update "$into" --body-file "$tmp" >/dev/null \
+        || { rm -f "$tmp"; fail "could not record the folded finding on $into"; }
+      rm -f "$tmp"
+      ;;
+  esac
+
+  meta="$STATE/$origin.meta"
+  if [ -f "$meta" ]; then
+    previous=$(meta_value "$meta" decision_folds)
+    folds=$(sorted_key_union "$previous" "$into")
+    [ "$previous" = "$folds" ] || printf 'decision_folds=%s\n' "$folds" >> "$meta"
+  fi
+  printf 'folded: %s -> %s\n' "$origin" "$into"
+}
+
 command_complete() {
-  local origin=${1:-} meta previous='' supplied='' keys='' key status_file open raw_open key_seen=0 has_meta=0
+  local origin=${1:-} meta previous='' supplied='' keys='' key status_file open raw_open key_seen=0 has_meta=0 folds=''
   [ "$#" -ge 2 ] || { usage >&2; exit 2; }
   validate_slug origin-id "$origin"
   shift
@@ -450,15 +807,31 @@ command_complete() {
   fi
   require_tasks_axi
   origin_exists_here "$origin" || fail "origin $origin is not owned by the active home $FM_HOME"
+  folds=$(origin_fold_ids "$origin")
   if [ "$#" -eq 1 ] && [ "$1" = --none ]; then
+    [ -z "$folds" ] \
+      || fail "--none contradicts the folds recorded for $origin ($folds); use --folded"
+    supplied=''
+  elif [ "$#" -eq 1 ] && [ "$1" = --folded ]; then
+    [ -n "$folds" ] \
+      || fail "--folded requires at least one recorded fold; run fm-decision-hold.sh fold first"
     supplied=''
   else
     while [ "$#" -gt 0 ]; do
       [ "$1" != --none ] || fail "--none cannot be combined with decision keys"
+      [ "$1" != --folded ] || fail "--folded cannot be combined with decision keys"
       validate_slug decision-key "$1"
       supplied="${supplied}${supplied:+ }$1"
       shift
     done
+  fi
+  if [ -n "$folds" ]; then
+    while IFS= read -r key; do
+      [ -n "$key" ] || continue
+      verify_hold_durable "$key"
+    done <<EOF
+$(printf '%s\n' "$folds" | tr ',' '\n')
+EOF
   fi
   if [ "$has_meta" = 1 ]; then
     previous=$(meta_value "$meta" decision_keys)
@@ -510,11 +883,12 @@ $raw_open
 EOF
   fi
   : "$key_seen"
-  printf 'complete: %s decision inventory reviewed%s\n' "$origin" "${keys:+ ($keys)}"
+  printf 'complete: %s decision inventory reviewed%s%s\n' \
+    "$origin" "${keys:+ ($keys)}" "${folds:+ [folded into $folds]}"
 }
 
 command_verify() {
-  local origin=${1:-} meta reviewed keys key open
+  local origin=${1:-} meta reviewed keys key open folds
   [ "$#" -eq 1 ] || { usage >&2; exit 2; }
   validate_slug origin-id "$origin"
   meta="$STATE/$origin.meta"
@@ -522,6 +896,15 @@ command_verify() {
   require_tasks_axi
   reviewed=$(meta_value "$meta" decisions_reviewed)
   [ "$reviewed" = 1 ] || fail "origin $origin has no completed unresolved-decision inventory"
+  folds=$(meta_value "$meta" decision_folds)
+  if [ -n "$folds" ]; then
+    while IFS= read -r key; do
+      [ -n "$key" ] || continue
+      verify_hold_durable "$key"
+    done <<EOF
+$(printf '%s\n' "$folds" | tr ',' '\n')
+EOF
+  fi
   keys=$(meta_value "$meta" decision_keys)
   if [ -n "$keys" ]; then
     while IFS= read -r key; do
@@ -544,29 +927,57 @@ EOF
 }
 
 command_resolve() {
-  local origin=${1:-} key=${2:-} decision_file='' id='' body='' routed='' routed_csv='' dep show blocked state hold_show hold_body resolution_recorded=0
+  local origin=${1:-} key=${2:-} decision_file='' decision_text='' decided_by=captain no_routed=0 id='' decision='' decision_digest='' body='' routed='' routed_csv='' dep show blocked state hold_show hold_body resolution_recorded=0 still_blocked prior=''
   [ "$#" -ge 2 ] || { usage >&2; exit 2; }
   shift 2
   while [ "$#" -gt 0 ]; do
     case "$1" in
       --decision-file) shift; decision_file=${1:-} ;;
+      --decision) shift; decision_text=${1:-} ;;
+      --decided-by) shift; decided_by=${1:-} ;;
       --routed-to) shift; validate_slug routed-task "${1:-}"; routed="${routed}${routed:+ }${1:-}" ;;
+      --no-routed-work) no_routed=1 ;;
       *) usage >&2; exit 2 ;;
     esac
     shift
   done
   validate_slug origin-id "$origin"
   validate_slug decision-key "$key"
-  load_decision "$decision_file"
-  [ -n "$routed" ] || fail "at least one --routed-to task is required; use decline when the captain's answer routes no work"
-  routed=$(printf '%s\n' "$routed" | tr ' ' '\n' | sed '/^$/d' | LC_ALL=C sort -u | paste -sd' ' -)
-  routed_csv=$(printf '%s\n' "$routed" | tr ' ' ',')
+  case "$decided_by" in
+    captain|firstmate) : ;;
+    *) fail "--decided-by must be captain or firstmate" ;;
+  esac
+  [ -z "$decision_file" ] || [ -z "$decision_text" ] \
+    || fail "--decision and --decision-file are mutually exclusive"
+  if [ -n "$decision_file" ]; then
+    [ -f "$decision_file" ] || fail "decision file does not exist: $decision_file"
+    decision=$(cat "$decision_file")
+    [ -n "$decision" ] || fail "decision file must not be empty"
+  else
+    [ -n "$decision_text" ] || fail "--decision <text> or --decision-file <path> is required"
+    decision=$decision_text
+  fi
+  [ "$(printf '%s' "$decision" | LC_ALL=C wc -c | tr -d ' ')" -le 8192 ] \
+    || fail "the captain decision exceeds 8192 bytes"
   require_tasks_axi
   id=$(hold_id "$origin" "$key")
+  if [ "$no_routed" = 1 ]; then
+    [ -z "$routed" ] || fail "--no-routed-work cannot be combined with --routed-to"
+    # The routing requirement survives wherever dependent work genuinely exists.
+    still_blocked=$(list_tasks_blocked_by "$id" | paste -sd' ' - | sed 's/ *$//')
+    [ -z "$still_blocked" ] \
+      || fail "work is blocked by $id ($still_blocked); route it with --routed-to instead of --no-routed-work"
+    routed_csv='(none)'
+  else
+    [ -n "$routed" ] || fail "--routed-to <task-id> or --no-routed-work is required"
+    routed=$(printf '%s\n' "$routed" | tr ' ' '\n' | sed '/^$/d' | LC_ALL=C sort -u | paste -sd' ' -)
+    routed_csv=$(printf '%s\n' "$routed" | tr ' ' ',')
+  fi
+  decision_digest=$(sha256_text "$decision")
   if verify_hold_resolved "$id"; then
     hold_show=$(task_show "$id")
     hold_body=$(show_field "$hold_show" body)
-    verify_resolution_identity "$id" "$hold_body" "$DECISION_DIGEST" "$routed_csv"
+    verify_resolution_identity "$id" "$hold_body" "$decision_digest" "$routed_csv" "$decided_by"
     printf 'resolved: %s\n' "$id"
     return 0
   fi
@@ -575,7 +986,7 @@ command_resolve() {
   hold_body=$(show_field "$hold_show" body)
   case "$hold_body" in
     *"Resolution recorded by fm-decision-hold."*)
-      verify_resolution_identity "$id" "$hold_body" "$DECISION_DIGEST" "$routed_csv"
+      verify_resolution_identity "$id" "$hold_body" "$decision_digest" "$routed_csv" "$decided_by"
       resolution_recorded=1
       ;;
   esac
@@ -594,8 +1005,21 @@ command_resolve() {
     fi
   done
 
-  # shellcheck disable=SC2086  # routed is a validated space-separated slug list.
-  body=$(resolution_body routed "$routed_csv" $routed)
+  # Keep the registration record - the origin, key, distinctness attestation, and
+  # any folded findings - readable after the resolution is written over it.
+  prior=$(prior_registration "$id")
+  body=$(printf 'Resolution recorded by fm-decision-hold.\nDecision digest: %s\nRouted identities: %s\nDecided by: %s\nResolution mode: resolved\n\nCaptain decision:\n%s\n\nRouted work:' "$decision_digest" "$routed_csv" "$decided_by" "$decision")
+  body="${body}"$'\n'
+  if [ "$no_routed" = 1 ]; then
+    body="${body}- (none: no dependent work existed when the captain decided)"$'\n'
+  else
+    for dep in $routed; do
+      body="${body}- ${dep}"$'\n'
+    done
+  fi
+  if [ -n "$prior" ]; then
+    body="${body}"$'\nOrigin record:\n'"${prior}"$'\n'
+  fi
   tasks_axi update "$id" --body "$body" >/dev/null \
     || fail "could not record the captain decision on $id"
   for dep in $routed; do
@@ -607,19 +1031,7 @@ command_resolve() {
   done
   tasks_axi "done" "$id" >/dev/null || fail "could not close resolved captain hold $id"
   verify_hold_resolved "$id" || fail "captain hold $id did not retain its durable resolution record"
-  printf 'resolved: %s -> %s\n' "$id" "$routed"
-}
-
-parse_decision_only_flags() {  # <args...>; prints the --decision-file value
-  local decision_file=''
-  while [ "$#" -gt 0 ]; do
-    case "$1" in
-      --decision-file) shift; decision_file=${1:-} ;;
-      *) usage >&2; exit 2 ;;
-    esac
-    shift
-  done
-  printf '%s' "$decision_file"
+  printf 'resolved: %s -> %s\n' "$id" "${routed:-(no dependent work)}"
 }
 
 # The one unrouted close path, shared by `answer` and `decline`. They differ only
@@ -628,18 +1040,17 @@ parse_decision_only_flags() {  # <args...>; prints the --decision-file value
 # identity, and the refusal to release still-routed work - is identical, so
 # neither can drift into a weaker close than the other.
 close_unrouted_hold() {  # <mode> <outcome-word> <origin-id> <decision-key> <flag-args...>
-  local mode=$1 outcome=$2 origin=$3 key=$4 decision_file id body hold_show hold_body state dependents
+  local mode=$1 outcome=$2 origin=$3 key=$4 id body hold_show hold_body state dependents
   shift 4
-  decision_file=$(parse_decision_only_flags "$@") || exit 2
+  parse_decision_answer "$@"
   validate_slug origin-id "$origin"
   validate_slug decision-key "$key"
-  load_decision "$decision_file"
   require_tasks_axi
   id=$(hold_id "$origin" "$key")
   if verify_hold_resolved "$id"; then
     hold_show=$(task_show "$id")
     hold_body=$(show_field "$hold_show" body)
-    verify_resolution_identity "$id" "$hold_body" "$DECISION_DIGEST" "$ROUTED_NONE"
+    verify_resolution_identity "$id" "$hold_body" "$DECISION_DIGEST" "$ROUTED_NONE" "$DECIDED_BY"
     printf '%s: %s\n' "$outcome" "$id"
     return 0
   fi
@@ -651,7 +1062,7 @@ close_unrouted_hold() {  # <mode> <outcome-word> <origin-id> <decision-key> <fla
   hold_body=$(show_field "$hold_show" body)
   case "$hold_body" in
     *"Resolution recorded by fm-decision-hold."*)
-      verify_resolution_identity "$id" "$hold_body" "$DECISION_DIGEST" "$ROUTED_NONE"
+      verify_resolution_identity "$id" "$hold_body" "$DECISION_DIGEST" "$ROUTED_NONE" "$DECIDED_BY"
       ;;
   esac
   dependents=$(tasks_blocked_by "$id") || exit 1
@@ -796,13 +1207,12 @@ command_decline() {
 }
 
 command_repair() {
-  local origin=${1:-} key=${2:-} decision_file id body show state kind hold_kind hold_body
+  local origin=${1:-} key=${2:-} id body show state kind hold_kind hold_body
   [ "$#" -ge 2 ] || { usage >&2; exit 2; }
   shift 2
-  decision_file=$(parse_decision_only_flags "$@") || exit 2
+  parse_decision_answer "$@"
   validate_slug origin-id "$origin"
   validate_slug decision-key "$key"
-  load_decision "$decision_file"
   require_tasks_axi
   id=$(hold_id "$origin" "$key")
   show=$(task_show "$id") || fail "captain decision $id is absent from $FM_HOME/data/backlog.md"
@@ -817,7 +1227,7 @@ command_repair() {
   state=$(show_field "$show" state)
   hold_body=$(show_field "$show" body)
   if [ "$state" = "done" ] && body_has_resolution_record "$hold_body"; then
-    verify_resolution_identity "$id" "$hold_body" "$DECISION_DIGEST" "$ROUTED_NONE"
+    verify_resolution_identity "$id" "$hold_body" "$DECISION_DIGEST" "$ROUTED_NONE" "$DECIDED_BY"
     printf 'repaired: %s\n' "$id"
     return 0
   fi
@@ -834,7 +1244,9 @@ command_repair() {
 
 case "${1:-}" in
   id) shift; command_id "$@" ;;
+  open) shift; command_open "$@" ;;
   hold) shift; command_hold "$@" ;;
+  fold) shift; command_fold "$@" ;;
   complete) shift; command_complete "$@" ;;
   verify) shift; command_verify "$@" ;;
   resolve) shift; command_resolve "$@" ;;

--- a/bin/fm-fleet-snapshot.sh
+++ b/bin/fm-fleet-snapshot.sh
@@ -22,8 +22,9 @@
 #     resolves only when its structured record is Done, and missing ids stay open.
 #     Every captain-actionable row also carries waiting_days, the whole days since
 #     its `since` date, and decision_aging, true once that reaches
-#     FM_SNAPSHOT_DECISION_AGING_DAYS (default 3), so an open decision's age is
-#     visible in the fleet view without anyone remembering to look for it.
+#     FM_DECISION_AGING_DAYS (default 3), the same threshold
+#     bin/fm-decision-hold.sh applies, so an open decision's age is visible in the
+#     fleet view without anyone remembering to look for it.
 #   tasks[]: one row per state/<id>.meta, sorted by id.
 #     current_state is parsed from bin/fm-crew-state.sh <id> and preserves
 #     state, source, detail, and raw line separately.
@@ -102,9 +103,11 @@ FM_SNAPSHOT_REGISTRY_TIMEOUT=${FM_SNAPSHOT_REGISTRY_TIMEOUT:-2}
 # ageing. Three days is the shortest span that cannot fire on a decision the
 # captain simply has not reached yet - it always covers at least one full working
 # day plus a weekend edge - while still surfacing a stalled decision long before
-# the week-long silences this threshold exists to prevent.
-FM_SNAPSHOT_DECISION_AGING_DAYS=${FM_SNAPSHOT_DECISION_AGING_DAYS:-3}
-case "$FM_SNAPSHOT_DECISION_AGING_DAYS" in ''|*[!0-9]*) FM_SNAPSHOT_DECISION_AGING_DAYS=3 ;; esac
+# the week-long silences this threshold exists to prevent. It is one variable,
+# shared with bin/fm-decision-hold.sh, so the fleet view and the `open
+# --aging-only` listing cannot disagree about which decisions are ageing.
+FM_DECISION_AGING_DAYS=${FM_DECISION_AGING_DAYS:-3}
+case "$FM_DECISION_AGING_DAYS" in ''|*[!0-9]*) FM_DECISION_AGING_DAYS=3 ;; esac
 validate_positive_bound() {  # <name> <value>
   case "$2" in
     ''|*[!0-9]*|0)
@@ -271,7 +274,7 @@ backlog_json() {  # [<backlog-path>] - defaults to this home's $BACKLOG
   # shellcheck disable=SC2094
   jq -Rn --arg path "$backlog" \
     --argjson now_epoch "$SNAPSHOT_EPOCH" \
-    --argjson aging_days "$FM_SNAPSHOT_DECISION_AGING_DAYS" '
+    --argjson aging_days "$FM_DECISION_AGING_DAYS" '
     def trim: gsub("^[[:space:]]+|[[:space:]]+$"; "");
     def section_state:
       if . == "In flight" then "in_flight"

--- a/bin/fm-fleet-snapshot.sh
+++ b/bin/fm-fleet-snapshot.sh
@@ -20,6 +20,10 @@
 #     requires_child_metadata, blocked_by_ids, unresolved_blocker_ids, and
 #     captain_actionable fields. Repeated blocker tokens remain ordered; a blocker
 #     resolves only when its structured record is Done, and missing ids stay open.
+#     Every captain-actionable row also carries waiting_days, the whole days since
+#     its `since` date, and decision_aging, true once that reaches
+#     FM_SNAPSHOT_DECISION_AGING_DAYS (default 3), so an open decision's age is
+#     visible in the fleet view without anyone remembering to look for it.
 #   tasks[]: one row per state/<id>.meta, sorted by id.
 #     current_state is parsed from bin/fm-crew-state.sh <id> and preserves
 #     state, source, detail, and raw line separately.
@@ -94,6 +98,13 @@ FM_SNAPSHOT_REGISTRY_LINES=${FM_SNAPSHOT_REGISTRY_LINES:-256}
 FM_SNAPSHOT_REGISTRY_BYTES=${FM_SNAPSHOT_REGISTRY_BYTES:-65536}
 FM_SNAPSHOT_REGISTRY_RECORDS=${FM_SNAPSHOT_REGISTRY_RECORDS:-40}
 FM_SNAPSHOT_REGISTRY_TIMEOUT=${FM_SNAPSHOT_REGISTRY_TIMEOUT:-2}
+# Days an open captain decision may wait before every fleet view marks it as
+# ageing. Three days is the shortest span that cannot fire on a decision the
+# captain simply has not reached yet - it always covers at least one full working
+# day plus a weekend edge - while still surfacing a stalled decision long before
+# the week-long silences this threshold exists to prevent.
+FM_SNAPSHOT_DECISION_AGING_DAYS=${FM_SNAPSHOT_DECISION_AGING_DAYS:-3}
+case "$FM_SNAPSHOT_DECISION_AGING_DAYS" in ''|*[!0-9]*) FM_SNAPSHOT_DECISION_AGING_DAYS=3 ;; esac
 validate_positive_bound() {  # <name> <value>
   case "$2" in
     ''|*[!0-9]*|0)
@@ -258,7 +269,9 @@ backlog_json() {  # [<backlog-path>] - defaults to this home's $BACKLOG
   fi
 
   # shellcheck disable=SC2094
-  jq -Rn --arg path "$backlog" '
+  jq -Rn --arg path "$backlog" \
+    --argjson now_epoch "$SNAPSHOT_EPOCH" \
+    --argjson aging_days "$FM_SNAPSHOT_DECISION_AGING_DAYS" '
     def trim: gsub("^[[:space:]]+|[[:space:]]+$"; "");
     def section_state:
       if . == "In flight" then "in_flight"
@@ -395,6 +408,16 @@ backlog_json() {  # [<backlog-path>] - defaults to this home's $BACKLOG
           | .captain_actionable =
               (.state == "queued" and .kind == "captain" and .hold_kind == "captain"
                and .hold_reason != null and (.unresolved_blocker_ids | length) == 0)
+          # An unanswered decision is otherwise indistinguishable from one raised
+          # an hour ago, so every open captain decision carries how long it has
+          # been waiting and whether that has passed the ageing threshold.
+          | .waiting_days =
+              (if .captain_actionable and .since != null then
+                 ((try (($now_epoch - (.since | strptime("%Y-%m-%d") | mktime)) / 86400 | floor)
+                   catch null) as $d
+                  | if $d == null or $d < 0 then null else $d end)
+               else null end)
+          | .decision_aging = (.waiting_days != null and .waiting_days >= $aging_days)
         else . end)
     | del(.section,.order)
   ' < "$backlog"
@@ -660,7 +683,11 @@ secondmate_home_summary_json() {  # <backlog-json> <tasks-json>
     | ([ $queued_all[]
          | select(.captain_actionable == true)
          | {id,key:.id,verb:"captain-hold",summary:(.title | trunc(160)),
-            reason:(.hold_reason | trunc(160)),source:"backlog"} ]) as $captain_holds_all
+            reason:(.hold_reason | trunc(160)),
+            since:(.since // null),
+            waiting_days:(.waiting_days // null),
+            aging:(.decision_aging // false),
+            source:"backlog"} ]) as $captain_holds_all
     | ([ $backlog.records[]? | select(.state == "done" and .structured and .kind != "captain")
          | {id:(.id | trunc(120)),title:(.title | trunc(120)),
             pr_url:((.pr_url // null) | if . == null then null else trunc(500) end),
@@ -758,6 +785,8 @@ secondmate_home_summary_json() {  # <backlog-json> <tasks-json>
           hold_reason:((.hold_reason // null) | if . == null then null else trunc(160) end),
           hold_kind:((.hold_kind // null) | if . == null then null else trunc(40) end),
           captain_actionable:(.captain_actionable // false),
+          waiting_days:(.waiting_days // null),
+          decision_aging:(.decision_aging // false),
           repo:((.repo // null) | if . == null then null else trunc(120) end),
           kind:((.kind // null) | if . == null then null else trunc(40) end)}][:$queued_n]),
         landed:(if $landed_n == 0 then $landed_all else $landed_all[:$landed_n] end),

--- a/docs/decision-hold-lifecycle.md
+++ b/docs/decision-hold-lifecycle.md
@@ -13,10 +13,22 @@ The `hold` subcommand maps an originating work id and stable decision key to `<o
 It creates a kind `captain` backlog item when absent and invokes `tasks-axi hold <id> --reason <reason> --kind captain` on every retry.
 It rejects an identity collision, a changed title, and attempts to reopen an already resolved identity.
 
+Creating a new identity while the home already holds other open captain decisions exits 3 and prints that open set with each decision's age.
+Exact-key repetition never reaches this branch, so idempotent retry and recovery are unaffected.
+The refusal is deliberate rather than a warning: success output is not reliably read, and semantic duplicate matching needs the open set in context before the write, not after it.
+It is not a hard block, because a genuinely distinct decision must still be registrable; `--distinct` clears it and records the attestation in the new decision's body.
+The `open` subcommand prints the same listing on demand, with `--aging-only` for the threshold subset.
+
+The `fold` subcommand is the alternative path when the finding belongs to a decision that is already open.
+It appends `Also raised by <origin>: <note>` to the target's body through `tasks-axi update --body-file`, skipping the write when the same marker is already present, and unions the target identity into the origin's `decision_folds=` metadata.
+It refuses a target that is not an actively held captain decision and refuses an origin folding into its own decision namespace.
+Reading the target body decodes the JSON string literal tasks-axi emits, so `jq` is required for `fold` and `resolve`.
+
 The `complete` subcommand unions the reviewed keys into `decision_keys=` and appends `decisions_reviewed=1` while originating task metadata is live.
 A post-teardown visual review can complete against the surviving report and durable holds without recreating volatile task metadata.
 It accepts `--none` as an explicit semantic inventory result, not as inferred absence.
-It verifies every listed identity against tasks-axi before recording completion.
+It accepts `--folded` when every unresolved decision the pass found is already owned by a hold the origin folded into, and refuses `--none` while any fold is recorded, so folding cannot become a way to attest an empty surface.
+It verifies every listed identity and every recorded fold identity against tasks-axi before recording completion; `verify` applies the same check, so the teardown gate is strictly stronger than before folds existed.
 For an open keyed status decision, it appends a `captain-held [key=<key>]: ...` transfer event only after the matching backlog hold is durable.
 `bin/fm-classify-lib.sh` recognizes that transfer as closing the live status copy without claiming that the captain has answered it.
 
@@ -24,12 +36,16 @@ Scout teardown calls the script's read-only `verify` subcommand after checking f
 The `--force` path remains the explicit captain-approved discard escape hatch.
 
 The `resolve`, `answer`, and `decline` subcommands close active holds, while `repair` attests a hold already closed outside the script.
-All four require a non-empty captain decision file and record the same resolution block in the hold body with the decision digest, routed identities, and a `Resolution mode:` naming the path.
+All four take the captain's answer as `--decision <text>` or `--decision-file <path>` and record the same resolution block in the hold body with the decision digest, routed identities, and a `Resolution mode:` naming the path.
 An exact retry is idempotent, while a changed decision or, for `resolve`, a changed routed-task set is rejected.
 
-The `resolve` subcommand is the routed path and additionally requires at least one existing dependent task whose structured `blocked-by` edge points to the hold.
-It clears each dependency edge through tasks-axi and marks the hold Done only after those writes succeed.
-An exact retry can finish a partial routing operation, and a failed intermediate step leaves the hold open.
+The `resolve` subcommand is the routed path: it routes dependent work with `--routed-to` or declares its absence with `--no-routed-work`.
+`--routed-to` requires every named task to exist and to carry a structured `blocked-by` edge to the hold.
+`--no-routed-work` is refused whenever `tasks-axi list --blocked` reports any task blocked by the hold, so the routing requirement is enforced by observed state rather than by the caller's claim, and survives wherever dependent work genuinely exists.
+The two lighter inputs exist because the previous shape - write a file, invent a dependent task, block it - made recording an answer more expensive than repeating the question, which is how an answered decision came to be lost while its authority was cited elsewhere.
+It records the decision digest and routed task identities as a retry identity in the hold body, carries the prior registration record forward under `Origin record:` so the distinctness attestation and any folded findings survive closure, clears each dependency edge through tasks-axi, and marks the hold Done only after those writes succeed.
+An exact retry can finish a partial routing operation and does not nest the carried-forward record, while a changed decision or routed-task set is rejected.
+A failed intermediate step leaves the hold open.
 
 The `answer` and `decline` subcommands share one unrouted close implementation and differ only in the `Resolution mode:` they record and the outcome word they print, so neither can drift into a weaker close than the other.
 Both record `(none)` as the routed identities and refuse while any task in the same backlog is still blocked by the hold, because releasing routed work without recording it is `resolve`'s job.
@@ -69,6 +85,26 @@ After capture, a bound source has its result passed to `bin/fm-procevent-<adapte
 Feeding is independent of handling: it never acknowledges a result and never suppresses a wake, so recording the captain's answer cannot retire the notification firstmate needs in order to act on it.
 `bin/fm-procevent-lavish.sh answers` is one such adapter command; it reports the structured choices a review captured and stops there, reading only rows tagged `choice` so freeform captain prose can never forge a decision key.
 
+## What counts as durably resolved
+
+`verify_hold_durable` backs both the completion gate and the teardown gate, and accepts four shapes.
+A decision is still actively held; or it carries this script's canonical resolution record; or it is closed with some other decision record in its body; or Done retention has rotated it into `data/done-archive.md`.
+
+The third and fourth shapes exist because the gate was rejecting on formatting rather than on substance.
+A decision closed by hand with a written record - because firstmate decided it, or because an earlier captain answer already settled it - is resolved, and a decision that aged out of the live backlog through ordinary retention is resolved too.
+Rejecting either strands the finished investigation that found the decision, which is a failure of the gate rather than a defence of it.
+
+The gate is not weakened, because each accepted shape still requires durable evidence that the decision was answered.
+A closed decision whose body is empty, or whose body still carries the untouched registration record saying `State: awaiting captain decision.`, is refused: it says in its own words that no answer was ever written down, which is exactly the loss this gate exists to prevent.
+`--decided-by firstmate` records a firstmate-decided closure honestly rather than attributing it to the captain.
+
+## Ageing
+
+Every captain-actionable backlog row carries `waiting_days`, the whole days since its `since` date, and `decision_aging`, true once that reaches `FM_SNAPSHOT_DECISION_AGING_DAYS` (default 3).
+Both are computed in `bin/fm-fleet-snapshot.sh` from the existing `since` metadata that `tasks-axi add` already writes, so every decision registered before this behavior existed reports its age with no migration and no schema change.
+`bin/fm-bearings-snapshot.sh` carries `since`, `waiting_days`, and `aging` into `decisions_open` and orders it ageing-first then oldest-first, so an ageing decision leads the section and cannot be truncated away by the bounded cap.
+The threshold is three days because that is the shortest span that always covers a full working day plus a weekend edge, so it cannot fire on a decision the captain has simply not reached yet, while still surfacing a stalled decision long before the week-long silences it exists to prevent.
+
 ## Structured read surfaces
 
 `bin/fm-fleet-snapshot.sh` parses canonical tasks-axi `(hold: ...)` and `(hold-kind: captain)` metadata alongside existing backlog fields.
@@ -84,6 +120,7 @@ The projection remains read-only and does not inspect historical prose.
 Verification date: 2026-07-14.
 Additional quoted `blocked_by` regression verification date: 2026-07-17.
 Plural blocker-readiness and mixed-home projection verification date: 2026-07-22.
+Duplicate refusal, folding, ageing, lightweight resolution, and externally closed recognition verification date: 2026-08-02.
 Unrouted close-path verification date: 2026-08-13.
 Answer-time closure verification date: 2026-08-16.
 
@@ -110,6 +147,10 @@ The final verification commands and their exact summarized outputs follow.
 ```text
 $ bash tests/fm-decision-hold-lifecycle.test.sh
 ok - report-only unresolved decision is reproduced and completion refuses before loss
+ok - externally closed and archived decisions are durably resolved, recordless closure is not
+ok - a firstmate-decided closure is first-class and attributed honestly
+ok - a second pass cannot silently duplicate an open decision and can fold into it
+ok - an answer is recorded in one call and routing survives where dependent work exists
 ok - non-forced scout teardown always requires durable inventory verification
 ok - a declined decision closes with a recorded answer and no routed work
 ok - a decision closed outside the script is repairable and then clears teardown
@@ -134,6 +175,7 @@ ok - snapshot parses tasks-axi rows and respects operational overrides
 $ bash tests/fm-bearings-snapshot.test.sh
 ok - a completed scout with decision-like report prose is a pointer, not pending
 ok - an authoritative captain hold surfaces end-to-end
+ok - an ageing open decision carries its age, leads the section, and survives the cap
 ok - action-free items (working/done/queued/landed) do not leak into Captain's Call
 ok - main and secondmate captain actionability use the same blocker readiness
 

--- a/docs/decision-hold-lifecycle.md
+++ b/docs/decision-hold-lifecycle.md
@@ -152,6 +152,7 @@ The final verification commands and their exact summarized outputs follow.
 $ bash tests/fm-decision-hold-lifecycle.test.sh
 ok - report-only unresolved decision is reproduced and completion refuses before loss
 ok - externally closed and archived decisions are durably resolved, recordless closure is not
+ok - a fold that cannot be recorded refuses instead of reporting success
 ok - a firstmate-decided closure is first-class and attributed honestly
 ok - a second pass cannot silently duplicate an open decision and can fold into it
 ok - an answer is recorded in one call and routing survives where dependent work exists

--- a/docs/decision-hold-lifecycle.md
+++ b/docs/decision-hold-lifecycle.md
@@ -23,6 +23,9 @@ The `fold` subcommand is the alternative path when the finding belongs to a deci
 It appends `Also raised by <origin>: <note>` to the target's body through `tasks-axi update --body-file`, skipping the write when the same marker is already present, and unions the target identity into the origin's `decision_folds=` metadata.
 It refuses a target that is not an actively held captain decision and refuses an origin folding into its own decision namespace.
 It also refuses, before writing anything to the target, an origin with no `state/<origin>.meta` to record the fold in, because a fold that cannot be recorded would report success and then be rejected by `complete --folded`.
+It transfers the origin's open keyed status decision to the target with the same `captain-held [key=<key>]: ...` event `complete` writes, because that live copy would otherwise stay open waiting for a key this origin never registers, and `complete --folded` would dead-end on it.
+`--key` names which open status decision the fold covers and is required while several are open, so one fold satisfies exactly the question it folded and never blanket-closes the rest; a key already transferred to the same target is skipped, which keeps repeating a fold idempotent.
+Coverage is resolved before any write, so a fold that cannot name it refuses with the target untouched.
 Reading the target body decodes the JSON string literal tasks-axi emits, so `jq` is required for `fold` and `resolve`.
 
 The `complete` subcommand unions the reviewed keys into `decision_keys=` and appends `decisions_reviewed=1` while originating task metadata is live.
@@ -105,6 +108,8 @@ Retention therefore only changes where a decision's record lives, never whether 
 
 Every captain-actionable backlog row carries `waiting_days`, the whole days since its `since` date, and `decision_aging`, true once that reaches `FM_DECISION_AGING_DAYS` (default 3).
 That is one variable for one policy: `bin/fm-fleet-snapshot.sh` and `bin/fm-decision-hold.sh` read the same name, so the fleet view and `open --aging-only` cannot disagree about which decisions are ageing.
+They cannot disagree about the decision set either: the CLI listing applies the same `captain_actionable` predicate the fleet view applies - queued, kind `captain`, held for the captain with a reason, and carrying no unresolved blocker - so a refusal can never cite a decision Bearings does not show.
+Both day counts anchor each endpoint at midnight UTC explicitly, so two reads straddling a second boundary cannot shorten a decision's age by a day and drop it out of the ageing set.
 Both are computed in `bin/fm-fleet-snapshot.sh` from the existing `since` metadata that `tasks-axi add` already writes, so every decision registered before this behavior existed reports its age with no migration and no schema change.
 `bin/fm-bearings-snapshot.sh` carries `since`, `waiting_days`, and `aging` into `decisions_open` and orders it ageing-first then oldest-first, so an ageing decision leads the section and cannot be truncated away by the bounded cap.
 The threshold is three days because that is the shortest span that always covers a full working day plus a weekend edge, so it cannot fire on a decision the captain has simply not reached yet, while still surfacing a stalled decision long before the week-long silences it exists to prevent.
@@ -152,6 +157,8 @@ The final verification commands and their exact summarized outputs follow.
 $ bash tests/fm-decision-hold-lifecycle.test.sh
 ok - report-only unresolved decision is reproduced and completion refuses before loss
 ok - externally closed and archived decisions are durably resolved, recordless closure is not
+ok - a folded status decision satisfies completion without a second captain decision
+ok - a decision at exactly the ageing threshold is ageing and one below it is not
 ok - a fold that cannot be recorded refuses instead of reporting success
 ok - a firstmate-decided closure is first-class and attributed honestly
 ok - a second pass cannot silently duplicate an open decision and can fold into it

--- a/docs/decision-hold-lifecycle.md
+++ b/docs/decision-hold-lifecycle.md
@@ -140,6 +140,7 @@ Verification date: 2026-07-14.
 Additional quoted `blocked_by` regression verification date: 2026-07-17.
 Plural blocker-readiness and mixed-home projection verification date: 2026-07-22.
 Duplicate refusal, folding, ageing, lightweight resolution, and externally closed recognition verification date: 2026-08-02.
+Sign-off-owned status accounting, with folding decoupled from it, verification date: 2026-08-04.
 Unrouted close-path verification date: 2026-08-13.
 Answer-time closure verification date: 2026-08-16.
 

--- a/docs/decision-hold-lifecycle.md
+++ b/docs/decision-hold-lifecycle.md
@@ -24,7 +24,9 @@ It appends `Also raised by <origin>: <note>` to the target's body through `tasks
 It refuses a target that is not an actively held captain decision and refuses an origin folding into its own decision namespace.
 It also refuses, before writing anything to the target, an origin with no `state/<origin>.meta` to record the fold in, because a fold that cannot be recorded would report success and then be rejected by `complete --folded`.
 It transfers the origin's open keyed status decision to the target with the same `captain-held [key=<key>]: ...` event `complete` writes, because that live copy would otherwise stay open waiting for a key this origin never registers, and `complete --folded` would dead-end on it.
-`--key` names which open status decision the fold covers and is required while several are open, so one fold satisfies exactly the question it folded and never blanket-closes the rest; a key already transferred to the same target is skipped, which keeps repeating a fold idempotent.
+`--key` names which open status decision the fold covers and is required whenever the origin has any open status decision, so one fold satisfies exactly the question it folded and never blanket-closes the rest.
+A sole open decision does not relax that: an unqualified fold has said nothing about which question it covers, and transferring the only one on offer would mark a question as owned by a decision that never mentions it.
+Repeated keys collapse, and a key already transferred to the same target is skipped, so neither a repeated key nor a repeated fold writes a second transfer event.
 Coverage is resolved before any write, so a fold that cannot name it refuses with the target untouched.
 Reading the target body decodes the JSON string literal tasks-axi emits, so `jq` is required for `fold` and `resolve`.
 

--- a/docs/decision-hold-lifecycle.md
+++ b/docs/decision-hold-lifecycle.md
@@ -22,6 +22,7 @@ The `open` subcommand prints the same listing on demand, with `--aging-only` for
 The `fold` subcommand is the alternative path when the finding belongs to a decision that is already open.
 It appends `Also raised by <origin>: <note>` to the target's body through `tasks-axi update --body-file`, skipping the write when the same marker is already present, and unions the target identity into the origin's `decision_folds=` metadata.
 It refuses a target that is not an actively held captain decision and refuses an origin folding into its own decision namespace.
+It also refuses, before writing anything to the target, an origin with no `state/<origin>.meta` to record the fold in, because a fold that cannot be recorded would report success and then be rejected by `complete --folded`.
 Reading the target body decodes the JSON string literal tasks-axi emits, so `jq` is required for `fold` and `resolve`.
 
 The `complete` subcommand unions the reviewed keys into `decision_keys=` and appends `decisions_reviewed=1` while originating task metadata is live.
@@ -96,11 +97,14 @@ Rejecting either strands the finished investigation that found the decision, whi
 
 The gate is not weakened, because each accepted shape still requires durable evidence that the decision was answered.
 A closed decision whose body is empty, or whose body still carries the untouched registration record saying `State: awaiting captain decision.`, is refused: it says in its own words that no answer was ever written down, which is exactly the loss this gate exists to prevent.
+The archive preserves an entry's indented body lines verbatim, so the fourth shape reads them and applies that same record test through one shared predicate.
+Retention therefore only changes where a decision's record lives, never whether the gate accepts it: a recordless closure that is refused in the live backlog stays refused after it rotates into the archive.
 `--decided-by firstmate` records a firstmate-decided closure honestly rather than attributing it to the captain.
 
 ## Ageing
 
-Every captain-actionable backlog row carries `waiting_days`, the whole days since its `since` date, and `decision_aging`, true once that reaches `FM_SNAPSHOT_DECISION_AGING_DAYS` (default 3).
+Every captain-actionable backlog row carries `waiting_days`, the whole days since its `since` date, and `decision_aging`, true once that reaches `FM_DECISION_AGING_DAYS` (default 3).
+That is one variable for one policy: `bin/fm-fleet-snapshot.sh` and `bin/fm-decision-hold.sh` read the same name, so the fleet view and `open --aging-only` cannot disagree about which decisions are ageing.
 Both are computed in `bin/fm-fleet-snapshot.sh` from the existing `since` metadata that `tasks-axi add` already writes, so every decision registered before this behavior existed reports its age with no migration and no schema change.
 `bin/fm-bearings-snapshot.sh` carries `since`, `waiting_days`, and `aging` into `decisions_open` and orders it ageing-first then oldest-first, so an ageing decision leads the section and cannot be truncated away by the bounded cap.
 The threshold is three days because that is the shortest span that always covers a full working day plus a weekend edge, so it cannot fire on a decision the captain has simply not reached yet, while still surfacing a stalled decision long before the week-long silences it exists to prevent.

--- a/docs/decision-hold-lifecycle.md
+++ b/docs/decision-hold-lifecycle.md
@@ -22,21 +22,29 @@ The `open` subcommand prints the same listing on demand, with `--aging-only` for
 The `fold` subcommand is the alternative path when the finding belongs to a decision that is already open.
 It appends `Also raised by <origin>: <note>` to the target's body through `tasks-axi update --body-file`, skipping the write when the same marker is already present, and unions the target identity into the origin's `decision_folds=` metadata.
 It refuses a target that is not an actively held captain decision and refuses an origin folding into its own decision namespace.
-It also refuses, before writing anything to the target, an origin with no `state/<origin>.meta` to record the fold in, because a fold that cannot be recorded would report success and then be rejected by `complete --folded`.
-It transfers the origin's open keyed status decision to the target with the same `captain-held [key=<key>]: ...` event `complete` writes, because that live copy would otherwise stay open waiting for a key this origin never registers, and `complete --folded` would dead-end on it.
-`--key` names which open status decision the fold covers and is required whenever the origin has any open status decision, so one fold satisfies exactly the question it folded and never blanket-closes the rest.
-A sole open decision does not relax that: an unqualified fold has said nothing about which question it covers, and transferring the only one on offer would mark a question as owned by a decision that never mentions it.
-Repeated keys collapse, and a key already transferred to the same target is skipped, so neither a repeated key nor a repeated fold writes a second transfer event.
-Coverage is resolved before any write, so a fold that cannot name it refuses with the target untouched.
+It also refuses, before writing anything to the target, an origin with no `state/<origin>.meta` to record the fold in, because a fold that cannot be recorded would report success and then be rejected at sign-off.
 Reading the target body decodes the JSON string literal tasks-axi emits, so `jq` is required for `fold` and `resolve`.
 
-The `complete` subcommand unions the reviewed keys into `decision_keys=` and appends `decisions_reviewed=1` while originating task metadata is live.
+## Where folding ends and accounting begins
+
+`fold` does not touch the origin's status log and takes no decision key.
+Which live question a fold answers for is a judgement about the reviewed surface, and a fold cannot be trusted to imply it: a fold about one question, applied to whichever entry happened to be open, would mark that entry as owned by a decision that never mentions it.
+So folding records only two facts - the finding is on the target decision, and the origin folded into it - and `complete` owns every statement about the live status log.
+
+`complete` requires every structured decision still open in the origin's status log to be explicitly accounted for.
+An entry is accounted for when its decision key is supplied, so this origin's own captain hold carries it, or when that exact key is named with `--folded-key`, so a recorded fold carries it.
+Nothing is inferred from how many entries are open, and no path satisfies an entry the caller did not name, so a question can only leave the live log by someone saying which durable decision now holds it.
+`--folded-key` is refused for a key that is not open, was not already accounted for, and has no recorded transfer, so an entry that never existed cannot be attested away; the three tolerances exist so re-running sign-off stays idempotent.
+This makes the mixed pass expressible in one call: register the genuinely new question with its own key, fold the duplicate finding, then `complete <origin> <new-key> --folded-key <folded-entry-key>`.
+
+The `complete` subcommand unions the reviewed keys into `decision_keys=`, the accounted-for folded keys into `decision_folded_keys=`, and appends `decisions_reviewed=1` while originating task metadata is live.
 A post-teardown visual review can complete against the surviving report and durable holds without recreating volatile task metadata.
-It accepts `--none` as an explicit semantic inventory result, not as inferred absence.
-It accepts `--folded` when every unresolved decision the pass found is already owned by a hold the origin folded into, and refuses `--none` while any fold is recorded, so folding cannot become a way to attest an empty surface.
-It verifies every listed identity and every recorded fold identity against tasks-axi before recording completion; `verify` applies the same check, so the teardown gate is strictly stronger than before folds existed.
-For an open keyed status decision, it appends a `captain-held [key=<key>]: ...` transfer event only after the matching backlog hold is durable.
+It accepts `--none` as an explicit semantic inventory result, not as inferred absence, and refuses it while any fold is recorded or any status entry is open, so neither folding nor a live question can become a way to attest an empty surface.
+It accepts `--folded` when every unresolved decision the pass found is already owned by a hold the origin folded into.
+It verifies every listed identity and every recorded fold identity against tasks-axi before recording completion.
+`complete` is the only subcommand that appends a `captain-held [key=<key>]: ...` transfer event, and it names the durable owner that carries the entry - this origin's hold for a supplied key, the recorded folds for a key named as folded.
 `bin/fm-classify-lib.sh` recognizes that transfer as closing the live status copy without claiming that the captain has answered it.
+`verify` applies the identical accounting check through the same helper, reading the keys and folded keys sign-off recorded, so the completion gate and the teardown gate cannot drift.
 
 Scout teardown calls the script's read-only `verify` subcommand after checking for the report and before removing any source state.
 The `--force` path remains the explicit captain-approved discard escape hatch.
@@ -159,7 +167,8 @@ The final verification commands and their exact summarized outputs follow.
 $ bash tests/fm-decision-hold-lifecycle.test.sh
 ok - report-only unresolved decision is reproduced and completion refuses before loss
 ok - externally closed and archived decisions are durably resolved, recordless closure is not
-ok - a folded status decision satisfies completion without a second captain decision
+ok - sign-off owns status accounting and the mixed fold-and-register pass works
+ok - folding a finished investigation needs no status accounting
 ok - a decision at exactly the ageing threshold is ageing and one below it is not
 ok - a fold that cannot be recorded refuses instead of reporting success
 ok - a firstmate-decided closure is first-class and attributed honestly

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -25,7 +25,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-remote-doctor.sh`    | Check, and with `--fix` repair, one remote account's second-mate readiness (remote job worker, Herdr, Aqua launch agents, PATH, and required tools) |
 | `fm-backlog-handoff.sh`  | Validate and delegate queued backlog-item moves into a secondmate home               |
 | `fm-backlog-receive.sh`  | Idempotently ingest one confined remote handoff outbox through tasks-axi             |
-| `fm-decision-hold.sh`    | Create, verify, complete, close, and repair durable captain-held decisions       |
+| `fm-decision-hold.sh`    | List, create, fold, verify, complete, resolve, decline, and repair durable captain-held decisions |
 | `fm-brief.sh`            | Scaffold ship (explicit `--mode`), scout, secondmate-charter, and Herdr-lab briefs   |
 | `fm-herdr-lab.sh`        | Provision and guardedly operate an isolated, never-default Herdr lab session         |
 | `fm-install-herdr.sh`    | Install CI's exact-version Herdr pin with official asset URL, SHA-256, and protocol checks |

--- a/tests/fm-bearings-snapshot.test.sh
+++ b/tests/fm-bearings-snapshot.test.sh
@@ -945,6 +945,45 @@ test_open_decision_surfaces_end_to_end() {
   pass "an authoritative captain hold surfaces end-to-end"
 }
 
+# An unanswered decision from last week must not read like one raised an hour ago.
+# Age has to reach the fleet view on its own, and the oldest must survive the
+# bounded decisions_open cap so it cannot be truncated into silence.
+test_open_decision_age_surfaces_and_leads() {
+  local home fakebin json i
+  home=$(make_home decision-age)
+  cat > "$home/data/backlog.md" <<'EOF'
+## In flight
+
+## Queued
+- [ ] sample-stalled-decision - Stalled question (repo: sample) (kind: captain) (since 2026-07-26) (hold: waiting on the captain) (hold-kind: captain)
+- [ ] sample-fresh-decision - Fresh question (repo: sample) (kind: captain) (since 2026-08-02) (hold: raised today) (hold-kind: captain)
+
+## Done
+EOF
+  fakebin=$(make_fakebin "$home")
+  json=$(PATH="$fakebin:$PATH" FM_HOME="$home" FM_BEARINGS_NOW=2026-08-02T12:00:00Z \
+    FM_SNAPSHOT_NOW=2026-08-02T12:00:00Z NET_LOG="$home/net.log" "$BEARINGS" --json)
+  printf '%s' "$json" | jq -e '
+    (.decisions_open | map(select(.id == "sample-stalled-decision"))[0]) as $old
+    | (.decisions_open | map(select(.id == "sample-fresh-decision"))[0]) as $new
+    | $old.waiting_days == 7 and $old.aging == true and $old.since == "2026-07-26"
+      and $new.waiting_days == 0 and $new.aging == false
+      and (.decisions_open[0].id == "sample-stalled-decision")
+  ' >/dev/null || fail "an ageing decision must carry its age and lead the section: $json"
+
+  # Under the bounded cap, the ageing decision must still be the one shown.
+  for i in $(seq 1 30); do
+    printf -- '- [ ] sample-noise-%s - Noise %s (repo: sample) (kind: captain) (since 2026-08-02) (hold: raised today) (hold-kind: captain)\n' \
+      "$i" "$i" >> "$home/data/backlog.md"
+  done
+  json=$(PATH="$fakebin:$PATH" FM_HOME="$home" FM_BEARINGS_NOW=2026-08-02T12:00:00Z \
+    FM_SNAPSHOT_NOW=2026-08-02T12:00:00Z NET_LOG="$home/net.log" "$BEARINGS" --json)
+  printf '%s' "$json" | jq -e '
+    .decisions_open | any(.[]; .id == "sample-stalled-decision" and .aging == true)
+  ' >/dev/null || fail "the ageing decision must survive the bounded cap: $json"
+  pass "an ageing open decision carries its age, leads the section, and survives the cap"
+}
+
 test_report_pointers_surface() {
   local home fakebin json
   home=$(make_home reports); write_fixture "$home"
@@ -1926,6 +1965,7 @@ test_mixed_secondmate_roles_partial_state_and_captain_readiness
 test_main_captain_readiness_matches_secondmate_projection
 test_completed_scout_report_not_pending
 test_open_decision_surfaces_end_to_end
+test_open_decision_age_surfaces_and_leads
 test_report_pointers_surface
 test_superseded_queued_item_dropped_by_default
 test_include_prs_is_the_only_fetch_path

--- a/tests/fm-bearings-snapshot.test.sh
+++ b/tests/fm-bearings-snapshot.test.sh
@@ -971,13 +971,24 @@ EOF
       and (.decisions_open[0].id == "sample-stalled-decision")
   ' >/dev/null || fail "an ageing decision must carry its age and lead the section: $json"
 
-  # Under the bounded cap, the ageing decision must still be the one shown.
-  for i in $(seq 1 30); do
-    printf -- '- [ ] sample-noise-%s - Noise %s (repo: sample) (kind: captain) (since 2026-08-02) (hold: raised today) (hold-kind: captain)\n' \
-      "$i" "$i" >> "$home/data/backlog.md"
-  done
+  # Under the bounded cap, the ageing decision must still be the one shown. The
+  # filler rows have to land in Queued: a Done row is not captain-actionable, so
+  # appending them past the `## Done` heading would leave the cap unexercised.
+  {
+    printf '## In flight\n\n## Queued\n'
+    printf -- '- [ ] sample-stalled-decision - Stalled question (repo: sample) (kind: captain) (since 2026-07-26) (hold: waiting on the captain) (hold-kind: captain)\n'
+    printf -- '- [ ] sample-fresh-decision - Fresh question (repo: sample) (kind: captain) (since 2026-08-02) (hold: raised today) (hold-kind: captain)\n'
+    for i in $(seq 1 30); do
+      printf -- '- [ ] sample-noise-%s - Noise %s (repo: sample) (kind: captain) (since 2026-08-02) (hold: raised today) (hold-kind: captain)\n' \
+        "$i" "$i"
+    done
+    printf '\n## Done\n'
+  } > "$home/data/backlog.md"
   json=$(PATH="$fakebin:$PATH" FM_HOME="$home" FM_BEARINGS_NOW=2026-08-02T12:00:00Z \
     FM_SNAPSHOT_NOW=2026-08-02T12:00:00Z NET_LOG="$home/net.log" "$BEARINGS" --json)
+  printf '%s' "$json" | jq -e --argjson cap "${FM_BEARINGS_DECISIONS:-20}" '
+    (.decisions_open | length) == $cap and $cap < 32
+  ' >/dev/null || fail "the filler decisions must actually exceed the bounded cap: $json"
   printf '%s' "$json" | jq -e '
     .decisions_open | any(.[]; .id == "sample-stalled-decision" and .aging == true)
   ' >/dev/null || fail "the ageing decision must survive the bounded cap: $json"

--- a/tests/fm-decision-hold-lifecycle.test.sh
+++ b/tests/fm-decision-hold-lifecycle.test.sh
@@ -905,7 +905,22 @@ test_folded_status_decision_satisfies_completion() {
   printf 'working: auditing retention\nneeds-decision: how long are sample records retained\n' \
     > "$home/state/$origin.status"
 
+  # An unqualified fold has said nothing about which question it covers, so it must
+  # not claim the sole open decision on the strength of it being the only one there.
+  set +e
   run_decisions "$home" fold "$origin" --into "$hold" \
+    --note "the audit pass reaches the same question" \
+    > "$home/sole.out" 2> "$home/sole.err"
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "an unqualified fold claimed the origin's sole open status decision"
+  assert_grep "--key" "$home/sole.err" "the refusal must ask which decision the fold covers"
+  assert_grep "1 open structured decision;" "$home/sole.err" \
+    "the single-open refusal must read as one decision, not several"
+  assert_no_grep "captain-held" "$home/state/$origin.status" \
+    "a refused fold must not transfer any status decision"
+
+  run_decisions "$home" fold "$origin" --into "$hold" --key default \
     --note "the audit pass reaches the same question" >/dev/null \
     || fail "could not fold the audit finding into the owning decision"
   assert_grep "captain-held [key=default]: tracked by $hold" "$home/state/$origin.status" \
@@ -916,7 +931,7 @@ test_folded_status_decision_satisfies_completion() {
     || fail "teardown verification must accept a folded status decision"
   [ "$(grep -cE '^- \[ \] .*-decision-.* -' "$home/data/backlog.md")" = 1 ] \
     || fail "satisfying the gate required a second captain decision"
-  run_decisions "$home" fold "$origin" --into "$hold" \
+  run_decisions "$home" fold "$origin" --into "$hold" --key default \
     --note "the audit pass reaches the same question" >/dev/null \
     || fail "repeating the fold must stay idempotent"
   [ "$(grep -cF "captain-held [key=default]: tracked by $hold" "$home/state/$origin.status")" = 1 ] \
@@ -933,12 +948,16 @@ test_folded_status_decision_satisfies_completion() {
   rc=$?
   set -e
   [ "$rc" -ne 0 ] || fail "one unqualified fold blanket-satisfied several open status decisions"
+  assert_grep "2 open structured decisions;" "$home/blanket.err" \
+    "the several-open refusal wording must be unchanged"
   assert_grep "--key" "$home/blanket.err" "the refusal must ask which decision the fold covers"
-  run_decisions "$home" fold "$origin" --into "$hold" --key purge-cadence \
+  run_decisions "$home" fold "$origin" --into "$hold" --key purge-cadence --key purge-cadence \
     --note "the purge cadence is the same retention question" >/dev/null \
     || fail "a keyed fold must cover the decision it names"
   assert_grep "captain-held [key=purge-cadence]: tracked by $hold" "$home/state/$origin.status" \
     "the keyed fold must transfer the decision it named"
+  [ "$(grep -cF "captain-held [key=purge-cadence]: tracked by $hold" "$home/state/$origin.status")" = 1 ] \
+    || fail "a key repeated within one invocation wrote the transfer line twice"
   assert_no_grep "captain-held [key=export-shape]" "$home/state/$origin.status" \
     "a keyed fold must not close a decision it did not cover"
   if run_decisions "$home" complete "$origin" --folded \

--- a/tests/fm-decision-hold-lifecycle.test.sh
+++ b/tests/fm-decision-hold-lifecycle.test.sh
@@ -760,7 +760,54 @@ test_externally_closed_decisions_are_durably_resolved() {
   fi
   assert_grep "no decision record" "$home/norec.err" \
     "the refusal must name the missing record rather than the formatting"
+
+  # Ordinary Done retention must not launder that refusal into an acceptance: the
+  # archive keeps the untouched registration body, so the archived shape is held
+  # to the same record test as the live one.
+  tasks_in "$home" prune --keep 0 >/dev/null 2>&1 || true
+  if ! grep -F -- "- [x] $hold - " "$home/data/backlog.md" >/dev/null 2>&1; then
+    assert_grep "State: awaiting captain decision." "$home/data/done-archive.md" \
+      "the archive must preserve the untouched registration body"
+    if run_decisions "$home" complete "$origin" already-answered no-record \
+      > "$home/archived-norec.out" 2> "$home/archived-norec.err"; then
+      fail "retention turned a refused recordless closure into an accepted one"
+    fi
+    assert_grep "no decision record" "$home/archived-norec.err" \
+      "the archived refusal must name the missing record too"
+  fi
   pass "externally closed and archived decisions are durably resolved, recordless closure is not"
+}
+
+# A fold that cannot be recorded must not report success: the origin would then
+# fail `complete --folded` and could attest `--none` over a live decision.
+test_unrecordable_fold_refuses_rather_than_reporting_success() {
+  local home origin other hold show
+  home=$(make_home unrecordable-fold)
+  origin=sample-owning-review
+  other=sample-later-review
+  mkdir -p "$home/data/$origin" "$home/data/$other"
+  printf '# owning\n' > "$home/data/$origin/report.md"
+  printf '# later\n' > "$home/data/$other/report.md"
+  write_origin_meta "$home" "$origin"
+
+  hold=$(run_decisions "$home" hold "$origin" scope \
+    --title "Choose the sample scope" --reason "captain scope call" --repo sample) \
+    || fail "could not register the decision to fold into"
+
+  # The later review is known only by its report - the post-teardown shape - so no
+  # state/<origin>.meta exists to record the fold in.
+  [ ! -f "$home/state/$other.meta" ] || fail "fixture must have no runtime metadata"
+  if run_decisions "$home" fold "$other" --into "$hold" --note "the same scope question" \
+    > "$home/fold.out" 2> "$home/fold.err"; then
+    fail "fold reported success while it could not record the fold: $(cat "$home/fold.out")"
+  fi
+  assert_grep "no runtime metadata" "$home/fold.err" \
+    "the refusal must name the missing origin metadata"
+  show=$(tasks_in "$home" show "$hold" --full)
+  case "$show" in
+    *"Also raised by $other"*) fail "a refused fold still mutated the target body" ;;
+  esac
+  pass "a fold that cannot be recorded refuses instead of reporting success"
 }
 
 # A question that turns out to be firstmate's own call must be closable as such,
@@ -1335,6 +1382,7 @@ SH
 
 test_uninventoried_report_decision_refuses_completion
 test_externally_closed_decisions_are_durably_resolved
+test_unrecordable_fold_refuses_rather_than_reporting_success
 test_firstmate_decided_closure_is_first_class
 test_second_pass_cannot_silently_duplicate_an_open_decision
 test_answer_is_recorded_without_inventing_dependent_work

--- a/tests/fm-decision-hold-lifecycle.test.sh
+++ b/tests/fm-decision-hold-lifecycle.test.sh
@@ -128,6 +128,24 @@ run_decisions() {  # <home> <command args...>
     FM_CONFIG_OVERRIDE="$home/config" "$ROOT/bin/fm-decision-hold.sh" "$@"
 }
 
+run_decisions_now() {  # <home> <today> <command args...>
+  local home=$1 now=$2
+  shift 2
+  PATH="$home/fakebin:$PATH" REAL_TASKS_AXI="$TASKS_AXI_BIN" \
+    FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
+    FM_CONFIG_OVERRIDE="$home/config" FM_DECISION_NOW="$now" \
+    "$ROOT/bin/fm-decision-hold.sh" "$@"
+}
+
+# Backdate one queued row's registration date, which is what tasks-axi reports as
+# its created date and what the ageing threshold is measured from.
+set_since() {  # <home> <id> <date>
+  local home=$1 id=$2 date=$3
+  sed "/^- \[ \] $id - /s/(since [0-9][0-9-]*)/(since $date)/" \
+    "$home/data/backlog.md" > "$home/backlog.since"
+  mv "$home/backlog.since" "$home/data/backlog.md"
+}
+
 write_origin_meta() {  # <home> <id> [kind]
   local home=$1 id=$2 kind=${3:-scout}
   fm_write_meta "$home/state/$id.meta" \
@@ -660,6 +678,23 @@ test_second_pass_cannot_silently_duplicate_an_open_decision() {
   open_out=$(run_decisions "$home" open) || fail "open listing failed"
   assert_contains "$open_out" "open captain decisions in" "open must report the current set"
   assert_contains "$open_out" "$first-decision-handbook-authority" "open must list the folded-into decision"
+
+  # The listing must cite only decisions the captain can actually see, so an
+  # unresolved blocker removes a decision here exactly as it does in Bearings.
+  tasks_in "$home" add sample-prerequisite "Land the prerequisite first" --kind ship --repo sample >/dev/null \
+    || fail "could not create the blocking prerequisite"
+  tasks_in "$home" block "$first-decision-handbook-authority" --by sample-prerequisite >/dev/null \
+    || fail "could not block the decision by its prerequisite"
+  open_out=$(run_decisions "$home" open) || fail "open listing failed while a decision was blocked"
+  case "$open_out" in
+    *"$first-decision-handbook-authority"*)
+      fail "open listed a blocked decision the fleet view does not show as actionable" ;;
+  esac
+  tasks_in "$home" unblock "$first-decision-handbook-authority" --by sample-prerequisite >/dev/null \
+    || fail "could not clear the prerequisite edge"
+  open_out=$(run_decisions "$home" open) || fail "open listing failed after unblocking"
+  assert_contains "$open_out" "$first-decision-handbook-authority" \
+    "clearing the blocker must return the decision to the actionable listing"
   pass "a second pass cannot silently duplicate an open decision and can fold into it"
 }
 
@@ -834,9 +869,125 @@ test_firstmate_decided_closure_is_first_class() {
     --decision "Firstmate decided: land the schema change first; the evidence settles it." \
     --decided-by firstmate --no-routed-work >/dev/null \
     || fail "a firstmate-decided closure must stay idempotent on retry"
+  if run_decisions "$home" resolve "$origin" merge-order \
+    --decision "Firstmate decided: land the schema change first; the evidence settles it." \
+    --decided-by captain --no-routed-work > "$home/attr.out" 2> "$home/attr.err"; then
+    fail "a retry reattributing the same answer to the captain reported success"
+  fi
+  assert_grep "different decider" "$home/attr.err" \
+    "attribution must be part of the retry identity, not outside it"
   run_decisions "$home" complete "$origin" merge-order >/dev/null \
     || fail "a firstmate-decided closure must satisfy the completion gate"
   pass "a firstmate-decided closure is first-class and attributed honestly"
+}
+
+# A finding folded into the decision that already owns the question must also close
+# that question's live status copy. Otherwise the origin's own keys never cover it,
+# `complete --folded` dead-ends, and the only way forward is the second captain
+# decision this whole path exists to prevent.
+test_folded_status_decision_satisfies_completion() {
+  local home owner origin hold rc
+  home=$(make_home folded-status)
+  owner=sample-policy-review
+  origin=sample-policy-audit
+  mkdir -p "$home/data/$owner" "$home/data/$origin"
+  printf '# owner\n' > "$home/data/$owner/report.md"
+  printf '# audit\n' > "$home/data/$origin/report.md"
+  write_origin_meta "$home" "$owner"
+  write_origin_meta "$home" "$origin"
+  hold=$(run_decisions "$home" hold "$owner" retention-window \
+    --title "How long should sample records be retained" \
+    --reason "policy the captain owns" --repo sample) \
+    || fail "could not register the owning decision"
+
+  # The later pass's crewmate raised the same question as a structured status
+  # decision, which is the shape that used to make the fold path a dead end.
+  printf 'working: auditing retention\nneeds-decision: how long are sample records retained\n' \
+    > "$home/state/$origin.status"
+
+  run_decisions "$home" fold "$origin" --into "$hold" \
+    --note "the audit pass reaches the same question" >/dev/null \
+    || fail "could not fold the audit finding into the owning decision"
+  assert_grep "captain-held [key=default]: tracked by $hold" "$home/state/$origin.status" \
+    "the fold must transfer the live status decision to the decision that now owns it"
+  run_decisions "$home" complete "$origin" --folded >/dev/null \
+    || fail "--folded must satisfy the gate for an origin whose status decision was folded"
+  run_decisions "$home" verify "$origin" >/dev/null \
+    || fail "teardown verification must accept a folded status decision"
+  [ "$(grep -cE '^- \[ \] .*-decision-.* -' "$home/data/backlog.md")" = 1 ] \
+    || fail "satisfying the gate required a second captain decision"
+  run_decisions "$home" fold "$origin" --into "$hold" \
+    --note "the audit pass reaches the same question" >/dev/null \
+    || fail "repeating the fold must stay idempotent"
+  [ "$(grep -cF "captain-held [key=default]: tracked by $hold" "$home/state/$origin.status")" = 1 ] \
+    || fail "repeating the fold duplicated the status transfer"
+
+  # One fold covers exactly the question it folded, never the rest of the open set.
+  printf 'needs-decision [key=purge-cadence]: how often should the purge run\n' \
+    >> "$home/state/$origin.status"
+  printf 'needs-decision [key=export-shape]: which export shape is authoritative\n' \
+    >> "$home/state/$origin.status"
+  set +e
+  run_decisions "$home" fold "$origin" --into "$hold" --note "both open questions at once" \
+    > "$home/blanket.out" 2> "$home/blanket.err"
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "one unqualified fold blanket-satisfied several open status decisions"
+  assert_grep "--key" "$home/blanket.err" "the refusal must ask which decision the fold covers"
+  run_decisions "$home" fold "$origin" --into "$hold" --key purge-cadence \
+    --note "the purge cadence is the same retention question" >/dev/null \
+    || fail "a keyed fold must cover the decision it names"
+  assert_grep "captain-held [key=purge-cadence]: tracked by $hold" "$home/state/$origin.status" \
+    "the keyed fold must transfer the decision it named"
+  assert_no_grep "captain-held [key=export-shape]" "$home/state/$origin.status" \
+    "a keyed fold must not close a decision it did not cover"
+  if run_decisions "$home" complete "$origin" --folded \
+    > "$home/rest.out" 2> "$home/rest.err"; then
+    fail "a status decision no fold covered passed the completion gate"
+  fi
+  assert_grep "export-shape" "$home/rest.err" "the refusal must name the decision still open"
+  pass "a folded status decision satisfies completion without a second captain decision"
+}
+
+# The threshold is inclusive, and both day-boundary reads are anchored at midnight,
+# so a decision at exactly FM_DECISION_AGING_DAYS cannot lose a day and drop out of
+# the set that resurfaces on its own.
+test_decision_at_exactly_the_ageing_threshold_is_ageing() {
+  local home origin at_threshold below out
+  home=$(make_home ageing-threshold)
+  origin=sample-threshold-review
+  mkdir -p "$home/data/$origin"
+  printf '# threshold\n' > "$home/data/$origin/report.md"
+  write_origin_meta "$home" "$origin"
+  at_threshold=$(run_decisions "$home" hold "$origin" cutover-date \
+    --title "Which cutover date is authoritative" \
+    --reason "schedule the captain owns" --repo sample) \
+    || fail "could not register the threshold decision"
+  below=$(run_decisions "$home" hold "$origin" rollout-shape \
+    --title "Which rollout shape should be used" \
+    --reason "shape the captain owns" --repo sample --distinct) \
+    || fail "could not register the younger decision"
+  set_since "$home" "$at_threshold" 2026-07-23
+  set_since "$home" "$below" 2026-07-24
+
+  out=$(run_decisions_now "$home" 2026-07-26 open --aging-only) \
+    || fail "the ageing listing failed"
+  assert_contains "$out" "$at_threshold" \
+    "a decision at exactly the threshold must be reported as ageing"
+  assert_contains "$out" "waiting 3 days" \
+    "the age at the threshold must be reported as the whole days waited"
+  case "$out" in
+    *"$below"*) fail "a decision below the threshold leaked into the ageing set" ;;
+  esac
+
+  out=$(run_decisions_now "$home" 2026-07-25 open --aging-only) \
+    || fail "the ageing listing failed one day earlier"
+  case "$out" in
+    *"$at_threshold"*) fail "a decision one day below the threshold was reported as ageing" ;;
+  esac
+  out=$(run_decisions_now "$home" 2026-07-26 open) || fail "the full listing failed"
+  assert_contains "$out" "$below" "the full listing must still carry the younger decision"
+  pass "a decision at exactly the ageing threshold is ageing and one below it is not"
 }
 
 # A captain who declines a held decision leaves no follow-up work to route, so the
@@ -1382,6 +1533,8 @@ SH
 
 test_uninventoried_report_decision_refuses_completion
 test_externally_closed_decisions_are_durably_resolved
+test_folded_status_decision_satisfies_completion
+test_decision_at_exactly_the_ageing_threshold_is_ageing
 test_unrecordable_fold_refuses_rather_than_reporting_success
 test_firstmate_decided_closure_is_first_class
 test_second_pass_cannot_silently_duplicate_an_open_decision

--- a/tests/fm-decision-hold-lifecycle.test.sh
+++ b/tests/fm-decision-hold-lifecycle.test.sh
@@ -176,7 +176,7 @@ EOF
     fail "completion succeeded while one of two distinct decisions lacked a hold"
   fi
   access_hold=$(run_decisions "$home" hold "$id" access \
-    --title "Choose the sample access level" --reason "captain access choice pending" --repo sample) \
+    --title "Choose the sample access level" --reason "captain access choice pending" --repo sample --distinct) \
     || fail "could not register access hold"
   [ "$access_hold" = "$id-decision-access" ] || fail "access hold identity was not distinct: $access_hold"
   [ "$(grep -cE "^- \[ \] $route_hold -" "$home/data/backlog.md")" = 1 ] \
@@ -504,13 +504,13 @@ test_resolve_matches_quoted_blocked_by_edges() {
     --title "First edge decision" --reason "captain first pending" --repo sample) \
     || fail "could not register first-edge hold"
   hold_mid=$(run_decisions "$home" hold "$origin" edge-mid \
-    --title "Middle edge decision" --reason "captain mid pending" --repo sample) \
+    --title "Middle edge decision" --reason "captain mid pending" --repo sample --distinct) \
     || fail "could not register mid-edge hold"
   hold_last=$(run_decisions "$home" hold "$origin" edge-last \
-    --title "Last edge decision" --reason "captain last pending" --repo sample) \
+    --title "Last edge decision" --reason "captain last pending" --repo sample --distinct) \
     || fail "could not register last-edge hold"
   hold_absent=$(run_decisions "$home" hold "$origin" edge-absent \
-    --title "Absent edge decision" --reason "captain absent pending" --repo sample) \
+    --title "Absent edge decision" --reason "captain absent pending" --repo sample --distinct) \
     || fail "could not register absent-edge hold"
 
   tasks_in "$home" add pad-a "Pad A" --kind ship --repo sample >/dev/null \
@@ -579,6 +579,217 @@ test_resolve_matches_quoted_blocked_by_edges() {
   assert_contains "$show" "held: yes" "failed absent resolve must leave the hold held"
 
   pass "resolve matches first/middle/last in quoted blocked_by and rejects a genuinely absent id"
+}
+
+# A second review pass of the same subject reaches the same question under a
+# different key. That is how the queue compounds, so registering the duplicate
+# must not be possible without the open set being seen first, and folding must
+# leave exactly one captain decision behind.
+test_second_pass_cannot_silently_duplicate_an_open_decision() {
+  local home first second rc out show open_out
+  home=$(make_home duplicate-guard)
+  first=sample-handbook-review
+  second=sample-handbook-audit
+  mkdir -p "$home/data/$first" "$home/data/$second"
+  printf '# first pass\n' > "$home/data/$first/report.md"
+  printf '# second pass\n' > "$home/data/$second/report.md"
+  write_origin_meta "$home" "$first"
+  write_origin_meta "$home" "$second"
+
+  run_decisions "$home" hold "$first" handbook-authority \
+    --title "Which handbook is authoritative for the coding rules" \
+    --reason "standing policy choice" --repo sample >/dev/null \
+    || fail "could not register the first-pass decision"
+
+  # The second pass asks the same question under its own key.
+  set +e
+  run_decisions "$home" hold "$second" canonical-handbook \
+    --title "Which text is canonical for the coding rules" \
+    --reason "same authority question" --repo sample \
+    > "$home/dup.out" 2> "$home/dup.err"
+  rc=$?
+  set -e
+  [ "$rc" -eq 3 ] || fail "a same-subject duplicate registered without review (exit $rc)"
+  assert_grep "$first-decision-handbook-authority" "$home/dup.err" \
+    "the refusal must put the open decision set in front of the agent"
+  assert_grep "fold" "$home/dup.err" "the refusal must offer folding as the first-class alternative"
+  ! grep -F -- "$second-decision-canonical-handbook" "$home/data/backlog.md" >/dev/null \
+    || fail "the refused duplicate still reached the backlog"
+
+  # Folding records the finding on the decision that already owns the question.
+  run_decisions "$home" fold "$second" --into "$first-decision-handbook-authority" \
+    --note "the audit pass reaches the same question" >/dev/null \
+    || fail "could not fold the second pass into the open decision"
+  run_decisions "$home" fold "$second" --into "$first-decision-handbook-authority" \
+    --note "the audit pass reaches the same question" >/dev/null \
+    || fail "folding the same finding twice must be idempotent"
+  [ "$(grep -cE "^- \[ \] .*-decision-.* -" "$home/data/backlog.md")" = 1 ] \
+    || fail "folding created a second captain decision"
+  show=$(tasks_in "$home" show "$first-decision-handbook-authority" --full)
+  assert_contains "$show" "Also raised by $second" \
+    "the folded finding must be durable on the decision that owns the question"
+  assert_grep "decision_folds=$first-decision-handbook-authority" "$home/state/$second.meta" \
+    "the fold must be recorded against the origin that found it"
+
+  # The completion gate stays intact: --none would be a false attestation.
+  if run_decisions "$home" complete "$second" --none > "$home/none.out" 2> "$home/none.err"; then
+    fail "--none passed while the origin had folded a real unresolved decision"
+  fi
+  assert_grep "use --folded" "$home/none.err" "the refusal must name the honest attestation"
+  run_decisions "$home" complete "$second" --folded >/dev/null \
+    || fail "--folded must satisfy the gate for a fully folded review pass"
+  run_decisions "$home" verify "$second" >/dev/null \
+    || fail "teardown verification must accept a folded inventory"
+
+  # A genuinely different question still gets through, once attested.
+  out=$(run_decisions "$home" hold "$second" rollout-window \
+    --title "When should the rollout window open" \
+    --reason "schedule choice" --repo sample --distinct) \
+    || fail "--distinct must let a genuinely distinct decision through"
+  [ "$out" = "$second-decision-rollout-window" ] || fail "distinct decision identity was wrong: $out"
+  show=$(tasks_in "$home" show "$out" --full)
+  assert_contains "$show" "Distinct-from-open: attested" \
+    "the distinctness attestation must be durable"
+
+  # Repeating an existing identity is a retry, never a new registration.
+  run_decisions "$home" hold "$first" handbook-authority \
+    --title "Which handbook is authoritative for the coding rules" \
+    --reason "standing policy choice" --repo sample >/dev/null \
+    || fail "an exact-key retry must stay idempotent and ungated"
+
+  open_out=$(run_decisions "$home" open) || fail "open listing failed"
+  assert_contains "$open_out" "open captain decisions in" "open must report the current set"
+  assert_contains "$open_out" "$first-decision-handbook-authority" "open must list the folded-into decision"
+  pass "a second pass cannot silently duplicate an open decision and can fold into it"
+}
+
+# An answer must be recordable in the turn it arrives. The ceremony that made
+# answers go unrecorded - write a file, invent a dependent task, block it - must
+# survive only where dependent work genuinely exists.
+test_answer_is_recorded_without_inventing_dependent_work() {
+  local home origin hold show
+  home=$(make_home light-resolve)
+  origin=sample-sequencing-review
+  mkdir -p "$home/data/$origin"
+  printf '# sequencing\n' > "$home/data/$origin/report.md"
+  write_origin_meta "$home" "$origin"
+  hold=$(run_decisions "$home" hold "$origin" accepted-risk \
+    --title "Accept the known gap to ship sooner" --reason "risk the captain owns" --repo sample) \
+    || fail "could not register the decision"
+
+  run_decisions "$home" resolve "$origin" accepted-risk \
+    --decision "Captain accepted the gap and asked to ship." --no-routed-work >/dev/null \
+    || fail "an answer with no dependent work must be recordable in one call"
+  show=$(tasks_in "$home" show "$hold" --full)
+  assert_contains "$show" "state: done" "the answered decision must be closed"
+  assert_contains "$show" "Captain accepted the gap and asked to ship." \
+    "the captain's exact words must be preserved durably"
+  assert_contains "$show" "Origin record:" \
+    "closing must not erase the registration record"
+  run_decisions "$home" resolve "$origin" accepted-risk \
+    --decision "Captain accepted the gap and asked to ship." --no-routed-work >/dev/null \
+    || fail "recording the same answer twice must be idempotent"
+
+  # Where dependent work genuinely exists, routing is still mandatory.
+  hold=$(run_decisions "$home" hold "$origin" split-or-fix \
+    --title "Split the change or fix in place" --reason "captain scope call" --repo sample --distinct) \
+    || fail "could not register the routed-work decision"
+  tasks_in "$home" add sample-followup "Apply the chosen shape" --kind ship --repo sample >/dev/null \
+    || fail "could not create dependent work"
+  tasks_in "$home" block sample-followup --by "$hold" >/dev/null \
+    || fail "could not block dependent work by the decision"
+  if run_decisions "$home" resolve "$origin" split-or-fix \
+    --decision "Split it." --no-routed-work > "$home/skip.out" 2> "$home/skip.err"; then
+    fail "--no-routed-work bypassed genuinely existing dependent work"
+  fi
+  assert_grep "sample-followup" "$home/skip.err" "the refusal must name the work that must be routed"
+  show=$(tasks_in "$home" show "$hold" --full)
+  assert_contains "$show" "state: queued" "a refused resolve must leave the decision open"
+  run_decisions "$home" resolve "$origin" split-or-fix \
+    --decision "Split it." --routed-to sample-followup >/dev/null \
+    || fail "routing the answer to real dependent work must still work"
+  show=$(tasks_in "$home" show sample-followup --full)
+  assert_contains "$show" "blocked: no" "routing must clear the dependency edge"
+  pass "an answer is recorded in one call and routing survives where dependent work exists"
+}
+
+# Decisions closed outside this script - firstmate decided them, or an earlier
+# captain answer already settled them - carry a real decision record but not this
+# script's formatting, and Done retention rotates older ones into the archive.
+# Neither may strand a finished investigation at the completion gate, and a
+# decision closed with no record at all must still be refused.
+test_externally_closed_decisions_are_durably_resolved() {
+  local home origin hold
+  home=$(make_home external-closure)
+  origin=sample-answered-review
+  mkdir -p "$home/data/$origin"
+  printf '# answered\n' > "$home/data/$origin/report.md"
+  write_origin_meta "$home" "$origin"
+
+  # Closed by hand with a decision record, exactly as a bulk close does it.
+  hold=$(run_decisions "$home" hold "$origin" already-answered \
+    --title "Bound the retry budget or fail fast" --reason "captain policy call" --repo sample) \
+    || fail "could not register the decision"
+  tasks_in "$home" update "$hold" --body \
+    "CLOSED as ALREADY ANSWERED - the captain settled this on 2026-01-05 under key retry-budget." >/dev/null \
+    || fail "could not record the external decision record"
+  tasks_in "$home" unhold "$hold" >/dev/null || fail "could not release the hold"
+  tasks_in "$home" "done" "$hold" >/dev/null || fail "could not close the decision"
+  run_decisions "$home" complete "$origin" already-answered >/dev/null \
+    || fail "a decision closed with a real record must pass the completion gate"
+  run_decisions "$home" verify "$origin" >/dev/null \
+    || fail "a decision closed with a real record must pass the teardown gate"
+
+  # Retention rotates the closed decision out of the live backlog.
+  tasks_in "$home" prune --keep 0 >/dev/null 2>&1 || tasks_in "$home" "done" "$hold" --keep 0 >/dev/null 2>&1 || true
+  if ! grep -F -- "- [x] $hold - " "$home/data/backlog.md" >/dev/null 2>&1; then
+    assert_present "$home/data/done-archive.md" "retention must archive the closed decision"
+    run_decisions "$home" verify "$origin" >/dev/null \
+      || fail "Done retention alone must not make a reviewed inventory unverifiable"
+  fi
+
+  # Closure with no record at all is still the loss this gate prevents.
+  hold=$(run_decisions "$home" hold "$origin" no-record \
+    --title "Closed with nothing written down" --reason "captain call" --repo sample --distinct) \
+    || fail "could not register the second decision"
+  tasks_in "$home" unhold "$hold" >/dev/null || fail "could not release the second hold"
+  tasks_in "$home" "done" "$hold" >/dev/null || fail "could not close the second decision"
+  if run_decisions "$home" complete "$origin" already-answered no-record \
+    > "$home/norec.out" 2> "$home/norec.err"; then
+    fail "a decision closed with no record at all passed the gate"
+  fi
+  assert_grep "no decision record" "$home/norec.err" \
+    "the refusal must name the missing record rather than the formatting"
+  pass "externally closed and archived decisions are durably resolved, recordless closure is not"
+}
+
+# A question that turns out to be firstmate's own call must be closable as such,
+# without pretending the captain answered it.
+test_firstmate_decided_closure_is_first_class() {
+  local home origin hold show
+  home=$(make_home firstmate-decided)
+  origin=sample-sequencing
+  mkdir -p "$home/data/$origin"
+  printf '# sequencing\n' > "$home/data/$origin/report.md"
+  write_origin_meta "$home" "$origin"
+  hold=$(run_decisions "$home" hold "$origin" merge-order \
+    --title "Which of the two changes lands first" --reason "sequencing" --repo sample) \
+    || fail "could not register the decision"
+  run_decisions "$home" resolve "$origin" merge-order \
+    --decision "Firstmate decided: land the schema change first; the evidence settles it." \
+    --decided-by firstmate --no-routed-work >/dev/null \
+    || fail "a firstmate-decided closure must be a first-class resolve"
+  show=$(tasks_in "$home" show "$hold" --full)
+  assert_contains "$show" "state: done" "the firstmate-decided closure must close the decision"
+  assert_contains "$show" "Decided by: firstmate" \
+    "the record must not attribute a firstmate decision to the captain"
+  run_decisions "$home" resolve "$origin" merge-order \
+    --decision "Firstmate decided: land the schema change first; the evidence settles it." \
+    --decided-by firstmate --no-routed-work >/dev/null \
+    || fail "a firstmate-decided closure must stay idempotent on retry"
+  run_decisions "$home" complete "$origin" merge-order >/dev/null \
+    || fail "a firstmate-decided closure must satisfy the completion gate"
+  pass "a firstmate-decided closure is first-class and attributed honestly"
 }
 
 # A captain who declines a held decision leaves no follow-up work to route, so the
@@ -800,7 +1011,7 @@ test_unanswered_decision_still_blocks_completion_and_teardown() {
 # hold open, so the captain was asked to re-answer decisions already on his own
 # disk. Capturing the answer must now BE closing the hold.
 test_bound_channel_answers_close_their_holds_at_answer_time() {
-  local home id sid artifact result out show key rc
+  local home id sid artifact result out show key rc first
   home=$(make_home lavish-answer-closure)
   id=sample-eval-proposal
   mkdir -p "$home/data/$id"
@@ -809,10 +1020,18 @@ test_bound_channel_answers_close_their_holds_at_answer_time() {
   write_origin_meta "$home" "$id"
   printf 'done: proposal deck ready for the captain\n' > "$home/state/$id.status"
   printf '# Sample eval proposal\n\nFour captain choices remain.\n' > "$home/data/$id/report.md"
+  first=1
   for key in diversified-membership precision-headline fp-approve-merge eval-holdout routed-phase forged-choice; do
-    run_decisions "$home" hold "$id" "$key" \
-      --title "Captain call: $key" --reason "captain $key choice pending" --repo sample >/dev/null \
-      || fail "could not register the $key hold"
+    if [ "$first" = 1 ]; then
+      run_decisions "$home" hold "$id" "$key" \
+        --title "Captain call: $key" --reason "captain $key choice pending" --repo sample >/dev/null \
+        || fail "could not register the $key hold"
+      first=0
+    else
+      run_decisions "$home" hold "$id" "$key" \
+        --title "Captain call: $key" --reason "captain $key choice pending" --repo sample --distinct >/dev/null \
+        || fail "could not register the $key hold"
+    fi
   done
   run_decisions "$home" complete "$id" \
     diversified-membership precision-headline fp-approve-merge eval-holdout routed-phase forged-choice >/dev/null \
@@ -1115,6 +1334,10 @@ SH
 }
 
 test_uninventoried_report_decision_refuses_completion
+test_externally_closed_decisions_are_durably_resolved
+test_firstmate_decided_closure_is_first_class
+test_second_pass_cannot_silently_duplicate_an_open_decision
+test_answer_is_recorded_without_inventing_dependent_work
 
 test_scout_teardown_always_requires_inventory_verification
 test_declined_decision_closes_without_routed_work

--- a/tests/fm-decision-hold-lifecycle.test.sh
+++ b/tests/fm-decision-hold-lifecycle.test.sh
@@ -653,7 +653,8 @@ test_second_pass_cannot_silently_duplicate_an_open_decision() {
   if run_decisions "$home" complete "$second" --none > "$home/none.out" 2> "$home/none.err"; then
     fail "--none passed while the origin had folded a real unresolved decision"
   fi
-  assert_grep "use --folded" "$home/none.err" "the refusal must name the honest attestation"
+  assert_grep "contradicts the folds" "$home/none.err" \
+    "the refusal must name the folds it contradicts"
   run_decisions "$home" complete "$second" --folded >/dev/null \
     || fail "--folded must satisfy the gate for a fully folded review pass"
   run_decisions "$home" verify "$second" >/dev/null \
@@ -881,12 +882,13 @@ test_firstmate_decided_closure_is_first_class() {
   pass "a firstmate-decided closure is first-class and attributed honestly"
 }
 
-# A finding folded into the decision that already owns the question must also close
-# that question's live status copy. Otherwise the origin's own keys never cover it,
-# `complete --folded` dead-ends, and the only way forward is the second captain
-# decision this whole path exists to prevent.
-test_folded_status_decision_satisfies_completion() {
-  local home owner origin hold rc
+# Folding records a finding against the decision that already owns the question and
+# says nothing about the live status log. Sign-off is the single owner of that
+# accounting: every open entry must be named, either by its own key or as carried by
+# a recorded fold, and the mixed pass - one genuinely new question plus one folded
+# duplicate - must be expressible without inverting the documented order.
+test_status_accounting_is_owned_by_sign_off() {
+  local home owner origin hold
   home=$(make_home folded-status)
   owner=sample-policy-review
   origin=sample-policy-audit
@@ -900,72 +902,111 @@ test_folded_status_decision_satisfies_completion() {
     --reason "policy the captain owns" --repo sample) \
     || fail "could not register the owning decision"
 
-  # The later pass's crewmate raised the same question as a structured status
-  # decision, which is the shape that used to make the fold path a dead end.
-  printf 'working: auditing retention\nneeds-decision: how long are sample records retained\n' \
-    > "$home/state/$origin.status"
-
-  # An unqualified fold has said nothing about which question it covers, so it must
-  # not claim the sole open decision on the strength of it being the only one there.
-  set +e
-  run_decisions "$home" fold "$origin" --into "$hold" \
-    --note "the audit pass reaches the same question" \
-    > "$home/sole.out" 2> "$home/sole.err"
-  rc=$?
-  set -e
-  [ "$rc" -ne 0 ] || fail "an unqualified fold claimed the origin's sole open status decision"
-  assert_grep "--key" "$home/sole.err" "the refusal must ask which decision the fold covers"
-  assert_grep "1 open structured decision;" "$home/sole.err" \
-    "the single-open refusal must read as one decision, not several"
-  assert_no_grep "captain-held" "$home/state/$origin.status" \
-    "a refused fold must not transfer any status decision"
-
-  run_decisions "$home" fold "$origin" --into "$hold" --key default \
-    --note "the audit pass reaches the same question" >/dev/null \
-    || fail "could not fold the audit finding into the owning decision"
-  assert_grep "captain-held [key=default]: tracked by $hold" "$home/state/$origin.status" \
-    "the fold must transfer the live status decision to the decision that now owns it"
-  run_decisions "$home" complete "$origin" --folded >/dev/null \
-    || fail "--folded must satisfy the gate for an origin whose status decision was folded"
-  run_decisions "$home" verify "$origin" >/dev/null \
-    || fail "teardown verification must accept a folded status decision"
-  [ "$(grep -cE '^- \[ \] .*-decision-.* -' "$home/data/backlog.md")" = 1 ] \
-    || fail "satisfying the gate required a second captain decision"
-  run_decisions "$home" fold "$origin" --into "$hold" --key default \
-    --note "the audit pass reaches the same question" >/dev/null \
-    || fail "repeating the fold must stay idempotent"
-  [ "$(grep -cF "captain-held [key=default]: tracked by $hold" "$home/state/$origin.status")" = 1 ] \
-    || fail "repeating the fold duplicated the status transfer"
-
-  # One fold covers exactly the question it folded, never the rest of the open set.
-  printf 'needs-decision [key=purge-cadence]: how often should the purge run\n' \
+  # The audit's crewmate left two live questions: one this pass judges a duplicate
+  # of the open decision, one that is genuinely its own new captain question.
+  printf 'working: auditing retention\n' > "$home/state/$origin.status"
+  printf 'needs-decision [key=retention-span]: how long are sample records retained\n' \
     >> "$home/state/$origin.status"
   printf 'needs-decision [key=export-shape]: which export shape is authoritative\n' \
     >> "$home/state/$origin.status"
-  set +e
-  run_decisions "$home" fold "$origin" --into "$hold" --note "both open questions at once" \
-    > "$home/blanket.out" 2> "$home/blanket.err"
-  rc=$?
-  set -e
-  [ "$rc" -ne 0 ] || fail "one unqualified fold blanket-satisfied several open status decisions"
-  assert_grep "2 open structured decisions;" "$home/blanket.err" \
-    "the several-open refusal wording must be unchanged"
-  assert_grep "--key" "$home/blanket.err" "the refusal must ask which decision the fold covers"
-  run_decisions "$home" fold "$origin" --into "$hold" --key purge-cadence --key purge-cadence \
-    --note "the purge cadence is the same retention question" >/dev/null \
-    || fail "a keyed fold must cover the decision it names"
-  assert_grep "captain-held [key=purge-cadence]: tracked by $hold" "$home/state/$origin.status" \
-    "the keyed fold must transfer the decision it named"
-  [ "$(grep -cF "captain-held [key=purge-cadence]: tracked by $hold" "$home/state/$origin.status")" = 1 ] \
-    || fail "a key repeated within one invocation wrote the transfer line twice"
-  assert_no_grep "captain-held [key=export-shape]" "$home/state/$origin.status" \
-    "a keyed fold must not close a decision it did not cover"
+
+  run_decisions "$home" fold "$origin" --into "$hold" \
+    --note "the audit pass reaches the same retention question" >/dev/null \
+    || fail "could not fold the duplicate finding into the owning decision"
+  assert_no_grep "captain-held" "$home/state/$origin.status" \
+    "folding must not touch the origin status log"
+  assert_grep "decision_folds=$hold" "$home/state/$origin.meta" \
+    "the fold must be recorded in the origin metadata"
+  run_decisions "$home" fold "$origin" --into "$hold" \
+    --note "the audit pass reaches the same retention question" >/dev/null \
+    || fail "repeating the fold must stay idempotent"
+  [ "$(grep -cF "decision_folds=$hold" "$home/state/$origin.meta")" = 1 ] \
+    || fail "repeating the fold recorded the same fold twice"
+
+  # The genuinely new question gets its own captain decision.
+  run_decisions "$home" hold "$origin" export-shape \
+    --title "Which export shape is authoritative" \
+    --reason "format the captain owns" --repo sample --distinct >/dev/null \
+    || fail "could not register the genuinely new question"
+
+  # Sign-off that leaves either entry unnamed is refused, whatever else it names.
   if run_decisions "$home" complete "$origin" --folded \
-    > "$home/rest.out" 2> "$home/rest.err"; then
-    fail "a status decision no fold covered passed the completion gate"
+    > "$home/unnamed.out" 2> "$home/unnamed.err"; then
+    fail "a fold attestation alone accounted for entries the caller never named"
   fi
-  assert_grep "export-shape" "$home/rest.err" "the refusal must name the decision still open"
-  pass "a folded status decision satisfies completion without a second captain decision"
+  assert_grep "unaccounted for" "$home/unnamed.err" \
+    "the refusal must say the entry is unaccounted for"
+  if run_decisions "$home" complete "$origin" export-shape \
+    > "$home/half.out" 2> "$home/half.err"; then
+    fail "an entry carried only by a fold passed without being named"
+  fi
+  assert_grep "retention-span" "$home/half.err" "the refusal must name the unaccounted entry"
+  if run_decisions "$home" complete "$origin" --none \
+    > "$home/none.out" 2> "$home/none.err"; then
+    fail "--none passed while a fold was recorded"
+  fi
+  assert_grep "contradicts the folds" "$home/none.err" \
+    "--none must stay refused while any fold is recorded"
+  if run_decisions "$home" complete "$origin" --folded-key not-a-live-question \
+    > "$home/ghost.out" 2> "$home/ghost.err"; then
+    fail "a key that was never open was attested away as folded"
+  fi
+  assert_grep "no open structured decision under key not-a-live-question" \
+    "$home/ghost.err" "the refusal must name the key that was never open"
+  assert_no_grep "captain-held" "$home/state/$origin.status" \
+    "a refused sign-off must not transfer any status decision"
+
+  # The mixed pass in one call: own key for the new question, --folded-key for the
+  # entry the recorded fold carries.
+  run_decisions "$home" complete "$origin" export-shape --folded-key retention-span >/dev/null \
+    || fail "the mixed pass must be expressible in one sign-off"
+  assert_grep "captain-held [key=export-shape]: tracked by $origin-decision-export-shape" \
+    "$home/state/$origin.status" "a supplied key must be transferred to this origin's own hold"
+  assert_grep "captain-held [key=retention-span]: tracked by $hold" \
+    "$home/state/$origin.status" "a folded key must be transferred to the decision that carries it"
+  assert_grep "decision_folded_keys=retention-span" "$home/state/$origin.meta" \
+    "sign-off must record which entries a fold accounted for"
+  run_decisions "$home" verify "$origin" >/dev/null \
+    || fail "teardown verification must accept the accounted-for inventory"
+  run_decisions "$home" complete "$origin" export-shape --folded-key retention-span >/dev/null \
+    || fail "re-running the same sign-off must stay idempotent"
+  [ "$(grep -cF "captain-held [key=retention-span]: tracked by $hold" "$home/state/$origin.status")" = 1 ] \
+    || fail "re-running sign-off duplicated the folded transfer"
+  [ "$(grep -cE '^- \[ \] .*-decision-.* -' "$home/data/backlog.md")" = 2 ] \
+    || fail "accounting for the folded entry created an extra captain decision"
+  pass "sign-off owns status accounting and the mixed fold-and-register pass works"
+}
+
+# The shape this policy is most often invoked on: the investigation has finished, so
+# its status stream ends in a terminal event and no entry is open. Folding must work
+# there with nothing to name, and sign-off must accept the fold attestation alone.
+test_fold_on_a_finished_investigation_needs_no_accounting() {
+  local home owner origin hold
+  home=$(make_home finished-fold)
+  owner=sample-owning-pass
+  origin=sample-finished-pass
+  mkdir -p "$home/data/$owner" "$home/data/$origin"
+  printf '# owner\n' > "$home/data/$owner/report.md"
+  printf '# finished\n' > "$home/data/$origin/report.md"
+  write_origin_meta "$home" "$owner"
+  write_origin_meta "$home" "$origin"
+  hold=$(run_decisions "$home" hold "$owner" ordering-rule \
+    --title "Which ordering rule is authoritative" \
+    --reason "policy the captain owns" --repo sample) \
+    || fail "could not register the owning decision"
+  printf 'needs-decision: which ordering rule is authoritative\ndone: report complete\n' \
+    > "$home/state/$origin.status"
+
+  run_decisions "$home" fold "$origin" --into "$hold" \
+    --note "the finished pass reaches the same ordering question" >/dev/null \
+    || fail "folding on a finished investigation must not require anything to name"
+  run_decisions "$home" complete "$origin" --folded >/dev/null \
+    || fail "a fold attestation must satisfy sign-off when no entry is open"
+  run_decisions "$home" verify "$origin" >/dev/null \
+    || fail "teardown verification must accept a finished folded pass"
+  assert_no_grep "captain-held" "$home/state/$origin.status" \
+    "nothing was open, so nothing may be transferred"
+  pass "folding a finished investigation needs no status accounting"
 }
 
 # The threshold is inclusive, and both day-boundary reads are anchored at midnight,
@@ -1552,7 +1593,8 @@ SH
 
 test_uninventoried_report_decision_refuses_completion
 test_externally_closed_decisions_are_durably_resolved
-test_folded_status_decision_satisfies_completion
+test_status_accounting_is_owned_by_sign_off
+test_fold_on_a_finished_investigation_needs_no_accounting
 test_decision_at_exactly_the_ageing_threshold_is_ageing
 test_unrecordable_fold_refuses_rather_than_reporting_success
 test_firstmate_decided_closure_is_first_class


### PR DESCRIPTION
Four defects in firstmate's captain-decision handling let the decision queue grow without draining. Together they mean a decision can be registered twice, can wait indefinitely without anyone noticing, is expensive to close, and can strand the investigation that raised it.

## A. A second review pass can duplicate an open decision

`bin/fm-decision-hold.sh hold` builds its identity as `<origin-id>-decision-<decision-key>`, so a later pass over the same subject registers a second captain decision whenever it picks a different key, even though `decision-hold-lifecycle` asks the agent to match semantically. Nothing put the already-open set in front of the caller before the write.

`hold` now refuses to create a *new* identity while the home holds other open captain decisions: it prints the open set with each decision's age and exits 3. A refusal rather than a warning, because output after a successful write is not reliably read, and semantic matching needs the open set in context before the write rather than after it. It is not a hard block - `--distinct` clears it and records the attestation in the new decision's body. `fold` is the first-class alternative for a finding that belongs to a question already open: it appends the finding to the existing decision and records the fold in the origin's metadata, so the origin still satisfies the completion gate via `complete --folded`. Exact-key repetition never reaches the gate, so idempotent retry and recovery paths are unchanged. `open` prints the same listing on demand, with `--aging-only` for the threshold subset.

## B. An open decision's age is invisible

`bin/fm-fleet-snapshot.sh` marked a row `captain_actionable` but carried nothing about how long it had waited, so `bin/fm-bearings-snapshot.sh`'s Captain's Call could not distinguish a decision raised an hour ago from one waiting a week, and the bounded `decisions_open` cap could truncate the oldest away entirely.

Every captain-actionable row now carries `waiting_days` and `decision_aging`, computed from the `since` metadata `tasks-axi add` already writes. There is no schema change and nothing to backfill, so decisions registered before this change report their age immediately. Bearings carries `since`, `waiting_days`, and `aging` into `decisions_open` and orders it ageing-first then oldest-first, so an ageing decision leads the section and cannot be truncated away by the cap. One `FM_DECISION_AGING_DAYS` (default 3) drives both the fleet view and the CLI listing, so they cannot disagree about which decisions are ageing. Three days is the shortest span that always covers a full working day plus a weekend edge, so it cannot fire on a decision the captain simply has not reached yet, while still surfacing a stalled one long before the week-long silences it exists to prevent.

## C. Recording an answer cost more than repeating the question

`resolve` required a decision *file* plus at least one dependent task already blocked by the decision. Where the answer spawned no dependent work, satisfying that meant inventing a task purely to block it - so an answer that arrives in conversation is cheaper to leave unrecorded, which is how a decision stays open and gets asked again.

`--decision <text>` and `--no-routed-work` remove that cost, and `--decided-by captain|firstmate` records who actually settled it. The routing requirement survives where it matters: `--no-routed-work` is refused while any task is blocked by the decision, checked against `tasks-axi list --blocked` rather than against the caller's claim. Closing now carries the prior registration record forward under `Origin record:` instead of overwriting it, so the distinctness attestation and any folded findings survive closure.

Separately, `verify_hold_durable` - which backs both the completion gate and scout teardown - accepted only this script's own resolution formatting. A decision closed with a real written record by any other route was rejected as "neither actively held nor durably resolved", and one that ordinary Done retention had rotated into `data/done-archive.md` was rejected as absent, stranding the finished investigation that raised it. The gate was rejecting on formatting, not on substance. One shared `closed_body_has_record()` predicate now applies to a closed decision's body, and `archived_done_body()` reads the archive's preserved indented body lines so the archived shape is held to that same test. Retention therefore only changes where a decision's record lives, never whether the gate accepts it.

This does not weaken the gate. A closed decision whose body is empty, or one still carrying the untouched registration record saying `State: awaiting captain decision.`, is refused wherever it lives - it says in its own words that no answer was ever written down, which is exactly the loss the gate exists to prevent. The regression covers that refusal both in the live backlog and after `prune` rotates it into the archive, so retention cannot launder a closure the live branch refused.

## D. The bar for asking was never written down

`ask-user-authority` owned the ask-user authority boundary but stated no threshold for whether a question belongs to the captain at all, so an investigation could register anything it found unclear. It now carries a concrete four-step escalate-or-decide test with worked examples on both sides, and `decision-hold-lifecycle` routes every candidate through that bar before registering anything, so the queue stops growing at the source. `AGENTS.md` section 13's trigger is widened to match, and `AGENTS.md` section 8 gains one line requiring an ageing decision to be resurfaced as still waiting rather than re-asked.

## Verification

```
bash tests/fm-decision-hold-lifecycle.test.sh   # 14 cases
bash tests/fm-bearings-snapshot.test.sh         # 42 cases
bin/fm-lint.sh
bin/fm-doc-audience-check.sh
```

The tests are behavioural, through the CLI and the snapshot contracts, on synthetic `sample-*` identities, with no assertions on implementation source. `FM_DECISION_NOW` and `FM_SNAPSHOT_NOW` pin the clock so the ageing arithmetic is deterministic.

New cases cover duplicate refusal and its exit code, the open set reaching the caller, folding (idempotence, no second decision, and refusal when the origin has no metadata to record the fold in), `--none` refused against recorded folds, `--distinct` passing a genuinely distinct decision, exact-key retry staying ungated, one-call answer recording, `--no-routed-work` refused while dependent work is blocked, externally closed and archived recognition, recordless closure refused both in the backlog and after it rotates into the archive, firstmate-decided attribution, and an ageing decision carrying its age, leading the section, and surviving the bounded cap.

## Scope

No migration and no schema change. Ageing is computed from the `since` metadata every row already carries, and the duplicate gate applies only to new registrations, so an existing queue stays readable and closable.


## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Rebase** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `docs/scripts.md` - merge conflict rebasing onto origin/main

🔧 Fix applied.
✅ Re-checked - no issues remain.

</details>

<details>
<summary>⚠️ **Review** - 2 infos</summary>

- ⚠️ `bin/fm-decision-hold.sh:673` - `complete --folded` cannot satisfy an origin that has an open keyed *status* decision, leaving the new fold path a dead end. The status-open loop at 670-675 requires each open status key to be present in `$keys`, but on the `--folded` branch (633-636) `supplied` is empty, so `keys` is empty (unless an earlier `complete` already recorded keys) and `list_has_key &#34;&#34; &#34;default&#34;` fails. Failing sequence: a crewmate writes `needs-decision: ...` into `state/&lt;origin&gt;.status` (opening key `default` per fm-classify-lib.sh:148-159); a later review pass judges that question already owned by another home decision and runs `fold &lt;origin&gt; --into &lt;other-hold&gt;`; `complete &lt;origin&gt; --folded` then aborts with &#34;open structured decision &lt;origin&gt;/default has no captain-held inventory entry&#34;. Only `hold` appends the `captain-held [key=...]` transfer that closes a status fold (line 690), and `fold` writes no such transfer. The sole way forward is to register a second captain decision under that key — the exact compounding this change exists to prevent — or to attest `--distinct` falsely. Recommend making `fold` record the transfer for the covered status key(s), or teaching the `complete` status loop to accept a recorded `decision_folds` owner, at the shared status-fold boundary rather than in each caller.
- ⚠️ `bin/fm-decision-hold.sh:163` - `waiting_days` can under-report by a full day because `date_epoch` (157-161) parses a bare `%Y-%m-%d` and BSD `date -j -f` inherits the *current* H:M:S — confirmed on this host: `date -u -j -f &#39;%Y-%m-%d&#39; 2026-07-26 +%T` returns the live wall-clock time, not `00:00:00`. `waiting_days` makes two separate `date` invocations (now first, then since), so if a second ticks between them the difference is `N*86400 - 1`, and `/ 86400` floors to `N-1`. Concretely: a decision registered exactly `FM_DECISION_AGING_DAYS` days ago is rendered as `waiting 2 days` instead of 3 and is silently dropped by `open --aging-only`, roughly whenever the two calls straddle a second boundary. Fix by pinning the time explicitly, e.g. `date -u -j -f &#39;%Y-%m-%d %H:%M:%S&#39; &#34;$1 00:00:00&#34; +%s` with the GNU fallback already in place, so both endpoints are midnight-anchored and the subtraction is exact. The jq path in bin/fm-fleet-snapshot.sh:415 is unaffected (it uses `strptime`/`mktime` against a single `SNAPSHOT_EPOCH`).
- ℹ️ `bin/fm-decision-hold.sh:441` - `verify_resolution_identity` compares only the decision digest and routed identities, so `--decided-by` is outside the retry identity. Re-running `resolve` on an already-closed decision with the same text but `--decided-by captain` after it was first closed `--decided-by firstmate` (or vice versa) short-circuits at line 786-791 and prints `resolved: &lt;id&gt;` while the durable `Decided by:` line still records the original attributor. Given the change&#39;s own stated point that attribution must be honest, the recorded `Decided by:` value should be compared alongside the digest and routes and mismatches rejected like the others.
- ℹ️ `bin/fm-decision-hold.sh:202` - `list_open_captain_decisions` filters only on `--state held --kind captain` plus `hold_kind == captain`, while the fleet view&#39;s `captain_actionable` (bin/fm-fleet-snapshot.sh:409-411) additionally requires `state == &#34;queued&#34;` and `(.unresolved_blocker_ids | length) == 0`. A captain decision carrying an unresolved `blocked-by` edge therefore appears in `open`, in `open --aging-only`, and in the `hold` refusal set, but never in Bearings&#39; Captain&#39;s Call — so the refusal can cite a decision the captain cannot see. docs/decision-hold-lifecycle.md:65 states the fleet view and `open --aging-only` &#34;cannot disagree about which decisions are ageing&#34;, which holds for the threshold but not for the decision set. Either add the blocked/queued filter to the listing or narrow the doc claim to the threshold.
- ℹ️ `bin/fm-decision-hold.sh:649` - The fold-verification loop is byte-for-byte duplicated between `command_complete` (646-652) and `command_verify` (708-715), and `command_verify` re-reads `decision_folds` via `meta_value` (708) instead of the `origin_fold_ids` helper added at 259-263. Extracting a single `verify_folds &lt;folds&gt;` helper and using `origin_fold_ids` in both places removes the drift risk between the completion gate and the teardown gate, which the docs assert apply the same check.

🔧 Fix: fix folded status-decision deadlock and ageing boundary
3 issues (1 warning, 2 infos) still open:
- ⚠️ `bin/fm-decision-hold.sh:406` - An unqualified `fold` silently transfers the origin&#39;s *sole* open status decision even when the fold is about a different question, which can lose a captain question. `fold_covered_keys` only demands `--key` when more than one status decision is open (406-407); at exactly one it returns that key unconditionally (408) with nothing tying it to the note being folded. Concrete path: origin X&#39;s crewmate writes `needs-decision: &lt;question A&gt;` into `state/X.status`; a review pass of X finds a different question B, judges B already owned by open hold H, and runs `fold X --into H --note &#34;B&#34;`. Coverage resolves to `default` (question A), line 711 appends `captain-held [key=default]: tracked by H`, and H&#39;s body records only `Also raised by X: B`. Question A is now marked as owned by a decision that never mentions it, `complete X --folded` succeeds, and A is gone — the exact loss class this gate exists to prevent. This is likely rather than theoretical because .agents/skills/decision-hold-lifecycle/SKILL.md:23 and :44 tell the agent to run `fold` with no mention of `--key`, and one open status decision is the common shape. Suggest requiring `--key` whenever any status decision is open (`-ge 1` rather than `-gt 1`) — the caller always knows which question it folded — and naming `--key` in the skill&#39;s fold step. This tightens rather than contradicts the instruction not to let one fold satisfy several.
- ℹ️ `bin/fm-decision-hold.sh:392` - Repeating the same `--key` in one `fold` invocation appends the transfer line twice. `fold X --into H --key a --key a` builds `requested=&#34;a a&#34;`; both loop iterations at 392-400 find `a` in `open_keys` (the `status_transfer_recorded` skip at 395 cannot fire because nothing has been written yet), so `covered` becomes `a\na` and the loop at 710-712 appends `captain-held [key=a]: tracked by H` twice to `state/X.status`. Harmless to the gate but it corrupts the status log the crew-state reader consumes, and the existing idempotency test only covers repeated *invocations*. Dedupe `requested` (or `covered`) with the `sorted_key_union` helper already in the file.
- ℹ️ `bin/fm-decision-hold.sh:213` - Noting the accepted consequence of the requested fleet-view parity: because `list_open_captain_decisions` now excludes a captain decision carrying an unresolved blocker (new `f9` check at 213), that decision no longer appears in the `hold` refusal set, so a later review pass can register a second key for a question that is open-but-blocked without any warning. This is the direct trade the instruction asked for — the listing can no longer cite a decision Bearings does not show — and blocked decisions are not captain-actionable anyway, so no action is implied. Flagged only so the narrowing of the duplicate gate is on the record.

🔧 Fix: require fold --key while a status decision is open
2 warnings still open:
- ⚠️ `bin/fm-decision-hold.sh:410` - There is now no way to fold a finding that covers none of the origin&#39;s open status decisions, so the mixed case dead-ends. `fold` accepts only `--into`, `--note` and `--key` (654-663), and `fold_covered_keys` fails at 409-410 whenever `origin_open_decisions` is non-empty. Concrete path: origin X&#39;s live crewmate status ends `working: ...` / `needs-decision: &lt;question A&gt;` (exactly the round-3 fixture shape, so `origin_open_decisions` does not gate it to empty); A is a genuine captain question needing its own `hold`, and the same review pass separately finds B, already owned by open hold H. `fold X --into H --note B` is refused with &#34;origin X has 1 open structured decision&#34;, and `--key &lt;A&gt;` would append `captain-held [key=A]: tracked by H`, marking A as owned by a decision that never mentions it - the loss the refusal exists to prevent. `hold` does not write the transfer (only `complete` at 779 and `fold` at 711 do), so registering A&#39;s hold first does not clear it either. The only escape is to run `complete X &lt;A&gt;` before the fold and again after, inverting the documented order (skill Operating sequence puts fold at step 3 and complete at step 4). Suggest an explicit no-coverage attestation on `fold` - e.g. `--covers-no-status-decision` - so the strict `--key` requirement is kept while a fold that genuinely covers nothing can still say so.
- ⚠️ `.agents/skills/decision-hold-lifecycle/SKILL.md:23` - The skill now tells the agent to pass `--key` on every fold, but `--key` is rejected whenever the origin has no open status decision, so following the documented flow verbatim fails in the common shapes. `fold_covered_keys` (391-406) fails with &#34;origin X has no open structured decision under key K&#34; when the key is not in `origin_open_decisions`&#39; output, and that output is empty both when the origin has no status file at all (the shape in tests/fm-decision-hold-lifecycle.test.sh:607, which folds unqualified) and - more importantly - when the status ends in a terminal verb: `origin_open_decisions` (bin/fm-decision-hold.sh:357-369) returns empty for a non-secondmate origin whose last status line is `done:` or `failed:`, which is precisely the completed-investigation shape this skill is invoked on (see the `needs-decision` ... `done:` fixture at tests/fm-decision-hold-lifecycle.test.sh:147-151). SKILL.md:23 (&#34;naming the origin&#39;s open decision key with `--key`&#34;) and :44 (&#34;naming the covered decision key with `--key`&#34;) should condition the instruction on the origin actually having an open status decision, and tell the agent how to see that set, so the documented flow matches the script&#39;s contract.

🔧 Fix: decouple folding from status accounting at sign-off
2 infos still open:
- ℹ️ `bin/fm-decision-hold.sh:384` - `status_transfer_recorded` now matches `captain-held [key=&lt;k&gt;]: ` as a substring anywhere in a line rather than at line start, so an ordinary status note that happens to contain that text would let `--folded-key &lt;k&gt;` be accepted for a key that was never open. Path: a crewmate writes `working: captain-held [key=ghost]: copied from the other task` into `state/X.status`; `_fm_decision_key` reads the prefix before the first colon so the verb stays `working` and `ghost` never enters the open set, but the liveness check at 758-766 falls through to `status_transfer_recorded`, which matches, and the third tolerance accepts `--folded-key ghost` — recording a folded-key attestation for a question that never existed. Narrow because it needs that literal in crew prose, but the anchor is free: match `^captain-held \[key=&lt;k&gt;\]: ` (a `grep -q` with the brackets escaped, or an awk index test) so only a real transfer event satisfies it.
- ℹ️ `bin/fm-decision-hold.sh:795` - For a key accounted for as folded, the transfer event is written as `tracked by $folds`, and `folds` is the comma-separated union of every fold the origin recorded — so with two or more folds the durable status line reads `captain-held [key=K]: tracked by H1,H2` and cannot say which decision actually carries K. Exact in the single-fold case (what the new test asserts), and harmless mechanically: nothing parses the text after `tracked by` — `status_open_decisions` and `status_is_paused_or_captain_held` key off the verb only — and docs/decision-hold-lifecycle.md:45 documents it as &#34;the recorded folds&#34;. Noted only because the status log is a durable audit record; if per-key precision is ever wanted, `--folded-key` would need to carry the owning hold id.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>Replicated the `macos-stock-bash` CI lane verbatim under `/bin/bash` 3.2.57 (parse sweep over `bin/fm-lint.sh --list-files`, then both pinned suites) — lane exit 0</code>
- <code>`/bin/bash tests/fm-fleet-snapshot-view.test.sh` → 15 `ok -` lines, matches the lane&#39;s pin of 15</code>
- <code>`/bin/bash tests/fm-bearings-snapshot.test.sh` → 42 `ok -` lines, matches the new pin of 42; verified the base pin of 41 would emit `::error::expected 41 Bearings tests, got 42`</code>
- <code>`bash tests/fm-decision-hold-lifecycle.test.sh` → 17 cases pass, exit 0 (targeted product suite for the four decision-queue defects)</code>
- <code>Manual CLI render of the ageing decision: `FM_HOME=&lt;fixture&gt; FM_BEARINGS_NOW=2026-08-02T12:00:00Z /bin/bash bin/fm-bearings-snapshot.sh` showing `waiting_days,aging` and the ageing decision leading `decisions_open`</code>
- <code>Manual end-to-end `bin/fm-decision-hold.sh` transcript: `hold` (register), duplicate-key `hold` refused with exit 3, `fold --into` happy path plus `decision_folds=` recorded in origin metadata, `open` / `open --aging-only` at and below the ageing threshold, single-call `resolve`, then `open` showing a cleared queue</code>
- <code>Privacy scan of `git diff cf95112..f705263` and of the commit messages for concrete deployment identifiers — no hits</code>
- <code>`git status --porcelain` — worktree clean, no transient artifacts left behind</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>