### PR TITLE
fix(bin): make away-mode supervision fail safe instead of silently stopping

### DIFF
--- a/.agents/skills/afk/SKILL.md
+++ b/.agents/skills/afk/SKILL.md
@@ -49,10 +49,15 @@ batched digest rather than per-wake injections.
    The daemon is **presence-gated**: it injects escalations only while
    `state/.afk` exists, and stays quiet otherwise.
 
-3. **Do not separately arm `fm-watch.sh`.** The daemon manages the watcher as
+3. **Verify supervision is real before reporting it.**
+   Launching the daemon is not evidence that it is supervising: while `state/.afk` exists the watcher drops to one-shot and hands triage to the daemon, so a flag with a dead daemon means nothing triages at all.
+   Wait for the daemon's own `afk: supervision live` line, which it prints only after its first housekeeping tick has actually run, or confirm with `bin/fm-afk-health.sh` (`AFK_HEALTHY`).
+   Never acknowledge away mode on `AFK_DEGRADED`: repair the daemon or clear the flag first.
+
+4. **Do not separately arm `fm-watch.sh`.** The daemon manages the watcher as
    its child; the singleton lock no-ops a stray arm harmlessly.
 
-4. **Acknowledge** in `AGENTS.md` section 9 language: "Captain, away mode is active; I will batch routine updates and surface only decisions, failures, credentials, or review-ready work until you return."
+5. **Acknowledge** in `AGENTS.md` section 9 language: "Captain, away mode is active; I will batch routine updates and surface only decisions, failures, credentials, or review-ready work until you return."
 
 ## How to exit afk
 

--- a/bin/fm-afk-health.sh
+++ b/bin/fm-afk-health.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Firstmate away-mode health check.
+#
+# Answers one question the fleet cannot afford to get wrong: is away-mode
+# supervision REAL right now?
+#
+# While state/.afk exists, bin/fm-watch.sh deliberately drops to one-shot and
+# hands triage to bin/fm-supervise-daemon.sh. So an .afk flag with no live
+# daemon is the single worst combination available - nothing triages, and away
+# mode still reports itself active. This script makes that state loud instead of
+# silent, and is the reason the daemon writes its readiness beacon and its
+# durable exit record.
+#
+# Verdicts (first token of the single status line, also the exit code):
+#   AFK_OFF        0  no away-mode flag; nothing to supervise
+#   AFK_HEALTHY    0  flag present, daemon live, past its first housekeeping tick
+#   AFK_STARTING   0  flag present, daemon live, not yet ready (still arming)
+#   AFK_DEGRADED   1  flag present, NO live daemon - away mode is a lie, repair now
+#
+# Usage: fm-afk-health.sh [--quiet]
+#   --quiet  print nothing; use the exit code only
+set -eu
+
+FM_AFK_HEALTH_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$FM_AFK_HEALTH_DIR/.." && pwd)}"
+FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
+FM_AFK_HEALTH_STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
+
+# Reuse the arming path's own liveness predicate rather than restating it: that
+# script's source guard means sourcing it defines the helpers without arming.
+# shellcheck source=bin/fm-afk-start.sh
+. "$FM_AFK_HEALTH_DIR/fm-afk-start.sh"
+
+fm_afk_health_main() {
+  local quiet=0
+  case "${1:-}" in
+    '') ;;
+    --quiet) quiet=1 ;;
+    -h|--help) sed -n '2,20p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'; return 0 ;;
+    *) echo "usage: fm-afk-health.sh [--quiet]" >&2; return 2 ;;
+  esac
+
+  local state=$FM_AFK_HEALTH_STATE
+  local ready="$state/.subsuper-daemon-ready"
+  local exited="$state/.subsuper-daemon-exit"
+  local log="$state/.supervise-daemon.log"
+  local verdict rc detail=""
+
+  if [ ! -f "$state/.afk" ]; then
+    verdict=AFK_OFF; rc=0; detail="no away-mode flag"
+  elif daemon_lock_held_by_live_daemon; then
+    local pid; pid=$(daemon_lock_pid 2>/dev/null || true)
+    if [ -f "$ready" ]; then
+      verdict=AFK_HEALTHY; rc=0; detail="daemon pid=${pid:-?} ready"
+    else
+      verdict=AFK_STARTING; rc=0; detail="daemon pid=${pid:-?} not yet past its first housekeeping tick"
+    fi
+  else
+    verdict=AFK_DEGRADED; rc=1
+    # The whole point of the durable exit record: say WHY, not just "gone".
+    if [ -f "$exited" ]; then
+      detail="away-mode flag present but NO live daemon; last exit: $(tr '\t' ' ' < "$exited" | head -1)"
+    else
+      detail="away-mode flag present but NO live daemon; no exit record (killed, or never started)"
+    fi
+  fi
+
+  if [ "$quiet" -eq 0 ]; then
+    echo "$verdict: $detail"
+    if [ "$verdict" = AFK_DEGRADED ]; then
+      echo "AFK_DEGRADED: nothing is triaging this fleet while state/.afk exists - re-arm away mode or clear the flag"
+      if [ -f "$log" ]; then
+        echo "AFK_DEGRADED: last daemon log lines:"
+        tail -5 "$log" 2>/dev/null | sed 's/^/  /'
+      fi
+    fi
+  fi
+  return "$rc"
+}
+
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+  fm_afk_health_main "$@"
+fi

--- a/bin/fm-afk-health.sh
+++ b/bin/fm-afk-health.sh
@@ -13,9 +13,12 @@
 #
 # Verdicts (first token of the single status line, also the exit code):
 #   AFK_OFF        0  no away-mode flag; nothing to supervise
-#   AFK_HEALTHY    0  flag present, daemon live, past its first housekeeping tick
-#   AFK_STARTING   0  flag present, daemon live, not yet ready (still arming)
-#   AFK_DEGRADED   1  flag present, NO live daemon - away mode is a lie, repair now
+#   AFK_HEALTHY    0  flag present, daemon live and past its first housekeeping
+#                     tick - away-mode supervision is active
+#   AFK_STARTING   0  flag present, daemon live but not yet ready - away mode is
+#                     still arming, NOT yet supervising (bounded window)
+#   AFK_DEGRADED   1  flag present but NOT SUPERVISED: no live daemon, or a live
+#                     daemon that never armed within the window - repair now
 #
 # Usage: fm-afk-health.sh [--quiet]
 #   --quiet  print nothing; use the exit code only
@@ -30,6 +33,34 @@ FM_AFK_HEALTH_STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
 # script's source guard means sourcing it defines the helpers without arming.
 # shellcheck source=bin/fm-afk-start.sh
 . "$FM_AFK_HEALTH_DIR/fm-afk-start.sh"
