### PR TITLE
docs: require deliberate context discipline

### DIFF
--- a/.agents/skills/stuck-crewmate-recovery/SKILL.md
+++ b/.agents/skills/stuck-crewmate-recovery/SKILL.md
@@ -44,7 +44,6 @@ Escalate in order:
    For example, for a single-Escape adapter: `FM_HOME=<this-firstmate-home> bin/fm-send.sh <window> --key Escape`.
 4. If the crewmate is genuinely wedged after redirection, exit the agent with the adapter's exit command and relaunch with the same brief plus a `progress so far` note appended to it.
    Genuine wedging means looping, unresponsive, repeating the same obstacle, or truly dead.
-   A low context reading is not wedging by itself and never justifies exiting a working crewmate.
-   The fleet runs with harness auto-compact off, so treat it as a cue to redirect through step 3: tell the crewmate to write its live state to its durable file and compact deliberately.
+   A low context reading is not wedging and is never grounds to interrupt, exit, or relaunch a working crewmate, but with harness auto-compact off it is no longer harmless, so note it.
    The worktree and commits persist, so relaunch is cheap.
 5. If a second relaunch fails too, write `failed` to the backlog and tell the captain the plain failure, preserved work, and consequence using `AGENTS.md` section 9; do not mention metadata, harness, window, or worktree unless the path itself is needed for action.

--- a/.agents/skills/stuck-crewmate-recovery/SKILL.md
+++ b/.agents/skills/stuck-crewmate-recovery/SKILL.md
@@ -44,6 +44,7 @@ Escalate in order:
    For example, for a single-Escape adapter: `FM_HOME=<this-firstmate-home> bin/fm-send.sh <window> --key Escape`.
 4. If the crewmate is genuinely wedged after redirection, exit the agent with the adapter's exit command and relaunch with the same brief plus a `progress so far` note appended to it.
    Genuine wedging means looping, unresponsive, repeating the same obstacle, or truly dead.
-   A low context reading is not wedging; modern harnesses auto-compact and keep going.
+   A low context reading is not wedging by itself and never justifies exiting a working crewmate.
+   The fleet runs with harness auto-compact off, so treat it as a cue to redirect through step 3: tell the crewmate to write its live state to its durable file and compact deliberately.
    The worktree and commits persist, so relaunch is cheap.
 5. If a second relaunch fails too, write `failed` to the backlog and tell the captain the plain failure, preserved work, and consequence using `AGENTS.md` section 9; do not mention metadata, harness, window, or worktree unless the path itself is needed for action.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,7 +48,7 @@ Keep your own context small and compact it deliberately.
 Read what the task needs rather than what sits near it: prefer a targeted read over a bulk read, and a pointer to an authoritative file over a copy of its contents.
 Section 3 owns the read-once contract for the session-start digest.
 Compact at a boundary you choose, such as a finished investigation whose findings are already written down, a landed pipeline step, a closed decision, or a completed sub-task, never partway through a gate, a recovery, or a decision.
-Anything that must survive, including a gate's finding identifiers, a decision, a report conclusion, a PR URL, or a blocker, belongs on disk before you compact rather than only in the conversation; section 6's `stow` skill owns that capture pass.
+Anything that must survive, including a gate's finding identifiers, a decision, a report conclusion, a PR URL, or a blocker, belongs in its durable file before you compact rather than only in the conversation.
 No threshold or cadence governs this; compact when you judge it right.
 
 ## 2. Layout and state
@@ -235,7 +235,7 @@ Route durable knowledge to its most specific owner:
 Firstmate never writes a project's `AGENTS.md` directly.
 A crewmate creates or updates it lazily through the project's selected delivery path, using `bin/fm-ensure-agents-md.sh` and preferring pointers to authoritative sources over copied detail.
 Keep fleet delivery posture and captain-private strategy out of project memory.
