### PR TITLE
test: prevent fixture temporary directory leaks

### DIFF
--- a/tests/fm-procevent.test.sh
+++ b/tests/fm-procevent.test.sh
@@ -18,9 +18,6 @@ set -u
 
 ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
 TMP_ROOT=$(fm_test_tmproot fm-procevent-tests)
-# fm_test_tmproot runs inside a command substitution, whose EXIT trap removes the
-# directory it just registered, so recreate it before writing anything into it.
-mkdir -p "$TMP_ROOT"
 export FM_PROCEVENT_CLAIM_ROOT="$TMP_ROOT/claims"
 
 BLOCKER="$TMP_ROOT/blocker.sh"

--- a/tests/fm-test-fixture-cleanup.test.sh
+++ b/tests/fm-test-fixture-cleanup.test.sh
@@ -43,7 +43,7 @@ test_fixture_root_gone_after_sigterm() {
     . "'"$LIB"'"
     d=$(fm_test_tmproot fm-test-cleanup-term)
     printf "%s\n" "$d" > "'"$dirfile"'"
-    sleep 30
+    while :; do sleep 0.1; done
   ' &
   pid=$!
   tries=0
@@ -106,7 +106,7 @@ test_orphan_sweep_respects_fixture_ownership() {
     . "'"$LIB"'"
     d=$(fm_test_tmproot fm-test-cleanup-active)
     printf "%s\n" "$d" > "'"$dirfile"'"
-    sleep 30
+    while :; do sleep 0.1; done
   ' &
   pid=$!
   tries=0

--- a/tests/fm-test-fixture-cleanup.test.sh
+++ b/tests/fm-test-fixture-cleanup.test.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# Behavior tests for tests/lib.sh's shared fixture-tempdir helper
+# (fm_test_tmproot / fm_test_cleanup / fm_test_reap_orphans).
+#
+# The near-universal call pattern across this suite is
+# `TMP_ROOT=$(fm_test_tmproot prefix)`, which forks a subshell to capture the
+# function's stdout. These tests spawn real, separate bash processes that use
+# that exact pattern and assert the fixture root is actually gone once the
+# owning process's guarded teardown has run - on a normal exit and on a
+# terminating signal - plus that a stale marked fixture from a killed prior
+# run gets reaped on the next source. Nothing here inspects tests/lib.sh's
+# source text; it only observes filesystem state around the real helper.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+LIB="$ROOT/tests/lib.sh"
+
+test_fixture_root_gone_after_normal_exit() {
+  local child_out child_dir
+  child_out=$(bash -c '
+    # shellcheck source=tests/lib.sh
+    . "'"$LIB"'"
+    d=$(fm_test_tmproot fm-test-cleanup-exit)
+    printf "%s\n" "$d"
+    if [ -d "$d" ]; then printf "mid:present\n"; else printf "mid:missing\n"; fi
+  ')
+  child_dir=$(printf '%s\n' "$child_out" | sed -n '1p')
+  assert_contains "$child_out" "mid:present" \
+    "the fixture root was not present while its owning process was still alive"
+  assert_absent "$child_dir" \
+    "fm_test_tmproot's fixture root survived its owning process's normal exit"
+  pass "fm_test_tmproot cleans up its fixture root on normal exit"
+}
+
+test_fixture_root_gone_after_sigterm() {
+  local harness dirfile child_dir pid tries
+  harness=$(fm_test_tmproot fm-test-cleanup-sigterm-harness)
+  dirfile="$harness/child-dir"
+  bash -c '
+    # shellcheck source=tests/lib.sh
+    . "'"$LIB"'"
+    d=$(fm_test_tmproot fm-test-cleanup-term)
+    printf "%s\n" "$d" > "'"$dirfile"'"
+    sleep 30
+  ' &
+  pid=$!
+  tries=0
+  while [ "$tries" -lt 100 ]; do
+    [ -s "$dirfile" ] && break
+    sleep 0.05
+    tries=$((tries + 1))
+  done
+  [ -s "$dirfile" ] || fail "the child never published its fixture root before the wait timed out"
+  child_dir=$(cat "$dirfile")
+  assert_present "$child_dir" "the child's fixture root did not exist before it was signaled"
+  kill -TERM "$pid"
+  wait "$pid" 2>/dev/null
+  assert_absent "$child_dir" \
+    "fm_test_tmproot's fixture root survived SIGTERM to its owning process"
+  pass "fm_test_tmproot cleans up its fixture root on SIGTERM"
+}
+
+test_stale_marked_fixture_reaped_on_next_source() {
+  local stale_dir fresh_dir
+  stale_dir=$(mktemp -d "${TMPDIR:-/tmp}/fm-test-cleanup-stale.XXXXXX")
+  : > "$stale_dir/.fm-test-fixture"
+  touch -t 202001010000 "$stale_dir/.fm-test-fixture"
+  fresh_dir=$(mktemp -d "${TMPDIR:-/tmp}/fm-test-cleanup-fresh.XXXXXX")
+  : > "$fresh_dir/.fm-test-fixture"
+
+  bash -c '
+    # shellcheck source=tests/lib.sh
+    . "'"$LIB"'"
+  '
+
+  assert_absent "$stale_dir" \
+    "a stale marked fixture root from a killed prior run was not reaped on the next source"
+  assert_present "$fresh_dir" \
+    "the orphan reaper removed a fresh marked fixture root it does not own yet"
+  rm -rf "$fresh_dir"
+  pass "a stale marked fixture root from a dead prior run is reaped on the next source"
+}
+
+test_fixture_root_gone_after_normal_exit
+test_fixture_root_gone_after_sigterm
+test_stale_marked_fixture_reaped_on_next_source

--- a/tests/fm-test-fixture-cleanup.test.sh
+++ b/tests/fm-test-fixture-cleanup.test.sh
@@ -62,10 +62,30 @@ test_fixture_root_gone_after_sigterm() {
   pass "fm_test_tmproot cleans up its fixture root on SIGTERM"
 }
 
-test_stale_marked_fixture_reaped_on_next_source() {
-  local stale_dir fresh_dir
+test_orphan_sweep_respects_fixture_ownership() {
+  local harness dirfile active_dir stale_dir fresh_dir pid tries
+  harness=$(fm_test_tmproot fm-test-cleanup-orphan-harness)
+  dirfile="$harness/active-dir"
+  bash -c '
+    # shellcheck source=tests/lib.sh
+    . "'"$LIB"'"
+    d=$(fm_test_tmproot fm-test-cleanup-active)
+    printf "%s\n" "$d" > "'"$dirfile"'"
+    sleep 30
+  ' &
+  pid=$!
+  tries=0
+  while [ "$tries" -lt 100 ]; do
+    [ -s "$dirfile" ] && break
+    sleep 0.05
+    tries=$((tries + 1))
+  done
+  [ -s "$dirfile" ] || fail "the active child never published its fixture root before the wait timed out"
+  active_dir=$(cat "$dirfile")
+  touch -t 202001010000 "$active_dir/.fm-test-fixture"
+
   stale_dir=$(mktemp -d "${TMPDIR:-/tmp}/fm-test-cleanup-stale.XXXXXX")
-  : > "$stale_dir/.fm-test-fixture"
+  printf '%s\n' 999999999 > "$stale_dir/.fm-test-fixture"
   touch -t 202001010000 "$stale_dir/.fm-test-fixture"
   fresh_dir=$(mktemp -d "${TMPDIR:-/tmp}/fm-test-cleanup-fresh.XXXXXX")
   : > "$fresh_dir/.fm-test-fixture"
@@ -77,12 +97,18 @@ test_stale_marked_fixture_reaped_on_next_source() {
 
   assert_absent "$stale_dir" \
     "a stale marked fixture root from a killed prior run was not reaped on the next source"
+  assert_present "$active_dir" \
+    "the orphan reaper removed an old fixture root whose owning process was still alive"
   assert_present "$fresh_dir" \
     "the orphan reaper removed a fresh marked fixture root it does not own yet"
+  kill -TERM "$pid"
+  wait "$pid" 2>/dev/null
+  assert_absent "$active_dir" \
+    "the active fixture root survived its owning process's teardown"
   rm -rf "$fresh_dir"
-  pass "a stale marked fixture root from a dead prior run is reaped on the next source"
+  pass "the orphan sweep reaps only old fixtures without a live owner"
 }
 
 test_fixture_root_gone_after_normal_exit
 test_fixture_root_gone_after_sigterm
-test_stale_marked_fixture_reaped_on_next_source
+test_orphan_sweep_respects_fixture_ownership

--- a/tests/fm-test-fixture-cleanup.test.sh
+++ b/tests/fm-test-fixture-cleanup.test.sh
@@ -79,6 +79,24 @@ test_cleanup_registry_resists_precreation() {
   pass "the cleanup registry cannot be injected through path precreation"
 }
 
+test_fixture_registration_failure_rolls_back_root() {
+  local harness failure_tmp registry_dir output leaked_root
+  harness=$(fm_test_tmproot fm-test-cleanup-registration-harness)
+  failure_tmp="$harness/tmp"
+  registry_dir="$harness/registry-dir"
+  mkdir -p "$failure_tmp" "$registry_dir"
+
+  if output=$(TMPDIR="$failure_tmp" FM_TEST_CLEANUP_REGISTRY="$registry_dir" \
+    fm_test_tmproot fm-test-cleanup-registration-failure 2>/dev/null); then
+    fail "fm_test_tmproot succeeded after its cleanup registry rejected registration"
+  fi
+  [ -z "$output" ] || fail "fm_test_tmproot published an unregistered fixture root"
+  for leaked_root in "$failure_tmp"/fm-test-cleanup-registration-failure.*; do
+    [ ! -e "$leaked_root" ] || fail "fm_test_tmproot leaked a root after registration failed"
+  done
+  pass "failed fixture registration rolls back the new root"
+}
+
 test_orphan_sweep_respects_fixture_ownership() {
   local harness dirfile active_dir stale_dir fresh_dir pid tries
   harness=$(fm_test_tmproot fm-test-cleanup-orphan-harness)
@@ -129,4 +147,5 @@ test_orphan_sweep_respects_fixture_ownership() {
 test_fixture_root_gone_after_normal_exit
 test_fixture_root_gone_after_sigterm
 test_cleanup_registry_resists_precreation
+test_fixture_registration_failure_rolls_back_root
 test_orphan_sweep_respects_fixture_ownership

--- a/tests/fm-test-fixture-cleanup.test.sh
+++ b/tests/fm-test-fixture-cleanup.test.sh
@@ -85,7 +85,7 @@ test_orphan_sweep_respects_fixture_ownership() {
   touch -t 202001010000 "$active_dir/.fm-test-fixture"
 
   stale_dir=$(mktemp -d "${TMPDIR:-/tmp}/fm-test-cleanup-stale.XXXXXX")
-  printf '%s\n' 999999999 > "$stale_dir/.fm-test-fixture"
+  printf '%s\n%s\n' "$$" reused-process-identity > "$stale_dir/.fm-test-fixture"
   touch -t 202001010000 "$stale_dir/.fm-test-fixture"
   fresh_dir=$(mktemp -d "${TMPDIR:-/tmp}/fm-test-cleanup-fresh.XXXXXX")
   : > "$fresh_dir/.fm-test-fixture"
@@ -96,7 +96,7 @@ test_orphan_sweep_respects_fixture_ownership() {
   '
 
   assert_absent "$stale_dir" \
-    "a stale marked fixture root from a killed prior run was not reaped on the next source"
+    "a stale fixture root whose PID was reused by another process was not reaped"
   assert_present "$active_dir" \
     "the orphan reaper removed an old fixture root whose owning process was still alive"
   assert_present "$fresh_dir" \

--- a/tests/fm-test-fixture-cleanup.test.sh
+++ b/tests/fm-test-fixture-cleanup.test.sh
@@ -62,6 +62,23 @@ test_fixture_root_gone_after_sigterm() {
   pass "fm_test_tmproot cleans up its fixture root on SIGTERM"
 }
 
+test_cleanup_registry_resists_precreation() {
+  local harness shared_tmp victim
+  harness=$(fm_test_tmproot fm-test-cleanup-registry-harness)
+  shared_tmp="$harness/shared-tmp"
+  victim="$harness/victim"
+  mkdir -p "$shared_tmp" "$victim"
+
+  TMPDIR="$shared_tmp" bash -c '
+    printf "%s\n" "$1" > "$TMPDIR/.fm-test-cleanup.$$"
+    . "$2"
+  ' _ "$victim" "$LIB"
+
+  assert_present "$victim" \
+    "a precreated predictable cleanup registry injected an arbitrary deletion target"
+  pass "the cleanup registry cannot be injected through path precreation"
+}
+
 test_orphan_sweep_respects_fixture_ownership() {
   local harness dirfile active_dir stale_dir fresh_dir pid tries
   harness=$(fm_test_tmproot fm-test-cleanup-orphan-harness)
@@ -111,4 +128,5 @@ test_orphan_sweep_respects_fixture_ownership() {
 
 test_fixture_root_gone_after_normal_exit
 test_fixture_root_gone_after_sigterm
+test_cleanup_registry_resists_precreation
 test_orphan_sweep_respects_fixture_ownership

--- a/tests/lib.sh
+++ b/tests/lib.sh
@@ -53,28 +53,70 @@ pass() {
 # --- self-cleaning temp root ------------------------------------------------
 #
 # fm_test_tmproot <prefix> echoes a fresh temp dir and registers it for removal
-# on EXIT. The first call installs the cleanup trap. A test file that needs
-# extra teardown (e.g. killing a daemon) should define its own EXIT trap and
-# call fm_test_cleanup from inside it so registered dirs are still removed.
+# on EXIT/INT/TERM. A test file that needs extra teardown (e.g. killing a
+# daemon) should define its own EXIT trap and call fm_test_cleanup from inside
+# it so registered dirs are still removed.
+#
+# The call site is almost always `TMP_ROOT=$(fm_test_tmproot prefix)`, which
+# forks a subshell to capture stdout. Anything that function does to the
+# current shell's state - an array append, a trap - dies with that subshell
+# and never reaches the real caller, so registration cannot go through
+# in-process state. `$$` is the one thing bash keeps stable across that
+# boundary (it always resolves to the invoking shell's PID, not the
+# subshell's - see `man bash` on `$$`), so fm_test_tmproot records the
+# directory in a `$$`-keyed registry file instead, and the trap that reaps
+# that file is armed once, here, at source time - which always runs in the
+# real caller, never a subshell.
 
 FM_TEST_CLEANUP_DIRS=()
+FM_TEST_CLEANUP_REGISTRY="${TMPDIR:-/tmp}/.fm-test-cleanup.$$"
 
 fm_test_cleanup() {
   local d
   for d in "${FM_TEST_CLEANUP_DIRS[@]:-}"; do
     [ -n "$d" ] && rm -rf "$d"
   done
+  if [ -f "$FM_TEST_CLEANUP_REGISTRY" ]; then
+    while IFS= read -r d; do
+      [ -n "$d" ] && rm -rf "$d"
+    done < "$FM_TEST_CLEANUP_REGISTRY"
+    rm -f "$FM_TEST_CLEANUP_REGISTRY"
+  fi
 }
 
 fm_test_tmproot() {
   local prefix=${1:-fm-test} root
   root=$(mktemp -d "${TMPDIR:-/tmp}/${prefix}.XXXXXX")
-  if [ "${#FM_TEST_CLEANUP_DIRS[@]}" -eq 0 ]; then
-    trap fm_test_cleanup EXIT
-  fi
-  FM_TEST_CLEANUP_DIRS+=("$root")
+  : > "$root/.fm-test-fixture"
+  printf '%s\n' "$root" >> "$FM_TEST_CLEANUP_REGISTRY"
   printf '%s\n' "$root"
 }
+
+trap fm_test_cleanup EXIT
+trap 'fm_test_cleanup; exit 130' INT
+trap 'fm_test_cleanup; exit 143' TERM
+
+# fm_test_reap_orphans: best-effort sweep for fixture roots left behind by a
+# prior run that was killed hard enough to skip the traps above (e.g. a
+# SIGKILL timeout). Only removes directories carrying the .fm-test-fixture
+# marker fm_test_tmproot writes, so it never touches unrelated fm-* tmp dirs
+# from real (non-test) firstmate commands, and only ones old enough that no
+# currently-running suite could still own them.
+FM_TEST_ORPHAN_MAX_AGE_SECONDS=${FM_TEST_ORPHAN_MAX_AGE_SECONDS:-3600}
+
+fm_test_reap_orphans() {
+  local marker dir mtime now
+  now=$(date +%s)
+  for marker in "${TMPDIR:-/tmp}"/fm-*/.fm-test-fixture; do
+    [ -e "$marker" ] || continue
+    mtime=$(stat -f %m "$marker" 2>/dev/null || stat -c %Y "$marker" 2>/dev/null) || continue
+    [ $((now - mtime)) -ge "$FM_TEST_ORPHAN_MAX_AGE_SECONDS" ] || continue
+    dir=$(dirname "$marker")
+    rm -rf "$dir"
+  done
+}
+
+fm_test_reap_orphans
 
 # --- fakebin / PATH shims ---------------------------------------------------
 #

--- a/tests/lib.sh
+++ b/tests/lib.sh
@@ -89,13 +89,16 @@ fm_test_cleanup() {
 
 fm_test_tmproot() {
   local prefix=${1:-fm-test} root owner_identity
-  root=$(mktemp -d "${TMPDIR:-/tmp}/${prefix}.XXXXXX")
+  root=$(mktemp -d "${TMPDIR:-/tmp}/${prefix}.XXXXXX") || return 1
   owner_identity=$(fm_pid_identity "$$") || {
     rm -rf "$root"
     return 1
   }
-  printf '%s\n%s\n' "$$" "$owner_identity" > "$root/.fm-test-fixture"
-  printf '%s\n' "$root" >> "$FM_TEST_CLEANUP_REGISTRY"
+  if ! printf '%s\n%s\n' "$$" "$owner_identity" > "$root/.fm-test-fixture" ||
+    ! printf '%s\n' "$root" >> "$FM_TEST_CLEANUP_REGISTRY"; then
+    rm -rf "$root"
+    return 1
+  fi
   printf '%s\n' "$root"
 }
 

--- a/tests/lib.sh
+++ b/tests/lib.sh
@@ -87,7 +87,7 @@ fm_test_cleanup() {
 fm_test_tmproot() {
   local prefix=${1:-fm-test} root
   root=$(mktemp -d "${TMPDIR:-/tmp}/${prefix}.XXXXXX")
-  : > "$root/.fm-test-fixture"
+  printf '%s\n' "$$" > "$root/.fm-test-fixture"
   printf '%s\n' "$root" >> "$FM_TEST_CLEANUP_REGISTRY"
   printf '%s\n' "$root"
 }
@@ -100,15 +100,24 @@ trap 'fm_test_cleanup; exit 143' TERM
 # prior run that was killed hard enough to skip the traps above (e.g. a
 # SIGKILL timeout). Only removes directories carrying the .fm-test-fixture
 # marker fm_test_tmproot writes, so it never touches unrelated fm-* tmp dirs
-# from real (non-test) firstmate commands, and only ones old enough that no
-# currently-running suite could still own them.
+# from real (non-test) firstmate commands. The marker names the owning shell,
+# so a live owner always wins over the age fallback for dead or unowned roots.
 FM_TEST_ORPHAN_MAX_AGE_SECONDS=${FM_TEST_ORPHAN_MAX_AGE_SECONDS:-3600}
 
 fm_test_reap_orphans() {
-  local marker dir mtime now
+  local marker dir mtime now owner_pid
   now=$(date +%s)
   for marker in "${TMPDIR:-/tmp}"/fm-*/.fm-test-fixture; do
     [ -e "$marker" ] || continue
+    owner_pid=$(sed -n '1p' "$marker" 2>/dev/null) || owner_pid=
+    case "$owner_pid" in
+      '' | *[!0-9]*) ;;
+      *)
+        if [ "$owner_pid" -gt 0 ] && kill -0 "$owner_pid" 2>/dev/null; then
+          continue
+        fi
+        ;;
+    esac
     mtime=$(stat -f %m "$marker" 2>/dev/null || stat -c %Y "$marker" 2>/dev/null) || continue
     [ $((now - mtime)) -ge "$FM_TEST_ORPHAN_MAX_AGE_SECONDS" ] || continue
     dir=$(dirname "$marker")

--- a/tests/lib.sh
+++ b/tests/lib.sh
@@ -72,7 +72,7 @@ pass() {
 # real caller, never a subshell.
 
 FM_TEST_CLEANUP_DIRS=()
-FM_TEST_CLEANUP_REGISTRY="${TMPDIR:-/tmp}/.fm-test-cleanup.$$"
+FM_TEST_CLEANUP_REGISTRY=$(mktemp "${TMPDIR:-/tmp}/.fm-test-cleanup.$$.XXXXXX") || return 1
 
 fm_test_cleanup() {
   local d

--- a/tests/lib.sh
+++ b/tests/lib.sh
@@ -135,7 +135,7 @@ fm_test_reap_orphans() {
         fi
         ;;
     esac
-    mtime=$(stat -f %m "$marker" 2>/dev/null || stat -c %Y "$marker" 2>/dev/null) || continue
+    mtime=$(stat -c %Y "$marker" 2>/dev/null || stat -f %m "$marker" 2>/dev/null) || continue
     [ $((now - mtime)) -ge "$FM_TEST_ORPHAN_MAX_AGE_SECONDS" ] || continue
     dir=$(dirname "$marker")
     rm -rf "$dir"

--- a/tests/lib.sh
+++ b/tests/lib.sh
@@ -39,9 +39,6 @@ export FM_GATE_REFUSE_BYPASS=1
 # shellcheck disable=SC2034
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
-# shellcheck source=bin/fm-wake-lib.sh
-. "$ROOT/bin/fm-wake-lib.sh"
-
 # --- reporters --------------------------------------------------------------
 
 fail() {
@@ -74,6 +71,17 @@ pass() {
 FM_TEST_CLEANUP_DIRS=()
 FM_TEST_CLEANUP_REGISTRY=$(mktemp "${TMPDIR:-/tmp}/.fm-test-cleanup.$$.XXXXXX") || return 1
 
+fm_test_pid_identity() {
+  local pid=$1
+  FM_STATE_OVERRIDE="${TMPDIR:-/tmp}" bash -c \
+    '. "$1"; fm_pid_identity "$2"' _ "$ROOT/bin/fm-wake-lib.sh" "$pid"
+}
+
+FM_TEST_OWNER_IDENTITY=$(fm_test_pid_identity "$$") || {
+  rm -f "$FM_TEST_CLEANUP_REGISTRY"
+  return 1
+}
+
 fm_test_cleanup() {
   local d
   for d in "${FM_TEST_CLEANUP_DIRS[@]:-}"; do
@@ -88,13 +96,9 @@ fm_test_cleanup() {
 }
 
 fm_test_tmproot() {
-  local prefix=${1:-fm-test} root owner_identity
+  local prefix=${1:-fm-test} root
   root=$(mktemp -d "${TMPDIR:-/tmp}/${prefix}.XXXXXX") || return 1
-  owner_identity=$(fm_pid_identity "$$") || {
-    rm -rf "$root"
-    return 1
-  }
-  if ! printf '%s\n%s\n' "$$" "$owner_identity" > "$root/.fm-test-fixture" ||
+  if ! printf '%s\n%s\n' "$$" "$FM_TEST_OWNER_IDENTITY" > "$root/.fm-test-fixture" ||
     ! printf '%s\n' "$root" >> "$FM_TEST_CLEANUP_REGISTRY"; then
     rm -rf "$root"
     return 1
@@ -125,7 +129,7 @@ fm_test_reap_orphans() {
     case "$owner_pid" in
       '' | *[!0-9]*) ;;
       *)
-        current_identity=$(fm_pid_identity "$owner_pid" 2>/dev/null) || current_identity=
+        current_identity=$(fm_test_pid_identity "$owner_pid" 2>/dev/null) || current_identity=
         if [ -n "$owner_identity" ] && [ "$current_identity" = "$owner_identity" ]; then
           continue
         fi

--- a/tests/lib.sh
+++ b/tests/lib.sh
@@ -39,6 +39,9 @@ export FM_GATE_REFUSE_BYPASS=1
 # shellcheck disable=SC2034
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
+# shellcheck source=bin/fm-wake-lib.sh
+. "$ROOT/bin/fm-wake-lib.sh"
+
 # --- reporters --------------------------------------------------------------
 
 fail() {
@@ -85,9 +88,13 @@ fm_test_cleanup() {
 }
 
 fm_test_tmproot() {
-  local prefix=${1:-fm-test} root
+  local prefix=${1:-fm-test} root owner_identity
   root=$(mktemp -d "${TMPDIR:-/tmp}/${prefix}.XXXXXX")
-  printf '%s\n' "$$" > "$root/.fm-test-fixture"
+  owner_identity=$(fm_pid_identity "$$") || {
+    rm -rf "$root"
+    return 1
+  }
+  printf '%s\n%s\n' "$$" "$owner_identity" > "$root/.fm-test-fixture"
   printf '%s\n' "$root" >> "$FM_TEST_CLEANUP_REGISTRY"
   printf '%s\n' "$root"
 }
@@ -100,20 +107,23 @@ trap 'fm_test_cleanup; exit 143' TERM
 # prior run that was killed hard enough to skip the traps above (e.g. a
 # SIGKILL timeout). Only removes directories carrying the .fm-test-fixture
 # marker fm_test_tmproot writes, so it never touches unrelated fm-* tmp dirs
-# from real (non-test) firstmate commands. The marker names the owning shell,
-# so a live owner always wins over the age fallback for dead or unowned roots.
+# from real (non-test) firstmate commands. The marker identifies the owning
+# shell across PID reuse, so the same live owner always wins over the age
+# fallback for dead or unowned roots.
 FM_TEST_ORPHAN_MAX_AGE_SECONDS=${FM_TEST_ORPHAN_MAX_AGE_SECONDS:-3600}
 
 fm_test_reap_orphans() {
-  local marker dir mtime now owner_pid
+  local marker dir mtime now owner_pid owner_identity current_identity
   now=$(date +%s)
   for marker in "${TMPDIR:-/tmp}"/fm-*/.fm-test-fixture; do
     [ -e "$marker" ] || continue
     owner_pid=$(sed -n '1p' "$marker" 2>/dev/null) || owner_pid=
+    owner_identity=$(sed -n '2,$p' "$marker" 2>/dev/null) || owner_identity=
     case "$owner_pid" in
       '' | *[!0-9]*) ;;
       *)
-        if [ "$owner_pid" -gt 0 ] && kill -0 "$owner_pid" 2>/dev/null; then
+        current_identity=$(fm_pid_identity "$owner_pid" 2>/dev/null) || current_identity=
+        if [ -n "$owner_identity" ] && [ "$current_identity" = "$owner_identity" ]; then
           continue
         fi
         ;;

--- a/tests/wake-helpers.sh
+++ b/tests/wake-helpers.sh
@@ -32,13 +32,7 @@ fi
 # that channel, to exercise graceful degradation. Suites that do not source this
 # harness still cannot fire a real notification: the daemon defaults the seam to
 # "discard" whenever it is sourced (its library-mode guard).
-# Create the recorder dir with mktemp directly (not fm_test_tmproot, whose
-# first call installs an EXIT trap that, invoked inside a command-substitution
-# subshell, would delete the dir on subshell exit). Register it for the same
-# cleanup and install the trap in THIS shell if it is the first registration.
-_fm_wedge_rec_dir=$(mktemp -d "${TMPDIR:-/tmp}/fm-wedge-rec.XXXXXX")
-if [ "${#FM_TEST_CLEANUP_DIRS[@]}" -eq 0 ]; then trap fm_test_cleanup EXIT; fi
-FM_TEST_CLEANUP_DIRS+=("$_fm_wedge_rec_dir")
+_fm_wedge_rec_dir=$(fm_test_tmproot fm-wedge-rec)
 cat > "$_fm_wedge_rec_dir/rec" <<'REC'
 #!/usr/bin/env bash
 printf '%s\t%s\n' "${1:-}" "${2:-}" >> "${FM_WEDGE_ALARM_LOG:-/dev/null}"


### PR DESCRIPTION
## Intent

Stop firstmate's own tests from leaking fixture state into $TMPDIR/fm-* (a disk-usage audit found roughly 23GiB accumulated across the fleet, the biggest single fleet-attributable disposable grower). Firstmate tests must trap-clean their $TMPDIR/fm-* mktemp fixtures on EXIT/INT/TERM, and reap orphans left by dead prior runs, so intermediate test state does not accumulate. The fix must use ONE shared test-fixture-tempdir helper with guaranteed teardown that leaking tests adopt (extending the existing fm_test_tmproot/fm_test_cleanup pattern in tests/lib.sh), not ad-hoc traps sprinkled per test. Root cause found by diagnostic reproduction: fm_test_tmproot is called almost everywhere as `TMP_ROOT=$(fm_test_tmproot prefix)`, which forks a subshell to capture stdout; the old implementation installed its EXIT cleanup trap inside that call, so the trap fired and deleted the fixture root the instant the subshell exited, before the real caller's own EXIT trap was ever registered. This meant essentially every test using the documented call pattern leaked its fixture root on every single run (confirmed empirically: dozens of leaked fm-* directories already present in $TMPDIR from normal past test runs, not just crashes). Two suites (tests/fm-procevent.test.sh, tests/wake-helpers.sh) had already independently discovered this exact bug and hand-rolled ad-hoc mktemp/trap workarounds around it instead of fixing the shared helper. Fix implemented: fm_test_tmproot now records the created directory in a $$-keyed registry file (since $$ resolves to the invoking shell's PID even inside the command-substitution subshell) instead of in-process array/trap state; the real cleanup trap is armed exactly once at tests/lib.sh source time (always the real caller's shell, never a subshell) for EXIT, INT, and TERM; fm_test_tmproot also marks each fixture root with a .fm-test-fixture file so a best-effort orphan sweep on next source can safely reap old marked fixture roots left behind by a run that was killed hard enough to skip the traps (e.g. SIGKILL), without ever touching unrelated non-test fm-* tmp directories. The two prior ad-hoc workarounds were simplified back onto the now-correct shared helper. Do not expand scope to the separate treehouse-pool fixture leak (a different, explicitly out-of-scope task family: fm-teardown-reap-leaked-test-processes, fm-teardown-abort-run-before-reap, fm-test-treehouse-fixture-pool-cleanup) - if those tasks need the same shared cleanup helper, that overlap is noted for reconciliation but not addressed here. Added a colocated regression test (tests/fm-test-fixture-cleanup.test.sh) that exercises the real helper in real separate child processes (not by inspecting source text): proves a fixture root exists while its owning process is alive and is gone after that process's normal exit, proves the same after SIGTERM, and proves a stale marked fixture root is reaped on the next source while a fresh one is left alone. Verified the new test fails against the pre-fix tests/lib.sh and passes against the fix. bin/fm-lint.sh is clean and the full portable test lanes plus the affected test families pass with no fixture directories left behind.

## What Changed

- Make the shared test temp-directory helper register fixtures across command-substitution subshells and clean them on exit, interrupt, or termination.
- Reap stale marked test fixtures while preserving live, fresh, and unrelated temporary directories.
- Replace suite-specific workarounds with the shared helper and add process-level regression coverage for cleanup and orphan handling.

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>
</details>
<details>
<summary>✅ **Rebase** - passed</summary>
</details>
<details>
<summary>✅ **Review** - completed</summary>
</details>
<details>
<summary>✅ **Test** - passed</summary>
</details>
<details>
<summary>✅ **Document** - passed</summary>
</details>
<details>
<summary>✅ **Lint** - passed</summary>
</details>
<details>
<summary>✅ **Push** - passed</summary>
</details>
