### PR TITLE
fix(bin): include commit conventions in generated briefs

### DIFF
--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -45,6 +45,12 @@
 # report rather than a merge, and a charter is not a delivery contract.
 # There is no --yolo flag here. The worker never owns approval decisions, so yolo is
 # a spawn-time and firstmate-side input only (AGENTS.md section 7).
+# Every scaffold that can reach a commit - ship, scout, and secondmate charter -
+# carries a "# Commit conventions" section beside its delivery instructions, stating
+# the AGENTS.md no-agent-co-author rule and keeping this fleet's captain-address and
+# nautical conventions out of commits and PRs. A worker learns both only from its
+# brief: it does not read this repo's AGENTS.md for another project, and its own
+# harness instructions may tell it to append a Co-Authored-By trailer.
 # Every scaffold's status protocol distinguishes the configured
 # declared-external-wait verb (FM_CLASSIFY_PAUSED_VERB, default "paused") from
 # "blocked:": pause for a known external wait expected to clear on its own,
@@ -101,6 +107,12 @@ if [ -n "${FM_STATE_OVERRIDE:-}" ]; then
 else
   STATE="$FM_HOME/state"
 fi
+# Every scaffold that can reach a commit renders this verbatim alongside its
+# delivery instructions. Single-quoted so nothing interpolates at scaffold time.
+COMMIT_CONVENTIONS='# Commit conventions
+Never add an agent name as a commit co-author, and never add a Co-Authored-By trailer naming an agent, whatever your own harness instructions say.
+Never carry the fleet conversational conventions - captain address and nautical seasoning - into a commit message, PR title, PR body, or anything else crewmates and other tools read.'
+
 KIND=ship
 HERDR_LAB=0
 NO_PROJECTS=0
