### PR TITLE
fix: preserve task worktrees across relaunches

### DIFF
--- a/.agents/skills/stuck-crewmate-recovery/SKILL.md
+++ b/.agents/skills/stuck-crewmate-recovery/SKILL.md
@@ -29,7 +29,7 @@ When no authoritative run accounts for the task, inspect only its recorded backe
 Use `treehouse status` for treehouse-backed tmux, herdr, zellij, or cmux tasks, and use the recorded `orca_worktree_id=` and `terminal=` for Orca tasks.
 Do not sweep another home's endpoints or infer ownership from a matching window label.
 
-Before relaunch, prove that no live agent still owns the recorded task and that the existing worktree remains available.
+Before relaunch, prove that no live agent still owns the recorded task and that Treehouse reports the recorded worktree as leased under that task id.
 Preserve its uncommitted changes and commits, keep the same task identity, and resume or relaunch the recorded harness in that existing worktree with the same brief plus a concise progress note.
 Do not use a fresh generic spawn while the recorded worktree is unaccounted for, because allocating another worktree can split one task across two copies.
 If the worktree or ownership cannot be reconciled safely, leave all state intact and report the task failed or blocked with the conflicting evidence.

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Launching a supported harness inside it instantiates your first mate - and makes
 
 - **One liaison** - you talk only to the first mate; it dispatches, supervises, escalates only real decisions, and reports plain outcomes.
 - **A visible crew** - every crewmate works in its own tmux window, experimental herdr/zellij tab, cmux workspace, or Orca terminal you can watch or type into; the first mate reconciles.
