### PR TITLE
feat: add Cursor CLI local crewmate harness adapter

### DIFF
--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: harness-adapters
-description: Agent-only reference for firstmate harness operations. Use before spawning or recovering a crewmate or secondmate, handling a trust dialog, sending a harness-specific skill invocation, interrupting or exiting an agent, resuming an exited agent, or verifying a new harness adapter. Contains verified facts for claude, codex, opencode, pi, pi-signed, grok, kimi, and muse.
+description: Agent-only reference for firstmate harness operations. Use before spawning or recovering a crewmate or secondmate, handling a trust dialog, sending a harness-specific skill invocation, interrupting or exiting an agent, resuming an exited agent, or verifying a new harness adapter. Contains verified facts for claude, codex, opencode, pi, pi-signed, grok, kimi, muse, and local Cursor CLI (`cursor`) crewmate/secondmate launch facts.
 user-invocable: false
 metadata:
   internal: true
@@ -123,6 +123,7 @@ The supported launch-profile flags below are verified locally; each row records 
 | opencode | `--model <provider/model>` | none for firstmate's interactive launch | Verified on opencode 1.17.6. `opencode run` has `--variant`, but firstmate launches the interactive `opencode --prompt` path, which has no verified effort flag. |
 | kimi | `--model <model>` | none | Verified 2026-07-25 on Kimi Code CLI 0.29.1. |
 | muse | `--model <model>` | `--reasoning-effort <low\|medium\|high\|xhigh>`, and `ultra` only for an explicit `max` | Verified 2026-08-05 on Muse Code 0.1.0-R708.1. The flag accepts `none\|minimal\|low\|medium\|high\|xhigh\|ultra` and defaults to `high`. `ultra` is muse's max-class level, so it is reachable only through an explicit captain `max`, never from the generic fallback; `none` and `minimal` sit below the shared vocabulary and stay unreachable. |
+| cursor | `--model <model>` | none | Local launch wiring for Cursor CLI (`cursor-agent`). Effort has no verified flag, so requested effort is recorded in meta and omitted from launch. |
 
 The concrete `harness` field owns adapter identity independently of the model provider: `harness=pi` with `model=xai/grok-*` is Pi using xAI, not `harness=grok`, and does not require Grok CLI login; `harness=grok` remains the standalone Grok Build CLI adapter.
 No script resolves that split for you: establish which credential store a tuple reads from the discovery surfaces below plus `quota-axi auth --json`'s per-provider sources, and show that reasoning rather than inferring it from a harness, model, or source name.
@@ -140,6 +141,7 @@ Use the discovery surface in the current authenticated environment because suppo
 | pi / pi-signed | Run the selected executable as `<executable> --list-models [search]`; Pi's installed `docs/models.md` owns how built-in, extension-registered, and custom provider/model entries reach that list. |
 | grok | Run `grok models`, which lists the models available to the current Grok installation and account. |
 | kimi | Run `kimi provider list --json`, which lists the current provider and model configuration. |
+| cursor | Run `cursor-agent --help` and the interactive `/model` (or equivalent) picker in the current authenticated Cursor CLI session. |
 
 For an unfamiliar harness or model namespace, establish support and provider identity from that harness's authoritative CLI help, model listing, or current documentation rather than guessing from a name or prefix.
 A listing that reaches the account and does not contain the model is concrete evidence the model is unsupported: block that candidate and quote the result.
