### PR TITLE
feat(skills): add review-round pull-request review sweep

### DIFF
--- a/.agents/skills/review-round/SKILL.md
+++ b/.agents/skills/review-round/SKILL.md
@@ -16,17 +16,20 @@ This skill is the single owner of that procedure.
 
 ## Build the inventory
 
-The two classes need two different commands, because `gh-axi search prs` has no requested-reviewer facet - its only review flag is `--review <none|required|approved|changes_requested>`, and a raw `review-requested:` qualifier passed as the positional query is rejected as an invalid search query:
+Scope the round to the projects registered in `data/projects.md` plus anything the captain names in the request, and report what was excluded rather than silently dropping it.
+That scope is also a hard constraint on the commands: `gh-axi search prs` injects `repo:<current repo>` into every query, so one call never sweeps the fleet - it sweeps whatever repository `-R <owner/repo>` retargets it at, and must be run once per project in scope.
+The two classes then need two different commands, because `gh-axi search prs` has no requested-reviewer facet: its only review flag is `--review <none|required|approved|changes_requested>`, which is about whether a review is required, not about who it is required from, and a raw `review-requested:` qualifier passed as the positional query is rejected as an invalid search query.
 
 - **Incoming** - someone else wrote it, the captain is the requested reviewer.
-  Discover these through the search API directly: `gh-axi api "/search/issues?q=is%3Apr+is%3Aopen+review-requested%3A%40me"`, or `gh-axi pr list --state open` per project when the round is already scoped to one repository.
+  The requested-reviewer facet exists only on the search API, so go there directly, once per project: `gh-axi api "/search/issues?q=is%3Apr+is%3Aopen+review-requested%3A%40me+repo%3A<owner>%2F<name>"`.
+  Dropping the `repo:` qualifier gives the whole fleet in one call, which is the cheaper way in - then keep only what falls inside the round's scope.
+  Reaching for `gh-axi pr list --state open` instead costs a `gh-axi pr view <n> --reviews` pass per pull request, because `pr list` has no reviewer filter and no reviewer field to select.
   The verdict becomes the review he posts under his own name, so firstmate must get it right before it reaches him.
 - **Self** - the captain wrote it.
-  Discover these with `gh-axi search prs --author <handle> --state open` (no positional query needed).
+  Discover these with `gh-axi search prs -R <owner/repo> --author <handle> --state open` (no positional query needed), once per project in scope.
   He wants defects found, not reassurance.
 
-The authored-by search reaches back years and surfaces old contributions to repositories that are not part of the fleet.
-Scope the round to projects registered in `data/projects.md` plus anything the captain names in the request, and report what was excluded rather than silently dropping it.
+Within a project the authored-by facet reaches back years and surfaces work long since abandoned or superseded, so age is not evidence that a pull request still belongs in the round - decide that from what it is waiting on.
 
 Before dispatching a reviewer, check whether the pull request already has a report from an earlier round and an existing review decision under the captain's account.
 A pull request already reviewed and still waiting on someone else is not re-reviewed.