+
+# Mirrors HOUSEKEEPING_TICK_DEFAULT in bin/fm-supervise-daemon.sh, which owns it.
+FM_AFK_HEALTH_TICK_DEFAULT=15
+
+# Arming window: a live daemon that has never completed a housekeeping tick is
+# only credibly "starting" for a bounded time. One missed tick is a slow start;
+# two consecutive missed ticks is a daemon that is not triaging. So the window is
+# twice the configured tick, floored at 60s so a fast tick cannot make the
+# verdict hair-trigger, and capped at 300s so the worst case stays bounded.
+fm_afk_arming_window() {
+  local tick window
+  tick=${FM_HOUSEKEEPING_TICK:-$FM_AFK_HEALTH_TICK_DEFAULT}
+  case $tick in ''|*[!0-9]*) tick=$FM_AFK_HEALTH_TICK_DEFAULT ;; esac
+  window=$(( tick * 2 ))
+  if [ "$window" -lt 60 ]; then window=60; fi
+  if [ "$window" -gt 300 ]; then window=300; fi
+  echo "$window"
+}
+
+# Elapsed arming time, measured from the daemon's own start evidence on disk (the
+# lock it holds), through the fail-safe age helper: an unreadable age reads as
+# very old and therefore resolves toward AFK_DEGRADED rather than leaving away
+# mode "starting" forever.
+fm_afk_arming_age() {
+  local owner
+  owner=$(daemon_lock_owner 2>/dev/null) || { echo 999999; return; }
+  fm_path_age "$owner"
+}
 
 fm_afk_health_main() {
   local quiet=0
@@ -53,7 +84,16 @@ fm_afk_health_main() {
     if [ -f "$ready" ]; then
       verdict=AFK_HEALTHY; rc=0; detail="daemon pid=${pid:-?} ready"
     else
-      verdict=AFK_STARTING; rc=0; detail="daemon pid=${pid:-?} not yet past its first housekeeping tick"
+      local arming window
+      arming=$(fm_afk_arming_age)
+      window=$(fm_afk_arming_window)
+      if [ "$arming" -lt "$window" ]; then
+        verdict=AFK_STARTING; rc=0
+        detail="daemon pid=${pid:-?} not yet past its first housekeeping tick (arming ${arming}s of ${window}s)"
+      else
+        verdict=AFK_DEGRADED; rc=1
+        detail="daemon pid=${pid:-?} is alive but never reached its first housekeeping tick within ${window}s (arming ${arming}s); it is not triaging"
+      fi
     fi
   else
     verdict=AFK_DEGRADED; rc=1

--- a/bin/fm-afk-launch.sh
+++ b/bin/fm-afk-launch.sh
@@ -431,7 +431,7 @@ fm_afk_launch_create_herdr() {  # <captain-target> <captain-backend>
     return 1
   fi
   fm_afk_launch_commit_terminal herdr "$session:$pane" "$wsid" 1 || return 1
-  fm_afk_launch_log "daemon launched in non-visible herdr workspace $wsid (pane $session:$pane), supervising $captain_target"
+  fm_afk_launch_log "daemon process launched in non-visible herdr workspace $wsid (pane $session:$pane), target $captain_target; supervision is NOT yet confirmed - run bin/fm-afk-health.sh for the verdict"
 }
 
 # Launch the daemon in a detached tmux session (never a split-window in the
@@ -457,7 +457,7 @@ fm_afk_launch_create_tmux() {  # <captain-target> <captain-backend>
     return 1
   fi
   fm_afk_launch_commit_terminal tmux "$session" "" 1 || return 1
-  fm_afk_launch_log "daemon launched in detached tmux session '$session', supervising $captain_target"
+  fm_afk_launch_log "daemon process launched in detached tmux session '$session', target $captain_target; supervision is NOT yet confirmed - run bin/fm-afk-health.sh for the verdict"
 }
 
 fm_afk_launch_start() {

--- a/bin/fm-session-start.sh
+++ b/bin/fm-session-start.sh
@@ -402,7 +402,7 @@ subsection "AFK"
 # drops to one-shot and hands triage to the daemon, so a flag with a dead daemon
 # means nothing is triaging at all. bin/fm-afk-health.sh owns that verdict.
 if [ -e "$STATE/.afk" ]; then
-  if AFK_HEALTH=$("$FM_ROOT/bin/fm-afk-health.sh" 2>&1); then
+  if AFK_HEALTH=$("$SCRIPT_DIR/fm-afk-health.sh" 2>&1); then
     case "$AFK_HEALTH" in
       AFK_STARTING*)
         printf 'present - away mode is still arming, not yet supervising.\n' ;;

--- a/bin/fm-session-start.sh
+++ b/bin/fm-session-start.sh
@@ -398,8 +398,17 @@ done
 [ "$ORPHAN_STATUS_FOUND" -eq 1 ] || printf '(none)\n'
 
 subsection "AFK"
+# The flag alone is NOT evidence of supervision: while it exists the watcher
+# drops to one-shot and hands triage to the daemon, so a flag with a dead daemon
+# means nothing is triaging at all. bin/fm-afk-health.sh owns that verdict.
 if [ -e "$STATE/.afk" ]; then
-  printf 'present - away-mode supervision is active; the daemon owns the watcher.\n'
+  if AFK_HEALTH=$("$FM_ROOT/bin/fm-afk-health.sh" 2>&1); then
+    printf 'present - away-mode supervision is active; the daemon owns the watcher.\n'
+    printf '%s\n' "$AFK_HEALTH"
+  else
+    printf 'present but NOT SUPERVISED - the away-mode flag is set and no daemon is triaging.\n'
+    printf '%s\n' "$AFK_HEALTH"
+  fi
 else
   printf 'absent\n'
 fi

--- a/bin/fm-session-start.sh
+++ b/bin/fm-session-start.sh
@@ -403,7 +403,12 @@ subsection "AFK"
 # means nothing is triaging at all. bin/fm-afk-health.sh owns that verdict.
 if [ -e "$STATE/.afk" ]; then
   if AFK_HEALTH=$("$FM_ROOT/bin/fm-afk-health.sh" 2>&1); then
-    printf 'present - away-mode supervision is active; the daemon owns the watcher.\n'
+    case "$AFK_HEALTH" in
+      AFK_STARTING*)
+        printf 'present - away mode is still arming, not yet supervising.\n' ;;
+      *)
+        printf 'present - away-mode supervision is active; the daemon owns the watcher.\n' ;;
+    esac
     printf '%s\n' "$AFK_HEALTH"
   else
     printf 'present but NOT SUPERVISED - the away-mode flag is set and no daemon is triaging.\n'

--- a/bin/fm-supervise-daemon.sh
+++ b/bin/fm-supervise-daemon.sh
@@ -235,10 +235,23 @@ else
   _stat_file_mtime() { stat -c %Y "$1" 2>/dev/null; }
 fi
 _now() { date +%s; }
-_file_age() {  # seconds since mtime; very large if missing
-  local f=$1 m
+# Seconds since mtime; "very old" (999999) whenever the age cannot be trusted.
+# bin/fm-wake-lib.sh's fm_path_age owns the fail-safe age contract this follows:
+# an unreadable or unparseable age must read as DUE, never as an empty string.
+# Checking only the exit status is not enough. A `stat` that exits 0 while
+# printing non-numeric text (a wrapper/shim, or a non-BSD stat reached with BSD
+# flags) reaches $(( )), where `set -u` turns the recursive arithmetic
+# evaluation of $m into an unbound-variable error, so the echo never runs and
+# the caller's `-ge` gate receives an EMPTY operand: it dies with "integer
+# expression expected" and reads as FALSE, silently stopping housekeeping while
+# away mode still reports itself active.
+_file_age() {
+  local f=$1 m now
   m=$(_stat_file_mtime "$f") || { echo 999999; return; }
-  echo $(( $(_now) - m ))
+  case $m in ''|*[!0-9]*) echo 999999; return ;; esac
+  now=$(_now) || { echo 999999; return; }
+  case $now in ''|*[!0-9]*) echo 999999; return ;; esac
+  echo $(( now - m ))
 }
 
 _hash_text() {
@@ -932,14 +945,17 @@ inject_wedge_alarm() {  # <state> <age-seconds>
 }
 
 _oldest_line_age() {  # <buf> -> seconds since the oldest buffered item first arrived (sidecar epoch)
-  local f=$1 since
+  local f=$1 since epoch now
   [ -s "$f" ] || { echo 999999; return; }
   since="${f}.since"
-  if [ -r "$since" ]; then
-    echo $(( $(_now) - $(cat "$since" 2>/dev/null || echo 0) ))
-  else
-    echo 999999
-  fi
+  [ -r "$since" ] || { echo 999999; return; }
+  # Same fail-safe age contract as _file_age: a truncated or corrupt sidecar
+  # must flush the buffer, never abort the tick with an empty operand.
+  epoch=$(cat "$since" 2>/dev/null || true)
+  case $epoch in ''|*[!0-9]*) echo 999999; return ;; esac
+  now=$(_now) || { echo 999999; return; }
+  case $now in ''|*[!0-9]*) echo 999999; return ;; esac
+  echo $(( now - epoch ))
 }
 
 # --- housekeeping (runs every tick while the watcher is mid-cycle) ----------
