### PR TITLE
fix(bin): bound remote SSH dead-peer detection

### DIFF
--- a/bin/fm-on.sh
+++ b/bin/fm-on.sh
@@ -21,6 +21,14 @@
 # This command explicitly disables agent forwarding, forwarding setup, and
 # configured SendEnv patterns. The remote entrypoint executes the selected
 # command under an empty environment with only its fixed runtime values.
+#
+# ServerAliveInterval/ServerAliveCountMax arm dead-peer detection so a vanished
+# peer (a reboot, a dropped link) becomes a bounded ssh failure (exit 255)
+# instead of an indefinite hang on a half-open TCP connection. The remote
+# sshd answers keepalive probes independently of whatever the remote command
+# is doing, so a legitimately long-but-alive remote command is never falsely
+# killed. FM_SSH_ALIVE_INTERVAL and FM_SSH_ALIVE_COUNT_MAX override the
+# defaults; the worst-case detection window is roughly interval * count.
 set -eu
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -88,9 +96,17 @@ ROOT_B64=$(printf '%s' "$ROOT" | encode_base64)
 HOME_B64=$(printf '%s' "$HOME_PATH" | encode_base64)
 ARGV_B64=$(printf '%s\0' "$COMMAND" "$@" | encode_base64)
 SSH_BIN=${FM_SSH_BIN:-ssh}
+ALIVE_INTERVAL=${FM_SSH_ALIVE_INTERVAL:-15}
+ALIVE_COUNT_MAX=${FM_SSH_ALIVE_COUNT_MAX:-3}
+case "$ALIVE_INTERVAL" in ''|*[!0-9]*) die "FM_SSH_ALIVE_INTERVAL must be a positive integer: $ALIVE_INTERVAL" ;; esac
+case "$ALIVE_COUNT_MAX" in ''|*[!0-9]*) die "FM_SSH_ALIVE_COUNT_MAX must be a positive integer: $ALIVE_COUNT_MAX" ;; esac
+[ "$ALIVE_INTERVAL" -gt 0 ] || die "FM_SSH_ALIVE_INTERVAL must be a positive integer: $ALIVE_INTERVAL"
+[ "$ALIVE_COUNT_MAX" -gt 0 ] || die "FM_SSH_ALIVE_COUNT_MAX must be a positive integer: $ALIVE_COUNT_MAX"
 
 "$SSH_BIN" \
   -o ForwardAgent=no \
   -o ClearAllForwardings=yes \
   -o 'SendEnv=-*' \
+  -o "ServerAliveInterval=$ALIVE_INTERVAL" \
+  -o "ServerAliveCountMax=$ALIVE_COUNT_MAX" \
   -- "$HOST" fm-remote-entrypoint.sh "$PROTOCOL" "$ROOT_B64" "$HOME_B64" "$ARGV_B64"

--- a/docs/remote-secondmates.md
+++ b/docs/remote-secondmates.md
@@ -15,7 +15,7 @@ Local second mates are unaffected and keep their ordinary backend and session se
 Configure an SSH alias in the primary account's normal OpenSSH configuration.
 Use ordinary public-key authentication, strict host-key verification, and a dedicated remote account where practical.
 Do not enable agent forwarding for Firstmate.
-`fm-on.sh` also disables agent forwarding, forwarding setup, and configured `SendEnv` patterns on every call, and arms bounded SSH dead-peer detection so a vanished host (a reboot, a dropped link) fails within a bounded window instead of hanging indefinitely.
+`fm-on.sh` also disables agent forwarding, forwarding setup, and configured `SendEnv` patterns on every call, and arms bounded SSH dead-peer detection so a vanished host (a reboot, a dropped link) fails within a bounded window instead of hanging indefinitely; its [script header](../bin/fm-on.sh) owns the keepalive defaults and environment overrides.
 
 Clone Firstmate on the remote host at an absolute code-root path.
 Expose that clone's fixed entrypoint on the account's non-interactive SSH `PATH`, for example:

--- a/docs/remote-secondmates.md
+++ b/docs/remote-secondmates.md
@@ -15,7 +15,7 @@ Local second mates are unaffected and keep their ordinary backend and session se
 Configure an SSH alias in the primary account's normal OpenSSH configuration.
 Use ordinary public-key authentication, strict host-key verification, and a dedicated remote account where practical.
 Do not enable agent forwarding for Firstmate.
-`fm-on.sh` also disables agent forwarding, forwarding setup, and configured `SendEnv` patterns on every call.
+`fm-on.sh` also disables agent forwarding, forwarding setup, and configured `SendEnv` patterns on every call, and arms bounded SSH dead-peer detection so a vanished host (a reboot, a dropped link) fails within a bounded window instead of hanging indefinitely.
 
 Clone Firstmate on the remote host at an absolute code-root path.
 Expose that clone's fixed entrypoint on the account's non-interactive SSH `PATH`, for example:

--- a/tests/fm-on.test.sh
+++ b/tests/fm-on.test.sh
@@ -165,6 +165,20 @@ assert_contains "$OVERRIDE_ARGV" 'ServerAliveInterval=7' "FM_SSH_ALIVE_INTERVAL 
 assert_contains "$OVERRIDE_ARGV" 'ServerAliveCountMax=2' "FM_SSH_ALIVE_COUNT_MAX override was not honored on the ssh transport"
 pass "fm-on's dead-peer detection window is env-overridable"
 
+SSH_CALLS_BEFORE_INVALID=$(cat "$SSH_COUNT")
+set +e
+INVALID_INTERVAL_OUT=$(FM_SSH_ALIVE_INTERVAL=0 fm_on ios fm-probe-two.sh 2>&1)
+INVALID_INTERVAL_RC=$?
+INVALID_COUNT_OUT=$(FM_SSH_ALIVE_COUNT_MAX=not-a-number fm_on ios fm-probe-two.sh 2>&1)
+INVALID_COUNT_RC=$?
+set -e
+[ "$INVALID_INTERVAL_RC" -eq 1 ] || fail "a zero FM_SSH_ALIVE_INTERVAL was accepted (got exit $INVALID_INTERVAL_RC)"
+[ "$INVALID_COUNT_RC" -eq 1 ] || fail "a non-integer FM_SSH_ALIVE_COUNT_MAX was accepted (got exit $INVALID_COUNT_RC)"
+assert_contains "$INVALID_INTERVAL_OUT" 'FM_SSH_ALIVE_INTERVAL must be a positive integer' "invalid interval did not explain its constraint"
+assert_contains "$INVALID_COUNT_OUT" 'FM_SSH_ALIVE_COUNT_MAX must be a positive integer' "invalid count did not explain its constraint"
+[ "$(cat "$SSH_COUNT")" -eq "$SSH_CALLS_BEFORE_INVALID" ] || fail "invalid keepalive configuration launched ssh"
+pass "fm-on rejects invalid dead-peer settings before launching ssh"
+
 out=$(TOP_SECRET='must-not-cross' fm_on remote-mac fm-probe-two.sh)
 assert_contains "$out" "home=$REMOTE_HOME" "remote FM_HOME was not explicit"
 assert_contains "$out" "root=$REMOTE_ROOT" "remote root was not explicit"

--- a/tests/fm-on.test.sh
+++ b/tests/fm-on.test.sh
@@ -141,6 +141,30 @@ assert_grep 'stderr: separate' "$TMP_ROOT/stderr" "remote stderr was not preserv
 assert_absent /tmp/fm-on-injected "shell-looking argv was interpreted"
 pass "fm-on preserves argv, stdin, stdout, stderr, and exit status without shell interpretation"
 
