### PR TITLE
feat(skills): add gauntlet-loop agent skill

### DIFF
--- a/.agents/skills/gauntlet-loop/SKILL.md
+++ b/.agents/skills/gauntlet-loop/SKILL.md
@@ -1,0 +1,138 @@
+---
+name: gauntlet-loop
+description: >-
+  Agent-only procedure for running the Gauntlet Loop quality method.
+  Load before starting owner-facing, design-craft, or claim-making work, including detector claims and proof that depends on target box hardware, and whenever the captain invokes a gauntlet.
+  It owns the inspectable quality bar, independent builder and critic loop, live workbench, stopping conditions, and composition with no-mistakes.
+user-invocable: false
+metadata:
+  internal: true
+---
+
+# gauntlet-loop
+
+Use this skill to drive inspectable output toward a real quality bar through repeated building and independent criticism.
+This procedure adapts Matt Shumer's [Gauntlet Loop](https://somethingbig.ai/gauntlet-loop/), adopted by the captain as a core development method on 2026-08-04.
+It is the single owner of Firstmate's Gauntlet Loop procedure.
+
+## Preserve authority and settled law
+
+Start from the accepted product goal, not an implementation recipe.
+Treat the captain's settled laws and the task's accepted constraints as fixed boundaries for both builder and critic.
+Never use a gauntlet to reopen offline-only operation, no streaming, a films-only corpus, truthfulness, no red merges, or any other settled captain law.
+A critic suggestion that requires violating settled law is not an option and must be replaced by criticism against the lawful bar.
+If the goal cannot meet its bar inside those boundaries, report that incompatibility instead of negotiating against the boundary through repeated criticism.
+The loop does not expand merge, destructive-action, irreversible-action, security-sensitive, or ask-user authority.
+
+## Decide whether to run the loop
+
+Prefer the loop when the outcome will be directly judged by an owner or user, when design craft materially affects success, or when the work makes a detector or product claim that must survive inspection.
+Prefer it when proof depends on the real target box or other hardware rather than a proxy environment.
+Examples include interfaces, demos, visual or interaction design, generated media, owner-facing reports, detector quality, comparative product claims, latency claims, and target-hardware evidence.
+Default the loop off for pure plumbing whose complete contract is exercised by green tests and that has no owner-facing surface or qualitative claim.
+Do not add the loop merely to make routine infrastructure work sound more rigorous.
+When applicability is uncertain, identify whether a reasonable critic could inspect a real artifact against a stronger bar than the existing executable contract.
+Use the loop only when the answer is yes.
+
+## Frame the gauntlet
+
+State one outcome goal in terms of what the finished artifact must accomplish for its owner.
+Do not prescribe architecture, file changes, or a sequence of implementation steps unless an accepted constraint requires one.
+Define the bar with evidence the critic can inspect, such as approved references, target screenshots, executable behavior, benchmark thresholds, latency budgets, best-in-class comparisons, factual claim evidence, recordings from the target box, or tests on the real artifact.
+Replace vague standards such as "make it amazing" with observable comparisons or thresholds.
+Record which references are authoritative, which are directional, and which claims require direct proof.
+Set a spend cap before the first build wave using the captain's cap when one exists or an explicit proportionate operational cap otherwise.
+Express the cap in a form that can actually stop work, such as token spend, monetary spend, or elapsed agent effort, without turning it into a planned fixed round count.
+The only loop exits are a pass against the bar, a captain stop, or the spend cap.
+
+## Establish the live workbench
+
+Have the lead publish a live progress page or workbench before the first artifact is judged.
+Use a project preview, artifact index, task-owned report, or another durable surface that the captain can inspect without interrupting the work.
+Keep the workbench current with the goal, fixed constraints, quality bar, judgeable pieces, links or captures plus a stable identity for the latest real artifacts, the current largest gap, resolved gaps, spend against cap, and the active stop condition.
+Update the workbench as part of each build and critic handoff rather than asking the captain for routine progress checks.
+The workbench reports evidence and progress, but it does not create approval authority or substitute for a required captain decision.
+
+## Split and build
+
+Have the lead split the goal into the smallest pieces that can be built and judged independently against a meaningful part of the bar.
+A piece is too large when a critic could fail unrelated qualities in one verdict.
+A piece is too small when passing it says nothing useful about the owner-visible outcome.
+Keep cross-piece constraints visible in the workbench so local optimization does not silently break the whole.
+Give the builder the goal, bar, fixed constraints, current piece, current largest gap when one exists, and the artifact location.
+Do not turn critic observations into a mandatory implementation recipe.
+The builder owns how to close the gap and updates the real artifact plus workbench evidence.
+
+## Run an independent critic wave
+
+Use a separate spawn with a fresh context for every critic judgment.
+Never let the builder continue in its own pane as the critic, and never let a self-review count as a gauntlet verdict.
+Treat the critic as a bounded knowledge-only scout attached to the accepted task, not as a second delivery owner or a replacement for the selected delivery path.
+Give the critic the goal, fixed constraints, inspectable bar, relevant piece or whole-artifact scope, and direct access to the latest real artifact.
+Withhold the builder's rationale and implementation narrative unless either is itself part of the artifact being judged.
+Require inspection of the artifact rather than acceptance of screenshots, summaries, or claimed test results when the real surface is safely available.
+For visual, interaction, latency, detector, and hardware-dependent claims, judge the surface and environment on which the claim depends.
+Use blind A/B comparison when feasible by anonymizing candidates, randomizing their order, and asking for the bar-based verdict before revealing identity.
+The critic returns only a pass or one largest remaining gap, supported by concrete evidence and the relevant bar criterion.
+The critic may inspect broadly to identify that gap, but it must not send the builder a backlog of lesser preferences.
+A pass means the judged scope meets the declared bar without relying on the builder's explanation.
+
+## Loop on the largest gap
+
+Route the critic's single largest gap back to the builder as the next outcome to improve.
+Preserve the goal, bar, and fixed constraints while leaving the implementation choice to the builder.
+After the builder updates the artifact and workbench, commission another fresh critic context against the new real artifact.
+Do not set a fixed number of rounds and do not stop because an arbitrary iteration count has elapsed.
+Continue until the current scope passes, the captain stops the loop, or the spend cap is reached.
+When the cap is reached without a pass, stop and report the strongest current artifact, the unmet bar criterion, the evidence for the largest remaining gap, and the consequence of shipping as-is.
+Do not relabel a capped result as a pass.
+
+## Reconcile the whole artifact
+
+After independently judged pieces pass, optionally run an end-of-wave smoothing pass when their combination can create visible seams, inconsistent language, uneven interaction, conflicting timings, or other coherence defects.
+Give the builder a coherence goal and the complete artifact rather than a list of implementation edits.
+Follow smoothing with a fresh independent critic judgment of the whole artifact.
+Do not use smoothing to reopen settled constraints or to replace the critic.
+The gauntlet passes only when the relevant piece-level bars and the required whole-artifact bar pass.
+
+## Compose with delivery and no-mistakes
+
+Run the gauntlet inside the accepted task and selected delivery path.
+The gauntlet adds a quality critic loop for inspectable output, but it does not replace executable tests, CI, code review, documentation checks, or no-mistakes.
+Complete builder changes and the gauntlet verdict before starting no-mistakes validation so the quality loop does not compete with pipeline ownership of the branch.
+Do not run the critic as a parallel code reviewer while no-mistakes owns validation.
+The critic judges the owner-visible artifact and declared claims, while no-mistakes retains ownership of delivery review and verification.
+A gauntlet pass cannot authorize a red merge, and green tests cannot substitute for a failed owner-visible bar when the gauntlet applies.
+
+## When not to use it
+
+Do not use the loop for pure plumbing with a complete green executable contract and no owner-facing surface.
+Do not use it to seek a different answer to a settled captain decision.
+Do not use it when no real artifact or honest proxy can be inspected, and first establish an inspectable proof surface instead.
+Do not use it as open-ended polish without a declared bar and spend cap.
+Do not use the builder's confidence, prose explanation, or self-score as the critic verdict.
+Do not use it to duplicate no-mistakes review or bypass the project's delivery and approval rules.
+
+## Appendix: task-specific meta-prompt
+
+Use this short meta-prompt to produce the builder and critic instructions for one gauntlet.
+
+```text
+Turn the accepted task below into a Gauntlet Loop packet.
+Write an outcome-focused builder prompt and a separate fresh-context critic prompt.
+Preserve every settled law and accepted constraint without proposing alternatives to them.
+Define an inspectable bar from the supplied references, tests, comparisons, thresholds, and real artifact surface.
+Split the goal into the smallest independently judgeable pieces.
+Specify the live workbench fields and artifact links the lead must maintain.
+Make the critic inspect the real artifact, use blind A/B when feasible, and return only pass or the single largest remaining evidence-backed gap.
+Route gaps as outcomes rather than implementation recipes.
+State the spend cap and stop only on pass, captain stop, or that cap.
+Include an optional final coherence pass when independently improved pieces can create seams.
+Keep no-mistakes, tests, CI, review, merge authority, and settled captain law unchanged.
+
+Accepted task: {task}
+Settled laws and constraints: {constraints}
+Inspectable references and bar evidence: {bar_evidence}
+Real artifact and target environment: {artifact}
+Spend cap: {cap}
+```