@@ -1332,6 +1348,29 @@ fm_super_main() {
   echo "$$" > "$PIDFILE"
   fm_pid_identity "${BASHPID:-$$}" > "$LOCK/pid-identity" 2>/dev/null || true
 
+  # --- the daemon must never die silently ----------------------------------
+  # Away mode hands triage to this process while state/.afk exists, so a death
+  # here stops all triage while away mode still reports itself active. Two
+  # durable records make that impossible to miss:
+  #   1. stderr is appended to the daemon log, so a bash error (the class that
+  #      caused the housekeeping-gate incident) lands where supervision already
+  #      looks instead of in a harness task-output file nobody reads;
+  #   2. an EXIT trap records the exit code, so a gone process always leaves a
+  #      reason behind. bin/fm-afk-health.sh reads both.
+  local READY="$STATE/.subsuper-daemon-ready"
+  local EXITED="$STATE/.subsuper-daemon-exit"
+  rm -f "$READY" "$EXITED" 2>/dev/null || true
+  exec 2>>"$LOG"
+  record_exit() {
+    local rc=$?
+    printf '%s\texit=%s\tpid=%s\tready=%s\n' \
+      "$(date '+%Y-%m-%dT%H:%M:%S%z')" "$rc" "$$" \
+      "$([ -f "$READY" ] && echo yes || echo no)" > "$EXITED" 2>/dev/null || true
+    log "daemon exited rc=$rc"
+    rm -f "$READY" 2>/dev/null || true
+  }
+  trap record_exit EXIT
+
   # --- auto-discover the supervisor BACKEND (tmux vs herdr) first -----------
   # Priority: FM_SUPERVISOR_BACKEND override > $TMUX_PANE (tmux) > $HERDR_ENV=1
   # (herdr) > tmux fallback. Resolved before the target below, since target
@@ -1519,6 +1558,15 @@ fm_super_main() {
     if [ "$(_file_age "$STATE/.subsuper-last-housekeep")" -ge "${FM_HOUSEKEEPING_TICK:-$HOUSEKEEPING_TICK_DEFAULT}" ]; then
       _now > "$STATE/.subsuper-last-housekeep"
       housekeeping "$STATE"
+      # Readiness is claimed only here, AFTER a housekeeping tick has actually
+      # run. Arming reports success from this beacon rather than from "the
+      # process was launched", so a daemon that starts and then dies before it
+      # ever triages can no longer be reported as live away-mode supervision.
+      if [ ! -f "$READY" ]; then
+        _now > "$READY"
+        log "daemon ready (first housekeeping tick complete)"
+        echo "afk: supervision live (first housekeeping tick complete)"
+      fi
     fi
   done
 }

--- a/bin/fm-supervise-daemon.sh
+++ b/bin/fm-supervise-daemon.sh
@@ -1374,10 +1374,13 @@ fm_super_main() {
   #      looks instead of in a harness task-output file nobody reads;
   #   2. an EXIT trap records the exit code, so a gone process always leaves a
   #      reason behind. bin/fm-afk-health.sh reads both.
+  # stderr is rebound to the log only after startup validation (below), so a
+  # launcher that starts the daemon in the foreground still SEES an unsupported
+  # backend or an unresolvable target on its own stderr instead of having the
+  # refusal disappear into a log file it never reads.
   local READY="$STATE/.subsuper-daemon-ready"
   local EXITED="$STATE/.subsuper-daemon-exit"
   rm -f "$READY" "$EXITED" 2>/dev/null || true
-  exec 2>>"$LOG"
   record_exit() {
     local rc=$?
     printf '%s\texit=%s\tpid=%s\tready=%s\n' \
@@ -1461,6 +1464,11 @@ fm_super_main() {
     rm -f "$PIDFILE" 2>/dev/null || true
     exit 1
   fi
+
+  # Startup validation has passed: from here on this process is long-lived and
+  # nobody is reading its stderr, so bind fd 2 to the log (see the durability
+  # note above the EXIT trap).
+  exec 2>>"$LOG"
 
   local afk_status="off"
   afk_active "$STATE" && afk_status="on"

--- a/bin/fm-supervise-daemon.sh
+++ b/bin/fm-supervise-daemon.sh
@@ -254,6 +254,18 @@ _file_age() {
   echo $(( now - m ))
 }
 
+# Age of the epoch RECORDED INSIDE a marker file (not its mtime). Same fail-safe
+# contract as fm_path_age in bin/fm-wake-lib.sh: unreadable or unparseable reads
+# as very old, so a cadence gate errs toward doing the work.
+_marker_age() {
+  local f=$1 v now
+  v=$(cat "$f" 2>/dev/null || true)
+  case $v in ''|*[!0-9]*) echo 999999; return ;; esac
+  now=$(_now) || { echo 999999; return; }
+  case $now in ''|*[!0-9]*) echo 999999; return ;; esac
+  echo $(( now - v ))
+}
+
 _hash_text() {
   if command -v md5 >/dev/null 2>&1; then printf '%s' "$1" | md5 -q
   else printf '%s' "$1" | md5sum | cut -d ' ' -f1; fi
@@ -973,8 +985,7 @@ _oldest_line_age() {  # <buf> -> seconds since the oldest buffered item first ar
 #  3) heartbeat scan: every HEARTBEAT_SCAN_SECS, grep state/*.status for a
 #     captain-relevant line the per-wake classifier missed and escalate it.
 housekeeping() {  # <state>
-  local state=$1 now due f key task win marker age last max_defer oldest pause_secs
-  now=$(_now)
+  local state=$1 due f key task win marker age last max_defer oldest pause_secs
   migrate_watcher_pause_markers "$state"
 
   # (1) batch flush
@@ -1024,7 +1035,7 @@ housekeeping() {  # <state>
       reconcile_pause_tracking "$win" "$state" "$last"
       continue
     fi
-    age=$(( now - $(cat "$marker" 2>/dev/null || echo "$now") ))
+    age=$(_marker_age "$marker")
     [ "$age" -ge "${FM_STALE_ESCALATE_SECS:-$STALE_ESCALATE_SECS_DEFAULT}" ] || continue
     stale_window_is_busy "$win" "$state"
     case "$?" in
@@ -1055,7 +1066,7 @@ housekeeping() {  # <state>
       reconcile_pause_tracking "$win" "$state" "$last"
       continue
     fi
-    age=$(( now - $(cat "$marker" 2>/dev/null || echo "$now") ))
+    age=$(_marker_age "$marker")
     [ "$age" -ge "$pause_secs" ] || continue
     stale_window_is_busy "$win" "$state"
     case "$?" in
@@ -1305,7 +1316,13 @@ trim_log() {
   sz=$(wc -c < "$LOG" 2>/dev/null) || return 0
   [ "$sz" -ge "${FM_LOG_MAX_BYTES:-$LOG_MAX_BYTES_DEFAULT}" ] || return 0
   tmp=$(mktemp "${TMPDIR:-/tmp}/fm-daemon-log.XXXXXX") || return 0
-  tail -n "${FM_LOG_KEEP_LINES:-$LOG_KEEP_LINES_DEFAULT}" "$LOG" >"$tmp" 2>/dev/null && mv -f "$tmp" "$LOG"
+  # Written back IN PLACE rather than mv'd over: the daemon's stderr is bound to
+  # this file's inode (exec 2>>"$LOG"), so replacing the inode would silently
+  # send every later bash error to an unlinked file.
+  if tail -n "${FM_LOG_KEEP_LINES:-$LOG_KEEP_LINES_DEFAULT}" "$LOG" >"$tmp" 2>/dev/null; then
+    cat "$tmp" > "$LOG" 2>/dev/null || true
+  fi
+  rm -f "$tmp" 2>/dev/null || true
 }
 
 # ============================================================================

--- a/bin/fm-wake-lib.sh
+++ b/bin/fm-wake-lib.sh
@@ -72,10 +72,25 @@ fm_path_mtime() {
   fi
 }
 
+# Owner of the fail-safe age contract shared with fm-watch.sh's age_of and
+# fm-supervise-daemon.sh's _file_age: every age helper must emit a bare integer
+# on every path, and must report "very old" (999999, i.e. DUE) whenever the age
+# cannot be trusted, so a cadence gate errs toward doing the work.
+#
+# Validating the OUTPUT matters as much as the exit status. A `stat` that exits
+# 0 while printing non-numeric text (a wrapper/shim, or a non-BSD stat reached
+# with BSD flags) reaches $(( )); under `set -u` the recursive arithmetic
+# evaluation of that text raises an unbound-variable error, the echo never runs,
+# and the helper returns an EMPTY string on a ZERO exit status. Callers then die
+# with "integer expression expected" and the gate reads FALSE, which silently
+# disables the very cadence it guards instead of failing loudly.
 fm_path_age() {
-  local path=$1 m
+  local path=$1 m now
   m=$(fm_path_mtime "$path") || { echo 999999; return; }
-  echo $(( $(date +%s) - m ))
+  case $m in ''|*[!0-9]*) echo 999999; return ;; esac
+  now=$(date +%s) || { echo 999999; return; }
+  case $now in ''|*[!0-9]*) echo 999999; return ;; esac
+  echo $(( now - m ))
 }
 
 FM_WATCHER_MATCHED_IDENTITY=

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -286,7 +286,7 @@ wedge_timer_check() {  # <window> <since-file> <triage-label> <escalation-count-
     *)
       age=$(( $(date +%s) - since ))
       if [ "$age" -ge "$STALE_ESCALATE_SECS" ]; then
-        n=$(( $(cat "$escalation_file" 2>/dev/null || echo 0) + 1 ))
+        n=$(( $(read_counter "$escalation_file") + 1 ))
         echo "$n" > "$escalation_file"
         reason="stale: $win (idle ${age}s, possible wedge, escalation $n)"
         if [ "$n" -ge "$FM_WEDGE_DEMAND_INSPECT_COUNT" ]; then
@@ -432,10 +432,26 @@ surface_nonterminal_stale() {  # <window> <hash>
 # Check and heartbeat cadence must survive actionable exits and restarts: the
 # watcher may be relaunched before in-memory counters reach their threshold on a
 # busy fleet. Persist the schedule as file mtimes instead.
-age_of() {  # seconds since file mtime; "due immediately" if missing
-  local f=$1 m
+# Seconds since file mtime; "due immediately" if missing OR unreadable.
+# bin/fm-wake-lib.sh's fm_path_age owns the fail-safe age contract: validate the
+# output, not just the exit status, so an unparseable age reads as DUE instead
+# of returning an empty string that makes the caller's `-ge` gate die and read
+# as false, silently disabling the cadence it guards.
+age_of() {
+  local f=$1 m now
   m=$(stat_mtime "$f") || { echo 999999; return; }
-  echo $(( $(date +%s) - m ))
+  case $m in ''|*[!0-9]*) echo 999999; return ;; esac
+  now=$(date +%s) || { echo 999999; return; }
+  case $now in ''|*[!0-9]*) echo 999999; return ;; esac
+  echo $(( now - m ))
+}
+
+# Counter state files follow the same contract: a truncated, empty, or corrupt
+# file must never reach $(( )), where `set -u` would abort the poll mid-cycle.
+read_counter() {  # <file> -> non-negative integer; 0 when missing or unparseable
+  local v
+  v=$(cat "$1" 2>/dev/null || true)
+  case $v in ''|*[!0-9]*) echo 0 ;; *) echo "$v" ;; esac
 }
 
 # Layer 2 + 3 signal scan: status files and turn-end markers. Each file is
@@ -953,7 +969,7 @@ EOF
     # reused below so a busy verdict is consistent within one cycle.
     if window_is_busy "$w" "$tail40"; then busy_now=0; else busy_now=1; fi
     if [ "$h" = "$prev" ]; then
-      n=$(( $(cat "$cf" 2>/dev/null || echo 0) + 1 ))
+      n=$(( $(read_counter "$cf") + 1 ))
       echo "$n" > "$cf"
       if [ "$n" -ge 2 ] && [ "$busy_now" -ne 0 ]; then
         # The pane is idle/stale at hash $h. Triage decides whether this wakes
@@ -1115,7 +1131,7 @@ EOF
       wake "heartbeat"
     else
       touch "$STATE/.last-heartbeat"
-      echo $(( $(cat "$STATE/.heartbeat-streak" 2>/dev/null || echo 0) + 1 )) > "$STATE/.heartbeat-streak"
+      echo $(( $(read_counter "$STATE/.heartbeat-streak") + 1 )) > "$STATE/.heartbeat-streak"
       triage_log "absorbed heartbeat (no captain-relevant change)"
     fi
   fi

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -1107,7 +1107,7 @@ EOF
   # what. Time-based via .last-heartbeat mtime; interval doubles per consecutive
   # no-change heartbeat (idle fleet) up to HEARTBEAT_MAX, and resets on any
   # surfaced non-heartbeat wake.
-  streak=$(cat "$STATE/.heartbeat-streak" 2>/dev/null || echo 0)
+  streak=$(read_counter "$STATE/.heartbeat-streak")
   [ "$streak" -gt 12 ] && streak=12
   hb=$(( HEARTBEAT * (1 << streak) ))
   [ "$hb" -gt "$HEARTBEAT_MAX" ] && hb=$HEARTBEAT_MAX

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -65,6 +65,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-afk-start.sh`        | Run the common sourceable away-mode daemon entry in the foreground                      |
 | `fm-afk-launch.sh`       | Own away-mode entry, exit, rollback, and any backend terminal lifecycle                 |
 | `fm-afk-return.sh`       | Own deterministic return shutdown, catch-up evidence, and the firstmate-actionable blocker gate |
+| `fm-afk-health.sh`       | Own the away-mode liveness verdict: is supervision real, still arming, or a flag with no daemon |
 | `fm-supervisor-target-lib.sh` | Resolve the shared supervisor target and backend for the daemon and launcher       |
 | `fm-supervise-daemon.sh` | Presence-gated away-mode sub-supervisor: self-handle routine wakes, guard injection by the detected primary harness, escalate batched digests, alert on failed delivery |
 | `fm-crew-state.sh`       | Print one deterministic current-state line for a crew                                |

--- a/docs/verification/supervision.md
+++ b/docs/verification/supervision.md
@@ -241,6 +241,49 @@ tests/fm-claude-stop-autoarm.test.sh
 tests/fm-turnend-guard.test.sh
 ```
 
+## Away-mode daemon liveness
+
+The fail-safe age contract and the away-mode liveness verdict behind [`bin/fm-afk-health.sh`](../../bin/fm-afk-health.sh) were verified on 2026-08-03 with isolated homes and daemons stopped by exact pid.
+
+```sh
+bash tests/fm-afk-daemon-liveness.test.sh
+bin/fm-lint.sh
+bin/fm-doc-audience-check.sh
+```
+
+Observed output:
+
+```text
+ok - fm-supervise-daemon.sh _file_age: unparseable mtime reads as due (999999), gate survives
+ok - fm-watch.sh age_of: unparseable mtime reads as due (999999), gate survives
+ok - fm-wake-lib.sh fm_path_age: unparseable mtime reads as due (999999), gate survives
+ok - housekeeping gate evaluates cleanly and runs housekeeping
+ok - corrupt counter file reads as 0 instead of aborting the poll
+ok - no away-mode flag reports AFK_OFF
+ok - away-mode flag with no live daemon is loudly AFK_DEGRADED
+ok - durable exit record is surfaced as the reason the daemon is gone
+ok - a freshly launched, not-yet-ready daemon reports AFK_STARTING
+ok - an unarmed daemon past the arming window is AFK_DEGRADED
+ok - the readiness beacon is what makes away mode AFK_HEALTHY
+ok - daemon stderr still lands in the log after repeated rotation
+fm-lint.sh: ShellCheck 0.11.0 (pinned 0.11.0)
+fm-doc-audience-check: ok surfaces=64 local_links=185
+```
+
+The same suite was rerun against the pre-change `bin/` tree extracted from `cf95112`, with only the new health script and the new test copied in, and reported six failures.
+The untrusted age reached the housekeeping gate as an empty string on a zero exit status, so the gate printed both `line 241: File: unbound variable` and `[: : integer expression expected` and then evaluated to `NOTDUE`.
+That silent `NOTDUE` is the guarantee this record supports: an untrustworthy age must read as due, because a gate that errors and also reads false stops housekeeping while away mode still reports itself active.
+The same baseline lost daemon stderr after log rotation and let a corrupt counter file abort the poll.
+
+The related supervision suites passed on 2026-08-03 with zero `not ok` lines.
+
+```sh
+tests/fm-afk-launch.test.sh
+tests/fm-afk-return.test.sh
+tests/fm-wake-queue.test.sh
+tests/fm-supervision-events.test.sh
+```
+
 ## Wedge-alarm channels
 
 The two real notification channels were bounded manually on 2026-07-10 on macOS 26.5.2 with Herdr 0.7.3.

--- a/tests/fm-afk-daemon-liveness.test.sh
+++ b/tests/fm-afk-daemon-liveness.test.sh
@@ -150,4 +150,84 @@ case $out in
   *) fail "exit record not surfaced by the health check: $out" ;;
 esac
 
+# --- 5. a live-but-unarmed daemon is "starting" only for a bounded window ----
+# A daemon that never reaches its first housekeeping tick is not triaging, so
+# AFK_STARTING must age into AFK_DEGRADED instead of reading as supervision.
+mkdir -p "$WORK/fakebin"
+cat > "$WORK/fakebin/fm-supervise-daemon.sh" <<'FAKE'
+#!/bin/sh
+sleep 120
+FAKE
+chmod +x "$WORK/fakebin/fm-supervise-daemon.sh"
+"$WORK/fakebin/fm-supervise-daemon.sh" &
+FAKE_PID=$!
+# shellcheck disable=SC2329 # Invoked indirectly by the EXIT trap below.
+cleanup() { kill "$FAKE_PID" 2>/dev/null || true; rm -rf "$WORK"; }
+
+LOCKDIR="$FM_STATE_OVERRIDE/.supervise-daemon.lock"
+mkdir -p "$LOCKDIR"
+echo "$FAKE_PID" > "$LOCKDIR/pid"
+
+if out=$("$HEALTH" 2>&1); then
+  case $out in
+    AFK_STARTING*) pass "a freshly launched, not-yet-ready daemon reports AFK_STARTING" ;;
+    *) fail "expected AFK_STARTING inside the arming window, got: $out" ;;
+  esac
+else
+  fail "health check exited non-zero inside the arming window: $out"
+fi
+
+# Age the daemon's own start evidence past the window.
+touch -t 202001010000 "$LOCKDIR"
+if out=$("$HEALTH" 2>&1); then
+  fail "a daemon that never armed still reported success: $out"
+else
+  case $out in
+    AFK_DEGRADED*) pass "an unarmed daemon past the arming window is AFK_DEGRADED" ;;
+    *) fail "expected AFK_DEGRADED past the arming window, got: $out" ;;
+  esac
+fi
+
+# Ready beacon present: supervision is real again regardless of arming age.
+touch "$FM_STATE_OVERRIDE/.subsuper-daemon-ready"
+if out=$("$HEALTH" 2>&1); then
+  case $out in
+    AFK_HEALTHY*) pass "the readiness beacon is what makes away mode AFK_HEALTHY" ;;
+    *) fail "expected AFK_HEALTHY with the ready beacon, got: $out" ;;
+  esac
+else
+  fail "health check failed with a ready daemon: $out"
+fi
+
+kill "$FAKE_PID" 2>/dev/null || true
+
+# --- 6. daemon stderr must survive log rotation ------------------------------
+# The daemon binds fd 2 to its log so a bash error lands where supervision
+# already looks. Rotation must not detach that fd from the log file.
+STDERR_LOG="$WORK/daemon.log"
+cat > "$WORK/trimcheck.sh" <<TRIM
+set -u
+FM_HOME=$WORK
+FM_STATE_OVERRIDE=$WORK/state
+. '$ROOT/bin/fm-supervise-daemon.sh' >/dev/null 2>&1 || true
+LOG='$STDERR_LOG'
+: > "\$LOG"
+exec 2>>"\$LOG"
+export FM_LOG_MAX_BYTES=200 FM_LOG_KEEP_LINES=3
+r=0
+while [ \$r -lt 3 ]; do
+  i=0
+  while [ \$i -lt 100 ]; do echo "filler line \$i" >> "\$LOG"; i=\$(( i + 1 )); done
+  trim_log
+  r=\$(( r + 1 ))
+done
+echo 'DAEMON-STDERR-MARKER' >&2
+TRIM
+bash "$WORK/trimcheck.sh" >/dev/null 2>&1 || true
+if grep -q 'DAEMON-STDERR-MARKER' "$STDERR_LOG" 2>/dev/null; then
+  pass "daemon stderr still lands in the log after repeated rotation"
+else
+  fail "daemon stderr was lost after log rotation - a crash would be invisible"
+fi
+
 exit "$FAILED"

