### PR TITLE
feat(bin): seed the first commit of a brand-new empty GitHub repo

### DIFF
--- a/.agents/skills/project-management/SKILL.md
+++ b/.agents/skills/project-management/SKILL.md
@@ -82,6 +82,12 @@ Initialization configures the local gate and does not vendor a no-mistakes skill
 Do not create a commit merely because initialization ran.
 If doctor reports an environment, authentication, or daemon problem, resolve that blocker before dispatching work and never restart the shared daemon from a project operation.
 
+A freshly created GitHub repository can come back with zero commits, since `gh-axi repo create` does not auto-initialize with a README: git cannot create a worktree for a branch with zero commits, so an empty repo is otherwise a dead end no crewmate can reach.
+Run `bin/fm-seed-empty-repo.sh <project>` to seed exactly that first commit before attempting to clone or dispatch a crewmate against it.
+That script is the sixth sanctioned exception to `AGENTS.md` hard rule #1 and is narrow by construction: it verifies live against the GitHub API, never by trusting a flag or argument, that the repo genuinely has zero commits on every branch, then pushes one `git commit --allow-empty` and nothing else.
+This path applies strictly to a repo with zero commits.
+Once a project has any real history, this path never applies again, and every subsequent change goes through a crewmate as normal.
+
 ## Remove
 
 Project removal is destructive.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,7 @@ Hard rules, in priority order:
 
 1. **Never write to a project.**
    Do not edit, commit, or run state-changing commands under `projects/` or in any project worktree; firstmate reads projects and crewmates change them.
-   The only exceptions are the guarded project initialization, fleet sync, secondmate sync and inherited local-material propagation, self-update, and approved `local-only` merge paths, each owned by its referenced skill or script, plus a concrete captain-approved project operation governed directly by this rule.
+   The only exceptions are the guarded project initialization, fleet sync, secondmate sync and inherited local-material propagation, self-update, approved `local-only` merge paths owned by their referenced skills and scripts, seeding a brand-new zero-commit repo's first commit via `bin/fm-seed-empty-repo.sh` (section 6), and a concrete captain-approved project operation governed directly by this rule.
    Those paths never authorize forcing, stashing, discarding unlanded work, or hand-writing a project's `AGENTS.md`.
    Firstmate may directly edit, create, move, or delete project files or directories only when the captain clearly and concretely approves, in the moment, for a specific project, either a specific operation or a concrete scope whose authorized action needs no inference; firstmate performs exactly that approval with its own file tools, never infers or broadens it, and gains no standing authority, while the force, discard, unlanded-work, merge-authority, destructive, irreversible, and security-sensitive boundaries remain independently in force.
 2. **Never merge a PR without the captain's explicit word.**
@@ -208,6 +208,7 @@ Load `project-management` before adding, creating, removing, or initializing a p
 Cloning or registering a project is add intake and uses the same trigger.
 That skill owns registry syntax, delivery-mode selection, outward-facing consent, clone and initialization procedure, safe rollback, and removal preflight.
 Project creation never authorizes an unmentioned remote, and project removal never bypasses that preflight or unlanded-work checks; hard rule 1's concrete captain-approved project operation exception remains available when its exact conditions are met.
+That skill's initialization procedure also covers the narrow case of a freshly created repository coming back with zero commits, seeding its first commit through `bin/fm-seed-empty-repo.sh` before any clone or crewmate dispatch against it; that path never applies once the project has any real history.
 
 Load `secondmate-provisioning` before creating, seeding, validating, launching, handing backlog to, recovering, pushing inherited local material into, or retiring a secondmate home, and before editing `data/secondmates.md`.
 Its scope field drives routing and its project list is non-exclusive provisioning data, not ownership.