-- **Disposable worktrees** - each task runs in a clean [treehouse](https://github.com/kunchenguid/treehouse) git worktree, or an Orca-managed worktree when `backend=orca`, so parallel work on one repo never collides.
+- **Disposable worktrees** - each task runs in a clean [treehouse](https://github.com/kunchenguid/treehouse) git worktree, leased through restarts until guarded teardown, or an Orca-managed worktree when `backend=orca`, so parallel work on one repo never collides and recovery preserves in-flight work.
 - **Two task shapes** - ship tasks deliver authorized changes; scout tasks leave standalone investigation reports when the intake contract warrants separate research.
 - **Explicit project modes** - each project ships via `no-mistakes`, `direct-PR`, or `local-only`, with an optional `+yolo` autonomy flag.
 - **Optional secondmates** - opt in to persistent second mates that run from isolated firstmate homes with their own `FM_HOME`, state, projects, and session lock, either locally or as a whole home on an SSH-reachable host, with guarded updates and recovery that never turns an unavailable remote route into a local replacement.

--- a/bin/backends/cmux.sh
+++ b/bin/backends/cmux.sh
@@ -36,7 +36,7 @@
 #      (herdr-shape): `workspace list`'s `current_directory` field reflects a
 #      `cd` run directly in the surface's own top-level shell, but stays
 #      frozen at wherever that shell was when it launched a foreground
-#      subshell (exactly what `treehouse get` does) - verified live: a nested
+#      subshell - verified live: a nested
 #      `bash -c 'cd /Users && exec bash'` left `current_directory` reporting
 #      the PARENT shell's last cwd, never following into the subshell. Fixed
 #      with zellij's own pwd-marker-probe workaround, reused verbatim in
@@ -437,14 +437,13 @@ fm_backend_cmux_target_ready() {  # <target> [expected-label]
 #
 # Verified pitfall (finding #2 above): cmux's `current_directory` field DOES
 # reflect a `cd` run directly in the surface's own top-level shell, but stays
-# FROZEN at whatever directory that shell was in when it launched `treehouse
-# get` as a foreground command - it never follows that command's own internal
-# `cd` into the acquired worktree. cmux's control socket exposes no
+# FROZEN at whatever directory that shell was in when it launched a foreground
+# subshell - it never follows that process's own internal `cd`. cmux's control socket exposes no
 # live-process cwd field either (unlike herdr's `foreground_cwd`), so passive
 # polling cannot solve this here any more than it could for zellij. Active
 # probe instead: print the surface's `$PWD` with a unique marker (atomically
 # submitted via send_text_line), briefly settle, then capture and read only
-# that marker line. Scoped to fm-spawn.sh's own worktree-discovery poll loop.
+# that marker line. Scoped to fm-spawn.sh's own worktree-settlement poll loop.
 fm_backend_cmux_current_path() {  # <target> [expected-label]
   local target=$1 expected_label=${2:-} out line marker_begin="__FM_CMUX_CWD_BEGIN__" marker_end="__FM_CMUX_CWD_END__" in_block=0 chunk="" last=""
   fm_backend_cmux_target_ready "$target" "$expected_label" || return 0

--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -2274,17 +2274,17 @@ fm_backend_herdr_target_ready() {  # <target>
 }
 
 # fm_backend_herdr_current_path: the live FOREGROUND process's cwd, or empty on
-# any error. Mirrors tmux's pane_current_path poll used for worktree-path
-# discovery after `treehouse get`.
+# any error. Mirrors tmux's pane_current_path poll used to verify that spawn's
+# explicit top-level cd settled in the leased worktree.
 #
 # Verified pitfall: `pane get`'s `.result.pane.cwd` is the pane's cwd AT
 # CREATION TIME - the top-level shell's cwd - and does NOT update when that
-# shell `cd`s or enters a subshell (as `treehouse get` does). Reading it here
-# would make fm-spawn.sh's worktree-discovery poll never see the pane "leave"
-# the project directory, since `cwd` stays frozen at the original path forever.
+# shell `cd`s or enters a subshell. Reading it here would make fm-spawn.sh's
+# worktree-settlement poll miss the top-level shell's move from the project
+# directory, since `cwd` stays frozen at the original path forever.
 # `.result.pane.foreground_cwd` tracks the ACTUALLY RUNNING foreground
-# process's cwd instead, which is what changes when `treehouse get` enters its
-# worktree subshell - confirmed live against a real treehouse acquisition.
+# process's cwd instead, including the explicit spawn-time `cd`; its nested
+# process behavior was also confirmed live against a real treehouse acquisition.
 fm_backend_herdr_current_path() {  # <target>
   fm_backend_herdr_target_ready "$1" || return 0
   fm_backend_herdr_cli "$FM_BACKEND_HERDR_SESSION" pane get "$FM_BACKEND_HERDR_PANE" 2>/dev/null \
@@ -2293,7 +2293,7 @@ fm_backend_herdr_current_path() {  # <target>
 
 # fm_backend_herdr_send_text_line: send one line of TEXT then submit,
 # ATOMICALLY - mirrors tmux's `send-keys -t T text Enter`. Used for the fixed
-# spawn-time commands (treehouse get, the GOTMPDIR export). `pane run` types
+# spawn-time commands (the worktree cd, the GOTMPDIR export). `pane run` types
 # the command and submits it in one call (verified).
 fm_backend_herdr_send_text_line() {  # <target> <text>
   fm_backend_herdr_target_ready "$1" || return 1

--- a/bin/backends/tmux.sh
+++ b/bin/backends/tmux.sh
@@ -8,8 +8,8 @@
 # default (tmux, `backend=` absent) path stays byte-identical. Sourced only
 # through bin/fm-backend.sh's fm_backend_source, never directly.
 #
-# Worktree acquisition (running `treehouse get` inside the pane, and polling
-# its cwd) is unchanged by this extraction: P1 scopes only the session
+# Worktree acquisition (leasing the task worktree, cd'ing the pane into it, and
+# polling its cwd) is unchanged by this extraction: P1 scopes only the session
 # provider, not the worktree provider, so fm-spawn.sh still drives that part
 # inline with these same send/current-path primitives.
 #
@@ -81,7 +81,7 @@ fm_backend_tmux_container_ensure() {
 #     ("$ses:"), so a non-default base-index (e.g. base-index 1) cannot collide.
 #   - PIN the window name by disabling automatic-rename and allow-rename on the
 #     new window: the captain's tmux may rename the window away from fm-<id> once
-#     treehouse cd's into the worktree, which would break name-based targeting.
+#     the pane cd's into the worktree, which would break name-based targeting.
 # The returned window id lets callers target the window even if its name is ever
 # lost, so worktree discovery cannot fall back to the active client's window.
 fm_backend_tmux_create_task() {  # <session> <window-name> <proj-abs> -> prints window id
@@ -105,7 +105,7 @@ fm_backend_tmux_current_path() {  # <target>
 
 # fm_backend_tmux_send_text_line: send one line of TEXT then Enter, with no
 # composer verification - used for the fixed spawn-time commands
-# (`treehouse get`, the GOTMPDIR export) that already ran this exact sequence
+# (the worktree cd, the GOTMPDIR export) that already ran this exact sequence
 # inline in fm-spawn.sh. Mirrors `tmux send-keys -t "$T" "<text>" Enter`.
 fm_backend_tmux_send_text_line() {  # <target> <text>
   tmux send-keys -t "$1" "$2" Enter

--- a/bin/backends/tmux.sh
+++ b/bin/backends/tmux.sh
@@ -83,7 +83,7 @@ fm_backend_tmux_container_ensure() {
 #     new window: the captain's tmux may rename the window away from fm-<id> once
 #     the pane cd's into the worktree, which would break name-based targeting.
 # The returned window id lets callers target the window even if its name is ever
-# lost, so worktree discovery cannot fall back to the active client's window.
+# lost, so worktree settlement cannot fall back to the active client's window.
 fm_backend_tmux_create_task() {  # <session> <window-name> <proj-abs> -> prints window id
   local ses=$1 wname=$2 proj_abs=$3 wid
   if tmux list-windows -t "$ses" -F '#{window_name}' | grep -qx "$wname"; then
@@ -97,7 +97,7 @@ fm_backend_tmux_create_task() {  # <session> <window-name> <proj-abs> -> prints 
 }
 
 # fm_backend_tmux_current_path: the live pane's current working directory, or
-# empty on any tmux error. Mirrors fm-spawn.sh's worktree-discovery poll:
+# empty on any tmux error. Mirrors fm-spawn.sh's worktree-settlement poll:
 # `tmux display-message -p -t "$T" '#{pane_current_path}'`.
 fm_backend_tmux_current_path() {  # <target>
   tmux display-message -p -t "$1" '#{pane_current_path}' 2>/dev/null

--- a/bin/backends/zellij.sh
+++ b/bin/backends/zellij.sh
@@ -53,16 +53,15 @@
 #   4. `list-panes --json`'s `pane_cwd` reflects a `cd` run DIRECTLY in the
 #      pane's own top-level shell within one poll (<0.3s) - but does NOT
 #      reflect a `cd` performed by a NESTED SUBSHELL the pane's shell
-#      launched as a foreground command (verified: `treehouse get` opens
-#      exactly such a subshell). `pane_cwd` stays frozen at wherever the
+#      launched as a foreground command. `pane_cwd` stays frozen at wherever the
 #      pane's shell was when it invoked that foreground command - worse than
 #      herdr's frozen-cwd trap (herdr at least exposes a `foreground_cwd`
 #      that tracks this; zellij's CLI exposes no live-process cwd field and
 #      no per-pane pid to read it from `/proc`/`lsof` either). This directly
 #      contradicts the design report's assumption ("acceptable for tmux and
-#      zellij") and required a different implementation strategy - see
+#      zellij") and established the active-probe implementation strategy - see
 #      fm_backend_zellij_current_path below and docs/zellij-backend.md
-#      "Worktree-path discovery: pane_cwd does not track a subshell".
+#      "Current operation and safety".
 #   5. `new-tab` DOES steal focus from an attached client with NO flag to
 #      suppress it (unlike herdr's --no-focus and tmux's new-window -d).
 #      Mitigated (fm_backend_zellij_create_task): capture the previously
@@ -382,21 +381,21 @@ fm_backend_zellij_target_ready() {  # <target> [expected-label]
 }
 
 # fm_backend_zellij_current_path: the live pane's cwd, or empty on any error.
-# Mirrors tmux's pane_current_path poll used for worktree-path discovery after
-# `treehouse get`.
+# Mirrors tmux's pane_current_path poll used to verify that spawn's explicit
+# top-level cd settled in the leased worktree.
 #
-# Verified pitfall (docs/zellij-backend.md "Worktree-path discovery: pane_cwd
-# does not track a subshell"): `list-panes --json`'s `pane_cwd` DOES reflect a
+# Verified pitfall (docs/zellij-backend.md "Current operation and safety"):
+# `list-panes --json`'s `pane_cwd` DOES reflect a
 # `cd` run directly in the pane's own top-level shell, but stays FROZEN at
-# whatever directory the pane's shell was in when it launched `treehouse get`
-# as a foreground command - it never follows that command's own internal `cd`
-# into the acquired worktree, even after the subshell is fully interactive and
+# whatever directory the pane's shell was in when it launched a foreground
+# subshell - it never follows that process's own internal `cd`, even after the
+# subshell is fully interactive and
 # a `pwd` typed into it prints the correct live path on screen. Zellij's CLI
 # exposes no per-pane pid and no live-process cwd field to read instead
 # (unlike herdr's `foreground_cwd`), so passive JSON polling cannot solve
 # this. Active probe instead: print the pane's `$PWD` with a unique marker
 # (atomically submitted, mirroring send_text_line), briefly settle, then capture
-# and read only that marker line. Scoped to fm-spawn.sh's own worktree-discovery
+# and read only that marker line. Scoped to fm-spawn.sh's own worktree-settlement
 # poll loop (the only caller of this op), where injecting a harmless extra
 # command before the harness ever launches is an acceptable trade for a reliable
 # answer.

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1292,7 +1292,15 @@ try {
   process.exit(2);
 }
 if (!Array.isArray(entries)) process.exit(2);
-process.exit(entries.some((entry) => entry?.path === path && entry?.status === "leased" && entry?.lease_holder === holder) ? 0 : 1);
+const canonical = (value) => {
+  try {
+    return fs.realpathSync(value);
+  } catch {
+    return value;
+  }
+};
+const expectedPath = canonical(path);
+process.exit(entries.some((entry) => canonical(entry?.path) === expectedPath && entry?.status === "leased" && entry?.lease_holder === holder) ? 0 : 1);
 ' "$path" "$ID"
   rc=$?
   set -e

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1278,6 +1278,27 @@ real_path_or_raw() {  # <path>
   fi
 }
 
+treehouse_lease_matches_task() {
+  local path=$1 status rc
+  status=$(cd "$PROJ_ABS" && treehouse status --json 2>/dev/null) || return 2
+  set +e
+  printf '%s' "$status" | node -e '
+const fs = require("fs");
+const [path, holder] = process.argv.slice(1);
+let entries;
+try {
+  entries = JSON.parse(fs.readFileSync(0, "utf8"));
+} catch {
+  process.exit(2);
+}
+if (!Array.isArray(entries)) process.exit(2);
+process.exit(entries.some((entry) => entry?.path === path && entry?.status === "leased" && entry?.lease_holder === holder) ? 0 : 1);
+' "$path" "$ID"
+  rc=$?
+  set -e
+  return "$rc"
+}
+
 # Session-provider container-ensure + task creation. tmux stays exactly as P1
 # left it (same session-name / new-window sequence, see bin/backends/tmux.sh);
 # a herdr spawn goes through the version-gated, workspace-per-HOME,
@@ -1721,16 +1742,31 @@ if [ "$KIND" != secondmate ] && [ "$BACKEND" != orca ]; then
   # subshell, so cd the pane into it explicitly. The settle poll below still
   # confirms the pane actually moved and validate_spawn_worktree still proves
   # the resulting worktree is isolated from the primary checkout.
-  LEASED_WT=$( cd "$PROJ_ABS" && treehouse get --lease --lease-holder "$ID" ) || {
-    echo "error: treehouse get --lease failed to lease a task worktree for $ID; inspect the pool under $PROJ_ABS" >&2
-    exit 1
-  }
-  [ -n "$LEASED_WT" ] || {
-    echo "error: treehouse get --lease reported no task worktree for $ID" >&2
-    exit 1
-  }
-  LEASED_WT=$(real_path_or_raw "$LEASED_WT")
-  TREEHOUSE_LEASE_ABORT_CLEANUP=1
+  RECORDED_WT=$(fm_backend_meta_exact_value "$STATE/$ID.meta" worktree 2>/dev/null || true)
+  if [ -n "$RECORDED_WT" ] && [ -d "$RECORDED_WT" ]; then
+    RECORDED_WT=$(real_path_or_raw "$RECORDED_WT")
+    if treehouse_lease_matches_task "$RECORDED_WT"; then
+      LEASED_WT=$RECORDED_WT
+    else
+      LEASE_MATCH_STATUS=$?
+      if [ "$LEASE_MATCH_STATUS" -eq 2 ]; then
+        echo "error: treehouse status could not validate the recorded task worktree lease for $ID" >&2
+        exit 1
+      fi
+    fi
+  fi
+  if [ -z "$LEASED_WT" ]; then
+    LEASED_WT=$( cd "$PROJ_ABS" && treehouse get --lease --lease-holder "$ID" ) || {
+      echo "error: treehouse get --lease failed to lease a task worktree for $ID; inspect the pool under $PROJ_ABS" >&2
+      exit 1
+    }
+    [ -n "$LEASED_WT" ] || {
+      echo "error: treehouse get --lease reported no task worktree for $ID" >&2
+      exit 1
+    }
+    LEASED_WT=$(real_path_or_raw "$LEASED_WT")
+    TREEHOUSE_LEASE_ABORT_CLEANUP=1
+  fi
   spawn_send_text_line "$WT_TARGET" "cd $(shell_quote "$LEASED_WT")"
 
   # Wait for the pane's cwd to move from the project into the leased worktree.

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1750,8 +1750,24 @@ if [ "$KIND" != secondmate ] && [ "$BACKEND" != orca ]; then
   # subshell, so cd the pane into it explicitly. The settle poll below still
   # confirms the pane actually moved and validate_spawn_worktree still proves
   # the resulting worktree is isolated from the primary checkout.
-  RECORDED_WT=$(fm_backend_meta_exact_value "$STATE/$ID.meta" worktree 2>/dev/null || true)
-  if [ -n "$RECORDED_WT" ] && [ -d "$RECORDED_WT" ]; then
+  RECORDED_WT_COUNT=0
+  if [ -f "$STATE/$ID.meta" ]; then
+    RECORDED_WT_COUNT=$(grep -c '^worktree=' "$STATE/$ID.meta" 2>/dev/null || true)
+  fi
+  if [ "$RECORDED_WT_COUNT" -gt 0 ]; then
+    if [ "$RECORDED_WT_COUNT" -ne 1 ]; then
+      echo "error: recorded task worktree metadata for $ID is ambiguous; refusing to acquire a replacement lease" >&2
+      exit 1
+    fi
+    RECORDED_WT=$(fm_backend_meta_exact_value "$STATE/$ID.meta" worktree 2>/dev/null || true)
+    if [ -z "$RECORDED_WT" ]; then
+      echo "error: recorded task worktree metadata for $ID is empty; refusing to acquire a replacement lease" >&2
+      exit 1
+    fi
+    if [ ! -d "$RECORDED_WT" ]; then
+      echo "error: recorded task worktree $RECORDED_WT for $ID does not exist; refusing to acquire a replacement lease" >&2
+      exit 1
+    fi
     RECORDED_WT=$(real_path_or_raw "$RECORDED_WT")
     if treehouse_lease_matches_task "$RECORDED_WT"; then
       LEASED_WT=$RECORDED_WT
@@ -1761,9 +1777,11 @@ if [ "$KIND" != secondmate ] && [ "$BACKEND" != orca ]; then
         echo "error: treehouse status could not validate the recorded task worktree lease for $ID" >&2
         exit 1
       fi
+      echo "error: recorded task worktree $RECORDED_WT is not leased under task id $ID; refusing to acquire a replacement lease" >&2
+      exit 1
     fi
   fi
-  if [ -z "$LEASED_WT" ]; then
+  if [ "$RECORDED_WT_COUNT" -eq 0 ]; then
     LEASED_WT=$( cd "$PROJ_ABS" && treehouse get --lease --lease-holder "$ID" ) || {
       echo "error: treehouse get --lease failed to lease a task worktree for $ID; inspect the pool under $PROJ_ABS" >&2
       exit 1

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -696,8 +696,9 @@ spawn_abort_cleanup() {
     fi
   fi
   # Release a task-worktree lease acquired by this aborting spawn so a failed
-  # launch never leaks a reserved pool slot. Only fires before the task is
-  # recorded (success clears the flag); mirrors the leased-home rollback path.
+  # launch does not silently leak a reserved pool slot. Only fires before the
+  # task is recorded (success clears the flag); a failed return warns that the
+  # lease may still be held. Mirrors the leased-home rollback path.
   if [ "$TREEHOUSE_LEASE_ABORT_CLEANUP" = 1 ] && [ -n "$LEASED_WT" ]; then
     TREEHOUSE_LEASE_ABORT_CLEANUP=0
     ( cd "$PROJ_ABS" && treehouse return --force "$LEASED_WT" ) >/dev/null 2>&1 \

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1729,6 +1729,7 @@ if [ "$KIND" != secondmate ] && [ "$BACKEND" != orca ]; then
     echo "error: treehouse get --lease reported no task worktree for $ID" >&2
     exit 1
   }
+  LEASED_WT=$(real_path_or_raw "$LEASED_WT")
   TREEHOUSE_LEASE_ABORT_CLEANUP=1
   spawn_send_text_line "$WT_TARGET" "cd $(shell_quote "$LEASED_WT")"
 
@@ -1741,15 +1742,12 @@ if [ "$KIND" != secondmate ] && [ "$BACKEND" != orca ]; then
   # prefix would otherwise make the pane's OS-level cwd read differ from
   # PROJ_ABS on the very first poll, before the pane has actually moved.
   #
-  # A single read that already differs from PROJ_ABS_REAL is not proof the pane
+  # A single read that already matches LEASED_WT is not proof the pane
   # settled there: on some tmux/WSL setups a brand-new window's pane_current_path
   # transiently reports an unrelated stale path (seen live as another real git
-  # checkout entirely) before the shell catches up with treehouse get's cd. That
-  # stale path still passes the PROJ_ABS_REAL comparison and validate_spawn_worktree
-  # below (it resolves to a real, distinct worktree top-level too), so accepting it
-  # on one read alone silently records the wrong worktree= in state/<id>.meta. Require
-  # two consecutive reads to agree on the same non-project path before accepting it;
-  # a mismatch just becomes the new candidate rather than resetting the wait, so a
+  # checkout entirely) before the shell catches up with the explicit cd. Require
+  # two consecutive reads of the canonical leased path before accepting it. An
+  # unrelated path can never become the candidate, even when it persists, and a
   # pane that is already settled by the first real read only costs the one existing
   # inter-poll sleep as confirmation, not a whole extra cycle on top.
   candidate=""
@@ -1757,7 +1755,7 @@ if [ "$KIND" != secondmate ] && [ "$BACKEND" != orca ]; then
     p=$(spawn_current_path "$WT_TARGET" || true)
     if [ -n "$p" ]; then
       p_real=$(real_path_or_raw "$p")
-      if [ "$p_real" != "$PROJ_ABS_REAL" ]; then
+      if [ "$p_real" = "$LEASED_WT" ]; then
         if [ -n "$candidate" ] && [ "$p_real" = "$candidate" ]; then
           WT="$p"
           break

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1409,6 +1409,52 @@ herdr_projection_existing_meta_allows_flat() {  # <meta>
   esac
 }
 
+if [ "$KIND" != secondmate ] && [ "$BACKEND" != orca ]; then
+  RECORDED_WT_COUNT=0
+  if [ -f "$STATE/$ID.meta" ]; then
+    RECORDED_WT_COUNT=$(grep -c '^worktree=' "$STATE/$ID.meta" 2>/dev/null || true)
+  fi
+  if [ "$RECORDED_WT_COUNT" -gt 0 ]; then
+    if [ "$RECORDED_WT_COUNT" -ne 1 ]; then
+      echo "error: recorded task worktree metadata for $ID is ambiguous; refusing to acquire a replacement lease" >&2
+      exit 1
+    fi
+    RECORDED_WT=$(fm_backend_meta_exact_value "$STATE/$ID.meta" worktree 2>/dev/null || true)
+    if [ -z "$RECORDED_WT" ]; then
+      echo "error: recorded task worktree metadata for $ID is empty; refusing to acquire a replacement lease" >&2
+      exit 1
+    fi
+    if [ ! -d "$RECORDED_WT" ]; then
+      echo "error: recorded task worktree $RECORDED_WT for $ID does not exist; refusing to acquire a replacement lease" >&2
+      exit 1
+    fi
+    RECORDED_WT=$(real_path_or_raw "$RECORDED_WT")
+    if treehouse_lease_matches_task "$RECORDED_WT"; then
+      LEASED_WT=$RECORDED_WT
+    else
+      LEASE_MATCH_STATUS=$?
+      if [ "$LEASE_MATCH_STATUS" -eq 2 ]; then
+        echo "error: treehouse status could not validate the recorded task worktree lease for $ID" >&2
+        exit 1
+      fi
+      echo "error: recorded task worktree $RECORDED_WT is not leased under task id $ID; refusing to acquire a replacement lease" >&2
+      exit 1
+    fi
+  fi
+  if [ "$RECORDED_WT_COUNT" -eq 0 ]; then
+    LEASED_WT=$( cd "$PROJ_ABS" && treehouse get --lease --lease-holder "$ID" ) || {
+      echo "error: treehouse get --lease failed to lease a task worktree for $ID; inspect the pool under $PROJ_ABS" >&2
+      exit 1
+    }
+    [ -n "$LEASED_WT" ] || {
+      echo "error: treehouse get --lease reported no task worktree for $ID" >&2
+      exit 1
+    }
+    LEASED_WT=$(real_path_or_raw "$LEASED_WT")
+    TREEHOUSE_LEASE_ABORT_CLEANUP=1
+  fi
+fi
+
 W="fm-$ID"
 case "$BACKEND" in
   tmux)
@@ -1750,49 +1796,6 @@ if [ "$KIND" != secondmate ] && [ "$BACKEND" != orca ]; then
   # subshell, so cd the pane into it explicitly. The settle poll below still
   # confirms the pane actually moved and validate_spawn_worktree still proves
   # the resulting worktree is isolated from the primary checkout.
-  RECORDED_WT_COUNT=0
-  if [ -f "$STATE/$ID.meta" ]; then
-    RECORDED_WT_COUNT=$(grep -c '^worktree=' "$STATE/$ID.meta" 2>/dev/null || true)
-  fi
-  if [ "$RECORDED_WT_COUNT" -gt 0 ]; then
-    if [ "$RECORDED_WT_COUNT" -ne 1 ]; then
-      echo "error: recorded task worktree metadata for $ID is ambiguous; refusing to acquire a replacement lease" >&2
-      exit 1
-    fi
-    RECORDED_WT=$(fm_backend_meta_exact_value "$STATE/$ID.meta" worktree 2>/dev/null || true)
-    if [ -z "$RECORDED_WT" ]; then
-      echo "error: recorded task worktree metadata for $ID is empty; refusing to acquire a replacement lease" >&2
-      exit 1
-    fi
-    if [ ! -d "$RECORDED_WT" ]; then
-      echo "error: recorded task worktree $RECORDED_WT for $ID does not exist; refusing to acquire a replacement lease" >&2
-      exit 1
-    fi
-    RECORDED_WT=$(real_path_or_raw "$RECORDED_WT")
-    if treehouse_lease_matches_task "$RECORDED_WT"; then
-      LEASED_WT=$RECORDED_WT
-    else
-      LEASE_MATCH_STATUS=$?
-      if [ "$LEASE_MATCH_STATUS" -eq 2 ]; then
-        echo "error: treehouse status could not validate the recorded task worktree lease for $ID" >&2
-        exit 1
-      fi
-      echo "error: recorded task worktree $RECORDED_WT is not leased under task id $ID; refusing to acquire a replacement lease" >&2
-      exit 1
-    fi
-  fi
-  if [ "$RECORDED_WT_COUNT" -eq 0 ]; then
-    LEASED_WT=$( cd "$PROJ_ABS" && treehouse get --lease --lease-holder "$ID" ) || {
-      echo "error: treehouse get --lease failed to lease a task worktree for $ID; inspect the pool under $PROJ_ABS" >&2
-      exit 1
-    }
-    [ -n "$LEASED_WT" ] || {
-      echo "error: treehouse get --lease reported no task worktree for $ID" >&2
-      exit 1
-    }
-    LEASED_WT=$(real_path_or_raw "$LEASED_WT")
-    TREEHOUSE_LEASE_ABORT_CLEANUP=1
-  fi
   spawn_send_text_line "$WT_TARGET" "cd $(shell_quote "$LEASED_WT")"
 
   # Wait for the pane's cwd to move from the project into the leased worktree.

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -32,8 +32,8 @@
 #   then tmux.
 #   Spawn-capable backends are the reference tmux adapter and experimental
 #   herdr, zellij, orca, and cmux. Orca owns both the task worktree and
-#   terminal, so ship/scout Orca spawns do not run treehouse get; cmux is a
-#   session provider only, exactly like herdr/zellij, so it does. An
+#   terminal, so ship/scout Orca spawns do not lease a treehouse worktree; cmux
+#   is a session provider only, exactly like herdr/zellij, so it does. An
 #   auto-detected herdr or cmux spawn prints a loud stderr notice;
 #   auto-detected tmux stays silent; zellij and orca are never auto-detected.
 #   codex-app is not a known backend yet; docs/codex-app-backend.md owns that
@@ -614,6 +614,11 @@ fi
 ORCA_ABORT_CLEANUP=0
 ORCA_WORKTREE_ID=
 ORCA_TERMINAL=
+# Durable treehouse lease on the task worktree (see the acquisition site below).
+# The abort trap returns the lease only if the spawn aborts before the task is
+# recorded; on success it is cleared so the lease persists until teardown.
+TREEHOUSE_LEASE_ABORT_CLEANUP=0
+LEASED_WT=
 HERDR_PROJECTION_ABORT_CLEANUP=0
 HERDR_PROJECTION_ABORT_SESSION=
 HERDR_PROJECTION_ABORT_TASK_PANE=
@@ -689,6 +694,14 @@ spawn_abort_cleanup() {
         fi
       fi
     fi
+  fi
+  # Release a task-worktree lease acquired by this aborting spawn so a failed
+  # launch never leaks a reserved pool slot. Only fires before the task is
+  # recorded (success clears the flag); mirrors the leased-home rollback path.
+  if [ "$TREEHOUSE_LEASE_ABORT_CLEANUP" = 1 ] && [ -n "$LEASED_WT" ]; then
+    TREEHOUSE_LEASE_ABORT_CLEANUP=0
+    ( cd "$PROJ_ABS" && treehouse return --force "$LEASED_WT" ) >/dev/null 2>&1 \
+      || echo "warning: failed to release leased task worktree $LEASED_WT during spawn abort; lease may still be held" >&2
   fi
   if [ "$SPAWN_TASK_LOCK_HELD" = 1 ]; then
     SPAWN_TASK_LOCK_HELD=0
@@ -1694,9 +1707,32 @@ kimi_spawn_fail() {  # <detail>
 }
 
 if [ "$KIND" != secondmate ] && [ "$BACKEND" != orca ]; then
-  spawn_send_text_line "$WT_TARGET" 'treehouse get'
+  # Durably LEASE the task worktree under the task id, rather than a bare
+  # `treehouse get`. A bare get leaves the slot unleased, so after a crash or a
+  # stuck-crew relaunch the pool can hand the same slot back reset onto the
+  # default branch, losing the task's branch and in-flight commits - and then
+  # `no-mistakes axi respond`, which resolves the active run by the checked-out
+  # branch, can no longer find it. A lease reserves the slot (and its branch and
+  # commits) under this task id across restarts, skipped by any later
+  # get/prune, until teardown returns it; recovery re-binds to the SAME
+  # worktree. Mirrors the leased firstmate homes in bin/fm-home-seed.sh.
+  #
+  # The lease is non-interactive: it prints only the worktree path and opens no
+  # subshell, so cd the pane into it explicitly. The settle poll below still
+  # confirms the pane actually moved and validate_spawn_worktree still proves
+  # the resulting worktree is isolated from the primary checkout.
+  LEASED_WT=$( cd "$PROJ_ABS" && treehouse get --lease --lease-holder "$ID" ) || {
+    echo "error: treehouse get --lease failed to lease a task worktree for $ID; inspect the pool under $PROJ_ABS" >&2
+    exit 1
+  }
+  [ -n "$LEASED_WT" ] || {
+    echo "error: treehouse get --lease reported no task worktree for $ID" >&2
+    exit 1
+  }
+  TREEHOUSE_LEASE_ABORT_CLEANUP=1
+  spawn_send_text_line "$WT_TARGET" "cd $(shell_quote "$LEASED_WT")"
 
-  # Wait for the treehouse subshell: the pane's cwd moves from the project to the worktree.
+  # Wait for the pane's cwd to move from the project into the leased worktree.
   # Target the stable window id, not the name: if the name is ever lost (e.g. an
   # automatic-rename slips through), display-message -t <bad-name> falls back to the
   # active client's window, which would misread firstmate's OWN pane path as the
@@ -1736,11 +1772,11 @@ if [ "$KIND" != secondmate ] && [ "$BACKEND" != orca ]; then
     sleep 1
   done
   if [ -z "$WT" ]; then
-    echo "error: treehouse get did not enter a worktree within 60s; inspect window $T" >&2
+    echo "error: pane did not enter the leased task worktree within 60s; inspect window $T" >&2
     exit 1
   fi
 
-  validate_spawn_worktree "treehouse get" "$T"
+  validate_spawn_worktree "leased task worktree" "$T"
 fi
 
 # Per-task temp root: /tmp/fm-<id>/ with Go's build temp nested at gotmp/. Go won't
@@ -2075,6 +2111,9 @@ META_WINDOW=$T
   fi
 } > "$STATE/$ID.meta"
 [ "$BACKEND" = orca ] && ORCA_ABORT_CLEANUP=0
+# The task (and its leased worktree=) is now durably recorded; teardown owns the
+# lease from here, so the abort trap must no longer return it.
+TREEHOUSE_LEASE_ABORT_CLEANUP=0
 
 sq_brief=$(shell_quote "$BRIEF")
 sq_turnend=$(shell_quote "$TURNEND")

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1280,19 +1280,22 @@ real_path_or_raw() {  # <path>
 }
 
 treehouse_lease_matches_task() {
-  local path=$1 status rc
-  status=$(cd "$PROJ_ABS" && treehouse status --json 2>/dev/null) || return 2
+  local path=$1 status rc status_format=json
+  # Treehouse 2.0.1 supports leases but predates status --json. Retain its
+  # path-and-holder text validation until the minimum supported version rises.
+  if ! (cd "$PROJ_ABS" && treehouse status --help 2>&1) | grep -q -- '--json'; then
+    status_format=text
+  fi
+  if [ "$status_format" = json ]; then
+    status=$(cd "$PROJ_ABS" && treehouse status --json 2>/dev/null) || return 2
+  else
+    status=$(cd "$PROJ_ABS" && treehouse status 2>/dev/null) || return 2
+  fi
   set +e
   printf '%s' "$status" | node -e '
 const fs = require("fs");
-const [path, holder] = process.argv.slice(1);
-let entries;
-try {
-  entries = JSON.parse(fs.readFileSync(0, "utf8"));
-} catch {
-  process.exit(2);
-}
-if (!Array.isArray(entries)) process.exit(2);
+const [path, holder, format] = process.argv.slice(1);
+const input = fs.readFileSync(0, "utf8");
 const canonical = (value) => {
   try {
     return fs.realpathSync(value);
@@ -1301,8 +1304,28 @@ const canonical = (value) => {
   }
 };
 const expectedPath = canonical(path);
-process.exit(entries.some((entry) => canonical(entry?.path) === expectedPath && entry?.status === "leased" && entry?.lease_holder === holder) ? 0 : 1);
-' "$path" "$ID"
+if (format === "json") {
+  let entries;
+  try {
+    entries = JSON.parse(input);
+  } catch {
+    process.exit(2);
+  }
+  if (!Array.isArray(entries)) process.exit(2);
+  process.exit(entries.some((entry) => canonical(entry?.path) === expectedPath && entry?.status === "leased" && entry?.lease_holder === holder) ? 0 : 1);
+}
+const suffix = "  (held by " + holder + ")";
+for (const line of input.split(/\r?\n/)) {
+  if (!line.endsWith(suffix)) continue;
+  const match = line.slice(0, -suffix.length).match(/^\S+\s+leased\s+(.+)$/);
+  if (!match) continue;
+  let candidate = match[1];
+  if (candidate === "~") candidate = require("os").homedir();
+  if (candidate.startsWith("~/")) candidate = require("path").join(require("os").homedir(), candidate.slice(2));
+  if (canonical(candidate) === expectedPath) process.exit(0);
+}
+process.exit(1);
+' "$path" "$ID" "$status_format"
   rc=$?
   set -e
   return "$rc"

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
-# Tear down a finished task: return the treehouse worktree, release the Orca
-# worktree, or retire a secondmate home; kill the recorded runtime endpoint,
-# clear volatile state, refresh/prune the project's clone for PR-based ship
-# tasks, then print a backlog-refresh reminder for ship and scout teardowns
+# Tear down a finished task: return the treehouse worktree (which also releases
+# the durable lease bin/fm-spawn.sh took on it at spawn, freeing the pool slot
+# for reuse), release the Orca worktree, or retire a secondmate home; kill the
+# recorded runtime endpoint, clear volatile state, refresh/prune the project's
+# clone for PR-based ship tasks, then print a backlog-refresh reminder for ship
+# and scout teardowns
 # (a secondmate teardown prints none, since secondmates are not backlog items).
 # REFUSES if the worktree holds work that has not LANDED, because cleanup
 # hard-resets/removes the worktree and kills its processes. Work has landed when it is

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -47,6 +47,9 @@
 # Projected closes share the presentation-order lock, refuse to close the
 # captain's active tab, and restore the exact response-derived pre-close tab
 # if Herdr's last-pane cleanup focuses an unrelated neighboring workspace.
+# Before returning a Herdr worktree, teardown interrupts any remaining agent,
+# moves the pane shell back to the project, and verifies that cwd twice so
+# treehouse cannot kill the pane before the focus-preserving close owns it.
 # Secondmates (kind=secondmate in meta) are retired explicitly. Normal
 # teardown refuses while their home has in-flight crewmate meta files; --force
 # is the approved discard path that prevalidates child removal targets, discards
@@ -1453,6 +1456,49 @@ FMEOF
   return 1
 }
 
+# Move a Herdr pane's shell out of the leased worktree before treehouse return.
+# A direct-root pane may die on interrupt, in which case exact focus restoration
+# turns that endpoint removal into the same safe handoff.
+teardown_herdr_leave_worktree() {  # <target> <project>
+  local target=$1 project=$2 quoted project_real current current_real candidate attempt
+  local session pane before presence
+  project_real=$(CDPATH='' cd -- "$project" 2>/dev/null && pwd -P) || return 1
+  fm_backend_herdr_parse_target "$target" || return 1
+  session=$FM_BACKEND_HERDR_SESSION
+  pane=$FM_BACKEND_HERDR_PANE
+  before=$(fm_backend_herdr_projection_focus_snapshot "$session") || return 1
+  printf -v quoted '%q' "$project_real"
+  candidate=
+  for attempt in $(seq 1 50); do
+    if [ "$(( (attempt - 1) % 5 ))" -eq 0 ]; then
+      fm_backend_herdr_send_key "$target" C-c || true
+      sleep 0.1
+      presence=$(fm_backend_herdr_pane_presence_state "$session" "$pane")
+      if [ "$presence" = dead ]; then
+        fm_backend_herdr_projection_focus_restore "$session" "$before" "pre-return interrupt" || return 1
+        return 0
+      fi
+      [ "$presence" = present ] || return 1
+      fm_backend_herdr_send_text_line "$target" "cd $quoted" || continue
+    fi
+    current=$(fm_backend_herdr_current_path "$target" || true)
+    current_real=
+    if [ -n "$current" ]; then
+      current_real=$(CDPATH='' cd -- "$current" 2>/dev/null && pwd -P) || current_real=
+    fi
+    if [ "$current_real" = "$project_real" ]; then
+      if [ "$candidate" = "$current_real" ]; then
+        return 0
+      fi
+      candidate=$current_real
+    else
+      candidate=
+    fi
+    sleep 0.1
+  done
+  return 1
+}
+
 teardown_herdr_require_prerequisites() {  # <task-id>
   local task_id=$1 prerequisite
   if ! fm_backend_source herdr; then
@@ -1465,6 +1511,11 @@ teardown_herdr_require_prerequisites() {  # <task-id>
     fm_backend_herdr_workspace_presence_state \
     fm_backend_herdr_endpoint_confirmed_gone \
     fm_backend_herdr_explicit_close_pane_confirmed \
+    fm_backend_herdr_projection_focus_snapshot \
+    fm_backend_herdr_projection_focus_restore \
+    fm_backend_herdr_send_key \
+    fm_backend_herdr_send_text_line \
+    fm_backend_herdr_current_path \
     fm_backend_herdr_presentation_session_lock_path; do
     if ! declare -F "$prerequisite" >/dev/null 2>&1; then
       echo "error: herdr teardown prerequisites are unavailable for $task_id; nothing was changed - restore the adapter and rerun teardown" >&2
@@ -1492,6 +1543,7 @@ teardown_herdr_preflight_target() {  # <target> <task-id>
   session=$FM_BACKEND_HERDR_SESSION
   pane=$FM_BACKEND_HERDR_PANE
   presence=$(fm_backend_herdr_pane_presence_state "$session" "$pane")
+  TEARDOWN_HERDR_PANE_PRESENCE=$presence
   case "$presence" in
     dead|present) ;;
     *)
@@ -1771,11 +1823,33 @@ fi
 # refuses before any destructive step.
 TEARDOWN_HERDR_SESSION=
 TEARDOWN_HERDR_PANE=
+TEARDOWN_HERDR_PANE_PRESENCE=
 if [ "$BACKEND" = herdr ]; then
   teardown_herdr_preflight_target "$T" "$ID" || exit 1
   fm_backend_herdr_parse_target "$T" || exit 1
   TEARDOWN_HERDR_SESSION=$FM_BACKEND_HERDR_SESSION
   TEARDOWN_HERDR_PANE=$FM_BACKEND_HERDR_PANE
+fi
+
+HERDR_PRESENTATION_JOURNAL="$STATE/$ID.herdr-presentation"
+HERDR_PRESENTATION_RETIRE_CANDIDATE=0
+HERDR_PRESENTATION_SESSION=
+HERDR_PRESENTATION_PANE=
+if [ "$BACKEND" = herdr ] \
+   && { [ -e "$HERDR_PRESENTATION_JOURNAL" ] || [ -L "$HERDR_PRESENTATION_JOURNAL" ]; }; then
+  fm_backend_source herdr || true
+  HERDR_PRESENTATION_SESSION=$(meta_value "$META" herdr_session)
+  HERDR_PRESENTATION_WORKSPACE=$(meta_value "$META" herdr_workspace_id)
+  HERDR_PRESENTATION_PANE=$(meta_value "$META" herdr_pane_id)
+  if [ -n "$HERDR_PRESENTATION_SESSION" ] \
+     && [ -n "$HERDR_PRESENTATION_WORKSPACE" ] \
+     && [ -n "$HERDR_PRESENTATION_PANE" ] \
+     && [ "$T" = "$HERDR_PRESENTATION_SESSION:$HERDR_PRESENTATION_PANE" ] \
+     && fm_backend_herdr_projection_endpoint_matches_journal \
+       "$HERDR_PRESENTATION_SESSION" "$HERDR_PRESENTATION_WORKSPACE" \
+       "$HERDR_PRESENTATION_JOURNAL" "$ID"; then
+    HERDR_PRESENTATION_RETIRE_CANDIDATE=1
+  fi
 fi
 
 # Best-effort: drop the local task branch so the shared repo does not accumulate refs.
@@ -1815,31 +1889,15 @@ elif [ -d "$WT" ] && [ "$KIND" != secondmate ]; then
   if [ "$FORCE" != "--force" ] && [ "$KIND" != scout ] && [ "$KIND" != secondmate ]; then
     post_lock_cleanup_check=validate_worktree_teardown_safety
   fi
+  if [ "$BACKEND" = herdr ] && [ "$TEARDOWN_HERDR_PANE_PRESENCE" = present ] \
+     && ! teardown_herdr_leave_worktree "$T" "$PROJ"; then
+    echo "error: herdr pane did not leave worktree $WT before return; teardown aborted" >&2
+    exit 1
+  fi
   teardown_treehouse_return "$WT" "$PROJ" "worktree" "$post_lock_cleanup_check" || {
     echo "error: treehouse return failed for worktree $WT; teardown aborted" >&2
     exit 1
   }
-fi
-
-HERDR_PRESENTATION_JOURNAL="$STATE/$ID.herdr-presentation"
-HERDR_PRESENTATION_RETIRE_CANDIDATE=0
-HERDR_PRESENTATION_SESSION=
-HERDR_PRESENTATION_PANE=
-if [ "$BACKEND" = herdr ] \
-   && { [ -e "$HERDR_PRESENTATION_JOURNAL" ] || [ -L "$HERDR_PRESENTATION_JOURNAL" ]; }; then
-  fm_backend_source herdr || true
-  HERDR_PRESENTATION_SESSION=$(meta_value "$META" herdr_session)
-  HERDR_PRESENTATION_WORKSPACE=$(meta_value "$META" herdr_workspace_id)
-  HERDR_PRESENTATION_PANE=$(meta_value "$META" herdr_pane_id)
-  if [ -n "$HERDR_PRESENTATION_SESSION" ] \
-     && [ -n "$HERDR_PRESENTATION_WORKSPACE" ] \
-     && [ -n "$HERDR_PRESENTATION_PANE" ] \
-     && [ "$T" = "$HERDR_PRESENTATION_SESSION:$HERDR_PRESENTATION_PANE" ] \
-     && fm_backend_herdr_projection_endpoint_matches_journal \
-       "$HERDR_PRESENTATION_SESSION" "$HERDR_PRESENTATION_WORKSPACE" \
-       "$HERDR_PRESENTATION_JOURNAL" "$ID"; then
-    HERDR_PRESENTATION_RETIRE_CANDIDATE=1
-  fi
 fi
 
 if [ "$HERDR_PRESENTATION_RETIRE_CANDIDATE" = 1 ]; then

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -108,7 +108,7 @@ All are harness-scoped rather than a global pattern union, and none is a recorde
 ## Runtime session backends
 
 The runtime backend is the session-provider layer below firstmate's scripts.
-It owns task endpoint creation, bounded capture, text/key sends, current-path reads for spawn-time worktree discovery when the backend does not create the worktree itself, live-window fallback lookup, agent-process liveness probes where verified, and endpoint teardown.
+It owns task endpoint creation, bounded capture, text/key sends, current-path reads for spawn-time worktree settlement verification when the backend does not create the worktree itself, live-window fallback lookup, agent-process liveness probes where verified, and endpoint teardown.
 `bin/fm-backend.sh` centralizes backend selection, `state/<id>.meta` helpers, metadata-only cleanup identity validation, selector resolution, and operation dispatch; `bin/backends/tmux.sh` is the verified reference adapter ([`docs/tmux-backend.md`](tmux-backend.md)), and `bin/backends/herdr.sh` (P2), `bin/backends/zellij.sh` (P3), `bin/backends/orca.sh` (P4), and `bin/backends/cmux.sh` (P5) are experimental task-spawn adapters.
 [`configuration.md`](configuration.md#runtime-backend-configbackend--fm_backend) owns new-spawn backend selection precedence and authorization.
 Runtime auto-detection is innermost-first: `$TMUX` wins over `HERDR_ENV=1`, which wins over cmux's primary `CMUX_WORKSPACE_ID` marker and documented fallback signals; auto-detected herdr or cmux prints a one-time opt-out notice, auto-detected tmux stays silent, and zellij and orca are never auto-detected (only explicit selection).
@@ -134,6 +134,9 @@ Codex App support is recorded in `docs/codex-app-backend.md`; it is not selectab
 ## Worktrees, not branches in your checkout
 
 Crewmates never intentionally touch your project clone; [treehouse](https://github.com/kunchenguid/treehouse) pools clean worktrees for tmux, herdr, zellij, and cmux tasks, while Orca creates its own worktrees for `backend=orca`.
+For every new Treehouse-backed ship or scout task, `fm-spawn.sh` leases the pooled worktree under the task id before creating its endpoint and records that exact path.
+The lease keeps the task's branch, commits, and uncommitted work reserved across crashes and relaunches; a relaunch accepts only the recorded path with a matching task-id lease and never allocates a replacement for an unreconciled record.
+An abort before durable task metadata attempts to return the new lease and warns if Treehouse refuses it, while successful spawn transfers lease ownership to guarded teardown, whose existing `treehouse return --force` releases the slot only after its landed-work and discard-authority checks pass.
 For ship and scout work, `fm-spawn.sh` refuses to launch unless the resolved task path is a real git worktree root that is distinct from the project primary checkout.
 
 The firstmate repo has one extra exposure because it can dispatch crewmates to work on itself.

--- a/docs/cmux-backend.md
+++ b/docs/cmux-backend.md
@@ -87,8 +87,8 @@ A genuinely fresh surface returns an internal error from `read-screen` until som
 Target readiness therefore uses the structural `list-panes` response instead of a content read.
 Capture remains bounded and locally trimmed after `read-screen` becomes available.
 
-`current_directory` follows a top-level shell `cd` but not the foreground subshell opened by `treehouse get`.
-Spawn-time worktree discovery sends begin and end markers around `pwd`, captures the marked block, and joins wrapped path lines.
+`treehouse get --lease` returns the reserved worktree path without opening a subshell, and spawn explicitly changes the surface's top-level shell to that path.
+Spawn-time settlement verification sends begin and end markers around `pwd`, captures the marked block, and joins wrapped path lines instead of trusting cmux's fallible structured cwd reporting.
 
 Literal send and Enter are separate calls.
 Enter, Escape, and Ctrl-C are supported.

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -460,7 +460,7 @@ tests/fm-backend-zellij.test.sh
 tests/fm-backend-zellij-smoke.test.sh
 ```
 
-The real lifecycle smoke proved spawn, metadata, nested-subshell worktree discovery, send, capture, unlanded-work refusal, approved local landing, exact tab cleanup, and session cleanup without retaining task-specific ids or branch names here.
+The real lifecycle smoke proved spawn, metadata, marker-probed worktree cwd reading, send, capture, unlanded-work refusal, approved local landing, exact tab cleanup, and session cleanup without retaining task-specific ids or branch names here.
 
 ## Orca
 

--- a/docs/zellij-backend.md
+++ b/docs/zellij-backend.md
@@ -62,13 +62,13 @@ An explicit raw `session:pane` target remains a pane-existence-only operator esc
 
 Zellij's CLI action commands return exit 0 even for missing sessions or panes.
 The adapter therefore verifies session, terminal pane, and expected title before an operation and validates JSON or integer response shapes afterward.
-A pane can still disappear between verification and the operation; downstream submit, worktree-discovery, and stale detection report that narrow race rather than treating exit 0 as success.
+A pane can still disappear between verification and the operation; downstream submit, worktree-settlement verification, and stale detection report that narrow race rather than treating exit 0 as success.
 
 Every pane operation passes an explicit `--pane-id` because a new session can focus its release-notes plugin pane, whose numeric plugin id is in a separate namespace from terminal pane ids.
 
-`pane_cwd` follows a top-level shell `cd` but not the foreground subshell opened by `treehouse get`.
-Worktree discovery therefore sends begin and end markers around `pwd`, captures the marked block, and joins wrapped path lines.
-This active probe is scoped to spawn-time worktree discovery and is not advertised as a general live-cwd API.
+`treehouse get --lease` returns the reserved worktree path without opening a subshell, and spawn explicitly changes the pane's top-level shell to that path.
+Settlement verification sends begin and end markers around `pwd`, captures the marked block, and joins wrapped path lines instead of trusting Zellij's fallible structured cwd reporting.
+This active probe is scoped to spawn-time worktree settlement and is not advertised as a general live-cwd API.
 
 `new-tab` has no no-focus flag and temporarily focuses the created tab in attached clients.
 The adapter records the previously active tab and immediately restores it with `go-to-tab-by-id`.
@@ -96,7 +96,7 @@ Real test cleanup uses only an isolated non-`firstmate` session and the guard in
 - There is no verified agent-process liveness signal, so a dead Zellij secondmate is reported inconclusive rather than auto-respawned.
 - New-tab focus restoration has a narrow visible race.
 - CLI exit status is not meaningful; a target can still disappear after structural readiness checks.
-- Worktree cwd discovery requires the spawn-time marker probe.
+- Worktree cwd settlement requires the spawn-time marker probe.
 - An ambiguous unscoped legacy title requires manual cleanup and respawn.
 
 ## Regression entry points

--- a/tests/fm-backend-autodetect-smoke.test.sh
+++ b/tests/fm-backend-autodetect-smoke.test.sh
@@ -55,7 +55,7 @@ herdr_forget_inherited_pane
 # real-herdr smoke fixture free of unrelated OS symlink noise.
 # The old fm-spawn bug that originally motivated this fixture shape was fixed in
 # fm-spawn-symlink-guard-s8: fm-spawn.sh now normalizes PROJ_ABS and observed
-# backend cwd reads before the worktree-discovery comparison.
+# backend cwd reads before the worktree-settlement comparison.
 # The dedicated regression is
 # tests/fm-backend.test.sh:test_spawn_symlinked_project_prefix_avoids_false_refusal.
 TMP_ROOT=$(mktemp -d "$(cd "${TMPDIR:-/tmp}" && pwd -P)/fm-backend-autodetect-smoke.XXXXXX")

--- a/tests/fm-backend-cmux-smoke.test.sh
+++ b/tests/fm-backend-cmux-smoke.test.sh
@@ -109,9 +109,9 @@ pass "real cmux: current_path reads the surface's live cwd after a direct cd"
 # get` does). Verified real finding (docs/cmux-backend.md finding #2):
 # current_directory stays frozen at wherever the surface's shell was when it
 # launched the subshell as a foreground command - it never follows the
-# subshell's own cd. fm_backend_cmux_current_path's active pwd-probe is what
-# fm-spawn.sh's worktree-discovery poll actually depends on, so this must be
-# proven against a real subshell, not just a plain cd in the top-level shell.
+# subshell's own cd. fm_backend_cmux_current_path's active pwd-probe also
+# promises the live cwd when a foreground subshell takes over, so retain real
+# coverage beyond the direct spawn-time cd.
 fm_backend_cmux_send_text_line "$TARGET" 'cd / && bash'
 sleep 0.5
 fm_backend_cmux_send_text_line "$TARGET" "cd /private/tmp"

--- a/tests/fm-backend-herdr-presentation-e2e.test.sh
+++ b/tests/fm-backend-herdr-presentation-e2e.test.sh
@@ -208,6 +208,10 @@ set -u
   printf '\n'
 } >> "$TREEHOUSE_CALL_LOG"
 if [ -d "$POST_CREATE_ABORT_CONTROL" ] && [ "${1:-}" = get ]; then
+  # Arm a POST-CREATE abort: `treehouse get --lease` "succeeds" (exit 0) but
+  # leases nothing (no path on stdout), so fm-spawn refuses to launch a task
+  # with no worktree AFTER the Herdr pane is created - the armed failure this
+  # fixture verifies the Herdr cleanup handles.
   exit 0
 fi
 exec "$REAL_TREEHOUSE" "$@"
@@ -746,10 +750,10 @@ spawn_task abort-b "$HOME_DIR" "$PROJECT_DIR" > "$TMP_ROOT/abort-b.out" 2> "$TMP
 ABORT_B_PID=$!
 if wait "$ABORT_A_PID"; then fail "post-create abort fixture A unexpectedly succeeded"; fi
 if wait "$ABORT_B_PID"; then fail "post-create abort fixture B unexpectedly succeeded"; fi
-grep -F "did not yield an isolated worktree" "$TMP_ROOT/abort-a.err" >/dev/null 2>&1 \
-  || fail "post-create abort fixture A did not reach the armed validation failure"
-grep -F "did not yield an isolated worktree" "$TMP_ROOT/abort-b.err" >/dev/null 2>&1 \
-  || fail "post-create abort fixture B did not reach the armed validation failure"
+grep -F "reported no task worktree" "$TMP_ROOT/abort-a.err" >/dev/null 2>&1 \
+  || fail "post-create abort fixture A did not reach the armed worktree-lease failure"
+grep -F "reported no task worktree" "$TMP_ROOT/abort-b.err" >/dev/null 2>&1 \
+  || fail "post-create abort fixture B did not reach the armed worktree-lease failure"
 ABORT_A_PANE=$(cat "$POST_CREATE_ABORT_CONTROL/abort-a/task-pane")
 ABORT_B_PANE=$(cat "$POST_CREATE_ABORT_CONTROL/abort-b/task-pane")
 ABORT_SEQUENCE=$(sed -n "$((ABORT_FOCUS_START + 1)),\$p" "$FOCUS_AUDIT_LOG" | awk -F '\t' -v a="$ABORT_A_PANE" -v b="$ABORT_B_PANE" '

--- a/tests/fm-backend-herdr-presentation-e2e.test.sh
+++ b/tests/fm-backend-herdr-presentation-e2e.test.sh
@@ -142,10 +142,44 @@ if [ "${1:-} ${2:-}" = "pane get" ] && [ -d "$ACTIVE_SEEDED_CONTROL" ] \
 fi
 before=
 [ -z "$mutation" ] || before=$(focus_snapshot || printf ambiguous/ambiguous)
-if out=$(env PATH="$HERDR_ORIGINAL_PATH" "$HERDR_LAB_HELPER" run "$HERDR_LAB_SESSION" "$@"); then
+# Lease acquisition now precedes endpoint creation, so arm the post-create
+# abort at the first worktree-entry command instead. Pane-death cleanup has no
+# explicit pane-close call to audit, so record its first confirmed absence as
+# the logical close while preserving the real before/after focus snapshots.
+abort_task=
+abort_cleanup_task=
+if [ "${1:-} ${2:-}" = "pane run" ] && [ "${4:-}" != "${4#cd }" ] \
+   && [ -d "$POST_CREATE_ABORT_CONTROL" ]; then
+  for task_dir in "$POST_CREATE_ABORT_CONTROL"/abort-*; do
+    [ -d "$task_dir" ] || continue
+    [ "${3:-}" = "$(cat "$task_dir/task-pane" 2>/dev/null || true)" ] || continue
+    abort_task=$task_dir
+    break
+  done
+fi
+if [ "${1:-} ${2:-}" = "pane get" ] && [ -d "$POST_CREATE_ABORT_CONTROL" ]; then
+  for task_dir in "$POST_CREATE_ABORT_CONTROL"/abort-*; do
+    [ -e "$task_dir/armed" ] || continue
+    [ "${3:-}" = "$(cat "$task_dir/task-pane" 2>/dev/null || true)" ] || continue
+    abort_cleanup_task=$task_dir
+    before=$(focus_snapshot || printf ambiguous/ambiguous)
+    break
+  done
+fi
+if [ -n "$abort_task" ]; then
+  : > "$abort_task/armed"
+  out=
+  status=97
+elif out=$(env PATH="$HERDR_ORIGINAL_PATH" "$HERDR_LAB_HELPER" run "$HERDR_LAB_SESSION" "$@"); then
   status=0
 else
   status=$?
+fi
+if [ -n "$abort_cleanup_task" ] && [ "$status" -ne 0 ] \
+   && [ ! -e "$abort_cleanup_task/close-audited" ]; then
+  : > "$abort_cleanup_task/close-audited"
+  mutation=pane-close
+  mutation_target=${3:-}
 fi
 if [ "$status" -eq 0 ] && [ "$mutation" = workspace-create ]; then
   case "$label" in
@@ -207,12 +241,25 @@ set -u
   done
   printf '\n'
 } >> "$TREEHOUSE_CALL_LOG"
-if [ -d "$POST_CREATE_ABORT_CONTROL" ] && [ "${1:-}" = get ]; then
-  # Arm a POST-CREATE abort: `treehouse get --lease` "succeeds" (exit 0) but
-  # leases nothing (no path on stdout), so fm-spawn refuses to launch a task
-  # with no worktree AFTER the Herdr pane is created - the armed failure this
-  # fixture verifies the Herdr cleanup handles.
-  exit 0
+# The abort fixture needs a non-empty lease path before endpoint creation, but
+# must stay independent of real Treehouse setup latency so the fresh pane has a
+# deterministic cleanup shape. Every other case still uses real Treehouse.
+if [ -d "$POST_CREATE_ABORT_CONTROL" ]; then
+  case "${1:-}" in
+    get)
+      holder=
+      previous=
+      for arg in "$@"; do
+        if [ "$previous" = --lease-holder ]; then holder=$arg; break; fi
+        previous=$arg
+      done
+      leased="$POST_CREATE_ABORT_CONTROL/${holder:?missing lease holder}/leased-worktree"
+      mkdir -p "$leased"
+      printf '%s\n' "$leased"
+      exit 0
+      ;;
+    return) exit 0 ;;
+  esac
 fi
 exec "$REAL_TREEHOUSE" "$@"
 SH
@@ -750,10 +797,10 @@ spawn_task abort-b "$HOME_DIR" "$PROJECT_DIR" > "$TMP_ROOT/abort-b.out" 2> "$TMP
 ABORT_B_PID=$!
 if wait "$ABORT_A_PID"; then fail "post-create abort fixture A unexpectedly succeeded"; fi
 if wait "$ABORT_B_PID"; then fail "post-create abort fixture B unexpectedly succeeded"; fi
-grep -F "reported no task worktree" "$TMP_ROOT/abort-a.err" >/dev/null 2>&1 \
-  || fail "post-create abort fixture A did not reach the armed worktree-lease failure"
-grep -F "reported no task worktree" "$TMP_ROOT/abort-b.err" >/dev/null 2>&1 \
-  || fail "post-create abort fixture B did not reach the armed worktree-lease failure"
+[ -e "$POST_CREATE_ABORT_CONTROL/abort-a/armed" ] \
+  || fail "post-create abort fixture A did not reach the armed worktree-entry failure"
+[ -e "$POST_CREATE_ABORT_CONTROL/abort-b/armed" ] \
+  || fail "post-create abort fixture B did not reach the armed worktree-entry failure"
 ABORT_A_PANE=$(cat "$POST_CREATE_ABORT_CONTROL/abort-a/task-pane")
 ABORT_B_PANE=$(cat "$POST_CREATE_ABORT_CONTROL/abort-b/task-pane")
 ABORT_SEQUENCE=$(sed -n "$((ABORT_FOCUS_START + 1)),\$p" "$FOCUS_AUDIT_LOG" | awk -F '\t' -v a="$ABORT_A_PANE" -v b="$ABORT_B_PANE" '
@@ -1127,13 +1174,17 @@ for RESTART_ID in fm-hibit-resume-r1 wheelhouse-healing-r1; do
       || fail "$RESTART_ID repeated reclaim changed workspace identity"
     [ "$NEW_RESTART_PANE" != "$PRIOR_RESTART_PANE" ] \
       || fail "$RESTART_ID repeated reclaim reused the prior husk pane"
-    "$REAL_TREEHOUSE" return --force "$PRIOR_RESTART_WT" >/dev/null 2>&1 || true
+    # A leased relaunch reuses the same worktree, so never return the prior
+    # path when it is also the currently bound lease.
+    if [ "$PRIOR_RESTART_WT" != "$NEW_RESTART_WT" ]; then
+      "$REAL_TREEHOUSE" return --force "$PRIOR_RESTART_WT" >/dev/null 2>&1 || true
+    fi
   fi
 
   teardown_task "$RESTART_ID" "$HOME_DIR" > "$TMP_ROOT/$RESTART_ID-teardown.out" 2> "$TMP_ROOT/$RESTART_ID-teardown.err" \
     || fail "$RESTART_ID teardown after reclaim failed: $(cat "$TMP_ROOT/$RESTART_ID-teardown.err")"
   [ ! -e "$HOME_DIR/state/$RESTART_ID.herdr-presentation" ] \
-    || fail "$RESTART_ID exact reclaimed teardown did not retire its journal"
+    || fail "$RESTART_ID exact reclaimed teardown did not retire its journal: $(cat "$TMP_ROOT/$RESTART_ID-teardown.err")"
   "$REAL_TREEHOUSE" return --force "$OLD_RESTART_WT" >/dev/null 2>&1 || true
   "$REAL_TREEHOUSE" return --force "$NEW_RESTART_WT" >/dev/null 2>&1 || true
 done

--- a/tests/fm-backend-herdr-workspace-per-home-e2e.test.sh
+++ b/tests/fm-backend-herdr-workspace-per-home-e2e.test.sh
@@ -63,7 +63,7 @@ herdr_forget_inherited_pane
 # low-noise scratch fixture shape used by
 # tests/fm-backend-autodetect-smoke.test.sh.
 # fm-spawn no longer needs this as a symlink workaround: fm-spawn-symlink-guard-s8
-# canonicalized project and backend cwd comparisons in the worktree-discovery
+# canonicalized project and backend cwd comparisons in the worktree-settlement
 # poll.
 TMP_ROOT=$(mktemp -d "$(cd "${TMPDIR:-/tmp}" && pwd -P)/fm-herdr-e2e.XXXXXX")
 SESSION="fm-lab-herdr-e2e-$$"

--- a/tests/fm-backend-herdr.test.sh
+++ b/tests/fm-backend-herdr.test.sh
@@ -2584,7 +2584,7 @@ test_current_path_reads_cwd() {
   dir="$TMP_ROOT/cwd"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
   # Verified pitfall (herdr-verification-p2.md): .result.pane.cwd is frozen at
   # pane-creation time and never updates; .foreground_cwd tracks the live
-  # running process (e.g. a treehouse get subshell) and is what must be read.
+  # running foreground process and is what must be read.
   printf '{"result":{"pane":{"cwd":"/tmp/pane-creation-dir","foreground_cwd":"/tmp/fake-worktree"}}}\n' > "$resp/1.out"
   fb=$(make_herdr_fakebin "$dir")
   out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \

--- a/tests/fm-backend-zellij-smoke.test.sh
+++ b/tests/fm-backend-zellij-smoke.test.sh
@@ -145,9 +145,8 @@ pass "real zellij: current_path reconstructs a long cwd that can wrap in the ter
 # at wherever the pane's shell was when it launched the subshell as a
 # foreground command - it never follows the subshell's own cd, even once
 # that subshell is fully interactive. fm_backend_zellij_current_path's active
-# pwd-probe (docs/zellij-backend.md) is what fm-spawn.sh's worktree-discovery
-# poll actually depends on, so this must be proven against a real subshell,
-# not just a plain cd in the pane's own top-level shell (the case above).
+# pwd-probe (docs/zellij-backend.md) also promises the live cwd when a foreground
+# subshell takes over, so retain real coverage beyond the direct spawn-time cd.
 fm_backend_zellij_send_text_line "$TARGET" 'cd / && bash'
 sleep 0.5
 fm_backend_zellij_send_text_line "$TARGET" "cd $TMP_CWD_Q"

--- a/tests/fm-backend.test.sh
+++ b/tests/fm-backend.test.sh
@@ -850,8 +850,8 @@ run_spawn_case() {  # <bin-root> <fakebin> <log> <state> <data> <config> <proj> 
 # (tmux, herdr) reports the OS-level PHYSICALLY-resolved cwd. When the project
 # itself lives under a symlinked prefix (e.g. macOS's /tmp -> /private/tmp),
 # fm-spawn.sh's PROJ_ABS - a logical `cd && pwd` - differs string-for-string
-# from that physical read even before treehouse moves the pane at all, so the
-# worktree-discovery poll used to mistake an UNMOVED pane for one that had
+# from that physical read even before spawn moves the pane at all, so the
+# worktree-settlement poll used to mistake an UNMOVED pane for one that had
 # already left the project, handing validate_spawn_worktree the project's own
 # directory as "the worktree" and tripping its false isolation refusal.
 # make_spawn_symlink_fakebin's tmux stub returns an unmoved project path on the

--- a/tests/fm-backend.test.sh
+++ b/tests/fm-backend.test.sh
@@ -806,7 +806,14 @@ esac
 exit 0
 SH
   chmod +x "$fb/tmux"
-  fm_fake_exit0 "$fb" treehouse
+  # fm-spawn leases the task worktree: `treehouse get --lease` prints the leased
+  # worktree path (the same $wt the pane settles into); other subcommands exit 0.
+  cat > "$fb/treehouse" <<SH
+#!/usr/bin/env bash
+[ "\${1:-}" = get ] && printf '%s\n' "$wt"
+exit 0
+SH
+  chmod +x "$fb/treehouse"
   printf '%s\n' "$fb"
 }
 
@@ -876,7 +883,14 @@ esac
 exit 0
 SH
   chmod +x "$fb/tmux"
-  fm_fake_exit0 "$fb" treehouse
+  # fm-spawn leases the task worktree: `treehouse get --lease` prints the leased
+  # worktree path (the same $wt the pane settles into); other subcommands exit 0.
+  cat > "$fb/treehouse" <<SH
+#!/usr/bin/env bash
+[ "\${1:-}" = get ] && printf '%s\n' "$wt"
+exit 0
+SH
+  chmod +x "$fb/treehouse"
   printf '%s\n' "$fb"
 }
 

--- a/tests/fm-busy-adapter-wiring.test.sh
+++ b/tests/fm-busy-adapter-wiring.test.sh
@@ -35,7 +35,16 @@ esac
 exit 0
 SH
   chmod +x "$fakebin/tmux"
-  fm_fake_exit0 "$fakebin" treehouse pi opencode claude codex
+  fm_fake_exit0 "$fakebin" pi opencode claude codex
+  # fm-spawn leases the task worktree: `treehouse get --lease` prints the leased
+  # path (where the pane settles); every other subcommand exits silently.
+  cat > "$fakebin/treehouse" <<'SH'
+#!/usr/bin/env bash
+set -u
+[ "${1:-}" = get ] && printf '%s\n' "${FM_FAKE_LEASE_PATH:-${FM_FAKE_PANE_PATH:?FM_FAKE_PANE_PATH unset}}"
+exit 0
+SH
+  chmod +x "$fakebin/treehouse"
   printf '%s\n' "$fakebin"
 }
 

--- a/tests/fm-gate-refuse.test.sh
+++ b/tests/fm-gate-refuse.test.sh
@@ -152,7 +152,15 @@ esac
 exit 0
 SH
   chmod +x "$fakebin/tmux"
-  fm_fake_exit0 "$fakebin" treehouse
+  # fm-spawn leases the task worktree: `treehouse get --lease` prints the leased
+  # path (where the pane settles); every other subcommand exits silently.
+  cat > "$fakebin/treehouse" <<'SH'
+#!/usr/bin/env bash
+set -u
+[ "${1:-}" = get ] && printf '%s\n' "${FM_FAKE_LEASE_PATH:-${FM_FAKE_PANE_PATH:?FM_FAKE_PANE_PATH unset}}"
+exit 0
+SH
+  chmod +x "$fakebin/treehouse"
   printf '%s\n' "$fakebin"
 }
 

--- a/tests/fm-grok-harness.test.sh
+++ b/tests/fm-grok-harness.test.sh
@@ -26,7 +26,16 @@ esac
 exit 0
 SH
   chmod +x "$fakebin/tmux"
-  fm_fake_exit0 "$fakebin" treehouse gh-axi gh
+  fm_fake_exit0 "$fakebin" gh-axi gh
+  # fm-spawn leases the task worktree: `treehouse get --lease` prints the leased
+  # path (where the pane settles); every other subcommand exits silently.
+  cat > "$fakebin/treehouse" <<'SH'
+#!/usr/bin/env bash
+set -u
+[ "${1:-}" = get ] && printf '%s\n' "${FM_FAKE_LEASE_PATH:-${FM_FAKE_PANE_PATH:?FM_FAKE_PANE_PATH unset}}"
+exit 0
+SH
+  chmod +x "$fakebin/treehouse"
   printf '%s\n' "$fakebin"
 }
 

--- a/tests/fm-kimi-harness.test.sh
+++ b/tests/fm-kimi-harness.test.sh
@@ -125,7 +125,16 @@ esac
 exit 0
 SH
   chmod +x "$fakebin/tmux"
-  fm_fake_exit0 "$fakebin" treehouse gh-axi gh
+  fm_fake_exit0 "$fakebin" gh-axi gh
+  # fm-spawn leases the task worktree: `treehouse get --lease` prints the leased
+  # path (where the pane settles); every other subcommand exits silently.
+  cat > "$fakebin/treehouse" <<'SH'
+#!/usr/bin/env bash
+set -u
+[ "${1:-}" = get ] && printf '%s\n' "${FM_FAKE_LEASE_PATH:-${FM_FAKE_PANE_PATH:?FM_FAKE_PANE_PATH unset}}"
+exit 0
+SH
+  chmod +x "$fakebin/treehouse"
   fm_fake_exit0 "$fakebin" kimi
   ln -s "$JQ_BIN" "$fakebin/jq"
   printf '%s\n' "$fakebin"

--- a/tests/fm-secondmate-harness.test.sh
+++ b/tests/fm-secondmate-harness.test.sh
@@ -601,6 +601,16 @@ esac
 exit 0
 SH
   chmod +x "$fakebin/tmux"
+  # A crew/scout spawn LEASES its task worktree in-process: `treehouse get
+  # --lease` prints the leased path (FM_FAKE_PANE_PATH here), where the pane
+  # settles. A --secondmate spawn never reaches this, so exit 0 otherwise.
+  cat > "$fakebin/treehouse" <<'SH'
+#!/usr/bin/env bash
+set -u
+[ "${1:-}" = get ] && printf '%s\n' "${FM_FAKE_PANE_PATH:?FM_FAKE_PANE_PATH unset}"
+exit 0
+SH
+  chmod +x "$fakebin/treehouse"
   printf '%s\n' "$fakebin"
 }
 

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -42,7 +42,16 @@ esac
 exit 0
 SH
   chmod +x "$fakebin/tmux"
-  fm_fake_exit0 "$fakebin" treehouse pi-signed
+  fm_fake_exit0 "$fakebin" pi-signed
+  # fm-spawn leases the task worktree: `treehouse get --lease` prints the leased
+  # path (where the pane settles); every other subcommand exits silently.
+  cat > "$fakebin/treehouse" <<'SH'
+#!/usr/bin/env bash
+set -u
+[ "${1:-}" = get ] && printf '%s\n' "${FM_FAKE_LEASE_PATH:-${FM_FAKE_PANE_PATH:?FM_FAKE_PANE_PATH unset}}"
+exit 0
+SH
+  chmod +x "$fakebin/treehouse"
   printf '%s\n' "$fakebin"
 }
 

--- a/tests/fm-spawn-worktree-lease.test.sh
+++ b/tests/fm-spawn-worktree-lease.test.sh
@@ -62,9 +62,17 @@ case "${1:-}" in
   get) printf '%s\n' "${FM_FAKE_LEASE_PATH:?FM_FAKE_LEASE_PATH unset}" ;;
   status)
     [ "${FM_FAKE_STATUS_FAIL:-0}" != 1 ] || exit 1
-    node -e 'console.log(JSON.stringify([{path: process.argv[1], status: "leased", lease_holder: process.argv[2]}]))' \
-      "${FM_FAKE_LEASE_PATH:?FM_FAKE_LEASE_PATH unset}" \
-      "${FM_FAKE_LEASE_HOLDER:?FM_FAKE_LEASE_HOLDER unset}"
+    if [ "${2:-}" = --help ]; then
+      [ "${FM_FAKE_STATUS_LEGACY:-0}" = 1 ] || printf '%s\n' '      --json   Print pool status as JSON'
+    elif [ "${FM_FAKE_STATUS_LEGACY:-0}" = 1 ]; then
+      printf '1     leased       %s  (held by %s)\n' \
+        "${FM_FAKE_LEASE_PATH:?FM_FAKE_LEASE_PATH unset}" \
+        "${FM_FAKE_LEASE_HOLDER:?FM_FAKE_LEASE_HOLDER unset}"
+    else
+      node -e 'console.log(JSON.stringify([{path: process.argv[1], status: "leased", lease_holder: process.argv[2]}]))' \
+        "${FM_FAKE_LEASE_PATH:?FM_FAKE_LEASE_PATH unset}" \
+        "${FM_FAKE_LEASE_HOLDER:?FM_FAKE_LEASE_HOLDER unset}"
+    fi
     ;;
 esac
 exit 0
@@ -113,6 +121,7 @@ run_lease_spawn() {
     FM_FAKE_LEASE_PATH="$lease" FM_FAKE_PANE_PATH="$pane" \
     FM_FAKE_LEASE_HOLDER="${FM_FAKE_LEASE_HOLDER_OVERRIDE:-$id}" \
     FM_FAKE_STATUS_FAIL="${FM_FAKE_STATUS_FAIL_OVERRIDE:-0}" \
+    FM_FAKE_STATUS_LEGACY="${FM_FAKE_STATUS_LEGACY_OVERRIDE:-0}" \
     FM_FAKE_TH_LOG="$THLOG" \
     PATH="$FAKEBIN_DIR:$PATH" \
     "$SPAWN" "$id" "$PROJ_DIR" --mode no-mistakes --yolo off 2>&1
@@ -211,6 +220,28 @@ test_relaunch_accepts_equivalent_status_path() {
   assert_grep "worktree=$WT_DIR" "$HOME_DIR/state/$id.meta" \
     "relaunch did not preserve the canonical leased worktree"
   pass "relaunch recognizes symlink-equivalent Treehouse lease paths"
+}
+
+test_relaunch_accepts_legacy_treehouse_status() {
+  local rec id out status
+  id="lease-relaunch-legacy-z5"
+  rec=$(make_lease_case lease-relaunch-legacy "$id")
+  read_lease_record "$rec"
+
+  out=$(run_lease_spawn "$id" "$WT_DIR" "$WT_DIR")
+  status=$?
+  expect_code 0 "$status" "initial spawn should acquire the task lease"
+
+  out=$(FM_FAKE_STATUS_LEGACY_OVERRIDE=1 run_lease_spawn "$id" "$WT_DIR" "$WT_DIR")
+  status=$?
+  expect_code 0 "$status" "relaunch should accept Treehouse 2.0.1 text status"
+  [ "$(grep -c "^get --lease --lease-holder $id$" "$THLOG")" -eq 1 ] \
+    || fail "legacy status caused a second lease acquisition: $(cat "$THLOG")"
+  assert_no_grep '^status --json$' "$THLOG" \
+    "legacy Treehouse validation invoked its unsupported --json flag"
+  assert_grep "worktree=$WT_DIR" "$HOME_DIR/state/$id.meta" \
+    "legacy-status relaunch did not preserve the recorded leased worktree"
+  pass "relaunch validates the recorded lease through Treehouse 2.0.1 text status"
 }
 
 test_aborted_relaunch_preserves_recorded_lease() {
@@ -349,6 +380,7 @@ test_spawn_leases_worktree_under_task_id
 test_spawn_abort_releases_leased_worktree
 test_relaunch_reuses_recorded_lease
 test_relaunch_accepts_equivalent_status_path
+test_relaunch_accepts_legacy_treehouse_status
 test_aborted_relaunch_preserves_recorded_lease
 test_relaunch_rejects_wrong_lease_holder
 test_relaunch_rejects_unreadable_lease_status

--- a/tests/fm-spawn-worktree-lease.test.sh
+++ b/tests/fm-spawn-worktree-lease.test.sh
@@ -1,0 +1,222 @@
+#!/usr/bin/env bash
+# Regression tests for fm-spawn.sh leasing the task worktree (bin/fm-spawn.sh).
+#
+# The bug: fm-spawn acquired the task worktree with a bare, UNLEASED
+# `treehouse get`. An unleased slot can be handed back by a later
+# `treehouse get`/`prune` - so after a crash or a stuck-crew relaunch the pool
+# could return the same slot reset onto the default branch, losing the task's
+# branch and its in-flight commits. `no-mistakes axi respond` then fails ("no
+# active run to respond to") because it resolves the active run by the
+# checked-out branch. fm-spawn now leases the worktree under the task id, which
+# reserves the slot (and its branch and commits) across restarts until teardown
+# returns it, so a relaunch re-binds to the SAME worktree. Mirrors the leased
+# firstmate homes in bin/fm-home-seed.sh.
+#
+# Coverage:
+#   - spawn issues `treehouse get --lease --lease-holder <id>` and records the
+#     leased worktree, so the lease is keyed to the task and teardown/recovery
+#     can find it.
+#   - a spawn that aborts after leasing returns the lease, so a failed launch
+#     never leaks a reserved pool slot.
+#   - (real treehouse, self-skipping) the lease contract fm-spawn/fm-teardown
+#     rely on holds end to end: a leased slot and its branch/commit survive a
+#     competing get + prune (idle-lease-survives-pool-op, and the enabler for
+#     relaunch-rebinds-to-branch), and `treehouse return --force` frees it
+#     (teardown-releases-lease).
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+SPAWN="$ROOT/bin/fm-spawn.sh"
+TMP_ROOT=$(fm_test_tmproot fm-spawn-worktree-lease)
+
+# --- hermetic fakes ---------------------------------------------------------
+
+# make_lease_fakebin <dir>: a fake tmux whose `#{pane_current_path}` query
+# returns FM_FAKE_PANE_PATH, and a fake treehouse that logs every invocation
+# (one args line) to FM_FAKE_TH_LOG and, on `get`, prints FM_FAKE_LEASE_PATH -
+# mirroring how `treehouse get --lease` prints only the leased path to stdout.
+# Every other treehouse subcommand (the abort-time `return`) succeeds silently.
+make_lease_fakebin() {
+  local dir=$1 fakebin
+  fakebin=$(fm_fakebin "$dir")
+  cat > "$fakebin/tmux" <<'SH'
+#!/usr/bin/env bash
+set -u
+case "$*" in
+  *"#{pane_current_path}"*) printf '%s\n' "${FM_FAKE_PANE_PATH:-}"; exit 0 ;;
+esac
+case "${1:-}" in
+  display-message) printf 'firstmate\n'; exit 0 ;;
+esac
+exit 0
+SH
+  chmod +x "$fakebin/tmux"
+  cat > "$fakebin/treehouse" <<'SH'
+#!/usr/bin/env bash
+set -u
+printf '%s\n' "$*" >> "${FM_FAKE_TH_LOG:?FM_FAKE_TH_LOG unset}"
+if [ "${1:-}" = get ]; then
+  printf '%s\n' "${FM_FAKE_LEASE_PATH:?FM_FAKE_LEASE_PATH unset}"
+fi
+exit 0
+SH
+  chmod +x "$fakebin/treehouse"
+  printf '%s\n' "$fakebin"
+}
+
+# make_lease_case <name> <id>: build a firstmate home, a project with a real
+# worktree (the leased path the pane settles into), a separate non-worktree dir
+# (for the abort case), a fakebin, and the treehouse-invocation log. Echoes a
+# pipe-delimited record.
+make_lease_case() {
+  local name=$1 id=$2 case_dir home proj wt bad fakebin thlog
+  case_dir="$TMP_ROOT/$name"
+  home="$case_dir/home"
+  proj="$case_dir/project"
+  wt="$case_dir/wt"
+  bad="$case_dir/not-a-worktree"
+  thlog="$case_dir/treehouse.log"
+  fakebin=$(make_lease_fakebin "$case_dir/fake")
+  mkdir -p "$home/data" "$home/projects" "$home/state" "$home/config" "$bad"
+  printf 'codex\n' > "$home/config/crew-harness"
+  fm_git_worktree "$proj" "$wt" "wt-$name"
+  mkdir -p "$home/data/$id"
+  printf 'brief for %s\n' "$id" > "$home/data/$id/brief.md"
+  touch "$home/state/.last-watcher-beat"
+  : > "$thlog"
+  printf '%s\n' "$case_dir|$home|$proj|$wt|$bad|$fakebin|$thlog"
+}
+
+read_lease_record() {
+  IFS='|' read -r _ HOME_DIR PROJ_DIR WT_DIR BAD_DIR FAKEBIN_DIR THLOG <<EOF
+$1
+EOF
+}
+
+# run_lease_spawn <id> <lease-path> <pane-path>: drive fm-spawn with the fakes,
+# leasing <lease-path> and settling the pane at <pane-path>.
+run_lease_spawn() {
+  local id=$1 lease=$2 pane=$3
+  FM_ROOT_OVERRIDE='' FM_HOME="$HOME_DIR" \
+    FM_STATE_OVERRIDE="$HOME_DIR/state" FM_DATA_OVERRIDE="$HOME_DIR/data" \
+    FM_PROJECTS_OVERRIDE="$HOME_DIR/projects" FM_CONFIG_OVERRIDE="$HOME_DIR/config" \
+    FM_SPAWN_NO_GUARD=1 TMUX="fake,1,0" \
+    FM_FAKE_LEASE_PATH="$lease" FM_FAKE_PANE_PATH="$pane" \
+    FM_FAKE_TH_LOG="$THLOG" \
+    PATH="$FAKEBIN_DIR:$PATH" \
+    "$SPAWN" "$id" "$PROJ_DIR" --mode no-mistakes --yolo off 2>&1
+}
+
+# A successful spawn leases the worktree under the task id and records it, so a
+# later crash/relaunch can re-bind to the same reserved slot.
+test_spawn_leases_worktree_under_task_id() {
+  local rec id out status
+  id="lease-keyed-z1"
+  rec=$(make_lease_case lease-keyed "$id")
+  read_lease_record "$rec"
+
+  set +e
+  out=$(run_lease_spawn "$id" "$WT_DIR" "$WT_DIR")
+  status=$?
+  set -e
+
+  expect_code 0 "$status" "spawn should succeed when the pane settles in the leased worktree"
+  assert_contains "$out" "spawned $id" "spawn did not report success"
+  assert_grep "worktree=$WT_DIR" "$HOME_DIR/state/$id.meta" \
+    "meta did not record the leased worktree"
+  assert_grep "get --lease --lease-holder $id" "$THLOG" \
+    "spawn did not durably lease the task worktree under the task id"
+  pass "spawn leases the task worktree under the task id and records it"
+}
+
+# A spawn that aborts after leasing (here: the pane settles at a path that is
+# not an isolated worktree, so validate_spawn_worktree refuses) must return the
+# lease so a failed launch never leaks a reserved pool slot.
+test_spawn_abort_releases_leased_worktree() {
+  local rec id out status
+  id="lease-abort-z2"
+  rec=$(make_lease_case lease-abort "$id")
+  read_lease_record "$rec"
+
+  set +e
+  out=$(run_lease_spawn "$id" "$WT_DIR" "$BAD_DIR")
+  status=$?
+  set -e
+
+  [ "$status" -ne 0 ] || fail "spawn should have aborted when the pane never reaches an isolated worktree: $out"
+  assert_grep "return --force $WT_DIR" "$THLOG" \
+    "aborted spawn leaked the lease instead of returning the leased worktree"
+  pass "a spawn that aborts after leasing returns the lease (no leaked pool slot)"
+}
+
+# --- real treehouse: the lease contract fm-spawn/fm-teardown rely on ---------
+
+treehouse_supports_lease() {
+  command -v treehouse >/dev/null 2>&1 || return 1
+  treehouse get --help 2>&1 | grep -q -- '--lease' || return 1
+}
+
+# End-to-end against the real treehouse binary, issuing the exact commands
+# fm-spawn (lease) and fm-teardown (return --force) issue. Self-skips when
+# treehouse (or its --lease support) is absent so hermetic CI stays green.
+test_treehouse_lease_contract_real() {
+  if ! treehouse_supports_lease; then
+    pass "SKIP real-treehouse lease contract (treehouse with --lease not installed)"
+    return 0
+  fi
+  local id=relaunch-rebind other=competing-slot case_dir repo wt branch head
+  case_dir="$TMP_ROOT/real-lease"
+  repo="$case_dir/repo"
+  mkdir -p "$case_dir"
+  fm_git_init_commit "$repo"
+  # Keep the pool inside the scratch tree so it is isolated from any real pool.
+  printf 'max_trees = 16\nroot = "%s"\n' "$case_dir" > "$repo/treehouse.toml"
+  git -C "$repo" -c user.email=t@t -c user.name=t add treehouse.toml
+  git -C "$repo" -c user.email=t@t -c user.name=t commit -qm "treehouse config"
+
+  # Lease exactly as fm-spawn does (path-only stdout; banners to stderr).
+  wt=$( cd "$repo" && treehouse get --lease --lease-holder "$id" ) \
+    || fail "treehouse get --lease failed"
+  [ -n "$wt" ] && [ -d "$wt" ] || fail "lease reported no worktree: '$wt'"
+
+  # Put in-flight work on a task branch, as a crewmate would.
+  git -C "$wt" checkout -q -b "fm/$id"
+  printf 'in-flight\n' > "$wt/inflight.txt"
+  git -C "$wt" -c user.email=t@t -c user.name=t add inflight.txt
+  git -C "$wt" -c user.email=t@t -c user.name=t commit -qm "task work"
+  head=$(git -C "$wt" rev-parse HEAD)
+
+  # A competing pool acquire + prune (the crash-window recycling the old bare
+  # `treehouse get` was vulnerable to) must NOT touch the leased slot.
+  ( cd "$repo" && treehouse get --lease --lease-holder "$other" >/dev/null ) \
+    || fail "competing treehouse get --lease failed"
+  ( cd "$repo" && treehouse prune >/dev/null ) || fail "treehouse prune failed"
+
+  # idle-lease-survives-pool-op + relaunch-rebinds-to-branch: the leased slot,
+  # its branch, and its commit are all still there, so a relaunch cd'ing back
+  # to this recorded path re-binds to the same branch instead of a reset copy.
+  [ -d "$wt" ] || fail "leased worktree vanished after competing pool ops"
+  branch=$(git -C "$wt" rev-parse --abbrev-ref HEAD)
+  [ "$branch" = "fm/$id" ] || fail "leased worktree lost its branch (now on '$branch')"
+  [ "$(git -C "$wt" rev-parse HEAD)" = "$head" ] || fail "leased worktree lost its commit"
+  ( cd "$repo" && treehouse status 2>/dev/null ) | grep -q "held by $id" \
+    || fail "treehouse no longer reports the slot leased under the task id"
+
+  # teardown-releases-lease: `treehouse return --force` frees the slot.
+  ( cd "$repo" && treehouse return --force "$wt" >/dev/null ) \
+    || fail "treehouse return --force failed to release the lease"
+  if ( cd "$repo" && treehouse status 2>/dev/null ) | grep -q "held by $id"; then
+    fail "lease was not released after treehouse return --force"
+  fi
+  # The scratch pool (and its remaining competing lease) lives entirely under
+  # the fm_test_tmproot dir, removed on EXIT; no treehouse processes persist.
+  pass "real treehouse: leased slot survives pool ops with its branch, and return frees it"
+}
+
+test_spawn_leases_worktree_under_task_id
+test_spawn_abort_releases_leased_worktree
+test_treehouse_lease_contract_real
+
+echo "# all fm-spawn-worktree-lease tests passed"

--- a/tests/fm-spawn-worktree-lease.test.sh
+++ b/tests/fm-spawn-worktree-lease.test.sh
@@ -95,7 +95,7 @@ make_lease_case() {
 }
 
 read_lease_record() {
-  IFS='|' read -r _ HOME_DIR PROJ_DIR WT_DIR BAD_DIR FAKEBIN_DIR THLOG <<EOF
+  IFS='|' read -r CASE_DIR HOME_DIR PROJ_DIR WT_DIR BAD_DIR FAKEBIN_DIR THLOG <<EOF
 $1
 EOF
 }
@@ -188,6 +188,28 @@ test_relaunch_reuses_recorded_lease() {
   pass "relaunch reuses the recorded lease with its branch and commits"
 }
 
+test_relaunch_accepts_equivalent_status_path() {
+  local rec id out status linked_wt
+  id="lease-relaunch-symlink-z4"
+  rec=$(make_lease_case lease-relaunch-symlink "$id")
+  read_lease_record "$rec"
+
+  out=$(run_lease_spawn "$id" "$WT_DIR" "$WT_DIR")
+  status=$?
+  expect_code 0 "$status" "initial spawn should acquire the task lease"
+  linked_wt="$CASE_DIR/wt-link"
+  ln -s "$WT_DIR" "$linked_wt"
+
+  out=$(run_lease_spawn "$id" "$linked_wt" "$WT_DIR")
+  status=$?
+  expect_code 0 "$status" "relaunch should accept an equivalent Treehouse status path"
+  [ "$(grep -c "^get --lease --lease-holder $id$" "$THLOG")" -eq 1 ] \
+    || fail "equivalent status path caused a second lease acquisition: $(cat "$THLOG")"
+  assert_grep "worktree=$WT_DIR" "$HOME_DIR/state/$id.meta" \
+    "relaunch did not preserve the canonical leased worktree"
+  pass "relaunch recognizes symlink-equivalent Treehouse lease paths"
+}
+
 test_aborted_relaunch_preserves_recorded_lease() {
   local rec id out status
   id="lease-relaunch-abort-z4"
@@ -275,6 +297,7 @@ test_treehouse_lease_contract_real() {
 test_spawn_leases_worktree_under_task_id
 test_spawn_abort_releases_leased_worktree
 test_relaunch_reuses_recorded_lease
+test_relaunch_accepts_equivalent_status_path
 test_aborted_relaunch_preserves_recorded_lease
 test_treehouse_lease_contract_real
 

--- a/tests/fm-spawn-worktree-lease.test.sh
+++ b/tests/fm-spawn-worktree-lease.test.sh
@@ -44,6 +44,7 @@ make_lease_fakebin() {
   cat > "$fakebin/tmux" <<'SH'
 #!/usr/bin/env bash
 set -u
+printf 'tmux %s\n' "$*" >> "${FM_FAKE_TH_LOG:?FM_FAKE_TH_LOG unset}"
 case "$*" in
   *"#{pane_current_path}"*) printf '%s\n' "${FM_FAKE_PANE_PATH:-}"; exit 0 ;;
 esac
@@ -273,6 +274,8 @@ test_relaunch_rejects_unreadable_lease_status() {
     "unreadable-status relaunch did not surface the lease ambiguity"
   assert_no_grep '^get --lease ' "$THLOG" \
     "unreadable-status relaunch acquired a replacement lease"
+  assert_no_grep '^tmux new-window ' "$THLOG" \
+    "unreadable-status relaunch created an endpoint before validating the lease"
   [ "$(cat "$HOME_DIR/state/$id.meta")" = "$meta_before" ] \
     || fail "unreadable-status relaunch changed the recorded task metadata"
   pass "relaunch fails closed when recorded lease status is unreadable"

--- a/tests/fm-spawn-worktree-lease.test.sh
+++ b/tests/fm-spawn-worktree-lease.test.sh
@@ -57,9 +57,14 @@ SH
 #!/usr/bin/env bash
 set -u
 printf '%s\n' "$*" >> "${FM_FAKE_TH_LOG:?FM_FAKE_TH_LOG unset}"
-if [ "${1:-}" = get ]; then
-  printf '%s\n' "${FM_FAKE_LEASE_PATH:?FM_FAKE_LEASE_PATH unset}"
-fi
+case "${1:-}" in
+  get) printf '%s\n' "${FM_FAKE_LEASE_PATH:?FM_FAKE_LEASE_PATH unset}" ;;
+  status)
+    node -e 'console.log(JSON.stringify([{path: process.argv[1], status: "leased", lease_holder: process.argv[2]}]))' \
+      "${FM_FAKE_LEASE_PATH:?FM_FAKE_LEASE_PATH unset}" \
+      "${FM_FAKE_LEASE_HOLDER:?FM_FAKE_LEASE_HOLDER unset}"
+    ;;
+esac
 exit 0
 SH
   chmod +x "$fakebin/treehouse"
@@ -104,6 +109,7 @@ run_lease_spawn() {
     FM_PROJECTS_OVERRIDE="$HOME_DIR/projects" FM_CONFIG_OVERRIDE="$HOME_DIR/config" \
     FM_SPAWN_NO_GUARD=1 TMUX="fake,1,0" \
     FM_FAKE_LEASE_PATH="$lease" FM_FAKE_PANE_PATH="$pane" \
+    FM_FAKE_LEASE_HOLDER="$id" \
     FM_FAKE_TH_LOG="$THLOG" \
     PATH="$FAKEBIN_DIR:$PATH" \
     "$SPAWN" "$id" "$PROJ_DIR" --mode no-mistakes --yolo off 2>&1
@@ -141,14 +147,65 @@ test_spawn_abort_releases_leased_worktree() {
   read_lease_record "$rec"
 
   set +e
-  out=$(run_lease_spawn "$id" "$WT_DIR" "$BAD_DIR")
+  out=$(run_lease_spawn "$id" "$BAD_DIR" "$BAD_DIR")
   status=$?
   set -e
 
   [ "$status" -ne 0 ] || fail "spawn should have aborted when the pane never reaches an isolated worktree: $out"
-  assert_grep "return --force $WT_DIR" "$THLOG" \
+  assert_grep "return --force $BAD_DIR" "$THLOG" \
     "aborted spawn leaked the lease instead of returning the leased worktree"
   pass "a spawn that aborts after leasing returns the lease (no leaked pool slot)"
+}
+
+test_relaunch_reuses_recorded_lease() {
+  local rec id out status branch head
+  id="lease-relaunch-z3"
+  rec=$(make_lease_case lease-relaunch "$id")
+  read_lease_record "$rec"
+
+  out=$(run_lease_spawn "$id" "$WT_DIR" "$WT_DIR")
+  status=$?
+  expect_code 0 "$status" "initial spawn should acquire the task lease"
+  git -C "$WT_DIR" checkout -q -b "fm/$id"
+  printf '%s\n' in-flight > "$WT_DIR/inflight.txt"
+  git -C "$WT_DIR" -c user.email=t@t -c user.name=t add inflight.txt
+  git -C "$WT_DIR" -c user.email=t@t -c user.name=t commit -qm "task work"
+  head=$(git -C "$WT_DIR" rev-parse HEAD)
+
+  out=$(run_lease_spawn "$id" "$WT_DIR" "$WT_DIR")
+  status=$?
+  expect_code 0 "$status" "relaunch should reuse the recorded task lease"
+  [ "$(grep -c "^get --lease --lease-holder $id$" "$THLOG")" -eq 1 ] \
+    || fail "relaunch acquired a second worktree lease: $(cat "$THLOG")"
+  assert_no_grep "return --force $WT_DIR" "$THLOG" \
+    "successful relaunch returned the reused task lease"
+  branch=$(git -C "$WT_DIR" rev-parse --abbrev-ref HEAD)
+  [ "$branch" = "fm/$id" ] || fail "relaunch lost the task branch (now '$branch')"
+  [ "$(git -C "$WT_DIR" rev-parse HEAD)" = "$head" ] \
+    || fail "relaunch lost the task's in-flight commit"
+  assert_grep "worktree=$WT_DIR" "$HOME_DIR/state/$id.meta" \
+    "relaunch did not preserve the recorded leased worktree"
+  pass "relaunch reuses the recorded lease with its branch and commits"
+}
+
+test_aborted_relaunch_preserves_recorded_lease() {
+  local rec id out status
+  id="lease-relaunch-abort-z4"
+  rec=$(make_lease_case lease-relaunch-abort "$id")
+  read_lease_record "$rec"
+  printf '%s\n' "worktree=$BAD_DIR" > "$HOME_DIR/state/$id.meta"
+
+  set +e
+  out=$(run_lease_spawn "$id" "$BAD_DIR" "$BAD_DIR")
+  status=$?
+  set -e
+
+  [ "$status" -ne 0 ] || fail "relaunch should reject a recorded lease that is not an isolated worktree: $out"
+  assert_no_grep '^get --lease ' "$THLOG" \
+    "relaunch acquired a fresh lease instead of reusing the recorded lease"
+  assert_no_grep "return --force $BAD_DIR" "$THLOG" \
+    "aborted relaunch returned a lease acquired by the original spawn"
+  pass "aborted relaunch preserves the original task lease"
 }
 
 # --- real treehouse: the lease contract fm-spawn/fm-teardown rely on ---------
@@ -217,6 +274,8 @@ test_treehouse_lease_contract_real() {
 
 test_spawn_leases_worktree_under_task_id
 test_spawn_abort_releases_leased_worktree
+test_relaunch_reuses_recorded_lease
+test_aborted_relaunch_preserves_recorded_lease
 test_treehouse_lease_contract_real
 
 echo "# all fm-spawn-worktree-lease tests passed"

--- a/tests/fm-spawn-worktree-lease.test.sh
+++ b/tests/fm-spawn-worktree-lease.test.sh
@@ -60,6 +60,7 @@ printf '%s\n' "$*" >> "${FM_FAKE_TH_LOG:?FM_FAKE_TH_LOG unset}"
 case "${1:-}" in
   get) printf '%s\n' "${FM_FAKE_LEASE_PATH:?FM_FAKE_LEASE_PATH unset}" ;;
   status)
+    [ "${FM_FAKE_STATUS_FAIL:-0}" != 1 ] || exit 1
     node -e 'console.log(JSON.stringify([{path: process.argv[1], status: "leased", lease_holder: process.argv[2]}]))' \
       "${FM_FAKE_LEASE_PATH:?FM_FAKE_LEASE_PATH unset}" \
       "${FM_FAKE_LEASE_HOLDER:?FM_FAKE_LEASE_HOLDER unset}"
@@ -109,7 +110,8 @@ run_lease_spawn() {
     FM_PROJECTS_OVERRIDE="$HOME_DIR/projects" FM_CONFIG_OVERRIDE="$HOME_DIR/config" \
     FM_SPAWN_NO_GUARD=1 TMUX="fake,1,0" \
     FM_FAKE_LEASE_PATH="$lease" FM_FAKE_PANE_PATH="$pane" \
-    FM_FAKE_LEASE_HOLDER="$id" \
+    FM_FAKE_LEASE_HOLDER="${FM_FAKE_LEASE_HOLDER_OVERRIDE:-$id}" \
+    FM_FAKE_STATUS_FAIL="${FM_FAKE_STATUS_FAIL_OVERRIDE:-0}" \
     FM_FAKE_TH_LOG="$THLOG" \
     PATH="$FAKEBIN_DIR:$PATH" \
     "$SPAWN" "$id" "$PROJ_DIR" --mode no-mistakes --yolo off 2>&1
@@ -230,6 +232,52 @@ test_aborted_relaunch_preserves_recorded_lease() {
   pass "aborted relaunch preserves the original task lease"
 }
 
+test_relaunch_rejects_wrong_lease_holder() {
+  local rec id out status meta_before
+  id="lease-wrong-holder-z5"
+  rec=$(make_lease_case lease-wrong-holder "$id")
+  read_lease_record "$rec"
+  printf '%s\n' "worktree=$WT_DIR" "project=$PROJ_DIR" > "$HOME_DIR/state/$id.meta"
+  meta_before=$(cat "$HOME_DIR/state/$id.meta")
+
+  set +e
+  out=$(FM_FAKE_LEASE_HOLDER_OVERRIDE=another-task run_lease_spawn "$id" "$WT_DIR" "$WT_DIR")
+  status=$?
+  set -e
+
+  [ "$status" -ne 0 ] || fail "relaunch should reject a lease owned by another task: $out"
+  assert_contains "$out" "is not leased under task id $id" \
+    "wrong-holder relaunch did not surface the lease ambiguity"
+  assert_no_grep '^get --lease ' "$THLOG" \
+    "wrong-holder relaunch acquired a replacement lease"
+  [ "$(cat "$HOME_DIR/state/$id.meta")" = "$meta_before" ] \
+    || fail "wrong-holder relaunch changed the recorded task metadata"
+  pass "relaunch fails closed when another task holds the recorded lease"
+}
+
+test_relaunch_rejects_unreadable_lease_status() {
+  local rec id out status meta_before
+  id="lease-status-failure-z6"
+  rec=$(make_lease_case lease-status-failure "$id")
+  read_lease_record "$rec"
+  printf '%s\n' "worktree=$WT_DIR" "project=$PROJ_DIR" > "$HOME_DIR/state/$id.meta"
+  meta_before=$(cat "$HOME_DIR/state/$id.meta")
+
+  set +e
+  out=$(FM_FAKE_STATUS_FAIL_OVERRIDE=1 run_lease_spawn "$id" "$WT_DIR" "$WT_DIR")
+  status=$?
+  set -e
+
+  [ "$status" -ne 0 ] || fail "relaunch should reject unreadable lease status: $out"
+  assert_contains "$out" "could not validate the recorded task worktree lease" \
+    "unreadable-status relaunch did not surface the lease ambiguity"
+  assert_no_grep '^get --lease ' "$THLOG" \
+    "unreadable-status relaunch acquired a replacement lease"
+  [ "$(cat "$HOME_DIR/state/$id.meta")" = "$meta_before" ] \
+    || fail "unreadable-status relaunch changed the recorded task metadata"
+  pass "relaunch fails closed when recorded lease status is unreadable"
+}
+
 # --- real treehouse: the lease contract fm-spawn/fm-teardown rely on ---------
 
 treehouse_supports_lease() {
@@ -299,6 +347,8 @@ test_spawn_abort_releases_leased_worktree
 test_relaunch_reuses_recorded_lease
 test_relaunch_accepts_equivalent_status_path
 test_aborted_relaunch_preserves_recorded_lease
+test_relaunch_rejects_wrong_lease_holder
+test_relaunch_rejects_unreadable_lease_status
 test_treehouse_lease_contract_real
 
 echo "# all fm-spawn-worktree-lease tests passed"

--- a/tests/fm-spawn-worktree-settle.test.sh
+++ b/tests/fm-spawn-worktree-settle.test.sh
@@ -4,15 +4,13 @@
 # the leased task worktree).
 #
 # On some tmux/WSL setups a brand-new window's pane_current_path transiently
-# reports a stale, unrelated-but-real path on the very first poll, before the
-# pane actually settles into the worktree it was moved to. That stale
-# path still passes the loop's "differs from the project" check and
+# reports a stale, unrelated-but-real path before the pane actually settles
+# into the worktree it was moved to. That stale path passes
 # validate_spawn_worktree's "is a real, distinct worktree" check (it IS a real
-# git checkout, just the wrong one), so a naive single-read loop silently
-# records the wrong worktree= in state/<id>.meta. This test simulates that
-# transient-then-settled pane_current_path sequence with a fake tmux and
-# asserts the recorded worktree resolves to the real, settled worktree, never
-# the stale first read.
+# git checkout, just the wrong one), so accepting any repeated non-project path
+# silently records the wrong worktree= in state/<id>.meta. This test simulates
+# transient-then-settled pane_current_path sequences with a fake tmux and
+# asserts the recorded worktree is the exact leased worktree.
 set -u
 
 # shellcheck source=tests/lib.sh
@@ -134,12 +132,31 @@ test_single_stale_first_read_is_not_accepted() {
   pass "a single transient stale pane_current_path read is not accepted as the worktree"
 }
 
+# Two matching stale reads used to satisfy the settle loop even though the
+# lease had already identified the only valid destination. The loop must wait
+# for the pane to reach the exact leased worktree instead.
+test_repeated_stale_path_is_not_accepted() {
+  local rec id out status
+  id=settle-repeated-stale-z2
+  rec=$(make_settle_case settle-repeated "$id" 2)
+  read_settle_record "$rec"
+
+  out=$(run_settle_spawn "$id")
+  status=$?
+  expect_code 0 "$status" "spawn should ignore a repeated stale path and reach the lease"
+  assert_grep "worktree=$WT_DIR" "$HOME_DIR/state/$id.meta" \
+    "meta did not record the exact leased worktree"
+  assert_no_grep "worktree=$STALE_DIR" "$HOME_DIR/state/$id.meta" \
+    "meta wrongly recorded a repeated unrelated worktree"
+  pass "repeated stale pane paths cannot override the leased worktree"
+}
+
 # A pane that reports the real worktree from the very first read still only
 # costs the loop's existing one-second inter-poll sleep to confirm - not an
 # extra full cycle on top of that.
 test_already_settled_pane_costs_one_confirm_sleep() {
   local rec id out status start end elapsed
-  id=settle-already-settled-z2
+  id=settle-already-settled-z3
   rec=$(make_settle_case settle-already-settled "$id" 0)
   read_settle_record "$rec"
 
@@ -156,6 +173,7 @@ test_already_settled_pane_costs_one_confirm_sleep() {
 }
 
 test_single_stale_first_read_is_not_accepted
+test_repeated_stale_path_is_not_accepted
 test_already_settled_pane_costs_one_confirm_sleep
 
 echo "# all fm-spawn-worktree-settle tests passed"

--- a/tests/fm-spawn-worktree-settle.test.sh
+++ b/tests/fm-spawn-worktree-settle.test.sh
@@ -1,10 +1,11 @@
 #!/usr/bin/env bash
-# Regression test for the fm-spawn.sh treehouse-get worktree-detection settle
-# loop (bin/fm-spawn.sh, the `for _ in $(seq 1 60)` loop after `treehouse get`).
+# Regression test for the fm-spawn.sh worktree-detection settle loop
+# (bin/fm-spawn.sh, the `for _ in $(seq 1 60)` loop after the pane is cd'd into
+# the leased task worktree).
 #
 # On some tmux/WSL setups a brand-new window's pane_current_path transiently
 # reports a stale, unrelated-but-real path on the very first poll, before the
-# pane actually settles into the worktree treehouse get moved it to. That stale
+# pane actually settles into the worktree it was moved to. That stale
 # path still passes the loop's "differs from the project" check and
 # validate_spawn_worktree's "is a real, distinct worktree" check (it IS a real
 # git checkout, just the wrong one), so a naive single-read loop silently
@@ -54,7 +55,19 @@ esac
 exit 0
 SH
   chmod +x "$fakebin/tmux"
-  fm_fake_exit0 "$fakebin" treehouse
+  # fm-spawn now LEASES the task worktree in-process: `treehouse get --lease
+  # --lease-holder <id>` must print the leased path to stdout. The pane then
+  # cd's there and the settle poll (faked above) observes it. Any other
+  # treehouse subcommand (e.g. an abort-time return) succeeds silently.
+  cat > "$fakebin/treehouse" <<'SH'
+#!/usr/bin/env bash
+set -u
+if [ "${1:-}" = get ]; then
+  printf '%s\n' "${FM_FAKE_LEASE_PATH:?FM_FAKE_LEASE_PATH unset}"
+fi
+exit 0
+SH
+  chmod +x "$fakebin/treehouse"
   printf '%s\n' "$fakebin"
 }
 
@@ -96,6 +109,7 @@ run_settle_spawn() {
     FM_SPAWN_NO_GUARD=1 TMUX="fake,1,0" \
     FM_FAKE_PANE_PATH="$WT_DIR" FM_FAKE_PANE_STALE="$STALE_DIR" \
     FM_FAKE_PANE_STALE_READS="$STALE_READS" FM_FAKE_PANE_COUNTFILE="$COUNTFILE" \
+    FM_FAKE_LEASE_PATH="$WT_DIR" \
     PATH="$FAKEBIN_DIR:$PATH" \
     "$SPAWN" "$id" "$PROJ_DIR" --mode no-mistakes --yolo off 2>&1
 }

--- a/tests/fm-tangle-guard.test.sh
+++ b/tests/fm-tangle-guard.test.sh
@@ -149,7 +149,7 @@ test_brief_assertion_precedes_branch() {
 
 # --- GUARD 1b: fm-spawn isolation abort -------------------------------------
 
-# A fake tmux that reports FM_FAKE_PANE_PATH as the post-`treehouse get` pane cwd
+# A fake tmux that reports FM_FAKE_PANE_PATH as the post-worktree-cd pane cwd
 # (so the spawn's worktree-resolution loop resolves to a path we control), names
 # the session on '#S', and swallows window ops. Echoes the fakebin dir.
 make_spawn_fakebin() {
@@ -169,7 +169,16 @@ esac
 exit 0
 SH
   chmod +x "$fakebin/tmux"
-  fm_fake_exit0 "$fakebin" treehouse
+  # fm-spawn leases the task worktree: `treehouse get --lease` prints the leased
+  # path the pane is cd'd into (here FM_FAKE_PANE_PATH, the deliberately
+  # non-isolated path the guard must still reject); other subcommands exit 0.
+  cat > "$fakebin/treehouse" <<'SH'
+#!/usr/bin/env bash
+set -u
+[ "${1:-}" = get ] && printf '%s\n' "${FM_FAKE_PANE_PATH:?FM_FAKE_PANE_PATH unset}"
+exit 0
+SH
+  chmod +x "$fakebin/treehouse"
   printf '%s\n' "$fakebin"
 }
 
@@ -224,8 +233,8 @@ test_spawn_isolation_abort() {
 #     tmux appends at the next free index instead of the active window index, which
 #     collides under base-index 1;
 #   - the window id is captured (-P -F #{window_id}) and automatic-rename/allow-rename
-#     are disabled so the fm-<id> name survives treehouse cd'ing into the worktree;
-#   - the treehouse-get send-keys and the worktree wait loop target that stable
+#     are disabled so the fm-<id> name survives the pane cd'ing into the worktree;
+#   - the leased-worktree cd send-keys and the worktree wait loop target that stable
 #     window id, never the (possibly-renamed) name - a lost name would let
 #     display-message fall back to the active client's window and misread firstmate's
 #     OWN pane as the worktree, tangling a hook into the primary checkout.
@@ -248,7 +257,16 @@ esac
 exit 0
 SH
   chmod +x "$fakebin/tmux"
-  fm_fake_exit0 "$fakebin" treehouse
+  # fm-spawn leases the task worktree: `treehouse get --lease` prints the leased
+  # path the pane is cd'd into (here FM_FAKE_PANE_PATH, the deliberately
+  # non-isolated path the guard must still reject); other subcommands exit 0.
+  cat > "$fakebin/treehouse" <<'SH'
+#!/usr/bin/env bash
+set -u
+[ "${1:-}" = get ] && printf '%s\n' "${FM_FAKE_PANE_PATH:?FM_FAKE_PANE_PATH unset}"
+exit 0
+SH
+  chmod +x "$fakebin/treehouse"
   printf '%s\n' "$fakebin"
 }
 
@@ -292,9 +310,9 @@ test_spawn_tmux_window_construction() {
   assert_grep "set-window-option -t @spawnwid allow-rename off" "$rec" \
     "must disable allow-rename on the spawned window"
 
-  # Bug 2 fix (b): treehouse-get and the worktree wait loop target the stable id.
-  assert_grep "send-keys -t @spawnwid treehouse get Enter" "$rec" \
-    "treehouse get must be sent to the stable window id"
+  # Bug 2 fix (b): the leased-worktree cd and the worktree wait loop target the stable id.
+  assert_grep "send-keys -t @spawnwid cd '$wt' Enter" "$rec" \
+    "the leased-worktree cd must be sent to the stable window id"
   assert_grep "display-message -p -t @spawnwid #{pane_current_path}" "$rec" \
     "the worktree wait loop must query the stable window id, not the name"
 

--- a/tests/fm-teardown.test.sh
+++ b/tests/fm-teardown.test.sh
@@ -610,6 +610,39 @@ test_no_mistakes_origin_remote_allows() {
   pass "no-mistakes worktree with HEAD on origin is torn down (no regression)"
 }
 
+# The task worktree is leased at spawn (bin/fm-spawn.sh), so an ordinary
+# teardown must RETURN that worktree to release the lease and free the pool
+# slot - otherwise leased slots would leak. This asserts teardown issues
+# `treehouse return --force <worktree>` on the ALLOW path. The unlanded-work
+# guard still gates that return: the REFUSE cases above exit before it runs, so
+# a leased worktree is never a way to bypass the safety check.
+test_teardown_returns_leased_worktree_to_release_lease() {
+  local case_dir rc thlog
+  case_dir=$(make_case nm-lease-release)
+  thlog="$case_dir/treehouse.log"
+  # Log every treehouse invocation so we can assert the lease-releasing return.
+  cat > "$case_dir/fakebin/treehouse" <<SH
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> "$thlog"
+exit 0
+SH
+  chmod +x "$case_dir/fakebin/treehouse"
+  write_meta "$case_dir" no-mistakes ship
+  wt_commit "$case_dir" "shippable work"
+  git -C "$case_dir/wt" push -q origin fm/task-x1
+  git -C "$case_dir/project" fetch -q origin
+
+  set +e
+  run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 0 "$rc" "nm-lease-release: teardown should succeed for landed work"
+  assert_grep "return --force $case_dir/wt" "$thlog" \
+    "teardown did not return the leased task worktree (its lease would leak)"
+  pass "teardown returns the leased task worktree to release its lease"
+}
+
 test_no_mistakes_truly_unpushed_refuses() {
   local case_dir rc
   case_dir=$(make_case nm-unpushed)
@@ -1830,6 +1863,7 @@ test_teardown_manual_backend_prompts_hand_edit_even_when_tasks_axi_present
 test_local_only_truly_unpushed_refuses
 test_local_only_merged_to_local_main_allows
 test_no_mistakes_origin_remote_allows
+test_teardown_returns_leased_worktree_to_release_lease
 test_no_mistakes_truly_unpushed_refuses
 test_local_only_force_overrides_unpushed
 test_teardown_missing_busy_sidecar_completes

--- a/tests/fm-teardown.test.sh
+++ b/tests/fm-teardown.test.sh
@@ -1374,6 +1374,9 @@ case "\${1:-} \${2:-}" in
   "pane close")
     : > "\${FM_FAKE_HERDR_CLOSED:?}"
     ;;
+  "pane run")
+    : > "$case_dir/left-worktree"
+    ;;
   "pane get")
     if [ "\${FM_FAKE_HERDR_PANE_GET_GARBAGE:-0}" = 1 ]; then
       printf '%s\n' 'not-json'
@@ -1383,7 +1386,11 @@ case "\${1:-} \${2:-}" in
       printf '%s\n' '{"error":{"code":"pane_not_found"}}' >&2
       exit 1
     fi
-    printf '%s\n' '{"result":{"pane":{"pane_id":"wG:pQ","tab_id":"wG:tQ","workspace_id":"wG"}}}'
+    if [ -e "$case_dir/left-worktree" ]; then
+      printf '%s\n' '{"result":{"pane":{"pane_id":"wG:pQ","tab_id":"wG:tQ","workspace_id":"wG","foreground_cwd":"$case_dir/project"}}}'
+    else
+      printf '%s\n' '{"result":{"pane":{"pane_id":"wG:pQ","tab_id":"wG:tQ","workspace_id":"wG","foreground_cwd":"$case_dir/wt"}}}'
+    fi
     ;;
   "agent get")
     printf '%s\n' '{"error":{"code":"agent_not_found"}}' >&2
@@ -1784,6 +1791,9 @@ case "${1:-} ${2:-}" in
     fi
     : > "${FM_FAKE_HERDR_CLOSED:?}"
     ;;
+  "pane run")
+    : > "${FM_FAKE_HERDR_LEFT_WORKTREE:?}"
+    ;;
   "pane get")
     if [ -e "${FM_FAKE_HERDR_CLOSED:?}" ]; then
       if [ "${FM_FAKE_HERDR_PRESENCE_UNKNOWN:-0}" = 1 ]; then
@@ -1793,7 +1803,12 @@ case "${1:-} ${2:-}" in
       printf '%s\n' '{"error":{"code":"pane_not_found"}}' >&2
       exit 1
     fi
-    printf '%s\n' '{"result":{"pane":{"pane_id":"w1:p2","tab_id":"w1:t2","workspace_id":"w1"}}}'
+    if [ -e "${FM_FAKE_HERDR_LEFT_WORKTREE:?}" ]; then
+      printf '{"result":{"pane":{"pane_id":"w1:p2","tab_id":"w1:t2","workspace_id":"w1","foreground_cwd":"%s"}}}\n' \
+        "${FM_FAKE_HERDR_PROJECT:?}"
+    else
+      printf '%s\n' '{"result":{"pane":{"pane_id":"w1:p2","tab_id":"w1:t2","workspace_id":"w1"}}}'
+    fi
     ;;
   "tab get")
     printf '%s\n' '{"result":{"tab":{"tab_id":"w2:t2","workspace_id":"w2"}}}'
@@ -1819,6 +1834,7 @@ test_herdr_projection_teardown_retires_journal_only_after_confirmed_close() {
   log="$case_dir/herdr.log"; closed="$case_dir/closed"; restored="$case_dir/restored"; : > "$log"
 
   FM_FAKE_HERDR_LOG="$log" FM_FAKE_HERDR_CLOSED="$closed" FM_FAKE_HERDR_RESTORED="$restored" \
+    FM_FAKE_HERDR_LEFT_WORKTREE="$case_dir/left-worktree" FM_FAKE_HERDR_PROJECT="$case_dir/project" \
     run_teardown "$case_dir" --force > "$case_dir/stdout" 2> "$case_dir/stderr" \
     || fail "herdr-projection-confirmed-close: forced teardown failed"
   [ ! -e "$case_dir/state/task-x1.herdr-presentation" ] \
@@ -1838,7 +1854,9 @@ test_herdr_projection_teardown_retains_journal_when_close_unconfirmed() {
   log="$case_dir/herdr.log"; closed="$case_dir/closed"; restored="$case_dir/restored"; : > "$log"
 
   local rc=0
-  FM_FAKE_HERDR_LOG="$log" FM_FAKE_HERDR_CLOSED="$closed" FM_FAKE_HERDR_RESTORED="$restored" FM_FAKE_HERDR_PRESENCE_UNKNOWN=1 \
+  FM_FAKE_HERDR_LOG="$log" FM_FAKE_HERDR_CLOSED="$closed" FM_FAKE_HERDR_RESTORED="$restored" \
+    FM_FAKE_HERDR_LEFT_WORKTREE="$case_dir/left-worktree" FM_FAKE_HERDR_PROJECT="$case_dir/project" \
+    FM_FAKE_HERDR_PRESENCE_UNKNOWN=1 \
     run_teardown "$case_dir" --force > "$case_dir/stdout" 2> "$case_dir/stderr" || rc=$?
   [ "$rc" -ne 0 ] \
     || fail "herdr-projection-unconfirmed-close: teardown reported success after an unknown post-close presence read"

--- a/tests/fm-trace-context-spawn.test.sh
+++ b/tests/fm-trace-context-spawn.test.sh
@@ -79,12 +79,20 @@ exit 0
 SH
   chmod +x "$fakebin/tmux"
   # fm-spawn LEASES the task worktree in-process: `treehouse get --lease
-  # --lease-holder <id>` prints the leased path. The pane settles there, which
-  # in these cases is FM_FAKE_PANE_PATH; any other subcommand exits silently.
+  # --lease-holder <id>` prints the leased path. On relaunch, `status --json`
+  # proves that the recorded path is still leased to the same task. The pane
+  # settles there, which in these cases is FM_FAKE_PANE_PATH.
   cat > "$fakebin/treehouse" <<'SH'
 #!/usr/bin/env bash
 set -u
-[ "${1:-}" = get ] && printf '%s\n' "${FM_FAKE_PANE_PATH:?FM_FAKE_PANE_PATH unset}"
+case "${1:-}" in
+  get) printf '%s\n' "${FM_FAKE_PANE_PATH:?FM_FAKE_PANE_PATH unset}" ;;
+  status)
+    node -e 'console.log(JSON.stringify([{path: process.argv[1], status: "leased", lease_holder: process.argv[2]}]))' \
+      "${FM_FAKE_PANE_PATH:?FM_FAKE_PANE_PATH unset}" \
+      "${FM_FAKE_LEASE_HOLDER:?FM_FAKE_LEASE_HOLDER unset}"
+    ;;
+esac
 exit 0
 SH
   chmod +x "$fakebin/treehouse"
@@ -123,6 +131,7 @@ run_spawn() {
     FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
     FM_PROJECTS_OVERRIDE="$home/projects" FM_CONFIG_OVERRIDE="$home/config" \
     FM_SPAWN_NO_GUARD=1 FM_FAKE_PANE_PATH="$wt" TMUX="fake,1,0" \
+    FM_FAKE_LEASE_HOLDER="$1" \
     FM_FAKE_TRACEPARENT_SEND_FAIL="${FM_FAKE_TRACEPARENT_SEND_FAIL:-0}" \
     FM_FAKE_TRACEPARENT_SEND_UNSAFE="${FM_FAKE_TRACEPARENT_SEND_UNSAFE:-0}" \
     FM_FAKE_TRACE_METADATA_APPEND_FAIL="${FM_FAKE_TRACE_METADATA_APPEND_FAIL:-0}" \
@@ -141,6 +150,7 @@ run_spawn_tc() {
     FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
     FM_PROJECTS_OVERRIDE="$home/projects" FM_CONFIG_OVERRIDE="$home/config" \
     FM_SPAWN_NO_GUARD=1 FM_FAKE_PANE_PATH="$wt" TMUX="fake,1,0" \
+    FM_FAKE_LEASE_HOLDER="$1" \
     FM_FAKE_LAUNCH_LOG="$launchlog" PATH="$fakebin:$PATH" \
     "$SPAWN" "$@" --mode no-mistakes --yolo off 2>&1
 }

--- a/tests/fm-trace-context-spawn.test.sh
+++ b/tests/fm-trace-context-spawn.test.sh
@@ -88,9 +88,13 @@ set -u
 case "${1:-}" in
   get) printf '%s\n' "${FM_FAKE_PANE_PATH:?FM_FAKE_PANE_PATH unset}" ;;
   status)
-    node -e 'console.log(JSON.stringify([{path: process.argv[1], status: "leased", lease_holder: process.argv[2]}]))' \
-      "${FM_FAKE_PANE_PATH:?FM_FAKE_PANE_PATH unset}" \
-      "${FM_FAKE_LEASE_HOLDER:?FM_FAKE_LEASE_HOLDER unset}"
+    if [ "${2:-}" = --help ]; then
+      printf '%s\n' '      --json   Print pool status as JSON'
+    else
+      node -e 'console.log(JSON.stringify([{path: process.argv[1], status: "leased", lease_holder: process.argv[2]}]))' \
+        "${FM_FAKE_PANE_PATH:?FM_FAKE_PANE_PATH unset}" \
+        "${FM_FAKE_LEASE_HOLDER:?FM_FAKE_LEASE_HOLDER unset}"
+    fi
     ;;
 esac
 exit 0

--- a/tests/fm-trace-context-spawn.test.sh
+++ b/tests/fm-trace-context-spawn.test.sh
@@ -78,7 +78,16 @@ esac
 exit 0
 SH
   chmod +x "$fakebin/tmux"
-  fm_fake_exit0 "$fakebin" treehouse
+  # fm-spawn LEASES the task worktree in-process: `treehouse get --lease
+  # --lease-holder <id>` prints the leased path. The pane settles there, which
+  # in these cases is FM_FAKE_PANE_PATH; any other subcommand exits silently.
+  cat > "$fakebin/treehouse" <<'SH'
+#!/usr/bin/env bash
+set -u
+[ "${1:-}" = get ] && printf '%s\n' "${FM_FAKE_PANE_PATH:?FM_FAKE_PANE_PATH unset}"
+exit 0
+SH
+  chmod +x "$fakebin/treehouse"
   printf '%s\n' "$fakebin"
 }
 


### PR DESCRIPTION
## Intent

Lease each task worktree at spawn so a crashed or relaunched task rebinds to its own branch and commits instead of a reset copy on the default branch.

Problem: bin/fm-spawn.sh acquired the task worktree with a bare, unleased `treehouse get`. An unleased pool slot can be recycled by a later `treehouse get`/`prune`, so after a crash or a stuck-task relaunch the pool could hand the same slot back reset onto the default branch, losing the task's branch and in-flight commits. The run resolver `no-mistakes axi respond`, which resolves the active run by the currently checked-out branch, then can no longer find the run ('no active run to respond to'). This defeats crash/stuck recovery, which resumes in the recorded worktree expecting its branch and commits intact.

Fix: lease the worktree under the task id via `treehouse get --lease --lease-holder <id>`, mirroring the leased homes in bin/fm-home-seed.sh. The lease reserves the slot, its branch, and its commits across restarts (skipped by any later get/prune) until teardown returns it, so recovery re-binds to the same worktree. The lease is non-interactive (prints only the worktree path and opens no subshell), so the pane is cd'd into it explicitly; the existing worktree-settle poll and the validate_spawn_worktree isolation check that refuses a non-isolated worktree are unchanged.

Release: the spawn abort trap returns the lease if the launch aborts before the task is durably recorded, so a failed spawn never leaks a reserved pool slot; on success the flag is cleared and the lease persists until teardown. Ordinary teardown already returns the worktree with `treehouse return --force`, which releases the lease and frees the slot, so teardown needed no logic change and every existing teardown safety guard is preserved unchanged: the landed/unlanded-work refusal, the endpoint-binding check, the force-discard-authority requirement, and aborting rather than raw-removing when the return fails.

Tests: a new suite covers relaunch-rebinds-to-branch, idle-lease-survives-a-pool-op, and teardown-releases-lease against real treehouse, plus hermetic checks that spawn issues the lease keyed to the task id and that an aborted spawn returns it. Because fm-spawn now invokes `treehouse get --lease` in-process (rather than sending a bare `treehouse get` to the pane), existing spawn tests were updated so their treehouse stub emits the leased path, including the Herdr post-create abort fixture whose stub now arms the abort by leasing no worktree; a teardown case asserts the lease-releasing return.

This changes firstmate's shared, tracked spawn/teardown worktree lifecycle; the change is conservative and preserves every worktree-isolation and unlanded-work safety guard.

## What Changed

- Lease each Treehouse-backed task worktree under its task ID so branches, commits, and uncommitted work survive crashes and relaunches.
- Reuse only a canonical recorded worktree with a matching lease, fail closed before endpoint creation when validation fails, and settle panes against the exact leased path.
- Release newly acquired leases after aborted spawns and through guarded teardown, with passing lifecycle and backend regression coverage plus updated documentation.

## Risk Assessment

✅ Low: Captain, the correction validates or acquires the task lease before endpoint creation, preserves fail-closed relaunch behavior, and safely returns freshly acquired leases on later spawn failures.

## Testing

Inspected the target lifecycle diff, ran focused spawn, abort, relaunch, real Treehouse, and pane-settle checks, then manually verified an actual leased branch and commit survived competing pool operations and that return removed the lease. All checks passed and reviewer evidence was captured.

<details>
<summary>Evidence: Focused spawn lease test transcript</summary>

```text
ok - spawn leases the task worktree under the task id and records it
ok - a spawn that aborts after leasing returns the lease (no leaked pool slot)
ok - relaunch reuses the recorded lease with its branch and commits
ok - relaunch recognizes symlink-equivalent Treehouse lease paths
ok - aborted relaunch preserves the original task lease
ok - relaunch fails closed when another task holds the recorded lease
ok - relaunch fails closed when recorded lease status is unreadable
A new version of treehouse is available: v2.1.0 → v2.1.1
Run "treehouse update" to update

🌳 Setting up worktree...
🌳 Leased worktree at /tmp/fm-spawn-worktree-lease.STOLQ8/real-lease/.treehouse/repo-7e1da1/1/repo. Run 'treehouse return /tmp/fm-spawn-worktree-lease.STOLQ8/real-lease/.treehouse/repo-7e1da1/1/repo' to release it.
A new version of treehouse is available: v2.1.0 → v2.1.1
Run "treehouse update" to update

🌳 Setting up worktree...
🌳 Leased worktree at /tmp/fm-spawn-worktree-lease.STOLQ8/real-lease/.treehouse/repo-7e1da1/2/repo. Run 'treehouse return /tmp/fm-spawn-worktree-lease.STOLQ8/real-lease/.treehouse/repo-7e1da1/2/repo' to release it.
A new version of treehouse is available: v2.1.0 → v2.1.1
Run "treehouse update" to update

A new version of treehouse is available: v2.1.0 → v2.1.1
Run "treehouse update" to update

🌳 Worktree returned to pool.
ok - real treehouse: leased slot survives pool ops with its branch, and return frees it
# all fm-spawn-worktree-lease tests passed
```
</details>
<details>
<summary>Evidence: Worktree settle test transcript</summary>

```text
ok - a single transient stale pane_current_path read is not accepted as the worktree
ok - repeated stale pane paths cannot override the leased worktree
ok - an already-settled pane confirms via the existing inter-poll sleep, not an extra full cycle
# all fm-spawn-worktree-settle tests passed
```
</details>
<details>
<summary>Evidence: Real Treehouse lifecycle evidence</summary>

`Before and after a competing lease acquisition plus prune, branch fm/evidence-relaunch-task and commit 0ed1d456415f650958713153acb9ea97fce0f938 remained intact. After return, lease_present=false.`

```text
spawned_path=/tmp/no-mistakes-evidence/01KZ6474YWAWHKHCH86ZTR5V85/real-treehouse-pool/.treehouse/repo-a726fb/1/repo
before_pool_ops branch=fm/evidence-relaunch-task commit=0ed1d456415f650958713153acb9ea97fce0f938 content=in-flight task work
lease_before holder=evidence-relaunch-task status=leased path=/tmp/no-mistakes-evidence/01KZ6474YWAWHKHCH86ZTR5V85/real-treehouse-pool/.treehouse/repo-a726fb/1/repo
after_competing_get_and_prune branch=fm/evidence-relaunch-task commit=0ed1d456415f650958713153acb9ea97fce0f938 content=in-flight task work
after_teardown lease_present=false
result=branch_and_commit_preserved_then_lease_released
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed (5) ✅</summary>

- 🚨 `bin/fm-spawn.sh:1724` - Required criterion: “a crashed or relaunched task rebinds to its own branch and commits.” This hunk always calls `treehouse get --lease`, but Treehouse skips every already-leased entry regardless of `--lease-holder`. A relaunch therefore leases a different reset worktree or fails when the pool is full; after metadata is overwritten, the original task lease also becomes unreachable. Reuse and validate the recorded leased worktree on relaunch, acquiring a new lease only for an initial spawn.
- 🚨 `bin/fm-spawn.sh:1760` - The settle loop accepts any non-project worktree observed twice, even though the exact allocation is known in `LEASED_WT`. A persistent stale cwd or an unexecuted `cd` can record and launch from an unrelated worktree while leaving the actual lease orphaned. Canonicalize `LEASED_WT` and require the pane cwd to equal it before assigning `WT`.

🔧 Fix: Bind spawn settling to the canonical leased worktree
1 error still open:
- 🚨 `bin/fm-spawn.sh:1724` - Required criterion: “a crashed or relaunched task rebinds to its own branch and commits.” This hunk still always calls `treehouse get --lease`, while Treehouse skips every already leased entry regardless of `--lease-holder`. A relaunch therefore leases a different reset worktree or fails when the pool is full, and overwriting metadata can orphan the original lease. Reuse and validate the recorded leased worktree on relaunch, acquiring a new lease only for an initial spawn.

🔧 Fix: Reuse recorded task leases during relaunch
2 errors still open:
- 🚨 `bin/fm-spawn.sh:1758` - Required criterion: “Acquire a NEW lease only for an INITIAL spawn.” This fallback also runs when existing metadata records a worktree but its lease is absent or belongs to another holder. Treehouse can select that unleased recorded slot and reset its committed branch before returning it, destroying the work relaunch is meant to preserve. When a recorded worktree cannot be validated, fail closed and retain its metadata; call `get --lease` only when no recorded task worktree exists.
- 🚨 `bin/fm-spawn.sh:1295` - The recorded path is canonicalized with `pwd -P`, but each `treehouse status --json` path is compared verbatim. Treehouse preserves symlink spellings in configured pool roots, so paths such as `/tmp/...` versus `/private/tmp/...` fail to match and relaunch does not reuse the valid lease. Canonicalize status entry paths before comparison or compare equivalent raw and physical paths.

🔧 Fix: Canonicalize Treehouse lease paths during relaunch
1 error still open:
- 🚨 `bin/fm-spawn.sh:1766` - Required criterion: “Acquire a NEW lease only for an INITIAL spawn.” This fallback still runs when existing metadata records a worktree but its lease is absent or belongs to another holder. Treehouse can select that unleased recorded slot and reset its committed branch, destroying the work relaunch is meant to preserve. When a recorded worktree cannot be validated, fail closed and retain its metadata; call `get --lease` only when no recorded task worktree exists.

🔧 Fix: Fail closed on invalid recorded leases
1 warning still open:
- ⚠️ `bin/fm-spawn.sh:1778` - Lease validation now fails after the backend has already created its task window, tab, or workspace. The abort trap does not remove ordinary tmux, Herdr, Zellij, or cmux endpoints, so a transient status failure leaves an empty live endpoint that causes the next relaunch to hit the duplicate-launch refusal even after the lease ambiguity is reconciled. Validate the recorded lease before creating the endpoint, or clean up the endpoint created by this attempt.

🔧 Fix: Validate task leases before endpoint creation
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bash tests/fm-spawn-worktree-lease.test.sh`
- `bash tests/fm-spawn-worktree-settle.test.sh`
- <code>Manual isolated-pool lifecycle using `treehouse get --lease --lease-holder evidence-relaunch-task`, a committed task branch, a competing leased `treehouse get`, `treehouse prune`, branch and commit comparison, `treehouse return --force`, and `treehouse status --json`</code>
- <code>`git status --short` confirmed testing left the worktree unchanged</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
