### PR TITLE
feat(bin): surface documentation-vault drift during bootstrap

### DIFF
--- a/.agents/skills/bootstrap-diagnostics/SKILL.md
+++ b/.agents/skills/bootstrap-diagnostics/SKILL.md
@@ -31,6 +31,7 @@ When any diagnostic needs captain attention, report the plain consequence and re
   An `in-repo vault stale` line is ordinary project work: brief a crewmate to refresh that vault in its own worktree through the project's selected delivery path.
   An `external vault stale` line names a vault that lives in a SEPARATE repo, which an isolated project worktree structurally cannot write; dispatch that work against the vault repo's own clone instead, and never tell a crewmate to write the captain's live copy.
   An `external vault link absent` or `link broken` line means drift cannot be measured there at all - the exact blindness this check exists to end - so treat restoring the link (or registering the vault repo as its own project) as the fix, and do not read the missing measurement as "the vault is current".
+  An `external vault target invalid` line means a declared location lacks the OKF marker or a recognized bundle is not backed by Git; correct the target or declaration before treating it as a measurable vault.
   The check is detection only by design: a vault is curated knowledge, so never auto-write one, and never modify a project clone to silence the line.
 - `STARTUP_MEMORY_BUDGET: invalid config/startup-memory-budget - <reason>` - the visible startup-memory budget is not a safe one-line positive decimal file; do not infer the default or propagate it.
   Correct the local primary file, then rerun session start so the normal convergence path can deliver the validated value to secondmate homes.

--- a/.agents/skills/bootstrap-diagnostics/SKILL.md
+++ b/.agents/skills/bootstrap-diagnostics/SKILL.md
@@ -31,7 +31,7 @@ When any diagnostic needs captain attention, report the plain consequence and re
   An `in-repo vault stale` line is ordinary project work: brief a crewmate to refresh that vault in its own worktree through the project's selected delivery path.
   An `external vault stale` line names a vault that lives in a SEPARATE repo, which an isolated project worktree structurally cannot write; dispatch that work against the vault repo's own clone instead, and never tell a crewmate to write the captain's live copy.
   An `external vault link absent` or `link broken` line means drift cannot be measured there at all - the exact blindness this check exists to end - so treat restoring the link (or registering the vault repo as its own project) as the fix, and do not read the missing measurement as "the vault is current".
-  An `external vault target invalid` line means a declared location lacks the OKF marker or a recognized bundle is not backed by Git; correct the target or declaration before treating it as a measurable vault.
+  An `external vault target invalid` line means a declared location lacks the OKF marker or a recognized bundle is not backed by a separate Git repository; correct the target or declaration before treating it as a measurable vault.
   The check is detection only by design: a vault is curated knowledge, so never auto-write one, and never modify a project clone to silence the line.
 - `STARTUP_MEMORY_BUDGET: invalid config/startup-memory-budget - <reason>` - the visible startup-memory budget is not a safe one-line positive decimal file; do not infer the default or propagate it.
   Correct the local primary file, then rerun session start so the normal convergence path can deliver the validated value to secondmate homes.

--- a/.agents/skills/bootstrap-diagnostics/SKILL.md
+++ b/.agents/skills/bootstrap-diagnostics/SKILL.md
@@ -12,7 +12,7 @@ metadata:
 # bootstrap-diagnostics
 
 Handle each printed line as below, before dispatching work that depends on it.
-The line formats themselves are owned by `bin/fm-bootstrap.sh`'s header; this playbook owns the response to actionable lines.
+The top-level diagnostic vocabulary is owned by `bin/fm-bootstrap.sh`'s header, delegated detector headers own their exact subtype wording, and this playbook owns the response to actionable lines.
 The inline rules in `AGENTS.md` section 3 still bind: detect, then consent, then install - never install anything the captain has not approved in this session - and no work is dispatched until the tools it needs are present and GitHub auth is good.
 When any diagnostic needs captain attention, report the plain consequence and requested action using `AGENTS.md` section 9's captain-facing translation contract; do not name the diagnostic label unless the captain needs to paste it into a command or issue.
 
@@ -27,7 +27,7 @@ When any diagnostic needs captain attention, report the plain consequence and re
 - `TANGLE: <remediation>` - the primary checkout is stranded on a feature branch instead of its default branch; `AGENTS.md` section 8 explains why this guard exists and what it protects.
   The work is safe on that branch ref; restore the primary to its default branch with the printed `git -C <root> checkout <default>`, then re-validate that branch in a proper worktree.
   This is the only sanctioned firstmate-initiated git write to the primary, and it is a non-destructive branch switch that strands nothing.
-- `VAULT_DRIFT: <project>: <vault problem and remedy>` - a project's documentation vault has drifted, and the line already names which of the two shapes it is, because they need different remedies.
+- `VAULT_DRIFT: <project>: <vault problem and remedy>` - a project's documentation vault is stale or its declared external location cannot be measured, and the line names the shape and problem because they need different remedies.
   An `in-repo vault stale` line is ordinary project work: brief a crewmate to refresh that vault in its own worktree through the project's selected delivery path.
   An `external vault stale` line names a vault that lives in a SEPARATE repo, which an isolated project worktree structurally cannot write; dispatch that work against the vault repo's own clone instead, and never tell a crewmate to write the captain's live copy.
   An `external vault link absent` or `link broken` line means drift cannot be measured there at all - the exact blindness this check exists to end - so treat restoring the link (or registering the vault repo as its own project) as the fix, and do not read the missing measurement as "the vault is current".

--- a/.agents/skills/bootstrap-diagnostics/SKILL.md
+++ b/.agents/skills/bootstrap-diagnostics/SKILL.md
@@ -2,7 +2,7 @@
 name: bootstrap-diagnostics
 description: >-
   Agent-only handling playbook for session-start bootstrap diagnostics.
-  Use whenever the session-start digest's bootstrap section prints an actionable diagnostic line - MISSING, MISSING_MANUAL, BACKEND_INVALID, NEEDS_GH_AUTH, TANGLE, STARTUP_MEMORY_BUDGET, CREW_DISPATCH invalid, FLEET_SYNC, PR_CHECK_MIGRATION, SECONDMATE_SYNC, SECONDMATE_LIVENESS, SECONDMATE_HANDOFF, NUDGE_SECONDMATES, or FMX - or when a standalone bin/fm-bootstrap.sh run prints one of those lines.
+  Use whenever the session-start digest's bootstrap section prints an actionable diagnostic line - MISSING, MISSING_MANUAL, BACKEND_INVALID, NEEDS_GH_AUTH, TANGLE, VAULT_DRIFT, STARTUP_MEMORY_BUDGET, CREW_DISPATCH invalid, FLEET_SYNC, PR_CHECK_MIGRATION, SECONDMATE_SYNC, SECONDMATE_LIVENESS, SECONDMATE_HANDOFF, NUDGE_SECONDMATES, or FMX - or when a standalone bin/fm-bootstrap.sh run prints one of those lines.
   A silent bootstrap section, or a BOOTSTRAP_INFO fact, means no skill load.
 user-invocable: false
 metadata:
@@ -27,6 +27,11 @@ When any diagnostic needs captain attention, report the plain consequence and re
 - `TANGLE: <remediation>` - the primary checkout is stranded on a feature branch instead of its default branch; `AGENTS.md` section 8 explains why this guard exists and what it protects.
   The work is safe on that branch ref; restore the primary to its default branch with the printed `git -C <root> checkout <default>`, then re-validate that branch in a proper worktree.
   This is the only sanctioned firstmate-initiated git write to the primary, and it is a non-destructive branch switch that strands nothing.
+- `VAULT_DRIFT: <project>: <vault problem and remedy>` - a project's documentation vault has drifted, and the line already names which of the two shapes it is, because they need different remedies.
+  An `in-repo vault stale` line is ordinary project work: brief a crewmate to refresh that vault in its own worktree through the project's selected delivery path.
+  An `external vault stale` line names a vault that lives in a SEPARATE repo, which an isolated project worktree structurally cannot write; dispatch that work against the vault repo's own clone instead, and never tell a crewmate to write the captain's live copy.
+  An `external vault link absent` or `link broken` line means drift cannot be measured there at all - the exact blindness this check exists to end - so treat restoring the link (or registering the vault repo as its own project) as the fix, and do not read the missing measurement as "the vault is current".
+  The check is detection only by design: a vault is curated knowledge, so never auto-write one, and never modify a project clone to silence the line.
 - `STARTUP_MEMORY_BUDGET: invalid config/startup-memory-budget - <reason>` - the visible startup-memory budget is not a safe one-line positive decimal file; do not infer the default or propagate it.
   Correct the local primary file, then rerun session start so the normal convergence path can deliver the validated value to secondmate homes.
 - `CREW_DISPATCH: invalid config/crew-dispatch.json - <reason>` - the optional dispatch profile file exists but failed low-cost bootstrap validation; stop profile-based dispatch, report the actionable error, and require correction of the malformed schema, unverified harness name, or invalid harness/effort pair rather than falling back around it or selecting a bad profile.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -495,7 +495,7 @@ It performs guarded fast-forward updates of firstmate and registered secondmate 
 
 These skills are not captain-invocable; load them only at their precise triggers.
 
-- `bootstrap-diagnostics` - load whenever the session-start digest's bootstrap section prints an actionable diagnostic line (`MISSING:`, `MISSING_MANUAL:`, `BACKEND_INVALID:`, `NEEDS_GH_AUTH`, `TANGLE:`, `STARTUP_MEMORY_BUDGET:`, `CREW_DISPATCH: invalid`, `FLEET_SYNC:`, `PR_CHECK_MIGRATION:`, `SECONDMATE_SYNC:`, `SECONDMATE_LIVENESS:`, `SECONDMATE_HANDOFF:`, `NUDGE_SECONDMATES:`, or `FMX:`); silence and `BOOTSTRAP_INFO:` need no load.
+- `bootstrap-diagnostics` - load whenever the session-start digest's bootstrap section prints an actionable diagnostic line (`MISSING:`, `MISSING_MANUAL:`, `BACKEND_INVALID:`, `NEEDS_GH_AUTH`, `TANGLE:`, `VAULT_DRIFT:`, `STARTUP_MEMORY_BUDGET:`, `CREW_DISPATCH: invalid`, `FLEET_SYNC:`, `PR_CHECK_MIGRATION:`, `SECONDMATE_SYNC:`, `SECONDMATE_LIVENESS:`, `SECONDMATE_HANDOFF:`, `NUDGE_SECONDMATES:`, or `FMX:`); silence and `BOOTSTRAP_INFO:` need no load.
 - `diagnostic-reasoning` - load before scoping a reported bug and before acting on a diagnostic report.
 - `ask-user-authority` - load before deciding any ask-user finding, regardless of the project's `yolo` posture.
 - `quota-array-dispatch` - load before choosing among a matched crew-dispatch profile array from current quota-axi output.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -140,7 +140,7 @@ If the session lock cannot be acquired and verified, report its exact diagnostic
 A lock-refused session must not spawn, steer, merge, drain the wake queue, repair supervision, repair a checkout, or perform any other fleet mutation.
 
 1. **Lock** - acquires the per-home session lock first, before anything mutates shared state.