+# A vanished remote peer must become a bounded ssh failure instead of an
+# indefinite hang on a half-open TCP connection, so the existing no-result ->
+# reconcile re-arm recovery can self-heal without manual intervention. Assert
+# this on the real ssh argv the FM_SSH_BIN process seam captured, never on
+# fm-on.sh source text.
+LAST_SSH_ARGV=$(tail -n 1 "$SSH_LOG")
+DEFAULT_INTERVAL=$(printf '%s\n' "$LAST_SSH_ARGV" | grep -oE 'ServerAliveInterval=[0-9]+' | cut -d= -f2)
+DEFAULT_COUNT=$(printf '%s\n' "$LAST_SSH_ARGV" | grep -oE 'ServerAliveCountMax=[0-9]+' | cut -d= -f2)
+[ -n "$DEFAULT_INTERVAL" ] || fail "the ssh transport did not arm ServerAliveInterval dead-peer detection"
+[ -n "$DEFAULT_COUNT" ] || fail "the ssh transport did not arm ServerAliveCountMax dead-peer detection"
+[ "$DEFAULT_INTERVAL" -gt 0 ] || fail "ServerAliveInterval was not a positive interval (got $DEFAULT_INTERVAL)"
+[ "$DEFAULT_COUNT" -gt 0 ] || fail "ServerAliveCountMax was not a positive count (got $DEFAULT_COUNT)"
+DEFAULT_WINDOW=$((DEFAULT_INTERVAL * DEFAULT_COUNT))
+[ "$DEFAULT_WINDOW" -le 120 ] \
+  || fail "the default dead-peer detection window is not bounded to a sane ceiling (got ${DEFAULT_WINDOW}s = ${DEFAULT_INTERVAL}s x $DEFAULT_COUNT)"
+pass "fm-on arms a bounded SSH dead-peer detection window by default (${DEFAULT_INTERVAL}s x $DEFAULT_COUNT = ${DEFAULT_WINDOW}s)"
+
+: > "$SSH_LOG"
+FM_SSH_ALIVE_INTERVAL=7 FM_SSH_ALIVE_COUNT_MAX=2 fm_on ios fm-probe-two.sh >/dev/null
+OVERRIDE_ARGV=$(tail -n 1 "$SSH_LOG")
+assert_contains "$OVERRIDE_ARGV" 'ServerAliveInterval=7' "FM_SSH_ALIVE_INTERVAL override was not honored on the ssh transport"
+assert_contains "$OVERRIDE_ARGV" 'ServerAliveCountMax=2' "FM_SSH_ALIVE_COUNT_MAX override was not honored on the ssh transport"
+pass "fm-on's dead-peer detection window is env-overridable"
+
 out=$(TOP_SECRET='must-not-cross' fm_on remote-mac fm-probe-two.sh)
 assert_contains "$out" "home=$REMOTE_HOME" "remote FM_HOME was not explicit"
 assert_contains "$out" "root=$REMOTE_ROOT" "remote root was not explicit"


### PR DESCRIPTION
## Intent

Fix the remote-secondmate reply ferry so it can no longer wedge forever when the remote host reboots or otherwise vanishes mid-poll.

Root cause (already diagnosed, confirmed not re-litigated): bin/fm-on.sh's ssh invocation had no ServerAliveInterval/ServerAliveCountMax dead-peer detection. When a remote peer vanishes mid-poll (observed real incident: alive 1h25m after a nominally 55s poll), the TCP connection goes half-open and ssh blocks indefinitely. This wedges the whole remote-reply ferry (fm-procevent-remote-reply.sh -> fm-on.sh -> ssh -> remote fm-remote-delta-read.sh, supervised by fm-procevent.sh): fm-procevent.sh's runner blocks inside the ssh child capture and never reaches its own no-result -> claim-release -> reconcile re-arm self-healing path, which already works correctly once the child actually returns (a nonzero exit with empty output hits the no-result branch, releases the claim, and reconcile re-arms the source). The only broken thing was that the child never returned. The compounding fact that a wedged-but-alive runner looks healthy to reconcile is a consequence of the unbounded transport, not a separate bug.

