### PR TITLE
feat(bin): add verified legacy Herdr endpoint re-binding

### DIFF
--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -2273,6 +2273,87 @@ fm_backend_herdr_target_ready() {  # <target>
   fm_backend_herdr_server_ensure "$FM_BACKEND_HERDR_SESSION" || return 1
 }
 
+# fm_backend_herdr_task_binding_snapshot_matches: one read-only proof sample for
+# repairing pre-endpoint_task_id metadata. The exact pane must still report the
+# recorded tab and workspace, the tab must still carry the Firstmate task label
+# expected at spawn, and the pane's live foreground cwd must resolve
+# to the recorded isolated worktree. Labels alone never authorize this proof.
+fm_backend_herdr_task_binding_snapshot_matches() {  # <session> <workspace-id> <tab-id> <pane-id> <task-id> <canonical-worktree>
+  local session=$1 workspace=$2 tab=$3 pane=$4 id=$5 worktree=$6 pane_out tab_out live_cwd live_worktree
+  pane_out=$(fm_backend_herdr_cli "$session" pane get "$pane" 2>/dev/null) || return 1
+  live_cwd=$(printf '%s' "$pane_out" | jq -r --arg pane "$pane" --arg tab "$tab" --arg workspace "$workspace" '
+    select(.result.pane.pane_id == $pane)
+    | select(.result.pane.tab_id == $tab)
+    | select(.result.pane.workspace_id == $workspace)
+    | select((.result.pane.foreground_cwd | type) == "string" and (.result.pane.foreground_cwd | length) > 0)
+    | .result.pane.foreground_cwd
+  ' 2>/dev/null)
+  [ -n "$live_cwd" ] || return 1
+  live_worktree=$(CDPATH='' cd -- "$live_cwd" 2>/dev/null && pwd -P) || return 1
+  [ "$live_worktree" = "$worktree" ] || return 1
+
+  tab_out=$(fm_backend_herdr_cli "$session" tab get "$tab" 2>/dev/null) || return 1
+  printf '%s' "$tab_out" | jq -e --arg tab "$tab" --arg workspace "$workspace" --arg label "fm-$id" '
+    .result.tab.tab_id == $tab
+    and .result.tab.workspace_id == $workspace
+    and .result.tab.label == $label
+  ' >/dev/null 2>&1
+}
+
+# fm_backend_herdr_verify_task_binding: verify that one legacy metadata endpoint
+# still belongs to one exact task before a caller publishes endpoint_task_id.
+# The proof is deliberately read-only. It checks both directions of the live
+# pane/tab/workspace relationships, unique task labeling inside the workspace,
+# canonical worktree identity, and a repeated final snapshot so changed live
+# state is ambiguity rather than repair authority.
+fm_backend_herdr_verify_task_binding() {  # <session> <workspace-id> <tab-id> <pane-id> <task-id> <worktree>
+  local session=$1 workspace=$2 tab=$3 pane=$4 id=$5 worktree=$6 canonical_worktree
+  local workspaces tabs panes
+  canonical_worktree=$(CDPATH='' cd -- "$worktree" 2>/dev/null && pwd -P) || {
+    echo "REFUSED: recorded Herdr worktree for task $id is absent or unreadable; preserving task state." >&2
+    return 1
+  }
+  fm_backend_herdr_task_binding_snapshot_matches \
+    "$session" "$workspace" "$tab" "$pane" "$id" "$canonical_worktree" || {
+      echo "REFUSED: live Herdr pane, task label, or worktree does not exactly match task $id; preserving task state." >&2
+      return 1
+    }
+
+  workspaces=$(fm_backend_herdr_cli "$session" workspace list 2>/dev/null) || workspaces=
+  if ! printf '%s' "$workspaces" | jq -e --arg workspace "$workspace" '
+    (.result.workspaces | type) == "array"
+    and ([.result.workspaces[] | select(.workspace_id == $workspace)] | length) == 1
+  ' >/dev/null 2>&1; then
+    echo "REFUSED: recorded Herdr workspace for task $id is absent or ambiguous; preserving task state." >&2
+    return 1
+  fi
+
+  tabs=$(fm_backend_herdr_cli "$session" tab list --workspace "$workspace" 2>/dev/null) || tabs=
+  if ! printf '%s' "$tabs" | jq -e --arg tab "$tab" --arg label "fm-$id" '
+    (.result.tabs | type) == "array"
+    and ([.result.tabs[] | select(.label == $label)] | length) == 1
+    and ([.result.tabs[] | select(.tab_id == $tab and .label == $label)] | length) == 1
+  ' >/dev/null 2>&1; then
+    echo "REFUSED: Herdr task tab for task $id is absent, duplicated, or relabeled; preserving task state." >&2
+    return 1
+  fi
+
+  panes=$(fm_backend_herdr_cli "$session" pane list --workspace "$workspace" 2>/dev/null) || panes=
+  if ! printf '%s' "$panes" | jq -e --arg pane "$pane" --arg tab "$tab" '
+    (.result.panes | type) == "array"
+    and ([.result.panes[] | select(.pane_id == $pane and .tab_id == $tab)] | length) == 1
+  ' >/dev/null 2>&1; then
+    echo "REFUSED: Herdr pane-to-tab relationship for task $id is absent or ambiguous; preserving task state." >&2
+    return 1
+  fi
+
+  fm_backend_herdr_task_binding_snapshot_matches \
+    "$session" "$workspace" "$tab" "$pane" "$id" "$canonical_worktree" || {
+      echo "REFUSED: live Herdr endpoint for task $id changed during ownership verification; preserving task state." >&2
+      return 1
+    }
+}
+
 # fm_backend_herdr_current_path: the live FOREGROUND process's cwd, or empty on
 # any error. Mirrors tmux's pane_current_path poll used for worktree-path
 # discovery after `treehouse get`.

--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -2309,6 +2309,7 @@ fm_backend_herdr_task_binding_snapshot_matches() {  # <session> <workspace-id> <
 fm_backend_herdr_verify_task_binding() {  # <session> <workspace-id> <tab-id> <pane-id> <task-id> <worktree>
   local session=$1 workspace=$2 tab=$3 pane=$4 id=$5 worktree=$6 canonical_worktree
   local workspaces tabs panes
+  fm_backend_herdr_tool_check || return 1
   canonical_worktree=$(CDPATH='' cd -- "$worktree" 2>/dev/null && pwd -P) || {
     echo "REFUSED: recorded Herdr worktree for task $id is absent or unreadable; preserving task state." >&2
     return 1

--- a/bin/fm-backend.sh
+++ b/bin/fm-backend.sh
@@ -454,6 +454,7 @@ fm_backend_validate_task_endpoint() {  # <meta-file> <task-id>
     herdr)
       [ "$binding" = "$id" ] || {
         echo "REFUSED: legacy Herdr endpoint metadata for task $id lacks an exact task binding; preserving task state." >&2
+        echo "Verify and record ownership with bin/fm-endpoint-rebind.sh $id before retrying cleanup." >&2
         return 1
       }
       recorded_session=$(fm_backend_meta_exact_value "$meta" herdr_session) || recorded_session=

--- a/bin/fm-endpoint-rebind.sh
+++ b/bin/fm-endpoint-rebind.sh
@@ -95,9 +95,8 @@ backend=$(fm_backend_meta_exact_value "$META" backend 2>/dev/null || true)
   exit 1
 }
 
-umask 077
-SNAPSHOT=$(mktemp "$STATE/.$ID.endpoint-rebind-source.XXXXXX") || exit 1
-CANDIDATE=$(mktemp "$STATE/.$ID.endpoint-rebind-candidate.XXXXXX") || exit 1
+SNAPSHOT=$(umask 077; mktemp "$STATE/.$ID.endpoint-rebind-source.XXXXXX") || exit 1
+CANDIDATE=$(umask 077; mktemp "$STATE/.$ID.endpoint-rebind-candidate.XXXXXX") || exit 1
 cp -- "$META" "$SNAPSHOT"
 cmp -s "$SNAPSHOT" "$META" || {
   echo "REFUSED: endpoint metadata for task $ID changed while it was being read; preserving task state." >&2
@@ -122,6 +121,14 @@ WORKTREE=$(fm_backend_meta_exact_value "$CANDIDATE" worktree)
 WORKTREE_REAL=$(CDPATH='' cd -- "$WORKTREE" 2>/dev/null && pwd -P) || {
   echo "REFUSED: recorded Herdr worktree for task $ID is absent or unreadable; preserving task state." >&2
   exit 1
+}
+
+legacy_endpoint_file_mode() {  # <file>
+  if [ "$(uname)" = Darwin ]; then
+    stat -f %Lp "$1" 2>/dev/null
+  else
+    stat -c %a "$1" 2>/dev/null
+  fi
 }
 
 legacy_endpoint_has_competing_claim() {
@@ -172,6 +179,17 @@ if [ ! -f "$META" ] || [ -L "$META" ] || ! cmp -s "$SNAPSHOT" "$META"; then
   exit 1
 fi
 
+META_MODE=$(legacy_endpoint_file_mode "$META") || META_MODE=
+case "$META_MODE" in
+  ''|*[!0-7]*)
+    echo "REFUSED: file mode of endpoint metadata for task $ID could not be read; preserving task state." >&2
+    exit 1
+    ;;
+esac
+chmod "$META_MODE" "$CANDIDATE" || {
+  echo "REFUSED: repaired endpoint metadata for task $ID could not keep the recorded file mode; preserving task state." >&2
+  exit 1
+}
 mv -f -- "$CANDIDATE" "$META"
 CANDIDATE=
 printf 'verified endpoint binding recorded for task %s\n' "$ID"

--- a/bin/fm-endpoint-rebind.sh
+++ b/bin/fm-endpoint-rebind.sh
@@ -123,12 +123,20 @@ WORKTREE_REAL=$(CDPATH='' cd -- "$WORKTREE" 2>/dev/null && pwd -P) || {
   exit 1
 }
 
+# Read one octal file mode from whichever stat flavor this host actually has,
+# probed by trying BSD syntax and accepting only a well-formed octal answer.
+# GNU coreutils can shadow BSD stat (and the reverse), so the installed flavor
+# is not derivable from the OS name.
 legacy_endpoint_file_mode() {  # <file>
-  if [ "$(uname)" = Darwin ]; then
-    stat -f %Lp "$1" 2>/dev/null
-  else
-    stat -c %a "$1" 2>/dev/null
-  fi
+  local mode
+  mode=$(stat -f %Lp "$1" 2>/dev/null) || mode=
+  case "$mode" in
+    ''|*[!0-7]*) mode=$(stat -c %a "$1" 2>/dev/null) || mode= ;;
+  esac
+  case "$mode" in
+    ''|*[!0-7]*) return 1 ;;
+  esac
+  printf '%s\n' "$mode"
 }
 
 legacy_endpoint_has_competing_claim() {

--- a/bin/fm-endpoint-rebind.sh
+++ b/bin/fm-endpoint-rebind.sh
@@ -1,0 +1,177 @@
+#!/usr/bin/env bash
+# Repair one legacy Herdr task record that predates endpoint_task_id.
+#
+# Usage: fm-endpoint-rebind.sh <task-id>
+#
+# This is the only supported re-binding path for an opaque Herdr endpoint.
+# It never infers ownership from a label alone and never relaxes teardown's
+# metadata-only authorization guard. Before atomically adding the binding, it:
+#   - acquires the task's existing spawn lock;
+#   - validates the complete prospective metadata record through teardown's
+#     unchanged endpoint validator;
+#   - refuses another task record that claims the same worktree, tab, or pane;
+#   - verifies the exact live pane/tab/workspace relationships, unique fm-<id>
+#     task label, and canonical foreground cwd equal to the recorded worktree;
+#   - repeats the endpoint snapshot and competing-record scan, then requires the source
+#     metadata bytes to be unchanged before publishing.
+# Existing correct bindings are a validated no-op. Empty, duplicate, mismatched,
+# non-Herdr, missing-live-endpoint, relabeled, moved, or ambiguous records are
+# preserved and refused.
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
+STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
+# shellcheck source=bin/fm-backend.sh
+. "$SCRIPT_DIR/fm-backend.sh"
+# shellcheck source=bin/fm-gate-refuse-lib.sh
+. "$SCRIPT_DIR/fm-gate-refuse-lib.sh"
+# shellcheck source=bin/fm-pr-lib.sh
+. "$SCRIPT_DIR/fm-pr-lib.sh"
+# shellcheck source=bin/fm-wake-lib.sh
+. "$SCRIPT_DIR/fm-wake-lib.sh"
+
+if [ "$#" -ne 1 ] || ! fm_task_id_path_safe "$1"; then
+  echo "error: usage: fm-endpoint-rebind.sh <task-id>" >&2
+  exit 2
+fi
+ID=$1
+fm_refuse_if_gate_agent
+
+META="$STATE/$ID.meta"
+[ -f "$META" ] && [ ! -L "$META" ] || {
+  echo "REFUSED: task $ID has no regular endpoint metadata at $META; preserving task state." >&2
+  exit 1
+}
+
+LOCK="$STATE/.spawn-$ID.lock"
+LOCK_HELD=0
+SNAPSHOT=
+CANDIDATE=
+cleanup() {
+  [ -z "$SNAPSHOT" ] || rm -f -- "$SNAPSHOT"
+  [ -z "$CANDIDATE" ] || rm -f -- "$CANDIDATE"
+  if [ "$LOCK_HELD" -eq 1 ]; then
+    LOCK_HELD=0
+    fm_lock_release "$LOCK" || true
+  fi
+}
+trap cleanup EXIT
+trap 'exit 129' HUP
+trap 'exit 130' INT
+trap 'exit 143' TERM
+if ! fm_lock_try_acquire "$LOCK"; then
+  echo "REFUSED: task $ID is being created or recovered; preserving task state." >&2
+  exit 1
+fi
+LOCK_HELD=1
+
+binding_count=$(grep -c '^endpoint_task_id=' "$META" 2>/dev/null || true)
+case "$binding_count" in
+  0) ;;
+  1)
+    binding=$(fm_backend_meta_exact_value "$META" endpoint_task_id) || {
+      echo "REFUSED: task $ID has an empty endpoint task binding; preserving task state." >&2
+      exit 1
+    }
+    [ "$binding" = "$ID" ] || {
+      echo "REFUSED: endpoint metadata belongs to task $binding, not $ID; preserving task state." >&2
+      exit 1
+    }
+    fm_backend_validate_task_endpoint "$META" "$ID" || exit 1
+    printf 'endpoint binding for task %s is already valid\n' "$ID"
+    exit 0
+    ;;
+  *)
+    echo "REFUSED: task $ID has an ambiguous endpoint task binding; preserving task state." >&2
+    exit 1
+    ;;
+esac
+
+backend=$(fm_backend_meta_exact_value "$META" backend 2>/dev/null || true)
+[ "$backend" = herdr ] || {
+  echo "REFUSED: verified legacy endpoint re-binding currently supports Herdr metadata only; preserving task state." >&2
+  exit 1
+}
+
+umask 077
+SNAPSHOT=$(mktemp "$STATE/.$ID.endpoint-rebind-source.XXXXXX") || exit 1
+CANDIDATE=$(mktemp "$STATE/.$ID.endpoint-rebind-candidate.XXXXXX") || exit 1
+cp -- "$META" "$SNAPSHOT"
+cmp -s "$SNAPSHOT" "$META" || {
+  echo "REFUSED: endpoint metadata for task $ID changed while it was being read; preserving task state." >&2
+  exit 1
+}
+{
+  cat "$SNAPSHOT"
+  if [ -s "$SNAPSHOT" ] \
+    && [ "$(tail -c 1 "$SNAPSHOT" | wc -l | tr -d '[:space:]')" -eq 0 ]; then
+    printf '\n'
+  fi
+  printf 'endpoint_task_id=%s\n' "$ID"
+} > "$CANDIDATE"
+fm_backend_validate_task_endpoint "$CANDIDATE" "$ID" || exit 1
+
+SESSION=$(fm_backend_meta_exact_value "$CANDIDATE" herdr_session)
+WORKSPACE=$(fm_backend_meta_exact_value "$CANDIDATE" herdr_workspace_id)
+TAB=$(fm_backend_meta_exact_value "$CANDIDATE" herdr_tab_id)
+PANE=$(fm_backend_meta_exact_value "$CANDIDATE" herdr_pane_id)
+WINDOW=$(fm_backend_meta_exact_value "$CANDIDATE" window)
+WORKTREE=$(fm_backend_meta_exact_value "$CANDIDATE" worktree)
+WORKTREE_REAL=$(CDPATH='' cd -- "$WORKTREE" 2>/dev/null && pwd -P) || {
+  echo "REFUSED: recorded Herdr worktree for task $ID is absent or unreadable; preserving task state." >&2
+  exit 1
+}
+
+legacy_endpoint_has_competing_claim() {
+  local other other_id other_worktree other_worktree_real
+  for other in "$STATE"/*.meta; do
+    [ -e "$other" ] || [ -L "$other" ] || continue
+    [ "$other" != "$META" ] || continue
+    if [ ! -f "$other" ] || [ -L "$other" ]; then
+      echo "REFUSED: task endpoint ownership cannot be verified while another task record is unsafe; preserving task state." >&2
+      return 0
+    fi
+    other_id=$(basename "$other" .meta)
+    while IFS= read -r other_worktree; do
+      other_worktree=${other_worktree#worktree=}
+      [ -n "$other_worktree" ] || continue
+      if [ "$other_worktree" = "$WORKTREE" ]; then
+        echo "REFUSED: task $other_id also claims the recorded worktree for task $ID; preserving task state." >&2
+        return 0
+      fi
+      other_worktree_real=$(CDPATH='' cd -- "$other_worktree" 2>/dev/null && pwd -P) || continue
+      if [ "$other_worktree_real" = "$WORKTREE_REAL" ]; then
+        echo "REFUSED: task $other_id also claims the recorded worktree for task $ID; preserving task state." >&2
+        return 0
+      fi
+    done < <(grep '^worktree=' "$other" 2>/dev/null || true)
+    grep -Fqx -- 'backend=herdr' "$other" || continue
+    if grep -Fqx -- "window=$WINDOW" "$other" \
+      || grep -Fqx -- "herdr_tab_id=$TAB" "$other" \
+      || grep -Fqx -- "herdr_pane_id=$PANE" "$other"; then
+      echo "REFUSED: task $other_id also claims the recorded Herdr endpoint for task $ID; preserving task state." >&2
+      return 0
+    fi
+  done
+  return 1
+}
+
+if legacy_endpoint_has_competing_claim; then
+  exit 1
+fi
+fm_backend_source herdr || exit 1
+fm_backend_herdr_verify_task_binding \
+  "$SESSION" "$WORKSPACE" "$TAB" "$PANE" "$ID" "$WORKTREE" || exit 1
+if legacy_endpoint_has_competing_claim; then
+  exit 1
+fi
+if [ ! -f "$META" ] || [ -L "$META" ] || ! cmp -s "$SNAPSHOT" "$META"; then
+  echo "REFUSED: endpoint metadata for task $ID changed during ownership verification; preserving task state." >&2
+  exit 1
+fi
+
+mv -f -- "$CANDIDATE" "$META"
+CANDIDATE=
+printf 'verified endpoint binding recorded for task %s\n' "$ID"

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -189,7 +189,7 @@ family_for_basename() {
     fm-herdr-session-cleanup.test.sh|fm-send-strict.test.sh|fm-spawn-batch.test.sh|\
     fm-spawn-dispatch-profile.test.sh|\
     fm-trace-context-spawn.test.sh|fm-spawn-worktree-settle.test.sh|\
-    fm-teardown-endpoint-safety.test.sh)
+    fm-endpoint-rebind.test.sh|fm-teardown-endpoint-safety.test.sh)
       printf '%s\n' backend-dispatch
       ;;
     fm-pr-check-security.test.sh|fm-pr-merge.test.sh|fm-review-diff.test.sh|\
@@ -865,7 +865,7 @@ families_for_changed_path() {
       printf '%s\n' backend-dispatch
       printf '%s\n' orca
       ;;
-    bin/fm-backend.sh|bin/fm-backend-hometag-lib.sh)
+    bin/fm-backend.sh|bin/fm-backend-hometag-lib.sh|bin/fm-endpoint-rebind.sh)
       printf '%s\n' backend-dispatch
       printf '%s\n' real-herdr-gated
       ;;

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -81,6 +81,8 @@ These five sentences are the single owner of the task-selector vocabulary; backe
 `fm-teardown.sh <id>` takes a task id directly and validates the complete metadata-only endpoint identity before any runtime dispatch or cleanup mutation.
 Missing, empty, duplicate, malformed, backend-inconsistent, or task-mismatched endpoint records are preserved and refused.
 Legacy tmux metadata remains cleanup-compatible when its exact window name is `fm-<id>`; opaque non-tmux endpoints require their recorded `endpoint_task_id=` binding.
+For legacy Herdr records that predate that field, `bin/fm-endpoint-rebind.sh <id>` is the supported repair path and writes the binding only after the live pane, tab, workspace, task label, isolated worktree, competing metadata, and unchanged source record all prove one exact owner.
+The repair refuses existing empty, duplicate, or mismatched bindings, non-Herdr records, absent live endpoints, and any ambiguous or changed evidence.
 `FM_HOME` determines Herdr's home label: the primary home uses `firstmate`, and a secondmate home marked by `.fm-secondmate-home` uses `2ndmate-<secondmate-id>`.
 [`herdr-backend.md`](herdr-backend.md#watching-and-task-containers) owns launcher-bound workspace placement, the label-only fallback, collision handling, and recovery behavior.
 The optional local `config/herdr-presentation-spaces` presence flag instead enables Herdr's default-off disposable single-task visual projection; [Optional presentation spaces](herdr-backend.md#optional-presentation-spaces) owns its behavior, safety limits, recovery contract, and narrow locked session-start cleanup of exact restored idle-shell children.

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -93,6 +93,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-pr-merge.sh`         | Record PR metadata, then merge a task's canonical full GitHub URL                    |
 | `fm-promote.sh`          | Promote a scout task in place to a protected ship task with an explicit delivery mode |
 | `fm-teardown.sh`         | Fail-closed teardown: return landed ship worktrees, require completed scout deliverables, retire secondmate homes |
+| `fm-endpoint-rebind.sh`  | Record a verified `endpoint_task_id=` binding for one legacy Herdr task that predates it |
 | `fm-harness.sh`          | Detect the running harness and resolve crew or secondmate harness, model, and effort |
 | `fm-lock.sh`             | Per-home firstmate session lock                                                      |
 | `fm-x-lib.sh`            | Shared X-mode config, relay, and reply-threading helpers                             |

--- a/tests/fm-endpoint-rebind.test.sh
+++ b/tests/fm-endpoint-rebind.test.sh
@@ -5,6 +5,14 @@ set -u
 # shellcheck source=tests/lib.sh
 . "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
 
+file_mode() {  # <path>
+  if [ "$(uname)" = Darwin ]; then
+    stat -f %Lp "$1"
+  else
+    stat -c %a "$1"
+  fi
+}
+
 REBIND="$ROOT/bin/fm-endpoint-rebind.sh"
 TEARDOWN="$ROOT/bin/fm-teardown.sh"
 TMP_ROOT=$(fm_test_tmproot fm-endpoint-rebind)
@@ -27,9 +35,17 @@ case "$cmd $sub" in
       : > "$FM_FAKE_MUTATE_MARKER"
       printf 'note=changed-during-proof\n' >> "$FM_FAKE_MUTATE_META"
     fi
+    cwd=${FM_FAKE_CWD:?}
+    if [ -n "${FM_FAKE_DRIFT_CWD:-}" ]; then
+      if [ -e "${FM_FAKE_DRIFT_MARKER:?}" ]; then
+        cwd=$FM_FAKE_DRIFT_CWD
+      else
+        : > "$FM_FAKE_DRIFT_MARKER"
+      fi
+    fi
     printf '{"result":{"pane":{"pane_id":"%s","tab_id":"%s","workspace_id":"%s","foreground_cwd":"%s"}}}\n' \
       "${FM_FAKE_PANE:-w1:p2}" "${FM_FAKE_PANE_TAB:-w1:t2}" \
-      "${FM_FAKE_PANE_WORKSPACE:-w1}" "${FM_FAKE_CWD:?}"
+      "${FM_FAKE_PANE_WORKSPACE:-w1}" "$cwd"
     ;;
   'tab get')
     printf '{"result":{"tab":{"tab_id":"%s","workspace_id":"%s","label":"%s"}}}\n' \
@@ -82,8 +98,8 @@ run_rebind() {  # <case> [id]
     "$REBIND" "$id"
 }
 
-assert_rebind_refused_unchanged() {  # <case> <description>
-  local dir=$1 description=$2 before rc
+assert_rebind_refused_unchanged() {  # <case> <description> <expected-refusal>
+  local dir=$1 description=$2 expected=$3 before rc
   before="$dir/before.meta"
   cp "$dir/home/state/legacy-task.meta" "$before"
   set +e
@@ -91,6 +107,8 @@ assert_rebind_refused_unchanged() {  # <case> <description>
   rc=$?
   set -e
   [ "$rc" -ne 0 ] || fail "$description: re-binding unexpectedly succeeded"
+  assert_grep "$expected" "$dir/stderr" \
+    "$description: refusal did not report the expected reason"
   cmp -s "$before" "$dir/home/state/legacy-task.meta" \
     || fail "$description: refused repair changed metadata"
   assert_no_grep 'endpoint_task_id=' "$dir/home/state/legacy-task.meta" \
@@ -103,6 +121,7 @@ test_verified_live_identity_is_published() {
   seed_legacy_meta "$dir"
   legacy=$(cat "$dir/home/state/legacy-task.meta")
   printf '%s' "$legacy" > "$dir/home/state/legacy-task.meta"
+  chmod 0644 "$dir/home/state/legacy-task.meta"
   set +e
   FM_HOME="$dir/home" FM_ROOT_OVERRIDE="$ROOT" FM_HERDR_LOG="$dir/herdr.log" \
     PATH="$dir/fakebin:$PATH" "$TEARDOWN" legacy-task --force \
@@ -129,6 +148,8 @@ test_verified_live_identity_is_published() {
     || fail "published metadata does not pass the unchanged teardown validator"
   [ "$(wc -l < "$dir/herdr.log" | tr -d '[:space:]')" -eq 7 ] \
     || fail "successful repair did not perform the bounded live proof"
+  [ "$(file_mode "$dir/home/state/legacy-task.meta")" = 644 ] \
+    || fail "successful repair did not preserve the metadata file mode"
   pass "endpoint re-binding: exact live Herdr identity and worktree proof publishes one teardown-valid binding"
 }
 
@@ -147,20 +168,24 @@ test_wrong_live_evidence_refuses_without_mutation() {
   local dir
   dir=$(make_case wrong-label)
   seed_legacy_meta "$dir"
-  FM_FAKE_LABEL=fm-other-task assert_rebind_refused_unchanged "$dir" "wrong task label"
+  FM_FAKE_LABEL=fm-other-task assert_rebind_refused_unchanged "$dir" "wrong task label" \
+    'live Herdr pane, task label, or worktree does not exactly match task legacy-task'
 
   dir=$(make_case wrong-cwd)
   seed_legacy_meta "$dir"
   mkdir -p "$dir/other-worktree"
-  FM_FAKE_CWD="$dir/other-worktree" assert_rebind_refused_unchanged "$dir" "wrong live worktree"
+  FM_FAKE_CWD="$dir/other-worktree" assert_rebind_refused_unchanged "$dir" "wrong live worktree" \
+    'live Herdr pane, task label, or worktree does not exactly match task legacy-task'
 
   dir=$(make_case wrong-relation)
   seed_legacy_meta "$dir"
-  FM_FAKE_PANE_TAB=w1:t9 assert_rebind_refused_unchanged "$dir" "wrong pane-to-tab relationship"
+  FM_FAKE_PANE_TAB=w1:t9 assert_rebind_refused_unchanged "$dir" "wrong pane-to-tab relationship" \
+    'live Herdr pane, task label, or worktree does not exactly match task legacy-task'
 
   dir=$(make_case duplicate-label)
   seed_legacy_meta "$dir"
-  FM_FAKE_DUPLICATE_LABEL=1 assert_rebind_refused_unchanged "$dir" "duplicate task label"
+  FM_FAKE_DUPLICATE_LABEL=1 assert_rebind_refused_unchanged "$dir" "duplicate task label" \
+    'Herdr task tab for task legacy-task is absent, duplicated, or relabeled'
   pass "endpoint re-binding: relabeled, moved, contradictory, and duplicate live Herdr evidence is preserved and refused"
 }
 
@@ -172,7 +197,8 @@ test_competing_metadata_claim_refuses_before_runtime_read() {
     'window=lab:w1:p2' "worktree=$dir/other" "project=$dir/project" \
     'backend=herdr' 'herdr_session=lab' 'herdr_workspace_id=w1' \
     'herdr_tab_id=w1:t2' 'herdr_pane_id=w1:p2'
-  assert_rebind_refused_unchanged "$dir" "competing task metadata"
+  assert_rebind_refused_unchanged "$dir" "competing task metadata" \
+    'task other-task also claims the recorded Herdr endpoint for task legacy-task'
   [ ! -s "$dir/herdr.log" ] || fail "competing metadata claim reached the runtime"
 
   dir=$(make_case competing-worktree-alias)
@@ -182,7 +208,8 @@ test_competing_metadata_claim_refuses_before_runtime_read() {
     'window=lab:w9:p9' "worktree=$dir/worktree-alias" "project=$dir/project" \
     'backend=herdr' 'herdr_session=lab' 'herdr_workspace_id=w9' \
     'herdr_tab_id=w9:t9' 'herdr_pane_id=w9:p9'
-  assert_rebind_refused_unchanged "$dir" "competing canonical worktree metadata"
+  assert_rebind_refused_unchanged "$dir" "competing canonical worktree metadata" \
+    'task other-task also claims the recorded worktree for task legacy-task'
   [ ! -s "$dir/herdr.log" ] || fail "canonical worktree collision reached the runtime"
   pass "endpoint re-binding: another task's endpoint or canonical worktree claim refuses before any Herdr read"
 }
@@ -197,6 +224,8 @@ test_invalid_legacy_metadata_refuses_before_runtime_read() {
   rc=$?
   set -e
   [ "$rc" -ne 0 ] || fail "empty existing binding unexpectedly repaired"
+  assert_grep 'task legacy-task has an empty endpoint task binding' "$dir/stderr" \
+    "empty existing binding did not report the expected reason"
   [ ! -s "$dir/herdr.log" ] || fail "empty existing binding reached the runtime"
 
   dir=$(make_case malformed-shape)
@@ -204,14 +233,16 @@ test_invalid_legacy_metadata_refuses_before_runtime_read() {
   awk '{ sub(/^window=.*/, "window=lab:w1:p9"); print }' \
     "$dir/home/state/legacy-task.meta" > "$dir/new"
   mv "$dir/new" "$dir/home/state/legacy-task.meta"
