### PR TITLE
fix(bin): forward ANTHROPIC_BASE_URL to claude crewmate launches

### DIFF
--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -2665,6 +2665,13 @@ esac
 if [ "$HARNESS" = claude ] && [ -n "${CLAUDE_CONFIG_DIR:-}" ]; then
   LAUNCH="CLAUDE_CONFIG_DIR=$(shell_quote "$CLAUDE_CONFIG_DIR") $LAUNCH"
 fi
+# When firstmate's own session runs claude through a local proxy in front of the
+# model API (for example for cost tracking), forward that same ANTHROPIC_BASE_URL
+# onto the claude launch so the crewmate routes through the same proxy. Only when
+# set; an unset value is the direct-API default and needs no prefix.
+if [ "$HARNESS" = claude ] && [ -n "${ANTHROPIC_BASE_URL:-}" ]; then
+  LAUNCH="ANTHROPIC_BASE_URL=$(shell_quote "$ANTHROPIC_BASE_URL") $LAUNCH"
+fi
 if [ "$KIND" = secondmate ]; then
   sq_home=$(shell_quote "$PROJ_ABS")
   sq_primary_home=$(shell_quote "$FM_HOME")

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -103,15 +103,17 @@ run_spawn() {
   local home=$1 wt=$2 fakebin=$3 launchlog=$4
   shift 4
   : > "$launchlog"
-  # CLAUDE_CONFIG_DIR is forwarded onto claude launches by fm-spawn, so pin it
-  # explicitly (empty by default) instead of leaking the invoking shell's value,
-  # which would make launch assertions depend on the developer's environment.
-  # A test opts in to the set case via FM_TEST_CLAUDE_CONFIG_DIR.
+  # CLAUDE_CONFIG_DIR and ANTHROPIC_BASE_URL are forwarded onto claude launches by
+  # fm-spawn, so pin them explicitly (empty by default) instead of leaking the
+  # invoking shell's values, which would make launch assertions depend on the
+  # developer's environment. A test opts in to the set case via
+  # FM_TEST_CLAUDE_CONFIG_DIR / FM_TEST_ANTHROPIC_BASE_URL.
   FM_ROOT_OVERRIDE='' FM_HOME="$home" \
     FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
     FM_PROJECTS_OVERRIDE="$home/projects" FM_CONFIG_OVERRIDE="$home/config" \
     FM_SPAWN_NO_GUARD=1 FM_FAKE_PANE_PATH="$wt" TMUX="fake,1,0" \
     CLAUDE_CONFIG_DIR="${FM_TEST_CLAUDE_CONFIG_DIR:-}" \
+    ANTHROPIC_BASE_URL="${FM_TEST_ANTHROPIC_BASE_URL:-}" \
     FM_FAKE_LAUNCH_LOG="$launchlog" FM_FAKE_PI_VERSION="${FM_TEST_PI_VERSION:-0.84.0}" \
     GROK_HOME="$home/grok-home" PATH="$fakebin:$PATH" \
     "$SPAWN" "$@" 2>&1
@@ -706,6 +708,55 @@ test_non_claude_harness_ignores_config_dir() {
   pass "non-claude harnesses do not receive the claude CLAUDE_CONFIG_DIR prefix"
 }
 
+test_claude_forwards_firstmate_anthropic_base_url_when_set() {
+  local rec id out status launch
+  id=profile-claude-baseurl-z20
+  rec=$(make_spawn_case profile-claude-baseurl claude "$id")
+  read_case_record "$rec"
+
+  out=$(FM_TEST_ANTHROPIC_BASE_URL="http://127.0.0.1:8787" \
+    run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR")
+  status=$?
+  expect_code 0 "$status" "claude spawn with ANTHROPIC_BASE_URL set should succeed"
+  launch=$(cat "$LAUNCH_LOG")
+  assert_contains "$launch" "ANTHROPIC_BASE_URL='http://127.0.0.1:8787'" \
+    "claude launch did not forward firstmate's ANTHROPIC_BASE_URL to the crewmate pane"
+  pass "claude forwards firstmate's ANTHROPIC_BASE_URL so the crewmate routes through the same proxy"
+}
+
+test_claude_omits_anthropic_base_url_prefix_when_unset() {
+  local rec id out status launch
+  id=profile-claude-nobaseurl-z21
+  rec=$(make_spawn_case profile-claude-nobaseurl claude "$id")
+  read_case_record "$rec"
+
+  # run_spawn pins ANTHROPIC_BASE_URL empty by default, exercising the direct-API
+  # default path where fm-spawn adds no prefix.
+  out=$(run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR")
+  status=$?
+  expect_code 0 "$status" "claude spawn without ANTHROPIC_BASE_URL should succeed"
+  launch=$(cat "$LAUNCH_LOG")
+  assert_not_contains "$launch" "ANTHROPIC_BASE_URL=" \
+    "claude launch must not add an ANTHROPIC_BASE_URL prefix when firstmate has none set"
+  pass "claude omits the ANTHROPIC_BASE_URL prefix when firstmate runs with the direct-API default"
+}
+
+test_non_claude_harness_ignores_anthropic_base_url() {
+  local rec id out status launch
+  id=profile-codex-nobaseurl-z22
+  rec=$(make_spawn_case profile-codex-nobaseurl codex "$id")
+  read_case_record "$rec"
+
+  out=$(FM_TEST_ANTHROPIC_BASE_URL="http://127.0.0.1:8787" \
+    run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR")
+  status=$?
+  expect_code 0 "$status" "codex spawn with ANTHROPIC_BASE_URL set should succeed"
+  launch=$(cat "$LAUNCH_LOG")
+  assert_not_contains "$launch" "ANTHROPIC_BASE_URL=" \
+    "non-claude harness launch must not receive the claude-specific ANTHROPIC_BASE_URL prefix"
+  pass "non-claude harnesses do not receive the claude ANTHROPIC_BASE_URL prefix"
+}
+
 test_active_dispatch_profile_does_not_block_secondmate_launch() {
   local rec id sm out status
   id=profile-secondmate-z16
@@ -750,6 +801,9 @@ test_batch_forwards_shared_profile_flags
 test_claude_forwards_firstmate_config_dir_when_set
 test_claude_omits_config_dir_prefix_when_unset
 test_non_claude_harness_ignores_config_dir
+test_claude_forwards_firstmate_anthropic_base_url_when_set
+test_claude_omits_anthropic_base_url_prefix_when_unset
+test_non_claude_harness_ignores_anthropic_base_url
 test_active_dispatch_profile_does_not_block_secondmate_launch
 
 echo "# all fm-spawn-dispatch-profile tests passed"


### PR DESCRIPTION
## Intent

**Handwritten section:**
This pull requests allows firstmate integration with https://github.com/headroomlabs-ai/headroom proxy for subagents to save on the LLM cost.

Forward firstmate's ANTHROPIC_BASE_URL to claude crewmate launches in bin/fm-spawn.sh, mirroring the existing CLAUDE_CONFIG_DIR forwarding precedent (commit 41ffd45). The captain runs their primary firstmate session as ANTHROPIC_BASE_URL=http://127.0.0.1:8787 claude, a local proxy in front of the model API used for cost tracking, and wants claude crewmates spawned by fm-spawn.sh to route through the same proxy when the captain's session has it set. This is a plain environment-variable forward of firstmate's own resolved value, not a new config file or captain-facing knob: only add the ANTHROPIC_BASE_URL= prefix when HARNESS=claude and the var is set, add no prefix when unset, and leave non-claude harnesses unaffected. The existing CLAUDE_CONFIG_DIR block runs before the KIND=secondmate branch, so this new block is placed alongside it in the same file at the same point, meaning it also applies to secondmate launches, consistent with CLAUDE_CONFIG_DIR's current placement (deliberately not restricted to crew-only). Followed the one-owner rule: no AGENTS.md or docs/configuration.md change, just a code comment in fm-spawn.sh explaining the rationale, exactly like the CLAUDE_CONFIG_DIR block. Added three tests to tests/fm-spawn-dispatch-profile.test.sh mirroring the CLAUDE_CONFIG_DIR test shape (forwarded-when-set, omitted-when-unset, non-claude-harness-ignores-it), and pinned ANTHROPIC_BASE_URL empty by default in the run_spawn test helper (alongside the existing CLAUDE_CONFIG_DIR pin) so launch assertions do not depend on the developer's environment. A manual PR (#1695) was previously opened by hand via push+gh pr create because push to origin was denied; the captain has since forked to PavelSusloparov/firstmate and added it as a 'fork' remote, and no-mistakes init --fork-url has now registered that fork, so this run should push/PR properly through the pipeline's own push and PR steps instead of the manual path.

## What Changed

- `bin/fm-spawn.sh` now prefixes the claude launch command with `ANTHROPIC_BASE_URL='<value>'` whenever `HARNESS=claude` and firstmate's own environment has `ANTHROPIC_BASE_URL` set, mirroring the existing `CLAUDE_CONFIG_DIR` forwarding block and placed at the same point (before the secondmate branch, so it also applies to secondmate launches).
- When `ANTHROPIC_BASE_URL` is unset, no prefix is added; non-claude harnesses are unaffected.
- `tests/fm-spawn-dispatch-profile.test.sh` gains three cases covering forwarded-when-set, omitted-when-unset, and ignored-by-non-claude-harness behavior, and pins `ANTHROPIC_BASE_URL` empty by default in the `run_spawn` test helper so launch assertions don't depend on the developer's environment.

## Risk Assessment

✅ Low: Minimal, well-bounded diff that copies an existing, already-proven pattern (guard, quoting, placement, and test shape) verbatim for a new environment variable, with no other call sites or docs left inconsistent.

## Testing

Ran the full fm-spawn-dispatch-profile test suite (29 tests) on the target commit; all pass, including the three new tests that directly demonstrate the end-user behavior: a claude launch's actual constructed shell command line gets `ANTHROPIC_BASE_URL='...'` prefixed when firstmate's session has that variable set, omits it when unset, and non-claude harnesses (codex) never pick it up. The launch-log assertions are a faithful proxy for end-user experience here since fm-spawn's output is the literal shell command string handed to the crewmate pane. Working tree is clean after the run with no stray artifacts.

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash tests/fm-spawn-dispatch-profile.test.sh` (full suite, 29 cases including the 3 new ones)</code>
- <code>test_claude_forwards_firstmate_anthropic_base_url_when_set — asserts the claude launch command line contains `ANTHROPIC_BASE_URL=&#39;http://127.0.0.1:8787&#39;` when firstmate&#39;s env has it set</code>
- <code>test_claude_omits_anthropic_base_url_prefix_when_unset — asserts no `ANTHROPIC_BASE_URL=` prefix appears when unset</code>
- `test_non_claude_harness_ignores_anthropic_base_url — asserts a codex-harness launch never receives the claude-specific prefix even when ANTHROPIC_BASE_URL is set`
- `manual code inspection of bin/fm-spawn.sh diff confirming the new block reuses shell_quote() consistent with the CLAUDE_CONFIG_DIR block for safe quoting`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
