### PR TITLE
fix(herdr): a labelled composer rule makes an idle claude pane read unknown, in front of the NBSP defect

### DIFF
--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -2440,7 +2440,13 @@ fm_backend_herdr_strip_ansi() {  # <text>
 # afk-herdr-false-pending); it superseded a herdr-only faint byte-pattern check
 # that recognized only codex's bold-wrapped bare prompt and missed claude's own
 # dim ghost - the overnight away-mode injection wedge on the primary claude pane.
-FM_BACKEND_HERDR_COMPOSER_LINES=${FM_BACKEND_HERDR_COMPOSER_LINES:-20}
+# Rows of the pane tail the structural composer scan looks at. WHY 40: a harness
+# footer plus a multi-line custom statusline can occupy 11-12 rows under the
+# composer, and at 20 the composer row itself falls out of the window, which
+# reads as `unknown` and defers injection just as a false `pending` does. The
+# read is free: the capture already pulls 200 rows and this only bounds the tail
+# it scans.
+FM_BACKEND_HERDR_COMPOSER_LINES=${FM_BACKEND_HERDR_COMPOSER_LINES:-40}
 # Known ghost/placeholder composer text. Extend this if another
 # herdr-verified harness needs its own idle placeholder recognized.
 FM_BACKEND_HERDR_IDLE_RE=${FM_BACKEND_HERDR_IDLE_RE:-'^Type a message\.\.\.$'}
@@ -2588,9 +2594,29 @@ EOF
     esac
   elif [ "$FM_BACKEND_HERDR_PI_PAIR_FOUND" -eq 0 ] \
        && [ "$FM_BACKEND_HERDR_PI_LAST_SEPARATOR_LINE" -gt "$generic_line" ]; then
-    # A lower unmatched separator proves the generic row is stale, but does
-    # not provide the complete Pi composer structure required for injection.
-    found=0
+    # A lower unmatched separator can mean the generic row is stale - a partly
+    # captured Pi composer whose opening separator fell out of the window, with
+    # a decorative box still visible above it - without providing the complete
+    # Pi composer structure injection requires.
+    #
+    # It only means that on a Pi target. A solid `─` rule is ordinary chrome for
+    # other harnesses: claude frames its own live composer between two rules, and
+    # the upper one carries a label ("─── name ──") so it is not a bare
+    # separator, leaving exactly the lone-trailing-rule shape above. Reading that
+    # as staleness discarded a live, idle claude composer and returned `unknown`
+    # on every poll, which deferred every away-mode escalation for a whole night.
+    # Gate on the same native identity the complete-pair branch above already
+    # relies on: only a Pi pane's separator invalidates a generic match. An
+    # unreadable identity cannot rule Pi out, so it still invalidates - doubt
+    # keeps blocking injection, exactly as before.
+    identity=$(fm_backend_herdr_agent_identity_raw "$session" "$pane" 2>/dev/null || true)
+    IFS=$'\t' read -r agent agent_status <<EOF
+$identity
+EOF
+    case "$agent" in
+      ''|pi) found=0 ;;
+      *) : ;;  # A known non-Pi agent keeps its established generic verdict.
+    esac
   fi
   [ "$found" -eq 1 ] || { printf 'unknown'; return 0; }
   # Content: extract the real typed text from the raw row with the shared,

--- a/bin/fm-composer-lib.sh
+++ b/bin/fm-composer-lib.sh
@@ -160,6 +160,34 @@ fm_composer_strip_ghost() {
   '
 }
 