--- a/bin/fm-seed-empty-repo.sh
+++ b/bin/fm-seed-empty-repo.sh
@@ -1,0 +1,189 @@
+#!/usr/bin/env bash
+# Seed the first commit of a genuinely brand-new, zero-commit GitHub repo, so its
+# default branch exists and a crewmate can get a worktree at all: git cannot
+# create a worktree for a branch with zero commits, and gh-axi repo create does
+# not auto-initialize with a README, so a just-created empty repo is otherwise a
+# dead end no crewmate can reach and firstmate is not allowed to write to.
+#
+# This is the sixth sanctioned exception to AGENTS.md hard rule #1 "never write
+# to a project" (see section 1 and section 6), and it is narrow by construction:
+# it only ever runs one `git commit --allow-empty` and pushes it, and only after
+# verifying live against the GitHub API - never by trusting a flag or argument -
+# that the repo has zero commits reachable from every branch. That verification
+# is the entire safety net here, so any existing history, on any branch, is
+# refused loudly and nothing is pushed. No file content, no other commits, no
+# force-push, ever.
+# Usage: fm-seed-empty-repo.sh <project-dir-or-name>
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
+PROJECTS="${FM_PROJECTS_OVERRIDE:-$FM_HOME/projects}"
+"$FM_ROOT/bin/fm-guard.sh" || true
+
+usage() {
+  echo "usage: fm-seed-empty-repo.sh <project-dir-or-name>" >&2
+}
+
+if [ "${1:-}" = "--help" ] || [ "${1:-}" = "-h" ]; then
+  usage
+  exit 0
+fi
+[ $# -eq 1 ] || { usage; exit 1; }
+
+# resolve_project_arg <arg>: same convention as fm-fleet-sync.sh - accept a path
+# used as-is when it already exists, or a bare "<name>"/"projects/<name>" form
+# resolved against $PROJECTS. Falls back to the raw argument unresolved so a
+# genuinely bad path still hits the existence check below.
+resolve_project_arg() {
+  local arg=$1 candidate
+  case "$arg" in
+    projects/*)
+      candidate="$PROJECTS/${arg#projects/}"
+      if [ -d "$candidate" ]; then
+        printf '%s\n' "$candidate"
+        return 0
+      fi
+      ;;
+    */*)
+      if [ -d "$arg" ]; then
+        printf '%s\n' "$arg"
+        return 0
+      fi
+      ;;
+    *)
+      candidate="$PROJECTS/$arg"
+      if [ -d "$candidate" ]; then
+        printf '%s\n' "$candidate"
+        return 0
+      fi
+      if [ -d "$arg" ]; then
+        printf '%s\n' "$arg"
+        return 0
+      fi
+      ;;
+  esac
+  printf '%s\n' "$arg"
+}
+
+PROJ=$(resolve_project_arg "$1")
+[ -d "$PROJ" ] || { echo "error: no project directory at $PROJ" >&2; exit 1; }
+git -C "$PROJ" rev-parse --is-inside-work-tree >/dev/null 2>&1 \
+  || { echo "error: $PROJ is not a git repository" >&2; exit 1; }
+
+REMOTE_URL=$(git -C "$PROJ" remote get-url origin 2>/dev/null) \
+  || { echo "error: $PROJ has no origin remote" >&2; exit 1; }
+
+# Parse owner/repo from an https or ssh GitHub remote URL; same pattern as
+# bin/fm-bearings-snapshot.sh's repo_slug.
+SLUG=$(printf '%s' "$REMOTE_URL" | sed -n 's#.*github\.com[:/]\([^/]*/[^/]*\)#\1#p' | sed 's#\.git$##; s#/$##')
+[ -n "$SLUG" ] || { echo "error: origin remote '$REMOTE_URL' is not a GitHub repository" >&2; exit 1; }
+OWNER=${SLUG%%/*}
+REPO=${SLUG#*/}
+
+command -v gh-axi >/dev/null 2>&1 \
+  || { echo "error: gh-axi is required to verify repo emptiness" >&2; exit 1; }
+
+# --- The entire safety net: verify live, via the GitHub API, that $OWNER/$REPO
+# genuinely has zero commits reachable from every branch. Never trust a flag or
+# argument for this; refuse loudly on anything that is not an unambiguous
+# confirmation of emptiness. ---
+
+REPO_INFO=$(gh-axi api "/repos/$OWNER/$REPO" 2>&1) || {
+  echo "REFUSED: could not read repo info for $OWNER/$REPO via the GitHub API: $REPO_INFO" >&2
+  exit 1
+}
+SIZE=$(printf '%s\n' "$REPO_INFO" | sed -n 's/^size: *//p' | head -1)
+case "$SIZE" in
+  ''|*[!0-9]*)
+    echo "REFUSED: could not parse repo size from the GitHub API response for $OWNER/$REPO" >&2
+    exit 1
+    ;;
+esac
+if [ "$SIZE" -ne 0 ]; then
+  echo "REFUSED: $OWNER/$REPO has non-zero size ($SIZE); it is not a genuinely empty repo" >&2
+  exit 1
+fi
+
+BRANCHES=$(gh-axi api "/repos/$OWNER/$REPO/branches" 2>&1) || {
+  echo "REFUSED: could not list branches for $OWNER/$REPO via the GitHub API: $BRANCHES" >&2
+  exit 1
+}
+case "$(printf '%s' "$BRANCHES" | tr -d '[:space:]')" in
+  '[]')
+    BRANCH_COUNT=0
+    ;;
+  *)
+    BRANCH_COUNT=$(printf '%s\n' "$BRANCHES" | sed -n 's/^\[\([0-9]*\)\]:.*/\1/p' | head -1)
+    ;;
+esac
+case "${BRANCH_COUNT:-}" in
+  ''|*[!0-9]*)
+    echo "REFUSED: could not parse branch count from the GitHub API response for $OWNER/$REPO" >&2
+    exit 1
+    ;;
+esac
+if [ "$BRANCH_COUNT" -ne 0 ]; then
+  echo "REFUSED: $OWNER/$REPO already has $BRANCH_COUNT branch(es); it is not empty" >&2
+  exit 1
+fi
+
+# The commits endpoint returns a 409 "Git Repository is empty" failure on a
+# genuinely empty repo, and succeeds with real commit data otherwise. A success
+# means real history exists somewhere and must refuse; a failure is only
+# accepted as confirmation when it carries that expected empty-repo signature -
+# any other failure (auth, rate limit, network) is inconclusive, not a
+# confirmation, and must refuse just as loudly.
+if COMMITS=$(gh-axi api "/repos/$OWNER/$REPO/commits?per_page=1" 2>&1); then
+  echo "REFUSED: $OWNER/$REPO already has commit history via the commits API: $(printf '%s' "$COMMITS" | head -1)" >&2
+  exit 1
+fi
+case "$COMMITS" in
+  *[Ee]mpty*)
+    :
+    ;;
+  *)
+    echo "REFUSED: could not confirm $OWNER/$REPO has zero commits; the commits API call failed for an unexpected reason: $(printf '%s' "$COMMITS" | head -1)" >&2
+    exit 1
+    ;;
+esac
+
+# Verified empty on every branch: zero size, zero branches, and the commits API
+# itself reports the repository as empty. Determine the branch to seed -
+# prefer the remote's recorded default branch name, then the local clone's
+# origin/HEAD symref, then "main".
+DEFAULT_BRANCH=$(printf '%s\n' "$REPO_INFO" | sed -n 's/^default_branch: *//p' | head -1)
+if [ -z "$DEFAULT_BRANCH" ]; then
+  DEFAULT_BRANCH=$(git -C "$PROJ" symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null | sed 's#^origin/##')
+fi
+DEFAULT_BRANCH=${DEFAULT_BRANCH:-main}
+
+# A fresh clone of a genuinely empty repo already has local HEAD symbolically
+# pointing at the right branch name (git reads that from the remote's HEAD
+# symref even though the branch has no commit yet - "unborn"), so this is a
+# safety check, not a normal setup step: refuse rather than guess if the local
+# checkout disagrees with the remote-declared default.
+CUR_BRANCH=$(git -C "$PROJ" symbolic-ref --quiet --short HEAD 2>/dev/null || true)
+if [ -z "$CUR_BRANCH" ]; then
+  git -C "$PROJ" checkout --orphan "$DEFAULT_BRANCH" >/dev/null 2>&1 \
+    || { echo "error: could not create local branch $DEFAULT_BRANCH in $PROJ" >&2; exit 1; }
+elif [ "$CUR_BRANCH" != "$DEFAULT_BRANCH" ]; then
+  echo "error: $PROJ is on local branch '$CUR_BRANCH', expected '$DEFAULT_BRANCH'; refusing to seed the wrong branch" >&2
+  exit 1
+fi
+
+if [ -n "$(git -C "$PROJ" status --porcelain 2>/dev/null | head -1)" ]; then
+  echo "error: $PROJ has a dirty working tree; refusing to seed a commit into it" >&2
+  exit 1
+fi
+
+if git -C "$PROJ" rev-parse --verify --quiet HEAD >/dev/null 2>&1; then
+  echo "error: $PROJ's local $DEFAULT_BRANCH already has a commit; this exception only ever seeds the very first commit" >&2
+  exit 1
+fi
+
+git -C "$PROJ" commit --allow-empty -m "Initial commit" >/dev/null
+git -C "$PROJ" push origin "$DEFAULT_BRANCH" >/dev/null
+
+echo "seeded: pushed the first commit to $OWNER/$REPO ($DEFAULT_BRANCH); $PROJ is ready for cloning and dispatch"

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -53,6 +53,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-config-push.sh`      | Push declared inherited local material to live local or remote secondmates and send the placement-specific config reread when changed |
 | `fm-project-mode.sh`     | Resolve a project's registered delivery posture from `data/projects.md` for fleet sync and home seeding |
 | `fm-merge-local.sh`      | Fast-forward a `local-only` project's local default branch after approval            |
+| `fm-seed-empty-repo.sh`  | Seed a genuinely zero-commit GitHub repo's first commit, verified live via the GitHub API |
 | `fm-review-diff.sh`      | Review a crewmate branch or resolved PR head against the authoritative base          |
 | `fm-marker-lib.sh`       | Compatibility entry point for the from-firstmate carrier owned by `fm-operational-input.sh` |
 | `fm-pending-reply-lib.sh` | Parent-owned secondmate pending-reply expectations, recovery, and one-shot escalation |

--- a/tests/fm-seed-empty-repo.test.sh
+++ b/tests/fm-seed-empty-repo.test.sh
@@ -91,6 +91,7 @@ SH
 run_seed() {
   local case_dir=$1 proj=$2
   FM_ROOT_OVERRIDE="$ROOT" \
+  FM_STATE_OVERRIDE="$case_dir/state" \
   FM_TEST_GH_AXI_LOG="$case_dir/gh-axi.log" \
   PATH="$case_dir/fakebin:$PATH" \
     "$SEED" "$proj"
@@ -326,7 +327,7 @@ test_refuses_without_gh_axi() {
   make_empty_clone "$case_dir" example repo
 
   set +e
-  FM_ROOT_OVERRIDE="$ROOT" PATH="/usr/bin:/bin" \
+  FM_ROOT_OVERRIDE="$ROOT" FM_STATE_OVERRIDE="$case_dir/state" PATH="/usr/bin:/bin" \
     "$SEED" "$case_dir/proj" \
     > "$case_dir/stdout" 2> "$case_dir/stderr"
   rc=$?

--- a/tests/fm-seed-empty-repo.test.sh
+++ b/tests/fm-seed-empty-repo.test.sh
@@ -1,0 +1,352 @@
+#!/usr/bin/env bash
+# Tests for bin/fm-seed-empty-repo.sh: the sixth sanctioned exception to hard
+# rule #1 - seeding the first commit of a genuinely brand-new, zero-commit
+# GitHub repo so a crewmate can get a worktree at all. The entire safety net is
+# the live GitHub API verification, so this suite spends most of its matrix on
+# refusal paths: any signal short of an unambiguous "empty on every branch"
+# confirmation must refuse loudly and must never touch git commit or git push.
+#
+# Matrix:
+#   (a) seeds and pushes a single empty commit on a genuinely empty repo
+#   (b) refuses when repo size is non-zero
+#   (c) refuses when the branches list is non-empty
+#   (d) refuses when the commits API unexpectedly succeeds (real history exists)
+#   (e) refuses when the commits API fails for an unrelated, inconclusive reason
+#   (f) refuses when the project has no origin remote
+#   (g) refuses when the origin remote is not GitHub
+#   (h) refuses when the working tree is dirty
+#   (i) refuses when the local default branch already has a commit
+#   (j) refuses when the local branch disagrees with the remote's default branch
+#   (k) refuses when gh-axi is not available to run the verification
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+fm_git_identity fmtest fmtest@example.invalid
+
+SEED="$ROOT/bin/fm-seed-empty-repo.sh"
+TMP_ROOT=$(fm_test_tmproot fm-seed-empty-repo-tests)
+
+# make_empty_clone <case_dir> <owner> <repo> [default_branch]: create a bare
+# "remote" with zero commits at a path carrying a literal github.com/<owner>/<repo>
+# segment (so the script's github.com URL parsing sees a real owner/repo while
+# the actual git push stays local), then clone it to <case_dir>/proj. Echoes
+# nothing; the clone lands at "$case_dir/proj".
+make_empty_clone() {
+  local case_dir=$1 owner=$2 repo=$3 branch=${4:-main} bare
+  bare="$case_dir/remotes/github.com/$owner/$repo"
+  mkdir -p "$bare"
+  git init --quiet --bare "$bare"
+  git -C "$bare" symbolic-ref HEAD "refs/heads/$branch"
+  git clone --quiet "file://$bare" "$case_dir/proj"
+}
+
+# gh-axi mock: logs every invocation, then answers the three calls the script
+# makes based on env vars the test sets before invoking run_seed.
+#   FM_TEST_REPO_SIZE       size: value for the base repo info call (default 0)
+#   FM_TEST_DEFAULT_BRANCH  default_branch: value for the base repo info call
+#   FM_TEST_BRANCHES        raw body for the branches call (default "[]")
+#   FM_TEST_COMMITS_MODE    empty|success|error for the commits call
+add_gh_axi_mock() {
+  local case_dir=$1
+  mkdir -p "$case_dir/fakebin"
+  cat > "$case_dir/fakebin/gh-axi" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$FM_TEST_GH_AXI_LOG"
+path=${2:-}
+case "$path" in
+  */branches)
+    printf '%s\n' "${FM_TEST_BRANCHES:-[]}"
+    exit 0
+    ;;
+  */commits*)
+    case "${FM_TEST_COMMITS_MODE:-empty}" in
+      success)
+        printf '%s\n' "[1]:" "  - sha: deadbeefcafefeed0000000000000000deadbeef"
+        exit 0
+        ;;
+      error)
+        echo 'error: "gh: API rate limit exceeded (HTTP 403)"' >&2
+        exit 1
+        ;;
+      *)
+        echo 'error: "gh: Git Repository is empty. (HTTP 409)"' >&2
+        exit 1
+        ;;
+    esac
+    ;;
+  *)
+    printf 'size: %s\n' "${FM_TEST_REPO_SIZE:-0}"
+    printf 'default_branch: %s\n' "${FM_TEST_DEFAULT_BRANCH:-main}"
+    exit 0
+    ;;
+esac
+SH
+  chmod +x "$case_dir/fakebin/gh-axi"
+}
+
+# run_seed <case_dir> <proj-path>: invoke the script with this case's mock on
+# PATH and the case's own gh-axi call log, honoring whatever FM_TEST_* env vars
+# the test already exported.
+run_seed() {
+  local case_dir=$1 proj=$2
+  FM_ROOT_OVERRIDE="$ROOT" \
+  FM_TEST_GH_AXI_LOG="$case_dir/gh-axi.log" \
+  PATH="$case_dir/fakebin:$PATH" \
+    "$SEED" "$proj"
+}
+
+test_seeds_and_pushes_genuinely_empty_repo() {
+  local case_dir rc
+  case_dir="$TMP_ROOT/happy-path"
+  mkdir -p "$case_dir"
+  make_empty_clone "$case_dir" example promo-reel-forge
+  add_gh_axi_mock "$case_dir"
+  : > "$case_dir/gh-axi.log"
+
+  set +e
+  run_seed "$case_dir" "$case_dir/proj" \
+    > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 0 "$rc" "happy-path: fm-seed-empty-repo should succeed on a genuinely empty repo"
+  assert_grep 'seeded:' "$case_dir/stdout" "happy-path: missing success message"
+  [ "$(git -C "$case_dir/proj" log --oneline | wc -l | tr -d ' ')" = 1 ] \
+    || fail "happy-path: local branch should have exactly one commit"
+  [ "$(git -C "$case_dir/proj" log -1 --format=%s)" = "Initial commit" ] \
+    || fail "happy-path: commit message was not 'Initial commit'"
+  [ "$(git -C "$case_dir/remotes/github.com/example/promo-reel-forge" log --oneline | wc -l | tr -d ' ')" = 1 ] \
+    || fail "happy-path: the commit was not pushed to the remote"
+  pass "fm-seed-empty-repo seeds and pushes a single empty commit on a genuinely empty repo"
+}
+
+test_refuses_nonzero_size() {
+  local case_dir rc
+  case_dir="$TMP_ROOT/nonzero-size"
+  mkdir -p "$case_dir"
+  make_empty_clone "$case_dir" example repo
+  add_gh_axi_mock "$case_dir"
+  : > "$case_dir/gh-axi.log"
+
+  set +e
+  FM_TEST_REPO_SIZE=42 run_seed "$case_dir" "$case_dir/proj" \
+    > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 1 "$rc" "nonzero-size: fm-seed-empty-repo should refuse"
+  assert_grep 'REFUSED:' "$case_dir/stderr" "nonzero-size: refusal was not loud"
+  assert_grep 'non-zero size' "$case_dir/stderr" "nonzero-size: refusal did not explain the size mismatch"
+  [ "$(git -C "$case_dir/proj" log --oneline 2>/dev/null | wc -l | tr -d ' ')" = 0 ] \
+    || fail "nonzero-size: a commit was created despite refusal"
+  pass "fm-seed-empty-repo refuses a repo with non-zero size"
+}
+
+test_refuses_nonempty_branches() {
+  local case_dir rc
+  case_dir="$TMP_ROOT/nonempty-branches"
+  mkdir -p "$case_dir"
+  make_empty_clone "$case_dir" example repo
+  add_gh_axi_mock "$case_dir"
+  : > "$case_dir/gh-axi.log"
+
+  set +e
+  FM_TEST_BRANCHES=$'[1]:\n  - name: main' run_seed "$case_dir" "$case_dir/proj" \
+    > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 1 "$rc" "nonempty-branches: fm-seed-empty-repo should refuse"
+  assert_grep 'REFUSED:' "$case_dir/stderr" "nonempty-branches: refusal was not loud"
+  assert_grep 'branch(es)' "$case_dir/stderr" "nonempty-branches: refusal did not explain the branch count"
+  [ "$(git -C "$case_dir/proj" log --oneline 2>/dev/null | wc -l | tr -d ' ')" = 0 ] \
+    || fail "nonempty-branches: a commit was created despite refusal"
+  pass "fm-seed-empty-repo refuses a repo with any existing branch"
+}
+
+test_refuses_commits_api_success() {
+  local case_dir rc
+  case_dir="$TMP_ROOT/commits-succeed"
+  mkdir -p "$case_dir"
+  make_empty_clone "$case_dir" example repo
+  add_gh_axi_mock "$case_dir"
+  : > "$case_dir/gh-axi.log"
+
+  set +e
+  FM_TEST_COMMITS_MODE=success run_seed "$case_dir" "$case_dir/proj" \
+    > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 1 "$rc" "commits-succeed: fm-seed-empty-repo should refuse"
+  assert_grep 'REFUSED:' "$case_dir/stderr" "commits-succeed: refusal was not loud"
+  assert_grep 'commit history' "$case_dir/stderr" "commits-succeed: refusal did not cite commit history"
+  [ "$(git -C "$case_dir/proj" log --oneline 2>/dev/null | wc -l | tr -d ' ')" = 0 ] \
+    || fail "commits-succeed: a commit was created despite refusal"
+  pass "fm-seed-empty-repo refuses when the commits API unexpectedly returns real history"
+}
+
+test_refuses_inconclusive_commits_failure() {
+  local case_dir rc
+  case_dir="$TMP_ROOT/commits-inconclusive"
+  mkdir -p "$case_dir"
+  make_empty_clone "$case_dir" example repo
+  add_gh_axi_mock "$case_dir"
+  : > "$case_dir/gh-axi.log"
+
+  set +e
+  FM_TEST_COMMITS_MODE=error run_seed "$case_dir" "$case_dir/proj" \
+    > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 1 "$rc" "commits-inconclusive: fm-seed-empty-repo should refuse"
+  assert_grep 'REFUSED:' "$case_dir/stderr" "commits-inconclusive: refusal was not loud"
+  assert_grep 'could not confirm' "$case_dir/stderr" \
+    "commits-inconclusive: refusal did not distinguish an inconclusive failure from a confirmed-empty one"
+  [ "$(git -C "$case_dir/proj" log --oneline 2>/dev/null | wc -l | tr -d ' ')" = 0 ] \
+    || fail "commits-inconclusive: a commit was created despite refusal"
+  pass "fm-seed-empty-repo refuses when the commits API fails for a reason other than emptiness"
+}
+
+test_refuses_no_origin_remote() {
+  local case_dir rc
+  case_dir="$TMP_ROOT/no-origin"
+  mkdir -p "$case_dir/proj"
+  git init --quiet "$case_dir/proj"
+  add_gh_axi_mock "$case_dir"
+  : > "$case_dir/gh-axi.log"
+
+  set +e
+  run_seed "$case_dir" "$case_dir/proj" \
+    > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 1 "$rc" "no-origin: fm-seed-empty-repo should refuse"
+  assert_grep 'error: ' "$case_dir/stderr" "no-origin: refusal message missing"
+  assert_grep 'no origin remote' "$case_dir/stderr" "no-origin: refusal did not name the missing remote"
+  [ ! -s "$case_dir/gh-axi.log" ] || fail "no-origin: gh-axi was invoked despite no origin remote"
+  pass "fm-seed-empty-repo refuses a project with no origin remote"
+}
+
+test_refuses_non_github_origin() {
+  local case_dir rc bare
+  case_dir="$TMP_ROOT/non-github"
+  bare="$case_dir/remotes/gitlab.com/example/repo"
+  mkdir -p "$bare"
+  git init --quiet --bare "$bare"
+  git -C "$bare" symbolic-ref HEAD refs/heads/main
+  git clone --quiet "file://$bare" "$case_dir/proj"
+  add_gh_axi_mock "$case_dir"
+  : > "$case_dir/gh-axi.log"
+
+  set +e
+  run_seed "$case_dir" "$case_dir/proj" \
+    > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 1 "$rc" "non-github: fm-seed-empty-repo should refuse"
+  assert_grep 'not a GitHub repository' "$case_dir/stderr" "non-github: refusal did not name the problem"
+  [ ! -s "$case_dir/gh-axi.log" ] || fail "non-github: gh-axi was invoked despite a non-GitHub origin"
+  pass "fm-seed-empty-repo refuses a project whose origin is not a GitHub URL"
+}
+
+test_refuses_dirty_working_tree() {
+  local case_dir rc
+  case_dir="$TMP_ROOT/dirty-tree"
+  mkdir -p "$case_dir"
+  make_empty_clone "$case_dir" example repo
+  echo scratch > "$case_dir/proj/untracked.txt"
+  add_gh_axi_mock "$case_dir"
+  : > "$case_dir/gh-axi.log"
+
+  set +e
+  run_seed "$case_dir" "$case_dir/proj" \
+    > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 1 "$rc" "dirty-tree: fm-seed-empty-repo should refuse"
+  assert_grep 'dirty working tree' "$case_dir/stderr" "dirty-tree: refusal did not name the dirty tree"
+  [ "$(git -C "$case_dir/proj" log --oneline 2>/dev/null | wc -l | tr -d ' ')" = 0 ] \
+    || fail "dirty-tree: a commit was created despite refusal"
+  pass "fm-seed-empty-repo refuses to seed a commit into a dirty working tree"
+}
+
+test_refuses_when_local_branch_already_seeded() {
+  local case_dir rc
+  case_dir="$TMP_ROOT/already-seeded"
+  mkdir -p "$case_dir"
+  make_empty_clone "$case_dir" example repo
+  git -C "$case_dir/proj" commit --quiet --allow-empty -m "Initial commit"
+  add_gh_axi_mock "$case_dir"
+  : > "$case_dir/gh-axi.log"
+
+  set +e
+  run_seed "$case_dir" "$case_dir/proj" \
+    > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 1 "$rc" "already-seeded: fm-seed-empty-repo should refuse"
+  assert_grep 'already has a commit' "$case_dir/stderr" "already-seeded: refusal did not name the existing local commit"
+  [ "$(git -C "$case_dir/proj" log --oneline | wc -l | tr -d ' ')" = 1 ] \
+    || fail "already-seeded: a second commit was created despite refusal"
+  pass "fm-seed-empty-repo refuses when the local default branch already has a commit"
+}
+
+test_refuses_branch_mismatch() {
+  local case_dir rc
+  case_dir="$TMP_ROOT/branch-mismatch"
+  mkdir -p "$case_dir"
+  make_empty_clone "$case_dir" example repo main
+  git -C "$case_dir/proj" symbolic-ref HEAD refs/heads/other
+  add_gh_axi_mock "$case_dir"
+  : > "$case_dir/gh-axi.log"
+
+  set +e
+  FM_TEST_DEFAULT_BRANCH=main run_seed "$case_dir" "$case_dir/proj" \
+    > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 1 "$rc" "branch-mismatch: fm-seed-empty-repo should refuse"
+  assert_grep 'refusing to seed the wrong branch' "$case_dir/stderr" \
+    "branch-mismatch: refusal did not explain the branch mismatch"
+  pass "fm-seed-empty-repo refuses when the local branch disagrees with the remote's default branch"
+}
+
+test_refuses_without_gh_axi() {
+  local case_dir rc
+  case_dir="$TMP_ROOT/no-gh-axi"
+  mkdir -p "$case_dir"
+  make_empty_clone "$case_dir" example repo
+
+  set +e
+  FM_ROOT_OVERRIDE="$ROOT" PATH="/usr/bin:/bin" \
+    "$SEED" "$case_dir/proj" \
+    > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 1 "$rc" "no-gh-axi: fm-seed-empty-repo should refuse"
+  assert_grep 'gh-axi is required' "$case_dir/stderr" "no-gh-axi: refusal did not name the missing tool"
+  [ "$(git -C "$case_dir/proj" log --oneline 2>/dev/null | wc -l | tr -d ' ')" = 0 ] \
+    || fail "no-gh-axi: a commit was created despite refusal"
+  pass "fm-seed-empty-repo refuses when gh-axi is unavailable to verify emptiness"
+}
+
+test_seeds_and_pushes_genuinely_empty_repo
+test_refuses_nonzero_size
+test_refuses_nonempty_branches
+test_refuses_commits_api_success
+test_refuses_inconclusive_commits_failure
+test_refuses_no_origin_remote
+test_refuses_non_github_origin
+test_refuses_dirty_working_tree
+test_refuses_when_local_branch_already_seeded
+test_refuses_branch_mismatch
+test_refuses_without_gh_axi


### PR DESCRIPTION
## Intent

Add a narrow, scripted sixth exception to firstmate's hard rule #1 ('never write to a project'), covering exactly one case: seeding the very first commit of a genuinely brand-new, zero-commit GitHub repo, so its default branch exists and a crewmate can get a worktree at all. Git cannot create a worktree for a branch with zero commits - that is a git limitation, not a firstmate policy - so a just-created empty repo (gh-axi repo create does not auto-initialize with a README) was previously a dead end: no crewmate could touch it and firstmate was not allowed to either. This happened for real with a project called promo-reel-forge.

Built bin/fm-seed-empty-repo.sh (takes a project dir or registry name), following the existing patterns in bin/fm-project-mode.sh and bin/fm-fleet-sync.sh for resolving a project's dir/registry entry and origin remote. Deliberate design decisions:
- The safety net is a LIVE GitHub API check via gh-axi, never a trusted flag or argument: it checks repos/OWNER/REPO size==0, that the branches list is empty, AND that the commits API call fails with the expected "Git Repository is empty" signature (verified as a substring match) rather than succeeding or failing for some unrelated/inconclusive reason (auth, rate limit, network) - an inconclusive failure refuses loudly rather than being treated as confirmation of emptiness, since silently proceeding on an ambiguous signal would defeat the point of the safety net.
- Only after that full verification does it run exactly one empty-allowed commit ("Initial commit") and a plain push to the default branch - no file content, no other commits, never a force-push.
- Extra defense-in-depth refusals: dirty working tree, local branch already has a commit (already seeded), local branch name disagreeing with the remote's declared default branch, no origin remote, origin remote not on github.com, gh-axi unavailable.
- Owner/repo slug parsing reuses the same sed pattern already used in bin/fm-bearings-snapshot.sh's repo_slug helper.
- Refusal messages use REFUSED: for the safety-net verification failures (mirroring bin/fm-merge-local.sh's guarded-refusal style) and error: for ordinary usage/precondition failures.

Added a colocated test suite at tests/fm-seed-empty-repo.test.sh (11 cases) following the repo's tests/lib.sh conventions: a fake gh-axi in a per-case fakebin controls the three API responses via env vars, and real local git objects are used throughout, including for the one happy-path test where the origin remote is a real local bare repo whose path deliberately contains a github.com/owner/repo segment so the script's github.com URL-parsing regex sees a valid slug while the actual git push stays fully local (no network). Both the script and the test file are shellcheck-clean under the repo's pinned shellcheck 0.11.0 via bin/fm-lint.sh, and bin/fm-doc-audience-check.sh passes.

Updated AGENTS.md per the coding-guidelines skill's decision tree (detailed procedure belongs in the owning skill, not inline in AGENTS.md):
- Section 1: added the sixth exception to the existing prose list of sanctioned project-write exceptions in hard rule #1, pointing to section 6 for the procedure.
- Section 6: added one sentence noting that project-management's initialization procedure also covers this narrow empty-repo case via the new script, deferring detail to that skill.
- .agents/skills/project-management/SKILL.md: added the actual procedural paragraph directly after the existing "## Initialize" section (the closest existing match to the task's described "Initialize (no-mistakes mode only)" block), spelling out that this path is strictly for a zero-commit repo and never applies again once the project has any real history - every subsequent change goes through a crewmate as normal.

This is firstmate's own tracked repository, so I (a firstmate crewmate) was authorized to edit AGENTS.md, bin/, and .agents/skills/ directly per the task brief; ran bin/fm-ensure-agents-md.sh afterward per the brief's project-memory instructions and confirmed it was a no-op (AGENTS.md's "Maintaining this file" section was already present).

Note on this run: two earlier runs against this same branch content failed for reasons unrelated to the code under review - one hit a 403 push failure because origin was read-only and a writable fork remote had not yet been registered (now fixed via `no-mistakes init --fork-url`), and after that a stray empty commit I had accidentally created via a malformed shell command was surgically removed from branch history via `git rebase --onto` (verified byte-identical tree content before/after, both fix commits preserved), and the most recent attempt's review step failed only because the reviewing agent's own OAuth session had expired mid-run, not because of any issue with the change itself.

## What Changed

- Added `bin/fm-seed-empty-repo.sh`, a guarded script that resolves a project's directory/registry entry and origin remote, performs a live GitHub API check (repo size 0, empty branches list, and a commits-API call that fails with the expected "Git Repository is empty" signature) as the safety net, then pushes exactly one empty "Initial commit" to the default branch so a crewmate can obtain a worktree against a repo git otherwise cannot branch.
- Added defense-in-depth refusals for a dirty working tree, an already-seeded local branch, local/remote default-branch name mismatch, missing or non-GitHub origin, and unavailable `gh-axi`, distinguishing safety-net verification failures (`REFUSED:`) from ordinary precondition failures (`error:`).
- Added a colocated 11-case test suite (`tests/fm-seed-empty-repo.test.sh`) using a fake `gh-axi` to control the three API responses and real local git objects throughout, and isolated `FM_STATE_OVERRIDE` handling in those tests to prevent cross-test state leakage.
- Documented the new sixth exception to hard rule 1 in `AGENTS.md`, the initialization procedure in `.agents/skills/project-management/SKILL.md`, and added the script to the `bin/` toolbelt reference table in `docs/scripts.md`.

## Risk Assessment

✅ Low: A narrow, well-isolated addition (new script + colocated tests + doc pointers) with no changes to existing behavior; the safety net (triple live-verified GitHub API check before any commit/push, no force-push, fails closed on any ambiguous signal) is sound, its output parsing matches gh-axi's actual API response format (verified live against a real GitHub repo), and all 11 tests exercise the refusal paths that matter.

## Testing

Ran the full colocated test suite (11/11 passing) and performed manual end-to-end verification with real local git objects (no network) that reproduces the exact promo-reel-forge scenario: seeding a genuinely empty repo succeeds and unblocks `git worktree add` that previously failed with git's own limitation, while an inconclusive GitHub API failure is refused loudly with zero commits created, confirming the safety-net design decision works as intended.

<details>
<summary>Evidence: End-to-end CLI transcript: seed happy path, worktree-add before/after payoff, and inconclusive-failure refusal</summary>

```text
=== fm-seed-empty-repo.sh end-to-end demo ===

