### PR TITLE
feat(skills): add Lavish PR walkthrough skill

### DIFF
--- a/.agents/skills/lavish-pr-review/SKILL.md
+++ b/.agents/skills/lavish-pr-review/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: lavish-pr-review
+description: >-
+  Produce a Lavish walkthrough that explains an existing pull request with real code snippets, so the captain can understand the change and decide whether to merge it.
+  Use when the captain invokes /lavish-pr-review or asks for a lavish, visual, or guided walkthrough of a specific PR, such as "make a lavish that walks me through this PR with code snippets" or "walk me through PR 42 visually".
+  Do not use for judging a change's quality, for ordinary review or ship requests, or for investigation with no PR to explain.
+user-invocable: true
+metadata:
+  internal: true
+---
+
+# lavish-pr-review
+
+The deliverable is a Lavish artifact that orients the captain in a pull request he has not read, well enough to make a merge decision.
+It is not a diff dump and not a verdict on code quality: `/code-review` judges a change, and a scout report answers an open question.
+The walkthrough explains what exists on the branch and what merging it would mean.
+
+## Dispatch
+
+This reads project code, so it is project work: write a brief and dispatch a worker, never do it in the firstmate session.
+The task is read-only on someone else's branch.
+The worker checks the PR branch out in its own worktree and never commits, pushes, rebases, or comments on the PR.
+
+## Content spine
+
+Require these sections in the brief, in this order, adapted to the PR in hand.
+
+1. What the feature is, and what it is easy to confuse it with; name the near neighbour early and draw the distinction.
+2. The data model, with the real schema and any hand-written database constraints, plus why any deviation from project convention was accepted.
+3. The read and write paths, shown through the snippets that carry the real invariants - tenancy scoping, ordering of authorization checks, soft-delete filters, caps and guards - rather than the plumbing between them.
+4. The user-facing surface: where it mounts, the flows a user can start, and how state settles afterwards.
+5. What changed in the most recent commits, as before/after, so review work already done is visible.
+6. What is deliberately not done, so nothing surprises the captain after merge.
+7. A closing risk read, plus any open product calls presented as decisions he can answer.
+
+## Snippet discipline
+
+Every snippet is real code copied from the branch, with a `file:line` reference.
+Trim each one to what is being explained; never paste a whole file.
+Prefer a diagram over prose where the request path or a type model is genuinely clearer drawn.
+
+## Lavish mechanics
+
+Open the relevant `lavish-axi playbook` entries before writing any HTML, and follow `lavish-axi design`.
+The artifact is about the subject project, so match that project's own design system rather than the generic CDN default, and record which source was used.
+Write the artifact under `.lavish/` in the worktree, open it with `lavish-axi <html-file>`, then run `lavish-axi poll <html-file>` in the FOREGROUND so the captain's feedback returns to the worker.
+Never background the poll with `&` or `nohup`.
+
+## Feedback that asks for code changes
+
+Artifact feedback is applied to the artifact, and polling continues.
+Feedback asking for changes to the project's code is out of scope for this task: the worker records it and raises it instead of making it, so firstmate routes that work as its own task.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -258,6 +258,7 @@ If established evidence already answers an informational question, relay it with
 Never both present a likely-enough solution and launch a parallel design exercise that is not expected to change it.
 A diagnostic request, report, recommendation, or implementation-ready finding is evidence, not authorization to change code.
 Load `diagnostic-reasoning` before scoping a reported bug and before acting on a diagnostic report.
+Load `lavish-pr-review` when the captain invokes `/lavish-pr-review` or asks for a visual or guided walkthrough of a specific pull request.
 
 Resolve every ship task's concrete delivery mode and yolo posture at intake, and pass both explicitly to the brief, the spawn, and any scout promotion, which all refuse to guess.
 A current explicit captain instruction wins; otherwise the project's registry entry is the captain's standing posture, and dropping below its rigor needs a reason you can state.

