### PR TITLE
Add verified hermes crewmate harness adapter

### DIFF
--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: harness-adapters
-description: Agent-only reference for firstmate harness operations. Use before spawning or recovering a crewmate or secondmate, handling a trust dialog, sending a harness-specific skill invocation, interrupting or exiting an agent, resuming an exited agent, or verifying a new harness adapter. Contains verified facts for claude, codex, opencode, pi, pi-signed, grok, and kimi.
+description: Agent-only reference for firstmate harness operations. Use before spawning or recovering a crewmate or secondmate, handling a trust dialog, sending a harness-specific skill invocation, interrupting or exiting an agent, resuming an exited agent, or verifying a new harness adapter. Contains verified facts for claude, codex, opencode, pi, pi-signed, grok, kimi, and hermes.
 user-invocable: false
 metadata:
   internal: true
@@ -127,6 +127,7 @@ The supported launch-profile flags below are verified locally; each row records 
 | pi / pi-signed | `--model <model>` | `--thinking <low\|medium\|high\|xhigh\|max>` | Verified 2026-07-27 on Pi and pi-signed 0.82.0. Both expose the same accepted thinking levels and completed the same model-qualified max-thinking smoke. |
 | opencode | `--model <provider/model>` | none for firstmate's interactive launch | Verified on opencode 1.17.6. `opencode run` has `--variant`, but firstmate launches the interactive `opencode --prompt` path, which has no verified effort flag. |
 | kimi | `--model <model>` | none | Verified 2026-07-25 on Kimi Code CLI 0.29.1. |
+| hermes | `-m <model>` | none | Verified 2026-08-03 on Hermes Agent v0.19.0 (2026.7.20). |
 
 The concrete `harness` field owns adapter identity independently of the model provider: `harness=pi` with `model=xai/grok-*` is Pi using xAI, not `harness=grok`, and does not require Grok CLI login; `harness=grok` remains the standalone Grok Build CLI adapter.
 No script resolves that split for you: establish which credential store a tuple reads from the discovery surfaces below plus `quota-axi auth --json`'s per-provider sources, and show that reasoning rather than inferring it from a harness, model, or source name.
@@ -144,6 +145,7 @@ Use the discovery surface in the current authenticated environment because suppo
 | pi / pi-signed | Run the selected executable as `<executable> --list-models [search]`; Pi's installed `docs/models.md` owns how built-in, extension-registered, and custom provider/model entries reach that list. |
 | grok | Run `grok models`, which lists the models available to the current Grok installation and account. |
 | kimi | Run `kimi provider list --json`, which lists the current provider and model configuration. |
+| hermes | Run `hermes model` / `hermes chat --help`; default model comes from user config when `-m` is omitted. |
 
 For an unfamiliar harness or model namespace, establish support and provider identity from that harness's authoritative CLI help, model listing, or current documentation rather than guessing from a name or prefix.
 A listing that reaches the account and does not contain the model is concrete evidence the model is unsupported: block that candidate and quote the result.
@@ -163,6 +165,7 @@ Natural language is acceptable if uncertain.
 - pi and pi-signed: no separate verified skill invocation beyond normal command behavior; use natural language if the exact skill command is uncertain.
 - grok: `/<skill>`, for example `/no-mistakes` (same form as claude). Verified end to end: grok discovers the user-level `no-mistakes` skill, `/no-mistakes` invokes it, and grok drives a real `no-mistakes axi run`. Like codex's `$`/`/` popups, typing `/<skill>` opens grok's slash-autocomplete, so a too-fast Enter selects the popup entry instead of sending, and for an argument-taking command (like `/no-mistakes`'s optional task-first argument) that first Enter only expands the popup selection into an argument-hint placeholder rather than submitting - a genuine second Enter is required (see the grok section below for the 2026-07-03 incident and fix). `fm_tmux_submit_core`'s retried Enter (used by `fm-send` on the tmux backend) handles this through the structural composer reader; the herdr backend needed a dedicated fix (`fm_backend_herdr_composer_state`, docs/herdr-backend.md) because its prior delta-based verification false-positived on that same popup-close content change.
 - kimi: `/<skill>`, for example `/no-mistakes`.
+- hermes: natural language is acceptable; no separate verified slash-skill form beyond ordinary chat commands.
 
 ## Submission acknowledgement hazards
 
@@ -397,3 +400,28 @@ The delivery-only spinner match covers the full moon-phase glyph set rather than
 Each Kimi crew worktree receives a gitignored `.fm-kimi-turnend` token pointer, and the global hook touches that task's `state/<id>.turn-ended` only when the Stop payload's `cwd`, pointer, and registry entry all agree.
 A guarded silent hook cannot be verified from absence of effect, so prove invocation with an unguarded probe before concluding that the hook did not fire.
 The guarded turn-end signal remains a wake notification; standalone Kimi has no busy-state source until one is live-verified.
+
+## hermes (VERIFIED 2026-08-03, Hermes Agent v0.19.0 / 2026.7.20)
+
+Hermes Agent classic REPL launches from the absolute path resolved from `PATH` (`hermes`, then `hermes-agent`).
+
+| Fact | Value |
+|---|---|
+| Binary | Executable `hermes` from `PATH`, then `hermes-agent`; spawning refuses if neither exists. |
+| Launch | `hermes chat --yolo --accept-hooks` plus optional `-m MODEL`; bare launch, then readiness-gated absolute brief pointer delivery. |
+| Busy state | Harness-scoped rendered-tail fallback only (`hermes-regex`): stable ASCII `Ctrl+C cancel`, `msg=interrupt`, and/or `Initializing agent`. Idle is bare `❯` without that interrupt footer. Never classifies another adapter. |
+| Exit command | `/quit` or `/exit` |
+| Interrupt | single `Ctrl+C` while busy (returns to `❯`; shell tools may show exit 130). Prefer interrupt only when the busy footer shows `Ctrl+C cancel` - idle `Ctrl+C` can tear down the session. |
+| Skill invocation | Natural language; no separate verified slash-skill form. |
+| Autonomy | `--yolo` (banner: YOLO mode - all approval prompts bypassed). |
+| Trust dialog | None required for the verified crewmate path inside a worktree. |
+| Environment marker | None found; detection relies on process ancestry argv matching `hermes` / `hermes-agent`, not bare `Python` alone. |
+| Composer | Bare `❯` idle glyph (already an agent prompt glyph in `fm-composer-lib.sh`). Busy footer keeps `❯` beside `msg=interrupt` / `Ctrl+C cancel`. |
+| Effort | No reasoning-effort flag; requested effort is recorded in task metadata but omitted from launch. |
+| Resume | `hermes --resume <session-id>` (id printed on exit). |
+
+`fm-spawn.sh` launches Hermes bare on the classic REPL, waits for bare `❯` or a Welcome/Hermes Agent banner, sends only `Read the brief at <absolute-path> and follow it exactly.`, and requires either busy chrome or an idle composer with the pointer visible before accepting delivery.
+This launch-then-send shape is mandatory because Hermes has no crewmate positional-brief path comparable to Grok/Claude.
+Do **not** launch with modern `--tui` on the verified brew install: it is broken (missing `ui-tui`).
+No turn-end hook is installed; supervision uses the rendered-tail busy fallback plus ordinary status and watcher signals, the same Grok-style posture when structured lifecycle is unavailable.
+Process detection often sees `comm=Python` with argv containing `hermes`; ancestry matching must read argv, never bare Python alone.

--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -409,7 +409,7 @@ Hermes Agent classic REPL launches from the absolute path resolved from `PATH` (
 |---|---|
 | Binary | Executable `hermes` from `PATH`, then `hermes-agent`; spawning refuses if neither exists. |
 | Launch | `hermes chat --yolo --accept-hooks` plus optional `-m MODEL`; bare launch, then readiness-gated absolute brief pointer delivery. |
-| Busy state | Harness-scoped rendered-tail fallback only (`hermes-regex`): stable ASCII `Ctrl+C cancel`, `msg=interrupt`, and/or `Initializing agent`. Idle is bare `❯` without that interrupt footer. Never classifies another adapter. |
+| Busy state | Harness-scoped rendered-tail fallback only (`hermes-regex`): stable ASCII `Ctrl+C cancel`, `msg=interrupt`, and/or `Initializing agent`. Idle requires a bare `❯` row without that interrupt footer; a tail with neither is `unknown`, never idle. Never classifies another adapter. |
 | Exit command | `/quit` or `/exit` |
 | Interrupt | single `Ctrl+C` while busy (returns to `❯`; shell tools may show exit 130). Prefer interrupt only when the busy footer shows `Ctrl+C cancel` - idle `Ctrl+C` can tear down the session. |
 | Skill invocation | Natural language; no separate verified slash-skill form. |
@@ -420,7 +420,9 @@ Hermes Agent classic REPL launches from the absolute path resolved from `PATH` (
 | Effort | No reasoning-effort flag; requested effort is recorded in task metadata but omitted from launch. |
 | Resume | `hermes --resume <session-id>` (id printed on exit). |
 
-`fm-spawn.sh` launches Hermes bare on the classic REPL, waits for bare `❯` or a Welcome/Hermes Agent banner, sends only `Read the brief at <absolute-path> and follow it exactly.`, and requires either busy chrome or an idle composer with the pointer visible before accepting delivery.
+`fm-spawn.sh` launches Hermes bare on the classic REPL, waits for a Welcome to Hermes / Hermes Agent banner, sends only `Read the brief at <absolute-path> and follow it exactly.`, and requires either the post-submit interrupt footer or an idle composer with the pointer visible before accepting delivery.
+Readiness needs that Hermes-only chrome because a bare `❯` is also the default starship/oh-my-zsh shell prompt: a failed launch leaves the pane at the user's own shell, where the pointer would be executed as a command.
+For the same reason `Initializing agent` is startup chrome only and never confirms delivery - it is already in scrollback before the pointer is typed, so a swallowed keystroke would otherwise report a brief that was never delivered.
 This launch-then-send shape is mandatory because Hermes has no crewmate positional-brief path comparable to Grok/Claude.
 Do **not** launch with modern `--tui` on the verified brew install: it is broken (missing `ui-tui`).
 No turn-end hook is installed; supervision uses the rendered-tail busy fallback plus ordinary status and watcher signals, the same Grok-style posture when structured lifecycle is unavailable.

--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -420,7 +420,8 @@ Hermes Agent classic REPL launches from the absolute path resolved from `PATH` (
 | Effort | No reasoning-effort flag; requested effort is recorded in task metadata but omitted from launch. |
 | Resume | `hermes --resume <session-id>` (id printed on exit). |
 
-`fm-spawn.sh` launches Hermes bare on the classic REPL, waits for a Welcome to Hermes / Hermes Agent banner, sends only `Read the brief at <absolute-path> and follow it exactly.`, and requires either the post-submit interrupt footer or an idle composer with the pointer visible before accepting delivery.
+`fm-spawn.sh` launches Hermes bare on the classic REPL, waits for a Welcome to Hermes / Hermes Agent banner while `fm_backend_agent_state` reports a live agent, sends only `Read the brief at <absolute-path> and follow it exactly.`, and requires a still-live agent plus either the post-submit interrupt footer or an idle composer with the pointer visible before accepting delivery.
+Banner text left in scrollback after the process exits is not readiness or delivery proof.
 Readiness needs that Hermes-only chrome because a bare `❯` is also the default starship/oh-my-zsh shell prompt: a failed launch leaves the pane at the user's own shell, where the pointer would be executed as a command.
 For the same reason `Initializing agent` is startup chrome only and never confirms delivery - it is already in scrollback before the pointer is typed, so a swallowed keystroke would otherwise report a brief that was never delivered.
 This launch-then-send shape is mandatory because Hermes has no crewmate positional-brief path comparable to Grok/Claude.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -164,7 +164,7 @@ A silent bootstrap section needs no action; for any printed actionable diagnosti
 ## 4. Harness and runtime dispatch
 
 Load `harness-adapters` before every spawn or recovery and before trust handling, skill invocation, interrupt, exit, resume, or adapter verification.
-The verified harnesses are `claude`, `codex`, `opencode`, `pi`, `pi-signed`, `grok`, and `kimi`; never dispatch on an unverified adapter.
+The verified harnesses are `claude`, `codex`, `opencode`, `pi`, `pi-signed`, `grok`, `kimi`, and `hermes`; never dispatch on an unverified adapter.
 If static `config/crew-harness` or `config/secondmate-harness` names an unverified adapter, report it and fall back only to a verified adapter rather than launching it.
 
 `docs/configuration.md` owns dispatch-profile and runtime-backend schemas, `bin/fm-harness.sh` owns static resolution, and `bin/fm-spawn.sh` owns launch flags and fail-closed validation.

--- a/bin/backends/tmux.sh
+++ b/bin/backends/tmux.sh
@@ -160,7 +160,7 @@ fm_backend_tmux_classify_process_name() {  # <path> [argv0] -> agent|shell|other
   base=${path##*/}
   base=${base#-}
   case "$base" in
-    *claude*|*codex*|*opencode*|*grok*|*kimi*|pi|pi-signed|pi-launcher|Pi) printf 'agent' ;;
+    *claude*|*codex*|*opencode*|*grok*|*kimi*|*hermes*|pi|pi-signed|pi-launcher|Pi) printf 'agent' ;;
     zsh|bash|sh|dash|ash|ksh|mksh|tcsh|csh|fish) printf 'shell' ;;
     *)
       if fm_harness_path_name "$path" >/dev/null || fm_harness_path_name "$argv0" >/dev/null; then
@@ -210,7 +210,7 @@ fm_backend_tmux_foreground_comms() {  # <target>
 }
 
 fm_backend_tmux_foreground_argv0s() {  # <target>
-  local target=$1 tty pid pgid tpgid comm args argv0
+  local target=$1 tty pid pgid tpgid comm args argv0 token
   tty=$(tmux display-message -p -t "$target" '#{pane_tty}' 2>/dev/null) || return 0
   [ -n "$tty" ] || return 0
   LC_ALL=C ps -t "${tty#/dev/}" -o pid=,pgid=,tpgid=,comm= 2>/dev/null \
@@ -221,6 +221,17 @@ fm_backend_tmux_foreground_argv0s() {  # <target>
         args=${args#"${args%%[![:space:]]*}"}
         argv0=${args%%[[:space:]]*}
         [ -n "$argv0" ] && printf '%s\n' "$argv0"
+        # Interpreter-wrapped harnesses (Hermes: comm/argv0=Python, later argv
+        # carries /.../hermes) need those later path tokens classified too.
+        # shellcheck disable=SC2086 # deliberate word-split of ps args tokens
+        for token in $args; do
+          [ "$token" = "$argv0" ] && continue
+          case "$token" in
+            /*/*hermes*|/*/*hermes-agent*|*hermes*|*hermes-agent*)
+              printf '%s\n' "$token"
+              ;;
+          esac
+        done
       done
 }
 

--- a/bin/backends/tmux.sh
+++ b/bin/backends/tmux.sh
@@ -160,7 +160,7 @@ fm_backend_tmux_classify_process_name() {  # <path> [argv0] -> agent|shell|other
   base=${path##*/}
   base=${base#-}
   case "$base" in
-    *claude*|*codex*|*opencode*|*grok*|*kimi*|*hermes*|pi|pi-signed|pi-launcher|Pi) printf 'agent' ;;
+    *claude*|*codex*|*opencode*|*grok*|*kimi*|hermes|hermes-agent|pi|pi-signed|pi-launcher|Pi) printf 'agent' ;;
     zsh|bash|sh|dash|ash|ksh|mksh|tcsh|csh|fish) printf 'shell' ;;
     *)
       if fm_harness_path_name "$path" >/dev/null || fm_harness_path_name "$argv0" >/dev/null; then
@@ -223,13 +223,29 @@ fm_backend_tmux_foreground_argv0s() {  # <target>
         [ -n "$argv0" ] && printf '%s\n' "$argv0"
         # Interpreter-wrapped harnesses (Hermes: comm/argv0=Python, later argv
         # carries /.../hermes) need those later path tokens classified too.
+        # Only an interpreter's own argv is scanned, and only an absolute path
+        # whose basename is exactly the harness executable counts: any argv
+        # token can name a hermes-ish file (`vim ~/notes/hermes-todo.md`), and
+        # calling that an agent would report a live harness on an empty pane
+        # and suppress recovery forever.
+        case "${comm##*/}" in
+          python*|Python*|node*) ;;
+          *)
+            case "${argv0##*/}" in
+              python*|Python*|node*) ;;
+              *) continue ;;
+            esac
+            ;;
+        esac
         # shellcheck disable=SC2086 # deliberate word-split of ps args tokens
         for token in $args; do
           [ "$token" = "$argv0" ] && continue
           case "$token" in
