### PR TITLE
feat(bin): preflight remote runtime tool paths

### DIFF
--- a/bin/fm-remote-doctor.sh
+++ b/bin/fm-remote-doctor.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Report the runtime PATH and tool resolution of a Firstmate remote account.
+#
+# Usage:
+#   bin/fm-on.sh <secondmate-id|ssh-alias> fm-remote-doctor.sh
+#
+# Read-only preflight. Run it through fm-on.sh so the fixed remote entrypoint
+# composes and exports the child PATH: this command reports the PATH it inherits
+# instead of recomposing it, so the entrypoint stays the single owner of that
+# ordering and the two can never drift. Required tools that do not resolve are
+# listed and set a non-zero exit status; optional tools are reported either way
+# and never fail the check. Nothing on the host is created or modified.
+set -eu
+
+REQUIRED_TOOLS=(git)
+OPTIONAL_TOOLS=(tmux treehouse no-mistakes tasks-axi herdr claude codex opencode pi grok kimi)
+
+usage() { sed -n '2,12p' "$0" | sed 's/^# \{0,1\}//'; exit 2; }
+
+[ "$#" -eq 0 ] || usage
+
+printf 'path=%s\n' "${PATH:-}"
+if [ -n "${FM_ROOT_OVERRIDE:-}" ] && [ "${PATH%%:*}" = "$FM_ROOT_OVERRIDE/bin" ]; then
+  printf 'entrypoint=yes\n'
+else
+  printf 'entrypoint=no\n'
+  printf 'note: not launched through the fixed remote entrypoint; the reported PATH is this caller environment.\n' >&2
+fi
+
+MISSING=()
+for tool in "${REQUIRED_TOOLS[@]}"; do
+  if resolved=$(command -v "$tool" 2>/dev/null); then
+    printf 'required %s=%s\n' "$tool" "$resolved"
+  else
+    printf 'required %s=MISSING\n' "$tool"
+    MISSING+=("$tool")
+  fi
+done
+for tool in "${OPTIONAL_TOOLS[@]}"; do
+  if resolved=$(command -v "$tool" 2>/dev/null); then
+    printf 'optional %s=%s\n' "$tool" "$resolved"
+  else
+    printf 'optional %s=absent\n' "$tool"
+  fi
+done
+
+if [ "${#MISSING[@]}" -gt 0 ]; then
+  printf 'error: required tools do not resolve on the remote runtime PATH: %s\n' "${MISSING[*]}" >&2
+  printf 'fix: install each one where it resolves on the path reported above, or put a wrapper script for it in %s/.local/bin, which is always on that PATH.\n' "${HOME:-~}" >&2
+  printf 'fix: tools provided by nvm, asdf, or mise never resolve here because no login or interactive shell runs; see docs/remote-secondmates.md for the wrapper recipe.\n' >&2
+  exit 1
+fi
+printf 'ok: every required tool resolves on the remote runtime PATH\n'

--- a/bin/fm-remote-entrypoint.sh
+++ b/bin/fm-remote-entrypoint.sh
@@ -11,12 +11,50 @@
 # for protocol framing, so it remains byte-for-byte available to the command.
 # The child receives an empty environment plus fixed PATH, HOME, FM_HOME, and
 # FM_ROOT_OVERRIDE. stdout, stderr, and exit status pass through unchanged.
+#
+# This file is the single owner of the child PATH. compose_child_path builds it
+# in a fixed order from <root>/bin, the account's ~/.local/bin, the common
+# package-manager directories that exist on this host, and the always-present
+# system tail. No login or interactive shell is ever started, so a tool that
+# lives outside those directories - anything installed by nvm, asdf, or mise -
+# needs a wrapper in ~/.local/bin. bin/fm-remote-doctor.sh reports this exact
+# PATH by inheriting it rather than recomposing it, so the two cannot drift.
 set -eu
 
 PROTOCOL=1
-SAFE_PATH='/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin'
+CHILD_PATH=
 
 die() { printf 'error: %s\n' "$1" >&2; exit "${2:-64}"; }
