### PR TITLE
feat(bin): stage launch briefs and their firstmate references inside the task worktree

### DIFF
--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -380,7 +380,7 @@ Kimi Code CLI launches from the absolute path resolved from `PATH`, falling back
 `fm-spawn.sh` launches Kimi bare, waits for the composer box or `Welcome to Kimi Code!`, sends only `Read the brief at <absolute-path> and follow it exactly.`, and requires a cleared composer plus either the echoed `✨` submission or nonzero context before accepting delivery.
 This launch-then-send shape is mandatory because Kimi rejects a positional brief as an unknown command.
 Sending before readiness was reproduced as a silent drop with a zero exit status, an empty composer, `context: 0%`, no echoed user message, and a healthy-looking idle pane.
-The brief path must be absolute because the brief lives outside the task worktree, and Kimi reads it there without `--add-dir`.
+The pointer names the absolute path of the brief `fm-spawn.sh` stages inside the task worktree (`<worktree>/.fm/brief.md`), so Kimi reads it with no `--add-dir` grant for a directory outside the worktree.
 
 Observed live spinner captures included optional leading whitespace, a moon-phase glyph, whitespace around `·`, and rotating tip text, with the same shape observed during tool execution.
 Because every captured spinner row had whitespace on both sides of `·`, the matcher requires that whitespace, deliberately does not match the never-observed zero-whitespace form, and does not require trailing tip text.

--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -380,7 +380,7 @@ Kimi Code CLI launches from the absolute path resolved from `PATH`, falling back
 `fm-spawn.sh` launches Kimi bare, waits for the composer box or `Welcome to Kimi Code!`, sends only `Read the brief at <absolute-path> and follow it exactly.`, and requires a cleared composer plus either the echoed `✨` submission or nonzero context before accepting delivery.
 This launch-then-send shape is mandatory because Kimi rejects a positional brief as an unknown command.
 Sending before readiness was reproduced as a silent drop with a zero exit status, an empty composer, `context: 0%`, no echoed user message, and a healthy-looking idle pane.
-The pointer names the absolute path of the brief `fm-spawn.sh` stages inside the task worktree (`<worktree>/.fm/brief.md`), so Kimi reads it with no `--add-dir` grant for a directory outside the worktree.
+The pointer names the absolute path of the brief `fm-spawn.sh` stages inside the launch checkout - the task worktree, or the secondmate home for a `--secondmate` launch - as `.fm/brief.md`, so Kimi reads it with no `--add-dir` grant for a directory outside that checkout.
 
 Observed live spinner captures included optional leading whitespace, a moon-phase glyph, whitespace around `·`, and rotating tip text, with the same shape observed during tool execution.
 Because every captured spinner row had whitespace on both sides of `·`, the matcher requires that whitespace, deliberately does not match the never-observed zero-whitespace form, and does not require trailing tip text.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -475,6 +475,10 @@ Preserve durable structured identifiers, dependencies, and completion artifact l
 Use its scaffold as the contract, then replace every `{TASK}` placeholder with a clear task description, acceptance criteria, constraints, and necessary context before dispatch or seeding.
 Keep additions task-specific rather than repeating lifecycle instructions, and alter generated sections only when the task genuinely differs from the standard shape.
 
+An existing firstmate-home or firstmate-repo file a brief names reaches the crewmate as a staged snapshot copy inside its launch checkout, so never name one as a write target.
+The only live external write surfaces are the task's `state/<id>.status` and a scout's `data/<id>/report.md`; a path that does not exist yet keeps its real path.
+`bin/fm-spawn.sh` owns the exact staging mechanics.
+
 Every ship brief must retain the worktree-isolation assertion and stop if launched in the primary checkout.
 If a ship task touches firstmate's shared tracked material, explicitly require `firstmate-coding-guidelines` before editing.
 If a task will drive Herdr lifecycle behavior, scaffold with `--herdr-lab`; if that need appears after an unguarded scaffold, stop and regenerate rather than adding commands by hand.

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -133,11 +133,11 @@
 # .fm/brief.md, together with every firstmate-home or firstmate-repo file it
 # references under .fm/refs/<home|root|secondmate>/, and the brief's input paths
 # are rewritten to the absolute path of those copies, so no launch-visible input
-# needs a directory grant outside that checkout. A trusted firstmate enforcement
-# script (an executable interpreter script under a firstmate root's own bin/) is
-# invoked rather than read, so it is never copied into the writable worktree and
-# keeps its real path; an ordinary input that merely carries mode 755 is still
-# staged. Directory references are bounded: a broad firstmate root (bin, data,
+# needs a directory grant outside that checkout. Anything under a firstmate
+# root's own bin/ is firstmate's own code, invoked or sourced in place rather
+# than read as input, so it is never copied into the writable worktree and keeps
+# its real path; an ordinary input outside bin/ that merely carries mode 755 is
+# still staged. Directory references are bounded: a broad firstmate root (bin, data,
 # state, ...) is never staged, and depth/file-count/byte caps skip the rest with
 # a warning. A directory or glob reference is rewritten only when every file it
 # covers was staged, so a partial copy is reported rather than silently handed
@@ -1833,25 +1833,26 @@ stage_target_for_reference() {
   printf '%s/.fm/refs/%s/%s\n' "$WT" "$kind" "$rel"
 }
 