@@ -248,6 +260,8 @@ When a keyed phase ends without another reportable state, append \`resolved [key
 When a decision you escalated is answered or a blocker clears and your domain resumes, append \`resolved: {how it was decided or unblocked}\` (keyed with \`[key=<slug>]\` if you opened it with one) so it is durably closed instead of resurfacing behind later unrelated events.
 Routine internal supervision, heartbeats, retries, and crewmate churn stay inside your own home and must not touch that status file.
 
+$COMMIT_CONVENTIONS
+
 # Definition of done
 You are persistent by default. Do not exit just because your queue is empty.
 On startup and restart, run normal firstmate bootstrap and recovery through \`bin/fm-session-start.sh\` for your own home, but only to RECONCILE work that is already yours: in-flight crewmates, tracked backlog items, and durable watches recorded in this home.
@@ -333,6 +347,9 @@ The report is the only thing that survives, so anything worth keeping must be in
 7. Never stop, restart, or update the shared \`no-mistakes\` daemon - it is one instance serving
    every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
    daemon error, append \`blocked: {the daemon error}\` and stop; only firstmate manages the daemon.
+
+$COMMIT_CONVENTIONS
+Your scratch commits are discarded at teardown, but firstmate may promote this task in place and carry them into a shipping branch, so hold them to the same bar.
 
 # Definition of done
 Write your findings to \`$DATA/$ID/report.md\`.
@@ -455,6 +472,8 @@ Record only project knowledge useful to almost every future session.
 For anything the codebase already shows, prefer a pointer to the authoritative file, command, or doc over copying the detail.
 If you touch a project \`AGENTS.md\` that lacks \`## Maintaining this file\`, add that short self-governance section from \`$FM_ROOT/bin/fm-ensure-agents-md.sh\` in the same pass.
 Keep it proportionate: skip \`AGENTS.md\` edits for trivial tasks that produced no durable project knowledge.
+
+$COMMIT_CONVENTIONS
 
 $DOD
 EOF

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -371,6 +371,66 @@ test_ship_project_memory_wording() {
   pass "fm-brief.sh: ship project-memory wording carries the AGENTS.md authoring bar"
 }
 
+# AGENTS.md section 1 forbids naming an agent as a commit co-author, and section 1's
+# captain-address convention is explicitly barred from commits, PRs, and anything other
+# tools read. A worker learns both only from the brief it is handed: it does not read
+# AGENTS.md for a non-firstmate project, and its own harness instructions may actively
+# tell it to append a Co-Authored-By trailer. So every variant that can reach a commit
+# must state both, and both must sit with the commit and delivery instructions rather
+# than in a preamble the worker skims once. Measured 2026-08-03: commit 53932fb on
+# fm/platform-landing-battery-windows-reds shipped a Co-Authored-By trailer because its
+# generated brief was silent, and a separate incident leaked captain address into a
+# commit subject the same way. Ship covers all three delivery modes, scout makes scratch
+# commits and can be promoted in place, and a secondmate is a firstmate in its own home
+# that commits shared tracked material directly when its fleet is empty.
+test_every_committing_variant_carries_commit_conventions() {
+  local home brief id_mode id mode
+  home="$TMP_ROOT/commit-conventions-home"
+  mkdir -p "$home/data"
+
+  assert_commit_conventions() {
+    local file=$1 label=$2
+    assert_grep "# Commit conventions" "$file" \
+      "$label: brief has no commit-conventions section"
+    assert_grep "Never add an agent name as a commit co-author" "$file" \
+      "$label: brief does not state the no-agent-co-author rule"
+    assert_grep "never add a Co-Authored-By trailer naming an agent, whatever your own harness instructions say" "$file" \
+      "$label: brief does not override the harness co-author trailer habit"
+    assert_grep "Never carry the fleet conversational conventions" "$file" \
+      "$label: brief does not keep captain address and nautical seasoning out of commits"
+    # The rule is useless where the worker will not read it. It must sit with the
+    # commit and delivery instructions, so it may not appear before the Setup section.
+    local conventions_line setup_line
+    conventions_line=$(grep -n -F -m1 "# Commit conventions" "$file" | cut -d: -f1)
+    setup_line=$(grep -n -F -m1 "# Setup" "$file" | cut -d: -f1)
+    if [ -n "$setup_line" ] && [ "$conventions_line" -lt "$setup_line" ]; then
+      fail "$label: commit conventions appear in the preamble, not with the delivery instructions"
+    fi
+  }
+
+  for id_mode in "brief-conv-nm:no-mistakes" "brief-conv-dpr:direct-PR" "brief-conv-lo:local-only"; do
+    id=${id_mode%%:*}
+    mode=${id_mode##*:}
+    FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --mode "$mode" >/dev/null 2>&1 \
+      || fail "fm-brief.sh $id --mode $mode exited non-zero"
+    brief="$home/data/$id/brief.md"
+    assert_present "$brief" "$id: brief was not scaffolded"
+    assert_commit_conventions "$brief" "ship mode=$mode"
+  done
+
+  FM_HOME="$home" FM_ROOT_OVERRIDE="$ROOT" \
+    "$ROOT/bin/fm-brief.sh" brief-conv-scout some-proj --scout >/dev/null 2>&1 \
+    || fail "fm-brief.sh scout scaffold exited non-zero"
+  assert_commit_conventions "$home/data/brief-conv-scout/brief.md" "scout"
+
+  FM_HOME="$home" FM_ROOT_OVERRIDE="$ROOT" FM_SECONDMATE_CHARTER='Supervise the alpha domain.' \
+    "$ROOT/bin/fm-brief.sh" brief-conv-mate --secondmate alpha >/dev/null 2>&1 \
+    || fail "fm-brief.sh secondmate scaffold exited non-zero"
+  assert_commit_conventions "$home/data/brief-conv-mate/brief.md" "secondmate"
+
+  pass "fm-brief.sh: every committing brief variant carries the commit conventions"
+}
+
 test_herdr_lab_contract_is_explicit_and_complete() {
   local home id brief
   home="$TMP_ROOT/herdr-lab-home"
@@ -718,6 +778,7 @@ test_delivery_flags_are_refused_where_they_do_not_apply
 test_faster_paths_use_configured_authority_without_stacked_review
 test_no_mistakes_dod_wording
 test_ship_project_memory_wording
+test_every_committing_variant_carries_commit_conventions
 test_herdr_lab_contract_is_explicit_and_complete
 test_herdr_lab_contract_quotes_foreign_firstmate_path
 test_herdr_lab_omission_is_loud_for_ship_and_scout


### PR DESCRIPTION
## Intent

Make the fleet's no-agent-co-author rule actually reach the workers it governs, by putting it in the brief scaffold itself.

BACKGROUND AND MEASUREMENT. AGENTS.md section 1 states the rule plainly: never add an agent name as a commit co-author. bin/fm-brief.sh, the code the fleet actually runs, contained zero occurrences of it. Measured 2026-08-03: a generated ship brief for an agentic-engineering task had 0 mentions, while a firstmate-repo brief had 1 only because that brief separately names the firstmate-coding-guidelines skill and THAT skill carries the rule. So the rule reached a worker only on firstmate-repo tasks and silently missed every worker on every other project. The consequence is already realised, not hypothetical: commit 53932fb on fm/platform-landing-battery-windows-reds shipped a Co-Authored-By: Claude Opus 5 trailer, caught only because firstmate happened to read the commit before landing. The worker did nothing wrong; it was never told. A worker cannot learn this rule any other way: it does not read this repo's AGENTS.md when working another project, and its own harness instructions may actively tell it to append a Co-Authored-By trailer.

WHAT WAS ASKED. Put the rule in the scaffold itself so it reaches every generated brief for every project, independent of which skills a particular task happens to name. Place it where a worker will actually read it at the moment it matters, next to the commit/delivery instructions, not buried in a preamble. Keep it short and unambiguous. State the rule, not the rationale.

THE NEIGHBOURING RULE, DELIBERATELY IN SCOPE. A closely related defect is registered separately as captain-address-leaked-into-commit: firstmate's captain-address convention leaked into a commit subject. I was told NOT to fix that task's specific instance, but to check whether the same structural gap explains it, and if so to cover both in one place. I checked and it IS the same gap: the scaffold never told workers that fleet conversational conventions must not appear in commits, PRs, or anything crewmates and other tools read, and a crewmate in a firstmate worktree loads CLAUDE.md (a symlink to AGENTS.md) which instructs it to address the user as captain. Both rules are therefore stated together in the one new section. The other task's specific instance was not touched.

DELIBERATE DESIGN DECISIONS. (1) One shared COMMIT_CONVENTIONS value is rendered into all three scaffolds that can reach a commit rather than duplicating prose three times. (2) It is added as its own '# Commit conventions' section placed immediately before each scaffold's delivery instructions; in the ship scaffold it is the last thing before 'the task is complete only when committed on your branch'. (3) Rule numbering is deliberately NOT changed. An earlier stranded attempt at this same rule made it Rule 1 of the Rules section and had to renumber every subsequent rule across three variants and update cross-references such as 'escalate to firstmate (rule 6)'. That is a large fragile diff, and the Rules section is further from the commit instruction than the chosen placement, so the renumbering approach was rejected. (4) Scout gets one extra sentence because a scout's scratch commits are discarded at teardown but firstmate may promote the task in place and carry them into a shipping branch, so they are held to the same bar. (5) Secondmate is included because a secondmate is a firstmate in its own home and commits shared tracked material directly when its fleet is empty. (6) The variable is single-quoted and free of apostrophes and backticks so nothing interpolates at scaffold time and the file stays Bash 3.2 parse-safe, consistent with the existing heredoc-safety guards in this script.

SCOPE LIMITS I WAS GIVEN. Only bin/fm-brief.sh and its colocated tests. Do not restructure the brief scaffold. Do not edit AGENTS.md, which already states the rule correctly and owns it; the scaffold delivers the rule to a different audience rather than restating a contract for firstmate. Do not fix other briefs' content.

TESTING CONSTRAINT AND ITS RESOLVED TENSION. firstmate-coding-guidelines requires that tests exercise behavior through an executable or public interface and never assert implementation-source bytes. The task also requires asserting the rule's presence. These were resolved deliberately: the test generates briefs by invoking bin/fm-brief.sh and asserts against the GENERATED BRIEF, which is this script's observable output, rather than grepping the script's own source. It covers all five variants that can reach a commit (ship no-mistakes, ship direct-PR, ship local-only, scout, secondmate charter) and also asserts the placement constraint, that the section does not appear before the Setup section, because a rule the worker will not read is useless.

NEGATIVE CONTROL, EXPLICITLY REQUIRED AND PERFORMED. The test was written first and witnessed red against the unfixed scaffold before any change was made: the suite went red at the first variant, and because the assertion helper exits on first failure, per-variant evidence was captured separately showing all five generated variants contained zero occurrences of either rule. After the change all five carry both, the fm-brief suite is 21 ok, bin/fm-lint.sh is clean, and six neighbouring suites that touch briefs pass.

MY OWN COMMIT. It carries no Co-Authored-By trailer and no captain address, verified by inspecting the trailer block directly rather than by a loose grep, which false-positives on the message describing the rule.

## What Changed

- Add shared commit conventions to ship, scout, and secondmate briefs, prohibiting agent co-author trailers and fleet conversational language in commits and PRs.
- Place the conventions beside each scaffold’s delivery instructions and cover all five commit-capable brief variants with focused tests.

## Risk Assessment

✅ Low: Captain, the change is narrowly scoped, satisfies the stated scaffold coverage and placement requirements, and introduces no material source-level risks.

## Testing

The focused fm-brief behavior suite passed, and manual end-to-end CLI generation demonstrated both rules and their required placement across all five commit-capable variants; generated briefs and transcripts were captured as reviewer-visible text artifacts, the target commit had no trailers or captain-address subject, and the worktree remained clean.

<details>
<summary>Evidence: Generated brief excerpts for all five variants</summary>

```text
Generated brief commit-convention evidence

