### PR TITLE
feat: add local Pi usage report

### DIFF
--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -13,6 +13,7 @@ Use this reference before any harness-specific firstmate operation: spawn, recov
 Crewmates default to the same harness firstmate is running on unless `config/crew-harness` records an adapter name.
 Optional dispatch profiles in `config/crew-dispatch.json` can override that static default for one crewmate or scout dispatch by selecting concrete harness, model, and effort axes at intake.
 When a matched rule or default is a profile array, load `quota-array-dispatch` for the completion-aware candidate choice after this skill establishes harness and model/provider facts.
+When intake reaches the live Pi workload source, [`pi-workload-dispatch`](../pi-workload-dispatch/SKILL.md) owns selection and [`docs/configuration.md`](../../../docs/configuration.md#live-pi-workload-source) owns source and spawn mechanics.
 The captain may override that file at session start or later; a per-task instruction such as "run this one on codex" overrides it for that dispatch only.
 `default` means mirror firstmate's own harness.
 
@@ -124,7 +125,7 @@ The supported launch-profile flags below are verified locally; each row records 
 | claude | `--model <model>` | `--effort <low\|medium\|high\|xhigh\|max>` | Verified on Claude Code 2.1.196. |
 | codex | `--model <model>` | `-c 'model_reasoning_effort="<low\|medium\|high\|xhigh>"'` | Verified on codex-cli 0.142.1. The installed binary schema contains `model_reasoning_effort`, the active config uses it, and the bundled model catalog advertises only low/medium/high/xhigh. `max` is omitted. |
 | grok | `--model <model>` | `--reasoning-effort <low\|medium\|high>` | Verified on grok 0.2.99 (2026-07-13). `--effort` is an alias, but firstmate's profile axis is reasoning effort. As of 0.2.99 the ceiling is `high`; both `xhigh` and `max` are rejected with `use one of: high, medium, low`, so firstmate omits them. |
-| pi / pi-signed | `--model <model>` | `--thinking <low\|medium\|high\|xhigh\|max>` | Verified 2026-07-27 on Pi and pi-signed 0.82.0. Both expose the same accepted thinking levels and completed the same model-qualified max-thinking smoke. |
+| pi / pi-signed | `--model <model>` | `--thinking <off\|minimal\|low\|medium\|high\|xhigh\|max>` | Verified 2026-07-27 on Pi and pi-signed 0.82.0, which expose the same accepted thinking levels and completed the same model-qualified max-thinking smoke. |
 | opencode | `--model <provider/model>` | none for firstmate's interactive launch | Verified on opencode 1.17.6. `opencode run` has `--variant`, but firstmate launches the interactive `opencode --prompt` path, which has no verified effort flag. |
 | kimi | `--model <model>` | none | Verified 2026-07-25 on Kimi Code CLI 0.29.1. |
 
@@ -147,6 +148,7 @@ Use the discovery surface in the current authenticated environment because suppo
 
 For an unfamiliar harness or model namespace, establish support and provider identity from that harness's authoritative CLI help, model listing, or current documentation rather than guessing from a name or prefix.
 A listing that reaches the account and does not contain the model is concrete evidence the model is unsupported: block that candidate and quote the result.
+For a selected live Pi workload, that catalog result blocks the dispatch, and neither another workload nor another model may be substituted silently.
 A discovery surface you could not reach establishes nothing; report that as uncertainty rather than turning it into a supported or unsupported verdict.
 
 When a requested effort value is outside the harness-specific accepted set, `fm-spawn` records the requested `effort=` in meta but emits no effort flag for that harness.

--- a/.agents/skills/pi-workload-dispatch/SKILL.md
+++ b/.agents/skills/pi-workload-dispatch/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: pi-workload-dispatch
+description: Agent-only intake procedure for selecting live Pi workloads after captain and configured dispatch profiles have had precedence.
+user-invocable: false
+metadata:
+  internal: true
+---
+
+# pi-workload-dispatch
+
+Load this skill before every crewmate or scout intake unless the captain has concretely overridden the harness, model, or effort for that task.
+Load it again whenever selecting from the live Pi workload source.
+This skill owns the intake precedence and selection procedure, while [`docs/configuration.md`](../../../docs/configuration.md#live-pi-workload-source) owns source resolution, schema, helper output, spawn flags, and recorded metadata.
+
+## Intake precedence
+
+Apply these steps in order and stop at the first governing source.
+
+1. Any concrete per-task captain override on harness, model, or effort wins and bypasses both `config/crew-dispatch.json` profile selection and the live Pi workload source for that dispatch.
+   Preserve every explicitly supplied axis exactly.
+   Resolve unspecified harness, model, or effort axes through the existing static harness path and `harness-adapters` generic fallback as applicable, rather than composing the override with a potentially incompatible dispatch profile tuple.
+2. The best-fit rule in `config/crew-dispatch.json` wins, with any profile array resolved exactly through `quota-array-dispatch`.
+3. The dispatch file's `default` wins, with the same object-or-array behavior.
+4. Otherwise, when the live source is available and `harness-adapters` can verify the effective chosen runtime as `pi` or `pi-signed`, select a live workload by the procedure below.
+5. When the live source is absent, preserve its observable `SOURCE_ABSENT` result and continue through the legacy `config/crew-harness` resolution path.
+
+A malformed live source blocks only a dispatch that reached the live-source step, and that dispatch must not fall back to static configuration or another workload.
+A selected workload whose model is absent from the selected Pi-family executable's authoritative catalog is blocked, and no alternate workload or model may be substituted silently.
+An unavailable discovery surface establishes uncertainty rather than support, so report the uncertainty instead of inventing catalog or provider facts.
+
+## Selecting a live workload
+
+Run `bin/fm-subagent-dispatch.sh list` at intake and judge fit from the current workload descriptions.
+Use the balanced tier's `w1` workload only as a recommendation for unmatched ordinary work, never as a hard-coded model choice and never in place of a better description match.
+The live workload description decides task fit.
+Quota evidence does not rank live workloads and may resolve only genuinely comparable candidates already offered together by a matched `config/crew-dispatch.json` profile array.
+The array path still takes exactly one `quota-axi --json` snapshot for the intake, accounts for every candidate, and never uses array order or ranking.
+
+After choosing a tier and opaque workload key, run `bin/fm-subagent-dispatch.sh resolve <tier> <workload-key>` immediately before launch.
+Use `harness-adapters` to establish current model support, provider identity, authentication source, and accepted effort for the selected `pi` or `pi-signed` executable.
+Do not infer any of those facts from the workload key, tier, model spelling, source path, or another harness's catalog.
+Spawn with an explicit Pi-family harness, the freshly resolved model and effort, and the same source tier and workload flags so `fm-spawn.sh` can re-resolve and reject stale input before mutation.
+The exact commands and fields are documented in [`docs/configuration.md`](../../../docs/configuration.md#live-pi-workload-source).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -168,7 +168,7 @@ If static `config/crew-harness` or `config/secondmate-harness` names an unverifi
 
 `docs/configuration.md` owns dispatch-profile and runtime-backend schemas, `bin/fm-harness.sh` owns static resolution, and `bin/fm-spawn.sh` owns launch flags and fail-closed validation.
 When dispatch profiles exist, consult them at every crewmate or scout intake and pass the resolved concrete profile required by `fm-spawn`.
-Routing precedence is an explicit per-task captain override, then the best-fit configured rule, then the configured default, then the static crewmate harness.
+The `pi-workload-dispatch` skill owns crewmate and scout intake precedence beyond a concrete per-task captain profile.
 Firstmate alone resolves a matched profile array: run `quota-axi --json` at that intake, evaluate every configured candidate against that current output, and choose with inspectable effective headroom and usable runway, using pace and reserve only later when needed.
 Account for every candidate with the catalog evidence, provider relationship, applicable quota and authentication facts, remaining uncertainty, fit and reasoning class, and the headroom, runway, and later pace or reserve evidence used in selection; never omit a candidate, guess, fall back silently, or call the result quota-informed without them.
 Establish model support and provider family from that harness's own authoritative catalog, then read `quota-axi` at the granularity the vendor actually supplies: provider-level or all-model evidence applies to every model established in that family, and a named-model window bounds only that model.
@@ -505,6 +505,7 @@ These skills are not captain-invocable; load them only at their precise triggers
 - `stuck-crewmate-recovery` - load when the session-start digest reports an ordinary direct report's endpoint dead or its metadata has no window, or after a stale wake, looping pane, repeated confusion, an answered-by-brief question, an unresponsive crewmate, or a failed steer.
 - `secondmate-provisioning` - load before creating, seeding, validating, launching, handing backlog to, recovering, pushing inherited local material into, or retiring a secondmate home, and before editing `data/secondmates.md`.
 - `decision-hold-lifecycle` - load before treating an investigation or visual review as complete, before ending a visual review that exposed a decision, and when recording or routing the captain's answer.
+- `pi-workload-dispatch` - load before every crewmate or scout intake unless the captain concretely overrides that task's harness, model, or effort, and whenever selecting from live Pi workloads.
 - `process-event-sources` - load before arming a long-polling source, and on any `procevent <adapter> <source-id> <sequence>` check wake.
   Never run a registered source's blocking command yourself in a conversational turn.
 - `fmx-respond` - load on an `x-mention <request_id>` `check:` wake to handle the mention, on an `x-mode-error ...` `check:` wake to report the X-mode configuration blocker, on a `public-followup ...` `check:` wake or a startup-surfaced public commitment, and on any milestone or terminal wake for an X-mode-linked task before posting its completion follow-up; relevant only when X mode is on.

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -741,7 +741,7 @@ crew_dispatch_validate() {
       elif $h == "claude" then (["low","medium","high","xhigh","max"] | index($e))
       elif $h == "codex" then (["low","medium","high","xhigh"] | index($e))
       elif $h == "grok" then (["low","medium","high"] | index($e))
-      elif $h == "pi" or $h == "pi-signed" then (["low","medium","high","xhigh","max"] | index($e))
+      elif $h == "pi" or $h == "pi-signed" then (["off","minimal","low","medium","high","xhigh","max"] | index($e))
       elif $h == "opencode" or $h == "kimi" then false
       else true
       end;

--- a/bin/fm-costs.sh
+++ b/bin/fm-costs.sh
@@ -1,0 +1,600 @@
+#!/usr/bin/env bash
+# fm-costs.sh - local, read-only Pi AI usage and list-price cost report.
+#
+# Usage:
+#   fm-costs.sh [--json] [--home <dir>] [--session-dir <dir>]
+#               [--models-store <file>] [--now <iso8601>]
+#
+# The default scans only $HOME/.pi/agent/sessions. FM_COSTS_HOME,
+# FM_COSTS_SESSION_DIR, FM_COSTS_MODELS_STORE, and FM_COSTS_NOW are hermetic
+# overrides for the report home, Pi stores, and clock. The corresponding flags
+# take precedence. The command reads JSONL line by line, writes nothing, makes no
+# network calls, and emits no transcript content.
+#
+# Output contract: fm-costs.v1. Default output is compact TOON-like text;
+# --json emits the equivalent structured model. Pi's stored direct cost.total
+# and subagent flat cost are authoritative. Dollar values are list-price
+# valuations, not invoices.
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+FORMAT=toon
+REPORT_HOME=${FM_COSTS_HOME:-${FM_HOME:-$ROOT}}
+SESSION_DIR=${FM_COSTS_SESSION_DIR:-$HOME/.pi/agent/sessions}
+MODELS_STORE=${FM_COSTS_MODELS_STORE:-$HOME/.pi/agent/models-store.json}
+NOW=${FM_COSTS_NOW:-}
+
+usage() {
+  cat <<'EOF'
+usage: fm-costs.sh [--json] [--home <dir>] [--session-dir <dir>]
+                   [--models-store <file>] [--now <iso8601>]
+
+Local, read-only Pi usage report. The default scans only
+$HOME/.pi/agent/sessions, writes nothing, makes no network calls, and emits no
+transcript content. FM_COSTS_HOME, FM_COSTS_SESSION_DIR,
+FM_COSTS_MODELS_STORE, and FM_COSTS_NOW provide hermetic overrides.
+
+The output contract is fm-costs.v1. Default output is compact TOON-like text;
+--json emits the equivalent structured model.
+Dollar values are list-price valuations, not invoices.
+EOF
+}
+
+die_usage() {
+  printf 'fm-costs: %s\n' "$*" >&2
+  usage >&2
+  exit 2
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --json)
+      FORMAT=json
+      shift
+      ;;
+    --home)
+      [ "$#" -ge 2 ] || die_usage '--home requires a directory'
+      REPORT_HOME=$2
+      shift 2
+      ;;
+    --home=*)
+      REPORT_HOME=${1#*=}
+      shift
+      ;;
+    --session-dir|--sessions-dir)
+      [ "$#" -ge 2 ] || die_usage "$1 requires a directory"
+      SESSION_DIR=$2
+      shift 2
+      ;;
+    --session-dir=*|--sessions-dir=*)
+      SESSION_DIR=${1#*=}
+      shift
+      ;;
+    --models-store)
+      [ "$#" -ge 2 ] || die_usage '--models-store requires a file'
+      MODELS_STORE=$2
+      shift 2
+      ;;
+    --models-store=*)
+      MODELS_STORE=${1#*=}
+      shift
+      ;;
+    --now)
+      [ "$#" -ge 2 ] || die_usage '--now requires a value'
+      NOW=$2
+      shift 2
+      ;;
+    --now=*)
+      NOW=${1#*=}
+      shift
+      ;;
+    -h|--help)
+      [ "$#" -eq 1 ] || die_usage '--help takes no other arguments'
+      usage
+      exit 0
+      ;;
+    *)
+      die_usage "unknown argument '$1'"
+      ;;
+  esac
+done
+
+[ -n "$REPORT_HOME" ] || die_usage 'home must not be empty'
+[ -n "$SESSION_DIR" ] || die_usage 'session directory must not be empty'
+[ -n "$MODELS_STORE" ] || die_usage 'models store must not be empty'
+case "$REPORT_HOME" in
+  /) ;;
+  */) REPORT_HOME=${REPORT_HOME%/} ;;
+esac
+command -v jq >/dev/null 2>&1 || { printf 'fm-costs: jq not found\n' >&2; exit 1; }
+[ -n "$NOW" ] || NOW=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+emit_file_events() {
+  jq -Rrc '
+    def number_or_zero($v): if ($v | type) == "number" then $v else 0 end;
+    def stored_cost($v): if ($v | type) == "number" then $v else null end;
+    def message_text:
+      if (.message.content? | type) == "string" then .message.content
+      elif (.message.content? | type) == "array" then
+        [.message.content[]? |
+          if type == "string" then .
+          elif type == "object" and .type == "text" then (.text // "")
+          else ""
+          end] | join("\n")
+      else ""
+      end;
+    def direct_model:
+      (.message.provider // .provider // "unknown") as $provider |
+      (.message.responseModel // .message.model // "unknown") as $model |
+      if ($model | contains("/")) then
+        {provider:($model | split("/")[0]), model:$model}
+      else
+        {provider:$provider, model:($provider + "/" + $model)}
+      end;
+    def subagent_model($result):
+      ($result.provider // "unknown") as $provider |
+      ($result.model // "unknown") as $model |
+      if ($model | contains("/")) then
+        {provider:($model | split("/")[0]), model:$model}
+      else
+        {provider:$provider, model:($provider + "/" + $model)}
+      end;
+    def usage_event($record; $usage; $origin; $index; $model; $turns; $cost):
+      ($record.timestamp // $record.message.timestamp // "") as $timestamp |
+      {
+        kind:"usage",
+        line:input_line_number,
+        identity:[($record.id // ""), $timestamp, $origin, $index],
+        entry_id:($record.id // ""),
+        entry_timestamp:$timestamp,
+        origin:$origin,
+        result_index:$index,
+        provider:$model.provider,
+        model:$model.model,
+        calls:1,
+        turns:$turns,
+        tokens:{
+          input:number_or_zero($usage.input),
+          output:number_or_zero($usage.output),
+          cacheRead:number_or_zero($usage.cacheRead),
+          cacheWrite:number_or_zero($usage.cacheWrite),
+          reasoning:number_or_zero($usage.reasoning),
+          cacheWrite1h:number_or_zero($usage.cacheWrite1h)
+        },
+        cost:stored_cost($cost),
+        cost_known:(($cost | type) == "number")
+      };
+    if test("^[[:space:]]*$") then {kind:"parse_error",line:input_line_number}
+    else
+      (try fromjson catch {__fm_parse_error:true}) as $record |
+      if (($record | type) == "object" and ($record.__fm_parse_error // false)) then
+        {kind:"parse_error",line:input_line_number}
+      elif ($record | type) != "object" then
+        {kind:"parse_error",line:input_line_number}
+      elif $record.type == "session" then
+        {kind:"session",line:input_line_number,id:($record.id // ""),
+         timestamp:($record.timestamp // ""),cwd:($record.cwd // ""),
+         version:($record.version // null)}
+      elif $record.type == "message" and $record.message.role == "user" then
+        ($record | message_text) as $text |
+        {kind:"user",line:input_line_number,
+         refs:([$text |
+           scan("(/[^[:space:]]+)/state/([A-Za-z0-9._-]+)\\.status") |
+           {home:.[0],task:.[1],path:(.[0] + "/state/" + .[1] + ".status")}
+         ] | unique_by(.path))}
+      elif $record.type == "message" and $record.message.role == "assistant"
+           and (($record.message.usage? | type) == "object") then
+        ($record | direct_model) as $model |
+        usage_event($record; $record.message.usage; "direct"; -1; $model; 1;
+          $record.message.usage.cost.total)
+      elif $record.type == "message" and $record.message.role == "toolResult"
+           and $record.message.toolName == "subagent" then
+        ($record.message.details.results // []) as $results |
+        range(0; ($results | length)) as $index |
+        $results[$index] as $result |
+        select(($result.usage? | type) == "object") |
+        (subagent_model($result)) as $model |
+        usage_event($record; $result.usage; "subagent"; $index; $model;
+          number_or_zero($result.usage.turns); $result.usage.cost)
+      else empty
+      end
+    end
+  ' -- "$1"
+}
+
+json_array_from_lines() {
+  if [ "$#" -eq 0 ]; then
+    printf '[]\n'
+  else
+    printf '%s\n' "$@" | jq -sc '.'
+  fi
+}
+
+append_gap() {
+  local count=${4:-0}
+  GAPS+=("$(jq -cn --arg kind "$1" --arg path "$2" --arg reason "$3" \
+    --argjson count "$count" '{kind:$kind,path:$path,reason:$reason,count:$count}')")
+}
+
+declare -a EVENTS=()
+declare -a SESSIONS=()
+declare -a GAPS=()
+SCAN_FILES=0
+SCAN_BYTES=0
+PARSE_ERRORS=0
+VALID_SESSIONS=0
+
+if [ -d "$SESSION_DIR" ]; then
+  while IFS= read -r file; do
+    [ -n "$file" ] || continue
+    SCAN_FILES=$((SCAN_FILES + 1))
+    if bytes=$(wc -c < "$file" 2>/dev/null); then
+      SCAN_BYTES=$((SCAN_BYTES + bytes))
+    else
+      append_gap unreadable-session "$file" 'could not read session file size'
+      continue
+    fi
+    if ! raw=$(emit_file_events "$file" 2>/dev/null); then
+      append_gap unreadable-session "$file" 'could not read session file'
+      continue
+    fi
+
+    header_seen=0
+    session_id=
+    session_timestamp=
+    session_cwd=
+    first_user_seen=0
+    refs_json='[]'
+    file_parse_errors=0
+    declare -a FILE_USAGE=()
+
+    while IFS= read -r event; do
+      [ -n "$event" ] || continue
+      kind=$(printf '%s\n' "$event" | jq -r '.kind')
+      case "$kind" in
+        session)
+          line=$(printf '%s\n' "$event" | jq -r '.line')
+          if [ "$line" -eq 1 ] && [ "$header_seen" -eq 0 ]; then
+            header_seen=1
+            session_id=$(printf '%s\n' "$event" | jq -r '.id')
+            session_timestamp=$(printf '%s\n' "$event" | jq -r '.timestamp')
+            session_cwd=$(printf '%s\n' "$event" | jq -r '.cwd')
+          fi
+          ;;
+        user)
+          if [ "$first_user_seen" -eq 0 ]; then
+            first_user_seen=1
+            refs_json=$(printf '%s\n' "$event" | jq -c '.refs')
+          fi
+          ;;
+        usage)
+          FILE_USAGE+=("$event")
+          ;;
+        parse_error)
+          file_parse_errors=$((file_parse_errors + 1))
+          ;;
+      esac
+    done <<EOF
+$raw
+EOF
+
+    PARSE_ERRORS=$((PARSE_ERRORS + file_parse_errors))
+    if [ "$file_parse_errors" -gt 0 ]; then
+      append_gap malformed-lines "$file" 'malformed JSONL lines were skipped' "$file_parse_errors"
+    fi
+    if [ "$header_seen" -eq 0 ]; then
+      append_gap no-session-header "$file" 'line 1 is not a valid session header'
+      continue
+    fi
+    VALID_SESSIONS=$((VALID_SESSIONS + 1))
+
+    refs_count=$(printf '%s\n' "$refs_json" | jq 'length')
+    scope=unattributed
+    task=unattributed
+    other_home=
+    attribution=unattributed
+    reason='no unique current-home status path in the first user message'
+    if [ "$refs_count" -eq 1 ]; then
+      ref_home=$(printf '%s\n' "$refs_json" | jq -r '.[0].home')
+      ref_task=$(printf '%s\n' "$refs_json" | jq -r '.[0].task')
+      if [ "$ref_home" = "$REPORT_HOME" ]; then
+        scope=task
+        task=$ref_task
+        attribution=first-user-status-path
+        reason=
+      else
+        scope=other-home
+        task=$ref_task
+        other_home=$ref_home
+        attribution=other-home-status-path
+        reason='the first user message points to another Firstmate home'
+      fi
+    elif [ "$refs_count" -eq 0 ] && [ "$session_cwd" = "$REPORT_HOME" ]; then
+      scope=primary
+      task=primary
+      attribution=current-home-cwd
+      reason=
+    elif [ "$refs_count" -gt 1 ]; then
+      reason='multiple absolute Firstmate status paths occur in the first user message'
+    elif [ "$first_user_seen" -eq 0 ]; then
+      reason='no user message was found'
+    fi
+
+    SESSIONS+=("$(jq -cn \
+      --arg scope "$scope" --arg task "$task" --arg other_home "$other_home" \
+      --arg attribution "$attribution" --arg reason "$reason" \
+      --arg id "$session_id" --arg timestamp "$session_timestamp" \
+      --arg cwd "$session_cwd" --arg file "$file" \
+      '{scope:$scope,task:$task,other_home:$other_home,attribution:$attribution,
+        reason:$reason,id:$id,timestamp:$timestamp,cwd:$cwd,file:$file}')")
+    for event in "${FILE_USAGE[@]+"${FILE_USAGE[@]}"}"; do
+      EVENTS+=("$(printf '%s\n' "$event" | jq -c \
+        --arg scope "$scope" --arg task "$task" --arg other_home "$other_home" \
+        --arg session_id "$session_id" --arg file "$file" \
+        '. + {scope:$scope,task:$task,other_home:$other_home,
+              session_id:$session_id,file:$file}')")
+    done
+  done < <(find "$SESSION_DIR" -type f -name '*.jsonl' -print | LC_ALL=C sort)
+else
+  append_gap missing-session-dir "$SESSION_DIR" 'session directory does not exist'
+fi
+if [ "$SCAN_FILES" -eq 0 ] && [ -d "$SESSION_DIR" ]; then
+  append_gap no-sessions "$SESSION_DIR" 'no Pi session files were found'
+fi
+
+EVENTS_JSON=$(json_array_from_lines "${EVENTS[@]+"${EVENTS[@]}"}")
+SESSIONS_JSON=$(json_array_from_lines "${SESSIONS[@]+"${SESSIONS[@]}"}")
+
+MODELS_STORE_STATE=ok
+if [ ! -e "$MODELS_STORE" ]; then
+  MODELS_STORE_STATE=missing
+  KNOWN_MODELS_JSON='[]'
+elif [ ! -r "$MODELS_STORE" ]; then
+  MODELS_STORE_STATE=unreadable
+  KNOWN_MODELS_JSON='[]'
+elif KNOWN_MODELS_JSON=$(jq -ce '
+  if type != "object" then error("models store is not an object") else
+    [to_entries[] as $provider |
+      ($provider.value.models // [])[]? |
+      select((.id? | type) == "string") |
+      ($provider.key + "/" + .id)
+    ] | unique
+  end
+' -- "$MODELS_STORE" 2>/dev/null); then
+  :
+else
+  MODELS_STORE_STATE=corrupt
+  KNOWN_MODELS_JSON='[]'
+fi
+case "$MODELS_STORE_STATE" in
+  missing) append_gap models-store-missing "$MODELS_STORE" 'models store does not exist' ;;
+  unreadable) append_gap models-store-unreadable "$MODELS_STORE" 'models store is unreadable' ;;
+  corrupt) append_gap models-store-corrupt "$MODELS_STORE" 'models store is not valid supported JSON' ;;
+esac
+GAPS_JSON=$(json_array_from_lines "${GAPS[@]+"${GAPS[@]}"}")
+
+RESULT=$(jq -n \
+  --arg home "$REPORT_HOME" \
+  --arg generated_at "$NOW" \
+  --arg models_store_state "$MODELS_STORE_STATE" \
+  --argjson events "$EVENTS_JSON" \
+  --argjson sessions "$SESSIONS_JSON" \
+  --argjson initial_gaps "$GAPS_JSON" \
+  --argjson known_models "$KNOWN_MODELS_JSON" \
+  --argjson scan_files "$SCAN_FILES" \
+  --argjson scan_bytes "$SCAN_BYTES" \
+  --argjson parse_errors "$PARSE_ERRORS" \
+  --argjson valid_sessions "$VALID_SESSIONS" '
+  def sum_field($rows; $path):
+    ([$rows[] | getpath($path) | select(type == "number")] | add // 0);
+  def billing_basis($provider):
+    if $provider == "github-copilot" or $provider == "openai-codex" then "subscription"
+    else "unknown"
+    end;
+  def costs($rows):
+    ([$rows[] | select(.cost_known != true)] | length) as $unknown |
+    (sum_field($rows; ["cost"])) as $known |
+    {
+      est_cost_usd:(if $unknown == 0 then $known else null end),
+      known_cost_usd:$known,
+      unknown_cost_events:$unknown
+    };
+  def token_totals($rows):
+    {
+      input:sum_field($rows; ["tokens","input"]),
+      output:sum_field($rows; ["tokens","output"]),
+      cacheRead:sum_field($rows; ["tokens","cacheRead"]),
+      cacheWrite:sum_field($rows; ["tokens","cacheWrite"]),
+      reasoning:sum_field($rows; ["tokens","reasoning"]),
+      cacheWrite1h:sum_field($rows; ["tokens","cacheWrite1h"])
+    };
+  def aggregate($rows):
+    ({
+      calls:sum_field($rows; ["calls"]),
+      turns:sum_field($rows; ["turns"]),
+      tokens:token_totals($rows),
+      cost_source:"pi-stored"
+    } + costs($rows));
+  def origin_split($rows):
+    {
+      direct:aggregate([$rows[] | select(.origin == "direct")]),
+      subagent:aggregate([$rows[] | select(.origin == "subagent")])
+    };
+  def billing_split($rows):
+    {
+      subscription:costs([$rows[] | select(billing_basis(.provider) == "subscription")]),
+      metered:costs([$rows[] | select(billing_basis(.provider) == "metered")]),
+      unknown:costs([$rows[] | select(billing_basis(.provider) == "unknown")])
+    };
+  def model_rows($rows):
+    [$rows | sort_by([.model,.origin]) | group_by([.model,.origin])[] |
+      . as $group |
+      ({
+        model:$group[0].model,
+        origin:$group[0].origin,
+        calls:sum_field($group; ["calls"]),
+        turns:sum_field($group; ["turns"]),
+        tokens:token_totals($group),
+        billing_basis:billing_basis($group[0].provider),
+        cost_source:"pi-stored"
+      } + costs($group))
+    ];
+  def bucket($rows; $bucket_sessions):
+    ({
+      sessions:($bucket_sessions | length),
+      calls:sum_field($rows; ["calls"]),
+      turns:sum_field($rows; ["turns"]),
+      tokens:token_totals($rows),
+      models:model_rows($rows),
+      by_origin:origin_split($rows),
+      by_billing_basis:billing_split($rows),
+      cost_source:"pi-stored"
+    } + costs($rows));
+  ($events | sort_by([.identity,
+      (if .scope == "other-home" then 2 elif .scope == "unattributed" then 1 else 0 end),
+      .file,.line]) | group_by(.identity)) as $identity_groups |
+  ([$identity_groups[] | .[0]]) as $deduped |
+  ([$identity_groups[] | .[1:][]]) as $suppressed |
+  ([$deduped[] | select(.scope != "other-home")]) as $included |
+  ([$sessions[] | select(.scope != "other-home")]) as $included_sessions |
+  ([$deduped[] | select(.scope == "primary")]) as $primary_events |
+  ([$sessions[] | select(.scope == "primary")]) as $primary_sessions |
+  ([$deduped[] | select(.scope == "unattributed")]) as $unattributed_events |
+  ([$sessions[] | select(.scope == "unattributed")]) as $unattributed_sessions |
+  ([$sessions[] | select(.scope == "task") | .task] | unique) as $task_names |
+  ([$task_names[] as $task |
+    ([$deduped[] | select(.scope == "task" and .task == $task)]) as $rows |
+    ([$sessions[] | select(.scope == "task" and .task == $task)]) as $task_sessions |
+    ({task:$task,attribution:"first-user-status-path"} + bucket($rows; $task_sessions))
+  ]) as $tasks |
+  ([$sessions[] | select(.scope == "other-home") | .other_home] | unique) as $other_names |
+  ([$other_names[] as $other_home |
+    ([$deduped[] | select(.scope == "other-home" and .other_home == $other_home)]) as $rows |
+    ([$sessions[] | select(.scope == "other-home" and .other_home == $other_home)]) as $home_sessions |
+    ({home:$other_home,omitted:true,sessions:($home_sessions | length)} + costs($rows))
+  ]) as $other_homes |
+  ([$deduped[] |
+    . as $event |
+    select(($known_models | index($event.model)) == null) |
+    {kind:"missing-model-metadata",model:$event.model}
+  ] | group_by(.model) | map(.[0] + {count:length})) as $model_gaps |
+  ([$deduped[] | select(.cost_known != true) |
+    {kind:"unknown-cost",model:.model,origin:.origin}
+  ] | group_by([.model,.origin]) | map(.[0] + {count:length})) as $cost_gaps |
+  (if ($unattributed_sessions | length) > 0 then
+     [({kind:"unattributed",reason:"sessions could not be tied to one current-home task"}
+       + costs($unattributed_events)
+       + {sessions:($unattributed_sessions | length)})]
+   else [] end) as $unattributed_gaps |
+  ([$other_homes[] |
+    {kind:"other-home-omitted",home:.home,reason:"full all-home rollup is deferred",
+     sessions:.sessions,est_cost_usd:.est_cost_usd,
+     known_cost_usd:.known_cost_usd,unknown_cost_events:.unknown_cost_events}
+  ]) as $other_gaps |
+  {
+    contract:"fm-costs.v1",
+    caveat:"Dollar values are list-price valuations, not invoices.",
+    home:$home,
+    generated_at:$generated_at,
+    counting_rule:"executed-calls-global-structured-identity-dedup",
+    cost_source:"Pi stored per-call cost",
+    inputs:{models_store_state:$models_store_state},
+    scan:{
+      files:$scan_files,
+      bytes:$scan_bytes,
+      sessions:$valid_sessions,
+      included_sessions:($included_sessions | length),
+      parse_errors:$parse_errors,
+      deduplicated_entries:($suppressed | length),
+      deduplicated_known_cost_usd:sum_field($suppressed; ["cost"]),
+      deduplicated_unknown_cost_events:([$suppressed[] | select(.cost_known != true)] | length)
+    },
+    primary:({task:"primary",attribution:"current-home-cwd"} + bucket($primary_events; $primary_sessions)),
+    tasks:$tasks,
+    unattributed:(bucket($unattributed_events; $unattributed_sessions)
+      + {files:($unattributed_sessions | map(.file) | unique)}),
+    other_homes:$other_homes,
+    totals:({
+      calls:sum_field($included; ["calls"]),
+      turns:sum_field($included; ["turns"]),
+      tokens:token_totals($included),
+      by_origin:origin_split($included),
+      subagent:aggregate([$included[] | select(.origin == "subagent")]),
+      by_billing_basis:billing_split($included),
+      cost_source:"pi-stored"
+    } + costs($included)),
+    gaps:($initial_gaps + $model_gaps + $cost_gaps + $unattributed_gaps + $other_gaps)
+  }
+') || { printf 'fm-costs: report aggregation failed\n' >&2; exit 1; }
+
+if [ "$FORMAT" = json ]; then
+  printf '%s\n' "$RESULT"
+  exit 0
+fi
+
+printf '%s\n' "$RESULT" | jq -r '
+  def money: if . == null then "null" else tostring end;
+  def model_line:
+    "    " + .origin + " " + .model
+    + ": calls=" + (.calls|tostring)
+    + " turns=" + (.turns|tostring)
+    + " input=" + (.tokens.input|tostring)
+    + " output=" + (.tokens.output|tostring)
+    + " cacheRead=" + (.tokens.cacheRead|tostring)
+    + " cacheWrite=" + (.tokens.cacheWrite|tostring)
+    + " reasoning=" + (.tokens.reasoning|tostring)
+    + " cacheWrite1h=" + (.tokens.cacheWrite1h|tostring)
+    + " est_cost_usd=" + (.est_cost_usd|money)
+    + " known_cost_usd=" + (.known_cost_usd|money)
+    + " unknown_cost_events=" + (.unknown_cost_events|tostring)
+    + " billing_basis=" + .billing_basis
+    + " cost_source=" + .cost_source;
+  def bucket_lines($name; $bucket):
+    ($name + ": sessions=" + ($bucket.sessions|tostring)
+      + " est_cost_usd=" + ($bucket.est_cost_usd|money)
+      + " known_cost_usd=" + ($bucket.known_cost_usd|money)
+      + " unknown_cost_events=" + ($bucket.unknown_cost_events|tostring)),
+    ($bucket.models[]? | model_line);
+  "contract: " + .contract,
+  "caveat: " + .caveat,
+  "home: " + .home,
+  "generated_at: " + .generated_at,
+  "counting_rule: " + .counting_rule,
+  "cost_source: " + .cost_source,
+  "scan: files=" + (.scan.files|tostring)
+    + " bytes=" + (.scan.bytes|tostring)
+    + " sessions=" + (.scan.sessions|tostring)
+    + " included_sessions=" + (.scan.included_sessions|tostring)
+    + " parse_errors=" + (.scan.parse_errors|tostring)
+    + " deduplicated_entries=" + (.scan.deduplicated_entries|tostring)
+    + " deduplicated_known_cost_usd=" + (.scan.deduplicated_known_cost_usd|money)
+    + " deduplicated_unknown_cost_events=" + (.scan.deduplicated_unknown_cost_events|tostring),
+  bucket_lines("primary"; .primary),
+  "tasks[" + (.tasks|length|tostring) + "]:",
+  (.tasks[] | bucket_lines("  " + .task; .)),
+  bucket_lines("unattributed"; .unattributed),
+  "other_homes[" + (.other_homes|length|tostring) + "]:",
+  (.other_homes[] | "  " + .home + ": omitted=true sessions=" + (.sessions|tostring)
+    + " est_cost_usd=" + (.est_cost_usd|money)
+    + " known_cost_usd=" + (.known_cost_usd|money)
+    + " unknown_cost_events=" + (.unknown_cost_events|tostring)),
+  "totals: est_cost_usd=" + (.totals.est_cost_usd|money)
+    + " known_cost_usd=" + (.totals.known_cost_usd|money)
+    + " unknown_cost_events=" + (.totals.unknown_cost_events|tostring)
+    + " subagent_est_cost_usd=" + (.totals.subagent.est_cost_usd|money)
+    + " subagent_known_cost_usd=" + (.totals.subagent.known_cost_usd|money),
+  "billing_basis: subscription=" + (.totals.by_billing_basis.subscription.est_cost_usd|money)
+    + " metered=" + (.totals.by_billing_basis.metered.est_cost_usd|money)
+    + " unknown=" + (.totals.by_billing_basis.unknown.est_cost_usd|money),
+  "gaps[" + (.gaps|length|tostring) + "]:",
+  (.gaps[]? | "  " + .kind
+    + (if .home then " home=" + .home else "" end)
+    + (if .model then " model=" + .model else "" end)
+    + (if .origin then " origin=" + .origin else "" end)
+    + (if .sessions then " sessions=" + (.sessions|tostring) else "" end)
+    + (if .count and .count != 0 then " count=" + (.count|tostring) else "" end)
+    + (if has("known_cost_usd") then " known_cost_usd=" + (.known_cost_usd|money) else "" end)
+    + (if .reason then " reason=" + .reason else "" end)),
+  "caveat: " + .caveat
+'

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 # Spawn a direct report: a crewmate in a treehouse or Orca worktree, or a
 # secondmate in its isolated firstmate home.
-# Usage: fm-spawn.sh <task-id> <project-dir> --mode <no-mistakes|direct-PR|local-only> --yolo <on|off> [--harness <name>|harness|launch-command] [--model <name>] [--effort <level>] [--backend <name>]
-#        fm-spawn.sh <task-id> <project-dir> --scout [--harness <name>|harness|launch-command] [--model <name>] [--effort <level>] [--backend <name>]
+# Usage: fm-spawn.sh <task-id> <project-dir> --mode <no-mistakes|direct-PR|local-only> --yolo <on|off> [--harness <name>|harness|launch-command] [--model <name>] [--effort <level>] [--source-tier <tier> --source-workload <key>] [--backend <name>]
+#        fm-spawn.sh <task-id> <project-dir> --scout [--harness <name>|harness|launch-command] [--model <name>] [--effort <level>] [--source-tier <tier> --source-workload <key>] [--backend <name>]
 #        fm-spawn.sh <task-id> [<firstmate-home>] [--harness <name>|harness|launch-command] [--model <name>] [--effort <level>] [--backend <name>] --secondmate
 #   --mode and --yolo are this task's delivery contract, REQUIRED for every ship
 #   spawn and refused on --scout and --secondmate spawns. Firstmate resolves both
@@ -18,10 +18,15 @@
 #   refused as a flag value.
 #   --harness <name> is the explicit per-spawn harness/profile adapter. The old
 #   positional harness arg still works for back-compat.
-#   --model <name> and --effort <low|medium|high|xhigh|max> are concrete profile
-#   axes chosen by firstmate at intake. They are only threaded into harnesses whose
-#   installed CLIs were verified to support that axis; unsupported axes are omitted
-#   from that harness's launch rather than guessed.
+#   --model <name> and --effort <off|minimal|low|medium|high|xhigh|max> are concrete
+#   profile axes chosen by firstmate at intake. They are only threaded into harnesses
+#   whose installed CLIs were verified to support that axis; unsupported axes are
+#   omitted from that harness's launch rather than guessed.
+#   --source-tier and --source-workload opt an ordinary ship/scout into live Pi
+#   subagent workload resolution. They are required together and require explicit
+#   --harness pi|pi-signed, --model, and --effort. Immediately before any endpoint
+#   or worktree mutation, the live source is resolved and the supplied model/effort
+#   must match exactly; stale or incompatible routing is refused.
 #   --backend <name> is the explicit runtime session-provider backend for this
 #   exact task only (docs/configuration.md "Runtime backend" owns when that flag
 #   is authorized). Without it, the script resolves FM_BACKEND, then
@@ -112,8 +117,8 @@
 # Batch dispatch: pass one or more `id=repo` pairs instead of a single <id> <project>, e.g.
 #     fm-spawn.sh fix-a-k3=projects/foo add-b-q7=projects/bar [--scout]
 #   Each pair re-execs this script in single-task mode, so the single path stays the only
-#   source of truth; shared --scout/--harness/--model/--effort/--backend/--mode/--yolo
-#   applies to every pair. A ship batch therefore carries one delivery contract, and each
+#   source of truth; shared --scout/--harness/--model/--effort/--source-tier/
+#   --source-workload/--backend/--mode/--yolo applies to every pair. A ship batch therefore carries one delivery contract, and each
 #   pair still checks it against its own brief; a batch spanning modes is two invocations.
 #   If config/crew-dispatch.json exists, shared --harness is required for crewmate
 #   and scout batches. The loop lives here, in bash, so callers never hand-write a
@@ -203,12 +208,16 @@ KIND=ship
 HARNESS_ARG=
 MODEL=
 EFFORT=
+SOURCE_TIER=
+SOURCE_WORKLOAD=
 BACKEND_ARG=
 MODE=
 YOLO=
 HARNESS_SET=0
 MODEL_SET=0
 EFFORT_SET=0
+SOURCE_TIER_SET=0
+SOURCE_WORKLOAD_SET=0
 BACKEND_SET=0
 MODE_SET=0
 YOLO_SET=0
@@ -223,6 +232,8 @@ for a in "$@"; do
       harness) HARNESS_ARG=$a; HARNESS_SET=1 ;;
       model) MODEL=$a; MODEL_SET=1 ;;
       effort) EFFORT=$a; EFFORT_SET=1 ;;
+      source-tier) SOURCE_TIER=$a; SOURCE_TIER_SET=1 ;;
+      source-workload) SOURCE_WORKLOAD=$a; SOURCE_WORKLOAD_SET=1 ;;
       backend) BACKEND_ARG=$a; BACKEND_SET=1 ;;
       mode) MODE=$a; MODE_SET=1 ;;
       yolo) YOLO=$a; YOLO_SET=1 ;;
@@ -240,6 +251,10 @@ for a in "$@"; do
     --model=*) MODEL=${a#--model=}; MODEL_SET=1 ;;
     --effort) want_value=effort ;;
     --effort=*) EFFORT=${a#--effort=}; EFFORT_SET=1 ;;
+    --source-tier) want_value=source-tier ;;
+    --source-tier=*) SOURCE_TIER=${a#--source-tier=}; SOURCE_TIER_SET=1 ;;
+    --source-workload) want_value=source-workload ;;
+    --source-workload=*) SOURCE_WORKLOAD=${a#--source-workload=}; SOURCE_WORKLOAD_SET=1 ;;
     --backend) want_value=backend ;;
     --backend=*) BACKEND_ARG=${a#--backend=}; BACKEND_SET=1 ;;
     --mode) want_value=mode ;;