-            /*/*hermes*|/*/*hermes-agent*|*hermes*|*hermes-agent*)
-              printf '%s\n' "$token"
-              ;;
+            /*) ;;
+            *) continue ;;
+          esac
+          case "${token##*/}" in
+            hermes|hermes-agent) printf '%s\n' "$token" ;;
           esac
         done
       done

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -583,7 +583,7 @@ secondmate_liveness_sweep() {
     [ -n "$target" ] || target="$window"
     agent_state=$(fm_backend_agent_state "$backend" "$target" 2>/dev/null) || agent_state=unreadable
     case "$harness" in
-      claude|codex|opencode|pi|pi-signed|grok|kimi) ;;
+      claude|codex|opencode|pi|pi-signed|grok|kimi|hermes) ;;
       *)
         case "$agent_state" in dead|missing) agent_state=unverified-harness ;; esac
         ;;
@@ -888,7 +888,7 @@ crew_dispatch_validate() {
     return 0
   fi
   err=$(jq -r '
-    def verified($h): ["claude","codex","opencode","pi","pi-signed","grok","kimi"] | index($h);
+    def verified($h): ["claude","codex","opencode","pi","pi-signed","grok","kimi","hermes"] | index($h);
     def effort_ok($h; $e):
       if $e == null then true
       elif ($e | type) != "string" then false
@@ -896,7 +896,7 @@ crew_dispatch_validate() {
       elif $h == "codex" then (["low","medium","high","xhigh"] | index($e))
       elif $h == "grok" then (["low","medium","high"] | index($e))
       elif $h == "pi" or $h == "pi-signed" then (["low","medium","high","xhigh","max"] | index($e))
-      elif $h == "opencode" or $h == "kimi" then false
+      elif $h == "opencode" or $h == "kimi" or $h == "hermes" then false
       else true
       end;
     def profiles($value):

--- a/bin/fm-busy-lib.sh
+++ b/bin/fm-busy-lib.sh
@@ -39,7 +39,7 @@
 #   fm-interrupt     a firstmate-controlled interruption of the worker
 #   fm-recovery      a documented recovery reset after relaunch
 # Classifier-only sources (never written into a record):
-#   endpoint-gone, herdr-native, grok-regex, missing, malformed,
+#   endpoint-gone, herdr-native, grok-regex, hermes-regex, missing, malformed,
 #   gen-mismatch, source-mismatch, kimi-unverified, codex-unverified,
 #   capture-failed, no-target
 #
@@ -50,15 +50,15 @@
 #   3. a valid, gen-matching, source-trusted record -> its state and source
 #   4. no record at all: herdr's native busy verdict is trusted as busy
 #      (generation state is sufficient for busy, not for idle), then the
-#      Grok-only temporary regex fallback classifies a grok task from its
-#      rendered tail, then unknown missing
+#      harness-scoped temporary regex fallbacks classify a grok or hermes
+#      task from its rendered tail, then unknown missing
 #   5. malformed, stale, or untrusted records -> unknown, never a fallback
-# The Grok arm is the ONLY rendered-text classification that survives the
-# redesign, because Grok's structured lifecycle was not credited-live-verified
-# in the approved audit; it is scoped to harness=grok and can never classify
-# another adapter. The delivery guards in bin/fm-tmux-lib.sh match rendered
-# footers for submit acknowledgement and away-mode supervisor injection only;
-# neither is a recorded worker state source.
+# The Grok and Hermes arms are the ONLY rendered-text classifications that
+# survive the redesign: each lacks a live-verified structured lifecycle, and
+# each is scoped to its own harness= value so it can never classify another
+# adapter. The delivery guards in bin/fm-tmux-lib.sh match rendered footers
+# for submit acknowledgement and away-mode supervisor injection only; neither
+# is a recorded worker state source.
 #
 # Codex negotiation (fm_busy_codex_appserver_observable,
 # fm_busy_codex_hooks_verified): the approved contract prefers Codex's
@@ -161,8 +161,9 @@ fm_busy_current_gen() {  # <state-dir> <id>
 # fm_busy_sources_for_harness: the semantic sources trusted to classify a
 # task recorded with <harness>. One line, space-separated, possibly empty.
 # The firstmate-owned sources are appended for every converted adapter.
-# Grok deliberately trusts nothing: it has no semantic writer yet, and its
-# temporary rendered-tail fallback lives in the classifier, not in records.
+# Grok and Hermes deliberately trust nothing: neither has a semantic writer
+# yet, and each temporary rendered-tail fallback lives in the classifier,
+# not in records.
 fm_busy_sources_for_harness() {  # <harness>
   local adapter=
   case "${1:-}" in
@@ -255,12 +256,24 @@ fm_busy_grok_tail_busy() {
     | grep -qiE "${FM_BUSY_REGEX:-${FM_TMUX_GROK_BUSY_REGEX_DEFAULT:-Ctrl\\+c:cancel}}"
 }
 
+# fm_busy_hermes_tail_busy: the Hermes-only temporary rendered-tail fallback.
+# Consumes the tail on stdin; 0 when Hermes's verified busy signature matches.
+# Prefer stable ASCII from the classic REPL (Hermes Agent v0.19.0, 2026-08-03):
+# mid-turn footer Ctrl+C cancel and/or msg=interrupt, plus startup
+# Initializing agent. Idle is a bare ❯ without those tokens. Never match bare
+# Python, timer glyphs alone, or another harness's footer. FM_BUSY_REGEX still
+# globally overrides, matching the Grok arm.
+fm_busy_hermes_tail_busy() {
+  grep -v '^[[:space:]]*$' | tail -12 \
+    | grep -qiE "${FM_BUSY_REGEX:-${FM_TMUX_HERMES_BUSY_REGEX_DEFAULT:-Ctrl\\+C cancel|msg=interrupt|Initializing agent}}"
+}
+
 # fm_busy_classify: semantic classification for a task whose endpoint the
 # caller has already established as present. Prints "<verdict> <source>":
 # busy|idle|unknown plus the producing source (see header). Never probes
 # process state. <tail40> is optional pre-captured plain output used only by
-# the Grok arm; when absent the Grok arm captures through fm_backend_capture
-# if available, else reports unknown capture-failed.
+# the Grok/Hermes arms; when absent those arms capture through
+# fm_backend_capture if available, else report unknown capture-failed.
 fm_busy_classify() {  # <backend> <target> <harness> <id> <state-dir> [tail40]
   local backend=$1 target=$2 harness=$3 id=$4 state=$5 tail40=${6-}
   local out rc r_state r_source native
@@ -327,6 +340,25 @@ fm_busy_classify() {  # <backend> <target> <harness> <id> <state-dir> [tail40]
       fi
       return 0
       ;;
+    hermes*)
+      if [ -z "$tail40" ]; then
+        if command -v fm_backend_capture >/dev/null 2>&1; then
+          tail40=$(fm_backend_capture "$backend" "$target" 40 2>/dev/null) || {
+            printf 'unknown capture-failed'
+            return 0
+          }
+        else
+          printf 'unknown capture-failed'
+          return 0
+        fi
+      fi
+      if printf '%s' "$tail40" | fm_busy_hermes_tail_busy; then
+        printf 'busy hermes-regex'
+      else
+        printf 'idle hermes-regex'
+      fi
+      return 0
+      ;;
   esac
   printf 'unknown missing'
 }
@@ -350,7 +382,7 @@ fm_busy_classify_live() {  # <backend> <target> <harness> <id> <state-dir> [expe
 # fm_busy_classify_meta: classify a task from its recorded metadata, so every
 # consumer resolves backend, target, and harness the same way instead of
 # re-deriving them. Requires fm-backend.sh to be sourced. <tail40> is
-# optional pre-captured plain output reused by the Grok arm.
+# optional pre-captured plain output reused by the Grok/Hermes arms.
 fm_busy_classify_meta() {  # <meta-file> <id> <state-dir> [tail40]
   local meta=$1 id=$2 state=$3 tail40=${4-} backend target harness
   [ -f "$meta" ] || { printf 'unknown missing'; return 0; }

--- a/bin/fm-busy-lib.sh
+++ b/bin/fm-busy-lib.sh
@@ -268,6 +268,16 @@ fm_busy_hermes_tail_busy() {
     | grep -qiE "${FM_BUSY_REGEX:-${FM_TMUX_HERMES_BUSY_REGEX_DEFAULT:-Ctrl\\+C cancel|msg=interrupt|Initializing agent}}"
 }
 
+# fm_busy_hermes_tail_idle: positive evidence that a Hermes pane is between
+# turns. Consumes the tail on stdin; 0 only when the idle composer - a bare ❯
+# row - is present. Absence of the busy signature is not idleness: a scrolled
+# tool output, a pager, or a crashed REPL shows neither, and calling those idle
+# would tell the supervisor a mid-turn or dead crewmate is done.
+fm_busy_hermes_tail_idle() {
+  grep -v '^[[:space:]]*$' | tail -12 \
+    | grep -qE '^[[:space:]]*❯[[:space:]]*$'
+}
+
 # fm_busy_classify: semantic classification for a task whose endpoint the
 # caller has already established as present. Prints "<verdict> <source>":
 # busy|idle|unknown plus the producing source (see header). Never probes
@@ -354,8 +364,10 @@ fm_busy_classify() {  # <backend> <target> <harness> <id> <state-dir> [tail40]
       fi
       if printf '%s' "$tail40" | fm_busy_hermes_tail_busy; then
         printf 'busy hermes-regex'
-      else
+      elif printf '%s' "$tail40" | fm_busy_hermes_tail_idle; then
         printf 'idle hermes-regex'
+      else
+        printf 'unknown hermes-regex'
       fi
       return 0
       ;;

--- a/bin/fm-crew-state.sh
+++ b/bin/fm-crew-state.sh
@@ -153,15 +153,15 @@ pane_readable() {  # <target>
 }
 # crew_busy_verdict: the crew's semantic busy state from the one contract
 # owner (bin/fm-busy-lib.sh), as "<busy|idle|unknown> <source>". A converted
-# adapter answers from its own lifecycle record; Grok answers from its
-# isolated rendered-tail fallback; a herdr crew's native `busy` is accepted
-# when no record exists, but its native `idle` is NOT, because agent.get
-# reports generation state (idle while a crew blocks on its own long-running
-# foreground tool call) rather than turn state.
+# adapter answers from its own lifecycle record; Grok and Hermes answer from
+# their harness-scoped rendered-tail fallbacks; a herdr crew's native `busy`
+# is accepted when no record exists, but its native `idle` is NOT, because
+# agent.get reports generation state (idle while a crew blocks on its own
+# long-running foreground tool call) rather than turn state.
 crew_busy_verdict() {  # <target>
   local tail40=''
   case "$HARNESS" in
-    grok*) tail40=$(fm_backend_capture "$TASK_BACKEND" "$1" 40 "$EXPECTED_LABEL" 2>/dev/null) || tail40='' ;;
+    grok*|hermes*) tail40=$(fm_backend_capture "$TASK_BACKEND" "$1" 40 "$EXPECTED_LABEL" 2>/dev/null) || tail40='' ;;
   esac
   fm_busy_classify "$TASK_BACKEND" "$1" "$HARNESS" "$ID" "$STATE" "$tail40"
 }

--- a/bin/fm-harness.sh
+++ b/bin/fm-harness.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Detect the agent harness this process tree runs on.
-# Usage: fm-harness.sh                  print own harness: claude|codex|opencode|pi|pi-signed|grok|kimi|unknown
+# Usage: fm-harness.sh                  print own harness: claude|codex|opencode|pi|pi-signed|grok|kimi|hermes|unknown
 #        fm-harness.sh crew             print the effective CREWMATE harness
 #                                        (config/crew-harness; "default" resolves to own)
 #        fm-harness.sh secondmate       print the harness the PRIMARY uses to launch
@@ -31,10 +31,11 @@ detect_own() {
   # Layer 1: environment markers for verified harnesses.
   # Keep marker detection before ancestry detection as an explicit precedence rule.
   # Only claude, pi, and grok set verified markers of their own; codex, opencode,
-  # and kimi are markerless, so a foreign marker retained in a terminal
+  # kimi, and hermes are markerless, so a foreign marker retained in a terminal
   # multiplexer's stored environment can silently misidentify one of them before
   # ancestry is consulted. This is a precedence hazard, not evidence that
   # CLAUDECODE inheritance into a kimi child was observed; it was not observed.
+  # Hermes live probe (v0.19.0, 2026-08-03) found no reliable HERMES_*=1 child env.
   [ "${CLAUDECODE:-}" = "1" ] && { echo claude; return; }
   if [ "${PI_CODING_AGENT:-}" = "true" ]; then
     if [ "${FM_PI_HARNESS:-}" = pi-signed ]; then echo pi-signed; else echo pi; fi
@@ -54,16 +55,20 @@ detect_own() {
       *opencode*) echo opencode; return ;;
       *grok*) echo grok; return ;;
       kimi) echo kimi; return ;;
+      hermes|hermes-agent) echo hermes; return ;;
       pi-signed) echo pi; return ;;
       pi) echo pi; return ;;
-      node*|python*)
-        # Bare interpreter: match the harness name in its script path.
+      node*|python*|Python*)
+        # Bare interpreter: match the harness name in its script path / argv.
+        # Hermes often shows comm=Python (capital P) with argv containing hermes;
+        # never treat bare Python alone as hermes.
         args=$(ps -o args= -p "$pid" 2>/dev/null)
         case "$args" in
           *claude*) echo claude; return ;;
           *codex*) echo codex; return ;;
           *opencode*) echo opencode; return ;;
           *grok*) echo grok; return ;;
