### PR TITLE
fix(bin): resolve symlinks before validating startup-memory config

### DIFF
--- a/bin/fm-startup-memory-budget-lib.sh
+++ b/bin/fm-startup-memory-budget-lib.sh
@@ -29,13 +29,43 @@ fm_startup_memory_budget_link_count() {
   fi
 }
 
+# fm_startup_memory_budget_resolve <path>
+# Prints <path> with every symlink resolved, so the safety checks below apply
+# to the real target rather than to the link.  A symlink is a legitimate local
+# layout (an operator may keep private config in a separate tree and link it
+# into the home); the property worth enforcing is that whatever the name finally
+# names is an ordinary, single-linked, well-formed artifact.  Fails on a broken
+# or cyclic chain.  BSD and GNU userlands disagree about `realpath` and
+# `readlink -f`, so the chain is walked here instead of shelling out to either.
+fm_startup_memory_budget_resolve() {
+  local path=$1 depth=0 target parent base
+  while [ -L "$path" ]; do
+    if [ "$depth" -ge 40 ]; then
+      return 1
+    fi
+    target=$(readlink "$path") || return 1
+    case "$target" in
+      /*) path=$target ;;
+      *) path="$(dirname -- "$path")/$target" ;;
+    esac
+    depth=$((depth + 1))
+  done
+  parent=$(dirname -- "$path")
+  base=$(basename -- "$path")
+  parent=$(cd -P -- "$parent" 2>/dev/null && pwd -P) || return 1
+  case "$parent" in
+    */) printf '%s%s\n' "$parent" "$base" ;;
+    *) printf '%s/%s\n' "$parent" "$base" ;;
+  esac
+}
+
 fm_startup_memory_budget_config_dir_safe() {
-  local dir=$1
-  if [ -L "$dir" ]; then
-    fm_startup_memory_budget_fail "config directory is symlinked"
+  local dir=$1 resolved
+  resolved=$(fm_startup_memory_budget_resolve "$dir") || {
+    fm_startup_memory_budget_fail "config directory link could not be resolved"
     return 1
-  fi
-  if [ ! -d "$dir" ]; then
+  }
+  if [ ! -d "$resolved" ]; then
     fm_startup_memory_budget_fail "config directory is not a directory"
     return 1
   fi
@@ -43,24 +73,31 @@ fm_startup_memory_budget_config_dir_safe() {
 }
 
 # fm_startup_memory_budget_file_valid <path>
-# Sets FM_STARTUP_MEMORY_BUDGET_VALUE only for a regular, single-linked file
-# containing exactly one positive decimal value and one terminating newline.
+# Sets FM_STARTUP_MEMORY_BUDGET_VALUE only when <path> finally names a regular,
+# single-linked file containing exactly one positive decimal value and one
+# terminating newline.  Symlinks are resolved first and every check applies to
+# the resolved target; the hardlink-count check below is the anti-substitution
+# guard, and it is strictly stronger than refusing the link itself.
 fm_startup_memory_budget_file_valid() {
-  local path=$1 links value
+  local path=$1 resolved links value
   FM_STARTUP_MEMORY_BUDGET_VALUE=""
-  if [ -L "$path" ]; then
-    fm_startup_memory_budget_fail "file is symlinked"
-    return 1
-  fi
-  if [ ! -e "$path" ]; then
+  if [ ! -e "$path" ] && [ ! -L "$path" ]; then
     fm_startup_memory_budget_fail "file is absent"
     return 1
   fi
-  if [ ! -f "$path" ]; then
+  resolved=$(fm_startup_memory_budget_resolve "$path") || {
+    fm_startup_memory_budget_fail "file link could not be resolved"
+    return 1
+  }
+  if [ ! -e "$resolved" ]; then
+    fm_startup_memory_budget_fail "file is absent"
+    return 1
+  fi
+  if [ ! -f "$resolved" ]; then
     fm_startup_memory_budget_fail "file is not a regular file"
     return 1
   fi
-  links=$(fm_startup_memory_budget_link_count "$path") || {
+  links=$(fm_startup_memory_budget_link_count "$resolved") || {
     fm_startup_memory_budget_fail "could not inspect file link count"
     return 1
   }
@@ -68,7 +105,7 @@ fm_startup_memory_budget_file_valid() {
     fm_startup_memory_budget_fail "file is hardlinked"
     return 1
   fi
-  value=$(<"$path") || {
+  value=$(<"$resolved") || {
     fm_startup_memory_budget_fail "could not read file"
     return 1
   }
@@ -78,7 +115,7 @@ fm_startup_memory_budget_file_valid() {
       return 1
       ;;
   esac
-  if ! printf '%s\n' "$value" | cmp -s "$path" -; then
+  if ! printf '%s\n' "$value" | cmp -s "$resolved" -; then
     fm_startup_memory_budget_fail "file must contain exactly one value followed by one newline"
     return 1
   fi
@@ -161,11 +198,12 @@ fm_startup_memory_estimated_tokens_for_bytes() {
 }
 
 # fm_startup_memory_measure_file <path>
-# Prints "<bytes> <estimated-tokens> <present|absent>".  Memory files must be
-# ordinary files when present so a measurement never follows a symlink or reads
-# a special file.
+# Prints "<bytes> <estimated-tokens> <present|absent>".  Symlinks are resolved
+# first and the resolved target must be an ordinary regular file, so a
+# measurement still never reads a special file, a directory, or a broken link,
+# while a memory file legitimately linked into the home is measured normally.
 fm_startup_memory_measure_file() {
-  local path=$1 bytes tokens
+  local path=$1 resolved bytes tokens
   FM_STARTUP_MEMORY_MEASURE_BYTES=""
   FM_STARTUP_MEMORY_MEASURE_TOKENS=""
   FM_STARTUP_MEMORY_MEASURE_PRESENCE=""
@@ -176,11 +214,15 @@ fm_startup_memory_measure_file() {
     printf '0 0 absent\n'
     return 0
   fi
-  if [ -L "$path" ] || [ ! -f "$path" ]; then
+  resolved=$(fm_startup_memory_budget_resolve "$path") || {
+    fm_startup_memory_budget_fail "memory file link could not be resolved: $path"
+    return 1
+  }
+  if [ ! -f "$resolved" ]; then
     fm_startup_memory_budget_fail "memory file is not an ordinary regular file: $path"
     return 1
   fi
-  bytes=$(LC_ALL=C wc -c < "$path" 2>/dev/null | tr -d '[:space:]') || {
+  bytes=$(LC_ALL=C wc -c < "$resolved" 2>/dev/null | tr -d '[:space:]') || {
     fm_startup_memory_budget_fail "could not measure memory file: $path"
     return 1
   }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -152,8 +152,10 @@ There is no shared learnings file by captain decision.
 The locked mutable bootstrap path materializes its visible default of `7500` estimated tokens in a primary home when the file is absent.
 To select another allowance, replace the primary home's file with one valid positive value in the exact format below; the next locked bootstrap convergence or `bin/fm-config-push.sh` propagates it to registered secondmates.
 A secondmate does not create an independent default and instead receives the primary value through the inherited-local-material contract in [`secondmate-provisioning`](../.agents/skills/secondmate-provisioning/SKILL.md).
-The file must be one positive base-10 integer followed by exactly one newline in a regular, single-linked file beneath a non-symlinked `config/` directory.
-Malformed, multi-line, symlinked, hardlinked, special, or otherwise unsafe values are rejected rather than treated as a default.
+The file must be one positive base-10 integer followed by exactly one newline in a regular, single-linked file beneath a `config/` directory.
+Symlinks are resolved before validation, so `config/` or the file itself may be linked in from a separate tree - the common case being an operator who keeps private configuration outside a public checkout - and every safety check then applies to the resolved target rather than to the link.
+Malformed, multi-line, hardlinked, special, broken-link, cyclic, or otherwise unsafe values are rejected rather than treated as a default.
+The hardlink-count check is what refuses a substituted file; it applies to the resolved target and is unaffected by how the name was reached.
 Use `bin/fm-startup-memory-budget.sh read` to validate and print the effective value, or `bin/fm-startup-memory-budget.sh report` to account for the three files.
 The stable local estimate is `ceil(UTF-8 bytes / 3)` per file, a conservative portable approximation rather than a provider-exact tokenizer.
 An inherited `data/captain-shared.md` counts in a secondmate's total but remains primary-owned and read-only there.

--- a/tests/fm-startup-memory-budget.test.sh
+++ b/tests/fm-startup-memory-budget.test.sh
@@ -147,20 +147,49 @@ test_safe_parser_rejects_ambiguous_and_unsafe_values() {
   printf '77\n' > "$outside"
   rm -f "$home/config/startup-memory-budget"
   ln -s "$outside" "$home/config/startup-memory-budget"
-  expect_rejected_read "$home" 'file is symlinked'
-  [ "$(<"$outside")" = 77 ] || fail "symlink rejection changed its external target"
+  [ "$(FM_HOME="$home" "$BUDGET" read)" = 77 ] \
+    || fail "a symlink to an otherwise safe budget file was not resolved"
+  [ "$(<"$outside")" = 77 ] || fail "resolving a symlink changed its external target"
 
   rm -f "$home/config/startup-memory-budget"
   ln "$outside" "$home/config/startup-memory-budget"
   expect_rejected_read "$home" 'file is hardlinked'
   [ "$(<"$outside")" = 77 ] || fail "hardlink rejection changed its external source"
 
+  # Resolving the link must not launder a target past the anti-substitution guard.
+  printf '99\n' > "$TMP_ROOT/parser-hardlinked"
+  ln "$TMP_ROOT/parser-hardlinked" "$TMP_ROOT/parser-hardlinked-second"
+  rm -f "$home/config/startup-memory-budget"
+  ln -s "$TMP_ROOT/parser-hardlinked" "$home/config/startup-memory-budget"
+  expect_rejected_read "$home" 'file is hardlinked'
+
+  rm -f "$home/config/startup-memory-budget"
+  ln -s "$TMP_ROOT/parser-missing-target" "$home/config/startup-memory-budget"
+  expect_rejected_read "$home" 'file is absent'
+
+  mkdir -p "$TMP_ROOT/parser-dir-target"
+  rm -f "$home/config/startup-memory-budget"
+  ln -s "$TMP_ROOT/parser-dir-target" "$home/config/startup-memory-budget"
+  expect_rejected_read "$home" 'file is not a regular file'
+
+  ln -s "$TMP_ROOT/parser-cycle-b" "$TMP_ROOT/parser-cycle-a"
+  ln -s "$TMP_ROOT/parser-cycle-a" "$TMP_ROOT/parser-cycle-b"
+  rm -f "$home/config/startup-memory-budget"
+  ln -s "$TMP_ROOT/parser-cycle-a" "$home/config/startup-memory-budget"
+  expect_rejected_read "$home" 'file link could not be resolved'
+
   rm -f "$home/config/startup-memory-budget"
   rm -rf "$home/config"
-  ln -s "$TMP_ROOT/parser-config-target" "$home/config"
   mkdir -p "$TMP_ROOT/parser-config-target"
   printf '88\n' > "$TMP_ROOT/parser-config-target/startup-memory-budget"
-  expect_rejected_read "$home" 'config directory is symlinked'
+  ln -s "$TMP_ROOT/parser-config-target" "$home/config"
+  [ "$(FM_HOME="$home" "$BUDGET" read)" = 88 ] \
+    || fail "a symlinked config directory was not resolved to its real target"
+
+  rm -f "$home/config"
+  printf 'not a directory\n' > "$TMP_ROOT/parser-config-file"
+  ln -s "$TMP_ROOT/parser-config-file" "$home/config"
+  expect_rejected_read "$home" 'config directory is not a directory'
   pass "budget parser accepts one exact positive value and rejects malformed or unsafe inputs"
 }
 
@@ -192,14 +221,31 @@ test_budget_accounting_reports_all_three_files_and_safe_failure() {
   printf 'outside\n' > "$outside"
   rm -f "$home/data/captain.md"
   ln -s "$outside" "$home/data/captain.md"
+  out=$(FM_HOME="$home" "$BUDGET" report)
+  assert_contains "$out" 'file=data/captain.md bytes=8 estimated_tokens=3 status=present' \
+    "a memory file linked into the home was not measured through its target"
+  [ "$(<"$outside")" = outside ] || fail "measuring a symlink changed its target"
+
+  rm -f "$home/data/captain.md"
+  ln -s "$TMP_ROOT/accounting-missing" "$home/data/captain.md"
   set +e
   out=$(FM_HOME="$home" "$BUDGET" report 2>&1)
   rc=$?
   set -e
-  expect_code 2 "$rc" "unsafe memory input should fail the accounting command"
+  expect_code 2 "$rc" "a broken memory-file link should fail the accounting command"
   assert_contains "$out" 'memory file is not an ordinary regular file' \
     "accounting failure did not identify the unsafe memory file"
-  [ "$(<"$outside")" = outside ] || fail "accounting failure changed a symlink target"
+
+  rm -f "$home/data/captain.md"
+  mkdir -p "$TMP_ROOT/accounting-dir"
+  ln -s "$TMP_ROOT/accounting-dir" "$home/data/captain.md"
+  set +e
+  out=$(FM_HOME="$home" "$BUDGET" report 2>&1)
+  rc=$?
+  set -e
+  expect_code 2 "$rc" "a memory file linked to a directory should fail the accounting command"
+  assert_contains "$out" 'memory file is not an ordinary regular file' \
+    "accounting failure did not identify the non-regular memory target"
   pass "budget accounting sums the three startup files and reports safe failures"
 }
 
@@ -303,16 +349,23 @@ test_primary_budget_converges_with_exact_reread_and_safe_failures() {
   rm -f "$sm/config/startup-memory-budget"
   printf '555\n' > "$outside"
   ln -s "$outside" "$home/config/startup-memory-budget"
+  run_config_push "$root" "$home" "$fakebin" "$log" >/dev/null
+  [ "$(<"$sm/config/startup-memory-budget")" = 555 ] \
+    || fail "a primary budget linked into the home did not propagate its resolved bytes"
+  [ "$(<"$outside")" = 555 ] || fail "propagating a linked primary budget changed its target"
+
+  rm -f "$home/config/startup-memory-budget" "$sm/config/startup-memory-budget"
+  ln "$outside" "$home/config/startup-memory-budget"
   set +e
   out=$(run_config_push "$root" "$home" "$fakebin" "$log" 2>&1)
   rc=$?
   set -e
   expect_code 1 "$rc" "unsafe primary budget should stop propagation"
-  assert_contains "$out" 'startup-memory-budget: error - unsafe or invalid primary source: file is symlinked' \
+  assert_contains "$out" 'startup-memory-budget: error - unsafe or invalid primary source: file is hardlinked' \
     "unsafe primary budget did not produce a concrete propagation error"
   [ ! -e "$sm/config/startup-memory-budget" ] \
     || fail "unsafe primary budget changed the converged secondmate copy"
-  [ "$(<"$outside")" = 555 ] || fail "unsafe primary budget handling changed its symlink target"
+  [ "$(<"$outside")" = 555 ] || fail "unsafe primary budget handling changed its hardlinked source"
   pass "budget propagation converges through config push with exact rereads, absence, and safe rejection"
 }
 


### PR DESCRIPTION
## Problem

`bin/fm-startup-memory-budget-lib.sh` rejects a symlink outright in three places instead of resolving it:

- `fm_startup_memory_budget_config_dir_safe` - `config directory is symlinked`
- `fm_startup_memory_budget_file_valid` - `file is symlinked`
- `fm_startup_memory_measure_file` - `memory file is not an ordinary regular file`

This makes a legitimate layout unusable. An operator who keeps private configuration in a separate tree and symlinks it into the firstmate home (for example, because the checkout is a public fork and `config/` and `data/` must stay private) gets:

```
STARTUP_MEMORY_BUDGET: invalid config/startup-memory-budget - config directory is symlinked
```

on every session. The budget is never read, `bin/fm-startup-memory-budget.sh report` cannot run, and the internal `/stow` skill cannot verify it finished within budget - so the startup-memory limit is silently unenforced rather than merely unread. The recurring diagnostic reads as routine noise, which is how it stays that way.

## Change

Resolve the symlink chain first, then apply the existing checks to the resolved target.

The genuine anti-substitution guard is the hardlink-count check, and it is unaffected by how the name was reached - so applying it to the resolved target is strictly stronger than refusing the link. Still rejected, each with its own concrete message: a broken chain (`file is absent`), a cyclic or over-deep chain (`file link could not be resolved`), a non-regular target (`file is not a regular file`), a hardlinked target (`file is hardlinked`, including when reached through a symlink), and every existing content/format rule.

`fm_startup_memory_measure_file` is included deliberately. Memory files are commonly linked in individually rather than through a linked `data/`, so fixing only the two config paths moves the failure from the budget read to the accounting command instead of fixing it.

Chain resolution is walked in-shell because BSD and GNU userlands disagree about `realpath` and `readlink -f`.

## Verification

`tests/fm-startup-memory-budget.test.sh` updated and extended; the previous tests pinned the old refusals, so those assertions now pin the resolve-then-validate behavior, and new cases cover symlink-to-hardlinked-target, broken link, link-to-directory, link cycle, symlinked config dir, and config dir linked to a non-directory.

```
$ bash tests/fm-startup-memory-budget.test.sh
ok - primary bootstrap materializes only the visible default and preserves valid captain choices
ok - budget parser accepts one exact positive value and rejects malformed or unsafe inputs
ok - budget accounting sums the three startup files and reports safe failures
ok - budget propagation converges through config push with exact rereads, absence, and safe rejection
# all fm-startup-memory-budget tests passed
```

```
$ bin/fm-lint.sh
fm-lint.sh: ShellCheck 0.11.0 (pinned 0.11.0)
```

Also passing locally: `tests/fm-bootstrap.test.sh`, `tests/fm-shared-captain-inheritance.test.sh`, `tests/fm-gitignore-config.test.sh`, and `bin/fm-doc-audience-check.sh` (`ok surfaces=64 local_links=193`).

End to end on a home mirroring the affected layout (symlinked `config/` plus per-file memory symlinks) - before:

```
startup-memory-budget: invalid config/startup-memory-budget - config directory is symlinked
```

after:

```
estimator=ceil(UTF-8 bytes / 3) conservative-local-estimate
role=primary
effective_budget_tokens=7500
file=data/captain.md bytes=14 estimated_tokens=5 status=present
file=data/captain-shared.md bytes=0 estimated_tokens=0 status=absent
file=data/learnings.md bytes=10 estimated_tokens=4 status=present
total_estimated_tokens=9
budget_status=within-budget
```

`docs/configuration.md`'s "Startup memory budget" section is updated, since it documented the old refusal.