-  assert_rebind_refused_unchanged "$dir" "inconsistent Herdr metadata"
+  assert_rebind_refused_unchanged "$dir" "inconsistent Herdr metadata" \
+    'Herdr endpoint metadata for task legacy-task is malformed or inconsistent'
   [ ! -s "$dir/herdr.log" ] || fail "inconsistent Herdr metadata reached the runtime"
 
   dir=$(make_case non-herdr)
   seed_legacy_meta "$dir"
   awk '$0 != "backend=herdr"' "$dir/home/state/legacy-task.meta" > "$dir/new"
   mv "$dir/new" "$dir/home/state/legacy-task.meta"
-  assert_rebind_refused_unchanged "$dir" "non-Herdr metadata"
+  assert_rebind_refused_unchanged "$dir" "non-Herdr metadata" \
+    'verified legacy endpoint re-binding currently supports Herdr metadata only'
   [ ! -s "$dir/herdr.log" ] || fail "non-Herdr metadata reached the runtime"
   pass "endpoint re-binding: malformed bindings, inconsistent shapes, and non-Herdr records refuse before runtime access"
 }
@@ -234,8 +265,21 @@ test_metadata_change_during_proof_is_not_overwritten() {
   pass "endpoint re-binding: source-byte changes during live proof refuse instead of overwriting newer metadata"
 }
 