--- a/tests/fm-afk-daemon-liveness.test.sh
+++ b/tests/fm-afk-daemon-liveness.test.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+# tests/fm-afk-daemon-liveness.test.sh - away-mode supervision must be
+# trustworthy: it may not crash on an unreadable age, and it may not report
+# itself active while nothing is triaging.
+#
+# REGRESSION (the housekeeping-gate incident): every age helper guarded only the
+# EXIT STATUS of its stat call. A `stat` that exits 0 while printing non-numeric
+# text reached $(( )), where `set -u` turns the recursive arithmetic evaluation
+# of that text into an unbound-variable error. The echo then never ran, the
+# helper returned an EMPTY string on a ZERO exit status, and the caller's
+# `[ ... -ge <tick> ]` gate died with "integer expression expected" AND read as
+# FALSE - so housekeeping silently stopped running while away mode still
+# reported itself active. bin/fm-watch.sh's own header documents this exact
+# "File" stray-token hazard for the stat fallback form; these tests pin the
+# helpers themselves so any other route to non-numeric output fails safe.
+#
+# Every assertion drives a real interface: the shipped helper functions and the
+# shipped bin/fm-afk-health.sh, never implementation source bytes.
+set -u
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+HEALTH="$ROOT/bin/fm-afk-health.sh"
+
+FAILED=0
+fail() { printf 'not ok - %s\n' "$1" >&2; FAILED=1; }
+pass() { printf 'ok - %s\n' "$1"; }
+
+WORK=$(mktemp -d "${TMPDIR:-/tmp}/fm-afk-liveness.XXXXXX")
+# shellcheck disable=SC2329 # Invoked indirectly by the EXIT trap below.
+cleanup() { rm -rf "$WORK"; }
+trap cleanup EXIT
+
+# A `stat` earlier on PATH that exits 0 but prints non-integer text. This is the
+# real-world shape: a stat wrapper/shim, or a non-BSD stat reached with BSD
+# flags, where `-f` means --file-system and prints a filesystem block.
+mkdir -p "$WORK/shim"
+cat > "$WORK/shim/stat" <<'SHIM'
+#!/bin/sh
+echo "  File: \"/\""
+echo "  ID: 0 Namelen: 255 Type: apfs"
+exit 0
+SHIM
+chmod +x "$WORK/shim/stat"
+
+# --- 1. every age helper must fail SAFE, never return an empty operand -------
+# Each helper is exercised in its own shell with the shim first on PATH and with
+# `set -u` active, exactly as the daemon and watcher run.
+check_age_helper() {  # <label> <script> <load-snippet> <call>
+  local label=$1 script=$2 load=$3 call=$4 out rc
+  out=$(PATH="$WORK/shim:$PATH" bash -c "
+    set -u
+    $load
+    $call
+  " 2>/dev/null) || true
+  rc=0
+  # The defect signature: an EMPTY string, which then makes an integer gate die.
+  case $out in
+    '') fail "$label: returned an EMPTY age (the crash signature)"; return ;;
+    *[!0-9]*) fail "$label: returned a non-integer age [$out]"; return ;;
+  esac
+  # Fail-safe direction: an untrustworthy age must read as DUE, so the cadence
+  # gate does the work instead of silently skipping it forever.
+  if [ "$out" -ge 15 ]; then
+    pass "$label: unparseable mtime reads as due ($out), gate survives"
+  else
+    fail "$label: unparseable mtime read as NOT due ($out) - cadence would stall"
+  fi
+  : "$rc" "$script"
+}
+
+check_age_helper "fm-supervise-daemon.sh _file_age" \
+  "$ROOT/bin/fm-supervise-daemon.sh" \
+  "FM_HOME=$WORK; FM_STATE_OVERRIDE=$WORK/state; . '$ROOT/bin/fm-supervise-daemon.sh' >/dev/null 2>&1 || true" \
+  "_file_age '$WORK'"
+
+check_age_helper "fm-watch.sh age_of" \
+  "$ROOT/bin/fm-watch.sh" \
+  "FM_HOME=$WORK; FM_STATE_OVERRIDE=$WORK/state; . '$ROOT/bin/fm-watch.sh' >/dev/null 2>&1 || true" \
+  "age_of '$WORK'"
+
+check_age_helper "fm-wake-lib.sh fm_path_age" \
+  "$ROOT/bin/fm-wake-lib.sh" \
+  "FM_HOME=$WORK; STATE=$WORK/state; FM_STATE_OVERRIDE=$WORK/state; . '$ROOT/bin/fm-wake-lib.sh' >/dev/null 2>&1 || true" \
+  "fm_path_age '$WORK'"
+
+# --- 2. the gate the incident actually killed -------------------------------
+# Pin the caller, not just the helper: the housekeeping gate must still evaluate
+# cleanly (no "integer expression expected") when the age is untrustworthy.
+gate_err=$(PATH="$WORK/shim:$PATH" bash -c "
+  set -u
+  FM_HOME=$WORK; FM_STATE_OVERRIDE=$WORK/state
+  . '$ROOT/bin/fm-supervise-daemon.sh' >/dev/null 2>&1 || true
+  if [ \"\$(_file_age '$WORK/nofile')\" -ge 15 ]; then echo DUE; else echo NOTDUE; fi
+" 2>&1) || true
+case $gate_err in
+  *"integer expression expected"*)
+    fail "housekeeping gate still dies on an untrustworthy age: $gate_err" ;;
+  *DUE*)
+    pass "housekeeping gate evaluates cleanly and runs housekeeping" ;;
+  *)
+    fail "housekeeping gate produced an unexpected verdict: $gate_err" ;;
+esac
+
+# --- 3. counter files must not abort a poll either ---------------------------
+counter_out=$(bash -c "
+  set -u
+  FM_HOME=$WORK; FM_STATE_OVERRIDE=$WORK/state
+  . '$ROOT/bin/fm-watch.sh' >/dev/null 2>&1 || true
+  # Guard against a vacuous pass: an ABSENT validator must fail this test, not
+  # slip through as an empty command substitution that happens to sum to 1.
+  type read_counter >/dev/null 2>&1 || { echo 'NO-VALIDATOR'; exit 0; }
+  printf 'corrupt-not-a-number' > '$WORK/counter'
+  echo \$(( \$(read_counter '$WORK/counter') + 1 ))
+" 2>/dev/null) || true
+if [ "$counter_out" = "1" ]; then
+  pass "corrupt counter file reads as 0 instead of aborting the poll"
+else
+  fail "corrupt counter file did not fail safe (got [$counter_out], want 1)"
+fi
+
+# --- 4. away mode must not report itself active with no live daemon ---------
+export FM_STATE_OVERRIDE="$WORK/health-state"
+mkdir -p "$FM_STATE_OVERRIDE"
+
+if out=$("$HEALTH" 2>&1); then
+  case $out in
+    AFK_OFF*) pass "no away-mode flag reports AFK_OFF" ;;
+    *) fail "expected AFK_OFF with no flag, got: $out" ;;
+  esac
+else
+  fail "health check failed with no away-mode flag: $out"
+fi
+
+date +%s > "$FM_STATE_OVERRIDE/.afk"
+if out=$("$HEALTH" 2>&1); then
+  fail "away-mode flag with NO live daemon reported healthy: $out"
+else
+  case $out in
+    AFK_DEGRADED*) pass "away-mode flag with no live daemon is loudly AFK_DEGRADED" ;;
+    *) fail "expected AFK_DEGRADED, got: $out" ;;
+  esac
+fi
+
+# A durable exit record must be surfaced as the REASON, not just "gone".
+printf '2026-08-03T00:00:00-0700\texit=1\tpid=999\tready=no\n' \
+  > "$FM_STATE_OVERRIDE/.subsuper-daemon-exit"
+out=$("$HEALTH" 2>&1) || true
+case $out in
+  *"exit=1"*) pass "durable exit record is surfaced as the reason the daemon is gone" ;;
+  *) fail "exit record not surfaced by the health check: $out" ;;
+esac
+
+exit "$FAILED"

