### PR TITLE
fix(bin): pretty-print claude settings.local.json written by fm-spawn

### DIFF
--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1818,6 +1818,13 @@ if [ "$KIND" != secondmate ]; then
       j_stop=$(json_escape "touch $(shell_quote "$TURNEND"); $busy_cmd_prefix idle $busy_suffix --event stop 2>/dev/null || true")
       j_stopfail=$(json_escape "$busy_cmd_prefix idle $busy_suffix --event stop-failure 2>/dev/null || true")
       j_sessionend=$(json_escape "$busy_cmd_prefix idle $busy_suffix --event session-end 2>/dev/null || true")
+      # Pretty-printed, 2-space indent on purpose: downstream repos run biome
+      # repo-wide in their pre-push gate and reject minified JSON. Verified:
+      # projects/nice/biome.json sets formatter.indentStyle="space" with
+      # indentWidth 2, and projects/juicy carries no biome config at all, so
+      # 2-space matches the only downstream repo that gates on this file's
+      # formatting. Do not switch to tabs (biome's own default) - that would
+      # break Nice's format check. Settled; do not re-litigate.
       cat > "$WT/.claude/settings.local.json" <<EOF
 {
   "hooks": {

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1819,7 +1819,50 @@ if [ "$KIND" != secondmate ]; then
       j_stopfail=$(json_escape "$busy_cmd_prefix idle $busy_suffix --event stop-failure 2>/dev/null || true")
       j_sessionend=$(json_escape "$busy_cmd_prefix idle $busy_suffix --event session-end 2>/dev/null || true")
       cat > "$WT/.claude/settings.local.json" <<EOF
-{"hooks":{"UserPromptSubmit":[{"hooks":[{"type":"command","command":"$j_submit"}]}],"Stop":[{"hooks":[{"type":"command","command":"$j_stop"}]}],"StopFailure":[{"hooks":[{"type":"command","command":"$j_stopfail"}]}],"SessionEnd":[{"hooks":[{"type":"command","command":"$j_sessionend"}]}]}}
+{
+  "hooks": {
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$j_submit"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$j_stop"
+          }
+        ]
+      }
+    ],
+    "StopFailure": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$j_stopfail"
+          }
+        ]
+      }
+    ],
+    "SessionEnd": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$j_sessionend"
+          }
+        ]
+      }
+    ]
+  }
+}
 EOF
       exclude_path '.claude/settings.local.json'
       ;;

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1818,13 +1818,11 @@ if [ "$KIND" != secondmate ]; then
       j_stop=$(json_escape "touch $(shell_quote "$TURNEND"); $busy_cmd_prefix idle $busy_suffix --event stop 2>/dev/null || true")
       j_stopfail=$(json_escape "$busy_cmd_prefix idle $busy_suffix --event stop-failure 2>/dev/null || true")
       j_sessionend=$(json_escape "$busy_cmd_prefix idle $busy_suffix --event session-end 2>/dev/null || true")