-When the captain invokes `/stow`, or before you compact or reset the session, load the `stow` skill for the complete knowledge-routing and unfinished-work sweep.
+When the captain invokes `/stow`, load the `stow` skill for the complete knowledge-routing and unfinished-work sweep.
 
 ## 7. Task lifecycle
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,13 @@ This repo is a shared template, while `.env`, `data/`, `state/`, `config/`, `pro
 Ship shared tracked changes through this repo's no-mistakes pipeline and PR path, with the same merge authority as any other project.
 Never add an agent name as a commit co-author.
 
+Keep your own context small and compact it deliberately.
+Read what the task needs rather than what sits near it: prefer a targeted read over a bulk read, and a pointer to an authoritative file over a copy of its contents.
+Section 3 owns the read-once contract for the session-start digest.
+Compact at a boundary you choose, such as a finished investigation whose findings are already written down, a landed pipeline step, a closed decision, or a completed sub-task, never partway through a gate, a recovery, or a decision.
+Anything that must survive, including a gate's finding identifiers, a decision, a report conclusion, a PR URL, or a blocker, belongs in its durable file before you compact rather than only in the conversation.
+No threshold or cadence governs this; compact when you judge it right.
+
 ## 2. Layout and state
 
 `docs/configuration.md` is the single owner of the top-level operational-home layout and configuration schemas; each producing script's header and help own exact child fields and mutation mechanics.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,7 +48,7 @@ Keep your own context small and compact it deliberately.
 Read what the task needs rather than what sits near it: prefer a targeted read over a bulk read, and a pointer to an authoritative file over a copy of its contents.
 Section 3 owns the read-once contract for the session-start digest.
 Compact at a boundary you choose, such as a finished investigation whose findings are already written down, a landed pipeline step, a closed decision, or a completed sub-task, never partway through a gate, a recovery, or a decision.
-Anything that must survive, including a gate's finding identifiers, a decision, a report conclusion, a PR URL, or a blocker, belongs in its durable file before you compact rather than only in the conversation.
+Anything that must survive, including a gate's finding identifiers, a decision, a report conclusion, a PR URL, or a blocker, belongs on disk before you compact rather than only in the conversation; section 6's `stow` skill owns that capture pass.
 No threshold or cadence governs this; compact when you judge it right.
 
 ## 2. Layout and state
@@ -235,7 +235,7 @@ Route durable knowledge to its most specific owner:
 Firstmate never writes a project's `AGENTS.md` directly.
 A crewmate creates or updates it lazily through the project's selected delivery path, using `bin/fm-ensure-agents-md.sh` and preferring pointers to authoritative sources over copied detail.
 Keep fleet delivery posture and captain-private strategy out of project memory.
-When the captain invokes `/stow`, load the `stow` skill for the complete knowledge-routing and unfinished-work sweep.
+When the captain invokes `/stow`, or before you compact or reset the session, load the `stow` skill for the complete knowledge-routing and unfinished-work sweep.
 
 ## 7. Task lifecycle
 

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -256,10 +256,8 @@ IFS= read -r -d '' CONTEXT_RULE <<'EOF' || true
 8. Keep your context small and compact it deliberately. Read what the task needs, not what sits
    near it, and point at an authoritative file instead of copying it. Compact at a seam you
    choose - a finished investigation, a landed step, a closed decision - never partway through
-   one. Anything that must survive (findings, a decision, a blocker) goes into a durable file
-   BEFORE you compact, never only in this chat: your report if you have one, otherwise a scratch
-   notes file in your worktree. Rule 4 still governs the status file: never append a status line
-   just to preserve state. No threshold, no cadence: compact when you judge it right.
+   one. Anything that must survive (findings, a decision, a blocker) is written down BEFORE you
+   compact, never only in this chat. No threshold, no cadence: compact when you judge it right.
 EOF
 CONTEXT_RULE=${CONTEXT_RULE%$'\n'}
 

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -39,6 +39,8 @@
 # declared-external-wait verb (FM_CLASSIFY_PAUSED_VERB, default "paused") from
 # "blocked:": pause for a known external wait expected to clear on its own,
 # blocked when firstmate must act.
+# Ship and scout scaffolds share one context-discipline rule, because crewmates
+# never read firstmate's AGENTS.md; a secondmate gets it from its own AGENTS.md.
 # Ship tasks include a project-memory section so durable project-intrinsic
 # learnings can be committed to AGENTS.md through the project's delivery path;
 # it carries the AGENTS.md authoring bar (widely useful knowledge only, pointers
@@ -247,6 +249,19 @@ EOF
 HERDR_SECTION=${HERDR_SECTION%$'\n'}
 fi
 
+# Context discipline reaches crewmates only through this scaffold, since they
+# never read firstmate's AGENTS.md. Ship and scout share one definition so the
+# two rule lists cannot drift; secondmates get the rule from their own AGENTS.md.
+IFS= read -r -d '' CONTEXT_RULE <<'EOF' || true
+8. Keep your context small and compact it deliberately. Read what the task needs, not what sits
+   near it, and point at an authoritative file instead of copying it. Compact at a seam you
+   choose - a finished investigation, a landed step, a closed decision - never partway through
+   one. Anything that must survive (findings, a decision, a blocker) goes into its durable file
+   or a status line BEFORE you compact, never only in this chat. No threshold, no cadence:
+   compact when you judge it right.
+EOF
+CONTEXT_RULE=${CONTEXT_RULE%$'\n'}
+
 if [ "$KIND" = scout ]; then
 cat > "$BRIEF" <<EOF
 You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.
@@ -283,6 +298,7 @@ The report is the only thing that survives, so anything worth keeping must be in
 7. Never stop, restart, or update the shared \`no-mistakes\` daemon - it is one instance serving
    every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
    daemon error, append \`blocked: {the daemon error}\` and stop; only firstmate manages the daemon.
+$CONTEXT_RULE
 
 # Definition of done
 Write your findings to \`$DATA/$ID/report.md\`.
@@ -398,6 +414,7 @@ $RULE1
 7. Never stop, restart, or update the shared \`no-mistakes\` daemon - it is one instance serving
    every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
    daemon error, append \`blocked: {the daemon error}\` and stop; only firstmate manages the daemon.
+$CONTEXT_RULE
 
 # Project memory
 If \`AGENTS.md\` or \`CLAUDE.md\` already exists, or if this task produced durable project-intrinsic knowledge, run \`$FM_ROOT/bin/fm-ensure-agents-md.sh .\` in the worktree.

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -256,9 +256,10 @@ IFS= read -r -d '' CONTEXT_RULE <<'EOF' || true
 8. Keep your context small and compact it deliberately. Read what the task needs, not what sits
    near it, and point at an authoritative file instead of copying it. Compact at a seam you
    choose - a finished investigation, a landed step, a closed decision - never partway through
-   one. Anything that must survive (findings, a decision, a blocker) goes into its durable file
-   or a status line BEFORE you compact, never only in this chat. No threshold, no cadence:
-   compact when you judge it right.
+   one. Anything that must survive (findings, a decision, a blocker) goes into a durable file
+   BEFORE you compact, never only in this chat: your report if you have one, otherwise a scratch
+   notes file in your worktree. Rule 4 still governs the status file: never append a status line
+   just to preserve state. No threshold, no cadence: compact when you judge it right.
 EOF
 CONTEXT_RULE=${CONTEXT_RULE%$'\n'}
 

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -632,6 +632,47 @@ test_scout_and_secondmate_scaffold() {
   pass "fm-brief: scout and secondmate code paths still scaffold well-formed briefs"
 }
 
+# Crewmates never read firstmate's AGENTS.md, so the context-discipline rule
+# reaches them only through this scaffold. It must render identically in every
+# ship mode and in the scout contract, and must stay out of the secondmate
+# charter, whose home carries its own AGENTS.md copy of the same rule.
+test_context_discipline_rule_reaches_every_crewmate_scaffold() {
+  local home brief id
+  home="$TMP_ROOT/context-discipline-home"
+  write_registry "$home"
+
+  for id_proj in "brief-ctx-nomistakes:no-registry-proj" "brief-ctx-directpr:direct-proj" \
+    "brief-ctx-localonly:local-proj"; do
+    id=${id_proj%%:*}
+    FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" "${id_proj##*:}" >/dev/null 2>&1 \
+      || fail "$id: fm-brief.sh exited non-zero"
+    brief="$home/data/$id/brief.md"
+    assert_grep "8. Keep your context small and compact it deliberately." "$brief" \
+      "$id: ship brief lost the context-discipline rule"
+    assert_grep "never partway through" "$brief" \
+      "$id: ship brief lost the deliberate-boundary requirement"
+    assert_grep "goes into its durable file" "$brief" \
+      "$id: ship brief lost the durable-state-before-compacting requirement"
+    assert_grep "No threshold, no cadence" "$brief" \
+      "$id: ship brief lost the judgment-not-threshold requirement"
+  done
+
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" brief-ctx-scout alpha --scout >/dev/null 2>&1 \
+    || fail "scout: fm-brief.sh exited non-zero"
+  brief="$home/data/brief-ctx-scout/brief.md"
+  assert_grep "8. Keep your context small and compact it deliberately." "$brief" \
+    "scout brief lost the context-discipline rule"
+  assert_grep "No threshold, no cadence" "$brief" \
+    "scout brief lost the judgment-not-threshold requirement"
+
+  FM_SECONDMATE_CHARTER='Supervise the alpha domain.' \
+    FM_HOME="$home" "$ROOT/bin/fm-brief.sh" brief-ctx-mate --secondmate alpha >/dev/null 2>&1 \
+    || fail "secondmate: fm-brief.sh exited non-zero"
+  assert_no_grep "Keep your context small" "$home/data/brief-ctx-mate/brief.md" \
+    "secondmate charter duplicated a rule its own AGENTS.md already owns"
+  pass "fm-brief.sh: every crewmate scaffold carries one context-discipline rule"
+}
+
 test_script_parses
 test_no_heredoc_in_command_substitution
 test_help_includes_entire_header
@@ -649,3 +690,4 @@ test_secondmate_directory_paths_are_absolute_and_output_is_stable
 test_pause_verb_override_renders_all_brief_scaffolds
 test_scout_and_secondmate_load_decision_hold_policy
 test_scout_and_secondmate_scaffold
+test_context_discipline_rule_reaches_every_crewmate_scaffold

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -651,8 +651,10 @@ test_context_discipline_rule_reaches_every_crewmate_scaffold() {
       "$id: ship brief lost the context-discipline rule"
     assert_grep "never partway through" "$brief" \
       "$id: ship brief lost the deliberate-boundary requirement"
-    assert_grep "goes into its durable file" "$brief" \
+    assert_grep "goes into a durable file" "$brief" \
       "$id: ship brief lost the durable-state-before-compacting requirement"
+    assert_grep "Rule 4 still governs the status file" "$brief" \
+      "$id: ship brief lost the status-file precedence over rule 4"
     assert_grep "No threshold, no cadence" "$brief" \
       "$id: ship brief lost the judgment-not-threshold requirement"
   done
@@ -662,6 +664,8 @@ test_context_discipline_rule_reaches_every_crewmate_scaffold() {
   brief="$home/data/brief-ctx-scout/brief.md"
   assert_grep "8. Keep your context small and compact it deliberately." "$brief" \
     "scout brief lost the context-discipline rule"
+  assert_grep "Rule 4 still governs the status file" "$brief" \
+    "scout brief lost the status-file precedence over rule 4"
   assert_grep "No threshold, no cadence" "$brief" \
     "scout brief lost the judgment-not-threshold requirement"
 

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -651,10 +651,8 @@ test_context_discipline_rule_reaches_every_crewmate_scaffold() {
       "$id: ship brief lost the context-discipline rule"
     assert_grep "never partway through" "$brief" \
       "$id: ship brief lost the deliberate-boundary requirement"
-    assert_grep "goes into a durable file" "$brief" \
+    assert_grep "is written down BEFORE you" "$brief" \
       "$id: ship brief lost the durable-state-before-compacting requirement"
-    assert_grep "Rule 4 still governs the status file" "$brief" \
-      "$id: ship brief lost the status-file precedence over rule 4"
     assert_grep "No threshold, no cadence" "$brief" \
       "$id: ship brief lost the judgment-not-threshold requirement"
   done
@@ -664,8 +662,8 @@ test_context_discipline_rule_reaches_every_crewmate_scaffold() {
   brief="$home/data/brief-ctx-scout/brief.md"
   assert_grep "8. Keep your context small and compact it deliberately." "$brief" \
     "scout brief lost the context-discipline rule"
-  assert_grep "Rule 4 still governs the status file" "$brief" \
-    "scout brief lost the status-file precedence over rule 4"
+  assert_grep "is written down BEFORE you" "$brief" \
+    "scout brief lost the durable-state-before-compacting requirement"
   assert_grep "No threshold, no cadence" "$brief" \
     "scout brief lost the judgment-not-threshold requirement"
 


### PR DESCRIPTION
## What

Adds one context-discipline rule to firstmate's two instruction surfaces, so agents keep their own context small and compact at a boundary they choose.

Auto-compact fires on a token threshold, not a semantic boundary. It routinely lands mid-gate, mid-investigation, or mid-recovery, and the summary keeps the prose while dropping the operational state the agent needed next. With auto-compact off at the harness level, the failure mode flips: an agent that does not manage its own context runs out of it rather than being rescued.

## Where, and why only there

Two audiences, one place each - duplicated instructions drift.

- **`AGENTS.md` section 1** for firstmate. Placed at the tail of "Identity and prime directives", which already carries standing self-conduct that is not a numbered hard rule. Section 3 was rejected because its heading is scoped "run once at every session start"; section 8 was rejected because it is fleet supervision, where the rule would read as being about supervising crew rather than about the agent's own context.
- **`bin/fm-brief.sh`'s `# Rules`, as rule 8** for crewmates, who never read `AGENTS.md`.