--- a/.agents/skills/review-round/SKILL.md
+++ b/.agents/skills/review-round/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: review-round
+description: >-
+  Sweep every open pull request the captain is a requested reviewer on or the author of, review each one, and bring back one consolidated per-project decision surface.
+  Use when the captain invokes /review-round or asks for a pull-request review round, a review sweep, "what needs my review", or "review my open PRs".
+user-invocable: true
+metadata:
+  internal: true
+---
+
+# review-round
+
+A review round produces verdicts, never fixes, and it is a distinct deliverable from a ship or a scout: reviewing his own or someone else's pull request is evidence for a decision, not authorization to change code.
+The one standing exception is stated below under Self pull requests.
+This skill is the single owner of that procedure.
+
+## Build the inventory
+
+Discover both classes with `gh-axi search prs`, scoped to the requested-reviewer and authored-by facets for the captain's handle, state open.
+They are handled differently:
+
+- **Incoming** - someone else wrote it, the captain is the requested reviewer.
+  The verdict becomes the review he posts under his own name, so firstmate must get it right before it reaches him.
+- **Self** - the captain wrote it.
+  He wants defects found, not reassurance.
+
+The authored-by search reaches back years and surfaces old contributions to repositories that are not part of the fleet.
+Scope the round to projects registered in `data/projects.md` plus anything the captain names in the request, and report what was excluded rather than silently dropping it.
+
+Before dispatching a reviewer, check whether the pull request already has a report from an earlier round and an existing review decision under the captain's account.
+A pull request already reviewed and still waiting on someone else is not re-reviewed.
+Re-asking a question already answered is the specific failure this skill exists to prevent.
+
+## Dispatch one reviewer per pull request
+
+Each reviewer is a scout: it produces a report, never a pull request, per `AGENTS.md` section 7.
+Effort follows consequence, not diff size.
+Raise it where a mistake would cause an outage, data loss, a security hole, or a change that is hard to reverse.
+Keep it low where the change is documentation or is fully covered by a gate that actually runs.
+A two-line change to an account-lockout policy deserves more thought than a hundred lines of docs.
+
+Require every reviewer's brief to enforce:
+
+1. **Diff against the pull request's own base branch, never `main`.**
+   A stacked pull request reviewed against `main` shows its parent's changes as its own and produces findings that are not about the change under review at all.
+2. **Treat a passing check as evidence only about what it actually ran.**
+   Establish which workflow produced the check and whether that workflow exercises the changed files at all - a job defined in one workflow says nothing about a change to a workflow that fires only on a tag push or a comment trigger.
+   The reviewer's verdict must say explicitly whether the change was genuinely exercised, and say so plainly when it was not, rather than letting a green tick imply confidence it does not carry.
+3. **Never speak to GitHub.**
+   No comment, no review, no approval, no push, no merge.
+   The reviewer's only output is its report; firstmate delivers the verdict after the captain decides, which keeps his name off anything he has not seen.
+
+## Consolidate into one decision surface
+
+Build one Lavish page per project, grouped by project, and never publish a second competing page for a repository already covered by an open one - check `lavish-axi`'s session list first.
+The page must be self-contained: he decides from it alone, with no need to open a pull request or ask what a change was about, and every explanation assumes no prior knowledge of the change.
+Open with a status summary that separates what is already done and needs nothing from him from what needs his input.
+Every option set names exactly one `(Recommended)` choice with a one-line reason, and always leaves a free-text way to answer in his own words or ask for more explanation first.
+
+Load `decision-hold-lifecycle` before treating the round as complete: each verdict that needs the captain's word is an unresolved decision from a structured review under that skill's own definition, and it owns the hold-and-resolve mechanics.
+
+## Self pull requests
+
+Standing arrangement: real defects found in the captain's own pull requests may be fixed afterward through the project's normal delivery path, at the project's registered delivery posture.
+The merge always needs his explicit word regardless of that project's `yolo` posture - this is a standing exception to the ordinary routine-gate authority in `AGENTS.md` section 7, scoped to review-round merges only.
+
+## Drive the round to landing, not back to him
+
+Approved means merge it.
+Rejected means the fix is made and the review is re-requested.
+The round is not finished when the verdicts are delivered - it is finished when every pull request in it has either landed or is genuinely waiting on a named other person.
+State that name; a pull request left waiting on an unnamed human stalls invisibly.
+A pull request opened without a reviewer stalls the same way, so assign one at delivery.
+
+Two merge-mechanics traps cost real time:
+
+- A repository whose code-owner rule names the captain as its only owner cannot merge normally, because the code-owner gate refuses every merge where the only possible approver is the author.
+  Point at the project's existing merge helper first (`bin/fm-pr-merge.sh` for a task-owned pull request, `gh-axi pr merge` otherwise); an administrative override is the exception for this specific trap, taken only with the captain's explicit word, never the default path.
+- Where a ruleset requires branches to be up to date, merging one pull request invalidates every other open pull request's up-to-date status.
+  Plan a batch as update-branch-then-wait, once per pull request (`gh-axi pr update-branch`), never as a single merge-them-all step.
+
+## Report staleness as its own finding
+
+Report pull requests that have been open a long time as a finding in their own right, stating what each is waiting on, distinct from any defect in the change itself.
+Ten stale pull requests are a problem about the process, not about any one change, and that pattern only surfaces if every round looks at the whole inventory rather than only what changed since the last one.

--- a/.agents/skills/review-round/SKILL.md
+++ b/.agents/skills/review-round/SKILL.md
@@ -16,12 +16,13 @@ This skill is the single owner of that procedure.
 
 ## Build the inventory
 
