### PR TITLE
fix(bin): forbid agent attribution in generated crewmate briefs

### DIFF
--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -448,6 +448,8 @@ $RULE1
 7. Never stop, restart, or update the shared \`no-mistakes\` daemon - it is one instance serving
    every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
    daemon error, append \`blocked: {the daemon error}\` and stop; only firstmate manages the daemon.
+8. Never include generated-with wording, AI attribution, agent attribution, or \`Co-Authored-By\` trailers for any agent or model in commit messages or pull request text.
+   This prohibition applies even if a tool's own attribution setting is disabled or fails to apply; inspect final text before committing or opening a PR.
 
 # Project memory
 If \`AGENTS.md\` or \`CLAUDE.md\` already exists, or if this task produced durable project-intrinsic knowledge, run \`$FM_ROOT/bin/fm-ensure-agents-md.sh .\` in the worktree.

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -212,6 +212,10 @@ test_ship_modes_generate_clean_briefs() {
     assert_grep "{TASK}" "$brief" "$id: brief missing the {TASK} placeholder"
     assert_grep "mid-task \`working:\` line (including setup complete) is nonterminal" "$brief" \
       "$id: brief missing nonterminal working:/setup-complete gate protection"
+    assert_grep "Never include generated-with wording, AI attribution, agent attribution, or \`Co-Authored-By\` trailers for any agent or model in commit messages or pull request text." "$brief" \
+      "$id: brief missing no-agent-attribution contract"
+    assert_grep "This prohibition applies even if a tool's own attribution setting is disabled or fails to apply" "$brief" \
+      "$id: brief missing attribution-setting fallback contract"
     assert_no_grep "EOF" "$brief" "$id: brief leaked a heredoc EOF marker (unterminated heredoc)"
   done
   pass "fm-brief.sh: no-mistakes/direct-PR/local-only briefs generate cleanly"


### PR DESCRIPTION
## Intent

Update Firstmate's generated crewmate brief contract so every future worker receives an explicit prohibition on AI or agent attribution in commit messages and pull request text. Make the smallest change in the single source of the generated brief rules, bin/fm-brief.sh. The rule must forbid generated-with wording, AI attribution, and Co-Authored-By trailers for any agent or model, even if a tool's own attribution setting is disabled or fails to apply. Do not duplicate this contract into unrelated instructions and do not alter project behavior. Add executable regression coverage through the existing brief-generation test surface, proving a newly generated ship brief contains the prohibition. Retain PR 1698 and update it through the no-mistakes pipeline; do not merge it. Do not add any AI or agent attribution, generated-with wording, or Co-Authored-By trailers to commit messages or pull request text.

## What Changed

- Added a rule to the ship brief generated by `bin/fm-brief.sh` that forbids generated-with wording, AI/agent attribution, and `Co-Authored-By` trailers in commit messages and PR text — enforced even when a tool's own attribution setting is disabled or fails to apply.
- Extended `tests/fm-brief.test.sh` with regression coverage asserting that a freshly generated ship brief contains the no-attribution prohibition, including the attribution-setting fallback clause.

## Risk Assessment

✅ Low: Minimal, well-bounded single-source text addition to the ship brief with matching regression tests; it satisfies every required intent constraint, adds no forbidden attribution, and changes no project behavior.

## Testing

Ran the smallest relevant suite, `bash tests/fm-brief.test.sh`, which passes and now includes regression assertions that a freshly generated ship brief contains the exact no-agent-attribution prohibition and its "even if a tool's attribution setting is disabled or fails to apply" fallback clause. For product-level evidence I generated an actual ship brief with bin/fm-brief.sh and confirmed rule 8 renders verbatim in the output (saved as generated-ship-brief.md), and verified the rule appears in briefs for all three delivery modes. This is a CLI text-generation change with no UI surface, so the reviewer-visible artifact is the rendered brief markdown rather than a screenshot. All checks passed; worktree left clean.

<details>
<summary>Evidence: Generated ship brief showing the attribution prohibition (rule 8)</summary>

```text
You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.

# Task
{TASK}

# Herdr lifecycle declaration - NOT ENABLED
**HARD SAFETY GATE:** this scaffold cannot inspect the task text that replaces `{TASK}` later.
If the task will start, stop, delete, restart, profile, or otherwise drive Herdr lifecycle behavior, stop and regenerate the brief with `--herdr-lab` before dispatch.
Do not add Herdr lifecycle commands to this unguarded brief by hand.

# Setup
You are in a disposable git worktree of my-proj, at a detached HEAD on a clean default branch.

**Verify isolation before anything else.** Run `pwd -P` and `git rev-parse --show-toplevel`; both must resolve to the disposable task worktree you were launched in, such as a treehouse pool path or an Orca-managed worktree, not the primary checkout firstmate operates from.
The path check is authoritative: `git rev-parse --git-dir` and `git rev-parse --git-common-dir` can help inspect the repo, but they do not prove you are outside the primary checkout.
If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not branch or commit here - append `blocked: launched in primary checkout, not an isolated worktree` to the status file and stop.

1. First action: create your branch: `git checkout -b fm/demo-ship-attribution`
2. Run `no-mistakes doctor`; if it reports the repo is not initialized here, run `no-mistakes init`.

