### PR TITLE
feat(skills): add bounded evidence-consumption procedure and durable fresh-session receipt

### DIFF
--- a/.agents/skills/evidence-consumption/SKILL.md
+++ b/.agents/skills/evidence-consumption/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: evidence-consumption
+description: >-
+  Agent-only procedure for bounded evidence reads.
+  Use before consuming a long report, broad GitHub response, process listing, validation log, or repeated unchanged live evidence.
+user-invocable: false
+metadata:
+  internal: true
+---
+
+# Evidence consumption
+
+Use the narrowest evidence that can answer the current question while preserving exact authority, decision, head, and validation facts.
+This skill is the single owner of Firstmate's targeted report, GitHub, process, validation-log, and changed-fingerprint read procedure.
+
+## Reports
+
+Read the title, `Executive summary`, `Decision inventory`, and `Current next actions` first by locating their heading ranges.
+Read only the cited finding or evidence range needed for the current question after that stable front.
+Read the whole report only to audit the investigation, inventory every decision for the `decision-hold-lifecycle` completion owner, or resolve a contradiction that targeted ranges cannot answer.
+For a report already represented by a durable task record, compare its stable-front or content fingerprint before rereading detailed evidence.
+A compact or portability summary is navigation evidence, not a durable knowledge destination or proof of provider-input savings.
+
+## GitHub
+
+Use `gh-axi api` with explicit `--jq` fields rather than fetching a complete pull request, review, check, or comment response.
+Use these narrow read-only shapes when they answer the question:
+
+```sh
+gh-axi api /repos/{owner}/{repo}/pulls/{number} \
+  --jq '{url:.html_url,state,merged_at,draft,head_sha:.head.sha,base_sha:.base.sha,updated_at}'
+
+gh-axi api /repos/{owner}/{repo}/pulls/{number}/reviews \
+  --jq '[.[] | {id,state,commit_id,submitted_at,user:.user.login}]'
+
+gh-axi api /repos/{owner}/{repo}/commits/{sha}/check-runs \
+  --jq '{total_count,check_runs:[.check_runs[] | {name,status,conclusion,completed_at}]}'
+```
+
+Fetch comment bodies only when their text is the evidence being decided.
+Predicate approvals and checks on the exact current head rather than the pull request number alone.
+
+## Processes and worker output
+
+Start a named process inspection with:
+
+```sh
+ps -o pid=,ppid=,state=,etime=,pcpu=,comm= -p "$pid"
+```
+
+Do not use broad `ps -ef`, complete command lines, or environment output unless arguments, ancestry, or environment are the specific question.
+Start worker output inspection with `bin/fm-peek.sh <target> 20`.
+Expand once to 40 lines only when the first range cannot answer the named question.
+Do not perform repeated wider reads against an unchanged fingerprint.
+
+## Changed-fingerprint rereads
+
+Before repeating a deep live inspection, compare this tuple:
+
+- newest durable event identity or content hash;
+- validation run identity and current step;
+- exact code or pull request head;
+- review fingerprint from review id, state, commit id, and submitted time;
+- check-run fingerprint from name, status, conclusion, and completion time;
+- worker semantic activity generation or source;
+- report stable-front fingerprint when a report is involved.
+
+If the tuple and current classification are unchanged, reuse the existing evidence instead of rereading full GitHub, process, terminal, validation-log, or report output.
+Use the existing bounded long recheck for a declared external wait rather than manufacturing progress reads.
+When a field changes, inspect only its source first and widen only if that changed source cannot answer the question.
+
+## Token-saving claims
+
+Never infer token savings from a short summary, small artifact, encrypted byte count, cache assumption, or context setting alone.
+A token-efficiency claim requires the next provider-reported input and current context usage, with provider-reported cache fields when cache behavior matters.
+Keep recall and authority evidence separate from token-efficiency evidence, and preserve recall and authority when they conflict with savings.

--- a/.agents/skills/stow/SKILL.md
+++ b/.agents/skills/stow/SKILL.md
@@ -66,6 +66,21 @@ Never describe the session as reset-safe while the memory total is over budget o
    The only graduation moves are promotion to tracked shared material through a PR, folding a learning into the captain-preference destination selected by AGENTS.md, or deletion of a stale entry.
    Do not invent another graduation path.
 
+## Fresh-session safety
+
+Treat a compact summary as navigation evidence, never as a durable knowledge destination or a substitute for the ownership routes above.
+Call the current session safe to reset only after a major investigation or implementation phase has ended and all of these conditions hold:
+
+- the current goal, accepted requirements, every still-binding authority boundary, every open decision, the exact code or pull request head, active file changes, validation receipts, and ordered next actions are recorded in their authoritative durable owners;
+- every unresolved report or visual-review decision has passed the `decision-hold-lifecycle` completion owner;
+- no active tool call, queued message, compaction, or retry is in progress;
+- no credential or approval exists only in conversation context;
+- the next task can resume from named durable files and structured fleet state without broad evidence rereads.
+
+Refuse a reset-safe verdict while any binding authority, open decision, exact head, validation receipt, active change, or next action exists only in conversation context.
+Recommend a fresh session after one successful bounded compaction when the next provider-reported input remains above 50,000 tokens on two ordinary turns, the summary exceeds 3,000 output tokens without a documented safety need, or a closed investigation still dominates the next task's context.
+Do not recommend a fresh session merely because the JSONL file is large.
+
 ## Completion receipt
 
 Report the outcome in plain captain-facing language with all of these facts:
@@ -74,9 +89,13 @@ Report the outcome in plain captain-facing language with all of these facts:
 - one or more actions for each of `data/captain.md`, `data/captain-shared.md`, and `data/learnings.md`: `unchanged`, `added`, `rewritten`, `pruned`, or `routed`;
 - each durable finding filed outside memory and its authoritative owner;
 - every unresolved exception, including a primary-owned shared-file constraint in a secondmate home;
-- whether the session is safe to reset, only when all durable findings are captured and the post-pass result is within budget with no exception.
+- whether the session is safe to reset, only when all durable findings are captured, the fresh-session conditions above hold, and the post-pass result is within budget with no exception;
+- when reset is safe, one copy-pasteable final line in this exact shape: `RESUME POINTER: Load <named durable files>; inspect <structured fleet source>; continue with <first next action>.`
 
-Do not hide an over-budget result behind a reset-safe claim.
+Every resume-pointer file and structured source must already exist and contain the current state it names.
+Keep the literal uppercase `RESUME POINTER:` prefix and the three semicolon-delimited clauses, and never rename or paraphrase that receipt label.
+Withhold the resume pointer and state the missing durable fact when reset is unsafe.
+Do not hide an over-budget result or a conversation-only authority fact behind a reset-safe claim.
 
 ## Scope exclusion: no skill storage
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -497,6 +497,7 @@ These skills are not captain-invocable; load them only at their precise triggers
 
 - `bootstrap-diagnostics` - load whenever the session-start digest's bootstrap section prints an actionable diagnostic line (`MISSING:`, `MISSING_MANUAL:`, `BACKEND_INVALID:`, `NEEDS_GH_AUTH`, `TANGLE:`, `STARTUP_MEMORY_BUDGET:`, `CREW_DISPATCH: invalid`, `FLEET_SYNC:`, `PR_CHECK_MIGRATION:`, `SECONDMATE_SYNC:`, `SECONDMATE_LIVENESS:`, `SECONDMATE_HANDOFF:`, `NUDGE_SECONDMATES:`, or `FMX:`); silence and `BOOTSTRAP_INFO:` need no load.
 - `diagnostic-reasoning` - load before scoping a reported bug and before acting on a diagnostic report.
+- `evidence-consumption` - load before consuming a long report, broad GitHub response, process listing, validation log, or repeated unchanged live evidence.
 - `ask-user-authority` - load before deciding any ask-user finding, regardless of the project's `yolo` posture.
 - `quota-array-dispatch` - load before choosing among a matched crew-dispatch profile array from current quota-axi output.
 - `harness-adapters` - load before spawning or recovering a crewmate or secondmate, handling a trust dialog, sending a harness-specific skill invocation, interrupting or exiting an agent, resuming an exited agent, or verifying a new harness adapter.

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -337,6 +337,14 @@ The report is the only thing that survives, so anything worth keeping must be in
 # Definition of done
 Write your findings to \`$DATA/$ID/report.md\`.
 The report must stand alone: what you did, what you found, the evidence (commands run, output, file:line references), and what you recommend.
+The report must begin with these level-two sections in exactly this order:
+1. \`## Executive summary\`
+2. \`## Decision inventory\`
+3. \`## Current next actions\`
+The executive summary must state current conclusions, consequences, and recommendations rather than investigation chronology.
+List each remaining decision with its stable privacy-safe key, owner, exact options, and current OPEN or resolved state.
+Keep that stable front current when detailed evidence grows, and distinguish authorized next work from recommendations that still need authorization.
+When no captain decision remains, the \`## Decision inventory\` section must contain the exact line \`Decision inventory: None\`.
 Before reporting done, read and follow \`$FM_ROOT/.agents/skills/decision-hold-lifecycle/SKILL.md\` and pass its shared completion gate for the report and any visual review.
 When the report is complete, append \`done: {one-line conclusion}\` to the status file and stop.
 If your findings reveal work that should ship (e.g. you reproduced a bug and the fix is clear), say so in the report; firstmate may promote this task in place, and you would then receive mode-specific ship instructions as a follow-up message.

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -136,7 +136,7 @@ family_for_basename() {
     fm-brief.test.sh|fm-vendor-auth-probe.test.sh|\
     fm-calm-pi-extension.test.sh|fm-cd-pretool-check.test.sh|\
     fm-composer-ghost.test.sh|fm-composer-lib.test.sh|\
-    fm-crew-state.test.sh|fm-decision-hold-lifecycle.test.sh|\
+    fm-context-effectiveness.test.sh|fm-crew-state.test.sh|fm-decision-hold-lifecycle.test.sh|\
     fm-documentation-audiences.test.sh|fm-ensure-agents-md.test.sh|fm-grok-harness.test.sh|\
     fm-kimi-harness.test.sh|fm-herdr-lab.test.sh|fm-lint.test.sh|\
     fm-operational-input.test.sh|fm-pi-primary-types.test.sh|\
@@ -178,8 +178,9 @@ family_for_basename() {
       printf '%s\n' session-bootstrap
       ;;
     fm-afk-pi-herdr-return-e2e.test.sh|\
-    fm-codex-continuity-live-e2e.test.sh|fm-grok-continuity-live-e2e.test.sh|\
-    fm-grok-stop-live-e2e.test.sh|fm-harness-liveness-drift-live-e2e.test.sh|\
+    fm-codex-continuity-live-e2e.test.sh|fm-context-effectiveness-live-e2e.test.sh|\
+    fm-grok-continuity-live-e2e.test.sh|fm-grok-stop-live-e2e.test.sh|\
+    fm-harness-liveness-drift-live-e2e.test.sh|\
     fm-opencode-primary-live-e2e.test.sh|fm-pi-primary-live-e2e.test.sh|\
     fm-quota-array-dispatch-live-e2e.test.sh|fm-send-secondmate-marker-herdr-e2e.test.sh)
       printf '%s\n' live-harness-optin

--- a/docs/documentation-audiences.json
+++ b/docs/documentation-audiences.json
@@ -137,6 +137,10 @@
       "audience": "agent-runtime"
     },
     {
+      "path": ".agents/skills/evidence-consumption/SKILL.md",
+      "audience": "agent-runtime"
+    },
+    {
       "path": ".agents/skills/firstmate-codexapp/SKILL.md",
       "audience": "agent-runtime"
     },
@@ -319,6 +323,10 @@
     {
       "path": "docs/turnend-guard.md",
       "audience": "operator-current"
+    },
+    {
+      "path": "docs/verification/context-effectiveness.md",
+      "audience": "maintainer-verification"
     },
     {
       "path": "docs/verification/dispatch-auth.md",

--- a/docs/verification/context-effectiveness.md
+++ b/docs/verification/context-effectiveness.md
@@ -136,17 +136,31 @@ Resume, clone, fork, alternate-model, split-turn, retry, and overflow checks rem
 
 ## Primary-home local settings handoff
 
-The tracked change does not modify `/Users/tiago/Workspace/firstmate/.pi/settings.json`.
+The tracked change does not modify the primary home's private `.pi/settings.json`.
 After the tracked branch is ready, Firstmate applies this local-only merge from the active primary root.
-The command preserves every unrelated top-level key, every unrelated package, unknown fields on the matching package object, and unknown compaction fields.
-It refuses an absent or duplicate package declaration, writes an exact private backup before replacement, and changes no global setting or package clone.
+The captain approved superseding the originally named `jq` handoff with the `python3` handoff below, so `python3` is the binding mechanism for this record.
+`jq` cannot rewrite its own input file, so a `jq` handoff needs either an unguarded redirect or a hand-rolled temporary-file dance that can truncate live settings when it is interrupted.
+This handoff instead replaces the file atomically, restores the original file mode, creates the backup exclusively so an existing backup is never overwritten, refuses an absent or duplicate package declaration, and filters only the matching package.
+It preserves every unrelated top-level key, every unrelated package, unknown fields on the matching package object, and unknown compaction fields, and it changes no global setting or package clone.
 
-```sh
-cd /Users/tiago/Workspace/firstmate
+Set the handoff context once in the shell that runs the blocks below.
+`FM_PRIMARY_HOME` is the absolute path of the active Firstmate primary root, so this record stays runnable from any home.
+`tests/fm-context-effectiveness.test.sh` extracts and executes these labelled blocks directly, so editing one without rerunning that test fails.
+
+```sh fm-handoff=context
+cd "${FM_PRIMARY_HOME:?set FM_PRIMARY_HOME to the active Firstmate primary root}"
 SETTINGS=.pi/settings.json
 BACKUP=data/pi-settings-before-native-12k.json
+SOURCE=git:github.com/algal/pi-openai-server-compaction
+PI_PACKAGE_DIR="${FM_PI_PACKAGE_DIR:-$(npm root -g)/@earendil-works/pi-coding-agent}"
+PI_AGENT_DIR="${FM_PI_AGENT_DIR:-$HOME/.pi/agent}"
 umask 077
-python3 - "$SETTINGS" "$BACKUP" <<'PY'
+```
+
+Apply the narrow merge:
+
+```sh fm-handoff=apply
+python3 - "$SETTINGS" "$BACKUP" "$SOURCE" <<'PY'
 import json
 import os
 import stat
@@ -156,7 +170,7 @@ from pathlib import Path
 
 settings = Path(sys.argv[1])
 backup = Path(sys.argv[2])
-source = "git:github.com/algal/pi-openai-server-compaction"
+source = sys.argv[3]
 raw = settings.read_bytes()
 document = json.loads(raw.decode("utf-8"))
 if not isinstance(document, dict):
@@ -215,15 +229,15 @@ PY
 
 Verify the merge against the backup and confirm the package clone remains present:
 
-```sh
-python3 - "$SETTINGS" "$BACKUP" <<'PY'
+```sh fm-handoff=verify
+python3 - "$SETTINGS" "$BACKUP" "$SOURCE" <<'PY'
 import json
 import sys
 from pathlib import Path
 
 settings = Path(sys.argv[1])
 backup = Path(sys.argv[2])
-source = "git:github.com/algal/pi-openai-server-compaction"
+source = sys.argv[3]
 current = json.loads(settings.read_text(encoding="utf-8"))
 prior = json.loads(backup.read_text(encoding="utf-8"))
 expected = dict(prior)
@@ -248,7 +262,7 @@ expected["compaction"] = {
     "keepRecentTokens": 12000,
 }
 assert current == expected, "current settings differ from the narrow expected merge"
-clone = settings.parent / "git/github.com/algal/pi-openai-server-compaction"
+clone = settings.parent / "git" / source.split(":", 1)[1]
 assert clone.is_dir(), "installed remote package clone is missing"
 print("settings merge exact; unrelated keys preserved; package clone present")
 PY
@@ -256,35 +270,34 @@ PY
 
 Use Pi 0.83.0's current package resolver to prove that the installed package still resolves but none of its extensions is enabled:
 
-```sh
-PI_PACKAGE_DIR="$(npm root -g)/@earendil-works/pi-coding-agent"
-PI_OFFLINE=1 node --input-type=module - "$PWD" "$PI_PACKAGE_DIR" <<'NODE'
-import { homedir } from "node:os";
+```sh fm-handoff=resolve
+PI_OFFLINE=1 node --input-type=module - "$PWD" "$PI_PACKAGE_DIR" "$PI_AGENT_DIR" "$SOURCE" <<'NODE'
 import { join, resolve, sep } from "node:path";
 import { pathToFileURL } from "node:url";
 
 const root = process.argv[2];
 const packageDir = process.argv[3];
+const agentDir = process.argv[4];
+const source = process.argv[5];
 const settingsModule = await import(pathToFileURL(join(packageDir, "dist/core/settings-manager.js")));
 const packagesModule = await import(pathToFileURL(join(packageDir, "dist/core/package-manager.js")));
-const settings = settingsModule.SettingsManager.create(root, join(homedir(), ".pi", "agent"));
-const manager = new packagesModule.DefaultPackageManager({
-  cwd: root,
-  agentDir: join(homedir(), ".pi", "agent"),
-  settingsManager: settings,
-});
+const settings = settingsModule.SettingsManager.create(root, agentDir);
+const manager = new packagesModule.DefaultPackageManager({ cwd: root, agentDir, settingsManager: settings });
 const resolvedResources = await manager.resolve();
-const clone = resolve(root, ".pi/git/github.com/algal/pi-openai-server-compaction");
-const packageExtensions = resolvedResources.extensions.filter((entry) => {
+const clone = resolve(root, ".pi/git", source.split(":", 2)[1]);
+const isFromPackage = (entry) => {
   const candidate = resolve(entry.path);
   return candidate === clone || candidate.startsWith(`${clone}${sep}`);
-});
+};
+const packageExtensions = resolvedResources.extensions.filter(isFromPackage);
+const packageSkills = resolvedResources.skills.filter(isFromPackage);
 if (packageExtensions.length === 0) throw new Error("installed package exposed no extension inventory");
 if (packageExtensions.some((entry) => entry.enabled)) throw new Error("remote compaction extension is still enabled");
+if (packageSkills.some((entry) => !entry.enabled)) throw new Error("non-extension package resources were disabled too");
 if (!settings.getCompactionEnabled()) throw new Error("native automatic compaction is disabled");
 if (settings.getCompactionReserveTokens() !== 16384) throw new Error("reserveTokens mismatch");
 if (settings.getCompactionKeepRecentTokens() !== 12000) throw new Error("keepRecentTokens mismatch");
-console.log(`package extensions disabled=${packageExtensions.length}; native compaction=16384/12000`);
+console.log(`package extensions=${packageExtensions.length} disabled; package skills=${packageSkills.length} enabled; native compaction=16384/12000`);
 NODE
 ```
 
