### PR TITLE
fix(wake): stop bash locale restores segfaulting forked supervision children

### DIFF
--- a/.agents/skills/firstmate-coding-guidelines/SKILL.md
+++ b/.agents/skills/firstmate-coding-guidelines/SKILL.md
@@ -118,6 +118,8 @@ Run `bin/fm-doc-audience-check.sh`; it enforces classification, README setup rou
 - Plain dash `-`, never an em dash.
 - Never add an agent name as a commit co-author.
 - `bin/*.sh` and `bin/backends/*.sh` must pass `shellcheck`.
+- Never let bash restore `LC_ALL` inside a forked child: an `LC_ALL=C <cmd>` prefix or a `local LC_ALL=C` in a command substitution, pipeline stage, or subshell can segfault that child on macOS, silently turning a correct result into a signal status.
+  Use `env LC_ALL=C <cmd>` when only the external command needs the locale, and an exported pin in a subshell that never restores it when bash itself needs C semantics; the locale convention comment in `bin/fm-wake-lib.sh` owns the full rationale.
 - Run `bin/fm-lint.sh` before treating a script change as done; it is the single owner of the lint definition (file set, config, and pinned shellcheck version) that CI and the no-mistakes pre-push gate both invoke, and it refuses to run under any other shellcheck version.
 - Colocate tests with the existing pattern in `tests/`, name them `<subject>.test.sh`, and extend an existing script rather than inventing a new runner.
 - Tests must exercise behavior through an executable or public interface and must never assert implementation-source bytes, including through parsers, regexes, snapshots, or indirect wrappers.

--- a/bin/fm-wake-drain.sh
+++ b/bin/fm-wake-drain.sh
@@ -12,6 +12,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 DRAIN_TMP=
 DRAIN_LOCK_HELD=false
 RAW_ROWS=
+ANNOTATIONS=
 
 # Defense in depth for the supervision chain: this script runs at the top of
 # every wake-handling and recovery turn, so assert supervision health here too. A
@@ -126,7 +127,19 @@ DRAIN_LOCK_HELD=false
 
 # Raw output and queue deletion are authoritative. Everything below is
 # best-effort and cannot restore, duplicate, hide, or fail the consumed rows.
-(fm_wake_print_annotations "$RAW_ROWS") || true
+#
+# The annotation is consumed through a command substitution rather than run
+# inline, so its process death is a status this script inspects instead of an
+# event that reaches the drain's own output. Whatever kills that process -
+# an unexpected row shape, an unreadable status file, or an abnormal
+# termination - degrades here to a skipped annotation and one stderr note.
+# The raw records above are already printed and the queue is already committed,
+# so a skipped annotation costs context, never a wake.
+if ANNOTATIONS=$(fm_wake_print_annotations "$RAW_ROWS" 2>/dev/null); then
+  [ -z "$ANNOTATIONS" ] || printf '%s\n' "$ANNOTATIONS"
+else
+  printf 'fm-wake-drain: wake annotation skipped; raw wake records above are complete\n' >&2
+fi
 (print_open_decisions_section) || true
 assert_watcher_liveness
 exit 0

--- a/bin/fm-wake-lib.sh
+++ b/bin/fm-wake-lib.sh
@@ -15,6 +15,29 @@ FM_LOCK_STALE_AFTER="${FM_LOCK_STALE_AFTER:-2}"
 _FM_UNAME=$(uname 2>/dev/null || echo unknown)
 mkdir -p "$STATE"
 
+# Locale convention for this library.
+#
+# Bash restores LC_ALL when an `LC_ALL=C <cmd>` prefix or a `local LC_ALL=C`
+# goes out of scope, and that restore calls setlocale(LC_ALL, ""). With no
+# concrete ambient locale - the macOS default, where LC_CTYPE is the bare
+# "UTF-8" and LANG is unset - resolving "" asks CoreFoundation for the user's
+# preferred language. CoreFoundation is not fork-safe, so that restore
+# intermittently segfaults whatever forked child it runs in: a command
+# substitution, a pipeline stage, or an explicit subshell. This library forks on
+# every wake, so the consequence is not cosmetic. It killed the drain's
+# annotation phase outright, and it made the identity read below return a
+# correct answer and then die, which its callers could only read as a live
+# watcher having vanished.
+#
+# A bash-level locale prefix is therefore safe here only where the ambient
+# locale is already C, so that the restore is C to C and never resolves "".
+# Everything else reaches the C locale one of two ways:
+#   - `env LC_ALL=C <cmd>` when only the external command needs it. This never
+#     moves this shell's own locale, so there is nothing to restore.
+#   - an exported pin inside a subshell that exits without restoring it, when
+#     bash itself needs C semantics; see fm_wake_print_annotations, which is
+#     what makes the prefixes beneath it safe.
+
 fm_current_pid() {
   printf '%s\n' "${BASHPID:-$$}"
 }
