### PR TITLE
fix(bin): resolve remote entrypoint path through symlinks

### DIFF
--- a/bin/fm-remote-entrypoint.sh
+++ b/bin/fm-remote-entrypoint.sh
@@ -23,7 +23,10 @@ set -eu
 
 PROTOCOL=1
 DOCTOR_SHA256=7bb13d9fad8455978bf109d4681a3aa3cb170565c8a74be4ec7b520427db14c2
-SCRIPT_DIR=$(CDPATH='' cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)
+REAL_SOURCE=$(python3 -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "${BASH_SOURCE[0]}" 2>/dev/null) ||
+  REAL_SOURCE=$(realpath "${BASH_SOURCE[0]}" 2>/dev/null) ||
+  REAL_SOURCE=${BASH_SOURCE[0]}
+SCRIPT_DIR=$(CDPATH='' cd "$(dirname "$REAL_SOURCE")" && pwd -P)
 
 # shellcheck source=bin/fm-remote-job-lib.sh
 . "$SCRIPT_DIR/fm-remote-job-lib.sh"

--- a/tests/fm-remote-entrypoint.test.sh
+++ b/tests/fm-remote-entrypoint.test.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# fm-remote-entrypoint.sh installs as a PATH symlink under ~/.local/bin
+# (docs/remote-secondmates.md). SCRIPT_DIR must resolve to the real bin/
+# directory so it can source its sibling fm-remote-job-lib.sh, not to the
+# symlink's own directory.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+TMP_ROOT=$(fm_test_tmproot fm-remote-entrypoint)
+REAL_BIN="$TMP_ROOT/real-root/bin"
+LOCAL_BIN="$TMP_ROOT/local-bin"
+mkdir -p "$REAL_BIN" "$LOCAL_BIN"
+cp "$ROOT/bin/fm-remote-entrypoint.sh" "$ROOT/bin/fm-remote-job-lib.sh" "$REAL_BIN/"
+chmod +x "$REAL_BIN/fm-remote-entrypoint.sh"
+ln -s "$REAL_BIN/fm-remote-entrypoint.sh" "$LOCAL_BIN/fm-remote-entrypoint.sh"
+
+run_entrypoint() { # <path> <stdout-file> <stderr-file>
+  local path=$1 out=$2 err=$3 code
+  "$path" >"$out" 2>"$err"
+  code=$?
+  printf '%s' "$code"
+}
+
+test_symlink_invocation_resolves_sibling_lib() {
+  local out err code
+  out="$TMP_ROOT/symlink.stdout"
+  err="$TMP_ROOT/symlink.stderr"
+  code=$(run_entrypoint "$LOCAL_BIN/fm-remote-entrypoint.sh" "$out" "$err")
+
+  # A wrong SCRIPT_DIR fails while sourcing the sibling lib, before argv is
+  # even checked, with a "No such file or directory" source error and exit 1.
+  # Reaching the die() for missing protocol args proves the sibling lib
+  # sourced from the real bin/, not from the symlink's own directory.
+  assert_no_grep 'No such file or directory' "$err" \
+    "invoking fm-remote-entrypoint.sh through a symlink failed to source its sibling lib"
+  expect_code 64 "$code" "symlink invocation exit code"
+  assert_grep 'remote entrypoint expects protocol, root, home, and argv' "$err" \
+    "symlink invocation did not reach argument validation past sibling-lib sourcing"
+  pass "fm-remote-entrypoint.sh invoked via a PATH symlink resolves SCRIPT_DIR to the real bin/ directory"
+}
+
+test_direct_invocation_still_works() {
+  # Control: the same real script invoked directly (no symlink) must behave
+  # identically, so the symlink coverage above is proven by contrast.
+  local out err code
+  out="$TMP_ROOT/direct.stdout"
+  err="$TMP_ROOT/direct.stderr"
+  code=$(run_entrypoint "$REAL_BIN/fm-remote-entrypoint.sh" "$out" "$err")
+
+  expect_code 64 "$code" "direct invocation exit code"
+  assert_grep 'remote entrypoint expects protocol, root, home, and argv' "$err" \
+    "direct invocation did not reach argument validation"
+  pass "fm-remote-entrypoint.sh invoked directly still resolves SCRIPT_DIR correctly"
+}
+
+test_symlink_invocation_resolves_sibling_lib
+test_direct_invocation_still_works


### PR DESCRIPTION
## Intent

Fix bin/fm-remote-entrypoint.sh so SCRIPT_DIR resolves through a PATH symlink install: it currently takes the dirname of the symlink (e.g. ~/.local/bin) instead of the real bin/ directory, breaking sourcing of sibling libs (fm-remote-job-lib.sh) when invoked via the ~/.local/bin symlink. Resolve the real script path (follow the symlink, preferring python3 os.path.realpath, then realpath, falling back to the raw BASH_SOURCE on hosts with neither) before taking the dirname, keeping every existing safety line (DOCTOR_SHA256, protocol, env handling) intact. Add a colocated regression test that invokes the script through an actual symlink in a temp dir and asserts SCRIPT_DIR resolves to the real bin/ so sibling-lib sourcing works, not source-text matching. Must be shellcheck-clean via bin/fm-lint.sh with existing remote/entrypoint tests green.

## What Changed

- Resolve the remote entrypoint’s real source path through symlinks before locating and sourcing its sibling job library, with `python3`, `realpath`, and raw-path fallbacks.
- Add regression coverage for both PATH-symlink and direct invocation, verifying argument validation is reached after successful sibling-library loading.

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>
</details>
<details>
<summary>✅ **Rebase** - passed</summary>
</details>
<details>
<summary>✅ **Review** - completed</summary>
</details>
<details>
<summary>✅ **Test** - passed</summary>
</details>
<details>
<summary>✅ **Document** - passed</summary>
</details>
<details>
<summary>✅ **Lint** - passed</summary>
</details>
<details>
<summary>✅ **Push** - passed</summary>
</details>
