### PR TITLE
fix(herdr): read an idle claude composer as empty instead of unknown

### DIFF
--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -2622,7 +2622,15 @@ fm_backend_herdr_capture_ansi() {  # <target> <lines>
 fm_backend_herdr_agent_identity_raw() {  # <session> <pane> -> <agent>\t<status>
   local out
   out=$(fm_backend_herdr_cli "$1" agent get "$2" 2>/dev/null) || return 1
-  printf '%s' "$out" | jq -r '[.result.agent.agent // "", .result.agent.agent_status // ""] | @tsv' 2>/dev/null
+  printf '%s' "$out" | jq -er '
+    .result.agent as $identity
+    | select(($identity | type) == "object")
+    | select(($identity.agent | type) == "string")
+    | select(($identity.agent_status | type) == "string")
+    | select(($identity.agent | length) > 0 and ($identity.agent_status | length) > 0)
+    | [$identity.agent, $identity.agent_status]
+    | @tsv
+  ' 2>/dev/null
 }
 
 # fm_backend_herdr_composer_identity: the native agent identity/state probe

--- a/bin/fm-composer-lib.sh
+++ b/bin/fm-composer-lib.sh
@@ -1062,6 +1062,7 @@ _fm_composer_select_cursorless() {
     FM_COMPOSER_SELECTED_KIND=inline
     FM_COMPOSER_SELECTED_FIRST=$FM_COMPOSER_SCAN_INLINE_ROW
     FM_COMPOSER_SELECTED_LAST=$FM_COMPOSER_SCAN_INLINE_ROW
+    FM_COMPOSER_SELECTED_AMBIG=0
   fi
   if [ "$FM_COMPOSER_SCAN_INCOMPLETE_BOX_FROM" -gt "$generic" ]; then
     FM_COMPOSER_SELECTED_KIND=
@@ -1076,16 +1077,16 @@ _fm_composer_select_cursorless() {
     FM_COMPOSER_SELECTED_LAST=$((FM_COMPOSER_SCAN_PI_CLOSE - 1))
   fi
   if [ "$FM_COMPOSER_SCAN_PI_PAIR_FOUND" = 0 ] \
-     && [ "$FM_COMPOSER_SCAN_PI_LAST_SEPARATOR" -gt "$generic" ] \
-     && [ "$FM_COMPOSER_SELECTED_KIND" != bare ]; then
+     && [ "$FM_COMPOSER_SCAN_PI_LAST_SEPARATOR" -gt "$generic" ]; then
     if [ "${FM_COMPOSER_CAP_IDENTITY:-0}" = 1 ] && [ "$generic" -ge 0 ]; then
-      # Claude frames its positively identified bare agent glyph with a
-      # labelled upper rule and a bare lower rule. Pi uses the lower rule as a
-      # separator, so defer only candidates that lack that agent-glyph proof
-      # to native identity instead of rejecting Claude's idle composer.
-
+      # Claude frames its idle composer with a labelled upper rule and a bare
+      # lower rule. Pi uses that same lower rule as a separator whose opening
+      # rule can sit above the capture window, so defer this one ambiguity to
+      # native identity rather than rejecting Claude outright.
       FM_COMPOSER_NEEDS_LONE_RULE_IDENTITY=1
-    else
+    elif [ "$FM_COMPOSER_SELECTED_KIND" != bare ]; then
+      # With no identity probe available the bare agent glyph is its own
+      # container proof, the same rule the pi-pair overlap already applies.
       FM_COMPOSER_SELECTED_KIND=
       return 1
     fi
@@ -1319,12 +1320,8 @@ EOF
     pi)
       _fm_composer_pi_verdict "$screen" "$styled" "$has_identity" "$identity"
       ;;
-    box)
+    box|inline)
       _fm_composer_classify_rows "$screen" "$styled" "$FM_COMPOSER_SELECTED_AMBIG" \
-        "$FM_COMPOSER_SELECTED_FIRST" "$FM_COMPOSER_SELECTED_LAST"
-      ;;
-    inline)
-      _fm_composer_classify_rows "$screen" "$styled" 0 \
         "$FM_COMPOSER_SELECTED_FIRST" "$FM_COMPOSER_SELECTED_LAST"
       ;;
     bare)

--- a/bin/fm-composer-lib.sh
+++ b/bin/fm-composer-lib.sh
@@ -601,6 +601,7 @@ _fm_composer_scan_screen() {  # <plain-screen> <cursor-or-empty> [extract-wrap]
   FM_COMPOSER_SCAN_UNSAFE=0
   FM_COMPOSER_SCAN_CURSOR_EDGE=0
   FM_COMPOSER_SCAN_BARE_ROW=-1
+  FM_COMPOSER_SCAN_INLINE_ROW=-1
   FM_COMPOSER_SCAN_SHELL_ROW=-1
   FM_COMPOSER_SCAN_LEFTBAR_START=-1
   FM_COMPOSER_SCAN_LEFTBAR_END=-1
@@ -660,6 +661,13 @@ _fm_composer_scan_screen() {  # <plain-screen> <cursor-or-empty> [extract-wrap]
         FM_COMPOSER_SCAN_LEFTBAR_END=$row
         ;;
       *) leftbar_start=-1 ;;
+    esac
+    # A one-row side-bordered composer is a valid compact container used by
+    # Herdr's deterministic supervisor fixture and by bordered TUI panes that
+    # have no visible top or bottom rule. Keep it separate from complete-box
+    # geometry so the latter remains the stronger structural proof.
+    case "$trimmed" in
+      '│'*'│'|'┃'*'┃'|'║'*'║'|'|'*'|') FM_COMPOSER_SCAN_INLINE_ROW=$row ;;
     esac
     # Bare agent-glyph rows: the glyph itself is the container proof. Bare
     # shell glyphs are deliberately not candidates (dead-shell rule). Keep
@@ -1049,6 +1057,12 @@ _fm_composer_select_cursorless() {
     FM_COMPOSER_SELECTED_FIRST=$FM_COMPOSER_SCAN_LEFTBAR_START
     FM_COMPOSER_SELECTED_LAST=$FM_COMPOSER_SCAN_LEFTBAR_END
   fi
+  if [ "$FM_COMPOSER_SCAN_INLINE_ROW" -gt "$generic" ]; then
+    generic=$FM_COMPOSER_SCAN_INLINE_ROW
+    FM_COMPOSER_SELECTED_KIND=inline
+    FM_COMPOSER_SELECTED_FIRST=$FM_COMPOSER_SCAN_INLINE_ROW
+    FM_COMPOSER_SELECTED_LAST=$FM_COMPOSER_SCAN_INLINE_ROW
+  fi
   if [ "$FM_COMPOSER_SCAN_INCOMPLETE_BOX_FROM" -gt "$generic" ]; then
     FM_COMPOSER_SELECTED_KIND=
     return 1
@@ -1093,7 +1107,8 @@ _fm_composer_select_cursorless() {
     done
   fi
   if [ "$FM_COMPOSER_SELECTED_KIND" = box ] \
-     || [ "$FM_COMPOSER_SELECTED_KIND" = leftbar ]; then
+     || [ "$FM_COMPOSER_SELECTED_KIND" = leftbar ] \
+     || [ "$FM_COMPOSER_SELECTED_KIND" = inline ]; then
     boundary=$FM_COMPOSER_SELECTED_LAST
     if [ "$FM_COMPOSER_SELECTED_KIND" = box ]; then
       boundary=$FM_COMPOSER_SCAN_BOX_BOTTOM
@@ -1154,7 +1169,7 @@ EOF
           leading_blank=0
         fi
         ;;
-      box)
+      box|inline)
         if [ "$prompt_row" -lt 0 ] \
            && fm_composer_leading_prompt_glyph_var glyph "$content"; then
           prompt_row=$row
@@ -1230,6 +1245,12 @@ EOF
         "$FM_COMPOSER_SCAN_LEFTBAR_START" "$FM_COMPOSER_SCAN_LEFTBAR_END"
       return 0
     fi
+    if [ "$FM_COMPOSER_SCAN_INLINE_ROW" -ge 0 ] \
+       && [ "$cy" -eq "$FM_COMPOSER_SCAN_INLINE_ROW" ]; then
+      _fm_composer_classify_rows "$screen" "$styled" 0 \
+        "$FM_COMPOSER_SCAN_INLINE_ROW" "$FM_COMPOSER_SCAN_INLINE_ROW"
+      return 0
+    fi
     if [ "$FM_COMPOSER_SCAN_BARE_ROW" -ge 0 ] && [ "$cy" -eq "$FM_COMPOSER_SCAN_BARE_ROW" ]; then
       if [ "$FM_COMPOSER_SCAN_PI_PAIR_FOUND" = 1 ] \
          && [ "$cy" -gt "$FM_COMPOSER_SCAN_PI_OPEN" ] \
@@ -1300,6 +1321,10 @@ EOF
       ;;
     box)
       _fm_composer_classify_rows "$screen" "$styled" "$FM_COMPOSER_SELECTED_AMBIG" \
+        "$FM_COMPOSER_SELECTED_FIRST" "$FM_COMPOSER_SELECTED_LAST"
+      ;;
+    inline)
+      _fm_composer_classify_rows "$screen" "$styled" 0 \
         "$FM_COMPOSER_SELECTED_FIRST" "$FM_COMPOSER_SELECTED_LAST"
       ;;
     bare)

--- a/bin/fm-composer-lib.sh
+++ b/bin/fm-composer-lib.sh
@@ -1062,11 +1062,14 @@ _fm_composer_select_cursorless() {
     FM_COMPOSER_SELECTED_LAST=$((FM_COMPOSER_SCAN_PI_CLOSE - 1))
   fi
   if [ "$FM_COMPOSER_SCAN_PI_PAIR_FOUND" = 0 ] \
-     && [ "$FM_COMPOSER_SCAN_PI_LAST_SEPARATOR" -gt "$generic" ]; then
+     && [ "$FM_COMPOSER_SCAN_PI_LAST_SEPARATOR" -gt "$generic" ] \
+     && [ "$FM_COMPOSER_SELECTED_KIND" != bare ]; then
     if [ "${FM_COMPOSER_CAP_IDENTITY:-0}" = 1 ] && [ "$generic" -ge 0 ]; then
-      # Herdr can draw a Claude composer below a labelled upper rule and a
-      # bare lower rule. Pi uses the same lower rule as a separator, so defer
-      # this one ambiguity to native identity rather than rejecting Claude.
+      # Claude frames its positively identified bare agent glyph with a
+      # labelled upper rule and a bare lower rule. Pi uses the lower rule as a
+      # separator, so defer only candidates that lack that agent-glyph proof
+      # to native identity instead of rejecting Claude's idle composer.
+
       FM_COMPOSER_NEEDS_LONE_RULE_IDENTITY=1
     else
       FM_COMPOSER_SELECTED_KIND=

--- a/bin/fm-composer-lib.sh
+++ b/bin/fm-composer-lib.sh
@@ -1029,6 +1029,7 @@ _fm_composer_select_cursorless() {
   FM_COMPOSER_SELECTED_FIRST=-1
   FM_COMPOSER_SELECTED_LAST=-1
   FM_COMPOSER_SELECTED_AMBIG=0
+  FM_COMPOSER_NEEDS_LONE_RULE_IDENTITY=0
   if [ "$FM_COMPOSER_SCAN_BOX_BOTTOM" -ge 0 ]; then
     generic=$FM_COMPOSER_SCAN_BOX_BOTTOM
     FM_COMPOSER_SELECTED_KIND=box
@@ -1062,8 +1063,15 @@ _fm_composer_select_cursorless() {
   fi
   if [ "$FM_COMPOSER_SCAN_PI_PAIR_FOUND" = 0 ] \
      && [ "$FM_COMPOSER_SCAN_PI_LAST_SEPARATOR" -gt "$generic" ]; then
-    FM_COMPOSER_SELECTED_KIND=
-    return 1
+    if [ "${FM_COMPOSER_CAP_IDENTITY:-0}" = 1 ] && [ "$generic" -ge 0 ]; then
+      # Herdr can draw a Claude composer below a labelled upper rule and a
+      # bare lower rule. Pi uses the same lower rule as a separator, so defer
+      # this one ambiguity to native identity rather than rejecting Claude.
+      FM_COMPOSER_NEEDS_LONE_RULE_IDENTITY=1
+    else
+      FM_COMPOSER_SELECTED_KIND=
+      return 1
+    fi
   fi
   if [ "$FM_COMPOSER_SCAN_SHELL_ROW" -gt "$generic" ]; then
     FM_COMPOSER_SELECTED_KIND=
@@ -1186,11 +1194,12 @@ EOF
 fm_composer_classify_screen() {  # <caps> <screen> [cursor_row] [identity]
   local caps=$1 screen=$2 cy=${3:-} identity=${4:-}
   local styled=0 cursor=0 has_identity=0 kv plain
+  FM_COMPOSER_CAP_IDENTITY=0
   while IFS= read -r kv; do
     case "$kv" in
       styled=1) styled=1 ;;
       cursor=1) cursor=1 ;;
-      identity=1) has_identity=1 ;;
+      identity=1) has_identity=1; FM_COMPOSER_CAP_IDENTITY=1 ;;
     esac
   done <<EOF
 $caps
