### PR TITLE
fix: clarify remote doctor bootstrap path

### DIFF
--- a/bin/fm-remote-doctor.sh
+++ b/bin/fm-remote-doctor.sh
@@ -11,10 +11,11 @@
 #
 # A remote second mate always runs on the Herdr backend in the dedicated
 # fm-remote session. Its account therefore needs the Firstmate-owned Aqua Herdr
-# agent plus the sibling
-# dev.firstmate.remote-job worker that executes every fm-on command in the GUI
-# session. SSH cannot create an Aqua session, so a host with no GUI login is a
-# human gap rather than something --fix attempts to bypass.
+# agent plus the sibling dev.firstmate.remote-job worker that runs normal fm-on
+# commands through the Aqua or Linux job-worker path. Doctor remains invokable
+# over the plain-SSH bootstrap path to inspect and repair that worker. SSH cannot
+# create an Aqua session, so a host with no GUI login is a human gap rather than
+# something --fix attempts to bypass.
 #
 # Line protocol, one fact per line, stable for script consumers:
 #   mode=check|fix

--- a/bin/fm-remote-entrypoint.sh
+++ b/bin/fm-remote-entrypoint.sh
@@ -22,7 +22,7 @@
 set -eu
 
 PROTOCOL=1
-DOCTOR_SHA256=8746014c53bd5f195dd43444369b387e3fdb2b7d8f120b06e8f3c2a86ee31c3a
+DOCTOR_SHA256=7bb13d9fad8455978bf109d4681a3aa3cb170565c8a74be4ec7b520427db14c2
 SCRIPT_DIR=$(CDPATH='' cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)
 
 # shellcheck source=bin/fm-remote-job-lib.sh


### PR DESCRIPTION
## Summary
- clarify that normal remote commands use the Aqua/Linux job worker
- document doctor\u0027s plain-SSH inspect/repair exception
- refresh the pinned doctor SHA-256

## Validation
- verified the doctor SHA-256 equals `DOCTOR_SHA256`
- `git diff --check`