### PR TITLE
Add firstmate pr-shepherd skill for gated PR landing

### DIFF
--- a/.agents/skills/pr-shepherd/SKILL.md
+++ b/.agents/skills/pr-shepherd/SKILL.md
@@ -1,0 +1,314 @@
+---
+name: pr-shepherd
+description: >-
+  Thoroughly review one or more GitHub PRs and shepherd them to merge-ready
+  (or merge when authorized): inventory reviewer findings, verify each is fixed
+  or intentionally deferred with evidence, drive CI to green, fix real failures,
+  and report a gate-style outcome. Use when the captain asks to babysit/shepherd a
+  PR, ensure reviewer comments are addressed, get CI green and land a PR, "make
+  sure comments are fixed", "drive to merge", or invokes /pr-shepherd.
+user-invocable: true
+argument-hint: "<pr-number-or-url> [pr...] [--merge]"
+metadata:
+  internal: true
+---
+
+# pr-shepherd
+
+`pr-shepherd` is a gated PR landing pipeline for existing open pull requests.
+It is the counterpart of `no-mistakes` (which gates your uncommitted work before and through open): you drive a fixed sequence of phases until the PR is honestly merge-ready, and only then merge when authority allows.
+
+You are the pipeline driver: every phase produces evidence; skip nothing; never claim "comments addressed" without a per-finding disposition table.
+
+## When to load
+
+- Captain: `/pr-shepherd`, "shepherd this PR", "get comments fixed and CI green", "drive PR N to merge", "are reviewer comments addressed?"
+- Firstmate: before reporting a ship PR ready, before autonomous merge under `yolo`, and any time a bot or human left formal or informal review feedback.
+
+## Modes
+
+| Invocation | Behavior |
+|---|---|
+| `/pr-shepherd <n>` or URL | Full pipeline through **merge-ready**; **do not merge** unless authority exists. |
+| `/pr-shepherd <n> --merge` | Same pipeline; **merge only after** all hard gates pass **and** merge authority is satisfied (see Merge authority). |
+| Multiple PRs | Process **bottom-up** if stacked; otherwise one at a time. Stack desync is a hard gate. |
+
+Translate plain language ("merge when green") into `--merge` only when the captain explicitly authorized merge for that PR (or standing `yolo` covers it for that project).
+
+## Hard rules
+
+1. **Never invent "addressed."** Every unresolved thread, formal CHANGES_REQUESTED body, and consensus BLOCKER/WARN from bot review gets a disposition row.
+2. **Never merge red CI.** Optional/non-blocking checks (for example long-running advisory review jobs you have evidence are non-required) may remain pending only when explicitly classified - see CI.
+3. **Never merge without authority.** Default is report `merge-ready` and stop.
+4. **Never force-push without `--force-with-lease`.** Prefer rebase + lease after base advances.
+5. **Never discard unlanded work** to clear a path.
+6. **Dead-code / wrong-surface findings are blockers.** If a review says the change is on an unused component, **verify importers with `git grep` / search** before disposing as NIT.
+7. **Do not equate "I approved it" with "reviews addressed."** Your approval does not clear bot BLOCKERs or open threads.
+
+## Pipeline overview
+
+```
+intake → inventory → thorough-review → comments → ci → base/stack → report → [merge]
+```
+
+Each phase ends with a **gate**.
+Missing evidence means not ready.
+
+---
+
+## Phase 0 - Intake
+
+1. Resolve owner/repo (default: `gh-axi repo view --json nameWithOwner`, or `gh` when outside a firstmate home).
+2. For each PR number/URL:
+
+```bash
+gh-axi pr view <n> --repo <owner/repo> --json number,title,state,isDraft,url,baseRefName,headRefName,headRefOid,mergeable,mergeStateStatus,reviewDecision,author,commits,files
+```
+
+3. Refuse CLOSED/MERGED (report only).
+   Undraft if the captain wants land and the only draft reason was a temporary hold you placed - otherwise ask.
+4. Detect stack: walk open PRs where `baseRefName` is another PR's `headRefName`.
+   If stacked, process bottom-up; if desynced (independent rebases of the same stack), stop and fix topology before comment/CI work (rebase onto base PR or main, thin the upper PR to unique delta).
+
+**Gate 0:** Open PR identity, base/head SHAs, stack map recorded.
+
+---
+
+## Phase 1 - Inventory (read-only evidence pack)
+
+Collect **all** of the following before editing anything:
+
+### 1a. Human + formal reviews
+
+```bash
+gh-axi api repos/<o>/<r>/pulls/<n>/reviews --jq '.[] | {user: .user.login, state: .state, submitted_at, body}'
+```
+
+Note DISMISSED vs active CHANGES_REQUESTED / APPROVED.
+
+### 1b. Unresolved review threads (paginate)
+
+GraphQL `reviewThreads` with `isResolved`, `isOutdated`, full comment bodies, paths, authors.
+**Page until `hasNextPage` is false.**
+
+### 1c. Bot / issue review comments
+
+```bash
+gh-axi api repos/<o>/<r>/issues/<n>/comments --jq '.[] | select(.user.login|test("bot|github-actions|gemini|claude|copilot|coderabbit";"i")) | {user: .user.login, body}'
+```
+
+Parse **BLOCKER**, **WARN**, **NIT**, **CONSENSUS**, **CHANGES_REQUESTED** from bodies (including `<!-- claude-pr-review -->` style).
+
+### 1d. Checks
+
+```bash
+gh-axi pr checks <n> --repo <o>/<r>
+# and/or
+gh-axi pr view <n> --json statusCheckRollup
+```
+
+### 1e. Diff reality
+
+```bash
+gh-axi pr diff <n> --name-only
+gh-axi pr diff <n>   # or compare main...head for content questions
+```
+
+For any finding that claims "unused" / "dead component" / "zero importers":
+
+```bash
+git fetch origin <headRefName>
+git grep -n '<SymbolOrFilename>' origin/<headRefName> -- '*.ts' '*.tsx' '*.js' ...
+```
+
+**Gate 1:** Written inventory exists (in chat or a scratch note).
+No phase 2+ without it.
+
+---
+
+## Phase 2 - Thorough review (independent read)
+
+Before trusting prior approvals, do a **fresh** pass on the current head:
+
+1. Read the PR body for claimed scope and verification.
+2. Walk the diff for correctness, security, product mismatch, and tests.
+3. Cross-check bot/human findings against the code (confirm or refute with file evidence).
+4. Flag new issues you find that nobody mentioned.
+
+Optional: run a cross-vendor PR review skill if available; still validate every cited path against the real diff (hallucinated paths do not count).
+
+**Gate 2:** Short "shepherd review" note: approve-with-findings, or list new blockers.
+Empty "LGTM" without inventory is invalid.
+
+---
+
+## Phase 3 - Comments gate (hard)
+
+Build a disposition table for **every** item from Phase 1:
+
+| ID | Source | Severity | Summary | Disposition | Evidence |
+|----|--------|----------|---------|-------------|----------|
+| t1 | thread | … | … | fixed \| reply \| defer \| wontfix \| outdated | commit SHA / reply URL / reason |
+| b1 | bot BLOCKER | … | … | … | … |
+
+### Disposition rules
+
+| Severity | Allowed dispositions |
+|----------|----------------------|
+| **BLOCKER** / formal CHANGES_REQUESTED consensus | **fixed** (code + push) only. Reply after push with SHA. |
+| **WARN** (consensus or product-correctness) | **fixed** preferred; **defer** only with captain OK and backlog note; **wontfix** only with written technical rebuttal posted on the thread. |
+| **NIT** | fixed if cheap; else reply with rationale. |
+| Outdated / already on main | **outdated** with SHA proof. |
+| Question / clarification | **reply** with substantive technical answer (never "will fix" / "ack"). |
+
+### Required code verification for "fixed"
+
+1. Confirm the change is on the **PR head** (not only local dirty tree).
+2. Re-read the resolved path on `origin/<head>` after push.
+3. For dead-surface claims: re-run importer search post-fix.
+
+### Cap and re-run
+
+- Prefer fixing all WARNs that touch correctness in the same PR.
+- After pushes, **re-fetch** reviews/threads/bot comments - old DISMISSED reviews do not prove the new head is clean; wait for re-review when a formal bot CHANGES_REQUESTED was active.
+
+**Gate 3 (comments-addressed):** Zero open **BLOCKER** dispositions other than `fixed` with evidence; zero unresolved threads that still need code; every WARN either fixed or deferred with explicit authority.
+If any row is incomplete, the PR is **not ready**.
+
+---
+
+## Phase 4 - CI gate (hard)
+
+1. Classify checks:
+   - **Critical:** anything that is required for merge, all `CI` / test / lint / typecheck / quality / build / guardrail jobs that normally block, and any check the repo treats as required.
+   - **Advisory:** clearly non-blocking review bots (only if you have evidence they never block merge, for example optional check runs).
+     Default: treat unknown as **critical**.
+2. On failure:
+   - Pull logs (`gh-axi run view <id> --log-failed` or job URL).
+   - Fix on the PR branch in an isolated worktree when under firstmate; push.
+   - Re-wait.
+3. Do **not** claim green while critical checks are `pending` or `fail`.
+4. Flaky single flakes: one re-run max, then fix root cause.
+
+**Gate 4 (ci-green):** All critical checks `pass` (or `success`); no critical `fail`/`cancelled`/`timed_out` without resolution.
+
+---
+
+## Phase 5 - Base / stack / mergeability
+
+1. `mergeable` / `mergeStateStatus`: resolve CONFLICTING with rebase onto current base (stack-aware: bottom first).
+2. If behind main but clean, prefer update/rebase so CI matches landing base.
+3. Stack: upper PR diff vs main should **not** re-introduce lower PR content after lower merges.
+
+**Gate 5:** `MERGEABLE` (or known-platform lag with recheck); stack consistent.
+
+---
+
+## Phase 6 - Report (always)
+
+Emit a captain-facing summary **in outcomes, not mechanics** (AGENTS.md section 9):
+
+```markdown
+## PR shepherd: <title>
+URL: https://github.com/.../pull/N
+
+### Status: merge-ready | blocked | merged
+
+### Comments
+| Finding | Disposition | Evidence |
+| ... | ... | ... |
+
+### CI
+Critical: green | red (list failures)
+
+### Shepherd review
+1–5 bullets of independent findings (or "none beyond inventory")
+
+### Next
+- merge when you say / already merged / blocked on <decision>
+```
+
+**Gate 6:** Report delivered.
+Pipeline ends here unless merge authorized.
+
+---
+
+## Phase 7 - Merge (optional, gated)
+
+Merge **only if** all of:
+
+1. Gates 3–5 passed on the **current** head SHA.
+2. Merge authority:
+   - Explicit captain instruction to merge **this** PR, or
+   - Firstmate standing `yolo` for that project **and** PR is green and within original task scope (still never red merge).
+3. Prefer the project's merge path:
+   - Firstmate: `bin/fm-pr-merge.sh <task-id> <url>` when a task owns the PR.
+   - Else: `gh-axi pr merge <n> --squash` (or repo default); use `--admin` only when the captain authorized bypass of non-code gates **and** code/CI gates passed.
+
+After merge: confirm `state=MERGED`, full URL, one-line outcome.
+Firstmate: fleet-sync clone; cleanup only when unlanded-work checks pass.
+
+---
+
+## Firstmate integration
+
+When running as firstmate:
+
+| Concern | Rule |
+|---------|------|
+| Project edits | Worker / isolated copy only (hard rule 1). |
+| PR open from ship | After worker reports green, **still run Phase 1–3** before telling captain "ready" or merging under yolo. |
+| Bot formal CHANGES_REQUESTED | Block merge until re-run clears or code fixes land. |
+| Status line `done: PR … checks green` | Treat as worker claim; **re-verify** gates 3–4 yourself. |
+| Merge | Never without AGENTS.md section 7 authority. |
+
+Suggested captain invocation: `/pr-shepherd 4125` or `/pr-shepherd https://github.com/org/repo/pull/4125 --merge`.
+
+---
+
+## Relationship to other tools
+
+| Tool | Role |
+|------|------|
+| `no-mistakes` | Pre-merge validation of **your** branch/pipeline work. |
+| `pr-babysit` | Multi-PR loop with auto-fix; **never merges**; use for watch lists. |
+| **pr-shepherd** | **Thorough single/stack land gate** with mandatory comment disposition and optional authorized merge. |
+
+Prefer `pr-shepherd` when honesty of "comments addressed + CI green" matters more than polling many PRs.
+Use `pr-babysit` for ongoing multi-PR watch.
+
+---
+
+## Anti-patterns (learned the hard way)
+
+- Approving and merging while a bot **BLOCKER** is still formal CHANGES_REQUESTED.
+- Wiring UI to a component with **zero importers** because the PR body said so.
+- Treating quality/knip flake as "whole tree debt" without running the ratchet.
+- Claiming CI green when only title/body lint ran (full CI never triggered).
+- Merging the stack top while it still contains the bottom's files after both rebased independently.
+- Leaving collapsed a11y WARNs unfixed on the PR that introduced them.
+
+---
+
+## Minimal command cheatsheet
+
+```bash
+# Identity + checks
+gh-axi pr view N --json url,state,headRefOid,reviewDecision,mergeable,statusCheckRollup
+gh-axi pr checks N
+
+# Reviews + threads (see Phase 1 for full GraphQL pagination)
+gh-axi api repos/O/R/pulls/N/reviews
+gh-axi api repos/O/R/issues/N/comments
+
+# Diff + importers
+gh-axi pr diff N --name-only
+git grep -n Symbol origin/branch -- '*.ts' '*.tsx'
+
+# After fix
+git push --force-with-lease   # only if rebase rewrote
+gh-axi pr comment N --body "..."
+
+# Merge (only when authorized + gates green)
+gh-axi pr merge N --squash
+```

