### PR TITLE
fix: prevent false watcher-down alarms in Claude sessions

### DIFF
--- a/bin/fm-guard.sh
+++ b/bin/fm-guard.sh
@@ -6,12 +6,18 @@
 # non-default branch, because that means firstmate-on-itself work landed in the
 # primary instead of an isolated worktree.
 # Then, if a task is in flight (a state/<id>.meta exists) or X-mode relay
-# polling is active (state/x-watch.check.sh exists) and no identity-matched
-# watcher has a liveness beacon (state/.last-watcher-beat, touched every poll
-# cycle) fresh within FM_GUARD_GRACE seconds, prints a loud, clearly delimited
-# banner so the agent cannot skim past it in the tool output of whatever it was
-# doing - the one channel every harness has. The full banner is emitted once per
-# distinct staleness episode in this FM_HOME (keyed to beacon mtime or absence);
+# polling is active (state/x-watch.check.sh exists) and supervision is not
+# healthy, prints a loud, clearly delimited banner so the agent cannot skim past
+# it in the tool output of whatever it was doing - the one channel every harness
+# has. Supervision health is MODEL-AWARE (fm_watcher_supervision_verdict in
+# bin/fm-wake-lib.sh): under the Claude Stop auto-arm model the watcher runs only
+# between turns, so mid-turn a fresh beacon with no live watcher is healthy and
+# only a stale beacon (beyond FM_GUARD_GRACE) is a genuine lapse; under every
+# persistent-watcher harness a live identity-matched watcher with a fresh beacon
+# is required. The banner names the true failing condition (a missing live
+# watcher process vs a genuinely stale beacon). The full banner is emitted once
+# per distinct down-episode in this FM_HOME (keyed to the failing condition, not
+# the beacon mtime, which a healthy between-turns watcher advances every poll);
 # later guarded commands in the same episode print a one-line reminder instead.
 # Episode state lives only under state/.guard-watcher-stale-banner (volatile,
 # bounded). Independent alarms (queued wakes, worktree tangle) are never
@@ -43,18 +49,14 @@ STALE_BANNER_MARKER="$STATE/.guard-watcher-stale-banner"
 # shellcheck source=bin/fm-supervision-lib.sh
 . "$SCRIPT_DIR/fm-supervision-lib.sh"
 
-# Deterministic episode key from beacon state: same continuous stale beacon
-# (or continuous absence) shares a key; a recovered-then-restale beacon gets a
-# new mtime and therefore a new episode.
+# Deterministic episode key from the qualitative down-state (the failing
+# condition), NOT the beacon mtime: under the auto-arm model a healthy
+# between-turns watcher advances that mtime every poll, which made the "same
+# episode" key change every turn and re-print the full banner. Keying on the
+# failing condition keeps one continuous down-episode stable, while positive
+# recovery clears the marker (below) and re-arms the next episode.
 fm_guard_stale_episode_key() {
-  local state=$1 beat m
-  beat="$state/.last-watcher-beat"
-  if [ -e "$beat" ]; then
-    m=$(fm_sup_stat_mtime "$beat")
-    printf 'beat:%s\n' "${m:-unknown}"
-  else
-    printf 'beat:absent\n'
-  fi
+  printf '%s\n' "$1"
 }
 
 # Claim the full banner for this episode. Exit 0 = print full banner (this call
@@ -150,10 +152,9 @@ in_flight=$FM_SUP_IN_FLIGHT
 sources=$FM_SUP_SOURCES
 needed=$FM_SUP_NEEDED
 beacon_desc=$FM_SUP_BEACON_DESC
-watcher_healthy=false
-if fm_watcher_healthy "$STATE" "$WATCH" "$GRACE" "$FM_HOME"; then
-  watcher_healthy=true
-fi
+fm_watcher_supervision_verdict "$STATE" "$WATCH" "$GRACE" "$FM_HOME"
+watcher_healthy=$FM_WATCHER_VERDICT_OK
+watcher_down_reason=$FM_WATCHER_VERDICT_REASON
 if [ "$needed" = false ]; then
   # Leave the unhealthy state (nothing riding on the watcher): clear so a later
   # work or X-mode need + stale combination is a fresh episode even if the
@@ -168,7 +169,7 @@ fi
 # bordered banner FIRST so it reads as an alarm, not a buried stderr line. Later
 # calls in the same episode get a one-line reminder only.
 if [ "$watcher_healthy" = false ]; then
-  episode_key=$(fm_guard_stale_episode_key "$STATE")
+  episode_key=$(fm_guard_stale_episode_key "$watcher_down_reason")
   episode_key=${episode_key%$'\n'}
   print_full_banner=0
   if [ "$READ_ONLY" -eq 1 ]; then
@@ -193,12 +194,17 @@ if [ "$watcher_healthy" = false ]; then
     {
       printf '●%s\n' "$rule"
       printf '●  WATCHER DOWN - SUPERVISION IS OFF\n'
-      if [ "$in_flight" -gt 0 ]; then
-        printf '●  %s task(s) in flight, but no watcher has a fresh beacon (last beat: %s, grace %ss).\n' "$in_flight" "$beacon_desc" "$GRACE"
-      elif [ "$sources" -gt 0 ]; then
-        printf '●  %s process-event source(s) registered, but no watcher has a fresh beacon (last beat: %s, grace %ss).\n' "$sources" "$beacon_desc" "$GRACE"
+      if [ "$watcher_down_reason" = no-watcher ]; then
+        watcher_cause=$(printf 'no live watcher process holds this home lock (last beat: %s)' "$beacon_desc")
       else
-        printf '●  X-mode relay polling needs supervision, but no watcher has a fresh beacon (last beat: %s, grace %ss).\n' "$beacon_desc" "$GRACE"
+        watcher_cause=$(printf 'no watcher has a fresh beacon (last beat: %s, grace %ss)' "$beacon_desc" "$GRACE")
+      fi
+      if [ "$in_flight" -gt 0 ]; then
+        printf '●  %s task(s) in flight, but %s.\n' "$in_flight" "$watcher_cause"
+      elif [ "$sources" -gt 0 ]; then
+        printf '●  %s process-event source(s) registered, but %s.\n' "$sources" "$watcher_cause"
+      else
+        printf '●  X-mode relay polling needs supervision, but %s.\n' "$watcher_cause"
       fi
       if [ "$READ_ONLY" -eq 1 ]; then
         printf '●  This read-only session should report the lapse, not repair it.\n'

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -2105,6 +2105,10 @@ fi
 if [ "$KIND" = secondmate ]; then
   sq_home=$(shell_quote "$PROJ_ABS")
   sq_primary_home=$(shell_quote "$FM_HOME")
+  case "$HARNESS" in
+    claude) supervision_model=autoarm ;;
+    *) supervision_model=persistent ;;
+  esac
   # Deliver the primary's EFFECTIVE trace-context decision as a normalized on/off
   # literal (never the raw FM_TRACE_CONTEXT string) so a FM_TRACE_CONTEXT override
   # on the primary reaches the secondmate's OWN workers, not just the copied