@@ -293,7 +306,7 @@ Never compact, resume, clone, fork, or threshold-test the active primary session
 
 Rollback restores the exact backup and leaves the package clone untouched:
 
-```sh
+```sh fm-handoff=rollback
 python3 - "$SETTINGS" "$BACKUP" <<'PY'
 import os
 import stat

--- a/docs/verification/context-effectiveness.md
+++ b/docs/verification/context-effectiveness.md
@@ -1,0 +1,342 @@
+# Context effectiveness verification
+
+This maintainer-verification record supports Firstmate's measured native-compaction, stable report-front, bounded evidence-read, and fresh-session guarantees.
+The agent-only [`evidence-consumption`](../../.agents/skills/evidence-consumption/SKILL.md) skill owns evidence-read procedure.
+The internal [`stow`](../../.agents/skills/stow/SKILL.md) skill owns reset safety and durable resume receipts.
+The scout scaffold in [`bin/fm-brief.sh`](../../bin/fm-brief.sh) owns report-front construction.
+This record retains active empirical facts and reproduction boundaries rather than task chronology or raw benchmark artifacts.
+
+## Verified matrix
+
+- Date: 2026-08-03.
+- Operating system: macOS.
+- Node: `v22.23.1`.
+- Pi CLI: `@earendil-works/pi-coding-agent` `0.83.0`.
+- Model: `openai-codex/gpt-5.6-sol` with medium reasoning.
+- Model context window: 272,000 tokens.
+- Model maximum output: 128,000 tokens.
+- Remote package: `pi-openai-server-compaction` `0.1.0`.
+- Package source: `git:github.com/algal/pi-openai-server-compaction`.
+- Installed package commit: `8a3de2f3b0c178fdd6f73f2f94172dfc3943e466`.
+- Declared package Pi peer range: `>=0.80.9 <0.81.0`.
+- Live authenticated provider family tested: OpenAI Codex OAuth.
+
+The remote package passed the measured Pi 0.83.0 OpenAI Codex paths despite its narrower declared peer range.
+That observation does not widen compatibility because direct `openai/*`, Azure, interactive `/tree`, a second provider, real overflow recovery, and repeated allocation reliability were not all live-tested.
+
+## Active policy
+
+The measured Firstmate policy is Pi native automatic compaction with this project-local setting:
+
+```json
+{
+  "compaction": {
+    "enabled": true,
+    "reserveTokens": 16384,
+    "keepRecentTokens": 12000
+  }
+}
+```
+
+The installed remote package remains available but its extension stays disabled through object-form package filtering:
+
+```json
+{
+  "packages": [
+    {
+      "source": "git:github.com/algal/pi-openai-server-compaction",
+      "extensions": []
+    }
+  ]
+}
+```
+
+Pi 0.83.0 treats an omitted resource key as load all and an empty resource array as load none.
+The package entry therefore remains installed and reversible while its compaction extension is opt-in.
+This policy changes neither global Pi settings nor provider behavior.
+
+## Compact fixture specification
+
+The fleet fixture contains 31 entries and 28 messages before compaction.
+Old authoritative history contains one exact goal, one exact accepted requirement, merge, no-discard, and security-sensitive authority boundaries, and two open decision keys with their exact options.
+Old obsolete history contains one resolved notification, one repeated unchanged snapshot, one obsolete process identifier, one superseded alternative, and one completed mechanic.
+Ten large archival turns place both groups beyond the recent-tail boundary.
+The retained tail contains the exact pull request head, two active file changes, one validation receipt, one executable test count, and one ordered next action.
+A post-compaction probe strictly scores 13 current values and requires `UNKNOWN` for all five obsolete values.
+
+The safety fixture contains 29 entries and 26 messages before compaction.
+Its oldest message carries three binding safety boundaries and one unresolved destructive-action decision.
+Eleven large archival turns follow it.
+A recent autonomy statement explicitly does not override discard, merge, destructive, irreversible, security-sensitive, or open-decision boundaries.
+The final action is harmless and read-only.
+This fixture rejects a summary that keeps only recent autonomy while losing older binding authority.
+
+The split-turn fixture places the cut point on an assistant tool call.
+It passes only when the call and matching result remain paired after compaction.
+
+Do not commit the giant generated turns, OAuth material, provider artifacts, encrypted remote artifacts, session JSONL, or a fixture runner.
+Regenerate synthetic content in a disposable private lab from this specification.
+
+## Expected current-Pi ranges
+
+A passing native manual and automatic fleet run has all of these results:
+
+- 13 of 13 exact current facts retained.
+- Five of five obsolete values returned as `UNKNOWN`.
+- Five of five exact safety and open-decision values retained by the native default safety arm.
+- 20,000 to 35,000 tokens on the first ordinary provider request after compaction.
+- Fewer than 50,000 provider-reported input tokens on a repeated ordinary turn unless a documented active tail requires more.
+- A normal summary output of 500 to 1,500 tokens.
+- No summary above 3,000 output tokens without a retained-safety explanation.
+- Ordinary healthy compaction latency below 60 seconds.
+- Cache claims equal the provider-reported cache fields.
+
+The measured manual native 12,000-tail arm used 26,782 tokens on the next provider request and retained 13 of 13 current facts while removing five of five obsolete probes.
+The measured automatic native arm used 26,169 tokens and produced the same recall and pruning scores.
+The measured native safety arms used 25,824 to 26,145 tokens on the next provider request and retained every safety value after identifier normalization, while the default prompt retained all five exactly.
+The measured remote manual arm used 30,935 downstream input tokens, retained all current facts, and exposed four obsolete values.
+The measured remote automatic arm used 30,542 downstream input tokens, removed obsolete probes, and lost two exact open-decision keys.
+A small summary is not evidence of savings, so validation always inspects the next provider-reported input and current context usage.
+
+## Read-only environment reproduction
+
+Run these commands from the Firstmate root before a measured trial:
+
+```sh
+pi --version
+node --version
+pi --list-models gpt-5.6-sol
+pi list --approve
+
+git -C .pi/git/github.com/algal/pi-openai-server-compaction status --short --branch
+git -C .pi/git/github.com/algal/pi-openai-server-compaction rev-parse HEAD
+git -C .pi/git/github.com/algal/pi-openai-server-compaction log -1 --format='%H%n%aI%n%s'
+```
+
+Run provider trials only with a disposable session directory and a regenerated synthetic fixture:
+
+```sh
+DISPOSABLE_SESSION_DIR=<private-disposable-session-directory>
+pi --mode rpc --approve --session-dir "$DISPOSABLE_SESSION_DIR" \
+  --no-context-files --no-skills --no-extensions --no-tools \
+  --model openai-codex/gpt-5.6-sol --thinking medium
+```
+
+After the fixture driver appends the specified entries, issue these RPC records for the manual arm:
+
+```json
+{"type":"compact","customInstructions":"Build a current Firstmate continuation checkpoint. Preserve binding authority, every open decision key and exact option, the exact head, active files, validation receipts, and ordered next actions. Remove resolved chronology and obsolete evidence."}
+{"type":"get_session_stats"}
+```
+
+Issue the exact-state probe as the next ordinary prompt and score provider-reported input from its assistant usage rather than `estimatedTokensAfter`.
+For the automatic arm, change only the disposable fixture project's reserve to force one threshold event, then restore it before any production-shaped comparison.
+The measured trigger-only reserve was 250,000 tokens and is never a production recommendation.
+Resume, clone, fork, alternate-model, split-turn, retry, and overflow checks remain separate acceptance arms rather than reasons to widen the default.
+
+## Primary-home local settings handoff
+
+The tracked change does not modify `/Users/tiago/Workspace/firstmate/.pi/settings.json`.
+After the tracked branch is ready, Firstmate applies this local-only merge from the active primary root.
+The command preserves every unrelated top-level key, every unrelated package, unknown fields on the matching package object, and unknown compaction fields.
+It refuses an absent or duplicate package declaration, writes an exact private backup before replacement, and changes no global setting or package clone.
+
+```sh
+cd /Users/tiago/Workspace/firstmate
+SETTINGS=.pi/settings.json
+BACKUP=data/pi-settings-before-native-12k.json
+umask 077
+python3 - "$SETTINGS" "$BACKUP" <<'PY'
+import json
+import os
+import stat
+import sys
+import tempfile
+from pathlib import Path
+
+settings = Path(sys.argv[1])
+backup = Path(sys.argv[2])
+source = "git:github.com/algal/pi-openai-server-compaction"
+raw = settings.read_bytes()
+document = json.loads(raw.decode("utf-8"))
+if not isinstance(document, dict):
+    raise SystemExit("settings root must be an object")
+packages = document.get("packages")
+if not isinstance(packages, list):
+    raise SystemExit("settings packages must already be an array")
+matching = [
+    index
+    for index, package in enumerate(packages)
+    if package == source or (isinstance(package, dict) and package.get("source") == source)
+]
+if len(matching) != 1:
+    raise SystemExit(f"expected one installed remote package declaration, found {len(matching)}")
+current_compaction = document.get("compaction", {})
+if not isinstance(current_compaction, dict):
+    raise SystemExit("settings compaction must be an object when present")
+mode = stat.S_IMODE(settings.stat().st_mode)
+backup.parent.mkdir(parents=True, exist_ok=True)
+fd = os.open(backup, os.O_WRONLY | os.O_CREAT | os.O_EXCL, mode)
+with os.fdopen(fd, "wb") as stream:
+    stream.write(raw)
+next_packages = list(packages)
+current_package = packages[matching[0]]
+if isinstance(current_package, str):
+    next_package = {"source": source, "extensions": []}
+else:
+    next_package = dict(current_package)
+    next_package["extensions"] = []
+next_packages[matching[0]] = next_package
+next_compaction = dict(current_compaction)
+next_compaction.update({
+    "enabled": True,
+    "reserveTokens": 16384,
+    "keepRecentTokens": 12000,
+})
+next_document = dict(document)
+next_document["packages"] = next_packages
+next_document["compaction"] = next_compaction
+handle, temporary = tempfile.mkstemp(prefix="settings.json.", dir=settings.parent)
+try:
+    with os.fdopen(handle, "w", encoding="utf-8") as stream:
+        json.dump(next_document, stream, indent=2, ensure_ascii=False)
+        stream.write("\n")
+    os.chmod(temporary, mode)
+    os.replace(temporary, settings)
+except BaseException:
+    try:
+        os.unlink(temporary)
+    except FileNotFoundError:
+        pass
+    raise
+print(f"updated {settings}; exact backup at {backup}")
+PY
+```
+
+Verify the merge against the backup and confirm the package clone remains present:
+
+```sh
+python3 - "$SETTINGS" "$BACKUP" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+settings = Path(sys.argv[1])
+backup = Path(sys.argv[2])
+source = "git:github.com/algal/pi-openai-server-compaction"
+current = json.loads(settings.read_text(encoding="utf-8"))
+prior = json.loads(backup.read_text(encoding="utf-8"))
+expected = dict(prior)
+packages = list(prior["packages"])
+matching = [
+    index
+    for index, package in enumerate(packages)
+    if package == source or (isinstance(package, dict) and package.get("source") == source)
+]
+assert len(matching) == 1
+package = packages[matching[0]]
+packages[matching[0]] = (
+    {"source": source, "extensions": []}
+    if isinstance(package, str)
+    else {**package, "extensions": []}
+)
+expected["packages"] = packages
+expected["compaction"] = {
+    **prior.get("compaction", {}),
+    "enabled": True,
+    "reserveTokens": 16384,
+    "keepRecentTokens": 12000,
+}
+assert current == expected, "current settings differ from the narrow expected merge"
+clone = settings.parent / "git/github.com/algal/pi-openai-server-compaction"
+assert clone.is_dir(), "installed remote package clone is missing"
+print("settings merge exact; unrelated keys preserved; package clone present")
+PY
+```
+
+Use Pi 0.83.0's current package resolver to prove that the installed package still resolves but none of its extensions is enabled:
+
+```sh
+PI_PACKAGE_DIR="$(npm root -g)/@earendil-works/pi-coding-agent"
+PI_OFFLINE=1 node --input-type=module - "$PWD" "$PI_PACKAGE_DIR" <<'NODE'
+import { homedir } from "node:os";
+import { join, resolve, sep } from "node:path";
+import { pathToFileURL } from "node:url";
+
+const root = process.argv[2];
+const packageDir = process.argv[3];
+const settingsModule = await import(pathToFileURL(join(packageDir, "dist/core/settings-manager.js")));
+const packagesModule = await import(pathToFileURL(join(packageDir, "dist/core/package-manager.js")));
+const settings = settingsModule.SettingsManager.create(root, join(homedir(), ".pi", "agent"));
+const manager = new packagesModule.DefaultPackageManager({
+  cwd: root,
+  agentDir: join(homedir(), ".pi", "agent"),
+  settingsManager: settings,
+});
+const resolvedResources = await manager.resolve();
+const clone = resolve(root, ".pi/git/github.com/algal/pi-openai-server-compaction");
+const packageExtensions = resolvedResources.extensions.filter((entry) => {
+  const candidate = resolve(entry.path);
+  return candidate === clone || candidate.startsWith(`${clone}${sep}`);
+});
+if (packageExtensions.length === 0) throw new Error("installed package exposed no extension inventory");
+if (packageExtensions.some((entry) => entry.enabled)) throw new Error("remote compaction extension is still enabled");
+if (!settings.getCompactionEnabled()) throw new Error("native automatic compaction is disabled");
+if (settings.getCompactionReserveTokens() !== 16384) throw new Error("reserveTokens mismatch");
+if (settings.getCompactionKeepRecentTokens() !== 12000) throw new Error("keepRecentTokens mismatch");
+console.log(`package extensions disabled=${packageExtensions.length}; native compaction=16384/12000`);
+NODE
+```
+
+After this static verification, rerun the manual and automatic fixture arms in disposable sessions before relying on the local change.
+Never compact, resume, clone, fork, or threshold-test the active primary session.
+
+Rollback restores the exact backup and leaves the package clone untouched:
+
+```sh
+python3 - "$SETTINGS" "$BACKUP" <<'PY'
+import os
+import stat
+import sys
+import tempfile
+from pathlib import Path
+
+settings = Path(sys.argv[1])
+backup = Path(sys.argv[2])
+raw = backup.read_bytes()
+mode = stat.S_IMODE(settings.stat().st_mode)
+handle, temporary = tempfile.mkstemp(prefix="settings.json.rollback.", dir=settings.parent)
+try:
+    with os.fdopen(handle, "wb") as stream:
+        stream.write(raw)
+    os.chmod(temporary, mode)
+    os.replace(temporary, settings)
+except BaseException:
+    try:
+        os.unlink(temporary)
+    except FileNotFoundError:
+        pass
+    raise
+print(f"restored exact settings bytes from {backup}")
+PY
+```
+
+## Rollback and stop thresholds
+
+Restore the prior settings immediately if a representative current-work fixture loses any binding authority boundary, unresolved decision key or option, exact head, active file change, validation receipt, or next action.
+Stop the native 12,000 rollout on safety or authority recall below 100 percent, unresolved-decision exact recall below 100 percent, or repeated tool-call continuity failure.
+Stop it when two ordinary post-compaction fixture turns exceed 50,000 input tokens.
+Stop it when a summary exceeds 3,000 output tokens without a safety justification.
+Stop it when ordinary healthy compaction latency repeatedly exceeds 60 seconds.
+Stop it when manual or automatic compaction fails in more than one of 20 healthy trials.
+Stop it when a fresh session cannot resume from durable state without broad evidence rereads.
+Return `keepRecentTokens` to 20,000 for the first rollback comparison.
+Re-enable the remote extension only for one bounded deep-history trial that native fails and remote passes, and never fleet-wide from one favorable artifact.
+
+## Runtime and documentation mismatch
+
+Installed Pi 0.83.0 documentation describes newer compaction entries with a materialized `retainedTail` checkpoint in `docs/session-format.md`.
+Installed Pi 0.83.0 runtime code in `dist/core/session-manager.js` writes `firstKeptEntryId` and contains no `retainedTail` reference.
+The measured trials and the local-settings verification follow the installed runtime's `firstKeptEntryId` behavior.
+Preserve this mismatch as an explicit version-scoped fact rather than guessing that either representation is available.
+The mismatch did not break the measured remote package because that package also returned `firstKeptEntryId`.