@@ -253,12 +268,14 @@ done
 [ "$HARNESS_SET" -eq 0 ] || [ -n "$HARNESS_ARG" ] || { echo "error: --harness requires a non-empty value" >&2; exit 1; }
 [ "$MODEL_SET" -eq 0 ] || [ -n "$MODEL" ] || { echo "error: --model requires a non-empty value" >&2; exit 1; }
 [ "$EFFORT_SET" -eq 0 ] || [ -n "$EFFORT" ] || { echo "error: --effort requires a non-empty value" >&2; exit 1; }
+[ "$SOURCE_TIER_SET" -eq 0 ] || [ -n "$SOURCE_TIER" ] || { echo "error: --source-tier requires a non-empty value" >&2; exit 1; }
+[ "$SOURCE_WORKLOAD_SET" -eq 0 ] || [ -n "$SOURCE_WORKLOAD" ] || { echo "error: --source-workload requires a non-empty value" >&2; exit 1; }
 [ "$BACKEND_SET" -eq 0 ] || [ -n "$BACKEND_ARG" ] || { echo "error: --backend requires a non-empty value" >&2; exit 1; }
 [ "$MODE_SET" -eq 0 ] || [ -n "$MODE" ] || { echo "error: --mode requires a non-empty value" >&2; exit 1; }
 [ "$YOLO_SET" -eq 0 ] || [ -n "$YOLO" ] || { echo "error: --yolo requires a non-empty value" >&2; exit 1; }
 case "$EFFORT" in