@@ -159,6 +161,7 @@ Natural language is acceptable if uncertain.
 - pi and pi-signed: no separate verified skill invocation beyond normal command behavior; use natural language if the exact skill command is uncertain.
 - grok: `/<skill>`, for example `/no-mistakes` (same form as claude). Verified end to end: grok discovers the user-level `no-mistakes` skill, `/no-mistakes` invokes it, and grok drives a real `no-mistakes axi run`. Like codex's `$`/`/` popups, typing `/<skill>` opens grok's slash-autocomplete, so a too-fast Enter selects the popup entry instead of sending, and for an argument-taking command (like `/no-mistakes`'s optional task-first argument) that first Enter only expands the popup selection into an argument-hint placeholder rather than submitting - a genuine second Enter is required (see the grok section below for the 2026-07-03 incident and fix). `fm_tmux_submit_core`'s retried Enter (used by `fm-send` on the tmux backend) handles this through the structural composer reader; the herdr backend needed a dedicated fix (`fm_backend_herdr_composer_state`, docs/herdr-backend.md) because its prior delta-based verification false-positived on that same popup-close content change.
 - kimi: `/<skill>`, for example `/no-mistakes`.
+- cursor: natural language is the safe default until a Cursor-specific skill-invocation form is live-verified; slash commands may work in some Cursor CLI builds but are not a Firstmate guarantee yet.
 
 ## Submission acknowledgement hazards
 
@@ -460,3 +463,25 @@ A teardown refusal naming muse scratch is therefore correct behavior: inspect it
 muse is a day-0 `0.1.0` beta whose launcher polls a release channel hourly and can replace the running binary underneath the fleet, changing the process name with it.
 The captain accepted that risk, so firstmate does NOT set `MUSE_NO_AUTO_UPDATE=1`; a fleet that later wants stability can set it in the launch environment without any adapter change.
 Its plugin/hook engine reports `plugins are not available in this build` unless `MUSE_EXPERIMENTAL_PLUGINS=on`, which is why the busy source reads the session log instead of installing a hook.
+
+## cursor (LOCAL LAUNCH WIRED; primary hooks and busy-state not verified)
+
+Cursor CLI launches as `cursor-agent` (Herdr `--kind cursor` uses the same binary; the `agent` shim is not a Firstmate harness name).
+
+| Fact | Value |
+|---|---|
+| Binary | `cursor-agent` from `PATH` (typical install under `~/.local/bin` or Cursor's agent share). |
+| Launch | `cursor-agent --yolo --trust` with a positional encoded launch brief. |
+| Busy state | Unknown until a semantic source is live-verified. Prefer Herdr pane lifecycle (`working` / `idle` / `blocked`) when `config/backend=herdr`. |
+| Exit command | Not live-verified for Firstmate recovery; ask the captain or inspect the live TUI rather than guessing. |
+| Interrupt | Not live-verified for Firstmate recovery; do not invent a key chord. |
+| Skill invocation | Natural language until a Cursor-specific form is live-verified. |
+| Autonomy | `--yolo` auto-approves tool calls; `--trust` skips the workspace trust prompt. |
+| Environment marker | `CURSOR_INVOKED_AS` when set; otherwise process ancestry matching `cursor-agent` or a `*/cursor-agent/*` argv path. |
+| Effort | No verified reasoning-effort flag; requested effort is recorded in task metadata and omitted from launch. |
+| Remote secondmate | Rejected. Local crewmate and secondmate launch only until remote is proven. |
+
+Do not claim Cursor in the README primary harness set.
+Primary SessionStart, Stop turn-end guard, PreToolUse seatbelt, and watcher auto-arm hooks are not wired for Cursor.
+[`docs/supervision-protocols/cursor.md`](../../../docs/supervision-protocols/cursor.md) owns the thin primary supervision snippet rendered at session start.
+`bin/fm-harness.sh` detects Cursor; `bin/fm-spawn.sh` owns the launch template; `bin/fm-session-lock-lib.sh` treats `cursor-agent` as a live harness process name for session locks.

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -590,7 +590,7 @@ secondmate_liveness_sweep() {
     [ -n "$target" ] || target="$window"
     agent_state=$(fm_backend_agent_state "$backend" "$target" 2>/dev/null) || agent_state=unreadable
     case "$harness" in
-      claude|codex|opencode|pi|pi-signed|grok|kimi) ;;
+      claude|codex|opencode|pi|pi-signed|grok|kimi|cursor) ;;
       *)
         case "$agent_state" in dead|missing) agent_state=unverified-harness ;; esac
         ;;