+test_live_endpoint_change_between_snapshots_refuses() {
+  local dir
+  dir=$(make_case drifted-endpoint)
+  seed_legacy_meta "$dir"
+  mkdir -p "$dir/other-worktree"
+  FM_FAKE_DRIFT_CWD="$dir/other-worktree" FM_FAKE_DRIFT_MARKER="$dir/drifted" \
+    assert_rebind_refused_unchanged "$dir" "live endpoint changed between snapshots" \
+    'live Herdr endpoint for task legacy-task changed during ownership verification'
+  [ -e "$dir/drifted" ] || fail "live endpoint drift case never reached the first live snapshot"
+  pass "endpoint re-binding: live endpoint state that changes between snapshots is ambiguity, not repair authority"
+}
+
 test_verified_live_identity_is_published
 test_existing_valid_binding_is_idempotent
+test_live_endpoint_change_between_snapshots_refuses
 test_wrong_live_evidence_refuses_without_mutation
 test_competing_metadata_claim_refuses_before_runtime_read
 test_invalid_legacy_metadata_refuses_before_runtime_read

--- a/tests/fm-endpoint-rebind.test.sh
+++ b/tests/fm-endpoint-rebind.test.sh
@@ -6,11 +6,68 @@ set -u
 . "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
 
 file_mode() {  # <path>
-  if [ "$(uname)" = Darwin ]; then
-    stat -f %Lp "$1"
-  else
-    stat -c %a "$1"
-  fi
+  local mode
+  mode=$(stat -f %Lp "$1" 2>/dev/null) || mode=
+  case "$mode" in
+    ''|*[!0-7]*) mode=$(stat -c %a "$1" 2>/dev/null) || mode= ;;
+  esac
+  case "$mode" in
+    ''|*[!0-7]*) return 1 ;;
+  esac
+  printf '%s\n' "$mode"
+}
+
+# Install a single-flavor stat (and a contradicting uname) so the repair's mode
+# read is exercised against a host whose stat syntax the OS name would mispick.
+install_stat_flavor() {  # <case> <bsd|gnu|broken>
+  local dir=$1 flavor=$2 fakebin
+  fakebin=$(fm_fakebin "$dir")
+  case "$flavor" in
+    bsd)
+      cat > "$fakebin/uname" <<'SH'
+#!/usr/bin/env bash
+printf 'Linux\n'
+SH
+      cat > "$fakebin/stat" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "${FM_STAT_LOG:?}"
+case "$1 $2" in
+  '-f %Lp') printf '644\n' ;;
+  -c\ *) printf 'stat: illegal option -- c\n' >&2; exit 1 ;;
+  *) exit 2 ;;
+esac
+SH
+      ;;
+    gnu)
+      cat > "$fakebin/uname" <<'SH'
+#!/usr/bin/env bash
+printf 'Darwin\n'
+SH
+      cat > "$fakebin/stat" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "${FM_STAT_LOG:?}"
+case "$1 $2" in
+  '-c %a') printf '644\n' ;;
+  -f\ *)
+    printf '  File: "%s"\nBlocks: Total: 1\n' "$2"
+    exit 1
+    ;;
+  *) exit 2 ;;
+esac
+SH
+      ;;
+    broken)
+      cat > "$fakebin/stat" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "${FM_STAT_LOG:?}"
+printf 'stat: cannot read file mode\n' >&2
+exit 1
+SH
+      ;;
+    *) fail "unknown stat flavor $flavor" ;;
+  esac
+  chmod +x "$fakebin/stat"
+  [ ! -e "$fakebin/uname" ] || chmod +x "$fakebin/uname"
 }
 
 REBIND="$ROOT/bin/fm-endpoint-rebind.sh"