@@ -1261,6 +1270,26 @@ EOF
   if ! _fm_composer_select_cursorless "$plain"; then
     printf 'unknown'
     return 0
+  fi
+  if [ "$FM_COMPOSER_NEEDS_LONE_RULE_IDENTITY" = 1 ]; then
+    local lone_agent
+    if [ "$has_identity" != 1 ]; then
+      printf 'unknown'
+      return 0
+    fi
+    if [ -z "$identity" ]; then
+      printf 'need-identity'
+      return 0
+    fi
+    if [ "$identity" = probe-absent ]; then
+      printf 'unknown'
+      return 0
+    fi
+    lone_agent=${identity%%$'\t'*}
+    if [ "$lone_agent" = pi ]; then
+      printf 'unknown'
+      return 0
+    fi
   fi
   case "$FM_COMPOSER_SELECTED_KIND" in
     pi)

--- a/bin/fm-composer-lib.sh
+++ b/bin/fm-composer-lib.sh
@@ -601,7 +601,6 @@ _fm_composer_scan_screen() {  # <plain-screen> <cursor-or-empty> [extract-wrap]
   FM_COMPOSER_SCAN_UNSAFE=0
   FM_COMPOSER_SCAN_CURSOR_EDGE=0
   FM_COMPOSER_SCAN_BARE_ROW=-1
-  FM_COMPOSER_SCAN_INLINE_ROW=-1
   FM_COMPOSER_SCAN_SHELL_ROW=-1
   FM_COMPOSER_SCAN_LEFTBAR_START=-1
   FM_COMPOSER_SCAN_LEFTBAR_END=-1
@@ -661,13 +660,6 @@ _fm_composer_scan_screen() {  # <plain-screen> <cursor-or-empty> [extract-wrap]
         FM_COMPOSER_SCAN_LEFTBAR_END=$row
         ;;
       *) leftbar_start=-1 ;;
-    esac
-    # A one-row side-bordered composer is a valid compact container used by
-    # Herdr's deterministic supervisor fixture and by bordered TUI panes that
-    # have no visible top or bottom rule. Keep it separate from complete-box
-    # geometry so the latter remains the stronger structural proof.
-    case "$trimmed" in
-      '│'*'│'|'┃'*'┃'|'║'*'║'|'|'*'|') FM_COMPOSER_SCAN_INLINE_ROW=$row ;;
     esac
     # Bare agent-glyph rows: the glyph itself is the container proof. Bare
     # shell glyphs are deliberately not candidates (dead-shell rule). Keep
@@ -1057,13 +1049,6 @@ _fm_composer_select_cursorless() {
     FM_COMPOSER_SELECTED_FIRST=$FM_COMPOSER_SCAN_LEFTBAR_START
     FM_COMPOSER_SELECTED_LAST=$FM_COMPOSER_SCAN_LEFTBAR_END
   fi
-  if [ "$FM_COMPOSER_SCAN_INLINE_ROW" -gt "$generic" ]; then
-    generic=$FM_COMPOSER_SCAN_INLINE_ROW
-    FM_COMPOSER_SELECTED_KIND=inline
-    FM_COMPOSER_SELECTED_FIRST=$FM_COMPOSER_SCAN_INLINE_ROW
-    FM_COMPOSER_SELECTED_LAST=$FM_COMPOSER_SCAN_INLINE_ROW
-    FM_COMPOSER_SELECTED_AMBIG=0
-  fi
   if [ "$FM_COMPOSER_SCAN_INCOMPLETE_BOX_FROM" -gt "$generic" ]; then
     FM_COMPOSER_SELECTED_KIND=
     return 1
@@ -1108,8 +1093,7 @@ _fm_composer_select_cursorless() {
     done
   fi
   if [ "$FM_COMPOSER_SELECTED_KIND" = box ] \
-     || [ "$FM_COMPOSER_SELECTED_KIND" = leftbar ] \
-     || [ "$FM_COMPOSER_SELECTED_KIND" = inline ]; then
+     || [ "$FM_COMPOSER_SELECTED_KIND" = leftbar ]; then
     boundary=$FM_COMPOSER_SELECTED_LAST
     if [ "$FM_COMPOSER_SELECTED_KIND" = box ]; then
       boundary=$FM_COMPOSER_SCAN_BOX_BOTTOM
@@ -1170,7 +1154,7 @@ EOF
           leading_blank=0
         fi
         ;;
-      box|inline)
+      box)
         if [ "$prompt_row" -lt 0 ] \
            && fm_composer_leading_prompt_glyph_var glyph "$content"; then
           prompt_row=$row
@@ -1246,12 +1230,6 @@ EOF
         "$FM_COMPOSER_SCAN_LEFTBAR_START" "$FM_COMPOSER_SCAN_LEFTBAR_END"
       return 0
     fi
-    if [ "$FM_COMPOSER_SCAN_INLINE_ROW" -ge 0 ] \
-       && [ "$cy" -eq "$FM_COMPOSER_SCAN_INLINE_ROW" ]; then
-      _fm_composer_classify_rows "$screen" "$styled" 0 \
-        "$FM_COMPOSER_SCAN_INLINE_ROW" "$FM_COMPOSER_SCAN_INLINE_ROW"
-      return 0
-    fi
     if [ "$FM_COMPOSER_SCAN_BARE_ROW" -ge 0 ] && [ "$cy" -eq "$FM_COMPOSER_SCAN_BARE_ROW" ]; then
       if [ "$FM_COMPOSER_SCAN_PI_PAIR_FOUND" = 1 ] \
          && [ "$cy" -gt "$FM_COMPOSER_SCAN_PI_OPEN" ] \
@@ -1297,7 +1275,7 @@ EOF
     return 0
   fi
   if [ "$FM_COMPOSER_NEEDS_LONE_RULE_IDENTITY" = 1 ]; then
-    local lone_agent
+    local lone_agent lone_status
     if [ "$has_identity" != 1 ]; then
       printf 'unknown'
       return 0
@@ -1306,11 +1284,23 @@ EOF
       printf 'need-identity'
       return 0
     fi
-    if [ "$identity" = probe-absent ]; then
+    case "$identity" in
+      probe-absent|*$'\n'*|*$'\r'*|*$'\t'*$'\t'*)
+        printf 'unknown'
+        return 0
+        ;;
+      *$'\t'*) ;;
+      *)
+        printf 'unknown'
+        return 0
+        ;;
+    esac
+    lone_agent=${identity%%$'\t'*}
+    lone_status=${identity#*$'\t'}
+    if [ -z "$lone_agent" ] || [ -z "$lone_status" ]; then
       printf 'unknown'
       return 0
     fi
-    lone_agent=${identity%%$'\t'*}
     if [ "$lone_agent" = pi ]; then
       printf 'unknown'
       return 0
@@ -1320,7 +1310,7 @@ EOF
     pi)
       _fm_composer_pi_verdict "$screen" "$styled" "$has_identity" "$identity"
       ;;
-    box|inline)
+    box)
       _fm_composer_classify_rows "$screen" "$styled" "$FM_COMPOSER_SELECTED_AMBIG" \
         "$FM_COMPOSER_SELECTED_FIRST" "$FM_COMPOSER_SELECTED_LAST"
       ;;

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -235,8 +235,10 @@ A human-blocked permission dialog has no busy banner and still surfaces.
 
 Herdr has no direct cursor-row primitive.
 The adapter is a thin capture: it hands a bounded ANSI tail plus Herdr's capability facts to the fleet-wide classifier in `bin/fm-composer-lib.sh`, which owns every shape - bordered boxes, bare agent-glyph rows (including muse's `⟩`, which the adapter's retired local pattern silently omitted), opencode's left bar, and the Pi separator region this adapter pioneered, admitted only when native `agent get` identity is exactly Pi and state is idle, done, or blocked.
-A working Pi, pending middle row, missing identity, incomplete separator pair, or over-tall candidate remains unknown or pending.
-Identity stays a lazy second read, consulted only when a separator pair could change the verdict.
+A working Pi, pending middle row, missing identity, or over-tall candidate remains unknown or pending.
+An incomplete separator pair - a trailing rule whose opening rule is not in the capture - is claude's own composer frame as often as it is a scrolled-out Pi pair, so it does not reject the pane on its own.
+With no recognized composer shape above that rule the verdict is unknown; otherwise the shape keeps its own verdict when native identity names a non-Pi agent, and a Pi, unreadable, or malformed identity holds it at unknown.
+Identity stays a lazy second read, consulted only when a separator pair or that lone trailing rule could change the verdict.
 
 ANSI capture preserves de-emphasized placeholder style.
 `bin/fm-composer-lib.sh` is the fleet-wide owner that strips dim or faint runs and dark truecolor placeholders while retaining bright typed input.

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -528,6 +528,13 @@ Real captures verified these active distinctions:
 - Grok dark truecolor placeholders are ghost content, while bright truecolor typed input remains pending.
 - A bare shell prompt has no safe agent-composer container and is unknown.
 
+Two further per-harness distinctions were verified on 2026-08-04 from real captures of a live idle Claude pane on Herdr:
+
+- An idle Claude composer renders as the bare agent glyph followed by U+00A0 NO-BREAK SPACE, which is not in `[[:space:]]` in any glibc locale, so the shared classifier normalizes it and reads empty instead of pending.
+- A lone trailing separator rule no longer invalidates a recognized composer row on its own, because it is now gated on Herdr's native pane identity, so only a Pi pane's separator invalidates a match and an unreadable identity still yields unknown.
+
+Scenario E of `tests/fm-afk-inject-herdr-e2e.test.sh` is the real-Herdr regression for both, driving a fixture that draws Claude's rule-framed, NBSP-padded composer.
+
 `tests/fm-composer-ghost.test.sh`, `tests/fm-composer-lib.test.sh`, and the Herdr composer cases pin the exact captured ANSI bytes.
 The U+2063 operational and routed-request separators were exercised through a real Pi-on-Herdr path; the byte-exact active regression is:
 

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -531,7 +531,7 @@ Real captures verified these active distinctions:
 Two further per-harness distinctions were verified on 2026-08-04 from real captures of a live idle Claude pane on Herdr:
 
 - An idle Claude composer renders as the bare agent glyph followed by U+00A0 NO-BREAK SPACE, which is not in `[[:space:]]` in any glibc locale, so the shared classifier normalizes it and reads empty instead of pending.
-- A lone trailing separator rule no longer invalidates a recognized composer row on its own, because it is now gated on Herdr's native pane identity, so only a Pi pane's separator invalidates a match and an unreadable identity still yields unknown.
+- A lone trailing separator rule no longer invalidates a recognized composer row on its own. On Herdr the verdict is gated on the native pane identity, so only a Pi pane's separator invalidates a match and an unreadable identity still yields unknown. On backends with no identity probe the bare agent glyph remains the container proof and every other candidate shape stays unknown.
 
 Scenario E of `tests/fm-afk-inject-herdr-e2e.test.sh` is the real-Herdr regression for both, driving a fixture that draws Claude's rule-framed, NBSP-padded composer.
 

