### PR TITLE
fix(bin): keep fleet snapshots reliable at scale

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -350,8 +350,8 @@ jobs:
           snapshot_output=$(/bin/bash tests/fm-fleet-snapshot-view.test.sh)
           printf '%s\n' "$snapshot_output"
           snapshot_count=$(printf '%s\n' "$snapshot_output" | grep -c '^ok - ')
-          [ "$snapshot_count" -eq 15 ] || {
-            echo "::error::expected 15 snapshot/fleet-view tests, got $snapshot_count"
+          [ "$snapshot_count" -eq 20 ] || {
+            echo "::error::expected 20 snapshot/fleet-view tests, got $snapshot_count"
             exit 1
           }
 

--- a/bin/fm-fleet-snapshot.sh
+++ b/bin/fm-fleet-snapshot.sh
@@ -53,6 +53,14 @@
 #     unreadable, and retain independently trustworthy structured surfaces.
 #   secondmate_guidance: return-channel action note for renderers and bearings.
 #
+# Failure contract: a snapshot that cannot be built completely exits nonzero
+# with a diagnostic on stderr and prints no partial document, so a caller that
+# branches on exit status can trust success.
+# An empty fleet is a valid observation, not a failure, and still exits 0.
+# Bulk JSON therefore travels between jq stages on stdin rather than in argv:
+# see json_inputs below for why an --argjson command-line argument cannot carry
+# a whole backlog or task inventory.
+#
 # Compatibility: JSON is the primary machine-readable surface.
 # Human views must render this output instead of parsing state files again.
 set -u
@@ -176,6 +184,20 @@ command -v jq >/dev/null 2>&1 || { echo "fm-fleet-snapshot: jq not found" >&2; e
 
 bool_json() {
   if [ "$1" = 1 ]; then printf 'true'; else printf 'false'; fi
+}
+
+# Bulk JSON must never travel in argv. Linux caps one argv entry at
+# MAX_ARG_STRLEN (131072 bytes) independently of the far larger ARG_MAX total,
+# so --argjson carrying a whole backlog, task inventory, or cross-home roll-up
+# fails with "Argument list too long" once the fleet grows.
+# Stream those values on stdin instead and bind them positionally with `input`,
+# which also aborts jq when a value is missing rather than binding null.
+# Only values with a fixed small shape stay on --arg/--argjson.
+json_inputs() {  # <json>... - emit values for positional `input` binding
+  local value
+  for value in "$@"; do
+    printf '%s\n' "$value"
+  done
 }
 
 path_present_json() {  # <path>
@@ -402,7 +424,7 @@ task_json_lines() {
   local remote_host remote_root remote_state remote_rc remote_home_present
   local pr pr_source event_json current_json endpoint_exists agent_alive meta_json status_json report_json worktree_json home_json
   local last_event_raw current_state current_source pending_decision blocked_event report_present=0 pr_from_status
-  local open_decisions_tsv open_decisions_json
+  local open_decisions_tsv open_decisions_json row rows=''
 
   for meta in "$STATE"/*.meta; do
     [ -e "$meta" ] || continue
@@ -525,7 +547,10 @@ task_json_lines() {
       home_json=$(jq -n '{path:null,present:false}')
     fi
 
-    jq -n \
+    # A dropped row would silently shrink the live fleet inventory, so a failed
+    # row build aborts the whole snapshot instead of being absorbed by the
+    # collecting sort below.
+    row=$(json_inputs "$open_decisions_json" | jq -n \
       --arg id "$id" \
       --arg kind "$kind" \
       --arg harness "$harness" \
@@ -551,11 +576,11 @@ task_json_lines() {
       --argjson worktree_path "$worktree_json" \
       --argjson home_path "$home_json" \
       --argjson endpoint_exists "$endpoint_exists" \
-      --argjson open_decisions "$open_decisions_json" \
       --argjson pending_decision "$(bool_json "$pending_decision")" \
       --argjson blocked_event "$(bool_json "$blocked_event")" \
       --argjson report_present "$(bool_json "$report_present")" \
-      '{
+      '(input) as $open_decisions
+      | {
         id:$id,
         kind:$kind,
         harness:($harness // ""),
@@ -596,8 +621,13 @@ task_json_lines() {
              steer:"bin/fm-send.sh fm-\($id) \u0027<instruction>\u0027",
              return_channel_note:null}
           end)
-      }'
-  done | jq -s 'sort_by(.id)'
+      }') || {
+      printf 'fm-fleet-snapshot: task row build failed for %s\n' "$id" >&2
+      return 1
+    }
+    rows="$rows$row"$'\n'
+  done
+  printf '%s' "$rows" | jq -s 'sort_by(.id)'
 }
 
 # Main-home current-inventory validity: same orphan / unstructured-current checks
@@ -605,10 +635,10 @@ task_json_lines() {
 # Meta inventory remains the sole source of live workers; this object only
 # discloses backlog↔task inconsistency for renderers (Bearings omitted/gates).
 main_inventory_json() {  # <backlog-json> <tasks-json>
-  jq -n \
-    --argjson backlog "$1" \
-    --argjson tasks "$2" '
-    ([ $backlog.records[]?
+  json_inputs "$1" "$2" | jq -n '
+    (input) as $backlog
+    | (input) as $tasks
+    | ([ $backlog.records[]?
        | select((.state == "in_flight" or .state == "queued") and (.structured | not)) ]) as $unstructured_current
     | ([ $backlog.records[]?
          | select(.state == "in_flight" and .structured and .requires_child_metadata) ]) as $owned_in_flight
@@ -633,19 +663,19 @@ main_inventory_json() {  # <backlog-json> <tasks-json>
 # This mode never reads parent events or terminal text and never aggregates
 # nested secondmates.
 secondmate_home_summary_json() {  # <backlog-json> <tasks-json>
-  jq -n \
+  json_inputs "$1" "$2" | jq -n \
     --arg generated "$SNAPSHOT_NOW" \
     --arg home "$FM_HOME" \
     --argjson child_n "$FM_SNAPSHOT_SECONDMATE_CHILDREN" \
     --argjson queued_n "$FM_SNAPSHOT_SECONDMATE_QUEUED" \
     --argjson decisions_n "$FM_SNAPSHOT_SECONDMATE_DECISIONS" \
-    --argjson landed_n "$FM_SNAPSHOT_SECONDMATE_LANDED_PER_HOME" \
-    --argjson backlog "$1" \
-    --argjson tasks "$2" '
+    --argjson landed_n "$FM_SNAPSHOT_SECONDMATE_LANDED_PER_HOME" '
     def trunc($n):
       tostring | gsub("\\s+"; " ")
       | if length > $n then .[:$n] + "…" else . end;
-    ([ $backlog.records[]?
+    (input) as $backlog
+    | (input) as $tasks
+    | ([ $backlog.records[]?
        | select((.state == "in_flight" or .state == "queued") and (.structured | not)) ]) as $unstructured_current
     | ([ $backlog.records[]? | select(.state == "in_flight" and .structured) ]) as $owned_in_flight
     | ([ $backlog.records[]?
@@ -1062,7 +1092,7 @@ terminal_evidence_json() {  # <parent-task-json> <event-note> <evidence-contradi
 }
 
 parent_evidence_reconciliation_json() {  # <summary-json> <activities-json> <decisions-json>
-  jq -n --argjson summary "$1" --argjson activities "$2" --argjson decisions "$3" '
+  json_inputs "$1" "$2" "$3" | jq -n '
     def keyed: . != null and . != "" and . != "default";
     def result($e; $matches; $complete; $surface):
       $e + {
@@ -1073,7 +1103,10 @@ parent_evidence_reconciliation_json() {  # <summary-json> <activities-json> <dec
         compared_to:$surface,
         matched:(if ($e.key | keyed) then ($matches[0] // null) else null end)
       };
-    ([ $activities[] as $e
+    (input) as $summary
+    | (input) as $activities
+    | (input) as $decisions
+    | ([ $activities[] as $e
        | if $e.verb == "working" then
            ([ $summary.active_children[]
               | select(if ($e.key | keyed) then .id == $e.key else true end)
@@ -1127,8 +1160,10 @@ secondmate_current_json() {  # <parent-tasks-json>
   local activity_scan activities decisions reconciliation provenance freshness reason summary summary_rc summary_bytes summary_valid summary_reason summary_invalidity state current_reason terminal terminal_contradiction contradiction
   local records='[]' seen_homes=''
   registry=$(registry_secondmates_json) || return 1
-  union=$(jq -n --argjson registry "$registry" --argjson tasks "$tasks" '
-    ($registry.records // []) as $registered
+  union=$(json_inputs "$registry" "$tasks" | jq -n '
+    (input) as $registry
+    | (input) as $tasks
+    | ($registry.records // []) as $registered
     | (($registered | map(.id)) // []) as $registered_ids
     | ([ $registered[] as $r
          | $r + {parent_task:([$tasks[] | select(.id == $r.id)][0] // null)} ]
@@ -1266,13 +1301,18 @@ secondmate_current_json() {  # <parent-tasks-json>
           '{provenance:"parent-direct-report-terminal",trust:"untrusted-supplement",captured:false,observed_at:$observed,freshness:"not-collected",reason:"no useful contradiction check",lines:0,bytes:0,event_note_seen:false,contradiction:false}')
       fi
       if printf '%s' "$terminal" | jq -e '.contradiction == true' >/dev/null; then contradiction=true; fi
-      record=$(jq -n \
+      record=$(json_inputs "$summary" "$decisions" "$activities" "$activity_scan" "$reconciliation" "$terminal" | jq -n \
         --arg id "$id" --arg home "$home" --arg host "$host" --argjson remote "$remote" --arg state "$state" --arg current_reason "$current_reason" --arg observed "$SNAPSHOT_NOW" \
-        --argjson registered "$registered" --argjson summary "$summary" --argjson summary_valid "$summary_valid" --argjson decisions "$decisions" \
-        --argjson activities "$activities" --argjson activity_scan "$activity_scan" \
-        --argjson reconciliation "$reconciliation" --argjson terminal "$terminal" --argjson contradiction "$contradiction" \
+        --argjson registered "$registered" --argjson summary_valid "$summary_valid" \
+        --argjson contradiction "$contradiction" \
         --arg event_raw "$event_raw" --arg event_note "$event_note" --argjson event_age "$event_age" '
-        {id:$id,home:$home,host:($host | if . == "" then null else . end),remote:$remote,registered:$registered,
+        (input) as $summary
+        | (input) as $decisions
+        | (input) as $activities
+        | (input) as $activity_scan
+        | (input) as $reconciliation
+        | (input) as $terminal
+        | {id:$id,home:$home,host:($host | if . == "" then null else . end),remote:$remote,registered:$registered,
          current:{state:$state,reason:($current_reason | if . == "" then null else . end)},invalidity:$summary.invalidity,
          provenance:{selected:"structured-home",structured_home:$home,summary_valid:$summary_valid,
            trust:(if $summary_valid then "complete" else "partial-structured" end),parent_event_role:"historical-only"},
@@ -1281,7 +1321,8 @@ secondmate_current_json() {  # <parent-tasks-json>
          decisions_open:$summary.decisions_open,holds:$summary.holds,queued:$summary.queued,
          landed:$summary.landed,endpoints:$summary.endpoints,counts:$summary.counts,omitted:$summary.omitted,
          parent_event:{raw:$event_raw,note:$event_note,age_seconds:$event_age,open_activities:$activities,open_decisions:$decisions,activity_scan:$activity_scan,reconciliation:$reconciliation},
-         terminal_evidence:$terminal,contradiction:$contradiction}')
+         terminal_evidence:$terminal,contradiction:$contradiction}') \
+        || { printf 'fm-fleet-snapshot: secondmate record build failed for %s\n' "$id" >&2; return 1; }
     else
       if [ -n "$event_raw" ]; then
         provenance='parent-event-fallback'
@@ -1296,36 +1337,42 @@ secondmate_current_json() {  # <parent-tasks-json>
         terminal=$(jq -n --arg observed "$SNAPSHOT_NOW" \
           '{provenance:"parent-direct-report-terminal",trust:"untrusted-supplement",captured:false,observed_at:$observed,freshness:"not-collected",reason:"no parent event to compare",lines:0,bytes:0,event_note_seen:false,contradiction:false}')
       fi
-      record=$(jq -n \
+      record=$(json_inputs "$activities" "$activity_scan" "$decisions" "$terminal" | jq -n \
         --arg id "$id" --arg home "$home" --arg host "$host" --argjson remote "$remote" --arg reason "$reason" --arg observed "$SNAPSHOT_NOW" \
         --arg provenance "$provenance" --arg freshness "$freshness" --arg event_raw "$event_raw" --arg event_note "$event_note" \
-        --argjson registered "$registered" --argjson event_age "$event_age" --argjson activities "$activities" --argjson activity_scan "$activity_scan" \
-        --argjson decisions "$decisions" --argjson terminal "$terminal" '
-        {id:$id,home:($home | if . == "" then null else . end),host:($host | if . == "" then null else . end),remote:$remote,registered:$registered,
+        --argjson registered "$registered" --argjson event_age "$event_age" '
+        (input) as $activities
+        | (input) as $activity_scan
+        | (input) as $decisions
+        | (input) as $terminal
+        | {id:$id,home:($home | if . == "" then null else . end),host:($host | if . == "" then null else . end),remote:$remote,registered:$registered,
          current:{state:"unknown",reason:$reason},invalidity:null,
          provenance:{selected:$provenance,structured_home:($home | if . == "" then null else . end),parent_event_role:"fallback-only-not-current"},
          freshness:{status:$freshness,observed_at:$observed,age_seconds:$event_age},
          active_children:[],decisions_open:[],holds:[],queued:[],landed:[],endpoints:[],counts:{active_children:0,decisions_open:0,holds:0,queued:0,landed:0,endpoints:0},omitted:[],
          parent_event:{raw:$event_raw,note:$event_note,age_seconds:$event_age,open_activities:$activities,open_decisions:$decisions,activity_scan:$activity_scan},
-         terminal_evidence:$terminal,contradiction:false}')
+         terminal_evidence:$terminal,contradiction:false}') \
+        || { printf 'fm-fleet-snapshot: secondmate record build failed for %s\n' "$id" >&2; return 1; }
     fi
-    records=$(jq -n --argjson records "$records" --argjson record "$record" '$records + [$record]')
+    records=$(json_inputs "$records" "$record" | jq -n '(input) as $records | (input) as $record | $records + [$record]') \
+      || { printf 'fm-fleet-snapshot: secondmate record accumulation failed at %s\n' "$id" >&2; return 1; }
   done <<EOF
 $rows
 EOF
-  jq -n \
-    --argjson registry "$(printf '%s' "$union" | jq '.registry')" \
-    --argjson records "$records" \
+  json_inputs "$(printf '%s' "$union" | jq '.registry')" "$records" | jq -n \
     --argjson total_registered "$total_registered" \
     --argjson total "$total" \
     --argjson shown "$shown" \
     --argjson truncated "$truncated" \
-    '{registry:$registry,records:$records,total_registered:$total_registered,total:$total,shown:$shown,truncated:$truncated}'
+    '(input) as $registry
+     | (input) as $records
+     | {registry:$registry,records:$records,total_registered:$total_registered,total:$total,shown:$shown,truncated:$truncated}'
 }
 
 secondmate_landed_from_current_json() {  # <secondmate-current-json>
-  jq -n --argjson current "$1" '
-    {records:[ $current.records[]
+  json_inputs "$1" | jq -n '
+    (input) as $current
+    | {records:[ $current.records[]
       | select(.provenance.selected == "structured-home") as $mate
       | $mate.landed[]
       | . + {home:$mate.home,home_id:$mate.id}],
@@ -1342,18 +1389,27 @@ secondmate_landed_from_current_json() {  # <secondmate-current-json>
 }
 
 scout_report_lines() {
-  local report id
+  local report id row rows='' reports
   if [ ! -d "$DATA" ]; then
     jq -n '[]'
     return 0
   fi
-  LC_ALL=C find "$DATA" -mindepth 2 -maxdepth 2 -type f -name report.md -print \
-    | sort \
-    | while IFS= read -r report; do
-      id=$(basename "$(dirname "$report")")
-      jq -n --arg id "$id" --arg path "$report" '{id:$id,path:$path}'
-    done \
-    | jq -s 'sort_by(.id)'
+  # Capture before sorting so the scan's own exit status is not masked by sort.
+  reports=$(LC_ALL=C find "$DATA" -mindepth 2 -maxdepth 2 -type f -name report.md -print) \
+    || { echo "fm-fleet-snapshot: scout report scan failed" >&2; return 1; }
+  reports=$(printf '%s' "$reports" | sort)
+  while IFS= read -r report; do
+    [ -n "$report" ] || continue
+    id=$(basename "$(dirname "$report")")
+    # As with task rows, a dropped pointer would silently shrink the reported
+    # deliverables, so a failed row aborts rather than being absorbed.
+    row=$(jq -n --arg id "$id" --arg path "$report" '{id:$id,path:$path}') \
+      || { printf 'fm-fleet-snapshot: scout report row failed for %s\n' "$id" >&2; return 1; }
+    rows="$rows$row"$'\n'
+  done <<EOF
+$reports
+EOF
+  printf '%s' "$rows" | jq -s 'sort_by(.id)'
 }
 
 BACKLOG_JSON=$(backlog_json) || { echo "fm-fleet-snapshot: backlog read failed" >&2; exit 1; }
@@ -1365,7 +1421,8 @@ if [ "$OUTPUT_MODE" = secondmate-home-summary ]; then
   exit 0
 fi
 
-SCOUT_REPORTS_JSON=$(scout_report_lines)
+SCOUT_REPORTS_JSON=$(scout_report_lines) \
+  || { echo "fm-fleet-snapshot: scout report scan failed" >&2; exit 1; }
 MAIN_INVENTORY_JSON=$(main_inventory_json "$BACKLOG_JSON" "$TASKS_JSON") \
   || { echo "fm-fleet-snapshot: main inventory summary failed" >&2; exit 1; }
 SECONDMATE_CURRENT_JSON=$(secondmate_current_json "$TASKS_JSON") \
@@ -1373,7 +1430,8 @@ SECONDMATE_CURRENT_JSON=$(secondmate_current_json "$TASKS_JSON") \
 SECONDMATE_LANDED_JSON=$(secondmate_landed_from_current_json "$SECONDMATE_CURRENT_JSON") \
   || { echo "fm-fleet-snapshot: secondmate landed projection failed" >&2; exit 1; }
 
-jq -n \
+json_inputs "$BACKLOG_JSON" "$TASKS_JSON" "$MAIN_INVENTORY_JSON" "$SCOUT_REPORTS_JSON" \
+  "$SECONDMATE_CURRENT_JSON" "$SECONDMATE_LANDED_JSON" | jq -n \
   --arg generated "$SNAPSHOT_NOW" \
   --arg fm_home "$FM_HOME" \
   --arg fm_root "$FM_ROOT" \
@@ -1381,15 +1439,15 @@ jq -n \
   --arg data "$DATA" \
   --arg config "$CONFIG" \
   --arg projects "$PROJECTS" \
-  --argjson backlog "$BACKLOG_JSON" \
-  --argjson tasks "$TASKS_JSON" \
-  --argjson main_inventory "$MAIN_INVENTORY_JSON" \
-  --argjson scout_reports "$SCOUT_REPORTS_JSON" \
-  --argjson secondmate_current "$SECONDMATE_CURRENT_JSON" \
-  --argjson secondmate_landed "$SECONDMATE_LANDED_JSON" \
-  'def backlog_by_id($id): ($backlog.records[]? | select(.structured == true and .id == $id) | .) // null;
-   def task_by_id($id): ($tasks[]? | select(.id == $id) | .) // null;
-   def report_kind($id): (task_by_id($id).kind // backlog_by_id($id).kind // "scout");
+  '(input) as $backlog
+   | (input) as $tasks
+   | (input) as $main_inventory
+   | (input) as $scout_reports
+   | (input) as $secondmate_current
+   | (input) as $secondmate_landed
+   | def backlog_by_id($id): ($backlog.records[]? | select(.structured == true and .id == $id) | .) // null;
+     def task_by_id($id): ($tasks[]? | select(.id == $id) | .) // null;
+     def report_kind($id): (task_by_id($id).kind // backlog_by_id($id).kind // "scout");
    {
      schema:"fm-fleet-snapshot.v1",
      generated:$generated,

--- a/bin/fm-fleet-snapshot.sh
+++ b/bin/fm-fleet-snapshot.sh
@@ -1397,7 +1397,8 @@ scout_report_lines() {
   # Capture before sorting so the scan's own exit status is not masked by sort.
   reports=$(LC_ALL=C find "$DATA" -mindepth 2 -maxdepth 2 -type f -name report.md -print) \
     || { echo "fm-fleet-snapshot: scout report scan failed" >&2; return 1; }
-  reports=$(printf '%s' "$reports" | sort)
+  reports=$(printf '%s' "$reports" | sort) \
+    || { echo "fm-fleet-snapshot: scout report scan failed" >&2; return 1; }
   while IFS= read -r report; do
     [ -n "$report" ] || continue
     id=$(basename "$(dirname "$report")")

--- a/tests/fm-fleet-snapshot-view.test.sh
+++ b/tests/fm-fleet-snapshot-view.test.sh
@@ -779,6 +779,145 @@ test_parked_scout_decision_stays_pending() {
   pass "a scout still parked at a decision stays pending (terminal clear does not over-fire)"
 }
 
+# --- oversized-input regressions -------------------------------------------
+#
+# Linux caps a single argv entry at MAX_ARG_STRLEN (131072 bytes) regardless of
+# the far larger ARG_MAX total, so bulk JSON passed to jq as a command-line
+# argument aborts with "Argument list too long" once the fleet grows. Two
+# distinct failures followed: an oversized backlog killed the snapshot outright,
+# and an oversized per-task decision set silently dropped that task from the
+# live inventory while the snapshot still exited 0.
+#
+# Fixtures are generated here rather than copied from any real backlog.
+FM_ARGV_STRLEN_CAP=131072
+
+write_oversized_backlog() {  # <home> <record-count>
+  local home=$1 count=$2 i hold
+  # A long captain-hold reason per record, mirroring the shape real holds take.
+  hold="captain must choose between the narrow repair and the broader refactor "
+  hold="$hold$hold$hold$hold$hold$hold$hold$hold"
+  {
+    printf '## In flight\n\n## Queued\n'
+    i=0
+    while [ "$i" -lt "$count" ]; do
+      printf -- '- [ ] bulk-%03d - Bulk record %d (repo: alpha) (kind: ship) (hold: %s) (hold-kind: captain)\n' \
+        "$i" "$i" "$hold"
+      i=$((i + 1))
+    done
+    printf '\n## Done\n'
+  } > "$home/data/backlog.md"
+}
+
+test_oversized_backlog_renders_instead_of_dying() {
+  local home fakebin out rc backlog_bytes view view_rc
+  home=$(make_home oversized-backlog)
+  write_oversized_backlog "$home" 80
+  fakebin=$(make_fakebin "$home")
+  out=$(PATH="$fakebin:$PATH" FM_HOME="$home" "$SNAPSHOT" --json 2>/dev/null)
+  rc=$?
+  expect_code 0 "$rc" "oversized backlog must not abort the snapshot"
+  # Prove the fixture actually exercises the cap, so this test cannot quietly
+  # stop covering the defect if record sizes drift.
+  backlog_bytes=$(printf '%s' "$out" | jq -r '.backlog | tojson | length')
+  [ "$backlog_bytes" -gt "$FM_ARGV_STRLEN_CAP" ] \
+    || fail "fixture backlog JSON is $backlog_bytes bytes, under the $FM_ARGV_STRLEN_CAP argv cap it must exceed"
+  printf '%s' "$out" | jq -e '
+    .schema == "fm-fleet-snapshot.v1"
+      and ([.backlog.records[] | select(.structured)] | length) == 80
+      and .main_inventory.valid == true
+  ' >/dev/null || fail "oversized backlog produced no usable snapshot: $(printf '%s' "$out" | head -c 400)"
+  view=$(PATH="$fakebin:$PATH" FM_HOME="$home" "$VIEW" 2>/dev/null)
+  view_rc=$?
+  expect_code 0 "$view_rc" "oversized backlog must not abort the fleet view"
+  assert_contains "$view" "bulk-079" "fleet view must render rows from an oversized backlog"
+  pass "an oversized backlog still renders through the snapshot and the view"
+}
+
+test_oversized_task_decisions_keep_the_task_visible() {
+  local home fakebin out rc summary i
+  home=$(make_home oversized-decisions)
+  mkdir -p "$home/projects/wt"
+  printf '## In flight\n\n## Queued\n\n## Done\n' > "$home/data/backlog.md"
+  for i in quiet-task loud-task; do
+    fm_write_meta "$home/state/$i.meta" \
+      "window=firstmate:fm-$i" \
+      "worktree=$home/projects/wt" \
+      "project=alpha" \
+      "harness=claude" \
+      "kind=ship" \
+      "mode=ship"
+  done
+  printf 'working: nothing unusual\n' > "$home/state/quiet-task.status"
+  # A long-lived task parked at a gate keeps its whole keyed decision set open,
+  # which is what grows past the argv cap.
+  record_claude_idle "$home/state" quiet-task
+  record_claude_idle "$home/state" loud-task
+  summary="captain must choose between the narrow repair and the broader refactor "
+  summary="$summary$summary$summary$summary$summary$summary"
+  i=0
+  while [ "$i" -lt 400 ]; do
+    printf 'needs-decision [key=k%04d]: %s\n' "$i" "$summary" >> "$home/state/loud-task.status"
+    i=$((i + 1))
+  done
+  fakebin=$(make_fakebin "$home")
+  out=$(PATH="$fakebin:$PATH" FM_HOME="$home" "$SNAPSHOT" --json 2>/dev/null)
+  rc=$?
+  expect_code 0 "$rc" "an oversized decision set must not abort the snapshot"
+  # The defect: loud-task vanished from the inventory while the snapshot still
+  # reported success, so supervision reviewed a fleet that was missing a worker.
+  printf '%s' "$out" | jq -e '[.tasks[].id] == ["loud-task","quiet-task"]' >/dev/null \
+    || fail "a task with an oversized decision set was dropped from the inventory: $(printf '%s' "$out" | jq -c '[.tasks[].id]')"
+  printf '%s' "$out" | jq -e '
+    .tasks[] | select(.id == "loud-task")
+    | (.hints.open_decisions | length) == 400 and .hints.pending_decision == true
+  ' >/dev/null || fail "the oversized decision set was not preserved for loud-task"
+  pass "a task with an oversized decision set stays in the inventory"
+}
+
+test_snapshot_failure_exits_nonzero_with_diagnostic() {
+  local home fakebin out rc err view_rc view_out
+  home=$(make_home snapshot-failure)
+  write_fixture "$home"
+  fakebin=$(make_fakebin "$home")
+  # A genuine total failure of the JSON engine the snapshot depends on. It must
+  # surface as a nonzero exit with a diagnostic, never as silent empty output.
+  cat > "$fakebin/jq" <<'SH'
+#!/usr/bin/env bash
+echo "jq: simulated failure" >&2
+exit 1
+SH
+  chmod +x "$fakebin/jq"
+  err="$home/snapshot.err"
+  out=$(PATH="$fakebin:$PATH" FM_HOME="$home" "$SNAPSHOT" --json 2>"$err")
+  rc=$?
+  [ "$rc" -ne 0 ] || fail "a failed snapshot must not exit 0 (stdout was: '$out')"
+  [ -z "$out" ] || fail "a failed snapshot must not emit a partial document: $out"
+  assert_contains "$(cat "$err")" "fm-fleet-snapshot:" "a failed snapshot must say what failed"
+  view_out=$(PATH="$fakebin:$PATH" FM_HOME="$home" "$VIEW" 2>/dev/null)
+  view_rc=$?
+  [ "$view_rc" -ne 0 ] || fail "the fleet view must not exit 0 when its snapshot failed"
+  [ -z "$view_out" ] || fail "a failed fleet view must not emit a partial render: $view_out"
+  pass "a genuine snapshot failure exits nonzero, says what failed, and emits nothing"
+}
+
+test_empty_fleet_is_success_not_failure() {
+  local home out rc view view_rc
+  home=$(make_home empty-success)
+  out=$(FM_HOME="$home" "$SNAPSHOT" --json 2>/dev/null)
+  rc=$?
+  # An empty fleet is a valid observation and must stay distinguishable from the
+  # failure case above, which exits nonzero and prints nothing.
+  expect_code 0 "$rc" "an empty-but-valid fleet must exit 0"
+  printf '%s' "$out" | jq -e '
+    .schema == "fm-fleet-snapshot.v1" and (.tasks | length) == 0 and .main_inventory.valid == true
+  ' >/dev/null || fail "an empty fleet must still produce a valid snapshot document: $out"
+  view=$(FM_HOME="$home" "$VIEW" 2>/dev/null)
+  view_rc=$?
+  expect_code 0 "$view_rc" "an empty-but-valid fleet view must exit 0"
+  assert_contains "$view" "No live task metadata found." "an empty fleet view must state the absence explicitly"
+  pass "an empty-but-valid fleet exits 0 and is not confused with a failed snapshot"
+}
+
 test_empty_fleet_json
 test_fixture_snapshot_json
 test_main_inventory_orphan_and_unstructured_disclosure
@@ -794,3 +933,7 @@ test_scout_reports_include_teardown_reports
 test_backlog_tasks_axi_forms_and_overrides
 test_view_renders_snapshot
 test_view_renders_dead_secondmate_agent_status
+test_oversized_backlog_renders_instead_of_dying
+test_oversized_task_decisions_keep_the_task_visible
+test_snapshot_failure_exits_nonzero_with_diagnostic
+test_empty_fleet_is_success_not_failure

--- a/tests/fm-fleet-snapshot-view.test.sh
+++ b/tests/fm-fleet-snapshot-view.test.sh
@@ -900,6 +900,33 @@ SH
   pass "a genuine snapshot failure exits nonzero, says what failed, and emits nothing"
 }
 
+test_scout_report_sort_failure_exits_nonzero() {
+  local home fakebin out rc err real_sort
+  home=$(make_home scout-sort-failure)
+  mkdir -p "$home/data/reported-scout"
+  printf '# Reported Scout\n' > "$home/data/reported-scout/report.md"
+  fakebin=$(make_fakebin "$home")
+  real_sort=$(command -v sort)
+  cat > "$fakebin/sort" <<SH
+#!/usr/bin/env bash
+set -u
+input=\$(cat)
+case "\$input" in
+  *"/data/reported-scout/report.md"*) exit 1 ;;
+esac
+printf '%s' "\$input" | "$real_sort" "\$@"
+SH
+  chmod +x "$fakebin/sort"
+  err="$home/snapshot.err"
+  out=$(PATH="$fakebin:$PATH" FM_HOME="$home" "$SNAPSHOT" --json 2>"$err")
+  rc=$?
+  [ "$rc" -ne 0 ] || fail "a scout report sort failure must not exit 0"
+  [ -z "$out" ] || fail "a scout report sort failure must not emit a partial document: $out"
+  assert_contains "$(cat "$err")" "fm-fleet-snapshot: scout report scan failed" \
+    "a scout report sort failure must identify the failed scan"
+  pass "a scout report sort failure aborts the snapshot"
+}
+
 test_empty_fleet_is_success_not_failure() {
   local home out rc view view_rc
   home=$(make_home empty-success)
@@ -936,4 +963,5 @@ test_view_renders_dead_secondmate_agent_status
 test_oversized_backlog_renders_instead_of_dying
 test_oversized_task_decisions_keep_the_task_visible
 test_snapshot_failure_exits_nonzero_with_diagnostic
+test_scout_report_sort_failure_exits_nonzero
 test_empty_fleet_is_success_not_failure


### PR DESCRIPTION
## Intent

Fix the structured fleet view (bin/fm-fleet-snapshot.sh and bin/fm-fleet-view.sh), which fails silently and completely once the backlog grows past a size the fleet has already reached. This is a defect repair, not a feature change: do not redesign the fleet view's output format and do not change what it reports.

DEFECT 1, the size limit. main_inventory_json() passed the entire backlog JSON and the entire tasks JSON to jq as --argjson COMMAND-LINE arguments. Linux caps any single argv entry at MAX_ARG_STRLEN = 131072 bytes, independent of the much larger ARG_MAX total (2097152 here, which is why a total-size intuition misleads). data/backlog.md is already ~96-104KB of markdown and its JSON expansion exceeds the per-argument cap at the current backlog size, several records carrying long captain-hold reasons. The cure was to stop putting bulk data in argv. The user asked me to choose deliberately between stdin, process substitution, and a temp file, and to say why. I chose stdin: values are emitted by a small json_inputs helper and bound positionally in the jq filter with `input`. Rationale, which a reviewer reading only the diff would not know: temp files would need mktemp plus cleanup traps that fire correctly inside the command-substitution subshells this script uses throughout; process substitution adds a /dev/fd dependency and cannot be built dynamically from a variable-length list; and stdin binding additionally makes a MISSING value abort jq (exit 5, "break") rather than silently binding null, so the mechanism is fail-closed by construction, which is the whole point of the second defect.

The user explicitly asked me to audit the WHOLE file rather than patch only the reported line 567. I did, and the same latent failure was present in five further places, all fixed in this change: secondmate_home_summary_json (confirmed independently dying at line 595), the cross-home union in secondmate_current_json, both per-secondmate record builders and the records accumulation, parent_evidence_reconciliation_json, secondmate_landed_from_current_json, and the final document assembly, which carried the whole backlog through argv a SECOND time. Deliberate decision: values with a fixed small shape (booleans, integers, single-path presence objects, single-line status/crew-state objects) intentionally stay on --arg/--argjson, because they cannot grow with the backlog, the fleet, or a status history. That asymmetry is intentional and documented in the json_inputs comment, not an oversight.

DEFECT 2, the fail-open, which the user identified as the serious one and the defect class this fleet cares most about: a check that reports success while establishing nothing. AGENTS.md section 8 directs heartbeat handling to review the fleet from this structured view, so fleet supervision silently degrades as the fleet and backlog grow, without any signal that it has.

Important correction the reviewer should know: the originally reported measurement showed exit status 0, but that reading was confounded, because `echo $?` there followed a pipe to `wc -l` and so reported wc's status. The snapshot does exit 1 on the oversized-backlog path. However a genuine fail-open does exist in the same script and I found and fixed it: a per-task row that failed to build was absorbed by the collecting `| jq -s`, so a LIVE WORKER silently vanished from the fleet inventory while the snapshot still exited 0. Reproduced directly: snapshot rc=0 with stderr "line 490: jq: Argument list too long" and task ids ["small-task"] where big-task had disappeared. Task rows and scout report pointers now abort the snapshot with a diagnostic instead of quietly shrinking the reported fleet, the previously unguarded scout report scan is now checked, and the find scan is captured before sorting so its exit status is not masked by the pipe. An empty fleet remains a valid observation that exits 0, so absence stays distinguishable from failure. A failure contract paragraph was added to the script header, which is the owner tier for this kind of mechanics per the repo's firstmate-coding-guidelines.

VERIFICATION DISCIPLINE, which the user made non-optional because the defect is precisely a false success. Proving the fix by "it stopped printing an error" was explicitly not acceptable. I witnessed the negative control fail first: both new oversized-input tests were run against the CURRENT UNFIXED code and confirmed RED before the fix was applied. test_oversized_backlog_renders_instead_of_dying failed with "expected exit 0, got 1", and test_oversized_task_decisions_keep_the_task_visible failed with "a task with an oversized decision set was dropped from the inventory: [quiet-task]". The other two new tests (the nonzero-exit-with-diagnostic contract and the empty-fleet-is-not-failure contract) are green both before and after by design; they are contract locks required by the definition of done, not proof of the fix, and that distinction was stated plainly rather than glossed. The oversized backlog fixture is generated programmatically inside the test, deliberately NOT copied from the captain's real backlog, and the test asserts the generated backlog's JSON expansion actually exceeds the 131072-byte cap so it cannot quietly stop covering the defect if record sizes drift.

DEFINITION OF DONE: the fleet view renders correctly against the current real backlog (verified at 87 structured records / ~104KB via a scratch copy, grown from the 76 cited when the task was written); a genuine snapshot failure exits nonzero and says what failed; an empty-but-valid fleet still exits 0 and is not confused with failure; and a regression test drives the snapshot with a backlog large enough to exceed the per-argument cap and asserts BOTH that real output is produced AND that a genuine failure surfaces as a nonzero exit.

REPO CONSTRAINTS accepted: this is firstmate's shared tracked material, so the firstmate-coding-guidelines skill was loaded and followed - one sentence per line in tracked markdown, plain dash never an em dash, no agent name as a commit co-author, shellcheck-clean bin scripts via the pinned bin/fm-lint.sh, tests colocated by extending the existing tests/fm-fleet-snapshot-view.test.sh rather than inventing a new runner, and tests that exercise behavior through an executable interface rather than asserting implementation-source bytes.

BASE CONSTRAINT accepted, and deliberate: this worktree sits on upstream trunk 4ee4a0a while the fleet actually runs fork trunk 631c248, 33 commits ahead. The user directed that code being WRITTEN must keep the upstream base, because upstream contribution branches must be cut from upstream trunk or they silently carry unlanded fork work into the contribution. I verified that all three files in scope are byte-identical between 4ee4a0a and 631c248, so the divergence does not touch this task's surface. Do not flag the base as stale.

Verification run: 19/19 tests in tests/fm-fleet-snapshot-view.test.sh pass (15 pre-existing plus 4 new, no regression), tests/fm-bearings-snapshot.test.sh passes as the primary downstream consumer of this snapshot contract, plus fm-secondmate-safety (70 ok), fm-secondmate-liveness (15 ok) and fm-decision-hold-lifecycle (9 ok); bin/fm-lint.sh and bin/fm-doc-audience-check.sh are both clean.

## What Changed

- Stream growing backlog, task, and secondmate JSON through stdin so fleet snapshots and views continue working beyond Linux’s per-argument size limit.
- Fail closed with diagnostics when task rows, scout report scans or sorting, secondmate records, or final snapshot assembly cannot complete, while preserving successful empty-fleet snapshots.
- Add regression coverage for oversized backlogs and decision sets, snapshot and scout-sort failures, and valid empty fleets.

## Risk Assessment

✅ Low: The follow-up correctly propagates scout-report sort failures while preserving valid empty results, and the full change remains a well-bounded defect repair consistent with the stated output and failure contracts.

## Testing

After two initial runs exceeded the command tool’s 30-second observation window, the focused suite completed successfully in a persistent PTY; manual executable checks then demonstrated a 142,820-byte backlog rendering all 80 records with clean stderr, and confirmed the current empty fleet still returns a valid explicit view.

<details>
<summary>Evidence: Oversized backlog rendered fleet view</summary>

```text
# Fleet View

Schema: fm-fleet-snapshot.v1
Home: /tmp/no-mistakes-evidence/01KZ3T0KR5R3FCH3WGY9Z37217/oversized-backlog-home

## Under Way
No live task metadata found.

## Queued
| ID | Title | Repo | Kind | Blocked By | Artifact |
| --- | --- | --- | --- | --- | --- |
| bulk-000 | Bulk record 0 | alpha | ship | - | - |
| bulk-001 | Bulk record 1 | alpha | ship | - | - |
| bulk-002 | Bulk record 2 | alpha | ship | - | - |
| bulk-003 | Bulk record 3 | alpha | ship | - | - |
| bulk-004 | Bulk record 4 | alpha | ship | - | - |
| bulk-005 | Bulk record 5 | alpha | ship | - | - |
| bulk-006 | Bulk record 6 | alpha | ship | - | - |
| bulk-007 | Bulk record 7 | alpha | ship | - | - |
| bulk-008 | Bulk record 8 | alpha | ship | - | - |
| bulk-009 | Bulk record 9 | alpha | ship | - | - |
| bulk-010 | Bulk record 10 | alpha | ship | - | - |
| bulk-011 | Bulk record 11 | alpha | ship | - | - |
| bulk-012 | Bulk record 12 | alpha | ship | - | - |
| bulk-013 | Bulk record 13 | alpha | ship | - | - |
| bulk-014 | Bulk record 14 | alpha | ship | - | - |
| bulk-015 | Bulk record 15 | alpha | ship | - | - |
| bulk-016 | Bulk record 16 | alpha | ship | - | - |
| bulk-017 | Bulk record 17 | alpha | ship | - | - |
| bulk-018 | Bulk record 18 | alpha | ship | - | - |
| bulk-019 | Bulk record 19 | alpha | ship | - | - |
| bulk-020 | Bulk record 20 | alpha | ship | - | - |
| bulk-021 | Bulk record 21 | alpha | ship | - | - |
| bulk-022 | Bulk record 22 | alpha | ship | - | - |
| bulk-023 | Bulk record 23 | alpha | ship | - | - |
| bulk-024 | Bulk record 24 | alpha | ship | - | - |
| bulk-025 | Bulk record 25 | alpha | ship | - | - |
| bulk-026 | Bulk record 26 | alpha | ship | - | - |
| bulk-027 | Bulk record 27 | alpha | ship | - | - |
| bulk-028 | Bulk record 28 | alpha | ship | - | - |
| bulk-029 | Bulk record 29 | alpha | ship | - | - |
| bulk-030 | Bulk record 30 | alpha | ship | - | - |
| bulk-031 | Bulk record 31 | alpha | ship | - | - |
| bulk-032 | Bulk record 32 | alpha | ship | - | - |
| bulk-033 | Bulk record 33 | alpha | ship | - | - |
| bulk-034 | Bulk record 34 | alpha | ship | - | - |
| bulk-035 | Bulk record 35 | alpha | ship | - | - |
| bulk-036 | Bulk record 36 | alpha | ship | - | - |
| bulk-037 | Bulk record 37 | alpha | ship | - | - |
| bulk-038 | Bulk record 38 | alpha | ship | - | - |
| bulk-039 | Bulk record 39 | alpha | ship | - | - |
| bulk-040 | Bulk record 40 | alpha | ship | - | - |
| bulk-041 | Bulk record 41 | alpha | ship | - | - |
| bulk-042 | Bulk record 42 | alpha | ship | - | - |
| bulk-043 | Bulk record 43 | alpha | ship | - | - |
| bulk-044 | Bulk record 44 | alpha | ship | - | - |
| bulk-045 | Bulk record 45 | alpha | ship | - | - |
| bulk-046 | Bulk record 46 | alpha | ship | - | - |
| bulk-047 | Bulk record 47 | alpha | ship | - | - |
| bulk-048 | Bulk record 48 | alpha | ship | - | - |
| bulk-049 | Bulk record 49 | alpha | ship | - | - |
| bulk-050 | Bulk record 50 | alpha | ship | - | - |
| bulk-051 | Bulk record 51 | alpha | ship | - | - |
| bulk-052 | Bulk record 52 | alpha | ship | - | - |
| bulk-053 | Bulk record 53 | alpha | ship | - | - |
| bulk-054 | Bulk record 54 | alpha | ship | - | - |
| bulk-055 | Bulk record 55 | alpha | ship | - | - |
| bulk-056 | Bulk record 56 | alpha | ship | - | - |
| bulk-057 | Bulk record 57 | alpha | ship | - | - |
| bulk-058 | Bulk record 58 | alpha | ship | - | - |
| bulk-059 | Bulk record 59 | alpha | ship | - | - |
| bulk-060 | Bulk record 60 | alpha | ship | - | - |
| bulk-061 | Bulk record 61 | alpha | ship | - | - |
| bulk-062 | Bulk record 62 | alpha | ship | - | - |
| bulk-063 | Bulk record 63 | alpha | ship | - | - |
| bulk-064 | Bulk record 64 | alpha | ship | - | - |
| bulk-065 | Bulk record 65 | alpha | ship | - | - |
| bulk-066 | Bulk record 66 | alpha | ship | - | - |
| bulk-067 | Bulk record 67 | alpha | ship | - | - |
| bulk-068 | Bulk record 68 | alpha | ship | - | - |
| bulk-069 | Bulk record 69 | alpha | ship | - | - |
| bulk-070 | Bulk record 70 | alpha | ship | - | - |
| bulk-071 | Bulk record 71 | alpha | ship | - | - |
| bulk-072 | Bulk record 72 | alpha | ship | - | - |
| bulk-073 | Bulk record 73 | alpha | ship | - | - |
| bulk-074 | Bulk record 74 | alpha | ship | - | - |
| bulk-075 | Bulk record 75 | alpha | ship | - | - |
| bulk-076 | Bulk record 76 | alpha | ship | - | - |
| bulk-077 | Bulk record 77 | alpha | ship | - | - |
| bulk-078 | Bulk record 78 | alpha | ship | - | - |
| bulk-079 | Bulk record 79 | alpha | ship | - | - |

## Done
No done backlog records found.

## Secondmates
For kind=secondmate, bearings selects validated structured state from that registered home; parent events and bounded terminal evidence are fallback-only supplements and never current-state authority.
```
</details>
<details>
<summary>Evidence: Oversized backlog structured snapshot</summary>

```text
{
  "schema": "fm-fleet-snapshot.v1",
  "generated": "2026-08-03T21:31:55Z",
  "fm_home": "/tmp/no-mistakes-evidence/01KZ3T0KR5R3FCH3WGY9Z37217/oversized-backlog-home",
  "roots": {
    "fm_root": "/home/shane/.no-mistakes/worktrees/5f306883d81c/01KZ3T0KR5R3FCH3WGY9Z37217",
    "state": "/tmp/no-mistakes-evidence/01KZ3T0KR5R3FCH3WGY9Z37217/oversized-backlog-home/state",
    "data": "/tmp/no-mistakes-evidence/01KZ3T0KR5R3FCH3WGY9Z37217/oversized-backlog-home/data",
    "config": "/tmp/no-mistakes-evidence/01KZ3T0KR5R3FCH3WGY9Z37217/oversized-backlog-home/config",
    "projects": "/tmp/no-mistakes-evidence/01KZ3T0KR5R3FCH3WGY9Z37217/oversized-backlog-home/projects"
  },
  "backlog": {
    "path": "/tmp/no-mistakes-evidence/01KZ3T0KR5R3FCH3WGY9Z37217/oversized-backlog-home/data/backlog.md",
    "present": true,
    "records": [
      {
        "order": 1,
        "state": "queued",
        "structured": true,
        "id": "bulk-000",
        "checked": false,
        "title": "Bulk record 0",
        "repo": "alpha",
        "kind": "ship",
        "priority": null,
        "hold_reason": "captain must choose between the narrow repair and the broader refactor captain must choose between the narrow repair and the broader refactor captain must choose between the narrow repair and the broader refactor captain must choose between the narrow repair and the broader refactor captain must choose between the narrow repair and the broader refactor captain must choose between the narrow repair and the broader refactor captain must choose between the narrow repair and the broader refactor captain must choose between the narrow repair and the broader refactor",
        "hold_kind": "captain",
        "blocked_by": null,
        "blocked_by_ids": [],
        "blocked_reason": null,
        "since": null,
        "merged": null,
        "reported": null,
        "done": null,
        "completion": {
          "verb": null,
          "date": null
        },
        "links": [],
        "pr_url": null,
        "report_path": null,
        "local_note": null,
        "raw": "- [ ] bulk-000 - Bulk record 0 (repo: alpha) (kind: ship) (hold: captain must choose between the narrow repair and the broader refactor captain must choose between the narrow repair and the broader refactor captain must choose between the narrow repair and the broader refactor captain must choose between the narrow repair and the broader refactor captain must choose between the narrow repair and the broader refactor captain must choose between the narrow repair and the broader refactor captain must choose between the narrow repair and the broader refactor captain must choose between the narrow repair and the broader refactor ) (hold-kind: captain)",
        "body_lines": [],
        "body_excerpt": null,
        "unresolved_blocker_ids": [],
        "current_role": "queued",
        "requires_child_metadata": false,
        "captain_actionable": false
      },
      {
        "order": 2,
        "state": "queued",
        "structured": true,
        "id": "bulk-001",
        "checked": false,
        "title": "Bulk record 1",
        "repo": "alpha",
        "kind": "ship",
        "priority": null,
        "hold_reason": "captain must choose between the narrow repair and the broader refactor captain must choose between the narrow repair and the broader refactor captain must choose between the narrow repair and the broader refactor captain must choose between the narrow repair and the broader refactor captain must choose between the narrow repair and the broader refactor captain must choose between the narrow repair and the broader refactor captain must choose between the narrow repair and the broader refactor captain must choose between the narrow repair and the broader refactor",
        "hold_kind": "captain",
        "blocked_by": null,
        "blocked_by_ids": [],
        "blocked_reason": null,
        "since": null,
        "merged": null,
        "reported": null,
        "done": null,
        "completion": {
          "verb": null,
          "date": null
        },
        "links": [],
        "pr_url": null,
        "report_path": null,
        "local_note": null,
        "raw": "- [ ] bulk-001 - Bulk record 1 (repo: alpha) (kind: ship) (hold: captain must choose between the narrow repair and the broader refactor captain must choose between the narrow repair and the broader refactor captain must choose between the narrow repair and the broader refactor captain must choose between the narrow repair and the broader refactor captain must choose between the narrow repair and the broader refactor captain must choose between the narrow repair and the broader refactor captain must choose between the narrow repair and the broader refactor captain must choose between the narrow repair and the broader refactor ) (hold-kind: captain)",
        "body_lines": [],
        "body_excerpt": null,
        "unresolved_blocker_ids": [],
        "current_role": "queued",
        "requires_child_metadata": false,
        "captain_actionable": false
      },
      {
        "order": 3,
        "state": "queued",
        "structured": true,
        "id": "bulk-002",
        "checked": false,
        "title": "Bulk record 2",
        "repo": "alpha",
        "kind": "ship",
        "priority": null,
        "hold_reason": "captain must choose between the narrow repair and the broader refactor captain must choose between the narrow repair and the broader refactor captain must choose between the narrow repair and the broader refactor captain must choose between the narrow repair and the broader refactor captain must choose between the narrow repair and the broader refactor captain must choose between the narrow repair and the broader refactor captain must choose between the narrow repair and the broader refactor captain must choose between the narrow repair and the broader refactor",
        "hold_kind": "captain",
        "blocked_by": null,
        "blocked_by_ids": [],
        "blocked_reason": null,
        "since": null,
        "merged": null,
        "reported": null,
        "done": null,
        "completion": {
          "verb": null,
          "date": null
        },
        "links": [],
        "pr_url": null,
        "report_path": null,
        "local_note": null,
        "raw": "- [ ] bulk-002 - Bulk record 2 (repo: alpha) (kind: ship) (hold: captain must choose between the narrow repair and the broader refactor captain must choose between the narrow repair and the broader refactor captain must choose between the narrow repair and the broader refactor captain must choose between the narrow repair and the broader refactor captain must choose between the narrow repair and the broader refactor captain must choose between the narrow repair and the broader refactor captain must choose between the narrow repair and the broader refactor captain must choose between the narrow repair and the broader refactor ) (hold-kind: captain)",
        "body_lines": [],
        "body_excerpt": null,
        "unresolved_blocker_ids": [],
        "current_role": "queued",
        "requires_child_metadata": false,
        "captain_actionable": false
      },
      {
        "order": 4,
        "state": "queued",
        "structured": true,
        "id": "bulk-003",
        "checked": false,
        "title": "Bulk record 3",
        "repo": "alpha",
        "kind": "ship",
        "priority": null,
        "hold_reason": "captain must choose between the narrow repair and the broader refactor captain must choose between the narrow repair and the broader refactor captain must choose between the narrow repair and the broader refactor captain must choose between the narrow repair and the broader refactor captain must choose between the narrow repair and the broader refactor captain must choose between the narrow repair and the broader refactor captain must choose between the narrow repair and the broader refactor captain must choose between the narrow repair and the broader refactor",
        "hold_kind": "captain",
        "blocked_by": null,
        "blocked_by_ids": [],
        "blocked_reason": null,
        "si

... [156109 bytes truncated] ...

aptain must choose between the narrow repair and the broader refactor captain must choose between the narrow repair and the broader refactor captain must choose between the narrow repair and the broader refactor captain must choose between the narrow repair and the broader refactor captain must choose between the narrow repair and the broader refactor ) (hold-kind: captain)",
        "body_lines": [],
        "body_excerpt": null,
        "unresolved_blocker_ids": [],
        "current_role": "queued",
        "requires_child_metadata": false,
        "captain_actionable": false
      },
      {
        "order": 78,
        "state": "queued",
        "structured": true,
        "id": "bulk-077",
        "checked": false,
        "title": "Bulk record 77",
        "repo": "alpha",
        "kind": "ship",
        "priority": null,
        "hold_reason": "captain must choose between the narrow repair and the broader refactor captain must choose between the narrow repair and the broader refactor captain must choose between the narrow repair and the broader refactor captain must choose between the narrow repair and the broader refactor captain must choose between the narrow repair and the broader refactor captain must choose between the narrow repair and the broader refactor captain must choose between the narrow repair and the broader refactor captain must choose between the narrow repair and the broader refactor",
        "hold_kind": "captain",
        "blocked_by": null,
        "blocked_by_ids": [],
        "blocked_reason": null,
        "since": null,
        "merged": null,
        "reported": null,
        "done": null,
        "completion": {
          "verb": null,
          "date": null
        },
        "links": [],
        "pr_url": null,
        "report_path": null,
        "local_note": null,
        "raw": "- [ ] bulk-077 - Bulk record 77 (repo: alpha) (kind: ship) (hold: captain must choose between the narrow repair and the broader refactor captain must choose between the narrow repair and the broader refactor captain must choose between the narrow repair and the broader refactor captain must choose between the narrow repair and the broader refactor captain must choose between the narrow repair and the broader refactor captain must choose between the narrow repair and the broader refactor captain must choose between the narrow repair and the broader refactor captain must choose between the narrow repair and the broader refactor ) (hold-kind: captain)",
        "body_lines": [],
        "body_excerpt": null,
        "unresolved_blocker_ids": [],
        "current_role": "queued",
        "requires_child_metadata": false,
        "captain_actionable": false
      },
      {
        "order": 79,
        "state": "queued",
        "structured": true,
        "id": "bulk-078",
        "checked": false,
        "title": "Bulk record 78",
        "repo": "alpha",
        "kind": "ship",
        "priority": null,
        "hold_reason": "captain must choose between the narrow repair and the broader refactor captain must choose between the narrow repair and the broader refactor captain must choose between the narrow repair and the broader refactor captain must choose between the narrow repair and the broader refactor captain must choose between the narrow repair and the broader refactor captain must choose between the narrow repair and the broader refactor captain must choose between the narrow repair and the broader refactor captain must choose between the narrow repair and the broader refactor",
        "hold_kind": "captain",
        "blocked_by": null,
        "blocked_by_ids": [],
        "blocked_reason": null,
        "since": null,
        "merged": null,
        "reported": null,
        "done": null,
        "completion": {
          "verb": null,
          "date": null
        },
        "links": [],
        "pr_url": null,
        "report_path": null,
        "local_note": null,
        "raw": "- [ ] bulk-078 - Bulk record 78 (repo: alpha) (kind: ship) (hold: captain must choose between the narrow repair and the broader refactor captain must choose between the narrow repair and the broader refactor captain must choose between the narrow repair and the broader refactor captain must choose between the narrow repair and the broader refactor captain must choose between the narrow repair and the broader refactor captain must choose between the narrow repair and the broader refactor captain must choose between the narrow repair and the broader refactor captain must choose between the narrow repair and the broader refactor ) (hold-kind: captain)",
        "body_lines": [],
        "body_excerpt": null,
        "unresolved_blocker_ids": [],
        "current_role": "queued",
        "requires_child_metadata": false,
        "captain_actionable": false
      },
      {
        "order": 80,
        "state": "queued",
        "structured": true,
        "id": "bulk-079",
        "checked": false,
        "title": "Bulk record 79",
        "repo": "alpha",
        "kind": "ship",
        "priority": null,
        "hold_reason": "captain must choose between the narrow repair and the broader refactor captain must choose between the narrow repair and the broader refactor captain must choose between the narrow repair and the broader refactor captain must choose between the narrow repair and the broader refactor captain must choose between the narrow repair and the broader refactor captain must choose between the narrow repair and the broader refactor captain must choose between the narrow repair and the broader refactor captain must choose between the narrow repair and the broader refactor",
        "hold_kind": "captain",
        "blocked_by": null,
        "blocked_by_ids": [],
        "blocked_reason": null,
        "since": null,
        "merged": null,
        "reported": null,
        "done": null,
        "completion": {
          "verb": null,
          "date": null
        },
        "links": [],
        "pr_url": null,
        "report_path": null,
        "local_note": null,
        "raw": "- [ ] bulk-079 - Bulk record 79 (repo: alpha) (kind: ship) (hold: captain must choose between the narrow repair and the broader refactor captain must choose between the narrow repair and the broader refactor captain must choose between the narrow repair and the broader refactor captain must choose between the narrow repair and the broader refactor captain must choose between the narrow repair and the broader refactor captain must choose between the narrow repair and the broader refactor captain must choose between the narrow repair and the broader refactor captain must choose between the narrow repair and the broader refactor ) (hold-kind: captain)",
        "body_lines": [],
        "body_excerpt": null,
        "unresolved_blocker_ids": [],
        "current_role": "queued",
        "requires_child_metadata": false,
        "captain_actionable": false
      }
    ]
  },
  "tasks": [],
  "main_inventory": {
    "valid": true,
    "reason": null,
    "orphan_in_flight": [],
    "unstructured_current_count": 0
  },
  "scout_reports": [],
  "secondmate_current": {
    "registry": {
      "present": false,
      "available": true,
      "complete": true,
      "reason": null,
      "provenance": "registered-table",
      "path": "/tmp/no-mistakes-evidence/01KZ3T0KR5R3FCH3WGY9Z37217/oversized-backlog-home/data/secondmates.md",
      "freshness": {
        "status": "fresh",
        "observed_at": "2026-08-03T21:31:55Z"
      },
      "records": [],
      "input_truncated": false,
      "records_truncated": false,
      "reasons": [],
      "lines_in_window": 0,
      "records_in_window": 0
    },
    "records": [],
    "total_registered": 0,
    "total": 0,
    "shown": 0,
    "truncated": 0
  },
  "secondmate_landed": {
    "records": [],
    "truncated": [],
    "unreadable": [],
    "partial": []
  },
  "secondmate_guidance": {
    "note": "For kind=secondmate, bearings selects validated structured state from that registered home; parent events and bounded terminal evidence are fallback-only supplements and never current-state authority."
  }
}
```
</details>
<details>
<summary>Evidence: Oversized backlog verification</summary>

<code>snapshot_rc=0&#10;view_rc=0&#10;backlog_json_bytes=142820&#10;structured_records=80&#10;main_inventory_valid=true</code>

```text
snapshot_rc=0
view_rc=0
backlog_json_bytes=142820
structured_records=80
main_inventory_valid=true
```
</details>
<details>
<summary>Evidence: Empty-but-valid current fleet view</summary>

```text
# Fleet View

Schema: fm-fleet-snapshot.v1
Home: /home/shane/.no-mistakes/worktrees/5f306883d81c/01KZ3T0KR5R3FCH3WGY9Z37217

## Under Way
No live task metadata found.

## Queued
No queued backlog records found.

## Done
No done backlog records found.

## Secondmates
For kind=secondmate, bearings selects validated structured state from that registered home; parent events and bounded terminal evidence are fallback-only supplements and never current-state authority.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- 🚨 `bin/fm-fleet-snapshot.sh:1334` - The required contract says “a snapshot that cannot be built completely exits nonzero,” but the changed collector leaves `reports=$(printf &#39;%s&#39; &#34;$reports&#34; | sort)` unchecked. If `sort` fails, `reports` becomes empty and the snapshot can still exit 0 while silently omitting every scout report. Propagate this assignment’s failure with a diagnostic and nonzero return.

🔧 Fix: Fail closed on scout report sort errors
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>Inspected `git diff 4ee4a0a2790cfaa5e47b30fa462f16546f2ab5b6..4c912c72068e5247b8521ad97e37075a55e91ddb -- bin/fm-fleet-snapshot.sh bin/fm-fleet-view.sh tests/fm-fleet-snapshot-view.test.sh`</code>
- <code>Ran `tests/fm-fleet-snapshot-view.test.sh` in a persistent PTY to completion (exit 0)</code>
- <code>Generated an 80-record, 142,820-byte JSON backlog fixture and ran `FM_HOME=&#34;$fixture_home&#34; bin/fm-fleet-snapshot.sh --json`</code>
- <code>Rendered the same oversized fixture with `FM_HOME=&#34;$fixture_home&#34; bin/fm-fleet-view.sh` and verified rows `bulk-000` and `bulk-079`</code>
- <code>Ran `bin/fm-fleet-snapshot.sh --json` and `bin/fm-fleet-view.sh` against the current empty workspace state to verify explicit empty-fleet success</code>
- <code>Checked `git status --short` after testing; no working-tree artifacts remained</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