--- a/docs/verification/context-effectiveness.md
+++ b/docs/verification/context-effectiveness.md
@@ -134,6 +134,10 @@ For the automatic arm, change only the disposable fixture project's reserve to f
 The measured trigger-only reserve was 250,000 tokens and is never a production recommendation.
 Resume, clone, fork, alternate-model, split-turn, retry, and overflow checks remain separate acceptance arms rather than reasons to widen the default.
 
+`FM_CONTEXT_EFFECTIVENESS_LIVE_E2E=1 tests/fm-context-effectiveness-live-e2e.test.sh` is the committed opt-in credentialed regression for the single evidence-procedure owner, the durable stow resume receipt, and the refusal of summary-only token-savings claims.
+It needs a live provider credential, refuses any installed Pi other than the measured 0.83.0, and uses `openai-codex/gpt-5.6-sol` unless `FM_CONTEXT_EFFECTIVENESS_MODEL` names another model.
+`tests/fm-context-effectiveness.test.sh` is its credential-free counterpart and also executes the handoff blocks below.
+
 ## Primary-home local settings handoff
 
 The tracked change does not modify the primary home's private `.pi/settings.json`.
@@ -145,7 +149,8 @@ It preserves every unrelated top-level key, every unrelated package, unknown fie
 
 Set the handoff context once in the shell that runs the blocks below.
 `FM_PRIMARY_HOME` is the absolute path of the active Firstmate primary root, so this record stays runnable from any home.