@@ -277,8 +334,38 @@ test_live_endpoint_change_between_snapshots_refuses() {
   pass "endpoint re-binding: live endpoint state that changes between snapshots is ambiguity, not repair authority"
 }
 
+test_metadata_mode_survives_either_stat_flavor() {
+  local dir output flavor
+  for flavor in bsd gnu; do
+    dir=$(make_case "stat-$flavor")
+    seed_legacy_meta "$dir"
+    install_stat_flavor "$dir" "$flavor"
+    chmod 0644 "$dir/home/state/legacy-task.meta"
+    output=$(FM_STAT_LOG="$dir/stat.log" run_rebind "$dir") \
+      || fail "$flavor stat flavor blocked an otherwise verified repair"
+    assert_contains "$output" 'verified endpoint binding recorded for task legacy-task' \
+      "$flavor stat flavor did not publish the verified binding"
+    [ "$(file_mode "$dir/home/state/legacy-task.meta")" = 644 ] \
+      || fail "$flavor stat flavor did not preserve the metadata file mode"
+  done
+  assert_grep '-f %Lp' "$TMP_ROOT/stat-bsd/stat.log" \
+    "BSD-only stat host never received a BSD-syntax mode read"
+  assert_no_grep '-c ' "$TMP_ROOT/stat-bsd/stat.log" \
+    "BSD-only stat host was asked for a GNU-syntax mode"
+  assert_grep '-c %a' "$TMP_ROOT/stat-gnu/stat.log" \
+    "GNU-only stat host never received a GNU-syntax mode read"
+
+  dir=$(make_case stat-unreadable)
+  seed_legacy_meta "$dir"
+  install_stat_flavor "$dir" broken
+  FM_STAT_LOG="$dir/stat.log" assert_rebind_refused_unchanged "$dir" "unreadable metadata file mode" \
+    'file mode of endpoint metadata for task legacy-task could not be read'
+  pass "endpoint re-binding: the published mode follows the installed stat flavor, not the OS name, and an unreadable mode refuses"
+}
+
 test_verified_live_identity_is_published
 test_existing_valid_binding_is_idempotent
+test_metadata_mode_survives_either_stat_flavor
 test_live_endpoint_change_between_snapshots_refuses
 test_wrong_live_evidence_refuses_without_mutation
 test_competing_metadata_claim_refuses_before_runtime_read