+          *hermes*|*hermes-agent*) echo hermes; return ;;
           *" pi "*|*/pi) echo pi; return ;;
         esac ;;
     esac

--- a/bin/fm-remote-doctor.sh
+++ b/bin/fm-remote-doctor.sh
@@ -56,7 +56,7 @@ FM_ROOT="${FM_ROOT_OVERRIDE:-$(CDPATH='' cd "$SCRIPT_DIR/.." && pwd -P)}"
 # shellcheck source=bin/fm-tasks-axi-lib.sh
 . "$SCRIPT_DIR/fm-tasks-axi-lib.sh"
 REQUIRED_TOOLS=(git jq herdr tasks-axi treehouse)
-HARNESS_TOOLS=(claude codex opencode pi pi-signed grok kimi)
+HARNESS_TOOLS=(claude codex opencode pi pi-signed grok kimi hermes)
 OPTIONAL_TOOLS=(tmux no-mistakes gh)
 LAUNCH_AGENT_LABEL=dev.firstmate.herdr.fm-remote
 # The dedicated remote-secondmate session. The user's interactive Herdr work

--- a/bin/fm-remote-secondmate-control.sh
+++ b/bin/fm-remote-secondmate-control.sh
@@ -138,7 +138,7 @@ cmd_launch() {
 
   validate_id "$id"
   validate_home "$id"
-  case "$harness" in claude|codex|opencode|pi|pi-signed|grok|kimi) ;; *) die "unverified remote secondmate harness: $harness" ;; esac
+  case "$harness" in claude|codex|opencode|pi|pi-signed|grok|kimi|hermes) ;; *) die "unverified remote secondmate harness: $harness" ;; esac
   case "$effort" in -|low|medium|high|xhigh|max) ;; *) die "invalid remote secondmate effort: $effort" ;; esac
   # Herdr is required on this host, not merely preferred: its server belongs to
   # the GUI login session, so the endpoint survives every SSH disconnection that

--- a/bin/fm-session-lock-lib.sh
+++ b/bin/fm-session-lock-lib.sh
@@ -9,13 +9,14 @@
 # This file is sourced by scripts and has no side effects on source.
 
 # Known harness command names; extend when a new adapter is verified.
-FM_HARNESS_RE='claude|codex|opencode|grok|kimi|^pi$|^pi-signed$'
+FM_HARNESS_RE='claude|codex|opencode|grok|kimi|hermes-agent|hermes|^pi$|^pi-signed$'
 
 # The same harnesses as exact executable names. Keep in sync with
 # FM_HARNESS_RE. Used only for the stricter path evidence below, where the
 # loose regex would also match ordinary firstmate paths such as
-# bin/fm-claude-stop-autoarm.sh.
-FM_HARNESS_NAMES=(claude codex opencode grok kimi pi-signed pi)
+# bin/fm-claude-stop-autoarm.sh. hermes-agent is listed before hermes so a path
+# component match prefers the longer brew package name.
+FM_HARNESS_NAMES=(claude codex opencode grok kimi hermes-agent hermes pi-signed pi)
 
 # Print the exact harness name carried by executable path $1 - its own basename
 # or any directory component - or return 1.
@@ -62,9 +63,11 @@ fm_harness_process_matches() {  # <comm> <args>
     case "$name" in claude) FM_HARNESS_IS_CLAUDE=1 ;; esac
     return 0
   fi
-  # Bare interpreter (e.g. node): match the harness name in its script path.
+  # Bare interpreter (e.g. node/Python): match the harness name in its script
+  # path or argv. Include capital-P Python because Hermes Agent reports that
+  # exact comm on macOS while argv carries hermes.
   case "$comm" in
-    *node*|*python*)
+    *node*|*python*|*Python*)
       if printf '%s' "$args" | grep -qE "$FM_HARNESS_RE"; then
         case "$args" in *claude*) FM_HARNESS_IS_CLAUDE=1 ;; esac
         return 0

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -83,7 +83,7 @@
 #   profile consultation. A --secondmate spawn is exempt and resolves the SECONDMATE
 #   harness (config/secondmate-harness -> config/crew-harness -> own), so the
 #   secondmate-vs-crewmate split is DURABLE across every respawn (recovery,
-#   /updatefirstmate, restart). A bare adapter name (claude|codex|opencode|pi|pi-signed|grok|kimi)
+#   /updatefirstmate, restart). A bare adapter name (claude|codex|opencode|pi|pi-signed|grok|kimi|hermes)
 #   overrides it for this spawn (either kind). A non-flag string containing
 #   whitespace is treated as a RAW launch command - the escape hatch for verifying
 #   new adapters. pi-signed launches that exact executable name from PATH and
@@ -376,7 +376,7 @@ spawn_remote_secondmate() {
     harness=$("$FM_ROOT/bin/fm-harness.sh" secondmate)
   fi
   case "$harness" in
-    claude|codex|opencode|pi|pi-signed|grok|kimi) ;;
+    claude|codex|opencode|pi|pi-signed|grok|kimi|hermes) ;;
     *)
       fm_lock_release "$registry_lock" || true
       fm_lock_release "$SPAWN_TASK_LOCK" || true
@@ -783,7 +783,7 @@ FIRSTMATE_HOME=
 
 if [ "$KIND" = secondmate ]; then
   case "${POS[1]:-}" in
-    ''|claude|codex|opencode|pi|pi-signed|grok|kimi)
+    ''|claude|codex|opencode|pi|pi-signed|grok|kimi|hermes)
       ARG3=${POS[1]:-}
       ;;
     *' '*)
@@ -849,6 +849,11 @@ launch_template() {
     # Its turn-end signal is a globally configured Stop hook plus a guarded
     # per-task worktree token, so no launch placeholder belongs here.
     kimi) printf '%s' '__KIMIBIN__ __MODELFLAG__--auto' ;;
+    # Hermes Agent (classic REPL): no positional brief; launch bare with YOLO
+    # autonomy, wait for the idle composer, then deliver an absolute brief
+    # pointer. Modern --tui is broken on the verified brew install (missing
+    # ui-tui), so firstmate never selects it. No turn-end hook is wired yet.
+    hermes) printf '%s' '__HERMESBIN__ chat --yolo --accept-hooks __MODELFLAG__' ;;
     *) return 1 ;;
   esac
 }
@@ -957,12 +962,39 @@ resolve_kimi_binary() {
   return 1
 }
 