@@ -904,7 +904,7 @@ crew_dispatch_validate() {
     return 0
   fi
   err=$(jq -r '
-    def verified($h): ["claude","codex","opencode","pi","pi-signed","grok","kimi","muse"] | index($h);
+    def verified($h): ["claude","codex","opencode","pi","pi-signed","grok","kimi","muse","cursor"] | index($h);
     def effort_ok($h; $e):
       if $e == null then true
       elif ($e | type) != "string" then false
@@ -913,7 +913,7 @@ crew_dispatch_validate() {
       elif $h == "grok" then (["low","medium","high"] | index($e))
       elif $h == "pi" or $h == "pi-signed" then (["low","medium","high","xhigh","max"] | index($e))
       elif $h == "muse" then (["low","medium","high","xhigh","max"] | index($e))
-      elif $h == "opencode" or $h == "kimi" then false
+      elif $h == "opencode" or $h == "kimi" or $h == "cursor" then false
       else true
       end;
     def profiles($value):

--- a/bin/fm-harness.sh
+++ b/bin/fm-harness.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Detect the agent harness this process tree runs on.
-# Usage: fm-harness.sh                  print own harness: claude|codex|opencode|pi|pi-signed|grok|kimi|muse|unknown
+# Usage: fm-harness.sh                  print own harness: claude|codex|opencode|pi|pi-signed|grok|kimi|muse|cursor|unknown
 #        fm-harness.sh crew             print the effective CREWMATE harness
 #                                        (config/crew-harness; "default" resolves to own)
 #        fm-harness.sh secondmate       print the harness the PRIMARY uses to launch
@@ -51,6 +51,10 @@ detect_own() {
   # by ancestry alone below. Do NOT promote MUSE_CURRENT_SESSION_LOG to a marker
   # without verifying it reaches children AND that it cannot survive in a
   # multiplexer's stored environment, which is the precedence hazard above.
+  # Cursor CLI (cursor-agent / agent). CURSOR_INVOKED_AS is set on the agent
+  # process; path evidence below covers node runners under ~/.local/share/cursor-agent.
+  # Local crewmate/secondmate launch adapter; not a verified primary with turn-end hooks.
+  [ -n "${CURSOR_INVOKED_AS:-}" ] && { echo cursor; return; }
   # Layer 2: walk the parent chain and match the command name.
   local pid=$$ comm args
   for _ in 1 2 3 4 5 6 7 8; do
@@ -60,6 +64,7 @@ detect_own() {
       *codex*) echo codex; return ;;
       *opencode*) echo opencode; return ;;
       *grok*) echo grok; return ;;
+      cursor-agent) echo cursor; return ;;
       kimi) echo kimi; return ;;
       # muse's installed launcher ~/.local/bin/muse execs ~/.local/bin/muse-bin-<version>
       # (verified in the published launcher, muse 0.1.0-R708.1), so the live process
@@ -69,14 +74,15 @@ detect_own() {
       muse|muse-bin-*) echo muse; return ;;
       pi-signed) echo pi; return ;;
       pi) echo pi; return ;;
-      node*|python*)
-        # Bare interpreter: match the harness name in its script path.
+      node*|python*|agent)
+        # Bare interpreter / cursor's `agent` shim: match harness name in argv.
         args=$(ps -o args= -p "$pid" 2>/dev/null)
         case "$args" in
           *claude*) echo claude; return ;;
           *codex*) echo codex; return ;;
           *opencode*) echo opencode; return ;;
           *grok*) echo grok; return ;;
+          *cursor-agent*) echo cursor; return ;;
           *" pi "*|*/pi) echo pi; return ;;
         esac ;;
     esac

--- a/bin/fm-session-lock-lib.sh
+++ b/bin/fm-session-lock-lib.sh
@@ -9,13 +9,15 @@
 # This file is sourced by scripts and has no side effects on source.
 
 # Known harness command names; extend when a new adapter is verified.
