### PR TITLE
fix(bin): keep claude crewmate hooks out of the project worktree

### DIFF
--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -179,6 +179,10 @@ The shared symptom is a healthy-looking pane with no work in progress, so each a
 | Interrupt | single Escape |
 | Skill invocation | `/<skill>` (e.g. `/no-mistakes`) |
 
+A crewmate's per-task hooks live OUTSIDE the worktree, in `state/<id>.claude-settings.json`, and reach the session through `claude --settings <file>` on the launch command (`bin/fm-spawn.sh`).
+Nothing is written into the project, so a project that tracks `.claude/settings.local.json` keeps its committed content, and its own settings still load alongside firstmate's hooks because `--settings` is additive (verified live, [`docs/verification/supervision.md`](../../../docs/verification/supervision.md)).
+Because the hooks ride the launch command rather than the worktree, any manual resume or relaunch of a claude crewmate must carry the same `--settings <state/<id>.claude-settings.json>` argument; a bare `claude` in the worktree starts with no turn-end wake and no busy-state reporting.
+
 First launch in a fresh worktree, or first ever on a machine, may show a trust or bypass-permissions confirmation.
 After every spawn, peek the pane within about 20 seconds.
 If such a dialog is showing, accept it from an active firstmate session using `FM_HOME=<this-firstmate-home> bin/fm-send.sh <window> --key Enter`, or the choice the dialog requires, unless `FM_HOME` is already set to the active firstmate home; verify the brief started processing.
@@ -193,7 +197,7 @@ That styled capture is internal to the boolean detector only.
 `fm-peek` and every other human or LLM-facing capture path stays plain `tmux capture-pane` with no escape codes.
 
 **Primary-session guard fact (verified 2026-07-04, Claude Code 2.1.201; preserved 2026-07-08, Claude Code 2.1.204; Stop-owned auto-arm revalidated 2026-07-24, Claude Code 2.1.219).**
-This is separate from the per-task crewmate turn-end hook above (that one just `touch`es a marker file in a task's own `.claude/settings.local.json`).
+This is separate from the per-task crewmate hooks above (those come from the task's own `state/<id>.claude-settings.json`, and their `Stop` hook just `touch`es a marker file).
 The firstmate PRIMARY's own `.claude/settings.json` registers two Stop hooks: `bin/fm-turnend-guard.sh --claude` and the Stop-owned auto-arm `bin/fm-claude-stop-autoarm.sh` (`asyncRewake: true`, `timeout: 28800`), and exiting the guard with status 2 plus stderr reliably forces the model to continue.
 Claude Code's stdin payload to a Stop hook carries a `stop_hook_active` boolean that is `true` when the current stop attempt follows ANY stop-hook-driven continuation, including `asyncRewake` rewakes; the primary guard therefore ignores it in `--claude` mode and uses the cooperative claim/epoch check plus a bounded re-block budget instead, while the codex-mode default still treats it as a one-block loop guard.
 A project-level `.claude/settings.json` only takes effect when Claude Code's project root is that exact directory - it does not walk up from a subdirectory looking for one, so firstmate launches the primary from the repo root.

--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -182,6 +182,7 @@ The shared symptom is a healthy-looking pane with no work in progress, so each a
 A crewmate's per-task hooks live OUTSIDE the worktree, in `state/<id>.claude-settings.json`, and reach the session through `claude --settings <file>` on the launch command (`bin/fm-spawn.sh`).
 Nothing is written into the project, so a project that tracks `.claude/settings.local.json` keeps its committed content, and its own settings still load alongside firstmate's hooks because `--settings` is additive (verified live, [`docs/verification/supervision.md`](../../../docs/verification/supervision.md)).
 Because the hooks ride the launch command rather than the worktree, any manual resume or relaunch of a claude crewmate must carry the same `--settings <state/<id>.claude-settings.json>` argument; a bare `claude` in the worktree starts with no turn-end wake and no busy-state reporting.
+For the same reason, a claude spawn through `fm-spawn`'s raw-launch-command escape hatch cannot receive that argument, so `fm-spawn` warns and names it, leaves the busy-state contract unarmed rather than seeding a busy nothing could clear, and that worker classifies `unknown` until the argument is added by hand.
 
 First launch in a fresh worktree, or first ever on a machine, may show a trust or bypass-permissions confirmation.
 After every spawn, peek the pane within about 20 seconds.

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -123,12 +123,18 @@
 #     __BRIEF__    absolute path to data/<task-id>/brief.md
 #     __TURNEND__  absolute path to state/<task-id>.turn-ended (for harnesses whose
 #                  turn-end signal rides the launch command, e.g. codex -c notify=[...])
+#     __CLAUDESETTINGS__ absolute path to state/<task-id>.claude-settings.json (claude
+#                  turn-end and busy-state hooks, written by this script; outside the
+#                  worktree so a project that tracks .claude/settings.local.json is
+#                  never modified, and additive to the project's own settings)
 #     __PIEXT__    absolute path to state/<task-id>.pi-ext.ts (pi turn-end extension,
 #                  written by this script; outside the worktree to avoid pi's trust gate)
 #     __PITURNEND__ absolute path to .pi/extensions/fm-primary-turnend-guard.ts in a pi secondmate home
 #     __PIWATCH__   absolute path to .pi/extensions/fm-primary-pi-watch.ts in a pi secondmate home
 #     __OPINPUT__   absolute path to the canonical operational-input encoder
 # Verified per-harness turn-end hooks are installed automatically where enabled; some live outside the worktree.
+# claude uses a per-task state/<task-id>.claude-settings.json passed with --settings,
+# so no file is written into the worktree and a project's own .claude settings still load.
 # Kimi uses one surgically installed Firstmate region in $HOME/.kimi-code/config.toml,
 # a firstmate-owned global hook and registry, and a gitignored per-task pointer.
 # grok uses a firstmate-owned global hook under ${GROK_HOME:-$HOME/.grok}/hooks
@@ -769,7 +775,17 @@ launch_template() {
     # does NOT suppress the interactive ghost text (verified empirically), so the env
     # var is the correct control. The dim-aware composer reader in fm-tmux-lib.sh is
     # the defense-in-depth backstop for any pane this flag cannot reach.
-    claude) printf '%s' 'CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions __MODELFLAG____EFFORTFLAG__"$(__OPINPUT__ encode launch-brief < __BRIEF__)"' ;;
+    # --settings loads the per-task hook file written OUTSIDE the worktree (see the
+    # claude branch of the turn-end/busy-state installer below). A secondmate gets no
+    # per-task hooks - its own home's tracked .claude/settings.json owns them - so it
+    # launches without the flag.
+    claude)
+      if [ "$kind" = secondmate ]; then
+        printf '%s' 'CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions __MODELFLAG____EFFORTFLAG__"$(__OPINPUT__ encode launch-brief < __BRIEF__)"'
+      else
+        printf '%s' 'CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions --settings __CLAUDESETTINGS__ __MODELFLAG____EFFORTFLAG__"$(__OPINPUT__ encode launch-brief < __BRIEF__)"'
+      fi
+      ;;
     codex)
       if [ "$kind" = secondmate ]; then
         printf '%s' 'codex __MODELFLAG____EFFORTFLAG__--dangerously-bypass-approvals-and-sandbox "$(__OPINPUT__ encode launch-brief < __BRIEF__)"'
@@ -1707,6 +1723,10 @@ mkdir -p "$TASK_TMP/gotmp"
 mkdir -p "$STATE"
 STATE_REAL=$(cd "$STATE" && pwd -P)
 TURNEND="$STATE_REAL/$ID.turn-ended"
+# Claude's per-task hook file. Written here, outside the worktree, and passed to
+# the launch with --settings; fm-teardown removes it with the other per-task
+# state artifacts.
+CLAUDE_SETTINGS="$STATE/$ID.claude-settings.json"
 exclude_path() {
   local rel=$1 EXCL
   EXCL=$(git -C "$WT" rev-parse --git-path info/exclude 2>/dev/null || true)
@@ -1760,17 +1780,30 @@ if [ "$KIND" != secondmate ]; then
       # turn-ended NOTIFICATION touch for the watcher. Every hook command
       # tolerates a refused event (|| true) so a stale-gen writer can never
       # break Claude's own lifecycle.
-      mkdir -p "$WT/.claude"
+      #
+      # Written OUTSIDE the worktree and loaded with `claude --settings <file>`,
+      # for the same reason pi's extension lives in state/: a project may TRACK
+      # .claude/settings.local.json, and writing that path wholesale destroyed
+      # the project's committed content in the worktree, left every claude
+      # crewmate starting on a modified tracked file, and could make teardown
+      # refuse on a dirty worktree. --settings is ADDITIVE (verified live on
+      # Claude Code 2.1.220, docs/verification/supervision.md), so a
+      # project's own settings still load and its rules still apply to the
+      # crewmate alongside these hooks. Nothing is written into the worktree,
+      # so there is no project file to parse, merge, or unpick at teardown.
       busy_cmd_prefix="$(shell_quote "$FM_ROOT/bin/fm-busy-event.sh") apply $(shell_quote "$STATE_REAL") $(shell_quote "$ID")"
       busy_suffix="--gen $(shell_quote "$BUSY_GEN") --source claude-hook"
       j_submit=$(json_escape "$busy_cmd_prefix busy $busy_suffix --event user-prompt-submit 2>/dev/null || true")
       j_stop=$(json_escape "touch $(shell_quote "$TURNEND"); $busy_cmd_prefix idle $busy_suffix --event stop 2>/dev/null || true")
       j_stopfail=$(json_escape "$busy_cmd_prefix idle $busy_suffix --event stop-failure 2>/dev/null || true")
       j_sessionend=$(json_escape "$busy_cmd_prefix idle $busy_suffix --event session-end 2>/dev/null || true")
-      cat > "$WT/.claude/settings.local.json" <<EOF
+      if ! cat > "$CLAUDE_SETTINGS" <<EOF
 {"hooks":{"UserPromptSubmit":[{"hooks":[{"type":"command","command":"$j_submit"}]}],"Stop":[{"hooks":[{"type":"command","command":"$j_stop"}]}],"StopFailure":[{"hooks":[{"type":"command","command":"$j_stopfail"}]}],"SessionEnd":[{"hooks":[{"type":"command","command":"$j_sessionend"}]}]}}
 EOF
-      exclude_path '.claude/settings.local.json'
+      then
+        echo "error: failed to write the claude hook settings for $ID at $CLAUDE_SETTINGS" >&2
+        exit 1
+      fi
       ;;
     opencode*)
       mkdir -p "$WT/.opencode/plugins"
@@ -2027,6 +2060,7 @@ META_WINDOW=$T
 
 sq_brief=$(shell_quote "$BRIEF")
 sq_turnend=$(shell_quote "$TURNEND")
+sq_claudesettings=$(shell_quote "$CLAUDE_SETTINGS")
 sq_piext=$(shell_quote "$STATE/$ID.pi-ext.ts")
 sq_piturnend=$(shell_quote "$PROJ_ABS/.pi/extensions/fm-primary-turnend-guard.ts")
 sq_piwatch=$(shell_quote "$PROJ_ABS/.pi/extensions/fm-primary-pi-watch.ts")
