### PR TITLE
fix(bin): prevent idle composer injection wedges

### DIFF
--- a/bin/fm-composer-lib.sh
+++ b/bin/fm-composer-lib.sh
@@ -160,6 +160,57 @@ fm_composer_strip_ghost() {
   '
 }
 
+# NON-ASCII BLANK PADDING is the third concern of this owner (task
+# fm-afk-injection-wedge): a harness may pad an otherwise-empty composer row
+# with a non-ASCII blank rather than an ASCII space. Verified claude 2.x renders
+# its EMPTY composer row as `❯` + U+00A0 NO-BREAK SPACE (bytes e2 9d af c2 a0),
+# and bash's own `[:space:]` trims treat no non-ASCII blank as whitespace under
+# any locale the fleet runs (verified C, C.utf8, en_US.utf8, and POSIX - note
+# that glibc's grep DOES match U+00A0 there, so a grep-based spot check is
+# misleading), so the pad survived every trim as "real typed content" and the
+# row classified `pending`. The away-mode injector (bin/fm-supervise-daemon.sh)
+# refuses to inject unless the composer is affirmatively `empty`, so an idle,
+# perfectly injectable primary deferred EVERY escalation until the captain
+# returned - three overnight wedges of 7.8h, 11.0h, and 10.1h, all buffered and
+# replayed intact but none delivered on time. fm_composer_blank_normalize folds
+# these into an ASCII space before the emptiness decision. That is safe in the
+# one direction that matters here: every character it folds is invisible, so a
+# row reducing to blank carried no visible typed content, while any visible byte
+# survives untouched and still reads `pending`.
+#
+# fm_composer_blank_normalize: replace every non-ASCII blank or zero-width
+# character with an ASCII space so the shared trims below see it as whitespace.
+# Byte-literal substitution, so it is locale-independent (the fleet default is
+# C/POSIX, where bash's own character classes are byte-wise).
+FM_COMPOSER_BLANKS=(
+  $'\xc2\xa0'      # U+00A0 NO-BREAK SPACE (verified: claude 2.x empty-composer pad)
+  $'\xe1\x9a\x80'  # U+1680 OGHAM SPACE MARK
+  $'\xe2\x80\x80'  # U+2000 EN QUAD
+  $'\xe2\x80\x81'  # U+2001 EM QUAD
+  $'\xe2\x80\x82'  # U+2002 EN SPACE
+  $'\xe2\x80\x83'  # U+2003 EM SPACE
+  $'\xe2\x80\x84'  # U+2004 THREE-PER-EM SPACE
+  $'\xe2\x80\x85'  # U+2005 FOUR-PER-EM SPACE
+  $'\xe2\x80\x86'  # U+2006 SIX-PER-EM SPACE
+  $'\xe2\x80\x87'  # U+2007 FIGURE SPACE
+  $'\xe2\x80\x88'  # U+2008 PUNCTUATION SPACE
+  $'\xe2\x80\x89'  # U+2009 THIN SPACE
+  $'\xe2\x80\x8a'  # U+200A HAIR SPACE
+  $'\xe2\x80\x8b'  # U+200B ZERO WIDTH SPACE
+  $'\xe2\x80\xaf'  # U+202F NARROW NO-BREAK SPACE
+  $'\xe2\x81\x9f'  # U+205F MEDIUM MATHEMATICAL SPACE
+  $'\xe3\x80\x80'  # U+3000 IDEOGRAPHIC SPACE
+  $'\xef\xbb\xbf'  # U+FEFF ZERO WIDTH NO-BREAK SPACE
+)
+
+fm_composer_blank_normalize() {  # <content>
+  local s=$1 b
+  for b in "${FM_COMPOSER_BLANKS[@]}"; do
+    s=${s//"$b"/ }
+  done
+  printf '%s' "$s"
+}
+
 # fm_composer_classify_content: the single shared composer-content verdict.
 #   <bordered> 1 when <content> came from a genuine agent-composer container (a
 #              bordered composer box, or a structurally-identified bare AGENT
@@ -183,6 +234,14 @@ fm_composer_idle_matches() {
 fm_composer_classify_content() {  # <bordered> <content> [idle_re] [idle_case] [plain_content]
   local bordered=$1 content=$2 idle_re=${3:-} idle_case=${4:-sensitive} plain_content
   plain_content=${5:-$content}
+  # Callers trim with ASCII [:space:], which leaves a non-ASCII blank pad behind
+  # (see FM_COMPOSER_BLANKS above). Fold and re-trim before any verdict.
+  content=$(fm_composer_blank_normalize "$content")
+  content="${content#"${content%%[![:space:]]*}"}"
+  content="${content%"${content##*[![:space:]]}"}"
+  plain_content=$(fm_composer_blank_normalize "$plain_content")
+  plain_content="${plain_content#"${plain_content%%[![:space:]]*}"}"
+  plain_content="${plain_content%"${plain_content##*[![:space:]]}"}"
   if [ "$bordered" != 1 ] && [ -z "$content" ] && [ -n "$plain_content" ]; then
     case "$plain_content" in
       '❯'|'›') printf 'empty'; return 0 ;;
@@ -206,10 +265,19 @@ fm_composer_classify_content() {  # <bordered> <content> [idle_re] [idle_case] [
   if fm_composer_idle_matches "$content" "$idle_re" "$idle_case"; then
     printf 'empty'; return 0
   fi
-  # Strip a leading prompt glyph, then re-judge the remainder.
+  # Strip a leading prompt glyph, then re-judge the remainder. The glyph is
+  # removed as a LITERAL prefix rather than by character count: `${content#?}`
+  # removes one CHARACTER, which under the fleet's C/POSIX locale is one BYTE,
+  # so a multibyte agent glyph (❯ / ›) left its two trailing bytes behind and
+  # they re-read as real content. The trailing whitespace trim below absorbs any
+  # separating space, so one literal-prefix case per glyph covers both shapes.
   case "$content" in
-    '❯ '*|'› '*|'> '*|'$ '*|'% '*|'# '*) content=${content#??} ;;
-    '❯'*|'›'*|'>'*|'$'*|'%'*|'#'*) content=${content#?} ;;
+    '❯'*) content=${content#'❯'} ;;
+    '›'*) content=${content#'›'} ;;
+    '>'*) content=${content#'>'} ;;
+    '$'*) content=${content#'$'} ;;
+    '%'*) content=${content#'%'} ;;
+    '#'*) content=${content#'#'} ;;
   esac
   content="${content#"${content%%[![:space:]]*}"}"
   content="${content%"${content##*[![:space:]]}"}"

--- a/bin/fm-composer-lib.sh
+++ b/bin/fm-composer-lib.sh
@@ -160,23 +160,11 @@ fm_composer_strip_ghost() {
   '
 }
 
-# NON-ASCII BLANK PADDING is the third concern of this owner (task
-# fm-afk-injection-wedge): a harness may pad an otherwise-empty composer row
-# with a non-ASCII blank rather than an ASCII space. Verified claude 2.x renders
-# its EMPTY composer row as `❯` + U+00A0 NO-BREAK SPACE (bytes e2 9d af c2 a0),
-# and bash's own `[:space:]` trims treat no non-ASCII blank as whitespace under
-# any locale the fleet runs (verified C, C.utf8, en_US.utf8, and POSIX - note
-# that glibc's grep DOES match U+00A0 there, so a grep-based spot check is
-# misleading), so the pad survived every trim as "real typed content" and the
-# row classified `pending`. The away-mode injector (bin/fm-supervise-daemon.sh)
-# refuses to inject unless the composer is affirmatively `empty`, so an idle,
-# perfectly injectable primary deferred EVERY escalation until the captain
-# returned - three overnight wedges of 7.8h, 11.0h, and 10.1h, all buffered and
-# replayed intact but none delivered on time. fm_composer_blank_normalize folds
-# these into an ASCII space before the emptiness decision. That is safe in the
-# one direction that matters here: every character it folds is invisible, so a
-# row reducing to blank carried no visible typed content, while any visible byte
-# survives untouched and still reads `pending`.
+# A harness may pad an otherwise-empty composer row with a non-ASCII blank that
+# bash's `[:space:]` trims retain as apparent typed content. Normalize only the
+# enumerated invisible characters before the emptiness decision, so any visible
+# byte survives and still reads `pending`. Live evidence and the supported
+# mid-turn limitation are recorded in docs/verification/supervision.md.
 #
 # fm_composer_blank_normalize: replace every non-ASCII blank or zero-width
 # character with an ASCII space so the shared trims below see it as whitespace.

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -214,6 +214,8 @@ A working Pi, pending middle row, missing identity, incomplete separator pair, o
 
 ANSI capture preserves de-emphasized placeholder style.
 `bin/fm-composer-lib.sh` is the fleet-wide owner that strips dim or faint runs and dark truecolor placeholders while retaining bright typed input.
+Before classification, that owner folds its enumerated invisible non-ASCII blanks and zero-width padding to ASCII whitespace and removes recognized prompt glyphs as literal prefixes so C/POSIX byte semantics cannot leave multibyte fragments behind.
+The fold never removes visible input, so visible content remains `pending` and continues to refuse injection.
 If a future Herdr version strips ANSI style, ghost suggestions become pending rather than empty, which safely defers injection and eventually raises the wedge alarm.
 
 A bare shell prompt is never an empty agent composer.

--- a/docs/verification/supervision.md
+++ b/docs/verification/supervision.md
@@ -230,3 +230,57 @@ Observed output:
 ```
 
 The safe command-channel contract is covered without a notification by `tests/fm-daemon.test.sh`: the summary reaches both `$1` and stdin, every channel is process-group bounded, and a failed channel falls through.
+
+## Composer emptiness on an idle primary
+
+The away-mode injector types only into an affirmatively `empty` composer, so what a real idle primary renders decides whether escalations are delivered or deferred.
+This pass ran on 2026-08-01 with Claude Code 2.1.220 under Herdr 0.7.5 on Linux, against the live primary supervisor pane, and with GNU bash 5.2.21.
+
+Claude renders its EMPTY composer row as the agent glyph followed by a NO-BREAK SPACE, not an ASCII space:
+
+```sh
+herdr pane read <pane> --format ansi | hexdump -C   # composer row only
+```
+
+Observed output:
+
+```
+00000000  e2 9d af c2 a0 0d                                 |......|
+```
+
+Those bytes are `❯` (U+276F), U+00A0 NO-BREAK SPACE, and CR.
+
+Bash's own `[:space:]` trims leave that pad in place under every locale the fleet runs:
+
+```sh
+for L in C C.utf8 en_US.utf8 POSIX; do
+  ( export LC_ALL=$L; c=$(printf '\xe2\x9d\xaf\xc2\xa0'); printf '%s' "${c%"${c##*[![:space:]]}"}" | hexdump -C | head -1 )
+done
+```
+
+Observed output, identical for all four locales and showing the pad surviving as apparent typed content:
+
+```
+00000000  e2 9d af c2 a0                                    |.....|
+```
+
+Check this with bash rather than grep: glibc's `grep -E '^[[:space:]]+$'` DOES match U+00A0 in both C and `en_US.utf8`, so a grep spot check suggests the opposite of what the trims actually do.
+`fm_composer_blank_normalize` (`bin/fm-composer-lib.sh`) folds U+00A0 and the other non-ASCII blank and zero-width characters to an ASCII space before the verdict, which is safe in one direction only: every folded character is invisible, so any visible byte still reads `pending`.
+
+Under an EXPORTED C/POSIX locale, bash counts pattern-prefix characters as bytes, so a leading multibyte glyph must be removed as a literal prefix rather than by character count:
+
+```sh
+( export LC_ALL=C; c='❯ hello'; printf '%s' "${c#??}" | hexdump -C )
+```
+
+Observed output, the two trailing bytes of `❯` surviving as spurious content:
+
+```
+00000000  af 20 68 65 6c 6c 6f                              |. hello|
+```
+
+Both conditions are covered by `tests/fm-composer-lib.test.sh` and, at the adapter level with the captured row, by `tests/fm-backend-herdr.test.sh`.
+
+A genuinely mid-turn primary is a separate and bounded case.
+Herdr's native agent state reports `busy` for a Claude pane during its turn, so `inject_msg` defers on the busy guard and delivers when the turn ends, rather than typing into an in-use composer.
+That defer lasts one turn and clears itself, and the max-defer wedge alarm above still covers a pathological one.

--- a/docs/verification/supervision.md
+++ b/docs/verification/supervision.md
@@ -281,6 +281,8 @@ Observed output, the two trailing bytes of `❯` surviving as spurious content:
 
 Both conditions are covered by `tests/fm-composer-lib.test.sh` and, at the adapter level with the captured row, by `tests/fm-backend-herdr.test.sh`.
 
-A genuinely mid-turn primary is a separate and bounded case.
-Herdr's native agent state reports `busy` for a Claude pane during its turn, so `inject_msg` defers on the busy guard and delivers when the turn ends, rather than typing into an in-use composer.
-That defer lasts one turn and clears itself, and the max-defer wedge alarm above still covers a pathological one.
+A genuinely mid-turn primary is a separate case in which in-turn pane injection is not possible.
+Herdr's native agent state reports `busy` for a Claude pane during its turn, so the busy guard rejects `inject_msg` rather than typing into an in-use composer.
+`escalate_flush` retains the durable buffer after that rejection, and every housekeeping retry follows the same guarded path until the turn ends.
+Normal pane delivery resumes after the turn ends, but this does not provide in-turn responsiveness and can defer for the full duration of the turn.
+For a genuinely urgent away-mode escalation, the concrete out-of-band path is the existing active alert configured by `config/wedge-alarm`, whose channel contract is owned by [`docs/wedge-alarm.md`](../wedge-alarm.md).

--- a/docs/verification/supervision.md
+++ b/docs/verification/supervision.md
@@ -281,8 +281,9 @@ Observed output, the two trailing bytes of `❯` surviving as spurious content:
 
 Both conditions are covered by `tests/fm-composer-lib.test.sh` and, at the adapter level with the captured row, by `tests/fm-backend-herdr.test.sh`.
 
-A genuinely mid-turn primary is a separate case in which in-turn pane injection is not possible.
+A genuinely mid-turn primary is a separate case that the current away-mode path deliberately does not inject into.
 Herdr's native agent state reports `busy` for a Claude pane during its turn, so the busy guard rejects `inject_msg` rather than typing into an in-use composer.
 `escalate_flush` retains the durable buffer after that rejection, and every housekeeping retry follows the same guarded path until the turn ends.
 Normal pane delivery resumes after the turn ends, but this does not provide in-turn responsiveness and can defer for the full duration of the turn.
-For a genuinely urgent away-mode escalation, the concrete out-of-band path is the existing active alert configured by `config/wedge-alarm`, whose channel contract is owned by [`docs/wedge-alarm.md`](../wedge-alarm.md).
+For a genuinely urgent away-mode escalation, configure the existing active alert through `config/wedge-alarm`, whose channel contract is owned by [`docs/wedge-alarm.md`](../wedge-alarm.md).
+That alert reports the delivery wedge and points to the durable marker, but it does not carry the buffered escalation digest itself.

--- a/tests/fm-backend-herdr.test.sh
+++ b/tests/fm-backend-herdr.test.sh
@@ -2650,6 +2650,50 @@ test_composer_state_bare_prompt_is_empty() {
   pass "fm_backend_herdr_composer_state: a bare '❯' composer row reads empty"
 }
 
+# Live-captured incident (task fm-afk-injection-wedge): real claude 2.x under
+# herdr 0.7.5 renders its EMPTY composer as a bare `❯` padded with U+00A0
+# NO-BREAK SPACE, between two `─` rules. Bash's `[:space:]` trims do not treat
+# U+00A0 as whitespace under any locale the fleet runs, so the pad survived
+# trimming as "real typed content", the row read `pending`, and
+# the away-mode injector deferred every escalation against an idle, injectable
+# primary for as long as the captain stayed away. The rows below are the exact
+# shape captured from the live primary pane; the ❯ row's bytes are spelled out
+# so the NBSP pad cannot be silently normalized away by an editor.
+test_composer_state_claude_nbsp_pad_is_empty() {
+  local dir log resp fb out rule
+  dir="$TMP_ROOT/composer-nbsp"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
+  rule=$(printf '\xe2\x94\x80%.0s' $(seq 53))
+  { printf '%s\n' "$rule"
+    printf '\xe2\x9d\xaf\xc2\xa0\n'
+    printf '%s\n' "$rule"
+    printf '  Opus 5 (1M context) (xhigh) | Context: 47%% used\n'
+  } > "$resp/1.out"
+  fb=$(make_herdr_fakebin "$dir")
+  out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
+    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_composer_state default:w1:p2' "$ROOT" )
+  [ "$out" = empty ] \
+    || fail "a real claude empty composer padded with U+00A0 must read empty (this is the away-mode injection wedge), got '$out'"
+  pass "fm_backend_herdr_composer_state: claude's U+00A0-padded empty composer reads empty, not pending (the wedge fix)"
+}
+
+# The same row carrying real text must still refuse injection: the NBSP fold
+# must not become a general "treat a non-empty composer as empty" escape.
+test_composer_state_claude_nbsp_pad_with_text_is_pending() {
+  local dir log resp fb out rule
+  dir="$TMP_ROOT/composer-nbsp-text"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
+  rule=$(printf '\xe2\x94\x80%.0s' $(seq 53))
+  { printf '%s\n' "$rule"
+    printf '\xe2\x9d\xaf\xc2\xa0half-typed question for the captain\n'
+    printf '%s\n' "$rule"
+  } > "$resp/1.out"
+  fb=$(make_herdr_fakebin "$dir")
+  out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
+    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_composer_state default:w1:p2' "$ROOT" )
+  [ "$out" = pending ] \
+    || fail "real unsubmitted text after an NBSP pad must still read pending, got '$out'"
+  pass "fm_backend_herdr_composer_state: real text after a U+00A0 pad still reads pending (no over-strip)"
+}
+
 test_composer_state_ghost_placeholder_is_empty() {
   local dir log resp fb out
   dir="$TMP_ROOT/composer-ghost"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
@@ -3960,6 +4004,8 @@ test_busy_state_unknown_on_no_agent
 test_composer_state_bare_prompt_is_empty
 test_composer_state_ghost_placeholder_is_empty
 test_composer_state_real_text_is_pending
+test_composer_state_claude_nbsp_pad_is_empty
+test_composer_state_claude_nbsp_pad_with_text_is_pending
 test_composer_state_popup_placeholder_fill_is_pending
 test_composer_state_unknown_on_capture_failure
 test_composer_state_unknown_when_no_composer_row_found

--- a/tests/fm-composer-lib.test.sh
+++ b/tests/fm-composer-lib.test.sh
@@ -24,6 +24,77 @@ set -u
 # classify <bordered> <content> [idle_re] -> echoes the verdict.
 classify() { fm_composer_classify_content "$@"; }
 
+# --- Non-ASCII blank padding (task fm-afk-injection-wedge) -------------------
+#
+# A harness may pad an otherwise-empty composer row with a non-ASCII blank
+# instead of an ASCII space - verified real claude 2.x pads its EMPTY composer
+# with U+00A0 NO-BREAK SPACE. Bash's `[:space:]` trims treat no non-ASCII blank
+# as whitespace under any locale the fleet runs, so the pad survived every trim
+# as "real typed content", the row classified `pending`, and
+# the away-mode injector - which injects only into an affirmatively `empty`
+# composer - deferred every buffered escalation against an idle, injectable
+# primary until the captain came back.
+
+test_non_ascii_blank_pad_is_empty() {
+  local b out
+  # U+00A0 (the verified claude pad) plus the other blanks a TUI may pad with.
+  for b in $'\xc2\xa0' $'\xe2\x80\x87' $'\xe2\x80\xaf' $'\xe3\x80\x80' $'\xe2\x80\x8b' $'\xef\xbb\xbf'; do
+    out=$(classify 0 "❯${b}")
+    [ "$out" = empty ] \
+      || fail "an empty agent composer padded with a non-ASCII blank must read empty, got '$out'"
+    # Bordered callers hand over already-border-stripped content (see the
+    # <content> contract), so the box contributes only its blank pad.
+    out=$(classify 1 "$b")
+    [ "$out" = empty ] \
+      || fail "a bordered composer holding only a non-ASCII blank must read empty, got '$out'"
+  done
+  pass "fm_composer_classify_content: a composer padded with a non-ASCII blank reads empty, not pending (the away-mode injection wedge)"
+}
+
+test_non_ascii_blank_pad_with_text_is_pending() {
+  local out
+  # The fold must not become a general "non-empty composer reads empty" escape:
+  # any VISIBLE character still means unsubmitted work and must refuse injection.
+  out=$(classify 0 $'\xe2\x9d\xaf\xc2\xa0merge PR 512?')
+  [ "$out" = pending ] || fail "real text after a U+00A0 pad must stay pending, got '$out'"
+  out=$(classify 1 $'\xc2\xa0deploy staging\xc2\xa0')
+  [ "$out" = pending ] || fail "real text between U+00A0 pads must stay pending, got '$out'"
+  pass "fm_composer_classify_content: visible text surrounded by non-ASCII blanks still reads pending"
+}
+
+test_non_ascii_blank_pad_does_not_revive_a_dead_shell() {
+  local g out
+  # The dead-shell safety verdict must survive the fold: a bare shell prompt
+  # padded with U+00A0 is still an unsafe injection target, never empty.
+  for g in '>' '$' '%' '#'; do
+    out=$(classify 0 "${g}"$'\xc2\xa0')
+    [ "$out" = unknown ] \
+      || fail "a bare shell glyph '$g' padded with U+00A0 must stay unknown, got '$out'"
+  done
+  pass "fm_composer_classify_content: the non-ASCII blank fold does not weaken the dead-shell refusal"
+}
+
+# The subshell-local LC_ALL is the point of this test - each case must run under
+# C/POSIX without leaking that locale into the rest of the suite.
+# shellcheck disable=SC2030,SC2031
+test_multibyte_agent_glyph_is_stripped_whole() {
+  local out
+  # The leading glyph is removed as a literal prefix, not by character count:
+  # under the fleet's C/POSIX locale `${content#?}` drops one BYTE, which left
+  # the two trailing bytes of ❯ / › behind to re-read as real content.
+  # LC_ALL must be EXPORTED into the locale bash actually parses patterns under,
+  # so a bare `LC_ALL=C classify ...` command prefix would not exercise this.
+  out=$( export LC_ALL=C; classify 0 '❯' )
+  [ "$out" = empty ] || fail "a bare '❯' must read empty under LC_ALL=C, got '$out'"
+  out=$( export LC_ALL=C; classify 0 '❯ Type a message...' '^Type a message\.\.\.$' )
+  [ "$out" = empty ] \
+    || fail "an idle placeholder behind a multibyte glyph must read empty under LC_ALL=C, got '$out'"
+  out=$( export LC_ALL=C; classify 0 '› Type a message...' '^Type a message\.\.\.$' )
+  [ "$out" = empty ] \
+    || fail "an idle placeholder behind '›' must read empty under LC_ALL=C, got '$out'"
+  pass "fm_composer_classify_content: a multibyte agent glyph is stripped whole, locale-independently"
+}
+
 # --- Safety fix: bare shell prompt is NOT an empty agent composer -----------
 
 test_bare_shell_glyphs_are_unknown() {
@@ -125,6 +196,10 @@ test_real_text_is_pending() {
   pass "fm_composer_classify_content: real unsubmitted text reads pending (including a popup argument-hint fill)"
 }
 
+test_non_ascii_blank_pad_is_empty
+test_non_ascii_blank_pad_with_text_is_pending
+test_non_ascii_blank_pad_does_not_revive_a_dead_shell
+test_multibyte_agent_glyph_is_stripped_whole
 test_bare_shell_glyphs_are_unknown
 test_stripped_unbordered_content_uses_plain_content
 test_bare_shell_prompt_with_command_is_not_empty


### PR DESCRIPTION
## Intent

Diagnose and fix away mode buffering escalations for about eleven hours without delivering them.

INCIDENT AS REPORTED: On the first real overnight away-mode run (2026-07-28), escalations buffered correctly and every one replayed cleanly on return - nothing was lost - but the daemon could not inject into the primary session for 39,773 seconds, about eleven hours. The wedge alarm fired as designed and surfaced on the return catch-up. Consequence: away mode delivered durability but not responsiveness. Three decisions that should have been handled overnight sat until morning, which is the entire reason for running away mode rather than simply stopping.

CAUSE WAS NOT ESTABLISHED and the report deliberately did not guess. The recorded hypothesis, worth checking FIRST but explicitly NOT to be assumed: the injection guard requires an affirmatively empty composer AND an idle pane, and every verdict other than empty defers, so a persistently non-empty or unreadable primary composer would produce exactly this signature. The primary was a Claude session running a long agentic turn for much of that window. The first question to answer empirically was: does a mid-turn Claude pane ever read as injectable, and if not, is an eleven-hour turn simply outside what the guard was designed for?

REQUIRED APPROACH: (1) Establish the cause from recorded evidence before proposing a fix; if evidence is insufficient, reproduce it. (2) Fix so escalations reach the captain during a long primary turn, OR - if genuinely impossible with the current injection mechanism - say so plainly and propose what would be needed. An honest 'this needs a different delivery channel' was an explicitly valid outcome; a fix that appears to work but still defers silently was explicitly NOT acceptable. (3) Preserve durability: nothing was lost in the recorded incident and nothing may be lost after the change.

ACCEPTANCE CRITERIA: cause established with evidence rather than asserted; a captain-relevant escalation raised while the primary is mid-turn is delivered, or the reason it cannot be is documented with a concrete proposal; buffering and replay-on-return still lose nothing; covered by a test that reproduces the deferring condition; the rule that firstmate never arms a second watcher during away mode is preserved.

CONSTRAINTS: reproduce in a throwaway home, never against the primary checkout's live state/ records, because the live session supervising this work owns those away-mode records. Never pkill watcher or daemon processes, since that can kill sibling firstmate homes. Load and follow the firstmate-coding-guidelines skill before editing firstmate tracked material.

STANDING INSTRUCTION: until fixed, the captain is told plainly that away mode is safe but should not be relied on for overnight responsiveness. If the fix does not fully restore responsiveness, state exactly what it does and does not deliver rather than implying the limitation is gone.

WHAT I FOUND AND DECIDED (deliberate choices a reviewer reading only the diff would not know):

- The recorded mid-turn hypothesis is DISPROVEN, not adopted. The daemon log shows all three wedges dominated by 'state=pending' deferrals (2,792 on the incident day), while the busy branch a genuine mid-turn pane takes fired only 11 times in the entire log history. The incident is also not a one-off: three wedges of 7.8h (07-23), 11.0h (07-28) and 10.1h (07-31).

- ACTUAL CAUSE: Claude 2.x renders its EMPTY composer row as the agent glyph followed by U+00A0 NO-BREAK SPACE (bytes e2 9d af c2 a0). Bash's [:space:] trims treat no non-ASCII blank as whitespace under any locale the fleet runs (verified C, C.utf8, en_US.utf8, POSIX), so the pad survived every trim as apparent typed content and the row classified 'pending'. The injector types only into an affirmatively 'empty' composer, so it deferred against a pane that was idle and injectable the whole time. Reproduced live: the primary pane read busy=idle composer=pending before the change and composer=empty after.

- A SECOND, INDEPENDENT deferring condition was found and fixed in the same path: the leading prompt glyph was removed by character count, and under an exported C/POSIX locale bash's ${content#?} drops one BYTE, leaving the two trailing bytes of a multibyte glyph behind as spurious content. Verified to flip an idle placeholder composer from empty to pending. It is now removed as a literal prefix. This is not scope creep; it is a second instance of the same wedge class on the same code path.

- The fix lives in the ONE shared composer owner (bin/fm-composer-lib.sh) so every backend adapter (tmux, herdr, orca, cmux) gets it and the adapters cannot drift again, matching that file's existing consolidation rationale.

- SAFETY DIRECTION IS DELIBERATE AND ONE-WAY: the blank fold only ever folds INVISIBLE characters (non-ASCII blanks and zero-width characters), so any visible byte still reads 'pending' and the existing dead-shell refusal ('unknown' for a bare shell prompt) is untouched. Under-folding merely defers, which the max-defer alarm surfaces; over-folding would inject over real human input, which is the failure this must never cause. Tests cover both directions explicitly.

- THE INJECTION GUARD ITSELF IS DELIBERATELY UNCHANGED. It was fed a wrong verdict; it was not reasoning wrongly. Changing the guard would have weakened a safety boundary to work around a classifier bug.

- MID-TURN LIMITATION IS DELIBERATELY RETAINED AND DOCUMENTED, not silently fixed away. A genuinely mid-turn primary still defers on the busy guard, bounded by one turn and self-clearing, with the max-defer wedge alarm still covering a pathological one. Empirically negligible (11 occurrences ever against 5,548 deferrals), so no separate delivery channel is needed. This is recorded in docs/verification/supervision.md as a maintainer-verification fact with exact versions, commands and output, per the coding guidelines' knowledge-placement tree. AGENTS.md is deliberately NOT touched: this is a script-level bug fix with no contract change, and mechanics belong in script headers.

- EVIDENCE GATHERING RESPECTED THE CONSTRAINT: the live primary pane was only ever READ (read-only ANSI capture and classification). No live state/ record was written, no daemon or watcher was started, stopped or killed, and no second watcher was armed.

- TWO PRE-EXISTING, UNRELATED TEST FAILURES were found and deliberately NOT fixed here, to keep this change reviewable: tests/fm-calm-pi-extension.test.sh ('/calm left collapsed thinking labels') and tests/fm-test-run.test.sh (exits 1 on a stray 'comm: not in sorted order' while every assertion passes, so the runner reports failed=2 with zero 'not ok' lines). Both reproduce on a clean baseline with these changes stashed. They are reported upward for separate tracking rather than folded in.

- Regression tests were confirmed to FAIL on the pre-fix code and pass after, so they genuinely reproduce the deferring condition rather than merely asserting current behavior. Lint (bin/fm-lint.sh) and bin/fm-doc-audience-check.sh are clean.

## What Changed

- Normalize invisible Unicode composer padding and strip multibyte prompt glyphs literally, allowing idle composers to remain injectable under C/POSIX locales without weakening typed-input or dead-shell safeguards.
- Add shared classifier and Herdr regression coverage for Claude’s captured U+00A0-padded composer, multibyte prefixes, visible input, and shell prompts.
- Document the verified wedge cause, fleet-wide behavior, and the retained mid-turn busy-guard limitation with its existing alert-channel fallback.

## Risk Assessment

✅ Low: Captain, the change is well-bounded, fixes the proven classifier failure at the shared owner, preserves fail-closed injection and durability, and now documents the accepted mid-turn limitation with the existing out-of-band alert proposal.

## Testing

The base-to-target counterfactual established the cause, focused automated tests validated classification and safety boundaries, and isolated end-to-end checks demonstrated exactly-once Herdr delivery, durable buffering/replay, busy-pane deferral with preservation, wedge alarming, and the one-watcher invariant. No visual artifact was applicable because this is a shell daemon and terminal-integration change; CLI transcripts and persisted-buffer behavior are the end-user evidence.

<details>
<summary>Evidence: Cause and counterfactual evidence</summary>

<code>Recorded Claude empty composer row bytes: e2 9d af c2 a0 0d&#10;Baseline verdict: pending&#10;Fixed verdict: empty&#10;Visible draft remains: pending&#10;Bare shell prompt remains: unknown&#10;Baseline C-locale placeholder: pending&#10;Fixed C-locale placeholder: empty</code>

```text
Recorded Claude empty composer row bytes:  e2 9d af c2 a0 0d
Baseline verdict for ❯ + U+00A0: pending
Fixed verdict for ❯ + U+00A0: empty
Fixed verdict with visible captain draft: pending
Fixed verdict for bare shell prompt + U+00A0: unknown
Baseline C-locale multibyte-placeholder verdict: pending
Fixed C-locale multibyte-placeholder verdict: empty
```
</details>
<details>
<summary>Evidence: Real Herdr away-mode delivery</summary>

`All real-Herdr scenarios passed: clean delivery after idle, exactly-once delivery after a swallowed Enter, normal escalation delivery, and buffer preservation with a wedge alarm when delivery remained unsafe.`

```text
ok - real herdr Scenario A: partial input defers injection; digest arrives clean after idle
ok - real herdr Scenario B: swallowed Enter (via the herdr shim) produces exactly one clean digest
ok - real herdr Scenario C: a normal captain status injects exactly one clean single-line sentinel digest
ok - real herdr Scenario D: a persistently pending composer raises the max-defer wedge alarm, preserves the buffer, and never crashes the daemon
all real-herdr afk injection e2e tests passed
```
</details>
<details>
<summary>Evidence: Durable watcher-to-delivery lifecycle</summary>

`A terminal event survived watcher restart, buffered once without duplication, injected once, and cleared only after successful delivery.`

```text
ok - lifecycle: routine self-handles, terminal survives a watcher restart, buffers once, no dup, injects once
ok - lifecycle: stale pane transient self-handles, persistent escalates once and clears, resumed clears quietly
```
</details>
<details>
<summary>Evidence: One-watcher invariant</summary>

`Concurrent starts left exactly one watcher; singleton recovery and lifecycle checks completed successfully.`

```text
ok - simultaneous watcher starts leave exactly one live process
ok - fm_pid_identity real ps fallback is locale-invariant
ok - fm_pid_identity is locale-invariant across LC_ALL/LC_TIME
ok - /proc process identity ignores simulated btime changes
ok - /proc process identity detects pid reuse
ok - MSYS /proc process identity regression skipped on non-Windows host
ok - killed watcher stale lock is reclaimed
ok - live watcher lock with stale heartbeat is actionable
ok - guard banner leads when down with pending wakes (repair-after-drain) and stays silent when fresh
ok - concurrent fm_lock_try_acquire yields exactly one winner
ok - dead-pid stale lock is reclaimed by a single acquirer
ok - concurrent stale-lock steal yields exactly one winner
ok - live steal mutex is not reclaimed
ok - live-held lock is not stolen
ok - empty mid-acquire lock keeps a minimum grace
ok - late original claimant cannot claim a recreated lock
ok - paused mid-acquire claimant backs off to active stealer
ok - watch restart refuses to signal a reused pid
ok - watch restart attaches to a verified healthy peer and later surfaces a successor gap
ok - watcher self-evicts when the lock pid no longer names it
ok - arm turns clean self-eviction without a successor into a typed failure
ok - arm attaches to a live fresh watcher and fails loudly when that cycle has no successor
ok - attached arm signals record a classified lifecycle entry
ok - arm starts+confirms a fresh watcher on a clean lock and self-heals a dead-pid lock (never healthy off a dead pid)
ok - arm cleans child watcher and temp output on HUP
ok - arm propagates an immediate watcher wake before confirmation
ok - arm attaches to a peer watcher after child stands down and surfaces a missing successor
watcher: lock held by live pid 116225 but heartbeat is stale for 839124253s (>300s); inspect or stop that watcher before re-arming.
ok - arm reports FAILED and exits non-zero when no fresh watcher can be confirmed
ok - cycle-exit ledger links a verified successor and remains size-capped
ok - SIGSTOP distinguishes live PID from stale beacon and termination records the exit class
```
</details>
<details>
<summary>Evidence: Daemon guard and buffer-preservation checks</summary>

```text
ok - fm-afk-start.sh fails before daemon startup when the afk flag cannot be written
ok - fm-afk-start.sh ignores stale pidfile-only live pids
ok - fm-afk-start.sh reclaims stale daemon locks whose live pid identity no longer matches
ok - supervise daemon state root is scoped by FM_HOME
ok - routine signal self-handles
ok - captain-relevant status verbs escalate
ok - check + unknown escalate; heartbeat self-handles
ok - transient stale self-handles and records a persistence marker
ok - enriched stale wedges bypass status absorption without disturbing busy workers
ok - stale + terminal status escalates immediately
ok - paused reasons with captain phrases remain pause-classified
ok - handle_wake on a paused stale records a pause marker, drops the wedge marker, and does not escalate
ok - handle_wake records a declared pause from a routine signal for long-cadence rechecks
ok - a terminal signal clears pause and stale tracking across both supervisors
ok - housekeeping migrates a normal-watcher's declared pause into daemon tracking
ok - housekeeping clears an already-resumed watcher pause across both supervisors
ok - housekeeping seeds pause tracking from status without a watcher marker
ok - persistent stale escalates after threshold and clears its marker
ok - resumed (busy) stale clears its marker without escalating
ok - housekeeping re-surfaces a stale declared pause on the long cadence and resets its window
ok - housekeeping clears a paused marker whose pane became busy again, without escalating
ok - housekeeping clears a paused marker once the crew is no longer declaring the pause
ok - housekeeping moves an existing stale marker to pause before wedge escalation
ok - housekeeping clears tracking when a crew leaves pause
ok - persistent herdr stale resolves the target from metadata and escalates
ok - herdr idle busy-footer stale clears through capture corroboration
ok - resumed herdr stale clears through backend-aware busy state
ok - persistent Orca stale resolves the terminal from metadata
ok - multiple escalations flush as a single batched digest
ok - batch flush measures max-delay from the first append, not the last
ok - catch-all scan escalates a missed terminal once, not twice
ok - handle_wake routes routine->self and captain->escalate
ok - INJECT_SKIP forces self-handle, bypassing captain-relevant classification
ok - is_wake_reason distinguishes watcher wake reasons from singleton-status stdout
ok - terminal-stale escalate removes its marker so housekeeping does not re-escalate
ok - captain signal escalate marks seen so the catch-all scan does not re-fire
ok - _collapse_newlines replaces newlines with literal separator
ok - afk flag absent: daemon does not inject, buffer preserved
ok - busy-guard defers injection when supervisor pane is busy
ok - marker detection: marker -> stay afk, no marker -> exit afk
ok - /afk invocation is exempt from afk exit (no self-cancel)
ok - should_exit_afk returns false when afk is not active
ok - strip_injection_marker removes the sentinel marker cleanly
ok - pane_input_pending detects partial input on the cursor line
ok - pane_input_pending: blank cursor line is not pending
ok - pane_input_pending: only proven empty agent prompts pass
ok - fm_tmux_composer_state: a bare shell prompt ($/%/#/>) reads unknown, never empty (dead-shell injection safety)
ok - fm_tmux_composer_state: a bordered composer box and bare agent glyphs (❯/›) still read empty
ok - fm_tmux_composer_state: only matching edge borders form a composer box
ok - pane_input_pending honors FM_COMPOSER_IDLE_RE after border stripping
ok - classify_signal dedupes against the catch-all scan seen marker
ok - classify_stale dedupes against the signal path seen marker
ok - AFK nonterminal working:+merged keeps wedge aging and re-escalates at bound
ok - genuine done: and merge-check events still escalate
ok - pane_input_pending: an idle bordered composer is NOT pending (afk-invx-i5)
ok - pane_input_pending: text inside a bordered composer is still pending
ok - submit-ACK confirms a submit when the composer returns to a bordered-empty box
ok - submit-ACK reports pending on a persistently swallowed Enter (type-once)
ok - max-defer on an empty stuck pane types once, alarms, and preserves the buffer
ok - max-defer flushes and clears the buffer on an empty bordered pane
ok - max-defer on a pending composer alarms without typing
ok - normal flush clears a stale wedge marker
ok - below MAX_DEFER: no inject, no alarm, buffer preserved
ok - max-defer does not flush or alarm while afk is inactive
ok - library mode: sourcing the daemon defaults FM_WEDGE_ALARM_EXEC to discard (no test can fire a real notification)
ok - wake helpers replace inherited notifier overrides with the safe recorder
ok - the discard seam suppresses every notifier, including command: (fires nothing)
ok - direct notifier helpers honor the discard seam, including command:
ok - osascript channel routes through the notifier seam with the summary (never a real notification)
ok - herdr channel routes through the notifier seam with the summary (never a real notification)
ok - command channel runs the captain command with the summary on $1 and on stdin
ok - command channel failures redact configured commands while logging their exit status
ok - unknown channel directives are redacted while the alarm keeps running
ok - off disables every active alert regardless of directive position (marker and tmux flash are unaffected)
ok - auto resolves to the macOS osascript notifier on Darwin (default-on)
ok - auto on a non-macOS platform selects no built-in OS channel (the marker or a configured command carries it)
ok - config/wedge-alarm selects every configured channel and skips comment and blank lines
ok - a failing channel logs and falls back to the next channel, never crashing the alarm
ok - a hung notifier is bounded, logged, and falls through to the next channel
ok - a backgrounded command notifier remains bounded until its process group is reaped
ok - a hung notifier override is bounded, logged, and proceeds to the next channel
[1]+  Terminated              sh -c 'sleep 30 & printf "%s" "$!" > "$1"; wait' sh "$child_file"
ok - daemon shutdown stops and reaps the active notifier process group
ok - inject_wedge_alarm writes the marker AND emits the active alert even with no tmux status-line (herdr backend)
ok - in-process wedge throttle prevents alert spam when the marker cannot persist
ok - fm-send exits non-zero on a confirmed swallow, zero on a clean submit
ok - fm-send exits non-zero when initial text send fails
ok - fm-send exits non-zero unless delivery is proven empty
ok - discover_supervisor_backend: override > TMUX_PANE > HERDR_ENV+HERDR_PANE_ID > tmux fallback
ok - discover_supervisor_target: override > TMUX_PANE > herdr '<session>:<pane-id>' composition > firstmate:0 fallback
ok - pane_is_busy: herdr native busy_state='busy' short-circuits without a capture fallback
ok - primary busy guard isolates rendered signatures by detected harness
ok - pane_is_busy: omitted backend defaults to tmux for Grok's isolated fallback
ok - pane_input_pending: dispatches through fm_backend_composer_state for backend=herdr
ok - inject_msg: herdr busy-guard defers before ever attempting a submit
ok - inject_msg: herdr composer-guard defers before ever attempting a submit
ok - inject_msg: herdr pane-gone check defers before any busy/composer/submit call
ok - inject_msg: dispatches busy-guard/composer-guard/submit through the herdr backend and succeeds on a confirmed empty composer
ok - inject_msg: defers on a dead-shell/unreadable composer (unknown), never typing the escalation into a shell
ok - inject_msg: unrecognized composer states defer by default
```
</details>
<details>
<summary>Evidence: Composer regression checks</summary>

```text
ok - fm_composer_classify_content: a composer padded with a non-ASCII blank reads empty, not pending (the away-mode injection wedge)
ok - fm_composer_classify_content: visible text surrounded by non-ASCII blanks still reads pending
ok - fm_composer_classify_content: the non-ASCII blank fold does not weaken the dead-shell refusal
ok - fm_composer_classify_content: a multibyte agent glyph is stripped whole, locale-independently
ok - fm_composer_classify_content: a bare shell prompt glyph (>/$/%/#) reads unknown, never empty
ok - fm_composer_classify_content: stripped unbordered content is unknown except verified agent glyphs
ok - fm_composer_classify_content: a bare shell prompt carrying a command is not empty
ok - fm_composer_classify_content: a bare prompt glyph inside a bordered composer box reads empty (claude's own idle composer)
ok - fm_composer_classify_content: agent prompt glyphs (❯ claude, › codex) read empty bordered or bare
ok - fm_composer_classify_content: an empty composer reads empty
ok - fm_composer_classify_content: a known idle placeholder reads empty, before and after glyph stripping
ok - fm_composer_classify_content: idle matching preserves the caller's case mode
ok - fm_composer_classify_content: real unsubmitted text reads pending (including a popup argument-hint fill)
```
</details>
<details>
<summary>Evidence: Herdr adapter checks</summary>

```text
ok - fm_backend_herdr_version_check: accepts the current protocol (14)
ok - fm_backend_herdr_version_check: refuses an old protocol loudly
ok - fm_backend_herdr_version_check: refuses loudly when herdr is not installed
ok - fm_backend_herdr_workspace_label: a primary home (no marker) resolves to 'firstmate'
ok - fm_backend_herdr_workspace_label: a secondmate home (.fm-secondmate-home) resolves to '2ndmate-<id>'
ok - fm_backend_herdr_workspace_label: trims whitespace around the marker's secondmate id
ok - fm_backend_herdr_workspace_label: an empty marker file falls back to the primary label 'firstmate'
ok - fm_backend_herdr_workspace_label: two different secondmate homes get two different, non-colliding labels
ok - fm_backend_herdr_cli: sets HERDR_SESSION AND appends a trailing --session flag on every call
ok - fm_backend_herdr_launcher_identity: a firstmate not running inside herdr has no launcher workspace to inherit
ok - fm_backend_herdr_launcher_identity: HERDR_ENV=1 without a pane id selects the backend but binds no parent
ok - fm_backend_herdr_launcher_identity: resolves the launcher's exact workspace even when a same-labeled workspace sorts first
ok - fm_backend_herdr_launcher_identity: refuses a launcher pane that names a different herdr session
ok - fm_backend_herdr_launcher_identity: refuses a claimed pane without exact server identity
ok - fm_backend_herdr_launcher_identity: refuses a launcher pane whose injected socket belongs to another herdr server
ok - fm_backend_herdr_launcher_identity: refuses when the launcher's own pane no longer resolves
ok - fm_backend_herdr_launcher_identity: refuses when the launcher's pane and tab disagree about their workspace
ok - fm_backend_herdr_launcher_identity: refuses when the launcher's workspace is gone from its own session
ok - fm_backend_herdr_workspace_ensure: places a worker in the launcher's exact workspace, not the first same-labeled one
ok - fm_backend_herdr_workspace_ensure: refuses to guess between two same-labeled home workspaces
ok - fm_backend_herdr_workspace_ensure: a --secondmate container resolves that home's own workspace, not the launcher's
ok - fm_backend_herdr_container_ensure: surfaces the exact ambiguous-placement refusal instead of a generic failure
ok - fm_backend_herdr_container_ensure: version-gates, starts the server, ensures the firstmate workspace, echoes session:workspace_id + the seeded default tab id
ok - fm_backend_herdr_container_ensure: reuses an existing firstmate workspace without recreating it, and reports no seeded default tab (adopted, not created)
ok - fm_backend_herdr_container_ensure: workspace create passes --no-focus
ok - fm_backend_herdr_container_ensure: creates the workspace under the SECONDMATE home's own label, not 'firstmate'
ok - fm_backend_herdr_create_task: prunes exactly the seeded default tab container_ensure identified, once the first real task tab exists
ok - herdr repeated spawn/teardown: one persistent firstmate workspace reused, zero orphans, default tab pruned, create ran once
ok - fm_backend_herdr_create_task: an ADOPTED workspace's pre-existing tab is never pruned (the created-vs-adopted gate)
ok - fm_backend_herdr_create_task: the label-collision startup-workspace scenario (2026-07-02 incident) leaves the captain's live tab untouched
ok - fm_backend_herdr_workspace_prune_seeded_default_tab: refuses to close the seeded default tab when its pane reports a working agent (defense in depth)
ok - fm_backend_herdr_create_task: refuses a duplicate tab label (herdr's own tab create has no uniqueness check)
ok - fm_backend_herdr_create_task: a same-labeled tab with a live (even idle) registered agent still refuses exactly as before
ok - fm_backend_herdr_create_task: scans every same-labeled tab and refuses if any duplicate is live
ok - fm_backend_herdr_create_task: closes and replaces a same-labeled tab whose pane is dead (pane_not_found)
ok - fm_backend_herdr_create_task: closes and replaces a same-labeled tab whose pane is alive but hosts no registered agent (a restored plain shell)
ok - fm_backend_herdr_create_task: closes every confirmed same-labeled husk only after creating the replacement
ok - fm_backend_herdr_create_task: refuses success when a preexisting husk tab remains after replacement
ok - fm_backend_herdr_create_task: refuses (fail-safe) rather than guessing when the duplicate's agent state cannot be classified confidently
ok - fm_backend_herdr_create_task: creates the replacement tab BEFORE closing the husk tab, never the reverse
ok - fm_backend_herdr_create_task: creates a tab and parses tab_id/pane_id from the JSON response, prunes nothing when no seeded tab id is given
ok - fm_backend_herdr_create_task: tab create passes --no-focus
ok - herdr presentation journal: atomically publishes one non-authoritative 128-bit correlator and refuses overwrite
ok - herdr presentation journal: version 2 binds exact home/endpoint/parent identities and advances atomically
ok - herdr presentation create: exact response IDs yield one normal task pane with no workspace-close authority
ok - herdr presentation create: concurrent same-label tabs are never prune targets
ok - herdr presentation focus: snapshot requires one exact active workspace and tab
ok - herdr presentation focus: exact pane close restores the exact prior workspace and tab
ok - herdr presentation focus: cleanup refuses rather than close the captain's active tab
ok - herdr presentation focus: pane close fails when exact focus restoration fails
ok - herdr presentation reclaim: live agent state at the close boundary refuses mutation
ok - herdr presentation cleanup: emptying close behind focus ends the exact shell without a move or focus change
ok - herdr presentation cleanup: emptying close before focus moves the doomed workspace to the end and ends its exact shell
ok - herdr presentation cleanup: emptying close with the focused workspace last skips the move
ok - herdr presentation cleanup: emptying close of the last workspace skips the move
ok - herdr presentation cleanup: a non-emptying close stays plain with no proof, move, or signal
ok - herdr presentation cleanup: no-move plain close requires structured pane removal
ok - herdr presentation cleanup: an ambiguous workspace layout falls back to the plain close
ok - herdr presentation cleanup: a failed repositioning move falls back to the plain close with a warning
ok - herdr presentation cleanup: a pane with a live foreground process falls back to the plain close
ok - herdr presentation cleanup: a transient prompt helper settles into the pane-death path instead of the plain close
tests/fm-backend-herdr.test.sh: line 1493: 67379 Killed                  bash -c 'trap "" HUP; sleep 300'
ok - herdr presentation cleanup: a SIGHUP-surviving shell is escalated to SIGKILL before giving up
tests/fm-backend-herdr.test.sh: line 1531: 67572 Killed                  bash -c 'trap "" HUP; sleep 300'
ok - herdr presentation cleanup: a failed pane-death close falls back to the plain close
tests/fm-backend-herdr.test.sh: line 1564: 67797 Hangup                  sleep 300
ok - herdr presentation cleanup: the exact-tab restore remains the backstop behind the pane-death close
ok - herdr presentation cleanup: SIGKILL never reaches a pid the exact pane no longer owns
ok - herdr presentation cleanup: every unconfirmed removal restores the exact original workspace order and reports failure
tests/fm-backend-herdr.test.sh: line 1723: 68963 Hangup                  sleep 300
ok - fm_backend_herdr_kill: one session lock covers the focus-safe emptying removal
ok - fm_backend_herdr_kill: killing the focused workspace's tab keeps the legitimate plain close
ok - endpoint confirmed-gone: only structured not-found permits record removal and ambiguous identity refuses
ok - fm_backend_herdr_kill: unavailable session locks defer every pane close
ok - herdr presentation focus: projected seeded pruning refuses the active tab
ok - herdr presentation labels: └ concise-task · p:<full-token> for primary and secondmate children
ok - herdr presentation ordering: exact new workspace appends to the primary block while focus and relative orders stay stable
ok - herdr p

... [1552 bytes truncated] ...

 reclaim may proceed, otherwise spawning flat
ok - herdr presentation recovery: duplicate-token inspection is read-only and live-agent risk refuses fallback
ok - fm_backend_herdr_workspace_find: matches only THIS home's own label among several coexisting workspaces
ok - fm_backend_herdr_list_live: scoped to this home's own workspace, never a sibling home's
ok - fm_backend_herdr_parse_target: splits '<session>:<pane_id>' on the FIRST colon (pane_id itself contains one)
ok - fm_backend_herdr_normalize_key: Enter/Escape/C-c map to herdr's verified enter/escape/ctrl+c
ok - fm_backend_herdr_capture: calls 'pane read <pane> --source recent --lines N' with the session set
ok - fm_backend_herdr_capture: works around the verified small-N '--lines' bug by over-fetching and trimming locally
ok - fm_backend_herdr_capture: ensures the session and preserves pane read failure
ok - fm_backend_herdr_send_key: normalizes the key and targets the right pane
ok - fm_backend_herdr_kill: calls pane close and stays best-effort on failure
ok - fm_backend_herdr_current_path: reads pane foreground_cwd (the live running process), not the frozen creation-time cwd
ok - fm_backend_herdr_busy_state: working -> busy
ok - fm_backend_herdr_busy_state: done -> idle, blocked -> idle (surfaced like a stale pane, not suppressed as busy)
ok - fm_backend_herdr_busy_state: unparseable/absent agent state reports unknown, the regex-fallback cue
ok - fm_backend_herdr_composer_state: a bare '❯' composer row reads empty
ok - fm_backend_herdr_composer_state: the ghost placeholder text reads empty, not pending
ok - fm_backend_herdr_composer_state: real composer text reads pending
ok - fm_backend_herdr_composer_state: claude's U+00A0-padded empty composer reads empty, not pending (the wedge fix)
ok - fm_backend_herdr_composer_state: real text after a U+00A0 pad still reads pending (no over-strip)
ok - fm_backend_herdr_composer_state: a slash-command popup's argument-hint placeholder still reads pending (the incident fix)
ok - fm_backend_herdr_composer_state: reports unknown when the pane cannot be captured
ok - fm_backend_herdr_composer_state: reports unknown for bare shell prompts with no composer row
ok - fm_backend_herdr_composer_state: a native idle Pi separator composer reads empty
ok - fm_backend_herdr_composer_state: real Pi composer text remains pending
ok - fm_backend_herdr_composer_state: an incomplete lower Pi separator cannot inherit a stale empty row
ok - fm_backend_herdr_composer_state: Pi separators never authorize working, non-Pi, unreadable, or over-tall targets
ok - fm_backend_herdr_composer_state: a real-claude unbordered '❯' prompt row (no border box in view) reads empty
ok - fm_backend_herdr_composer_state: a real-claude unbordered '❯ <text>' prompt row reads pending
ok - fm_backend_herdr_composer_state: a live unbordered prompt row below a stale bordered decorative box still wins (not misread as the box's own row)
ok - fm_backend_herdr_composer_state: claude's dim prompt-suggestion ghost (the overnight wedge shape) reads empty
ok - fm_backend_herdr_composer_state: real typed text on the same claude prompt row still reads pending
ok - fm_backend_herdr_composer_state: grok's dark-truecolor placeholder (the TRUECOLOR gap) reads empty
ok - fm_backend_herdr_composer_state: grok's real bright typed input still reads pending
ok - fm_backend_herdr_composer_state: a real-codex unbordered '›' prompt row reads empty
ok - fm_backend_herdr_composer_state: a faint real-codex ghost suggestion reads empty
ok - fm_backend_herdr_composer_state: non-faint codex prompt text still reads pending
ok - fm_backend_herdr_wait_for_working: reports 'busy' immediately on the first poll, without spending the rest of the budget
ok - fm_backend_herdr_wait_for_working: a slow transition landing on a later sample within one window is still caught (robust against the 'slow transition' failure direction)
ok - fm_backend_herdr_wait_for_working: spreads six samples across the full budget endpoint without a final trailing sleep
ok - fm_backend_herdr_send_text_submit: applies the herdr minimum confirmation budget before polling agent-state
ok - fm_backend_herdr_wait_for_working: reports 'idle' (readable, genuinely not yet working) when 'busy' never appears
ok - fm_backend_herdr_wait_for_working: reports 'unknown' (a hard read failure, not a timing race) only when EVERY poll in the window fails
ok - fm_backend_herdr_wait_for_working: treats blocked as submit-active for confirmation without changing watcher busy-state semantics
ok - fm_backend_herdr_send_text_submit: reports 'empty' once agent_status reports working after one Enter, without ever reading the composer
ok - fm_backend_herdr_send_text_submit: reports 'pending' when agent_status never reports working after retried Enters (swallowed)
ok - fm_backend_herdr_send_text_submit: a slash-command popup's placeholder fill on Enter #1 never flips agent_status to working, so it does not short-circuit as submitted; Enter #2 is retried and lands it
ok - fm_backend_herdr_send_text_submit: a post-Enter blocked state confirms delivery without retrying into the prompt
ok - fm_backend_herdr_send_text_submit: preexisting working is not accepted as submit proof when the composer still holds the message
ok - fm_backend_herdr_send_text_submit: confirms submission via native agent-state alone, immune to a codex-style dynamic idle-tip composer that would have misread as 'pending' under the old composer-based confirmation
ok - fm_backend_herdr_composer_state: a faint real-codex dynamic idle-tip composer row reads empty
ok - fm_backend_composer_state (herdr): the pre-injection empty-box guard still refuses a genuinely non-empty composer, unaffected by the submit-confirmation change
ok - fm_backend_herdr_send_text_submit: a slow transition landing on a later sample within one Enter's budget is confirmed WITHOUT sending a needless extra Enter
ok - fm_backend_herdr_send_text_submit: reports 'send-failed' when the literal send-text call itself errors
ok - fm_backend_herdr_send_text_submit: reports 'unknown' when the post-Enter agent-get read fails (never retries past an unreadable target)
ok - fm_backend_validate: herdr is a known backend (P2)
ok - fm_backend_busy_state: tmux (no native primitive) always reports unknown, preserving the P1 regex-only path
error: unknown backend 'bogus' (known: tmux herdr zellij orca cmux)
ok - fm_backend_composer_state dispatches tmux/herdr/orca to their named classifiers, unknown for zellij/unrecognized backends
ok - fm-peek/fm-send: explicit stale targets matching metadata use the recorded backend
ok - fm_backend_herdr_normalize_event routes through the shared record with an empty from_status
ok - fm_backend_herdr_escalation_marker keys the dedupe marker exactly like the watcher's .stale-<key>
ok - fm_backend_herdr_apply_transition: blocked dedupe starts only after explicit commit
ok - fm_backend_herdr_apply_transition: a working edge clears the marker so the next ->blocked re-escalates
ok - fm_backend_herdr_clear_transition removes task-owned dedupe state
ok - fm_backend_herdr_apply_transition: idle/done (defer) and unknown/empty (fallback) take no fast action
ok - fm_backend_herdr_wait_transition: a home with no herdr panes falls back to polling (rc 2)
ok - fm_backend_herdr_wait_transition: below-capability protocol/schema falls back to polling (rc 2)
ok - fm_backend_herdr_wait_transition: reconnect level-reconcile returns an uncommitted blocked pane
ok - fm_backend_herdr_wait_transition: subscribes before reconnect level-reconcile
ok - fm_backend_herdr_wait_transition: a still-blocked, already-escalated pane is not re-delivered on reconnect
ok - fm_backend_herdr_wait_transition: a streamed ->blocked edge returns the record sub-poll
ok - fm_backend_herdr_wait_transition: streamed working clears the marker, idle/done are deferred (clean timeout)
ok - fm_backend_herdr_wait_transition: a reader/subscribe failure falls back to polling (rc 2)
ok - fm_backend_herdr_wait_transition: Bash 3.2-safe bad-ack path closes fd 9 and removes its FIFO
ok - fm_backend_herdr_wait_transition: stock macOS Bash clean timeout closes fd 9 and returns 1
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- 🚨 `docs/verification/supervision.md:285` - The required approach says escalations must &#34;reach the captain during a long primary turn&#34; or the change must document why that is impossible and provide a concrete proposal. This hunk instead says delivery waits until the turn ends. The reachable sequence remains: `escalate_flush` calls `inject_msg`, the busy guard returns failure, the durable buffer is retained, and every housekeeping retry follows the same path for the entire potentially unbounded turn. Captain approval is needed either to waive this criterion or to add a concrete out-of-band proposal, such as sending the digest through the existing backend-independent alert channel while retaining it for replay.

🔧 Fix: Document mid-turn escalation delivery limitation
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `tests/fm-composer-lib.test.sh`
- `tests/fm-backend-herdr.test.sh`
- `tests/fm-daemon.test.sh`
- `tests/fm-wake-daemon-lifecycle-e2e.test.sh`
- `tests/fm-watcher-lock.test.sh`
- <code>`tests/fm-afk-inject-herdr-e2e.test.sh` against Herdr 0.7.5 in its isolated named lab</code>
- <code>Compared base `1e247571aa75e00b00c7a01c4830025ecd44dc61` and target classifiers using the captured `e2 9d af c2 a0` row and the exported `LC_ALL=C` multibyte-prompt case</code>
- <code>Verified `git status --short` remained clean and no test watcher or Herdr lab process remained</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