-2. **Bootstrap** - detect-only checks (tool/version problems, GitHub auth, the worktree-tangle check, harness override, dispatch-profile validation, backlog-backend status) always run, but routine confirmations stay silent by default.
+2. **Bootstrap** - detect-only checks (tool/version problems, GitHub auth, the worktree-tangle check, documentation-vault drift, harness override, dispatch-profile validation, backlog-backend status) always run, but routine confirmations stay silent by default.
    When the lock could not be acquired, the worktree-tangle check uses read-only advisory wording without a checkout repair command.
    Home-local stale Herdr projection cleanup and the six bootstrap MUTATING sweeps - non-executing legacy PR-check migration, fleet sync, secondmate convergence, secondmate liveness, pending remote handoff retry, and X-mode artifact writes - run only when this session actually holds the lock from step 1.
    The secondmate liveness sweep deterministically accounts for every registered secondmate: it relaunches only from the recovery-grade `dead` or `missing` states, preserves ambiguous, unreadable, or unreachable remote targets, and reports skipped or failed guarantees as `SECONDMATE_LIVENESS:` lines (`bin/fm-bootstrap.sh`; `bin/fm-backend.sh`'s `fm_backend_agent_state`; `docs/remote-secondmates.md`).

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -210,6 +210,11 @@ fleet_sync() {
   rm -f "$tmp"
 }
 
+vault_drift_check() {
+  FM_HOME="$FM_HOME" FM_PROJECTS_OVERRIDE="$PROJECTS" FM_DATA_OVERRIDE="$DATA" \
+    "$SCRIPT_DIR/fm-vault-drift.sh" || true
+}
+
 secondmate_sync() {
   # shellcheck source=bin/fm-wake-lib.sh disable=SC1091
   . "$SCRIPT_DIR/fm-wake-lib.sh"
@@ -1020,11 +1025,13 @@ if [ -n "$tangle_branch" ]; then
     echo "TANGLE: primary checkout on feature branch '$tangle_branch' (expected '$tangle_default'); the work is safe on that ref - restore the primary with: git -C $FM_ROOT checkout $tangle_default, then re-validate the branch in a proper worktree"
   fi
 fi
-# Documentation-vault drift: read-only inspection of the project clones, so it
-# runs in detect-only sessions too. bin/fm-vault-drift.sh owns the shapes,
+# Documentation-vault drift is read-only, so a detect-only session can inspect
+# the clones immediately. A normal session checks after fleet sync below so it
+# inspects the resulting clone state. bin/fm-vault-drift.sh owns the shapes,
 # thresholds, and line wording.
-FM_HOME="$FM_HOME" FM_PROJECTS_OVERRIDE="$PROJECTS" FM_DATA_OVERRIDE="$DATA" \
-  "$SCRIPT_DIR/fm-vault-drift.sh" || true
+if [ "${FM_BOOTSTRAP_DETECT_ONLY:-0}" = 1 ]; then
+  vault_drift_check
+fi
 crew=
 [ -f "$CONFIG/crew-harness" ] && crew=$(tr -d '[:space:]' < "$CONFIG/crew-harness" || true)
 if [ "${FM_BOOTSTRAP_VERBOSE_FACTS:-0}" = 1 ] && [ -n "$crew" ] && [ "$crew" != "default" ]; then
@@ -1041,6 +1048,7 @@ if [ "${FM_BOOTSTRAP_DETECT_ONLY:-0}" != 1 ]; then
   secondmate_handoff_resume
   x_mode_setup
   fleet_sync
+  vault_drift_check
 fi
 secondmate_handoff_detect
 exit 0

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -13,6 +13,7 @@
 #                 "FLEET_SYNC: <repo>: skipped|recovered|STUCK: <detail>",
 #                 "PR_CHECK_MIGRATION: <private remediation>",
 #                 "TANGLE: <remediation>",
+#                 "VAULT_DRIFT: <project>: <vault problem and remedy>",
 #                 "SECONDMATE_SYNC: secondmate <id>: skipped: <reason>",
 #                 "NUDGE_SECONDMATES: secondmate <id>: send failed: <reason>",
 #                 "BOOTSTRAP_INFO: nudged fm-<id> with '<message>'",
@@ -48,6 +49,11 @@
 #          A TANGLE line means the firstmate primary checkout (FM_ROOT) is stranded
 #          on a feature branch instead of its default branch - a crewmate's work
 #          landed in the primary instead of its own worktree; restore it per the line.
+#          A VAULT_DRIFT line means a project's documentation vault is stale, or
+#          its external vault link is absent or broken so drift cannot be
+#          measured at all; the check is read-only and runs in detect-only
+#          sessions too. bin/fm-vault-drift.sh owns the vault shapes, thresholds,
+#          and exact wording.
 #          treehouse is also MISSING when its installed version lacks
 #          "treehouse get --lease" support.
 #          no-mistakes is also MISSING when its installed version is older than
@@ -1014,6 +1020,11 @@ if [ -n "$tangle_branch" ]; then
     echo "TANGLE: primary checkout on feature branch '$tangle_branch' (expected '$tangle_default'); the work is safe on that ref - restore the primary with: git -C $FM_ROOT checkout $tangle_default, then re-validate the branch in a proper worktree"
   fi
 fi
+# Documentation-vault drift: read-only inspection of the project clones, so it
+# runs in detect-only sessions too. bin/fm-vault-drift.sh owns the shapes,
+# thresholds, and line wording.
+FM_HOME="$FM_HOME" FM_PROJECTS_OVERRIDE="$PROJECTS" FM_DATA_OVERRIDE="$DATA" \
+  "$SCRIPT_DIR/fm-vault-drift.sh" || true
 crew=
 [ -f "$CONFIG/crew-harness" ] && crew=$(tr -d '[:space:]' < "$CONFIG/crew-harness" || true)
 if [ "${FM_BOOTSTRAP_VERBOSE_FACTS:-0}" = 1 ] && [ -n "$crew" ] && [ "$crew" != "default" ]; then

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -174,7 +174,7 @@ family_for_basename() {
       ;;
     fm-bootstrap.test.sh|fm-fleet-sync.test.sh|fm-gate-refuse.test.sh|fm-gotmp.test.sh|\
     fm-session-start.test.sh|fm-sessionstart-nudge.test.sh|fm-tangle-guard.test.sh|\
-    fm-update.test.sh)
+    fm-update.test.sh|fm-vault-drift.test.sh)
       printf '%s\n' session-bootstrap
       ;;
     fm-afk-pi-herdr-return-e2e.test.sh|\
@@ -581,8 +581,8 @@ run_coverage_guard() {
     return 1
   fi
   cat "$tmp/s1" "$tmp/s2" | LC_ALL=C sort -u >"$tmp/shards_union"
-  missing=$(comm -23 "$tmp/proven" "$tmp/shards_union" || true)
-  extra=$(comm -13 "$tmp/proven" "$tmp/shards_union" || true)
+  missing=$(LC_ALL=C comm -23 "$tmp/proven" "$tmp/shards_union" || true)
+  extra=$(LC_ALL=C comm -13 "$tmp/proven" "$tmp/shards_union" || true)
   if [ -n "$missing" ] || [ -n "$extra" ]; then
     log "coverage guard: portable shards must equal the proven-isolated set"
     [ -z "$missing" ] || { log "missing from shards:"; printf '%s\n' "$missing" >&2; }
@@ -639,7 +639,7 @@ run_coverage_guard() {
   for pair in "shards_union:serial" "shards_union:herdr" "serial:herdr"; do
     a=${pair%%:*}
     b=${pair#*:}
-    comm -12 "$tmp/$a" "$tmp/$b" >"$tmp/overlap"
+    LC_ALL=C comm -12 "$tmp/$a" "$tmp/$b" >"$tmp/overlap"
     if [ -s "$tmp/overlap" ]; then
       log "coverage guard: overlap between $a and $b:"
       cat "$tmp/overlap" >&2
@@ -657,8 +657,8 @@ run_coverage_guard() {
     return 1
   fi
   LC_ALL=C sort -u "$tmp/union_raw" >"$tmp/union"
-  missing=$(comm -23 "$tmp/all" "$tmp/union" || true)
-  extra=$(comm -13 "$tmp/all" "$tmp/union" || true)
+  missing=$(LC_ALL=C comm -23 "$tmp/all" "$tmp/union" || true)
+  extra=$(LC_ALL=C comm -13 "$tmp/all" "$tmp/union" || true)
   if [ -n "$missing" ] || [ -n "$extra" ]; then
     log "coverage guard: union of portable shards + portable serial + Herdr must equal tests/*.test.sh"
     [ -z "$missing" ] || { log "missing from union:"; printf '%s\n' "$missing" >&2; }
@@ -671,7 +671,7 @@ run_coverage_guard() {
     "$ROOT/bin/fm-test-isolation-proof.sh" --list | LC_ALL=C sort -u >"$tmp/proof_list"
     if ! cmp -s "$tmp/proven" "$tmp/proof_list"; then
       log "coverage guard: embedded proven-isolated set diverges from bin/fm-test-isolation-proof.sh --list"
-      comm -3 "$tmp/proven" "$tmp/proof_list" >&2 || true
+      LC_ALL=C comm -3 "$tmp/proven" "$tmp/proof_list" >&2 || true
       rm -rf "$tmp"
       return 1
     fi

--- a/bin/fm-vault-drift.sh
+++ b/bin/fm-vault-drift.sh
@@ -21,7 +21,8 @@
 #     00-Home.md, which is an IN-REPO vault (a tracked directory named vault
 #     WITHOUT that marker is some other directory - e.g. a test fixture - and is
 #     deliberately ignored, so it can never raise a false alarm);
-#   - a root-level "vault" symlink, however it got there.
+#   - a root-level "vault" symlink whose resolved target carries the OKF marker,
+#     however it got there.
 #
 # Each location is classified and reported as one of:
 #   link absent    - an external vault is declared but nothing is linked here, so
@@ -29,6 +30,8 @@
 #                    hides staleness, and it is reported separately from staleness
 #                    because the remedy is different.
 #   link broken    - the symlink exists but its target does not.
+#   target invalid - a declared location resolves without the OKF marker, or a
+#                    recognized bundle is not in a Git repository.
 #   in-repo vault stale   - fixable inside an ordinary project worktree.
 #   external vault stale  - NOT fixable from a project worktree: the vault is a
 #                    separate repo, so the work belongs to that repo's own clone.
@@ -176,10 +179,19 @@ report_stale() {
   esac
 }
 
-# check_external <name> <proj> <rel> <vault-repo-dir> <detail-suffix>
+# check_external <name> <proj> <rel> <vault-repo-dir> <detail-suffix> <declared>
 check_external() {
-  local name=$1 proj=$2 rel=$3 dir=$4 suffix=$5 top vault_ts vault_date head_ts behind
-  top=$(git -C "$dir" rev-parse --show-toplevel 2>/dev/null) || return 0
+  local name=$1 proj=$2 rel=$3 dir=$4 suffix=$5 declared=$6 top vault_ts vault_date head_ts behind
+  if [ ! -f "$dir/$VAULT_MARKER" ]; then
+    if [ "$declared" -eq 1 ]; then
+      report "$name" "external vault target invalid at $rel$suffix - $VAULT_MARKER marker missing, so this declared location is not a valid OKF bundle and vault drift cannot be measured"
+    fi
+    return 0
+  fi
+  if ! top=$(git -C "$dir" rev-parse --show-toplevel 2>/dev/null); then
+    report "$name" "external vault target invalid at $rel$suffix - the OKF bundle is not in a Git repository, so vault drift cannot be measured"
+    return 0
+  fi
   vault_ts=$(git -C "$top" log -1 --format=%ct 2>/dev/null) || return 0
   [ -n "$vault_ts" ] || return 0
   vault_date=$(git -C "$top" log -1 --format=%cd --date=short 2>/dev/null) || return 0
@@ -207,29 +219,34 @@ check_in_repo() {
 # check_location <name> <proj> <rel>: classify one candidate location by what is
 # actually on disk and in the index, and report only a real problem.
 check_location() {
-  local name=$1 proj=$2 rel=$3 full="$2/$3" target
+  local name=$1 proj=$2 rel=$3 full="$2/$3" target declared=0
+  if declared_paths "$proj" | grep -Fxq "$rel"; then
+    declared=1
+  fi
   if [ -L "$full" ]; then
     target=$(readlink "$full")
     if [ ! -e "$full" ]; then
-      report "$name" "external vault link broken at $rel -> $target (target missing); the vault content is not reachable from this clone, so its drift cannot be measured"
+      if [ "$declared" -eq 1 ]; then
+        report "$name" "external vault link broken at $rel -> $target (target missing); the vault content is not reachable from this clone, so its drift cannot be measured"
+      fi
       return 0
     fi
-    check_external "$name" "$proj" "$rel" "$full" " -> $target"
+    check_external "$name" "$proj" "$rel" "$full" " -> $target" "$declared"
     return 0
   fi
   if [ -d "$full" ]; then
     if git -C "$proj" cat-file -e "HEAD:$rel/$VAULT_MARKER" 2>/dev/null; then
       check_in_repo "$name" "$proj" "$rel"
-    elif [ -e "$full/.git" ]; then
+    elif [ "$declared" -eq 1 ] || [ -e "$full/.git" ]; then
       # An untracked, ignored clone of the vault repo sitting in place of a
       # symlink: same external shape, same remedy.
-      check_external "$name" "$proj" "$rel" "$full" ""
+      check_external "$name" "$proj" "$rel" "$full" "" "$declared"
     fi
     return 0
   fi
   # Nothing there. Only a declared external vault is a problem: a tracked vault
   # path that is merely missing from a dirty checkout is not this check's business.
-  if declared_paths "$proj" | grep -Fxq "$rel"; then
+  if [ "$declared" -eq 1 ]; then
     report "$name" "external vault link absent at $rel - the project declares an external vault there but this clone has none, so vault drift cannot be measured here at all; restore the link in the clone, or track the vault through its own registered repo"
   fi
 }

--- a/bin/fm-vault-drift.sh
+++ b/bin/fm-vault-drift.sh
@@ -31,7 +31,7 @@
 #                    because the remedy is different.
 #   link broken    - the symlink exists but its target does not.
 #   target invalid - a declared location resolves without the OKF marker, or a
-#                    recognized bundle is not in a Git repository.
+#                    recognized bundle is not in a separate Git repository.
 #   in-repo vault stale   - fixable inside an ordinary project worktree.
 #   external vault stale  - NOT fixable from a project worktree: the vault is a
 #                    separate repo, so the work belongs to that repo's own clone.
@@ -181,7 +181,7 @@ report_stale() {
 
 # check_external <name> <proj> <rel> <vault-repo-dir> <detail-suffix> <declared>
 check_external() {
-  local name=$1 proj=$2 rel=$3 dir=$4 suffix=$5 declared=$6 top vault_ts vault_date head_ts behind
+  local name=$1 proj=$2 rel=$3 dir=$4 suffix=$5 declared=$6 top vault_repo project_repo vault_ts vault_date head_ts behind
   if [ ! -f "$dir/$VAULT_MARKER" ]; then
     if [ "$declared" -eq 1 ]; then
       report "$name" "external vault target invalid at $rel$suffix - $VAULT_MARKER marker missing, so this declared location is not a valid OKF bundle and vault drift cannot be measured"
@@ -190,6 +190,12 @@ check_external() {
   fi
   if ! top=$(git -C "$dir" rev-parse --show-toplevel 2>/dev/null); then
     report "$name" "external vault target invalid at $rel$suffix - the OKF bundle is not in a Git repository, so vault drift cannot be measured"
+    return 0
+  fi
+  vault_repo=$(git -C "$top" rev-parse --path-format=absolute --git-common-dir 2>/dev/null) || return 0
+  project_repo=$(git -C "$proj" rev-parse --path-format=absolute --git-common-dir 2>/dev/null) || return 0
+  if [ "$vault_repo" = "$project_repo" ]; then
+    report "$name" "external vault target invalid at $rel$suffix - the resolved Git repository is the project repository, not a separate vault repository, so vault drift cannot be measured"
     return 0
   fi
   vault_ts=$(git -C "$top" log -1 --format=%ct 2>/dev/null) || return 0

--- a/bin/fm-vault-drift.sh
+++ b/bin/fm-vault-drift.sh
@@ -1,0 +1,250 @@
+#!/usr/bin/env bash
+# fm-vault-drift.sh - read-only documentation-vault drift detector.
+#
+# Prints one "VAULT_DRIFT: <project>: <problem>" line per vault problem found in
+# this home's project clones, then exits 0. Silent = every vault is either
+# current or absent by design. Detection only: it never writes a vault, never
+# writes anything under projects/, and never touches the captain's live Obsidian
+# copy - a vault is curated knowledge, so every remedy is a human or crewmate
+# decision, not an automatic sync.
+#
+# Usage: fm-vault-drift.sh [--help]
+#
+# Projects come from data/projects.md when that registry exists (falling back to
+# the clone directories under projects/), and every vault shape is established by
+# INSPECTING the clone rather than by trusting the registry prose.
+#
+# Vault locations per project, deduplicated:
+#   - an anchored data-vault path declared in the clone's root .gitignore
+#     (a "/vault" or "/<dir>/vault" line), which declares an EXTERNAL vault;
+#   - a tracked directory named vault/ that carries the OKF bundle marker
+#     00-Home.md, which is an IN-REPO vault (a tracked directory named vault
+#     WITHOUT that marker is some other directory - e.g. a test fixture - and is
+#     deliberately ignored, so it can never raise a false alarm);
+#   - a root-level "vault" symlink, however it got there.
+#
+# Each location is classified and reported as one of:
+#   link absent    - an external vault is declared but nothing is linked here, so
+#                    drift cannot be measured at all. This is the failure that
+#                    hides staleness, and it is reported separately from staleness
+#                    because the remedy is different.
+#   link broken    - the symlink exists but its target does not.
+#   in-repo vault stale   - fixable inside an ordinary project worktree.
+#   external vault stale  - NOT fixable from a project worktree: the vault is a
+#                    separate repo, so the work belongs to that repo's own clone.
+#
+# Staleness is measured as project commits landed since the vault's own last
+# commit, plus the window between those two commits. Both endpoints are commit
+# timestamps, never the wall clock, so a run is deterministic and repeatable.
+# A location is reported stale only when at least one project commit landed since
+# the vault's last commit AND either threshold is crossed:
+#   FM_VAULT_DRIFT_COMMITS  commits behind (default 20)
+#   FM_VAULT_DRIFT_DAYS     days in the drift window (default 7)
+# A non-numeric override warns on stderr and falls back to its default rather
+# than silently disabling the check.
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
+PROJECTS="${FM_PROJECTS_OVERRIDE:-$FM_HOME/projects}"
+DATA="${FM_DATA_OVERRIDE:-$FM_HOME/data}"
+REGISTRY="$DATA/projects.md"
+
+# The OKF vault bundle marker. Every vault in the fleet carries it at its root,
+# and nothing else named vault/ does, so it is what separates a knowledge vault
+# from a directory that merely shares the name.
+VAULT_MARKER=00-Home.md
+
+if [ "${1:-}" = "--help" ] || [ "${1:-}" = "-h" ]; then
+  echo "usage: fm-vault-drift.sh [--help]" >&2
+  exit 0
+fi
+[ $# -eq 0 ] || { echo "usage: fm-vault-drift.sh [--help]" >&2; exit 1; }
+
+threshold() {
+  local name=$1 value=$2 fallback=$3
+  case "$value" in
+    ''|*[!0-9]*)
+      echo "vault-drift: invalid $name '$value'; using $fallback" >&2
+      printf '%s\n' "$fallback"
+      ;;
+    *) printf '%s\n' "$value" ;;
+  esac
+}
+
+COMMITS_THRESHOLD=$(threshold FM_VAULT_DRIFT_COMMITS "${FM_VAULT_DRIFT_COMMITS:-20}" 20)
+DAYS_THRESHOLD=$(threshold FM_VAULT_DRIFT_DAYS "${FM_VAULT_DRIFT_DAYS:-7}" 7)
+
+report() {
+  printf 'VAULT_DRIFT: %s: %s\n' "$1" "$2"
+}
+
+# project_names: registered project names, one per line, in registry order.
+# Falls back to the clone directory names so a home with no registry (or a clone
+# that was never registered) is still inspected rather than silently skipped.
+project_names() {
+  local seen=" " name proj
+  if [ -f "$REGISTRY" ]; then
+    while read -r name; do
+      [ -n "$name" ] || continue
+      case "$seen" in *" $name "*) continue ;; esac
+      seen="$seen$name "
+      printf '%s\n' "$name"
+    done < <(awk '$1=="-" && $2!="" { print $2 }' "$REGISTRY")
+  fi
+  [ -d "$PROJECTS" ] || return 0
+  for proj in "$PROJECTS"/*; do
+    [ -d "$proj" ] || continue
+    name=$(basename "$proj")
+    case "$seen" in *" $name "*) continue ;; esac
+    seen="$seen$name "
+    printf '%s\n' "$name"
+  done
+}
+
+# declared_paths <proj>: anchored vault paths from the clone's root .gitignore.
+# An anchored "/vault" or "/<dir>/vault" line is the project declaring that a
+# vault belongs there but lives outside the repo.
+declared_paths() {
+  local proj=$1
+  [ -f "$proj/.gitignore" ] || return 0
+  awk '
+    { sub(/\r$/, ""); sub(/[ \t]+$/, "") }
+    /^\// {
+      p = $0
+      sub(/\/$/, "", p)
+      if (p ~ /\/vault$/) print substr(p, 2)
+    }
+  ' "$proj/.gitignore"
+}
+
+# tracked_vault_paths <proj>: tracked directories named vault that carry the OKF
+# bundle marker. The marker check is what keeps an unrelated tracked directory
+# named vault (a test fixture, a sample tree) from ever being reported.
+tracked_vault_paths() {
+  local proj=$1 path
+  git -C "$proj" rev-parse --verify --quiet HEAD >/dev/null 2>&1 || return 0
+  while read -r path; do
+    [ -n "$path" ] || continue
+    git -C "$proj" cat-file -e "HEAD:$path/$VAULT_MARKER" 2>/dev/null || continue
+    printf '%s\n' "$path"
+  done < <(git -C "$proj" ls-tree -d -r --name-only HEAD 2>/dev/null | grep -E '(^|/)vault$' || true)
+}
+
+# vault_paths <proj>: every candidate location, deduplicated, deterministic order.
+vault_paths() {
+  local proj=$1 seen=" " path
+  {
+    declared_paths "$proj"
+    tracked_vault_paths "$proj"
+    [ -L "$proj/vault" ] && printf '%s\n' vault
+  } | while read -r path; do
+    [ -n "$path" ] || continue
+    case "$seen" in *" $path "*) continue ;; esac
+    seen="$seen$path "
+    printf '%s\n' "$path"
+  done
+}
+
+# drift_window_days <vault-epoch> <head-epoch>: whole days between the two
+# commits, floored at 0 so a vault ahead of the project never reads as negative.
+drift_window_days() {
+  local days=$(((${2} - ${1}) / 86400))
+  [ "$days" -ge 0 ] || days=0
+  printf '%s\n' "$days"
+}
+
+is_stale() {
+  local behind=$1 days=$2
+  [ "$behind" -gt 0 ] || return 1
+  [ "$behind" -ge "$COMMITS_THRESHOLD" ] || [ "$days" -ge "$DAYS_THRESHOLD" ]
+}
+
+# report_stale <name> <shape> <rel> <detail-suffix> <vault-epoch> <vault-date> <head-epoch> <behind>
+report_stale() {
+  local name=$1 shape=$2 rel=$3 suffix=$4 vault_ts=$5 vault_date=$6 head_ts=$7 behind=$8 days
+  days=$(drift_window_days "$vault_ts" "$head_ts")
+  is_stale "$behind" "$days" || return 0
+  case "$shape" in
+    in-repo)
+      report "$name" "in-repo vault stale at $rel/ - vault last updated $vault_date, $behind project commits landed since, drift window ${days}d; a crewmate can refresh it in its own worktree"
+      ;;
+    external)
+      report "$name" "external vault stale at $rel$suffix - vault last updated $vault_date, $behind project commits landed since, drift window ${days}d; the vault is a separate repo, which an isolated project worktree cannot write, so dispatch the update against that repo's own clone"
+      ;;
+  esac
+}
+
+# check_external <name> <proj> <rel> <vault-repo-dir> <detail-suffix>
+check_external() {
+  local name=$1 proj=$2 rel=$3 dir=$4 suffix=$5 top vault_ts vault_date head_ts behind
+  top=$(git -C "$dir" rev-parse --show-toplevel 2>/dev/null) || return 0
+  vault_ts=$(git -C "$top" log -1 --format=%ct 2>/dev/null) || return 0
+  [ -n "$vault_ts" ] || return 0
+  vault_date=$(git -C "$top" log -1 --format=%cd --date=short 2>/dev/null) || return 0
+  head_ts=$(git -C "$proj" log -1 --format=%ct 2>/dev/null) || return 0
+  [ -n "$head_ts" ] || return 0
+  # An external vault has no shared history with the project, so "landed since"
+  # is a timestamp comparison. --since is inclusive of its own second, so start
+  # one second after the vault commit to count only what landed after it.
+  behind=$(git -C "$proj" rev-list --count "--since=@$((vault_ts + 1))" HEAD 2>/dev/null) || return 0
+  report_stale "$name" external "$rel" "$suffix" "$vault_ts" "$vault_date" "$head_ts" "$behind"
+}
+
+# check_in_repo <name> <proj> <rel>
+check_in_repo() {
+  local name=$1 proj=$2 rel=$3 vault_commit vault_ts vault_date head_ts behind
+  vault_commit=$(git -C "$proj" log -1 --format=%H -- "$rel" 2>/dev/null) || return 0
+  [ -n "$vault_commit" ] || return 0
+  vault_ts=$(git -C "$proj" log -1 --format=%ct "$vault_commit" 2>/dev/null) || return 0
+  vault_date=$(git -C "$proj" log -1 --format=%cd --date=short "$vault_commit" 2>/dev/null) || return 0
+  head_ts=$(git -C "$proj" log -1 --format=%ct HEAD 2>/dev/null) || return 0
+  behind=$(git -C "$proj" rev-list --count "$vault_commit..HEAD" 2>/dev/null) || return 0
+  report_stale "$name" in-repo "$rel" "" "$vault_ts" "$vault_date" "$head_ts" "$behind"
+}
+
+# check_location <name> <proj> <rel>: classify one candidate location by what is
+# actually on disk and in the index, and report only a real problem.
+check_location() {
+  local name=$1 proj=$2 rel=$3 full="$2/$3" target
+  if [ -L "$full" ]; then
+    target=$(readlink "$full")
+    if [ ! -e "$full" ]; then
+      report "$name" "external vault link broken at $rel -> $target (target missing); the vault content is not reachable from this clone, so its drift cannot be measured"
+      return 0
+    fi
+    check_external "$name" "$proj" "$rel" "$full" " -> $target"
+    return 0
+  fi
+  if [ -d "$full" ]; then
+    if git -C "$proj" cat-file -e "HEAD:$rel/$VAULT_MARKER" 2>/dev/null; then
+      check_in_repo "$name" "$proj" "$rel"
+    elif [ -e "$full/.git" ]; then
+      # An untracked, ignored clone of the vault repo sitting in place of a
+      # symlink: same external shape, same remedy.
+      check_external "$name" "$proj" "$rel" "$full" ""
+    fi
+    return 0
+  fi
+  # Nothing there. Only a declared external vault is a problem: a tracked vault
+  # path that is merely missing from a dirty checkout is not this check's business.
+  if declared_paths "$proj" | grep -Fxq "$rel"; then
+    report "$name" "external vault link absent at $rel - the project declares an external vault there but this clone has none, so vault drift cannot be measured here at all; restore the link in the clone, or track the vault through its own registered repo"
+  fi
+}
+
+command -v git >/dev/null 2>&1 || exit 0
+
+while read -r name; do
+  [ -n "$name" ] || continue
+  proj="$PROJECTS/$name"
+  [ -d "$proj" ] || continue
+  git -C "$proj" rev-parse --git-dir >/dev/null 2>&1 || continue
+  while read -r rel; do
+    [ -n "$rel" ] || continue
+    check_location "$name" "$proj" "$rel"
+  done < <(vault_paths "$proj")
+done < <(project_names)
+
+exit 0

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -304,6 +304,8 @@ In a read-only session that did not get the fleet lock, the same line is advisor
 The locked session-start bootstrap step also runs a best-effort project clone refresh through `fm-fleet-sync.sh`.
 It emits `FLEET_SYNC:` for skipped refreshes that may matter, recovered self-heals, and `STUCK:` alarms.
 Normal completed runs keep local-only and no-origin skips silent.
+After that refresh, bootstrap runs the read-only `fm-vault-drift.sh` detector and emits `VAULT_DRIFT:` for stale vaults or external vault locations whose drift cannot be measured.
+The same detector runs in lock-refused detect-only sessions because it never writes project clones or vaults; the script header owns the vault-shape, threshold, and diagnostic contracts.
 If bootstrap kills a timed-out refresh, it replays any completed `fm-fleet-sync.sh` output before the aggregate timeout skip so no finished result is lost.
 A killed refresh (or a teardown process kill) can leave an orphaned `.git/packed-refs.lock` in a clone, which makes the next refresh's fetch fail with Git's `Unable to create '...packed-refs.lock': File exists`.
 On that signature only, `fm-fleet-sync.sh` retries the fetch with a bounded wait for the lock to self-clear, then removes the lock and retries once more only when it can prove the lock stale, exactly like the `fm-teardown.sh` `index.lock` recovery.
@@ -546,6 +548,8 @@ FM_PAUSE_RESURFACE_SECS=3600       # seconds before an idle declared external wa
 FM_WEDGE_DEMAND_INSPECT_COUNT=3    # consecutive provably-working stale escalations on the same unchanged pane before demand-deep-inspection is added
 FM_WATCH_TRIAGE_LOG_MAX_BYTES=262144   # size cap for the watcher's absorbed-wake debug log
 FM_FLEET_SYNC_BOOTSTRAP_TIMEOUT=     # optional seconds allowed for bootstrap's best-effort clone refresh; unset/blank defaults to max(20, 5 + 3 * origin-backed-project-count)
+FM_VAULT_DRIFT_COMMITS=20            # project commits landed since a vault update before bootstrap reports drift
+FM_VAULT_DRIFT_DAYS=7                # commit-to-commit drift-window days before bootstrap reports drift
 FM_FLEET_PRUNE=1        # set to 0 to skip pruning local branches whose upstream is gone
 FM_STALE_WORKTREE_LOCK_AGE_SECS=30       # min mtime age before fm-teardown.sh treats a leftover worktree git index.lock as provably stale
 FM_TREEHOUSE_RETURN_LOCK_RETRIES=3        # retries after a treehouse return fails on the transient git index.lock signature

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -12,6 +12,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-operational-input.sh` | Construct and parse the canonical cross-language operational-input protocol |
 | `fm-bootstrap.sh`        | Detect toolchain and fleet problems, run the locked session-start sweeps, and install approved tools |
 | `fm-fleet-sync.sh`       | Refresh project clones with safe fast-forwards, self-heals, `STUCK:` reports, branch pruning, and bounded recovery from an orphaned `.git/packed-refs.lock` |
+| `fm-vault-drift.sh`      | Detect stale, unlinked, or broken documentation vaults across project clones, read-only |
 | `fm-fleet-snapshot.sh`   | Print the read-only structured fleet snapshot JSON (schema `fm-fleet-snapshot.v1`)   |
 | `fm-fleet-view.sh`       | Render the fleet snapshot as a human Markdown view                                   |
 | `fm-bearings-snapshot.sh` | Project the fleet snapshot to the compact TOON bearings view; local-only unless `--include-prs` |

--- a/tests/fm-bootstrap.test.sh
+++ b/tests/fm-bootstrap.test.sh
@@ -128,12 +128,14 @@ make_fake_fleet_sync_root() {
   local dir=$1 fake_root
   fake_root="$dir/fake-root"
   mkdir -p "$fake_root/bin"
-  cat > "$fake_root/bin/fm-fleet-sync.sh" <<'SH'
+cat > "$fake_root/bin/fm-fleet-sync.sh" <<'SH'
 #!/usr/bin/env bash
 [ -z "${FM_FAKE_FLEET_SYNC_STARTED_MARKER:-}" ] || : > "$FM_FAKE_FLEET_SYNC_STARTED_MARKER"
+[ -z "${FM_FAKE_FLEET_SYNC_STARTED_MARKER:-}" ] \
+  || trap ': > "${FM_FAKE_FLEET_SYNC_STARTED_MARKER}.finished"' EXIT
 printf '%s\n' 'alpha: synced'
 printf '%s\n' 'beta: skipped: no origin remote'
-exec perl -e 'sleep 300'
+perl -e 'sleep 300'
 SH
   chmod +x "$fake_root/bin/fm-fleet-sync.sh"
   printf '%s\n' "$fake_root"
@@ -189,7 +191,10 @@ run_bootstrap_timeout_case() {
           tries=$((tries + 1))
         done
       fi
-      if [ -n "${FM_FAKE_GIT_SYNC_STARTED_RECORD:-}" ] && [ -n "${FM_FAKE_FLEET_SYNC_STARTED_MARKER:-}" ] && [ -e "$FM_FAKE_FLEET_SYNC_STARTED_MARKER" ]; then
+      if [ -n "${FM_FAKE_GIT_SYNC_STARTED_RECORD:-}" ] \
+        && [ -n "${FM_FAKE_FLEET_SYNC_STARTED_MARKER:-}" ] \
+        && [ -e "$FM_FAKE_FLEET_SYNC_STARTED_MARKER" ] \
+        && [ ! -e "${FM_FAKE_FLEET_SYNC_STARTED_MARKER}.finished" ]; then
         printf '%s\n' "$*" >> "$FM_FAKE_GIT_SYNC_STARTED_RECORD"
       fi
       command git "$@"
@@ -764,9 +769,9 @@ test_routine_bootstrap_contract_runs_under_system_bash() {
 # and the detect-only (lock-refused) session, and never rewrite the clone.
 # bin/fm-vault-drift.sh's own suite owns the vault shapes and thresholds.
 test_bootstrap_relays_vault_drift_in_both_modes() {
-  local case_dir fakebin proj out i mode
+  local case_dir fakebin proj out i mode seed
   case_dir="$TMP_ROOT/vault-drift"
-  mkdir -p "$case_dir/home/config" "$case_dir/home/projects"
+  mkdir -p "$case_dir/home/bin" "$case_dir/home/config" "$case_dir/home/projects"
   printf '%s\n' manual > "$case_dir/home/config/backlog-backend"
   fakebin=$(make_fake_toolchain "$case_dir")
 
@@ -779,16 +784,30 @@ test_bootstrap_relays_vault_drift_in_both_modes() {
   git -C "$proj" add -A
   GIT_AUTHOR_DATE='@1700000000 +0000' GIT_COMMITTER_DATE='@1700000000 +0000' \
     git -C "$proj" commit -qm 'vault: seed'
+  seed=$(git -C "$proj" rev-parse HEAD)
   for ((i = 1; i <= 20; i++)); do
     printf '%s\n' "change $i" > "$proj/file-$i.txt"
     git -C "$proj" add -A
     GIT_AUTHOR_DATE='@1700086400 +0000' GIT_COMMITTER_DATE='@1700086400 +0000' \
       git -C "$proj" commit -qm "work $i"
   done
+  git -C "$proj" branch upstream
+  git -C "$proj" reset -q --hard "$seed"
+  cat > "$case_dir/home/bin/fm-fleet-sync.sh" <<'SH'
+#!/usr/bin/env bash
+git -C "$FM_FAKE_VAULT_PROJECT" merge -q --ff-only upstream
+SH
+  chmod +x "$case_dir/home/bin/fm-fleet-sync.sh"
 
   for mode in 0 1; do
+    if [ "$mode" -eq 0 ]; then
+      git -C "$proj" reset -q --hard "$seed"
+    else
+      git -C "$proj" reset -q --hard upstream
+    fi
     out=$(PATH="$fakebin:$BASE_PATH" FM_HOME="$case_dir/home" FM_ROOT_OVERRIDE="$case_dir/home" \
-      FM_BOOTSTRAP_DETECT_ONLY="$mode" FM_FAKE_TREEHOUSE_LEASE_HELP=1 "$ROOT/bin/fm-bootstrap.sh")
+      FM_BOOTSTRAP_DETECT_ONLY="$mode" FM_FAKE_TREEHOUSE_LEASE_HELP=1 \
+      FM_FAKE_VAULT_PROJECT="$proj" "$ROOT/bin/fm-bootstrap.sh")
     printf '%s\n' "$out" \
       | grep -F 'VAULT_DRIFT: hermes: in-repo vault stale at vault/ - vault last updated 2023-11-14, 20 project commits landed since, drift window 1d' \
         >/dev/null \
@@ -796,7 +815,7 @@ test_bootstrap_relays_vault_drift_in_both_modes() {
   done
   [ -z "$(git -C "$proj" status --porcelain)" ] \
     || fail "bootstrap's vault check must leave the clone untouched"
-  pass "bootstrap relays vault-drift detection in normal and detect-only sessions"
+  pass "bootstrap checks post-sync drift normally and relays it in detect-only sessions"
 }
 
 test_crew_dispatch_active_rules_are_verbose_bootstrap_info() {

--- a/tests/fm-bootstrap.test.sh
+++ b/tests/fm-bootstrap.test.sh
@@ -760,6 +760,45 @@ test_routine_bootstrap_contract_runs_under_system_bash() {
   pass "bootstrap routine contract runs under system /bin/bash"
 }
 
+# Vault drift is detection only, so bootstrap must surface it in BOTH the normal
+# and the detect-only (lock-refused) session, and never rewrite the clone.
+# bin/fm-vault-drift.sh's own suite owns the vault shapes and thresholds.
+test_bootstrap_relays_vault_drift_in_both_modes() {
+  local case_dir fakebin proj out i mode
+  case_dir="$TMP_ROOT/vault-drift"
+  mkdir -p "$case_dir/home/config" "$case_dir/home/projects"
+  printf '%s\n' manual > "$case_dir/home/config/backlog-backend"
+  fakebin=$(make_fake_toolchain "$case_dir")
+
+  proj="$case_dir/home/projects/hermes"
+  mkdir -p "$proj/vault"
+  git -C "$proj" init -q
+  git -C "$proj" config user.name fmtest
+  git -C "$proj" config user.email fmtest@example.invalid
+  printf '%s\n' '# Vault home' > "$proj/vault/00-Home.md"
+  git -C "$proj" add -A
+  GIT_AUTHOR_DATE='@1700000000 +0000' GIT_COMMITTER_DATE='@1700000000 +0000' \
+    git -C "$proj" commit -qm 'vault: seed'
+  for ((i = 1; i <= 20; i++)); do
+    printf '%s\n' "change $i" > "$proj/file-$i.txt"
+    git -C "$proj" add -A
+    GIT_AUTHOR_DATE='@1700086400 +0000' GIT_COMMITTER_DATE='@1700086400 +0000' \
+      git -C "$proj" commit -qm "work $i"
+  done
+
+  for mode in 0 1; do
+    out=$(PATH="$fakebin:$BASE_PATH" FM_HOME="$case_dir/home" FM_ROOT_OVERRIDE="$case_dir/home" \
+      FM_BOOTSTRAP_DETECT_ONLY="$mode" FM_FAKE_TREEHOUSE_LEASE_HELP=1 "$ROOT/bin/fm-bootstrap.sh")
+    printf '%s\n' "$out" \
+      | grep -F 'VAULT_DRIFT: hermes: in-repo vault stale at vault/ - vault last updated 2023-11-14, 20 project commits landed since, drift window 1d' \
+        >/dev/null \
+      || fail "detect-only=$mode: bootstrap must relay the vault drift line (got: $out)"
+  done
+  [ -z "$(git -C "$proj" status --porcelain)" ] \
+    || fail "bootstrap's vault check must leave the clone untouched"
+  pass "bootstrap relays vault-drift detection in normal and detect-only sessions"
+}
+
 test_crew_dispatch_active_rules_are_verbose_bootstrap_info() {
   local case_dir fakebin out expect
   case_dir="$TMP_ROOT/dispatch-active"
@@ -851,5 +890,6 @@ test_fleet_sync_timeout_empty_override_uses_default
 test_fleet_sync_timeout_is_computed_before_launch
 test_routine_bootstrap_confirmations_are_silent
 test_routine_bootstrap_contract_runs_under_system_bash
+test_bootstrap_relays_vault_drift_in_both_modes
 test_crew_dispatch_active_rules_are_verbose_bootstrap_info
 test_crew_dispatch_validation

--- a/tests/fm-session-start.test.sh
+++ b/tests/fm-session-start.test.sh
@@ -793,7 +793,7 @@ SH
 # --- output ordering ----------------------------------------------------------
 
 test_output_ordering_diagnostics_lead() {
-  local rec root home fakebin out lock_line boot_line wake_line context_line fleet_line next_line missing_line
+  local rec root home fakebin out lock_line boot_line wake_line context_line fleet_line next_line
   rec=$(new_world ordering)
   IFS='|' read -r root home fakebin <<EOF
 $rec
@@ -801,10 +801,7 @@ EOF
   make_fake_toolchain "$fakebin"
   make_fake_ps_claude "$fakebin"
   # Force a MISSING diagnostic line so the bootstrap section is non-trivial.
-  # Drop a fleet-only tool, never a general one like node: the base PATH is a
-  # real system PATH, so a host-installed /usr/bin/node would satisfy the check
-  # again and this ordering case would silently stop testing anything.
-  rm -f "$fakebin/lavish-axi"
+  rm -f "$fakebin/node"
 
   printf 'window=fm-sess:w1\nkind=ship\n' > "$home/state/task-a.meta"
 
@@ -827,7 +824,7 @@ EOF
   [ "$context_line" -lt "$fleet_line" ] || fail "CONTEXT did not precede FLEET STATE"
   [ "$fleet_line" -lt "$next_line" ] || fail "FLEET STATE did not precede NEXT STEP"
 
-  missing_line=$(printf '%s\n' "$out" | grep -n 'MISSING: lavish-axi' | head -1 | cut -d: -f1)
+  missing_line=$(printf '%s\n' "$out" | grep -n 'MISSING: node' | head -1 | cut -d: -f1)
   [ -n "$missing_line" ] || fail "MISSING diagnostic did not appear at all"
   [ "$missing_line" -lt "$fleet_line" ] || fail "actionable MISSING diagnostic was buried after the bulk fleet-state digest"
 
@@ -1086,10 +1083,7 @@ $rec
 EOF
   make_fake_toolchain "$fakebin"
   make_fake_ps_claude "$fakebin"
-  # A fleet-only tool, never a general one like node: the base PATH is a real
-  # system PATH, so a host-installed /usr/bin/node would satisfy the check again
-  # and this composition case would silently stop testing the detect line.
-  rm -f "$fakebin/lavish-axi"
+  rm -f "$fakebin/node"
 
   printf 'needs-decision: pick a library\n' > "$home/state/task-z.status"
   append_wake "$home/state" signal task-z.status "needs-decision: pick a library"
@@ -1099,7 +1093,7 @@ EOF
   # fm-lock.sh's own exact success text.
   assert_contains "$out" "lock acquired: harness pid" "fm-lock.sh's real output did not appear (composition, not reimplementation)"
   # fm-bootstrap.sh's own exact MISSING-tool line format.
-  assert_contains "$out" "MISSING: lavish-axi (install:" "fm-bootstrap.sh's real detect line did not appear verbatim"
+  assert_contains "$out" "MISSING: node (install:" "fm-bootstrap.sh's real detect line did not appear verbatim"
   # fm-wake-drain.sh's real drained record (raw tab-separated queue line).
   assert_contains "$out" "$(printf 'signal\ttask-z.status\tneeds-decision: pick a library')" "fm-wake-drain.sh's real drained record did not appear"
   assert_contains "$out" "wake annotation: latest wake-EVENT observed at drain, not current state: task-z.status: needs-decision: pick a library" "fm-session-start.sh did not preserve the drain's separate annotation line"

--- a/tests/fm-session-start.test.sh
+++ b/tests/fm-session-start.test.sh
@@ -793,7 +793,7 @@ SH
 # --- output ordering ----------------------------------------------------------
 
 test_output_ordering_diagnostics_lead() {
-  local rec root home fakebin out lock_line boot_line wake_line context_line fleet_line next_line
+  local rec root home fakebin out lock_line boot_line wake_line context_line fleet_line next_line missing_line
   rec=$(new_world ordering)
   IFS='|' read -r root home fakebin <<EOF
 $rec
@@ -801,7 +801,10 @@ EOF
   make_fake_toolchain "$fakebin"
   make_fake_ps_claude "$fakebin"
   # Force a MISSING diagnostic line so the bootstrap section is non-trivial.
-  rm -f "$fakebin/node"
+  # Drop a fleet-only tool, never a general one like node: the base PATH is a
+  # real system PATH, so a host-installed /usr/bin/node would satisfy the check
+  # again and this ordering case would silently stop testing anything.
+  rm -f "$fakebin/lavish-axi"
 
   printf 'window=fm-sess:w1\nkind=ship\n' > "$home/state/task-a.meta"
 
@@ -824,7 +827,7 @@ EOF
   [ "$context_line" -lt "$fleet_line" ] || fail "CONTEXT did not precede FLEET STATE"
   [ "$fleet_line" -lt "$next_line" ] || fail "FLEET STATE did not precede NEXT STEP"
 
-  missing_line=$(printf '%s\n' "$out" | grep -n 'MISSING: node' | head -1 | cut -d: -f1)
+  missing_line=$(printf '%s\n' "$out" | grep -n 'MISSING: lavish-axi' | head -1 | cut -d: -f1)
   [ -n "$missing_line" ] || fail "MISSING diagnostic did not appear at all"
   [ "$missing_line" -lt "$fleet_line" ] || fail "actionable MISSING diagnostic was buried after the bulk fleet-state digest"
 
@@ -1083,7 +1086,10 @@ $rec
 EOF
   make_fake_toolchain "$fakebin"
   make_fake_ps_claude "$fakebin"
-  rm -f "$fakebin/node"
+  # A fleet-only tool, never a general one like node: the base PATH is a real
+  # system PATH, so a host-installed /usr/bin/node would satisfy the check again
+  # and this composition case would silently stop testing the detect line.
+  rm -f "$fakebin/lavish-axi"
 
   printf 'needs-decision: pick a library\n' > "$home/state/task-z.status"
   append_wake "$home/state" signal task-z.status "needs-decision: pick a library"
@@ -1093,7 +1099,7 @@ EOF
   # fm-lock.sh's own exact success text.
   assert_contains "$out" "lock acquired: harness pid" "fm-lock.sh's real output did not appear (composition, not reimplementation)"
   # fm-bootstrap.sh's own exact MISSING-tool line format.
-  assert_contains "$out" "MISSING: node (install:" "fm-bootstrap.sh's real detect line did not appear verbatim"
+  assert_contains "$out" "MISSING: lavish-axi (install:" "fm-bootstrap.sh's real detect line did not appear verbatim"
   # fm-wake-drain.sh's real drained record (raw tab-separated queue line).
   assert_contains "$out" "$(printf 'signal\ttask-z.status\tneeds-decision: pick a library')" "fm-wake-drain.sh's real drained record did not appear"
   assert_contains "$out" "wake annotation: latest wake-EVENT observed at drain, not current state: task-z.status: needs-decision: pick a library" "fm-session-start.sh did not preserve the drain's separate annotation line"

--- a/tests/fm-test-run.test.sh
+++ b/tests/fm-test-run.test.sh
@@ -25,8 +25,8 @@ test_list_all_exact_suite_coverage() {
     done | LC_ALL=C sort
   )
   [ -n "$listed" ] || fail "--list --all printed nothing"
-  missing=$(comm -23 <(printf '%s\n' "$expected") <(printf '%s\n' "$listed") || true)
-  extra=$(comm -13 <(printf '%s\n' "$expected") <(printf '%s\n' "$listed") || true)
+  missing=$(LC_ALL=C comm -23 <(printf '%s\n' "$expected") <(printf '%s\n' "$listed") || true)
+  extra=$(LC_ALL=C comm -13 <(printf '%s\n' "$expected") <(printf '%s\n' "$listed") || true)
   [ -z "$missing" ] || fail "--list --all missing scripts: $missing"
   [ -z "$extra" ] || fail "--list --all unexpected scripts: $extra"
   # No duplicates.
@@ -359,7 +359,7 @@ test_portable_shard_union_and_coverage_guard() {
   herdr=$("$RUNNER" --list --family real-herdr-gated)
   [ -n "$s1" ] && [ -n "$s2" ] || fail "portable parallel shards must be non-empty"
   # Shards disjoint.
-  overlap=$(comm -12 <(printf '%s\n' "$s1" | LC_ALL=C sort) <(printf '%s\n' "$s2" | LC_ALL=C sort) || true)
+  overlap=$(LC_ALL=C comm -12 <(printf '%s\n' "$s1" | LC_ALL=C sort) <(printf '%s\n' "$s2" | LC_ALL=C sort) || true)
   [ -z "$overlap" ] || fail "portable parallel shards overlap: $overlap"
   # Union of shards equals proven-isolated.
   [ "$(printf '%s\n' "$s1" "$s2" | LC_ALL=C sort -u)" = \

--- a/tests/fm-vault-drift.test.sh
+++ b/tests/fm-vault-drift.test.sh
@@ -234,6 +234,25 @@ test_declared_external_target_without_marker_reports_invalid() {
   pass "a declared external target without the marker reports invalid"
 }
 
+test_declared_external_directory_in_project_repo_reports_invalid() {
+  local home proj out
+  home=$(new_home declared-external-directory-in-project-repo-reports-invalid)
+  proj="$home/projects/arknode"
+  init_repo "$proj" "$T0"
+  declare_external "$proj" /vault
+  mkdir -p "$proj/vault"
+  printf '%s\n' '# Vault home' > "$proj/vault/00-Home.md"
+  project_commits "$proj" 30 $((T0 + 30 * DAY))
+
+  out=$(run_drift "$home")
+  assert_contains "$out" \
+    "VAULT_DRIFT: arknode: external vault target invalid at vault - the resolved Git repository is the project repository, not a separate vault repository" \
+    "a declared ignored vault directory must resolve to a separate repository"
+  assert_not_contains "$out" "vault stale at" \
+    "a declared directory inside the project repository must never be measured as external"
+  pass "a declared external directory in the project repository reports invalid"
+}
+
 test_undeclared_root_symlink_to_non_vault_repo_is_silent() {
   local home proj target out
   home=$(new_home undeclared-root-symlink-to-non-vault-repo-is-silent)
@@ -400,6 +419,7 @@ test_in_repo_vault_stale_by_drift_window
 test_external_symlinked_vault_stale_reports_the_separate_repo_remedy
 test_current_external_symlinked_vault_is_silent
 test_declared_external_target_without_marker_reports_invalid
+test_declared_external_directory_in_project_repo_reports_invalid
 test_undeclared_root_symlink_to_non_vault_repo_is_silent
 test_broken_link_reports_distinctly_from_staleness
 test_absent_link_reports_distinctly_from_staleness

--- a/tests/fm-vault-drift.test.sh
+++ b/tests/fm-vault-drift.test.sh
@@ -214,6 +214,41 @@ test_current_external_symlinked_vault_is_silent() {
   pass "a current external symlinked vault is silent"
 }
 
+test_declared_external_target_without_marker_reports_invalid() {
+  local home proj target out
+  home=$(new_home declared-external-target-without-marker-reports-invalid)
+  proj="$home/projects/arknode"
+  init_repo "$proj" "$T0"
+  declare_external "$proj" /vault
+  target="$home/vaults/not-a-vault"
+  init_repo "$target" "$T0"
+  ln -s "$target" "$proj/vault"
+  project_commits "$proj" 30 $((T0 + 30 * DAY))
+
+  out=$(run_drift "$home")
+  assert_contains "$out" \
+    "VAULT_DRIFT: arknode: external vault target invalid at vault -> $target - 00-Home.md marker missing" \
+    "a declared external target without the bundle marker must report as invalid"
+  assert_not_contains "$out" "vault stale at" \
+    "a declared non-vault target must never be classified as stale"
+  pass "a declared external target without the marker reports invalid"
+}
+
+test_undeclared_root_symlink_to_non_vault_repo_is_silent() {
+  local home proj target out
+  home=$(new_home undeclared-root-symlink-to-non-vault-repo-is-silent)
+  proj="$home/projects/fixtures"
+  init_repo "$proj" "$T0"
+  target="$home/repos/unrelated"
+  init_repo "$target" "$T0"
+  ln -s "$target" "$proj/vault"
+  project_commits "$proj" 30 $((T0 + 30 * DAY))
+
+  out=$(run_drift "$home")
+  [ -z "$out" ] || fail "an undeclared symlink to a non-vault repo must be ignored, got: $out"
+  pass "an undeclared root symlink to a non-vault repo is silent"
+}
+
 test_broken_link_reports_distinctly_from_staleness() {
   local home proj out
   home=$(new_home broken-link-reports-distinctly-from-staleness)
@@ -364,6 +399,8 @@ test_in_repo_vault_stale_by_commit_count
 test_in_repo_vault_stale_by_drift_window
 test_external_symlinked_vault_stale_reports_the_separate_repo_remedy
 test_current_external_symlinked_vault_is_silent
+test_declared_external_target_without_marker_reports_invalid
+test_undeclared_root_symlink_to_non_vault_repo_is_silent
 test_broken_link_reports_distinctly_from_staleness
 test_absent_link_reports_distinctly_from_staleness
 test_arknode_absent_link_and_stale_vault_at_once

--- a/tests/fm-vault-drift.test.sh
+++ b/tests/fm-vault-drift.test.sh
@@ -1,0 +1,372 @@
+#!/usr/bin/env bash
+# Behavior tests for fm-vault-drift.sh, the read-only documentation-vault drift
+# detector.
+#
+# The check exists because a project's vault fell dozens of commits behind with
+# nothing surfacing it, so these cases pin the four properties that make it
+# trustworthy rather than noisy:
+#   - the two vault shapes are told apart by INSPECTION, because they need
+#     different remedies: an in-repo vault a crewmate can refresh in its own
+#     worktree, and an external vault living in a separate repo that a project
+#     worktree structurally cannot write;
+#   - an absent or broken external link reports distinctly from a stale vault,
+#     because "drift cannot be measured at all" is a different problem from
+#     "drift measured and too large" - the ArkNode-AI case has both at once;
+#   - a project with no vault, and a directory that merely shares the name
+#     vault/ without the OKF bundle marker, produce no output at all;
+#   - staleness is reported with the commit count behind and the drift window,
+#     measured from commit timestamps so a run is deterministic.
+# Bootstrap's relay of these lines is pinned in tests/fm-bootstrap.test.sh.
+set -u
+
+# shellcheck source=tests/lib.sh disable=SC1091
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+fm_git_identity fmtest fmtest@example.invalid
+
+TMP_ROOT=$(fm_test_tmproot fm-vault-drift-tests)
+DRIFT="$ROOT/bin/fm-vault-drift.sh"
+
+# Fixed fixture clock. Every commit gets an explicit epoch so drift windows are
+# byte-stable regardless of when the suite runs.
+DAY=86400
+T0=1700000000 # 2023-11-14 22:13:20 UTC
+T0_DATE=2023-11-14
+
+# --- fixtures ---------------------------------------------------------------
+
+# new_home <case-label>: a fresh isolated FM_HOME with an empty projects/ dir.
+# The label is explicit rather than a counter because new_home is called in a
+# command substitution, where a counter would never advance in the parent and
+# every case would silently share one home and one set of fixture commits.
+new_home() {
+  local h="$TMP_ROOT/$1"
+  mkdir -p "$h/projects"
+  printf '%s\n' "$h"
+}
+
+# commit_at <repo> <epoch> <path> <content> <msg>
+commit_at() {
+  local repo=$1 epoch=$2 path=$3 content=$4 msg=$5
+  mkdir -p "$repo/$(dirname "$path")"
+  printf '%s\n' "$content" > "$repo/$path"
+  git -C "$repo" add -A -- "$path"
+  GIT_AUTHOR_DATE="@$epoch +0000" GIT_COMMITTER_DATE="@$epoch +0000" \
+    git -C "$repo" commit -qm "$msg" \
+    || fail "fixture commit failed in $repo: $msg"
+}
+
+# init_repo <dir> <epoch>: a git repo with one initial commit.
+init_repo() {
+  local dir=$1 epoch=$2
+  mkdir -p "$dir"
+  git -C "$dir" init -q
+  git -C "$dir" config user.name fmtest
+  git -C "$dir" config user.email fmtest@example.invalid
+  commit_at "$dir" "$epoch" README.md "# $(basename "$dir")" initial
+}
+
+# project_commits <repo> <count> <epoch>: <count> ordinary project commits.
+project_commits() {
+  local repo=$1 count=$2 epoch=$3 i
+  for ((i = 1; i <= count; i++)); do
+    commit_at "$repo" "$epoch" "src/file-$i.txt" "change $i" "work $i"
+  done
+}
+
+# in_repo_vault <repo> <epoch> [relpath]: commit an OKF vault bundle in the repo.
+in_repo_vault() {
+  local repo=$1 epoch=$2 rel=${3:-vault}
+  commit_at "$repo" "$epoch" "$rel/00-Home.md" '# Vault home' "vault: seed $rel"
+}
+
+# external_vault <dir> <epoch>: a separate vault repo carrying the bundle marker.
+external_vault() {
+  local dir=$1 epoch=$2
+  init_repo "$dir" "$epoch"
+  commit_at "$dir" "$epoch" 00-Home.md '# Vault home' 'vault: seed'
+}
+
+declare_external() {
+  local repo=$1
+  shift
+  printf '%s\n' "$@" > "$repo/.gitignore"
+  git -C "$repo" add .gitignore
+  GIT_AUTHOR_DATE="@$T0 +0000" GIT_COMMITTER_DATE="@$T0 +0000" \
+    git -C "$repo" commit -qm 'declare external vault'
+}
+
+run_drift() {
+  local home=$1
+  shift
+  env "$@" FM_HOME="$home" FM_ROOT_OVERRIDE="$home" "$DRIFT" 2>/dev/null
+}
+
+# --- cases ------------------------------------------------------------------
+
+test_no_vault_is_silent() {
+  local home out code
+  home=$(new_home no-vault-is-silent)
+  init_repo "$home/projects/plain" "$T0"
+  project_commits "$home/projects/plain" 40 $((T0 + 30 * DAY))
+
+  out=$(run_drift "$home")
+  code=$?
+  expect_code 0 "$code" "no-vault project"
+  [ -z "$out" ] || fail "a project with no vault must produce no output, got: $out"
+  pass "a project with no vault is silent"
+}
+
+test_directory_named_vault_without_marker_is_silent() {
+  local home proj out
+  home=$(new_home directory-named-vault-without-marker-is-silent)
+  proj="$home/projects/fixtures"
+  init_repo "$proj" "$T0"
+  # A tracked directory that merely shares the name - e.g. a test fixture tree -
+  # carries no OKF bundle marker and must never raise an alarm.
+  commit_at "$proj" "$T0" scripts/testing/vault/test_verify.sh 'echo hi' 'add vault test fixture'
+  project_commits "$proj" 40 $((T0 + 30 * DAY))
+
+  out=$(run_drift "$home")
+  [ -z "$out" ] || fail "a directory named vault without the bundle marker must be ignored, got: $out"
+  pass "a same-named directory without the vault bundle marker is never reported"
+}
+
+test_current_in_repo_vault_is_silent() {
+  local home proj out
+  home=$(new_home current-in-repo-vault-is-silent)
+  proj="$home/projects/hermes"
+  init_repo "$proj" "$T0"
+  in_repo_vault "$proj" "$T0"
+  project_commits "$proj" 3 $((T0 + 2 * DAY))
+
+  out=$(run_drift "$home")
+  [ -z "$out" ] || fail "a current in-repo vault must be silent, got: $out"
+  pass "an in-repo vault inside both thresholds is silent"
+}
+
+test_in_repo_vault_stale_by_commit_count() {
+  local home proj out
+  home=$(new_home in-repo-vault-stale-by-commit-count)
+  proj="$home/projects/hermes"
+  init_repo "$proj" "$T0"
+  in_repo_vault "$proj" "$T0"
+  project_commits "$proj" 20 $((T0 + DAY))
+
+  out=$(run_drift "$home")
+  assert_contains "$out" \
+    "VAULT_DRIFT: hermes: in-repo vault stale at vault/ - vault last updated $T0_DATE, 20 project commits landed since, drift window 1d" \
+    "in-repo staleness must report the commit count behind and the drift window"
+  assert_contains "$out" "a crewmate can refresh it in its own worktree" \
+    "an in-repo vault must carry the in-worktree remedy"
+  pass "an in-repo vault behind by commit count reports count and window"
+}
+
+test_in_repo_vault_stale_by_drift_window() {
+  local home proj out
+  home=$(new_home in-repo-vault-stale-by-drift-window)
+  proj="$home/projects/bzsim"
+  init_repo "$proj" "$T0"
+  in_repo_vault "$proj" "$T0"
+  project_commits "$proj" 2 $((T0 + 8 * DAY))
+
+  out=$(run_drift "$home")
+  assert_contains "$out" \
+    "VAULT_DRIFT: bzsim: in-repo vault stale at vault/ - vault last updated $T0_DATE, 2 project commits landed since, drift window 8d" \
+    "a long drift window must report even with few commits behind"
+  pass "an in-repo vault behind by drift window reports count and window"
+}
+
+test_external_symlinked_vault_stale_reports_the_separate_repo_remedy() {
+  local home proj out
+  home=$(new_home external-symlinked-vault-stale-reports-the-separate-repo-remedy)
+  proj="$home/projects/arknode"
+  init_repo "$proj" "$T0"
+  declare_external "$proj" /vault
+  external_vault "$home/vaults/arknode" "$T0"
+  ln -s "$home/vaults/arknode" "$proj/vault"
+  project_commits "$proj" 25 $((T0 + 3 * DAY))
+
+  out=$(run_drift "$home")
+  assert_contains "$out" \
+    "VAULT_DRIFT: arknode: external vault stale at vault -> $home/vaults/arknode - vault last updated $T0_DATE, 25 project commits landed since, drift window 3d" \
+    "external staleness must name the link target, the count behind, and the window"
+  assert_contains "$out" \
+    "the vault is a separate repo, which an isolated project worktree cannot write, so dispatch the update against that repo's own clone" \
+    "an external vault must carry the separate-repo remedy"
+  assert_not_contains "$out" "a crewmate can refresh it in its own worktree" \
+    "an external vault must never be given the in-worktree remedy"
+  pass "a stale external symlinked vault reports the separate-repo remedy"
+}
+
+test_current_external_symlinked_vault_is_silent() {
+  local home proj out
+  home=$(new_home current-external-symlinked-vault-is-silent)
+  proj="$home/projects/arknode"
+  init_repo "$proj" "$T0"
+  declare_external "$proj" /vault
+  external_vault "$home/vaults/arknode" $((T0 + 3 * DAY))
+  ln -s "$home/vaults/arknode" "$proj/vault"
+  project_commits "$proj" 2 $((T0 + 4 * DAY))
+
+  out=$(run_drift "$home")
+  [ -z "$out" ] || fail "a current external vault must be silent, got: $out"
+  pass "a current external symlinked vault is silent"
+}
+
+test_broken_link_reports_distinctly_from_staleness() {
+  local home proj out
+  home=$(new_home broken-link-reports-distinctly-from-staleness)
+  proj="$home/projects/arknode"
+  init_repo "$proj" "$T0"
+  declare_external "$proj" /vault
+  ln -s "$home/vaults/gone" "$proj/vault"
+  project_commits "$proj" 30 $((T0 + 30 * DAY))
+
+  out=$(run_drift "$home")
+  assert_contains "$out" \
+    "VAULT_DRIFT: arknode: external vault link broken at vault -> $home/vaults/gone (target missing)" \
+    "a dangling vault link must be reported as broken"
+  assert_not_contains "$out" "vault stale at" \
+    "a broken link must not be reported as staleness"
+  pass "a broken vault link reports distinctly from a stale vault"
+}
+
+test_absent_link_reports_distinctly_from_staleness() {
+  local home proj out
+  home=$(new_home absent-link-reports-distinctly-from-staleness)
+  proj="$home/projects/arknode"
+  init_repo "$proj" "$T0"
+  declare_external "$proj" /vault
+  project_commits "$proj" 30 $((T0 + 30 * DAY))
+
+  out=$(run_drift "$home")
+  assert_contains "$out" \
+    "VAULT_DRIFT: arknode: external vault link absent at vault - the project declares an external vault there but this clone has none, so vault drift cannot be measured here at all" \
+    "a declared-but-missing external vault must be reported as an absent link"
+  assert_not_contains "$out" "vault stale at" \
+    "an absent link must not be reported as staleness"
+  assert_not_contains "$out" "link broken at" \
+    "an absent link must not be reported as a broken link"
+  pass "an absent vault link reports distinctly from a stale vault"
+}
+
+# The regression that motivated the whole check: one project holding an absent
+# external link at one declared location AND a genuinely stale external vault at
+# another, which must surface as two separate problems with two separate remedies.
+test_arknode_absent_link_and_stale_vault_at_once() {
+  local home proj out lines
+  home=$(new_home arknode-absent-link-and-stale-vault-at-once)
+  proj="$home/projects/ArkNode-AI"
+  init_repo "$proj" "$T0"
+  declare_external "$proj" /vault /projects/trading-signal-ai/vault
+  external_vault "$home/vaults/ArkNode-AI" "$T0"
+  mkdir -p "$proj/projects/trading-signal-ai"
+  ln -s "$home/vaults/ArkNode-AI" "$proj/projects/trading-signal-ai/vault"
+  project_commits "$proj" 52 $((T0 + 7 * DAY))
+
+  out=$(run_drift "$home")
+  assert_contains "$out" \
+    "VAULT_DRIFT: ArkNode-AI: external vault link absent at vault -" \
+    "the unlinked declared vault must surface"
+  assert_contains "$out" \
+    "VAULT_DRIFT: ArkNode-AI: external vault stale at projects/trading-signal-ai/vault -> $home/vaults/ArkNode-AI - vault last updated $T0_DATE, 52 project commits landed since, drift window 7d" \
+    "the stale external vault must surface with its own count and window"
+  lines=$(printf '%s\n' "$out" | grep -c '^VAULT_DRIFT: ')
+  [ "$lines" -eq 2 ] || fail "expected exactly two problems, got $lines:"$'\n'"$out"
+  pass "a project with an absent link and a stale vault reports both, distinctly"
+}
+
+test_thresholds_are_overridable_and_invalid_values_fall_back() {
+  local home proj out err
+  home=$(new_home thresholds-are-overridable-and-invalid-values-fall-back)
+  proj="$home/projects/hermes"
+  init_repo "$proj" "$T0"
+  in_repo_vault "$proj" "$T0"
+  project_commits "$proj" 3 $((T0 + DAY))
+
+  out=$(run_drift "$home")
+  [ -z "$out" ] || fail "3 commits behind must be silent at the default threshold, got: $out"
+
+  out=$(run_drift "$home" FM_VAULT_DRIFT_COMMITS=3)
+  assert_contains "$out" "3 project commits landed since, drift window 1d" \
+    "a lowered commit threshold must surface the drift"
+
+  err=$(env FM_VAULT_DRIFT_COMMITS=soon FM_HOME="$home" FM_ROOT_OVERRIDE="$home" \
+    "$DRIFT" 2>&1 >/dev/null)
+  assert_contains "$err" "invalid FM_VAULT_DRIFT_COMMITS 'soon'; using 20" \
+    "an invalid threshold must warn instead of silently disabling the check"
+  out=$(run_drift "$home" FM_VAULT_DRIFT_COMMITS=soon)
+  [ -z "$out" ] || fail "an invalid threshold must fall back to the default, got: $out"
+  pass "drift thresholds are overridable and invalid values fall back loudly"
+}
+
+test_every_registered_project_is_covered() {
+  local home out
+  home=$(new_home every-registered-project-is-covered)
+  mkdir -p "$home/data"
+  cat > "$home/data/projects.md" <<'REG'
+# Projects
+
+- registered [no-mistakes +yolo] - a registered clone with a stale vault (added 2026-07-27)
+- never-cloned [direct-PR] - registered but not cloned here (added 2026-07-27)
+REG
+  init_repo "$home/projects/registered" "$T0"
+  in_repo_vault "$home/projects/registered" "$T0"
+  project_commits "$home/projects/registered" 25 $((T0 + DAY))
+  init_repo "$home/projects/unregistered" "$T0"
+  in_repo_vault "$home/projects/unregistered" "$T0"
+  project_commits "$home/projects/unregistered" 25 $((T0 + DAY))
+
+  out=$(run_drift "$home")
+  assert_contains "$out" "VAULT_DRIFT: registered: in-repo vault stale" \
+    "a registered project must be checked"
+  assert_contains "$out" "VAULT_DRIFT: unregistered: in-repo vault stale" \
+    "a clone missing from the registry must still be checked"
+  assert_not_contains "$out" "never-cloned" \
+    "a registered project with no clone here has nothing to inspect"
+  pass "every registered project with a clone is classified, and extra clones too"
+}
+
+test_detection_never_writes() {
+  local home proj vault before after
+  home=$(new_home detection-never-writes)
+  proj="$home/projects/arknode"
+  init_repo "$proj" "$T0"
+  declare_external "$proj" /vault
+  vault="$home/vaults/arknode"
+  external_vault "$vault" "$T0"
+  ln -s "$vault" "$proj/vault"
+  in_repo_vault "$proj" "$T0" docs/vault
+  project_commits "$proj" 30 $((T0 + 30 * DAY))
+
+  before=$(cd "$proj" && find . -not -path './.git/*' | sort
+    git -C "$proj" status --porcelain
+    git -C "$proj" rev-parse HEAD
+    cd "$vault" && find . -not -path './.git/*' | sort
+    git -C "$vault" status --porcelain
+    git -C "$vault" rev-parse HEAD)
+  run_drift "$home" >/dev/null
+  after=$(cd "$proj" && find . -not -path './.git/*' | sort
+    git -C "$proj" status --porcelain
+    git -C "$proj" rev-parse HEAD
+    cd "$vault" && find . -not -path './.git/*' | sort
+    git -C "$vault" status --porcelain
+    git -C "$vault" rev-parse HEAD)
+  [ "$before" = "$after" ] || fail "detection must not touch the clone or the vault"$'\n'"before: $before"$'\n'"after: $after"
+  pass "detection never writes to a project clone or to a vault"
+}
+
+test_no_vault_is_silent
+test_directory_named_vault_without_marker_is_silent
+test_current_in_repo_vault_is_silent
+test_in_repo_vault_stale_by_commit_count
+test_in_repo_vault_stale_by_drift_window
+test_external_symlinked_vault_stale_reports_the_separate_repo_remedy
+test_current_external_symlinked_vault_is_silent
+test_broken_link_reports_distinctly_from_staleness
+test_absent_link_reports_distinctly_from_staleness
+test_arknode_absent_link_and_stale_vault_at_once
+test_thresholds_are_overridable_and_invalid_values_fall_back
+test_every_registered_project_is_covered
+test_detection_never_writes


### PR DESCRIPTION
## Intent

Build a cheap, deterministic check that surfaces documentation-vault drift for every registered project, so a vault can never again silently fall dozens of commits behind (an ArkNode-AI vault fell 52 commits / 7 days behind on 2026-07-27 and nothing surfaced it - detection depended entirely on a human remembering to look).

Settled design constraints that were given up front, so they are deliberate choices rather than oversights:
- DETECTION ONLY, never auto-write a vault. Vault content is curated knowledge needing judgment; an automated writer would manufacture exactly the stale-but-confident prose that caused the original harm. So there is intentionally no remediation, no sync, no scheduling.
- Handle BOTH vault shapes because they behave completely differently and need different remedies: an in-repo vault directory, which a crewmate can and should update inside its own worktree; and an external symlinked vault pointing at a separate git repo, which a worktree-isolated crewmate structurally CANNOT write and must never be told to.
- No false alarms on a project with no vault. A tracked directory merely named vault/ without the OKF bundle marker 00-Home.md (e.g. ArkNode-AI's scripts/testing/vault fixture) is deliberately ignored, or the check would alarm forever on a test fixture.
- An ABSENT or BROKEN external symlink must report distinctly from a STALE vault, because 'drift cannot be measured at all' is the failure that HIDES staleness, not a form of it, and its remedy differs. ArkNode-AI has both problems at once.
- Report the commit count behind and the drift window, not a bare boolean. Both endpoints are commit timestamps rather than the wall clock, deliberately, so runs are deterministic and repeatable.
- Verify each project's real vault shape by INSPECTION rather than trusting the registry prose in data/projects.md.
- Read-only against project clones: never write under projects/, never touch the captain's live Obsidian copy under ~/.superset/vaults/. A test pins this.
- Keep it proportionate: a small detector, not a sync engine or control plane. Resist added configuration surface beyond the two thresholds detection needs.

Integration was specified to follow the EXISTING detect-only bootstrap convention rather than inventing a new alarm channel, so it emits a VAULT_DRIFT: diagnostic line from bin/fm-bootstrap.sh's detect path (running in detect-only/lock-refused sessions too, since it is read-only), with the handling playbook added to the bootstrap-diagnostics skill and the load trigger added to AGENTS.md section 13.

Two pre-existing, unrelated problems were also found while validating this work, and the standing instruction is to fix test failures encountered along the way. One of them - the session-start suite forcing its MISSING diagnostic by deleting fake node, which a host-installed /usr/bin/node silently satisfied again - was deliberately REVERTED in a follow-up commit on this branch because the same fix already exists on another branch with an open PR, and carrying two copies would guarantee a merge conflict. That revert commit is intentional, not an accidental regression. The other one is kept: bin/fm-test-run.sh's coverage guard compared LC_ALL=C-sorted files using an ambient-locale comm, so --check-coverage failed outright in any non-C locale; nothing else is addressing it.

## What Changed

- Add a read-only detector that inspects project clones for stale in-repo and external documentation vaults, reporting commit and day drift while distinguishing absent, broken, and invalid external targets.
- Surface vault diagnostics after fleet sync and during detect-only bootstrap sessions, with configurable thresholds, handling guidance, and documentation.
- Add deterministic detector and bootstrap coverage, and make the test coverage guard locale-independent.

## Risk Assessment

✅ Low: The detector is read-only and well bounded, and the prior post-sync, marker-validation, and same-repository false-negative paths are now addressed at their shared boundaries with focused regression coverage.

## Testing

After branch-diff inspection, all three targeted behavior scripts and the non-C-locale coverage check passed; fixed-timestamp direct and detect-only bootstrap CLI runs produced attached transcripts proving correct classifications, deterministic counts and windows, marker suppression, and read-only behavior, with a clean worktree afterward.

<details>
<summary>Evidence: Direct vault-drift CLI transcript</summary>

```text
$ FM_HOME=<fixture-home> bin/fm-vault-drift.sh
VAULT_DRIFT: ArkNode-AI: external vault link absent at vault - the project declares an external vault there but this clone has none, so vault drift cannot be measured here at all; restore the link in the clone, or track the vault through its own registered repo
VAULT_DRIFT: ArkNode-AI: external vault stale at projects/trading-signal-ai/vault -> /tmp/no-mistakes-evidence/01KYZECJV2WRBS5KZ71QEJY85W/vault-drift-e2e/external-vaults/ArkNode-AI - vault last updated 2023-11-14, 52 project commits landed since, drift window 7d; the vault is a separate repo, which an isolated project worktree cannot write, so dispatch the update against that repo's own clone
VAULT_DRIFT: Hermes: in-repo vault stale at vault/ - vault last updated 2023-11-14, 20 project commits landed since, drift window 1d; a crewmate can refresh it in its own worktree

$ repeat the same command and compare byte-for-byte
deterministic-repeat: identical

$ compare project and vault Git HEAD/tree/status signatures before and after both runs
read-only-signatures: unchanged

$ verify the tracked scripts/testing/vault directory without 00-Home.md produced no diagnostic
markerless-vault-fixture: ignored
```
</details>
<details>
<summary>Evidence: Detect-only bootstrap relay transcript</summary>

```text
$ FM_BOOTSTRAP_DETECT_ONLY=1 FM_HOME=<fixture-home> bin/fm-bootstrap.sh | grep ^VAULT_DRIFT:
VAULT_DRIFT: ArkNode-AI: external vault link absent at vault - the project declares an external vault there but this clone has none, so vault drift cannot be measured here at all; restore the link in the clone, or track the vault through its own registered repo
VAULT_DRIFT: ArkNode-AI: external vault stale at projects/trading-signal-ai/vault -> /tmp/no-mistakes-evidence/01KYZECJV2WRBS5KZ71QEJY85W/vault-drift-e2e/external-vaults/ArkNode-AI - vault last updated 2023-11-14, 52 project commits landed since, drift window 7d; the vault is a separate repo, which an isolated project worktree cannot write, so dispatch the update against that repo's own clone
VAULT_DRIFT: Hermes: in-repo vault stale at vault/ - vault last updated 2023-11-14, 20 project commits landed since, drift window 1d; a crewmate can refresh it in its own worktree
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed (2) ✅</summary>

- 🚨 `bin/fm-bootstrap.sh:906` - The required goal says vault drift must not silently fall dozens of commits behind, but this check runs before normal-mode `fleet_sync`. A clone can initially appear current, then bootstrap fast-forwards it by 52 commits and exits without checking the resulting state. Run detection after `fleet_sync` in normal mode while retaining a read-only detect-only path.
- 🚨 `bin/fm-vault-drift.sh:141` - The required no-false-alarm criterion relies on `00-Home.md` to distinguish a vault, but every root `vault` symlink is accepted and `check_external` never verifies that marker. A project with an unrelated `vault` symlink to any Git repository can therefore emit a stale-vault diagnostic. Validate the marker before stale classification, distinguishing declared-but-invalid targets from undeclared non-vault symlinks.

🔧 Fix: Fix post-sync vault drift and marker validation
1 error still open:
- 🚨 `bin/fm-vault-drift.sh:191` - The required external shape is “an external symlinked vault pointing at a separate git repo,” but `rev-parse --show-toplevel` accepts an ancestor repository. A declared ignored `vault/` directory containing `00-Home.md` but no separate `.git` resolves to the project repo, making `vault_ts` equal project HEAD and silently reporting no drift. Before measuring timestamps, require the resolved vault repository to differ from the project repository and report `target invalid` otherwise.

🔧 Fix: Reject project repository as external vault target
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>Inspected `git diff --stat` and changed files for `1e247571aa75e00b00c7a01c4830025ecd44dc61..838f0195e7c0a5bee94ae7c63c3e6a140665875e`</code>
- `bin/fm-test-run.sh tests/fm-vault-drift.test.sh tests/fm-bootstrap.test.sh tests/fm-test-run.test.sh`
- `LC_ALL=en_US.utf8 bin/fm-test-run.sh --check-coverage`
- <code>Ran `bin/fm-vault-drift.sh` twice against fixed-timestamp external, in-repo, absent-link, and markerless fixtures; compared output byte-for-byte and verified unchanged Git signatures</code>
- <code>Ran `FM_BOOTSTRAP_DETECT_ONLY=1 bin/fm-bootstrap.sh` against the fixture and captured the relayed diagnostics</code>
- <code>`git status --porcelain` confirmed no testing artifacts remained in the worktree</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