--- a/.agents/skills/gauntlet-loop/SKILL.md
+++ b/.agents/skills/gauntlet-loop/SKILL.md
@@ -33,6 +33,8 @@ Default the loop off for pure plumbing whose complete contract is exercised by g
 Do not add the loop merely to make routine infrastructure work sound more rigorous.
 When applicability is uncertain, identify whether a reasonable critic could inspect a real artifact against a stronger bar than the existing executable contract.
 Use the loop only when the answer is yes.
+Load the loop only when the captain invokes a gauntlet or when the accepted task is already owner-facing, design-craft, or claim-making at intake, never as a discretionary extra review layered onto other work.
+The lead duty belongs to whoever owns the accepted task, normally firstmate for a directly owned task or the crewmate lead of its worktree, the builder duty belongs to that task's existing worker, and the critic duty belongs to a fresh separate spawn, so the loop uses only the existing captain, firstmate, crewmate, and secondmate roles and invents no new fleet role.
 
 ## Frame the gauntlet
 
@@ -43,7 +45,7 @@ Replace vague standards such as "make it amazing" with observable comparisons or
 Record which references are authoritative, which are directional, and which claims require direct proof.
 Set a spend cap before the first build wave using the captain's cap when one exists or an explicit proportionate operational cap otherwise.
 Express the cap in a form that can actually stop work, such as token spend, monetary spend, or elapsed agent effort, without turning it into a planned fixed round count.
-The only loop exits are a pass against the bar, a captain stop, or the spend cap.
+The only loop exits are a pass against the bar, a captain stop, the spend cap, or rounds that no longer shrink the gap against the bar.
 
 ## Establish the live workbench
 
@@ -67,7 +69,10 @@ The builder owns how to close the gap and updates the real artifact plus workben
 
 Use a separate spawn with a fresh context for every critic judgment.
 Never let the builder continue in its own pane as the critic, and never let a self-review count as a gauntlet verdict.
-Treat the critic as a bounded knowledge-only scout attached to the accepted task, not as a second delivery owner or a replacement for the selected delivery path.
+Treat the critic as a bounded knowledge-only judgment inside the accepted task, not as a second delivery owner or a replacement for the selected delivery path.
+Default to a short-lived separate spawn or subagent that reads the real artifact and returns its verdict, rather than a full scout task with its own backlog entry, scratch worktree, and teardown.
+Record each verdict as a written artifact under the parent task, such as `data/<id>/critic-round-N.md` or a dated workbench section, so the judgment survives the spawn.
+Promote a round to a full scout task, with the usual dispatch-profile resolution, `bin/fm-brief.sh` scaffold, `harness-adapters` load, and `report.md`, only when the lead deliberately chooses that shape for a large independent piece.
 Give the critic the goal, fixed constraints, inspectable bar, relevant piece or whole-artifact scope, and direct access to the latest real artifact.
 Withhold the builder's rationale and implementation narrative unless either is itself part of the artifact being judged.
 Require inspection of the artifact rather than acceptance of screenshots, summaries, or claimed test results when the real surface is safely available.
@@ -83,9 +88,10 @@ Route the critic's single largest gap back to the builder as the next outcome to
 Preserve the goal, bar, and fixed constraints while leaving the implementation choice to the builder.
 After the builder updates the artifact and workbench, commission another fresh critic context against the new real artifact.
 Do not set a fixed number of rounds and do not stop because an arbitrary iteration count has elapsed.
-Continue until the current scope passes, the captain stops the loop, or the spend cap is reached.
-When the cap is reached without a pass, stop and report the strongest current artifact, the unmet bar criterion, the evidence for the largest remaining gap, and the consequence of shipping as-is.
-Do not relabel a capped result as a pass.
+Continue until the current scope passes, the captain stops the loop, the spend cap is reached, or successive rounds stop producing a materially smaller gap against the bar.
+Treat that diminishing return as a real stop condition rather than a reason to keep spawning critics indefinitely.
+When the loop stops without a pass, report the strongest current artifact, the unmet bar criterion, the evidence for the largest remaining gap, and the consequence of shipping as-is.
+Do not relabel a capped or stalled result as a pass.
 
 ## Reconcile the whole artifact
 