--- a/tests/fm-session-start.test.sh
+++ b/tests/fm-session-start.test.sh
@@ -1261,7 +1261,12 @@ EOF
 
   out=$(run_session_start "$home" "$root" "$fakebin:$BASE_PATH")
 
-  assert_contains "$out" "away-mode supervision is active" "AFK digest did not report away mode"
+  # The flag alone is not evidence of supervision: this world has the flag and no
+  # daemon, so the digest must report the real (degraded) verdict, not claim
+  # supervision from the flag's existence.
+  assert_contains "$out" "present but NOT SUPERVISED" "AFK digest did not report the flag-without-daemon verdict"
+  assert_contains "$out" "AFK_DEGRADED" "AFK digest did not surface the health verdict"
+  assert_not_contains "$out" "away-mode supervision is active" "AFK digest claimed supervision with no live daemon"
   assert_contains "$out" "Away mode is active" "next step did not switch to AFK guidance"
   assert_contains "$out" "daemon owns the watcher" "next step did not delegate watcher ownership to the daemon"
   assert_contains "$out" "- Away mode: active" "supervision block did not include active AFK state"


### PR DESCRIPTION
## Intent

Make firstmate's away-mode (/afk) supervision trustworthy: it was crashing intermittently and reporting success while doing so.

The observed failure: bin/fm-supervise-daemon.sh died with 'line 1513: [: : integer expression expected' at the housekeeping-tick gate, which compares _file_age against FM_HOUSEKEEPING_TICK. The user explicitly required reproducing the bug end-to-end before fixing, not fixing on inspection.