-      # Pretty-printed, 2-space indent on purpose: downstream repos run biome
-      # repo-wide in their pre-push gate and reject minified JSON. Verified:
-      # projects/nice/biome.json sets formatter.indentStyle="space" with
-      # indentWidth 2, and projects/juicy carries no biome config at all, so
-      # 2-space matches the only downstream repo that gates on this file's
-      # formatting. Do not switch to tabs (biome's own default) - that would
-      # break Nice's format check. Settled; do not re-litigate.
+      # Pretty-printed with a 2-space indent on purpose: downstream project
+      # repos run biome repo-wide in their pre-push gate, and biome rejects
+      # this file when it is minified. Those repos configure space indentation
+      # at width 2, so do not switch to tabs even though tabs are biome's own
+      # default. Guarded by tests/fm-busy-adapter-wiring.test.sh.
       cat > "$WT/.claude/settings.local.json" <<EOF
 {
   "hooks": {

--- a/tests/fm-busy-adapter-wiring.test.sh
+++ b/tests/fm-busy-adapter-wiring.test.sh
@@ -268,6 +268,11 @@ test_claude_hooks_semantic_lifecycle() {
   jq -e . "$settings" >/dev/null || fail "claude hook settings are not valid JSON"
   [ "$(wc -l <"$settings")" -gt 1 ] \
     || fail "claude hook settings must be pretty-printed multi-line JSON, not minified to one line"
+  if grep -q $'\t' "$settings"; then
+    fail "claude hook settings must be indented with spaces, not tabs, or biome's format gate rejects them downstream"
+  fi
+  grep -qFx '  "hooks": {' "$settings" \
+    || fail "claude hook settings must use a 2-space indent width, expected a line '  \"hooks\": {'"
   for ev in UserPromptSubmit Stop StopFailure SessionEnd; do
     jq -e ".hooks[\"$ev\"]" "$settings" >/dev/null || fail "claude hook settings lack $ev"
   done

--- a/tests/fm-busy-adapter-wiring.test.sh
+++ b/tests/fm-busy-adapter-wiring.test.sh
@@ -266,6 +266,8 @@ test_claude_hooks_semantic_lifecycle() {
   settings="$WT_DIR/.claude/settings.local.json"
   assert_present "$settings" "claude spawn did not write hook settings"
   jq -e . "$settings" >/dev/null || fail "claude hook settings are not valid JSON"
+  [ "$(wc -l <"$settings")" -gt 1 ] \
+    || fail "claude hook settings must be pretty-printed multi-line JSON, not minified to one line"
   for ev in UserPromptSubmit Stop StopFailure SessionEnd; do
     jq -e ".hooks[\"$ev\"]" "$settings" >/dev/null || fail "claude hook settings lack $ev"
   done


### PR DESCRIPTION
## What Changed

- `bin/fm-spawn.sh` now writes the claude adapter's `.claude/settings.local.json` as multi-line, 2-space-indented JSON instead of a single minified line, with an inline comment recording the indent style as a deliberate invariant so repo-wide format gates accept the generated file.
- `tests/fm-busy-adapter-wiring.test.sh` pins that formatting in `test_claude_hooks_semantic_lifecycle`: the generated file must span more than one line, contain no tab characters, and carry a depth-1 `  "hooks": {` line.

## Risk Assessment

✅ Low: The branch is a reformat of a generated hook file with byte-identical hook wiring plus a tightened regression guard, and the existing jq-driven lifecycle assertions still prove the hook semantics are unchanged.

## Testing

Ran the targeted `tests/fm-busy-adapter-wiring.test.sh` (all 8 pass, covering the new formatting assertions plus the full claude hook busy/idle lifecycle), then produced product-level evidence by driving the real fm-spawn for a claude spawn and capturing the `.claude/settings.local.json` it actually writes into the worktree: 44 pretty-printed lines where the base commit emitted one minified line, zero tabs, trailing newline present, and byte-identical to `jq --indent 2` canonical form at every nesting level rather than only at the top key the test greps. I also confirmed the new regression guard has teeth by replaying its assertions against minified and tab-indented renderings of the same settings, both correctly rejected, and grepped the repo to confirm no other test asserts on this file's exact bytes. I deliberately did not run biome — this phase forbids linters and formatters, and the downstream repos the comment cites are absent from this machine, so the 2-space-vs-tabs justification remains an unverified downstream claim reported as a non-blocking warning. This is a non-visual CLI/file-generation change, so the reviewer-visible artifact is the generated settings file itself rather than a screenshot. The worktree is clean and the transient spawn temp directory was removed.

<details>
<summary>Evidence: Generated .claude/settings.local.json from a real fm-spawn claude run (the end-user surface)</summary>

```text
{
  "hooks": {
    "UserPromptSubmit": [
      {
        "hooks": [
          {
            "type": "command",
            "command": "'/Users/oscarmuhlbauer/.no-mistakes/worktrees/8c045c5a84c5/01KZ85M8JRFEFJ2DTXBY16DZK0/bin/fm-busy-event.sh' apply '/private/var/folders/0j/3zwwly210nbfhf4nh9b5l7mh0000gn/T/fm-settings-evidence.34saR2/claude-evidence/home/state' 'busy-evidence-1' busy --gen 'g1785907802.69635.8394' --source claude-hook --event user-prompt-submit 2>/dev/null || true"
          }
        ]
      }
    ],
    "Stop": [
      {
        "hooks": [
          {
            "type": "command",
            "command": "touch '/private/var/folders/0j/3zwwly210nbfhf4nh9b5l7mh0000gn/T/fm-settings-evidence.34saR2/claude-evidence/home/state/busy-evidence-1.turn-ended'; '/Users/oscarmuhlbauer/.no-mistakes/worktrees/8c045c5a84c5/01KZ85M8JRFEFJ2DTXBY16DZK0/bin/fm-busy-event.sh' apply '/private/var/folders/0j/3zwwly210nbfhf4nh9b5l7mh0000gn/T/fm-settings-evidence.34saR2/claude-evidence/home/state' 'busy-evidence-1' idle --gen 'g1785907802.69635.8394' --source claude-hook --event stop 2>/dev/null || true"
          }
        ]
      }
    ],
    "StopFailure": [
      {
        "hooks": [
          {
            "type": "command",
            "command": "'/Users/oscarmuhlbauer/.no-mistakes/worktrees/8c045c5a84c5/01KZ85M8JRFEFJ2DTXBY16DZK0/bin/fm-busy-event.sh' apply '/private/var/folders/0j/3zwwly210nbfhf4nh9b5l7mh0000gn/T/fm-settings-evidence.34saR2/claude-evidence/home/state' 'busy-evidence-1' idle --gen 'g1785907802.69635.8394' --source claude-hook --event stop-failure 2>/dev/null || true"
          }
        ]
      }
    ],
    "SessionEnd": [
      {
        "hooks": [
          {
            "type": "command",
            "command": "'/Users/oscarmuhlbauer/.no-mistakes/worktrees/8c045c5a84c5/01KZ85M8JRFEFJ2DTXBY16DZK0/bin/fm-busy-event.sh' apply '/private/var/folders/0j/3zwwly210nbfhf4nh9b5l7mh0000gn/T/fm-settings-evidence.34saR2/claude-evidence/home/state' 'busy-evidence-1' idle --gen 'g1785907802.69635.8394' --source claude-hook --event session-end 2>/dev/null || true"
          }
        ]
      }
    ]
  }
}
```
</details>
<details>
<summary>Evidence: Before/after transcript with verified formatting properties and guard-teeth check</summary>

<code>BEFORE (heredoc body in bin/fm-spawn.sh at base 71f0b3f) — 1 line, minified:&#10;&#10;{&#34;hooks&#34;:{&#34;UserPromptSubmit&#34;:[{&#34;hooks&#34;:[{&#34;type&#34;:&#34;command&#34;,&#34;command&#34;:&#34;$j_submit&#34;}]}],&#34;Stop&#34;:[{&#34;hooks&#34;:[{&#34;type&#34;:&#34;command&#34;,&#34;command&#34;:&#34;$j_stop&#34;}]}],&#34;StopFailure&#34;:[{&#34;hooks&#34;:[{&#34;type&#34;:&#34;command&#34;,&#34;command&#34;:&#34;$j_stopfail&#34;}]}],&#34;SessionEnd&#34;:[{&#34;hooks&#34;:[{&#34;type&#34;:&#34;command&#34;,&#34;command&#34;:&#34;$j_sessionend&#34;}]}]}}&#10;&#10;AFTER — file written into the worktree by a real fm-spawn claude run at af70012 (hook commands elided for width):&#10;&#10;{&#10;&#34;hooks&#34;: {&#10;&#34;UserPromptSubmit&#34;: [&#10;{&#10;&#34;hooks&#34;: [&#10;{&#10;&#34;type&#34;: &#34;command&#34;,&#10;&#34;command&#34;: &#34;&#39;.../bin/fm-busy-event.sh&#39; apply &#39;.../state&#39; &#39;busy-evidence-1&#39; busy --gen &#39;g1785907802.69635.8394&#39; --source claude-hook --event user-prompt-submit 2&gt;/dev/null || true&#34;&#10;}&#10;]&#10;}&#10;],&#10;&#34;Stop&#34;: [ ... ],&#10;&#34;StopFailure&#34;: [ ... ],&#10;&#34;SessionEnd&#34;: [ ... ]&#10;}&#10;}&#10;&#10;Properties verified on the generated file:&#10;lines................. 44 (was 1)&#10;tab characters........ 0&#10;final byte............ 0x0a (trailing newline present)&#10;canonical form........ byte-identical to `jq --indent 2`&#10;hook events present... UserPromptSubmit, Stop, StopFailure, SessionEnd&#10;&#10;Regression guard has teeth — the three new assertions replayed against regressed&#10;renderings (minified and tab-indented renderings are SYNTHESIZED from the generated&#10;file purely to exercise the guard, not outputs of a base-commit spawn run):&#10;&#10;after (fix) multi-line PASS no-tabs PASS 2-space PASS&#10;minified (synthesized) multi-line FAIL no-tabs PASS 2-space FAIL&#10;tab-indented (synthesized) multi-line PASS no-tabs FAIL 2-space FAIL</code>

```text
fm-spawn claude settings.local.json — pretty-print fix (af70012 vs base 71f0b3f)

BEFORE (heredoc body in bin/fm-spawn.sh at base 71f0b3f) — 1 line, minified:

{"hooks":{"UserPromptSubmit":[{"hooks":[{"type":"command","command":"$j_submit"}]}],"Stop":[{"hooks":[{"type":"command","command":"$j_stop"}]}],"StopFailure":[{"hooks":[{"type":"command","command":"$j_stopfail"}]}],"SessionEnd":[{"hooks":[{"type":"command","command":"$j_sessionend"}]}]}}

AFTER — file written into the worktree by a real fm-spawn claude run at af70012:

{
  "hooks": {
    "UserPromptSubmit": [
      {
        "hooks": [
          {
            "type": "command",
            "command": "'/Users/oscarmuhlbauer/.no-mistakes/worktrees/8c045c5a84c5/01KZ85M8JRFEFJ2DTXBY16DZK0/bin/fm-busy-event.sh' apply '/private/var/folders/0j/3zwwly210nbfhf4nh9b5l7mh0000gn/T/fm-settings-evidence.34saR2/claude-evidence/home/state' 'busy-evidence-1' busy --gen 'g1785907802.69635.8394' --source claude-hook --event user-prompt-submit 2>/dev/null || true"
          }
        ]
      }
    ],
    "Stop": [
      {
        "hooks": [
          {
            "type": "command",
            "command": "touch '/private/var/folders/0j/3zwwly210nbfhf4nh9b5l7mh0000gn/T/fm-settings-evidence.34saR2/claude-evidence/home/state/busy-evidence-1.turn-ended'; '/Users/oscarmuhlbauer/.no-mistakes/worktrees/8c045c5a84c5/01KZ85M8JRFEFJ2DTXBY16DZK0/bin/fm-busy-event.sh' apply '/private/var/folders/0j/3zwwly210nbfhf4nh9b5l7mh0000gn/T/fm-settings-evidence.34saR2/claude-evidence/home/state' 'busy-evidence-1' idle --gen 'g1785907802.69635.8394' --source claude-hook --event stop 2>/dev/null || true"
          }
        ]
      }
    ],
    "StopFailure": [
      {
        "hooks": [
          {
            "type": "command",
            "command": "'/Users/oscarmuhlbauer/.no-mistakes/worktrees/8c045c5a84c5/01KZ85M8JRFEFJ2DTXBY16DZK0/bin/fm-busy-event.sh' apply '/private/var/folders/0j/3zwwly210nbfhf4nh9b5l7mh0000gn/T/fm-settings-evidence.34saR2/claude-evidence/home/state' 'busy-evidence-1' idle --gen 'g1785907802.69635.8394' --source claude-hook --event stop-failure 2>/dev/null || true"
          }
        ]
      }
    ],
    "SessionEnd": [
      {
        "hooks": [
          {
            "type": "command",
            "command": "'/Users/oscarmuhlbauer/.no-mistakes/worktrees/8c045c5a84c5/01KZ85M8JRFEFJ2DTXBY16DZK0/bin/fm-busy-event.sh' apply '/private/var/folders/0j/3zwwly210nbfhf4nh9b5l7mh0000gn/T/fm-settings-evidence.34saR2/claude-evidence/home/state' 'busy-evidence-1' idle --gen 'g1785907802.69635.8394' --source claude-hook --event session-end 2>/dev/null || true"
          }
        ]
      }
    ]
  }
}

Properties verified on the generated file:
  lines................. 44 (was 1)
  tab characters........ 0
  final byte............ 0x0a (trailing newline present)
  canonical form........ byte-identical to `jq --indent 2`
  hook events present... UserPromptSubmit, Stop, StopFailure, SessionEnd

Regression guard has teeth — the three new assertions replayed against regressed renderings.
The minified and tab-indented renderings are SYNTHESIZED from the generated file above
(jq -c, and jq --indent 1 piped through sed to tabs) purely to exercise the guard; they are
not outputs of a base-commit spawn run. The genuine base-commit artifact is the one-line
heredoc body quoted at the top, taken from `git show 71f0b3f:bin/fm-spawn.sh`.

  after (fix)                 multi-line PASS  no-tabs PASS  2-space PASS
  minified (synthesized)      multi-line FAIL  no-tabs PASS  2-space FAIL
  tab-indented (synthesized)  multi-line PASS  no-tabs FAIL  2-space FAIL
```
</details>
<details>
<summary>Evidence: Reproducible capture script (drives real fm-spawn and copies out the generated settings file)</summary>

```text
#!/usr/bin/env bash
# Drive the REAL bin/fm-spawn.sh for a claude harness spawn and capture the
# .claude/settings.local.json it writes into the worktree, verbatim.
set -u
ROOT=${ROOT:?}
EV=${EV:?}
. "$ROOT/tests/lib.sh"
SPAWN="$ROOT/bin/fm-spawn.sh"
TMP_ROOT=$(fm_test_tmproot fm-settings-evidence)

case_dir="$TMP_ROOT/claude-evidence"
home="$case_dir/home"; proj="$case_dir/project"; wt="$case_dir/wt"
fakebin=$(fm_fakebin "$case_dir/fake")
cat > "$fakebin/tmux" <<'SH'
#!/usr/bin/env bash
set -u
case "$*" in
  *"#{pane_current_path}"*) printf '%s\n' "${FM_FAKE_PANE_PATH:-}"; exit 0 ;;
esac
case "${1:-}" in
  display-message) printf 'firstmate\n'; exit 0 ;;
  list-windows) exit 0 ;;
  has-session|new-session|new-window|kill-window|send-keys) exit 0 ;;
esac
exit 0
SH
chmod +x "$fakebin/tmux"
fm_fake_exit0 "$fakebin" treehouse pi opencode claude codex

mkdir -p "$home/data" "$home/projects" "$home/state" "$home/config"
printf 'claude\n' > "$home/config/crew-harness"
fm_git_worktree "$proj" "$wt" "wt-evidence"
touch "$home/state/.last-watcher-beat"
mkdir -p "$home/data/busy-evidence-1"
printf 'brief for busy-evidence-1\n' > "$home/data/busy-evidence-1/brief.md"

FM_ROOT_OVERRIDE='' FM_HOME="$home" \
  FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
  FM_PROJECTS_OVERRIDE="$home/projects" FM_CONFIG_OVERRIDE="$home/config" \
  FM_SPAWN_NO_GUARD=1 FM_FAKE_PANE_PATH="$wt" TMUX="fake,1,0" \
  PATH="$fakebin:$PATH" \
  "$SPAWN" busy-evidence-1 "$proj" --mode no-mistakes --yolo off

settings="$wt/.claude/settings.local.json"
cp "$settings" "$EV/settings.local.json.after"
printf '%s\n' "$settings"
```
</details>
<details>
<summary>Evidence: Base-commit minified heredoc body (from git show 71f0b3f)</summary>

```text
{"hooks":{"UserPromptSubmit":[{"hooks":[{"type":"command","command":"$j_submit"}]}],"Stop":[{"hooks":[{"type":"command","command":"$j_stop"}]}],"StopFailure":[{"hooks":[{"type":"command","command":"$j_stopfail"}]}],"SessionEnd":[{"hooks":[{"type":"command","command":"$j_sessionend"}]}]}}
```
</details>
<details>
<summary>Evidence: Synthesized regressed renderings used for the guard-teeth check</summary>

```text
{"hooks":{"UserPromptSubmit":[{"hooks":[{"type":"command","command":"'/Users/oscarmuhlbauer/.no-mistakes/worktrees/8c045c5a84c5/01KZ85M8JRFEFJ2DTXBY16DZK0/bin/fm-busy-event.sh' apply '/private/var/folders/0j/3zwwly210nbfhf4nh9b5l7mh0000gn/T/fm-settings-evidence.34saR2/claude-evidence/home/state' 'busy-evidence-1' busy --gen 'g1785907802.69635.8394' --source claude-hook --event user-prompt-submit 2>/dev/null || true"}]}],"Stop":[{"hooks":[{"type":"command","command":"touch '/private/var/folders/0j/3zwwly210nbfhf4nh9b5l7mh0000gn/T/fm-settings-evidence.34saR2/claude-evidence/home/state/busy-evidence-1.turn-ended'; '/Users/oscarmuhlbauer/.no-mistakes/worktrees/8c045c5a84c5/01KZ85M8JRFEFJ2DTXBY16DZK0/bin/fm-busy-event.sh' apply '/private/var/folders/0j/3zwwly210nbfhf4nh9b5l7mh0000gn/T/fm-settings-evidence.34saR2/claude-evidence/home/state' 'busy-evidence-1' idle --gen 'g1785907802.69635.8394' --source claude-hook --event stop 2>/dev/null || true"}]}],"StopFailure":[{"hooks":[{"type":"command","command":"'/Users/oscarmuhlbauer/.no-mistakes/worktrees/8c045c5a84c5/01KZ85M8JRFEFJ2DTXBY16DZK0/bin/fm-busy-event.sh' apply '/private/var/folders/0j/3zwwly210nbfhf4nh9b5l7mh0000gn/T/fm-settings-evidence.34saR2/claude-evidence/home/state' 'busy-evidence-1' idle --gen 'g1785907802.69635.8394' --source claude-hook --event stop-failure 2>/dev/null || true"}]}],"SessionEnd":[{"hooks":[{"type":"command","command":"'/Users/oscarmuhlbauer/.no-mistakes/worktrees/8c045c5a84c5/01KZ85M8JRFEFJ2DTXBY16DZK0/bin/fm-busy-event.sh' apply '/private/var/folders/0j/3zwwly210nbfhf4nh9b5l7mh0000gn/T/fm-settings-evidence.34saR2/claude-evidence/home/state' 'busy-evidence-1' idle --gen 'g1785907802.69635.8394' --source claude-hook --event session-end 2>/dev/null || true"}]}]}}
```
</details>
- Outcome: ⚠️ 1 warning across 1 run (6m31s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>⏭️ **intent** - skipped</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed ✅</summary>

- ⚠️ `tests/fm-busy-adapter-wiring.test.sh:269` - The new regression guard asserts only that settings.local.json spans more than one line, but the invariant the fix documents at bin/fm-spawn.sh:1821-1827 is 2-space indentation specifically (&#34;Do not switch to tabs (biome&#39;s own default)&#34;). Rewriting the heredoc with tab indentation keeps the file multi-line, so this assertion stays green while Nice&#39;s biome format gate - the failure this branch fixes - breaks again. Harden it with shebang-agnostic checks instead: fail if the file contains any tab character, and assert the depth-1 line matches &#39;^  &#34;hooks&#34;: {&#39; so the width is pinned to 2 spaces. Note: this phase does not run tests, so any edit here ships unverified until the pipeline&#39;s test step.
- ℹ️ `bin/fm-spawn.sh:1821` - The fix pins the generated file&#39;s formatting to one downstream repo&#39;s biome config (space/2). This is an accepted, honestly documented tradeoff rather than a defect: no currently reachable path fails, since projects/juicy runs no biome, grok&#39;s minified hook JSON is written to ~/.grok/hooks outside the worktree, and the opencode/pi heredocs are already 2-space. Recorded for awareness only; no action needed unless a downstream repo later adopts a different indent style.

🔧 Fix: harden claude settings.local.json 2-space indent regression guard
✅ Re-checked - no issues remain.

</details>

<details>
<summary>⚠️ **Test** - 1 warning</summary>

- ⚠️ `bin/fm-spawn.sh:1821` - The code comment at bin/fm-spawn.sh:1821-1827 and the tab-rejection assertion in tests/fm-busy-adapter-wiring.test.sh:271-273 both encode a claim about downstream repos (projects/nice/biome.json setting indentStyle=&#34;space&#34;/indentWidth 2, projects/juicy carrying no biome config). Neither repo exists on this machine, so the specific 2-space-vs-tabs choice rests on a downstream assertion that cannot be confirmed from this worktree. The pretty-print intent itself is fully demonstrated by the captured artifact; only the indent-width justification is unverifiable here. You may want to re-confirm the downstream biome config.
- <code>`bash tests/fm-busy-adapter-wiring.test.sh` — all 8 tests pass, including `test_claude_hooks_semantic_lifecycle` with the three new formatting assertions and the full UserPromptSubmit/Stop/StopFailure/SessionEnd classification lifecycle driven out of the reformatted JSON</code>
- <code>Manual end-to-end capture: ran the real `bin/fm-spawn.sh busy-evidence-1 &lt;project&gt; --mode no-mistakes --yolo off` against a fake tmux pane and isolated git worktree, then copied the generated `.claude/settings.local.json` verbatim into the evidence directory</code>
- <code>`wc -l` on the generated file — 44 lines (base commit produced 1)</code>
- <code>`grep -c $&#39;\t&#39;` on the generated file — 0 tab characters</code>
- <code>`tail -c1 &lt;file&gt; | xxd` — final byte 0x0a, trailing newline present (a format gate rejects a file with no final newline)</code>
- <code>`diff &lt;(jq --indent 2 . &#34;$settings&#34;) &#34;$settings&#34;` — byte-identical, so the file is its own canonical 2-space pretty-print at every nesting level, not just the top-level `hooks` key the test greps</code>
- <code>`jq -r &#39;.hooks | keys_unsorted[]&#39;` — all four hook events (UserPromptSubmit, Stop, StopFailure, SessionEnd) present and parseable</code>
- <code>Guard-teeth check: replayed the three new assertions (multi-line, no-tabs, 2-space) against a `jq -c` minified rendering and a tab-indented rendering of the same settings — minified fails multi-line and 2-space, tab-indented fails no-tabs and 2-space</code>
- <code>`grep -rn &#34;settings\.local&#34; tests/ bin/ skills/ docs/` — checked for other tests with content-sensitive assertions on this file; only `tests/fm-claude-stop-autoarm-live-e2e.test.sh` (writes its own unrelated fixture, opt-in behind FM_CLAUDE_LIVE_E2E) and `bin/fm-teardown.sh` (content-agnostic `rm -f`) reference it</code>
- <code>`git show 71f0b3f:bin/fm-spawn.sh` — extracted the base-commit single-line minified heredoc body for the before/after contrast</code>

</details>

<details>
<summary>⚠️ **Document** - 1 info</summary>

- ℹ️ `bin/fm-spawn.sh:1821` - I removed the per-repo verification detail from the new fm-spawn comment (that projects/nice/biome.json sets indentStyle=&#34;space&#34;/indentWidth 2 and projects/juicy has no biome config), keeping only the general invariant. Judgment call: that detail is an undated empirical claim about repos outside this one, which the coding guidelines route to a dated docs/verification record rather than a code comment, and creating such a record for a downstream formatting fact would mean adding a new documentation surface plus a documentation-audiences.json entry. If maintainers consider the specific downstream repo names load-bearing, the right home is a dated maintainer-verification entry, not the comment.

</details>

<details>
<summary>⏭️ **Lint** - skipped</summary>

- ⚠️ linter found issues (exit code 127)

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