@@ -98,6 +104,9 @@ The gauntlet passes only when the relevant piece-level bars and the required who
 ## Compose with delivery and no-mistakes
 
 Run the gauntlet inside the accepted task and selected delivery path.
+The gauntlet is an in-task quality loop on inspectable owner-facing craft and claims, so it is not a second pull-request review and not one of the stacked serial manual clean-verdict gates that section 8 forbids.
+It never authorizes holding a pull request, a merge, or any delivery step open for extra manual review, and it never converts its own verdict into delivery approval.
+The captain keeps merge authority, and standing `yolo` authority changes that only where section 8 already allows it.
 The gauntlet adds a quality critic loop for inspectable output, but it does not replace executable tests, CI, code review, documentation checks, or no-mistakes.
 Complete builder changes and the gauntlet verdict before starting no-mistakes validation so the quality loop does not compete with pipeline ownership of the branch.
 Do not run the critic as a parallel code reviewer while no-mistakes owns validation.

--- a/.agents/skills/gauntlet-loop/SKILL.md
+++ b/.agents/skills/gauntlet-loop/SKILL.md
@@ -33,7 +33,7 @@ Default the loop off for pure plumbing whose complete contract is exercised by g
 Do not add the loop merely to make routine infrastructure work sound more rigorous.
 When applicability is uncertain, identify whether a reasonable critic could inspect a real artifact against a stronger bar than the existing executable contract.
 Use the loop only when the answer is yes.
-Load the loop only when the captain invokes a gauntlet or when the accepted task is already owner-facing, design-craft, or claim-making at intake, never as a discretionary extra review layered onto other work.
+Load the loop only when the captain invokes a gauntlet, when the accepted task is already owner-facing, design-craft, or claim-making at intake, or when its proof depends on the real target box rather than a proxy environment, never as a discretionary extra review layered onto other work.
 The lead duty belongs to whoever owns the accepted task, normally firstmate for a directly owned task or the crewmate lead of its worktree, the builder duty belongs to that task's existing worker, and the critic duty belongs to a fresh separate spawn, so the loop uses only the existing captain, firstmate, crewmate, and secondmate roles and invents no new fleet role.
 
 ## Frame the gauntlet
@@ -104,9 +104,9 @@ The gauntlet passes only when the relevant piece-level bars and the required who
 ## Compose with delivery and no-mistakes
 
 Run the gauntlet inside the accepted task and selected delivery path.
-The gauntlet is an in-task quality loop on inspectable owner-facing craft and claims, so it is not a second pull-request review and not one of the stacked serial manual clean-verdict gates that section 8 forbids.
+The gauntlet is an in-task quality loop on inspectable owner-facing craft and claims, so it is not a second pull-request review and not one of the stacked serial manual clean-verdict gates that `AGENTS.md` section 7's selected delivery path and approval authority forbids.
 It never authorizes holding a pull request, a merge, or any delivery step open for extra manual review, and it never converts its own verdict into delivery approval.
-The captain keeps merge authority, and standing `yolo` authority changes that only where section 8 already allows it.
+The captain keeps merge authority, and standing `yolo` authority changes that only where `AGENTS.md` section 7's selected delivery path and approval authority already allows it.
 The gauntlet adds a quality critic loop for inspectable output, but it does not replace executable tests, CI, code review, documentation checks, or no-mistakes.
 Complete builder changes and the gauntlet verdict before starting no-mistakes validation so the quality loop does not compete with pipeline ownership of the branch.
 Do not run the critic as a parallel code reviewer while no-mistakes owns validation.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -497,6 +497,7 @@ These skills are not captain-invocable; load them only at their precise triggers
 
 - `bootstrap-diagnostics` - load whenever the session-start digest's bootstrap section prints an actionable diagnostic line (`MISSING:`, `MISSING_MANUAL:`, `BACKEND_INVALID:`, `NEEDS_GH_AUTH`, `TANGLE:`, `STARTUP_MEMORY_BUDGET:`, `CREW_DISPATCH: invalid`, `FLEET_SYNC:`, `PR_CHECK_MIGRATION:`, `SECONDMATE_SYNC:`, `SECONDMATE_LIVENESS:`, `SECONDMATE_HANDOFF:`, `NUDGE_SECONDMATES:`, or `FMX:`); silence and `BOOTSTRAP_INFO:` need no load.
 - `diagnostic-reasoning` - load before scoping a reported bug and before acting on a diagnostic report.
+- `gauntlet-loop` - load before starting owner-facing, design-craft, or claim-making work, including detector claims and proof that depends on target box hardware, and whenever the captain invokes a gauntlet.
 - `ask-user-authority` - load before deciding any ask-user finding, regardless of the project's `yolo` posture.
 - `quota-array-dispatch` - load before choosing among a matched crew-dispatch profile array from current quota-axi output.
 - `harness-adapters` - load before spawning or recovering a crewmate or secondmate, handling a trust dialog, sending a harness-specific skill invocation, interrupting or exiting an agent, resuming an exited agent, or verifying a new harness adapter.

--- a/docs/documentation-audiences.json
+++ b/docs/documentation-audiences.json
@@ -153,6 +153,10 @@
       "audience": "agent-runtime"
     },
     {
+      "path": ".agents/skills/gauntlet-loop/SKILL.md",
+      "audience": "agent-runtime"
+    },
+    {
       "path": ".agents/skills/harness-adapters/SKILL.md",
       "audience": "agent-runtime"
     },


### PR DESCRIPTION
## Intent

Add a Firstmate agent-only skill that owns the Gauntlet Loop development method adapted from Matt Shumer's https://somethingbig.ai/gauntlet-loop/, captain-approved as a core loop on 2026-08-04, and wire its precise load trigger into AGENTS.md. The skill must carry metadata.internal=true, have clear description and triggers, and fully own this procedure: frame a goal rather than an implementation recipe; establish a real inspectable quality bar from references, screenshots, tests, latency, best-in-class comparisons, or equivalent evidence rather than vague praise; have the lead split the goal into the smallest independently judgeable pieces; never let the builder grade itself; use a separate fresh-context critic spawn against the real artifact, with blind A/B when possible, that identifies only the largest remaining gap; continue without a fixed round count until pass, captain stop, or spend cap; maintain a live progress page or workbench that the lead updates without interrupting the captain; and optionally run an end-of-wave smoothing pass for coherence. Adapt the method for Firstmate by preferring it for owner-facing surfaces, design craft, detector or product claims, and proof that depends on target box hardware, while defaulting it off for pure plumbing with green tests and no owner surface. Never let the gauntlet reopen settled captain law, including offline-only operation, no streaming, a films-only corpus, truthfulness, and no red merges. Compose it with no-mistakes as an added inspectable-output quality loop that does not replace tests, CI, review, documentation checks, or delivery authority. Include when not to use it and a short meta-prompt appendix for generating task-specific gauntlet prompts. Add only a one-line section 13 load trigger for owner-facing, design-craft, or claim-making work and whenever the captain invokes a gauntlet, using the inline-stub pattern without restating the procedure in AGENTS.md. Rely on the existing .claude/skills compatibility symlink if it exposes the new standard-layout skill. Do not add mechanical helpers, tests, or docs/verification material when the change remains pure skill Markdown without enforceable behavior. Keep one full sentence per Markdown line, use plain dashes, and add no agent co-author.