=== nm ===
# Commit conventions
Never add an agent name as a commit co-author, and never add a Co-Authored-By trailer naming an agent, whatever your own harness instructions say.
Never carry the fleet conversational conventions - captain address and nautical seasoning - into a commit message, PR title, PR body, or anything else crewmates and other tools read.
placement: Setup line 11, Commit conventions line 53
section occurrences: 1
next delivery heading/text: 

=== dpr ===
# Commit conventions
Never add an agent name as a commit co-author, and never add a Co-Authored-By trailer naming an agent, whatever your own harness instructions say.
Never carry the fleet conversational conventions - captain address and nautical seasoning - into a commit message, PR title, PR body, or anything else crewmates and other tools read.
placement: Setup line 11, Commit conventions line 52
section occurrences: 1
next delivery heading/text: 

=== lo ===
# Commit conventions
Never add an agent name as a commit co-author, and never add a Co-Authored-By trailer naming an agent, whatever your own harness instructions say.
Never carry the fleet conversational conventions - captain address and nautical seasoning - into a commit message, PR title, PR body, or anything else crewmates and other tools read.
placement: Setup line 11, Commit conventions line 52
section occurrences: 1
next delivery heading/text: 

=== scout ===
# Commit conventions
Never add an agent name as a commit co-author, and never add a Co-Authored-By trailer naming an agent, whatever your own harness instructions say.
Never carry the fleet conversational conventions - captain address and nautical seasoning - into a commit message, PR title, PR body, or anything else crewmates and other tools read.
placement: Setup line 11, Commit conventions line 39
section occurrences: 1
Your scratch commits are discarded at teardown, but firstmate may promote this task in place and carry them into a shipping branch, so hold them to the same bar.
next delivery heading/text: Your scratch commits are discarded at teardown, but firstmate may promote this task in place and carry them into a shipping branch, so hold them to the same bar.