--- a/.agents/skills/pr-shepherd/SKILL.md
+++ b/.agents/skills/pr-shepherd/SKILL.md
@@ -1,14 +1,14 @@
 ---
 name: pr-shepherd
 description: >-
-  Thoroughly review one or more GitHub PRs and shepherd them to merge-ready
-  (or merge when authorized): inventory reviewer findings, verify each is fixed
-  or intentionally deferred with evidence, drive CI to green, fix real failures,
-  and report a gate-style outcome. Use when the captain asks to babysit/shepherd a
-  PR, ensure reviewer comments are addressed, get CI green and land a PR, "make
-  sure comments are fixed", "drive to merge", or invokes /pr-shepherd.
+  Thoroughly review one or more GitHub PRs and shepherd them to merge when gates
+  pass: inventory reviewer findings, verify each is fixed or intentionally deferred
+  with evidence, drive CI to green, fix real failures, report a gate-style outcome,
+  and merge by default. Use when the captain asks to babysit/shepherd a PR, ensure
+  reviewer comments are addressed, get CI green and land a PR, "make sure comments
+  are fixed", "drive to merge", or invokes /pr-shepherd.
 user-invocable: true
-argument-hint: "<pr-number-or-url> [pr...] [--merge]"
+argument-hint: "<pr-number-or-url> [pr...] [--no-merge]"
 metadata:
   internal: true
 ---