## What Changed

- Added `.agents/skills/gauntlet-loop/SKILL.md`, an agent-only (`metadata.internal: true`, not captain-invocable) skill that owns Firstmate's Gauntlet Loop procedure adapted from Matt Shumer's method: framing an outcome goal instead of an implementation recipe, establishing an inspectable evidence-based quality bar, splitting into smallest independently judgeable pieces, running fresh-context critic spawns with blind A/B that return only the single largest remaining gap, maintaining a live workbench, stopping on pass/captain stop/spend cap/diminishing returns, and an optional end-of-wave coherence pass. It also fixes the boundaries: settled captain law stays closed, the critic is an in-task quality loop rather than a stacked manual review gate under `AGENTS.md` section 7, and it composes with no-mistakes without replacing tests, CI, review, docs checks, or delivery authority. Includes `## When not to use it` and a meta-prompt appendix for generating task-specific gauntlet packets.
- Registered a single-line `gauntlet-loop` load trigger in `AGENTS.md` section 13 (owner-facing, design-craft, or claim-making work, including detector claims and target-box hardware proof, plus any captain-invoked gauntlet) using the existing inline-stub pattern, with no procedure restated.
- Classified the new skill as `agent-runtime` in `docs/documentation-audiences.json` so `bin/fm-doc-audience-check.sh` and `tests/fm-documentation-audiences.test.sh` stay green; the `.claude/skills` compatibility symlink already exposes the standard-layout skill, so no new helpers or tests were needed.

## Risk Assessment

✅ Low: The change is pure agent-instruction Markdown plus one required documentation-audience inventory entry, every earlier finding the author chose to fix is now correctly and minimally resolved, and the remaining branch carries no executable behavior or runtime risk.

## Testing

Ran the two targeted suites the changed files actually touch (documentation-audience inventory and AGENTS.md handling), both green, instead of the 28-script family the changed-file map selects. Because the end user of this change is an agent rather than a human UI, I produced the equivalent product-level artifact: a CLI transcript of the harness skill-discovery path showing `gauntlet-loop` resolving through the existing `.claude/skills` symlink into the agent-only registry with `metadata.internal=true` and `user-invocable=false`, its strict-YAML frontmatter, and the single AGENTS.md section 13 line that routes an agent to it with the procedure left entirely in the skill. I also swept all 27 required and forbidden clauses of the stated intent against the diff and every one passed, including the style rules and the constraint that no helper scripts, tests, or verification docs be added. There is no rendered UI, image, or GIF artifact because the change ships no visual surface - it is Markdown consumed by an agent, so the reviewer-visible surface is the skill registry transcript itself.

<details>
<summary>Evidence: Agent-visible skill discovery transcript (symlink resolution, registry entry, section 13 trigger)</summary>

<code>=== harness skill discovery path ===&#10;.claude/skills -&gt; ../.agents/skills (compatibility symlink)&#10;resolves to -&gt; .agents/skills&#10;gauntlet-loop visible at -&gt; .claude/skills/gauntlet-loop/SKILL.md [readable=True, bytes=12898]&#10;&#10;=== registry entry an agent reads for gauntlet-loop ===&#10;name: gauntlet-loop&#10;user-invocable: false&#10;metadata.internal: true&#10;&#10;=== AGENTS.md section 13 load trigger (what routes the agent here) ===&#10;## 13. Agent-only reference skills&#10;These skills are not captain-invocable; load them only at their precise triggers.&#10;AGENTS.md:500: - `gauntlet-loop` - load before starting owner-facing, design-craft, or claim-making work, including detector claims and proof that depends on target box hardware, and whenever the captain invokes a gauntlet.&#10;-&gt; single line, 208 chars, no procedure restated in AGENTS.md&#10;-&gt; gauntlet-loop mentioned in AGENTS.md exactly 1 time(s); procedure lives in the skill (147 lines)&#10;&#10;=== procedure the skill owns (headings) ===&#10;## Preserve authority and settled law&#10;## Decide whether to run the loop&#10;## Frame the gauntlet&#10;## Establish the live workbench&#10;## Split and build&#10;## Run an independent critic wave&#10;## Loop on the largest gap&#10;## Reconcile the whole artifact&#10;## Compose with delivery and no-mistakes&#10;## When not to use it&#10;## Appendix: task-specific meta-prompt&#10;&#10;strict YAML frontmatter parse OK&#10;assertions OK: name=gauntlet-loop, user-invocable=False, metadata.internal=True</code>

```text
=== harness skill discovery path ===
.claude/skills            -> ../.agents/skills  (compatibility symlink)
resolves to               -> .agents/skills
gauntlet-loop visible at  -> .claude/skills/gauntlet-loop/SKILL.md  [readable=True, bytes=12898]

=== agent-only (internal) skills the harness registers ===
  afk                          metadata.internal=true  user-invocable=true  
  ahoy                         metadata.internal=true  user-invocable=true  
  ask-user-authority           metadata.internal=true  user-invocable=false 
  bearings                     metadata.internal=true  user-invocable=true  
  bootstrap-diagnostics        metadata.internal=true  user-invocable=false 
  decision-hold-lifecycle      metadata.internal=true  user-invocable=false 
  diagnostic-reasoning         metadata.internal=true  user-invocable=false 
  firstmate-codexapp           metadata.internal=true  user-invocable=false 
  firstmate-coding-guidelines  metadata.internal=true  user-invocable=false 
  firstmate-orca               metadata.internal=true  user-invocable=false 
  fmx-respond                  metadata.internal=true  user-invocable=false 
  gauntlet-loop                metadata.internal=true  user-invocable=false <-- new
  harness-adapters             metadata.internal=true  user-invocable=false 
  process-event-sources        metadata.internal=true  user-invocable=false 
  project-management           metadata.internal=true  user-invocable=false 
  quota-array-dispatch         metadata.internal=true  user-invocable=false 
  secondmate-provisioning      metadata.internal=true  user-invocable=false 
  stow                         metadata.internal=true  user-invocable=true  
  stuck-crewmate-recovery      metadata.internal=true  user-invocable=false 
  updatefirstmate              metadata.internal=true  user-invocable=true  

=== registry entry an agent reads for gauntlet-loop ===
  name:        gauntlet-loop
  description: Agent-only procedure for running the Gauntlet Loop quality method. Load before starting owner-facing, design-craft, or claim-making work, including detector claims and proof that depends on target box hardware, and whenever the captain invokes a gauntlet. It owns the inspectable quality bar, independent builder and critic loop, live workbench, stopping conditions, and composition with no-mistakes.
  user-invocable: false
  metadata.internal: true

=== AGENTS.md section 13 load trigger (what routes the agent here) ===
  ## 13. Agent-only reference skills
  These skills are not captain-invocable; load them only at their precise triggers.
  AGENTS.md:500: - `gauntlet-loop` - load before starting owner-facing, design-craft, or claim-making work, including detector claims and proof that depends on target box hardware, and whenever the captain invokes a gauntlet.
  -> single line, 208 chars, no procedure restated in AGENTS.md
  -> gauntlet-loop mentioned in AGENTS.md exactly 1 time(s); procedure lives in the skill (147 lines)

=== procedure the skill owns (headings) ===
  ## Preserve authority and settled law
  ## Decide whether to run the loop
  ## Frame the gauntlet
  ## Establish the live workbench
  ## Split and build
  ## Run an independent critic wave
  ## Loop on the largest gap
  ## Reconcile the whole artifact
  ## Compose with delivery and no-mistakes
  ## When not to use it
  ## Appendix: task-specific meta-prompt
strict YAML frontmatter parse OK
{'name': 'gauntlet-loop', 'description': 'Agent-only procedure for running the Gauntlet Loop quality m...', 'user-invocable': False, 'metadata': {'internal': True}}
assertions OK: name=gauntlet-loop, user-invocable=False, metadata.internal=True
```
</details>
<details>
<summary>Evidence: Intent constraint coverage (27/27 required and forbidden clauses)</summary>

