### PR TITLE
fix: harden external Codex supervision

### DIFF
--- a/.agents/skills/afk/SKILL.md
+++ b/.agents/skills/afk/SKILL.md
@@ -48,6 +48,7 @@ batched digest rather than per-wake injections.
    It exits immediately if the identity-backed daemon lock already names a live process, otherwise it execs `bin/fm-supervise-daemon.sh` in the foreground.
    The daemon is **presence-gated**: it injects escalations only while
    `state/.afk` exists, and stays quiet otherwise.
+   An external Codex thread without an inherited tmux or Herdr pane cannot enter away mode, because it has no safe asynchronous callback; follow the Codex protocol's [no-pane boundary](../../../docs/supervision-protocols/codex.md) and keep foreground checkpoints running instead.
 
 3. **Do not separately arm `fm-watch.sh`.** The daemon manages the watcher as
    its child; the singleton lock no-ops a stray arm harmlessly.

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -33,7 +33,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash -lc 'payload=$(cat 2>/dev/null || true); [ -n \"$payload\" ] || exit 0; command -v jq >/dev/null 2>&1 || exit 0; root=$(pwd -P) || exit 0; [ -x \"$root/bin/fm-turnend-guard.sh\" ] || exit 0; [ -f \"$root/AGENTS.md\" ] || exit 0; [ -f \"$root/.codex/hooks.json\" ] || exit 0; jq -e \"any(.hooks.Stop[]?.hooks[]?.command?; type == \\\"string\\\" and contains(\\\"fm-turnend-guard.sh\\\"))\" \"$root/.codex/hooks.json\" >/dev/null 2>&1 || exit 0; printf \"%s\" \"$payload\" | \"$root/bin/fm-turnend-guard.sh\"'",
+            "command": "bash -lc 'payload=$(cat 2>/dev/null || true); [ -n \"$payload\" ] || exit 0; command -v jq >/dev/null 2>&1 || exit 0; root=$(pwd -P) || exit 0; [ -x \"$root/bin/fm-turnend-guard.sh\" ] || exit 0; [ -f \"$root/AGENTS.md\" ] || exit 0; [ -f \"$root/.codex/hooks.json\" ] || exit 0; jq -e \"any(.hooks.Stop[]?.hooks[]?.command?; type == \\\"string\\\" and contains(\\\"fm-turnend-guard.sh\\\"))\" \"$root/.codex/hooks.json\" >/dev/null 2>&1 || exit 0; printf \"%s\" \"$payload\" | FM_TURNEND_HARNESS=codex \"$root/bin/fm-turnend-guard.sh\"'",
             "timeout": 30
           }
         ]

--- a/bin/fm-afk-launch.sh
+++ b/bin/fm-afk-launch.sh
@@ -26,9 +26,12 @@
 #                              record it. Idempotent: an already-running daemon
 #                              just refreshes state/.afk; a recorded-but-dead
 #                              terminal is reconciled (closed by id) first.
+#                              Refuses before any lifecycle write when an external
+#                              Codex thread has no verified tmux or Herdr pane.
 #   fm-afk-launch.sh start-native
 #                              Prepare lifecycle state for a harness-native
 #                              background job and record that no terminal exists.
+#                              It has the same external-Codex no-pane refusal.
 #   fm-afk-launch.sh stop      Correct-ordered exit: SIGTERM the daemon so its
 #                              cleanup flushes WHILE state/.afk is still present,
 #                              wait for it, close the recorded terminal by exact

--- a/bin/fm-afk-launch.sh
+++ b/bin/fm-afk-launch.sh
@@ -89,6 +89,14 @@ set +e
 
 fm_afk_launch_log() { printf 'fm-afk-launch: %s\n' "$*" >&2; }
 