-  ''|low|medium|high|xhigh|max) ;;
-  *) echo "error: --effort must be one of low, medium, high, xhigh, max" >&2; exit 1 ;;
+  ''|off|minimal|low|medium|high|xhigh|max) ;;
+  *) echo "error: --effort must be one of off, minimal, low, medium, high, xhigh, max" >&2; exit 1 ;;
 esac
 
 # Delivery contract (AGENTS.md section 7). A ship task's mode and yolo are
@@ -294,6 +311,39 @@ else
     echo "error: --yolo applies only to ship spawns; a scout delivers a report and a secondmate records its own fixed posture" >&2
     exit 1
   }
+fi
+
+SOURCE_ROUTED=0
+if [ "$SOURCE_TIER_SET" -ne "$SOURCE_WORKLOAD_SET" ]; then
+  echo "error: --source-tier and --source-workload are required together" >&2
+  exit 1
+fi
+if [ "$SOURCE_TIER_SET" -eq 1 ]; then
+  [ "$KIND" != secondmate ] || { echo "error: --source-tier and --source-workload are not allowed on --secondmate spawns" >&2; exit 1; }
+  [ "$HARNESS_SET" -eq 1 ] || { echo "error: source-routed spawns require explicit --harness pi or --harness pi-signed" >&2; exit 1; }
+  case "$HARNESS_ARG" in
+    pi|pi-signed) ;;
+    *) echo "error: source-routed spawns require verified --harness pi or --harness pi-signed; got '$HARNESS_ARG'" >&2; exit 1 ;;
+  esac
+  [ "$MODEL_SET" -eq 1 ] || { echo "error: source-routed spawns require explicit --model from a fresh resolution" >&2; exit 1; }
+  [ "$EFFORT_SET" -eq 1 ] || { echo "error: source-routed spawns require explicit --effort from a fresh resolution" >&2; exit 1; }
+  if ! SOURCE_RESOLUTION=$("$FM_ROOT/bin/fm-subagent-dispatch.sh" resolve "$SOURCE_TIER" "$SOURCE_WORKLOAD"); then
+    echo "error: could not resolve live Pi subagent source for tier=$SOURCE_TIER workload=$SOURCE_WORKLOAD" >&2
+    exit 1
+  fi
+  SOURCE_MODEL=$(printf '%s' "$SOURCE_RESOLUTION" | jq -er '.model | select(type == "string")') || {
+    echo "error: live Pi subagent resolution returned invalid model JSON; re-resolve before spawning" >&2
+    exit 1
+  }
+  SOURCE_EFFORT=$(printf '%s' "$SOURCE_RESOLUTION" | jq -er '.effort | select(type == "string")') || {
+    echo "error: live Pi subagent resolution returned invalid effort JSON; re-resolve before spawning" >&2
+    exit 1
+  }
+  if [ "$MODEL" != "$SOURCE_MODEL" ] || [ "$EFFORT" != "$SOURCE_EFFORT" ]; then
+    echo "error: stale Pi subagent route for tier=$SOURCE_TIER workload=$SOURCE_WORKLOAD: supplied model=$MODEL effort=$EFFORT, fresh source requires model=$SOURCE_MODEL effort=$SOURCE_EFFORT; re-resolve and retry" >&2
+    exit 1
+  fi
+  SOURCE_ROUTED=1
 fi
 
 # Backend selection (data/fm-backend-design-d7): explicit --backend, else
