### PR TITLE
fix: preserve pending-reply identities across caller locales

### DIFF
--- a/bin/fm-pending-reply-lib.sh
+++ b/bin/fm-pending-reply-lib.sh
@@ -727,7 +727,7 @@ fm_pending_reply_send_recovery() {  # <state-dir> <corr_id>
 fm_pending_reply_pid_identity() {  # <pid>
   local pid=$1 identity
   case "$pid" in ''|*[!0-9]*) return 1 ;; esac
-  identity=$(COLUMNS=10000 LC_ALL=C ps -p "$pid" -o lstart= -o command= 2>/dev/null) || return 1
+  identity=$(env COLUMNS=10000 LC_ALL=C ps -p "$pid" -o lstart= -o command= 2>/dev/null) || return 1
   [ -n "$identity" ] || return 1
   printf '%s' "$identity"
 }

--- a/tests/fm-pending-reply.test.sh
+++ b/tests/fm-pending-reply.test.sh
@@ -259,6 +259,7 @@ test_pending_reply_pid_identity_is_locale_invariant() (
   fm_pending_reply_set "$rec" recovery_sender_identity "$expected" \
     || fail "could not record sender identity"
 
+  # shellcheck disable=SC2016 # Child script intentionally uses single quotes.
   observed=$(env -u LANG -u LC_ALL LC_CTYPE=UTF-8 bash -c '
     set -u
     lib=$1

--- a/tests/fm-pending-reply.test.sh
+++ b/tests/fm-pending-reply.test.sh
@@ -19,6 +19,8 @@
 #  10. fm-send secondmate path embeds corr and creates durable pending records
 #  11. Backend busy/idle observation works through the shared busy abstraction
 #      used by Pi/Claude secondmate backends (no conversation scrape)
+#  12. Pending-reply process identities survive the macOS forked-child locale
+#      boundary across the public helper and sender-liveness path
 set -u
 
 # shellcheck source=tests/lib.sh
@@ -231,6 +233,52 @@ test_recovery_attempt_is_never_reinjected() {
   unset FM_PENDING_REPLY_SEND_HOOK
   pass "recovery attempts reconcile without reinjection"
 }
+
+test_pending_reply_pid_identity_is_locale_invariant() (
+  local home state corr rec pid expected observed
+  home=$(setup_parent locale-identity)
+  state="$home/state"
+  sleep 300 &
+  pid=$!
+  trap 'kill "$pid" 2>/dev/null || true; wait "$pid" 2>/dev/null || true' EXIT
+
+  # The pending-reply helper is the portable ps identity path. Keep this
+  # behavioral check available on hosts whose ps supports the documented fields.
+  if ! env LC_ALL=C ps -p "$pid" -o lstart= -o command= >/dev/null 2>&1; then
+    pass "pending-reply ps identity locale check skipped where ps -o lstart= is unsupported"
+    return 0
+  fi
+
+  expected=$(fm_pending_reply_pid_identity "$pid") \
+    || fail "pending-reply identity helper produced no baseline identity"
+  corr=$(fm_pending_reply_create "$home" "$state" hibit "locale identity") \
+    || fail "could not create sender-liveness identity fixture"
+  rec=$(fm_pending_reply_path "$state" "$corr")
+  fm_pending_reply_set "$rec" recovery_sender_pid "$pid" \
+    || fail "could not record sender pid"
+  fm_pending_reply_set "$rec" recovery_sender_identity "$expected" \
+    || fail "could not record sender identity"
+
+  observed=$(env -u LANG -u LC_ALL LC_CTYPE=UTF-8 bash -c '
+    set -u
+    lib=$1
+    pid=$2
+    rec=$3
+    expected=$4
+    . "$lib"
+    last=
+    for i in $(seq 1 96); do
+      last=$(fm_pending_reply_pid_identity "$pid") || exit 1
+      [ "$last" = "$expected" ] || exit 2
+      fm_pending_reply_sender_alive "$rec" || exit 3
+    done
+    printf "%s" "$last"
+  ' _ "$ROOT/bin/fm-pending-reply-lib.sh" "$pid" "$rec" "$expected") \
+    || fail "pending-reply identity paths failed under bare LC_CTYPE=UTF-8"
+  [ "$observed" = "$expected" ] \
+    || fail "pending-reply identity changed under caller locale (got '$observed', want '$expected')"
+  pass "pending-reply identity and sender liveness stay stable under bare LC_CTYPE=UTF-8"
+)
 
 test_recovery_reply_resolves_original() {
   local home state corr hook_log
@@ -910,6 +958,7 @@ test_failed_send_discards_undelivered_expectation() {
 test_normal_correlated_reply_resolves_once
 test_completed_turn_no_report_triggers_one_recovery
 test_recovery_attempt_is_never_reinjected
+test_pending_reply_pid_identity_is_locale_invariant
 test_recovery_reply_resolves_original
 test_second_missed_turn_escalates_once_and_stays_durable
 test_escalation_publication_failure_retries


### PR DESCRIPTION
## Summary

This is the pending-reply follow-up to [#1658](https://github.com/kunchenguid/firstmate/pull/1658)'s wake-locale fix. The remaining `LC_ALL=C` shell assignment inside the command substitution can trigger locale restoration/fork issues on macOS/Homebrew Bash, making a live pending-reply sender identity look unreadable.

## Why it matters

The identity is used during durable recovery, so a false read failure can make a live recovery sender appear gone and lead to incorrect recovery or escalation decisions.

## Fix

Externalize the locale with `env` while preserving `COLUMNS=10000`, matching `fm_pid_identity`. This keeps the lookup locale-invariant without asking Bash to restore `LC_ALL` in the command-substitution child.

## Regression test

Added colocated coverage with 96 repeated identity and liveness checks under `env -u LANG -u LC_ALL LC_CTYPE=UTF-8`. The test exercises the public pending-reply identity helper and sender-liveness path, with portable `ps` fallback handling where supported.

## Validation

- Focused pending-reply suite under the issue locale
- Wake-queue regression suite
- `bin/fm-lint.sh` (ShellCheck 0.11.0)
- `bin/fm-doc-audience-check.sh`
- No duplicate upstream pending-reply locale issue or PR found during intake

## Scope / Risk

Two files: one behavior-preserving lookup change and colocated regression coverage. No watcher cadence changes. Low risk; `COLUMNS=10000`, the C locale, and identity comparison semantics remain unchanged.

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

- intent: passed
- rebase: passed
- review: passed
- test: passed
- document: passed
- lint: passed after the pipeline silenced the intentional SC2016 warning
- push: passed
- CI: monitoring; PR-open run `30907819057` passed and current CI run `30907821114` is in progress
