### PR TITLE
fix: accommodate mode-inert filesystems in PR-check migration

### DIFF
--- a/bin/fm-pr-check-migrate.sh
+++ b/bin/fm-pr-check-migrate.sh
@@ -6,6 +6,12 @@
 # registered custom checks remain armed, and every other task poll is
 # quarantined for private review. A current X-mode shim is preserved by exact
 # content, while the recognized older byte-static shim is refreshed in place.
+#
+# Private artifacts are expected at mode 0600 and the quarantine directory at
+# 0700, but some filesystems cannot enforce POSIX permission bits (a WSL2 v9fs
+# or DrvFs mount of a Windows drive reads every file back as 0777). There the
+# exact-mode assertions are skipped through fm_pr_mode_matches while every other
+# protection stays in force; bin/fm-pr-lib.sh owns that mode-inert accommodation.
 # Usage: fm-pr-check-migrate.sh [--checks-safe]
 set -u
 
@@ -97,7 +103,7 @@ private_migration_boundaries_valid() {
   fi
   if [ -e "$QUARANTINE" ] || [ -L "$QUARANTINE" ]; then
     [ -d "$QUARANTINE" ] && [ ! -L "$QUARANTINE" ] || return 1
-    [ "$(fm_pr_file_mode "$QUARANTINE")" = 700 ] || return 1
+    fm_pr_mode_matches "$QUARANTINE" 700 || return 1
     [ "$(fm_pr_file_device "$QUARANTINE")" = "$state_device" ] || return 1
     for artifact in "$QUARANTINE"/* "$QUARANTINE"/.[!.]* "$QUARANTINE"/..?*; do
       [ -e "$artifact" ] || [ -L "$artifact" ] || continue
@@ -461,7 +467,7 @@ publish_scan_marker() {
 
 quarantine_dir_valid() {
   [ -d "$QUARANTINE" ] && [ ! -L "$QUARANTINE" ] || return 1
-  [ "$(fm_pr_file_mode "$QUARANTINE")" = 700 ] || return 1
+  fm_pr_mode_matches "$QUARANTINE" 700 || return 1
   [ "$(fm_pr_file_device "$QUARANTINE")" = "$STATE_DEVICE" ]
 }
 
@@ -486,7 +492,7 @@ quarantine_tree_repair_and_validate() {
     [ "$(fm_pr_file_device "$artifact")" = "$STATE_DEVICE" ] || return 1
     [ "$(fm_pr_file_link_count "$artifact")" = 1 ] || return 1
     chmod 0600 "$artifact" || return 1
-    [ "$(fm_pr_file_mode "$artifact")" = 600 ] || return 1
+    fm_pr_mode_matches "$artifact" 600 || return 1
     [ "$(fm_pr_file_device "$artifact")" = "$STATE_DEVICE" ] || return 1
     [ "$(fm_pr_file_link_count "$artifact")" = 1 ] || return 1
   done
@@ -535,7 +541,7 @@ quarantine_artifact() {
   [ "$(fm_pr_file_link_count "$destination")" = 1 ] || return 1
   chmod 0600 "$destination" || return 1
   [ -f "$destination" ] && [ ! -L "$destination" ] || return 1
-  [ "$(fm_pr_file_mode "$destination")" = 600 ] || return 1
+  fm_pr_mode_matches "$destination" 600 || return 1
   [ "$(fm_pr_file_device "$destination")" = "$STATE_DEVICE" ] || return 1
   [ "$(fm_pr_file_link_count "$destination")" = 1 ] || return 1
   [ ! -e "$source" ] && [ ! -L "$source" ]

--- a/bin/fm-pr-lib.sh
+++ b/bin/fm-pr-lib.sh
@@ -263,10 +263,60 @@ fm_pr_sha256() {
   fi
 }
 
+# Some filesystems cannot enforce POSIX permission bits. A WSL2 v9fs or DrvFs
+# mount of a Windows drive, and some network mounts, report every file as 0777
+# no matter what chmod requested, so an exact-mode equality assertion can never
+# be satisfied there. This probe decides whether the filesystem holding <dir>
+# enforces chmod: it creates a private temp file, requests mode 0600, and reads
+# the mode back. The verdict is cached per device so the probe runs at most once
+# per filesystem. When the probe cannot run for any reason the verdict defaults
+# to enforced, so a real POSIX filesystem is never weakened by a failed probe.
+# Returns 0 when modes are enforced (strict assertions apply) and 1 when the
+# filesystem is mode-inert. The verdict is cached against the last probed device;
+# the state directory and its quarantine share one device, so one probe answers
+# every call in a run.
+FM_PR_MODE_PROBE_DEVICE=
+FM_PR_MODE_PROBE_VERDICT=
+
+fm_pr_fs_enforces_mode() {
+  local dir=$1 device probe verdict
+  device=$(fm_pr_file_device "$dir" 2>/dev/null) || device=
+  if [ -n "$device" ] && [ "$device" = "$FM_PR_MODE_PROBE_DEVICE" ]; then
+    return "$FM_PR_MODE_PROBE_VERDICT"
+  fi
+  verdict=0
+  probe=$(mktemp "$dir/.fm-mode-probe.XXXXXX" 2>/dev/null) || probe=
+  if [ -n "$probe" ]; then
+    if chmod 0600 "$probe" 2>/dev/null; then
+      [ "$(fm_pr_file_mode "$probe")" = 600 ] || verdict=1
+    fi
+    rm -f -- "$probe"
+  fi
+  if [ -n "$device" ]; then
+    FM_PR_MODE_PROBE_DEVICE=$device
+    FM_PR_MODE_PROBE_VERDICT=$verdict
+  fi
+  return "$verdict"
+}
+
+# Assert <path> has exactly <mode>, unless the filesystem holding it cannot
+# enforce chmod (see fm_pr_fs_enforces_mode), in which case the permission bits
+# carry no meaning and the equality check is skipped. Every other protection at
+# the call site (regular file, single link, expected device, content) stays in
+# force; on a mode-inert filesystem privacy comes from the OS or mount, for
+# example Windows ACLs, rather than the POSIX bits.
+fm_pr_mode_matches() {
+  local path=$1 mode=$2 dir
+  dir=${path%/*}
+  [ "$dir" != "$path" ] || dir=.
+  fm_pr_fs_enforces_mode "$dir" || return 0
+  [ "$(fm_pr_file_mode "$path")" = "$mode" ]
+}
+
 fm_pr_private_file_valid() {
   local path=$1 mode=$2 device=$3
   [ -f "$path" ] && [ ! -L "$path" ] || return 1
-  [ "$(fm_pr_file_mode "$path")" = "$mode" ] || return 1
+  fm_pr_mode_matches "$path" "$mode" || return 1
   [ "$(fm_pr_file_device "$path")" = "$device" ] || return 1
   [ "$(fm_pr_file_link_count "$path")" = 1 ]
 }

--- a/tests/fm-pr-check-security.test.sh
+++ b/tests/fm-pr-check-security.test.sh
@@ -910,6 +910,118 @@ test_migration_initializes_fresh_state() {
   pass "migration creates and validates private state before watcher exclusion"
 }
 
+# Some filesystems cannot enforce POSIX permission bits (a WSL2 v9fs or DrvFs
+# mount of a Windows drive reads every file back as 0777). fm_pr_private_file_valid
+# must skip the exact-mode equality there while keeping every other protection,
+# and must still reject a wrong-mode private file on a mode-enforcing filesystem.
+test_private_file_mode_validation_accommodates_mode_inert_fs() {
+  local dir device file
+  dir="$TMP_ROOT/mode-inert-private-file"
+  mkdir -p "$dir"
+  device=$(fm_pr_file_device "$dir") || fail "could not read fixture device"
+  file="$dir/marker"
+  printf 'x\n' > "$file"
+
+  # The temp filesystem enforces modes, so the probe must report enforcement and
+  # the validator must reject a world-readable private file but accept 0600.
+  fm_pr_fs_enforces_mode "$dir" \
+    || fail "probe reported a mode-enforcing filesystem as mode-inert"
+  chmod 0644 "$file"
+  ! fm_pr_private_file_valid "$file" 600 "$device" \
+    || fail "mode-enforcing filesystem accepted a world-readable private marker"
+  chmod 0600 "$file"
+  fm_pr_private_file_valid "$file" 600 "$device" \
+    || fail "mode-enforcing filesystem rejected a correct 0600 private marker"
+
+  # Simulate a mode-inert filesystem by stubbing the probe to report no
+  # enforcement. The exact-mode check is skipped, but the regular-file, single-
+  # link, and device protections stay in force.
+  local real_probe
+  real_probe=$(declare -f fm_pr_fs_enforces_mode)
+  fm_pr_fs_enforces_mode() { return 1; }
+  chmod 0644 "$file"
+  fm_pr_private_file_valid "$file" 600 "$device" \
+    || fail "mode-inert filesystem rejected a private marker on its permission bits"
+  ln -s "$file" "$dir/link"
+  ! fm_pr_private_file_valid "$dir/link" 600 "$device" \
+    || fail "mode-inert filesystem accepted a symlinked private marker"
+  ! fm_pr_private_file_valid "$file" 600 999999 \
+    || fail "mode-inert filesystem accepted a private marker on the wrong device"
+  eval "$real_probe"
+  pass "private-file validation skips only exact mode on a mode-inert filesystem"
+}
+
+# The non-executing migration arms the watcher's PR checks. On a mode-inert
+# state filesystem its 0600/0700 assertions can never be satisfied, so before
+# this accommodation the migration failed permanently and the watcher refused to
+# run. A stat shim reproduces that filesystem by reporting every mode as 0777
+# while device, inode, and link count stay real; the migration must complete and
+# --checks-safe must exit 0 so the watcher can arm.
+test_migration_completes_on_mode_inert_fs() {
+  local dir state fakebin rc
+  dir="$TMP_ROOT/migration-mode-inert"
+  state="$dir/home/state"
+  fakebin="$dir/fakebin"
+  mkdir -p "$dir/home" "$fakebin"
+  cat > "$fakebin/stat" <<'SH'
+#!/usr/bin/env bash
+# Mode-inert filesystem simulation: permission bits always read back as 0777
+# while device, inode, and link count pass through to the real stat.
+for arg in "$@"; do
+  case "$arg" in
+    '%a'|'%Lp') printf '%s\n' 777; exit 0 ;;
+  esac
+done
+exec "${FM_TEST_REAL_STAT:?}" "$@"
+SH
+  chmod +x "$fakebin/stat"
+
+  # Confirm the shim actually reports an inert mode, so a passing migration below
+  # is proof of the accommodation rather than a vacuous run.
+  printf 'x\n' > "$dir/probe"
+  chmod 0600 "$dir/probe"
+  [ "$(FM_TEST_REAL_STAT="$REAL_STAT" PATH="$fakebin:$BASE_PATH" stat -c %a "$dir/probe")" = 777 ] \
+    || fail "mode-inert stat shim did not report inert permission bits"
+
+  set +e
+  FM_TEST_REAL_STAT="$REAL_STAT" FM_HOME="$dir/home" PATH="$fakebin:$BASE_PATH" \
+    "$MIGRATE" --checks-safe > "$dir/migrate-safe.out" 2> "$dir/migrate-safe.err"
+  rc=$?
+  set -e
+  [ "$rc" -eq 0 ] \
+    || fail "mode-inert --checks-safe migration failed so the watcher cannot arm: $(cat "$dir/migrate-safe.err")"
+  [ -f "$state/.pr-check-migration-scan-v1" ] && [ ! -L "$state/.pr-check-migration-scan-v1" ] \
+    || fail "mode-inert --checks-safe migration did not publish a scan marker"
+  grep -qxF fm-pr-check-migration-scan-v1 "$state/.pr-check-migration-scan-v1" \
+    || fail "mode-inert scan marker bytes were not exact"
+
+  set +e
+  FM_TEST_REAL_STAT="$REAL_STAT" FM_HOME="$dir/home" PATH="$fakebin:$BASE_PATH" \
+    "$MIGRATE" > "$dir/migrate.out" 2> "$dir/migrate.err"
+  rc=$?
+  set -e
+  [ "$rc" -eq 0 ] || fail "mode-inert full migration failed: $(cat "$dir/migrate.err")"
+  [ -f "$state/.pr-check-migration-v1" ] && [ ! -L "$state/.pr-check-migration-v1" ] \
+    || fail "mode-inert migration did not publish a completion marker"
+  grep -qxF fm-pr-check-migration-v1 "$state/.pr-check-migration-v1" \
+    || fail "mode-inert migration marker bytes were not exact"
+
+  # Regression guard: on the mode-enforcing temp filesystem (no shim) the same
+  # migration still completes and still writes strict 0600 private markers.
+  dir="$TMP_ROOT/migration-mode-enforcing"
+  state="$dir/home/state"
+  mkdir -p "$dir/home"
+  set +e
+  FM_HOME="$dir/home" PATH="$BASE_PATH" "$MIGRATE" --checks-safe \
+    > "$dir/migrate.out" 2> "$dir/migrate.err"
+  rc=$?
+  set -e
+  [ "$rc" -eq 0 ] || fail "mode-enforcing migration failed: $(cat "$dir/migrate.err")"
+  assert_valid_scan_marker "$state/.pr-check-migration-scan-v1"
+  assert_valid_migration_marker "$state/.pr-check-migration-v1"
+  pass "migration arms the watcher on a mode-inert filesystem and stays strict on a mode-enforcing one"
+}
+
 test_private_artifact_paths_refuse_symlinks_and_directories() {
   local artifact kind dir state destination rc
   for artifact in task-a.pr-poll task-a.pr-poll-registration task-a.check.sh; do
@@ -3342,6 +3454,8 @@ test_atomic_interruption_leaves_no_partial_artifact
 test_concurrent_watcher_sees_only_complete_publication
 test_postrename_poll_validation_revokes_and_retries
 test_migration_initializes_fresh_state
+test_private_file_mode_validation_accommodates_mode_inert_fs
+test_migration_completes_on_mode_inert_fs
 test_migration_excludes_older_watcher_before_scan
 test_private_artifact_paths_refuse_symlinks_and_directories
 test_marker_and_diagnostic_rename_fail_closed


### PR DESCRIPTION
## Summary

On a filesystem that cannot enforce POSIX permission bits - a WSL2 `v9fs`/DrvFs mount of a Windows drive reads every file back as `0777` no matter what `chmod` requested - the PR-check migration's exact `0600`/`0700` assertions can never be satisfied. `fm-pr-check-migrate.sh --checks-safe` then exits 1 ("PR check migration blocked; refusing to execute state checks") and the watcher never arms, so supervision stays down for the whole session on a home whose `state/` lives on a Windows drive.

## Change

- Add a cached `fm_pr_fs_enforces_mode` probe: create a private temp file, `chmod 0600`, read the mode back, and cache the verdict per device. It defaults to "enforced" whenever it cannot run, so a real POSIX filesystem is never weakened by a failed probe.
- Add `fm_pr_mode_matches`, which skips **only** the exact-mode equality on a mode-inert filesystem and keeps every other protection at the call site (regular file, single hard link, expected device, content) fully in force.
- Route the private-artifact and quarantine mode assertions through the new helper.

## Testing

- New coverage in `tests/fm-pr-check-security.test.sh` exercises both an enforcing filesystem (strict assertions still apply) and a mode-inert one (equality skipped, other guards intact).
- Verified `fm-pr-check-migrate.sh --checks-safe` returns 0 on an affected `v9fs` `state/` directory.

Related watcher-down reports on Windows-drive homes: #1692, #1685, #1694.