@@ -16,7 +16,7 @@ metadata:
 # pr-shepherd
 
 `pr-shepherd` is a gated PR landing pipeline for existing open pull requests.
-It is the counterpart of `no-mistakes` (which gates your uncommitted work before and through open): you drive a fixed sequence of phases until the PR is honestly merge-ready, and only then merge when authority allows.
+It is the counterpart of `no-mistakes` (which gates your uncommitted work before and through open): you drive a fixed sequence of phases until the PR is honestly merge-ready, then **merge by default** when all hard gates pass.
 
 You are the pipeline driver: every phase produces evidence; skip nothing; never claim "comments addressed" without a per-finding disposition table.
 
@@ -29,17 +29,19 @@ You are the pipeline driver: every phase produces evidence; skip nothing; never 
 
 | Invocation | Behavior |
 |---|---|
-| `/pr-shepherd <n>` or URL | Full pipeline through **merge-ready**; **do not merge** unless authority exists. |
-| `/pr-shepherd <n> --merge` | Same pipeline; **merge only after** all hard gates pass **and** merge authority is satisfied (see Merge authority). |
+| `/pr-shepherd <n>` or URL | Full pipeline; **default terminal is merge** after all hard gates pass. |
+| `/pr-shepherd <n> --no-merge` | Same pipeline through report only; stop at **merge-ready** without merging. |
 | Multiple PRs | Process **bottom-up** if stacked; otherwise one at a time. Stack desync is a hard gate. |
 
-Translate plain language ("merge when green") into `--merge` only when the captain explicitly authorized merge for that PR (or standing `yolo` covers it for that project).
+Invoking `/pr-shepherd` (without `--no-merge`) is merge authority for that PR once gates pass.
+Standing firstmate `yolo` is not required for a captain-invoked `/pr-shepherd`, but red CI and incomplete comment dispositions still block merge.
+Translate "report only" / "don't merge yet" into `--no-merge`.
 
 ## Hard rules
 
 1. **Never invent "addressed."** Every unresolved thread, formal CHANGES_REQUESTED body, and consensus BLOCKER/WARN from bot review gets a disposition row.
 2. **Never merge red CI.** Optional/non-blocking checks (for example long-running advisory review jobs you have evidence are non-required) may remain pending only when explicitly classified - see CI.
-3. **Never merge without authority.** Default is report `merge-ready` and stop.
+3. **Default terminal is merge.** When gates 3–5 pass on the current head, merge unless `--no-merge` was requested.
 4. **Never force-push without `--force-with-lease`.** Prefer rebase + lease after base advances.
 5. **Never discard unlanded work** to clear a path.
 6. **Dead-code / wrong-surface findings are blockers.** If a review says the change is on an unused component, **verify importers with `git grep` / search** before disposing as NIT.
@@ -48,11 +50,12 @@ Translate plain language ("merge when green") into `--merge` only when the capta
 ## Pipeline overview
 
 ```
-intake → inventory → thorough-review → comments → ci → base/stack → report → [merge]
+intake → inventory → thorough-review → comments → ci → base/stack → report → merge
 ```
 
 Each phase ends with a **gate**.
 Missing evidence means not ready.
+Merge is the default final step when gates pass; only `--no-merge` stops after the report.
 
 ---
 
