### PR TITLE
fix(bin): resolve firstmate's harness from live ancestry before env markers

### DIFF
--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -39,7 +39,7 @@ If the captain asks for a new harness, propose verifying it first: spawn a trivi
 
 ## Detection
 
-`bin/fm-harness.sh` prints firstmate's own harness, using verified env markers first and then process ancestry.
+`bin/fm-harness.sh` prints firstmate's own harness, resolving live process ancestry first and falling back to verified env markers only when ancestry cannot name a harness, so a stale marker inherited from a dead ancestor (such as a `CLAUDECODE=1` that survived a prior session's `/exit`) never outranks the harness whose process is actually running firstmate.
 Within the Pi family, only the exact launch-boundary marker `FM_PI_HARNESS=pi-signed` alongside `PI_CODING_AGENT=true` selects the signed identity; unmarked shared launcher ancestry remains `pi`.
 `bin/fm-harness.sh crew` resolves the effective crewmate harness from `config/crew-harness` (absent or `default` -> own).
 `bin/fm-harness.sh secondmate` resolves the secondmate-launch harness through the chain `config/secondmate-harness` -> `config/crew-harness` -> own, so an unset `config/secondmate-harness` matches the crew harness.

--- a/bin/fm-harness.sh
+++ b/bin/fm-harness.sh
@@ -18,8 +18,15 @@
 # harness only, no model/effort. Only the first non-empty, non-comment line is parsed.
 # Model/effort come ONLY from this file - config/crew-harness stays a bare adapter
 # name and is never parsed for a model.
-# Detection layers: verified environment markers first, then process ancestry.
-# Record each newly verified env marker here.
+# Detection layers: live process ancestry FIRST, then verified environment
+# markers as a fallback when ancestry cannot see the harness. Ancestry is the
+# authoritative signal because the parent chain reflects the process tree as it
+# exists right now and can never name a dead ancestor (a process whose parent
+# exits is reparented to pid 1, where the walk stops). An exported marker such as
+# CLAUDECODE=1 outlives the process that set it - it persists in an interactive
+# shell across `/exit` and into the next program launched there - so a stale
+# inherited marker must never outrank the harness whose process actually launched
+# this one. Record each newly verified env marker in the fallback layer below.
 set -u
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -27,24 +34,27 @@ FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
 FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
 CONFIG="${FM_CONFIG_OVERRIDE:-$FM_HOME/config}"
 
