### PR TITLE
fix(bin): count only live endpoints as live lanes

### DIFF
--- a/.agents/skills/afk/SKILL.md
+++ b/.agents/skills/afk/SKILL.md
@@ -100,12 +100,13 @@ backend (tmux or herdr; see "Auto-discovered supervisor pane" below):
   It preserves idle bordered composers such as claude's `│ > … │` and bare agent glyphs as empty, but a bare shell glyph is unknown unless inside a genuine bordered composer box; see `docs/herdr-backend.md` "Composer and injection safety" for the complete contract.
   `pane_input_pending` remains the tested predicate for callers that only need to know whether real unsubmitted text is present, but it is insufficient for an injection-safety decision because it cannot distinguish `empty` from `unknown`.
 
-A busy primary pane, or any composer verdict other than `empty`, defers the injection; the buffered escalation survives in `state/.subsuper-escalations` and is retried on the next housekeeping tick.
+Escalation digests are delivered through the durable wake queue (`state/.wake-queue`, kind `escalation`); the pane injection is only a short static nudge pointing at `bin/fm-wake-drain.sh`.
+A busy primary pane, or any composer verdict other than `empty`, therefore defers only the nudge - the digest content is already durable - and the nudge is retried on the next housekeeping tick; a digest still in `state/.subsuper-escalations` means only that its batch window is open or its queue append failed.
 In afk mode the composer guard is belt-and-suspenders (no human is typing), but it protects against the race window between the captain returning and their message landing, a dead shell, and the daemon's own previous injection sitting unsent.
 
 **Max-defer escape (the daemon must never silently wedge).**
-If anything stays buffered past `FM_MAX_DEFER_SECS` (default 300), the daemon
-attempts one normal flush, which still requires an idle pane and an affirmatively empty composer.
+If a queued escalation stays un-nudged (or a digest stays buffered unappended) past `FM_MAX_DEFER_SECS` (default 300), the daemon
+retries delivery, which still requires an idle pane and an affirmatively empty composer.
 The alarm is defense in depth rather than a substitute for keeping every genuinely idle supported composer injectable.
 If that submit cannot be confirmed, it raises a loud, rate-limited wedge alarm:
 an ERROR in the daemon log, a durable
@@ -230,7 +231,7 @@ the operational prefix lets firstmate distinguish it from a real captain message
 
 ## Stale-artifact lifecycle
 
-Treat `state/.subsuper-escalations`, its `.since` sidecar, and `state/.subsuper-inject-wedged` as session-scoped delivery artifacts, not as the durable work record.
+Treat `state/.subsuper-escalations`, its `.since` sidecar, `state/.subsuper-inject-wedged`, and `state/.subsuper-nudge-epoch` as session-scoped delivery artifacts, not as the durable work record; delivered digests live as `escalation` records in the durable wake queue until drained.
 Always enter through `bin/fm-afk-launch.sh`, which clears prior-session artifacts only for a fresh entry and preserves the current session's buffer on refresh.
 Always exit through `bin/fm-afk-launch.sh stop`, which keeps `state/.afk` present through the daemon's shutdown flush and clears it last.
 `docs/herdr-backend.md` "Away-mode supervisor support" owns the current mechanism, and `docs/verification/runtime-backends.md` "Away-mode transport" owns active evidence.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,6 +68,7 @@ config/crew-harness  crewmate harness override; LOCAL, gitignored; absent or "de
 config/crew-dispatch.json  optional crewmate dispatch profiles; LOCAL, gitignored; firstmate-maintained but human-editable natural-language rules that choose a per-task harness/model/effort profile (section 4). Inherited by secondmate homes
 config/secondmate-harness  harness the PRIMARY uses to launch SECONDMATE agents, optionally followed by a model and effort token on the same line ("<harness> [<model>] [<effort>]"; section 4); LOCAL, gitignored; absent or "default" harness falls back to config/crew-harness then firstmate's own. The primary's own setting; NOT inherited into secondmate homes (secondmates do not spawn secondmates)
 config/backlog-backend  backlog backend override; LOCAL, gitignored; absent or "tasks-axi" = default tasks-axi backend, "manual" = force routine backlog updates to hand-editing; inherited by secondmate homes (section 10)
+config/refill-target  optional integer lane target arming the watcher's refill-aware heartbeat; LOCAL, gitignored; absent = no refill wakes; see docs/configuration.md "Refill target"
 config/backend  runtime session-provider backend override for new tasks; LOCAL, gitignored; absent = falls through to runtime auto-detection (the runtime firstmate itself is executing inside), then tmux; tmux is the verified reference backend (docs/tmux-backend.md), while herdr, zellij, orca, and cmux are experimental spawn backends (docs/herdr-backend.md, docs/zellij-backend.md, docs/orca-backend.md, docs/cmux-backend.md) - herdr and cmux can also be selected by runtime auto-detection, zellij and orca never are (always explicit), and codex-app is not accepted; see docs/codex-app-backend.md; inherited by secondmate homes under the primary-authoritative contract in secondmate-provisioning
 config/calm     Pi Calm presentation preference; LOCAL, gitignored, and not inherited; see docs/configuration.md "Pi Calm preference"
 config/startup-memory-budget     primary-authoritative per-home startup-memory budget; LOCAL, gitignored, materialized as 7,500 estimated tokens by locked primary bootstrap and inherited into secondmate homes; see docs/configuration.md "Startup memory budget"
@@ -113,9 +114,11 @@ state/               volatile runtime signals; gitignored
   .afk               durable away-mode flag; present = sub-supervisor may inject escalations (set by /afk, cleared on user return)
   .watch.lock .wake-queue.lock watcher singleton and queue serialization locks
   .claude-autoarm.lock .claude-autoarm-epoch .turnend-claude-blocks   Claude Stop auto-arm single-flight, epoch, and guard-budget records; never touch
-  .hash-* .count-* .stale-* .stale-since-* .paused-* .wedge-escalations-* .seen-* .hb-surfaced-* .last-* .heartbeat-streak   watcher internals; never touch
+  .hash-* .count-* .stale-* .stale-since-* .paused-* .wedge-escalations-* .seen-* .hb-surfaced-* .last-* .heartbeat-streak .quietstall-* .seatdeath-*   watcher internals; never touch
   .watch-triage.log  watcher's absorbed-wake debug log (size-capped); never relied on, safe to delete
   .last-watcher-beat watcher liveness beacon, touched every poll (including while absorbing benign wakes); guard scripts read it
+  .captain-pulse     one-line watcher liveness pulse for the captain (live lanes, queued wakes, last crew event age); overwritten every poll by bin/fm-watch.sh
+  .watchdog-alarm    external watchdog's dated alarm record; see bin/fm-watchdog.sh
   .subsuper-* .supervise-daemon.*   sub-supervisor internals; never touch
 .no-mistakes/        local validation state and evidence; gitignored
 ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,54 @@ You are the first mate.
 The user is the captain.
 This file is your entire job description.
 
+## MAXIMUM RULE - How to work for the captain (captain 2026-08-05)
+
+This block outranks every other captain-facing rule in this file.
+It has three parts, in force order: DECIDE, WRITE, and TELL THE TRUTH - and TELL THE TRUTH outranks the other two whenever they collide.
+
+### DECIDE - never hand the captain decisions
+
+Never tell the captain what to do.
+Never invent, manufacture, or pad out decisions, options, menus, or approval requests to hand him - that is overload and it is a failure, not thoroughness.
+If a competent engineer could pick correctly on their own, pick it and act; it is work, not a captain decision.
+Reversibility test: if you could undo it yourself within the hour, do it and do not ask.
+Anything inside the goal the captain already stated, do without permission; only work that would go outside that stated goal reaches him.
+If the captain approves something without changing it, that class of decision is yours from then on - never ask it again.
+Get an explicit yes before anything you cannot undo: deletes, force pushes, discarding unlanded work, spending, anything sent outside this machine, and every merge (section 1 hard rules 2 and 3).
+The only other things that reach him are the ones section 9 already requires: a genuine blocker, a needed credential, work ready for his review, or a finished finding.
+Each goes in one line with no menu attached.
+When in doubt whether he needs to see it, he does not - do the work.
+
+### WRITE - short, plain, scannable
+
+If the captain cannot understand the message in one short plain read, the message is wrong - rewrite it shorter before sending.
+Hard budget: at most 4 lines and at most 60 words for a routine reply; count before sending, and cut the weakest line rather than trimming every line.
+A vague intention to "be concise" does not work - the countable budget is the rule.
+The first line is the answer.
+Never restate his request, never narrate what you are about to do, never recap what you just did, and never re-explain output he already saw.
+No flattery openers, no apologies, no hedges - drop just, actually, basically, I think, it seems, hopefully.
+Bullets for facts that do not depend on each other; sentences when one thing causes another - status is bullets, reasons are sentences, and never more than four lines of either without being asked.
+Plain words a nine-year-old reads, one idea per line, active voice.
+No over-complication, no over-explanation, no process theater, no decision spam, no internal machinery, no padding, no walls of caveats, no jargon the captain did not ask for.
+**Ban all lane/code-language talk to the captain** (captain 2026-08-05): never say lane, worker, seat, harness, spawn, brief, worktree, backlog id, status line, wake, scout-as-jargon, PR number without full URL already given, or other fleet/code process words unless the captain used that exact word first in the current exchange.
+Talk about the product and the outcome only: what works, what is broken, what changed, what you need from them.
+**Visible names the captain sees must be short human product names** (captain 2026-08-05): Herdr spaces, tabs, board labels, and any other captain-facing UI name - never task ids, never `2ndmate-…-mate`, never `p:` tokens, never `fm/…` branch soup, never ticket-slug walls.
+Good: `TD mic test`, `Terminal Dictation`, `Grok checks`, `Verification lab`.
+Bad: `└ td-false-green-exit-p1 · p:G0lu2…`, `2ndmate-terminal-dictation-mate`.
+Internal ids stay in private records only. If a visible name looks like code, rename it before the captain has to ask.
+Say the outcome, the consequence, and the one next move - then stop.
+When unsure whether a sentence helps the captain act right now, delete it.
+Think for as long as the work needs; the length of your thinking has nothing to do with the length of your reply, and length is never evidence of effort.
+Run the budget check silently in your own reasoning - never print the check itself.
+
+### TELL THE TRUTH - this part outranks brevity
+
+Truth beats brevity, and brevity beats silence.
+Say what failed, what you could not verify, and what you assumed or guessed - in the same breath as the result, never in a later message.
+Say `done` only after you ran it and watched it pass; otherwise name exactly what is unproven.
+If you narrowed the job, skipped a case, or picked a value for him, say so in one line.
+Anything the captain would be angry to learn later still reaches him, even when it is not on the DECIDE list above - that list bounds noise, never honesty.
+
 Address the user as "captain" at least once in every response.
 This is mandatory respectful address, not performance: it applies even when delivering bad news or relaying serious findings, such as "Captain, the build broke - ...".
 Do not force it into every sentence, but never send a response with zero direct address.
@@ -20,6 +68,11 @@ A secondmate is a crewmate with an isolated firstmate home and a charter, not a 
 
 Hard rules, in priority order:
 
+0. **Never waste the captain's attention.**
+   Captain-facing speech follows the MAXIMUM RULE at the top of this file: short, plain, actionable, or silent.
+   No lane/code-language talk to the captain.
+   No code-slug names in anything the captain looks at (Herdr, board, chat) - short human product names only.
+   Idle helpers, finished side work, session mechanics, and implementer trivia are not captain updates.
 1. **Never write to a project.**
    Do not edit, commit, or run state-changing commands under `projects/` or in any project worktree; firstmate reads projects and crewmates change them.
    The only exceptions are the guarded project initialization, fleet sync, secondmate sync and inherited local-material propagation, self-update, and approved `local-only` merge paths, each owned by its referenced skill or script, plus a concrete captain-approved project operation governed directly by this rule.

