### PR TITLE
fix: resolve detached Codex hooks through Herdr pane identity

### DIFF
--- a/bin/fm-session-lock-lib.sh
+++ b/bin/fm-session-lock-lib.sh
@@ -74,6 +74,26 @@ fm_harness_process_matches() {  # <comm> <args>
   return 1
 }
 
+# Codex can execute a project hook in a detached helper process, so the hook's
+# ancestry may not reach the Codex process that owns the Herdr pane. Herdr's
+# pane process record is an equivalent identity proof here: the pane id is
+# injected into every process in that pane, and process-info reports the exact
+# foreground agent. Use this only for a native Codex process under Herdr, and
+# only after the ordinary ancestry walk finds no harness at all.
+fm_herdr_codex_pid() {
+  local payload
+  [ "${HERDR_ENV:-}" = 1 ] || return 1
+  [ -n "${HERDR_PANE_ID:-}" ] || return 1
+  command -v herdr >/dev/null 2>&1 || return 1
+  command -v jq >/dev/null 2>&1 || return 1
+  payload=$(herdr pane process-info --pane "$HERDR_PANE_ID" 2>/dev/null) || return 1
+  printf '%s\n' "$payload" | jq -r '
+    .result.process_info.foreground_processes[]?
+    | select(.name == "codex" or (.name == "node" and ((.cmdline // "") | test("(^|/|[[:space:]])codex([[:space:]]|$)"))))
+    | .pid
+  ' 2>/dev/null | awk 'match($0, /^[0-9]+$/) { print; exit }'
+}
+
 # Walk the current process ancestry (up to 16 hops) and print this session's
 # contiguous verified-harness ancestry, innermost pid first.
 #
@@ -108,6 +128,14 @@ fm_harness_ancestry_pids() {
     pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' ')
     [ -n "$pid" ] && [ "$pid" -gt 1 ] || break
   done
+  if [ "$printed" -eq 0 ]; then
+    local herdr_pid
+    herdr_pid=$(fm_herdr_codex_pid 2>/dev/null || true)
+    case "$herdr_pid" in
+      ''|*[!0-9]*) ;;
+      *) printf '%s\n' "$herdr_pid"; printed=1 ;;
+    esac
+  fi
   [ "$printed" -eq 1 ]
 }
 

--- a/tests/fm-session-lock-ancestry.test.sh
+++ b/tests/fm-session-lock-ancestry.test.sh
@@ -220,6 +220,51 @@ SH
   pass "session-lock: a live version-named session holding the lock is not mistaken for a stale owner"
 }
 
+test_detached_codex_hook_uses_exact_herdr_pane_identity() {
+  local dir fakebin got
+  dir="$TMP_ROOT/detached-codex-herdr"
+  fakebin=$(fm_fakebin "$dir")
+  mkdir -p "$dir/state"
+  cat > "$fakebin/ps" <<'SH'
+#!/usr/bin/env bash
+set -u
+field= pid=
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -o) field=$2; shift 2 ;;
+    -p) pid=$2; shift 2 ;;
+    *) shift ;;
+  esac
+done
+case "$pid:$field" in
+  720:comm=) printf '%s\n' codex ;;
+  720:args=) printf '%s\n' '/opt/codex/codex' ;;
+  720:ppid=) printf '%s\n' 1 ;;
+  *:comm=) printf '%s\n' bash ;;
+  *:args=) printf '%s\n' bash ;;
+  *:ppid=) printf '%s\n' 1 ;;
+esac
+SH
+  cat > "$fakebin/herdr" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' '{"result":{"process_info":{"foreground_processes":[{"name":"codex","pid":720,"cmdline":"/opt/codex/codex"}]}}}'
+SH
+  chmod +x "$fakebin/ps" "$fakebin/herdr"
+  printf '720\n' > "$dir/state/.lock"
+
+  got=$(HERDR_ENV=1 HERDR_PANE_ID=w2:p1 HERDR_SESSION=firstmate-codex \
+    lib_eval "$fakebin" 'fm_harness_ancestry_pid') \
+    || fail "a detached Codex hook did not resolve its exact Herdr pane agent"
+  [ "$got" = 720 ] || fail "Herdr fallback resolved '$got', expected Codex pid 720"
+  HERDR_ENV=1 HERDR_PANE_ID=w2:p1 HERDR_SESSION=firstmate-codex \
+    lib_eval "$fakebin" 'fm_harness_pid_alive 720' \
+    || fail "the Herdr-resolved Codex process was not considered live"
+  HERDR_ENV=1 HERDR_PANE_ID=w2:p1 HERDR_SESSION=firstmate-codex \
+    lib_eval "$fakebin" "fm_session_lock_owned_by_self '$dir/state'" \
+    || fail "the detached Codex hook did not recognize its own Herdr lock"
+  pass "session-lock: a detached Codex hook uses the exact Herdr pane identity"
+}
+
 # --- end-to-end layer: the real Stop auto-arm in real process trees ----------
 
 install_autoarm_scripts() {
@@ -358,6 +403,7 @@ test_version_named_session_is_identified_on_both_platforms
 test_ordinary_paths_are_never_harness_processes
 test_harness_beyond_a_gap_never_owns_the_lock
 test_competing_version_named_session_is_seen_as_live
+test_detached_codex_hook_uses_exact_herdr_pane_identity
 test_e2e_version_named_session_claims_the_home
 test_e2e_daemon_parented_session_claims_the_home
 test_e2e_daemon_parented_version_named_session_keeps_its_lock


### PR DESCRIPTION
## What changed

Add a narrowly scoped Herdr fallback for Firstmate session-lock ownership when a Codex project hook runs in a detached helper process.

## Root cause

Codex 0.146.0 can execute the Firstmate hook without a parent-process path back to the Codex process. The existing lock implementation only trusted ancestry, so `fm-lock.sh` reported `cannot locate harness process in ancestry` and correctly forced the Firstmate home into read-only mode, even though Codex was the active foreground agent in the exact Herdr pane.

## Fix

When ordinary ancestry resolution finds no harness, and only when Herdr has injected `HERDR_ENV=1` and `HERDR_PANE_ID`, query `herdr pane process-info` and accept a foreground native Codex process as the lock identity. Non-Herdr sessions retain the existing fail-closed ancestry behavior. Added a regression test for the detached Codex hook shape.

## Validation

- `tests/fm-session-lock-ancestry.test.sh` — all tests pass, including the new detached Codex/Herdr case.
- Live WSL/Herdr validation with Codex 0.146.0 and Herdr 0.7.5: `fm-lock.sh` acquired the lock and `fm-session-start.sh` entered the locked path.
- `bash -n` and `git diff --check` pass.
- Full ShellCheck lint was unavailable because ShellCheck is not installed in the test environment.
- The broader session-start test has an unrelated OpenCode fixture failure (`exit 127`) because OpenCode is not installed.