-detect_own() {
-  # Layer 1: environment markers for verified harnesses.
-  # Keep marker detection before ancestry detection as an explicit precedence rule.
-  # Only claude, pi, and grok set verified markers of their own; codex, opencode,
-  # and kimi are markerless, so a foreign marker retained in a terminal
-  # multiplexer's stored environment can silently misidentify one of them before
-  # ancestry is consulted. This is a precedence hazard, not evidence that
-  # CLAUDECODE inheritance into a kimi child was observed; it was not observed.
-  [ "${CLAUDECODE:-}" = "1" ] && { echo claude; return; }
-  if [ "${PI_CODING_AGENT:-}" = "true" ]; then
-    if [ "${FM_PI_HARNESS:-}" = pi-signed ]; then echo pi-signed; else echo pi; fi
-    return
+# resolve_pi_identity: refine a Pi-family result into the signed identity ONLY
+# when both live Pi markers are present - the family marker PI_CODING_AGENT=true
+# AND the exact signed launch-boundary marker FM_PI_HARNESS=pi-signed. Firstmate
+# sets FM_PI_HARNESS explicitly on every Pi launch (pi-signed for the signed
+# wrapper, pi for plain Pi; see bin/fm-spawn.sh and docs/configuration.md), so a
+# plain-Pi launch cannot be relabelled by an inherited FM_PI_HARNESS=pi-signed,
+# and shared unmarked Pi ancestry stays plain pi.
+resolve_pi_identity() {
+  if [ "${PI_CODING_AGENT:-}" = "true" ] && [ "${FM_PI_HARNESS:-}" = "pi-signed" ]; then
+    echo pi-signed
+  else
+    echo pi
   fi
-  # grok sets GROK_AGENT=1 for its child/tool processes (verified, grok 0.2.73).
-  # It does NOT set CLAUDECODE despite being Claude-Code-compatible, so this marker
-  # is unambiguous when firstmate runs natively on grok.
-  [ "${GROK_AGENT:-}" = "1" ] && { echo grok; return; }
-  # Layer 2: walk the parent chain and match the command name.
+}
+
+# detect_ancestry: walk the live parent chain and return the CLOSEST verified
+# harness (the Pi family is reported as the base name "pi"; the pi-signed
+# refinement is applied by the caller), or "unknown" when no ancestor matches.
+# The walk starts at this process and stops at pid 1, so it only ever reflects
+# processes that are alive right now - it cannot be fooled by a stale env marker.
+detect_ancestry() {
   local pid=$$ comm args
   for _ in 1 2 3 4 5 6 7 8; do
     comm=$(ps -o comm= -p "$pid" 2>/dev/null) || break
@@ -72,6 +82,33 @@ detect_own() {
       break
     fi
   done
+  echo unknown
+}
+
+detect_own() {
+  # Layer 1: live process ancestry is authoritative. Whichever verified harness
+  # the parent chain names is the one whose process actually launched firstmate,
+  # so it wins even when a stale exported marker from a dead ancestor is still in
+  # the environment - the exact leak seen when a captain runs `pi` in the shell a
+  # `/exit`ed claude session left behind (CLAUDECODE=1 survives, but the live
+  # parent is pi). This also resolves genuine nesting (e.g. a pi launched from a
+  # claude tool shell): the CLOSEST harness in the chain is the operative one.
+  local anc
+  anc=$(detect_ancestry)
+  case "$anc" in
+    pi) resolve_pi_identity; return ;;
+    claude|codex|opencode|grok|kimi) echo "$anc"; return ;;
+  esac
+  # Layer 2: ancestry could not name a verified harness (a bare interpreter whose
+  # script path did not match, or ps was unavailable). Fall back to the verified
+  # environment markers as the best remaining evidence. Only claude, the Pi
+  # family, and grok expose a marker of their own; codex, opencode, and kimi are
+  # markerless and are therefore detectable ONLY through ancestry above.
+  [ "${CLAUDECODE:-}" = "1" ] && { echo claude; return; }
+  if [ "${PI_CODING_AGENT:-}" = "true" ]; then resolve_pi_identity; return; fi
+  # grok sets GROK_AGENT=1 for its child/tool processes (verified, grok 0.2.73)
+  # and does NOT set CLAUDECODE despite being Claude-Code-compatible.
+  [ "${GROK_AGENT:-}" = "1" ] && { echo grok; return; }
   echo unknown
 }
 

--- a/tests/fm-kimi-harness.test.sh
+++ b/tests/fm-kimi-harness.test.sh
@@ -503,7 +503,12 @@ test_kimi_readiness_gate_precedes_pointer() {
   pass "fm-spawn: kimi never sends the brief pointer before an observable ready signal"
 }
 