--- a/tests/fm-endpoint-rebind.test.sh
+++ b/tests/fm-endpoint-rebind.test.sh
@@ -1,0 +1,242 @@
+#!/usr/bin/env bash
+# Regression tests for verified legacy Herdr endpoint re-binding.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+REBIND="$ROOT/bin/fm-endpoint-rebind.sh"
+TEARDOWN="$ROOT/bin/fm-teardown.sh"
+TMP_ROOT=$(fm_test_tmproot fm-endpoint-rebind)
+
+make_case() {  # <name>
+  local dir="$TMP_ROOT/$1" fakebin
+  mkdir -p "$dir/home/state" "$dir/home/data" "$dir/home/config" "$dir/worktree" "$dir/project"
+  fakebin=$(fm_fakebin "$dir")
+  : > "$dir/herdr.log"
+  cat > "$fakebin/herdr" <<'SH'
+#!/usr/bin/env bash
+set -eu
+printf '<%s>' "$@" >> "${FM_HERDR_LOG:?}"
+printf '\n' >> "${FM_HERDR_LOG:?}"
+cmd=${1:-}
+sub=${2:-}
+case "$cmd $sub" in
+  'pane get')
+    if [ -n "${FM_FAKE_MUTATE_META:-}" ] && [ ! -e "${FM_FAKE_MUTATE_MARKER:?}" ]; then
+      : > "$FM_FAKE_MUTATE_MARKER"
+      printf 'note=changed-during-proof\n' >> "$FM_FAKE_MUTATE_META"
+    fi
+    printf '{"result":{"pane":{"pane_id":"%s","tab_id":"%s","workspace_id":"%s","foreground_cwd":"%s"}}}\n' \
+      "${FM_FAKE_PANE:-w1:p2}" "${FM_FAKE_PANE_TAB:-w1:t2}" \
+      "${FM_FAKE_PANE_WORKSPACE:-w1}" "${FM_FAKE_CWD:?}"
+    ;;
+  'tab get')
+    printf '{"result":{"tab":{"tab_id":"%s","workspace_id":"%s","label":"%s"}}}\n' \
+      "${FM_FAKE_TAB:-w1:t2}" "${FM_FAKE_TAB_WORKSPACE:-w1}" \
+      "${FM_FAKE_LABEL:-fm-legacy-task}"
+    ;;
+  'workspace list')
+    printf '{"result":{"workspaces":[{"workspace_id":"%s"}]}}\n' \
+      "${FM_FAKE_WORKSPACE:-w1}"
+    ;;
+  'tab list')
+    if [ "${FM_FAKE_DUPLICATE_LABEL:-0}" = 1 ]; then
+      printf '{"result":{"tabs":[{"tab_id":"w1:t2","label":"fm-legacy-task"},{"tab_id":"w1:t9","label":"fm-legacy-task"}]}}\n'
+    else
+      printf '{"result":{"tabs":[{"tab_id":"%s","label":"%s"}]}}\n' \
+        "${FM_FAKE_TAB:-w1:t2}" "${FM_FAKE_LABEL:-fm-legacy-task}"
+    fi
+    ;;
+  'pane list')
+    printf '{"result":{"panes":[{"pane_id":"%s","tab_id":"%s"}]}}\n' \
+      "${FM_FAKE_PANE:-w1:p2}" "${FM_FAKE_PANE_TAB:-w1:t2}"
+    ;;
+  *) exit 91 ;;
+esac
+SH
+  chmod +x "$fakebin/herdr"
+  printf '%s\n' "$dir"
+}
+
+seed_legacy_meta() {  # <case> [id]
+  local dir=$1 id=${2:-legacy-task}
+  fm_write_meta "$dir/home/state/$id.meta" \
+    'window=lab:w1:p2' \
+    "worktree=$dir/worktree" \
+    "project=$dir/project" \
+    'harness=claude' \
+    'kind=ship' \
+    'backend=herdr' \
+    'herdr_session=lab' \
+    'herdr_workspace_id=w1' \
+    'herdr_tab_id=w1:t2' \
+    'herdr_pane_id=w1:p2'
+}
+
+run_rebind() {  # <case> [id]
+  local dir=$1 id=${2:-legacy-task}
+  FM_HOME="$dir/home" FM_ROOT_OVERRIDE="$ROOT" \
+    FM_HERDR_LOG="$dir/herdr.log" FM_FAKE_CWD="${FM_FAKE_CWD:-$dir/worktree}" \
+    FM_FAKE_LABEL="${FM_FAKE_LABEL:-fm-$id}" PATH="$dir/fakebin:$PATH" \
+    "$REBIND" "$id"
+}
+
+assert_rebind_refused_unchanged() {  # <case> <description>
+  local dir=$1 description=$2 before rc
+  before="$dir/before.meta"
+  cp "$dir/home/state/legacy-task.meta" "$before"
+  set +e
+  run_rebind "$dir" > "$dir/stdout" 2> "$dir/stderr"
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "$description: re-binding unexpectedly succeeded"
+  cmp -s "$before" "$dir/home/state/legacy-task.meta" \
+    || fail "$description: refused repair changed metadata"
+  assert_no_grep 'endpoint_task_id=' "$dir/home/state/legacy-task.meta" \
+    "$description: refused repair published a binding"
+}
+
+test_verified_live_identity_is_published() {
+  local dir output rc legacy
+  dir=$(make_case success)
+  seed_legacy_meta "$dir"
+  legacy=$(cat "$dir/home/state/legacy-task.meta")
+  printf '%s' "$legacy" > "$dir/home/state/legacy-task.meta"
+  set +e
+  FM_HOME="$dir/home" FM_ROOT_OVERRIDE="$ROOT" FM_HERDR_LOG="$dir/herdr.log" \
+    PATH="$dir/fakebin:$PATH" "$TEARDOWN" legacy-task --force \
+    > "$dir/teardown.out" 2> "$dir/teardown.err"
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "legacy Herdr metadata unexpectedly bypassed teardown's binding guard"
+  assert_grep 'lacks an exact task binding' "$dir/teardown.err" \
+    "legacy Herdr metadata did not reproduce the cleanup refusal"
+  assert_grep 'fm-endpoint-rebind.sh legacy-task' "$dir/teardown.err" \
+    "cleanup refusal did not identify the supported repair path"
+  [ ! -s "$dir/herdr.log" ] || fail "legacy cleanup refusal reached Herdr before repair"
+
+  output=$(run_rebind "$dir") || fail "verified legacy Herdr endpoint did not re-bind"
+  assert_contains "$output" 'verified endpoint binding recorded for task legacy-task' \
+    "successful repair did not report its result"
+  [ "$(grep -c '^endpoint_task_id=' "$dir/home/state/legacy-task.meta")" -eq 1 ] \
+    || fail "successful repair did not publish exactly one endpoint binding"
+  assert_grep 'endpoint_task_id=legacy-task' "$dir/home/state/legacy-task.meta" \
+    "successful repair published the wrong task binding"
+  FM_ROOT_OVERRIDE="$ROOT" bash -c \
+    '. "$1/bin/fm-backend.sh"; fm_backend_validate_task_endpoint "$2" legacy-task' \
+    _ "$ROOT" "$dir/home/state/legacy-task.meta" \
+    || fail "published metadata does not pass the unchanged teardown validator"
+  [ "$(wc -l < "$dir/herdr.log" | tr -d '[:space:]')" -eq 7 ] \
+    || fail "successful repair did not perform the bounded live proof"
+  pass "endpoint re-binding: exact live Herdr identity and worktree proof publishes one teardown-valid binding"
+}
+
+test_existing_valid_binding_is_idempotent() {
+  local dir output
+  dir=$(make_case already-bound)
+  seed_legacy_meta "$dir"
+  printf 'endpoint_task_id=legacy-task\n' >> "$dir/home/state/legacy-task.meta"
+  output=$(run_rebind "$dir") || fail "existing valid binding was not accepted idempotently"
+  assert_contains "$output" 'already valid' "idempotent repair did not report the existing binding"
+  [ ! -s "$dir/herdr.log" ] || fail "idempotent repair queried Herdr unnecessarily"
+  pass "endpoint re-binding: an existing exact binding is a validated read-only no-op"
+}
+
+test_wrong_live_evidence_refuses_without_mutation() {
+  local dir
+  dir=$(make_case wrong-label)
+  seed_legacy_meta "$dir"
+  FM_FAKE_LABEL=fm-other-task assert_rebind_refused_unchanged "$dir" "wrong task label"
+
+  dir=$(make_case wrong-cwd)
+  seed_legacy_meta "$dir"
+  mkdir -p "$dir/other-worktree"
+  FM_FAKE_CWD="$dir/other-worktree" assert_rebind_refused_unchanged "$dir" "wrong live worktree"
+
+  dir=$(make_case wrong-relation)
+  seed_legacy_meta "$dir"
+  FM_FAKE_PANE_TAB=w1:t9 assert_rebind_refused_unchanged "$dir" "wrong pane-to-tab relationship"
+
+  dir=$(make_case duplicate-label)
+  seed_legacy_meta "$dir"
+  FM_FAKE_DUPLICATE_LABEL=1 assert_rebind_refused_unchanged "$dir" "duplicate task label"
+  pass "endpoint re-binding: relabeled, moved, contradictory, and duplicate live Herdr evidence is preserved and refused"
+}
+
+test_competing_metadata_claim_refuses_before_runtime_read() {
+  local dir
+  dir=$(make_case competing)
+  seed_legacy_meta "$dir"
+  fm_write_meta "$dir/home/state/other-task.meta" \
+    'window=lab:w1:p2' "worktree=$dir/other" "project=$dir/project" \
+    'backend=herdr' 'herdr_session=lab' 'herdr_workspace_id=w1' \
+    'herdr_tab_id=w1:t2' 'herdr_pane_id=w1:p2'
+  assert_rebind_refused_unchanged "$dir" "competing task metadata"
+  [ ! -s "$dir/herdr.log" ] || fail "competing metadata claim reached the runtime"
+
+  dir=$(make_case competing-worktree-alias)
+  seed_legacy_meta "$dir"
+  ln -s "$dir/worktree" "$dir/worktree-alias"
+  fm_write_meta "$dir/home/state/other-task.meta" \
+    'window=lab:w9:p9' "worktree=$dir/worktree-alias" "project=$dir/project" \
+    'backend=herdr' 'herdr_session=lab' 'herdr_workspace_id=w9' \
+    'herdr_tab_id=w9:t9' 'herdr_pane_id=w9:p9'
+  assert_rebind_refused_unchanged "$dir" "competing canonical worktree metadata"
+  [ ! -s "$dir/herdr.log" ] || fail "canonical worktree collision reached the runtime"
+  pass "endpoint re-binding: another task's endpoint or canonical worktree claim refuses before any Herdr read"
+}
+
+test_invalid_legacy_metadata_refuses_before_runtime_read() {
+  local dir rc
+  dir=$(make_case malformed)
+  seed_legacy_meta "$dir"
+  printf 'endpoint_task_id=\n' >> "$dir/home/state/legacy-task.meta"
+  set +e
+  run_rebind "$dir" > "$dir/stdout" 2> "$dir/stderr"
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "empty existing binding unexpectedly repaired"
+  [ ! -s "$dir/herdr.log" ] || fail "empty existing binding reached the runtime"
+
+  dir=$(make_case malformed-shape)
+  seed_legacy_meta "$dir"
+  awk '{ sub(/^window=.*/, "window=lab:w1:p9"); print }' \
+    "$dir/home/state/legacy-task.meta" > "$dir/new"
+  mv "$dir/new" "$dir/home/state/legacy-task.meta"
+  assert_rebind_refused_unchanged "$dir" "inconsistent Herdr metadata"
+  [ ! -s "$dir/herdr.log" ] || fail "inconsistent Herdr metadata reached the runtime"
+
+  dir=$(make_case non-herdr)
+  seed_legacy_meta "$dir"
+  awk '$0 != "backend=herdr"' "$dir/home/state/legacy-task.meta" > "$dir/new"
+  mv "$dir/new" "$dir/home/state/legacy-task.meta"
+  assert_rebind_refused_unchanged "$dir" "non-Herdr metadata"
+  [ ! -s "$dir/herdr.log" ] || fail "non-Herdr metadata reached the runtime"
+  pass "endpoint re-binding: malformed bindings, inconsistent shapes, and non-Herdr records refuse before runtime access"
+}
+
+test_metadata_change_during_proof_is_not_overwritten() {
+  local dir rc
+  dir=$(make_case changed-source)
+  seed_legacy_meta "$dir"
+  set +e
+  FM_FAKE_MUTATE_META="$dir/home/state/legacy-task.meta" \
+    FM_FAKE_MUTATE_MARKER="$dir/mutated" run_rebind "$dir" \
+    > "$dir/stdout" 2> "$dir/stderr"
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "metadata changed during proof was overwritten"
+  assert_grep 'note=changed-during-proof' "$dir/home/state/legacy-task.meta" \
+    "concurrent metadata change was not preserved"
+  assert_no_grep 'endpoint_task_id=' "$dir/home/state/legacy-task.meta" \
+    "metadata changed during proof gained a binding"
+  pass "endpoint re-binding: source-byte changes during live proof refuse instead of overwriting newer metadata"
+}
+
+test_verified_live_identity_is_published
+test_existing_valid_binding_is_idempotent
+test_wrong_live_evidence_refuses_without_mutation
+test_competing_metadata_claim_refuses_before_runtime_read
+test_invalid_legacy_metadata_refuses_before_runtime_read
+test_metadata_change_during_proof_is_not_overwritten


### PR DESCRIPTION
## Intent

Add a verified re-binding path so finished tasks whose metadata predates endpoint_task_id can be cleaned up without relaxing the teardown guard. The repair must prove that the recorded Herdr endpoint really belongs to the task before writing endpoint_task_id; it must not simply relax the guard. A bounded per-task migration helper is acceptable only when it verifies ownership evidence for that task. Preserve refusal for empty, duplicate, mismatched, malformed, non-Herdr, missing, changed, or ambiguous evidence. Keep tests colocated, keep bin scripts ShellCheck-clean, and document the supported path.

## What Changed