-Discover both classes with `gh-axi search prs`, scoped to the requested-reviewer and authored-by facets for the captain's handle, state open.
-They are handled differently:
+The two classes need two different commands, because `gh-axi search prs` has no requested-reviewer facet - its only review flag is `--review <none|required|approved|changes_requested>`, and a raw `review-requested:` qualifier passed as the positional query is rejected as an invalid search query:
 
 - **Incoming** - someone else wrote it, the captain is the requested reviewer.
+  Discover these through the search API directly: `gh-axi api "/search/issues?q=is%3Apr+is%3Aopen+review-requested%3A%40me"`, or `gh-axi pr list --state open` per project when the round is already scoped to one repository.
   The verdict becomes the review he posts under his own name, so firstmate must get it right before it reaches him.
 - **Self** - the captain wrote it.
+  Discover these with `gh-axi search prs --author <handle> --state open` (no positional query needed).
   He wants defects found, not reassurance.
 
 The authored-by search reaches back years and surfaces old contributions to repositories that are not part of the fleet.

--- a/.agents/skills/review-round/SKILL.md
+++ b/.agents/skills/review-round/SKILL.md
@@ -21,12 +21,15 @@ That scope is also a hard constraint on the commands: `gh-axi search prs` inject
 The two classes then need two different commands, because `gh-axi search prs` has no requested-reviewer facet: its only review flag is `--review <none|required|approved|changes_requested>`, which is about whether a review is required, not about who it is required from, and a raw `review-requested:` qualifier passed as the positional query is rejected as an invalid search query.
 
 - **Incoming** - someone else wrote it, the captain is the requested reviewer.
-  The requested-reviewer facet exists only on the search API, so go there directly, once per project: `gh-axi api "/search/issues?q=is%3Apr+is%3Aopen+review-requested%3A%40me+repo%3A<owner>%2F<name>"`.
-  Dropping the `repo:` qualifier gives the whole fleet in one call, which is the cheaper way in - then keep only what falls inside the round's scope.
+  The requested-reviewer facet exists only on the search API, so go there directly: `gh-axi api "/search/issues?q=is%3Apr+is%3Aopen+review-requested%3A%40me+repo%3A<owner>%2F<name>"`.
+  Make a first pass with the `repo:` qualifier dropped, which returns the whole fleet in one call: that pass buys speed only, and what it returns is never the inventory.
+  Then run the scoped form above once per registered fleet project plus any repository the captain named, and treat that per-repository loop as the authoritative completeness check.
+  It runs every time, whatever the fleet-wide pass returned, because the search index lags and so a fleet-wide result cannot be trusted as complete - and a missed pull request is the exact failure this skill exists to prevent.
   Reaching for `gh-axi pr list --state open` instead costs a `gh-axi pr view <n> --reviews` pass per pull request, because `pr list` has no reviewer filter and no reviewer field to select.
   The verdict becomes the review he posts under his own name, so firstmate must get it right before it reaches him.
 - **Self** - the captain wrote it.
   Discover these with `gh-axi search prs -R <owner/repo> --author <handle> --state open` (no positional query needed), once per project in scope.
+  The authored-by facet also reaches every repository the captain has ever contributed to, so an unscoped variant returns years of unrelated upstream contributions to repositories outside the fleet: filter its results down to the registered fleet plus any captain-named repository before treating anything as in scope.
   He wants defects found, not reassurance.
 
 Within a project the authored-by facet reaches back years and surfaces work long since abandoned or superseded, so age is not evidence that a pull request still belongs in the round - decide that from what it is waiting on.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -254,6 +254,8 @@ Classify the deliverable:
 - **Ship** is the default and produces a project change through the selected delivery mode; once implementation is authorized, dispatch a ship and keep any remaining bounded research inside it unless unresolved uncertainty could materially change whether or what to build.
 - **Scout** produces knowledge in `data/<id>/report.md`, never a PR, and is appropriate for investigation, diagnosis, planning, reproduction, or audit work when the captain explicitly requests a separate knowledge or design deliverable or unresolved uncertainty could materially change whether or what to build.
 