--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ Claude and grok use the slash form shown here; codex uses the same names with `$
 | `/afk`             | Enter away-mode supervision: the sub-supervisor self-handles routine notifications in bash, escalates captain-relevant events and bounded declared-external-wait rechecks as batched digests, and actively alerts if delivery gets stuck while you step away |
 | `/ahoy`            | Recap visible session events since the prior real captain message plus visibly unanswered captain decisions, falling back to Bearings when invoked as the session's first real captain message |
 | `/bearings`        | Generate a concise four-section chat digest from bounded local fleet and registered-secondmate state; use `/bearings file` to also replace today's dated report in `data/`, and add `include PRs` when live PR enrichment is wanted |
+| `/lavish-pr-review` | Produce a Lavish walkthrough of an existing pull request, with real code snippets from its branch, so the change can be understood well enough to decide on merging |
 | `/updatefirstmate` | Self-update the running firstmate and its secondmates to the latest from origin with fast-forward-only pulls, then re-read instructions and nudge secondmates |
 | `/stow`            | Sweep the session for uncaptured durable knowledge, route each finding to its disk home per AGENTS.md, file undone next steps to the backlog, and report what is now safe to reset |
 

--- a/docs/documentation-audiences.json
+++ b/docs/documentation-audiences.json
@@ -157,6 +157,10 @@
       "audience": "agent-runtime"
     },
     {
+      "path": ".agents/skills/lavish-pr-review/SKILL.md",
+      "audience": "agent-runtime"
+    },
+    {
       "path": ".agents/skills/process-event-sources/SKILL.md",
       "audience": "agent-runtime"
     },


### PR DESCRIPTION
## Intent

Add a short captain-invocable skill to the firstmate repo, lavish-pr-review, capturing the ask 'make a lavish that walks me through this PR with code snippets'.

Goal: when the captain says '/lavish-PR-review', 'make a lavish walkthrough of PR N', 'walk me through this PR visually', or 'lavish me that PR with code snippets', firstmate should produce a Lavish artifact that explains a pull request well enough for a merge decision - not a diff dump and not a code review.

Required content, deliberately kept short (procedure skill, not an essay; existing skills in .agents/skills/ are the length and tone model):
- Trigger phrasing in the frontmatter description, precise enough to fire on this ask and not on ordinary review or ship requests.
- The deliverable is a walkthrough for understanding and a merge decision - distinct from /code-review, which judges the change, and distinct from a scout report.
- Dispatch shape: this is project work, so it goes to a worker, not to firstmate directly; the worker reads the PR branch READ-ONLY and never commits, pushes, or comments on the PR.
- The content spine: what the feature is and what it is easy to confuse it with; the data model with the real schema and any hand-written database constraints; the read and write paths shown through the snippets that carry the real invariants rather than the plumbing; the user-facing surface; what changed in the most recent commits as before/after; what is deliberately not done; and a closing risk read plus any product calls presented as decisions.
- Snippet discipline: real code from the branch with file:line references, trimmed to what is being explained, never a whole file.
- Lavish mechanics: open the relevant lavish-axi playbook entries before writing HTML, follow lavish-axi design and match the SUBJECT project's design system rather than the generic CDN default, write the artifact under .lavish/, then open it and poll in the FOREGROUND so feedback returns to the worker - never background the poll.
- When the captain's feedback asks for code changes rather than artifact changes: do not make them, raise them so firstmate routes the work properly.

Deliberate decisions and constraints:
- The skill deliberately does NOT restate the general crewmate lifecycle, status protocol, or delivery rules - those already have owners in AGENTS.md, per the one-owner rule in the firstmate-coding-guidelines skill.
- It was derived from a live example brief written for one specific PR, but is intentionally generalized to any PR with no project-specific detail copied in.
- Frontmatter is captain-invocable: user-invocable: true with metadata.internal: true, matching neighbouring built-in skills such as ahoy, bearings, and stow; it is NOT an agent-only skill, so it does not carry user-invocable: false.
- Shortness is an explicit acceptance criterion: roughly a screen and a half maximum.
- Registration was checked rather than assumed, and the skill is registered in the three places this repo expects: a one-line load trigger in AGENTS.md section 7 (per the trigger-hygiene rule that every new skill needs its trigger declared inline), a row in the README 'Built-in skills' table for user-invocable skills, and an agent-runtime surface entry in docs/documentation-audiences.json. bin/fm-doc-audience-check.sh passes.
- Repo style rules from firstmate-coding-guidelines are followed, including one sentence per line in tracked Markdown and plain dashes rather than em dashes.

## What Changed

- Adds the captain-invocable `lavish-pr-review` skill for visual PR walkthroughs focused on merge decisions, with real branch code snippets and read-only worker dispatch.
- Defines the walkthrough content spine, snippet discipline, Lavish artifact workflow, and handling for feedback that requests project code changes.
- Registers the skill in `AGENTS.md`, the README built-in skills table, and `docs/documentation-audiences.json`.

## Risk Assessment

✅ Low: The change is a bounded documentation/skill addition that satisfies the stated walkthrough, dispatch, Lavish, feedback, style, and registration requirements.

## Testing

No baseline test command was provided. The focused documentation-audience check and regression test passed, and the acceptance transcript directly records the captain-facing trigger, read-only worker dispatch, required walkthrough content, Lavish mechanics, feedback boundary, and three registration surfaces. The changed-file suite and isolated rerun reproduced two unrelated harness failures in Pi Calm and Kimi; the worktree remained clean and no transient project artifacts were created.

<details>
<summary>Evidence: Skill acceptance transcript</summary>

```text
Captain-facing skill acceptance transcript