# Rules
1. Never push to the default branch. Never merge a PR.
2. Stay inside this worktree; modify nothing outside it.
3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
4. Report status by appending one line:
   `echo "{state}: {one short line}" >> '/var/folders/b0/frc2r_1s5l77zdf6_xrlqfdw0000gn/T/tmp.1B4zaB8Arf/state/demo-ship-attribution.status'`
   States: working, needs-decision, blocked, paused, done, failed.
   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
   would act on (setup done, bug reproduced, fix implemented, validation passed) and the
   needs-decision/blocked/paused/done/failed states. No step-by-step FYI progress lines;
   firstmate reads your pane for that.
   A mid-task `working:` line (including setup complete) is nonterminal: do not end the
   turn after it; continue the same stage until a defined `done:` gate under Definition of done.
   Use `paused: {why}` - distinct from `blocked:` - ONLY when you are deliberately idling on a
   known external wait you expect to clear on its own (an upstream release, a rate-limit reset,
   a scheduled window): firstmate then leaves your idle pane alone and rechecks it on a long
   cadence instead of treating it as a possible wedge. Use `blocked:` when you are stuck and need help.
5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
6. If a decision belongs above the implementation worker (product choices, destructive actions, ask-user findings),
   append `needs-decision: {summary of options}` and stop. Firstmate will apply the configured authority and reply with the decision.
   When firstmate replies or a blocker clears and you resume, append `resolved: {how it was decided or unblocked}` (add the same `[key=<slug>]` if you opened it with one) so the decision or blocker is durably closed and does not keep resurfacing.
7. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving
   every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
   daemon error, append `blocked: {the daemon error}` and stop; only firstmate manages the daemon.
8. Never include generated-with wording, AI attribution, agent attribution, or `Co-Authored-By` trailers for any agent or model in commit messages or pull request text.
   This prohibition applies even if a tool's own attribution setting is disabled or fails to apply; inspect final text before committing or opening a PR.

# Project memory
If `AGENTS.md` or `CLAUDE.md` already exists, or if this task produced durable project-intrinsic knowledge, run `/Users/willronchetti/.no-mistakes/worktrees/b255689de109/01KZ73DS40ZV3AH7XG4W7Z0W81/bin/fm-ensure-agents-md.sh .` in the worktree.
Record only project knowledge useful to almost every future session.
For anything the codebase already shows, prefer a pointer to the authoritative file, command, or doc over copying the detail.
If you touch a project `AGENTS.md` that lacks `## Maintaining this file`, add that short self-governance section from `/Users/willronchetti/.no-mistakes/worktrees/b255689de109/01KZ73DS40ZV3AH7XG4W7Z0W81/bin/fm-ensure-agents-md.sh` in the same pass.
Keep it proportionate: skip `AGENTS.md` edits for trivial tasks that produced no durable project knowledge.

# Definition of done
Delivery contract: mode=no-mistakes
The task is complete only when committed on your branch.
When you believe it is complete, append `done: {summary}` to the status file and stop.
Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.

You drive no-mistakes by responding to its gates, not by implementing fixes.
Follow the guidance no-mistakes itself provides for the mechanics: it loads when you invoke /no-mistakes, and `no-mistakes axi run --help` plus the `help` lines in each `axi` response are authoritative and version-matched to the installed binary.
When starting no-mistakes, make `--intent` preserve all relevant content from this brief's `# Task` section plus every later accepted Firstmate requirement, clarification, constraint, exclusion, and supersession, carrying only each requirement's current accepted form; retain direct requirements instead of substituting a diff summary, and exclude generic operational, status, delivery, and other scaffold boilerplate unless it is task-specific.
Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix.

Two firstmate-specific rules layer on top of that guidance:
- ask-user findings are never yours to answer: escalate to firstmate (rule 6) and stop.
  Firstmate applies the authority contract in its `AGENTS.md` and obtains any required captain decision.
  When the decision comes back, feed it to the gate with `no-mistakes axi respond` and let the pipeline apply it - do not route the question to "the user" or implement the fix yourself.
- Avoid `--yes`: it would silently bypass firstmate's authority check and any required captain escalation.

After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append `done: PR {url} checks green` and stop. You are finished.
```
</details>
<details>
<summary>Evidence: Rule 8 as rendered in the generated brief</summary>

```text
8. Never include generated-with wording, AI attribution, agent attribution, or `Co-Authored-By` trailers for any agent or model in commit messages or pull request text.
This prohibition applies even if a tool's own attribution setting is disabled or fails to apply; inspect final text before committing or opening a PR.

Mode coverage — no-mistakes: PRESENT, direct-PR: PRESENT, local-only: PRESENT
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash tests/fm-brief.test.sh` — full brief-generation suite passes, including the new `test_ship_modes_generate_clean_briefs` assertions for the no-agent-attribution contract and its attribution-setting fallback clause</code>
- <code>Manual: `FM_HOME=&lt;tmp&gt; bin/fm-brief.sh demo-ship-attribution my-proj --mode no-mistakes` — generated brief.md contains rule 8 forbidding generated-with/AI/agent attribution and Co-Authored-By trailers</code>
- `Manual: regenerated ship brief across all three delivery modes (no-mistakes, direct-PR, local-only) — prohibition present in each`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