+
+path_append() { # <directory>
+  case ":$CHILD_PATH:" in *":$1:"*) return 0 ;; esac
+  CHILD_PATH="${CHILD_PATH:+$CHILD_PATH:}$1"
+}
+
+path_append_if_dir() { # <directory>
+  [ -d "$1" ] || return 0
+  path_append "$1"
+}
+
+compose_child_path() { # <remote-root> <account-home>
+  local root=$1 account_home=$2 account_user
+  CHILD_PATH=
+  path_append "$root/bin"
+  path_append "$account_home/.local/bin"
+  path_append_if_dir "$account_home/.nix-profile/bin"
+  # env -i clears USER, so ask the password database rather than the environment.
+  account_user=$(id -un 2>/dev/null) || account_user=
+  if [ -n "$account_user" ]; then
+    path_append_if_dir "/etc/profiles/per-user/$account_user/bin"
+  fi
+  path_append_if_dir /run/current-system/sw/bin
+  path_append_if_dir /opt/homebrew/bin
+  path_append_if_dir /usr/local/bin
+  path_append /usr/bin
+  path_append /bin
+  path_append /usr/sbin
+  path_append /sbin
+}
 
 base64_decode_to() { # <encoded> <destination>
   local encoded=$1 destination=$2
@@ -119,15 +157,18 @@ case "$COMMAND" in */*|*..*) die "command contains a path or traversal: $COMMAND
 COMMAND_PATH="$ROOT/bin/$COMMAND"
 [ -f "$COMMAND_PATH" ] && [ ! -L "$COMMAND_PATH" ] && [ -x "$COMMAND_PATH" ] \
   || die "command is not a genuine executable in the configured remote root: $COMMAND"
-git -C "$ROOT" ls-files --error-unmatch "bin/$COMMAND" >/dev/null 2>&1 \
-  || die "command is not tracked by the configured remote root: $COMMAND"
-
 unset HOME
 ACCOUNT_HOME=$(CDPATH='' cd ~ 2>/dev/null && pwd -P) || die "cannot resolve the remote account home"
+compose_child_path "$ROOT" "$ACCOUNT_HOME"
+# Resolve the tracked-command check under the same PATH the child will use, so a
+# host whose non-interactive SSH PATH lacks git fails the doctor rather than here.
+PATH="$CHILD_PATH" git -C "$ROOT" ls-files --error-unmatch "bin/$COMMAND" >/dev/null 2>&1 \
+  || die "command is not tracked by the configured remote root: $COMMAND"
+
 trap - EXIT
 rm -rf -- "$TMP"
 exec /usr/bin/env -i \
-  PATH="$ROOT/bin:$ACCOUNT_HOME/.local/bin:$SAFE_PATH" \
+  PATH="$CHILD_PATH" \
   HOME="$ACCOUNT_HOME" \
   FM_HOME="$HOME_PATH" \
   FM_ROOT_OVERRIDE="$ROOT" \

--- a/bin/fm-remote-entrypoint.sh
+++ b/bin/fm-remote-entrypoint.sh
@@ -12,23 +12,25 @@
 # The child receives an empty environment plus fixed PATH, HOME, FM_HOME, and
 # FM_ROOT_OVERRIDE. stdout, stderr, and exit status pass through unchanged.
 #
-# This file is the single owner of the child PATH. compose_child_path builds it
-# in a fixed order from <root>/bin, the account's ~/.local/bin, the common
+# This file is the single owner of the child PATH. compose_operator_path builds
+# its operator portion from the account's ~/.local/bin, the common
 # package-manager directories that exist on this host, and the always-present
-# system tail. No login or interactive shell is ever started, so a tool that
+# system tail. The tracked-command check resolves git from that portion before
+# <root>/bin is prepended for the child. No login or interactive shell is ever
+# started, so a tool that
 # lives outside those directories - anything installed by nvm, asdf, or mise -
 # needs a wrapper in ~/.local/bin. bin/fm-remote-doctor.sh reports this exact
 # PATH by inheriting it rather than recomposing it, so the two cannot drift.
 set -eu
 
 PROTOCOL=1
-CHILD_PATH=
+OPERATOR_PATH=
 
 die() { printf 'error: %s\n' "$1" >&2; exit "${2:-64}"; }
 
 path_append() { # <directory>
-  case ":$CHILD_PATH:" in *":$1:"*) return 0 ;; esac
-  CHILD_PATH="${CHILD_PATH:+$CHILD_PATH:}$1"
+  case ":$OPERATOR_PATH:" in *":$1:"*) return 0 ;; esac
+  OPERATOR_PATH="${OPERATOR_PATH:+$OPERATOR_PATH:}$1"
 }
 
 path_append_if_dir() { # <directory>
@@ -36,10 +38,21 @@ path_append_if_dir() { # <directory>
   path_append "$1"
 }
 
-compose_child_path() { # <remote-root> <account-home>
-  local root=$1 account_home=$2 account_user
-  CHILD_PATH=
-  path_append "$root/bin"
+build_child_path() { # <remote-root-bin>
+  local root_bin=$1 directory old_ifs
+  CHILD_PATH=$root_bin
+  old_ifs=$IFS
+  IFS=:
+  for directory in $OPERATOR_PATH; do
+    case ":$CHILD_PATH:" in *":$directory:"*) continue ;; esac
+    CHILD_PATH="$CHILD_PATH:$directory"
+  done
+  IFS=$old_ifs
+}
+
+compose_operator_path() { # <account-home>
+  local account_home=$1 account_user
+  OPERATOR_PATH=
   path_append "$account_home/.local/bin"
   path_append_if_dir "$account_home/.nix-profile/bin"
   # env -i clears USER, so ask the password database rather than the environment.
@@ -159,11 +172,19 @@ COMMAND_PATH="$ROOT/bin/$COMMAND"
   || die "command is not a genuine executable in the configured remote root: $COMMAND"
 unset HOME
 ACCOUNT_HOME=$(CDPATH='' cd ~ 2>/dev/null && pwd -P) || die "cannot resolve the remote account home"
-compose_child_path "$ROOT" "$ACCOUNT_HOME"
-# Resolve the tracked-command check under the same PATH the child will use, so a
-# host whose non-interactive SSH PATH lacks git fails the doctor rather than here.
-PATH="$CHILD_PATH" git -C "$ROOT" ls-files --error-unmatch "bin/$COMMAND" >/dev/null 2>&1 \
+compose_operator_path "$ACCOUNT_HOME"
+GIT_BIN=$(PATH="$OPERATOR_PATH" command -v git 2>/dev/null || true)
+case "$GIT_BIN" in
+  /*)
+    [ -x "$GIT_BIN" ] || GIT_BIN=
+    case ":$OPERATOR_PATH:" in *":${GIT_BIN%/*}:"*) ;; *) GIT_BIN= ;; esac
+    ;;
+  *) GIT_BIN= ;;
+esac
+[ -n "$GIT_BIN" ] || die "required tool git does not resolve on the remote operator PATH; install git there or put a wrapper for it in ~/.local/bin using the recipe in docs/remote-secondmates.md"
+"$GIT_BIN" -C "$ROOT" ls-files --error-unmatch "bin/$COMMAND" >/dev/null 2>&1 \
   || die "command is not tracked by the configured remote root: $COMMAND"
+build_child_path "$ROOT/bin"
 
 trap - EXIT
 rm -rf -- "$TMP"

--- a/bin/fm-remote-home-seed.sh
+++ b/bin/fm-remote-home-seed.sh
@@ -6,7 +6,8 @@
 #
 # The SSH alias must already reach a host whose non-interactive PATH exposes the
 # fixed fm-remote-entrypoint.sh from <remote-root>. The command records the
-# remote host dimension in data/secondmates.md, sends a bounded provisioning
+# remote host dimension in data/secondmates.md, preflights the remote runtime
+# with fm-remote-doctor.sh before touching that host, sends a bounded provisioning
 # manifest through fm-on.sh, and lets the remote host clone its own Firstmate
 # home and project origins. No project tree or secret environment is copied.
 # Known provisioning failure rolls the registry back. SSH status 255 preserves
@@ -30,7 +31,7 @@ MAX_MANIFEST_BYTES=1048576
 . "$SCRIPT_DIR/fm-wake-lib.sh"
 
 die() { printf 'error: %s\n' "$1" >&2; exit 1; }
-usage() { sed -n '2,13p' "$0" | sed 's/^# \{0,1\}//'; exit 2; }
+usage() { sed -n '2,14p' "$0" | sed 's/^# \{0,1\}//'; exit 2; }
 encode() { base64 | tr -d '\n'; }
 safe_id() { case "$1" in ''|*[!A-Za-z0-9._-]*) return 1 ;; esac; }
 
@@ -178,14 +179,31 @@ if ! secondmate_registry_validate_bindings "$REG" secondmate_registry_path_key "
   die "$SECONDMATE_REGISTRY_ERROR"
 fi
 
+restore_registry_and_brief() {
+  if [ "$REG_EXISTED" -eq 1 ]; then cp "$TMP/registry.before" "$REG"; else rm -f -- "$REG"; fi
+  [ "$BRIEF_CREATED" -eq 0 ] || rm -f -- "$BRIEF"
+}
+
+# Preflight the remote runtime before anything is created on that host. The
+# doctor runs through the same fixed entrypoint as every later call, so it sees
+# the exact PATH the remote home will run under.
+set +e
+PREFLIGHT_OUT=$("$SCRIPT_DIR/fm-on.sh" "$ID" fm-remote-doctor.sh 2>&1)
+PREFLIGHT_RC=$?
+set -e
+if [ "$PREFLIGHT_RC" -ne 0 ]; then
+  restore_registry_and_brief
+  [ -z "$PREFLIGHT_OUT" ] || printf '%s\n' "$PREFLIGHT_OUT" >&2
+  die "remote runtime preflight failed; nothing was provisioned. Fix the reported tools, or update the remote code root if it predates fm-remote-doctor.sh"
+fi
+
 set +e
 PROVISION_OUT=$("$SCRIPT_DIR/fm-on.sh" "$ID" fm-remote-home-provision.sh < "$TMP/manifest" 2>&1)
 PROVISION_RC=$?
 set -e
 if [ "$PROVISION_RC" -ne 0 ]; then
   if [ "$PROVISION_RC" -ne 255 ]; then
-    if [ "$REG_EXISTED" -eq 1 ]; then cp "$TMP/registry.before" "$REG"; else rm -f -- "$REG"; fi
-    [ "$BRIEF_CREATED" -eq 0 ] || rm -f -- "$BRIEF"
+    restore_registry_and_brief
   fi
   [ -z "$PROVISION_OUT" ] || printf '%s\n' "$PROVISION_OUT" >&2
   if [ "$PROVISION_RC" -eq 255 ]; then

--- a/docs/remote-secondmates.md
+++ b/docs/remote-secondmates.md
@@ -36,6 +36,8 @@ No login or interactive shell ever runs on the remote host, so `~/.profile`, `~/
 4. The system tail `/usr/bin:/bin:/usr/sbin:/sbin`.
 
 Repeated directories are collapsed to their first position, so the order above is exactly what a remote command sees.
+The entrypoint resolves `git` from the operator directories in steps 2 through 4 for tracked-command authorization, then prepends `<remote-root>/bin` only for the authorized child.
+A checkout-local `bin/git` therefore cannot authorize an untracked command, and a host with no operator `git` receives an install-or-wrapper diagnostic before command execution.
 
 A tool that only exists inside a version manager - nvm, asdf, or mise - never resolves under that contract, because those managers publish their shims through shell initialization.
 The supported escape hatch is a wrapper in `~/.local/bin` rather than special-casing a version manager inside the entrypoint:

--- a/docs/remote-secondmates.md
+++ b/docs/remote-secondmates.md
@@ -46,14 +46,16 @@ The supported escape hatch is a wrapper in `~/.local/bin` rather than special-ca
 mkdir -p ~/.local/bin
 cat > ~/.local/bin/tasks-axi <<'SH'
 #!/usr/bin/env bash
-export NVM_DIR="$HOME/.nvm"
-. "$NVM_DIR/nvm.sh"
-exec tasks-axi "$@"
+tool_bin="$HOME/.nvm/versions/node/<selected-version>/bin"
+PATH="$tool_bin:$PATH"
+exec "$tool_bin/tasks-axi" "$@"
 SH
 chmod +x ~/.local/bin/tasks-axi
 ```
 
-Use the same shape for `asdf` (`. "$HOME/.asdf/asdf.sh"`) or `mise` (`eval "$(mise activate bash)"`), one wrapper per tool the remote home actually needs.
+Replace the placeholder with the remote account's selected nvm version.
+For asdf or mise, use the same shape with the selected version's absolute `bin` directory, one wrapper per tool the remote home actually needs.
+The wrapper must execute that absolute target rather than resolving its own name again through `~/.local/bin`.
 
 Check any host against the real contract:
 

--- a/docs/remote-secondmates.md
+++ b/docs/remote-secondmates.md
@@ -25,6 +25,44 @@ It never accepts a shell command string and starts the selected script with a mi
 The remote account must provide Firstmate's universal toolchain, the selected worker runtime, the selected session backend, and credentials that work on that host.
 Project origin URLs recorded by the primary must be reachable from the remote account because projects are cloned on that host rather than copied from the primary.
 
+## Non-interactive tool contract
+
+No login or interactive shell ever runs on the remote host, so `~/.profile`, `~/.bashrc`, and `~/.zshrc` never contribute to the runtime `PATH`.
+`bin/fm-remote-entrypoint.sh` is the single owner of the `PATH` its children receive and composes it in this order:
+
+1. `<remote-root>/bin`.
+2. The account's `~/.local/bin`, always included so an account can add tools without changing this contract.
+3. Each of `~/.nix-profile/bin`, `/etc/profiles/per-user/<account>/bin`, `/run/current-system/sw/bin`, `/opt/homebrew/bin`, and `/usr/local/bin`, in that order, and only when the directory exists on the host.
+4. The system tail `/usr/bin:/bin:/usr/sbin:/sbin`.
+
+Repeated directories are collapsed to their first position, so the order above is exactly what a remote command sees.
+
+A tool that only exists inside a version manager - nvm, asdf, or mise - never resolves under that contract, because those managers publish their shims through shell initialization.
+The supported escape hatch is a wrapper in `~/.local/bin` rather than special-casing a version manager inside the entrypoint:
+
+```sh
+mkdir -p ~/.local/bin
+cat > ~/.local/bin/tasks-axi <<'SH'
+#!/usr/bin/env bash
+export NVM_DIR="$HOME/.nvm"
+. "$NVM_DIR/nvm.sh"
+exec tasks-axi "$@"
+SH
+chmod +x ~/.local/bin/tasks-axi
+```
+
+Use the same shape for `asdf` (`. "$HOME/.asdf/asdf.sh"`) or `mise` (`eval "$(mise activate bash)"`), one wrapper per tool the remote home actually needs.
+
+Check any host against the real contract:
+
+```sh
+bin/fm-on.sh <secondmate-id|ssh-alias> fm-remote-doctor.sh
+```
+
+The doctor is read-only.
+It prints the exact `PATH` its own entrypoint launch produced, then reports where each required and optional tool resolved.
+It exits non-zero and names every required tool that did not resolve, so the output is the install-or-shim list for that host.
+
 ## Provision a route
 
 Create and fill the normal secondmate charter first, then run:
@@ -35,7 +73,8 @@ bin/fm-remote-home-seed.sh <id> <ssh-alias> <remote-root> <remote-home> {<projec
 
 `<remote-root>` is the remote Firstmate code clone that supplies tracked scripts.
 `<remote-home>` is a separate absolute path for the persistent secondmate home and must not overlap the code root.
-The seed records `host:`, `root:`, and `home:` in `data/secondmates.md`, sends a bounded manifest, and lets the remote host clone its own Firstmate home and project origins.
+The seed records `host:`, `root:`, and `home:` in `data/secondmates.md`, preflights the host with `fm-remote-doctor.sh`, sends a bounded manifest, and lets the remote host clone its own Firstmate home and project origins.
+A failing preflight prints the doctor's missing-tool list, restores the registry, and creates nothing on the remote host.
 It does not copy project trees or the primary process environment.
 A known provisioning failure rolls back the new route, while SSH exit 255 preserves it because remote completion is unknown and must be reconciled on the same host.
 

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -17,6 +17,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-bearings-snapshot.sh` | Project the fleet snapshot to the compact TOON bearings view; local-only unless `--include-prs` |
 | `fm-update.sh`           | Fast-forward-only self-update of firstmate and local or remote secondmate homes       |
 | `fm-on.sh`               | Execute one tracked Firstmate command in a configured remote secondmate home          |
+| `fm-remote-doctor.sh`    | Report the inherited remote runtime PATH and required or optional tool resolution     |
 | `fm-backlog-handoff.sh`  | Validate and delegate queued backlog-item moves into a secondmate home               |
 | `fm-backlog-receive.sh`  | Idempotently ingest one confined remote handoff outbox through tasks-axi             |
 | `fm-decision-hold.sh`    | Create, verify, complete, and resolve durable captain-held decisions                 |

--- a/tests/fm-on.test.sh
+++ b/tests/fm-on.test.sh
@@ -181,6 +181,8 @@ pass "the entrypoint composes a deduplicated child PATH (kept $PRESENT_CHECKED e
 
 set +e
 out=$(
+  # The entrypoint's subprocess invokes this indirectly through export -f.
+  # shellcheck disable=SC2329
   command() {
     if [ "${1:-}" = -v ] && [ "${2:-}" = git ]; then return 1; fi
     builtin command "$@"

--- a/tests/fm-on.test.sh
+++ b/tests/fm-on.test.sh
@@ -39,6 +39,11 @@ cat > "$REMOTE_ROOT/bin/fm-probe-two.sh" <<'SH'
 printf 'home=%s\nroot=%s\n' "$FM_HOME" "$FM_ROOT_OVERRIDE"
 if [ -n "${TOP_SECRET:-}" ]; then printf 'secret=leaked\n'; else printf 'secret=absent\n'; fi
 SH
+cat > "$REMOTE_ROOT/bin/fm-probe-path.sh" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$PATH"
+SH
+cp "$ROOT/bin/fm-remote-doctor.sh" "$REMOTE_ROOT/bin/fm-remote-doctor.sh"
 cat > "$REMOTE_ROOT/bin/fm-mutate.sh" <<'SH'
 #!/usr/bin/env bash
 printf 'mutation\n' >> "$1"
@@ -124,6 +129,84 @@ assert_contains "$out" "home=$REMOTE_HOME" "remote FM_HOME was not explicit"
 assert_contains "$out" "root=$REMOTE_ROOT" "remote root was not explicit"
 assert_contains "$out" 'secret=absent' "the primary ambient environment crossed the transport"
 pass "the fixed entrypoint sets only its explicit environment"
+
+# The child PATH is the entrypoint's own composition, so it is asserted on the
+# PATH a real child receives rather than on the script that builds it. The
+# expectation is rebuilt here from the documented contract - fixed head, the
+# package-manager directories that exist on this host, fixed tail - so a host
+# with nix, homebrew, or neither exercises both the include and omit directions.
+ACCOUNT_HOME=$(unset HOME; CDPATH='' cd ~ && pwd -P)
+ACCOUNT_USER=$(id -un)
+OPTIONAL_DIRS=(
+  "$ACCOUNT_HOME/.nix-profile/bin"
+  "/etc/profiles/per-user/$ACCOUNT_USER/bin"
+  /run/current-system/sw/bin
+  /opt/homebrew/bin
+  /usr/local/bin
+)
+EXPECTED_PATH=
+expect_dir() {
+  case ":$EXPECTED_PATH:" in *":$1:"*) return 0 ;; esac
+  EXPECTED_PATH="${EXPECTED_PATH:+$EXPECTED_PATH:}$1"
+}
+path_has() { case ":$1:" in *":$2:"*) return 0 ;; esac; return 1; }
+expect_dir "$REMOTE_ROOT/bin"
+expect_dir "$ACCOUNT_HOME/.local/bin"
+for candidate in "${OPTIONAL_DIRS[@]}"; do
+  [ -d "$candidate" ] && expect_dir "$candidate"
+done
+for fixed in /usr/bin /bin /usr/sbin /sbin; do expect_dir "$fixed"; done
+
+CHILD_PATH=$(fm_on ios fm-probe-path.sh)
+[ "$CHILD_PATH" = "$EXPECTED_PATH" ] \
+  || fail "composed child PATH did not match the portable contract"$'\n'"expected: $EXPECTED_PATH"$'\n'"actual:   $CHILD_PATH"
+[ "${CHILD_PATH%%:*}" = "$REMOTE_ROOT/bin" ] || fail "the remote code root's bin was not first on the child PATH"
+[ "$(printf '%s' "$CHILD_PATH" | cut -d: -f2)" = "$ACCOUNT_HOME/.local/bin" ] \
+  || fail "the account's ~/.local/bin was not second on the child PATH"
+case "$CHILD_PATH" in *:/usr/bin:/bin:/usr/sbin:/sbin) ;; *) fail "the child PATH did not end with the portable system tail" ;; esac
+DUPES=$(printf '%s\n' "$CHILD_PATH" | tr ':' '\n' | sort | uniq -d)
+[ -z "$DUPES" ] || fail "the child PATH repeated entries: $DUPES"
+PRESENT_CHECKED=0
+ABSENT_CHECKED=0
+for candidate in "${OPTIONAL_DIRS[@]}"; do
+  if [ -d "$candidate" ]; then
+    path_has "$CHILD_PATH" "$candidate" || fail "an existing package-manager directory was dropped: $candidate"
+    PRESENT_CHECKED=$((PRESENT_CHECKED + 1))
+  else
+    path_has "$CHILD_PATH" "$candidate" && fail "an absent directory was added to the child PATH: $candidate"
+    ABSENT_CHECKED=$((ABSENT_CHECKED + 1))
+  fi
+done
+pass "the entrypoint composes a deduplicated child PATH (kept $PRESENT_CHECKED existing, omitted $ABSENT_CHECKED absent)"
+
+out=$(fm_on ios fm-remote-doctor.sh)
+rc=$?
+expect_code 0 "$rc" "the remote doctor failed through the transport"
+assert_contains "$out" "path=$EXPECTED_PATH" "the remote doctor did not report the entrypoint child PATH"
+assert_contains "$out" 'entrypoint=yes' "the remote doctor did not detect its entrypoint launch"
+assert_contains "$out" 'required git=' "the remote doctor did not report the required tool"
+pass "the remote doctor reports the same PATH the entrypoint hands its children"
+
+DOCTOR_BIN="$TMP_ROOT/doctor-bin"
+mkdir -p "$DOCTOR_BIN"
+ln -sf "$(command -v bash)" "$DOCTOR_BIN/bash"
+set +e
+out=$(PATH="$DOCTOR_BIN" "$ROOT/bin/fm-remote-doctor.sh" 2>&1)
+rc=$?
+set -e
+[ "$rc" -ne 0 ] || fail "the remote doctor passed with a missing required tool"
+assert_contains "$out" 'required git=MISSING' "the remote doctor did not mark the missing required tool"
+assert_contains "$out" 'required tools do not resolve on the remote runtime PATH: git' "the remote doctor did not name the missing tool"
+assert_contains "$out" '.local/bin' "the remote doctor did not offer the wrapper escape hatch"
+ln -sf "$(command -v git)" "$DOCTOR_BIN/git"
+set +e
+out=$(PATH="$DOCTOR_BIN" "$ROOT/bin/fm-remote-doctor.sh" 2>&1)
+rc=$?
+set -e
+expect_code 0 "$rc" "the remote doctor failed with every required tool present"
+assert_contains "$out" "required git=$DOCTOR_BIN/git" "the remote doctor did not report where the required tool resolved"
+assert_contains "$out" 'optional tmux=absent' "the remote doctor did not report an absent optional tool"
+pass "the remote doctor fails only on missing required tools and names them"
 
 out=$(fm_on ios fm-probe-two.sh)
 assert_contains "$out" "home=$REMOTE_HOME" "first dynamic command stopped resolving"

--- a/tests/fm-on.test.sh
+++ b/tests/fm-on.test.sh
@@ -185,6 +185,9 @@ out=$(
     if [ "${1:-}" = -v ] && [ "${2:-}" = git ]; then return 1; fi
     builtin command "$@"
   }
+  if command -v git >/dev/null 2>&1; then
+    fail "the missing-git fixture still resolved git"
+  fi
   export -f command
   fm_on ios fm-remote-doctor.sh 2>&1
 )
@@ -192,7 +195,7 @@ rc=$?
 set -e
 [ "$rc" -ne 0 ] || fail "the entrypoint passed when git did not resolve on its operator PATH"
 assert_contains "$out" 'required tool git does not resolve on the remote operator PATH' "the entrypoint did not name the missing prerequisite"
-assert_contains "$out" '~/.local/bin' "the entrypoint did not point at the wrapper escape hatch"
+assert_contains "$out" '/.local/bin' "the entrypoint did not point at the wrapper escape hatch"
 assert_not_contains "$out" 'command is not tracked by the configured remote root' "missing git was misreported as an untracked command"
 pass "the entrypoint gives an actionable missing-git diagnostic"
 

--- a/tests/fm-on.test.sh
+++ b/tests/fm-on.test.sh
@@ -179,6 +179,23 @@ for candidate in "${OPTIONAL_DIRS[@]}"; do
 done
 pass "the entrypoint composes a deduplicated child PATH (kept $PRESENT_CHECKED existing, omitted $ABSENT_CHECKED absent)"
 
+set +e
+out=$(
+  command() {
+    if [ "${1:-}" = -v ] && [ "${2:-}" = git ]; then return 1; fi
+    builtin command "$@"
+  }
+  export -f command
+  fm_on ios fm-remote-doctor.sh 2>&1
+)
+rc=$?
+set -e
+[ "$rc" -ne 0 ] || fail "the entrypoint passed when git did not resolve on its operator PATH"
+assert_contains "$out" 'required tool git does not resolve on the remote operator PATH' "the entrypoint did not name the missing prerequisite"
+assert_contains "$out" '~/.local/bin' "the entrypoint did not point at the wrapper escape hatch"
+assert_not_contains "$out" 'command is not tracked by the configured remote root' "missing git was misreported as an untracked command"
+pass "the entrypoint gives an actionable missing-git diagnostic"
+
 out=$(fm_on ios fm-remote-doctor.sh)
 rc=$?
 expect_code 0 "$rc" "the remote doctor failed through the transport"
@@ -230,9 +247,30 @@ cat > "$REMOTE_ROOT/bin/fm-untracked.sh" <<'SH'
 printf 'untracked command ran\n'
 SH
 chmod +x "$REMOTE_ROOT/bin/fm-untracked.sh"
-if fm_on ios fm-untracked.sh >/dev/null 2>&1; then
+GIT_SHADOW_LOG="$TMP_ROOT/git-shadow.log"
+cat > "$REMOTE_ROOT/bin/git" <<'SH'
+#!/usr/bin/env bash
+printf 'consulted\n' >> "$FM_GIT_SHADOW_LOG"
+exit 0
+SH
+chmod +x "$REMOTE_ROOT/bin/git"
+FM_GIT_SHADOW_LOG="$GIT_SHADOW_LOG" "$REMOTE_ROOT/bin/git" -C "$REMOTE_ROOT" ls-files --error-unmatch bin/fm-untracked.sh \
+  || fail "the checkout-local git shim did not demonstrate that it would authorize the untracked command"
+untracked_root_b64=$(printf '%s' "$REMOTE_ROOT" | base64 | tr -d '\n')
+untracked_home_b64=$(printf '%s' "$REMOTE_HOME" | base64 | tr -d '\n')
+untracked_argv_b64=$(printf '%s\0' fm-untracked.sh | base64 | tr -d '\n')
+set +e
+out=$(FM_GIT_SHADOW_LOG="$GIT_SHADOW_LOG" "$REMOTE_ROOT/bin/fm-remote-entrypoint.sh" \
+  1 "$untracked_root_b64" "$untracked_home_b64" "$untracked_argv_b64" 2>&1)
+rc=$?
+set -e
+if [ "$rc" -eq 0 ]; then
   fail "an untracked fm-*.sh executable was accepted"
 fi
+assert_contains "$out" 'command is not tracked by the configured remote root' "the untracked command did not fail at tracked-command authorization"
+[ "$(wc -l < "$GIT_SHADOW_LOG" | tr -d ' ')" -eq 1 ] \
+  || fail "the tracked-command authorization consulted checkout-local git"
+pass "tracked-command authorization excludes checkout-local git"
 if FM_HOME="$LOCAL_HOME" FM_ROOT_OVERRIDE="$REMOTE_ROOT" FM_SSH_BIN="$FAKEBIN/fake-ssh" \
   "$ROOT/bin/fm-on.sh" '-oProxyCommand=bad' fm-probe-two.sh >/dev/null 2>&1; then
   fail "an option-shaped SSH route was accepted"

--- a/tests/fm-remote-secondmate-lifecycle-e2e.test.sh
+++ b/tests/fm-remote-secondmate-lifecycle-e2e.test.sh
@@ -132,6 +132,11 @@ case "${FM_FAKE_SSH_MODE:-normal}:$command_name:$command_rel" in
     "$FM_FAKE_REMOTE_ENTRYPOINT" "$@" < "$FM_FAKE_INHERIT_PAYLOAD"
     exit $?
     ;;
+  doctor-fail:fm-remote-doctor.sh:*)
+    printf 'required git=MISSING\n'
+    printf 'error: required tools do not resolve on the remote runtime PATH: git\n' >&2
+    exit 1
+    ;;
   provision-block-fail:fm-remote-home-provision.sh:*)
     touch "$FM_FAKE_SEED_ENTERED"
     while [ ! -f "$FM_FAKE_SEED_RELEASE" ]; do sleep 0.02; done
@@ -276,6 +281,25 @@ assert_no_grep '- seed-fail ' "$TMP_ROOT/seed-parent/data/secondmates.md" "faile
 assert_grep '- seed-keep ' "$TMP_ROOT/seed-parent/data/secondmates.md" "failed seed rollback removed a competing successful route"
 assert_present "$TMP_ROOT/seed-keep-home/.fm-secondmate-home" "serialized seed lost its published remote home"
 pass "remote seed rollback preserves serialized competing routes"
+
+# A remote that cannot run the basic toolchain must be rejected by the preflight
+# before any home is created on that host.
+if FM_SECONDMATE_CHARTER='Toolless host charter.' FM_SECONDMATE_SCOPE='toolless host' \
+  FM_FAKE_SSH_MODE=doctor-fail seed_env "$ROOT/bin/fm-remote-home-seed.sh" \
+  seed-toolless remote-mac "$REMOTE_ROOT" "$TMP_ROOT/seed-toolless-home" --no-projects \
+  > "$TMP_ROOT/seed-toolless.out" 2>&1; then
+  fail "seeding proceeded against a remote that cannot run the required tools"
+fi
+assert_grep 'required tools do not resolve on the remote runtime PATH: git' \
+  "$TMP_ROOT/seed-toolless.out" "the seed hid the remote runtime diagnostics"
+assert_grep 'remote runtime preflight failed' "$TMP_ROOT/seed-toolless.out" \
+  "the seed did not report the failing stage"
+assert_absent "$TMP_ROOT/seed-toolless-home" "the seed provisioned a home despite a failing preflight"
+assert_no_grep '- seed-toolless ' "$TMP_ROOT/seed-parent/data/secondmates.md" \
+  "the refused route survived the preflight rollback"
+assert_absent "$TMP_ROOT/seed-parent/data/seed-toolless/brief.md" \
+  "the refused route left its scaffolded charter behind"
+pass "remote seeding stops on the runtime preflight before touching the host"
 
 # Provision and register the remote route from the captain-facing primary.
 out=$(FM_SECONDMATE_CHARTER='Own iOS delivery on the build Mac.' \


### PR DESCRIPTION
## Intent

Make the remote second-mate runtime PATH realistic for common operator machines WITHOUT running every SSH call under a login or interactive shell, and add a remote doctor/preflight that checks tools under the exact PATH the entrypoint will use.

Requirement 1 - widen the entrypoint PATH in bin/fm-remote-entrypoint.sh: replace the tiny fixed SAFE_PATH ('/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin') with a composed portable PATH in this precedence order, including each optional directory ONLY when it exists on the remote host at entrypoint time: (1) $ROOT/bin always first; (2) $ACCOUNT_HOME/.local/bin always included even if absent; (3) existing-only, in order: $ACCOUNT_HOME/.nix-profile/bin, /etc/profiles/per-user/$USER/bin resolved with $(id -un) because env -i clears USER (deliberately NOT reading a $USER env var), /run/current-system/sw/bin, /opt/homebrew/bin, /usr/local/bin; (4) the always-present base tail /usr/bin:/bin:/usr/sbin:/sbin. The env -i + direct-exec model is preserved exactly: same allowlist (PATH, HOME, FM_HOME, FM_ROOT_OVERRIDE), no remote shell command string, no login or interactive shell on any SSH call. The PATH is built deterministically with stable order and no duplicate entries.

Requirement 2 - new tracked bin/fm-remote-doctor.sh: a genuine fm-*.sh executable runnable via fm-on through the entrypoint so its own PATH is exactly the entrypoint child PATH. Read-only and safe. Prints the PATH the entrypoint child sees and, for each required/optional tool, whether it resolves and where. Required tool: git. Optional tools reported when present: tmux, treehouse, herdr, tasks-axi, and any named harness binary (claude/codex/opencode/pi/grok/kimi); no-mistakes was included in the optional list too because remote provisioning needs it for no-mistakes-mode projects. Exits non-zero with a clear captain-operable missing list (what to install or how to shim) when an essential tool is missing, zero when essentials resolve.

Requirement 2a - one PATH-composition owner, no drift: the entrypoint must stay a fixed, self-contained installed file, so a shared sourced lib was rejected. The chosen structure is that the doctor does not recompose the ordering at all - it INHERITS the PATH from its own entrypoint launch and reports it. That is why the doctor reads $PATH and prints an entrypoint=yes/no line (derived from FM_ROOT_OVERRIDE and the first PATH element) rather than listing directories; there is deliberately exactly one copy of the ordering, in the entrypoint. Reviewers should not ask the doctor to re-derive or duplicate the directory list.

Requirement 3 - wire the preflight into seeding: bin/fm-remote-home-seed.sh now runs the doctor through fm-on before sending the provisioning manifest, so a remote that cannot run basic tooling fails early with doctor-quality, captain-operable diagnostics; on failure it restores the registry and any scaffolded charter (reusing the existing rollback, extracted as restore_registry_and_brief) and nothing is created on the remote host. The doctor's logic is reused, not duplicated. Seeding is the only documented path into provisioning, so the preflight was deliberately placed there once rather than also in fm-remote-home-provision.sh.

Requirement 4 - docs: docs/remote-secondmates.md documents the non-interactive tool contract, the curated PATH and its precedence, a shim recipe for version-manager tools (nvm/asdf/mise) into ~/.local/bin as the documented escape hatch, and the fm-remote-doctor.sh command. Deliberately NOT special-casing nvm/asdf/mise inside the hot entrypoint - the wrapper recipe is the answer. No AGENTS.md change was made on purpose (the brief said not to bloat it and to prefer no change); documentation-audiences.json needed no change because no new doc surface was added.

Requirement 5 - behavioral tests, never source-text grep. tests/fm-on.test.sh drives the real entrypoint through the real protocol and asserts on the actual composed PATH a real child process receives: it rebuilds the expected PATH from the documented contract using real filesystem existence checks, asserts exact equality, asserts $ROOT/bin first, ~/.local/bin second, the fixed system tail last, no duplicate entries, that every existing optional directory is kept and every absent one omitted, and reports how many of each direction were exercised so the case cannot go quietly vacuous. It also drives the real fm-remote-doctor.sh both through fm-on (asserting it reports the same PATH and detects its entrypoint launch) and directly with a controlled fixture PATH (missing git yields non-zero exit naming git plus the ~/.local/bin escape hatch; git present yields exit zero while optional tools remain absent, proving optional tools never fail the check). tests/fm-remote-secondmate-lifecycle-e2e.test.sh adds a doctor-fail transport mode proving seeding stops at the preflight: non-zero exit, the diagnostics surfaced, no remote home created, the route rolled out of the registry, and the scaffolded charter removed.

One extra change made deliberately while implementing: the entrypoint's own 'git ls-files --error-unmatch' tracked-command check now runs under the composed child PATH (PATH="$CHILD_PATH" git ...) instead of the ambient non-interactive SSH PATH. Without it, a host whose git lives only in a curated directory fails inside the entrypoint with the misleading 'command is not tracked by the configured remote root' error and the doctor could never even run, which would defeat the point of a preflight that checks the exact PATH the entrypoint uses. The ACCOUNT_HOME resolution (unset HOME; cd ~) was moved earlier in the script for the same reason, since the composition needs it.

Out of scope and intentionally not done: running a login shell on any SSH call; auto-detecting nvm/asdf/mise inside the entrypoint hot path; actually provisioning the real MacBook remote second mate.

Repo constraints followed: this is firstmate shared tracked material, so the firstmate-coding-guidelines skill was loaded and applied - one-owner rule for the PATH contract, AGENTS.md size discipline, mechanics kept in script headers and --help, one sentence per line in tracked Markdown, plain dash instead of em dash, colocated tests extending the existing suites rather than a new runner, shellcheck-clean bin scripts, and no agent commit co-author. bin/fm-lint.sh and bin/fm-doc-audience-check.sh both pass, and the whole secondmate test family passes locally.

## What Changed

- Compose a deterministic, deduplicated remote child PATH from the checkout, account-local tools, existing package-manager directories, and system paths while preserving direct `env -i` execution.
- Add `fm-remote-doctor.sh` to report the inherited entrypoint PATH, resolve required and optional tools, and provide actionable diagnostics when `git` is missing.
- Preflight remote seeding through the doctor, roll back local registry and charter changes on failure, and document and behaviorally test the non-interactive tool contract.

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>
</details>
<details>
<summary>✅ **Rebase** - passed</summary>
</details>
<details>
<summary>✅ **Review** - completed</summary>
</details>
<details>
<summary>✅ **Test** - passed</summary>
</details>
<details>
<summary>✅ **Document** - passed</summary>
</details>
<details>
<summary>🔧 **Lint** - 1 issue found → auto-fixed (2) ✅</summary>
</details>
<details>
<summary>✅ **Push** - passed</summary>
</details>