Frontmatter and trigger boundary (.agents/skills/lavish-pr-review/SKILL.md:3-9)
     3	description: >-
     4	  Produce a Lavish walkthrough that explains an existing pull request with real code snippets, so the captain can understand the change and decide whether to merge it.
     5	  Use when the captain invokes /lavish-pr-review or asks for a lavish, visual, or guided walkthrough of a specific PR, such as "make a lavish that walks me through this PR with code snippets" or "walk me through PR 42 visually".
     6	  Do not use for judging a change's quality, for ordinary review or ship requests, or for investigation with no PR to explain.
     7	user-invocable: true
     8	metadata:
     9	  internal: true

Deliverable and dispatch (.agents/skills/lavish-pr-review/SKILL.md:14-22)
    14	The deliverable is a Lavish artifact that orients the captain in a pull request he has not read, well enough to make a merge decision.
    15	It is not a diff dump and not a verdict on code quality: `/code-review` judges a change, and a scout report answers an open question.
    16	The walkthrough explains what exists on the branch and what merging it would mean.
    17	
    18	## Dispatch
    19	
    20	This reads project code, so it is project work: write a brief and dispatch a worker, never do it in the firstmate session.
    21	The task is read-only on someone else's branch.
    22	The worker checks the PR branch out in its own worktree and never commits, pushes, rebases, or comments on the PR.

Content spine (.agents/skills/lavish-pr-review/SKILL.md:24-34)
    24	## Content spine
    25	
    26	Require these sections in the brief, in this order, adapted to the PR in hand.
    27	
    28	1. What the feature is, and what it is easy to confuse it with; name the near neighbour early and draw the distinction.
    29	2. The data model, with the real schema and any hand-written database constraints, plus why any deviation from project convention was accepted.
    30	3. The read and write paths, shown through the snippets that carry the real invariants - tenancy scoping, ordering of authorization checks, soft-delete filters, caps and guards - rather than the plumbing between them.
    31	4. The user-facing surface: where it mounts, the flows a user can start, and how state settles afterwards.
    32	5. What changed in the most recent commits, as before/after, so review work already done is visible.
    33	6. What is deliberately not done, so nothing surprises the captain after merge.
    34	7. A closing risk read, plus any open product calls presented as decisions he can answer.

