### PR TITLE
feat(skills): require a post-PR retrospective before presenting a ready PR

### DIFF
--- a/.agents/skills/post-pr-retrospective/SKILL.md
+++ b/.agents/skills/post-pr-retrospective/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: post-pr-retrospective
+description: >-
+  Agent-only procedure for every Firstmate-owned PR that becomes review-ready.
+  Use before presenting the PR recap or merging to ask every material worker how the work could have been completed faster and more effectively, verify the answers, and immediately route reusable improvements into their authoritative AGENTS.md, skill, script, documentation, or private operational owner.
+user-invocable: false
+metadata:
+  internal: true
+---
+
+# post-pr-retrospective
+
+Load this skill whenever a Firstmate-owned PR first becomes ready for review, before the required Lavish PR recap and before any merge.
+This retrospective is part of finishing the PR, not optional backlog work.
+A truthful no-op is correct when the evidence reveals no reusable improvement.
+
+## Ask the workers
+
+Ask every worker that materially implemented, investigated, reviewed, or recovered the delivered result this exact bounded question without authorizing file changes:
+
+> Looking only at this completed work, what could have made it materially faster or more effective without weakening safety, correctness, proof, or the captain's accepted intent?
+> Name the concrete friction or mistake, the earliest point it could have been prevented, and one reusable change to an existing instruction, skill, script, test, or tool.
+> Omit generic advice, task-specific trivia, and anything already owned correctly.
+> If no reusable change is justified, say so.
+
+Use the target worker's verified send path from `harness-adapters`.
+Do not ask a worker to edit the PR after validation has completed.
+When multiple workers contributed, preserve disagreements rather than averaging them into false consensus.
+
+## Verify before distilling
+
+Treat each answer as a hypothesis until direct evidence supports it.
+Check the completed diff, validation findings, status history, report, or exact tool behavior that the worker cites.
+Reject suggestions that merely request more process, duplicate an existing owner, restate task chronology, optimize for one harness without reviewing the supported fleet, or weaken a safety or proof boundary.
+Ask what observation would disconfirm the proposed improvement, and run the smallest safe check when the claim is load-bearing.
+
+A reusable improvement must satisfy all of these conditions:
+
+- It prevented or prolonged a real issue in the completed work.
+- It applies beyond the exact branch, identifier, temporary path, or incident.
+- Its destination is the authoritative owner rather than a convenient duplicate.
+- The proposed change is smaller than the recurring cost it removes.
+- Its acceptance check can show the process became faster or more effective without weakening correctness.
+
+## Route immediately
+
+Route each verified improvement to the most specific owner.
+
+- Project-wide knowledge needed by almost every contributor belongs in that project's `AGENTS.md`, using `bin/fm-ensure-agents-md.sh` and the project's normal delivery path.
+- A named conditional workflow belongs in the relevant project or Firstmate skill, with one concise load trigger in its always-loaded instruction surface.
+- Deterministic mechanics belong in the owning script and its `--help`, with a behavior-level regression test.
+- Shared Firstmate lifecycle behavior belongs in Firstmate's tracked surface after loading `firstmate-coding-guidelines`.
+- Captain working preferences belong in the appropriate private `data/captain.md` or main-authoritative `data/captain-shared.md` after inspect-then-update.
+- Task chronology and one-off evidence stay in the report or PR and never become standing instruction.
+
+Apply verified improvements in the current workflow rather than creating ordinary backlog debt.
+Do not widen or mutate the already-validated PR.
+Use a separate small delivery change when tracked material must change, and follow that repository's normal validation, visual recap, and merge authority.
+When direct project editing is not currently and concretely authorized, dispatch the immediate bounded follow-up through Firstmate rather than writing the project yourself.
+Record a captain decision only when the improvement changes product behavior, approval authority, destructive scope, security posture, or another boundary the captain owns.
+
+## Report the result
+
+Include a short retrospective section in the PR's Lavish recap with:
+
+- the concrete friction found;
+- the verified reusable improvement and its owner;
+- whether it was applied, opened as an immediate separate delivery, or rejected;
+- the evidence that safety, correctness, and proof were not weakened.
+
+Do not expose worker mechanics or internal status labels in captain-facing text.
+Do not claim continuous improvement when the result was a no-op.

--- a/.agents/skills/post-pr-retrospective/SKILL.md
+++ b/.agents/skills/post-pr-retrospective/SKILL.md
@@ -10,13 +10,13 @@ metadata:
 
 # post-pr-retrospective
 
-Load this skill whenever a Firstmate-owned PR first becomes ready for review, before the required Lavish PR recap and before any merge.
+Load this skill whenever a Firstmate-owned PR first becomes ready for review, before section 7's PR-ready captain report and before any merge.
 This retrospective is part of finishing the PR, not optional backlog work.
 A truthful no-op is correct when the evidence reveals no reusable improvement.
 
 ## Ask the workers
 
-Ask every worker that materially implemented, investigated, reviewed, or recovered the delivered result this exact bounded question without authorizing file changes:
+Ask every still-reachable worker that materially implemented, investigated, reviewed, or recovered the delivered result this exact bounded question without authorizing file changes:
 
 > Looking only at this completed work, what could have made it materially faster or more effective without weakening safety, correctness, proof, or the captain's accepted intent?
 > Name the concrete friction or mistake, the earliest point it could have been prevented, and one reusable change to an existing instruction, skill, script, test, or tool.
@@ -24,6 +24,7 @@ Ask every worker that materially implemented, investigated, reviewed, or recover
 > If no reusable change is justified, say so.
 
 Use the target worker's verified send path from `harness-adapters`.
+Cover a material contributor that no longer has a live send path, such as a torn-down scout, a replaced worker, or an automated validation step, from its self-contained report, review or validation findings, status history, and the completed diff, and never relaunch or rebuild one to answer this question.
 Do not ask a worker to edit the PR after validation has completed.
 When multiple workers contributed, preserve disagreements rather than averaging them into false consensus.
 
@@ -36,7 +37,7 @@ Ask what observation would disconfirm the proposed improvement, and run the smal
 
 A reusable improvement must satisfy all of these conditions:
 
-- It prevented or prolonged a real issue in the completed work.
+- It would have prevented or shortened a real issue in the completed work.
 - It applies beyond the exact branch, identifier, temporary path, or incident.
 - Its destination is the authoritative owner rather than a convenient duplicate.
 - The proposed change is smaller than the recurring cost it removes.
@@ -44,28 +45,31 @@ A reusable improvement must satisfy all of these conditions:
 
 ## Route immediately
 
-Route each verified improvement to the most specific owner.
+AGENTS.md section 6 is the source of truth for durable-knowledge destinations; select each verified improvement's owner there rather than re-deriving that mapping.
 
-- Project-wide knowledge needed by almost every contributor belongs in that project's `AGENTS.md`, using `bin/fm-ensure-agents-md.sh` and the project's normal delivery path.
-- A named conditional workflow belongs in the relevant project or Firstmate skill, with one concise load trigger in its always-loaded instruction surface.
-- Deterministic mechanics belong in the owning script and its `--help`, with a behavior-level regression test.
-- Shared Firstmate lifecycle behavior belongs in Firstmate's tracked surface after loading `firstmate-coding-guidelines`.
-- Captain working preferences belong in the appropriate private `data/captain.md` or main-authoritative `data/captain-shared.md` after inspect-then-update.
+Only these routing behaviors are specific to a retrospective improvement:
+
+- A deterministic mechanic belongs in the owning script and its `--help`, and lands together with a behavior-level regression test.
+- A named conditional workflow belongs in the relevant skill, with one concise load trigger in its always-loaded instruction surface.
+- Firstmate's shared tracked material changes only after loading `firstmate-coding-guidelines`.
+- A project's `AGENTS.md` is written only by a crewmate through that project's selected delivery path with `bin/fm-ensure-agents-md.sh`, never by Firstmate.
 - Task chronology and one-off evidence stay in the report or PR and never become standing instruction.
 
 Apply verified improvements in the current workflow rather than creating ordinary backlog debt.
 Do not widen or mutate the already-validated PR.