<code>[PASS] source attributed to Matt Shumer&#39;s gauntlet-loop post&#10;[PASS] captain-approved as a core loop on 2026-08-04&#10;[PASS] metadata.internal=true&#10;[PASS] clear description and load triggers in frontmatter&#10;[PASS] frame a goal, not an implementation recipe&#10;[PASS] inspectable quality bar from real evidence, not vague praise&#10;[PASS] lead splits goal into smallest independently judgeable pieces&#10;[PASS] builder never grades itself&#10;[PASS] separate fresh-context critic spawn against the real artifact&#10;[PASS] blind A/B when possible&#10;[PASS] critic returns only the largest remaining gap&#10;[PASS] no fixed round count; stop on pass, captain stop, or spend cap&#10;[PASS] live progress page / workbench the lead updates without interrupting captain&#10;[PASS] optional end-of-wave smoothing pass for coherence&#10;[PASS] prefer for owner-facing, design craft, detector/product claims, hardware proof&#10;[PASS] default off for pure plumbing with green tests and no owner surface&#10;[PASS] never reopens settled captain law (offline-only, no streaming, films-only, truthfulness, no red merges)&#10;[PASS] composes with no-mistakes without replacing tests/CI/review/docs/delivery&#10;[PASS] &#34;When not to use it&#34; section present&#10;[PASS] meta-prompt appendix present&#10;[PASS] AGENTS.md gains exactly one section 13 stub line&#10;[PASS] AGENTS.md stub sits inside section 13&#10;[PASS] relies on existing .claude/skills symlink (no new harness plumbing)&#10;[PASS] one full sentence per Markdown line (prose)&#10;[PASS] plain dashes and plain quotes only&#10;[PASS] no agent co-author on the branch commits&#10;[PASS] no helper scripts, tests, or verification docs added (changed: .agents/skills/gauntlet-loop/SKILL.md, AGENTS.md, docs/documentation-audiences.json)&#10;&#10;27/27 intent constraints satisfied</code>

```text
  [PASS] source attributed to Matt Shumer's gauntlet-loop post
  [PASS] captain-approved as a core loop on 2026-08-04
  [PASS] metadata.internal=true
  [PASS] clear description and load triggers in frontmatter
  [PASS] frame a goal, not an implementation recipe
  [PASS] inspectable quality bar from real evidence, not vague praise
  [PASS] lead splits goal into smallest independently judgeable pieces
  [PASS] builder never grades itself
  [PASS] separate fresh-context critic spawn against the real artifact
  [PASS] blind A/B when possible
  [PASS] critic returns only the largest remaining gap
  [PASS] no fixed round count; stop on pass, captain stop, or spend cap
  [PASS] live progress page / workbench the lead updates without interrupting captain
  [PASS] optional end-of-wave smoothing pass for coherence
  [PASS] prefer for owner-facing, design craft, detector/product claims, hardware proof
  [PASS] default off for pure plumbing with green tests and no owner surface
  [PASS] never reopens settled captain law (offline-only, no streaming, films-only, truthfulness, no red merges)
  [PASS] composes with no-mistakes without replacing tests/CI/review/docs/delivery
  [PASS] "When not to use it" section present
  [PASS] meta-prompt appendix present
  [PASS] AGENTS.md gains exactly one section 13 stub line
  [PASS] AGENTS.md stub sits inside section 13
  [PASS] relies on existing .claude/skills symlink (no new harness plumbing)
  [PASS] one full sentence per Markdown line (prose)
  [PASS] plain dashes and plain quotes only
  [PASS] no agent co-author on the branch commits
  [PASS] no helper scripts, tests, or verification docs added (changed: .agents/skills/gauntlet-loop/SKILL.md, AGENTS.md, docs/documentation-audiences.json)

  27/27 intent constraints satisfied
```
</details>
<details>
<summary>Evidence: Targeted suite run (documentation-audience inventory + AGENTS.md handling)</summary>

```text
$ bin/fm-test-run.sh tests/fm-documentation-audiences.test.sh tests/fm-ensure-agents-md.test.sh
ok - documentation inventory classifies every maintained prose surface exactly once
ok - classification, setup routing, and maintained-prose scope fail safely
ok - required documentation owner pointers cannot silently disappear
ok - local links resolve while dates, versions, commands, and incident prose remain semantically reviewed
ok - fm-ensure-agents-md.sh: created AGENTS.md includes self-governance section
ok - fm-ensure-agents-md.sh: existing symlinked AGENTS.md gains the section idempotently
ok - fm-ensure-agents-md.sh: AGENTS.md that already has the section stays unchanged
FM_TEST_SUMMARY total=2 failed=0 skipped_gate=0 duration_ms=682
```
</details>
<details>
<summary>Evidence: Evidence generator: harness skill-discovery render</summary>