Snippet discipline and Lavish mechanics (.agents/skills/lavish-pr-review/SKILL.md:36-47)
    36	## Snippet discipline
    37	
    38	Every snippet is real code copied from the branch, with a `file:line` reference.
    39	Trim each one to what is being explained; never paste a whole file.
    40	Prefer a diagram over prose where the request path or a type model is genuinely clearer drawn.
    41	
    42	## Lavish mechanics
    43	
    44	Open the relevant `lavish-axi playbook` entries before writing any HTML, and follow `lavish-axi design`.
    45	The artifact is about the subject project, so match that project's own design system rather than the generic CDN default, and record which source was used.
    46	Write the artifact under `.lavish/` in the worktree, open it with `lavish-axi <html-file>`, then run `lavish-axi poll <html-file>` in the FOREGROUND so the captain's feedback returns to the worker.
    47	Never background the poll with `&` or `nohup`.

Code-change feedback boundary (.agents/skills/lavish-pr-review/SKILL.md:49-52)
    49	## Feedback that asks for code changes
    50	
    51	Artifact feedback is applied to the artifact, and polling continues.
    52	Feedback asking for changes to the project's code is out of scope for this task: the worker records it and raises it instead of making it, so firstmate routes that work as its own task.

Registration surfaces
AGENTS.md
   258	Never both present a likely-enough solution and launch a parallel design exercise that is not expected to change it.
   259	A diagnostic request, report, recommendation, or implementation-ready finding is evidence, not authorization to change code.
   260	Load `diagnostic-reasoning` before scoping a reported bug and before acting on a diagnostic report.
   261	Load `lavish-pr-review` when the captain invokes `/lavish-pr-review` or asks for a visual or guided walkthrough of a specific pull request.
   262	
   263	Resolve every ship task's concrete delivery mode and yolo posture at intake, and pass both explicitly to the brief, the spawn, and any scout promotion, which all refuse to guess.
README.md
   172	| `/afk`             | Enter away-mode supervision: the sub-supervisor self-handles routine notifications in bash, escalates captain-relevant events and bounded declared-external-wait rechecks as batched digests, and actively alerts if delivery gets stuck while you step away |
   173	| `/ahoy`            | Recap visible session events since the prior real captain message plus visibly unanswered captain decisions, falling back to Bearings when invoked as the session's first real captain message |
   174	| `/bearings`        | Generate a concise four-section chat digest from bounded local fleet and registered-secondmate state; use `/bearings file` to also replace today's dated report in `data/`, and add `include PRs` when live PR enrichment is wanted |
   175	| `/lavish-pr-review` | Produce a Lavish walkthrough of an existing pull request, with real code snippets from its branch, so the change can be understood well enough to decide on merging |
   176	| `/updatefirstmate` | Self-update the running firstmate and its secondmates to the latest from origin with fast-forward-only pulls, then re-read instructions and nudge secondmates |
   177	| `/stow`            | Sweep the session for uncaptured durable knowledge, route each finding to its disk home per AGENTS.md, file undone next steps to the backlog, and report what is now safe to reset |
