### PR TITLE
fix(bin): stop reading an unpushed pipeline head as run divergence

### DIFF
--- a/bin/fm-crew-state.sh
+++ b/bin/fm-crew-state.sh
@@ -28,9 +28,10 @@
 #      is an ancestor of the run head (pipeline fix commits advanced the run on
 #      the same line of history). Local work that advanced past the run head, or
 #      diverged from it, invalidates attribution. A run head that does not
-#      resolve here at all is a THIRD case, not divergence: the pipeline commits
-#      before it pushes, so it is routine and expected mid-run. It is settled
-#      from branch_sync (see nm_run_pipeline_owns_branch), never from the sha.
+#      resolve here at all is a THIRD case, not divergence: the pipeline writes
+#      commits in its own copy, so its advanced head can remain absent from this
+#      worktree throughout the run, including after it pushes. It is settled from
+#      branch_sync (see nm_run_pipeline_owns_branch), never from the sha.
 #      The run-step is AUTHORITATIVE: running/fixing -> working, ci -> working,
 #      awaiting_approval/fix_review -> parked (with gate findings), terminal
 #      passed/checks-passed -> done, failed/cancelled -> failed. EXCEPT: while
@@ -423,7 +424,7 @@ nm_run_pipeline_owns_branch() {  # <unresolvable-run-head>
   # 4. Same code: the commit this run took custody of binds to our code identity
   #    under the UNCHANGED rule. This is where a rewritten or locally-advanced
   #    branch is still caught - the submitted head is resolvable precisely
-  #    because it predates the pipeline's own unpushed commits.
+  #    because it predates the pipeline's own commits.
   submitted=$(strip_quotes "$(fm_nm_branch_sync_field "$RUN_OUT" pipeline submitted_head)")
   fm_nm_head_matches_worktree "$WT" "$submitted"
 }

--- a/bin/fm-crew-state.sh
+++ b/bin/fm-crew-state.sh
@@ -27,7 +27,10 @@
 #      A run matches when its head equals the worktree HEAD, or the worktree HEAD
 #      is an ancestor of the run head (pipeline fix commits advanced the run on
 #      the same line of history). Local work that advanced past the run head, or
-#      diverged from it, invalidates attribution.
+#      diverged from it, invalidates attribution. A run head that does not
+#      resolve here at all is a THIRD case, not divergence: the pipeline commits
+#      before it pushes, so it is routine and expected mid-run. It is settled
+#      from branch_sync (see nm_run_pipeline_owns_branch), never from the sha.
 #      The run-step is AUTHORITATIVE: running/fixing -> working, ci -> working,
 #      awaiting_approval/fix_review -> parked (with gate findings), terminal
 #      passed/checks-passed -> done, failed/cancelled -> failed. EXCEPT: while
@@ -349,11 +352,20 @@ nm_runs_status_for_branch() {  # <branch>
     rest=$(trim "$rest")
     sha=${rest%% *}
     if [ "$br" = "$branch" ]; then
-      # Same code-identity rule as axi status: skip a same-branch row whose
-      # short-sha does not match this worktree (rewritten or advanced tip).
-      if ! nm_coarse_head_matches_worktree "$sha"; then
-        continue
-      fi
+      # Same code-identity rule as axi status, with the same three outcomes.
+      case "$(nm_coarse_head_verdict "$sha")" in
+        match) ;;
+        # A rewritten or superseded tip: this row is provably not ours, but an
+        # older row on the same branch still can be. Keep scanning.
+        mismatch) continue ;;
+        # This branch's most recent run holds commits that are not here yet, and
+        # the plain runs list carries nothing to corroborate ownership with. The
+        # rows below it are OLDER runs of the same branch, which that live one
+        # supersedes - answering from them is how a running pipeline came back
+        # as `failed`. Decline to answer instead, and let the pane and status-log
+        # sources report current state.
+        *) return 0 ;;
+      esac
       printf '%s' "$st"
       return 0
     fi