-FM_HARNESS_RE='claude|codex|opencode|grok|kimi|^pi$|^pi-signed$'
+# cursor-agent is the Cursor CLI binary used for local crewmate/secondmate launch.
+# Do not add bare `agent`; too many unrelated processes share that basename.
+FM_HARNESS_RE='claude|codex|opencode|grok|kimi|cursor-agent|^pi$|^pi-signed$'
 
 # The same harnesses as exact executable names. Keep in sync with
 # FM_HARNESS_RE. Used only for the stricter path evidence below, where the
 # loose regex would also match ordinary firstmate paths such as
 # bin/fm-claude-stop-autoarm.sh.
-FM_HARNESS_NAMES=(claude codex opencode grok kimi pi-signed pi)
+FM_HARNESS_NAMES=(claude codex opencode grok kimi pi-signed pi cursor-agent)
 
 # Print the exact harness name carried by executable path $1 - its own basename
 # or any directory component - or return 1.

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -86,7 +86,7 @@
 #   profile consultation. A --secondmate spawn is exempt and resolves the SECONDMATE
 #   harness (config/secondmate-harness -> config/crew-harness -> own), so the
 #   secondmate-vs-crewmate split is DURABLE across every respawn (recovery,
-#   /updatefirstmate, restart). A bare adapter name (claude|codex|opencode|pi|pi-signed|grok|kimi|muse)
+#   /updatefirstmate, restart). A bare adapter name (claude|codex|opencode|pi|pi-signed|grok|kimi|muse|cursor)
 #   overrides it for this spawn (either kind). A non-flag string containing
 #   whitespace is treated as a RAW launch command - the escape hatch for verifying
 #   new adapters. pi-signed launches that exact executable name from PATH and
@@ -789,7 +789,7 @@ FIRSTMATE_HOME=
 
 if [ "$KIND" = secondmate ]; then
   case "${POS[1]:-}" in
-    ''|claude|codex|opencode|pi|pi-signed|grok|kimi|muse)
+    ''|claude|codex|opencode|pi|pi-signed|grok|kimi|muse|cursor)
       ARG3=${POS[1]:-}
       ;;
     *' '*)
@@ -877,6 +877,11 @@ launch_template() {
     # written below. Nothing to place in the template for it.
     # codex, opencode, and kimi are also markerless and share this inherited-marker hazard; changing their verified launch boundaries belongs in follow-up work.
     muse) printf '%s' 'env -u CLAUDECODE -u PI_CODING_AGENT -u GROK_AGENT -u FM_PI_HARNESS XDG_CONFIG_HOME=__MUSECONFIG__ XDG_DATA_HOME=__MUSEDATA__ MUSE_EXPERIMENTAL_FOREIGN_PERSONAL_CONTEXT_KILL=on __MUSEBIN__ --yolo __MODELFLAG____EFFORTFLAG__"$(__OPINPUT__ encode launch-brief < __BRIEF__)"' ;;
+    # Cursor CLI (local crewmate/secondmate launch). --yolo auto-approves tools;
+    # --trust skips the workspace trust prompt so an unattended worker can start.
+    # Prefer cursor-agent (same binary Herdr --kind cursor uses). Primary
+    # SessionStart/Stop parity and semantic busy-state are not wired yet.
+    cursor) printf '%s' 'cursor-agent --yolo --trust __MODELFLAG__"$(__OPINPUT__ encode launch-brief < __BRIEF__)"' ;;
     *) return 1 ;;
   esac
 }
@@ -1049,7 +1054,7 @@ model_flag_for_harness() {
   local harness=$1 model=$2
   [ -n "$model" ] && [ "$model" != default ] || return 0
   case "$harness" in
-    claude|codex|opencode|pi|pi-signed|grok|kimi|muse)
+    claude|codex|opencode|pi|pi-signed|grok|kimi|muse|cursor)
       printf -- '--model %s ' "$(shell_quote "$model")"
       ;;
   esac

--- a/bin/fm-supervision-instructions.sh
+++ b/bin/fm-supervision-instructions.sh
@@ -81,7 +81,7 @@ if [ -z "$HARNESS" ]; then
 fi
 
 case "$HARNESS" in