docs/documentation-audiences.json
   157	      "audience": "agent-runtime"
   158	    },
   159	    {
   160	      "path": ".agents/skills/lavish-pr-review/SKILL.md",
   161	      "audience": "agent-runtime"
   162	    },
   163	    {
   164	      "path": ".agents/skills/process-event-sources/SKILL.md",

Shortness/style checks
lines=      52
words=     559
em_dashes=       0
```
</details>
<details>
<summary>Evidence: Focused registration test</summary>

```text
$ bin/fm-doc-audience-check.sh
fm-doc-audience-check: ok surfaces=65 local_links=185

$ bin/fm-test-run.sh tests/fm-documentation-audiences.test.sh
FM_TEST_BEGIN 2026-08-03T19:19:24Z tests/fm-documentation-audiences.test.sh family=pure-contract-unit expected_gate_skip=none
ok - documentation inventory classifies every maintained prose surface exactly once
ok - classification, setup routing, and maintained-prose scope fail safely
ok - required documentation owner pointers cannot silently disappear
ok - local links resolve while dates, versions, commands, and incident prose remain semantically reviewed
FM_TEST_END 2026-08-03T19:19:26Z tests/fm-documentation-audiences.test.sh exit=0 duration_ms=1550 gate_skip=false
FM_TEST_SUMMARY total=1 failed=0 skipped_gate=0 duration_ms=1754
FM_TEST_SUMMARY_FAMILY family=pure-contract-unit count=1 duration_ms=1550 failed=0
FM_TEST_SLOWEST rank=1 script=tests/fm-documentation-audiences.test.sh duration_ms=1550
```
</details>
<details>
<summary>Evidence: Unrelated failure recheck</summary>

```text
$ bin/fm-test-run.sh tests/fm-calm-pi-extension.test.sh tests/fm-kimi-harness.test.sh
FM_TEST_BEGIN 2026-08-03T19:24:49Z tests/fm-calm-pi-extension.test.sh family=pure-contract-unit expected_gate_skip=none
skip: installed @earendil-works/pi-coding-agent package not found
ok - Pi calm compatibility evidence never rejects a Pi version for being newer than 0.82.0, and still fails closed on a missing or malformed version
skip: installed @earendil-works/pi-coding-agent package not found
ok - missing Pi presentation class exports reach the independent adapter degradation path
skip: installed @earendil-works/pi-coding-agent package not found
ok - Pi operational follow-up E2E processes exact user-role notifications once while Calm hides current and adjacent rows, Calm off and absent render them, and restart preserves semantics
ok - Pi Calm native /skill:ahoy geometry keeps every collapsed thinking and tool block at zero height while preserving expansion, history, restart, and Calm-off rendering
skip: installed @earendil-works/pi-coding-agent package not found
not ok - /export did not complete while calm mode was on
FM_TEST_END 2026-08-03T19:25:23Z tests/fm-calm-pi-extension.test.sh exit=1 duration_ms=33943 gate_skip=false
FM_TEST_BEGIN 2026-08-03T19:25:23Z tests/fm-kimi-harness.test.sh family=pure-contract-unit expected_gate_skip=none
ok - Kimi hook install is idempotent and removal restores every foreign config byte
ok - Kimi hook removal preserves owned newline boundaries and pristine bytes
ok - Kimi hook install refuses missing, malformed, and surprising config without writing
ok - Kimi hook install refuses without jq before any config write
not ok - verified kimi launch-then-send should succeed: expected exit 0, got 1
FM_TEST_END 2026-08-03T19:25:25Z tests/fm-kimi-harness.test.sh exit=1 duration_ms=1557 gate_skip=false
FM_TEST_SUMMARY total=2 failed=2 skipped_gate=0 duration_ms=35792
FM_TEST_SUMMARY_FAMILY family=pure-contract-unit count=2 duration_ms=35500 failed=2
FM_TEST_SLOWEST rank=1 script=tests/fm-calm-pi-extension.test.sh duration_ms=33943
FM_TEST_SLOWEST rank=2 script=tests/fm-kimi-harness.test.sh duration_ms=1557
```
</details>
- Outcome: ⚠️ 2 warnings across 1 run (8m58s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Test** - 2 warnings</summary>

- ⚠️ `tests/fm-calm-pi-extension.test.sh:2866` - The broader changed-file run reproducibly failed in the unrelated Pi Calm E2E test: `/export did not complete while calm mode was on`. The target diff changes no Pi or E2E files.
- ⚠️ `tests/fm-kimi-harness.test.sh:191` - The broader changed-file run reproducibly failed in the unrelated Kimi harness test: `verified kimi launch-then-send should succeed`. The target diff changes no Kimi or harness files.
- `bin/fm-doc-audience-check.sh`
- `bin/fm-test-run.sh tests/fm-documentation-audiences.test.sh`
- `bin/fm-test-run.sh --changed --base cf9511217d885cd2127d50993e672c2dfa0539cf`
- `bin/fm-test-run.sh tests/fm-calm-pi-extension.test.sh tests/fm-kimi-harness.test.sh`
- `Manual inspection of the skill frontmatter, dispatch contract, content spine, snippet discipline, Lavish mechanics, feedback boundary, and AGENTS.md/README.md/documentation-audiences.json registration`
- `git status --short --branch`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