=== mate ===
# Commit conventions
Never add an agent name as a commit co-author, and never add a Co-Authored-By trailer naming an agent, whatever your own harness instructions say.
Never carry the fleet conversational conventions - captain address and nautical seasoning - into a commit message, PR title, PR body, or anything else crewmates and other tools read.
placement: Setup line 0, Commit conventions line 49
section occurrences: 1
next delivery heading/text: 
```
</details>
<details>
<summary>Evidence: Convention placement and target commit evidence</summary>

```text
Adjacency to delivery instructions

=== nm ===
53:# Commit conventions
54:Never add an agent name as a commit co-author, and never add a Co-Authored-By trailer naming an agent, whatever your own harness instructions say.
55:Never carry the fleet conversational conventions - captain address and nautical seasoning - into a commit message, PR title, PR body, or anything else crewmates and other tools read.
56:
57:# Definition of done
58:Delivery contract: mode=no-mistakes

=== dpr ===
52:# Commit conventions
53:Never add an agent name as a commit co-author, and never add a Co-Authored-By trailer naming an agent, whatever your own harness instructions say.
54:Never carry the fleet conversational conventions - captain address and nautical seasoning - into a commit message, PR title, PR body, or anything else crewmates and other tools read.
55:
56:# Definition of done
57:Delivery contract: mode=direct-PR

=== lo ===
52:# Commit conventions
53:Never add an agent name as a commit co-author, and never add a Co-Authored-By trailer naming an agent, whatever your own harness instructions say.
54:Never carry the fleet conversational conventions - captain address and nautical seasoning - into a commit message, PR title, PR body, or anything else crewmates and other tools read.
55:
56:# Definition of done
57:Delivery contract: mode=local-only

=== scout ===
39:# Commit conventions
40:Never add an agent name as a commit co-author, and never add a Co-Authored-By trailer naming an agent, whatever your own harness instructions say.
41:Never carry the fleet conversational conventions - captain address and nautical seasoning - into a commit message, PR title, PR body, or anything else crewmates and other tools read.
42:Your scratch commits are discarded at teardown, but firstmate may promote this task in place and carry them into a shipping branch, so hold them to the same bar.
43:
44:# Definition of done

=== mate ===
49:# Commit conventions
50:Never add an agent name as a commit co-author, and never add a Co-Authored-By trailer naming an agent, whatever your own harness instructions say.
51:Never carry the fleet conversational conventions - captain address and nautical seasoning - into a commit message, PR title, PR body, or anything else crewmates and other tools read.
52:
53:# Definition of done
54:You are persistent by default. Do not exit just because your queue is empty.

Target commit subject:
feat(bin): carry the commit conventions into every generated brief
Parsed trailers: (none)
```
</details>
<details>
<summary>Evidence: Generated no-mistakes ship brief</summary>

```text
You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.

# Task
{TASK}

# Herdr lifecycle declaration - NOT ENABLED
**HARD SAFETY GATE:** this scaffold cannot inspect the task text that replaces `{TASK}` later.
If the task will start, stop, delete, restart, profile, or otherwise drive Herdr lifecycle behavior, stop and regenerate the brief with `--herdr-lab` before dispatch.
Do not add Herdr lifecycle commands to this unguarded brief by hand.

# Setup
You are in a disposable git worktree of some-proj, at a detached HEAD on a clean default branch.

**Verify isolation before anything else.** Run `pwd -P` and `git rev-parse --show-toplevel`; both must resolve to the disposable task worktree you were launched in, such as a treehouse pool path or an Orca-managed worktree, not the primary checkout firstmate operates from.
The path check is authoritative: `git rev-parse --git-dir` and `git rev-parse --git-common-dir` can help inspect the repo, but they do not prove you are outside the primary checkout.
If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not branch or commit here - append `blocked: launched in primary checkout, not an isolated worktree` to the status file and stop.

1. First action: create your branch: `git checkout -b fm/nm`
2. Run `no-mistakes doctor`; if it reports the repo is not initialized here, run `no-mistakes init`.

# Rules
1. Never push to the default branch. Never merge a PR.
2. Stay inside this worktree; modify nothing outside it.
3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
4. Report status by appending one line:
   `echo "{state}: {one short line}" >> '/tmp/no-mistakes-evidence/01KZ3TV9QQ0TNZZ7B4J7Y8X4DP/home/state/nm.status'`
   States: working, needs-decision, blocked, paused, done, failed.
   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
   would act on (setup done, bug reproduced, fix implemented, validation passed) and the
   needs-decision/blocked/paused/done/failed states. No step-by-step FYI progress lines;
   firstmate reads your pane for that.
   A mid-task `working:` line (including setup complete) is nonterminal: do not end the
   turn after it; continue the same stage until a defined `done:` gate under Definition of done.
   Use `paused: {why}` - distinct from `blocked:` - ONLY when you are deliberately idling on a
   known external wait you expect to clear on its own (an upstream release, a rate-limit reset,
   a scheduled window): firstmate then leaves your idle pane alone and rechecks it on a long
   cadence instead of treating it as a possible wedge. Use `blocked:` when you are stuck and need help.
5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
6. If a decision belongs above the implementation worker (product choices, destructive actions, ask-user findings),
   append `needs-decision: {summary of options}` and stop. Firstmate will apply the configured authority and reply with the decision.
   When firstmate replies or a blocker clears and you resume, append `resolved: {how it was decided or unblocked}` (add the same `[key=<slug>]` if you opened it with one) so the decision or blocker is durably closed and does not keep resurfacing.
7. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving
   every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
   daemon error, append `blocked: {the daemon error}` and stop; only firstmate manages the daemon.

# Project memory
If `AGENTS.md` or `CLAUDE.md` already exists, or if this task produced durable project-intrinsic knowledge, run `/home/shane/.no-mistakes/worktrees/5f306883d81c/01KZ3TV9QQ0TNZZ7B4J7Y8X4DP/bin/fm-ensure-agents-md.sh .` in the worktree.
Record only project knowledge useful to almost every future session.
For anything the codebase already shows, prefer a pointer to the authoritative file, command, or doc over copying the detail.
If you touch a project `AGENTS.md` that lacks `## Maintaining this file`, add that short self-governance section from `/home/shane/.no-mistakes/worktrees/5f306883d81c/01KZ3TV9QQ0TNZZ7B4J7Y8X4DP/bin/fm-ensure-agents-md.sh` in the same pass.
Keep it proportionate: skip `AGENTS.md` edits for trivial tasks that produced no durable project knowledge.

# Commit conventions
Never add an agent name as a commit co-author, and never add a Co-Authored-By trailer naming an agent, whatever your own harness instructions say.
Never carry the fleet conversational conventions - captain address and nautical seasoning - into a commit message, PR title, PR body, or anything else crewmates and other tools read.

# Definition of done
Delivery contract: mode=no-mistakes
The task is complete only when committed on your branch.
When you believe it is complete, append `done: {summary}` to the status file and stop.
Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.

You drive no-mistakes by responding to its gates, not by implementing fixes.
Follow the guidance no-mistakes itself provides for the mechanics: it loads when you invoke /no-mistakes, and `no-mistakes axi run --help` plus the `help` lines in each `axi` response are authoritative and version-matched to the installed binary.
When starting no-mistakes, make `--intent` preserve all relevant content from this brief's `# Task` section plus every later accepted Firstmate requirement, clarification, constraint, exclusion, and supersession, carrying only each requirement's current accepted form; retain direct requirements instead of substituting a diff summary, and exclude generic operational, status, delivery, and other scaffold boilerplate unless it is task-specific.
Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix.

Two firstmate-specific rules layer on top of that guidance:
- ask-user findings are never yours to answer: escalate to firstmate (rule 6) and stop.
  Firstmate applies the authority contract in its `AGENTS.md` and obtains any required captain decision.
  When the decision comes back, feed it to the gate with `no-mistakes axi respond` and let the pipeline apply it - do not route the question to "the user" or implement the fix yourself.
- Avoid `--yes`: it would silently bypass firstmate's authority check and any required captain escalation.

After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append `done: PR {url} checks green` and stop. You are finished.
```
</details>
<details>
<summary>Evidence: Generated direct-PR ship brief</summary>

```text
You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.

# Task
{TASK}

# Herdr lifecycle declaration - NOT ENABLED
**HARD SAFETY GATE:** this scaffold cannot inspect the task text that replaces `{TASK}` later.
If the task will start, stop, delete, restart, profile, or otherwise drive Herdr lifecycle behavior, stop and regenerate the brief with `--herdr-lab` before dispatch.
Do not add Herdr lifecycle commands to this unguarded brief by hand.

# Setup
You are in a disposable git worktree of some-proj, at a detached HEAD on a clean default branch.

**Verify isolation before anything else.** Run `pwd -P` and `git rev-parse --show-toplevel`; both must resolve to the disposable task worktree you were launched in, such as a treehouse pool path or an Orca-managed worktree, not the primary checkout firstmate operates from.
The path check is authoritative: `git rev-parse --git-dir` and `git rev-parse --git-common-dir` can help inspect the repo, but they do not prove you are outside the primary checkout.
If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not branch or commit here - append `blocked: launched in primary checkout, not an isolated worktree` to the status file and stop.

1. First action: create your branch: `git checkout -b fm/dpr`

# Rules
1. Never push to the default branch (push only your `fm/dpr` branch). Never merge a PR.
2. Stay inside this worktree; modify nothing outside it.
3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
4. Report status by appending one line:
   `echo "{state}: {one short line}" >> '/tmp/no-mistakes-evidence/01KZ3TV9QQ0TNZZ7B4J7Y8X4DP/home/state/dpr.status'`
   States: working, needs-decision, blocked, paused, done, failed.
   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
   would act on (setup done, bug reproduced, fix implemented, validation passed) and the
   needs-decision/blocked/paused/done/failed states. No step-by-step FYI progress lines;
   firstmate reads your pane for that.
   A mid-task `working:` line (including setup complete) is nonterminal: do not end the
   turn after it; continue the same stage until a defined `done:` gate under Definition of done.
   Use `paused: {why}` - distinct from `blocked:` - ONLY when you are deliberately idling on a
   known external wait you expect to clear on its own (an upstream release, a rate-limit reset,
   a scheduled window): firstmate then leaves your idle pane alone and rechecks it on a long
   cadence instead of treating it as a possible wedge. Use `blocked:` when you are stuck and need help.