Root cause found by reproduction: the age helpers guarded only the EXIT STATUS of their stat call, never the OUTPUT. A stat that exits 0 while printing non-numeric text (a wrapper/shim, or a non-BSD stat reached with BSD flags where -f means --file-system) reaches $(( )); because m is referenced as a bare name, bash arithmetic recursively evaluates its contents, and under the daemon's 'set -u' a stray word raises an unbound-variable error, so the echo never runs and the helper returns an EMPTY string on a ZERO exit status. The caller's [ ... -ge <tick> ] then both errored AND read as FALSE (rc=2), so housekeeping silently stopped running while away mode still reported itself active. That silent-skip consequence is worse than the crash and is asserted in the test.

Deliberate decisions the user asked for, which may look surprising in the diff:
- Fail-safe direction is intentional: an untrustworthy age returns 999999 ('very old' = DUE) so a cadence gate errs toward doing the work rather than stalling. The user explicitly forbade silencing the symptom by removing the housekeeping check.
- The fix was deliberately extended beyond the one crashing script into bin/fm-watch.sh and bin/fm-wake-lib.sh. The user's brief required auditing for sibling occurrences of the same shape; these are the same defect in the code path away mode depends on (the daemon sources the wake lib and runs the watcher as its child), so hardening only the daemon would have left the crash reachable. Counter reads and _oldest_line_age were routed through validating helpers for the same reason.
- Per the repo's firstmate-coding-guidelines one-owner rule, the fail-safe age contract is stated in full once in bin/fm-wake-lib.sh's fm_path_age and the other two helpers carry one-line cross-references rather than restating it.
- bin/fm-afk-health.sh is a NEW script, deliberately added: the user required that an .afk flag with a dead daemon be loudly detectable, because while that flag exists the watcher drops to one-shot and hands triage to the daemon, so flag-plus-dead-daemon means nothing triages at all.
- bin/fm-session-start.sh previously printed 'away-mode supervision is active' from the flag's mere existence. That was the lie the user asked to remove, so it now prints the real liveness verdict.
- The daemon had TERM/INT traps but no EXIT trap and sent stderr to the harness task-output file; it now appends stderr to its own log and records a durable exit reason, because during the incident the real bash error sat unread in a file nobody checks.
- Readiness is claimed only AFTER a housekeeping tick actually runs, so 'launched' can never be reported as 'supervising'.

