### PR TITLE
fix(bin): preserve working state for advanced pipeline runs

### DIFF
--- a/bin/fm-crew-state.sh
+++ b/bin/fm-crew-state.sh
@@ -27,7 +27,11 @@
 #      A run matches when its head equals the worktree HEAD, or the worktree HEAD
 #      is an ancestor of the run head (pipeline fix commits advanced the run on
 #      the same line of history). Local work that advanced past the run head, or
-#      diverged from it, invalidates attribution.
+#      diverged from it, invalidates attribution. A run head that no longer
+#      resolves here is the live pipeline's tip advanced in the daemon's own
+#      repo; these read-only lookups attribute it (see nm_run_head_matches_worktree),
+#      while the strict shared owner that fm-teardown.sh's destructive abort
+#      consumes never does.
 #      The run-step is AUTHORITATIVE: running/fixing -> working, ci -> working,
 #      awaiting_approval/fix_review -> parked (with gate findings), terminal
 #      passed/checks-passed -> done, failed/cancelled -> failed. EXCEPT: while
@@ -335,24 +339,32 @@ nm_ci_checks_state() {
 # matching row's status word (running/completed/cancelled/failed), or empty
 # when the branch has no run within FM_CREW_STATE_RUNS_LIMIT rows.
 nm_runs_status_for_branch() {  # <branch>
-  local branch=$1 out row st rest br sha
+  local branch=$1 out row st br sha
   out=$(nm_run runs --limit "$FM_CREW_STATE_RUNS_LIMIT")
   [ -n "$out" ] || return 0
   while IFS= read -r row; do
     row=$(trim "$row")
     [ -n "$row" ] || continue
-    st=${row%% *}
-    rest=${row#* }
-    rest=$(trim "$rest")
-    br=${rest%% *}
-    rest=${rest#* }
-    rest=$(trim "$rest")
-    sha=${rest%% *}
+    read -r st br sha _ <<< "$row"
     if [ "$br" = "$branch" ]; then
-      # Same code-identity rule as axi status: skip a same-branch row whose
-      # short-sha does not match this worktree (rewritten or advanced tip).
-      if ! nm_coarse_head_matches_worktree "$sha"; then
-        continue
+      # A truncated "<status> <branch>" row has no sha column: read leaves sha
+      # empty and a non-hex token is rejected, so a missing head is never taken
+      # as a live head.
+      case "$sha" in ''|*[!0-9a-fA-F]*) continue ;; esac
+      # Read-only attribution split (see nm_run_head_matches_worktree below and
+      # fm-teardown.sh): a resolvable head uses the STRICT shared code-identity
+      # rule (exact, or worktree HEAD is an ancestor of the run tip; a
+      # strict-ancestor/diverged head is skipped). An UNRESOLVABLE head - the
+      # live pipeline's tip advanced in the daemon's own repo, not fetched here -
+      # is attributed only for a live running/fixing row, because a terminal
+      # unresolvable row may be ambiguous daemon-only history from a reused
+      # branch. This leniency is safe only because this path merely READS state;
+      # it must never move to the shared owner, which fm-teardown.sh consumes to
+      # decide a destructive run abort.
+      if git -C "$WT" rev-parse --verify "${sha}^{commit}" >/dev/null 2>&1; then
+        fm_nm_head_matches_worktree "$WT" "$sha" || continue
+      else
+        case "$st" in running|fixing) ;; *) continue ;; esac
       fi
       printf '%s' "$st"
       return 0
@@ -366,19 +378,31 @@ nm_runs_status_for_branch() {  # <branch>
 CREW_BRANCH=$(git -C "$WT" symbolic-ref --quiet --short HEAD 2>/dev/null || true)
 
 # 0 if the active axi-status run's head field matches this worktree's code
-# identity. Branch match is a precondition (caller). Rule owned by
-# fm_nm_head_matches_worktree in bin/fm-nm-run-lib.sh.
+# identity. Branch match is a precondition (caller). The resolvable rule is owned
+# by the STRICT, fail-closed fm_nm_head_matches_worktree in bin/fm-nm-run-lib.sh.
+# This wrapper adds a read-only leniency ON TOP: a non-empty head that does not
+# resolve here is the live pipeline's tip advanced in the no-mistakes daemon's
+# own repo, and `axi status` already vouched this is the branch's
+# active-or-most-recent run, so attribute it - a live run must not read as failed
+# just because its advanced tip was never fetched into this worktree.
+#
+# The leniency lives HERE, not in the shared owner, on purpose. The two call
+# sites have opposite risk profiles: fm-crew-state.sh only READS and reports a
+# state, so a wrong attribution costs a wrong label; fm-teardown.sh feeds the
+# same shared predicate into a decision to ABORT a parked validation run, where a
+# wrong match destroys another task's work. Leniency that is right for a status
+# read is dangerous on that destructive path, so the shared owner stays strict
+# and this benign interpretation is local. Do NOT re-unify them by folding this
+# into fm_nm_head_matches_worktree - it would silently arm teardown.
 nm_run_head_matches_worktree() {
   local run_head
   run_head=$(strip_quotes "$(nm_field head)")
-  fm_nm_head_matches_worktree "$WT" "$run_head"
-}
-
-# Coarse runs-list rows are "<status> <branch> <short-sha> ...". 0 if the short
-# sha for this branch row matches the worktree head under the same rules as
-# nm_run_head_matches_worktree (equal, or local is ancestor of run tip).
-nm_coarse_head_matches_worktree() {  # <short-sha>
-  fm_nm_head_matches_worktree "$WT" "$1"
+  [ -n "$run_head" ] || return 1
+  fm_nm_head_matches_worktree "$WT" "$run_head" && return 0
+  # Not a resolvable match: attribute only when the head does not resolve here
+  # (advanced daemon-side tip); a resolvable-but-diverged head stays rejected.
+  git -C "$WT" rev-parse --verify "${run_head}^{commit}" >/dev/null 2>&1 && return 1
+  return 0
 }
 
 HAVE_RUN=0
@@ -430,7 +454,7 @@ if [ "$HAVE_RUN" = 1 ]; then
     # surfaced through signal_reason_is_actionable regardless of this
     # coarse-vs-full distinction, so a real gate is never silently missed.
     case "$COARSE_STATUS" in
-      running)   RUN_STATE=working; RUN_DETAIL="validating (background run)" ;;
+      running|fixing) RUN_STATE=working; RUN_DETAIL="validating (background run)" ;;
       completed) RUN_STATE="done";  RUN_DETAIL="run completed" ;;
       failed)    RUN_STATE=failed;  RUN_DETAIL="run failed" ;;
       cancelled) RUN_STATE=failed;  RUN_DETAIL="run cancelled" ;;

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -1074,6 +1074,12 @@ task_status_is_own_parked_run() {  # <worktree> <axi-status-output>
   run_branch=$(fm_nm_strip_quotes "$(fm_nm_field "$out" branch)")
   [ -n "$run_branch" ] && [ "$run_branch" = "$branch" ] || return 1
   run_head=$(fm_nm_strip_quotes "$(fm_nm_field "$out" head)")
+  # This is the DESTRUCTIVE call site of the shared code-identity rule: a match
+  # here authorizes aborting a parked run. It MUST stay strict/fail-closed - an
+  # unresolvable head is NOT treated as this task's run, so teardown never aborts
+  # another task's work on an advanced or reused-branch head. The lenient
+  # read-only interpretation (attribute an unresolvable advanced tip) lives only
+  # in bin/fm-crew-state.sh's status read; do not fold it into the shared owner.
   fm_nm_head_matches_worktree "$wt" "$run_head" || return 1
   outcome=$(fm_nm_strip_quotes "$(fm_nm_field "$out" outcome)")
   [ -z "$outcome" ] || return 1

--- a/tests/fm-crew-state.test.sh
+++ b/tests/fm-crew-state.test.sh
@@ -1309,6 +1309,167 @@ test_missing_run_head_falls_back_to_current_state() {
   pass "missing run head falls back instead of matching by branch"
 }
 
+# Regression: a live pipeline advances the run tip (rebase + fix commits) in the
+# no-mistakes daemon's OWN repo, so the run head never lands in this worktree's
+# object db. The newest same-branch runs-list row therefore names an
+# unresolvable sha. It must still be attributed to this crew (working), not
+# skipped in favour of an older, superseded row still on the pre-run worktree
+# sha - that fall-through mislabelled an actively-fixing run "failed" and, via a
+# crew_absorb_class=none verdict, fired a no-timer stale cascade.
+test_runs_list_advanced_unresolvable_tip_stays_working() {
+  reset_fakes
+  local d head_short absent_short out
+  d=$(new_case runs-advanced-unresolvable)
+  make_repo_on_branch "$d/wt" fm/feat-adv-tip
+  head_short=$(git -C "$d/wt" rev-parse --short=7 HEAD)
+  # Mint a real, well-formed sha in a throwaway repo to stand in for the
+  # daemon-side advanced tip that this worktree can never resolve.
+  git -C "$d" init -q other
+  git -C "$d/other" commit -q --allow-empty -m 'daemon-side pipeline fix commit'
+  absent_short=$(git -C "$d/other" rev-parse --short=7 HEAD)
+  git -C "$d/wt" rev-parse --verify "${absent_short}^{commit}" >/dev/null 2>&1 \
+    && fail "the advanced-tip sha must be unresolvable in the worktree for this case"
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/adv-tip.meta" "window=fm:fm-adv-tip" "worktree=$d/wt" "kind=ship"
+  # Force the runs-list fallback: the bare axi status answers another crew's branch.
+  FM_FAKE_AXI_STATUS="$(run_running fm/other-crew)"
+  # Newest row: the live run on the advanced (unresolvable) tip. Older row: a
+  # cancelled run still sitting on the pre-run worktree sha. The live row wins.
+  FM_FAKE_RUNS_LIST="$(cat <<EOF
+  running    fm/feat-adv-tip ${absent_short}  2026-07-02 22:10
+  cancelled  fm/feat-adv-tip ${head_short}  2026-07-02 20:00
+EOF
+)"
+  out=$(run_crew_state "$d" adv-tip)
+  assert_contains "$out" "state: working" "a live run on an advanced (unresolvable) tip stays working"
+  assert_contains "$out" "source: run-step" "the advanced-tip live run is attributed via run-step"
+  assert_not_contains "$out" "state: failed" "must not fall through to the older cancelled row"
+  pass "advanced (unresolvable) pipeline tip is attributed, not mislabelled failed"
+}
+
+test_runs_list_fixing_unresolvable_tip_stays_working() {
+  reset_fakes
+  local d absent_short out
+  d=$(new_case runs-fixing-unresolvable)
+  make_repo_on_branch "$d/wt" fm/feat-fixing
+  git -C "$d" init -q other
+  git -C "$d/other" commit -q --allow-empty -m 'daemon-side fixing commit'
+  absent_short=$(git -C "$d/other" rev-parse --short=7 HEAD)
+  git -C "$d/wt" rev-parse --verify "${absent_short}^{commit}" >/dev/null 2>&1 \
+    && fail "the fixing sha must be unresolvable in the worktree for this case"
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/fixing.meta" "window=fm:fm-fixing" "worktree=$d/wt" "kind=ship"
+  FM_FAKE_AXI_STATUS="$(run_running fm/other-crew)"
+  FM_FAKE_RUNS_LIST="$(cat <<EOF
+  fixing  fm/feat-fixing ${absent_short}  2026-07-02 22:10
+EOF
+)"
+  out=$(run_crew_state "$d" fixing)
+  assert_contains "$out" "state: working" "a fixing run on an unresolvable tip stays working"
+  assert_contains "$out" "source: run-step" "the fixing run is attributed via run-step"
+  assert_not_contains "$out" "state: unknown" "fixing must not map to unknown"
+  pass "unresolvable fixing pipeline tip is attributed as working"
+}
+
+test_runs_list_missing_head_row_skipped() {
+  reset_fakes
+  local d out
+  d=$(new_case runs-missing-head)
+  make_repo_on_branch "$d/wt" fm/feat-headless
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/headless.meta" "window=fm:fm-headless" "worktree=$d/wt" "kind=ship" "harness=claude"
+  printf 'working: current implementation in progress\n' > "$d/state/headless.status"
+  FM_FAKE_AXI_STATUS="$(run_running fm/other-crew)"
+  FM_FAKE_RUNS_LIST='  running  fm/feat-headless'
+  FM_FAKE_BUSY=0
+  arm_idle_record "$d/state" headless
+  out=$(run_crew_state "$d" headless)
+  assert_not_contains "$out" "source: run-step" "a runs-list row without a head must not be attributed"
+  assert_contains "$out" "source: status-log" "a headless row falls back to current state"
+  assert_contains "$out" "state: working" "the current working status remains authoritative"
+  pass "runs walk skips a row with no head"
+}
+
+# A terminal runs-list row on an unresolvable daemon-only tip may be historical
+# state from a reused branch. Unlike an active row, it has no signal proving the
+# tip belongs to the current crew, so it must not override current-state sources.
+test_runs_list_terminal_unresolvable_row_skipped() {
+  reset_fakes
+  local d absent_short out
+  d=$(new_case runs-terminal-unresolvable)
+  make_repo_on_branch "$d/wt" fm/feat-historical
+  git -C "$d" init -q other
+  git -C "$d/other" commit -q --allow-empty -m 'historical daemon-side tip'
+  absent_short=$(git -C "$d/other" rev-parse --short=7 HEAD)
+  git -C "$d/wt" rev-parse --verify "${absent_short}^{commit}" >/dev/null 2>&1 \
+    && fail "the historical terminal sha must be unresolvable in the worktree for this case"
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/historical.meta" "window=fm:fm-historical" "worktree=$d/wt" "kind=ship" "harness=claude"
+  printf 'working: current implementation in progress\n' > "$d/state/historical.status"
+  FM_FAKE_AXI_STATUS="$(run_running fm/other-crew)"
+  FM_FAKE_RUNS_LIST="$(cat <<EOF
+  cancelled  fm/feat-historical ${absent_short}  2026-07-02 20:00
+EOF
+)"
+  FM_FAKE_BUSY=0
+  arm_idle_record "$d/state" historical
+  out=$(run_crew_state "$d" historical)
+  assert_not_contains "$out" "source: run-step" "an unresolvable terminal row must not be attributed"
+  assert_not_contains "$out" "state: failed" "an ambiguous historical cancellation must not read failed"
+  assert_contains "$out" "source: status-log" "falls back to current state after skipping terminal history"
+  assert_contains "$out" "state: working" "the current working status remains authoritative"
+  pass "runs walk skips an unresolvable terminal row"
+}
+
+# The advanced-tip attribution must NOT mask a genuinely superseded run: when the
+# worktree HEAD has advanced past the run head (the run's sha is a strict
+# ancestor of HEAD - local work outside the run), that resolvable row is still
+# skipped, and the crew falls back to its current-state sources.
+test_runs_list_superseded_ancestor_row_skipped() {
+  reset_fakes
+  local d anc_short out
+  d=$(new_case runs-superseded-ancestor)
+  make_repo_on_branch "$d/wt" fm/feat-sup
+  anc_short=$(git -C "$d/wt" rev-parse --short=7 HEAD)
+  git -C "$d/wt" commit -q --allow-empty -m 'local work advanced past the run head'
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/sup.meta" "window=fm:fm-sup" "worktree=$d/wt" "kind=ship" "harness=claude"
+  printf 'working: stage 2 implementation in progress\n' > "$d/state/sup.status"
+  FM_FAKE_AXI_STATUS="$(run_running fm/other-crew)"
+  FM_FAKE_RUNS_LIST="$(cat <<EOF
+  cancelled  fm/feat-sup ${anc_short}  2026-07-02 20:00
+EOF
+)"
+  FM_FAKE_BUSY=0
+  arm_idle_record "$d/state" sup
+  out=$(run_crew_state "$d" sup)
+  assert_not_contains "$out" "source: run-step" "a strict-ancestor superseded row must not be attributed"
+  assert_not_contains "$out" "state: failed" "a superseded cancelled row must not read failed"
+  assert_contains "$out" "source: status-log" "falls back to current state after skipping the superseded row"
+  pass "runs walk skips a strict-ancestor superseded row"
+}
+
+# The fix must not mask a real terminal state: a genuinely cancelled current run
+# (its sha matches the worktree HEAD) still reports failed.
+test_runs_list_current_cancelled_run_reported_failed() {
+  reset_fakes
+  local d head_short out
+  d=$(new_case runs-current-cancelled)
+  make_repo_on_branch "$d/wt" fm/feat-cancel
+  head_short=$(git -C "$d/wt" rev-parse --short=7 HEAD)
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/cancel.meta" "window=fm:fm-cancel" "worktree=$d/wt" "kind=ship"
+  FM_FAKE_AXI_STATUS="$(run_running fm/other-crew)"
+  FM_FAKE_RUNS_LIST="$(cat <<EOF
+  cancelled  fm/feat-cancel ${head_short}  2026-07-02 22:10
+EOF
+)"
+  out=$(run_crew_state "$d" cancel)
+  assert_contains "$out" "state: failed" "a genuinely cancelled current run reports failed"
+  assert_contains "$out" "source: run-step" "the cancelled current run is attributed via run-step"
+  pass "runs walk reports a genuinely cancelled current run as failed"
+}
+
 test_active_run_is_authoritative
 test_stale_needs_decision_superseded
 test_stale_blocked_superseded