-test_kimi_detection_uses_ancestry_after_markers() {
+# kimi is markerless (no env marker of its own), so it is detectable ONLY through
+# live process ancestry. bin/fm-harness.sh resolves ancestry FIRST, so a stale
+# CLAUDECODE=1 inherited from a dead claude session must NOT relabel a live kimi
+# process as claude - the same leak the Pi cases hit, in a harness that has no
+# marker to fall back to.
+test_kimi_detection_prefers_live_ancestry_over_stale_markers() {
   local dir fakebin cfg out
   dir="$TMP_ROOT/detection"
   fakebin=$(fm_fakebin "$dir")
@@ -533,9 +538,10 @@ SH
   out=$(env -u CLAUDECODE -u PI_CODING_AGENT -u GROK_AGENT \
     PATH="$fakebin:$BASE_PATH" FM_CONFIG_OVERRIDE="$cfg" "$ROOT/bin/fm-harness.sh")
   [ "$out" = kimi ] || fail "kimi ancestry detection returned '$out'"
+  # The leak: CLAUDECODE=1 is stale (dead claude ancestor); the live parent is kimi.
   out=$(CLAUDECODE=1 PATH="$fakebin:$BASE_PATH" FM_CONFIG_OVERRIDE="$cfg" "$ROOT/bin/fm-harness.sh")
-  [ "$out" = claude ] || fail "verified env-marker precedence changed, got '$out'"
-  pass "fm-harness: markerless kimi is detected by ancestry after env-marker precedence"
+  [ "$out" = kimi ] || fail "stale CLAUDECODE outranked live kimi ancestry, got '$out'"
+  pass "fm-harness: live kimi ancestry beats a stale inherited CLAUDECODE marker"
 }
 
 test_kimi_session_lock_identity() {
@@ -669,7 +675,7 @@ test_kimi_falls_back_to_expanded_home_binary
 test_kimi_missing_binary_refuses_before_pane_creation
 test_kimi_unconfirmed_delivery_fails_loudly
 test_kimi_readiness_gate_precedes_pointer
-test_kimi_detection_uses_ancestry_after_markers
+test_kimi_detection_prefers_live_ancestry_over_stale_markers
 test_kimi_session_lock_identity
 test_kimi_busy_signature_is_scoped_to_spinner_lines
 test_watcher_never_classifies_kimi_from_its_spinner

--- a/tests/fm-secondmate-harness.test.sh
+++ b/tests/fm-secondmate-harness.test.sh
@@ -61,6 +61,35 @@ fm_git_identity fmtest fmtest@example.com
 TMP_ROOT=$(fm_test_tmproot fm-secondmate-harness)
 export FM_BACKEND=tmux
 
+# The config-resolution cases below only need detect_own pinned to a KNOWN value,
+# not to a specific ancestry: they set CLAUDECODE=1 to mean "own harness = claude".
+# bin/fm-harness.sh now resolves live process ancestry FIRST, so without a
+# controlled parent chain those cases would silently resolve to whichever harness
+# actually launched the suite (claude under one runner, pi under another). Running
+# them through a neutral fake `ps` that reports no verified harness in the chain
+# keeps ancestry deliberately blind, so the env marker each case sets is the sole
+# signal and the assertions no longer depend on the runner.
+NEUTRAL_PS_BIN=$(fm_fakebin "$TMP_ROOT/neutral-ps")
+cat > "$NEUTRAL_PS_BIN/ps" <<'SH'
+#!/usr/bin/env bash
+# A parent chain with no verified harness: any pid reports comm=bash, ppid=1, so
+# the ancestry walk stops immediately and detect_own falls back to env markers.
+set -u
+field=
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -o) field=$2; shift 2 ;;
+    -p) shift 2 ;;
+    *) shift ;;
+  esac
+done
+case "$field" in
+  comm=|args=) printf '%s\n' bash ;;
+  ppid=) printf '%s\n' 1 ;;
+esac
+SH
+chmod +x "$NEUTRAL_PS_BIN/ps"
+
 # ===========================================================================
 # A) fm-harness.sh secondmate resolution + fallback (deterministic detect_own)
 # ===========================================================================
