### PR TITLE
fix(guard): never report a fresh-beacon live watcher as down

### DIFF
--- a/bin/fm-guard.sh
+++ b/bin/fm-guard.sh
@@ -154,6 +154,17 @@ watcher_healthy=false
 if fm_watcher_healthy "$STATE" "$WATCH" "$GRACE" "$FM_HOME"; then
   watcher_healthy=true
 fi
+# The alarm gate is the weaker, beacon-anchored liveness, not the strict identity
+# match: a fresh beacon with a live lock holder means a watcher IS beating, so
+# supervision is happening even if the recorded identity does not byte-match (a
+# transient identity read, a benign re-render, or a mid-handoff). This is what
+# keeps a demonstrably fresh beacon from ever being reported as "watcher down".
+# fm_watcher_healthy stays authoritative for the turn-end block and arm/attach
+# paths; only this advisory relaxes to the beacon.
+watcher_beating=false
+if [ "$watcher_healthy" = true ] || fm_watcher_beating "$STATE" "$GRACE" "$FM_HOME"; then
+  watcher_beating=true
+fi
 if [ "$needed" = false ]; then
   # Leave the unhealthy state (nothing riding on the watcher): clear so a later
   # work or X-mode need + stale combination is a fresh episode even if the
@@ -164,10 +175,10 @@ fi
 
 [ -s "$FM_WAKE_QUEUE" ] && queue_pending=true
 
-# No fresh watcher with tasks in flight is the dangerous state: emit a prominent,
-# bordered banner FIRST so it reads as an alarm, not a buried stderr line. Later
-# calls in the same episode get a one-line reminder only.
-if [ "$watcher_healthy" = false ]; then
+# No beating watcher with tasks in flight is the dangerous state: emit a
+# prominent, bordered banner FIRST so it reads as an alarm, not a buried stderr
+# line. Later calls in the same episode get a one-line reminder only.
+if [ "$watcher_beating" = false ]; then
   episode_key=$(fm_guard_stale_episode_key "$STATE")
   episode_key=${episode_key%$'\n'}
   print_full_banner=0
@@ -190,15 +201,25 @@ if [ "$watcher_healthy" = false ]; then
       --queue-pending "$queue_arg" \
       --repair-line 2>/dev/null || printf '%s\n' 'Repair missing watcher supervision according to the session-start operating block.')
     rule='━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━'