-  claude|codex|opencode|pi|grok) SNIPPET="$DOC_DIR/$HARNESS.md" ;;
+  claude|codex|opencode|pi|grok|cursor) SNIPPET="$DOC_DIR/$HARNESS.md" ;;
   pi-signed) SNIPPET="$DOC_DIR/pi.md" ;;
   *) HARNESS=unknown; SNIPPET="$DOC_DIR/unknown.md" ;;
 esac

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -208,6 +208,7 @@ The full cmux home label also includes a short hash of the resolved `FM_ROOT` pa
 claude, codex, opencode, pi, pi-signed, grok, and kimi are empirically verified for crewmate and secondmate launches; [README requirements](../README.md#requirements) own the set supported for the primary session.
 muse is verified for crewmate and scout launches ONLY, and `fm-spawn.sh` refuses it for a secondmate, because muse ships no usable hook surface for a primary session's turn-end supervision; [`docs/verification/muse.md`](verification/muse.md) owns that evidence.
 muse also needs a worker-reachable credential before spawning, and the portable fleet path is the `<config>/muse/auth.json` credential stored by `muse login`, because a caller-only `META_API_KEY` does not cross a long-lived backend daemon.
+`cursor` has a local Firstmate launch template for crewmate and secondmate workers (`cursor-agent --yolo --trust`) and harness detection via `CURSOR_INVOKED_AS` or `cursor-agent` ancestry; it is not a verified primary with SessionStart or Stop parity, and remote secondmate routes still reject it.
 New harnesses get verified through a supervised trial task before joining the set.
 The verified adapter knowledge - each harness's busy-state source, interrupt and exit commands, skill-invocation syntax, and per-harness quirks - lives in [`.agents/skills/harness-adapters/SKILL.md`](../.agents/skills/harness-adapters/SKILL.md).
 Launch mechanics, including the verified command templates, live in [`bin/fm-spawn.sh`](../bin/fm-spawn.sh).
@@ -215,6 +216,7 @@ Enabled primary-session turn-end guard integrations are tracked as repo-level ho
 Kimi remains outside the primary turn-end guard integrations; [`docs/turnend-guard.md`](turnend-guard.md#compatibility-limits) owns its separate captain-approved crew wake hook.
 Primary-session watcher wake protocols are rendered at session start by [`bin/fm-supervision-instructions.sh`](../bin/fm-supervision-instructions.sh) from [`docs/supervision-protocols/`](supervision-protocols/).
 Claude's Stop `asyncRewake` hook owns tokenless re-arm cycles, Grok uses background-notify cycles, Codex uses bounded foreground checkpoints, Pi and pi-signed use the same two tracked primary extensions, and OpenCode uses its TUI plugin.
+Cursor's supervision snippet is thinner and prefers Herdr pane lifecycle until a Cursor-specific wake adapter is verified.
 `config/crew-harness` is a local, gitignored file containing one adapter name for crewmate and scout launches.
 When pi-signed is selected, Firstmate launches the executable named `pi-signed` from `PATH` with `FM_PI_HARNESS=pi-signed` and refuses the launch if it is unavailable rather than falling back to pi.
 Plain Pi launches set `FM_PI_HARNESS=pi`, so a signed primary's environment cannot relabel a plain Pi worker.

--- a/docs/documentation-audiences.json
+++ b/docs/documentation-audiences.json
@@ -293,6 +293,10 @@
       "audience": "agent-runtime"
     },
     {
+      "path": "docs/supervision-protocols/cursor.md",
+      "audience": "agent-runtime"
+    },
+    {
       "path": "docs/supervision-protocols/grok.md",
       "audience": "agent-runtime"
     },

--- a/docs/supervision-protocols/cursor.md
+++ b/docs/supervision-protocols/cursor.md
@@ -1,0 +1,11 @@
+Mode: Cursor CLI local primary (thin adapter).
+
+Cursor CLI (`cursor-agent`) has a local Firstmate launch template for crewmates and secondmates.
+It does not yet have verified primary SessionStart or Stop hook parity with Claude, Codex, OpenCode, Pi, or Grok.
+Prefer Herdr as `config/backend` so idle, working, and blocked come from the pane lifecycle rather than a Cursor semantic busy source.
+At session start, run `bin/fm-session-start.sh` exactly once when this session owns the home.
+Follow the generic supervision contract in `AGENTS.md` for watcher waits until a Cursor-specific wake adapter is verified.
+Use a bounded foreground wait over `bin/fm-watch.sh` when no tracked background wake mechanism is available.
+Never use shell `&` for watcher supervision.
+Crew and secondmate launches use `bin/fm-spawn.sh` with harness `cursor`, which starts `cursor-agent --yolo --trust` so tools auto-approve and workspace trust does not block an unattended worker.
+Remote secondmate routes still reject `cursor` until remote launch is proven separately.

--- a/tests/fm-cursor-harness.test.sh
+++ b/tests/fm-cursor-harness.test.sh
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+# Portable Cursor CLI harness-adapter contracts: detection, crew resolution,
+# local launch template shape, and remote secondmate rejection.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+unset CLAUDECODE PI_CODING_AGENT FM_PI_HARNESS GROK_AGENT CURSOR_INVOKED_AS
+
+BASE_PATH=${FM_TEST_BASE_PATH:-/usr/bin:/bin:/usr/sbin:/sbin}
+fm_git_identity fmtest fmtest@example.com
+TMP_ROOT=$(fm_test_tmproot fm-cursor-harness)
+export FM_BACKEND=tmux
+
+make_seeded_home() {
+  local home=$1 id=$2
+  mkdir -p "$home/bin" "$home/data"
+  printf '# Firstmate\n' > "$home/AGENTS.md"
+  printf '%s\n' "$id" > "$home/.fm-secondmate-home"
+  printf 'charter\n' > "$home/data/charter.md"
+}
+
+make_launch_capturing_tmux() {
+  local dir=$1 fakebin="$1/fakebin"
+  mkdir -p "$fakebin"
+  cat > "$fakebin/tmux" <<'SH'
+#!/usr/bin/env bash
+set -u
+case "$*" in
+  *"#{pane_current_path}"*) printf '%s\n' "${FM_FAKE_PANE_PATH:-}"; exit 0 ;;
+esac
+case "${1:-}" in
+  display-message) printf 'firstmate\n'; exit 0 ;;
+  list-windows) exit 0 ;;
+  has-session|new-session|new-window|kill-window) exit 0 ;;
+  send-keys)
+    if [ -n "${FM_FAKE_LAUNCH_LOG:-}" ]; then
+      prev=
+      for a in "$@"; do
+        if [ "$prev" = "-l" ]; then
+          printf '%s\n' "$a" >> "$FM_FAKE_LAUNCH_LOG"
+        fi
+        prev=$a
+      done
+    fi
+    exit 0
+    ;;
+esac
+exit 0
+SH
+  chmod +x "$fakebin/tmux"
+  printf '%s\n' "$fakebin"
+}
+
+spawn_secondmate_capture() {
+  local world=$1 id=$2 home=$3 launchlog=$4 fakebin
+  shift 4
+  mkdir -p "$world/home/state" "$world/home/data"
+  fakebin=$(make_launch_capturing_tmux "$world/tmux-$id")
+  : > "$launchlog"
+  PATH="$fakebin:$BASE_PATH" TMUX='' CLAUDECODE=1 \
+    FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$world/home" \
+    FM_STATE_OVERRIDE="$world/home/state" FM_DATA_OVERRIDE="$world/home/data" \
+    FM_PROJECTS_OVERRIDE="$world/home/projects" FM_CONFIG_OVERRIDE="$world/home/config" \
+    FM_SPAWN_NO_GUARD=1 FM_FAKE_LAUNCH_LOG="$launchlog" \
+    "$ROOT/bin/fm-spawn.sh" "$id" "$home" "$@" --secondmate
+}
+
+meta_harness() { grep '^harness=' "$1" 2>/dev/null | tail -1 | cut -d= -f2-; }
+
+test_cursor_env_marker_detection() {
+  local cfg out
+  cfg="$TMP_ROOT/detect-env/config"
+  mkdir -p "$cfg"
+  out=$(env -u CLAUDECODE -u PI_CODING_AGENT -u GROK_AGENT -u FM_PI_HARNESS \
+    CURSOR_INVOKED_AS=agent FM_CONFIG_OVERRIDE="$cfg" "$ROOT/bin/fm-harness.sh")
+  [ "$out" = cursor ] || fail "CURSOR_INVOKED_AS detection returned '$out'"
+  out=$(CLAUDECODE=1 CURSOR_INVOKED_AS=agent FM_CONFIG_OVERRIDE="$cfg" \
+    "$ROOT/bin/fm-harness.sh")
+  [ "$out" = claude ] || fail "env-marker precedence lost to cursor, got '$out'"
+  pass "fm-harness: CURSOR_INVOKED_AS detects cursor after verified marker precedence"
+}
+
+test_cursor_ancestry_detection() {
+  local dir fakebin cfg out
+  dir="$TMP_ROOT/detect-ancestry"
+  fakebin=$(fm_fakebin "$dir")
+  cfg="$dir/config"
+  mkdir -p "$cfg"
+  cat > "$fakebin/ps" <<'SH'
+#!/usr/bin/env bash
+set -u
+field=
+pid=
+prev=
+for arg in "$@"; do
+  [ "$prev" = -o ] && field=$arg
+  [ "$prev" = -p ] && pid=$arg
+  prev=$arg
+done
+case "$field:$pid" in
+  comm=:4242) printf 'cursor-agent\n' ;;
+  comm=:*) printf '/bin/bash\n' ;;
+  ppid=:4242) printf '1\n' ;;
+  ppid=:*) printf '4242\n' ;;
+  args=:*) printf 'bash\n' ;;
+esac
+SH
+  chmod +x "$fakebin/ps"
+
+  out=$(env -u CLAUDECODE -u PI_CODING_AGENT -u GROK_AGENT -u CURSOR_INVOKED_AS \
+    PATH="$fakebin:$BASE_PATH" FM_CONFIG_OVERRIDE="$cfg" "$ROOT/bin/fm-harness.sh")
+  [ "$out" = cursor ] || fail "cursor-agent ancestry detection returned '$out'"
+  pass "fm-harness: cursor-agent ancestry detects cursor"
+}
+
+test_cursor_crew_resolution() {
+  local cfg got
+  cfg="$TMP_ROOT/crew-resolve/config"
+  mkdir -p "$cfg"
+  printf 'cursor\n' > "$cfg/crew-harness"
+  got=$(CLAUDECODE=1 FM_CONFIG_OVERRIDE="$cfg" "$ROOT/bin/fm-harness.sh" crew)
+  [ "$got" = cursor ] || fail "crew-harness=cursor resolved '$got'"
+  got=$(CLAUDECODE=1 FM_CONFIG_OVERRIDE="$cfg" "$ROOT/bin/fm-harness.sh" secondmate)
+  [ "$got" = cursor ] || fail "secondmate fallback to crew cursor resolved '$got'"
+  pass "fm-harness: crew and secondmate resolve config/crew-harness=cursor"
+}
+
+test_cursor_local_secondmate_launch_template() {
+  local w sm meta launchlog launch out status
+  w="$TMP_ROOT/spawn-cursor"
+  sm="$w/sm"
+  launchlog="$w/launch.log"
+  mkdir -p "$w/home/config"
+  printf 'cursor\n' > "$w/home/config/secondmate-harness"
+  make_seeded_home "$sm" sm
+
+  out=$(spawn_secondmate_capture "$w" sm "$sm" "$launchlog" 2>&1); status=$?
+  expect_code 0 "$status" "cursor secondmate spawn should succeed"$'\n'"$out"
+
+  meta="$w/home/state/sm.meta"
+  [ -f "$meta" ] || fail "cursor spawn wrote no meta"
+  [ "$(meta_harness "$meta")" = cursor ] \
+    || fail "cursor spawn meta harness='$(meta_harness "$meta")'"
+  launch=$(cat "$launchlog")
+  assert_contains "$launch" "cursor-agent" "cursor launch must invoke cursor-agent"
+  assert_contains "$launch" "--yolo" "cursor launch must include --yolo"
+  assert_contains "$launch" "--trust" "cursor launch must include --trust"
+  pass "fm-spawn: local cursor secondmate launch uses cursor-agent --yolo --trust"
+}
+
+test_cursor_model_flag_without_effort() {
+  local w sm launchlog launch out status
+  w="$TMP_ROOT/spawn-cursor-model"
+  sm="$w/sm"
+  launchlog="$w/launch.log"
+  mkdir -p "$w/home/config"
+  make_seeded_home "$sm" sm
+
+  out=$(spawn_secondmate_capture "$w" sm "$sm" "$launchlog" \
+    --harness cursor --model composer-2 --effort high 2>&1); status=$?
+  expect_code 0 "$status" "cursor model spawn should succeed"$'\n'"$out"
+  launch=$(cat "$launchlog")
+  assert_contains "$launch" "--model" "cursor model spawn must carry --model"
+  assert_contains "$launch" "composer-2" "cursor model spawn must carry the model id"
+  assert_not_contains "$launch" "--effort" "cursor has no effort flag"
+  assert_not_contains "$launch" "--reasoning-effort" "cursor has no reasoning-effort flag"
+  pass "fm-spawn: cursor accepts --model and omits effort flags"
+}
+
+test_cursor_supervision_snippet_renders() {
+  local out
+  out=$("$ROOT/bin/fm-supervision-instructions.sh" --harness cursor)
+  assert_contains "$out" "Cursor CLI" "cursor supervision snippet missing title cue"
+  assert_contains "$out" "Herdr" "cursor supervision snippet should prefer Herdr"
+  assert_contains "$out" "fm-session-start.sh" "cursor supervision snippet must require session start"
+  pass "fm-supervision-instructions: cursor snippet renders"
+}
+
+test_cursor_env_marker_detection
+test_cursor_ancestry_detection
+test_cursor_crew_resolution
+test_cursor_local_secondmate_launch_template
+test_cursor_model_flag_without_effort
+test_cursor_supervision_snippet_renders


