### PR TITLE
feat(bin): propagate trace context to remote secondmates

### DIFF
--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -463,7 +463,8 @@ secondmate_sync() {
       echo "SECONDMATE_SYNC: secondmate $id: skipped: remote tracked-file sync failed on $remote_host: $(first_line "$sync_out")"
       converged=0
     fi
-    if inherit_out=$("$SCRIPT_DIR/fm-remote-inherit-push.sh" "$id" "$remote_generation" 2>&1); then
+    if inherit_out=$(FM_CONFIG_INHERIT_LIVE=1 \
+      "$SCRIPT_DIR/fm-remote-inherit-push.sh" "$id" "$remote_generation" 2>&1); then
       if printf '%s\n' "$inherit_out" | grep -Eq '^(pushed|removed):'; then nudge_needed=1; fi
     else
       echo "SECONDMATE_SYNC: secondmate $id: skipped: remote inheritance failed on $remote_host: $(first_line "$inherit_out")"

--- a/bin/fm-config-inherit-lib.sh
+++ b/bin/fm-config-inherit-lib.sh
@@ -39,6 +39,15 @@
 # secondmates, and a secondmate never spawns secondmates, so it must not flow
 # downstream.
 #
+# That single declaration is also the ONE owner of the inherited-material
+# allowlist for remote routes: bin/fm-remote-inherit-push.sh (sender) and
+# bin/fm-remote-inherit.sh (receiver, executing inside the remote home) both
+# derive their item set from fm_config_inherit_items rather than restating it,
+# so a new inheritable item cannot be accepted by one side and refused by the
+# other. A local and remote code root that disagree about this list must be
+# reconciled by the ordinary remote sync/update path before the transfer
+# succeeds; there is no separate allowlist version negotiation.
+#
 # shellcheck source=bin/fm-startup-memory-budget-lib.sh
 . "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/fm-startup-memory-budget-lib.sh"
 
@@ -52,6 +61,34 @@ FM_SHARED_CAPTAIN_MODE="444"
 # Extend here to inherit more of the primary's local config; override via the
 # environment only in tests. Items must not contain whitespace.
 FM_INHERITABLE_CONFIG="${FM_INHERITABLE_CONFIG:-crew-dispatch.json crew-harness backlog-backend backend herdr-presentation-spaces startup-memory-budget trace-context}"
+
+# Items whose value is a home-SESSION enablement decision rather than durable
+# local configuration. They are inherited at the launch convergence point, where
+# the primary also hands the new process its frozen on/off decision, and left
+# untouched by live convergence into an already-running home, whose decision is
+# already frozen for its current session (bin/fm-trace-context-lib.sh).
+FM_SESSION_SCOPED_INHERITABLE_CONFIG="trace-context"
+
+# True when <item> is session-scoped in the sense above.
+fm_config_inherit_item_session_scoped() {  # <item>
+  local item=$1 candidate
+  for candidate in $FM_SESSION_SCOPED_INHERITABLE_CONFIG; do
+    [ "$candidate" = "$item" ] && return 0
+  done
+  return 1
+}
+
+# The complete declared inherited-material set as home-relative paths, one per
+# line, in propagation order: every FM_INHERITABLE_CONFIG item under config/,
+# then the one shared data file. This is what remote senders and receivers
+# derive from, so both ends of a transfer agree by construction.
+fm_config_inherit_items() {
+  local item
+  for item in $FM_INHERITABLE_CONFIG; do
+    printf 'config/%s\n' "$item"
+  done
+  printf '%s\n' "$FM_SHARED_CAPTAIN_REL"
+}
 
 fm_inherit_file_mode() {
   if [ "$(uname)" = Darwin ]; then
@@ -408,7 +445,7 @@ propagate_inheritable_config() {
     case "$item" in
       ''|/*|.|..|../*|*/../*|*/..) return 1 ;;
     esac
-    if [ "${FM_CONFIG_INHERIT_LIVE:-0}" = 1 ] && [ "$item" = trace-context ]; then
+    if [ "${FM_CONFIG_INHERIT_LIVE:-0}" = 1 ] && fm_config_inherit_item_session_scoped "$item"; then
       record_inheritable_config_result "$item" unchanged "session-scoped"
       continue
     fi

--- a/bin/fm-config-push.sh
+++ b/bin/fm-config-push.sh
@@ -145,7 +145,8 @@ while IFS='|' read -r id home _window meta; do
       fm_lock_release "$remote_lock" || true
       continue
     fi
-    if remote_out=$("$SCRIPT_DIR/fm-remote-inherit-push.sh" "$id" "$remote_generation" 2>&1); then
+    if remote_out=$(FM_CONFIG_INHERIT_LIVE=1 \
+      "$SCRIPT_DIR/fm-remote-inherit-push.sh" "$id" "$remote_generation" 2>&1); then
       printf '%s\n' "$remote_out" | sed 's/^/  /'
       remote_nudge=0
       if printf '%s\n' "$remote_out" | grep -Eq '^(pushed|removed):'; then remote_nudge=1; fi

--- a/bin/fm-remote-inherit-push.sh
+++ b/bin/fm-remote-inherit-push.sh
@@ -4,10 +4,11 @@
 #
 # The item set is derived from the ONE declared owner
 # (FM_INHERITABLE_CONFIG in bin/fm-config-inherit-lib.sh), the same declaration
-# the receiving bin/fm-remote-inherit.sh enforces, so sender and receiver cannot
-# drift apart. FM_CONFIG_INHERIT_LIVE=1 marks a live convergence push into an
-# already-running home and skips session-scoped items, exactly as the local
-# propagation path does.
+# the receiving bin/fm-remote-inherit.sh enforces, so the two implementations in
+# one code revision cannot drift silently. Different local and remote revisions
+# fail closed as documented by that owner. FM_CONFIG_INHERIT_LIVE=1 marks a live
+# convergence push into an already-running home and skips session-scoped items,
+# exactly as the local propagation path does.
 set -eu
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/bin/fm-remote-inherit-push.sh
+++ b/bin/fm-remote-inherit-push.sh
@@ -1,6 +1,13 @@
 #!/usr/bin/env bash
 # Push the declared inherited-material allowlist to one remote secondmate route.
 # Usage: fm-remote-inherit-push.sh <secondmate-id> <generation>
+#
+# The item set is derived from the ONE declared owner
+# (FM_INHERITABLE_CONFIG in bin/fm-config-inherit-lib.sh), the same declaration
+# the receiving bin/fm-remote-inherit.sh enforces, so sender and receiver cannot
+# drift apart. FM_CONFIG_INHERIT_LIVE=1 marks a live convergence push into an
+# already-running home and skips session-scoped items, exactly as the local
+# propagation path does.
 set -eu
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -11,6 +18,8 @@ DATA="${FM_DATA_OVERRIDE:-$FM_HOME/data}"
 
 # shellcheck source=bin/fm-secondmate-registry-lib.sh
 . "$SCRIPT_DIR/fm-secondmate-registry-lib.sh"
+# shellcheck source=bin/fm-config-inherit-lib.sh
+. "$SCRIPT_DIR/fm-config-inherit-lib.sh"
 
 die() { printf 'error: %s\n' "$1" >&2; exit 1; }
 sha256_file() {
@@ -42,15 +51,19 @@ EMPTY="$TMP/empty"
 : > "$EMPTY"
 EMPTY_HASH=$(sha256_file "$EMPTY") || die "cannot hash empty inheritance payload"
 
-ITEMS='config/crew-dispatch.json
-config/crew-harness
-config/backlog-backend
-config/backend
-config/herdr-presentation-spaces
-config/startup-memory-budget
-data/captain-shared.md'
+ITEMS=$(fm_config_inherit_items)
 while IFS= read -r rel; do
   [ -n "$rel" ] || continue
+  if [ "${FM_CONFIG_INHERIT_LIVE:-0}" = 1 ]; then
+    case "$rel" in
+      config/*)
+        if fm_config_inherit_item_session_scoped "${rel#config/}"; then
+          printf 'unchanged: %s\n' "$rel"
+          continue
+        fi
+        ;;
+    esac
+  fi
   case "$rel" in
     config/*) source="$CONFIG/${rel#config/}" ;;
     data/*) source="$DATA/${rel#data/}" ;;

--- a/bin/fm-remote-inherit.sh
+++ b/bin/fm-remote-inherit.sh
@@ -28,10 +28,11 @@ sha256_file() {
   if command -v shasum >/dev/null 2>&1; then shasum -a 256 "$1" | awk '{print $1}'; else sha256sum "$1" | awk '{print $1}'; fi
 }
 # Writable set, derived from the ONE declared inherited-material owner
-# (FM_INHERITABLE_CONFIG in bin/fm-config-inherit-lib.sh) so the receiver can
-# never accept less - or more - than the sender declares. This runs under the
-# remote entrypoint's fixed empty environment, so the declaration is this code
-# root's own, never something the caller can widen over SSH.
+# (FM_INHERITABLE_CONFIG in bin/fm-config-inherit-lib.sh), so this code root's
+# receiver and sender cannot drift silently. This runs under the remote
+# entrypoint's fixed empty environment, so the declaration is this code root's
+# own, never something the caller can widen over SSH; a caller from a different
+# revision must match it or the transfer fails closed.
 allowed() {
   local candidate
   while IFS= read -r candidate; do

--- a/bin/fm-remote-inherit.sh
+++ b/bin/fm-remote-inherit.sh
@@ -16,6 +16,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # shellcheck source=bin/fm-wake-lib.sh
 . "$SCRIPT_DIR/fm-wake-lib.sh"
+# shellcheck source=bin/fm-config-inherit-lib.sh
+. "$SCRIPT_DIR/fm-config-inherit-lib.sh"
 
 die() { printf 'error: %s\n' "$1" >&2; exit 1; }
 usage() { sed -n '2,10p' "$0" | sed 's/^# \{0,1\}//'; exit 2; }
@@ -25,11 +27,19 @@ file_link_count() {
 sha256_file() {
   if command -v shasum >/dev/null 2>&1; then shasum -a 256 "$1" | awk '{print $1}'; else sha256sum "$1" | awk '{print $1}'; fi
 }
+# Writable set, derived from the ONE declared inherited-material owner
+# (FM_INHERITABLE_CONFIG in bin/fm-config-inherit-lib.sh) so the receiver can
+# never accept less - or more - than the sender declares. This runs under the
+# remote entrypoint's fixed empty environment, so the declaration is this code
+# root's own, never something the caller can widen over SSH.
 allowed() {
-  case "$1" in
-    config/crew-dispatch.json|config/crew-harness|config/backlog-backend|config/backend|config/herdr-presentation-spaces|config/startup-memory-budget|data/captain-shared.md) return 0 ;;
-    *) return 1 ;;
-  esac
+  local candidate
+  while IFS= read -r candidate; do
+    [ "$candidate" = "$1" ] && return 0
+  done <<EOF
+$(fm_config_inherit_items)
+EOF
+  return 1
 }
 
 [ "$#" -eq 5 ] || usage

--- a/bin/fm-remote-secondmate-control.sh
+++ b/bin/fm-remote-secondmate-control.sh
@@ -2,7 +2,7 @@
 # Host-local lifecycle control for the remote secondmate home selected by fm-on.
 #
 # Usage:
-#   fm-remote-secondmate-control.sh launch <id> <harness> <model|-> <effort|-> <backend|->
+#   fm-remote-secondmate-control.sh launch <id> <harness> <model|-> <effort|-> <backend|-> [traceparent]
 #   fm-remote-secondmate-control.sh state <id>
 #   fm-remote-secondmate-control.sh send <id> <message>
 #   fm-remote-secondmate-control.sh key <id> <key>
@@ -17,6 +17,13 @@
 # owning those local endpoint mechanics. A private parent-route state directory
 # stores only the remote secondmate agent's endpoint record; the home's own
 # state/*.meta remains reserved for workers the secondmate supervises.
+#
+# The optional launch traceparent is the per-task W3C trace-context carrier the
+# PARENT home resolved for this secondmate; this host only delivers it to the
+# pane, and fm-spawn validates it (bin/fm-trace-context-lib.sh). Omitting it is
+# the default-off path. print_route echoes the carrier the endpoint actually
+# holds, including for an already-alive endpoint that was not relaunched, so the
+# parent records the identity the agent really received rather than an intent.
 set -eu
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -58,19 +65,22 @@ state_value() { # <id>; prints recovery-grade state
 }
 
 print_route() { # <id>
-  local meta=$1 backend target harness
+  local meta=$1 backend target harness traceparent
   meta=$(meta_path "$meta")
   backend=$(fm_backend_of_meta "$meta")
   target=$(fm_backend_target_of_meta "$meta")
   harness=$(fm_meta_get "$meta" harness)
+  traceparent=$(fm_meta_get "$meta" traceparent)
   printf 'schema=fm-remote-secondmate-control.v1\n'
   printf 'backend=%s\n' "$backend"
   printf 'target=%s\n' "$target"
   printf 'harness=%s\n' "$harness"
+  [ -z "$traceparent" ] || printf 'traceparent=%s\n' "$traceparent"
 }
 
 cmd_launch() {
-  local id=$1 harness=$2 model=$3 effort=$4 selected_backend=$5 current meta out backend target
+  local id=$1 harness=$2 model=$3 effort=$4 selected_backend=$5 traceparent=${6:-}
+  local current meta out backend target
 
   validate_id "$id"
   validate_home "$id"
@@ -95,6 +105,7 @@ cmd_launch() {
   [ "$model" = - ] || ARGS+=(--model "$model")
   [ "$effort" = - ] || ARGS+=(--effort "$effort")
   [ "$selected_backend" = - ] || ARGS+=(--backend "$selected_backend")
+  [ -z "$traceparent" ] || ARGS+=(--traceparent "$traceparent")
   if ! out=$(FM_HOME="$FM_ROOT" FM_ROOT_OVERRIDE="$FM_ROOT" \
     FM_STATE_OVERRIDE="$CONTROL_STATE" FM_DATA_OVERRIDE="$CONTROL_DATA" \
     FM_CONFIG_OVERRIDE="$TARGET_HOME/config" FM_SKIP_SECONDMATE_INHERIT=1 \
@@ -226,7 +237,7 @@ cmd_retire() {
 }
 
 case "${1:-}" in
-  launch) shift; [ "$#" -eq 5 ] || usage; cmd_launch "$@" ;;
+  launch) shift; [ "$#" -ge 5 ] && [ "$#" -le 6 ] || usage; cmd_launch "$@" ;;
   state) shift; [ "$#" -eq 1 ] || usage; validate_id "$1"; validate_home "$1"; state_value "$1" ;;
   send) shift; [ "$#" -eq 2 ] || usage; cmd_send "$@" ;;
   key) shift; [ "$#" -eq 2 ] || usage; cmd_key "$@" ;;

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -488,8 +488,9 @@ spawn_remote_secondmate() {
   # Record what the remote endpoint ACTUALLY carries, read back from its own
   # launch, rather than what this side hoped to deliver. That keeps the #995
   # guarantee that the recorded carrier is the identity the child received even
-  # when the remote host already had a live agent and reused its endpoint, and
-  # it writes nothing at all while trace context is off.
+  # when the remote host already had a live agent and reused its endpoint. An
+  # off decision delivers no carrier, but an endpoint already holding one still
+  # reports it here so the parent does not deny the agent's actual identity.
   remote_recorded_traceparent=$(printf '%s\n' "$out" | sed -n 's/^traceparent=//p' | tail -1)
   fm_trace_context_valid "$remote_recorded_traceparent" || remote_recorded_traceparent=
   tmp="$meta.tmp.$$"

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -142,6 +142,13 @@
 # one W3C traceparent= carrier, the same value injected into the pane as
 # TRACEPARENT; the default-off path writes neither, leaving the generated meta
 # and launch environment unchanged.
+#   --traceparent <carrier> delivers a carrier that a REMOTE parent already
+#   resolved and will record, instead of resolving one from this home's frozen
+#   decision. It is accepted only for --secondmate spawns, only as a strictly
+#   validated W3C traceparent, and exists because a remote secondmate's task
+#   identity is owned by the parent home that holds its task metadata, while the
+#   pane export happens on the remote host (bin/fm-remote-secondmate-control.sh).
+#   Local spawns never pass it and resolve their own carrier exactly as before.
 set -eu
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -215,12 +222,14 @@ EFFORT=
 BACKEND_ARG=
 MODE=
 YOLO=
+TRACEPARENT_ARG=
 HARNESS_SET=0
 MODEL_SET=0
 EFFORT_SET=0
 BACKEND_SET=0
 MODE_SET=0
 YOLO_SET=0
+TRACEPARENT_SET=0
 POS=()
 want_value=
 for a in "$@"; do
@@ -235,6 +244,7 @@ for a in "$@"; do
       backend) BACKEND_ARG=$a; BACKEND_SET=1 ;;
       mode) MODE=$a; MODE_SET=1 ;;
       yolo) YOLO=$a; YOLO_SET=1 ;;
+      traceparent) TRACEPARENT_ARG=$a; TRACEPARENT_SET=1 ;;
       *) echo "error: internal parser state for --$want_value" >&2; exit 1 ;;
     esac
     want_value=
@@ -255,6 +265,8 @@ for a in "$@"; do
     --mode=*) MODE=${a#--mode=}; MODE_SET=1 ;;
     --yolo) want_value=yolo ;;
     --yolo=*) YOLO=${a#--yolo=}; YOLO_SET=1 ;;
+    --traceparent) want_value=traceparent ;;
+    --traceparent=*) TRACEPARENT_ARG=${a#--traceparent=}; TRACEPARENT_SET=1 ;;
     *) POS+=("$a") ;;
   esac
 done
@@ -265,6 +277,20 @@ done
 [ "$BACKEND_SET" -eq 0 ] || [ -n "$BACKEND_ARG" ] || { echo "error: --backend requires a non-empty value" >&2; exit 1; }
 [ "$MODE_SET" -eq 0 ] || [ -n "$MODE" ] || { echo "error: --mode requires a non-empty value" >&2; exit 1; }
 [ "$YOLO_SET" -eq 0 ] || [ -n "$YOLO" ] || { echo "error: --yolo requires a non-empty value" >&2; exit 1; }
+[ "$TRACEPARENT_SET" -eq 0 ] || [ -n "$TRACEPARENT_ARG" ] || { echo "error: --traceparent requires a non-empty value" >&2; exit 1; }
+# A parent-delivered carrier replaces this home's own resolution, so it is
+# refused unless it is a secondmate spawn carrying a strictly valid W3C value.
+# Nothing else may reach the pane's TRACEPARENT export.
+if [ "$TRACEPARENT_SET" -eq 1 ]; then
+  [ "$KIND" = secondmate ] || {
+    echo "error: --traceparent applies only to --secondmate spawns; every other spawn resolves its own carrier from this home's frozen trace-context decision" >&2
+    exit 1
+  }
+  fm_trace_context_valid "$TRACEPARENT_ARG" || {
+    echo "error: --traceparent is not a valid W3C traceparent" >&2
+    exit 1
+  }
+fi
 case "$EFFORT" in
   ''|low|medium|high|xhigh|max) ;;
   *) echo "error: --effort must be one of low, medium, high, xhigh, max" >&2; exit 1 ;;
@@ -308,6 +334,8 @@ fi
 spawn_remote_secondmate() {
   local id=$1 remote host root home harness positional model effort backend out rc meta tmp
   local remote_backend remote_target remote_harness registry_lock remote_lock remote_generation
+  local remote_traceparent remote_recorded_traceparent
+  local -a launch_args
   id=${POS[0]:-}
   fm_task_id_creation_valid "$id" || { echo "error: invalid task id" >&2; return 2; }
   mkdir -p "$STATE" || { echo "error: could not create parent state directory" >&2; return 1; }
@@ -418,8 +446,21 @@ spawn_remote_secondmate() {
     fi
     return "$rc"
   fi
+  # This parent home owns the remote secondmate's task identity because it holds
+  # the task metadata an observer reads, exactly as for a local spawn: the
+  # carrier is resolved against THIS task's own meta (reused verbatim on
+  # relaunch, freshly rooted otherwise, never adopting this process's ambient
+  # TRACEPARENT) under this home's frozen decision, then handed to the remote
+  # host to export into the agent's pane. Disabled resolves to empty and the
+  # remote launch call stays byte-identical to the untraced one.
+  remote_traceparent=
+  if [ "$(fm_trace_context_session_effective "$STATE/.trace-context-effective")" = on ]; then
+    remote_traceparent=$(FM_TRACE_CONTEXT=on fm_trace_context_resolve "$CONFIG" "$meta" || true)
+  fi
+  launch_args=("$id" "$harness" "$model" "$effort" "$backend")
+  [ -z "$remote_traceparent" ] || launch_args+=("$remote_traceparent")
   if out=$("$SCRIPT_DIR/fm-on.sh" "$id" fm-remote-secondmate-control.sh launch \
-    "$id" "$harness" "$model" "$effort" "$backend" 2>&1); then
+    "${launch_args[@]}" 2>&1); then
     rc=0
   else
     rc=$?
@@ -444,6 +485,13 @@ spawn_remote_secondmate() {
     echo "error: remote launch returned malformed route metadata; preserving the remote route for reconciliation" >&2
     return 1
   }
+  # Record what the remote endpoint ACTUALLY carries, read back from its own
+  # launch, rather than what this side hoped to deliver. That keeps the #995
+  # guarantee that the recorded carrier is the identity the child received even
+  # when the remote host already had a live agent and reused its endpoint, and
+  # it writes nothing at all while trace context is off.
+  remote_recorded_traceparent=$(printf '%s\n' "$out" | sed -n 's/^traceparent=//p' | tail -1)
+  fm_trace_context_valid "$remote_recorded_traceparent" || remote_recorded_traceparent=
   tmp="$meta.tmp.$$"
   {
     echo "window=remote:$id"
@@ -463,6 +511,7 @@ spawn_remote_secondmate() {
     echo "remote_root=$root"
     echo "remote_backend=$remote_backend"
     echo "remote_target=$remote_target"
+    [ -z "$remote_recorded_traceparent" ] || echo "traceparent=$remote_recorded_traceparent"
   } > "$tmp"
   mv -f -- "$tmp" "$meta"
   fm_lock_release "$remote_lock" || true
@@ -1911,11 +1960,22 @@ fi
 #
 # The session-start path owns input resolution. Spawn consumes only the frozen
 # home-session state and reuses it for the carrier and Secondmate launch prefix.
-SPAWN_TRACE_EFFECTIVE=$(fm_trace_context_session_effective "$STATE/.trace-context-effective")
-if [ "$SPAWN_TRACE_EFFECTIVE" = on ]; then
-  SPAWN_TRACEPARENT=$(FM_TRACE_CONTEXT=on fm_trace_context_resolve "$CONFIG" "$STATE/$ID.meta" || true)
+#
+# A remote secondmate launch is the one case where this process is not the home
+# that owns the task's identity: the parent home resolved and will record the
+# carrier, and this host only delivers it. The validated --traceparent value
+# then IS the decision, so the enablement snapshot handed to the new Secondmate
+# agrees with the carrier it receives exactly as on the local path.
+if [ "$TRACEPARENT_SET" -eq 1 ]; then
+  SPAWN_TRACE_EFFECTIVE=on
+  SPAWN_TRACEPARENT=$TRACEPARENT_ARG
 else
-  SPAWN_TRACEPARENT=
+  SPAWN_TRACE_EFFECTIVE=$(fm_trace_context_session_effective "$STATE/.trace-context-effective")
+  if [ "$SPAWN_TRACE_EFFECTIVE" = on ]; then
+    SPAWN_TRACEPARENT=$(FM_TRACE_CONTEXT=on fm_trace_context_resolve "$CONFIG" "$STATE/$ID.meta" || true)
+  else
+    SPAWN_TRACEPARENT=
+  fi
 fi
 
 META_WINDOW=$T

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -165,6 +165,7 @@ family_for_basename() {
       ;;
     fm-backlog-handoff.test.sh|fm-on.test.sh|fm-remote-backlog-handoff.test.sh|\
     fm-remote-reply.test.sh|fm-remote-secondmate-lifecycle-e2e.test.sh|\
+    fm-remote-secondmate-trace-context.test.sh|\
     fm-secondmate-harness.test.sh|fm-secondmate-lifecycle-e2e.test.sh|\
     fm-secondmate-liveness.test.sh|fm-secondmate-safety.test.sh|fm-secondmate-sync.test.sh|\
     fm-startup-memory-budget.test.sh|\

--- a/bin/fm-trace-context-lib.sh
+++ b/bin/fm-trace-context-lib.sh
@@ -58,6 +58,11 @@
 #   frozen on/off decision into the new process as a non-empty FM_TRACE_CONTEXT
 #   value in the launch prefix (bin/fm-spawn.sh). The Secondmate freezes that
 #   inherited decision when its own home session starts.
+#   A REMOTE secondmate route resolves here too, in the PARENT process that owns
+#   that task's meta: fm-spawn's spawn_remote_secondmate resolves the carrier,
+#   hands it to the configured host through fm-spawn's --traceparent, and records
+#   the carrier the remote endpoint reports back. Only the pane export moves
+#   hosts; identity, enablement, and the per-task boundary do not.
 #
 # Wire shape: version 00 only, "00-<32 hex trace>-<16 hex span>-<2 hex flags>",
 # with the trace id and span id never all-zero (W3C rejects both). New roots use
@@ -140,7 +145,10 @@ fm_trace_context_session_lock() {  # <effective-state-file>
   local effective_file=$1 state_dir lock_pid
   state_dir=${effective_file%/*}
   [ "$state_dir" = "$effective_file" ] && state_dir=.
-  IFS= read -r lock_pid < "$state_dir/.lock" 2>/dev/null || return 1
+  # Grouped so the stderr redirect is in place BEFORE the input redirect is
+  # attempted: an absent lock is an ordinary silent "not locked" answer, and a
+  # trailing 2>/dev/null on the bare read would still leak the open failure.
+  { IFS= read -r lock_pid < "$state_dir/.lock"; } 2>/dev/null || return 1
   case "$lock_pid" in
     '' | *[!0-9]*) return 1 ;;
   esac

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -122,6 +122,8 @@ The optional local, gitignored `config/trace-context` presence flag enables defa
 `FM_TRACE_CONTEXT` overrides the file: `1`/`on`/`true`/`yes` enables, any other non-empty value disables, and unset or empty defers to the file.
 Each locked home session resolves those inputs once, and all spawns from that home use the frozen decision until a new session starts.
 When launching a Secondmate, the primary copies the presence flag into its home and passes the primary session's frozen decision as a non-empty `FM_TRACE_CONTEXT=on|off` override for the Secondmate's own session start.
+A Secondmate on a remote route is covered the same way: the primary resolves and records that task's carrier, and the configured host exports it and receives the same enablement snapshot.
+The presence flag is session-scoped enablement, so it transfers at launch and is left unchanged by live convergence into a running home.
 See [`trace-context.md`](trace-context.md) for carrier semantics, supported routes, the manual fleet-restart requirement, the session boundary, and safety limits; `bin/fm-trace-context-lib.sh`'s header owns the exact mechanics, and [`verification/trace-context.md`](verification/trace-context.md) records repeatable evidence.
 
 ## Gate defaults (.no-mistakes.yaml)

--- a/docs/remote-secondmates.md
+++ b/docs/remote-secondmates.md
@@ -117,6 +117,7 @@ bin/fm-test-run.sh tests/fm-on.test.sh
 bin/fm-test-run.sh tests/fm-remote-reply.test.sh
 bin/fm-test-run.sh tests/fm-remote-backlog-handoff.test.sh
 bin/fm-test-run.sh tests/fm-remote-secondmate-lifecycle-e2e.test.sh
+bin/fm-test-run.sh tests/fm-remote-secondmate-trace-context.test.sh
 ```
 
 For a real-host smoke test, provision a disposable remote account and project, launch the second mate, send one marked request, verify its correlated reply and structured fleet projection, simulate an unreachable host to confirm unknown-without-failover behavior, then retire only after the remote queue is empty.

--- a/docs/trace-context.md
+++ b/docs/trace-context.md
@@ -26,6 +26,15 @@ Because the injected carrier and the recorded carrier are the same string, an ob
 The injection sits at the unconditional pre-launch export site, so it covers ship, scout, and Secondmate spawns and is identical across every harness (`claude`, `codex`, `opencode`, `pi`, `grok`, `kimi`) - the same coverage `GOTMPDIR` already has, with no `launch_template()` change.
 Ship and scout spawns reach that site on every spawn backend (`tmux`, `herdr`, `zellij`, `orca`, `cmux`); a Secondmate reaches it on every backend that accepts a Secondmate spawn (`tmux`, `herdr`, `zellij`), because `bin/fm-spawn.sh` rejects a Secondmate on `orca` and `cmux`.
 
+### Remote Secondmate routes
+
+A Secondmate on a [remote route](remote-secondmates.md) never reaches that export site in the parent's own process: the parent hands the launch to the configured host, which runs its own `bin/fm-spawn.sh` there.
+The identity is still the parent's, because the parent home holds the task metadata an observer reads.
+The parent therefore resolves the carrier against that task's own metadata under its own frozen decision - reused verbatim on relaunch, freshly rooted otherwise, never adopting the parent process's ambient `TRACEPARENT` - and passes it to the remote host, which exports it at the same unconditional pre-launch site and returns the carrier its endpoint actually holds.
+The parent records that returned value, so an already-alive remote endpoint that was not relaunched reports the identity its agent really received rather than one the parent merely intended.
+The remote host validates the delivered carrier as a strict W3C value before it can reach any pane, and a disabled parent passes nothing, leaving the remote launch identical to the untraced one.
+The enablement decision travels with it exactly as on the local path: the remote home inherits `config/trace-context` as declared inherited material and the new Secondmate process receives the parent's frozen `FM_TRACE_CONTEXT=on|off` snapshot.
+
 ## Root and recovery semantics
 
 The point of these rules is one trace per task: never merge unrelated tasks, and never mint a second identity for the same task.
@@ -49,8 +58,9 @@ Every spawn from that home reads only the frozen `on` or `off` decision.
 Later config or environment edits are ignored until that home starts a new session.
 Missing, stale, unreadable, invalid, or unsuccessfully published effective state defaults safely to `off`.
 
-When the primary launches a Secondmate, it propagates `config/trace-context` into the Secondmate home and passes the primary session's frozen decision as a non-empty `FM_TRACE_CONTEXT=on|off` launch override.
+When the primary launches a Secondmate, local or remote, it propagates `config/trace-context` into the Secondmate home and passes the primary session's frozen decision as a non-empty `FM_TRACE_CONTEXT=on|off` launch override.
 The Secondmate resolves that inherited override when its own home session starts.
+That flag is session-scoped enablement rather than durable configuration, so it is transferred at the launch convergence point - where the frozen decision is handed over with it - and left untouched by live convergence into an already-running home, on local and remote routes alike.
 What propagates is the enablement decision, never trace identity: a Secondmate launched while enabled receives its own task carrier from the primary - the Secondmate agent's identity, reused verbatim when the Secondmate itself is relaunched - and each worker it spawns roots its own per-task trace.
 A Secondmate launched while disabled keeps its workers untraced even if `config/trace-context` is present in its home.
 When enabled, a relaunch reuses the task's valid recorded carrier; a task without one roots a fresh trace.

--- a/docs/trace-context.md
+++ b/docs/trace-context.md
@@ -33,6 +33,7 @@ The identity is still the parent's, because the parent home holds the task metad
 The parent therefore resolves the carrier against that task's own metadata under its own frozen decision - reused verbatim on relaunch, freshly rooted otherwise, never adopting the parent process's ambient `TRACEPARENT` - and passes it to the remote host, which exports it at the same unconditional pre-launch site and returns the carrier its endpoint actually holds.
 The parent records that returned value, so an already-alive remote endpoint that was not relaunched reports the identity its agent really received rather than one the parent merely intended.
 The remote host validates the delivered carrier as a strict W3C value before it can reach any pane, and a disabled parent passes nothing, leaving the remote launch identical to the untraced one.
+If the endpoint is already alive, no new launch or injection occurs; the parent still records any carrier that endpoint reports, even when the parent's current decision is `off`, so its metadata does not deny the running agent's actual identity.
 The enablement decision travels with it exactly as on the local path: the remote home inherits `config/trace-context` as declared inherited material and the new Secondmate process receives the parent's frozen `FM_TRACE_CONTEXT=on|off` snapshot.
 
 ## Root and recovery semantics
@@ -47,8 +48,8 @@ The point of these rules is one trace per task: never merge unrelated tasks, and
   A corrupt recorded value is re-minted as a fresh root rather than propagated.
 
 Because ambient `TRACEPARENT` is never read, the environment a supervisor happens to run under - a Secondmate's launch-time carrier, or an operator shell with a leftover `TRACEPARENT` - cannot leak into new task identities.
-Disabling propagation is an intentional trace boundary: a disabled home injects no carrier even when the task meta already contains a valid `traceparent=`.
-A disabled relaunch regenerates the task meta without `traceparent=`, so a later enabled relaunch roots a new trace instead of resuming the identity from before the boundary.
+Disabling propagation is an intentional trace boundary: a disabled home injects no carrier into a newly launched or relaunched agent even when the task meta already contains a valid `traceparent=`.
+An actual disabled relaunch regenerates the task meta without `traceparent=`, so a later enabled relaunch roots a new trace instead of resuming the identity from before the boundary; reusing an already-alive remote endpoint is not a relaunch and preserves the carrier that agent already holds.
 
 ### Enablement is home-session-scoped
 
@@ -86,7 +87,8 @@ This is a deliberate, source-owned choice:
 ## Safety
 
 - **Default-off.**
-  With no `config/trace-context` and no `FM_TRACE_CONTEXT`, nothing is injected and no `traceparent=` line is written, so the generated meta and the launch environment are unchanged.
+  With no `config/trace-context` and no `FM_TRACE_CONTEXT`, a fresh spawn or actual relaunch injects nothing and writes no `traceparent=` line, so the generated meta and the launch environment are unchanged.
+  Reusing an already-alive remote endpoint records any carrier that endpoint reports without injecting a new one.
   A locked session start makes the one config-file check, and each spawn sources one extra library and reads the frozen effective-state file, so the process is not literally byte-for-byte identical, but nothing an agent, an observer, or the task meta can see differs.
 - **What is and is not exposed.**
   A Firstmate-*minted* root uses a random id and reads no prompt, path, task prose, credential, or arbitrary environment key, so Firstmate never *originates* sensitive data in the carrier.

--- a/docs/verification/trace-context.md
+++ b/docs/verification/trace-context.md
@@ -5,7 +5,7 @@ Current behavior and rationale are owned by [`../trace-context.md`](../trace-con
 
 Date: 2026-08-03.
 Shell: GNU bash 3.2.57 (macOS).
-Comparison base: `main` at `4ee4a0a`.
+Comparison base: `main` at `976d97f`.
 
 The colocated unit suite `tests/fm-trace-context-lib.test.sh` (26 assertions) exercises validation (valid accepted; malformed, wrong-length, uppercase, all-zero, `ff` version, and shell-metacharacter values rejected), root minting with every mint a distinct sampled root and no parent-adoption input, the recovery reuse path with the recorded carrier winning over the ambient environment, default-off omission, the enable precedence of `FM_TRACE_CONTEXT` over `config/trace-context` with unset or empty deferring to the file, normalized home-session state, atomic replacement of a read-only prior record, stale-session rejection after failed publication, missing or invalid state defaulting off, the Secondmate home-session boundary with later file state plus the per-task trace boundary (two resolves under one persistent ambient `TRACEPARENT` root two distinct traces and adopt neither), forced entropy failure omitting safely, and the minted-root fixed-shape check.
 
@@ -16,12 +16,16 @@ A final assertion drives the file-decided path (`FM_TRACE_CONTEXT` unset) and pr
 The suite touches no real harness or live fleet.
 `tests/fm-session-start.test.sh` additionally proves only a lock-owning session start writes the effective state and a lock-refused read-only start leaves it unchanged.
 
+The remote-route suite `tests/fm-remote-secondmate-trace-context.test.sh` (6 assertions) covers the Secondmate path that never reaches the local export site, driving the real chain - the parent's `bin/fm-spawn.sh`, `bin/fm-on.sh`, the real remote entrypoint, `bin/fm-remote-secondmate-control.sh`, and the remote host's own `bin/fm-spawn.sh` - over the deterministic SSH boundary with a fake tmux, so the carrier the remote pane receives is read back from that pane's own log: disabled, the parent records no `traceparent=`, the remote pane receives no export, the remote home inherits no enablement flag, and the delivered snapshot is `FM_TRACE_CONTEXT=off` while `GOTMPDIR` still ships; enabled, the parent's recorded carrier, the remote endpoint's own record, and the exported pane value are one identical valid carrier sent after `GOTMPDIR` and before the launch command, with `FM_TRACE_CONTEXT=on` and the inherited flag delivered; a relaunch keeps that carrier verbatim in both the parent record and the pane export; a second remote route resolved from an environment holding a fixed ambient `TRACEPARENT` roots a trace id distinct from both that ambient carrier and the first route; the remote receiver accepts `config/trace-context` as ordinary declared inherited material while refusing `config/secondmate-harness`, which the primary deliberately does not propagate; and the delivery argument that carries a parent's carrier to a remote host is refused on a ship spawn, on a shell-metacharacter value, on an all-zero trace id, and on an empty value, so nothing but a strict W3C carrier on a Secondmate launch can reach a pane export.
+
 ```console
 $ bash tests/fm-trace-context-lib.test.sh | tail -1
 # fm-trace-context-lib.test.sh: all assertions passed
 $ bash tests/fm-trace-context-spawn.test.sh | tail -1
 # all fm-trace-context-spawn tests passed
+$ bash tests/fm-remote-secondmate-trace-context.test.sh | tail -1
+ALL TESTS PASSED
 ```
 
-Run both trace-context suites from the repo root; each prints one `ok - ...` per assertion.
+Run all three trace-context suites from the repo root; each prints one `ok - ...` per assertion.
 A single live-backend end-to-end check - a real spawn confirming the pane received the `TRACEPARENT` export before the launch line, with nothing left after teardown - is a bounded manual step, deferred here because a live agent spawn disrupts a running fleet.

--- a/tests/fm-remote-secondmate-trace-context.test.sh
+++ b/tests/fm-remote-secondmate-trace-context.test.sh
@@ -1,0 +1,293 @@
+#!/usr/bin/env bash
+# tests/fm-remote-secondmate-trace-context.test.sh - trace-context regressions for
+# the REMOTE second mate route, over the deterministic generic SSH boundary.
+#
+# The local spawn path's coverage lives in tests/fm-trace-context-spawn.test.sh.
+# A remote second mate never reaches that path: bin/fm-spawn.sh routes it through
+# spawn_remote_secondmate, which hands the launch to the remote host. These
+# assertions drive the real chain - parent fm-spawn -> fm-on -> the real remote
+# entrypoint -> fm-remote-secondmate-control -> the remote host's own fm-spawn -
+# against a fake tmux, so the carrier the remote pane receives is observable.
+# See docs/verification/trace-context.md for the maintained coverage inventory.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+# shellcheck source=/dev/null
+. "$ROOT/bin/fm-trace-context-lib.sh"
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)
+TMP_ROOT=$(fm_test_tmproot fm-remote-trace-context)
+mkdir -p "$TMP_ROOT"
+TMP_ROOT=$(cd "$TMP_ROOT" && pwd -P)
+PARENT="$TMP_ROOT/parent"
+REMOTE_ROOT="$TMP_ROOT/remote-root"
+REMOTE_HOME="$TMP_ROOT/remote-home"
+SECOND_HOME="$TMP_ROOT/remote-home-2"
+FAKEBIN=$(fm_fakebin "$TMP_ROOT/fake")
+TMUX_LOG="$TMP_ROOT/remote-tmux.log"
+TMUX_STATE="$TMP_ROOT/remote-tmux.state"
+CLAIMS="$TMP_ROOT/claims"
+mkdir -p "$PARENT/data" "$PARENT/state" "$PARENT/config" "$PARENT/projects" "$REMOTE_ROOT" "$CLAIMS"
+trap 'FM_HOME="$PARENT" FM_PROCEVENT_CLAIM_ROOT="$CLAIMS" "$ROOT/bin/fm-procevent.sh" sweep-home >/dev/null 2>&1 || true; rm -rf -- "$TMP_ROOT"' EXIT
+
+# The remote host's tracked code root is this branch, as a real git repository:
+# fm-on and the remote entrypoint both require the dispatched command to be
+# tracked there, and the remote side runs the real scripts under test.
+(
+  cd "$ROOT" || exit
+  tar --exclude=.git --exclude=.no-mistakes --exclude=data --exclude=state --exclude=config -cf - .
+) | (cd "$REMOTE_ROOT" && tar -xf -)
+
+# Fake tmux on the remote host. Every invocation is logged verbatim, so the
+# pre-launch `export TRACEPARENT=` line and the launch literal's
+# FM_TRACE_CONTEXT prefix are both observable exactly as the pane received them.
+cat > "$REMOTE_ROOT/bin/tmux" <<SH
+#!/usr/bin/env bash
+set -u
+log='$TMUX_LOG'
+state='$TMUX_STATE'
+printf '%s\n' "\$*" >> "\$log"
+case "\${1:-}" in
+  has-session|new-session|set-window-option) exit 0 ;;
+  list-windows)
+    [ -f "\$state" ] || exit 0
+    name=\$(cut -d'|' -f1 "\$state")
+    case "\$*" in *'#{session_name}:#{window_name}'*) printf 'firstmate:%s\n' "\$name" ;; *) printf '%s\n' "\$name" ;; esac
+    exit 0
+    ;;
+  new-window)
+    name=; cwd=
+    while [ "\$#" -gt 0 ]; do
+      case "\$1" in -n) shift; name=\$1 ;; -c) shift; cwd=\$1 ;; esac
+      shift
+    done
+    printf '%s|%s\n' "\$name" "\$cwd" > "\$state"
+    printf '@1\n'
+    exit 0
+    ;;
+  display-message)
+    case "\$*" in
+      *'#{pane_current_path}'*) cut -d'|' -f2- "\$state" ;;
+      *'#{pane_current_command}'*) printf 'codex\n' ;;
+      *'#{cursor_y}'*) printf '0\n' ;;
+      *'#S'*) printf 'firstmate\n' ;;
+      *) printf '%%1\n' ;;
+    esac
+    exit 0
+    ;;
+  capture-pane) printf '\n'; exit 0 ;;
+  send-keys) exit 0 ;;
+  kill-window) rm -f -- "\$state"; exit 0 ;;
+  list-panes) printf 'codex\n'; exit 0 ;;
+esac
+exit 0
+SH
+chmod +x "$REMOTE_ROOT/bin/tmux"
+git -C "$REMOTE_ROOT" init -q -b main
+git -C "$REMOTE_ROOT" config user.email test@example.com
+git -C "$REMOTE_ROOT" config user.name Test
+git -C "$REMOTE_ROOT" add .
+git -C "$REMOTE_ROOT" commit -qm 'remote fixture root'
+
+cat > "$FAKEBIN/fake-ssh" <<'SH'
+#!/usr/bin/env bash
+while [ "$#" -gt 0 ]; do
+  case "$1" in -o) shift 2 ;; --) shift; break ;; *) exit 90 ;; esac
+done
+host=$1
+entry=$2
+shift 2
+[ "$host" = remote-mac ] || exit 91
+[ "$entry" = fm-remote-entrypoint.sh ] || exit 92
+cd "$FM_FAKE_REMOTE_CWD" || exit 93
+exec "$FM_FAKE_REMOTE_ENTRYPOINT" "$@"
+SH
+chmod +x "$FAKEBIN/fake-ssh"
+
+printf 'codex\n' > "$PARENT/config/secondmate-harness"
+printf 'tmux\n' > "$PARENT/config/backend"
+printf 'codex\n' > "$PARENT/config/crew-harness"
+printf '## In flight\n\n## Queued\n\n## Done\n' > "$PARENT/data/backlog.md"
+
+remote_env() {
+  FM_HOME="$PARENT" \
+  FM_ROOT_OVERRIDE="$REMOTE_ROOT" \
+  FM_PROCEVENT_CLAIM_ROOT="$CLAIMS" \
+  FM_SSH_BIN="$FAKEBIN/fake-ssh" \
+  FM_FAKE_REMOTE_ENTRYPOINT="$REMOTE_ROOT/bin/fm-remote-entrypoint.sh" \
+  FM_FAKE_REMOTE_CWD="$TMP_ROOT" \
+  FM_SEND_SETTLE=0 FM_SEND_SLEEP=0 \
+  "$@"
+}
+
+# Freeze the parent home's trace-context decision the way a locked session start
+# does, hermetically against an ambient FM_TRACE_CONTEXT.
+freeze_parent_session() {
+  printf '%s\n' "$$" > "$PARENT/state/.lock"
+  (
+    unset FM_TRACE_CONTEXT
+    fm_trace_context_session_start "$PARENT/config" "$PARENT/state/.trace-context-effective"
+  )
+}
+
+# What the remote pane actually received, read back from the remote tmux log.
+remote_injected_traceparent() {
+  sed -n 's/.*export TRACEPARENT=\([0-9a-f-]*\).*/\1/p' "$TMUX_LOG" | tail -1
+}
+remote_launch_snapshot() {
+  grep -o 'FM_TRACE_CONTEXT=[a-z]*' "$TMUX_LOG" | tail -1 | cut -d= -f2
+}
+meta_traceparent() { sed -n 's/^traceparent=//p' "$1"; }
+
+# Provision and register the remote route from the captain-facing primary.
+FM_SECONDMATE_CHARTER='Own iOS delivery on the build Mac.' \
+  FM_SECONDMATE_SCOPE='iOS implementation and Xcode validation' \
+  remote_env "$ROOT/bin/fm-remote-home-seed.sh" ios remote-mac "$REMOTE_ROOT" "$REMOTE_HOME" --no-projects >/dev/null \
+  || fail "remote seed did not provision the traced route"
+
+# --- disabled: the remote route must stay byte-identically untraced ----------
+freeze_parent_session
+: > "$TMUX_LOG"
+remote_env "$ROOT/bin/fm-spawn.sh" ios --secondmate >/dev/null 2>&1 \
+  || fail "default-off remote secondmate spawn failed"
+assert_present "$PARENT/state/ios.meta" "default-off remote spawn published no parent metadata"
+! grep -q '^traceparent=' "$PARENT/state/ios.meta" \
+  || fail "default-off remote spawn must not record a traceparent= line"
+! grep -q 'export TRACEPARENT=' "$TMUX_LOG" \
+  || fail "default-off remote spawn must not export a carrier into the remote pane"
+! grep -q '^traceparent=' "$REMOTE_HOME/state/parent-route/ios.meta" \
+  || fail "default-off remote spawn must not record a carrier on the remote host"
+[ "$(remote_launch_snapshot)" = off ] \
+  || fail "default-off remote spawn must deliver FM_TRACE_CONTEXT=off (got '$(remote_launch_snapshot)')"
+assert_absent "$REMOTE_HOME/config/trace-context" "default-off remote spawn inherited an enablement flag"
+grep -q 'export GOTMPDIR=' "$TMUX_LOG" || fail "the remote spawn should still run (GOTMPDIR is always exported)"
+pass "disabled: a remote-routed second mate records and receives no carrier and stays enabled-off end to end"
+
+# --- enabled: one carrier is recorded by the parent and received remotely ----
+: > "$PARENT/config/trace-context"
+freeze_parent_session
+rm -f "$TMUX_STATE"   # the previous endpoint is gone; this is an ordinary relaunch
+: > "$TMUX_LOG"
+remote_env "$ROOT/bin/fm-spawn.sh" ios --secondmate >/dev/null 2>&1 \
+  || fail "enabled remote secondmate spawn failed"
+
+PARENT_TP=$(meta_traceparent "$PARENT/state/ios.meta")
+REMOTE_TP=$(meta_traceparent "$REMOTE_HOME/state/parent-route/ios.meta")
+INJECTED_TP=$(remote_injected_traceparent)
+fm_trace_context_valid "$PARENT_TP" \
+  || fail "an enabled remote spawn must record a valid carrier in the parent metadata (got '$PARENT_TP')"
+fm_trace_context_valid "$INJECTED_TP" \
+  || fail "an enabled remote spawn must export a valid carrier into the remote pane (got '$INJECTED_TP')"
+[ "$PARENT_TP" = "$INJECTED_TP" ] \
+  || fail "the parent's recorded carrier and the remote pane's carrier must be identical (parent='$PARENT_TP' pane='$INJECTED_TP')"
+[ "$REMOTE_TP" = "$PARENT_TP" ] \
+  || fail "the remote endpoint record must carry the parent's identity (remote='$REMOTE_TP' parent='$PARENT_TP')"
+[ "$(remote_launch_snapshot)" = on ] \
+  || fail "an enabled remote spawn must deliver FM_TRACE_CONTEXT=on (got '$(remote_launch_snapshot)')"
+assert_present "$REMOTE_HOME/config/trace-context" \
+  "an enabled remote launch did not inherit the enablement flag into the remote home"
+GOTMP_LINE=$(grep -n 'export GOTMPDIR=' "$TMUX_LOG" | tail -1 | cut -d: -f1)
+TP_LINE=$(grep -n 'export TRACEPARENT=' "$TMUX_LOG" | tail -1 | cut -d: -f1)
+LAUNCH_LINE=$(grep -n 'FM_TRACE_CONTEXT=' "$TMUX_LOG" | tail -1 | cut -d: -f1)
+[ -n "$GOTMP_LINE" ] && [ -n "$TP_LINE" ] && [ -n "$LAUNCH_LINE" ] \
+  || fail "remote pane log missing GOTMPDIR/TRACEPARENT/launch lines"
+[ "$TP_LINE" -gt "$GOTMP_LINE" ] \
+  || fail "the remote TRACEPARENT export must ride the GOTMPDIR pre-launch site (gotmp=$GOTMP_LINE tp=$TP_LINE)"
+[ "$TP_LINE" -lt "$LAUNCH_LINE" ] \
+  || fail "the remote TRACEPARENT export must be sent before the launch command (tp=$TP_LINE launch=$LAUNCH_LINE)"
+pass "enabled: a remote-routed second mate receives one carrier in its pane, identical to the parent's recorded identity, before launch"
+
+# --- relaunch stability on the remote path ----------------------------------
+rm -f "$TMUX_STATE"
+: > "$TMUX_LOG"
+remote_env "$ROOT/bin/fm-spawn.sh" ios --secondmate >/dev/null 2>&1 \
+  || fail "enabled remote secondmate relaunch failed"
+RELAUNCH_TP=$(meta_traceparent "$PARENT/state/ios.meta")
+RELAUNCH_INJECTED=$(remote_injected_traceparent)
+[ "$RELAUNCH_TP" = "$PARENT_TP" ] \
+  || fail "a remote relaunch must keep the task's recorded carrier (first='$PARENT_TP' relaunch='$RELAUNCH_TP')"
+[ "$RELAUNCH_INJECTED" = "$PARENT_TP" ] \
+  || fail "a remote relaunch must re-export the original carrier (first='$PARENT_TP' injected='$RELAUNCH_INJECTED')"
+pass "relaunch: a remote-routed second mate keeps one stable identity across restarts"
+
+# --- per-task boundary: ambient carriers are never adopted or shared ---------
+# A persistent supervisor exports its own launch-time TRACEPARENT for its whole
+# life. A second remote route resolved from that same environment must root its
+# own trace rather than chain onto it or onto the first route.
+AMBIENT='00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab-bbbbbbbbbbbbbbbb-01'
+FM_SECONDMATE_CHARTER='Own the second build Mac.' \
+  FM_SECONDMATE_SCOPE='second remote domain' \
+  TRACEPARENT="$AMBIENT" \
+  remote_env "$ROOT/bin/fm-remote-home-seed.sh" ios2 remote-mac "$REMOTE_ROOT" "$SECOND_HOME" --no-projects >/dev/null \
+  || fail "second remote seed failed"
+rm -f "$TMUX_STATE"
+: > "$TMUX_LOG"
+TRACEPARENT="$AMBIENT" remote_env "$ROOT/bin/fm-spawn.sh" ios2 --secondmate >/dev/null 2>&1 \
+  || fail "second remote secondmate spawn failed"
+SECOND_TP=$(meta_traceparent "$PARENT/state/ios2.meta")
+fm_trace_context_valid "$SECOND_TP" \
+  || fail "the second remote route must record a valid carrier (got '$SECOND_TP')"
+[ "${SECOND_TP:3:32}" != "${AMBIENT:3:32}" ] \
+  || fail "a remote route must not adopt the spawning process's ambient trace id (got '$SECOND_TP')"
+[ "${SECOND_TP:3:32}" != "${PARENT_TP:3:32}" ] \
+  || fail "two remote routes must root distinct traces (first='$PARENT_TP' second='$SECOND_TP')"
+[ "$(remote_injected_traceparent)" = "$SECOND_TP" ] \
+  || fail "the second remote route's pane must receive its own recorded carrier"
+pass "boundary: each remote-routed second mate roots its own trace and never adopts the spawning environment's carrier"
+
+# --- the enablement flag is one allowlist, shared by both remote ends --------
+# config/trace-context reaches the remote home only because the sender and the
+# receiver derive the same declared inherited-material set. Prove the receiver
+# accepts it as ordinary inherited material rather than by name.
+PROTOCOL_HOME="$TMP_ROOT/protocol-home"
+mkdir -p "$PROTOCOL_HOME/config" "$PROTOCOL_HOME/data" "$PROTOCOL_HOME/state"
+: > "$TMP_ROOT/flag-payload"
+FLAG_BYTES=$(LC_ALL=C wc -c < "$TMP_ROOT/flag-payload" | tr -d ' ')
+if command -v shasum >/dev/null 2>&1; then
+  FLAG_HASH=$(shasum -a 256 "$TMP_ROOT/flag-payload" | awk '{print $1}')
+else
+  FLAG_HASH=$(sha256sum "$TMP_ROOT/flag-payload" | awk '{print $1}')
+fi
+FM_HOME="$PROTOCOL_HOME" "$REMOTE_ROOT/bin/fm-remote-inherit.sh" \
+  put config/trace-context "$FLAG_BYTES" "$FLAG_HASH" 1 < "$TMP_ROOT/flag-payload" >/dev/null \
+  || fail "the remote inherit receiver refused a declared inheritable item"
+assert_present "$PROTOCOL_HOME/config/trace-context" "the accepted inherited enablement flag was not published"
+if FM_HOME="$PROTOCOL_HOME" "$REMOTE_ROOT/bin/fm-remote-inherit.sh" \
+  put config/secondmate-harness "$FLAG_BYTES" "$FLAG_HASH" 1 < "$TMP_ROOT/flag-payload" >/dev/null 2>&1; then
+  fail "the remote inherit receiver accepted an item outside the declared set"
+fi
+assert_absent "$PROTOCOL_HOME/config/secondmate-harness" "a non-inheritable item was published remotely"
+pass "allowlist: the remote receiver accepts exactly the declared inherited-material set, including the enablement flag"
+
+# --- the delivery flag is the only caller-supplied path to a pane export -----
+# A remote host receives the carrier as an argument rather than resolving it, so
+# that argument is refused unless it is a secondmate launch carrying a strictly
+# valid W3C value. Nothing else may reach `export TRACEPARENT=`.
+FLAG_HOME="$TMP_ROOT/flag-home"
+mkdir -p "$FLAG_HOME/state" "$FLAG_HOME/data" "$FLAG_HOME/config" "$FLAG_HOME/projects" "$TMP_ROOT/flag-proj"
+VALID='00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab-bbbbbbbbbbbbbbbb-01'
+try_flag() { # <expect-substring> <message> [extra args...]
+  local expect=$1 message=$2 out
+  shift 2
+  if out=$(FM_SPAWN_NO_GUARD=1 FM_HOME="$FLAG_HOME" "$ROOT/bin/fm-spawn.sh" \
+    flag-a-b1 "$TMP_ROOT/flag-proj" "$@" 2>&1); then
+    fail "$message (the spawn succeeded instead)"
+  fi
+  assert_contains "$out" "$expect" "$message"
+}
+try_flag 'applies only to --secondmate spawns' \
+  "a ship spawn must refuse a caller-supplied carrier" \
+  --mode no-mistakes --yolo off --traceparent "$VALID"
+try_flag 'not a valid W3C traceparent' \
+  "a shell-metacharacter carrier must be refused before any pane export" \
+  --secondmate --traceparent 'bogus; rm -rf /'
+try_flag 'not a valid W3C traceparent' \
+  "an all-zero trace id must be refused as W3C-invalid" \
+  --secondmate --traceparent '00-00000000000000000000000000000000-bbbbbbbbbbbbbbbb-01'
+try_flag 'requires a non-empty value' \
+  "an empty carrier must be refused rather than silently ignored" \
+  --secondmate --traceparent=
+pass "delivery: a parent-supplied carrier is accepted only for a secondmate launch and only as a strict W3C value"
+
+echo "ALL TESTS PASSED"


### PR DESCRIPTION
## Intent

Extend firstmate's per-task W3C trace-context propagation to the REMOTE second mate spawn path, and fix the two-owner inheritable-config allowlist drift and stale docs surfaced by the PR #995 review (finding 6). This is firstmate-side follow-up to #995 (merged to main), which added per-task trace context but only for the local spawn path. Delivery contract: mode=no-mistakes.

BACKGROUND. The trace feature resolves and injects a per-task carrier at the local spawn path in bin/fm-spawn.sh. A REMOTE second mate is instead routed through spawn_remote_secondmate, which exits roughly 1400 lines BEFORE that resolve/export site and writes its own metadata block with no traceparent= and no FM_TRACE_CONTEXT snapshot. So a remote second mate was silently UNTRACED even when the capability was enabled.

REQUIRED WORK, as accepted.
(1) Give the remote second mate a consistent per-task trace: resolve the per-task carrier the same way the local path does (fm_trace_context_resolve against the task's own meta, honoring the frozen FM_TRACE_CONTEXT enablement decision), record traceparent= in the remote meta block, and deliver both the carrier and the FM_TRACE_CONTEXT snapshot to the remote agent, matching the local path's per-task-boundary semantics: never inherit an ambient/parent carrier, and reuse a recorded carrier on relaunch/recovery. Keep it default-off and identical in spirit to the local behavior #995 established.
(2) Reconcile the split inheritable-config allowlist to one owner, so future inheritable-config additions cannot silently drift between the two sides.
(3) Fix the now-inaccurate docs: docs/trace-context.md and the docs/configuration.md 'Trace context propagation' section overstated coverage by implying all secondmate spawns were covered.
(4) Add behavioral tests proving a remote-routed second mate now gets a per-task carrier recorded and delivered, and that per-task boundary and relaunch stability hold on the remote path too, following the existing fake-boundary style of tests/fm-trace-context-spawn.test.sh and the remote fake-ssh harness of tests/fm-remote-secondmate-lifecycle-e2e.test.sh. Prefer exercising the real spawn code over source-text matching.

EXPLICITLY OUT OF SCOPE, as instructed: do not change the local-path trace behavior #995 established, and do not add real remote/SSH infrastructure - use the existing fake-ssh test harness only.

DELIBERATE DECISIONS AND TRADEOFFS MADE WHILE DOING THE WORK, which a reviewer reading only the diff would not know:
- The allowlist drift was WIDER than the review reported. The review named only bin/fm-remote-inherit.sh (the remote receiver). The sender, bin/fm-remote-inherit-push.sh, carried its own separate hardcoded copy that had drifted the same way. Both remote ends now derive from the single canonical FM_INHERITABLE_CONFIG declaration in bin/fm-config-inherit-lib.sh through a new fm_config_inherit_items helper. This widening is intended, not scope creep: fixing only the receiver would have left the identical class of bug in place on the sender.
- A new bin/fm-spawn.sh --traceparent option is a deliberate new CLI surface, not an accident. It is accepted ONLY for --secondmate spawns and ONLY as a strictly validated W3C traceparent. It exists because a remote second mate's task identity is owned by the PARENT home that holds the task metadata an observer reads, while the pane export necessarily happens on the remote host. Local spawns never pass it and resolve their own carrier exactly as before, which is how the out-of-scope constraint on local behavior is honored.
- The strict validation on that flag is a security boundary, deliberately fail-closed with a loud refusal rather than a silent omission: it is the only caller-supplied value that can reach an 'export TRACEPARENT=' in a pane, so a malformed or shell-metacharacter value must be refused rather than passed through. This is intentionally different from #995's rule that entropy/resolution FAILURES omit telemetry without aborting a spawn; an explicitly supplied invalid carrier means a broken or hostile caller, not an entropy failure.
- print_route in bin/fm-remote-secondmate-control.sh now echoes the carrier the remote endpoint ACTUALLY holds, and the parent records that read-back value rather than what it intended to deliver. This is deliberate: when the remote host already had a live agent and reused its endpoint instead of relaunching, recording the intended value would have claimed an identity the running agent never received. Recording the read-back keeps #995's guarantee that the recorded carrier is the identity the child actually got.
- config/trace-context is session-scoped enablement rather than durable configuration, so a new FM_SESSION_SCOPED_INHERITABLE_CONFIG declaration plus predicate now governs it in ONE place, consumed by both the local propagate_inheritable_config and the new remote push skip. This replaced an inline literal comparison in the local library. It required marking the two live-convergence remote call sites (bin/fm-bootstrap.sh and bin/fm-config-push.sh) with FM_CONFIG_INHERIT_LIVE=1, symmetric with how those same files already mark their local convergence calls.
- A consequence was weighed and deliberately accepted: adding an item to the shared allowlist means a local code root NEWER than its remote code root will now refuse the inheritance transfer rather than silently skipping it. That is correct fail-closed behavior and matches the existing convergence model where /updatefirstmate updates remote code roots, and there is deliberately no separate allowlist version negotiation. It is documented in the fm-config-inherit-lib.sh header.
- The new grouped-redirect change in bin/fm-trace-context-lib.sh fixes a PRE-EXISTING stderr leak, verified byte-identical on main: an absent session lock printed a raw shell redirect failure because a trailing 2>/dev/null on a bare read does not suppress the input-redirect open failure. It was previously invisible only because every existing test seeds a lock file; the new remote resolve site made it visible. The function's documented contract was already to fail silently, so this restores intended behavior rather than changing it.
- The new test was verified to genuinely catch the bug rather than pass vacuously: stashing the bin/ changes and re-running reproduces the untraced remote second mate ('an enabled remote spawn must record a valid carrier in the parent metadata (got \"\")'), and it passes with the fix.
- The new test is registered in the secondmate family in bin/fm-test-run.sh, matching its sibling remote lifecycle suite.

## What Changed

- Propagate per-task W3C trace context through remote Secondmate spawns, including strict carrier validation, frozen enablement delivery, endpoint read-back, and stable relaunch identity.
- Centralize local and remote inheritable-config allowlists, preserving session-scoped trace configuration during live convergence and silencing missing session-lock reads.
- Update trace-context documentation and add fake-SSH behavioral coverage for delivery, task isolation, relaunch stability, allowlist enforcement, and invalid carriers.

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>
</details>
<details>
<summary>✅ **Rebase** - passed</summary>
</details>
<details>
<summary>✅ **Review** - completed</summary>
</details>
<details>
<summary>✅ **Test** - passed</summary>
</details>
<details>
<summary>✅ **Document** - passed</summary>
</details>
<details>
<summary>✅ **Lint** - passed</summary>
</details>
<details>
<summary>✅ **Push** - passed</summary>
</details>