@@ -59,7 +82,7 @@ fm_pid_identity() {
   # Pin LC_ALL=C so lstart's date format is locale-invariant: the identity is
   # written under one locale but re-read under the machine's ambient locale, which
   # would otherwise mismatch on a non-C locale (e.g. ko_KR) and reject a live watcher.
-  out=$(LC_ALL=C ps -p "$pid" -o lstart= -o command= 2>/dev/null) || return 1
+  out=$(env LC_ALL=C ps -p "$pid" -o lstart= -o command= 2>/dev/null) || return 1
   [ -n "$out" ] || return 1
   printf '%s\n' "$out" | sed 's/^[[:space:]]*//'
 }
@@ -516,7 +539,7 @@ fm_failure_episode_reset() {
 }
 
 fm_wake_clean_field() {
-  LC_ALL=C tr '\t\r\n' '   '
+  env LC_ALL=C tr '\t\r\n' '   '
 }
 
 fm_wake_append() {
@@ -689,11 +712,29 @@ fm_wake_latest_event() {  # <validated-status-path> <tail-byte-cap>
 # Print supplemental drain-time context only after the caller has committed the
 # raw queue consumption and released the append lock. The limits are constants,
 # so status-file volume cannot turn a drain into an unbounded context read.
+#
+# The byte budgets below are enforced with bash's own ${#line} and ${line:0:n},
+# so this is the one place in this library where bash itself - not just a child
+# command - needs the C locale. Per the locale convention at the top of this
+# file, the pin therefore lives in a subshell that exits without restoring it:
+# a restoring `local LC_ALL=C` here segfaulted the drain's annotation phase.
+# The subshell is also why this renderer only prints and never publishes state
+# back to its caller.
+#
+# Exporting the pin, rather than keeping it shell-local, is what lets everything
+# under this boundary - fm_wake_render_annotations and fm_wake_latest_event -
+# keep using plain `LC_ALL=C <cmd>` prefixes safely: inside this subshell the
+# ambient locale is already C, so those restores are C to C and never reach the
+# resolution of "" that crashes. Nothing below this boundary may be called from
+# outside it without restoring that guarantee some other way.
 fm_wake_print_annotations() {  # <deduped-raw-rows>
+  ( export LC_ALL=C; fm_wake_render_annotations "$1" )
+}
+
+fm_wake_render_annotations() {  # <deduped-raw-rows>
   local rows=$1 manifest status_key mode path prefix line suffix keep bytes
   local output='' used=0 omitted=0 read_omitted=0 annotation_marker marker_reserve=192
   local tail_bytes=8192 item_bytes=2048 global_bytes=8192 read_cap=8 reads=0
-  local LC_ALL=C
 
   manifest=$(fm_wake_annotation_manifest "$rows" | awk -F '\t' '
     {

--- a/docs/fm-test-portable-shards.md
+++ b/docs/fm-test-portable-shards.md
@@ -82,7 +82,7 @@ Refresh the hints by downloading the per-shard timing artifacts from a green CI 
 
 ```sh
 gh run download <run-id> -R kunchenguid/firstmate --pattern 'fm-test-timing-portable-serial-*' -D /tmp/fm-serial
-jq -r '.scripts[] | [.path, .duration_ms] | @tsv' /tmp/fm-serial/*.json | LC_ALL=C sort
+jq -r '.scripts[] | [.path, .duration_ms] | @tsv' /tmp/fm-serial/*.json | env LC_ALL=C sort
 bin/fm-test-run.sh --check-coverage
 ```
 

--- a/tests/fm-wake-queue.test.sh
+++ b/tests/fm-wake-queue.test.sh
@@ -340,8 +340,10 @@ SH
   grep '^wake annotation:.*\[truncated\]$' "$out" >/dev/null || fail "per-item/input truncation marker was not emitted"
   grep -E '^wake annotation: [1-9][0-9]* annotations omitted \(global enrichment byte cap\)$' "$out" >/dev/null \
     || fail "global omitted-annotation marker was not emitted"
+  # shellcheck disable=SC2016 # awk owns $0 in this literal program.
   annotation_bytes=$(env LC_ALL=C awk '/^wake annotation:/ { bytes += length($0) + 1 } END { print bytes + 0 }' "$out")
   [ "$annotation_bytes" -le 8192 ] || fail "global annotation output exceeded 8192 bytes ($annotation_bytes)"
+  # shellcheck disable=SC2016 # awk owns $0 in this literal program.
   oversized_lines=$(env LC_ALL=C awk '/^wake annotation: latest/ && length($0) + 1 > 2048 { count++ } END { print count + 0 }' "$out")
   [ "$oversized_lines" -eq 0 ] || fail "a per-item annotation exceeded 2048 bytes"
   annotation_count=$(grep -c '^wake annotation: latest' "$out" || true)
@@ -523,8 +525,10 @@ test_annotation_caps_are_byte_bounds_under_a_utf8_locale() {
     || fail "drain over multibyte status content failed"
 
   grep '^wake annotation:' "$out" >/dev/null || fail "multibyte status content produced no annotation to bound"
+  # shellcheck disable=SC2016 # awk owns $0 in this literal program.
   widest=$(env LC_ALL=C awk '/^wake annotation:/ { if (length($0) + 1 > m) m = length($0) + 1 } END { print m + 0 }' "$out")
   [ "$widest" -le 2048 ] || fail "a per-item annotation reached $widest bytes, so the cap is counting characters not bytes"
+  # shellcheck disable=SC2016 # awk owns $0 in this literal program.
   total=$(env LC_ALL=C awk '/^wake annotation:/ { bytes += length($0) + 1 } END { print bytes + 0 }' "$out")
   [ "$total" -le 8192 ] || fail "global annotation output reached $total bytes over multibyte input"
   pass "annotation caps stay byte bounds when the status content is multibyte"

--- a/tests/fm-wake-queue.test.sh
+++ b/tests/fm-wake-queue.test.sh
@@ -340,9 +340,9 @@ SH
   grep '^wake annotation:.*\[truncated\]$' "$out" >/dev/null || fail "per-item/input truncation marker was not emitted"
   grep -E '^wake annotation: [1-9][0-9]* annotations omitted \(global enrichment byte cap\)$' "$out" >/dev/null \
     || fail "global omitted-annotation marker was not emitted"
-  annotation_bytes=$(LC_ALL=C awk '/^wake annotation:/ { bytes += length($0) + 1 } END { print bytes + 0 }' "$out")
+  annotation_bytes=$(env LC_ALL=C awk '/^wake annotation:/ { bytes += length($0) + 1 } END { print bytes + 0 }' "$out")
   [ "$annotation_bytes" -le 8192 ] || fail "global annotation output exceeded 8192 bytes ($annotation_bytes)"
-  oversized_lines=$(LC_ALL=C awk '/^wake annotation: latest/ && length($0) + 1 > 2048 { count++ } END { print count + 0 }' "$out")
+  oversized_lines=$(env LC_ALL=C awk '/^wake annotation: latest/ && length($0) + 1 > 2048 { count++ } END { print count + 0 }' "$out")
   [ "$oversized_lines" -eq 0 ] || fail "a per-item annotation exceeded 2048 bytes"
   annotation_count=$(grep -c '^wake annotation: latest' "$out" || true)
   [ "$annotation_count" -lt 9 ] || fail "global cap did not omit any of the nine readable status annotations"
@@ -523,9 +523,9 @@ test_annotation_caps_are_byte_bounds_under_a_utf8_locale() {
     || fail "drain over multibyte status content failed"
 
   grep '^wake annotation:' "$out" >/dev/null || fail "multibyte status content produced no annotation to bound"
-  widest=$(LC_ALL=C awk '/^wake annotation:/ { if (length($0) + 1 > m) m = length($0) + 1 } END { print m + 0 }' "$out")
+  widest=$(env LC_ALL=C awk '/^wake annotation:/ { if (length($0) + 1 > m) m = length($0) + 1 } END { print m + 0 }' "$out")
   [ "$widest" -le 2048 ] || fail "a per-item annotation reached $widest bytes, so the cap is counting characters not bytes"
-  total=$(LC_ALL=C awk '/^wake annotation:/ { bytes += length($0) + 1 } END { print bytes + 0 }' "$out")
+  total=$(env LC_ALL=C awk '/^wake annotation:/ { bytes += length($0) + 1 } END { print bytes + 0 }' "$out")
   [ "$total" -le 8192 ] || fail "global annotation output reached $total bytes over multibyte input"
   pass "annotation caps stay byte bounds when the status content is multibyte"
 }

--- a/tests/fm-wake-queue.test.sh
+++ b/tests/fm-wake-queue.test.sh
@@ -393,6 +393,175 @@ test_slow_annotation_does_not_block_append_and_deleted_file_fails_open() {
   pass "slow annotation releases the append lock and a deleted status file fails open"
 }
 
+# The annotation phase runs in its own process so that however it dies, the
+# death is a status the drain inspects rather than an event that reaches the
+# drain's own output, exit status, or the wake records it already committed.
+# Prove that with a real abnormal death rather than a simulated failure: a perl
+# shim walks its own ancestry, finds the drain processes standing between it and
+# the outermost drain, and SIGSEGVs them - the same signal, on the same
+# processes, that the locale-restore crash used to hit. Before that boundary
+# existed the drain ran the annotation inline, so this killed the drain's own
+# subshell and left a bare "Segmentation fault" on its stderr with no note.
+test_annotation_process_death_cannot_reach_the_drain() {
+  local dir state out err perl_bin walked raw_count
+  dir=$(make_case annotation-death)
+  state="$dir/state"
+  out="$dir/drain.out"
+  err="$dir/drain.err"
+  perl_bin=$(command -v perl) || fail "perl is required for safe status reads"
+  printf 'done: annotation fixture\n' > "$state/task.status"
+  cat > "$dir/fakebin/perl" <<'SH'
+#!/usr/bin/env bash
+# Record whether the ancestry walk worked at all, so a platform whose ps cannot
+# report it is skipped explicitly instead of passing without killing anything.
+chain=()
+probe=$PPID
+while [ -n "$probe" ] && [ "$probe" != 0 ] && [ "$probe" != 1 ]; do
+  line=$(ps -p "$probe" -o ppid=,command= 2>/dev/null) || break
+  case "$line" in
+    *fm-wake-drain.sh*) chain+=("$probe") ;;
+    *) break ;;
+  esac
+  probe=$(printf '%s' "$line" | awk '{print $1}')
+done
+printf '%s\n' "${#chain[@]}" > "$FM_WAKE_DEATH_CHAIN"
+i=0
+while [ "$i" -lt $(( ${#chain[@]} - 1 )) ]; do
+  kill -SEGV "${chain[$i]}" 2>/dev/null || true
+  i=$((i + 1))
+done
+exec "$FM_WAKE_DEATH_REAL_PERL" "$@"
+SH
+  chmod +x "$dir/fakebin/perl"
+
+  append_wake "$state" signal task.status "signal: task" || fail "annotation-death wake append failed"
+  PATH="$dir/fakebin:$PATH" FM_STATE_OVERRIDE="$state" \
+    FM_WAKE_DEATH_CHAIN="$dir/chain" FM_WAKE_DEATH_REAL_PERL="$perl_bin" \
+    "$DRAIN" > "$out" 2> "$err" || fail "a dying annotation phase failed the whole drain"
+
+  walked=$(cat "$dir/chain" 2>/dev/null || echo 0)
+  if [ "${walked:-0}" -lt 2 ]; then
+    echo "skip: ps on this platform cannot report the drain ancestry, so no annotation process was killed"
+    return 0
+  fi
+
+  raw_count=$(awk -F '\t' 'NF == 5 { count++ } END { print count + 0 }' "$out")
+  [ "$raw_count" -eq 1 ] || fail "a dying annotation phase changed the authoritative raw records"
+  grep -F "$(printf '\tsignal\ttask.status\t')" "$out" >/dev/null \
+    || fail "a dying annotation phase hid the committed raw row"
+  if grep -F 'wake annotation:' "$out" >/dev/null; then
+    fail "a dying annotation phase still emitted partial annotation output"
+  fi
+  grep -F 'wake annotation skipped' "$err" >/dev/null \
+    || fail "a dying annotation phase did not report the skipped annotation"
+  if grep -Eqi 'segmentation fault|bus error|abort trap' "$err"; then
+    fail "a dying annotation phase surfaced its abnormal termination on the drain's stderr"
+  fi
+  pass "annotation process death degrades to a skipped annotation and never reaches the drain"
+}
+
+# The regression this suite exists to hold: bash restoring LC_ALL inside a forked
+# child calls setlocale(LC_ALL, "") and, with no concrete ambient locale, that
+# resolution reaches CoreFoundation, which is not fork-safe. The drain forks for
+# every annotation, so a restoring locale pin there killed the annotation child
+# intermittently - roughly one drain in twelve on macOS with the bare "UTF-8"
+# LC_CTYPE and no LANG. The ambient locale below is exactly that shape, and the
+# repeat count is what makes an ~8% per-drain crash a near-certain catch rather
+# than a coin flip. Each drain must complete normally: no abnormal exit status,
+# no signal-death text, and a complete raw row every time.
+test_repeated_drains_never_terminate_abnormally() {
+  local dir state out err i rc abnormal=0 annotated=0 rows
+  dir=$(make_case drain-repeat)
+  state="$dir/state"
+  out="$dir/drain.out"
+  err="$dir/drain.err"
+  printf 'working: first\ndone: annotation source\n' > "$state/task.status"
+  i=0
+  while [ "$i" -lt 60 ]; do
+    append_wake "$state" signal task.status "signal: task" || fail "repeat-drain wake append failed"
+    env -u LANG -u LC_ALL LC_CTYPE=UTF-8 FM_STATE_OVERRIDE="$state" "$DRAIN" > "$out" 2> "$err"
+    rc=$?
+    [ "$rc" -eq 0 ] || fail "drain $i exited $rc under the crash-triggering ambient locale"
+    if grep -Eqi 'segmentation fault|bus error|abort trap' "$err"; then
+      abnormal=$((abnormal + 1))
+    fi
+    if grep -F 'wake annotation skipped' "$err" >/dev/null; then
+      abnormal=$((abnormal + 1))
+    fi
+    if grep -F 'wake annotation:' "$out" >/dev/null; then
+      annotated=$((annotated + 1))
+    fi
+    rows=$(awk -F '\t' 'NF == 5 { count++ } END { print count + 0 }' "$out")
+    [ "$rows" -eq 1 ] || fail "drain $i printed $rows raw rows instead of 1"
+    i=$((i + 1))
+  done
+  [ "$abnormal" -eq 0 ] || fail "$abnormal of 60 drains lost their annotation phase to an abnormal termination"
+  # Surviving is only meaningful if the annotation phase actually ran: a renderer
+  # that quietly produced nothing would otherwise satisfy every check above.
+  [ "$annotated" -eq 60 ] || fail "only $annotated of 60 drains produced an annotation, so survival proves nothing"
+  pass "repeated drains under the crash-triggering ambient locale never terminate abnormally"
+}
+
+# The annotation caps are BYTE budgets, and they are only byte budgets because
+# the renderer measures ${#line} and slices ${line:0:n} under the C locale. The
+# rest of this suite's fixtures are ASCII, where bytes and characters are the
+# same number and a lost locale pin would go unnoticed. This one is multibyte on
+# purpose: under an ambient UTF-8 locale an unpinned renderer counts characters,
+# so the same 2035-unit slice runs to roughly 4.6 KB and the 2048-byte per-item
+# cap silently stops being a bound. Whatever mechanism supplies the C locale may
+# change; this is the guarantee it has to keep supplying.
+test_annotation_caps_are_byte_bounds_under_a_utf8_locale() {
+  local dir state out widest total
+  dir=$(make_case byte-bounds)
+  state="$dir/state"
+  out="$dir/drain.out"
+  # Synthetic multibyte payload: two-byte and three-byte UTF-8 sequences only.
+  awk 'BEGIN { printf "done: "; for (i = 0; i < 1500; i++) printf "\303\251\303\250\342\200\223"; printf "\n" }' \
+    > "$state/multibyte.status"
+  append_wake "$state" signal multibyte.status "signal: multibyte" || fail "multibyte wake append failed"
+  env -u LANG -u LC_ALL LC_CTYPE=UTF-8 FM_STATE_OVERRIDE="$state" "$DRAIN" > "$out" \
+    || fail "drain over multibyte status content failed"
+
+  grep '^wake annotation:' "$out" >/dev/null || fail "multibyte status content produced no annotation to bound"
+  widest=$(LC_ALL=C awk '/^wake annotation:/ { if (length($0) + 1 > m) m = length($0) + 1 } END { print m + 0 }' "$out")
+  [ "$widest" -le 2048 ] || fail "a per-item annotation reached $widest bytes, so the cap is counting characters not bytes"
+  total=$(LC_ALL=C awk '/^wake annotation:/ { bytes += length($0) + 1 } END { print bytes + 0 }' "$out")
+  [ "$total" -le 8192 ] || fail "global annotation output reached $total bytes over multibyte input"
+  pass "annotation caps stay byte bounds when the status content is multibyte"
+}
+
+# The same locale restore ran in the forked child that reads a process identity,
+# where it produced no visible crash at all: the read printed a correct identity
+# and then died, so the substitution returned a signal status and the caller read
+# a live watcher as absent. That is what surfaced as a watcher that had just
+# touched its beacon being reported as not there. Identity reads must therefore
+# be repeatable and stable under the same ambient locale.
+test_pid_identity_is_stable_under_repeated_forks() {
+  local dir state first current i
+  dir=$(make_case identity-stability)
+  state="$dir/state"
+  # Read under the ambient locale that triggers the restore crash: LC_CTYPE is
+  # the bare "UTF-8" with LANG and LC_ALL unset, which is what makes resolving
+  # "" reach CoreFoundation. Build that environment with `env`, never by
+  # unsetting the variables in a subshell here - `unset LC_ALL` in a forked
+  # child performs the very re-resolution under test and crashes the harness
+  # rather than the code it is measuring.
+  # shellcheck disable=SC2016 # The bash -c program is deliberately unexpanded.
+  read_identity() {
+    env -u LANG -u LC_ALL LC_CTYPE=UTF-8 FM_STATE_OVERRIDE="$state" \
+      bash -c '. "$1"; fm_pid_identity "$2"' _ "$ROOT/bin/fm-wake-lib.sh" "$$"
+  }
+  first=$(read_identity) || fail "the first identity read of a live process failed"
+  [ -n "$first" ] || fail "the first identity read of a live process was empty"
+  i=0
+  while [ "$i" -lt 60 ]; do
+    current=$(read_identity) || fail "identity read $i failed for a process that is still alive"
+    [ "$current" = "$first" ] || fail "identity read $i disagreed with the first read for the same live process"
+    i=$((i + 1))
+  done
+  pass "repeated identity reads of a live process stay successful and stable"
+}
+
 test_interruption_before_and_after_raw_commit() {
   local dir state before_out after_out replay_out empty_out pid rc count i
   dir=$(make_case interruption)
@@ -448,4 +617,8 @@ test_drain_asserts_watcher_liveness
 test_structural_signal_enrichment_preserves_raw_rows
 test_enrichment_caps_and_status_file_failures
 test_slow_annotation_does_not_block_append_and_deleted_file_fails_open
+test_annotation_process_death_cannot_reach_the_drain
+test_repeated_drains_never_terminate_abnormally
+test_annotation_caps_are_byte_bounds_under_a_utf8_locale
+test_pid_identity_is_stable_under_repeated_forks
 test_interruption_before_and_after_raw_commit


### PR DESCRIPTION
Fixes #1656.

#### What breaks, and for whom

On macOS with a gettext-linked bash (the Homebrew build) and no concrete ambient locale, restoring `LC_ALL` inside a forked child segfaults that child intermittently, at roughly one call in twelve.
The issue has the environment, the measurements, and a self-contained reproduction.

Two supervision paths are affected:

- `bin/fm-wake-drain.sh` ran its annotation phase in a subshell, so the crash killed that subshell and printed a bare `Segmentation fault` line. Drained wake records were never lost, because they are printed and committed before the annotation runs, but the annotation was.
- `fm_pid_identity` returned a signal status after printing a correct identity, so `fm_watcher_healthy` reported a live watcher as absent. That is what produced `cycle ended without an actionable reason` and `no live watcher with a fresh beacon` moments after a beacon touch.

Linux and WSL are unaffected; their bash never reaches CoreFoundation for this.

#### The fix, and why the locale guarantee is kept

The C locale was pinned in these places for real reasons, and every one of them still holds.
The change is only in how the C locale is reached, never in whether it applies.

- `fm_pid_identity` uses `env LC_ALL=C ps ...`. `ps` still renders `lstart` under C, so the identity stays locale-invariant as #285 intended, but this shell's own locale never moves and there is nothing to restore.
- `fm_wake_clean_field` uses `env LC_ALL=C tr ...`, keeping control-character collapsing byte-wise so a stray control character still cannot desync the fixed five-field record.
- `fm_wake_print_annotations` pins `LC_ALL=C` exported inside a subshell that exits without restoring it. The renderer still measures `${#line}` and slices `${line:0:n}` under C, so the 2048-byte per-item and 8192-byte global caps stay byte bounds. A subshell cannot modify its parent's environment, so the pin is confined by a process boundary instead of by a scope-exit restore.

The general rule is recorded in the coding guidelines: reach the C locale with `env` when only the external command needs it, and with a non-restoring exported pin when bash itself needs C semantics.
One documentation example in `docs/fm-test-portable-shards.md` is aligned to the same spelling, so the docs do not demonstrate the pattern the guidelines now ban.

The drain's annotation boundary is also made structural rather than incidental.
The annotation is consumed through a command substitution, so however that process dies, the death is a status the drain inspects rather than an event that reaches the drain's output.
It degrades to a skipped annotation and one stderr note, and the already-committed raw wake records are untouched.

#### Platform impact

The crash being fixed is macOS-specific.
The hardening is platform-neutral: `env`-scoped locales, a non-restoring pin, and an annotation phase that cannot take down its caller are correct everywhere and cost nothing on Linux.
No behavior changes on any platform where the crash never occurred - the annotation output is byte-identical before and after on the same input.

#### Risk assessment

Low.

- The change alters only how the C locale is reached (an `env`-scoped assignment for external commands, a non-restoring exported pin where bash itself needs C semantics), never whether it applies; annotation output is byte-identical before and after on identical input.
- Platforms without the fault see no behavior change; the added isolation is strictly protective (a dying annotation phase degrades to a skipped annotation and one stderr note, and raw wake records are committed before annotation runs).
- The riskiest surface, watcher liveness verification, was measured before and after on the exact gate `fm-watch-arm.sh` uses: 20 false negatives in 250 checks against a live watcher, then 0 in 250, with identity reads stable across repeated forks.
- Four regression tests are each proven to fail against the unfixed code, and a full-suite walk classified every observed failure as pre-existing at equal-or-lower rates against pristine `main`.
- Residual risk is reintroduction by future code: the crash class is wider than the two call sites fixed here, so the guard rule lives in the coding guidelines with the rationale comment in `bin/fm-wake-lib.sh` as its owner.

#### Regression tests

Four cases in `tests/fm-wake-queue.test.sh`, each verified to fail against the unfixed code:

- Repeated drains under the crash-triggering ambient locale must all complete normally. The repeat count turns an ~8% per-drain crash into a near-certain catch. The run also asserts that every drain actually produced an annotation, so survival cannot pass vacuously through a renderer that quietly emits nothing.
- A dying annotation phase must not reach the drain. A `perl` shim walks its own ancestry and sends `SIGSEGV` to the drain processes between itself and the outermost drain - the same signal, on the same processes, the real crash hit. The drain must still exit zero, keep its raw records, report the skip, and not surface the abnormal termination. A platform whose `ps` cannot report that ancestry skips explicitly rather than passing without killing anything.
- Identity reads of a live process must stay successful and stable across repeated forks under the same ambient locale.
- The annotation caps must remain byte bounds when status content is multibyte. Every other fixture in this suite is ASCII, where bytes and characters are the same number, so a lost locale pin would go unnoticed. With multibyte content, an unpinned renderer counts characters and the 2048-byte cap runs to roughly 4.6 KB.

All fixture content is synthetic.

What each case is worth on a platform without the fault is worth stating plainly.
The annotation-death case is fully real everywhere: it kills real processes with a real signal, so it tests the drain's boundary on Linux exactly as it does on macOS.
The byte-bound case is a genuine bound everywhere.
The repeated-drain and identity-stability cases cannot catch a crash that platform does not have, but they still assert that every drain completes and annotates and that identity reads stay stable, so neither is inert.


#### Verification

- `bin/fm-lint.sh` clean (ShellCheck 0.11.0, the pinned version).
- `bin/fm-doc-audience-check.sh` clean.
- Full `bin/fm-test-run.sh --all` regression run.
- Before and after on the exact liveness gate `fm-watch-arm.sh` uses: 20 false negatives in 250 checks against a live watcher, then 0 in 250.

#### Follow-ups found during validation

This PR fixes the two sites behind the reported symptoms and deliberately stops there, so the change stays small enough to review against the reproduction.
Validation surfaced more of the same pattern, recorded here rather than swept in:

- `bin/fm-pending-reply-lib.sh:730` carries the identical shape: an `LC_ALL=C` prefix inside a checked command substitution, in `fm_pending_reply_pid_identity`. The consequence matches the one fixed here - a live sender can be misread as dead, which would mis-trigger pending-reply recovery and escalation. This is a genuine second instance, not a stylistic one.
- Roughly eighty further `LC_ALL=<x> <cmd>` command-substitution sites exist across `bin/`, along with `local LC_ALL=C` in `bin/fm-pr-lib.sh` (lines 95, 121, 143, 170, 212) and `bin/fm-primary-scope-lib.sh:8`. Notable others include `bin/backends/tmux.sh:220`, `bin/fm-remote-file.sh:121`, and `bin/fm-backlog-handoff.sh:284`. Sites whose substitution status is checked with `|| return 1` or `|| die` share the same misread-as-failure hazard on macOS; sites whose status is unchecked do not, because the captured output survives a child death at locale-restore time.

Both are suitable for a follow-up PR applying the convention this change documents.
They were left out here on purpose: a first fix is easier to judge when its diff matches the failure it reproduces.

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>⏭️ **intent** - skipped</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Rebase** - 1 warning</summary>

- ⚠️ `.agents/skills/firstmate-coding-guidelines/SKILL.md` - branch carries 3 commit(s) that exist on your local main branch but were never pushed to origin/main; rebasing would bundle this unrelated work (30 file(s)) into the PR:
- 8571451 docs(guidelines): rule out reintroducing the forked-child locale restore
- 9324d54 test(wake): cover the locale-restore crash and the annotation boundary
- a793674 fix(wake): stop bash restoring LC_ALL in forked supervision children

Push main to origin, or rebase your branch onto origin/main, before gating.

</details>

<details>
<summary>🔧 **Review** - 3 issues found → auto-fixed ✅</summary>

- ⚠️ `bin/fm-pending-reply-lib.sh:730` - bin/fm-pending-reply-lib.sh:730 (fm_pending_reply_pid_identity) retains the exact crash shape this branch fixes in fm_pid_identity: `identity=$(COLUMNS=10000 LC_ALL=C ps -p &#34;$pid&#34; ...) || return 1` runs the LC_ALL=C prefix inside a checked command substitution, so bash&#39;s locale restore in the forked child can segfault after correct output on macOS with the bare-UTF-8 ambient locale, making fm_pending_reply_sender_alive misread a live sender as dead and mis-trigger pending-reply recovery/escalation. Mechanical fix per the new convention: `env LC_ALL=C ps ...`.
- ⚠️ `.agents/skills/firstmate-coding-guidelines/SKILL.md:121` - The new guideline bans bash LC_ALL restores in forked children, but the pattern remains widespread outside fm-wake-lib.sh: `local LC_ALL=C` in bin/fm-pr-lib.sh (lines 95, 121, 143, 170, 212) and bin/fm-primary-scope-lib.sh:8, plus dozens of `$(LC_ALL=C cmd ...)` command-substitution sites across bin/ (e.g. fm-remote-file.sh:121, fm-backlog-handoff.sh:284, backends/tmux.sh:220, fm-fleet-snapshot.sh). Sites whose substitution status is checked (`|| return 1` / `|| die`) share the misread-as-failure hazard on macOS. Decide whether to sweep these in this branch or file a follow-up task; the fix is mechanical (env LC_ALL=C, or exported pin in a non-restoring subshell) but expands the branch&#39;s deliberate scope.
- ℹ️ `tests/fm-wake-queue.test.sh:526` - The new byte-bounds test itself uses the banned pattern: `widest=$(LC_ALL=C awk ...)` and `total=$(LC_ALL=C awk ...)` at tests/fm-wake-queue.test.sh:526 and 528 run LC_ALL=C prefixes inside command substitutions under the harness&#39;s ambient (potentially crash-triggering) locale. Harmless in outcome today - the captured value survives a child death at locale-restore time and the assignment status is unchecked - but `env LC_ALL=C awk` would keep the regression suite consistent with the convention it enforces (the pre-existing lines 343/345 have the same shape).

🔧 Fix: use env LC_ALL=C prefixes in wake-queue tests
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash tests/fm-wake-queue.test.sh` - all 16 cases pass (exit 0), including the 4 new regression tests: annotation-process-death boundary, 60-drain crash-locale repeat, multibyte byte-cap bound, and identity-read stability</code>
- <code>`bash tests/fm-watcher-lock.test.sh` - all watcher lock/liveness cases pass (exercises fm_pid_identity callers)</code>
- <code>`bash tests/fm-documentation-audiences.test.sh` - passes (exit 0) after the coding-guidelines SKILL.md addition</code>
- <code>Manual before/after repro: 120 runs of `bin/fm-wake-drain.sh` under `env -u LANG -u LC_ALL LC_CTYPE=UTF-8` against base cf95112 (5 drains printed `Segmentation fault: 11` from the annotation subshell) vs target 2e218b2 (0 signal deaths, 120/120 annotations produced, all exit 0)</code>
- <code>Manual before/after repro: 120 `fm_pid_identity` reads of a live process under the same locale against base (5 failed reads of a live process) vs target (0 failures, identity stable across all reads)</code>
- `Captured one fixed drain's user-visible transcript under the crash-triggering locale: raw wake row + annotation, exit 0, silent stderr`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Lint** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ linter found issues (exit code 1)

🔧 Fix: silence SC2016 on literal awk programs in wake-queue tests
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>