@@ -392,6 +442,11 @@ spawn_abort_cleanup() {
             echo "tasktmp=${TASK_TMP:-}"
             echo "model=${MODEL:-default}"
             echo "effort=${EFFORT:-default}"
+            if [ "${SOURCE_ROUTED:-0}" = 1 ]; then
+              echo "dispatch_source=pi-subagents"
+              echo "dispatch_tier=$SOURCE_TIER"
+              echo "dispatch_workload=$SOURCE_WORKLOAD"
+            fi
             echo "backend=orca"
             echo "orca_worktree_id=$ORCA_WORKTREE_ID"
             [ -z "${ORCA_TERMINAL:-}" ] || echo "terminal=$ORCA_TERMINAL"
@@ -456,6 +511,7 @@ if [ "${#POS[@]}" -gt 0 ] && [ "${POS[0]}" != "$idpart" ] && case "$idpart" in *
   [ -z "$HARNESS_ARG" ] || shared_args+=(--harness "$HARNESS_ARG")
   [ -z "$MODEL" ] || shared_args+=(--model "$MODEL")
   [ -z "$EFFORT" ] || shared_args+=(--effort "$EFFORT")
+  [ "$SOURCE_TIER_SET" -eq 0 ] || shared_args+=(--source-tier "$SOURCE_TIER" --source-workload "$SOURCE_WORKLOAD")
   [ -z "$BACKEND_ARG" ] || shared_args+=(--backend "$BACKEND_ARG")
   # One delivery contract applies to every pair in a batch, exactly like the shared
   # harness. Each pair still re-validates it against its own brief, so a batch
@@ -626,8 +682,8 @@ if [ "$KIND" = secondmate ] && [ -z "$ARG3" ]; then
     SM_EFFORT=$("$SCRIPT_DIR/fm-harness.sh" secondmate-effort)
     if [ -n "$SM_EFFORT" ]; then
       case "$SM_EFFORT" in
-        low|medium|high|xhigh|max) EFFORT=$SM_EFFORT ;;
-        *) echo "warning: config/secondmate-harness effort token '$SM_EFFORT' is not one of low, medium, high, xhigh, max; ignoring" >&2 ;;
+        off|minimal|low|medium|high|xhigh|max) EFFORT=$SM_EFFORT ;;
+        *) echo "warning: config/secondmate-harness effort token '$SM_EFFORT' is not one of off, minimal, low, medium, high, xhigh, max; ignoring" >&2 ;;
       esac
     fi
   fi
@@ -704,10 +760,9 @@ effort_flag_for_harness() {
       esac
       ;;
     pi|pi-signed)
-      # Pi 0.80.6 accepts the full shared effort vocabulary, including max, through
-      # its --thinking flag.
+      # Pi accepts its full thinking vocabulary through --thinking.
       case "$effort" in
-        low|medium|high|xhigh|max) printf -- '--thinking %s ' "$(shell_quote "$effort")" ;;
+        off|minimal|low|medium|high|xhigh|max) printf -- '--thinking %s ' "$(shell_quote "$effort")" ;;
       esac
       ;;
     # opencode's interactive `opencode --prompt` launch has a verified --model
@@ -1717,6 +1772,11 @@ META_WINDOW=$T
   echo "tasktmp=$TASK_TMP"
   echo "model=${MODEL:-default}"
   echo "effort=${EFFORT:-default}"
+  if [ "$SOURCE_ROUTED" = 1 ]; then
+    echo "dispatch_source=pi-subagents"
+    echo "dispatch_tier=$SOURCE_TIER"
+    echo "dispatch_workload=$SOURCE_WORKLOAD"
+  fi
   [ -z "${BUSY_GEN:-}" ] || echo "busy_gen=$BUSY_GEN"
   # backend= is written only for a non-default (non-tmux) backend, so the
   # default path's meta stays byte-identical (absent backend= means tmux;
@@ -1827,4 +1887,6 @@ fi
 
 SPAWN_DELIVERY=
 [ -z "$MODE" ] || SPAWN_DELIVERY=" mode=$MODE yolo=$YOLO"
-echo "spawned $ID harness=$HARNESS kind=$KIND$SPAWN_DELIVERY window=$META_WINDOW worktree=$WT"
+SPAWN_SOURCE=
+[ "$SOURCE_ROUTED" = 0 ] || SPAWN_SOURCE=" source=pi-subagents tier=$SOURCE_TIER workload=$SOURCE_WORKLOAD"
+echo "spawned $ID harness=$HARNESS kind=$KIND$SPAWN_DELIVERY window=$META_WINDOW worktree=$WT$SPAWN_SOURCE"