+fm_afk_launch_refuse_external_codex_without_pane() {
+  fm_supervisor_external_codex_without_pane || return 1
+  fm_afk_launch_log "away mode is unavailable from an external Codex thread without a primary tmux or Herdr pane"
+  fm_afk_launch_log "Codex provides no safe asynchronous callback to this thread; do not set FM_SUPERVISOR_TARGET to a worker pane"
+  fm_afk_launch_log "keep foreground checkpoints running while present, or restart the primary inside tmux or Herdr before leaving work unattended"
+  return 0
+}
+
 fm_afk_launch_lock_owned() {
   local pid expected actual
   [ -d "$FM_AFK_LAUNCH_LOCK" ] || return 1
@@ -462,6 +470,7 @@ fm_afk_launch_create_tmux() {  # <captain-target> <captain-backend>
 
 fm_afk_launch_start() {
   local captain_target captain_backend backup artifact had_afk=0 result
+  fm_afk_launch_refuse_external_codex_without_pane && return 1
   if [ -e "$FM_AFK_LAUNCH_STATE/.afk-return-catchup" ]; then
     fm_afk_launch_log "return catch-up is still pending; run bin/fm-afk-return.sh check before re-entering away mode"
     return 1
@@ -531,6 +540,7 @@ fm_afk_launch_start() {
 
 fm_afk_launch_start_native() {
   local backup artifact had_afk=0 result=0
+  fm_afk_launch_refuse_external_codex_without_pane && return 1
   mkdir -p "$FM_AFK_LAUNCH_STATE" || return 1
   if [ -e "$FM_AFK_LAUNCH_STATE/.afk-return-catchup" ]; then
     fm_afk_launch_log "return catch-up is still pending; run bin/fm-afk-return.sh check before re-entering away mode"

--- a/bin/fm-afk-start.sh
+++ b/bin/fm-afk-start.sh
@@ -41,6 +41,8 @@ FM_AFK_DAEMON="$FM_AFK_START_DIR/fm-supervise-daemon.sh"
 
 # shellcheck source=bin/fm-wake-lib.sh
 . "$FM_AFK_START_DIR/fm-wake-lib.sh"
+# shellcheck source=bin/fm-supervisor-target-lib.sh
+. "$FM_AFK_START_DIR/fm-supervisor-target-lib.sh"
 
 fm_afk_start_usage() {
   sed -n '2,14p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
@@ -116,6 +118,12 @@ fm_afk_start_main() {
     -h|--help) fm_afk_start_usage; return 0 ;;
     * ) echo "usage: $(basename "${BASH_SOURCE[1]:-fm-afk-start.sh}")" >&2; return 2 ;;
   esac
+
+  if fm_supervisor_external_codex_without_pane; then
+    echo "afk: away mode is unavailable from an external Codex thread without a primary tmux or Herdr pane" >&2
+    echo "afk: Codex provides no safe asynchronous callback to this thread" >&2
+    return 1
+  fi
 
   mkdir -p "$FM_AFK_STATE"
   if [ "${FM_AFK_STATE_PREPARED:-0}" = 1 ]; then

--- a/bin/fm-afk-start.sh
+++ b/bin/fm-afk-start.sh
@@ -3,7 +3,9 @@
 # foreground process when one is not already alive.
 #
 # Usage: fm-afk-start.sh
-#   Sets state/.afk unless FM_AFK_STATE_PREPARED=1, checks
+#   Refuses an external Codex thread without a verified tmux or Herdr pane
+#   before it writes state/.afk. Otherwise sets state/.afk unless
+#   FM_AFK_STATE_PREPARED=1, checks
 #   state/.supervise-daemon.lock, and:
 #     - prints "afk: daemon already running pid=<pid>" then exits 0 when that
 #       lock is held by a live daemon (a REFRESH: no stale-artifact clear);

--- a/bin/fm-supervisor-target-lib.sh
+++ b/bin/fm-supervisor-target-lib.sh
@@ -21,6 +21,25 @@
 FM_SUPERVISOR_TARGET_DEFAULT="firstmate:0"
 FM_SUPERVISOR_BACKEND_DEFAULT="tmux"
 
+# fm_supervisor_primary_pane_available: return success only when this process
+# itself carries a verified captain-pane marker. An explicit target does not
+# count here: an external Codex thread has no safe way to prove that a manually
+# supplied tmux or herdr target is its own primary rather than a worker pane.
+fm_supervisor_primary_pane_available() {
+  [ -n "${TMUX_PANE:-}" ] && return 0
+  [ "${HERDR_ENV:-}" = "1" ] && [ -n "${HERDR_PANE_ID:-}" ] && return 0
+  return 1
+}
+
+# fm_supervisor_external_codex_without_pane: Codex Desktop marks the active
+# external thread with CODEX_THREAD_ID but provides neither a primary-terminal
+# marker nor an asynchronous callback into that thread. AFK must refuse this
+# surface instead of accepting a guessed worker pane as its delivery target.
+fm_supervisor_external_codex_without_pane() {
+  [ -n "${CODEX_THREAD_ID:-}" ] || return 1
+  ! fm_supervisor_primary_pane_available
+}
+
 # discover_supervisor_target: resolve the pane running firstmate. Priority:
 #   1. FM_SUPERVISOR_TARGET env (explicit override) - may be a tmux target or a
 #      herdr "<session>:<pane-id>" target (paired with discover_supervisor_backend

--- a/bin/fm-turnend-guard.sh
+++ b/bin/fm-turnend-guard.sh
@@ -28,15 +28,17 @@
 # primary checkout - the main home or a genuinely marked secondmate home - and
 # stay a silent, fast no-op inside child task worktrees.
 #
-# Loop-guard, codex/Grok (default) mode: never block twice in the same turn.
-# Codex uses stop_hook_active and Grok uses stopHookActive; typed camel-case
-# takes precedence when both spellings are present. A true value means the
-# current stop attempt already follows a block, so this guard always allows it.
-# Passive harness adapters provide their own one-follow-up guard before calling
-# this script.
-# That bounds those harnesses to at most one forced continuation per turn -
-# never a wedged, un-endable session - while still nagging again on a later turn
-# if the problem persists.
+# Loop-guard, Grok and ordinary default mode: never block twice in the same turn.
+# Grok uses stopHookActive; typed camel-case takes precedence when both spellings
+# are present. A true value means the current stop attempt already follows a
+# block, so those paths allow it. Passive harness adapters provide their own
+# one-follow-up guard before calling this script.
+# External Codex is different: a quiet foreground checkpoint ends its watcher
+# before the following Stop, and Codex supplies no durable callback or owner.
+# When the tracked Codex adapter marks that surface with FM_TURNEND_HARNESS=codex
+# and CODEX_THREAD_ID, a true stop_hook_active must re-check supervision and
+# block again while it is needed. The later no-work gate keeps an empty fleet
+# from looping.
 #
 # Loop-guard, --claude mode (Stop-owned auto-arm cooperation): Claude Code
 # marks EVERY stop after ANY stop-hook-driven continuation stop_hook_active=true,
@@ -106,7 +108,8 @@ STOP_HOOK_ACTIVE=$(printf '%s' "$PAYLOAD" | jq -r '
   else false
   end
 ' 2>/dev/null) || exit 0
-if [ "$CLAUDE_MODE" -eq 0 ] && [ "$STOP_HOOK_ACTIVE" = "true" ]; then
+if [ "$CLAUDE_MODE" -eq 0 ] && [ "$STOP_HOOK_ACTIVE" = "true" ] \
+  && { [ "${FM_TURNEND_HARNESS:-}" != codex ] || [ -z "${CODEX_THREAD_ID:-}" ]; }; then
   exit 0
 fi
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -100,6 +100,7 @@ Test cleanup must use the guarded path in [`docs/cmux-backend.md`](cmux-backend.
 The `/afk` sub-supervisor injects escalation digests into firstmate's own pane independently of where new task endpoints are spawned.
 It currently supports only `tmux` and `herdr` supervisor panes.
 Set `FM_SUPERVISOR_BACKEND=tmux|herdr` and `FM_SUPERVISOR_TARGET=<target>` to override both axes explicitly; for herdr the target is `"<session>:<pane-id>"`.
+Those overrides cannot establish a verified primary for an external Codex thread without an inherited tmux or Herdr pane, so away-mode entry refuses rather than targeting a possible worker pane; [`supervision-protocols/codex.md`](supervision-protocols/codex.md) owns that operating boundary.
 Without overrides, backend detection uses `$TMUX_PANE` first, then `HERDR_ENV=1` with `HERDR_PANE_ID`, then falls back to `tmux`.
 That keeps a tmux pane nested inside herdr on the tmux transport, matching the runtime backend's innermost-first rule.
 Target detection uses `FM_SUPERVISOR_TARGET`, then `$TMUX_PANE`, then `"${HERDR_SESSION:-default}:${HERDR_PANE_ID}"` under herdr, then the legacy `firstmate:0` tmux fallback with a warning.

--- a/docs/supervision-protocols/codex.md
+++ b/docs/supervision-protocols/codex.md
@@ -13,3 +13,8 @@ When this session owns supervision and away mode is not active:
 
 Codex cannot reason while a foreground tool call is running.
 The bounded checkpoint returns control regularly so user messages and queued wakes can be handled without relying on background-task wake semantics.
+
+Away mode needs a verified primary tmux or Herdr pane where the daemon can deliver its return and escalation messages.
+An external Codex thread identified by `CODEX_THREAD_ID` without either pane has no safe asynchronous callback, so `bin/fm-afk-launch.sh` refuses before it writes away state.
+Do not supply `FM_SUPERVISOR_TARGET` for a worker pane.
+Keep foreground checkpoints running while present, or restart the primary in tmux or Herdr before leaving work unattended.

--- a/docs/supervision-protocols/codex.md
+++ b/docs/supervision-protocols/codex.md
@@ -13,6 +13,8 @@ When this session owns supervision and away mode is not active:
 
 Codex cannot reason while a foreground tool call is running.
 The bounded checkpoint returns control regularly so user messages and queued wakes can be handled without relying on background-task wake semantics.
+When work still needs supervision, the tracked Codex Stop hook re-blocks after a quiet checkpoint expires until another foreground checkpoint proves a live watcher or the fleet becomes empty.
+That continuation is owned by the active Codex Stop surface and never by a reaped child, a worker pane, or a second primary.
 
 Away mode needs a verified primary tmux or Herdr pane where the daemon can deliver its return and escalation messages.
 An external Codex thread identified by `CODEX_THREAD_ID` without either pane has no safe asynchronous callback, so `bin/fm-afk-launch.sh` refuses before it writes away state.

--- a/docs/supervision-protocols/codex.md
+++ b/docs/supervision-protocols/codex.md
@@ -17,6 +17,6 @@ When work still needs supervision, the tracked Codex Stop hook re-blocks after a
 That continuation is owned by the active Codex Stop surface and never by a reaped child, a worker pane, or a second primary.
 
 Away mode needs a verified primary tmux or Herdr pane where the daemon can deliver its return and escalation messages.
-An external Codex thread identified by `CODEX_THREAD_ID` without either pane has no safe asynchronous callback, so `bin/fm-afk-launch.sh` refuses before it writes away state.
+An external Codex thread identified by `CODEX_THREAD_ID` without either pane has no safe asynchronous callback, so both `bin/fm-afk-launch.sh` and its common `bin/fm-afk-start.sh` entry refuse before they write away state.
 Do not supply `FM_SUPERVISOR_TARGET` for a worker pane.
 Keep foreground checkpoints running while present, or restart the primary in tmux or Herdr before leaving work unattended.

--- a/docs/turnend-guard.md
+++ b/docs/turnend-guard.md
@@ -50,7 +50,10 @@ If `jq` is missing or hook stdin is empty, the guard exits 0 because it cannot s
 
 Claude and Codex can block a Stop directly with exit status 2 and stderr.
 Both payloads carry `stop_hook_active`.
-In the default Codex mode, a true value lets the second stop finish after one forced continuation.
+For an external Codex thread carrying `CODEX_THREAD_ID`, the tracked Codex hook marks `FM_TURNEND_HARNESS=codex` so a true value does not reopen a blind Stop while supervision is still needed.
+The guard rechecks after every bounded foreground checkpoint expiry and blocks another continuation until a live watcher proves health or the fleet becomes empty.
+This is not a detached watcher or a pane injection path, and it creates no competing primary.
+The ordinary default and Grok paths retain their one-block loop guard.
 
 Claude runs the guard with `--claude`, which ignores `stop_hook_active` and cooperates with the Stop-owned auto-arm.
 Claude Code sets `stop_hook_active=true` on every stop after any stop-hook continuation, including `asyncRewake` rewakes, which re-opened the 2026-07-21 blind window under the default one-shot behavior.
@@ -103,7 +106,7 @@ That warning uses `bin/fm-supervision-instructions.sh --repair-line`, so it alwa
 
 ## Regression coverage
 
-`tests/fm-turnend-guard.test.sh` covers the predicate, main and secondmate primary scope, child-worktree exclusion, `FM_HOME` and `FM_STATE_OVERRIDE` precedence, the live-lock and fresh-beacon guard predicate, the cooperative `--claude` claim wait, monotonic failed-epoch progression, bounded attended fail-open, post-alarm continuation suppression, positive recovery reset, Pi logical-run latching, missing-`jq` behavior, all five primary registrations, Grok native and legacy selection, typed field precedence, malformed input, and exactly-one-path safety.
+`tests/fm-turnend-guard.test.sh` covers the predicate, main and secondmate primary scope, child-worktree exclusion, `FM_HOME` and `FM_STATE_OVERRIDE` precedence, the live-lock and fresh-beacon guard predicate, external-Codex checkpoint-expiry reblocking including the 219-second and 545-second stale-beacon incidents, the cooperative `--claude` claim wait, monotonic failed-epoch progression, bounded attended fail-open, post-alarm continuation suppression, positive recovery reset, Pi logical-run latching, missing-`jq` behavior, all five primary registrations, Grok native and legacy selection, typed field precedence, malformed input, and exactly-one-path safety.
 `tests/fm-guard-stale-banner.test.sh` covers the matching pull-guard predicate, including the fresh-leftover-beacon negative control.
 `tests/fm-kimi-harness.test.sh` covers the separate Kimi crew hook's format preservation, idempotence, refusal cases, token guard, spawn registration, and teardown cleanup.
 `tests/fm-supervision-instructions.test.sh` covers recovery-line ownership and pi-signed's identity-preserving reuse of Pi's protocol.

--- a/docs/verification/supervision.md
+++ b/docs/verification/supervision.md
@@ -244,17 +244,18 @@ tests/fm-turnend-guard.test.sh
 ### External Codex no-pane AFK boundary
 
 The external-Codex AFK boundary was verified on 2026-08-04 with the installed tmux and Herdr transports.
-`tests/fm-afk-launch.test.sh` reconstructs the bounded no-pane Codex checkpoint, retains an actionable wake, rejects both normal and native daemon entry before away state exists, and refuses an explicit worker-looking target.
-The same test keeps the established tmux and Herdr detached-daemon lifetime and exact cleanup coverage, while `tests/fm-afk-return.test.sh` covers return catch-up cleanup.
+`tests/fm-afk-launch.test.sh` reconstructs the bounded no-pane Codex checkpoint, retains an actionable wake, rejects both launcher paths before away state exists, and refuses an explicit worker-looking target.
+`tests/fm-daemon.test.sh` also invokes the common `bin/fm-afk-start.sh` entry directly and confirms that it refuses before it writes away state.
+The focused coverage retains the established tmux and Herdr detached-daemon lifetime and exact cleanup assertions.
 
 ```sh
-bin/fm-test-run.sh tests/fm-afk-launch.test.sh tests/fm-watch-checkpoint.test.sh tests/fm-afk-return.test.sh tests/fm-supervision-instructions.test.sh
+bin/fm-test-run.sh tests/fm-daemon.test.sh tests/fm-afk-launch.test.sh
 ```
 
 Observed output:
 
 ```text
-FM_TEST_SUMMARY total=4 failed=0 skipped_gate=0 duration_ms=13718
+FM_TEST_SUMMARY total=2 failed=0 skipped_gate=0 duration_ms=22837
 ```
 
 The supported external-Codex result is an early refusal with no away flag, daemon record, or daemon lock because the surface has no safe asynchronous callback into its active thread.

--- a/docs/verification/supervision.md
+++ b/docs/verification/supervision.md
@@ -241,6 +241,25 @@ tests/fm-claude-stop-autoarm.test.sh
 tests/fm-turnend-guard.test.sh
 ```
 
+### External Codex no-pane AFK boundary
+
+The external-Codex AFK boundary was verified on 2026-08-04 with the installed tmux and Herdr transports.
+`tests/fm-afk-launch.test.sh` reconstructs the bounded no-pane Codex checkpoint, retains an actionable wake, rejects both normal and native daemon entry before away state exists, and refuses an explicit worker-looking target.
+The same test keeps the established tmux and Herdr detached-daemon lifetime and exact cleanup coverage, while `tests/fm-afk-return.test.sh` covers return catch-up cleanup.
+
+```sh
+bin/fm-test-run.sh tests/fm-afk-launch.test.sh tests/fm-watch-checkpoint.test.sh tests/fm-afk-return.test.sh tests/fm-supervision-instructions.test.sh
+```
+
+Observed output:
+
+```text
+FM_TEST_SUMMARY total=4 failed=0 skipped_gate=0 duration_ms=13718
+```
+
+The supported external-Codex result is an early refusal with no away flag, daemon record, or daemon lock because the surface has no safe asynchronous callback into its active thread.
+The current operator mechanism and supported route are owned by [`supervision-protocols/codex.md`](../supervision-protocols/codex.md).
+
 ## Wedge-alarm channels
 
 The two real notification channels were bounded manually on 2026-07-10 on macOS 26.5.2 with Herdr 0.7.3.

--- a/docs/verification/supervision.md
+++ b/docs/verification/supervision.md
@@ -261,6 +261,21 @@ FM_TEST_SUMMARY total=2 failed=0 skipped_gate=0 duration_ms=22837
 The supported external-Codex result is an early refusal with no away flag, daemon record, or daemon lock because the surface has no safe asynchronous callback into its active thread.
 The current operator mechanism and supported route are owned by [`supervision-protocols/codex.md`](../supervision-protocols/codex.md).
 
+### External Codex Stop continuity
+
+The external-Codex Stop escape was reproduced and corrected on 2026-08-04.
+The original sequence was one Stop block, one bounded foreground checkpoint, then a `stop_hook_active=true` Stop that allowed the turn to end after the checkpoint removed its watcher lock.
+`tests/fm-turnend-guard.test.sh` now makes that sequence public, proves the external Codex re-block after quiet expiry, pins the observed 219-second and 545-second stale-beacon cases, and proves that an empty fleet remains a silent non-looping Stop.
+The preserved ordinary default loop guard is the smallest counterfactual, while Claude's distinct repeated-rewake path remains covered by its `--claude` cooperative tests and is not evidence that Codex has an asynchronous callback.
+
+```sh
+bin/fm-test-run.sh tests/fm-turnend-guard.test.sh tests/fm-watch-checkpoint.test.sh tests/fm-claude-stop-autoarm.test.sh
+```
+
+The supported-script reproduction observed `first_stop_rc=2`, `checkpoint_rc=124`, `escape_stop_rc=0`, and no watcher lock before the correction.
+After the correction, the same fixture observed `first_stop_rc=2`, `checkpoint_rc=124`, `escape_stop_rc=2`, and no watcher lock.
+The ordinary default-mode continuation remains the disconfirming control, and the Claude `--claude` auto-arm path remains separately covered rather than reused as Codex callback evidence.
+
 ## Wedge-alarm channels
 
 The two real notification channels were bounded manually on 2026-07-10 on macOS 26.5.2 with Herdr 0.7.3.

--- a/tests/fm-afk-launch.test.sh
+++ b/tests/fm-afk-launch.test.sh
@@ -22,6 +22,9 @@ set -u
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 LAUNCH="$ROOT/bin/fm-afk-launch.sh"
 START="$ROOT/bin/fm-afk-start.sh"
+CHECKPOINT="$ROOT/bin/fm-watch-checkpoint.sh"
+WATCH="$ROOT/bin/fm-watch.sh"
+DRAIN="$ROOT/bin/fm-wake-drain.sh"
 
 FAILED=0
 fail() { printf 'not ok - %s\n' "$1" >&2; FAILED=1; }
@@ -291,7 +294,7 @@ unit_signal_exits_with_lock_cleanup() {
   marker="$st/resumed"
   FM_HOME="$st" FM_STATE_OVERRIDE="$st/state" bash -c '
     . "$1"
-    fm_afk_launch_start() { sleep 30; }
+    fm_afk_launch_start() { sleep 1; }
     fm_afk_launch_main start
     : > "$2"
   ' _ "$LAUNCH" "$marker" &
@@ -823,6 +826,77 @@ unit_flag_write_failure_aborts() {
 }
 
 # ---------------------------------------------------------------------------
+# UNIT 4: an external Codex thread has no owned pane or callback destination.
+# A bounded checkpoint remains intentionally finite, while away entry rejects
+# both the normal and native paths before they can create daemon state or consume
+# a durable wake. An explicit worker-looking target must not bypass that check.
+# ---------------------------------------------------------------------------
+unit_external_codex_no_pane_refuses_before_away_state() {
+  local st checkpoint_out checkpoint_err watch_out launch_out launch_rc checkpoint_rc native_out native_rc drained
+  st=$(mktemp -d "${TMPDIR:-/tmp}/fm-afk-codex-no-pane.XXXXXX")
+  mkdir -p "$st/state" "$st/config" "$st/data"
+  printf 'window=worker-pane\nkind=ship\n' > "$st/state/demo.meta"
+  checkpoint_out="$st/checkpoint.out"
+  checkpoint_err="$st/checkpoint.err"
+  watch_out="$st/watch.out"
+  checkpoint_rc=0
+  env -u TMUX -u TMUX_PANE -u HERDR_ENV -u HERDR_PANE_ID \
+    CODEX_THREAD_ID=fixture FM_HOME="$st" FM_STATE_OVERRIDE="$st/state" \
+    FM_POLL=1 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 \
+    "$CHECKPOINT" --seconds 1 > "$checkpoint_out" 2> "$checkpoint_err" || checkpoint_rc=$?
+  if [ "$checkpoint_rc" -eq 124 ] \
+    && grep -F 'checkpoint: no actionable wake within 1s' "$checkpoint_out" >/dev/null \
+    && [ ! -e "$st/state/.watch.lock" ]; then
+    pass "external Codex: bounded checkpoint returns without retaining a watcher lock"
+  else
+    fail "external Codex: bounded checkpoint did not leave the expected finite no-lock state"
+  fi
+
+  printf 'done: fixture wake after checkpoint\n' > "$st/state/demo.status"
+  FM_HOME="$st" FM_STATE_OVERRIDE="$st/state" FM_POLL=1 FM_SIGNAL_GRACE=1 \
+    FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$watch_out" 2>&1 \
+    || fail "external Codex: could not create a durable fixture wake"
+  launch_out="$st/launch.out"
+  launch_rc=0
+  env -u TMUX -u TMUX_PANE -u HERDR_ENV -u HERDR_PANE_ID \
+    CODEX_THREAD_ID=fixture FM_HOME="$st" FM_STATE_OVERRIDE="$st/state" \
+    FM_SUPERVISOR_TARGET=worker-pane FM_SUPERVISOR_BACKEND=tmux "$LAUNCH" start > "$launch_out" 2>&1 \
+    || launch_rc=$?
+  if [ "$launch_rc" -ne 0 ] \
+    && grep -F 'no safe asynchronous callback' "$launch_out" >/dev/null \
+    && grep -F 'do not set FM_SUPERVISOR_TARGET to a worker pane' "$launch_out" >/dev/null \
+    && [ ! -e "$st/state/.afk" ] \
+    && [ ! -e "$st/state/.afk-daemon-terminal" ] \
+    && [ ! -e "$st/state/.supervise-daemon.lock" ]; then
+    pass "external Codex: wrong pane target is refused before daemon lifecycle state"
+  else
+    fail "external Codex: wrong pane target bypassed or obscured the explicit AFK refusal"
+  fi
+
+  native_out="$st/native.out"
+  native_rc=0
+  env -u TMUX -u TMUX_PANE -u HERDR_ENV -u HERDR_PANE_ID \
+    CODEX_THREAD_ID=fixture FM_HOME="$st" FM_STATE_OVERRIDE="$st/state" "$LAUNCH" start-native > "$native_out" 2>&1 \
+    || native_rc=$?
+  if [ "$native_rc" -ne 0 ] \
+    && grep -F 'no safe asynchronous callback' "$native_out" >/dev/null \
+    && [ ! -e "$st/state/.afk" ] \
+    && [ ! -e "$st/state/.afk-daemon-terminal" ]; then
+    pass "external Codex: native launch path cannot create a reapable daemon"
+  else
+    fail "external Codex: native launch path created away state without a delivery surface"
+  fi
+
+  drained=$(FM_HOME="$st" FM_STATE_OVERRIDE="$st/state" "$DRAIN")
+  if printf '%s\n' "$drained" | grep "$(printf '\tsignal\t')" | grep -F "$st/state/demo.status" >/dev/null; then
+    pass "external Codex: refusal preserves the durable wake for the captain's return"
+  else
+    fail "external Codex: away refusal consumed or lost the durable wake"
+  fi
+  rm -rf "$st"
+}
+
+# ---------------------------------------------------------------------------
 # E2E herdr: topology invariant.
 # ---------------------------------------------------------------------------
 e2e_herdr() {
@@ -951,6 +1025,7 @@ unit_clear_failure_aborts_entry
 unit_confirmed_absence_succeeds
 unit_incomplete_restore_retains_backup
 unit_flag_write_failure_aborts
+unit_external_codex_no_pane_refuses_before_away_state
 e2e_herdr
 e2e_tmux
 

--- a/tests/fm-afk-launch.test.sh
+++ b/tests/fm-afk-launch.test.sh
@@ -18,6 +18,7 @@
 #   sleeper replaces the real daemon (FM_AFK_LAUNCH_ENTRY) so the test observes
 #   only the terminal lifecycle.
 set -u
+unset CODEX_THREAD_ID
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 LAUNCH="$ROOT/bin/fm-afk-launch.sh"

--- a/tests/fm-daemon.test.sh
+++ b/tests/fm-daemon.test.sh
@@ -31,7 +31,7 @@ test_afk_start_refuses_when_flag_cannot_be_written() {
   state="$dir/state"
   mkdir -p "$state/.afk"
 
-  out=$(FM_STATE_OVERRIDE="$state" FM_SUPERVISOR_BACKEND=unsupported "$AFK_START" 2>&1)
+  out=$(env -u CODEX_THREAD_ID FM_STATE_OVERRIDE="$state" FM_SUPERVISOR_BACKEND=unsupported "$AFK_START" 2>&1)
   status=$?
 
   [ "$status" -ne 0 ] || fail "fm-afk-start.sh should fail when state/.afk cannot be written"
@@ -40,13 +40,31 @@ test_afk_start_refuses_when_flag_cannot_be_written() {
   pass "fm-afk-start.sh fails before daemon startup when the afk flag cannot be written"
 }
 
+test_afk_start_refuses_external_codex_without_pane_before_state() {
+  local dir state out status
+  dir=$(make_supercase afk-start-external-codex-no-pane)
+  state="$dir/state"
+
+  out=$(env -u TMUX -u TMUX_PANE -u HERDR_ENV -u HERDR_PANE_ID \
+    CODEX_THREAD_ID=fixture FM_STATE_OVERRIDE="$state" FM_SUPERVISOR_BACKEND=unsupported \
+    "$AFK_START" 2>&1)
+  status=$?
+
+  [ "$status" -ne 0 ] || fail "fm-afk-start.sh should reject an external Codex thread without a pane"
+  assert_contains "$out" "no safe asynchronous callback" "fm-afk-start.sh did not explain the external Codex refusal"
+  assert_absent "$state/.afk" "fm-afk-start.sh wrote away state before rejecting an external Codex thread"
+  assert_absent "$state/.supervise-daemon.lock" "fm-afk-start.sh created a daemon lock before rejecting an external Codex thread"
+  assert_not_contains "$out" "starting supervise daemon" "fm-afk-start.sh continued into daemon startup after rejecting an external Codex thread"
+  pass "fm-afk-start.sh rejects no-pane external Codex before away state"
+}
+
 test_afk_start_ignores_stale_pidfile_without_lock() {
   local dir state out status
   dir=$(make_supercase afk-start-stale-pidfile)
   state="$dir/state"
   printf '%s\n' "$$" > "$state/.supervise-daemon.pid"
 
-  out=$(FM_STATE_OVERRIDE="$state" FM_SUPERVISOR_BACKEND=unsupported "$AFK_START" 2>&1)
+  out=$(env -u CODEX_THREAD_ID FM_STATE_OVERRIDE="$state" FM_SUPERVISOR_BACKEND=unsupported "$AFK_START" 2>&1)
   status=$?
 
   [ "$status" -ne 0 ] || fail "fm-afk-start.sh should attempt daemon startup instead of trusting a pidfile-only live pid"
@@ -66,7 +84,7 @@ test_afk_start_reclaims_stale_daemon_lock_reused_pid() {
   printf '%s\n' "$$" > "$lock/pid"
   printf '%s\n' "stale daemon identity" > "$lock/pid-identity"
 
-  out=$(FM_STATE_OVERRIDE="$state" FM_SUPERVISOR_BACKEND=unsupported "$AFK_START" 2>&1)
+  out=$(env -u CODEX_THREAD_ID FM_STATE_OVERRIDE="$state" FM_SUPERVISOR_BACKEND=unsupported "$AFK_START" 2>&1)
   status=$?
 
   [ "$status" -ne 0 ] || fail "fm-afk-start.sh should attempt daemon startup after rejecting a reused-pid lock"
@@ -1828,6 +1846,7 @@ test_inject_msg_defers_on_unrecognized_composer_state() {
 }
 
 test_afk_start_refuses_when_flag_cannot_be_written
+test_afk_start_refuses_external_codex_without_pane_before_state
 test_afk_start_ignores_stale_pidfile_without_lock
 test_afk_start_reclaims_stale_daemon_lock_reused_pid
 test_daemon_state_root_uses_fm_home

--- a/tests/fm-turnend-guard.test.sh
+++ b/tests/fm-turnend-guard.test.sh
@@ -191,7 +191,25 @@ make_secondmate_linked_home_dir() {
 run_hook() {
   local dir=$1 stop_active=$2 home
   home=$(cd "$dir" && pwd)
-  printf '{"stop_hook_active":%s}' "$stop_active" | CLAUDECODE=1 FM_HOME="$home" bash "$dir/bin/fm-turnend-guard.sh" 2>&1
+  printf '{"stop_hook_active":%s}' "$stop_active" | env -u CODEX_THREAD_ID CLAUDECODE=1 FM_HOME="$home" bash "$dir/bin/fm-turnend-guard.sh" 2>&1
+}
+
+run_hook_external_codex() {
+  local dir=$1 stop_active=$2 home
+  home=$(cd "$dir" && pwd)
+  printf '{"stop_hook_active":%s}' "$stop_active" | env -u CLAUDECODE CODEX_THREAD_ID=fixture FM_TURNEND_HARNESS=codex FM_HOME="$home" bash "$dir/bin/fm-turnend-guard.sh" 2>&1
+}
+
+set_mtime_seconds_ago() {
+  local seconds=$1 path=$2 epoch stamp
+  epoch=$(( $(date +%s) - seconds ))
+  if stamp=$(date -r "$epoch" '+%Y%m%d%H%M.%S' 2>/dev/null); then
+    touch -mt "$stamp" "$path"
+  elif stamp=$(date -d "@$epoch" '+%Y%m%d%H%M.%S' 2>/dev/null); then
+    touch -mt "$stamp" "$path"
+  else
+    fail "host cannot set a deterministic beacon age"
+  fi
 }
 
 nonexistent_pid() {
@@ -427,9 +445,62 @@ test_hook_loop_guard_allows_retry() {
   dir=$(make_primary_dir "$TMP_ROOT/hook-loopguard")
   : > "$dir/state/task1.meta"
   out=$(run_hook "$dir" true); status=$?
-  expect_code 0 "$status" "hook must allow the stop when stop_hook_active is already true"
+  expect_code 0 "$status" "ordinary default hook must allow the stop when stop_hook_active is already true"
   [ -z "$out" ] || fail "hook produced output on the loop-guarded retry: $out"
-  pass "fm-turnend-guard: stop_hook_active=true always allows the stop (never blocks twice in one turn)"
+  pass "fm-turnend-guard: ordinary default stop_hook_active=true allows the bounded continuation"
+}
+
+test_external_codex_checkpoint_expiry_reblocks_until_empty() {
+  local dir checkpoint out status stale_age
+  dir=$(make_primary_dir "$TMP_ROOT/codex-checkpoint-expiry")
+  : > "$dir/state/task1.meta"
+
+  out=$(run_hook_external_codex "$dir" false); status=$?
+  expect_code 2 "$status" "external Codex initial blind Stop must force a checkpoint continuation"
+
+  checkpoint=$(CODEX_THREAD_ID=fixture FM_HOME="$dir" FM_POLL=1 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$ROOT/bin/fm-watch-checkpoint.sh" --seconds 1 2>&1); status=$?
+  expect_code 124 "$status" "external Codex bounded checkpoint must end quietly"
+  assert_contains "$checkpoint" "checkpoint: no actionable wake within 1s" "external Codex checkpoint did not report its bounded expiry"
+  assert_absent "$dir/state/.watch.lock/pid" "external Codex checkpoint left a watcher owner after expiry"
+
+  out=$(run_hook_external_codex "$dir" true); status=$?
+  expect_code 2 "$status" "external Codex stop_hook_active escape must re-block after the checkpoint owner disappears"
+  assert_contains "$out" "TURN WOULD END BLIND" "external Codex re-block lost the blind-turn banner"
+
+  for stale_age in 219 545; do
+    : > "$dir/state/.last-watcher-beat"
+    set_mtime_seconds_ago "$stale_age" "$dir/state/.last-watcher-beat"
+    out=$(FM_GUARD_GRACE=180 run_hook_external_codex "$dir" true); status=$?
+    expect_code 2 "$status" "external Codex ${stale_age}s stale beacon must not reopen the stop_hook_active escape"
+    assert_contains "$out" "TURN WOULD END BLIND" "external Codex ${stale_age}s stale beacon lost the blind-turn banner"
+  done
+
+  rm -f "$dir/state/task1.meta"
+  out=$(run_hook_external_codex "$dir" true); status=$?
+  expect_code 0 "$status" "external Codex must not loop once the fleet is empty"
+  [ -z "$out" ] || fail "external Codex idle Stop produced output: $out"
+  pass "fm-turnend-guard: external Codex re-blocks checkpoint expiry and the 219s/545s stale incidents without looping when idle"
+}
+
+test_external_codex_allows_a_verified_live_checkpoint_owner() {
+  local dir pid identity out status
+  dir=$(make_primary_dir "$TMP_ROOT/codex-live-checkpoint-owner")
+  : > "$dir/state/task1.meta"
+  sleep 60 &
+  pid=$!
+  identity=$(watcher_identity "$dir" "$pid") || {
+    kill "$pid" 2>/dev/null || true
+    wait "$pid" 2>/dev/null || true
+    fail "could not identify external Codex checkpoint owner"
+  }
+  record_watcher_lock "$dir" "$pid" "$identity"
+  touch "$dir/state/.last-watcher-beat"
+  out=$(run_hook_external_codex "$dir" true); status=$?
+  kill "$pid" 2>/dev/null || true
+  wait "$pid" 2>/dev/null || true
+  expect_code 0 "$status" "external Codex must allow a live identity-matched checkpoint owner"
+  [ -z "$out" ] || fail "external Codex healthy Stop produced output: $out"
+  pass "fm-turnend-guard: external Codex allows a verified live checkpoint owner"
 }
 
 # A secondmate's OWN home runs a primary firstmate session and must be guarded
@@ -796,6 +867,7 @@ test_codex_hook_uses_process_pwd_when_payload_cwd_is_outside_root() {
   cat > "$dir/bin/fm-turnend-guard.sh" <<'EOF'
 #!/usr/bin/env bash
 printf 'guard=%s\n' "$0"
+printf 'harness=%s\n' "${FM_TURNEND_HARNESS:-missing}"
 cat
 EOF
   chmod +x "$dir/bin/fm-turnend-guard.sh"
@@ -803,6 +875,7 @@ EOF
   out=$(printf '%s' "$payload" | (cd "$dir" && bash -c "$command") 2>&1); status=$?
   expect_code 0 "$status" "codex hook must execute successfully when payload cwd is outside the firstmate root"
   assert_contains "$out" "guard=$expected_root/bin/fm-turnend-guard.sh" "codex hook must use the hook process root"
+  assert_contains "$out" "harness=codex" "codex hook must mark the shared guard's harness surface"
   assert_contains "$out" "$payload" "codex hook must pass the original payload to the guard"
   pass ".codex/hooks.json: Stop hook uses hook process root when payload cwd is outside"
 }
@@ -1556,6 +1629,8 @@ test_hook_x_mode_only_blocks_in_default_mode
 test_hook_ignores_repo_state_when_fm_home_set
 test_hook_uses_state_override
 test_hook_loop_guard_allows_retry
+test_external_codex_checkpoint_expiry_reblocks_until_empty
+test_external_codex_allows_a_verified_live_checkpoint_owner
 test_hook_blocks_in_secondmate_own_home
 test_hook_silent_in_idle_secondmate_home
 test_hook_secondmate_loop_guard_allows_retry


### PR DESCRIPTION
## Intent

Fix Firstmate overnight supervision for an external Codex primary with CODEX_THREAD_ID outside tmux and Herdr. A finite 180-second foreground checkpoint must not let stop_hook_active=true end the turn while work remains and no verified watcher exists; use the active Codex Stop surface to re-block until a live watcher proves health or the fleet becomes empty. There is no safe asynchronous callback into that external Codex thread, so do not claim daemon continuity from a reaped child, inject into a worker pane, create a competing primary, or weaken watcher/session locks, the durable wake queue, busy/composer guards, or absent-is-absent reporting. Preserve the bounded foreground checkpoint while present and the existing default/Grok and Claude paths. Extend the same no-pane external-Codex pre-state refusal into the common bin/fm-afk-start.sh entry so every AFK entry refuses before state/.afk or durable-supervision state exists; preserve proven terminal-backed tmux and Herdr AFK paths, reject worker-pane targets, retain wakes, and clean up correctly on return. Keep public behavioral regressions for the no-pane reproduction, 219s/545s stale beacons, direct-entry bypass, daemon lifetime, wake retention, return cleanup, and supported backend/harness applicability. Update the authoritative mechanism and verification documentation. Deliver through the configured pipeline and PR/CI path, but do not merge.

## What Changed

- Re-block Codex Stop-hook continuations after foreground checkpoint expiry until watcher health is verified or the fleet is empty.
- Refuse AFK entry before lifecycle state is written when an external Codex thread has no verified tmux or Herdr primary pane.
- Document the external-Codex boundary and add regressions for stale beacons, direct entry, daemon lifetime, wake retention, and return cleanup.

## Risk Assessment

✅ Low: The change is narrowly scoped and preserves the required no-pane refusal, durable-watcher health check, and existing non-Codex guard paths.

## Testing

Focused behavioral validation passed: external Codex re-blocks after bounded checkpoint expiry and stale 219s/545s beacons, no-pane AFK entry refuses before durable state while retaining wakes, supported tmux/Herdr paths clean up correctly, and checkpoint/Claude control behavior remains intact. The initial guard run exposed this environment’s Node TypeScript-loader gap; enabling Node’s built-in type stripping (with warnings suppressed because the test asserts silent output) fixed setup and the retry passed.

<details>
<summary>Evidence: Stop continuity evidence</summary>

<code>External Codex: checkpoint expiry re-blocked on `stop_hook_active=true`, including 219s/545s stale beacons; a verified live checkpoint owner was allowed.</code>

```text
FM_TEST_BEGIN 2026-08-04T19:47:26Z tests/fm-turnend-guard.test.sh family=watcher-wake-lock expected_gate_skip=none
ok - fm_supervision_unhealthy: false with no state/*.meta at all
ok - fm_supervision_unhealthy: true with in-flight task and no beacon ever
ok - fm_supervision_unhealthy: true with in-flight task and a beacon far outside the grace window
ok - fm_supervision_unhealthy: false with in-flight task and a fresh beacon
ok - fm_supervision_status: FM_SUP_QUEUE_PENDING tracks state/.wake-queue
ok - fm_supervision_needed: X-mode relay poll needs supervision
ok - fm_supervision_unhealthy: source-only home needs supervision
ok - fm-turnend-guard: silent no-op with nothing in flight
ok - fm-turnend-guard: blocks when a fresh beacon has no live watcher lock
ok - fm-turnend-guard: non-Claude path blocks a source-only home
ok - fm-turnend-guard: blocks on a dead watcher lock even when the beacon is fresh
ok - fm-turnend-guard: silent no-op with a live watcher lock and fresh beacon
ok - fm-turnend-guard: healthy non-Claude harness paths ignore Claude episode contention
ok - fm-turnend-guard: blocks on a live watcher lock with an ancient beacon
ok - fm-turnend-guard: blocks with the exact required reason in the primary when unhealthy
ok - fm-turnend-guard: blocks from active FM_HOME state, not only repo-root state
ok - fm-turnend-guard: X-mode repair reason sources the cadence config
ok - fm-turnend-guard: X-mode-only supervision remains guarded in default mode
ok - fm-turnend-guard: ignores stale repo-root state when FM_HOME is set
ok - fm-turnend-guard: uses FM_STATE_OVERRIDE ahead of FM_HOME/state
ok - fm-turnend-guard: ordinary default stop_hook_active=true allows the bounded continuation
ok - fm-turnend-guard: external Codex re-blocks checkpoint expiry and the 219s/545s stale incidents without looping when idle
ok - fm-turnend-guard: external Codex allows a verified live checkpoint owner
ok - fm-turnend-guard: blocks a blind turn end in a secondmate's own home (.fm-secondmate-home no longer excludes it)
ok - fm-turnend-guard: idle-by-default - silent in a secondmate home with nothing in flight
ok - fm-turnend-guard: stop_hook_active=true allows the stop in a secondmate home (never blocks twice in one turn)
ok - fm-turnend-guard: secondmate deferred-death recovery - silent while watched, forces re-arm once the watcher exits
ok - fm-turnend-guard: inert in a secondmate's own child worktree (linked git worktree) even when unhealthy
ok - fm-turnend-guard: blocks a blind turn end in a treehouse-leased LINKED secondmate home (marker force-include)
ok - fm-turnend-guard: an invalid (empty) marker cannot spoof inclusion; linked worktree stays exempt
ok - fm-turnend-guard: a non-ASCII marker cannot spoof inclusion; linked worktree stays exempt
ok - fm-turnend-guard: inert in a crewmate/scout task worktree (linked git worktree) even when unhealthy
ok - fm-turnend-guard: fails open (never blocks) when jq is missing
ok - fm-turnend-guard: silent no-op on empty stdin
ok - fm-turnend-guard: runs well under the generous timing margin (0s)
ok - fm-turnend-guard-grok: forces one explicitly marked same-session resume when the shared predicate blocks
ok - fm-turnend-guard-grok: legacy environment loop guard prevents a nested resume loop
ok - fm-turnend-guard-grok: native false delegates blocking feedback with zero resume processes
ok - fm-turnend-guard-grok: native true remains bounded and starts no resume process
ok - fm-turnend-guard-grok: both spellings are typed and camelCase has deterministic precedence
ok - fm-turnend-guard-grok: malformed, invalidly typed, and missing-prerequisite payloads start neither path
ok - fm-turnend-guard-grok: missing jq and no-supervision-needed stops stay silent and bounded
ok - .codex/hooks.json: Stop hook uses hook process root when payload cwd is outside
ok - .codex/hooks.json: Stop hook ignores nested git root guard scripts
ok - .opencode primary plugin: guard path is anchored to worktree, not directory
ok - .pi primary extension: no-tool and multi-tool runs each inject exactly one guard follow-up
ok - .pi primary extension: delivery failure resets the logical-run latch
ok - fm-turnend-guard --claude: re-blocks a loop-guarded stop while unhealthy and unclaimed (incident regression)
ok - fm-turnend-guard --claude: X-mode-only homes re-block when auto-arm recovery is absent
ok - fm-turnend-guard --claude: a live arming epoch advances once and repeated observation is idempotent
ok - fm-turnend-guard --claude: repeated failed-to-arming races make bounded monotonic progress
ok - fm-turnend-guard --claude: terminal owner boundary excludes a concurrent start without deadlock
ok - fm-turnend-guard --claude: fresh rewake epoch prevents a duplicate continuation for the same event
ok - fm-turnend-guard --claude: fresh failed epochs preserve and advance monotonic fail-open progression
ok - fm-turnend-guard --claude: integrated fresh failures reach one bounded fail-open, stop continuation, and reset on recovery
ok - fm-turnend-guard --claude: reset contention preserves all episode state until retry
ok - fm-turnend-guard --claude: concurrent auto-arm and guard resets are idempotent and deadlock-free
ok - fm-turnend-guard --claude: stale rewake epoch does not allow a blind stop
ok - fm-turnend-guard --claude: budget exhaustion alone cannot permit a blind stop
ok - fm-turnend-guard --claude: verified fail-open is loud, bounded, attended, and non-repeating
ok - fm-turnend-guard --claude: fail-open requires both exhausted retries and consumed notice
ok - fm-turnend-guard --claude: away ownership excludes the Stop-autoarm fail-open
ok - fm-turnend-guard --claude: positive watcher recovery resets failure episode state
ok - fm-turnend-guard --claude: bounded claim wait avoids a token-consuming forced continuation
ok - fm-turnend-guard --claude: secondmate home re-blocks unclaimed and allows auto-arm-claimed stops
FM_TEST_END 2026-08-04T19:47:52Z tests/fm-turnend-guard.test.sh exit=0 duration_ms=25992 gate_skip=false
FM_TEST_SUMMARY total=1 failed=0 skipped_gate=0 duration_ms=26035
FM_TEST_SUMMARY_FAMILY family=watcher-wake-lock count=1 duration_ms=25992 failed=0
FM_TEST_SLOWEST rank=1 script=tests/fm-turnend-guard.test.sh duration_ms=25992
```
</details>
<details>
<summary>Evidence: AFK boundary evidence</summary>

`No-pane external Codex was refused before lifecycle state, retained its durable wake, and terminal-backed tmux/Herdr detached daemon paths retained cleanup behavior.`

```text
FM_TEST_BEGIN 2026-08-04T19:45:20Z tests/fm-afk-launch.test.sh family=real-herdr-gated expected_gate_skip=herdr
ok - clear-stale: removes escalations buffer, sidecar, and wedge marker
ok - clear-stale: leaves the durable wake-queue intact (no pending work dropped)
ok - launcher paths: relative home and state ignore CDPATH before daemon command construction
ok - launcher paths: absolute symlink spellings are preserved
ok - launcher paths: unresolved relative FM_HOME fails loudly
ok - launcher paths: unresolved relative FM_STATE_OVERRIDE fails loudly
ok - refresh: daemon already alive - stale artifacts preserved (current session's buffer kept)
ok - stop-ordering: daemon SIGTERM'd while .afk still present (flush is not a no-op)
ok - stop-ordering: .afk cleared last
ok - stop-ordering: daemon-terminal record removed
ok - stop identity: stale lock cannot signal an unrelated live process
ok - failed start: away flag and delivery artifacts roll back
ok - concurrent start: one serialized daemon terminal remains tracked
ok - launcher lock: incomplete publication receives initialization grace
ok - launcher signal: TERM exits and releases the lifecycle lock
fm-afk-launch: daemon launched in non-visible herdr workspace ws-partial (pane lab:pane-exact), supervising lab:captain
ok - herdr create: malformed response recovers durable exact ownership
fm-afk-launch: herdr create failed after returning exact ids; closing lab:pane-exact
fm-afk-launch: recorded terminal teardown is unconfirmed; preserving exact id
ok - herdr create error: unconfirmed exact id is persisted for reconciliation
fm-afk-launch: failed to run daemon in herdr pane lab:pane-exact; closing it
fm-afk-launch: recorded terminal teardown is unconfirmed; preserving exact id
ok - herdr run failure: unconfirmed exact id remains reconcilable
fm-afk-launch: failed to persist daemon terminal record; closing tmux:exact-session
ok - record failure: newly created terminal is closed by exact id
fm-afk-launch: daemon did not become ready; closing tmux:exact-session
ok - readiness failure: exact terminal and durable record roll back
fm-afk-launch: daemon did not become ready; closing tmux:exact-session
fm-afk-launch: recorded terminal teardown is unconfirmed; preserving exact id
ok - readiness failure: unconfirmed terminal retains its reconciliation id
ok - tmux absence: clean missing differs from transport probe failure
ok - native lifecycle: launcher owns state with no terminal
ok - native lifecycle: uniform stop clears state without closing a terminal
ok - native entry: launcher-prepared lifecycle state is not rewritten
fm-afk-launch: reconciling leaked daemon terminal tmux:exact-session
fm-afk-launch: recorded terminal teardown is unconfirmed; preserving exact id
ok - teardown failure: exact terminal record is preserved
ok - record publication: failed atomic rename preserves the complete prior record
fm-afk-launch: daemon terminal record is malformed; refusing to act on it
ok - record read: malformed record fails closed without acting on a partial id
fm-afk-launch: daemon terminal record is malformed; refusing to act on it
fm-afk-launch: malformed daemon terminal record; refusing to stop away mode
ok - stop: malformed terminal record preserves away state and fails closed
fm-afk-launch: failed to create detached tmux daemon session 'fm-afk-daemon-3901877418-2979145-15801-1785872723'
ok - tmux launch: planned exact target is recorded before creation and removed on failure
fm-afk-launch: failed to create detached tmux daemon session 'fm-afk-daemon-1717992741-2979180-28235-1785872723'
ok - tmux launch: unique names eliminate collision teardown
ok - stop validation: malformed record causes no daemon or state side effects
ok - launcher lock: incomplete metadata fails acquisition and releases lock
fm-afk-launch: failed to clear away-mode flag
fm-afk-launch: away mode stopped; terminal teardown remains recorded for retry
ok - stop state: away-flag removal failure is surfaced
fm-afk-launch: away-mode daemon did not exit after SIGTERM; preserving lifecycle state
ok - stop liveness: captured live daemon preserves lifecycle state after lock release
fm-afk-launch: daemon terminal record is malformed; refusing to act on it
fm-afk-launch: daemon terminal record is malformed; refusing to act on it
ok - refresh record: malformed terminal identity fails closed
fm-afk-launch: failed to clear stale away-mode artifacts
ok - clear failure: native entry aborts and restores prior state
fm-afk-launch: reconciling leaked daemon terminal tmux:exact-session
fm-afk-launch: terminal close command failed, but exact absence was confirmed
ok - confirmed absence: cleanup succeeds and removes the stale record
fm-afk-launch: rollback restoration incomplete; backup retained at /tmp/fm-afk-restore-fail.7XbaGv/state/.afk-launch-backup.bsRJhy
ok - rollback restore: incomplete restoration retains its recovery backup
ok - flag failure: lifecycle aborts without active state
ok - external Codex: bounded checkpoint returns without retaining a watcher lock
ok - external Codex: wrong pane target is refused before daemon lifecycle state
ok - external Codex: native launch path cannot create a reapable daemon
●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
●  WATCHER DOWN - SUPERVISION IS OFF
●  1 task(s) in flight, but no watcher has a fresh beacon (last beat: 1s ago, grace 300s).
●  Trust the emitted supervision protocol for this harness; do not use shell & for watcher repair.
●  This is a supervision warning only; the guarded operation WILL still run.
●  repair missing watcher supervision according to the session-start block for this harness; do not use shell &.
●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
ok - external Codex: refusal preserves the durable wake for the captain's return
ok - herdr e2e: captain tab pane count unchanged after start (no split)
ok - herdr e2e: daemon launched in a separate non-visible workspace
ok - herdr e2e: daemon pane is NOT in the captain's tab
ok - herdr e2e: daemon terminal scoped to the lab session
ok - herdr e2e: captain tab pane count restored after stop
ok - herdr e2e: daemon workspace removed by exact id on stop
ok - herdr e2e: record + .afk cleared on stop
ok - tmux e2e: captain window pane count unchanged after start (no split-window)
ok - tmux e2e: daemon launched in a separate detached session
ok - tmux e2e: captain window pane count unchanged after stop
ok - tmux e2e: daemon session killed by exact id on stop
ok - tmux e2e: record + .afk cleared on stop
FM_TEST_END 2026-08-04T19:45:28Z tests/fm-afk-launch.test.sh exit=0 duration_ms=8139 gate_skip=false
FM_TEST_BEGIN 2026-08-04T19:45:28Z tests/fm-daemon.test.sh family=watcher-wake-lock expected_gate_skip=none
ok - fm-afk-start.sh fails before daemon startup when the afk flag cannot be written
ok - fm-afk-start.sh rejects no-pane external Codex before away state
ok - fm-afk-start.sh ignores stale pidfile-only live pids
ok - fm-afk-start.sh reclaims stale daemon locks whose live pid identity no longer matches
ok - supervise daemon state root is scoped by FM_HOME
ok - routine signal self-handles
ok - captain-relevant status verbs escalate
ok - check + unknown escalate; heartbeat self-handles
ok - transient stale self-handles and records a persistence marker
ok - enriched stale wedges bypass status absorption without disturbing busy workers
ok - stale + terminal status escalates immediately
ok - paused reasons with captain phrases remain pause-classified
ok - handle_wake on a paused stale records a pause marker, drops the wedge marker, and does not escalate
ok - handle_wake records a declared pause from a routine signal for long-cadence rechecks
ok - a terminal signal clears pause and stale tracking across both supervisors
ok - housekeeping migrates a normal-watcher's declared pause into daemon tracking
ok - housekeeping clears an already-resumed watcher pause across both supervisors
ok - housekeeping seeds pause tracking from status without a watcher marker
ok - persistent stale escalates after threshold and clears its marker
ok - resumed (busy) stale clears its marker without escalating
ok - housekeeping re-surfaces a stale declared pause on the long cadence and resets its window
ok - housekeeping clears a paused marker whose pane became busy again, without escalating
ok - housekeeping clears a paused marker once the crew is no longer declaring the pause
ok - housekeeping moves an existing stale marker to pause before wedge escalation
ok - housekeeping clears tracking when a crew leaves pause
ok - persistent herdr stale resolves the target from metadata and escalates
ok - herdr idle busy-footer stale clears through capture corroboration
ok - resumed herdr stale clears through backend-aware busy state
ok - persistent Orca stale resolves the terminal from metadata
ok - multiple escalations flush as a single batched digest
ok - batch flush measures max-delay from the first append, not the last
ok - catch-all scan escalates a missed terminal once, not twice
ok - handle_wake routes routine->self and captain->escalate
ok - INJECT_SKIP forces self-handle, bypassing captain-relevant classification
ok - is_wake_reason distinguishes watcher wake reasons from singleton-status stdout
ok - terminal-stale escalate removes its marker so housekeeping does not re-escalate
ok - captain signal escalate marks seen so the catch-all scan does not re-fire
ok - _collapse_newlines replaces newlines with literal separator
ok - afk flag absent: daemon does not inject, buffer preserved
ok - busy-guard defers injection when supervisor pane is busy
ok - marker detection: marker -> stay afk, no marker -> exit afk
ok - /afk invocation is exempt from afk exit (no self-cancel)
ok - should_exit_afk returns false when afk is not active
ok - strip_injection_marker removes the sentinel marker cleanly
ok - pane_input_pending detects partial input on the cursor line
ok - pane_input_pending: blank cursor line is not pending
ok - pane_input_pending: only proven empty agent prompts pass
ok - fm_tmux_composer_state: a bare shell prompt ($/%/#/>) reads unknown, never empty (dead-shell injection safety)
ok - fm_tmux_composer_state: a bordered composer box and bare agent glyphs (❯/›) still read empty
ok - fm_tmux_composer_state: only matching edge borders form a composer box
ok - pane_input_pending honors FM_COMPOSER_IDLE_RE after border stripping
ok - classify_signal dedupes against the catch-all scan seen marker
ok - classify_stale dedupes against the signal path seen marker
ok - AFK nonterminal working:+merged keeps wedge aging and re-escalates at bound
ok - genuine done: and merge-check events still escalate
ok - pane_input_pending: an idle bordered composer is NOT pending (afk-invx-i5)
ok - pane_input_pending: text inside a bordered composer is still pending
ok - submit-ACK confirms a submit when the composer returns to a bordered-empty box
ok - submit-ACK reports pending on a persistently swallowed Enter (type-once)
ok - max-defer on an empty stuck pane types once, alarms, and preserves the buffer
ok - max-defer flushes and clears the buffer on an empty bordered pane
ok - max-defer on a pending composer alarms without typing
ok - normal flush clears a stale wedge marker
ok - below MAX_DEFER: no inject, no alarm, buffer preserved
ok - max-defer does not flush or alarm while afk is inactive
ok - library mode: sourcing the daemon defaults FM_WEDGE_ALARM_EXEC to discard (no test can fire a real notification)
ok - wake helpers replace inherited notifier overrides with the safe recorder
ok - the discard seam suppresses every notifier, including command: (fires nothing)
ok - direct notifier helpers honor the discard seam, including command:
ok - osascript channel routes through the notifier seam with the summary (never a real notification)
ok - herdr channel routes through the notifier seam with the summary (never a real notification)
ok - command channel runs the captain command with the summary on $1 and on stdin
ok - command channel failures redact configured commands while logging their exit status
ok - unknown channel directives are redacted while the alarm keeps running
ok - off disables every active alert regardless of directive position (marker and tmux flash are unaffected)
ok - auto resolves to the macOS osascript notifier on Darwin (default-on)
ok - auto on a non-macOS platform selects no built-in OS channel (the marker or a configured command carries it)
ok - config/wedge-alarm selects every configured channel and skips comment and blank lines
ok - a failing channel logs and falls back to the next channel, never crashing the alarm
ok - a hung notifier is bounded, logged, and falls through to the next channel
ok - a backgrounded command notifier remains bounded until its process group is reaped
ok - a hung notifier override is bounded, logged, and proceeds to the next channel
[1]+  Terminated              sh -c 'sleep 30 & printf "%s" "$!" > "$1"; wait' sh "$child_file"
ok - daemon shutdown stops and reaps the active notifier process group
ok - inject_wedge_alarm writes the marker AND emits the active alert even with no tmux status-line (herdr backend)
ok - in-process wedge throttle prevents alert spam when the marker cannot persist
ok - fm-send exits non-zero on a confirmed swallow, zero on a clean submit
ok - fm-send exits non-zero when initial text send fails
ok - fm-send exits non-zero unless delivery is proven empty
ok - discover_supervisor_backend: override > TMUX_PANE > HERDR_ENV+HERDR_PANE_ID > tmux fallback
ok - discover_supervisor_target: override > TMUX_PANE > herdr '<session>:<pane-id>' composition > firstmate:0 fallback
ok - pane_is_busy: herdr native busy_state='busy' short-circuits without a capture fallback
ok - primary busy guard isolates rendered signatures by detected harness
ok - pane_is_busy: omitted backend defaults to tmux for Grok's isolated fallback
ok - pane_input_pending: dispatches through fm_backend_composer_state for backend=herdr
ok - inject_msg: herdr busy-guard defers before ever attempting a submit
ok - inject_msg: herdr composer-guard defers before ever attempting a submit
ok - inject_msg: herdr pane-gone check defers before any busy/composer/submit call
ok - inject_msg: dispatches busy-guard/composer-guard/submit through the herdr backend and succeeds on a confirmed empty composer
ok - inject_msg: defers on a dead-shell/unreadable composer (unknown), never typing the escalation into a shell
ok - inject_msg: unrecognized composer states defer by default
FM_TEST_END 2026-08-04T19:45:46Z tests/fm-daemon.test.sh exit=0 duration_ms=18440 gate_skip=false
FM_TEST_SUMMARY total=2 failed=0 skipped_gate=0 duration_ms=26651
FM_TEST_SUMMARY_FAMILY family=real-herdr-gated count=1 duration_ms=8139 failed=0
FM_TEST_SUMMARY_FAMILY family=watcher-wake-lock count=1 duration_ms=18440 failed=0
FM_TEST_SLOWEST rank=1 script=tests/fm-daemon.test.sh duration_ms=18440
FM_TEST_SLOWEST rank=2 script=tests/fm-afk-launch.test.sh duration_ms=8139
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bin/fm-test-run.sh tests/fm-afk-launch.test.sh tests/fm-daemon.test.sh`
- `bin/fm-test-run.sh tests/fm-watch-checkpoint.test.sh tests/fm-claude-stop-autoarm.test.sh`
- `NODE_NO_WARNINGS=1 NODE_OPTIONS=--experimental-strip-types bin/fm-test-run.sh tests/fm-turnend-guard.test.sh`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Lint** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ linter found issues (exit code 1)

🔧 Fix: Confirm lint passes under pinned ShellCheck
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