@@ -365,20 +377,85 @@ nm_runs_status_for_branch() {  # <branch>
 # scratch worktree); with no branch there is no run to attribute to this crew.
 CREW_BRANCH=$(git -C "$WT" symbolic-ref --quiet --short HEAD 2>/dev/null || true)
 
-# 0 if the active axi-status run's head field matches this worktree's code
-# identity. Branch match is a precondition (caller). Rule owned by
-# fm_nm_head_matches_worktree in bin/fm-nm-run-lib.sh.
-nm_run_head_matches_worktree() {
-  local run_head
-  run_head=$(strip_quotes "$(nm_field head)")
-  fm_nm_head_matches_worktree "$WT" "$run_head"
+# What the head check protects, stated before it is relaxed below: branch name
+# alone is not identity. The same branch name is reused across stages and across
+# crews, so a HISTORICAL run - one whose head was rewritten, or one the local
+# tree has since committed past - must never be reported as this crew's current
+# state. That protection is a claim about DIVERGENT HISTORY, and it needs both
+# commits in hand to make it.
+#
+# It used to be enforced with a two-way test that read "run head does not resolve
+# here" as divergence. Those are different facts. The gate commits into its own
+# copy, so from its first pipeline commit onward the run head is simply not an
+# object in the crew's worktree - and it does not become one when the gate
+# pushes, because that push goes to the remote, not here. Verified against the
+# installed gate v1.41.2 on one live run, whose head stayed unresolvable both at
+# `phase: pre_push` (empty pushed_head, step document) and after `pushed_head`
+# filled in (step ci): the window is most of every no-mistakes delivery, not a
+# narrow pre-push moment. Reading that as divergence lost attribution, dropped
+# through to the coarse runs-list fallback, and let a superseded terminal row
+# report a LIVE run as failed - a verdict that invites tearing down or
+# restarting a worker holding unlanded work.
+#
+# So: divergence still rejects, unchanged. An unresolvable head is not decided by
+# the sha at all - it is decided by branch_sync, which carries exactly the
+# missing facts (bin/fm-nm-run-lib.sh's fm_nm_branch_sync_field).
+# nm_run_pipeline_owns_branch below requires all four to line up before it binds;
+# any one absent - including an older gate that emits no branch_sync - leaves the
+# conservative rejection in place.
+nm_run_pipeline_owns_branch() {  # <unresolvable-run-head>
+  local run_head=$1 run_id pipeline_run pipeline_head local_head submitted
+  # 1. Same run: the branch_sync report describes the run we are attributing,
+  #    not some other run that happens to be the branch's most recent.
+  run_id=$(strip_quotes "$(nm_field id)")
+  pipeline_run=$(strip_quotes "$(fm_nm_branch_sync_field "$RUN_OUT" pipeline run)")
+  [ -n "$run_id" ] && [ "$pipeline_run" = "$run_id" ] || return 1
+  # 2. Same head: the head we could not resolve IS this pipeline's own advanced
+  #    head, so its absence here is explained rather than assumed. run.head is
+  #    abbreviated and pipeline.current_head is full, so bind on the prefix.
+  pipeline_head=$(strip_quotes "$(fm_nm_branch_sync_field "$RUN_OUT" pipeline current_head)")
+  [ -n "$run_head" ] && [ -n "$pipeline_head" ] || return 1
+  case "$pipeline_head" in "$run_head"*) ;; *) return 1 ;; esac
+  # 3. Same worktree: branch_sync's local view is the tree we are reporting on.
+  local_head=$(strip_quotes "$(fm_nm_branch_sync_field "$RUN_OUT" local head)")
+  [ -n "$local_head" ] || return 1
+  [ "$local_head" = "$(git -C "$WT" rev-parse HEAD 2>/dev/null)" ] || return 1
+  # 4. Same code: the commit this run took custody of binds to our code identity
+  #    under the UNCHANGED rule. This is where a rewritten or locally-advanced
+  #    branch is still caught - the submitted head is resolvable precisely
+  #    because it predates the pipeline's own unpushed commits.
+  submitted=$(strip_quotes "$(fm_nm_branch_sync_field "$RUN_OUT" pipeline submitted_head)")
+  fm_nm_head_matches_worktree "$WT" "$submitted"
 }
 
-# Coarse runs-list rows are "<status> <branch> <short-sha> ...". 0 if the short
-# sha for this branch row matches the worktree head under the same rules as
-# nm_run_head_matches_worktree (equal, or local is ancestor of run tip).
-nm_coarse_head_matches_worktree() {  # <short-sha>
+# 0 if the active axi-status run belongs to this worktree's code identity.
+# Branch match is a precondition (caller). Sha rule owned by
+# fm_nm_head_matches_worktree in bin/fm-nm-run-lib.sh; its unresolvable verdict
+# (2) is referred to branch_sync rather than treated as divergence.
+nm_run_head_matches_worktree() {
+  local run_head rc
+  run_head=$(strip_quotes "$(nm_field head)")
+  fm_nm_head_matches_worktree "$WT" "$run_head"
+  rc=$?
+  [ "$rc" = 0 ] && return 0
+  [ "$rc" = 2 ] || return 1
+  nm_run_pipeline_owns_branch "$run_head"
+}
+
+# Coarse runs-list rows are "<status> <branch> <short-sha> ...". Echoes the
+# verdict for one row's sha under the same rules as nm_run_head_matches_worktree:
+# `match`, `mismatch`, or `unresolvable`. The plain runs list carries no
+# branch_sync, so an unresolvable sha cannot be corroborated here - it is left
+# undecided for the caller rather than downgraded to either answer.
+nm_coarse_head_verdict() {  # <short-sha>
+  local rc
   fm_nm_head_matches_worktree "$WT" "$1"
+  rc=$?
+  case "$rc" in
+    0) printf 'match' ;;
+    2) printf 'unresolvable' ;;
+    *) printf 'mismatch' ;;
+  esac
 }
 
 HAVE_RUN=0