@@ -2112,7 +2116,7 @@ if [ "$KIND" = secondmate ]; then
   # not enable them across the launch boundary (bin/fm-trace-context-lib.sh header).
   # Reuse the single frozen decision from the carrier resolution above so the
   # injected carrier and this on/off snapshot are guaranteed to agree.
-  LAUNCH="FM_ROOT_OVERRIDE= FM_STATE_OVERRIDE= FM_DATA_OVERRIDE= FM_PROJECTS_OVERRIDE= FM_CONFIG_OVERRIDE= FM_PUBLIC_FOLLOWUP_PRIMARY_HOME=$sq_primary_home FM_HOME=$sq_home FM_TRACE_CONTEXT=$SPAWN_TRACE_EFFECTIVE $LAUNCH"
+  LAUNCH="FM_ROOT_OVERRIDE= FM_STATE_OVERRIDE= FM_DATA_OVERRIDE= FM_PROJECTS_OVERRIDE= FM_CONFIG_OVERRIDE= FM_PUBLIC_FOLLOWUP_PRIMARY_HOME=$sq_primary_home FM_HOME=$sq_home FM_TRACE_CONTEXT=$SPAWN_TRACE_EFFECTIVE FM_SUPERVISION_MODEL=$supervision_model $LAUNCH"
 fi
 # Export GOTMPDIR into the crewmate's pane shell so the agent and every child
 # process (go build, go test, ...) inherit it. Sent before the launch command so

--- a/bin/fm-supervision-lib.sh
+++ b/bin/fm-supervision-lib.sh
@@ -6,9 +6,12 @@
 # work (a state/<id>.meta exists) or an X-mode relay poll
 # (state/x-watch.check.sh), and whether its watcher has a fresh liveness beacon
 # (state/.last-watcher-beat, touched every poll cycle, within the grace window).
-# bin/fm-guard.sh and bin/fm-turnend-guard.sh use fm_watcher_healthy from
-# bin/fm-wake-lib.sh for their warning and block decisions, so a fresh leftover
-# beacon never counts as a live watcher. The status fields here retain the
+# bin/fm-turnend-guard.sh uses the PID-strict fm_watcher_healthy from
+# bin/fm-wake-lib.sh for its block decision. bin/fm-guard.sh uses the model-aware
+# fm_watcher_supervision_verdict (also in bin/fm-wake-lib.sh): under the Claude
+# Stop auto-arm model, where the watcher only runs between turns, a fresh beacon
+# with no live watcher is healthy; under persistent-watcher harnesses a live
+# identity-matched watcher is still required. The status fields here retain the
 # beacon-age details used in their messages.
 
 # Portable mtime; Linux stat lacks -f, macOS stat lacks -c.

--- a/bin/fm-wake-drain.sh
+++ b/bin/fm-wake-drain.sh
@@ -12,16 +12,16 @@ DRAIN_LOCK_HELD=false
 RAW_ROWS=
 
 # Defense in depth for the supervision chain: this script runs at the top of
-# every wake-handling and recovery turn, so assert watcher liveness here too. A
+# every wake-handling and recovery turn, so assert supervision health here too. A
 # lapsed supervision chain then surfaces on a plain drain-and-handle turn, not
 # only when a guarded supervision script (fm-peek/fm-send/...) happens to run.
-# Reuse fm-guard.sh's existing graced, beacon-based alarm (FM_GUARD_GRACE) - do
-# not duplicate the beacon math. Because the watcher touches its beacon every
-# poll cycle, a normal fire leaves a recent beacon well inside grace and stays
-# silent; only a genuine stale-beyond-grace lapse with work in flight warns. Call
-# after the queue is emptied so guard never re-prints its own queued-wakes notice
-# for the records this run just drained, and never let a guard hiccup change the
-# drain's exit status.
+# Reuse fm-guard.sh's model-aware alarm and FM_GUARD_GRACE instead of duplicating
+# its supervision verdict. Under Claude's between-turns auto-arm model, a normal
+# fire leaves a recent beacon well inside grace and stays silent mid-turn. Under
+# persistent-watcher models, the guard also requires the live identity-matched
+# watcher. Call after the queue is emptied so guard never re-prints its own
+# queued-wakes notice for the records this run just drained, and never let a
+# guard hiccup change the drain's exit status.
 assert_watcher_liveness() {
   "$SCRIPT_DIR/fm-guard.sh" || true
 }

--- a/bin/fm-wake-lib.sh
+++ b/bin/fm-wake-lib.sh
@@ -115,6 +115,82 @@ fm_watcher_healthy() {
   return 0
 }
 