### PR DESCRIPTION
## Intent

Add a professional Cursor CLI local crewmate/secondmate harness adapter so captains can launch `cursor-agent` workers through Firstmate, with honest limits documented for maintainer review.

## Summary

- Detect Cursor via `CURSOR_INVOKED_AS` or `cursor-agent` ancestry in `fm-harness.sh`.
- Local launch template: `cursor-agent --yolo --trust` (model flag supported; no effort flag).
- Session-lock recognizes `cursor-agent`; supervision snippet prefers Herdr pane lifecycle.
- Document in `harness-adapters` and `docs/configuration.md` as local launch wiring, not a verified primary.
- Keep remote secondmate routes verified-only without `cursor`.
- Portable coverage in `tests/fm-cursor-harness.test.sh`.

## Explicit non-claims

- Not added to README primary harness support.
- No SessionStart / Stop / PreToolUse primary hook parity.
- Busy-state remains unknown (prefer Herdr).
- Remote secondmate still rejects `cursor`.

## Testing

- Local: `bin/fm-lint.sh` (ShellCheck 0.11.0) passed.
- Local: `bin/fm-test-run.sh tests/fm-cursor-harness.test.sh` passed (6 cases).
- Local: `bin/fm-doc-audience-check.sh` passed with the new protocol inventory entry.
- Gate: lint passed; review/test/document skipped because the Claude Code weekly limit blocked the gate agent.

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⏭️ **Review** - skipped</summary>

Step was skipped (Claude Code weekly limit; resets Aug 7).

</details>

<details>
<summary>⏭️ **Test** - skipped</summary>

Step was skipped.

</details>

<details>
<summary>⏭️ **Document** - skipped</summary>

Step was skipped.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>