@@ -80,8 +109,8 @@ test_harness_resolution() {
     mkdir -p "$cfg"
     [ "$crew" = "-" ] || printf '%s\n' "$crew" > "$cfg/crew-harness"
     [ "$sm" = "-" ] || printf '%s\n' "$sm" > "$cfg/secondmate-harness"
-    got_sm=$(CLAUDECODE=1 FM_CONFIG_OVERRIDE="$cfg" "$ROOT/bin/fm-harness.sh" secondmate)
-    got_crew=$(CLAUDECODE=1 FM_CONFIG_OVERRIDE="$cfg" "$ROOT/bin/fm-harness.sh" crew)
+    got_sm=$(CLAUDECODE=1 PATH="$NEUTRAL_PS_BIN:$BASE_PATH" FM_CONFIG_OVERRIDE="$cfg" "$ROOT/bin/fm-harness.sh" secondmate)
+    got_crew=$(CLAUDECODE=1 PATH="$NEUTRAL_PS_BIN:$BASE_PATH" FM_CONFIG_OVERRIDE="$cfg" "$ROOT/bin/fm-harness.sh" crew)
     [ "$got_sm" = "$exp_sm" ] || fail "$label: secondmate resolved '$got_sm', expected '$exp_sm'"
     [ "$got_crew" = "$exp_crew" ] || fail "$label: crew resolved '$got_crew', expected '$exp_crew'"
   done <<'ROWS'
@@ -116,9 +145,9 @@ test_secondmate_model_effort_tokens() {
     cfg="$case_dir/config"
     mkdir -p "$cfg"
     [ "$line" = ABSENT ] || printf '%b\n' "$line" > "$cfg/secondmate-harness"
-    got_h=$(CLAUDECODE=1 FM_CONFIG_OVERRIDE="$cfg" "$ROOT/bin/fm-harness.sh" secondmate)
-    got_m=$(CLAUDECODE=1 FM_CONFIG_OVERRIDE="$cfg" "$ROOT/bin/fm-harness.sh" secondmate-model)
-    got_e=$(CLAUDECODE=1 FM_CONFIG_OVERRIDE="$cfg" "$ROOT/bin/fm-harness.sh" secondmate-effort)
+    got_h=$(CLAUDECODE=1 PATH="$NEUTRAL_PS_BIN:$BASE_PATH" FM_CONFIG_OVERRIDE="$cfg" "$ROOT/bin/fm-harness.sh" secondmate)
+    got_m=$(CLAUDECODE=1 PATH="$NEUTRAL_PS_BIN:$BASE_PATH" FM_CONFIG_OVERRIDE="$cfg" "$ROOT/bin/fm-harness.sh" secondmate-model)
+    got_e=$(CLAUDECODE=1 PATH="$NEUTRAL_PS_BIN:$BASE_PATH" FM_CONFIG_OVERRIDE="$cfg" "$ROOT/bin/fm-harness.sh" secondmate-effort)
     [ "$got_h" = "$exp_harness" ] || fail "$label: harness resolved '$got_h', expected '$exp_harness'"
     [ "$got_m" = "$exp_model" ] || fail "$label: model resolved '$got_m', expected '$exp_model'"
     [ "$got_e" = "$exp_effort" ] || fail "$label: effort resolved '$got_e', expected '$exp_effort'"
@@ -249,6 +278,92 @@ SH
   [ ! -s "$err" ] || fail "session-lock liveness wrote basename option noise for literal -codex: $(cat "$err")"
 
   pass "harness identity: dash-leading ps command names are basename operands, not options"
+}
+
+# ===========================================================================
+# A) detect_own: a stale INHERITED env marker never outranks live ancestry
+# ===========================================================================
+# Regression for the CLAUDECODE-leak bug. A captain who `/exit`s a claude session
+# and starts `pi` in the same shell leaves CLAUDECODE=1 (and the other CLAUDE_CODE_*
+# vars) exported. bin/fm-harness.sh must still report the LIVE harness - its running
+# parent - because an exported marker outlives the process that set it while the
+# live process ancestry cannot name a dead ancestor. A fake `ps` supplies the live
+# chain; FM_TEST_ANC (a test-only selector, NOT read by fm-harness.sh) picks the
+# harness at the top of that chain. Both leak directions are covered, plus the
+# FM_PI_HARNESS=pi-signed launch boundary and a markerless harness (kimi) leak, plus
+# the blind-ancestry fallback where the env marker is legitimately the only signal.
+test_stale_env_marker_never_outranks_live_ancestry() {
+  local dir fakebin label anc cc pc fp ga exp got n
+  dir="$TMP_ROOT/stale-marker-leak"
+  fakebin=$(fm_fakebin "$dir")
+  cat > "$fakebin/ps" <<'SH'
+#!/usr/bin/env bash
+# Live parent chain: <self> -bash-> pid 4242 -> init(1). The harness named at pid
+# 4242 is chosen by FM_TEST_ANC; FM_TEST_ANC=none leaves the chain harness-free so
+# ancestry is blind and detect_own falls back to whatever env markers are set.
+set -u
+field= pid=
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -o) field=$2; shift 2 ;;
+    -p) pid=$2; shift 2 ;;
+    *) shift ;;
+  esac
+done
+anc=${FM_TEST_ANC:-none}
+if [ "$pid" = 4242 ]; then
+  case "$field" in
+    comm=)
+      case "$anc" in
+        pi)     printf '%s\n' '/opt/homebrew/bin/pi' ;;
+        claude) printf '%s\n' '/opt/homebrew/bin/claude' ;;
+        grok)   printf '%s\n' '/usr/local/bin/grok' ;;
+        kimi)   printf '%s\n' 'kimi' ;;
+        *)      printf '%s\n' 'bash' ;;
+      esac ;;
+    args=) printf '%s\n' "$anc" ;;
+    ppid=) printf '%s\n' 1 ;;
+  esac
+else
+  case "$field" in
+    comm=|args=) printf '%s\n' bash ;;
+    ppid=) printf '%s\n' 4242 ;;
+  esac
+fi
+SH
+  chmod +x "$fakebin/ps"
+
+  n=0
+  while IFS='^' read -r label anc cc pc fp ga exp; do
+    [ -n "$label" ] || continue
+    n=$((n + 1))
+    # Drop every ambient marker, then set only this row's markers (a literal '-'
+    # means leave that marker unset). FM_TEST_ANC drives the faked live chain.
+    set -- env -u CLAUDECODE -u PI_CODING_AGENT -u FM_PI_HARNESS -u GROK_AGENT \
+      PATH="$fakebin:$BASE_PATH" "FM_TEST_ANC=$anc"
+    [ "$cc" = - ] || set -- "$@" "CLAUDECODE=$cc"
+    [ "$pc" = - ] || set -- "$@" "PI_CODING_AGENT=$pc"
+    [ "$fp" = - ] || set -- "$@" "FM_PI_HARNESS=$fp"
+    [ "$ga" = - ] || set -- "$@" "GROK_AGENT=$ga"
+    got=$("$@" "$ROOT/bin/fm-harness.sh")
+    [ "$got" = "$exp" ] || fail "$label: resolved '$got', expected '$exp' (row $n)"
+  done <<'ROWS'
+leak A: dead claude marker + live pi ancestry -> pi^pi^1^-^-^-^pi
+leak A + pi-signed launch boundary survives the leak^pi^1^true^pi-signed^-^pi-signed
+live pi ancestry, only a stale claude marker (no pi marker) -> pi^pi^1^-^-^-^pi
+leak B: dead pi markers + live claude ancestry + claude marker -> claude^claude^1^true^pi-signed^-^claude
+leak B: dead pi markers + live claude ancestry, no claude marker -> claude^claude^-^true^pi-signed^-^claude
+markerless leak: dead claude marker + live kimi ancestry -> kimi^kimi^1^-^-^-^kimi
+markerless leak: dead pi marker + live kimi ancestry -> kimi^kimi^-^true^-^-^kimi
+leak: dead claude marker + live grok ancestry -> grok^grok^1^-^-^-^grok
+blind ancestry falls back to the claude marker^none^1^-^-^-^claude
+blind ancestry falls back to the pi marker^none^-^true^-^-^pi
+blind ancestry: pi marker + signed boundary -> pi-signed^none^-^true^pi-signed^-^pi-signed
+blind ancestry: signed boundary without the pi family marker -> unknown^none^-^-^pi-signed^-^unknown
+blind ancestry falls back to the grok marker^none^-^-^-^1^grok
+blind ancestry with no marker -> unknown^none^-^-^-^-^unknown
+ROWS
+  pass "detect_own: live ancestry beats a stale inherited marker in both directions; pi-signed boundary and markerless harnesses preserved"
 }
 
 # ===========================================================================