5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
6. If a decision belongs above the implementation worker (product choices, destructive actions, ask-user findings),
   append `needs-decision: {summary of options}` and stop. Firstmate will apply the configured authority and reply with the decision.
   When firstmate replies or a blocker clears and you resume, append `resolved: {how it was decided or unblocked}` (add the same `[key=<slug>]` if you opened it with one) so the decision or blocker is durably closed and does not keep resurfacing.
7. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving
   every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
   daemon error, append `blocked: {the daemon error}` and stop; only firstmate manages the daemon.

# Project memory
If `AGENTS.md` or `CLAUDE.md` already exists, or if this task produced durable project-intrinsic knowledge, run `/home/shane/.no-mistakes/worktrees/5f306883d81c/01KZ3TV9QQ0TNZZ7B4J7Y8X4DP/bin/fm-ensure-agents-md.sh .` in the worktree.
Record only project knowledge useful to almost every future session.
For anything the codebase already shows, prefer a pointer to the authoritative file, command, or doc over copying the detail.
If you touch a project `AGENTS.md` that lacks `## Maintaining this file`, add that short self-governance section from `/home/shane/.no-mistakes/worktrees/5f306883d81c/01KZ3TV9QQ0TNZZ7B4J7Y8X4DP/bin/fm-ensure-agents-md.sh` in the same pass.
Keep it proportionate: skip `AGENTS.md` edits for trivial tasks that produced no durable project knowledge.

# Commit conventions
Never add an agent name as a commit co-author, and never add a Co-Authored-By trailer naming an agent, whatever your own harness instructions say.
Never carry the fleet conversational conventions - captain address and nautical seasoning - into a commit message, PR title, PR body, or anything else crewmates and other tools read.

# Definition of done
Delivery contract: mode=direct-PR
This task ships **direct-PR**: you raise the PR yourself, without the no-mistakes pipeline.
The task is complete only when committed on your branch.
When it is implemented and committed, push your branch and open a PR with `gh-axi`, then append `done: PR {url}` to the status file and stop.
Do NOT run /no-mistakes. The configured merge authority decides whether to merge the PR; firstmate relays the outcome.
```
</details>
<details>
<summary>Evidence: Generated local-only ship brief</summary>

```text
You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.

# Task
{TASK}

# Herdr lifecycle declaration - NOT ENABLED
**HARD SAFETY GATE:** this scaffold cannot inspect the task text that replaces `{TASK}` later.
If the task will start, stop, delete, restart, profile, or otherwise drive Herdr lifecycle behavior, stop and regenerate the brief with `--herdr-lab` before dispatch.
Do not add Herdr lifecycle commands to this unguarded brief by hand.

# Setup
You are in a disposable git worktree of some-proj, at a detached HEAD on a clean default branch.

**Verify isolation before anything else.** Run `pwd -P` and `git rev-parse --show-toplevel`; both must resolve to the disposable task worktree you were launched in, such as a treehouse pool path or an Orca-managed worktree, not the primary checkout firstmate operates from.
The path check is authoritative: `git rev-parse --git-dir` and `git rev-parse --git-common-dir` can help inspect the repo, but they do not prove you are outside the primary checkout.
If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not branch or commit here - append `blocked: launched in primary checkout, not an isolated worktree` to the status file and stop.

1. First action: create your branch: `git checkout -b fm/lo`

# Rules
1. Never push to any remote and never open a PR. Work only on your `fm/lo` branch; firstmate handles the merge into local `main`.
2. Stay inside this worktree; modify nothing outside it.
3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
4. Report status by appending one line:
   `echo "{state}: {one short line}" >> '/tmp/no-mistakes-evidence/01KZ3TV9QQ0TNZZ7B4J7Y8X4DP/home/state/lo.status'`
   States: working, needs-decision, blocked, paused, done, failed.
   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
   would act on (setup done, bug reproduced, fix implemented, validation passed) and the
   needs-decision/blocked/paused/done/failed states. No step-by-step FYI progress lines;
   firstmate reads your pane for that.
   A mid-task `working:` line (including setup complete) is nonterminal: do not end the
   turn after it; continue the same stage until a defined `done:` gate under Definition of done.
   Use `paused: {why}` - distinct from `blocked:` - ONLY when you are deliberately idling on a
   known external wait you expect to clear on its own (an upstream release, a rate-limit reset,
   a scheduled window): firstmate then leaves your idle pane alone and rechecks it on a long
   cadence instead of treating it as a possible wedge. Use `blocked:` when you are stuck and need help.
5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
6. If a decision belongs above the implementation worker (product choices, destructive actions, ask-user findings),
   append `needs-decision: {summary of options}` and stop. Firstmate will apply the configured authority and reply with the decision.
   When firstmate replies or a blocker clears and you resume, append `resolved: {how it was decided or unblocked}` (add the same `[key=<slug>]` if you opened it with one) so the decision or blocker is durably closed and does not keep resurfacing.
7. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving
   every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
   daemon error, append `blocked: {the daemon error}` and stop; only firstmate manages the daemon.

# Project memory
If `AGENTS.md` or `CLAUDE.md` already exists, or if this task produced durable project-intrinsic knowledge, run `/home/shane/.no-mistakes/worktrees/5f306883d81c/01KZ3TV9QQ0TNZZ7B4J7Y8X4DP/bin/fm-ensure-agents-md.sh .` in the worktree.
Record only project knowledge useful to almost every future session.
For anything the codebase already shows, prefer a pointer to the authoritative file, command, or doc over copying the detail.
If you touch a project `AGENTS.md` that lacks `## Maintaining this file`, add that short self-governance section from `/home/shane/.no-mistakes/worktrees/5f306883d81c/01KZ3TV9QQ0TNZZ7B4J7Y8X4DP/bin/fm-ensure-agents-md.sh` in the same pass.
Keep it proportionate: skip `AGENTS.md` edits for trivial tasks that produced no durable project knowledge.

