### PR TITLE
fix: recognize benign owner-delivered watcher closes on OpenCode and Pi

### DIFF
--- a/.opencode/plugins/fm-primary-watch-arm.js
+++ b/.opencode/plugins/fm-primary-watch-arm.js
@@ -131,9 +131,12 @@ async function sessionOwnsLock(paths) {
 
 function classifyArmClose(stdout, stderr, code, signal) {
   const combined = `${stdout}\n${stderr}`;
-  const reason = combined.split(/\r?\n/).find((line) => /^(signal:|stale:|check:|heartbeat($|:))/.test(line));
+  const lines = combined.split(/\r?\n/);
+  const reason = lines.find((line) => /^(signal:|stale:|check:|heartbeat($|:))/.test(line));
   if (reason) return { kind: "actionable", message: reason };
-  const healthy = combined.split(/\r?\n/).find((line) => /^watcher: healthy\b/.test(line));
+  const benignClose = lines.find((line) => line === "watcher: cycle closed actionably (reason delivered by its owner arm)");
+  if (benignClose) return { kind: "benign", message: benignClose };
+  const healthy = lines.find((line) => /^watcher: healthy\b/.test(line));
   if (healthy) {
     return {
       kind: "failure",
@@ -354,6 +357,7 @@ function spawnArm(paths, sessionID, client, predecessorArmPid = "") {
       setArmStatus("failed");
       return;
     }
+    if (classification.kind === "benign") retryFailures = 0;
     void scheduleRetry(paths, sessionID, client, classification.message, predecessor);
   });
   armChild.on("error", (error) => {

--- a/.pi/extensions/fm-primary-pi-watch.ts
+++ b/.pi/extensions/fm-primary-pi-watch.ts
@@ -31,7 +31,7 @@ type ArmResult = {
 type LockOwnership = "owned" | "missing" | "other";
 
 type CloseClassification = {
-  kind: "actionable" | "failure";
+  kind: "actionable" | "benign" | "failure";
   message: string;
 };
 
@@ -157,7 +157,10 @@ function classifyClose(stdout: string, stderr: string, code: number | null, sign
   const combined = `${stdout}\n${stderr}`.trim();
   const reason = actionableLine(combined);
   if (reason) return { kind: "actionable", message: reason };
-  const healthy = combined.split(/\r?\n/).find((line) => /^watcher: healthy\b/.test(line));
+  const lines = combined.split(/\r?\n/);
+  const benignClose = lines.find((line) => line === "watcher: cycle closed actionably (reason delivered by its owner arm)");
+  if (benignClose) return { kind: "benign", message: benignClose };
+  const healthy = lines.find((line) => /^watcher: healthy\b/.test(line));
   if (healthy) {
     return {
       kind: "failure",
@@ -435,6 +438,7 @@ export default function (pi: ExtensionAPI) {
         return;
       }
       if (owner.restoring) return;
+      if (classification.kind === "benign") owner.retryFailures = 0;
       scheduleRetry(owner, classification.message, predecessor);
     });
     armChild.on("error", (error: Error) => {

--- a/docs/watcher-continuity.md
+++ b/docs/watcher-continuity.md
@@ -8,6 +8,8 @@ Must-work continuity now lives above that process boundary instead of depending 
 Pi's `.pi/extensions/fm-primary-pi-watch.ts` and OpenCode's `.opencode/plugins/fm-primary-watch-arm.js` own continuous re-arm after an actionable child close.
 Each adapter starts the next arm before delivering the wake prompt, checks current session-lock ownership at launch, preserves one child or scheduled retry at a time, and applies bounded exponential retry after an unexpected or failed close.
 A failed follow-up never cancels continuity restoration.
+Both adapters classify a close whose only status line is the typed owner-delivered clean close, `watcher: cycle closed actionably (reason delivered by its owner arm)`, as benign: the wake was already delivered by the arm that owned it, so the adapter re-arms through the same bounded retry path but resets its failure count instead of counting a generic failure or reporting a watcher failure.
+Repeated benign closes therefore never exhaust the retry limit, and Claude keeps its own separate live-watcher benign predicate below.
 Pi same-process session replacement follows the generation-owner contract in `.pi/extensions/fm-primary-pi-watch.ts`.
 Claude's `.claude/settings.json` Stop `asyncRewake` hook (`bin/fm-claude-stop-autoarm.sh`) owns routine tokenless re-arm.
 The hook fires on every Stop, and an eligible primary with supervision need admits one home-scoped owner that foregrounds `bin/fm-watch-arm.sh` inside the hook-owned process tree.
@@ -61,6 +63,7 @@ Only the watcher process touches `state/.last-watcher-beat`; no helper process c
 ## Regression coverage
 
 `tests/fm-pi-watch-extension.test.sh` checks Pi's first-cycle-or-explicit-repair tool metadata and ownership-based redundant-call no-ops, then simulates actionable and empty child closes against the actual Pi and OpenCode close handlers, blocks prompt delivery to prove the successor launches first, verifies single-flight behavior, changes the session lock before close to prove ownership is rechecked, and hangs each successor arm to prove bounded fallback delivery includes the typed restoration failure.
+It also drives repeated owner-delivered clean closes past the ordinary failure retry limit on both Pi and OpenCode to prove that vocabulary keeps re-arming without accumulating generic-failure retries or surfacing a watcher-failure prompt.
 The same suite covers ordinary same-process session replacement for `/new`, `/resume`, and `/fork`, same-instance shutdown-plus-start, stale prior-generation callbacks, repeated transitions with exactly one live cycle, disappearance of the shutting-down refusal after a valid replacement activates, and terminal quit still refusing late rearm.
 `tests/fm-watcher-lock.test.sh` covers verified-successor attach, the typed self-eviction failure, bounded and successor-linked lifecycle rows, and a SIGSTOP counterfactual that distinguishes a live PID from a stale beacon before classifying termination.
 `tests/fm-subagent-pretool-check.test.sh` proves Claude retains only the non-status Bash seatbelts.

--- a/tests/fm-pi-watch-extension.test.sh
+++ b/tests/fm-pi-watch-extension.test.sh
@@ -630,6 +630,69 @@ EOF
   pass "Pi late unretired closes resume classified supervision"
 }
 
+test_pi_benign_attached_closes_refresh_retry_budget() {
+  local repo home plugin log stop out status
+  repo="$TMP_ROOT/pi-benign-attached-close-root"
+  home="$TMP_ROOT/pi-benign-attached-close-home"
+  log="$TMP_ROOT/pi-benign-attached-close.log"
+  stop="$TMP_ROOT/pi-benign-attached-close.stop"
+  mkdir -p "$repo/bin" "$home/state" "$home/config"
+  install_pi_watch_extension_fixture "$repo"
+  plugin="$repo/.pi/extensions/fm-primary-pi-watch.ts"
+  cat > "$repo/bin/fm-watch-arm.sh" <<'SH'
+#!/usr/bin/env bash
+printf 'arm=%s\n' "$$" >> "${FM_ARM_LOG:?}"
+count=$(wc -l < "$FM_ARM_LOG" | tr -d '[:space:]')
+if [ "$count" -le 4 ]; then
+  printf 'watcher: attached pid=%s (beacon 0s)\n' "$$"
+  printf 'watcher: cycle closed actionably (reason delivered by its owner arm)\n'
+  exit 0
+fi
+printf 'watcher: started pid=%s (beacon fresh)\n' "$$"
+trap 'exit 0' TERM INT
+while [ ! -e "$FM_STOP_FILE" ]; do sleep 0.02; done
+SH
+  chmod +x "$repo/bin/fm-watch-arm.sh"
+  out=$(PLUGIN="$plugin" FM_HOME="$home" FM_ROOT_OVERRIDE="$repo" FM_ARM_LOG="$log" FM_STOP_FILE="$stop" FM_WATCH_REARM_RETRY_BASE_MS=5 FM_WATCH_REARM_RETRY_MAX_MS=10 FM_WATCH_REARM_RETRY_LIMIT=2 node --input-type=module 2>&1 <<'EOF'
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+
+let tool = null;
+const prompts = [];
+const pi = {
+  on() {},
+  registerCommand() {},
+  registerTool(candidate) {
+    if (candidate.name === "fm_watch_arm_pi") tool = candidate;
+  },
+  sendUserMessage: async (message) => {
+    prompts.push(message);
+  },
+};
+writeFileSync(`${process.env.FM_HOME}/state/.lock`, `${process.pid}\n`);
+const mod = await import(pathToFileURL(process.env.PLUGIN).href);
+mod.default(pi);
+await tool.execute("tool-call-benign-attached-close", {}, undefined, undefined, {});
+for (let i = 0; i < 250; i += 1) {
+  const rows = existsSync(process.env.FM_ARM_LOG)
+    ? readFileSync(process.env.FM_ARM_LOG, "utf8").trim().split("\n")
+    : [];
+  if (rows.length >= 5) break;
+  await new Promise((resolve) => setTimeout(resolve, 10));
+}
+const rows = readFileSync(process.env.FM_ARM_LOG, "utf8").trim().split("\n");
+if (rows.length !== 5) throw new Error(`benign attached closes exhausted the retry budget after ${rows.length} arms`);
+if (prompts.length !== 0) throw new Error(`benign attached closes surfaced a failure prompt: ${prompts.join(" | ")}`);
+writeFileSync(process.env.FM_STOP_FILE, "stop\n");
+await new Promise((resolve) => setTimeout(resolve, 80));
+EOF
+  )
+  status=$?
+  expect_code 0 "$status" "Pi must recognize owner-delivered attached closes as benign"
+  [ -z "$out" ] || fail "Pi benign attached-close test printed output: $out"
+  pass "Pi recognizes owner-delivered attached closes without exhausting failure retries"
+}
+
 test_pi_empty_close_retries_instead_of_disappearing() {
   local repo home plugin log stop out status
   repo="$TMP_ROOT/pi-empty-close-root"
@@ -1796,6 +1859,71 @@ EOF
   pass "OpenCode late unretired closes resume classified supervision"
 }
 
+test_opencode_benign_attached_closes_refresh_retry_budget() {
+  local plugin repo home log stop out status
+  plugin="$ROOT/.opencode/plugins/fm-primary-watch-arm.js"
+  repo="$TMP_ROOT/opencode-benign-attached-close-root"
+  home="$TMP_ROOT/opencode-benign-attached-close-home"
+  log="$TMP_ROOT/opencode-benign-attached-close.log"
+  stop="$TMP_ROOT/opencode-benign-attached-close.stop"
+  mkdir -p "$repo/bin" "$home/state" "$home/config"
+  git init -q "$repo"
+  : > "$repo/AGENTS.md"
+  : > "$home/state/task.meta"
+  cat > "$repo/bin/fm-watch-arm.sh" <<'SH'
+#!/usr/bin/env bash
+printf 'arm=%s\n' "$$" >> "${FM_ARM_LOG:?}"
+count=$(wc -l < "$FM_ARM_LOG" | tr -d '[:space:]')
+if [ "$count" -le 4 ]; then
+  printf 'watcher: attached pid=%s (beacon 0s)\n' "$$"
+  printf 'watcher: cycle closed actionably (reason delivered by its owner arm)\n'
+  exit 0
+fi
+printf 'watcher: started pid=%s (beacon fresh)\n' "$$"
+trap 'exit 0' TERM INT
+while [ ! -e "$FM_STOP_FILE" ]; do sleep 0.02; done
+SH
+  chmod +x "$repo/bin/fm-watch-arm.sh"
+  out=$(PLUGIN="$plugin" WORKTREE="$repo" FM_HOME="$home" FM_ARM_LOG="$log" FM_STOP_FILE="$stop" FM_WATCH_REARM_RETRY_BASE_MS=5 FM_WATCH_REARM_RETRY_MAX_MS=10 FM_WATCH_REARM_RETRY_LIMIT=2 node 2>&1 <<'EOF'
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+
+const mod = await import(pathToFileURL(process.env.PLUGIN).href);
+const prompts = [];
+const client = {
+  session: {
+    promptAsync: async (request) => {
+      prompts.push(request.body.parts[0].text);
+    },
+  },
+};
+const hooks = await mod.FmPrimaryWatchArm({
+  client,
+  directory: process.env.WORKTREE,
+  worktree: process.env.WORKTREE,
+});
+writeFileSync(`${process.env.FM_HOME}/state/.lock`, `${process.pid}\n`);
+await hooks.event({ event: { type: "session.idle", properties: { sessionID: "session-test" } } });
+for (let i = 0; i < 250; i += 1) {
+  const rows = existsSync(process.env.FM_ARM_LOG)
+    ? readFileSync(process.env.FM_ARM_LOG, "utf8").trim().split("\n")
+    : [];
+  if (rows.length >= 5) break;
+  await new Promise((resolve) => setTimeout(resolve, 10));
+}
+const rows = readFileSync(process.env.FM_ARM_LOG, "utf8").trim().split("\n");
+if (rows.length !== 5) throw new Error(`benign attached closes exhausted the retry budget after ${rows.length} arms`);
+if (prompts.length !== 0) throw new Error(`benign attached closes surfaced a failure prompt: ${prompts.join(" | ")}`);
+writeFileSync(process.env.FM_STOP_FILE, "stop\n");
+await new Promise((resolve) => setTimeout(resolve, 80));
+EOF
+  )
+  status=$?
+  expect_code 0 "$status" "OpenCode must recognize owner-delivered attached closes as benign"
+  [ -z "$out" ] || fail "OpenCode benign attached-close test printed output: $out"
+  pass "OpenCode recognizes owner-delivered attached closes without exhausting failure retries"
+}
+
 test_opencode_empty_close_retries_instead_of_disappearing() {
   local plugin repo home log stop out status
   plugin="$ROOT/.opencode/plugins/fm-primary-watch-arm.js"
@@ -2132,6 +2260,7 @@ test_pi_actionable_close_starts_single_successor_before_delivery
 test_pi_hung_successor_falls_back_to_typed_wake
 test_pi_unretired_successor_falls_back_without_retry
 test_pi_late_unretired_close_resumes_supervision
+test_pi_benign_attached_closes_refresh_retry_budget
 test_pi_empty_close_retries_instead_of_disappearing
 test_pi_established_empty_close_honors_retry_limit
 test_pi_actionable_close_rechecks_session_lock
@@ -2149,6 +2278,7 @@ test_opencode_pre_ready_actionable_close_preserves_its_successor
 test_opencode_hung_successor_falls_back_to_typed_wake
 test_opencode_unretired_successor_falls_back_without_retry
 test_opencode_late_unretired_close_resumes_supervision
+test_opencode_benign_attached_closes_refresh_retry_budget
 test_opencode_empty_close_retries_instead_of_disappearing
 test_opencode_established_empty_close_honors_retry_limit
 test_opencode_actionable_close_rechecks_session_lock


### PR DESCRIPTION
## Intent

Extend the benign attached-close vocabulary to the OpenCode and Pi arm extensions so the typed owner-delivered clean close from PR 1416 is recognized as benign and no longer accumulates generic-failure retries or reports false watcher failures on those harnesses. Preserve Claude behavior. Add regression tests proving the new vocabulary recognition on both OpenCode and Pi, including repeated benign closes beyond the ordinary failure retry limit.

## What Changed

- `.opencode/plugins/fm-primary-watch-arm.js` and `.pi/extensions/fm-primary-pi-watch.ts` now classify an arm close whose only status line is `watcher: cycle closed actionably (reason delivered by its owner arm)` as a new `benign` kind, ahead of the existing `watcher: healthy` check; both adapters hoist the single line split used by the surrounding classification branches.
- On a benign close each adapter resets its failure counter (`retryFailures` / `owner.retryFailures`) before scheduling the bounded retry, so repeated owner-delivered closes re-arm indefinitely instead of exhausting the retry limit and surfacing a generic watcher-failure prompt. No Claude-side file changed, so the Stop-hook path is untouched.
- `tests/fm-pi-watch-extension.test.sh` adds `test_pi_benign_attached_closes_refresh_retry_budget` and `test_opencode_benign_attached_closes_refresh_retry_budget`, driving repeated benign closes past the ordinary retry limit on both harnesses; `docs/watcher-continuity.md` documents the new class as adapter-side recognition and its regression coverage.

Review flagged the adapters' exact-string match (siblings use anchored prefix regexes) and noted the producing line lands with PR 1416, so this recognition is a runtime no-op until that merges; the test suites (`fm-pi-watch-extension.test.sh`, 32 passing; `fm-claude-stop-autoarm.test.sh`, 22 passing) drive the contract string from fixtures. Documentation review also asks that `docs/verification/supervision.md` gain an observed-evidence entry for this guarantee.

## Risk Assessment

✅ Low: The change is a tightly bounded, additive third classification kind in two adapters that mirrors an already-accepted design, leaves Claude untouched, cannot produce a re-arm hot loop (the ledger predicate is time-bounded and the benign row is not self-matching), and ships discriminating regression tests on both harnesses; the only issues found are informational robustness and dedup nits.

## Testing

Ran the two targeted suites (the Pi/OpenCode watch-extension file, 32 tests, and the Claude Stop auto-arm file, 22 tests) — all green, covering the two new benign-close regression tests, the retained retry-limit tests for genuinely unexplained closes, and Claude behavior preservation. Beyond unit results I drove the base-commit and target-commit adapters through the same repeated owner-delivered clean close and captured the operator-facing outcome: before the change both OpenCode and Pi stopped after 3 arms and delivered a false "could not restore watcher continuity after 2 retries" prompt into the agent session; after the change both kept supervision alive well past the retry limit (16 and 17 arms) and surfaced no prompt at all. No rendered-UI artifact applies here because the end-user surface for this change is the CLI/agent-session prompt stream, which the captured transcript shows directly.

<details>
<summary>Evidence: Before/after transcript: benign close on OpenCode and Pi adapters</summary>

<code>Scenario: watcher arm repeatedly closes with the PR-1416 typed owner-delivered clean close&#10;&#34;watcher: cycle closed actionably (reason delivered by its owner arm)&#34;&#10;retry limit = 2 (ordinary generic-failure budget), observation window caps at 8 arms&#10;&#10;=== opencode adapter | before (3d9d12d) ===&#10;arms launched by the adapter: 3&#10;operator-visible prompts surfaced into the session: 1&#10;--- prompt delivered to the agent session ---&#10;FIRSTMATE_OP: v1 watcher: WATCHER FIRED - drain queued wakes with bin/fm-wake-drain.sh and handle the reported wake. Watcher continuity is plugin-owned.&#10;&#10;watcher: FAILED - OpenCode could not restore watcher continuity after 2 retries&#10;watcher: FAILED - OpenCode arm cycle ended without an actionable reason&#10;&#10;=== opencode adapter | after (86cd70d) ===&#10;arms launched by the adapter: 16&#10;operator-visible prompts surfaced into the session: 0&#10;&#10;=== pi adapter | before (3d9d12d) ===&#10;arms launched by the adapter: 3&#10;operator-visible prompts surfaced into the session: 1&#10;--- prompt delivered to the agent session ---&#10;FIRSTMATE_OP: v1 watcher: FIRSTMATE WATCHER WAKE: watcher: FAILED - Pi extension could not restore watcher continuity after 2 retries&#10;watcher: FAILED - Pi extension arm cycle ended without an actionable reason&#10;&#10;Run bin/fm-wake-drain.sh first and handle the queued wake. Watcher continuity is extension-owned.&#10;&#10;=== pi adapter | after (86cd70d) ===&#10;arms launched by the adapter: 17&#10;operator-visible prompts surfaced into the session: 0</code>

```text
Scenario: watcher arm repeatedly closes with the PR-1416 typed owner-delivered clean close
          "watcher: cycle closed actionably (reason delivered by its owner arm)"
          retry limit = 2 (ordinary generic-failure budget), observation window caps at 8 arms

========================================================================
opencode adapter | before (3d9d12d)
========================================================================
arms launched by the adapter: 3
operator-visible prompts surfaced into the session: 1
--- prompt delivered to the agent session ---
⁣FIRSTMATE_OP: v1 watcher: WATCHER FIRED - drain queued wakes with bin/fm-wake-drain.sh and handle the reported wake. Watcher continuity is plugin-owned.

watcher: FAILED - OpenCode could not restore watcher continuity after 2 retries
watcher: FAILED - OpenCode arm cycle ended without an actionable reason

========================================================================
opencode adapter | after (86cd70d)
========================================================================
arms launched by the adapter: 16
operator-visible prompts surfaced into the session: 0

========================================================================
pi adapter | before (3d9d12d)
========================================================================
arms launched by the adapter: 3
operator-visible prompts surfaced into the session: 1
--- prompt delivered to the agent session ---
⁣FIRSTMATE_OP: v1 watcher: FIRSTMATE WATCHER WAKE: watcher: FAILED - Pi extension could not restore watcher continuity after 2 retries
watcher: FAILED - Pi extension arm cycle ended without an actionable reason

Run bin/fm-wake-drain.sh first and handle the queued wake. Watcher continuity is extension-owned.

========================================================================
pi adapter | after (86cd70d)
========================================================================
arms launched by the adapter: 17
operator-visible prompts surfaced into the session: 0
```
</details>
<details>
<summary>Evidence: Reproducible before/after driver script</summary>

```text
#!/usr/bin/env bash
# Before/after demonstration of the benign attached-close vocabulary on the
# OpenCode and Pi arm extensions.
#
# Scenario (identical for every run): the watcher arm keeps closing with the
# typed owner-delivered clean close introduced by PR 1416
#   watcher: cycle closed actionably (reason delivered by its owner arm)
# which is what a duplicate/attached observer sees for an ordinary wake that the
# owner arm already delivered. The retry limit is set to 2 so the "generic
# failure retries" budget is small and easy to observe.
#
# Recorded per run: how many arms the adapter launched inside the window and any
# operator-visible prompt the adapter surfaced into the agent session.
set -u

ROOT=${ROOT:?repo root required}
EVID=${EVID:?evidence dir required}
BASE_REV=${BASE_REV:-3d9d12db7412e5da0751745c14603e7e427f8877}
HEAD_REV=${HEAD_REV:-86cd70db2db89f7ba8ce0984e50c6d70cc0e2915}
WORK="$EVID/work"
rm -rf "$WORK"
mkdir -p "$WORK"
export NODE_NO_WARNINGS=1

write_fake_arm() {
  # Always closes with the typed owner-delivered benign line, so the whole run
  # exercises exactly the vocabulary this change teaches the adapters.
  cat > "$1" <<'SH'
#!/usr/bin/env bash
printf 'arm=%s\n' "$$" >> "${FM_ARM_LOG:?}"
printf 'watcher: attached pid=%s (beacon 0s)\n' "$$"
printf 'watcher: cycle closed actionably (reason delivered by its owner arm)\n'
exit 0
SH
  chmod +x "$1"
}

install_pi_fixture() {
  local repo=$1 rev=$2
  mkdir -p "$repo/.pi/extensions/lib" \
    "$repo/node_modules/@earendil-works/pi-coding-agent" \
    "$repo/node_modules/@earendil-works/pi-tui" \
    "$repo/node_modules/typebox" "$repo/bin"
  git -C "$ROOT" show "$rev:.pi/extensions/fm-primary-pi-watch.ts" > "$repo/.pi/extensions/fm-primary-pi-watch.ts"
  cp "$ROOT/.pi/extensions/lib/fm-calm-visibility.ts" "$repo/.pi/extensions/lib/fm-calm-visibility.ts"
  cp "$ROOT/.pi/extensions/lib/fm-operational-input.ts" "$repo/.pi/extensions/lib/fm-operational-input.ts"
  cp "$ROOT/bin/fm-operational-input.sh" "$repo/bin/fm-operational-input.sh"
  chmod +x "$repo/bin/fm-operational-input.sh"
  printf '%s\n' '{"name":"@earendil-works/pi-coding-agent","type":"module","exports":"./index.js"}' > "$repo/node_modules/@earendil-works/pi-coding-agent/package.json"
  cat > "$repo/node_modules/@earendil-works/pi-coding-agent/index.js" <<'JS'
export function getMarkdownTheme() { return {}; }
export class UserMessageComponent { render() { return []; } invalidate() {} }
JS
  printf '%s\n' '{"name":"@earendil-works/pi-tui","type":"module","exports":"./index.js"}' > "$repo/node_modules/@earendil-works/pi-tui/package.json"
  cat > "$repo/node_modules/@earendil-works/pi-tui/index.js" <<'JS'
export class Box { addChild() {} clear() {} setBgFn() {} }
export class Container {}
export class Text {}
JS
  printf '%s\n' '{"name":"typebox","type":"module","exports":"./index.js"}' > "$repo/node_modules/typebox/package.json"
  cat > "$repo/node_modules/typebox/index.js" <<'JS'
export const Type = { Object(properties) { return { type: "object", properties, additionalProperties: false }; } };
JS
}

run_case() {
  local harness=$1 label=$2 rev=$3
  local repo="$WORK/$harness-$label" home="$WORK/$harness-$label-home"
  local log="$WORK/$harness-$label.armlog"
  mkdir -p "$repo/bin" "$home/state" "$home/config"
  : > "$home/state/task.meta"

  printf '\n========================================================================\n'
  printf '%s adapter | %s (%s)\n' "$harness" "$label" "${rev:0:7}"
  printf '========================================================================\n'

  if [ "$harness" = "opencode" ]; then
    git init -q "$repo"
    : > "$repo/AGENTS.md"
    mkdir -p "$repo/.opencode"
    cp -R "$ROOT/.opencode/plugins" "$repo/.opencode/plugins"
    git -C "$ROOT" show "$rev:.opencode/plugins/fm-primary-watch-arm.js" > "$repo/.opencode/plugins/fm-primary-watch-arm.js"
    cp "$ROOT/bin/fm-operational-input.sh" "$repo/bin/fm-operational-input.sh"
    chmod +x "$repo/bin/fm-operational-input.sh"
    write_fake_arm "$repo/bin/fm-watch-arm.sh"
    PLUGIN="$repo/.opencode/plugins/fm-primary-watch-arm.js" WORKTREE="$repo" FM_HOME="$home" \
      FM_ARM_LOG="$log" FM_WATCH_REARM_RETRY_BASE_MS=5 FM_WATCH_REARM_RETRY_MAX_MS=10 \
      FM_WATCH_REARM_RETRY_LIMIT=2 node <<'EOF'
import { existsSync, readFileSync, writeFileSync } from "node:fs";
import { pathToFileURL } from "node:url";

const mod = await import(pathToFileURL(process.env.PLUGIN).href);
const prompts = [];
const client = { session: { promptAsync: async (request) => { prompts.push(request.body.parts[0].text); } } };
const hooks = await mod.FmPrimaryWatchArm({ client, directory: process.env.WORKTREE, worktree: process.env.WORKTREE });
writeFileSync(`${process.env.FM_HOME}/state/.lock`, `${process.pid}\n`);
await hooks.event({ event: { type: "session.idle", properties: { sessionID: "session-demo" } } });
const armCount = () => (existsSync(process.env.FM_ARM_LOG)
  ? readFileSync(process.env.FM_ARM_LOG, "utf8").trim().split("\n").filter(Boolean).length
  : 0);
for (let i = 0; i < 300; i += 1) {
  if (prompts.length > 0 || armCount() >= 8) break;
  await new Promise((r) => setTimeout(r, 10));
}
await new Promise((r) => setTimeout(r, 120));
console.log(`arms launched by the adapter: ${armCount()}`);
console.log(`operator-visible prompts surfaced into the session: ${prompts.length}`);
for (const p of prompts) console.log(`--- prompt delivered to the agent session ---\n${p}`);
process.exit(0);
EOF
  else
    install_pi_fixture "$repo" "$rev"
    write_fake_arm "$repo/bin/fm-watch-arm.sh"
    PLUGIN="$repo/.pi/extensions/fm-primary-pi-watch.ts" FM_HOME="$home" FM_ROOT_OVERRIDE="$repo" \
      FM_ARM_LOG="$log" FM_WATCH_REARM_RETRY_BASE_MS=5 FM_WATCH_REARM_RETRY_MAX_MS=10 \
      FM_WATCH_REARM_RETRY_LIMIT=2 node --input-type=module <<'EOF'
import { existsSync, readFileSync, writeFileSync } from "node:fs";
import { pathToFileURL } from "node:url";

let tool = null;
const prompts = [];
const pi = {
  on() {},
  registerCommand() {},
  registerTool(candidate) { if (candidate.name === "fm_watch_arm_pi") tool = candidate; },
  sendUserMessage: async (message) => { prompts.push(message); },
};
writeFileSync(`${process.env.FM_HOME}/state/.lock`, `${process.pid}\n`);
const mod = await import(pathToFileURL(process.env.PLUGIN).href);
mod.default(pi);
await tool.execute("tool-call-demo", {}, undefined, undefined, {});
const armCount = () => (existsSync(process.env.FM_ARM_LOG)
  ? readFileSync(process.env.FM_ARM_LOG, "utf8").trim().split("\n").filter(Boolean).length
  : 0);
for (let i = 0; i < 300; i += 1) {
  if (prompts.length > 0 || armCount() >= 8) break;
  await new Promise((r) => setTimeout(r, 10));
}
await new Promise((r) => setTimeout(r, 120));
console.log(`arms launched by the adapter: ${armCount()}`);
console.log(`operator-visible prompts surfaced into the session: ${prompts.length}`);
for (const p of prompts) console.log(`--- prompt delivered to the agent session ---\n${p}`);
process.exit(0);
EOF
  fi
}

printf 'Scenario: watcher arm repeatedly closes with the PR-1416 typed owner-delivered clean close\n'
printf '          "watcher: cycle closed actionably (reason delivered by its owner arm)"\n'
printf '          retry limit = 2 (ordinary generic-failure budget), observation window caps at 8 arms\n'

run_case opencode before "$BASE_REV"
run_case opencode after "$HEAD_REV"
run_case pi before "$BASE_REV"
run_case pi after "$HEAD_REV"

printf '\n'
```
</details>
- Outcome: ⚠️ 1 info across 1 run (4m53s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 3 infos</summary>

- ℹ️ `.opencode/plugins/fm-primary-watch-arm.js:137` - Both adapters recognize the benign close with strict string equality (`line === &#34;watcher: cycle closed actionably (reason delivered by its owner arm)&#34;`) at .opencode/plugins/fm-primary-watch-arm.js:137 and .pi/extensions/fm-primary-pi-watch.ts:161, while every sibling classification in the same functions uses an anchored prefix regex (`/^watcher: healthy\b/`, `/^watcher: FAILED/`, `/^(signal:|stale:|check:|heartbeat($|:))/`). The producing line lives in still-open PR 1416 (`report_owner_delivered_close` in bin/fm-watch-arm.sh), i.e. in a different change than this one, and the tests hardcode their own copy of it, so nothing cross-checks the two. If the producer ever gains a suffix (a pid, a cycle id), both adapters silently fall back to the generic `cycle ended without an actionable reason` failure — exactly the symptom this change removes — with every test still green. An anchored prefix match (`/^watcher: cycle closed actionably\b/`) is one line and is also what the Claude-side test in PR 1416 uses (`grep -qF`, substring, not equality).
- ℹ️ `.opencode/plugins/fm-primary-watch-arm.js:146` - The diff hoisted `const lines = combined.split(/\r?\n/)` in both files but left the immediately following FAILED lookup recomputing the same split: `.opencode/plugins/fm-primary-watch-arm.js:146` (`const failed = combined.split(/\r?\n/).find(...)`) and the mirror at `.pi/extensions/fm-primary-pi-watch.ts:170`. Reuse `lines` in both so the hoist is complete and the function has a single tokenization of the arm output.
- ℹ️ `tests/fm-pi-watch-extension.test.sh:648` - No code in this branch (or on main) emits the benign line: `bin/fm-watch-arm.sh` at the target commit has no `cycle closed actionably` output, and PR 1416 — which adds `report_owner_delivered_close` — is still open and unmerged. The two new tests supply the line from their own bash fixtures (tests/fm-pi-watch-extension.test.sh:648 and :1879), so they pass regardless. This is consistent with the stated intent (which names PR 1416 as the source of the vocabulary) and PR 1416&#39;s own deferred finding C, so it is not a defect — just noting that this change is a runtime no-op until 1416 lands, and that no test in either branch pins the adapter matcher to the real emitter.

</details>

<details>
<summary>⚠️ **Test** - 1 info</summary>

- ℹ️ `bin/fm-watch-arm.sh` - The typed line the adapters now recognize (&#34;watcher: cycle closed actionably (reason delivered by its owner arm)&#34;) is emitted by bin/fm-watch-arm.sh only on the unmerged PR-1416 branch (fm/fm-watcher-stale-churn); it is absent from this branch&#39;s base, so the real arm cannot produce it until 1416 lands. Evidence therefore drives the adapters with a scripted arm emitting the exact contract string. No action needed for this change.
- <code>`bash tests/fm-pi-watch-extension.test.sh` — 32 tests pass, including the new `test_pi_benign_attached_closes_refresh_retry_budget` and `test_opencode_benign_attached_closes_refresh_retry_budget`</code>
- <code>`test_pi_established_empty_close_honors_retry_limit` and `test_opencode_established_empty_close_honors_retry_limit` — confirm genuinely unexplained closes still stop at the retry limit</code>
- <code>`bash tests/fm-claude-stop-autoarm.test.sh` — 22 tests pass, confirming Claude Stop-hook behavior is preserved (no Claude-side file in the diff)</code>
- <code>`ROOT=$PWD EVID=/tmp/no-mistakes-evidence/01KZ4XMFN33EJF0B2GV2VVCJSB bash /tmp/no-mistakes-evidence/01KZ4XMFN33EJF0B2GV2VVCJSB/benign-close-demo.sh` — before/after driver loading base (3d9d12d) vs target (86cd70d) OpenCode plugin and Pi extension against an arm that repeatedly emits the typed owner-delivered close, recording arms launched and prompts surfaced into the session</code>
- <code>`git show --stat HEAD` and `git log --all -S&#34;cycle closed actionably&#34;` — confirmed no Claude adapter file changed and located the emitter&#39;s origin branch</code>

</details>

<details>
<summary>⚠️ **Document** - 2 issues (1 warning, 1 info)</summary>

- ⚠️ `docs/watcher-continuity.md:11` - No file in this repository emits the exact line `watcher: cycle closed actionably (reason delivered by its owner arm)` that both adapters now recognize — the only occurrences are the two adapters and the new test fixtures. `bin/fm-watch-arm.sh`&#39;s attached/unobserved-cycle path (`close_unobserved_cycle`, bin/fm-watch-arm.sh:279-306) prints the recorded reason line itself and otherwise emits `watcher: FAILED - cycle ended without an actionable reason`, which is what docs/watcher-continuity.md:49-53 documents. I therefore documented the new class strictly as adapter-side recognition and did not claim the arm layer emits it. Someone should confirm whether PR 1416&#39;s typed owner-delivered clean-close line actually landed in this repo&#39;s arm layer; if it did not, the new benign branch is currently unreachable outside tests and the arm-layer cycle contract section needs a corresponding line once the producer exists.
- ℹ️ `docs/verification/supervision.md:186` - docs/verification/supervision.md (maintainer-verification) records dated evidence for each active supervision guarantee, but has no entry for the new benign owner-delivered close guarantee. Producing that entry requires actually running `tests/fm-pi-watch-extension.test.sh` and pasting real output, which belongs to the validation phase rather than this documentation phase; I did not fabricate an evidence block. Consider appending the observed run there when the suite passes.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