--- a/bin/fm-nm-run-lib.sh
+++ b/bin/fm-nm-run-lib.sh
@@ -81,12 +81,12 @@ fm_nm_branch_sync_field() {  # <toon-output> <section> <key>
 #                   advanced outside the run, or the branch tip was rewritten);
 #                   also the unbindable inputs: missing head, unreadable worktree
 #   2 unresolvable - the run head is not an object in this worktree at all. The
-#                   routine cause is a pipeline that has committed but not yet
-#                   pushed (branch_sync phase pre_push, empty pushed_head), so
-#                   its commits exist only in the gate's own copy. NOT evidence
-#                   of non-ownership: callers must corroborate from another
-#                   binding (fm_nm_branch_sync_field above) or stay conservative,
-#                   but must never read it as divergence.
+#                   routine cause is a pipeline committing in the gate's own
+#                   copy; even after the gate pushes to the remote, those commits
+#                   remain absent here until fetched. NOT evidence of
+#                   non-ownership: callers must corroborate from another binding
+#                   (fm_nm_branch_sync_field above) or stay conservative, but
+#                   must never read it as divergence.
 # Callers using plain `|| return 1` therefore keep the pre-tri-state behavior of
 # refusing to bind on an unresolvable head.
 fm_nm_head_matches_worktree() {  # <worktree> <run_head>

--- a/bin/fm-nm-run-lib.sh
+++ b/bin/fm-nm-run-lib.sh
@@ -55,19 +55,45 @@ fm_nm_field() {  # <toon-output> <key>
   printf '%s\n' "$1" | sed -n "s/^[[:space:]]*$2:[[:space:]]*\(.*\)/\1/p" | head -1
 }
 
-# 0 if run head $2 matches worktree $1's code identity, per the same rule
-# everywhere this attribution is needed:
-#   - missing/empty head: cannot bind; reject
-#   - equal commits (short or full SHA): match
-#   - worktree HEAD is an ancestor of run head: match (pipeline fix commits on
-#     the same history advanced the run tip past local HEAD)
-#   - run head is a strict ancestor of worktree HEAD, or diverged: no match
-#     (local work advanced outside the run, or the branch tip was rewritten)
+# Scalar value of key $3 inside the `$2:` sub-block of the top-level
+# `branch_sync:` block of `axi status` output $1 (e.g. section `pipeline`, key
+# `submitted_head`). Scoped because branch_sync repeats key names the run block
+# already uses - `head`, `status`, `run`, `branch` - so the unscoped fm_nm_field
+# above would answer from the wrong block. Section and key are literal
+# identifiers supplied by callers, never user data.
+fm_nm_branch_sync_field() {  # <toon-output> <section> <key>
+  printf '%s\n' "$1" \
+    | sed -n '/^branch_sync:[[:space:]]*$/,/^[^[:space:]]/p' \
+    | sed -n "/^  $2:[[:space:]]*\$/,/^  [^[:space:]]/p" \
+    | sed -n "s/^    $3:[[:space:]]*\(.*\)/\1/p" \
+    | head -1
+}
+
+# Code-identity verdict for run head $2 against worktree $1. THREE outcomes,
+# because "the run head is not an object in this worktree" and "the run head is
+# a different line of history" are different facts and only the second is
+# evidence that the run does not belong here:
+#   0 match       - equal commits (short or full SHA), or worktree HEAD is an
+#                   ancestor of the run head (pipeline fix commits on the same
+#                   history advanced the run tip past local HEAD)
+#   1 mismatch    - both commits resolve here and the run head is a strict
+#                   ancestor of worktree HEAD or diverged from it (local work
+#                   advanced outside the run, or the branch tip was rewritten);
+#                   also the unbindable inputs: missing head, unreadable worktree
+#   2 unresolvable - the run head is not an object in this worktree at all. The
+#                   routine cause is a pipeline that has committed but not yet
+#                   pushed (branch_sync phase pre_push, empty pushed_head), so
+#                   its commits exist only in the gate's own copy. NOT evidence
+#                   of non-ownership: callers must corroborate from another
+#                   binding (fm_nm_branch_sync_field above) or stay conservative,
+#                   but must never read it as divergence.
+# Callers using plain `|| return 1` therefore keep the pre-tri-state behavior of
+# refusing to bind on an unresolvable head.
 fm_nm_head_matches_worktree() {  # <worktree> <run_head>
   local wt=$1 run_head=$2 local_full run_full
   [ -n "$run_head" ] || return 1
   local_full=$(git -C "$wt" rev-parse HEAD 2>/dev/null) || return 1
-  run_full=$(git -C "$wt" rev-parse --verify "${run_head}^{commit}" 2>/dev/null) || return 1
+  run_full=$(git -C "$wt" rev-parse --verify "${run_head}^{commit}" 2>/dev/null) || return 2
   [ "$run_full" = "$local_full" ] && return 0
-  git -C "$wt" merge-base --is-ancestor "$local_full" "$run_full" 2>/dev/null
+  git -C "$wt" merge-base --is-ancestor "$local_full" "$run_full" 2>/dev/null || return 1
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -31,7 +31,7 @@ A declared external wait trades that silence for one bounded recheck per pause w
 Crew status files are append-only wake-event logs, not current-state fields.
 Because of that, a per-wake read of only the latest line can bury an earlier still-open `needs-decision`/`blocked` under later unrelated appends; `fm-wake-drain.sh` prints a separate, fleet-wide OPEN DECISIONS section on every drain (including the empty-queue path session-start relies on), built from `fm-classify-lib.sh`'s `status_open_decisions` fold so the buried decision keeps surfacing until it is explicitly resolved.
 `bin/fm-crew-state.sh <id>` is the cheap current-state read for an actionable heartbeat review: it attributes a no-mistakes run, active or terminal, only when it matches the crew's branch and current code identity, then keeps that run-step authoritative even if the pane has closed.
-The script header owns the exact run-head ancestry rules.
+The `bin/fm-nm-run-lib.sh` header owns the exact run-head ancestry verdicts, while the `bin/fm-crew-state.sh` header owns branch-sync corroboration and fallback attribution.
 During no-mistakes' `ci` monitor phase, it also reads the ci step log tail because `axi status` reports both "still waiting on checks" and "checks green, waiting on merge" as `ci,running`.
 The most recent recognized ci log marker wins, so checks-green monitoring reports done while a later re-arm, failed-check, or issue marker returns the crew to working.
 Only when no matching run exists does it consult semantic busy state; exact busy reports working, exact idle permits fallback to a status-log event whose verb maps to a recognized run-state, and unknown or a dead pane stays unknown instead of trusting a stale log.

--- a/tests/fm-crew-state.test.sh
+++ b/tests/fm-crew-state.test.sh
@@ -325,6 +325,19 @@ outcome: passed
 EOF
 }
 
+run_checks_passed() {  # <branch>
+  cat <<EOF
+run:
+  id: "01RUN"
+  branch: $1
+  status: completed
+  head: "${FM_FAKE_RUN_HEAD:-abc1234}"
+  pr: "https://github.com/o/r/pull/1"
+  findings: none
+outcome: checks-passed
+EOF
+}
+
 run_failed() {  # <branch>
   cat <<EOF
 run:
@@ -335,6 +348,19 @@ run:
   pr: ""
   findings: none
 outcome: failed
+EOF
+}
+
+run_cancelled() {  # <branch>
+  cat <<EOF
+run:
+  id: "01RUN"
+  branch: $1
+  status: cancelled
+  head: "${FM_FAKE_RUN_HEAD:-abc1234}"
+  pr: ""
+  findings: none
+outcome: cancelled
 EOF
 }
 
@@ -718,6 +744,20 @@ test_terminal_passed() {
   pass "terminal passed run is authoritative"
 }
 
+test_terminal_checks_passed() {
+  reset_fakes
+  local d; d=$(new_case checks-passed)
+  make_repo_on_branch "$d/wt" fm/feat-checks-passed
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/checks-passed.meta" "window=fm:fm-checks-passed" "worktree=$d/wt" "kind=ship"
+  FM_FAKE_AXI_STATUS="$(run_checks_passed fm/feat-checks-passed)"
+  local out; out=$(run_crew_state "$d" checks-passed)
+  assert_contains "$out" "state: done" "checks-passed run -> done"
+  assert_contains "$out" "source: run-step" "checks-passed -> run-step source"
+  assert_contains "$out" "checks green: PR ready for review" "checks-passed keeps review-ready detail"
+  pass "terminal checks-passed run is authoritative"
+}
+
 test_terminal_failed() {
   reset_fakes
   local d; d=$(new_case failed)
@@ -729,6 +769,20 @@ test_terminal_failed() {
   assert_contains "$out" "state: failed" "failed run -> failed"
   assert_contains "$out" "source: run-step" "failed -> run-step source"
   pass "terminal failed run is authoritative"
+}
+
+test_terminal_cancelled() {
+  reset_fakes
+  local d; d=$(new_case cancelled)
+  make_repo_on_branch "$d/wt" fm/feat-cancelled
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/cancelled.meta" "window=fm:fm-cancelled" "worktree=$d/wt" "kind=ship"
+  FM_FAKE_AXI_STATUS="$(run_cancelled fm/feat-cancelled)"
+  local out; out=$(run_crew_state "$d" cancelled)
+  assert_contains "$out" "state: failed" "cancelled run -> failed"
+  assert_contains "$out" "source: run-step" "cancelled -> run-step source"
+  assert_contains "$out" "run cancelled" "cancelled keeps terminal detail"
+  pass "terminal cancelled run is authoritative"
 }
 
 # (e) cross-branch attribution: `axi status` returns ANOTHER branch's run (the
@@ -1545,7 +1599,9 @@ test_ci_fixing_after_green_stays_working
 test_top_level_fixing_ci_running_after_green_stays_working
 test_top_level_fixing_done_log_stays_working
 test_terminal_passed
+test_terminal_checks_passed
 test_terminal_failed
+test_terminal_cancelled
 test_cross_branch_attribution_via_runs_list
 test_cross_branch_attribution_picks_most_recent_row
 test_coarse_run_does_not_probe_other_branch_ci_log_for_ready_status

--- a/tests/fm-crew-state.test.sh
+++ b/tests/fm-crew-state.test.sh
@@ -25,6 +25,10 @@
 #       This is the direct regression pair for the 2026-07-02 herdr incident,
 #       proving the watcher's own absorb-only-when-provably-working predicate
 #       benefits from the fix in both directions.
+#   (l) head-binding: a rewritten or locally-advanced tip is still rejected,
+#       while a run head that is merely absent from the worktree (the gate
+#       commits into its own copy) is attributed on branch_sync corroboration
+#       instead of being read as divergence and answered from a superseded row.
 set -u
 
 # shellcheck source=tests/lib.sh
@@ -201,6 +205,49 @@ run:
   pr: ""
   findings: none
 EOF
+}
+
+# `axi status`'s branch_sync block, in the shape the real gate emits whenever the
+# pipeline holds commits this worktree does not have (verified against the
+# installed v1.41.2 on a live run, in both its pre-push and post-push halves -
+# the pipeline's commits stay unresolvable here even after `pushed_head` fills
+# in, because the push goes to the remote, not into the crew's worktree).
+branch_sync_block() {  # <branch> <run-id> <local-head> <submitted-head> <current-head>
+  cat <<EOF
+branch_sync:
+  state: pipeline_owned
+  changed: false
+  local:
+    branch: $1
+    head: $3
+    clean: true
+  pipeline:
+    run: "$2"
+    status: running
+    phase: pre_push
+    submitted_head: $4
+    current_head: $5
+    pushed_head: ""
+    pushed_at: 0
+    push_generation: 0
+  target:
+    kind: ""
+    remote: origin
+    url: "https://example.invalid/r.git"
+    ref: ""
+  relation: unknown
+  safety: blocked_pipeline_owned
+EOF
+}
+
+# A 40-hex commit-shaped sha that is deliberately NOT an object in any fixture
+# repo, standing in for a pipeline commit that has not reached the worktree.
+UNRESOLVABLE_SHA=16f026f7f982fc043b54a6f4fcd2c05c98f53701
+
+assert_absent_object() {  # <repo> <sha>
+  git -C "$1" rev-parse --verify "$2^{commit}" >/dev/null 2>&1 \
+    && fail "fixture sha $2 must not resolve in $1"
+  return 0
 }
 
 run_top_level_ci() {  # <branch>
@@ -1309,6 +1356,176 @@ test_missing_run_head_falls_back_to_current_state() {
   pass "missing run head falls back instead of matching by branch"
 }
 
+# Head-binding, the third case: the run's head is not an object in this worktree
+# at all, because the pipeline commits into its own copy. That is the routine
+# mid-run condition for every no-mistakes delivery, not divergence. With
+# branch_sync corroborating ownership the LIVE run must be attributed and report
+# its real step - never the superseded terminal row the runs list still carries.
+test_pipeline_head_absent_locally_stays_working() {
+  reset_fakes
+  local d local_head short out
+  d=$(new_case pipeline-unpushed)
+  make_repo_on_branch "$d/wt" fm/feat-unpushed
+  local_head=$(git -C "$d/wt" rev-parse HEAD)
+  short=$(git -C "$d/wt" rev-parse --short=8 HEAD)
+  assert_absent_object "$d/wt" "$UNRESOLVABLE_SHA"
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/unpushed.meta" "window=fm:fm-unpushed" "worktree=$d/wt" "kind=ship" "harness=claude"
+  printf 'working: implementation committed, validating\n' > "$d/state/unpushed.status"
+  FM_FAKE_RUN_HEAD=${UNRESOLVABLE_SHA:0:8}
+  FM_FAKE_AXI_STATUS="$(run_running fm/feat-unpushed
+branch_sync_block fm/feat-unpushed 01RUN "$local_head" "$local_head" "$UNRESOLVABLE_SHA")"
+  # The exact runs list the live incident had: the branch's own newest row is the
+  # live run at the unresolvable pipeline head, and below it sits an OLDER failed
+  # run submitted at the head this worktree is still on.
+  FM_FAKE_RUNS_LIST="$(cat <<EOF
+  running    fm/feat-unpushed ${UNRESOLVABLE_SHA:0:8}  2026-08-05 11:01
+  failed     fm/feat-unpushed ${short}  2026-08-04 21:08
+EOF
+)"
+  out=$(run_crew_state "$d" unpushed)
+  assert_contains "$out" "state: working" "a live run whose head is not local yet is still working"
+  assert_contains "$out" "source: run-step" "corroborated ownership keeps the run-step source"
+  assert_not_contains "$out" "state: failed" "a superseded terminal row must never report a live run as failed"
+  pass "unpushed pipeline head is attributed and reports the live run step"
+}
+
+# The relaxation is evidence-driven, not assumed: with no branch_sync to
+# corroborate ownership (an older gate, or a run that says nothing about this
+# tree), an unresolvable head keeps the conservative pre-existing rejection.
+test_absent_head_without_branch_sync_not_attributed() {
+  reset_fakes
+  local d out
+  d=$(new_case unpushed-nosync)
+  make_repo_on_branch "$d/wt" fm/feat-nosync
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/nosync.meta" "window=fm:fm-nosync" "worktree=$d/wt" "kind=ship" "harness=claude"
+  printf 'working: current stage still in progress\n' > "$d/state/nosync.status"
+  FM_FAKE_RUN_HEAD=${UNRESOLVABLE_SHA:0:8}
+  FM_FAKE_AXI_STATUS="$(run_parked fm/feat-nosync)"
+  FM_FAKE_RUNS_LIST=""
+  FM_FAKE_BUSY=0
+  arm_idle_record "$d/state" nosync
+  out=$(run_crew_state "$d" nosync)
+  assert_not_contains "$out" "source: run-step" "an uncorroborated absent head must not bind by branch alone"
+  assert_not_contains "$out" "parked at" "an unattributed run must not mask current state"
+  assert_contains "$out" "source: status-log" "falls back to current-state sources instead"
+  pass "absent run head without branch_sync keeps the conservative rejection"
+}
+
+# What the head check protected stays protected. A historical run on a reused,
+# rewritten branch reports a head that is absent here too, and branch_sync is
+# present - but the commit that run took custody of is on the abandoned line of
+# history, so the code-identity rule still rejects it.
+test_absent_head_diverged_submitted_head_not_attributed() {
+  reset_fakes
+  local d old_head new_head out
+  d=$(new_case unpushed-diverged)
+  make_repo_on_branch "$d/wt" fm/feat-diverged
+  old_head=$(git -C "$d/wt" rev-parse HEAD)
+  git -C "$d/wt" checkout -q --orphan tmp-rewrite
+  git -C "$d/wt" commit -q --allow-empty -m 'rewritten tip'
+  git -C "$d/wt" branch -q -M fm/feat-diverged
+  new_head=$(git -C "$d/wt" rev-parse HEAD)
+  [ "$old_head" != "$new_head" ] || fail "rewrite did not produce a new head"
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/diverged.meta" "window=fm:fm-diverged" "worktree=$d/wt" "kind=ship" "harness=claude"
+  printf 'working: stage 2 setup complete\n' > "$d/state/diverged.status"
+  FM_FAKE_RUN_HEAD=${UNRESOLVABLE_SHA:0:8}
+  FM_FAKE_AXI_STATUS="$(run_parked fm/feat-diverged
+branch_sync_block fm/feat-diverged 01RUN "$new_head" "$old_head" "$UNRESOLVABLE_SHA")"
+  FM_FAKE_BUSY=0
+  arm_idle_record "$d/state" diverged
+  out=$(run_crew_state "$d" diverged)
+  assert_not_contains "$out" "source: run-step" "a run holding a diverged submitted head is not ours"
+  assert_not_contains "$out" "parked at" "historical parked run must not mask current state"
+  assert_contains "$out" "source: status-log" "falls back after the divergence rejection"
+  assert_contains "$out" "state: working" "status-log working: remains current"
+  pass "diverged submitted head is still rejected when the run head is absent"
+}
+
+# branch_sync must describe the SAME run being attributed. A report about some
+# other run of this branch proves nothing about the one `axi status` returned.
+test_absent_head_foreign_branch_sync_run_not_attributed() {
+  reset_fakes
+  local d local_head out
+  d=$(new_case unpushed-foreignrun)
+  make_repo_on_branch "$d/wt" fm/feat-foreign
+  local_head=$(git -C "$d/wt" rev-parse HEAD)
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/foreign.meta" "window=fm:fm-foreign" "worktree=$d/wt" "kind=ship" "harness=claude"
+  printf 'working: current stage still in progress\n' > "$d/state/foreign.status"
+  FM_FAKE_RUN_HEAD=${UNRESOLVABLE_SHA:0:8}
+  FM_FAKE_AXI_STATUS="$(run_parked fm/feat-foreign
+branch_sync_block fm/feat-foreign 01OTHERRUN "$local_head" "$local_head" "$UNRESOLVABLE_SHA")"
+  FM_FAKE_RUNS_LIST=""
+  FM_FAKE_BUSY=0
+  arm_idle_record "$d/state" foreign
+  out=$(run_crew_state "$d" foreign)
+  assert_not_contains "$out" "source: run-step" "branch_sync for another run must not corroborate this one"
+  assert_contains "$out" "source: status-log" "falls back when the corroboration is about a different run"
+  pass "branch_sync naming a different run does not attribute an absent head"
+}
+
+# branch_sync must also describe THIS tree. `axi status` answers repo-wide, and
+# two worktrees of one repo can carry the same branch name, so a report whose
+# local view is some other head is not evidence about this crew's code - even
+# when the run id, the pipeline head, and the submitted head all line up.
+test_absent_head_foreign_local_view_not_attributed() {
+  reset_fakes
+  local d base_head head out
+  d=$(new_case unpushed-foreignlocal)
+  make_repo_on_branch "$d/wt" fm/feat-foreignlocal
+  base_head=$(git -C "$d/wt" rev-parse HEAD)
+  git -C "$d/wt" commit -q --allow-empty -m 'this crew work'
+  head=$(git -C "$d/wt" rev-parse HEAD)
+  [ "$base_head" != "$head" ] || fail "fixture did not advance the head"
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/foreignlocal.meta" "window=fm:fm-foreignlocal" "worktree=$d/wt" "kind=ship" "harness=claude"
+  printf 'working: current stage still in progress\n' > "$d/state/foreignlocal.status"
+  FM_FAKE_RUN_HEAD=${UNRESOLVABLE_SHA:0:8}
+  # Submitted head IS this tree's head, so the code-identity rule alone would
+  # accept; only the mismatched local view rejects.
+  FM_FAKE_AXI_STATUS="$(run_parked fm/feat-foreignlocal
+branch_sync_block fm/feat-foreignlocal 01RUN "$base_head" "$head" "$UNRESOLVABLE_SHA")"
+  FM_FAKE_RUNS_LIST=""
+  FM_FAKE_BUSY=0
+  arm_idle_record "$d/state" foreignlocal
+  out=$(run_crew_state "$d" foreignlocal)
+  assert_not_contains "$out" "source: run-step" "branch_sync describing another tree must not corroborate"
+  assert_contains "$out" "source: status-log" "falls back when the corroboration is about a different tree"
+  pass "branch_sync reporting a different local head does not attribute an absent head"
+}
+
+# The coarse runs list carries no branch_sync, so it cannot corroborate an
+# unresolvable sha - and the rows beneath the branch's newest one are OLDER runs
+# that the live one supersedes. Answering from them is precisely how a running
+# pipeline was reported failed, so the fallback declines instead.
+test_coarse_absent_head_row_does_not_fall_through_to_stale_row() {
+  reset_fakes
+  local d short out
+  d=$(new_case coarse-unpushed)
+  make_repo_on_branch "$d/wt" fm/feat-coarse-unpushed
+  short=$(git -C "$d/wt" rev-parse --short=8 HEAD)
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/coarseunp.meta" "window=fm:fm-coarseunp" "worktree=$d/wt" "kind=ship" "harness=claude"
+  printf 'working: implementation committed, validating\n' > "$d/state/coarseunp.status"
+  # The repo-wide answer belongs to another crew, so attribution falls to the list.
+  FM_FAKE_AXI_STATUS="$(run_running fm/other-crew)"
+  FM_FAKE_RUNS_LIST="$(cat <<EOF
+  running    fm/feat-coarse-unpushed ${UNRESOLVABLE_SHA:0:8}  2026-08-05 11:01
+  failed     fm/feat-coarse-unpushed ${short}  2026-08-04 21:08
+EOF
+)"
+  FM_FAKE_BUSY=0
+  arm_idle_record "$d/state" coarseunp
+  out=$(run_crew_state "$d" coarseunp)
+  assert_not_contains "$out" "state: failed" "a superseded coarse row must not report the live run as failed"
+  assert_not_contains "$out" "source: run-step" "an uncorroborated coarse row must not be attributed"
+  assert_contains "$out" "source: status-log" "declines the coarse answer and reads current state instead"
+  pass "coarse fallback declines rather than answering from a superseded row"
+}
+
 test_active_run_is_authoritative
 test_stale_needs_decision_superseded
 test_stale_blocked_superseded
