### PR TITLE
fix(bin): advance a bare-flagged clone with a ref-only fetch

### DIFF
--- a/bin/fm-fleet-sync.sh
+++ b/bin/fm-fleet-sync.sh
@@ -132,6 +132,19 @@ first_line() {
   printf '%s\n' "$1" | sed -n '1s/[[:space:]]\{1,\}/ /g;1p'
 }
 
+# The line of a failed command's output that names the reason. `git fetch`'s
+# refspec report leads with a "From <url>" line and puts the refusal itself in a
+# later "! [rejected] ..." line, so the first line alone would report the remote
+# URL instead of the failure. Falls back to the first line when no recognisable
+# failure line is present (which is what `git merge --ff-only` produces: its
+# "fatal: Not possible to fast-forward, aborting." is already line one).
+failure_line() {
+  local line
+  line=$(printf '%s\n' "$1" | grep -m1 -E '^[[:space:]]*(fatal:|error:|! \[rejected\]|! \[remote rejected\])' || true)
+  [ -n "$line" ] || line=$1
+  first_line "$(printf '%s\n' "$line" | sed '1s/^[[:space:]]*//')"
+}
+
 # True when git stderr shows the packed-refs.lock "File exists" race. The lock
 # path can appear anywhere in the message (git prefixes it with the failed ref op,
 # e.g. "could not delete reference ...:"). Other "File exists" errors must not match.