-# A trusted firstmate enforcement script is invoked, never read as input.
-# Staging one would hand the crewmate a writable copy of a script such as
-# bin/fm-herdr-lab.sh inside the very laboratory that script isolates, and would
-# repoint an invocation that has to work from any directory. Execution needs no
-# read grant, so such a reference keeps its real absolute path. The test is
-# deliberately narrow - an executable interpreter script under a firstmate root's
-# own bin/ - so that an ordinary brief input that merely carries mode 755, such
-# as a repro script a prior scout wrote under data/<task>/, is still staged.
+# Nothing under a firstmate root's own bin/ is ever a brief input: it is
+# firstmate's own code, invoked or sourced in place. Staging any of it would hand
+# the crewmate a writable copy of trusted code - an enforcement script such as
+# bin/fm-herdr-lab.sh inside the very laboratory it isolates, or a library whose
+# `. "$(dirname "${BASH_SOURCE[0]}")/..."` sibling never came along - and would
+# repoint an invocation that has to work from any directory. The path is the
+# whole test, deliberately: the exec bit and a shebang do not distinguish
+# firstmate code from anything else (a third of bin/ is mode 644 and some of that
+# carries no shebang). An ordinary input outside bin/ that merely carries mode
+# 755, such as a repro script a prior scout wrote under data/<task>/, is still
+# staged.
 stage_is_program() {
   local path=$1 kind rel
   kind=$(stage_kind_for_path "$path" 2>/dev/null || true)
   [ -n "$kind" ] || return 1
   rel=$(stage_rel_for_path "$kind" "$path" 2>/dev/null || true)
   case "$rel" in
-    bin/*) ;;
-    *) return 1 ;;
+    bin/*) return 0 ;;
   esac
-  [ -f "$path" ] && [ -x "$path" ] || return 1
-  [ "$(head -c 2 "$path" 2>/dev/null)" = '#!' ]
+  return 1
 }
 
 stage_path_within_root() {

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -120,7 +120,7 @@
 #   multi-task shell loop (the tool shell is zsh, which does not word-split unquoted
 #   $vars and silently breaks ad-hoc `for ... in $pairs` loops).
 #   Launch templates live in launch_template() below; placeholders replaced before launch:
-#     __BRIEF__    absolute path to data/<task-id>/brief.md
+#     __BRIEF__    absolute path to the task worktree's staged .fm/brief.md
 #     __TURNEND__  absolute path to state/<task-id>.turn-ended (for harnesses whose
 #                  turn-end signal rides the launch command, e.g. codex -c notify=[...])
 #     __PIEXT__    absolute path to state/<task-id>.pi-ext.ts (pi turn-end extension,
@@ -727,7 +727,11 @@ launch_template() {
         printf '%s' 'codex __MODELFLAG____EFFORTFLAG__--dangerously-bypass-approvals-and-sandbox -c "notify=[\"bash\",\"-c\",\"touch __TURNEND__\"]" "$(__OPINPUT__ encode launch-brief < __BRIEF__)"'
       fi
       ;;
-    opencode) printf '%s' 'OPENCODE_CONFIG_CONTENT='\''{"permission":{"*":"allow"}}'\'' opencode __MODELFLAG__--prompt "$(__OPINPUT__ encode launch-brief < __BRIEF__)"' ;;
+    # OpenCode 1.18.10 names the outside-worktree gate
+    # `permission.external_directory`. The value is filled in after the task
+    # worktree and the task's external output directories are known, so this
+    # firstmate-only launch rule never changes the captain's global config.
+    opencode) printf '%s' 'OPENCODE_CONFIG_CONTENT=__OPENCODE_CONFIG__ opencode __MODELFLAG__--prompt "$(__OPINPUT__ encode launch-brief < __BRIEF__)"' ;;
     pi|pi-signed)
       if [ "$kind" = secondmate ]; then
         printf '%s%s' "$harness" ' __MODELFLAG____EFFORTFLAG__-e __PITURNEND__ -e __PIWATCH__ "$(__OPINPUT__ encode launch-brief < __BRIEF__)"'
@@ -1664,6 +1668,423 @@ exclude_path() {
   mkdir -p "$(dirname "$EXCL")"
   grep -qxF "$rel" "$EXCL" 2>/dev/null || echo "$rel" >> "$EXCL"
 }
+
+# OpenCode's external-directory permission is still needed for the deliberate
+# firstmate output writes, but brief inputs should not depend on that gate.
+# Copy the brief and the firstmate-home files it names into the task worktree,
+# then rewrite those input references to the copies before any harness sees the
+# launch envelope. The original status and scout-report paths remain external
+# output paths by contract.
+STAGE_DIR="$WT/.fm"
+STAGE_REF_DIR="$STAGE_DIR/refs"
+STAGE_MAP="$STAGE_DIR/path-map"
+STAGE_SOURCES="$STAGE_DIR/source-list"
+STAGE_BRIEF="$STAGE_DIR/brief.md"
+STAGE_OUTPUT_DIR_REAL="$BRIEF_DIR_REAL"
+STAGE_HOME_REAL=$(cd "$FM_HOME" && pwd -P)
+STAGE_ROOT_REAL=$(cd "$FM_ROOT" && pwd -P)
+STAGE_SECOND_HOME_REAL=
+if [ "$KIND" = secondmate ]; then
+  STAGE_SECOND_HOME_REAL=$(cd "$PROJ_ABS" && pwd -P)
+fi
+
+stage_path_has_glob() {
+  case "$1" in
+    *'*'*|*'?'*|*'['*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+stage_glob_base() {
+  local pattern=$1 prefix
+  prefix=$(printf '%s\n' "$pattern" | sed -E 's/[?*\[].*$//')
+  case "$prefix" in
+    */) prefix=${prefix%/} ;;
+    */*) prefix=${prefix%/*} ;;
+    *) prefix=. ;;
+  esac
+  [ -n "$prefix" ] || prefix=/
+  printf '%s\n' "$prefix"
+}
+
+stage_root_path() {
+  case "$1" in
+    home) printf '%s\n' "$FM_HOME" ;;
+    root) printf '%s\n' "$FM_ROOT" ;;
+    secondmate) printf '%s\n' "${PROJ_ABS:-}" ;;
+    *) return 1 ;;
+  esac
+}
+
+stage_root_real() {
+  case "$1" in
+    home) printf '%s\n' "$STAGE_HOME_REAL" ;;
+    root) printf '%s\n' "$STAGE_ROOT_REAL" ;;
+    secondmate) printf '%s\n' "$STAGE_SECOND_HOME_REAL" ;;
+    *) return 1 ;;
+  esac
+}
+
+stage_kind_for_path() {
+  local path=$1
+  case "$path" in
+    "$FM_HOME"/*|"$STAGE_HOME_REAL"/*) printf 'home\n'; return 0 ;;
+    "$FM_ROOT"/*|"$STAGE_ROOT_REAL"/*) printf 'root\n'; return 0 ;;
+    "$PROJ_ABS"/*|"$STAGE_SECOND_HOME_REAL"/*)
+      [ "$KIND" = secondmate ] || return 1
+      printf 'secondmate\n'
+      return 0
+      ;;
+  esac
+  return 1
+}
+
+stage_rel_for_path() {
+  local kind=$1 path=$2 root root_real rel
+  root=$(stage_root_path "$kind")
+  root_real=$(stage_root_real "$kind")
+  case "$path" in
+    "$root"/*) rel=${path#"$root"/} ;;
+    "$root_real"/*) rel=${path#"$root_real"/} ;;
+    *) return 1 ;;
+  esac
+  case "$rel" in
+    ''|/*|.|..|../*|*/../*) return 1 ;;
+  esac
+  printf '%s\n' "$rel"
+}
+
+stage_rel_for_reference() {
+  local kind=$1 reference=$2
+  if [ "${reference#/}" != "$reference" ]; then
+    stage_rel_for_path "$kind" "$reference"
+  else
+    reference=${reference#./}
+    case "$reference" in
+      ''|/*|.|..|../*|*/../*) return 1 ;;
+    esac
+    printf '%s\n' "$reference"
+  fi
+}
+
+stage_target_for_path() {
+  local kind=$1 path=$2 rel
+  rel=$(stage_rel_for_path "$kind" "$path") || return 1
+  printf '.fm/refs/%s/%s\n' "$kind" "$rel"
+}
+
+stage_target_for_reference() {
+  local kind=$1 reference=$2 rel
+  rel=$(stage_rel_for_reference "$kind" "$reference") || return 1
+  printf '.fm/refs/%s/%s\n' "$kind" "$rel"
+}
+
+stage_path_within_root() {
+  local root=$1 path=$2
+  case "$path" in
+    "$root"|"$root"/*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+stage_target_parent_safe() {
+  local target=$1 parent
+  case "$target" in
+    "$WT"/*) ;;
+    *)
+      echo "error: staged target escapes the task worktree: $target" >&2
+      return 1
+      ;;
+  esac
+  while [ "$target" != "$WT" ]; do
+    if [ -L "$target" ]; then
+      echo "error: staged target traverses a symlink in the task worktree: $target" >&2
+      return 1
+    fi
+    parent=$(dirname "$target")
+    [ "$parent" != "$target" ] || return 1
+    target=$parent
+  done
+}
+
+stage_resolve_file_real() {
+  local path=$1 link target dir
+  while [ -L "$path" ]; do
+    link=$(readlink "$path") || return 1
+    case "$link" in
+      /*) target=$link ;;
+      *) target="$(dirname "$path")/$link" ;;
+    esac
+    path=$target
+  done
+  dir=$(cd "$(dirname "$path")" 2>/dev/null && pwd -P) || return 1
+  printf '%s/%s\n' "$dir" "$(basename "$path")"
+}
+
+stage_add_map() {
+  local old=$1 new=$2
+  [ -n "$old" ] || return 0
+  if ! awk -F '\t' -v old="$old" -v new="$new" \
+    '$1 == old && $2 == new { found=1 } END { exit(found ? 0 : 1) }' \
+    "$STAGE_MAP" 2>/dev/null; then
+    printf '%s\t%s\n' "$old" "$new" >> "$STAGE_MAP"
+  fi
+}
+
+stage_scan_references() {
+  FM_STAGE_HOME="$FM_HOME" \
+  FM_STAGE_HOME_REAL="$STAGE_HOME_REAL" \
+  FM_STAGE_ROOT="$FM_ROOT" \
+  FM_STAGE_ROOT_REAL="$STAGE_ROOT_REAL" \
+  FM_STAGE_SECOND_HOME="${PROJ_ABS:-}" \
+  FM_STAGE_SECOND_HOME_REAL="$STAGE_SECOND_HOME_REAL" \
+    perl -0 - "$1" <<'PERL'
+use strict;
+use warnings;
+
+my %seen;
+sub emit {
+  my ($path) = @_;
+  return if !defined($path) || $path eq "";
+  $path =~ s/\r$//;
+  return if $seen{$path}++;
+  print "$path\n";
+}
+
+local $/;
+$_ = <>;
+
+for my $root (
+  $ENV{FM_STAGE_HOME}, $ENV{FM_STAGE_HOME_REAL},
+  $ENV{FM_STAGE_ROOT}, $ENV{FM_STAGE_ROOT_REAL},
+  $ENV{FM_STAGE_SECOND_HOME}, $ENV{FM_STAGE_SECOND_HOME_REAL},
+) {
+  next if !defined($root) || $root eq "";
+  $root =~ s{/$}{};
+  # Briefs commonly wrap paths in Markdown backticks. Keep spaces inside the
+  # rooted path so a home such as `/Users/.../cfb models/firstmate` is still
+  # recognized, then trim sentence punctuation before staging it.
+  while (/\Q$root\E\/[^`'"()\[\]{}>,;:\r\n]+/g) {
+    my $path = $&;
+    $path =~ s/[.!?]+$//;
+    emit($path);
+  }
+}
+
+while (/(?:^|[^A-Za-z0-9_.\/-])((?:data)\/[A-Za-z0-9._*?\/-]+)/g) {
+  emit($1);
+}
+
+while (/(?:^|[^A-Za-z0-9_.\/-])((?:state)\/[A-Za-z0-9._*?\/-]+\.status)/g) {
+  emit($1);
+}
+PERL
+}
+
+stage_preserve_external() {
+  case "$1" in
+    "${STATE}/${ID}.status"|"${STATE_REAL}/${ID}.status"|\
+    "${FM_HOME}/state/${ID}.status"|"${STAGE_HOME_REAL}/state/${ID}.status")
+      return 0
+      ;;
+  esac
+  case "$1" in
+    "$DATA"/"$ID"/report.md|"$STAGE_OUTPUT_DIR_REAL"/report.md|\
+    "$FM_HOME"/data/"$ID"/report.md|"$STAGE_HOME_REAL"/data/"$ID"/report.md)
+      return 0
+      ;;
+  esac
+  return 1
+}
+
+stage_reference_has_matches() {
+  local source=$1 base match
+  if [ -e "$source" ]; then
+    return 0
+  fi
+  stage_path_has_glob "$source" || return 1
+  base=$(stage_glob_base "$source")
+  [ -d "$base" ] || return 1
+  match=$(find "$base" -type f -path "$source" -print -quit 2>/dev/null || true)
+  [ -n "$match" ]
+}
+
+stage_file() {
+  local source=$1 kind=$2 source_real root_real target_rel target nested_reference
+  source_real=$(stage_resolve_file_real "$source") || {
+    echo "error: cannot resolve staged firstmate reference: $source" >&2
+    return 1
+  }
+  root_real=$(stage_root_real "$kind")
+  stage_path_within_root "$root_real" "$source_real" || {
+    echo "error: staged firstmate reference escapes its home: $source" >&2
+    return 1
+  }
+  target_rel=$(stage_target_for_path "$kind" "$source") || {
+    echo "error: cannot map staged firstmate reference: $source" >&2
+    return 1
+  }
+  if grep -Fqx "$kind$(printf '\t')$source" "$STAGE_SOURCES" 2>/dev/null; then
+    return 0
+  fi
+  target="$WT/$target_rel"
+  stage_target_parent_safe "$target" || return 1
+  mkdir -p "$(dirname "$target")"
+  cp -p "$source" "$target" || {
+    echo "error: cannot stage firstmate reference: $source" >&2
+    return 1
+  }
+  printf '%s\t%s\n' "$kind" "$source" >> "$STAGE_SOURCES"
+  stage_add_map "$source" "$target_rel"
+  while IFS= read -r nested_reference; do
+    [ -n "$nested_reference" ] || continue
+    stage_reference "$nested_reference" || return 1
+  done < <(stage_scan_references "$source")
+}
+
+stage_source() {
+  local source=$1 kind=$2 reference=$3 target_rel base file
+  target_rel=$(stage_target_for_reference "$kind" "$reference") || {
+    echo "error: cannot map firstmate reference: $reference" >&2
+    return 1
+  }
+  if [ -d "$source" ]; then
+    local source_real root_real
+    source_real=$(cd "$source" 2>/dev/null && pwd -P) || return 1
+    root_real=$(stage_root_real "$kind")
+    stage_path_within_root "$root_real" "$source_real" || {
+      echo "error: staged firstmate directory escapes its home: $source" >&2
+      return 1
+    }
+    while IFS= read -r file; do
+      stage_file "$file" "$kind" || return 1
+    done < <(find "$source" -type f -print)
+    stage_add_map "$reference" "$target_rel"
+    return 0
+  fi
+  if [ -f "$source" ]; then
+    stage_add_map "$reference" "$target_rel"
+    stage_file "$source" "$kind"
+    return $?
+  fi
+  stage_path_has_glob "$source" || return 0
+  base=$(stage_glob_base "$source")
+  [ -d "$base" ] || return 0
+  local matched=0
+  while IFS= read -r file; do
+    matched=1
+    stage_file "$file" "$kind" || return 1
+  done < <(find "$base" -type f -path "$source" -print)
+  if [ "$matched" -eq 1 ]; then
+    stage_add_map "$reference" "$target_rel"
+  fi
+  return 0
+}
+
+stage_reference() {
+  local reference=$1 kind root source
+  [ -n "$reference" ] || return 0
+  case "$reference" in
+    state/"$ID".status)
+      stage_add_map "$reference" "$STATE_REAL/$ID.status"
+      return 0
+      ;;
+    data/"$ID"/report.md)
+      stage_add_map "$reference" "$STAGE_OUTPUT_DIR_REAL/report.md"
+      return 0
+      ;;
+  esac
+  stage_preserve_external "$reference" && return 0
+  case "$reference" in
+    /*)
+      kind=$(stage_kind_for_path "$reference" 2>/dev/null || true)
+      [ -n "$kind" ] || return 0
+      stage_source "$reference" "$kind" "$reference"
+      ;;
+    data/*|state/*)
+      # An existing project-relative data or state path belongs to the project,
+      # not the firstmate home, so leave that path untouched.
+      [ -e "$WT/$reference" ] && return 0
+      for kind in home root secondmate; do
+        root=$(stage_root_path "$kind" 2>/dev/null || true)
+        [ -n "$root" ] || continue
+        source="$root/$reference"
+        if stage_reference_has_matches "$source"; then
+          stage_source "$source" "$kind" "$reference"
+          return $?
+        fi
+      done
+      # A missing firstmate data path is not an input file. Leave it untouched
+      # so a future output path is not silently redirected into the worktree.
+      ;;
+  esac
+}
+
+stage_rewrite_file() {
+  FM_STAGE_MAP="$STAGE_MAP" perl -0pi - "$1" <<'PERL'
+use strict;
+use warnings;
+
+open my $map, "<", $ENV{FM_STAGE_MAP} or die "cannot read staged path map: $!\n";
+my @pairs;
+{
+  local $/ = "\n";
+  while (my $line = <$map>) {
+    chomp $line;
+    my ($old, $new) = split(/\t/, $line, 2);
+    push @pairs, [$old, $new] if defined($old) && defined($new);
+  }
+}
+@pairs = sort { length($b->[0]) <=> length($a->[0]) } @pairs;
+for my $pair (@pairs) {
+  my ($old, $new) = @$pair;
+  if ($old =~ m{^(?:data|state)/}) {
+    # A relative output alias can also be the suffix of an absolute path that
+    # must stay external. Rewrite only a path-boundary occurrence.
+    s/(?<![A-Za-z0-9_.\/-])\Q$old\E/$new/g;
+  } else {
+    s/\Q$old\E/$new/g;
+  }
+}
+PERL
+}
+
+stage_launch_brief() {
+  local reference
+  stage_target_parent_safe "$STAGE_REF_DIR/.firstmate-stage" || return 1
+  mkdir -p "$STAGE_REF_DIR"
+  # The staging directory is firstmate-owned and excluded from this worktree's
+  # private Git metadata, so a respawn may refresh its generated files safely.
+  while IFS= read -r reference; do
+    rm -f "$reference"
+  done < <(find "$STAGE_REF_DIR" -type f -print 2>/dev/null)
+  : > "$STAGE_MAP"
+  : > "$STAGE_SOURCES"
+  stage_target_parent_safe "$STAGE_BRIEF" || return 1
+  cp -p "$BRIEF" "$STAGE_BRIEF" || {
+    echo "error: cannot stage launch brief: $BRIEF" >&2
+    return 1
+  }
+  stage_add_map "$BRIEF" '.fm/brief.md'
+  case "$BRIEF" in
+    "$FM_HOME"/*) stage_add_map "${BRIEF#"$FM_HOME"/}" '.fm/brief.md' ;;
+    "$STAGE_HOME_REAL"/*) stage_add_map "${BRIEF#"$STAGE_HOME_REAL"/}" '.fm/brief.md' ;;
+  esac
+  while IFS= read -r reference; do
+    [ -n "$reference" ] || continue
+    stage_reference "$reference" || return 1
+  done < <(stage_scan_references "$BRIEF")
+  stage_rewrite_file "$STAGE_BRIEF"
+  while IFS= read -r reference; do
+    stage_rewrite_file "$reference"
+  done < <(find "$STAGE_REF_DIR" -type f -print)
+  exclude_path '.fm/'
+  BRIEF="$STAGE_BRIEF"
+  BRIEF_DIR_REAL="$WT/.fm"
+  BRIEF_REAL="$STAGE_BRIEF"
+}
+
+stage_launch_brief || exit 1
 if [ "$KIND" != secondmate ]; then
   # Arm the semantic busy-state contract (bin/fm-busy-lib.sh) for every
   # adapter with a verified semantic source. The launch brief sent below IS a
@@ -1980,6 +2401,17 @@ LAUNCH=${LAUNCH//__PIEXT__/$sq_piext}
 LAUNCH=${LAUNCH//__PITURNEND__/$sq_piturnend}
 LAUNCH=${LAUNCH//__PIWATCH__/$sq_piwatch}
 LAUNCH=${LAUNCH//__OPINPUT__/$sq_opinput}
+if [ "$HARNESS" = opencode ]; then
+  # OpenCode 1.18.10 asks external_directory for the target's parent plus `/*`.
+  # Permit only the task's deliberate firstmate output directories; all brief
+  # and report inputs have already been copied under the task worktree.
+  opencode_state_rule=$(json_escape "$STATE_REAL/*")
+  opencode_output_rule=$(json_escape "$STAGE_OUTPUT_DIR_REAL/*")
+  opencode_config=$(printf '{"permission":{"*":"allow","external_directory":{"%s":"allow","%s":"allow"}}}' \
+    "$opencode_state_rule" "$opencode_output_rule")
+  opencode_config_quoted=$(shell_quote "$opencode_config")
+  LAUNCH=${LAUNCH//__OPENCODE_CONFIG__/$opencode_config_quoted}
+fi
 # Crewmate panes are created by a long-lived tmux/herdr daemon that does not
 # inherit firstmate's current environment, so a bare `claude` in the pane falls
 # back to the default ~/.claude store even when firstmate itself runs under a

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -132,12 +132,19 @@
 # task worktree, or the secondmate home for --secondmate) as gitignored
 # .fm/brief.md, together with every firstmate-home or firstmate-repo file it
 # references under .fm/refs/<home|root|secondmate>/, and the brief's input paths
-# are rewritten to those copies, so no launch-visible input needs a directory
-# grant outside that checkout. The deliberate external writes keep their real
-# outside paths: state/<id>.status and a scout's data/<id>/report.md. For
-# opencode, the launch config additionally allows exactly those two output
-# directories through permission.external_directory (opencode 1.18.10), scoped to
-# this launch so the captain's own opencode config is never touched.
+# are rewritten to the absolute path of those copies, so no launch-visible input
+# needs a directory grant outside that checkout. Firstmate programs (anything
+# under a bin/, and any executable) are invoked rather than read, so they are
+# never copied into the writable worktree and keep their real path. Directory
+# references are bounded: a broad firstmate root (bin, data, state, ...) is never
+# staged, and depth/file-count/byte caps skip the rest with a warning. Each map
+# entry rewrites only the exact path it was recorded for, so a staged parent
+# directory can never redirect a longer path underneath it. The deliberate
+# external writes keep their real outside paths: state/<id>.status and a scout's
+# data/<id>/report.md. For opencode, the launch config additionally allows those
+# output directories plus the per-task temp root through
+# permission.external_directory (opencode 1.18.10), scoped to this launch so the
+# captain's own opencode config is never touched.
 # Verified per-harness turn-end hooks are installed automatically where enabled; some live outside the worktree.
 # Kimi uses one surgically installed Firstmate region in $HOME/.kimi-code/config.toml,
 # a firstmate-owned global hook and registry, and a gitignored per-task pointer.
@@ -1663,6 +1670,7 @@ fi
 # targeted knob: TMPDIR is too broad (affects every program's temp, not just Go's).
 TASK_TMP="/tmp/fm-$ID"
 mkdir -p "$TASK_TMP/gotmp"
+TASK_TMP_REAL=$(cd "$TASK_TMP" && pwd -P)
 
 # Per-harness turn-end hook where enabled: a file that touches
 # state/<id>.turn-ended when the agent finishes a turn. Worktree-resident hooks
@@ -1697,6 +1705,22 @@ STAGE_SECOND_HOME_REAL=
 if [ "$KIND" = secondmate ]; then
   STAGE_SECOND_HOME_REAL=$(cd "$PROJ_ABS" && pwd -P)
 fi
+# Staging runs on the critical path between worktree creation and launch, and a
+# firstmate home holds every prior task's brief and report, so a directory
+# reference is bounded rather than copied wholesale: a broad firstmate root is
+# never a staging source, and a directory or a run that exceeds the depth,
+# file-count, or byte budget is skipped with a warning while its real path is
+# left in the brief.
+STAGE_MAX_DIR_DEPTH=${FM_STAGE_MAX_DIR_DEPTH:-3}
+STAGE_MAX_DIR_FILES=${FM_STAGE_MAX_DIR_FILES:-64}
+STAGE_MAX_DIR_BYTES=${FM_STAGE_MAX_DIR_BYTES:-2097152}
+STAGE_MAX_FILES=${FM_STAGE_MAX_FILES:-256}
+STAGE_MAX_BYTES=${FM_STAGE_MAX_BYTES:-8388608}
+STAGE_MAX_SCAN_DEPTH=${FM_STAGE_MAX_SCAN_DEPTH:-4}
+STAGE_FILE_COUNT=0
+STAGE_BYTE_COUNT=0
+STAGE_SCAN_DEPTH=0
+STAGE_BUDGET_WARNED=0
 
 stage_path_has_glob() {
   case "$1" in
@@ -1787,16 +1811,34 @@ stage_rel_for_reference() {
   fi
 }
 
+# Staged targets are absolute paths inside the launch checkout, not worktree-
+# relative ones: a rewritten brief is read by an agent whose working directory
+# is not guaranteed to be the worktree root (a bash tool call from a
+# subdirectory, or an EXIT trap that fires after a `cd`), and an absolute path
+# under $WT still needs no directory grant outside the checkout.
 stage_target_for_path() {
   local kind=$1 path=$2 rel
   rel=$(stage_rel_for_path "$kind" "$path") || return 1
-  printf '.fm/refs/%s/%s\n' "$kind" "$rel"
+  printf '%s/.fm/refs/%s/%s\n' "$WT" "$kind" "$rel"
 }
 
 stage_target_for_reference() {
   local kind=$1 reference=$2 rel
   rel=$(stage_rel_for_reference "$kind" "$reference") || return 1
-  printf '.fm/refs/%s/%s\n' "$kind" "$rel"
+  printf '%s/.fm/refs/%s/%s\n' "$WT" "$kind" "$rel"
+}
+
+# Firstmate helper programs are invoked, never read as input. Staging one would
+# hand the crewmate a writable copy of a trusted enforcement script such as
+# bin/fm-herdr-lab.sh inside the very laboratory that script isolates, and would
+# repoint an invocation that has to work from any directory. Execution needs no
+# read grant, so a program reference keeps its real absolute path.
+stage_is_program() {
+  local path=$1
+  case "$path" in
+    */bin/*) return 0 ;;
+  esac
+  [ -f "$path" ] && [ -x "$path" ]
 }
 
 stage_path_within_root() {
@@ -1941,8 +1983,64 @@ stage_reference_has_matches() {
   [ -n "$match" ]
 }
 
+stage_file_size() {
+  local size
+  size=$(wc -c < "$1" 2>/dev/null || true)
+  size=${size//[!0-9]/}
+  printf '%s\n' "${size:-0}"
+}
+
+# A firstmate root and its top-level buckets are the whole repo, the whole home,
+# or every prior task's brief and report. None of them is a deliberate brief
+# input, so they are never staging sources.
+stage_is_broad_root() {
+  local kind=$1 dir=$2 rel
+  rel=$(stage_rel_for_path "$kind" "$dir" 2>/dev/null || true)
+  [ -n "$rel" ] || return 0
+  case "${rel%/}" in
+    bin|data|state|logs|config|projects|.git) return 0 ;;
+    .git/*) return 0 ;;
+  esac
+  return 1
+}
+
+stage_dir_within_caps() {
+  local dir=$1 count=0 bytes=0 file size
+  if [ -n "$(find "$dir" -mindepth "$((STAGE_MAX_DIR_DEPTH + 1))" -print -quit 2>/dev/null)" ]; then
+    echo "warning: not staging firstmate directory nested deeper than $STAGE_MAX_DIR_DEPTH levels: $dir" >&2
+    return 1
+  fi
+  while IFS= read -r file; do
+    count=$((count + 1))
+    if [ "$count" -gt "$STAGE_MAX_DIR_FILES" ]; then
+      echo "warning: not staging firstmate directory holding more than $STAGE_MAX_DIR_FILES files: $dir" >&2
+      return 1
+    fi
+    size=$(stage_file_size "$file")
+    bytes=$((bytes + size))
+    if [ "$bytes" -gt "$STAGE_MAX_DIR_BYTES" ]; then
+      echo "warning: not staging firstmate directory larger than $STAGE_MAX_DIR_BYTES bytes: $dir" >&2
+      return 1
+    fi
+  done < <(find "$dir" -type f -print)
+  return 0
+}
+
+stage_budget_allows() {
+  local size=$1
+  if [ "$STAGE_FILE_COUNT" -ge "$STAGE_MAX_FILES" ] || [ "$((STAGE_BYTE_COUNT + size))" -gt "$STAGE_MAX_BYTES" ]; then
+    if [ "$STAGE_BUDGET_WARNED" -eq 0 ]; then
+      STAGE_BUDGET_WARNED=1
+      echo "warning: staged firstmate reference budget exhausted ($STAGE_MAX_FILES files / $STAGE_MAX_BYTES bytes); remaining references keep their real paths" >&2
+    fi
+    return 1
+  fi
+  return 0
+}
+
 stage_file() {
-  local source=$1 kind=$2 source_real root_real target_rel target nested_reference
+  local source=$1 kind=$2 source_real root_real target nested_reference size
+  stage_is_program "$source" && return 0
   source_real=$(stage_resolve_file_real "$source") || {
     echo "error: cannot resolve staged firstmate reference: $source" >&2
     return 1
@@ -1952,31 +2050,47 @@ stage_file() {
     echo "error: staged firstmate reference escapes its home: $source" >&2
     return 1
   }
-  target_rel=$(stage_target_for_path "$kind" "$source") || {
+  target=$(stage_target_for_path "$kind" "$source") || {
     echo "error: cannot map staged firstmate reference: $source" >&2
     return 1
   }
   if grep -Fqx "$kind$(printf '\t')$source" "$STAGE_SOURCES" 2>/dev/null; then
     return 0
   fi
-  target="$WT/$target_rel"
+  size=$(stage_file_size "$source")
+  stage_budget_allows "$size" || return 0
   stage_target_parent_safe "$target" || return 1
-  mkdir -p "$(dirname "$target")"
+  mkdir -p "$(dirname "$target")" || {
+    echo "error: cannot create the staged reference directory for: $source" >&2
+    return 1
+  }
   cp -p "$source" "$target" || {
     echo "error: cannot stage firstmate reference: $source" >&2
     return 1
   }
+  STAGE_FILE_COUNT=$((STAGE_FILE_COUNT + 1))
+  STAGE_BYTE_COUNT=$((STAGE_BYTE_COUNT + size))
   printf '%s\t%s\n' "$kind" "$source" >> "$STAGE_SOURCES"
-  stage_add_map "$source" "$target_rel"
+  stage_add_map "$source" "$target"
+  # A staged copy may itself name further firstmate paths, but that recursion is
+  # bounded so a cycle of cross-referencing briefs cannot walk the whole home.
+  [ "$STAGE_SCAN_DEPTH" -lt "$STAGE_MAX_SCAN_DEPTH" ] || return 0
+  STAGE_SCAN_DEPTH=$((STAGE_SCAN_DEPTH + 1))
   while IFS= read -r nested_reference; do
     [ -n "$nested_reference" ] || continue
     stage_reference "$nested_reference" || return 1
   done < <(stage_scan_references "$source")
+  STAGE_SCAN_DEPTH=$((STAGE_SCAN_DEPTH - 1))
+  return 0
 }
 
+# A reference is mapped only once the copy it points at actually exists, so a
+# skipped program, a refused directory, or an exhausted budget leaves the real
+# path in the brief instead of aiming it at a file that was never staged.
 stage_source() {
-  local source=$1 kind=$2 reference=$3 target_rel base file
-  target_rel=$(stage_target_for_reference "$kind" "$reference") || {
+  local source=$1 kind=$2 reference=$3 target base file file_target
+  stage_is_program "$source" && return 0
+  target=$(stage_target_for_reference "$kind" "$reference") || {
     echo "error: cannot map firstmate reference: $reference" >&2
     return 1
   }
@@ -1988,27 +2102,35 @@ stage_source() {
       echo "error: staged firstmate directory escapes its home: $source" >&2
       return 1
     }
+    if stage_is_broad_root "$kind" "$source"; then
+      echo "warning: not staging broad firstmate root: $source" >&2
+      return 0
+    fi
+    stage_dir_within_caps "$source" || return 0
     while IFS= read -r file; do
       stage_file "$file" "$kind" || return 1
     done < <(find "$source" -type f -print)
-    stage_add_map "$reference" "$target_rel"
+    [ -d "$target" ] && stage_add_map "$reference" "$target"
     return 0
   fi
   if [ -f "$source" ]; then
-    stage_add_map "$reference" "$target_rel"
-    stage_file "$source" "$kind"
-    return $?
+    stage_file "$source" "$kind" || return 1
+    [ -f "$target" ] && stage_add_map "$reference" "$target"
+    return 0
   fi
   stage_path_has_glob "$source" || return 0
   base=$(stage_glob_base "$source")
   [ -d "$base" ] || return 0
   local matched=0
   while IFS= read -r file; do
-    matched=1
     stage_file "$file" "$kind" || return 1
+    file_target=$(stage_target_for_path "$kind" "$file" 2>/dev/null || true)
+    if [ -n "$file_target" ] && [ -f "$file_target" ]; then
+      matched=1
+    fi
   done < <(find "$base" -type f -path "$source" -print)
   if [ "$matched" -eq 1 ]; then
-    stage_add_map "$reference" "$target_rel"
+    stage_add_map "$reference" "$target"
   fi
   return 0
 }
@@ -2075,6 +2197,11 @@ if (@pairs) {
   # path it contains, and one single pass so a replacement is never itself
   # rewritten by a later pair.
   @pairs = sort { length($b) <=> length($a) } @pairs;
+  # Every mapping rewrites only the exact path it was recorded for. A staged
+  # directory therefore cannot extend itself over a longer path underneath it,
+  # so a file the brief names inside a staged directory but that was never
+  # staged - a not-yet-created output, or one skipped by the staging caps -
+  # keeps its real path instead of being silently redirected into the worktree.
   my $alternation = join "|", map {
     my $quoted = quotemeta($_);
     # A relative output alias can also be the suffix of an absolute path that
@@ -2084,7 +2211,7 @@ if (@pairs) {
   # Require a trailing path boundary so a path is never rewritten as the
   # prefix of a sibling name or of a longer extension, while a path that ends
   # a sentence still matches.
-  s{($alternation)(?![A-Za-z0-9_-])(?!\.[A-Za-z0-9])}{ $repl{$1} // $1 }ge;
+  s{($alternation)(?![A-Za-z0-9_-])(?!/[A-Za-z0-9_.-])(?!\.[A-Za-z0-9])}{ $repl{$1} // $1 }ge;
 }
 PERL
 }
@@ -2092,14 +2219,29 @@ PERL
 stage_launch_brief() {
   local reference
   stage_target_parent_safe "$STAGE_REF_DIR/.firstmate-stage" || return 1
-  mkdir -p "$STAGE_REF_DIR"
-  # The staging directory is firstmate-owned and excluded from this worktree's
-  # private Git metadata, so a respawn may refresh its generated files safely.
+  mkdir -p "$STAGE_REF_DIR" || {
+    echo "error: cannot create the staged reference directory: $STAGE_REF_DIR" >&2
+    return 1
+  }
+  # The staging directory is firstmate-owned, so a respawn may refresh its
+  # generated files safely. Every unchecked step below fails the spawn instead:
+  # `set -e` is suppressed for this whole function by its `|| exit 1` caller, so
+  # a silent failure here would launch a brief that still names outside-worktree
+  # paths, which is exactly the condition staging exists to remove.
   while IFS= read -r reference; do
-    rm -f "$reference"
+    rm -f "$reference" || {
+      echo "error: cannot clear the stale staged reference: $reference" >&2
+      return 1
+    }
   done < <(find "$STAGE_REF_DIR" -type f -print 2>/dev/null)
-  : > "$STAGE_MAP"
-  : > "$STAGE_SOURCES"
+  : > "$STAGE_MAP" || {
+    echo "error: cannot reset the staged path map: $STAGE_MAP" >&2
+    return 1
+  }
+  : > "$STAGE_SOURCES" || {
+    echo "error: cannot reset the staged source list: $STAGE_SOURCES" >&2
+    return 1
+  }
   # Claim the deliberate external writes first: mapping each one to itself
   # pins it through the single rewrite pass, so no staged parent directory can
   # redirect the status file or the scout report into the worktree.
@@ -2111,19 +2253,28 @@ stage_launch_brief() {
     echo "error: cannot stage launch brief: $BRIEF" >&2
     return 1
   }
-  stage_add_map "$BRIEF" '.fm/brief.md'
+  stage_add_map "$BRIEF" "$STAGE_BRIEF"
   case "$BRIEF" in
-    "$FM_HOME"/*) stage_add_map "${BRIEF#"$FM_HOME"/}" '.fm/brief.md' ;;
-    "$STAGE_HOME_REAL"/*) stage_add_map "${BRIEF#"$STAGE_HOME_REAL"/}" '.fm/brief.md' ;;
+    "$FM_HOME"/*) stage_add_map "${BRIEF#"$FM_HOME"/}" "$STAGE_BRIEF" ;;
+    "$STAGE_HOME_REAL"/*) stage_add_map "${BRIEF#"$STAGE_HOME_REAL"/}" "$STAGE_BRIEF" ;;
   esac
   while IFS= read -r reference; do
     [ -n "$reference" ] || continue
     stage_reference "$reference" || return 1
   done < <(stage_scan_references "$BRIEF")
-  stage_rewrite_file "$STAGE_BRIEF"
+  stage_rewrite_file "$STAGE_BRIEF" || {
+    echo "error: cannot rewrite the staged launch brief: $STAGE_BRIEF" >&2
+    return 1
+  }
   while IFS= read -r reference; do
-    stage_rewrite_file "$reference"
+    stage_rewrite_file "$reference" || {
+      echo "error: cannot rewrite the staged firstmate reference: $reference" >&2
+      return 1
+    }
   done < <(find "$STAGE_REF_DIR" -type f -print)
+  # `git rev-parse --git-path info/exclude` resolves to the COMMON git dir, so
+  # this entry ignores `.fm/` repo-wide for every checkout of the project, not
+  # only for this worktree.
   exclude_path '.fm/'
   BRIEF="$STAGE_BRIEF"
   BRIEF_DIR_REAL="$WT/.fm"
@@ -2449,12 +2600,15 @@ LAUNCH=${LAUNCH//__PIWATCH__/$sq_piwatch}
 LAUNCH=${LAUNCH//__OPINPUT__/$sq_opinput}
 if [ "$HARNESS" = opencode ]; then
   # OpenCode 1.18.10 asks external_directory for the target's parent plus `/*`.
-  # Permit only the task's deliberate firstmate output directories; all brief
-  # and report inputs have already been copied under the task worktree.
+  # Permit only the task's deliberate outside-worktree writes - its status file,
+  # its report directory, and the per-task temp root this spawn creates and
+  # exports as GOTMPDIR; all brief and report inputs have already been copied
+  # under the task worktree.
   opencode_state_rule=$(json_escape "$STATE_REAL/*")
   opencode_output_rule=$(json_escape "$STAGE_OUTPUT_DIR_REAL/*")
-  opencode_config=$(printf '{"permission":{"*":"allow","external_directory":{"%s":"allow","%s":"allow"}}}' \
-    "$opencode_state_rule" "$opencode_output_rule")
+  opencode_tmp_rule=$(json_escape "$TASK_TMP_REAL/*")
+  opencode_config=$(printf '{"permission":{"*":"allow","external_directory":{"%s":"allow","%s":"allow","%s":"allow"}}}' \
+    "$opencode_state_rule" "$opencode_output_rule" "$opencode_tmp_rule")
   opencode_config_quoted=$(shell_quote "$opencode_config")
   LAUNCH=${LAUNCH//__OPENCODE_CONFIG__/$opencode_config_quoted}
 fi

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -133,16 +133,20 @@
 # .fm/brief.md, together with every firstmate-home or firstmate-repo file it
 # references under .fm/refs/<home|root|secondmate>/, and the brief's input paths
 # are rewritten to the absolute path of those copies, so no launch-visible input
-# needs a directory grant outside that checkout. Firstmate programs (anything
-# under a bin/, and any executable) are invoked rather than read, so they are
-# never copied into the writable worktree and keep their real path. Directory
-# references are bounded: a broad firstmate root (bin, data, state, ...) is never
-# staged, and depth/file-count/byte caps skip the rest with a warning. Each map
-# entry rewrites only the exact path it was recorded for, so a staged parent
-# directory can never redirect a longer path underneath it. The deliberate
-# external writes keep their real outside paths: state/<id>.status and a scout's
-# data/<id>/report.md. For opencode, the launch config additionally allows those
-# output directories plus the per-task temp root through
+# needs a directory grant outside that checkout. A trusted firstmate enforcement
+# script (an executable interpreter script under a firstmate root's own bin/) is
+# invoked rather than read, so it is never copied into the writable worktree and
+# keeps its real path; an ordinary input that merely carries mode 755 is still
+# staged. Directory references are bounded: a broad firstmate root (bin, data,
+# state, ...) is never staged, and depth/file-count/byte caps skip the rest with
+# a warning. A directory or glob reference is rewritten only when every file it
+# covers was staged, so a partial copy is reported rather than silently handed
+# over. Each map entry rewrites only the exact path it was recorded for, so a
+# staged parent directory can never redirect a longer path underneath it. The
+# deliberate external writes keep their real outside paths: state/<id>.status and
+# a scout's data/<id>/report.md. For opencode, the launch config additionally
+# allows those output directories plus the per-task temp root - in every spelling
+# the crewmate can reach them by - through
 # permission.external_directory (opencode 1.18.10), scoped to this launch so the
 # captain's own opencode config is never touched.
 # Verified per-harness turn-end hooks are installed automatically where enabled; some live outside the worktree.
@@ -1717,6 +1721,7 @@ STAGE_MAX_DIR_BYTES=${FM_STAGE_MAX_DIR_BYTES:-2097152}
 STAGE_MAX_FILES=${FM_STAGE_MAX_FILES:-256}
 STAGE_MAX_BYTES=${FM_STAGE_MAX_BYTES:-8388608}
 STAGE_MAX_SCAN_DEPTH=${FM_STAGE_MAX_SCAN_DEPTH:-4}
+STAGE_MISSING_NAMED=${FM_STAGE_MISSING_NAMED:-5}
 STAGE_FILE_COUNT=0
 STAGE_BYTE_COUNT=0
 STAGE_SCAN_DEPTH=0
@@ -1828,17 +1833,25 @@ stage_target_for_reference() {
   printf '%s/.fm/refs/%s/%s\n' "$WT" "$kind" "$rel"
 }
 
-# Firstmate helper programs are invoked, never read as input. Staging one would
-# hand the crewmate a writable copy of a trusted enforcement script such as
+# A trusted firstmate enforcement script is invoked, never read as input.
+# Staging one would hand the crewmate a writable copy of a script such as
 # bin/fm-herdr-lab.sh inside the very laboratory that script isolates, and would
 # repoint an invocation that has to work from any directory. Execution needs no
-# read grant, so a program reference keeps its real absolute path.
+# read grant, so such a reference keeps its real absolute path. The test is
+# deliberately narrow - an executable interpreter script under a firstmate root's
+# own bin/ - so that an ordinary brief input that merely carries mode 755, such
+# as a repro script a prior scout wrote under data/<task>/, is still staged.
 stage_is_program() {
-  local path=$1
-  case "$path" in
-    */bin/*) return 0 ;;
+  local path=$1 kind rel
+  kind=$(stage_kind_for_path "$path" 2>/dev/null || true)
+  [ -n "$kind" ] || return 1
+  rel=$(stage_rel_for_path "$kind" "$path" 2>/dev/null || true)
+  case "$rel" in
+    bin/*) ;;
+    *) return 1 ;;
   esac
-  [ -f "$path" ] && [ -x "$path" ]
+  [ -f "$path" ] && [ -x "$path" ] || return 1
+  [ "$(head -c 2 "$path" 2>/dev/null)" = '#!' ]
 }
 
 stage_path_within_root() {
@@ -2038,9 +2051,11 @@ stage_budget_allows() {
   return 0
 }
 
+# Exit status: 0 staged (or already staged), 2 deliberately not staged so the
+# caller keeps the real path, 1 a hard failure that must fail the spawn.
 stage_file() {
   local source=$1 kind=$2 source_real root_real target nested_reference size
-  stage_is_program "$source" && return 0
+  stage_is_program "$source" && return 2
   source_real=$(stage_resolve_file_real "$source") || {
     echo "error: cannot resolve staged firstmate reference: $source" >&2
     return 1
@@ -2058,7 +2073,7 @@ stage_file() {
     return 0
   fi
   size=$(stage_file_size "$source")
-  stage_budget_allows "$size" || return 0
+  stage_budget_allows "$size" || return 2
   stage_target_parent_safe "$target" || return 1
   mkdir -p "$(dirname "$target")" || {
     echo "error: cannot create the staged reference directory for: $source" >&2
@@ -2084,11 +2099,33 @@ stage_file() {
   return 0
 }
 
-# A reference is mapped only once the copy it points at actually exists, so a
-# skipped program, a refused directory, or an exhausted budget leaves the real
-# path in the brief instead of aiming it at a file that was never staged.
+# A reference is rewritten only when EVERY file it covers was staged. A skipped
+# enforcement script, a refused directory, or an exhausted budget leaves the real
+# path in the brief and says exactly what is missing, so the agent is never sent
+# to a staged copy that silently lacks the file it was sent for.
+stage_missing_reset() {
+  STAGE_MISSING_COUNT=0
+  STAGE_MISSING_LIST=
+}
+
+stage_missing_add() {
+  STAGE_MISSING_COUNT=$((STAGE_MISSING_COUNT + 1))
+  if [ "$STAGE_MISSING_COUNT" -le "$STAGE_MISSING_NAMED" ]; then
+    STAGE_MISSING_LIST=${STAGE_MISSING_LIST:+$STAGE_MISSING_LIST, }$1
+  fi
+}
+
+stage_missing_warn() {
+  local reference=$1 suffix=
+  [ "$STAGE_MISSING_COUNT" -gt "$STAGE_MISSING_NAMED" ] \
+    && suffix=" (and $((STAGE_MISSING_COUNT - STAGE_MISSING_NAMED)) more)"
+  echo "warning: keeping the real path for firstmate reference $reference; $STAGE_MISSING_COUNT file(s) under it were not staged: $STAGE_MISSING_LIST$suffix" >&2
+}
+
 stage_source() {
-  local source=$1 kind=$2 reference=$3 target base file file_target
+  local source=$1 kind=$2 reference=$3 target base file rc matched
+  local STAGE_MISSING_COUNT STAGE_MISSING_LIST
+  stage_missing_reset
   stage_is_program "$source" && return 0
   target=$(stage_target_for_reference "$kind" "$reference") || {
     echo "error: cannot map firstmate reference: $reference" >&2
@@ -2108,27 +2145,45 @@ stage_source() {
     fi
     stage_dir_within_caps "$source" || return 0
     while IFS= read -r file; do
-      stage_file "$file" "$kind" || return 1
+      stage_file "$file" "$kind"
+      rc=$?
+      case "$rc" in
+        0) ;;
+        2) stage_missing_add "$file" ;;
+        *) return 1 ;;
+      esac
     done < <(find "$source" -type f -print)
+    if [ "$STAGE_MISSING_COUNT" -gt 0 ]; then
+      stage_missing_warn "$reference"
+      return 0
+    fi
     [ -d "$target" ] && stage_add_map "$reference" "$target"
     return 0
   fi
   if [ -f "$source" ]; then
-    stage_file "$source" "$kind" || return 1
-    [ -f "$target" ] && stage_add_map "$reference" "$target"
+    stage_file "$source" "$kind"
+    rc=$?
+    [ "$rc" -eq 1 ] && return 1
+    [ "$rc" -eq 0 ] && [ -f "$target" ] && stage_add_map "$reference" "$target"
     return 0
   fi
   stage_path_has_glob "$source" || return 0
   base=$(stage_glob_base "$source")
   [ -d "$base" ] || return 0
-  local matched=0
+  matched=0
   while IFS= read -r file; do
-    stage_file "$file" "$kind" || return 1
-    file_target=$(stage_target_for_path "$kind" "$file" 2>/dev/null || true)
-    if [ -n "$file_target" ] && [ -f "$file_target" ]; then
-      matched=1
-    fi
+    stage_file "$file" "$kind"
+    rc=$?
+    case "$rc" in
+      0) matched=1 ;;
+      2) stage_missing_add "$file" ;;
+      *) return 1 ;;
+    esac
   done < <(find "$base" -type f -path "$source" -print)
+  if [ "$STAGE_MISSING_COUNT" -gt 0 ]; then
+    stage_missing_warn "$reference"
+    return 0
+  fi
   if [ "$matched" -eq 1 ]; then
     stage_add_map "$reference" "$target"
   fi
@@ -2604,11 +2659,23 @@ if [ "$HARNESS" = opencode ]; then
   # its report directory, and the per-task temp root this spawn creates and
   # exports as GOTMPDIR; all brief and report inputs have already been copied
   # under the task worktree.
-  opencode_state_rule=$(json_escape "$STATE_REAL/*")
-  opencode_output_rule=$(json_escape "$STAGE_OUTPUT_DIR_REAL/*")
-  opencode_tmp_rule=$(json_escape "$TASK_TMP_REAL/*")
-  opencode_config=$(printf '{"permission":{"*":"allow","external_directory":{"%s":"allow","%s":"allow","%s":"allow"}}}' \
-    "$opencode_state_rule" "$opencode_output_rule" "$opencode_tmp_rule")
+  # Every spelling the crewmate can reach a granted directory by is listed, not
+  # just the physically resolved one: /tmp is a symlink to /private/tmp on
+  # darwin and GOTMPDIR is exported with the logical /tmp spelling, and a
+  # firstmate home reached through a symlink hands out a logical status path the
+  # resolved rule would not match. Duplicates collapse, so the common case where
+  # the two agree still emits one rule per directory.
+  opencode_rules=
+  while IFS= read -r opencode_dir; do
+    [ -n "$opencode_dir" ] || continue
+    opencode_rule=$(json_escape "${opencode_dir%/}/*")
+    opencode_rules=${opencode_rules:+$opencode_rules,}$(printf '"%s":"allow"' "$opencode_rule")
+  done < <(printf '%s\n' \
+    "$STATE" "$STATE_REAL" "$FM_HOME/state" "$STAGE_HOME_REAL/state" \
+    "$DATA/$ID" "$STAGE_OUTPUT_DIR_REAL" "$FM_HOME/data/$ID" "$STAGE_HOME_REAL/data/$ID" \
+    "$TASK_TMP" "$TASK_TMP_REAL" \
+    | awk 'NF { sub(/\/+$/, "", $0); if (!seen[$0]++) print }')
+  opencode_config=$(printf '{"permission":{"*":"allow","external_directory":{%s}}}' "$opencode_rules")
   opencode_config_quoted=$(shell_quote "$opencode_config")
   LAUNCH=${LAUNCH//__OPENCODE_CONFIG__/$opencode_config_quoted}
 fi

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1711,7 +1711,12 @@ stage_root_path() {
   case "$1" in
     home) printf '%s\n' "$FM_HOME" ;;
     root) printf '%s\n' "$FM_ROOT" ;;
-    secondmate) printf '%s\n' "${PROJ_ABS:-}" ;;
+    secondmate)
+      # Only a secondmate spawn owns a firstmate home at PROJ_ABS. On a crewmate
+      # spawn PROJ_ABS is the project checkout, which is not a staging root.
+      [ "$KIND" = secondmate ] || return 1
+      printf '%s\n' "${PROJ_ABS:-}"
+      ;;
     *) return 1 ;;
   esac
 }
@@ -1720,7 +1725,10 @@ stage_root_real() {
   case "$1" in
     home) printf '%s\n' "$STAGE_HOME_REAL" ;;
     root) printf '%s\n' "$STAGE_ROOT_REAL" ;;
-    secondmate) printf '%s\n' "$STAGE_SECOND_HOME_REAL" ;;
+    secondmate)
+      [ "$KIND" = secondmate ] || return 1
+      printf '%s\n' "$STAGE_SECOND_HOME_REAL"
+      ;;
     *) return 1 ;;
   esac
 }
@@ -1741,8 +1749,10 @@ stage_kind_for_path() {
 
 stage_rel_for_path() {
   local kind=$1 path=$2 root root_real rel
-  root=$(stage_root_path "$kind")
-  root_real=$(stage_root_real "$kind")
+  root=$(stage_root_path "$kind") || return 1
+  root_real=$(stage_root_real "$kind") || return 1
+  [ -n "$root" ] || return 1
+  [ -n "$root_real" ] || return 1
   case "$path" in
     "$root"/*) rel=${path#"$root"/} ;;
     "$root_real"/*) rel=${path#"$root_real"/} ;;
@@ -1781,6 +1791,9 @@ stage_target_for_reference() {
 
 stage_path_within_root() {
   local root=$1 path=$2
+  # An empty root would degenerate into the pattern `/*` and accept every
+  # absolute path, so a missing root is never a containment match.
+  [ -n "$root" ] || return 1
   case "$path" in
     "$root"|"$root"/*) return 0 ;;
     *) return 1 ;;
@@ -1881,19 +1894,28 @@ while (/(?:^|[^A-Za-z0-9_.\/-])((?:state)\/[A-Za-z0-9._*?\/-]+\.status)/g) {
 PERL
 }
 
+# The deliberate external writes, in every spelling a brief can name them by.
+# This is the single source of truth for both "never stage this" and "never
+# rewrite this", so a staged parent directory cannot redirect an output path.
+stage_external_outputs() {
+  printf '%s\n' \
+    "${STATE}/${ID}.status" \
+    "${STATE_REAL}/${ID}.status" \
+    "${FM_HOME}/state/${ID}.status" \
+    "${STAGE_HOME_REAL}/state/${ID}.status" \
+    "${DATA}/${ID}/report.md" \
+    "${STAGE_OUTPUT_DIR_REAL}/report.md" \
+    "${FM_HOME}/data/${ID}/report.md" \
+    "${STAGE_HOME_REAL}/data/${ID}/report.md"
+}
+
 stage_preserve_external() {
-  case "$1" in
-    "${STATE}/${ID}.status"|"${STATE_REAL}/${ID}.status"|\
-    "${FM_HOME}/state/${ID}.status"|"${STAGE_HOME_REAL}/state/${ID}.status")
+  local candidate
+  while IFS= read -r candidate; do
+    if [ "$candidate" = "$1" ]; then
       return 0
-      ;;
-  esac
-  case "$1" in
-    "$DATA"/"$ID"/report.md|"$STAGE_OUTPUT_DIR_REAL"/report.md|\
-    "$FM_HOME"/data/"$ID"/report.md|"$STAGE_HOME_REAL"/data/"$ID"/report.md)
-      return 0
-      ;;
-  esac
+    fi
+  done < <(stage_external_outputs)
   return 1
 }
 
@@ -1915,7 +1937,7 @@ stage_file() {
     echo "error: cannot resolve staged firstmate reference: $source" >&2
     return 1
   }
-  root_real=$(stage_root_real "$kind")
+  root_real=$(stage_root_real "$kind" 2>/dev/null || true)
   stage_path_within_root "$root_real" "$source_real" || {
     echo "error: staged firstmate reference escapes its home: $source" >&2
     return 1
@@ -1951,7 +1973,7 @@ stage_source() {
   if [ -d "$source" ]; then
     local source_real root_real
     source_real=$(cd "$source" 2>/dev/null && pwd -P) || return 1
-    root_real=$(stage_root_real "$kind")
+    root_real=$(stage_root_real "$kind" 2>/dev/null || true)
     stage_path_within_root "$root_real" "$source_real" || {
       echo "error: staged firstmate directory escapes its home: $source" >&2
       return 1
@@ -2026,25 +2048,33 @@ use strict;
 use warnings;
 
 open my $map, "<", $ENV{FM_STAGE_MAP} or die "cannot read staged path map: $!\n";
-my @pairs;
+my (@pairs, %repl);
 {
   local $/ = "\n";
   while (my $line = <$map>) {
     chomp $line;
     my ($old, $new) = split(/\t/, $line, 2);
-    push @pairs, [$old, $new] if defined($old) && defined($new);
+    next if !defined($old) || !defined($new) || $old eq "";
+    next if exists $repl{$old};
+    $repl{$old} = $new;
+    push @pairs, $old;
   }
 }
-@pairs = sort { length($b->[0]) <=> length($a->[0]) } @pairs;
-for my $pair (@pairs) {
-  my ($old, $new) = @$pair;
-  if ($old =~ m{^(?:data|state)/}) {
+if (@pairs) {
+  # Longest first so a staged parent directory never wins over the longer
+  # path it contains, and one single pass so a replacement is never itself
+  # rewritten by a later pair.
+  @pairs = sort { length($b) <=> length($a) } @pairs;
+  my $alternation = join "|", map {
+    my $quoted = quotemeta($_);
     # A relative output alias can also be the suffix of an absolute path that
-    # must stay external. Rewrite only a path-boundary occurrence.
-    s/(?<![A-Za-z0-9_.\/-])\Q$old\E/$new/g;
-  } else {
-    s/\Q$old\E/$new/g;
-  }
+    # must stay external, so it needs the stricter leading boundary.
+    m{^/} ? "(?<![A-Za-z0-9_.-])$quoted" : "(?<![A-Za-z0-9_./-])$quoted";
+  } @pairs;
+  # Require a trailing path boundary so a path is never rewritten as the
+  # prefix of a sibling name or of a longer extension, while a path that ends
+  # a sentence still matches.
+  s{($alternation)(?![A-Za-z0-9_-])(?!\.[A-Za-z0-9])}{ $repl{$1} // $1 }ge;
 }
 PERL
 }
@@ -2060,6 +2090,12 @@ stage_launch_brief() {
   done < <(find "$STAGE_REF_DIR" -type f -print 2>/dev/null)
   : > "$STAGE_MAP"
   : > "$STAGE_SOURCES"
+  # Claim the deliberate external writes first: mapping each one to itself
+  # pins it through the single rewrite pass, so no staged parent directory can
+  # redirect the status file or the scout report into the worktree.
+  while IFS= read -r reference; do
+    stage_add_map "$reference" "$reference"
+  done < <(stage_external_outputs)
   stage_target_parent_safe "$STAGE_BRIEF" || return 1
   cp -p "$BRIEF" "$STAGE_BRIEF" || {
     echo "error: cannot stage launch brief: $BRIEF" >&2

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1687,6 +1687,14 @@ exclude_path() {
   local rel=$1 EXCL
   EXCL=$(git -C "$WT" rev-parse --git-path info/exclude 2>/dev/null || true)
   [ -n "$EXCL" ] || return 0
+  # git prints --git-path relative to its own working directory, so a checkout
+  # whose git dir is a plain `.git` (a secondmate home clone) answers
+  # `.git/info/exclude`, while a linked worktree answers an absolute common-dir
+  # path. fm-spawn.sh never cds into $WT, so a relative answer has to be
+  # anchored there - otherwise the entry lands in a stray .git next to the
+  # spawn's cwd and the launch checkout reads dirty to every sync and teardown
+  # dirty check.
+  case "$EXCL" in /*) ;; *) EXCL="$WT/$EXCL" ;; esac
   mkdir -p "$(dirname "$EXCL")"
   grep -qxF "$rel" "$EXCL" 2>/dev/null || echo "$rel" >> "$EXCL"
 }

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -128,6 +128,16 @@
 #     __PITURNEND__ absolute path to .pi/extensions/fm-primary-turnend-guard.ts in a pi secondmate home
 #     __PIWATCH__   absolute path to .pi/extensions/fm-primary-pi-watch.ts in a pi secondmate home
 #     __OPINPUT__   absolute path to the canonical operational-input encoder
+# Brief staging: before launch, the brief is copied into the launch checkout (the
+# task worktree, or the secondmate home for --secondmate) as gitignored
+# .fm/brief.md, together with every firstmate-home or firstmate-repo file it
+# references under .fm/refs/<home|root|secondmate>/, and the brief's input paths
+# are rewritten to those copies, so no launch-visible input needs a directory
+# grant outside that checkout. The deliberate external writes keep their real
+# outside paths: state/<id>.status and a scout's data/<id>/report.md. For
+# opencode, the launch config additionally allows exactly those two output
+# directories through permission.external_directory (opencode 1.18.10), scoped to
+# this launch so the captain's own opencode config is never touched.
 # Verified per-harness turn-end hooks are installed automatically where enabled; some live outside the worktree.
 # Kimi uses one surgically installed Firstmate region in $HOME/.kimi-code/config.toml,
 # a firstmate-owned global hook and registry, and a gitignored per-task pointer.

--- a/tests/fm-kimi-harness.test.sh
+++ b/tests/fm-kimi-harness.test.sh
@@ -164,7 +164,7 @@ run_spawn() {
     FM_FAKE_KIMI_SWALLOWED="$case_dir/kimi.swallowed" \
     FM_FAKE_KIMI_SWALLOW_FIRST="${FM_FAKE_KIMI_SWALLOW_FIRST:-no}" \
     FM_FAKE_TMUX_CALL_LOG="$case_dir/tmux-calls.log" \
-    FM_FAKE_BRIEF_REAL="$(cd "$home/data/$id" && pwd -P)/brief.md" \
+    FM_FAKE_BRIEF_REAL="$wt/.fm/brief.md" \
     FM_KIMI_READY_POLLS=2 FM_KIMI_DELIVERY_POLLS=2 FM_KIMI_POLL_INTERVAL=0 \
     PATH="$fakebin:$BASE_PATH" \
     "$SPAWN" "$id" "$proj" --harness kimi --mode no-mistakes --yolo off "$@" 2>&1
@@ -198,7 +198,7 @@ test_kimi_launch_then_send_is_verified() {
   assert_not_contains "$launch" "turn-ended" "kimi launch embedded a turn-end path"
   assert_not_contains "$launch" "__TURNEND__" "kimi launch retained a turn-end placeholder"
 
-  brief_real="$(cd "$HOME_DIR/data/$id" && pwd -P)/brief.md"
+  brief_real="$WT_DIR/.fm/brief.md"
   pointer=$(cat "$CASE_DIR/pointer.log")
   [ "$pointer" = "Read the brief at $brief_real and follow it exactly." ] \
     || fail "kimi pointer was not the exact absolute-path-only instruction: $pointer"

--- a/tests/fm-secondmate-lifecycle-e2e.test.sh
+++ b/tests/fm-secondmate-lifecycle-e2e.test.sh
@@ -126,7 +126,16 @@ phase_spawn() {
   assert_grep "FM_HOME='$SUB_ABS'" "$LOG" "secondmate launch did not set FM_HOME to the subhome"
   assert_grep 'FM_ROOT_OVERRIDE= FM_STATE_OVERRIDE= FM_DATA_OVERRIDE= FM_PROJECTS_OVERRIDE=' "$LOG" "launch did not clear operational overrides"
   assert_grep 'FM_CONFIG_OVERRIDE=' "$LOG" "launch did not clear the config override"
-  assert_grep "$SUB_ABS/data/charter.md" "$LOG" "launch did not use the persistent charter"
+  # The launch reads the charter staged inside the subhome (bin/fm-spawn.sh brief
+  # staging), so no launch-visible input sits outside the checkout. It must still
+  # be this home's persistent charter, not an ephemeral or parent-home brief, and
+  # the staged copy must stay out of git's view so the home reads clean to every
+  # sync and teardown dirty check.
+  assert_grep "$SUB_ABS/.fm/brief.md" "$LOG" "launch did not use the staged persistent charter"
+  cmp -s "$SUB_ABS/data/charter.md" "$SUB_ABS/.fm/brief.md" \
+    || fail "the staged launch brief is not the persistent charter"
+  [ -z "$(git -C "$SUB_ABS" status --porcelain)" ] \
+    || fail "spawn left the secondmate home dirty: $(git -C "$SUB_ABS" status --porcelain)"
   assert_no_grep 'notify=' "$LOG" "secondmate codex launch included the parent turn-end notify hook"
   assert_no_grep 'turn-ended' "$LOG" "secondmate codex launch referenced a parent turn-ended signal"
   assert_no_grep 'treehouse get' "$LOG" "secondmate spawn ran a project treehouse get"

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -47,7 +47,7 @@ SH
 }
 
 make_spawn_case() {
-  local name=$1 harness=$2 case_dir home proj wt fakebin launchlog id
+  local name=$1 harness=$2 case_dir home proj wt fakebin launchlog id branch_name
   shift 2
   case_dir="$TMP_ROOT/$name"
   home="$case_dir/home"
@@ -57,7 +57,8 @@ make_spawn_case() {
   fakebin=$(make_spawn_fakebin "$case_dir/fake")
   mkdir -p "$home/data" "$home/projects" "$home/state" "$home/config"
   printf '%s\n' "$harness" > "$home/config/crew-harness"
-  fm_git_worktree "$proj" "$wt" "wt-$name"
+  branch_name=${name//[^A-Za-z0-9_-]/-}
+  fm_git_worktree "$proj" "$wt" "wt-$branch_name"
   touch "$home/state/.last-watcher-beat"
   for id in "$@"; do
     mkdir -p "$home/data/$id"
@@ -129,7 +130,7 @@ test_no_profile_keeps_claude_profile_defaults() {
   assert_meta_profile "$HOME_DIR/state/$id.meta" claude default default
 
   launch=$(cat "$LAUNCH_LOG")
-  expected="CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions \"\$('${ROOT}/bin/fm-operational-input.sh' encode launch-brief < '$HOME_DIR/data/$id/brief.md')\""
+  expected="CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions \"\$('${ROOT}/bin/fm-operational-input.sh' encode launch-brief < '$WT_DIR/.fm/brief.md')\""
   [ "$launch" = "$expected" ] || fail "no-profile claude launch did not use the canonical launch kind"$'\n'"expected: $expected"$'\n'"actual:   $launch"
   pass "no --model/--effort records defaults and types the claude launch instructions"
 }
@@ -158,8 +159,8 @@ test_relative_home_overrides_launch_with_absolute_cross_process_paths() {
   launch=$(cat "$LAUNCH_LOG")
   assert_contains "$launch" "-e '$home_real/state/$id.pi-ext.ts'" \
     "relative FM_STATE_OVERRIDE leaked into Pi's cross-process extension path"
-  assert_contains "$launch" "< '$home_real/data/$id/brief.md'" \
-    "relative FM_DATA_OVERRIDE leaked into the cross-process brief path"
+  assert_contains "$launch" "< '$WT_DIR/.fm/brief.md'" \
+    "relative FM_DATA_OVERRIDE did not stage the brief inside the worktree"
   pass "relative home overrides ignore CDPATH and become absolute before spawn launch construction"
 }
 
@@ -187,8 +188,8 @@ test_home_defaults_preserve_absolute_or_resolve_relative_paths() {
   launch=$(cat "$LAUNCH_LOG")
   assert_contains "$launch" "-e '$home_real/state/$relative_id.pi-ext.ts'" \
     "relative FM_HOME leaked into Pi's default cross-process extension path"
-  assert_contains "$launch" "< '$home_real/data/$relative_id/brief.md'" \
-    "relative FM_HOME leaked into the default cross-process brief path"
+  assert_contains "$launch" "< '$WT_DIR/.fm/brief.md'" \
+    "relative FM_HOME did not stage the brief inside the worktree"
 
   linked_home="$CASE_DIR/home-link"
   ln -s "$HOME_DIR" "$linked_home"
@@ -207,8 +208,8 @@ test_home_defaults_preserve_absolute_or_resolve_relative_paths() {
   launch=$(cat "$LAUNCH_LOG")
   assert_contains "$launch" "-e '$linked_home/state/$absolute_id.pi-ext.ts'" \
     "absolute FM_HOME spelling changed in Pi's default cross-process extension path"
-  assert_contains "$launch" "< '$linked_home/data/$absolute_id/brief.md'" \
-    "absolute FM_HOME spelling changed in the default cross-process brief path"
+  assert_contains "$launch" "< '$WT_DIR/.fm/brief.md'" \
+    "absolute FM_HOME did not stage the brief inside the worktree"
   pass "FM_HOME defaults resolve relative paths and preserve absolute spellings"
 }
 
@@ -235,8 +236,8 @@ test_absolute_override_spelling_is_preserved_in_launch_paths() {
   launch=$(cat "$LAUNCH_LOG")
   assert_contains "$launch" "-e '$linked_home/state/$id.pi-ext.ts'" \
     "absolute FM_STATE_OVERRIDE spelling changed in Pi's cross-process extension path"
-  assert_contains "$launch" "< '$linked_home/data/$id/brief.md'" \
-    "absolute FM_DATA_OVERRIDE spelling changed in the cross-process brief path"
+  assert_contains "$launch" "< '$WT_DIR/.fm/brief.md'" \
+    "absolute FM_DATA_OVERRIDE did not stage the brief inside the worktree"
   pass "absolute override spellings are preserved in spawn launch paths"
 }
 
@@ -470,7 +471,7 @@ test_grok_omits_invalid_xhigh_reasoning_effort() {
 }
 
 test_opencode_threads_model_and_ignores_effort_axis() {
-  local rec id out status launch
+  local rec id out status launch config home_real
   id=profile-opencode-z7
   rec=$(make_spawn_case profile-opencode opencode "$id")
   read_case_record "$rec"
@@ -480,12 +481,67 @@ test_opencode_threads_model_and_ignores_effort_axis() {
   expect_code 0 "$status" "opencode spawn with model and ignored effort should succeed"
   assert_meta_profile "$HOME_DIR/state/$id.meta" opencode anthropic/claude-sonnet-4-5 high
   launch=$(cat "$LAUNCH_LOG")
+  home_real=$(cd "$HOME_DIR" && pwd -P)
   assert_contains "$launch" "opencode --model 'anthropic/claude-sonnet-4-5' --prompt" \
     "opencode launch did not thread model"
+  config="OPENCODE_CONFIG_CONTENT='{\"permission\":{\"*\":\"allow\",\"external_directory\":{\"$home_real/state/*\":\"allow\",\"$home_real/data/$id/*\":\"allow\"}}}'"
+  assert_contains "$launch" "$config" \
+    "opencode launch did not scope external_directory to the task's output paths"
+  assert_contains "$launch" "< '$WT_DIR/.fm/brief.md'" \
+    "opencode launch did not read the staged brief"
   assert_not_contains "$launch" "--effort" "opencode launch must not pass unsupported --effort"
   assert_not_contains "$launch" "--variant" "opencode launch must not pass run-only --variant"
   assert_not_contains "$launch" "--thinking" "opencode launch must not pass pi thinking flag"
   pass "opencode receives --model and omits the unsupported effort axis"
+}
+
+test_spawn_stages_firstmate_brief_and_references() {
+  local rec id out status launch staged
+  id=profile-staged-z20
+  rec=$(make_spawn_case 'profile-staged spaces' opencode "$id")
+  read_case_record "$rec"
+  mkdir -p "$HOME_DIR/data/prior" "$HOME_DIR/data/plan-review/decisions"
+  printf 'prior report; see data/prior/notes.md\n' > "$HOME_DIR/data/prior/report.md"
+  printf 'prior notes\n' > "$HOME_DIR/data/prior/notes.md"
+  printf 'decision one\n' > "$HOME_DIR/data/plan-review/decisions/one.md"
+  printf 'prior status\n' > "$HOME_DIR/state/prior.status"
+  cat > "$HOME_DIR/data/$id/brief.md" <<EOF
+Read \`$HOME_DIR/data/prior/report.md\` and \`data/prior/notes.md\`.
+Read all decisions at \`$HOME_DIR/data/plan-review/decisions/*.md\`.
+Read prior status at \`$HOME_DIR/state/prior.status\` and \`state/prior.status\`.
+The helper is \`$ROOT/bin/fm-ensure-agents-md.sh\`.
+Write findings to \`$HOME_DIR/data/$id/report.md\`.
+Append status to \`$HOME_DIR/state/$id.status\`.
+Relative output aliases are \`data/$id/report.md\` and \`state/$id.status\`.
+EOF
+
+  out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR")
+  status=$?
+  expect_code 0 "$status" "spawn with firstmate-home references should succeed"
+  assert_contains "$out" "spawned $id harness=opencode" "staged-reference spawn did not report opencode"
+  assert_present "$WT_DIR/.fm/brief.md" "spawn did not stage the brief"
+  assert_present "$WT_DIR/.fm/refs/home/data/prior/report.md" "spawn did not stage the absolute report reference"
+  assert_present "$WT_DIR/.fm/refs/home/data/prior/notes.md" "spawn did not stage the transitive report reference"
+  assert_present "$WT_DIR/.fm/refs/home/data/plan-review/decisions/one.md" "spawn did not expand the decision glob"
+  assert_present "$WT_DIR/.fm/refs/home/state/prior.status" "spawn did not stage the prior status reference"
+  assert_present "$WT_DIR/.fm/refs/root/bin/fm-ensure-agents-md.sh" "spawn did not stage the firstmate helper reference"
+  staged=$(cat "$WT_DIR/.fm/brief.md")
+  assert_not_contains "$staged" "$HOME_DIR/data/prior/report.md" "staged brief retained an absolute firstmate report input"
+  assert_not_contains "$staged" "$ROOT/bin/fm-ensure-agents-md.sh" "staged brief retained an absolute firstmate helper input"
+  assert_contains "$staged" '.fm/refs/home/data/prior/report.md' "staged brief did not rewrite the absolute report input"
+  assert_contains "$staged" '.fm/refs/home/data/prior/notes.md' "staged brief did not rewrite the relative report input"
+  assert_contains "$staged" '.fm/refs/home/data/plan-review/decisions/*.md' "staged brief did not rewrite the decision glob"
+  assert_contains "$staged" '.fm/refs/home/state/prior.status' "staged brief did not rewrite the prior status input"
+  assert_contains "$staged" "$HOME_DIR/data/$id/report.md" "scout report output path was not preserved"
+  assert_contains "$staged" "$HOME_DIR/state/$id.status" "status output path was not preserved"
+  assert_not_contains "$staged" "\`data/$id/report.md\`" "relative scout report output was not redirected"
+  assert_not_contains "$staged" "\`state/$id.status\`" "relative status output was not redirected"
+  launch=$(cat "$LAUNCH_LOG")
+  assert_contains "$launch" "< '$WT_DIR/.fm/brief.md'" "launch command still points at the home brief"
+  assert_not_contains "$launch" "$HOME_DIR/data/$id/brief.md" "launch command retained the external brief"
+  ( cd "$WT_DIR" && git check-ignore -q .fm/brief.md ) \
+    || fail "staged brief is not excluded from the task worktree"
+  pass "spawn stages firstmate inputs, rewrites references, and preserves external outputs"
 }
 
 test_pi_threads_model_and_max_effort() {
@@ -584,6 +640,9 @@ test_pi_signed_persistent_secondmate_uses_pi_extensions_and_identity() {
   launch=$(cat "$LAUNCH_LOG")
   assert_contains "$launch" "FM_PI_HARNESS=pi-signed pi-signed -e '$sm/.pi/extensions/fm-primary-turnend-guard.ts' -e '$sm/.pi/extensions/fm-primary-pi-watch.ts'" \
     "pi-signed secondmate did not share Pi's primary extension launch shape"
+  assert_present "$sm/.fm/brief.md" "secondmate charter was not staged inside its home"
+  assert_contains "$(cat "$sm/.fm/brief.md")" "charter for $id" \
+    "secondmate staged brief did not preserve the charter"
   pass "pi-signed is a distinct persistent secondmate runtime with shared Pi supervision semantics"
 }
 
@@ -690,6 +749,7 @@ test_grok_threads_model_and_reasoning_effort
 test_grok_omits_invalid_max_reasoning_effort
 test_grok_omits_invalid_xhigh_reasoning_effort
 test_opencode_threads_model_and_ignores_effort_axis
+test_spawn_stages_firstmate_brief_and_references
 test_pi_threads_model_and_max_effort
 test_pi_signed_threads_shared_pi_profile_and_preserves_identity
 test_pi_signed_missing_binary_refuses_before_endpoint_or_metadata

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -531,7 +531,7 @@ Read \`$HOME_DIR/data/prior/report.md\` and \`data/prior/notes.md\`.
 Reproduce with \`$HOME_DIR/data/prior/repro.sh\`.
 Read all decisions at \`$HOME_DIR/data/plan-review/decisions/*.md\`.
 Read prior status at \`$HOME_DIR/state/prior.status\` and \`state/prior.status\`.
-The helper is \`$ROOT/bin/fm-ensure-agents-md.sh\`.
+The helper is \`$ROOT/bin/fm-ensure-agents-md.sh\` and the library is \`$ROOT/bin/fm-config-inherit-lib.sh\`.
 The task directory is \`$HOME_DIR/data/$id\` and the prior directory is \`$HOME_DIR/data/prior\`.
 Append your decision to \`$HOME_DIR/data/prior/new-decision.md\`.
 The whole home data root is \`$HOME_DIR/data\` and must never be staged.
@@ -550,11 +550,13 @@ EOF
   assert_present "$WT_DIR/.fm/refs/home/data/prior/notes.md" "spawn did not stage the transitive report reference"
   assert_present "$WT_DIR/.fm/refs/home/data/plan-review/decisions/one.md" "spawn did not expand the decision glob"
   assert_present "$WT_DIR/.fm/refs/home/state/prior.status" "spawn did not stage the prior status reference"
-  [ -e "$WT_DIR/.fm/refs/root/bin/fm-ensure-agents-md.sh" ] \
-    && fail "spawn copied a firstmate enforcement script into the writable task worktree"
+  [ -e "$WT_DIR/.fm/refs/root/bin" ] \
+    && fail "spawn copied firstmate's own bin/ tree into the writable task worktree"
   assert_present "$WT_DIR/.fm/refs/home/data/prior/repro.sh" \
     "spawn refused to stage an ordinary brief input that merely carries the exec bit"
   staged=$(cat "$WT_DIR/.fm/brief.md")
+  assert_contains "$staged" "$ROOT/bin/fm-config-inherit-lib.sh" \
+    "staged brief repointed a non-executable firstmate bin/ library away from its real path"
   assert_contains "$staged" "$WT_DIR/.fm/refs/home/data/prior/repro.sh" \
     "staged brief did not rewrite an executable data input to its staged copy"
   assert_not_contains "$staged" "$HOME_DIR/data/prior/report.md" "staged brief retained an absolute firstmate report input"

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -485,9 +485,27 @@ test_opencode_threads_model_and_ignores_effort_axis() {
   tmp_real=$(cd "/tmp/fm-$id" && pwd -P)
   assert_contains "$launch" "opencode --model 'anthropic/claude-sonnet-4-5' --prompt" \
     "opencode launch did not thread model"
-  config="OPENCODE_CONFIG_CONTENT='{\"permission\":{\"*\":\"allow\",\"external_directory\":{\"$home_real/state/*\":\"allow\",\"$home_real/data/$id/*\":\"allow\",\"$tmp_real/*\":\"allow\"}}}'"
+  config="OPENCODE_CONFIG_CONTENT='{\"permission\":{\"*\":\"allow\",\"external_directory\":{"
   assert_contains "$launch" "$config" \
-    "opencode launch did not scope external_directory to the task's output and temp paths"
+    "opencode launch did not scope permissions through external_directory"
+  # Every spelling the crewmate can reach an allowed directory by must be granted:
+  # the logical one it is handed and the physically resolved one.
+  assert_contains "$launch" "\"$HOME_DIR/state/*\":\"allow\"" \
+    "opencode launch did not grant the logical status directory"
+  assert_contains "$launch" "\"$home_real/state/*\":\"allow\"" \
+    "opencode launch did not grant the resolved status directory"
+  assert_contains "$launch" "\"$HOME_DIR/data/$id/*\":\"allow\"" \
+    "opencode launch did not grant the logical report directory"
+  assert_contains "$launch" "\"$home_real/data/$id/*\":\"allow\"" \
+    "opencode launch did not grant the resolved report directory"
+  assert_contains "$launch" "\"/tmp/fm-$id/*\":\"allow\"" \
+    "opencode launch did not grant the logical GOTMPDIR root the pane exports"
+  assert_contains "$launch" "\"$tmp_real/*\":\"allow\"" \
+    "opencode launch did not grant the resolved task temp root"
+  assert_not_contains "$launch" "\"$home_real/*\":\"allow\"" \
+    "opencode launch granted the whole firstmate home"
+  assert_not_contains "$launch" "\"/tmp/*\":\"allow\"" \
+    "opencode launch granted the whole temp root"
   assert_contains "$launch" "< '$WT_DIR/.fm/brief.md'" \
     "opencode launch did not read the staged brief"
   assert_not_contains "$launch" "--effort" "opencode launch must not pass unsupported --effort"
@@ -504,10 +522,13 @@ test_spawn_stages_firstmate_brief_and_references() {
   mkdir -p "$HOME_DIR/data/prior" "$HOME_DIR/data/plan-review/decisions"
   printf 'prior report; see data/prior/notes.md\n' > "$HOME_DIR/data/prior/report.md"
   printf 'prior notes\n' > "$HOME_DIR/data/prior/notes.md"
+  printf '#!/usr/bin/env bash\necho repro\n' > "$HOME_DIR/data/prior/repro.sh"
+  chmod +x "$HOME_DIR/data/prior/repro.sh"
   printf 'decision one\n' > "$HOME_DIR/data/plan-review/decisions/one.md"
   printf 'prior status\n' > "$HOME_DIR/state/prior.status"
   cat > "$HOME_DIR/data/$id/brief.md" <<EOF
 Read \`$HOME_DIR/data/prior/report.md\` and \`data/prior/notes.md\`.
+Reproduce with \`$HOME_DIR/data/prior/repro.sh\`.
 Read all decisions at \`$HOME_DIR/data/plan-review/decisions/*.md\`.
 Read prior status at \`$HOME_DIR/state/prior.status\` and \`state/prior.status\`.
 The helper is \`$ROOT/bin/fm-ensure-agents-md.sh\`.
@@ -530,8 +551,12 @@ EOF
   assert_present "$WT_DIR/.fm/refs/home/data/plan-review/decisions/one.md" "spawn did not expand the decision glob"
   assert_present "$WT_DIR/.fm/refs/home/state/prior.status" "spawn did not stage the prior status reference"
   [ -e "$WT_DIR/.fm/refs/root/bin/fm-ensure-agents-md.sh" ] \
-    && fail "spawn copied a firstmate program into the writable task worktree"
+    && fail "spawn copied a firstmate enforcement script into the writable task worktree"
+  assert_present "$WT_DIR/.fm/refs/home/data/prior/repro.sh" \
+    "spawn refused to stage an ordinary brief input that merely carries the exec bit"
   staged=$(cat "$WT_DIR/.fm/brief.md")
+  assert_contains "$staged" "$WT_DIR/.fm/refs/home/data/prior/repro.sh" \
+    "staged brief did not rewrite an executable data input to its staged copy"
   assert_not_contains "$staged" "$HOME_DIR/data/prior/report.md" "staged brief retained an absolute firstmate report input"
   assert_contains "$staged" "$ROOT/bin/fm-ensure-agents-md.sh" \
     "staged brief repointed a firstmate program away from its real path"
@@ -558,6 +583,30 @@ EOF
   ( cd "$WT_DIR" && git check-ignore -q .fm/brief.md ) \
     || fail "staged brief is not excluded from the task worktree"
   pass "spawn stages firstmate inputs, rewrites references, and preserves external outputs"
+}
+
+test_spawn_keeps_the_real_path_for_a_partially_staged_reference() {
+  local rec id out status staged
+  id=profile-staged-partial-z22
+  rec=$(make_spawn_case profile-staged-partial opencode "$id")
+  read_case_record "$rec"
+  mkdir -p "$HOME_DIR/data/lab"
+  printf 'lab note one\n' > "$HOME_DIR/data/lab/one.md"
+  printf 'lab note two\n' > "$HOME_DIR/data/lab/two.md"
+  cat > "$HOME_DIR/data/$id/brief.md" <<EOF
+Everything you need is in \`$HOME_DIR/data/lab\`.
+Write findings to \`$HOME_DIR/data/$id/report.md\`.
+EOF
+
+  out=$(FM_STAGE_MAX_FILES=1 run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR")
+  status=$?
+  expect_code 0 "$status" "spawn with a partially staged directory should succeed"
+  assert_contains "$out" "keeping the real path for firstmate reference $HOME_DIR/data/lab" \
+    "spawn did not name the reference whose files were not all staged"
+  staged=$(cat "$WT_DIR/.fm/brief.md")
+  assert_contains "$staged" "is in \`$HOME_DIR/data/lab\`" \
+    "spawn rewrote a reference to a directory copy that is missing files"
+  pass "a partially staged reference keeps its real path and reports what is missing"
 }
 
 test_crewmate_spawn_never_stages_from_the_project_checkout() {
@@ -792,6 +841,7 @@ test_grok_omits_invalid_max_reasoning_effort
 test_grok_omits_invalid_xhigh_reasoning_effort
 test_opencode_threads_model_and_ignores_effort_axis
 test_spawn_stages_firstmate_brief_and_references
+test_spawn_keeps_the_real_path_for_a_partially_staged_reference
 test_crewmate_spawn_never_stages_from_the_project_checkout
 test_pi_threads_model_and_max_effort
 test_pi_signed_threads_shared_pi_profile_and_preserves_identity

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -510,6 +510,8 @@ Read \`$HOME_DIR/data/prior/report.md\` and \`data/prior/notes.md\`.
 Read all decisions at \`$HOME_DIR/data/plan-review/decisions/*.md\`.
 Read prior status at \`$HOME_DIR/state/prior.status\` and \`state/prior.status\`.
 The helper is \`$ROOT/bin/fm-ensure-agents-md.sh\`.
+The task directory is \`$HOME_DIR/data/$id\` and the prior directory is \`$HOME_DIR/data/prior\`.
+The sibling \`$HOME_DIR/data/prior-two/missing.md\` is not staged.
 Write findings to \`$HOME_DIR/data/$id/report.md\`.
 Append status to \`$HOME_DIR/state/$id.status\`.
 Relative output aliases are \`data/$id/report.md\` and \`state/$id.status\`.
@@ -532,7 +534,12 @@ EOF
   assert_contains "$staged" '.fm/refs/home/data/prior/notes.md' "staged brief did not rewrite the relative report input"
   assert_contains "$staged" '.fm/refs/home/data/plan-review/decisions/*.md' "staged brief did not rewrite the decision glob"
   assert_contains "$staged" '.fm/refs/home/state/prior.status' "staged brief did not rewrite the prior status input"
+  assert_contains "$staged" ".fm/refs/home/data/$id" "staged brief did not rewrite the task directory input"
   assert_contains "$staged" "$HOME_DIR/data/$id/report.md" "scout report output path was not preserved"
+  assert_not_contains "$staged" ".fm/refs/home/data/$id/report.md" \
+    "a staged parent directory redirected the external scout report output"
+  assert_contains "$staged" "$HOME_DIR/data/prior-two/missing.md" \
+    "a staged path rewrote a sibling path that only shares its prefix"
   assert_contains "$staged" "$HOME_DIR/state/$id.status" "status output path was not preserved"
   assert_not_contains "$staged" "\`data/$id/report.md\`" "relative scout report output was not redirected"
   assert_not_contains "$staged" "\`state/$id.status\`" "relative status output was not redirected"
@@ -542,6 +549,32 @@ EOF
   ( cd "$WT_DIR" && git check-ignore -q .fm/brief.md ) \
     || fail "staged brief is not excluded from the task worktree"
   pass "spawn stages firstmate inputs, rewrites references, and preserves external outputs"
+}
+
+test_crewmate_spawn_never_stages_from_the_project_checkout() {
+  local rec id out status staged outside
+  id=profile-staged-project-z21
+  rec=$(make_spawn_case profile-staged-project opencode "$id")
+  read_case_record "$rec"
+  outside="$CASE_DIR/outside"
+  mkdir -p "$outside" "$PROJ_DIR/data/generated"
+  printf 'outside the project\n' > "$outside/secret.md"
+  ln -s "$outside/secret.md" "$PROJ_DIR/data/generated/notes.md"
+  cat > "$HOME_DIR/data/$id/brief.md" <<EOF
+Read \`data/generated/notes.md\` before you start.
+Write findings to \`$HOME_DIR/data/$id/report.md\`.
+EOF
+
+  out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR")
+  status=$?
+  expect_code 0 "$status" "crewmate spawn with a project-only data reference should succeed"
+  assert_contains "$out" "spawned $id harness=opencode" "project-reference spawn did not report opencode"
+  [ -e "$WT_DIR/.fm/refs/secondmate" ] \
+    && fail "crewmate spawn staged the project checkout as a secondmate home"
+  staged=$(cat "$WT_DIR/.fm/brief.md")
+  assert_contains "$staged" "\`data/generated/notes.md\`" \
+    "crewmate spawn rewrote a project-relative reference it must leave alone"
+  pass "crewmate spawn never stages the project checkout through the secondmate root"
 }
 
 test_pi_threads_model_and_max_effort() {
@@ -750,6 +783,7 @@ test_grok_omits_invalid_max_reasoning_effort
 test_grok_omits_invalid_xhigh_reasoning_effort
 test_opencode_threads_model_and_ignores_effort_axis
 test_spawn_stages_firstmate_brief_and_references
+test_crewmate_spawn_never_stages_from_the_project_checkout
 test_pi_threads_model_and_max_effort
 test_pi_signed_threads_shared_pi_profile_and_preserves_identity
 test_pi_signed_missing_binary_refuses_before_endpoint_or_metadata

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -471,7 +471,7 @@ test_grok_omits_invalid_xhigh_reasoning_effort() {
 }
 
 test_opencode_threads_model_and_ignores_effort_axis() {
-  local rec id out status launch config home_real
+  local rec id out status launch config home_real tmp_real
   id=profile-opencode-z7
   rec=$(make_spawn_case profile-opencode opencode "$id")
   read_case_record "$rec"
@@ -482,11 +482,12 @@ test_opencode_threads_model_and_ignores_effort_axis() {
   assert_meta_profile "$HOME_DIR/state/$id.meta" opencode anthropic/claude-sonnet-4-5 high
   launch=$(cat "$LAUNCH_LOG")
   home_real=$(cd "$HOME_DIR" && pwd -P)
+  tmp_real=$(cd "/tmp/fm-$id" && pwd -P)
   assert_contains "$launch" "opencode --model 'anthropic/claude-sonnet-4-5' --prompt" \
     "opencode launch did not thread model"
-  config="OPENCODE_CONFIG_CONTENT='{\"permission\":{\"*\":\"allow\",\"external_directory\":{\"$home_real/state/*\":\"allow\",\"$home_real/data/$id/*\":\"allow\"}}}'"
+  config="OPENCODE_CONFIG_CONTENT='{\"permission\":{\"*\":\"allow\",\"external_directory\":{\"$home_real/state/*\":\"allow\",\"$home_real/data/$id/*\":\"allow\",\"$tmp_real/*\":\"allow\"}}}'"
   assert_contains "$launch" "$config" \
-    "opencode launch did not scope external_directory to the task's output paths"
+    "opencode launch did not scope external_directory to the task's output and temp paths"
   assert_contains "$launch" "< '$WT_DIR/.fm/brief.md'" \
     "opencode launch did not read the staged brief"
   assert_not_contains "$launch" "--effort" "opencode launch must not pass unsupported --effort"
@@ -511,13 +512,15 @@ Read all decisions at \`$HOME_DIR/data/plan-review/decisions/*.md\`.
 Read prior status at \`$HOME_DIR/state/prior.status\` and \`state/prior.status\`.
 The helper is \`$ROOT/bin/fm-ensure-agents-md.sh\`.
 The task directory is \`$HOME_DIR/data/$id\` and the prior directory is \`$HOME_DIR/data/prior\`.
+Append your decision to \`$HOME_DIR/data/prior/new-decision.md\`.
+The whole home data root is \`$HOME_DIR/data\` and must never be staged.
 The sibling \`$HOME_DIR/data/prior-two/missing.md\` is not staged.
 Write findings to \`$HOME_DIR/data/$id/report.md\`.
 Append status to \`$HOME_DIR/state/$id.status\`.
 Relative output aliases are \`data/$id/report.md\` and \`state/$id.status\`.
 EOF
 
-  out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR")
+  out=$(run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR")
   status=$?
   expect_code 0 "$status" "spawn with firstmate-home references should succeed"
   assert_contains "$out" "spawned $id harness=opencode" "staged-reference spawn did not report opencode"
@@ -526,15 +529,21 @@ EOF
   assert_present "$WT_DIR/.fm/refs/home/data/prior/notes.md" "spawn did not stage the transitive report reference"
   assert_present "$WT_DIR/.fm/refs/home/data/plan-review/decisions/one.md" "spawn did not expand the decision glob"
   assert_present "$WT_DIR/.fm/refs/home/state/prior.status" "spawn did not stage the prior status reference"
-  assert_present "$WT_DIR/.fm/refs/root/bin/fm-ensure-agents-md.sh" "spawn did not stage the firstmate helper reference"
+  [ -e "$WT_DIR/.fm/refs/root/bin/fm-ensure-agents-md.sh" ] \
+    && fail "spawn copied a firstmate program into the writable task worktree"
   staged=$(cat "$WT_DIR/.fm/brief.md")
   assert_not_contains "$staged" "$HOME_DIR/data/prior/report.md" "staged brief retained an absolute firstmate report input"
-  assert_not_contains "$staged" "$ROOT/bin/fm-ensure-agents-md.sh" "staged brief retained an absolute firstmate helper input"
-  assert_contains "$staged" '.fm/refs/home/data/prior/report.md' "staged brief did not rewrite the absolute report input"
-  assert_contains "$staged" '.fm/refs/home/data/prior/notes.md' "staged brief did not rewrite the relative report input"
-  assert_contains "$staged" '.fm/refs/home/data/plan-review/decisions/*.md' "staged brief did not rewrite the decision glob"
-  assert_contains "$staged" '.fm/refs/home/state/prior.status' "staged brief did not rewrite the prior status input"
-  assert_contains "$staged" ".fm/refs/home/data/$id" "staged brief did not rewrite the task directory input"
+  assert_contains "$staged" "$ROOT/bin/fm-ensure-agents-md.sh" \
+    "staged brief repointed a firstmate program away from its real path"
+  assert_contains "$staged" "$WT_DIR/.fm/refs/home/data/prior/report.md" "staged brief did not rewrite the absolute report input to an absolute staged path"
+  assert_contains "$staged" "$WT_DIR/.fm/refs/home/data/prior/notes.md" "staged brief did not rewrite the relative report input"
+  assert_contains "$staged" "$WT_DIR/.fm/refs/home/data/plan-review/decisions/*.md" "staged brief did not rewrite the decision glob"
+  assert_contains "$staged" "$WT_DIR/.fm/refs/home/state/prior.status" "staged brief did not rewrite the prior status input"
+  assert_contains "$staged" "$WT_DIR/.fm/refs/home/data/$id" "staged brief did not rewrite the task directory input"
+  assert_contains "$staged" "decision to \`$HOME_DIR/data/prior/new-decision.md\`" \
+    "a staged parent directory redirected a not-yet-created file underneath it"
+  assert_contains "$staged" "data root is \`$HOME_DIR/data\`" \
+    "spawn staged and rewrote a broad firstmate root"
   assert_contains "$staged" "$HOME_DIR/data/$id/report.md" "scout report output path was not preserved"
   assert_not_contains "$staged" ".fm/refs/home/data/$id/report.md" \
     "a staged parent directory redirected the external scout report output"
@@ -565,7 +574,7 @@ Read \`data/generated/notes.md\` before you start.
 Write findings to \`$HOME_DIR/data/$id/report.md\`.
 EOF
 
-  out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR")
+  out=$(run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR")
   status=$?
   expect_code 0 "$status" "crewmate spawn with a project-only data reference should succeed"
   assert_contains "$out" "spawned $id harness=opencode" "project-reference spawn did not report opencode"


### PR DESCRIPTION
## Intent

The developer was running a validation/no-mistakes pipeline for a change in the firstmate repo, which had stalled because they lacked push access to the upstream kunchenguid/firstmate repository. Having created a personal fork at https://github.com/mhs-7/firstmate, they instructed the agent to add it as a git remote named "fork" in the worktree (git remote add fork https://github.com/mhs-7/firstmate.git) and to point the pipeline's push and PR targets at that fork so the PR would open from mhs-7/firstmate against kunchenguid/firstmate's main branch as a cross-fork PR. They explicitly wanted the already-recovered validation run resumed from the push step rather than restarted from the beginning. They also asked the agent to append a "resolved:" marker once the resumed run was actually moving. The instruction was sent twice verbatim, underscoring that unblocking the push and resuming the pipeline was the only immediate goal.

## What Changed

- `bin/fm-spawn.sh` now stages the launch brief into the launch checkout (the task worktree, or the secondmate home for `--secondmate`) as gitignored `.fm/brief.md`, copies every firstmate-home/firstmate-repo file the brief transitively references under `.fm/refs/<home|root|secondmate>/`, and rewrites the brief's input paths to those copies — so no launch-visible input lives outside the checkout. Staging is bounded and fails closed: broad firstmate roots are never staged, anything under a firstmate root's own `bin/` is left at its real path, depth/file-count/byte caps (tunable via `FM_STAGE_MAX_*`) skip the rest with a warning, and a directory or glob reference is rewritten only when every file it covers was staged. The deliberate external writes — `state/<id>.status` and a scout's `data/<id>/report.md` — are pinned to their real outside paths.
- The opencode launch template gained a per-launch `permission.external_directory` map (opencode 1.18.10) built at spawn time, granting only the task's status file, report directory, and per-task temp root, in every spelling the crewmate can reach them by (logical and physically-resolved), without touching the captain's global opencode config.
- Docs updated to match: `AGENTS.md` states the brief-authoring contract that a named existing firstmate file arrives as a snapshot copy and must not be used as a write target, and the harness-adapters skill's Kimi pointer now names the staged `<checkout>/.fm/brief.md`. Tests in `tests/fm-spawn-dispatch-profile.test.sh` cover staging of a brief and its references, keeping the real path for a partially staged reference, and never staging from the project checkout; `tests/fm-kimi-harness.test.sh` follows the new pointer path.

## Risk Assessment

⚠️ Medium: Every defect raised across the four review rounds is now closed with a test covering its invariant, and this round's change is a tight, correct narrowing of one predicate — but the branch as a whole still adds roughly 700 lines of new shell that rewires brief delivery on the critical launch path for every harness, so the mechanism remains broad and unproven against real briefs rather than synthetic ones.

## Testing

<code>Ran the two directly-affected test scripts (fm-spawn-dispatch-profile, fm-kimi-harness) and five neighboring spawn/brief scripts — all pass with no failures or gate skips. Since passing units alone would not show what a crewmate actually receives, I also drove the real fm-spawn.sh end-to-end with a fake tmux pane and captured a CLI transcript: it shows the captain&#39;s brief rewritten so the prior report, its transitively-referenced trace log, the exec-bit repro script, and the decision glob all resolve inside `&lt;worktree&gt;/.fm/refs/`, while firstmate&#39;s own bin/ helper and both deliberate output paths keep their real external paths; the launch command reads the staged brief and grants opencode only the status dir, report dir, and per-task temp root instead of the whole home or /tmp; and `.fm/` is gitignored with a clean worktree. This is a CLI/shell change with no rendered UI surface, so the reviewer-visible artifact is the command transcript rather than a screenshot. Demo scratch directories were removed and the working tree is clean.</code>

<details>
<summary>Evidence: End-to-end brief staging transcript (before/after brief, staged tree, launch command, gitignore proof)</summary>

<code>=== 1. The brief firstmate wrote (every input lives OUTSIDE the task worktree) ===&#10;# Task demo-staging-1&#10;&#10;Read the prior scout report at `&lt;home&gt;/data/scout-4711/report.md`.&#10;Reproduce the failure with `&lt;home&gt;/data/scout-4711/repro.sh`.&#10;Honor every decision in `&lt;home&gt;/data/plan-review/decisions/*.md`.&#10;Use the helper `&lt;repo&gt;/bin/fm-ensure-agents-md.sh` in place; do not copy it.&#10;&#10;Write your findings to `&lt;home&gt;/data/demo-staging-1/report.md`.&#10;Append your status events to `&lt;home&gt;/state/demo-staging-1.status`.&#10;&#10;=== 2. Spawning the crewmate ===&#10;spawned demo-staging-1 harness=opencode kind=ship mode=no-mistakes yolo=off worktree=&lt;wt&gt;&#10;spawn exit status: 0&#10;&#10;=== 3. The brief the crewmate actually reads: &lt;wt&gt;/.fm/brief.md ===&#10;# Task demo-staging-1&#10;&#10;Read the prior scout report at `&lt;wt&gt;/.fm/refs/home/data/scout-4711/report.md`.&#10;Reproduce the failure with `&lt;wt&gt;/.fm/refs/home/data/scout-4711/repro.sh`.&#10;Honor every decision in `&lt;wt&gt;/.fm/refs/home/data/plan-review/decisions/*.md`.&#10;Use the helper `&lt;repo&gt;/bin/fm-ensure-agents-md.sh` in place; do not copy it.&#10;&#10;Write your findings to `&lt;home&gt;/data/demo-staging-1/report.md`.&#10;Append your status events to `&lt;home&gt;/state/demo-staging-1.status`.&#10;&#10;=== 4. What staging copied into the task worktree ===&#10;.fm/brief.md&#10;.fm/path-map&#10;.fm/refs/home/data/plan-review/decisions/deps.md&#10;.fm/refs/home/data/plan-review/decisions/retries.md&#10;.fm/refs/home/data/scout-4711/report.md&#10;.fm/refs/home/data/scout-4711/repro.sh&#10;.fm/refs/home/data/scout-4711/trace.log&#10;.fm/source-list&#10;&#10;=== 5. The launch command firstmate typed into the pane ===&#10;OPENCODE_CONFIG_CONTENT=&#39;{&#34;permission&#34;:{&#34;*&#34;:&#34;allow&#34;,&#34;external_directory&#34;:{&#34;/tmp/.../home/state/*&#34;:&#34;allow&#34;,&#34;/private/tmp/.../home/state/*&#34;:&#34;allow&#34;,&#34;/tmp/.../home/data/demo-staging-1/*&#34;:&#34;allow&#34;,&#34;/private/tmp/.../home/data/demo-staging-1/*&#34;:&#34;allow&#34;,&#34;/tmp/fm-demo-staging-1/*&#34;:&#34;allow&#34;,&#34;/private/tmp/fm-demo-staging-1/*&#34;:&#34;allow&#34;}}}&#39; opencode --prompt &#34;$(&#39;&lt;repo&gt;/bin/fm-operational-input.sh&#39; encode launch-brief &lt; &#39;&lt;wt&gt;/.fm/brief.md&#39;)&#34;&#10;&#10;=== 6. Staged material is gitignored ===&#10;&lt;project&gt;/.git/info/exclude:7:.fm/ .fm/brief.md&#10;(empty `git status --porcelain` above means a clean task worktree)&#10;&#10;=== 7. Every input path in the staged brief resolves inside the worktree ===&#10;outside worktree : &lt;home&gt;/data/demo-staging-1/report.md&#10;outside worktree : &lt;home&gt;/state/demo-staging-1.status&#10;INSIDE worktree : &lt;wt&gt;/.fm/refs/home/data/plan-review/decisions/*.md&#10;INSIDE worktree : &lt;wt&gt;/.fm/refs/home/data/scout-4711/report.md&#10;INSIDE worktree : &lt;wt&gt;/.fm/refs/home/data/scout-4711/repro.sh&#10;&#10;(only the two deliberate OUTPUT paths - report.md and .status - stay outside)</code>

```text

=== 1. The brief firstmate wrote (every input lives OUTSIDE the task worktree) ===
# Task demo-staging-1

Read the prior scout report at `/tmp/fm-staging-demo-lab/home/data/scout-4711/report.md`.
Reproduce the failure with `/tmp/fm-staging-demo-lab/home/data/scout-4711/repro.sh`.
Honor every decision in `/tmp/fm-staging-demo-lab/home/data/plan-review/decisions/*.md`.
Use the helper `/Users/mhs/.no-mistakes/worktrees/ca7a67a1beee/01KZ49Y5AVX66Q1KY3VBH8ZQT2/bin/fm-ensure-agents-md.sh` in place; do not copy it.

Write your findings to `/tmp/fm-staging-demo-lab/home/data/demo-staging-1/report.md`.
Append your status events to `/tmp/fm-staging-demo-lab/home/state/demo-staging-1.status`.

=== 2. Spawning the crewmate: bin/fm-spawn.sh demo-staging-1 <project> --mode no-mistakes --yolo off ===
warning: /tmp/fm-staging-demo-lab/home/data/demo-staging-1/brief.md records no delivery contract line (scaffolded before ship briefs recorded one); launching on the explicit --mode no-mistakes - confirm its definition of done matches
/Users/mhs/.no-mistakes/worktrees/ca7a67a1beee/01KZ49Y5AVX66Q1KY3VBH8ZQT2/bin/fm-trace-context-lib.sh: line 143: /tmp/fm-staging-demo-lab/home/state/.lock: No such file or directory
spawned demo-staging-1 harness=opencode kind=ship mode=no-mistakes yolo=off window=firstmate:fm-demo-staging-1 worktree=/tmp/fm-staging-demo-lab/wt
spawn exit status: 0

=== 3. The brief the crewmate actually reads: /tmp/fm-staging-demo-lab/wt/.fm/brief.md ===
# Task demo-staging-1

Read the prior scout report at `/tmp/fm-staging-demo-lab/wt/.fm/refs/home/data/scout-4711/report.md`.
Reproduce the failure with `/tmp/fm-staging-demo-lab/wt/.fm/refs/home/data/scout-4711/repro.sh`.
Honor every decision in `/tmp/fm-staging-demo-lab/wt/.fm/refs/home/data/plan-review/decisions/*.md`.
Use the helper `/Users/mhs/.no-mistakes/worktrees/ca7a67a1beee/01KZ49Y5AVX66Q1KY3VBH8ZQT2/bin/fm-ensure-agents-md.sh` in place; do not copy it.

Write your findings to `/tmp/fm-staging-demo-lab/home/data/demo-staging-1/report.md`.
Append your status events to `/tmp/fm-staging-demo-lab/home/state/demo-staging-1.status`.

=== 4. What staging copied into the task worktree ===
.fm/brief.md
.fm/path-map
.fm/refs/home/data/plan-review/decisions/deps.md
.fm/refs/home/data/plan-review/decisions/retries.md
.fm/refs/home/data/scout-4711/report.md
.fm/refs/home/data/scout-4711/repro.sh
.fm/refs/home/data/scout-4711/trace.log
.fm/source-list

=== 5. The launch command firstmate typed into the pane ===
OPENCODE_CONFIG_CONTENT='{"permission":{"*":"allow","external_directory":{"/tmp/fm-staging-demo-lab/home/state/*":"allow","/private/tmp/fm-staging-demo-lab/home/state/*":"allow","/tmp/fm-staging-demo-lab/home/data/demo-staging-1/*":"allow","/private/tmp/fm-staging-demo-lab/home/data/demo-staging-1/*":"allow","/tmp/fm-demo-staging-1/*":"allow","/private/tmp/fm-demo-staging-1/*":"allow"}}}' opencode --prompt "$('/Users/mhs/.no-mistakes/worktrees/ca7a67a1beee/01KZ49Y5AVX66Q1KY3VBH8ZQT2/bin/fm-operational-input.sh' encode launch-brief < '/tmp/fm-staging-demo-lab/wt/.fm/brief.md')"

=== 6. Staged material is gitignored, so it never pollutes the crewmate's branch ===
/private/tmp/fm-staging-demo-lab/project/.git/info/exclude:7:.fm/	.fm/brief.md
(empty `git status --porcelain` above means a clean task worktree)

=== 7. Every input path in the staged brief resolves inside the worktree ===
  outside worktree : /tmp/fm-staging-demo-lab/home/data/demo-staging-1/report.md
  outside worktree : /tmp/fm-staging-demo-lab/home/state/demo-staging-1.status
  INSIDE  worktree : /tmp/fm-staging-demo-lab/wt/.fm/refs/home/data/plan-review/decisions/*.md
  INSIDE  worktree : /tmp/fm-staging-demo-lab/wt/.fm/refs/home/data/scout-4711/report.md
  INSIDE  worktree : /tmp/fm-staging-demo-lab/wt/.fm/refs/home/data/scout-4711/repro.sh

(only the two deliberate OUTPUT paths - report.md and .status - stay outside)
```
</details>
<details>
<summary>Evidence: Reproducible demo script used to produce the transcript</summary>

```text
#!/usr/bin/env bash
# Manual end-to-end demo of worktree brief staging.
#
# Drives the real bin/fm-spawn.sh with a fake tmux pane (so the launch command
# is captured verbatim instead of starting a real harness) against a realistic
# firstmate home whose brief names outside-worktree paths. Prints the brief the
# captain wrote, the brief the crewmate actually receives, the launch command,
# and the resulting worktree contents.
set -u

ROOT=${1:?usage: demo-brief-staging.sh <firstmate-repo-root> <scratch-dir>}
LAB=${2:?usage: demo-brief-staging.sh <firstmate-repo-root> <scratch-dir>}
SPAWN="$ROOT/bin/fm-spawn.sh"

rm -rf "$LAB"
mkdir -p "$LAB"
HOME_DIR="$LAB/home"
PROJ="$LAB/project"
WT="$LAB/wt"
FAKEBIN="$LAB/fakebin"
LAUNCH_LOG="$LAB/launch.log"
ID=demo-staging-1

mkdir -p "$HOME_DIR"/{data,state,config,projects} "$FAKEBIN"

# --- fake tmux: record the literal launch command, answer pane queries --------
cat > "$FAKEBIN/tmux" <<'SH'
#!/usr/bin/env bash
set -u
case "$*" in
  *"#{pane_current_path}"*) printf '%s\n' "${FM_FAKE_PANE_PATH:-}"; exit 0 ;;
esac
case "${1:-}" in
  display-message) printf 'firstmate\n'; exit 0 ;;
  list-windows) exit 0 ;;
  has-session|new-session|new-window|kill-window) exit 0 ;;
  send-keys)
    prev=
    for a in "$@"; do
      [ "$prev" = "-l" ] && printf '%s\n' "$a" >> "$FM_FAKE_LAUNCH_LOG"
      prev=$a
    done
    exit 0
    ;;
esac
exit 0
SH
chmod +x "$FAKEBIN/tmux"
for p in opencode treehouse; do
  printf '#!/usr/bin/env bash\nexit 0\n' > "$FAKEBIN/$p"
  chmod +x "$FAKEBIN/$p"
done

printf 'opencode\n' > "$HOME_DIR/config/crew-harness"
touch "$HOME_DIR/state/.last-watcher-beat"

# --- a real project checkout and a real task worktree ------------------------
mkdir -p "$PROJ"
git -C "$PROJ" init -q
printf '# demo project\n' > "$PROJ/README.md"
git -C "$PROJ" add -A
git -C "$PROJ" -c user.email=demo@example.com -c user.name=demo commit -qm init
git -C "$PROJ" worktree add -q -b wt-demo-staging "$WT" >/dev/null

# --- prior fleet material the brief points a crewmate at ---------------------
mkdir -p "$HOME_DIR/data/$ID" "$HOME_DIR/data/scout-4711" "$HOME_DIR/data/plan-review/decisions"
printf 'Scout 4711 report.\nFull trace in `data/scout-4711/trace.log`.\n' \
  > "$HOME_DIR/data/scout-4711/report.md"
printf 'boot ok\nhandshake ok\ntimeout after 30s\n' > "$HOME_DIR/data/scout-4711/trace.log"
printf '#!/usr/bin/env bash\necho reproducing the timeout\n' > "$HOME_DIR/data/scout-4711/repro.sh"
chmod +x "$HOME_DIR/data/scout-4711/repro.sh"
printf 'Decision 1: keep the retry budget at 3.\n' > "$HOME_DIR/data/plan-review/decisions/retries.md"
printf 'Decision 2: no new dependencies.\n' > "$HOME_DIR/data/plan-review/decisions/deps.md"

cat > "$HOME_DIR/data/$ID/brief.md" <<EOF
# Task $ID

Read the prior scout report at \`$HOME_DIR/data/scout-4711/report.md\`.
Reproduce the failure with \`$HOME_DIR/data/scout-4711/repro.sh\`.
Honor every decision in \`$HOME_DIR/data/plan-review/decisions/*.md\`.
Use the helper \`$ROOT/bin/fm-ensure-agents-md.sh\` in place; do not copy it.

Write your findings to \`$HOME_DIR/data/$ID/report.md\`.
Append your status events to \`$HOME_DIR/state/$ID.status\`.
EOF

banner() { printf '\n\033[1m=== %s ===\033[0m\n' "$1"; }

banner "1. The brief firstmate wrote (every input lives OUTSIDE the task worktree)"
cat "$HOME_DIR/data/$ID/brief.md"

banner "2. Spawning the crewmate: bin/fm-spawn.sh $ID <project> --mode no-mistakes --yolo off"
: > "$LAUNCH_LOG"
FM_GATE_REFUSE_BYPASS=1 FM_ROOT_OVERRIDE='' FM_HOME="$HOME_DIR" \
  FM_STATE_OVERRIDE="$HOME_DIR/state" FM_DATA_OVERRIDE="$HOME_DIR/data" \
  FM_PROJECTS_OVERRIDE="$HOME_DIR/projects" FM_CONFIG_OVERRIDE="$HOME_DIR/config" \
  FM_SPAWN_NO_GUARD=1 FM_FAKE_PANE_PATH="$WT" TMUX="fake,1,0" \
  CLAUDE_CONFIG_DIR='' FM_FAKE_LAUNCH_LOG="$LAUNCH_LOG" \
  PATH="$FAKEBIN:$PATH" \
  "$SPAWN" "$ID" "$PROJ" --mode no-mistakes --yolo off 2>&1
printf 'spawn exit status: %s\n' "$?"

banner "3. The brief the crewmate actually reads: $WT/.fm/brief.md"
cat "$WT/.fm/brief.md"

banner "4. What staging copied into the task worktree"
(cd "$WT" && find .fm -type f | sort)

banner "5. The launch command firstmate typed into the pane"
cat "$LAUNCH_LOG"

banner "6. Staged material is gitignored, so it never pollutes the crewmate's branch"
(cd "$WT" && git check-ignore -v .fm/brief.md; git status --porcelain)
printf '(empty `git status --porcelain` above means a clean task worktree)\n'

banner "7. Every input path in the staged brief resolves inside the worktree"
grep -oE '/[^ `]*(report\.md|repro\.sh|trace\.log|\*\.md|\.status)' "$WT/.fm/brief.md" \
  | sort -u \
  | while IFS= read -r p; do
      case "$p" in
        "$WT"/*) printf '  INSIDE  worktree : %s\n' "$p" ;;
        *)       printf '  outside worktree : %s\n' "$p" ;;
      esac
    done
printf '\n(only the two deliberate OUTPUT paths - report.md and .status - stay outside)\n'
```
</details>
<details>
<summary>Evidence: Staging-specific test results</summary>

<code>ok - opencode receives --model and omits the unsupported effort axis&#10;ok - spawn stages firstmate inputs, rewrites references, and preserves external outputs&#10;ok - a partially staged reference keeps its real path and reports what is missing&#10;ok - crewmate spawn never stages the project checkout through the secondmate root&#10;FM_TEST_SUMMARY total=1 failed=0 skipped_gate=0 duration_ms=63948</code>

```text
ok - opencode receives --model and omits the unsupported effort axis
ok - spawn stages firstmate inputs, rewrites references, and preserves external outputs
ok - a partially staged reference keeps its real path and reports what is missing
ok - crewmate spawn never stages the project checkout through the secondmate root
FM_TEST_SUMMARY total=1 failed=0 skipped_gate=0 duration_ms=63948
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 8 issues found → auto-fixed (3) ✅</summary>

- ⚠️ `bin/fm-spawn.sh:1790` - stage_target_for_path/stage_target_for_reference emit worktree-RELATIVE targets (.fm/refs/&lt;kind&gt;/&lt;rel&gt;), and stage_rewrite_file substitutes them verbatim into the brief. Every ship brief generated by bin/fm-brief.sh:508 tells the crewmate to `run &#34;$FM_ROOT/bin/fm-ensure-agents-md.sh .&#34; in the worktree`, and a --herdr-lab brief (bin/fm-brief.sh:283) sets `HERDR_LAB_HELPER=&#39;&lt;abs path&gt;&#39;` which is then used inside a `trap ... EXIT`. Failing sequence: the scan at bin/fm-spawn.sh:2072 captures the backticked absolute helper path, stages it, and the rewrite turns every occurrence into `.fm/refs/root/bin/fm-ensure-agents-md.sh` / `.fm/refs/root/bin/fm-herdr-lab.sh`; the agent then runs a bash tool call from any subdirectory (or the EXIT trap fires after a `cd`) and gets &#34;no such file or directory&#34; — for the herdr-lab case that is the guaranteed-teardown leg of the isolation contract. Nothing requires the target to be relative: mapping to &#34;$WT/.fm/refs/...&#34; is still inside the launch checkout, needs no directory grant, and keeps the existing test assertions (they match on the `.fm/refs/...` substring) satisfied.
- ⚠️ `bin/fm-spawn.sh:1944` - stage_file copies referenced firstmate files with `cp -p` (preserving the exec bit) into the task worktree, and the rewrite repoints the brief at the copy. For a --herdr-lab brief this moves bin/fm-herdr-lab.sh — described in the brief itself as a HARD SAFETY CONTRACT whose refuse-default tripwires must not be bypassed — into $WT/.fm/refs/root/bin/, i.e. the agent&#39;s own writable laboratory that the brief explicitly invites it to edit freely. Failing sequence: a crewmate that trips the helper&#39;s tripwire can now edit or delete the very script enforcing Herdr session isolation (previously it lived outside the worktree under rule 2 &#39;modify nothing outside it&#39;), and the captain&#39;s audited copy is no longer the one being executed. Consider leaving executable firstmate helpers (e.g. anything under bin/) unstaged and absolute, since they are invoked, not read as input, and an execute path does not need the opencode external_directory read grant.
- ⚠️ `bin/fm-spawn.sh:2123` - stage_launch_brief is invoked as `stage_launch_brief || exit 1` (line 2133), which disables `set -e` for the entire dynamic extent of the function, yet `stage_rewrite_file &#34;$STAGE_BRIEF&#34;` (2123), the ref-file rewrite loop (2125), `mkdir -p &#34;$STAGE_REF_DIR&#34;` (2095) and the `: &gt; &#34;$STAGE_MAP&#34;` / `: &gt; &#34;$STAGE_SOURCES&#34;` truncations (2101-2102) are all unchecked. Failing sequence: the embedded perl dies (its own `die &#34;cannot read staged path map&#34;` path, or an unwritable/stale $STAGE_MAP left behind because the truncation failed on a respawn) — the function still returns 0, BRIEF is repointed at $WT/.fm/brief.md, and the spawn launches a brief that still names outside-worktree paths, which is exactly the condition this change exists to remove, with no diagnostic. Add `|| return 1` to those calls (with an error message) so staging fails closed.
- ⚠️ `bin/fm-spawn.sh:1994` - stage_source maps a whole referenced directory (`stage_add_map &#34;$reference&#34; &#34;$target_rel&#34;`), and the perl rewrite&#39;s boundary `(?![A-Za-z0-9_-])` deliberately allows `/`, so the directory mapping also rewrites every longer path under it. The comment at 2064-2066 claims &#39;a staged parent directory never wins over the longer path it contains&#39;, but longest-first ordering only protects paths that are themselves in the map — and only the eight enumerated spellings in stage_external_outputs are pinned. Failing sequence: a brief that names an existing firstmate directory (`The prior task directory is `$FM_HOME/data/plan-review``) and then a file to create inside it (`append your decision to `$FM_HOME/data/plan-review/decisions/new.md``) stages the directory, leaves the not-yet-existing file unmapped, and the parent-prefix rewrite silently redirects the write into $WT/.fm/refs/home/data/plan-review/decisions/new.md, which is discarded at teardown. Either do not map bare directories, or restrict the directory mapping to a prefix rewrite for paths that were actually staged.
- ⚠️ `bin/fm-spawn.sh:1993` - A directory reference walks `find &#34;$source&#34; -type f -print` and stage_file copies every file, then re-scans each copy for nested references (2050), with no depth, count, or size cap. Note that in the default single-home layout FM_HOME == FM_ROOT (line 171), so the whole firstmate repo and the whole home are staging roots. Failing sequence: a brief whose {TASK} context names `$FM_HOME/data` or `$FM_ROOT/bin` copies the entire subtree into the project worktree before launch — on a busy home that is every prior task&#39;s brief and report, one `perl` process per file for the reference scan and another per file for the rewrite, all on the critical path between worktree creation and the harness launch that later polls with a 60s budget. Consider refusing (or logging and skipping) a directory reference above a small file-count threshold rather than staging it wholesale.
- ℹ️ `bin/fm-spawn.sh:2455` - The new external_directory map grants exactly $STATE_REAL/* and $STAGE_OUTPUT_DIR_REAL/*, described as &#39;the task&#39;s deliberate firstmate output directories&#39;. But fm-spawn.sh itself creates /tmp/fm-&lt;id&gt;/gotmp (line 1664) and exports GOTMPDIR into the pane for every harness (line 2486), and a mode=no-mistakes ship task additionally drives the no-mistakes pipeline, which writes under its own home outside the worktree. Those are equally deliberate outside-worktree writes and are not in the map, so an opencode crewmate on a Go project or running /no-mistakes can still hit the gate this change was added to close. This is not a regression (the previous config had no external_directory key at all), so it is a completeness question rather than a break — worth confirming whether the grant is intended to stay this narrow.
- ℹ️ `bin/fm-spawn.sh:2096` - The comment says the staging directory is &#39;excluded from this worktree&#39;s private Git metadata&#39;, but exclude_path resolves the target with `git rev-parse --git-path info/exclude`, which returns the COMMON git dir&#39;s info/exclude, shared by the project&#39;s primary checkout and every other worktree (verified in this repo: it resolves to the bare repo&#39;s info/exclude, not a per-worktree file). So `exclude_path &#39;.fm/&#39;` makes `.fm/` ignored repo-wide in the user&#39;s project for as long as that clone exists, and would mask a legitimate project-owned .fm/ directory. The mechanism is pre-existing (four other call sites), but this is the first directory-wide entry and the comment&#39;s claim is inaccurate — correct the comment to say the exclusion is repo-wide.
- ℹ️ `bin/fm-spawn.sh:2092` - Staging copies firstmate-home content (other tasks&#39; briefs and reports, plan documents, whatever the brief happens to name) into a project worktree whose branch the crewmate is instructed to commit and push as a PR. Containment rests entirely on the info/exclude entry: `git add -A` honours it, but a `git add -f`, a tool that bypasses excludes, or a project hook that stages everything would carry firstmate-internal content into a public PR. Noting the new exposure surface as a tradeoff of the design rather than a defect — the exclude is the right first-line control.

🔧 Fix: Bound brief staging paths, programs, and directory caps
3 issues (2 warnings, 1 info) still open:
- ⚠️ `bin/fm-spawn.sh:2609` - The opencode external_directory rules are built from physically-resolved paths ($TASK_TMP_REAL at 2609, $STATE_REAL at 2607, $STAGE_OUTPUT_DIR_REAL at 2608) while the paths the crewmate actually uses keep their logical spelling. Concrete and guaranteed on darwin, the platform this fleet targets: /tmp is a symlink to private/tmp, so TASK_TMP_REAL is /private/tmp/fm-&lt;id&gt; and the grant is &#34;/private/tmp/fm-&lt;id&gt;/*&#34;, but line 2640 still exports GOTMPDIR=$TASK_TMP/gotmp, i.e. /tmp/fm-&lt;id&gt;/gotmp. If opencode matches the rule against the literal path a tool was handed, the rule this round added to close the GOTMPDIR gap never matches and the gap stays open. The same class applies to the status file: stage_external_outputs (2166-2176) deliberately enumerates BOTH the $STATE and $STATE_REAL spellings because the brief can carry either, yet the grant lists only $STATE_REAL - a firstmate home reached through a symlink (exercised by test_home_defaults_preserve_absolute_or_resolve_relative_paths) gives the crewmate a status path that no rule covers. Either emit both spellings when they differ, or derive the exported GOTMPDIR from TASK_TMP_REAL so the two agree.
- ⚠️ `bin/fm-spawn.sh:2113` - The new comment at 2087-2089 states the invariant &#39;A reference is mapped only once the copy it points at actually exists, so a skipped program, a refused directory, or an exhausted budget leaves the real path in the brief&#39;. That holds only when NOTHING under the reference staged. For a directory, `[ -d &#34;$target&#34; ] &amp;&amp; stage_add_map` (2113) fires as soon as one file landed; for a glob, `matched=1` (2129) needs only one surviving match. Failing sequence: a brief says &#39;everything you need is in `$FM_HOME/data/plan-review`&#39; and that directory holds notes.md plus an executable repro.sh - stage_is_program (2043) silently skips repro.sh, notes.md stages, the directory target exists, so the reference is rewritten to the staged copy and the agent is pointed at a directory that is missing the file it was sent for, with no warning naming the reference. The same happens mid-directory when the 256-file / 8 MiB run budget is exhausted (stage_budget_allows returns non-zero and stage_file returns 0 at 2061, so the loop keeps going and earlier files remain staged). Either skip the mapping when any file under the reference was not staged, or emit a per-reference warning naming what is missing so the incompleteness is not silent.
- ℹ️ `bin/fm-spawn.sh:1836` - stage_is_program classifies a path as a program on `*/bin/*` OR on `[ -f ] &amp;&amp; [ -x ]`. Excluding trusted enforcement scripts is exactly what was asked for, but the exec-bit half also captures ordinary brief INPUTS that merely carry mode 755 - a repro script a prior scout wrote under data/&lt;task&gt;/, a fixture checked out with an odd mode. Such a file is never staged and keeps its outside path, and the opencode external_directory grant covers only state, the report directory, and the temp root, so an opencode crewmate cannot read it. The module header at 135-139 scopes its claim correctly (&#39;invoked rather than read&#39;), so this is a completeness question rather than a contradiction: worth confirming whether the exec-bit test should be narrowed (e.g. to a bin/ path plus a shebang check) so an executable data input is still staged as an input.

🔧 Fix: Grant both path spellings and refuse partial staging
1 warning still open:
- ⚠️ `bin/fm-spawn.sh:1853` - stage_is_program now requires rel to start with bin/ AND the file to be executable AND to start with &#39;#!&#39;. The bin/ path test alone was what kept firstmate&#39;s own code out of the writable worktree; adding `[ -x ]` re-admits it. Measured in this checkout: of 123 files under bin/, 27 are mode 644 (every bin/*-lib.sh, bin/fm-backend.sh, and bin/backends/{cmux,herdr,orca,tmux,zellij}.sh), and 11 of those also have no shebang (they start with `# shellcheck shell=bash`), so relaxing only the -x half would still miss them. Concrete failing sequence: a firstmate-repo brief names `$FM_ROOT/bin/fm-config-inherit-lib.sh` (mode 644, no shebang) - stage_is_program returns 1, stage_file copies it to $WT/.fm/refs/root/bin/, and stage_rewrite_file repoints the brief at that copy; line 43 of that lib sources `$(dirname &#34;${BASH_SOURCE[0]}&#34;)/fm-startup-memory-budget-lib.sh`, which does not exist in the staged directory, so using the copy fails under set -e - and a writable copy of trusted firstmate code now sits in the agent&#39;s own laboratory, the condition the previous round closed. A directory reference has the same shape: `$FM_ROOT/bin/backends` passes stage_is_broad_root (only bare `bin` is listed) and the caps (7 files, ~270 KB &lt; 2 MiB), so the two executable .py files return 2 and the reference correctly keeps its real path, but ~260 KB of backend source is still copied into the worktree for nothing. The earliest boundary that restores the invariant is the bin/ path test on its own: nothing under a firstmate root&#39;s own bin/ is ever a brief input, so dropping the -x and shebang conditions there keeps &#39;ordinary executable data inputs must still be staged&#39; intact (the new test&#39;s data/prior/repro.sh lives under data/, not bin/, and stays staged). Flagging as ask-user because the shebang/interpreter check was an explicit instruction, and this revisits it.

🔧 Fix: Exclude all firstmate bin/ content from brief staging
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bin/fm-test-run.sh tests/fm-spawn-dispatch-profile.test.sh` — 29 tests pass, including the three new staging tests (`test_spawn_stages_firstmate_brief_and_references`, `test_spawn_keeps_the_real_path_for_a_partially_staged_reference`, `test_crewmate_spawn_never_stages_from_the_project_checkout`) and the tightened `test_opencode_threads_model_and_ignores_effort_axis`</code>
- <code>`bin/fm-test-run.sh tests/fm-kimi-harness.test.sh` — 17 tests pass; covers the Kimi pointer now naming `&lt;worktree&gt;/.fm/brief.md`</code>
- <code>`bin/fm-test-run.sh tests/fm-spawn-batch.test.sh tests/fm-spawn-worktree-settle.test.sh tests/fm-secondmate-harness.test.sh tests/fm-trace-context-spawn.test.sh tests/fm-brief.test.sh` — 5 neighboring spawn/brief scripts pass, no regressions from inserting staging on the spawn critical path</code>
- <code>Manual end-to-end demo: drove the real `bin/fm-spawn.sh &lt;id&gt; &lt;project&gt; --mode no-mistakes --yolo off` with a fake tmux pane against a synthetic firstmate home whose brief names an absolute prior report, an exec-bit repro script, a decision glob, a firstmate `bin/` helper, and both output paths; captured the original brief, the staged `&lt;wt&gt;/.fm/brief.md`, the staged file tree, and the literal launch command</code>
- <code>Manual check: `find .fm -type f` in the task worktree shows the transitively-referenced `trace.log` (named only inside the staged report, never in the brief) was staged, and the decision glob expanded to both decision files</code>
- <code>Manual check: `git check-ignore -v .fm/brief.md` plus `git status --porcelain` in the task worktree — staged material is excluded and the crewmate&#39;s branch stays clean</code>
- <code>Manual check: classified every input path in the staged brief as inside/outside the worktree — only the two deliberate output paths (`data/&lt;id&gt;/report.md`, `state/&lt;id&gt;.status`) remain external</code>
- <code>Manual check: `ls -l bin/fm-config-inherit-lib.sh bin/fm-ensure-agents-md.sh` confirms the test exercises both a mode-644 library and a mode-755 program under `bin/`, so the path-based (not exec-bit-based) program rule is genuinely covered</code>

</details>

<details>
<summary>🔧 **Document** - 2 issues found → auto-fixed ✅</summary>

- ⚠️ `AGENTS.md:472` - Brief staging changes a contract for brief authors that no brief-authoring surface states: a firstmate-home path a brief names is now handed to the crewmate as a snapshot copy under `.fm/refs/`, and an EXISTING firstmate-home file named as a write target (e.g. a shared decisions file) is rewritten to that copy, so the write lands in the disposable worktree and is lost. Only `state/&lt;id&gt;.status` and a scout&#39;s `data/&lt;id&gt;/report.md` stay external, and a not-yet-created path keeps its real path. `bin/fm-spawn.sh`&#39;s header records this as launch mechanics, but brief authors read `AGENTS.md` section 11 and `bin/fm-brief.sh`&#39;s help, neither of which mentions it. I did not fix it because the only owners are always-loaded `AGENTS.md` (high bar for an addition) and the script&#39;s help output (executable behavior this phase must not change) - a placement call worth an explicit decision.
- ℹ️ `docs/configuration.md:469` - The seven new staging knobs (FM_STAGE_MAX_DIR_DEPTH, FM_STAGE_MAX_DIR_FILES, FM_STAGE_MAX_DIR_BYTES, FM_STAGE_MAX_FILES, FM_STAGE_MAX_BYTES, FM_STAGE_MAX_SCAN_DEPTH, FM_STAGE_MISSING_NAMED) are not in the `Environment variables` list in docs/configuration.md, which otherwise carries 86 FM_ entries including test-mainly ones. I deliberately left them out: that list already omits the comparable spawn-internal knobs (FM_KIMI_READY_POLLS, FM_KIMI_DELIVERY_POLLS, FM_KIMI_POLL_INTERVAL), and configuration.md names `bin/fm-spawn.sh` as the owner of launch mechanics, where the caps and their rationale already live. Flagging in case the list is meant to be exhaustive for operator-tunable caps.

🔧 Fix: State brief write-target contract for staged firstmate paths
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