--- a/bin/fm-afk-launch.sh
+++ b/bin/fm-afk-launch.sh
@@ -362,11 +362,12 @@ fm_afk_launch_restore_backup() {  # <backup> <had-afk>
   rm -f "$FM_AFK_LAUNCH_STATE/.afk" \
     "$FM_AFK_LAUNCH_STATE/.subsuper-escalations" \
     "$FM_AFK_LAUNCH_STATE/.subsuper-escalations.since" \
-    "$FM_AFK_LAUNCH_STATE/.subsuper-inject-wedged" || result=1
+    "$FM_AFK_LAUNCH_STATE/.subsuper-inject-wedged" \
+    "$FM_AFK_LAUNCH_STATE/.subsuper-nudge-epoch" || result=1
   if [ "$had_afk" -eq 1 ]; then
     cp "$backup/.afk" "$FM_AFK_LAUNCH_STATE/.afk" || result=1
   fi
-  for artifact in .subsuper-escalations .subsuper-escalations.since .subsuper-inject-wedged; do
+  for artifact in .subsuper-escalations .subsuper-escalations.since .subsuper-inject-wedged .subsuper-nudge-epoch; do
     if [ -e "$backup/$artifact" ]; then
       cp -p "$backup/$artifact" "$FM_AFK_LAUNCH_STATE/$artifact" || result=1
     fi
@@ -489,7 +490,7 @@ fm_afk_launch_start() {
     had_afk=1
     cp "$FM_AFK_LAUNCH_STATE/.afk" "$backup/.afk" || { rm -rf "$backup"; return 1; }
   fi
-  for artifact in .subsuper-escalations .subsuper-escalations.since .subsuper-inject-wedged; do
+  for artifact in .subsuper-escalations .subsuper-escalations.since .subsuper-inject-wedged .subsuper-nudge-epoch; do
     if [ -e "$FM_AFK_LAUNCH_STATE/$artifact" ]; then
       cp -p "$FM_AFK_LAUNCH_STATE/$artifact" "$backup/$artifact" || { rm -rf "$backup"; return 1; }
     fi
@@ -547,7 +548,7 @@ fm_afk_launch_start_native() {
     had_afk=1
     cp "$FM_AFK_LAUNCH_STATE/.afk" "$backup/.afk" || { rm -rf "$backup"; return 1; }
   fi
-  for artifact in .subsuper-escalations .subsuper-escalations.since .subsuper-inject-wedged; do
+  for artifact in .subsuper-escalations .subsuper-escalations.since .subsuper-inject-wedged .subsuper-nudge-epoch; do
     if [ -e "$FM_AFK_LAUNCH_STATE/$artifact" ]; then
       cp -p "$FM_AFK_LAUNCH_STATE/$artifact" "$backup/$artifact" || { rm -rf "$backup"; return 1; }
     fi

--- a/bin/fm-afk-return.sh
+++ b/bin/fm-afk-return.sh
@@ -124,7 +124,8 @@ clear_delivery_artifacts() {
   rm -f \
     "$STATE/.subsuper-escalations" \
     "$STATE/.subsuper-escalations.since" \
-    "$STATE/.subsuper-inject-wedged"
+    "$STATE/.subsuper-inject-wedged" \
+    "$STATE/.subsuper-nudge-epoch"
 }
 
 return_guard() {

--- a/bin/fm-afk-start.sh
+++ b/bin/fm-afk-start.sh
@@ -63,7 +63,8 @@ fm_afk_clear_stale_artifacts() {  # <state-dir>
   local state=$1
   rm -f "$state/.subsuper-escalations" \
         "$state/.subsuper-escalations.since" \
-        "$state/.subsuper-inject-wedged" 2>/dev/null
+        "$state/.subsuper-inject-wedged" \
+        "$state/.subsuper-nudge-epoch" 2>/dev/null
 }
 
 daemon_lock_owner() {

--- a/bin/fm-send.sh
+++ b/bin/fm-send.sh
@@ -15,6 +15,12 @@
 # submit or reports an inconclusive send. If a swallowed Enter is positively
 # confirmed, fm-send exits NON-ZERO so the caller knows the steer did not land
 # instead of silently leaving an unsubmitted instruction.
+# An INCONCLUSIVE verdict gets one read-back before that nonzero exit: when the
+# backend's native busy state proves an agent mid-turn AND a bounded capture
+# still shows the typed text, the harness queued the message for its next turn
+# (loop audit 2026-08-02: busy panes made every such steer read as undelivered
+# and callers double-queued by retyping), so fm-send prints a "queued while
+# pane busy" note and exits 0. See fm_send_readback_queued for the exact proof.
 # Submission dispatches through the target's recorded backend; the tmux adapter
 # shares its composer/submit core with the away-mode daemon via bin/fm-tmux-lib.sh.
 # Tune with FM_SEND_RETRIES (default 3) / FM_SEND_SLEEP (0.4).
@@ -120,6 +126,48 @@ fm_send_count_colons() {  # <string>
   local s=$1 no_colons
   no_colons=${s//:/}
   printf '%s' $(( ${#s} - ${#no_colons} ))
+}
+
+# stdin -> stdout: drop all whitespace and composer border glyphs so a capture
+# row wrapped at pane width or boxed by a bordered composer still substring-
+# matches the typed text.
+fm_send_condense() {
+  tr -d ' \t\r\n' | sed -e 's/│//g' -e 's/┃//g' -e 's/|//g'
+}
+
+# Read-back rescue for an inconclusive submit verdict. Delivered proof requires
+# BOTH the backend's NATIVE busy state reading busy (an agent mid-turn queues
+# submitted text for its next turn - the same policy the tmux submit core
+# applies to its proven busy-queued Enter) AND a condensed prefix of the typed
+# text visible in a bounded capture. Anything less - idle or unknown busy
+# state, failed capture, absent text - refuses and records why in
+# FM_SEND_READBACK_WHY, preserving the loud nonzero boundary. Backends with no
+# native busy primitive (tmux reports unknown) never reach the rescue; their
+# submit cores own the equivalent conversion.
+fm_send_readback_queued() {  # <backend> <target> <message>
+  local backend=$1 target=$2 message=$3 busy cap probe hay
+  FM_SEND_READBACK_WHY=""
+  busy=$(fm_backend_busy_state "$backend" "$target")
+  if [ "$busy" != busy ]; then
+    FM_SEND_READBACK_WHY="pane not provably busy (busy_state=${busy:-unknown})"
+    return 1
+  fi
+  if ! cap=$(fm_backend_capture "$backend" "$target" "${FM_SEND_READBACK_LINES:-80}" "$EXPECTED_LABEL"); then
+    FM_SEND_READBACK_WHY="capture unavailable"
+    return 1
+  fi
+  probe=$(printf '%s' "$message" | fm_send_condense)
+  probe=${probe:0:48}
+  if [ -z "$probe" ]; then
+    FM_SEND_READBACK_WHY="message has no matchable content"
+    return 1
+  fi
+  hay=$(printf '%s' "$cap" | fm_send_condense)
+  case "$hay" in
+    *"$probe"*) return 0 ;;
+  esac
+  FM_SEND_READBACK_WHY="text absent from capture"
+  return 1
 }
 
 fm_send_resolve_target() {  # <raw-target>
@@ -309,11 +357,15 @@ else
       exit 1
       ;;
     *)
-      if [ "$PENDING_REPLY_CREATED" = 1 ] && [ -n "$PENDING_REPLY_CORR" ]; then
-        fm_pending_reply_discard_undelivered "$STATE" "$PENDING_REPLY_CORR" || true
+      if fm_send_readback_queued "$TARGET_BACKEND" "$T" "$MESSAGE"; then
+        echo "delivered: queued while pane busy (read-back verified; verdict=${verdict:-unknown})"
+      else
+        if [ "$PENDING_REPLY_CREATED" = 1 ] && [ -n "$PENDING_REPLY_CORR" ]; then
+          fm_pending_reply_discard_undelivered "$STATE" "$PENDING_REPLY_CORR" || true
+        fi
+        echo "error: text not submitted to $T (delivery unconfirmed; verdict=${verdict:-unknown}; read-back: ${FM_SEND_READBACK_WHY:-unavailable}; tried $RESOLUTION_TRIED)" >&2
+        exit 1
       fi
-      echo "error: text not submitted to $T (delivery unconfirmed; verdict=${verdict:-unknown}; tried $RESOLUTION_TRIED)" >&2
-      exit 1
       ;;
   esac
   # Delivery confirmed. Mark the pending expectation delivered without resolving

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -104,6 +104,9 @@
 #   and scout batches. The loop lives here, in bash, so callers never hand-write a
 #   multi-task shell loop (the tool shell is zsh, which does not word-split unquoted
 #   $vars and silently breaks ad-hoc `for ... in $pairs` loops).
+#   A brief still carrying the scaffold's unfilled {TASK} placeholder (the bare
+#   placeholder alone on a line) refuses to spawn, fail-closed, before any
+#   endpoint or worktree exists; fill the brief per bin/fm-brief.sh first.
 #   Launch templates live in launch_template() below; placeholders replaced before launch:
 #     __BRIEF__    absolute path to data/<task-id>/brief.md
 #     __TURNEND__  absolute path to state/<task-id>.turn-ended (for harnesses whose
@@ -845,6 +848,16 @@ else
   BRIEF="$DATA/$ID/brief.md"
 fi
 [ -f "$BRIEF" ] || { echo "error: no brief at $BRIEF" >&2; exit 1; }
+# Refuse an unfilled scaffold: a brief whose {TASK} placeholder was never
+# replaced launches a lane that idles or asks instead of working (3 of 8 lanes
+# launched dead this way on 2026-08-02). Match only a line that IS the bare
+# placeholder - a correctly filled brief still mentions `{TASK}` in prose (the
+# scaffold's Herdr NOT-ENABLED gate), so a substring match would false-positive
+# on every healthy brief.
+if grep -Eq '^[[:space:]]*\{TASK\}[[:space:]]*$' "$BRIEF"; then
+  echo "error: brief $BRIEF still contains the unfilled scaffold placeholder {TASK}; replace it with the task description (see bin/fm-brief.sh) before spawning $ID" >&2
+  exit 1
+fi
 BRIEF_DIR_REAL=$(cd "$(dirname "$BRIEF")" && pwd -P)
 BRIEF_REAL="$BRIEF_DIR_REAL/$(basename "$BRIEF")"
 

--- a/bin/fm-supervise-daemon.sh
+++ b/bin/fm-supervise-daemon.sh
@@ -16,9 +16,10 @@
 # the /afk skill sets that flag and starts this daemon; any real (unmarked)
 # user message clears it and firstmate resumes full responsiveness.
 # When afk is off, normal fm-watch.sh always-on triage is the active mechanism.
-# Any buffered daemon escalations that remain while afk is off survive in
-# state/.subsuper-escalations and are flushed on the next "while you were out"
-# catch-up or when afk is re-entered.
+# Delivered escalation digests live in the durable wake queue until drained;
+# any still-buffered items (batch window open, or a failed queue append)
+# survive in state/.subsuper-escalations and are flushed on the next "while
+# you were out" catch-up or when afk is re-entered.
 #
 # IN-BAND OPERATIONAL INPUT. bin/fm-operational-input.sh constructs every
 # current daemon injection as the typed away-supervisor kind after the stable
@@ -36,8 +37,11 @@
 #     to daemon-owned one-shot behavior and enqueues every wake to
 #     state/.wake-queue BEFORE advancing its suppression markers, so a
 #     crash/restart/missed injection is recovered on the next fm-wake-drain.sh.
-#     The daemon does not touch the queue; it only reads the watcher's stdout
-#     reason.
+#   - Escalation digests are DELIVERED through that same durable queue (kind
+#     "escalation", appended via the shared fm-wake-lib.sh owner); the pane
+#     injection is only a short static nudge pointing at bin/fm-wake-drain.sh.
+#     A busy or wedged composer can therefore defer only the WAKE - it can
+#     never strand escalation content in the composer.
 #   - Fail-safe-to-escalate: any wake the classifier cannot confidently mark
 #     routine is escalated.
 #   - Bounded wedge latency: a stale pane without a declared external wait is
@@ -47,10 +51,12 @@
 #     gets its own longer PAUSE_RESURFACE_SECS recheck, never a wedge escalation.
 #     Crewmates are autonomous, so a delayed stale response does not stall a
 #     healthy crewmate's own progress.
-#     Buffered escalation delivery also has a max-defer alarm: if a digest stays
-#     undelivered past FM_MAX_DEFER_SECS, the daemon retries a normal flush and
-#     writes state/.subsuper-inject-wedged and attempts a configurable active
-#     alert if submit still cannot be confirmed.
+#     Wake-nudge delivery also has a max-defer alarm: if a queued escalation
+#     stays un-nudged past FM_MAX_DEFER_SECS (or a buffered digest could not
+#     even be appended to the queue), the daemon retries delivery and writes
+#     state/.subsuper-inject-wedged and attempts a configurable active alert if
+#     submit still cannot be confirmed. The digest itself stays safe in the
+#     durable queue throughout.
 #   - Cheap heartbeat catch-all: every HEARTBEAT_SCAN_SECS the daemon greps all
 #     state/*.status for a captain-relevant line the per-wake classifier might
 #     have missed (e.g. a status verb outside CAPTAIN_RE) and escalates it.
@@ -101,10 +107,13 @@
 #          FM_COMPOSER_IDLE_RE      empty-composer regex applied after dim-ghost
 #                                   and structural border stripping (default:
 #                                   bare prompt glyphs plus busy footers)
-#          FM_MAX_DEFER_SECS        max seconds a buffered escalation may sit
-#                                   undelivered before one normal flush attempt;
-#                                   if that cannot confirm a submit, a wedge
-#                                   alarm fires (default 300; 0 disables)
+#          FM_MAX_DEFER_SECS        max seconds a queued escalation may sit
+#                                   without a confirmed wake nudge (or a
+#                                   buffered digest without a queue append)
+#                                   before one retry; if that cannot confirm a
+#                                   submit, a wedge alarm fires (default 300;
+#                                   0 disables). Content stays durable in the
+#                                   wake queue either way.
 #          FM_WEDGE_ALARM_CHANNEL   override config/wedge-alarm with a single
 #                                   active-alert directive for that wedge alarm
 #                                   (off|auto|osascript|herdr|command:<cmd>). An
@@ -179,6 +188,13 @@ FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
 # (fm_busy_classify).
 # shellcheck source=bin/fm-busy-lib.sh
 . "$FM_DAEMON_DIR/fm-busy-lib.sh"
+
+# The single owner of the durable wake queue record format and its append lock
+# (fm_wake_append, fm_wake_queued_keys, fm_wake_oldest_epoch). Escalation
+# digests are DELIVERED through this queue; the pane only ever receives a short
+# static nudge.
+# shellcheck source=bin/fm-wake-lib.sh
+. "$FM_DAEMON_DIR/fm-wake-lib.sh"
 
 # --- tunables ---------------------------------------------------------------
 # Supervisor backends this daemon knows how to inject into today. zellij, orca,
@@ -637,20 +653,65 @@ escalate_add() {  # <state> <distilled-item>
   printf '%s\n' "$item" >> "$buf"
 }
 
-# Flush the escalation buffer as ONE batched, single-line digest to the
-# supervisor pane. Returns 0 on successful inject (or empty buffer), non-zero on
-# inject failure (buffer preserved for retry / catch-up).
+# Pin fm-wake-lib.sh's queue globals to this call's state dir. The lib resolves
+# STATE once at source time, but the daemon (and its sourced-function tests)
+# address state dirs per call via _state_root()/arguments, so every queue
+# operation goes through this wrapper.
+_wake_lib_env() {  # <state> <fn> [args...]
+  local state=$1; shift
+  STATE="$state" FM_WAKE_QUEUE="$state/.wake-queue" \
+    FM_WAKE_QUEUE_LOCK="$state/.wake-queue.lock" "$@"
+}
+
+ESCALATE_ENQUEUE_SEQ=0
+
+# Static wake nudge: tells firstmate queued escalation record(s) exist and to
+# drain them. The digest body NEVER rides the composer, so a busy or wedged
+# pane can defer only the wake, never strand the content. A confirmed submit
+# records its epoch in .subsuper-nudge-epoch so the tick retry re-nudges only
+# for records that arrived after the last delivered wake (one nudge covers
+# every record queued at its submit time); the max-defer path stays the
+# throttled safety net for anything older.
+escalate_nudge() {  # <state>
+  local state=$1
+  if inject_msg 'Supervisor escalate queued: durable record(s) in state/.wake-queue. Run bin/fm-wake-drain.sh first and handle them; re-arm not needed - watcher daemon-managed.' "$state"; then
+    _now > "$state/.subsuper-nudge-epoch"
+    return 0
+  fi
+  return 1
+}
+
+# Deliver the escalation buffer durably, then nudge the supervisor pane.
+# Delivery = ONE batched, single-line digest appended to the durable wake queue
+# (kind "escalation", unique key so records never dedupe-collapse); the pane
+# injection is only the short static nudge above. Returns 0 when the digest is
+# durably queued AND the nudge submit is confirmed (or the buffer was empty);
+# 1 when the digest is safely queued but the nudge could not be confirmed;
+# 2 when even the queue append failed (buffer preserved for retry / catch-up).
 escalate_flush() {  # <state>
-  local state=$1 buf item n msg
+  local state=$1 buf n msg key
   buf="$state/.subsuper-escalations"
   [ -s "$buf" ] || return 0
+  # Presence-gated like the nudge itself: while afk is OFF the captain is
+  # present and firstmate drives normal triage, so the buffer survives intact
+  # for the catch-up flush or afk re-entry instead of entering the queue.
+  afk_active "$state" || return 1
   n=$(wc -l < "$buf" 2>/dev/null || echo 0)
   # Join buffered items with the literal " | " separator into one digest line.
   msg=$(awk 'NR>1{printf " | "} {printf "%s",$0} END{print ""}' "$buf" 2>/dev/null)
-  # Single-line wrapper: no embedded newlines (inject_msg also collapses as a
-  # safety net, but keeping the source single-line makes the intent explicit).
   msg=$(printf 'Supervisor escalate (%s event(s)): %s (pre-read; re-arm not needed — watcher daemon-managed)' "$n" "$msg")
-  if inject_msg "$msg" "$state"; then : > "$buf"; rm -f "${buf}.since" "$state/.subsuper-inject-wedged"; return 0; fi
+  ESCALATE_ENQUEUE_SEQ=$((ESCALATE_ENQUEUE_SEQ + 1))
+  key="away-digest-$(_now)-$$-$ESCALATE_ENQUEUE_SEQ"
+  if ! _wake_lib_env "$state" fm_wake_append escalation "$key" "$msg"; then
+    log "escalate enqueue FAILED (queue append error); buffer preserved for retry"
+    return 2
+  fi
+  : > "$buf"
+  rm -f "${buf}.since"
+  if escalate_nudge "$state"; then
+    rm -f "$state/.subsuper-inject-wedged"
+    return 0
+  fi
   return 1
 }
 
@@ -905,12 +966,17 @@ inject_wedge_alarm() {  # <state> <age-seconds>
     notify=0
   else
     WEDGE_ALARM_LAST_EPOCH=$now
-    log "ERROR: away-mode escalation undelivered ${age}s; inject could not confirm a submit (supervisor pane busy or wedged). Buffer + wake-queue preserved; alarm marker written."
+    log "ERROR: away-mode wake nudge undelivered ${age}s; escalation content is safe in the durable wake queue; inject could not confirm a submit (supervisor pane busy or wedged). Alarm marker written."
   fi
   {
     printf 'fm away-mode inject WEDGED: %ss undelivered as of %s\n' "$age" "$(date '+%Y-%m-%dT%H:%M:%S%z')"
-    printf 'The supervisor pane could not accept an escalation. Buffered items:\n'
-    cat "$state/.subsuper-escalations" 2>/dev/null
+    printf 'The supervisor pane could not accept the wake nudge. Escalation content is durable in state/.wake-queue (kind "escalation"); run bin/fm-wake-drain.sh to read it.\n'
+    printf 'Queued escalation record key(s):\n'
+    _wake_lib_env "$state" fm_wake_queued_keys escalation 2>/dev/null
+    if [ -s "$state/.subsuper-escalations" ]; then
+      printf 'Additionally still buffered (queue append failed):\n'
+      cat "$state/.subsuper-escalations" 2>/dev/null
+    fi
   } 2>/dev/null > "$marker" || true
   target="${FM_SUPERVISOR_TARGET:-$FM_SUPERVISOR_TARGET_DEFAULT}"
   backend="${FM_SUPERVISOR_BACKEND:-$FM_SUPERVISOR_BACKEND_DEFAULT}"
@@ -961,7 +1027,10 @@ housekeeping() {  # <state>
   now=$(_now)
   migrate_watcher_pause_markers "$state"
 
-  # (1) batch flush
+  # (1) batch flush + nudge retry. Flush moves buffered items into the durable
+  # queue when the batch window closes. While escalation records remain queued
+  # (a prior nudge could not be confirmed), retry the cheap static nudge each
+  # tick - content is already safe, only the wake is outstanding.
   if [ "${FM_ESCALATE_BATCH_SECS:-$ESCALATE_BATCH_SECS_DEFAULT}" -le 0 ]; then
     escalate_flush "$state" || true
   else
@@ -970,23 +1039,51 @@ housekeeping() {  # <state>
       escalate_flush "$state" || true
     fi
   fi
-
-  # (1b) max-defer escape. If anything is still buffered past MAX_DEFER_SECS,
-  # retry the normal delivery path. If that still cannot confirm, raise a loud
-  # wedge alarm while preserving the buffer.
-  max_defer=${FM_MAX_DEFER_SECS:-$MAX_DEFER_SECS_DEFAULT}
-  if afk_active "$state" && [ "$max_defer" -gt 0 ] && [ -s "$state/.subsuper-escalations" ]; then
-    oldest=$(_oldest_line_age "$state/.subsuper-escalations")
-    # Throttle the alarm to once per max-defer window (the wedge marker doubles
-    # as the throttle). A successful flush clears the buffer; a failed one alarms
-    # and waits.
-    if [ "$oldest" -ge "$max_defer" ] \
-       && [ "$(_file_age "$state/.subsuper-inject-wedged")" -ge "$max_defer" ]; then
-      if escalate_flush "$state"; then
-        log "inject recovered: max-defer flush succeeded after ${oldest}s undelivered"
+  if [ ! -s "$state/.subsuper-escalations" ]; then
+    local q_newest last_nudge
+    q_newest=$(_wake_lib_env "$state" fm_wake_newest_epoch escalation 2>/dev/null || true)
+    last_nudge=$(cat "$state/.subsuper-nudge-epoch" 2>/dev/null || echo 0)
+    case "$last_nudge" in ''|*[!0-9]*) last_nudge=0 ;; esac
+    if [ -n "$q_newest" ] && [ "$q_newest" -gt "$last_nudge" ]; then
+      if escalate_nudge "$state"; then
         rm -f "$state/.subsuper-inject-wedged"
-      else
-        inject_wedge_alarm "$state" "$oldest"
+      fi
+    fi
+  fi
+
+  # (1b) max-defer escape. Two cases, alarm throttled by the wedge marker:
+  #   - buffer still non-empty past MAX_DEFER_SECS: the queue append itself
+  #     failed, so retry the whole flush (enqueue + nudge);
+  #   - escalation records queued past MAX_DEFER_SECS with no confirmed nudge:
+  #     content is durable, but firstmate has not been woken - retry the nudge
+  #     and alarm if it still cannot confirm. Never silently defer forever.
+  max_defer=${FM_MAX_DEFER_SECS:-$MAX_DEFER_SECS_DEFAULT}
+  if afk_active "$state" && [ "$max_defer" -gt 0 ]; then
+    if [ -s "$state/.subsuper-escalations" ]; then
+      oldest=$(_oldest_line_age "$state/.subsuper-escalations")
+      if [ "$oldest" -ge "$max_defer" ] \
+         && [ "$(_file_age "$state/.subsuper-inject-wedged")" -ge "$max_defer" ]; then
+        if escalate_flush "$state"; then
+          log "inject recovered: max-defer flush succeeded after ${oldest}s undelivered"
+          rm -f "$state/.subsuper-inject-wedged"
+        else
+          inject_wedge_alarm "$state" "$oldest"
+        fi
+      fi
+    else
+      local q_epoch
+      q_epoch=$(_wake_lib_env "$state" fm_wake_oldest_epoch escalation 2>/dev/null || true)
+      if [ -n "$q_epoch" ]; then
+        oldest=$(( now - q_epoch ))
+        if [ "$oldest" -ge "$max_defer" ] \
+           && [ "$(_file_age "$state/.subsuper-inject-wedged")" -ge "$max_defer" ]; then
+          if escalate_nudge "$state"; then
+            log "nudge recovered: wake delivered after ${oldest}s queued"
+            rm -f "$state/.subsuper-inject-wedged"
+          else
+            inject_wedge_alarm "$state" "$oldest"
+          fi
+        fi
       fi
     fi
   fi
@@ -1092,11 +1189,13 @@ window_for_task() {  # <task-key> [state]
 }
 
 # --- injection --------------------------------------------------------------
-# inject_msg: send one escalation digest to the supervisor pane.
-# Returns 0 on successful inject (or empty buffer), non-zero if the pane is
-# gone, the supervisor is busy, afk is inactive, or the verified submit cannot
-# be confirmed after bounded retries. On non-zero the caller preserves
-# the buffer so the escalation survives for the next cycle or the catch-up flush.
+# inject_msg: send one short operational message (normally the static
+# escalation nudge) to the supervisor pane.
+# Returns 0 on successful inject, non-zero if the pane is gone, the supervisor
+# is busy, afk is inactive, or the verified submit cannot be confirmed after
+# bounded retries. Escalation content is durable in the wake queue before any
+# nudge is attempted, so a non-zero return defers only the wake; the caller
+# retries the nudge on later ticks or the max-defer path.
 #
 # Submit model:
 #   - TYPE ONCE, then submit with Enter. Never retype the digest: a swallowed

--- a/bin/fm-supervise-daemon.sh
+++ b/bin/fm-supervise-daemon.sh
@@ -1410,6 +1410,8 @@ fm_super_main() {
   local LOG="$STATE/.supervise-daemon.log"
   local WATCH_ERR="$STATE/.supervise-daemon.watcher.err"
   local LOCK="$STATE/.supervise-daemon.lock"
+  # Second reader: bin/fm-watchdog.sh checks this exact pidfile name while
+  # state/.afk is present. Rename it there too or the watchdog false-alarms.
   local PIDFILE="$STATE/.supervise-daemon.pid"
   local INJECT_FAIL_SLEEP=${FM_INJECT_FAIL_SLEEP:-$INJECT_FAIL_SLEEP_DEFAULT}
   local CRASH_THRESHOLD=${FM_CRASH_THRESHOLD:-$CRASH_THRESHOLD_DEFAULT}

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -13,6 +13,13 @@
 # already present in the up-to-date default branch. This recognizes the common
 # squash-merge-then-delete-branch flow, where the branch's own commits live nowhere
 # on a remote yet the change is fully in main.
+# Before those landed checks, a task whose metadata records pr= REFUSES teardown
+# while that PR or MR is still OPEN on its forge, even when every commit is
+# pushed: teardown removes the lane that owns the PR and its armed merge poll,
+# orphaning a PR nobody is driving (the 2026-08-02 orphaned-PR sweeps). A merged
+# or closed PR proceeds to the ordinary landed checks, and a failed state lookup
+# refuses rather than guessing (fail closed). --force keeps its explicit-discard
+# override.
 # The PR itself is resolved from the task's recorded pr= when present, or - when
 # no pr= was ever recorded (e.g. a yolo-authorized merge on a repo with no PR CI,
 # where the usual "checks green" fm-pr-check.sh trigger never fires) - by looking
@@ -53,7 +60,8 @@
 # never left leased forever. If the treehouse return fails, teardown leaves the
 # leased home and state in place instead of hiding a still-held lease.
 # Usage: fm-teardown.sh <task-id> [--force]
-#   --force skips ordinary-task dirty and landed-work checks, skips scout report
+#   --force skips the open-PR refusal and ordinary-task dirty and landed-work
+#   checks, skips scout report
 #   checks, and discards secondmate child work for kind=secondmate. Only use it
 #   when the captain has explicitly said to discard the work.
 #
@@ -500,6 +508,52 @@ work_is_landed() {
   local branch=$1
   pr_is_merged "$branch" && return 0
   content_in_default
+}
+
+# State of the recorded pr= URL on its forge: prints open, merged, or closed and
+# returns 0; returns non-zero on an unparseable URL, an unsupported provider, or
+# any lookup failure. Each provider is read through the same CLI and field
+# choices as bin/fm-pr-poll.sh: gh takes the URL directly, and glab takes the
+# validated number plus -R project URL because it cannot take an MR URL (see
+# that script's rationale).
+recorded_pr_state() {
+  local state raw
+  fm_pr_url_parse "$PR_URL" || return 1
+  case "$FM_PR_PROVIDER" in
+    github)
+      state=$(gh pr view "$FM_PR_URL" --json state -q .state 2>/dev/null) || return 1
+      ;;
+    gitlab)
+      raw=$(glab mr view "$FM_PR_NUMBER" -R "https://$FM_PR_HOST/$FM_PR_PATH" 2>/dev/null) || return 1
+      state=$(printf '%s\n' "$raw" | sed -n 's/^state:[[:space:]]*//p' | head -1)
+      ;;
+    *) return 1 ;;
+  esac
+  case "$state" in
+    OPEN|open|opened) printf '%s\n' open ;;
+    MERGED|merged) printf '%s\n' merged ;;
+    CLOSED|closed) printf '%s\n' closed ;;
+    *) return 1 ;;
+  esac
+}
+
+# Refuse while the recorded PR is still open, and refuse when its state cannot
+# be read (fail closed): teardown removes the PR's owner lane and its armed
+# merge poll either way, so proceeding on an open or unknown state orphans the
+# PR. Runs even when the worktree is already gone - the orphaning harm is
+# losing the owner and the poll, not just local commits.
+refuse_teardown_while_recorded_pr_open() {
+  local state
+  if ! state=$(recorded_pr_state); then
+    echo "REFUSED: cannot read the state of recorded PR $PR_URL; refusing teardown while it may still be open." >&2
+    echo "Fix the forge lookup (auth, network, or CLI), or get the captain's explicit OK to discard, then --force." >&2
+    return 1
+  fi
+  if [ "$state" = open ]; then
+    echo "REFUSED: PR $PR_URL is still open; this task still owns it and its merge poll." >&2
+    echo "Wait for the merge, merge or close it under the configured authority, or get the captain's explicit OK to discard, then --force." >&2
+    return 1
+  fi
 }
 
 backlog_refresh_reminder() {
@@ -1531,6 +1585,13 @@ if [ "$BACKEND" = orca ] && [ "$KIND" != scout ] && [ "$KIND" != secondmate ] &&
   fi
   require_orca_worktree_path_match "$ORCA_WORKTREE_ID" "$WT" || exit 1
   ORCA_PATH_MATCH_VERIFIED=1
+fi
+
+# Open-PR refusal (see header): independent of the worktree checks below so it
+# still fires when the worktree is already gone.
+if [ "$FORCE" != "--force" ] && [ -n "$PR_URL" ] \
+  && [ "$KIND" != scout ] && [ "$KIND" != secondmate ]; then
+  refuse_teardown_while_recorded_pr_open || exit 1
 fi
 
 if [ -d "$WT" ] && [ "$FORCE" != "--force" ]; then

--- a/bin/fm-wake-lib.sh
+++ b/bin/fm-wake-lib.sh
@@ -379,12 +379,18 @@ fm_wake_clean_field() {
   LC_ALL=C tr '\t\r\n' '   '
 }
 
+# Single owner of the wake-kind vocabulary. Every entry point validates
+# through here so adding a kind is a one-line change, never a four-case hunt.
+_fm_wake_kind_valid() {  # <caller> <kind>
+  case "$2" in
+    signal|stale|check|heartbeat|escalation) return 0 ;;
+    *) printf '%s: invalid wake kind: %s\n' "$1" "$2" >&2; return 2 ;;
+  esac
+}
+
 fm_wake_append() {
   local kind=$1 key=$2 payload=$3 clean_key clean_payload epoch seq seq_file status
-  case "$kind" in
-    signal|stale|check|heartbeat|escalation) ;;
-    *) printf 'fm_wake_append: invalid wake kind: %s\n' "$kind" >&2; return 2 ;;
-  esac
+  _fm_wake_kind_valid fm_wake_append "$kind" || return 2
 
   clean_key=$(printf '%s' "$key" | fm_wake_clean_field)
   clean_payload=$(printf '%s' "$payload" | fm_wake_clean_field)
@@ -413,10 +419,7 @@ fm_wake_append() {
 # for it is queued and unconsumed, and disappears when a drain consumes it.
 fm_wake_queued_keys() {
   local kind=$1
-  case "$kind" in
-    signal|stale|check|heartbeat|escalation) ;;
-    *) printf 'fm_wake_queued_keys: invalid wake kind: %s\n' "$kind" >&2; return 2 ;;
-  esac
+  _fm_wake_kind_valid fm_wake_queued_keys "$kind" || return 2
   fm_lock_acquire_wait "$FM_WAKE_QUEUE_LOCK"
   fm_wake_queued_keys_locked "$kind"
   fm_lock_release "$FM_WAKE_QUEUE_LOCK"
@@ -426,27 +429,22 @@ fm_wake_queued_keys() {
 # Print the epoch of the oldest / newest queued record for <kind>, or nothing
 # when none is queued. Append order makes the first match the oldest and the
 # last match the newest; read under the append lock like fm_wake_queued_keys.
-fm_wake_oldest_epoch() {
-  local kind=$1
-  case "$kind" in
-    signal|stale|check|heartbeat|escalation) ;;
-    *) printf 'fm_wake_oldest_epoch: invalid wake kind: %s\n' "$kind" >&2; return 2 ;;
+_fm_wake_epoch() {  # <caller> <oldest|newest> <kind>
+  local caller=$1 bound=$2 kind=$3 prog
+  _fm_wake_kind_valid "$caller" "$kind" || return 2
+  # shellcheck disable=SC2016  # single quotes are deliberate: awk expands its own variables.
+  case "$bound" in
+    oldest) prog='NF >= 5 && $3 == kind { print $1; exit }' ;;
+    *)      prog='NF >= 5 && $3 == kind { e = $1 } END { if (e != "") print e }' ;;
   esac
   fm_lock_acquire_wait "$FM_WAKE_QUEUE_LOCK"
-  awk -F '\t' -v kind="$kind" 'NF >= 5 && $3 == kind { print $1; exit }' "$FM_WAKE_QUEUE" 2>/dev/null || true
+  awk -F '\t' -v kind="$kind" "$prog" "$FM_WAKE_QUEUE" 2>/dev/null || true
   fm_lock_release "$FM_WAKE_QUEUE_LOCK"
 }
 