Ship and scout share a single `CONTEXT_RULE` shell variable, so the two rule lists cannot diverge. The secondmate charter is deliberately excluded: a secondmate is a firstmate in its own home and reads its own `AGENTS.md`. The new test asserts that exclusion.

Also corrects a line in `.agents/skills/stuck-crewmate-recovery/SKILL.md` that had become false. It told firstmate "A low context reading is not wedging; modern harnesses auto-compact and keep going." With auto-compact off, that is the exact rule firstmate applies when deciding whether to help a crewmate approaching exhaustion, so leaving it would have made this change actively counterproductive. The correction is that firstmate should *notice*, not that firstmate should intervene: the existing guarantee that a low reading is never grounds to interrupt, exit, or relaunch a working crewmate is preserved explicitly.

## The rule states a principle and names no mechanism

Two review rounds established this the hard way. Earlier drafts named a "how" - a scratch notes file, the `stow` skill, a recovery step - and every named mechanism collided with a contract that already owned it: the scratch file tripped `fm-teardown.sh`'s dirty check, the `stow` pointer summoned its mandatory complete pass at every seam, and the recovery-step pointer routed a nudge through an *interrupt*, landing mid-edit - precisely the "partway through" moment this change exists to prevent.

Three for three is not bad luck, so the mechanisms are gone. The rule says what must be true and stops: keep context small; compact at a seam you choose; write down what must survive before you compact; no threshold and no cadence. It names no destination file, no skill, and no recovery step. Notably, no teardown exemption was added to accommodate a scratch file - that would have traded a rule collision for a permanent hole in the unlanded-work check.

