### PR TITLE
fix: require resolved decisions before scout teardown

### DIFF
--- a/.agents/skills/decision-hold-lifecycle/SKILL.md
+++ b/.agents/skills/decision-hold-lifecycle/SKILL.md
@@ -20,8 +20,9 @@ Give each distinct unresolved decision a stable privacy-safe key, register it th
 After inventorying the whole report and review surface, run `bin/fm-decision-hold.sh complete` with every unresolved key, or with `--none` only when the reviewed surface contains no unresolved captain decision.
 A completed investigation and an ended visual review use this same owner and completion command; a visual tool, including Lavish, never owns a parallel completion policy.
 Run the command in the originating work's authoritative `FM_HOME`; main-home work creates main-home holds, and secondmate-owned work creates holds in that secondmate home's backlog rather than copying them into the main backlog.
-Do not close a hold merely because the originating investigation completed, its report was archived, its visual review ended, or its task was torn down.
+Do not close a hold merely because the originating investigation completed, its report was archived, or its visual review ended.
 The hold remains the authoritative Captain's Call item until the captain's answer is durably recorded, dependent work is created in the same backlog and blocked by that hold, and `bin/fm-decision-hold.sh resolve` routes the answer by clearing those dependency edges before closing the hold.
+An originating scout with inventoried decisions remains non-teardownable until every listed hold has that durable resolution.
 Resolved findings, recommendations that need no captain choice, and prose that merely sounds decision-like do not create holds.
 Bearings reads the resulting structured state and must never compensate by scraping historical reports, visual-review artifacts, terminal output, chat, or other prose.
 
@@ -34,7 +35,7 @@ Bearings reads the resulting structured state and must never compensate by scrap
 5. Relay the choices to the captain as decisions from Bearings' Captain's Call section under `AGENTS.md` section 9; do not use the word hold in captain chat.
 6. After the captain decides, record dependent work with normal tasks-axi commands and block it by the hold identity.
 7. Put the captain's exact durable decision in a file and use the script's `resolve` command with every routed task.
