### PR TITLE
fix: deliver max Codex reasoning effort across spawn paths

### DIFF
--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -123,7 +123,7 @@ The supported launch-profile flags below are verified locally; each row records 
 |---|---|---|---|
 | claude | `--model <model>` | `--effort <low\|medium\|high\|xhigh\|max>` | Verified on Claude Code 2.1.196. |
 | codex | `--model <model>` | `-c 'model_reasoning_effort="<low\|medium\|high\|xhigh\|max>"'` | Verified history: codex-cli 0.142.1 lacked `max`, while 0.146.0 (2026-08-05) accepts `none\|minimal\|low\|medium\|high\|xhigh\|max`; Firstmate threads its shared `low\|medium\|high\|xhigh\|max` vocabulary and leaves `none` and `minimal` out of scope. |
-| grok | `--model <model>` | `--reasoning-effort <low\|medium\|high>` | Verified on grok 0.2.99 (2026-07-13). `--effort` is an alias, but firstmate's profile axis is reasoning effort. As of 0.2.99 the ceiling is `high`; both `xhigh` and `max` are rejected with `use one of: high, medium, low`, so firstmate omits them. |
+| grok | `--model <model>` | `--reasoning-effort <low\|medium\|high>` | Verified on grok 0.2.99 (2026-07-13). `--effort` is an alias, but firstmate's profile axis is reasoning effort. As of 0.2.99 the ceiling is `high`; both `xhigh` and `max` are rejected with `use one of: high, medium, low`, so Firstmate applies the unsupported-axis behavior below. |
 | pi / pi-signed | `--model <model>` | `--thinking <low\|medium\|high\|xhigh\|max>` | Verified 2026-07-27 on Pi and pi-signed 0.82.0. Both expose the same accepted thinking levels and completed the same model-qualified max-thinking smoke. |
 | opencode | `--model <provider/model>` | none for firstmate's interactive launch | Verified on opencode 1.17.6. `opencode run` has `--variant`, but firstmate launches the interactive `opencode --prompt` path, which has no verified effort flag. |
 | kimi | `--model <model>` | none | Verified 2026-07-25 on Kimi Code CLI 0.29.1. |
@@ -149,8 +149,10 @@ For an unfamiliar harness or model namespace, establish support and provider ide
 A listing that reaches the account and does not contain the model is concrete evidence the model is unsupported: block that candidate and quote the result.
 A discovery surface you could not reach establishes nothing; report that as uncertainty rather than turning it into a supported or unsupported verdict.
 
-When a requested effort value is outside the harness-specific accepted set, `fm-spawn` records the requested `effort=` in meta but emits no effort flag for that harness.
-This preserves launch success instead of passing a known-bad value.
+When a requested effort value is outside the harness-specific accepted set, a verified adapter launch emits no effort flag and warns on stderr with the harness, requested value, and accepted set.
+`fm-spawn` preserves the requested `effort=` for traceability while its verified delivery metadata records that the harness received its default.
+Raw launch commands are outside that verification path and refuse separate `--model` or `--effort` axes before launch or metadata publication; put those flags in the raw command itself.
+`bin/fm-spawn.sh`'s header owns the exact diagnostic and metadata mechanics.
 
 ## no-mistakes skill invocation
 
@@ -375,7 +377,7 @@ Kimi Code CLI launches from the absolute path resolved from `PATH`, falling back
 | Slash submission | One Enter submits, with no popup swallow or settle hazard. |
 | Environment marker | None; detection relies on process ancestry command name `kimi`. |
 | Composer | Bordered box with a bare `>` prompt glyph and no observed ghost or placeholder text. |