Constraints honored: no watchers or daemons outside the task worktree were touched (no broad pkill), every test daemon was isolated via FM_STATE_OVERRIDE and killed by exact PID. Verified: new colocated tests/fm-afk-daemon-liveness.test.sh passes on fixed code and produces 5 failures on the un-fixed script with the original error; bin/fm-lint.sh clean; fm-doc-audience-check ok; fm-afk-launch, fm-afk-return, fm-wake-queue and fm-supervision-events all pass.

## What Changed

- Hardened the age/counter helpers in `bin/fm-supervise-daemon.sh`, `bin/fm-watch.sh`, and `bin/fm-wake-lib.sh` to validate `stat` *output*, not just its exit status. Previously a zero-exit `stat` that printed non-numeric text reached `$(( ))`, tripped `set -u`, and made the helper return an empty string on success - so the housekeeping-tick gate both errored (`[: : integer expression expected`) and read as false, silently stopping housekeeping while away mode still reported itself active. Unreadable ages now return a large sentinel so cadence gates err toward doing the work.
- Added `bin/fm-afk-health.sh`, a new liveness check that reports a real verdict for an `.afk` flag with a dead daemon, and rewired `bin/fm-session-start.sh` to print that verdict instead of asserting "supervision is active" from the flag's mere existence. The daemon now records a durable exit reason, appends its stderr to its own log, and only claims readiness after a housekeeping tick has actually run.
- Added `tests/fm-afk-daemon-liveness.test.sh` (12 assertions), plus docs updates to the afk skill, `docs/scripts.md`, and `docs/verification/supervision.md`. The test passes on the fixed code and reproduces 5 failures - including the original `unbound variable` error and the silent housekeeping skip - against the base commit.

## Risk Assessment

✅ Low: All five prior findings are correctly and narrowly fixed, every arithmetic and counter path in the touched files is now validated, the arming-window evidence source (lock dir mtime) provably ages, and the only remaining issue is cosmetic wording in an escalation message.

## Testing

Reproduced the reported failure end-to-end first: running the new colocated liveness test against the unfixed base commit yields the incident's exact `File: unbound variable` / `[: : integer expression expected` pair plus a `NOTDUE` verdict, proving both the crash and the worse silent-skip consequence. On the target commit all three age helpers fail safe to 999999, the housekeeping gate evaluates cleanly, corrupt counters read as 0, the new fm-afk-health.sh reports AFK_OFF/STARTING/DEGRADED/HEALTHY correctly with a bounded arming window, and daemon stderr survives log rotation. A manual CLI transcript shows the user-visible change: with an .afk flag and a dead daemon, session-start previously printed "away-mode supervision is active" and now prints "present but NOT SUPERVISED" with the AFK_DEGRADED reason and last exit record. The four sibling suites named in the intent all pass; no evidence was produced as screenshots because this change has no rendered UI surface - CLI transcripts are the actual end-user surface.

<details>
<summary>Evidence: Baseline reproduction on unfixed base commit cf95112 (crash + silent skip)</summary>

<code>not ok - fm-supervise-daemon.sh _file_age: returned an EMPTY age (the crash signature)&#10;not ok - fm-watch.sh age_of: returned an EMPTY age (the crash signature)&#10;not ok - fm-wake-lib.sh fm_path_age: returned an EMPTY age (the crash signature)&#10;not ok - housekeeping gate still dies on an untrustworthy age: bin/fm-supervise-daemon.sh: line 241: File: unbound variable&#10;bash: line 4: [: : integer expression expected&#10;NOTDUE&#10;EXIT=1</code>

```text
not ok - fm-supervise-daemon.sh _file_age: returned an EMPTY age (the crash signature)
not ok - fm-watch.sh age_of: returned an EMPTY age (the crash signature)
not ok - fm-wake-lib.sh fm_path_age: returned an EMPTY age (the crash signature)
not ok - housekeeping gate still dies on an untrustworthy age: /var/folders/hd/71xc74mj7577fdx2v0djth580000gn/T/tmp.QYdajOI8qf/bin/fm-supervise-daemon.sh: line 241: File: unbound variable
bash: line 4: [: : integer expression expected
NOTDUE
not ok - corrupt counter file did not fail safe (got [NO-VALIDATOR], want 1)
not ok - health check failed with no away-mode flag: tests/fm-afk-daemon-liveness.test.sh: line 125: /var/folders/hd/71xc74mj7577fdx2v0djth580000gn/T/tmp.QYdajOI8qf/bin/fm-afk-health.sh: No such file or directory
not ok - expected AFK_DEGRADED, got: tests/fm-afk-daemon-liveness.test.sh: line 135: /var/folders/hd/71xc74mj7577fdx2v0djth580000gn/T/tmp.QYdajOI8qf/bin/fm-afk-health.sh: No such file or directory
not ok - exit record not surfaced by the health check: tests/fm-afk-daemon-liveness.test.sh: line 147: /var/folders/hd/71xc74mj7577fdx2v0djth580000gn/T/tmp.QYdajOI8qf/bin/fm-afk-health.sh: No such file or directory
not ok - health check exited non-zero inside the arming window: tests/fm-afk-daemon-liveness.test.sh: line 171: /var/folders/hd/71xc74mj7577fdx2v0djth580000gn/T/tmp.QYdajOI8qf/bin/fm-afk-health.sh: No such file or directory
not ok - expected AFK_DEGRADED past the arming window, got: tests/fm-afk-daemon-liveness.test.sh: line 182: /var/folders/hd/71xc74mj7577fdx2v0djth580000gn/T/tmp.QYdajOI8qf/bin/fm-afk-health.sh: No such file or directory
not ok - health check failed with a ready daemon: tests/fm-afk-daemon-liveness.test.sh: line 193: /var/folders/hd/71xc74mj7577fdx2v0djth580000gn/T/tmp.QYdajOI8qf/bin/fm-afk-health.sh: No such file or directory
tests/fm-afk-daemon-liveness.test.sh: line 225: 94259 Terminated: 15          "$WORK/fakebin/fm-supervise-daemon.sh"
not ok - daemon stderr was lost after log rotation - a crash would be invisible
EXIT=1
```
</details>
<details>
<summary>Evidence: After: away-mode health + session-start report the real verdict</summary>

<code>$ bin/fm-afk-health.sh # NEW script&#10;AFK_DEGRADED: away-mode flag present but NO live daemon; last exit: 2026-08-03T00:00:00-0700 exit=1 pid=999 ready=no&#10;AFK_DEGRADED: nothing is triaging this fleet while state/.afk exists - re-arm away mode or clear the flag&#10;exit=1&#10;&#10;AFK&#10;--------------------------------------------------------------------------------&#10;present but NOT SUPERVISED - the away-mode flag is set and no daemon is triaging.</code>