@@ -212,7 +215,7 @@ Emit a captain-facing summary **in outcomes, not mechanics** (AGENTS.md section 
 ## PR shepherd: <title>
 URL: https://github.com/.../pull/N
 
-### Status: merge-ready | blocked | merged
+### Status: merged | merge-ready | blocked
 
 ### Comments
 | Finding | Disposition | Evidence |
@@ -225,26 +228,29 @@ Critical: green | red (list failures)
 1–5 bullets of independent findings (or "none beyond inventory")
 
 ### Next
-- merge when you say / already merged / blocked on <decision>
+- merged at <SHA> / merge-ready (--no-merge) / blocked on <decision>
 ```
 
 **Gate 6:** Report delivered.
-Pipeline ends here unless merge authorized.
+Proceed to Phase 7 unless `--no-merge` or a hard gate failed.
 
 ---
 
-## Phase 7 - Merge (optional, gated)
+## Phase 7 - Merge (default terminal)
 
-Merge **only if** all of:
+Merge when all of the following hold:
 
 1. Gates 3–5 passed on the **current** head SHA.
-2. Merge authority:
+2. `--no-merge` was **not** requested.
+3. Merge authority is satisfied by one of:
+   - Captain invoked `/pr-shepherd` (or equivalent land intent) for this PR, or
    - Explicit captain instruction to merge **this** PR, or
-   - Firstmate standing `yolo` for that project **and** PR is green and within original task scope (still never red merge).
-3. Prefer the project's merge path:
+   - Firstmate standing `yolo` for that project **and** PR is green and within original task scope.
+4. Prefer the project's merge path:
    - Firstmate: `bin/fm-pr-merge.sh <task-id> <url>` when a task owns the PR.
    - Else: `gh-axi pr merge <n> --squash` (or repo default); use `--admin` only when the captain authorized bypass of non-code gates **and** code/CI gates passed.
 
+Still never merge red CI or incomplete BLOCKER dispositions.
 After merge: confirm `state=MERGED`, full URL, one-line outcome.
 Firstmate: fleet-sync clone; cleanup only when unlanded-work checks pass.
 
@@ -257,12 +263,13 @@ When running as firstmate:
 | Concern | Rule |
 |---------|------|
 | Project edits | Worker / isolated copy only (hard rule 1). |
-| PR open from ship | After worker reports green, **still run Phase 1–3** before telling captain "ready" or merging under yolo. |
+| PR open from ship | After worker reports green, **still run Phase 1–3** before telling captain "ready" or merging under yolo / default shepherd merge. |
 | Bot formal CHANGES_REQUESTED | Block merge until re-run clears or code fixes land. |
 | Status line `done: PR … checks green` | Treat as worker claim; **re-verify** gates 3–4 yourself. |
-| Merge | Never without AGENTS.md section 7 authority. |
+| Default merge | Captain `/pr-shepherd` (or ship yolo path) is land authority once gates pass; use `--no-merge` to stop at report. |
 
-Suggested captain invocation: `/pr-shepherd 4125` or `/pr-shepherd https://github.com/org/repo/pull/4125 --merge`.
+Suggested captain invocation: `/pr-shepherd 4125` or `/pr-shepherd https://github.com/org/repo/pull/4125`.
+Use `/pr-shepherd 4125 --no-merge` when the captain wants a merge-ready report only.
 
 ---
 
@@ -272,9 +279,9 @@ Suggested captain invocation: `/pr-shepherd 4125` or `/pr-shepherd https://githu
 |------|------|
 | `no-mistakes` | Pre-merge validation of **your** branch/pipeline work. |
 | `pr-babysit` | Multi-PR loop with auto-fix; **never merges**; use for watch lists. |
-| **pr-shepherd** | **Thorough single/stack land gate** with mandatory comment disposition and optional authorized merge. |
+| **pr-shepherd** | **Thorough single/stack land gate** with mandatory comment disposition; **merges by default** when hard gates pass. |
 
-Prefer `pr-shepherd` when honesty of "comments addressed + CI green" matters more than polling many PRs.
+Prefer `pr-shepherd` when honesty of "comments addressed + CI green" and landing matter more than polling many PRs.
 Use `pr-babysit` for ongoing multi-PR watch.
 
 ---
@@ -309,6 +316,6 @@ git grep -n Symbol origin/branch -- '*.ts' '*.tsx'
 git push --force-with-lease   # only if rebase rewrote
 gh-axi pr comment N --body "..."
 
-# Merge (only when authorized + gates green)
+# Merge (default terminal when gates green; skip if --no-merge)
 gh-axi pr merge N --squash
 ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -327,6 +327,7 @@ The worker reports the PR when CI first becomes green rather than waiting for me
 For PR-based ship tasks, the ready signal depends on mode: `no-mistakes` reports `done: PR <url> checks green` after CI is green, while `direct-PR` reports `done: PR <url>` after opening the PR.
 Run `bin/fm-pr-check.sh <id> <PR url>` - it records `pr=` and the forge's `pr_head=` when available in the task's meta and arms the watcher's merge poll.
 Tell the captain the PR's full URL, always the complete `https://...` link rather than a bare `#number`, a concise outcome summary, and the no-mistakes risk level when applicable.
+Load `pr-shepherd` before claiming reviewer comments are addressed or merging a ship PR, and when the captain invokes `/pr-shepherd`.
 A captain instruction to merge is explicit authority; `yolo` is the only standing routine authority.
 For any custom `state/<id>.check.sh` you write yourself, keep it an ordinary single-link mode-`0700` file, print one line only when firstmate should wake, print nothing otherwise, finish before `FM_CHECK_TIMEOUT`, then bind its current bytes with `bin/fm-check-register.sh <id>` before the watcher may execute it.
 

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ Claude and grok use the slash form shown here; codex uses the same names with `$
 | `/bearings`        | Generate a concise four-section chat digest from bounded local fleet and registered-secondmate state; use `/bearings file` to also replace today's dated report in `data/`, and add `include PRs` when live PR enrichment is wanted |
 | `/updatefirstmate` | Self-update the running firstmate and its secondmates to the latest from origin with fast-forward-only pulls, then re-read instructions and nudge secondmates |
 | `/stow`            | Sweep the session for uncaptured durable knowledge, route each finding to its disk home per AGENTS.md, file undone next steps to the backlog, and report what is now safe to reset |
-| `/pr-shepherd`     | Gate an open PR to merge-ready: inventory reviews, disposition every comment, drive critical CI green, report honestly, and merge only with authority |
+| `/pr-shepherd`     | Gate an open PR and merge by default when gates pass: inventory reviews, disposition every comment, drive critical CI green, report honestly; use `--no-merge` for report-only |
 
 Bearings invocation examples:
 

--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ Claude and grok use the slash form shown here; codex uses the same names with `$
 | `/bearings`        | Generate a concise four-section chat digest from bounded local fleet and registered-secondmate state; use `/bearings file` to also replace today's dated report in `data/`, and add `include PRs` when live PR enrichment is wanted |
 | `/updatefirstmate` | Self-update the running firstmate and its secondmates to the latest from origin with fast-forward-only pulls, then re-read instructions and nudge secondmates |
 | `/stow`            | Sweep the session for uncaptured durable knowledge, route each finding to its disk home per AGENTS.md, file undone next steps to the backlog, and report what is now safe to reset |
+| `/pr-shepherd`     | Gate an open PR to merge-ready: inventory reviews, disposition every comment, drive critical CI green, report honestly, and merge only with authority |
 
 Bearings invocation examples:
 

--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -50,9 +50,10 @@
 #
 # Authoritative task recovery/orphan discovery (ids may not deterministically match live state
 # after a server restart in a differently-configured session; see the
-# verification doc) uses LABEL matching (fm-<id> tab labels), never trusts a
-# stored pane id blindly: fm_backend_herdr_list_live. The presentation journal
-# is deliberately excluded from that path.
+# verification doc) uses LABEL matching (fm-<id> create labels and post-spawn
+# scout-/ship- display names), never trusts a stored pane id blindly:
+# fm_backend_herdr_list_live. The presentation journal is deliberately excluded
+# from that path.
 #
 # Requires: herdr (CLI + socket), jq (JSON parsing). Bootstrap detects these
 # through fm_backend_required_tools only when herdr is the resolved backend;
@@ -420,6 +421,129 @@ fm_backend_herdr_projection_concise_task_label() {  # <task-id>
     fm-*) task=${task#fm-} ;;
   esac
   printf '%s' "$task"
+}
+
+# fm_backend_herdr_display_name: pure map of (task_id, kind) to a valid Herdr
+# agent/tab display name matching ^[a-z][a-z0-9_-]{0,31}$.
+# kind=scout -> scout-<slug>; any other kind -> ship-<slug>.
+# Strips redundant fm-/scout-/ship- prefixes from the id before composing,
+# lowercases, replaces invalid characters with '-', collapses runs of '-',
+# truncates to 32 characters, and never leaves a trailing '-' or '_'.
+# Pure: no I/O. Display names are never ownership authority (recorded pane/tab
+# ids in meta remain authoritative; see docs/herdr-backend.md).
+fm_backend_herdr_display_name() {  # <task-id> <kind>
+  local id=$1 kind=$2 prefix slug out
+  case "$kind" in
+    scout) prefix=scout ;;
+    *) prefix=ship ;;
+  esac
+  id=$(printf '%s' "$id" | tr '[:upper:]' '[:lower:]')
+  while :; do
+    case "$id" in
+      fm-*) id=${id#fm-} ;;
+      scout-*) id=${id#scout-} ;;
+      ship-*) id=${id#ship-} ;;
+      *) break ;;
+    esac
+  done
+  # tr -c replaces every non-allowed char with '-'; tr -s collapses runs.
+  slug=$(printf '%s' "$id" | tr -c 'a-z0-9_-' '-' | tr -s '-')
+  while [ -n "$slug" ]; do
+    case "$slug" in
+      -*|_* ) slug=${slug#?} ;;
+      *-|*_ ) slug=${slug%?} ;;
+      *) break ;;
+    esac
+  done
+  if [ -n "$slug" ]; then
+    out="${prefix}-${slug}"
+  else
+    out=$prefix
+  fi
+  if [ "${#out}" -gt 32 ]; then
+    out=${out:0:32}
+    while [ -n "$out" ]; do
+      case "$out" in
+        *-|*_ ) out=${out%?} ;;
+        *) break ;;
+      esac
+    done
+  fi
+  case "$out" in
+    [a-z]|[a-z][a-z0-9_-]*) ;;
+    *) out=$prefix ;;
+  esac
+  if [ "${#out}" -gt 32 ] || [ -z "$out" ]; then
+    out=$prefix
+  fi
+  printf '%s' "$out"
+}
+
+# fm_backend_herdr_task_label_candidates: labels that may identify a prior
+# instance of the same task tab for husk close-and-replace. Always includes
+# the create label fm-<id> plus both role display names (scout- and ship-)
+# derived from that id, so a post-spawn tab rename does not strand husks.
+# Accepts either a bare task id or an fm-<id> create label. Prints one label
+# per line; pure aside from the display-name helper.
+fm_backend_herdr_task_label_candidates() {  # <task-id-or-fm-label>
+  local raw=$1 id scout_name ship_name
+  id=$raw
+  case "$id" in
+    fm-*) id=${id#fm-} ;;
+  esac
+  [ -n "$id" ] || return 0
+  scout_name=$(fm_backend_herdr_display_name "$id" scout)
+  ship_name=$(fm_backend_herdr_display_name "$id" ship)
+  printf 'fm-%s\n' "$id"
+  printf '%s\n' "$scout_name"
+  [ "$ship_name" = "$scout_name" ] || printf '%s\n' "$ship_name"
+}
+
+# fm_backend_herdr_apply_display_name: best-effort wait until <pane> reports a
+# registered agent, then rename the agent and tab to <name>.
+# Failures warn on stderr and never fail the spawn (exit 0 always).
+# Does not touch the primary seed tab labeled "1" (callers never pass it).
+# Polls/sleep are overridable for tests via FM_BACKEND_HERDR_DISPLAY_NAME_POLLS
+# and FM_BACKEND_HERDR_DISPLAY_NAME_SLEEP.
+fm_backend_herdr_apply_display_name() {  # <session> <pane_id> <tab_id> <name>
+  local session=$1 pane=$2 tab=$3 name=$4 state i
+  local polls=${FM_BACKEND_HERDR_DISPLAY_NAME_POLLS:-20}
+  local sleep_s=${FM_BACKEND_HERDR_DISPLAY_NAME_SLEEP:-0.25}
+  case "$name" in
+    [a-z]|[a-z][a-z0-9_-]*)
+      if [ "${#name}" -gt 32 ]; then
+        echo "warning: herdr display name '$name' exceeds 32 chars; skipping rename" >&2
+        return 0
+      fi
+      ;;
+    *)
+      echo "warning: herdr display name '$name' is invalid; skipping rename" >&2
+      return 0
+      ;;
+  esac
+  [ -n "$session" ] && [ -n "$pane" ] || {
+    echo "warning: herdr display rename missing session or pane; skipping" >&2
+    return 0
+  }
+  state=no-agent
+  for ((i = 0; i < polls; i++)); do
+    state=$(fm_backend_herdr_pane_agent_state "$session" "$pane")
+    [ "$state" = live ] && break
+    sleep "$sleep_s"
+  done
+  if [ "$state" != live ]; then
+    echo "warning: herdr agent not registered in time to rename to $name; leaving default names" >&2
+    return 0
+  fi
+  if ! fm_backend_herdr_cli "$session" agent rename "$pane" "$name" >/dev/null 2>&1; then
+    echo "warning: herdr agent rename to $name failed" >&2
+  fi
+  if [ -n "$tab" ] && [ "$tab" != 1 ]; then
+    if ! fm_backend_herdr_cli "$session" tab rename "$tab" "$name" >/dev/null 2>&1; then
+      echo "warning: herdr tab rename to $name failed" >&2
+    fi
+  fi
+  return 0
 }
 
 # fm_backend_herdr_projection_workspace_label: presentation-only child label.
