### PR TITLE
fix: reject AFK mode without a Codex callback pane

### DIFF
--- a/.agents/skills/afk/SKILL.md
+++ b/.agents/skills/afk/SKILL.md
@@ -48,6 +48,7 @@ batched digest rather than per-wake injections.
    It exits immediately if the identity-backed daemon lock already names a live process, otherwise it execs `bin/fm-supervise-daemon.sh` in the foreground.
    The daemon is **presence-gated**: it injects escalations only while
    `state/.afk` exists, and stays quiet otherwise.
+   An external Codex thread without an inherited tmux or Herdr pane cannot enter away mode, because it has no safe asynchronous callback; follow the Codex protocol's [no-pane boundary](../../../docs/supervision-protocols/codex.md) and keep foreground checkpoints running instead.
 
 3. **Do not separately arm `fm-watch.sh`.** The daemon manages the watcher as
    its child; the singleton lock no-ops a stray arm harmlessly.

--- a/bin/fm-afk-launch.sh
+++ b/bin/fm-afk-launch.sh
@@ -26,9 +26,12 @@
 #                              record it. Idempotent: an already-running daemon
 #                              just refreshes state/.afk; a recorded-but-dead
 #                              terminal is reconciled (closed by id) first.
+#                              Refuses before any lifecycle write when an external
+#                              Codex thread has no verified tmux or Herdr pane.
 #   fm-afk-launch.sh start-native
 #                              Prepare lifecycle state for a harness-native
 #                              background job and record that no terminal exists.
+#                              It has the same external-Codex no-pane refusal.
 #   fm-afk-launch.sh stop      Correct-ordered exit: SIGTERM the daemon so its
 #                              cleanup flushes WHILE state/.afk is still present,
 #                              wait for it, close the recorded terminal by exact

--- a/bin/fm-afk-launch.sh
+++ b/bin/fm-afk-launch.sh
@@ -89,6 +89,14 @@ set +e
 
 fm_afk_launch_log() { printf 'fm-afk-launch: %s\n' "$*" >&2; }
 