1) Simulated a genuinely empty GitHub repo (zero commits, local and remote).
2) Ran the script exactly as an operator would:

$ bash bin/fm-seed-empty-repo.sh $PROJ
To file://.../remotes/github.com/example/promo-reel-forge
 * [new branch]      main -> main
seeded: pushed the first commit to example/promo-reel-forge (main); $PROJ is ready for cloning and dispatch

3) Verified the actual crewmate payoff: git worktree add for a task branch.

BEFORE (unseeded repo, git's own limitation):
$ git worktree add -b task/demo wt main
fatal: not a valid object name: 'main'
exit code: 255

AFTER (seeded via fm-seed-empty-repo.sh):
$ git worktree add -b task/demo wt main
Preparing worktree (new branch 'task/demo')
HEAD is now at f04cf07 Initial commit
exit code: 0

4) Verified the safety-net design decision: an inconclusive commits-API
   failure (e.g. rate limit) is refused loudly, never treated as confirmation
   of emptiness, and no commit is created.

$ bash bin/fm-seed-empty-repo.sh $PROJ   # commits API fails with 403 rate-limit, not the "empty" signature
REFUSED: could not confirm example/some-repo has zero commits; the commits API call failed for an unexpected reason: error: "gh: API rate limit exceeded (HTTP 403)"
exit code: 1