@@ -1753,10 +1877,17 @@ fm_backend_herdr_agent_alive() {  # <target>
 # case. Echoes "<tab_id> <pane_id>" on success.
 fm_backend_herdr_create_task() {  # <container> <label> <cwd> <seeded_default_tab_id>
   local container=$1 label=$2 cwd=$3 seeded_tab_id=${4:-} session wsid list dup_tabs dup dup_pane dup_tab_ids out tab_id pane_id remaining_dup_tabs
+  local want_json
   session=${container%%:*}
   wsid=${container#*:}
   list=$(fm_backend_herdr_cli "$session" tab list --workspace "$wsid" 2>/dev/null) || return 1
-  dup_tabs=$(printf '%s' "$list" | jq -r --arg want "$label" 'if (.result.tabs | type) == "array" then .result.tabs[] | select(.label == $want) | .tab_id else error("missing result.tabs") end' 2>/dev/null) || {
+  # Husk/dup match uses the create label (fm-<id>) plus post-spawn display
+  # names (scout-/ship-) so a renamed tab is still found on re-spawn.
+  want_json=$(fm_backend_herdr_task_label_candidates "$label" | jq -R . | jq -s -c .) || {
+    echo "error: could not build herdr tab label candidates for '$label'" >&2
+    return 1
+  }
+  dup_tabs=$(printf '%s' "$list" | jq -r --argjson want "$want_json" 'if (.result.tabs | type) == "array" then .result.tabs[] | select(.label as $l | ($want | index($l)) != null) | .tab_id else error("missing result.tabs") end' 2>/dev/null) || {
     echo "error: could not parse herdr tab list output for workspace $wsid (session $session)" >&2
     return 1
   }
@@ -1797,8 +1928,8 @@ EOF
       echo "error: could not parse herdr tab list output for workspace $wsid (session $session)" >&2
       return 1
     fi
-    remaining_dup_tabs=$(printf '%s' "$list" | jq -r --arg want "$label" --arg replacement "$tab_id" \
-      '.result.tabs[]? | select(.label == $want and .tab_id != $replacement) | .tab_id' 2>/dev/null)
+    remaining_dup_tabs=$(printf '%s' "$list" | jq -r --argjson want "$want_json" --arg replacement "$tab_id" \
+      '.result.tabs[]? | select((.label as $l | ($want | index($l)) != null) and .tab_id != $replacement) | .tab_id' 2>/dev/null)
     remaining_dup_tabs=${remaining_dup_tabs//$'\n'/ }
     if [ -n "$remaining_dup_tabs" ]; then
       echo "error: failed to remove preexisting herdr tab(s) $remaining_dup_tabs for label '$label' in workspace $wsid (session $session)" >&2
@@ -2978,15 +3109,16 @@ EOF
 }
 
 # fm_backend_herdr_list_live: recovery/orphan discovery. Lists every tab whose
-# label looks like a firstmate task window (fm-<id>) in <session>'s, THIS
-# HOME'S OWN workspace (fm_backend_herdr_workspace_label - never another
-# home's), by LABEL - never by trusting a stored pane id, since ids are not
-# guaranteed stable across every server lifecycle (see herdr-verification-p2.md
-# "ID stability"). A caller running as a given home (e.g. a secondmate
-# recovering its own in-flight work) naturally scopes to that home's own
-# workspace because FM_HOME already names it - no glue needed, unlike the
-# primary-spawns-a-secondmate path in fm-spawn.sh. Read-only: a session/
-# workspace that does not exist yet simply lists nothing. One
+# label looks like a firstmate task window in <session>'s, THIS HOME'S OWN
+# workspace (fm_backend_herdr_workspace_label - never another home's), by
+# LABEL - never by trusting a stored pane id, since ids are not guaranteed
+# stable across every server lifecycle (see herdr-verification-p2.md
+# "ID stability"). Matches create labels (fm-<id>) and post-spawn human
+# display names (scout-<slug>, ship-<slug>). A caller running as a given home
+# (e.g. a secondmate recovering its own in-flight work) naturally scopes to
+# that home's own workspace because FM_HOME already names it - no glue needed,
+# unlike the primary-spawns-a-secondmate path in fm-spawn.sh. Read-only: a
+# session/workspace that does not exist yet simply lists nothing. One
 # "<session>:<pane_id>\t<label>" line per live task tab.
 fm_backend_herdr_list_live() {  # <session>
   local session=$1 wsid tabs tab_id label pane_id
@@ -2998,7 +3130,7 @@ fm_backend_herdr_list_live() {  # <session>
     pane_id=$(fm_backend_herdr_pane_for_tab "$session" "$wsid" "$tab_id") || continue
     [ -n "$pane_id" ] || continue
     printf '%s:%s\t%s\n' "$session" "$pane_id" "$label"
-  done < <(printf '%s' "$tabs" | jq -r '.result.tabs[]? | select(.label | startswith("fm-")) | "\(.tab_id)\t\(.label)"' 2>/dev/null)
+  done < <(printf '%s' "$tabs" | jq -r '.result.tabs[]? | select((.label | type) == "string" and (.label | test("^(fm|scout|ship)-"))) | "\(.tab_id)\t\(.label)"' 2>/dev/null)
 }
 
 # --- native event push: pane.agent_status_changed subscriber -----------------

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1624,6 +1624,12 @@ META_WINDOW=$T
     echo "herdr_workspace_id=$HERDR_WORKSPACE_ID"
     echo "herdr_tab_id=$HERDR_TAB_ID"
     echo "herdr_pane_id=$HERDR_PANE_ID"
+    # Human-readable agents-sidebar / tab display name (not ownership authority).
+    # Computed for ship/scout only; secondmates keep the default Herdr names.
+    if [ "$KIND" != secondmate ]; then
+      HERDR_DISPLAY_NAME=$(fm_backend_herdr_display_name "$ID" "$KIND")
+      [ -n "$HERDR_DISPLAY_NAME" ] && echo "herdr_display_name=$HERDR_DISPLAY_NAME"
+    fi
   fi
   if [ "$BACKEND" = zellij ]; then
     echo "zellij_session=$ZELLIJ_SES"
@@ -1688,6 +1694,14 @@ if [ "${HERDR_PROJECTED:-0}" -eq 1 ]; then
   spawn_herdr_presentation_order_lock_release
 fi
 spawn_send_key "$T" Enter
+# Best-effort Herdr agents-sidebar (and tab) rename after the harness has been
+# launched. Wait until the pane registers an agent; rename failures never fail
+# the spawn. Secondmates are out of scope. Ownership stays on recorded pane/tab
+# ids in meta (docs/herdr-backend.md).
+if [ "$BACKEND" = herdr ] && [ "$KIND" != secondmate ] && [ -n "${HERDR_DISPLAY_NAME:-}" ]; then
+  fm_backend_herdr_apply_display_name \
+    "$HERDR_SES" "$HERDR_PANE_ID" "$HERDR_TAB_ID" "$HERDR_DISPLAY_NAME" || true
+fi
 if [ "$HARNESS" = kimi ]; then
   if ! kimi_wait_for_ready; then
     kimi_spawn_fail "kimi did not show a verified ready signal before brief delivery"

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1699,8 +1699,12 @@ spawn_send_key "$T" Enter
 # the spawn. Secondmates are out of scope. Ownership stays on recorded pane/tab
 # ids in meta (docs/herdr-backend.md).
 if [ "$BACKEND" = herdr ] && [ "$KIND" != secondmate ] && [ -n "${HERDR_DISPLAY_NAME:-}" ]; then
+  HERDR_RENAME_TAB_ID=$HERDR_TAB_ID
+  if [ "${HERDR_PROJECTED:-0}" -eq 1 ]; then
+    HERDR_RENAME_TAB_ID=
+  fi
   fm_backend_herdr_apply_display_name \
-    "$HERDR_SES" "$HERDR_PANE_ID" "$HERDR_TAB_ID" "$HERDR_DISPLAY_NAME" || true
+    "$HERDR_SES" "$HERDR_PANE_ID" "$HERDR_RENAME_TAB_ID" "$HERDR_DISPLAY_NAME" || true
 fi
 if [ "$HARNESS" = kimi ]; then
   if ! kimi_wait_for_ready; then

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -68,7 +68,7 @@ A cmux spawn additionally version-gates against the installed `cmux` binary's ve
 A backend spawn refusal from a missing dependency, version gate, or unauthenticated socket is terminal for that selected backend; firstmate surfaces it as a blocker instead of silently retrying another backend.
 Task meta records `backend=` only for a non-default backend; an absent `backend=` means `tmux`, preserving existing default-path meta files.
 Every new task records `endpoint_task_id=` as the cleanup binding between the metadata filename and its opaque runtime endpoint.
-A herdr task additionally records `herdr_session=`, `herdr_workspace_id=`, `herdr_tab_id=`, and `herdr_pane_id=`.
+A herdr task additionally records `herdr_session=`, `herdr_workspace_id=`, `herdr_tab_id=`, and `herdr_pane_id=`; a ship or scout task also records `herdr_display_name=` for the best-effort agent/tab rename (see [`herdr-backend.md`](herdr-backend.md#crewmate-display-names)).
 A zellij task additionally records `zellij_session=`, `zellij_tab_id=`, and `zellij_pane_id=`.
 An Orca task additionally records `orca_worktree_id=` and `terminal=`, with `window=fm-<id>` kept as the shared firstmate alias.
 A cmux task additionally records `cmux_workspace_id=` and `cmux_surface_id=`.
@@ -472,6 +472,8 @@ FM_BACKEND_HERDR_BARE_PROMPT_RE='^(❯|›)'  # herdr-only: verified agent glyph
 FM_BACKEND_HERDR_PI_COMPOSER_MAX_LINES=8  # herdr-only: maximum rows admitted between Pi's native-identity-corroborated separator pair; taller or ambiguous candidates stay unknown (docs/herdr-backend.md "Composer and injection safety")
 FM_BACKEND_HERDR_SUBMIT_POLLS=6  # herdr-only: agent-state samples spread across each Enter attempt's budget when confirming a submit (docs/herdr-backend.md "Current transport behavior")
 FM_BACKEND_HERDR_SUBMIT_MIN_SLEEP=0.6  # herdr-only: minimum per-Enter confirmation budget before polling agent-state after an idle baseline
+FM_BACKEND_HERDR_DISPLAY_NAME_POLLS=20  # herdr-only: samples waiting for a registered agent before the best-effort post-spawn display-name rename gives up (docs/herdr-backend.md "Crewmate display names")
+FM_BACKEND_HERDR_DISPLAY_NAME_SLEEP=0.25  # herdr-only: seconds between those polls
 FM_BACKEND_ORCA_COMPOSER_LINES=200  # orca-only: terminal-read lines scanned to locate the composer row for submit verification
 FM_BACKEND_ORCA_IDLE_RE='^Type a message\.\.\.$'  # orca-only: empty-composer placeholder regex after border/prompt stripping
 FM_ZELLIJ_SESSION=firstmate  # zellij-only: named session for normal backend ops and test isolation (docs/zellij-backend.md)

--- a/docs/documentation-audiences.json
+++ b/docs/documentation-audiences.json
@@ -160,9 +160,14 @@
       "audience": "agent-runtime"
     },
     {
+      "path": ".agents/skills/pr-shepherd/SKILL.md",
+      "audience": "agent-runtime"
+    },
+    {
       "path": ".agents/skills/quota-array-dispatch/SKILL.md",
       "audience": "agent-runtime"
     },
+
     {
       "path": ".agents/skills/secondmate-provisioning/SKILL.md",
       "audience": "agent-runtime"

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -75,6 +75,7 @@ Tabs are still created as `fm-<id>`; post-spawn rename is best-effort and must n
 Husk re-spawn and list-live therefore match either the create label or the scout/ship display form so a renamed husk is not stranded.
 The primary seed tab labeled `1` is never renamed.
 Secondmate launches are out of scope for automatic display names.
+When presentation spaces are enabled and the task tab is a projected child, only the agent is renamed: the tab keeps its `fm-<id>` label so husk reclaim's exact-label match (see below) still finds it on re-spawn.
 
 ## Optional presentation spaces
 

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -65,6 +65,17 @@ Existing task operations use recorded endpoint ids and do not move a live task w
 The per-home workspace is reused while it has task tabs.
 Closing its last tab can remove the workspace, and the next spawn recreates it.
 
+### Crewmate display names
+
+After a ship or scout harness launch on Herdr, Firstmate best-effort renames the registered agent and its tab to a short role-plus-topic name (`scout-<slug>` or `ship-<slug>`) so the agents sidebar is readable without a manual rename.
+The name is pure-derived from the task id and kind (`fm_backend_herdr_display_name`), capped at 32 characters, and matches Herdr's agent-name grammar.
+It is also recorded as `herdr_display_name=` in task meta for recovery and debugging.
+Display names are never ownership authority: peeks, sends, teardown, and supervision keep using recorded pane and tab ids.
+Tabs are still created as `fm-<id>`; post-spawn rename is best-effort and must not fail the spawn.
+Husk re-spawn and list-live therefore match either the create label or the scout/ship display form so a renamed husk is not stranded.
+The primary seed tab labeled `1` is never renamed.
+Secondmate launches are out of scope for automatic display names.
+
 ## Optional presentation spaces
 
 Create local gitignored `config/herdr-presentation-spaces` to request a disposable one-task workspace for each new crewmate or scout.

--- a/tests/fm-backend-herdr.test.sh
+++ b/tests/fm-backend-herdr.test.sh
@@ -739,6 +739,134 @@ test_create_task_refuses_when_agent_state_ambiguous() {
   pass "fm_backend_herdr_create_task: refuses (fail-safe) rather than guessing when the duplicate's agent state cannot be classified confidently"
 }
 
+# --- display names (pure helper + husk safety for post-spawn rename) ---------
+
+test_display_name_pure_helper_shapes() {
+  (
+    . "$ROOT/bin/backends/herdr.sh"
+    [ "$(fm_backend_herdr_display_name terse-oss-phase01 scout)" = scout-terse-oss-phase01 ] || {
+      echo "scout id: $(fm_backend_herdr_display_name terse-oss-phase01 scout)" >&2; exit 1
+    }
+    [ "$(fm_backend_herdr_display_name memberos-auth ship)" = ship-memberos-auth ] || exit 1
+    [ "$(fm_backend_herdr_display_name memberos-auth crew)" = ship-memberos-auth ] || exit 1
+    # Already-prefixed ids do not double the role prefix.
+    [ "$(fm_backend_herdr_display_name scout-terse-phase01 scout)" = scout-terse-phase01 ] || exit 1
+    [ "$(fm_backend_herdr_display_name ship-memberos-auth ship)" = ship-memberos-auth ] || exit 1
+    [ "$(fm_backend_herdr_display_name fm-terse-oss-phase01 scout)" = scout-terse-oss-phase01 ] || exit 1
+    # Uppercase and invalid characters are sanitized.
+    [ "$(fm_backend_herdr_display_name 'Terse/OSS Phase01!' scout)" = scout-terse-oss-phase01 ] || {
+      echo "sanitized: $(fm_backend_herdr_display_name 'Terse/OSS Phase01!' scout)" >&2; exit 1
+    }
+    # Long ids truncate to 32 without trailing - or _.
+    long=$(fm_backend_herdr_display_name very-long-task-id-that-exceeds-the-thirty-two-char-limit scout)
+    [ "${#long}" -le 32 ] || { echo "too long: $long (${#long})" >&2; exit 1; }
+    case "$long" in
+      *-|*_) echo "trailing separator: $long" >&2; exit 1 ;;
+      scout-*) ;;
+      *) echo "bad prefix: $long" >&2; exit 1 ;;
+    esac
+    # Grammar: ^[a-z][a-z0-9_-]{0,31}$
+    case "$long" in
+      [a-z]|[a-z][a-z0-9_-]*) ;;
+      *) echo "grammar fail: $long" >&2; exit 1 ;;
+    esac
+  ) || fail "fm_backend_herdr_display_name pure helper failed an edge case"
+  pass "fm_backend_herdr_display_name: scout/ship prefixes, strip, sanitize, truncate to 32"
+}
+
+test_task_label_candidates_include_display_names() {
+  (
+    . "$ROOT/bin/backends/herdr.sh"
+    out=$(fm_backend_herdr_task_label_candidates fm-terse-oss-phase01)
+    printf '%s\n' "$out" | grep -Fxq 'fm-terse-oss-phase01' || exit 1
+    printf '%s\n' "$out" | grep -Fxq 'scout-terse-oss-phase01' || exit 1
+    printf '%s\n' "$out" | grep -Fxq 'ship-terse-oss-phase01' || exit 1
+  ) || fail "fm_backend_herdr_task_label_candidates missing expected labels"
+  pass "fm_backend_herdr_task_label_candidates: fm- plus scout- and ship- display forms"
+}
+
+test_create_task_closes_and_replaces_renamed_display_husk() {
+  # After a successful spawn the tab may have been renamed from fm-<id> to
+  # scout-<slug>. Re-spawn must still find that husk by display name.
+  local dir log resp fb out tab pane
+  dir="$TMP_ROOT/husk-display-name"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
+  printf '{"result":{"tabs":[{"tab_id":"w1:t2","label":"scout-terse-oss-phase01","workspace_id":"w1"}]}}\n' > "$resp/1.out"
+  printf '{"result":{"panes":[{"pane_id":"w1:p2","tab_id":"w1:t2"}]}}\n' > "$resp/2.out"
+  printf '{"result":{"pane":{"pane_id":"w1:p2"}}}\n' > "$resp/3.out"
+  printf '{"error":{"code":"agent_not_found","message":"agent target w1:p2 not found"}}\n' > "$resp/4.out"
+  printf '{"result":{"tab":{"tab_id":"w1:t3"},"root_pane":{"pane_id":"w1:p3"}}}\n' > "$resp/5.out"
+  printf '{"result":{"tabs":[{"tab_id":"w1:t3","label":"fm-terse-oss-phase01","workspace_id":"w1"}]}}\n' > "$resp/7.out"
+  fb=$(make_herdr_fakebin "$dir")
+  out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
+    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_create_task fmtest:w1 fm-terse-oss-phase01 /tmp/proj' "$ROOT" ) \
+    || fail "create_task should close-and-replace a display-renamed husk"
+  read -r tab pane <<EOF
+$out
+EOF
+  if [ "$tab" != "w1:t3" ] || [ "$pane" != "w1:p3" ]; then
+    fail "create_task should echo the NEW tab/pane ids, got '$out'"
+  fi
+  assert_contains "$(cat "$log")" $'\x1f''tab'$'\x1f''close'$'\x1f''w1:t2' \
+    "create_task did not close the display-renamed husk tab"
+  assert_contains "$(cat "$log")" $'\x1f''tab'$'\x1f''create' \
+    "create_task did not create a replacement for the display-renamed husk"
+  pass "fm_backend_herdr_create_task: replaces a husk whose tab was renamed to scout-<slug>"
+}
+
+test_list_live_includes_display_name_labels() {
+  local dir log resp fb out home
+  dir="$TMP_ROOT/list-live-display"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
+  home="$TMP_ROOT/list-live-display-home"; mkdir -p "$home"
+  printf '{"result":{"workspaces":[{"workspace_id":"w1","label":"firstmate"}]}}\n' > "$resp/1.out"
+  printf '{"result":{"tabs":[{"tab_id":"w1:t1","label":"scout-terse-phase01"},{"tab_id":"w1:t2","label":"1"},{"tab_id":"w1:t3","label":"ship-memberos-auth"}]}}\n' > "$resp/2.out"
+  printf '{"result":{"panes":[{"pane_id":"w1:p1","tab_id":"w1:t1"},{"pane_id":"w1:p2","tab_id":"w1:t2"},{"pane_id":"w1:p3","tab_id":"w1:t3"}]}}\n' > "$resp/3.out"
+  printf '{"result":{"panes":[{"pane_id":"w1:p1","tab_id":"w1:t1"},{"pane_id":"w1:p2","tab_id":"w1:t2"},{"pane_id":"w1:p3","tab_id":"w1:t3"}]}}\n' > "$resp/4.out"
+  fb=$(make_herdr_fakebin "$dir")
+  out=$( PATH="$fb:$PATH" FM_HOME="$home" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
+    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_list_live fmtest' "$ROOT" )
+  assert_contains "$out" $'fmtest:w1:p1\tscout-terse-phase01' "list_live missed scout- display label"
+  assert_contains "$out" $'fmtest:w1:p3\tship-memberos-auth' "list_live missed ship- display label"
+  assert_not_contains "$out" $'w1:p2' "list_live must not treat seed tab '1' as a task"
+  pass "fm_backend_herdr_list_live: includes scout-/ship- display labels, not seed tab 1"
+}
+
+test_apply_display_name_renames_agent_and_tab() {
+  local dir log resp fb
+  dir="$TMP_ROOT/apply-display"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
+  # apply polls pane_agent_state: pane get + agent get until live, then renames.
+  printf '{"result":{"pane":{"pane_id":"w1:p9"}}}\n' > "$resp/1.out"
+  printf '{"result":{"agent":{"agent_status":"working"}}}\n' > "$resp/2.out"
+  # 3: agent rename (empty success)
+  # 4: tab rename (empty success)
+  fb=$(make_herdr_fakebin "$dir")
+  PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
+    FM_BACKEND_HERDR_DISPLAY_NAME_POLLS=2 FM_BACKEND_HERDR_DISPLAY_NAME_SLEEP=0 \
+    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_apply_display_name fmtest w1:p9 w1:t9 scout-terse-phase01' "$ROOT" \
+    || fail "apply_display_name should return 0"
+  assert_contains "$(cat "$log")" $'\x1f''agent'$'\x1f''rename'$'\x1f''w1:p9'$'\x1f''scout-terse-phase01' \
+    "apply_display_name did not agent-rename"
+  assert_contains "$(cat "$log")" $'\x1f''tab'$'\x1f''rename'$'\x1f''w1:t9'$'\x1f''scout-terse-phase01' \
+    "apply_display_name did not tab-rename"
+  pass "fm_backend_herdr_apply_display_name: renames agent and tab after agent is live"
+}
+
+test_apply_display_name_skips_when_agent_never_registers() {
+  local dir log resp fb err
+  dir="$TMP_ROOT/apply-display-skip"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
+  printf '{"result":{"pane":{"pane_id":"w1:p9"}}}\n' > "$resp/1.out"
+  printf '{"error":{"code":"agent_not_found","message":"none"}}\n' > "$resp/2.out"
+  printf '{"result":{"pane":{"pane_id":"w1:p9"}}}\n' > "$resp/3.out"
+  printf '{"error":{"code":"agent_not_found","message":"none"}}\n' > "$resp/4.out"
+  fb=$(make_herdr_fakebin "$dir")
+  err=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
+    FM_BACKEND_HERDR_DISPLAY_NAME_POLLS=2 FM_BACKEND_HERDR_DISPLAY_NAME_SLEEP=0 \
+    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_apply_display_name fmtest w1:p9 w1:t9 scout-x' "$ROOT" 2>&1 ) \
+    || fail "apply_display_name must return 0 even when rename is skipped"
+  assert_contains "$err" "not registered in time" "expected skip warning when agent never appears"
+  assert_not_contains "$(cat "$log")" $'\x1f''agent'$'\x1f''rename' "must not rename without a live agent"
+  pass "fm_backend_herdr_apply_display_name: skips rename without failing when agent never registers"
+}
+
 test_create_task_husk_replacement_creates_before_closing() {
   # Safety-critical ordering: the replacement tab must be created BEFORE the
   # husk tab is closed, never the reverse - closing a workspace's LAST
@@ -3946,6 +4074,12 @@ test_projection_reclaim_replaces_only_exact_husk_and_advances_binding
 test_projection_recovery_is_read_only_and_refuses_live_duplicate_risk
 test_workspace_find_matches_only_this_homes_own_label
 test_list_live_scoped_to_this_homes_workspace_only
+test_display_name_pure_helper_shapes
+test_task_label_candidates_include_display_names
+test_create_task_closes_and_replaces_renamed_display_husk
+test_list_live_includes_display_name_labels
+test_apply_display_name_renames_agent_and_tab
+test_apply_display_name_skips_when_agent_never_registers
 test_parse_target
 test_normalize_key
 test_capture_calls_pane_read

--- a/tests/fm-backend-herdr.test.sh
+++ b/tests/fm-backend-herdr.test.sh
@@ -867,6 +867,27 @@ test_apply_display_name_skips_when_agent_never_registers() {
   pass "fm_backend_herdr_apply_display_name: skips rename without failing when agent never registers"
 }
 
+test_apply_display_name_skips_tab_rename_when_projected() {
+  local dir log resp fb
+  dir="$TMP_ROOT/apply-display-projected"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
+  # presentation-projected spawns pass an empty tab id (fm-spawn.sh clears
+  # HERDR_RENAME_TAB_ID when HERDR_PROJECTED=1) so the task's real tab, which
+  # belongs to the presentation host, is never touched.
+  printf '{"result":{"pane":{"pane_id":"w1:p9"}}}\n' > "$resp/1.out"
+  printf '{"result":{"agent":{"agent_status":"working"}}}\n' > "$resp/2.out"
+  # 3: agent rename (empty success); no tab rename call should be made.
+  fb=$(make_herdr_fakebin "$dir")
+  PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
+    FM_BACKEND_HERDR_DISPLAY_NAME_POLLS=2 FM_BACKEND_HERDR_DISPLAY_NAME_SLEEP=0 \
+    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_apply_display_name fmtest w1:p9 "" scout-terse-phase01' "$ROOT" \
+    || fail "apply_display_name should return 0 for a projected (empty-tab-id) task"
+  assert_contains "$(cat "$log")" $'\x1f''agent'$'\x1f''rename'$'\x1f''w1:p9'$'\x1f''scout-terse-phase01' \
+    "apply_display_name did not agent-rename when tab id is empty"
+  assert_not_contains "$(cat "$log")" $'\x1f''tab'$'\x1f''rename' \
+    "apply_display_name must not tab-rename a presentation-projected (empty tab id) task"
+  pass "fm_backend_herdr_apply_display_name: skips tab rename but still agent-renames when tab id is empty (projected)"
+}
+
 test_create_task_husk_replacement_creates_before_closing() {
   # Safety-critical ordering: the replacement tab must be created BEFORE the
   # husk tab is closed, never the reverse - closing a workspace's LAST
@@ -4080,6 +4101,7 @@ test_create_task_closes_and_replaces_renamed_display_husk
 test_list_live_includes_display_name_labels
 test_apply_display_name_renames_agent_and_tab
 test_apply_display_name_skips_when_agent_never_registers
+test_apply_display_name_skips_tab_rename_when_projected
 test_parse_target
 test_normalize_key
 test_capture_calls_pane_read


### PR DESCRIPTION
## Summary
- Add captain-invocable `.agents/skills/pr-shepherd/SKILL.md` that gates open-PR landing and **merges by default** when hard gates pass (`--no-merge` for report-only).
- Wire AGENTS.md §7 load trigger, README built-in skill row, and documentation-audiences inventory entry.

## Test plan
- [x] `bin/fm-doc-audience-check.sh` passes
- [ ] CI green on this PR

Do not merge without captain word (this delivery PR itself).