### PR TITLE
fix(bin): surface fleet-wide open decisions on every wake drain

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -145,6 +145,7 @@ A lock-refused session must not spawn, steer, merge, drain the wake queue, repai
    Home-local stale Herdr projection cleanup and the six bootstrap MUTATING sweeps - non-executing legacy PR-check migration, fleet sync, secondmate convergence, secondmate liveness, pending remote handoff retry, and X-mode artifact writes - run only when this session actually holds the lock from step 1.
    The secondmate liveness sweep deterministically accounts for every registered secondmate: it relaunches only from the recovery-grade `dead` or `missing` states, preserves ambiguous, unreadable, or unreachable remote targets, and reports skipped or failed guarantees as `SECONDMATE_LIVENESS:` lines (`bin/fm-bootstrap.sh`; `bin/fm-backend.sh`'s `fm_backend_agent_state`; `docs/remote-secondmates.md`).
 3. **Wake queue** - when locked, drains the durable wake queue and prints the raw records prominently as this turn's first work queue; a bounded, clearly labeled historical status-event annotation may follow a valid `signal` record but never replaces it or current-state reconciliation, and a lapsed watcher chain still surfaces here via the same guard alarm.
+   Every locked drain also prints a bounded fleet-wide `OPEN DECISIONS` section when durable decision records remain open, including when the queue itself is empty; reconcile those entries before continuing.
    When the lock could not be acquired and verified, the queue is left untouched because no session mutation is authorized, and the guard's tangle/watcher-liveness alarms still print in read-only advisory mode without drain, supervision repair, or checkout repair commands.
 4. **Context digest** - the full contents of `data/projects.md`, `data/secondmates.md`, `data/captain.md`, `data/captain-shared.md`, and `data/learnings.md`, each clearly delimited.
    A file that does not exist prints an explicit `ABSENT` marker, never confused with an empty-but-present file: absence is meaningful (`captain.md` absent means use the firstmate repo's built-in defaults, `projects.md` absent means rebuild it from the clones under `projects/`, etc.).
@@ -365,6 +366,7 @@ No turn ends blind while work is under way, including turns described as holding
 
 At the start of every wake-handling turn, drain the durable wake queue before peeking, reading beyond the reason line, steering, or starting work.
 Session start is the only exception because its one-shot digest already drained while locked or deliberately left the queue untouched in lock-refused read-only mode.
+Treat any `OPEN DECISIONS` section from the drain as actionable reconciliation input even when no wake record was queued.
 A status line is a wake event, not current state; use `bin/fm-crew-state.sh` when current state matters, especially before re-escalating an old decision, blocker, or pause.
 A declared `paused:` event means a bounded external wait expected to clear on its own, while `blocked:` means firstmate action is needed.
 

--- a/bin/fm-classify-lib.sh
+++ b/bin/fm-classify-lib.sh
@@ -209,7 +209,7 @@ EOF
 # instead of trusting the last status line.
 status_open_decisions() {  # <status-file>
   local f=$1 line verb key note resolve held open='' stripped
-  [ -f "$f" ] || return 0
+  [ -f "$f" ] && [ -r "$f" ] || return 0
   resolve=${FM_CLASSIFY_RESOLVE_VERB:-$FM_CLASSIFY_RESOLVE_VERB_DEFAULT}
   held=${FM_CLASSIFY_CAPTAIN_HELD_VERB:-$FM_CLASSIFY_CAPTAIN_HELD_VERB_DEFAULT}
   while IFS= read -r line || [ -n "$line" ]; do
@@ -231,6 +231,30 @@ status_open_decisions() {  # <status-file>
     esac
   done < "$f"
   printf '%s' "$open"
+}
+
+# Fleet-wide wrapper around status_open_decisions: scans every task's status
+# log under <state> and prefixes each still-open decision with its owning task
+# id, so a per-wake or per-session surface can print the consolidated open set
+# without re-walking the fold itself. A thin directory scan only - the fold
+# above remains the ONE place the open/resolved semantics are decided. Prints
+# one "<task>\t<key>\t<verb>\t<note>" line per open decision, in glob (task id)
+# order; prints nothing when none are open.
+scan_open_decisions() {  # <state>
+  local state=$1 f task open line
+  for f in "$state"/*.status; do
+    [ -e "$f" ] || continue
+    task=$(basename "$f"); task="${task%.status}"
+    open=$(status_open_decisions "$f") || continue
+    [ -n "$open" ] || continue
+    while IFS= read -r line; do
+      [ -n "$line" ] || continue
+      printf '%s\t%s\n' "$task" "$line"
+    done <<EOF
+$open
+EOF
+  done
+  return 0
 }
 
 # Fold material routed-work phases in the same keyed event stream.

--- a/bin/fm-classify-lib.sh
+++ b/bin/fm-classify-lib.sh
@@ -201,6 +201,20 @@ $set
 EOF
   printf '%s' "$out"
 }
+_fm_status_nofollow_read() {  # <status-file>
+  perl -MFcntl=:DEFAULT -e '
+    my ($path) = @ARGV;
+    sysopen(my $file, $path, O_RDONLY | O_NOFOLLOW) or exit 1;
+    my @stat = stat $file or exit 1;
+    exit 1 unless -f _;
+    while (1) {
+      my $read = read($file, my $buffer, 65536);
+      exit 1 unless defined $read;
+      last unless $read;
+      print $buffer or exit 1;
+    }
+  ' "$1" 2>/dev/null
+}
 # Fold the WHOLE status stream into the set of decisions still open. Prints one
 # TAB-separated "<key>\t<verb>\t<summary>" line per still-open decision, in
 # most-recently-opened-last order; prints nothing when none are open. Pure read of
@@ -209,7 +223,7 @@ EOF
 # instead of trusting the last status line.
 status_open_decisions() {  # <status-file>
   local f=$1 line verb key note resolve held open='' stripped
-  [ -f "$f" ] && [ -r "$f" ] || return 0
+  [ -f "$f" ] && [ -r "$f" ] && [ ! -L "$f" ] || return 0
   resolve=${FM_CLASSIFY_RESOLVE_VERB:-$FM_CLASSIFY_RESOLVE_VERB_DEFAULT}
   held=${FM_CLASSIFY_CAPTAIN_HELD_VERB:-$FM_CLASSIFY_CAPTAIN_HELD_VERB_DEFAULT}
   while IFS= read -r line || [ -n "$line" ]; do
@@ -229,7 +243,7 @@ status_open_decisions() {  # <status-file>
         [ -n "$open" ] && open="${open}"$'\n'
         ;;
     esac
-  done < "$f"
+  done < <(_fm_status_nofollow_read "$f")
   printf '%s' "$open"
 }
 

--- a/bin/fm-classify-lib.sh
+++ b/bin/fm-classify-lib.sh
@@ -201,26 +201,18 @@ $set
 EOF
   printf '%s' "$out"
 }
-_fm_status_nofollow_read() {  # <status-file>
-  perl -MFcntl=:DEFAULT -e '
-    my ($path) = @ARGV;
-    sysopen(my $file, $path, O_RDONLY | O_NOFOLLOW) or exit 1;
-    my @stat = stat $file or exit 1;
-    exit 1 unless -f _;
-    while (1) {
-      my $read = read($file, my $buffer, 65536);
-      exit 1 unless defined $read;
-      last unless $read;
-      print $buffer or exit 1;
-    }
-  ' "$1" 2>/dev/null
-}
 # Fold the WHOLE status stream into the set of decisions still open. Prints one
 # TAB-separated "<key>\t<verb>\t<summary>" line per still-open decision, in
 # most-recently-opened-last order; prints nothing when none are open. Pure read of
 # the file, no globals beyond the optional FM_CLASSIFY_RESOLVE_VERB override. This
 # is the durable open-set the fleet snapshot and any point-in-time consumer must use
 # instead of trusting the last status line.
+# The scan_open_decisions wrapper below enumerates a whole directory rather than
+# a single caller-chosen path, so a status file that is itself a symlink (e.g.
+# escaping the state directory) is rejected outright with a plain [ -L ] check
+# before any read - a cheap builtin, unlike fm_wake_latest_event's O_NOFOLLOW
+# subprocess read, which exists for that function's much narrower payload-driven
+# path resolution rather than this directory-local glob.
 status_open_decisions() {  # <status-file>
   local f=$1 line verb key note resolve held open='' stripped
   [ -f "$f" ] && [ -r "$f" ] && [ ! -L "$f" ] || return 0
@@ -243,7 +235,7 @@ status_open_decisions() {  # <status-file>
         [ -n "$open" ] && open="${open}"$'\n'
         ;;
     esac
-  done < <(_fm_status_nofollow_read "$f")
+  done < "$f"
   printf '%s' "$open"
 }
 

--- a/bin/fm-session-start.sh
+++ b/bin/fm-session-start.sh
@@ -292,8 +292,10 @@ else
 fi
 
 # --- 3. wake-drain -------------------------------------------------------
-# Drained records are this turn's first work queue (AGENTS.md section 8); the
-# drain also runs fm-guard.sh internally on the locked path, so the
+# Drained records are this turn's first work queue, and the drain's separate
+# OPEN DECISIONS section remains actionable even when that queue is empty
+# (AGENTS.md sections 3 and 8).
+# The drain also runs fm-guard.sh internally on the locked path, so the
 # tangle/watcher-liveness alarms land right here too, ahead of the bulk digest
 # below. The read-only path never touches the queue because it lacks mutation
 # authority, and another session may be actively draining it. It still runs

--- a/bin/fm-wake-drain.sh
+++ b/bin/fm-wake-drain.sh
@@ -6,6 +6,8 @@ set -u
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=bin/fm-wake-lib.sh
 . "$SCRIPT_DIR/fm-wake-lib.sh"
+# shellcheck source=bin/fm-classify-lib.sh
+. "$SCRIPT_DIR/fm-classify-lib.sh"
 
 DRAIN_TMP=
 DRAIN_LOCK_HELD=false
@@ -24,6 +26,53 @@ RAW_ROWS=
 # guard hiccup change the drain's exit status.
 assert_watcher_liveness() {
   "$SCRIPT_DIR/fm-guard.sh" || true
+}
+
+# Print the consolidated OPEN DECISIONS section: every still-open
+# needs-decision/blocked, fleet-wide, folded from the durable status logs by
+# fm-classify-lib.sh's status_open_decisions (via its scan_open_decisions
+# wrapper) rather than from the latest-line annotations above, so a decision
+# buried under later unrelated appends cannot be silently missed. Runs on
+# every drain - including the empty-queue fast path - because the decision can
+# still be open even when nothing new is queued for its task this turn.
+# Bounded and silent: prints nothing when no decision is open, which is the
+# common case.
+print_open_decisions_section() {
+  local open task key verb note line item_bytes=220 global_bytes=4000
+  local output='' used=0 shown=0 omitted=0 bytes suffix keep
+
+  open=$(scan_open_decisions "$STATE") || return 0
+  [ -n "$open" ] || return 0
+
+  while IFS=$(printf '\t') read -r task key verb note; do
+    [ -n "$task" ] || continue
+    line="$task"
+    [ "$key" = default ] || line="$line [key=$key]"
+    line="$line $verb: $note"
+    if [ $(( ${#line} + 1 )) -gt "$item_bytes" ]; then
+      suffix=' [truncated]'
+      keep=$((item_bytes - ${#suffix} - 1))
+      line="${line:0:$keep}$suffix"
+    fi
+    bytes=$(( ${#line} + 1 ))
+    if [ $((used + bytes)) -gt "$global_bytes" ]; then
+      omitted=$((omitted + 1))
+      continue
+    fi
+    output="$output$line
+"
+    used=$((used + bytes))
+    shown=$((shown + 1))
+  done <<EOF
+$open
+EOF
+
+  [ "$shown" -gt 0 ] || [ "$omitted" -gt 0 ] || return 0
+  printf 'OPEN DECISIONS (still open, folded from the durable status logs - not just the latest line):\n'
+  printf '%s' "$output"
+  if [ "$omitted" -gt 0 ]; then
+    printf 'OPEN DECISIONS: %d more omitted (byte cap)\n' "$omitted"
+  fi
 }
 
 # shellcheck disable=SC2317,SC2329 # Invoked by trap handlers below.
@@ -47,6 +96,9 @@ DRAIN_LOCK_HELD=true
 
 if [ ! -s "$FM_WAKE_QUEUE" ]; then
   : > "$FM_WAKE_QUEUE"
+  fm_lock_release "$FM_WAKE_QUEUE_LOCK"
+  DRAIN_LOCK_HELD=false
+  (print_open_decisions_section) || true
   assert_watcher_liveness
   exit 0
 fi
@@ -75,5 +127,6 @@ DRAIN_LOCK_HELD=false
 # Raw output and queue deletion are authoritative. Everything below is
 # best-effort and cannot restore, duplicate, hide, or fail the consumed rows.
 (fm_wake_print_annotations "$RAW_ROWS") || true
+(print_open_decisions_section) || true
 assert_watcher_liveness
 exit 0

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -29,6 +29,7 @@ After each drain, `fm-wake-drain.sh` runs the same liveness guard as the supervi
 Routine watcher polling, supervision no-ops, elapsed waiting time, and absorbed benign wakes stay silent.
 A declared external wait trades that silence for one bounded recheck per pause window, so a forgotten pause cannot remain invisible indefinitely.
 Crew status files are append-only wake-event logs, not current-state fields.
+Because of that, a per-wake read of only the latest line can bury an earlier still-open `needs-decision`/`blocked` under later unrelated appends; `fm-wake-drain.sh` prints a separate, fleet-wide OPEN DECISIONS section on every drain (including the empty-queue path session-start relies on), built from `fm-classify-lib.sh`'s `status_open_decisions` fold so the buried decision keeps surfacing until it is explicitly resolved.
 `bin/fm-crew-state.sh <id>` is the cheap current-state read for an actionable heartbeat review: it attributes a no-mistakes run, active or terminal, only when it matches the crew's branch and current code identity, then keeps that run-step authoritative even if the pane has closed.
 The script header owns the exact run-head ancestry rules.
 During no-mistakes' `ci` monitor phase, it also reads the ci step log tail because `axi status` reports both "still waiting on checks" and "checks green, waiting on merge" as `ci,running`.

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -82,7 +82,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-vendor-auth-probe.sh`| Run one hard-bounded, non-destructive authentication probe of a named vendor CLI and report the fact |
 | `fm-wake-drain.sh`       | Atomically drain queued watcher wakes, emit bounded best-effort status-event annotations and a fleet-wide OPEN DECISIONS section, then assert supervision health |
 | `fm-wake-lib.sh`         | Shared durable wake queue, portable locks, and watcher identity/health helpers       |
-| `fm-classify-lib.sh`     | Shared captain-relevant and declared-external-wait wake classification vocabulary    |
+| `fm-classify-lib.sh`     | Shared wake-classification vocabulary and durable keyed-decision folds and scans     |
 | `fm-send.sh`             | Send one verified literal line or supported key through the target's recorded backend |
 | `fm-busy-lib.sh`         | Single owner of the semantic busy-state contract: verdicts, source attribution, and per-harness sources |
 | `fm-busy-event.sh`       | The only writer of a task's semantic busy-state record; arms an incarnation and applies lifecycle events |

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -80,7 +80,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-tasks-axi-lib.sh`    | Shared backlog-backend selector and `tasks-axi` compatibility probe                  |
 | `fm-quota-axi-lib.sh`    | Shared `quota-axi` compatibility floor for the bootstrap diagnostic                  |
 | `fm-vendor-auth-probe.sh`| Run one hard-bounded, non-destructive authentication probe of a named vendor CLI and report the fact |
-| `fm-wake-drain.sh`       | Atomically drain queued watcher wakes, emit bounded best-effort status-event annotations, then assert supervision health |
+| `fm-wake-drain.sh`       | Atomically drain queued watcher wakes, emit bounded best-effort status-event annotations and a fleet-wide OPEN DECISIONS section, then assert supervision health |
 | `fm-wake-lib.sh`         | Shared durable wake queue, portable locks, and watcher identity/health helpers       |
 | `fm-classify-lib.sh`     | Shared captain-relevant and declared-external-wait wake classification vocabulary    |
 | `fm-send.sh`             | Send one verified literal line or supported key through the target's recorded backend |

--- a/docs/supervision-protocols/claude.md
+++ b/docs/supervision-protocols/claude.md
@@ -7,7 +7,7 @@ When this session owns supervision and away mode is not active:
    An actionable close wakes you through the hook's exit-2 rewake, delivered as a `Stop hook feedback` message.
 3. On a `Stop hook feedback` wake (`signal:`, `stale:`, `check:`, or `heartbeat`), run `bin/fm-wake-drain.sh` first and handle the wake.
    Do not run `bin/fm-watch-arm.sh` after an ordinary wake; the next turn end re-arms automatically when supervision is still needed.
-   Do not invent a wake from an attach-status line alone; drain and act only on real wake records or a real watcher reason line.
+   Do not invent a wake from an attach-status line alone; drain and act only on real wake records, the drain's `OPEN DECISIONS` entries, or a real watcher reason line.
 4. On the one `Stop hook feedback` automatic-mechanism failure notice (`firstmate watcher auto-arm FAILED ...`), drain, inspect the automatic mechanism failure, and do not turn the notice into a repeating manual-arm loop.
 5. If the Stop hook does not claim the home or reports an exhausted failure, inspect its registration and watcher startup path before ending blind.
    Keep the Stop-owned automatic mechanism as the only Claude arm owner.

--- a/docs/supervision-protocols/grok.md
+++ b/docs/supervision-protocols/grok.md
@@ -26,7 +26,7 @@ When you see a background-task-completed system reminder for the arm:
 3. Handle `signal`, `stale`, `check`, or `heartbeat` using the harness-neutral contract in `AGENTS.md`.
 4. Ordinary wake: re-arm the next cycle with the same background `bin/fm-watch-arm.sh` call if work remains in flight or X mode still needs polling.
 5. Do not invent a wake from an attach-status line alone.
-   Drain the queue and act only on real wake records or a real watcher reason line.
+   Drain the queue and act only on real wake records, the drain's `OPEN DECISIONS` entries, or a real watcher reason line.
    Re-arm attaches to an existing healthy cycle when one is already present and follows its verified successor chain.
    See [`watcher-continuity.md`](../watcher-continuity.md) for the arm-layer successor and clean-close failure contract.
 

--- a/tests/fm-wake-drain-open-decisions.test.sh
+++ b/tests/fm-wake-drain-open-decisions.test.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# tests/fm-wake-drain-open-decisions.test.sh - behavior tests for the OPEN
+# DECISIONS section bin/fm-wake-drain.sh prints on every drain (including the
+# empty-queue fast path). The section is pure wiring around
+# fm-classify-lib.sh's status_open_decisions fold (the ONE authoritative
+# open/resolved statement); these tests exercise the real drain script over
+# crafted status logs and assert on its printed output, not on the fold's own
+# source text.
+set -u
+
+# shellcheck source=tests/wake-helpers.sh
+. "$(dirname "${BASH_SOURCE[0]}")/wake-helpers.sh"
+
+DRAIN="$ROOT/bin/fm-wake-drain.sh"
+
+TMP_ROOT=$(fm_test_tmproot fm-wake-drain-open-decisions-tests)
+
+test_buried_decision_still_surfaces() {
+  local dir state out
+  dir=$(make_case buried)
+  state="$dir/state"
+  out="$dir/drain.out"
+  # The needs-decision line sits under later routine and unrelated-key lines,
+  # exactly the burial scenario the fix targets: last-line-only reads would
+  # show "resolved [key=other]" and hide the still-open api-shape decision.
+  printf 'needs-decision [key=api-shape]: pick REST or RPC\n' > "$state/task1.status"
+  printf 'working: continuing other work\n' >> "$state/task1.status"
+  printf 'resolved [key=other]: unrelated decision closed\n' >> "$state/task1.status"
+
+  FM_STATE_OVERRIDE="$state" "$DRAIN" > "$out" || fail "drain failed on a buried decision"
+
+  grep -F 'OPEN DECISIONS' "$out" >/dev/null || fail "buried decision produced no OPEN DECISIONS section"
+  grep -F 'task1' "$out" | grep -F '[key=api-shape]' | grep -F 'pick REST or RPC' >/dev/null \
+    || fail "buried needs-decision was not surfaced with its task, key, and note"
+  pass "a needs-decision buried under later routine/other-key lines still reports as open"
+}
+
+test_explicit_resolution_closes_it() {
+  local dir state out
+  dir=$(make_case resolved)
+  state="$dir/state"
+  out="$dir/drain.out"
+  printf 'needs-decision [key=api-shape]: pick REST or RPC\n' > "$state/task2.status"
+  printf 'resolved [key=api-shape]: went with REST\n' >> "$state/task2.status"
+  printf 'done: shipped\n' >> "$state/task2.status"
+
+  FM_STATE_OVERRIDE="$state" "$DRAIN" > "$out" || fail "drain failed after an explicit resolution"
+
+  if grep -F 'OPEN DECISIONS' "$out" >/dev/null; then
+    fail "an explicitly resolved decision still printed as open: $(cat "$out")"
+  fi
+  pass "an explicit resolved [key=X] closes the keyed decision"
+}
+
+test_later_unrelated_terminal_line_does_not_close_it() {
+  local dir state out
+  dir=$(make_case unrelated-terminal)
+  state="$dir/state"
+  out="$dir/drain.out"
+  # A later done: with no matching [key=...] token opens/closes only the
+  # "default" key; it must never clear the still-open api-shape decision.
+  printf 'needs-decision [key=api-shape]: pick REST or RPC\n' > "$state/task3.status"
+  printf 'done: unrelated later milestone\n' >> "$state/task3.status"
+
+  FM_STATE_OVERRIDE="$state" "$DRAIN" > "$out" || fail "drain failed after an unrelated terminal line"
+
+  grep -F 'task3' "$out" | grep -F '[key=api-shape]' | grep -F 'pick REST or RPC' >/dev/null \
+    || fail "a later unrelated terminal line incorrectly cleared the open decision"
+  pass "a later unrelated terminal line never clears an open decision"
+}
+
+test_no_open_decisions_prints_nothing() {
+  local dir state out
+  dir=$(make_case none-open)
+  state="$dir/state"
+  out="$dir/drain.out"
+  printf 'working: on it\n' > "$state/task4.status"
+  printf 'done: shipped clean\n' > "$state/task5.status"
+
+  FM_STATE_OVERRIDE="$state" "$DRAIN" > "$out" || fail "drain failed with no open decisions"
+
+  if grep -F 'OPEN DECISIONS' "$out" >/dev/null; then
+    fail "the empty case printed an OPEN DECISIONS section: $(cat "$out")"
+  fi
+  [ ! -s "$out" ] || fail "the empty case with no queued wakes was not silent: $(cat "$out")"
+  pass "no open decisions across the fleet prints nothing"
+}
+
+test_open_decision_surfaces_even_with_an_unrelated_queued_wake() {
+  local dir state out
+  dir=$(make_case fleet-wide)
+  state="$dir/state"
+  out="$dir/drain.out"
+  # task6 has a buried, still-open decision but generates NO new queue record
+  # this turn; task7 is what actually wakes the drain. The fleet-wide scan
+  # must still catch task6's decision alongside task7's own raw row.
+  printf 'needs-decision [key=migration]: pick the rollout plan\n' > "$state/task6.status"
+  printf 'working: continuing\n' >> "$state/task6.status"
+  printf 'blocked: waiting on credentials\n' > "$state/task7.status"
+  append_wake "$state" signal task7.status "blocked: waiting on credentials" \
+    || fail "queueing the unrelated wake failed"
+
+  FM_STATE_OVERRIDE="$state" "$DRAIN" > "$out" || fail "drain failed with a mixed fleet"
+
+  grep "$(printf '\tsignal\ttask7.status\t')" "$out" >/dev/null || fail "task7's own raw row is missing"
+  grep -F 'task6' "$out" | grep -F '[key=migration]' >/dev/null \
+    || fail "task6's buried decision was not surfaced even though only task7 queued a wake"
+  pass "the open-decision section is fleet-wide, not scoped to this drain's own queued records"
+}
+
+test_buried_decision_surfaces_on_the_empty_queue_fast_path() {
+  local dir state out
+  dir=$(make_case empty-queue-fast-path)
+  state="$dir/state"
+  out="$dir/drain.out"
+  # No wake is queued at all (the empty-queue exit), but the decision is still
+  # open on disk - session-start relies on exactly this path.
+  printf 'needs-decision [key=api-shape]: pick REST or RPC\n' > "$state/task8.status"
+  printf 'working: continuing\n' >> "$state/task8.status"
+
+  FM_STATE_OVERRIDE="$state" "$DRAIN" > "$out" || fail "empty-queue drain failed"
+
+  grep -F 'task8' "$out" | grep -F '[key=api-shape]' >/dev/null \
+    || fail "the empty-queue fast path did not surface a still-open decision"
+  pass "a buried open decision surfaces even when the wake queue itself is empty"
+}
+
+test_buried_decision_still_surfaces
+test_explicit_resolution_closes_it
+test_later_unrelated_terminal_line_does_not_close_it
+test_no_open_decisions_prints_nothing
+test_open_decision_surfaces_even_with_an_unrelated_queued_wake
+test_buried_decision_surfaces_on_the_empty_queue_fast_path

--- a/tests/fm-wake-drain-open-decisions.test.sh
+++ b/tests/fm-wake-drain-open-decisions.test.sh
@@ -125,9 +125,30 @@ test_buried_decision_surfaces_on_the_empty_queue_fast_path() {
   pass "a buried open decision surfaces even when the wake queue itself is empty"
 }
 
+test_status_symlink_is_not_followed() {
+  local dir state out
+  dir=$(make_case status-symlink)
+  state="$dir/state"
+  out="$dir/drain.out"
+  mkdir -p "$dir/outside"
+  printf 'needs-decision [key=local]: keep this visible\n' > "$state/local.status"
+  printf 'needs-decision [key=foreign]: do not expose this\n' > "$dir/outside/foreign.status"
+  ln -s ../outside/foreign.status "$state/linked.status"
+
+  FM_STATE_OVERRIDE="$state" "$DRAIN" > "$out" || fail "drain failed with a symlinked status file"
+
+  grep -F 'local [key=local] needs-decision: keep this visible' "$out" >/dev/null \
+    || fail "the valid local decision did not surface alongside a rejected status symlink"
+  if grep -F 'do not expose this' "$out" >/dev/null; then
+    fail "the fleet scan followed a status symlink outside the state directory"
+  fi
+  pass "the fleet-wide decision scan does not follow status symlinks"
+}
+
 test_buried_decision_still_surfaces
 test_explicit_resolution_closes_it
 test_later_unrelated_terminal_line_does_not_close_it
 test_no_open_decisions_prints_nothing
 test_open_decision_surfaces_even_with_an_unrelated_queued_wake
 test_buried_decision_surfaces_on_the_empty_queue_fast_path
+test_status_symlink_is_not_followed


### PR DESCRIPTION
## What Changed

- Scan durable task status logs for still-open keyed `needs-decision` and `blocked` records while rejecting unreadable files and status symlinks.
- Emit a bounded, fleet-wide `OPEN DECISIONS` section after every wake drain, including the empty-queue path, until each decision is explicitly resolved.
- Document the new reconciliation contract and add end-to-end coverage for buried, resolved, unrelated, fleet-wide, empty-queue, and symlink cases.

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>⏭️ **intent** - skipped</summary>
</details>
<details>
<summary>✅ **Rebase** - passed</summary>
</details>
<details>
<summary>✅ **Review** - completed</summary>
</details>
<details>
<summary>✅ **Test** - passed</summary>
</details>
<details>
<summary>✅ **Document** - passed</summary>
</details>
<details>
<summary>✅ **Lint** - passed</summary>
</details>
<details>
<summary>✅ **Push** - passed</summary>
</details>