--- a/tests/fm-afk-inject-herdr-e2e.test.sh
+++ b/tests/fm-afk-inject-herdr-e2e.test.sh
@@ -131,13 +131,12 @@ read -r _FAKE_TAB_ID FAKE_CREW_PANE_ID <<EOF
 $FAKE_CREW_IDS
 EOF
 
-# --- deterministic bare-composer loop, drawn in the scratch pane -------------
-# Mirrors tests/fm-afk-inject-e2e.test.sh's supervisor-loop.sh, but draws the
-# shared classifier's positively identified bare-agent shape (`❯ <buf>`). This
-# remains readable under the strict blank-row posture without pretending that
-# one side-bordered row is a complete composer box. ALSO registers itself as a
-# real herdr agent via `herdr pane report-agent` and reports idle/working
-# transitions around each
+# --- deterministic bordered-composer loop, drawn in the scratch pane ---------
+# Mirrors tests/fm-afk-inject-e2e.test.sh's supervisor-loop.sh, but draws a
+# "│ > <buf> │" border so the bordered branch of
+# fm_backend_herdr_composer_state recognizes it, exactly like a bordered-TUI
+# harness composer. ALSO registers itself as a real herdr agent via `herdr
+# pane report-agent` and reports idle/working transitions around each
 # submission: fm_backend_herdr_send_text_submit's confirmation is now native
 # agent-state (agent get), not composer content (docs/herdr-backend.md
 # "Native agent-state submit confirmation"), so a synthetic pane that only
@@ -151,11 +150,21 @@ EOF
 # documented integration-protocol primitive for a non-built-in-harness process
 # to report its own agent state, verified empirically against real herdr 0.7.1
 # in an isolated session.
+#
+# The loop takes an optional SHAPE argument. `bordered` (the default) is the
+# box-composer fixture described above. `claude` redraws the shape real claude
+# presents through herdr: a labelled upper rule, a bare `❯` prompt padded with
+# U+00A0, a bare lower rule, and a multi-row statusline under it. That shape is
+# what wedged away-mode delivery overnight, and it exercises two code paths the
+# bordered fixture cannot reach - the invisible-padding normalization in
+# bin/fm-composer-lib.sh and the identity gate on the lone-trailing-rule
+# staleness rule in bin/backends/herdr.sh.
 LOOP_SCRIPT="$STATE_DIR/supervisor-loop.sh"
 cat > "$LOOP_SCRIPT" <<'LOOP'
 #!/usr/bin/env bash
 MARK=$'\xE2\x81\xA3'
 LOG="$1"
+SHAPE="${2:-bordered}"
 AGENT_SOURCE=fm-test-supervisor
 AGENT_LABEL=fm-test-supervisor
 report_agent_state() {  # <idle|working>
@@ -166,7 +175,12 @@ OLD_STTY=$(stty -g 2>/dev/null || true)
 cleanup() {
   [ -z "$OLD_STTY" ] || stty "$OLD_STTY" 2>/dev/null || true
 }
-trap cleanup EXIT INT TERM
+# INT/TERM must actually END the loop, not just run cleanup and resume reading:
+# a scenario that switches composer shape sends C-c and then starts the next
+# fixture, and a loop that survived would swallow that command as composer input
+# and leave the previous shape on screen.
+trap cleanup EXIT
+trap 'cleanup; exit 0' INT TERM
 report_agent_state idle
 
 _buf=
@@ -182,15 +196,33 @@ _buf=
 # a separate interactively-typed `tput cols`), so trusting it here silently
 # let content overflow the real width and wrap across two rows. 40 is
 # comfortably under every real pane width observed on this machine.
-redraw() {
-  local avail=40 shown tail_n
+_shown() {
+  local avail=40 tail_n
   if [ "${#_buf}" -gt "$avail" ]; then
     tail_n=$((avail - 3))
-    shown="...${_buf: -$tail_n}"
+    printf '...%s' "${_buf: -$tail_n}"
   else
-    shown="$_buf"
+    printf '%s' "$_buf"
   fi
-  printf '\r\033[K❯ %s' "$shown"
+}
+redraw_bordered() { printf '\r\033[K│ > %s │' "$(_shown)"; }
+# The claude shape occupies five rows and is rewritten in place: print the block,
+# then walk the cursor back to its first row. The screen was cleared once before
+# the first redraw, so nothing sits below the statusline that a later capture
+# could mistake for a more recent composer.
+redraw_claude() {
+  printf '\r\033[K──────────────── fm-lab-supervisor ──\n'
+  printf '\033[K\342\235\257\302\240%s\n' "$(_shown)"
+  printf '\033[K────────────────────────────────────\n'
+  printf '\033[K  ctx 17%%  ·  wk 25%% 3d01h Fri\n'
+  printf '\033[K  auto mode on · 1 shell · ← for agents'
+  printf '\033[4A\r'
+}
+redraw() {
+  case "$SHAPE" in
+    claude) redraw_claude ;;
+    *) redraw_bordered ;;
+  esac
 }
 submit_line() {
   local _line=$_buf _c _hex
@@ -202,8 +234,13 @@ submit_line() {
   _hex=$(printf '%s' "$_line" | od -An -tx1 | tr -d ' \n')
   printf '%s\t%s\t%s\n' "$_hex" "$_line" "$_c" >> "$LOG"
   _buf=
-  printf '\r\033[K\n'
-  redraw
+  # The bordered fixture scrolls a fresh composer row after each submit; the
+  # claude block is a fixed five-row region rewritten where it stands, so
+  # advancing a row there would walk it down the screen instead.
+  case "$SHAPE" in
+    claude) redraw ;;
+    *) printf '\r\033[K\n'; redraw ;;
+  esac
   # Report a real idle->working->idle cycle around the submission, exactly
   # like a real harness's agent_status - this is the signal
   # fm_backend_herdr_send_text_submit now confirms against. The 0.6s "working"
@@ -214,6 +251,7 @@ submit_line() {
   report_agent_state idle
 }
 
+[ "$SHAPE" != claude ] || printf '\033[2J\033[H'
 redraw
 while IFS= read -r -n 1 _ch; do
   if [ -z "$_ch" ]; then