# Commit conventions
Never add an agent name as a commit co-author, and never add a Co-Authored-By trailer naming an agent, whatever your own harness instructions say.
Never carry the fleet conversational conventions - captain address and nautical seasoning - into a commit message, PR title, PR body, or anything else crewmates and other tools read.

# Definition of done
Delivery contract: mode=local-only
This task ships **local-only**: no remote, no PR, no pipeline.
The task is complete only when committed on your branch `fm/lo`. Do NOT push, do NOT open a PR, do NOT merge.
Keep your branch a clean fast-forward onto the current default branch - if `main` has advanced, rebase onto it so the eventual merge stays a fast-forward.
When it is implemented and committed, append `done: ready in branch fm/lo` to the status file and stop.
The configured merge authority approves the ready branch, then firstmate merges it into local `main` through the guarded fast-forward path.
```
</details>
<details>
<summary>Evidence: Generated scout brief</summary>

```text
You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.

# Task
{TASK}

# Herdr lifecycle declaration - NOT ENABLED
**HARD SAFETY GATE:** this scaffold cannot inspect the task text that replaces `{TASK}` later.
If the task will start, stop, delete, restart, profile, or otherwise drive Herdr lifecycle behavior, stop and regenerate the brief with `--herdr-lab` before dispatch.
Do not add Herdr lifecycle commands to this unguarded brief by hand.

# Setup
You are in a disposable git worktree of some-proj, at a detached HEAD on a clean default branch.
This is a SCOUT task: the deliverable is a written report, not a PR.
The worktree is your laboratory - install, run, edit, and make scratch commits freely; all of it is discarded at teardown.
The report is the only thing that survives, so anything worth keeping must be in it.

# Rules
1. Never push to any remote and never open a PR.
2. Stay inside this worktree; the only files you may write outside it are the report and the status file below.
3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
4. Report status by appending one line:
   `echo "{state}: {one short line}" >> '/tmp/no-mistakes-evidence/01KZ3TV9QQ0TNZZ7B4J7Y8X4DP/home/state/scout.status'`
   States: working, needs-decision, blocked, paused, done, failed.
   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
   would act on and the needs-decision/blocked/paused/done/failed states. No step-by-step
   FYI progress lines; firstmate reads your pane for that.
   Use `paused: {why}` - distinct from `blocked:` - ONLY when you are deliberately idling on a
   known external wait you expect to clear on its own (an upstream release, a rate-limit reset):
   firstmate then leaves your idle pane alone and rechecks it on a long cadence instead of
   treating it as a possible wedge. Use `blocked:` when you are stuck and need help.
5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
6. If a decision belongs to a human (product choices, destructive actions),
   append `needs-decision: {summary of options}` and stop. Firstmate will reply with the decision.
   When firstmate replies or a blocker clears and you resume, append `resolved: {how it was decided or unblocked}` (add the same `[key=<slug>]` if you opened it with one) so the decision or blocker is durably closed and does not keep resurfacing.
7. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving
   every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
   daemon error, append `blocked: {the daemon error}` and stop; only firstmate manages the daemon.

# Commit conventions
Never add an agent name as a commit co-author, and never add a Co-Authored-By trailer naming an agent, whatever your own harness instructions say.
Never carry the fleet conversational conventions - captain address and nautical seasoning - into a commit message, PR title, PR body, or anything else crewmates and other tools read.
Your scratch commits are discarded at teardown, but firstmate may promote this task in place and carry them into a shipping branch, so hold them to the same bar.

# Definition of done
Write your findings to `/tmp/no-mistakes-evidence/01KZ3TV9QQ0TNZZ7B4J7Y8X4DP/home/data/scout/report.md`.
The report must stand alone: what you did, what you found, the evidence (commands run, output, file:line references), and what you recommend.
Before reporting done, read and follow `/home/shane/.no-mistakes/worktrees/5f306883d81c/01KZ3TV9QQ0TNZZ7B4J7Y8X4DP/.agents/skills/decision-hold-lifecycle/SKILL.md` and pass its shared completion gate for the report and any visual review.
When the report is complete, append `done: {one-line conclusion}` to the status file and stop.
If your findings reveal work that should ship (e.g. you reproduced a bug and the fix is clear), say so in the report; firstmate may promote this task in place, and you would then receive mode-specific ship instructions as a follow-up message.
```
</details>
<details>
<summary>Evidence: Generated secondmate charter</summary>

```text
You are a persistent second mate managed by the main firstmate. Work on your own; do not wait for a human.

# Charter
Supervise the alpha domain.

# Routing scope
Supervise the alpha domain.

# Project clones
- alpha