-Use a separate small delivery change when tracked material must change, and follow that repository's normal validation, visual recap, and merge authority.
-When direct project editing is not currently and concretely authorized, dispatch the immediate bounded follow-up through Firstmate rather than writing the project yourself.
+Use a separate small delivery change when tracked material must change, and follow that repository's normal validation and merge authority.
+The retrospective and its routing decision must finish before the PR is presented, while that separate delivery only has to be initiated immediately and does not itself block presenting or merging the already-ready PR.
+The single exception is an improvement whose evidence shows the ready PR is unsafe, which is a stop-and-report result rather than a follow-up.
 Record a captain decision only when the improvement changes product behavior, approval authority, destructive scope, security posture, or another boundary the captain owns.
 
 ## Report the result
 
-Include a short retrospective section in the PR's Lavish recap with:
+Include a short retrospective note in the PR-ready captain report with:
 
 - the concrete friction found;
 - the verified reusable improvement and its owner;
-- whether it was applied, opened as an immediate separate delivery, or rejected;
+- whether it was applied, initiated as an immediate separate delivery, or rejected;
+- any material contributor covered only from recorded artifacts because it was no longer reachable;
 - the evidence that safety, correctness, and proof were not weakened.
 
 Do not expose worker mechanics or internal status labels in captain-facing text.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -511,7 +511,7 @@ These skills are not captain-invocable; load them only at their precise triggers
   Never run a registered source's blocking command yourself in a conversational turn.
 - `fmx-respond` - load on an `x-mention <request_id>` `check:` wake to handle the mention, on an `x-mode-error ...` `check:` wake to report the X-mode configuration blocker, on a `public-followup ...` `check:` wake or a startup-surfaced public commitment, and on any milestone or terminal wake for an X-mode-linked task before posting its completion follow-up; relevant only when X mode is on.
 - `firstmate-codexapp` - load before coordinating a visible Codex Desktop thread, evaluating a Codex App backend request, or reconciling Codex Desktop host-tool smoke evidence for Firstmate work.
-- `post-pr-retrospective` - load whenever a Firstmate-owned PR first becomes ready, before its Lavish recap or merge, to ask every material worker how the completed work could have been faster or more effective and immediately route only verified reusable improvements to their authoritative owners.
+- `post-pr-retrospective` - load whenever a Firstmate-owned PR first becomes ready, before its PR-ready captain report or merge, to ask every material worker how the completed work could have been faster or more effective and immediately route only verified reusable improvements to their authoritative owners.
 - `firstmate-coding-guidelines` - load before changing firstmate's shared, tracked material, as defined by section 1's list, whether editing directly or briefing a crewmate for a firstmate-repo task.
 
 ## 14. X mode

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -332,6 +332,7 @@ The worker reports the PR when CI first becomes green rather than waiting for me
 ### PR ready, landing, and teardown
 
 For PR-based ship tasks, the ready signal depends on mode: `no-mistakes` reports `done: PR <url> checks green` after CI is green, while `direct-PR` reports `done: PR <url>` after opening the PR.
+Before presenting any ready PR or merging it, load `post-pr-retrospective` and immediately complete its evidence-backed improvement routing; a truthful no-op is allowed, but ordinary backlog deferral is not.
 Run `bin/fm-pr-check.sh <id> <PR url>` - it records `pr=` and the forge's `pr_head=` when available in the task's meta and arms the watcher's merge poll.
 Tell the captain the PR's full URL, always the complete `https://...` link rather than a bare `#number`, a concise outcome summary, and the no-mistakes risk level when applicable.
 A captain instruction to merge is explicit authority; `yolo` is the only standing routine authority.
@@ -510,6 +511,7 @@ These skills are not captain-invocable; load them only at their precise triggers
   Never run a registered source's blocking command yourself in a conversational turn.
 - `fmx-respond` - load on an `x-mention <request_id>` `check:` wake to handle the mention, on an `x-mode-error ...` `check:` wake to report the X-mode configuration blocker, on a `public-followup ...` `check:` wake or a startup-surfaced public commitment, and on any milestone or terminal wake for an X-mode-linked task before posting its completion follow-up; relevant only when X mode is on.
 - `firstmate-codexapp` - load before coordinating a visible Codex Desktop thread, evaluating a Codex App backend request, or reconciling Codex Desktop host-tool smoke evidence for Firstmate work.
+- `post-pr-retrospective` - load whenever a Firstmate-owned PR first becomes ready, before its Lavish recap or merge, to ask every material worker how the completed work could have been faster or more effective and immediately route only verified reusable improvements to their authoritative owners.
 - `firstmate-coding-guidelines` - load before changing firstmate's shared, tracked material, as defined by section 1's list, whether editing directly or briefing a crewmate for a firstmate-repo task.
 
 ## 14. X mode

--- a/docs/documentation-audiences.json
+++ b/docs/documentation-audiences.json
@@ -157,6 +157,10 @@
       "audience": "agent-runtime"
     },
     {
+      "path": ".agents/skills/post-pr-retrospective/SKILL.md",
+      "audience": "agent-runtime"
+    },
+    {
       "path": ".agents/skills/process-event-sources/SKILL.md",
       "audience": "agent-runtime"
     },


### PR DESCRIPTION
## Intent

The captain requires every completed pull request to receive an immediate manual retrospective before review or merge: ask every materially involved worker how the work could have been completed faster and more effectively without weakening safety, verify the claims, and distill only reusable evidence-backed improvements into the authoritative AGENTS.md, skill, script, test, documentation, or private preference owner. This must be part of finishing the PR rather than ordinary backlog debt, while a truthful no-op remains valid. Do not mutate an already-validated PR; use an immediate separate delivery when tracked changes are justified. Preserve Firstmate's project-write, merge-authority, no-mistakes, visual-review, one-owner, and safety boundaries. Implement the policy now in Firstmate's shared instructions and an internal trigger-specific skill, with no script because no deterministic mechanic is justified yet.

## What Changed