@@ -1331,6 +1492,12 @@ test_terminal_passed
 test_terminal_failed
 test_cross_branch_attribution_via_runs_list
 test_cross_branch_attribution_picks_most_recent_row
+test_runs_list_advanced_unresolvable_tip_stays_working
+test_runs_list_fixing_unresolvable_tip_stays_working
+test_runs_list_missing_head_row_skipped
+test_runs_list_terminal_unresolvable_row_skipped
+test_runs_list_superseded_ancestor_row_skipped
+test_runs_list_current_cancelled_run_reported_failed
 test_coarse_run_does_not_probe_other_branch_ci_log_for_ready_status
 test_other_branch_run_ignored
 test_no_run_busy_pane


### PR DESCRIPTION
## Intent

Fix bin/fm-crew-state.sh so it stops reporting a live, actively-fixing no-mistakes run as 'failed'. nm_runs_status_for_branch walks the no-mistakes runs rows for the crew's branch and gates each same-branch row on a head/worktree code-identity check. Root cause: a running pipeline advances the branch tip (rebase + fix commits) in the no-mistakes daemon's OWN repo, so the run head named by the runs list no longer resolves in the crew's worktree; both head-match predicates did 'git rev-parse --verify <head> || return 1', treating an unresolvable head as 'not this crew', so the live running row was skipped and the walk fell through to an older, superseded row still sitting on the pre-run worktree sha (e.g. a cancelled row) and reported it - mislabelling an actively-fixing run 'failed'. Because a failed verdict carries no absorb class, this also fired a no-timer stale cascade of false wakes (related to issue #1598); reproduced identically on herdr/tmux/zellij. Fix: treat a non-empty but unresolvable run head as a MATCH - since the branch already matched and the runs list is newest-first, an unresolvable head is the live pipeline's advanced tip, so it is attributed rather than skipped to an older row. The two byte-identical predicates (nm_run_head_matches_worktree, the old nm_coarse_head_matches_worktree) are deliberately unified into a single owner nm_head_matches_worktree so the rule cannot drift, with nm_run_head_matches_worktree reduced to a thin delegating wrapper - this is an intentional refactor, not accidental duplication removal. Preserved behaviours (must not regress): an empty/missing head still rejects; a resolvable run head that is a strict ancestor of the worktree HEAD (local work advanced past the run) or diverged/rewritten is still skipped (a rewritten old tip stays a dangling-but-resolvable object, so it is still caught as diverged); and a genuinely cancelled/failed CURRENT run still reports its terminal state. Added three colocated regression tests in tests/fm-crew-state.test.sh: an advanced-tip live run on an unresolvable sha (attributed working, verified to fail against the unpatched code), a strict-ancestor superseded row (skipped), and a genuinely cancelled current run (reported failed). This is firstmate's own shared tracked material; changes are backend-agnostic git plumbing (rev-parse/merge-base), which is why the bug reproduced identically across backends.