- Adds `bin/fm-endpoint-rebind.sh`, a per-task repair entrypoint that records `endpoint_task_id=` for one legacy Herdr record only after proving ownership: it holds the task's spawn lock, validates the full prospective record through teardown's unchanged endpoint validator, scans for competing metadata claims on the same worktree/tab/pane, verifies live evidence, re-scans, and requires the source bytes to be unchanged before an atomic mode-preserving publish. Empty, duplicate, mismatched, malformed, non-Herdr, missing, changed, or ambiguous evidence is refused with the record left untouched.
- Adds `fm_backend_herdr_verify_task_binding` and `fm_backend_herdr_task_binding_snapshot_matches` to `bin/backends/herdr.sh`, a read-only live proof over pane/tab/workspace relationships, unique `fm-<id>` tab label, and canonical foreground cwd equal to the recorded worktree, sampled twice so live state that changes mid-proof reads as ambiguity rather than repair authority. The teardown guard in `bin/fm-backend.sh` is unchanged; its refusal now points at the repair helper.
- Registers the new colocated `tests/fm-endpoint-rebind.test.sh` in the `backend-dispatch` family and routes `bin/fm-endpoint-rebind.sh` changes to `backend-dispatch` plus `real-herdr-gated` in `bin/fm-test-run.sh`; documents the supported path in `docs/configuration.md` and the bin toolbelt table in `docs/scripts.md`. Review also probes the installed `stat` flavor rather than dispatching on `uname`, so mode preservation works where GNU coreutils shadows BSD `stat`.

## Risk Assessment

✅ Low: The final commit is a well-bounded, fail-closed portability fix that replaces OS-name stat dispatch with a doubly-validated capability probe and adds a genuine two-direction regression guard, leaving the ownership proof, teardown guard, and every refusal path intact with no remaining substantiated issues.

## Testing

I ran the new colocated suite (tests/fm-endpoint-rebind.test.sh, 8 cases), the existing teardown endpoint-safety suite to confirm the cleanup guard was not relaxed, and the Herdr backend suite (159 cases) since bin/backends/herdr.sh gained the two verification functions — all green — plus the test-runner's changed-path selection and coverage check to confirm the new test is wired into the backend-dispatch family. For product-level proof I drove the real scripts end-to-end from the CLI against a stand-in Herdr runtime: a legacy task record is refused by fm-teardown.sh with the new pointer to the repair, fm-endpoint-rebind.sh performs its read-only twice-sampled ownership proof and publishes exactly one endpoint_task_id while preserving the 0644 file mode, and the retried teardown then completes real cleanup — closing the recorded pane, returning the worktree, and removing the state record. The same transcript walks eleven refusal cases (relabeled, moved, mismatched, duplicate, competing claim, empty/wrong/ambiguous binding, non-Herdr, missing worktree, dead pane), each exiting non-zero with metadata byte-identical and no binding written, and the competing-claim case refusing before any Herdr read. This change is CLI/shell-only with no rendered UI surface, so the reviewer-visible evidence is a terminal transcript rather than a screenshot.

<details>
<summary>Evidence: End-to-end CLI transcript: refusal → verified repair → successful cleanup, plus the full refusal matrix</summary>

```text

=== 1. A finished task whose metadata predates endpoint_task_id ===

$ cat state/legacy-task.meta
window=lab:w1:p2
worktree=/tmp/no-mistakes-evidence/01KZ4YD7VX7S1YAPY1YZKKY6MY/e2e/journey/worktree
project=/tmp/no-mistakes-evidence/01KZ4YD7VX7S1YAPY1YZKKY6MY/e2e/journey/project
harness=claude
kind=ship
backend=herdr
herdr_session=lab
herdr_workspace_id=w1
herdr_tab_id=w1:t2
herdr_pane_id=w1:p2

=== 2. Cleanup refuses today, and now names the supported repair path ===

$ bin/fm-teardown.sh legacy-task --force
exit=1
REFUSED: legacy Herdr endpoint metadata for task legacy-task lacks an exact task binding; preserving task state.
Verify and record ownership with bin/fm-endpoint-rebind.sh legacy-task before retrying cleanup.
herdr calls made before repair: 0

=== 3. Operator runs the documented repair ===

$ bin/fm-endpoint-rebind.sh legacy-task
verified endpoint binding recorded for task legacy-task
exit=0

$ read-only ownership proof it performed against the live Herdr endpoint
pane get w1:p2 --session lab
tab get w1:t2 --session lab
workspace list --session lab
tab list --workspace w1 --session lab
pane list --workspace w1 --session lab
pane get w1:p2 --session lab
tab get w1:t2 --session lab

=== 4. The repaired record ===

$ diff (before -> after)
endpoint_task_id lines: 1
11:endpoint_task_id=legacy-task

$ stat -c %a state/legacy-task.meta   (mode preserved)
644

=== 5. Cleanup's unchanged guard now authorizes this task ===

$ bin/fm-teardown.sh legacy-task --force
exit=0
endpoint authorization guard PASSED - teardown proceeded into task cleanup
/tmp/no-mistakes-evidence/01KZ4YD7VX7S1YAPY1YZKKY6MY/e2e/journey/project: skipped: not a git repo
teardown legacy-task complete (window lab:w1:p2, worktree /tmp/no-mistakes-evidence/01KZ4YD7VX7S1YAPY1YZKKY6MY/e2e/journey/worktree)
Backlog: legacy-task just finished. Run tasks-axi done legacy-task --pr PR_URL, then run tasks-axi ready for dependency-cleared candidates, check date gates, and dispatch only work whose blockers are gone and date is due.

$ what cleanup actually did to the recorded endpoint and worktree
7:pane close w1:p2 --session lab
treehouse return --force /tmp/no-mistakes-evidence/01KZ4YD7VX7S1YAPY1YZKKY6MY/e2e/journey/worktree
state record: removed
worktree: returned

=== 6. Refusal matrix: every ambiguous or mismatched evidence class ===

--- tab no longer carries this task's label
exit=1
REFUSED: live Herdr pane, task label, or worktree does not exactly match task legacy-task; preserving task state.
metadata: unchanged, no binding written

--- live pane cwd is not the recorded worktree
exit=1
REFUSED: live Herdr pane, task label, or worktree does not exactly match task legacy-task; preserving task state.
metadata: unchanged, no binding written

--- live pane belongs to a different tab
exit=1
REFUSED: live Herdr pane, task label, or worktree does not exactly match task legacy-task; preserving task state.
metadata: unchanged, no binding written

--- two live tabs carry the same task label
exit=1
REFUSED: Herdr task tab for task legacy-task is absent, duplicated, or relabeled; preserving task state.
metadata: unchanged, no binding written

--- another task record claims the same endpoint
exit=1
REFUSED: task other-task also claims the recorded Herdr endpoint for task legacy-task; preserving task state.
herdr calls made: 0 (refused before any runtime read)

--- existing empty binding
exit=1
REFUSED: task legacy-task has an empty endpoint task binding; preserving task state.

--- binding that names a different task
exit=1
REFUSED: endpoint metadata belongs to task someone-else, not legacy-task; preserving task state.

--- duplicate binding lines
exit=1
REFUSED: task legacy-task has an ambiguous endpoint task binding; preserving task state.

--- non-Herdr record
exit=1
REFUSED: verified legacy endpoint re-binding currently supports Herdr metadata only; preserving task state.

--- recorded worktree no longer exists
exit=1
REFUSED: recorded Herdr worktree for task legacy-task is absent or unreadable; preserving task state.

--- recorded pane is no longer live in Herdr
exit=1
REFUSED: live Herdr pane, task label, or worktree does not exactly match task legacy-task; preserving task state.
metadata: unchanged, no binding written

--- already-correct binding (idempotent no-op)
exit=0
endpoint binding for task legacy-task is already valid
herdr calls made: 0

=== 7. Documented path ===
84:For legacy Herdr records that predate that field, `bin/fm-endpoint-rebind.sh <id>` is the supported repair path and writes the binding only after the live pane, tab, workspace, task label, isolated worktree, competing metadata, and unchanged source record all prove one exact owner.
```
</details>
<details>
<summary>Evidence: Reproducer script for the end-to-end walkthrough (fake Herdr runtime + treehouse, real fm-teardown.sh / fm-endpoint-rebind.sh)</summary>