+# fm_watcher_healthy above is the PID-STRICT primitive: true only when a live,
+# identity-matched watcher PROCESS holds this home's lock with a fresh beacon. The
+# arm layer (bin/fm-watch-arm.sh, bin/fm-claude-stop-autoarm.sh) needs exactly
+# that - it decides whether to start, attach to, or replace a real watcher
+# process, so a leftover beacon must never satisfy it. bin/fm-turnend-guard.sh
+# also keeps this strict check because it fires at the turn boundary where the
+# auto-arm brings a fresh watcher up. The pull warning (bin/fm-guard.sh) fires
+# mid-turn, where the auto-arm model runs no watcher at all, so it wants a
+# different, model-aware question:
+
+# fm_supervision_model
+# Print the supervision model of this home's PRIMARY harness:
+#   autoarm     Claude Stop-hook auto-arm: the watcher is armed at each turn end
+#               and exits on its wake, so it runs only BETWEEN turns. Mid-turn a
+#               fresh beacon with no live watcher process is the healthy state.
+#   persistent  every other harness (codex foreground checkpoint, opencode/pi/grok
+#               background arm, tmux, unknown): the watcher runs as a tracked live
+#               process, so a live identity-matched pid is the real liveness signal.
+# FM_SUPERVISION_MODEL overrides detection (tests, and callers that already know
+# the harness). Otherwise bin/fm-harness.sh is the single detection owner, so this
+# stays consistent with the harness-specific repair line the guards already emit.
+fm_supervision_model() {
+  local harness
+  case "${FM_SUPERVISION_MODEL:-}" in
+    autoarm|persistent) printf '%s\n' "$FM_SUPERVISION_MODEL"; return 0 ;;
+  esac
+  harness=$("$FM_WAKE_LIB_DIR/fm-harness.sh" 2>/dev/null || printf unknown)
+  case "$harness" in
+    claude) printf 'autoarm\n' ;;
+    *) printf 'persistent\n' ;;
+  esac
+}
+
+# fm_watcher_supervision_verdict <state> <watch-path> [grace] [home]
+# Model-aware "is supervision healthy right now" verdict for the pull warning
+# guard (bin/fm-guard.sh), NOT the arm layer or the turn-end guard. Sets:
+#   FM_WATCHER_VERDICT_OK      true when supervision is healthy for this model
+#   FM_WATCHER_VERDICT_REASON  when not ok, the true failing condition:
+#                              no-watcher   - a live watcher process is the real
+#                                             signal for this model but none holds
+#                                             the lock (the beacon is still fresh)
+#                              stale-beacon - the beacon is stale beyond grace or
+#                                             absent (a genuine supervision lapse)
+# autoarm: a fresh beacon within grace is healthy even with no live watcher,
+# because the watcher only runs between turns; only a stale beacon is a lapse.
+# persistent: require a live identity-matched watcher with a fresh beacon
+# (fm_watcher_healthy); a fresh leftover beacon with no live watcher is still down.
+# shellcheck disable=SC2034 # Read by callers after the function returns.
+FM_WATCHER_VERDICT_OK=false
+# shellcheck disable=SC2034 # Read by callers after the function returns.
+FM_WATCHER_VERDICT_REASON=stale-beacon
+fm_watcher_supervision_verdict() {
+  local state=$1 watch=$2 grace=${3:-${FM_GUARD_GRACE:-300}} home=${4:-$FM_HOME}
+  local beat age fresh=false
+  FM_WATCHER_VERDICT_OK=false
+  FM_WATCHER_VERDICT_REASON=stale-beacon
+  beat="$state/.last-watcher-beat"
+  age=$(fm_path_age "$beat")
+  case "$age" in
+    ''|*[!0-9]*) ;;
+    *) [ "$age" -lt "$grace" ] && fresh=true ;;
+  esac
+  if [ "$(fm_supervision_model)" = autoarm ]; then
+    [ "$fresh" = true ] && FM_WATCHER_VERDICT_OK=true
+    return 0
+  fi
+  if fm_watcher_healthy "$state" "$watch" "$grace" "$home"; then
+    # shellcheck disable=SC2034 # Read by callers after the function returns.
+    FM_WATCHER_VERDICT_OK=true
+  elif [ "$fresh" = true ]; then
+    # shellcheck disable=SC2034 # Read by callers after the function returns.
+    FM_WATCHER_VERDICT_REASON=no-watcher
+  fi
+  return 0
+}
+
 fm_lock_clean_known_files() {
   local lockdir=$1
   rm -f \

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -65,9 +65,9 @@ It suppresses failed-looking closes when the same identity-matched watcher is he
 [`watcher-continuity.md`](watcher-continuity.md) owns Claude's residual active-turn coverage and watcher-status command-gating boundary.
 The existing turn-end guard remains the final backstop for all five harness-engine protocols, with pi-signed sharing Pi's protocol and the `--claude` mode cooperating with the auto-arm claim.
 Its `--restart` mode signals only the watcher recorded in the current home's `state/.watch.lock`, so restarting one home cannot kill sibling secondmate watchers.
-A pull-based guard (`bin/fm-guard.sh`) warns through supervision tool output if the primary checkout is tangled, if work, process-event sources, or X-mode relay polling needs supervision without a healthy identity-matched watcher, or if queued wakes are waiting to be drained.
-The drain script calls that guard after emptying the queue, which avoids repeating the queued-wakes warning for records it just consumed while still warning on stale watcher liveness.
-It leads with a prominent bordered tangle banner, while `bin/fm-guard.sh` owns the stale-watcher banner/reminder policy so repeated guarded commands stay noisy without reprinting the full watcher-down banner in the same episode.
+A pull-based guard (`bin/fm-guard.sh`) warns through supervision tool output if the primary checkout is tangled, if work, process-event sources, or X-mode relay polling has an unhealthy model-aware supervision verdict, or if queued wakes are waiting to be drained.
+The drain script calls that guard after emptying the queue, which avoids repeating the queued-wakes warning for records it just consumed while still warning on unhealthy supervision.
+It leads with a prominent bordered tangle banner, while `bin/fm-guard.sh` owns the watcher-down banner and reminder policy so repeated guarded commands stay noisy without reprinting the full banner in the same episode.
 On every verified primary harness, tracked hook integration gives the primary session a push-based backstop: when work, a process-event source, or X-mode relay polling needs supervision and no identity-matched watcher lock with a fresh beacon is live, direct Stop hooks block and passive turn-end hooks force one bounded follow-up.
 The guard covers the main primary and genuinely marked secondmate homes, exempts child crewmate/scout worktrees, is loop-safe per harness, and is documented in [turnend-guard.md](turnend-guard.md).
 

--- a/docs/arm-pretool-check.md
+++ b/docs/arm-pretool-check.md
@@ -13,7 +13,7 @@ A shell background operator, pipeline, redirection, wrapper, or unrelated comman
 The seatbelt rejects those command shapes before execution.
 
 This policy is not a post-arm liveness guarantee.
-`bin/fm-guard.sh`, `bin/fm-turnend-guard.sh`, the watcher lock, and the watcher beacon still prove whether supervision is healthy after an allowed call.
+`bin/fm-guard.sh` and `bin/fm-turnend-guard.sh` apply their respective post-arm supervision predicates to the watcher lock and beacon after an allowed call.
 
 The classifier never executes, sources, evaluates, or expands any part of the submitted command.
 It tokenizes the bytes and classifies lexical execution positions only.

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -29,7 +29,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-test-run.sh`         | Behavior-test runner: selection, portable lanes, proven-isolated `--jobs`, coverage guard, timing/JSON |
 | `fm-test-isolation-proof.sh` | Concurrent isolation proof and proven-isolated candidate set owner |
 | `fm-ensure-agents-md.sh` | Ensure a project's real `AGENTS.md`, its `CLAUDE.md` symlink, and the canonical self-governance section |
-| `fm-guard.sh`            | Warn on primary-checkout tangles, pending queued wakes, and stale watcher liveness   |
+| `fm-guard.sh`            | Warn on primary-checkout tangles, pending queued wakes, and unhealthy supervision    |
 | `fm-primary-scope-lib.sh` | Shared marker-or-plain-checkout primary-home predicate for tracked hooks             |
 | `fm-session-lock-lib.sh` | Shared session-lock harness identity (ancestry walk and holder liveness) for fm-lock.sh and the Claude Stop auto-arm |
 | `fm-claude-stop-autoarm.sh` | Claude Stop `asyncRewake` hook owning tokenless watcher continuity with single-flight exit-2 rewake (docs/watcher-continuity.md) |
@@ -78,7 +78,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-tasks-axi-lib.sh`    | Shared backlog-backend selector and `tasks-axi` compatibility probe                  |
 | `fm-quota-axi-lib.sh`    | Shared `quota-axi` compatibility floor for the bootstrap diagnostic                  |
 | `fm-vendor-auth-probe.sh`| Run one hard-bounded, non-destructive authentication probe of a named vendor CLI and report the fact |
-| `fm-wake-drain.sh`       | Atomically drain queued watcher wakes, emit bounded best-effort status-event annotations, then assert watcher liveness |
+| `fm-wake-drain.sh`       | Atomically drain queued watcher wakes, emit bounded best-effort status-event annotations, then assert supervision health |
 | `fm-wake-lib.sh`         | Shared durable wake queue, portable locks, and watcher identity/health helpers       |
 | `fm-classify-lib.sh`     | Shared captain-relevant and declared-external-wait wake classification vocabulary    |
 | `fm-send.sh`             | Send one verified literal line or supported key through the target's recorded backend |

--- a/docs/sessionstart-nudge.md
+++ b/docs/sessionstart-nudge.md
@@ -10,7 +10,7 @@ The Ahoy skill owns the rule that this marked operational input is never a capta
 `bin/fm-sessionstart-nudge.sh` is the single command every harness adapter invokes.
 It sources `bin/fm-gate-refuse-lib.sh` and stays silent for a no-mistakes gate agent identified by `NO_MISTAKES_GATE` or a `.no-mistakes/repos/*.git` git-common-dir.
 It shares `bin/fm-primary-scope-lib.sh` with `bin/fm-turnend-guard.sh`, so the hooks use one primary-detection owner.
-The Shared Predicate section of [`turnend-guard.md`](turnend-guard.md#shared-predicate) owns marker validation, plain-checkout detection, and required Firstmate-shaped paths.
+The Guard Predicates section of [`turnend-guard.md`](turnend-guard.md#guard-predicates) owns marker validation, plain-checkout detection, and required Firstmate-shaped paths.
 
 Before printing, the wrapper reads `state/.lock` and walks at most eight parents from its own pid in its own separate, hard-coded loop, independent of `bin/fm-lock.sh`'s ancestry walk (`fm_harness_ancestry_pid()` in `bin/fm-session-lock-lib.sh`, which now walks up to sixteen parents and can extend past a claude-named match to a still-more-ancestral one) and of Pi's `lockOwnership()`.
 If the lock names a live pid in that ancestry, session start already ran in this harness session and the wrapper stays silent.

--- a/docs/supervision-protocols/claude.md
+++ b/docs/supervision-protocols/claude.md
@@ -17,7 +17,7 @@ When this session owns supervision and away mode is not active:
    No PreToolUse hook denies fleet commands based on watcher status.
    [`watcher-continuity.md`](../watcher-continuity.md) owns the exact session-lock recovery boundary.
 8. The turn-end guard (`bin/fm-turnend-guard.sh --claude`) remains the final backstop.
-   It uses the same live-watcher and fresh-beacon predicate as the pull guard.
+   It requires the PID-strict live-watcher and fresh-beacon predicate at the Stop boundary, while the mid-turn pull guard accepts a fresh beacon without a live process under Claude's between-turns auto-arm model.
    It allows the stop when a watcher is healthy or the role-verified auto-arm owns recovery, while fresh failure epochs advance the bounded one-time attended fail-open progression described in [`turnend-guard.md`](../turnend-guard.md).
 9. Waiting on the hook-owned cycle is silent: do not send idle progress while the watcher is parked.
 

--- a/docs/turnend-guard.md
+++ b/docs/turnend-guard.md
@@ -13,11 +13,11 @@ Do not infer this guard's scope, loop safety, or compatibility tradeoffs for tho
 
 `bin/fm-guard.sh` is a pull-based warning that runs only when another supervision command invokes it.
 The turn-end guard closes the remaining gap at the primary's own turn boundary.
-When work, a process-event source, or X-mode relay polling needs supervision and no identity-matched watcher has a fresh beacon, the harness integration must either block the turn end or force one bounded follow-up that uses the recovery instruction from the emitted session-start protocol.
-Both guards require the same live lock, process identity, home/path binding, and fresh-beacon predicate.
+When work, a process-event source, or X-mode relay polling needs supervision at that boundary and no identity-matched watcher has a fresh beacon, the harness integration must either block the turn end or force one bounded follow-up that uses the recovery instruction from the emitted session-start protocol.
+The mid-turn pull warning uses the model-aware supervision verdict described below, while the turn-end guard keeps the PID-strict watcher predicate.
 The guard remains a backstop; [`watcher-continuity.md`](watcher-continuity.md) owns normal continuity.
 
-## Shared predicate
+## Guard predicates
 
 The guard first calls the shared primary scope.
 A secondmate home runs its own primary Firstmate session, so a genuine `.fm-secondmate-home` marker includes it whether the home is a linked worktree or plain clone.
@@ -35,7 +35,7 @@ The turn-end guard needs that strict check because it fires at the turn boundary
 `bin/fm-guard.sh`, the pull warning, instead uses the model-aware `fm_watcher_supervision_verdict` from the same library, because it fires mid-turn when the auto-arm model runs no watcher at all.
 Under the Claude Stop auto-arm model a beacon fresh within grace is healthy even with no live watcher process, and only a beacon stale beyond grace (or absent) alarms.
 Under every persistent-watcher harness a live identity-matched watcher with a fresh beacon is still required, so the pull guard keeps the same strict semantics there.
-Its banner names the true failing condition - a missing live watcher process, or a genuinely stale beacon with its real age - and keys the once-per-episode dedup on that condition rather than the beacon mtime.
+Its banner names the true failing condition, either a missing live watcher process or a genuinely stale beacon with its real age, and keys the once-per-episode dedup on that condition rather than the beacon mtime.
 
 `FM_STATE_OVERRIDE` wins over `FM_HOME/state`, and `FM_HOME` wins over repository-root `state/`.
 `FM_GUARD_GRACE` controls beacon freshness and defaults to 300 seconds.
@@ -106,7 +106,7 @@ That warning uses `bin/fm-supervision-instructions.sh --repair-line`, so it alwa
 ## Regression coverage
 
 `tests/fm-turnend-guard.test.sh` covers the predicate, main and secondmate primary scope, child-worktree exclusion, `FM_HOME` and `FM_STATE_OVERRIDE` precedence, the live-lock and fresh-beacon guard predicate, the cooperative `--claude` claim wait, monotonic failed-epoch progression, bounded attended fail-open, post-alarm continuation suppression, positive recovery reset, Pi logical-run latching, missing-`jq` behavior, all five primary registrations, Grok native and legacy selection, typed field precedence, malformed input, and exactly-one-path safety.
-`tests/fm-guard-stale-banner.test.sh` covers the matching pull-guard predicate, including the persistent-model fresh-leftover-beacon negative control, the auto-arm model's healthy fresh-beacon-without-a-watcher case and its stale-beacon alarm, the true-reason banner wording, and the reason-keyed episode dedup surviving a beacon mtime change.
+`tests/fm-guard-stale-banner.test.sh` covers the pull-guard predicate, including the persistent-model fresh-leftover-beacon negative control, the auto-arm model's healthy fresh-beacon-without-a-watcher case and its stale-beacon alarm, the true-reason banner wording, and the reason-keyed episode dedup surviving a beacon mtime change.
 `tests/fm-kimi-harness.test.sh` covers the separate Kimi crew hook's format preservation, idempotence, refusal cases, token guard, spawn registration, and teardown cleanup.
 `tests/fm-supervision-instructions.test.sh` covers recovery-line ownership and pi-signed's identity-preserving reuse of Pi's protocol.
 `FM_PI_LIVE_E2E=1 tests/fm-pi-primary-live-e2e.test.sh` is the opt-in isolated Pi path.

--- a/docs/turnend-guard.md
+++ b/docs/turnend-guard.md
@@ -30,10 +30,12 @@ For an in-scope primary, the guard counts in-flight work from `state/*.meta`.
 Registered `state/procevent/*.source` records also require supervision even though they have no task metadata.
 The default cross-harness mode exits silently with no supervision need.
 Every mode treats `state/x-watch.check.sh` as supervision need, so X-mode relay polling remains guarded without an in-flight task.
-Otherwise it calls `fm_watcher_healthy <state-dir> <watch-path> [grace-seconds] [home]` from `bin/fm-wake-lib.sh`, the same identity-matched lock and fresh-beacon check used by `bin/fm-watch-arm.sh`.
-`bin/fm-guard.sh` uses that same check rather than treating the status helper's fresh-beacon field as sufficient.
-A stale beacon blocks even when a watcher pid is live.
-A fresh leftover beacon blocks when the lock is missing, dead, or identity-mismatched.
+Otherwise it calls `fm_watcher_healthy <state-dir> <watch-path> [grace-seconds] [home]` from `bin/fm-wake-lib.sh`, the same PID-strict identity-matched lock and fresh-beacon check used by `bin/fm-watch-arm.sh`: a stale beacon blocks even when a watcher pid is live, and a fresh leftover beacon blocks when the lock is missing, dead, or identity-mismatched.
+The turn-end guard needs that strict check because it fires at the turn boundary, where the auto-arm is bringing a fresh watcher up for the upcoming idle period, and it cooperates with that arm rather than trusting a beacon left by the cycle that just ended.
+`bin/fm-guard.sh`, the pull warning, instead uses the model-aware `fm_watcher_supervision_verdict` from the same library, because it fires mid-turn when the auto-arm model runs no watcher at all.
+Under the Claude Stop auto-arm model a beacon fresh within grace is healthy even with no live watcher process, and only a beacon stale beyond grace (or absent) alarms.
+Under every persistent-watcher harness a live identity-matched watcher with a fresh beacon is still required, so the pull guard keeps the same strict semantics there.
+Its banner names the true failing condition - a missing live watcher process, or a genuinely stale beacon with its real age - and keys the once-per-episode dedup on that condition rather than the beacon mtime.
 
 `FM_STATE_OVERRIDE` wins over `FM_HOME/state`, and `FM_HOME` wins over repository-root `state/`.
 `FM_GUARD_GRACE` controls beacon freshness and defaults to 300 seconds.
@@ -104,7 +106,7 @@ That warning uses `bin/fm-supervision-instructions.sh --repair-line`, so it alwa
 ## Regression coverage
 
 `tests/fm-turnend-guard.test.sh` covers the predicate, main and secondmate primary scope, child-worktree exclusion, `FM_HOME` and `FM_STATE_OVERRIDE` precedence, the live-lock and fresh-beacon guard predicate, the cooperative `--claude` claim wait, monotonic failed-epoch progression, bounded attended fail-open, post-alarm continuation suppression, positive recovery reset, Pi logical-run latching, missing-`jq` behavior, all five primary registrations, Grok native and legacy selection, typed field precedence, malformed input, and exactly-one-path safety.
-`tests/fm-guard-stale-banner.test.sh` covers the matching pull-guard predicate, including the fresh-leftover-beacon negative control.
+`tests/fm-guard-stale-banner.test.sh` covers the matching pull-guard predicate, including the persistent-model fresh-leftover-beacon negative control, the auto-arm model's healthy fresh-beacon-without-a-watcher case and its stale-beacon alarm, the true-reason banner wording, and the reason-keyed episode dedup surviving a beacon mtime change.
 `tests/fm-kimi-harness.test.sh` covers the separate Kimi crew hook's format preservation, idempotence, refusal cases, token guard, spawn registration, and teardown cleanup.
 `tests/fm-supervision-instructions.test.sh` covers recovery-line ownership and pi-signed's identity-preserving reuse of Pi's protocol.
 `FM_PI_LIVE_E2E=1 tests/fm-pi-primary-live-e2e.test.sh` is the opt-in isolated Pi path.

--- a/docs/verification/supervision.md
+++ b/docs/verification/supervision.md
@@ -171,6 +171,22 @@ fm-doc-audience-check: ok surfaces=61 local_links=174
 FM_TEST_SUMMARY total=4 failed=0 skipped_gate=0 duration_ms=102585
 ```
 
+The model-aware pull-guard predicate correction (`bin/fm-guard.sh` no longer reports a false watcher-down mid-turn under the Claude Stop auto-arm model, where the watcher runs only between turns) was verified on 2026-08-04 with the installed ShellCheck 0.11.0 and the same isolated behavior suites.
+
+```sh
+bin/fm-lint.sh
+bin/fm-doc-audience-check.sh
+bin/fm-test-run.sh tests/fm-claude-stop-autoarm.test.sh tests/fm-guard-stale-banner.test.sh tests/fm-turnend-guard.test.sh tests/fm-supervision-instructions.test.sh
+```
+
+Observed output:
+
+```text
+fm-lint.sh: ShellCheck 0.11.0 (pinned 0.11.0)
+fm-doc-audience-check: ok surfaces=64 local_links=188
+FM_TEST_SUMMARY total=4 failed=0 skipped_gate=0 duration_ms=80078
+```
+
 The broader relevant regression pass was rerun on 2026-08-02 without live-home or daemon mutation.
 
 ```sh

--- a/tests/fm-guard-stale-banner.test.sh
+++ b/tests/fm-guard-stale-banner.test.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Regression tests for fm-guard's stale-watcher banner deduplication.
+# Regression tests for fm-guard's watcher-down banner deduplication.
 #
 # The first stale command in one FM_HOME must print the full actionable watcher
 # banner.

--- a/tests/fm-guard-stale-banner.test.sh
+++ b/tests/fm-guard-stale-banner.test.sh
@@ -41,11 +41,15 @@ record_live_watcher() {
   printf '%s\n' "$identity" > "$home/state/.watch.lock/pid-identity"
 }
 
+# These cases exercise the persistent-watcher model (a live pid is the real
+# liveness signal), so pin the model rather than letting the host test runner's
+# ambient harness ancestry pick it.
 run_guard_case() {
   local dir=$1
   FM_ROOT_OVERRIDE="$(case_root "$dir")" \
     FM_HOME="$(case_home "$dir")" \
     FM_GUARD_GRACE=999 \
+    FM_SUPERVISION_MODEL=persistent \
     "$ROOT/bin/fm-guard.sh" 2>&1
 }
 
@@ -54,7 +58,19 @@ run_guard_case_read_only() {
   FM_ROOT_OVERRIDE="$(case_root "$dir")" \
     FM_HOME="$(case_home "$dir")" \
     FM_GUARD_GRACE=999 \
+    FM_SUPERVISION_MODEL=persistent \
     FM_GUARD_READ_ONLY=1 \
+    "$ROOT/bin/fm-guard.sh" 2>&1
+}
+
+# The Claude Stop auto-arm model: the watcher runs only between turns, so a fresh
+# beacon with no live watcher process is the healthy mid-turn state.
+run_guard_case_autoarm() {
+  local dir=$1
+  FM_ROOT_OVERRIDE="$(case_root "$dir")" \
+    FM_HOME="$(case_home "$dir")" \
+    FM_GUARD_GRACE=999 \
+    FM_SUPERVISION_MODEL=autoarm \
     "$ROOT/bin/fm-guard.sh" 2>&1
 }
 
@@ -283,8 +299,87 @@ test_read_only_never_mutates_stale_banner_state_files() {
   pass "fm-guard stale banner: read-only never mutates stale-banner state files"
 }
 
+test_autoarm_fresh_beacon_without_watcher_is_healthy() {
+  local dir out
+  dir=$(make_guard_case autoarm-fresh)
+  # A fresh beacon and NO live watcher: the healthy mid-turn state under the
+  # Claude Stop auto-arm model, where the watcher only runs between turns.
+  touch "$(case_home "$dir")/state/.last-watcher-beat"
+  out=$(run_guard_case_autoarm "$dir")
+  [ -z "$out" ] \
+    || fail "auto-arm model with a fresh beacon and no live watcher must stay silent, got: $out"
+  pass "fm-guard stale banner: auto-arm fresh beacon without a live watcher is healthy"
+}
+
+test_autoarm_stale_beacon_alarms_with_correct_reason() {
+  local dir out
+  dir=$(make_guard_case autoarm-stale)
+  # No beacon at all -> a genuine supervision lapse even under the auto-arm model.
+  out=$(run_guard_case_autoarm "$dir")
+  [ "$(count_text "$out" "WATCHER DOWN - SUPERVISION IS OFF")" -eq 1 ] \
+    || fail "auto-arm model with an absent/stale beacon must alarm: $out"
+  assert_contains "$out" "no watcher has a fresh beacon" \
+    "auto-arm stale-beacon banner must name the stale-beacon reason"
+  pass "fm-guard stale banner: auto-arm stale beacon alarms with the true reason"
+}
+
+test_autoarm_stale_episode_is_stable() {
+  local dir out1 out2
+  dir=$(make_guard_case autoarm-stable-episode)
+  out1=$(run_guard_case_autoarm "$dir")
+  out2=$(run_guard_case_autoarm "$dir")
+  [ "$(count_text "$out1" "WATCHER DOWN - SUPERVISION IS OFF")" -eq 1 ] \
+    || fail "first auto-arm stale call did not print the full banner: $out1"
+  [ "$(count_text "$out2" "WATCHER DOWN - SUPERVISION IS OFF")" -eq 0 ] \
+    || fail "auto-arm stale episode re-printed the full banner instead of deduping: $out2"
+  assert_contains "$out2" "full banner already printed this episode" \
+    "second auto-arm stale call did not print the concise reminder"
+  pass "fm-guard stale banner: auto-arm stale episode stays one episode across calls"
+}
+
+test_persistent_no_watcher_banner_names_missing_process() {
+  local dir out
+  dir=$(make_guard_case persistent-no-watcher-reason)
+  # A fresh beacon with no live watcher under the persistent model: the real
+  # failing condition is the missing process, not a stale beacon.
+  touch "$(case_home "$dir")/state/.last-watcher-beat"
+  out=$(run_guard_case "$dir")
+  assert_contains "$out" "no live watcher process holds this home lock" \
+    "persistent no-watcher banner must name the missing watcher process"
+  assert_not_contains "$out" "no watcher has a fresh beacon" \
+    "persistent no-watcher banner must not blame the fresh beacon"
+  pass "fm-guard stale banner: persistent no-watcher banner names the true reason"
+}
+
+test_persistent_no_watcher_episode_survives_beacon_touch() {
+  local dir home out1 out2
+  dir=$(make_guard_case persistent-no-watcher-episode)
+  home=$(case_home "$dir")
+  touch "$home/state/.last-watcher-beat"
+  out1=$(run_guard_case "$dir")
+  [ "$(count_text "$out1" "WATCHER DOWN - SUPERVISION IS OFF")" -eq 1 ] \
+    || fail "first persistent no-watcher call did not print the full banner: $out1"
+  # The beacon mtime advancing with NO live watcher must not split the continuous
+  # down-episode. The old beacon-mtime episode key re-printed the full banner
+  # here; the reason-based key keeps it a single episode. Separate the touches by
+  # a second so the mtime genuinely changes at whole-second stat granularity.
+  sleep 1
+  touch "$home/state/.last-watcher-beat"
+  out2=$(run_guard_case "$dir")
+  [ "$(count_text "$out2" "WATCHER DOWN - SUPERVISION IS OFF")" -eq 0 ] \
+    || fail "advancing the beacon mtime with no live watcher re-printed the banner: $out2"
+  assert_contains "$out2" "full banner already printed this episode" \
+    "same no-watcher episode did not print the concise reminder after a beacon touch"
+  pass "fm-guard stale banner: a no-watcher episode survives a beacon mtime change"
+}
+
 test_first_stale_call_prints_full_banner
 test_repeated_same_episode_prints_reminder_only
+test_autoarm_fresh_beacon_without_watcher_is_healthy
+test_autoarm_stale_beacon_alarms_with_correct_reason
+test_autoarm_stale_episode_is_stable
+test_persistent_no_watcher_banner_names_missing_process
+test_persistent_no_watcher_episode_survives_beacon_touch
 test_fresh_beacon_without_live_watcher_stays_alarm
 test_x_mode_without_live_watcher_stays_alarm
 test_healthy_recovery_rearms_next_stale_episode

--- a/tests/fm-secondmate-harness.test.sh
+++ b/tests/fm-secondmate-harness.test.sh
@@ -829,6 +829,41 @@ test_spawn_explicit_harness_uses_explicit_profile_axes() {
   pass "C8 spawn: an explicit --harness still honors explicit model/effort flags"
 }
 
+test_spawned_secondmate_uses_its_harness_supervision_model() {
+  local harness expected w sm launchlog launch fakebin out
+  for harness in codex claude; do
+    w="$TMP_ROOT/spawn-supervision-model-$harness"
+    sm="$w/sm"
+    launchlog="$w/launch.log"
+    mkdir -p "$w/home/config"
+    printf '%s\n' "$harness" > "$w/home/config/secondmate-harness"
+    make_seeded_home "$sm" sm
+    spawn_secondmate_capture "$w" sm "$sm" "$launchlog" >/dev/null 2>&1
+    fm_write_meta "$sm/state/task.meta" "window=firstmate:fm-task" "kind=ship"
+    touch "$sm/state/.last-watcher-beat"
+    fakebin="$w/tmux-sm/fakebin"
+    cat > "$fakebin/$harness" <<SH
+#!/usr/bin/env bash
+"$ROOT/bin/fm-guard.sh"
+SH
+    chmod +x "$fakebin/$harness"
+    launch=$(cat "$launchlog")
+    out=$(PATH="$fakebin:$BASE_PATH" CLAUDECODE=1 bash -c "$launch" 2>&1)
+    case "$harness" in
+      codex)
+        expected='WATCHER DOWN - SUPERVISION IS OFF'
+        assert_contains "$out" "$expected" \
+          "Codex secondmate inherited Claude auto-arm despite its persistent watcher model"
+        ;;
+      claude)
+        [ -z "$out" ] \
+          || fail "Claude secondmate with a fresh beacon should use auto-arm supervision, got: $out"
+        ;;
+    esac
+  done
+  pass "C9 spawn: secondmate launch pins supervision to its own harness"
+}
+
 # The harness fallback chain (secondmate-harness -> crew-harness -> own) still
 # resolves correctly with no model/effort tokens anywhere in the chain, and a
 # crew/scout (non-secondmate) launch is entirely unaffected by this feature: no
@@ -2356,6 +2391,7 @@ test_spawn_explicit_model_overrides_secondmate_harness_token
 test_spawn_explicit_effort_overrides_secondmate_harness_token
 test_spawn_explicit_harness_does_not_inherit_secondmate_harness_tokens
 test_spawn_explicit_harness_uses_explicit_profile_axes
+test_spawned_secondmate_uses_its_harness_supervision_model
 test_spawn_fallback_chain_and_crew_scout_unaffected
 test_bootstrap_sweep_propagates_and_reconverges
 test_bootstrap_sweep_propagates_when_tracked_current


### PR DESCRIPTION
## Intent

Fix bin/fm-guard.sh reporting a false "WATCHER DOWN - SUPERVISION IS OFF" alarm during a healthy Claude-primary session.

Root cause: the mid-turn pull guard derived watcher health from fm_watcher_healthy, which requires a live watcher PROCESS holding the home lock. Under Claude's Stop-hook auto-arm supervision model the watcher is armed at each turn end and exits on its wake, so it runs only BETWEEN turns. Every guarded command run mid-turn therefore found no live watcher and tripped the banner even though supervision was healthy. Because the dedup episode key was derived from the beacon mtime (which the between-turns watcher advances every poll) the full banner re-printed on essentially every command, and the message always blamed a "fresh beacon" that was in fact fresh.

Deliberate decisions and tradeoffs:
- Added a new model-aware verdict fm_watcher_supervision_verdict (and fm_supervision_model) in bin/fm-wake-lib.sh and switched ONLY the mid-turn pull guard (bin/fm-guard.sh) to it. fm_watcher_healthy itself is intentionally left unchanged and still PID-strict, because the arm layer (fm-watch-arm.sh, fm-claude-stop-autoarm.sh) needs a live process to decide start/attach/replace and must never be satisfied by a leftover beacon.
- The turn-end guard (fm-turnend-guard.sh) intentionally keeps the strict fm_watcher_healthy check: it fires at the turn boundary where the auto-arm brings a fresh watcher up and cooperates with that arm, so a beacon left by the just-ended cycle is not sufficient there.
- Model detection: the claude harness uses the between-turns auto-arm model (a beacon fresh within FM_GUARD_GRACE is healthy even with no live watcher; only a beacon stale beyond grace, or absent, alarms). Every other harness (codex foreground checkpoint, opencode/pi/grok background arm, tmux, unknown) uses the persistent-watcher model where a live identity-matched watcher is still required (unchanged). Detection uses the existing bin/fm-harness.sh (the single detection owner, consistent with the harness-specific repair line the guard already emits), with an FM_SUPERVISION_MODEL override for tests and callers that already know the harness.
- The banner now names the true failing condition (a missing live watcher process vs a genuinely stale beacon) instead of always blaming the beacon, and the once-per-episode dedup keys on that condition rather than the beacon mtime, so a genuine lapse announces once and does not re-print each turn. A genuinely lapsed chain (stale beacon beyond grace) still alarms.

Tests: tests/fm-guard-stale-banner.test.sh gains auto-arm healthy fresh-beacon-without-a-watcher, auto-arm stale-beacon alarm, stable auto-arm episode, true-reason banner wording, and a persistent no-watcher episode surviving a beacon mtime change; the existing persistent-model cases are pinned to FM_SUPERVISION_MODEL=persistent so the host runner's ambient harness ancestry cannot flip them. Docs updated: bin/fm-guard.sh header, bin/fm-supervision-lib.sh comment, docs/turnend-guard.md, and a dated maintainer-verification entry in docs/verification/supervision.md.

PR description should be a plain, public technical bug-fix write-up (observed behavior, root cause, fix) with no internal or operational framing.

## What Changed

- Make the mid-turn pull guard model-aware so healthy Claude auto-arm sessions accept a fresh watcher beacon without requiring a live between-turn watcher, while persistent harnesses remain PID-strict.
- Report the actual supervision failure and deduplicate continuous watcher-down episodes by failure condition instead of beacon timestamp.
- Pin secondmate supervision models to their launched harness and update regression coverage and supervision documentation.

## Risk Assessment

✅ Low: Captain, the follow-up safely pins each spawned secondmate to the supervision model implied by its resolved harness, closing the inherited Claude-marker hole without changing other spawn kinds.

## Testing

Diff inspection, both targeted regression scripts, and direct end-user CLI checks passed. The captured transcript demonstrates model-aware silence during a healthy Claude mid-turn session, correct persistent-model behavior, truthful stale-beacon wording, and stable alarm deduplication.

<details>
<summary>Evidence: End-user guard behavior transcript</summary>

```text
CASE 1: Claude primary, guarded command mid-turn, fresh beacon, no watcher process
Detected supervision model: autoarm
Guard output: <none; guarded command remains free of false alarms>

CASE 2: Same fresh beacon and no watcher process, persistent supervision model
●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
●  WATCHER DOWN - SUPERVISION IS OFF
●  1 task(s) in flight, but no live watcher process holds this home lock (last beat: 0s ago).
●  Trust the emitted supervision protocol for this harness; do not use shell & for watcher repair.
●  This is a supervision warning only; the guarded operation WILL still run.
●  repair missing watcher supervision with a foreground checkpoint: bin/fm-watch-checkpoint.sh --seconds 180.
●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

CASE 3: Claude primary with an absent beacon, first and repeated guarded commands
First guarded command:
●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
●  WATCHER DOWN - SUPERVISION IS OFF
●  1 task(s) in flight, but no watcher has a fresh beacon (last beat: never, grace 999s).
●  Trust the emitted supervision protocol for this harness; do not use shell & for watcher repair.
●  This is a supervision warning only; the guarded operation WILL still run.
●  watcher supervision needs Stop-owned automatic recovery; inspect the hook registration and startup status before ending the turn.
●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
Repeated guarded command in the same lapse:
WARNING: watcher still down (same stale episode; last beat: never, grace 999s) - full banner already printed this episode.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- 🚨 `bin/fm-wake-lib.sh:144` - `fm-harness.sh` prioritizes inherited `CLAUDECODE=1` over process ancestry. Non-Claude secondmates launched from Claude can therefore be classified as `autoarm`, causing line 180 to accept a fresh orphan beacon with no live watcher. This violates the required persistent-watcher behavior for every non-Claude harness and can silently disable the guard. Pass the known supervision model from launch, scrub foreign harness markers, or correct detection precedence, then cover the unforced integration path.

🔧 Fix: Pin secondmate supervision model to launched harness
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bash tests/fm-guard-stale-banner.test.sh`
- `bash tests/fm-secondmate-harness.test.sh`
- <code>Invoked `bin/fm-guard.sh` with `CLAUDECODE=1`, an in-flight task, a fresh beacon, and no watcher process; model detection returned `autoarm` and the guard emitted no alarm.</code>
- <code>Invoked `bin/fm-guard.sh` against the same fresh-beacon state with `FM_SUPERVISION_MODEL=persistent`; it correctly reported the missing live watcher process.</code>
- <code>Invoked `bin/fm-guard.sh` twice with `CLAUDECODE=1` and an absent beacon; the first command reported the stale-beacon cause and the second emitted only the same-episode reminder.</code>
- <code>Verified `fm-watch-arm.sh`, `fm-claude-stop-autoarm.sh`, and `fm-turnend-guard.sh` still call the PID-strict `fm_watcher_healthy` primitive.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