@@ -2037,10 +2071,27 @@ LAUNCH=${LAUNCH//__MODELFLAG__/$MODELFLAG}
 LAUNCH=${LAUNCH//__EFFORTFLAG__/$EFFORTFLAG}
 LAUNCH=${LAUNCH//__BRIEF__/$sq_brief}
 LAUNCH=${LAUNCH//__TURNEND__/$sq_turnend}
+LAUNCH=${LAUNCH//__CLAUDESETTINGS__/$sq_claudesettings}
 LAUNCH=${LAUNCH//__PIEXT__/$sq_piext}
 LAUNCH=${LAUNCH//__PITURNEND__/$sq_piturnend}
 LAUNCH=${LAUNCH//__PIWATCH__/$sq_piwatch}
 LAUNCH=${LAUNCH//__OPINPUT__/$sq_opinput}
+# A raw launch command (the unverified-adapter escape hatch) carries no
+# placeholder, so a hand-written claude command reaches the pane without the
+# --settings argument that loads the hooks written above. Say so loudly rather
+# than launching a worker whose turn-end wake silently never fires.
+if [ "$KIND" != secondmate ]; then
+  case "$HARNESS" in
+    claude*)
+      case "$LAUNCH" in
+        *--settings*) ;;
+        *)
+          echo "warning: this raw claude launch command carries no --settings argument, so $ID will run with no turn-end wake or busy-state reporting; add --settings $sq_claudesettings to the command" >&2
+          ;;
+      esac
+      ;;
+  esac
+fi
 # Crewmate panes are created by a long-lived tmux/herdr daemon that does not
 # inherit firstmate's current environment, so a bare `claude` in the pane falls
 # back to the default ~/.claude store even when firstmate itself runs under a

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -135,6 +135,9 @@
 # Verified per-harness turn-end hooks are installed automatically where enabled; some live outside the worktree.
 # claude uses a per-task state/<task-id>.claude-settings.json passed with --settings,
 # so no file is written into the worktree and a project's own .claude settings still load.
+# A raw claude launch command cannot carry that argument, so it is warned about, left
+# unarmed (its busy state reads unknown, never a stranded busy), and given a hook file
+# holding only the turn-end touch, which works as soon as --settings is added by hand.
 # Kimi uses one surgically installed Firstmate region in $HOME/.kimi-code/config.toml,
 # a firstmate-owned global hook and registry, and a gitignored per-task pointer.
 # grok uses a firstmate-owned global hook under ${GROK_HOME:-$HOME/.grok}/hooks
@@ -1727,6 +1730,17 @@ TURNEND="$STATE_REAL/$ID.turn-ended"
 # the launch with --settings; fm-teardown removes it with the other per-task
 # state artifacts.
 CLAUDE_SETTINGS="$STATE/$ID.claude-settings.json"
+# Whether this launch can actually load that file. The templated claude launch
+# carries the __CLAUDESETTINGS__ placeholder; a raw launch command (the
+# unverified-adapter escape hatch) carries no placeholder, so it loads the hooks
+# only when the operator wrote the --settings argument themselves. This one
+# predicate drives every downstream decision - whether to arm the busy-state
+# contract, what the hook file may contain, and whether to warn - so those three
+# can never disagree about whether a hook writer exists.
+CLAUDE_HOOKS_LOADED=
+case "$LAUNCH" in
+  *__CLAUDESETTINGS__*|*"$CLAUDE_SETTINGS"*) CLAUDE_HOOKS_LOADED=1 ;;
+esac
 exclude_path() {
   local rel=$1 EXCL
   EXCL=$(git -C "$WT" rev-parse --git-path info/exclude 2>/dev/null || true)
@@ -1752,7 +1766,21 @@ if [ "$KIND" != secondmate ]; then
       ;;
   esac
   case "$HARNESS" in
-    claude*|opencode*|pi|pi-signed)
+    claude*)
+      # A claude launch that cannot load the per-task hook file (a raw launch
+      # command with no --settings) has no writer that could ever close the
+      # seeded turn, so arming would strand a busy record nothing can clear.
+      # Such a spawn stays unarmed and classifies unknown, the same way codex
+      # and standalone Kimi decline rather than report a verdict they cannot
+      # back. The launch still happens; see the warning below.
+      if [ -n "$CLAUDE_HOOKS_LOADED" ]; then
+        BUSY_GEN=$("$FM_ROOT/bin/fm-busy-event.sh" arm "$STATE_REAL" "$ID") || {
+          echo "error: failed to arm the busy-state contract for $ID" >&2
+          exit 1
+        }
+      fi
+      ;;
+    opencode*|pi|pi-signed)
       BUSY_GEN=$("$FM_ROOT/bin/fm-busy-event.sh" arm "$STATE_REAL" "$ID") || {
         echo "error: failed to arm the busy-state contract for $ID" >&2
         exit 1
@@ -1791,16 +1819,30 @@ if [ "$KIND" != secondmate ]; then
       # project's own settings still load and its rules still apply to the
       # crewmate alongside these hooks. Nothing is written into the worktree,
       # so there is no project file to parse, merge, or unpick at teardown.
-      busy_cmd_prefix="$(shell_quote "$FM_ROOT/bin/fm-busy-event.sh") apply $(shell_quote "$STATE_REAL") $(shell_quote "$ID")"
-      busy_suffix="--gen $(shell_quote "$BUSY_GEN") --source claude-hook"
-      j_submit=$(json_escape "$busy_cmd_prefix busy $busy_suffix --event user-prompt-submit 2>/dev/null || true")
-      j_stop=$(json_escape "touch $(shell_quote "$TURNEND"); $busy_cmd_prefix idle $busy_suffix --event stop 2>/dev/null || true")
-      j_stopfail=$(json_escape "$busy_cmd_prefix idle $busy_suffix --event stop-failure 2>/dev/null || true")
-      j_sessionend=$(json_escape "$busy_cmd_prefix idle $busy_suffix --event session-end 2>/dev/null || true")
-      if ! cat > "$CLAUDE_SETTINGS" <<EOF
+      if [ -n "$BUSY_GEN" ]; then
+        busy_cmd_prefix="$(shell_quote "$FM_ROOT/bin/fm-busy-event.sh") apply $(shell_quote "$STATE_REAL") $(shell_quote "$ID")"
+        busy_suffix="--gen $(shell_quote "$BUSY_GEN") --source claude-hook"
+        j_submit=$(json_escape "$busy_cmd_prefix busy $busy_suffix --event user-prompt-submit 2>/dev/null || true")
+        j_stop=$(json_escape "touch $(shell_quote "$TURNEND"); $busy_cmd_prefix idle $busy_suffix --event stop 2>/dev/null || true")
+        j_stopfail=$(json_escape "$busy_cmd_prefix idle $busy_suffix --event stop-failure 2>/dev/null || true")
+        j_sessionend=$(json_escape "$busy_cmd_prefix idle $busy_suffix --event session-end 2>/dev/null || true")
+        claude_hooks_json=$(cat <<EOF
 {"hooks":{"UserPromptSubmit":[{"hooks":[{"type":"command","command":"$j_submit"}]}],"Stop":[{"hooks":[{"type":"command","command":"$j_stop"}]}],"StopFailure":[{"hooks":[{"type":"command","command":"$j_stopfail"}]}],"SessionEnd":[{"hooks":[{"type":"command","command":"$j_sessionend"}]}]}}
 EOF
-      then
+        )
+      else
+        # Unarmed spawn (see the arm above): no gen exists, so every busy-state
+        # event would be refused and the record stays unknown rather than a
+        # verdict nothing can clear. The plain turn-end touch needs no gen and
+        # IS the supervision wake, so it still ships - an operator who follows
+        # the warning below and adds --settings by hand gets the wake back.
+        j_stop=$(json_escape "touch $(shell_quote "$TURNEND")")
+        claude_hooks_json=$(cat <<EOF
+{"hooks":{"Stop":[{"hooks":[{"type":"command","command":"$j_stop"}]}]}}
+EOF
+        )
+      fi
+      if ! printf '%s\n' "$claude_hooks_json" > "$CLAUDE_SETTINGS"; then
         echo "error: failed to write the claude hook settings for $ID at $CLAUDE_SETTINGS" >&2
         exit 1
       fi
@@ -2079,16 +2121,14 @@ LAUNCH=${LAUNCH//__OPINPUT__/$sq_opinput}
 # A raw launch command (the unverified-adapter escape hatch) carries no
 # placeholder, so a hand-written claude command reaches the pane without the
 # --settings argument that loads the hooks written above. Say so loudly rather
-# than launching a worker whose turn-end wake silently never fires.
-if [ "$KIND" != secondmate ]; then
+# than launching a worker whose turn-end wake silently never fires. The spawn
+# was left unarmed above, so its busy state reads unknown instead of a stranded
+# busy; the hook file still holds the turn-end touch, so adding the argument by
+# hand restores the wake.
+if [ "$KIND" != secondmate ] && [ -z "$CLAUDE_HOOKS_LOADED" ]; then
   case "$HARNESS" in
     claude*)
-      case "$LAUNCH" in
-        *--settings*) ;;
-        *)
-          echo "warning: this raw claude launch command carries no --settings argument, so $ID will run with no turn-end wake or busy-state reporting; add --settings $sq_claudesettings to the command" >&2
-          ;;
-      esac
+      echo "warning: this raw claude launch command carries no --settings argument, so $ID will run with no turn-end wake and its busy state stays unknown; add --settings $sq_claudesettings to the command to restore the turn-end wake" >&2
       ;;
   esac
 fi

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -126,7 +126,10 @@
 #     __CLAUDESETTINGS__ absolute path to state/<task-id>.claude-settings.json (claude
 #                  turn-end and busy-state hooks, written by this script; outside the
 #                  worktree so a project that tracks .claude/settings.local.json is
-#                  never modified, and additive to the project's own settings)
+#                  never modified, and additive to the project's own settings).
+#                  A claude secondmate launch omits the flag: no per-task hooks are
+#                  written for it, since its own home's tracked .claude/settings.json
+#                  owns them
 #     __PIEXT__    absolute path to state/<task-id>.pi-ext.ts (pi turn-end extension,
 #                  written by this script; outside the worktree to avoid pi's trust gate)
 #     __PITURNEND__ absolute path to .pi/extensions/fm-primary-turnend-guard.ts in a pi secondmate home

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -496,6 +496,11 @@ remove_kimi_turnend_auth() {
 # this task's own firstmate hook wiring - so a project's own file, tracked or not,
 # is never touched. Both legacy shapes are covered: the bare turn-end touch and
 # the later busy-state hooks.
+# A worktree whose TRACKED copy the old wholesale write already overwrote is
+# deliberately left alone, so a ship teardown still sees a modified tracked file
+# and refuses on uncommitted changes; restoring it automatically would put
+# firstmate back to writing into a project. Recover it by hand in that worktree
+# with `git checkout -- .claude/settings.local.json`, then tear down again.
 remove_legacy_claude_worktree_settings() {
   local wt=$1 id=$2 rel='.claude/settings.local.json' f
   f="$wt/$rel"

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -487,6 +487,26 @@ remove_kimi_turnend_auth() {
   rm -f "$hooks_dir/$token"
 }
 
+# Firstmate used to write a claude crewmate's per-task hooks into
+# <worktree>/.claude/settings.local.json, which destroyed that file's committed
+# content in projects that track it. fm-spawn now keeps those hooks in
+# state/<id>.claude-settings.json instead, but a task launched before that change
+# can still carry the old worktree file, so teardown clears it. Removal is gated
+# twice - the path must be untracked in that worktree AND its content must name
+# this task's own firstmate hook wiring - so a project's own file, tracked or not,
+# is never touched. Both legacy shapes are covered: the bare turn-end touch and
+# the later busy-state hooks.
+remove_legacy_claude_worktree_settings() {
+  local wt=$1 id=$2 rel='.claude/settings.local.json' f
+  f="$wt/$rel"
+  [ -f "$f" ] || return 0
+  ! git -C "$wt" ls-files --error-unmatch "$rel" >/dev/null 2>&1 || return 0
+  grep -qF "$id.turn-ended" "$f" 2>/dev/null \
+    || grep -qF 'fm-busy-event.sh' "$f" 2>/dev/null \
+    || return 0
+  rm -f "$f"
+}
+
 retire_busy_state() {
   local state_dir=$1 id=$2 gen=${3:-}
   if [ -n "$gen" ]; then
@@ -1616,13 +1636,15 @@ cleanup_firstmate_home_children() {
     elif [ "$child_backend" = orca ]; then
       if [ -n "$child_wt" ] && [ -d "$child_wt" ]; then
         validate_child_worktree_for_removal "$child_wt" "$child_proj" >/dev/null || return 1
-        rm -f "$child_wt/.claude/settings.local.json" "$child_wt/.opencode/plugins/fm-turn-end.js" \
+        remove_legacy_claude_worktree_settings "$child_wt" "$child_id"
+        rm -f "$child_wt/.opencode/plugins/fm-turn-end.js" \
           "$child_wt/.fm-grok-turnend" "$child_wt/.fm-kimi-turnend"
       fi
       fm_backend_remove_worktree "$child_backend" "$child_orca_worktree_id" || return 1
     elif [ -n "$child_wt" ] && [ -d "$child_wt" ]; then
       validate_child_worktree_for_removal "$child_wt" "$child_proj" >/dev/null || return 1
-      rm -f "$child_wt/.claude/settings.local.json" "$child_wt/.opencode/plugins/fm-turn-end.js" \
+      remove_legacy_claude_worktree_settings "$child_wt" "$child_id"
+      rm -f "$child_wt/.opencode/plugins/fm-turn-end.js" \
         "$child_wt/.opencode/plugins/fm-busy-state.js" \
         "$child_wt/.fm-grok-turnend" "$child_wt/.fm-kimi-turnend"
       if [ -n "$child_proj" ] && [ -d "$child_proj" ] && command -v treehouse >/dev/null 2>&1; then
@@ -1649,6 +1671,7 @@ cleanup_firstmate_home_children() {
     retire_busy_state "$sub_state" "$child_id" "$child_busy_gen" || return 1
     rm -f "$sub_state/$child_id.status" "$sub_state/$child_id.turn-ended" \
       "$sub_state/$child_id.meta" "$sub_state/$child_id.pi-ext.ts" \
+      "$sub_state/$child_id.claude-settings.json" \
       "$sub_state/$child_id.grok-turnend-token" "$sub_state/$child_id.kimi-turnend-token"
   done
 }
@@ -1789,7 +1812,8 @@ if [ "$BACKEND" = orca ] && [ "$KIND" != secondmate ]; then
         git -C "$WT" branch -D "$branch" >/dev/null 2>&1 || true
       fi
     fi
-    rm -f "$WT/.claude/settings.local.json" "$WT/.opencode/plugins/fm-turn-end.js" \
+    remove_legacy_claude_worktree_settings "$WT" "$ID"
+    rm -f "$WT/.opencode/plugins/fm-turn-end.js" \
       "$WT/.opencode/plugins/fm-busy-state.js" \
       "$WT/.fm-grok-turnend" "$WT/.fm-kimi-turnend"
   fi
@@ -1803,7 +1827,8 @@ elif [ -d "$WT" ] && [ "$KIND" != secondmate ]; then
     fi
   fi
   # Remove our hook file so a reused pool worktree cannot fire signals for a dead task.
-  rm -f "$WT/.claude/settings.local.json" "$WT/.opencode/plugins/fm-turn-end.js" \
+  remove_legacy_claude_worktree_settings "$WT" "$ID"
+  rm -f "$WT/.opencode/plugins/fm-turn-end.js" \
     "$WT/.fm-grok-turnend" "$WT/.fm-kimi-turnend"
   # Kills remaining processes in the worktree (including the agent), resets, returns
   # to pool. treehouse resolves the pool from the working directory, so run it from
@@ -1899,8 +1924,8 @@ fm_backend_clear_transition "$BACKEND" "$STATE" "$T" || true
 remove_pr_poll_artifacts "$STATE" "$ID" || exit 1
 retire_busy_state "$STATE" "$ID" "$BUSY_GEN" || exit 1
 rm -f "$STATE/$ID.status" "$STATE/$ID.turn-ended" "$STATE/$ID.meta" \
-  "$STATE/$ID.pi-ext.ts" "$STATE/$ID.grok-turnend-token" \
-  "$STATE/$ID.kimi-turnend-token"
+  "$STATE/$ID.pi-ext.ts" "$STATE/$ID.claude-settings.json" \
+  "$STATE/$ID.grok-turnend-token" "$STATE/$ID.kimi-turnend-token"
 if [ "$KIND" != scout ] && [ "$KIND" != secondmate ] && [ "$MODE" != local-only ]; then
   "$FM_ROOT/bin/fm-fleet-sync.sh" "$PROJ" || true
 fi

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -179,6 +179,7 @@ family_for_basename() {
       ;;
     fm-afk-pi-herdr-return-e2e.test.sh|\
     fm-codex-continuity-live-e2e.test.sh|fm-grok-continuity-live-e2e.test.sh|\
+    fm-claude-settings-hook-live-e2e.test.sh|\
     fm-grok-stop-live-e2e.test.sh|fm-harness-liveness-drift-live-e2e.test.sh|\
     fm-opencode-primary-live-e2e.test.sh|fm-pi-primary-live-e2e.test.sh|\
     fm-quota-array-dispatch-live-e2e.test.sh|fm-send-secondmate-marker-herdr-e2e.test.sh)
@@ -383,6 +384,7 @@ tests/fm-bootstrap.test.sh 21912
 tests/fm-busy-adapter-wiring.test.sh 13962
 tests/fm-busy-state.test.sh 607
 tests/fm-calm-pi-extension.test.sh 203
+tests/fm-claude-settings-hook-live-e2e.test.sh 19
 tests/fm-claude-stop-autoarm-live-e2e.test.sh 19
 tests/fm-claude-stop-autoarm.test.sh 60521
 tests/fm-codex-continuity-live-e2e.test.sh 19

--- a/docs/verification/supervision.md
+++ b/docs/verification/supervision.md
@@ -86,6 +86,24 @@ Firstmate-written project hooks under `<worktree>/.codex/hooks.json` fired for n
 Codex also exposes no `StopFailure` hook, so an API-error turn end would need separate coverage even after hook discovery works.
 The app-server protocol schema does define the required lifecycle (`turn/started`, plus a `turn/completed` status of `completed`, `interrupted`, `failed`, or `inProgress`), so the gate is a reachability problem rather than a protocol gap.
 
+Claude's per-task hooks reach the crewmate through `claude --settings <file>` rather than a file written into the worktree, because a project may track `.claude/settings.local.json` and a wholesale write destroyed its committed content.
+The two vendor behaviors that design depends on were live-verified on 2026-08-03 with Claude Code 2.1.220 against an isolated scratch repository that tracks that path.
+
+```sh
+claude --version
+FM_CLAUDE_LIVE_E2E=1 tests/fm-claude-settings-hook-live-e2e.test.sh
+```
+
+Observed output:
+
+```text
+2.1.220 (Claude Code)
+ok - Claude 2.1.220 (Claude Code): --settings hooks fired the turn-end wake, loaded additively beside the project's own tracked settings, and left that tracked file unmodified
+```
+
+Hooks supplied through `--settings` fire in a real interactive pane, so the turn-end wake still reaches firstmate, and they load in addition to the project's own settings rather than replacing them, so the project's committed rules still apply to the crewmate.
+That guard is the command that refreshes this evidence after a Claude Code upgrade.
+
 Deterministic entry points:
 
 ```sh

--- a/tests/fm-busy-adapter-wiring.test.sh
+++ b/tests/fm-busy-adapter-wiring.test.sh
@@ -30,7 +30,11 @@ esac
 case "${1:-}" in
   display-message) printf 'firstmate\n'; exit 0 ;;
   list-windows) exit 0 ;;
-  has-session|new-session|new-window|kill-window|send-keys) exit 0 ;;
+  send-keys)
+    [ -z "${FM_TMUX_LOG:-}" ] || printf '%s\n' "$*" >> "$FM_TMUX_LOG"
+    exit 0
+    ;;
+  has-session|new-session|new-window|kill-window) exit 0 ;;
 esac
 exit 0
 SH
@@ -263,7 +267,7 @@ test_claude_hooks_semantic_lifecycle() {
   out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$id" "$PROJ_DIR")
   expect_code 0 $? "claude spawn should succeed: $out"
   state="$HOME_DIR/state"
-  settings="$WT_DIR/.claude/settings.local.json"
+  settings="$HOME_DIR/state/$id.claude-settings.json"
   assert_present "$settings" "claude spawn did not write hook settings"
   jq -e . "$settings" >/dev/null || fail "claude hook settings are not valid JSON"
   for ev in UserPromptSubmit Stop StopFailure SessionEnd; do
@@ -301,13 +305,118 @@ test_claude_hooks_stale_incarnation_harmless() {
   out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$id" "$PROJ_DIR")
   expect_code 0 $? "claude spawn should succeed: $out"
   state="$HOME_DIR/state"
-  settings="$WT_DIR/.claude/settings.local.json"
+  settings="$HOME_DIR/state/$id.claude-settings.json"
   "$ROOT/bin/fm-busy-event.sh" arm "$state" "$id" >/dev/null
   run_claude_hook "$settings" UserPromptSubmit \
     || fail "a stale-gen hook must still exit 0 so Claude's lifecycle is never broken"
   out=$(classify claude "$id" "$state")
   [ "$out" = "busy fm-spawn" ] || fail "a stale-gen hook event must not change state, got '$out'"
   pass "claude hook events from a superseded incarnation are rejected without breaking the hook"
+}
+
+# seed_project_claude_settings <proj> <wt> <tracked|untracked> <content>: put a
+# .claude/settings.local.json into the case's worktree, either committed in the
+# project (the shape that made fm-spawn destroy real committed content) or left
+# untracked in the worktree.
+seed_project_claude_settings() {
+  local proj=$1 wt=$2 kind=$3 content=$4
+  if [ "$kind" = tracked ]; then
+    mkdir -p "$proj/.claude"
+    printf '%s\n' "$content" > "$proj/.claude/settings.local.json"
+    # -f because a host or repo ignore rule for .claude/ must not decide whether
+    # this fixture is tracked.
+    git -C "$proj" add -f .claude/settings.local.json
+    git -C "$proj" commit -qm "track claude settings"
+    git -C "$wt" reset -q --hard "$(git -C "$proj" rev-parse HEAD)"
+  else
+    mkdir -p "$wt/.claude"
+    printf '%s\n' "$content" > "$wt/.claude/settings.local.json"
+  fi
+}
+
+test_claude_hooks_leave_a_tracked_project_settings_file_untouched() {
+  local rec id=busy-cl-3 out state settings content before after status
+  rec=$(make_spawn_case claude-tracked-settings claude "$id")
+  read_case_record "$rec"
+  content='{"permissions":{"allow":["Bash(npm run test:*)","Bash(gh pr view:*)"]}}'
+  seed_project_claude_settings "$PROJ_DIR" "$WT_DIR" tracked "$content"
+  before=$(cat "$WT_DIR/.claude/settings.local.json")
+
+  out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$id" "$PROJ_DIR")
+  expect_code 0 $? "claude spawn should succeed: $out"
+
+  after=$(cat "$WT_DIR/.claude/settings.local.json")
+  [ "$before" = "$after" ] \
+    || fail "spawn rewrote the project's tracked .claude/settings.local.json"
+  status=$(git -C "$WT_DIR" status --porcelain)
+  [ -z "$status" ] || fail "spawn left the worktree dirty: $status"
+
+  state="$HOME_DIR/state"
+  settings="$state/$id.claude-settings.json"
+  assert_present "$settings" "claude spawn must still install its own hook settings"
+  jq -e '.hooks.Stop' "$settings" >/dev/null || fail "the out-of-tree hook settings lack Stop"
+  pass "a claude spawn into a project that tracks .claude/settings.local.json leaves it unmodified"
+}
+
+test_claude_hooks_preserve_an_untracked_project_settings_file() {
+  local rec id=busy-cl-4 out content before after
+  rec=$(make_spawn_case claude-untracked-settings claude "$id")
+  read_case_record "$rec"
+  content='{"permissions":{"allow":["Bash(ls:*)"]}}'
+  seed_project_claude_settings "$PROJ_DIR" "$WT_DIR" untracked "$content"
+  before=$(cat "$WT_DIR/.claude/settings.local.json")
+
+  out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$id" "$PROJ_DIR")
+  expect_code 0 $? "claude spawn should succeed: $out"
+
+  after=$(cat "$WT_DIR/.claude/settings.local.json")
+  [ "$before" = "$after" ] \
+    || fail "spawn rewrote an untracked .claude/settings.local.json that was already there"
+  pass "a claude spawn preserves an existing untracked .claude/settings.local.json"
+}
+
+test_claude_launch_loads_the_out_of_tree_hook_settings() {
+  local rec id=busy-cl-5 out settings log
+  rec=$(make_spawn_case claude-launch-settings claude "$id")
+  read_case_record "$rec"
+  log="$CASE_DIR/tmux.log"
+  : > "$log"
+
+  out=$(FM_TMUX_LOG="$log" run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$id" "$PROJ_DIR")
+  expect_code 0 $? "claude spawn should succeed: $out"
+
+  settings="$HOME_DIR/state/$id.claude-settings.json"
+  assert_present "$settings" "claude spawn did not write its hook settings"
+  assert_grep "--settings '$settings'" "$log" \
+    "the launch command must load the out-of-tree hook settings, or the turn-end wake never arms"
+  assert_absent "$WT_DIR/.claude/settings.local.json" \
+    "claude spawn must write nothing into the worktree"
+  assert_absent "$WT_DIR/.claude" "claude spawn must not create a .claude directory in the worktree"
+
+  rm -f "$HOME_DIR/state/$id.turn-ended"
+  run_claude_hook "$settings" Stop || fail "Stop hook command failed"
+  assert_present "$HOME_DIR/state/$id.turn-ended" \
+    "the Stop hook loaded by --settings must still touch the turn-end marker"
+  pass "the claude launch command loads the out-of-tree settings whose Stop hook wakes firstmate"
+}
+
+test_raw_claude_launch_without_settings_warns_instead_of_going_quiet() {
+  local rec id=busy-cl-6 out settings
+  rec=$(make_spawn_case claude-raw-launch claude "$id")
+  read_case_record "$rec"
+
+  # The unverified-adapter escape hatch: a hand-written command carries no
+  # placeholder, so nothing can insert --settings for it.
+  out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$id" "$PROJ_DIR" \
+    "claude --dangerously-skip-permissions 'do the thing'")
+  expect_code 0 $? "raw claude launch should still spawn: $out"
+
+  settings="$HOME_DIR/state/$id.claude-settings.json"
+  assert_present "$settings" "the hook settings should still be written for a raw claude launch"
+  assert_contains "$out" "carries no --settings argument" \
+    "a raw claude launch that cannot load the hooks must say so, not go quietly unsupervised"
+  assert_contains "$out" "$settings" "the warning must name the settings file to add"
+  pass "a raw claude launch command with no --settings warns loudly instead of losing the turn-end wake"
 }
 
 test_codex_unverified_until_a_semantic_source_exists() {
@@ -349,6 +458,10 @@ test_kimi_and_grok_install_no_unverified_wiring
 test_opencode_plugin_semantic_lifecycle
 test_claude_hooks_semantic_lifecycle
 test_claude_hooks_stale_incarnation_harmless
+test_claude_hooks_leave_a_tracked_project_settings_file_untouched
+test_claude_hooks_preserve_an_untracked_project_settings_file
+test_claude_launch_loads_the_out_of_tree_hook_settings
+test_raw_claude_launch_without_settings_warns_instead_of_going_quiet
 test_codex_unverified_until_a_semantic_source_exists
 
 echo "all fm-busy-adapter-wiring tests passed"

--- a/tests/fm-busy-adapter-wiring.test.sh
+++ b/tests/fm-busy-adapter-wiring.test.sh
@@ -401,7 +401,7 @@ test_claude_launch_loads_the_out_of_tree_hook_settings() {
 }
 
 test_raw_claude_launch_without_settings_warns_instead_of_going_quiet() {
-  local rec id=busy-cl-6 out settings
+  local rec id=busy-cl-6 out state settings
   rec=$(make_spawn_case claude-raw-launch claude "$id")
   read_case_record "$rec"
 
@@ -411,12 +411,36 @@ test_raw_claude_launch_without_settings_warns_instead_of_going_quiet() {
     "claude --dangerously-skip-permissions 'do the thing'")
   expect_code 0 $? "raw claude launch should still spawn: $out"
 
-  settings="$HOME_DIR/state/$id.claude-settings.json"
+  state="$HOME_DIR/state"
+  settings="$state/$id.claude-settings.json"
   assert_present "$settings" "the hook settings should still be written for a raw claude launch"
   assert_contains "$out" "carries no --settings argument" \
     "a raw claude launch that cannot load the hooks must say so, not go quietly unsupervised"
   assert_contains "$out" "$settings" "the warning must name the settings file to add"
-  pass "a raw claude launch command with no --settings warns loudly instead of losing the turn-end wake"
+
+  # Nothing can load those hooks, so nothing could ever close a seeded turn:
+  # the spawn must stay unarmed and classify unknown rather than report a busy
+  # verdict no writer can clear.
+  assert_absent "$state/$id.busy-gen" \
+    "a claude launch that cannot load the hooks must not arm the busy-state contract"
+  out=$(classify claude "$id" "$state")
+  [ "$out" = "unknown missing" ] \
+    || fail "an unarmed raw claude launch must classify unknown, got '$out'"
+
+  # The turn-end touch needs no gen, so it must survive for an operator who
+  # follows the warning and adds --settings by hand.
+  jq -e . "$settings" >/dev/null || fail "the raw-launch hook settings are not valid JSON"
+  if jq -e '.hooks.UserPromptSubmit' "$settings" >/dev/null 2>&1; then
+    fail "an unarmed spawn must not ship busy-state hooks whose gen every writer would refuse"
+  fi
+  rm -f "$state/$id.turn-ended"
+  run_claude_hook "$settings" Stop || fail "Stop hook command failed"
+  [ -f "$state/$id.turn-ended" ] \
+    || fail "the Stop hook must still touch the turn-end marker so a hand-added --settings restores the wake"
+  out=$(classify claude "$id" "$state")
+  [ "$out" = "unknown missing" ] \
+    || fail "the gen-free Stop hook must leave the classification unknown, got '$out'"
+  pass "a raw claude launch command with no --settings warns, stays unarmed, and classifies unknown"
 }
 
 test_codex_unverified_until_a_semantic_source_exists() {

--- a/tests/fm-claude-settings-hook-live-e2e.test.sh
+++ b/tests/fm-claude-settings-hook-live-e2e.test.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# Opt-in credentialed Claude live regression for the per-task crewmate hooks that
+# bin/fm-spawn.sh installs outside the worktree.
+#
+# Firstmate keeps a claude crewmate's turn-end and busy-state hooks in
+# state/<id>.claude-settings.json and loads them with `claude --settings <file>`,
+# because writing <worktree>/.claude/settings.local.json destroyed that file's
+# committed content in every project that tracks it. Two vendor behaviors carry
+# that design, and only the real binary can confirm them:
+#
+#   1. hooks supplied through --settings actually fire in an interactive session,
+#      so the turn-end wake still reaches firstmate; and
+#   2. --settings is ADDITIVE, so the project's own .claude settings still load
+#      and its rules still apply to the crewmate.
+#
+# The lab is an isolated scratch repo and tmux server; Claude keeps using its
+# existing managed authentication. No live fleet home, worktree, or session is
+# touched.
+set -u
+
+if [ "${FM_CLAUDE_LIVE_E2E:-0}" != 1 ]; then
+  echo "skip: set FM_CLAUDE_LIVE_E2E=1 to run the Claude --settings hook regression"
+  exit 0
+fi
+
+fail() {
+  printf 'not ok - %s\n' "$1" >&2
+  exit 1
+}
+
+command -v claude >/dev/null 2>&1 || fail "claude not found"
+command -v tmux >/dev/null 2>&1 || fail "tmux not found"
+
+CLAUDE_VERSION=$(claude --version)
+LAB=$(mktemp -d "${TMPDIR:-/tmp}/fm-claude-settings-live.XXXXXX")
+PROJECT="$LAB/project"
+STATE="$LAB/state"
+SOCK="$LAB/tmux.sock"
+SESSION=fm-claude-settings-live
+
+cleanup() {
+  env -u TMUX -u TMUX_PANE tmux -S "$SOCK" kill-server >/dev/null 2>&1 || true
+  rm -rf "$LAB"
+}
+trap cleanup EXIT
+
+mkdir -p "$PROJECT/.claude" "$STATE"
+git init -q "$PROJECT"
+
+# The project's OWN settings, committed exactly as an affected project has them.
+# Its Stop hook is the additive-load probe: if --settings replaced project
+# settings instead of adding to them, this marker would never appear.
+cat > "$PROJECT/.claude/settings.local.json" <<JSON
+{"permissions":{"allow":["Bash(echo:*)"]},"hooks":{"Stop":[{"hooks":[{"type":"command","command":"touch '$STATE/project-stop'"}]}]}}
+JSON
+git -C "$PROJECT" add -f .claude/settings.local.json
+git -C "$PROJECT" -c user.email=t@t -c user.name=t commit -q -m "track claude settings"
+git -C "$PROJECT" ls-files --error-unmatch .claude/settings.local.json >/dev/null 2>&1 \
+  || fail "fixture project does not track .claude/settings.local.json"
+BEFORE=$(cat "$PROJECT/.claude/settings.local.json")
+
+# Firstmate's per-task hook file, in the shape fm-spawn writes and at the place it
+# writes it: outside the worktree, in the home's state directory.
+cat > "$STATE/task-live.claude-settings.json" <<JSON
+{"hooks":{"UserPromptSubmit":[{"hooks":[{"type":"command","command":"touch '$STATE/task-live.prompt-submitted'"}]}],"Stop":[{"hooks":[{"type":"command","command":"touch '$STATE/task-live.turn-ended'"}]}]}}
+JSON
+
+tmux() { env -u TMUX -u TMUX_PANE command tmux -S "$SOCK" "$@"; }
+
+tmux new-session -d -s "$SESSION" -c "$PROJECT" -x 200 -y 50 \
+  || fail "could not start the isolated tmux server"
+# The launch shape fm-spawn.sh builds for a claude crewmate.
+tmux send-keys -t "$SESSION" \
+  "CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions --settings '$STATE/task-live.claude-settings.json' 'reply with the single word ok'" Enter
+
+# Accept the folder-trust dialog if this scratch repo triggers one, then wait for
+# the turn to complete. Both markers must appear within the budget.
+deadline=$(( $(date +%s) + 300 ))
+trusted=0
+while [ "$(date +%s)" -lt "$deadline" ]; do
+  if [ -f "$STATE/task-live.turn-ended" ] && [ -f "$STATE/project-stop" ]; then
+    break
+  fi
+  if [ "$trusted" -eq 0 ] && tmux capture-pane -pt "$SESSION" 2>/dev/null | grep -q 'trust this folder'; then
+    tmux send-keys -t "$SESSION" Enter
+    trusted=1
+  fi
+  sleep 2
+done
+
+[ -f "$STATE/task-live.prompt-submitted" ] \
+  || fail "Claude $CLAUDE_VERSION: --settings UserPromptSubmit hook never fired"
+[ -f "$STATE/task-live.turn-ended" ] \
+  || fail "Claude $CLAUDE_VERSION: --settings Stop hook never touched the turn-end marker; the crewmate turn-end wake is dead"
+[ -f "$STATE/project-stop" ] \
+  || fail "Claude $CLAUDE_VERSION: --settings is no longer additive; the project's own settings did not load"
+
+AFTER=$(cat "$PROJECT/.claude/settings.local.json")
+[ "$BEFORE" = "$AFTER" ] \
+  || fail "Claude $CLAUDE_VERSION: the project's tracked .claude/settings.local.json was modified"
+STATUS=$(git -C "$PROJECT" status --porcelain)
+[ -z "$STATUS" ] || fail "Claude $CLAUDE_VERSION: the checkout was left dirty: $STATUS"
+
+printf 'ok - Claude %s: --settings hooks fired the turn-end wake, loaded additively beside the project'"'"'s own tracked settings, and left that tracked file unmodified\n' "$CLAUDE_VERSION"

--- a/tests/fm-secondmate-harness.test.sh
+++ b/tests/fm-secondmate-harness.test.sh
@@ -514,6 +514,29 @@ test_spawn_bare_backward_compat() {
   pass "B4 spawn: no config at all -> own harness and no propagation side effects"
 }
 
+# A claude crewmate's per-task hooks ride --settings on the launch command, but a
+# secondmate gets no per-task hooks at all (its own home's tracked .claude/settings.json
+# owns them), so its launch must NOT carry a --settings flag pointing at a file that
+# was never written.
+test_spawn_claude_secondmate_launches_without_per_task_settings() {
+  local w sm launchlog out status
+  w="$TMP_ROOT/spawn-claude-secondmate-settings"
+  sm="$w/sm"
+  launchlog="$w/launch.log"
+  make_seeded_home "$sm" sm
+
+  out=$(spawn_secondmate_capture "$w" sm "$sm" "$launchlog" claude 2>&1); status=$?
+  expect_code 0 "$status" "claude secondmate spawn should succeed"$'\n'"$out"
+
+  assert_grep 'claude --dangerously-skip-permissions' "$launchlog" \
+    "the claude secondmate launch command was not captured"
+  assert_no_grep '--settings' "$launchlog" \
+    "a secondmate launch must not reference a per-task settings file"
+  [ -e "$w/home/state/sm.claude-settings.json" ] \
+    && fail "a secondmate spawn must not write per-task claude hook settings"
+  pass "B5c spawn: a claude secondmate launches with no per-task --settings file"
+}
+
 # An explicit per-spawn harness arg wins over config/secondmate-harness.
 test_spawn_explicit_harness_wins() {
   local w sm meta
@@ -2346,6 +2369,7 @@ test_spawn_split_and_inherit
 test_spawn_backward_compat_crew_fallback
 test_spawn_bare_backward_compat
 test_spawn_explicit_harness_wins
+test_spawn_claude_secondmate_launches_without_per_task_settings
 test_spawn_unverified_secondmate_harness_refused
 test_spawn_backend_precedence_over_inherited_config
 test_spawn_explicit_backend_precedence_over_env_and_inherited_config

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -129,7 +129,7 @@ test_no_profile_keeps_claude_profile_defaults() {
   assert_meta_profile "$HOME_DIR/state/$id.meta" claude default default
 
   launch=$(cat "$LAUNCH_LOG")
-  expected="CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions \"\$('${ROOT}/bin/fm-operational-input.sh' encode launch-brief < '$HOME_DIR/data/$id/brief.md')\""
+  expected="CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions --settings '$HOME_DIR/state/$id.claude-settings.json' \"\$('${ROOT}/bin/fm-operational-input.sh' encode launch-brief < '$HOME_DIR/data/$id/brief.md')\""
   [ "$launch" = "$expected" ] || fail "no-profile claude launch did not use the canonical launch kind"$'\n'"expected: $expected"$'\n'"actual:   $launch"
   pass "no --model/--effort records defaults and types the claude launch instructions"
 }
@@ -377,7 +377,7 @@ test_claude_threads_model_and_effort() {
   expect_code 0 "$status" "claude spawn with profile flags should succeed"
   assert_meta_profile "$HOME_DIR/state/$id.meta" claude sonnet high
   launch=$(cat "$LAUNCH_LOG")
-  assert_contains "$launch" "claude --dangerously-skip-permissions --model 'sonnet' --effort 'high'" \
+  assert_contains "$launch" "--settings '$HOME_DIR/state/$id.claude-settings.json' --model 'sonnet' --effort 'high'" \
     "claude launch did not thread model and effort flags"
   pass "claude receives --model and --effort profile flags"
 }

--- a/tests/fm-teardown.test.sh
+++ b/tests/fm-teardown.test.sh
@@ -515,6 +515,82 @@ test_local_only_fork_remote_allows() {
   pass "local-only worktree with HEAD on a fork remote is torn down (fix holds)"
 }
 
+# Firstmate's own per-task claude hooks now live in state/<id>.claude-settings.json,
+# so cleanup must retire that artifact and must never delete a project's committed
+# .claude/settings.local.json - the file whose wholesale rewrite caused the incident.
+test_teardown_retires_claude_hooks_and_keeps_tracked_project_settings() {
+  local case_dir rc project_settings before after
+  case_dir=$(make_case claude-settings-cleanup)
+  write_meta "$case_dir" local-only ship
+  project_settings='{"permissions":{"allow":["Bash(npm run test:*)"]}}'
+  mkdir -p "$case_dir/wt/.claude"
+  printf '%s\n' "$project_settings" > "$case_dir/wt/.claude/settings.local.json"
+  # -f so a host ignore rule for .claude/ cannot decide whether the fixture is tracked.
+  git -C "$case_dir/wt" add -f -- .claude/settings.local.json
+  git -C "$case_dir/wt" -c user.email=t@t -c user.name=t commit -q -m "track claude settings"
+  add_fork_with_pushed_branch "$case_dir"
+  before=$(cat "$case_dir/wt/.claude/settings.local.json")
+  printf '%s\n' '{"hooks":{}}' > "$case_dir/state/task-x1.claude-settings.json"
+
+  set +e
+  run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 0 "$rc" "claude-settings-cleanup: teardown should succeed on a clean worktree"
+  ! grep -q REFUSED "$case_dir/stderr" \
+    || fail "claude-settings-cleanup: teardown refused on a clean worktree"
+  assert_absent "$case_dir/state/task-x1.claude-settings.json" \
+    "cleanup left firstmate's own claude hook settings behind"
+  after=$(cat "$case_dir/wt/.claude/settings.local.json" 2>/dev/null || printf 'MISSING')
+  [ "$before" = "$after" ] \
+    || fail "cleanup changed or removed the project's tracked .claude/settings.local.json"
+  pass "cleanup retires firstmate's claude hook settings and leaves a tracked project file intact"
+}
+
+# A task launched before the hooks moved out of the worktree can still carry the old
+# firstmate-written file. Cleanup removes that one, and only that one.
+test_teardown_removes_a_legacy_firstmate_hook_file_but_not_a_foreign_one() {
+  local case_dir rc foreign before after
+  case_dir=$(make_case claude-settings-legacy)
+  write_meta "$case_dir" local-only ship
+  wt_commit "$case_dir" "work"
+  add_fork_with_pushed_branch "$case_dir"
+  mkdir -p "$case_dir/wt/.claude"
+  printf '%s\n' \
+    '{"hooks":{"Stop":[{"hooks":[{"type":"command","command":"touch '"'"'/s/task-x1.turn-ended'"'"'"}]}]}}' \
+    > "$case_dir/wt/.claude/settings.local.json"
+
+  set +e
+  run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 0 "$rc" "claude-settings-legacy: teardown should succeed"
+  assert_absent "$case_dir/wt/.claude/settings.local.json" \
+    "cleanup left a legacy firstmate hook file in the worktree"
+
+  case_dir=$(make_case claude-settings-foreign)
+  write_meta "$case_dir" local-only ship
+  wt_commit "$case_dir" "work"
+  add_fork_with_pushed_branch "$case_dir"
+  mkdir -p "$case_dir/wt/.claude"
+  foreign='{"permissions":{"allow":["Bash(ls:*)"]}}'
+  printf '%s\n' "$foreign" > "$case_dir/wt/.claude/settings.local.json"
+  before=$(cat "$case_dir/wt/.claude/settings.local.json")
+
+  set +e
+  run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 0 "$rc" "claude-settings-foreign: teardown should succeed"
+  after=$(cat "$case_dir/wt/.claude/settings.local.json" 2>/dev/null || printf 'MISSING')
+  [ "$before" = "$after" ] \
+    || fail "cleanup removed an untracked .claude/settings.local.json that firstmate never wrote"
+  pass "cleanup removes only a legacy firstmate hook file, never someone else's settings"
+}
+
 test_teardown_prompts_tasks_axi_done_when_compatible() {
   local case_dir out
   case_dir=$(make_case tasks-axi-reminder)
@@ -1825,6 +1901,8 @@ test_herdr_projection_teardown_retains_journal_when_close_unconfirmed() {
 }
 
 test_local_only_fork_remote_allows
+test_teardown_retires_claude_hooks_and_keeps_tracked_project_settings
+test_teardown_removes_a_legacy_firstmate_hook_file_but_not_a_foreign_one
 test_teardown_prompts_tasks_axi_done_when_compatible
 test_teardown_manual_backend_prompts_hand_edit_even_when_tasks_axi_present
 test_local_only_truly_unpushed_refuses


### PR DESCRIPTION
## Intent

Fix a defect in bin/fm-spawn.sh: launching a claude crewmate destroyed a project's tracked .claude/settings.local.json.

The defect. For a claude crewmate, fm-spawn installed the per-task turn-end and busy-state hooks by writing <worktree>/.claude/settings.local.json wholesale. Many projects TRACK that path, and in one affected repository 300 committed lines of permission rules were replaced by a single hook line. Three consequences followed: the committed content was destroyed in the worktree, every claude crewmate in such a project started work on a modified tracked file, and fm-teardown could then refuse to clean up because the worktree was dirty. It also breaks firstmate's own first rule, that firstmate reads projects and only crewmates change them.

The fix, and why this shape. Two approaches were on the table: merge into the existing JSON and unpick only the added hook at teardown, or move the hook out of the worktree entirely the way the other adapters already do. This change takes the second. The hooks now live in state/<id>.claude-settings.json and reach the session through 'claude --settings <file>' on the launch command. That mirrors what pi already does with '-e state/<id>.pi-ext.ts', and follows the same outside-the-worktree principle as grok and kimi, which keep a global hook plus a small firstmate-named worktree pointer. Claude was the odd one out. Merging would have meant owning a JSON parser, an unparseable-file failure path, and a partial unpick at teardown; writing nothing into the project removes all three. That is why the diff contains no JSON-merge code and no 'existing file is unparseable' branch: the requirement to fail rather than guess on an unparseable file is satisfied by never reading or writing the project's file at all.

Verified live against the installed Claude Code 2.1.220, in a real interactive tmux pane rather than print mode: hooks supplied through --settings do fire, and --settings is additive, so the project's own .claude settings still load alongside them. The second property means this also restores something the old wholesale write had been silently removing, since the project's own permission rules now reach the crewmate instead of being overwritten.

Decisions a reviewer reading only the diff would not know:
- A secondmate's launch template intentionally omits --settings. Secondmates get no per-task hooks, because their own home's tracked .claude/settings.json owns them, so passing the flag would point claude at a file that was never written. Hence the kind branch in launch_template, mirroring the existing codex and pi kind branches.
- The raw launch command, the unverified-adapter escape hatch, carries no placeholder, so nothing can substitute --settings into it. Previously the worktree file loaded implicitly for any claude invocation in that directory, so this path would have silently lost its turn-end wake. Trading the clobber for a silently missing hook is not acceptable, so fm-spawn warns and names the exact argument to add. A warning rather than a hard refusal is deliberate: that hatch exists precisely for launching a runtime firstmate does not understand yet, which is when an operator most needs it.
- A follow-up commit on this branch already addresses a review finding on that same escape hatch: the busy-state contract is no longer armed when the launch cannot load the hooks, so such a worker classifies unknown rather than being seeded busy with nothing able to clear it, the same way codex and standalone kimi already decline to arm. That decision was made deliberately and should not be re-litigated.
- fm-teardown no longer removes <worktree>/.claude/settings.local.json unconditionally, because that rm was itself deleting tracked project content. It is replaced by remove_legacy_claude_worktree_settings, gated twice: the path must be untracked in that worktree AND its content must name that task's own hook wiring, either '<id>.turn-ended' or 'fm-busy-event.sh', covering both legacy shapes. This exists only for tasks launched before this change that still carry the old file, and it is deliberately conservative so a project's own file, tracked or not, is never touched.
- The existing teardown dirty-check tolerance for untracked '.claude/' was left alone on purpose. Claude itself can create that directory, and narrowing it would be unrelated scope that could cause teardown refusals. One consequence is recorded rather than fixed: a worktree already damaged by the original bug still needs a manual 'git checkout -- .claude/settings.local.json'. Restoring it automatically would put firstmate back to writing into a project, which is the behaviour this change removes.
- Because the hooks now ride the launch command rather than the worktree, any manual resume or relaunch of a claude crewmate must carry the same --settings argument. That fact is recorded in the harness-adapters skill, which the stuck-crewmate-recovery procedure already loads before any resume or relaunch, so it arrives when it is needed rather than depending on memory.

Verification already performed: the original clobber was reproduced end to end with the real fm-spawn before any fix; the fix was then demonstrated against a real affected repository, a read-only clone carrying its real 300 committed lines, leaving that file byte-identical and the worktree clean, rather than only against a synthetic fixture; the new tests were confirmed to fail against the pre-fix scripts so they are not vacuous; bin/fm-lint.sh passes on pinned ShellCheck 0.11.0 with every touched bin/*.sh clean; bin/fm-doc-audience-check.sh passes. Two test failures in the development environment, tests/fm-gotmp.test.sh and one Orca metadata-write case in tests/fm-backend-orca.test.sh, reproduce on unmodified HEAD and are unrelated to this change.

Tests are colocated in tests/ and extend existing scripts rather than adding a new runner: fm-busy-adapter-wiring covers the tracked file staying untouched, an untracked file being preserved, the launch command carrying --settings, the Stop hook still touching the turn-end marker, and the raw-launch path warning while staying unarmed and classifying unknown; fm-teardown covers the state artifact being retired, a tracked project file being kept, and a legacy firstmate file being removed while a foreign one is preserved; fm-secondmate-harness covers a secondmate launch carrying no --settings; fm-spawn-dispatch-profile has its exact launch-string expectations updated. One new file is added deliberately: tests/fm-claude-settings-hook-live-e2e.test.sh, an opt-in credentialed live guard registered in the existing live-harness-optin family and gated on the existing FM_CLAUDE_LIVE_E2E variable, so no new knob. A vendor-behaviour dependency like --settings needs a live guard that fails loudly naming the harness and version; it is the command that refreshes the dated evidence in docs/verification/supervision.md after a Claude Code upgrade.

Compatibility was reviewed across every supported harness and runtime backend rather than only the ones currently in use. codex carries its turn-end on the launch command through -c notify=, pi and pi-signed already keep their extension in state/, and grok and kimi use firstmate-named worktree pointers, .fm-grok-turnend and .fm-kimi-turnend, so none of them writes to a standard project path. opencode writes a firstmate-named plugin file, .opencode/plugins/fm-busy-state.js, which no project would track, so it is not the same class of defect. tmux, herdr, zellij, orca, and cmux are unaffected after inspection: this is a launch-string argument and a file location, both backend-agnostic, and orca's own teardown branch uses the same guarded removal.

Repo conventions followed: one sentence per line in tracked Markdown, plain dash rather than an em dash, no agent name as a commit co-author, and documented behaviour changes went into the owning script header and the harness-adapters skill rather than into AGENTS.md.

## What Changed

- `bin/fm-spawn.sh` no longer writes a claude crewmate's turn-end and busy-state hooks into `<worktree>/.claude/settings.local.json`, which overwrote that file's committed content in projects that track it. The hooks now go to `state/<id>.claude-settings.json` and reach the session through `claude --settings <file>` on the templated launch, mirroring how pi already passes `-e state/<id>.pi-ext.ts`. Because `--settings` is additive, the project's own `.claude` settings still load alongside the per-task hooks. A claude secondmate launch omits the flag, since no per-task hook file is written for it.
- A raw claude launch command (the unverified-adapter escape hatch) carries no placeholder to substitute `--settings` into, so `fm-spawn` now warns and names the exact argument to add, declines to arm the busy-state contract for that spawn (it classifies unknown rather than being seeded busy with nothing able to clear it), and writes a hook file holding only the turn-end touch.
- `bin/fm-teardown.sh` replaces its unconditional `rm` of `<worktree>/.claude/settings.local.json` with `remove_legacy_claude_worktree_settings`, which only removes the path when it is untracked in that worktree and its content names firstmate's own hook wiring; it also retires the new `state/<id>.claude-settings.json` artifact. Coverage was added in `tests/fm-busy-adapter-wiring`, `fm-teardown`, `fm-secondmate-harness`, and `fm-spawn-dispatch-profile`, plus a new opt-in live guard `tests/fm-claude-settings-hook-live-e2e.test.sh` gated on the existing `FM_CLAUDE_LIVE_E2E` variable, and the `--settings` requirement for manual resume or relaunch is recorded in the harness-adapters skill.

## Risk Assessment

✅ Low: The change removes the clobbering write entirely rather than patching a symptom, every intent-required behavior is verifiable in source (out-of-worktree hook file, additive --settings on the launch, secondmate omission, warned-and-unarmed raw launch, doubly-gated legacy removal, artifact retirement at both cleanup sites), downstream busy-state consumers already tolerate the unarmed case, and the only finding is informational.

## Testing

`Ran the four targeted test files touched by this change (fm-busy-adapter-wiring, fm-spawn-dispatch-profile, fm-secondmate-harness, fm-teardown) and every new and changed case passes, including tracked-file-untouched, launch-carries---settings, raw-launch-warns-and-stays-unarmed, legacy-teardown-removal, and secondmate-no---settings. Beyond the unit level I built a before/after end-to-end transcript running the real fm-spawn.sh from the base commit and from this branch against an identical project tracking a 302-line .claude/settings.local.json: the base commit destroys it (302 lines to 1, worktree dirty, real fm-teardown then REFUSES on uncommitted changes) while this branch leaves it byte-identical with a clean worktree, writes the hooks to state/<id>.claude-settings.json, types --settings into the launch command, fires the turn-end marker from that file's Stop hook, and tears down cleanly. I also ran the opt-in live guard and captured the real Claude 2.1.221 crewmate pane, where firstmate's --settings hooks and the project's own tracked Stop hook both fired and the tracked file was unmodified, and captured the operator-visible raw-launch warning naming the exact --settings argument to add. The only failure seen was herdr-preflight-missing-adapter in fm-teardown.test.sh, which reproduces identically on unmodified base commit 733a504 and is unrelated to this change; the working tree was left clean with all evidence in the dedicated evidence directory.`

<details>
<summary>Evidence: Before/after end-to-end: claude crewmate spawn + teardown against a project tracking a 302-line .claude/settings.local.json</summary>

<code>=== BEFORE the fix (base commit 733a504) ===&#10;project file : .claude/settings.local.json (TRACKED, 302 lines)&#10;lines after spawn : 1&#10;sha256 before : 694c9775f7caeec777b839847e9d4d48f0343686c89cb0c3a3bb8bd442323e9b&#10;sha256 after : 4ae9aeb4c77834e1fcd3e256cd8d9b2d125c619f90b35e5dbfc627dc715a5737&#10;verdict : DESTROYED - committed content was overwritten&#10;git status of the crewmate worktree:&#10;M .claude/settings.local.json&#10;launch command typed into the crewmate pane:&#10;CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions &#34;$(...encode launch-brief &lt; .../brief.md)&#34;&#10;--- real fm-teardown of the same task ---&#10;teardown exit status: 1&#10;REFUSED: worktree .../before-fix/wt has uncommitted changes.&#10;uncommitted changes present&#10;&#10;=== AFTER the fix (branch fm/fm-spawn-clobbers-settings) ===&#10;project file : .claude/settings.local.json (TRACKED, 302 lines)&#10;lines after spawn : 302&#10;sha256 before : 694c9775f7caeec777b839847e9d4d48f0343686c89cb0c3a3bb8bd442323e9b&#10;sha256 after : 694c9775f7caeec777b839847e9d4d48f0343686c89cb0c3a3bb8bd442323e9b&#10;verdict : UNCHANGED - the committed content survived&#10;git status of the crewmate worktree:&#10;(clean)&#10;per-task hook file outside the worktree (state/):&#10;.../home/state/demo-task.claude-settings.json&#10;hooks: [&#34;SessionEnd&#34;,&#34;Stop&#34;,&#34;StopFailure&#34;,&#34;UserPromptSubmit&#34;]&#10;launch command typed into the crewmate pane:&#10;CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions --settings &#39;.../home/state/demo-task.claude-settings.json&#39; &#34;$(...encode launch-brief &lt; .../brief.md)&#34;&#10;Stop hook from that file executed -&gt; turn-end marker present: yes&#10;--- real fm-teardown of the same task ---&#10;teardown exit status: 0&#10;teardown demo-task complete (window firstmate:fm-demo-task, worktree .../after-fix/wt)&#10;per-task hook file left in state/ after teardown: no (retired)&#10;project&#39;s tracked file after teardown: 694c9775f7caeec777b839847e9d4d48f0343686c89cb0c3a3bb8bd442323e9b</code>

```text
Claude crewmate spawn into a project that TRACKS .claude/settings.local.json

=== BEFORE the fix (base commit 733a504) ===
fm-spawn under test : /tmp/fm-base-30223/bin/fm-spawn.sh
project file        : .claude/settings.local.json (TRACKED, 302 lines)
spawn exit status   : 0

--- what happened to the project's tracked file ---
lines after spawn   : 1
sha256 before       : 694c9775f7caeec777b839847e9d4d48f0343686c89cb0c3a3bb8bd442323e9b  -
sha256 after        : 4ae9aeb4c77834e1fcd3e256cd8d9b2d125c619f90b35e5dbfc627dc715a5737  -
verdict             : DESTROYED - committed content was overwritten
file now contains   :
{"hooks":{"UserPromptSubmit":[{"hooks":[{"type":"command","command":"'/tmp/fm-base-30223/bin/fm-busy-event.sh' apply '/private/var/folders/qj/nm_q_vss1vzdjqzljg

git status of the crewmate worktree:
   M .claude/settings.local.json
  -> the crewmate starts work on a modified tracked file, and a ship
     teardown can refuse to clean the worktree up.

per-task hook file outside the worktree (state/):
  (none written)

launch command typed into the crewmate pane:
  CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions "$('/tmp/fm-base-30223/bin/fm-operational-input.sh' encode launch-bri
  ef < '/var/folders/qj/nm_q_vss1vzdjqzljg79ks3h0000gn/T//fm-clobber-demo.KBRSsj/before-fix/home/data/demo-task/brief.md')"

--- real fm-teardown of the same task ---
teardown exit status: 1
  REFUSED: worktree /var/folders/qj/nm_q_vss1vzdjqzljg79ks3h0000gn/T//fm-clobber-demo.KBRSsj/before-fix/wt has uncommitted changes.
  uncommitted changes present
per-task hook file left in state/ after teardown: no (retired)
project's tracked file after teardown: 4ae9aeb4c77834e1fcd3e256cd8d9b2d125c619f90b35e5dbfc627dc715a5737  -

=== AFTER the fix  (branch fm/fm-spawn-clobbers-settings) ===
fm-spawn under test : /Users/lochlann/.no-mistakes/worktrees/96926a3e34ba/01KZ528YWSENMHB938Z9GX07AA/bin/fm-spawn.sh
project file        : .claude/settings.local.json (TRACKED, 302 lines)
spawn exit status   : 0

--- what happened to the project's tracked file ---
lines after spawn   : 302
sha256 before       : 694c9775f7caeec777b839847e9d4d48f0343686c89cb0c3a3bb8bd442323e9b  -
sha256 after        : 694c9775f7caeec777b839847e9d4d48f0343686c89cb0c3a3bb8bd442323e9b  -
verdict             : UNCHANGED - the committed content survived

git status of the crewmate worktree:
  (clean)

per-task hook file outside the worktree (state/):
  /var/folders/qj/nm_q_vss1vzdjqzljg79ks3h0000gn/T//fm-clobber-demo.KBRSsj/after-fix/home/state/demo-task.claude-settings.json
  hooks: ["SessionEnd","Stop","StopFailure","UserPromptSubmit"]

launch command typed into the crewmate pane:
  CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions --settings '/var/folders/qj/nm_q_vss1vzdjqzljg79ks3h0000gn/T//fm-clob
  ber-demo.KBRSsj/after-fix/home/state/demo-task.claude-settings.json' "$('/Users/lochlann/.no-mistakes/worktrees/96926a3e34ba/01KZ528YWSENMHB938Z9GX07A
  A/bin/fm-operational-input.sh' encode launch-brief < '/var/folders/qj/nm_q_vss1vzdjqzljg79ks3h0000gn/T//fm-clobber-demo.KBRSsj/after-fix/home/data/dem
  o-task/brief.md')"

Stop hook from that file executed -> turn-end marker present: yes

--- real fm-teardown of the same task ---
teardown exit status: 0
  teardown demo-task complete (window firstmate:fm-demo-task, worktree /var/folders/qj/nm_q_vss1vzdjqzljg79ks3h0000gn/T//fm-clobber-demo.KBRSs
per-task hook file left in state/ after teardown: no (retired)
project's tracked file after teardown: 694c9775f7caeec777b839847e9d4d48f0343686c89cb0c3a3bb8bd442323e9b  -
```
</details>
<details>
<summary>Evidence: Live Claude 2.1.221 crewmate pane launched with --settings (real tmux capture-pane)</summary>

<code>--- Claude Code v2.1.221 ---&#10;Welcome back Lochlann!&#10;Opus 5 with high effort - Claude Max&#10;/.../T/fm-claude-pane.GfXJvb/project&#10;&#10;&gt; reply with the single word ok&#10;&#10;* ok&#10;&#10;bypass permissions on (shift+tab to cycle)&#10;&#10;Hook markers left behind:&#10;firstmate UserPromptSubmit (from --settings) : FIRED&#10;firstmate Stop / turn-end wake (--settings) : FIRED&#10;the project&#39;s OWN Stop hook (tracked file) : FIRED &lt;- --settings is additive&#10;&#10;The project&#39;s tracked .claude/settings.local.json:&#10;sha256 before session : 9a02708915072a07baa9ebe2b94f0ea399093b1d5f405da490d806333d1cd8d6&#10;sha256 after session : 9a02708915072a07baa9ebe2b94f0ea399093b1d5f405da490d806333d1cd8d6&#10;git status : (clean)</code>

```text
Live claude crewmate pane, launched the way bin/fm-spawn.sh now launches one
(2.1.221 (Claude Code))

$ tmux capture-pane -p   # the real pane
--------------------------------------------------------------------------------

╭─── Claude Code v2.1.221 ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│                                                    │ Tips for getting started                                                                      │
│               Welcome back Lochlann!               │ Run /init to create a CLAUDE.md file with instructions for Claude                             │
│                                                    │ ───────────────────────────────────────────────────────────────────────────────────────────── │
│                       ▐▛███▜▌                      │ What's new                                                                                    │
│                      ▝▜█████▛▘                     │ [VSCode] Added Focus view: a chat-menu toggle that hides tool activity behind an expandable … │
│                        ▘▘ ▝▝                       │ Added `mode: "mask"` for sandbox credential files on Linux and WSL — sandboxed commands read… │
│      Opus 5 with high effort · Claude Max ·        │ Added warnings to `claude plugin validate` when a marketplace or plugin name would be reject… │
│      lochlann@massbaymovers.com's Organization     │ /release-notes for more                                                                       │
│         /…/T/fm-claude-pane.GfXJvb/project         │                                                                                               │
╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯

❯ reply with the single word ok

⏺ ok

✻ Sautéed for 1s

                                                                                                                                     ● high · /effort
──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
❯ 
──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
  Opus 5  [░░░░░░░░░░] 3%                                                                                                                         /rc
  ⏵⏵ bypass permissions on (shift+tab to cycle) · ← for agents
--------------------------------------------------------------------------------

Hook markers left behind:
  firstmate UserPromptSubmit (from --settings) : FIRED
  firstmate Stop / turn-end wake (--settings)  : FIRED
  the project's OWN Stop hook (tracked file)   : FIRED   <- --settings is additive

The project's tracked .claude/settings.local.json:
  sha256 before session : 9a02708915072a07baa9ebe2b94f0ea399093b1d5f405da490d806333d1cd8d6  -
  sha256 after session  : 9a02708915072a07baa9ebe2b94f0ea399093b1d5f405da490d806333d1cd8d6  -
  git status            : (clean)
```
</details>
<details>
<summary>Evidence: Opt-in live guard against the installed Claude Code</summary>

<code>$ claude --version&#10;2.1.221 (Claude Code)&#10;$ FM_CLAUDE_LIVE_E2E=1 bash tests/fm-claude-settings-hook-live-e2e.test.sh&#10;ok - Claude 2.1.221 (Claude Code): --settings hooks fired the turn-end wake, loaded additively beside the project&#39;s own tracked settings, and left that tracked file unmodified&#10;exit=0</code>

```text
2.1.221 (Claude Code)
ok - Claude 2.1.221 (Claude Code): --settings hooks fired the turn-end wake, loaded additively beside the project's own tracked settings, and left that tracked file unmodified
exit=0
```
</details>
<details>
<summary>Evidence: Operator-visible warning for the raw claude launch escape hatch</summary>

<code>$ fm-spawn.sh raw-task &lt;project&gt; --launch &#34;claude --dangerously-skip-permissions &#39;do the thing&#39;&#34;&#10;&#10;warning: this raw claude launch command carries no --settings argument, so raw-task will run with no turn-end wake and its busy state stays unknown; add --settings &#39;.../home/state/raw-task.claude-settings.json&#39; to the command to restore the turn-end wake&#10;spawned raw-task harness=claude kind=ship mode=no-mistakes yolo=off window=firstmate:fm-raw-task worktree=.../wt&#10;&#10;busy-state contract armed for this spawn : no (stays unarmed, so it classifies unknown - never a stranded busy)&#10;hook file still written, ready for a hand-added --settings:&#10;{&#34;hooks&#34;:{&#34;Stop&#34;:[{&#34;hooks&#34;:[{&#34;type&#34;:&#34;command&#34;,&#34;command&#34;:&#34;touch &#39;.../home/state/raw-task.turn-ended&#39;&#34;}]}]}}</code>

```text
$ fm-spawn.sh raw-task <project> --launch "claude --dangerously-skip-permissions 'do the thing'"

warning: /var/folders/qj/nm_q_vss1vzdjqzljg79ks3h0000gn/T//fm-raw-launch.lFbcmc/home/data/raw-task/brief.md records no delivery contract line (scaffol
ded before ship briefs recorded one); launching on the explicit --mode no-mistakes - confirm its definition of done matches
warning: this raw claude launch command carries no --settings argument, so raw-task will run with no turn-end wake and its busy state stays unknown; a
dd --settings '/var/folders/qj/nm_q_vss1vzdjqzljg79ks3h0000gn/T//fm-raw-launch.lFbcmc/home/state/raw-task.claude-settings.json' to the command to rest
ore the turn-end wake
spawned raw-task harness=claude kind=ship mode=no-mistakes yolo=off window=firstmate:fm-raw-task worktree=/var/folders/qj/nm_q_vss1vzdjqzljg79ks3h0000
gn/T//fm-raw-launch.lFbcmc/wt

busy-state contract armed for this spawn : no (stays unarmed, so it classifies unknown - never a stranded busy)
hook file still written, ready for a hand-added --settings:
  /var/folders/qj/nm_q_vss1vzdjqzljg79ks3h0000gn/T//fm-raw-launch.lFbcmc/home/state/raw-task.claude-settings.json
  {"hooks":{"Stop":[{"hooks":[{"type":"command","command":"touch '/private/var/folders/qj/nm_q_vss1vzdjqzljg79ks3h0000gn/T/fm-raw-launch.lFbcmc/home/sta
  te/raw-task.turn-ended'"}]}]}}
```
</details>
<details>
<summary>Evidence: Evidence-producing script: before/after spawn + teardown demo</summary>

```text
#!/usr/bin/env bash
# End-to-end demonstration of the fm-spawn claude-crewmate settings clobber and its fix.
#
# Runs the REAL bin/fm-spawn.sh twice - once from the pre-fix base commit, once from
# the fixed branch - against an identical project that TRACKS
# .claude/settings.local.json with 300 committed lines of permission rules.
# Only tmux (the pane) and the harness binaries are faked; everything else is real.
set -u

FIXED_ROOT=${FIXED_ROOT:?}
BASE_ROOT=${BASE_ROOT:?}
LAB=$(mktemp -d "${TMPDIR:-/tmp}/fm-clobber-demo.XXXXXX")
[ "${KEEP_LAB:-0}" = 1 ] || trap 'rm -rf "$LAB"' EXIT
[ "${KEEP_LAB:-0}" != 1 ] || printf 'lab: %s\n' "$LAB" >&2

# 300-line tracked settings file, the shape the affected repository has.
write_project_settings() {
  local f=$1 i
  {
    printf '{\n  "permissions": {\n    "allow": [\n'
    for i in $(seq 1 295); do
      printf '      "Bash(project-command-%03d:*)",\n' "$i"
    done
    printf '      "Bash(npm run test:*)"\n'
    printf '    ]\n  }\n}\n'
  } > "$f"
}

make_case() {  # <name> -> echoes case dir
  local name=$1 case_dir="$LAB/$name" proj="$LAB/$name/project" wt="$LAB/$name/wt"
  local home="$LAB/$name/home" fakebin="$LAB/$name/fakebin" id=demo-task
  mkdir -p "$home/data/$id" "$home/projects" "$home/state" "$home/config" "$fakebin"
  printf 'claude\n' > "$home/config/crew-harness"
  printf 'demo brief\n' > "$home/data/$id/brief.md"
  touch "$home/state/.last-watcher-beat"

  mkdir -p "$proj"
  git init -q "$proj"
  git -C "$proj" -c user.email=t@t -c user.name=t commit -q --allow-empty -m init
  mkdir -p "$proj/.claude"
  write_project_settings "$proj/.claude/settings.local.json"
  git -C "$proj" add -f .claude/settings.local.json
  git -C "$proj" -c user.email=t@t -c user.name=t commit -q -m "track claude settings"
  git -C "$proj" worktree add --quiet -b "wt-$name" "$wt"

  cat > "$fakebin/tmux" <<'SH'
#!/usr/bin/env bash
set -u
case "$*" in
  *"#{pane_current_path}"*) printf '%s\n' "${FM_FAKE_PANE_PATH:-}"; exit 0 ;;
esac
case "${1:-}" in
  display-message) printf 'firstmate\n'; exit 0 ;;
  list-windows) exit 0 ;;
  send-keys) [ -z "${FM_TMUX_LOG:-}" ] || printf '%s\n' "$*" >> "$FM_TMUX_LOG"; exit 0 ;;
esac
exit 0
SH
  chmod +x "$fakebin/tmux"
  for t in treehouse claude codex pi opencode; do
    printf '#!/usr/bin/env bash\nexit 0\n' > "$fakebin/$t"
    chmod +x "$fakebin/$t"
  done
  printf '%s\n' "$case_dir"
}

run_case() {  # <label> <fm-root> <case-name>
  local label=$1 root=$2 name=$3 case_dir proj wt home log before after id=demo-task
  case_dir=$(make_case "$name")
  proj="$case_dir/project"; wt="$case_dir/wt"; home="$case_dir/home"
  log="$case_dir/tmux-send-keys.log"; : > "$log"
  before=$(shasum -a 256 < "$wt/.claude/settings.local.json")

  printf '\n=== %s ===\n' "$label"
  printf 'fm-spawn under test : %s\n' "$root/bin/fm-spawn.sh"
  printf 'project file        : .claude/settings.local.json (TRACKED, %s lines)\n' \
    "$(wc -l < "$wt/.claude/settings.local.json" | tr -d ' ')"

  # Same escape hatch firstmate's own tests/lib.sh uses: this runs inside a
  # no-mistakes gate worktree, and the lab fleet below is entirely fake.
  FM_GATE_REFUSE_BYPASS=1 FM_ROOT_OVERRIDE='' FM_HOME="$home" \
    FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
    FM_PROJECTS_OVERRIDE="$home/projects" FM_CONFIG_OVERRIDE="$home/config" \
    FM_SPAWN_NO_GUARD=1 FM_FAKE_PANE_PATH="$wt" TMUX="fake,1,0" \
    FM_TMUX_LOG="$log" GROK_HOME="$home/grok-home" PATH="$case_dir/fakebin:$PATH" \
    "$root/bin/fm-spawn.sh" "$id" "$proj" --mode no-mistakes --yolo off \
    > "$case_dir/spawn.out" 2>&1
  printf 'spawn exit status   : %s\n' "$?"

  after=$(shasum -a 256 < "$wt/.claude/settings.local.json" 2>/dev/null || printf 'FILE MISSING')
  printf '\n--- what happened to the project'"'"'s tracked file ---\n'
  printf 'lines after spawn   : %s\n' \
    "$(wc -l < "$wt/.claude/settings.local.json" 2>/dev/null | tr -d ' ')"
  printf 'sha256 before       : %s\n' "$before"
  printf 'sha256 after        : %s\n' "$after"
  if [ "$before" = "$after" ]; then
    printf 'verdict             : UNCHANGED - the committed content survived\n'
  else
    printf 'verdict             : DESTROYED - committed content was overwritten\n'
    printf 'file now contains   :\n'
    sed -n '1,3p' "$wt/.claude/settings.local.json" | cut -c1-160
  fi
  printf '\ngit status of the crewmate worktree:\n'
  if [ -z "$(git -C "$wt" status --porcelain)" ]; then
    printf '  (clean)\n'
  else
    git -C "$wt" status --porcelain | sed 's/^/  /'
    printf '  -> the crewmate starts work on a modified tracked file, and a ship\n'
    printf '     teardown can refuse to clean the worktree up.\n'
  fi

  printf '\nper-task hook file outside the worktree (state/):\n'
  if [ -f "$home/state/$id.claude-settings.json" ]; then
    printf '  %s\n' "$home/state/$id.claude-settings.json"
    jq -c '.hooks | keys' "$home/state/$id.claude-settings.json" | sed 's/^/  hooks: /'
  else
    printf '  (none written)\n'
  fi

  printf '\nlaunch command typed into the crewmate pane:\n'
  grep -o "CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION[^\"]*claude[^|]*" "$log" \
    | head -1 | fold -w 150 | sed 's/^/  /'

  # Drive the real Stop hook to show the turn-end wake still fires.
  if [ -f "$home/state/$id.claude-settings.json" ]; then
    rm -f "$home/state/$id.turn-ended"
    cmd=$(jq -r '.hooks.Stop[0].hooks[0].command' "$home/state/$id.claude-settings.json")
    bash -c "$cmd" >/dev/null 2>&1
    printf '\nStop hook from that file executed -> turn-end marker present: %s\n' \
      "$([ -f "$home/state/$id.turn-ended" ] && printf yes || printf no)"
  fi

  # The third consequence: can the real fm-teardown still clean this task up?
  printf '\n--- real fm-teardown of the same task ---\n'
  FM_GATE_REFUSE_BYPASS=1 FM_ROOT_OVERRIDE='' FM_HOME="$home" \
    FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
    FM_PROJECTS_OVERRIDE="$home/projects" FM_CONFIG_OVERRIDE="$home/config" \
    TMUX="fake,1,0" PATH="$case_dir/fakebin:$PATH" \
    "$root/bin/fm-teardown.sh" "$id" > "$case_dir/teardown.out" 2>&1
  printf 'teardown exit status: %s\n' "$?"
  grep -E 'REFUSED|uncommitted|teardown .* complete' "$case_dir/teardown.out" \
    | cut -c1-140 | sed 's/^/  /'
  printf 'per-task hook file left in state/ after teardown: %s\n' \
    "$([ -e "$home/state/$id.claude-settings.json" ] && printf yes || printf 'no (retired)')"
  printf 'project'"'"'s tracked file after teardown: %s\n' \
    "$(shasum -a 256 < "$wt/.claude/settings.local.json" 2>/dev/null || printf 'FILE MISSING')"
}

printf 'Claude crewmate spawn into a project that TRACKS .claude/settings.local.json\n'
run_case "BEFORE the fix (base commit 733a504)" "$BASE_ROOT" before-fix
run_case "AFTER the fix  (branch fm/fm-spawn-clobbers-settings)" "$FIXED_ROOT" after-fix
printf '\n'
```
</details>
<details>
<summary>Evidence: Evidence-producing script: live Claude pane capture</summary>

```text
#!/usr/bin/env bash
# Captures the real crewmate-shaped Claude pane for reviewer-visible evidence:
# the launch command fm-spawn.sh now types (carrying --settings), the live session
# it produces, and the hook markers it leaves behind. Isolated tmux server and
# scratch repo; no fleet home, worktree, or session is touched.
set -u
OUT=${1:?output file}
LAB=$(mktemp -d "${TMPDIR:-/tmp}/fm-claude-pane.XXXXXX")
PROJECT="$LAB/project"; STATE="$LAB/state"; SOCK="$LAB/tmux.sock"; SESSION=fm-claude-pane
tm() { env -u TMUX -u TMUX_PANE command tmux -S "$SOCK" "$@"; }
cleanup() { tm kill-server >/dev/null 2>&1 || true; rm -rf "$LAB"; }
trap cleanup EXIT

mkdir -p "$PROJECT/.claude" "$STATE"
git init -q "$PROJECT"
cat > "$PROJECT/.claude/settings.local.json" <<JSON
{"permissions":{"allow":["Bash(echo:*)"]},"hooks":{"Stop":[{"hooks":[{"type":"command","command":"touch '$STATE/project-own-stop-hook-fired'"}]}]}}
JSON
git -C "$PROJECT" add -f .claude/settings.local.json
git -C "$PROJECT" -c user.email=t@t -c user.name=t commit -q -m "track claude settings"
BEFORE=$(shasum -a 256 < "$PROJECT/.claude/settings.local.json")

cat > "$STATE/task-live.claude-settings.json" <<JSON
{"hooks":{"UserPromptSubmit":[{"hooks":[{"type":"command","command":"touch '$STATE/firstmate-prompt-submitted'"}]}],"Stop":[{"hooks":[{"type":"command","command":"touch '$STATE/firstmate-turn-ended'"}]}]}}
JSON

tm new-session -d -s "$SESSION" -c "$PROJECT" -x 150 -y 44
tm send-keys -t "$SESSION" \
  "CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions --settings '$STATE/task-live.claude-settings.json' 'reply with the single word ok'" Enter

deadline=$(( $(date +%s) + 300 )); trusted=0
while [ "$(date +%s)" -lt "$deadline" ]; do
  [ -f "$STATE/firstmate-turn-ended" ] && [ -f "$STATE/project-own-stop-hook-fired" ] && break
  if [ "$trusted" -eq 0 ] && tm capture-pane -pt "$SESSION" 2>/dev/null | grep -q 'trust this folder'; then
    tm send-keys -t "$SESSION" Enter; trusted=1
  fi
  sleep 2
done
sleep 2

{
  printf 'Live claude crewmate pane, launched the way bin/fm-spawn.sh now launches one\n'
  printf '(%s)\n\n' "$(claude --version)"
  printf '$ tmux capture-pane -p   # the real pane\n'
  printf -- '--------------------------------------------------------------------------------\n'
  tm capture-pane -pt "$SESSION" | sed -e 's/[[:space:]]*$//' | cat -s
  printf -- '--------------------------------------------------------------------------------\n\n'
  printf 'Hook markers left behind:\n'
  printf '  firstmate UserPromptSubmit (from --settings) : %s\n' \
    "$([ -f "$STATE/firstmate-prompt-submitted" ] && printf FIRED || printf 'never fired')"
  printf '  firstmate Stop / turn-end wake (--settings)  : %s\n' \
    "$([ -f "$STATE/firstmate-turn-ended" ] && printf FIRED || printf 'never fired')"
  printf "  the project's OWN Stop hook (tracked file)   : %s   <- --settings is additive\\n" \
    "$([ -f "$STATE/project-own-stop-hook-fired" ] && printf FIRED || printf 'never fired')"
  printf '\nThe project'"'"'s tracked .claude/settings.local.json:\n'
  printf '  sha256 before session : %s\n' "$BEFORE"
  printf '  sha256 after session  : %s\n' "$(shasum -a 256 < "$PROJECT/.claude/settings.local.json")"
  printf '  git status            : %s\n' \
    "$([ -z "$(git -C "$PROJECT" status --porcelain)" ] && printf '(clean)' || git -C "$PROJECT" status --porcelain)"
} > "$OUT"
```
</details>
<details>
<summary>Evidence: Evidence-producing script: raw-launch warning demo</summary>

```text
#!/usr/bin/env bash
# What an operator sees when they use the raw-launch escape hatch for claude:
# the launch command cannot carry --settings, so fm-spawn warns, names the exact
# argument to add, and declines to arm the busy-state contract.
set -u
ROOT=${ROOT:?}
LAB=$(mktemp -d "${TMPDIR:-/tmp}/fm-raw-launch.XXXXXX")
trap 'rm -rf "$LAB"' EXIT
id=raw-task
home="$LAB/home"; proj="$LAB/project"; wt="$LAB/wt"; fakebin="$LAB/fakebin"
mkdir -p "$home/data/$id" "$home/projects" "$home/state" "$home/config" "$fakebin"
printf 'claude\n' > "$home/config/crew-harness"
printf 'demo brief\n' > "$home/data/$id/brief.md"
touch "$home/state/.last-watcher-beat"
git init -q "$proj"
git -C "$proj" -c user.email=t@t -c user.name=t commit -q --allow-empty -m init
git -C "$proj" worktree add --quiet -b wt-raw "$wt"
cat > "$fakebin/tmux" <<'SH'
#!/usr/bin/env bash
set -u
case "$*" in *"#{pane_current_path}"*) printf '%s\n' "${FM_FAKE_PANE_PATH:-}"; exit 0 ;; esac
case "${1:-}" in display-message) printf 'firstmate\n'; exit 0 ;; list-windows) exit 0 ;; esac
exit 0
SH
chmod +x "$fakebin/tmux"
for t in treehouse claude codex pi opencode; do
  printf '#!/usr/bin/env bash\nexit 0\n' > "$fakebin/$t"; chmod +x "$fakebin/$t"
done

printf '$ fm-spawn.sh %s <project> --launch "claude --dangerously-skip-permissions '"'"'do the thing'"'"'"\n\n' "$id"
FM_GATE_REFUSE_BYPASS=1 FM_ROOT_OVERRIDE='' FM_HOME="$home" \
  FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
  FM_PROJECTS_OVERRIDE="$home/projects" FM_CONFIG_OVERRIDE="$home/config" \
  FM_SPAWN_NO_GUARD=1 FM_FAKE_PANE_PATH="$wt" TMUX="fake,1,0" \
  GROK_HOME="$home/grok-home" PATH="$fakebin:$PATH" \
  "$ROOT/bin/fm-spawn.sh" "$id" "$proj" --mode no-mistakes --yolo off \
  "claude --dangerously-skip-permissions 'do the thing'" 2>&1 \
  | grep -E 'warning|spawned|launch' | fold -w 150

printf '\nbusy-state contract armed for this spawn : %s\n' \
  "$([ -e "$home/state/$id.busy-gen" ] && printf 'yes' || printf 'no (stays unarmed, so it classifies unknown - never a stranded busy)')"
printf 'hook file still written, ready for a hand-added --settings:\n'
printf '  %s\n' "$home/state/$id.claude-settings.json"
jq -c . "$home/state/$id.claude-settings.json" | fold -w 150 | sed 's/^/  /'
```
</details>
- Outcome: ⚠️ 1 warning across 1 run (12m15s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ℹ️ `bin/fm-teardown.sh:510` - The second content gate in remove_legacy_claude_worktree_settings (`grep -qF &#39;fm-busy-event.sh&#39;`) is redundant for its stated purpose and quietly wider than the comment describes. Both legacy shapes fm-spawn ever wrote embedded `touch &#39;&lt;STATE&gt;/&lt;id&gt;.turn-ended&#39;` in the Stop hook (the busy-state shape prefixed the busy call onto that same touch), so gate 1 at :509 already matches both; the comment&#39;s &#34;Both legacy shapes are covered&#34; rationale is therefore inaccurate. What gate 2 actually adds is matching a firstmate legacy file belonging to a different task id - plausibly useful for a reused treehouse pool worktree, but undocumented and unexercised by the new tests (the legacy fixture uses `task-x1.turn-ended`, which matches gate 1). Residual cost: any untracked .claude/settings.local.json mentioning fm-busy-event.sh is removed regardless of task, narrow but reachable in the firstmate repo itself, the one project whose files name that script.

</details>

<details>
<summary>⚠️ **Test** - 1 warning</summary>

- ⚠️ `tests/fm-teardown.test.sh:1582` - tests/fm-teardown.test.sh fails at `herdr-preflight-missing-adapter` (&#34;the retryable pre-return refusal was not explained visibly&#34;), so the file exits 1. This is NOT caused by this change: running the same test file from the unmodified base commit 733a504 (extracted with `git archive` into a temp dir) produces the identical single failure. Flagged only so the non-zero exit of a test file this change touches is not mistaken for a regression; deciding whether to fix it is out of scope here.
- <code>`bash tests/fm-busy-adapter-wiring.test.sh` - all pass, including the four new claude cases (tracked file untouched, untracked file preserved, launch loads out-of-tree settings, raw launch warns/unarmed/unknown)</code>
- <code>`bash tests/fm-spawn-dispatch-profile.test.sh` - all pass, exact claude launch strings now include `--settings &#39;&lt;state&gt;/&lt;id&gt;.claude-settings.json&#39;`</code>
- <code>`bash tests/fm-secondmate-harness.test.sh` - all pass, including `test_spawn_claude_secondmate_launches_without_per_task_settings`</code>
- <code>`bash tests/fm-teardown.test.sh` - both new claude cases pass; one pre-existing unrelated failure (`herdr-preflight-missing-adapter`)</code>
- <code>`cd /tmp/fm-base-30223 &amp;&amp; bash tests/fm-teardown.test.sh` (base commit 733a504 extracted via `git archive`) - same `herdr-preflight-missing-adapter` failure, confirming it is pre-existing</code>
- <code>Manual before/after end-to-end: real `bin/fm-spawn.sh` from base commit vs branch against a project tracking a 302-line `.claude/settings.local.json`, comparing sha256, line count, `git status --porcelain`, the tmux `send-keys` launch command, and the written hook file (`clobber-e2e-demo.sh`)</code>
- <code>Manual end-to-end continuation: real `bin/fm-teardown.sh` on both spawned tasks - base case REFUSES on uncommitted changes, fixed case completes and retires `state/&lt;id&gt;.claude-settings.json`</code>
- <code>`FM_CLAUDE_LIVE_E2E=1 bash tests/fm-claude-settings-hook-live-e2e.test.sh` against installed Claude Code 2.1.221 - passes</code>
- <code>Manual live pane capture: launched a real Claude session in an isolated tmux server with the exact launch shape fm-spawn builds, captured `tmux capture-pane -p`, and checked firstmate&#39;s `--settings` hooks, the project&#39;s own Stop hook, and the tracked file&#39;s sha256 (`live-pane-capture.sh`)</code>
- <code>Manual raw-launch escape hatch: real `fm-spawn.sh` with a hand-written claude launch command, capturing the operator-visible warning, the unarmed busy contract, and the turn-end-only hook file (`raw-launch-warning-demo.sh`)</code>

</details>

<details>
<summary>⚠️ **Document** - 1 info</summary>

- ℹ️ `docs/fm-test-portable-shards.md:73` - docs/fm-test-portable-shards.md&#39;s portable-serial shard table (15/18/17/19 = 69 scripts, dated 2026-08-02) no longer matches the derived lane, which now holds 82 scripts across 16/21/23/22. This change contributes exactly one of that gap (tests/fm-claude-settings-hook-live-e2e.test.sh lands in portable-serial-4of4); the other 12 predate it. Refreshing the table correctly requires the per-shard CI timing artifacts named in that document&#39;s own refresh procedure, which are not available here, and editing only the counts while leaving stale durations would misrepresent the balance evidence. Proposed follow-up: refresh the hints and table together from a green CI run. Coverage is unaffected - membership is derived and the coverage guard keeps the partition complete.

</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 127)

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