-fm_wake_newest_epoch() {
-  local kind=$1
-  case "$kind" in
-    signal|stale|check|heartbeat|escalation) ;;
-    *) printf 'fm_wake_newest_epoch: invalid wake kind: %s\n' "$kind" >&2; return 2 ;;
-  esac
-  fm_lock_acquire_wait "$FM_WAKE_QUEUE_LOCK"
-  awk -F '\t' -v kind="$kind" 'NF >= 5 && $3 == kind { e = $1 } END { if (e != "") print e }' "$FM_WAKE_QUEUE" 2>/dev/null || true
-  fm_lock_release "$FM_WAKE_QUEUE_LOCK"
-}
+fm_wake_oldest_epoch() { _fm_wake_epoch fm_wake_oldest_epoch oldest "$1"; }
+
+fm_wake_newest_epoch() { _fm_wake_epoch fm_wake_newest_epoch newest "$1"; }
 
 fm_wake_queued_keys_locked() {
   local kind=$1

--- a/bin/fm-wake-lib.sh
+++ b/bin/fm-wake-lib.sh
@@ -382,7 +382,7 @@ fm_wake_clean_field() {
 fm_wake_append() {
   local kind=$1 key=$2 payload=$3 clean_key clean_payload epoch seq seq_file status
   case "$kind" in
-    signal|stale|check|heartbeat) ;;
+    signal|stale|check|heartbeat|escalation) ;;
     *) printf 'fm_wake_append: invalid wake kind: %s\n' "$kind" >&2; return 2 ;;
   esac
 
@@ -414,11 +414,37 @@ fm_wake_append() {
 fm_wake_queued_keys() {
   local kind=$1
   case "$kind" in
-    signal|stale|check|heartbeat) ;;
+    signal|stale|check|heartbeat|escalation) ;;
     *) printf 'fm_wake_queued_keys: invalid wake kind: %s\n' "$kind" >&2; return 2 ;;
   esac
   fm_lock_acquire_wait "$FM_WAKE_QUEUE_LOCK"
   fm_wake_queued_keys_locked "$kind"
+  fm_lock_release "$FM_WAKE_QUEUE_LOCK"
+}
+
+# fm_wake_oldest_epoch <kind> / fm_wake_newest_epoch <kind>
+# Print the epoch of the oldest / newest queued record for <kind>, or nothing
+# when none is queued. Append order makes the first match the oldest and the
+# last match the newest; read under the append lock like fm_wake_queued_keys.
+fm_wake_oldest_epoch() {
+  local kind=$1
+  case "$kind" in
+    signal|stale|check|heartbeat|escalation) ;;
+    *) printf 'fm_wake_oldest_epoch: invalid wake kind: %s\n' "$kind" >&2; return 2 ;;
+  esac
+  fm_lock_acquire_wait "$FM_WAKE_QUEUE_LOCK"
+  awk -F '\t' -v kind="$kind" 'NF >= 5 && $3 == kind { print $1; exit }' "$FM_WAKE_QUEUE" 2>/dev/null || true
+  fm_lock_release "$FM_WAKE_QUEUE_LOCK"
+}
+
+fm_wake_newest_epoch() {
+  local kind=$1
+  case "$kind" in
+    signal|stale|check|heartbeat|escalation) ;;
+    *) printf 'fm_wake_newest_epoch: invalid wake kind: %s\n' "$kind" >&2; return 2 ;;
+  esac
+  fm_lock_acquire_wait "$FM_WAKE_QUEUE_LOCK"
+  awk -F '\t' -v kind="$kind" 'NF >= 5 && $3 == kind { e = $1 } END { if (e != "") print e }' "$FM_WAKE_QUEUE" 2>/dev/null || true
   fm_lock_release "$FM_WAKE_QUEUE_LOCK"
 }
 

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -53,6 +53,24 @@
 #                          running a check or removing poll artifacts
 #   heartbeat              fleet-scan backstop found an unsurfaced captain-relevant
 #                          status, unless afk is active
+#   stale: <window> (quiet stall: ...)
+#                          a non-busy pane whose task has completed no turn,
+#                          written no status, and landed no worktree commit for
+#                          FM_QUIET_STALL_SECS - catches the idle prompt whose
+#                          churning footer defeats hash-stability detection
+#   stale: <window> (endpoint dead: ...)
+#                          pane capture failed and the backend confirms the
+#                          agent dead while the task's last status is
+#                          non-terminal - a provider or process exit would
+#                          otherwise leave a phantom in-flight lane invisible
+#                          to every poll above
+#   heartbeat (refill: ...)
+#                          config/refill-target is set, the backlog has ready
+#                          work, and live lanes are under target - wakes an
+#                          idle fleet to refill instead of absorbing forever
+# Every poll also overwrites state/.captain-pulse with a one-line liveness
+# summary (live lanes, queued wakes, last crew event age) so healthy quiet
+# stays distinguishable from a dead loop without reading watcher internals.
 # For normal supervision, resume the session-start primary-harness protocol
 # after each printed reason. Direct duplicate invocations of this script still
 # no-op through the watcher singleton lock.
@@ -151,6 +169,12 @@ STALE_ESCALATE_SECS=${FM_STALE_ESCALATE_SECS:-240}  # idle secs before a provabl
 # turn-ended and resets the age. Set generously above any legitimate interval
 # between completed turns, including long tool calls, builds, or test runs.
 BUSY_TURN_MAX_SECS=${FM_BUSY_TURN_MAX_SECS:-3600}
+# A non-busy pane whose task shows NO engagement signal - no completed turn,
+# no status write, no new worktree commit - for this long is a quiet stall:
+# the idle-prompt-with-churning-footer state that never yields two identical
+# hashes, so the stability path below cannot see it idling (2026-08-02 audit:
+# 82k tokens burned over 10 silent minutes, caught only by a manual peek).
+QUIET_STALL_SECS=${FM_QUIET_STALL_SECS:-900}
 # A crew that declared a pause is idling on a known external wait, so its stale
 # pane is absorbed rather than wedge-escalated.
 # A captain-held or paused crew whose agent has confidently exited uses the same
@@ -312,6 +336,93 @@ busy_turn_over_age() {  # <task>
   f="$STATE/$task.turn-ended"
   [ -e "$f" ] || f="$STATE/$task.meta"
   [ "$(age_of "$f")" -ge "$BUSY_TURN_MAX_SECS" ]
+}
+
+# Seconds since the newest commit on <task>'s recorded worktree HEAD, 999999
+# when the worktree or its git history cannot be read. A fresh commit is an
+# engagement signal even when the harness writes no status and ends no turn.
+task_commit_age() {  # <task>
+  local wt ts
+  wt=$(grep '^worktree=' "$STATE/$1.meta" 2>/dev/null | cut -d= -f2- || true)
+  [ -n "$wt" ] && [ -d "$wt" ] || { echo 999999; return; }
+  ts=$(git -C "$wt" log -1 --format=%ct 2>/dev/null | tr -d '[:space:]')
+  case "$ts" in ''|*[!0-9]*) echo 999999; return ;; esac
+  echo $(( $(date +%s) - ts ))
+}
+
+# Quiet-stall detection: the not-busy twin of busy_turn_over_age. A pane that
+# keeps repainting (a token counter, a clock) never yields two identical
+# hashes, so the stability path below cannot see it idling; this keys on the
+# task's own engagement signals instead and fires independently of hashing.
+# Declared pauses, captain holds, secondmate endpoints, and provably-working
+# crews keep their existing owners. Re-fires on the bounded
+# PAUSE_RESURFACE_SECS cadence, never every poll.
+quiet_stall_check() {  # <window> <task> <busy_now> <kind>
+  local win=$1 task=$2 busy_now=$3 kind=$4 key qsf last idle te st reason
+  [ "$kind" = secondmate ] && return 0
+  [ -n "$task" ] || return 0
+  key=$(printf '%s' "$win" | tr ':/.' '___')
+  qsf="$STATE/.quietstall-$key"
+  if [ "$busy_now" -eq 0 ]; then
+    rm -f "$qsf"
+    return 0
+  fi
+  last=$(last_status_line "$STATE/$task.status")
+  if status_is_paused_or_captain_held "$last"; then
+    rm -f "$qsf"
+    return 0
+  fi
+  te=$(age_of "$STATE/$task.turn-ended")
+  [ -e "$STATE/$task.turn-ended" ] || te=$(age_of "$STATE/$task.meta")
+  st=$(age_of "$STATE/$task.status")
+  idle=$te
+  [ "$st" -lt "$idle" ] && idle=$st
+  if [ "$idle" -lt "$QUIET_STALL_SECS" ]; then
+    rm -f "$qsf"
+    return 0
+  fi
+  [ "$(age_of "$qsf")" -lt "$PAUSE_RESURFACE_SECS" ] && return 0
+  if [ "$(task_commit_age "$task")" -lt "$QUIET_STALL_SECS" ]; then
+    rm -f "$qsf"
+    return 0
+  fi
+  if crew_is_provably_working "$task"; then
+    triage_log "absorbed quiet stall (provably working): $win"
+    return 0
+  fi
+  reason="stale: $win (quiet stall: not busy, no completed turn, status write, or new commit for ${idle}s - inspect and re-engage)"
+  fm_wake_append stale "$win" "$reason" || exit 1
+  date +%s > "$qsf"
+  wake "$reason"
+}
+
+# Endpoint-death surfacing for a pane whose capture failed. Healthy panes
+# never pay this cost; a failed capture is the first sign the pane may be
+# gone, and only a confident backend dead verdict fires (a transient backend
+# hiccup stays absorbed exactly as before). A task whose last status already
+# carries a captain-relevant verb keeps its existing signal-path owner; the
+# target is the silent seat death - a provider or process exit that leaves a
+# non-terminal status and a phantom in-flight lane (2026-08-02 audit:
+# spending-limit and content-filter kills sat invisible ~13h). Re-fires on
+# the bounded PAUSE_RESURFACE_SECS cadence.
+seat_death_check() {  # <window> <task> <kind>
+  local win=$1 task=$2 kind=$3 key sdf last alive reason
+  [ "$kind" = secondmate ] && return 0
+  [ -n "$task" ] || return 0
+  key=$(printf '%s' "$win" | tr ':/.' '___')
+  sdf="$STATE/.seatdeath-$key"
+  last=$(last_status_line "$STATE/$task.status")
+  if [ -n "$last" ]; then
+    status_is_captain_relevant "$last" && return 0
+    status_is_paused_or_captain_held "$last" && return 0
+  fi
+  alive=$(fm_backend_agent_alive "$(window_backend "$win")" "$win" 2>/dev/null) || alive=unknown
+  [ "$alive" = dead ] || return 0
+  [ "$(age_of "$sdf")" -lt "$PAUSE_RESURFACE_SECS" ] && return 0
+  reason="stale: $win (endpoint dead: worker gone with non-terminal status - provider or process exit suspected; recover or tear down)"
+  fm_wake_append stale "$win" "$reason" || exit 1
+  date +%s > "$sdf"
+  wake "$reason"
 }
 
 # Absorb a stale pane under a declared external-wait pause (paused:) or a
@@ -621,6 +732,58 @@ heartbeat_scan_finds_actionable() {
   return 1
 }
 