```text
#!/usr/bin/env python3
"""Render the agent-visible skill surface for the gauntlet-loop skill.

This walks the same path a Claude-family harness walks: it resolves the
.claude/skills compatibility symlink, reads every SKILL.md frontmatter, and
prints what the agent would see in its skill registry, then prints the
AGENTS.md section 13 load trigger that tells an agent when to load it.
"""
import os
import re
import sys
from pathlib import Path

ROOT = Path(sys.argv[1]).resolve()


def frontmatter(path):
    text = path.read_text(encoding="utf-8")
    if not text.startswith("---\n"):
        return {}
    block = text.split("\n---\n", 1)[0][4:]
    data, key, buf = {}, None, []
    for line in block.splitlines():
        if line.startswith("  ") and key:
            buf.append(line.strip())
            continue
        if key:
            data[key] = " ".join(buf).strip() or data.get(key, "")
            key, buf = None, []
        m = re.match(r"^([A-Za-z0-9_-]+):\s*(.*)$", line)
        if m:
            name, value = m.group(1), m.group(2).strip()
            if value in (">-", "|", ">", ""):
                key, buf = name, []
            else:
                data[name] = value
    if key:
        data[key] = " ".join(buf).strip()
    return data


link = ROOT / ".claude" / "skills"
print("=== harness skill discovery path ===")
print(f".claude/skills            -> {os.readlink(link)}  (compatibility symlink)")
print(f"resolves to               -> {link.resolve().relative_to(ROOT)}")
target = link / "gauntlet-loop" / "SKILL.md"
print(f"gauntlet-loop visible at  -> .claude/skills/gauntlet-loop/SKILL.md  "
      f"[readable={target.is_file()}, bytes={target.stat().st_size}]")

print("\n=== agent-only (internal) skills the harness registers ===")
rows = []
for skill in sorted((ROOT / ".agents" / "skills").iterdir()):
    md = skill / "SKILL.md"
    if not md.is_file():
        continue
    fm = frontmatter(md)
    body = md.read_text(encoding="utf-8")
    internal = "internal: true" in body.split("\n---\n", 1)[0]
    invocable = fm.get("user-invocable", "true")
    rows.append((skill.name, internal, invocable))
width = max(len(r[0]) for r in rows)
for name, internal, invocable in rows:
    mark = "<-- new" if name == "gauntlet-loop" else ""
    print(f"  {name:<{width}}  metadata.internal={str(internal).lower():<5} "
          f"user-invocable={invocable:<5} {mark}")

print("\n=== registry entry an agent reads for gauntlet-loop ===")
fm = frontmatter(target)
print(f"  name:        {fm.get('name')}")
print(f"  description: {fm.get('description')}")
print(f"  user-invocable: {fm.get('user-invocable')}")
print("  metadata.internal: true"
      if "internal: true" in target.read_text(encoding="utf-8")
      else "  metadata.internal: MISSING")

print("\n=== AGENTS.md section 13 load trigger (what routes the agent here) ===")
agents = (ROOT / "AGENTS.md").read_text(encoding="utf-8").splitlines()
start = next(i for i, l in enumerate(agents) if l.startswith("## 13."))
end = next(i for i, l in enumerate(agents[start + 1:], start + 1)
           if l.startswith("## "))
section = agents[start:end]
for i, line in enumerate(section):
    if line.startswith("## 13.") or line.startswith("These skills"):
        print(f"  {line}")
    if "`gauntlet-loop`" in line:
        print(f"  AGENTS.md:{start + i + 1}: {line}")
        print(f"  -> single line, {len(line)} chars, no procedure restated in AGENTS.md")

body = target.read_text(encoding="utf-8")
print(f"  -> gauntlet-loop mentioned in AGENTS.md exactly "
      f"{sum('gauntlet-loop' in l for l in agents)} time(s); "
      f"procedure lives in the skill ({len(body.splitlines())} lines)")

print("\n=== procedure the skill owns (headings) ===")
for line in body.splitlines():
    if line.startswith("## "):
        print(f"  {line}")
```
</details>
<details>
<summary>Evidence: Evidence generator: intent constraint sweep</summary>

```text
#!/usr/bin/env python3
"""Check every required/forbidden clause of the stated intent against the change."""
import re
import subprocess
import sys
from pathlib import Path

ROOT = Path(sys.argv[1]).resolve()
SKILL = ROOT / ".agents/skills/gauntlet-loop/SKILL.md"
body = SKILL.read_text(encoding="utf-8")
low = body.lower()
agents = (ROOT / "AGENTS.md").read_text(encoding="utf-8")

CHECKS = [
    ("source attributed to Matt Shumer's gauntlet-loop post",
     "somethingbig.ai/gauntlet-loop" in body and "Matt Shumer" in body),
    ("captain-approved as a core loop on 2026-08-04",
     "2026-08-04" in body and "core development method" in low),
    ("metadata.internal=true", "internal: true" in body.split("\n---\n")[0]),
    ("clear description and load triggers in frontmatter",
     "description:" in body and "Load before" in body.split("\n---\n")[0]),
    ("frame a goal, not an implementation recipe",
     "not an implementation recipe" in low
     and "do not prescribe architecture" in low),
    ("inspectable quality bar from real evidence, not vague praise",
     'make it amazing' in low and "benchmark thresholds" in low
     and "best-in-class comparisons" in low),
    ("lead splits goal into smallest independently judgeable pieces",
     "smallest pieces that can be built and judged independently" in low),
    ("builder never grades itself",
     "never let the builder continue in its own pane as the critic" in low
     and "self-review count as a gauntlet verdict" in low),
    ("separate fresh-context critic spawn against the real artifact",
     "separate spawn with a fresh context" in low and "real artifact" in low),
    ("blind A/B when possible",
     "blind a/b comparison when feasible" in low),
    ("critic returns only the largest remaining gap",
     "only a pass or one largest remaining gap" in low),
    ("no fixed round count; stop on pass, captain stop, or spend cap",
     "do not set a fixed number of rounds" in low
     and "the captain stops the loop, the spend cap is reached" in low),
    ("live progress page / workbench the lead updates without interrupting captain",
     "live progress page or workbench" in low
     and "without interrupting the work" in low),
    ("optional end-of-wave smoothing pass for coherence",
     "optionally run an end-of-wave smoothing pass" in low),
    ("prefer for owner-facing, design craft, detector/product claims, hardware proof",
     all(s in low for s in ["owner or user", "design craft",
                            "detector or product claim",
                            "real target box"])),
    ("default off for pure plumbing with green tests and no owner surface",
     "default the loop off for pure plumbing" in low),
    ("never reopens settled captain law (offline-only, no streaming, films-only, "
     "truthfulness, no red merges)",
     all(s in low for s in ["offline-only operation", "no streaming",
                            "films-only corpus", "truthfulness",
                            "no red merges"])),
    ("composes with no-mistakes without replacing tests/CI/review/docs/delivery",
     "does not replace executable tests, ci, code review, documentation checks, "
     "or no-mistakes" in low.replace("but it ", "")),
    ('"When not to use it" section present', "## When not to use it" in body),
    ("meta-prompt appendix present",
     "## Appendix: task-specific meta-prompt" in body and "`` `text" in body),
    ("AGENTS.md gains exactly one section 13 stub line",
     agents.count("`gauntlet-loop`") == 1
     and "- `gauntlet-loop` - load before starting owner-facing, design-craft, "
         "or claim-making work" in agents),
    ("AGENTS.md stub sits inside section 13",
     agents.index("`gauntlet-loop`") > agents.index("## 13. Agent-only reference skills")
     and agents.index("`gauntlet-loop`") < agents.index("## 14.")),
    ("relies on existing .claude/skills symlink (no new harness plumbing)",
     (ROOT / ".claude/skills").is_symlink()),
]