+# Resolve hermes or hermes-agent from PATH to an absolute executable.
+# No HOME fallback: both brew and pip expose one of those names on PATH.
+resolve_hermes_binary() {
+  local name candidate dir
+  for name in hermes hermes-agent; do
+    candidate=$(command -v "$name" 2>/dev/null || true)
+    if [ -n "$candidate" ] && [ -x "$candidate" ]; then
+      case "$candidate" in
+        /*) printf '%s\n' "$candidate"; return 0 ;;
+        *)
+          dir=$(cd "$(dirname "$candidate")" 2>/dev/null && pwd -P) || dir=
+          if [ -n "$dir" ]; then
+            printf '%s/%s\n' "$dir" "$(basename "$candidate")"
+            return 0
+          fi
+          ;;
+      esac
+    fi
+  done
+  echo "error: hermes executable not found; searched PATH for 'hermes' then 'hermes-agent'" >&2
+  return 1
+}
+
 model_flag_for_harness() {
   local harness=$1 model=$2
   [ -n "$model" ] && [ "$model" != default ] || return 0
   case "$harness" in
     claude|codex|opencode|pi|pi-signed|grok|kimi)
       printf -- '--model %s ' "$(shell_quote "$model")"
+      ;;
+    hermes)
+      # Hermes accepts -m/--model; firstmate uses the short form verified live.
+      printf -- '-m %s ' "$(shell_quote "$model")"
       ;;
   esac
 }
@@ -1003,8 +1035,8 @@ effort_flag_for_harness() {
     # opencode's interactive `opencode --prompt` launch has a verified --model
     # flag but no verified effort flag. Its `opencode run --variant` flag belongs
     # to a different, non-interactive launch mode, so fm-spawn does not pass it.
-    # kimi likewise has no reasoning-effort flag; the requested axis stays in
-    # task metadata but never reaches the launch command.
+    # kimi and hermes likewise have no reasoning-effort flag; the requested axis
+    # stays in task metadata but never reaches the launch command.
   esac
 }
 
@@ -1018,6 +1050,10 @@ case "$LAUNCH" in
         exit 1
       }
     fi
+    ;;
+  *__HERMESBIN__*)
+    HERMES_BIN=$(resolve_hermes_binary) || exit 1
+    LAUNCH=${LAUNCH//__HERMESBIN__/$(shell_quote "$HERMES_BIN")}
     ;;
 esac
 
@@ -1693,6 +1729,59 @@ kimi_spawn_fail() {  # <detail>
   echo "error: $1; inspect window $T" >&2
 }
 
+hermes_capture() {
+  fm_backend_capture "$BACKEND" "$T" 120 "$W" 2>/dev/null || true
+}
+
+# Idle Hermes classic-REPL composer is a bare ❯ row (verified Hermes Agent
+# v0.19.0). Busy mid-turn footers keep ❯ but add msg=interrupt / Ctrl+C cancel,
+# so readiness requires the bare form.
+hermes_capture_has_idle_composer() {  # <plain-pane-capture>
+  printf '%s\n' "$1" | grep -Eq '^[[:space:]]*❯[[:space:]]*$'
+}
+
+hermes_wait_for_ready() {
+  local pane i=0 max=${FM_HERMES_READY_POLLS:-60} interval=${FM_HERMES_POLL_INTERVAL:-0.5}
+  while [ "$i" -lt "$max" ]; do
+    pane=$(hermes_capture)
+    if printf '%s\n' "$pane" | grep -qiE 'Welcome to Hermes|Hermes Agent' \
+       || hermes_capture_has_idle_composer "$pane"; then
+      return 0
+    fi
+    i=$((i + 1))
+    [ "$i" -ge "$max" ] || sleep "$interval"
+  done
+  return 1
+}
+
+hermes_delivery_is_confirmed() {  # <plain-pane-capture>
+  local pane=$1
+  # Started working on the brief: stable ASCII busy chrome from the verified TUI.
+  if printf '%s\n' "$pane" | grep -qiE 'Ctrl\+C cancel|msg=interrupt|Initializing agent'; then
+    return 0
+  fi
+  # Or back at idle with the pointer visible in scrollback.
+  hermes_capture_has_idle_composer "$pane" || return 1
+  printf '%s\n' "$pane" | grep -Fq 'Read the brief at' || return 1
+  return 0
+}
+
+hermes_wait_for_delivery() {
+  local pane i=0 max=${FM_HERMES_DELIVERY_POLLS:-40} interval=${FM_HERMES_POLL_INTERVAL:-0.5}
+  while [ "$i" -lt "$max" ]; do
+    pane=$(hermes_capture)
+    hermes_delivery_is_confirmed "$pane" && return 0
+    i=$((i + 1))
+    [ "$i" -ge "$max" ] || sleep "$interval"
+  done
+  return 1
+}
+
+hermes_spawn_fail() {  # <detail>
+  printf 'failed: %s\n' "$1" >> "$STATE/$ID.status"
+  echo "error: $1; inspect window $T" >&2
+}
+
 if [ "$KIND" != secondmate ] && [ "$BACKEND" != orca ]; then
   spawn_send_text_line "$WT_TARGET" 'treehouse get'
 
@@ -2163,6 +2252,30 @@ if [ "$HARNESS" = kimi ]; then
   fi
   if ! kimi_wait_for_delivery; then
     kimi_spawn_fail "kimi brief pointer delivery was not confirmed"
+    exit 1
+  fi
+fi
+if [ "$HARNESS" = hermes ]; then
+  if ! hermes_wait_for_ready; then
+    hermes_spawn_fail "hermes did not show a verified ready signal before brief delivery"
+    exit 1
+  fi
+  HERMES_POINTER="Read the brief at $BRIEF_REAL and follow it exactly."
+  HERMES_SUBMIT_RETRIES=${FM_HERMES_SUBMIT_RETRIES:-3}
+  HERMES_SUBMIT_SLEEP=${FM_HERMES_SUBMIT_SLEEP:-${FM_HERMES_POLL_INTERVAL:-0.5}}
+  HERMES_SUBMIT_SETTLE=${FM_HERMES_SUBMIT_SETTLE:-0}
+  HERMES_SUBMIT_VERDICT=$(fm_backend_send_text_submit \
+    "$BACKEND" "$T" "$HERMES_POINTER" "$HERMES_SUBMIT_RETRIES" \
+    "$HERMES_SUBMIT_SLEEP" "$HERMES_SUBMIT_SETTLE" "$W") || {
+    hermes_spawn_fail "hermes brief pointer could not be submitted"
+    exit 1
+  }
+  if [ "$HERMES_SUBMIT_VERDICT" = send-failed ]; then
+    hermes_spawn_fail "hermes brief pointer could not be submitted"
+    exit 1
+  fi
+  if ! hermes_wait_for_delivery; then
+    hermes_spawn_fail "hermes brief pointer delivery was not confirmed"
     exit 1
   fi
 fi

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1740,12 +1740,19 @@ hermes_capture_has_idle_composer() {  # <plain-pane-capture>
   printf '%s\n' "$1" | grep -Eq '^[[:space:]]*❯[[:space:]]*$'
 }
 
+# A bare ❯ is also the default starship/oh-my-zsh shell prompt, so it can never
+# be readiness on its own: a failed `hermes chat` launch leaves the pane at the
+# user's own shell, where the pointer would be executed as a command. Readiness
+# requires Hermes-only startup chrome.
+hermes_capture_has_hermes_chrome() {  # <plain-pane-capture>
+  printf '%s\n' "$1" | grep -qiE 'Welcome to Hermes|Hermes Agent'
+}
+
 hermes_wait_for_ready() {
   local pane i=0 max=${FM_HERMES_READY_POLLS:-60} interval=${FM_HERMES_POLL_INTERVAL:-0.5}
   while [ "$i" -lt "$max" ]; do
     pane=$(hermes_capture)
-    if printf '%s\n' "$pane" | grep -qiE 'Welcome to Hermes|Hermes Agent' \
-       || hermes_capture_has_idle_composer "$pane"; then
+    if hermes_capture_has_hermes_chrome "$pane"; then
       return 0
     fi
     i=$((i + 1))
@@ -1756,8 +1763,11 @@ hermes_wait_for_ready() {
 
 hermes_delivery_is_confirmed() {  # <plain-pane-capture>
   local pane=$1
-  # Started working on the brief: stable ASCII busy chrome from the verified TUI.
-  if printf '%s\n' "$pane" | grep -qiE 'Ctrl\+C cancel|msg=interrupt|Initializing agent'; then
+  # Started working on the brief: post-submit mid-turn footer from the verified
+  # TUI. Startup chrome such as Initializing agent is deliberately absent here:
+  # it is already in scrollback before the pointer is ever typed, so it would
+  # confirm a delivery that never happened.
+  if printf '%s\n' "$pane" | grep -qiE 'Ctrl\+C cancel|msg=interrupt'; then
     return 0
   fi
   # Or back at idle with the pointer visible in scrollback.

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1748,11 +1748,22 @@ hermes_capture_has_hermes_chrome() {  # <plain-pane-capture>
   printf '%s\n' "$1" | grep -qiE 'Welcome to Hermes|Hermes Agent'
 }
 
+# Scrollback alone is not proof the REPL is still alive: hermes can print its
+# banner and then exit, leaving Welcome/Hermes Agent text while the pane is a
+# bare shell. Gate send and idle delivery on a live agent process (tmux classifies
+# bare shell as shell/dead, not agent).
+hermes_agent_is_live() {
+  case "$(fm_backend_agent_state "$BACKEND" "$T")" in
+    alive) return 0 ;;
+  esac
+  return 1
+}
+
 hermes_wait_for_ready() {
   local pane i=0 max=${FM_HERMES_READY_POLLS:-60} interval=${FM_HERMES_POLL_INTERVAL:-0.5}
   while [ "$i" -lt "$max" ]; do
     pane=$(hermes_capture)
-    if hermes_capture_has_hermes_chrome "$pane"; then
+    if hermes_capture_has_hermes_chrome "$pane" && hermes_agent_is_live; then
       return 0
     fi
     i=$((i + 1))
@@ -1763,6 +1774,9 @@ hermes_wait_for_ready() {
 
 hermes_delivery_is_confirmed() {  # <plain-pane-capture>
   local pane=$1
+  # A dead/exited agent must never confirm delivery, even if scrollback still
+  # shows the pointer echo and a shell ❯.
+  hermes_agent_is_live || return 1
   # Started working on the brief: post-submit mid-turn footer from the verified
   # TUI. Startup chrome such as Initializing agent is deliberately absent here:
   # it is already in scrollback before the pointer is ever typed, so it would

--- a/bin/fm-tmux-lib.sh
+++ b/bin/fm-tmux-lib.sh
@@ -82,13 +82,17 @@
 # busy signals on their own.
 # The full moon-phase set remains locale- and emoji-font-sensitive because Kimi
 # exposes no stable ASCII busy token.
-FM_TMUX_BUSY_REGEX_DEFAULT='esc (to )?interrupt|Working\.\.\.|Ctrl\+c:cancel'
+FM_TMUX_BUSY_REGEX_DEFAULT='esc (to )?interrupt|Working\.\.\.|Ctrl\+c:cancel|Ctrl\+C cancel|msg=interrupt'
 FM_TMUX_CLAUDE_BUSY_REGEX_DEFAULT='esc to interrupt|…[[:space:]]+\([0-9]+[smh]'
 FM_TMUX_CODEX_BUSY_REGEX_DEFAULT='esc to interrupt'
 FM_TMUX_OPENCODE_BUSY_REGEX_DEFAULT='esc interrupt'
 FM_TMUX_PI_BUSY_REGEX_DEFAULT='Working\.\.\.'
 FM_TMUX_GROK_BUSY_REGEX_DEFAULT='Ctrl\+c:cancel'
 FM_TMUX_KIMI_BUSY_REGEX_DEFAULT='^[[:space:]]*(🌑|🌒|🌓|🌔|🌕|🌖|🌗|🌘)[[:space:]]+·[[:space:]]+'
+# Hermes classic REPL (v0.19.0): mid-turn footer carries Ctrl+C cancel and/or
+# msg=interrupt; startup shows Initializing agent. Distinct from Grok's
+# Ctrl+c:cancel (lowercase c, colon). Idle is bare ❯ without these tokens.
+FM_TMUX_HERMES_BUSY_REGEX_DEFAULT='Ctrl\+C cancel|msg=interrupt|Initializing agent'
 
 fm_busy_lines_match() {  # [harness]
   local harness=${1:-} lines regex
@@ -103,6 +107,7 @@ fm_busy_lines_match() {  # [harness]
       pi|pi-signed) regex=$FM_TMUX_PI_BUSY_REGEX_DEFAULT ;;
       grok) regex=$FM_TMUX_GROK_BUSY_REGEX_DEFAULT ;;
       kimi) regex=$FM_TMUX_KIMI_BUSY_REGEX_DEFAULT ;;
+      hermes) regex=$FM_TMUX_HERMES_BUSY_REGEX_DEFAULT ;;
       '') regex=$FM_TMUX_BUSY_REGEX_DEFAULT ;;
       *)
         # A supplied harness must never borrow another harness's signature.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -206,7 +206,7 @@ The full cmux home label also includes a short hash of the resolved `FM_ROOT` pa
 
 ## Harness support
 
-claude, codex, opencode, pi, pi-signed, grok, and kimi are empirically verified for crewmate and secondmate launches; [README requirements](../README.md#requirements) own the set supported for the primary session.
+claude, codex, opencode, pi, pi-signed, grok, kimi, and hermes are empirically verified for crewmate and secondmate launches; [README requirements](../README.md#requirements) own the set supported for the primary session.
 New harnesses get verified through a supervised trial task before joining the set.
 The verified adapter knowledge - each harness's busy-state source, interrupt and exit commands, skill-invocation syntax, and per-harness quirks - lives in [`.agents/skills/harness-adapters/SKILL.md`](../.agents/skills/harness-adapters/SKILL.md).
 Launch mechanics, including the verified command templates, live in [`bin/fm-spawn.sh`](../bin/fm-spawn.sh).

--- a/docs/verification/supervision.md
+++ b/docs/verification/supervision.md
@@ -73,6 +73,7 @@ Each pass polled `state/<id>.busy-state` while a real turn ran.
 | Codex | codex-cli 0.145.0 | None usable | See below; classifies `unknown codex-unverified`. |
 | Kimi (standalone) | not installed | None usable | No binary on `PATH`, so the gate stays closed and it classifies `unknown kimi-unverified`. |
 | Grok | 0.2.112 | Isolated rendered-tail fallback | Retained unconverted; the approved audit could not credit a live structured-lifecycle run. |
+| Hermes | v0.19.0 (2026.7.20) | Isolated rendered-tail fallback (`hermes-regex`) | Classic REPL only; no structured lifecycle wired. Live-verified 2026-08-03: busy footer carries `Ctrl+C cancel` and/or `msg=interrupt`; idle is bare `❯`. Scoped to `harness=hermes` only. |
 
 Codex was probed two ways, both refused:
 
@@ -92,7 +93,29 @@ Deterministic entry points:
 tests/fm-busy-state.test.sh
 tests/fm-busy-adapter-wiring.test.sh
 tests/fm-crew-state.test.sh
+tests/fm-hermes-harness.test.sh
 ```
+
+### Hermes adapter (crewmate path, 2026-08-03)
+
+Live-verified on Hermes Agent v0.19.0 (2026.7.20), brew `hermes-agent`:
+
+```text
+$ hermes version
+Hermes Agent v0.19.0 (2026.7.20)
+
+$ hermes chat --yolo --accept-hooks
+# classic REPL; idle composer is bare ❯
+# mid-turn footer includes Ctrl+C cancel and/or msg=interrupt with ⚕ ❯
+# interrupt: Ctrl+C (mid-tool returns to ❯)
+# exit: /quit or /exit
+# resume: hermes --resume <session-id>
+```
+
+Modern `--tui` is broken on this brew install (missing `ui-tui`) and is not used.
+No reliable `HERMES_*=1` child env marker was found; detection matches argv `hermes` / `hermes-agent`, not bare `Python`.
+Smoke scout `hermes-smoke-h1` passed under raw launch plus post-ready brief pointer delivery.
+No turn-end hook is wired; busy classification is the harness-scoped `hermes-regex` rendered-tail fallback only.
 
 ## Turn-end guard
 

--- a/docs/verification/supervision.md
+++ b/docs/verification/supervision.md
@@ -73,7 +73,7 @@ Each pass polled `state/<id>.busy-state` while a real turn ran.
 | Codex | codex-cli 0.145.0 | None usable | See below; classifies `unknown codex-unverified`. |
 | Kimi (standalone) | not installed | None usable | No binary on `PATH`, so the gate stays closed and it classifies `unknown kimi-unverified`. |
 | Grok | 0.2.112 | Isolated rendered-tail fallback | Retained unconverted; the approved audit could not credit a live structured-lifecycle run. |
-| Hermes | v0.19.0 (2026.7.20) | Isolated rendered-tail fallback (`hermes-regex`) | Classic REPL only; no structured lifecycle wired. Live-verified 2026-08-03: busy footer carries `Ctrl+C cancel` and/or `msg=interrupt`; idle is bare `❯`. Scoped to `harness=hermes` only. |
+| Hermes | v0.19.0 (2026.7.20) | Isolated rendered-tail fallback (`hermes-regex`) | Classic REPL only; no structured lifecycle wired. Live-verified 2026-08-03: busy footer carries `Ctrl+C cancel` and/or `msg=interrupt`; idle requires a bare `❯` row and a tail with neither signal stays `unknown`. Scoped to `harness=hermes` only. |
 
 Codex was probed two ways, both refused:
 
@@ -115,6 +115,7 @@ $ hermes chat --yolo --accept-hooks
 Modern `--tui` is broken on this brew install (missing `ui-tui`) and is not used.
 No reliable `HERMES_*=1` child env marker was found; detection matches argv `hermes` / `hermes-agent`, not bare `Python`.
 Smoke scout `hermes-smoke-h1` passed under raw launch plus post-ready brief pointer delivery.
+Readiness is gated on the Welcome to Hermes / Hermes Agent banner rather than a bare `❯`, which is also the default starship shell prompt, and `Initializing agent` is startup chrome that never confirms delivery.
 No turn-end hook is wired; busy classification is the harness-scoped `hermes-regex` rendered-tail fallback only.
 
 ## Turn-end guard

--- a/docs/verification/supervision.md
+++ b/docs/verification/supervision.md
@@ -115,7 +115,8 @@ $ hermes chat --yolo --accept-hooks
 Modern `--tui` is broken on this brew install (missing `ui-tui`) and is not used.
 No reliable `HERMES_*=1` child env marker was found; detection matches argv `hermes` / `hermes-agent`, not bare `Python`.
 Smoke scout `hermes-smoke-h1` passed under raw launch plus post-ready brief pointer delivery.
-Readiness is gated on the Welcome to Hermes / Hermes Agent banner rather than a bare `❯`, which is also the default starship shell prompt, and `Initializing agent` is startup chrome that never confirms delivery.
+Readiness is gated on the Welcome to Hermes / Hermes Agent banner plus a live agent process (`fm_backend_agent_state`), not a bare `❯` alone (also the default starship shell prompt) and not banner text left after the process exits.
+`Initializing agent` is startup chrome that never confirms delivery.
 No turn-end hook is wired; busy classification is the harness-scoped `hermes-regex` rendered-tail fallback only.
 
 ## Turn-end guard

--- a/tests/fm-busy-state.test.sh
+++ b/tests/fm-busy-state.test.sh
@@ -243,7 +243,32 @@ Ctrl+c:cancel')
   # Another adapter's footer never makes grok busy either.
   out=$(fm_busy_classify tmux w1 grok t1 "$state" '• Working (6s • esc to interrupt)')
   [ "$out" = "idle grok-regex" ] || fail "a claude footer must not classify grok busy, got '$out'"
+  # Hermes busy chrome must not classify a grok task (colon vs space form).
+  out=$(fm_busy_classify tmux w1 grok t1 "$state" '⚕ ❯ msg=interrupt · Ctrl+C cancel')
+  [ "$out" = "idle grok-regex" ] || fail "hermes busy chrome must not classify grok busy, got '$out'"
   pass "the grok fallback is regex-scoped to grok and classifies only grok tasks"
+}
+
+test_hermes_regex_isolated() {
+  local state out
+  state=$(new_state_dir hermes-arm)
+  out=$(fm_busy_classify tmux w1 hermes t1 "$state" 'tool running
+⚕ ❯ msg=interrupt · /queue · Ctrl+C cancel')
+  [ "$out" = "busy hermes-regex" ] || fail "hermes busy tail must classify 'busy hermes-regex', got '$out'"
+  out=$(fm_busy_classify tmux w1 hermes t1 "$state" 'Initializing agent...')
+  [ "$out" = "busy hermes-regex" ] || fail "hermes startup must classify busy, got '$out'"
+  out=$(fm_busy_classify tmux w1 hermes t1 "$state" 'ready
+❯')
+  [ "$out" = "idle hermes-regex" ] || fail "hermes bare ❯ must classify idle, got '$out'"
+  # Grok's colon form must not classify hermes busy.
+  out=$(fm_busy_classify tmux w1 hermes t1 "$state" 'Ctrl+c:cancel')
+  [ "$out" = "idle hermes-regex" ] || fail "grok busy token must not classify hermes busy, got '$out'"
+  # Another adapter never receives hermes-regex.
+  out=$(fm_busy_classify tmux w1 claude t1 "$state" '⚕ ❯ msg=interrupt · Ctrl+C cancel')
+  [ "$out" = "unknown missing" ] || fail "hermes chrome must not classify claude, got '$out'"
+  out=$(fm_busy_classify tmux w1 grok t1 "$state" '⚕ ❯ msg=interrupt · Ctrl+C cancel')
+  [ "$out" = "idle grok-regex" ] || fail "hermes chrome must not classify grok via hermes-regex, got '$out'"
+  pass "the hermes fallback is regex-scoped to hermes and classifies only hermes tasks"
 }
 
 # --- kimi verification gate -----------------------------------------------------
@@ -370,6 +395,7 @@ test_record_without_sidecar_unknown
 test_source_mismatch_cross_adapter
 test_converted_adapters_ignore_footer_text
 test_grok_regex_isolated
+test_hermes_regex_isolated
 test_codex_unverified_gate
 test_kimi_unverified_gate
 test_dead_endpoint_overrides

--- a/tests/fm-busy-state.test.sh
+++ b/tests/fm-busy-state.test.sh
@@ -260,9 +260,15 @@ test_hermes_regex_isolated() {
   out=$(fm_busy_classify tmux w1 hermes t1 "$state" 'ready
 ❯')
   [ "$out" = "idle hermes-regex" ] || fail "hermes bare ❯ must classify idle, got '$out'"
-  # Grok's colon form must not classify hermes busy.
+  # Grok's colon form must not classify hermes busy - and with no bare ❯ it is
+  # not idle either, only unknown.
   out=$(fm_busy_classify tmux w1 hermes t1 "$state" 'Ctrl+c:cancel')
-  [ "$out" = "idle hermes-regex" ] || fail "grok busy token must not classify hermes busy, got '$out'"
+  [ "$out" = "unknown hermes-regex" ] || fail "grok busy token must not classify hermes busy, got '$out'"
+  # A tail with no composer at all (scrolled tool output, pager, crashed REPL)
+  # is never idle: a false idle tells the supervisor a live crewmate is done.
+  out=$(fm_busy_classify tmux w1 hermes t1 "$state" 'diff --git a/x b/x
++ added a line')
+  [ "$out" = "unknown hermes-regex" ] || fail "a hermes tail without ❯ must be unknown, got '$out'"
   # Another adapter never receives hermes-regex.
   out=$(fm_busy_classify tmux w1 claude t1 "$state" '⚕ ❯ msg=interrupt · Ctrl+C cancel')
   [ "$out" = "unknown missing" ] || fail "hermes chrome must not classify claude, got '$out'"

--- a/tests/fm-composer-lib.test.sh
+++ b/tests/fm-composer-lib.test.sh
@@ -79,7 +79,10 @@ test_agent_glyphs_are_empty_bordered_and_bare() {
   out=$(classify 0 '›'); [ "$out" = empty ] || fail "bare codex '›' should read empty, got '$out'"
   out=$(classify 1 '❯'); [ "$out" = empty ] || fail "bordered claude '❯' should read empty, got '$out'"
   out=$(classify 1 '›'); [ "$out" = empty ] || fail "bordered codex '›' should read empty, got '$out'"
-  pass "fm_composer_classify_content: agent prompt glyphs (❯ claude, › codex) read empty bordered or bare"
+  # Hermes classic REPL idle composer is the same bare ❯ agent glyph.
+  out=$(classify 0 '❯'); [ "$out" = empty ] \
+    || fail "bare hermes '❯' must not read as a dead shell, got '$out'"
+  pass "fm_composer_classify_content: agent prompt glyphs (❯ claude/hermes, › codex) read empty bordered or bare"
 }
 
 # --- Empty content and idle placeholder -------------------------------------

--- a/tests/fm-hermes-harness.test.sh
+++ b/tests/fm-hermes-harness.test.sh
@@ -1,0 +1,432 @@
+#!/usr/bin/env bash
+# Behavior tests for the verified Hermes Agent crewmate adapter.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+SPAWN="$ROOT/bin/fm-spawn.sh"
+TMP_ROOT=$(fm_test_tmproot fm-hermes-harness)
+HERMES_RUNTIME_TASK_TMP=
+PYTHON_BIN=$(command -v python3) || fail "test needs python3"
+PYTHON_BIN_DIR=$(dirname "$PYTHON_BIN")
+BASE_PATH=${FM_TEST_BASE_PATH:-$PYTHON_BIN_DIR:/usr/bin:/bin:/usr/sbin:/sbin}
+
+cleanup_hermes_harness() {
+  [ -z "$HERMES_RUNTIME_TASK_TMP" ] || rm -rf "$HERMES_RUNTIME_TASK_TMP"
+  rm -rf "$TMP_ROOT"
+}
+trap cleanup_hermes_harness EXIT
+
+make_spawn_fakebin() {
+  local dir=$1 fakebin
+  fakebin=$(fm_fakebin "$dir")
+  cat > "$fakebin/tmux" <<'SH'
+#!/usr/bin/env bash
+set -u
+printf '%s\n' "$*" >> "$FM_FAKE_TMUX_CALL_LOG"
+state=$(cat "$FM_FAKE_HERMES_STATE" 2>/dev/null || true)
+fake_screen() {
+  case "$state" in
+    ready)
+      printf 'Hermes Agent v0.19.0\nWelcome to Hermes\n❯\n'
+      ;;
+    pointer-typed)
+      printf 'Hermes Agent v0.19.0\n❯ Read the brief and follow it\n'
+      ;;
+    delivered-idle)
+      printf '✨ Read the brief at %s and follow it exactly.\n❯\n' "$FM_FAKE_BRIEF_REAL"
+      ;;
+    delivered-busy)
+      printf 'Read the brief at %s and follow it exactly.\nInitializing agent...\n⚕ ❯ msg=interrupt · /queue · Ctrl+C cancel\n' "$FM_FAKE_BRIEF_REAL"
+      ;;
+    *)
+      printf 'shell starting\n$ \n'
+      ;;
+  esac
+}
+fake_cursor_y() {
+  case "$state" in
+    pointer-typed) printf '1\n' ;;
+    ready|delivered-idle|delivered-busy) printf '2\n' ;;
+    *) printf '1\n' ;;
+  esac
+}
+case "$*" in
+  *"#{pane_current_path}"*) printf '%s\n' "$FM_FAKE_PANE_PATH"; exit 0 ;;
+  *"#{cursor_y}"*) fake_cursor_y; exit 0 ;;
+esac
+case "${1:-}" in
+  display-message) printf 'firstmate\n'; exit 0 ;;
+  list-windows) exit 0 ;;
+  has-session|new-session|new-window|kill-window) exit 0 ;;
+  send-keys)
+    prev=
+    literal=
+    for arg in "$@"; do
+      if [ "$prev" = -l ]; then literal=$arg; break; fi
+      prev=$arg
+    done
+    if [ -n "$literal" ]; then
+      case "$literal" in
+        *' chat --yolo --accept-hooks'*)
+          printf '%s\n' "$literal" >> "$FM_FAKE_LAUNCH_LOG"
+          printf 'launched\n' > "$FM_FAKE_HERMES_STATE"
+          ;;
+        *)
+          printf '%s\n' "$literal" >> "$FM_FAKE_POINTER_LOG"
+          printf 'pointer-typed\n' > "$FM_FAKE_HERMES_STATE"
+          ;;
+      esac
+      exit 0
+    fi
+    case " $* " in
+      *' Enter '*)
+        case "$state" in
+          launched)
+            if [ "${FM_FAKE_HERMES_READY:-yes}" = yes ]; then
+              printf 'ready\n' > "$FM_FAKE_HERMES_STATE"
+            fi
+            ;;
+          pointer-typed)
+            if [ "${FM_FAKE_HERMES_DELIVERY:-yes}" = yes ]; then
+              if [ "${FM_FAKE_HERMES_SWALLOW_FIRST:-no}" = yes ] \
+                 && [ ! -f "$FM_FAKE_HERMES_SWALLOWED" ]; then
+                : > "$FM_FAKE_HERMES_SWALLOWED"
+              else
+                printf '%s\n' "${FM_FAKE_HERMES_DELIVERED_STATE:-delivered-busy}" \
+                  > "$FM_FAKE_HERMES_STATE"
+              fi
+            else
+              printf 'ready\n' > "$FM_FAKE_HERMES_STATE"
+            fi
+            ;;
+        esac
+        ;;
+    esac
+    exit 0
+    ;;
+  capture-pane)
+    start= end= prev=
+    for arg in "$@"; do
+      case "$prev" in
+        -S) start=$arg ;;
+        -E) end=$arg ;;
+      esac
+      case "$arg" in -S|-E) prev=$arg ;; *) prev= ;; esac
+    done
+    case "$start:$end" in
+      *[!0-9:]*|'':*|*:'') fake_screen ;;
+      *) fake_screen | awk -v start="$start" -v end="$end" \
+           'NR - 1 >= start && NR - 1 <= end' ;;
+    esac
+    exit 0
+    ;;
+esac
+exit 0
+SH
+  chmod +x "$fakebin/tmux"
+  fm_fake_exit0 "$fakebin" treehouse gh-axi gh
+  fm_fake_exit0 "$fakebin" hermes
+  printf '%s\n' "$fakebin"
+}
+
+make_spawn_case() {
+  local name=$1 id=$2 case_dir home proj wt fakebin
+  case_dir="$TMP_ROOT/$name"
+  home="$case_dir/home"
+  proj="$case_dir/project"
+  wt="$case_dir/wt"
+  fakebin=$(make_spawn_fakebin "$case_dir/fake")
+  mkdir -p "$home/data/$id" "$home/projects" "$home/state" "$home/config"
+  printf 'brief for hermes\n' > "$home/data/$id/brief.md"
+  printf 'hermes\n' > "$home/config/crew-harness"
+  fm_git_worktree "$proj" "$wt" "wt-$name"
+  touch "$home/state/.last-watcher-beat"
+  : > "$case_dir/launch.log"
+  : > "$case_dir/pointer.log"
+  : > "$case_dir/hermes.state"
+  : > "$case_dir/tmux-calls.log"
+  printf '%s\n' "$case_dir|$home|$proj|$wt|$fakebin"
+}
+
+run_spawn() {
+  local case_dir=$1 home=$2 proj=$3 wt=$4 fakebin=$5 id=$6
+  shift 6
+  HOME="$home" FM_ROOT_OVERRIDE='' FM_HOME="$home" \
+    FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
+    FM_PROJECTS_OVERRIDE="$home/projects" FM_CONFIG_OVERRIDE="$home/config" \
+    FM_SPAWN_NO_GUARD=1 FM_FAKE_PANE_PATH="$wt" TMUX="fake,1,0" \
+    FM_FAKE_LAUNCH_LOG="$case_dir/launch.log" \
+    FM_FAKE_POINTER_LOG="$case_dir/pointer.log" \
+    FM_FAKE_HERMES_STATE="$case_dir/hermes.state" \
+    FM_FAKE_HERMES_SWALLOWED="$case_dir/hermes.swallowed" \
+    FM_FAKE_HERMES_SWALLOW_FIRST="${FM_FAKE_HERMES_SWALLOW_FIRST:-no}" \
+    FM_FAKE_HERMES_DELIVERED_STATE="${FM_FAKE_HERMES_DELIVERED_STATE:-delivered-busy}" \
+    FM_FAKE_TMUX_CALL_LOG="$case_dir/tmux-calls.log" \
+    FM_FAKE_BRIEF_REAL="$(cd "$home/data/$id" && pwd -P)/brief.md" \
+    FM_HERMES_READY_POLLS=2 FM_HERMES_DELIVERY_POLLS=2 FM_HERMES_POLL_INTERVAL=0 \
+    PATH="$fakebin:$BASE_PATH" \
+    "$SPAWN" "$id" "$proj" --harness hermes --mode no-mistakes --yolo off "$@" 2>&1
+}
+
+read_spawn_record() {
+  IFS='|' read -r CASE_DIR HOME_DIR PROJ_DIR WT_DIR FAKEBIN_DIR <<EOF
+$1
+EOF
+}
+
+test_hermes_launch_then_send_is_verified() {
+  local id rec out rc launch pointer brief_real meta task_tmp
+  id="hermes-success-z1-$$"
+  task_tmp="/tmp/fm-$id"
+  HERMES_RUNTIME_TASK_TMP=$task_tmp
+  rm -rf "$task_tmp"
+  rec=$(make_spawn_case success "$id")
+  read_spawn_record "$rec"
+  out=$(FM_FAKE_HERMES_SWALLOW_FIRST=yes run_spawn \
+    "$CASE_DIR" "$HOME_DIR" "$PROJ_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$id" \
+    --model grok-4.5 --effort high)
+  rc=$?
+  expect_code 0 "$rc" "verified hermes launch-then-send should succeed"
+  assert_contains "$out" "spawned $id harness=hermes" "hermes spawn did not report success"
+
+  launch=$(cat "$CASE_DIR/launch.log")
+  [ "$launch" = "'$FAKEBIN_DIR/hermes' chat --yolo --accept-hooks -m 'grok-4.5' " ] \
+    || fail "hermes launch did not use absolute binary, yolo, accept-hooks, and -m only: $launch"
+  assert_not_contains "$launch" "--effort" "hermes launch emitted a nonexistent effort flag"
+  assert_not_contains "$launch" "--tui" "hermes launch must not use broken --tui"
+  assert_not_contains "$launch" "turn-ended" "hermes launch embedded a turn-end path"
+
+  brief_real="$(cd "$HOME_DIR/data/$id" && pwd -P)/brief.md"
+  pointer=$(cat "$CASE_DIR/pointer.log")
+  [ "$pointer" = "Read the brief at $brief_real and follow it exactly." ] \
+    || fail "hermes pointer was not the exact absolute-path-only instruction: $pointer"
+  meta="$HOME_DIR/state/$id.meta"
+  assert_grep 'model=grok-4.5' "$meta" "hermes meta lost the requested model"
+  assert_grep 'effort=high' "$meta" "hermes meta did not retain the unsupported effort axis"
+  assert_grep 'harness=hermes' "$meta" "hermes meta lost harness identity"
+  assert_grep "tasktmp=$task_tmp" "$meta" "hermes meta did not record its task temp root"
+  assert_present "$task_tmp/gotmp" "hermes spawn did not create its Go temp directory"
+  pass "fm-spawn: hermes launches, delivers its brief, and records profile axes"
+}
+
+test_hermes_idle_delivery_is_accepted() {
+  local id rec out rc
+  id=hermes-idle-delivery-z2
+  rec=$(make_spawn_case idle-delivery "$id")
+  read_spawn_record "$rec"
+  out=$(FM_FAKE_HERMES_DELIVERED_STATE=delivered-idle run_spawn \
+    "$CASE_DIR" "$HOME_DIR" "$PROJ_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$id")
+  rc=$?
+  expect_code 0 "$rc" "hermes idle pointer echo should confirm delivery"
+  assert_contains "$out" "spawned $id harness=hermes" "idle delivery spawn did not report success"
+  pass "fm-spawn: hermes accepts idle composer plus visible pointer as delivery"
+}
+
+test_hermes_missing_binary_refuses_before_pane_creation() {
+  local id rec out rc
+  id=hermes-missing-z3
+  rec=$(make_spawn_case missing "$id")
+  read_spawn_record "$rec"
+  rm -f "$FAKEBIN_DIR/hermes" "$FAKEBIN_DIR/hermes-agent"
+  rc=0
+  out=$(run_spawn "$CASE_DIR" "$HOME_DIR" "$PROJ_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$id") || rc=$?
+  [ "$rc" -ne 0 ] || fail "missing hermes executable should refuse the spawn"
+  assert_contains "$out" "searched PATH for 'hermes'" "missing hermes diagnostic omitted PATH"
+  assert_contains "$out" "hermes-agent" "missing hermes diagnostic omitted hermes-agent fallback"
+  if grep -Eq '(^| )new-(session|window)( |$)' "$CASE_DIR/tmux-calls.log"; then
+    fail "missing hermes executable created a tmux container or pane"
+  fi
+  pass "fm-spawn: missing hermes executable refuses before pane creation"
+}
+
+test_hermes_falls_back_to_hermes_agent_binary() {
+  local id rec out rc launch
+  id=hermes-agent-fallback-z4
+  rec=$(make_spawn_case agent-fallback "$id")
+  read_spawn_record "$rec"
+  rm -f "$FAKEBIN_DIR/hermes"
+  fm_fake_exit0 "$FAKEBIN_DIR" hermes-agent
+  out=$(run_spawn "$CASE_DIR" "$HOME_DIR" "$PROJ_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$id")
+  rc=$?
+  expect_code 0 "$rc" "hermes-agent PATH fallback spawn should succeed"
+  launch=$(cat "$CASE_DIR/launch.log")
+  [ "$launch" = "'$FAKEBIN_DIR/hermes-agent' chat --yolo --accept-hooks " ] \
+    || fail "hermes-agent fallback did not expand to an absolute executable: $launch"
+  pass "fm-spawn: hermes falls back to hermes-agent on PATH"
+}
+
+test_hermes_unconfirmed_delivery_fails_loudly() {
+  local id rec out rc
+  id=hermes-drop-z5
+  rec=$(make_spawn_case drop "$id")
+  read_spawn_record "$rec"
+  rc=0
+  out=$(FM_FAKE_HERMES_DELIVERY=no run_spawn \
+    "$CASE_DIR" "$HOME_DIR" "$PROJ_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$id") || rc=$?
+  [ "$rc" -ne 0 ] || fail "an unconfirmed hermes delivery should fail"
+  assert_contains "$out" "hermes brief pointer delivery was not confirmed" \
+    "unconfirmed hermes delivery lacked a loud diagnostic"
+  assert_grep 'failed: hermes brief pointer delivery was not confirmed' "$HOME_DIR/state/$id.status" \
+    "unconfirmed hermes delivery did not leave a supervisor-visible failure"
+  pass "fm-spawn: hermes treats an unconfirmed pointer as a failed spawn"
+}
+
+test_hermes_readiness_gate_precedes_pointer() {
+  local id rec out rc
+  id=hermes-not-ready-z6
+  rec=$(make_spawn_case not-ready "$id")
+  read_spawn_record "$rec"
+  rc=0
+  out=$(FM_FAKE_HERMES_READY=no run_spawn \
+    "$CASE_DIR" "$HOME_DIR" "$PROJ_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$id") || rc=$?
+  [ "$rc" -ne 0 ] || fail "hermes spawn without a ready signal should fail"
+  assert_contains "$out" "hermes did not show a verified ready signal" \
+    "hermes readiness failure lacked a loud diagnostic"
+  [ ! -s "$CASE_DIR/pointer.log" ] || fail "hermes pointer was sent before readiness"
+  pass "fm-spawn: hermes never sends the brief pointer before an observable ready signal"
+}
+
+test_hermes_detection_uses_argv_not_bare_python() {
+  local dir fakebin cfg out
+  dir="$TMP_ROOT/detection"
+  fakebin=$(fm_fakebin "$dir")
+  cfg="$dir/config"
+  mkdir -p "$cfg"
+  cat > "$fakebin/ps" <<'SH'
+#!/usr/bin/env bash
+set -u
+field=
+pid=
+prev=
+for arg in "$@"; do
+  [ "$prev" = -o ] && field=$arg
+  [ "$prev" = -p ] && pid=$arg
+  prev=$arg
+done
+case "$field:$pid" in
+  comm=:5151) printf 'Python\n' ;;
+  comm=:*) printf '/bin/bash\n' ;;
+  ppid=:5151) printf '1\n' ;;
+  ppid=:*) printf '5151\n' ;;
+  args=:5151) printf 'Python /opt/homebrew/bin/hermes chat --yolo\n' ;;
+  args=:*) printf 'bash\n' ;;
+esac
+SH
+  chmod +x "$fakebin/ps"
+
+  out=$(env -u CLAUDECODE -u PI_CODING_AGENT -u GROK_AGENT \
+    PATH="$fakebin:$BASE_PATH" FM_CONFIG_OVERRIDE="$cfg" "$ROOT/bin/fm-harness.sh")
+  [ "$out" = hermes ] || fail "hermes argv detection returned '$out'"
+
+  cat > "$fakebin/ps" <<'SH'
+#!/usr/bin/env bash
+set -u
+field=
+pid=
+prev=
+for arg in "$@"; do
+  [ "$prev" = -o ] && field=$arg
+  [ "$prev" = -p ] && pid=$arg
+  prev=$arg
+done
+case "$field:$pid" in
+  comm=:6161) printf 'Python\n' ;;
+  comm=:*) printf '/bin/bash\n' ;;
+  ppid=:6161) printf '1\n' ;;
+  ppid=:*) printf '6161\n' ;;
+  args=:6161) printf 'Python /usr/bin/some-other-tool\n' ;;
+  args=:*) printf 'bash\n' ;;
+esac
+SH
+  chmod +x "$fakebin/ps"
+  out=$(env -u CLAUDECODE -u PI_CODING_AGENT -u GROK_AGENT \
+    PATH="$fakebin:$BASE_PATH" FM_CONFIG_OVERRIDE="$cfg" "$ROOT/bin/fm-harness.sh")
+  [ "$out" = unknown ] || fail "bare Python without hermes argv must stay unknown, got '$out'"
+  pass "fm-harness: hermes is detected from argv hermes, never bare Python alone"
+}
+
+test_hermes_composer_idle_glyph_is_empty() {
+  local out
+  # shellcheck source=/dev/null
+  . "$ROOT/bin/fm-composer-lib.sh"
+  out=$(fm_composer_classify_content 0 '❯')
+  [ "$out" = empty ] || fail "hermes bare ❯ must read empty, got '$out'"
+  out=$(fm_composer_classify_content 0 '⚕ ❯ msg=interrupt · Ctrl+C cancel')
+  [ "$out" = pending ] || fail "hermes busy footer content must not read empty, got '$out'"
+  pass "composer classifier: hermes idle ❯ is empty and busy footer is not"
+}
+
+test_hermes_busy_signature_is_harness_scoped() {
+  local capture
+  # shellcheck source=/dev/null
+  . "$ROOT/bin/fm-tmux-lib.sh"
+  unset FM_BUSY_REGEX
+  capture="$TMP_ROOT/busy-pane"
+  tmux() {
+    case "${1:-}" in
+      capture-pane) cat "$capture" ;;
+      *) return 0 ;;
+    esac
+  }
+  printf '⚕ ❯ msg=interrupt · /queue · Ctrl+C cancel\n' > "$capture"
+  fm_pane_is_busy fake hermes || fail "hermes busy footer was not recognized as busy"
+  printf 'Initializing agent...\n❯\n' > "$capture"
+  fm_pane_is_busy fake hermes || fail "hermes initializing line was not recognized as busy"
+  printf '❯\n' > "$capture"
+  if fm_pane_is_busy fake hermes; then
+    fail "hermes bare idle ❯ was misread as busy"
+  fi
+  printf 'Ctrl+c:cancel\n' > "$capture"
+  if fm_pane_is_busy fake hermes; then
+    fail "Grok's exact busy token leaked into hermes"
+  fi
+  printf '⚕ ❯ msg=interrupt · Ctrl+C cancel\n' > "$capture"
+  if fm_pane_is_busy fake grok; then
+    fail "hermes busy chrome leaked into grok"
+  fi
+  if fm_pane_is_busy fake claude; then
+    fail "hermes busy chrome leaked into claude"
+  fi
+  pass "busy detection: hermes ASCII busy tokens stay harness-scoped"
+}
+
+test_watcher_classifies_hermes_from_its_own_fallback_only() (
+  local state="$TMP_ROOT/watch-state"
+  mkdir -p "$state"
+  printf 'window=fake\nharness=hermes\n' > "$state/hermes-watch.meta"
+  unset FM_BUSY_REGEX
+  FM_HOME="$TMP_ROOT/watch-home"
+  FM_STATE_OVERRIDE="$state"
+  export FM_HOME FM_STATE_OVERRIDE
+  # shellcheck source=/dev/null
+  . "$ROOT/bin/fm-watch.sh"
+  # shellcheck disable=SC2329 # Runtime override called by the sourced watcher.
+  fm_backend_busy_state() { printf 'unknown'; }
+  window_is_busy fake '⚕ ❯ msg=interrupt · Ctrl+C cancel' \
+    || fail "fm-watch must classify a hermes task busy from hermes chrome"
+  if window_is_busy fake 'Ctrl+c:cancel'; then
+    fail "fm-watch applied Grok's token to a recorded hermes task"
+  fi
+  [ "$(fm_busy_classify tmux fake hermes hermes-watch "$state" '❯')" = "idle hermes-regex" ] \
+    || fail "a hermes idle pane must classify idle hermes-regex"
+  printf 'window=fake\nharness=grok\n' > "$state/hermes-watch.meta"
+  if window_is_busy fake '⚕ ❯ msg=interrupt · Ctrl+C cancel'; then
+    fail "hermes chrome classified a recorded Grok task"
+  fi
+  window_is_busy fake 'Ctrl+c:cancel' \
+    || fail "Grok's own verified token must still classify a recorded Grok task busy"
+  pass "fm-watch classifies hermes only through hermes-regex and keeps Grok isolated"
+)
+
+test_hermes_launch_then_send_is_verified
+test_hermes_idle_delivery_is_accepted
+test_hermes_missing_binary_refuses_before_pane_creation
+test_hermes_falls_back_to_hermes_agent_binary
+test_hermes_unconfirmed_delivery_fails_loudly
+test_hermes_readiness_gate_precedes_pointer
+test_hermes_detection_uses_argv_not_bare_python
+test_hermes_composer_idle_glyph_is_empty
+test_hermes_busy_signature_is_harness_scoped
+test_watcher_classifies_hermes_from_its_own_fallback_only

--- a/tests/fm-hermes-harness.test.sh
+++ b/tests/fm-hermes-harness.test.sh
@@ -46,6 +46,13 @@ fake_screen() {
     initializing-only)
       printf 'Hermes Agent v0.19.0\nWelcome to Hermes\nInitializing agent...\n'
       ;;
+    banner-dead)
+      # Banner left in scrollback after hermes exited to a shell.
+      printf 'Hermes Agent v0.19.0\nWelcome to Hermes\n❯\n'
+      ;;
+    banner-dead-delivered)
+      printf 'Hermes Agent v0.19.0\nWelcome to Hermes\nRead the brief at %s and follow it exactly.\n❯\n' "$FM_FAKE_BRIEF_REAL"
+      ;;
     *)
       printf 'shell starting\n$ \n'
       ;;
@@ -54,18 +61,55 @@ fake_screen() {
 fake_cursor_y() {
   case "$state" in
     pointer-typed) printf '1\n' ;;
-    ready|delivered-idle|delivered-busy|initializing-only) printf '2\n' ;;
+    ready|delivered-idle|delivered-busy|initializing-only|banner-dead|banner-dead-delivered) printf '2\n' ;;
     *) printf '1\n' ;;
+  esac
+}
+fake_current_command() {
+  # Live hermes states report the harness; dead/shell states report zsh so
+  # fm_backend_tmux_agent_state classifies shell/dead rather than agent.
+  case "$state" in
+    ready|pointer-typed|delivered-idle|delivered-busy|initializing-only|launched)
+      if [ "${FM_FAKE_HERMES_AGENT_ALIVE:-yes}" = yes ]; then
+        printf 'hermes\n'
+      else
+        printf 'zsh\n'
+      fi
+      ;;
+    banner-dead|banner-dead-delivered|bare-prompt|*)
+      printf 'zsh\n'
+      ;;
   esac
 }
 case "$*" in
   *"#{pane_current_path}"*) printf '%s\n' "$FM_FAKE_PANE_PATH"; exit 0 ;;
+  *"#{pane_current_command}"*) fake_current_command; exit 0 ;;
+  *"#{pane_tty}"*) printf '\n'; exit 0 ;;
   *"#{cursor_y}"*) fake_cursor_y; exit 0 ;;
 esac
 case "${1:-}" in
   display-message) printf 'firstmate\n'; exit 0 ;;
-  list-windows) exit 0 ;;
-  has-session|new-session|new-window|kill-window) exit 0 ;;
+  list-windows)
+    # Only report windows after new-window, so spawn create does not see a
+    # pre-existing name. Agent-state probes need the name present once created.
+    if [ -f "${FM_FAKE_WINDOWS_FILE:-}" ]; then
+      cat "${FM_FAKE_WINDOWS_FILE}"
+    fi
+    exit 0
+    ;;
+  has-session|new-session|kill-window) exit 0 ;;
+  new-window)
+    # Record the -n name so later list-windows / agent_state inventory succeeds.
+    prev=
+    for arg in "$@"; do
+      if [ "$prev" = -n ]; then
+        printf '%s\n' "$arg" >> "${FM_FAKE_WINDOWS_FILE:-/dev/null}"
+        break
+      fi
+      prev=$arg
+    done
+    exit 0
+    ;;
   send-keys)
     prev=
     literal=
@@ -157,6 +201,7 @@ make_spawn_case() {
   : > "$case_dir/pointer.log"
   : > "$case_dir/hermes.state"
   : > "$case_dir/tmux-calls.log"
+  : > "$case_dir/windows.list"
   printf '%s\n' "$case_dir|$home|$proj|$wt|$fakebin"
 }
 
@@ -175,6 +220,9 @@ run_spawn() {
     FM_FAKE_HERMES_DELIVERED_STATE="${FM_FAKE_HERMES_DELIVERED_STATE:-delivered-busy}" \
     FM_FAKE_HERMES_UNDELIVERED_STATE="${FM_FAKE_HERMES_UNDELIVERED_STATE:-ready}" \
     FM_FAKE_HERMES_UNREADY_STATE="${FM_FAKE_HERMES_UNREADY_STATE:-launched}" \
+    FM_FAKE_HERMES_AGENT_ALIVE="${FM_FAKE_HERMES_AGENT_ALIVE:-yes}" \
+    FM_FAKE_WINDOW_NAME="fm-$id" \
+    FM_FAKE_WINDOWS_FILE="$case_dir/windows.list" \
     FM_FAKE_TMUX_CALL_LOG="$case_dir/tmux-calls.log" \
     FM_FAKE_BRIEF_REAL="$(cd "$home/data/$id" && pwd -P)/brief.md" \
     FM_HERMES_READY_POLLS=2 FM_HERMES_DELIVERY_POLLS=2 FM_HERMES_POLL_INTERVAL=0 \
@@ -330,6 +378,39 @@ test_hermes_startup_chrome_alone_is_not_delivery() {
   pass "fm-spawn: startup Initializing agent alone never confirms brief delivery"
 }
 
+test_hermes_banner_without_live_agent_is_not_readiness() {
+  local id rec out rc
+  id=hermes-banner-dead-z9
+  rec=$(make_spawn_case banner-dead "$id")
+  read_spawn_record "$rec"
+  rc=0
+  # banner-dead screen keeps Hermes chrome but pane_current_command is zsh.
+  out=$(FM_FAKE_HERMES_READY=no FM_FAKE_HERMES_UNREADY_STATE=banner-dead \
+    run_spawn "$CASE_DIR" "$HOME_DIR" "$PROJ_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$id") || rc=$?
+  [ "$rc" -ne 0 ] || fail "Hermes banner with a dead agent must not be readiness"
+  assert_contains "$out" "hermes did not show a verified ready signal" \
+    "banner-without-live-agent readiness failure lacked a loud diagnostic"
+  [ ! -s "$CASE_DIR/pointer.log" ] \
+    || fail "hermes typed the brief pointer after the agent had exited"
+  pass "fm-spawn: Hermes banner in scrollback without a live agent is never readiness"
+}
+
+test_hermes_idle_delivery_requires_live_agent() {
+  local id rec out rc
+  id=hermes-dead-delivery-z10
+  rec=$(make_spawn_case dead-delivery "$id")
+  read_spawn_record "$rec"
+  rc=0
+  # Ready while live (state=ready → hermes), then after submit the undelivered
+  # state is banner-dead-delivered (zsh + pointer echo + ❯). Idle delivery must refuse.
+  out=$(FM_FAKE_HERMES_DELIVERY=no FM_FAKE_HERMES_UNDELIVERED_STATE=banner-dead-delivered \
+    run_spawn "$CASE_DIR" "$HOME_DIR" "$PROJ_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$id") || rc=$?
+  [ "$rc" -ne 0 ] || fail "idle pointer echo without a live agent must not confirm delivery"
+  assert_contains "$out" "hermes brief pointer delivery was not confirmed" \
+    "dead-agent idle delivery lacked a loud diagnostic"
+  pass "fm-spawn: idle delivery confirmation requires a live hermes agent"
+}
+
 test_hermes_detection_uses_argv_not_bare_python() {
   local dir fakebin cfg out
   dir="$TMP_ROOT/detection"
@@ -470,6 +551,8 @@ test_hermes_unconfirmed_delivery_fails_loudly
 test_hermes_readiness_gate_precedes_pointer
 test_hermes_bare_shell_prompt_is_not_readiness
 test_hermes_startup_chrome_alone_is_not_delivery
+test_hermes_banner_without_live_agent_is_not_readiness
+test_hermes_idle_delivery_requires_live_agent
 test_hermes_detection_uses_argv_not_bare_python
 test_hermes_composer_idle_glyph_is_empty
 test_hermes_busy_signature_is_harness_scoped

--- a/tests/fm-hermes-harness.test.sh
+++ b/tests/fm-hermes-harness.test.sh
@@ -40,6 +40,12 @@ fake_screen() {
     delivered-busy)
       printf 'Read the brief at %s and follow it exactly.\nInitializing agent...\n⚕ ❯ msg=interrupt · /queue · Ctrl+C cancel\n' "$FM_FAKE_BRIEF_REAL"
       ;;
+    bare-prompt)
+      printf 'shell starting\n❯\n'
+      ;;
+    initializing-only)
+      printf 'Hermes Agent v0.19.0\nWelcome to Hermes\nInitializing agent...\n'
+      ;;
     *)
       printf 'shell starting\n$ \n'
       ;;
@@ -48,7 +54,7 @@ fake_screen() {
 fake_cursor_y() {
   case "$state" in
     pointer-typed) printf '1\n' ;;
-    ready|delivered-idle|delivered-busy) printf '2\n' ;;
+    ready|delivered-idle|delivered-busy|initializing-only) printf '2\n' ;;
     *) printf '1\n' ;;
   esac
 }
@@ -86,6 +92,9 @@ case "${1:-}" in
           launched)
             if [ "${FM_FAKE_HERMES_READY:-yes}" = yes ]; then
               printf 'ready\n' > "$FM_FAKE_HERMES_STATE"
+            else
+              printf '%s\n' "${FM_FAKE_HERMES_UNREADY_STATE:-launched}" \
+                > "$FM_FAKE_HERMES_STATE"
             fi
             ;;
           pointer-typed)
@@ -98,7 +107,8 @@ case "${1:-}" in
                   > "$FM_FAKE_HERMES_STATE"
               fi
             else
-              printf 'ready\n' > "$FM_FAKE_HERMES_STATE"
+              printf '%s\n' "${FM_FAKE_HERMES_UNDELIVERED_STATE:-ready}" \
+                > "$FM_FAKE_HERMES_STATE"
             fi
             ;;
         esac
@@ -163,6 +173,8 @@ run_spawn() {
     FM_FAKE_HERMES_SWALLOWED="$case_dir/hermes.swallowed" \
     FM_FAKE_HERMES_SWALLOW_FIRST="${FM_FAKE_HERMES_SWALLOW_FIRST:-no}" \
     FM_FAKE_HERMES_DELIVERED_STATE="${FM_FAKE_HERMES_DELIVERED_STATE:-delivered-busy}" \
+    FM_FAKE_HERMES_UNDELIVERED_STATE="${FM_FAKE_HERMES_UNDELIVERED_STATE:-ready}" \
+    FM_FAKE_HERMES_UNREADY_STATE="${FM_FAKE_HERMES_UNREADY_STATE:-launched}" \
     FM_FAKE_TMUX_CALL_LOG="$case_dir/tmux-calls.log" \
     FM_FAKE_BRIEF_REAL="$(cd "$home/data/$id" && pwd -P)/brief.md" \
     FM_HERMES_READY_POLLS=2 FM_HERMES_DELIVERY_POLLS=2 FM_HERMES_POLL_INTERVAL=0 \
@@ -286,6 +298,36 @@ test_hermes_readiness_gate_precedes_pointer() {
     "hermes readiness failure lacked a loud diagnostic"
   [ ! -s "$CASE_DIR/pointer.log" ] || fail "hermes pointer was sent before readiness"
   pass "fm-spawn: hermes never sends the brief pointer before an observable ready signal"
+}
+
+test_hermes_bare_shell_prompt_is_not_readiness() {
+  local id rec out rc
+  id=hermes-shell-prompt-z7
+  rec=$(make_spawn_case shell-prompt "$id")
+  read_spawn_record "$rec"
+  rc=0
+  out=$(FM_FAKE_HERMES_READY=no FM_FAKE_HERMES_UNREADY_STATE=bare-prompt run_spawn \
+    "$CASE_DIR" "$HOME_DIR" "$PROJ_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$id") || rc=$?
+  [ "$rc" -ne 0 ] || fail "a bare ❯ with no Hermes chrome should not be readiness"
+  assert_contains "$out" "hermes did not show a verified ready signal" \
+    "bare shell prompt readiness failure lacked a loud diagnostic"
+  [ ! -s "$CASE_DIR/pointer.log" ] \
+    || fail "hermes typed the brief pointer into a bare shell prompt"
+  pass "fm-spawn: a bare ❯ shell prompt without Hermes chrome is never readiness"
+}
+
+test_hermes_startup_chrome_alone_is_not_delivery() {
+  local id rec out rc
+  id=hermes-init-only-z8
+  rec=$(make_spawn_case init-only "$id")
+  read_spawn_record "$rec"
+  rc=0
+  out=$(FM_FAKE_HERMES_DELIVERY=no FM_FAKE_HERMES_UNDELIVERED_STATE=initializing-only \
+    run_spawn "$CASE_DIR" "$HOME_DIR" "$PROJ_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$id") || rc=$?
+  [ "$rc" -ne 0 ] || fail "pre-submit Initializing agent must not confirm delivery"
+  assert_contains "$out" "hermes brief pointer delivery was not confirmed" \
+    "swallowed pointer with startup chrome left in scrollback did not fail loudly"
+  pass "fm-spawn: startup Initializing agent alone never confirms brief delivery"
 }
 
 test_hermes_detection_uses_argv_not_bare_python() {
@@ -426,6 +468,8 @@ test_hermes_missing_binary_refuses_before_pane_creation
 test_hermes_falls_back_to_hermes_agent_binary
 test_hermes_unconfirmed_delivery_fails_loudly
 test_hermes_readiness_gate_precedes_pointer
+test_hermes_bare_shell_prompt_is_not_readiness
+test_hermes_startup_chrome_alone_is_not_delivery
 test_hermes_detection_uses_argv_not_bare_python
 test_hermes_composer_idle_glyph_is_empty
 test_hermes_busy_signature_is_harness_scoped

--- a/tests/fm-tmux-agent-liveness.test.sh
+++ b/tests/fm-tmux-agent-liveness.test.sh
@@ -215,6 +215,40 @@ kill -0 "$bg_pid" 2>/dev/null \
   || fail "the background harness-named process died during the check, so this case proves nothing"
 pass "tmux liveness: a harness-named background process in an idle pane still classifies dead"
 
+# --- an argv path that merely mentions a harness is not an agent ------------
+# The interpreter-wrapped Hermes scan reads later argv tokens, not just argv[0],
+# so it can see any file an ordinary command was pointed at. An editor opened on
+# a hermes-named note is the cheap way to prove that scan cannot manufacture an
+# agent: a false alive here would suppress recovery on an empty pane forever.
+
+mkdir -p "$LAB/notes"
+cat > "$LAB/bin/editor-decoy" <<'SH'
+#!/bin/sh
+/bin/sh
+SH
+chmod +x "$LAB/bin/editor-decoy"
+new_window editor "$LAB/bin/editor-decoy" "$LAB/notes/hermes-todo.md"
+wait_for_state "$SESSION:editor" dead \
+  || fail "a non-interpreter command whose argv names a hermes path must classify dead"
+pass "tmux liveness: an editor opened on a hermes-named file never classifies as an agent"
+
+# --- an interpreter-wrapped hermes is still found through its argv ----------
+# The positive half of the same scan: Hermes really does run as Python with the
+# executable path in a later argv token, and that pane must stay alive.
+
+if PYTHON_BIN=$(command -v python3 2>/dev/null); then
+  cat > "$LAB/bin/hermes" <<'PY'
+import time
+time.sleep(900)
+PY
+  new_window hermespy "$PYTHON_BIN" "$LAB/bin/hermes" chat --yolo
+  wait_for_state "$SESSION:hermespy" alive \
+    || fail "an interpreter-wrapped hermes must classify alive from its argv path token"
+  pass "tmux liveness: python-wrapped hermes classifies alive through its absolute argv path"
+else
+  echo "skip: python3 not found; interpreter-wrapped hermes case not run"
+fi
+
 # --- an absent window never inherits tmux's active-window fallback ----------
 # tmux answers a display-message for an absent target from the CLIENT's active
 # window instead of failing, so both raw name reads can describe a completely


### PR DESCRIPTION
## Summary
- Add Hermes Agent as a verified firstmate crewmate harness (classic REPL: `hermes chat --yolo --accept-hooks`).
- Kimi-style bare launch with readiness-gated absolute brief pointer delivery; fail closed if undelivered.
- Harness-scoped busy classification (`hermes-regex`), argv-based detection (not bare Python), composer idle `❯`, remote-doctor parity, and public-interface tests.

## Safety gates in this ship
- Readiness requires Hermes banner chrome **and** a live agent process (not bare `❯`, not banner left after exit).
- Delivery requires a live agent plus post-submit busy footer or idle `❯` with pointer text; never `Initializing agent` alone.
- Busy idle only with bare `❯`; otherwise unknown (never false idle).
- tmux argv scan: interpreter-wrapped only, exact basename `hermes`/`hermes-agent`.

## Test plan
- [x] `tests/fm-hermes-harness.test.sh`
- [x] `tests/fm-busy-state.test.sh` (hermes isolation)
- [x] Related busy/composer/adapter tests during development
- [ ] CI green on PR

Shipped **direct-PR** (no-mistakes gate skipped for this task only; gate agents were exhausted).