### PR TITLE
fix(bin): deliver away-mode escalations when the runtime owns the watcher

### DIFF
--- a/.agents/skills/afk/SKILL.md
+++ b/.agents/skills/afk/SKILL.md
@@ -49,8 +49,10 @@ batched digest rather than per-wake injections.
    The daemon is **presence-gated**: it injects escalations only while
    `state/.afk` exists, and stays quiet otherwise.
 
-3. **Do not separately arm `fm-watch.sh`.** The daemon manages the watcher as
-   its child; the singleton lock no-ops a stray arm harmlessly.
+3. **Do not separately arm `fm-watch.sh`.** Either the daemon manages the watcher
+   as its child, or the runtime's own supervision already owns it (see the
+   ownership contract referenced under "Classification policy"); the singleton
+   lock no-ops a stray arm harmlessly either way.
 
 4. **Acknowledge** in `AGENTS.md` section 9 language: "Captain, away mode is active; I will batch routine updates and surface only decisions, failures, credentials, or review-ready work until you return."
 
@@ -146,12 +148,15 @@ behavior but needs a separate fix; the gap is recorded in
 
 ## Classification policy
 
-The daemon wraps `fm-watch.sh`, runs the watcher as a child, classifies each
-wake reason in bash, and self-handles the routine majority without consuming a
-firstmate turn.
+The daemon classifies each wake reason in bash and self-handles the routine
+majority without consuming a firstmate turn.
 Captain-relevant events, plus a bounded recheck of a declared external wait that remains idle, escalate to firstmate's context as one pre-read, single-line, batched digest.
 The classification predicates (the captain-relevant verb set, declared-pause vocabulary, signal/stale tests, and fleet-scan) live in the shared `bin/fm-classify-lib.sh`, the same library the always-on watcher uses for its own triage when afk is off, so the two modes apply one identical policy.
-While `state/.afk` exists the daemon owns the watcher, so the watcher reverts to one-shot and lets the daemon do the triage - the two never run their triage at the same time.
+While `state/.afk` exists the daemon owns triage, so `fm-watch.sh` reverts to one-shot and never triages at the same time.
+
+Which component owns the WATCHER while the daemon owns triage depends on the runtime, and `docs/architecture.md` "Away-mode watcher ownership" is the single owner of that contract.
+In short: where nothing else arms a watcher (claude/tmux, whose Stop auto-arm stands down during away mode) the daemon runs `fm-watch.sh` as its own child and reads that child's reasons; where the runtime owns watcher continuity (Pi, whose tracked extension keeps arming but suppresses the per-wake model handoff) the daemon instead classifies from the durable `state/.wake-queue` that same watcher fills, through a forward-only cursor that never consumes a record firstmate's own drain still needs.
+The daemon detects which case it is in from the singleton lock's health, so neither shape needs a separate away-mode mechanism.
 
 Classify each wake this way:
 

--- a/.pi/extensions/fm-primary-pi-watch.ts
+++ b/.pi/extensions/fm-primary-pi-watch.ts
@@ -10,7 +10,7 @@
 // callbacks from a prior generation are no-ops against the active replacement.
 import { spawn, spawnSync, type ChildProcess } from "node:child_process";
 import { createHash } from "node:crypto";