No machinery: no context-measuring script, no hook, no threshold checker. No safety boundary was reworded or reordered.

## Rendered `# Rules` section from a scaffolded ship brief

```
7. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving
   every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
   daemon error, append `blocked: {the daemon error}` and stop; only firstmate manages the daemon.
8. Keep your context small and compact it deliberately. Read what the task needs, not what sits
   near it, and point at an authoritative file instead of copying it. Compact at a seam you
   choose - a finished investigation, a landed step, a closed decision - never partway through
   one. Anything that must survive (findings, a decision, a blocker) is written down BEFORE you
   compact, never only in this chat. No threshold, no cadence: compact when you judge it right.
```

The scout contract renders rule 8 identically; the secondmate charter omits it.

## Verification

- New behavior test `test_context_discipline_rule_reaches_every_crewmate_scaffold` asserts the rule renders in all three ship delivery modes and in the scout contract, and is absent from the secondmate charter. **Proven to fail against the pre-change script** (restored `bin/fm-brief.sh` from `HEAD`, reran, got `not ok - brief-ctx-nomistakes: ship brief lost the context-discipline rule`) - a green run on unchanged code would have proved nothing.
- `tests/fm-brief.test.sh` green.
- `bin/fm-lint.sh` **could not run locally**: ShellCheck is not installed on this machine, and installing it would have reached outside the worktree. CI owns that gate.
