### PR TITLE
fix(bin): persist secondmate parent bindings for cleanup

### DIFF
--- a/.agents/skills/secondmate-provisioning/SKILL.md
+++ b/.agents/skills/secondmate-provisioning/SKILL.md
@@ -82,7 +82,7 @@ The slot stays reserved across restarts until the lease is released.
 Release happens only on explicit retirement or seed rollback, never on routine restart or recovery.
 
 `bin/fm-home-seed.sh` copies the charter into the secondmate home as `data/charter.md`.
-It also writes the required `.fm-secondmate-home` identity marker, which is gitignored and must remain in place for home validation.
+It also writes the gitignored `.fm-secondmate-parent` durable binding before the required `.fm-secondmate-home` identity marker; the parser header in [`bin/fm-secondmate-parent-lib.sh`](../../../bin/fm-secondmate-parent-lib.sh) owns the record contract, and both files must remain in place.
 `bin/fm-spawn.sh --secondmate` launches it through the secondmate harness path, resolving `config/secondmate-harness` -> `config/crew-harness` -> the primary's own harness unless an explicit per-spawn harness override is passed.
 
 `config/secondmate-harness` may also pin a concrete model and effort for the secondmate agent, in the SAME file rather than a new one: the format is a single whitespace-separated line `<harness> [<model>] [<effort>]`, with only the first non-empty, non-comment line parsed.

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ data/
 .no-mistakes/
 .lavish/
 .fm-secondmate-home
+.fm-secondmate-parent
 .DS_Store
 __pycache__/
 *.pyc

--- a/bin/fm-home-seed.sh
+++ b/bin/fm-home-seed.sh
@@ -40,6 +40,7 @@ PROJECTS="${FM_PROJECTS_OVERRIDE:-$FM_HOME/projects}"
 STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
 REG="$DATA/secondmates.md"
 SUB_HOME_MARKER=".fm-secondmate-home"
+SUB_HOME_PARENT_MARKER=".fm-secondmate-parent"
 # shellcheck source=bin/fm-secondmate-registry-lib.sh
 . "$SCRIPT_DIR/fm-secondmate-registry-lib.sh"
 # shellcheck source=bin/fm-secondmate-charter-lib.sh