body_lines = body.split("\n---\n", 1)[1].splitlines()
in_code = False
multi = []
for i, line in enumerate(body_lines, 1):
    if line.strip().startswith("`` `"):
        in_code = not in_code
        continue
    if in_code or not line.strip():
        continue
    if re.search(r"[.!?] +\S", line):
        multi.append((i, line))
CHECKS.append(("one full sentence per Markdown line (prose)", not multi))

fancy = sorted({c for c in body if c in "–—‘’“”"})
CHECKS.append(("plain dashes and plain quotes only", not fancy))

log = subprocess.run(
    ["git", "log", "--format=%an <%ae>%n%b", "a83be60..HEAD"],
    cwd=ROOT, capture_output=True, text=True).stdout
CHECKS.append(("no agent co-author on the branch commits",
               "Co-Authored-By" not in log and "claude" not in log.lower()))

# Forbidden: no mechanical helpers, tests, or docs/verification material added.
changed = subprocess.run(
    ["git", "diff", "--name-only", "a83be60", "HEAD"],
    cwd=ROOT, capture_output=True, text=True).stdout.split()
allowed = {".agents/skills/gauntlet-loop/SKILL.md", "AGENTS.md",
           "docs/documentation-audiences.json"}
CHECKS.append((f"no helper scripts, tests, or verification docs added "
               f"(changed: {', '.join(changed)})", set(changed) <= allowed))

bad = 0
for label, ok in CHECKS:
    print(f"  [{'PASS' if ok else 'FAIL'}] {label}")
    bad += not ok
if multi:
    print("\n  multi-sentence lines:")
    for i, line in multi:
        print(f"    L{i}: {line[:100]}")
if fancy:
    print(f"\n  non-plain punctuation found: {fancy}")
print(f"\n  {len(CHECKS) - bad}/{len(CHECKS)} intent constraints satisfied")
sys.exit(1 if bad else 0)
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 4 issues found → auto-fixed (2) ✅</summary>

- 🚨 `docs/documentation-audiences.json:155` - The new tracked prose surface `.agents/skills/gauntlet-loop/SKILL.md` is not classified in `docs/documentation-audiences.json`. `bin/fm-doc-audience-check.sh` compares `git ls-files -- *.md *.mdx *.rst *.txt docs/examples/*` against the inventory and fails with `unclassified: .agents/skills/gauntlet-loop/SKILL.md`; `tests/fm-documentation-audiences.test.sh::test_repository_inventory_passes` runs that same check against the real repo, so this fails the docs gate and CI. Every one of the 19 pre-existing `.agents/skills/*/SKILL.md` files is registered with `&#34;audience&#34;: &#34;agent-runtime&#34;`. Fix: insert `{ &#34;path&#34;: &#34;.agents/skills/gauntlet-loop/SKILL.md&#34;, &#34;audience&#34;: &#34;agent-runtime&#34; }` in the alphabetical slot between the `fmx-respond` and `harness-adapters` entries (before line 155). This is a required classification entry enforced by an existing check, not new docs/verification material, so it does not conflict with the intent&#39;s &#34;do not add docs/verification material&#34; constraint.
- ⚠️ `.agents/skills/gauntlet-loop/SKILL.md:102` - The skill authorizes an agent-initiated critic review that AGENTS.md section 8 currently forbids, and the two owners are not reconciled. AGENTS.md:288 says &#34;Never hold work outside no-mistakes for a manual clean verdict, stack serial manual reviews, or infer authority for one from security, architecture, or risk alone,&#34; and AGENTS.md:289 says &#34;A separate review or audit is allowed only when the captain explicitly requests that deliverable or the authorized task is a knowledge-only review.&#34; The new section 13 trigger fires the gauntlet on any &#34;owner-facing, design-craft, or claim-making work&#34; without a captain request, and SKILL.md:102 requires completing &#34;the gauntlet verdict before starting no-mistakes validation&#34; with SKILL.md:96 making the gauntlet pass a precondition. Concrete path: an ordinary no-mistakes ship task on an owner-facing surface, where an agent following AGENTS.md:289 must not spawn a separate critic while an agent following this skill must. SKILL.md:70 and :103-104 attempt the distinction (&#34;the critic judges the owner-visible artifact... no-mistakes retains ownership of delivery review&#34;) but never cite section 8, so the reader has two unlinked rules. Since the intent forbids restating the procedure in AGENTS.md, the resolution belongs in the skill: add an explicit cross-reference stating that the gauntlet critic is not a &#34;separate review or audit&#34; under AGENTS.md section 8. Flagging rather than fixing because it touches the author&#39;s deliberate composition boundary.
- ⚠️ `.agents/skills/gauntlet-loop/SKILL.md:68` - The critic-spawn mechanics do not connect to Firstmate&#39;s existing spawn contract, and the loop runs an unbounded number of these spawns. SKILL.md:68 requires &#34;a separate spawn with a fresh context for every critic judgment&#34; and SKILL.md:70 calls it &#34;a bounded knowledge-only scout attached to the accepted task,&#34; but in Firstmate a scout is its own task with a scratch worktree and a mandatory `report.md` (AGENTS.md:87, :350) - there is no &#34;scout attached to an existing task,&#34; so a reader cannot tell whether each round needs a task, worktree, and report or a lightweight subagent. The skill also never points at the three obligations that fire on such a spawn: dispatch-profile resolution at every crewmate-or-scout intake (AGENTS.md:171, :182 `quota-array-dispatch`), the `bin/fm-brief.sh` scaffold contract (AGENTS.md section 11), and the `harness-adapters` load required &#34;before spawning or recovering a crewmate&#34; (AGENTS.md:499). Because SKILL.md:85-86 forbids a fixed round count, the ambiguity compounds across rounds and, under the heavy reading, multiplies quota-relevant dispatches with no profile resolution. Adding one cross-reference line naming the intended spawn shape would resolve it; the choice of shape is the author&#39;s.
- ℹ️ `.agents/skills/gauntlet-loop/SKILL.md:50` - The skill assigns duties to &#34;the lead&#34; (SKILL.md:50, :58) and &#34;the builder&#34; (SKILL.md:62-64) without mapping either to Firstmate&#39;s role vocabulary (captain, firstmate, crewmate, secondmate), which AGENTS.md:412 otherwise treats as the fixed noun set. &#34;Lead&#34; appears nowhere else in AGENTS.md or the other 19 skills. This is a deliberate carry-over of the source method&#39;s vocabulary from the intent text, so it is noted as a tradeoff rather than a defect; the loop is still executable because the duties themselves are unambiguous.