-8. Confirm Bearings no longer shows the closed hold and that routed work remains in structured backlog state.
+8. Confirm Bearings no longer shows the closed hold, routed work remains in structured backlog state, and the originating scout can pass teardown verification.
 
 `bin/fm-decision-hold.sh --help` owns command syntax, identity construction, completion attestation, retry behavior, and close ordering.
 `docs/decision-hold-lifecycle.md` records the mechanism and regression evidence without restating this policy.

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ Setup guides for tmux (the default) and every other supported backend (herdr, ze
      │
      ├─ ship: project mode ► PR/local merge ► teardown
      │
-     └─ scout: report at data/<id>/report.md ► decision inventory ► relay findings ► teardown
+     └─ scout: report at data/<id>/report.md ► decision inventory ► resolve any calls ► teardown
 ```
 
 You chat with the first mate.

--- a/bin/fm-decision-hold.sh
+++ b/bin/fm-decision-hold.sh
@@ -31,7 +31,9 @@
 # metadata inventory is unioned idempotently. A post-teardown visual review can
 # complete against the surviving report and holds without recreating task state.
 # `verify` is read-only and is called by scout teardown so teardown cannot erase a
-# source before this gate has succeeded.
+# source before every inventoried decision has a positive durable resolution.
+# A resolved row may have moved from the live backlog into its configured archive.
+# Missing, duplicated, malformed, or still-open records keep teardown refusing.
 #
 # `resolve` requires every --routed-to task to exist and to be blocked by the hold.
 # It writes the captain decision and routed identities into the hold body, clears
@@ -110,6 +112,46 @@ task_show() {  # <id>
   tasks_axi show "$1" --full 2>/dev/null
 }
 
+archived_task_show() {  # <id>
+  local id=$1 archive="$DATA/done-archive.md" prefix matches
+  [ -f "$archive" ] || return 1
+  prefix="- [x] $id - "
+  matches=$(awk -v prefix="$prefix" '
+    index($0, prefix) == 1 { count++ }
+    END { print count + 0 }
+  ' "$archive") || return 1
+  [ "$matches" -eq 1 ] || return 1
+  {
+    printf '## In flight\n\n## Queued\n\n## Done\n'
+    awk -v prefix="$prefix" '
+      /^- \[[ x]\] / {
+        if (capture) exit
+        if (index($0, prefix) == 1) {
+          capture = 1
+          print
+        }
+        next
+      }
+      capture {
+        if ($0 ~ /^## /) exit
+        print
+      }
+    ' "$archive"
+  } | tasks_axi show "$id" --full --file /dev/stdin 2>/dev/null
+}
+
+task_show_durable() {  # <id>
+  local id=$1 show
+  if show=$(tasks_axi show "$id" --full 2>&1); then
+    printf '%s\n' "$show"
+    return 0
+  fi
+  case "$show" in
+    *"code: NOT_FOUND"*) archived_task_show "$id" ;;
+    *) return 1 ;;
+  esac
+}
+
 show_field() {  # <show-output> <field>
   local output=$1 field=$2
   printf '%s\n' "$output" | sed -n "s/^  $field: //p" | head -1
@@ -172,7 +214,7 @@ verify_hold_active() {  # <hold-id>
 
 verify_hold_resolved() {  # <hold-id>
   local id=$1 show state kind body
-  show=$(task_show "$id") || return 1
+  show=$(task_show_durable "$id") || return 1
   state=$(show_field "$show" state)
   kind=$(show_field "$show" kind)
   body=$(show_field "$show" body)
@@ -186,7 +228,8 @@ verify_hold_resolved() {  # <hold-id>
 
 verify_hold_durable() {  # <hold-id>
   local id=$1 show state held kind hold_kind body
-  show=$(task_show "$id") || fail "captain decision $id is absent from $FM_HOME/data/backlog.md"
+  show=$(task_show_durable "$id") \
+    || fail "captain decision $id is absent or indeterminate in the live backlog and durable archive"
   state=$(show_field "$show" state)
   held=$(show_field "$show" held)
   kind=$(show_field "$show" kind)
@@ -249,7 +292,7 @@ command_hold() {
   require_tasks_axi
   origin_exists_here "$origin" || fail "origin $origin is not owned by the active home $FM_HOME"
   id=$(hold_id "$origin" "$key")
-  if show=$(task_show "$id"); then
+  if show=$(task_show_durable "$id"); then
     state=$(show_field "$show" state)
     kind=$(show_field "$show" kind)
     existing_title=$(show_field "$show" title)
@@ -350,7 +393,8 @@ command_verify() {
   if [ -n "$keys" ]; then
     while IFS= read -r key; do
       [ -n "$key" ] || continue
-      verify_hold_durable "$(hold_id "$origin" "$key")"
+      verify_hold_resolved "$(hold_id "$origin" "$key")" \
+        || fail "captain decision $(hold_id "$origin" "$key") is unresolved, absent, or indeterminate"
     done <<EOF
 $(printf '%s\n' "$keys" | tr ',' '\n')
 EOF
@@ -360,7 +404,8 @@ EOF
     [ -n "$key" ] || continue
     list_has_key "$keys" "$key" \
       || fail "open structured decision $origin/$key is outside the reviewed inventory"
-    verify_hold_durable "$(hold_id "$origin" "$key")"
+    verify_hold_resolved "$(hold_id "$origin" "$key")" \
+      || fail "captain decision $(hold_id "$origin" "$key") is unresolved, absent, or indeterminate"
   done <<EOF
 $open
 EOF
@@ -394,7 +439,8 @@ command_resolve() {
   require_tasks_axi
   id=$(hold_id "$origin" "$key")
   if verify_hold_resolved "$id"; then
-    hold_show=$(task_show "$id")
+    hold_show=$(task_show_durable "$id") \
+      || fail "captain hold $id disappeared after its durable resolution was verified"
     hold_body=$(show_field "$hold_show" body)
     verify_resolution_identity "$id" "$hold_body" "$decision_digest" "$routed_csv"
     printf 'resolved: %s\n' "$id"

--- a/docs/decision-hold-lifecycle.md
+++ b/docs/decision-hold-lifecycle.md
@@ -21,11 +21,14 @@ For an open keyed status decision, it appends a `captain-held [key=<key>]: ...` 
 `bin/fm-classify-lib.sh` recognizes that transfer as closing the live status copy without claiming that the captain has answered it.
 
 Scout teardown calls the script's read-only `verify` subcommand after checking for the report and before removing any source state.
+Verification accepts a listed decision only when tasks-axi parses it as a resolved captain row in the live backlog or as one unique resolved captain row in `data/done-archive.md`.
+An active unresolved row, an absent row, a duplicate archived identity, a malformed row, or an indeterminate live lookup keeps teardown refusing.
 The `--force` path remains the explicit captain-approved discard escape hatch.
 
 The `resolve` subcommand requires a decision file and at least one existing dependent task whose structured `blocked-by` edge points to the hold.
 It records the decision digest and routed task identities as a retry identity in the hold body, clears each dependency edge through tasks-axi, and marks the hold Done only after those writes succeed.
 An exact retry can finish a partial routing operation, while a changed decision or routed-task set is rejected.
+A later tasks-axi prune moves the resolved row to `data/done-archive.md` without invalidating the teardown proof.
 A failed intermediate step leaves the hold open.
 
 ## Structured read surfaces
@@ -43,6 +46,7 @@ The projection remains read-only and does not inspect historical prose.
 Verification date: 2026-07-14.
 Additional quoted `blocked_by` regression verification date: 2026-07-17.
 Plural blocker-readiness and mixed-home projection verification date: 2026-07-22.
+Resolved-row archive verification date: 2026-07-30.
 
 The focused end-to-end regression uses only synthetic `sample` identities and decision text.
 It begins with a completed investigation and visual review whose genuine unresolved choice exists only in the report.
@@ -55,7 +59,10 @@ The final verification commands and their exact summarized outputs follow.
 $ bash tests/fm-decision-hold-lifecycle.test.sh
 ok - report-only unresolved decision is reproduced and completion refuses before loss
 ok - non-forced scout teardown always requires durable inventory verification
-ok - captain holds are idempotent, distinct, teardown-safe, Bearings-visible, and durably routed before close
+ok - resolved and durably pruned captain decision allows teardown
+ok - unresolved captain decision still refuses teardown
+ok - never-existing or indeterminate captain decision still refuses teardown
+ok - captain holds are idempotent, distinct, teardown-blocking until resolved, and durably routed
 ok - completion and verification validate origins before constructing paths
 ok - ended visual review follows the same decision-hold completion owner
 ok - resolved findings and decision-like prose do not create false holds

--- a/docs/decision-hold-lifecycle.md
+++ b/docs/decision-hold-lifecycle.md
@@ -21,14 +21,14 @@ For an open keyed status decision, it appends a `captain-held [key=<key>]: ...` 
 `bin/fm-classify-lib.sh` recognizes that transfer as closing the live status copy without claiming that the captain has answered it.
 
 Scout teardown calls the script's read-only `verify` subcommand after checking for the report and before removing any source state.
-Verification accepts a listed decision only when tasks-axi parses it as a resolved captain row in the live backlog or as one unique resolved captain row in `data/done-archive.md`.
-An active unresolved row, an absent row, a duplicate archived identity, a malformed row, or an indeterminate live lookup keeps teardown refusing.
+Verification requires tasks-axi to parse each listed decision as a resolved captain row, falling back to exactly one matching row in `data/done-archive.md` only when the live lookup reports `NOT_FOUND`.
+A live row that is unresolved or malformed, any live lookup failure other than `NOT_FOUND`, or a fallback with an absent, malformed, or duplicated archived record keeps teardown refusing.
 The `--force` path remains the explicit captain-approved discard escape hatch.
 
 The `resolve` subcommand requires a decision file and at least one existing dependent task whose structured `blocked-by` edge points to the hold.
 It records the decision digest and routed task identities as a retry identity in the hold body, clears each dependency edge through tasks-axi, and marks the hold Done only after those writes succeed.
 An exact retry can finish a partial routing operation, while a changed decision or routed-task set is rejected.
-A later tasks-axi prune moves the resolved row to `data/done-archive.md` without invalidating the teardown proof.
+A later tasks-axi prune moves the resolved row to `data/done-archive.md` without invalidating the teardown proof or identical resolution retries.
 A failed intermediate step leaves the hold open.
 
 ## Structured read surfaces

--- a/tests/fm-decision-hold-lifecycle.test.sh
+++ b/tests/fm-decision-hold-lifecycle.test.sh
@@ -39,7 +39,8 @@ run_bearings() {  # <home>
 
 run_teardown() {  # <home> <id>
   local home=$1 id=$2
-  PATH="$home/fakebin:$PATH" FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" \
+  PATH="$home/fakebin:$PATH" REAL_TASKS_AXI="$TASKS_AXI_BIN" \
+    FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" \
     FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
     FM_CONFIG_OVERRIDE="$home/config" "$TEARDOWN" "$id"
 }
@@ -181,21 +182,6 @@ EOF
       and (.gates | any(.id == $route or .id == $access) | not)
   ' >/dev/null || fail "Bearings did not surface structured captain holds: $json"
 
-  run_teardown "$home" "$id" >/dev/null 2> "$home/teardown.err" \
-    || fail "reviewed investigation teardown failed: $(cat "$home/teardown.err")"
-  tasks_in "$home" "done" "$id" --report "data/$id/report.md" --keep 0 >/dev/null \
-    || fail "could not archive completed investigation"
-  ! grep -E "^- \[[ x]\] $id -" "$home/data/backlog.md" >/dev/null \
-    || fail "origin remained in the live backlog after archival"
-  grep -E "^- \[x\] $id -" "$home/data/done-archive.md" >/dev/null \
-    || fail "origin was not durably archived"
-  json=$(run_bearings "$home") || fail "Bearings failed after source teardown and archival"
-  printf '%s' "$json" | jq -e --arg route "$route_hold" --arg access "$access_hold" '
-    (.decisions_open | any(.id == $route and .verb == "captain-hold"))
-      and (.decisions_open | any(.id == $access and .verb == "captain-hold"))
-      and (.in_flight | any(.id == "sample-systems-review") | not)
-  ' >/dev/null || fail "teardown or archival erased a captain-held decision: $json"
-
   tasks_in "$home" add sample-route-implementation "Apply the selected sample route" \
     --kind ship --repo sample >/dev/null \
     || fail "could not create dependent work fixture"
@@ -273,7 +259,28 @@ EOF
       and (.gates | any(.id == "sample-route-implementation"))
       and (.decisions_open | any(.id == "sample-systems-review") | not)
   ' >/dev/null || fail "resolved or decision-like report prose produced a false hold: $json"
-  pass "captain holds are idempotent, distinct, teardown-safe, Bearings-visible, and durably routed before close"
+
+  tasks_in "$home" add sample-access-implementation "Apply the selected sample access" \
+    --kind ship --repo sample --blocked-by "$access_hold" >/dev/null \
+    || fail "could not create access dependent work fixture"
+  printf 'Use restricted sample access.\n' > "$home/access-decision.txt"
+  run_decisions "$home" resolve "$id" access --decision-file "$home/access-decision.txt" \
+    --routed-to sample-access-implementation >/dev/null \
+    || fail "could not resolve the access decision"
+  run_teardown "$home" "$id" >/dev/null 2> "$home/teardown.err" \
+    || fail "fully resolved investigation teardown failed: $(cat "$home/teardown.err")"
+  tasks_in "$home" "done" "$id" --report "data/$id/report.md" --keep 0 >/dev/null \
+    || fail "could not archive completed investigation"
+  ! grep -E "^- \[[ x]\] $id -" "$home/data/backlog.md" >/dev/null \
+    || fail "origin remained in the live backlog after archival"
+  grep -E "^- \[x\] $id -" "$home/data/done-archive.md" >/dev/null \
+    || fail "origin was not durably archived"
+  json=$(run_bearings "$home") || fail "Bearings failed after source teardown and archival"
+  printf '%s' "$json" | jq -e --arg route "$route_hold" --arg access "$access_hold" '
+    (.decisions_open | any(.id == $route or .id == $access) | not)
+      and (.in_flight | any(.id == "sample-systems-review") | not)
+  ' >/dev/null || fail "resolved teardown left an open decision or live origin: $json"
+  pass "captain holds are idempotent, distinct, teardown-blocking until resolved, and durably routed"
 }
 
 test_scout_teardown_always_requires_inventory_verification() {
@@ -303,6 +310,113 @@ EOF
   fi
   assert_present "$home/state/$id.meta" "refused unavailable-task teardown removed metadata"
   pass "non-forced scout teardown always requires durable inventory verification"
+}
+
+test_resolved_pruned_hold_allows_teardown() {
+  local home id hold filler
+  home=$(make_home resolved-pruned-teardown)
+  id=sample-pruned-review
+  mkdir -p "$home/data/$id"
+  tasks_in "$home" add "$id" "Review the pruned sample decision" \
+    --kind scout --repo sample --start >/dev/null \
+    || fail "could not create pruned-decision origin fixture"
+  write_origin_meta "$home" "$id"
+  printf 'needs-decision [key=route]: choose the sample route\ndone: report complete\n' \
+    > "$home/state/$id.status"
+  printf '# Pruned sample review\n\nThe route decision was inventoried.\n' \
+    > "$home/data/$id/report.md"
+  hold=$(run_decisions "$home" hold "$id" route \
+    --title "Choose the pruned sample route" --reason "captain route pending" --repo sample) \
+    || fail "could not register pruned-decision hold"
+  run_decisions "$home" complete "$id" route >/dev/null \
+    || fail "could not complete the pruned-decision inventory"
+  tasks_in "$home" add sample-pruned-route "Apply the pruned sample route" \
+    --kind ship --repo sample --blocked-by "$hold" >/dev/null \
+    || fail "could not create pruned-decision routed work"
+  printf 'Use the north sample route.\n' > "$home/route-decision.txt"
+  run_decisions "$home" resolve "$id" route --decision-file "$home/route-decision.txt" \
+    --routed-to sample-pruned-route >/dev/null \
+    || fail "could not resolve the pruned-decision hold"
+
+  filler=1
+  while [ "$filler" -le 10 ]; do
+    tasks_in "$home" add "done-filler-$filler" "Done filler $filler" \
+      --kind ship --repo sample >/dev/null \
+      || fail "could not create done filler $filler"
+    tasks_in "$home" "done" "done-filler-$filler" >/dev/null \
+      || fail "could not close done filler $filler"
+    filler=$((filler + 1))
+  done
+  if tasks_in "$home" show "$hold" --full >/dev/null 2>&1; then
+    fail "resolved hold remained in the live backlog instead of being pruned"
+  fi
+  assert_grep "$hold" "$home/data/done-archive.md" \
+    "resolved hold was not durably archived after pruning"
+  assert_grep "Resolution recorded by fm-decision-hold" "$home/data/done-archive.md" \
+    "pruned hold archive lost the resolution record"
+  run_decisions "$home" resolve "$id" route --decision-file "$home/route-decision.txt" \
+    --routed-to sample-pruned-route >/dev/null \
+    || fail "identical resolution retry could not use the durable archive"
+  if run_decisions "$home" hold "$id" route \
+    --title "Choose the pruned sample route" --reason "captain route pending" --repo sample \
+    > "$home/reopened-hold.out" 2> "$home/reopened-hold.err"; then
+    fail "resolved archived identity was reopened as a new hold"
+  fi
+  assert_grep "already durably resolved" "$home/reopened-hold.err" \
+    "archived identity refusal did not preserve the resolved-key contract"
+
+  run_teardown "$home" "$id" > "$home/teardown.out" 2> "$home/teardown.err" \
+    || fail "resolved and durably pruned decision blocked teardown: $(cat "$home/teardown.err")"
+  pass "resolved and durably pruned captain decision allows teardown"
+}
+
+test_unresolved_hold_refuses_teardown() {
+  local home id hold
+  home=$(make_home unresolved-teardown)
+  id=sample-unresolved-review
+  mkdir -p "$home/data/$id"
+  tasks_in "$home" add "$id" "Review the unresolved sample decision" \
+    --kind scout --repo sample --start >/dev/null \
+    || fail "could not create unresolved origin fixture"
+  write_origin_meta "$home" "$id"
+  printf 'needs-decision [key=route]: choose the sample route\ndone: report complete\n' \
+    > "$home/state/$id.status"
+  printf '# Unresolved sample review\n\nThe route decision remains open.\n' \
+    > "$home/data/$id/report.md"
+  hold=$(run_decisions "$home" hold "$id" route \
+    --title "Choose the unresolved sample route" --reason "captain route pending" --repo sample) \
+    || fail "could not register unresolved-decision hold"
+  run_decisions "$home" complete "$id" route >/dev/null \
+    || fail "could not complete the unresolved-decision inventory"
+  assert_grep "$hold" "$home/data/backlog.md" "unresolved hold is not in the live backlog"
+
+  if run_teardown "$home" "$id" > "$home/teardown.out" 2> "$home/teardown.err"; then
+    fail "unresolved captain decision allowed teardown"
+  fi
+  assert_present "$home/state/$id.meta" "unresolved-decision refusal removed origin metadata"
+  assert_grep "is unresolved, absent, or indeterminate" "$home/teardown.err" \
+    "unresolved-decision refusal did not identify the failed resolution gate"
+  pass "unresolved captain decision still refuses teardown"
+}
+
+test_never_existed_inventory_refuses_teardown() {
+  local home id
+  home=$(make_home never-existed-teardown)
+  id=sample-never-existed-review
+  mkdir -p "$home/data/$id"
+  write_origin_meta "$home" "$id"
+  printf 'decisions_reviewed=1\ndecision_keys=missing-route\n' >> "$home/state/$id.meta"
+  printf 'done: report complete\n' > "$home/state/$id.status"
+  printf '# Never-existing sample review\n\nThe recorded identity has no durable row.\n' \
+    > "$home/data/$id/report.md"
+
+  if run_teardown "$home" "$id" > "$home/teardown.out" 2> "$home/teardown.err"; then
+    fail "never-existing captain decision allowed teardown"
+  fi
+  assert_present "$home/state/$id.meta" "indeterminate-decision refusal removed origin metadata"
+  assert_grep "is unresolved, absent, or indeterminate" "$home/teardown.err" \
+    "indeterminate-decision refusal did not identify the failed resolution gate"
+  pass "never-existing or indeterminate captain decision still refuses teardown"
 }
 
 test_origin_slug_validation_precedes_path_construction() {
@@ -438,9 +552,6 @@ EOF
     || fail "secondmate-owned hold creation failed"
   run_decisions "$mate" complete "$origin" release >/dev/null \
     || fail "secondmate-owned completion failed"
-  run_teardown "$mate" "$origin" >/dev/null 2> "$mate/teardown.err" \
-    || fail "secondmate investigation teardown failed: $(cat "$mate/teardown.err")"
-  tasks_in "$mate" "done" "$origin" --report "data/$origin/report.md" --keep 0 >/dev/null
 
   printf -- '- sample-mate - synthetic scope (home: %s; scope: sample reviews; projects: sample; added 2026-07-14)\n' \
     "$mate" > "$parent/data/secondmates.md"
@@ -452,6 +563,23 @@ EOF
   ' >/dev/null || fail "secondmate captain hold did not surface with authoritative owner: $json"
   assert_no_grep "$hold" "$parent/data/backlog.md" "secondmate hold leaked into the main backlog"
   assert_grep "$hold" "$mate/data/backlog.md" "secondmate hold left its authoritative backlog"
+
+  tasks_in "$mate" add sample-mate-release "Apply the sample mate release" \
+    --kind ship --repo sample --blocked-by "$hold" >/dev/null \
+    || fail "could not create secondmate-owned routed work"
+  printf 'Use the stable sample release.\n' > "$mate/release-decision.txt"
+  run_decisions "$mate" resolve "$origin" release --decision-file "$mate/release-decision.txt" \
+    --routed-to sample-mate-release >/dev/null \
+    || fail "could not resolve the secondmate-owned decision"
+  run_teardown "$mate" "$origin" >/dev/null 2> "$mate/teardown.err" \
+    || fail "secondmate investigation teardown failed: $(cat "$mate/teardown.err")"
+  tasks_in "$mate" "done" "$origin" --report "data/$origin/report.md" --keep 0 >/dev/null
+  json=$(run_bearings "$parent") || fail "parent Bearings failed after secondmate resolution"
+  printf '%s' "$json" | jq -e --arg hold "$hold" '
+    .decisions_open | any(.id == $hold) | not
+  ' >/dev/null || fail "resolved secondmate hold remained in Captain's Call: $json"
+  assert_grep "$hold" "$mate/data/done-archive.md" \
+    "resolved secondmate hold was not archived in its authoritative home"
   pass "main-home and secondmate-home captain holds remain correctly routed"
 }
 
@@ -553,6 +681,9 @@ test_resolve_matches_quoted_blocked_by_edges() {
 test_uninventoried_report_decision_refuses_completion
 
 test_scout_teardown_always_requires_inventory_verification
+test_resolved_pruned_hold_allows_teardown
+test_unresolved_hold_refuses_teardown
+test_never_existed_inventory_refuses_teardown
 test_structured_holds_survive_teardown_and_route_resolution
 test_origin_slug_validation_precedes_path_construction
 test_visual_review_uses_shared_completion_owner


### PR DESCRIPTION
## Intent

Publish an already-authored fix that closes a hole in scout teardown's decision-hold verification gate, as a small reviewable PR against kunchenguid/firstmate.

The bug: bin/fm-decision-hold.sh's read-only `verify` subcommand, which scout teardown calls before removing any source state, used verify_hold_durable. That helper accepts a captain decision that is EITHER actively held OR durably resolved. An actively held row is by definition an unanswered decision, so the gate that exists to stop teardown erasing a source before its decisions are answered passed on exactly the state it was meant to refuse. A scout whose inventoried decision was still open could be torn down, taking its report's context with it. `verify` now requires a positive durable resolution for every inventoried key (verify_hold_resolved).

The deliberate second half, which a reviewer reading only the diff would likely question as unrelated: strengthening the gate alone would introduce a worse failure mode. tasks-axi prunes resolved Done rows out of the live backlog into data/done-archive.md, so a correctly resolved decision returns NOT_FOUND from a live lookup once pruned, and its originating scout would become permanently unverifiable with no recovery short of recreating the row. This home has already lost five gate scouts to that exact class of failure. So resolution lookup falls back to the archive: a new task_show_durable reparses exactly one unique resolved captain row out of data/done-archive.md when the live lookup reports NOT_FOUND. The asymmetry is intentional and load-bearing - the fallback widens what counts as FINDABLE, never what counts as RESOLVED. A missing, duplicated, malformed, or indeterminate record still keeps teardown refusing.

Deliberate decisions to preserve, not flag:
- The two halves ship together on purpose. Shipping them separately was tested empirically in a throwaway clone and rejected: the archive-fallback half alone leaves "unresolved captain decision allowed teardown", and the strengthened-verify half alone leaves "identical resolution retry could not use the durable archive". Each half fails a regression case the other passes, so a split would ship a knowingly broken intermediate, and one ordering would make the permanently-unverifiable failure class easier to hit.
- archived_task_show reconstructs a minimal synthetic backlog document and pipes it to tasks-axi show --file /dev/stdin rather than parsing the archived row's fields directly. This is deliberate: it keeps tasks-axi the single parser of the row format so the archive path cannot drift from the live path.
- The strict "exactly one match" requirement in archived_task_show is deliberate. A duplicated archived identity is ambiguous, and ambiguity must refuse rather than guess.
- The documentation edits to README.md, docs/decision-hold-lifecycle.md, and .agents/skills/decision-hold-lifecycle/SKILL.md correct statements this change itself falsifies (they previously said a hold could be closed on teardown, and described the old verification semantics). They are in scope for that reason and for no other; no unrelated documentation was added or improved.
- tests/fm-decision-hold-lifecycle.test.sh gains three cases that drive the halves apart on purpose: resolved-then-pruned must allow teardown, unresolved must still refuse it, and never-existing or indeterminate must still refuse it.

Constraints: this is a cherry-pick of commit b437c69 rebased onto the current default-branch head, verified to preserve its exact 5 files / 216 insertions / 31 deletions. The repository style rules in the firstmate-coding-guidelines skill apply (one sentence per line in tracked Markdown, plain dash never an em dash, bin/*.sh shellcheck-clean, no agent co-author on commits). Locally the full suite passes, bin/fm-lint.sh is clean at pinned ShellCheck 0.11.0, and bin/fm-doc-audience-check.sh reports ok at 64 surfaces / 185 local links. Do not merge.

## What Changed

- Require `verify` to confirm every inventoried captain decision is durably resolved, so active holds continue to block scout teardown.
- Fall back to exactly one matching row in `data/done-archive.md` when a live task is not found, while refusing missing, duplicate, malformed, or indeterminate records.
- Update lifecycle documentation and regression coverage for pruned resolutions, unresolved decisions, and absent or indeterminate records.

## Risk Assessment

✅ Low: Captain, the change is narrowly scoped, preserves fail-closed behavior, and satisfies the stated durable-resolution and archive-fallback invariants.

## Testing

Exact-footprint inspection, base guard falsification, the targeted lifecycle suite, and real CLI teardown/resolve/prune/archive scenarios all passed: target refuses open, missing, duplicate, and malformed decisions while accepting one uniquely archived durable resolution.

<details>
<summary>Evidence: End-to-end teardown and archive transcript</summary>

```text
Decision-hold teardown end-to-end evidence
target_commit=df4dbce69ffec81db67fafcc3820ede9fde11c8d
tasks_axi_version=0.2.4

SCENARIO 1: inventoried but unanswered decision
teardown_exit=1
fm-decision-hold: captain decision sample-e2e-review-decision-route is unresolved, absent, or indeterminate
REFUSED: scout task sample-e2e-review has not passed the unresolved-decision completion gate.
source_metadata=preserved

SCENARIO 2: answered decision pruned from live backlog
live_lookup_exit=1
code: NOT_FOUND
- [x] sample-e2e-review-decision-route - Choose the sample route (repo: sample) (kind: captain) (done 2026-08-03) (hold: captain route pending) (hold-kind: captain)
  Resolution recorded by fm-decision-hold.
verified: sample-e2e-review unresolved-decision inventory
teardown=allowed; volatile_source_state=removed; report=preserved

SCENARIO 3: duplicate archived identity is ambiguous
verify_exit=1
fm-decision-hold: captain decision sample-e2e-review-decision-route is unresolved, absent, or indeterminate

SCENARIO 4: malformed archived captain row
verify_exit=1
fm-decision-hold: captain decision sample-malformed-review-decision-route is unresolved, absent, or indeterminate

SCENARIO 5: inventoried identity never existed
verify_exit=1
fm-decision-hold: captain decision sample-missing-review-decision-route is unresolved, absent, or indeterminate

RESULT: PASS - teardown refuses open, missing, duplicate, and malformed decisions; unique archived resolution passes.
```
</details>
<details>
<summary>Evidence: Base-versus-target guard falsification</summary>

```text
Guard falsification against base commit 3d9d12db7412e5da0751745c14603e7e427f8877
Fixture: one inventoried captain row is queued, held, and unanswered.

BASE verify (old behavior):
exit=0
verified: sample-baseline-review unresolved-decision inventory

TARGET verify (fixed behavior):
exit=1
fm-decision-hold: captain decision sample-baseline-review-decision-route is unresolved, absent, or indeterminate

RESULT: RED reproduced on base; target closes the open-hold teardown gate hole.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`git diff --stat 3d9d12db7412e5da0751745c14603e7e427f8877..df4dbce69ffec81db67fafcc3820ede9fde11c8d` and `git diff --name-only ...` confirmed the required 5 files / 216 insertions / 31 deletions</code>
- `bash tests/fm-decision-hold-lifecycle.test.sh`
- <code>`decision-hold-baseline-compare.sh &gt; decision-hold-baseline-compare.txt` reproduced the base bug and target refusal</code>
- <code>`decision-hold-e2e.sh &gt; decision-hold-e2e-transcript.txt` exercised real hold, complete, verify, resolve, pruning, archive fallback, and teardown paths with tasks-axi 0.2.4</code>
- <code>`git status --short` plus generated-directory inspection confirmed no testing artifacts or source changes remained in the worktree</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
