### PR TITLE
fix(pi): gate Calm built-in overrides by activation state

### DIFF
--- a/.pi/extensions/fm-calm.ts
+++ b/.pi/extensions/fm-calm.ts
@@ -11,10 +11,49 @@
 // diagnostic (see installCalmPresentationAdapter below) if a future Pi removes it; Pi
 // still exposes no global renderer for arbitrary built-in or custom rows.
 // docs/configuration.md owns the home-local Calm preference contract.
+//
+// Built-in tool presentation (bash, read, edit, write, grep, find, ls) is claimed by
+// name through pi.registerTool(), the only seam Pi exposes for it. Pi resolves two
+// extensions registering the same tool name by first-registered-extension-wins with no
+// merge (verified in installed Pi's ExtensionRunner.getAllRegisteredTools): the loser's
+// whole ToolDefinition, execute included, is dropped, not just its rendering, and there
+// is no unregister call. This is the plan Calm follows to avoid claiming a name a
+// differently-loaded extension already owns, given that constraint:
+//
+// - Registration is gated on config/calm already being "on" at load time (the
+//   loadCalmPreference() check right before the wrappedBuiltIns registration loop
+//   below). A calm-off session or reload registers nothing, so a non-Calm user never
+//   contests a name. This must stay synchronous during this
+//   factory's own load, not deferred to session_start: /reload (and
+//   ctx.newSession/fork/switchSession) render the restored transcript from a
+//   pre-session_start snapshot of the tool registry (AgentSession.reload's
+//   beforeSessionStart callback runs before its own session_start emit), so a deferred
+//   claim would miss that render. Confirmed bound: the first time a session that
+//   started Calm-off turns Calm on, tool-call rows from before that toggle do not
+//   retroactively hide, because Pi's ToolExecutionComponent captures its tool
+//   definition once at construction with no re-read hook; every session after that
+//   first toggle starts with the preference already "on" and takes this same
+//   synchronous path from the top, so the guarantee is intact from then on.
+// - When Calm turns on for the first time in a session that started off
+//   (activateBuiltInsIfNeeded below, called from the /calm command handler), Calm can
+//   safely call pi.getAllTools() - a runtime action, valid only once every extension
+//   has finished loading, unlike the synchronous load-time path above - to see whether
+//   a different, non-builtin extension already owns a name, and skip claiming only
+//   that one, leaving it fully intact and callable. There is no equivalent read for a
+//   full, executable ToolDefinition (pi.getAllTools() returns metadata only: name,
+//   description, parameters, promptGuidelines, sourceInfo - no execute/renderCall/
+//   renderResult), so wrapping the other extension's own tool instead of Pi's built-in
+//   is not reachable by any exposed API.
+// - A name Calm could not check before claiming - because Calm registered
+//   unconditionally at load since Calm was already on - can still be silently lost to
+//   an earlier-loaded extension. reportBuiltInLosses() below is the backstop for that
+//   residual case: a session-start diagnostic naming the tool and the extension that
+//   won it, whenever Calm currently does not own a name it wrapped.
 import { randomUUID } from "node:crypto";
 import {
   mkdirSync,
   readFileSync,
+  realpathSync,
   renameSync,
   rmSync,
   writeFileSync,
@@ -25,6 +64,7 @@ import type {
   ExtensionAPI,
   ExtensionUIContext,
   ToolDefinition,
+  ToolInfo,
   ToolRenderResultOptions,
 } from "@earendil-works/pi-coding-agent";
 import {
@@ -83,6 +123,21 @@ type StandardShellState = {
 const extensionFile = fileURLToPath(import.meta.url);
 const extensionDir = dirname(extensionFile);
 const root = resolve(extensionDir, "../..");
+
+// Resolves symlinks before comparing tool-ownership identity below: sourceInfo.path
+// values come from independent path-resolution code paths (this module's own
+// import.meta.url vs. Pi's extension loader), and macOS alone symlinks /tmp and /var
+// to /private/..., so lexical string comparison alone spuriously reads a symlinked
+// self-path as a foreign one. Falls back to the raw path for synthetic, non-file
+// sourceInfo paths such as "<builtin:read>" or "<inline>", which realpathSync rejects.
+const realpathOrSelf = (path: string): string => {
+  try {
+    return realpathSync(path);
+  } catch {
+    return path;
+  }
+};
+const extensionRealFile = realpathOrSelf(extensionFile);
 
 // Each presentation adapter probes the exact Pi API it patches. If a future Pi removes
 // that API, only the affected adapter degrades; the rest of Calm keeps working.
@@ -166,9 +221,9 @@ export default function (pi: ExtensionAPI) {
 
   registerFirstmateSyntheticPresentation(pi);
 
-  function registerBuiltIn<TParams extends TSchema, TDetails, TState>(
+  function wrapBuiltIn<TParams extends TSchema, TDetails, TState>(
     factory: DefinitionFactory<TParams, TDetails, TState>,
-  ): void {
+  ): ToolDefinition<TParams, TDetails, TState> {
     const definitions = new Map<string, ToolDefinition<TParams, TDetails, TState>>();
     const definitionFor = (cwd: string): ToolDefinition<TParams, TDetails, TState> => {
       let definition = definitions.get(cwd);
@@ -220,7 +275,7 @@ export default function (pi: ExtensionAPI) {
       return shell;
     };
 
-    pi.registerTool({
+    return {
       ...original,
       renderShell: "self",
 
@@ -263,18 +318,108 @@ export default function (pi: ExtensionAPI) {
         refreshStandardShell(state, theme, context);
         return new Container();
       },
+    };
+  }
+
+  // Each wrapBuiltIn() call below has its own concrete TParams/TDetails/TState; the
+  // array holding all seven has no single sound instantiation, so it is typed the same
+  // way Pi's own ToolDefinition consumers erase this (any, any, any).
+  const wrappedBuiltIns: ToolDefinition<any, any, any>[] = [
+    wrapBuiltIn(createReadToolDefinition),
+    wrapBuiltIn(createBashToolDefinition),
+    wrapBuiltIn(createEditToolDefinition),
+    wrapBuiltIn(createWriteToolDefinition),
+    wrapBuiltIn(createGrepToolDefinition),
+    wrapBuiltIn(createFindToolDefinition),
+    wrapBuiltIn(createLsToolDefinition),
+  ];
+
+  // True once the 7 built-ins have been registered, whichever path did it: the
+  // synchronous load-time path just below (Calm already on), or the first-activation
+  // path in the /calm command handler (Calm turned on mid-session, see
+  // activateBuiltInsIfNeeded).
+  let builtInsRegistered = false;
+
+  // Part A: gate on Calm already being on at load time. Must stay synchronous and
+  // unconditional here (see file header) - a foreign-claim check is not reachable at
+  // this point, so a Calm-on session or reload keeps today's behavior exactly. A
+  // Calm-off session or reload registers nothing: zero collision exposure for anyone
+  // who has never turned Calm on.
+  if (loadCalmPreference()) {
+    for (const tool of wrappedBuiltIns) pi.registerTool(tool);
+    builtInsRegistered = true;
+  }
+
+  // Which of the 7 built-ins are currently owned by a different, non-builtin
+  // extension. Only safe to call once every extension has finished loading (see file
+  // header); never call this during the factory's own synchronous execution above.
+  function contestedBuiltIns(): ToolDefinition<any, any, any>[] {
+    let registered: ToolInfo[];
+    try {
+      registered = pi.getAllTools();
+    } catch (error) {
+      const reason = error instanceof Error ? error.message : String(error);
+      console.error(`Firstmate Calm: built-in ownership check unavailable, claiming every built-in unconditionally. ${reason}`);
+      return [];
+    }
+    return wrappedBuiltIns.filter((tool) => {
+      const owner = registered.find((info) => info.name === tool.name)?.sourceInfo;
+      return owner !== undefined && owner.source !== "builtin" && realpathOrSelf(owner.path) !== extensionRealFile;
     });
   }
 
-  registerBuiltIn(createReadToolDefinition);
-  registerBuiltIn(createBashToolDefinition);
-  registerBuiltIn(createEditToolDefinition);
-  registerBuiltIn(createWriteToolDefinition);
-  registerBuiltIn(createGrepToolDefinition);
-  registerBuiltIn(createFindToolDefinition);
-  registerBuiltIn(createLsToolDefinition);
+  // Part B: the first time Calm turns on in a session that started off, claim every
+  // uncontested built-in and leave any contested one, and its owning extension,
+  // completely untouched. Part C: tell the user plainly which built-in Calm could not
+  // take over and why, since Calm's presentation silently does not apply to it.
+  function activateBuiltInsIfNeeded(ui: ExtensionUIContext): void {
+    if (builtInsRegistered) return;
+    const contested = contestedBuiltIns();
+    const contestedNames = new Set(contested.map((tool) => tool.name));
+    for (const tool of wrappedBuiltIns) {
+      if (!contestedNames.has(tool.name)) pi.registerTool(tool);
+    }
+    builtInsRegistered = true;
+    if (contested.length === 0) return;
+    const names = contested.map((tool) => `"${tool.name}"`).join(", ");
+    const plural = contested.length > 1;
+    ui.notify(
+      `Firstmate Calm: the ${names} built-in tool${plural ? "s are" : " is"} already provided by another extension, so Calm may not fully function for ${plural ? "them" : "it"} this session.`,
+      "warning",
+    );
+    for (const tool of contested) {
+      console.error(`Firstmate Calm: skipped claiming built-in "${tool.name}" because another extension already owns it.`);
+    }
+  }
+
+  // Backstop for the one case activateBuiltInsIfNeeded cannot reach: Calm registered
+  // unconditionally at load time (Part A, Calm was already on) without any chance to
+  // check for a foreign claim first, so it can still silently lose a name to an
+  // earlier-loaded extension. Runs on every session_start reason because a reload
+  // rebuilds every extension's registrations from scratch, so last session's clean
+  // bill of health does not carry over.
+  function reportBuiltInLosses(): void {
+    if (!builtInsRegistered) return;
+    let registered: ToolInfo[];
+    try {
+      registered = pi.getAllTools();
+    } catch (error) {
+      const reason = error instanceof Error ? error.message : String(error);
+      console.error(`Firstmate Calm: built-in ownership check unavailable. ${reason}`);
+      return;
+    }
+    for (const tool of wrappedBuiltIns) {
+      const owner = registered.find((info) => info.name === tool.name)?.sourceInfo;
+      if (owner && owner.source !== "builtin" && realpathOrSelf(owner.path) !== extensionRealFile) {
+        console.error(
+          `Firstmate Calm: another extension (${owner.path}) also claimed the built-in "${tool.name}" tool and won; Calm's presentation for it is unavailable this session.`,
+        );
+      }
+    }
+  }
 
   pi.on("session_start", (_event, ctx) => {
+    reportBuiltInLosses();
     exportRendering = false;
     setCalmPresentation(loadCalmPreference());
     setCalmStockExportRendering(false);
@@ -335,6 +480,7 @@ export default function (pi: ExtensionAPI) {
       const active = !calmPresentationIsActive();
       persistCalmPreference(active);
       setCalmPresentation(active);
+      if (active) activateBuiltInsIfNeeded(ctx.ui);
       publishPresentationState();
       applyWorkingPresentation(ctx.ui, true);
       ctx.ui.setHiddenThinkingLabel(active ? "" : undefined);

--- a/.pi/extensions/fm-calm.ts
+++ b/.pi/extensions/fm-calm.ts
@@ -12,43 +12,12 @@
 // still exposes no global renderer for arbitrary built-in or custom rows.
 // docs/configuration.md owns the home-local Calm preference contract.
 //
-// Built-in tool presentation (bash, read, edit, write, grep, find, ls) is claimed by
-// name through pi.registerTool(), the only seam Pi exposes for it. Pi resolves two
-// extensions registering the same tool name by first-registered-extension-wins with no
-// merge (verified in installed Pi's ExtensionRunner.getAllRegisteredTools): the loser's
-// whole ToolDefinition, execute included, is dropped, not just its rendering, and there
-// is no unregister call. This is the plan Calm follows to avoid claiming a name a
-// differently-loaded extension already owns, given that constraint:
-//
-// - Registration is gated on config/calm already being "on" at load time (the
-//   loadCalmPreference() check right before the wrappedBuiltIns registration loop
-//   below). A calm-off session or reload registers nothing, so a non-Calm user never
-//   contests a name. This must stay synchronous during this
-//   factory's own load, not deferred to session_start: /reload (and
-//   ctx.newSession/fork/switchSession) render the restored transcript from a
-//   pre-session_start snapshot of the tool registry (AgentSession.reload's
-//   beforeSessionStart callback runs before its own session_start emit), so a deferred
-//   claim would miss that render. Confirmed bound: the first time a session that
-//   started Calm-off turns Calm on, tool-call rows from before that toggle do not
-//   retroactively hide, because Pi's ToolExecutionComponent captures its tool
-//   definition once at construction with no re-read hook; every session after that
-//   first toggle starts with the preference already "on" and takes this same
-//   synchronous path from the top, so the guarantee is intact from then on.
-// - When Calm turns on for the first time in a session that started off
-//   (activateBuiltInsIfNeeded below, called from the /calm command handler), Calm can
-//   safely call pi.getAllTools() - a runtime action, valid only once every extension
-//   has finished loading, unlike the synchronous load-time path above - to see whether
-//   a different, non-builtin extension already owns a name, and skip claiming only
-//   that one, leaving it fully intact and callable. There is no equivalent read for a
-//   full, executable ToolDefinition (pi.getAllTools() returns metadata only: name,
-//   description, parameters, promptGuidelines, sourceInfo - no execute/renderCall/
-//   renderResult), so wrapping the other extension's own tool instead of Pi's built-in
-//   is not reachable by any exposed API.
-// - A name Calm could not check before claiming - because Calm registered
-//   unconditionally at load since Calm was already on - can still be silently lost to
-//   an earlier-loaded extension. reportBuiltInLosses() below is the backstop for that
-//   residual case: a session-start diagnostic naming the tool and the extension that
-//   won it, whenever Calm currently does not own a name it wrapped.
+// Pi has one first-registration-wins ToolDefinition per tool name, with no merge or
+// unregister operation. Keep Calm-off registration empty; keep Calm-on load-time
+// registration synchronous because restored rows capture the registry before
+// session_start; and collision-check only the later first-activation path, when
+// getAllTools() is reliable. docs/calm-mode-feasibility.md owns the Pi-source evidence
+// and docs/calm.md owns the user-facing behavior and non-retroactive first-toggle bound.
 import { randomUUID } from "node:crypto";
 import {
   mkdirSync,
@@ -334,17 +303,15 @@ export default function (pi: ExtensionAPI) {
     wrapBuiltIn(createLsToolDefinition),
   ];
 
-  // True once the 7 built-ins have been registered, whichever path did it: the
-  // synchronous load-time path just below (Calm already on), or the first-activation
-  // path in the /calm command handler (Calm turned on mid-session, see
-  // activateBuiltInsIfNeeded).
+  // True once this extension has handled built-in registration for its lifetime:
+  // either all seven synchronously at load, or only the uncontested subset during
+  // first activation.
   let builtInsRegistered = false;
 
-  // Part A: gate on Calm already being on at load time. Must stay synchronous and
-  // unconditional here (see file header) - a foreign-claim check is not reachable at
-  // this point, so a Calm-on session or reload keeps today's behavior exactly. A
-  // Calm-off session or reload registers nothing: zero collision exposure for anyone
-  // who has never turned Calm on.
+  // Gate on Calm already being on at load time. This must stay synchronous and
+  // unconditional here (see file header): a foreign-claim check is not reachable at
+  // this point, while deferral would make restored rows capture the wrong definition.
+  // A Calm-off session or reload registers nothing and creates no collision exposure.
   if (loadCalmPreference()) {
     for (const tool of wrappedBuiltIns) pi.registerTool(tool);
     builtInsRegistered = true;
@@ -368,10 +335,10 @@ export default function (pi: ExtensionAPI) {
     });
   }
 
-  // Part B: the first time Calm turns on in a session that started off, claim every
-  // uncontested built-in and leave any contested one, and its owning extension,
-  // completely untouched. Part C: tell the user plainly which built-in Calm could not
-  // take over and why, since Calm's presentation silently does not apply to it.
+  // The first time Calm turns on in a session that started off, claim every
+  // uncontested built-in and leave each contested tool and its owning extension
+  // untouched. Tell the user which built-in Calm could not take over, since Calm's
+  // presentation does not apply to it.
   function activateBuiltInsIfNeeded(ui: ExtensionUIContext): void {
     if (builtInsRegistered) return;
     const contested = contestedBuiltIns();
@@ -393,7 +360,7 @@ export default function (pi: ExtensionAPI) {
   }
 
   // Backstop for the one case activateBuiltInsIfNeeded cannot reach: Calm registered
-  // unconditionally at load time (Part A, Calm was already on) without any chance to
+  // unconditionally at load time because it was already on, without any chance to
   // check for a foreign claim first, so it can still silently lose a name to an
   // earlier-loaded extension. Runs on every session_start reason because a reload
   // rebuilds every extension's registrations from scratch, so last session's clean

--- a/docs/calm-mode-feasibility.md
+++ b/docs/calm-mode-feasibility.md
@@ -18,6 +18,18 @@ The inspected Pi CHANGELOG shows no relevant presentation API introduced at eith
 The exported classes used by the adapters (`AssistantMessageComponent` and `InteractiveMode`) are undocumented internals with no stated version guarantee.
 `tests/fm-calm-pi-extension.test.sh` records the installed Pi version as evidence without gating on it and covers both newer synthetic versions and an unavailable adapter seam.
 
+### Built-in tool override constraints
+
+[`calm.md`](calm.md#pi-compatibility) owns the current user-facing collision behavior and limitation.
+Inspection of Pi 0.80.10 and 0.82.0 established that extensions override a built-in tool by registering the same name, the first registered extension wins the complete `ToolDefinition` without merging, and Pi exposes no unregister operation.
+Pi loads project-local extensions before global or CLI-configured extensions, so Firstmate's tracked Calm extension previously won those collisions even when its persisted preference was off.
+The losing definition's execution and render functions are both discarded, so unconditionally registering Calm's wrappers would replace another extension's same-named tool rather than changing presentation alone.
+
+Pi's `getAllTools()` exposes tool metadata and source identity but not the executable or rendering functions needed to wrap another extension's full definition.
+It is also usable for reliable collision detection only after extension binding, which makes it suitable for the first same-session `/calm` activation but not for synchronous extension loading.
+Deferring registration to `session_start` is not an equivalent path: Pi constructs restored tool rows from an earlier tool-registry snapshot during reload, new-session, fork, and session switching, so those rows retain the definition captured before `session_start`.
+`tests/fm-calm-pi-extension.test.sh` covers the resulting split contract: no load-time claims while Calm is off, synchronous claims while it is already on, collision-checked first activation with a warning, preservation of a contested tool's execution, and the non-retroactive bound for rows rendered before first activation.
+
 ## Pi 0.81.1 end-to-end reproduction
 
 The Pi version installed at the time was verified on 2026-07-22.

--- a/docs/calm.md
+++ b/docs/calm.md
@@ -13,12 +13,12 @@ Hidden elapsed time does not advance the animation, and a resize while hidden cl
 A fresh Pi session or new Calm extension lifetime starts at the normal initial position.
 Very narrow terminals fall back to a smaller deterministic sprite.
 While Calm is off, Pi's stock working row is left exactly as Pi renders it.
-Calm hides collapsed thinking labels, the shells for Pi's seven built-in tools, the `fm_watch_arm_pi` tool shell, and canonically classified Firstmate operational user rows.
+Calm hides collapsed thinking labels, the shells for the Pi built-in tool names Calm owns, the `fm_watch_arm_pi` tool shell, and canonically classified Firstmate operational user rows.
 The operational inputs remain ordinary user-role messages, while Pi's transcript layout renders their complete rows at zero height.
 The session-start nudge remains on its existing non-displayed custom-message path.
 
-Calm changes presentation only.
-Tool execution, input delivery, ordering, model context, session storage, diagnostics, and `/export` and `/share` operation remain unchanged.
+Outside Pi's same-name built-in override collision described below, Calm changes presentation only.
+Calm's built-in wrappers preserve Pi's execution behavior, and input delivery, ordering, model context, session storage, diagnostics, and `/export` and `/share` operation remain unchanged.
 Every hidden Firstmate input remains available to the model and in serialized session data and exported artifacts.
 Legacy operational custom messages remain in session data and Pi's sidebar tree, although the main HTML transcript may omit them.
 Toggling Calm off restores ordinary rendering, and `Ctrl+O` expansion state is preserved.
@@ -33,15 +33,15 @@ Calm has no numeric Pi version minimum or maximum and never refuses Pi solely be
 The collapsed-thinking and operational-user-row presentation adapters probe the exact Pi API seam they patch when Calm loads.
 If Pi removes one of those seams, Calm logs a diagnostic naming the unavailable adapter and skips only that adapter; `/calm`, the other adapter, and unrelated Pi extensions remain available.
 
-Calm's built-in tool presentation (`bash`, `read`, `edit`, `write`, `grep`, `find`, `ls`) shares Pi's single, unmerged built-in-tool-override slot per name with any other extension that also overrides one of those tools, so Calm only claims a name a different extension has not already claimed.
-It registers nothing at all while Calm is off, so a user who has never turned Calm on never contests a name.
-The first time Calm turns on in a session that started off, it claims every built-in name no other extension already owns and prints a prominent warning naming any it could not, leaving that other extension's own tool fully intact and working; every session afterward starts with Calm already on and re-claims all seven at once, matching a captain's own long-running preference.
-One bound comes with that: the very first time a session that started Calm-off turns Calm on, tool-call rows already on screen from before that toggle do not retroactively collapse, because Pi never lets an extension re-point an already-rendered row at a definition registered later; new rows from that point on, and every row in every later session, are unaffected.
-One case still cannot be checked ahead of time: a session that starts, or reloads, with Calm already on, where the tool registry snapshot Pi needs for that render is taken before Calm gets any chance to check who owns a name.
-For that case a session-start diagnostic names the tool and the extension that won it.
-`.pi/extensions/fm-calm.ts`'s file header carries the full explanation and the Pi-source evidence behind it.
+Calm's built-in tool presentation (`bash`, `read`, `edit`, `write`, `grep`, `find`, `ls`) shares Pi's single, unmerged override slot per name with any other extension that overrides the same tool.
+While the persisted Calm preference is off, Calm registers none of those overrides and therefore contests no built-in tool name.
+The first time Calm turns on in a session that started off, it claims every built-in name no other extension already owns, leaves every contested tool intact and callable, and displays a prominent warning naming the tools it skipped.
+Tool-call rows already on screen before that first toggle do not retroactively collapse; later rows for the names Calm claimed use Calm presentation.
+When a session starts or reloads with Calm already on, Calm must instead register all seven overrides synchronously so Pi can render restored rows with them.
+Pi provides no ownership check early enough for that load-time path, and the first registrant wins the complete tool definition.
+If the other extension wins, a session-start console diagnostic names the tool and winning extension; if Calm wins, Pi does not expose the losing registration, so the other extension's override is unavailable and cannot be named.
 
-[`calm-mode-feasibility.md`](calm-mode-feasibility.md) owns the version-scoped renderer taxonomy and empirical evidence.
+[`calm-mode-feasibility.md`](calm-mode-feasibility.md) owns the version-scoped renderer taxonomy, built-in override constraints, and empirical evidence.
 [`configuration.md`](configuration.md#pi-calm-preference-configcalm) owns the persisted preference file and resolution rules.
 `.pi/extensions/lib/fm-calm-visibility.ts` owns the visibility policy, `.pi/extensions/lib/fm-calm-operational-user-layout.ts` owns the zero-height operational-user row adapter, and `.pi/extensions/lib/fm-calm-working-ship.ts` owns the animated working presentation.
 

--- a/docs/calm.md
+++ b/docs/calm.md
@@ -33,6 +33,14 @@ Calm has no numeric Pi version minimum or maximum and never refuses Pi solely be
 The collapsed-thinking and operational-user-row presentation adapters probe the exact Pi API seam they patch when Calm loads.
 If Pi removes one of those seams, Calm logs a diagnostic naming the unavailable adapter and skips only that adapter; `/calm`, the other adapter, and unrelated Pi extensions remain available.
 
+Calm's built-in tool presentation (`bash`, `read`, `edit`, `write`, `grep`, `find`, `ls`) shares Pi's single, unmerged built-in-tool-override slot per name with any other extension that also overrides one of those tools, so Calm only claims a name a different extension has not already claimed.
+It registers nothing at all while Calm is off, so a user who has never turned Calm on never contests a name.
+The first time Calm turns on in a session that started off, it claims every built-in name no other extension already owns and prints a prominent warning naming any it could not, leaving that other extension's own tool fully intact and working; every session afterward starts with Calm already on and re-claims all seven at once, matching a captain's own long-running preference.
+One bound comes with that: the very first time a session that started Calm-off turns Calm on, tool-call rows already on screen from before that toggle do not retroactively collapse, because Pi never lets an extension re-point an already-rendered row at a definition registered later; new rows from that point on, and every row in every later session, are unaffected.
+One case still cannot be checked ahead of time: a session that starts, or reloads, with Calm already on, where the tool registry snapshot Pi needs for that render is taken before Calm gets any chance to check who owns a name.
+For that case a session-start diagnostic names the tool and the extension that won it.
+`.pi/extensions/fm-calm.ts`'s file header carries the full explanation and the Pi-source evidence behind it.
+
 [`calm-mode-feasibility.md`](calm-mode-feasibility.md) owns the version-scoped renderer taxonomy and empirical evidence.
 [`configuration.md`](configuration.md#pi-calm-preference-configcalm) owns the persisted preference file and resolution rules.
 `.pi/extensions/lib/fm-calm-visibility.ts` owns the visibility policy, `.pi/extensions/lib/fm-calm-operational-user-layout.ts` owns the zero-height operational-user row adapter, and `.pi/extensions/lib/fm-calm-working-ship.ts` owns the animated working presentation.

--- a/tests/fm-calm-pi-extension.test.sh
+++ b/tests/fm-calm-pi-extension.test.sh
@@ -127,6 +127,9 @@ function registerCalm() {
     },
     registerEntryRenderer() {},
     registerTool() {},
+    getAllTools() {
+      return [];
+    },
   };
   extension.default(pi);
   if (!calmCommand || !handlers.has("session_start")) {
@@ -150,6 +153,7 @@ const context = {
     setStatus() {},
     setToolsExpanded() {},
     setWorkingVisible() {},
+    notify() {},
   },
 };
 
@@ -350,6 +354,306 @@ JS
   pass "missing Pi presentation class exports reach the independent adapter degradation path"
 }
 
+test_builtin_gate_load_time() {
+  local fixture out status
+  if ! command -v node >/dev/null 2>&1 || ! command -v npm >/dev/null 2>&1; then
+    echo "skip: node or npm not found for Pi calm gate test"
+    return 0
+  fi
+  if [ ! -f "$PI_PACKAGE_DIR/package.json" ]; then
+    echo "skip: installed @earendil-works/pi-coding-agent package not found"
+    return 0
+  fi
+
+  fixture="$TMP_ROOT/gate-load-time"
+  mkdir -p \
+    "$fixture/project/.pi/extensions/lib" \
+    "$fixture/project/node_modules/@earendil-works" \
+    "$fixture/home-off/config" \
+    "$fixture/home-on/config"
+  cp "$EXT" "$fixture/project/.pi/extensions/fm-calm.ts"
+  cp "$ASSISTANT_LAYOUT" "$fixture/project/.pi/extensions/lib/fm-calm-assistant-layout.ts"
+  cp "$OPERATIONAL_USER_LAYOUT" "$fixture/project/.pi/extensions/lib/fm-calm-operational-user-layout.ts"
+  cp "$VISIBILITY" "$fixture/project/.pi/extensions/lib/fm-calm-visibility.ts"
+  cp "$WORKING_SHIP" "$fixture/project/.pi/extensions/lib/fm-calm-working-ship.ts"
+  cp "$PI_OPERATIONAL_INPUT" "$fixture/project/.pi/extensions/lib/fm-operational-input.ts"
+  ln -s "$PI_PACKAGE_DIR" "$fixture/project/node_modules/@earendil-works/pi-coding-agent"
+  ln -s "$PI_PACKAGE_DIR/node_modules/@earendil-works/pi-tui" "$fixture/project/node_modules/@earendil-works/pi-tui"
+  ln -s "$PI_PACKAGE_DIR/node_modules/typebox" "$fixture/project/node_modules/typebox"
+  printf '%s\n' '{"type":"module"}' >"$fixture/project/package.json"
+  printf '%s\n' on >"$fixture/home-on/config/calm"
+
+  out=$(cd "$fixture/project" && \
+    EXT="$fixture/project/.pi/extensions/fm-calm.ts" \
+    HOME_OFF="$fixture/home-off" \
+    HOME_ON="$fixture/home-on" \
+    node --input-type=module 2>&1 <<'JS'
+import { pathToFileURL } from "node:url";
+
+function fakePi() {
+  const tools = [];
+  const handlers = new Map();
+  const pi = {
+    events: { emit() {}, on() {} },
+    on(event, handler) {
+      handlers.set(event, handler);
+    },
+    registerCommand() {},
+    registerEntryRenderer() {},
+    registerTool(tool) {
+      tools.push(tool);
+    },
+    getAllTools() {
+      return tools.map((tool) => ({ name: tool.name, sourceInfo: { source: "extension", path: "self" } }));
+    },
+  };
+  return { pi, tools, handlers };
+}
+
+// Calm-off (config/calm absent for this home): load-time registration must be
+// entirely skipped, so a non-Calm user contests nothing.
+process.env.FM_HOME = process.env.HOME_OFF;
+const offRun = fakePi();
+const extensionOff = await import(`${pathToFileURL(process.env.EXT).href}?gate-off=${Date.now()}`);
+extensionOff.default(offRun.pi);
+if (offRun.tools.length !== 0) {
+  throw new Error(`Calm registered ${offRun.tools.length} built-ins while config/calm was absent: ${offRun.tools.map((t) => t.name).join(",")}`);
+}
+
+// Calm-on (config/calm="on" for this home): registration must happen synchronously,
+// during this same factory call, exactly the timing /reload's pre-session_start
+// transcript render depends on - not deferred to session_start or later.
+process.env.FM_HOME = process.env.HOME_ON;
+const onRun = fakePi();
+const extensionOn = await import(`${pathToFileURL(process.env.EXT).href}?gate-on=${Date.now()}`);
+extensionOn.default(onRun.pi);
+const names = onRun.tools.map((t) => t.name).sort();
+const expected = ["bash", "edit", "find", "grep", "ls", "read", "write"];
+if (JSON.stringify(names) !== JSON.stringify(expected)) {
+  throw new Error(`Calm registered ${JSON.stringify(names)} synchronously at load with config/calm=on, expected ${JSON.stringify(expected)}`);
+}
+JS
+)
+  status=$?
+  [ "$status" -eq 0 ] || fail "Pi calm gate-at-load-time path failed: $out"
+  [ -z "$out" ] || fail "Pi calm gate-at-load-time test printed output: $out"
+  pass "Calm registers none of its 7 built-in tool wrappers at load while config/calm is off, and all 7 synchronously at load while config/calm is on"
+}
+
+test_calm_activation_collision_and_regression_bound() {
+  local fixture out status
+  if ! command -v node >/dev/null 2>&1 || ! command -v npm >/dev/null 2>&1; then
+    echo "skip: node or npm not found for Pi calm activation test"
+    return 0
+  fi
+  if [ ! -f "$PI_PACKAGE_DIR/package.json" ]; then
+    echo "skip: installed @earendil-works/pi-coding-agent package not found"
+    return 0
+  fi
+
+  fixture="$TMP_ROOT/activation-collision"
+  mkdir -p \
+    "$fixture/project/.pi/extensions/lib" \
+    "$fixture/project/node_modules/@earendil-works" \
+    "$fixture/home/config"
+  cp "$EXT" "$fixture/project/.pi/extensions/fm-calm.ts"
+  cp "$ASSISTANT_LAYOUT" "$fixture/project/.pi/extensions/lib/fm-calm-assistant-layout.ts"
+  cp "$OPERATIONAL_USER_LAYOUT" "$fixture/project/.pi/extensions/lib/fm-calm-operational-user-layout.ts"
+  cp "$VISIBILITY" "$fixture/project/.pi/extensions/lib/fm-calm-visibility.ts"
+  cp "$WORKING_SHIP" "$fixture/project/.pi/extensions/lib/fm-calm-working-ship.ts"
+  cp "$PI_OPERATIONAL_INPUT" "$fixture/project/.pi/extensions/lib/fm-operational-input.ts"
+  ln -s "$PI_PACKAGE_DIR" "$fixture/project/node_modules/@earendil-works/pi-coding-agent"
+  ln -s "$PI_PACKAGE_DIR/node_modules/@earendil-works/pi-tui" "$fixture/project/node_modules/@earendil-works/pi-tui"
+  ln -s "$PI_PACKAGE_DIR/node_modules/typebox" "$fixture/project/node_modules/typebox"
+  printf '%s\n' '{"type":"module"}' >"$fixture/project/package.json"
+  printf '%s\n' 'export default function () {}' >"$fixture/project/foreign-bash-extension.ts"
+
+  out=$(cd "$fixture/project" && \
+    EXT="$fixture/project/.pi/extensions/fm-calm.ts" \
+    FOREIGN_EXT="$fixture/project/foreign-bash-extension.ts" \
+    FM_HOME="$fixture/home" \
+    PI_PACKAGE_DIR="$PI_PACKAGE_DIR" \
+    node --input-type=module 2>&1 <<'JS'
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const packageRoot = process.env.PI_PACKAGE_DIR;
+const { ToolExecutionComponent } = await import(
+  pathToFileURL(`${packageRoot}/dist/modes/interactive/components/tool-execution.js`).href
+);
+const { initTheme } = await import(pathToFileURL(`${packageRoot}/dist/modes/interactive/theme/theme.js`).href);
+const { setCapabilities } = await import(
+  pathToFileURL(`${packageRoot}/node_modules/@earendil-works/pi-tui/dist/index.js`).href
+);
+initTheme("dark");
+setCapabilities({ images: null, trueColor: true, hyperlinks: false });
+
+// Reproduces the collision: a different, earlier-loaded extension already owns
+// "bash" by the time Calm's first activation runs, exactly as Pi's real
+// ExtensionRunner resolves same-name pi.registerTool() calls (first-registered-
+// extension-per-name wins, verified in the installed Pi package's
+// ExtensionRunner.getAllRegisteredTools).
+const foreignPath = fileURLToPath(pathToFileURL(process.env.FOREIGN_EXT).href);
+const FOREIGN_MARKER = "FOREIGN_BASH_EXECUTED";
+const foreignBash = {
+  name: "bash",
+  label: "Foreign bash",
+  description: "A different extension's own bash override, e.g. an approval gate.",
+  parameters: { type: "object", properties: {} },
+  async execute() {
+    return { content: [{ type: "text", text: FOREIGN_MARKER }], details: {}, isError: false };
+  },
+};
+
+const registry = new Map([["bash", { tool: foreignBash, ownerPath: foreignPath }]]);
+const notifications = [];
+const diagnostics = [];
+const originalConsoleError = console.error;
+console.error = (...args) => diagnostics.push(args.join(" "));
+
+const handlers = new Map();
+let calmCommand;
+const extPath = fileURLToPath(pathToFileURL(process.env.EXT).href);
+const pi = {
+  events: { emit() {}, on() {} },
+  on(event, handler) {
+    handlers.set(event, handler);
+  },
+  registerCommand(name, command) {
+    if (name === "calm") calmCommand = command;
+  },
+  registerEntryRenderer() {},
+  // Mirrors Pi's own arbitration: first registrant for a name keeps it, silently.
+  registerTool(tool) {
+    if (!registry.has(tool.name)) {
+      registry.set(tool.name, { tool, ownerPath: extPath });
+    }
+  },
+  getAllTools() {
+    return Array.from(registry.entries()).map(([name, { ownerPath }]) => ({
+      name,
+      sourceInfo: { source: "extension", path: ownerPath },
+    }));
+  },
+};
+
+let threw = false;
+try {
+  const extension = await import(`${pathToFileURL(process.env.EXT).href}?activation=${Date.now()}`);
+  extension.default(pi);
+} catch {
+  threw = true;
+}
+if (threw) throw new Error("Calm's own factory threw while config/calm was absent and another extension already owned bash");
+if (registry.size !== 1) {
+  throw new Error(`Calm registered built-ins at load time despite config/calm being absent: ${JSON.stringify(Array.from(registry.keys()))}`);
+}
+if (!calmCommand || !handlers.has("session_start")) {
+  throw new Error("Calm did not finish registering its command and session handler");
+}
+
+// A row constructed before Calm's first-ever activation this session: this is the
+// captain-accepted, documented bound on the gate-at-load fix (see fm-calm.ts's file
+// header and docs/calm.md) - Pi gives no way to re-point an already-constructed
+// ToolExecutionComponent at a definition registered later, so this row can never
+// retroactively collapse. Lock that in explicitly rather than let it regress further.
+const renderUi = { requestRender() {} };
+const preToggleReadArgs = { path: "sample.txt" };
+const preToggleRead = new ToolExecutionComponent(
+  "read",
+  "pre-toggle-read",
+  preToggleReadArgs,
+  { showImages: false },
+  registry.get("read")?.tool,
+  renderUi,
+  process.cwd(),
+);
+preToggleRead.markExecutionStarted();
+preToggleRead.setArgsComplete();
+preToggleRead.updateResult({ content: [{ type: "text", text: "PRE_TOGGLE_READ_OUTPUT" }], details: {}, isError: false });
+const preToggleRenderedBefore = preToggleRead.render(100);
+if (preToggleRenderedBefore.length === 0) {
+  throw new Error("a tool row rendered as hidden before Calm was ever activated");
+}
+
+const ctx = {
+  ui: {
+    getEditorText: () => "",
+    getToolsExpanded: () => false,
+    onTerminalInput: () => () => {},
+    setHiddenThinkingLabel() {},
+    setStatus() {},
+    setToolsExpanded() {},
+    setWorkingVisible() {},
+    notify(message, type) {
+      notifications.push({ message, type });
+    },
+  },
+};
+console.error = (...args) => diagnostics.push(args.join(" "));
+await calmCommand.handler("", ctx);
+console.error = originalConsoleError;
+
+const bashEntry = registry.get("bash");
+if (bashEntry.tool !== foreignBash) {
+  throw new Error("Calm replaced the foreign extension's bash registration instead of leaving it alone");
+}
+const bashResult = await bashEntry.tool.execute();
+if (bashResult.content[0]?.text !== FOREIGN_MARKER) {
+  throw new Error("the foreign extension's bash tool no longer executes its own real behavior");
+}
+for (const name of ["read", "edit", "write", "grep", "find", "ls"]) {
+  const entry = registry.get(name);
+  if (!entry || entry.ownerPath !== extPath) {
+    throw new Error(`Calm failed to claim the uncontested built-in "${name}" on first activation`);
+  }
+}
+
+// Part C: a single, prominent, user-facing warning naming the contested tool, not
+// merely a console diagnostic.
+if (notifications.length !== 1) {
+  throw new Error(`expected exactly one contested-tool notification, saw ${JSON.stringify(notifications)}`);
+}
+if (notifications[0].type !== "warning") {
+  throw new Error(`contested-tool notification was not type "warning": ${JSON.stringify(notifications[0])}`);
+}
+if (!notifications[0].message.includes("bash") || !notifications[0].message.toLowerCase().includes("calm")) {
+  throw new Error(`contested-tool notification did not name the tool clearly: ${JSON.stringify(notifications[0])}`);
+}
+const sawBashDiagnostic = diagnostics.some((line) => line.includes("bash"));
+if (!sawBashDiagnostic) {
+  throw new Error(`expected a console diagnostic naming the skipped built-in too; saw: ${JSON.stringify(diagnostics)}`);
+}
+
+// The documented bound itself: still non-empty after Calm is now active, because it
+// was constructed before Calm ever claimed anything.
+if (preToggleRead.render(100).length === 0) {
+  throw new Error("a pre-activation tool row retroactively hid after Calm turned on; the documented bound regressed");
+}
+
+// A row for the same tool constructed after activation behaves normally: it does hide.
+const postToggleRead = new ToolExecutionComponent(
+  "read",
+  "post-toggle-read",
+  preToggleReadArgs,
+  { showImages: false },
+  registry.get("read")?.tool,
+  renderUi,
+  process.cwd(),
+);
+postToggleRead.markExecutionStarted();
+postToggleRead.setArgsComplete();
+postToggleRead.updateResult({ content: [{ type: "text", text: "POST_TOGGLE_READ_OUTPUT" }], details: {}, isError: false });
+if (postToggleRead.render(100).length !== 0) {
+  throw new Error("a tool row constructed after Calm's activation did not hide");
+}
+JS
+)
+  status=$?
+  [ "$status" -eq 0 ] || fail "Pi calm activation/collision/regression-bound path failed: $out"
+  [ -z "$out" ] || fail "Pi calm activation/collision/regression-bound test printed output: $out"
+  pass "Calm's first same-session /calm activation claims every uncontested built-in, leaves a foreign bash tool fully intact and callable, warns prominently and logs the contested name, and only rows constructed before that activation - the documented bound - fail to retroactively collapse"
+}
+
 test_rendering_and_session_lifecycle() {
   local fixture out status version
   if ! command -v node >/dev/null 2>&1 || ! command -v npm >/dev/null 2>&1; then
@@ -385,7 +689,13 @@ SH
 
   out=$(cd "$fixture" && EXT="$fixture/fm-calm.ts" WATCH_EXT="$fixture/fm-primary-pi-watch.ts" FM_HOME="$fixture/home" FM_OPERATIONAL_INPUT_SCRIPT="$fixture/operational-input-probe.sh" FM_OPERATIONAL_INPUT_OWNER="$OPERATIONAL_INPUT" FM_OPERATIONAL_INPUT_CALLS="$fixture/operational-input-calls" PI_PACKAGE_DIR="$PI_PACKAGE_DIR" node --input-type=module 2>&1 <<'JS'
 import { readFileSync, writeFileSync } from "node:fs";
-import { pathToFileURL } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+// fm-calm.ts derives its own identity the same way (fileURLToPath(import.meta.url)),
+// which normalizes away irregularities like a symlinked TMPDIR (macOS /tmp, /var);
+// comparing against the raw env var would spuriously read this fixture's own
+// registration as foreign.
+const extPath = fileURLToPath(pathToFileURL(process.env.EXT).href);
 
 const packageRoot = process.env.PI_PACKAGE_DIR;
 const [{ AssistantMessageComponent }, { CustomEntryComponent }, { ToolExecutionComponent }, { UserMessageComponent }, { InteractiveMode }, { initTheme, theme }, { Text, getKeybindings, setCapabilities }, { createToolHtmlRenderer }] = await Promise.all([
@@ -429,13 +739,46 @@ const pi = {
     entryRenderers.set(customType, renderer);
   },
   registerTool(tool) {
-    tools.push(tool);
+    const existingIndex = tools.findIndex((existing) => existing.name === tool.name);
+    if (existingIndex === -1) tools.push(tool);
+    else tools[existingIndex] = tool;
+  },
+  getAllTools() {
+    // Only Calm itself has registered anything in this fixture, so every entry
+    // reports Calm's own extension path; the dedicated collision fixture below is
+    // what exercises a foreign extension already owning a name.
+    return tools.map((tool) => ({
+      name: tool.name,
+      sourceInfo: { source: "extension", path: extPath },
+    }));
   },
 };
 const extension = await import(`${pathToFileURL(process.env.EXT).href}?test=${Date.now()}`);
 extension.default(pi);
 const visibility = await import(`${pathToFileURL(`${process.cwd()}/lib/fm-calm-visibility.ts`).href}?policy=${Date.now()}`);
 const operationalInput = await import(`${pathToFileURL(`${process.cwd()}/lib/fm-operational-input.ts`).href}?input=${Date.now()}`);
+
+// Registration is gated on config/calm at load (see fm-calm.ts's file header); this
+// fixture has no config/calm file, so nothing is registered yet. Every render-
+// equivalence assertion below needs the wrapped definitions the way a user who kept
+// Calm on across a previous session would already have them, so force that here via
+// the same /calm command path a real activation uses, then round-trip back off so the
+// rest of this fixture's own off/on toggle sequence still observes its usual starting
+// state. This does not touch the calm-off/toggle-on assertions further down: those
+// exercise activateBuiltInsIfNeeded's own contested-name skip and warning through the
+// dedicated fixture below, not this one.
+const earlyActivationUi = {
+  getEditorText: () => "",
+  getToolsExpanded: () => false,
+  onTerminalInput: () => () => {},
+  setHiddenThinkingLabel() {},
+  setStatus() {},
+  setToolsExpanded() {},
+  setWorkingVisible() {},
+  notify() {},
+};
+await calmCommand.handler("", { ui: earlyActivationUi });
+await calmCommand.handler("", { ui: earlyActivationUi });
 
 const names = tools.map((tool) => tool.name);
 const expectedNames = ["read", "bash", "edit", "write", "grep", "find", "ls"];
@@ -2185,6 +2528,9 @@ const pi = {
   },
   registerEntryRenderer() {},
   registerTool() {},
+  getAllTools() {
+    return [];
+  },
   appendEntry: (...args) => sessionWrites.push(["appendEntry", ...args]),
   sendMessage: (...args) => sessionWrites.push(["sendMessage", ...args]),
   sendUserMessage: (...args) => sessionWrites.push(["sendUserMessage", ...args]),
@@ -2228,6 +2574,7 @@ const ui = {
   setHiddenThinkingLabel() {},
   setStatus() {},
   setToolsExpanded() {},
+  notify() {},
   theme,
 };
 const ctx = { ui };
@@ -2718,11 +3065,18 @@ JSON
   tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" M-s
   active_screen_wait=0
   while [ "$active_screen_wait" -lt 120 ]; do
-    tmux -L "$TMUX_SOCKET" capture-pane -p -t "$TMUX_SESSION" >"$hidden_snapshot"
-    # Wait for the redraw this block actually asserts: hidden rows gone AND the
-    # retained genuine rows back on screen. Breaking on the hidden rows alone can
-    # observe a half-redrawn transcript.
-    if ! grep -Fq "CALM_E2E_OUTPUT" "$hidden_snapshot" &&
+    # Include scrollback: the built-in tool rows this documented bound keeps visible
+    # (see below) lengthen the transcript enough to push earlier genuine content, such
+    # as the original user prompt, above the plain viewport.
+    tmux -L "$TMUX_SOCKET" capture-pane -p -t "$TMUX_SESSION" -S -600 >"$hidden_snapshot"
+    # Wait for the redraw this block actually asserts: the collapsed-thinking adapter
+    # (unconditional, unaffected by the built-in tool gate below) hides, and the
+    # retained genuine rows are back on screen. Built-in tool rows from before this
+    # first-ever activation are a separate, documented exception (see fm-calm.ts's
+    # file header and docs/calm.md): Pi gives no way to re-point an already-rendered
+    # tool row at a definition registered later, so CALM_E2E_OUTPUT and friends stay
+    # on screen through this whole redraw rather than disappearing with it.
+    if ! grep -Fq "Thinking..." "$hidden_snapshot" &&
       ! grep -Fq "/calm" "$hidden_snapshot" &&
       grep -Fq "FIRSTMATE WATCHER WAKE: can you explain this phrase?" "$hidden_snapshot" &&
       grep -Fq "The deterministic tool example is complete." "$hidden_snapshot"; then
@@ -2731,12 +3085,20 @@ JSON
     sleep 0.05
     active_screen_wait=$((active_screen_wait + 1))
   done
-  assert_not_contains "$(cat "$hidden_snapshot")" "CALM_E2E_OUTPUT" "/calm left tool result output in the transcript"
+  # This session's built-in tool rows (bash/grep/find) were all rendered during the
+  # initial session restore, before Calm's first-ever activation in this session had
+  # claimed any built-in name; they keep their stock presentation for the rest of the
+  # session. This is the captain-accepted, documented bound on the collision fix (see
+  # fm-calm.ts's file header and docs/calm.md): the alternative was letting Calm
+  # silently disable a differently loaded extension's own bash/read/etc override. A
+  # fresh built-in tool call made after this same activation does hide correctly;
+  # that path is covered by this file's own test_calm_activation_collision_and
+  # _regression_bound against real Pi rendering components, not repeated here.
+  assert_contains "$(cat "$hidden_snapshot")" "CALM_E2E_OUTPUT" "a pre-activation built-in tool row unexpectedly hid; the documented bound regressed"
   assert_not_contains "$(cat "$hidden_snapshot")" "calm transcript" "/calm added a persistent Calm status row"
   [ "$(cat "$home/config/calm")" = on ] || fail "/calm did not persist its active choice"
-  assert_not_contains "$(cat "$hidden_snapshot")" "CALM_EXPORT_GREP" "/calm left the grep row in the transcript"
-  assert_not_contains "$(cat "$hidden_snapshot")" "CALM_EXPORT_FIND" "/calm left the find row in the transcript"
-  assert_not_contains "$(cat "$hidden_snapshot")" "\$ printf" "/calm left the tool-call row in the transcript"
+  assert_contains "$(cat "$hidden_snapshot")" "CALM_EXPORT_GREP" "a pre-activation grep row unexpectedly hid; the documented bound regressed"
+  assert_contains "$(cat "$hidden_snapshot")" "CALM_EXPORT_FIND" "a pre-activation find row unexpectedly hid; the documented bound regressed"
   assert_not_contains "$(cat "$hidden_snapshot")" "Thinking..." "/calm left collapsed thinking labels in the transcript"
   assert_not_contains "$(cat "$hidden_snapshot")" "fm_watch_arm_pi" "/calm left the Firstmate watcher tool call shell in the transcript"
   assert_not_contains "$(cat "$hidden_snapshot")" "watcher: started Pi extension arm child" "/calm left the Firstmate watcher tool result in the transcript"
@@ -2943,10 +3305,13 @@ JS
   tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" -l "/calm"
   tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" M-s
   active_screen_wait=0
+  # CALM_E2E_OUTPUT is not a useful redraw signal here: it is the pre-activation
+  # bash row covered by the documented bound above, so it never leaves the screen
+  # again this session regardless of this toggle.
   while [ "$active_screen_wait" -lt 120 ]; do
     tmux -L "$TMUX_SOCKET" capture-pane -p -t "$TMUX_SESSION" >"$working_snapshot"
-    if ! grep -Fq "CALM_E2E_OUTPUT" "$working_snapshot" &&
-      ! grep -Fq "/calm" "$working_snapshot"; then
+    if ! grep -Fq "/calm" "$working_snapshot" &&
+      [ "$(cat "$home/config/calm")" = on ]; then
       break
     fi
     sleep 0.05
@@ -3277,6 +3642,8 @@ test_home_resolution
 test_pi_compat_no_upper_bound
 test_pi_compat_degraded_adapter
 test_pi_compat_missing_adapter_exports
+test_builtin_gate_load_time
+test_calm_activation_collision_and_regression_bound
 test_rendering_and_session_lifecycle
 test_operational_followup_turn_e2e
 test_hidden_block_geometry_e2e

--- a/tests/fm-calm-pi-extension.test.sh
+++ b/tests/fm-calm-pi-extension.test.sh
@@ -355,7 +355,7 @@ JS
 }
 
 test_builtin_gate_load_time() {
-  local fixture out status
+  local fixture out output_file status
   if ! command -v node >/dev/null 2>&1 || ! command -v npm >/dev/null 2>&1; then
     echo "skip: node or npm not found for Pi calm gate test"
     return 0
@@ -383,11 +383,12 @@ test_builtin_gate_load_time() {
   printf '%s\n' '{"type":"module"}' >"$fixture/project/package.json"
   printf '%s\n' on >"$fixture/home-on/config/calm"
 
-  out=$(cd "$fixture/project" && \
+  output_file="$fixture/node-output"
+  (cd "$fixture/project" && \
     EXT="$fixture/project/.pi/extensions/fm-calm.ts" \
     HOME_OFF="$fixture/home-off" \
     HOME_ON="$fixture/home-on" \
-    node --input-type=module 2>&1 <<'JS'
+    node --input-type=module) >"$output_file" 2>&1 <<'JS'
 import { pathToFileURL } from "node:url";
 
 function fakePi() {
@@ -433,15 +434,15 @@ if (JSON.stringify(names) !== JSON.stringify(expected)) {
   throw new Error(`Calm registered ${JSON.stringify(names)} synchronously at load with config/calm=on, expected ${JSON.stringify(expected)}`);
 }
 JS
-)
   status=$?
+  out=$(cat "$output_file")
   [ "$status" -eq 0 ] || fail "Pi calm gate-at-load-time path failed: $out"
   [ -z "$out" ] || fail "Pi calm gate-at-load-time test printed output: $out"
   pass "Calm registers none of its 7 built-in tool wrappers at load while config/calm is off, and all 7 synchronously at load while config/calm is on"
 }
 
 test_calm_activation_collision_and_regression_bound() {
-  local fixture out status
+  local fixture out output_file status
   if ! command -v node >/dev/null 2>&1 || ! command -v npm >/dev/null 2>&1; then
     echo "skip: node or npm not found for Pi calm activation test"
     return 0
@@ -468,12 +469,13 @@ test_calm_activation_collision_and_regression_bound() {
   printf '%s\n' '{"type":"module"}' >"$fixture/project/package.json"
   printf '%s\n' 'export default function () {}' >"$fixture/project/foreign-bash-extension.ts"
 
-  out=$(cd "$fixture/project" && \
+  output_file="$fixture/node-output"
+  (cd "$fixture/project" && \
     EXT="$fixture/project/.pi/extensions/fm-calm.ts" \
     FOREIGN_EXT="$fixture/project/foreign-bash-extension.ts" \
     FM_HOME="$fixture/home" \
     PI_PACKAGE_DIR="$PI_PACKAGE_DIR" \
-    node --input-type=module 2>&1 <<'JS'
+    node --input-type=module) >"$output_file" 2>&1 <<'JS'
 import { fileURLToPath, pathToFileURL } from "node:url";
 
 const packageRoot = process.env.PI_PACKAGE_DIR;
@@ -647,15 +649,15 @@ if (postToggleRead.render(100).length !== 0) {
   throw new Error("a tool row constructed after Calm's activation did not hide");
 }
 JS
-)
   status=$?
+  out=$(cat "$output_file")
   [ "$status" -eq 0 ] || fail "Pi calm activation/collision/regression-bound path failed: $out"
   [ -z "$out" ] || fail "Pi calm activation/collision/regression-bound test printed output: $out"
   pass "Calm's first same-session /calm activation claims every uncontested built-in, leaves a foreign bash tool fully intact and callable, warns prominently and logs the contested name, and only rows constructed before that activation - the documented bound - fail to retroactively collapse"
 }
 
 test_rendering_and_session_lifecycle() {
-  local fixture out status version
+  local fixture out output_file status version
   if ! command -v node >/dev/null 2>&1 || ! command -v npm >/dev/null 2>&1; then
     echo "skip: node or npm not found for Pi calm renderer test"
     return 0
@@ -687,7 +689,8 @@ exec "$FM_OPERATIONAL_INPUT_OWNER" "$@"
 SH
   chmod +x "$fixture/operational-input-probe.sh"
 
-  out=$(cd "$fixture" && EXT="$fixture/fm-calm.ts" WATCH_EXT="$fixture/fm-primary-pi-watch.ts" FM_HOME="$fixture/home" FM_OPERATIONAL_INPUT_SCRIPT="$fixture/operational-input-probe.sh" FM_OPERATIONAL_INPUT_OWNER="$OPERATIONAL_INPUT" FM_OPERATIONAL_INPUT_CALLS="$fixture/operational-input-calls" PI_PACKAGE_DIR="$PI_PACKAGE_DIR" node --input-type=module 2>&1 <<'JS'
+  output_file="$fixture/node-output"
+  (cd "$fixture" && EXT="$fixture/fm-calm.ts" WATCH_EXT="$fixture/fm-primary-pi-watch.ts" FM_HOME="$fixture/home" FM_OPERATIONAL_INPUT_SCRIPT="$fixture/operational-input-probe.sh" FM_OPERATIONAL_INPUT_OWNER="$OPERATIONAL_INPUT" FM_OPERATIONAL_INPUT_CALLS="$fixture/operational-input-calls" PI_PACKAGE_DIR="$PI_PACKAGE_DIR" node --input-type=module) >"$output_file" 2>&1 <<'JS'
 import { readFileSync, writeFileSync } from "node:fs";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
@@ -1342,8 +1345,8 @@ if (JSON.stringify(wrappedResult) !== JSON.stringify(originalResult)) {
   throw new Error("calm wrapper changed built-in read execution or result data");
 }
 JS
-)
   status=$?
+  out=$(cat "$output_file")
   [ "$status" -eq 0 ] || fail "Pi calm renderer and lifecycle contract failed: $out"
   [ -z "$out" ] || fail "Pi calm renderer test printed output: $out"
   pass "Pi calm centralizes transcript visibility, preserves execution/export data, keeps Pi's stock working row visible while no run is active, and persists its choice across session starts"


### PR DESCRIPTION
## Intent

Fix fm-calm.ts (.pi/extensions/fm-calm.ts) so it no longer collides with other Pi extensions when applying Calm presentation rendering: it registered wrapped versions of Pi's 7 built-in tools (read, bash, edit, write, grep, find, ls) unconditionally at extension load via pi.registerTool(), regardless of whether Calm was on. Pi resolves two extensions registering the same built-in tool name by first-registered-extension-wins with no merge and no unregister call (verified against installed Pi 0.80.10 and 0.82.0 source), and fm-calm.ts's project-local .pi/extensions/ position beats any global or CLI-configured extension, so even a user who never enabled Calm could have their own bash/read/etc override silently replaced.

A prior attempt (option A, deferring registration to session_start with a pi.getAllTools() collision check) was implemented, then reverted after tests/fm-calm-pi-extension.test.sh's hidden-block-geometry E2E proved it breaks /reload: /reload (and ctx.newSession/fork/switchSession) render the restored transcript from a pre-session_start snapshot of the tool registry, so a session_start-deferred claim misses that render for every already-open built-in tool row. A full feasibility investigation followed (Pi-source-backed, both installed 0.80.10 and running 0.82.0), producing a report with a confident verdict: WRAP-THEIRS (reading back another extension's full ToolDefinition to wrap it) is not feasible anywhere, because pi.getAllTools() returns metadata only (name/description/parameters/sourceInfo, no execute/renderCall/renderResult) and no exposed API returns a full definition. SKIP-IF-CONTESTED (checking pi.getAllTools() before claiming a name) is feasible only post-bind, i.e. only for a same-session dynamic /calm activation, not for the load-time/session_start/reload path.

Captain approved this plan (with one modification to part C) and authorized implementation:
Part A: gate the 7 built-in tool-wrapper registrations on config/calm==on at load time (synchronous, during the extension factory's own execution, not deferred) so a Calm-off session or reload registers nothing and a non-Calm user never contests a name. Accept one confirmed, bounded, documented trade-off: the first time a session that started Calm-off turns Calm on, tool-call rows already on screen from before that toggle do not retroactively collapse, because Pi's ToolExecutionComponent captures its tool definition once at construction with no re-read hook; every session after that first toggle starts with the preference already on and takes the same synchronous load-time path, so the guarantee is intact from then on.
Part B: dynamic, collision-checked registration inside the /calm command handler for the first same-session activation - skip contested names via pi.getAllTools() plus a realpath-normalized sourceInfo.path comparison (symlink-safe: macOS symlinks /tmp and /var to /private/..., which would otherwise misreport Calm's own registration as foreign) - leaving the other extension's own same-named tool fully intact and callable.
Part C (captain-modified from the original report's recommendation to file an upstream Pi report): instead, when a user toggles /calm on and a contested tool is detected, print a prominent user-facing warning via ctx.ui.notify(message, 'warning') naming the conflicting tool, plus a console diagnostic. Keep the pre-existing session-start loss diagnostic (reportBuiltInLosses) as the backstop for the one residual case neither part can reach: a session that starts or reloads with Calm already on, where the registry snapshot is taken before Calm gets any chance to check ownership.

Option B (changing how firstmate launches Pi so Calm loads from a weaker extension tier) is explicitly off the table per the captain: Calm is a primary-firstmate-only presentation feature, not something crewmates launch, so that approach does not apply.

Delivered and committed on this branch (fm/fm-calm-collision-gate-fix, built fresh off origin/main - the prior option-A branch fm/fm-calm-builtin-tool-name-collision is reference only, not built upon): the Part A/B/C implementation in .pi/extensions/fm-calm.ts; updated docs/calm.md documenting the new gate-at-load behavior and the documented bound; and tests/fm-calm-pi-extension.test.sh changes - two new tests (test_builtin_gate_load_time verifying config/calm off registers nothing and on registers all 7 synchronously at load; test_calm_activation_collision_and_regression_bound verifying first-activation claims every uncontested built-in, leaves a foreign bash tool fully intact and callable including its execute(), fires the prominent ctx.ui.notify warning and a console diagnostic naming the contested tool, and locks in the documented pre-activation bound against real Pi ToolExecutionComponent rendering) plus updates to the existing test_rendering_and_session_lifecycle and the full live interactive-terminal E2E test to match the new gate-at-load and first-activation-bound contract. All 10 tests in that file pass (including the real tmux/pi live E2E), strict Pi extension typecheck passes, and bin/fm-lint.sh is clean.

## What Changed

- Register Calm’s seven built-in tool wrappers synchronously only when Calm is already enabled, avoiding tool-name collisions for Calm-off sessions.
- On first same-session activation, claim only uncontested built-ins and warn when another extension owns a tool; normalize ownership paths for symlink-safe checks.
- Document the collision behavior and non-retroactive first-toggle limitation, with regression coverage for load-time gating, contested tools, warnings, and preserved execution.

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>
</details>
<details>
<summary>✅ **Rebase** - passed</summary>
</details>
<details>
<summary>✅ **Review** - completed</summary>
</details>
<details>
<summary>✅ **Test** - passed</summary>
</details>
<details>
<summary>✅ **Document** - passed</summary>
</details>
<details>
<summary>✅ **Lint** - passed</summary>
</details>
<details>
<summary>✅ **Push** - passed</summary>
</details>