🔧 Fix: register gauntlet skill and clarify authority and critic spawn
3 issues (1 warning, 2 infos) still open:
- ⚠️ `.agents/skills/gauntlet-loop/SKILL.md:107` - The new authority-reconciliation lines point at the wrong AGENTS.md section, which defeats the purpose of the round-2 fix. SKILL.md:107 says &#34;not one of the stacked serial manual clean-verdict gates that section 8 forbids&#34; and SKILL.md:109 says &#34;standing `yolo` authority changes that only where section 8 already allows it.&#34; Both rules actually live in AGENTS.md section 7, subsection `### Selected delivery path and approval authority` (AGENTS.md:284-307): the stacked-serial-manual-review prohibition is at AGENTS.md:288-289 and the merge-authority/`yolo` text is at AGENTS.md:296-300. AGENTS.md section 8 begins at line 356 and is the Supervision protocol (live supervision cycles, wake draining, status lines) - it contains neither rule. The likely source of the slip is AGENTS.md:282&#39;s forward pointer &#34;Supervise all live work under section 8,&#34; which sits just above the section 7 subsection. Concrete impact: an agent that follows the pointer to resolve a gauntlet-versus-delivery-authority conflict lands on the wrong contract and finds nothing, so the reconciliation this commit was made to add does not actually resolve. Fix: change both references to `AGENTS.md` section 7&#39;s selected delivery path and approval authority. Note the repo convention is to qualify the reference with the file name - `firstmate-coding-guidelines` writes &#34;as defined by `AGENTS.md` section 1&#34; and `afk/SKILL.md:78` already cites &#34;`AGENTS.md` section 7&#34; for this same merge-authority contract - so the bare &#34;section 8&#34; is also ambiguous against the skill&#39;s own headings. Mechanical and non-user-visible.
- ℹ️ `.agents/skills/gauntlet-loop/SKILL.md:34` - The new load gate at SKILL.md:34 drops the target-box hardware case that both the AGENTS.md trigger and the skill&#39;s own applicability section keep. AGENTS.md:500 triggers on &#34;owner-facing, design-craft, or claim-making work, including detector claims and proof that depends on target box hardware,&#34; and SKILL.md:30-31 says &#34;Prefer it when proof depends on the real target box or other hardware rather than a proxy environment.&#34; SKILL.md:34 narrows to &#34;the captain invokes a gauntlet or when the accepted task is already owner-facing, design-craft, or claim-making at intake.&#34; The user intent requires &#34;preferring it for owner-facing surfaces, design craft, detector or product claims, and proof that depends on target box hardware.&#34; Concrete path: a task whose whole point is proving behavior on the real target box, framed at intake as hardware verification rather than an owner-facing or claim-making deliverable - AGENTS.md:500 and SKILL.md:30 both say run it, SKILL.md:34&#39;s enumeration does not list it. A generous reading folds hardware proof into &#34;claim-making,&#34; so this is a wording narrowing rather than a functional removal, and the sentence otherwise matches the author&#39;s round-1 fix instruction verbatim. Adding the hardware-proof clause to the SKILL.md:34 list would align the three statements; flagged rather than fixed because the sentence was directed by the author.
- ℹ️ `.agents/skills/gauntlet-loop/SKILL.md:48` - The loop now has a fourth exit condition beyond the three the intent enumerates. The intent requires &#34;continue without a fixed round count until pass, captain stop, or spend cap,&#34; while SKILL.md:48 reads &#34;a pass against the bar, a captain stop, the spend cap, or rounds that no longer shrink the gap against the bar&#34; and SKILL.md:91-92 adds &#34;or successive rounds stop producing a materially smaller gap&#34; and &#34;Treat that diminishing return as a real stop condition.&#34; This is a self-judged exit that lets the loop terminate on the lead&#39;s assessment rather than only on the three objective conditions. Recorded for transparency only, with no action: the author&#39;s round-1 fix instruction explicitly directed it - &#34;Bound rounds by spend/diminishing returns/captain stop, not infinite&#34; - which is a later and more specific directive from the same author than the original intent enumeration. SKILL.md:93 correctly preserves the honesty guard by forbidding relabeling a &#34;capped or stalled result as a pass.&#34;

🔧 Fix: fix AGENTS.md section pointer and restore hardware load case
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bin/fm-test-run.sh tests/fm-documentation-audiences.test.sh tests/fm-ensure-agents-md.test.sh` - inventory classification, owner pointers, and local-link resolution for the new SKILL.md, plus AGENTS.md handling (13 assertions, all pass)</code>
- <code>`bin/fm-test-run.sh --list --changed --base a83be60` - confirmed the repo&#39;s own changed-file map routes this diff to the pure-contract-unit family, then narrowed to the two scripts that exercise the changed surfaces</code>
- <code>Manual harness-discovery render: resolved `.claude/skills -&gt; ../.agents/skills`, read `.claude/skills/gauntlet-loop/SKILL.md` through the symlink, and printed the agent-visible skill registry showing `gauntlet-loop` with `metadata.internal=true` and `user-invocable=false`</code>
- <code>`python3 -c &#34;yaml.safe_load(...)&#34;` - strict YAML frontmatter parse asserting `name=gauntlet-loop`, `user-invocable=False`, `metadata.internal=True`</code>
- <code>Manual AGENTS.md trigger check: `gauntlet-loop` appears exactly once, as a single 208-char bullet located between `## 13. Agent-only reference skills` and `## 14.`, with no procedure restated</code>
- <code>Manual intent-constraint sweep (27 checks): source attribution and 2026-08-04 approval, goal-not-recipe framing, inspectable bar, smallest judgeable pieces, no builder self-grading, fresh-context critic spawn, blind A/B, single-largest-gap verdict, no fixed round count, live workbench, optional smoothing pass, applicability and default-off rules, the five settled captain laws, no-mistakes composition, `## When not to use it`, meta-prompt appendix, one-sentence-per-line, plain dashes/quotes, no agent co-author, and no added helpers/tests/docs</code>
- <code>Verified the section 7 pointer added by commit 30ed67d is correct: `### Selected delivery path and approval authority` is at AGENTS.md:284, inside section 7 (lines 234-355)</code>
- <code>`git status --porcelain --untracked-files=all` - worktree clean, no transient artifacts left behind</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
