### PR TITLE
fix(watch): absorb a live declared-paused crewmate on the bounded pause cadence

### DIFF
--- a/bin/fm-classify-lib.sh
+++ b/bin/fm-classify-lib.sh
@@ -129,9 +129,11 @@ status_is_paused() {  # <status-line>
 
 # 0 if a status line declares either an external-wait pause or a verified
 # captain-held transfer.
-# Both declarations can intentionally leave an exited crew's endpoint idle, so
-# the watcher applies its bounded pause cadence when agent death confirms that
-# no live decision gate is being silenced.
+# A declared paused: is a live external wait - the crew stays alive and idle - so
+# the watcher applies its bounded pause cadence regardless of agent liveness. A
+# captain-held transfer instead expects the endpoint to have exited, so the
+# watcher applies the same cadence only when agent death confirms it and surfaces
+# a still-live captain-held endpoint. pause_state_class owns that split.
 status_is_paused_or_captain_held() {  # <status-line>
   local line=$1 verb
   status_is_paused "$line" && return 0

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -152,9 +152,10 @@ STALE_ESCALATE_SECS=${FM_STALE_ESCALATE_SECS:-240}  # idle secs before a provabl
 # between completed turns, including long tool calls, builds, or test runs.
 BUSY_TURN_MAX_SECS=${FM_BUSY_TURN_MAX_SECS:-3600}
 # A crew that declared a pause is idling on a known external wait, so its stale
-# pane is absorbed rather than wedge-escalated.
-# A captain-held or paused crew whose agent has confidently exited uses the same
-# bounded cadence, while a live or ambiguously read agent still surfaces once.
+# pane is absorbed rather than wedge-escalated - whether the agent is still live
+# (the normal external-wait case) or has confidently exited. A captain-held
+# transfer whose agent has confidently exited uses the same bounded cadence,
+# while a still-live captain-held endpoint is suspect and still surfaces once.
 # These cases re-surface once for a recheck every PAUSE_RESURFACE_SECS - far
 # longer than the wedge threshold, but finite so a forgotten hold cannot rot invisibly.
 PAUSE_RESURFACE_SECS=${FM_PAUSE_RESURFACE_SECS:-$FM_PAUSE_RESURFACE_SECS_DEFAULT}
@@ -363,8 +364,16 @@ clear_pause_tracking() {  # <window>
 }
 
 # Reconcile a declared pause or captain-held status with authoritative crew state.
-# Only a confidently dead ordinary crew may recover paused classification after
-# fm-crew-state has fallen back to stopped or unknown.
+# A genuine declared paused: is a LIVE external wait: the crew is expected to sit
+# alive and idle, so it classifies `paused` (absorbed on the bounded cadence)
+# whenever crew state still agrees, independent of agent liveness. A captain-held
+# transfer instead expects the agent to have EXITED, so a still-live captain-held
+# endpoint is suspect and classifies `none` (surfaces); only a confidently dead
+# ordinary crew recovers paused after fm-crew-state has fallen back to stopped or
+# unknown. The safety net for a wrongly-declared or forgotten pause is
+# handle_paused_stale's PAUSE_RESURFACE_SECS recheck, never a liveness gate: a
+# live crew that keeps sitting on paused: is rechecked on that long cadence, not
+# surfaced as a wedge every poll.
 pause_state_class() {  # <window> <task>
   local win=$1 task=$2 key last recheck_file class agent_alive
   key=${win//:/_}
@@ -377,8 +386,11 @@ pause_state_class() {  # <window> <task>
     crew_absorb_class "$task"
     return
   fi
+  # Fast path: a recently-classified pause skips the costly crew-state read. The
+  # dead-agent liveness gate applies ONLY to a captain-held transfer; a genuine
+  # paused: is a live external wait, so a live agent is expected and absorbed.
   if [ -e "$STATE/.paused-$key" ] && [ "$(age_of "$recheck_file")" -lt "$STALE_ESCALATE_SECS" ]; then
-    if [ "$(window_kind "$win")" != secondmate ]; then
+    if ! status_is_paused "$last" && [ "$(window_kind "$win")" != secondmate ]; then
       agent_alive=$(fm_backend_agent_alive "$(window_backend "$win")" "$win" 2>/dev/null) || agent_alive=unknown
       if [ "$agent_alive" != dead ]; then
         rm -f "$recheck_file"
@@ -390,25 +402,40 @@ pause_state_class() {  # <window> <task>
     return
   fi
   class=$(crew_absorb_class "$task")
-  if [ "$class" = working ]; then
-    rm -f "$recheck_file"
-    printf 'working'
-    return
-  fi
+  case "$class" in
+    working)
+      rm -f "$recheck_file"
+      printf 'working'
+      return
+      ;;
+    paused)
+      # crew_absorb_class reports paused only for a genuine declared paused: with
+      # no active run overriding it, so absorb on the bounded cadence regardless
+      # of agent liveness.
+      date +%s > "$recheck_file"
+      printf 'paused'
+      return
+      ;;
+  esac
+  # class is none: a captain-held transfer, or a declared pause whose crew state
+  # no longer confirms the pause. A still-live captain-held endpoint surfaces; a
+  # confidently dead endpoint under either declaration recovers the bounded
+  # cadence. A live declared pause with no confirming crew state surfaces once.
   if [ "$(window_kind "$win")" != secondmate ]; then
     agent_alive=$(fm_backend_agent_alive "$(window_backend "$win")" "$win" 2>/dev/null) || agent_alive=unknown
-    if [ "$agent_alive" != dead ]; then
+    if [ "$agent_alive" != dead ] && ! status_is_paused "$last"; then
       rm -f "$recheck_file"
       printf 'none'
       return
     fi
   fi
-  [ "$class" = none ] && [ "${agent_alive:-unknown}" = dead ] && class=paused
-  case "$class" in
-    paused) date +%s > "$recheck_file" ;;
-    *) rm -f "$recheck_file" ;;
-  esac
-  printf '%s' "$class"
+  if [ "${agent_alive:-unknown}" = dead ]; then
+    date +%s > "$recheck_file"
+    printf 'paused'
+    return
+  fi
+  rm -f "$recheck_file"
+  printf 'none'
 }
 
 surface_nonterminal_stale() {  # <window> <hash>
@@ -1014,9 +1041,9 @@ EOF
           #   - working: an actively-running pipeline legitimately sits on a static
           #     pane (e.g. waiting on CI), so absorb and start the wedge timer so a
           #     genuinely frozen run still escalates past STALE_ESCALATE_SECS;
-          #   - paused: the crew declared an external wait, or a declared pause or
-          #     captain hold is paired with a confidently dead agent, so absorb on
-          #     the long PAUSE_RESURFACE_SECS cadence instead of wedge-escalating;
+          #   - paused: the crew declared an external wait (live or exited), or a
+          #     captain-held transfer is paired with a confidently dead agent, so
+          #     absorb on the long PAUSE_RESURFACE_SECS cadence instead of wedge-escalating;
           #   - none: no running pipeline, no exact busy verdict, no declared pause.
           #     Surface immediately so firstmate inspects the inconclusive state
           #     (it may be done via an interactive menu that wrote no done: status,

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -19,7 +19,8 @@ A concurrent replacement remains armed, every non-merged or invalid observation 
 `bin/fm-pr-lib.sh` owns the receipt format and strict identity mechanics, while `bin/fm-watch.sh` owns queue-before-retirement ordering.
 No-verb wakes, such as `working:` notes and bare turn-ended signals, are benign only when `bin/fm-crew-state.sh` reports positive evidence that the crew is still working: an actively running no-mistakes step attributed to that crew's current code, or an exact busy verdict from the semantic busy-state contract.
 A crew that declares `paused:` for a known external wait is separately absorbed while idle and re-surfaced only on the longer pause cadence, rather than being treated as a possible wedge.
-That absorption holds whether the paused agent is still live, which is the normal external-wait case, or has exited; a wrongly-declared or forgotten pause is caught by that same bounded recheck, not by a liveness gate.
+That absorption holds whenever the current-state read still reports the pause, whether the agent is still live, which is the normal external-wait case, or has exited; a confidently dead agent keeps the bounded cadence even after that read falls back to stopped or unknown, while a live pane whose current state no longer reports the pause surfaces once.
+A wrongly-declared or forgotten pause is caught by that same bounded recheck, not by a liveness gate.
 A durable `captain-held` endpoint instead expects the agent to have exited, so the normal-mode watcher first surfaces one stale wake, then applies that same cadence only when the backend confidently reports its agent dead, while a still-live or inconclusive `captain-held` endpoint stays surfaced.
 The secondmate idle-endpoint exemption is unchanged.
 Its initial normal-mode status signal still surfaces through the no-verb path, while away mode self-handles that routine signal and owns the later recheck.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -19,8 +19,9 @@ A concurrent replacement remains armed, every non-merged or invalid observation 
 `bin/fm-pr-lib.sh` owns the receipt format and strict identity mechanics, while `bin/fm-watch.sh` owns queue-before-retirement ordering.
 No-verb wakes, such as `working:` notes and bare turn-ended signals, are benign only when `bin/fm-crew-state.sh` reports positive evidence that the crew is still working: an actively running no-mistakes step attributed to that crew's current code, or an exact busy verdict from the semantic busy-state contract.
 A crew that declares `paused:` for a known external wait is separately absorbed while idle and re-surfaced only on the longer pause cadence, rather than being treated as a possible wedge.
-For an ordinary crew that has stopped, the normal-mode watcher first surfaces one stale wake, then applies that same cadence to an unchanged `paused:` or durable `captain-held` endpoint only when the backend confidently reports its agent dead.
-Live or inconclusive liveness remains fail-open at that initial surface, and the secondmate idle-endpoint exemption is unchanged.
+That absorption holds whether the paused agent is still live, which is the normal external-wait case, or has exited; a wrongly-declared or forgotten pause is caught by that same bounded recheck, not by a liveness gate.
+A durable `captain-held` endpoint instead expects the agent to have exited, so the normal-mode watcher first surfaces one stale wake, then applies that same cadence only when the backend confidently reports its agent dead, while a still-live or inconclusive `captain-held` endpoint stays surfaced.
+The secondmate idle-endpoint exemption is unchanged.
 Its initial normal-mode status signal still surfaces through the no-verb path, while away mode self-handles that routine signal and owns the later recheck.
 Fresh stale panes use the same current-state read before trusting the status log, so an active run or a proven busy worker outranks an old captain-relevant status-log line left behind before validation.
 No-change heartbeats are also benign.

--- a/tests/fm-watch-triage.test.sh
+++ b/tests/fm-watch-triage.test.sh
@@ -574,6 +574,10 @@ test_nonterminal_stale_provably_working_absorbed_then_escalated() {
 # not busy) has stopped - it may be done via interactive menus, waiting, or wedged.
 # It must surface at once, never wait out the wedge timer, so these users (a
 # non-no-mistakes crew, or any crew with no running pipeline) are never left hanging.
+# The agent is deliberately LIVE here (FM_FAKE_TMUX_CURRENT_COMMAND=grok): pause
+# absorption keys off the declared status verb, never off liveness, so a live crew
+# that did NOT declare a pause must keep producing ordinary stale wakes. This is
+# the no-wedge-detection-regression half of the paused-absorption contract.
 
 test_nonterminal_stale_not_working_surfaced() {
   local dir state fakebin out drain_out capture_file window key pane_hash sig pid
@@ -581,7 +585,7 @@ test_nonterminal_stale_not_working_surfaced() {
   out="$dir/watch.out"; drain_out="$dir/drain.out"; capture_file="$dir/pane.txt"
   window="test:fm-stopped"
   printf 'idle prompt, finished' > "$capture_file"
-  printf 'window=%s\nkind=ship\n' "$window" > "$state/stopped.meta"
+  printf 'window=%s\nkind=ship\nharness=grok\nbackend=tmux\n' "$window" > "$state/stopped.meta"
   # Non-terminal status (the crew never wrote a captain-relevant verb), .seen-*
   # primed so the signal scan does not pre-empt the stale path.
   printf 'working: implementing\n' > "$state/stopped.status"
@@ -595,6 +599,7 @@ test_nonterminal_stale_not_working_surfaced() {
 
   # Even with a high wedge threshold, a not-provably-working stale surfaces at once.
   PATH="$fakebin:$PATH" FM_FAKE_TMUX_WINDOW="$window" FM_FAKE_TMUX_CAPTURE="$capture_file" \
+    FM_FAKE_TMUX_CURRENT_COMMAND=grok \
     FM_STATE_OVERRIDE="$state" FM_CREW_STATE_BIN="$fakebin/fm-crew-state.sh" FM_STALE_ESCALATE_SECS=999 FM_POLL=1 FM_SIGNAL_GRACE=1 \
     FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$out" &
   pid=$!
@@ -605,7 +610,7 @@ test_nonterminal_stale_not_working_surfaced() {
   [ ! -e "$state/.stale-since-$key" ] || fail "stale-since timer should not be set when surfacing immediately"
   FM_STATE_OVERRIDE="$state" "$DRAIN" > "$drain_out" 2>/dev/null || fail "drain after the immediate stale failed"
   grep "$(printf '\tstale\t')" "$drain_out" | grep -F "$window" >/dev/null || fail "immediate stale wake was not queued"
-  pass "a not-provably-working non-terminal stale is surfaced immediately (never left to wait out the timer)"
+  pass "a LIVE, not-provably-working, non-paused stale is surfaced immediately (never left to wait out the timer)"
 }
 
 # --- non-terminal stale, crew DECLARED a pause: absorbed, re-surfaced on a long
@@ -799,6 +804,46 @@ test_exited_and_live_declared_pause_and_captain_held_are_bounded() {
   pass "exited and LIVE declared-pause plus exited captain-held panes all use the bounded pause cadence, never a per-hash stale flood"
 }
 
+# --- the other half of the split: a LIVE captain-held endpoint still surfaces ---
+# The liveness gate survives for exactly one case. A captain-held transfer means the
+# work moved to a held-decision route and the agent is expected to have EXITED, so an
+# endpoint still running its harness contradicts the declaration and must surface
+# rather than hide on the pause cadence. The load-bearing guard is pause_state_class's
+# fast path: with .paused-<key> present and a fresh .paused-rechecked-<key> the crew
+# state is never re-read, so only the captain-held-plus-live check keeps this from
+# being absorbed. Pre-seed both markers so the fast path is the branch under test.
+test_live_captain_held_still_surfaces() {
+  local dir state fakebin out drain_out capture_file statusf window key pane_hash sig pid
+  dir=$(make_case live-captain-held); state="$dir/state"; fakebin="$dir/fakebin"
+  out="$dir/watch.out"; drain_out="$dir/drain.out"; capture_file="$dir/pane.txt"; statusf="$state/held.status"
+  window="test:fm-held"
+  printf 'idle agent pane after a captain-held transfer\n' > "$capture_file"
+  printf 'window=%s\nkind=ship\nharness=grok\nbackend=tmux\n' "$window" > "$state/held.meta"
+  printf 'captain-held [key=route]: tracked by held-decision-route\n' > "$statusf"
+  sig=$(seen_sig "$statusf"); printf '%s' "$sig" > "$state/.seen-held_status"
+  key=$(printf '%s' "$window" | tr ':/.' '___')
+  pane_hash=$(hash_text "idle agent pane after a captain-held transfer")
+  printf '%s' "$pane_hash" > "$state/.hash-$key"
+  printf '1\n' > "$state/.count-$key"
+  # A pause cadence already running, rechecked just now: the fast path applies.
+  : > "$state/.paused-$key"
+  date +%s > "$state/.paused-rechecked-$key"
+
+  PATH="$fakebin:$PATH" FM_FAKE_TMUX_WINDOW="$window" FM_FAKE_TMUX_CAPTURE="$capture_file" \
+    FM_FAKE_TMUX_CURRENT_COMMAND=grok FM_FAKE_CREW_STATE='state: unknown · source: pane · no current-state source available' \
+    FM_STATE_OVERRIDE="$state" FM_CREW_STATE_BIN="$fakebin/fm-crew-state.sh" FM_STALE_ESCALATE_SECS=240 FM_PAUSE_RESURFACE_SECS=999 FM_POLL=1 FM_SIGNAL_GRACE=1 \
+    FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$out" &
+  pid=$!
+  wait_for_exit "$pid" 40 || fail "a still-live captain-held endpoint was absorbed on the pause cadence instead of surfacing"
+  grep -Fx "stale: $window" "$out" >/dev/null || fail "live captain-held endpoint did not print the bare stale wake"
+  grep -F "awaiting external" "$out" >/dev/null && fail "live captain-held endpoint was hidden behind the paused recheck label"
+  grep -F "possible wedge" "$out" >/dev/null && fail "live captain-held endpoint was mislabeled a possible wedge"
+  FM_STATE_OVERRIDE="$state" "$DRAIN" > "$drain_out" 2>/dev/null || fail "drain after the live captain-held surface failed"
+  grep "$(printf '\tstale\t')" "$drain_out" | grep -F "stale: $window" >/dev/null \
+    || fail "live captain-held bare stale wake was not queued"
+  pass "a still-live captain-held endpoint surfaces a bare stale wake, keeping the liveness gate for the transfer case only"
+}
+
 # --- the 2026-08-03 flood reproduction: a LIVE declared pause on a churny idle
 #     pane must be absorbed on EVERY distinct hash, never surfaced per hash ------
 # A live crew holding a declared paused: often sits on a pane that still ticks (a
@@ -807,7 +852,7 @@ test_exited_and_live_declared_pause_and_captain_held_are_bounded() {
 # bare "stale:" wake for each one, costing firstmate a supervision turn per tick
 # all day. Every one must now be absorbed on the bounded cadence.
 test_live_declared_pause_churny_pane_not_flooded() {
-  local dir state fakebin out capture_file statusf window key pid round content wakes
+  local dir state fakebin out capture_file statusf window key sig pid round content wakes
   dir=$(make_case live-pause-churny); state="$dir/state"; fakebin="$dir/fakebin"
   out="$dir/watch.out"; capture_file="$dir/pane.txt"; statusf="$state/held.status"
   window="test:fm-held"
@@ -1920,6 +1965,7 @@ test_busy_pane_default_turn_age_bound_is_3600s
 test_nonterminal_stale_not_working_surfaced
 test_nonterminal_stale_paused_absorbed_then_resurfaced
 test_exited_and_live_declared_pause_and_captain_held_are_bounded
+test_live_captain_held_still_surfaces
 test_live_declared_pause_churny_pane_not_flooded
 test_live_declared_pause_resurfaces_on_bounded_cadence
 test_secondmate_paused_resurfaces_in_normal_mode

--- a/tests/fm-watch-triage.test.sh
+++ b/tests/fm-watch-triage.test.sh
@@ -681,10 +681,11 @@ test_nonterminal_stale_paused_absorbed_then_resurfaced() {
 # fm-crew-state then authoritatively reports stopped rather than paused, but the
 # confirmed-dead agent plus the declared wait or captain-held transfer must retain
 # bounded pause handling.
-# A still-live agent at an external-decision gate is the disconfirming case: it
-# must surface once, while the unchanged hash must not append the same wake on
-# every watcher re-arm.
-test_exited_declared_pause_is_bounded_but_live_gate_surfaces() {
+# A declared paused: is a live external wait by design, so a still-live paused
+# agent must be absorbed on the same bounded cadence, never surfaced per hash: the
+# liveness gate applies only to a captain-held transfer, where a live endpoint is
+# genuinely suspect.
+test_exited_and_live_declared_pause_and_captain_held_are_bounded() {
   local dir state fakebin out capture_file statusf window key pane_hash sig pid back round wakes bare
   dir=$(make_case exited-declared-pause); state="$dir/state"; fakebin="$dir/fakebin"
   out="$dir/watch.out"; capture_file="$dir/pane.txt"; statusf="$state/held.status"
@@ -741,49 +742,142 @@ test_exited_declared_pause_is_bounded_but_live_gate_surfaces() {
   grep -F "awaiting external" "$state/.wake-queue" >/dev/null \
     || fail "captain-held dead-agent pane surfaced as a stopped crew"
 
-  dir=$(make_case alive-decision-gate); state="$dir/state"; fakebin="$dir/fakebin"
+  # A LIVE crew that declared a pause is a normal external wait, not a wedge: the
+  # agent stays alive and idle by design. It must be absorbed on the bounded
+  # cadence, exactly like the exited case, never surfaced as a bare stale. This
+  # is the regression for the 2026-08-03 flood, where a live declared-paused crew
+  # emitted a fresh bare "stale:" wake on every distinct idle hash all day.
+  dir=$(make_case alive-declared-pause); state="$dir/state"; fakebin="$dir/fakebin"
   out="$dir/watch.out"; capture_file="$dir/pane.txt"; statusf="$state/gate.status"
   window="test:fm-gate"
-  printf 'idle external-decision gate\n' > "$capture_file"
+  printf 'idle awaiting external\n' > "$capture_file"
   printf 'window=%s\nkind=ship\nharness=grok\nbackend=tmux\n' "$window" > "$state/gate.meta"
-  printf 'paused: waiting at an active external-decision gate\n' > "$statusf"
+  printf 'paused: waiting on the upstream release window\n' > "$statusf"
   sig=$(seen_sig "$statusf"); printf '%s' "$sig" > "$state/.seen-gate_status"
   key=$(printf '%s' "$window" | tr ':/.' '___')
-  pane_hash=$(hash_text "idle external-decision gate")
+  pane_hash=$(hash_text "idle awaiting external")
   printf '%s' "$pane_hash" > "$state/.hash-$key"
   printf '1\n' > "$state/.count-$key"
 
-  # First sight must surface promptly so a live external-decision gate is not
-  # hidden behind the pause cadence.
+  # First sight of a fresh pause under a high re-surface threshold is absorbed:
+  # the watcher keeps running (no exit), enqueues no wake, records the pause
+  # cadence marker, and starts no wedge timer. FM_FAKE_TMUX_CURRENT_COMMAND=grok
+  # makes the agent read as ALIVE, the exact case the old liveness gate surfaced.
   PATH="$fakebin:$PATH" FM_FAKE_TMUX_WINDOW="$window" FM_FAKE_TMUX_CAPTURE="$capture_file" \
-    FM_FAKE_TMUX_CURRENT_COMMAND=grok FM_FAKE_CREW_STATE='state: paused · source: status-log · waiting at an active external-decision gate' \
+    FM_FAKE_TMUX_CURRENT_COMMAND=grok FM_FAKE_CREW_STATE='state: paused · source: status-log · waiting on the upstream release window' \
     FM_STATE_OVERRIDE="$state" FM_CREW_STATE_BIN="$fakebin/fm-crew-state.sh" FM_PAUSE_RESURFACE_SECS=999 FM_POLL=1 FM_SIGNAL_GRACE=1 \
     FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" >> "$out" &
   pid=$!
-  wait_for_exit "$pid" 40 || fail "live external-decision gate did not surface immediately"
+  if ! wait_live "$pid" 30; then
+    reap "$pid"; fail "live declared pause exited (surfaced) instead of being absorbed: $(cat "$out")"
+  fi
+  [ -e "$state/.paused-$key" ] || { reap "$pid"; fail "live declared pause did not record its pause cadence marker"; }
+  [ ! -e "$state/.stale-since-$key" ] || { reap "$pid"; fail "live declared pause started a wedge timer"; }
+  reap "$pid"
 
-  # Re-arm with the stale timer already beyond the wedge threshold. This is the
-  # exact unchanged-hash fallback after the immediate surface: it must retain
-  # the pause cadence and discard any residual wedge timer instead of emitting
-  # a second possible-wedge wake.
+  # Re-arm with the stale timer already beyond the wedge threshold on the
+  # unchanged hash: it must retain the pause cadence and discard the residual
+  # wedge timer rather than emitting a possible-wedge wake.
   printf '%s\n' $(( $(date +%s) - 500 )) > "$state/.stale-since-$key"
   PATH="$fakebin:$PATH" FM_FAKE_TMUX_WINDOW="$window" FM_FAKE_TMUX_CAPTURE="$capture_file" \
-    FM_FAKE_TMUX_CURRENT_COMMAND=grok FM_FAKE_CREW_STATE='state: paused · source: status-log · waiting at an active external-decision gate' \
+    FM_FAKE_TMUX_CURRENT_COMMAND=grok FM_FAKE_CREW_STATE='state: paused · source: status-log · waiting on the upstream release window' \
     FM_STATE_OVERRIDE="$state" FM_CREW_STATE_BIN="$fakebin/fm-crew-state.sh" FM_STALE_ESCALATE_SECS=240 FM_PAUSE_RESURFACE_SECS=999 FM_POLL=1 FM_SIGNAL_GRACE=1 \
     FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" >> "$out" &
   pid=$!
   if ! wait_live "$pid" 30; then
     reap "$pid"
-    fail "live external-decision gate escalated on the wedge timer after its immediate surface: $(cat "$out")"
+    fail "live declared pause escalated on the wedge timer instead of holding the pause cadence: $(cat "$out")"
   fi
-  [ -e "$state/.paused-$key" ] || { reap "$pid"; fail "live external-decision gate lost its pause cadence marker"; }
-  [ ! -e "$state/.stale-since-$key" ] || { reap "$pid"; fail "live external-decision gate retained the wedge timer"; }
+  [ -e "$state/.paused-$key" ] || { reap "$pid"; fail "live declared pause lost its pause cadence marker"; }
+  [ ! -e "$state/.stale-since-$key" ] || { reap "$pid"; fail "live declared pause retained the wedge timer"; }
   reap "$pid"
-  wakes=$(awk -F '\t' -v w="$window" '$3 == "stale" && $4 == w { n++ } END { print n + 0 }' "$state/.wake-queue")
-  bare=$(awk -F '\t' -v w="$window" '$3 == "stale" && $4 == w && $5 == "stale: " w { n++ } END { print n + 0 }' "$state/.wake-queue")
-  [ "$wakes" -eq 1 ] || fail "live external-decision gate should surface once, got $wakes wakes"
-  [ "$bare" -eq 1 ] || fail "live external-decision gate lost its immediate bare stale surface"
-  pass "exited declared-pause and captain-held panes use bounded pause cadence while a live decision gate still surfaces once"
+  # An absorbed pause enqueues nothing, so the durable queue may not exist at all.
+  wakes=$(awk -F '\t' -v w="$window" '$3 == "stale" && $4 == w { n++ } END { print n + 0 }' "$state/.wake-queue" 2>/dev/null)
+  bare=$(awk -F '\t' -v w="$window" '$3 == "stale" && $4 == w && $5 == "stale: " w { n++ } END { print n + 0 }' "$state/.wake-queue" 2>/dev/null)
+  [ "${wakes:-0}" -eq 0 ] || fail "live declared pause surfaced $wakes stale wakes; a fresh high-threshold pause must be absorbed"
+  [ "${bare:-0}" -eq 0 ] || fail "live declared pause emitted $bare bare stale wakes; the 2026-08-03 flood is back"
+  pass "exited and LIVE declared-pause plus exited captain-held panes all use the bounded pause cadence, never a per-hash stale flood"
+}
+
+# --- the 2026-08-03 flood reproduction: a LIVE declared pause on a churny idle
+#     pane must be absorbed on EVERY distinct hash, never surfaced per hash ------
+# A live crew holding a declared paused: often sits on a pane that still ticks (a
+# token counter, a clock), so each distinct stable value is a fresh first-sighting
+# stale. The old liveness gate classified a live paused crew `none` and surfaced a
+# bare "stale:" wake for each one, costing firstmate a supervision turn per tick
+# all day. Every one must now be absorbed on the bounded cadence.
+test_live_declared_pause_churny_pane_not_flooded() {
+  local dir state fakebin out capture_file statusf window key pid round content wakes
+  dir=$(make_case live-pause-churny); state="$dir/state"; fakebin="$dir/fakebin"
+  out="$dir/watch.out"; capture_file="$dir/pane.txt"; statusf="$state/held.status"
+  window="test:fm-held"
+  printf 'window=%s\nkind=ship\nharness=grok\nbackend=tmux\n' "$window" > "$state/held.meta"
+  printf 'paused: holding for the upstream release window\n' > "$statusf"
+  sig=$(seen_sig "$statusf"); printf '%s' "$sig" > "$state/.seen-held_status"
+  key=$(printf '%s' "$window" | tr ':/.' '___')
+
+  round=1
+  while [ "$round" -le 5 ]; do
+    content="idle - waiting on upstream (tokens: ${round}00)"
+    printf '%s\n' "$content" > "$capture_file"
+    printf '%s' "$(hash_text "$content")" > "$state/.hash-$key"
+    printf '1\n' > "$state/.count-$key"
+    PATH="$fakebin:$PATH" FM_FAKE_TMUX_WINDOW="$window" FM_FAKE_TMUX_CAPTURE="$capture_file" \
+      FM_FAKE_TMUX_CURRENT_COMMAND=grok FM_FAKE_CREW_STATE='state: paused · source: status-log · holding for the upstream release window' \
+      FM_STATE_OVERRIDE="$state" FM_CREW_STATE_BIN="$fakebin/fm-crew-state.sh" FM_PAUSE_RESURFACE_SECS=999 FM_POLL=1 FM_SIGNAL_GRACE=1 \
+      FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" >> "$out" &
+    pid=$!
+    if ! wait_live "$pid" 20; then
+      reap "$pid"; fail "live declared pause surfaced (exited) on churny idle hash round $round: $(cat "$out")"
+    fi
+    reap "$pid"
+    round=$((round + 1))
+  done
+  [ -e "$state/.paused-$key" ] || fail "churny live pause did not hold its pause cadence marker"
+  [ ! -e "$state/.stale-since-$key" ] || fail "churny live pause started a wedge timer"
+  wakes=$(awk -F '\t' -v w="$window" '$3 == "stale" && $4 == w { n++ } END { print n + 0 }' "$state/.wake-queue" 2>/dev/null)
+  [ "${wakes:-0}" -eq 0 ] || fail "churny live pause flooded $wakes stale wakes across five distinct idle hashes"
+  pass "a live declared pause on a churny idle pane is absorbed on every distinct hash, never flooding bare stale wakes"
+}
+
+# --- a LIVE declared pause still re-surfaces on the bounded cadence ------------
+# The liveness gate is dropped for the paused case, so the ONLY thing keeping a
+# wrongly-declared or forgotten live pause from hiding forever is handle_paused_stale's
+# PAUSE_RESURFACE_SECS recheck. A live crew still sitting on paused: past that
+# threshold must re-surface once as an awaiting-external recheck, never a wedge.
+test_live_declared_pause_resurfaces_on_bounded_cadence() {
+  local dir state fakebin out drain_out capture_file statusf window key pane_hash sig pid back
+  dir=$(make_case live-pause-resurface); state="$dir/state"; fakebin="$dir/fakebin"
+  out="$dir/watch.out"; drain_out="$dir/drain.out"; capture_file="$dir/pane.txt"; statusf="$state/held.status"
+  window="test:fm-held"
+  printf 'idle - still waiting on upstream\n' > "$capture_file"
+  printf 'window=%s\nkind=ship\nharness=grok\nbackend=tmux\n' "$window" > "$state/held.meta"
+  printf 'paused: holding for the upstream release window\n' > "$statusf"
+  # Age the declared pause past the recheck threshold, and prime .seen-* to the
+  # aged signature so the signal scan stays quiet.
+  back=$(( $(date +%s) - 500 ))
+  if [ "$(uname)" = Darwin ]; then touch -mt "$(date -r "$back" '+%Y%m%d%H%M.%S')" "$statusf"
+  else touch -m -d "@$back" "$statusf"; fi
+  sig=$(seen_sig "$statusf"); printf '%s' "$sig" > "$state/.seen-held_status"
+  key=$(printf '%s' "$window" | tr ':/.' '___')
+  pane_hash=$(hash_text "idle - still waiting on upstream")
+  printf '%s' "$pane_hash" > "$state/.hash-$key"
+  printf '1\n' > "$state/.count-$key"
+
+  PATH="$fakebin:$PATH" FM_FAKE_TMUX_WINDOW="$window" FM_FAKE_TMUX_CAPTURE="$capture_file" \
+    FM_FAKE_TMUX_CURRENT_COMMAND=grok FM_FAKE_CREW_STATE='state: paused · source: status-log · holding for the upstream release window' \
+    FM_STATE_OVERRIDE="$state" FM_CREW_STATE_BIN="$fakebin/fm-crew-state.sh" FM_PAUSE_RESURFACE_SECS=240 FM_POLL=1 FM_SIGNAL_GRACE=1 \
+    FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$out" &
+  pid=$!
+  wait_for_exit "$pid" 40 || fail "live declared pause did not re-surface on the bounded cadence past the threshold"
+  grep -F "stale: $window" "$out" >/dev/null || fail "live pause re-surface did not print a stale wake"
+  grep -F "awaiting external" "$out" >/dev/null || fail "live pause re-surface was not labeled a paused/awaiting-external recheck"
+  grep -F "possible wedge" "$out" >/dev/null && fail "a live declared pause re-surface was mislabeled a possible wedge"
+  [ -e "$state/.paused-resurfaced-$key" ] || fail "the live pause re-surface throttle marker was not recorded"
+  [ ! -e "$state/.stale-since-$key" ] || fail "a live pause re-surface must not use the wedge timer"
+  FM_STATE_OVERRIDE="$state" "$DRAIN" > "$drain_out" 2>/dev/null || fail "drain after the live pause re-surface failed"
+  grep "$(printf '\tstale\t')" "$drain_out" | grep -F "$window" >/dev/null || fail "live pause re-surface was not queued"
+  pass "a live declared pause is rechecked on the bounded cadence past the threshold, labeled awaiting-external, never a wedge"
 }
 
 test_secondmate_paused_resurfaces_in_normal_mode() {
@@ -1825,7 +1919,9 @@ test_busy_pane_repeated_escalation_reaches_demand_deep_inspection
 test_busy_pane_default_turn_age_bound_is_3600s
 test_nonterminal_stale_not_working_surfaced
 test_nonterminal_stale_paused_absorbed_then_resurfaced
-test_exited_declared_pause_is_bounded_but_live_gate_surfaces
+test_exited_and_live_declared_pause_and_captain_held_are_bounded
+test_live_declared_pause_churny_pane_not_flooded
+test_live_declared_pause_resurfaces_on_bounded_cadence
 test_secondmate_paused_resurfaces_in_normal_mode
 test_secondmate_nonpaused_stale_remains_suppressed
 test_secondmate_unpause_clears_pause_tracking


### PR DESCRIPTION
## Problem

A healthy crewmate whose last status line is `paused:` emitted repeated bare `stale: <window>` wakes, each costing firstmate a supervision turn. Observed live on 2026-08-03 on two separate tasks.

`bin/fm-crew-state.sh` was already correct, reporting `state: paused · source: status-log`. Only the watcher's absorption path was wrong.

`pause_state_class` short-circuited to `none` whenever `fm_backend_agent_alive` reported anything other than `dead`, in both its fast path and its fallback path. A crewmate that declared `paused:` and then sat alive and idle therefore classified as `none` and fell through to ordinary stale handling, never reaching `handle_paused_stale`. Pause absorption was reachable only for a confidently dead agent, which inverts the documented contract: `AGENTS.md` section 8 and the `bin/fm-brief.sh` status protocol both state that a declared `paused:` means firstmate leaves the idle pane alone and rechecks on a long cadence rather than treating it as a possible wedge.

The `.paused-*` / `.paused-rechecked-*` / `.paused-resurfaced-*` markers were still being written as a side effect of `surface_nonterminal_stale`, which is why they looked freshly stamped even though pause handling never ran.

## Fix

Split the liveness gate by declaration type rather than dropping it.

A genuine `paused:` is a live external wait, so the crew is expected to sit alive and idle. It now classifies `paused` and is absorbed on the bounded cadence whenever crew state still agrees, independent of agent liveness.

The dead-agent gate now applies only to a `captain-held` transfer. There the agent was meant to have exited, so an endpoint still running its harness contradicts the declaration and must surface. `map_log_state` maps `captain-held` to `unknown` and never to `paused`, so the new early return cannot absorb a live captain-held endpoint.

This aligns the normal-mode watcher with `bin/fm-supervise-daemon.sh`, which already classified declared pauses without a liveness gate, rather than creating a second owner for the behavior.

### How the safety property is preserved

The liveness gate existed so a live-but-wedged worker that wrongly declared `paused:` could not hide forever. That property is preserved, not removed.

It now routes through `handle_paused_stale`'s existing `PAUSE_RESURFACE_SECS` recheck and the `.paused-resurfaced-*` throttle. Because that cadence is anchored on the status file's own mtime, a churny idle pane cannot reset it, so a forgotten pause still resurfaces on a bounded cadence as an awaiting-external recheck rather than a wedge.

## Coverage

Added to `tests/fm-watch-triage.test.sh`, in the file's colocated style:

- `test_live_declared_pause_churny_pane_not_flooded` - the 2026-08-03 flood reproduction. A live declared pause on a pane that keeps ticking must be absorbed on every distinct hash, never surfaced per hash.
- `test_live_declared_pause_resurfaces_on_bounded_cadence` - a live declared pause that stops matching still resurfaces within the bounded cadence.
- `test_live_captain_held_still_surfaces` - the other half of the split. A still-live captain-held endpoint keeps producing a bare stale wake, so the retained gate stays under test.
- `test_exited_and_live_declared_pause_and_captain_held_are_bounded` - the dead-agent pause case.
- `test_nonterminal_stale_not_working_surfaced` now pins `FM_FAKE_TMUX_CURRENT_COMMAND`, so the live and not-paused case is asserted with a genuinely live agent and wedge detection is protected against regression.

## Documentation

`docs/architecture.md` owned the inaccurate liveness precondition and is corrected there, along with the `status_is_paused_or_captain_held` header and the watcher comments. `AGENTS.md` section 8 and `bin/fm-brief.sh` never asserted a liveness gate, so nothing there went stale and the contract is not restated in a second place.

## Known limitation, filed as separate follow-up

This does not cure harnesses with no verified busy source. `fm_busy_classify` hardcodes `unknown` for `codex*` and `kimi*` (`bin/fm-busy-lib.sh`), so `fm-crew-state.sh` emits `unknown pane` and exits before its status-log fallback. `pause_state_class` then still receives `class=none` and a live declared-paused Codex or Kimi crewmate continues to emit a bare stale wake roughly every `STALE_ESCALATE_SECS`.

That is better than the previous per-hash flood but is the same underlying failure. Closing it means changing the crew-state and busy-classification contract, which is deliberately out of scope here and tracked as separate follow-up work.