@@ -220,11 +233,14 @@ fetch_with_packed_refs_lock_guard() {
 # merge into, so it advances the local ref directly with a ref-only
 # `git fetch origin <branch>:<branch>` - the same pattern that harness's own
 # tooling uses (see the bare-clone note near the top of this file). Git refuses
-# a non-fast-forward update here the same way --ff-only refuses one. Sets
-# ADVANCE_OUTPUT to the command's combined output; returns its exit status.
+# a non-fast-forward update here the same way --ff-only refuses one. The fetch
+# runs without --quiet because that flag suppresses git's refspec report - the
+# only place a rejection states its reason - which would leave that failure
+# reported with no reason at all. Sets ADVANCE_OUTPUT to the command's combined
+# output (only read on failure); returns its exit status.
 advance_local_default() {
   if [ "$bare" = yes ]; then
-    ADVANCE_OUTPUT=$(git -C "$PROJ" fetch origin --quiet "$DEFAULT:$DEFAULT" 2>&1)
+    ADVANCE_OUTPUT=$(git -C "$PROJ" fetch origin "$DEFAULT:$DEFAULT" 2>&1)
   else
     ADVANCE_OUTPUT=$(git -C "$PROJ" merge --ff-only "$BASE" 2>&1)
   fi
@@ -430,7 +446,7 @@ sync_project() {
   if ! advance_local_default; then
     reason="fast-forward failed"
     if [ -n "$ADVANCE_OUTPUT" ]; then
-      reason="$reason: $(first_line "$ADVANCE_OUTPUT")"
+      reason="$reason: $(failure_line "$ADVANCE_OUTPUT")"
     fi
     echo "$label: skipped: $reason"
     return 0

--- a/bin/fm-fleet-sync.sh
+++ b/bin/fm-fleet-sync.sh
@@ -13,6 +13,11 @@
 # stashed, or discarded.
 # Still skips (benignly) local-only/no-origin projects, missing remotes/branches,
 # and fetch failures.
+# A clone with core.bare=true set (a harness's main checkout deliberately
+# bare-flagged so it can serve as a ref-only fetch target while a branch stays
+# checked out, e.g. Nice's .claude/hooks/worktreeContext.sh) has no work tree to
+# run `git status`/`git merge` against, so it is advanced with a ref-only
+# `git fetch origin <branch>:<branch>` instead - see advance_local_default.
 # Pruning never deletes the checked-out branch or a branch that still has a
 # worktree, so it cannot discard unlanded work; set FM_FLEET_PRUNE=0 to disable it.
 # When the fetch fails on an orphaned .git/packed-refs.lock (left by a ref rewrite
@@ -210,6 +215,21 @@ fetch_with_packed_refs_lock_guard() {
   return "$rc"
 }
 
+# Fast-forward $DEFAULT to $BASE. An ordinary clone uses `git merge --ff-only`,
+# which needs a work tree to update. A clone with $bare=yes has no work tree to
+# merge into, so it advances the local ref directly with a ref-only
+# `git fetch origin <branch>:<branch>` - the same pattern that harness's own
+# tooling uses (see the bare-clone note near the top of this file). Git refuses
+# a non-fast-forward update here the same way --ff-only refuses one. Sets
+# ADVANCE_OUTPUT to the command's combined output; returns its exit status.
+advance_local_default() {
+  if [ "$bare" = yes ]; then
+    ADVANCE_OUTPUT=$(git -C "$PROJ" fetch origin --quiet "$DEFAULT:$DEFAULT" 2>&1)
+  else
+    ADVANCE_OUTPUT=$(git -C "$PROJ" merge --ff-only "$BASE" 2>&1)
+  fi
+}
+
 prune_gone_branches() {
   # Delete local branches whose upstream tracking branch is gone - the remote
   # branch was deleted, which in this fleet means its PR merged - as long as
@@ -312,6 +332,11 @@ sync_project() {
     return 0
   fi
 
+  bare=no
+  if [ "$(git -C "$PROJ" rev-parse --is-bare-repository 2>/dev/null)" = "true" ]; then
+    bare=yes
+  fi
+
   if ! fetch_with_packed_refs_lock_guard; then
     reason="fetch failed"
     if [ -n "$FETCH_OUTPUT" ]; then
@@ -335,7 +360,12 @@ sync_project() {
 
   cur=$(git -C "$PROJ" symbolic-ref --short HEAD 2>/dev/null || echo "")
   dirty=no
-  [ -z "$(git -C "$PROJ" status --porcelain 2>/dev/null | head -1)" ] || dirty=yes
+  # `git status` requires a work tree; a bare-flagged clone has none to inspect,
+  # so there is nothing to detect as dirty (matches that harness's own ref-only
+  # treatment of this checkout - see the bare-clone note near the top of this file).
+  if [ "$bare" = no ]; then
+    [ -z "$(git -C "$PROJ" status --porcelain 2>/dev/null | head -1)" ] || dirty=yes
+  fi
   recovered=no
 
   if [ "$cur" != "$DEFAULT" ]; then
@@ -397,10 +427,10 @@ sync_project() {
     echo "$label: skipped: cannot read local $DEFAULT"
     return 0
   }
-  if ! merge_output=$(git -C "$PROJ" merge --ff-only "$BASE" 2>&1); then
+  if ! advance_local_default; then
     reason="fast-forward failed"
-    if [ -n "$merge_output" ]; then
-      reason="$reason: $(first_line "$merge_output")"
+    if [ -n "$ADVANCE_OUTPUT" ]; then
+      reason="$reason: $(first_line "$ADVANCE_OUTPUT")"
     fi
     echo "$label: skipped: $reason"
     return 0

--- a/bin/fm-fleet-sync.sh
+++ b/bin/fm-fleet-sync.sh
@@ -15,9 +15,10 @@
 # and fetch failures.
 # A clone with core.bare=true set (a harness's main checkout deliberately
 # bare-flagged so it can serve as a ref-only fetch target while a branch stays
-# checked out, e.g. Nice's .claude/hooks/worktreeContext.sh) has no work tree to
-# run `git status`/`git merge` against, so it is advanced with a ref-only
-# `git fetch origin <branch>:<branch>` instead - see advance_local_default.
+# checked out, e.g. Nice's .claude/hooks/worktreeContext.sh) makes git refuse
+# every work-tree operation, including `git status` and `git merge`, so it is
+# advanced with a ref-only `git fetch origin <branch>:<branch>` instead - see
+# advance_local_default.
 # Pruning never deletes the checked-out branch or a branch that still has a
 # worktree, so it cannot discard unlanded work; set FM_FLEET_PRUNE=0 to disable it.
 # When the fetch fails on an orphaned .git/packed-refs.lock (left by a ref rewrite
@@ -229,10 +230,11 @@ fetch_with_packed_refs_lock_guard() {
 }
 
 # Fast-forward $DEFAULT to $BASE. An ordinary clone uses `git merge --ff-only`,
-# which needs a work tree to update. A clone with $bare=yes has no work tree to
-# merge into, so it advances the local ref directly with a ref-only
-# `git fetch origin <branch>:<branch>` - the same pattern that harness's own
-# tooling uses (see the bare-clone note near the top of this file). Git refuses
+# which needs a work tree to update. A clone with $bare=yes refuses that merge
+# (see the dirty-check note in sync_project), so it advances the local ref
+# directly with a ref-only `git fetch origin <branch>:<branch>` - the same
+# pattern that harness's own tooling uses (see the bare-clone note near the top
+# of this file). Git refuses
 # a non-fast-forward update here the same way --ff-only refuses one. The fetch
 # runs without --quiet because that flag suppresses git's refspec report - the
 # only place a rejection states its reason - which would leave that failure
@@ -376,9 +378,11 @@ sync_project() {
 
   cur=$(git -C "$PROJ" symbolic-ref --short HEAD 2>/dev/null || echo "")
   dirty=no
-  # `git status` requires a work tree; a bare-flagged clone has none to inspect,
-  # so there is nothing to detect as dirty (matches that harness's own ref-only
-  # treatment of this checkout - see the bare-clone note near the top of this file).
+  # `git status` requires a work tree. The files are still on disk (the harness
+  # keeps a branch checked out), but core.bare=true makes git refuse every
+  # work-tree operation there, so no dirty check is possible - which is the same
+  # ref-only treatment that harness gives this checkout itself (see the
+  # bare-clone note near the top of this file).
   if [ "$bare" = no ]; then
     [ -z "$(git -C "$PROJ" status --porcelain 2>/dev/null | head -1)" ] || dirty=yes
   fi

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -291,6 +291,7 @@ Generalizable firstmate knowledge goes to shared tracked docs through the normal
 The locked session-start bootstrap step, PR-based teardown, and merged-PR wake handling refresh remote-backed project clones when the clone is safe to move.
 Wake-time refreshes can target a single clone by project name, so the primary home also catches up when a secondmate reports a merge from its own home.
 Clean default-branch clones fast-forward to `origin/<default>`, and a clean detached HEAD that holds no unique commits is re-attached to the default branch before the same fast-forward path runs.
+A clone whose own harness deliberately sets `core.bare=true` on its checkout advances instead through a ref-only `git fetch origin <branch>:<branch>`, because git refuses every work-tree operation there, which also makes the dirty-tree check impossible; git still refuses a non-fast-forward update, so a genuinely stuck bare clone is still reported as a skip rather than silently advanced.
 Dirty clones, non-default branches, detached HEADs with unique commits, diverged defaults, and default branches checked out in another worktree are reported as `STUCK:` with their behind count and left untouched.
 Fetches blocked by an orphaned `.git/packed-refs.lock` use bounded retries and remove the lock only when the shared staleness proof can prove it abandoned; [configuration.md](configuration.md#toolchain) owns the recovery details and tuning knobs.
 Local-only projects, clones without an origin remote, and fetch failures remain benign skips.

--- a/tests/fm-fleet-sync.test.sh
+++ b/tests/fm-fleet-sync.test.sh
@@ -72,6 +72,18 @@ build_pair() {
   printf '%s\n' "$clone"
 }
 
+# build_pair_bare <home> <name>: like build_pair, but the clone has core.bare=true
+# set while a branch stays checked out - the pattern a harness uses to make its
+# main checkout double as a ref-only fetch target (e.g. Nice's
+# .claude/hooks/worktreeContext.sh). git refuses ordinary work-tree operations
+# (status, merge, checkout) against it; only ref-only updates are permitted.
+build_pair_bare() {
+  local home=$1 name=$2 clone
+  clone=$(build_pair "$home" "$name")
+  git -C "$clone" config core.bare true
+  printf '%s\n' "$clone"
+}
+
 # advance_origin <home> <name> <msg>: push one more commit to <name>'s origin via
 # its work repo, so the clone (until it fetches) is one commit behind origin/main.
 advance_origin() {
@@ -176,6 +188,31 @@ if [ "$is_fetch" = 1 ]; then
     exit 1
   fi
 fi
+exec "$real" "$@"
+SH
+  chmod +x "$1/git"
+}
+
+# git shim: reject a ref-only "fetch origin <branch>:<branch>" update (the form
+# advance_local_default uses for a bare-flagged clone) with a non-fast-forward
+# error, while delegating every other call - including the plain prune fetch -
+# to real git.
+git_bare_fetch_rejects() {
+  cat > "$1/git" <<'SH'
+#!/usr/bin/env bash
+real=${REAL_GIT_FOR_TEST:?}
+for a in "$@"; do
+  case "$a" in
+    *:*)
+      branch=${a%%:*}
+      branch2=${a#*:}
+      if [ -n "$branch" ] && [ "$branch" = "$branch2" ]; then
+        echo "! [rejected]        $branch -> $branch  (non-fast-forward)" >&2
+        exit 1
+      fi
+      ;;
+  esac
+done
 exec "$real" "$@"
 SH
   chmod +x "$1/git"
@@ -323,6 +360,58 @@ test_on_default_clean_behind_fast_forwards() {
   assert_not_contains "$out" "STUCK" "ordinary fast-forward is not flagged STUCK"
   [ "$(head_sha "$clone")" = "$(git -C "$clone" rev-parse origin/main)" ] || fail "clone was not fast-forwarded"
   pass "on-default clean behind clone still fast-forwards"
+}
+
+test_bare_clone_behind_fast_forwards() {
+  local home fakebin clone out err
+  home=$(new_home)
+  fakebin="$home/fb-bare-behind"; rm -rf "$fakebin"; mkdir -p "$fakebin"
+  clone=$(build_pair_bare "$home" bare-behind)
+  advance_origin "$home" bare-behind C1
+  out="$home/out-bare-behind"; err="$home/err-bare-behind"
+
+  set +e
+  run_sync_guarded "$home" "$fakebin" "$out" "$err" bare-behind
+  set -e
+
+  assert_contains "$(cat "$out")" "bare-behind: synced" "bare clone still fast-forwards via ref-only update"
+  assert_no_grep "must be run in a work tree" "$err" "bare clone advance never hits the work-tree error"
+  [ "$(head_sha "$clone")" = "$(git -C "$clone" rev-parse origin/main)" ] \
+    || fail "bare clone was not fast-forwarded"
+  pass "a core.bare=true clone still fast-forwards via a ref-only fetch"
+}
+
+test_bare_clone_already_current_unchanged() {
+  local home clone out before
+  home=$(new_home)
+  clone=$(build_pair_bare "$home" bare-current)
+  before=$(head_sha "$clone")
+
+  out=$(run_sync "$home" "$clone")
+
+  assert_contains "$out" "bare-current: already current" "bare clone at HEAD reports unchanged, no work-tree probe needed"
+  [ "$(head_sha "$clone")" = "$before" ] || fail "already-current bare clone was moved"
+  pass "an already-current bare clone is reported unchanged"
+}
+
+test_bare_clone_rejected_advance_reports_skip_untouched() {
+  local home fakebin clone out err before
+  home=$(new_home)
+  fakebin="$home/fb-bare-reject"; rm -rf "$fakebin"; mkdir -p "$fakebin"
+  clone=$(build_pair_bare "$home" bare-reject)
+  advance_origin "$home" bare-reject C1
+  before=$(head_sha "$clone")
+  git_bare_fetch_rejects "$fakebin"
+  out="$home/out-bare-reject"; err="$home/err-bare-reject"
+
+  set +e
+  run_sync_guarded "$home" "$fakebin" "$out" "$err" bare-reject
+  set -e
+
+  assert_contains "$(cat "$out")" "bare-reject: skipped: fast-forward failed" \
+    "a rejected bare ref-only advance reports a clear skip, not a silent success"
+  [ "$(head_sha "$clone")" = "$before" ] || fail "bare clone advanced despite the rejected fetch"
+  pass "a bare clone whose ref-only advance is rejected reports a clear skip and is left untouched"
 }
 
 test_already_current_unchanged() {
@@ -610,6 +699,9 @@ test_dirty_is_stuck_untouched
 test_non_default_branch_is_stuck_untouched
 test_diverged_is_stuck_untouched
 test_on_default_clean_behind_fast_forwards
+test_bare_clone_behind_fast_forwards
+test_bare_clone_already_current_unchanged
+test_bare_clone_rejected_advance_reports_skip_untouched
 test_already_current_unchanged
 test_no_origin_skipped
 test_local_only_skipped

--- a/tests/fm-fleet-sync.test.sh
+++ b/tests/fm-fleet-sync.test.sh
@@ -196,18 +196,29 @@ SH
 # git shim: reject a ref-only "fetch origin <branch>:<branch>" update (the form
 # advance_local_default uses for a bare-flagged clone) with a non-fast-forward
 # error, while delegating every other call - including the plain prune fetch -
-# to real git.
+# to real git. Mirrors real git's reporting exactly: the refspec report is the
+# only place the refusal states its reason, it is suppressed entirely by
+# --quiet, and it leads with a "From <url>" line before the rejection itself.
 git_bare_fetch_rejects() {
   cat > "$1/git" <<'SH'
 #!/usr/bin/env bash
 real=${REAL_GIT_FOR_TEST:?}
+quiet=no
+for a in "$@"; do
+  if [ "$a" = --quiet ] || [ "$a" = -q ]; then
+    quiet=yes
+  fi
+done
 for a in "$@"; do
   case "$a" in
     *:*)
       branch=${a%%:*}
       branch2=${a#*:}
       if [ -n "$branch" ] && [ "$branch" = "$branch2" ]; then
-        echo "! [rejected]        $branch -> $branch  (non-fast-forward)" >&2
+        if [ "$quiet" = no ]; then
+          echo "From /fake/origin-should-not-be-reported" >&2
+          echo " ! [rejected]        $branch -> $branch  (non-fast-forward)" >&2
+        fi
         exit 1
       fi
       ;;
@@ -408,8 +419,13 @@ test_bare_clone_rejected_advance_reports_skip_untouched() {
   run_sync_guarded "$home" "$fakebin" "$out" "$err" bare-reject
   set -e
 
-  assert_contains "$(cat "$out")" "bare-reject: skipped: fast-forward failed" \
-    "a rejected bare ref-only advance reports a clear skip, not a silent success"
+  assert_contains "$(cat "$out")" \
+    "bare-reject: skipped: fast-forward failed: ! [rejected] main -> main (non-fast-forward)" \
+    "a rejected bare ref-only advance reports a clear skip with git's reason, not a silent success"
+  # The reason must be the rejection line, not the "From <url>" line git prints
+  # ahead of it.
+  assert_not_contains "$(cat "$out")" "origin-should-not-be-reported" \
+    "the skip reason quoted the fetch's From line instead of the rejection"
   [ "$(head_sha "$clone")" = "$before" ] || fail "bare clone advanced despite the rejected fetch"
   pass "a bare clone whose ref-only advance is rejected reports a clear skip and is left untouched"
 }


### PR DESCRIPTION
## Intent

Fix bin/fm-fleet-sync.sh so it can refresh a project clone whose harness deliberately sets core.bare=true on its main checkout (a ref-host pattern, e.g. Nice's own .claude/hooks/worktreeContext.sh keeps the branch checked out but flags core.bare=true so its own tooling can advance it with a ref-only 'git fetch origin main:main' without a working tree). Previously fleet-sync used 'git merge --ff-only', which requires a work tree, so it always failed with 'this operation must be run in a work tree' and silently skipped the clone - once misdiagnosed as clone corruption needing a manual unset of core.bare, which is wrong: the flag is intentional and gets reapplied by the harness's own hooks. The fix detects core.bare via 'git rev-parse --is-bare-repository' and, when true, advances the local branch with a ref-only 'git fetch origin <branch>:<branch>' instead of the work-tree merge; git still refuses a non-fast-forward update the same way --ff-only did, so a genuinely stuck clone still reports a clear skip rather than a silent success. The dirty-tree check (git status --porcelain) is skipped for a bare clone for the same work-tree reason - there is no working tree to be dirty. Ordinary non-bare clones are completely unaffected; they still use the original merge --ff-only path. Added three colocated tests to tests/fm-fleet-sync.test.sh covering: a bare clone behind origin fast-forwarding via the ref-only fetch, a bare clone already at HEAD reporting unchanged, and a bare clone whose ref-only fetch is rejected (non-fast-forward) reporting a clear skip with the clone left untouched. Manually verified against the real Nice and Juicy clones in production: this branch's script advanced the bare Nice clone from 36291fb to 36ed864 (the exact case that was previously failing), while the non-bare Juicy clone correctly reported already-current with no behavior change.

## What Changed

- `bin/fm-fleet-sync.sh` now detects `core.bare=true` via `git rev-parse --is-bare-repository` and advances such a clone with a ref-only `git fetch origin <branch>:<branch>` instead of `git merge --ff-only`, which requires a work tree and previously failed with `this operation must be run in a work tree` on every sync. The `git status --porcelain` dirty check is skipped for those clones for the same reason. Non-bare clones keep the existing merge path unchanged.
- Added a `failure_line` helper that picks the `fatal:`/`error:`/`! [rejected]` line out of a failed advance instead of the first line, so a rejected ref-only fetch reports git's rejection rather than its leading `From <url>` line; the fetch deliberately omits `--quiet`, which would suppress that report entirely. This was raised in review and fixed in `81dfdb6`.
- Added three cases to `tests/fm-fleet-sync.test.sh` (bare clone behind origin fast-forwards, bare clone already current reports unchanged, rejected non-fast-forward reports a skip with the clone untouched) and a line in `docs/architecture.md` describing the ref-only advance path.

## Risk Assessment

✅ Low: The round-2 commit strictly improves diagnostics and tightens the test to pin the exact reason string, the non-bare path remains byte-identical on every reachable failure, and the only surviving item is an inaccurate comment.

## Testing

<code>I ran the colocated suite `tests/fm-fleet-sync.test.sh` (25 tests, all pass, including the three new bare-clone cases) and then drove the real `bin/fm-fleet-sync.sh` CLI end-to-end over a fixture fleet that reproduces the production shape: a `nice` clone whose simulated `.claude/hooks/worktreeContext.sh` sets core.bare=true while main stays checked out, and an ordinary non-bare `juicy` clone, both behind origin. Running the base-commit script produced exactly the reported failure — `nice: skipped: fast-forward failed: fatal: this operation must be run in a work tree`, with the clone left behind origin — while this branch&#39;s script on an identical fleet reported `nice: synced 5385206..5f8ac81` and left `core.bare=true` intact; `juicy` fast-forwarded through the untouched `merge --ff-only` path identically in both runs. I also confirmed on the bare clone that branch pruning still works (`nice: pruned pr-1234`), that re-applying the harness hook and re-syncing reports `already current` (so the flag being reapplied does not reintroduce the failure), that a genuinely diverged bare clone reports a loud STUCK warning and is left untouched under real git, and that a refused ref-only advance reports `skipped: fast-forward failed: ! [rejected] main -&gt; main (non-fast-forward)`. That last case is a race guard the script&#39;s own ancestry check screens out before real git could hit it, so it is exercised with a git shim that mirrors real git&#39;s rejection reporting — the unshimmed protection for a stuck clone is the diverged→STUCK case, also in the transcript. This is a shell CLI change with no rendered UI surface, so the reviewer-visible evidence is the before/after command transcript rather than a screenshot. The worktree is clean; no source or test files were modified during testing.</code>

<details>
<summary>Evidence: Before/after fleet-sync CLI transcript (base 71f0b3f vs target 81dfdb6)</summary>

<code>BEFORE (base 71f0b3f):&#10;$ FM_HOME=&lt;fleet&gt; bin/fm-fleet-sync.sh&#10;juicy: synced 71e384f..7881d63&#10;nice: pruned pr-1234&#10;nice: skipped: fast-forward failed: fatal: this operation must be run in a work tree&#10;-&gt; nice core.bare=true local main=d464e75 origin/main=4acb45a (left behind)&#10;&#10;AFTER (this branch 81dfdb6), same fleet, same command:&#10;$ FM_HOME=&lt;fleet&gt; bin/fm-fleet-sync.sh&#10;juicy: synced 7845157..ea2391b&#10;nice: pruned pr-1234&#10;nice: synced 5385206..5f8ac81&#10;-&gt; nice core.bare=true local main=5f8ac81 origin/main=5f8ac81 (caught up, flag intact)&#10;&#10;$ .claude/hooks/worktreeContext.sh # harness re-applies the flag; sync again&#10;juicy: already current&#10;nice: already current&#10;&#10;STUCK BARE CLONE (real git, local main diverged):&#10;nice: STUCK: on diverged main, 2 commits behind origin/main - needs attention&#10;-&gt; local main unchanged&#10;&#10;REJECTED ADVANCE (git shim refusing the ref-only main:main update):&#10;nice: skipped: fast-forward failed: ! [rejected] main -&gt; main (non-fast-forward)&#10;-&gt; local main unchanged</code>

```text
==============================================================================
BEFORE  (base 71f0b3f): fm-fleet-sync.sh over a fleet with a core.bare=true clone
==============================================================================
### fleet before sync
  nice   core.bare=true  HEAD=main local main=d464e75 origin/main=d464e75 branches=[main pr-1234]
  juicy  core.bare=false HEAD=main local main=71e384f origin/main=71e384f branches=[main pr-1234]

$ FM_HOME=<fleet> bin/fm-fleet-sync.sh
  juicy: synced 71e384f..7881d63
  nice: pruned pr-1234
  nice: skipped: fast-forward failed: fatal: this operation must be run in a work tree

### fleet after sync
  nice   core.bare=true  HEAD=main local main=d464e75 origin/main=4acb45a branches=[main]
  juicy  core.bare=false HEAD=main local main=7881d63 origin/main=7881d63 branches=[main pr-1234]

==============================================================================
AFTER   (this branch 81dfdb6): same fleet, same command
==============================================================================
### fleet before sync
  nice   core.bare=true  HEAD=main local main=5385206 origin/main=5385206 branches=[main pr-1234]
  juicy  core.bare=false HEAD=main local main=7845157 origin/main=7845157 branches=[main pr-1234]

$ FM_HOME=<fleet> bin/fm-fleet-sync.sh
  juicy: synced 7845157..ea2391b
  nice: pruned pr-1234
  nice: synced 5385206..5f8ac81

### fleet after sync
  nice   core.bare=true  HEAD=main local main=5f8ac81 origin/main=5f8ac81 branches=[main]
  juicy  core.bare=false HEAD=main local main=ea2391b origin/main=ea2391b branches=[main pr-1234]

$ .claude/hooks/worktreeContext.sh   # harness re-applies the flag; sync it again
  juicy: already current
  nice: already current

==============================================================================
STUCK BARE CLONE (real git): local main diverged from origin - never silently
advanced, never force-updated
==============================================================================
### fleet before sync
  nice   core.bare=true  HEAD=main local main=437b850 origin/main=cad0a8c branches=[main pr-1234]
  juicy  core.bare=false HEAD=main local main=7ed253a origin/main=7ed253a branches=[main pr-1234]

$ FM_HOME=<fleet> bin/fm-fleet-sync.sh nice
  nice: pruned pr-1234
  nice: STUCK: on diverged main, 2 commits behind origin/main - needs attention

### fleet after sync (must be untouched)
  nice   core.bare=true  HEAD=main local main=437b850 origin/main=4aa2641 branches=[main]
  juicy  core.bare=false HEAD=main local main=7ed253a origin/main=7ed253a branches=[main pr-1234]

==============================================================================
REJECTED ADVANCE: git refuses the ref-only update (non-fast-forward).
The script's own ancestry check screens divergence out first, so this race
guard is driven with a git shim that rejects only the ref-only 'main:main'
update exactly the way real git reports one.
==============================================================================
### fleet before sync
  nice   core.bare=true  HEAD=main local main=6452e74 origin/main=6452e74 branches=[main pr-1234]
  juicy  core.bare=false HEAD=main local main=8895e04 origin/main=8895e04 branches=[main pr-1234]

$ FM_HOME=<fleet> bin/fm-fleet-sync.sh nice
  nice: pruned pr-1234
  nice: skipped: fast-forward failed: ! [rejected] main -> main (non-fast-forward)

### fleet after sync (must be untouched)
  nice   core.bare=true  HEAD=main local main=6452e74 origin/main=9be14a2 branches=[main]
  juicy  core.bare=false HEAD=main local main=8895e04 origin/main=8895e04 branches=[main pr-1234]
```
</details>
<details>
<summary>Evidence: Reproducible end-to-end evidence script</summary>

```text
#!/usr/bin/env bash
# End-to-end evidence for the core.bare=true fleet-sync fix.
#
# Builds a two-project fleet that mirrors production:
#   projects/nice  - main checked out, but a harness hook (worktreeContext.sh)
#                    has flagged it core.bare=true (the ref-host pattern), behind
#                    origin, and carrying a merged-PR branch for the prune path.
#   projects/juicy - an ordinary non-bare clone, also behind origin.
# Then runs the real fm-fleet-sync.sh CLI over the whole fleet - once with the
# base-commit script, once with this branch's script - on identical fixtures.
set -u

EV=$(cd "$(dirname "$0")" && pwd)
ROOT=${ROOT:?set ROOT to the repo worktree}
WORK="$EV/e2e"
rm -rf "$WORK"; mkdir -p "$WORK"

export GIT_AUTHOR_NAME=fmtest GIT_AUTHOR_EMAIL=fmtest@example.invalid
export GIT_COMMITTER_NAME=fmtest GIT_COMMITTER_EMAIL=fmtest@example.invalid

# The harness hook that makes a checkout double as a ref-only fetch target.
# This is the thing that keeps re-applying core.bare=true - it is intentional,
# not corruption.
make_hook() {
  mkdir -p "$1/.claude/hooks"
  cat > "$1/.claude/hooks/worktreeContext.sh" <<'SH'
#!/usr/bin/env bash
# Flags the main checkout as a ref-host so our own tooling can advance it with a
# ref-only `git fetch origin main:main` while the branch stays checked out.
git -C "$(cd "$(dirname "$0")/../.." && pwd)" config core.bare true
SH
  chmod +x "$1/.claude/hooks/worktreeContext.sh"
}

build_fleet() {
  local home=$1 name
  mkdir -p "$home/projects" "$home/remotes"

  for name in nice juicy; do
    git init -q --bare "$home/remotes/$name.git"
    git init -q "$home/seed-$name"
    ( cd "$home/seed-$name"
      git symbolic-ref HEAD refs/heads/main
      echo "$name v0" > README.md
      git add README.md && git commit -qm "C0: initial $name"
      git remote add origin "$home/remotes/$name.git"
      git push -q -u origin main
      # A branch whose PR later merges - origin deletes it, fleet-sync prunes it.
      git checkout -q -b pr-1234
      echo "$name pr work" > feature.txt
      git add feature.txt && git commit -qm "C1: pr-1234 work"
      git push -q -u origin pr-1234
      git checkout -q main ) >/dev/null 2>&1
    git clone -q "$home/remotes/$name.git" "$home/projects/$name"
    git -C "$home/projects/$name" branch -q --track pr-1234 origin/pr-1234
  done

  # Origin moves ahead of both clones (other agents landed work).
  ( cd "$home/seed-nice"
    echo "nice v1" > README.md
    git commit -qam "C2: landed nice change"
    echo "nice v2" > README.md
    git commit -qam "C3: another landed nice change"
    git push -q origin main
    git push -q origin --delete pr-1234 ) >/dev/null 2>&1
  ( cd "$home/seed-juicy"
    echo "juicy v1" > README.md
    git commit -qam "C2: landed juicy change"
    git push -q origin main ) >/dev/null 2>&1

  # The harness flags nice as a ref-host. juicy stays an ordinary clone.
  make_hook "$home/projects/nice"
  "$home/projects/nice/.claude/hooks/worktreeContext.sh"
}

show_state() {
  local home=$1 label=$2 name
  echo "### $label"
  for name in nice juicy; do
    local p="$home/projects/$name"
    printf '  %-6s core.bare=%-5s HEAD=%s local main=%s origin/main=%s branches=[%s]\n' \
      "$name" \
      "$(git -C "$p" config --get core.bare || echo '<unset>')" \
      "$(git -C "$p" symbolic-ref --short HEAD 2>/dev/null || echo detached)" \
      "$(git -C "$p" rev-parse --short main)" \
      "$(git -C "$p" rev-parse --short origin/main)" \
      "$(git -C "$p" for-each-ref --format='%(refname:short)' refs/heads | tr '\n' ' ' | sed 's/ $//')"
  done
}

run_fleet_sync() {
  local script=$1 home=$2
  FM_HOME="$home" FM_ROOT_OVERRIDE="$ROOT" "$script" 2>&1
}

# --- the base-commit script, extracted next to its own lock lib ---------------
mkdir -p "$WORK/base-bin"
git -C "$ROOT" show 71f0b3f:bin/fm-fleet-sync.sh > "$WORK/base-bin/fm-fleet-sync.sh"
git -C "$ROOT" show 71f0b3f:bin/fm-lock-lib.sh   > "$WORK/base-bin/fm-lock-lib.sh"
chmod +x "$WORK/base-bin/fm-fleet-sync.sh"

echo "=============================================================================="
echo "BEFORE  (base 71f0b3f): fm-fleet-sync.sh over a fleet with a core.bare=true clone"
echo "=============================================================================="
build_fleet "$WORK/home-before"
show_state "$WORK/home-before" "fleet before sync"
echo
echo "\$ FM_HOME=<fleet> bin/fm-fleet-sync.sh"
run_fleet_sync "$WORK/base-bin/fm-fleet-sync.sh" "$WORK/home-before" | sed 's/^/  /'
echo
show_state "$WORK/home-before" "fleet after sync"

echo
echo "=============================================================================="
echo "AFTER   (this branch 81dfdb6): same fleet, same command"
echo "=============================================================================="
build_fleet "$WORK/home-after"
show_state "$WORK/home-after" "fleet before sync"
echo
echo "\$ FM_HOME=<fleet> bin/fm-fleet-sync.sh"
run_fleet_sync "$ROOT/bin/fm-fleet-sync.sh" "$WORK/home-after" | sed 's/^/  /'
echo
show_state "$WORK/home-after" "fleet after sync"
echo
echo "\$ .claude/hooks/worktreeContext.sh   # harness re-applies the flag; sync it again"
"$WORK/home-after/projects/nice/.claude/hooks/worktreeContext.sh"
run_fleet_sync "$ROOT/bin/fm-fleet-sync.sh" "$WORK/home-after" | sed 's/^/  /'
echo

echo "=============================================================================="
echo "STUCK BARE CLONE (real git): local main diverged from origin - never silently"
echo "advanced, never force-updated"
echo "=============================================================================="
build_fleet "$WORK/home-diverged"
NICE="$WORK/home-diverged/projects/nice"
# A commit the bare clone holds that origin does not: local main and origin/main
# have genuinely diverged.
git -C "$NICE" update-ref refs/heads/main \
  "$(git -C "$NICE" commit-tree "$(git -C "$NICE" rev-parse main^{tree})" \
       -p "$(git -C "$NICE" rev-parse main)" -m 'local-only commit')"
show_state "$WORK/home-diverged" "fleet before sync"
echo
echo "\$ FM_HOME=<fleet> bin/fm-fleet-sync.sh nice"
FM_HOME="$WORK/home-diverged" FM_ROOT_OVERRIDE="$ROOT" \
  "$ROOT/bin/fm-fleet-sync.sh" nice 2>&1 | sed 's/^/  /'
echo
show_state "$WORK/home-diverged" "fleet after sync (must be untouched)"

echo
echo "=============================================================================="
echo "REJECTED ADVANCE: git refuses the ref-only update (non-fast-forward)."
echo "The script's own ancestry check screens divergence out first, so this race"
echo "guard is driven with a git shim that rejects only the ref-only 'main:main'"
echo "update exactly the way real git reports one."
echo "=============================================================================="
build_fleet "$WORK/home-reject"
mkdir -p "$WORK/fakebin"
cat > "$WORK/fakebin/git" <<'SH'
#!/usr/bin/env bash
real=${REAL_GIT_FOR_TEST:?}
for a in "$@"; do
  case "$a" in
    *:*)
      b=${a%%:*}; b2=${a#*:}
      if [ -n "$b" ] && [ "$b" = "$b2" ]; then
        echo "From $HOME_REMOTE_FOR_TEST" >&2
        echo " ! [rejected]        $b -> $b  (non-fast-forward)" >&2
        exit 1
      fi
      ;;
  esac
done
exec "$real" "$@"
SH
chmod +x "$WORK/fakebin/git"
show_state "$WORK/home-reject" "fleet before sync"
echo
echo "\$ FM_HOME=<fleet> bin/fm-fleet-sync.sh nice"
PATH="$WORK/fakebin:$PATH" REAL_GIT_FOR_TEST="$(command -v git)" \
  HOME_REMOTE_FOR_TEST="$WORK/home-reject/remotes/nice.git" \
  FM_HOME="$WORK/home-reject" FM_ROOT_OVERRIDE="$ROOT" \
  "$ROOT/bin/fm-fleet-sync.sh" nice 2>&1 | sed 's/^/  /'
echo
show_state "$WORK/home-reject" "fleet after sync (must be untouched)"
```
</details>
- Evidence: Fixture fleet the transcript was produced from (bare `nice` + non-bare `juicy` clones and their origins) (local file: <code>/var/folders/0j/3zwwly210nbfhf4nh9b5l7mh0000gn/T/no-mistakes-evidence/01KZ85A7QM4TGVNQ8GYSR4RQSW/e2e</code>)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ⚠️ `bin/fm-fleet-sync.sh:227` - The bare-clone advance passes --quiet, which suppresses git&#39;s refspec rejection report, so the one failure mode this change singles out reports no reason at all. Verified with git 2.50.1 on a core.bare=true clone: `git fetch origin --quiet main:main` against a non-fast-forwardable origin returns rc=1 with completely empty combined output, while the same command without --quiet prints `From file://…` / `! [rejected]        main       -&gt; main  (non-fast-forward)`. Because ADVANCE_OUTPUT is empty, the guard at :432 is skipped and the operator sees only `&lt;label&gt;: skipped: fast-forward failed` — versus the non-bare merge path&#39;s `fast-forward failed: fatal: Not possible to fast-forward, aborting.`. (Other failures are unaffected: `fatal: refusing to fetch into branch &#39;refs/heads/main&#39; checked out at …`, which fires when the bare-flagged clone also has DEFAULT in a linked worktree, still prints under --quiet.) Fix: drop --quiet AND select the meaningful line — `first_line` alone is insufficient here, it would yield the misleading `fast-forward failed: From file://…`; pick the `! [rejected]` / `error:` / `fatal:` line and fall back to first_line. (Aside: the existing merge-base ancestor check at :421 already proves the fast-forward, so a purely local `git update-ref` would give a deterministic message and drop the second network round-trip per bare clone — but the fetch form was a deliberate choice to mirror the harness&#39;s own tooling, so this is only an alternative, not a request to change it.)
- ℹ️ `tests/fm-fleet-sync.test.sh:210` - The git_bare_fetch_rejects shim writes a `! [rejected] … (non-fast-forward)` line to stderr, which real git under the script&#39;s `--quiet` invocation never emits, and test_bare_clone_rejected_advance_reports_skip_untouched only asserts the `bare-reject: skipped: fast-forward failed` prefix. The test therefore passes identically whether or not a reason is reported, so it cannot detect the empty-reason gap above and gives false confidence that the skip is &#39;clear&#39;. Once the --quiet finding is fixed, tighten the assertion to also require the rejection reason in the skip line so the diagnostic is actually pinned.
- ℹ️ `bin/fm-merge-local.sh:66` - Sibling path note, not a blocker for this change: fm-merge-local.sh is the other place firstmate runs a state-changing fast-forward against a projects/ clone, and it still uses the work-tree-only `git merge --ff-only`. If a bare-flagged clone is ever a local-only project, this script&#39;s dirty check at :54 silently passes (git status fails with stderr discarded, yielding empty output) and :66 then aborts under `set -eu` with the same `fatal: this operation must be run in a work tree` that this change fixes in fleet-sync. I did not confirm that fm-project-mode.sh&#39;s project mode and the task meta&#39;s `mode=` field agree, so I am not claiming this is reachable today for the two verified clones (fleet-sync skips local-only projects at :326, and both Nice and Juicy were processed by it) — flagging it only so the work-tree assumption is a known one rather than a surprise later.

🔧 Fix: report git&#39;s reason for a rejected bare-clone advance
1 info still open:
- ℹ️ `bin/fm-fleet-sync.sh:136` - The failure_line doc comment misdescribes both the helper and git, and would mislead anyone maintaining the pattern list. It says the helper &#34;[f]alls back to the first line when no recognisable failure line is present (which is what `git merge --ff-only` produces: its &#39;fatal: Not possible to fast-forward, aborting.&#39; is already line one)&#34;. Both claims are wrong: (a) `fatal:` is one of the alternations in the grep at :143, so merge output MATCHES and never reaches the fallback branch; (b) verified with git 2.50.1, `merge --ff-only` on a diverged branch emits five `hint:` lines first and puts `fatal: Not possible to fast-forward, aborting.` LAST, not on line one — which is precisely why first_line used to report the hint preamble there. The code itself is correct (probed against four output shapes under bash and zsh: fetch-reject → `! [rejected] main -&gt; main (non-fast-forward)`, merge → the `fatal:` line, untracked-overwrite → the `error:` line, unmarked → line one). Only the comment needs fixing: state that merge output matches on `fatal:` — which for the diverging case selects the last line rather than the first — and that the fallback branch covers only output carrying no recognizable failure marker. Written that way the comment also documents the one place the shared helper differs from the old first_line on the non-bare path, which is otherwise invisible to a reader. That difference is not a behavior concern: :437&#39;s `merge-base --is-ancestor` routes divergence to STUCK at :438, so the diverging-merge fatal is unreachable here, and every reachable merge failure (`error: Your local changes…`, `error: The following untracked working tree files…`) has `error:` on line one, making failure_line byte-identical to first_line on all reachable non-bare paths.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash tests/fm-fleet-sync.test.sh` — full colocated suite, 25 tests pass including the three new cases: `test_bare_clone_behind_fast_forwards`, `test_bare_clone_already_current_unchanged`, `test_bare_clone_rejected_advance_reports_skip_untouched`</code>
- <code>Git-behavior probe on a real `core.bare=true` clone with a branch checked out: confirmed `git rev-parse --is-inside-work-tree` prints `false` but exits 0 (so the script&#39;s early guard does not short-circuit), `--is-bare-repository` returns `true`, and both `git merge --ff-only` and `git status --porcelain` die with `fatal: this operation must be run in a work tree`</code>
- <code>End-to-end CLI comparison via `ROOT=$PWD bash /var/folders/0j/3zwwly210nbfhf4nh9b5l7mh0000gn/T/no-mistakes-evidence/01KZ85A7QM4TGVNQ8GYSR4RQSW/e2e-bare-clone-fleet-sync.sh` — builds a fleet with a bare-flagged `nice` clone (flag applied by a simulated `.claude/hooks/worktreeContext.sh`) plus an ordinary `juicy` clone, both behind origin, then runs `FM_HOME=&lt;fleet&gt; bin/fm-fleet-sync.sh` under the base commit `71f0b3f` and under target `81dfdb6`</code>
- <code>Verified on the bare clone after the target run: `git config --get core.bare` still `true`, local `main` == `origin/main`, and `nice: pruned pr-1234` (the prune path, which runs before the advance, works with no work tree)</code>
- <code>Re-applied the harness hook and re-ran fleet-sync: reports `nice: already current`, showing the flag being reapplied does not reintroduce the failure</code>
- <code>Unshimmed stuck-clone check: a bare clone whose local `main` genuinely diverged reports `nice: STUCK: on diverged main, 2 commits behind origin/main - needs attention` and is left untouched</code>
- <code>Rejected-advance check with a `git` shim that refuses only the ref-only `main:main` update: reports `nice: skipped: fast-forward failed: ! [rejected] main -&gt; main (non-fast-forward)` with the clone untouched, quoting git&#39;s rejection line rather than the preceding `From &lt;url&gt;` line</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⏭️ **Lint** - skipped</summary>

- ⚠️ linter found issues (exit code 127)

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
