### PR TITLE
docs: route merge authority through AGENTS.md section 7

### DIFF
--- a/.agents/skills/stow/SKILL.md
+++ b/.agents/skills/stow/SKILL.md
@@ -56,7 +56,7 @@ Never describe the session as reset-safe while the memory total is over budget o
      In a secondmate home, route a newly discovered shared preference to the main firstmate through marked status or a document pointer instead of editing the inherited file.
    - Project-intrinsic knowledge never goes directly into a project's `AGENTS.md`.
      Route it through a normal ship task so a crewmate records it with `bin/fm-ensure-agents-md.sh` and the project's delivery path.
-   - Knowledge general to every Firstmate user belongs in this repo's shared tracked material through the normal branch, no-mistakes, PR, and captain-merge path.
+   - Knowledge general to every Firstmate user belongs in this repo's shared tracked material through the normal branch, no-mistakes, and PR path, landing under the configured merge authority owned by AGENTS.md section 7.
    - For task-scoped notes, inspect the item with `tasks-axi show <id> --full`, classify the change as new, duplicate, superseding, or obsolete, then use a considered replacement body through `tasks-axi update <id> --body-file <path>`.
      Use `--archive-body` when recoverability matters.
      Never append.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,7 +56,7 @@ See the [no-mistakes quick start](https://kunchenguid.github.io/no-mistakes/star
 
 ## Development
 
-Tracked changes to firstmate itself - `AGENTS.md`, `README.md`, `CONTRIBUTING.md`, `.tasks.toml`, `.github/workflows/`, `bin/`, `.agents/skills/`, and `skills/` - ship through the `no-mistakes` pipeline on a feature branch and require an explicit merge approval.
+Tracked changes to firstmate itself - `AGENTS.md`, `README.md`, `CONTRIBUTING.md`, `.tasks.toml`, `.github/workflows/`, `bin/`, `.agents/skills/`, and `skills/` - ship through the `no-mistakes` pipeline on a feature branch and land under the configured merge authority owned by [`AGENTS.md`](AGENTS.md) section 7, where standing `+yolo` can authorize routine green merges and yolo-off work awaits the captain.
 Before making any such change, load the agent-only `firstmate-coding-guidelines` skill (`.agents/skills/firstmate-coding-guidelines/SKILL.md`).
 It has the knowledge-placement rules that keep `AGENTS.md` from regrowing after each diet pass.
 There is no reliable way for `bin/fm-brief.sh`'s scaffold to detect that a task's repo is firstmate itself, so firstmate adds this skill's load line to firstmate-repo briefs by hand.


### PR DESCRIPTION
## Intent

The developer wanted Firstmate's tracked CONTRIBUTING.md brought in line with the merge-authority contract that AGENTS.md section 7 already owns, applying a one-owner documentation rule: AGENTS.md remains the sole authority and CONTRIBUTING.md gets only a concise cross-reference rather than a duplicated policy. Specifically, they asked that the single stale sentence requiring fresh explicit approval for every Firstmate PR be replaced with wording saying tracked changes still ship through the no-mistakes PR path and land under the configured merge authority, making clear via that pointer that standing +yolo authority can approve routine green merges while yolo-off work still waits for the captain, and that stronger boundaries (no red merges; destructive, irreversible, or security-sensitive actions needing concrete captain authority) stay enforced by the authoritative owner. Constraints: change nothing else — not AGENTS.md, scripts, workflows, tests, or other shared surfaces — unless a deterministic documentation check demanded a minimal directly related fix; one sentence per line, plain dashes, no chronology or private project context; bin/fm-doc-audience-check.sh and the applicable repository validation must pass. The work had to ship as a single no-mistakes PR that the agent must not merge itself, run without --yes, with any ask-user finding escalated rather than answered. When validation surfaced a separate pre-existing contradiction in .agents/skills/stow/SKILL.md describing a "captain-merge path," the developer directed the agent to read and execute a specific recorded document-decision file, processing every synchronous return and escalating only a genuinely new decision.

## What Changed

- `CONTRIBUTING.md` Development section no longer says tracked firstmate changes "require an explicit merge approval". It now states they ship through the `no-mistakes` pipeline on a feature branch and land under the configured merge authority owned by [`AGENTS.md`](AGENTS.md) section 7, with a one-clause gloss that standing `+yolo` can authorize routine green merges while yolo-off work awaits the captain.
- `.agents/skills/stow/SKILL.md` knowledge-routing bullet drops the stale "captain-merge path" wording; general Firstmate knowledge now routes through the normal branch, no-mistakes, and PR path, landing under the same `AGENTS.md` section 7 authority.
- Single-owner documentation shape: `AGENTS.md` keeps the full policy (including the never-merge-red and destructive/irreversible/security-sensitive boundaries) and both files carry pointers rather than duplicated rules. `bin/fm-doc-audience-check.sh` passes (64 surfaces, 195 local links) and the new cross-reference was confirmed machine-validated via a negative control on a throwaway copy.

## Risk Assessment

✅ Low: Two documentation lines are replaced with wording that now matches the authoritative merge-authority contract in AGENTS.md section 1 line 44 and section 7 lines 294-305, the added local link resolves, and no code, script, workflow, or inventory surface changed.

## Testing

I exercised the repository's own deterministic documentation gate (`bin/fm-doc-audience-check.sh`, 64 surfaces / 195 local links, passing) plus the two focused test scripts that own documentation structure and the ask-user authority contract, then added a negative control that deliberately broke the new CONTRIBUTING.md cross-reference on a throwaway copy and confirmed the checker catches it - so the pointer is machine-guarded, not just prose. Because this is a docs change whose end user reads rendered markdown, I rendered CONTRIBUTING.md, AGENTS.md, and the stow skill with pandoc, drove them in Chrome, and captured screenshots including an actual click on the new AGENTS.md link, which lands on section 7 where the standing-yolo, yolo-off captain, never-merge-red, and destructive-action boundaries are all stated - demonstrating the one-owner documentation rule working end to end. I also confirmed no stale "captain-merge path" or "explicit merge approval" wording survives anywhere, the added lines are plain ASCII one-sentence-per-line, and `+yolo` is real registry syntax; everything passed and the worktree was left clean.

- Evidence: Rendered CONTRIBUTING.md Development section - new merge-authority sentence highlighted, AGENTS.md rendered as a live link (local file: <code>/var/folders/yj/d8t5bhcx7231xwzv1347p3t40000gn/T/no-mistakes-evidence/01KZ83QFJCM74GHJCE5E759GXC/01-contributing-development.png</code>)
- Evidence: AGENTS.md section 7 reached by clicking the new CONTRIBUTING.md link - yolo-off captain merges, yolo-on green-only merges, never merge a red PR, and destructive/irreversible/security-sensitive captain boundaries all highlighted (local file: <code>/var/folders/yj/d8t5bhcx7231xwzv1347p3t40000gn/T/no-mistakes-evidence/01KZ83QFJCM74GHJCE5E759GXC/02-agents-section7-authority.png</code>)
- Evidence: Rendered .agents/skills/stow/SKILL.md knowledge-routing bullet - now lands under the configured merge authority instead of the contradicting captain-merge path (local file: <code>/var/folders/yj/d8t5bhcx7231xwzv1347p3t40000gn/T/no-mistakes-evidence/01KZ83QFJCM74GHJCE5E759GXC/03-stow-skill-knowledge-routing.png</code>)
<details>
<summary>Evidence: Link-validation transcript: passing doc-audience check, negative control catching a broken cross-reference, and focused test results</summary>

<code>$ bin/fm-doc-audience-check.sh&#10;fm-doc-audience-check: ok surfaces=64 local_links=195&#10;EXIT=0&#10;&#10;# negative control on a scratch copy: repoint the new cross-reference at a missing file&#10;$ bin/fm-doc-audience-check.sh --root &lt;scratch&gt;&#10;fm-doc-audience-check: unresolved local link in CONTRIBUTING.md: AGENTS-MOVED.md&#10;EXIT=1&#10;&#10;$ bin/fm-test-run.sh tests/fm-documentation-audiences.test.sh tests/fm-ask-user-authority.test.sh&#10;ok - documentation inventory classifies every maintained prose surface exactly once&#10;ok - classification, setup routing, and maintained-prose scope fail safely&#10;ok - required documentation owner pointers cannot silently disappear&#10;ok - local links resolve while dates, versions, commands, and incident prose remain semantically reviewed&#10;ok - primary workers and secondmates receive the authority rule through generated instructions&#10;FM_TEST_SUMMARY total=2 failed=0 skipped_gate=0 duration_ms=1814</code>

```text
$ bin/fm-doc-audience-check.sh
fm-doc-audience-check: ok surfaces=64 local_links=195
EXIT=0

# negative control on a scratch copy: repoint the new CONTRIBUTING.md cross-reference
# at a non-existent file to prove the pointer is machine-validated, not just prose.
$ sed -i '' 's|[`AGENTS.md`](AGENTS.md) section 7|[`AGENTS.md`](AGENTS-MOVED.md) section 7|' CONTRIBUTING.md
$ bin/fm-doc-audience-check.sh --root <scratch>
fm-doc-audience-check: unresolved local link in CONTRIBUTING.md: AGENTS-MOVED.md
EXIT=1

$ bin/fm-test-run.sh tests/fm-documentation-audiences.test.sh tests/fm-ask-user-authority.test.sh
ok - documentation inventory classifies every maintained prose surface exactly once
ok - classification, setup routing, and maintained-prose scope fail safely
ok - required documentation owner pointers cannot silently disappear
ok - local links resolve while dates, versions, commands, and incident prose remain semantically reviewed
ok - primary workers and secondmates receive the authority rule through generated instructions
FM_TEST_SUMMARY total=2 failed=0 skipped_gate=0 duration_ms=1814
```
</details>
<details>
<summary>Evidence: Reviewer-openable rendered CONTRIBUTING.md (click the AGENTS.md link to reach the sibling AGENTS.html)</summary>

```text
<!DOCTYPE html>
<html xmlns="http://www.w3.org/1999/xhtml" lang="" xml:lang="">
<head>
  <meta charset="utf-8" />
  <meta name="generator" content="pandoc" />
  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes" />
  <title>CONTRIBUTING.md</title>
  <style>
    /* Default styles provided by pandoc.
    ** See https://pandoc.org/MANUAL.html#variables-for-html for config info.
    */
    code{white-space: pre-wrap;}
    span.smallcaps{font-variant: small-caps;}
    div.columns{display: flex; gap: min(4vw, 1.5em);}
    div.column{flex: auto; overflow-x: auto;}
    div.hanging-indent{margin-left: 1.5em; text-indent: -1.5em;}
    /* The extra [class] is a hack that increases specificity enough to
       override a similar rule in reveal.js */
    ul.task-list[class]{list-style: none;}
    ul.task-list li input[type="checkbox"] {
      font-size: inherit;
      width: 0.8em;
      margin: 0 0.8em 0.2em -1.6em;
      vertical-align: middle;
    }
    .display.math{display: block; text-align: center; margin: 0.5rem auto;}
    /* CSS for syntax highlighting */
    html { -webkit-text-size-adjust: 100%; }
    pre > code.sourceCode { white-space: pre; position: relative; }
    pre > code.sourceCode > span { display: inline-block; line-height: 1.25; }
    pre > code.sourceCode > span:empty { height: 1.2em; }
    .sourceCode { overflow: visible; }
    code.sourceCode > span { color: inherit; text-decoration: inherit; }
    div.sourceCode { margin: 1em 0; }
    pre.sourceCode { margin: 0; }
    @media screen {
    div.sourceCode { overflow: auto; }
    }
    @media print {
    pre > code.sourceCode { white-space: pre-wrap; }
    pre > code.sourceCode > span { text-indent: -5em; padding-left: 5em; }
    }
    pre.numberSource code
      { counter-reset: source-line 0; }
    pre.numberSource code > span
      { position: relative; left: -4em; counter-increment: source-line; }
    pre.numberSource code > span > a:first-child::before
      { content: counter(source-line);
        position: relative; left: -1em; text-align: right; vertical-align: baseline;
        border: none; display: inline-block;
        -webkit-touch-callout: none; -webkit-user-select: none;
        -khtml-user-select: none; -moz-user-select: none;
        -ms-user-select: none; user-select: none;
        padding: 0 4px; width: 4em;
        color: #aaaaaa;
      }
    pre.numberSource { margin-left: 3em; border-left: 1px solid #aaaaaa;  padding-left: 4px; }
    div.sourceCode
      {   }
    @media screen {
    pre > code.sourceCode > span > a:first-child::before { text-decoration: underline; }
    }
    code span.al { color: #ff0000; font-weight: bold; } /* Alert */
    code span.an { color: #60a0b0; font-weight: bold; font-style: italic; } /* Annotation */
    code span.at { color: #7d9029; } /* Attribute */
    code span.bn { color: #40a070; } /* BaseN */
    code span.bu { color: #008000; } /* BuiltIn */
    code span.cf { color: #007020; font-weight: bold; } /* ControlFlow */
    code span.ch { color: #4070a0; } /* Char */
    code span.cn { color: #880000; } /* Constant */
    code span.co { color: #60a0b0; font-style: italic; } /* Comment */
    code span.cv { color: #60a0b0; font-weight: bold; font-style: italic; } /* CommentVar */
    code span.do { color: #ba2121; font-style: italic; } /* Documentation */
    code span.dt { color: #902000; } /* DataType */
    code span.dv { color: #40a070; } /* DecVal */
    code span.er { color: #ff0000; font-weight: bold; } /* Error */
    code span.ex { } /* Extension */
    code span.fl { color: #40a070; } /* Float */
    code span.fu { color: #06287e; } /* Function */
    code span.im { color: #008000; font-weight: bold; } /* Import */
    code span.in { color: #60a0b0; font-weight: bold; font-style: italic; } /* Information */
    code span.kw { color: #007020; font-weight: bold; } /* Keyword */
    code span.op { color: #666666; } /* Operator */
    code span.ot { color: #007020; } /* Other */
    code span.pp { color: #bc7a00; } /* Preprocessor */
    code span.sc { color: #4070a0; } /* SpecialChar */
    code span.ss { color: #bb6688; } /* SpecialString */
    code span.st { color: #4070a0; } /* String */
    code span.va { color: #19177c; } /* Variable */
    code span.vs { color: #4070a0; } /* VerbatimString */
    code span.wa { color: #60a0b0; font-weight: bold; font-style: italic; } /* Warning */
  </style>
  <link rel="stylesheet" href="gh.css" />
</head>
<body>
<header id="title-block-header">
<h1 class="title">CONTRIBUTING.md</h1>
</header>
<h1 id="contributing">Contributing</h1>
<p>Thanks for wanting to contribute. One rule up front:</p>
<p><strong>Human-authored pull requests targeting <code>main</code> must
be raised through <a
href="https://github.com/kunchenguid/no-mistakes"><code>no-mistakes</code></a>.</strong>
We require this to reduce the maintainer's burden of reviewing and
merging contributions.</p>
<p><code>no-mistakes</code> puts a local git proxy in front of your real
remote. Pushing through it runs an AI-driven review/test/lint pipeline
in an isolated worktree, forwards the push upstream only after every
check passes, and opens a clean PR automatically.</p>
<p>A GitHub Actions check (<code>Require no-mistakes</code>) runs on PRs
targeting <code>main</code> and fails if the body is missing the
deterministic signature that no-mistakes writes. It evaluates every PR
opening and body edit independently, so a later edit cannot replace an
earlier pending compliance check. GitHub Actions and Dependabot are
exempt so their automation keeps working, but regular contributor PRs
without the signature will not be reviewed or merged.</p>
<h2 id="workflow">Workflow</h2>
<ol type="1">
<li><p>Fork the repo, then clone the parent repo or set your local
<code>origin</code> back to the parent
(<code>git@github.com:kunchenguid/firstmate.git</code>).</p></li>
<li><p>Create a branch and make your changes.</p></li>
<li><p>Initialize the gate with your fork as the push target:
<code>no-mistakes init --fork-url git@github.com:&lt;you&gt;/firstmate.git</code>
(firstmate expects <strong>no-mistakes v1.31.2+</strong>; without a
fork, plain <code>no-mistakes init</code> still works for maintainers
with push access).</p></li>
<li><p>Commit your changes.</p></li>
<li><p>Push through the gate instead of pushing to
<code>origin</code>:</p>
<div class="sourceCode" id="cb1"><pre
class="sourceCode sh"><code class="sourceCode bash"><span id="cb1-1"><a href="#cb1-1" aria-hidden="true" tabindex="-1"></a><span class="fu">git</span> push no-mistakes</span></code></pre></div></li>
<li><p>Run <code>no-mistakes</code> to attach to the pipeline, watch
findings, authorize auto-fixes, and review ask-user findings as needed.
Follow the installed no-mistakes version's SKILL.md and live
<code>axi</code> help for gate mechanics.</p></li>
<li><p>Once the pipeline passes, it pushes the branch to your fork and
opens the PR against the parent repo for you.</p></li>
</ol>
<p>See the <a
href="https://kunchenguid.github.io/no-mistakes/start-here/quick-start/">no-mistakes
quick start</a> for the full first-run walkthrough.</p>
<h2 id="repo-conventions">Repo conventions</h2>
<ul>
<li>This repo is a template for running a firstmate orchestrator agent.
<code>AGENTS.md</code> is the agent's main job description and names
when to load bundled firstmate skills; <code>CLAUDE.md</code> is a
symlink to it, and <code>.claude/skills</code> is a symlink to
<code>.agents/skills</code>.</li>
<li>Only shared material is tracked: <code>AGENTS.md</code>,
<code>README.md</code>, <code>CONTRIBUTING.md</code>,
<code>.tasks.toml</code>, <code>.github/workflows/</code>,
<code>bin/</code>, <code>.agents/skills/</code>, and
<code>skills/</code>. <code>.agents/skills/</code> holds agent-loaded
skills that assume a live firstmate home and carry
<code>metadata.internal: true</code> so installers such as <a
href="https://skills.sh">skills.sh</a> hide them from discovery;
<code>skills/</code> holds standalone, installer-facing public skills
with no firstmate dependency (see the README's "Two-tier skill layout").
Everything personal to one captain's fleet (<c

... [5315 bytes truncated] ...

s platform-specific compatibility lanes.
That is firstmate-specific; do not commit
<code>.no-mistakes/evidence/</code> here even when another
no-mistakes-managed target project keeps committed PR evidence.</p>
<p>Check and test the toolbelt before pushing:</p>
<div class="sourceCode" id="cb2"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb2-1"><a href="#cb2-1" aria-hidden="true" tabindex="-1"></a><span class="cf">while</span> <span class="va">IFS</span><span class="op">=</span> <span class="bu">read</span> <span class="at">-r</span> <span class="va">script</span><span class="kw">;</span> <span class="cf">do</span> <span class="ex">/bin/bash</span> <span class="at">-n</span> <span class="st">&quot;</span><span class="va">$script</span><span class="st">&quot;</span> <span class="kw">||</span> <span class="bu">exit</span><span class="kw">;</span> <span class="cf">done</span> <span class="op">&lt;</span> <span class="op">&lt;(</span><span class="ex">bin/fm-lint.sh</span> <span class="at">--list-files</span><span class="op">)</span>   <span class="co"># syntax-check the canonical shell surface</span></span>
<span id="cb2-2"><a href="#cb2-2" aria-hidden="true" tabindex="-1"></a><span class="ex">bin/fm-lint.sh</span>   <span class="co"># lint the toolbelt and behavior tests; the single owner CI and the no-mistakes gate both run</span></span>
<span id="cb2-3"><a href="#cb2-3" aria-hidden="true" tabindex="-1"></a><span class="ex">bin/fm-test-run.sh</span> tests/<span class="op">&lt;</span>subject<span class="op">&gt;</span>.test.sh   <span class="co"># one script (primary local focus path, timed)</span></span>
<span id="cb2-4"><a href="#cb2-4" aria-hidden="true" tabindex="-1"></a><span class="ex">bin/fm-test-run.sh</span> <span class="at">--family</span> pure-contract-unit   <span class="co"># ordinary family-scoped local path (serial, timed)</span></span>
<span id="cb2-5"><a href="#cb2-5" aria-hidden="true" tabindex="-1"></a><span class="ex">bin/fm-test-run.sh</span> <span class="at">--changed</span>   <span class="co"># conservative changed-file-informed set (never silent full suite)</span></span>
<span id="cb2-6"><a href="#cb2-6" aria-hidden="true" tabindex="-1"></a><span class="ex">bin/fm-test-run.sh</span> <span class="at">--proven-isolated</span> <span class="at">--jobs</span> 4   <span class="co"># explicit local parallel of the proven set only (default is serial)</span></span>
<span id="cb2-7"><a href="#cb2-7" aria-hidden="true" tabindex="-1"></a><span class="ex">bin/fm-test-run.sh</span> <span class="at">--lane</span> portable-serial   <span class="co"># portable serial remainder (watcher/AFK/tmux/stateful)</span></span>
<span id="cb2-8"><a href="#cb2-8" aria-hidden="true" tabindex="-1"></a><span class="ex">bin/fm-test-run.sh</span> <span class="at">--list-lanes</span>   <span class="co"># discover exact lane names, including the current CI serial shards</span></span>
<span id="cb2-9"><a href="#cb2-9" aria-hidden="true" tabindex="-1"></a><span class="ex">bin/fm-test-run.sh</span> <span class="at">--check-coverage</span>   <span class="co"># prove portable shards + serial + serial shards + Herdr equal the full inventory</span></span>
<span id="cb2-10"><a href="#cb2-10" aria-hidden="true" tabindex="-1"></a><span class="ex">bin/fm-test-run.sh</span> <span class="at">--all</span>   <span class="co"># deliberate complete regression (optional local full walk; not no-mistakes Test)</span></span>
<span id="cb2-11"><a href="#cb2-11" aria-hidden="true" tabindex="-1"></a><span class="ex">bin/fm-test-isolation-proof.sh</span> <span class="at">--list</span>   <span class="co"># proven parallel candidate set (Phase 2 owner)</span></span>
<span id="cb2-12"><a href="#cb2-12" aria-hidden="true" tabindex="-1"></a><span class="ex">bin/fm-test-isolation-proof.sh</span> <span class="at">--jobs</span> 4 <span class="at">--json</span> /tmp/fm-isolation-proof.json   <span class="co"># re-run concurrent isolation proof only</span></span>
<span id="cb2-13"><a href="#cb2-13" aria-hidden="true" tabindex="-1"></a><span class="bu">[</span> <span class="st">&quot;</span><span class="va">$(</span><span class="fu">readlink</span> CLAUDE.md<span class="va">)</span><span class="st">&quot;</span> <span class="ot">=</span> <span class="st">&quot;AGENTS.md&quot;</span> <span class="bu">]</span></span>
<span id="cb2-14"><a href="#cb2-14" aria-hidden="true" tabindex="-1"></a><span class="bu">[</span> <span class="st">&quot;</span><span class="va">$(</span><span class="fu">readlink</span> .claude/skills<span class="va">)</span><span class="st">&quot;</span> <span class="ot">=</span> <span class="st">&quot;../.agents/skills&quot;</span> <span class="bu">]</span></span>
<span id="cb2-15"><a href="#cb2-15" aria-hidden="true" tabindex="-1"></a><span class="va">tmp</span><span class="op">=</span><span class="va">$(</span><span class="fu">mktemp</span> <span class="at">-d</span><span class="va">)</span> <span class="kw">&amp;&amp;</span> <span class="bu">printf</span> <span class="st">&#39;done: smoke\n&#39;</span> <span class="op">&gt;</span> <span class="st">&quot;</span><span class="va">$tmp</span><span class="st">/smoke.status&quot;</span> <span class="kw">&amp;&amp;</span> <span class="va">FM_STATE_OVERRIDE</span><span class="op">=</span><span class="st">&quot;</span><span class="va">$tmp</span><span class="st">&quot;</span> <span class="va">FM_SIGNAL_GRACE</span><span class="op">=</span>1 <span class="va">FM_POLL</span><span class="op">=</span>1 <span class="va">FM_HEARTBEAT</span><span class="op">=</span>999999 <span class="ex">bin/fm-watch-arm.sh</span>  <span class="co"># watcher re-arm smoke test (prints arm status, then an actionable signal)</span></span></code></pre></div>
<p><code>bin/fm-test-run.sh</code> is the single owner of behavior-suite
selection, portable CI lane composition, optional local
<code>--jobs</code> for the proven-isolated set only, per-script timing
markers, family totals, the coverage guard, and the optional JSON timing
artifact. Its header and <code>--help</code> own the flags, family
labels, lanes, and changed-file map; this section only documents the
entry points. <code>bin/fm-test-isolation-proof.sh</code> remains the
single owner of the Phase 2 concurrent isolation proof and the exact
proven candidate set; see <code>docs/fm-test-isolation-proof.md</code>.
Portable shard balance evidence lives in
<code>docs/fm-test-portable-shards.md</code>. Local no-mistakes Test
stays intent-targeted and must not wire <code>commands.test</code> to
<code>--all</code> or a <code>tests/*.test.sh</code> walk. Family
selection is the ordinary local path; <code>--all</code> is deliberate
full regression only. CI owns broad regression across required portable
parallel shards, the portable serial lane's separate-runner shards, the
Herdr lane, lint, invariants, the coverage guard, and stock macOS Bash
compatibility in <a
href=".github/workflows/ci.yml"><code>.github/workflows/ci.yml</code></a>.
Use <code>bin/fm-test-run.sh --list-lanes</code> for exact lane names
and <code>--help</code> for <code>--jobs</code> rules and required
gate-skip flags when reproducing a lane locally. Discover tests by
listing <code>tests/*.test.sh</code>: each is a self-contained bash
script named <code>&lt;subject&gt;.test.sh</code>, and its header
comment describes what it covers, so pass one to
<code>bin/fm-test-run.sh</code> to focus on a subject with canonical
timing output. Tests that need a real optional backend or an explicit
opt-in (real herdr/zellij/cmux smoke tests, the live Pi regression) skip
themselves and print the tool or environment gate needed to enable them,
so the portable suite remains safe on machines without those tools. The
<a href="docs/herdr-backend.md#destructive-lab-safety">Herdr backend
guide</a> owns the lane's isolation boundary, while <a
href="docs/verification/runtime-backends.md#herdr">runtime backend
verification</a> owns active empirical evidence; live harness credential
tests remain opt-in.</p>
<h2 id="questions">Questions</h2>
<p>Open an issue, or talk to me on <a
href="https://discord.gg/Wsy2NpnZDu">Discord</a>.</p>
</body>
</html>
```
</details>
- Evidence: Reviewer-openable rendered AGENTS.md (merge-authority owner, section 7) (local file: <code>/var/folders/yj/d8t5bhcx7231xwzv1347p3t40000gn/T/no-mistakes-evidence/01KZ83QFJCM74GHJCE5E759GXC/AGENTS.html</code>)
<details>
<summary>Evidence: Reviewer-openable rendered .agents/skills/stow/SKILL.md</summary>

```text
<!DOCTYPE html>
<html xmlns="http://www.w3.org/1999/xhtml" lang="" xml:lang="">
<head>
  <meta charset="utf-8" />
  <meta name="generator" content="pandoc" />
  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes" />
  <meta name="description" content="Sweep the current session for uncaptured durable knowledge and file it to disk before a context reset. Use when the captain invokes /stow (e.g. &quot;/stow&quot;, &quot;stow what you've learned&quot;), before a session reset or context compaction, or periodically to keep operational memory current." />
  <title>.agents/skills/stow/SKILL.md</title>
  <style>
    /* Default styles provided by pandoc.
    ** See https://pandoc.org/MANUAL.html#variables-for-html for config info.
    */
    code{white-space: pre-wrap;}
    span.smallcaps{font-variant: small-caps;}
    div.columns{display: flex; gap: min(4vw, 1.5em);}
    div.column{flex: auto; overflow-x: auto;}
    div.hanging-indent{margin-left: 1.5em; text-indent: -1.5em;}
    /* The extra [class] is a hack that increases specificity enough to
       override a similar rule in reveal.js */
    ul.task-list[class]{list-style: none;}
    ul.task-list li input[type="checkbox"] {
      font-size: inherit;
      width: 0.8em;
      margin: 0 0.8em 0.2em -1.6em;
      vertical-align: middle;
    }
    .display.math{display: block; text-align: center; margin: 0.5rem auto;}
  </style>
  <link rel="stylesheet" href="gh.css" />
</head>
<body>
<header id="title-block-header">
<h1 class="title">.agents/skills/stow/SKILL.md</h1>
</header>
<!-- maintainers: this is the firstmate-internal skill. The public, installer-facing counterpart lives at skills/stow/SKILL.md - deliberately a separate file with no shared code or environment branching. Keep them independent. -->

<h1 id="stow">stow</h1>
<p>Sweep this session for durable knowledge that exists only in
conversation, then leave the next session with a compact current
operating map rather than an accumulating journal. This skill writes
only through the existing Firstmate ownership and write boundaries.</p>
<h2 id="required-startup-memory-pass">Required startup-memory pass</h2>
<p>Every <code>/stow</code> invocation performs this complete pass, even
when the session contains no new finding:</p>
<ol type="1">
<li>Run <code>bin/fm-startup-memory-budget.sh report</code> before
considering a write. Record its effective budget and each file's
estimated-token total. The helper's stable estimate is the documented
conservative local approximation, not provider-exact accounting. If it
rejects the setting or a memory file, do not infer a default or silently
continue. Report that concrete exception and do not call the session
reset-safe.</li>
<li>Read every current memory file completely:
<code>data/captain.md</code>, <code>data/captain-shared.md</code>, and
<code>data/learnings.md</code>. Treat an absent local file as absent,
not as an invitation to manufacture content. In a primary home, all
three are curation inputs under their existing ownership rules. In a
secondmate home, <code>data/captain-shared.md</code> is a read-only
primary-owned input: count it, never edit it, and curate only the
editable local files.</li>
<li>Build one whole-file retention plan before editing. Retain, in
order: current captain preferences, authority and safety boundaries, and
recurring working style; stable home-local operating facts that
repeatedly affect future work and are expensive to rediscover; then
concise pointers to an existing authoritative report, project document,
configuration, or backlog item. Retain lower-priority material only
while budget remains.</li>
<li>Consolidate every editable memory file as needed, not only the file
apparently related to a new finding. Prefer one concise current rule or
authoritative pointer over duplicate prose. Remove, merge, or route
completed incident and release chronology, stale versions and paths,
transient task state, resolved alternatives, old metrics, superseded
claims, duplicates, and report-sized procedures. Do not remove a unique
current fact unless it is preserved directly elsewhere through a
stronger existing owner.</li>
<li>Run <code>bin/fm-startup-memory-budget.sh report</code> again after
the complete pass. Finish at or below the effective budget unless a
concrete inability remains. A secondmate must explicitly report
<code>primary-owned-shared-file-alone-exceeds-budget</code> when the
inherited shared file alone exceeds its allowance, because local
curation cannot resolve it. Any other unresolved excess must identify
the fact that cannot safely be removed or routed and why.</li>
</ol>
<p>A net increase is allowed only for a genuinely new current fact with
no stronger owner. Before allowing it, consolidate enough lower-priority
material to remain within budget. Never describe the session as
reset-safe while the memory total is over budget or an exception is
unresolved.</p>
<h2 id="knowledge-sweep-and-routing">Knowledge sweep and routing</h2>
<ol type="1">
<li><strong>Sweep the session for uncaptured durable knowledge.</strong>
Look for operational learnings, captain preferences expressed in
passing, project-intrinsic facts, standing decisions, and undone next
steps.</li>
<li><strong>Route each finding using AGENTS.md's knowledge-routing
table.</strong> AGENTS.md section 6 is the source of truth for
destinations. Do not re-derive or duplicate that mapping here.</li>
<li><strong>Write within the existing boundaries.</strong>
<ul>
<li>Captain preferences and fleet-local operational facts belong in the
destination selected by AGENTS.md after the required whole-file curation
pass. Create <code>data/learnings.md</code> only for a genuinely new
local learning with no stronger owner.</li>
<li>In a primary home, curate shared captain preferences only under the
existing primary-authoritative shared-preference contract. In a
secondmate home, route a newly discovered shared preference to the main
firstmate through marked status or a document pointer instead of editing
the inherited file.</li>
<li>Project-intrinsic knowledge never goes directly into a project's
<code>AGENTS.md</code>. Route it through a normal ship task so a
crewmate records it with <code>bin/fm-ensure-agents-md.sh</code> and the
project's delivery path.</li>
<li>Knowledge general to every Firstmate user belongs in this repo's
shared tracked material through the normal branch, no-mistakes, and PR
path, landing under the configured merge authority owned by AGENTS.md
section 7.</li>
<li>For task-scoped notes, inspect the item with
<code>tasks-axi show &lt;id&gt; --full</code>, classify the change as
new, duplicate, superseding, or obsolete, then use a considered
replacement body through
<code>tasks-axi update &lt;id&gt; --body-file &lt;path&gt;</code>. Use
<code>--archive-body</code> when recoverability matters. Never
append.</li>
<li>File each undone next step as a queued backlog item with a genuine
<code>blocked-by</code> dependency when applicable.</li>
</ul></li>
<li><strong>Use inspect-then-update.</strong> For every retained fact,
ask which current statement it supersedes, whether it can be a
one-sentence rewrite, and whether a stale entry should be deleted,
retired, or routed to an existing stronger owner. The only graduation
moves are promotion to tracked shared material through a PR, folding a
learning into the captain-preference destination selected by AGENTS.md,
or deletion of a stale entry. Do not invent another graduation
path.</li>
</ol>
<h2 id="completion-receipt">Completion receipt</h2>
<p>Report the outcome in plain captain-facing language with all of these
facts:</p>
<ul>
<li>effective startup-memory budget and total estimated tokens before
and after;</li>
<li>one or more actions for each of <code>data/captain.md</code>,
<code>data/captain-shared.md</code>, and <code>data/learnings.md</code>:
<code>unchanged</code>, <code>added</code>, <code>rewritten</code>,
<code>pruned</code>, or <code>routed</code>;</li>
<li>each durable finding filed outside memory and its authoritative
owner;</li>
<li>every unresolved exception, including a primary-owned shared-file
constraint in a secondmate home;</li>
<li>whether the session is safe to reset, only when all durable findings
are captured and the post-pass result is within budget with no
exception.</li>
</ul>
<p>Do not hide an over-budget result behind a reset-safe claim.</p>
<h2 id="scope-exclusion-no-skill-storage">Scope exclusion: no skill
storage</h2>
<p><code>/stow</code> must never store, create, or edit a skill as a
destination for any finding. There is no "graduate this to a skill" move
in this skill's routing. Until a human deliberately scopes a skill
change as Firstmate repository work, route generalizable knowledge to
shared tracked material through its pipeline and fleet-local knowledge
to <code>data/</code>, never to <code>.agents/skills/</code> or public
<code>skills/</code>.</p>
</body>
</html>
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bin/fm-doc-audience-check.sh` (the check CONTRIBUTING.md requires after documentation changes) - ok surfaces=64 local_links=195, exit 0</code>
- <code>Negative control: on a throwaway `git archive` copy, repointed the new `[`AGENTS.md`](AGENTS.md)` cross-reference at a non-existent file and re-ran `bin/fm-doc-audience-check.sh --root &lt;scratch&gt;` - failed with `unresolved local link in CONTRIBUTING.md: AGENTS-MOVED.md`, exit 1, proving the pointer is machine-validated; scratch copy deleted</code>
- <code>`bin/fm-test-run.sh tests/fm-documentation-audiences.test.sh tests/fm-ask-user-authority.test.sh` - 2 scripts, 5 assertions, 0 failures</code>
- <code>`bin/fm-test-run.sh --list --changed --base 71f0b3f` - inspected the conservative 28-script selection and narrowed to the two doc/authority-relevant scripts rather than running the over-selected set</code>
- <code>Manual visual verification: rendered `CONTRIBUTING.md`, `AGENTS.md`, and `.agents/skills/stow/SKILL.md` with `pandoc --from=gfm` and drove them in Chrome via `chrome-devtools-axi`, screenshotting the Development section, the stow knowledge-routing bullet, and AGENTS.md section 7</code>
- <code>Click-through verification: clicked the new `AGENTS.md` link in the rendered CONTRIBUTING.md Development section and confirmed it lands on AGENTS.md section 7, which states yolo-off gives the captain PR merges, yolo-on merges only green work, `Never merge a red PR`, and destructive/irreversible/security-sensitive choices remain captain boundaries</code>
- <code>`grep -rn &#34;captain-merge|explicit merge approval|require an explicit merge&#34;` across tracked md/sh/json/yaml - 0 hits, confirming no stale merge-approval wording survives</code>
- <code>Checked the added lines are plain ASCII with plain hyphens and one sentence per line, and that `+yolo` is real repo syntax (`README.md:48`, `bin/fm-project-mode.sh`)</code>
- <code>`git status --porcelain` - clean worktree after testing; scratch clone and temp screenshots removed</code>

</details>

<details>
<summary>⚠️ **Document** - 1 info</summary>

- ℹ️ `CONTRIBUTING.md:59` - Placement judgment, no action required. The new sentence pairs the pointer to AGENTS.md section 7 with a one-clause gloss of the authority split (&#34;standing `+yolo` can authorize routine green merges and yolo-off work awaits the captain&#34;). Under the strict one-owner rule this clause is a compressed second copy of a fact AGENTS.md:299-300 owns, so it can drift if that rule changes. I kept it rather than reducing the line to a bare pointer: it is short, explicitly attributed to the owner, verified accurate against AGENTS.md:299-300, and gives a maintainer-architecture reader enough orientation to know whether their change needs the captain before they open the owner document. The stronger boundaries (AGENTS.md:301 destructive/irreversible/security-sensitive, AGENTS.md:304 never merge a red PR) are deliberately not glossed and remain owner-only.

</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 127)

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