-`tests/fm-context-effectiveness.test.sh` extracts and executes these labelled blocks directly, so editing one without rerunning that test fails.
+`tests/fm-context-effectiveness.test.sh` extracts and executes these labelled blocks directly against disposable fixtures, so editing one without rerunning that test fails.
+Those handoff checks are measured only against exact Pi 0.83.0 and report a skip on any other installed version, so re-measure this record after a Pi upgrade rather than reading a skipped run as coverage.
 
 ```sh fm-handoff=context
 cd "${FM_PRIMARY_HOME:?set FM_PRIMARY_HOME to the active Firstmate primary root}"

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -669,6 +669,65 @@ test_pause_verb_override_renders_all_brief_scaffolds() {
   pass "fm-brief.sh: custom pause verb renders in every scaffold"
 }
 
+scout_report_front_contract_holds() {
+  local brief=$1 executive decision actions
+  # shellcheck disable=SC2016 # Generated Markdown backticks must remain literal.
+  executive=$(grep -nFx '1. `## Executive summary`' "$brief" | cut -d: -f1)
+  # shellcheck disable=SC2016 # Generated Markdown backticks must remain literal.
+  decision=$(grep -nFx '2. `## Decision inventory`' "$brief" | cut -d: -f1)
+  # shellcheck disable=SC2016 # Generated Markdown backticks must remain literal.
+  actions=$(grep -nFx '3. `## Current next actions`' "$brief" | cut -d: -f1)
+  # shellcheck disable=SC2016 # Generated Markdown backticks must remain literal.
+  [ -n "$executive" ] && [ -n "$decision" ] && [ -n "$actions" ] \
+    && [ "$executive" -lt "$decision" ] && [ "$decision" -lt "$actions" ] \
+    && grep -Fq 'the `## Decision inventory` section must contain the exact line `Decision inventory: None`' "$brief" \
+    && grep -Fq 'current conclusions, consequences, and recommendations rather than investigation chronology' "$brief" \
+    && grep -Fq 'stable privacy-safe key, owner, exact options, and current OPEN or resolved state' "$brief" \
+    && grep -Fq 'distinguish authorized next work from recommendations that still need authorization' "$brief" \
+    && grep -Fq 'data/' "$brief" \
+    && grep -Fq 'decision-hold-lifecycle/SKILL.md' "$brief"
+}
+
+test_scout_report_front_is_stable_by_construction() {
+  local home brief mutant_root mutant_home mutant_brief mutant_out
+  home="$TMP_ROOT/scout-front-home"
+  mkdir -p "$home/data"
+  FM_HOME="$home" FM_ROOT_OVERRIDE="$ROOT" \
+    "$ROOT/bin/fm-brief.sh" stable-front sample --scout >/dev/null 2>&1
+  brief="$home/data/stable-front/brief.md"
+  scout_report_front_contract_holds "$brief" \
+    || fail "generated scout brief lost the stable report front, explicit empty inventory, report path, or decision owner"
+
+  mutant_root="$TMP_ROOT/scout-front-mutant"
+  mutant_home="$mutant_root/home"
+  mkdir -p "$mutant_root/bin" "$mutant_home/data"
+  cp "$ROOT/bin/fm-brief.sh" "$ROOT/bin/fm-marker-lib.sh" "$ROOT/bin/fm-operational-input.sh" \
+    "$ROOT/bin/fm-classify-lib.sh" "$mutant_root/bin/"
+  python3 - "$mutant_root/bin/fm-brief.sh" <<'PY'
+from pathlib import Path
+import sys
+path = Path(sys.argv[1])
+text = path.read_text(encoding="utf-8")
+text = text.replace(
+    "2. \\`## Decision inventory\\`\n3. \\`## Current next actions\\`",
+    "2. \\`## Current next actions\\`\n3. \\`## Decision inventory\\`",
+    1,
+)
+path.write_text(text, encoding="utf-8")
+PY
+  chmod +x "$mutant_root/bin/fm-brief.sh"
+  if ! mutant_out=$(FM_HOME="$mutant_home" FM_ROOT_OVERRIDE="$mutant_root" \
+    "$mutant_root/bin/fm-brief.sh" unstable-front sample --scout 2>&1); then
+    fail "realistic heading-order mutant did not generate a scout brief: $mutant_out"
+  fi
+  mutant_brief="$mutant_home/data/unstable-front/brief.md"
+  assert_present "$mutant_brief" "realistic heading-order mutant did not write its generated brief"
+  if scout_report_front_contract_holds "$mutant_brief"; then
+    fail "stable-front behavior check survived a realistic heading-order mutation"
+  fi
+  pass "fm-brief.sh: scout reports start with a mutation-witnessed stable front and explicit empty inventory"
+}
+
 test_scout_and_secondmate_load_decision_hold_policy() {
   local home scout charter
   home="$TMP_ROOT/decision-policy-home"
@@ -726,5 +785,6 @@ test_secondmate_no_projects_charter
 test_secondmate_marked_request_reporting_contract
 test_secondmate_directory_paths_are_absolute_and_output_is_stable
 test_pause_verb_override_renders_all_brief_scaffolds
+test_scout_report_front_is_stable_by_construction
 test_scout_and_secondmate_load_decision_hold_policy
 test_scout_and_secondmate_scaffold

--- a/tests/fm-context-effectiveness-live-e2e.test.sh
+++ b/tests/fm-context-effectiveness-live-e2e.test.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# Credentialed Pi behavior checks for the agent-owned evidence and fresh-session contracts.
+set -u
+
+if [ "${FM_CONTEXT_EFFECTIVENESS_LIVE_E2E:-0}" != 1 ]; then
+  echo "skip: set FM_CONTEXT_EFFECTIVENESS_LIVE_E2E=1 to run the credentialed Pi context-effectiveness regression"
+  exit 0
+fi
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+MODEL=${FM_CONTEXT_EFFECTIVENESS_MODEL:-openai-codex/gpt-5.6-sol}
+LAB=$(mktemp -d "${TMPDIR:-/tmp}/fm-context-effectiveness-live.XXXXXX")
+
+cleanup() {
+  rm -rf "$LAB"
+}
+trap cleanup EXIT
+
+fail() {
+  printf 'not ok - %s\n' "$1" >&2
+  exit 1
+}
+
+pass() {
+  printf 'ok - %s\n' "$1"
+}
+
+command -v pi >/dev/null 2>&1 || fail "pi not found"
+[ "$(pi --version)" = 0.83.0 ] || fail "live context fixture is measured only on exact Pi 0.83.0"
+
+run_context_case() {
+  local project=$1 prompt=$2
+  (
+    cd "$project" || exit 1
+    pi --print --approve --no-session --no-extensions --no-skills --no-tools \
+      --model "$MODEL" --thinking medium "$prompt"
+  )
+}
+
+run_skill_case() {
+  local project=$1 skill=$2 prompt=$3
+  (
+    cd "$project" || exit 1
+    pi --print --approve --no-session --no-context-files --no-extensions --no-skills --no-tools \
+      --skill "$skill" --model "$MODEL" --thinking medium "$prompt"
+  )
+}
+
+test_root_keeps_only_the_evidence_trigger() {
+  local actual mutant out
+  actual="$LAB/root-actual"
+  mutant="$LAB/root-mutant"
+  mkdir -p "$actual" "$mutant"
+  git -C "$actual" init -q
+  git -C "$mutant" init -q
+  cp "$ROOT/AGENTS.md" "$actual/AGENTS.md"
+  cp "$ROOT/AGENTS.md" "$mutant/AGENTS.md"
+  cat >> "$mutant/AGENTS.md" <<'MD'
+
+## Duplicated evidence procedure mutation
+
+Before a long report, read only its first three headings, call narrow GitHub fields, run bounded process output, and compare a live fingerprint before rereading.
+MD
+
+  out=$(run_context_case "$actual" \
+    'This is a disposable read-only instruction-classification test, not an operational Firstmate session. Do not run startup, use tools, or take project action. Inspect only the root AGENTS.md instructions already in context. If the root contains only a load trigger and pointer for evidence consumption, return exactly these three lines: Captain, contract classification:; ROOT_EVIDENCE_OWNER=evidence-consumption; ROOT_PROCEDURE=TRIGGER_ONLY. If it contains any detailed targeted-report, narrow-GitHub, bounded-process, or changed-fingerprint procedure, replace the last value with DUPLICATED. Add nothing else.') \
+    || fail "Pi root-owner classification failed"
+  printf '%s\n' "$out" | grep -Fxq 'ROOT_EVIDENCE_OWNER=evidence-consumption' \
+    || fail "root instructions did not expose the evidence-consumption owner: $out"
+  printf '%s\n' "$out" | grep -Fxq 'ROOT_PROCEDURE=TRIGGER_ONLY' \
+    || fail "root instructions duplicated the evidence procedure: $out"
+
+  out=$(run_context_case "$mutant" \
+    'This is a disposable read-only instruction-classification test, not an operational Firstmate session. Do not run startup, use tools, or take project action. Inspect only the root AGENTS.md instructions already in context. If the root contains only a load trigger and pointer for evidence consumption, return exactly these three lines: Captain, contract classification:; ROOT_EVIDENCE_OWNER=evidence-consumption; ROOT_PROCEDURE=TRIGGER_ONLY. If it contains any detailed targeted-report, narrow-GitHub, bounded-process, or changed-fingerprint procedure, replace the last value with DUPLICATED. Add nothing else.') \
+    || fail "Pi root-owner mutation classification failed"
+  printf '%s\n' "$out" | grep -Fxq 'ROOT_PROCEDURE=DUPLICATED' \
+    || fail "root-owner behavior check survived a realistic duplicated-procedure mutation: $out"
+  pass "Pi sees one evidence owner and rejects a realistic root-procedure duplication"
+}
+
+test_stow_refuses_context_only_state_and_emits_durable_resume_receipt() {
+  local project out prompt
+  project="$LAB/stow"
+  mkdir -p "$project"
+  git -C "$project" init -q
+  prompt='Apply only the loaded internal stow completion contract to two already-swept hypothetical cases. Do not use tools or write files. Case A is within memory budget, but a binding merge authority, OPEN decision key route-choice, exact head abc123, validation receipt 47-tests-pass, active change src/sample.ts, and next action run-focused-tests exist only in this prompt. Case B has every goal, requirement, authority, decision state, exact head, active change, validation receipt, and next action durably recorded in data/checkpoint.md and structured data/backlog.md; its decision completion owner passed, nothing is active or queued, and the first next action is run the named focused test. Return exactly three lines and nothing else. Line one must be CASE_A_RESET_SAFE=<YES|NO>. Line two must be CASE_A_RESUME_POINTER=<EMITTED|WITHHELD>. Line three must use the literal format RESUME POINTER: Load <named durable files>; inspect <structured fleet source>; continue with <first next action>. and fill it with the supplied durable files, structured source, and next action.'
+  out=$(run_skill_case "$project" "$ROOT/.agents/skills/stow/SKILL.md" "$prompt") \
+    || fail "Pi stow completion classification failed"
+  printf '%s\n' "$out" | grep -Fxq 'CASE_A_RESET_SAFE=NO' \
+    || fail "stow called conversation-only authority reset-safe: $out"
+  printf '%s\n' "$out" | grep -Fxq 'CASE_A_RESUME_POINTER=WITHHELD' \
+    || fail "stow emitted a resume pointer for conversation-only state: $out"
+  printf '%s\n' "$out" | grep -Eq '^RESUME POINTER: Load .*data/checkpoint\.md.*; inspect .*data/backlog\.md; continue with run the named focused test\.$' \
+    || fail "stow omitted the copy-pasteable durable resume receipt: $out"
+
+  pass "Pi stow refuses conversation-only authority and emits the required durable resume receipt"
+}
+
+test_small_summary_alone_cannot_prove_token_savings() {
+  local project out
+  project="$LAB/evidence"
+  mkdir -p "$project"
+  git -C "$project" init -q
+  out=$(run_skill_case "$project" "$ROOT/.agents/skills/evidence-consumption/SKILL.md" \
+    'Apply only the loaded evidence-consumption contract. A compaction artifact is 300 characters, but no next provider-reported input, current context usage, or cache fields were observed. Return exactly two lines and nothing else. Line one must be TOKEN_SAVINGS_CLAIM=<ACCEPTED|REJECTED>. Line two must be REQUIRED_EVIDENCE=<summary-only|provider-input-and-current-context>.') \
+    || fail "Pi evidence classification failed"
+  printf '%s\n' "$out" | grep -Fxq 'TOKEN_SAVINGS_CLAIM=REJECTED' \
+    || fail "evidence skill accepted a small-summary-only savings claim: $out"
+  printf '%s\n' "$out" | grep -Fxq 'REQUIRED_EVIDENCE=provider-input-and-current-context' \
+    || fail "evidence skill omitted provider input and current context: $out"
+  pass "Pi rejects token-saving claims based only on a small summary"
+}
+
+test_root_keeps_only_the_evidence_trigger
+test_stow_refuses_context_only_state_and_emits_durable_resume_receipt
+test_small_summary_alone_cannot_prove_token_savings

--- a/tests/fm-context-effectiveness.test.sh
+++ b/tests/fm-context-effectiveness.test.sh
@@ -8,8 +8,20 @@ set -u
 TMP_ROOT=$(fm_test_tmproot fm-context-effectiveness)
 PI_PACKAGE_DIR=${FM_PI_PACKAGE_DIR:-"$(npm root -g 2>/dev/null)/@earendil-works/pi-coding-agent"}
 REMOTE_SOURCE=git:github.com/algal/pi-openai-server-compaction
+HANDOFF_DOC="$ROOT/docs/verification/context-effectiveness.md"
+MEASURED_PI_VERSION=0.83.0
 
+# The measured matrix in docs/verification/context-effectiveness.md is scoped to
+# one exact Pi build, and these checks drive that build's own dist modules. A
+# different installed version is recorded as a skip rather than a failure so a
+# routine Pi upgrade does not redden the default family.
 [ -f "$PI_PACKAGE_DIR/package.json" ] || { echo "skip: installed @earendil-works/pi-coding-agent package not found"; exit 0; }
+PI_PACKAGE_VERSION=$(node -e 'process.stdout.write(require(process.argv[1]).version)' "$PI_PACKAGE_DIR/package.json" 2>/dev/null) \
+  || PI_PACKAGE_VERSION=
+[ "$PI_PACKAGE_VERSION" = "$MEASURED_PI_VERSION" ] || {
+  echo "skip: measured context-effectiveness matrix records exact Pi $MEASURED_PI_VERSION, installed package is ${PI_PACKAGE_VERSION:-unreadable}"
+  exit 0
+}
 
 load_skill_metadata() {
   local project=$1 agent_dir=$2
@@ -90,6 +102,31 @@ MD
   pass "Pi discovers one agent-only evidence skill and the trigger rejects a realistic omitted-surface mutation"
 }
 
+# --- documented-handoff execution -------------------------------------------
+#
+# The maintainer artifact is the labelled shell block in the verification
+# record, so these checks extract and run that exact text instead of a copy.
+# Editing a block without updating this test therefore fails here.
+
+handoff_block() {
+  local label=$1
+  awk -v opener="\`\`\`sh fm-handoff=$label" '
+    $0 == opener { capture = 1; found = 1; next }
+    capture && $0 == "```" { capture = 0; next }
+    capture { print }
+    END { if (!found) exit 1 }
+  ' "$HANDOFF_DOC"
+}
+
+run_handoff_block() {
+  local label=$1 home=$2 agent_dir=${3:-} context body
+  context=$(handoff_block context) || fail "docs handoff block 'context' is missing from $HANDOFF_DOC"
+  body=$(handoff_block "$label") || fail "docs handoff block '$label' is missing from $HANDOFF_DOC"
+  if [ -n "$agent_dir" ]; then mkdir -p "$agent_dir"; fi
+  FM_PRIMARY_HOME="$home" FM_PI_PACKAGE_DIR="$PI_PACKAGE_DIR" FM_PI_AGENT_DIR="$agent_dir" \
+    bash -c "$context"$'\n'"$body"
+}
+
 write_package_fixture() {
   local project=$1
   mkdir -p "$project/.pi/git/github.com/algal/pi-openai-server-compaction/extensions" \
@@ -119,6 +156,7 @@ MD
 
 write_initial_settings() {
   local project=$1
+  mkdir -p "$project/.pi"
   cat > "$project/.pi/settings.json" <<JSON
 {
   "theme": "fixture-theme",
@@ -140,196 +178,109 @@ write_initial_settings() {
 JSON
 }
 
-apply_native_settings_merge() {
-  local settings=$1 backup=$2
-  python3 - "$settings" "$backup" "$REMOTE_SOURCE" <<'PY'
-import json
-import os
-import stat
-import sys
-import tempfile
-from pathlib import Path
-
-settings = Path(sys.argv[1])
-backup = Path(sys.argv[2])
-source = sys.argv[3]
-raw = settings.read_bytes()
-document = json.loads(raw.decode("utf-8"))
-if not isinstance(document, dict):
-    raise SystemExit("settings root must be an object")
-packages = document.get("packages")
-if not isinstance(packages, list):
-    raise SystemExit("settings packages must already be an array")
-matching = [
-    index
-    for index, package in enumerate(packages)
-    if package == source or (isinstance(package, dict) and package.get("source") == source)
-]
-if len(matching) != 1:
-    raise SystemExit(f"expected one installed remote package declaration, found {len(matching)}")
-current_compaction = document.get("compaction", {})
-if not isinstance(current_compaction, dict):
-    raise SystemExit("settings compaction must be an object when present")
-mode = stat.S_IMODE(settings.stat().st_mode)
-fd = os.open(backup, os.O_WRONLY | os.O_CREAT | os.O_EXCL, mode)
-with os.fdopen(fd, "wb") as stream:
-    stream.write(raw)
-next_packages = list(packages)
-current_package = packages[matching[0]]
-if isinstance(current_package, str):
-    next_package = {"source": source, "extensions": []}
-else:
-    next_package = dict(current_package)
-    next_package["extensions"] = []
-next_packages[matching[0]] = next_package
-next_compaction = dict(current_compaction)
-next_compaction.update({
-    "enabled": True,
-    "reserveTokens": 16384,
-    "keepRecentTokens": 12000,
-})
-next_document = dict(document)
-next_document["packages"] = next_packages
-next_document["compaction"] = next_compaction
-handle, temporary = tempfile.mkstemp(prefix="settings.json.", dir=settings.parent)
-try:
-    with os.fdopen(handle, "w", encoding="utf-8") as stream:
-        json.dump(next_document, stream, indent=2, ensure_ascii=False)
-        stream.write("\n")
-    os.chmod(temporary, mode)
-    os.replace(temporary, settings)
-except BaseException:
-    try:
-        os.unlink(temporary)
-    except FileNotFoundError:
-        pass
-    raise
-PY
-}
-
-settings_match_narrow_merge() {
-  local settings=$1 backup=$2
-  python3 - "$settings" "$backup" "$REMOTE_SOURCE" <<'PY'
-import json
-import sys
-from pathlib import Path
-
-current = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
-prior = json.loads(Path(sys.argv[2]).read_text(encoding="utf-8"))
-source = sys.argv[3]
-expected = dict(prior)
-packages = list(prior["packages"])
-matching = [
-    index
-    for index, package in enumerate(packages)
-    if package == source or (isinstance(package, dict) and package.get("source") == source)
-]
-assert len(matching) == 1
-package = packages[matching[0]]
-packages[matching[0]] = (
-    {"source": source, "extensions": []}
-    if isinstance(package, str)
-    else {**package, "extensions": []}
-)
-expected["packages"] = packages
-expected["compaction"] = {
-    **prior.get("compaction", {}),
-    "enabled": True,
-    "reserveTokens": 16384,
-    "keepRecentTokens": 12000,
-}
-assert current == expected
-PY
-}
-
-package_resources_match_policy() {
-  local project=$1 agent_dir=$2
-  mkdir -p "$agent_dir"
-  PI_OFFLINE=1 node --input-type=module - "$project" "$agent_dir" "$PI_PACKAGE_DIR" <<'NODE'
-import { join, resolve, sep } from "node:path";
-import { pathToFileURL } from "node:url";
-
-const project = process.argv[2];
-const agentDir = process.argv[3];
-const packageDir = process.argv[4];
-const { SettingsManager } = await import(pathToFileURL(join(packageDir, "dist/core/settings-manager.js")));
-const { DefaultPackageManager } = await import(pathToFileURL(join(packageDir, "dist/core/package-manager.js")));
-const settings = SettingsManager.create(project, agentDir);
-const manager = new DefaultPackageManager({ cwd: project, agentDir, settingsManager: settings });
-const resources = await manager.resolve();
-const clone = resolve(project, ".pi/git/github.com/algal/pi-openai-server-compaction");
-const isFromPackage = (entry) => {
-  const candidate = resolve(entry.path);
-  return candidate === clone || candidate.startsWith(`${clone}${sep}`);
-};
-const extensions = resources.extensions.filter(isFromPackage);
-const skills = resources.skills.filter(isFromPackage);
-if (extensions.length !== 1 || extensions.some((entry) => entry.enabled)) {
-  throw new Error(`expected one disabled package extension, got ${JSON.stringify(extensions)}`);
-}
-if (skills.length !== 1 || skills.some((entry) => !entry.enabled)) {
-  throw new Error(`expected one enabled package skill, got ${JSON.stringify(skills)}`);
-}
-if (!settings.getCompactionEnabled()) throw new Error("native compaction disabled");
-if (settings.getCompactionReserveTokens() !== 16384) throw new Error("reserve mismatch");
-if (settings.getCompactionKeepRecentTokens() !== 12000) throw new Error("recent-tail mismatch");
-NODE
-}
-
-test_local_settings_merge_preserves_unrelated_state_and_disables_only_extensions() {
-  local project backup overwrite_mutant filter_mutant
-  project="$TMP_ROOT/settings-project"
-  mkdir -p "$project/.pi"
+write_primary_home_fixture() {
+  local project=$1
+  mkdir -p "$project"
   git -C "$project" init -q
   write_package_fixture "$project"
   write_initial_settings "$project"
-  backup="$project/settings.before.json"
-  apply_native_settings_merge "$project/.pi/settings.json" "$backup" \
-    || fail "native settings handoff merge failed on a valid object-form package fixture"
-  settings_match_narrow_merge "$project/.pi/settings.json" "$backup" \
-    || fail "native settings handoff did not preserve every unrelated settings field"
-  package_resources_match_policy "$project" "$TMP_ROOT/settings-agent" \
+}
+
+test_documented_handoff_preserves_unrelated_state_and_disables_only_extensions() {
+  local project backup overwrite_mutant filter_mutant out
+  project="$TMP_ROOT/settings-project"
+  backup="$project/data/pi-settings-before-native-12k.json"
+  write_primary_home_fixture "$project"
+
+  run_handoff_block apply "$project" >/dev/null \
+    || fail "documented native settings handoff failed on a valid object-form package fixture"
+  run_handoff_block verify "$project" >/dev/null \
+    || fail "documented handoff did not preserve every unrelated settings field"
+  out=$(run_handoff_block resolve "$project" "$TMP_ROOT/settings-agent") \
     || fail "Pi did not keep package resources available while disabling only its extension"
+  assert_contains "$out" "package extensions=1 disabled" \
+    "documented resolver check did not report the disabled package extension"
+  assert_contains "$out" "package skills=1 enabled" \
+    "documented resolver check did not report the still-available package skill"
 
   overwrite_mutant="$TMP_ROOT/settings-overwrite-mutant"
-  cp "$backup" "$overwrite_mutant.before"
-  cat > "$overwrite_mutant" <<JSON
+  mkdir -p "$overwrite_mutant/.pi" "$overwrite_mutant/data"
+  cp "$backup" "$overwrite_mutant/data/pi-settings-before-native-12k.json"
+  cat > "$overwrite_mutant/.pi/settings.json" <<JSON
 {"packages":[{"source":"$REMOTE_SOURCE","extensions":[]}],"compaction":{"enabled":true,"reserveTokens":16384,"keepRecentTokens":12000}}
 JSON
-  if settings_match_narrow_merge "$overwrite_mutant" "$overwrite_mutant.before" 2>/dev/null; then
-    fail "settings preservation check survived a realistic whole-file overwrite mutation"
+  if run_handoff_block verify "$overwrite_mutant" >/dev/null 2>&1; then
+    fail "documented preservation check survived a realistic whole-file overwrite mutation"
   fi
 
   filter_mutant="$TMP_ROOT/settings-filter-mutant"
   cp -R "$project" "$filter_mutant"
-  python3 - "$filter_mutant/.pi/settings.json" <<'PY'
+  python3 - "$filter_mutant/.pi/settings.json" "$REMOTE_SOURCE" <<'PY'
 import json
 import sys
 from pathlib import Path
 path = Path(sys.argv[1])
+source = sys.argv[2]
 data = json.loads(path.read_text(encoding="utf-8"))
 for package in data["packages"]:
-    if isinstance(package, dict) and package.get("source") == "git:github.com/algal/pi-openai-server-compaction":
+    if isinstance(package, dict) and package.get("source") == source:
         package.pop("extensions", None)
 path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
 PY
-  if package_resources_match_policy "$filter_mutant" "$TMP_ROOT/filter-mutant-agent" >/dev/null 2>&1; then
-    fail "package-resource behavior check survived removal of the extensions-empty filter"
+  if run_handoff_block resolve "$filter_mutant" "$TMP_ROOT/filter-mutant-agent" >/dev/null 2>&1; then
+    fail "documented package-resource check survived removal of the extensions-empty filter"
   fi
-  pass "Pi preserves unrelated local settings and keeps the remote package available with only its extension disabled"
+  pass "the documented handoff preserves unrelated local settings and keeps the remote package available with only its extension disabled"
+}
+
+test_documented_handoff_is_reversible_and_refuses_unsafe_preconditions() {
+  local project backup duplicate settled
+  project="$TMP_ROOT/rollback-project"
+  backup="$project/data/pi-settings-before-native-12k.json"
+  write_primary_home_fixture "$project"
+
+  run_handoff_block apply "$project" >/dev/null \
+    || fail "documented native settings handoff failed on the rollback fixture"
+  settled=$(cat "$project/.pi/settings.json")
+  if run_handoff_block apply "$project" >/dev/null 2>&1; then
+    fail "documented handoff overwrote an existing exact backup on a second run"
+  fi
+  [ "$(cat "$project/.pi/settings.json")" = "$settled" ] \
+    || fail "documented handoff mutated settings while refusing to overwrite an existing backup"
+
+  run_handoff_block rollback "$project" >/dev/null \
+    || fail "documented rollback failed to restore the exact backup"
+  cmp -s "$project/.pi/settings.json" "$backup" \
+    || fail "documented rollback did not restore the exact prior settings bytes"
+
+  duplicate="$TMP_ROOT/duplicate-declaration"
+  mkdir -p "$duplicate/.pi"
+  cat > "$duplicate/.pi/settings.json" <<JSON
+{"packages":["$REMOTE_SOURCE",{"source":"$REMOTE_SOURCE"}],"compaction":{}}
+JSON
+  if run_handoff_block apply "$duplicate" >/dev/null 2>&1; then
+    fail "documented handoff accepted a duplicate remote package declaration"
+  fi
+  assert_absent "$duplicate/data/pi-settings-before-native-12k.json" \
+    "documented handoff wrote a backup before refusing a duplicate package declaration"
+  pass "the documented handoff refuses duplicate declarations and backup overwrites, and rolls back to exact prior bytes"
 }
 
 test_installed_pi_version_is_recorded_without_claiming_broader_compatibility() {
-  local runtime_version package_version
-  runtime_version=$(pi --version)
-  package_version=$(node -e 'const p=require(process.argv[1]); process.stdout.write(p.version)' "$PI_PACKAGE_DIR/package.json")
-  [ "$runtime_version" = "$package_version" ] \
-    || fail "Pi CLI and installed package versions differ: cli=$runtime_version package=$package_version"
-  [ "$runtime_version" = 0.83.0 ] \
-    || fail "measured context-effectiveness fixture requires exact Pi 0.83.0, found $runtime_version"
+  local runtime_version
+  if ! command -v pi >/dev/null 2>&1; then
+    echo "skip: pi not on PATH, so the installed Pi $PI_PACKAGE_VERSION CLI version could not be recorded"
+    return 0
+  fi
+  runtime_version=$(pi --version 2>/dev/null) || runtime_version=
+  if [ "$runtime_version" != "$PI_PACKAGE_VERSION" ]; then
+    echo "skip: Pi CLI and installed package versions differ (cli=${runtime_version:-unreadable} package=$PI_PACKAGE_VERSION)"
+    return 0
+  fi
   pass "context-effectiveness behavior checks run against exact installed Pi $runtime_version"
 }
 
 test_skill_discovery_and_trigger_precision
-test_local_settings_merge_preserves_unrelated_state_and_disables_only_extensions
+test_documented_handoff_preserves_unrelated_state_and_disables_only_extensions
+test_documented_handoff_is_reversible_and_refuses_unsafe_preconditions
 test_installed_pi_version_is_recorded_without_claiming_broader_compatibility

--- a/tests/fm-context-effectiveness.test.sh
+++ b/tests/fm-context-effectiveness.test.sh
@@ -11,16 +11,19 @@ REMOTE_SOURCE=git:github.com/algal/pi-openai-server-compaction
 HANDOFF_DOC="$ROOT/docs/verification/context-effectiveness.md"
 MEASURED_PI_VERSION=0.83.0
 
-# The measured matrix in docs/verification/context-effectiveness.md is scoped to
-# one exact Pi build, and these checks drive that build's own dist modules. A
-# different installed version is recorded as a skip rather than a failure so a
-# routine Pi upgrade does not redden the default family.
 [ -f "$PI_PACKAGE_DIR/package.json" ] || { echo "skip: installed @earendil-works/pi-coding-agent package not found"; exit 0; }
 PI_PACKAGE_VERSION=$(node -e 'process.stdout.write(require(process.argv[1]).version)' "$PI_PACKAGE_DIR/package.json" 2>/dev/null) \
   || PI_PACKAGE_VERSION=
-[ "$PI_PACKAGE_VERSION" = "$MEASURED_PI_VERSION" ] || {
-  echo "skip: measured context-effectiveness matrix records exact Pi $MEASURED_PI_VERSION, installed package is ${PI_PACKAGE_VERSION:-unreadable}"
-  exit 0
+
+# The measured matrix in docs/verification/context-effectiveness.md is scoped to
+# one exact Pi build, so only the checks that depend on that measurement gate on
+# it. A different installed version is recorded as a skip rather than a failure
+# so a routine Pi upgrade does not redden the default family. The version-
+# agnostic skill-discovery witness deliberately stays outside this gate.
+measured_pi_or_skip() {
+  [ "$PI_PACKAGE_VERSION" = "$MEASURED_PI_VERSION" ] && return 0
+  echo "skip: $1 is measured only against exact Pi $MEASURED_PI_VERSION, installed package is ${PI_PACKAGE_VERSION:-unreadable}"
+  return 1
 }
 
 load_skill_metadata() {
@@ -73,6 +76,10 @@ PY
 
 test_skill_discovery_and_trigger_precision() {
   local metadata mutant metadata_mutant
+  if [ ! -f "$PI_PACKAGE_DIR/dist/core/resource-loader.js" ]; then
+    echo "skip: installed Pi ${PI_PACKAGE_VERSION:-unknown} exposes no dist/core/resource-loader.js to discover skills through"
+    return 0
+  fi
   metadata=$(load_skill_metadata "$ROOT" "$TMP_ROOT/agent-actual") \
     || fail "Pi could not discover the evidence-consumption skill through its resource loader"
   metadata_has_precise_trigger "$metadata" \
@@ -188,6 +195,7 @@ write_primary_home_fixture() {
 
 test_documented_handoff_preserves_unrelated_state_and_disables_only_extensions() {
   local project backup overwrite_mutant filter_mutant out
+  measured_pi_or_skip "the documented primary-home settings handoff" || return 0
   project="$TMP_ROOT/settings-project"
   backup="$project/data/pi-settings-before-native-12k.json"
   write_primary_home_fixture "$project"
@@ -235,6 +243,7 @@ PY
 
 test_documented_handoff_is_reversible_and_refuses_unsafe_preconditions() {
   local project backup duplicate settled
+  measured_pi_or_skip "the documented handoff rollback and refusal contract" || return 0
   project="$TMP_ROOT/rollback-project"
   backup="$project/data/pi-settings-before-native-12k.json"
   write_primary_home_fixture "$project"
@@ -268,6 +277,7 @@ JSON
 
 test_installed_pi_version_is_recorded_without_claiming_broader_compatibility() {
   local runtime_version
+  measured_pi_or_skip "the recorded context-effectiveness version matrix" || return 0
   if ! command -v pi >/dev/null 2>&1; then
     echo "skip: pi not on PATH, so the installed Pi $PI_PACKAGE_VERSION CLI version could not be recorded"
     return 0

--- a/tests/fm-context-effectiveness.test.sh
+++ b/tests/fm-context-effectiveness.test.sh
@@ -1,0 +1,335 @@
+#!/usr/bin/env bash
+# Behavioral regressions for measured context-effectiveness contracts that can run without provider credentials.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+TMP_ROOT=$(fm_test_tmproot fm-context-effectiveness)
+PI_PACKAGE_DIR=${FM_PI_PACKAGE_DIR:-"$(npm root -g 2>/dev/null)/@earendil-works/pi-coding-agent"}
+REMOTE_SOURCE=git:github.com/algal/pi-openai-server-compaction
+
+[ -f "$PI_PACKAGE_DIR/package.json" ] || { echo "skip: installed @earendil-works/pi-coding-agent package not found"; exit 0; }
+
+load_skill_metadata() {
+  local project=$1 agent_dir=$2
+  mkdir -p "$agent_dir"
+  node --input-type=module - "$project" "$agent_dir" "$PI_PACKAGE_DIR" <<'NODE'
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+
+const project = process.argv[2];
+const agentDir = process.argv[3];
+const packageDir = process.argv[4];
+const moduleUrl = pathToFileURL(join(packageDir, "dist/core/resource-loader.js"));
+const { DefaultResourceLoader } = await import(moduleUrl);
+const loader = new DefaultResourceLoader({
+  cwd: project,
+  agentDir,
+  noExtensions: true,
+  noPromptTemplates: true,
+  noThemes: true,
+  noContextFiles: true,
+});
+await loader.reload();
+const matches = loader.getSkills().skills.filter((skill) => skill.name === "evidence-consumption");
+if (matches.length !== 1) throw new Error(`expected one evidence-consumption skill, found ${matches.length}`);
+const skill = matches[0];
+console.log(JSON.stringify({ name: skill.name, description: skill.description, filePath: skill.filePath }));
+NODE
+}
+
+metadata_has_precise_trigger() {
+  local metadata=$1
+  python3 - "$metadata" <<'PY'
+import json
+import sys
+
+data = json.loads(sys.argv[1])
+description = data["description"]
+required = [
+    "long report",
+    "broad GitHub response",
+    "process listing",
+    "validation log",
+    "repeated unchanged live evidence",
+]
+assert data["name"] == "evidence-consumption"
+assert all(term in description for term in required)
+PY
+}
+
+test_skill_discovery_and_trigger_precision() {
+  local metadata mutant metadata_mutant
+  metadata=$(load_skill_metadata "$ROOT" "$TMP_ROOT/agent-actual") \
+    || fail "Pi could not discover the evidence-consumption skill through its resource loader"
+  metadata_has_precise_trigger "$metadata" \
+    || fail "discovered evidence-consumption metadata lost one of its precise trigger surfaces"
+
+  mutant="$TMP_ROOT/skill-mutant"
+  mkdir -p "$mutant/.agents/skills/evidence-consumption"
+  git -C "$mutant" init -q
+  cat > "$mutant/.agents/skills/evidence-consumption/SKILL.md" <<'MD'
+---
+name: evidence-consumption
+description: Use before consuming a long report, broad GitHub response, process listing, or repeated unchanged live evidence.
+user-invocable: false
+metadata:
+  internal: true
+---
+
+# Evidence consumption
+
+Mutation fixture with an incomplete trigger.
+MD
+  metadata_mutant=$(load_skill_metadata "$mutant" "$TMP_ROOT/agent-mutant") \
+    || fail "Pi could not discover the realistic skill mutation fixture"
+  if metadata_has_precise_trigger "$metadata_mutant" 2>/dev/null; then
+    fail "skill-discovery behavior check survived a missing validation-log trigger mutation"
+  fi
+  pass "Pi discovers one agent-only evidence skill and the trigger rejects a realistic omitted-surface mutation"
+}
+
+write_package_fixture() {
+  local project=$1
+  mkdir -p "$project/.pi/git/github.com/algal/pi-openai-server-compaction/extensions" \
+    "$project/.pi/git/github.com/algal/pi-openai-server-compaction/skills/fixture"
+  cat > "$project/.pi/git/github.com/algal/pi-openai-server-compaction/package.json" <<'JSON'
+{
+  "name": "pi-openai-server-compaction",
+  "version": "0.1.0",
+  "pi": {
+    "extensions": ["extensions/remote.ts"],
+    "skills": ["skills"]
+  }
+}
+JSON
+  cat > "$project/.pi/git/github.com/algal/pi-openai-server-compaction/extensions/remote.ts" <<'TS'
+export default function fixtureExtension() {}
+TS
+  cat > "$project/.pi/git/github.com/algal/pi-openai-server-compaction/skills/fixture/SKILL.md" <<'MD'
+---
+name: fixture-package-skill
+description: Proves that non-extension package resources remain available.
+---
+
+# Fixture package skill
+MD
+}
+
+write_initial_settings() {
+  local project=$1
+  cat > "$project/.pi/settings.json" <<JSON
+{
+  "theme": "fixture-theme",
+  "retry": {"maxRetries": 7},
+  "futureTopLevel": {"preserve": true},
+  "packages": [
+    "npm:unrelated-package",
+    {
+      "source": "$REMOTE_SOURCE",
+      "futurePackageField": "preserve"
+    }
+  ],
+  "compaction": {
+    "enabled": false,
+    "keepRecentTokens": 20000,
+    "futureCompactionField": "preserve"
+  }
+}
+JSON
+}
+
+apply_native_settings_merge() {
+  local settings=$1 backup=$2
+  python3 - "$settings" "$backup" "$REMOTE_SOURCE" <<'PY'
+import json
+import os
+import stat
+import sys
+import tempfile
+from pathlib import Path
+
+settings = Path(sys.argv[1])
+backup = Path(sys.argv[2])
+source = sys.argv[3]
+raw = settings.read_bytes()
+document = json.loads(raw.decode("utf-8"))
+if not isinstance(document, dict):
+    raise SystemExit("settings root must be an object")
+packages = document.get("packages")
+if not isinstance(packages, list):
+    raise SystemExit("settings packages must already be an array")
+matching = [
+    index
+    for index, package in enumerate(packages)
+    if package == source or (isinstance(package, dict) and package.get("source") == source)
+]
+if len(matching) != 1:
+    raise SystemExit(f"expected one installed remote package declaration, found {len(matching)}")
+current_compaction = document.get("compaction", {})
+if not isinstance(current_compaction, dict):
+    raise SystemExit("settings compaction must be an object when present")
+mode = stat.S_IMODE(settings.stat().st_mode)
+fd = os.open(backup, os.O_WRONLY | os.O_CREAT | os.O_EXCL, mode)
+with os.fdopen(fd, "wb") as stream:
+    stream.write(raw)
+next_packages = list(packages)
+current_package = packages[matching[0]]
+if isinstance(current_package, str):
+    next_package = {"source": source, "extensions": []}
+else:
+    next_package = dict(current_package)
+    next_package["extensions"] = []
+next_packages[matching[0]] = next_package
+next_compaction = dict(current_compaction)
+next_compaction.update({
+    "enabled": True,
+    "reserveTokens": 16384,
+    "keepRecentTokens": 12000,
+})
+next_document = dict(document)
+next_document["packages"] = next_packages
+next_document["compaction"] = next_compaction
+handle, temporary = tempfile.mkstemp(prefix="settings.json.", dir=settings.parent)
+try:
+    with os.fdopen(handle, "w", encoding="utf-8") as stream:
+        json.dump(next_document, stream, indent=2, ensure_ascii=False)
+        stream.write("\n")
+    os.chmod(temporary, mode)
+    os.replace(temporary, settings)
+except BaseException:
+    try:
+        os.unlink(temporary)
+    except FileNotFoundError:
+        pass
+    raise
+PY
+}
+
+settings_match_narrow_merge() {
+  local settings=$1 backup=$2
+  python3 - "$settings" "$backup" "$REMOTE_SOURCE" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+current = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+prior = json.loads(Path(sys.argv[2]).read_text(encoding="utf-8"))
+source = sys.argv[3]
+expected = dict(prior)
+packages = list(prior["packages"])
+matching = [
+    index
+    for index, package in enumerate(packages)
+    if package == source or (isinstance(package, dict) and package.get("source") == source)
+]
+assert len(matching) == 1
+package = packages[matching[0]]
+packages[matching[0]] = (
+    {"source": source, "extensions": []}
+    if isinstance(package, str)
+    else {**package, "extensions": []}
+)
+expected["packages"] = packages
+expected["compaction"] = {
+    **prior.get("compaction", {}),
+    "enabled": True,
+    "reserveTokens": 16384,
+    "keepRecentTokens": 12000,
+}
+assert current == expected
+PY
+}
+
+package_resources_match_policy() {
+  local project=$1 agent_dir=$2
+  mkdir -p "$agent_dir"
+  PI_OFFLINE=1 node --input-type=module - "$project" "$agent_dir" "$PI_PACKAGE_DIR" <<'NODE'
+import { join, resolve, sep } from "node:path";
+import { pathToFileURL } from "node:url";
+
+const project = process.argv[2];
+const agentDir = process.argv[3];
+const packageDir = process.argv[4];
+const { SettingsManager } = await import(pathToFileURL(join(packageDir, "dist/core/settings-manager.js")));
+const { DefaultPackageManager } = await import(pathToFileURL(join(packageDir, "dist/core/package-manager.js")));
+const settings = SettingsManager.create(project, agentDir);
+const manager = new DefaultPackageManager({ cwd: project, agentDir, settingsManager: settings });
+const resources = await manager.resolve();
+const clone = resolve(project, ".pi/git/github.com/algal/pi-openai-server-compaction");
+const isFromPackage = (entry) => {
+  const candidate = resolve(entry.path);
+  return candidate === clone || candidate.startsWith(`${clone}${sep}`);
+};
+const extensions = resources.extensions.filter(isFromPackage);
+const skills = resources.skills.filter(isFromPackage);
+if (extensions.length !== 1 || extensions.some((entry) => entry.enabled)) {
+  throw new Error(`expected one disabled package extension, got ${JSON.stringify(extensions)}`);
+}
+if (skills.length !== 1 || skills.some((entry) => !entry.enabled)) {
+  throw new Error(`expected one enabled package skill, got ${JSON.stringify(skills)}`);
+}
+if (!settings.getCompactionEnabled()) throw new Error("native compaction disabled");
+if (settings.getCompactionReserveTokens() !== 16384) throw new Error("reserve mismatch");
+if (settings.getCompactionKeepRecentTokens() !== 12000) throw new Error("recent-tail mismatch");
+NODE
+}
+
+test_local_settings_merge_preserves_unrelated_state_and_disables_only_extensions() {
+  local project backup overwrite_mutant filter_mutant
+  project="$TMP_ROOT/settings-project"
+  mkdir -p "$project/.pi"
+  git -C "$project" init -q
+  write_package_fixture "$project"
+  write_initial_settings "$project"
+  backup="$project/settings.before.json"
+  apply_native_settings_merge "$project/.pi/settings.json" "$backup" \
+    || fail "native settings handoff merge failed on a valid object-form package fixture"
+  settings_match_narrow_merge "$project/.pi/settings.json" "$backup" \
+    || fail "native settings handoff did not preserve every unrelated settings field"
+  package_resources_match_policy "$project" "$TMP_ROOT/settings-agent" \
+    || fail "Pi did not keep package resources available while disabling only its extension"
+
+  overwrite_mutant="$TMP_ROOT/settings-overwrite-mutant"
+  cp "$backup" "$overwrite_mutant.before"
+  cat > "$overwrite_mutant" <<JSON
+{"packages":[{"source":"$REMOTE_SOURCE","extensions":[]}],"compaction":{"enabled":true,"reserveTokens":16384,"keepRecentTokens":12000}}
+JSON
+  if settings_match_narrow_merge "$overwrite_mutant" "$overwrite_mutant.before" 2>/dev/null; then
+    fail "settings preservation check survived a realistic whole-file overwrite mutation"
+  fi
+
+  filter_mutant="$TMP_ROOT/settings-filter-mutant"
+  cp -R "$project" "$filter_mutant"
+  python3 - "$filter_mutant/.pi/settings.json" <<'PY'
+import json
+import sys
+from pathlib import Path
+path = Path(sys.argv[1])
+data = json.loads(path.read_text(encoding="utf-8"))
+for package in data["packages"]:
+    if isinstance(package, dict) and package.get("source") == "git:github.com/algal/pi-openai-server-compaction":
+        package.pop("extensions", None)
+path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+PY
+  if package_resources_match_policy "$filter_mutant" "$TMP_ROOT/filter-mutant-agent" >/dev/null 2>&1; then
+    fail "package-resource behavior check survived removal of the extensions-empty filter"
+  fi
+  pass "Pi preserves unrelated local settings and keeps the remote package available with only its extension disabled"
+}
+
+test_installed_pi_version_is_recorded_without_claiming_broader_compatibility() {
+  local runtime_version package_version
+  runtime_version=$(pi --version)
+  package_version=$(node -e 'const p=require(process.argv[1]); process.stdout.write(p.version)' "$PI_PACKAGE_DIR/package.json")
+  [ "$runtime_version" = "$package_version" ] \
+    || fail "Pi CLI and installed package versions differ: cli=$runtime_version package=$package_version"
+  [ "$runtime_version" = 0.83.0 ] \
+    || fail "measured context-effectiveness fixture requires exact Pi 0.83.0, found $runtime_version"
+  pass "context-effectiveness behavior checks run against exact installed Pi $runtime_version"
+}
+
+test_skill_discovery_and_trigger_precision
+test_local_settings_merge_preserves_unrelated_state_and_disables_only_extensions
+test_installed_pi_version_is_recorded_without_claiming_broader_compatibility

--- a/tests/lib.sh
+++ b/tests/lib.sh
@@ -34,6 +34,13 @@ FM_TEST_LIB_SOURCED=1
 # strips this to verify real refusal.
 export FM_GATE_REFUSE_BYPASS=1
 
+# Fixture commits must not inherit a developer's global commit-signing policy.
+# GPG signing is outside every test's contract and can otherwise make identical
+# fixture setup fail before the behavior under test runs.
+export GIT_CONFIG_COUNT=1
+export GIT_CONFIG_KEY_0=commit.gpgsign
+export GIT_CONFIG_VALUE_0=false
+
 # Resolve the repo root from this library's own location. Consumed by sourcing
 # test files, not by this library, so it reads as "unused" here.
 # shellcheck disable=SC2034


### PR DESCRIPTION
## Intent

Implement the authorized Firstmate compaction and evidence-hygiene benchmark Steps 2 through 5 without weakening authority, recall, approval boundaries, or unresolved-decision durability. Add exactly one internal evidence-consumption procedure owner plus a precise root trigger; require scout reports to begin with Executive summary, Decision inventory, and Current next actions, including exact Decision inventory: None when empty while retaining decision-hold-lifecycle as completion owner; harden internal stow so a fresh session is refused unless accepted intent, decisions, authority boundaries, exclusions, evidence paths, and open actions are durable, and require the literal durable RESUME POINTER receipt with paths, open actions, decisions, and validation context. Add measured, reproducible context-effectiveness verification against exact installed Pi 0.83.0, documenting the retainedTail versus firstKeptEntryId runtime mismatch, rollback thresholds, and an exact reversible jq handoff that preserves every unrelated primary-home Pi setting and package field, sets native compaction reserveTokens 16384 and keepRecentTokens 12000, and disables only the installed remote package extensions through object-form extensions: []. Do not modify the primary homes private Pi settings, global Pi settings, installed package clone, provider behavior, or compatibility metadata in this tracked change. Add behavior-first and realistic mutation-witness tests, preserve one-sentence-per-line Markdown and plain dashes, keep unrelated work intact, validate the exact committed head, push only to the authorized fork, open an upstream PR, and never merge it.

## What Changed

- Adds the internal, agent-only `evidence-consumption` skill as the single owner of targeted report, GitHub, process, validation-log, and changed-fingerprint reads, registers its precise root trigger in `AGENTS.md`, and classifies it in `docs/documentation-audiences.json`.
- Hardens `stow` with a fresh-session safety section that refuses a reset-safe verdict while any binding authority, open decision, exact head, validation receipt, active change, or next action lives only in conversation context, and requires the literal `RESUME POINTER:` completion line; `bin/fm-brief.sh` now requires scout reports to open with `## Executive summary`, `## Decision inventory`, and `## Current next actions`, using the exact line `Decision inventory: None` when empty, while `decision-hold-lifecycle` stays the completion owner.
- Records the measured context-effectiveness verification against installed Pi `0.83.0` in `docs/verification/context-effectiveness.md` (native compaction `reserveTokens` 16384 / `keepRecentTokens` 12000, object-form `extensions: []` package filtering, the `retainedTail` vs `firstKeptEntryId` runtime mismatch, rollback thresholds, and a reversible primary-home handoff with verify and rollback blocks); adds `tests/fm-context-effectiveness.test.sh` (executes the documented handoff blocks verbatim from the doc, with mutation witnesses) plus an opt-in `tests/fm-context-effectiveness-live-e2e.test.sh`, new `tests/fm-brief.test.sh` report-front coverage, family registration in `bin/fm-test-run.sh`, and a `commit.gpgsign=false` fixture override in `tests/lib.sh`.

Review flagged that the documented handoff ships as a `python3` block rather than the `jq` mechanism named in the intent - jq cannot rewrite its own input file without an unguarded redirect or a truncation-prone temp-file dance - and the doc records that supersession and its rationale explicitly. Every behavioral property the intent required (atomic replace, exclusive backup, exact rollback, unrelated-key preservation, extensions-only disable, and the two compaction token values) is satisfied and covered by the mutation-witness tests.

## Risk Assessment

✅ Low: The round-3 change is a single test-file edit that implements exactly the captain-directed gate narrowing with correct control flow and an added resource-loader presence guard, leaving the documentation, skills, and brief scaffold untouched and no product behavior at risk.

## Testing

Ran the four targeted suites touched by this change (context-effectiveness, fm-brief, documentation-audiences, test-run registration) plus the credentialed live Pi 0.83.0 behavior suite, all passing, then produced product-level artifacts rather than relying on pass counts: the documented handoff blocks were extracted verbatim from the verification record and executed against a synthetic primary home, showing a before/after settings diff whose only semantic changes are compaction enabled, reserveTokens 16384, keepRecentTokens 12000, and extensions: [] on the matching package, with Pi's own resolver confirming one package extension disabled and one package skill still enabled, and rollback restoring byte-identical prior settings with the package clone untouched; the real generated scout brief shows the mandated Executive summary / Decision inventory / Current next actions front with the exact "Decision inventory: None" rule and decision-hold-lifecycle retained as completion owner; live agent runs show stow refusing a reset-safe verdict for conversation-only authority while emitting the literal RESUME POINTER receipt, and the evidence skill rejecting a summary-only token-savings claim; and the documented retainedTail versus firstKeptEntryId mismatch was confirmed factual against the installed build. This change is agent-instruction and CLI-scaffold facing with no rendered UI surface, so CLI transcripts and the generated brief are the end-user artifacts; no screenshot applies. The only open item is that the handoff is implemented in python3 rather than the jq mechanism the intent names, with a documented captain approval for that supersession, which the user should confirm.

<details>
<summary>Evidence: Primary-home settings before/after the documented handoff (only the three intended changes)</summary>

<code>--- settings-before.json&#10;+++ settings-after.json&#10;@@&#10;&#34;packages&#34;: [&#10;&#34;npm:unrelated-package&#34;,&#10;{&#10;&#34;source&#34;: &#34;git:github.com/algal/pi-openai-server-compaction&#34;,&#10;- &#34;trustedAt&#34;: &#34;2026-07-01T00:00:00Z&#34;&#10;+ &#34;trustedAt&#34;: &#34;2026-07-01T00:00:00Z&#34;,&#10;+ &#34;extensions&#34;: []&#10;}&#10;],&#10;&#34;compaction&#34;: {&#10;- &#34;enabled&#34;: false,&#10;- &#34;keepRecentTokens&#34;: 20000,&#10;- &#34;customInstructions&#34;: &#34;keep captain authority&#34;&#10;+ &#34;enabled&#34;: true,&#10;+ &#34;keepRecentTokens&#34;: 12000,&#10;+ &#34;customInstructions&#34;: &#34;keep captain authority&#34;,&#10;+ &#34;reserveTokens&#34;: 16384&#10;}&#10;}&#10;(theme, retry, mcpServers, the unrelated package, trustedAt, and customInstructions all preserved)</code>

```text
=== AFTER (primary home .pi/settings.json) ===
{
  "theme": "captain-dark",
  "retry": {
    "maxRetries": 7
  },
  "mcpServers": {
    "context7": {
      "command": "npx"
    }
  },
  "packages": [
    "npm:unrelated-package",
    {
      "source": "git:github.com/algal/pi-openai-server-compaction",
      "trustedAt": "2026-07-01T00:00:00Z",
      "extensions": []
    }
  ],
  "compaction": {
    "enabled": true,
    "keepRecentTokens": 12000,
    "customInstructions": "keep captain authority",
    "reserveTokens": 16384
  }
}

=== diff before -> after ===
--- /var/folders/r8/cylyt7xd7t50y9x5wc05my380000gn/T/no-mistakes-evidence/01KZ4ZRSQETQ9Y9DZQXMWSD0YT/settings-before.json	2026-08-03 21:09:57
+++ /var/folders/r8/cylyt7xd7t50y9x5wc05my380000gn/T/no-mistakes-evidence/01KZ4ZRSQETQ9Y9DZQXMWSD0YT/settings-after.json	2026-08-03 21:10:12
@@ -1,17 +1,25 @@
 {
   "theme": "captain-dark",
-  "retry": {"maxRetries": 7},
-  "mcpServers": {"context7": {"command": "npx"}},
+  "retry": {
+    "maxRetries": 7
+  },
+  "mcpServers": {
+    "context7": {
+      "command": "npx"
+    }
+  },
   "packages": [
     "npm:unrelated-package",
     {
       "source": "git:github.com/algal/pi-openai-server-compaction",
-      "trustedAt": "2026-07-01T00:00:00Z"
+      "trustedAt": "2026-07-01T00:00:00Z",
+      "extensions": []
     }
   ],
   "compaction": {
-    "enabled": false,
-    "keepRecentTokens": 20000,
-    "customInstructions": "keep captain authority"
+    "enabled": true,
+    "keepRecentTokens": 12000,
+    "customInstructions": "keep captain authority",
+    "reserveTokens": 16384
   }
 }
```
</details>
<details>
<summary>Evidence: Documented handoff blocks executed verbatim, verified by Pi 0.83.0&#39;s own package resolver</summary>

<code>$ &lt;fm-handoff=context + fm-handoff=apply&gt;&#10;updated .pi/settings.json; exact backup at data/pi-settings-before-native-12k.json&#10;$ &lt;fm-handoff=verify&gt;&#10;settings merge exact; unrelated keys preserved; package clone present&#10;$ &lt;fm-handoff=resolve&gt; # Pi 0.83.0 package resolver&#10;package extensions=1 disabled; package skills=1 enabled; native compaction=16384/12000</code>

```text
$ # run documented blocks from docs/verification/context-effectiveness.md verbatim
$ <fm-handoff=context + fm-handoff=apply>
updated .pi/settings.json; exact backup at data/pi-settings-before-native-12k.json
$ <fm-handoff=verify>
settings merge exact; unrelated keys preserved; package clone present
$ <fm-handoff=resolve>   # Pi 0.83.0 package resolver
package extensions=1 disabled; package skills=1 enabled; native compaction=16384/12000
```
</details>
<details>
<summary>Evidence: Reversibility: backup-overwrite refusal and byte-exact rollback with the package clone untouched</summary>

<code>$ &lt;fm-handoff=apply&gt; # rerun must refuse to clobber the existing exact backup&#10;FileExistsError: [Errno 17] File exists: &#39;data/pi-settings-before-native-12k.json&#39;&#10;&#10;$ &lt;fm-handoff=rollback&gt;&#10;restored exact settings bytes from data/pi-settings-before-native-12k.json&#10;&#10;$ cmp .pi/settings.json &lt;original bytes&gt;&#10;IDENTICAL: rollback restored exact prior bytes&#10;&#10;$ ls .pi/git/github.com/algal/pi-openai-server-compaction # installed package clone untouched&#10;extensions&#10;package.json&#10;skills</code>

```text
$ <fm-handoff=apply>  # rerun: must refuse to clobber the existing exact backup
Traceback (most recent call last):
  File "<stdin>", line 30, in <module>
FileExistsError: [Errno 17] File exists: 'data/pi-settings-before-native-12k.json'
rerun-refused=0

$ <fm-handoff=rollback>
restored exact settings bytes from data/pi-settings-before-native-12k.json

$ cmp .pi/settings.json <original bytes>
IDENTICAL: rollback restored exact prior bytes

$ ls .pi/git/github.com/algal/pi-openai-server-compaction  # installed package clone untouched
extensions
package.json
skills
```
</details>
<details>
<summary>Evidence: Real generated scout brief: mandated stable report front with decision-hold-lifecycle retained as completion owner</summary>

<code># Definition of done&#10;Write your findings to `.../data/art-9001/report.md`.&#10;The report must stand alone: what you did, what you found, the evidence (commands run, output, file:line references), and what you recommend.&#10;The report must begin with these level-two sections in exactly this order:&#10;1. `## Executive summary`&#10;2. `## Decision inventory`&#10;3. `## Current next actions`&#10;The executive summary must state current conclusions, consequences, and recommendations rather than investigation chronology.&#10;List each remaining decision with its stable privacy-safe key, owner, exact options, and current OPEN or resolved state.&#10;Keep that stable front current when detailed evidence grows, and distinguish authorized next work from recommendations that still need authorization.&#10;When no captain decision remains, the `## Decision inventory` section must contain the exact line `Decision inventory: None`.&#10;Before reporting done, read and follow `.../.agents/skills/decision-hold-lifecycle/SKILL.md` and pass its shared completion gate for the report and any visual review.</code>

```text
You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.

# Task
{TASK}

# Herdr lifecycle declaration - NOT ENABLED
**HARD SAFETY GATE:** this scaffold cannot inspect the task text that replaces `{TASK}` later.
If the task will start, stop, delete, restart, profile, or otherwise drive Herdr lifecycle behavior, stop and regenerate the brief with `--herdr-lab` before dispatch.
Do not add Herdr lifecycle commands to this unguarded brief by hand.

# Setup
You are in a disposable git worktree of audit compaction recall, at a detached HEAD on a clean default branch.
This is a SCOUT task: the deliverable is a written report, not a PR.
The worktree is your laboratory - install, run, edit, and make scratch commits freely; all of it is discarded at teardown.
The report is the only thing that survives, so anything worth keeping must be in it.

# Rules
1. Never push to any remote and never open a PR.
2. Stay inside this worktree; the only files you may write outside it are the report and the status file below.
3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
4. Report status by appending one line:
   `echo "{state}: {one short line}" >> '/var/folders/r8/cylyt7xd7t50y9x5wc05my380000gn/T/no-mistakes-evidence/01KZ4ZRSQETQ9Y9DZQXMWSD0YT/scout-brief-home/state/art-9001.status'`
   States: working, needs-decision, blocked, paused, done, failed.
   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
   would act on and the needs-decision/blocked/paused/done/failed states. No step-by-step
   FYI progress lines; firstmate reads your pane for that.
   Use `paused: {why}` - distinct from `blocked:` - ONLY when you are deliberately idling on a
   known external wait you expect to clear on its own (an upstream release, a rate-limit reset):
   firstmate then leaves your idle pane alone and rechecks it on a long cadence instead of
   treating it as a possible wedge. Use `blocked:` when you are stuck and need help.
5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
6. If a decision belongs to a human (product choices, destructive actions),
   append `needs-decision: {summary of options}` and stop. Firstmate will reply with the decision.
   When firstmate replies or a blocker clears and you resume, append `resolved: {how it was decided or unblocked}` (add the same `[key=<slug>]` if you opened it with one) so the decision or blocker is durably closed and does not keep resurfacing.
7. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving
   every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
   daemon error, append `blocked: {the daemon error}` and stop; only firstmate manages the daemon.

# Definition of done
Write your findings to `/var/folders/r8/cylyt7xd7t50y9x5wc05my380000gn/T/no-mistakes-evidence/01KZ4ZRSQETQ9Y9DZQXMWSD0YT/scout-brief-home/data/art-9001/report.md`.
The report must stand alone: what you did, what you found, the evidence (commands run, output, file:line references), and what you recommend.
The report must begin with these level-two sections in exactly this order:
1. `## Executive summary`
2. `## Decision inventory`
3. `## Current next actions`
The executive summary must state current conclusions, consequences, and recommendations rather than investigation chronology.
List each remaining decision with its stable privacy-safe key, owner, exact options, and current OPEN or resolved state.
Keep that stable front current when detailed evidence grows, and distinguish authorized next work from recommendations that still need authorization.
When no captain decision remains, the `## Decision inventory` section must contain the exact line `Decision inventory: None`.
Before reporting done, read and follow `/Users/tiago/.no-mistakes/worktrees/bbb16e1f0808/01KZ4ZRSQETQ9Y9DZQXMWSD0YT/.agents/skills/decision-hold-lifecycle/SKILL.md` and pass its shared completion gate for the report and any visual review.
When the report is complete, append `done: {one-line conclusion}` to the status file and stop.
If your findings reveal work that should ship (e.g. you reproduced a bug and the fix is clear), say so in the report; firstmate may promote this task in place, and you would then receive mode-specific ship instructions as a follow-up message.
```
</details>
<details>
<summary>Evidence: Live Pi 0.83.0 agent output: stow withholds the pointer for conversation-only authority and emits the literal durable receipt</summary>

<code>CASE_A_RESET_SAFE=NO&#10;CASE_A_RESUME_POINTER=WITHHELD&#10;RESUME POINTER: Load data/checkpoint.md and data/backlog.md; inspect data/backlog.md; continue with run the named focused test.</code>

```text
CASE_A_RESET_SAFE=NO
CASE_A_RESUME_POINTER=WITHHELD
RESUME POINTER: Load data/checkpoint.md and data/backlog.md; inspect data/backlog.md; continue with run the named focused test.
```
</details>
<details>
<summary>Evidence: Live Pi 0.83.0 agent output: evidence skill rejects a summary-only token-savings claim</summary>

<code>TOKEN_SAVINGS_CLAIM=REJECTED&#10;REQUIRED_EVIDENCE=provider-input-and-current-context</code>

```text
TOKEN_SAVINGS_CLAIM=REJECTED
REQUIRED_EVIDENCE=provider-input-and-current-context
```
</details>
<details>
<summary>Evidence: Credentialed live e2e suite result against exact installed Pi 0.83.0</summary>

<code>ok - Pi sees one evidence owner and rejects a realistic root-procedure duplication&#10;ok - Pi stow refuses conversation-only authority and emits the required durable resume receipt&#10;ok - Pi rejects token-saving claims based only on a small summary</code>

```text
ok - Pi sees one evidence owner and rejects a realistic root-procedure duplication
ok - Pi stow refuses conversation-only authority and emits the required durable resume receipt
ok - Pi rejects token-saving claims based only on a small summary
```
</details>
<details>
<summary>Evidence: Documented retainedTail vs firstKeptEntryId mismatch confirmed against the installed build</summary>

<code>installed Pi: 0.83.0&#10;grep -c retainedTail dist/core/session-manager.js -&gt; 0&#10;grep -o firstKeptEntryId dist/core/session-manager.js | wc -l -&gt; 6&#10;grep -c retainedTail docs/session-format.md -&gt; 5</code>

```text
$ node -e 'require(pkg).version'   # installed Pi
0.83.0

$ grep -c retainedTail dist/core/session-manager.js
0
0
$ grep -o firstKeptEntryId dist/core/session-manager.js | wc -l
6

$ grep -c retainedTail docs/session-format.md   # installed docs
5
```
</details>
- Outcome: ⚠️ 1 warning across 1 run (18m21s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 6 issues found → auto-fixed (2) ✅</summary>

- ⚠️ `docs/verification/context-effectiveness.md:149` - Intent requires &#34;an exact reversible jq handoff that preserves every unrelated primary-home Pi setting and package field, sets native compaction reserveTokens 16384 and keepRecentTokens 12000, and disables only the installed remote package extensions through object-form extensions: []&#34;. The delivered handoff, its verifier, and its rollback are all `python3` heredocs (docs/verification/context-effectiveness.md:149, 209, 268) - there is no `jq` anywhere in the change (`grep -n jq docs/verification/context-effectiveness.md` returns nothing). The Python version is functionally stronger (atomic replace, mode preservation, O_EXCL backup, duplicate-declaration refusal), so this reads as a deliberate substitution rather than an oversight, but it contradicts the named mechanism in the acceptance criteria and needs captain confirmation rather than silent acceptance.
- ⚠️ `tests/fm-context-effectiveness.test.sh:328` - `[ &#34;$runtime_version&#34; = 0.83.0 ] || fail ...` hard-fails, and bin/fm-test-run.sh:129 puts fm-context-effectiveness.test.sh in the default `pure-contract-unit` family. A routine `pi` upgrade to 0.84.x therefore turns the default suite red on every unrelated PR until someone edits this literal. The opt-in live twin (tests/fm-context-effectiveness-live-e2e.test.sh:29) can justify a hard pin because it is gated behind FM_CONTEXT_EFFECTIVENESS_LIVE_E2E, but the repo convention for unconditional Pi-dependent unit tests is to skip or merely record (tests/fm-calm-pi-extension.test.sh:26-29 only asserts the version is non-empty; tests/fm-pi-primary-types.test.sh:11-14 skips outright). Recommend printing a `skip:` line on a version other than 0.83.0 so the measured-version fact stays recorded without making an upgrade a suite failure.
- ⚠️ `tests/fm-context-effectiveness.test.sh:324` - The file&#39;s only precondition guard is `[ -f &#34;$PI_PACKAGE_DIR/package.json&#34; ]` (line 13), which checks the npm global package dir, not the `pi` executable. When FM_PI_PACKAGE_DIR points at an installed package but `pi` is not on PATH (a CI image installing the package without linking the bin, for example), `runtime_version=$(pi --version)` emits `pi: command not found`, leaves the variable empty under `set -u` with no `set -e`, and the run dies at line 326 with the misleading message `Pi CLI and installed package versions differ: cli= package=0.83.0` instead of skipping. Add `command -v pi &gt;/dev/null 2&gt;&amp;1 || { echo &#34;skip: pi not found&#34;; exit 0; }` alongside the existing guard, matching tests/fm-context-effectiveness-live-e2e.test.sh:28.
- ⚠️ `tests/fm-context-effectiveness.test.sh:143` - `apply_native_settings_merge` and `settings_match_narrow_merge` are verbatim copies of the Python blocks in docs/verification/context-effectiveness.md:149 and :209, retyped into the test rather than extracted from the doc. The test therefore proves the copy is correct, not that the documented handoff is - the two can drift silently, and the doc block is the artifact a maintainer will actually paste into the primary home. Since the intent asks for a reproducible handoff plus realistic mutation-witness tests, the witness should read the fenced block out of docs/verification/context-effectiveness.md (by fence index or a named marker) and execute that text, so editing the doc without editing the test fails.
- ⚠️ `docs/verification/context-effectiveness.md:145` - `cd /Users/tiago/Workspace/firstmate` (line 145) and the same absolute path at line 139 embed one maintainer&#39;s home directory into a tracked, shared doc. No other file in the repo contains `/Users/tiago` (`grep -rn &#39;/Users/tiago&#39; docs/ .agents/ AGENTS.md bin/ tests/` matches only this file), and the sibling record in the same directory states the convention explicitly: docs/verification/dispatch-auth.md:10 says &#34;Credential paths below are shown with the home directory replaced by `&lt;home&gt;`&#34;. As written the reproduction section is non-runnable for any other Firstmate home, which undercuts the &#34;reproducible&#34; goal. Replace with `&lt;primary-home&gt;` or `$FM_ROOT`.
- ℹ️ `tests/lib.sh:40` - `export GIT_CONFIG_COUNT=1` with KEY_0/VALUE_0 unconditionally claims slot 0 and pins the count at 1, so any future test (or an enclosing harness) that wants a second env-based git override must know to renumber and bump the count, and any pre-existing GIT_CONFIG_* env config in the parent environment is silently dropped rather than extended. Because the variables are exported, they also propagate into every child process the suite spawns - real pi/herdr/tmux harnesses in the e2e families and the no-mistakes gate - forcing commit.gpgsign=false there too. No current caller conflicts (`grep -rn GIT_CONFIG tests/ bin/` matches only these three lines), and the effect is benign today, so this is a note on the shared-infra contract rather than a defect. It is also unrelated to the stated compaction intent, which is fine but worth calling out as bundled scope.

🔧 Fix: Execute documented handoff blocks and skip on Pi drift
4 issues (2 warnings, 2 infos) still open:
- ⚠️ `tests/fm-context-effectiveness.test.sh:206` - The overwrite mutant is built as a bare `.pi/settings.json` plus `data/` with no `.pi/git/github.com/algal/pi-openai-server-compaction` clone, so `run_handoff_block verify` on it can fail for two independent reasons: the intended `assert current == expected` (docs/verification/context-effectiveness.md:264) and the unrelated `assert clone.is_dir()` (docs:266). The test only checks for a non-zero exit, so it cannot tell them apart. Concretely: delete the `assert current == expected` line from the doc&#39;s verify block and this suite stays green - line 197 still passes on the real merge, and line 212 still fails, now from the missing clone. That leaves the preservation guarantee the intent calls out (&#34;preserves every unrelated primary-home Pi setting and package field&#34;) without a working mutation witness, which is the one thing this refactor was meant to establish. Call `write_package_fixture &#34;$overwrite_mutant&#34;` when building the mutant so the clone exists and the preservation assertion is the only thing that can fire.
- ⚠️ `docs/verification/context-effectiveness.md:151` - `cd &#34;${FM_PRIMARY_HOME:?set FM_PRIMARY_HOME to the active Firstmate primary root}&#34;` guards only unset/empty, not a failed `cd`. The remaining context lines and every later block then run against whatever directory the shell is already in. tests/fm-context-effectiveness.test.sh:127 composes context and body into a single `bash -c` with no `set -e`, so in the test a bad fixture path silently redirects the destructive apply at the runner&#39;s cwd instead of failing (the mutation branches discard stderr with `2&gt;&amp;1`, so the `cd:` diagnostic is swallowed). This worktree has no `.pi/settings.json`, so today the apply would die at `settings.read_bytes()` before writing anything - but the same footgun ships to the maintainer this doc is written for: with `FM_PRIMARY_HOME` pointing at home A while the shell sits in home B (a secondmate home), the merge lands on home B&#39;s private settings, which the intent explicitly forbids. Append `|| exit 1` to the `cd`, or prefix the composed script in `run_handoff_block` with `set -e`.
- ℹ️ `docs/verification/context-effectiveness.md:287` - The resolve block derives the clone path with `source.split(&#34;:&#34;, 2)[1]`, while the verify block derives the same path with Python&#39;s `source.split(&#34;:&#34;, 1)[1]` (docs:265). These are not equivalent: JavaScript&#39;s second argument truncates the result array rather than limiting the number of splits. For the current single-colon `git:github.com/algal/pi-openai-server-compaction` both yield the same string, so this is latent only - but if `SOURCE` ever takes a second colon (an SCP-style or port-bearing remote), Python keeps the full remainder while JavaScript silently drops everything after the second colon and the resolver then filters against a clone path that matches nothing. Use `source.slice(source.indexOf(&#34;:&#34;) + 1)` so both derivations agree.
- ℹ️ `tests/fm-context-effectiveness.test.sh:21` - The new skip is at file scope, so a Pi bump to 0.84.x also stops running `test_skill_discovery_and_trigger_precision` (line 78) - the only non-live mutation witness for &#34;exactly one internal evidence-consumption procedure owner plus a precise root trigger&#34;, which the intent marks required. That check is not part of the 0.83.0-measured matrix; only the handoff and resolver checks are. The captain&#39;s correction instruction did ask for a version skip, so this is a scoping question rather than a defect: consider gating only the two documented-handoff tests on `MEASURED_PI_VERSION` and letting the skill-discovery check run on any installed Pi (it would still skip when the package is absent), so a routine upgrade does not silently retire that witness. The counter-argument is real too - `dist/core/resource-loader.js` is a private path that can move between versions - so this is worth a decision rather than an automatic change.

🔧 Fix: Scope Pi version gate to measured handoff checks
✅ Re-checked - no issues remain.

</details>

<details>
<summary>⚠️ **Test** - 1 warning</summary>

- ⚠️ `docs/verification/context-effectiveness.md:133` - The user intent requires &#34;an exact reversible jq handoff&#34;, but docs/verification/context-effectiveness.md ships a python3 handoff instead, stating the captain approved superseding jq because jq cannot rewrite its own input file without an unguarded redirect or a truncation-prone temp-file dance. I verified the python3 handoff satisfies every behavioral property the intent demanded (atomic replace, exclusive backup, exact rollback, unrelated-key preservation, extensions-only disable, reserveTokens 16384 / keepRecentTokens 12000), but I cannot produce evidence for a jq mechanism because none exists in the change. You need to confirm the documented supersession is the accepted outcome.
- <code>`bash tests/fm-context-effectiveness.test.sh` - 4/4 ok (skill discovery + trigger mutation, documented handoff preservation and extension-only disable, rollback/refusal contract, exact Pi 0.83.0 version gate)</code>
- <code>`bash tests/fm-brief.test.sh` - 22/22 ok including `test_scout_report_front_is_stable_by_construction` and its heading-order mutation witness</code>
- <code>`bash tests/fm-documentation-audiences.test.sh` - 4/4 ok (both newly registered surfaces classified)</code>
- <code>`bash tests/fm-test-run.test.sh` - 17/17 ok (both new test scripts land in their declared families, `--all` coverage exact)</code>
- <code>`FM_CONTEXT_EFFECTIVENESS_LIVE_E2E=1 bash tests/fm-context-effectiveness-live-e2e.test.sh` - 3/3 ok against real Pi 0.83.0 + openai-codex/gpt-5.6-sol</code>
- <code>Manual: `FM_HOME=... ./bin/fm-brief.sh art-9001 &#39;audit compaction recall&#39; --scout` and inspected the generated brief&#39;s Definition of done section</code>
- <code>Manual: extracted `fm-handoff=context|apply|verify|resolve|rollback` blocks verbatim from `docs/verification/context-effectiveness.md` and executed them against a synthetic primary-home fixture, diffing settings.json before/after and after rollback</code>
- <code>Manual: `pi --print --approve --no-session --skill .agents/skills/stow/SKILL.md ...` and the same for `.agents/skills/evidence-consumption/SKILL.md`, capturing raw agent output</code>
- <code>Manual: `grep -c retainedTail` / `grep -o firstKeptEntryId` against the installed `@earendil-works/pi-coding-agent@0.83.0` `dist/core/session-manager.js` and its `docs/session-format.md`</code>
- <code>Manual: `git status --porcelain --untracked-files=all` (clean) and `grep -rn &#39;—&#39;` over changed files (none)</code>

</details>

<details>
<summary>⚠️ **Document** - 1 info</summary>

- ℹ️ `docs/verification/context-effectiveness.md:141` - The user intent names an &#34;exact reversible jq handoff&#34;, while docs/verification/context-effectiveness.md records that the captain approved superseding jq with a python3 handoff (jq cannot rewrite its own input file safely). The doc states that approval and its rationale explicitly, and the executed blocks match the python3 mechanism, so the documentation is internally consistent. Flagging only so the outer executor knows the doc deliberately diverges from the literal wording of the intent under a recorded captain decision.

</details>

<details>
<summary>🔧 **Lint** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ linter found issues (exit code 127)

🔧 Fix: No code changes; lint clean after ShellCheck install
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