@@ -1358,5 +1575,11 @@ test_historical_same_branch_rewritten_head_not_current
 test_active_run_descendant_fix_head_remains_current
 test_local_advanced_past_run_head_invalidates
 test_missing_run_head_falls_back_to_current_state
+test_pipeline_head_absent_locally_stays_working
+test_absent_head_without_branch_sync_not_attributed
+test_absent_head_diverged_submitted_head_not_attributed
+test_absent_head_foreign_branch_sync_run_not_attributed
+test_absent_head_foreign_local_view_not_attributed
+test_coarse_absent_head_row_does_not_fall_through_to_stale_row
 
 echo "all fm-crew-state tests passed"


### PR DESCRIPTION
## The defect

`bin/fm-crew-state.sh` reported `state: failed · source: run-step · run failed` for a no-mistakes run that was alive and validating normally.

`AGENTS.md` section 7 makes this script the authority for judging a validation: *"Judge validation by the current-code-matched run step through `bin/fm-crew-state.sh`, not by shell liveness or the last status event."* A `failed` verdict on a live run invites tearing down or restarting a worker mid-pipeline that still holds unlanded work, and it reaches a supervisor as a `stale:` wake — already disposed to act.

Reproduced live on task `delegated-run-durability`, and every link confirmed by running it, not by reading it:

| step | evidence |
|---|---|
| verdict | `state: failed · source: run-step · run failed` |
| `axi status` | run `01KZ8JGTAW3DN81Y658CVWYKJ8`, branch matched exactly, `status: running`, step `document`, `agent_pid` alive |
| `git rev-parse --verify 16f026f7^{commit}` | `fatal` — the object is not in the worktree |
| `no-mistakes runs` | `running … 16f026f7` (skipped as unresolvable) then `failed … 2e96f463` (matched local HEAD) |
| result | `RUN_SOURCE=coarse`, `COARSE_STATUS=failed` |

## Root cause: two facts conflated

`fm_nm_head_matches_worktree` resolved the run head with a single `git rev-parse --verify <run_head>^{commit}` and treated any failure as "not our run". That call fails for two unrelated reasons:

1. **The run head is on a divergent line of history** — real evidence of non-ownership.
2. **The run head is simply not an object in this worktree** — no evidence either way.

The gate commits into its own copy, so cause 2 is the *normal* mid-run condition. Attribution was lost, the coarse runs-list fallback took over, skipped the same unresolvable row, and answered from an **older, superseded `failed` run of the same branch**. That is how a missed attribution became a wrong *terminal* verdict.

### The window is wider than it first appears

The original report scoped this to the `document` and `lint` steps. Checking the same live run again after it pushed and opened a PR, its head was **still** unresolvable (`rc=2`) at step `ci` — because the gate's push goes to the **remote**, not into the crew's worktree. The window therefore spans from the first pipeline commit through push, pr and ci: most of every no-mistakes delivery.