## What Changed

- Attribute same-branch `running` and `fixing` runs with daemon-side tips that cannot resolve in the crew worktree, preventing stale failed or cancelled rows from overriding live state.
- Unify run-head matching while rejecting missing heads, ambiguous terminal history, superseded ancestors, and rewritten or diverged runs.
- Add regression coverage for advanced and fixing tips, malformed and historical rows, superseded runs, and current cancellations.

## Risk Assessment

✅ Low: Captain, the change is well-bounded, addresses both prior findings, preserves the required attribution invariants, and adds focused regression coverage for each edge case.

## Testing

Diff inspection, the focused fm-crew-state behavior suite, and end-to-end CLI scenarios all passed: an actively fixing advanced tip reports working and is absorbed, while superseded and genuinely cancelled runs retain their intended behavior.

<details>
<summary>Evidence: End-to-end fm-crew-state CLI transcript</summary>

<code>Live advanced tip: working, watcher wake absorbed.&#10;Superseded cancellation: current status remains working.&#10;Current cancellation: failed.</code>

```text
CASE: live run with daemon-only advanced tip, followed by older cancellation
state: working · source: run-step · validating (background run)
watcher classification: provably working, routine wake absorbed

CASE: cancelled row is a strict ancestor of current worktree HEAD
state: working · source: status-log · current implementation in progress

CASE: genuinely cancelled row matches current worktree HEAD
state: failed · source: run-step · run cancelled
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed (2) ✅</summary>

- 🚨 `bin/fm-crew-state.sh:416` - The required criterion says a rewritten run must still be skipped, but `rev-parse ... || return 0` attributes every unresolvable head. A historical run whose tip was created only in the daemon repository can also be unresolvable after its branch is reused, so its stale cancelled or failed row can again override the crew&#39;s current state. Please distinguish a live advanced tip from an unresolvable historical tip rather than assuming every resolution failure is live.

🔧 Fix: Captain: skip ambiguous terminal runs-list history
2 errors still open:
- 🚨 `bin/fm-crew-state.sh:483` - The refinement explicitly accepts `fixing` as a live runs-list status, but the coarse-state mapping handles only `running`; an unresolvable `fixing` row is therefore attributed as `state: unknown` instead of the required working state. Map `fixing` alongside `running` and cover that path.
- 🚨 `bin/fm-crew-state.sh:371` - The required criterion says an empty or missing head must reject, but for a truncated row such as `running fm/branch`, `${rest#* }` leaves the branch text unchanged and assigns it to `sha`; the non-empty guard passes, resolution fails, and the row is attributed as live. Parse or validate the SHA field so a missing third column is rejected.

🔧 Fix: Captain: validate coarse run heads and fixing state
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>Inspected `git diff c8edff36b8466ea0fe547d3abf4b8aa330489986..cd1be957bc2f5caaf081ac35788ec8a2c624820a -- bin/fm-crew-state.sh tests/fm-crew-state.test.sh`.</code>
- <code>Ran `bash tests/fm-crew-state.test.sh`.</code>
- <code>Manually invoked `bin/fm-crew-state.sh` with realistic git repositories and no-mistakes output for an unresolvable live tip, a superseded ancestor row, and a current cancelled row.</code>
- <code>Called `crew_is_provably_working` against the live advanced-tip scenario to verify the routine watcher wake is absorbed.</code>
- <code>Ran `git status --short` after testing to confirm no transient worktree artifacts remained.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