```text
#!/usr/bin/env bash
# Manual end-to-end walkthrough of the verified legacy Herdr endpoint re-binding
# path, driven exactly as an operator would drive it from the CLI.
set -u

ROOT=${ROOT:?set ROOT to the firstmate worktree}
EV=${EV:?set EV to the evidence dir}
WORK="$EV/e2e"
rm -rf "$WORK"
mkdir -p "$WORK"
export FM_GATE_REFUSE_BYPASS=1   # same bypass the repo's own suite uses

hdr() { printf '\n\033[1m=== %s ===\033[0m\n' "$*"; }
cmd() { printf '\n$ %s\n' "$*"; }

make_case() {  # <name>
  local dir="$WORK/$1"
  mkdir -p "$dir/home/state" "$dir/home/data" "$dir/home/config" "$dir/worktree" "$dir/project" "$dir/fakebin"
  : > "$dir/herdr.log"
  cat > "$dir/fakebin/herdr" <<'SH'
#!/usr/bin/env bash
# Stand-in for a live Herdr runtime holding one task pane.
set -eu
printf '%s\n' "$*" >> "${FM_HERDR_LOG:?}"
CLOSED="${FM_FAKE_CLOSED_MARKER:-/nonexistent}"
case "${1:-} ${2:-}" in
  'status --json') printf '{"server":{"running":true},"client":{"protocol":99,"version":"fake"}}\n' ;;
  'session list')
    printf '{"sessions":[{"name":"lab","running":true,"socket_path":"%s"}]}\n' "${FM_FAKE_SOCKET:?}" ;;
  'pane get')
    if [ -e "$CLOSED" ]; then
      printf '{"error":{"code":"pane_not_found"}}\n'
    else
      printf '{"result":{"pane":{"pane_id":"%s","tab_id":"%s","workspace_id":"%s","foreground_cwd":"%s"}}}\n' \
        "${FM_FAKE_PANE:-w1:p2}" "${FM_FAKE_PANE_TAB:-w1:t2}" "${FM_FAKE_PANE_WORKSPACE:-w1}" "${FM_FAKE_CWD:?}"
    fi ;;
  'pane close') : > "$CLOSED" ; printf '{"result":{"closed":true}}\n' ;;
  'tab get')
    printf '{"result":{"tab":{"tab_id":"%s","workspace_id":"w1","label":"%s"}}}\n' \
      "${FM_FAKE_TAB:-w1:t2}" "${FM_FAKE_LABEL:?}" ;;
  'workspace list')
    printf '{"result":{"workspaces":[{"workspace_id":"w1","focused":true,"active_tab_id":"w1:t2"}]}}\n' ;;
  'tab list')
    if [ "${FM_FAKE_DUPLICATE_LABEL:-0}" = 1 ]; then
      printf '{"result":{"tabs":[{"tab_id":"w1:t2","label":"%s","focused":true},{"tab_id":"w1:t9","label":"%s"}]}}\n' \
        "$FM_FAKE_LABEL" "$FM_FAKE_LABEL"
    else
      printf '{"result":{"tabs":[{"tab_id":"%s","label":"%s","focused":true}]}}\n' "${FM_FAKE_TAB:-w1:t2}" "$FM_FAKE_LABEL"
    fi ;;
  'pane list')
    printf '{"result":{"panes":[{"pane_id":"%s","tab_id":"%s"}]}}\n' \
      "${FM_FAKE_PANE:-w1:p2}" "${FM_FAKE_PANE_TAB:-w1:t2}" ;;
  *) exit 91 ;;
esac
SH
  chmod +x "$dir/fakebin/herdr"
  cat > "$dir/fakebin/treehouse" <<'SH'
#!/usr/bin/env bash
printf 'treehouse %s\n' "$*" >> "${FM_TREEHOUSE_LOG:?}"
case "${1:-}" in
  return) shift; [ "${1:-}" != --force ] || shift; rm -rf -- "${1:?}" ;;
esac
exit 0
SH
  chmod +x "$dir/fakebin/treehouse"
  : > "$dir/treehouse.log"
  : > "$dir/lab.sock"
  git -C "$dir/worktree" init -q 2>/dev/null
  git -C "$dir/worktree" -c user.name=t -c user.email=t@e.invalid commit -q --allow-empty -m init 2>/dev/null
  # legacy record: predates endpoint_task_id
  cat > "$dir/home/state/legacy-task.meta" <<META
window=lab:w1:p2
worktree=$dir/worktree
project=$dir/project
harness=claude
kind=ship
backend=herdr
herdr_session=lab
herdr_workspace_id=w1
herdr_tab_id=w1:t2
herdr_pane_id=w1:p2
META
  chmod 0644 "$dir/home/state/legacy-task.meta"
  printf '%s\n' "$dir"
}

run_rebind() {  # <dir> [env overrides via caller]
  local dir=$1
  FM_HOME="$dir/home" FM_ROOT_OVERRIDE="$ROOT" FM_HERDR_LOG="$dir/herdr.log" \
    FM_FAKE_CWD="${FM_FAKE_CWD:-$dir/worktree}" FM_FAKE_LABEL="${FM_FAKE_LABEL:-fm-legacy-task}" \
    FM_FAKE_SOCKET="$dir/lab.sock" FM_FAKE_CLOSED_MARKER="$dir/pane-closed" \
    FM_TREEHOUSE_LOG="$dir/treehouse.log" \
    PATH="$dir/fakebin:$PATH" "$ROOT/bin/fm-endpoint-rebind.sh" legacy-task
}

run_teardown() {  # <dir>
  local dir=$1
  FM_HOME="$dir/home" FM_ROOT_OVERRIDE="$ROOT" FM_HERDR_LOG="$dir/herdr.log" \
    FM_STATE_OVERRIDE="$dir/home/state" FM_DATA_OVERRIDE="$dir/home/data" \
    FM_CONFIG_OVERRIDE="$dir/home/config" FM_TEARDOWN_GUARD_DONE=1 \
    FM_FAKE_CWD="$dir/worktree" FM_FAKE_LABEL=fm-legacy-task \
    FM_FAKE_SOCKET="$dir/lab.sock" FM_FAKE_CLOSED_MARKER="$dir/pane-closed" \
    FM_TREEHOUSE_LOG="$dir/treehouse.log" \
    PATH="$dir/fakebin:$PATH" "$ROOT/bin/fm-teardown.sh" legacy-task --force
}

# ---------------------------------------------------------------------------
hdr "1. A finished task whose metadata predates endpoint_task_id"
DIR=$(make_case journey)
cmd "cat state/legacy-task.meta"
cat "$DIR/home/state/legacy-task.meta"

hdr "2. Cleanup refuses today, and now names the supported repair path"
cmd "bin/fm-teardown.sh legacy-task --force"
run_teardown "$DIR" > "$DIR/teardown1.out" 2>&1; echo "exit=$?"
grep -E 'REFUSED|fm-endpoint-rebind' "$DIR/teardown1.out"
printf 'herdr calls made before repair: %s\n' "$(wc -l < "$DIR/herdr.log" | tr -d ' ')"

hdr "3. Operator runs the documented repair"
cmd "bin/fm-endpoint-rebind.sh legacy-task"
run_rebind "$DIR"; echo "exit=$?"
cmd "read-only ownership proof it performed against the live Herdr endpoint"
cat "$DIR/herdr.log"

hdr "4. The repaired record"
cmd "diff (before -> after)"
printf 'endpoint_task_id lines: %s\n' "$(grep -c '^endpoint_task_id=' "$DIR/home/state/legacy-task.meta")"
grep -n 'endpoint_task_id' "$DIR/home/state/legacy-task.meta"
cmd "stat -c %a state/legacy-task.meta   (mode preserved)"
stat -c %a "$DIR/home/state/legacy-task.meta"

hdr "5. Cleanup's unchanged guard now authorizes this task"
: > "$DIR/herdr.log"
cmd "bin/fm-teardown.sh legacy-task --force"
run_teardown "$DIR" > "$DIR/teardown2.out" 2>&1; echo "exit=$?"
if grep -q 'lacks an exact task binding' "$DIR/teardown2.out"; then
  echo "STILL BLOCKED by the endpoint binding guard"
else
  echo "endpoint authorization guard PASSED - teardown proceeded into task cleanup"
fi
sed -n 1,12p "$DIR/teardown2.out"
cmd "what cleanup actually did to the recorded endpoint and worktree"
grep -n 'pane close' "$DIR/herdr.log" || echo '(no pane close)'
cat "$DIR/treehouse.log"
[ -e "$DIR/home/state/legacy-task.meta" ] && echo "state record: still present" || echo "state record: removed"
[ -d "$DIR/worktree" ] && echo "worktree: still present" || echo "worktree: returned"

# ---------------------------------------------------------------------------
hdr "6. Refusal matrix: every ambiguous or mismatched evidence class"
refuse_case() {  # <name> <label> <env...>
  local name=$1 desc=$2; shift 2
  local dir; dir=$(make_case "$name")
  local before="$dir/before"; cp "$dir/home/state/legacy-task.meta" "$before"
  printf '\n--- %s\n' "$desc"
  ( eval "$*" run_rebind "$dir" ) > "$dir/out" 2>&1
  printf 'exit=%s\n' "$?"
  sed -n 1,3p "$dir/out"
  if cmp -s "$before" "$dir/home/state/legacy-task.meta"; then
    printf 'metadata: unchanged, no binding written\n'
  else
    printf 'metadata: CHANGED (unexpected)\n'
  fi
}

refuse_case relabeled  "tab no longer carries this task's label"        FM_FAKE_LABEL=fm-other-task
refuse_case moved      "live pane cwd is not the recorded worktree"     FM_FAKE_CWD="$WORK/elsewhere"
refuse_case mismatched "live pane belongs to a different tab"           FM_FAKE_PANE_TAB=w1:t9
refuse_case duplicate  "two live tabs carry the same task label"        FM_FAKE_DUPLICATE_LABEL=1

DIR=$(make_case competing)
cat > "$DIR/home/state/other-task.meta" <<META
window=lab:w1:p2
worktree=$DIR/other
project=$DIR/project
backend=herdr
herdr_session=lab
herdr_workspace_id=w1
herdr_tab_id=w1:t2
herdr_pane_id=w1:p2
META
printf '\n--- another task record claims the same endpoint\n'
run_rebind "$DIR" > "$DIR/out" 2>&1; printf 'exit=%s\n' "$?"
sed -n 1,3p "$DIR/out"
printf 'herdr calls made: %s (refused before any runtime read)\n' "$(wc -l < "$DIR/herdr.log" | tr -d ' ')"

DIR=$(make_case empty-binding)
printf 'endpoint_task_id=\n' >> "$DIR/home/state/legacy-task.meta"
printf '\n--- existing empty binding\n'
run_rebind "$DIR" > "$DIR/out" 2>&1; printf 'exit=%s\n' "$?"; sed -n 1,3p "$DIR/out"

DIR=$(make_case wrong-owner)
printf 'endpoint_task_id=someone-else\n' >> "$DIR/home/state/legacy-task.meta"
printf '\n--- binding that names a different task\n'
run_rebind "$DIR" > "$DIR/out" 2>&1; printf 'exit=%s\n' "$?"; sed -n 1,3p "$DIR/out"

DIR=$(make_case ambiguous-binding)
printf 'endpoint_task_id=legacy-task\nendpoint_task_id=legacy-task\n' >> "$DIR/home/state/legacy-task.meta"
printf '\n--- duplicate binding lines\n'
run_rebind "$DIR" > "$DIR/out" 2>&1; printf 'exit=%s\n' "$?"; sed -n 1,3p "$DIR/out"

DIR=$(make_case non-herdr)
grep -v '^backend=herdr$' "$DIR/home/state/legacy-task.meta" > "$DIR/tmp" && mv "$DIR/tmp" "$DIR/home/state/legacy-task.meta"
printf '\n--- non-Herdr record\n'
run_rebind "$DIR" > "$DIR/out" 2>&1; printf 'exit=%s\n' "$?"; sed -n 1,3p "$DIR/out"

DIR=$(make_case missing-worktree)
printf '\n--- recorded worktree no longer exists\n'
rm -rf "$DIR/worktree"
run_rebind "$DIR" > "$DIR/out" 2>&1; printf 'exit=%s\n' "$?"; sed -n 1,3p "$DIR/out"

DIR=$(make_case missing-endpoint)
printf '\n--- recorded pane is no longer live in Herdr\n'
: > "$DIR/pane-closed"
run_rebind "$DIR" > "$DIR/out" 2>&1; printf 'exit=%s\n' "$?"; sed -n 1,3p "$DIR/out"
grep -q 'endpoint_task_id' "$DIR/home/state/legacy-task.meta" && echo 'metadata: CHANGED (unexpected)' || echo 'metadata: unchanged, no binding written'

DIR=$(make_case already-bound)
printf 'endpoint_task_id=legacy-task\n' >> "$DIR/home/state/legacy-task.meta"
printf '\n--- already-correct binding (idempotent no-op)\n'
run_rebind "$DIR" > "$DIR/out" 2>&1; printf 'exit=%s\n' "$?"; sed -n 1,3p "$DIR/out"
printf 'herdr calls made: %s\n' "$(wc -l < "$DIR/herdr.log" | tr -d ' ')"

hdr "7. Documented path"
grep -n 'fm-endpoint-rebind' "$ROOT/docs/configuration.md"
```
</details>
<details>
<summary>Evidence: Core operator journey (excerpt)</summary>