+When the captain invokes `/review-round` or asks for a pull-request review round, load the `review-round` skill for the sweep-review-decide-and-land procedure.
+
 If established evidence already answers an informational question, relay it without a design-only scout; when implementation intent is unclear, answer and ask one concise implementation question when useful rather than dispatching speculative design work.
 Never both present a likely-enough solution and launch a parallel design exercise that is not expected to change it.
 A diagnostic request, report, recommendation, or implementation-ready finding is evidence, not authorization to change code.

--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ Claude and grok use the slash form shown here; codex uses the same names with `$
 | `/bearings`        | Generate a concise four-section chat digest from bounded local fleet and registered-secondmate state; use `/bearings file` to also replace today's dated report in `data/`, and add `include PRs` when live PR enrichment is wanted |
 | `/updatefirstmate` | Self-update the running firstmate and its secondmates to the latest from origin with fast-forward-only pulls, then re-read instructions and nudge secondmates |
 | `/stow`            | Sweep the session for uncaptured durable knowledge, route each finding to its disk home per AGENTS.md, file undone next steps to the backlog, and report what is now safe to reset |
+| `/review-round`    | Sweep every open pull request the captain is a requested reviewer on or the author of, review each one, and bring back one consolidated per-project decision surface |
 
 Bearings invocation examples:
 

--- a/docs/documentation-audiences.json
+++ b/docs/documentation-audiences.json
@@ -169,6 +169,10 @@
       "audience": "agent-runtime"
     },
     {
+      "path": ".agents/skills/review-round/SKILL.md",
+      "audience": "agent-runtime"
+    },
+    {
       "path": ".agents/skills/secondmate-provisioning/SKILL.md",
       "audience": "agent-runtime"
     },


### PR DESCRIPTION
## Intent

Add a captain-invocable review-round skill that owns the pull-request review round: sweep every open PR the captain is requested-reviewer on or author of, dispatch one scaled-effort scout reviewer per PR (never touching GitHub - diffing against the PR's own base branch, and treating passing CI checks as evidence only of what they actually ran), consolidate verdicts into one self-contained per-project Lavish decision surface (one recommended option plus free text, status summary first), and drive approved/rejected outcomes to landing (merge or fix-and-re-request) rather than handing the loop back to the captain, including the CODEOWNERS solo-owner merge trap, sequential update-branch-then-wait for ruleset-gated batches, and reporting stale PRs as their own finding. Registered it in AGENTS.md section 7 (one trigger line, same pattern as /stow) and in README.md's built-in skills table. No scripts were added since the skill is a pure procedure; bin/fm-lint.sh and bin/fm-doc-audience-check.sh both pass.

## What Changed

- Adds `.agents/skills/review-round/SKILL.md`, a captain-invocable skill that owns a full pull-request review round: discover every open PR the captain is requested-reviewer on or author of (per-project `gh-axi api` search plus a documented fleet-wide shortcut), dispatch one scaled-effort scout reviewer per PR that never touches GitHub and diffs against the PR's own base branch, consolidate verdicts into one self-contained per-project Lavish decision surface, and drive outcomes to landing — including the CODEOWNERS solo-owner merge trap, sequential update-branch-then-wait for ruleset-gated batches, and stale PRs reported as their own finding.
- Registers the skill for discovery: one trigger line in AGENTS.md section 7 following the `/stow` pattern, and a row in the README built-in skills table.
- Classifies the new skill doc in `docs/documentation-audiences.json` as `agent-runtime` so `bin/fm-doc-audience-check.sh` stays green.

## Risk Assessment

✅ Low: Documentation-only skill addition whose two prior defects are now fixed and whose every documented command was verified working verbatim against the live tool, leaving only an unnamed source for the per-project GitHub slug.

## Testing

I exercised the captain-facing surface end-to-end rather than only reading the diff: a fresh headless Claude Code session in this repo discovers `/review-round` as a user-invocable skill with its intended description (via the existing `.claude/skills` symlink), and AGENTS.md §7 plus the README built-in skills table carry the registration in the same one-line form as `/stow`. Because the skill is a pure procedure whose last two commits fixed its prescribed commands, I ran those commands live against real repositories — the per-project and fleet-wide requested-reviewer search-API calls, the per-repository authored-PR sweep with `-R` retargeted at two different repos, the two negative cases the skill cites as reasons the search command cannot do the incoming class, and the existence of `gh-axi pr update-branch` and `bin/fm-pr-merge.sh` for the landing step. All behaved exactly as documented. The targeted automated check for the doc surface it registers (`tests/fm-documentation-audiences.test.sh`) passed 4/4. No screenshot or rendered-UI artifact applies: the change adds no rendered surface — the Lavish decision page it describes is produced at round-run time from live PR data, not by this change — so the reviewer-visible evidence is CLI transcripts of the prescribed commands and the harness skill listing. Worktree left clean; evidence files written only to the dedicated evidence directory.

<details>
<summary>Evidence: Prescribed review-round discovery and landing commands, run live</summary>

<code>## Incoming (captain is requested reviewer) - per project, as documented&#10;$ gh-axi api &#34;/search/issues?q=is%3Apr+is%3Aopen+review-requested%3A%40me+repo%3Aeufforic%2Filert-iac&#34;&#10;total_count: 2&#10;number: 45 title: &#34;Card #742: dev_slack_only pages sched-sre, not hardcoded Dimitri&#34;&#10;number: 44 title: &#34;Card #717: wire the public status page to real Gatus/Frisbii alerts&#34;&#10;&#10;## Incoming - fleet-wide (the documented &#34;cheaper way in&#34;)&#10;$ gh-axi api &#34;/search/issues?q=is%3Apr+is%3Aopen+review-requested%3A%40me&#34;&#10;total_count: 5 (eufforic/ilert-iac#45, eufforic/k8s-infra#262, eufforic/ilert-iac#44, office-eu-answering-agent#49, #44)&#10;&#10;## Self (captain is author) - per project, as documented&#10;$ gh-axi search prs -R kunchenguid/firstmate --author timidri --state open&#10;count: 1 -&gt; 1586 &#34;fix(bin): stop the captain decision queue compounding&#34;&#10;$ gh-axi search prs -R eufforic/office.eu --author timidri --state open # -R really retargets&#10;count: 3 -&gt; 856, 833, 561 (all eufforic/office.eu)&#10;&#10;## Why the search command cannot do &#34;incoming&#34; (skill&#39;s stated reasons, verified)&#10;$ gh-axi search prs --repo kunchenguid/firstmate --state open --review timidri&#10;error: invalid argument &#34;timidri&#34; for &#34;--review&#34; flag: valid values are {none|required|approved|changes_requested}&#10;$ gh-axi search prs &#34;review-requested:@me is:open&#34; --repo eufforic/ilert-iac&#10;error: &#34;Invalid search query \&#34;( review-requested:\\\&#34;@me is:open\\\&#34; ) repo:eufforic/ilert-iac type:pr\&#34;.&#34;&#10;&#10;## Landing mechanics the skill points at exist&#10;update-branch &lt;number&gt;&#10;bin/fm-pr-merge.sh</code>

```text
# review-round: documented discovery commands, run as prescribed by the skill