+# fm_composer_blank_normalize: turn a harness's INVISIBLE composer padding into
+# ordinary spaces, so the POSIX [[:space:]] trims below can actually remove it.
+#
+# WHY (the overnight away-mode wedge): claude draws its idle composer row as the
+# bare agent glyph followed by a NO-BREAK SPACE (bytes e2 9d af c2 a0). U+00A0 is
+# not in [[:space:]] in any glibc locale, so every trim left it in place, the
+# exact-glyph cases below never matched, and an IDLE composer classified as
+# `pending` - i.e. as text a human had typed but not sent. The away-mode injector
+# defers on anything but `empty`, so it deferred every escalation against a pane
+# that was ready for input the whole time.
+#
+# The escapes are OCTAL byte escapes, not \u, so these constants are the exact
+# UTF-8 bytes regardless of the caller's locale (the fleet runs LC_ALL=C in
+# places, where \u escapes and character-wise trimming both misbehave on
+# multibyte glyphs). Only characters that carry ZERO typed meaning are listed, so
+# a row holding nothing but these is empty by any reading and normalizing them
+# cannot swallow a human's half-typed line.
+fm_composer_blank_normalize() {  # <text>
+  local text=$1
+  text=${text//$'\302\240'/ }        # U+00A0 NO-BREAK SPACE (claude)
+  text=${text//$'\342\200\207'/ }    # U+2007 FIGURE SPACE
+  text=${text//$'\342\200\257'/ }    # U+202F NARROW NO-BREAK SPACE
+  text=${text//$'\342\200\213'/ }    # U+200B ZERO WIDTH SPACE
+  text=${text//$'\342\201\240'/ }    # U+2060 WORD JOINER
+  text=${text//$'\357\273\277'/ }    # U+FEFF ZERO WIDTH NO-BREAK SPACE / BOM
+  printf '%s' "$text"
+}
+
 # fm_composer_classify_content: the single shared composer-content verdict.
 #   <bordered> 1 when <content> came from a genuine agent-composer container (a
 #              bordered composer box, or a structurally-identified bare AGENT
@@ -183,6 +211,17 @@ fm_composer_idle_matches() {
 fm_composer_classify_content() {  # <bordered> <content> [idle_re] [idle_case] [plain_content]
   local bordered=$1 content=$2 idle_re=${3:-} idle_case=${4:-sensitive} plain_content
   plain_content=${5:-$content}
+  # Invisible padding must never read as typed content. Normalize here, in the
+  # one owner of the verdict, then re-trim: the caller's own trim ran before this
+  # owner ever saw the row, and every decision below - the exact-glyph cases, the
+  # emptiness checks, the idle-placeholder match - is written against visible
+  # characters only.
+  content=$(fm_composer_blank_normalize "$content")
+  content="${content#"${content%%[![:space:]]*}"}"
+  content="${content%"${content##*[![:space:]]}"}"
+  plain_content=$(fm_composer_blank_normalize "$plain_content")
+  plain_content="${plain_content#"${plain_content%%[![:space:]]*}"}"
+  plain_content="${plain_content%"${plain_content##*[![:space:]]}"}"
   if [ "$bordered" != 1 ] && [ -z "$content" ] && [ -n "$plain_content" ]; then
     case "$plain_content" in
       '❯'|'›') printf 'empty'; return 0 ;;

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -212,9 +212,10 @@ A human-blocked permission dialog has no busy banner and still surfaces.
 Herdr has no direct cursor-row primitive.
 The adapter locates the bottom-most recognized bordered row, Claude `❯` row, Codex `›` row, or a Pi separator region admitted only when native identity is exactly Pi and state is idle, done, or blocked.
 A working Pi, pending middle row, missing identity, incomplete separator pair, or over-tall candidate remains pending or unknown.
+A lone trailing separator with no matching opening one discards a recognized row above it only on a Pi or unidentifiable target, because other harnesses draw horizontal rules as ordinary chrome: Claude frames its own live composer between a labelled upper rule and a bare lower one.
 
-ANSI capture preserves de-emphasized placeholder style.
-`bin/fm-composer-lib.sh` is the fleet-wide owner that strips dim or faint runs and dark truecolor placeholders while retaining bright typed input.
+ANSI capture preserves de-emphasized placeholder style, and it is also the only capture that preserves invisible composer padding, which Herdr's plain read normalizes away.
+`bin/fm-composer-lib.sh` is the fleet-wide owner that strips dim or faint runs and dark truecolor placeholders while retaining bright typed input, and that normalizes invisible padding such as the U+00A0 Claude pads its idle composer with, so an idle composer reads empty rather than as unsent text.
 If a future Herdr version strips ANSI style, ghost suggestions become pending rather than empty, which safely defers injection and eventually raises the wedge alarm.
 
 A bare shell prompt is never an empty agent composer.

--- a/tests/fm-afk-inject-herdr-e2e.test.sh
+++ b/tests/fm-afk-inject-herdr-e2e.test.sh
@@ -150,11 +150,21 @@ EOF
 # documented integration-protocol primitive for a non-built-in-harness process
 # to report its own agent state, verified empirically against real herdr 0.7.1
 # in an isolated session.
+#
+# The loop takes an optional SHAPE argument. `bordered` (the default) is the
+# box-composer fixture described above. `claude` redraws the shape real claude
+# presents through herdr: a labelled upper rule, a bare `❯` prompt padded with
+# U+00A0, a bare lower rule, and a multi-row statusline under it. That shape is
+# what wedged away-mode delivery overnight, and it exercises two code paths the
+# bordered fixture cannot reach - the invisible-padding normalization in
+# bin/fm-composer-lib.sh and the identity gate on the lone-trailing-rule
+# staleness rule in bin/backends/herdr.sh.
 LOOP_SCRIPT="$STATE_DIR/supervisor-loop.sh"
 cat > "$LOOP_SCRIPT" <<'LOOP'
 #!/usr/bin/env bash
 MARK=$'\xE2\x81\xA3'
 LOG="$1"
+SHAPE="${2:-bordered}"
 AGENT_SOURCE=fm-test-supervisor
 AGENT_LABEL=fm-test-supervisor
 report_agent_state() {  # <idle|working>
@@ -165,7 +175,12 @@ OLD_STTY=$(stty -g 2>/dev/null || true)
 cleanup() {
   [ -z "$OLD_STTY" ] || stty "$OLD_STTY" 2>/dev/null || true
 }
-trap cleanup EXIT INT TERM
+# INT/TERM must actually END the loop, not just run cleanup and resume reading:
+# a scenario that switches composer shape sends C-c and then starts the next
+# fixture, and a loop that survived would swallow that command as composer input
+# and leave the previous shape on screen.
+trap cleanup EXIT
+trap 'cleanup; exit 0' INT TERM
 report_agent_state idle
 
 _buf=
@@ -181,15 +196,33 @@ _buf=
 # a separate interactively-typed `tput cols`), so trusting it here silently
 # let content overflow the real width and wrap across two rows. 40 is
 # comfortably under every real pane width observed on this machine.
-redraw() {
-  local avail=40 shown tail_n
+_shown() {
+  local avail=40 tail_n
   if [ "${#_buf}" -gt "$avail" ]; then
     tail_n=$((avail - 3))
-    shown="...${_buf: -$tail_n}"
+    printf '...%s' "${_buf: -$tail_n}"
   else
-    shown="$_buf"
+    printf '%s' "$_buf"
   fi
-  printf '\r\033[K│ > %s │' "$shown"
+}
+redraw_bordered() { printf '\r\033[K│ > %s │' "$(_shown)"; }
+# The claude shape occupies five rows and is rewritten in place: print the block,
+# then walk the cursor back to its first row. The screen was cleared once before
+# the first redraw, so nothing sits below the statusline that a later capture
+# could mistake for a more recent composer.
+redraw_claude() {
+  printf '\r\033[K──────────────── fm-lab-supervisor ──\n'
+  printf '\033[K\342\235\257\302\240%s\n' "$(_shown)"
+  printf '\033[K────────────────────────────────────\n'
+  printf '\033[K  ctx 17%%  ·  wk 25%% 3d01h Fri\n'
+  printf '\033[K  auto mode on · 1 shell · ← for agents'
+  printf '\033[4A\r'
+}
+redraw() {
+  case "$SHAPE" in
+    claude) redraw_claude ;;
+    *) redraw_bordered ;;
+  esac
 }
 submit_line() {
   local _line=$_buf _c _hex
@@ -201,8 +234,13 @@ submit_line() {
   _hex=$(printf '%s' "$_line" | od -An -tx1 | tr -d ' \n')
   printf '%s\t%s\t%s\n' "$_hex" "$_line" "$_c" >> "$LOG"
   _buf=
-  printf '\r\033[K\n'
-  redraw
+  # The bordered fixture scrolls a fresh composer row after each submit; the
+  # claude block is a fixed five-row region rewritten where it stands, so
+  # advancing a row there would walk it down the screen instead.
+  case "$SHAPE" in
+    claude) redraw ;;
+    *) printf '\r\033[K\n'; redraw ;;
+  esac
   # Report a real idle->working->idle cycle around the submission, exactly
   # like a real harness's agent_status - this is the signal
   # fm_backend_herdr_send_text_submit now confirms against. The 0.6s "working"
@@ -213,6 +251,7 @@ submit_line() {
   report_agent_state idle
 }
 
+[ "$SHAPE" != claude ] || printf '\033[2J\033[H'
 redraw
 while IFS= read -r -n 1 _ch; do
   if [ -z "$_ch" ]; then
@@ -521,10 +560,95 @@ test_scenario_d_max_defer() {
   pass "real herdr Scenario D: a persistently pending composer raises the max-defer wedge alarm, preserves the buffer, and never crashes the daemon"
 }
 
+# --- Scenario E: claude's own rule-framed, NBSP-padded composer --------------
+# The overnight wedge shape, end to end. An idle claude composer reads as the
+# bare `❯` glyph padded with U+00A0, framed by a labelled upper rule and a bare
+# lower rule, with a tall statusline below it. Both defects that shape triggered
+# refuse injection - the lower rule read as staleness (`unknown`), and the
+# padding read as unsent text (`pending`) - so a buffered escalation never left
+# the daemon. This asserts the escalation is actually SUBMITTED against that
+# exact fixture, and that real typed text there still defers.
+
+restart_supervisor_loop() {  # <shape>
+  fm_backend_herdr_send_key "$SUPERVISOR_TARGET" C-c >/dev/null 2>&1 || true
+  sleep 1
+  fm_backend_herdr_send_text_line "$SUPERVISOR_TARGET" "bash '$LOOP_SCRIPT' '$LOG_FILE' '$1'" \
+    || fail "could not restart the supervisor loop in shape '$1'"
+  sleep 1.5
+}
+
+# A shape switch that silently failed would leave the previous fixture on screen
+# and quietly turn the scenario into a duplicate of the bordered ones, so assert
+# the bytes under test are really there: the bare glyph plus U+00A0, and a lower
+# rule with no matching upper rule above it.
+assert_claude_shape_on_screen() {
+  local cap
+  # The ANSI capture, because that is the one the classifier reads first; herdr's
+  # plain read normalizes a trailing U+00A0 away, so it cannot see the padding at
+  # all.
+  cap=$(fm_backend_herdr_capture_ansi "$SUPERVISOR_TARGET" 20 \
+    | fm_composer_strip_ansi | tr -d '\r') \
+    || fail "Scenario E: could not capture the supervisor pane"
+  if ! printf '%s' "$cap" | grep -q $'\342\235\257\302\240'; then
+    printf '%s' "$cap" | od -c | sed 's/^/    /' >&2
+    fail "Scenario E: the pane is not showing a U+00A0-padded '❯' composer; the shape switch did not take"
+  fi
+  printf '%s' "$cap" | grep -qE '^────+$' \
+    || fail "Scenario E: the pane is not showing claude's bare lower rule; the shape switch did not take"
+  if printf '%s' "$cap" | grep -q '│ > '; then
+    fail "Scenario E: the bordered fixture is still on screen; the shape switch did not take"
+  fi
+}
+
+test_scenario_e_claude_shape() {
+  reset_state
+  restart_supervisor_loop claude
+  assert_claude_shape_on_screen
+
+  local verdict
+  verdict=$(PATH="$HERDR_SHIM_DIR:$PATH" fm_backend_herdr_composer_state "$SUPERVISOR_TARGET")
+  [ "$verdict" = empty ] \
+    || fail "Scenario E: an idle rule-framed claude composer read '$verdict', not empty"
+
+  afk_enter "$STATE_DIR"
+  start_daemon
+  echo "done: PR https://example.test/pr/500" > "$STATE_DIR/fake-c1.status"
+  sleep 8
+
+  grep -q 'Supervisor escalate' "$LOG_FILE" \
+    || fail "Scenario E: the escalation was never delivered into claude's own composer shape"
+  local marker_count
+  marker_count=$(awk -F '\t' '{ hex=$1; count += gsub(/e281a3/, "", hex) } END { print count + 0 }' "$LOG_FILE")
+  [ "$marker_count" -eq 1 ] \
+    || fail "Scenario E: expected exactly 1 U+2063 marker, got $marker_count"
+  [ ! -s "$STATE_DIR/.subsuper-inject-wedged" ] \
+    || fail "Scenario E: delivery succeeded but the wedge alarm fired anyway"
+
+  # Real typed text in that same shape must still defer.
+  reset_state
+  fm_backend_herdr_send_literal "$SUPERVISOR_TARGET" "human draft text"
+  sleep 0.5
+  verdict=$(PATH="$HERDR_SHIM_DIR:$PATH" fm_backend_herdr_composer_state "$SUPERVISOR_TARGET")
+  [ "$verdict" = pending ] \
+    || fail "Scenario E: typed text in a rule-framed claude composer read '$verdict', not pending"
+  echo "needs-decision: pick A or B" > "$STATE_DIR/fake-c1.status"
+  sleep 6
+  if grep -q 'Supervisor escalate' "$LOG_FILE"; then
+    fail "Scenario E: the daemon injected over a claude composer that held human text"
+  fi
+  fm_backend_herdr_send_key "$SUPERVISOR_TARGET" Enter
+  sleep 0.5
+
+  stop_daemon
+  restart_supervisor_loop bordered
+  pass "real herdr Scenario E: claude's rule-framed NBSP-padded composer accepts an escalation when idle and defers when a human is typing"
+}
+
 test_scenario_a
 test_scenario_b
 test_scenario_c
 test_scenario_d_max_defer
+test_scenario_e_claude_shape
 
 echo "all real-herdr afk injection e2e tests passed"
 

--- a/tests/fm-backend-herdr.test.sh
+++ b/tests/fm-backend-herdr.test.sh
@@ -2789,6 +2789,66 @@ test_composer_state_pi_separator_requires_safe_native_identity() {
   pass "fm_backend_herdr_composer_state: Pi separators never authorize working, non-Pi, unreadable, or over-tall targets"
 }
 
+# A lone trailing horizontal rule is Pi evidence only on a Pi pane. claude frames
+# its own live composer between two rules and labels the upper one
+# ("─── name ──"), so the upper rule is not a bare separator and the capture ends
+# in exactly the incomplete-pair shape above. Reading that as staleness discarded
+# a live idle claude composer and returned unknown on every poll, which deferred
+# every away-mode escalation overnight. The fixture is the recorded shape of that
+# pane, NBSP padding and tall statusline included.
+herdr_claude_rule_framed_capture() {  # -> the recorded claude composer screen
+  printf '  \xe2\x8e\xbf  Tip: Use /theme to change the color theme\n'
+  printf '\n'
+  printf '\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80 expose-demo-system-entry \xe2\x94\x80\xe2\x94\x80\n'
+  printf '\xe2\x9d\xaf\xc2\xa0\n'
+  printf '\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\n'
+  printf '  eduard@valhalla:~/p  \xe2\x8e\x87 main  \xe2\x97\x86 Opus 5 \xc2\xb7 high\n'
+  printf '  ctx 17%%  \xc2\xb7  5h 93%% 4h37m  \xc2\xb7  wk 25%% 3d01h Fri\n'
+  printf '  \xe2\x8f\xb5\xe2\x8f\xb5 auto mode on \xc2\xb7 1 shell \xc2\xb7 \xe2\x86\x90 for agents\n'
+}
+
+test_composer_state_claude_rule_framed_idle_is_empty() {
+  local dir log resp fb out
+  dir="$TMP_ROOT/composer-claude-rule-framed"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
+  herdr_claude_rule_framed_capture > "$resp/1.out"
+  printf '{"result":{"agent":{"agent":"claude","agent_status":"done"}}}\n' > "$resp/2.out"
+  fb=$(make_herdr_fakebin "$dir")
+  out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
+    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_composer_state lab:w1:p2' "$ROOT" )
+  [ "$out" = empty ] || fail "an idle rule-framed claude composer should read empty, got '$out'"
+  pass "fm_backend_herdr_composer_state: a claude composer framed by its own rules reads empty, not unknown"
+}
+
+test_composer_state_claude_rule_framed_real_text_is_pending() {
+  local dir log resp fb out
+  dir="$TMP_ROOT/composer-claude-rule-framed-pending"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
+  herdr_claude_rule_framed_capture | sed 's/^\xe2\x9d\xaf\xc2\xa0$/\xe2\x9d\xaf\xc2\xa0half typed answer/' > "$resp/1.out"
+  printf '{"result":{"agent":{"agent":"claude","agent_status":"done"}}}\n' > "$resp/2.out"
+  fb=$(make_herdr_fakebin "$dir")
+  out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
+    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_composer_state lab:w1:p2' "$ROOT" )
+  [ "$out" = pending ] || fail "unsent text in a rule-framed claude composer should read pending, got '$out'"
+  pass "fm_backend_herdr_composer_state: unsent text in a rule-framed claude composer stays pending"
+}
+
+test_composer_state_lone_rule_still_refuses_pi_and_unreadable() {
+  local dir log resp fb out case_id
+  for case_id in pi unreadable; do
+    dir="$TMP_ROOT/composer-lone-rule-$case_id"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
+    herdr_claude_rule_framed_capture > "$resp/1.out"
+    case "$case_id" in
+      pi) printf '{"result":{"agent":{"agent":"pi","agent_status":"idle"}}}\n' > "$resp/2.out" ;;
+      unreadable) printf '1\n' > "$resp/2.exit" ;;
+    esac
+    fb=$(make_herdr_fakebin "$dir")
+    out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
+      bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_composer_state lab:w1:p2' "$ROOT" )
+    [ "$out" = unknown ] \
+      || fail "a lone trailing rule on a '$case_id' target must stay unknown, got '$out'"
+  done
+  pass "fm_backend_herdr_composer_state: a lone trailing rule still refuses a Pi or unreadable target"
+}
+
 # --- composer_state: unbordered (bare) composer rows -------------------------
 # Regression coverage for the away-mode redelivery-loop incident
 # (docs/herdr-backend.md "Incident (2026-07-07)"): real claude and codex
@@ -3967,6 +4027,9 @@ test_composer_state_pi_separator_idle_is_empty
 test_composer_state_pi_separator_real_text_is_pending
 test_composer_state_pi_incomplete_separator_below_stale_generic_is_unknown
 test_composer_state_pi_separator_requires_safe_native_identity
+test_composer_state_claude_rule_framed_idle_is_empty
+test_composer_state_claude_rule_framed_real_text_is_pending
+test_composer_state_lone_rule_still_refuses_pi_and_unreadable
 test_composer_state_claude_unbordered_prompt_is_empty
 test_composer_state_claude_unbordered_prompt_is_pending
 test_composer_state_bare_prompt_below_stale_bordered_banner_wins

--- a/tests/fm-composer-lib.test.sh
+++ b/tests/fm-composer-lib.test.sh
@@ -125,8 +125,57 @@ test_real_text_is_pending() {
   pass "fm_composer_classify_content: real unsubmitted text reads pending (including a popup argument-hint fill)"
 }
 
+# --- Invisible composer padding (the overnight away-mode wedge) -------------
+# claude draws its IDLE composer as the agent glyph plus U+00A0 NO-BREAK SPACE,
+# which no glibc locale counts as [[:space:]], so every trim left it in place and
+# an idle pane classified as `pending`. Injection proceeds only on `empty`.
+
+test_invisible_padding_after_an_agent_glyph_is_empty() {
+  local out
+  out=$(classify 0 $'❯ ')
+  [ "$out" = empty ] || fail "'❯' + U+00A0 (claude's idle composer) must read empty, got '$out'"
+  out=$(classify 0 $'› ')
+  [ "$out" = empty ] || fail "'›' + U+00A0 must read empty, got '$out'"
+  out=$(classify 1 $'❯ ')
+  [ "$out" = empty ] || fail "bordered '❯' + U+00A0 must read empty, got '$out'"
+  pass "fm_composer_classify_content: an agent glyph padded with U+00A0 reads empty, not pending"
+}
+
+test_invisible_padding_alone_is_empty() {
+  local out pad
+  for pad in $' ' $' ' $' ' $'​' $'⁠' $'﻿'; do
+    out=$(classify 1 "$pad")
+    [ "$out" = empty ] \
+      || fail "a row holding only invisible padding must read empty, got '$out'"
+  done
+  pass "fm_composer_classify_content: every normalized invisible pad reads empty on its own"
+}
+
+test_invisible_padding_never_swallows_real_text() {
+  local out
+  out=$(classify 0 $'❯ fix findings 1 and 3')
+  [ "$out" = pending ] || fail "NBSP-padded real text must stay pending, got '$out'"
+  out=$(classify 1 $'deploy staging')
+  [ "$out" = pending ] || fail "NBSP-joined real text must stay pending, got '$out'"
+  pass "fm_composer_classify_content: normalizing invisible padding cannot swallow typed text"
+}
+
+test_invisible_padding_keeps_the_dead_shell_refusal() {
+  local g out
+  for g in '>' '$' '%' '#'; do
+    out=$(classify 0 "$g"$' ')
+    [ "$out" = unknown ] \
+      || fail "a bare shell glyph padded with U+00A0 must stay unknown (dead shell), got '$out'"
+  done
+  pass "fm_composer_classify_content: padding normalization does not weaken the dead-shell refusal"
+}
+
 test_bare_shell_glyphs_are_unknown
 test_stripped_unbordered_content_uses_plain_content
+test_invisible_padding_after_an_agent_glyph_is_empty
+test_invisible_padding_alone_is_empty
+test_invisible_padding_never_swallows_real_text
+test_invisible_padding_keeps_the_dead_shell_refusal
 test_bare_shell_prompt_with_command_is_not_empty
 test_bordered_shell_glyph_is_empty
 test_agent_glyphs_are_empty_bordered_and_bare


### PR DESCRIPTION
## The incident

Away-mode escalation undelivered for **21249s (5h54m)** on a herdr home, and ~8h in an earlier
stretch, against a **live, idle claude primary that the daemon had resolved correctly**:

```
daemon starting; target=default:w3:pJ; target_source=HERDR_ENV(HERDR_PANE_ID);
  backend=herdr; backend_source=HERDR_ENV
```

Deferral reasons that night:

```
2524  deferred: supervisor composer not confirmed-empty (state=unknown)
  57  deferred: supervisor pane busy (agent mid-turn)
```

The injector was right to refuse — an unreadable pane is genuinely unsafe to type into. The bug is
that the pane was readable and the classifier said otherwise.

## Two defects, stacked on one row

**1. Structural (this pull request's own finding).** `fm_backend_herdr_composer_state` treats a lone
trailing horizontal rule with no matching opening rule as proof that a composer row found above it is
stale. That heuristic is correct for Pi, whose composer sits between two *bare* separators. claude
frames its live composer the same way **except its upper rule carries a label** (`--- name --`), so it
is not a bare separator, the capture ends in exactly the incomplete-pair shape, and the live composer
is discarded before its content is ever examined.

The complete-pair branch immediately above already corroborates the Pi shape against herdr's native
agent identity; this branch did not. It now does: only a Pi pane's separator invalidates a match, and
an unreadable identity still invalidates — so **doubt keeps blocking injection exactly as before**.

**2. Content.** With the row admitted, claude's idle composer reads as the bare agent glyph plus
U+00A0 NO-BREAK SPACE (`e2 9d af c2 a0`), which is not in `[[:space:]]` in any glibc locale, so no
trim removes it and the exact-glyph cases miss.

**Defect 1 sits in front of defect 2.** On herdr, the composer is rejected structurally before
normalisation runs — so #1322 or #1285 landing alone still leaves a herdr home with a claude primary
reading `unknown` and still wedging.

## Attribution

The normalisation for defect 2 is **taken from #1322 by @KD5694**, which root-caused it byte by byte
against a 1562-deferral incident, together with that pull request's composer scan-window increase.
**#1285 carries an equivalent independent fix for the same defect; only one is applied.** Neither is
reimplemented here. If you would rather keep this in one place, I am happy to close this and fold the
structural half into #1322 instead — that pull request did the harder half.

Related: #1506 records the same symptom from a third cause (target discovery falling back to a crew
shell). Our discovery worked and we wedged anyway, so that root cause is sufficient but not necessary;
I have added our measurements there.

## Evidence

Verified on the exact pane that wedged, same pane and same moment:

```
before:  fm_backend_composer_state herdr <primary>  ->  unknown
after:   fm_backend_composer_state herdr <primary>  ->  empty
```

A real buffered escalation then delivers end to end. All three affected suites pass **on this
repository's base**, not only on our fork: `fm-composer-lib`, `fm-backend-herdr`, and
`fm-afk-inject-herdr-e2e` (which drives an actual delivery rather than mocking one — a unit test
cannot prove a defect whose whole nature is that the unit looked fine).