@@ -306,7 +344,6 @@ reset_state() {
          "$STATE_DIR"/.subsuper-* \
          "$STATE_DIR"/.wake-queue* \
          "$STATE_DIR"/.watch.lock* \
-         "$STATE_DIR"/.watcher-down* \
          "$STATE_DIR"/.last-* \
          "$STATE_DIR"/.hash-* \
          "$STATE_DIR"/.count-* \
@@ -523,10 +560,121 @@ test_scenario_d_max_defer() {
   pass "real herdr Scenario D: a persistently pending composer raises the max-defer wedge alarm, preserves the buffer, and never crashes the daemon"
 }
 
+# --- Scenario E: claude's own rule-framed, NBSP-padded composer --------------
+# The overnight wedge shape, end to end. An idle claude composer reads as the
+# bare `❯` glyph padded with U+00A0, framed by a labelled upper rule and a bare
+# lower rule, with a tall statusline below it. Both defects that shape triggered
+# refuse injection - the lower rule read as staleness (`unknown`), and the
+# padding read as unsent text (`pending`) - so a buffered escalation never left
+# the daemon. This asserts the escalation is actually SUBMITTED against that
+# exact fixture, and that real typed text there still defers.
+
+restart_supervisor_loop() {  # <shape>
+  fm_backend_herdr_send_key "$SUPERVISOR_TARGET" C-c >/dev/null 2>&1 || true
+  sleep 1
+  fm_backend_herdr_send_text_line "$SUPERVISOR_TARGET" "bash '$LOOP_SCRIPT' '$LOG_FILE' '$1'" \
+    || fail "could not restart the supervisor loop in shape '$1'"
+  sleep 1.5
+}
+
+# A shape switch that silently failed would leave the previous fixture on screen
+# and quietly turn the scenario into a duplicate of the bordered ones, so assert
+# the bytes under test are really there: the bare glyph plus U+00A0, and a lower
+# rule with no matching upper rule above it.
+assert_claude_shape_on_screen() {
+  local cap
+  # The ANSI capture, because that is the one the classifier reads first; herdr's
+  # plain read normalizes a trailing U+00A0 away, so it cannot see the padding at
+  # all.
+  cap=$(fm_backend_herdr_capture_ansi "$SUPERVISOR_TARGET" 20 \
+    | fm_composer_strip_ansi | tr -d '\r') \
+    || fail "Scenario E: could not capture the supervisor pane"
+  if ! printf '%s' "$cap" | grep -q $'\342\235\257\302\240'; then
+    printf '%s' "$cap" | od -c | sed 's/^/    /' >&2
+    fail "Scenario E: the pane is not showing a U+00A0-padded '❯' composer; the shape switch did not take"
+  fi
+  printf '%s' "$cap" | grep -qE '^────+$' \
+    || fail "Scenario E: the pane is not showing claude's bare lower rule; the shape switch did not take"
+  if printf '%s' "$cap" | grep -q '│ > '; then
+    fail "Scenario E: the bordered fixture is still on screen; the shape switch did not take"
+  fi
+}
+
+test_scenario_e_claude_shape() {
+  reset_state
+  restart_supervisor_loop claude
+  assert_claude_shape_on_screen
+
+  local verdict
+  verdict=$(PATH="$HERDR_SHIM_DIR:$PATH" fm_backend_herdr_composer_state "$SUPERVISOR_TARGET")
+  [ "$verdict" = empty ] \
+    || fail "Scenario E: an idle rule-framed claude composer read '$verdict', not empty"
+
+  afk_enter "$STATE_DIR"
+  start_daemon
+  echo "done: PR https://example.test/pr/500" > "$STATE_DIR/fake-c1.status"
+  sleep 8
+
+  grep -q 'Supervisor escalate' "$LOG_FILE" \
+    || fail "Scenario E: the escalation was never delivered into claude's own composer shape"
+  local marker_count
+  marker_count=$(awk -F '\t' '{ hex=$1; count += gsub(/e281a3/, "", hex) } END { print count + 0 }' "$LOG_FILE")
+  [ "$marker_count" -eq 1 ] \
+    || fail "Scenario E: expected exactly 1 U+2063 marker, got $marker_count"
+  [ ! -s "$STATE_DIR/.subsuper-inject-wedged" ] \
+    || fail "Scenario E: delivery succeeded but the wedge alarm fired anyway"
+
+  # Real typed text in that same shape must still defer.
+  reset_state
+  local defer_log_start=0
+  [ ! -f "$STATE_DIR/.supervise-daemon.log" ] || defer_log_start=$(wc -l < "$STATE_DIR/.supervise-daemon.log")
+  fm_backend_herdr_send_literal "$SUPERVISOR_TARGET" "human draft text"
+  sleep 0.5
+  verdict=$(PATH="$HERDR_SHIM_DIR:$PATH" fm_backend_herdr_composer_state "$SUPERVISOR_TARGET")
+  [ "$verdict" = pending ] \
+    || fail "Scenario E: typed text in a rule-framed claude composer read '$verdict', not pending"
+  echo "needs-decision: pick A or B" > "$STATE_DIR/fake-c1.status"
+  # Wait for the daemon to actually REACH an injection decision instead of
+  # assuming a fixed sleep is enough: the mid-scenario reset_state removes state
+  # under a running watcher, which ends that watcher cleanly and costs a 5s
+  # restart backoff before the next escalation cycle. A fixed sleep shorter than
+  # the backoff reads as "no deferral recorded" no matter how the pane classifies.
+  local deferred=0 waited=0
+  while [ "$waited" -lt 30 ]; do
+    if tail -n +"$((defer_log_start + 1))" "$STATE_DIR/.supervise-daemon.log" 2>/dev/null \
+      | grep -q 'inject deferred: supervisor composer not confirmed-empty'; then
+      deferred=1
+      break
+    fi
+    grep -q 'Supervisor escalate' "$LOG_FILE" && break
+    sleep 1
+    waited=$((waited + 1))
+  done
+  if grep -q 'Supervisor escalate' "$LOG_FILE"; then
+    fail "Scenario E: the daemon injected over a claude composer that held human text"
+  fi
+  # Absence of a delivery line alone would also pass if the mid-run reset_state
+  # had knocked the daemon out of escalating at all, so require the positive
+  # deferral record and a live daemon behind it.
+  kill -0 "$DAEMON_PID" 2>/dev/null \
+    || fail "Scenario E: the daemon died instead of deferring over the human's typed text"
+  if [ "$deferred" -ne 1 ]; then
+    tail -n +"$((defer_log_start + 1))" "$STATE_DIR/.supervise-daemon.log" 2>/dev/null | sed 's/^/    /' >&2
+    fail "Scenario E: the daemon never recorded a composer deferral, so the absent delivery proves nothing"
+  fi
+  fm_backend_herdr_send_key "$SUPERVISOR_TARGET" Enter
+  sleep 0.5
+
+  stop_daemon
+  restart_supervisor_loop bordered
+  pass "real herdr Scenario E: claude's rule-framed NBSP-padded composer accepts an escalation when idle and defers when a human is typing"
+}
+
 test_scenario_a
 test_scenario_b
 test_scenario_c
 test_scenario_d_max_defer
+test_scenario_e_claude_shape
 
 echo "all real-herdr afk injection e2e tests passed"
 

--- a/tests/fm-afk-inject-herdr-e2e.test.sh
+++ b/tests/fm-afk-inject-herdr-e2e.test.sh
@@ -18,8 +18,8 @@
 # binary untouched.
 #
 # The "supervisor pane" is a tiny deterministic bash loop (not a real harness
-# binary): it draws a bordered composer row ("│ > <buf> │") that exercises the
-# bordered branch of fm_backend_herdr_composer_state, and logs every submitted
+# binary): it draws the verified bare-agent composer shape (`❯ <buf>`) and
+# logs every submitted
 # line (hex + text + injection/user classification) - the same technique
 # tests/fm-afk-inject-e2e.test.sh uses for its tmux supervisor pane, so this
 # test asserts on submitted CONTENT, not pane appearance. It ALSO registers
@@ -131,12 +131,13 @@ read -r _FAKE_TAB_ID FAKE_CREW_PANE_ID <<EOF
 $FAKE_CREW_IDS
 EOF
 
-# --- deterministic bordered-composer loop, drawn in the scratch pane ---------
-# Mirrors tests/fm-afk-inject-e2e.test.sh's supervisor-loop.sh, but draws a
-# "│ > <buf> │" border so the bordered branch of
-# fm_backend_herdr_composer_state recognizes it, exactly like a bordered-TUI
-# harness composer. ALSO registers itself as a real herdr agent via `herdr
-# pane report-agent` and reports idle/working transitions around each
+# --- deterministic bare-composer loop, drawn in the scratch pane -------------
+# Mirrors tests/fm-afk-inject-e2e.test.sh's supervisor-loop.sh, but draws the
+# shared classifier's positively identified bare-agent shape (`❯ <buf>`). This
+# remains readable under the strict blank-row posture without pretending that
+# one side-bordered row is a complete composer box. ALSO registers itself as a
+# real herdr agent via `herdr pane report-agent` and reports idle/working
+# transitions around each
 # submission: fm_backend_herdr_send_text_submit's confirmation is now native
 # agent-state (agent get), not composer content (docs/herdr-backend.md
 # "Native agent-state submit confirmation"), so a synthetic pane that only
@@ -151,12 +152,12 @@ EOF
 # to report its own agent state, verified empirically against real herdr 0.7.1
 # in an isolated session.
 #
-# The loop takes an optional SHAPE argument. `bordered` (the default) is the
-# box-composer fixture described above. `claude` redraws the shape real claude
+# The loop takes an optional SHAPE argument. `bare` (the default) is the
+# agent-glyph fixture described above. `claude` redraws the shape real claude
 # presents through herdr: a labelled upper rule, a bare `❯` prompt padded with
 # U+00A0, a bare lower rule, and a multi-row statusline under it. That shape is
 # what wedged away-mode delivery overnight, and it exercises two code paths the
-# bordered fixture cannot reach - the invisible-padding normalization in
+# bare fixture cannot reach - the invisible-padding normalization in
 # bin/fm-composer-lib.sh and the identity gate on the lone-trailing-rule
 # staleness rule in bin/backends/herdr.sh.
 LOOP_SCRIPT="$STATE_DIR/supervisor-loop.sh"
@@ -164,7 +165,7 @@ cat > "$LOOP_SCRIPT" <<'LOOP'
 #!/usr/bin/env bash
 MARK=$'\xE2\x81\xA3'
 LOG="$1"
-SHAPE="${2:-bordered}"
+SHAPE="${2:-bare}"
 AGENT_SOURCE=fm-test-supervisor
 AGENT_LABEL=fm-test-supervisor
 report_agent_state() {  # <idle|working>
@@ -185,10 +186,9 @@ report_agent_state idle
 
 _buf=
 # redraw: keep the composer visually pinned to ONE terminal row regardless of
-# _buf's length - a realistic bordered single-line composer horizontally
+# _buf's length - a realistic single-line composer horizontally
 # scrolls to show the tail near the cursor rather than letting the terminal
-# hard-wrap a too-long line across multiple rows (which would break the
-# structural border-row classifier's one-row assumption: a batched escalation
+# hard-wrap a too-long line across multiple rows (a batched escalation
 # digest easily exceeds a narrow pane's column width). A hardcoded width
 # (not `tput cols`) is used deliberately: verified empirically against a real
 # herdr pane launched this same way that `tput cols` inside this script's own
@@ -205,7 +205,7 @@ _shown() {
     printf '%s' "$_buf"
   fi
 }
-redraw_bordered() { printf '\r\033[K│ > %s │' "$(_shown)"; }
+redraw_bare() { printf '\r\033[K❯ %s' "$(_shown)"; }
 # The claude shape occupies five rows and is rewritten in place: print the block,
 # then walk the cursor back to its first row. The screen was cleared once before
 # the first redraw, so nothing sits below the statusline that a later capture
@@ -221,7 +221,7 @@ redraw_claude() {
 redraw() {
   case "$SHAPE" in
     claude) redraw_claude ;;
-    *) redraw_bordered ;;
+    *) redraw_bare ;;
   esac
 }
 submit_line() {
@@ -234,7 +234,7 @@ submit_line() {
   _hex=$(printf '%s' "$_line" | od -An -tx1 | tr -d ' \n')
   printf '%s\t%s\t%s\n' "$_hex" "$_line" "$_c" >> "$LOG"
   _buf=
-  # The bordered fixture scrolls a fresh composer row after each submit; the
+  # The bare fixture scrolls a fresh composer row after each submit; the
   # claude block is a fixed five-row region rewritten where it stands, so
   # advancing a row there would walk it down the screen instead.
   case "$SHAPE" in
@@ -578,7 +578,7 @@ restart_supervisor_loop() {  # <shape>
 }
 
 # A shape switch that silently failed would leave the previous fixture on screen
-# and quietly turn the scenario into a duplicate of the bordered ones, so assert
+# and quietly turn the scenario into a duplicate of the bare ones, so assert
 # the bytes under test are really there: the bare glyph plus U+00A0, and a lower
 # rule with no matching upper rule above it.
 assert_claude_shape_on_screen() {
@@ -595,8 +595,8 @@ assert_claude_shape_on_screen() {
   fi
   printf '%s' "$cap" | grep -qE '^────+$' \
     || fail "Scenario E: the pane is not showing claude's bare lower rule; the shape switch did not take"
-  if printf '%s' "$cap" | grep -q '│ > '; then
-    fail "Scenario E: the bordered fixture is still on screen; the shape switch did not take"
+  if printf '%s' "$cap" | grep -q '^❯ '; then
+    fail "Scenario E: the bare fixture is still on screen; the shape switch did not take"
   fi
 }
 
@@ -666,7 +666,7 @@ test_scenario_e_claude_shape() {
   sleep 0.5
 
   stop_daemon
-  restart_supervisor_loop bordered
+  restart_supervisor_loop bare
   pass "real herdr Scenario E: claude's rule-framed NBSP-padded composer accepts an escalation when idle and defers when a human is typing"
 }
 

--- a/tests/fm-afk-inject-herdr-e2e.test.sh
+++ b/tests/fm-afk-inject-herdr-e2e.test.sh
@@ -344,6 +344,7 @@ reset_state() {
          "$STATE_DIR"/.subsuper-* \
          "$STATE_DIR"/.wake-queue* \
          "$STATE_DIR"/.watch.lock* \
+         "$STATE_DIR"/.watcher-down* \
          "$STATE_DIR"/.last-* \
          "$STATE_DIR"/.hash-* \
          "$STATE_DIR"/.count-* \

--- a/tests/fm-backend-herdr.test.sh
+++ b/tests/fm-backend-herdr.test.sh
@@ -3134,6 +3134,66 @@ test_composer_state_pi_separator_requires_safe_native_identity() {
   pass "fm_backend_herdr_composer_state: Pi separators never authorize working, non-Pi, unreadable, or over-tall targets"
 }
 
+# A lone trailing horizontal rule is Pi evidence only on a Pi pane. claude frames
+# its own live composer between two rules and labels the upper one
+# ("─── name ──"), so the upper rule is not a bare separator and the capture ends
+# in exactly the incomplete-pair shape above. Reading that as staleness discarded
+# a live idle claude composer and returned unknown on every poll, which deferred
+# every away-mode escalation overnight. The fixture is the recorded shape of that
+# pane, NBSP padding and tall statusline included.
+herdr_claude_rule_framed_capture() {  # -> the recorded claude composer screen
+  printf '  \xe2\x8e\xbf  Tip: Use /theme to change the color theme\n'
+  printf '\n'
+  printf '\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80 expose-demo-system-entry \xe2\x94\x80\xe2\x94\x80\n'
+  printf '\xe2\x9d\xaf\xc2\xa0\n'
+  printf '\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\n'
+  printf '  eduard@valhalla:~/p  \xe2\x8e\x87 main  \xe2\x97\x86 Opus 5 \xc2\xb7 high\n'
+  printf '  ctx 17%%  \xc2\xb7  5h 93%% 4h37m  \xc2\xb7  wk 25%% 3d01h Fri\n'
+  printf '  \xe2\x8f\xb5\xe2\x8f\xb5 auto mode on \xc2\xb7 1 shell \xc2\xb7 \xe2\x86\x90 for agents\n'
+}
+
+test_composer_state_claude_rule_framed_idle_is_empty() {
+  local dir log resp fb out
+  dir="$TMP_ROOT/composer-claude-rule-framed"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
+  herdr_claude_rule_framed_capture > "$resp/1.out"
+  printf '{"result":{"agent":{"agent":"claude","agent_status":"done"}}}\n' > "$resp/2.out"
+  fb=$(make_herdr_fakebin "$dir")
+  out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
+    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_composer_state lab:w1:p2' "$ROOT" )
+  [ "$out" = empty ] || fail "an idle rule-framed claude composer should read empty, got '$out'"
+  pass "fm_backend_herdr_composer_state: a claude composer framed by its own rules reads empty, not unknown"
+}
+
+test_composer_state_claude_rule_framed_real_text_is_pending() {
+  local dir log resp fb out
+  dir="$TMP_ROOT/composer-claude-rule-framed-pending"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
+  herdr_claude_rule_framed_capture | sed 's/^\xe2\x9d\xaf\xc2\xa0$/\xe2\x9d\xaf\xc2\xa0half typed answer/' > "$resp/1.out"
+  printf '{"result":{"agent":{"agent":"claude","agent_status":"done"}}}\n' > "$resp/2.out"
+  fb=$(make_herdr_fakebin "$dir")
+  out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
+    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_composer_state lab:w1:p2' "$ROOT" )
+  [ "$out" = pending ] || fail "unsent text in a rule-framed claude composer should read pending, got '$out'"
+  pass "fm_backend_herdr_composer_state: unsent text in a rule-framed claude composer stays pending"
+}
+
+test_composer_state_lone_rule_still_refuses_pi_and_unreadable() {
+  local dir log resp fb out case_id
+  for case_id in pi unreadable; do
+    dir="$TMP_ROOT/composer-lone-rule-$case_id"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
+    herdr_claude_rule_framed_capture > "$resp/1.out"
+    case "$case_id" in
+      pi) printf '{"result":{"agent":{"agent":"pi","agent_status":"idle"}}}\n' > "$resp/2.out" ;;
+      unreadable) printf '1\n' > "$resp/2.exit" ;;
+    esac
+    fb=$(make_herdr_fakebin "$dir")
+    out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
+      bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_composer_state lab:w1:p2' "$ROOT" )
+    [ "$out" = unknown ] \
+      || fail "a lone trailing rule on a '$case_id' target must stay unknown, got '$out'"
+  done
+  pass "fm_backend_herdr_composer_state: a lone trailing rule still refuses a Pi or unreadable target"
+}
+
 # --- composer_state: unbordered (bare) composer rows -------------------------
 # Regression coverage for the away-mode redelivery-loop incident
 # (docs/herdr-backend.md "Incident (2026-07-07)"): real claude and codex
@@ -4438,6 +4498,9 @@ test_composer_state_pi_separator_idle_is_empty
 test_composer_state_pi_separator_real_text_is_pending
 test_composer_state_pi_incomplete_separator_below_stale_generic_is_unknown
 test_composer_state_pi_separator_requires_safe_native_identity
+test_composer_state_claude_rule_framed_idle_is_empty
+test_composer_state_claude_rule_framed_real_text_is_pending
+test_composer_state_lone_rule_still_refuses_pi_and_unreadable
 test_composer_state_claude_unbordered_prompt_is_empty
 test_composer_state_claude_unbordered_prompt_is_pending
 test_composer_state_bare_prompt_below_stale_bordered_banner_wins

--- a/tests/fm-backend-herdr.test.sh
+++ b/tests/fm-backend-herdr.test.sh
@@ -3142,10 +3142,11 @@ test_composer_state_pi_separator_requires_safe_native_identity() {
 # every away-mode escalation overnight. The fixture is the recorded shape of that
 # pane, NBSP padding and tall statusline included.
 herdr_claude_rule_framed_capture() {  # -> the recorded claude composer screen
+  local composer_text=${1-}
   printf '  \xe2\x8e\xbf  Tip: Use /theme to change the color theme\n'
   printf '\n'
   printf '\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80 expose-demo-system-entry \xe2\x94\x80\xe2\x94\x80\n'
-  printf '\xe2\x9d\xaf\xc2\xa0\n'
+  printf '\xe2\x9d\xaf\xc2\xa0%s\n' "$composer_text"
   printf '\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\n'
   printf '  eduard@valhalla:~/p  \xe2\x8e\x87 main  \xe2\x97\x86 Opus 5 \xc2\xb7 high\n'
   printf '  ctx 17%%  \xc2\xb7  5h 93%% 4h37m  \xc2\xb7  wk 25%% 3d01h Fri\n'
@@ -3167,7 +3168,7 @@ test_composer_state_claude_rule_framed_idle_is_empty() {
 test_composer_state_claude_rule_framed_real_text_is_pending() {
   local dir log resp fb out
   dir="$TMP_ROOT/composer-claude-rule-framed-pending"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
-  herdr_claude_rule_framed_capture | sed 's/^\xe2\x9d\xaf\xc2\xa0$/\xe2\x9d\xaf\xc2\xa0half typed answer/' > "$resp/1.out"
+  herdr_claude_rule_framed_capture 'half typed answer' > "$resp/1.out"
   printf '{"result":{"agent":{"agent":"claude","agent_status":"done"}}}\n' > "$resp/2.out"
   fb=$(make_herdr_fakebin "$dir")
   out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \

--- a/tests/fm-backend-herdr.test.sh
+++ b/tests/fm-backend-herdr.test.sh
@@ -3177,14 +3177,18 @@ test_composer_state_claude_rule_framed_real_text_is_pending() {
   pass "fm_backend_herdr_composer_state: unsent text in a rule-framed claude composer stays pending"
 }
 
-test_composer_state_lone_rule_still_refuses_pi_and_unreadable() {
+test_composer_state_lone_rule_requires_valid_non_pi_identity() {
   local dir log resp fb out case_id
-  for case_id in pi unreadable; do
+  for case_id in pi unreadable agent-not-found empty-agent missing-status malformed; do
     dir="$TMP_ROOT/composer-lone-rule-$case_id"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
     herdr_claude_rule_framed_capture > "$resp/1.out"
     case "$case_id" in
       pi) printf '{"result":{"agent":{"agent":"pi","agent_status":"idle"}}}\n' > "$resp/2.out" ;;
       unreadable) printf '1\n' > "$resp/2.exit" ;;
+      agent-not-found) printf '{"error":{"code":"agent_not_found"}}\n' > "$resp/2.out" ;;
+      empty-agent) printf '{"result":{"agent":{"agent":"","agent_status":"idle"}}}\n' > "$resp/2.out" ;;
+      missing-status) printf '{"result":{"agent":{"agent":"claude"}}}\n' > "$resp/2.out" ;;
+      malformed) printf 'not-json\n' > "$resp/2.out" ;;
     esac
     fb=$(make_herdr_fakebin "$dir")
     out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
@@ -3192,7 +3196,7 @@ test_composer_state_lone_rule_still_refuses_pi_and_unreadable() {
     [ "$out" = unknown ] \
       || fail "a lone trailing rule on a '$case_id' target must stay unknown, got '$out'"
   done
-  pass "fm_backend_herdr_composer_state: a lone trailing rule still refuses a Pi or unreadable target"
+  pass "fm_backend_herdr_composer_state: a lone trailing rule requires a valid non-Pi identity"
 }
 
 # --- composer_state: unbordered (bare) composer rows -------------------------
@@ -4501,7 +4505,7 @@ test_composer_state_pi_incomplete_separator_below_stale_generic_is_unknown
 test_composer_state_pi_separator_requires_safe_native_identity
 test_composer_state_claude_rule_framed_idle_is_empty
 test_composer_state_claude_rule_framed_real_text_is_pending
-test_composer_state_lone_rule_still_refuses_pi_and_unreadable
+test_composer_state_lone_rule_requires_valid_non_pi_identity
 test_composer_state_claude_unbordered_prompt_is_empty
 test_composer_state_claude_unbordered_prompt_is_pending
 test_composer_state_bare_prompt_below_stale_bordered_banner_wins

--- a/tests/fm-composer-lib.test.sh
+++ b/tests/fm-composer-lib.test.sh
@@ -188,6 +188,17 @@ test_matrix_claude_bare_nbsp_row() {
   pass "matrix: claude's ❯+NBSP row reads empty on every profile in both locales (#1988)"
 }
 
+test_matrix_inline_bordered_composer() {
+  # Herdr's compact supervisor and some bordered panes expose only one row of
+  # side borders, not a complete top/content/bottom box.
+  local idle typed
+  idle=$'│ > │'
+  assert_screen "inline bordered idle" empty "$CAPS_STYLED" "$idle"
+  typed=$'│ > human draft text │'
+  assert_screen "inline bordered draft" pending "$CAPS_STYLED" "$typed"
+  pass "matrix: a one-row side-bordered composer remains classified safely"
+}
+
 test_matrix_claude_labelled_rule_does_not_need_native_identity() {
   # Claude's labelled upper rule plus bare lower rule is not Pi's separated
   # composer: the live bare agent glyph positively identifies the candidate.
@@ -623,6 +634,7 @@ test_idle_placeholder_case_mode_is_explicit
 test_real_text_is_pending
 test_matrix_claude_bare_nbsp_row
 test_matrix_claude_labelled_rule_does_not_need_native_identity
+test_matrix_inline_bordered_composer
 test_matrix_codex_dim_hint_row
 test_matrix_muse_truecolor_glyph_survives_signal_loss
 test_matrix_cursor_reverse_video_placeholder_remnant

--- a/tests/fm-composer-lib.test.sh
+++ b/tests/fm-composer-lib.test.sh
@@ -188,6 +188,20 @@ test_matrix_claude_bare_nbsp_row() {
   pass "matrix: claude's ❯+NBSP row reads empty on every profile in both locales (#1988)"
 }
 
+test_matrix_claude_labelled_rule_does_not_need_native_identity() {
+  # Claude's labelled upper rule plus bare lower rule is not Pi's separated
+  # composer: the live bare agent glyph positively identifies the candidate.
+  # The classifier must not turn this idle pane into unknown merely because an
+  # adapter's native identity probe is unavailable while the pane is idle.
+  local idle typed
+  idle=$'──────────────── fm-lab-supervisor ──\n❯'"$NBSP"$'\n────────────────────────────────────\n  ctx 17%  ·  wk 25% 3d01h Fri'
+  assert_screen "labelled-rule claude idle" empty "$CAPS_STYLED" "$idle"
+  assert_screen "labelled-rule claude idle without identity capability" empty "$CAPS_STYLED_NOID" "$idle"
+  typed=$'──────────────── fm-lab-supervisor ──\n❯ fix the regression\n────────────────────────────────────'
+  assert_screen "labelled-rule claude draft" pending "$CAPS_STYLED" "$typed"
+  pass "matrix: claude's labelled upper rule and bare lower rule stay identified by the agent glyph"
+}
+
 test_matrix_codex_dim_hint_row() {
   # Real idle codex: bold `›`, reset, then an SGR-2 dim hint. Styled captures
   # strip the ghost and prove empty; plain captures must defer as unknown -
@@ -608,6 +622,7 @@ test_idle_placeholder_is_empty
 test_idle_placeholder_case_mode_is_explicit
 test_real_text_is_pending
 test_matrix_claude_bare_nbsp_row
+test_matrix_claude_labelled_rule_does_not_need_native_identity
 test_matrix_codex_dim_hint_row
 test_matrix_muse_truecolor_glyph_survives_signal_loss
 test_matrix_cursor_reverse_video_placeholder_remnant

--- a/tests/fm-composer-lib.test.sh
+++ b/tests/fm-composer-lib.test.sh
@@ -188,15 +188,13 @@ test_matrix_claude_bare_nbsp_row() {
   pass "matrix: claude's ❯+NBSP row reads empty on every profile in both locales (#1988)"
 }
 
-test_matrix_inline_bordered_composer() {
-  # Herdr's compact supervisor and some bordered panes expose only one row of
-  # side borders, not a complete top/content/bottom box.
-  local idle typed
-  idle=$'│ > │'
-  assert_screen "inline bordered idle" empty "$CAPS_STYLED" "$idle"
-  typed=$'│ > human draft text │'
-  assert_screen "inline bordered draft" pending "$CAPS_STYLED" "$typed"
-  pass "matrix: a one-row side-bordered composer remains classified safely"
+test_unverified_inline_rows_are_unknown() {
+  local incomplete
+  assert_screen "standalone side-bordered row" unknown "$CAPS_STYLED" $'| |'
+  incomplete=$'╭──╮\n│ > human draft │\n│ │'
+  assert_screen "incomplete bordered draft" unknown "$CAPS_STYLED" "$incomplete"
+  assert_screen "cursor on unidentified side-bordered row" unknown "$CAPS_TMUX" $'│ │' 0 probe-absent
+  pass "matrix: side borders without a complete box never prove a composer"
 }
 
 test_matrix_claude_labelled_rule_defers_to_native_identity() {
@@ -214,6 +212,9 @@ test_matrix_claude_labelled_rule_defers_to_native_identity() {
   assert_screen "labelled-rule claude idle" empty "$CAPS_STYLED" "$idle" '' "$claude_idle"
   assert_screen "labelled-rule pi target" unknown "$CAPS_STYLED" "$idle" '' "$pi_idle"
   assert_screen "labelled-rule unreadable identity" unknown "$CAPS_STYLED" "$idle" '' probe-absent
+  assert_screen "labelled-rule empty agent identity" unknown "$CAPS_STYLED" "$idle" '' $'\tidle'
+  assert_screen "labelled-rule empty status identity" unknown "$CAPS_STYLED" "$idle" '' $'claude\t'
+  assert_screen "labelled-rule malformed identity" unknown "$CAPS_STYLED" "$idle" '' claude
   assert_screen "labelled-rule claude idle without identity capability" empty "$CAPS_STYLED_NOID" "$idle"
   typed=$'──────────────── fm-lab-supervisor ──\n❯ fix the regression\n────────────────────────────────────'
   assert_screen "labelled-rule claude draft" pending "$CAPS_STYLED" "$typed" '' "$claude_idle"
@@ -641,8 +642,8 @@ test_idle_placeholder_is_empty
 test_idle_placeholder_case_mode_is_explicit
 test_real_text_is_pending
 test_matrix_claude_bare_nbsp_row
+test_unverified_inline_rows_are_unknown
 test_matrix_claude_labelled_rule_defers_to_native_identity
-test_matrix_inline_bordered_composer
 test_matrix_codex_dim_hint_row
 test_matrix_muse_truecolor_glyph_survives_signal_loss
 test_matrix_cursor_reverse_video_placeholder_remnant

--- a/tests/fm-composer-lib.test.sh
+++ b/tests/fm-composer-lib.test.sh
@@ -199,18 +199,26 @@ test_matrix_inline_bordered_composer() {
   pass "matrix: a one-row side-bordered composer remains classified safely"
 }
 
-test_matrix_claude_labelled_rule_does_not_need_native_identity() {
-  # Claude's labelled upper rule plus bare lower rule is not Pi's separated
-  # composer: the live bare agent glyph positively identifies the candidate.
-  # The classifier must not turn this idle pane into unknown merely because an
-  # adapter's native identity probe is unavailable while the pane is idle.
-  local idle typed
+test_matrix_claude_labelled_rule_defers_to_native_identity() {
+  # Claude's labelled upper rule plus bare lower rule looks exactly like a Pi
+  # separated composer whose opening rule scrolled out of the capture window,
+  # so an identity-capable adapter resolves it natively (claude reads empty,
+  # Pi and an unreadable probe stay unknown). Backends with no identity probe
+  # keep the bare agent glyph as the container proof, the same rule the
+  # pi-pair overlap above already applies.
+  local idle typed claude_idle pi_idle
+  claude_idle=$(printf 'claude\tidle'); pi_idle=$(printf 'pi\tidle')
   idle=$'──────────────── fm-lab-supervisor ──\n❯'"$NBSP"$'\n────────────────────────────────────\n  ctx 17%  ·  wk 25% 3d01h Fri'
-  assert_screen "labelled-rule claude idle" empty "$CAPS_STYLED" "$idle"
+  [ "$(fm_composer_classify_screen "$CAPS_STYLED" "$idle")" = need-identity ] \
+    || fail "an identity-capable profile should request the lazy probe for a lone trailing rule"
+  assert_screen "labelled-rule claude idle" empty "$CAPS_STYLED" "$idle" '' "$claude_idle"
+  assert_screen "labelled-rule pi target" unknown "$CAPS_STYLED" "$idle" '' "$pi_idle"
+  assert_screen "labelled-rule unreadable identity" unknown "$CAPS_STYLED" "$idle" '' probe-absent
   assert_screen "labelled-rule claude idle without identity capability" empty "$CAPS_STYLED_NOID" "$idle"
   typed=$'──────────────── fm-lab-supervisor ──\n❯ fix the regression\n────────────────────────────────────'
-  assert_screen "labelled-rule claude draft" pending "$CAPS_STYLED" "$typed"
-  pass "matrix: claude's labelled upper rule and bare lower rule stay identified by the agent glyph"
+  assert_screen "labelled-rule claude draft" pending "$CAPS_STYLED" "$typed" '' "$claude_idle"
+  assert_screen "labelled-rule draft without identity capability" pending "$CAPS_STYLED_NOID" "$typed"
+  pass "matrix: a lone trailing rule under claude's labelled frame defers to native identity"
 }
 
 test_matrix_codex_dim_hint_row() {
@@ -633,7 +641,7 @@ test_idle_placeholder_is_empty
 test_idle_placeholder_case_mode_is_explicit
 test_real_text_is_pending
 test_matrix_claude_bare_nbsp_row
-test_matrix_claude_labelled_rule_does_not_need_native_identity
+test_matrix_claude_labelled_rule_defers_to_native_identity
 test_matrix_inline_bordered_composer
 test_matrix_codex_dim_hint_row
 test_matrix_muse_truecolor_glyph_survives_signal_loss


### PR DESCRIPTION
## Intent

Take an already-written, reviewed change through the no-mistakes pipeline so it lands upstream (kunchenguid/firstmate main) with provenance the required 'PR must be raised via no-mistakes' gate accepts. The change itself is settled and must not be redesigned; it is being moved through a different door, not rewritten.

Goal of the change (commit 'fix(afk): read an idle claude composer as empty instead of unknown'): away mode stopped delivering escalations for hours against a live, idle claude primary because the composer classifier returned state=unknown, and the injector correctly refuses to type into a pane it cannot confirm empty. Two stacked defects are fixed:
1. Structural (bin/backends/herdr.sh): the herdr adapter treated a lone trailing horizontal rule with no matching opening rule as proof that a composer row above it is stale. That rule was written for Pi, whose composer lives between two bare separators. claude frames its composer the same way but its upper rule carries a label, so the capture ends in the incomplete-pair shape and the live composer was discarded before its content was read. Now only a Pi pane's separator invalidates a match, and an unreadable agent identity still invalidates, so doubt keeps blocking injection exactly as before.
2. Content (bin/fm-composer-lib.sh): claude's idle composer reads as the agent glyph plus U+00A0 NO-BREAK SPACE, which is not in [[:space:]] in any glibc locale, so no trim removed it and an idle composer classified as 'pending'. The normalization is taken from upstream PR #1322 by KD5694, together with its composer scan-window increase from 20 to 40 rows. The rest of #1322 and of #1285 is deliberately not adopted: the shutdown reap budget and the herdr wedge-alarm 'shown' handling address problems this incident did not hit, and wiring an OS alert channel is an operator decision.

Deliberate decisions a reviewer reading only the diff would not know:
- Injection safety is intentionally unchanged: 'unknown' still blocks injection. The fix is to read the pane correctly, never to inject on doubt. Only characters with zero typed meaning are normalized, so a half-typed line still reads 'pending', and the dead-shell refusal for a bare >/$/%/# row is untouched.
- docs/herdr-backend.md's one-line addition is the documented consequence; the docs owner rule in .agents/skills/firstmate-coding-guidelines applies.
- Tests are colocated as tests/<subject>.test.sh per repo convention: tests/fm-afk-inject-herdr-e2e.test.sh gains Scenario E driving real herdr with a fixture drawing claude's rule-framed, NBSP-padded composer; tests/fm-backend-herdr.test.sh and tests/fm-composer-lib.test.sh add unit coverage for both defects. Each new assertion was confirmed to fail on the base commit.
- Repo style constraints are binding: one sentence per line in tracked Markdown, plain dashes never em dashes, shellcheck-clean bin scripts via bin/fm-lint.sh, and no commit co-author trailer or AI-attribution line naming a model or assistant anywhere in commits, the PR body, or PR comments.
- The change is currently open upstream as https://github.com/kunchenguid/firstmate/pull/1654 from branch fm/herdr-claude-composer-unknown, blocked solely by the missing no-mistakes signature; it is cherry-picked unchanged onto current upstream main here. If this run opens a replacement PR, #1654 will be closed pointing at it.

## What Changed

- `bin/backends/herdr.sh`: a lone trailing separator rule now only invalidates a recognized composer row when native pane identity is Pi or unreadable, so Claude's rule-framed live composer is no longer discarded as stale; the structural scan window `FM_BACKEND_HERDR_COMPOSER_LINES` moves from 20 to 40 rows so a harness footer plus a multi-line statusline cannot push the composer row out of view.
- `bin/fm-composer-lib.sh`: new `fm_composer_blank_normalize` converts invisible padding (U+00A0, U+2007, U+202F, U+200B, U+2060, U+FEFF) to spaces inside the shared content classifier before re-trimming, so Claude's idle glyph + NO-BREAK SPACE row reads `empty` instead of `pending`. Injection safety is unchanged: `unknown` still blocks injection, half-typed text still reads `pending`, and the bare-shell-prompt refusal is untouched.
- Coverage and docs: `tests/fm-afk-inject-herdr-e2e.test.sh` gains Scenario E driving real herdr against a fixture that draws Claude's rule-framed, NBSP-padded composer (with a bounded poll for the injection decision), `tests/fm-backend-herdr.test.sh` and `tests/fm-composer-lib.test.sh` add unit cases for both defects, and `docs/herdr-backend.md`, `docs/configuration.md`, and `docs/verification/runtime-backends.md` record the new behavior and the 2026-08-04 real-capture evidence.

## Risk Assessment

✅ Low: The round-3 commit is a documentation-only addition that accurately records the two verified per-harness facts against the shipped code and repo style rules, leaving the already-reviewed, fail-closed source change unmodified with no outstanding findings.

## Testing

I ran the two new unit suites and the real-herdr away-mode e2e suite, all of which pass end to end, and then built a live-herdr demo that reproduces the actual incident: a real isolated herdr pane drawing claude's rule-framed, U+00A0-padded idle composer, classified by the base-commit adapter and by the fixed adapter, with the real away-mode daemon from each tree driven against that same pane. The base tree reads the live idle composer as `unknown` and logs `inject deferred: supervisor composer not confirmed-empty` for 25 seconds without ever delivering, while the target tree reads it as `empty` and the escalation line is actually submitted into the composer within 7 seconds - the overnight wedge reproduced and fixed on the same pane. The safety invariants the intent marks as non-negotiable also hold: human-typed text in that same shape still reads `pending`, a Pi or unreadable identity still reads `unknown`, and bare shell glyphs padded with U+00A0 still read `unknown`. Round 1's Scenario E poll fix held with no flake. No screenshot or GIF applies here: the change is a shell composer classifier and the end-user surface is a terminal pane, so the evidence captures the live pane's actual rendered rows and the bytes of the composer row rather than a rendered image. Worktree is clean and no lab herdr sessions or temporary trees were left behind.

<details>
<summary>Evidence: Live herdr pane: idle claude composer, base-vs-fix verdict, and real away-mode delivery</summary>

<code>=== Live herdr pane, exactly as a user sees an idle claude harness ===&#10;&#10;⎿ Tip: Use /theme to change the color theme&#10;──────────── fm-evidence-claude ──&#10;❯&#10;────────────────&#10;eduard@valhalla:~/p ⎇ main ◆ Opus 5 · high&#10;ctx 17% · 5h 93% 4h37m · wk 25% 3d01h Fri&#10;⏵⏵ auto mode on · 1 shell · ← for agents&#10;=== The composer row&#39;s raw bytes (U+00A0 = c2 a0, not [[:space:]]) ===&#10;e2 9d af c2 a0 0a &gt;......&lt;&#10;&#10;=== Away-mode composer verdict on that same live pane ===&#10;base c8edff3 (before the fix): composer_state = unknown&#10;target 8ef7e80 (after the fix): composer_state = empty&#10;&#10;The away-mode injector delivers only on &#39;empty&#39; and defers on anything else,&#10;so &#39;unknown&#39; is the state that held every escalation back overnight.&#10;&#10;=== Same live pane with a human&#39;s half-typed line in the composer ===&#10;❯ half typed answer&#10;target 8ef7e80: composer_state = pending (injection still deferred)&#10;&#10;=== Away mode with the base c8edff3 (before the fix) tree, 25s after the crewmate reported done ===&#10;NOTHING DELIVERED - the escalation is still buffered in the daemon:&#10;[2026-08-04T12:56:22+0200] inject deferred: supervisor composer not confirmed-empty (state=unknown: pending input, dead-shell prompt, or unreadable pane)&#10;[2026-08-04T12:56:23+0200] inject deferred: supervisor composer not confirmed-empty (state=unknown: pending input, dead-shell prompt, or unreadable pane)&#10;[2026-08-04T12:56:24+0200] inject deferred: supervisor composer not confirmed-empty (state=unknown: pending input, dead-shell prompt, or unreadable pane)&#10;&#10;=== Away mode with the target 8ef7e80 (after the fix) tree, 7s after the crewmate reported done ===&#10;DELIVERED into the claude composer:&#10;⁣FIRSTMATE_OP: v1 away-supervisor: Supervisor escalate (1 event(s)): fake-c1.status: done: PR https://example.test/pr/500 (pre-read; re-arm not needed — watcher daemon-managed)</code>

```text
=== Live herdr pane, exactly as a user sees an idle claude harness ===

  ⎿  Tip: Use /theme to change the color theme
──────────── fm-evidence-claude ──
❯ 
────────────────
  eduard@valhalla:~/p  ⎇ main  ◆ Opus 5 · high
  ctx 17%  ·  5h 93% 4h37m  ·  wk 25% 3d01h Fri
  ⏵⏵ auto mode on · 1 shell · ← for agents
=== The composer row's raw bytes (U+00A0 = c2 a0, not [[:space:]]) ===
   e2 9d af c2 a0 0a                                >......<

=== Away-mode composer verdict on that same live pane ===
  base   c8edff3 (before the fix): composer_state = unknown
  target 8ef7e80 (after the fix):  composer_state = empty

The away-mode injector delivers only on 'empty' and defers on anything else,
so 'unknown' is the state that held every escalation back overnight.

=== Same live pane with a human's half-typed line in the composer ===
  ❯ half typed answer
  target 8ef7e80: composer_state = pending  (injection still deferred)

=== Away mode with the base c8edff3 (before the fix) tree, 25s after the crewmate reported done ===
  NOTHING DELIVERED - the escalation is still buffered in the daemon:
    [2026-08-04T12:56:22+0200] inject deferred: supervisor composer not confirmed-empty (state=unknown: pending input, dead-shell prompt, or unreadable pane)
    [2026-08-04T12:56:23+0200] inject deferred: supervisor composer not confirmed-empty (state=unknown: pending input, dead-shell prompt, or unreadable pane)
    [2026-08-04T12:56:24+0200] inject deferred: supervisor composer not confirmed-empty (state=unknown: pending input, dead-shell prompt, or unreadable pane)

=== Away mode with the target 8ef7e80 (after the fix) tree, 7s after the crewmate reported done ===
  DELIVERED into the claude composer:
    ⁣FIRSTMATE_OP: v1 away-supervisor: Supervisor escalate (1 event(s)): fake-c1.status: done: PR https://example.test/pr/500 (pre-read; re-arm not needed — watcher daemon-managed)
```
</details>
<details>
<summary>Evidence: Real-herdr away-mode injection e2e suite (Scenarios A-E)</summary>

<code>ok - real herdr Scenario A: partial input defers injection; digest arrives clean after idle&#10;ok - real herdr Scenario B: swallowed Enter (via the herdr shim) produces exactly one clean digest&#10;ok - real herdr Scenario C: a normal captain status injects exactly one clean single-line sentinel digest&#10;ok - real herdr Scenario D: a persistently pending composer raises the max-defer wedge alarm, preserves the buffer, and never crashes the daemon&#10;ok - real herdr Scenario E: claude&#39;s rule-framed NBSP-padded composer accepts an escalation when idle and defers when a human is typing&#10;all real-herdr afk injection e2e tests passed&#10;EXIT=0</code>

```text
ok - real herdr Scenario A: partial input defers injection; digest arrives clean after idle
ok - real herdr Scenario B: swallowed Enter (via the herdr shim) produces exactly one clean digest
ok - real herdr Scenario C: a normal captain status injects exactly one clean single-line sentinel digest
ok - real herdr Scenario D: a persistently pending composer raises the max-defer wedge alarm, preserves the buffer, and never crashes the daemon
ok - real herdr Scenario E: claude's rule-framed NBSP-padded composer accepts an escalation when idle and defers when a human is typing
all real-herdr afk injection e2e tests passed
EXIT=0
```
</details>
<details>
<summary>Evidence: Reproduction harness for the live before/after demo</summary>

```text
#!/usr/bin/env bash
# Live-herdr before/after evidence for the "idle claude composer reads unknown"
# fix. Draws claude's real rule-framed, NBSP-padded idle composer in an isolated
# herdr lab pane, then classifies that same live pane with the BASE commit's
# adapter and with the FIXED adapter, and shows what the away-mode injector
# would do in each case.
set -u

ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
ROOT=${FM_ROOT:?FM_ROOT must point at the worktree}
BASE_ROOT=${FM_BASE_ROOT:?FM_BASE_ROOT must point at the base-commit tree}
OUT=${FM_EVIDENCE_OUT:?FM_EVIDENCE_OUT must be set}

command -v herdr >/dev/null 2>&1 || { echo "skip: herdr not found"; exit 0; }
command -v jq >/dev/null 2>&1 || { echo "skip: jq not found"; exit 0; }

. "$ROOT/tests/herdr-test-safety.sh"
herdr_forget_inherited_pane

SESSION="fm-lab-claude-composer-evidence-$$"
export HERDR_SESSION="$SESSION"
cleanup() { herdr_safe_stop_and_delete "$SESSION" >/dev/null 2>&1 || true; }
trap cleanup EXIT

. "$ROOT/bin/backends/herdr.sh"
fm_herdr_lab_prepare "$SESSION" >/dev/null || { echo "could not prepare lab session"; exit 1; }
fm_backend_herdr_version_check >/dev/null || { echo "version_check failed"; exit 1; }

CONTAINER_RAW=$(fm_backend_herdr_container_ensure /tmp) || exit 1
CONTAINER=${CONTAINER_RAW%%$'\t'*}
SEEDED_TAB_ID=${CONTAINER_RAW#*$'\t'}
IDS=$(fm_backend_herdr_create_task "$CONTAINER" "fm-claude-composer-evidence" /tmp "$SEEDED_TAB_ID") || exit 1
read -r _TAB PANE <<EOF
$IDS
EOF
TARGET="$SESSION:$PANE"

for _ in $(seq 1 100); do
  info=$(fm_backend_herdr_cli "$SESSION" pane process-info --pane "$PANE" 2>/dev/null || true)
  printf '%s' "$info" | jq -e '.result.process_info as $p
    | ($p.foreground_processes | length == 1)
      and ($p.foreground_processes[0].pid == $p.shell_pid)' >/dev/null 2>&1 && break
  sleep 0.1
done

# The pane fixture: exactly what a live, idle claude composer renders through
# herdr - a labelled upper rule, the bare agent glyph padded with U+00A0, a bare
# lower rule, and a multi-row statusline below it.
FIXTURE=/tmp/fm-claude-composer-fixture.sh
cat > "$FIXTURE" <<'FIX'
#!/usr/bin/env bash
# A claude-shaped composer: registered as a real herdr agent (the identity the
# adapter's staleness gate consults), drawing the rule-framed, NBSP-padded idle
# row and echoing whatever a human types into it.
herdr pane report-agent "$HERDR_PANE_ID" --source fm-evidence --agent claude --state idle --session "$HERDR_SESSION" >/dev/null 2>&1
stty -echo -icanon min 1 time 0 2>/dev/null || true
_buf=
redraw() {
  printf '\r\033[K\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80 fm-evidence-claude \xe2\x94\x80\xe2\x94\x80\n'
  printf '\033[K\xe2\x9d\xaf\xc2\xa0%s\n' "$_buf"
  printf '\033[K\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\n'
  printf '\033[K  eduard@valhalla:~/p  \xe2\x8e\x87 main  \xe2\x97\x86 Opus 5 \xc2\xb7 high\n'
  printf '\033[K  ctx 17%%  \xc2\xb7  5h 93%% 4h37m  \xc2\xb7  wk 25%% 3d01h Fri\n'
  printf '\033[K  \xe2\x8f\xb5\xe2\x8f\xb5 auto mode on \xc2\xb7 1 shell \xc2\xb7 \xe2\x86\x90 for agents'
  printf '\033[5A\r'
}
submit_line() {
  [ -n "$_buf" ] || { redraw; return; }
  printf '%s\n' "$_buf" >> "$LOG"
  _buf=
  redraw
  herdr pane report-agent "$HERDR_PANE_ID" --source fm-evidence --agent claude --state working --session "$HERDR_SESSION" >/dev/null 2>&1
  sleep 0.6
  herdr pane report-agent "$HERDR_PANE_ID" --source fm-evidence --agent claude --state idle --session "$HERDR_SESSION" >/dev/null 2>&1
}
printf '\033[2J\033[H'
printf '  \xe2\x8e\xbf  Tip: Use /theme to change the color theme\n\n'
redraw
while IFS= read -r -n 1 _ch; do
  case "$_ch" in
    ''|$'\r'|$'\n') submit_line ;;
    $'\177'|$'\b') _buf=${_buf%?}; redraw ;;
    *) _buf="${_buf}${_ch}"; redraw ;;
  esac
done
FIX
chmod +x "$FIXTURE"
STATE_DIR=$(mktemp -d "${TMPDIR:-/tmp}/fm-claude-composer-evidence.XXXXXX")
LOG="$STATE_DIR/submitted.log"
: > "$LOG"
fm_backend_herdr_send_text_line "$TARGET" "LOG='$LOG' bash '$FIXTURE'" || exit 1
sleep 2

{
  echo "=== Live herdr pane, exactly as a user sees an idle claude harness ==="
  echo
  fm_backend_herdr_capture_ansi "$TARGET" 40 | fm_composer_strip_ansi | sed -e 's/\r//' -e '/^$/d'
  echo
  echo "=== The composer row's raw bytes (U+00A0 = c2 a0, not [[:space:]]) ==="
  fm_backend_herdr_capture_ansi "$TARGET" 40 | fm_composer_strip_ansi | tr -d '\r' \
    | grep -a $'\342\235\257' | head -1 | od -An -tx1z | sed 's/^/  /'
  echo
  echo "=== Away-mode composer verdict on that same live pane ==="
} > "$OUT"

classify() {  # <tree>
  bash -c '. "$1/bin/backends/herdr.sh"; fm_backend_herdr_composer_state "$2"' _ "$1" "$TARGET" 2>/dev/null
}
BEFORE=$(HERDR_SESSION="$SESSION" classify "$BASE_ROOT")
AFTER=$(HERDR_SESSION="$SESSION" classify "$ROOT")

{
  printf '  base   c8edff3 (before the fix): composer_state = %s\n' "$BEFORE"
  printf '  target 8ef7e80 (after the fix):  composer_state = %s\n' "$AFTER"
  echo
  echo "The away-mode injector delivers only on 'empty' and defers on anything else,"
  echo "so 'unknown' is the state that held every escalation back overnight."
  echo
  echo "=== Same live pane with a human's half-typed line in the composer ==="
} >> "$OUT"

fm_backend_herdr_send_literal "$TARGET" "half typed answer" >/dev/null 2>&1 || true
sleep 1
TYPED=$(HERDR_SESSION="$SESSION" classify "$ROOT")
{
  fm_backend_herdr_capture_ansi "$TARGET" 40 | fm_composer_strip_ansi | tr -d '\r' | grep -a $'\342\235\257' | head -1 | sed 's/^/  /'
  printf '  target 8ef7e80: composer_state = %s  (injection still deferred)\n' "$TYPED"
} >> "$OUT"


# --- the actual end-user outcome: does away mode deliver the escalation? -----
# Same live pane, same idle claude composer, the real away-mode daemon from each
# tree. This is what the captain experienced overnight: a buffered escalation
# that never arrived.
fm_backend_herdr_send_key "$TARGET" Enter >/dev/null 2>&1 || true
sleep 1.5
: > "$LOG"

. "$ROOT/bin/fm-supervise-daemon.sh"

run_away_mode() {  # <tree> <label>
  local tree=$1 label=$2 pid waited
  rm -rf "$STATE_DIR/.supervise-daemon.log" "$STATE_DIR/fake-c1.status" "$STATE_DIR/.subsuper"* 2>/dev/null || true
  : > "$LOG"
  afk_enter "$STATE_DIR"
  HERDR_SESSION="$SESSION" \
  FM_STATE_OVERRIDE="$STATE_DIR" \
  FM_SUPERVISOR_BACKEND=herdr \
  FM_SUPERVISOR_TARGET="$TARGET" \
  FM_ESCALATE_BATCH_SECS=0 \
  FM_HOUSEKEEPING_TICK=1 \
  FM_POLL=1 \
  FM_SIGNAL_GRACE=1 \
  FM_HEARTBEAT=999999 \
  FM_CHECK_INTERVAL=999999 \
  FM_INJECT_CONFIRM_SLEEP=0.5 \
  FM_INJECT_CONFIRM_RETRIES=6 \
  FM_STALE_ESCALATE_SECS=999999 \
  nohup "$tree/bin/fm-supervise-daemon.sh" >"$STATE_DIR/daemon.out" 2>"$STATE_DIR/daemon.err" &
  pid=$!
  waited=0
  while [ "$waited" -lt 25 ]; do
    grep -q . "$LOG" 2>/dev/null && break
    sleep 1
    waited=$((waited + 1))
    [ "$waited" -eq 3 ] && echo "done: PR https://example.test/pr/500" > "$STATE_DIR/fake-c1.status"
  done
  {
    printf '\n=== Away mode with the %s tree, %ss after the crewmate reported done ===\n' "$label" "$waited"
    if grep -q . "$LOG" 2>/dev/null; then
      echo "  DELIVERED into the claude composer:"
      sed 's/^/    /' "$LOG"
    else
      echo "  NOTHING DELIVERED - the escalation is still buffered in the daemon:"
      grep -a 'inject deferred\|composer' "$STATE_DIR/.supervise-daemon.log" 2>/dev/null | tail -3 | sed 's/^/    /'
    fi
  } >> "$OUT"
  afk_exit "$STATE_DIR"
  kill "$pid" 2>/dev/null || true
  wait "$pid" 2>/dev/null || true
  sleep 1
  grep -q . "$LOG" 2>/dev/null
}

run_away_mode "$BASE_ROOT" "base c8edff3 (before the fix)" && BASE_DELIVERED=1 || BASE_DELIVERED=0
run_away_mode "$ROOT" "target 8ef7e80 (after the fix)" && TARGET_DELIVERED=1 || TARGET_DELIVERED=0

cat "$OUT"
rm -rf "$STATE_DIR"
[ "$BEFORE" = unknown ] && [ "$AFTER" = empty ] && [ "$TYPED" = pending ] \
  && [ "$BASE_DELIVERED" = 0 ] && [ "$TARGET_DELIVERED" = 1 ]
```
</details>
- Outcome: 🔧 2 issues found → auto-fixed ✅ across 2 runs (20m40s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 4 issues found → auto-fixed (2) ✅</summary>

- ℹ️ `bin/backends/herdr.sh:2595` - The new lone-trailing-rule branch reads native identity (`herdr agent get` + `jq`, an extra CLI round trip) even when `found` is already 0, where every case arm can only re-assert `found=0`. Gate the elif on `[ &#34;$found&#34; -eq 1 ]` as well - behavior-identical, and it drops one CLI+jq invocation per composer poll on every pane whose tail ends in a rule with no recognized composer row above it (the common no-composer-row-found case, hit on every daemon cycle).
- ℹ️ `docs/verification/runtime-backends.md:392` - .agents/skills/firstmate-coding-guidelines makes docs/verification/runtime-backends.md the owner of per-harness rendered-surface evidence (&#34;update the corresponding verification evidence when behavior changes&#34;, &#34;Record the dated per-harness result in docs/verification/runtime-backends.md&#34;). The &#34;Composer and operational input&#34; bullets still say only &#34;Claude and Codex use bare ❯ and › agent composers&#34; and &#34;Pi uses content between complete separator rows&#34;; the two newly verified real-capture distinctions this change relies on - claude&#39;s idle composer padding with U+00A0, and a lone trailing rule invalidating a generic match only on a Pi or unidentifiable pane - are not recorded there. The intent scopes docs to a one-line addition in docs/herdr-backend.md, so this is the author&#39;s call.
- ℹ️ `bin/backends/herdr.sh:2449` - FM_BACKEND_HERDR_COMPOSER_LINES 20 -&gt; 40 doubles the tail the structural scan accepts a composer row from, and the scan has no requirement that the match be near the live bottom of the pane. For claude this is now safer than before (its trailing rule plus the new identity gate turns a dead pane into `unknown`), but for a harness with no trailing rule - codex&#39;s bare `›` - a stale render left on screen after the agent exits to its login shell now wins from 21-40 rows up and classifies `empty`, so the daemon types and submits the escalation into a shell. Same class of exposure existed at 20 rows when the exit output was shorter; the window increase widens it. Adopted deliberately from upstream #1322, so flagging the tradeoff rather than the value.
- ℹ️ `tests/fm-afk-inject-herdr-e2e.test.sh:628` - Scenario E calls reset_state while the daemon is still running (Scenarios A-D and the tmux e2e sibling only ever reset before start_daemon). reset_state removes .subsuper-* and .watch.lock*, i.e. the running daemon&#39;s escalation buffer and its watcher singleton lock. The deferral is then proven only by the absence of &#39;Supervisor escalate&#39; in LOG_FILE, so if that state removal disturbed the daemon into not escalating at all, the assertion passes vacuously and the second half of the scenario stops testing anything. Add positive proof - grep .supervise-daemon.log for &#39;inject deferred: supervisor composer not confirmed-empty&#39; - and a `kill -0 &#34;$DAEMON_PID&#34;` liveness check as Scenario D does.

🔧 Fix: gate identity read on found; assert scenario E defer
2 infos still open:
- ℹ️ `docs/verification/runtime-backends.md:392` - Carried forward from round 1, still unaddressed (author&#39;s call, not auto-fixable). .agents/skills/firstmate-coding-guidelines makes docs/verification/runtime-backends.md the owner of per-harness rendered-surface evidence (&#34;update the corresponding verification evidence when behavior changes&#34;, &#34;Record the dated per-harness result in docs/verification/runtime-backends.md&#34;). The &#34;Composer and operational input&#34; bullets still say only &#34;Claude and Codex use bare ❯ and › agent composers&#34; and &#34;Pi uses content between complete separator rows&#34;; the two newly verified real-capture distinctions this change relies on - claude&#39;s idle composer padding with U+00A0, and a lone trailing rule invalidating a generic match only on a Pi or unidentifiable pane - are not recorded there. The intent scopes docs to a one-line addition in docs/herdr-backend.md.
- ℹ️ `bin/backends/herdr.sh:2449` - Carried forward from round 1, still unaddressed (deliberate adopted value, not auto-fixable). FM_BACKEND_HERDR_COMPOSER_LINES 20 -&gt; 40 doubles the tail the structural scan accepts a composer row from, and the scan has no requirement that the match be near the live bottom of the pane. For claude this is now safer than before (its trailing rule plus the new identity gate turns a dead pane into `unknown`), but for a harness with no trailing rule - codex&#39;s bare `›` - a stale render left on screen after the agent exits to its login shell can now win from 21-40 rows up and classify `empty`, so the daemon types and submits the escalation into a shell. The same class of exposure existed at 20 rows when the exit output was shorter; the window increase widens it. Adopted deliberately from upstream #1322, so this flags the tradeoff rather than the value.

🔧 Fix: record claude composer evidence in runtime-backends verification
✅ Re-checked - no issues remain.

</details>

<details>
<summary>🔧 **Test** - 2 issues found → auto-fixed ✅</summary>

- ⚠️ `tests/fm-afk-inject-herdr-e2e.test.sh:637` - Fixed a real defect in the new Scenario E of `tests/fm-afk-inject-herdr-e2e.test.sh`: after the scenario&#39;s mid-run `reset_state`, the daemon&#39;s watcher exits cleanly and waits 5 seconds before restarting, so the fixed `sleep 6` frequently expired before any injection decision was logged and the `inject deferred: supervisor composer not confirmed-empty` assertion failed even though the product behaved correctly (the daemon never injected over the human&#39;s text). Replaced the sleep with a bounded poll for the actual decision - the deferral record or a delivery line, whichever lands first - and made the failure path dump the daemon log tail. Product code is untouched. Confirmed by `[2026-08-04T12:44:17+0200] watcher exited rc=0 reason=&#39;&#39;; restarting after 5s` in the failing run&#39;s daemon log.
- ℹ️ `tests/fm-afk-inject-herdr-e2e.test.sh` - One stopped leftover herdr lab session, `fm-lab-afk-herdr-e2e-505591`, remains from the run I invalidated by clobbering the source files; it is stopped, outside the worktree, and harmless, but worth deleting with `herdr session delete fm-lab-afk-herdr-e2e-505591` once no e2e run is active. I did not delete it myself because a run was still in flight and the boundary rules keep me out of unrelated system state.
- <code>`bash tests/fm-composer-lib.test.sh` - passes, including `test_invisible_padding_after_an_agent_glyph_is_empty`, `test_invisible_padding_alone_is_empty`, `test_invisible_padding_never_swallows_real_text`, `test_invisible_padding_keeps_the_dead_shell_refusal`</code>
- <code>`bash tests/fm-backend-herdr.test.sh` - passes, including `test_composer_state_claude_rule_framed_idle_is_empty`, `test_composer_state_claude_rule_framed_real_text_is_pending`, `test_composer_state_lone_rule_still_refuses_pi_and_unreadable`</code>
- <code>Manual base-vs-fix verification: `bash /tmp/no-mistakes-evidence/01KZ64M81F42Q0GS0PVC87VSF5/compare-base-vs-fix.sh` - runs `fm_backend_herdr_composer_state` over the recorded live-Claude pane against base commit c8edff3 sources and against this change, for four identity/content cases</code>
- <code>`FM_E2E_ONLY_E=1 bash tests/fm-afk-inject-herdr-e2e.test.sh` (temporary scaffold, since removed) - isolated real-herdr run of `test_scenario_e_claude_shape`: fails on the pre-fix fixed sleep, passes after the poll fix</code>
- <code>`bash tests/fm-afk-inject-herdr-e2e.test.sh` - full real-herdr run; Scenarios A-D green on an earlier complete run, final confirmation run still in progress at report time</code>
- <code>`git status --porcelain` - only the intended `tests/fm-afk-inject-herdr-e2e.test.sh` timing fix is left in the worktree; the two `bin/` files my evidence script clobbered were restored</code>

🔧 Fix: poll for injection decision in herdr e2e scenario E
✅ Re-checked - no issues remain.
- <code>`bash tests/fm-composer-lib.test.sh` - all pass, including the four new invisible-padding cases (`test_invisible_padding_after_an_agent_glyph_is_empty`, `test_invisible_padding_alone_is_empty`, `test_invisible_padding_never_swallows_real_text`, `test_invisible_padding_keeps_the_dead_shell_refusal`)</code>
- <code>`bash tests/fm-backend-herdr.test.sh` - exit 0, 162 assertions, including `test_composer_state_claude_rule_framed_idle_is_empty`, `test_composer_state_claude_rule_framed_real_text_is_pending`, `test_composer_state_lone_rule_still_refuses_pi_and_unreadable`</code>
- <code>`bash tests/fm-afk-inject-herdr-e2e.test.sh` - exit 0, real herdr 0.7.5 in an isolated lab session, Scenarios A-E all pass including the new Scenario E (claude&#39;s rule-framed NBSP-padded composer)</code>
- <code>Manual live-herdr before/after demo (`/tmp/no-mistakes-evidence/01KZ64M81F42Q0GS0PVC87VSF5/live-claude-composer-away-mode-evidence.sh`): drew claude&#39;s real idle composer shape in an isolated herdr pane registered as a native agent, then classified that same live pane with the base tree (`git archive c8edff36`) and the target tree</code>
- <code>Manual end-to-end away-mode run against that live pane: started the real `bin/fm-supervise-daemon.sh` from the base tree and from the target tree with `FM_SUPERVISOR_BACKEND=herdr`, wrote a crewmate `done:` status, and recorded what reached the composer in each case</code>
- <code>Verified injection-safety invariants on the live pane: `fm_backend_herdr_send_literal` typed text still classifies `pending`, and the unit cases confirm Pi / unreadable identity still classify `unknown`</code>
- <code>Cleanup checks: `herdr session list` shows only `default` (no leftover lab sessions), `git status --short` clean, transient base tree and fixture removed</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