That result is why the fix is deliberately **not** gated on `phase: pre_push`. Doing so would have left the same false verdict live across the second half of every run.

## What the head check was protecting, stated before relaxing it

Branch name alone is not identity. The same branch name is reused across stages and across crews, so a **historical run** — one whose head was rewritten, or one the local tree has since committed past — must never be reported as this crew's current state.

That protection is a claim about **divergent history**, and it needs both commits in hand to make it. It says nothing about a head that is merely absent. Relaxing the absent case therefore gives up none of it.

## The fix

`fm_nm_head_matches_worktree` becomes **tri-state**:

| verdict | meaning |
|---|---|
| `0` match | equal commits, or worktree HEAD is an ancestor of the run head |
| `1` mismatch | both resolve here and the run head is a strict ancestor or diverged; also unbindable inputs (missing head, unreadable worktree) |
| `2` unresolvable | the run head is not an object here at all |

Divergence rejects exactly as before. An unresolvable head is settled from `branch_sync` rather than from the sha, and binds only when **all four** line up:

1. `branch_sync.pipeline.run` is the run being attributed — the report is about *this run*.
2. `branch_sync.pipeline.current_head` prefix-matches the head that failed to resolve — its absence is *explained*, not assumed.
3. `branch_sync.local.head` is this worktree's HEAD — the report is about *this tree*. `axi status` answers repo-wide, and two worktrees can carry the same branch name.
4. `branch_sync.pipeline.submitted_head` passes the **unchanged** code-identity rule. It is resolvable precisely because it predates the pipeline's own unpushed commits, and this is where a rewritten or locally-advanced branch is still caught.