## Incoming (captain is requested reviewer) - per project, as documented
$ gh-axi api "/search/issues?q=is%3Apr+is%3Aopen+review-requested%3A%40me+repo%3Aeufforic%2Filert-iac"
total_count: 2
    number: 45
    title: "Card #742: dev_slack_only pages sched-sre, not hardcoded Dimitri"
    number: 44
    title: "Card #717: wire the public status page to real Gatus/Frisbii alerts"

## Incoming - fleet-wide (the documented "cheaper way in": drop the repo: qualifier)
$ gh-axi api "/search/issues?q=is%3Apr+is%3Aopen+review-requested%3A%40me"
total_count: 5
    number: 45
    title: "Card #742: dev_slack_only pages sched-sre, not hardcoded Dimitri"
      diff_url: "https://github.com/eufforic/ilert-iac/pull/45.diff"
    number: 262
    title: "gatus: regroup Frisbii checks to app (Card #717)"
      diff_url: "https://github.com/eufforic/k8s-infra/pull/262.diff"
    number: 44
    title: "Card #717: wire the public status page to real Gatus/Frisbii alerts"
      diff_url: "https://github.com/eufforic/ilert-iac/pull/44.diff"
    number: 49
    title: "build(deps): bump anthropics/claude-code-action from 1 to 1.0.183"
      diff_url: "https://github.com/eufforic/office-eu-answering-agent/pull/49.diff"
    number: 44
    title: "Release status lives in the vault, not in Python"
      diff_url: "https://github.com/eufforic/office-eu-answering-agent/pull/44.diff"