-| Effort | No reasoning-effort flag exists, so requested effort is recorded in task metadata but omitted from launch. |
+| Effort | No reasoning-effort flag exists; `fm-spawn` follows the unsupported-axis warning and verified-delivery behavior in [Launch profile axes](#launch-profile-axes). |
 
 `fm-spawn.sh` launches Kimi bare, waits for the composer box or `Welcome to Kimi Code!`, sends only `Read the brief at <absolute-path> and follow it exactly.`, and requires a cleared composer plus either the echoed `✨` submission or nonzero context before accepting delivery.
 This launch-then-send shape is mandatory because Kimi rejects a positional brief as an unknown command.

--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -122,7 +122,7 @@ The supported launch-profile flags below are verified locally; each row records 
 | Harness | Model flag | Effort flag | Notes |
 |---|---|---|---|
 | claude | `--model <model>` | `--effort <low\|medium\|high\|xhigh\|max>` | Verified on Claude Code 2.1.196. |
-| codex | `--model <model>` | `-c 'model_reasoning_effort="<low\|medium\|high\|xhigh>"'` | Verified on codex-cli 0.142.1. The installed binary schema contains `model_reasoning_effort`, the active config uses it, and the bundled model catalog advertises only low/medium/high/xhigh. `max` is omitted. |
+| codex | `--model <model>` | `-c 'model_reasoning_effort="<low\|medium\|high\|xhigh\|max>"'` | Verified history: codex-cli 0.142.1 lacked `max`, while 0.146.0 (2026-08-05) accepts `none\|minimal\|low\|medium\|high\|xhigh\|max`; Firstmate threads its shared `low\|medium\|high\|xhigh\|max` vocabulary and leaves `none` and `minimal` out of scope. |
 | grok | `--model <model>` | `--reasoning-effort <low\|medium\|high>` | Verified on grok 0.2.99 (2026-07-13). `--effort` is an alias, but firstmate's profile axis is reasoning effort. As of 0.2.99 the ceiling is `high`; both `xhigh` and `max` are rejected with `use one of: high, medium, low`, so firstmate omits them. |
 | pi / pi-signed | `--model <model>` | `--thinking <low\|medium\|high\|xhigh\|max>` | Verified 2026-07-27 on Pi and pi-signed 0.82.0. Both expose the same accepted thinking levels and completed the same model-qualified max-thinking smoke. |
 | opencode | `--model <provider/model>` | none for firstmate's interactive launch | Verified on opencode 1.17.6. `opencode run` has `--variant`, but firstmate launches the interactive `opencode --prompt` path, which has no verified effort flag. |

--- a/.agents/skills/secondmate-provisioning/SKILL.md
+++ b/.agents/skills/secondmate-provisioning/SKILL.md
@@ -89,7 +89,7 @@ It also writes the gitignored `.fm-secondmate-parent` durable binding before the
 A bare `<harness>` (today's format, e.g. `claude`) behaves exactly as before - harness only, no model/effort flag - so this is fully backward-compatible.
 `bin/fm-harness.sh secondmate-model` and `bin/fm-harness.sh secondmate-effort` print the optional 2nd/3rd tokens (empty when absent, or when the file is absent/`default`/harness-only); they read only `config/secondmate-harness`, never `config/crew-harness`, which stays a bare adapter name.
 For a `--secondmate` spawn, `bin/fm-spawn.sh` populates `MODEL`/`EFFORT` from those tokens only when the harness itself came from the secondmate config path for that spawn.
-For a local route, an explicit per-spawn `--harness` flag, positional harness arg, or raw launch command starts clean on model and effort too, unless the caller also passes explicit `--model` or `--effort`.
+For local-route per-spawn harness, model, and effort override semantics, including raw commands' refusal of separate profile axes, follow [`docs/configuration.md` "Harness support"](../../../docs/configuration.md#harness-support) and `bin/fm-spawn.sh`'s header.
 A remote route accepts only a verified harness adapter and refuses a raw launch command at the host boundary.
 When the file's tokens do apply, an explicit per-spawn `--model` or `--effort` flag always wins over the file's token for that axis.
 Because this resolves from the file on every spawn, the pin is durable across every respawn (recovery, `/updatefirstmate`, restart) exactly like the harness axis itself - e.g. `config/secondmate-harness` containing `claude opus` keeps a secondmate pinned to Opus even if the primary's own default model later changes.

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -489,6 +489,29 @@ secondmate_sync() {
   return 0
 }
 
+secondmate_respawn() {
+  local id=$1 out rc stderr_file stderr_output
+  stderr_file=$(mktemp "$STATE/.secondmate-respawn-stderr.XXXXXX") || {
+    echo "error: secondmate $id respawn diagnostics could not be captured"
+    return 1
+  }
+  if out=$(FM_SPAWN_NO_GUARD=1 "$FM_ROOT/bin/fm-spawn.sh" "$id" --secondmate 2>"$stderr_file"); then
+    rc=0
+  else
+    rc=$?
+  fi
+  stderr_output=$(cat "$stderr_file")
+  rm -f -- "$stderr_file"
+  if [ "$rc" -eq 0 ]; then
+    [ -z "$stderr_output" ] || printf '%s\n' "$stderr_output" >&2
+    [ -z "$out" ] || printf '%s\n' "$out"
+  else
+    [ -z "$stderr_output" ] || printf '%s\n' "$stderr_output"
+    [ -z "$out" ] || printf '%s\n' "$out"
+  fi
+  return "$rc"
+}
+
 secondmate_liveness_sweep() {
   # Idempotent secondmate liveness guarantee - SESSION START ONLY. The detailed
   # state machine and its only recovery-authorizing states are owned by
@@ -565,7 +588,7 @@ secondmate_liveness_sweep() {
           ;;
         dead|missing)
           cause="remote endpoint $agent_state on its configured host"
-          if out=$(FM_SPAWN_NO_GUARD=1 "$FM_ROOT/bin/fm-spawn.sh" "$id" --secondmate 2>&1); then
+          if out=$(secondmate_respawn "$id"); then
             SECONDMATE_RESPAWNED_IDS="$SECONDMATE_RESPAWNED_IDS $id"
           else
             echo "SECONDMATE_LIVENESS: secondmate $id: respawn failed after $cause: $(first_line "$out")"
@@ -601,7 +624,7 @@ secondmate_liveness_sweep() {
         else
           cause="recorded endpoint confidently missing"
         fi
-        if out=$(FM_SPAWN_NO_GUARD=1 "$FM_ROOT/bin/fm-spawn.sh" "$id" --secondmate 2>&1); then
+        if out=$(secondmate_respawn "$id"); then
           SECONDMATE_RESPAWNED_IDS="$SECONDMATE_RESPAWNED_IDS $id"
           if [ "${FM_BOOTSTRAP_VERBOSE_FACTS:-0}" = 1 ]; then
             echo "BOOTSTRAP_INFO: secondmate $id relaunched after $cause (backend=$backend)"

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -43,8 +43,9 @@
 #          fm_backend_agent_state: skipped distinguishes an existing ambiguous
 #          process, an unreadable target, and an unverified backend; respawn
 #          failed names whether the endpoint was missing or agent-less.
-#          Already-live and successfully relaunched secondmates are silent
-#          unless FM_BOOTSTRAP_VERBOSE_FACTS=1 requests BOOTSTRAP_INFO facts.
+#          Already-live and successfully relaunched secondmates emit no liveness
+#          line unless FM_BOOTSTRAP_VERBOSE_FACTS=1 requests BOOTSTRAP_INFO facts.
+#          A successful relaunch's adapter warning remains on stderr.
 #          A TANGLE line means the firstmate primary checkout (FM_ROOT) is stranded
 #          on a feature branch instead of its default branch - a crewmate's work
 #          landed in the primary instead of its own worktree; restore it per the line.

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -902,7 +902,7 @@ crew_dispatch_validate() {
       if $e == null then true
       elif ($e | type) != "string" then false
       elif $h == "claude" then (["low","medium","high","xhigh","max"] | index($e))
-      elif $h == "codex" then (["low","medium","high","xhigh"] | index($e))
+      elif $h == "codex" then (["low","medium","high","xhigh","max"] | index($e))
       elif $h == "grok" then (["low","medium","high"] | index($e))
       elif $h == "pi" or $h == "pi-signed" then (["low","medium","high","xhigh","max"] | index($e))
       elif $h == "opencode" or $h == "kimi" then false

--- a/bin/fm-remote-secondmate-control.sh
+++ b/bin/fm-remote-secondmate-control.sh
@@ -33,6 +33,10 @@
 # the default-off path. print_route echoes the carrier the endpoint actually
 # holds, including for an already-alive endpoint that was not relaunched, so the
 # parent records the identity the agent really received rather than an intent.
+# Route output also echoes versioned proof of the endpoint's requested and
+# delivered model and effort. An alive endpoint without that proof is unverified
+# for ordinary launch and control but remains retireable; a dead or missing
+# endpoint can be relaunched to publish fresh proof.
 set -eu
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/bin/fm-remote-secondmate-control.sh
+++ b/bin/fm-remote-secondmate-control.sh
@@ -109,15 +109,19 @@ state_value() { # <id>; prints recovery-grade state
 }
 
 print_route() { # <id>
-  local id=$1 harness traceparent
+  local id=$1 harness model effort traceparent
   remote_endpoint_require "$id"
   harness=$(fm_meta_get "$REMOTE_ENDPOINT_META" harness)
+  model=$(fm_meta_get "$REMOTE_ENDPOINT_META" model)
+  effort=$(fm_meta_get "$REMOTE_ENDPOINT_META" effort)
   traceparent=$(fm_meta_get "$REMOTE_ENDPOINT_META" traceparent)
   printf 'schema=fm-remote-secondmate-control.v1\n'
   printf 'backend=%s\n' "$REMOTE_ENDPOINT_BACKEND"
   printf 'target=%s\n' "$REMOTE_ENDPOINT_TARGET"
   printf 'herdr_session=%s\n' "$REMOTE_HERDR_SESSION"
   printf 'harness=%s\n' "$harness"
+  printf 'model=%s\n' "$model"
+  printf 'effort=%s\n' "$effort"
   [ -z "$traceparent" ] || printf 'traceparent=%s\n' "$traceparent"
 }
 
@@ -134,7 +138,7 @@ cmd_route() {
 
 cmd_launch() {
   local id=$1 harness=$2 model=$3 effort=$4 selected_backend=$5 traceparent=${6:-}
-  local current meta out herdr_session
+  local current meta out herdr_session rc spawn_stderr_file spawn_stderr
 
   validate_id "$id"
   validate_home "$id"
@@ -166,13 +170,24 @@ cmd_launch() {
   [ "$model" = - ] || ARGS+=(--model "$model")
   [ "$effort" = - ] || ARGS+=(--effort "$effort")
   [ -z "$traceparent" ] || ARGS+=(--traceparent "$traceparent")
-  if ! out=$(HERDR_SESSION="$REMOTE_HERDR_SESSION" FM_HOME="$FM_ROOT" FM_ROOT_OVERRIDE="$FM_ROOT" \
+  spawn_stderr_file=$(mktemp "$CONTROL_STATE/.launch-stderr.XXXXXX") \
+    || die "remote launch diagnostics could not be captured"
+  if out=$(HERDR_SESSION="$REMOTE_HERDR_SESSION" FM_HOME="$FM_ROOT" FM_ROOT_OVERRIDE="$FM_ROOT" \
     FM_STATE_OVERRIDE="$CONTROL_STATE" FM_DATA_OVERRIDE="$CONTROL_DATA" \
     FM_CONFIG_OVERRIDE="$TARGET_HOME/config" FM_SKIP_SECONDMATE_INHERIT=1 \
-    "$SCRIPT_DIR/fm-spawn.sh" "${ARGS[@]}" 2>&1); then
+    "$SCRIPT_DIR/fm-spawn.sh" "${ARGS[@]}" 2>"$spawn_stderr_file"); then
+    rc=0
+  else
+    rc=$?
+  fi
+  spawn_stderr=$(cat "$spawn_stderr_file")
+  rm -f -- "$spawn_stderr_file"
+  if [ "$rc" -ne 0 ]; then
     [ -z "$out" ] || printf '%s\n' "$out" >&2
+    [ -z "$spawn_stderr" ] || printf '%s\n' "$spawn_stderr" >&2
     die "remote host-local secondmate launch failed"
   fi
+  [ -z "$spawn_stderr" ] || printf '%s\n' "$spawn_stderr" >&2
   [ -f "$meta" ] || die "remote launch returned without endpoint metadata"
   herdr_session=$(fm_meta_get "$meta" herdr_session)
   [ "$herdr_session" = "$REMOTE_HERDR_SESSION" ] \

--- a/bin/fm-remote-secondmate-control.sh
+++ b/bin/fm-remote-secondmate-control.sh
@@ -41,6 +41,7 @@ TARGET_HOME=${FM_HOME:?FM_HOME is required}
 CONTROL_STATE="$TARGET_HOME/state/parent-route"
 CONTROL_DATA="$TARGET_HOME/data/.parent-route"
 REMOTE_HERDR_SESSION=fm-remote
+REMOTE_PROFILE_DELIVERY=fm-spawn.v1
 
 # shellcheck source=bin/fm-backend.sh
 . "$SCRIPT_DIR/fm-backend.sh"
@@ -96,6 +97,28 @@ remote_endpoint_require() {
   remote_endpoint_load "$1" || die "$REMOTE_ENDPOINT_ERROR"
 }
 
+remote_profile_load() {
+  local id=$1 profile_delivery
+  REMOTE_PROFILE_ERROR=
+  profile_delivery=$(fm_backend_meta_exact_value "$REMOTE_ENDPOINT_META" profile_delivery 2>/dev/null || true)
+  if [ "$profile_delivery" != "$REMOTE_PROFILE_DELIVERY" ]; then
+    REMOTE_PROFILE_ERROR="remote secondmate $id delivered profile is unproven; refusing access until the endpoint is explicitly refreshed"
+    return 1
+  fi
+  if ! REMOTE_REQUESTED_MODEL=$(fm_backend_meta_exact_value "$REMOTE_ENDPOINT_META" model 2>/dev/null) \
+    || ! REMOTE_REQUESTED_EFFORT=$(fm_backend_meta_exact_value "$REMOTE_ENDPOINT_META" effort 2>/dev/null) \
+    || ! REMOTE_DELIVERED_MODEL=$(fm_backend_meta_exact_value "$REMOTE_ENDPOINT_META" delivered_model 2>/dev/null) \
+    || ! REMOTE_DELIVERED_EFFORT=$(fm_backend_meta_exact_value "$REMOTE_ENDPOINT_META" delivered_effort 2>/dev/null); then
+    REMOTE_PROFILE_ERROR="remote secondmate $id delivered profile metadata is invalid; refusing access until the endpoint is explicitly refreshed"
+    return 1
+  fi
+}
+
+remote_endpoint_require_profile() {
+  remote_endpoint_require "$1"
+  remote_profile_load "$1" || die "$REMOTE_PROFILE_ERROR"
+}
+
 state_value() { # <id>; prints recovery-grade state
   local id=$1 meta
   meta=$(meta_path "$id")
@@ -105,23 +128,29 @@ state_value() { # <id>; prints recovery-grade state
     printf 'unverified\n'
     return 0
   fi
+  if ! remote_profile_load "$id"; then
+    printf 'error: %s\n' "$REMOTE_PROFILE_ERROR" >&2
+    printf 'unverified\n'
+    return 0
+  fi
   fm_backend_agent_state "$REMOTE_ENDPOINT_BACKEND" "$REMOTE_ENDPOINT_TARGET" 2>/dev/null || printf 'unreadable\n'
 }
 
 print_route() { # <id>
-  local id=$1 harness model effort traceparent
-  remote_endpoint_require "$id"
+  local id=$1 harness traceparent
+  remote_endpoint_require_profile "$id"
   harness=$(fm_meta_get "$REMOTE_ENDPOINT_META" harness)
-  model=$(fm_meta_get "$REMOTE_ENDPOINT_META" model)
-  effort=$(fm_meta_get "$REMOTE_ENDPOINT_META" effort)
   traceparent=$(fm_meta_get "$REMOTE_ENDPOINT_META" traceparent)
   printf 'schema=fm-remote-secondmate-control.v1\n'
   printf 'backend=%s\n' "$REMOTE_ENDPOINT_BACKEND"
   printf 'target=%s\n' "$REMOTE_ENDPOINT_TARGET"
   printf 'herdr_session=%s\n' "$REMOTE_HERDR_SESSION"
   printf 'harness=%s\n' "$harness"
-  printf 'model=%s\n' "$model"
-  printf 'effort=%s\n' "$effort"
+  printf 'profile_delivery=%s\n' "$REMOTE_PROFILE_DELIVERY"
+  printf 'requested_model=%s\n' "$REMOTE_REQUESTED_MODEL"
+  printf 'requested_effort=%s\n' "$REMOTE_REQUESTED_EFFORT"
+  printf 'model=%s\n' "$REMOTE_DELIVERED_MODEL"
+  printf 'effort=%s\n' "$REMOTE_DELIVERED_EFFORT"
   [ -z "$traceparent" ] || printf 'traceparent=%s\n' "$traceparent"
 }
 
@@ -199,7 +228,7 @@ cmd_send() {
   local id=$1 message=$2
   validate_id "$id"
   validate_home "$id"
-  remote_endpoint_require "$id"
+  remote_endpoint_require_profile "$id"
   FM_HOME="$TARGET_HOME" FM_ROOT_OVERRIDE="$FM_ROOT" FM_STATE_OVERRIDE="$TARGET_HOME/state" \
     "$SCRIPT_DIR/fm-send.sh" "$REMOTE_ENDPOINT_TARGET" "$message"
 }
@@ -208,7 +237,7 @@ cmd_key() {
   local id=$1 key=$2
   validate_id "$id"
   validate_home "$id"
-  remote_endpoint_require "$id"
+  remote_endpoint_require_profile "$id"
   FM_HOME="$TARGET_HOME" FM_ROOT_OVERRIDE="$FM_ROOT" FM_STATE_OVERRIDE="$TARGET_HOME/state" \
     "$SCRIPT_DIR/fm-send.sh" "$REMOTE_ENDPOINT_TARGET" --key "$key"
 }
@@ -219,7 +248,7 @@ cmd_capture() {
   validate_home "$id"
   case "$lines" in ''|*[!0-9]*|0) die "capture line count must be positive" ;; esac
   [ "$lines" -le 100 ] || die "capture line count exceeds 100"
-  remote_endpoint_require "$id"
+  remote_endpoint_require_profile "$id"
   fm_backend_capture "$REMOTE_ENDPOINT_BACKEND" "$REMOTE_ENDPOINT_TARGET" "$lines" "fm-$id" | head -c 65536
 }
 
@@ -227,7 +256,7 @@ cmd_observe() {
   local id=$1 harness
   validate_id "$id"
   validate_home "$id"
-  remote_endpoint_require "$id"
+  remote_endpoint_require_profile "$id"
   harness=$(fm_meta_get "$REMOTE_ENDPOINT_META" harness)
   fm_pending_reply_backend_observation "$REMOTE_ENDPOINT_BACKEND" "$REMOTE_ENDPOINT_TARGET" "fm-$id" "$harness"
   printf '\n'
@@ -285,7 +314,7 @@ cmd_retire() {
     return 0
   fi
   [ -z "$force" ] || [ "$force" = --force ] || usage
-  remote_endpoint_require "$id"
+  remote_endpoint_require_profile "$id"
   FM_HOME="$TARGET_HOME" FM_ROOT_OVERRIDE="$FM_ROOT" FM_STATE_OVERRIDE="$TARGET_HOME/state" \
     FM_CONFIG_OVERRIDE="$TARGET_HOME/config" "$SCRIPT_DIR/fm-guard.sh" || true
   if [ -n "$force" ]; then

--- a/bin/fm-remote-secondmate-control.sh
+++ b/bin/fm-remote-secondmate-control.sh
@@ -120,7 +120,7 @@ remote_endpoint_require_profile() {
 }
 
 state_value() { # <id>; prints recovery-grade state
-  local id=$1 meta
+  local id=$1 meta state
   meta=$(meta_path "$id")
   [ -f "$meta" ] && [ ! -L "$meta" ] || { printf 'missing\n'; return 0; }
   if ! remote_endpoint_load "$id"; then
@@ -128,12 +128,15 @@ state_value() { # <id>; prints recovery-grade state
     printf 'unverified\n'
     return 0
   fi
-  if ! remote_profile_load "$id"; then
+  if ! state=$(fm_backend_agent_state "$REMOTE_ENDPOINT_BACKEND" "$REMOTE_ENDPOINT_TARGET" 2>/dev/null); then
+    state=unreadable
+  fi
+  if [ "$state" = alive ] && ! remote_profile_load "$id"; then
     printf 'error: %s\n' "$REMOTE_PROFILE_ERROR" >&2
     printf 'unverified\n'
     return 0
   fi
-  fm_backend_agent_state "$REMOTE_ENDPOINT_BACKEND" "$REMOTE_ENDPOINT_TARGET" 2>/dev/null || printf 'unreadable\n'
+  printf '%s\n' "$state"
 }
 
 print_route() { # <id>
@@ -314,7 +317,7 @@ cmd_retire() {
     return 0
   fi
   [ -z "$force" ] || [ "$force" = --force ] || usage
-  remote_endpoint_require_profile "$id"
+  remote_endpoint_require "$id"
   FM_HOME="$TARGET_HOME" FM_ROOT_OVERRIDE="$FM_ROOT" FM_STATE_OVERRIDE="$TARGET_HOME/state" \
     FM_CONFIG_OVERRIDE="$TARGET_HOME/config" "$SCRIPT_DIR/fm-guard.sh" || true
   if [ -n "$force" ]; then

--- a/bin/fm-session-start.sh
+++ b/bin/fm-session-start.sh
@@ -12,8 +12,10 @@
 # belong in a script, not in N agent turns.
 #
 # COMPOSITION, NOT DUPLICATION: this script calls fm-lock.sh, fm-bootstrap.sh,
-# and fm-wake-drain.sh as real subprocesses and prints their real output. It
-# never re-implements their logic; all sequencing/formatting logic added here
+# and fm-wake-drain.sh as real subprocesses and prints their real output.
+# It keeps subprocess stderr on stderr so launch warnings are neither swallowed
+# by command substitution nor reclassified as digest output.
+# It never re-implements their logic; all sequencing/formatting logic added here
 # stays local to this file. Those three scripts remain fully working
 # standalone with unchanged default behavior - other flows (fm-bootstrap.sh
 # install <tools> after consent, /updatefirstmate, the afk daemon, existing

--- a/bin/fm-session-start.sh
+++ b/bin/fm-session-start.sh
@@ -278,11 +278,11 @@ fi
 # --- 2. bootstrap --------------------------------------------------------
 subsection "BOOTSTRAP"
 if [ "$READ_ONLY" -eq 1 ]; then
-  BOOT_OUT=$(FM_BOOTSTRAP_DETECT_ONLY=1 "$SCRIPT_DIR/fm-bootstrap.sh" 2>&1)
+  BOOT_OUT=$(FM_BOOTSTRAP_DETECT_ONLY=1 "$SCRIPT_DIR/fm-bootstrap.sh")
 else
   BOOT_OUT=$(
-    "$SCRIPT_DIR/fm-herdr-session-cleanup.sh" 2>&1 || true
-    "$SCRIPT_DIR/fm-bootstrap.sh" 2>&1
+    "$SCRIPT_DIR/fm-herdr-session-cleanup.sh" || true
+    "$SCRIPT_DIR/fm-bootstrap.sh"
   )
 fi
 if [ -n "$BOOT_OUT" ]; then

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -2229,11 +2229,10 @@ if [ "${HERDR_PROJECTED:-0}" -eq 1 ]; then
 fi
 spawn_send_key "$T" Enter
 if [ "$RAW_LAUNCH" -eq 0 ]; then
-  {
-    echo "profile_delivery=fm-spawn.v1"
-    echo "delivered_model=$DELIVERED_MODEL"
-    echo "delivered_effort=$DELIVERED_EFFORT"
-  } >> "$STATE/$ID.meta"
+  if ! printf 'profile_delivery=fm-spawn.v1\ndelivered_model=%s\ndelivered_effort=%s\n' \
+    "$DELIVERED_MODEL" "$DELIVERED_EFFORT" >> "$STATE/$ID.meta"; then
+    echo "warning: delivered profile metadata could not be recorded for $ID; launch remains active without verified profile delivery" >&2
+  fi
 fi
 if [ "$HARNESS" = kimi ]; then
   if ! kimi_wait_for_ready; then

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -340,6 +340,7 @@ spawn_remote_secondmate() {
   local id=$1 remote host root home harness positional model effort backend out rc meta tmp
   local remote_backend remote_target remote_harness remote_herdr_session registry_lock remote_lock remote_generation
   local remote_traceparent remote_recorded_traceparent remote_model remote_effort
+  local remote_profile_delivery remote_requested_model remote_requested_effort
   local remote_recorded_model remote_recorded_effort remote_stderr_file remote_stderr
   local -a launch_args
   id=${POS[0]:-}
@@ -529,6 +530,9 @@ spawn_remote_secondmate() {
   remote_target=$(printf '%s\n' "$out" | sed -n 's/^target=//p' | tail -1)
   remote_harness=$(printf '%s\n' "$out" | sed -n 's/^harness=//p' | tail -1)
   remote_herdr_session=$(printf '%s\n' "$out" | sed -n 's/^herdr_session=//p' | tail -1)
+  remote_profile_delivery=$(printf '%s\n' "$out" | sed -n 's/^profile_delivery=//p' | tail -1)
+  remote_requested_model=$(printf '%s\n' "$out" | sed -n 's/^requested_model=//p' | tail -1)
+  remote_requested_effort=$(printf '%s\n' "$out" | sed -n 's/^requested_effort=//p' | tail -1)
   remote_model=$(printf '%s\n' "$out" | sed -n 's/^model=//p' | tail -1)
   remote_effort=$(printf '%s\n' "$out" | sed -n 's/^effort=//p' | tail -1)
   if [ "$remote_backend" != herdr ]; then
@@ -552,25 +556,27 @@ spawn_remote_secondmate() {
     echo "error: remote launch returned Herdr session '${remote_herdr_session:-missing}', expected 'fm-remote'; preserving the remote route for reconciliation" >&2
     return 1
   fi
-  if [ -z "$remote_model" ] || [ -z "$remote_effort" ]; then
+  if [ "$remote_profile_delivery" != fm-spawn.v1 ] \
+    || [ -z "$remote_requested_model" ] || [ -z "$remote_requested_effort" ] \
+    || [ -z "$remote_model" ] || [ -z "$remote_effort" ]; then
     fm_lock_release "$remote_lock" || true
     fm_lock_release "$registry_lock" || true
     fm_lock_release "$SPAWN_TASK_LOCK" || true
-    echo "error: remote launch returned no actual model or effort; preserving the remote route for reconciliation" >&2
+    echo "error: remote launch returned no verified delivered profile; preserving the remote route for reconciliation" >&2
     return 1
   fi
-  if [ "$model" != - ] && [ "$remote_model" != "$model" ]; then
+  if [ "$model" != - ] && [ "$remote_requested_model" != "$model" ]; then
     fm_lock_release "$remote_lock" || true
     fm_lock_release "$registry_lock" || true
     fm_lock_release "$SPAWN_TASK_LOCK" || true
-    echo "error: remote secondmate $id is already live with model '$remote_model', not requested model '$model'; live endpoint was not restarted" >&2
+    echo "error: remote secondmate $id is already live with model '$remote_requested_model', not requested model '$model'; live endpoint was not restarted" >&2
     return 1
   fi
-  if [ "$effort" != - ] && [ "$remote_effort" != "$effort" ]; then
+  if [ "$effort" != - ] && [ "$remote_requested_effort" != "$effort" ]; then
     fm_lock_release "$remote_lock" || true
     fm_lock_release "$registry_lock" || true
     fm_lock_release "$SPAWN_TASK_LOCK" || true
-    echo "error: remote secondmate $id is already live with effort '$remote_effort', not requested effort '$effort'; live endpoint was not restarted" >&2
+    echo "error: remote secondmate $id is already live with effort '$remote_requested_effort', not requested effort '$effort'; live endpoint was not restarted" >&2
     return 1
   fi
   remote_recorded_model=$remote_model
@@ -598,6 +604,9 @@ spawn_remote_secondmate() {
     echo "tasktmp="
     echo "model=$remote_recorded_model"
     echo "effort=$remote_recorded_effort"
+    echo "profile_delivery=$remote_profile_delivery"
+    echo "delivered_model=$remote_model"
+    echo "delivered_effort=$remote_effort"
     echo "home=$home"
     echo "projects=$(secondmate_registry_field "$DATA/secondmates.md" "$id" projects)"
     echo "remote_host=$host"
@@ -2066,6 +2075,13 @@ elif [ "$KIND" = scout ]; then
   YOLO=
 fi
 
+MODELFLAG=$(model_flag_for_harness "$HARNESS" "$MODEL")
+EFFORTFLAG=$(effort_flag_for_harness "$HARNESS" "$EFFORT")
+DELIVERED_MODEL=default
+DELIVERED_EFFORT=default
+[ -z "$MODELFLAG" ] || DELIVERED_MODEL=${MODEL:-default}
+[ -z "$EFFORTFLAG" ] || DELIVERED_EFFORT=${EFFORT:-default}
+
 # Resolve the optional default-off W3C trace context (bin/fm-trace-context-lib.sh,
 # docs/configuration.md): the one carrier both recorded in meta and injected into
 # the pane, so an observer reads exactly what the child receives. Empty only when
@@ -2147,8 +2163,6 @@ sq_piext=$(shell_quote "$STATE/$ID.pi-ext.ts")
 sq_piturnend=$(shell_quote "$PROJ_ABS/.pi/extensions/fm-primary-turnend-guard.ts")
 sq_piwatch=$(shell_quote "$PROJ_ABS/.pi/extensions/fm-primary-pi-watch.ts")
 sq_opinput=$(shell_quote "$FM_ROOT/bin/fm-operational-input.sh")
-MODELFLAG=$(model_flag_for_harness "$HARNESS" "$MODEL")
-EFFORTFLAG=$(effort_flag_for_harness "$HARNESS" "$EFFORT")
 LAUNCH=${LAUNCH//__MODELFLAG__/$MODELFLAG}
 LAUNCH=${LAUNCH//__EFFORTFLAG__/$EFFORTFLAG}
 LAUNCH=${LAUNCH//__BRIEF__/$sq_brief}
@@ -2211,6 +2225,13 @@ if [ "${HERDR_PROJECTED:-0}" -eq 1 ]; then
   spawn_herdr_presentation_order_lock_release
 fi
 spawn_send_key "$T" Enter
+if [ "$RAW_LAUNCH" -eq 0 ]; then
+  {
+    echo "profile_delivery=fm-spawn.v1"
+    echo "delivered_model=$DELIVERED_MODEL"
+    echo "delivered_effort=$DELIVERED_EFFORT"
+  } >> "$STATE/$ID.meta"
+fi
 if [ "$HARNESS" = kimi ]; then
   if ! kimi_wait_for_ready; then
     kimi_spawn_fail "kimi did not show a verified ready signal before brief delivery"

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -137,6 +137,9 @@
 # grok uses a firstmate-owned global hook under ${GROK_HOME:-$HOME/.grok}/hooks
 # plus a gitignored .fm-grok-turnend worktree pointer and a state token.
 # On success prints: spawned <id> harness=<name> kind=<ship|scout|secondmate> [mode=<mode> yolo=<on|off>] window=<backend-target> worktree=<path>
+# A verified adapter launch appends versioned delivered-profile metadata only
+# after launch submission; a raw command never claims verified profile delivery.
+# AGENTS.md section 2 owns the exact fields and local-versus-remote meaning.
 # A ship task records the explicit mode/yolo it was passed; a secondmate spawn records
 # mode=secondmate, yolo=off, home=, and projects=; a scout records neither, and both the
 # success line and state/<id>.meta omit them.

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -21,7 +21,8 @@
 #   --model <name> and --effort <low|medium|high|xhigh|max> are concrete profile
 #   axes chosen by firstmate at intake. They are only threaded into harnesses whose
 #   installed CLIs were verified to support that axis; unsupported axes are omitted
-#   from that harness's launch rather than guessed.
+#   from that harness's launch rather than guessed, with a warning that names the
+#   harness, requested value, and adapter's accepted set.
 #   --backend <name> is the explicit runtime session-provider backend for this
 #   exact task only (docs/configuration.md "Runtime backend" owns when that flag
 #   is authorized). Without it, the script resolves FM_BACKEND, then
@@ -977,11 +978,12 @@ effort_flag_for_harness() {
       esac
       ;;
     codex)
-      # The installed codex config schema uses model_reasoning_effort, and the
-      # bundled model catalog advertises low|medium|high|xhigh. Omit max rather
-      # than passing an unsupported value.
+      # Verified with codex-cli 0.146.0 on 2026-08-05: the server accepts
+      # none|minimal|low|medium|high|xhigh|max through model_reasoning_effort.
+      # Firstmate threads its shared low|medium|high|xhigh|max vocabulary here;
+      # none and minimal remain outside the shared profile axis.
       case "$effort" in
-        low|medium|high|xhigh) printf -- '-c %s ' "$(shell_quote "model_reasoning_effort=\"$effort\"")" ;;
+        low|medium|high|xhigh|max) printf -- '-c %s ' "$(shell_quote "model_reasoning_effort=\"$effort\"")" ;;
       esac
       ;;
     grok)
@@ -991,6 +993,7 @@ effort_flag_for_harness() {
       # than passing a known-bad value.
       case "$effort" in
         low|medium|high) printf -- '--reasoning-effort %s ' "$(shell_quote "$effort")" ;;
+        *) echo "warning: harness '$harness' cannot thread requested effort '$effort'; accepted effort values: low, medium, high; omitting effort flag" >&2 ;;
       esac
       ;;
     pi|pi-signed)
@@ -1005,6 +1008,12 @@ effort_flag_for_harness() {
     # to a different, non-interactive launch mode, so fm-spawn does not pass it.
     # kimi likewise has no reasoning-effort flag; the requested axis stays in
     # task metadata but never reaches the launch command.
+    opencode|kimi)
+      echo "warning: harness '$harness' cannot thread requested effort '$effort'; accepted effort values: no supported values; omitting effort flag" >&2
+      ;;
+    *)
+      echo "warning: harness '$harness' cannot thread requested effort '$effort'; accepted effort values through fm-spawn: no supported values; raw launch commands must carry their own effort flags" >&2
+      ;;
   esac
 }
 

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -89,6 +89,8 @@
 #   whitespace is treated as a RAW launch command - the escape hatch for verifying
 #   new adapters. pi-signed launches that exact executable name from PATH and
 #   refuses before endpoint creation when it is unavailable; it never falls back to pi.
+#   Raw launch commands cannot carry separate --model/--effort profile axes;
+#   put those flags directly in the raw command or the spawn is refused.
 #   config/secondmate-harness may also carry an optional model and effort as extra
 #   whitespace-separated tokens ("<harness> [<model>] [<effort>]"). For a
 #   --secondmate spawn, those tokens apply only when this spawn also resolves its
@@ -337,7 +339,8 @@ fi
 spawn_remote_secondmate() {
   local id=$1 remote host root home harness positional model effort backend out rc meta tmp
   local remote_backend remote_target remote_harness remote_herdr_session registry_lock remote_lock remote_generation
-  local remote_traceparent remote_recorded_traceparent
+  local remote_traceparent remote_recorded_traceparent remote_model remote_effort
+  local remote_recorded_model remote_recorded_effort remote_stderr_file remote_stderr
   local -a launch_args
   id=${POS[0]:-}
   fm_task_id_creation_valid "$id" || { echo "error: invalid task id" >&2; return 2; }
@@ -495,26 +498,39 @@ spawn_remote_secondmate() {
   fi
   launch_args=("$id" "$harness" "$model" "$effort" "$backend")
   [ -z "$remote_traceparent" ] || launch_args+=("$remote_traceparent")
+  remote_stderr_file=$(mktemp "$STATE/.remote-spawn-stderr.XXXXXX") || {
+    fm_lock_release "$remote_lock" || true
+    fm_lock_release "$registry_lock" || true
+    fm_lock_release "$SPAWN_TASK_LOCK" || true
+    echo "error: remote secondmate $id launch diagnostics could not be captured" >&2
+    return 1
+  }
   if out=$("$SCRIPT_DIR/fm-on.sh" "$id" fm-remote-secondmate-control.sh launch \
-    "${launch_args[@]}" < /dev/null 2>&1); then
+    "${launch_args[@]}" < /dev/null 2>"$remote_stderr_file"); then
     rc=0
   else
     rc=$?
   fi
+  remote_stderr=$(cat "$remote_stderr_file")
+  rm -f -- "$remote_stderr_file"
   if [ "$rc" -ne 0 ]; then
     fm_lock_release "$remote_lock" || true
     fm_lock_release "$registry_lock" || true
     fm_lock_release "$SPAWN_TASK_LOCK" || true
     [ -z "$out" ] || printf '%s\n' "$out" >&2
+    [ -z "$remote_stderr" ] || printf '%s\n' "$remote_stderr" >&2
     if [ "$rc" -eq 255 ]; then
       echo "error: remote secondmate $id is unavailable or launch completion is unknown; preserved route $host:$home" >&2
     fi
     return "$rc"
   fi
+  [ -z "$remote_stderr" ] || printf '%s\n' "$remote_stderr" >&2
   remote_backend=$(printf '%s\n' "$out" | sed -n 's/^backend=//p' | tail -1)
   remote_target=$(printf '%s\n' "$out" | sed -n 's/^target=//p' | tail -1)
   remote_harness=$(printf '%s\n' "$out" | sed -n 's/^harness=//p' | tail -1)
   remote_herdr_session=$(printf '%s\n' "$out" | sed -n 's/^herdr_session=//p' | tail -1)
+  remote_model=$(printf '%s\n' "$out" | sed -n 's/^model=//p' | tail -1)
+  remote_effort=$(printf '%s\n' "$out" | sed -n 's/^effort=//p' | tail -1)
   if [ "$remote_backend" != herdr ]; then
     fm_lock_release "$remote_lock" || true
     fm_lock_release "$registry_lock" || true
@@ -536,6 +552,31 @@ spawn_remote_secondmate() {
     echo "error: remote launch returned Herdr session '${remote_herdr_session:-missing}', expected 'fm-remote'; preserving the remote route for reconciliation" >&2
     return 1
   fi
+  if [ -z "$remote_model" ] || [ -z "$remote_effort" ]; then
+    fm_lock_release "$remote_lock" || true
+    fm_lock_release "$registry_lock" || true
+    fm_lock_release "$SPAWN_TASK_LOCK" || true
+    echo "error: remote launch returned no actual model or effort; preserving the remote route for reconciliation" >&2
+    return 1
+  fi
+  if [ "$model" != - ] && [ "$remote_model" != "$model" ]; then
+    fm_lock_release "$remote_lock" || true
+    fm_lock_release "$registry_lock" || true
+    fm_lock_release "$SPAWN_TASK_LOCK" || true
+    echo "error: remote secondmate $id is already live with model '$remote_model', not requested model '$model'; live endpoint was not restarted" >&2
+    return 1
+  fi
+  if [ "$effort" != - ] && [ "$remote_effort" != "$effort" ]; then
+    fm_lock_release "$remote_lock" || true
+    fm_lock_release "$registry_lock" || true
+    fm_lock_release "$SPAWN_TASK_LOCK" || true
+    echo "error: remote secondmate $id is already live with effort '$remote_effort', not requested effort '$effort'; live endpoint was not restarted" >&2
+    return 1
+  fi
+  remote_recorded_model=$remote_model
+  remote_recorded_effort=$remote_effort
+  [ "$remote_recorded_model" != default ] || remote_recorded_model=
+  [ "$remote_recorded_effort" != default ] || remote_recorded_effort=
   # Record what the remote endpoint ACTUALLY carries, read back from its own
   # launch, rather than what this side hoped to deliver. That keeps the #995
   # guarantee that the recorded carrier is the identity the child received even
@@ -555,8 +596,8 @@ spawn_remote_secondmate() {
     echo "mode=secondmate"
     echo "yolo=off"
     echo "tasktmp="
-    echo "model=${model#-}"
-    echo "effort=${effort#-}"
+    echo "model=$remote_recorded_model"
+    echo "effort=$remote_recorded_effort"
     echo "home=$home"
     echo "projects=$(secondmate_registry_field "$DATA/secondmates.md" "$id" projects)"
     echo "remote_host=$host"
@@ -854,8 +895,10 @@ launch_template() {
   esac
 }
 
+RAW_LAUNCH=0
 case "$ARG3" in
   *' '*)  # raw launch command (unverified-adapter escape hatch)
+    RAW_LAUNCH=1
     LAUNCH=$ARG3
     HARNESS=""
     for word in $LAUNCH; do
@@ -889,6 +932,19 @@ case "$ARG3" in
     LAUNCH=$(launch_template "$HARNESS" "$KIND") || { echo "error: unknown harness '$HARNESS'; pass a raw launch command to use an unverified adapter" >&2; exit 1; }
     ;;
 esac
+
+if [ "$RAW_LAUNCH" -eq 1 ]; then
+  RAW_PROFILE_INVALID=0
+  if [ -n "$MODEL" ]; then
+    echo "error: raw launch harness '$HARNESS' cannot thread requested model '$MODEL'; accepted model values through fm-spawn raw commands: no supported values; put the model flag in the raw command instead" >&2
+    RAW_PROFILE_INVALID=1
+  fi
+  if [ -n "$EFFORT" ]; then
+    echo "error: raw launch harness '$HARNESS' cannot thread requested effort '$EFFORT'; accepted effort values through fm-spawn raw commands: no supported values; put the effort flag in the raw command instead" >&2
+    RAW_PROFILE_INVALID=1
+  fi
+  [ "$RAW_PROFILE_INVALID" -eq 0 ] || exit 1
+fi
 
 case "$HARNESS" in
   pi|pi-signed) LAUNCH="FM_PI_HARNESS=$HARNESS $LAUNCH" ;;

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -168,8 +168,8 @@ The shell scripts validate the JSON shape and verified harness/effort combinatio
 The session-start bootstrap step keeps valid dispatch configuration silent unless verbose facts are enabled and surfaces a concise invalid-config line when validation fails.
 When the file exists, `fm-spawn.sh` refuses crewmate and scout launches without an explicit harness, so `config/crew-harness` is only automatic when no dispatch profile file is active.
 Secondmate launches are exempt because they resolve the secondmate harness and any optional secondmate model or effort tokens instead.
-Unsupported effort values are still recorded in task meta when passed to `fm-spawn.sh`, but the launch template omits any effort flag that the selected harness does not accept.
-That keeps spawn launch compatible across claude, codex, grok, pi, opencode, and kimi while preserving the requested profile for later audit.
+The launch boundary filters each concrete profile through the selected adapter's capability instead of passing a known-bad flag.
+The [`harness-adapters` launch-profile table](../.agents/skills/harness-adapters/SKILL.md#launch-profile-axes) owns exact accepted sets and [`configuration.md`](configuration.md#harness-support) owns the operator-visible omission and metadata behavior.
 
 ## Optional secondmates
 
@@ -207,8 +207,8 @@ Secondmate agents can run on a different verified harness than crewmates.
 A bare harness line remains harness-only, so existing `config/secondmate-harness` files keep their previous behavior.
 When the harness token is unset or `default`, launch falls back to `config/crew-harness`, then to the primary's own harness, and the model and effort tokens are ignored.
 Those optional tokens are re-read on every secondmate spawn or respawn and are overridden by explicit per-spawn `--model` or `--effort` flags.
-For a local route, an explicit per-spawn harness or raw launch command does not inherit model or effort tokens from `config/secondmate-harness`.
-Remote routes accept verified harness adapters only and reject raw launch commands.
+[`configuration.md`](configuration.md#harness-support) owns per-spawn model and effort inheritance plus raw-launch profile handling.
+[`remote-secondmates.md`](remote-secondmates.md#normal-operation) owns the remote route's verified-adapter-only boundary.
 `config/crew-harness` remains the crewmate harness and is inherited into secondmate homes.
 `config/crew-dispatch.json` is inherited too; secondmates use the same natural-language dispatch profiles when spawning their own crewmates.
 The [`secondmate-provisioning` skill](../.agents/skills/secondmate-provisioning/SKILL.md) owns the complete inherited-local-material allowlist and propagation contract.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -223,7 +223,9 @@ A bare `<harness>` preserves the previous behavior: harness only, with no model 
 When the harness token is absent or `default`, secondmate launch falls back through `config/crew-harness` and then the primary's own harness, and no model or effort is read from that file.
 `fm-harness.sh secondmate-model` and `fm-harness.sh secondmate-effort` expose only the optional tokens from `config/secondmate-harness`; `config/crew-harness` remains a bare adapter-name file.
 An explicit harness argument to `fm-spawn.sh` still overrides either config file for that spawn only.
-An explicit `--model` or `--effort` overrides the matching token from `config/secondmate-harness`; for a local route, an explicit harness or raw launch command starts with clean model and effort defaults unless those flags are also passed.
+An explicit `--model` or `--effort` overrides the matching token from `config/secondmate-harness` for a verified adapter launch.
+For a local route, an explicit verified harness starts with clean model and effort defaults unless those flags are also passed.
+A raw launch command also starts clean but refuses separate `--model` or `--effort` axes; embed any profile flags in the raw command itself under [`bin/fm-spawn.sh`'s header contract](../bin/fm-spawn.sh).
 Remote secondmate routes accept verified harness adapters only and reject raw launch commands.
 When `config/crew-dispatch.json` exists, crewmate and scout spawns require an explicit resolved harness instead of automatically falling back to `config/crew-harness`.
 The inherited-local-material contract is owned by [`secondmate-provisioning`](../.agents/skills/secondmate-provisioning/SKILL.md); its harness-relevant consequence is that a secondmate's own crewmates use the primary's dispatch profiles and static harness value.
@@ -235,6 +237,9 @@ Kimi continues to use the captain's normal Kimi home, including the existing con
 The Kimi installer requires an existing regular non-symlink `~/.kimi-code/config.toml`, `python3` with `tomllib`, and `jq`; it validates but never serializes the captain's TOML and refuses before writing when the config is missing, malformed, or surprising or when either tool requirement is unavailable.
 Its `remove` action excises only the marker-delimited Firstmate region and removes Firstmate's hook files.
 For Pi and pi-signed secondmate launches, `fm-spawn.sh` starts the selected executable with `-e` pointed at the secondmate home's own tracked `.pi/extensions/fm-primary-pi-watch.ts` and `.pi/extensions/fm-primary-turnend-guard.ts`, both already present from the secondmate home's git worktree.
+The [Launch profile axes](../.agents/skills/harness-adapters/SKILL.md#launch-profile-axes) table owns each harness's accepted effort set and the fail-safe behavior when a valid shared effort cannot be carried.
+Such an omission warns on stderr instead of disappearing silently, and requested versus delivered values remain distinguishable in task metadata.
+`bin/fm-spawn.sh`'s header owns exact diagnostics and raw-command mechanics.
 
 ## Crew dispatch profiles (config/crew-dispatch.json)
 
@@ -270,7 +275,7 @@ Profile `model` and `effort` fields and rule `why` are optional.
 An omitted model or effort means the selected harness uses its own default for that axis.
 Every profile array is an implicit quota-aware choice resolved through `quota-array-dispatch`.
 If no dispatch rule fits, firstmate resolves `default` through the same object-or-array path before falling back to `config/crew-harness`.
-If a selected profile carries an effort value the chosen harness does not accept, `fm-spawn.sh` records the requested `effort=` in task meta for traceability but omits the launch flag, and bootstrap reports the invalid harness/effort pair as a `CREW_DISPATCH` diagnostic when it is visible in the file.
+Bootstrap rejects a crew-dispatch profile whose effort value is outside the chosen harness's accepted set before dispatch; the "Harness support" section above owns the launch-time behavior for explicit flags and secondmate pins.
 See [`docs/examples/crew-dispatch.json`](examples/crew-dispatch.json) for a starting point to copy into local `config/crew-dispatch.json`.
 When the file exists, bootstrap validates it with `jq`.
 Valid files stay silent by default; with `FM_BOOTSTRAP_VERBOSE_FACTS=1`, bootstrap emits `BOOTSTRAP_INFO: crew dispatch active config/crew-dispatch.json`, one `BOOTSTRAP_INFO:` fact per rule, and one fact for the optional default profile set.
@@ -314,7 +319,7 @@ Local routes use direct guarded filesystem operations, while remote routes deleg
 It emits `SECONDMATE_SYNC:` only when a home was skipped for an actionable sync reason, inheritance failed, or a divergent shared captain-preference copy was quarantined.
 When a running home advances and its loaded instruction surface (`AGENTS.md`, `bin/`, or `.agents/skills/`) changed, bootstrap sends the re-read nudge itself through the stable `fm-<id>` selector and reports the exact completed send as `BOOTSTRAP_INFO:`.
 If that send fails, bootstrap keeps an idempotent retry marker and emits `NUDGE_SECONDMATES:` with the failure reason.
-The same bootstrap run emits `SECONDMATE_LIVENESS:` only when a registered secondmate is skipped or its relaunch fails; already-live and successfully relaunched secondmates are handled silently.
+The same bootstrap run emits `SECONDMATE_LIVENESS:` only when a registered secondmate is skipped or its relaunch fails; already-live and successful relaunches produce no liveness line, while any launch-profile omission remains a stderr diagnostic under [`fm-bootstrap.sh`'s output contract](../bin/fm-bootstrap.sh).
 For a mid-session inherited local-material edit where tracked-file sync is not needed, run `bin/fm-config-push.sh`.
 It uses the same live secondmate discovery and propagation helper as bootstrap, prints each live home's `crew-dispatch.json`, `crew-harness`, `backlog-backend`, `backend`, `herdr-presentation-spaces`, `startup-memory-budget`, `trace-context`, and `data/captain-shared.md` result as `pushed`, `unchanged`, `skipped`, or `error`, and exits non-zero for real propagation errors or config-reread send failures.
 When an allowlisted config item changes for an already-running local home, it sends the literal-content reread pointer described in [`secondmate-provisioning`](../.agents/skills/secondmate-provisioning/SKILL.md); unchanged allowlisted config sends no pointer unless a previous delivery is pending.

--- a/docs/remote-secondmates.md
+++ b/docs/remote-secondmates.md
@@ -143,11 +143,15 @@ The primary resolves the verified secondmate harness and optional model and effo
 All remote secondmates on one host share `fm-remote` and retain separate `2ndmate-<id>` workspaces inside it.
 An explicit request for any other backend is refused rather than honored, and the remote host refuses one too.
 An existing remote endpoint recorded in another Herdr session, including `default`, is classified as unverified and left untouched; launch, liveness recovery, control, and retirement refuse it until an operator explicitly migrates it instead of attempting a live cutover.
+A live endpoint is reused only when its endpoint record proves both the requested and delivered model and effort.
+An older live endpoint without that proof is unverified and remains untouched by ordinary launch and control, while guarded teardown remains available; after the endpoint is dead or missing, normal recovery relaunches it with fresh proof.
+If a current launch names a model or effort that differs from the live endpoint's recorded request, it refuses without restarting the endpoint or rewriting either metadata record.
 A launch after a host has drifted out of readiness fails with the doctor's own gap text instead of leaving a half-created endpoint.
 Raw launch commands are not accepted for remote secondmates.
 Backends that already refuse secondmate launch, currently Orca and cmux, remain unsupported on the remote host.
 
 Startup liveness recovery relaunches a dead or missing remote second mate through this same command, so recovery passes the same readiness gate rather than a weaker one.
+The unsupported-axis warning owned by [Harness support](configuration.md#harness-support) remains on stderr through both remote launch and startup recovery.
 
 Send routed requests normally:
 

--- a/tests/fm-bootstrap.test.sh
+++ b/tests/fm-bootstrap.test.sh
@@ -923,7 +923,7 @@ test_crew_dispatch_validation() {
   done <<'ROWS'
 malformed dispatch config is flagged^{"rules":[^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - malformed JSON
 unverified dispatch harness is flagged^{"rules":[{"when":"anything","use":{"harness":"spaceship"}}],"default":{"harness":"codex"}}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - unverified harness: spaceship
-unsupported codex max effort is flagged^{"rules":[{"when":"big feature","use":{"harness":"codex","model":"gpt-5","effort":"max"}}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - invalid effort: codex:max
+codex max effort is accepted^{"rules":[{"when":"big feature","use":{"harness":"codex","model":"gpt-5","effort":"max"}}]}^empty^
 unsupported grok max effort is flagged^{"rules":[{"when":"deep current work","use":{"harness":"grok","model":"grok-4","effort":"max"}}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - invalid effort: grok:max
 unsupported grok xhigh effort is flagged^{"rules":[{"when":"deep current work","use":{"harness":"grok","model":"grok-4","effort":"xhigh"}}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - invalid effort: grok:xhigh
 pi max effort is accepted^{"rules":[{"when":"deep coding","use":{"harness":"pi","model":"openai-codex/gpt-5.6-sol","effort":"max"}}]}^empty^
@@ -940,7 +940,7 @@ empty array use is flagged^{"rules":[{"when":"big feature","use":[]}]}^exact^CRE
 array profile without harness is flagged^{"rules":[{"when":"big feature","use":[{"model":"gpt-5.5"}]}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - each use profile needs harness
 array profile with malformed model is flagged^{"rules":[{"when":"big feature","use":[{"harness":"codex","model":5}]}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - use profile model and effort must be non-empty strings when present
 unknown select is flagged^{"rules":[{"when":"big feature","use":[{"harness":"claude"},{"harness":"codex"}],"select":"mystery"}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - unknown select: mystery
-array profile unsupported effort is flagged^{"rules":[{"when":"big feature","use":[{"harness":"codex","effort":"max"}]}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - invalid effort: codex:max
+array profile codex max effort is accepted^{"rules":[{"when":"big feature","use":[{"harness":"codex","effort":"max"}]}]}^empty^
 empty default array is flagged^{"default":[]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - default needs at least one profile
 non-object default array entry is flagged^{"default":["codex"]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - each default profile must be an object
 default array profile without harness is flagged^{"default":[{"model":"gpt-5.5"}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - each default profile needs harness

--- a/tests/fm-kimi-harness.test.sh
+++ b/tests/fm-kimi-harness.test.sh
@@ -190,6 +190,8 @@ test_kimi_launch_then_send_is_verified() {
   rc=$?
   expect_code 0 "$rc" "verified kimi launch-then-send should succeed"
   assert_contains "$out" "spawned $id harness=kimi" "kimi spawn did not report success"
+  assert_contains "$out" "warning: harness 'kimi' cannot thread requested effort 'high'; accepted effort values: no supported values; omitting effort flag" \
+    "kimi effort-axis omission was silent"
 
   launch=$(cat "$CASE_DIR/launch.log")
   [ "$launch" = "'$FAKEBIN_DIR/kimi' --model 'kimi-code/k3' --auto" ] \

--- a/tests/fm-remote-secondmate-lifecycle-e2e.test.sh
+++ b/tests/fm-remote-secondmate-lifecycle-e2e.test.sh
@@ -601,8 +601,31 @@ cmp -s "$TMP_ROOT/parent-ios-before-legacy-profile.meta" "$PARENT/state/ios.meta
 launches_after_legacy_profile=$(grep -c '^tab create' "$HERDR_LOG" || true)
 [ "$launches_before_legacy_profile" -eq "$launches_after_legacy_profile" ] \
   || fail "pre-fix live Codex max refusal restarted the endpoint"
-mv -f "$TMP_ROOT/remote-ios-proven-profile.meta" "$remote_route_meta"
 pass "live pre-fix Codex max metadata is rejected without restart or republication"
+
+reset_remote_herdr_fixture "$HERDR_STATE"
+legacy_dead_profile_state=$(remote_env "$ROOT/bin/fm-on.sh" ios fm-remote-secondmate-control.sh state ios \
+  2> "$TMP_ROOT/legacy-dead-profile-state.err")
+[ "$legacy_dead_profile_state" = missing ] \
+  || fail "dead pre-upgrade endpoint was masked as $legacy_dead_profile_state instead of missing"
+[ ! -s "$TMP_ROOT/legacy-dead-profile-state.err" ] \
+  || fail "dead pre-upgrade endpoint emitted a profile-proof refusal"
+launches_before_legacy_recovery=$(grep -c '^tab create' "$HERDR_LOG" || true)
+if ! legacy_recovery_out=$(remote_env "$ROOT/bin/fm-spawn.sh" ios --secondmate --effort high \
+  2> "$TMP_ROOT/legacy-profile-recovery.err"); then
+  fail "dead pre-upgrade endpoint did not recover"$'\n'"$(cat "$TMP_ROOT/legacy-profile-recovery.err")"
+fi
+assert_contains "$legacy_recovery_out" 'harness=codex' "dead pre-upgrade recovery did not relaunch Codex"
+launches_after_legacy_recovery=$(grep -c '^tab create' "$HERDR_LOG" || true)
+[ "$launches_after_legacy_recovery" -eq $((launches_before_legacy_recovery + 1)) ] \
+  || fail "dead pre-upgrade recovery did not perform exactly one relaunch"
+assert_grep 'profile_delivery=fm-spawn.v1' "$remote_route_meta" \
+  "dead pre-upgrade recovery did not publish fresh profile provenance"
+assert_grep 'delivered_effort=high' "$remote_route_meta" \
+  "dead pre-upgrade recovery did not record its delivered effort"
+[ "$(remote_env "$ROOT/bin/fm-on.sh" ios fm-remote-secondmate-control.sh state ios)" = alive ] \
+  || fail "dead pre-upgrade recovery did not produce a live proven endpoint"
+pass "dead pre-upgrade endpoints recover with fresh delivered-profile provenance"
 
 if [ "${FM_TEST_PROFILE_ONLY:-0}" = 1 ]; then
   echo "ALL PROFILE TESTS PASSED"
@@ -1073,6 +1096,17 @@ if ! wait "$spawn_retirement_pid"; then
   printf 'serialized respawn output:\n%s\n' "$(cat "$TMP_ROOT/spawn-retirement.out")" >&2
   fail "serialized remote respawn failed"
 fi
+[ "$(remote_env "$ROOT/bin/fm-on.sh" ios fm-remote-secondmate-control.sh state ios)" = alive ] \
+  || fail "retirement fixture did not produce a live endpoint"
+awk '
+  /^profile_delivery=/ || /^delivered_model=/ || /^delivered_effort=/ { next }
+  { print }
+' "$remote_route_meta" > "$TMP_ROOT/remote-ios-live-legacy-retire.meta"
+mv -f "$TMP_ROOT/remote-ios-live-legacy-retire.meta" "$remote_route_meta"
+legacy_retire_state=$(remote_env "$ROOT/bin/fm-on.sh" ios fm-remote-secondmate-control.sh state ios \
+  2> "$TMP_ROOT/legacy-retire-state.err")
+[ "$legacy_retire_state" = unverified ] \
+  || fail "live pre-upgrade retirement fixture was not classified unverified"
 sleep 0.2
 kill -0 "$teardown_pid" 2>/dev/null || fail "remote retirement bypassed an active backlog handoff"
 touch "$TMP_ROOT/handoff.release"
@@ -1091,6 +1125,7 @@ jq -e --arg workspace "$SIBLING_WORKSPACE" --arg pane "$SIBLING_PANE" '
   || fail "remote retirement removed the sibling secondmate workspace or pane from fm-remote"
 assert_no_grep 'session stop' "$HERDR_LOG" "remote retirement stopped the shared fm-remote session"
 assert_no_grep 'server stop' "$HERDR_LOG" "remote retirement stopped the shared fm-remote server"
+pass "live pre-upgrade endpoint retires through the documented teardown path"
 pass "remote retirement refuses child work, then removes only its own endpoint while a shared-session sibling survives"
 
 echo "ALL TESTS PASSED"

--- a/tests/fm-remote-secondmate-lifecycle-e2e.test.sh
+++ b/tests/fm-remote-secondmate-lifecycle-e2e.test.sh
@@ -518,6 +518,8 @@ assert_no_grep '--session default' "$HERDR_LOG" "remote launch targeted the inte
 assert_grep 'window=remote:ios' "$PARENT/state/ios.meta" "parent metadata pretended the endpoint was local"
 assert_grep 'effort=high' "$PARENT/state/ios.meta" "parent metadata omitted the delivered remote effort"
 assert_grep 'effort=high' "$REMOTE_HOME/state/parent-route/ios.meta" "remote route metadata omitted the delivered effort"
+assert_grep 'profile_delivery=fm-spawn.v1' "$REMOTE_HOME/state/parent-route/ios.meta" "remote route metadata omitted delivered-profile provenance"
+assert_grep 'delivered_effort=high' "$REMOTE_HOME/state/parent-route/ios.meta" "remote route metadata omitted the verified delivered effort"
 assert_present "$PARENT/state/procevent/remote-reply-ios.source" "remote spawn did not arm its reply source"
 publish_healthy_watcher_identity "$PARENT/state" "$PARENT" "$ROOT/bin/fm-watch.sh"
 [ "$(remote_env "$ROOT/bin/fm-on.sh" ios fm-remote-secondmate-control.sh state ios)" = alive ] \
@@ -558,6 +560,10 @@ assert_not_contains "$BOOT_PROFILE_WARNING" "cannot thread requested effort" \
   "successful remote startup relaunch moved the effort warning onto stdout"
 assert_grep 'harness=opencode' "$PARENT/state/ios.meta" "warning-path relaunch did not publish the remote harness"
 assert_grep 'harness=opencode' "$REMOTE_HOME/state/parent-route/ios.meta" "warning-path relaunch did not publish endpoint metadata"
+grep -qxF 'effort=' "$PARENT/state/ios.meta" \
+  || fail "warning-path parent metadata published the omitted effort as delivered"
+assert_grep 'effort=high' "$REMOTE_HOME/state/parent-route/ios.meta" "warning-path endpoint lost the requested effort trace"
+assert_grep 'delivered_effort=default' "$REMOTE_HOME/state/parent-route/ios.meta" "warning-path endpoint did not distinguish the omitted effort from its delivered default"
 pass "remote and startup relaunch wrappers preserve successful effort diagnostics on stderr"
 publish_healthy_watcher_identity "$PARENT/state" "$PARENT" "$ROOT/bin/fm-watch.sh"
 
@@ -568,12 +574,41 @@ restore_rc=$?
 [ "$restore_rc" -eq 0 ] || fail "remote profile restore failed"$'\n'"$(cat "$TMP_ROOT/spawn-profile-restore.err")"
 assert_contains "$restore_out" 'harness=codex' "remote profile restore did not relaunch codex"
 assert_grep 'effort=high' "$PARENT/state/ios.meta" "remote profile restore lost the delivered effort"
+
+remote_route_meta="$REMOTE_HOME/state/parent-route/ios.meta"
+cp "$remote_route_meta" "$TMP_ROOT/remote-ios-proven-profile.meta"
+cp "$PARENT/state/ios.meta" "$TMP_ROOT/parent-ios-before-legacy-profile.meta"
+awk '
+  /^profile_delivery=/ || /^delivered_model=/ || /^delivered_effort=/ { next }
+  /^effort=/ { print "effort=max"; next }
+  { print }
+' "$TMP_ROOT/remote-ios-proven-profile.meta" > "$remote_route_meta"
+cp "$remote_route_meta" "$TMP_ROOT/remote-ios-legacy-max.meta"
+legacy_profile_state=$(remote_env "$ROOT/bin/fm-on.sh" ios fm-remote-secondmate-control.sh state ios \
+  2> "$TMP_ROOT/legacy-profile-state.err")
+[ "$legacy_profile_state" = unverified ] || fail "pre-fix live Codex max metadata was not classified unverified"
+launches_before_legacy_profile=$(grep -c '^tab create' "$HERDR_LOG" || true)
+if remote_env "$ROOT/bin/fm-spawn.sh" ios --secondmate --effort max \
+  > "$TMP_ROOT/legacy-profile-spawn.out" 2> "$TMP_ROOT/legacy-profile-spawn.err"; then
+  fail "pre-fix live Codex max metadata was accepted as delivered"
+fi
+assert_grep 'delivered profile is unproven' "$TMP_ROOT/legacy-profile-spawn.err" \
+  "pre-fix live Codex max refusal did not identify missing delivery provenance"
+cmp -s "$TMP_ROOT/remote-ios-legacy-max.meta" "$remote_route_meta" \
+  || fail "pre-fix live Codex max refusal rewrote endpoint metadata"
+cmp -s "$TMP_ROOT/parent-ios-before-legacy-profile.meta" "$PARENT/state/ios.meta" \
+  || fail "pre-fix live Codex max refusal rewrote parent metadata"
+launches_after_legacy_profile=$(grep -c '^tab create' "$HERDR_LOG" || true)
+[ "$launches_before_legacy_profile" -eq "$launches_after_legacy_profile" ] \
+  || fail "pre-fix live Codex max refusal restarted the endpoint"
+mv -f "$TMP_ROOT/remote-ios-proven-profile.meta" "$remote_route_meta"
+pass "live pre-fix Codex max metadata is rejected without restart or republication"
+
 if [ "${FM_TEST_PROFILE_ONLY:-0}" = 1 ]; then
   echo "ALL PROFILE TESTS PASSED"
   exit 0
 fi
 
-remote_route_meta="$REMOTE_HOME/state/parent-route/ios.meta"
 cp "$remote_route_meta" "$TMP_ROOT/remote-ios-before-default-session.meta"
 legacy_pane=$(sed -n 's/^herdr_pane_id=//p' "$remote_route_meta")
 awk -v pane="$legacy_pane" '

--- a/tests/fm-remote-secondmate-lifecycle-e2e.test.sh
+++ b/tests/fm-remote-secondmate-lifecycle-e2e.test.sh
@@ -831,11 +831,11 @@ FM_FAKE_SSH_MODE=inherit-block remote_env "$ROOT/bin/fm-config-push.sh" \
   > "$TMP_ROOT/config-concurrent-first.out" 2>&1 &
 config_first=$!
 inherit_wait=0
+# Earlier inherited files traverse the worker before captain-shared.md, so give
+# a loaded portable runner 30 seconds to reach this deliberately blocked write.
 while [ ! -f "$TMP_ROOT/inherit.entered" ]; do
   kill -0 "$config_first" 2>/dev/null || fail "first inheritance transaction exited before its blocked write"
   inherit_wait=$((inherit_wait + 1))
-  # Match the earlier spawn/inheritance wait: a loaded portable runner can
-  # spend several seconds in the remote entrypoint before reaching this write.
   [ "$inherit_wait" -le 1500 ] || fail "first inheritance transaction never reached its blocked write"
   sleep 0.02
 done

--- a/tests/fm-remote-secondmate-lifecycle-e2e.test.sh
+++ b/tests/fm-remote-secondmate-lifecycle-e2e.test.sh
@@ -506,7 +506,7 @@ launches_after_inherit=0
 [ "$launches_before_inherit" -eq "$launches_after_inherit" ] \
   || fail "remote spawn reached launch after ambiguous partial inheritance"
 assert_absent "$PARENT/state/ios.meta" "failed remote inheritance published launch metadata"
-out=$(remote_env "$ROOT/bin/fm-spawn.sh" ios --secondmate)
+out=$(remote_env "$ROOT/bin/fm-spawn.sh" ios --secondmate --effort high)
 assert_contains "$out" 'remote=remote-mac backend=herdr' "remote spawn did not report separate host and backend dimensions"
 assert_grep 'remote_host=remote-mac' "$PARENT/state/ios.meta" "parent metadata omitted the remote host"
 assert_grep 'remote_backend=herdr' "$PARENT/state/ios.meta" "parent metadata omitted the remote-local backend"
@@ -516,6 +516,8 @@ assert_grep 'herdr_session=fm-remote' "$REMOTE_HOME/state/parent-route/ios.meta"
 assert_grep '--session fm-remote' "$HERDR_LOG" "remote launch did not target the fm-remote session"
 assert_no_grep '--session default' "$HERDR_LOG" "remote launch targeted the interactive default session"
 assert_grep 'window=remote:ios' "$PARENT/state/ios.meta" "parent metadata pretended the endpoint was local"
+assert_grep 'effort=high' "$PARENT/state/ios.meta" "parent metadata omitted the delivered remote effort"
+assert_grep 'effort=high' "$REMOTE_HOME/state/parent-route/ios.meta" "remote route metadata omitted the delivered effort"
 assert_present "$PARENT/state/procevent/remote-reply-ios.source" "remote spawn did not arm its reply source"
 publish_healthy_watcher_identity "$PARENT/state" "$PARENT" "$ROOT/bin/fm-watch.sh"
 [ "$(remote_env "$ROOT/bin/fm-on.sh" ios fm-remote-secondmate-control.sh state ios)" = alive ] \
@@ -525,6 +527,51 @@ publish_healthy_watcher_identity "$PARENT/state" "$PARENT" "$ROOT/bin/fm-watch.s
 [ "$(remote_env "$ROOT/bin/fm-on.sh" ios fm-remote-secondmate-control.sh observe ios)" = idle ] \
   || fail "remote endpoint delivery observation did not execute on its own host"
 pass "remote spawn launches on the remote-local backend and records a host-qualified route"
+
+cp "$PARENT/state/ios.meta" "$TMP_ROOT/parent-ios-before-effort-mismatch.meta"
+cp "$REMOTE_HOME/state/parent-route/ios.meta" "$TMP_ROOT/remote-ios-before-effort-mismatch.meta"
+launches_before_effort_mismatch=$(grep -c '^tab create' "$HERDR_LOG" || true)
+remote_env "$ROOT/bin/fm-spawn.sh" ios --secondmate --effort max \
+  > "$TMP_ROOT/spawn-effort-mismatch.out" 2> "$TMP_ROOT/spawn-effort-mismatch.err"
+effort_mismatch_rc=$?
+[ "$effort_mismatch_rc" -ne 0 ] || fail "live remote endpoint accepted an undelivered effort change"
+assert_grep "remote secondmate ios is already live with effort 'high', not requested effort 'max'; live endpoint was not restarted" \
+  "$TMP_ROOT/spawn-effort-mismatch.err" "live remote effort mismatch did not name actual and requested values"
+cmp -s "$TMP_ROOT/parent-ios-before-effort-mismatch.meta" "$PARENT/state/ios.meta" \
+  || fail "live remote effort mismatch rewrote parent metadata"
+cmp -s "$TMP_ROOT/remote-ios-before-effort-mismatch.meta" "$REMOTE_HOME/state/parent-route/ios.meta" \
+  || fail "live remote effort mismatch rewrote endpoint metadata"
+launches_after_effort_mismatch=$(grep -c '^tab create' "$HERDR_LOG" || true)
+[ "$launches_before_effort_mismatch" -eq "$launches_after_effort_mismatch" ] \
+  || fail "live remote effort mismatch restarted the endpoint"
+pass "live remote reuse rejects profile drift without restart or metadata divergence"
+
+printf 'opencode default high\n' > "$PARENT/config/secondmate-harness"
+reset_remote_herdr_fixture "$HERDR_STATE"
+rm -rf -- "$PARENT/state/.watch.lock"
+rm -f -- "$PARENT/state/.last-watcher-beat"
+BOOT_PROFILE_WARNING=$(FM_FLEET_SYNC_BOOTSTRAP_TIMEOUT=1 remote_env \
+  "$ROOT/bin/fm-bootstrap.sh" 2> "$TMP_ROOT/bootstrap-profile-warning.err")
+assert_grep "warning: harness 'opencode' cannot thread requested effort 'high'; accepted effort values: no supported values; omitting effort flag" \
+  "$TMP_ROOT/bootstrap-profile-warning.err" "successful remote startup relaunch swallowed the effort warning"
+assert_not_contains "$BOOT_PROFILE_WARNING" "cannot thread requested effort" \
+  "successful remote startup relaunch moved the effort warning onto stdout"
+assert_grep 'harness=opencode' "$PARENT/state/ios.meta" "warning-path relaunch did not publish the remote harness"
+assert_grep 'harness=opencode' "$REMOTE_HOME/state/parent-route/ios.meta" "warning-path relaunch did not publish endpoint metadata"
+pass "remote and startup relaunch wrappers preserve successful effort diagnostics on stderr"
+publish_healthy_watcher_identity "$PARENT/state" "$PARENT" "$ROOT/bin/fm-watch.sh"
+
+printf 'codex default high\n' > "$PARENT/config/secondmate-harness"
+reset_remote_herdr_fixture "$HERDR_STATE"
+restore_out=$(remote_env "$ROOT/bin/fm-spawn.sh" ios --secondmate 2> "$TMP_ROOT/spawn-profile-restore.err")
+restore_rc=$?
+[ "$restore_rc" -eq 0 ] || fail "remote profile restore failed"$'\n'"$(cat "$TMP_ROOT/spawn-profile-restore.err")"
+assert_contains "$restore_out" 'harness=codex' "remote profile restore did not relaunch codex"
+assert_grep 'effort=high' "$PARENT/state/ios.meta" "remote profile restore lost the delivered effort"
+if [ "${FM_TEST_PROFILE_ONLY:-0}" = 1 ]; then
+  echo "ALL PROFILE TESTS PASSED"
+  exit 0
+fi
 
 remote_route_meta="$REMOTE_HOME/state/parent-route/ios.meta"
 cp "$remote_route_meta" "$TMP_ROOT/remote-ios-before-default-session.meta"

--- a/tests/fm-session-start.test.sh
+++ b/tests/fm-session-start.test.sh
@@ -842,7 +842,7 @@ EOF
 }
 
 test_herdr_backend_diagnostics_follow_real_session_start() {
-  local mode rec root home fakebin mask out
+  local mode rec root home fakebin mask out err
   for mode in configured autodetected; do
     rec=$(new_world "herdr-$mode")
     IFS='|' read -r root home fakebin <<EOF
@@ -862,15 +862,20 @@ command() {
   builtin command "$@"
 }
 SH
+    err="$home/session-start.err"
     if [ "$mode" = configured ]; then
       printf '%s\n' herdr > "$home/config/backend"
-      out=$(TMUX='' HERDR_ENV='' BASH_ENV="$mask" run_session_start "$home" "$root" "$fakebin:$BASE_PATH")
+      out=$(TMUX='' HERDR_ENV='' BASH_ENV="$mask" run_session_start "$home" "$root" "$fakebin:$BASE_PATH" 2> "$err")
       assert_not_contains "$out" "NOTICE: auto-detected herdr runtime" \
         "an explicit Herdr home should not be reported as auto-detected"
+      assert_no_grep "NOTICE: auto-detected herdr runtime" "$err" \
+        "an explicit Herdr home reported auto-detection on stderr"
     else
-      out=$(TMUX='' HERDR_ENV=1 BASH_ENV="$mask" run_session_start "$home" "$root" "$fakebin:$BASE_PATH")
-      assert_contains "$out" "NOTICE: auto-detected herdr runtime (HERDR_ENV=1)" \
-        "session start did not preserve the Herdr runtime auto-detection fallback"
+      out=$(TMUX='' HERDR_ENV=1 BASH_ENV="$mask" run_session_start "$home" "$root" "$fakebin:$BASE_PATH" 2> "$err")
+      assert_grep "NOTICE: auto-detected herdr runtime (HERDR_ENV=1)" "$err" \
+        "session start did not preserve the Herdr runtime auto-detection fallback on stderr"
+      assert_not_contains "$out" "NOTICE: auto-detected herdr runtime" \
+        "session start moved the Herdr runtime auto-detection notice onto stdout"
     fi
     assert_contains "$out" "SESSION START - $home" "the real session-start path did not run in the throwaway home"
     assert_not_contains "$out" "MISSING: tmux" "Herdr session start falsely required masked tmux"
@@ -968,6 +973,27 @@ EOF
   [ "$first_calls" -eq 1 ] && [ "$second_calls" -eq 1 ] \
     || fail "a second session-start pass duplicated the relaunched Pi secondmate: $(cat "$log")"
   pass "session start: an absent recorded tmux window relaunches its Pi secondmate exactly once"
+}
+
+test_session_start_preserves_bootstrap_profile_warning_stderr() {
+  local rec root home fakebin mate log spawned out err
+  rec=$(prepare_session_start_secondmate secondmate-profile-warning)
+  IFS='|' read -r root home fakebin mate log spawned <<EOF
+$rec
+EOF
+  printf '%s\n' 'opencode default high' > "$home/config/secondmate-harness"
+  err="${root%/root}/session-start.err"
+
+  out=$(run_session_start_secondmate "$root" "$home" "$fakebin" "$mate" "$log" "$spawned" missing 2> "$err")
+
+  assert_grep "warning: harness 'opencode' cannot thread requested effort 'high'; accepted effort values: no supported values; omitting effort flag" \
+    "$err" "session start swallowed or rechanneled the bootstrap respawn effort warning"
+  assert_not_contains "$out" "cannot thread requested effort" \
+    "session start moved the bootstrap respawn effort warning onto stdout"
+  assert_grep 'harness=opencode' "$home/state/$SESSION_START_SECOND_MATE_ID.meta" \
+    "session-start warning regression did not exercise the real opencode respawn"
+
+  pass "session start preserves successful bootstrap profile diagnostics on stderr"
 }
 
 test_session_start_preserves_ambiguous_pi_process() {
@@ -1442,6 +1468,7 @@ test_session_lock_concurrent_single_winner
 test_output_ordering_diagnostics_lead
 test_herdr_backend_diagnostics_follow_real_session_start
 test_session_start_relaunches_missing_pi_secondmate
+test_session_start_preserves_bootstrap_profile_warning_stderr
 test_session_start_preserves_ambiguous_pi_process
 test_session_start_preserves_transiently_unreadable_tmux
 test_session_start_preserves_proven_bare_shell_recovery

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -432,6 +432,12 @@ test_codex_threads_max_effort() {
   status=$?
   expect_code 0 "$status" "codex spawn with max effort should succeed"
   assert_meta_profile "$HOME_DIR/state/$id.meta" codex gpt-5 max
+  assert_grep 'profile_delivery=fm-spawn.v1' "$HOME_DIR/state/$id.meta" \
+    "codex max metadata omitted delivered-profile provenance"
+  assert_grep 'delivered_model=gpt-5' "$HOME_DIR/state/$id.meta" \
+    "codex max metadata omitted the delivered model"
+  assert_grep 'delivered_effort=max' "$HOME_DIR/state/$id.meta" \
+    "codex max metadata omitted the delivered effort"
   launch=$(cat "$LAUNCH_LOG")
   assert_contains "$launch" "codex --model 'gpt-5' -c 'model_reasoning_effort=\"max\"' --dangerously-bypass-approvals-and-sandbox" \
     "codex launch dropped max reasoning effort while metadata recorded it"

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -368,7 +368,7 @@ test_active_dispatch_profile_allows_positional_harness() {
   pass "active crew-dispatch profile allows the legacy positional harness form"
 }
 
-test_active_dispatch_profile_allows_raw_launch_command() {
+test_raw_codex_refuses_unthreaded_effort() {
   local rec id out status launch stderr_log err
   id=profile-raw-z15
   rec=$(make_spawn_case profile-raw claude "$id")
@@ -377,18 +377,17 @@ test_active_dispatch_profile_allows_raw_launch_command() {
   stderr_log="$CASE_DIR/spawn.stderr"
 
   out=$(run_ship_spawn_with_stderr "$stderr_log" "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" \
-    "$id" "$PROJ_DIR" "custom-agent --flag" --effort high)
+    "$id" "$PROJ_DIR" "codex --custom-flag" --effort max)
   status=$?
-  expect_code 0 "$status" "raw launch command should satisfy active dispatch-profile requirement"
-  assert_contains "$out" "spawned $id harness=custom-agent" "spawn did not report raw command harness"
-  assert_meta_profile "$HOME_DIR/state/$id.meta" custom-agent default high
+  expect_code 1 "$status" "raw codex launch with a separate effort axis should be refused"
+  assert_absent "$HOME_DIR/state/$id.meta" "raw codex refusal published requested effort as delivered metadata"
   launch=$(cat "$LAUNCH_LOG")
-  [ "$launch" = "custom-agent --flag" ] || fail "raw launch command changed"$'\n'"actual: $launch"
+  [ -z "$launch" ] || fail "raw codex refusal still launched"$'\n'"actual: $launch"
   err=$(cat "$stderr_log")
-  assert_contains "$err" "warning: harness 'custom-agent' cannot thread requested effort 'high'; accepted effort values through fm-spawn: no supported values; raw launch commands must carry their own effort flags" \
-    "raw launch effort omission was not reported on stderr"
+  assert_contains "$err" "error: raw launch harness 'codex' cannot thread requested effort 'max'; accepted effort values through fm-spawn raw commands: no supported values; put the effort flag in the raw command instead" \
+    "raw codex refusal did not diagnose the unthreaded effort on stderr"
   assert_not_contains "$out" "cannot thread requested effort" "raw launch effort warning leaked onto stdout"
-  pass "raw launch commands stay unchanged and warn on stderr about unthreaded effort"
+  pass "raw codex commands refuse separate effort axes before launch or metadata publication"
 }
 
 test_claude_threads_model_and_effort() {
@@ -718,7 +717,7 @@ test_active_dispatch_profile_requires_explicit_harness_for_ship
 test_active_dispatch_profile_requires_explicit_harness_for_scout
 test_active_dispatch_profile_allows_explicit_harness
 test_active_dispatch_profile_allows_positional_harness
-test_active_dispatch_profile_allows_raw_launch_command
+test_raw_codex_refuses_unthreaded_effort
 test_claude_threads_model_and_effort
 test_codex_threads_model_and_effort
 test_codex_threads_max_effort

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -80,10 +80,9 @@ make_seeded_secondmate_home() {
   printf 'charter for %s\n' "$id" > "$home/data/charter.md"
 }
 
-run_spawn() {
+invoke_spawn() {
   local home=$1 wt=$2 fakebin=$3 launchlog=$4
   shift 4
-  : > "$launchlog"
   # CLAUDE_CONFIG_DIR is forwarded onto claude launches by fm-spawn, so pin it
   # explicitly (empty by default) instead of leaking the invoking shell's value,
   # which would make launch assertions depend on the developer's environment.
@@ -94,13 +93,34 @@ run_spawn() {
     FM_SPAWN_NO_GUARD=1 FM_FAKE_PANE_PATH="$wt" TMUX="fake,1,0" \
     CLAUDE_CONFIG_DIR="${FM_TEST_CLAUDE_CONFIG_DIR:-}" \
     FM_FAKE_LAUNCH_LOG="$launchlog" GROK_HOME="$home/grok-home" PATH="$fakebin:$PATH" \
-    "$SPAWN" "$@" 2>&1
+    "$SPAWN" "$@"
+}
+
+run_spawn() {
+  local launchlog=$4
+  : > "$launchlog"
+  invoke_spawn "$@" 2>&1
+}
+
+run_spawn_with_stderr() {
+  local stderr_log=$1 launchlog
+  shift
+  launchlog=$4
+  : > "$launchlog"
+  : > "$stderr_log"
+  invoke_spawn "$@" 2>"$stderr_log"
 }
 
 # Ship spawns carry an explicit delivery contract (AGENTS.md section 7); these
 # tests are about profile resolution, so they pass a fixed valid one.
 run_ship_spawn() {
   run_spawn "$@" --mode no-mistakes --yolo off
+}
+
+run_ship_spawn_with_stderr() {
+  local stderr_log=$1
+  shift
+  run_spawn_with_stderr "$stderr_log" "$@" --mode no-mistakes --yolo off
 }
 
 read_case_record() {
@@ -349,21 +369,26 @@ test_active_dispatch_profile_allows_positional_harness() {
 }
 
 test_active_dispatch_profile_allows_raw_launch_command() {
-  local rec id out status launch
+  local rec id out status launch stderr_log err
   id=profile-raw-z15
   rec=$(make_spawn_case profile-raw claude "$id")
   read_case_record "$rec"
   enable_dispatch_profile "$HOME_DIR"
+  stderr_log="$CASE_DIR/spawn.stderr"
 
-  out=$(run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" \
-    "$id" "$PROJ_DIR" "custom-agent --flag")
+  out=$(run_ship_spawn_with_stderr "$stderr_log" "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" \
+    "$id" "$PROJ_DIR" "custom-agent --flag" --effort high)
   status=$?
   expect_code 0 "$status" "raw launch command should satisfy active dispatch-profile requirement"
   assert_contains "$out" "spawned $id harness=custom-agent" "spawn did not report raw command harness"
-  assert_meta_profile "$HOME_DIR/state/$id.meta" custom-agent default default
+  assert_meta_profile "$HOME_DIR/state/$id.meta" custom-agent default high
   launch=$(cat "$LAUNCH_LOG")
   [ "$launch" = "custom-agent --flag" ] || fail "raw launch command changed"$'\n'"actual: $launch"
-  pass "active crew-dispatch profile allows the raw launch-command escape hatch"
+  err=$(cat "$stderr_log")
+  assert_contains "$err" "warning: harness 'custom-agent' cannot thread requested effort 'high'; accepted effort values through fm-spawn: no supported values; raw launch commands must carry their own effort flags" \
+    "raw launch effort omission was not reported on stderr"
+  assert_not_contains "$out" "cannot thread requested effort" "raw launch effort warning leaked onto stdout"
+  pass "raw launch commands stay unchanged and warn on stderr about unthreaded effort"
 }
 
 test_claude_threads_model_and_effort() {
@@ -398,7 +423,7 @@ test_codex_threads_model_and_effort() {
   pass "codex receives --model and model_reasoning_effort profile flags"
 }
 
-test_codex_omits_invalid_max_effort() {
+test_codex_threads_max_effort() {
   local rec id out status launch
   id=profile-codex-max-z4
   rec=$(make_spawn_case profile-codex-max codex "$id")
@@ -406,13 +431,12 @@ test_codex_omits_invalid_max_effort() {
 
   out=$(run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR" --model gpt-5 --effort max)
   status=$?
-  expect_code 0 "$status" "codex spawn with unsupported max effort should omit the effort flag"
+  expect_code 0 "$status" "codex spawn with max effort should succeed"
   assert_meta_profile "$HOME_DIR/state/$id.meta" codex gpt-5 max
   launch=$(cat "$LAUNCH_LOG")
-  assert_contains "$launch" "codex --model 'gpt-5' --dangerously-bypass-approvals-and-sandbox" \
-    "codex launch did not preserve the model flag when max effort was omitted"
-  assert_not_contains "$launch" "model_reasoning_effort" "codex launch must omit unsupported max reasoning effort"
-  pass "codex omits unsupported max effort instead of passing a bad config value"
+  assert_contains "$launch" "codex --model 'gpt-5' -c 'model_reasoning_effort=\"max\"' --dangerously-bypass-approvals-and-sandbox" \
+    "codex launch dropped max reasoning effort while metadata recorded it"
+  pass "codex threads max reasoning effort so launch and metadata agree"
 }
 
 test_grok_threads_model_and_reasoning_effort() {
@@ -433,12 +457,13 @@ test_grok_threads_model_and_reasoning_effort() {
 }
 
 test_grok_omits_invalid_max_reasoning_effort() {
-  local rec id out status launch
+  local rec id out status launch stderr_log err
   id=profile-grok-max-z6
   rec=$(make_spawn_case profile-grok-max grok "$id")
   read_case_record "$rec"
+  stderr_log="$CASE_DIR/spawn.stderr"
 
-  out=$(run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR" --model grok-4 --effort max)
+  out=$(run_ship_spawn_with_stderr "$stderr_log" "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR" --model grok-4 --effort max)
   status=$?
   expect_code 0 "$status" "grok spawn with unsupported max reasoning effort should omit the effort flag"
   assert_meta_profile "$HOME_DIR/state/$id.meta" grok grok-4 max
@@ -447,7 +472,11 @@ test_grok_omits_invalid_max_reasoning_effort() {
     "grok launch did not preserve the model flag and typed brief when max effort was omitted"
   assert_not_contains "$launch" "--reasoning-effort" "grok launch must omit unsupported max reasoning effort"
   assert_not_contains "$launch" "--effort" "grok launch must not fall back to --effort for reasoning effort"
-  pass "grok omits unsupported max reasoning effort"
+  err=$(cat "$stderr_log")
+  assert_contains "$err" "warning: harness 'grok' cannot thread requested effort 'max'; accepted effort values: low, medium, high; omitting effort flag" \
+    "grok max-effort omission was not reported on stderr"
+  assert_not_contains "$out" "cannot thread requested effort" "grok max-effort warning leaked onto stdout"
+  pass "grok loudly omits unsupported max reasoning effort"
 }
 
 test_grok_omits_invalid_xhigh_reasoning_effort() {
@@ -466,16 +495,19 @@ test_grok_omits_invalid_xhigh_reasoning_effort() {
     "grok launch did not preserve the model flag and typed brief when xhigh effort was omitted"
   assert_not_contains "$launch" "--reasoning-effort" "grok launch must omit unsupported xhigh reasoning effort"
   assert_not_contains "$launch" "--effort" "grok launch must not fall back to --effort for reasoning effort"
-  pass "grok omits unsupported xhigh reasoning effort"
+  assert_contains "$out" "warning: harness 'grok' cannot thread requested effort 'xhigh'; accepted effort values: low, medium, high; omitting effort flag" \
+    "grok xhigh-effort omission was silent"
+  pass "grok loudly omits unsupported xhigh reasoning effort"
 }
 
-test_opencode_threads_model_and_ignores_effort_axis() {
-  local rec id out status launch
+test_opencode_threads_model_and_warns_for_ignored_effort_axis() {
+  local rec id out status launch stderr_log err
   id=profile-opencode-z7
   rec=$(make_spawn_case profile-opencode opencode "$id")
   read_case_record "$rec"
+  stderr_log="$CASE_DIR/spawn.stderr"
 
-  out=$(run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR" --model anthropic/claude-sonnet-4-5 --effort high)
+  out=$(run_ship_spawn_with_stderr "$stderr_log" "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR" --model anthropic/claude-sonnet-4-5 --effort high)
   status=$?
   expect_code 0 "$status" "opencode spawn with model and ignored effort should succeed"
   assert_meta_profile "$HOME_DIR/state/$id.meta" opencode anthropic/claude-sonnet-4-5 high
@@ -485,7 +517,11 @@ test_opencode_threads_model_and_ignores_effort_axis() {
   assert_not_contains "$launch" "--effort" "opencode launch must not pass unsupported --effort"
   assert_not_contains "$launch" "--variant" "opencode launch must not pass run-only --variant"
   assert_not_contains "$launch" "--thinking" "opencode launch must not pass pi thinking flag"
-  pass "opencode receives --model and omits the unsupported effort axis"
+  err=$(cat "$stderr_log")
+  assert_contains "$err" "warning: harness 'opencode' cannot thread requested effort 'high'; accepted effort values: no supported values; omitting effort flag" \
+    "opencode effort-axis omission was not reported on stderr"
+  assert_not_contains "$out" "cannot thread requested effort" "opencode effort warning leaked onto stdout"
+  pass "opencode receives --model and loudly omits the unsupported effort axis"
 }
 
 test_pi_threads_model_and_max_effort() {
@@ -685,11 +721,11 @@ test_active_dispatch_profile_allows_positional_harness
 test_active_dispatch_profile_allows_raw_launch_command
 test_claude_threads_model_and_effort
 test_codex_threads_model_and_effort
-test_codex_omits_invalid_max_effort
+test_codex_threads_max_effort
 test_grok_threads_model_and_reasoning_effort
 test_grok_omits_invalid_max_reasoning_effort
 test_grok_omits_invalid_xhigh_reasoning_effort
-test_opencode_threads_model_and_ignores_effort_axis
+test_opencode_threads_model_and_warns_for_ignored_effort_axis
 test_pi_threads_model_and_max_effort
 test_pi_signed_threads_shared_pi_profile_and_preserves_identity
 test_pi_signed_missing_binary_refuses_before_endpoint_or_metadata

--- a/tests/fm-trace-context-spawn.test.sh
+++ b/tests/fm-trace-context-spawn.test.sh
@@ -337,9 +337,13 @@ test_failed_metadata_append_unsets_carrier_and_still_launches() {
 
   ! grep -q '^traceparent=' "$meta" \
     || fail "failed metadata append must not leave a traceparent= claim in meta"
+  ! grep -Eq '^(profile_delivery|delivered_model|delivered_effort)=' "$meta" \
+    || fail "failed metadata append must not leave an unproven delivered-profile claim in meta"
   grep -q '^unset TRACEPARENT; .*claude' "$LAUNCH_LOG" \
     || fail "failed metadata append must unset TRACEPARENT in the launch command"
-  pass "failed traceparent metadata append removes the carrier from the launched task"
+  assert_contains "$out" "warning: delivered profile metadata could not be recorded for $CASE_ID; launch remains active without verified profile delivery" \
+    "failed delivered-profile metadata append must be diagnosed without aborting spawn"
+  pass "failed metadata appends remove the carrier, retain the launch, and leave profile delivery unverified"
 }
 
 test_duplicate_secondmate_spawn_does_not_converge_trace_context() {


### PR DESCRIPTION
## Intent

Fix the stale Codex capability guard so a captain-requested max reasoning effort is actually passed to codex-cli instead of being silently omitted while metadata records max. Codex CLI 0.146.0 was empirically verified on 2026-08-05 with gpt-5.6-terra and gpt-5.6-sol; add max to Firstmate shared low-through-max vocabulary while keeping none and minimal out of scope. Preserve fail-safe omission for genuinely unsupported harness effort levels, including existing Grok, OpenCode, and Kimi ceilings, but emit a loud stderr warning naming the harness, requested value, and accepted set. Ensure that warning provably reaches the caller through direct spawn, raw profile rejection, remote spawn/control, bootstrap respawn, and session-start paths. Update the dated harness-adapters evidence, every sibling Codex ceiling such as dispatch validation, and red-before-fix regressions for metadata-versus-launch divergence plus stderr diagnostics. Do not alter dispatch profiles, live task metadata, or existing Grok/OpenCode capability ceilings.

## What Changed

- Pass `max` reasoning effort to Codex and accept it in dispatch profiles, with updated capability documentation.
- Warn on stderr when verified adapters omit unsupported effort values, reject separate profile axes for raw commands, and record requested-versus-delivered profile metadata.
- Preserve diagnostics and profile proof through remote control, bootstrap respawns, and session start; guard remote endpoint reuse against missing or mismatched profiles and add regression coverage.

## Testing

- ⏭️ **Test** - skipped

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Rebase** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `AGENTS.md` - merge conflict rebasing onto origin/main

🔧 Fix applied.
✅ Re-checked - no issues remain.

</details>

<details>
<summary>⏭️ **Review** - skipped</summary>

Step was skipped.

</details>

<details>
<summary>⏭️ **Test** - skipped</summary>

Step was skipped.

</details>

<details>
<summary>⏭️ **Document** - skipped</summary>

Step was skipped.

</details>

<details>
<summary>⏭️ **Lint** - skipped</summary>

Step was skipped.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