- Adds the internal, agent-only `.agents/skills/post-pr-retrospective/SKILL.md`: it defines the bounded question asked of every material worker over its verified `harness-adapters` send path, covers unreachable contributors (torn-down scouts, replaced workers, automated validation steps) from their recorded artifacts instead of relaunching them, sets a five-condition evidence bar before an answer counts as a reusable improvement, and defers to AGENTS.md section 6 for destination routing while adding only the retrospective-specific rules (script plus regression test, skill plus one load trigger, `firstmate-coding-guidelines` before shared tracked material, a project's `AGENTS.md` written only by a crewmate via `bin/fm-ensure-agents-md.sh`, chronology stays in the report).
- Wires the policy into `AGENTS.md`: section 7's PR-ready path now requires loading the skill and completing its routing before presenting or merging a ready PR, with a truthful no-op allowed but ordinary backlog deferral disallowed, and section 13 gains the matching non-captain-invocable load trigger. The skill keeps the already-validated PR unmutated by routing justified tracked changes into an immediate separate delivery that only has to be initiated, not merged, before presentation.
- Classifies the new skill as `agent-runtime` in `docs/documentation-audiences.json`, which `bin/fm-doc-audience-check.sh` and `tests/fm-documentation-audiences.test.sh` require for every tracked prose surface. One review info note remains open: the skill's frontmatter description still says "PR recap" where the body and AGENTS.md now name section 7's PR-ready captain report. The Test phase flagged `tests/fm-calm-pi-extension.test.sh` as a pre-existing machine-local flake unrelated to these three files.

## Risk Assessment

✅ Low: The change is instruction-only and well-bounded, the blocking documentation-inventory failure is fixed and verified by set comparison, and every boundary-wording concern now matches AGENTS.md sections 1, 6, and 7, leaving only a one-line terminology leftover in the skill's frontmatter.

## Testing

Ran the repo's own change-based selection (28 pure-contract-unit scripts) plus the directly relevant documentation-audience suite, then proved the actual intent with real-harness transcripts rather than assertions on instruction bytes, which this repo's coding guidelines explicitly forbid: an isolated `claude` session loaded with the tracked AGENTS.md and skills invoked `Skill(post-pr-retrospective)` as its first move at the PR-ready moment, quoted the section 7 trigger, and sequenced ask-workers, artifact-only coverage for the torn-down scout, verification, immediate routing, recap, and merge-waits-for-captain; the same prompt against the base commit produced no retrospective and stated no skill was triggered. A second probe confirmed the forbidden behaviors are refused (no amending the validated PR, no Firstmate write to a project's AGENTS.md, no backlog deferral, truthful no-op accepted). There is no UI surface in this change, so evidence is CLI transcripts of the real harness rather than screenshots. The only failure was `tests/fm-calm-pi-extension.test.sh`, which I confirmed flaky by rerunning it (different sub-case failed, then a clean pass) and which touches none of the changed files. The worktree is clean and all evidence lives in the dedicated evidence directory.

<details>
<summary>Evidence: Live harness A/B evidence: retrospective fires at PR-ready with the change, absent at base</summary>

```text
# Live evidence: post-PR retrospective policy (branch fm/post-pr-retrospective)

Real `claude` harness driven headlessly against an isolated copy of Firstmate's tracked instruction surface.
Lab A = target commit 66b7761 (AGENTS.md + .agents/skills). Lab B = base commit e5e8a67.
Tools limited to Read/Glob/Grep/Skill; no project state touched.

## Scenario 1 prompt (identical in both labs)
`` `
Crewmate task fm-1841 (mode: no-mistakes, in your own firstmate repo) just reported: done: PR https://github.com/arena/firstmate/pull/1650 checks green.
Materially involved workers: the implementation crewmate (still live in its window), a scout that was torn down after writing its report, and the no-mistakes review and test validation steps.
Walk me through exactly what you do next, in order, before I see the PR recap or approve a merge.
Name every skill you load and quote the specific instruction line that requires each step.
`` `

## Lab A (with the change) - firstmate loads post-pr-retrospective before recap or merge
`` `
[TEXT] I'll load the skill that governs this exact moment so I can quote its procedure precisely rather than paraphrase it.
[TOOL] Skill {"skill": "post-pr-retrospective"}
[TEXT] Captain, here's the exact sequence, in order, before you see anything.

**1. Load `post-pr-retrospective` — mandatory before presenting or merging.**
AGENTS.md section 7 requires it directly: *"Before presenting any ready PR or merging it, load `post-pr-retrospective` and immediately complete its evidence-backed improvement routing; a truthful no-op is allowed, but ordinary backlog deferral is not."*
The skill itself restates its own trigger: *"Load this skill whenever a Firstmate-owned PR first becomes ready for review, before section 7's PR-ready captain report and before any merge."*

**2. Load `harness-adapters` before contacting the still-live implementation crewmate.**
The retrospective skill says: *"Use the target worker's verified send path from `harness-adapters`."* Section 13 backs that: *"harness-adapters - load before spawning or recovering a crewmate or secondmate, handling a trust dialog, sending a harness-specific skill invocation..."* I send the implementation crewmate the exact bounded question from the skill, without authorizing any file changes.

**3. Cover the torn-down scout and the automated no-mistakes review/test steps from their artifacts, not by relaunching them.**
Quoting the skill: *"Cover a material contributor that no longer has a live send path, such as a torn-down scout, a replaced worker, or an automated validation step, from its self-contained report, review or validation findings, status history, and the completed diff, and never relaunch or rebuild one to answer this question."* So the scout's report and the recorded no-mistakes review/test findings substitute for asking them directly.

**4. Verify each answer before accepting it.**
*"Treat each answer as a hypothesis until direct evidence supports it... Reject suggestions that merely request more process, duplicate an existing owner, restate task chronology, optimize for one harness... or weaken a safety or proof boundary."* I check the diff, validation findings, and status history against whatever the crewmate reports.

**5. Route any verified improvement to its authoritative owner immediately.**
Per the skill, AGENTS.md section 6 governs the destination. If a verified improvement targets firstmate's own tracked material (this is fm-1841, in the firstmate repo itself), I load `firstmate-coding-guidelines` first: *"Firstmate's shared tracked material changes only after loading `firstmate-coding-guidelines`."* — and section 11 independently requires it for any ship brief touching shared tracked material: *"If a ship task touches firstmate's shared tracked material, explicitly require `firstmate-coding-guidelines` before editing."* A genuine no-op finding is acceptable and gets recorded as such; deferring a real one to ordinary backlog is not.

**6. Record `bin/fm-pr-check.sh <id> <PR url>`.**
Section 7: *"Run `bin/fm-pr-check.sh <id> <PR url>` - it records `pr=` and the forge's `pr_head=` when available in the task's meta and arms the watcher's merge poll."*

**7. Only then, present the PR recap to you.**
Section 7: *"Tell the captain the PR's full URL, always the complete `https://...` link rather than a bare `#number`, a concise outcome summary, and the no-mistakes risk level when applicable."* That recap includes the retrospective's short note (friction found, improvement and owner, applied/initiated/rejected, any contributor covered only from artifacts, and the safety-not-weakened evidence) per the skill's "Report the result" section.

**8. Merge waits for your explicit word.**
Hard rule 2: *"Never merge a PR without the captain's explicit word."* Nothing in this task's recorded posture makes it `yolo`, so this repo's own PR follows the same standing default as any other project — I hold at the recap and wait for you to say merge.

So: `post-pr-retrospective` (with `harness-adapters` nested inside it, and `firstmate-coding-guidelines` only if a fix lands in firstmate's own tracked material) is the entire gate between "checks green" and the recap you'll see, aye.
[RESULT turns=3]
`` `

## Lab B (baseline, same prompt) - no retrospective exists
`` `
[TEXT] Captain, here's the exact sequence, in order, before the recap reaches you.

**1. Drain the wake queue first, don't act on the report line alone.**
Section 8: *"At the start of every wake-handling turn, drain the durable wake queue before peeking, reading beyond the reason line, steering, or starting work."*
This "done" report is a wake event, so it gets read in that queue context, not treated as a standalone message.

**2. Reconcile actual state through the crew-state tool, not the status line.**
Section 8: *"A status line is a wake event, not current state; use bin/fm-crew-state.sh when current state matters."*
And section 7 (Validate): *"Judge validation by the current-code-matched run step through bin/fm-crew-state.sh, not by shell liveness or the last status event... passed or checks-passed is done; failed or cancelled is failed."*
So I run `bin/fm-crew-state.sh fm-1841` and confirm the pipeline is genuinely at checks-passed, not just trusting the reported line. This also matches the wake-type handling in section 8: *"For signal:, read the listed event lines first, then reconcile current state only where action depends on it."*

**3. Confirm the report matches the mode's actual definition of done.**
Section 7: *"For PR-based ship tasks, the ready signal depends on mode: no-mistakes reports done: PR <url> checks green after CI is green."*
fm-1841 is no-mistakes mode and reported exactly that shape, consistent with: *"The worker reports the PR when CI first becomes green rather than waiting for merge monitoring to finish."*

**4. Register the PR and arm the merge poll.**
Section 7: *"Run bin/fm-pr-check.sh <id> <PR url> - it records pr= and the forge's pr_head= when available in the task's meta and arms the watcher's merge poll."*
I run `bin/fm-pr-check.sh fm-1841 https://github.com/arena/firstmate/pull/1650`.

**5. Leave the implementation crewmate's window alone.**
Section 7: *"Tear down a ship task only after landing is confirmed."*
It stays live, untouched, until the PR actually lands, not just because checks are green.

**6. Update the backlog entry.**
Section 10: *"Update the backlog on every dispatch, completion, and decision for a work item."*
I mark fm-1841 as PR-ready and awaiting your merge decision, not "done" (it isn't, until merged).

**7. No skill load is triggered here.**
No ask-user finding was returned (checks green implies none), so `ask-user-authority` doesn't fire. The scout's completion gate already ran before its worktree was discarded (hard rule 3: *"A scout worktree is declared scratch and may be discarded only after its report exists and the shared unresolved-decision completion gate passes"*), so `decision-hold-lifecycle` isn't reloaded now. Nothing here spawns, recovers, or resumes an agent, so `harness-adapters` isn't loaded either. This step runs entirely on the always-loaded section 7/8/9/10 contract, no skill needed.

**8. Then, and only then, the recap.**
Section 9: *"Whenever a PR is mentioned, include its full https://... URL before any shorthand reference"* and *"Lead directly with concrete evidence, then the consequence, options when applicable, and a recommendation."* That's the message you'd actually see next: full PR URL, outcome, no-mistakes risk level, and a merge recommendation, but no merge action, since hard rule 2 stands: *"Never merge a PR without the captain's explicit word."*

Nothing beyond step 4 changes any project state, aye.
[RESULT turns=1]
`` `

## Scenario 2 prompt (boundary probe, Lab A)
`` `
Continuing task fm-1841 (no-mistakes PR https://github.com/arena/firstmate/pull/1650, checks green, validation already complete).
You ran the post-PR retrospective. The live implementation crewmate answered with three items:
(a) "bin/fm-brief.sh should say when to load firstmate-coding-guidelines for firstmate-repo briefs - I lost 40 minutes rediscovering it, and the guidelines skill itself says firstmate adds it by hand";
(b) "the project we touched should get a note in its own AGENTS.md so the next worker knows";
(c) "we should all just be more careful next time".
The scout's report shows no friction beyond (a). Answer precisely, for each item:
1. Do you accept or reject it, and on what evidence?
2. Where does an accepted improvement land, and who is allowed to write there?
3. Do you amend or re-push PR 1650 to carry the fix?
4. If nothing survived verification, what do you tell me, and may you park the retrospective on the backlog instead?
Quote the instruction line that decides each answer.
`` `

## Lab A boundary result
`` `
[TEXT] Captain, here is the retrospective disposition for fm-1841, item by item, with the deciding instruction quoted for each call.

## (a) bin/fm-brief.sh should document when to load firstmate-coding-guidelines

**1. Accept.** Concrete evidence: 40 minutes lost, and the gap is corroborated by the guidelines skill's own text ("firstmate adds it by hand"). The scout's report independently confirms this is the only friction encountered, satisfying the retrospective's verification bar: *"ask every material worker how the completed work could have been faster or more effective and immediately route only verified reusable improvements to their authoritative owners."* (post-pr-retrospective, section 13)

**2. Lands in `bin/fm-brief.sh`, which is shared tracked material** — *"Shared tracked material is AGENTS.md, README.md, CONTRIBUTING.md, .tasks.toml, .github/workflows/, bin/, .agents/skills/, and public skills/."* (section 1). Editing it first requires the guidelines skill itself: *"load before changing firstmate's shared, tracked material, as defined by section 1's list, whether editing directly or briefing a crewmate for a firstmate-repo task."* (section 13, firstmate-coding-guidelines) Who may write it depends on current fleet state: *"When any crewmate is live, delegate changes to shared tracked material rather than competing with supervision; when the fleet is empty, firstmate may change it directly."* (section 1) I'll check the live fleet before touching it myself.

**3. No amend/re-push of PR 1650.** PR 1650 belongs to the project repo; `bin/fm-brief.sh` belongs to firstmate's own repo — different delivery surface entirely. It ships as its own task: *"Ship shared tracked changes through this repo's no-mistakes pipeline and PR path, with the same merge authority as any other project."* (section 1)

## (b) note in the project's own AGENTS.md

**1. Reject, unverified.** The worker's ask names no concrete friction it caused; the scout's independent report shows *"no friction beyond (a)"* — that's the verification check, and it fails for (b). The mandate is explicit that only *verified* improvements get routed: *"immediately complete its evidence-backed improvement routing; a truthful no-op is allowed, but ordinary backlog deferral is not."* (section 7)

**2. N/A given the rejection**, but for completeness: even if it had survived, I could not write it myself — *"Firstmate never writes a project's AGENTS.md directly. A crewmate creates or updates it lazily through the project's selected delivery path, using bin/fm-ensure-agents-md.sh and preferring pointers to authoritative sources over copied detail."* (section 6)

**3. No amend/re-push** — moot, since it did not survive verification.

## (c) "we should all just be more careful next time"

**1. Reject outright.** Not evidence-backed and not mechanically actionable — nothing to verify or route, so it never engages the retrospective's routing step at all.

**2/3.** N/A.

## 4. Overall disposition and reporting

Not everything failed verification — (a) survived, (b) and (c) did not. For (b) and (c), the answer is the same line that governs a full null result: *"a truthful no-op is allowed, but ordinary backlog deferral is not."* (section 7) So I'm telling you plainly, right now, that (b) and (c) were rejected for lack of verifying evidence — I am not filing them as backlog items to revisit later; that would be exactly the "ordinary backlog deferral" the instruction forbids. (a) alone gets routed as a new firstmate-repo task against `bin/fm-brief.sh`.
[RESULT turns=1]
`` `
```
</details>
<details>
<summary>Evidence: Decisive transcript excerpt (target commit): skill loaded before recap or merge</summary>

```text
[TEXT] I'll load the skill that governs this exact moment so I can quote its procedure precisely rather than paraphrase it.
[TOOL] Skill {"skill": "post-pr-retrospective"}
[TEXT] Captain, here's the exact sequence, in order, before you see anything.

**1. Load `post-pr-retrospective` - mandatory before presenting or merging.**
AGENTS.md section 7 requires it directly: "Before presenting any ready PR or merging it, load `post-pr-retrospective` and immediately complete its evidence-backed improvement routing; a truthful no-op is allowed, but ordinary backlog deferral is not."
...
**3. Cover the torn-down scout and the automated no-mistakes review/test steps from their artifacts, not by relaunching them.**
...
**8. Merge waits for your explicit word.**

--- same prompt, BASELINE e5e8a67 ---
**7. No skill load is triggered here.**
... This step runs entirely on the always-loaded section 7/8/9/10 contract, no skill needed.
(baseline transcript contains 0 occurrences of "retrospective")
```
</details>
<details>
<summary>Evidence: Boundary probe transcript (target commit): rejects unverified items, refuses PR mutation and backlog deferral</summary>

```text
(a) accept -> lands in bin/fm-brief.sh, shared tracked material, requires firstmate-coding-guidelines first; "No amend/re-push of PR 1650 ... It ships as its own task"
(b) reject, unverified -> "even if it had survived, I could not write it myself - 'Firstmate never writes a project's AGENTS.md directly.'"
(c) reject outright -> "Not evidence-backed and not mechanically actionable"
overall -> "I am not filing them as backlog items to revisit later; that would be exactly the 'ordinary backlog deferral' the instruction forbids."
```
</details>
<details>
<summary>Evidence: Raw stream-json transcript, target commit, PR-ready scenario</summary>

```text
{"type":"system","subtype":"init","cwd":"/private/var/folders/h4/lyvh74bs0vbcnzfccgwt5lcc0000gn/T/no-mistakes-evidence/01KZ5J7GJ2MJF9EZYVT92K7NBF/live-firstmate-lab","session_id":"79a8c399-fbf2-4361-99ff-bf5c31ad80e6","tools":["Task","Bash","CronCreate","CronDelete","CronList","DesignSync","Edit","EnterWorktree","ExitWorktree","Glob","Grep","Monitor","NotebookEdit","PushNotification","Read","RemoteTrigger","ReportFindings","ScheduleWakeup","SendMessage","Skill","TaskCreate","TaskGet","TaskList","TaskOutput","TaskStop","TaskUpdate","ToolSearch","WebFetch","WebSearch","Workflow","Write","mcp__claude_ai_Gmail__apply_sensitive_message_label","mcp__claude_ai_Gmail__apply_sensitive_thread_label","mcp__claude_ai_Gmail__create_draft","mcp__claude_ai_Gmail__create_label","mcp__claude_ai_Gmail__delete_label","mcp__claude_ai_Gmail__get_message","mcp__claude_ai_Gmail__get_thread","mcp__claude_ai_Gmail__label_message","mcp__claude_ai_Gmail__label_thread","mcp__claude_ai_Gmail__list_drafts","mcp__claude_ai_Gmail__list_labels","mcp__claude_ai_Gmail__search_threads","mcp__claude_ai_Gmail__unlabel_message","mcp__claude_ai_Gmail__unlabel_thread","mcp__claude_ai_Gmail__update_draft","mcp__claude_ai_Gmail__update_label","mcp__claude_ai_Google_Drive__copy_file","mcp__claude_ai_Google_Drive__create_file","mcp__claude_ai_Google_Drive__download_file_content","mcp__claude_ai_Google_Drive__get_file_metadata","mcp__claude_ai_Google_Drive__get_file_permissions","mcp__claude_ai_Google_Drive__list_recent_files","mcp__claude_ai_Google_Drive__read_file_content","mcp__claude_ai_Google_Drive__search_files"],"mcp_servers":[{"name":"claude.ai Google Drive","status":"connected"},{"name":"claude.ai Gmail","status":"connected"}],"model":"claude-sonnet-5","permissionMode":"default","slash_commands":["no-mistakes","afk","ahoy","bearings","stow","updatefirstmate","deep-research","design-sync","dataviz","update-config","verify","debug","code-review","simplify","batch","fewer-permission-prompts","doctor","loop","schedule","claude-api","run","run-skill-generator","agents","autocompact","clear","color","compact","config","context","effort","fast","heapdump","init","mcp","model","__remote-workflow","workflow-launch-exec","reload-skills","rename","review","ultrareview","security-review","usage-credits","extra-usage","usage","insights","recap","goal","design","design-consent","design-revoke","team-onboarding"],"apiKeySource":"none","claude_code_version":"2.1.221","output_style":"default","agents":["claude","Explore","general-purpose","Plan","statusline-setup"],"skills":["no-mistakes","afk","ahoy","bearings","stow","updatefirstmate","deep-research","design-sync","dataviz","update-config","verify","debug","code-review","simplify","batch","fewer-permission-prompts","doctor","loop","schedule","claude-api","run","run-skill-generator"],"plugins":[],"capabilities":["interrupt_receipt_v1","interrupt_cancel_queued_v1","msg_lifecycle_v1"],"analytics_disabled":false,"product_feedback_disabled":false,"uuid":"2ce685ef-280b-4eff-821f-04ca1ad073ea","memory_paths":{"auto":"/Users/alimohammad/.claude/projects/-private-var-folders-h4-lyvh74bs0vbcnzfccgwt5lcc0000gn-T-no-mistakes-evidence-01KZ5J7GJ2MJF9EZYVT92K7NBF-live-firstmate-lab/memory/"},"fast_mode_state":"off","fast_mode_disabled_reason":"sdk_opt_in_required"}
{"type":"rate_limit_event","rate_limit_info":{"status":"allowed","resetsAt":1785831600,"rateLimitType":"five_hour","overageStatus":"rejected","overageDisabledReason":"org_level_disabled","isUsingOverage":false},"uuid":"c677be79-4b66-4bcf-9c7c-a5c2c6a20bc3","session_id":"79a8c399-fbf2-4361-99ff-bf5c31ad80e6"}
{"type":"system","subtype":"thinking_tokens","estimated_tokens":50,"estimated_tokens_delta":50,"uuid":"5a3d0154-b21b-4d7a-b15c-8bda1cdb734b","session_id":"79a8c399-fbf2-4361-99ff-bf5c31ad80e6"}
{"type":"system","subtype":"thinking_tokens","estimated_tokens":150,"estimated_tokens_delta":100,"uuid":"37c98165-55b9-49c9-b057-6c3fb68b820c","session_id":"79a8c399-fbf2-4361-99ff-bf5c31ad80e6"}
{"type":"system","subtype":"thinking_tokens","estimated_tokens":300,"estimated_tokens_delta":150,"uuid":"4aba25de-5622-4751-942f-bb6d7d4a31c0","session_id":"79a8c399-fbf2-4361-99ff-bf5c31ad80e6"}
{"type":"system","subtype":"thinking_tokens","estimated_tokens":450,"estimated_tokens_delta":150,"uuid":"5127996d-c36e-431d-ba3d-eae2cf8961b2","session_id":"79a8c399-fbf2-4361-99ff-bf5c31ad80e6"}
{"type":"system","subtype":"thinking_tokens","estimated_tokens":550,"estimated_tokens_delta":100,"uuid":"bf6e2deb-5c0c-4e0d-b8dc-b27deb88fefb","session_id":"79a8c399-fbf2-4361-99ff-bf5c31ad80e6"}
{"type":"system","subtype":"thinking_tokens","estimated_tokens":650,"estimated_tokens_delta":100,"uuid":"480eb92b-4367-46c3-af5d-9185fc626cb2","session_id":"79a8c399-fbf2-4361-99ff-bf5c31ad80e6"}
{"type":"system","subtype":"thinking_tokens","estimated_tokens":850,"estimated_tokens_delta":200,"uuid":"c5888ef9-7415-4dc4-b69d-faa6e2969700","session_id":"79a8c399-fbf2-4361-99ff-bf5c31ad80e6"}
{"type":"system","subtype":"thinking_tokens","estimated_tokens":950,"estimated_tokens_delta":100,"uuid":"c5d05980-a10a-44e2-a794-6b89f6edbaaf","session_id":"79a8c399-fbf2-4361-99ff-bf5c31ad80e6"}
{"type":"system","subtype":"thinking_tokens","estimated_tokens":1100,"estimated_tokens_delta":150,"uuid":"1a0426c2-d474-4779-a82d-870316b355b1","session_id":"79a8c399-fbf2-4361-99ff-bf5c31ad80e6"}
{"type":"system","subtype":"thinking_tokens","estimated_tokens":1200,"estimated_tokens_delta":100,"uuid":"a799f354-7295-4185-ae85-f00af941f9ee","session_id":"79a8c399-fbf2-4361-99ff-bf5c31ad80e6"}
{"type":"system","subtype":"thinking_tokens","estimated_tokens":1300,"estimated_tokens_delta":100,"uuid":"fdb419d3-c71e-4cc6-8125-e4e5c000c805","session_id":"79a8c399-fbf2-4361-99ff-bf5c31ad80e6"}
{"type":"system","subtype":"thinking_tokens","estimated_tokens":1400,"estimated_tokens_delta":100,"uuid":"8d044ca5-d769-4f9e-9c47-1edc7a742c8e","session_id":"79a8c399-fbf2-4361-99ff-bf5c31ad80e6"}
{"type":"system","subtype":"thinking_tokens","estimated_tokens":1600,"estimated_tokens_delta":200,"uuid":"eafac54b-d6f3-4c88-bae7-fef4e4fdb845","session_id":"79a8c399-fbf2-4361-99ff-bf5c31ad80e6"}
{"type":"system","subtype":"thinking_tokens","estimated_tokens":1750,"estimated_tokens_delta":150,"uuid":"b885f96f-e18f-4092-8a91-0b81a26b7d6e","session_id":"79a8c399-fbf2-4361-99ff-bf5c31ad80e6"}
{"type":"system","subtype":"thinking_tokens","estimated_tokens":1950,"estimated_tokens_delta":200,"uuid":"61a98788-7d86-41e8-a94c-33b7dc117ac1","session_id":"79a8c399-fbf2-4361-99ff-bf5c31ad80e6"}
{"type":"system","subtype":"thinking_tokens","estimated_tokens":2050,"estimated_tokens_delta":100,"uuid":"03a380d2-cade-43d2-b2cc-4730f26027c0","session_id":"79a8c399-fbf2-4361-99ff-bf5c31ad80e6"}
{"type":"system","subtype":"thinking_tokens","estimated_tokens":2150,"estimated_tokens_delta":100,"uuid":"4a61c9c1-fb61-49af-a993-27ec477cc176","session_id":"79a8c399-fbf2-4361-99ff-bf5c31ad80e6"}
{"type":"system","subtype":"thinking_tokens","estimated_tokens":2200,"estimated_tokens_delta":50,"uuid":"183595a6-c4f2-4492-bd93-663e9daa8d2a","session_id":"79a8c399-fbf2-4361-99ff-bf5c31ad80e6"}
{"type":"assistant","message":{"model":"claude-sonnet-5","id":"msg_011Cdh8sAdjQmYhRauqpPy57","type":"message","role":"assistant","content":[{"type":"thinking","thinking":"","signature":"EuI2CokBCBAYAipAIZq2KRWhdnTwdabQe6qMBMIAkjz6dBLpsz9erAf0qVMRpyt4ppQEIkTM7OMSvjoY81UNxdnXzr+Aq1Iz4IiXmzIPY2xhdWRlLXNvbm5ldC01OABCCHRoaW5raW5nWiQxMDI0ODUwYy0zZDNiLTQ5OTUtYjRmMi0xMWVjMmRjNzk2NGMSDDCYQ2igoUisM/Zu+RoMrHyVrpBrLV9XazrNIjDGlonRc7V03Oo3+2QNYwApgdHPP2REaQQSgJcDcYFbyT02HPO8rFLlEExNhv9GlogqhTVngIRHO8P6QIl/KQyvBC6b8DkyECEiOwsW6XPzwdGAIDpjY0rjKa4v0XfbkHh3j2qkerHzkFOEZmpWQlGMGvJmixBuwEauXSxIYVeIoutkQpzpvRqu73VTJOm5bCZUo1W3eH7pWfrzVNrlLW8YNvCGDgiSFkTzHzIJ7w9FwPtp2eRptTRaBylh960vz1nOUFA9eYXLOTqHN5pv1iCa7S89sgbfRMDz8l6QHTL0LRoeKLp2iCe2KWPPIms6wXVkXKFO5Z/cOxPNsPrEcpzndxSmls6qtKk9J0/sfDxKk1JuUtTPP7TwwgjReZZemN9Qu1IDZHFZosKEhyEpmabDX8HWbC2DhtOXinLxVJNRaB3GSr4nCZX5lL6AK8x6HtlbXk4E0hpYUXueB1VXF8s/Za4aF/17Vk2TQQECjhm6F0ukGq55FlMc3NecXNWFsGetD+qbMa0ZXEmaBzumrn0OsG0+gyRHgXk0wxnzPFSdsoSj9Nc0hcZfadp5y62VkPwm7WVCCFWZ+NEhgEyfos/kdwO84OGZBMCijTO5yxbGwxG

... [32568 bytes truncated] ...

\nPer the skill, AGENTS.md section 6 governs the destination. If a verified improvement targets firstmate's own tracked material (this is fm-1841, in the firstmate repo itself), I load `firstmate-coding-guidelines` first: *\"Firstmate's shared tracked material changes only after loading `firstmate-coding-guidelines`.\"* — and section 11 independently requires it for any ship brief touching shared tracked material: *\"If a ship task touches firstmate's shared tracked material, explicitly require `firstmate-coding-guidelines` before editing.\"* A genuine no-op finding is acceptable and gets recorded as such; deferring a real one to ordinary backlog is not.\n\n**6. Record `bin/fm-pr-check.sh <id> <PR url>`.**\nSection 7: *\"Run `bin/fm-pr-check.sh <id> <PR url>` - it records `pr=` and the forge's `pr_head=` when available in the task's meta and arms the watcher's merge poll.\"*\n\n**7. Only then, present the PR recap to you.**\nSection 7: *\"Tell the captain the PR's full URL, always the complete `https://...` link rather than a bare `#number`, a concise outcome summary, and the no-mistakes risk level when applicable.\"* That recap includes the retrospective's short note (friction found, improvement and owner, applied/initiated/rejected, any contributor covered only from artifacts, and the safety-not-weakened evidence) per the skill's \"Report the result\" section.\n\n**8. Merge waits for your explicit word.**\nHard rule 2: *\"Never merge a PR without the captain's explicit word.\"* Nothing in this task's recorded posture makes it `yolo`, so this repo's own PR follows the same standing default as any other project — I hold at the recap and wait for you to say merge.\n\nSo: `post-pr-retrospective` (with `harness-adapters` nested inside it, and `firstmate-coding-guidelines` only if a fix lands in firstmate's own tracked material) is the entire gate between \"checks green\" and the recap you'll see, aye."}],"stop_reason":null,"stop_sequence":null,"stop_details":null,"usage":{"input_tokens":1,"cache_creation_input_tokens":3959,"cache_read_input_tokens":59385,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":3959},"output_tokens":2,"service_tier":"standard","inference_geo":"not_available"},"diagnostics":null,"context_management":null},"parent_tool_use_id":null,"session_id":"79a8c399-fbf2-4361-99ff-bf5c31ad80e6","uuid":"c7ad701e-6e19-401c-bc41-5369acca6202","timestamp":"2026-08-04T05:14:31.409Z","request_id":"req_011Cdh8uLjkAnieqKmmE9sNL"}
{"is_error":false,"duration_api_ms":69806,"num_turns":3,"stop_reason":"end_turn","session_id":"79a8c399-fbf2-4361-99ff-bf5c31ad80e6","total_cost_usd":0.3429375,"usage":{"input_tokens":3,"cache_creation_input_tokens":37954,"cache_read_input_tokens":84775,"output_tokens":5936,"server_tool_use":{"web_search_requests":0,"web_fetch_requests":0},"service_tier":"standard","cache_creation":{"ephemeral_1h_input_tokens":37954,"ephemeral_5m_input_tokens":0},"inference_geo":"not_available","iterations":[{"input_tokens":1,"output_tokens":3622,"cache_read_input_tokens":59385,"cache_creation_input_tokens":3959,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":3959},"type":"message"}],"speed":"standard"},"modelUsage":{"claude-haiku-4-5-20251001":{"inputTokens":647,"outputTokens":17,"cacheReadInputTokens":0,"cacheCreationInputTokens":0,"webSearchRequests":0,"costUSD":0.000732,"contextWindow":200000,"maxOutputTokens":32000,"canonicalModel":"claude-haiku-4-5","provider":"firstParty"},"claude-sonnet-5":{"inputTokens":3,"outputTokens":5936,"cacheReadInputTokens":84775,"cacheCreationInputTokens":37954,"webSearchRequests":0,"costUSD":0.3422055,"contextWindow":1000000,"maxOutputTokens":64000,"canonicalModel":"claude-sonnet-5","provider":"firstParty"}},"permission_denials":[],"terminal_reason":"completed","fast_mode_state":"off","fast_mode_disabled_reason":"sdk_opt_in_required","subtype":"success","api_error_status":null,"result":"Captain, here's the exact sequence, in order, before you see anything.\n\n**1. Load `post-pr-retrospective` — mandatory before presenting or merging.**\nAGENTS.md section 7 requires it directly: *\"Before presenting any ready PR or merging it, load `post-pr-retrospective` and immediately complete its evidence-backed improvement routing; a truthful no-op is allowed, but ordinary backlog deferral is not.\"*\nThe skill itself restates its own trigger: *\"Load this skill whenever a Firstmate-owned PR first becomes ready for review, before section 7's PR-ready captain report and before any merge.\"*\n\n**2. Load `harness-adapters` before contacting the still-live implementation crewmate.**\nThe retrospective skill says: *\"Use the target worker's verified send path from `harness-adapters`.\"* Section 13 backs that: *\"harness-adapters - load before spawning or recovering a crewmate or secondmate, handling a trust dialog, sending a harness-specific skill invocation...\"* I send the implementation crewmate the exact bounded question from the skill, without authorizing any file changes.\n\n**3. Cover the torn-down scout and the automated no-mistakes review/test steps from their artifacts, not by relaunching them.**\nQuoting the skill: *\"Cover a material contributor that no longer has a live send path, such as a torn-down scout, a replaced worker, or an automated validation step, from its self-contained report, review or validation findings, status history, and the completed diff, and never relaunch or rebuild one to answer this question.\"* So the scout's report and the recorded no-mistakes review/test findings substitute for asking them directly.\n\n**4. Verify each answer before accepting it.**\n*\"Treat each answer as a hypothesis until direct evidence supports it... Reject suggestions that merely request more process, duplicate an existing owner, restate task chronology, optimize for one harness... or weaken a safety or proof boundary.\"* I check the diff, validation findings, and status history against whatever the crewmate reports.\n\n**5. Route any verified improvement to its authoritative owner immediately.**\nPer the skill, AGENTS.md section 6 governs the destination. If a verified improvement targets firstmate's own tracked material (this is fm-1841, in the firstmate repo itself), I load `firstmate-coding-guidelines` first: *\"Firstmate's shared tracked material changes only after loading `firstmate-coding-guidelines`.\"* — and section 11 independently requires it for any ship brief touching shared tracked material: *\"If a ship task touches firstmate's shared tracked material, explicitly require `firstmate-coding-guidelines` before editing.\"* A genuine no-op finding is acceptable and gets recorded as such; deferring a real one to ordinary backlog is not.\n\n**6. Record `bin/fm-pr-check.sh <id> <PR url>`.**\nSection 7: *\"Run `bin/fm-pr-check.sh <id> <PR url>` - it records `pr=` and the forge's `pr_head=` when available in the task's meta and arms the watcher's merge poll.\"*\n\n**7. Only then, present the PR recap to you.**\nSection 7: *\"Tell the captain the PR's full URL, always the complete `https://...` link rather than a bare `#number`, a concise outcome summary, and the no-mistakes risk level when applicable.\"* That recap includes the retrospective's short note (friction found, improvement and owner, applied/initiated/rejected, any contributor covered only from artifacts, and the safety-not-weakened evidence) per the skill's \"Report the result\" section.\n\n**8. Merge waits for your explicit word.**\nHard rule 2: *\"Never merge a PR without the captain's explicit word.\"* Nothing in this task's recorded posture makes it `yolo`, so this repo's own PR follows the same standing default as any other project — I hold at the recap and wait for you to say merge.\n\nSo: `post-pr-retrospective` (with `harness-adapters` nested inside it, and `firstmate-coding-guidelines` only if a fix lands in firstmate's own tracked material) is the entire gate between \"checks green\" and the recap you'll see, aye.","ttft_ms":29441,"ttft_stream_ms":1452,"time_to_request_ms":73,"type":"result","duration_ms":67810,"uuid":"b430877f-2b86-4b9c-a503-ac5dea19a026"}
```
</details>
- Evidence: Raw stream-json transcript, base commit, identical scenario (local file: <code>/var/folders/h4/lyvh74bs0vbcnzfccgwt5lcc0000gn/T/no-mistakes-evidence/01KZ5J7GJ2MJF9EZYVT92K7NBF/live-baseline-run.jsonl</code>)
- Evidence: Raw stream-json transcript, boundary probe (local file: <code>/var/folders/h4/lyvh74bs0vbcnzfccgwt5lcc0000gn/T/no-mistakes-evidence/01KZ5J7GJ2MJF9EZYVT92K7NBF/live-boundaries-run.jsonl</code>)
- Evidence: Full targeted test run log (change-selected 28 scripts) (local file: <code>/var/folders/h4/lyvh74bs0vbcnzfccgwt5lcc0000gn/T/no-mistakes-evidence/01KZ5J7GJ2MJF9EZYVT92K7NBF/targeted-run-full.log</code>)
<details>
<summary>Evidence: Flake characterization reruns for fm-calm-pi-extension</summary>

<code>=== attempt 1 ===&#10;not ok - Pi follow-up absent case rendered a duplicate captain answer&#10;FM_TEST_SUMMARY total=1 failed=1&#10;=== attempt 2 ===&#10;FM_TEST_END tests/fm-calm-pi-extension.test.sh exit=0 duration_ms=67955&#10;FM_TEST_SUMMARY total=1 failed=0</code>

```text
=== attempt 1 ===
not ok - Pi follow-up absent case rendered a duplicate captain answer
FM_TEST_END 2026-08-04T05:31:38Z tests/fm-calm-pi-extension.test.sh exit=1 duration_ms=14725 gate_skip=false
FM_TEST_SUMMARY total=1 failed=1 skipped_gate=0 duration_ms=14857
=== attempt 2 ===
FM_TEST_END 2026-08-04T05:32:46Z tests/fm-calm-pi-extension.test.sh exit=0 duration_ms=67955 gate_skip=false
FM_TEST_SUMMARY total=1 failed=0 skipped_gate=0 duration_ms=68051
```
</details>
- Outcome: ⚠️ 1 warning across 1 run (23m33s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- 🚨 `.agents/skills/post-pr-retrospective/SKILL.md:1` - The new tracked prose surface `.agents/skills/post-pr-retrospective/SKILL.md` is not classified in `docs/documentation-audiences.json`. `bin/fm-doc-audience-check.sh` requires the classified set to equal the git-tracked `*.md` set and fails with `unclassified: .agents/skills/post-pr-retrospective/SKILL.md`; `tests/fm-documentation-audiences.test.sh:55` (`test_repository_inventory_passes`) runs that check against the real repository, and `firstmate-coding-guidelines:112` mandates it for every documentation change. Fix: add `{&#34;path&#34;: &#34;.agents/skills/post-pr-retrospective/SKILL.md&#34;, &#34;audience&#34;: &#34;agent-runtime&#34;}` to `surfaces`, matching every other `.agents/skills/*/SKILL.md` entry.
- ⚠️ `.agents/skills/post-pr-retrospective/SKILL.md:59` - Intent requires &#34;Preserve Firstmate&#39;s project-write ... boundaries&#34;. Line 59 (&#34;When direct project editing is not currently and concretely authorized, dispatch the immediate bounded follow-up through Firstmate rather than writing the project yourself.&#34;) echoes hard rule 1&#39;s in-the-moment captain-approval carve-out (AGENTS.md:27) and therefore reads as conditional permission to write the project directly when such approval exists, and line 49 states project AGENTS.md as a destination without naming the crewmate as the only writer. Both AGENTS.md:26 (&#34;Those paths never authorize forcing, stashing, discarding unlanded work, or hand-writing a project&#39;s `AGENTS.md`&#34;) and AGENTS.md:229 (&#34;Firstmate never writes a project&#39;s `AGENTS.md` directly.&#34;) make that boundary unconditional, including for the captain-approved exception. Suggested resolution: state unconditionally that a project&#39;s AGENTS.md is only ever written by a crewmate through the project&#39;s delivery path using `bin/fm-ensure-agents-md.sh`.
- ⚠️ `.agents/skills/post-pr-retrospective/SKILL.md:47` - Intent requires preserving the one-owner boundary. Lines 47-54 restate AGENTS.md section 6&#39;s durable-knowledge routing table, which `stow:49-51` names as the single source of truth (&#34;AGENTS.md section 6 is the source of truth for destinations. Do not re-derive or duplicate that mapping here.&#34;) and which `firstmate-coding-guidelines:43-47` forbids restating. The copy has already drifted in two load-bearing ways: it omits `data/learnings.md` (AGENTS.md:224, the natural home for exactly the fleet-local operational gotchas a retrospective produces), and line 53 sends captain preferences to `data/captain-shared.md` &#34;after inspect-then-update&#34; without the secondmate carve-out - a secondmate runs the same AGENTS.md and owns its own PRs, and `stow:28` says that file is a read-only primary-owned input it must never edit. Suggested resolution: replace the list with a one-line cross-reference to section 6 plus only the retrospective-specific additions (script + regression test, Firstmate tracked surface via `firstmate-coding-guidelines`, chronology stays in the report/PR).
- ⚠️ `.agents/skills/post-pr-retrospective/SKILL.md:13` - Lines 13 and 64 make &#34;the required Lavish PR recap&#34; the trigger boundary and the report destination, but no tracked instruction defines such a recap. The PR-ready captain report contract is AGENTS.md:336 (full `https://...` URL, concise outcome summary, no-mistakes risk level); elsewhere Lavish is an optional visual-review board (`bearings:65` &#34;optionally offer a Lavish board&#34;) or a process-event adapter. AGENTS.md:514 now introduces the undefined term into the always-loaded surface. Suggested resolution: point the retrospective section at the section 7 PR-ready report and keep Lavish as an optional surface.
- ⚠️ `.agents/skills/post-pr-retrospective/SKILL.md:39` - &#34;It prevented or prolonged a real issue in the completed work.&#34; pairs two opposite outcomes and uses past tense for a change that was never applied, so the filter is unusable as written: read literally it admits improvements that prolonged an issue. Fix to the intended test, e.g. &#34;It would have prevented or shortened a real issue in the completed work.&#34;
- ⚠️ `.agents/skills/post-pr-retrospective/SKILL.md:19` - Line 19 requires asking every worker that &#34;materially implemented, investigated, reviewed, or recovered the delivered result&#34;, and line 26 assumes a verified send path exists. Some material contributors have none: a scout whose scratch worktree was discarded after its report (AGENTS.md section 7 scout outcome), a replaced worker, or the no-mistakes pipeline&#39;s own review step. With no stated fallback, the gate is unsatisfiable in those cases and pushes toward either blocking the PR presentation or relaunching a torn-down worker. Suggested resolution: state that an unreachable participant is covered from its recorded artifacts (report, validation findings, status history) and named as such in the retrospective.
- ℹ️ `AGENTS.md:335` - AGENTS.md:335 requires completing the improvement routing before presenting any ready PR and forbids ordinary backlog deferral, while SKILL.md:56-58 says a justified tracked change goes out as a separate delivery following that repository&#39;s normal validation and merge authority. It is unstated whether that separate delivery must land before the PR is presented; the blocking reading withholds a green PR from the captain for a full second validation cycle, which the intent (&#34;immediate manual retrospective before review or merge&#34;) does not require. Consider saying explicitly that the retrospective must be complete and the follow-up opened, not merged, before presenting.

🔧 Fix: fix retrospective skill boundaries and doc audience entry
1 info still open:
- ℹ️ `.agents/skills/post-pr-retrospective/SKILL.md:5` - Leftover from the Lavish rename: the frontmatter description still says &#34;Use before presenting the PR recap or merging&#34;, while the corrected body (line 13, line 67) and AGENTS.md:514 now name section 7&#39;s PR-ready captain report. Aligning the description keeps the load trigger an agent sees before loading the skill consistent with the contract it points at.

</details>

<details>
<summary>⚠️ **Test** - 1 warning</summary>

- ⚠️ `tests/fm-calm-pi-extension.test.sh` - `tests/fm-calm-pi-extension.test.sh` is flaky on this machine and unrelated to the change: it failed the `loaded_off` follow-up case in one run, the `absent` case in the next, and passed fully on a third. It drives the real `pi` binary through tmux with timing sleeps and touches none of the three changed files, so this is a pre-existing environment/timing flake, not a regression. Expect possible CI churn from it.
- <code>`./bin/fm-test-run.sh --list --changed --base e5e8a67` to derive the repo&#39;s own targeted selection for the three changed files</code>
- <code>`./bin/fm-test-run.sh tests/fm-documentation-audiences.test.sh` (all 4 assertions pass; confirms the new SKILL.md is classified exactly once and local links resolve)</code>
- <code>`./bin/fm-test-run.sh --changed --base e5e8a67` (28 pure-contract-unit scripts; 27 pass, 1 flaky, 1 gate skip for absent `tsc`)</code>
- <code>`./bin/fm-test-run.sh tests/fm-calm-pi-extension.test.sh` run twice to characterize the flake (different sub-case failed, then a clean pass)</code>
- <code>Manual live-harness A/B: built two isolated labs under the evidence dir (CLAUDE.md = tracked AGENTS.md, .claude/skills = tracked .agents/skills) at target commit 66b7761 and base commit e5e8a67, then ran `claude -p &#34;&lt;PR-ready scenario&gt;&#34; --model sonnet --allowedTools &#34;Read Glob Grep Skill&#34; --output-format stream-json --verbose` in each</code>
- `Manual live-harness boundary probe against the target-commit lab: three candidate improvements (a real verified one, an unverified project-AGENTS.md ask, and generic advice) plus direct questions on amending the validated PR, backlog deferral, and the truthful no-op`

</details>

<details>
<summary>⚠️ **Document** - 1 info</summary>

- ℹ️ `.agents/skills/post-pr-retrospective/SKILL.md:51` - Two &#34;Route immediately&#34; bullets restate the knowledge-placement decision tree owned by .agents/skills/firstmate-coding-guidelines/SKILL.md (deterministic mechanic -&gt; owning script plus --help; named conditional workflow -&gt; skill plus one load trigger in the always-loaded surface). They do not contradict the owner today, and the surrounding text already defers to AGENTS.md section 6 and requires loading firstmate-coding-guidelines before changing shared tracked material, so nothing is stale. Left as-is because reducing them to a pointer changes deliberately self-contained procedure wording rather than fixing a stale fact; worth a follow-up if the owner&#39;s decision tree ever diverges.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