## Self (captain is author) - per project, as documented
$ gh-axi search prs -R kunchenguid/firstmate --author timidri --state open
count: 1
prs[1]{number,title,repo,state,author,created}:
  1586,"fix(bin): stop the captain decision queue compounding",kunchenguid/firstmate,open,timidri,1d ago
$ gh-axi search prs -R eufforic/office.eu --author timidri --state open   # -R really retargets: different repo, different PRs
count: 3
prs[3]{number,title,repo,state,author,created}:
  856,"ci: make the PR-size rule bind — size gate, no template escape hatch, real CODEOWNERS",eufforic/office.eu,open,timidri,16h ago
  833,"fix(billing): tell a misconfigured plan apart from a Frisbii outage (#806 follow-up)",eufforic/office.eu,open,timidri,4d ago
  561,"Scalingo review apps: manifest + fix SolidQueue fresh-DB boot deadlock (#607)",eufforic/office.eu,open,timidri,1mo ago

## Why the search command cannot do "incoming" (skill's stated reasons, verified)
$ gh-axi search prs --repo kunchenguid/firstmate --state open --review timidri   # --review is not a who-facet
error: "invalid argument \"timidri\" for \"--review\" flag: valid values are {none|required|approved|changes_requested}"
code: UNKNOWN
$ gh-axi search prs "review-requested:@me is:open" --repo eufforic/ilert-iac   # raw qualifier as positional query
error: "Invalid search query \"( review-requested:\\\"@me is:open\\\" ) repo:eufforic/ilert-iac type:pr\"."
code: UNKNOWN

## Landing mechanics the skill points at exist
$ gh-axi pr --help | grep update-branch
update-branch <number>
$ ls bin/fm-pr-merge.sh
bin/fm-pr-merge.sh
```
</details>
<details>
<summary>Evidence: Captain-facing registration + harness skill discovery</summary>

<code>## AGENTS.md section 7 trigger lines (/stow pattern vs new /review-round)&#10;232:When the captain invokes `/stow`, load the `stow` skill for the complete knowledge-routing and unfinished-work sweep.&#10;257:When the captain invokes `/review-round` or asks for a pull-request review round, load the `review-round` skill for the sweep-review-decide-and-land procedure.&#10;&#10;## README built-in skills table&#10;| `/stow` | Sweep the session for uncaptured durable knowledge, ... |&#10;| `/review-round` | Sweep every open pull request the captain is a requested reviewer on or the author of, review each one, and bring back one consolidated per-project decision surface |&#10;&#10;## Harness discovery (fresh headless Claude Code session in this repo)&#10;$ claude --print &#34;List every skill available to you whose name contains review ...&#34;&#10;review-round | true | Sweep open pull requests for review and consolidate verdicts per project</code>

```text
# Captain-facing registration surfaces

## AGENTS.md section 7 trigger lines (/stow pattern vs new /review-round)
232:When the captain invokes `/stow`, load the `stow` skill for the complete knowledge-routing and unfinished-work sweep.
257:When the captain invokes `/review-round` or asks for a pull-request review round, load the `review-round` skill for the sweep-review-decide-and-land procedure.
493:When the captain invokes `/updatefirstmate` or asks to update firstmate, load the `/updatefirstmate` skill.

## README built-in skills table
| Skill              | What it does                                                                                                                                  |
| ------------------ | -------------------------------------------------------------------------------------------------------------------------------------------- |
| `/afk`             | Enter away-mode supervision: the sub-supervisor self-handles routine notifications in bash, escalates captain-relevant events and bounded declared-external-wait rechecks as batched digests, and actively alerts if delivery gets stuck while you step away |
| `/ahoy`            | Recap visible session events since the prior real captain message plus visibly unanswered captain decisions, falling back to Bearings when invoked as the session's first real captain message |
| `/bearings`        | Generate a concise four-section chat digest from bounded local fleet and registered-secondmate state; use `/bearings file` to also replace today's dated report in `data/`, and add `include PRs` when live PR enrichment is wanted |
| `/updatefirstmate` | Self-update the running firstmate and its secondmates to the latest from origin with fast-forward-only pulls, then re-read instructions and nudge secondmates |
| `/stow`            | Sweep the session for uncaptured durable knowledge, route each finding to its disk home per AGENTS.md, file undone next steps to the backlog, and report what is now safe to reset |
| `/review-round`    | Sweep every open pull request the captain is a requested reviewer on or the author of, review each one, and bring back one consolidated per-project decision surface |