@@ -2341,6 +2456,7 @@ test_harness_resolution
 test_secondmate_model_effort_tokens
 test_pi_signed_detection_and_session_lock_identity
 test_dash_leading_process_names_are_basename_operands
+test_stale_env_marker_never_outranks_live_ancestry
 test_propagate_lib
 test_spawn_split_and_inherit
 test_spawn_backward_compat_crew_fallback


### PR DESCRIPTION
## What went wrong

A captain exited a Claude Code session with `/exit` and started `pi` in the **same shell**.
Claude Code's exported environment (`CLAUDECODE=1` and the other `CLAUDE_CODE_*` variables) survived that transition, because an exported variable outlives the process that set it.
Firstmate then ran on Pi for the whole session while reporting itself as Claude Code.

Harness identity selects the supervision protocol firstmate emits for its own turns.
Believing it was Claude Code, this Pi session emitted the Claude Stop-hook auto-arm protocol instead of Pi's extension-owned one. The observed fallout:

- repeated `TURN WOULD END BLIND - supervision is off` guard fires with no working repair path;
- `bin/fm-watch-arm.sh` refusing (surfaced as "this session is shutting down"), which was misread as a separate defect and drove a full session restart that did not fix it;
- the captain reporting that away-mode messages never arrived ("maybe it's not working in the Pi harness") - which was correct and was misdiagnosed at the time.

This is upstream of the `afk-pi-native` fix: that work assumes firstmate already knows it is Pi. Here it did not.

## Root cause

`bin/fm-harness.sh`'s `detect_own()` checked verified environment markers **first** and only fell back to live process ancestry.
It short-circuited on `CLAUDECODE=1` and returned `claude` before ever reaching the `PI_CODING_AGENT=true` check. A stale exported marker from a dead ancestor therefore outranked the currently-running agent's own live marker.

## The fix

Reorder detection so **live process ancestry is authoritative** and verified env markers are only a fallback used when ancestry cannot name a harness.

The precedence is not an arbitrary line swap - it follows which signals are launch-scoped and which can survive an `exec`:

- **Process ancestry** reflects the process tree as it exists *right now*. The walk starts at this process and stops at pid 1, so it can never name a dead ancestor: a process whose parent exits is reparented to pid 1, where the walk stops. The harness whose process actually launched firstmate always appears in this chain.
- **An exported marker** (`CLAUDECODE=1`, `PI_CODING_AGENT=true`, `GROK_AGENT=1`) outlives the process that set it - it persists in an interactive shell across `/exit` and into the next program launched there. So it must never outrank live ancestry.

Ancestry-first also correctly resolves genuine nesting (e.g. a `pi` launched from a Claude tool shell) to the **closest** harness in the chain.

`resolve_pi_identity` is extracted so the `pi-signed` launch boundary is applied consistently in both the ancestry and fallback paths: the signed identity is selected only when both live Pi markers are present (`PI_CODING_AGENT=true` **and** `FM_PI_HARNESS=pi-signed`). A plain-Pi launch cannot be relabelled by an inherited `FM_PI_HARNESS=pi-signed`, and unmarked shared Pi ancestry stays plain `pi`.

The env-marker fallback still matters: `codex`, `opencode`, and `kimi` are markerless and are detectable **only** through ancestry, while `claude`, the Pi family, and `grok` expose a marker used when ancestry is blind (no `ps`, or a bare interpreter whose script path did not match).

## Where harness identity is consumed (what was wrong this session)

Every consumer of firstmate's own harness identity was fed `claude` instead of `pi`:

1. **Supervision protocol emission** - `bin/fm-supervision-instructions.sh` selects the emitted protocol snippet purely from harness identity, so the Pi session got the Claude protocol. (`bin/fm-session-start.sh` and the away-mode `bin/fm-supervise-daemon.sh` read the same identity.)
2. **Turn-end guard mode** - the same snippet selection wires the turn-end guard: `pi.md` wires Pi's extension-owned guard, `claude.md` wires the Claude Stop-hook auto-arm whose `fm-watch-arm` refused. This is the direct source of the "turn would end blind" fires.
3. **Busy-state / turn-end signal** - the emitted protocol determines which harness's turn-end signal firstmate waits on, so a Pi primary told it was Claude waited on the wrong signal and never woke correctly.
4. **`fm-harness.sh crew` fallback** - `resolve_crew()` mirrors `detect_own` when `config/crew-harness` is absent or `default`, so crewmates would have been launched on the wrong harness too.

## Does spawn propagate the pollution? (reported, not fixed here)

Yes. `bin/fm-spawn.sh` does **not** scrub `CLAUDECODE` / `PI_CODING_AGENT` / `GROK_AGENT` from the child environment before launching a crewmate (it only sets `FM_PI_HARNESS` for Pi launches and unsets `TRACEPARENT`), so stale markers do propagate into every child.

This fix makes that largely harmless for the normal case: a child's own live parent is its launching harness, so ancestry-first detection now correctly ignores any inherited marker. The only residual gap is a markerless child whose ancestry walk cannot match (no `ps`, or a wrapper hiding the harness name in its path), which would then fall back to a stale inherited marker. Scrubbing markers at spawn would be defense-in-depth; I did **not** expand scope to do it here, per the task constraint - flagging it as a separate follow-up.

## Verification

- **Reproduced first.** With a fake `ps` supplying a live `pi` parent chain plus a stale `CLAUDECODE=1`, the pre-fix `bin/fm-harness.sh` (from `origin/main`) returns `claude`; the fixed script returns `pi`.
- **Regression coverage** added in `tests/fm-secondmate-harness.test.sh` (a table covering both leak directions, the `pi-signed` launch boundary, markerless-harness leaks, and every blind-ancestry fallback row) and `tests/fm-kimi-harness.test.sh` (markerless kimi: live ancestry beats a stale inherited `CLAUDECODE`). The two config-resolution suites were pinned with a neutral fake `ps` so their env-marker assertions no longer depend on whichever harness ran the suite.
- `bash tests/fm-secondmate-harness.test.sh` - all pass.
- `bash tests/fm-kimi-harness.test.sh` - all pass.
- `bin/fm-lint.sh` (the repo's pinned shellcheck owner, 0.11.0) - clean.

Note: `tests/fm-pi-primary-types.test.sh` and `tests/fm-calm-pi-extension.test.sh` fail on a clean tree too (Pi SDK type drift, unrelated to this branch); they are not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