$ git -C $PROJ log --oneline
fatal: your current branch 'main' does not have any commits yet   # no commit was created
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Rebase** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `AGENTS.md` - merge conflict rebasing onto origin/main

🔧 Fix applied.
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash tests/fm-seed-empty-repo.test.sh` — all 11 cases pass (happy path, non-zero size, non-empty branches, commits-API success, inconclusive commits-API failure, no origin, non-GitHub origin, dirty tree, already-seeded, branch mismatch, gh-axi missing)</code>
- <code>Manual E2E: built a real local bare &#39;GitHub&#39; remote at a github.com/owner/repo-shaped path with zero commits, ran `bin/fm-seed-empty-repo.sh` against a real clone of it with a gh-axi stub answering size=0/branches=[]/commits=409-empty, confirmed the script pushed exactly one &#39;Initial commit&#39; to both local and remote</code>
- <code>Manual E2E payoff check: confirmed `git worktree add -b task/demo wt main` fails with `fatal: not a valid object name: &#39;main&#39;` against the unseeded repo, and succeeds after seeding — demonstrating the actual crewmate-dispatch blocker the change fixes</code>
- <code>Manual E2E safety-net check: ran the script against a live-shaped inconclusive commits-API failure (403 rate limit, not the &#39;Git Repository is empty&#39; signature) and confirmed it printed `REFUSED: could not confirm ... failed for an unexpected reason` and created no commit</code>
- `Reviewed AGENTS.md, .agents/skills/project-management/SKILL.md, and docs/scripts.md diffs against the described intent (sixth hard-rule-1 exception, section 6 pointer, toolbelt table entry)`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