-import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import type { ExtensionAPI, Theme } from "@earendil-works/pi-coding-agent";
@@ -146,6 +146,23 @@ function markLoaded(): void {
   if (lockOwnership() === "other") return;
   mkdirSync(state, { recursive: true });
   writeFileSync(marker, `${extensionVersion}\n${process.pid}\n`);
+}
+
+// While the durable away-mode flag exists, bin/fm-supervise-daemon.sh owns wake
+// triage: it classifies every wake in bash and delivers only batched, pre-read
+// digests, so waking the model per wake is exactly the firehose /afk exists to
+// prevent. bin/fm-claude-stop-autoarm.sh enforces the same rule for a Claude
+// primary by standing its rewake down entirely.
+//
+// This extension keeps ARMING through away mode rather than standing down, and
+// the difference is deliberate: watcher continuity here is extension-owned
+// (bounded retry, session-lock verification, verified successor per
+// docs/watcher-continuity.md), which is worth keeping during the exact stretch
+// nobody is watching. The daemon reads the durable wake queue this
+// extension-owned watcher fills, so triage still reaches the captain as digests.
+// See docs/architecture.md "Away-mode watcher ownership".
+function awayModeActive(): boolean {
+  return existsSync(`${state}/.afk`);
 }
 
 function actionableLine(output: string): string {
@@ -428,6 +445,11 @@ export default function (pi: ExtensionAPI) {
           const failure = await restoreAfterActionableClose(owner, predecessor);
           if (generationIsLive(owner)) owner.restoring = false;
           if (!generationIsLive(owner)) return;
+          // Continuity is restored above whether or not away mode is active; only
+          // the model handoff is suppressed. An ordinary wake belongs to the away
+          // daemon, but a continuity FAILURE still surfaces: away mode batches
+          // routine notifications, it never hides a broken supervision chain.
+          if (!failure && awayModeActive()) return;
           const message = failure ? `${classification.message}\n\n${failure}` : classification.message;
           await sendWake(owner, message);
         })().catch(() => {

--- a/bin/fm-supervise-daemon.sh
+++ b/bin/fm-supervise-daemon.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # fm-supervise-daemon.sh — presence-gated sub-supervisor (closes #27's P2).
 #
-# Wraps bin/fm-watch.sh: runs it as a child, classifies each wake reason, and
+# Takes its wakes from bin/fm-watch.sh, classifies each wake reason, and
 # either SELF-HANDLES the routine majority in bash (no firstmate turn) or
 # ESCALATES a batched, distilled digest to the supervisor pane on
 # captain-relevant events plus bounded declared-pause rechecks. This is the
@@ -10,6 +10,18 @@
 # needs-decision/blocked/failed/persistent-wedge/check-output events and a
 # declared-pause recheck reach the LLM, and even then as one pre-read digest per
 # batch window.
+#
+# WATCHER OWNERSHIP (two input paths, one classifier). Where nothing else arms a
+# watcher for this home - the claude/tmux shape, whose Stop auto-arm stands down
+# while state/.afk exists - the daemon OWNS the cycle: it runs fm-watch.sh as its
+# own child and classifies that child's printed reasons. Where the runtime owns
+# watcher continuity itself - Pi, whose tracked extension arms fm-watch-arm.sh
+# and holds the home singleton - the daemon instead CONSUMES the durable wake
+# queue that same watcher fills. It detects which case it is in from the
+# singleton lock's health and adapts; see daemon_external_watcher_owns and
+# consume_wake_queue below, and docs/architecture.md "Away-mode watcher
+# ownership". Both paths run the identical handle_wake classification, so away
+# mode behaves the same way whoever owns the watcher.
 #
 # PRESENCE-GATING (the /afk contract). The daemon is the away-mode engine: it
 # injects ONLY when the durable away-mode flag state/.afk is present. Invoking
@@ -33,11 +45,13 @@
 #
 # Reliability model (see the /afk skill):
 #   - Nothing is lost in away mode: while state/.afk exists, the watcher reverts
-#     to daemon-owned one-shot behavior and enqueues every wake to
-#     state/.wake-queue BEFORE advancing its suppression markers, so a
-#     crash/restart/missed injection is recovered on the next fm-wake-drain.sh.
-#     The daemon does not touch the queue; it only reads the watcher's stdout
-#     reason.
+#     to one-shot behavior and enqueues every wake to state/.wake-queue BEFORE
+#     advancing its suppression markers, so a crash/restart/missed injection is
+#     recovered on the next fm-wake-drain.sh. The daemon never REMOVES a queue
+#     record: on the owner path it reads only the watcher child's stdout, and on
+#     the consumer path it reads the queue through a forward-only cursor. The
+#     destructive drain stays firstmate's alone, so neither reader can consume an
+#     event out from under the other.
 #   - Fail-safe-to-escalate: any wake the classifier cannot confidently mark
 #     routine is escalated.
 #   - Bounded wedge latency: a stale pane without a declared external wait is
@@ -96,6 +110,13 @@
 #                                   (default 300)
 #          FM_HOUSEKEEPING_TICK     seconds between housekeeping passes while
 #                                   the watcher is mid-cycle (default 15)
+#          FM_EXTERNAL_WATCHER_GRACE seconds a healthy external watcher must be
+#                                   CONTINUOUSLY absent before this daemon takes
+#                                   the cycle back and owns its own child again
+#                                   (default 20). An external owner swaps watcher
+#                                   generations on every actionable close, so a
+#                                   single missed observation is a handover gap,
+#                                   not a departure.
 #          FM_BUSY_REGEX            optional rendered busy-signature override
 #                                   for delivery guards and Grok's fallback
 #          FM_COMPOSER_IDLE_RE      empty-composer regex applied after dim-ghost
@@ -644,12 +665,18 @@ escalate_flush() {  # <state>
   local state=$1 buf item n msg
   buf="$state/.subsuper-escalations"
   [ -s "$buf" ] || return 0
-  n=$(wc -l < "$buf" 2>/dev/null || echo 0)
+  # BSD wc pads its count, which would render as "(       3 event(s))" in the
+  # digest the captain actually reads, so strip the padding.
+  n=$(wc -l < "$buf" 2>/dev/null | tr -d '[:space:]' || echo 0)
+  [ -n "$n" ] || n=0
   # Join buffered items with the literal " | " separator into one digest line.
   msg=$(awk 'NR>1{printf " | "} {printf "%s",$0} END{print ""}' "$buf" 2>/dev/null)
   # Single-line wrapper: no embedded newlines (inject_msg also collapses as a
   # safety net, but keeping the source single-line makes the intent explicit).
-  msg=$(printf 'Supervisor escalate (%s event(s)): %s (pre-read; re-arm not needed — watcher daemon-managed)' "$n" "$msg")
+  # The re-arm note stays owner-neutral: supervision may be owned by this daemon's
+  # own watcher child or by the runtime's (see the watcher-ownership contract at
+  # the top of this file), and firstmate must not re-arm in either case.
+  msg=$(printf 'Supervisor escalate (%s event(s)): %s (pre-read; re-arm not needed - supervision is already owned)' "$n" "$msg")
   if inject_msg "$msg" "$state"; then : > "$buf"; rm -f "${buf}.since" "$state/.subsuper-inject-wedged"; return 0; fi
   return 1
 }
@@ -1184,11 +1211,13 @@ should_force_self() {  # <reason>
 
 # A real watcher WAKE reason starts with one of these prefixes. Anything else on
 # the watcher child's stdout (e.g. "watcher: already running" on a singleton-lock
-# collision, reachable if the daemon was SIGKILL'd and its orphaned watcher child
-# still holds the #29 singleton lock) is a STATUS line, not a wake: handling it
-# as an unknown wake would flood the escalation buffer and restart the child with
-# no crash backoff. The main loop treats a non-wake line as idle (log + sleep +
-# continue), so a singleton collision cannot hot-loop escalations.
+# collision, reachable when another supervision owner holds the #29 singleton
+# lock) is a STATUS line, not a wake: handling it as an unknown wake would flood
+# the escalation buffer and restart the child with no crash backoff. The main
+# loop treats a non-wake line as idle (log + sleep + continue) whenever this
+# daemon is still the rightful cycle owner, so a transient collision cannot
+# hot-loop escalations; a non-wake close backed by a HEALTHY external owner
+# instead switches the daemon to queue-consumer mode below.
 is_wake_reason() {  # <reason>
   local reason=$1
   case "$reason" in
@@ -1276,6 +1305,118 @@ handle_wake() {  # <reason> <state>
       log "self-handle: $reason -> $distilled"
       ;;
   esac
+}
+
+# --- watcher ownership and durable-queue consumption ------------------------
+# This daemon normally OWNS the supervision cycle: it runs fm-watch.sh as its own
+# child and classifies the wake reasons that child prints. That holds wherever
+# nothing else arms a watcher for this home - notably the claude/tmux shape,
+# where bin/fm-claude-stop-autoarm.sh stands down entirely while state/.afk
+# exists so the daemon is the uncontested owner.
+#
+# Some runtimes own watcher continuity themselves. Under Pi,
+# .pi/extensions/fm-primary-pi-watch.ts arms bin/fm-watch-arm.sh and keeps that
+# child attached to the live Pi process, so the EXTENSION - not this daemon -
+# holds the home singleton lock. This daemon's own child then exits immediately
+# with "watcher: already running pid N", which is not a wake reason, and a daemon
+# that only knew the owner path would idle on that indefinitely while every
+# actionable event went unclassified.
+#
+# Both shapes write the SAME durable record: fm-watch.sh appends every actionable
+# wake to state/.wake-queue BEFORE advancing any suppression marker, whoever
+# started it. So when a healthy external watcher owns the cycle, this daemon
+# reads that queue and feeds each record's payload through the identical
+# handle_wake classifier. One classifier and one policy, two input paths.
+#
+# The cursor file records the highest wake sequence this daemon has classified.
+WAKE_CURSOR_NAME=".subsuper-wake-cursor"
+
+# How long a healthy external watcher must be CONTINUOUSLY absent before this
+# daemon takes the cycle back. An external owner hands over between its own
+# watcher generations, so the singleton is legitimately unheld for a moment on
+# every actionable close; taking over on a single observation makes the daemon
+# spawn a child that immediately loses the lock again, and the mode flaps. The
+# grace sits above bin/fm-watch-arm.sh's own 10s confirm timeout for a fresh
+# watcher to acquire the lock and beat, and far below the beacon grace, so a
+# genuinely dead external owner is still taken over promptly.
+EXTERNAL_WATCHER_GRACE_DEFAULT=20
+
+# 0 when a HEALTHY watcher that this daemon did not start holds the home
+# singleton. "Healthy" is the shared definition in bin/fm-wake-lib.sh
+# (fm_watcher_healthy): the lock is held by a live pid whose recorded process
+# identity still matches, for THIS home and THIS watcher path, with a liveness
+# beacon inside the guard grace window. A lock left by a dead, reused, or
+# stale-beaconed process is therefore NOT healthy, and this daemon falls back to
+# owning its own watcher rather than trusting a corpse and going silent.
+daemon_external_watcher_owns() {  # <state> <watch-path> [own-child-pid]
+  local state=$1 watch_path=$2 own=${3:-}
+  fm_watcher_healthy "$state" "$watch_path" || return 1
+  [ -n "$FM_WATCHER_HEALTHY_PID" ] || return 1
+  [ "$FM_WATCHER_HEALTHY_PID" != "$own" ] || return 1
+  return 0
+}
+
+# Classify every durable wake record newer than this daemon's cursor, exactly as
+# the owner path would.
+#
+# NON-DESTRUCTIVE BY CONTRACT. The destructive drain (bin/fm-wake-drain.sh) stays
+# firstmate's alone; this reader never removes a record. That is what makes the
+# two readers safe to run concurrently without a coordination protocol:
+#   - a record this daemon has classified is never reclassified, because the
+#     cursor only moves forward over the queue's own monotonic seq;
+#   - a record a concurrent drain removed is simply never seen here, because
+#     firstmate consumed and handled it in that turn;
+#   - a record stays queued until firstmate drains it, so the away-mode
+#     "while you were out" catch-up still sees the raw history.
+# The cursor advances only AFTER handle_wake has run, so a crash mid-batch
+# replays that batch rather than dropping it - the same at-least-once boundary
+# fm-wake-drain.sh already documents for its print-before-delete gap. The
+# seen-status markers then suppress a duplicate digest entry for the same line.
+consume_wake_queue() {  # <state>
+  local state=$1 cursor cursor_file highest batch epoch seq kind key payload
+  cursor_file="$state/$WAKE_CURSOR_NAME"
+  # Cheap idle short-circuit: an empty queue costs one stat and never takes the
+  # append lock, so a quiet fleet does not contend with the watcher's writes.
+  [ -s "$FM_WAKE_QUEUE" ] || return 0
+  cursor=$(cat "$cursor_file" 2>/dev/null || true)
+  case "$cursor" in ''|*[!0-9]*) cursor=0 ;; esac
+
+  batch="$state/.subsuper-wake-batch.$$"
+  fm_lock_acquire_wait "$FM_WAKE_QUEUE_LOCK"
+  highest=$(awk -F '\t' 'NF >= 5 && $2 + 0 > m { m = $2 + 0 } END { print m + 0 }' \
+    "$FM_WAKE_QUEUE" 2>/dev/null || echo 0)
+  case "$highest" in ''|*[!0-9]*) highest=0 ;; esac
+  # A non-empty queue whose highest sequence sits BELOW the cursor means the
+  # sequence counter was reset (state rebuilt by hand, a home restored from a
+  # copy). Trust the queue over the stale cursor, or every later record would be
+  # suppressed forever.
+  if [ "$highest" -gt 0 ] && [ "$highest" -lt "$cursor" ]; then
+    cursor=0
+  fi
+  awk -F '\t' -v c="$cursor" 'NF >= 5 && $2 + 0 > c' "$FM_WAKE_QUEUE" > "$batch" 2>/dev/null \
+    || : > "$batch"
+  fm_lock_release "$FM_WAKE_QUEUE_LOCK"
+
+  if [ ! -s "$batch" ]; then
+    rm -f "$batch" 2>/dev/null || true
+    return 0
+  fi
+
+  # Two collapses, so one chatty task cannot turn a single digest window into a
+  # firehose. fm_wake_print_deduped is the queue library's own owner of
+  # per-kind/key collapsing (latest record wins, all heartbeats fold into one);
+  # the second pass then drops payloads that are already byte-identical, because
+  # one watcher signal legitimately enqueues the SAME reason string under one key
+  # per changed file and this consumer classifies reasons rather than keys.
+  while IFS=$(printf '\t') read -r epoch seq kind key payload; do
+    [ -n "$payload" ] || continue
+    is_wake_reason "$payload" || continue
+    log "wake (queued): $payload"
+    handle_wake "$payload" "$state"
+  done < <(fm_wake_print_deduped "$batch" | awk -F '\t' 'NF >= 5 && !seen[$5]++')
+
+  printf '%s\n' "$highest" > "$cursor_file" 2>/dev/null || true
+  rm -f "$batch" 2>/dev/null || true
 }
 
 # --- log --------------------------------------------------------------------
@@ -1457,7 +1598,8 @@ fm_super_main() {
     WATCHER_PID=$!
   }
 
-  local rc reason
+  local rc reason consumer_mode=0 pending_non_wake="" external_absent_since=0
+  local own_cycle=1 external_grace
   while true; do
     # --- pane-gone guard (preserved) ---------------------------------------
     # With the #29 watcher's enqueue-before-suppress, a wake is no longer
@@ -1486,28 +1628,80 @@ fm_super_main() {
           rm -f "${CUR_TMP}" 2>/dev/null || true
         fi
         CUR_TMP=""
+        WATCHER_PID=""
         if [ "$rc" -ne 0 ] || [ -z "$reason" ]; then
           record_crash
           log "watcher exited rc=$rc reason='$reason'; restarting after ${backoff_secs}s"
-          WATCHER_PID=""
           sleep "$backoff_secs"
           continue
         fi
-        # Non-wake stdout (e.g. a watcher singleton-collision "already running"
-        # status line) is NOT a wake: idling here prevents an escalation flood
-        # and a backoff-less child restart. record_crash is intentionally
-        # skipped (rc=0, this is normal idle, not a crash).
-        if ! is_wake_reason "$reason"; then
-          log "watcher non-wake stdout, idling: $reason"
-          WATCHER_PID=""
+        if is_wake_reason "$reason"; then
+          log "wake: $reason"
+          handle_wake "$reason" "$STATE"
+          trim_log
+        else
+          # Non-wake stdout (e.g. a watcher singleton-collision "already running"
+          # status line) is NOT a wake. Defer the verdict to the ownership
+          # decision below: with no healthy external owner this stays the
+          # historical idle (which prevents an escalation flood and a
+          # backoff-less child restart), while a healthy external owner means the
+          # collision is permanent and this daemon must read the queue instead.
+          # record_crash is intentionally skipped either way (rc=0, normal idle).
+          pending_non_wake=$reason
+        fi
+      fi
+
+      # --- watcher-ownership decision ---------------------------------------
+      # Evaluated only when this daemon has no live watcher child, so the owner
+      # path pays nothing for it once its own child is running.
+      external_grace=${FM_EXTERNAL_WATCHER_GRACE:-$EXTERNAL_WATCHER_GRACE_DEFAULT}
+      if daemon_external_watcher_owns "$STATE" "$WATCH"; then
+        external_absent_since=0
+        own_cycle=0
+      elif [ "$consumer_mode" -eq 1 ]; then
+        # The external owner swaps watcher generations on every actionable close,
+        # so the singleton is legitimately unheld for a moment. Only a SUSTAINED
+        # absence means it is really gone; taking over on a single observation
+        # would spawn a child that immediately loses the lock again, and the mode
+        # would flap.
+        [ "$external_absent_since" -ne 0 ] || external_absent_since=$(_now)
+        if [ $(( $(_now) - external_absent_since )) -lt "$external_grace" ]; then
+          own_cycle=0
+        else
+          own_cycle=1
+        fi
+      else
+        own_cycle=1
+      fi
+
+      if [ "$own_cycle" -eq 0 ]; then
+        if [ "$consumer_mode" -eq 0 ]; then
+          consumer_mode=1
+          log "queue-consumer mode ON: watcher singleton held by healthy external pid $FM_WATCHER_HEALTHY_PID; classifying from the durable wake queue instead of competing for the lock"
+        fi
+        pending_non_wake=""
+      else
+        if [ "$consumer_mode" -eq 1 ]; then
+          consumer_mode=0
+          log "queue-consumer mode OFF: no healthy external watcher for ${external_grace}s; this daemon owns the cycle again"
+        fi
+        external_absent_since=0
+        if [ -n "$pending_non_wake" ]; then
+          log "watcher non-wake stdout, idling: $pending_non_wake"
+          pending_non_wake=""
           sleep "${HOUSEKEEPING_TICK:-$HOUSEKEEPING_TICK_DEFAULT}"
           continue
         fi
-        log "wake: $reason"
-        handle_wake "$reason" "$STATE"
-        trim_log
+        start_watcher || continue
       fi
-      start_watcher || continue
+    fi
+
+    # In queue-consumer mode the durable queue, not a child's stdout, is this
+    # daemon's wake input. Classification, batching, and injection below are
+    # untouched.
+    if [ "$consumer_mode" -eq 1 ]; then
+      consume_wake_queue "$STATE"
+      trim_log
     fi
 
     # --- one housekeeping tick (gated to HOUSEKEEPING_TICK), then poll -------

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -71,7 +71,8 @@ It leads with a prominent bordered tangle banner, while `bin/fm-guard.sh` owns t
 On every verified primary harness, tracked hook integration gives the primary session a push-based backstop: when work, a process-event source, or X-mode relay polling needs supervision and no identity-matched watcher lock with a fresh beacon is live, direct Stop hooks block and passive turn-end hooks force one bounded follow-up.
 The guard covers the main primary and genuinely marked secondmate homes, exempts child crewmate/scout worktrees, is loop-safe per harness, and is documented in [turnend-guard.md](turnend-guard.md).
 
-A presence-gated sub-supervisor (`bin/fm-supervise-daemon.sh`) extends this for walk-away supervision: the `/afk` skill starts it through the tracked foreground helper `bin/fm-afk-start.sh`, after which the watcher reverts to daemon-managed one-shot mode and the daemon self-handles routine wakes in bash.
+A presence-gated sub-supervisor (`bin/fm-supervise-daemon.sh`) extends this for walk-away supervision: the `/afk` skill starts it through the tracked foreground helper `bin/fm-afk-start.sh`, after which the watcher reverts to one-shot mode and the daemon self-handles routine wakes in bash.
+Which component runs that watcher depends on the runtime; [Away-mode watcher ownership](#away-mode-watcher-ownership) is the single owner of that contract.
 The watcher and daemon share `bin/fm-classify-lib.sh` for captain-relevant status verbs, declared-external-wait vocabulary, and status-scan primitives.
 Terminal verbs remain captain-relevant, while a nonterminal progress verb cannot become terminal merely because its prose contains a legacy free-text token such as `merged`; bare legacy free-text lines remain compatible.
 The always-on watcher also uses that library's absorb classification on no-verb signals and first-sighting stale panes before status-log terminality is trusted, while the daemon maintains distinct wedge and declared-pause recheck cadences.
@@ -86,6 +87,29 @@ Unsupported supervisor backends refuse at daemon startup.
 Stalled escalation delivery writes `state/.subsuper-inject-wedged` and attempts a configured backend-independent active alert after `FM_MAX_DEFER_SECS` instead of silently deferring forever.
 On an unmarked return, `bin/fm-afk-return.sh` owns ordered shutdown, durable catch-up evidence, and the fail-closed gate that keeps ordinary work behind every live firstmate-actionable blocker.
 `fm-send.sh` selects a pre-Enter popup-settle for slash commands and for codex `$...` skill invocations using metadata-routed target `harness=` values, then adds its own `FM_SEND_SETTLE` pause after successful text sends so immediate peeks catch the receiving turn starting; the sub-supervisor uses only the shared submit core and does not pay that post-submit pause.
+
+## Away-mode watcher ownership
+
+Away mode always has exactly one watcher and exactly one triage owner, but which component holds the watcher depends on the runtime, so the daemon detects its situation rather than assuming it.
+
+Where nothing else arms a watcher for the home, the daemon OWNS the cycle: it runs `bin/fm-watch.sh` as its own child and classifies the reasons that child prints.
+This is the claude and tmux shape, and it holds because `bin/fm-claude-stop-autoarm.sh` stands its rewake down entirely while `state/.afk` exists.
+
+Where the runtime owns watcher continuity itself, the daemon CONSUMES instead.
+Under Pi, `.pi/extensions/fm-primary-pi-watch.ts` arms `bin/fm-watch-arm.sh` and keeps that child attached to the live Pi process, so the extension holds the home singleton and the daemon's own child would exit immediately with `watcher: already running`.
+The extension keeps arming through away mode, because its continuity guarantees (bounded retry, session-lock verification, verified successor) are worth keeping during the unattended stretch, but it suppresses the per-wake model handoff while `state/.afk` exists so away mode is not a firehose of turns.
+A continuity FAILURE still reaches the captain: away mode batches routine notifications, it never hides a broken supervision chain.
+
+Both shapes produce the same durable record, which is what makes one classifier enough.
+`bin/fm-watch.sh` appends every actionable wake to `state/.wake-queue` before advancing any suppression marker, whoever started it, so the queue is a complete owner-independent log.
+The daemon decides between the two paths from the singleton lock's health through the shared `fm_watcher_healthy` predicate in `bin/fm-wake-lib.sh`: a lock held by a live process whose recorded identity still matches, for this home and this watcher path, with a liveness beacon inside the guard grace window.
+A lock left by a dead, reused, or stale-beaconed process is not healthy, so the daemon takes the cycle back rather than reading a queue nothing is filling.
+Because an external owner swaps watcher generations on every actionable close, the daemon requires a sustained absence (`FM_EXTERNAL_WATCHER_GRACE`) before taking over, so a momentary handover gap cannot make ownership flap.
+
+Consumption is non-destructive by contract, and that is what lets the daemon and firstmate read the same queue without a coordination protocol.
+The destructive drain (`bin/fm-wake-drain.sh`) stays firstmate's alone; the daemon only advances a forward-only cursor over the sequence the queue already assigns.
+A record the daemon classified is never reclassified, a record a concurrent drain removed is simply never seen because firstmate handled it in that turn, and a record stays queued until firstmate drains it so the return catch-up still sees the raw history.
+The cursor advances only after classification has run, so a crash mid-batch replays that batch rather than dropping it - the same at-least-once boundary the drain already documents - and the seen-status markers stop a replay from double-escalating one status line.
 
 ## Busy state is semantic, per adapter
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -323,7 +323,7 @@ The watcher accepts the shim only when its bytes match the expected generated co
 This section is the single owner of the X-mode cadence contract: an X instance polls every 30 seconds instead of the default 300, only an X instance speeds up because a non-X home has no `config/x-mode.env`, and the session-start supervision operating block includes the cadence instruction when that file exists.
 The active primary-harness supervision protocol owns how that sourced cadence reaches the watcher process.
 Because `bin/fm-watch.sh` reads `FM_CHECK_INTERVAL` only at process start, a cadence transition - opt-in while a watcher is already running, or opt-out - is applied by restarting the home-scoped watcher through the emitted harness protocol; bootstrap deliberately never restarts the watcher itself.
-While away mode is active the daemon owns the watcher and its default cadence applies; away-mode X cadence is a deferred follow-up.
+While away mode is active the default cadence applies, whichever component runs that watcher under [Away-mode watcher ownership](architecture.md#away-mode-watcher-ownership); away-mode X cadence is a deferred follow-up.
 When the token is removed or empty, the next locked session-start bootstrap step removes those artifacts.
 Steady-state off is silent and writes nothing.
 X mode remains additive to non-X lifecycle behavior: homes without the generated artifacts keep the default watcher cadence and do not run the X poll.

--- a/tests/fm-pi-watch-extension.test.sh
+++ b/tests/fm-pi-watch-extension.test.sh
@@ -59,6 +59,111 @@ export const Type = {
 JS
 }
 
+# While state/.afk exists, bin/fm-supervise-daemon.sh owns wake triage and
+# delivers batched digests, so a per-wake model handoff is the firehose away mode
+# exists to prevent (bin/fm-claude-stop-autoarm.sh enforces the same rule for a
+# Claude primary). Watcher CONTINUITY is a separate concern and must survive: the
+# daemon reads the durable queue this extension-owned watcher keeps filling.
+# Asserted both ways from one fixture so the guard cannot silently become
+# unconditional in either direction.
+test_pi_away_mode_afk_probe() {  # <case-name> <afk: on|off>
+  local name=$1 afk=$2 repo home plugin count release out status
+  repo="$TMP_ROOT/$name-root"
+  home="$TMP_ROOT/$name-home"
+  count="$TMP_ROOT/$name.count"
+  release="$TMP_ROOT/$name.release"
+  mkdir -p "$repo/bin" "$home/state" "$home/config"
+  install_pi_watch_extension_fixture "$repo"
+  plugin="$repo/.pi/extensions/fm-primary-pi-watch.ts"
+  [ "$afk" = on ] && printf '%s\n' "$(date +%s)" > "$home/state/.afk"
+  # First arm closes actionable. Its successor reports itself established and then
+  # parks, so continuity is observable while the case runs. The park is
+  # self-limiting and prints nothing on exit, so it can neither loop the extension
+  # into endless re-arms nor outlive the suite as an unbounded orphan.
+  cat > "$repo/bin/fm-watch-arm.sh" <<'SH'
+#!/usr/bin/env bash
+n=$(cat "${FM_ARM_COUNT:?}" 2>/dev/null || echo 0)
+n=$((n + 1))
+printf '%s\n' "$n" > "$FM_ARM_COUNT"
+if [ "$n" -eq 1 ]; then
+  printf 'signal: afk probe wake\n'
+  exit 0
+fi
+printf 'watcher: started pid=%s (beacon fresh)\n' "$$"
+i=0
+while [ ! -e "${FM_RELEASE_FILE:?}" ] && [ "$i" -lt 40 ]; do
+  sleep 0.05
+  i=$((i + 1))
+done
+SH
+  chmod +x "$repo/bin/fm-watch-arm.sh"
+  out=$(PLUGIN="$plugin" FM_HOME="$home" FM_ROOT_OVERRIDE="$repo" FM_ARM_COUNT="$count" \
+    FM_RELEASE_FILE="$release" FM_AFK_MODE="$afk" \
+    FM_WATCH_REARM_RETRY_BASE_MS=5 FM_WATCH_REARM_RETRY_MAX_MS=10 FM_WATCH_REARM_RETRY_LIMIT=1 \
+    node --input-type=module 2>&1 <<'EOF'
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+
+let tool = null;
+let prompt = "";
+const pi = {
+  on() {},
+  registerCommand() {},
+  registerTool(candidate) {
+    if (candidate.name === "fm_watch_arm_pi") tool = candidate;
+  },
+  sendUserMessage: async (message) => {
+    prompt += message;
+  },
+};
+writeFileSync(`${process.env.FM_HOME}/state/.lock`, `${process.pid}\n`);
+const mod = await import(pathToFileURL(process.env.PLUGIN).href);
+mod.default(pi);
+await tool.execute("tool-call-afk", {}, undefined, undefined, {});
+
+const armCount = () =>
+  existsSync(process.env.FM_ARM_COUNT)
+    ? Number(readFileSync(process.env.FM_ARM_COUNT, "utf8").trim() || 0)
+    : 0;
+// Wait for the successor: continuity must be restored in BOTH modes.
+for (let i = 0; i < 400 && armCount() < 2; i += 1) {
+  await new Promise((resolve) => setTimeout(resolve, 10));
+}
+if (armCount() < 2) throw new Error("no successor arm was started after the actionable close");
+
+if (process.env.FM_AFK_MODE === "on") {
+  // Give delivery a generous window to prove the wake is genuinely suppressed
+  // rather than merely slower than the assertion.
+  for (let i = 0; i < 60 && !prompt; i += 1) {
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  if (prompt) throw new Error(`away mode still woke the model: ${prompt}`);
+} else {
+  for (let i = 0; i < 400 && !prompt.includes("afk probe wake"); i += 1) {
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  if (!prompt.includes("FIRSTMATE WATCHER WAKE")) throw new Error(`no wake delivered off away mode: ${prompt}`);
+  if (!prompt.includes("afk probe wake")) throw new Error(`wake lost its reason: ${prompt}`);
+}
+// Release the parked successor and let it exit, so this case leaves no child
+// running into the cases that follow. It exits silently, so the bounded retry
+// budget above settles the extension rather than looping it into fresh arms.
+writeFileSync(process.env.FM_RELEASE_FILE, "release\n");
+await new Promise((resolve) => setTimeout(resolve, 300));
+EOF
+  )
+  status=$?
+  [ "$status" -eq 0 ] || fail "Pi away-mode wake probe ($afk) failed: $out"
+  [ -z "$out" ] || fail "Pi away-mode wake probe ($afk) printed output: $out"
+}
+
+test_pi_away_mode_suppresses_wake_but_keeps_continuity() {
+  test_pi_away_mode_afk_probe pi-afk-on on
+  pass "Pi away mode suppresses the per-wake model handoff while still restoring watcher continuity"
+  test_pi_away_mode_afk_probe pi-afk-off off
+  pass "Pi delivers the actionable wake normally when away mode is off"
+}
+
 test_pi_extension_reports_external_healthy_watcher() {
   local repo home plugin out status
   repo="$TMP_ROOT/pi-external-healthy-root"
@@ -2154,3 +2259,7 @@ test_opencode_established_empty_close_honors_retry_limit
 test_opencode_actionable_close_rechecks_session_lock
 test_opencode_watch_arm_coordinates_with_turnend_guard
 test_opencode_healthy_arm_output_does_not_suppress_guard
+# Runs last: this case deliberately parks a live successor arm to observe that
+# continuity is restored, so keeping it after the timing-sensitive arm and retry
+# cases above leaves those a quiet machine.
+test_pi_away_mode_suppresses_wake_but_keeps_continuity

--- a/tests/fm-wake-daemon-lifecycle-e2e.test.sh
+++ b/tests/fm-wake-daemon-lifecycle-e2e.test.sh
@@ -9,6 +9,11 @@
 #   buffered digest flushes to the supervisor pane as exactly ONE submission
 #   stale working-pane: transient (self + marker) -> persistent (escalates once,
 #     clears its marker) -> resumed/busy (clears without escalating)
+#   EXTERNAL watcher owner (the Pi shape, where the tracked extension arms and
+#     holds the singleton): the daemon classifies from the durable wake queue
+#     instead of idling on a child that can never win the lock - captain-relevant
+#     records escalate, routine records stay silent, the queue is never consumed
+#     destructively, and a replayed batch cannot double-escalate
 #
 # This proves the operator-visible routing/queueing/dedupe behavior through real
 # fm-watch.sh runs plus the daemon's own functions. The captain-relevant
@@ -30,6 +35,13 @@ if [ -z "${FM_TEST_DAEMON_SOURCED:-}" ]; then
   # shellcheck source=/dev/null
   . "$DAEMON"
 fi
+
+# The lock/queue helpers the daemon itself sources at runtime (inside
+# fm_super_main, which sourcing skips). fm_watcher_healthy takes its state root as
+# an argument, so one top-level source serves every case; only the queue path
+# globals are state-scoped, and consume_once below re-sources for those.
+# shellcheck source=bin/fm-wake-lib.sh
+. "$ROOT/bin/fm-wake-lib.sh"
 
 TMP_ROOT=$(fm_test_tmproot fm-wake-daemon-e2e)
 
@@ -153,5 +165,174 @@ test_stale_pane_transient_persistent_resume() {
   pass "lifecycle: stale pane transient self-handles, persistent escalates once and clears, resumed clears quietly"
 }
 
+# --- Phase 3: an EXTERNAL watcher owns the cycle ----------------------------
+# The Pi shape: .pi/extensions/fm-primary-pi-watch.ts arms bin/fm-watch-arm.sh and
+# keeps that watcher attached to the live Pi process, so the EXTENSION holds the
+# home singleton and the daemon's own child exits with "watcher: already running".
+# The owner here is a real bin/fm-watch.sh - the same process the extension arms -
+# so the contended lock, its identity record, and its liveness beacon are all
+# genuine; only the wake records are appended directly (through the production
+# fm_wake_append, exactly as that watcher would) to keep the phase deterministic.
+
+# Start a real watcher that ACQUIRES the singleton and then sleeps, so it stays a
+# healthy external owner for the rest of the case. A long FM_POLL keeps it parked:
+# the state starts with no status files, so its first scan finds nothing to
+# surface and it blocks instead of one-shot exiting. Echoes its pid.
+start_external_watcher() {  # <dir> <state> <fakebin>
+  local dir=$1 state=$2 fakebin=$3 pid i=0
+  mkdir -p "$state"
+  date '+%s' > "$state/.afk"
+  PATH="$fakebin:$PATH" FM_HOME="$dir" FM_STATE_OVERRIDE="$state" FM_POLL=60 \
+    FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 \
+    "$WATCH" > "$dir/external.out" 2>&1 &
+  pid=$!
+  while [ "$i" -lt 100 ]; do
+    [ -e "$state/.last-watcher-beat" ] && [ -n "$(cat "$state/.watch.lock/pid" 2>/dev/null)" ] && break
+    sleep 0.1
+    i=$((i + 1))
+  done
+  printf '%s' "$pid"
+}
+
+stop_external_watcher() {  # <pid>
+  local pid=$1
+  [ -n "$pid" ] || return 0
+  kill "$pid" 2>/dev/null || true
+  wait "$pid" 2>/dev/null || true
+}
+
+# Run the daemon's queue consumption against <state>. fm-wake-lib.sh is sourced in
+# a subshell so FM_WAKE_QUEUE resolves to THIS case's state root; consume_wake_queue
+# and handle_wake come from the daemon already sourced above.
+consume_once() {  # <state>
+  local state=$1
+  # The queue paths are resolved with ${VAR:-default}, so the top-level source
+  # above would otherwise pin them to ITS state root. Clear them first so this
+  # case's root wins.
+  ( unset FM_WAKE_QUEUE FM_WAKE_QUEUE_LOCK
+    FM_STATE_OVERRIDE="$state" . "$ROOT/bin/fm-wake-lib.sh"
+    consume_wake_queue "$state" )
+}
+
+test_external_owner_consumes_queue_without_draining_it() {
+  local dir state fakebin ext_pid queue_lines cursor
+  dir=$(make_supercase wd-external-owner)
+  state="$dir/state"
+  fakebin="$dir/fakebin"
+
+  ext_pid=$(start_external_watcher "$dir" "$state" "$fakebin")
+  [ -n "$(cat "$state/.watch.lock/pid" 2>/dev/null)" ] \
+    || { stop_external_watcher "$ext_pid"; fail "external watcher never acquired the singleton"; }
+
+  # The daemon must recognise the external owner. Its own child is not running,
+  # so no pid is passed as "ours".
+  FM_HOME="$dir" daemon_external_watcher_owns "$state" "$WATCH" \
+    || { stop_external_watcher "$ext_pid"; fail "a healthy external watcher was not detected as the cycle owner"; }
+
+  # ...and must NOT mistake its OWN child for an external owner, or it would
+  # starve itself the moment it did own the watcher.
+  if FM_HOME="$dir" daemon_external_watcher_owns "$state" "$WATCH" "$(cat "$state/.watch.lock/pid")"; then
+    stop_external_watcher "$ext_pid"
+    fail "the daemon treated its own watcher child as an external owner"
+  fi
+
+  # A captain-relevant record, appended exactly as the owning watcher appends it.
+  printf 'blocked: needs a credential\n' > "$state/ext-task.status"
+  append_wake "$state" signal ext-task.status "signal: $state/ext-task.status"
+
+  : > "$state/.subsuper-escalations" 2>/dev/null || true
+  FM_HOME="$dir" consume_once "$state"
+
+  [ -s "$state/.subsuper-escalations" ] \
+    || { stop_external_watcher "$ext_pid"; fail "captain-relevant queued record did not escalate under an external owner"; }
+  [ "$(wc -l < "$state/.subsuper-escalations" | tr -d ' ')" -eq 1 ] \
+    || { stop_external_watcher "$ext_pid"; fail "expected exactly one digest from one queued record"; }
+  grep -F 'blocked: needs a credential' "$state/.subsuper-escalations" >/dev/null \
+    || { stop_external_watcher "$ext_pid"; fail "the digest did not carry the captain-relevant status text"; }
+
+  # NON-DESTRUCTIVE: the record is still queued for firstmate's own drain, which
+  # is what keeps the away-mode return catch-up complete.
+  queue_lines=$(wc -l < "$state/.wake-queue" | tr -d ' ')
+  [ "$queue_lines" -eq 1 ] \
+    || { stop_external_watcher "$ext_pid"; fail "consumption removed queue records (expected 1, got $queue_lines)"; }
+  cursor=$(cat "$state/.subsuper-wake-cursor" 2>/dev/null || echo 0)
+  [ "$cursor" -eq 1 ] \
+    || { stop_external_watcher "$ext_pid"; fail "cursor did not advance to the consumed sequence (got '$cursor')"; }
+
+  # Re-running must NOT re-escalate: the cursor is the no-double-handling boundary.
+  FM_HOME="$dir" consume_once "$state"
+  [ "$(wc -l < "$state/.subsuper-escalations" | tr -d ' ')" -eq 1 ] \
+    || { stop_external_watcher "$ext_pid"; fail "a second consumption re-escalated an already-classified record"; }
+
+  # A routine record under the same external owner stays silent (away mode must
+  # not become a firehose just because its input moved to the queue).
+  printf 'working: still compiling\n' > "$state/ext-routine.status"
+  append_wake "$state" signal ext-routine.status "signal: $state/ext-routine.status"
+  FM_HOME="$dir" consume_once "$state"
+  [ "$(wc -l < "$state/.subsuper-escalations" | tr -d ' ')" -eq 1 ] \
+    || { stop_external_watcher "$ext_pid"; fail "a routine queued record escalated under an external owner"; }
+
+  stop_external_watcher "$ext_pid"
+  pass "external owner: queued captain-relevant record escalates once, routine stays silent, queue survives for firstmate's drain"
+}
+
+test_external_owner_replay_is_lossless_and_not_duplicated() {
+  local dir state fakebin ext_pid
+  dir=$(make_supercase wd-external-replay)
+  state="$dir/state"
+  fakebin="$dir/fakebin"
+
+  ext_pid=$(start_external_watcher "$dir" "$state" "$fakebin")
+  printf 'failed: build broke\n' > "$state/replay-task.status"
+  append_wake "$state" signal replay-task.status "signal: $state/replay-task.status"
+
+  : > "$state/.subsuper-escalations" 2>/dev/null || true
+  FM_HOME="$dir" consume_once "$state"
+  [ "$(wc -l < "$state/.subsuper-escalations" | tr -d ' ')" -eq 1 ] \
+    || { stop_external_watcher "$ext_pid"; fail "queued terminal record did not escalate"; }
+
+  # Simulate a daemon that crashed after classifying but BEFORE its cursor write:
+  # on restart the batch replays. Nothing may be lost, and the seen-status dedupe
+  # must stop the replay from double-escalating the same status line.
+  rm -f "$state/.subsuper-wake-cursor"
+  FM_HOME="$dir" consume_once "$state"
+  [ "$(wc -l < "$state/.subsuper-escalations" | tr -d ' ')" -eq 1 ] \
+    || { stop_external_watcher "$ext_pid"; fail "a replayed batch double-escalated the same status line"; }
+
+  # The record is still on the durable queue, so a drain after the away stretch
+  # still recovers it even if the daemon never ran at all.
+  FM_STATE_OVERRIDE="$state" "$DRAIN" > "$dir/drain.out" \
+    || { stop_external_watcher "$ext_pid"; fail "drain after external-owner consumption failed"; }
+  grep -F "signal: $state/replay-task.status" "$dir/drain.out" >/dev/null \
+    || { stop_external_watcher "$ext_pid"; fail "consumed-but-undrained record was lost to firstmate's drain"; }
+
+  stop_external_watcher "$ext_pid"
+  pass "external owner: a replayed batch cannot double-escalate, and firstmate's drain still recovers the record"
+}
+
+test_dead_lock_holder_is_not_an_external_owner() {
+  local dir state fakebin
+  dir=$(make_supercase wd-external-dead)
+  state="$dir/state"
+  fakebin="$dir/fakebin"
+  mkdir -p "$state/.watch.lock"
+
+  # A lock left behind by a process that is gone. The daemon must NOT treat this
+  # as an external owner, or it would sit reading a queue nothing is filling.
+  printf '999999\n' > "$state/.watch.lock/pid"
+  printf '%s\n' "$dir" > "$state/.watch.lock/fm-home"
+  printf '%s\n' "$WATCH" > "$state/.watch.lock/watcher-path"
+  printf 'stale-identity\n' > "$state/.watch.lock/pid-identity"
+  touch "$state/.last-watcher-beat"
+
+  if FM_HOME="$dir" daemon_external_watcher_owns "$state" "$WATCH"; then
+    fail "a lock held by a dead pid was treated as a healthy external owner"
+  fi
+  pass "external owner: a dead or stale lock holder never diverts the daemon from owning the cycle"
+}
+
 test_routine_then_terminal_after_restart
 test_stale_pane_transient_persistent_resume
+test_external_owner_consumes_queue_without_draining_it
+test_external_owner_replay_is_lossless_and_not_duplicated
+test_dead_lock_holder_is_not_an_external_owner


### PR DESCRIPTION
## Away mode could not deliver a single escalation on a runtime-owned watcher

On Pi (and any runtime whose extension owns the watcher), `/afk` starts the
sub-supervisor daemon, the daemon reports healthy, and **zero escalations ever reach
the captain**. Measured over a full night: ~2809 injection attempts, 0 delivered.

The daemon assumes it owns the watcher and tries to start its own. When the runtime
extension already owns one, the daemon's child logs `watcher: already running pid N`
every ~16s forever and the daemon is starved of wakes - it never classifies anything.
Only the 300s catch-all fleet scan ever produced an escalation.

That is the worst possible failure shape: away mode looks armed, every health check
passes, and the captain silently receives nothing.

### What this changes

The daemon detects a runtime-owned watcher and consumes its durable wake queue instead
of competing for ownership, so escalations flow on the path that is actually running.

### Verification

Diagnosed with two live probes before the fix, and the failure is reproducible:
probe 2 had the extension watcher wake firstmate directly with the probe line while
`state/.subsuper-escalations` stayed EMPTY - proving the daemon never saw it.