Required fix (smallest fundamental change, implemented exactly as specified): arm SSH-native dead-peer detection in bin/fm-on.sh's ssh invocation by adding ServerAliveInterval and ServerAliveCountMax options, so a vanished peer becomes a bounded ssh failure (exit 255) instead of an indefinite hang, which then flows through the existing no-result -> reconcile re-arm recovery with zero manual intervention. This is a transport-level fix that covers every remote command routed through fm-on.sh, not just this one poll - it must not be overfit to the reply ferry. SSH keepalive probes are answered by the remote sshd independently of whether the remote command is still blocking, so a legitimately long-but-alive remote command (a healthy 55s poll, a clone, the doctor) is never falsely killed - only a truly vanished peer trips it.

Explicitly excluded as the fix: a blanket local hard timeout (e.g. wrapping the whole ssh call in ) in fm-on.sh, because fm-on.sh is the generic transport for all remote commands and a fixed local cap would also kill legitimately long-but-alive remote operations that keepalives never affect; timeout is also not portable on macOS. No such caller-side bound was found to be needed after implementing the keepalive fix, so none was added.

Chosen values: ServerAliveInterval=15, ServerAliveCountMax=3, giving a bounded ~45 second worst-case detection window. Both are overridable via new FM_SSH_ALIVE_INTERVAL and FM_SSH_ALIVE_COUNT_MAX environment variables, following the codebase's existing FM_* override convention, with input validated as positive integers. The existing transport contract (exit-status passthrough, no auto-retry, no argv/stdin/stdout/stderr changes, existing safety validation) is otherwise unchanged.

Regression test: extended the existing tests/fm-on.test.sh (no new test runner invented) with a behavioral assertion, captured through the already-present FM_SSH_BIN fake-ssh process seam that logs the real ssh argv, that every fm-on transport invocation arms a positive ServerAliveInterval and a positive ServerAliveCountMax whose product (the detection window) is bounded to a sane ceiling, plus a case proving both values are honored when overridden via the new environment variables. This is a portable regression case with no live-harness guard needed, since SSH keepalive is a kernel/protocol-level mechanism rather than a harness-rendered signal (per firstmate-coding-guidelines' harness-dependent-check rule).

Compatibility: bin/fm-on.sh is harness- and backend-agnostic transport, so this change is not harness-dependent; it needed no per-harness or per-backend variation. Loaded and followed the firstmate-coding-guidelines skill before editing, since this touches firstmate's own shared tracked material. Updated docs/remote-secondmates.md with a one-line cross-reference alongside its existing description of fm-on.sh's SSH options.

Verified locally before requesting validation: bin/fm-lint.sh clean; tests/fm-on.test.sh, tests/fm-remote-reply.test.sh, tests/fm-remote-backlog-handoff.test.sh, tests/fm-remote-doctor.test.sh, tests/fm-remote-job.test.sh, tests/fm-remote-secondmate-trace-context.test.sh, tests/fm-remote-secondmate-lifecycle-e2e.test.sh, and tests/fm-procevent.test.sh all pass. Confirmed directly in bin/fm-procevent.sh that the no-result -> claim-release -> reconcile re-arm path referenced above is real and matches the diagnosed root cause.

## What Changed

- Add SSH dead-peer detection to `fm-on.sh` with 15-second keepalive intervals and a maximum of three missed responses.
- Support validated `FM_SSH_ALIVE_INTERVAL` and `FM_SSH_ALIVE_COUNT_MAX` overrides, with behavioral coverage for defaults, overrides, and invalid values.
- Document the bounded keepalive behavior for remote secondmates.

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>
</details>
<details>
<summary>✅ **Rebase** - passed</summary>
</details>
<details>
<summary>✅ **Review** - completed</summary>
</details>
<details>
<summary>✅ **Test** - passed</summary>
</details>
<details>
<summary>✅ **Document** - passed</summary>
</details>
<details>
<summary>✅ **Lint** - passed</summary>
</details>
<details>
<summary>✅ **Push** - passed</summary>
</details>