Any one absent — **including an older gate that emits no `branch_sync`** — keeps the previous conservative rejection. The relaxation is evidence-driven, never assumed.

`branch_sync` repeats key names the run block already uses (`head`, `status`, `run`, `branch`), so the existing unscoped `fm_nm_field` would answer from the wrong block. A scoped `fm_nm_branch_sync_field` was added rather than loosening `fm_nm_field`, and verified against real v1.41.2 output before being trusted.

### The coarse fallback stays a fallback

It carries no `branch_sync`, so an unresolvable sha cannot be corroborated there. It now distinguishes the same three outcomes: `match` answers, `mismatch` keeps scanning (unchanged — an older row on the same branch can still be ours), and `unresolvable` **declines** rather than falling through to the older rows that the live run supersedes.

## Tests

Six added to `tests/fm-crew-state.test.sh`, driven through the real executable with throwaway git repos and fake `no-mistakes`/`tmux`.

Two reproduce the defect — they fail against pre-fix code with the exact reported output and pass after:

- a live run whose head is absent locally reports `working`, not `failed`
- the coarse fallback declines instead of answering from a superseded row

Four pin the protection that had to survive:

- no `branch_sync` → conservative rejection preserved
- diverged `submitted_head` on a rewritten branch → rejected
- `branch_sync` naming a different run → rejected
- `branch_sync` reporting a different local head → rejected

Each of the four corroboration conditions was **mutation-tested individually** and confirmed to be caught by its own test, so none is vacuous. A `UNRESOLVABLE_SHA` fixture plus an `assert_absent_object` guard keep the "object absent" precondition from going quietly vacuous either.

## Related finding, not fixed here

`bin/fm-teardown.sh:1155` shares this one-owner function and has the same conflation. Its `|| return 1` call means this change leaves its behavior **byte-identical** — it still refuses to bind on an unresolvable head. It is fail-open by design ("never a guess"), but it can fail to abort a genuinely-parked run it owns during the same window. Reported rather than changed, to keep this PR scoped to the reported defect.

## Verification

- `tests/fm-crew-state.test.sh` green; `fm-teardown`, `fm-gotmp`, `fm-wake-queue`, `fm-watch-triage` green.
- `bin/fm-lint.sh` clean under the pinned ShellCheck 0.11.0.
- Live re-check after the fix: `state: working · source: run-step · validating (running)`.
- `tests/fm-backend.test.sh` and `tests/fm-backend-orca.test.sh` fail on an old-teardown conformance case with `fm-decision-hold: compatible tasks-axi is required`. Verified to fail **identically on the pristine base** — pre-existing and environmental, unrelated to this change.