+    # Word the verdict from the actual failure, never from stale-beacon wording
+    # the beacon does not support. A stale (or absent) beacon is a genuine "no
+    # fresh beacon"; a fresh beacon that still failed the beating check means the
+    # recorded watcher pid is not a live holder of this home's lock (a watcher
+    # died and left a not-yet-aged beacon), which is reported as such.
+    if [ "$FM_SUP_WATCHER_FRESH" = true ]; then
+      down_desc="no live watcher holds this home lock (last beat: $beacon_desc)"
+    else
+      down_desc="no watcher has a fresh beacon (last beat: $beacon_desc, grace ${GRACE}s)"
+    fi
     {
       printf '●%s\n' "$rule"
       printf '●  WATCHER DOWN - SUPERVISION IS OFF\n'
       if [ "$in_flight" -gt 0 ]; then
-        printf '●  %s task(s) in flight, but no watcher has a fresh beacon (last beat: %s, grace %ss).\n' "$in_flight" "$beacon_desc" "$GRACE"
+        printf '●  %s task(s) in flight, but %s.\n' "$in_flight" "$down_desc"
       elif [ "$sources" -gt 0 ]; then
-        printf '●  %s process-event source(s) registered, but no watcher has a fresh beacon (last beat: %s, grace %ss).\n' "$sources" "$beacon_desc" "$GRACE"
+        printf '●  %s process-event source(s) registered, but %s.\n' "$sources" "$down_desc"
       else
-        printf '●  X-mode relay polling needs supervision, but no watcher has a fresh beacon (last beat: %s, grace %ss).\n' "$beacon_desc" "$GRACE"
+        printf '●  X-mode relay polling needs supervision, but %s.\n' "$down_desc"
       fi
       if [ "$READ_ONLY" -eq 1 ]; then
         printf '●  This read-only session should report the lapse, not repair it.\n'

--- a/bin/fm-wake-lib.sh
+++ b/bin/fm-wake-lib.sh
@@ -115,6 +115,35 @@ fm_watcher_healthy() {
   return 0
 }
 
+# fm_watcher_beating <state-dir> [grace] [home]
+# A weaker, beacon-anchored liveness signal for the PULL-BASED advisory guard
+# (bin/fm-guard.sh) ONLY. True when a live process holds THIS home's watcher lock
+# AND the liveness beacon is fresh within grace. It deliberately does NOT require
+# the recorded pid-identity or watcher-path to still match, because the beacon is
+# the ground-truth "a watcher beat within grace" signal and a transient
+# fm_pid_identity read failure, a benign lstart re-render, or a brief mid-handoff
+# window must never make the advisory contradict a demonstrably fresh beacon by
+# declaring supervision off. fm_watcher_healthy stays the STRICT gate for
+# arm/attach (bin/fm-watch-arm.sh) and turn-end block (bin/fm-turnend-guard.sh)
+# decisions; this must never be substituted there. Home scoping is retained so a
+# foreign or stale lock record is never counted as this home's live watcher.
+FM_WATCHER_BEATING_PID=
+fm_watcher_beating() {
+  local state=$1 grace=${2:-${FM_GUARD_GRACE:-300}} home=${3:-$FM_HOME} lockdir beat pid lock_home age
+  FM_WATCHER_BEATING_PID=
+  lockdir="$state/.watch.lock"
+  beat="$state/.last-watcher-beat"
+  pid=$(cat "$lockdir/pid" 2>/dev/null || true)
+  fm_pid_alive "$pid" || return 1
+  lock_home=$(cat "$lockdir/fm-home" 2>/dev/null || true)
+  [ "$lock_home" = "$home" ] || return 1
+  age=$(fm_path_age "$beat")
+  [ "$age" -lt "$grace" ] || return 1
+  # shellcheck disable=SC2034 # Read by callers after fm_watcher_beating returns.
+  FM_WATCHER_BEATING_PID=$pid
+  return 0
+}
+
 fm_lock_clean_known_files() {
   local lockdir=$1
   rm -f \

--- a/tests/fm-watcher-lock.test.sh
+++ b/tests/fm-watcher-lock.test.sh
@@ -179,6 +179,116 @@ test_guard_warnings() {
   pass "guard banner leads when down with pending wakes (repair-after-drain) and stays silent when live and fresh"
 }
 
+# fm_watcher_beating is the beacon-anchored advisory predicate that keeps
+# bin/fm-guard.sh from reporting a demonstrably fresh beacon as "watcher down".
+# It is deliberately weaker than fm_watcher_healthy (no pid-identity / watcher-
+# path requirement) but still home-scoped and still requires a LIVE lock holder
+# plus a fresh beacon.
+test_watcher_beating_predicate() {
+  local dir state live rc
+  dir=$(make_case beating-predicate)
+  state="$dir/state"
+  sleep 60 &
+  live=$!
+  mkdir -p "$state/.watch.lock"
+  printf '%s\n' "$live" > "$state/.watch.lock/pid"
+  printf '%s\n' "$dir" > "$state/.watch.lock/fm-home"
+  touch "$state/.last-watcher-beat"
+
+  # live lock holder + home match + fresh beacon -> beating.
+  rc=0
+  FM_STATE_OVERRIDE="$state" bash -c '. "$1"; fm_watcher_beating "$2" 300 "$3"' _ "$LIB" "$state" "$dir" || rc=$?
+  [ "$rc" -eq 0 ] || fail "beating predicate rejected a live lock holder with a fresh beacon (rc=$rc)"
+
+  # stale beacon -> not beating.
+  touch -t 200001010000 "$state/.last-watcher-beat"
+  rc=0
+  FM_STATE_OVERRIDE="$state" bash -c '. "$1"; fm_watcher_beating "$2" 300 "$3"' _ "$LIB" "$state" "$dir" || rc=$?
+  [ "$rc" -ne 0 ] || fail "beating predicate accepted a stale beacon"
+  touch "$state/.last-watcher-beat"
+
+  # foreign home record -> not beating (home scoping preserved).
+  rc=0
+  FM_STATE_OVERRIDE="$state" bash -c '. "$1"; fm_watcher_beating "$2" 300 "$3"' _ "$LIB" "$state" "/some/other/home" || rc=$?
+  [ "$rc" -ne 0 ] || fail "beating predicate accepted a foreign-home lock record"
+
+  # dead recorded pid + fresh beacon -> not beating (no live holder).
+  printf '%s\n' "$(dead_pid)" > "$state/.watch.lock/pid"
+  rc=0
+  FM_STATE_OVERRIDE="$state" bash -c '. "$1"; fm_watcher_beating "$2" 300 "$3"' _ "$LIB" "$state" "$dir" || rc=$?
+  [ "$rc" -ne 0 ] || fail "beating predicate accepted a dead recorded pid"
+
+  kill "$live" 2>/dev/null || true
+  wait "$live" 2>/dev/null || true
+  pass "fm_watcher_beating requires a live home-matched lock holder and a fresh beacon"
+}
+
+# Regression for the false "WATCHER DOWN" verdict: a genuinely-live watcher whose
+# recorded identity or path no longer byte-matches (a transient identity read, a
+# benign re-render, or a mid-handoff) must NEVER be reported down while its beacon
+# is fresh, and a genuine leftover-beacon down must be worded from the lock, never
+# as a stale beacon it demonstrably is not.
+test_guard_fresh_beacon_is_never_reported_down() {
+  local dir state err live identity
+
+  # (1) fresh beacon + live lock holder + identity MISMATCH -> total silence.
+  dir=$(make_case guard-fresh-identity-mismatch)
+  state="$dir/state"; err="$dir/guard.err"
+  printf 'project=x\n' > "$state/task.meta"
+  sleep 60 & live=$!
+  mkdir -p "$state/.watch.lock"
+  printf '%s\n' "$live" > "$state/.watch.lock/pid"
+  printf '%s\n' "$dir" > "$state/.watch.lock/fm-home"
+  printf '%s\n' "$WATCH" > "$state/.watch.lock/watcher-path"
+  printf '%s\n' "stale recorded identity" > "$state/.watch.lock/pid-identity"
+  touch "$state/.last-watcher-beat"
+  FM_ROOT_OVERRIDE="$dir" FM_STATE_OVERRIDE="$state" FM_HOME="$dir" FM_GUARD_GRACE=300 \
+    "$ROOT/bin/fm-guard.sh" 2> "$err" >/dev/null || fail "guard failed (identity mismatch)"
+  ! grep -qF 'WATCHER DOWN' "$err" || fail "fresh beacon + live holder + identity mismatch was reported WATCHER DOWN: $(cat "$err")"
+  ! grep -qF 'no watcher has a fresh beacon' "$err" || fail "guard claimed no fresh beacon while the beacon was fresh"
+  kill "$live" 2>/dev/null || true
+  wait "$live" 2>/dev/null || true
+
+  # (2) fresh beacon + live lock holder + watcher-path MISMATCH -> total silence.
+  dir=$(make_case guard-fresh-path-mismatch)
+  state="$dir/state"; err="$dir/guard.err"
+  printf 'project=x\n' > "$state/task.meta"
+  sleep 60 & live=$!
+  identity=$(FM_STATE_OVERRIDE="$state" bash -c '. "$1"; fm_pid_identity "$2"' _ "$LIB" "$live") \
+    || fail "could not identify fresh path-mismatch holder"
+  mkdir -p "$state/.watch.lock"
+  printf '%s\n' "$live" > "$state/.watch.lock/pid"
+  printf '%s\n' "$dir" > "$state/.watch.lock/fm-home"
+  printf '%s\n' "/some/other/spelling/bin/fm-watch.sh" > "$state/.watch.lock/watcher-path"
+  printf '%s\n' "$identity" > "$state/.watch.lock/pid-identity"
+  touch "$state/.last-watcher-beat"
+  FM_ROOT_OVERRIDE="$dir" FM_STATE_OVERRIDE="$state" FM_HOME="$dir" FM_GUARD_GRACE=300 \
+    "$ROOT/bin/fm-guard.sh" 2> "$err" >/dev/null || fail "guard failed (path mismatch)"
+  ! grep -qF 'WATCHER DOWN' "$err" || fail "fresh beacon + live holder + path mismatch was reported WATCHER DOWN: $(cat "$err")"
+  kill "$live" 2>/dev/null || true
+  wait "$live" 2>/dev/null || true
+
+  # (3) genuine down: recorded pid DEAD with a not-yet-aged leftover beacon. The
+  # guard MUST alarm, but must report it as a lock/live-watcher failure, never as
+  # a stale beacon (which would contradict the demonstrably fresh beacon).
+  dir=$(make_case guard-dead-fresh-leftover)
+  state="$dir/state"; err="$dir/guard.err"
+  printf 'project=x\n' > "$state/task.meta"
+  mkdir -p "$state/.watch.lock"
+  printf '%s\n' "$(dead_pid)" > "$state/.watch.lock/pid"
+  printf '%s\n' "$dir" > "$state/.watch.lock/fm-home"
+  printf '%s\n' "$WATCH" > "$state/.watch.lock/watcher-path"
+  printf '%s\n' "dead watcher identity" > "$state/.watch.lock/pid-identity"
+  touch "$state/.last-watcher-beat"
+  FM_ROOT_OVERRIDE="$dir" FM_STATE_OVERRIDE="$state" FM_HOME="$dir" FM_GUARD_GRACE=300 \
+    "$ROOT/bin/fm-guard.sh" 2> "$err" >/dev/null || fail "guard failed (dead pid + fresh leftover)"
+  grep -qF 'WATCHER DOWN' "$err" || fail "dead pid + fresh leftover beacon did not alarm: $(cat "$err")"
+  grep -qF 'no live watcher holds this home lock' "$err" || fail "genuine leftover-beacon down did not use the lock-truthful wording: $(cat "$err")"
+  ! grep -qF 'no watcher has a fresh beacon' "$err" || fail "genuine leftover-beacon down falsely claimed a stale beacon: $(cat "$err")"
+
+  pass "guard never reports a fresh-beacon live watcher down and words a leftover-beacon down truthfully"
+}
+
 test_lock_single_winner_under_concurrency() {
   local dir state lockdir marker i pids pid wins
   dir=$(make_case lock-concurrency)
@@ -1028,6 +1138,8 @@ test_msys_pid_identity_uses_proc
 test_stale_watch_lock_reclaimed
 test_live_stale_watch_lock_is_actionable
 test_guard_warnings
+test_watcher_beating_predicate
+test_guard_fresh_beacon_is_never_reported_down
 test_lock_single_winner_under_concurrency
 test_lock_steals_dead_pid_lock
 test_lock_stale_steal_single_winner_under_concurrency


### PR DESCRIPTION
## Problem

Firstmate's supervision guard falsely declared `WATCHER DOWN - SUPERVISION IS OFF` while a watcher was demonstrably alive and beating.
Measured live: the beacon was 34 seconds old against a 300-second grace, yet the guard reported "no watcher has a fresh beacon."
Because the banner reads as a hard alarm, it pushes the operator to tear down and re-arm supervision that was never actually down.

The trigger is that the alarm gate used the strict `fm_watcher_healthy` check, which also requires the recorded watcher identity and path to byte-match the live process.
That match transiently fails on a benign identity read, a re-render, or a mid-handoff window, so a live, beating watcher was intermittently reported as dead.

## Fix

The advisory guard now gates its alarm on a weaker, beacon-anchored predicate, `fm_watcher_beating`: true when a live process holds this home's watcher lock and the beacon is fresh within grace, independent of the recorded identity bytes.
`fm_watcher_healthy` stays the strict gate for the turn-end block and the arm/attach paths, so the relaxation is confined to the pull-based advisory guard and does not weaken any decision that starts or attaches a watcher.
Home scoping is preserved, so a foreign or stale lock record is never counted as this home's live watcher.

When the guard genuinely does need to alarm, it now words the verdict from the actual failure instead of always blaming a stale beacon:

- A stale or absent beacon is reported as no fresh beacon (unchanged wording).
- A fresh beacon that still fails the beating check - a watcher that died and left a not-yet-aged beacon - is reported as no live watcher holding this home's lock, which is what actually happened.

## Verification

- `bash tests/fm-watcher-lock.test.sh` - all tests pass, including the new coverage below.
- `bash bin/fm-lint.sh` (pinned ShellCheck 0.11.0) - clean.

New regression tests:

- A fresh beacon with a live lock holder and an identity mismatch is silent (never `WATCHER DOWN`).
- Same, with a watcher-path mismatch, is silent.
- A dead recorded pid with a not-yet-aged leftover beacon still alarms, and uses the lock-truthful wording rather than falsely claiming a stale beacon.
- `fm_watcher_beating` directly requires a live, home-matched lock holder and a fresh beacon (rejects a stale beacon, a foreign-home record, and a dead pid).

## Scope note

This change is the guard-verdict half of the Pi-primary supervision work.
The ordinary-wake delivery path to a Pi primary is owned by the harness-identity fix and the sibling supervision-delivery PRs and is intentionally not duplicated here.

## Known unrelated failures

`tests/fm-pi-primary-types.test.sh` and `tests/fm-calm-pi-extension.test.sh` fail on a clean tree as well (Pi SDK type drift); they are unrelated to this branch and untouched by it.