## Harness discovery (fresh headless Claude Code session in this repo, model haiku)
$ claude --print "List every skill available to you whose name contains review ..."
review-round | true | Sweep open pull requests for review and consolidate verdicts per project
```
</details>
<details>
<summary>Evidence: Targeted doc-surface suite for the new documentation-audiences entry</summary>

```text
$ bash tests/fm-documentation-audiences.test.sh
ok - documentation inventory classifies every maintained prose surface exactly once
ok - classification, setup routing, and maintained-prose scope fail safely
ok - required documentation owner pointers cannot silently disappear
ok - local links resolve while dates, versions, commands, and incident prose remain semantically reviewed
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- 🚨 `docs/documentation-audiences.json:168` - The new tracked file `.agents/skills/review-round/SKILL.md` is not classified in the documentation-audience inventory. `bin/fm-doc-audience-check.sh` diffs `git ls-files -- *.md *.mdx *.rst *.txt docs/examples/*` against `surfaces[].path` and fails with `unclassified: …` on any tracked prose file missing from the inventory (bin/fm-doc-audience-check.sh:174-184). All 19 sibling internal skills are listed with `&#34;audience&#34;: &#34;agent-runtime&#34;`. This also contradicts the intent&#39;s claim that `bin/fm-doc-audience-check.sh` passes. Fix: add `{&#34;path&#34;: &#34;.agents/skills/review-round/SKILL.md&#34;, &#34;audience&#34;: &#34;agent-runtime&#34;}` in alphabetical position (after the quota-array-dispatch entry at line 168).
- ⚠️ `.agents/skills/review-round/SKILL.md:16` - The inventory step instructs discovery of both classes &#34;with `gh-axi search prs`, scoped to the requested-reviewer and authored-by facets&#34;, but `gh-axi search prs` cannot express requested-reviewer: its only review flag is `--review &lt;none|required|approved|changes_requested&gt;` (rejects `review-requested`), and it wraps the positional query in quotes so a raw qualifier fails — `gh-axi search prs &#34;review-requested:@me state:open&#34;` returns `error: Invalid search query &#34;( review-requested:\&#34;@me state:open\&#34; ) …&#34;`. The incoming class is the required half of the sweep, so as written the primary required behavior has no working command behind it. A supported path exists and was verified: `gh-axi api &#34;/search/issues?q=is%3Apr+is%3Aopen+review-requested%3A%40me&#34;` (returned 4). Name that command (or `gh-axi pr list` per project) for the incoming facet and keep `--author` for the self facet.
- ⚠️ `.agents/skills/review-round/SKILL.md:70` - &#34;Rejected means the fix is made and the review is re-requested&#34; sits in the landing section that governs every pull request in the round, but fix authority is granted only for the captain&#39;s own pull requests (lines 62-65) and line 12 states a review round &#34;produces verdicts, never fixes&#34;. Read literally, a rejected incoming pull request obliges firstmate to make the fix in another contributor&#39;s branch — crossing the authority boundary the skill&#39;s own opening paragraph draws. The incoming path should terminate at request-changes plus the &#34;genuinely waiting on a named other person&#34; state the same section already defines (line 71). Scoping this needs the author&#39;s word since it defines the round&#39;s product behavior.

🔧 Fix: classify review-round doc surface, fix PR discovery commands
1 warning still open:
- ⚠️ `.agents/skills/review-round/SKILL.md:26` - The self facet now names `gh-axi search prs --author &lt;handle&gt; --state open`, but gh-axi injects `repo:&lt;current repo&gt;` into every search query, so this can never leave the repository the process is sitting in. Evidence: the invalid-query echo prints `( … ) repo:kunchenguid/firstmate type:pr`; `gh-axi search prs --state open` with no scope flags returns only kunchenguid/firstmate PRs; and `--owner` cannot broaden it because it is ANDed with the injected repo scope (`--owner cli --state open` → 0 results). This falsifies the skill&#39;s own next paragraph at line 29 (&#34;The authored-by search reaches back years and surfaces old contributions to repositories that are not part of the fleet&#34;) and silently reduces the required cross-project authored-by sweep to a single repository. Use the same global path the incoming facet already uses — `gh-axi api &#34;/search/issues?q=is%3Apr+is%3Aopen+author%3A&lt;handle&gt;&#34;` (verified global: 7 results vs 5 repo-scoped) — or iterate `gh-axi pr list -R &lt;owner/repo&gt; --author &lt;handle&gt; --state open` over registered projects. Related smaller imprecision on line 23: the `gh-axi pr list --state open` fallback for the incoming class has no reviewer filter (list flags are only --state/--label/--assignee/--author/--base/--head/--draft/--limit/--fields), so it lists every open PR and needs a per-PR `gh-axi pr view` pass to isolate requested-reviewer PRs.