```text
$ # scenario: away mode flagged (/afk) but the supervising daemon is dead
$ date +%s > state/.afk

$ bin/fm-afk-health.sh   # NEW script
AFK_DEGRADED: away-mode flag present but NO live daemon; last exit: 2026-08-03T00:00:00-0700 exit=1 pid=999 ready=no
AFK_DEGRADED: nothing is triaging this fleet while state/.afk exists - re-arm away mode or clear the flag
exit=1

$ bin/fm-session-start.sh | sed -n AFK-section   # FIXED
AFK
--------------------------------------------------------------------------------
present but NOT SUPERVISED - the away-mode flag is set and no daemon is triaging.
AFK_DEGRADED: away-mode flag present but NO live daemon; last exit: 2026-08-03T00:00:00-0700 exit=1 pid=999 ready=no
AFK_DEGRADED: nothing is triaging this fleet while state/.afk exists - re-arm away mode or clear the flag

================================================================================
NEXT STEP
```
</details>
<details>
<summary>Evidence: Before: session-start claimed supervision was active with a dead daemon</summary>

<code>$ # SAME scenario on the UNFIXED base commit cf95112 (flag set, no daemon)&#10;AFK&#10;--------------------------------------------------------------------------------&#10;present - away-mode supervision is active; the daemon owns the watcher.</code>

```text
$ # SAME scenario on the UNFIXED base commit cf95112 (flag set, no daemon)
AFK
--------------------------------------------------------------------------------
present - away-mode supervision is active; the daemon owns the watcher.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- 🚨 `bin/fm-supervise-daemon.sh:1027` - The same defect the change fixes is still reachable inside housekeeping(): `age=$(( now - $(cat &#34;$marker&#34; 2&gt;/dev/null || echo &#34;$now&#34;) ))` (also at line 1058) feeds unvalidated file content straight into arithmetic. The `|| echo &#34;$now&#34;` fallback only covers a failed cat; a marker that exists but is empty or corrupt (truncated write, partial disk write - the same corruption class the diff explicitly guards for the `.since` sidecar in _oldest_line_age) yields a bare non-numeric word, and under the daemon&#39;s `set -u` bash&#39;s recursive arithmetic evaluation raises an unbound-variable error. `age` is then never assigned, so the following `[ &#34;$age&#34; -ge ... ]` dereferences an unset variable and the daemon dies mid-housekeeping - the exact failure mode this change exists to eliminate, in the exact function it protects. Route both reads through a validating helper (the _file_age/_oldest_line_age `case $v in &#39;&#39;|*[!0-9]*)` shape) or a shared read_epoch helper.
- ⚠️ `bin/fm-watch.sh:1110` - `streak=$(cat &#34;$STATE/.heartbeat-streak&#34; 2&gt;/dev/null || echo 0)` is read raw, while the *write* side of the very same file at line 1134 was routed through the new read_counter validator in this diff. A corrupt or truncated .heartbeat-streak makes `[ &#34;$streak&#34; -gt 12 ]` error and then `hb=$(( HEARTBEAT * (1 &lt;&lt; streak) ))` hit the non-numeric token under `set -u`, aborting the watcher poll cycle - the same crash class the change hardened elsewhere. Use `streak=$(read_counter &#34;$STATE/.heartbeat-streak&#34;)`.
- ⚠️ `bin/fm-supervise-daemon.sh:1363` - `exec 2&gt;&gt;&#34;$LOG&#34;` pins fd 2 to the log file&#39;s current inode, but trim_log (line 1308) rotates via `tail ... &gt;&#34;$tmp&#34; &amp;&amp; mv -f &#34;$tmp&#34; &#34;$LOG&#34;`, which replaces the inode. After the first trim - which the loop triggers on every wake - the daemon&#39;s stderr keeps writing to the now-unlinked old inode, so exactly the bash-error output this change added to make crashes visible is silently discarded, and fm-afk-health.sh&#39;s `tail -5` on the log shows nothing. Either truncate in place (write the kept tail back to the same file) or re-`exec 2&gt;&gt;&#34;$LOG&#34;` after a successful trim.
- ⚠️ `bin/fm-afk-launch.sh:460` - Intent requires &#34;Readiness is claimed only AFTER a housekeeping tick actually runs, so &#39;launched&#39; can never be reported as &#39;supervising&#39;&#34;, and the new comment at bin/fm-supervise-daemon.sh:1561 asserts &#34;Arming reports success from this beacon rather than from &#39;the process was launched&#39;&#34;. But fm-afk-launch.sh still logs &#34;daemon launched in detached tmux session &#39;$session&#39;, supervising $captain_target&#34; (and the herdr equivalent at line 434) purely from a successful spawn, and nothing outside fm-afk-health.sh ever reads .subsuper-daemon-ready. The launcher&#39;s success message therefore still reports &#39;launched&#39; as &#39;supervising&#39; - the exact claim the intent forbids. Either have the launcher poll the ready beacon (or fm-afk-health.sh) before claiming supervision, or correct the daemon comment and the wording to say &#39;launched, not yet verified&#39;.
- ℹ️ `bin/fm-session-start.sh:405` - fm-afk-health.sh returns 0 for AFK_STARTING, so a daemon that is alive but has never completed a housekeeping tick (e.g. wedged before its first tick, or stuck on target resolution) makes session-start print &#34;present - away-mode supervision is active&#34;. The detailed health line printed underneath does say &#39;not yet past its first housekeeping tick&#39;, so this is not silent, but the headline still asserts active supervision on liveness alone. Consider a distinct headline for the non-ready case, or aging AFK_STARTING into AFK_DEGRADED after a bounded arming window.

🔧 Fix: validate marker ages, bound afk arming, keep stderr durable
1 info still open:
- ℹ️ `bin/fm-supervise-daemon.sh:1042` - The fail-safe direction of _marker_age is correct and intended, but its sentinel now leaks into captain-facing text: a corrupt or empty stale/pause marker produces age=999999, so escalate_add emits &#34;stale persisted 999999s (possible wedge): $win&#34; (and the equivalent line in the pause loop around 1070). The escalation firing is the desired behavior; only the bogus 11.5-day duration is misleading. Consider having the escalation say &#34;unknown duration (marker unreadable)&#34; when age is the sentinel, or reuse the flush path&#39;s phrasing.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash tests/fm-afk-daemon-liveness.test.sh` on the target commit - 12/12 assertions pass</code>
- <code>Baseline reproduction: extracted `bin/` from base commit cf95112 into a temp dir and ran the same test against it - 5 failures including `line 241: File: unbound variable`, `[: : integer expression expected`, and `NOTDUE` (the silent housekeeping skip)</code>
- <code>Manual CLI scenario: `FM_STATE_OVERRIDE=&lt;tmp&gt; bin/fm-afk-health.sh` with `.afk` present and no daemon -&gt; `AFK_DEGRADED` + durable exit reason, exit 1</code>
- <code>Manual CLI scenario: `bin/fm-session-start.sh` AFK section on fixed code vs the same scenario on base commit cf95112 (before/after contrast of the false &#39;supervision is active&#39; claim)</code>
- `bash tests/fm-afk-launch.test.sh`
- `bash tests/fm-afk-return.test.sh`
- `bash tests/fm-wake-queue.test.sh`
- `bash tests/fm-supervision-events.test.sh`
- <code>`git status --porcelain` - worktree clean, no transient artifacts left behind</code>

</details>

<details>
<summary>🔧 **Document** - 1 issue found → auto-fixed ✅</summary>

- ℹ️ `docs/verification/supervision.md` - docs/verification/supervision.md is the dated evidence log for supervision changes, but it has no entry for this fix or for the new tests/fm-afk-daemon-liveness.test.sh run. I did not add one because recording a verification pass is the validation phase&#39;s evidence to write, not the documentation phase&#39;s - writing dated &#39;observed output&#39; I did not personally produce would be fabricated evidence. Suggest the validation/push phase append the actual run there.

🔧 Fix: docs: record away-mode daemon liveness verification
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