--- a/bin/fm-subagent-dispatch.sh
+++ b/bin/fm-subagent-dispatch.sh
@@ -1,0 +1,242 @@
+#!/usr/bin/env bash
+# fm-subagent-dispatch.sh - read, validate, and resolve the captain's live Pi
+# subagent workload configuration without changing it or persisting model data.
+#
+# Usage:
+#   fm-subagent-dispatch.sh path
+#   fm-subagent-dispatch.sh list
+#   fm-subagent-dispatch.sh resolve <cheap|balanced|strong> <workload-key>
+#   fm-subagent-dispatch.sh --help
+#
+# Source precedence is evaluated on every command invocation:
+#   1. $PI_CODING_AGENT_DIR/extensions/subagents/config.json when
+#      PI_CODING_AGENT_DIR is nonempty and that candidate is a regular file.
+#   2. $FM_SUBAGENTS_CONFIG when nonempty. This override must be absolute and a
+#      regular file; an explicitly invalid override is an error, not a fallback.
+#   3. $HOME/.pi/agent/extensions/subagents/config.json when it is regular.
+# No source prints SOURCE_ABSENT and exits 4. Invalid JSON or schema exits 3.
+# Usage errors exit 2, and an unknown tier or workload exits 5.
+#
+# Every selected source is snapshotted once into a private temporary file, then
+# validated and rendered only from that snapshot. The exact schema is a root
+# object containing only modelTiers and optional maxConcurrency. When present,
+# maxConcurrency is a positive integer; list exposes the extension default 4
+# when omitted. modelTiers contains exactly cheap, balanced, and strong. Each
+# tier contains only workloads, a nonempty array of exact workload objects: key,
+# description, model, and thinkingLevel. Keys are tier-local unique wN
+# identifiers, descriptions are nonempty strings, and models match
+# /^[^/\s]+\/.+\S$/: a provider with no slash or whitespace, then a model suffix
+# that may contain further slashes or internal spaces but ends non-whitespace and
+# contains no JavaScript line terminator. thinkingLevel is one of
+# off|minimal|low|medium|high|xhigh|max. resolve renames thinkingLevel to effort
+# without changing its value. list and resolve write JSON to stdout; path writes
+# the selected path.
+set -eu
+
+usage() {
+  awk '
+    NR == 1 { next }
+    /^#/ { sub(/^# ?/, ""); print; next }
+    { exit }
+  ' "$0" >&2
+}
+
+die_usage() {
+  printf 'fm-subagent-dispatch: %s\n' "$*" >&2
+  exit 2
+}
+
+select_source() {
+  local candidate
+  if [ -n "${PI_CODING_AGENT_DIR:-}" ]; then
+    candidate=${PI_CODING_AGENT_DIR}/extensions/subagents/config.json
+    if [ -f "$candidate" ]; then
+      printf '%s\n' "$candidate"
+      return 0
+    fi
+  fi
+
+  if [ -n "${FM_SUBAGENTS_CONFIG:-}" ]; then
+    case "$FM_SUBAGENTS_CONFIG" in
+      /*) ;;
+      *)
+        printf 'SUBAGENTS_CONFIG: invalid %s - FM_SUBAGENTS_CONFIG must be an absolute path\n' \
+          "$FM_SUBAGENTS_CONFIG" >&2
+        exit 3
+        ;;
+    esac
+    if [ ! -f "$FM_SUBAGENTS_CONFIG" ]; then
+      printf 'SUBAGENTS_CONFIG: invalid %s - FM_SUBAGENTS_CONFIG is not a regular file\n' \
+        "$FM_SUBAGENTS_CONFIG" >&2
+      exit 3
+    fi
+    printf '%s\n' "$FM_SUBAGENTS_CONFIG"
+    return 0
+  fi
+
+  if [ -n "${HOME:-}" ]; then
+    candidate=${HOME}/.pi/agent/extensions/subagents/config.json
+    if [ -f "$candidate" ]; then
+      printf '%s\n' "$candidate"
+      return 0
+    fi
+  fi
+
+  printf 'SOURCE_ABSENT: no Pi subagent config found in PI_CODING_AGENT_DIR, FM_SUBAGENTS_CONFIG, or HOME\n' >&2
+  exit 4
+}
+
+validate_config() {
+  jq -r '
+    def exact_keys($expected): (keys | sort) == ($expected | sort);
+    def valid_thinking:
+      . == "off" or . == "minimal" or . == "low" or . == "medium" or
+      . == "high" or . == "xhigh" or . == "max";
+    def tier_reason($name):
+      .modelTiers[$name] as $tier |
+      if ($tier | type) != "object" then
+        "modelTiers." + $name + " must be an object"
+      elif ($tier | exact_keys(["workloads"])) | not then
+        "modelTiers." + $name + " must contain exactly workloads"
+      elif ($tier.workloads | type) != "array" then
+        "modelTiers." + $name + ".workloads must be an array"
+      elif ($tier.workloads | length) == 0 then
+        "modelTiers." + $name + ".workloads must be nonempty"
+      elif any($tier.workloads[]; type != "object") then
+        "modelTiers." + $name + " has a workload that is not an object"
+      elif any($tier.workloads[]; (exact_keys(["key", "description", "model", "thinkingLevel"]) | not)) then
+        "modelTiers." + $name + " workload objects must contain exactly key, description, model, thinkingLevel"
+      elif any($tier.workloads[]; (.key | type) != "string" or (.key | test("^w[1-9][0-9]*$") | not)) then
+        "modelTiers." + $name + " workload key must match ^w[1-9][0-9]*$"
+      elif ([$tier.workloads[].key] | unique | length) != ($tier.workloads | length) then
+        "modelTiers." + $name + " workload keys must be unique within the tier"
+      elif any($tier.workloads[]; (.description | type) != "string" or (.description | length) == 0) then
+        "modelTiers." + $name + " workload description must be a nonempty string"
+      elif any($tier.workloads[]; (.model | type) != "string" or (.model | test("[\\r\\n\u2028\u2029]")) or (.model | test("^[^/\\s]+/.+\\S$") | not)) then
+        "modelTiers." + $name + " workload model must match ^[^/\\s]+/.+\\S$"
+      elif any($tier.workloads[]; (.thinkingLevel | type) != "string" or (.thinkingLevel | valid_thinking | not)) then
+        "modelTiers." + $name + " workload thinkingLevel is unsupported"
+      else
+        "OK"
+      end;
+    if type != "object" then
+      "root must be an object"
+    elif ((keys - ["maxConcurrency", "modelTiers"]) | length) != 0 or has("modelTiers") == false then
+      "root may contain only maxConcurrency and modelTiers, and modelTiers is required"
+    elif has("maxConcurrency") and ((.maxConcurrency | type) != "number" or .maxConcurrency <= 0 or (.maxConcurrency | floor) != .maxConcurrency) then
+      "maxConcurrency must be a positive integer when present"
+    elif (.modelTiers | type) != "object" then
+      "modelTiers must be an object"
+    elif (.modelTiers | exact_keys(["cheap", "balanced", "strong"]) | not) then
+      "modelTiers must contain exactly cheap, balanced, strong"
+    else
+      tier_reason("cheap") as $cheap |
+      if $cheap != "OK" then $cheap
+      else tier_reason("balanced") as $balanced |
+        if $balanced != "OK" then $balanced
+        else tier_reason("strong")
+        end
+      end
+    end
+  '
+}
+
+case "${1:-}" in
+  -h|--help)
+    [ "$#" -eq 1 ] || die_usage "--help takes no arguments"
+    usage
+    exit 0
+    ;;
+  path|list)
+    [ "$#" -eq 1 ] || die_usage "$1 takes no arguments"
+    ;;
+  resolve)
+    [ "$#" -eq 3 ] || die_usage "resolve requires <cheap|balanced|strong> <workload-key>"
+    ;;
+  '')
+    die_usage "command required (path, list, or resolve)"
+    ;;
+  *)
+    die_usage "unknown command '$1' (expected path, list, or resolve)"
+    ;;
+esac
+
+SOURCE=$(select_source)
+if ! command -v jq >/dev/null 2>&1; then
+  printf 'SUBAGENTS_CONFIG: unavailable - jq is required to validate %s\n' "$SOURCE" >&2
+  exit 3
+fi
+umask 077
+SNAPSHOT=$(mktemp "${TMPDIR:-/tmp}/fm-subagent-dispatch.XXXXXX") || {
+  printf 'SUBAGENTS_CONFIG: unavailable - could not create private source snapshot\n' >&2
+  exit 3
+}
+trap 'rm -f "$SNAPSHOT"' EXIT HUP INT TERM
+if ! cat -- "$SOURCE" >"$SNAPSHOT"; then
+  printf 'SUBAGENTS_CONFIG: invalid %s - could not snapshot selected source\n' "$SOURCE" >&2
+  exit 3
+fi
+set +e
+VALIDATION=$(validate_config <"$SNAPSHOT" 2>&1)
+VALIDATION_RC=$?
+set -e
+if [ "$VALIDATION_RC" -ne 0 ]; then
+  VALIDATION=$(printf '%s' "$VALIDATION" | tr '\n' ' ')
+  printf 'SUBAGENTS_CONFIG: invalid %s - malformed JSON: %s\n' "$SOURCE" "$VALIDATION" >&2
+  exit 3
+fi
+if [ "$VALIDATION" != "OK" ]; then
+  printf 'SUBAGENTS_CONFIG: invalid %s - %s\n' "$SOURCE" "$VALIDATION" >&2
+  exit 3
+fi
+
+if [ "$1" = resolve ]; then
+  case "$2" in
+    cheap|balanced|strong) ;;
+    *)
+      printf "SUBAGENTS_CONFIG: unknown tier '%s' (expected cheap, balanced, or strong)\n" "$2" >&2
+      exit 5
+      ;;
+  esac
+fi
+
+case "$1" in
+  path)
+    printf '%s\n' "$SOURCE"
+    ;;
+  list)
+    jq -c --arg source "$SOURCE" '
+      {
+        source: $source,
+        maxConcurrency: (.maxConcurrency // 4),
+        tiers: (.modelTiers | with_entries(
+          .value = [.value.workloads[] | {
+            workload: .key,
+            description,
+            model,
+            effort: .thinkingLevel
+          }]
+        ))
+      }
+    ' "$SNAPSHOT"
+    ;;
+  resolve)
+    if ! jq -e --arg tier "$2" --arg workload "$3" \
+      '.modelTiers[$tier].workloads | any(.key == $workload)' "$SNAPSHOT" >/dev/null; then
+      printf "SUBAGENTS_CONFIG: unknown workload '%s' in tier '%s'\n" "$3" "$2" >&2
+      exit 5
+    fi
+    jq -c --arg source "$SOURCE" --arg tier "$2" --arg workload "$3" '
+      .modelTiers[$tier].workloads[] |
+      select(.key == $workload) |
+      {
+        source: $source,
+        tier: $tier,
+        workload: .key,
+        model,
+        effort: .thinkingLevel,
+        description
+      }
+    ' "$SNAPSHOT"
+    ;;
+esac

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -226,12 +226,14 @@ For Pi and pi-signed secondmate launches, `fm-spawn.sh` starts the selected exec
 ## Crew dispatch profiles (config/crew-dispatch.json)
 
 `config/crew-dispatch.json` is an optional local, gitignored file containing natural-language rules that firstmate reads before dispatching a crewmate or scout.
-The shell scripts do not match those rules; firstmate chooses the best matching rule with judgment, resolves its profile object or array under the operating contract in `AGENTS.md` section 4 and `quota-array-dispatch`, and passes only concrete `--harness`, `--model`, and `--effort` flags to `fm-spawn.sh`.
-When the file exists, `fm-spawn.sh` enforces that contract by refusing crewmate and scout spawns that lack an explicit harness (`--harness`, a positional adapter, or a raw launch command).
+The shell scripts do not match those rules; firstmate chooses the best matching rule with judgment, resolves its profile object or array under `pi-workload-dispatch` and `quota-array-dispatch`, and passes only concrete `--harness`, `--model`, and `--effort` flags to `fm-spawn.sh`.
+Any concrete per-task captain override on harness, model, or effort bypasses profile selection for that dispatch, preserves every explicit axis, and resolves unspecified axes through the existing static harness path and `harness-adapters` generic fallback as applicable.
+This avoids composing a partial captain override with a potentially incompatible profile tuple and also bypasses live Pi workload routing.
+When the file exists, `fm-spawn.sh` enforces the profile contract for dispatches governed by that file by refusing crewmate and scout spawns that lack an explicit harness (`--harness`, a positional adapter, or a raw launch command).
 Batch spawns satisfy the same requirement with a shared `--harness`.
 Secondmate spawns are exempt and still resolve through `config/secondmate-harness` and its optional model and effort tokens.
 This section is the single owner of the canonical schema and its per-field semantics.
-`AGENTS.md` section 4 owns the always-loaded dispatch intake boundary, and `quota-array-dispatch` owns the completion-aware profile-array selection procedure.
+`pi-workload-dispatch` owns intake precedence, and `quota-array-dispatch` owns the completion-aware profile-array selection procedure.
 
 ```json
 {
@@ -256,7 +258,7 @@ The single-object form stays fully backward-compatible, and every profile needs 
 Profile `model` and `effort` fields and rule `why` are optional.
 An omitted model or effort means the selected harness uses its own default for that axis.
 Every profile array is an implicit quota-aware choice resolved through `quota-array-dispatch`.
-If no dispatch rule fits, firstmate resolves `default` through the same object-or-array path before falling back to `config/crew-harness`.
+If no dispatch rule fits, firstmate resolves `default` through the same object-or-array path before `pi-workload-dispatch` decides whether live Pi workload intake or the legacy `config/crew-harness` path applies.
 If a selected profile carries an effort value the chosen harness does not accept, `fm-spawn.sh` records the requested `effort=` in task meta for traceability but omits the launch flag, and bootstrap reports the invalid harness/effort pair as a `CREW_DISPATCH` diagnostic when it is visible in the file.
 See [`docs/examples/crew-dispatch.json`](examples/crew-dispatch.json) for a starting point to copy into local `config/crew-dispatch.json`.
 When the file exists, bootstrap validates it with `jq`.
@@ -264,6 +266,71 @@ Valid files stay silent by default; with `FM_BOOTSTRAP_VERBOSE_FACTS=1`, bootstr
 Malformed JSON, an empty or malformed rule/default array, an unverified harness, or an effort value unsupported by that harness is reported as `CREW_DISPATCH: invalid config/crew-dispatch.json - ...`; missing `jq` is reported through the normal `MISSING: jq` install-consent flow.
 While the file remains present, no crewmate or scout spawn may proceed without an explicit resolved harness; malformed configuration must be reported and corrected rather than selected around.
 Secondmate homes inherit this file from the primary, so a secondmate's own crewmates apply the same dispatch profile behavior.
+
+## Live Pi workload source
+
+The agent-only [`pi-workload-dispatch` skill](../.agents/skills/pi-workload-dispatch/SKILL.md) owns when this source is consulted and how a workload is selected.
+This section and the header of [`bin/fm-subagent-dispatch.sh`](../bin/fm-subagent-dispatch.sh) own source resolution, schema, helper output, failure behavior, and spawn wiring.
+
+`bin/fm-subagent-dispatch.sh` evaluates source candidates fresh on every invocation without writing the source or persisting a model list.
+It snapshots the selected source exactly once into a private temporary file, removes that file on exit, and validates and renders only from the snapshot so malformed bytes are not transformed and a concurrent source edit cannot separate validation from output.
+It first uses `$PI_CODING_AGENT_DIR/extensions/subagents/config.json` when `PI_CODING_AGENT_DIR` is nonempty and that candidate is a regular file.
+It next uses nonempty `FM_SUBAGENTS_CONFIG`, which must name an absolute regular file and fails as invalid when explicitly set otherwise instead of falling through.
+It finally uses `$HOME/.pi/agent/extensions/subagents/config.json` when that candidate is a regular file.
+When no candidate is available, it writes an observable `SOURCE_ABSENT` result to stderr and exits 4 so intake can retain that result before using the legacy static harness path.
+An invalid selected file writes `SUBAGENTS_CONFIG: invalid ...` to stderr and exits 3, and a source-routed dispatch must stop instead of falling back.
+
+`FM_SUBAGENTS_CONFIG` is an environment pointer, not inherited local material.
+Each secondmate home resolves the same live source procedure from its own current `PI_CODING_AGENT_DIR`, `FM_SUBAGENTS_CONFIG`, and `HOME` environment.
+The inherited `config/crew-dispatch.json` and `config/crew-harness` values retain their normal higher-precedence roles in that home.
+
+The selected JSON root allows only `maxConcurrency` and `modelTiers`, with `modelTiers` required.
+`maxConcurrency` is optional and must be a positive integer when present; when omitted, `list` exposes the extension default `4`.
+`modelTiers` contains exactly `cheap`, `balanced`, and `strong`.
+Each tier contains exactly `workloads`, which is a nonempty array of objects containing exactly `key`, `description`, `model`, and `thinkingLevel`.
+A workload key matches `^w[1-9][0-9]*$` and is unique within its tier, while its description is a nonempty string.
+A model matches the extension validator's `/^[^/\s]+\/.+\S$/`: the provider contains no slash or whitespace, while the model suffix may contain additional slashes or internal spaces, has the regex's same minimum length, ends in a non-whitespace character, and contains no newline.
+The exact thinking levels are `off`, `minimal`, `low`, `medium`, `high`, `xhigh`, and `max`.
+The helper renames `thinkingLevel` to `effort` in its output without changing the value.
+
+`bin/fm-subagent-dispatch.sh path` prints the selected path.
+`bin/fm-subagent-dispatch.sh list` prints compact JSON with `source`, `maxConcurrency`, and `tiers`, where each workload exposes `workload`, `description`, `model`, and `effort`.
+`bin/fm-subagent-dispatch.sh resolve <cheap|balanced|strong> <workload-key>` prints compact JSON with `source`, `tier`, `workload`, `model`, `effort`, and `description`.
+Usage errors exit 2, malformed JSON or schema and an explicitly invalid source exit 3, source absence exits 4, and unknown tiers or workload keys exit 5.
+
+The following commands demonstrate fresh resolution with opaque keys discovered from the live list rather than copied model identifiers.
+
+```bash
+listing=$(bin/fm-subagent-dispatch.sh list)
+cheap_key=$(printf '%s' "$listing" | jq -r '.tiers.cheap[0].workload')
+balanced_key=$(printf '%s' "$listing" | jq -r '.tiers.balanced[0].workload')
+strong_key=$(printf '%s' "$listing" | jq -r '.tiers.strong[0].workload')
+bin/fm-subagent-dispatch.sh resolve cheap "$cheap_key"
+bin/fm-subagent-dispatch.sh resolve balanced "$balanced_key"
+bin/fm-subagent-dispatch.sh resolve strong "$strong_key"
+```
+
+For a selected workload, resolve it again immediately before spawning and pass the returned axes with the same opaque source coordinates.
+
+```bash
+route=$(bin/fm-subagent-dispatch.sh resolve balanced "$balanced_key")
+bin/fm-spawn.sh <task-id> <project-dir> \
+  --scout \
+  --harness pi \
+  --model "$(printf '%s' "$route" | jq -r '.model')" \
+  --effort "$(printf '%s' "$route" | jq -r '.effort')" \
+  --source-tier "$(printf '%s' "$route" | jq -r '.tier')" \
+  --source-workload "$(printf '%s' "$route" | jq -r '.workload')"
+```
+
+`--source-tier` and `--source-workload` are required together for an ordinary ship or scout and are forbidden for secondmate launches.
+A source-routed spawn also requires explicit `--harness pi` or `--harness pi-signed`, `--model`, and `--effort` values.
+Immediately before endpoint or isolated-copy mutation, `fm-spawn.sh` resolves the live tier and workload again and refuses stale supplied model or effort values.
+A successful source-routed task records the normal `harness=`, `model=`, and `effort=` fields plus `dispatch_source=pi-subagents`, `dispatch_tier=<tier>`, and `dispatch_workload=<opaque-key>`.
+The source file path and a generated or copied model list are not recorded.
+
+A model selected from the live source must be established in the selected Pi-family executable's current authoritative catalog through `harness-adapters` before spawn.
+If that catalog proves the selected model unsupported, the dispatch is blocked and no alternate model or workload is chosen silently.
 
 ## Toolchain
 

--- a/docs/documentation-audiences.json
+++ b/docs/documentation-audiences.json
@@ -152,6 +152,10 @@
       "audience": "agent-runtime"
     },
     {
+      "path": ".agents/skills/pi-workload-dispatch/SKILL.md",
+      "audience": "agent-runtime"
+    },
+    {
       "path": ".agents/skills/process-event-sources/SKILL.md",
       "audience": "agent-runtime"
     },

--- a/tests/fm-bootstrap.test.sh
+++ b/tests/fm-bootstrap.test.sh
@@ -809,8 +809,22 @@ unverified dispatch harness is flagged^{"rules":[{"when":"anything","use":{"harn
 unsupported codex max effort is flagged^{"rules":[{"when":"big feature","use":{"harness":"codex","model":"gpt-5","effort":"max"}}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - invalid effort: codex:max
 unsupported grok max effort is flagged^{"rules":[{"when":"deep current work","use":{"harness":"grok","model":"grok-4","effort":"max"}}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - invalid effort: grok:max
 unsupported grok xhigh effort is flagged^{"rules":[{"when":"deep current work","use":{"harness":"grok","model":"grok-4","effort":"xhigh"}}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - invalid effort: grok:xhigh
+pi off effort is accepted^{"rules":[{"when":"direct coding","use":{"harness":"pi","model":"openai-codex/gpt-5.6-sol","effort":"off"}}]}^empty^
+pi minimal effort is accepted^{"rules":[{"when":"light coding","use":{"harness":"pi","model":"openai-codex/gpt-5.6-sol","effort":"minimal"}}]}^empty^
 pi max effort is accepted^{"rules":[{"when":"deep coding","use":{"harness":"pi","model":"openai-codex/gpt-5.6-sol","effort":"max"}}]}^empty^
+pi-signed off effort is accepted^{"rules":[{"when":"direct signed coding","use":{"harness":"pi-signed","model":"openai-codex/gpt-5.6-sol","effort":"off"}}]}^empty^
+pi-signed minimal effort is accepted^{"rules":[{"when":"light signed coding","use":{"harness":"pi-signed","model":"openai-codex/gpt-5.6-sol","effort":"minimal"}}]}^empty^
 pi-signed max effort is accepted^{"rules":[{"when":"signed coding","use":{"harness":"pi-signed","model":"openai-codex/gpt-5.6-sol","effort":"max"}}]}^empty^
+unsupported claude off effort is flagged^{"rules":[{"when":"claude work","use":{"harness":"claude","effort":"off"}}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - invalid effort: claude:off
+unsupported claude minimal effort is flagged^{"rules":[{"when":"claude work","use":{"harness":"claude","effort":"minimal"}}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - invalid effort: claude:minimal
+unsupported codex off effort is flagged^{"rules":[{"when":"codex work","use":{"harness":"codex","effort":"off"}}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - invalid effort: codex:off
+unsupported codex minimal effort is flagged^{"rules":[{"when":"codex work","use":{"harness":"codex","effort":"minimal"}}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - invalid effort: codex:minimal
+unsupported grok off effort is flagged^{"rules":[{"when":"grok work","use":{"harness":"grok","effort":"off"}}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - invalid effort: grok:off
+unsupported grok minimal effort is flagged^{"rules":[{"when":"grok work","use":{"harness":"grok","effort":"minimal"}}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - invalid effort: grok:minimal
+unsupported opencode off effort is flagged^{"rules":[{"when":"opencode work","use":{"harness":"opencode","effort":"off"}}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - invalid effort: opencode:off
+unsupported opencode minimal effort is flagged^{"rules":[{"when":"opencode work","use":{"harness":"opencode","effort":"minimal"}}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - invalid effort: opencode:minimal
+unsupported kimi off effort is flagged^{"rules":[{"when":"kimi work","use":{"harness":"kimi","effort":"off"}}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - invalid effort: kimi:off
+unsupported kimi minimal effort is flagged^{"rules":[{"when":"kimi work","use":{"harness":"kimi","effort":"minimal"}}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - invalid effort: kimi:minimal
 unsupported opencode effort is flagged^{"rules":[{"when":"opencode work","use":{"harness":"opencode","model":"anthropic/claude-sonnet-4-5","effort":"high"}}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - invalid effort: opencode:high
 kimi model profile is accepted^{"rules":[{"when":"kimi work","use":{"harness":"kimi","model":"kimi-code/k3"}}]}^empty^
 unsupported kimi effort is flagged^{"rules":[{"when":"kimi work","use":{"harness":"kimi","model":"kimi-code/k3","effort":"high"}}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - invalid effort: kimi:high

--- a/tests/fm-costs.test.sh
+++ b/tests/fm-costs.test.sh
@@ -1,0 +1,346 @@
+#!/usr/bin/env bash
+# Behavior tests for the local, read-only Pi AI usage report.
+# Covers the clean baseline; direct and subagent usage; responseModel preference;
+# structured origin/index fork deduplication; reused-path and first-user-only task
+# attribution; the separate primary and unattributed buckets; omitted other-home
+# subtotals; malformed final lines; missing headers; missing/corrupt model stores;
+# known stored cost without model metadata; unknown cost propagation; the exact
+# list-price caveat; default $HOME scanning; TOON/JSON key-value parity; transcript
+# non-disclosure; and no-write/no-network behavior. Every transcript is synthetic.
+set -u
+
+# shellcheck source=tests/lib.sh
+# shellcheck disable=SC1091
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+COSTS="$ROOT/bin/fm-costs.sh"
+TMP_ROOT=$(fm_test_tmproot fm-costs)
+
+command -v jq >/dev/null 2>&1 || { echo "skip: jq not found"; exit 0; }
+
+new_fixture() {  # <name>
+  local base="$TMP_ROOT/$1"
+  mkdir -p "$base/home" "$base/sessions/slot" "$base/pi"
+  printf '%s\n' "$base"
+}
+
+write_models() {  # <file>
+  cat > "$1" <<'JSON'
+{
+  "github-copilot": {
+    "models": [
+      {"id":"preferred"},
+      {"id":"beta"},
+      {"id":"primary"},
+      {"id":"ambiguous"},
+      {"id":"other"},
+      {"id":"unknown-cost"}
+    ]
+  },
+  "openai-codex": {"models":[{"id":"sub"}]}
+}
+JSON
+}
+
+run_json() {  # <base> [extra args]
+  local base=$1
+  shift
+  "$COSTS" --json --home "$base/home" --session-dir "$base/sessions" \
+    --models-store "$base/pi/models-store.json" --now 2026-08-10T12:00:00Z "$@"
+}
+
+run_toon() {  # <base> [extra args]
+  local base=$1
+  shift
+  "$COSTS" --home "$base/home" --session-dir "$base/sessions" \
+    --models-store "$base/pi/models-store.json" --now 2026-08-10T12:00:00Z "$@"
+}
+
+write_baseline() {  # <base>
+  local base=$1
+  write_models "$base/pi/models-store.json"
+  cat > "$base/sessions/slot/one.jsonl" <<EOF
+{"type":"session","version":3,"id":"session-one","timestamp":"2026-08-10T10:00:00Z","cwd":"$base/pool/reused"}
+{"type":"message","id":"user-one","timestamp":"2026-08-10T10:00:01Z","message":{"role":"user","content":"synthetic SECRET-TRANSCRIPT-TEXT; append to '$base/home/state/task-one.status'"}}
+{"type":"message","id":"direct-one","timestamp":"2026-08-10T10:00:02Z","message":{"role":"assistant","provider":"github-copilot","model":"obsolete","responseModel":"preferred","usage":{"input":10,"output":20,"cacheRead":30,"cacheWrite":40,"reasoning":5,"cacheWrite1h":6,"cost":{"total":1.25}}}}
+EOF
+}
+
+test_baseline_and_toon_json_equivalence() {
+  local base json toon
+  base=$(new_fixture baseline)
+  write_baseline "$base"
+  json=$(run_json "$base") || fail "baseline JSON invocation failed"
+  toon=$(run_toon "$base") || fail "baseline TOON invocation failed"
+
+  printf '%s\n' "$json" | jq -e --arg home "$base/home" '
+    .contract == "fm-costs.v1"
+      and .caveat == "Dollar values are list-price valuations, not invoices."
+      and .home == $home
+      and .generated_at == "2026-08-10T12:00:00Z"
+      and .scan.files == 1 and .scan.sessions == 1 and .scan.parse_errors == 0
+      and .primary.sessions == 0
+      and (.tasks | length) == 1
+      and (.tasks[0].task == "task-one" and .tasks[0].sessions == 1
+        and .tasks[0].est_cost_usd == 1.25)
+      and (.tasks[0].models[0]
+        | .model == "github-copilot/preferred"
+          and .origin == "direct" and .calls == 1 and .turns == 1
+          and .tokens == {input:10,output:20,cacheRead:30,cacheWrite:40,reasoning:5,cacheWrite1h:6}
+          and .billing_basis == "subscription"
+          and .cost_source == "pi-stored"
+          and .est_cost_usd == 1.25)
+      and .totals.est_cost_usd == 1.25
+      and .totals.subagent.est_cost_usd == 0
+      and .totals.by_billing_basis.subscription.est_cost_usd == 1.25
+      and (.gaps | length) == 0
+  ' >/dev/null || fail "baseline JSON contract or totals were wrong: $json"
+
+  assert_contains "$toon" 'contract: fm-costs.v1' "TOON must carry the same contract"
+  assert_contains "$toon" 'caveat: Dollar values are list-price valuations, not invoices.' "TOON must carry the exact caveat"
+  assert_contains "$toon" 'task-one: sessions=1 est_cost_usd=1.25' "TOON task cost must equal JSON"
+  assert_contains "$toon" 'direct github-copilot/preferred: calls=1 turns=1 input=10 output=20 cacheRead=30 cacheWrite=40 reasoning=5 cacheWrite1h=6 est_cost_usd=1.25' "TOON model values must equal JSON"
+  assert_contains "$toon" 'totals: est_cost_usd=1.25 known_cost_usd=1.25 unknown_cost_events=0 subagent_est_cost_usd=0' "TOON total values must equal JSON"
+  assert_not_contains "$json$toon" 'SECRET-TRANSCRIPT-TEXT' "neither output may emit transcript content"
+  pass "baseline JSON and TOON carry equivalent stable values without transcript content"
+}
+
+write_complex_fixture() {  # <base>
+  local base=$1 body
+  write_models "$base/pi/models-store.json"
+  mkdir -p "$base/sessions/reused" "$base/sessions/second-slot" "$base/sessions/gaps"
+
+  body="$base/alpha-body"
+  cat > "$body" <<EOF
+{"type":"message","id":"alpha-user","timestamp":"2026-08-10T09:00:01Z","message":{"role":"user","content":"append to '$base/home/state/alpha.status'"}}
+{"type":"message","id":"alpha-direct","timestamp":"2026-08-10T09:00:02Z","message":{"role":"assistant","provider":"github-copilot","model":"preferred","usage":{"input":10,"output":2,"cacheRead":3,"cacheWrite":4,"reasoning":1,"cacheWrite1h":0,"cost":{"total":0.5}}}}
+{"type":"message","id":"alpha-subagents","timestamp":"2026-08-10T09:00:03Z","message":{"role":"toolResult","toolName":"subagent","details":{"results":[{"model":"openai-codex/sub","usage":{"input":100,"output":10,"cacheRead":20,"cacheWrite":1,"reasoning":2,"cacheWrite1h":3,"turns":2,"cost":1}},{"model":"openai-codex/sub","usage":{"input":200,"output":20,"cacheRead":40,"cacheWrite":2,"reasoning":4,"cacheWrite1h":6,"turns":3,"cost":2}}]}}}
+EOF
+  {
+    printf '%s\n' "{\"type\":\"session\",\"version\":3,\"id\":\"alpha-original\",\"timestamp\":\"2026-08-10T09:00:00Z\",\"cwd\":\"$base/pool/reused\"}"
+    cat "$body"
+  } > "$base/sessions/reused/alpha-original.jsonl"
+  {
+    printf '%s\n' "{\"type\":\"session\",\"version\":3,\"id\":\"alpha-fork\",\"timestamp\":\"2026-08-10T09:10:00Z\",\"cwd\":\"$base/pool/second-slot\",\"parentSession\":\"alpha-original.jsonl\"}"
+    cat "$body"
+  } > "$base/sessions/second-slot/alpha-fork.jsonl"
+
+  cat > "$base/sessions/reused/beta.jsonl" <<EOF
+{"type":"session","version":3,"id":"beta-session","timestamp":"2026-08-10T09:20:00Z","cwd":"$base/pool/reused"}
+{"type":"message","id":"beta-user","timestamp":"2026-08-10T09:20:01Z","message":{"role":"user","content":"append to '$base/home/state/beta.status'"}}
+{"type":"message","id":"beta-direct","timestamp":"2026-08-10T09:20:02Z","message":{"role":"assistant","provider":"github-copilot","model":"beta","usage":{"input":4,"output":5,"cacheRead":6,"cacheWrite":7,"reasoning":2,"cacheWrite1h":0,"cost":{"total":0.4}}}}
+{"type":"message","id":"beta-later-user","timestamp":"2026-08-10T09:20:03Z","message":{"role":"user","content":"later mention $base/home/state/not-beta.status must not alter attribution"}}
+EOF
+  printf '%s' '{"type":"message","broken":' >> "$base/sessions/reused/beta.jsonl"
+
+  cat > "$base/sessions/gaps/primary.jsonl" <<EOF
+{"type":"session","version":3,"id":"primary-session","timestamp":"2026-08-10T09:30:00Z","cwd":"$base/home"}
+{"type":"message","id":"primary-user","timestamp":"2026-08-10T09:30:01Z","message":{"role":"user","content":"ordinary primary request"}}
+{"type":"message","id":"primary-direct","timestamp":"2026-08-10T09:30:02Z","message":{"role":"assistant","provider":"github-copilot","model":"primary","usage":{"input":1,"output":2,"cacheRead":3,"cacheWrite":4,"cost":{"total":0.6}}}}
+{"type":"message","id":"primary-later-user","timestamp":"2026-08-10T09:30:03Z","message":{"role":"user","content":"later read $base/home/state/alpha.status and $base/home/state/beta.status"}}
+EOF
+
+  cat > "$base/sessions/gaps/unattributed.jsonl" <<EOF
+{"type":"session","version":3,"id":"ambiguous-session","timestamp":"2026-08-10T09:40:00Z","cwd":"$base/pool/ambiguous"}
+{"type":"message","id":"ambiguous-user","timestamp":"2026-08-10T09:40:01Z","message":{"role":"user","content":"both $base/home/state/one.status and $base/home/state/two.status"}}
+{"type":"message","id":"ambiguous-direct","timestamp":"2026-08-10T09:40:02Z","message":{"role":"assistant","provider":"github-copilot","model":"ambiguous","usage":{"input":7,"output":8,"cacheRead":9,"cacheWrite":10,"cost":{"total":0.7}}}}
+EOF
+
+  cat > "$base/sessions/gaps/other-home.jsonl" <<EOF
+{"type":"session","version":3,"id":"other-session","timestamp":"2026-08-10T09:50:00Z","cwd":"$base/other-pool"}
+{"type":"message","id":"other-user","timestamp":"2026-08-10T09:50:01Z","message":{"role":"user","content":"append to '$base/other-home/state/remote-task.status'"}}
+{"type":"message","id":"other-direct","timestamp":"2026-08-10T09:50:02Z","message":{"role":"assistant","provider":"github-copilot","model":"other","usage":{"input":11,"output":12,"cacheRead":13,"cacheWrite":14,"cost":{"total":2.5}}}}
+EOF
+
+  cat > "$base/sessions/gaps/unknown-cost.jsonl" <<EOF
+{"type":"session","version":3,"id":"unknown-session","timestamp":"2026-08-10T10:00:00Z","cwd":"$base/pool/unknown"}
+{"type":"message","id":"unknown-user","timestamp":"2026-08-10T10:00:01Z","message":{"role":"user","content":"append to '$base/home/state/gamma.status'"}}
+{"type":"message","id":"unknown-direct","timestamp":"2026-08-10T10:00:02Z","message":{"role":"assistant","provider":"github-copilot","model":"unknown-cost","usage":{"input":15,"output":16,"cacheRead":17,"cacheWrite":18,"cost":{"total":"not-known"}}}}
+EOF
+
+  cat > "$base/sessions/gaps/no-header.jsonl" <<EOF
+{"type":"message","id":"ignored-user","timestamp":"2026-08-10T10:10:01Z","message":{"role":"user","content":"$base/home/state/ignored.status"}}
+{"type":"message","id":"ignored-cost","timestamp":"2026-08-10T10:10:02Z","message":{"role":"assistant","provider":"github-copilot","model":"preferred","usage":{"input":999,"cost":{"total":99}}}}
+EOF
+}
+
+test_direct_subagent_dedup_and_attribution() {
+  local base json
+  base=$(new_fixture complex)
+  write_complex_fixture "$base"
+  json=$(run_json "$base") || fail "complex JSON invocation failed"
+
+  printf '%s\n' "$json" | jq -e '
+    .scan.files == 8 and .scan.sessions == 7 and .scan.included_sessions == 6
+      and .scan.parse_errors == 1
+      and .scan.deduplicated_entries == 3
+      and .scan.deduplicated_known_cost_usd == 3.5
+      and .scan.deduplicated_unknown_cost_events == 0
+      and (.tasks[] | select(.task == "alpha")
+        | .sessions == 2 and (has("files") | not)
+          and .est_cost_usd == 3.5
+          and (.models | length) == 2
+          and (.models[] | select(.origin == "direct")
+            | .calls == 1 and .turns == 1 and .est_cost_usd == 0.5)
+          and (.models[] | select(.origin == "subagent")
+            | .model == "openai-codex/sub"
+              and .calls == 2 and .turns == 5
+              and .tokens == {input:300,output:30,cacheRead:60,cacheWrite:3,reasoning:6,cacheWrite1h:9}
+              and .est_cost_usd == 3)
+          and .by_origin.direct.calls == 1
+          and .by_origin.subagent.calls == 2 and .by_origin.subagent.turns == 5
+          and .by_origin.subagent.tokens.input == 300
+          and .by_billing_basis.subscription.est_cost_usd == 3.5
+          and .cost_source == "pi-stored")
+      and (.tasks[] | select(.task == "beta")
+        | .sessions == 1 and .est_cost_usd == 0.4)
+      and ([.tasks[].task] | index("not-beta") == null)
+      and .primary.sessions == 1 and .primary.est_cost_usd == 0.6
+      and .unattributed.sessions == 1 and .unattributed.est_cost_usd == 0.7
+      and (.unattributed.files | length) == 1 and (.unattributed.models | length) == 1
+      and (.other_homes | length) == 1
+      and (.other_homes[0].home | endswith("/other-home"))
+      and .other_homes[0].omitted == true
+      and .other_homes[0].sessions == 1 and .other_homes[0].est_cost_usd == 2.5
+      and (.other_homes[0] | has("models") | not)
+      and .totals.est_cost_usd == null
+      and .totals.known_cost_usd == 5.2
+      and .totals.unknown_cost_events == 1
+      and .totals.subagent.est_cost_usd == 3
+      and .totals.by_billing_basis.subscription.est_cost_usd == null
+      and .totals.by_billing_basis.subscription.known_cost_usd == 5.2
+      and (.gaps | any(.kind == "malformed-lines" and .count == 1))
+      and (.gaps | any(.kind == "no-session-header"))
+      and (.gaps | any(.kind == "unknown-cost" and .model == "github-copilot/unknown-cost" and .count == 1))
+      and (.gaps | any(.kind == "unattributed" and .sessions == 1 and .known_cost_usd == 0.7))
+      and (.gaps | any(.kind == "other-home-omitted" and .sessions == 1 and .known_cost_usd == 2.5))
+  ' >/dev/null || fail "direct/subagent dedup, path reuse, first-user attribution, or gap totals were wrong: $json"
+  pass "direct and subagent calls dedupe by structured origin/index and attribute from only the first user message"
+}
+
+test_missing_metadata_keeps_known_cost_and_unknown_cost_is_not_zero() {
+  local base json
+  base=$(new_fixture cost-gaps)
+  cat > "$base/pi/models-store.json" <<'JSON'
+{"github-copilot":{"models":[{"id":"unknown-cost"}]}}
+JSON
+  cat > "$base/sessions/slot/known-no-metadata.jsonl" <<EOF
+{"type":"session","version":3,"id":"known-session","timestamp":"2026-08-10T11:00:00Z","cwd":"$base/pool"}
+{"type":"message","id":"known-user","timestamp":"2026-08-10T11:00:01Z","message":{"role":"user","content":"$base/home/state/known.status"}}
+{"type":"message","id":"known-call","timestamp":"2026-08-10T11:00:02Z","message":{"role":"assistant","provider":"retired-provider","model":"retired-model","usage":{"input":3,"output":4,"cacheRead":5,"cacheWrite":6,"cost":{"total":4.75}}}}
+EOF
+  cat > "$base/sessions/slot/unknown.jsonl" <<EOF
+{"type":"session","version":3,"id":"unknown-session","timestamp":"2026-08-10T11:10:00Z","cwd":"$base/pool"}
+{"type":"message","id":"unknown-user","timestamp":"2026-08-10T11:10:01Z","message":{"role":"user","content":"$base/home/state/unknown.status"}}
+{"type":"message","id":"unknown-call","timestamp":"2026-08-10T11:10:02Z","message":{"role":"assistant","provider":"github-copilot","model":"unknown-cost","usage":{"input":7,"output":8,"cacheRead":9,"cacheWrite":10,"cost":{"total":null}}}}
+EOF
+  json=$(run_json "$base") || fail "cost-gap JSON invocation failed"
+  printf '%s\n' "$json" | jq -e '
+    (.tasks[] | select(.task == "known")
+      | .est_cost_usd == 4.75 and .known_cost_usd == 4.75 and .unknown_cost_events == 0
+        and .models[0].est_cost_usd == 4.75
+        and .models[0].cost_source == "pi-stored")
+      and (.gaps | any(.kind == "missing-model-metadata"
+        and .model == "retired-provider/retired-model"))
+      and (.tasks[] | select(.task == "unknown")
+        | .est_cost_usd == null and .known_cost_usd == 0 and .unknown_cost_events == 1
+          and .models[0].est_cost_usd == null
+          and .models[0].known_cost_usd == 0
+          and .models[0].unknown_cost_events == 1)
+      and .totals.est_cost_usd == null
+      and .totals.known_cost_usd == 4.75
+      and .totals.unknown_cost_events == 1
+  ' >/dev/null || fail "known stored cost or unknown-cost null propagation was wrong: $json"
+  pass "stored cost survives missing model metadata and unknown cost propagates as null, never zero"
+}
+
+test_models_store_missing_and_corrupt_are_labelled() {
+  local base missing corrupt
+  base=$(new_fixture model-store-state)
+  cat > "$base/sessions/slot/one.jsonl" <<EOF
+{"type":"session","version":3,"id":"one","timestamp":"2026-08-10T11:20:00Z","cwd":"$base/home"}
+{"type":"message","id":"user","timestamp":"2026-08-10T11:20:01Z","message":{"role":"user","content":"primary"}}
+{"type":"message","id":"call","timestamp":"2026-08-10T11:20:02Z","message":{"role":"assistant","provider":"github-copilot","model":"preferred","usage":{"input":1,"cost":{"total":0.25}}}}
+EOF
+  missing=$(run_json "$base") || fail "missing models-store run failed"
+  printf '%s\n' "$missing" | jq -e '
+    .inputs.models_store_state == "missing"
+      and .totals.est_cost_usd == 0.25
+      and (.gaps | any(.kind == "models-store-missing"))
+      and (.gaps | any(.kind == "missing-model-metadata"))
+  ' >/dev/null || fail "missing models store was not a labelled non-cost gap: $missing"
+  printf '{broken' > "$base/pi/models-store.json"
+  corrupt=$(run_json "$base") || fail "corrupt models-store run failed"
+  printf '%s\n' "$corrupt" | jq -e '
+    .inputs.models_store_state == "corrupt"
+      and .totals.est_cost_usd == 0.25
+      and (.gaps | any(.kind == "models-store-corrupt"))
+  ' >/dev/null || fail "corrupt models store was not a labelled non-cost gap: $corrupt"
+  pass "missing and corrupt models stores remain labelled while stored costs stay authoritative"
+}
+
+test_default_home_scan_is_read_only_and_network_free() {
+  local base agent home_dir fakebin before after json calls
+  base=$(new_fixture readonly)
+  home_dir="$base/operator-home"
+  agent="$home_dir/.pi/agent"
+  mkdir -p "$agent/sessions/default-slot" "$base/report-home" "$base/fakebin"
+  write_models "$agent/models-store.json"
+  cat > "$agent/sessions/default-slot/default.jsonl" <<EOF
+{"type":"session","version":3,"id":"default-session","timestamp":"2026-08-10T11:30:00Z","cwd":"$base/report-home"}
+{"type":"message","id":"default-user","timestamp":"2026-08-10T11:30:01Z","message":{"role":"user","content":"default scan with PRIVATE-SYNTHETIC-CONTENT"}}
+{"type":"message","id":"default-call","timestamp":"2026-08-10T11:30:02Z","message":{"role":"assistant","provider":"github-copilot","model":"primary","usage":{"input":2,"output":3,"cacheRead":4,"cacheWrite":5,"cost":{"total":0.75}}}}
+EOF
+  calls="$base/network-calls"
+  : > "$calls"
+  for tool in curl wget gh gh-axi quota-axi; do
+    cat > "$base/fakebin/$tool" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$0 $*" >> "$NETWORK_CALLS"
+exit 99
+SH
+    chmod +x "$base/fakebin/$tool"
+  done
+  before=$(find "$home_dir" -type f -print | LC_ALL=C sort; find "$home_dir" -type f -exec cksum {} \; | LC_ALL=C sort)
+  chmod -R a-w "$home_dir"
+  json=$(env -u FM_HOME -u FM_COSTS_HOME -u FM_COSTS_SESSION_DIR \
+    -u FM_COSTS_MODELS_STORE -u FM_COSTS_NOW \
+    HOME="$home_dir" PATH="$base/fakebin:$PATH" NETWORK_CALLS="$calls" \
+    "$COSTS" --json --home "$base/report-home" --now 2026-08-10T12:00:00Z) \
+    || fail "default read-only invocation failed"
+  after=$(find "$home_dir" -type f -print | LC_ALL=C sort; find "$home_dir" -type f -exec cksum {} \; | LC_ALL=C sort)
+  chmod -R u+w "$home_dir"
+  [ "$before" = "$after" ] || fail "report changed its synthetic Pi input tree"
+  [ ! -s "$calls" ] || fail "report invoked a network-capable command: $(cat "$calls")"
+  printf '%s\n' "$json" | jq -e --arg home "$base/report-home" '
+    .home == $home and .inputs == {models_store_state:"ok"} and .scan.files == 1
+      and .primary.sessions == 1 and .totals.est_cost_usd == 0.75
+      and .caveat == "Dollar values are list-price valuations, not invoices."
+  ' >/dev/null || fail "default HOME scan did not use only the synthetic Pi store: $json"
+  assert_not_contains "$json" 'PRIVATE-SYNTHETIC-CONTENT' "JSON must not copy transcript content"
+  pass "default HOME scan is hermetic, read-only, network-free, and transcript-safe"
+}
+
+test_env_overrides_are_hermetic() {
+  local base json
+  base=$(new_fixture env-overrides)
+  write_baseline "$base"
+  json=$(FM_COSTS_HOME="$base/home" \
+    FM_COSTS_SESSION_DIR="$base/sessions" \
+    FM_COSTS_MODELS_STORE="$base/pi/models-store.json" \
+    FM_COSTS_NOW=2026-08-10T12:34:56Z \
+    HOME="$base/empty-home" "$COSTS" --json) || fail "environment override run failed"
+  printf '%s\n' "$json" | jq -e '
+    .contract == "fm-costs.v1"
+      and .generated_at == "2026-08-10T12:34:56Z"
+      and .scan.files == 1 and .tasks[0].task == "task-one"
+  ' >/dev/null || fail "environment overrides did not select the synthetic fixture: $json"
+  pass "home, session-dir, models-store, and clock environment overrides are hermetic"
+}
+
+test_baseline_and_toon_json_equivalence
+test_direct_subagent_dedup_and_attribution
+test_missing_metadata_keeps_known_cost_and_unknown_cost_is_not_zero
+test_models_store_missing_and_corrupt_are_labelled
+test_default_home_scan_is_read_only_and_network_free
+test_env_overrides_are_hermetic

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -72,6 +72,18 @@ enable_dispatch_profile() {
     > "$home/config/crew-dispatch.json"
 }
 
+write_subagent_config() {
+  local path=$1 model=$2 effort=$3
+  jq -n --arg model "$model" --arg effort "$effort" '{
+    maxConcurrency: 3,
+    modelTiers: {
+      cheap: {workloads: [{key:"w1", description:"cheap", model:"openai/gpt-cheap", thinkingLevel:"minimal"}]},
+      balanced: {workloads: [{key:"w2", description:"balanced", model:$model, thinkingLevel:$effort}]},
+      strong: {workloads: [{key:"w3", description:"strong", model:"openai/gpt-strong", thinkingLevel:"max"}]}
+    }
+  }' > "$path"
+}
+
 make_seeded_secondmate_home() {
   local home=$1 id=$2
   mkdir -p "$home/bin" "$home/data"
@@ -93,6 +105,8 @@ run_spawn() {
     FM_PROJECTS_OVERRIDE="$home/projects" FM_CONFIG_OVERRIDE="$home/config" \
     FM_SPAWN_NO_GUARD=1 FM_FAKE_PANE_PATH="$wt" TMUX="fake,1,0" \
     CLAUDE_CONFIG_DIR="${FM_TEST_CLAUDE_CONFIG_DIR:-}" \
+    PI_CODING_AGENT_DIR="${FM_TEST_PI_CODING_AGENT_DIR:-}" \
+    FM_SUBAGENTS_CONFIG="${FM_TEST_SUBAGENTS_CONFIG:-}" \
     FM_FAKE_LAUNCH_LOG="$launchlog" GROK_HOME="$home/grok-home" PATH="$fakebin:$PATH" \
     "$SPAWN" "$@" 2>&1
 }
@@ -606,6 +620,213 @@ test_batch_forwards_shared_profile_flags() {
   pass "batch dispatch forwards shared --harness, --model, and --effort to every pair"
 }
 
+test_pi_source_route_uses_live_resolution() {
+  local rec id config out status launch meta current
+  id=profile-source-valid-z20
+  rec=$(make_spawn_case profile-source-valid pi "$id")
+  read_case_record "$rec"
+  config="$CASE_DIR/subagents.json"
+  write_subagent_config "$config" openai/gpt-balanced high
+
+  out=$(FM_TEST_SUBAGENTS_CONFIG="$config" run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" \
+    "$id" "$PROJ_DIR" --harness pi --model openai/gpt-balanced --effort high \
+    --source-tier balanced --source-workload w2)
+  status=$?
+  expect_code 0 "$status" "valid live Pi source route should spawn"
+  assert_contains "$out" "source=pi-subagents tier=balanced workload=w2" \
+    "source-routed spawn output omitted its source identity"
+  meta="$HOME_DIR/state/$id.meta"
+  assert_grep 'dispatch_source=pi-subagents' "$meta" "source route meta omitted dispatch_source"
+  assert_grep 'dispatch_tier=balanced' "$meta" "source route meta omitted dispatch_tier"
+  assert_grep 'dispatch_workload=w2' "$meta" "source route meta omitted dispatch_workload"
+  [ "$(grep -c '^dispatch_source=' "$meta")" -eq 1 ] || fail "source route meta duplicated dispatch_source"
+  [ "$(grep -c '^dispatch_tier=' "$meta")" -eq 1 ] || fail "source route meta duplicated dispatch_tier"
+  [ "$(grep -c '^dispatch_workload=' "$meta")" -eq 1 ] || fail "source route meta duplicated dispatch_workload"
+  launch=$(cat "$LAUNCH_LOG")
+  assert_contains "$launch" "FM_PI_HARNESS=pi pi --model 'openai/gpt-balanced' --thinking 'high'" \
+    "live Pi source route did not reach launch construction"
+  fm_fake_exit0 "$FAKEBIN_DIR" no-mistakes
+  current=$(FM_STATE_OVERRIDE="$HOME_DIR/state" PATH="$FAKEBIN_DIR:$PATH" \
+    "$ROOT/bin/fm-crew-state.sh" "$id")
+  assert_contains "$current" "state: working · source: pane" \
+    "public crew-state parser did not accept generated source-route metadata"
+  pass "live Pi source routes launch, record source identity, and remain parser-compatible"
+}
+
+test_pi_source_route_rejects_stale_args_then_accepts_fresh_args() {
+  local rec id config out status
+  id=profile-source-fresh-z21
+  rec=$(make_spawn_case profile-source-fresh pi "$id")
+  read_case_record "$rec"
+  config="$CASE_DIR/subagents.json"
+  write_subagent_config "$config" openai/old-model medium
+  write_subagent_config "$config" openai/new-model xhigh
+
+  out=$(FM_TEST_SUBAGENTS_CONFIG="$config" run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" \
+    "$id" "$PROJ_DIR" --harness pi --model openai/old-model --effort medium \
+    --source-tier balanced --source-workload w2)
+  status=$?
+  expect_code 1 "$status" "stale concrete source args should be refused"
+  assert_contains "$out" "fresh source requires model=openai/new-model effort=xhigh; re-resolve and retry" \
+    "stale route refusal was not actionable"
+  assert_absent "$HOME_DIR/state/$id.meta" "stale source args wrote metadata"
+  [ ! -s "$LAUNCH_LOG" ] || fail "stale source args launched an endpoint"
+
+  out=$(FM_TEST_SUBAGENTS_CONFIG="$config" run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" \
+    "$id" "$PROJ_DIR" --harness pi --model openai/new-model --effort xhigh \
+    --source-tier balanced --source-workload w2)
+  status=$?
+  expect_code 0 "$status" "fresh concrete source args should spawn"
+  pass "source routes re-read live configuration and refuse stale concrete args"
+}
+
+test_source_route_invalid_source_stops_before_metadata() {
+  local rec id config out status
+  id=profile-source-invalid-z22
+  rec=$(make_spawn_case profile-source-invalid pi "$id")
+  read_case_record "$rec"
+  config="$CASE_DIR/malformed.json"
+  printf '{bad json\n' > "$config"
+
+  out=$(FM_TEST_SUBAGENTS_CONFIG="$config" run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" \
+    "$id" "$PROJ_DIR" --harness pi --model openai/model --effort high \
+    --source-tier balanced --source-workload w2)
+  status=$?
+  expect_code 1 "$status" "malformed source should stop spawn"
+  assert_contains "$out" "SUBAGENTS_CONFIG: invalid" "malformed source diagnostic was lost"
+  assert_absent "$HOME_DIR/state/$id.meta" "malformed source wrote metadata"
+  [ ! -s "$LAUNCH_LOG" ] || fail "malformed source launched an endpoint"
+
+  out=$(FM_TEST_SUBAGENTS_CONFIG="$CASE_DIR/absent.json" run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" \
+    "$id" "$PROJ_DIR" --harness pi --model openai/model --effort high \
+    --source-tier balanced --source-workload w2)
+  status=$?
+  expect_code 1 "$status" "missing explicit source should stop spawn"
+  assert_contains "$out" "FM_SUBAGENTS_CONFIG is not a regular file" "missing source diagnostic was lost"
+  assert_absent "$HOME_DIR/state/$id.meta" "missing source wrote metadata"
+  pass "invalid and missing live sources stop before metadata or launch"
+}
+
+test_legacy_explicit_profile_bypasses_malformed_source() {
+  local rec id config out status
+  id=profile-source-bypass-z23
+  rec=$(make_spawn_case profile-source-bypass pi "$id")
+  read_case_record "$rec"
+  config="$CASE_DIR/malformed.json"
+  printf '{bad json\n' > "$config"
+
+  out=$(FM_TEST_SUBAGENTS_CONFIG="$config" run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" \
+    "$id" "$PROJ_DIR" --harness pi --model openai/captain --effort high)
+  status=$?
+  expect_code 0 "$status" "legacy explicit profile should not read malformed source"
+  assert_meta_profile "$HOME_DIR/state/$id.meta" pi openai/captain high
+  assert_not_contains "$out" "SUBAGENTS_CONFIG" "legacy explicit profile unexpectedly read source"
+  pass "explicit legacy harness/model/effort bypass live source resolution"
+}
+
+test_source_route_requires_paired_flags_and_verified_pi_harness() {
+  local rec id sm out status
+  id=profile-source-contract-z24
+  rec=$(make_spawn_case profile-source-contract pi "$id")
+  read_case_record "$rec"
+
+  out=$(run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" \
+    "$id" "$PROJ_DIR" --harness pi --model openai/model --effort high --source-tier balanced)
+  status=$?
+  expect_code 1 "$status" "unpaired source flags should fail"
+  assert_contains "$out" "--source-tier and --source-workload are required together" "paired-flag refusal missing"
+
+  out=$(run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" \
+    "$id" "$PROJ_DIR" --model openai/model --effort high \
+    --source-tier balanced --source-workload w2)
+  status=$?
+  expect_code 1 "$status" "source route without explicit harness should fail"
+  assert_contains "$out" "require explicit --harness pi or --harness pi-signed" "explicit harness requirement missing"
+
+  out=$(run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" \
+    "$id" "$PROJ_DIR" --harness pi --effort high \
+    --source-tier balanced --source-workload w2)
+  status=$?
+  expect_code 1 "$status" "source route without explicit model should fail"
+  assert_contains "$out" "require explicit --model" "explicit model requirement missing"
+
+  out=$(run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" \
+    "$id" "$PROJ_DIR" --harness pi --model openai/model \
+    --source-tier balanced --source-workload w2)
+  status=$?
+  expect_code 1 "$status" "source route without explicit effort should fail"
+  assert_contains "$out" "require explicit --effort" "explicit effort requirement missing"
+
+  out=$(run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" \
+    "$id" "$PROJ_DIR" --harness codex --model openai/model --effort high \
+    --source-tier balanced --source-workload w2)
+  status=$?
+  expect_code 1 "$status" "non-Pi source harness should fail"
+  assert_contains "$out" "require verified --harness pi or --harness pi-signed" "incompatible harness refusal missing"
+
+  out=$(run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" \
+    "$id" "$PROJ_DIR" --harness 'custom-agent --raw' --model openai/model --effort high \
+    --source-tier balanced --source-workload w2)
+  status=$?
+  expect_code 1 "$status" "raw source route should fail"
+  assert_contains "$out" "require verified --harness pi or --harness pi-signed" "raw route refusal missing"
+
+  sm="$CASE_DIR/secondmate-home"
+  make_seeded_secondmate_home "$sm" "$id"
+  out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" \
+    "$id" "$sm" --secondmate --harness pi --model openai/model --effort high \
+    --source-tier balanced --source-workload w2)
+  status=$?
+  expect_code 1 "$status" "secondmate source route should fail"
+  assert_contains "$out" "not allowed on --secondmate spawns" "secondmate source-route refusal missing"
+  assert_absent "$HOME_DIR/state/$id.meta" "invalid source route contract wrote metadata"
+  pass "source route flags are paired and restricted to explicit verified Pi harnesses"
+}
+
+test_pi_off_and_minimal_thinking_propagate() {
+  local rec off_id minimal_id out status launch
+  off_id=profile-pi-off-z25
+  minimal_id=profile-pi-minimal-z26
+  rec=$(make_spawn_case profile-pi-low-vocab pi "$off_id" "$minimal_id")
+  read_case_record "$rec"
+
+  out=$(run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" \
+    "$off_id" "$PROJ_DIR" --harness pi --model openai/model --effort off)
+  status=$?
+  expect_code 0 "$status" "Pi off thinking should parse and spawn"
+  launch=$(cat "$LAUNCH_LOG")
+  assert_contains "$launch" "--thinking 'off'" "Pi off thinking was not propagated"
+
+  out=$(run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" \
+    "$minimal_id" "$PROJ_DIR" --harness pi --model openai/model --effort minimal)
+  status=$?
+  expect_code 0 "$status" "Pi minimal thinking should parse and spawn"
+  launch=$(cat "$LAUNCH_LOG")
+  assert_contains "$launch" "--thinking 'minimal'" "Pi minimal thinking was not propagated"
+  pass "Pi propagates off and minimal through its full thinking vocabulary"
+}
+
+test_batch_forwards_live_source_flags() {
+  local rec id1 id2 config out status
+  id1=profile-source-batch-a-z27
+  id2=profile-source-batch-b-z28
+  rec=$(make_spawn_case profile-source-batch pi "$id1" "$id2")
+  read_case_record "$rec"
+  config="$CASE_DIR/subagents.json"
+  write_subagent_config "$config" openai/batch medium
+
+  out=$(FM_TEST_SUBAGENTS_CONFIG="$config" run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" \
+    "$id1=$PROJ_DIR" "$id2=$PROJ_DIR" --harness pi --model openai/batch --effort medium \
+    --source-tier balanced --source-workload w2)
+  status=$?
+  expect_code 0 "$status" "batch source route should spawn every task"
+  assert_grep 'dispatch_source=pi-subagents' "$HOME_DIR/state/$id1.meta" "first batch task lost source flags"
+  assert_grep 'dispatch_source=pi-subagents' "$HOME_DIR/state/$id2.meta" "second batch task lost source flags"
+  assert_contains "$out" "spawned $id1 harness=pi" "first source batch task did not spawn"
+  assert_contains "$out" "spawned $id2 harness=pi" "second source batch task did not spawn"
+  pass "batch dispatch forwards both live source flags"
+}
+
 test_claude_forwards_firstmate_config_dir_when_set() {
   local rec id out status launch
   id=profile-claude-cfgdir-z17
@@ -695,6 +916,13 @@ test_pi_signed_threads_shared_pi_profile_and_preserves_identity
 test_pi_signed_missing_binary_refuses_before_endpoint_or_metadata
 test_pi_signed_persistent_secondmate_uses_pi_extensions_and_identity
 test_batch_forwards_shared_profile_flags
+test_pi_source_route_uses_live_resolution
+test_pi_source_route_rejects_stale_args_then_accepts_fresh_args
+test_source_route_invalid_source_stops_before_metadata
+test_legacy_explicit_profile_bypasses_malformed_source
+test_source_route_requires_paired_flags_and_verified_pi_harness
+test_pi_off_and_minimal_thinking_propagate
+test_batch_forwards_live_source_flags
 test_claude_forwards_firstmate_config_dir_when_set
 test_claude_omits_config_dir_prefix_when_unset
 test_non_claude_harness_ignores_config_dir

--- a/tests/fm-subagent-dispatch.test.sh
+++ b/tests/fm-subagent-dispatch.test.sh
@@ -1,0 +1,250 @@
+#!/usr/bin/env bash
+# Behavioral coverage for live Pi subagent config source selection, exact schema
+# validation, and public workload resolution.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+TMP_ROOT=$(fm_test_tmproot fm-subagent-dispatch)
+DISPATCH="$ROOT/bin/fm-subagent-dispatch.sh"
+
+write_valid_config() {
+  local path=$1 cheap_model=${2:-vendor/cheap} cheap_thinking=${3:-minimal}
+  mkdir -p "$(dirname "$path")"
+  cat >"$path" <<JSON
+{
+  "maxConcurrency": 3,
+  "modelTiers": {
+    "cheap": {
+      "workloads": [
+        {"key":"w1","description":"Quick routing","model":"$cheap_model","thinkingLevel":"$cheap_thinking"},
+        {"key":"w2","description":"Second quick route","model":"vendor/cheap-two","thinkingLevel":"low"}
+      ]
+    },
+    "balanced": {
+      "workloads": [
+        {"key":"w1","description":"Normal implementation","model":"vendor/balanced","thinkingLevel":"medium"}
+      ]
+    },
+    "strong": {
+      "workloads": [
+        {"key":"w9","description":"Hard investigation","model":"vendor/strong","thinkingLevel":"xhigh"}
+      ]
+    }
+  }
+}
+JSON
+}
+
+run_override() {
+  local config=$1
+  shift
+  PI_CODING_AGENT_DIR= FM_SUBAGENTS_CONFIG="$config" HOME="$TMP_ROOT/no-home" \
+    "$DISPATCH" "$@"
+}
+
+expect_invalid() {
+  local config=$1 expected=$2 out rc
+  set +e
+  out=$(run_override "$config" list 2>&1)
+  rc=$?
+  set -e
+  expect_code 3 "$rc" "invalid subagent config"
+  assert_contains "$out" "SUBAGENTS_CONFIG: invalid $config -" \
+    "invalid config did not identify its selected source"
+  assert_contains "$out" "$expected" "invalid config reason was not concrete"
+}
+
+test_fixture_resolution_and_list_json() {
+  local config="$TMP_ROOT/fixture/config.json" out
+  write_valid_config "$config"
+
+  out=$(run_override "$config" resolve balanced w1)
+  printf '%s' "$out" | jq -e --arg source "$config" '
+    .source == $source and .tier == "balanced" and .workload == "w1" and
+    .model == "vendor/balanced" and .effort == "medium" and
+    .description == "Normal implementation"
+  ' >/dev/null || fail "resolve did not return the selected validated routing entry"
+
+  out=$(run_override "$config" list)
+  printf '%s' "$out" | jq -e --arg source "$config" '
+    .source == $source and .maxConcurrency == 3 and
+    (.tiers | keys | sort) == ["balanced", "cheap", "strong"] and
+    .tiers.cheap[1].workload == "w2" and .tiers.strong[0].description == "Hard investigation"
+  ' >/dev/null || fail "list did not emit parseable validated routing JSON"
+  [ "$(run_override "$config" path)" = "$config" ] || fail "path did not print the selected source"
+  pass "fixture path, list, and resolve expose validated routing through the public command"
+}
+
+test_optional_concurrency_and_extension_model_shape() {
+  local config="$TMP_ROOT/extension-shape/config.json" temp="$TMP_ROOT/extension-shape/temp.json" out
+  write_valid_config "$config" 'vendor/model/with internal spaces/end' low
+  jq 'del(.maxConcurrency)' "$config" >"$temp" && mv "$temp" "$config"
+
+  out=$(run_override "$config" list)
+  printf '%s' "$out" | jq -e '
+    .maxConcurrency == 4 and
+    .tiers.cheap[0].model == "vendor/model/with internal spaces/end"
+  ' >/dev/null || fail "omitted maxConcurrency or additional-slash model did not match extension behavior"
+  pass "omitted maxConcurrency defaults to 4 and extension-shaped model suffixes are accepted"
+}
+
+test_live_edit_is_seen_on_next_call() {
+  local config="$TMP_ROOT/live/config.json" replacement="$TMP_ROOT/live/replacement.json" out
+  write_valid_config "$config" vendor/before low
+  out=$(run_override "$config" resolve cheap w1)
+  [ "$(printf '%s' "$out" | jq -r .model)" = vendor/before ] || fail "initial live model was not read"
+
+  jq '.modelTiers.cheap.workloads[0].model = "vendor/after" |
+      .modelTiers.cheap.workloads[0].thinkingLevel = "high"' \
+    "$config" >"$replacement"
+  mv "$replacement" "$config"
+  out=$(run_override "$config" resolve cheap w1)
+  printf '%s' "$out" | jq -e '.model == "vendor/after" and .effort == "high"' >/dev/null \
+    || fail "next invocation did not reread the edited live source"
+  pass "each invocation sees the next live config edit"
+}
+
+test_source_precedence_and_fallbacks() {
+  local pi_root="$TMP_ROOT/pi-root" pi_config override home="$TMP_ROOT/home" home_config out rc
+  pi_config="$pi_root/extensions/subagents/config.json"
+  override="$TMP_ROOT/override/config.json"
+  home_config="$home/.pi/agent/extensions/subagents/config.json"
+  write_valid_config "$pi_config" pi/model low
+  write_valid_config "$override" override/model high
+  write_valid_config "$home_config" home/model medium
+
+  out=$(PI_CODING_AGENT_DIR="$pi_root" FM_SUBAGENTS_CONFIG="$override" HOME="$home" \
+    "$DISPATCH" resolve cheap w1)
+  printf '%s' "$out" | jq -e --arg source "$pi_config" \
+    '.source == $source and .model == "pi/model"' >/dev/null \
+    || fail "PI_CODING_AGENT_DIR regular candidate did not take precedence"
+
+  out=$(PI_CODING_AGENT_DIR="$TMP_ROOT/pi-missing" FM_SUBAGENTS_CONFIG="$override" HOME="$home" \
+    "$DISPATCH" resolve cheap w1)
+  printf '%s' "$out" | jq -e --arg source "$override" \
+    '.source == $source and .model == "override/model"' >/dev/null \
+    || fail "FM_SUBAGENTS_CONFIG did not act as the temporary override"
+
+  out=$(PI_CODING_AGENT_DIR= FM_SUBAGENTS_CONFIG= HOME="$home" "$DISPATCH" resolve cheap w1)
+  printf '%s' "$out" | jq -e --arg source "$home_config" \
+    '.source == $source and .model == "home/model"' >/dev/null \
+    || fail "HOME config was not used as the final fallback"
+
+  set +e
+  out=$(PI_CODING_AGENT_DIR= FM_SUBAGENTS_CONFIG=relative/config.json HOME="$home" \
+    "$DISPATCH" list 2>&1)
+  rc=$?
+  set -e
+  expect_code 3 "$rc" "relative explicit override"
+  assert_contains "$out" 'FM_SUBAGENTS_CONFIG must be an absolute path' \
+    "relative explicit override did not fail actionably"
+
+  set +e
+  out=$(PI_CODING_AGENT_DIR= FM_SUBAGENTS_CONFIG="$TMP_ROOT/missing.json" HOME="$home" \
+    "$DISPATCH" list 2>&1)
+  rc=$?
+  set -e
+  expect_code 3 "$rc" "missing explicit override"
+  assert_contains "$out" 'FM_SUBAGENTS_CONFIG is not a regular file' \
+    "missing explicit override silently fell through to HOME"
+  pass "Pi, explicit override, and HOME source precedence is deterministic and actionable"
+}
+
+test_secondmate_home_uses_pi_source_without_copying_config() {
+  local secondmate="$TMP_ROOT/secondmate-home" pi_root="$TMP_ROOT/secondmate-pi-root"
+  local pi_config="$TMP_ROOT/secondmate-pi-root/extensions/subagents/config.json"
+  local override="$TMP_ROOT/secondmate-override.json" home="$TMP_ROOT/secondmate-user-home" out entries
+  mkdir -p "$secondmate"
+  printf '%s\n' secondmate > "$secondmate/.fm-secondmate-home"
+  write_valid_config "$pi_config" pi/secondmate-source minimal
+  write_valid_config "$override" override/secondmate-source high
+  write_valid_config "$home/.pi/agent/extensions/subagents/config.json" home/secondmate-source medium
+
+  out=$(FM_HOME="$secondmate" PI_CODING_AGENT_DIR="$pi_root" FM_SUBAGENTS_CONFIG="$override" HOME="$home" \
+    "$DISPATCH" resolve cheap w1)
+  printf '%s' "$out" | jq -e --arg source "$pi_config" \
+    '.source == $source and .model == "pi/secondmate-source" and .effort == "minimal"' >/dev/null \
+    || fail "fake secondmate home did not resolve the Pi source independently of FM_HOME"
+  entries=$(ls -A "$secondmate")
+  [ "$entries" = .fm-secondmate-home ] \
+    || fail "public helper copied config or model data into the fake secondmate home: $entries"
+  pass "fake secondmate homes resolve PI_CODING_AGENT_DIR without copied config or model data"
+}
+
+test_malformed_and_exact_schema_rejections() {
+  local malformed="$TMP_ROOT/invalid/malformed.json" missing_tier="$TMP_ROOT/invalid/missing-tier.json"
+  local duplicate="$TMP_ROOT/invalid/duplicate.json" empty="$TMP_ROOT/invalid/empty.json"
+  local thinking="$TMP_ROOT/invalid/thinking.json" model="$TMP_ROOT/invalid/model.json"
+  local line_model="$TMP_ROOT/invalid/line-model.json" nul="$TMP_ROOT/invalid/nul.json" temp
+  mkdir -p "$TMP_ROOT/invalid"
+  printf '{not json\n' >"$malformed"
+  expect_invalid "$malformed" 'malformed JSON'
+
+  printf '{"maxConcurrency":3,"modelTiers":\0{}}\n' >"$nul"
+  expect_invalid "$nul" 'malformed JSON'
+
+  write_valid_config "$missing_tier"
+  temp="$TMP_ROOT/invalid/temp.json"
+  jq 'del(.modelTiers.strong)' "$missing_tier" >"$temp" && mv "$temp" "$missing_tier"
+  expect_invalid "$missing_tier" 'modelTiers must contain exactly cheap, balanced, strong'
+
+  write_valid_config "$duplicate"
+  jq '.modelTiers.cheap.workloads[1].key = "w1"' "$duplicate" >"$temp" && mv "$temp" "$duplicate"
+  expect_invalid "$duplicate" 'workload keys must be unique within the tier'
+
+  write_valid_config "$empty"
+  jq '.modelTiers.balanced.workloads = []' "$empty" >"$temp" && mv "$temp" "$empty"
+  expect_invalid "$empty" 'modelTiers.balanced.workloads must be nonempty'
+
+  write_valid_config "$thinking" vendor/model impossible
+  expect_invalid "$thinking" 'workload thinkingLevel is unsupported'
+
+  write_valid_config "$model" 'vendor /model' low
+  expect_invalid "$model" 'workload model must match'
+
+  write_valid_config "$line_model"
+  jq '.modelTiers.cheap.workloads[0].model = "vendor/a\rb"' "$line_model" >"$temp" && mv "$temp" "$line_model"
+  expect_invalid "$line_model" 'workload model must match'
+  pass "malformed JSON including NUL bytes and exact-schema violations are rejected with concrete diagnostics"
+}
+
+test_unknown_resolution_and_absent_source() {
+  local config="$TMP_ROOT/resolution/config.json" out rc empty_home="$TMP_ROOT/empty-home"
+  write_valid_config "$config"
+  set +e
+  out=$(run_override "$config" resolve cheap w404 2>&1)
+  rc=$?
+  set -e
+  expect_code 5 "$rc" "unknown workload"
+  assert_contains "$out" "unknown workload 'w404' in tier 'cheap'" \
+    "unknown workload did not identify its tier and key"
+
+  set +e
+  out=$(run_override "$config" resolve impossible w1 2>&1)
+  rc=$?
+  set -e
+  expect_code 5 "$rc" "unknown tier"
+  assert_contains "$out" "unknown tier 'impossible'" "unknown tier was not actionable"
+
+  mkdir -p "$empty_home"
+  set +e
+  out=$(PI_CODING_AGENT_DIR="$TMP_ROOT/no-pi" FM_SUBAGENTS_CONFIG= HOME="$empty_home" \
+    "$DISPATCH" list 2>&1)
+  rc=$?
+  set -e
+  expect_code 4 "$rc" "absent source"
+  assert_contains "$out" 'SOURCE_ABSENT:' "absent source did not emit its observable diagnostic"
+  pass "unknown routes and absent source use documented distinct failures"
+}
+
+test_fixture_resolution_and_list_json
+test_optional_concurrency_and_extension_model_shape
+test_live_edit_is_seen_on_next_call
+test_source_precedence_and_fallbacks
+test_secondmate_home_uses_pi_source_without_copying_config
+test_malformed_and_exact_schema_rejections
+test_unknown_resolution_and_absent_source
+
+echo '# all fm-subagent-dispatch tests passed'


### PR DESCRIPTION
## Summary
- add read-only `fm-costs.v1` reporting for direct and subagent Pi usage
- attribute usage to Firstmate tasks, deduplicate fork copies, and surface honest cost gaps
- add hermetic synthetic behavior coverage for privacy, attribution, cost, and output contracts

## Validation
- `bin/fm-test-run.sh tests/fm-costs.test.sh` passes
- `bin/fm-lint.sh bin/fm-costs.sh tests/fm-costs.test.sh` passes with ShellCheck 0.11.0
- full `bin/fm-lint.sh` currently reports pre-existing SC2100 warnings in `bin/fm-spawn.sh` and SC1007 warnings in `tests/fm-subagent-dispatch.test.sh` outside this change