🔧 Fix: scope review-round PR discovery per repository
1 info still open:
- ℹ️ `.agents/skills/review-round/SKILL.md:24` - Both per-project discovery commands need a GitHub slug - `repo%3A&lt;owner&gt;%2F&lt;name&gt;` on line 24 and `-R &lt;owner/repo&gt;` on line 29 - but the only registry the section names (line 19, `data/projects.md`) holds bare project names, not slugs: `bin/fm-project-mode.sh:14-17` documents the registry line format as `- &lt;name&gt; [&lt;mode&gt; +yolo] - &lt;desc&gt; (added &lt;date&gt;)`. The per-project loop therefore has an unresolved input, and an agent must guess the owner. Add one clause naming the source - resolve it from the project clone (`git -C projects/&lt;name&gt; remote get-url origin`), or run gh-axi from inside `projects/&lt;name&gt;` where it infers the repo and `-R` is unnecessary. Optional symmetry: the self facet is restricted to the per-project form while the incoming facet gets a single cheaper global call at line 25; the equivalent global self call is `gh-axi api &#34;/search/issues?q=is%3Apr+is%3Aopen+author%3A&lt;handle&gt;&#34;` (verified global).

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`gh-axi api &#34;/search/issues?q=is%3Apr+is%3Aopen+review-requested%3A%40me+repo%3Aeufforic%2Filert-iac&#34;` — prescribed per-project incoming sweep, returned PRs #45/#44</code>
- <code>`gh-axi api &#34;/search/issues?q=is%3Apr+is%3Aopen+review-requested%3A%40me&#34;` — documented fleet-wide shortcut, 5 PRs across 3 repos</code>
- <code>`gh-axi search prs -R kunchenguid/firstmate --author timidri --state open` and `gh-axi search prs -R eufforic/office.eu --author timidri --state open` — confirms `-R` retargets the sweep per repository</code>
- <code>`gh-axi search prs --repo kunchenguid/firstmate --state open --review timidri` — confirms `--review` is not a requested-reviewer facet</code>
- <code>`gh-axi search prs &#34;review-requested:@me is:open&#34; --repo eufforic/ilert-iac` — confirms the raw qualifier is rejected as an invalid search query</code>
- <code>`gh-axi pr --help` / `ls bin/fm-pr-merge.sh` — landing helpers the skill points at exist</code>
- <code>`claude --print` in a fresh headless session — harness lists `review-round` as user-invocable with its description</code>
- <code>`bash tests/fm-documentation-audiences.test.sh` — 4/4 ok, covers the new documentation-audiences.json entry</code>
- <code>`grep -n &#34;When the captain invokes&#34; AGENTS.md` and README skills-table inspection — trigger line and table row match the /stow pattern</code>

</details>

<details>
<summary>🔧 **Document** - 1 issue found → auto-fixed ✅</summary>

- ℹ️ `.agents/skills/review-round/SKILL.md:24` - The incoming-PR discovery step gives two competing instructions in adjacent sentences: line 24 prescribes the search-API call with a `repo:` qualifier &#34;once per project&#34;, while line 25 says dropping `repo:` sweeps the whole fleet in one call and is &#34;the cheaper way in&#34;. A reader cannot tell which is the procedure and which is the fallback. Commit f539e9c deliberately scoped discovery per repository yet kept the fleet-wide sentence, so resolving this needs the author&#39;s intent: either demote the fleet-wide call to an explicitly optional shortcut (and drop &#34;cheaper way in&#34; as a preference signal), or make it the default and reduce the per-project form to the scoped-round case. Left unedited to avoid overriding intent.

🔧 Fix: clarify review-round PR discovery passes
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