+# Refill-aware heartbeat: presence-gated by config/refill-target (an integer
+# lane target; absent means today's behavior, byte for byte). Under a standing
+# refill plan an idle fleet with ready backlog IS captain-relevant: without
+# this, every no-change heartbeat absorbs and a drained fleet never refills
+# (2026-08-02: 11.5h idle with ready work queued). Counts only this home's
+# non-secondmate lanes. Sets FM_REFILL_REASON on a 0 return.
+heartbeat_refill_due() {
+  local target ready live meta
+  [ -f "$FM_HOME/config/refill-target" ] || return 1
+  target=$(tr -d '[:space:]' < "$FM_HOME/config/refill-target" 2>/dev/null || true)
+  case "$target" in ''|*[!0-9]*) return 1 ;; esac
+  [ "$target" -gt 0 ] || return 1
+  command -v tasks-axi >/dev/null 2>&1 || return 1
+  ready=$( (cd "$FM_HOME" 2>/dev/null && tasks-axi ready 2>/dev/null) | awk -F': ' '/^count: [0-9]+$/ { print $2; exit }')
+  case "$ready" in ''|*[!0-9]*) return 1 ;; esac
+  [ "$ready" -gt 0 ] || return 1
+  live=0
+  for meta in "$STATE"/*.meta; do
+    [ -e "$meta" ] || continue
+    grep -q '^kind=secondmate$' "$meta" 2>/dev/null && continue
+    live=$((live + 1))
+  done
+  [ "$live" -lt "$target" ] || return 1
+  FM_REFILL_REASON="heartbeat (refill: $ready ready backlog item(s), $live live lane(s) under target $target - dispatch from the queue)"
+}
+
+# Captain-facing liveness pulse: one overwritten line in state/.captain-pulse
+# so healthy quiet stays distinguishable from a dead loop without reading
+# watcher internals (2026-08-02: a fully-working 7-lane fleet read as
+# inactive from outside). Best-effort; never blocks or fails the cycle.
+write_captain_pulse() {
+  local live=0 meta q=0 newest=999999 f a evt
+  for meta in "$STATE"/*.meta; do
+    [ -e "$meta" ] || continue
+    grep -q '^kind=secondmate$' "$meta" 2>/dev/null && continue
+    live=$((live + 1))
+  done
+  if [ -s "$FM_WAKE_QUEUE" ]; then
+    q=$(wc -l < "$FM_WAKE_QUEUE" 2>/dev/null | tr -d '[:space:]')
+    case "$q" in ''|*[!0-9]*) q=0 ;; esac
+  fi
+  for f in "$STATE"/*.status; do
+    [ -e "$f" ] || continue
+    a=$(age_of "$f")
+    [ "$a" -lt "$newest" ] && newest=$a
+  done
+  evt="${newest}s ago"
+  [ "$newest" -eq 999999 ] && evt="none"
+  printf '%s | watcher alive | live-lanes=%s | wakes-queued=%s | last-crew-event=%s\n' \
+    "$(date '+%Y-%m-%dT%H:%M:%S%z')" "$live" "$q" "$evt" > "$STATE/.captain-pulse" 2>/dev/null || true
+}
+
 # event_wait_or_sleep: the terminal wait of each supervision cycle. For a home
 # with push-capable windows (herdr), it replaces the blind `sleep POLL` with a
 # bounded wait on the backend's native transition stream, so a crew going
@@ -774,6 +937,7 @@ while :; do
   # Liveness beacon for fm-guard.sh: a fresh mtime here means a watcher is
   # alive. Supervision scripts warn when this goes stale with tasks in flight.
   touch "$STATE/.last-watcher-beat"
+  write_captain_pulse
 
   # Parent-owned secondmate pending-reply reconciliation: resolve correlated
   # parent reports, observe backend busy/idle turn completion, send one recovery
@@ -934,9 +1098,16 @@ EOF
     if [ "$kind" = secondmate ] && ! status_is_paused "$last"; then
       continue
     fi
-    tail40=$(fm_backend_capture "$(window_backend "$w")" "$w" 40 "$(window_label "$w")" 2>/dev/null) || continue
+    if ! tail40=$(fm_backend_capture "$(window_backend "$w")" "$w" 40 "$(window_label "$w")" 2>/dev/null); then
+      # A pane the poll loop cannot even read is invisible to every layer
+      # below; check for a confirmed-dead agent behind a non-terminal status
+      # before skipping, or a silent seat death stays a phantom forever.
+      seat_death_check "$w" "$task" "$kind"
+      continue
+    fi
     h=$(printf '%s' "$tail40" | hash_pane)
     key=$(printf '%s' "$w" | tr ':/.' '___')
+    rm -f "$STATE/.seatdeath-$key"
     hf="$STATE/.hash-$key"
     cf="$STATE/.count-$key"
     sf="$STATE/.stale-$key"
@@ -950,6 +1121,7 @@ EOF
     # content cannot suppress stale detection. Read once per window per poll and
     # reused below so a busy verdict is consistent within one cycle.
     if window_is_busy "$w" "$tail40"; then busy_now=0; else busy_now=1; fi
+    quiet_stall_check "$w" "$task" "$busy_now" "$kind"
     if [ "$h" = "$prev" ]; then
       n=$(( $(cat "$cf" 2>/dev/null || echo 0) + 1 ))
       echo "$n" > "$cf"
@@ -1111,6 +1283,12 @@ EOF
       touch "$STATE/.last-heartbeat"
       mark_all_captain_relevant_surfaced
       wake "heartbeat"
+    elif heartbeat_refill_due; then
+      # Presence-gated refill: ready backlog with live lanes under
+      # config/refill-target - see heartbeat_refill_due above.
+      fm_wake_append heartbeat heartbeat "$FM_REFILL_REASON" || exit 1
+      touch "$STATE/.last-heartbeat"
+      wake "$FM_REFILL_REASON"
     else
       touch "$STATE/.last-heartbeat"
       echo $(( $(cat "$STATE/.heartbeat-streak" 2>/dev/null || echo 0) + 1 )) > "$STATE/.heartbeat-streak"

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -68,9 +68,10 @@
 #                          config/refill-target is set, the backlog has ready
 #                          work, and live lanes are under target - wakes an
 #                          idle fleet to refill instead of absorbing forever
-# Every poll also overwrites state/.captain-pulse with a one-line liveness
-# summary (live lanes, queued wakes, last crew event age) so healthy quiet
-# stays distinguishable from a dead loop without reading watcher internals.
+# The poll loop also refreshes state/.captain-pulse (at most once a minute)
+# with a one-line liveness summary (live lanes, queued wakes, last crew event
+# age) so healthy quiet stays distinguishable from a dead loop without
+# reading watcher internals.
 # For normal supervision, resume the session-start primary-harness protocol
 # after each printed reason. Direct duplicate invocations of this script still
 # no-op through the watcher singleton lock.
@@ -338,6 +339,25 @@ busy_turn_over_age() {  # <task>
   [ "$(age_of "$f")" -ge "$BUSY_TURN_MAX_SECS" ]
 }
 
+# Canonical state-marker key for a window. Must stay byte-identical wherever a
+# marker written under one call site is cleared or aged under another (e.g.
+# .seatdeath-* written in seat_death_check, cleared in the poll loop).
+window_key() {  # <window>
+  printf '%s' "$1" | tr ':/.' '___'
+}
+
+# One definition of a live lane: a recorded non-secondmate task. The refill
+# gate and the captain pulse must agree on this number.
+count_live_lanes() {
+  local live=0 meta
+  for meta in "$STATE"/*.meta; do
+    [ -e "$meta" ] || continue
+    grep -q '^kind=secondmate$' "$meta" 2>/dev/null && continue
+    live=$((live + 1))
+  done
+  printf '%s' "$live"
+}
+
 # Seconds since the newest commit on <task>'s recorded worktree HEAD, 999999
 # when the worktree or its git history cannot be read. A fresh commit is an
 # engagement signal even when the harness writes no status and ends no turn.
@@ -355,27 +375,28 @@ task_commit_age() {  # <task>
 # hashes, so the stability path below cannot see it idling; this keys on the
 # task's own engagement signals instead and fires independently of hashing.
 # Declared pauses, captain holds, secondmate endpoints, and provably-working
-# crews keep their existing owners. Re-fires on the bounded
-# PAUSE_RESURFACE_SECS cadence, never every poll.
-quiet_stall_check() {  # <window> <task> <busy_now> <kind>
-  local win=$1 task=$2 busy_now=$3 kind=$4 key qsf last idle te st reason
+# crews keep their existing owners. The .quietstall-* marker stamps every
+# decision past the idle gate - fire or provably-working absorb - so the
+# costly commit and crew-state reads run once per PAUSE_RESURFACE_SECS window,
+# never every poll of a long validation.
+quiet_stall_check() {  # <window> <task> <busy_now> <kind> <last-status-line>
+  local win=$1 task=$2 busy_now=$3 kind=$4 last=$5 key qsf f idle st reason
   [ "$kind" = secondmate ] && return 0
   [ -n "$task" ] || return 0
-  key=$(printf '%s' "$win" | tr ':/.' '___')
+  key=$(window_key "$win")
   qsf="$STATE/.quietstall-$key"
   if [ "$busy_now" -eq 0 ]; then
     rm -f "$qsf"
     return 0
   fi
-  last=$(last_status_line "$STATE/$task.status")
   if status_is_paused_or_captain_held "$last"; then
     rm -f "$qsf"
     return 0
   fi
-  te=$(age_of "$STATE/$task.turn-ended")
-  [ -e "$STATE/$task.turn-ended" ] || te=$(age_of "$STATE/$task.meta")
+  f="$STATE/$task.turn-ended"
+  [ -e "$f" ] || f="$STATE/$task.meta"
+  idle=$(age_of "$f")
   st=$(age_of "$STATE/$task.status")
-  idle=$te
   [ "$st" -lt "$idle" ] && idle=$st
   if [ "$idle" -lt "$QUIET_STALL_SECS" ]; then
     rm -f "$qsf"
@@ -387,7 +408,8 @@ quiet_stall_check() {  # <window> <task> <busy_now> <kind>
     return 0
   fi
   if crew_is_provably_working "$task"; then
-    triage_log "absorbed quiet stall (provably working): $win"
+    date +%s > "$qsf"
+    triage_log "absorbed quiet stall (provably working, recheck in ${PAUSE_RESURFACE_SECS}s): $win"
     return 0
   fi
   reason="stale: $win (quiet stall: not busy, no completed turn, status write, or new commit for ${idle}s - inspect and re-engage)"
@@ -409,8 +431,11 @@ seat_death_check() {  # <window> <task> <kind>
   local win=$1 task=$2 kind=$3 key sdf last alive reason
   [ "$kind" = secondmate ] && return 0
   [ -n "$task" ] || return 0
-  key=$(printf '%s' "$win" | tr ':/.' '___')
+  key=$(window_key "$win")
   sdf="$STATE/.seatdeath-$key"
+  # Throttle first: inside the re-fire window nothing below can act, so skip
+  # the status read and the backend liveness round-trip entirely.
+  [ "$(age_of "$sdf")" -lt "$PAUSE_RESURFACE_SECS" ] && return 0
   last=$(last_status_line "$STATE/$task.status")
   if [ -n "$last" ]; then
     status_is_captain_relevant "$last" && return 0
@@ -418,7 +443,6 @@ seat_death_check() {  # <window> <task> <kind>
   fi
   alive=$(fm_backend_agent_alive "$(window_backend "$win")" "$win" 2>/dev/null) || alive=unknown
   [ "$alive" = dead ] || return 0
-  [ "$(age_of "$sdf")" -lt "$PAUSE_RESURFACE_SECS" ] && return 0
   reason="stale: $win (endpoint dead: worker gone with non-terminal status - provider or process exit suspected; recover or tear down)"
   fm_wake_append stale "$win" "$reason" || exit 1
   date +%s > "$sdf"
@@ -739,36 +763,32 @@ heartbeat_scan_finds_actionable() {
 # (2026-08-02: 11.5h idle with ready work queued). Counts only this home's
 # non-secondmate lanes. Sets FM_REFILL_REASON on a 0 return.
 heartbeat_refill_due() {
-  local target ready live meta
+  local target ready live
   [ -f "$FM_HOME/config/refill-target" ] || return 1
   target=$(tr -d '[:space:]' < "$FM_HOME/config/refill-target" 2>/dev/null || true)
   case "$target" in ''|*[!0-9]*) return 1 ;; esac
   [ "$target" -gt 0 ] || return 1
+  # Local lane count before the tasks-axi (node) spawn: a full fleet - the
+  # common state during an active push - answers without paying it.
+  live=$(count_live_lanes)
+  [ "$live" -lt "$target" ] || return 1
   command -v tasks-axi >/dev/null 2>&1 || return 1
   ready=$( (cd "$FM_HOME" 2>/dev/null && tasks-axi ready 2>/dev/null) | awk -F': ' '/^count: [0-9]+$/ { print $2; exit }')
   case "$ready" in ''|*[!0-9]*) return 1 ;; esac
   [ "$ready" -gt 0 ] || return 1
-  live=0
-  for meta in "$STATE"/*.meta; do
-    [ -e "$meta" ] || continue
-    grep -q '^kind=secondmate$' "$meta" 2>/dev/null && continue
-    live=$((live + 1))
-  done
-  [ "$live" -lt "$target" ] || return 1
   FM_REFILL_REASON="heartbeat (refill: $ready ready backlog item(s), $live live lane(s) under target $target - dispatch from the queue)"
 }
 
 # Captain-facing liveness pulse: one overwritten line in state/.captain-pulse
 # so healthy quiet stays distinguishable from a dead loop without reading
 # watcher internals (2026-08-02: a fully-working 7-lane fleet read as
-# inactive from outside). Best-effort; never blocks or fails the cycle.
+# inactive from outside). Refreshed at most once a minute - a human reads it
+# at minute granularity, and a per-poll refresh forks per state file for
+# nothing. Best-effort; never blocks or fails the cycle.
 write_captain_pulse() {
-  local live=0 meta q=0 newest=999999 f a evt
-  for meta in "$STATE"/*.meta; do
-    [ -e "$meta" ] || continue
-    grep -q '^kind=secondmate$' "$meta" 2>/dev/null && continue
-    live=$((live + 1))
-  done
+  local live q=0 newest=999999 f a evt
+  [ "$(age_of "$STATE/.captain-pulse")" -lt 60 ] && return 0
+  live=$(count_live_lanes)
   if [ -s "$FM_WAKE_QUEUE" ]; then
     q=$(wc -l < "$FM_WAKE_QUEUE" 2>/dev/null | tr -d '[:space:]')
     case "$q" in ''|*[!0-9]*) q=0 ;; esac
@@ -1121,7 +1141,7 @@ EOF
     # content cannot suppress stale detection. Read once per window per poll and
     # reused below so a busy verdict is consistent within one cycle.
     if window_is_busy "$w" "$tail40"; then busy_now=0; else busy_now=1; fi
-    quiet_stall_check "$w" "$task" "$busy_now" "$kind"
+    quiet_stall_check "$w" "$task" "$busy_now" "$kind" "$last"
     if [ "$h" = "$prev" ]; then
       n=$(( $(cat "$cf" 2>/dev/null || echo 0) + 1 ))
       echo "$n" > "$cf"

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -346,16 +346,42 @@ window_key() {  # <window>
   printf '%s' "$1" | tr ':/.' '___'
 }
 
-# One definition of a live lane: a recorded non-secondmate task. The refill
-# gate and the captain pulse must agree on this number.
+# One definition of a live lane: a recorded non-secondmate task whose endpoint
+# is not authoritatively gone. The refill gate and the captain pulse must agree
+# on this number.
+#
+# 2026-08-05: counting records alone reported a working fleet after every
+# endpoint had died - the pulse read "live-lanes=7" with nothing running, and
+# the refill gate stayed above target so a drained fleet never refilled. Only
+# an authoritative `dead` (the backend proving the endpoint missing or the
+# agent gone) is excluded; `unknown` still counts, so an unreadable backend can
+# never inflate dispatch by under-reporting. Costs one bounded backend probe
+# per recorded non-secondmate task, and the fleet size bounds that.
 count_live_lanes() {
-  local live=0 meta
+  local live=0 meta w
   for meta in "$STATE"/*.meta; do
     [ -e "$meta" ] || continue
     grep -q '^kind=secondmate$' "$meta" 2>/dev/null && continue
+    w=$(fm_backend_target_of_meta "$meta")
+    if [ -n "$w" ] &&
+      [ "$(fm_backend_agent_alive "$(window_backend "$w")" "$w" 2>/dev/null)" = dead ]; then
+      continue
+    fi
     live=$((live + 1))
   done
   printf '%s' "$live"
+}
+
+# Recorded non-secondmate tasks, live or not. The pulse pairs this with the
+# live count so a fleet of dead records reads as dead instead of as work.
+count_recorded_lanes() {
+  local n=0 meta
+  for meta in "$STATE"/*.meta; do
+    [ -e "$meta" ] || continue
+    grep -q '^kind=secondmate$' "$meta" 2>/dev/null && continue
+    n=$((n + 1))
+  done
+  printf '%s' "$n"
 }
 
 # Seconds since the newest commit on <task>'s recorded worktree HEAD, 999999
@@ -786,9 +812,12 @@ heartbeat_refill_due() {
 # at minute granularity, and a per-poll refresh forks per state file for
 # nothing. Best-effort; never blocks or fails the cycle.
 write_captain_pulse() {
-  local live q=0 newest=999999 f a evt
+  local live recorded q=0 newest=999999 f a evt lanes
   [ "$(age_of "$STATE/.captain-pulse")" -lt 60 ] && return 0
   live=$(count_live_lanes)
+  recorded=$(count_recorded_lanes)
+  lanes="$live"
+  [ "$live" != "$recorded" ] && lanes="$live (of $recorded recorded)"
   if [ -s "$FM_WAKE_QUEUE" ]; then
     q=$(wc -l < "$FM_WAKE_QUEUE" 2>/dev/null | tr -d '[:space:]')
     case "$q" in ''|*[!0-9]*) q=0 ;; esac
@@ -801,7 +830,7 @@ write_captain_pulse() {
   evt="${newest}s ago"
   [ "$newest" -eq 999999 ] && evt="none"
   printf '%s | watcher alive | live-lanes=%s | wakes-queued=%s | last-crew-event=%s\n' \
-    "$(date '+%Y-%m-%dT%H:%M:%S%z')" "$live" "$q" "$evt" > "$STATE/.captain-pulse" 2>/dev/null || true
+    "$(date '+%Y-%m-%dT%H:%M:%S%z')" "$lanes" "$q" "$evt" > "$STATE/.captain-pulse" 2>/dev/null || true
 }
 
 # event_wait_or_sleep: the terminal wait of each supervision cycle. For a home

--- a/bin/fm-watchdog.sh
+++ b/bin/fm-watchdog.sh
@@ -80,6 +80,10 @@ if [ "$(uname)" = Darwin ]; then
 else
   _stat_file_mtime() { stat -c %Y "$1" 2>/dev/null; }
 fi
+# Deliberate copies of fm_path_mtime/fm_path_age (bin/fm-wake-lib.sh): this
+# monitor must stay standalone and never source the stack it watches, so the
+# stat-portability rule is restated here on purpose. Keep the three copies
+# (this, fm-wake-lib.sh, fm-watch.sh age_of) behaviorally identical.
 _file_age() {  # seconds since mtime; very large if missing
   local f=$1 m
   m=$(_stat_file_mtime "$f") || { echo 999999; return; }
@@ -137,15 +141,10 @@ _alert_visible() {  # <condition> <summary>
   esac
   if command -v powershell.exe >/dev/null 2>&1; then
     safe=$(printf '%s' "$summary" | tr -cd 'A-Za-z0-9 ._:()/-')
-    if command -v timeout >/dev/null 2>&1; then
-      timeout 12 powershell.exe -NoProfile -NonInteractive -Command \
-        "(New-Object -ComObject WScript.Shell).Popup('$safe',10,'firstmate watchdog',48) | Out-Null" \
-        >/dev/null 2>&1 || true
-    else
-      powershell.exe -NoProfile -NonInteractive -Command \
-        "(New-Object -ComObject WScript.Shell).Popup('$safe',10,'firstmate watchdog',48) | Out-Null" \
-        >/dev/null 2>&1 || true
-    fi
+    set -- powershell.exe -NoProfile -NonInteractive -Command \
+      "(New-Object -ComObject WScript.Shell).Popup('$safe',10,'firstmate watchdog',48) | Out-Null"
+    command -v timeout >/dev/null 2>&1 && set -- timeout 12 "$@"
+    "$@" >/dev/null 2>&1 || true
     return 0
   fi
   if command -v notify-send >/dev/null 2>&1; then

--- a/bin/fm-watchdog.sh
+++ b/bin/fm-watchdog.sh
@@ -1,0 +1,207 @@
+#!/usr/bin/env bash
+# fm-watchdog.sh - cron-level liveness watchdog OUTSIDE the agent stack.
+#
+# The watcher chain, the away-mode daemon, and every turn-end guard live inside
+# the agent stack: when the harness, multiplexer, or daemon itself dies, none of
+# them can report that death (observed 2026-08-02: the away daemon died with
+# state/.afk still present and nothing alarmed; a home's watcher was dead 15.1h
+# with 26 task metas recorded). This script is the independent outer net: run it
+# from cron (or any external scheduler) and it checks two facts read-only:
+#
+#   watcher-stale - work is recorded (any state/<id>.meta) or away mode is on
+#                   (state/.afk), but state/.last-watcher-beat is missing or
+#                   older than FM_WATCHDOG_GRACE (default 900s; the watcher's
+#                   own guard grace is 300s, this net is deliberately coarser).
+#   daemon-dead   - state/.afk exists but the away-mode daemon is not running
+#                   (state/.supervise-daemon.pid missing or its pid dead; the
+#                   daemon removes that pidfile on clean shutdown, so absence
+#                   means not-running, matching bin/fm-supervise-daemon.sh).
+#
+# An idle home (no task metas, no .afk) is healthy regardless of the beacon: a
+# watcher is only required while work is recorded or away mode is on.
+#
+# ALARM = one dated line appended to state/.watchdog-alarm (the authoritative
+# record) plus a best-effort visible alert, tried in order:
+#   1. powershell.exe on PATH (WSL): a dependency-free WScript.Shell COM popup
+#      with a 10s self-timeout - no BurntToast, no module install.
+#   2. notify-send, if present.
+#   3. stderr echo (always emitted on a firing alarm; doubles as the cron-log
+#      record when stdout/stderr are redirected by the cron entry).
+# FM_WATCHDOG_ALERT_EXEC, when set, REPLACES the real channels: it is invoked as
+# `<exec> <condition> <summary>` (the same seam contract as the daemon's
+# FM_WEDGE_ALARM_EXEC; the special value "discard" fires nothing). Tests force
+# this seam so they can never raise a real popup.
+#
+# Dedupe: each condition re-alerts at most once per FM_WATCHDOG_REALERT
+# (default 3600s), tracked by the mtime of state/.watchdog-alerted-<condition>.
+# The alarm-file append and the visible alert fire only when an alert actually
+# fires (first failure, or the re-alert window elapsed); a still-failing but
+# deduped condition stays silent yet the exit code remains non-zero. A healthy
+# condition removes its marker so the next failure alerts immediately.
+#
+# Exit codes: 0 healthy (silent), 1 alarm condition present, 2 usage error.
+#
+# Usage:
+#   FM_HOME=/path/to/home bin/fm-watchdog.sh            one check pass
+#   FM_HOME=/path/to/home bin/fm-watchdog.sh --install-cron
+#     Installs (idempotently, replacing any prior entry for the same home) a
+#     crontab entry running this script every 10 minutes with the current
+#     FM_HOME, logging to state/.watchdog-cron.log. When crontab is missing,
+#     prints manual instructions (including a Windows Task Scheduler
+#     schtasks.exe alternative for WSL) and exits 1. When crontab exists but no
+#     cron daemon process is detected (common on WSL), the entry is still
+#     installed and a start-the-service warning is printed.
+#
+# Env knobs: FM_WATCHDOG_GRACE (900), FM_WATCHDOG_REALERT (3600),
+#            FM_WATCHDOG_ALERT_EXEC (unset = real channels; "discard" = none).
+set -eu
+
+usage() {
+  sed -n '2,56p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+}
+
+case "${1:-}" in
+  -h|--help) usage; exit 0 ;;
+esac
+
+if [ -z "${FM_HOME+x}" ] || [ -z "${FM_HOME:-}" ]; then
+  echo "error: FM_HOME is not set; fm-watchdog refuses to guess which firstmate home to check" >&2
+  exit 2
+fi
+
+STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
+GRACE=${FM_WATCHDOG_GRACE:-900}
+REALERT=${FM_WATCHDOG_REALERT:-3600}
+SELF="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/$(basename "${BASH_SOURCE[0]}")"
+
+# --- portable stat (same trap as fm-watch.sh: no `stat -f || stat -c`) -------
+if [ "$(uname)" = Darwin ]; then
+  _stat_file_mtime() { stat -f %m "$1" 2>/dev/null; }
+else
+  _stat_file_mtime() { stat -c %Y "$1" 2>/dev/null; }
+fi
+_file_age() {  # seconds since mtime; very large if missing
+  local f=$1 m
+  m=$(_stat_file_mtime "$f") || { echo 999999; return; }
+  echo $(( $(date +%s) - m ))
+}
+
+# --- cron install ------------------------------------------------------------
+install_cron() {
+  local entry marker tmp log
+  log="$STATE/.watchdog-cron.log"
+  marker="# fm-watchdog:$FM_HOME"
+  entry="*/10 * * * * FM_HOME=$FM_HOME $SELF >> $log 2>&1 $marker"
+  if ! command -v crontab >/dev/null 2>&1; then
+    cat >&2 <<EOF
+error: crontab not found; install cron or schedule this manually:
+  every 10 min: FM_HOME=$FM_HOME $SELF
+Windows Task Scheduler alternative (from Windows, for WSL):
+  schtasks.exe /Create /SC MINUTE /MO 10 /TN firstmate-watchdog \\
+    /TR "wsl.exe -- sh -c 'FM_HOME=$FM_HOME $SELF'"
+EOF
+    return 1
+  fi
+  tmp=$(mktemp "${TMPDIR:-/tmp}/fm-watchdog-cron.XXXXXX")
+  crontab -l 2>/dev/null | grep -Fv "$marker" > "$tmp" || true
+  printf '%s\n' "$entry" >> "$tmp"
+  crontab "$tmp"
+  rm -f "$tmp"
+  echo "installed crontab entry: $entry"
+  if ! pgrep -x cron >/dev/null 2>&1 && ! pgrep -x crond >/dev/null 2>&1; then
+    echo "warning: no cron daemon process detected; on WSL start it with: sudo service cron start" >&2
+  fi
+  return 0
+}
+
+if [ "${1:-}" = --install-cron ]; then
+  install_cron
+  exit $?
+fi
+if [ "$#" -gt 0 ]; then
+  echo "error: unknown argument '$1' (see --help)" >&2
+  exit 2
+fi
+
+[ -d "$STATE" ] || { echo "error: state dir not found: $STATE" >&2; exit 2; }
+
+# --- visible alert channels ---------------------------------------------------
+# Summary text is sanitized to a conservative character set before reaching
+# powershell so no quoting context can ever be escaped.
+_alert_visible() {  # <condition> <summary>
+  local condition=$1 summary=$2 safe
+  case "${FM_WATCHDOG_ALERT_EXEC:-}" in
+    discard) return 0 ;;
+    '') : ;;
+    *) "${FM_WATCHDOG_ALERT_EXEC}" "$condition" "$summary" >/dev/null 2>&1 || true; return 0 ;;
+  esac
+  if command -v powershell.exe >/dev/null 2>&1; then
+    safe=$(printf '%s' "$summary" | tr -cd 'A-Za-z0-9 ._:()/-')
+    if command -v timeout >/dev/null 2>&1; then
+      timeout 12 powershell.exe -NoProfile -NonInteractive -Command \
+        "(New-Object -ComObject WScript.Shell).Popup('$safe',10,'firstmate watchdog',48) | Out-Null" \
+        >/dev/null 2>&1 || true
+    else
+      powershell.exe -NoProfile -NonInteractive -Command \
+        "(New-Object -ComObject WScript.Shell).Popup('$safe',10,'firstmate watchdog',48) | Out-Null" \
+        >/dev/null 2>&1 || true
+    fi
+    return 0
+  fi
+  if command -v notify-send >/dev/null 2>&1; then
+    notify-send -u critical "firstmate watchdog" "$summary" >/dev/null 2>&1 || true
+    return 0
+  fi
+  return 0
+}
+
+RC=0
+
+# _check <condition> <failing:0|1> <summary>: dedupe bookkeeping + alert firing.
+_check() {
+  local condition=$1 failing=$2 summary=$3 marker
+  marker="$STATE/.watchdog-alerted-$condition"
+  if [ "$failing" -eq 0 ]; then
+    rm -f "$marker" 2>/dev/null || true
+    return 0
+  fi
+  RC=1
+  if [ -e "$marker" ] && [ "$(_file_age "$marker")" -lt "$REALERT" ]; then
+    return 0  # still failing, but inside the dedupe window: stay quiet
+  fi
+  touch "$marker"
+  printf '[%s] %s: %s\n' "$(date +%Y-%m-%dT%H:%M:%S%z)" "$condition" "$summary" >> "$STATE/.watchdog-alarm"
+  echo "fm-watchdog ALARM ($condition): $summary" >&2
+  _alert_visible "$condition" "$summary"
+}
+
+# --- condition a: watcher beacon stale/missing while work is recorded --------
+work_recorded=0
+if [ -e "$STATE/.afk" ]; then
+  work_recorded=1
+else
+  for _m in "$STATE"/*.meta; do
+    [ -e "$_m" ] && { work_recorded=1; break; }
+  done
+fi
+beacon_failing=0
+beacon_age=$(_file_age "$STATE/.last-watcher-beat")
+if [ "$work_recorded" -eq 1 ] && [ "$beacon_age" -ge "$GRACE" ]; then
+  beacon_failing=1
+fi
+_check watcher-stale "$beacon_failing" \
+  "watcher beacon stale/missing (age ${beacon_age}s, grace ${GRACE}s) with work recorded in $FM_HOME"
+
+# --- condition b: away daemon dead while afk is on ----------------------------
+daemon_failing=0
+if [ -e "$STATE/.afk" ]; then
+  daemon_pid=$(cat "$STATE/.supervise-daemon.pid" 2>/dev/null || true)
+  case "$daemon_pid" in
+    ''|*[!0-9]*) daemon_failing=1 ;;
+    *) kill -0 "$daemon_pid" 2>/dev/null || daemon_failing=1 ;;
+  esac
+fi
+_check daemon-dead "$daemon_failing" \
+  "away-mode daemon not running while state/.afk is present in $FM_HOME"
+
+exit "$RC"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -46,6 +46,13 @@ Set the local, gitignored `config/backlog-backend` file to `manual` to force man
 Absent or `tasks-axi` selects the default tasks-axi backend.
 The file format is unchanged in both modes; tasks-axi and manual edits produce the same `## In flight`, `## Queued`, and `## Done` sections.
 
+## Refill target (config/refill-target)
+
+The local, gitignored `config/refill-target` file holds one integer: the number of live non-secondmate lanes this home wants working whenever the backlog has ready items.
+While it is present, `bin/fm-watch.sh` upgrades an otherwise-absorbable no-change heartbeat into an actionable `heartbeat (refill: ...)` wake whenever `tasks-axi ready` reports at least one ready item and live lanes are under the target, so a drained fleet with queued work re-wakes firstmate to dispatch instead of idling until the next crew event.
+Absent means no refill wakes and byte-identical heartbeat behavior to before this knob existed.
+The refill check never spawns anything itself; it only wakes firstmate, which dispatches through the ordinary intake path.
+
 ## Runtime backend (config/backend / FM_BACKEND)
 
 For spawn-capable adapters, the runtime session-provider backend controls where task windows/endpoints are created, captured, sent to, watched, and killed.

--- a/tests/fm-afk-inject-herdr-e2e.test.sh
+++ b/tests/fm-afk-inject-herdr-e2e.test.sh
@@ -507,8 +507,8 @@ test_scenario_d_max_defer() {
 
   [ -s "$STATE_DIR/.subsuper-inject-wedged" ] \
     || fail "Scenario D: a persistently pending real herdr composer never raised the max-defer wedge alarm"
-  [ -s "$STATE_DIR/.subsuper-escalations" ] \
-    || fail "Scenario D: the buffered escalation was lost instead of preserved during the wedge"
+  awk -F '\t' '$3=="escalation"' "$STATE_DIR/.wake-queue" 2>/dev/null | grep -F 'needs-decision' >/dev/null \
+    || fail "Scenario D: the escalation was lost instead of preserved durably in the wake queue during the wedge"
   if grep -q 'Supervisor escalate' "$LOG_FILE" 2>/dev/null; then
     fail "Scenario D: a digest was somehow logged as submitted despite the composer never clearing"
   fi

--- a/tests/fm-daemon.test.sh
+++ b/tests/fm-daemon.test.sh
@@ -596,17 +596,21 @@ test_escalate_batches_into_one_digest() {
   PATH="$fakebin:$PATH" FM_FAKE_TMUX_PANE_ALIVE=1 FM_FAKE_TMUX_SENT="$sent" \
     FM_FAKE_TMUX_CAPTURE="$capture" FM_ESCALATE_BATCH_SECS=0 escalate_flush "$state" \
     || fail "escalate_flush failed"
+  # Delivery contract: the digest content rides the durable wake queue, and the
+  # pane receives only the short static nudge.
   grep -F 'FIRSTMATE_OP: v1 away-supervisor: ' "$sent" >/dev/null \
-    || fail "batch digest lacks the exact current away-supervisor kind"
-  grep -F "event A" "$sent" >/dev/null || fail "batch digest missing event A"
-  grep -F "event B" "$sent" >/dev/null || fail "batch digest missing event B"
-  grep -F 'event A: done: PR 1 | event B: done: PR 2' "$sent" >/dev/null \
-    || fail "batch digest did not join events with literal ' | '"
+    || fail "nudge lacks the exact current away-supervisor kind"
+  grep -F 'fm-wake-drain.sh' "$sent" >/dev/null || fail "nudge does not point at the drain"
+  grep -F "event A" "$sent" >/dev/null && fail "digest body leaked into the composer (event A typed)"
+  awk -F '\t' '$3=="escalation"' "$state/.wake-queue" | grep -F 'event A: done: PR 1 | event B: done: PR 2' >/dev/null \
+    || fail "queue record missing the joined digest content"
+  [ "$(awk -F '\t' '$3=="escalation"' "$state/.wake-queue" | wc -l | tr -d ' ')" -eq 1 ] \
+    || fail "expected exactly one queued escalation record"
   [ -s "$state/.subsuper-escalations" ] && fail "escalation buffer not cleared after flush"
   [ -e "$state/.subsuper-escalations.since" ] && fail "first-append sidecar not cleared after flush"
   n=$(grep -c '\[ENTER\]' "$sent")
-  [ "$n" -eq 1 ] || fail "expected one injected digest, got $n send-keys submits"
-  pass "multiple escalations flush as a single batched digest"
+  [ "$n" -eq 1 ] || fail "expected one injected nudge, got $n send-keys submits"
+  pass "multiple escalations flush as one queued digest plus one static nudge"
 }
 
 test_escalate_batch_age_uses_first_append() {
@@ -623,8 +627,8 @@ test_escalate_batch_age_uses_first_append() {
   PATH="$fakebin:$PATH" FM_FAKE_TMUX_PANE_ALIVE=1 FM_FAKE_TMUX_SENT="$sent" \
     FM_FAKE_TMUX_CAPTURE="$capture" FM_ESCALATE_BATCH_SECS=90 FM_HOUSEKEEPING_TICK=0 \
     housekeeping "$state"
-  grep -F 'event A: done: PR 1 | event B: done: PR 2' "$sent" >/dev/null \
-    || fail "backdated batch did not flush as a joined digest (max-delay measured from last append)"
+  awk -F '\t' '$3=="escalation"' "$state/.wake-queue" | grep -F 'event A: done: PR 1 | event B: done: PR 2' >/dev/null \
+    || fail "backdated batch did not flush as a joined queued digest (max-delay measured from last append)"
   [ -s "$state/.subsuper-escalations" ] && fail "escalation buffer not cleared after backdated flush"
   [ -e "$state/.subsuper-escalations.since" ] && fail "first-append sidecar not cleared after flush"
   pass "batch flush measures max-delay from the first append, not the last"
@@ -759,8 +763,9 @@ test_busy_guard_defers_when_supervisor_busy() {
     fail "escalate_flush should defer when supervisor pane busy"
   fi
   [ -s "$sent" ] && fail "daemon injected into a busy pane"
-  [ -s "$state/.subsuper-escalations" ] || fail "buffer not preserved when deferred"
-  pass "busy-guard defers injection when supervisor pane is busy"
+  awk -F '\t' '$3=="escalation"' "$state/.wake-queue" | grep -F 'done: PR 1' >/dev/null \
+    || fail "escalation content not preserved durably in the queue when the nudge deferred"
+  pass "busy-guard defers the nudge when supervisor pane is busy; content stays durable in the queue"
 }
 
 test_marker_detection() {
@@ -1136,12 +1141,14 @@ test_max_defer_empty_swallow_types_once_and_alarms() {
     FM_FAKE_SWALLOW="$dir/.swallow" FM_FAKE_PERSIST_SWALLOW=1 FM_INJECT_CONFIRM_SLEEP=0.05 \
     FM_ESCALATE_BATCH_SECS=99999 FM_MAX_DEFER_SECS=60 housekeeping "$state"
   [ "$(grep -c 'Supervisor escalate' "$sent" 2>/dev/null || true)" -eq 1 ] \
-    || fail "max-defer typed the digest more than once"
+    || fail "max-defer typed the nudge more than once"
+  grep -F 'needs-decision: pick A' "$sent" >/dev/null \
+    && fail "digest body leaked into the composer on the max-defer path"
   [ -s "$state/.subsuper-inject-wedged" ] \
     || fail "stuck max-defer inject did not raise a wedge alarm marker"
-  [ -s "$state/.subsuper-escalations" ] \
-    || fail "buffer lost after a failed max-defer inject (must be preserved)"
-  pass "max-defer on an empty stuck pane types once, alarms, and preserves the buffer"
+  awk -F '\t' '$3=="escalation"' "$state/.wake-queue" | grep -F 'needs-decision: pick A' >/dev/null \
+    || fail "escalation content lost after a failed max-defer nudge (must stay durable in the queue)"
+  pass "max-defer on an empty stuck pane nudges once, alarms, and keeps content durable in the queue"
 }
 
 test_max_defer_flushes_empty_idle_pane() {
@@ -1175,7 +1182,8 @@ test_max_defer_pending_composer_alarms_without_typing() {
     housekeeping "$state"
   [ ! -s "$sent" ] || fail "max-defer typed into a pending composer"
   [ -s "$state/.subsuper-inject-wedged" ] || fail "pending composer did not raise a wedge alarm marker"
-  [ -s "$state/.subsuper-escalations" ] || fail "buffer lost while composer was pending"
+  awk -F '\t' '$3=="escalation"' "$state/.wake-queue" | grep -F 'needs-decision: pick B' >/dev/null \
+    || fail "escalation content lost while composer was pending (must stay durable in the queue)"
   grep -F 'human draft' "$dir/composer" >/dev/null || fail "pending composer content changed"
   pass "max-defer on a pending composer alarms without typing"
 }
@@ -1559,7 +1567,7 @@ test_inject_wedge_alarm_throttles_when_marker_cannot_be_written() {
   [ ! -e "$state/.subsuper-inject-wedged" ] || fail "wedge marker unexpectedly persisted in an unwritable state directory"
   alerts=$(grep -c 'osascript' "$log" 2>/dev/null || true)
   [ "$alerts" -eq 1 ] || fail "unwritable marker emitted $alerts active alerts instead of one"
-  errors=$(grep -c 'ERROR: away-mode escalation undelivered' "$daemon_log" 2>/dev/null || true)
+  errors=$(grep -c 'ERROR: away-mode wake nudge undelivered' "$daemon_log" 2>/dev/null || true)
   [ "$errors" -eq 1 ] || fail "unwritable marker logged $errors wedge errors instead of one"
   pass "in-process wedge throttle prevents alert spam when the marker cannot persist"
 }

--- a/tests/fm-send-strict.test.sh
+++ b/tests/fm-send-strict.test.sh
@@ -5,6 +5,11 @@
 # well-formed backend target must fail loudly. These tests pin the historical
 # silent-fallback failures: missing FM_HOME, unresolved selectors, prefixless
 # herdr pane ids, dead explicit endpoints, and the healthy exact/fm-id paths.
+# They also pin the other side of the loud-failure boundary: an inconclusive
+# submit verdict on a provably BUSY pane whose capture still shows the typed
+# text is a queued delivery (exit 0), never a "retype it" failure (the loop
+# audit 2026-08-02 double-queue false negative), while absent text keeps the
+# nonzero refusal.
 set -u
 
 # shellcheck source=tests/lib.sh
@@ -163,9 +168,72 @@ test_healthy_fm_id_send_still_works() {
   pass "fm-send strict: healthy fm-<id> sends still type once and submit"
 }
 
+# A minimal herdr CLI fake for the read-back boundary: server always running,
+# agent get always "working" (busy pane), pane read prints the file named by
+# FM_FAKE_HERDR_PANEFILE. send-text/send-keys succeed silently like the real
+# CLI. jq stays real (a required tool for the herdr adapter, same stance as
+# tests/fm-backend-herdr.test.sh).
+make_herdr_stub() {  # <fakebin-dir>
+  cat > "$1/herdr" <<'SH'
+#!/usr/bin/env bash
+set -u
+case "${1:-} ${2:-}" in
+  "status --json") printf '{"server":{"running":true}}\n'; exit 0 ;;
+  "agent get") printf '{"result":{"agent":{"agent_status":"working"}}}\n'; exit 0 ;;
+  "pane read") cat "${FM_FAKE_HERDR_PANEFILE:?}"; exit 0 ;;
+esac
+exit 0
+SH
+  chmod +x "$1/herdr"
+}
+
+setup_readback_home() {  # <name> -> echoes home dir
+  local home
+  home=$(setup_home "$1")
+  fm_write_meta "$home/state/rb-lane.meta" \
+    "window=default:wB:p2" "backend=herdr" "herdr_session=default" \
+    "herdr_pane_id=wB:p2" "kind=ship"
+  printf '%s\n' "$home"
+}
+
+test_busy_pane_queued_text_readback_exits_zero() {
+  command -v jq >/dev/null 2>&1 || { echo "note: jq not found; read-back cases not exercised"; return 0; }
+  local dir fb home err out rc
+  dir="$TMP_ROOT/readback-queued"; mkdir -p "$dir"
+  fb=$(make_stubs "$dir"); make_herdr_stub "$fb"; home=$(setup_readback_home rbq)
+  err="$dir/send.err"; out="$dir/send.out"
+  # The pane shows the steer wrapped in a bordered composer, split across rows:
+  # the condensed comparison must still find it.
+  printf '│ ship the fix, push github, │\n│ open PR, done: PR url │\n' > "$dir/pane.txt"
+  PATH="$fb:$PATH" FM_HOME="$home" FM_ROOT_OVERRIDE="$home" FM_SEND_SETTLE=0 FM_SEND_RETRIES=1 FM_SEND_SLEEP=0 \
+    FM_FAKE_HERDR_PANEFILE="$dir/pane.txt" \
+    "$SEND" rb-lane "ship the fix, push github, open PR, done: PR url" >"$out" 2>"$err"; rc=$?
+  expect_code 0 "$rc" "busy pane with queued text should read back as delivered"$'\n'"$(cat "$err")"
+  assert_contains "$(cat "$out")" "queued while pane busy" "read-back success should say the message was queued"
+  pass "fm-send strict: busy-pane queued text read-back exits zero"
+}
+
+test_busy_pane_absent_text_readback_still_fails() {
+  command -v jq >/dev/null 2>&1 || { echo "note: jq not found; read-back cases not exercised"; return 0; }
+  local dir fb home err rc
+  dir="$TMP_ROOT/readback-absent"; mkdir -p "$dir"
+  fb=$(make_stubs "$dir"); make_herdr_stub "$fb"; home=$(setup_readback_home rba)
+  err="$dir/send.err"
+  printf 'some unrelated transcript output\n' > "$dir/pane.txt"
+  PATH="$fb:$PATH" FM_HOME="$home" FM_ROOT_OVERRIDE="$home" FM_SEND_SETTLE=0 FM_SEND_RETRIES=1 FM_SEND_SLEEP=0 \
+    FM_FAKE_HERDR_PANEFILE="$dir/pane.txt" \
+    "$SEND" rb-lane "ship the fix, push github, open PR" >/dev/null 2>"$err"; rc=$?
+  [ "$rc" -ne 0 ] || fail "absent text should keep the nonzero refusal"
+  assert_contains "$(cat "$err")" "delivery unconfirmed" "absent-text failure should keep the unconfirmed diagnostic"
+  assert_contains "$(cat "$err")" "read-back: text absent from capture" "absent-text failure should name the read-back result"
+  pass "fm-send strict: busy-pane absent text keeps the loud refusal"
+}
+
 test_exact_lane_id_send_still_works
 test_unset_fm_home_fails
 test_unresolvable_target_does_not_tmux_fallback
 test_prefixless_herdr_pane_id_fails
 test_unmatched_single_colon_target_must_exist
 test_healthy_fm_id_send_still_works
+test_busy_pane_queued_text_readback_exits_zero
+test_busy_pane_absent_text_readback_still_fails

--- a/tests/fm-spawn-batch.test.sh
+++ b/tests/fm-spawn-batch.test.sh
@@ -102,6 +102,39 @@ ROWS
   pass "projects/ paths are scoped through the firstmate home for single-task spawn"
 }
 
+# A brief still carrying the scaffold's bare {TASK} line is refused fail-closed
+# at the placeholder preflight, which sits right after the missing-brief check
+# and before any endpoint/worktree side effect. Covers single-task and the
+# batch re-exec path (one unfilled pair must not stop the loop, matching the
+# batch guarantee above).
+test_unfilled_brief_placeholder_refused() {
+  local home projects out status id=nope-placeholder-z9 idb=nope-placeholder-z10
+  home="$TMP_ROOT/placeholder home"
+  projects="$TMP_ROOT/placeholder projects"
+  mkdir -p "$home/data/$id" "$projects/alpha"
+  printf '# Task\n{TASK}\n\nDo not add Herdr lifecycle commands by hand.\n' > "$home/data/$id/brief.md"
+
+  out=$(FM_ROOT_OVERRIDE='' FM_STATE_OVERRIDE='' FM_DATA_OVERRIDE='' FM_CONFIG_OVERRIDE='' \
+    FM_HOME="$home" FM_PROJECTS_OVERRIDE="$projects" FM_SPAWN_NO_GUARD=1 \
+    "$SPAWN" "$id" projects/alpha codex 2>&1)
+  status=$?
+  [ "$status" -ne 0 ] || fail "single spawn with unfilled {TASK} brief should exit non-zero"
+  printf '%s\n' "$out" | grep -F "error: brief $home/data/$id/brief.md still contains the unfilled scaffold placeholder {TASK}" >/dev/null \
+    || fail "single spawn did not report the placeholder preflight error"
+
+  out=$(FM_ROOT_OVERRIDE='' FM_STATE_OVERRIDE='' FM_DATA_OVERRIDE='' FM_CONFIG_OVERRIDE='' \
+    FM_HOME="$home" FM_PROJECTS_OVERRIDE="$projects" FM_SPAWN_NO_GUARD=1 \
+    "$SPAWN" "$id=projects/alpha" "$idb=projects/alpha" codex 2>&1)
+  status=$?
+  [ "$status" -ne 0 ] || fail "batch with unfilled {TASK} brief should exit non-zero"
+  printf '%s\n' "$out" | grep -F 'unfilled scaffold placeholder {TASK}' >/dev/null \
+    || fail "batch pair did not hit the placeholder preflight"
+  printf '%s\n' "$out" | grep -F "batch: FAILED to spawn $idb (projects/alpha)" >/dev/null \
+    || fail "batch stopped early after the placeholder refusal"
+  pass "unfilled {TASK} brief is refused for single and batch spawn, before side effects"
+}
+
 test_batch_dispatches_every_pair
 test_batch_mode_boundaries
 test_projects_path_scoping
+test_unfilled_brief_placeholder_refused

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -61,7 +61,11 @@ make_spawn_case() {
   touch "$home/state/.last-watcher-beat"
   for id in "$@"; do
     mkdir -p "$home/data/$id"
-    printf 'brief for %s\n' "$id" > "$home/data/$id/brief.md"
+    # The prose `{TASK}` mention mirrors the scaffold's Herdr NOT-ENABLED gate:
+    # every successful spawn below doubles as regression proof that the
+    # placeholder preflight only refuses a bare {TASK} line, not filled briefs.
+    # shellcheck disable=SC2016 # Backticks are literal brief prose.
+    printf 'brief for %s\nthis scaffold cannot inspect the task text that replaces `{TASK}` later.\n' "$id" > "$home/data/$id/brief.md"
   done
   printf '%s\n' "$case_dir|$home|$proj|$wt|$fakebin|$launchlog"
 }

--- a/tests/fm-teardown.test.sh
+++ b/tests/fm-teardown.test.sh
@@ -41,6 +41,14 @@
 #
 # Also covers backlog teardown-lock-race: a git index.lock left in the worktree by a
 # killed crew process (bin/fm-teardown.sh's teardown_treehouse_return).
+# Open-PR refusal (recorded pr= still open on the forge orphans the PR's owner
+# lane and merge poll; fail closed on lookup errors):
+#   (aa) pr= recorded + forge says OPEN                        -> REFUSE (names URL)
+#   (ab) pr= recorded + OPEN + worktree already gone           -> REFUSE (owner loss)
+#   (ac) pr= recorded + forge says MERGED, nothing unpushed    -> ALLOW
+#   (ad) pr= recorded + state lookup errors, work landed       -> REFUSE (fail closed)
+#   (ae) pr= recorded + OPEN + --force                         -> ALLOW (escape hatch)
+#
 #   (r) provably-stale index.lock (old mtime, no live holder) -> lock removed, ALLOW
 #   (s) index.lock with a live holder, any age                -> lock kept, REFUSE
 #   (t) lsof error while checking index.lock                  -> lock kept, REFUSE
@@ -228,6 +236,7 @@ case "\${1:-} \${2:-}" in
     case " \$* " in
       *"state,headRefOid"*) printf '%s\t%s\n' 'MERGED' '$head' ; exit 0 ;;
       *"headRefOid"*) printf '%s\n' '$head' ; exit 0 ;;
+      *"--json state -q .state"*) printf '%s\n' 'MERGED' ; exit 0 ;;
     esac
     ;;
 esac
@@ -235,6 +244,26 @@ echo "error: pull request not found" >&2
 exit 1
 SH
   chmod +x "$case_dir/fakebin/gh-axi" "$case_dir/fakebin/gh"
+}
+
+# Override the gh PR-state lookup only: `gh pr view <url> --json state -q .state`
+# reports the supplied state (OPEN, MERGED, CLOSED) and every other gh call
+# fails. Drives the open-PR teardown refusal without implying a merged head.
+add_gh_pr_state() {
+  local case_dir=$1 state=$2
+  cat > "$case_dir/fakebin/gh" <<SH
+#!/usr/bin/env bash
+case "\${1:-} \${2:-}" in
+  "pr view")
+    case " \$* " in
+      *"--json state -q .state"*) printf '%s\n' '$state' ; exit 0 ;;
+    esac
+    ;;
+esac
+echo "error: pull request not found" >&2
+exit 1
+SH
+  chmod +x "$case_dir/fakebin/gh"
 }
 
 append_pr_meta_for_current_head() {
@@ -520,6 +549,7 @@ test_teardown_prompts_tasks_axi_done_when_compatible() {
   case_dir=$(make_case tasks-axi-reminder)
   write_meta "$case_dir" no-mistakes ship
   printf '%s\n' 'pr=https://github.com/example/repo/pull/7' >> "$case_dir/state/task-x1.meta"
+  add_gh_pr_state "$case_dir" MERGED
   add_compatible_tasks_axi "$case_dir"
 
   out=$(run_teardown "$case_dir") || fail "teardown failed with compatible tasks-axi"
@@ -539,6 +569,7 @@ test_teardown_manual_backend_prompts_hand_edit_even_when_tasks_axi_present() {
   case_dir=$(make_case tasks-axi-manual-optout)
   write_meta "$case_dir" no-mistakes ship
   printf '%s\n' 'pr=https://github.com/example/repo/pull/7' >> "$case_dir/state/task-x1.meta"
+  add_gh_pr_state "$case_dir" MERGED
   printf '%s\n' manual > "$case_dir/config/backlog-backend"
   add_compatible_tasks_axi "$case_dir"
 
@@ -885,6 +916,100 @@ test_gh_error_and_content_absent_refuses() {
   expect_code 1 "$rc" "gh-error: teardown should refuse when the PR lookup errors and content is not landed"
   grep -q REFUSED "$case_dir/stderr" || fail "gh-error: no REFUSED line in stderr"
   pass "gh lookup error with content not in default refuses (fail-safe)"
+}
+
+test_open_pr_refuses() {
+  local case_dir rc
+  case_dir=$(make_case open-pr)
+  write_meta "$case_dir" no-mistakes ship
+  printf '%s\n' 'pr=https://github.com/example/repo/pull/7' >> "$case_dir/state/task-x1.meta"
+  # Nothing dirty and nothing unpushed: without the open-PR refusal this case
+  # tears down cleanly, which is exactly how the 2026-08-02 sweeps orphaned
+  # open PRs whose branches were already pushed.
+  add_gh_pr_state "$case_dir" OPEN
+
+  set +e
+  run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 1 "$rc" "open-pr: teardown should refuse while the recorded PR is open"
+  grep -q REFUSED "$case_dir/stderr" || fail "open-pr: no REFUSED line in stderr"
+  grep -qF 'https://github.com/example/repo/pull/7' "$case_dir/stderr" \
+    || fail "open-pr: refusal did not name the PR URL"
+  pass "recorded open PR refuses teardown even with nothing unpushed"
+}
+
+test_open_pr_refuses_when_worktree_gone() {
+  local case_dir rc
+  case_dir=$(make_case open-pr-no-wt)
+  write_meta "$case_dir" no-mistakes ship
+  printf '%s\n' 'pr=https://github.com/example/repo/pull/7' >> "$case_dir/state/task-x1.meta"
+  add_gh_pr_state "$case_dir" OPEN
+  # The orphan scenario: the lane's worktree is already gone, so every
+  # worktree-gated safety check is skipped; the open PR must still refuse.
+  git -C "$case_dir/project" worktree remove --force "$case_dir/wt"
+
+  set +e
+  run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 1 "$rc" "open-pr-no-wt: teardown should refuse an open PR even without a worktree"
+  grep -q REFUSED "$case_dir/stderr" || fail "open-pr-no-wt: no REFUSED line in stderr"
+  pass "recorded open PR refuses teardown even when the worktree is already gone"
+}
+
+test_merged_pr_state_allows() {
+  local case_dir rc
+  case_dir=$(make_case merged-pr-state)
+  write_meta "$case_dir" no-mistakes ship
+  printf '%s\n' 'pr=https://github.com/example/repo/pull/7' >> "$case_dir/state/task-x1.meta"
+  add_gh_pr_state "$case_dir" MERGED
+
+  set +e
+  run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 0 "$rc" "merged-pr-state: teardown should proceed once the PR is merged"
+  ! grep -q REFUSED "$case_dir/stderr" || fail "merged-pr-state: teardown printed a REFUSED line"
+  pass "merged PR state falls through to the ordinary landed checks"
+}
+
+test_pr_state_lookup_error_refuses() {
+  local case_dir rc
+  case_dir=$(make_case pr-state-error)
+  write_meta "$case_dir" no-mistakes ship
+  printf '%s\n' 'pr=https://github.com/example/repo/pull/7' >> "$case_dir/state/task-x1.meta"
+  # Nothing dirty or unpushed - the landed checks alone would allow - but the
+  # default gh mock fails every lookup, so the state is unknown and the guard
+  # must refuse rather than risk orphaning a possibly-open PR.
+
+  set +e
+  run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 1 "$rc" "pr-state-error: teardown should refuse when the PR state cannot be read"
+  grep -q REFUSED "$case_dir/stderr" || fail "pr-state-error: no REFUSED line in stderr"
+  pass "unreadable PR state refuses teardown (fail closed)"
+}
+
+test_open_pr_force_overrides() {
+  local case_dir rc
+  case_dir=$(make_case open-pr-force)
+  write_meta "$case_dir" no-mistakes ship
+  printf '%s\n' 'pr=https://github.com/example/repo/pull/7' >> "$case_dir/state/task-x1.meta"
+  add_gh_pr_state "$case_dir" OPEN
+
+  set +e
+  run_teardown "$case_dir" --force > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 0 "$rc" "open-pr-force: --force should keep its explicit-discard override"
+  pass "--force overrides the open-PR refusal (explicit discard authority preserved)"
 }
 
 test_stale_index_lock_cleared_and_teardown_succeeds() {
@@ -1853,6 +1978,11 @@ test_content_in_default_fallback_allows
 test_content_fallback_refreshes_stale_origin_ref
 test_dirty_worktree_refuses
 test_gh_error_and_content_absent_refuses
+test_open_pr_refuses
+test_open_pr_refuses_when_worktree_gone
+test_merged_pr_state_allows
+test_pr_state_lookup_error_refuses
+test_open_pr_force_overrides
 test_stale_index_lock_cleared_and_teardown_succeeds
 test_live_index_lock_is_never_removed_and_teardown_refuses
 test_lsof_error_never_clears_index_lock

--- a/tests/fm-wake-daemon-lifecycle-e2e.test.sh
+++ b/tests/fm-wake-daemon-lifecycle-e2e.test.sh
@@ -99,9 +99,20 @@ test_routine_then_terminal_after_restart() {
   PATH="$fakebin:$PATH" FM_FAKE_TMUX_PANE_ALIVE=1 FM_FAKE_TMUX_SENT="$sent" \
     FM_FAKE_TMUX_CAPTURE="$dir/pane.txt" FM_ESCALATE_BATCH_SECS=0 escalate_flush "$state" \
     || fail "escalate_flush failed for the buffered digest"
-  [ "$(grep -c '\[ENTER\]' "$sent")" -eq 1 ] || fail "buffered digest was not submitted exactly once"
+  [ "$(grep -c '\[ENTER\]' "$sent")" -eq 1 ] || fail "wake nudge was not submitted exactly once"
   [ ! -s "$state/.subsuper-escalations" ] || fail "buffer not cleared after a successful flush"
-  pass "lifecycle: routine self-handles, terminal survives a watcher restart, buffers once, no dup, injects once"
+  # Delivery contract: the digest content is a durable escalation record; the
+  # composer only ever carried the static nudge.
+  awk -F '\t' '$3=="escalation"' "$state/.wake-queue" | grep -F 'https://example.test/pr/900' >/dev/null \
+    || fail "queued escalation record missing the digest content"
+  grep -F 'https://example.test/pr/900' "$sent" >/dev/null \
+    && fail "digest body leaked into the composer instead of riding the queue"
+  # The drain surfaces the record to firstmate.
+  : > "$drain_out"
+  FM_STATE_OVERRIDE="$state" "$DRAIN" > "$drain_out" || fail "drain after escalation enqueue failed"
+  grep "$(printf '\tescalation\t')" "$drain_out" | grep -F 'https://example.test/pr/900' >/dev/null \
+    || fail "drain did not surface the queued escalation record"
+  pass "lifecycle: routine self-handles, terminal survives a watcher restart, buffers once, no dup, queues digest + nudges once"
 }
 
 # --- Phase 2: stale working-pane transient -> persistent -> resumed ----------

--- a/tests/fm-watch-triage.test.sh
+++ b/tests/fm-watch-triage.test.sh
@@ -1848,14 +1848,11 @@ test_afk_paused_changed_pane_hands_off_plain_stale
 
 # --- quiet stall, seat death, refill heartbeat, captain pulse ---------------
 
-# A churning idle pane (every capture differs, e.g. a ticking token counter)
-# never yields two identical hashes, so the stability path cannot see it.
-# quiet_stall_check must key on engagement signals instead and surface it.
-test_quiet_stall_churning_idle_pane_surfaced() {
-  local dir state fakebin out drain_out old pid
-  dir=$(make_case quiet-stall-churn); state="$dir/state"; fakebin="$dir/fakebin"
-  out="$dir/watch.out"; drain_out="$dir/drain.out"
-  cat > "$fakebin/tmux" <<'SH'
+# Shims the stock make_case fake cannot express: a pane whose capture churns
+# every read (defeats hash stability), and a pane whose capture fails with the
+# window absent from the inventory (a confidently dead agent).
+install_churn_tmux() {  # <fakebin>
+  cat > "$1/tmux" <<'SH'
 #!/usr/bin/env bash
 set -u
 case "${1:-}" in
@@ -1865,14 +1862,37 @@ case "${1:-}" in
 esac
 exit 1
 SH
-  chmod +x "$fakebin/tmux"
+  chmod +x "$1/tmux"
+}
+
+install_dead_tmux() {  # <fakebin>
+  cat > "$1/tmux" <<'SH'
+#!/usr/bin/env bash
+set -u
+case "${1:-}" in
+  list-windows) exit 0 ;;
+  capture-pane) exit 1 ;;
+esac
+exit 1
+SH
+  chmod +x "$1/tmux"
+}
+
+# A churning idle pane (every capture differs, e.g. a ticking token counter)
+# never yields two identical hashes, so the stability path cannot see it.
+# quiet_stall_check must key on engagement signals instead and surface it.
+test_quiet_stall_churning_idle_pane_surfaced() {
+  local dir state fakebin out drain_out old pid
+  dir=$(make_case quiet-stall-churn); state="$dir/state"; fakebin="$dir/fakebin"
+  out="$dir/watch.out"; drain_out="$dir/drain.out"
+  install_churn_tmux "$fakebin"
   printf 'window=default:w9\nkind=ship\nharness=claude\n' > "$state/qs.meta"
   printf 'working: chewing\n' > "$state/qs.status"
   old=$(( $(date +%s) - 1800 ))
   set_mtime "$old" "$state/qs.meta"
   set_mtime "$old" "$state/qs.status"
   printf '%s' "$(seen_sig "$state/qs.status")" > "$state/.seen-qs_status"
-  PATH="$fakebin:$PATH" FM_STATE_OVERRIDE="$state" FM_CREW_STATE_BIN="$fakebin/fm-crew-state.sh" FM_FAKE_CREW_STATE='state: unknown · source: none · no current-state source available'  \
+  PATH="$fakebin:$PATH" FM_STATE_OVERRIDE="$state" FM_CREW_STATE_BIN="$fakebin/fm-crew-state.sh" FM_FAKE_CREW_STATE='state: unknown · source: none · no current-state source available' \
     FM_POLL=1 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 \
     FM_QUIET_STALL_SECS=5 "$WATCH" > "$out" &
   pid=$!
@@ -1890,17 +1910,7 @@ test_quiet_stall_fresh_commit_absorbed() {
   local dir state fakebin out old wt pid
   dir=$(make_case quiet-stall-commit); state="$dir/state"; fakebin="$dir/fakebin"
   out="$dir/watch.out"; wt="$dir/wt"
-  cat > "$fakebin/tmux" <<'SH'
-#!/usr/bin/env bash
-set -u
-case "${1:-}" in
-  list-windows) printf 'w9\n'; exit 0 ;;
-  capture-pane) printf 'churn %s\n' "$(date +%s%N)"; exit 0 ;;
-  display-message) printf 'claude\n'; exit 0 ;;
-esac
-exit 1
-SH
-  chmod +x "$fakebin/tmux"
+  install_churn_tmux "$fakebin"
   git init -q "$wt" && git -C "$wt" -c user.email=t@t -c user.name=t commit -q --allow-empty -m x
   printf 'window=default:w9\nkind=ship\nharness=claude\nworktree=%s\n' "$wt" > "$state/qs.meta"
   printf 'working: chewing\n' > "$state/qs.status"
@@ -1908,7 +1918,7 @@ SH
   set_mtime "$old" "$state/qs.meta"
   set_mtime "$old" "$state/qs.status"
   printf '%s' "$(seen_sig "$state/qs.status")" > "$state/.seen-qs_status"
-  PATH="$fakebin:$PATH" FM_STATE_OVERRIDE="$state" FM_CREW_STATE_BIN="$fakebin/fm-crew-state.sh" FM_FAKE_CREW_STATE='state: unknown · source: none · no current-state source available'  \
+  PATH="$fakebin:$PATH" FM_STATE_OVERRIDE="$state" FM_CREW_STATE_BIN="$fakebin/fm-crew-state.sh" FM_FAKE_CREW_STATE='state: unknown · source: none · no current-state source available' \
     FM_POLL=1 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 \
     FM_QUIET_STALL_SECS=5 "$WATCH" > "$out" &
   pid=$!
@@ -1927,20 +1937,11 @@ test_seat_death_capture_failed_dead_agent_surfaced() {
   local dir state fakebin out drain_out pid
   dir=$(make_case seat-death); state="$dir/state"; fakebin="$dir/fakebin"
   out="$dir/watch.out"; drain_out="$dir/drain.out"
-  cat > "$fakebin/tmux" <<'SH'
-#!/usr/bin/env bash
-set -u
-case "${1:-}" in
-  list-windows) exit 0 ;;
-  capture-pane) exit 1 ;;
-esac
-exit 1
-SH
-  chmod +x "$fakebin/tmux"
+  install_dead_tmux "$fakebin"
   printf 'window=default:w8\nkind=ship\nharness=claude\n' > "$state/sd.meta"
   printf 'working: mid-flight\n' > "$state/sd.status"
   printf '%s' "$(seen_sig "$state/sd.status")" > "$state/.seen-sd_status"
-  PATH="$fakebin:$PATH" FM_STATE_OVERRIDE="$state" FM_CREW_STATE_BIN="$fakebin/fm-crew-state.sh" FM_FAKE_CREW_STATE='state: unknown · source: none · no current-state source available'  \
+  PATH="$fakebin:$PATH" FM_STATE_OVERRIDE="$state" FM_CREW_STATE_BIN="$fakebin/fm-crew-state.sh" FM_FAKE_CREW_STATE='state: unknown · source: none · no current-state source available' \
     FM_POLL=1 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$out" &
   pid=$!
   wait_for_exit "$pid" 120 || { reap "$pid"; fail "dead endpoint behind a non-terminal status was not surfaced: $(cat "$out")"; }
@@ -1957,21 +1958,12 @@ test_seat_death_terminal_status_keeps_signal_owner() {
   local dir state fakebin out pid
   dir=$(make_case seat-death-terminal); state="$dir/state"; fakebin="$dir/fakebin"
   out="$dir/watch.out"
-  cat > "$fakebin/tmux" <<'SH'
-#!/usr/bin/env bash
-set -u
-case "${1:-}" in
-  list-windows) exit 0 ;;
-  capture-pane) exit 1 ;;
-esac
-exit 1
-SH
-  chmod +x "$fakebin/tmux"
+  install_dead_tmux "$fakebin"
   printf 'window=default:w8\nkind=ship\nharness=claude\n' > "$state/sd.meta"
   printf 'done: PR https://example.test/pr/9\n' > "$state/sd.status"
   printf '%s' "$(seen_sig "$state/sd.status")" > "$state/.seen-sd_status"
   printf 'done: PR https://example.test/pr/9' > "$state/.hb-surfaced-sd"
-  PATH="$fakebin:$PATH" FM_STATE_OVERRIDE="$state" FM_CREW_STATE_BIN="$fakebin/fm-crew-state.sh" FM_FAKE_CREW_STATE='state: unknown · source: none · no current-state source available'  \
+  PATH="$fakebin:$PATH" FM_STATE_OVERRIDE="$state" FM_CREW_STATE_BIN="$fakebin/fm-crew-state.sh" FM_FAKE_CREW_STATE='state: unknown · source: none · no current-state source available' \
     FM_POLL=1 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$out" &
   pid=$!
   if ! wait_live "$pid" 30; then

--- a/tests/fm-watch-triage.test.sh
+++ b/tests/fm-watch-triage.test.sh
@@ -1845,3 +1845,186 @@ test_heartbeat_backstop_surfaces_unsurfaced_status
 test_beacon_stays_fresh_while_absorbing
 test_afk_present_reverts_watcher_to_one_shot
 test_afk_paused_changed_pane_hands_off_plain_stale
+
+# --- quiet stall, seat death, refill heartbeat, captain pulse ---------------
+
+# A churning idle pane (every capture differs, e.g. a ticking token counter)
+# never yields two identical hashes, so the stability path cannot see it.
+# quiet_stall_check must key on engagement signals instead and surface it.
+test_quiet_stall_churning_idle_pane_surfaced() {
+  local dir state fakebin out drain_out old pid
+  dir=$(make_case quiet-stall-churn); state="$dir/state"; fakebin="$dir/fakebin"
+  out="$dir/watch.out"; drain_out="$dir/drain.out"
+  cat > "$fakebin/tmux" <<'SH'
+#!/usr/bin/env bash
+set -u
+case "${1:-}" in
+  list-windows) printf 'w9\n'; exit 0 ;;
+  capture-pane) printf 'churn %s\n' "$(date +%s%N)"; exit 0 ;;
+  display-message) printf 'claude\n'; exit 0 ;;
+esac
+exit 1
+SH
+  chmod +x "$fakebin/tmux"
+  printf 'window=default:w9\nkind=ship\nharness=claude\n' > "$state/qs.meta"
+  printf 'working: chewing\n' > "$state/qs.status"
+  old=$(( $(date +%s) - 1800 ))
+  set_mtime "$old" "$state/qs.meta"
+  set_mtime "$old" "$state/qs.status"
+  printf '%s' "$(seen_sig "$state/qs.status")" > "$state/.seen-qs_status"
+  PATH="$fakebin:$PATH" FM_STATE_OVERRIDE="$state" FM_CREW_STATE_BIN="$fakebin/fm-crew-state.sh" FM_FAKE_CREW_STATE='state: unknown · source: none · no current-state source available'  \
+    FM_POLL=1 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 \
+    FM_QUIET_STALL_SECS=5 "$WATCH" > "$out" &
+  pid=$!
+  wait_for_exit "$pid" 120 || { reap "$pid"; fail "quiet stall on a churning idle pane was not surfaced: $(cat "$out")"; }
+  grep -F "quiet stall" "$out" >/dev/null || fail "quiet-stall wake reason missing: $(cat "$out")"
+  FM_STATE_OVERRIDE="$state" "$DRAIN" > "$drain_out" 2>/dev/null || fail "drain after quiet-stall wake failed"
+  grep -F "quiet stall" "$drain_out" >/dev/null || fail "quiet-stall wake was not durably queued"
+  [ -e "$state/.quietstall-default_w9" ] || fail "quiet-stall re-fire throttle marker was not recorded"
+  pass "a churning idle pane with no engagement signals surfaces as a quiet stall"
+}
+
+# A fresh worktree commit is an engagement signal: the same fixture with a
+# just-committed worktree must absorb instead of firing.
+test_quiet_stall_fresh_commit_absorbed() {
+  local dir state fakebin out old wt pid
+  dir=$(make_case quiet-stall-commit); state="$dir/state"; fakebin="$dir/fakebin"
+  out="$dir/watch.out"; wt="$dir/wt"
+  cat > "$fakebin/tmux" <<'SH'
+#!/usr/bin/env bash
+set -u
+case "${1:-}" in
+  list-windows) printf 'w9\n'; exit 0 ;;
+  capture-pane) printf 'churn %s\n' "$(date +%s%N)"; exit 0 ;;
+  display-message) printf 'claude\n'; exit 0 ;;
+esac
+exit 1
+SH
+  chmod +x "$fakebin/tmux"
+  git init -q "$wt" && git -C "$wt" -c user.email=t@t -c user.name=t commit -q --allow-empty -m x
+  printf 'window=default:w9\nkind=ship\nharness=claude\nworktree=%s\n' "$wt" > "$state/qs.meta"
+  printf 'working: chewing\n' > "$state/qs.status"
+  old=$(( $(date +%s) - 1800 ))
+  set_mtime "$old" "$state/qs.meta"
+  set_mtime "$old" "$state/qs.status"
+  printf '%s' "$(seen_sig "$state/qs.status")" > "$state/.seen-qs_status"
+  PATH="$fakebin:$PATH" FM_STATE_OVERRIDE="$state" FM_CREW_STATE_BIN="$fakebin/fm-crew-state.sh" FM_FAKE_CREW_STATE='state: unknown · source: none · no current-state source available'  \
+    FM_POLL=1 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 \
+    FM_QUIET_STALL_SECS=5 "$WATCH" > "$out" &
+  pid=$!
+  if ! wait_live "$pid" 30; then
+    reap "$pid"; fail "quiet-stall fired despite a fresh worktree commit: $(cat "$out")"
+  fi
+  [ ! -s "$state/.wake-queue" ] || fail "fresh-commit case enqueued a durable wake"
+  reap "$pid"
+  pass "a fresh worktree commit suppresses the quiet-stall wake"
+}
+
+# A pane whose capture fails and whose backend confirms the agent gone, while
+# the task's last status is non-terminal, is a silent seat death: it must
+# surface instead of being skipped by the capture guard forever.
+test_seat_death_capture_failed_dead_agent_surfaced() {
+  local dir state fakebin out drain_out pid
+  dir=$(make_case seat-death); state="$dir/state"; fakebin="$dir/fakebin"
+  out="$dir/watch.out"; drain_out="$dir/drain.out"
+  cat > "$fakebin/tmux" <<'SH'
+#!/usr/bin/env bash
+set -u
+case "${1:-}" in
+  list-windows) exit 0 ;;
+  capture-pane) exit 1 ;;
+esac
+exit 1
+SH
+  chmod +x "$fakebin/tmux"
+  printf 'window=default:w8\nkind=ship\nharness=claude\n' > "$state/sd.meta"
+  printf 'working: mid-flight\n' > "$state/sd.status"
+  printf '%s' "$(seen_sig "$state/sd.status")" > "$state/.seen-sd_status"
+  PATH="$fakebin:$PATH" FM_STATE_OVERRIDE="$state" FM_CREW_STATE_BIN="$fakebin/fm-crew-state.sh" FM_FAKE_CREW_STATE='state: unknown · source: none · no current-state source available'  \
+    FM_POLL=1 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$out" &
+  pid=$!
+  wait_for_exit "$pid" 120 || { reap "$pid"; fail "dead endpoint behind a non-terminal status was not surfaced: $(cat "$out")"; }
+  grep -F "endpoint dead" "$out" >/dev/null || fail "seat-death wake reason missing: $(cat "$out")"
+  FM_STATE_OVERRIDE="$state" "$DRAIN" > "$drain_out" 2>/dev/null || fail "drain after seat-death wake failed"
+  grep -F "endpoint dead" "$drain_out" >/dev/null || fail "seat-death wake was not durably queued"
+  [ -e "$state/.seatdeath-default_w8" ] || fail "seat-death re-fire throttle marker was not recorded"
+  pass "a capture-failed pane with a confirmed-dead agent and non-terminal status surfaces"
+}
+
+# The same dead endpoint behind an already captain-relevant status keeps its
+# existing signal-path owner: no seat-death wake.
+test_seat_death_terminal_status_keeps_signal_owner() {
+  local dir state fakebin out pid
+  dir=$(make_case seat-death-terminal); state="$dir/state"; fakebin="$dir/fakebin"
+  out="$dir/watch.out"
+  cat > "$fakebin/tmux" <<'SH'
+#!/usr/bin/env bash
+set -u
+case "${1:-}" in
+  list-windows) exit 0 ;;
+  capture-pane) exit 1 ;;
+esac
+exit 1
+SH
+  chmod +x "$fakebin/tmux"
+  printf 'window=default:w8\nkind=ship\nharness=claude\n' > "$state/sd.meta"
+  printf 'done: PR https://example.test/pr/9\n' > "$state/sd.status"
+  printf '%s' "$(seen_sig "$state/sd.status")" > "$state/.seen-sd_status"
+  printf 'done: PR https://example.test/pr/9' > "$state/.hb-surfaced-sd"
+  PATH="$fakebin:$PATH" FM_STATE_OVERRIDE="$state" FM_CREW_STATE_BIN="$fakebin/fm-crew-state.sh" FM_FAKE_CREW_STATE='state: unknown · source: none · no current-state source available'  \
+    FM_POLL=1 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$out" &
+  pid=$!
+  if ! wait_live "$pid" 30; then
+    reap "$pid"; fail "seat-death fired for an already captain-relevant status: $(cat "$out")"
+  fi
+  [ ! -s "$state/.wake-queue" ] || fail "terminal-status seat death enqueued a durable wake"
+  reap "$pid"
+  pass "a dead endpoint behind a captain-relevant status stays with the signal path"
+}
+
+# config/refill-target + ready backlog + lanes under target upgrades a
+# no-change heartbeat into an actionable refill wake.
+test_heartbeat_refill_target_surfaces_idle_fleet() {
+  local dir state fakebin out drain_out pid
+  dir=$(make_case heartbeat-refill); state="$dir/state"; fakebin="$dir/fakebin"
+  out="$dir/watch.out"; drain_out="$dir/drain.out"
+  mkdir -p "$dir/config"
+  printf '3\n' > "$dir/config/refill-target"
+  cat > "$fakebin/tasks-axi" <<'SH'
+#!/usr/bin/env bash
+[ "${1:-}" = ready ] && printf 'count: 2\nready[2]{id}:\n  a\n  b\n'
+exit 0
+SH
+  chmod +x "$fakebin/tasks-axi"
+  PATH="$fakebin:$PATH" FM_HOME="$dir" FM_STATE_OVERRIDE="$state" FM_FAKE_CREW_STATE='state: unknown · source: none · no current-state source available' FM_POLL=1 FM_SIGNAL_GRACE=1 \
+    FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=1 "$WATCH" > "$out" &
+  pid=$!
+  wait_for_exit "$pid" 120 || { reap "$pid"; fail "refill heartbeat did not surface an idle fleet with ready backlog: $(cat "$out")"; }
+  grep -F "refill:" "$out" >/dev/null || fail "refill wake reason missing: $(cat "$out")"
+  FM_STATE_OVERRIDE="$state" "$DRAIN" > "$drain_out" 2>/dev/null || fail "drain after refill wake failed"
+  grep -F "refill:" "$drain_out" >/dev/null || fail "refill wake was not durably queued"
+  pass "an idle fleet with ready backlog under config/refill-target surfaces a refill heartbeat"
+}
+
+# Every poll overwrites the captain pulse line, so healthy quiet stays
+# distinguishable from a dead loop.
+test_captain_pulse_written_every_poll() {
+  local dir state fakebin out pid
+  dir=$(make_case captain-pulse); state="$dir/state"; fakebin="$dir/fakebin"; out="$dir/watch.out"
+  PATH="$fakebin:$PATH" FM_STATE_OVERRIDE="$state" FM_FAKE_CREW_STATE='state: unknown · source: none · no current-state source available' FM_POLL=1 FM_SIGNAL_GRACE=1 \
+    FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$out" &
+  pid=$!
+  wait_live "$pid" 20 || { reap "$pid"; fail "watcher exited unexpectedly while asserting the pulse: $(cat "$out")"; }
+  [ -s "$state/.captain-pulse" ] || { reap "$pid"; fail "state/.captain-pulse was not written"; }
+  grep -F "watcher alive" "$state/.captain-pulse" >/dev/null || { reap "$pid"; fail "pulse line lacks the liveness marker: $(cat "$state/.captain-pulse")"; }
+  grep -F "live-lanes=0" "$state/.captain-pulse" >/dev/null || { reap "$pid"; fail "pulse line lacks the lane count: $(cat "$state/.captain-pulse")"; }
+  reap "$pid"
+  pass "the captain pulse is overwritten every poll with lanes, queue depth, and event age"
+}
+
+test_quiet_stall_churning_idle_pane_surfaced
+test_quiet_stall_fresh_commit_absorbed
+test_seat_death_capture_failed_dead_agent_surfaced
+test_seat_death_terminal_status_keeps_signal_owner
+test_heartbeat_refill_target_surfaces_idle_fleet
+test_captain_pulse_written_every_poll

--- a/tests/fm-watch-triage.test.sh
+++ b/tests/fm-watch-triage.test.sh
@@ -2014,9 +2014,66 @@ test_captain_pulse_written_every_poll() {
   pass "the captain pulse is overwritten every poll with lanes, queue depth, and event age"
 }
 
+# A recorded task is not a live one. Counting records alone reported a working
+# fleet after every endpoint had died (2026-08-05: the pulse read live-lanes=7
+# with nothing running, and the refill gate stayed above target so a drained
+# fleet never refilled). Only an authoritative dead/missing endpoint is
+# excluded; an unreadable backend still counts, so it can never inflate
+# dispatch by under-reporting.
+test_live_lane_count_excludes_dead_endpoints() (
+  local dir state fakebin
+  dir=$(make_case live-lane-liveness); state="$dir/state"; fakebin="$dir/fakebin"
+  # Two recorded ship tasks plus one secondmate; the fake tmux reports an empty
+  # window inventory, so every endpoint resolves authoritatively missing.
+  fm_write_meta "$state/dead-a.meta" "window=sess:fm-dead-a" "backend=tmux" "kind=ship"
+  fm_write_meta "$state/dead-b.meta" "window=sess:fm-dead-b" "backend=tmux" "kind=ship"
+  fm_write_meta "$state/mate.meta" "window=sess:fm-mate" "backend=tmux" "kind=secondmate"
+  FM_HOME="$dir"
+  FM_STATE_OVERRIDE="$state"
+  export FM_HOME FM_STATE_OVERRIDE
+  PATH="$fakebin:$PATH"
+  export PATH
+  # shellcheck source=/dev/null
+  . "$ROOT/bin/fm-watch.sh"
+  [ "$(count_recorded_lanes)" = 2 ] \
+    || fail "recorded count did not see both non-secondmate tasks: $(count_recorded_lanes)"
+  [ "$(count_live_lanes)" = 0 ] \
+    || fail "dead endpoints still counted as live lanes: $(count_live_lanes)"
+  # An unreadable backend is not proof of death, so it must keep counting.
+  # shellcheck disable=SC2329 # Runtime override called by the sourced watcher.
+  fm_backend_agent_alive() { printf 'unknown'; }
+  [ "$(count_live_lanes)" = 2 ] \
+    || fail "an unreadable backend under-reported live lanes: $(count_live_lanes)"
+  # shellcheck disable=SC2329 # Runtime override called by the sourced watcher.
+  fm_backend_agent_alive() { printf 'alive'; }
+  [ "$(count_live_lanes)" = 2 ] || fail "live endpoints were not counted: $(count_live_lanes)"
+  pass "a live lane is a recorded task with an endpoint that is not authoritatively gone"
+)
+
+# The pulse must not read as a working fleet when every recorded endpoint is
+# gone; it shows the live count and, when they differ, the recorded total.
+test_captain_pulse_reports_dead_endpoints_as_zero() {
+  local dir state fakebin out pid
+  dir=$(make_case captain-pulse-dead); state="$dir/state"; fakebin="$dir/fakebin"; out="$dir/watch.out"
+  fm_write_meta "$state/dead-a.meta" "window=sess:fm-dead-a" "backend=tmux" "kind=ship"
+  fm_write_meta "$state/dead-b.meta" "window=sess:fm-dead-b" "backend=tmux" "kind=ship"
+  PATH="$fakebin:$PATH" FM_STATE_OVERRIDE="$state" FM_FAKE_CREW_STATE='state: unknown · source: none · no current-state source available' FM_POLL=1 FM_SIGNAL_GRACE=1 \
+    FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$out" &
+  pid=$!
+  wait_live "$pid" 20 || { reap "$pid"; fail "watcher exited unexpectedly while asserting the pulse: $(cat "$out")"; }
+  wait_numeric_file "$state/.captain-pulse" 40 >/dev/null 2>&1 || true
+  [ -s "$state/.captain-pulse" ] || { reap "$pid"; fail "state/.captain-pulse was not written"; }
+  grep -F "live-lanes=0 (of 2 recorded)" "$state/.captain-pulse" >/dev/null \
+    || { reap "$pid"; fail "the pulse reported dead endpoints as live lanes: $(cat "$state/.captain-pulse")"; }
+  reap "$pid"
+  pass "the captain pulse reports a fleet of dead endpoints as zero live lanes"
+}
+
 test_quiet_stall_churning_idle_pane_surfaced
 test_quiet_stall_fresh_commit_absorbed
 test_seat_death_capture_failed_dead_agent_surfaced
 test_seat_death_terminal_status_keeps_signal_owner
 test_heartbeat_refill_target_surfaces_idle_fleet
 test_captain_pulse_written_every_poll
+test_live_lane_count_excludes_dead_endpoints
+test_captain_pulse_reports_dead_endpoints_as_zero

--- a/tests/fm-watchdog.test.sh
+++ b/tests/fm-watchdog.test.sh
@@ -1,0 +1,267 @@
+#!/usr/bin/env bash
+# tests/fm-watchdog.test.sh - external cron-level watchdog: healthy silence,
+# stale-beacon and dead-daemon alarms, dedupe window, idle-home indifference,
+# marker cleanup on recovery, channel-order fallback, and idempotent cron
+# install. All visible-alert channels are stubbed (FM_WATCHDOG_ALERT_EXEC seam
+# or fakebin PATH shims); no test can raise a real popup or touch a real
+# crontab.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+WATCHDOG="$ROOT/bin/fm-watchdog.sh"
+
+TMP_ROOT=$(fm_test_tmproot fm-watchdog-tests)
+
+# make_home <name>: fresh fake FM_HOME with a state dir; echoes the home path.
+make_home() {
+  local name=$1 home
+  home="$TMP_ROOT/$name"
+  mkdir -p "$home/state"
+  printf '%s\n' "$home"
+}
+
+# recorder <dir>: drop an alert-seam recorder appending "<condition>\t<summary>"
+# to $dir/alerts.log; echoes the recorder path.
+make_recorder() {
+  local dir=$1
+  cat > "$dir/rec" <<'REC'
+#!/usr/bin/env bash
+printf '%s\t%s\n' "${1:-}" "${2:-}" >> "$(dirname "${BASH_SOURCE[0]}")/alerts.log"
+exit 0
+REC
+  chmod +x "$dir/rec"
+  printf '%s\n' "$dir/rec"
+}
+
+run_wd() {  # <home> [env overrides...] -- runs one watchdog pass, captures rc
+  local home=$1
+  shift
+  env FM_HOME="$home" "$@" "$WATCHDOG"
+}
+
+test_healthy_home_is_silent() {
+  local home rec out rc=0
+  home=$(make_home healthy)
+  rec=$(make_recorder "$home")
+  printf 'window=w1\n' > "$home/state/live-task.meta"
+  touch "$home/state/.last-watcher-beat"
+  out=$(run_wd "$home" FM_WATCHDOG_ALERT_EXEC="$rec" 2>&1) || rc=$?
+  [ "$rc" -eq 0 ] || fail "healthy home exited $rc: $out"
+  [ -z "$out" ] || fail "healthy home was not silent: $out"
+  [ ! -e "$home/state/.watchdog-alarm" ] || fail "healthy home wrote an alarm file"
+  [ ! -e "$home/alerts.log" ] || fail "healthy home fired a visible alert"
+  pass "healthy home: silent, exit 0, no alarm record"
+}
+
+test_stale_beacon_with_work_alarms() {
+  local home rec rc=0
+  home=$(make_home stale-beacon)
+  rec=$(make_recorder "$home")
+  printf 'window=w1\n' > "$home/state/live-task.meta"
+  touch -d '@1' "$home/state/.last-watcher-beat"
+  run_wd "$home" FM_WATCHDOG_ALERT_EXEC="$rec" 2>/dev/null || rc=$?
+  [ "$rc" -eq 1 ] || fail "stale beacon with work exited $rc, want 1"
+  grep -q 'watcher-stale' "$home/state/.watchdog-alarm" || fail "no watcher-stale alarm line"
+  grep -q $'^watcher-stale\t' "$home/alerts.log" || fail "no visible watcher-stale alert"
+  pass "stale beacon with recorded work: alarm line + visible alert + exit 1"
+}
+
+test_missing_beacon_with_work_alarms() {
+  local home rec rc=0
+  home=$(make_home missing-beacon)
+  rec=$(make_recorder "$home")
+  printf 'window=w1\n' > "$home/state/live-task.meta"
+  run_wd "$home" FM_WATCHDOG_ALERT_EXEC="$rec" 2>/dev/null || rc=$?
+  [ "$rc" -eq 1 ] || fail "missing beacon with work exited $rc, want 1"
+  grep -q 'watcher-stale' "$home/state/.watchdog-alarm" || fail "no watcher-stale alarm line"
+  pass "missing beacon with recorded work alarms"
+}
+
+test_afk_dead_daemon_alarms() {
+  local home rec dead_pid rc=0
+  home=$(make_home afk-dead-daemon)
+  rec=$(make_recorder "$home")
+  touch "$home/state/.afk"
+  touch "$home/state/.last-watcher-beat"
+  dead_pid=999999
+  while kill -0 "$dead_pid" 2>/dev/null; do dead_pid=$((dead_pid + 1)); done
+  printf '%s\n' "$dead_pid" > "$home/state/.supervise-daemon.pid"
+  run_wd "$home" FM_WATCHDOG_ALERT_EXEC="$rec" 2>/dev/null || rc=$?
+  [ "$rc" -eq 1 ] || fail "afk + dead daemon exited $rc, want 1"
+  grep -q 'daemon-dead' "$home/state/.watchdog-alarm" || fail "no daemon-dead alarm line"
+  grep -q $'^daemon-dead\t' "$home/alerts.log" || fail "no visible daemon-dead alert"
+  pass "afk with dead daemon pid: daemon-dead alarm"
+}
+
+test_afk_missing_pidfile_alarms() {
+  local home rec rc=0
+  home=$(make_home afk-no-pidfile)
+  rec=$(make_recorder "$home")
+  touch "$home/state/.afk"
+  touch "$home/state/.last-watcher-beat"
+  run_wd "$home" FM_WATCHDOG_ALERT_EXEC="$rec" 2>/dev/null || rc=$?
+  [ "$rc" -eq 1 ] || fail "afk + missing pidfile exited $rc, want 1"
+  grep -q 'daemon-dead' "$home/state/.watchdog-alarm" || fail "no daemon-dead alarm line"
+  pass "afk with missing daemon pidfile: daemon-dead alarm"
+}
+
+test_afk_live_daemon_is_healthy() {
+  local home rec rc=0
+  home=$(make_home afk-live-daemon)
+  rec=$(make_recorder "$home")
+  touch "$home/state/.afk"
+  touch "$home/state/.last-watcher-beat"
+  printf '%s\n' "$$" > "$home/state/.supervise-daemon.pid"
+  run_wd "$home" FM_WATCHDOG_ALERT_EXEC="$rec" 2>/dev/null || rc=$?
+  [ "$rc" -eq 0 ] || fail "afk + live daemon exited $rc, want 0"
+  [ ! -e "$home/state/.watchdog-alarm" ] || fail "live daemon produced an alarm"
+  pass "afk with live daemon pid: healthy"
+}
+
+test_dedupe_window_suppresses_second_alert() {
+  local home rec rc=0
+  home=$(make_home dedupe)
+  rec=$(make_recorder "$home")
+  printf 'window=w1\n' > "$home/state/live-task.meta"
+  touch -d '@1' "$home/state/.last-watcher-beat"
+  run_wd "$home" FM_WATCHDOG_ALERT_EXEC="$rec" 2>/dev/null || true
+  rc=0
+  run_wd "$home" FM_WATCHDOG_ALERT_EXEC="$rec" 2>/dev/null || rc=$?
+  [ "$rc" -eq 1 ] || fail "deduped failing pass exited $rc, want 1"
+  [ "$(wc -l < "$home/state/.watchdog-alarm")" -eq 1 ] || fail "dedupe window appended a second alarm line"
+  [ "$(wc -l < "$home/alerts.log")" -eq 1 ] || fail "dedupe window fired a second visible alert"
+  pass "second failing pass inside dedupe window: quiet but still exit 1"
+}
+
+test_realert_after_window_elapses() {
+  local home rec
+  home=$(make_home realert)
+  rec=$(make_recorder "$home")
+  printf 'window=w1\n' > "$home/state/live-task.meta"
+  touch -d '@1' "$home/state/.last-watcher-beat"
+  run_wd "$home" FM_WATCHDOG_ALERT_EXEC="$rec" 2>/dev/null || true
+  touch -d '@1' "$home/state/.watchdog-alerted-watcher-stale"
+  run_wd "$home" FM_WATCHDOG_ALERT_EXEC="$rec" 2>/dev/null || true
+  [ "$(wc -l < "$home/state/.watchdog-alarm")" -eq 2 ] || fail "elapsed re-alert window did not re-alert"
+  pass "re-alert fires again after FM_WATCHDOG_REALERT elapses"
+}
+
+test_recovery_clears_marker() {
+  local home rec rc=0
+  home=$(make_home recovery)
+  rec=$(make_recorder "$home")
+  printf 'window=w1\n' > "$home/state/live-task.meta"
+  touch -d '@1' "$home/state/.last-watcher-beat"
+  run_wd "$home" FM_WATCHDOG_ALERT_EXEC="$rec" 2>/dev/null || true
+  [ -e "$home/state/.watchdog-alerted-watcher-stale" ] || fail "failing pass left no dedupe marker"
+  touch "$home/state/.last-watcher-beat"
+  run_wd "$home" FM_WATCHDOG_ALERT_EXEC="$rec" 2>/dev/null || rc=$?
+  [ "$rc" -eq 0 ] || fail "recovered home exited $rc, want 0"
+  [ ! -e "$home/state/.watchdog-alerted-watcher-stale" ] || fail "recovery did not clear the dedupe marker"
+  pass "recovered condition clears its dedupe marker"
+}
+
+test_idle_home_ignores_beacon() {
+  local home rec out rc=0
+  home=$(make_home idle)
+  rec=$(make_recorder "$home")
+  out=$(run_wd "$home" FM_WATCHDOG_ALERT_EXEC="$rec" 2>&1) || rc=$?
+  [ "$rc" -eq 0 ] || fail "idle home (no metas, no afk, no beacon) exited $rc: $out"
+  [ -z "$out" ] || fail "idle home was not silent: $out"
+  pass "idle home: missing beacon is healthy with no work recorded"
+}
+
+test_channel_order_prefers_powershell() {
+  local home fakebin rc=0
+  home=$(make_home channels)
+  fakebin=$(fm_fakebin "$home")
+  cat > "$fakebin/powershell.exe" <<SH
+#!/usr/bin/env bash
+echo "ps-invoked \$*" >> "$home/ps.log"
+exit 0
+SH
+  chmod +x "$fakebin/powershell.exe"
+  cat > "$fakebin/notify-send" <<SH
+#!/usr/bin/env bash
+echo "ns-invoked" >> "$home/ns.log"
+exit 0
+SH
+  chmod +x "$fakebin/notify-send"
+  printf 'window=w1\n' > "$home/state/live-task.meta"
+  touch -d '@1' "$home/state/.last-watcher-beat"
+  PATH="$fakebin:$PATH" run_wd "$home" 2>/dev/null || rc=$?
+  [ "$rc" -eq 1 ] || fail "channel-order pass exited $rc, want 1"
+  [ -e "$home/ps.log" ] || fail "powershell.exe channel was not used"
+  [ ! -e "$home/ns.log" ] || fail "notify-send fired although powershell.exe was available"
+  pass "alert channel order: powershell.exe wins when present"
+}
+
+test_missing_fm_home_fails_closed() {
+  local rc=0
+  env -u FM_HOME "$WATCHDOG" 2>/dev/null || rc=$?
+  [ "$rc" -eq 2 ] || fail "missing FM_HOME exited $rc, want 2"
+  pass "missing FM_HOME refuses with exit 2"
+}
+
+test_install_cron_idempotent() {
+  local home fakebin crontab_store out
+  home=$(make_home cron-install)
+  fakebin=$(fm_fakebin "$home")
+  crontab_store="$home/crontab.store"
+  : > "$crontab_store"
+  cat > "$fakebin/crontab" <<SH
+#!/usr/bin/env bash
+if [ "\${1:-}" = "-l" ]; then cat "$crontab_store"; exit 0; fi
+cat "\$1" > "$crontab_store"
+SH
+  chmod +x "$fakebin/crontab"
+  cat > "$fakebin/pgrep" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+  chmod +x "$fakebin/pgrep"
+  out=$(PATH="$fakebin:$PATH" env FM_HOME="$home" "$WATCHDOG" --install-cron 2>&1) || fail "install-cron failed: $out"
+  out=$(PATH="$fakebin:$PATH" env FM_HOME="$home" "$WATCHDOG" --install-cron 2>&1) || fail "second install-cron failed: $out"
+  [ "$(grep -c "fm-watchdog:$home" "$crontab_store")" -eq 1 ] || fail "install-cron stacked duplicate entries"
+  grep -q '\*/10 \* \* \* \*' "$crontab_store" || fail "installed entry is not every-10-minutes"
+  pass "install-cron is idempotent for the same home"
+}
+
+test_install_cron_without_crontab_instructs() {
+  local home fakebin out rc=0
+  home=$(make_home cron-missing)
+  fakebin=$(fm_fakebin "$home")
+  # Restrict PATH to the fakebin plus core utils so `crontab` is absent.
+  cat > "$fakebin/runner" <<SH
+#!/usr/bin/env bash
+export PATH="/usr/bin:/bin"
+command -v crontab >/dev/null 2>&1 && exit 77
+FM_HOME="$home" "$WATCHDOG" --install-cron
+SH
+  chmod +x "$fakebin/runner"
+  out=$("$fakebin/runner" 2>&1) || rc=$?
+  if [ "$rc" -eq 77 ]; then
+    pass "install-cron missing-crontab case skipped (host has crontab in /usr/bin)"
+    return 0
+  fi
+  [ "$rc" -eq 1 ] || fail "install-cron without crontab exited $rc, want 1"
+  printf '%s' "$out" | grep -q 'schtasks.exe' || fail "manual instructions lack the schtasks.exe alternative"
+  pass "install-cron without crontab prints manual + schtasks instructions"
+}
+
+test_healthy_home_is_silent
+test_stale_beacon_with_work_alarms
+test_missing_beacon_with_work_alarms
+test_afk_dead_daemon_alarms
+test_afk_missing_pidfile_alarms
+test_afk_live_daemon_is_healthy
+test_dedupe_window_suppresses_second_alert
+test_realert_after_window_elapses
+test_recovery_clears_marker
+test_idle_home_ignores_beacon
+test_channel_order_prefers_powershell
+test_missing_fm_home_fails_closed
+test_install_cron_idempotent
+test_install_cron_without_crontab_instructs