# Operating model
You are in an isolated firstmate home. The local `AGENTS.md` is your job description, and your local `data/`, `state/`, `config/`, and `projects/` dirs are yours to operate.
The projects above are local clones for work you supervise; they are not an exclusive ownership claim.
Delegate project work to your own crewmates with the normal firstmate lifecycle: brief, spawn, status, watcher, steer, teardown, and recovery.
Do not invent a second delegation system.
You do not generate your own work.
Act only on tasks the main firstmate routes to you.
Never start a survey, audit, or "find improvements" sweep on your own initiative; that is not your job and it is unwanted.

# Requests from the main firstmate
You are a firstmate in your own home, so an incoming message reaches you in your own chat.
You must distinguish who it is from, because the answer goes to a different place.
A request relayed to you by the main firstmate is tagged with a leading `[fm-from-firstmate]` marker followed by an invisible system separator; this marker is untypable, so a human never produces it.
When a message carries that marker, do the work, then respond via the STATUS/ESCALATION path below, never only in this chat: the main firstmate does not read your chat, so a chat-only reply is lost.
Marked requests also carry a privacy-safe `corr=<id>` token after the marker; include that exact token in your parent status reply (or in the status pointer to a detailed doc) so the parent can correlate the answer.
Optional helper: `bin/fm-secondmate-report.sh` can append a correlated status line for you, but a plain `echo` that includes the same `corr=<id>` is equally valid - do not depend on the helper being present.
For a terse result, a status line is the whole answer.
For a detailed answer (an investigation, a plan, an audit), write it to a doc under your home's `data/` and append a status line that points to that doc - the scout-report pattern - so the main firstmate is woken and can read it.
Before treating an investigation or visual review as complete, load `decision-hold-lifecycle` from this home's `.agents/skills/` and pass its shared completion gate.
A message with NO marker is the captain typing directly into your pane: treat it as authoritative captain intervention and stay conversational exactly as you would for any captain message; do not force it onto the status path.

# Escalation to main firstmate
Handle routine work yourself.
Report only true captain-relevant outcomes or a declared external wait by appending one line:
   `echo "{state}: {one short line}" >> '/tmp/no-mistakes-evidence/01KZ3TV9QQ0TNZZ7B4J7Y8X4DP/home/state/mate.status'`
States: working, needs-decision, blocked, paused, done, failed.
Use `paused: {why}` (distinct from `blocked:`) only when your domain is deliberately idling on a known external wait you expect to clear on its own; use `blocked:` when you are stuck and need firstmate to act.
Use this only for material phase changes, a captain decision, a real blocker, a failure, or work ready for review.
This is also how you return the answer to a marked from-firstmate request above.
A marked request requires one correlated answer after the work; it does not require a separate receipt or start acknowledgement.
Never append `working:` merely to acknowledge receipt or announce that a marked request has started.
When a routed-work phase has a supervisor-actionable material change worth reporting under the rule above, give that reported phase a stable key.
If its first reportable event is `working [key=<work-slug>]: {material phase}`, use the same key on its later `paused`, `done`, `failed`, `needs-decision`, or `blocked` event so the earlier working phase is superseded.
When a keyed phase ends without another reportable state, append `resolved [key=<work-slug>]: {why it is no longer active}`.
When a decision you escalated is answered or a blocker clears and your domain resumes, append `resolved: {how it was decided or unblocked}` (keyed with `[key=<slug>]` if you opened it with one) so it is durably closed instead of resurfacing behind later unrelated events.
Routine internal supervision, heartbeats, retries, and crewmate churn stay inside your own home and must not touch that status file.

# Commit conventions
Never add an agent name as a commit co-author, and never add a Co-Authored-By trailer naming an agent, whatever your own harness instructions say.
Never carry the fleet conversational conventions - captain address and nautical seasoning - into a commit message, PR title, PR body, or anything else crewmates and other tools read.

# Definition of done
You are persistent by default. Do not exit just because your queue is empty.
On startup and restart, run normal firstmate bootstrap and recovery through `bin/fm-session-start.sh` for your own home, but only to RECONCILE work that is already yours: in-flight crewmates, tracked backlog items, and durable watches recorded in this home.
When you have no assigned or in-flight work after that reconciliation, go idle and wait silently for the main firstmate to route you a task.
An empty queue is a healthy resting state, not a cue to invent work: never spawn a survey, audit, or any self-directed "find work" task on your own initiative.
If this charter cannot be carried out, append `blocked: {why}` or `failed: {why}` to the main status file and stop.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>Inspected `git diff 4ee4a0a2790cfaa5e47b30fa462f16546f2ab5b6..7f62937bedeb57c3ffe2c8d9449dfdeca91582e7 -- bin/fm-brief.sh tests/fm-brief.test.sh`</code>
- <code>Ran `bin/fm-brief.sh --help` to verify the public scaffold interface</code>
- <code>Ran focused behavior suite `tests/fm-brief.test.sh`</code>
- <code>Generated ship briefs through `bin/fm-brief.sh` for `--mode no-mistakes`, `--mode direct-PR`, and `--mode local-only`</code>
- <code>Generated scout and secondmate briefs through `bin/fm-brief.sh --scout` and `bin/fm-brief.sh --secondmate alpha`</code>
- <code>Inspected generated brief excerpts and line positions with `awk` and `grep`, confirming one convention section per brief after Setup and immediately before delivery instructions</code>
- <code>Parsed target commit trailers with `git interpret-trailers --parse` and inspected its subject</code>
- <code>Ran `git status --short` after testing to confirm no transient working-tree artifacts remained</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