+fm_afk_launch_refuse_external_codex_without_pane() {
+  fm_supervisor_external_codex_without_pane || return 1
+  fm_afk_launch_log "away mode is unavailable from an external Codex thread without a primary tmux or Herdr pane"
+  fm_afk_launch_log "Codex provides no safe asynchronous callback to this thread; do not set FM_SUPERVISOR_TARGET to a worker pane"
+  fm_afk_launch_log "keep foreground checkpoints running while present, or restart the primary inside tmux or Herdr before leaving work unattended"
+  return 0
+}
+
 fm_afk_launch_lock_owned() {
   local pid expected actual
   [ -d "$FM_AFK_LAUNCH_LOCK" ] || return 1
@@ -462,6 +470,7 @@ fm_afk_launch_create_tmux() {  # <captain-target> <captain-backend>
 
 fm_afk_launch_start() {
   local captain_target captain_backend backup artifact had_afk=0 result
+  fm_afk_launch_refuse_external_codex_without_pane && return 1
   if [ -e "$FM_AFK_LAUNCH_STATE/.afk-return-catchup" ]; then
     fm_afk_launch_log "return catch-up is still pending; run bin/fm-afk-return.sh check before re-entering away mode"
     return 1
@@ -531,6 +540,7 @@ fm_afk_launch_start() {
 
 fm_afk_launch_start_native() {
   local backup artifact had_afk=0 result=0
+  fm_afk_launch_refuse_external_codex_without_pane && return 1
   mkdir -p "$FM_AFK_LAUNCH_STATE" || return 1
   if [ -e "$FM_AFK_LAUNCH_STATE/.afk-return-catchup" ]; then
     fm_afk_launch_log "return catch-up is still pending; run bin/fm-afk-return.sh check before re-entering away mode"

--- a/bin/fm-afk-start.sh
+++ b/bin/fm-afk-start.sh
@@ -41,6 +41,8 @@ FM_AFK_DAEMON="$FM_AFK_START_DIR/fm-supervise-daemon.sh"
 
 # shellcheck source=bin/fm-wake-lib.sh
 . "$FM_AFK_START_DIR/fm-wake-lib.sh"
+# shellcheck source=bin/fm-supervisor-target-lib.sh
+. "$FM_AFK_START_DIR/fm-supervisor-target-lib.sh"
 
 fm_afk_start_usage() {
   sed -n '2,14p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
@@ -116,6 +118,12 @@ fm_afk_start_main() {
     -h|--help) fm_afk_start_usage; return 0 ;;
     * ) echo "usage: $(basename "${BASH_SOURCE[1]:-fm-afk-start.sh}")" >&2; return 2 ;;
   esac
+
+  if fm_supervisor_external_codex_without_pane; then
+    echo "afk: away mode is unavailable from an external Codex thread without a primary tmux or Herdr pane" >&2
+    echo "afk: Codex provides no safe asynchronous callback to this thread" >&2
+    return 1
+  fi
 
   mkdir -p "$FM_AFK_STATE"
   if [ "${FM_AFK_STATE_PREPARED:-0}" = 1 ]; then

--- a/bin/fm-afk-start.sh
+++ b/bin/fm-afk-start.sh
@@ -3,7 +3,9 @@
 # foreground process when one is not already alive.
 #
 # Usage: fm-afk-start.sh
-#   Sets state/.afk unless FM_AFK_STATE_PREPARED=1, checks
+#   Refuses an external Codex thread without a verified tmux or Herdr pane
+#   before it writes state/.afk. Otherwise sets state/.afk unless
+#   FM_AFK_STATE_PREPARED=1, checks
 #   state/.supervise-daemon.lock, and:
 #     - prints "afk: daemon already running pid=<pid>" then exits 0 when that
 #       lock is held by a live daemon (a REFRESH: no stale-artifact clear);

--- a/bin/fm-supervisor-target-lib.sh
+++ b/bin/fm-supervisor-target-lib.sh
@@ -21,6 +21,25 @@
 FM_SUPERVISOR_TARGET_DEFAULT="firstmate:0"
 FM_SUPERVISOR_BACKEND_DEFAULT="tmux"
 
+# fm_supervisor_primary_pane_available: return success only when this process
+# itself carries a verified captain-pane marker. An explicit target does not
+# count here: an external Codex thread has no safe way to prove that a manually
+# supplied tmux or herdr target is its own primary rather than a worker pane.
+fm_supervisor_primary_pane_available() {
+  [ -n "${TMUX_PANE:-}" ] && return 0
+  [ "${HERDR_ENV:-}" = "1" ] && [ -n "${HERDR_PANE_ID:-}" ] && return 0
+  return 1
+}
+
+# fm_supervisor_external_codex_without_pane: Codex Desktop marks the active
+# external thread with CODEX_THREAD_ID but provides neither a primary-terminal
+# marker nor an asynchronous callback into that thread. AFK must refuse this
+# surface instead of accepting a guessed worker pane as its delivery target.
+fm_supervisor_external_codex_without_pane() {
+  [ -n "${CODEX_THREAD_ID:-}" ] || return 1
+  ! fm_supervisor_primary_pane_available
+}
+
 # discover_supervisor_target: resolve the pane running firstmate. Priority:
 #   1. FM_SUPERVISOR_TARGET env (explicit override) - may be a tmux target or a
 #      herdr "<session>:<pane-id>" target (paired with discover_supervisor_backend

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -100,6 +100,7 @@ Test cleanup must use the guarded path in [`docs/cmux-backend.md`](cmux-backend.
 The `/afk` sub-supervisor injects escalation digests into firstmate's own pane independently of where new task endpoints are spawned.
 It currently supports only `tmux` and `herdr` supervisor panes.
 Set `FM_SUPERVISOR_BACKEND=tmux|herdr` and `FM_SUPERVISOR_TARGET=<target>` to override both axes explicitly; for herdr the target is `"<session>:<pane-id>"`.
+Those overrides cannot establish a verified primary for an external Codex thread without an inherited tmux or Herdr pane, so away-mode entry refuses rather than targeting a possible worker pane; [`supervision-protocols/codex.md`](supervision-protocols/codex.md) owns that operating boundary.
 Without overrides, backend detection uses `$TMUX_PANE` first, then `HERDR_ENV=1` with `HERDR_PANE_ID`, then falls back to `tmux`.
 That keeps a tmux pane nested inside herdr on the tmux transport, matching the runtime backend's innermost-first rule.
 Target detection uses `FM_SUPERVISOR_TARGET`, then `$TMUX_PANE`, then `"${HERDR_SESSION:-default}:${HERDR_PANE_ID}"` under herdr, then the legacy `firstmate:0` tmux fallback with a warning.

--- a/docs/supervision-protocols/codex.md
+++ b/docs/supervision-protocols/codex.md
@@ -13,3 +13,8 @@ When this session owns supervision and away mode is not active:
 
 Codex cannot reason while a foreground tool call is running.
 The bounded checkpoint returns control regularly so user messages and queued wakes can be handled without relying on background-task wake semantics.
+
+Away mode needs a verified primary tmux or Herdr pane where the daemon can deliver its return and escalation messages.
+An external Codex thread identified by `CODEX_THREAD_ID` without either pane has no safe asynchronous callback, so `bin/fm-afk-launch.sh` refuses before it writes away state.
+Do not supply `FM_SUPERVISOR_TARGET` for a worker pane.
+Keep foreground checkpoints running while present, or restart the primary in tmux or Herdr before leaving work unattended.

--- a/docs/verification/supervision.md
+++ b/docs/verification/supervision.md
@@ -244,17 +244,18 @@ tests/fm-turnend-guard.test.sh
 ### External Codex no-pane AFK boundary
 
 The external-Codex AFK boundary was verified on 2026-08-04 with the installed tmux and Herdr transports.
-`tests/fm-afk-launch.test.sh` reconstructs the bounded no-pane Codex checkpoint, retains an actionable wake, rejects both normal and native daemon entry before away state exists, and refuses an explicit worker-looking target.
-The same test keeps the established tmux and Herdr detached-daemon lifetime and exact cleanup coverage, while `tests/fm-afk-return.test.sh` covers return catch-up cleanup.
+`tests/fm-afk-launch.test.sh` reconstructs the bounded no-pane Codex checkpoint, retains an actionable wake, rejects both launcher paths before away state exists, and refuses an explicit worker-looking target.
+`tests/fm-daemon.test.sh` also invokes the common `bin/fm-afk-start.sh` entry directly and confirms that it refuses before it writes away state.
+The focused coverage retains the established tmux and Herdr detached-daemon lifetime and exact cleanup assertions.
 
 ```sh
-bin/fm-test-run.sh tests/fm-afk-launch.test.sh tests/fm-watch-checkpoint.test.sh tests/fm-afk-return.test.sh tests/fm-supervision-instructions.test.sh
+bin/fm-test-run.sh tests/fm-daemon.test.sh tests/fm-afk-launch.test.sh
 ```
 
 Observed output:
 
 ```text
-FM_TEST_SUMMARY total=4 failed=0 skipped_gate=0 duration_ms=13718
+FM_TEST_SUMMARY total=2 failed=0 skipped_gate=0 duration_ms=22837
 ```
 
 The supported external-Codex result is an early refusal with no away flag, daemon record, or daemon lock because the surface has no safe asynchronous callback into its active thread.

--- a/docs/verification/supervision.md
+++ b/docs/verification/supervision.md
@@ -241,6 +241,25 @@ tests/fm-claude-stop-autoarm.test.sh
 tests/fm-turnend-guard.test.sh
 ```
 
+### External Codex no-pane AFK boundary
+
+The external-Codex AFK boundary was verified on 2026-08-04 with the installed tmux and Herdr transports.
+`tests/fm-afk-launch.test.sh` reconstructs the bounded no-pane Codex checkpoint, retains an actionable wake, rejects both normal and native daemon entry before away state exists, and refuses an explicit worker-looking target.
+The same test keeps the established tmux and Herdr detached-daemon lifetime and exact cleanup coverage, while `tests/fm-afk-return.test.sh` covers return catch-up cleanup.
+
+```sh
+bin/fm-test-run.sh tests/fm-afk-launch.test.sh tests/fm-watch-checkpoint.test.sh tests/fm-afk-return.test.sh tests/fm-supervision-instructions.test.sh
+```
+
+Observed output:
+
+```text
+FM_TEST_SUMMARY total=4 failed=0 skipped_gate=0 duration_ms=13718
+```
+
+The supported external-Codex result is an early refusal with no away flag, daemon record, or daemon lock because the surface has no safe asynchronous callback into its active thread.
+The current operator mechanism and supported route are owned by [`supervision-protocols/codex.md`](../supervision-protocols/codex.md).
+
 ## Wedge-alarm channels
 
 The two real notification channels were bounded manually on 2026-07-10 on macOS 26.5.2 with Herdr 0.7.3.

--- a/tests/fm-afk-launch.test.sh
+++ b/tests/fm-afk-launch.test.sh
@@ -22,6 +22,9 @@ set -u
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 LAUNCH="$ROOT/bin/fm-afk-launch.sh"
 START="$ROOT/bin/fm-afk-start.sh"
+CHECKPOINT="$ROOT/bin/fm-watch-checkpoint.sh"
+WATCH="$ROOT/bin/fm-watch.sh"
+DRAIN="$ROOT/bin/fm-wake-drain.sh"
 
 FAILED=0
 fail() { printf 'not ok - %s\n' "$1" >&2; FAILED=1; }
@@ -291,7 +294,7 @@ unit_signal_exits_with_lock_cleanup() {
   marker="$st/resumed"
   FM_HOME="$st" FM_STATE_OVERRIDE="$st/state" bash -c '
     . "$1"
-    fm_afk_launch_start() { sleep 30; }
+    fm_afk_launch_start() { sleep 1; }
     fm_afk_launch_main start
     : > "$2"
   ' _ "$LAUNCH" "$marker" &
@@ -823,6 +826,77 @@ unit_flag_write_failure_aborts() {
 }
 
 # ---------------------------------------------------------------------------
+# UNIT 4: an external Codex thread has no owned pane or callback destination.
+# A bounded checkpoint remains intentionally finite, while away entry rejects
+# both the normal and native paths before they can create daemon state or consume
+# a durable wake. An explicit worker-looking target must not bypass that check.
+# ---------------------------------------------------------------------------
+unit_external_codex_no_pane_refuses_before_away_state() {
+  local st checkpoint_out checkpoint_err watch_out launch_out launch_rc checkpoint_rc native_out native_rc drained
+  st=$(mktemp -d "${TMPDIR:-/tmp}/fm-afk-codex-no-pane.XXXXXX")
+  mkdir -p "$st/state" "$st/config" "$st/data"
+  printf 'window=worker-pane\nkind=ship\n' > "$st/state/demo.meta"
+  checkpoint_out="$st/checkpoint.out"
+  checkpoint_err="$st/checkpoint.err"
+  watch_out="$st/watch.out"
+  checkpoint_rc=0
+  env -u TMUX -u TMUX_PANE -u HERDR_ENV -u HERDR_PANE_ID \
+    CODEX_THREAD_ID=fixture FM_HOME="$st" FM_STATE_OVERRIDE="$st/state" \
+    FM_POLL=1 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 \
+    "$CHECKPOINT" --seconds 1 > "$checkpoint_out" 2> "$checkpoint_err" || checkpoint_rc=$?
+  if [ "$checkpoint_rc" -eq 124 ] \
+    && grep -F 'checkpoint: no actionable wake within 1s' "$checkpoint_out" >/dev/null \
+    && [ ! -e "$st/state/.watch.lock" ]; then
+    pass "external Codex: bounded checkpoint returns without retaining a watcher lock"
+  else
+    fail "external Codex: bounded checkpoint did not leave the expected finite no-lock state"
+  fi
+
+  printf 'done: fixture wake after checkpoint\n' > "$st/state/demo.status"
+  FM_HOME="$st" FM_STATE_OVERRIDE="$st/state" FM_POLL=1 FM_SIGNAL_GRACE=1 \
+    FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$watch_out" 2>&1 \
+    || fail "external Codex: could not create a durable fixture wake"
+  launch_out="$st/launch.out"
+  launch_rc=0
+  env -u TMUX -u TMUX_PANE -u HERDR_ENV -u HERDR_PANE_ID \
+    CODEX_THREAD_ID=fixture FM_HOME="$st" FM_STATE_OVERRIDE="$st/state" \
+    FM_SUPERVISOR_TARGET=worker-pane FM_SUPERVISOR_BACKEND=tmux "$LAUNCH" start > "$launch_out" 2>&1 \
+    || launch_rc=$?
+  if [ "$launch_rc" -ne 0 ] \
+    && grep -F 'no safe asynchronous callback' "$launch_out" >/dev/null \
+    && grep -F 'do not set FM_SUPERVISOR_TARGET to a worker pane' "$launch_out" >/dev/null \
+    && [ ! -e "$st/state/.afk" ] \
+    && [ ! -e "$st/state/.afk-daemon-terminal" ] \
+    && [ ! -e "$st/state/.supervise-daemon.lock" ]; then
+    pass "external Codex: wrong pane target is refused before daemon lifecycle state"
+  else
+    fail "external Codex: wrong pane target bypassed or obscured the explicit AFK refusal"
+  fi
+
+  native_out="$st/native.out"
+  native_rc=0
+  env -u TMUX -u TMUX_PANE -u HERDR_ENV -u HERDR_PANE_ID \
+    CODEX_THREAD_ID=fixture FM_HOME="$st" FM_STATE_OVERRIDE="$st/state" "$LAUNCH" start-native > "$native_out" 2>&1 \
+    || native_rc=$?
+  if [ "$native_rc" -ne 0 ] \
+    && grep -F 'no safe asynchronous callback' "$native_out" >/dev/null \
+    && [ ! -e "$st/state/.afk" ] \
+    && [ ! -e "$st/state/.afk-daemon-terminal" ]; then
+    pass "external Codex: native launch path cannot create a reapable daemon"
+  else
+    fail "external Codex: native launch path created away state without a delivery surface"
+  fi
+
+  drained=$(FM_HOME="$st" FM_STATE_OVERRIDE="$st/state" "$DRAIN")
+  if printf '%s\n' "$drained" | grep "$(printf '\tsignal\t')" | grep -F "$st/state/demo.status" >/dev/null; then
+    pass "external Codex: refusal preserves the durable wake for the captain's return"
+  else
+    fail "external Codex: away refusal consumed or lost the durable wake"
+  fi
+  rm -rf "$st"
+}
+
+# ---------------------------------------------------------------------------
 # E2E herdr: topology invariant.
 # ---------------------------------------------------------------------------
 e2e_herdr() {
@@ -951,6 +1025,7 @@ unit_clear_failure_aborts_entry
 unit_confirmed_absence_succeeds
 unit_incomplete_restore_retains_backup
 unit_flag_write_failure_aborts
+unit_external_codex_no_pane_refuses_before_away_state
 e2e_herdr
 e2e_tmux
 

--- a/tests/fm-afk-launch.test.sh
+++ b/tests/fm-afk-launch.test.sh
@@ -18,6 +18,7 @@
 #   sleeper replaces the real daemon (FM_AFK_LAUNCH_ENTRY) so the test observes
 #   only the terminal lifecycle.
 set -u
+unset CODEX_THREAD_ID
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 LAUNCH="$ROOT/bin/fm-afk-launch.sh"

--- a/tests/fm-daemon.test.sh
+++ b/tests/fm-daemon.test.sh
@@ -31,7 +31,7 @@ test_afk_start_refuses_when_flag_cannot_be_written() {
   state="$dir/state"
   mkdir -p "$state/.afk"
 
-  out=$(FM_STATE_OVERRIDE="$state" FM_SUPERVISOR_BACKEND=unsupported "$AFK_START" 2>&1)
+  out=$(env -u CODEX_THREAD_ID FM_STATE_OVERRIDE="$state" FM_SUPERVISOR_BACKEND=unsupported "$AFK_START" 2>&1)
   status=$?
 
   [ "$status" -ne 0 ] || fail "fm-afk-start.sh should fail when state/.afk cannot be written"
@@ -40,13 +40,31 @@ test_afk_start_refuses_when_flag_cannot_be_written() {
   pass "fm-afk-start.sh fails before daemon startup when the afk flag cannot be written"
 }
 
+test_afk_start_refuses_external_codex_without_pane_before_state() {
+  local dir state out status
+  dir=$(make_supercase afk-start-external-codex-no-pane)
+  state="$dir/state"
+
+  out=$(env -u TMUX -u TMUX_PANE -u HERDR_ENV -u HERDR_PANE_ID \
+    CODEX_THREAD_ID=fixture FM_STATE_OVERRIDE="$state" FM_SUPERVISOR_BACKEND=unsupported \
+    "$AFK_START" 2>&1)
+  status=$?
+
+  [ "$status" -ne 0 ] || fail "fm-afk-start.sh should reject an external Codex thread without a pane"
+  assert_contains "$out" "no safe asynchronous callback" "fm-afk-start.sh did not explain the external Codex refusal"
+  assert_absent "$state/.afk" "fm-afk-start.sh wrote away state before rejecting an external Codex thread"
+  assert_absent "$state/.supervise-daemon.lock" "fm-afk-start.sh created a daemon lock before rejecting an external Codex thread"
+  assert_not_contains "$out" "starting supervise daemon" "fm-afk-start.sh continued into daemon startup after rejecting an external Codex thread"
+  pass "fm-afk-start.sh rejects no-pane external Codex before away state"
+}
+
 test_afk_start_ignores_stale_pidfile_without_lock() {
   local dir state out status
   dir=$(make_supercase afk-start-stale-pidfile)
   state="$dir/state"
   printf '%s\n' "$$" > "$state/.supervise-daemon.pid"
 
-  out=$(FM_STATE_OVERRIDE="$state" FM_SUPERVISOR_BACKEND=unsupported "$AFK_START" 2>&1)
+  out=$(env -u CODEX_THREAD_ID FM_STATE_OVERRIDE="$state" FM_SUPERVISOR_BACKEND=unsupported "$AFK_START" 2>&1)
   status=$?
 
   [ "$status" -ne 0 ] || fail "fm-afk-start.sh should attempt daemon startup instead of trusting a pidfile-only live pid"
@@ -66,7 +84,7 @@ test_afk_start_reclaims_stale_daemon_lock_reused_pid() {
   printf '%s\n' "$$" > "$lock/pid"
   printf '%s\n' "stale daemon identity" > "$lock/pid-identity"
 
-  out=$(FM_STATE_OVERRIDE="$state" FM_SUPERVISOR_BACKEND=unsupported "$AFK_START" 2>&1)
+  out=$(env -u CODEX_THREAD_ID FM_STATE_OVERRIDE="$state" FM_SUPERVISOR_BACKEND=unsupported "$AFK_START" 2>&1)
   status=$?
 
   [ "$status" -ne 0 ] || fail "fm-afk-start.sh should attempt daemon startup after rejecting a reused-pid lock"
@@ -1828,6 +1846,7 @@ test_inject_msg_defers_on_unrecognized_composer_state() {
 }
 
 test_afk_start_refuses_when_flag_cannot_be_written
+test_afk_start_refuses_external_codex_without_pane_before_state
 test_afk_start_ignores_stale_pidfile_without_lock
 test_afk_start_reclaims_stale_daemon_lock_reused_pid
 test_daemon_state_root_uses_fm_home


### PR DESCRIPTION
## Intent

Fix Firstmate supervision continuity for a Codex primary running outside tmux or Herdr: reject AFK entry before any daemon or away state is created when no verified primary pane or safe callback exists; retain wakes and bounded foreground checkpoints; preserve terminal-backed AFK behavior; add behavioral regression coverage and maintainer verification evidence.

## What Changed

- Reject AFK entry from external Codex threads that lack an inherited tmux or Herdr primary pane, before creating away-mode or daemon lifecycle state.
- Apply the same no-pane boundary to both launcher paths and the shared AFK start entry, preventing explicit supervisor targets from selecting a worker pane.
- Document the supported foreground-checkpoint fallback and add regression coverage plus maintainer verification evidence for the refusal and terminal-backed lifecycle.

## Risk Assessment

✅ Low: The updated common AFK entry refuses no-pane external Codex before any away or daemon state is written, while the launcher guard preserves terminal-backed paths.

## Testing

Focused automated coverage passed for the external-Codex no-pane refusal, durable wake retention, direct daemon-entry refusal, and existing tmux/Herdr lifecycle behavior; the captured manual transcript also demonstrates refusal without state and successful terminal-backed AFK lifecycle when a verified tmux pane is present.

<details>
<summary>Evidence: Manual AFK boundary transcript: no-pane external Codex refusal plus verified-tmux successful lifecycle</summary>

```text
Scenario A: external Codex without a verified primary pane
fm-afk-launch: away mode is unavailable from an external Codex thread without a primary tmux or Herdr pane
fm-afk-launch: Codex provides no safe asynchronous callback to this thread; do not set FM_SUPERVISOR_TARGET to a worker pane
fm-afk-launch: keep foreground checkpoints running while present, or restart the primary inside tmux or Herdr before leaving work unattended
result=refused rc=1 state=absent

Scenario B: external Codex with a verified tmux primary pane
fm-afk-launch: daemon launched in detached tmux session 'fm-afk-daemon-2239899196-3724344-27330-1785855999', supervising %87
result=launched captain_pane=%87 daemon_session=fm-afk-daemon-2239899196-3724344-27330-1785855999
fm-afk-launch: away mode stopped; daemon terminal torn down and .afk cleared
result=cleaned (away state and daemon terminal removed)
```
</details>
<details>
<summary>Evidence: Focused automated AFK regression test transcript</summary>

```text
FM_TEST_BEGIN 2026-08-04T15:04:42Z tests/fm-daemon.test.sh family=watcher-wake-lock expected_gate_skip=none
ok - fm-afk-start.sh fails before daemon startup when the afk flag cannot be written
ok - fm-afk-start.sh rejects no-pane external Codex before away state
ok - fm-afk-start.sh ignores stale pidfile-only live pids
ok - fm-afk-start.sh reclaims stale daemon locks whose live pid identity no longer matches
ok - supervise daemon state root is scoped by FM_HOME
ok - routine signal self-handles
ok - captain-relevant status verbs escalate
ok - check + unknown escalate; heartbeat self-handles
ok - transient stale self-handles and records a persistence marker
ok - enriched stale wedges bypass status absorption without disturbing busy workers
ok - stale + terminal status escalates immediately
ok - paused reasons with captain phrases remain pause-classified
ok - handle_wake on a paused stale records a pause marker, drops the wedge marker, and does not escalate
ok - handle_wake records a declared pause from a routine signal for long-cadence rechecks
ok - a terminal signal clears pause and stale tracking across both supervisors
ok - housekeeping migrates a normal-watcher's declared pause into daemon tracking
ok - housekeeping clears an already-resumed watcher pause across both supervisors
ok - housekeeping seeds pause tracking from status without a watcher marker
ok - persistent stale escalates after threshold and clears its marker
ok - resumed (busy) stale clears its marker without escalating
ok - housekeeping re-surfaces a stale declared pause on the long cadence and resets its window
ok - housekeeping clears a paused marker whose pane became busy again, without escalating
ok - housekeeping clears a paused marker once the crew is no longer declaring the pause
ok - housekeeping moves an existing stale marker to pause before wedge escalation
ok - housekeeping clears tracking when a crew leaves pause
ok - persistent herdr stale resolves the target from metadata and escalates
ok - herdr idle busy-footer stale clears through capture corroboration
ok - resumed herdr stale clears through backend-aware busy state
ok - persistent Orca stale resolves the terminal from metadata
ok - multiple escalations flush as a single batched digest
ok - batch flush measures max-delay from the first append, not the last
ok - catch-all scan escalates a missed terminal once, not twice
ok - handle_wake routes routine->self and captain->escalate
ok - INJECT_SKIP forces self-handle, bypassing captain-relevant classification
ok - is_wake_reason distinguishes watcher wake reasons from singleton-status stdout
ok - terminal-stale escalate removes its marker so housekeeping does not re-escalate
ok - captain signal escalate marks seen so the catch-all scan does not re-fire
ok - _collapse_newlines replaces newlines with literal separator
ok - afk flag absent: daemon does not inject, buffer preserved
ok - busy-guard defers injection when supervisor pane is busy
ok - marker detection: marker -> stay afk, no marker -> exit afk
ok - /afk invocation is exempt from afk exit (no self-cancel)
ok - should_exit_afk returns false when afk is not active
ok - strip_injection_marker removes the sentinel marker cleanly
ok - pane_input_pending detects partial input on the cursor line
ok - pane_input_pending: blank cursor line is not pending
ok - pane_input_pending: only proven empty agent prompts pass
ok - fm_tmux_composer_state: a bare shell prompt ($/%/#/>) reads unknown, never empty (dead-shell injection safety)
ok - fm_tmux_composer_state: a bordered composer box and bare agent glyphs (❯/›) still read empty
ok - fm_tmux_composer_state: only matching edge borders form a composer box
ok - pane_input_pending honors FM_COMPOSER_IDLE_RE after border stripping
ok - classify_signal dedupes against the catch-all scan seen marker
ok - classify_stale dedupes against the signal path seen marker
ok - AFK nonterminal working:+merged keeps wedge aging and re-escalates at bound
ok - genuine done: and merge-check events still escalate
ok - pane_input_pending: an idle bordered composer is NOT pending (afk-invx-i5)
ok - pane_input_pending: text inside a bordered composer is still pending
ok - submit-ACK confirms a submit when the composer returns to a bordered-empty box
ok - submit-ACK reports pending on a persistently swallowed Enter (type-once)
ok - max-defer on an empty stuck pane types once, alarms, and preserves the buffer
ok - max-defer flushes and clears the buffer on an empty bordered pane
ok - max-defer on a pending composer alarms without typing
ok - normal flush clears a stale wedge marker
ok - below MAX_DEFER: no inject, no alarm, buffer preserved
ok - max-defer does not flush or alarm while afk is inactive
ok - library mode: sourcing the daemon defaults FM_WEDGE_ALARM_EXEC to discard (no test can fire a real notification)
ok - wake helpers replace inherited notifier overrides with the safe recorder
ok - the discard seam suppresses every notifier, including command: (fires nothing)
ok - direct notifier helpers honor the discard seam, including command:
ok - osascript channel routes through the notifier seam with the summary (never a real notification)
ok - herdr channel routes through the notifier seam with the summary (never a real notification)
ok - command channel runs the captain command with the summary on $1 and on stdin
ok - command channel failures redact configured commands while logging their exit status
ok - unknown channel directives are redacted while the alarm keeps running
ok - off disables every active alert regardless of directive position (marker and tmux flash are unaffected)
ok - auto resolves to the macOS osascript notifier on Darwin (default-on)
ok - auto on a non-macOS platform selects no built-in OS channel (the marker or a configured command carries it)
ok - config/wedge-alarm selects every configured channel and skips comment and blank lines
ok - a failing channel logs and falls back to the next channel, never crashing the alarm
ok - a hung notifier is bounded, logged, and falls through to the next channel
ok - a backgrounded command notifier remains bounded until its process group is reaped
ok - a hung notifier override is bounded, logged, and proceeds to the next channel
[1]+  Terminated              sh -c 'sleep 30 & printf "%s" "$!" > "$1"; wait' sh "$child_file"
ok - daemon shutdown stops and reaps the active notifier process group
ok - inject_wedge_alarm writes the marker AND emits the active alert even with no tmux status-line (herdr backend)
ok - in-process wedge throttle prevents alert spam when the marker cannot persist
ok - fm-send exits non-zero on a confirmed swallow, zero on a clean submit
ok - fm-send exits non-zero when initial text send fails
ok - fm-send exits non-zero unless delivery is proven empty
ok - discover_supervisor_backend: override > TMUX_PANE > HERDR_ENV+HERDR_PANE_ID > tmux fallback
ok - discover_supervisor_target: override > TMUX_PANE > herdr '<session>:<pane-id>' composition > firstmate:0 fallback
ok - pane_is_busy: herdr native busy_state='busy' short-circuits without a capture fallback
ok - primary busy guard isolates rendered signatures by detected harness
ok - pane_is_busy: omitted backend defaults to tmux for Grok's isolated fallback
ok - pane_input_pending: dispatches through fm_backend_composer_state for backend=herdr
ok - inject_msg: herdr busy-guard defers before ever attempting a submit
ok - inject_msg: herdr composer-guard defers before ever attempting a submit
ok - inject_msg: herdr pane-gone check defers before any busy/composer/submit call
ok - inject_msg: dispatches busy-guard/composer-guard/submit through the herdr backend and succeeds on a confirmed empty composer
ok - inject_msg: defers on a dead-shell/unreadable composer (unknown), never typing the escalation into a shell
ok - inject_msg: unrecognized composer states defer by default
FM_TEST_END 2026-08-04T15:04:57Z tests/fm-daemon.test.sh exit=0 duration_ms=15382 gate_skip=false
FM_TEST_BEGIN 2026-08-04T15:04:57Z tests/fm-afk-launch.test.sh family=real-herdr-gated expected_gate_skip=herdr
ok - clear-stale: removes escalations buffer, sidecar, and wedge marker
ok - clear-stale: leaves the durable wake-queue intact (no pending work dropped)
ok - launcher paths: relative home and state ignore CDPATH before daemon command construction
ok - launcher paths: absolute symlink spellings are preserved
ok - launcher paths: unresolved relative FM_HOME fails loudly
ok - launcher paths: unresolved relative FM_STATE_OVERRIDE fails loudly
ok - refresh: daemon already alive - stale artifacts preserved (current session's buffer kept)
ok - stop-ordering: daemon SIGTERM'd while .afk still present (flush is not a no-op)
ok - stop-ordering: .afk cleared last
ok - stop-ordering: daemon-terminal record removed
ok - stop identity: stale lock cannot signal an unrelated live process
ok - failed start: away flag and delivery artifacts roll back
ok - concurrent start: one serialized daemon terminal remains tracked
ok - launcher lock: incomplete publication receives initialization grace
ok - launcher signal: TERM exits and releases the lifecycle lock
fm-afk-launch: daemon launched in non-visible herdr workspace ws-partial (pane lab:pane-exact), supervising lab:captain
ok - herdr create: malformed response recovers durable exact ownership
fm-afk-launch: herdr create failed after returning exact ids; closing lab:pane-exact
fm-afk-launch: recorded terminal teardown is unconfirmed; preserving exact id
ok - herdr create error: unconfirmed exact id is persisted for reconciliation
fm-afk-launch: failed to run daemon in herdr pane lab:pane-exact; closing it
fm-afk-launch: recorded terminal teardown is unconfirmed; preserving exact id
ok - herdr run failure: unconfirmed exact id remains reconcilable
fm-afk-launch: failed to persist daemon terminal record; closing tmux:exact-session
ok - record failure: newly created terminal is closed by exact id
fm-afk-launch: daemon did not become ready; closing tmux:exact-session
ok - readiness failure: exact terminal and durable record roll back
fm-afk-launch: daemon did not become ready; closing tmux:exact-session
fm-afk-launch: recorded terminal teardown is unconfirmed; preserving exact id
ok - readiness failure: unconfirmed terminal retains its reconciliation id
ok - tmux absence: clean missing differs from transport probe failure
ok - native lifecycle: launcher owns state with no terminal
ok - native lifecycle: uniform stop clears state without closing a terminal
ok - native entry: launcher-prepared lifecycle state is not rewritten
fm-afk-launch: reconciling leaked daemon terminal tmux:exact-session
fm-afk-launch: recorded terminal teardown is unconfirmed; preserving exact id
ok - teardown failure: exact terminal record is preserved
ok - record publication: failed atomic rename preserves the complete prior record
fm-afk-launch: daemon terminal record is malformed; refusing to act on it
ok - record read: malformed record fails closed without acting on a partial id
fm-afk-launch: daemon terminal record is malformed; refusing to act on it
fm-afk-launch: malformed daemon terminal record; refusing to stop away mode
ok - stop: malformed terminal record preserves away state and fails closed
fm-afk-launch: failed to create detached tmux daemon session 'fm-afk-daemon-3837068492-3718075-19574-1785855900'
ok - tmux launch: planned exact target is recorded before creation and removed on failure
fm-afk-launch: failed to create detached tmux daemon session 'fm-afk-daemon-938681745-3718106-27210-1785855900'
ok - tmux launch: unique names eliminate collision teardown
ok - stop validation: malformed record causes no daemon or state side effects
ok - launcher lock: incomplete metadata fails acquisition and releases lock
fm-afk-launch: failed to clear away-mode flag
fm-afk-launch: away mode stopped; terminal teardown remains recorded for retry
ok - stop state: away-flag removal failure is surfaced
fm-afk-launch: away-mode daemon did not exit after SIGTERM; preserving lifecycle state
ok - stop liveness: captured live daemon preserves lifecycle state after lock release
fm-afk-launch: daemon terminal record is malformed; refusing to act on it
fm-afk-launch: daemon terminal record is malformed; refusing to act on it
ok - refresh record: malformed terminal identity fails closed
fm-afk-launch: failed to clear stale away-mode artifacts
ok - clear failure: native entry aborts and restores prior state
fm-afk-launch: reconciling leaked daemon terminal tmux:exact-session
fm-afk-launch: terminal close command failed, but exact absence was confirmed
ok - confirmed absence: cleanup succeeds and removes the stale record
fm-afk-launch: rollback restoration incomplete; backup retained at /tmp/fm-afk-restore-fail.vIH8xe/state/.afk-launch-backup.UhiOrG
ok - rollback restore: incomplete restoration retains its recovery backup
ok - flag failure: lifecycle aborts without active state
ok - external Codex: bounded checkpoint returns without retaining a watcher lock
ok - external Codex: wrong pane target is refused before daemon lifecycle state
ok - external Codex: native launch path cannot create a reapable daemon
●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
●  WATCHER DOWN - SUPERVISION IS OFF
●  1 task(s) in flight, but no watcher has a fresh beacon (last beat: 1s ago, grace 300s).
●  Trust the emitted supervision protocol for this harness; do not use shell & for watcher repair.
●  This is a supervision warning only; the guarded operation WILL still run.
●  repair missing watcher supervision according to the session-start block for this harness; do not use shell &.
●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
ok - external Codex: refusal preserves the durable wake for the captain's return
ok - herdr e2e: captain tab pane count unchanged after start (no split)
ok - herdr e2e: daemon launched in a separate non-visible workspace
ok - herdr e2e: daemon pane is NOT in the captain's tab
ok - herdr e2e: daemon terminal scoped to the lab session
ok - herdr e2e: captain tab pane count restored after stop
ok - herdr e2e: daemon workspace removed by exact id on stop
ok - herdr e2e: record + .afk cleared on stop
ok - tmux e2e: captain window pane count unchanged after start (no split-window)
ok - tmux e2e: daemon launched in a separate detached session
ok - tmux e2e: captain window pane count unchanged after stop
ok - tmux e2e: daemon session killed by exact id on stop
ok - tmux e2e: record + .afk cleared on stop
FM_TEST_END 2026-08-04T15:05:04Z tests/fm-afk-launch.test.sh exit=0 duration_ms=7226 gate_skip=false
FM_TEST_SUMMARY total=2 failed=0 skipped_gate=0 duration_ms=22664
FM_TEST_SUMMARY_FAMILY family=real-herdr-gated count=1 duration_ms=7226 failed=0
FM_TEST_SUMMARY_FAMILY family=watcher-wake-lock count=1 duration_ms=15382 failed=0
FM_TEST_SLOWEST rank=1 script=tests/fm-daemon.test.sh duration_ms=15382
FM_TEST_SLOWEST rank=2 script=tests/fm-afk-launch.test.sh duration_ms=7226
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- 🚨 `bin/fm-afk-launch.sh:473` - The required “reject AFK entry before any daemon or away state is created” invariant is still bypassable: the new no-pane predicate is called only by `fm-afk-launch.sh`, while executable common entry `bin/fm-afk-start.sh` can be invoked directly by an external `CODEX_THREAD_ID` process with no pane and writes `state/.afk` before execing the daemon. Put the same guard at the common entry before its first state write (or require launcher preparation) so every AFK start path satisfies the boundary.

🔧 Fix: Guard direct external Codex AFK entry
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bin/fm-test-run.sh tests/fm-daemon.test.sh tests/fm-afk-launch.test.sh`
- `Manual isolated external-Codex lifecycle exercise: no verified pane rejects before AFK/daemon state; a verified tmux pane launches and cleanly removes its detached daemon lifecycle.`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 1)

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