### PR DESCRIPTION
## Intent

Close a false-liveness defect in the watcher: `count_live_lanes` counted recorded `state/*.meta` files rather than live endpoints, so a home whose endpoints had all died still reported work in progress.

Reproduced live before the change: five recorded tasks, every endpoint resolving `missing` through `fm_backend_agent_state`, and the captain pulse still reporting live lanes. The same count gates the refill-aware heartbeat, so a fully drained fleet stayed above its refill target and never refilled — the failure mode that rule was added to prevent.

## What Changed

- `count_live_lanes` now excludes a recorded non-secondmate task whose endpoint is authoritatively gone. Only `dead` (the backend proving the endpoint missing or the agent gone) is excluded; `unknown` still counts, so an unreadable backend can never inflate dispatch by under-reporting. Cost is one bounded backend probe per recorded non-secondmate task.
- New `count_recorded_lanes`; the captain pulse prints `live-lanes=N (of M recorded)` when the two differ, so a fleet of dead records reads as dead instead of as work.
- Two regression tests in `tests/fm-watch-triage.test.sh`: the counter contract across dead/unknown/alive endpoints, and the pulse line itself under an all-dead fleet.
- Separately, the two competing captain-facing rule blocks at the top of `AGENTS.md` are merged into one ordered MAXIMUM RULE (DECIDE, WRITE, TELL THE TRUTH), with the honesty section outranking the brevity section.

## Risk Assessment

Low. The change only narrows a count, and narrows it in the safe direction: an unreadable or ambiguous backend keeps counting as live, so the refill gate cannot over-dispatch on a read failure. The pulse string gains a parenthetical only when live and recorded disagree.

## Testing

`bin/fm-test-run.sh tests/fm-watch-triage.test.sh` — 0 failures, exit 0, including both new assertions:

```
ok - a live lane is a recorded task with an endpoint that is not authoritatively gone
ok - the captain pulse reports a fleet of dead endpoints as zero live lanes
FM_TEST_END tests/fm-watch-triage.test.sh exit=0 duration_ms=157472
```

`bin/fm-lint.sh` exits 0. The full suite was not run for this change.