```text
$ bin/fm-teardown.sh legacy-task --force
REFUSED: legacy Herdr endpoint metadata for task legacy-task lacks an exact task binding; preserving task state.
Verify and record ownership with bin/fm-endpoint-rebind.sh legacy-task before retrying cleanup.
herdr calls made before repair: 0

$ bin/fm-endpoint-rebind.sh legacy-task
verified endpoint binding recorded for task legacy-task
read-only ownership proof performed against the live Herdr endpoint:
pane get w1:p2 --session lab
tab get w1:t2 --session lab
workspace list --session lab
tab list --workspace w1 --session lab
pane list --workspace w1 --session lab
pane get w1:p2 --session lab (repeat snapshot)
tab get w1:t2 --session lab (repeat snapshot)
endpoint_task_id lines: 1 -> endpoint_task_id=legacy-task
stat -c %a state/legacy-task.meta -> 644 (mode preserved)

$ bin/fm-teardown.sh legacy-task --force
teardown legacy-task complete (window lab:w1:p2, worktree .../journey/worktree)
pane close w1:p2 --session lab
treehouse return --force .../journey/worktree
state record: removed
worktree: returned
```
</details>
<details>
<summary>Evidence: Refusal matrix (excerpt)</summary>

```text
--- tab no longer carries this task's label
REFUSED: live Herdr pane, task label, or worktree does not exactly match task legacy-task; preserving task state.
metadata: unchanged, no binding written

--- two live tabs carry the same task label
REFUSED: Herdr task tab for task legacy-task is absent, duplicated, or relabeled; preserving task state.
metadata: unchanged, no binding written

--- another task record claims the same endpoint
REFUSED: task other-task also claims the recorded Herdr endpoint for task legacy-task; preserving task state.
herdr calls made: 0 (refused before any runtime read)

--- existing empty binding
REFUSED: task legacy-task has an empty endpoint task binding; preserving task state.

--- binding that names a different task
REFUSED: endpoint metadata belongs to task someone-else, not legacy-task; preserving task state.

--- duplicate binding lines
REFUSED: task legacy-task has an ambiguous endpoint task binding; preserving task state.

--- non-Herdr record
REFUSED: verified legacy endpoint re-binding currently supports Herdr metadata only; preserving task state.

--- recorded pane is no longer live in Herdr
REFUSED: live Herdr pane, task label, or worktree does not exactly match task legacy-task; preserving task state.

--- already-correct binding (idempotent no-op)
endpoint binding for task legacy-task is already valid (herdr calls made: 0)
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 3 issues found → auto-fixed (2) ✅</summary>

- ⚠️ `bin/fm-endpoint-rebind.sh:164` - The verification path never confirms that `herdr` and `jq` are installed, so missing tooling is reported as contradicted ownership evidence. `fm_backend_source herdr` only sources the adapter; `fm_backend_herdr_tool_check` is never called. In `fm_backend_herdr_task_binding_snapshot_matches` (bin/backends/herdr.sh:2283, 2296) both the CLI call and every jq pipeline are wrapped in `2&gt;/dev/null`, so a `command not found` is swallowed. Failure scenario: an operator on a host without `jq` (or without `herdr` on PATH) runs `bin/fm-endpoint-rebind.sh &lt;id&gt;` against a perfectly repairable legacy record; `pane_out`/`live_cwd` come back empty, and the script prints &#34;REFUSED: live Herdr pane, task label, or worktree does not exactly match task &lt;id&gt;; preserving task state.&#34; That message asserts the evidence contradicts the record when in fact nothing was ever read, sending the operator to investigate a non-existent endpoint drift. This is fail-closed (safe), but it is the one message this operator-facing repair entrypoint exists to get right. Fix: call `fm_backend_herdr_tool_check || exit 1` immediately after `fm_backend_source herdr` at line 164.
- ℹ️ `bin/fm-endpoint-rebind.sh:98` - `umask 077` is set process-wide rather than scoped to the `mktemp` calls, so the mode of the repaired metadata file silently changes. `CANDIDATE` is created 0600 and then `mv -f`&#39;d over `$META` at line 175, which replaces the inode and its permissions. Failure scenario: with the usual 022 umask, `state/&lt;id&gt;.meta` is 0644 before the repair (fm-spawn.sh:496-517 writes its tmp file under the ambient umask) and 0600 after, leaving the repaired record with different permissions from every sibling meta in the same directory. Every other umask-hardened write in this repo scopes it to a subshell precisely to avoid this leak (bin/fm-procevent-lib.sh:226, bin/fm-backlog-handoff.sh:295, bin/fm-secondmate-nudge-lib.sh:36). Fix: use `SNAPSHOT=$(umask 077; mktemp ...)` / `CANDIDATE=$(umask 077; mktemp ...)` and drop the process-wide `umask 077`, or `chmod --reference` the candidate from `$META` before the `mv`.
- ℹ️ `tests/fm-endpoint-rebind.test.sh:85` - The repeated final live snapshot — the check that makes changed live state ambiguity rather than repair authority (bin/backends/herdr.sh:2352-2356) — has no behavioral test; only the `-eq 7` herdr invocation count at line 130 proves it is called at all. The fake herdr already has a first-call-only mutation hook (`FM_FAKE_MUTATE_MARKER`), but it is used solely to mutate the metadata file, never the pane/tab response. Failure scenario: a regression that keeps the second `fm_backend_herdr_task_binding_snapshot_matches` call but discards its result (for example changing it to `|| true`) leaves all six tests green — the invocation count is still 7 and no case drives live state that changes between the two snapshots. Relatedly, `assert_rebind_refused_unchanged` captures stderr to `$dir/stderr` but never asserts on it, so each refusal case only proves that *some* refusal fired, not the intended one. Fix: have the fake vary its `pane get`/`tab get` response on the second call (e.g. a `FM_FAKE_DRIFT_ON_SECOND` marker) and assert the &#39;changed during ownership verification&#39; message, and add a refusal-message argument to `assert_rebind_refused_unchanged`.

🔧 Fix: harden endpoint re-bind tool check, file mode, and drift test
1 warning still open:
- ⚠️ `bin/fm-endpoint-rebind.sh:127` - The new mode-preservation step gates publication on a `uname`-dispatched `stat`, which hard-refuses the repair on macOS hosts where GNU coreutils shadows BSD `stat` — the exact host class tracked by open repo issue #1601 (&#34;BSD/GNU stat flavor: fleet helpers break on hosts where GNU coreutils shadows BSD stat&#34;). Failure scenario: on macOS with Homebrew coreutils `gnubin` ahead of `/usr/bin` on PATH, `legacy_endpoint_file_mode` takes the Darwin branch and runs `stat -f %Lp &#34;$META&#34;`; GNU `stat` reads `-f` as `--file-system` and treats `%Lp` as a file operand, so it exits non-zero, `META_MODE` is emptied by the `|| META_MODE=` at line 182, and the case at line 184 aborts with &#34;REFUSED: file mode of endpoint metadata for task &lt;id&gt; could not be read; preserving task state.&#34; A fully verified, otherwise-repairable legacy record is then unrepairable on that host, and the message points at metadata rather than at the real cause. This is a regression relative to commit 4459521, which published with a plain `mv` and had no stat dependency. The same dispatch is duplicated in the test helper at tests/fm-endpoint-rebind.test.sh:9 (there without `2&gt;/dev/null`), so the new 0644 assertion at tests/fm-endpoint-rebind.test.sh:151 also fails on that host. Mitigating context: the behavior is fail-closed, never mis-writes the mode, and the `uname` dispatch matches the dominant existing pattern (bin/fm-config-inherit-lib.sh:95-97, bin/fm-x-lib.sh:108-110, bin/fm-lock-lib.sh:27-29), so this is reasonably deferrable to #1601. Fix: use the flavor-probing pattern already in this repo at bin/fm-test-isolation-proof.sh:206-213 — `if stat -f %Lp &#34;$1&#34; &gt;/dev/null 2&gt;&amp;1; then stat -f %Lp &#34;$1&#34;; else stat -c %a &#34;$1&#34;; fi` — in both the script helper and the test helper, which detects the actual stat flavor instead of the OS.

🔧 Fix: probe stat flavor for endpoint re-bind mode preservation
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash tests/fm-endpoint-rebind.test.sh` — 8 colocated cases: verified publish, idempotent no-op, BSD/GNU/broken stat flavors, mid-proof endpoint drift, wrong label/cwd/tab/duplicate label, competing metadata claim, malformed &amp; non-Herdr records, source-bytes-changed-during-proof</code>
- <code>`bash tests/fm-teardown-endpoint-safety.test.sh` — confirms the teardown authorization guard itself is unchanged (not relaxed)</code>
- <code>`bash tests/fm-backend-herdr.test.sh` — 159 cases green after the two new functions were added to bin/backends/herdr.sh</code>
- <code>`bash bin/fm-test-run.sh --list --changed --base 3d9d12d` — new test is selected by the changed-path family mapping</code>
- <code>`bash bin/fm-test-run.sh --check-coverage` — FM_TEST_COVERAGE ok total=117 herdr=11 (new test registered)</code>
- <code>Manual end-to-end CLI walkthrough via `/tmp/no-mistakes-evidence/01KZ4YD7VX7S1YAPY1YZKKY6MY/rebind-e2e.sh`: legacy record → `bin/fm-teardown.sh legacy-task --force` refusal + repair pointer → `bin/fm-endpoint-rebind.sh legacy-task` verified publish (0644 mode preserved, exactly one binding line) → `bin/fm-teardown.sh legacy-task --force` completing real cleanup (pane close, treehouse return, state record removed)</code>
- `Manual refusal matrix in the same walkthrough: relabeled tab, live cwd not the recorded worktree, pane in a different tab, duplicate task label, competing task record (zero Herdr reads), empty binding, binding naming another task, duplicate binding lines, non-Herdr record, missing worktree, dead pane, already-correct binding`

</details>

<details>
<summary>⚠️ **Document** - 1 info</summary>

- ℹ️ `docs/verification/runtime-backends.md:141` - docs/verification/runtime-backends.md has no dated evidence for the new live ownership proof. The change routes bin/fm-endpoint-rebind.sh into the real-herdr-gated family, and fm_backend_herdr_verify_task_binding&#39;s verdict comes from live Herdr pane/tab/workspace/label/foreground-cwd responses, but the only colocated test drives a stubbed herdr CLI. Refreshing that maintainer-verification record requires an actual real-Herdr run with exact commands, version, and output, which this documentation phase cannot perform and must not fabricate. Recommend a follow-up that runs the real-Herdr lane and records the dated result in the &#39;Cleanup endpoint identity&#39; or Herdr section.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
