### PR TITLE
fix(bin): unblock session lock and CLAIM_LOCK on Windows Git Bash

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ Full detail on every feature lives in [docs/architecture.md](docs/architecture.m
 The first mate detects and offers to install supported missing tools after you approve.
 Backend-specific setup is linked in [Documentation](#documentation).
 
+**Windows (Git Bash):** enable Developer Mode (Settings > System > Advanced > For developers, first toggle - or just search "use developer features"), or grant your account the "Create symbolic links" privilege, before running firstmate, then fully restart your terminal. Without it, `ln -s` on a directory silently creates a plain empty directory instead of a real symlink, which breaks the session lock in ways that are hard to diagnose.
+
 ### Recommended harnesses
 
 **Claude Code, Grok, and Pi are equal co-primary recommendations** for running the primary firstmate session, with `pi-signed` supported as Pi's distinct signed-wrapper identity.

--- a/bin/fm-session-lock-lib.sh
+++ b/bin/fm-session-lock-lib.sh
@@ -74,6 +74,38 @@ fm_harness_process_matches() {  # <comm> <args>
   return 1
 }
 
+# Cached result of whether this platform's `ps` understands the POSIX -o
+# custom-format option (`-o comm=`, `-o ppid=`, `-o args=`), which every
+# function below depends on to read process identity. Verified broken: the
+# Cygwin ps 3.6.9 shipped with Git for Windows supports only
+# [-aefls] [-u UID] [-p PID] and rejects -o outright, so every comm/args/ppid
+# read above silently comes back empty (stderr is normally discarded) and the
+# ancestry walk fails on its very first hop. Probed once and cached because ps
+# is invoked many times per session.
+FM_PS_SUPPORTS_O=
+fm_ps_supports_o() {
+  if [ -z "$FM_PS_SUPPORTS_O" ]; then
+    if ps -o comm= -p $$ >/dev/null 2>&1; then
+      FM_PS_SUPPORTS_O=1
+    else
+      FM_PS_SUPPORTS_O=0
+    fi
+  fi
+  [ "$FM_PS_SUPPORTS_O" = 1 ]
+}
+
+# True when this process's environment carries one of the verified harness
+# markers fm-harness.sh's detect_own() trusts as its Layer 1: only claude, pi,
+# and grok set one of their own (codex, opencode, and kimi are markerless, so
+# they have no fallback here and still depend entirely on the ps ancestry walk
+# below). Keep in sync with detect_own() by hand - see comment there.
+fm_harness_verified_env_marker() {
+  [ "${CLAUDECODE:-}" = "1" ] && return 0
+  [ "${PI_CODING_AGENT:-}" = "true" ] && return 0
+  [ "${GROK_AGENT:-}" = "1" ] && return 0
+  return 1
+}
+
 # Walk the current process ancestry (up to 16 hops) and print this session's
 # contiguous verified-harness ancestry, innermost pid first.
 #
@@ -94,6 +126,14 @@ fm_harness_process_matches() {  # <comm> <args>
 # reported and the callers below decide what they need from it.
 fm_harness_ancestry_pids() {
   local pid=$$ comm args extending=0 printed=0
+  if ! fm_ps_supports_o && fm_harness_verified_env_marker; then
+    # ps can't report comm/ppid/args at all on this platform (see
+    # fm_ps_supports_o), so the walk below can never succeed. A verified env
+    # marker already proves this process runs under that harness, so trust it
+    # and report just the current pid instead of failing closed every time.
+    printf '%s\n' "$pid"
+    return 0
+  fi
   for _ in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16; do
     comm=$(ps -o comm= -p "$pid" 2>/dev/null) || break
     args=$(ps -o args= -p "$pid" 2>/dev/null)
@@ -133,6 +173,13 @@ EOF
 fm_harness_pid_alive() {
   local pid=$1 comm args
   kill -0 "$pid" 2>/dev/null || return 1
+  if ! fm_ps_supports_o; then
+    # Cannot verify identity via comm/args on this platform (see
+    # fm_ps_supports_o); trust liveness alone when a verified env marker is
+    # present, exactly as the ancestry fallback above does.
+    fm_harness_verified_env_marker
+    return $?
+  fi
   comm=$(ps -o comm= -p "$pid" 2>/dev/null) || return 1
   args=$(ps -o args= -p "$pid" 2>/dev/null)
   fm_harness_process_matches "$comm" "$args"

--- a/bin/fm-wake-lib.sh
+++ b/bin/fm-wake-lib.sh
@@ -152,6 +152,37 @@ fm_lock_abs_path() {
   printf '%s/%s\n' "$dir" "$base"
 }
 
+# Cached result of whether ln -s produces a real, working symlink on this
+# filesystem. Verified broken: some Windows/Git-Bash (MSYS) setups without
+# Developer Mode or SeCreateSymbolicLinkPrivilege silently create an ordinary
+# empty directory instead of a symlink when the target is a directory - `ln -s`
+# reports success (exit 0, no error) but `[ -L ... ]`/`readlink` on the result
+# say it never happened. That breaks every ownerdir+symlink claim below forever
+# (the "lock" this creates can never be verified as owned, never expires, and
+# the steal fallback recurses into deeper .steal.steal... paths without bound
+# trying to work around it), so probe once and fall back to a plain mkdir
+# claim - see fm_lock_try_create_plain.
+FM_FS_SUPPORTS_SYMLINKS=
+fm_fs_supports_symlinks() {
+  if [ -z "$FM_FS_SUPPORTS_SYMLINKS" ]; then
+    local probe_dir probe_link
+    probe_dir=$(mktemp -d "$STATE/.symlink-probe.XXXXXX" 2>/dev/null) || probe_dir=
+    if [ -n "$probe_dir" ]; then
+      probe_link="${probe_dir}.link"
+      rm -rf "$probe_link" 2>/dev/null
+      if ln -s "$probe_dir" "$probe_link" 2>/dev/null && [ -L "$probe_link" ]; then
+        FM_FS_SUPPORTS_SYMLINKS=1
+      else
+        FM_FS_SUPPORTS_SYMLINKS=0
+      fi
+      rm -rf "$probe_link" "$probe_dir" 2>/dev/null
+    else
+      FM_FS_SUPPORTS_SYMLINKS=0
+    fi
+  fi
+  [ "$FM_FS_SUPPORTS_SYMLINKS" = 1 ]
+}
+
 fm_lock_owner_dir() {
   local lockdir=$1 lock_abs
   lock_abs=$(fm_lock_abs_path "$lockdir") || return 1
@@ -178,8 +209,14 @@ fm_lock_link_owner() {
 
 fm_lock_points_to_owner() {
   local lockdir=$1 ownerdir=$2 actual
-  actual=$(readlink "$lockdir" 2>/dev/null) || return 1
-  [ "$actual" = "$ownerdir" ]
+  if [ -L "$lockdir" ]; then
+    actual=$(readlink "$lockdir" 2>/dev/null) || return 1
+    [ "$actual" = "$ownerdir" ]
+    return
+  fi
+  # Plain-mkdir shape (fm_fs_supports_symlinks is false): lockdir is claimed
+  # directly and is its own owner directory, so "points to" reduces to identity.
+  [ -n "$lockdir" ] && [ "$lockdir" = "$ownerdir" ]
 }
 
 fm_lock_discard_owner() {
@@ -233,9 +270,37 @@ fm_lock_claim() {
   return 0
 }
 
+# fm_lock_try_create's fallback when fm_fs_supports_symlinks is false: claim
+# lockdir directly via mkdir - already proven atomic and reliable here (unlike
+# ln -s, see fm_fs_supports_symlinks) since fm_lock_owner_dir's mktemp -d
+# already depends on it - instead of a separate owner directory linked in by a
+# symlink. lockdir is its own owner in this shape; fm_lock_release,
+# fm_lock_remove_path, and fm_lock_recheck_stale_owner already understand a
+# plain, non-symlink lockdir as a valid owned lock and need no changes.
+fm_lock_try_create_plain() {
+  local lockdir=$1 allowed_steal_owner=${2:-}
+  mkdir "$lockdir" 2>/dev/null || return 1
+  if ! fm_lock_prepare_owner "$lockdir"; then
+    fm_lock_clean_known_files "$lockdir"
+    rmdir "$lockdir" 2>/dev/null || true
+    return 1
+  fi
+  if fm_lock_claim_blocked_by_steal "$lockdir" "$allowed_steal_owner"; then
+    fm_lock_clean_known_files "$lockdir"
+    rmdir "$lockdir" 2>/dev/null || true
+    return 1
+  fi
+  FM_LOCK_OWNER_DIR=$lockdir
+  return 0
+}
+
 fm_lock_try_create() {
   local lockdir=$1 allowed_steal_owner=${2:-} ownerdir
   FM_LOCK_OWNER_DIR=
+  if ! fm_fs_supports_symlinks; then
+    fm_lock_try_create_plain "$lockdir" "$allowed_steal_owner"
+    return
+  fi
   ownerdir=$(fm_lock_owner_dir "$lockdir") || return 1
   if [ -e "$lockdir" ] || [ -L "$lockdir" ]; then
     fm_lock_discard_owner "$ownerdir"

--- a/bin/fm-wake-lib.sh
+++ b/bin/fm-wake-lib.sh
@@ -152,37 +152,6 @@ fm_lock_abs_path() {
   printf '%s/%s\n' "$dir" "$base"
 }
 
-# Cached result of whether ln -s produces a real, working symlink on this
-# filesystem. Verified broken: some Windows/Git-Bash (MSYS) setups without
-# Developer Mode or SeCreateSymbolicLinkPrivilege silently create an ordinary
-# empty directory instead of a symlink when the target is a directory - `ln -s`
-# reports success (exit 0, no error) but `[ -L ... ]`/`readlink` on the result
-# say it never happened. That breaks every ownerdir+symlink claim below forever
-# (the "lock" this creates can never be verified as owned, never expires, and
-# the steal fallback recurses into deeper .steal.steal... paths without bound
-# trying to work around it), so probe once and fall back to a plain mkdir
-# claim - see fm_lock_try_create_plain.
-FM_FS_SUPPORTS_SYMLINKS=
-fm_fs_supports_symlinks() {
-  if [ -z "$FM_FS_SUPPORTS_SYMLINKS" ]; then
-    local probe_dir probe_link
-    probe_dir=$(mktemp -d "$STATE/.symlink-probe.XXXXXX" 2>/dev/null) || probe_dir=
-    if [ -n "$probe_dir" ]; then
-      probe_link="${probe_dir}.link"
-      rm -rf "$probe_link" 2>/dev/null
-      if ln -s "$probe_dir" "$probe_link" 2>/dev/null && [ -L "$probe_link" ]; then
-        FM_FS_SUPPORTS_SYMLINKS=1
-      else
-        FM_FS_SUPPORTS_SYMLINKS=0
-      fi
-      rm -rf "$probe_link" "$probe_dir" 2>/dev/null
-    else
-      FM_FS_SUPPORTS_SYMLINKS=0
-    fi
-  fi
-  [ "$FM_FS_SUPPORTS_SYMLINKS" = 1 ]
-}
-
 fm_lock_owner_dir() {
   local lockdir=$1 lock_abs
   lock_abs=$(fm_lock_abs_path "$lockdir") || return 1
@@ -209,14 +178,8 @@ fm_lock_link_owner() {
 
 fm_lock_points_to_owner() {
   local lockdir=$1 ownerdir=$2 actual
-  if [ -L "$lockdir" ]; then
-    actual=$(readlink "$lockdir" 2>/dev/null) || return 1
-    [ "$actual" = "$ownerdir" ]
-    return
-  fi
-  # Plain-mkdir shape (fm_fs_supports_symlinks is false): lockdir is claimed
-  # directly and is its own owner directory, so "points to" reduces to identity.
-  [ -n "$lockdir" ] && [ "$lockdir" = "$ownerdir" ]
+  actual=$(readlink "$lockdir" 2>/dev/null) || return 1
+  [ "$actual" = "$ownerdir" ]
 }
 
 fm_lock_discard_owner() {
@@ -270,37 +233,9 @@ fm_lock_claim() {
   return 0
 }
 
-# fm_lock_try_create's fallback when fm_fs_supports_symlinks is false: claim
-# lockdir directly via mkdir - already proven atomic and reliable here (unlike
-# ln -s, see fm_fs_supports_symlinks) since fm_lock_owner_dir's mktemp -d
-# already depends on it - instead of a separate owner directory linked in by a
-# symlink. lockdir is its own owner in this shape; fm_lock_release,
-# fm_lock_remove_path, and fm_lock_recheck_stale_owner already understand a
-# plain, non-symlink lockdir as a valid owned lock and need no changes.
-fm_lock_try_create_plain() {
-  local lockdir=$1 allowed_steal_owner=${2:-}
-  mkdir "$lockdir" 2>/dev/null || return 1
-  if ! fm_lock_prepare_owner "$lockdir"; then
-    fm_lock_clean_known_files "$lockdir"
-    rmdir "$lockdir" 2>/dev/null || true
-    return 1
-  fi
-  if fm_lock_claim_blocked_by_steal "$lockdir" "$allowed_steal_owner"; then
-    fm_lock_clean_known_files "$lockdir"
-    rmdir "$lockdir" 2>/dev/null || true
-    return 1
-  fi
-  FM_LOCK_OWNER_DIR=$lockdir
-  return 0
-}
-
 fm_lock_try_create() {
   local lockdir=$1 allowed_steal_owner=${2:-} ownerdir
   FM_LOCK_OWNER_DIR=
-  if ! fm_fs_supports_symlinks; then
-    fm_lock_try_create_plain "$lockdir" "$allowed_steal_owner"
-    return
-  fi
   ownerdir=$(fm_lock_owner_dir "$lockdir") || return 1
   if [ -e "$lockdir" ] || [ -L "$lockdir" ]; then
     fm_lock_discard_owner "$ownerdir"

--- a/tests/fm-session-lock-ancestry.test.sh
+++ b/tests/fm-session-lock-ancestry.test.sh
@@ -220,6 +220,39 @@ SH
   pass "session-lock: a live version-named session holding the lock is not mistaken for a stale owner"
 }
 
+test_broken_ps_without_o_falls_back_to_verified_env_marker() {
+  local dir fakebin
+  dir="$TMP_ROOT/broken-ps-no-o"
+  fakebin=$(fm_fakebin "$dir")
+  mkdir -p "$dir/state"
+  # Simulates the Cygwin ps 3.6.9 shipped with Git for Windows: its entire
+  # flag set is [-aefls] [-u UID] [-p PID] and it rejects -o outright, so
+  # every comm/args/ppid read in the ancestry walk fails identically no
+  # matter what pid is requested.
+  cat > "$fakebin/ps" <<'SH'
+#!/usr/bin/env bash
+echo "ps: unknown option -- o" >&2
+exit 1
+SH
+  chmod +x "$fakebin/ps"
+
+  # Clear all three verified markers explicitly: this suite may itself be
+  # running inside a real Claude Code session, which sets CLAUDECODE=1 in the
+  # ambient environment that lib_eval's subshell would otherwise inherit.
+  if CLAUDECODE= PI_CODING_AGENT= GROK_AGENT= lib_eval "$fakebin" 'fm_harness_ancestry_pid'; then
+    fail "ancestry succeeded despite ps lacking -o support and no verified env marker present"
+  fi
+  if CLAUDECODE= PI_CODING_AGENT= GROK_AGENT= lib_eval "$fakebin" 'fm_harness_pid_alive 12345'; then
+    fail "pid_alive succeeded despite ps lacking -o support and no verified env marker present"
+  fi
+
+  CLAUDECODE=1 lib_eval "$fakebin" 'me=$$; got=$(fm_harness_ancestry_pid); [ "$got" = "$me" ]' \
+    || fail "CLAUDECODE=1 did not fall back to the current pid when ps lacks -o support"
+  CLAUDECODE=1 lib_eval "$fakebin" 'fm_harness_pid_alive 12345' \
+    || fail "CLAUDECODE=1 did not trust liveness alone for pid_alive when ps lacks -o support"
+  pass "session-lock: a verified env marker (CLAUDECODE=1) is trusted as a fallback when ps lacks -o support"
+}
+
 # --- end-to-end layer: the real Stop auto-arm in real process trees ----------
 
 install_autoarm_scripts() {
@@ -358,6 +391,7 @@ test_version_named_session_is_identified_on_both_platforms
 test_ordinary_paths_are_never_harness_processes
 test_harness_beyond_a_gap_never_owns_the_lock
 test_competing_version_named_session_is_seen_as_live
+test_broken_ps_without_o_falls_back_to_verified_env_marker
 test_e2e_version_named_session_claims_the_home
 test_e2e_daemon_parented_session_claims_the_home
 test_e2e_daemon_parented_version_named_session_keeps_its_lock


### PR DESCRIPTION
## Summary

Firstmate is permanently stuck read-only on Windows Git Bash (MSYS).

- **`bin/fm-session-lock-lib.sh`**: the harness-ancestry walk depends entirely on `ps -o comm=/-o ppid=/-o args=`. Git Bash's bundled Cygwin `ps` (3.6.9) doesn't support `-o` at all (`ps: unknown option -- o`), so the walk dies on hop one and `fm-lock.sh` always reports `cannot locate harness process in ancestry`. `fm-harness.sh` already trusts verified env markers (`CLAUDECODE=1`, `PI_CODING_AGENT`, `GROK_AGENT`) ahead of the `ps` walk; the session lock had no equivalent fallback. It now probes `ps -o` support once and falls back to the same verified-marker trust when unavailable.

This fallback is additive: `ps -o`-capable platforms (Linux, macOS - CI's only runners) take the exact same code path as before.

Separately, the session lock's `CLAIM_LOCK` mutex depends on `ln -s` producing a real symlink, which requires Windows Developer Mode (or the "Create symbolic links" privilege) to be enabled - without it `ln -s` on a directory silently creates a plain empty directory instead, and the lock can never be verified as owned. Rather than work around this in code, it's now documented as a hard requirement in the README.

## Verified

- `fm-lock.sh` now acquires instantly instead of hanging; `fm-session-start.sh` no longer falls into the read-only branch.
- `tests/fm-session-lock-ancestry.test.sh`: all pass, including a new case for the broken-`ps` fallback.
- CI only runs `ubuntu-latest`/`macos-latest`, so none of this was previously exercised on Windows.

## Test plan

- [ ] CI (Linux/macOS) stays green - the new code path is gated behind a capability probe that should evaluate to "supported" there, so behavior is unchanged.
- [ ] On Windows Git Bash (Developer Mode enabled): `bash bin/fm-session-start.sh` acquires the lock without a READ-ONLY banner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