@@ -284,7 +285,7 @@ validate_operational_dirs() {
 validate_seed_leaf_files() {
   local home=$1 label path abs_home abs_path
   abs_home=$(resolved_path "$home")
-  for label in "data/projects.md" "data/charter.md" "$SUB_HOME_MARKER"; do
+  for label in "data/projects.md" "data/charter.md" "$SUB_HOME_MARKER" "$SUB_HOME_PARENT_MARKER"; do
     path="$home/$label"
     if [ -L "$path" ]; then
       echo "error: secondmate leaf file must not be a symlink: $path" >&2
@@ -507,6 +508,7 @@ SEED_PARENT_BRIEF_DIR_CREATED=0
 SEED_SUB_REG_EXISTED=0
 SEED_CHARTER_EXISTED=0
 SEED_MARKER_EXISTED=0
+SEED_PARENT_MARKER_EXISTED=0
 
 restore_seed_file() {
   local existed=$1 backup=$2 path=$3
@@ -626,6 +628,7 @@ seed_rollback() {
       fi
       if [ -n "${SEED_BACKUP_DIR:-}" ] && [ "${SEED_HOME_BACKED_UP:-0}" = 1 ]; then
         restore_seed_file "$SEED_MARKER_EXISTED" "$SEED_BACKUP_DIR/marker" "$SEED_HOME/$SUB_HOME_MARKER"
+        restore_seed_file "$SEED_PARENT_MARKER_EXISTED" "$SEED_BACKUP_DIR/parent-marker" "$SEED_HOME/$SUB_HOME_PARENT_MARKER"
         restore_seed_file "$SEED_CHARTER_EXISTED" "$SEED_BACKUP_DIR/charter.md" "$SEED_HOME/data/charter.md"
         restore_seed_file "$SEED_SUB_REG_EXISTED" "$SEED_BACKUP_DIR/sub-projects.md" "$SEED_HOME/data/projects.md"
       fi
@@ -869,6 +872,10 @@ seed_home() {
     SEED_MARKER_EXISTED=1
     cp "$home/$SUB_HOME_MARKER" "$SEED_BACKUP_DIR/marker"
   fi
+  if [ -f "$home/$SUB_HOME_PARENT_MARKER" ]; then
+    SEED_PARENT_MARKER_EXISTED=1
+    cp "$home/$SUB_HOME_PARENT_MARKER" "$SEED_BACKUP_DIR/parent-marker"
+  fi
   SEED_HOME_BACKED_UP=1
 
   if [ ! -f "$SEED_PARENT_BRIEF" ]; then
@@ -918,6 +925,16 @@ seed_home() {
 
   projects_csv=$(join_projects "$@")
   printf '%s\n' "$id" > "$home/$SUB_HOME_MARKER"
+  # Durable record of this home's route to its parent, written once here next
+  # to the identity marker: the cleanup check in fm-teardown.sh reads it so a
+  # restart that drops the launch-time FM_PUBLIC_FOLLOWUP_PRIMARY_HOME prefix
+  # can still resolve the real parent instead of silently treating its relay
+  # as inactive.
+  {
+    printf 'schema=fm-secondmate-parent.v1\n'
+    printf 'route=local\n'
+    printf 'parent_home=%s\n' "$(resolved_path "$FM_HOME")"
+  } > "$home/$SUB_HOME_PARENT_MARKER"
   write_registry "$id" "$home" "$projects_csv" "$SEED_PARENT_BRIEF"
   validate_registry
   SEED_COMMITTED=1

--- a/bin/fm-home-seed.sh
+++ b/bin/fm-home-seed.sh
@@ -924,7 +924,6 @@ seed_home() {
   cp "$SEED_PARENT_BRIEF" "$home/data/charter.md"
 
   projects_csv=$(join_projects "$@")
-  printf '%s\n' "$id" > "$home/$SUB_HOME_MARKER"
   # Durable record of this home's route to its parent, written once here next
   # to the identity marker: the cleanup check in fm-teardown.sh reads it so a
   # restart that drops the launch-time FM_PUBLIC_FOLLOWUP_PRIMARY_HOME prefix
@@ -934,7 +933,10 @@ seed_home() {
     printf 'schema=fm-secondmate-parent.v1\n'
     printf 'route=local\n'
     printf 'parent_home=%s\n' "$(resolved_path "$FM_HOME")"
-  } > "$home/$SUB_HOME_PARENT_MARKER"
+  } > "$home/$SUB_HOME_PARENT_MARKER.tmp.$$"
+  mv -f -- "$home/$SUB_HOME_PARENT_MARKER.tmp.$$" "$home/$SUB_HOME_PARENT_MARKER"
+  printf '%s\n' "$id" > "$home/$SUB_HOME_MARKER.tmp.$$"
+  mv -f -- "$home/$SUB_HOME_MARKER.tmp.$$" "$home/$SUB_HOME_MARKER"
   write_registry "$id" "$home" "$projects_csv" "$SEED_PARENT_BRIEF"
   validate_registry
   SEED_COMMITTED=1

--- a/bin/fm-home-seed.sh
+++ b/bin/fm-home-seed.sh
@@ -16,8 +16,8 @@
 #       refuses a home with project clones or project-registry entries, so it
 #       never converts populated homes in place. The charter brief
 #       is copied to data/charter.md, newly cloned no-mistakes projects are
-#       initialized, an ignored .fm-secondmate-home identity marker is written, and
-#       data/secondmates.md is updated.
+#       initialized, an ignored .fm-secondmate-parent binding is published before
+#       the .fm-secondmate-home identity marker, and data/secondmates.md is updated.
 #       Seeding is transactional: on validation, clone, init, or registry failure,
 #       generated briefs, new homes, new project clones, and registry edits are
 #       rolled back. Treehouse-acquired homes are returned only when the rollback

--- a/bin/fm-home-seed.sh
+++ b/bin/fm-home-seed.sh
@@ -292,6 +292,10 @@ validate_seed_leaf_files() {
       return 1
     fi
     [ -e "$path" ] || continue
+    if [ ! -f "$path" ]; then
+      echo "error: secondmate leaf file must be a regular file: $path" >&2
+      return 1
+    fi
     abs_path=$(resolved_path "$path")
     case "$abs_path" in
       "$abs_home"/*) ;;

--- a/bin/fm-home-seed.sh
+++ b/bin/fm-home-seed.sh
@@ -43,6 +43,8 @@ SUB_HOME_MARKER=".fm-secondmate-home"
 SUB_HOME_PARENT_MARKER=".fm-secondmate-parent"
 # shellcheck source=bin/fm-secondmate-registry-lib.sh
 . "$SCRIPT_DIR/fm-secondmate-registry-lib.sh"
+# shellcheck source=bin/fm-secondmate-parent-lib.sh
+. "$SCRIPT_DIR/fm-secondmate-parent-lib.sh"
 # shellcheck source=bin/fm-secondmate-charter-lib.sh
 . "$SCRIPT_DIR/fm-secondmate-charter-lib.sh"
 # shellcheck source=bin/fm-wake-lib.sh
@@ -305,6 +307,21 @@ validate_seed_leaf_files() {
         ;;
     esac
   done
+}
+
+validate_existing_parent_binding() {
+  local home=$1 record recorded_parent requested_parent
+  record="$home/$SUB_HOME_PARENT_MARKER"
+  [ -f "$record" ] && [ ! -L "$record" ] || return 0
+  fm_secondmate_parent_record_parse "$record" || return 0
+  [ "$FM_SECONDMATE_PARENT_ROUTE" = local ] || return 0
+
+  recorded_parent=$(resolved_path "$FM_SECONDMATE_PARENT_HOME")
+  requested_parent=$(resolved_path "$FM_HOME")
+  [ "$recorded_parent" = "$requested_parent" ] && return 0
+  printf 'error: secondmate home is bound to parent %s, not requested parent %s\n' \
+    "$recorded_parent" "$requested_parent" >&2
+  return 1
 }
 
 validate_project_destination() {
@@ -857,6 +874,7 @@ seed_home() {
   validate_home_assignment "$id" "$home"
   validate_operational_dirs "$home" || return 1
   validate_seed_leaf_files "$home" || return 1
+  validate_existing_parent_binding "$home" || return 1
   if [ "$no_projects" -eq 1 ]; then
     refuse_populated_projectless_home "$home" || return 1
     if [ -f "$SEED_PARENT_BRIEF" ]; then

--- a/bin/fm-remote-home-provision.sh
+++ b/bin/fm-remote-home-provision.sh
@@ -4,10 +4,15 @@
 # Usage:
 #   fm-remote-home-provision.sh < manifest
 #
-# Manifest schema fm-remote-home-provision.v1 carries a base64 charter and one
-# base64 project record per line. The remote code root is cloned into an absent
-# home, project origins are cloned on this host, the project registry and charter
-# are published, and the .fm-secondmate-home marker commits the seed last.
+# Manifest schema fm-remote-home-provision.v1 carries a base64 charter, the
+# base64 parent SSH alias, and one base64 project record per line. The remote
+# code root is cloned into an absent home, project origins are cloned on this
+# host, the project registry and charter are published, and the
+# .fm-secondmate-home marker commits the seed last, alongside a durable
+# .fm-secondmate-parent record naming this home's route to its parent as
+# "remote" - read by bin/fm-teardown.sh's cleanup gate so a delegated public
+# reply promise, which the subsystem can only carry on the parent's own
+# filesystem, is never mistaken for one this child could hold.
 # A newly created home is removed on failure. An existing matching seeded home
 # is converged only through guarded ordinary-file updates and new project clones.
 set -eu
@@ -71,6 +76,7 @@ rollback() {
       restore_owned_file data/charter.md || true
       restore_owned_file data/projects.md || true
       restore_owned_file .fm-secondmate-home || true
+      restore_owned_file .fm-secondmate-parent || true
       [ "$CREATED_BACKLOG" -eq 0 ] || rm -f -- "$FM_HOME/data/backlog.md"
     fi
   fi
@@ -87,9 +93,18 @@ SCHEMA=$(manifest_value "$TMP/manifest" schema || true)
 [ "$SCHEMA" = fm-remote-home-provision.v1 ] || die "incompatible provisioning manifest"
 ID_B64=$(manifest_value "$TMP/manifest" id_b64 || true)
 CHARTER_B64=$(manifest_value "$TMP/manifest" charter_b64 || true)
+# Optional so a manifest sent by a not-yet-updated parent (predating this
+# field) still provisions; the durable parent record below simply omits the
+# host in that case rather than refusing the whole seed.
+PARENT_HOST_B64=$(manifest_value "$TMP/manifest" parent_host_b64 || true)
 COUNT=$(manifest_value "$TMP/manifest" project_count || true)
 base64_decode_to "$ID_B64" "$TMP/id" || die "manifest id is not valid base64"
 base64_decode_to "$CHARTER_B64" "$TMP/charter" || die "manifest charter is not valid base64"
+PARENT_HOST=
+if [ -n "$PARENT_HOST_B64" ]; then
+  base64_decode_to "$PARENT_HOST_B64" "$TMP/parent-host" || die "manifest parent host is not valid base64"
+  PARENT_HOST=$(cat "$TMP/parent-host")
+fi
 ID=$(cat "$TMP/id")
 safe_id "$ID" || die "manifest carries an unsafe secondmate id"
 case "$COUNT" in ''|*[!0-9]*) die "manifest project count is invalid" ;; esac
@@ -137,7 +152,7 @@ if [ -e "$FM_HOME" ] || [ -L "$FM_HOME" ]; then
     fi
   done
   mkdir -p "$TMP/before/data"
-  for rel in data/charter.md data/projects.md .fm-secondmate-home; do
+  for rel in data/charter.md data/projects.md .fm-secondmate-home .fm-secondmate-parent; do
     existing="$FM_HOME/$rel"
     if [ -e "$existing" ] || [ -L "$existing" ]; then
       [ -f "$existing" ] && [ ! -L "$existing" ] || die "existing remote home has unsafe owned file: $rel"
@@ -225,6 +240,12 @@ cp "$PROJECT_REG" "$FM_HOME/data/projects.md.tmp.$$"
 mv -f -- "$FM_HOME/data/projects.md.tmp.$$" "$FM_HOME/data/projects.md"
 printf '%s\n' "$ID" > "$FM_HOME/.fm-secondmate-home.tmp.$$"
 mv -f -- "$FM_HOME/.fm-secondmate-home.tmp.$$" "$FM_HOME/.fm-secondmate-home"
+{
+  printf 'schema=fm-secondmate-parent.v1\n'
+  printf 'route=remote\n'
+  [ -z "$PARENT_HOST" ] || printf 'parent_host=%s\n' "$PARENT_HOST"
+} > "$FM_HOME/.fm-secondmate-parent.tmp.$$"
+mv -f -- "$FM_HOME/.fm-secondmate-parent.tmp.$$" "$FM_HOME/.fm-secondmate-parent"
 PUBLISHED=1
 release_provision_lock
 trap - EXIT

--- a/bin/fm-remote-home-provision.sh
+++ b/bin/fm-remote-home-provision.sh
@@ -7,12 +7,12 @@
 # Manifest schema fm-remote-home-provision.v1 carries a base64 charter, the
 # base64 parent SSH alias, and one base64 project record per line. The remote
 # code root is cloned into an absent home, project origins are cloned on this
-# host, the project registry and charter are published, and the
-# .fm-secondmate-home marker commits the seed last, alongside a durable
-# .fm-secondmate-parent record naming this home's route to its parent as
+# host, the project registry and charter are published, the durable
+# .fm-secondmate-parent record names this home's route to its parent as
 # "remote" - read by bin/fm-teardown.sh's cleanup gate so a delegated public
 # reply promise, which the subsystem can only carry on the parent's own
-# filesystem, is never mistaken for one this child could hold.
+# filesystem, is never mistaken for one this child could hold - and the
+# .fm-secondmate-home marker commits the complete seed last.
 # A newly created home is removed on failure. An existing matching seeded home
 # is converged only through guarded ordinary-file updates and new project clones.
 set -eu
@@ -238,14 +238,14 @@ chmod 600 "$FM_HOME/data/charter.md.tmp.$$"
 mv -f -- "$FM_HOME/data/charter.md.tmp.$$" "$FM_HOME/data/charter.md"
 cp "$PROJECT_REG" "$FM_HOME/data/projects.md.tmp.$$"
 mv -f -- "$FM_HOME/data/projects.md.tmp.$$" "$FM_HOME/data/projects.md"
-printf '%s\n' "$ID" > "$FM_HOME/.fm-secondmate-home.tmp.$$"
-mv -f -- "$FM_HOME/.fm-secondmate-home.tmp.$$" "$FM_HOME/.fm-secondmate-home"
 {
   printf 'schema=fm-secondmate-parent.v1\n'
   printf 'route=remote\n'
   [ -z "$PARENT_HOST" ] || printf 'parent_host=%s\n' "$PARENT_HOST"
 } > "$FM_HOME/.fm-secondmate-parent.tmp.$$"
 mv -f -- "$FM_HOME/.fm-secondmate-parent.tmp.$$" "$FM_HOME/.fm-secondmate-parent"
+printf '%s\n' "$ID" > "$FM_HOME/.fm-secondmate-home.tmp.$$"
+mv -f -- "$FM_HOME/.fm-secondmate-home.tmp.$$" "$FM_HOME/.fm-secondmate-home"
 PUBLISHED=1
 release_provision_lock
 trap - EXIT

--- a/bin/fm-remote-home-seed.sh
+++ b/bin/fm-remote-home-seed.sh
@@ -163,6 +163,13 @@ done
   printf 'schema=fm-remote-home-provision.v1\n'
   printf 'id_b64=%s\n' "$(printf '%s' "$ID" | encode)"
   printf 'charter_b64=%s\n' "$(encode < "$TMP/charter.remote")"
+  # The SSH alias reaching this host from the parent's own config, carried
+  # only so the remote-provisioned home can record durably that its parent
+  # lives on another machine (bin/fm-teardown.sh's cleanup gate). It is
+  # diagnostic identity, never a route the remote host could use to reach
+  # back; the parent's real filesystem path is never sent, since it names
+  # nothing on the remote filesystem.
+  printf 'parent_host_b64=%s\n' "$(printf '%s' "$HOST" | encode)"
   printf 'project_count=%s\n' "${#PROJECT_NAMES[@]}"
   cat "$TMP/project.records"
 } > "$TMP/manifest"

--- a/bin/fm-secondmate-parent-lib.sh
+++ b/bin/fm-secondmate-parent-lib.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# shellcheck disable=SC2034 # parsed fields are output globals for sourcing callers.
 # Parse the durable parent binding written into a seeded secondmate home.
 #
 # The fm-secondmate-parent.v1 record contains exactly one schema and route.
@@ -13,7 +14,7 @@
 # marker remains the seed-completion point.
 
 fm_secondmate_parent_record_parse() {
-  local file=$1 line schema= route= parent_home= parent_host=
+  local file=$1 line schema='' route='' parent_home='' parent_host=''
   local schema_count=0 route_count=0 parent_home_count=0 parent_host_count=0
 
   FM_SECONDMATE_PARENT_ROUTE=

--- a/bin/fm-secondmate-parent-lib.sh
+++ b/bin/fm-secondmate-parent-lib.sh
@@ -2,7 +2,7 @@
 
 fm_secondmate_parent_record_parse() {
   local file=$1 line schema= route= parent_home= parent_host=
-  local schema_count=0 route_count=0 parent_home_count=0
+  local schema_count=0 route_count=0 parent_home_count=0 parent_host_count=0
 
   FM_SECONDMATE_PARENT_ROUTE=
   FM_SECONDMATE_PARENT_HOME=
@@ -24,6 +24,7 @@ fm_secondmate_parent_record_parse() {
         parent_home=${line#parent_home=}
         ;;
       parent_host=*)
+        parent_host_count=$((parent_host_count + 1))
         parent_host=${line#parent_host=}
         ;;
     esac
@@ -35,10 +36,13 @@ fm_secondmate_parent_record_parse() {
   case "$route" in
     local)
       [ "$parent_home_count" -eq 1 ] || return 1
+      [ "$parent_host_count" -eq 0 ] || return 1
       [ -n "$parent_home" ] || return 1
       FM_SECONDMATE_PARENT_HOME=$parent_home
       ;;
-    remote) ;;
+    remote)
+      [ "$parent_home_count" -eq 0 ] || return 1
+      ;;
     *) return 1 ;;
   esac
 

--- a/bin/fm-secondmate-parent-lib.sh
+++ b/bin/fm-secondmate-parent-lib.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+fm_secondmate_parent_record_parse() {
+  local file=$1 line schema= route= parent_home= parent_host=
+  local schema_count=0 route_count=0 parent_home_count=0
+
+  FM_SECONDMATE_PARENT_ROUTE=
+  FM_SECONDMATE_PARENT_HOME=
+  FM_SECONDMATE_PARENT_HOST=
+
+  [ -f "$file" ] && [ ! -L "$file" ] || return 1
+  while IFS= read -r line || [ -n "$line" ]; do
+    case "$line" in
+      schema=*)
+        schema_count=$((schema_count + 1))
+        schema=${line#schema=}
+        ;;
+      route=*)
+        route_count=$((route_count + 1))
+        route=${line#route=}
+        ;;
+      parent_home=*)
+        parent_home_count=$((parent_home_count + 1))
+        parent_home=${line#parent_home=}
+        ;;
+      parent_host=*)
+        parent_host=${line#parent_host=}
+        ;;
+    esac
+  done < "$file"
+
+  [ "$schema_count" -eq 1 ] || return 1
+  [ "$route_count" -eq 1 ] || return 1
+  [ "$schema" = fm-secondmate-parent.v1 ] || return 1
+  case "$route" in
+    local)
+      [ "$parent_home_count" -eq 1 ] || return 1
+      [ -n "$parent_home" ] || return 1
+      FM_SECONDMATE_PARENT_HOME=$parent_home
+      ;;
+    remote) ;;
+    *) return 1 ;;
+  esac
+
+  FM_SECONDMATE_PARENT_ROUTE=$route
+  FM_SECONDMATE_PARENT_HOST=$parent_host
+}

--- a/bin/fm-secondmate-parent-lib.sh
+++ b/bin/fm-secondmate-parent-lib.sh
@@ -1,4 +1,16 @@
 #!/usr/bin/env bash
+# Parse the durable parent binding written into a seeded secondmate home.
+#
+# The fm-secondmate-parent.v1 record contains exactly one schema and route.
+# A local route contains exactly one absolute parent_home and no parent_host.
+# A remote route contains no parent_home; current provisioning includes its SSH
+# alias as diagnostic-only parent_host, while legacy-compatible manifests may
+# omit that field.
+# Unknown fields are reserved for forward-compatible additions.
+# Duplicate schema or route fields, a malformed local binding, an unsupported
+# route or schema, and a symlinked record fail closed.
+# Writers publish this record before .fm-secondmate-home so that the identity
+# marker remains the seed-completion point.
 
 fm_secondmate_parent_record_parse() {
   local file=$1 line schema= route= parent_home= parent_host=

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -131,6 +131,7 @@ DATA="${FM_DATA_OVERRIDE:-$FM_HOME/data}"
 CONFIG="${FM_CONFIG_OVERRIDE:-$FM_HOME/config}"
 SECONDMATE_REG="$DATA/secondmates.md"
 SUB_HOME_MARKER=".fm-secondmate-home"
+SUB_HOME_PARENT_MARKER=".fm-secondmate-parent"
 # shellcheck source=bin/fm-tasks-axi-lib.sh
 . "$SCRIPT_DIR/fm-tasks-axi-lib.sh"
 # shellcheck source=bin/fm-backend.sh
@@ -421,36 +422,77 @@ public_followup_resolve_primary_home() {
 }
 if [ -f "$FM_HOME/$SUB_HOME_MARKER" ]; then
   SECOND_MATE_ID=$(sed -n '1p' "$FM_HOME/$SUB_HOME_MARKER")
-  # A marked child only enters the primary-binding path when the authoritative
-  # parent relay is active. A child that has not opted into the relay must
-  # retain the old teardown path, even without a durable parent registry.
-  if [ -n "${FM_PUBLIC_FOLLOWUP_PRIMARY_HOME:-}" ]; then
-    if fm_pf_relay_active "$FM_PUBLIC_FOLLOWUP_PRIMARY_HOME"; then
-      PUBLIC_FOLLOWUP_PARENT_RELAY_ACTIVE=1
-    fi
-  elif fm_pf_relay_active "$FM_HOME"; then
-    PUBLIC_FOLLOWUP_PARENT_RELAY_ACTIVE=1
+  # The durable parent record (written once at seeding, next to the identity
+  # marker) names this home's route to its parent: "local" when they share a
+  # filesystem, "remote" when the parent lives on another machine. Absent for
+  # a home seeded before this record existed, which preserves today's exact
+  # env-var-only behavior for that legacy home rather than guessing its route.
+  PARENT_ROUTE_FILE="$FM_HOME/$SUB_HOME_PARENT_MARKER"
+  PARENT_ROUTE=
+  PARENT_ROUTE_HOME=
+  if [ -f "$PARENT_ROUTE_FILE" ] && [ ! -L "$PARENT_ROUTE_FILE" ]; then
+    PARENT_ROUTE=$(fm_meta_get "$PARENT_ROUTE_FILE" route)
+    PARENT_ROUTE_HOME=$(fm_meta_get "$PARENT_ROUTE_FILE" parent_home)
   fi
-  if [ "$PUBLIC_FOLLOWUP_PARENT_RELAY_ACTIVE" = 1 ]; then
-    PUBLIC_FOLLOWUP_PARENT_UNRESOLVED=1
-    if fm_pf_home_id_valid "secondmate:$SECOND_MATE_ID"; then
-      PUBLIC_FOLLOWUP_WORK_HOME="secondmate:$SECOND_MATE_ID"
-      if PUBLIC_FOLLOWUP_HOME=$(public_followup_resolve_primary_home \
-          "${FM_PUBLIC_FOLLOWUP_PRIMARY_HOME:-}" "$FM_HOME" "$SECOND_MATE_ID"); then
-        PUBLIC_FOLLOWUP_STATE="$PUBLIC_FOLLOWUP_HOME/state"
-        PUBLIC_FOLLOWUP_PARENT_UNRESOLVED=0
-        if [ "$FORCE" != "--force" ] \
-          && fm_pf_relay_active "$PUBLIC_FOLLOWUP_HOME"; then
-          PUBLIC_FOLLOWUP_RELAY_ACTIVE=1
-        fi
-      else
-        PUBLIC_FOLLOWUP_HOME=
-        PUBLIC_FOLLOWUP_STATE=
-      fi
+  if [ "$PARENT_ROUTE" = remote ]; then
+    # The entire promised-public-reply subsystem is same-filesystem by
+    # construction (bin/fm-public-followup-emit.sh header): a parent recorded
+    # on another machine can never hold a delegated promise for this child, so
+    # the delegated-parent path is out of scope and never refuses cleanup on
+    # its own. A token committed directly to THIS home's own .env is still a
+    # real, same-filesystem signal, so it is still checked - but read only
+    # from the file, never from the process environment, so an unrelated
+    # export in the remote host's own login shell cannot trigger it the way
+    # fm_pf_relay_active's environment-wins rule would.
+    if [ -f "$FM_HOME/.env" ]; then
+      HOME_ENV_TOKEN=$(fmx_env_get FMX_PAIRING_TOKEN "$FM_HOME/.env")
+      [ -z "$HOME_ENV_TOKEN" ] || PUBLIC_FOLLOWUP_PARENT_RELAY_ACTIVE=1
+    fi
+    if [ "$PUBLIC_FOLLOWUP_PARENT_RELAY_ACTIVE" = 1 ]; then
+      PUBLIC_FOLLOWUP_PARENT_UNRESOLVED=1
+    else
+      PUBLIC_FOLLOWUP_HOME=
+      PUBLIC_FOLLOWUP_STATE=
     fi
   else
-    PUBLIC_FOLLOWUP_HOME=
-    PUBLIC_FOLLOWUP_STATE=
+    # A marked child only enters the primary-binding path when the authoritative
+    # parent relay is active. A child that has not opted into the relay must
+    # retain the old teardown path, even without a durable parent registry.
+    # The durable local parent_home only fills in when the launch-time env var
+    # is absent, so a restart that drops the launch prefix can still resolve
+    # the real parent instead of silently treating the relay as inactive.
+    PRIMARY_HOME_CANDIDATE=${FM_PUBLIC_FOLLOWUP_PRIMARY_HOME:-}
+    if [ -z "$PRIMARY_HOME_CANDIDATE" ] && [ "$PARENT_ROUTE" = local ]; then
+      PRIMARY_HOME_CANDIDATE=$PARENT_ROUTE_HOME
+    fi
+    if [ -n "$PRIMARY_HOME_CANDIDATE" ]; then
+      if fm_pf_relay_active "$PRIMARY_HOME_CANDIDATE"; then
+        PUBLIC_FOLLOWUP_PARENT_RELAY_ACTIVE=1
+      fi
+    elif fm_pf_relay_active "$FM_HOME"; then
+      PUBLIC_FOLLOWUP_PARENT_RELAY_ACTIVE=1
+    fi
+    if [ "$PUBLIC_FOLLOWUP_PARENT_RELAY_ACTIVE" = 1 ]; then
+      PUBLIC_FOLLOWUP_PARENT_UNRESOLVED=1
+      if fm_pf_home_id_valid "secondmate:$SECOND_MATE_ID"; then
+        PUBLIC_FOLLOWUP_WORK_HOME="secondmate:$SECOND_MATE_ID"
+        if PUBLIC_FOLLOWUP_HOME=$(public_followup_resolve_primary_home \
+            "$PRIMARY_HOME_CANDIDATE" "$FM_HOME" "$SECOND_MATE_ID"); then
+          PUBLIC_FOLLOWUP_STATE="$PUBLIC_FOLLOWUP_HOME/state"
+          PUBLIC_FOLLOWUP_PARENT_UNRESOLVED=0
+          if [ "$FORCE" != "--force" ] \
+            && fm_pf_relay_active "$PUBLIC_FOLLOWUP_HOME"; then
+            PUBLIC_FOLLOWUP_RELAY_ACTIVE=1
+          fi
+        else
+          PUBLIC_FOLLOWUP_HOME=
+          PUBLIC_FOLLOWUP_STATE=
+        fi
+      fi
+    else
+      PUBLIC_FOLLOWUP_HOME=
+      PUBLIC_FOLLOWUP_STATE=
+    fi
   fi
 elif [ "$KIND" = secondmate ]; then
   PUBLIC_FOLLOWUP_WORK_HOME="secondmate:$ID"

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -403,12 +403,16 @@ PUBLIC_FOLLOWUP_WORK_HOME=main
 PUBLIC_FOLLOWUP_PARENT_UNRESOLVED=0
 PUBLIC_FOLLOWUP_PARENT_RELAY_ACTIVE=0
 PUBLIC_FOLLOWUP_RELAY_ACTIVE=0
+public_followup_canonical_home() {
+  local home=$1
+  case "$home" in /*) ;; *) return 1 ;; esac
+  CDPATH='' cd -- "$home" 2>/dev/null && pwd -P
+}
 public_followup_resolve_primary_home() {
   local parent=$1 child=$2 id=$3 parent_meta registry meta_home
   fm_pf_home_id_valid "secondmate:$id" || return 1
-  case "$parent" in /*) ;; *) return 1 ;; esac
-  parent=$(CDPATH='' cd -- "$parent" 2>/dev/null && pwd -P) || return 1
-  child=$(CDPATH='' cd -- "$child" 2>/dev/null && pwd -P) || return 1
+  parent=$(public_followup_canonical_home "$parent") || return 1
+  child=$(public_followup_canonical_home "$child") || return 1
   [ "$parent" != "$child" ] || return 1
   parent_meta="$parent/state/$id.meta"
   [ -f "$parent_meta" ] && [ ! -L "$parent_meta" ] || return 1
@@ -471,10 +475,23 @@ if [ -f "$FM_HOME/$SUB_HOME_MARKER" ]; then
     fi
   elif [ "$PARENT_ROUTE" = local ]; then
     PUBLIC_FOLLOWUP_PARENT_UNRESOLVED=1
-    if fm_pf_home_id_valid "secondmate:$SECOND_MATE_ID"; then
+    PRIMARY_HOME_CANDIDATE=${FM_PUBLIC_FOLLOWUP_PRIMARY_HOME:-$PARENT_ROUTE_HOME}
+    PARENT_BINDINGS_MATCH=1
+    if [ -n "${FM_PUBLIC_FOLLOWUP_PRIMARY_HOME:-}" ]; then
+      LIVE_PARENT_HOME=$(public_followup_canonical_home \
+        "$FM_PUBLIC_FOLLOWUP_PRIMARY_HOME") || PARENT_BINDINGS_MATCH=0
+      DURABLE_PARENT_HOME=$(public_followup_canonical_home \
+        "$PARENT_ROUTE_HOME") || PARENT_BINDINGS_MATCH=0
+      if [ "$PARENT_BINDINGS_MATCH" = 1 ] \
+        && [ "$LIVE_PARENT_HOME" != "$DURABLE_PARENT_HOME" ]; then
+        PARENT_BINDINGS_MATCH=0
+      fi
+    fi
+    if [ "$PARENT_BINDINGS_MATCH" = 1 ] \
+      && fm_pf_home_id_valid "secondmate:$SECOND_MATE_ID"; then
       PUBLIC_FOLLOWUP_WORK_HOME="secondmate:$SECOND_MATE_ID"
       if PUBLIC_FOLLOWUP_HOME=$(public_followup_resolve_primary_home \
-          "$PARENT_ROUTE_HOME" "$FM_HOME" "$SECOND_MATE_ID"); then
+          "$PRIMARY_HOME_CANDIDATE" "$FM_HOME" "$SECOND_MATE_ID"); then
         PUBLIC_FOLLOWUP_STATE="$PUBLIC_FOLLOWUP_HOME/state"
         PUBLIC_FOLLOWUP_PARENT_UNRESOLVED=0
         if [ "$FORCE" != "--force" ] \

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -146,6 +146,8 @@ SUB_HOME_PARENT_MARKER=".fm-secondmate-parent"
 . "$SCRIPT_DIR/fm-public-followup-lib.sh"
 # shellcheck source=bin/fm-secondmate-registry-lib.sh
 . "$SCRIPT_DIR/fm-secondmate-registry-lib.sh"
+# shellcheck source=bin/fm-secondmate-parent-lib.sh
+. "$SCRIPT_DIR/fm-secondmate-parent-lib.sh"
 # shellcheck source=bin/fm-wake-lib.sh
 . "$SCRIPT_DIR/fm-wake-lib.sh"
 # shellcheck source=bin/fm-nm-run-lib.sh
@@ -437,18 +439,10 @@ if [ -f "$FM_HOME/$SUB_HOME_MARKER" ]; then
   PARENT_ROUTE_HOME=
   if [ -e "$PARENT_ROUTE_FILE" ] || [ -L "$PARENT_ROUTE_FILE" ]; then
     PARENT_ROUTE_RECORD=invalid
-    if [ -f "$PARENT_ROUTE_FILE" ] && [ ! -L "$PARENT_ROUTE_FILE" ] \
-      && [ "$(fm_meta_get "$PARENT_ROUTE_FILE" schema)" = fm-secondmate-parent.v1 ]; then
-      PARENT_ROUTE=$(fm_meta_get "$PARENT_ROUTE_FILE" route)
-      PARENT_ROUTE_HOME=$(fm_meta_get "$PARENT_ROUTE_FILE" parent_home)
-      case "$PARENT_ROUTE" in
-        local)
-          [ -n "$PARENT_ROUTE_HOME" ] && PARENT_ROUTE_RECORD=valid
-          ;;
-        remote)
-          PARENT_ROUTE_RECORD=valid
-          ;;
-      esac
+    if fm_secondmate_parent_record_parse "$PARENT_ROUTE_FILE"; then
+      PARENT_ROUTE=$FM_SECONDMATE_PARENT_ROUTE
+      PARENT_ROUTE_HOME=$FM_SECONDMATE_PARENT_HOME
+      PARENT_ROUTE_RECORD=valid
     fi
   fi
   if [ "$PARENT_ROUTE_RECORD" = invalid ]; then

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -428,13 +428,28 @@ if [ -f "$FM_HOME/$SUB_HOME_MARKER" ]; then
   # a home seeded before this record existed, which preserves today's exact
   # env-var-only behavior for that legacy home rather than guessing its route.
   PARENT_ROUTE_FILE="$FM_HOME/$SUB_HOME_PARENT_MARKER"
+  PARENT_ROUTE_RECORD=absent
   PARENT_ROUTE=
   PARENT_ROUTE_HOME=
-  if [ -f "$PARENT_ROUTE_FILE" ] && [ ! -L "$PARENT_ROUTE_FILE" ]; then
-    PARENT_ROUTE=$(fm_meta_get "$PARENT_ROUTE_FILE" route)
-    PARENT_ROUTE_HOME=$(fm_meta_get "$PARENT_ROUTE_FILE" parent_home)
+  if [ -e "$PARENT_ROUTE_FILE" ] || [ -L "$PARENT_ROUTE_FILE" ]; then
+    PARENT_ROUTE_RECORD=invalid
+    if [ -f "$PARENT_ROUTE_FILE" ] && [ ! -L "$PARENT_ROUTE_FILE" ] \
+      && [ "$(fm_meta_get "$PARENT_ROUTE_FILE" schema)" = fm-secondmate-parent.v1 ]; then
+      PARENT_ROUTE=$(fm_meta_get "$PARENT_ROUTE_FILE" route)
+      PARENT_ROUTE_HOME=$(fm_meta_get "$PARENT_ROUTE_FILE" parent_home)
+      case "$PARENT_ROUTE" in
+        local)
+          [ -n "$PARENT_ROUTE_HOME" ] && PARENT_ROUTE_RECORD=valid
+          ;;
+        remote)
+          PARENT_ROUTE_RECORD=valid
+          ;;
+      esac
+    fi
   fi
-  if [ "$PARENT_ROUTE" = remote ]; then
+  if [ "$PARENT_ROUTE_RECORD" = invalid ]; then
+    PUBLIC_FOLLOWUP_PARENT_UNRESOLVED=1
+  elif [ "$PARENT_ROUTE" = remote ]; then
     # The entire promised-public-reply subsystem is same-filesystem by
     # construction (bin/fm-public-followup-emit.sh header): a parent recorded
     # on another machine can never hold a delegated promise for this child, so

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -469,17 +469,27 @@ if [ -f "$FM_HOME/$SUB_HOME_MARKER" ]; then
       PUBLIC_FOLLOWUP_HOME=
       PUBLIC_FOLLOWUP_STATE=
     fi
-  else
-    # A marked child only enters the primary-binding path when the authoritative
-    # parent relay is active. A child that has not opted into the relay must
-    # retain the old teardown path, even without a durable parent registry.
-    # The durable local parent_home only fills in when the launch-time env var
-    # is absent, so a restart that drops the launch prefix can still resolve
-    # the real parent instead of silently treating the relay as inactive.
-    PRIMARY_HOME_CANDIDATE=${FM_PUBLIC_FOLLOWUP_PRIMARY_HOME:-}
-    if [ -z "$PRIMARY_HOME_CANDIDATE" ] && [ "$PARENT_ROUTE" = local ]; then
-      PRIMARY_HOME_CANDIDATE=$PARENT_ROUTE_HOME
+  elif [ "$PARENT_ROUTE" = local ]; then
+    PUBLIC_FOLLOWUP_PARENT_UNRESOLVED=1
+    if fm_pf_home_id_valid "secondmate:$SECOND_MATE_ID"; then
+      PUBLIC_FOLLOWUP_WORK_HOME="secondmate:$SECOND_MATE_ID"
+      if PUBLIC_FOLLOWUP_HOME=$(public_followup_resolve_primary_home \
+          "$PARENT_ROUTE_HOME" "$FM_HOME" "$SECOND_MATE_ID"); then
+        PUBLIC_FOLLOWUP_STATE="$PUBLIC_FOLLOWUP_HOME/state"
+        PUBLIC_FOLLOWUP_PARENT_UNRESOLVED=0
+        if [ "$FORCE" != "--force" ] \
+          && fm_pf_relay_active "$PUBLIC_FOLLOWUP_HOME"; then
+          PUBLIC_FOLLOWUP_RELAY_ACTIVE=1
+        fi
+      else
+        PUBLIC_FOLLOWUP_HOME=
+        PUBLIC_FOLLOWUP_STATE=
+      fi
     fi
+  else
+    # A home seeded before the durable record existed retains the legacy
+    # launch-time binding behavior unchanged.
+    PRIMARY_HOME_CANDIDATE=${FM_PUBLIC_FOLLOWUP_PRIMARY_HOME:-}
     if [ -n "$PRIMARY_HOME_CANDIDATE" ]; then
       if fm_pf_relay_active "$PRIMARY_HOME_CANDIDATE"; then
         PUBLIC_FOLLOWUP_PARENT_RELAY_ACTIVE=1

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -181,8 +181,8 @@ For `no-mistakes` projects, seeding initializes only projects newly cloned into 
 After creating a secondmate, move existing main-backlog queued items that you have judged in-scope with `fm-backlog-handoff.sh <secondmate-id> <item-key>...`; it is idempotent and refuses In flight, Done, or non-secondmate homes.
 Set `FM_SECONDMATE_CHARTER` to seed from inline charter text when no filled charter brief exists; set `FM_SECONDMATE_SCOPE` when the routing scope should differ from the charter text.
 The seeded home's `data/charter.md` owns the standard secondmate lifecycle and escalation contract; the route file points to it through the existing `home:` field instead of adding another pointer.
-Each seed writes an `.fm-secondmate-home` identity marker at the home root.
-The tracked root `.gitignore` ignores that marker, so validation can read it without making a freshly seeded home appear dirty to porcelain-based safety checks.
+Each seed writes an `.fm-secondmate-home` identity marker at the home root, alongside a durable `.fm-secondmate-parent` record of the home's route to its parent (see "Provision a route" in [`docs/remote-secondmates.md`](remote-secondmates.md)).
+The tracked root `.gitignore` ignores both markers, so validation can read them without making a freshly seeded home appear dirty to porcelain-based safety checks.
 This does not relax protection for any other untracked file.
 An existing linked-worktree home that predates this rule advances through its marker-only state during its next bootstrap or spawn local sync, after which Git ignores the marker normally.
 A standalone-clone home cannot receive a primary-local commit through that no-fetch sync, so it receives the rule through `/updatefirstmate`'s origin refresh instead.

--- a/docs/remote-secondmates.md
+++ b/docs/remote-secondmates.md
@@ -124,6 +124,9 @@ A host that stays red prints the doctor's remaining gaps and their operator step
 It does not copy project trees or the primary process environment.
 A known provisioning failure rolls back the new route, while SSH exit 255 preserves it because remote completion is unknown and must be reconciled on the same host.
 
+Seeding also writes a durable `.fm-secondmate-parent` record next to the home's `.fm-secondmate-home` identity marker, naming this home's route to its parent as `local` or `remote`.
+The promised-public-reply subsystem is same-filesystem by construction, so a remote route can never carry a delegated public-reply promise; `bin/fm-teardown.sh`'s cleanup gate reads this record to treat a remote parent as out of scope rather than an unresolved binding.
+
 Local secondmates keep the existing route form and need no migration.
 A fleet may contain local and remote routes together.
 Use `bin/fm-home-seed.sh validate` to validate either form.

--- a/tests/fm-backend.test.sh
+++ b/tests/fm-backend.test.sh
@@ -141,7 +141,7 @@ resolve_permissive_tmux_kill_ref() {
 # hence the dispatcher is a copied sibling, while the tmux adapter is extracted
 # from BASE_REF so conformance tests retain the exact historical behavior even
 # when this branch changes tmux dispatch semantics.
-OLD_BIN_UNCHANGED_SIBLINGS="fm-gate-refuse-lib.sh fm-guard.sh fm-lock-lib.sh fm-tasks-axi-lib.sh fm-pr-lib.sh fm-tangle-lib.sh fm-tmux-lib.sh fm-composer-lib.sh fm-wake-lib.sh fm-classify-lib.sh fm-supervision-lib.sh fm-ff-lib.sh fm-config-inherit-lib.sh fm-project-mode.sh fm-harness.sh fm-crew-state.sh fm-nm-run-lib.sh fm-decision-hold.sh fm-backend.sh fm-operational-input.sh fm-public-followup-lib.sh fm-secondmate-registry-lib.sh fm-x-lib.sh"
+OLD_BIN_UNCHANGED_SIBLINGS="fm-gate-refuse-lib.sh fm-guard.sh fm-lock-lib.sh fm-tasks-axi-lib.sh fm-pr-lib.sh fm-tangle-lib.sh fm-tmux-lib.sh fm-composer-lib.sh fm-wake-lib.sh fm-classify-lib.sh fm-supervision-lib.sh fm-ff-lib.sh fm-config-inherit-lib.sh fm-project-mode.sh fm-harness.sh fm-crew-state.sh fm-nm-run-lib.sh fm-decision-hold.sh fm-backend.sh fm-operational-input.sh fm-public-followup-lib.sh fm-secondmate-registry-lib.sh fm-secondmate-parent-lib.sh fm-x-lib.sh"
 # A pull-request merge may add a new main-only dependency that the branch's older baseline does not have yet.
 OLD_BIN_OPTIONAL_SIBLINGS="fm-pending-reply-lib.sh"
 OLD_BIN_REFACTORED="fm-send.sh fm-peek.sh fm-watch.sh fm-spawn.sh fm-teardown.sh fm-marker-lib.sh"

--- a/tests/fm-gotmp.test.sh
+++ b/tests/fm-gotmp.test.sh
@@ -72,6 +72,7 @@ make_fake_root() {
   ln -s "$ROOT/bin/fm-public-followup-lib.sh" "$fake/bin/fm-public-followup-lib.sh"
   ln -s "$ROOT/bin/fm-x-lib.sh" "$fake/bin/fm-x-lib.sh"
   ln -s "$ROOT/bin/fm-secondmate-registry-lib.sh" "$fake/bin/fm-secondmate-registry-lib.sh"
+  ln -s "$ROOT/bin/fm-secondmate-parent-lib.sh" "$fake/bin/fm-secondmate-parent-lib.sh"
   # fm-wake-lib.sh: teardown sources it for serialized secondmate lifecycle locks.
   ln -s "$ROOT/bin/fm-wake-lib.sh" "$fake/bin/fm-wake-lib.sh"
   # fm-guard.sh: stub (teardown calls it with `|| true`).
@@ -148,6 +149,7 @@ test_teardown_skips_gracefully_without_tasktmp() {
   ln -s "$ROOT/bin/fm-public-followup-lib.sh" "$fake/bin/fm-public-followup-lib.sh"
   ln -s "$ROOT/bin/fm-x-lib.sh" "$fake/bin/fm-x-lib.sh"
   ln -s "$ROOT/bin/fm-secondmate-registry-lib.sh" "$fake/bin/fm-secondmate-registry-lib.sh"
+  ln -s "$ROOT/bin/fm-secondmate-parent-lib.sh" "$fake/bin/fm-secondmate-parent-lib.sh"
   ln -s "$ROOT/bin/fm-wake-lib.sh" "$fake/bin/fm-wake-lib.sh"
   cat > "$fake/bin/fm-guard.sh" <<'SH'
 #!/usr/bin/env bash

--- a/tests/fm-public-followup.test.sh
+++ b/tests/fm-public-followup.test.sh
@@ -694,7 +694,7 @@ test_secondmate_teardown_resolves_parent_from_durable_record_when_env_lost() {
 
 test_secondmate_teardown_durable_record_missing_parent_registration_still_refuses() {
   local parent child parent_resolved
-  parent=$(make_home teardown-durable-missing-parent)
+  parent=$(make_home teardown-durable-missing-parent relay-off)
   child="$TMP_ROOT/teardown-durable-missing-child"
   FM_SECONDMATE_CHARTER='Durable-record missing-registration regression charter.' \
     FM_HOME="$parent" "$ROOT/bin/fm-home-seed.sh" mate "$child" --no-projects >/dev/null \
@@ -725,7 +725,7 @@ test_secondmate_teardown_durable_record_missing_parent_registration_still_refuse
 
 test_secondmate_teardown_durable_record_with_no_commitment_succeeds() {
   local parent child parent_resolved rc out
-  parent=$(make_home teardown-durable-clean-parent)
+  parent=$(make_home teardown-durable-clean-parent relay-off)
   child="$TMP_ROOT/teardown-durable-clean-child"
   FM_SECONDMATE_CHARTER='Durable-record clean-cleanup regression charter.' \
     FM_HOME="$parent" "$ROOT/bin/fm-home-seed.sh" mate "$child" --no-projects >/dev/null \

--- a/tests/fm-public-followup.test.sh
+++ b/tests/fm-public-followup.test.sh
@@ -844,7 +844,7 @@ test_secondmate_teardown_rejects_conflicting_live_and_durable_parent_bindings() 
 
 test_secondmate_teardown_rejects_unsafe_durable_parent_records() {
   local case_name parent child parent_record
-  for case_name in symlink invalid-route; do
+  for case_name in symlink invalid-route duplicate-route; do
     parent=$(make_home "teardown-durable-$case_name-parent" relay-off)
     child="$TMP_ROOT/teardown-durable-$case_name-child"
     FM_SECONDMATE_CHARTER='Unsafe durable-record regression charter.' \
@@ -864,6 +864,10 @@ test_secondmate_teardown_rejects_unsafe_durable_parent_records() {
         ;;
       invalid-route)
         printf 'schema=fm-secondmate-parent.v1\nroute=garbage\n' > "$parent_record"
+        ;;
+      duplicate-route)
+        printf 'schema=fm-secondmate-parent.v1\nroute=local\nparent_home=%s\nroute=remote\n' \
+          "$parent" > "$parent_record"
         ;;
     esac
 

--- a/tests/fm-public-followup.test.sh
+++ b/tests/fm-public-followup.test.sh
@@ -638,6 +638,116 @@ test_secondmate_teardown_requires_parent_binding() {
   pass "marked secondmate teardown resolves its parent and fails closed when unavailable"
 }
 
+# The three tests below exercise the durable .fm-secondmate-parent record a real
+# bin/fm-home-seed.sh seed now writes next to .fm-secondmate-home (fm-remote-sm-
+# cleanup-parent-binding-s1 report, section 7). Before this record existed, the
+# marked-child gate above could only ever see the parent through the launch-time
+# FM_PUBLIC_FOLLOWUP_PRIMARY_HOME env var: a restart that dropped that prefix made
+# the guard silently treat an actually-active parent relay as off, which could
+# drop a real public-reply obligation without anyone noticing. Each test drives
+# the real bin/fm-teardown.sh cleanup path against a home real fm-home-seed.sh
+# produced, never a hand-crafted marker.
+
+test_secondmate_teardown_resolves_parent_from_durable_record_when_env_lost() {
+  local parent child parent_resolved
+  parent=$(make_home teardown-durable-parent)
+  child="$TMP_ROOT/teardown-durable-child"
+  FM_SECONDMATE_CHARTER='Durable-record regression charter.' \
+    FM_HOME="$parent" "$ROOT/bin/fm-home-seed.sh" mate "$child" --no-projects >/dev/null \
+    || fail "real secondmate seeding failed"
+  child=$(cd "$child" && pwd -P)
+  parent_resolved=$(cd "$parent" && pwd -P)
+  make_fake_curl "$child" >/dev/null
+  fm_fake_exit0 "$child/fakebin" tmux treehouse no-mistakes gh gh-axi
+
+  assert_present "$child/.fm-secondmate-parent" \
+    "real secondmate seeding must write a durable parent record"
+  assert_grep 'route=local' "$child/.fm-secondmate-parent" \
+    "a same-filesystem secondmate must be recorded with a local route"
+  assert_grep "parent_home=$parent_resolved" "$child/.fm-secondmate-parent" \
+    "the durable record must name the real resolved parent home"
+
+  seed_commitment "$parent" pf-durable req-durable x secondmate:mate work-child
+  fm_write_meta "$parent/state/mate.meta" "kind=secondmate" "home=$child"
+  fm_write_meta "$child/state/work-child.meta" \
+    "window=firstmate:fm-work-child" "endpoint_task_id=work-child" \
+    "worktree=$child" "project=$child" "kind=ship" "mode=local-only"
+
+  # No FM_PUBLIC_FOLLOWUP_PRIMARY_HOME at all here: a restart of the secondmate
+  # agent that drops the launch-time prefix must still find the real parent
+  # through the durable record instead of silently treating the relay as off.
+  PATH="$child/fakebin:$PATH" FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$child" \
+    FM_STATE_OVERRIDE="$child/state" FM_DATA_OVERRIDE="$child/data" \
+    expect_failure "teardown with a lost launch binding must still find the real parent" \
+    "$TEARDOWN" work-child
+  assert_contains "$EXPECT_OUT" "still owes a public reply" \
+    "the durable record must resolve to the real parent's owed commitment"
+  case "$EXPECT_OUT" in
+    *"cannot resolve the primary home"*) fail "the durable local record was not used to resolve the parent" ;;
+  esac
+  assert_present "$child/state/work-child.meta" \
+    "a durably-resolved owed commitment must preserve the child work metadata"
+  pass "a lost launch-time parent binding is recovered from the durable local record"
+}
+
+test_secondmate_teardown_durable_record_missing_parent_registration_still_refuses() {
+  local parent child
+  parent=$(make_home teardown-durable-missing-parent)
+  child="$TMP_ROOT/teardown-durable-missing-child"
+  FM_SECONDMATE_CHARTER='Durable-record missing-registration regression charter.' \
+    FM_HOME="$parent" "$ROOT/bin/fm-home-seed.sh" mate "$child" --no-projects >/dev/null \
+    || fail "real secondmate seeding failed"
+  child=$(cd "$child" && pwd -P)
+  make_fake_curl "$child" >/dev/null
+  fm_fake_exit0 "$child/fakebin" tmux treehouse no-mistakes gh gh-axi
+  fm_write_meta "$child/state/work-child.meta" \
+    "window=firstmate:fm-work-child" "endpoint_task_id=work-child" \
+    "worktree=$child" "project=$child" "kind=ship" "mode=local-only"
+  # No parent/state/mate.meta at all: the parent never recorded this secondmate's
+  # own agent, so its side of the binding is genuinely missing. A durable LOCAL
+  # record naming the real parent path must not be enough on its own to bypass
+  # the check; the real protection this guard exists for must survive the fix.
+
+  PATH="$child/fakebin:$PATH" FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$child" \
+    FM_STATE_OVERRIDE="$child/state" FM_DATA_OVERRIDE="$child/data" \
+    expect_failure "a durable local record with no parent-side registration must still refuse" \
+    "$TEARDOWN" work-child
+  assert_contains "$EXPECT_OUT" "cannot resolve the primary home for marked secondmate mate" \
+    "a genuinely missing parent-side registration must remain an actionable teardown refusal"
+  assert_present "$child/state/work-child.meta" \
+    "a genuinely missing parent binding must preserve the child work metadata"
+  pass "a durable local parent record does not bypass a genuinely missing parent-side registration"
+}
+
+test_secondmate_teardown_durable_record_with_no_commitment_succeeds() {
+  local parent child rc out
+  parent=$(make_home teardown-durable-clean-parent)
+  child="$TMP_ROOT/teardown-durable-clean-child"
+  FM_SECONDMATE_CHARTER='Durable-record clean-cleanup regression charter.' \
+    FM_HOME="$parent" "$ROOT/bin/fm-home-seed.sh" mate "$child" --no-projects >/dev/null \
+    || fail "real secondmate seeding failed"
+  child=$(cd "$child" && pwd -P)
+  make_fake_curl "$child" >/dev/null
+  fm_fake_exit0 "$child/fakebin" tmux treehouse no-mistakes gh gh-axi
+  fm_write_meta "$parent/state/mate.meta" "kind=secondmate" "home=$child"
+  fm_git_init_commit "$child/projects/worktree"
+  printf 'manual\n' > "$child/config/backlog-backend"
+  fm_write_meta "$child/state/work-clean.meta" \
+    "window=firstmate:fm-work-clean" "endpoint_task_id=work-clean" \
+    "worktree=$child/projects/worktree" "project=$child/projects/worktree" \
+    "kind=ship" "mode=local-only"
+
+  rc=0
+  out=$(PATH="$child/fakebin:$PATH" FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$child" \
+    FM_STATE_OVERRIDE="$child/state" FM_DATA_OVERRIDE="$child/data" \
+    FM_CONFIG_OVERRIDE="$child/config" FM_PUBLIC_FOLLOWUP_PRIMARY_HOME="$parent" \
+    "$TEARDOWN" work-clean 2>&1) || rc=$?
+  [ "$rc" -eq 0 ] || fail "a resolved parent with no owed commitment must allow cleanup (rc=$rc): $out"
+  assert_not_contains "$out" "cannot resolve the primary home" \
+    "a real durable-record-backed parent must resolve cleanly"
+  pass "a resolved parent through the durable local record allows cleanup with nothing owed"
+}
+
 test_relay_disabled_unmarked_teardown_skips_public_path() {
   local home tasks_log out rc
   home=$(make_home teardown-disabled-unmarked relay-off)
@@ -1027,6 +1137,9 @@ test_interrupted_delivery_refuses_to_repost
 test_outward_delivery_stays_with_the_owning_home
 test_delivery_requires_registration_before_posting
 test_secondmate_teardown_requires_parent_binding
+test_secondmate_teardown_resolves_parent_from_durable_record_when_env_lost
+test_secondmate_teardown_durable_record_missing_parent_registration_still_refuses
+test_secondmate_teardown_durable_record_with_no_commitment_succeeds
 test_relay_disabled_unmarked_teardown_skips_public_path
 test_relay_disabled_parent_allows_marked_child_teardown
 test_secondmate_parent_binding_matches_literal_id

--- a/tests/fm-public-followup.test.sh
+++ b/tests/fm-public-followup.test.sh
@@ -648,6 +648,13 @@ test_secondmate_teardown_requires_parent_binding() {
 # the real bin/fm-teardown.sh cleanup path against a home real fm-home-seed.sh
 # produced, never a hand-crafted marker.
 
+assert_local_secondmate_parent_record() {
+  local child=$1 parent=$2
+  cmp -s "$child/.fm-secondmate-parent" <(
+    printf 'schema=fm-secondmate-parent.v1\nroute=local\nparent_home=%s\n' "$parent"
+  ) || fail "real secondmate seeding must write the exact durable local parent record"
+}
+
 test_secondmate_teardown_resolves_parent_from_durable_record_when_env_lost() {
   local parent child parent_resolved
   parent=$(make_home teardown-durable-parent)
@@ -660,12 +667,7 @@ test_secondmate_teardown_resolves_parent_from_durable_record_when_env_lost() {
   make_fake_curl "$child" >/dev/null
   fm_fake_exit0 "$child/fakebin" tmux treehouse no-mistakes gh gh-axi
 
-  assert_present "$child/.fm-secondmate-parent" \
-    "real secondmate seeding must write a durable parent record"
-  assert_grep 'route=local' "$child/.fm-secondmate-parent" \
-    "a same-filesystem secondmate must be recorded with a local route"
-  assert_grep "parent_home=$parent_resolved" "$child/.fm-secondmate-parent" \
-    "the durable record must name the real resolved parent home"
+  assert_local_secondmate_parent_record "$child" "$parent_resolved"
 
   seed_commitment "$parent" pf-durable req-durable x secondmate:mate work-child
   fm_write_meta "$parent/state/mate.meta" "kind=secondmate" "home=$child"
@@ -691,15 +693,17 @@ test_secondmate_teardown_resolves_parent_from_durable_record_when_env_lost() {
 }
 
 test_secondmate_teardown_durable_record_missing_parent_registration_still_refuses() {
-  local parent child
+  local parent child parent_resolved
   parent=$(make_home teardown-durable-missing-parent)
   child="$TMP_ROOT/teardown-durable-missing-child"
   FM_SECONDMATE_CHARTER='Durable-record missing-registration regression charter.' \
     FM_HOME="$parent" "$ROOT/bin/fm-home-seed.sh" mate "$child" --no-projects >/dev/null \
     || fail "real secondmate seeding failed"
   child=$(cd "$child" && pwd -P)
+  parent_resolved=$(cd "$parent" && pwd -P)
   make_fake_curl "$child" >/dev/null
   fm_fake_exit0 "$child/fakebin" tmux treehouse no-mistakes gh gh-axi
+  assert_local_secondmate_parent_record "$child" "$parent_resolved"
   fm_write_meta "$child/state/work-child.meta" \
     "window=firstmate:fm-work-child" "endpoint_task_id=work-child" \
     "worktree=$child" "project=$child" "kind=ship" "mode=local-only"
@@ -720,15 +724,17 @@ test_secondmate_teardown_durable_record_missing_parent_registration_still_refuse
 }
 
 test_secondmate_teardown_durable_record_with_no_commitment_succeeds() {
-  local parent child rc out
+  local parent child parent_resolved rc out
   parent=$(make_home teardown-durable-clean-parent)
   child="$TMP_ROOT/teardown-durable-clean-child"
   FM_SECONDMATE_CHARTER='Durable-record clean-cleanup regression charter.' \
     FM_HOME="$parent" "$ROOT/bin/fm-home-seed.sh" mate "$child" --no-projects >/dev/null \
     || fail "real secondmate seeding failed"
   child=$(cd "$child" && pwd -P)
+  parent_resolved=$(cd "$parent" && pwd -P)
   make_fake_curl "$child" >/dev/null
   fm_fake_exit0 "$child/fakebin" tmux treehouse no-mistakes gh gh-axi
+  assert_local_secondmate_parent_record "$child" "$parent_resolved"
   fm_write_meta "$parent/state/mate.meta" "kind=secondmate" "home=$child"
   fm_git_init_commit "$child/projects/worktree"
   printf 'manual\n' > "$child/config/backlog-backend"
@@ -746,6 +752,43 @@ test_secondmate_teardown_durable_record_with_no_commitment_succeeds() {
   assert_not_contains "$out" "cannot resolve the primary home" \
     "a real durable-record-backed parent must resolve cleanly"
   pass "a resolved parent through the durable local record allows cleanup with nothing owed"
+}
+
+test_secondmate_teardown_rejects_unsafe_durable_parent_records() {
+  local case_name parent child parent_record
+  for case_name in symlink invalid-route; do
+    parent=$(make_home "teardown-durable-$case_name-parent" relay-off)
+    child="$TMP_ROOT/teardown-durable-$case_name-child"
+    FM_SECONDMATE_CHARTER='Unsafe durable-record regression charter.' \
+      FM_HOME="$parent" "$ROOT/bin/fm-home-seed.sh" mate "$child" --no-projects >/dev/null \
+      || fail "real secondmate seeding failed for $case_name"
+    child=$(cd "$child" && pwd -P)
+    make_fake_curl "$child" >/dev/null
+    fm_fake_exit0 "$child/fakebin" tmux treehouse no-mistakes gh gh-axi
+    fm_write_meta "$child/state/work-child.meta" \
+      "window=firstmate:fm-work-child" "endpoint_task_id=work-child" \
+      "worktree=$child" "project=$child" "kind=ship" "mode=local-only"
+    parent_record="$child/.fm-secondmate-parent"
+    case "$case_name" in
+      symlink)
+        mv "$parent_record" "$parent_record.valid"
+        ln -s .fm-secondmate-parent.valid "$parent_record"
+        ;;
+      invalid-route)
+        printf 'schema=fm-secondmate-parent.v1\nroute=garbage\n' > "$parent_record"
+        ;;
+    esac
+
+    PATH="$child/fakebin:$PATH" FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$child" \
+      FM_STATE_OVERRIDE="$child/state" FM_DATA_OVERRIDE="$child/data" \
+      expect_failure "an unsafe $case_name durable parent record must refuse cleanup" \
+      "$TEARDOWN" work-child
+    assert_contains "$EXPECT_OUT" "cannot resolve the primary home for marked secondmate mate" \
+      "an unsafe $case_name durable parent record must produce the explicit binding refusal"
+    assert_present "$child/state/work-child.meta" \
+      "an unsafe $case_name durable parent record must preserve child work metadata"
+  done
+  pass "unsafe durable parent records fail closed before cleanup"
 }
 
 test_relay_disabled_unmarked_teardown_skips_public_path() {
@@ -1140,6 +1183,7 @@ test_secondmate_teardown_requires_parent_binding
 test_secondmate_teardown_resolves_parent_from_durable_record_when_env_lost
 test_secondmate_teardown_durable_record_missing_parent_registration_still_refuses
 test_secondmate_teardown_durable_record_with_no_commitment_succeeds
+test_secondmate_teardown_rejects_unsafe_durable_parent_records
 test_relay_disabled_unmarked_teardown_skips_public_path
 test_relay_disabled_parent_allows_marked_child_teardown
 test_secondmate_parent_binding_matches_literal_id

--- a/tests/fm-public-followup.test.sh
+++ b/tests/fm-public-followup.test.sh
@@ -776,7 +776,7 @@ test_secondmate_teardown_durable_record_missing_parent_registration_still_refuse
   pass "a durable local parent record does not bypass a genuinely missing parent-side registration"
 }
 
-test_secondmate_teardown_durable_record_with_no_commitment_succeeds() {
+test_secondmate_teardown_durable_record_with_unknown_field_succeeds() {
   local parent parent_alias child parent_resolved rc out
   parent=$(make_home teardown-durable-clean-parent relay-off)
   child="$TMP_ROOT/teardown-durable-clean-child"
@@ -788,6 +788,7 @@ test_secondmate_teardown_durable_record_with_no_commitment_succeeds() {
   make_fake_curl "$child" >/dev/null
   fm_fake_exit0 "$child/fakebin" tmux treehouse no-mistakes gh gh-axi
   assert_local_secondmate_parent_record "$child" "$parent_resolved"
+  printf 'some_future_field=value\n' >> "$child/.fm-secondmate-parent"
   parent_alias="$TMP_ROOT/teardown-durable-clean-parent-alias"
   ln -s "$parent" "$parent_alias"
   fm_write_meta "$parent/state/mate.meta" "kind=secondmate" "home=$child"
@@ -806,7 +807,7 @@ test_secondmate_teardown_durable_record_with_no_commitment_succeeds() {
   [ "$rc" -eq 0 ] || fail "a resolved parent with no owed commitment must allow cleanup (rc=$rc): $out"
   assert_not_contains "$out" "cannot resolve the primary home" \
     "a real durable-record-backed parent must resolve cleanly"
-  pass "a resolved parent through the durable local record allows cleanup with nothing owed"
+  pass "unknown durable parent fields remain forward-compatible"
 }
 
 test_secondmate_teardown_rejects_conflicting_live_and_durable_parent_bindings() {
@@ -844,7 +845,7 @@ test_secondmate_teardown_rejects_conflicting_live_and_durable_parent_bindings() 
 
 test_secondmate_teardown_rejects_unsafe_durable_parent_records() {
   local case_name parent child parent_record
-  for case_name in symlink invalid-route duplicate-route; do
+  for case_name in symlink invalid-route duplicate-route remote-parent-home local-parent-host; do
     parent=$(make_home "teardown-durable-$case_name-parent" relay-off)
     child="$TMP_ROOT/teardown-durable-$case_name-child"
     FM_SECONDMATE_CHARTER='Unsafe durable-record regression charter.' \
@@ -867,6 +868,14 @@ test_secondmate_teardown_rejects_unsafe_durable_parent_records() {
         ;;
       duplicate-route)
         printf 'schema=fm-secondmate-parent.v1\nroute=local\nparent_home=%s\nroute=remote\n' \
+          "$parent" > "$parent_record"
+        ;;
+      remote-parent-home)
+        printf 'schema=fm-secondmate-parent.v1\nroute=remote\nparent_home=%s\n' \
+          "$parent" > "$parent_record"
+        ;;
+      local-parent-host)
+        printf 'schema=fm-secondmate-parent.v1\nroute=local\nparent_home=%s\nparent_host=remote-host\n' \
           "$parent" > "$parent_record"
         ;;
     esac
@@ -1275,7 +1284,7 @@ test_secondmate_teardown_requires_parent_binding
 test_local_secondmate_seed_publishes_parent_before_identity
 test_secondmate_teardown_resolves_parent_from_durable_record_when_env_lost
 test_secondmate_teardown_durable_record_missing_parent_registration_still_refuses
-test_secondmate_teardown_durable_record_with_no_commitment_succeeds
+test_secondmate_teardown_durable_record_with_unknown_field_succeeds
 test_secondmate_teardown_rejects_conflicting_live_and_durable_parent_bindings
 test_secondmate_teardown_rejects_unsafe_durable_parent_records
 test_relay_disabled_unmarked_teardown_skips_public_path

--- a/tests/fm-public-followup.test.sh
+++ b/tests/fm-public-followup.test.sh
@@ -655,6 +655,57 @@ assert_local_secondmate_parent_record() {
   ) || fail "real secondmate seeding must write the exact durable local parent record"
 }
 
+test_local_secondmate_seed_publishes_parent_before_identity() {
+  local parent child parent_resolved fakebin entered release manifest_out real_mv seed_pid wait_count
+  parent=$(make_home seed-publication-parent relay-off)
+  child="$TMP_ROOT/seed-publication-child"
+  parent_resolved=$(cd "$parent" && pwd -P)
+  fakebin=$(fm_fakebin "$TMP_ROOT/seed-publication-fake")
+  entered="$TMP_ROOT/seed-publication-entered"
+  release="$TMP_ROOT/seed-publication-release"
+  manifest_out="$TMP_ROOT/seed-publication.out"
+  real_mv=$(command -v mv)
+  cat > "$fakebin/mv" <<'SH'
+#!/usr/bin/env bash
+destination=${!#}
+case "$destination" in
+  */.fm-secondmate-home)
+    touch "$FM_TEST_PUBLISH_ENTERED"
+    wait_count=0
+    while [ ! -f "$FM_TEST_PUBLISH_RELEASE" ]; do
+      wait_count=$((wait_count + 1))
+      [ "$wait_count" -le 250 ] || exit 97
+      sleep 0.02
+    done
+    ;;
+esac
+exec "$FM_TEST_REAL_MV" "$@"
+SH
+  chmod +x "$fakebin/mv"
+  PATH="$fakebin:$PATH" FM_HOME="$parent" \
+    FM_SECONDMATE_CHARTER='Local publication-order regression charter.' \
+    FM_TEST_REAL_MV="$real_mv" FM_TEST_PUBLISH_ENTERED="$entered" \
+    FM_TEST_PUBLISH_RELEASE="$release" \
+    "$ROOT/bin/fm-home-seed.sh" mate "$child" --no-projects > "$manifest_out" 2>&1 &
+  seed_pid=$!
+  wait_count=0
+  while [ ! -f "$entered" ]; do
+    kill -0 "$seed_pid" 2>/dev/null \
+      || fail "local seeding exited before its identity completion marker: $(cat "$manifest_out")"
+    wait_count=$((wait_count + 1))
+    [ "$wait_count" -le 250 ] || fail "local seeding never reached its identity completion marker"
+    sleep 0.02
+  done
+  assert_local_secondmate_parent_record "$child" "$parent_resolved"
+  assert_absent "$child/.fm-secondmate-home" \
+    "the local identity marker must remain absent until durable parent publication completes"
+  touch "$release"
+  wait "$seed_pid" || fail "local seeding failed after publishing durable parent state: $(cat "$manifest_out")"
+  assert_present "$child/.fm-secondmate-home" \
+    "local seeding must publish its identity marker as the completion point"
+  pass "local seeding publishes durable parent state before its identity marker"
+}
+
 test_secondmate_teardown_resolves_parent_from_durable_record_when_env_lost() {
   local parent child parent_resolved
   parent=$(make_home teardown-durable-parent)
@@ -1180,6 +1231,7 @@ test_interrupted_delivery_refuses_to_repost
 test_outward_delivery_stays_with_the_owning_home
 test_delivery_requires_registration_before_posting
 test_secondmate_teardown_requires_parent_binding
+test_local_secondmate_seed_publishes_parent_before_identity
 test_secondmate_teardown_resolves_parent_from_durable_record_when_env_lost
 test_secondmate_teardown_durable_record_missing_parent_registration_still_refuses
 test_secondmate_teardown_durable_record_with_no_commitment_succeeds

--- a/tests/fm-public-followup.test.sh
+++ b/tests/fm-public-followup.test.sh
@@ -618,6 +618,8 @@ test_secondmate_teardown_requires_parent_binding() {
   fm_write_meta "$child/state/work-child.meta" \
     "window=firstmate:fm-work-child" "endpoint_task_id=work-child" \
     "worktree=$child" "project=$child" "kind=ship" "mode=local-only"
+  assert_absent "$child/.fm-secondmate-parent" \
+    "the legacy env-only binding case must not gain a durable parent record"
 
   PATH="$child/fakebin:$PATH" FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$child" \
     FM_STATE_OVERRIDE="$child/state" FM_DATA_OVERRIDE="$child/data" \
@@ -775,7 +777,7 @@ test_secondmate_teardown_durable_record_missing_parent_registration_still_refuse
 }
 
 test_secondmate_teardown_durable_record_with_no_commitment_succeeds() {
-  local parent child parent_resolved rc out
+  local parent parent_alias child parent_resolved rc out
   parent=$(make_home teardown-durable-clean-parent relay-off)
   child="$TMP_ROOT/teardown-durable-clean-child"
   FM_SECONDMATE_CHARTER='Durable-record clean-cleanup regression charter.' \
@@ -786,6 +788,8 @@ test_secondmate_teardown_durable_record_with_no_commitment_succeeds() {
   make_fake_curl "$child" >/dev/null
   fm_fake_exit0 "$child/fakebin" tmux treehouse no-mistakes gh gh-axi
   assert_local_secondmate_parent_record "$child" "$parent_resolved"
+  parent_alias="$TMP_ROOT/teardown-durable-clean-parent-alias"
+  ln -s "$parent" "$parent_alias"
   fm_write_meta "$parent/state/mate.meta" "kind=secondmate" "home=$child"
   fm_git_init_commit "$child/projects/worktree"
   printf 'manual\n' > "$child/config/backlog-backend"
@@ -797,12 +801,45 @@ test_secondmate_teardown_durable_record_with_no_commitment_succeeds() {
   rc=0
   out=$(PATH="$child/fakebin:$PATH" FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$child" \
     FM_STATE_OVERRIDE="$child/state" FM_DATA_OVERRIDE="$child/data" \
-    FM_CONFIG_OVERRIDE="$child/config" FM_PUBLIC_FOLLOWUP_PRIMARY_HOME="$parent" \
+    FM_CONFIG_OVERRIDE="$child/config" FM_PUBLIC_FOLLOWUP_PRIMARY_HOME="$parent_alias" \
     "$TEARDOWN" work-clean 2>&1) || rc=$?
   [ "$rc" -eq 0 ] || fail "a resolved parent with no owed commitment must allow cleanup (rc=$rc): $out"
   assert_not_contains "$out" "cannot resolve the primary home" \
     "a real durable-record-backed parent must resolve cleanly"
   pass "a resolved parent through the durable local record allows cleanup with nothing owed"
+}
+
+test_secondmate_teardown_rejects_conflicting_live_and_durable_parent_bindings() {
+  local durable_parent live_parent child parent_resolved
+  durable_parent=$(make_home teardown-durable-conflict-recorded relay-off)
+  live_parent=$(make_home teardown-durable-conflict-live relay-off)
+  child="$TMP_ROOT/teardown-durable-conflict-child"
+  FM_SECONDMATE_CHARTER='Durable-record conflict regression charter.' \
+    FM_HOME="$durable_parent" "$ROOT/bin/fm-home-seed.sh" mate "$child" --no-projects >/dev/null \
+    || fail "real secondmate seeding failed"
+  child=$(cd "$child" && pwd -P)
+  parent_resolved=$(cd "$durable_parent" && pwd -P)
+  make_fake_curl "$child" >/dev/null
+  fm_fake_exit0 "$child/fakebin" tmux treehouse no-mistakes gh gh-axi
+  assert_local_secondmate_parent_record "$child" "$parent_resolved"
+  fm_write_meta "$durable_parent/state/mate.meta" "kind=secondmate" "home=$child"
+  fm_git_init_commit "$child/projects/worktree"
+  printf 'manual\n' > "$child/config/backlog-backend"
+  fm_write_meta "$child/state/work-conflict.meta" \
+    "window=firstmate:fm-work-conflict" "endpoint_task_id=work-conflict" \
+    "worktree=$child/projects/worktree" "project=$child/projects/worktree" \
+    "kind=ship" "mode=local-only"
+
+  PATH="$child/fakebin:$PATH" FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$child" \
+    FM_STATE_OVERRIDE="$child/state" FM_DATA_OVERRIDE="$child/data" \
+    FM_CONFIG_OVERRIDE="$child/config" FM_PUBLIC_FOLLOWUP_PRIMARY_HOME="$live_parent" \
+    expect_failure "conflicting live and durable parent bindings must refuse cleanup" \
+    "$TEARDOWN" work-conflict
+  assert_contains "$EXPECT_OUT" "cannot resolve the primary home for marked secondmate mate" \
+    "a conflicting live parent must produce the explicit durable-binding refusal"
+  assert_present "$child/state/work-conflict.meta" \
+    "a conflicting live parent must preserve child work metadata"
+  pass "conflicting live and durable parent bindings fail closed"
 }
 
 test_secondmate_teardown_rejects_unsafe_durable_parent_records() {
@@ -1235,6 +1272,7 @@ test_local_secondmate_seed_publishes_parent_before_identity
 test_secondmate_teardown_resolves_parent_from_durable_record_when_env_lost
 test_secondmate_teardown_durable_record_missing_parent_registration_still_refuses
 test_secondmate_teardown_durable_record_with_no_commitment_succeeds
+test_secondmate_teardown_rejects_conflicting_live_and_durable_parent_bindings
 test_secondmate_teardown_rejects_unsafe_durable_parent_records
 test_relay_disabled_unmarked_teardown_skips_public_path
 test_relay_disabled_parent_allows_marked_child_teardown

--- a/tests/fm-remote-secondmate-lifecycle-e2e.test.sh
+++ b/tests/fm-remote-secondmate-lifecycle-e2e.test.sh
@@ -729,7 +729,9 @@ inherit_wait=0
 while [ ! -f "$TMP_ROOT/inherit.entered" ]; do
   kill -0 "$config_first" 2>/dev/null || fail "first inheritance transaction exited before its blocked write"
   inherit_wait=$((inherit_wait + 1))
-  [ "$inherit_wait" -le 250 ] || fail "first inheritance transaction never reached its blocked write"
+  # Match the earlier spawn/inheritance wait: a loaded portable runner can
+  # spend several seconds in the remote entrypoint before reaching this write.
+  [ "$inherit_wait" -le 1500 ] || fail "first inheritance transaction never reached its blocked write"
   sleep 0.02
 done
 cat > "$PARENT/data/captain-shared.md" <<'EOF'

--- a/tests/fm-remote-secondmate-parent-binding.test.sh
+++ b/tests/fm-remote-secondmate-parent-binding.test.sh
@@ -149,12 +149,9 @@ FM_SECONDMATE_CHARTER='Own iOS delivery on the build Mac.' \
 # --- the durable record itself: the fundamental part of the fix -------------
 assert_present "$REMOTE_HOME/.fm-secondmate-parent" \
   "real remote provisioning must write a durable parent record"
-assert_grep 'route=remote' "$REMOTE_HOME/.fm-secondmate-parent" \
-  "a cross-machine secondmate must be recorded with a remote route"
-assert_grep 'parent_host=remote-mac' "$REMOTE_HOME/.fm-secondmate-parent" \
-  "the durable record must carry the parent's SSH alias for diagnostics"
-assert_no_grep "$PARENT" "$REMOTE_HOME/.fm-secondmate-parent" \
-  "a remote durable record must never carry a path meaningful only on the parent's filesystem"
+cmp -s "$REMOTE_HOME/.fm-secondmate-parent" <(
+  printf 'schema=fm-secondmate-parent.v1\nroute=remote\nparent_host=remote-mac\n'
+) || fail "real remote provisioning must write the exact durable remote parent record"
 
 remote_env "$ROOT/bin/fm-spawn.sh" ios --secondmate >/dev/null \
   || fail "real remote secondmate launch failed"

--- a/tests/fm-remote-secondmate-parent-binding.test.sh
+++ b/tests/fm-remote-secondmate-parent-binding.test.sh
@@ -46,10 +46,16 @@ DOCTOR_LOG="$TMP_ROOT/doctor.log"
 HERDR_STATE="$TMP_ROOT/remote-herdr.state"
 HERDR_LOG="$TMP_ROOT/remote-herdr.log"
 CLAIMS="$TMP_ROOT/claims"
+PUBLISH_PID=
 mkdir -p "$PARENT/data" "$PARENT/state" "$PARENT/config" "$PARENT/projects" "$REMOTE_ROOT" "$CLAIMS"
 
 cleanup() {
   local worker_pid=''
+  if [ -n "$PUBLISH_PID" ]; then
+    touch "$PUBLISH_RELEASE" 2>/dev/null || true
+    kill "$PUBLISH_PID" 2>/dev/null || true
+    wait "$PUBLISH_PID" 2>/dev/null || true
+  fi
   FM_HOME="$PARENT" FM_PROCEVENT_CLAIM_ROOT="$CLAIMS" \
     "$ROOT/bin/fm-procevent.sh" sweep-home >/dev/null 2>&1 || true
   if [ -f "$TMP_ROOT/remote-jobs/worker.pid" ]; then
@@ -59,6 +65,52 @@ cleanup() {
   rm -rf -- "$TMP_ROOT"
 }
 trap cleanup EXIT
+
+PUBLISH_HOME="$TMP_ROOT/publication-home"
+PUBLISH_FAKEBIN=$(fm_fakebin "$TMP_ROOT/publication-fake")
+PUBLISH_ENTERED="$TMP_ROOT/publication-marker-entered"
+PUBLISH_RELEASE="$TMP_ROOT/publication-marker-release"
+PUBLISH_MANIFEST="$TMP_ROOT/publication.manifest"
+REAL_MV=$(command -v mv)
+cat > "$PUBLISH_FAKEBIN/mv" <<'SH'
+#!/usr/bin/env bash
+destination=${!#}
+case "$destination" in
+  */.fm-secondmate-home)
+    touch "$FM_TEST_PUBLISH_ENTERED"
+    while [ ! -f "$FM_TEST_PUBLISH_RELEASE" ]; do sleep 0.02; done
+    ;;
+esac
+exec "$FM_TEST_REAL_MV" "$@"
+SH
+chmod +x "$PUBLISH_FAKEBIN/mv"
+printf 'schema=fm-remote-home-provision.v1\nid_b64=%s\ncharter_b64=%s\nparent_host_b64=%s\nproject_count=0\n' \
+  "$(printf publication | base64 | tr -d '\n')" \
+  "$(printf 'Publication-order regression charter.\n' | base64 | tr -d '\n')" \
+  "$(printf publish-host | base64 | tr -d '\n')" > "$PUBLISH_MANIFEST"
+PATH="$PUBLISH_FAKEBIN:$PATH" FM_HOME="$PUBLISH_HOME" FM_ROOT_OVERRIDE="$ROOT" \
+  FM_TEST_REAL_MV="$REAL_MV" FM_TEST_PUBLISH_ENTERED="$PUBLISH_ENTERED" \
+  FM_TEST_PUBLISH_RELEASE="$PUBLISH_RELEASE" \
+  "$ROOT/bin/fm-remote-home-provision.sh" < "$PUBLISH_MANIFEST" >/dev/null 2>&1 &
+PUBLISH_PID=$!
+publish_wait=0
+while [ ! -f "$PUBLISH_ENTERED" ]; do
+  kill -0 "$PUBLISH_PID" 2>/dev/null || fail "remote provisioning exited before its completion marker"
+  publish_wait=$((publish_wait + 1))
+  [ "$publish_wait" -le 250 ] || fail "remote provisioning never reached its completion marker"
+  sleep 0.02
+done
+cmp -s "$PUBLISH_HOME/.fm-secondmate-parent" <(
+  printf 'schema=fm-secondmate-parent.v1\nroute=remote\nparent_host=publish-host\n'
+) || fail "remote provisioning exposed completion before publishing the durable parent record"
+assert_absent "$PUBLISH_HOME/.fm-secondmate-home" \
+  "the remote identity marker must remain absent until durable parent publication completes"
+touch "$PUBLISH_RELEASE"
+wait "$PUBLISH_PID" || fail "remote provisioning failed after publishing durable state"
+PUBLISH_PID=
+assert_present "$PUBLISH_HOME/.fm-secondmate-home" \
+  "remote provisioning must publish its identity marker as the completion point"
+pass "remote provisioning publishes durable parent state before its completion marker"
 
 # --- the remote host's tracked code root, real git repos, one project --------
 (

--- a/tests/fm-remote-secondmate-parent-binding.test.sh
+++ b/tests/fm-remote-secondmate-parent-binding.test.sh
@@ -1,0 +1,244 @@
+#!/usr/bin/env bash
+# tests/fm-remote-secondmate-parent-binding.test.sh - regression coverage for the
+# fm-remote-sm-cleanup-parent-binding-s1 scout report: finished-worker cleanup
+# inside a REMOTE second-mate home refused forever with "cannot resolve the
+# primary home ... durable parent binding", because the remote launch hands the
+# child the remote code checkout as its parent home (bin/fm-spawn.sh's sole
+# writer of FM_PUBLIC_FOLLOWUP_PRIMARY_HOME receives FM_HOME=$FM_ROOT from
+# bin/fm-remote-secondmate-control.sh's host-local launch), and that path can
+# never carry the parent's real state or registry.
+#
+# The fix (report section 7, captain-approved same-machine scope): a durable
+# .fm-secondmate-parent record, written once at seeding next to the
+# .fm-secondmate-home identity marker, names this home's route to its parent as
+# "local" or "remote". bin/fm-teardown.sh's cleanup gate reads it and treats a
+# remote parent as OUT OF SCOPE (never refuses purely for being cross-machine,
+# since the whole promised-public-reply subsystem is same-filesystem by
+# construction) while still refusing on a genuine same-filesystem signal
+# committed directly to this home's own .env file - never on an unrelated
+# process-environment export, which is what let the remote host's own login
+# shell mask into this home's binding before.
+#
+# This drives the REAL remote route (fm-remote-home-seed.sh -> fm-on.sh ->
+# fm-remote-entrypoint.sh -> the host-local fm-remote-secondmate-control.sh ->
+# the real bin/fm-spawn.sh --secondmate) across the repo's own deterministic SSH
+# boundary and Herdr fixture, then runs the real bin/fm-teardown.sh for a
+# finished child worker inside the produced remote home - never source-text
+# matching.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+# shellcheck source=tests/remote-herdr-fixture.sh
+. "$(dirname "${BASH_SOURCE[0]}")/remote-herdr-fixture.sh"
+
+command -v jq >/dev/null 2>&1 || { echo "skip: jq not found"; exit 0; }
+
+TMP_ROOT=$(fm_test_tmproot fm-remote-parent-binding)
+mkdir -p "$TMP_ROOT"
+TMP_ROOT=$(cd "$TMP_ROOT" && pwd -P)
+PARENT="$TMP_ROOT/parent"
+REMOTE_ROOT="$TMP_ROOT/remote-root"
+REMOTE_HOME="$TMP_ROOT/remote-home"
+FAKEBIN=$(fm_fakebin "$TMP_ROOT/fake")
+SSH_COUNT="$TMP_ROOT/ssh.count"
+DOCTOR_LOG="$TMP_ROOT/doctor.log"
+HERDR_STATE="$TMP_ROOT/remote-herdr.state"
+HERDR_LOG="$TMP_ROOT/remote-herdr.log"
+CLAIMS="$TMP_ROOT/claims"
+mkdir -p "$PARENT/data" "$PARENT/state" "$PARENT/config" "$PARENT/projects" "$REMOTE_ROOT" "$CLAIMS"
+
+cleanup() {
+  local worker_pid=''
+  FM_HOME="$PARENT" FM_PROCEVENT_CLAIM_ROOT="$CLAIMS" \
+    "$ROOT/bin/fm-procevent.sh" sweep-home >/dev/null 2>&1 || true
+  if [ -f "$TMP_ROOT/remote-jobs/worker.pid" ]; then
+    worker_pid=$(cat "$TMP_ROOT/remote-jobs/worker.pid")
+    kill "$worker_pid" 2>/dev/null || true
+  fi
+  rm -rf -- "$TMP_ROOT"
+}
+trap cleanup EXIT
+
+# --- the remote host's tracked code root, real git repos, one project --------
+(
+  cd "$ROOT" || exit
+  tar --exclude=.git --exclude=.no-mistakes --exclude=data --exclude=state --exclude=config -cf - .
+) | (cd "$REMOTE_ROOT" && tar -xf -)
+install_remote_herdr_fixture "$REMOTE_ROOT" "$HERDR_STATE" "$HERDR_LOG" \
+  "$TMP_ROOT/herdr-send-fail" "$TMP_ROOT/herdr.sock"
+git -C "$REMOTE_ROOT" init -q -b main
+git -C "$REMOTE_ROOT" config user.email test@example.com
+git -C "$REMOTE_ROOT" config user.name Test
+git -C "$REMOTE_ROOT" add .
+git -C "$REMOTE_ROOT" commit -qm 'remote fixture root'
+REMOTE_ORIGIN="$TMP_ROOT/firstmate-origin.git"
+git init -q --bare "$REMOTE_ORIGIN"
+git -C "$REMOTE_ROOT" remote add origin "file://$REMOTE_ORIGIN"
+git -C "$REMOTE_ROOT" push -q -u origin main
+git --git-dir="$REMOTE_ORIGIN" symbolic-ref HEAD refs/heads/main
+
+git init -q --bare "$TMP_ROOT/alpha.git"
+git -C "$PARENT/projects" init -q -b main alpha
+git -C "$PARENT/projects/alpha" config user.email test@example.com
+git -C "$PARENT/projects/alpha" config user.name Test
+printf 'alpha\n' > "$PARENT/projects/alpha/README.md"
+git -C "$PARENT/projects/alpha" add README.md
+git -C "$PARENT/projects/alpha" commit -qm init
+git -C "$PARENT/projects/alpha" remote add origin "file://$TMP_ROOT/alpha.git"
+git -C "$PARENT/projects/alpha" push -q -u origin main
+printf -- '- alpha [direct-PR] - alpha project (added 2026-08-04)\n' > "$PARENT/data/projects.md"
+printf 'codex\n' > "$PARENT/config/secondmate-harness"
+printf 'tmux\n' > "$PARENT/config/backend"
+
+# The primary home is the X-mode / relay home: the captain's real activation.
+printf 'FMX_PAIRING_TOKEN=repro-token\n' > "$PARENT/.env"
+
+# --- deterministic SSH boundary, identical shape to the lifecycle e2e suite --
+cat > "$FAKEBIN/fake-ssh" <<'SH'
+#!/usr/bin/env bash
+count=$(cat "$FM_FAKE_SSH_COUNT" 2>/dev/null || echo 0)
+printf '%s\n' "$((count + 1))" > "$FM_FAKE_SSH_COUNT"
+while [ "$#" -gt 0 ]; do
+  case "$1" in -o) shift 2 ;; --) shift; break ;; *) exit 90 ;; esac
+done
+host=$1
+entry=$2
+shift 2
+[ "$host" = remote-mac ] || exit 91
+[ "$entry" = fm-remote-entrypoint.sh ] || exit 92
+cd "$FM_FAKE_REMOTE_CWD" || exit 93
+argv_b64=$4
+command_fields=$(perl -MMIME::Base64=decode_base64 -e '
+  my $data=decode_base64($ARGV[0]);
+  my @args=split(/\0/, $data);
+  print join("\t", map { defined $_ ? $_ : "" } @args[0..2]);
+' "$argv_b64")
+IFS=$'\t' read -r command_name _command_action command_rel <<EOF
+$command_fields
+EOF
+if [ "$command_name" = fm-remote-doctor.sh ]; then
+  printf 'check herdr=ok: /usr/bin/herdr\n'
+  printf 'ok: remote second-mate readiness confirmed on this host\n'
+  exit 0
+fi
+exec "$FM_FAKE_REMOTE_ENTRYPOINT" "$@"
+SH
+chmod +x "$FAKEBIN/fake-ssh"
+
+remote_env() {
+  FM_HOME="$PARENT" \
+  FM_ROOT_OVERRIDE="$REMOTE_ROOT" \
+  FM_PROCEVENT_CLAIM_ROOT="$CLAIMS" \
+  FM_SSH_BIN="$FAKEBIN/fake-ssh" \
+  FM_FAKE_SSH_COUNT="$SSH_COUNT" \
+  FM_FAKE_REMOTE_ENTRYPOINT="$REMOTE_ROOT/bin/fm-remote-entrypoint.sh" \
+  FM_REMOTE_JOB_PLATFORM_OVERRIDE=Linux \
+  FM_REMOTE_JOB_STATE_ROOT="$TMP_ROOT/remote-jobs" \
+  FM_FAKE_REMOTE_CWD="$TMP_ROOT" \
+  FM_FAKE_DOCTOR_LOG="$DOCTOR_LOG" \
+  FM_SEND_SETTLE=0 FM_SEND_SLEEP=0 \
+  "$@"
+}
+
+FM_SECONDMATE_CHARTER='Own iOS delivery on the build Mac.' \
+  FM_SECONDMATE_SCOPE='iOS implementation and Xcode validation' \
+  remote_env "$ROOT/bin/fm-remote-home-seed.sh" ios remote-mac "$REMOTE_ROOT" "$REMOTE_HOME" alpha \
+  >/dev/null || fail "real remote secondmate seeding failed"
+
+# --- the durable record itself: the fundamental part of the fix -------------
+assert_present "$REMOTE_HOME/.fm-secondmate-parent" \
+  "real remote provisioning must write a durable parent record"
+assert_grep 'route=remote' "$REMOTE_HOME/.fm-secondmate-parent" \
+  "a cross-machine secondmate must be recorded with a remote route"
+assert_grep 'parent_host=remote-mac' "$REMOTE_HOME/.fm-secondmate-parent" \
+  "the durable record must carry the parent's SSH alias for diagnostics"
+assert_no_grep "$PARENT" "$REMOTE_HOME/.fm-secondmate-parent" \
+  "a remote durable record must never carry a path meaningful only on the parent's filesystem"
+
+remote_env "$ROOT/bin/fm-spawn.sh" ios --secondmate >/dev/null \
+  || fail "real remote secondmate launch failed"
+
+DELIVERED_LINE=$(grep -F 'FM_PUBLIC_FOLLOWUP_PRIMARY_HOME' "$HERDR_LOG" | tail -1 || true)
+DELIVERED=$(printf '%s\n' "$DELIVERED_LINE" | tr ' ' '\n' \
+  | sed -n "s/^FM_PUBLIC_FOLLOWUP_PRIMARY_HOME='\{0,1\}\([^']*\)'\{0,1\}\$/\1/p" | tail -1)
+[ -n "$DELIVERED" ] || fail "the remote launch did not deliver a primary-home binding to assert against"
+case "$DELIVERED" in
+  "$REMOTE_ROOT") : ;;
+  *) fail "test setup drifted: expected the remote code root to be delivered as the (wrong) parent binding, got: $DELIVERED" ;;
+esac
+
+# --- a finished child worker inside the remote secondmate home --------------
+CHILD_WT="$REMOTE_HOME/projects/alpha"
+mkdir -p "$REMOTE_HOME/state"
+write_child_meta() {
+  fm_write_meta "$REMOTE_HOME/state/work-child.meta" \
+    "window=firstmate:fm-work-child" "endpoint_task_id=work-child" \
+    "worktree=$CHILD_WT" "project=$CHILD_WT" "harness=codex" "kind=ship" \
+    "mode=local-only" "yolo=off"
+}
+mkdir -p "$TMP_ROOT/childfake"
+for t in tmux treehouse no-mistakes gh gh-axi tasks-axi; do
+  printf '#!/usr/bin/env bash\nexit 0\n' > "$TMP_ROOT/childfake/$t"
+  chmod +x "$TMP_ROOT/childfake/$t"
+done
+
+run_child_teardown() { # <extra env assignments...>
+  local out rc=0
+  write_child_meta
+  out=$(env "$@" PATH="$TMP_ROOT/childfake:$PATH" \
+    FM_HOME="$REMOTE_HOME" FM_STATE_OVERRIDE="$REMOTE_HOME/state" \
+    FM_DATA_OVERRIDE="$REMOTE_HOME/data" FM_CONFIG_OVERRIDE="$REMOTE_HOME/config" \
+    "$REMOTE_ROOT/bin/fm-teardown.sh" work-child 2>&1) || rc=$?
+  CHILD_TEARDOWN_OUT=$out
+  CHILD_TEARDOWN_RC=$rc
+}
+
+# Case B-equivalent: the delivered (wrong) binding points at the remote code
+# root, and that root itself carries an X-mode .env - a plausible real-world
+# state (a captain who also runs Firstmate directly on the build Mac). Before
+# the fix this refused; the durable record now makes it out of scope.
+printf 'FMX_PAIRING_TOKEN=remote-host-token\n' > "$REMOTE_ROOT/.env"
+run_child_teardown FM_PUBLIC_FOLLOWUP_PRIMARY_HOME="$DELIVERED"
+rm -f "$REMOTE_ROOT/.env"
+[ "$CHILD_TEARDOWN_RC" -eq 0 ] \
+  || fail "a remote-routed child must allow cleanup when only the remote code root looks relay-active (rc=$CHILD_TEARDOWN_RC): $CHILD_TEARDOWN_OUT"
+assert_not_contains "$CHILD_TEARDOWN_OUT" "cannot resolve the primary home" \
+  "a cross-machine parent must never be reported as an unresolved binding"
+pass "a remote secondmate's finished worker cleans up when the remote code root's own .env looked relay-active"
+
+# Case C-equivalent: FMX_PAIRING_TOKEN exported directly in the process
+# environment, simulating the remote host's own login-shell export reaching the
+# agent's pane. fm_pf_relay_active's environment-wins rule would make this look
+# identical to a genuine same-home commitment; the fix must tell them apart by
+# reading only $FM_HOME/.env, never the process environment, once the durable
+# record says the parent is remote.
+run_child_teardown FM_PUBLIC_FOLLOWUP_PRIMARY_HOME="$DELIVERED" FMX_PAIRING_TOKEN=ambient-login-token
+[ "$CHILD_TEARDOWN_RC" -eq 0 ] \
+  || fail "a remote-routed child must allow cleanup when only an ambient exported token looks relay-active (rc=$CHILD_TEARDOWN_RC): $CHILD_TEARDOWN_OUT"
+assert_not_contains "$CHILD_TEARDOWN_OUT" "cannot resolve the primary home" \
+  "an ambient exported token from the remote host's own shell must never bind this child"
+pass "a remote secondmate's finished worker cleans up when only an ambient exported token looked relay-active"
+
+# Baseline: no signal anywhere. Must keep succeeding exactly as before the fix.
+run_child_teardown
+[ "$CHILD_TEARDOWN_RC" -eq 0 ] \
+  || fail "a remote-routed child with no relay signal anywhere must allow cleanup (rc=$CHILD_TEARDOWN_RC): $CHILD_TEARDOWN_OUT"
+pass "a remote secondmate's finished worker cleans up with no relay signal anywhere"
+
+# Protection-preserved case: THIS home's own .env file (not the process
+# environment, not the remote code root) carries a real token. That is a
+# genuine same-filesystem signal this child's own home could hold, so it must
+# still refuse even though the parent route is remote.
+printf 'FMX_PAIRING_TOKEN=child-own-token\n' > "$REMOTE_HOME/.env"
+run_child_teardown
+rm -f "$REMOTE_HOME/.env"
+[ "$CHILD_TEARDOWN_RC" -ne 0 ] \
+  || fail "a remote secondmate's own committed .env token must still refuse cleanup, got rc=0: $CHILD_TEARDOWN_OUT"
+assert_contains "$CHILD_TEARDOWN_OUT" "cannot resolve the primary home" \
+  "a genuine same-filesystem token on this home must remain an actionable refusal"
+assert_present "$REMOTE_HOME/state/work-child.meta" \
+  "a genuine refusal must preserve the child work metadata"
+pass "a remote secondmate's own committed relay token still refuses cleanup"
+
+echo "ALL TESTS PASSED"

--- a/tests/fm-remote-secondmate-parent-binding.test.sh
+++ b/tests/fm-remote-secondmate-parent-binding.test.sh
@@ -139,6 +139,7 @@ git -C "$PARENT/projects/alpha" add README.md
 git -C "$PARENT/projects/alpha" commit -qm init
 git -C "$PARENT/projects/alpha" remote add origin "file://$TMP_ROOT/alpha.git"
 git -C "$PARENT/projects/alpha" push -q -u origin main
+git --git-dir="$TMP_ROOT/alpha.git" symbolic-ref HEAD refs/heads/main
 printf -- '- alpha [direct-PR] - alpha project (added 2026-08-04)\n' > "$PARENT/data/projects.md"
 printf 'codex\n' > "$PARENT/config/secondmate-harness"
 printf 'tmux\n' > "$PARENT/config/backend"

--- a/tests/fm-secondmate-safety.test.sh
+++ b/tests/fm-secondmate-safety.test.sh
@@ -1307,6 +1307,53 @@ test_home_seed_refuses_unsafe_leaf_files() {
   pass "home seeding refuses symlinked and non-regular leaf files"
 }
 
+test_home_seed_preserves_existing_parent_binding() {
+  local parent_a parent_b child child_abs before err out parent_a_abs parent_b_abs leaf
+  parent_a="$TMP_ROOT/reseed-parent-a"
+  parent_b="$TMP_ROOT/reseed-parent-b"
+  child="$TMP_ROOT/reseed-parent-child"
+  before="$TMP_ROOT/reseed-parent-before"
+  err="$TMP_ROOT/reseed-parent.err"
+  mkdir -p "$parent_a/data" "$parent_a/state" "$parent_a/projects" \
+    "$parent_b/data" "$parent_b/state" "$parent_b/projects" "$before/data"
+
+  FM_HOME="$parent_a" FM_SECONDMATE_CHARTER='Durable parent reseed charter.' \
+    FM_SECONDMATE_SCOPE='durable parent reseed scope' \
+    "$ROOT/bin/fm-home-seed.sh" mate "$child" --no-projects >/dev/null \
+    || fail "initial durable-parent seed failed"
+  parent_a_abs=$(cd "$parent_a" && pwd -P)
+  parent_b_abs=$(cd "$parent_b" && pwd -P)
+  child_abs=$(cd "$child" && pwd -P)
+  for leaf in data/projects.md data/charter.md .fm-secondmate-home .fm-secondmate-parent; do
+    mkdir -p "$before/$(dirname "$leaf")"
+    cp "$child/$leaf" "$before/$leaf"
+  done
+
+  if FM_HOME="$parent_b" FM_SECONDMATE_CHARTER='Replacement parent charter.' \
+    FM_SECONDMATE_SCOPE='replacement parent scope' \
+    "$ROOT/bin/fm-home-seed.sh" mate "$child" --no-projects > /dev/null 2>"$err"; then
+    fail "reseed replaced a valid durable parent binding"
+  fi
+  grep -F "bound to parent $parent_a_abs, not requested parent $parent_b_abs" "$err" >/dev/null \
+    || fail "mismatched-parent reseed did not name both parent identities"
+  for leaf in data/projects.md data/charter.md .fm-secondmate-home .fm-secondmate-parent; do
+    cmp -s "$before/$leaf" "$child/$leaf" \
+      || fail "mismatched-parent reseed changed $leaf"
+  done
+  [ ! -e "$parent_b/data/mate/brief.md" ] \
+    || fail "mismatched-parent reseed created a replacement parent brief"
+  [ ! -e "$parent_b/data/secondmates.md" ] \
+    || fail "mismatched-parent reseed registered the child to the replacement parent"
+
+  out=$(FM_HOME="$parent_a" "$ROOT/bin/fm-home-seed.sh" mate "$child" --no-projects) \
+    || fail "matching-parent reseed failed"
+  printf '%s\n' "$out" | grep -F "home=$child_abs" >/dev/null \
+    || fail "matching-parent reseed did not report success"
+  cmp -s "$before/.fm-secondmate-parent" "$child/.fm-secondmate-parent" \
+    || fail "matching-parent reseed changed the durable parent binding"
+  pass "home reseeding preserves and enforces the durable parent binding"
+}
+
 test_secondmate_spawn_requires_seeded_matching_home() {
   local home subhome wronghome marker_only active_descendant active_ancestor ancestor_active_home fakeroot root_descendant root_ancestor root_inside fakebin log err
   home="$TMP_ROOT/spawn-validate-home"
@@ -2655,6 +2702,7 @@ test_home_seed_refuses_uninitialized_existing_no_mistakes_project
 test_home_seed_refuses_project_destinations_outside_subhome
 test_home_seed_refuses_operational_dirs_outside_subhome
 test_home_seed_refuses_unsafe_leaf_files
+test_home_seed_preserves_existing_parent_binding
 test_secondmate_spawn_requires_seeded_matching_home
 test_secondmate_spawn_refuses_operational_dirs_outside_subhome
 test_fm_send_refuses_bare_window_without_home_meta

--- a/tests/fm-secondmate-safety.test.sh
+++ b/tests/fm-secondmate-safety.test.sh
@@ -1259,7 +1259,7 @@ test_home_seed_refuses_operational_dirs_outside_subhome() {
   pass "home seeding refuses operational directories outside the subhome"
 }
 
-test_home_seed_refuses_symlinked_leaf_files() {
+test_home_seed_refuses_unsafe_leaf_files() {
   local home subhome sink err leaf target expected
   home="$TMP_ROOT/symlink-leaf-home"
   err="$TMP_ROOT/symlink-leaf.err"
@@ -1269,7 +1269,7 @@ test_home_seed_refuses_symlinked_leaf_files() {
   printf '%s\n' '- alpha [direct-PR] - alpha project (added 2026-06-22)' > "$home/data/projects.md"
   scaffold_secondmate_charter "$home" design 'design domain' alpha || fail "charter scaffold failed for symlink leaf seed test"
 
-  for leaf in data/projects.md data/charter.md .fm-secondmate-home; do
+  for leaf in data/projects.md data/charter.md .fm-secondmate-home .fm-secondmate-parent; do
     subhome="$TMP_ROOT/symlink-leaf-subhome-${leaf//\//-}"
     sink="$home/data/symlink-leaf-${leaf//\//-}"
     rm -rf "$subhome" "$sink"
@@ -1290,7 +1290,21 @@ test_home_seed_refuses_symlinked_leaf_files() {
     [ "$target" = "$expected" ] || fail "seed overwrote outside symlink target for $leaf"
     [ ! -f "$subhome/.fm-secondmate-home" ] || [ "$leaf" = ".fm-secondmate-home" ] || fail "seed marked subhome after symlinked leaf refusal"
   done
-  pass "home seeding refuses symlinked leaf files"
+  for leaf in data/projects.md data/charter.md .fm-secondmate-home .fm-secondmate-parent; do
+    subhome="$TMP_ROOT/directory-leaf-subhome-${leaf//\//-}"
+    rm -rf "$subhome"
+    git clone --quiet "$ROOT" "$subhome"
+    mkdir -p "$subhome/$leaf"
+    if FM_HOME="$home" "$ROOT/bin/fm-home-seed.sh" design "$subhome" alpha >/dev/null 2>"$err"; then
+      fail "seed accepted directory leaf $leaf"
+    fi
+    grep -F 'secondmate leaf file must be a regular file:' "$err" >/dev/null \
+      || fail "seed did not explain directory leaf refusal for $leaf"
+    [ -d "$subhome/$leaf" ] || fail "seed changed directory leaf $leaf"
+    [ ! -f "$subhome/.fm-secondmate-home" ] \
+      || fail "seed published an identity marker after directory leaf refusal for $leaf"
+  done
+  pass "home seeding refuses symlinked and non-regular leaf files"
 }
 
 test_secondmate_spawn_requires_seeded_matching_home() {
@@ -2640,7 +2654,7 @@ test_home_seed_skips_initialized_existing_no_mistakes_projects
 test_home_seed_refuses_uninitialized_existing_no_mistakes_project
 test_home_seed_refuses_project_destinations_outside_subhome
 test_home_seed_refuses_operational_dirs_outside_subhome
-test_home_seed_refuses_symlinked_leaf_files
+test_home_seed_refuses_unsafe_leaf_files
 test_secondmate_spawn_requires_seeded_matching_home
 test_secondmate_spawn_refuses_operational_dirs_outside_subhome
 test_fm_send_refuses_bare_window_without_home_meta


### PR DESCRIPTION
## Intent

Fix finished-worker cleanup on a REMOTE second-mate home so it stops refusing forever with "can't resolve its durable parent binding". This is the promotion of a completed diagnostic scout task (fm-remote-sm-cleanup-parent-binding-s1); implement the report's section-7 fix direction, which the captain approved.

Captain decision that scopes this: should a second mate on another machine ever carry a promised public reply? Answer is NO - keep the current same-machine design (the whole public-reply subsystem is same-filesystem by construction). So the fix is the small, contained one, NOT building a cross-machine reporting channel.

Root cause (confirmed by the scout): on the remote route, bin/fm-spawn.sh composes the child's parent binding as FM_PUBLIC_FOLLOWUP_PRIMARY_HOME=$FM_HOME, but the remote launch (bin/fm-remote-secondmate-control.sh) runs the spawn with FM_HOME=$FM_ROOT (the remote code checkout), so the second mate is told its parent home is the remote machine's own code checkout - a path holding none of the parent's records. The cleanup check (bin/fm-teardown.sh, public_followup_resolve_primary_home) then resolves to a wrong-but-plausible directory and refuses, permanently, once relay is active on that remote host. Deeper: a second-mate home has NO durable record of its parent - the binding was only a launch-time env var, which also made local relay silently fail-open on a restart that drops the prefix.

Fix (two levels, both required, per the report's section 7):
1. Durable local parent record. Write a durable record of the second-mate home's parent IDENTITY and ROUTE (parent host + parent home), once, at SEEDING/provisioning time, next to the existing .fm-secondmate-home id marker. The cleanup check must be able to read the parent binding from this durable record, not only from the launch-time env var. This also closes the local record-drift refusal and removes the silent local fail-open.
2. Cleanup distinguishes cross-machine from missing. The finished-worker cleanup check now treats "my parent is on another machine" as OUT OF SCOPE (skip the public-reply guard, allow cleanup) versus "my parent binding is genuinely missing/mismatched" (still refuse). A remote second mate cannot be bound to a public-reply promise under the same-machine design, so skipping the guard for a cross-machine parent is correct, not a safety loss.

Explicitly rejected: the narrow patch of "pass the captain-side parent path across" to the remote launch - the report explains this still fails, since that path doesn't exist on the remote filesystem. Went with the more fundamental durable-record fix instead.

Implementation:
- New durable record file .fm-secondmate-parent (gitignored, sibling of .fm-secondmate-home), written once at seed/provision time: route=local + parent_home=<abs path> for a local secondmate (bin/fm-home-seed.sh), or route=remote + parent_host=<ssh alias> (diagnostic only, never a resolvable path) for a remote secondmate (bin/fm-remote-home-seed.sh sends the SSH alias in the provisioning manifest; bin/fm-remote-home-provision.sh writes the record on the remote host). Full rollback/backup support mirrors the existing .fm-secondmate-home marker handling in both seed scripts.
- bin/fm-teardown.sh's marked-child gate reads this durable record. For route=remote, the delegated-parent resolution path is skipped entirely (out of scope); the only signal still checked is a token committed directly to this home's OWN .env FILE (never the process environment - deliberately avoids fm_pf_relay_active's environment-wins behavior, which would otherwise let an unrelated exported token in the remote host's own login shell masquerade as this home's binding). For route=local (or no durable record, i.e. a home seeded before this fix), the existing env-var-based resolution is preserved unchanged, except the durable parent_home now backs it up when the launch-time env var is absent, closing the fail-open where a restart that dropped the launch prefix made the guard silently treat a genuinely active parent relay as off.
- docs/remote-secondmates.md and docs/configuration.md get short pointers to the new durable record (one-owner rule: the full contract lives in the script comments/headers, not duplicated in prose).

Regression tests (colocated, tests/*.test.sh pattern, exercise the real cleanup path never source-text matching):
- tests/fm-remote-secondmate-parent-binding.test.sh (new): drives the REAL remote route (fm-remote-home-seed.sh -> SSH boundary -> Herdr fixture -> real fm-spawn.sh --secondmate) using the repo's own committed remote/herdr fixtures, then real bin/fm-teardown.sh cleanup. Asserts the durable record's exact content, and that cleanup now succeeds when only the remote code root's .env or an ambient exported FMX_PAIRING_TOKEN looked relay-active (previously refused), succeeds with no signal at all, and still refuses when the remote-provisioned home's own .env file genuinely carries a token (protection preserved).
- tests/fm-public-followup.test.sh (extended, 3 new tests): using REAL bin/fm-home-seed.sh seeding (not hand-crafted markers) for local secondmates - asserts the durable record's content; asserts a lost launch-time FM_PUBLIC_FOLLOWUP_PRIMARY_HOME env var is now recovered from the durable record and correctly refuses an actually-owed public-reply commitment (closing the fail-open); asserts a durable local record with a genuinely missing parent-side registration still refuses (protection preserved); asserts a resolved parent with nothing owed still allows cleanup (unaffected regression).

All existing tests pass unmodified (tests/fm-public-followup.test.sh full suite, tests/fm-remote-secondmate-lifecycle-e2e.test.sh, tests/fm-secondmate-lifecycle-e2e.test.sh, tests/fm-secondmate-safety.test.sh, tests/fm-secondmate-sync.test.sh, tests/fm-backlog-handoff.test.sh) and bin/fm-lint.sh is clean. Delivery: no-mistakes, yolo off, one PR held for the captain's explicit merge.

## What Changed

- Persist validated `.fm-secondmate-parent` records during local and remote seeding, with rollback and conflicting-binding safeguards.
- Resolve teardown guards from durable local bindings, while treating cross-machine parents as out of scope and preserving fail-closed behavior for invalid bindings or relay tokens in the secondmate home.
- Document the parent record and add end-to-end coverage for remote cleanup, local restart recovery, and safety regressions.

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>
</details>
<details>
<summary>✅ **Rebase** - passed</summary>
</details>
<details>
<summary>✅ **Review** - completed</summary>
</details>
<details>
<summary>✅ **Test** - passed</summary>
</details>
<details>
<summary>✅ **Document** - passed</summary>
</details>
<details>
<summary>🔧 **Lint** - 1 issue found → auto-fixed ✅</summary>
</details>
<details>
<summary>✅ **Push** - passed</summary>
</details>
