### PR TITLE
docs(skills): add refactor-campaign method skill

### DIFF
--- a/.agents/skills/refactor-campaign/SKILL.md
+++ b/.agents/skills/refactor-campaign/SKILL.md
@@ -14,6 +14,12 @@ metadata:
 Use this method when one body of work must be restructured across many pull requests, several waves of crew, and more than one delivery day.
 It is the single owner of Firstmate's campaign shape; the ordinary task lifecycle in `AGENTS.md` section 7 still owns intake, dispatch, supervision, and merge authority for each individual slice inside the campaign.
 
+## Scope
+
+This skill owns campaign-level orchestration only: how the whole body of work is planned, sliced, proven, and sequenced.
+It deliberately owns nothing about how one pull request is shepherded to landing, and nothing about the quality loop a worker runs inside a single task.
+Those are separate altitudes with their own owners; compose with whichever ones this fleet has installed and never restate their procedure here.
+
 ## When not to use this
 
 A small change, a single-concern fix, or anything that lands in one pull request needs none of this.

--- a/.agents/skills/refactor-campaign/SKILL.md
+++ b/.agents/skills/refactor-campaign/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: refactor-campaign
+description: >-
+  Agent-only method for large multi-PR refactor or realignment campaigns.
+  Load before planning or executing a campaign that will span many pull requests, several waves of crew, and more than one delivery day.
+  Owns adversarial planning, authoring fresh at final vocabulary, validate-whole-then-drip delivery, written campaign law with one decision authority, and the operational patterns a stacked campaign needs.
+user-invocable: false
+metadata:
+  internal: true
+---
+
+# refactor-campaign
+
+Use this method when one body of work must be restructured across many pull requests, several waves of crew, and more than one delivery day.
+It is the single owner of Firstmate's campaign shape; the ordinary task lifecycle in `AGENTS.md` section 7 still owns intake, dispatch, supervision, and merge authority for each individual slice inside the campaign.
+
+## When not to use this
+
+A small change, a single-concern fix, or anything that lands in one pull request needs none of this.
+The ordinary lifecycle already covers those, and campaign machinery on a one-PR change is pure overhead.
+Reach for the campaign shape only when the work genuinely cannot be reviewed, validated, or landed as one unit.
+
+## 1. Plan first, adversarially
+
+Commission exactly one planning investigation before any implementation, on the strongest reasoning class available, and give it the campaign's stated goals as its north star.
+Its deliverable is two things.
+
+The first is an abstraction audit.
+Every abstraction in the carved surface is either kept or cut, and every verdict carries one sentence of deletion-test evidence: delete it, and name the complexity that reappears.
+If nothing reappears, it goes.
+Each keep also names which campaign goal it serves; an abstraction that cannot name its goal does not belong in the campaign.
+An audit written this way shrinks the work before a single slice is authored, because most cuts remove diff rather than adding it.
+
+The second is a file-level slice map.
+Every slice states its one concern, its carve source, its base, its dependencies, its approximate size, and why the configured automated reviewer can approve it alone.
+Size the slices to that reviewer's approval capacity rather than to conceptual tidiness, because a slice no reviewer can approve is a slice that does not land.
+The map also states a dependency graph and a single linear ordering for the stack, so every branch has exactly one parent and the eventual landing order is already decided.
+
+Choices the captain owns surface in the plan as explicit decision items, each with a stated default the plan proceeds on until overridden.
+That keeps planning unblocked while the captain still owns every real choice, and it follows the durable unresolved-decision contract in `decision-hold-lifecycle`.
+
+## 2. Author fresh at final vocabulary
+
+When naming or design decisions supersede work already in flight, do not ship rename or transition pull requests on top of it.
+Close the superseded work and carve its validated content into new single-concern slices written directly in the final vocabulary, with the audit's cuts applied at authoring time.
+Carving means copy, rename, and apply the listed cuts, not replaying the original commits.
+
+The resubmission is the cheapest simplification moment the code will ever have.
+Every cut applied while authoring costs nothing; the same cut applied later costs a migration.
+Authoring fresh also removes compatibility shims from existing: a shim exists only because a file with the same name was rewritten in place, and new files from birth never need one.
+Old work is closed rather than merged, and closing is a captain-sequenced action like any other.
+
+## 3. Validate whole, then drip
+
+Do not land the campaign incrementally as it is authored.
+
+1. Author the entire stack first as stacked draft pull requests along the planned spine.
+   Nothing merges during authoring, and the stack tip assembles the complete result.
+2. Prove the assembled tip empirically in the real product before any merge: run the actual end-to-end scenarios a user exercises, in the real runtime, with any paired cross-repository changes in place, and capture evidence.
+   Unit tests alone are not proof.
+   An empirical gate catches what no unit test can, because unit suites run against the shapes the code was written for while the gate runs against how the product is actually built, installed, and operated.
+3. Then land bottom-up, one slice at a time: undraft the lowest slice, let the configured reviewer approve it, merge under the normal authority, rebase its children, repeat.
+   These reviews are low-risk precisely because the assembled behavior is already proven.
+4. A validation failure freezes the landing sequence: fix the owning slice, re-run the affected scenario, and only then start or resume.
+5. If a slice changes materially during its own review, re-check the affected scenario on the rebased stack before landing anything above it.
+
+Record what the gate did not cover as explicitly as what it did, and say which later claims remain unproven until that coverage exists.
+A purely mechanical root slice with a compatibility alias may land ahead of the gate when the captain says so, but that is a captain decision, not a default.
+
+## 4. Written law and one decision authority
+
+Campaign constraints, the closed naming table, and the delivery rules live in files, and every brief cites them.
+A brief that restates them instead of citing them will drift the moment one copy is edited.
+State plainly which decisions are settled and must not be relitigated, so successive crews stop re-deriving them.
+Close naming before authoring begins; a partially closed vocabulary produces slices that must be renamed later, which is exactly what section 2 exists to avoid.
+
+Every crew escalates its gate findings upward under the normal ask-user contract, and the implementation worker never answers its own finding.
+Firstmate rules against the campaign's recorded intent, using `ask-user-authority`, and obtains the captain's decision whenever the finding would expand the accepted contract.
+Rulings are keyed and durable so they can be cited by later slices, and a ruling later found wrong is corrected through the pipeline like any other finding rather than by hand-editing around it.
+
+## 5. Operational patterns
+
+- Stacked branches must skip the delivery pipeline's default-branch rebase step; rebasing a stacked lane onto the default branch drags parent commits into the child's pull request and drifts its base.
+- Some stack artifacts are accepted rather than fixed: extra commit counts, merge commits, and base drift on already-run lanes are documented per pull request and dissolve naturally when children rebase during the bottom-up landing.
+- Concentrate expected conflicts deliberately: where many slices must touch one shared build or index file, have each slice append one self-contained fenced block so conflicts become append-order trivia.
+- Under worker, allocator, or disk pressure, repurpose parked workers that already hold warm build trees instead of allocating fresh ones, and reclaim finished lanes' build artifacts between waves.
+- Verify each allocated isolated copy against the recorded runtime state after every spawn rather than trusting the allocation.
+- A long external wait during a campaign is a declared pause, not a silent idle, so supervision leaves the waiting worker alone instead of treating it as stuck.

--- a/.agents/skills/refactor-campaign/SKILL.md
+++ b/.agents/skills/refactor-campaign/SKILL.md
@@ -42,8 +42,9 @@ Every slice states its one concern, its carve source, its base, its dependencies
 Size the slices to that reviewer's approval capacity rather than to conceptual tidiness, because a slice no reviewer can approve is a slice that does not land.
 The map also states a dependency graph and a single linear ordering for the stack, so every branch has exactly one parent and the eventual landing order is already decided.
 
-Choices the captain owns surface in the plan as explicit decision items, each with a stated default the plan proceeds on until overridden.
-That keeps planning unblocked while the captain still owns every real choice, and it follows the durable unresolved-decision contract in `decision-hold-lifecycle`.
+Choices the captain owns surface in the plan as explicit decision items, and every one of them becomes a registered durable hold under `decision-hold-lifecycle`, which owns their identity, completion, and resolution contract.
+Each item also carries a stated default, and that default governs planning progress only: it lets the planning investigation keep moving instead of stalling on an unanswered choice.
+A stated default never governs landing, merging, or any other delivery decision, and each of those waits for the captain's recorded answer through the hold's normal resolution path.
 
 ## 2. Author fresh at final vocabulary
 
@@ -53,7 +54,7 @@ Carving means copy, rename, and apply the listed cuts, not replaying the origina
 
 The resubmission is the cheapest simplification moment the code will ever have.
 Every cut applied while authoring costs nothing; the same cut applied later costs a migration.
-Authoring fresh also removes compatibility shims from existing: a shim exists only because a file with the same name was rewritten in place, and new files from birth never need one.
+Authoring fresh also removes compatibility shims from existence: a shim exists only because a file with the same name was rewritten in place, and new files from birth never need one.
 Old work is closed rather than merged, and closing is a captain-sequenced action like any other.
 
 ## 3. Validate whole, then drip
@@ -91,4 +92,4 @@ Rulings are keyed and durable so they can be cited by later slices, and a ruling
 - Concentrate expected conflicts deliberately: where many slices must touch one shared build or index file, have each slice append one self-contained fenced block so conflicts become append-order trivia.
 - Under worker, allocator, or disk pressure, repurpose parked workers that already hold warm build trees instead of allocating fresh ones, and reclaim finished lanes' build artifacts between waves.
 - Verify each allocated isolated copy against the recorded runtime state after every spawn rather than trusting the allocation.
-- A long external wait during a campaign is a declared pause, not a silent idle, so supervision leaves the waiting worker alone instead of treating it as stuck.
+- A long external wait during a campaign is declared as a pause under the owning supervision contract rather than left as a silent idle.

--- a/.agents/skills/refactor-campaign/SKILL.md
+++ b/.agents/skills/refactor-campaign/SKILL.md
@@ -12,7 +12,7 @@ metadata:
 # refactor-campaign
 
 Use this method when one body of work must be restructured across many pull requests, several waves of crew, and more than one delivery day.
-It is the single owner of Firstmate's campaign shape; the ordinary task lifecycle in `AGENTS.md` section 7 still owns intake, dispatch, supervision, and merge authority for each individual slice inside the campaign.
+It is the single owner of Firstmate's campaign shape; `AGENTS.md` section 7 still owns intake, dispatch, delivery mode, and merge authority for each individual slice inside the campaign, and section 8 still owns its supervision.
 
 ## Scope
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -499,6 +499,7 @@ These skills are not captain-invocable; load them only at their precise triggers
 
 - `bootstrap-diagnostics` - load whenever the session-start digest's bootstrap section prints an actionable diagnostic line (`MISSING:`, `MISSING_MANUAL:`, `BACKEND_INVALID:`, `NEEDS_GH_AUTH`, `TANGLE:`, `STARTUP_MEMORY_BUDGET:`, `CREW_DISPATCH: invalid`, `FLEET_SYNC:`, `PR_CHECK_MIGRATION:`, `SECONDMATE_SYNC:`, `SECONDMATE_LIVENESS:`, `SECONDMATE_HANDOFF:`, `NUDGE_SECONDMATES:`, or `FMX:`); silence and `BOOTSTRAP_INFO:` need no load.
 - `diagnostic-reasoning` - load before scoping a reported bug and before acting on a diagnostic report.
+- `refactor-campaign` - load before planning or executing a large multi-PR refactor or realignment campaign.
 - `ask-user-authority` - load before deciding any ask-user finding, regardless of the project's `yolo` posture.
 - `quota-array-dispatch` - load before choosing among a matched crew-dispatch profile array from current quota-axi output.
 - `harness-adapters` - load before spawning or recovering a crewmate or secondmate, handling a trust dialog, sending a harness-specific skill invocation, interrupting or exiting an agent, resuming an exited agent, or verifying a new harness adapter.

--- a/docs/documentation-audiences.json
+++ b/docs/documentation-audiences.json
@@ -169,6 +169,10 @@
       "audience": "agent-runtime"
     },
     {
+      "path": ".agents/skills/refactor-campaign/SKILL.md",
+      "audience": "agent-runtime"
+    },
+    {
       "path": ".agents/skills/secondmate-provisioning/SKILL.md",
       "audience": "agent-runtime"
     },


### PR DESCRIPTION
## Intent

The developer wanted a new agent-only skill at .agents/skills/refactor-campaign/SKILL.md in the firstmate repo that distills the method of a large multi-PR refactor/realignment campaign into a reusable lifecycle: adversarial up-front planning (a deletion-test abstraction audit plus a reviewer-sized file-level slice map with explicit decision items and stated defaults), authoring fresh at final vocabulary via close-and-resubmit, validate-whole-then-drip using stacked draft PRs proven empirically in the real product before bottom-up merges, written campaign law with a single decision authority, and operational patterns for stacked branches and resource pressure, plus a short "when not to use this" note for small single-PR work. They required it to be fully generalized with no project-, host-, or home-specific residue (distilled from private source notes, never copied or path-referenced), to mirror an existing SKILL.md's structure and frontmatter including metadata.internal=true, to add exactly one condition-stated trigger line to AGENTS.md section 13 and nothing else there for size discipline, to obey the firstmate-coding-guidelines skill, and to pass bin/fm-doc-audience-check.sh and bin/fm-lint.sh before being declared done. Mid-task they amended the scope to a hold: finish authoring and local validation, commit on the branch, and report done, but push nothing and open no PR until the destination was decided. The captain then decided to ship upstream via the griswaldbrooks/firstmate fork and asked for one added scope note stating the skill owns campaign-level orchestration only and composes with, rather than restates, separate per-PR landing and in-task quality-loop skills (the unmerged neighbors pr-shepherd #1718 and gauntlet-loop #1689). Delivery was to go through the repo's normal no-mistakes pipeline path to a cross-repo PR against kunchenguid/firstmate's default branch following CONTRIBUTING conventions, with no agent co-author, leaving the merge to the captain.

## What Changed

- Adds `.agents/skills/refactor-campaign/SKILL.md`, an agent-only (`user-invocable: false`, `metadata.internal: true`) method skill covering the multi-PR campaign lifecycle: adversarial up-front planning (deletion-test abstraction audit plus reviewer-sized file-level slice map), authoring fresh at final vocabulary via close-and-resubmit, validate-whole-then-drip delivery over stacked draft PRs, written campaign law with one decision authority, and stacked-branch/resource-pressure operational patterns — plus a "when not to use this" note scoping it away from single-PR work.
- Scopes the skill to campaign-level orchestration only, deferring per-PR landing and in-task quality loops to their own owners, and cross-references `AGENTS.md` sections 7 and 8, `decision-hold-lifecycle`, and `ask-user-authority` instead of restating them. Review flagged and auto-fixed three issues here: campaign decision defaults now govern planning progress only (with every captain choice registered as a durable hold), the declared-pause bullet defers to its owning supervision contract, and a truncated sentence was completed.
- Registers the skill in the two indexes that must stay in sync: one condition-stated trigger line in `AGENTS.md` section 13 and an `agent-runtime` entry in `docs/documentation-audiences.json`. Tests confirmed the audience check classifies the new surface exactly once and that section 13's trigger set matches the full set of non-user-invocable skills.

## Risk Assessment

✅ Low: Additive documentation-only change adding one agent-only skill plus its two registration entries, with every repo convention, inventory classification, and test-routing surface satisfied and all three prior review findings resolved by citing owners instead of restating them.

## Testing

Treated the change as agent-facing documentation and validated the path an agent actually experiences. Ran the two targeted tests the changed paths select (`fm-documentation-audiences`, `fm-ensure-agents-md`, 13 assertions, all ok) rather than the full 28-script `pure-contract-unit` family; the first internally runs `bin/fm-doc-audience-check.sh`, which is one of the two gates the author was required to pass. Because unit passes alone do not show reachability, I additionally drove the real fleet update path: a sandbox crew home parked on the base commit was fast-forwarded through `ff_target` in `bin/fm-ff-lib.sh` and emitted the genuine crew-visible nudge `instructions changed: AGENTS.md, .agents/skills`, after which section 13 in that home lists the new `refactor-campaign` trigger and the skill file it names is present and readable there. Also verified by hand that section 13's triggers and the agent-only skill set are now exactly congruent (15/15), that the frontmatter mirrors the neighbouring internal skill including `metadata.internal: true`, that AGENTS.md gained exactly one line, that the added scope note states campaign-level-only ownership, and that a 16-pattern scan finds no project-, host-, or home-specific residue. No screenshot or rendered-UI artifact applies: the change ships no user-visible UI, HTML, or CSS surface, and its only end-user surface is markdown read by an agent, so the CLI transcripts capture that surface directly. `bin/fm-lint.sh` was deliberately not run here since linters are out of scope for this phase. Sandbox clone removed and the worktree is clean; everything passed with no actionable findings.

<details>
<summary>Evidence: Fleet instruction-change nudge: a crew home picks up the new skill</summary>

<code>=== A crew home sitting on the base commit fast-forwards onto this change ===&#10;(bin/fm-ff-lib.sh ff_target - the real path the fleet uses to update crew homes)&#10;&#10;crew-home: updated ef2c3a2..de9fca0 (instructions changed: AGENTS.md, .agents/skills)&#10;FF_STATUS=updated&#10;FF_INSTR=AGENTS.md, .agents/skills&#10;&#10;=== Section 13 as the updated crew home now shows it ===&#10;- `refactor-campaign` - load before planning or executing a large multi-PR refactor or realignment campaign.&#10;&#10;=== And the skill it names is present in that home ===&#10;# refactor-campaign&#10;&#10;Use this method when one body of work must be restructured across many pull requests, several waves of crew, and more than one delivery day.</code>

```text
=== A crew home sitting on the base commit fast-forwards onto this change ===
    (bin/fm-ff-lib.sh ff_target - the real path the fleet uses to update crew homes)

crew-home: updated ef2c3a2..de9fca0 (instructions changed: AGENTS.md, .agents/skills)
FF_STATUS=updated
FF_INSTR=AGENTS.md, .agents/skills

=== The running agent is told its instructions and its agent-loaded skills changed,
    so it re-reads AGENTS.md section 13 and can now load refactor-campaign. ===

=== Section 13 as the updated crew home now shows it ===
## 13. Agent-only reference skills

These skills are not captain-invocable; load them only at their precise triggers.

- `bootstrap-diagnostics` - load whenever the session-start digest's bootstrap section prints an actionable diagnostic line (`MISSING:`, `MISSING_MANUAL:`, `BACKEND_INVALID:`, `NEEDS_GH_AUTH`, `TANGLE:`, `STARTUP_MEMORY_BUDGET:`, `CREW_DISPATCH: invalid`, `FLEET_SYNC:`, `PR_CHECK_MIGRATION:`, `SECONDMATE_SYNC:`, `SECONDMATE_LIVENESS:`, `SECONDMATE_HANDOFF:`, `NUDGE_SECONDMATES:`, or `FMX:`); silence and `BOOTSTRAP_INFO:` need no load.
- `diagnostic-reasoning` - load before scoping a reported bug and before acting on a diagnostic report.
- `refactor-campaign` - load before planning or executing a large multi-PR refactor or realignment campaign.
- `ask-user-authority` - load before deciding any ask-user finding, regardless of the project's `yolo` posture.

=== And the skill it names is present in that home ===
# refactor-campaign

Use this method when one body of work must be restructured across many pull requests, several waves of crew, and more than one delivery day.
It is the single owner of Firstmate's campaign shape; the ordinary task lifecycle in `AGENTS.md` section 7 still owns intake, dispatch, supervision, and merge authority for each individual slice inside the campaign.

## Scope

This skill owns campaign-level orchestration only: how the whole body of work is planned, sliced, proven, and sequenced.
It deliberately owns nothing about how one pull request is shepherded to landing, and nothing about the quality loop a worker runs inside a single task.
Those are separate altitudes with their own owners; compose with whichever ones this fleet has installed and never restate their procedure here.
```
</details>
<details>
<summary>Evidence: Agent load path: section 13 trigger resolves to a conformant agent-only skill</summary>

<code>=== 4. Section 13 triggers and the agent-only (user-invocable: false) skill set agree exactly ===&#10;OK: 15 section-13 triggers == 15 agent-only skills; refactor-campaign present in both&#10;&#10;=== 5. AGENTS.md grew by exactly one line (size discipline) ===&#10;1 0 AGENTS.md&#10;&#10;=== 6. Section headings the skill actually delivers ===&#10;12:# refactor-campaign&#10;17:## Scope&#10;23:## When not to use this&#10;29:## 1. Plan first, adversarially&#10;49:## 2. Author fresh at final vocabulary&#10;60:## 3. Validate whole, then drip&#10;77:## 4. Written law and one decision authority&#10;88:## 5. Operational patterns</code>

```text
=== 1. A crew agent reads AGENTS.md section 13 and finds the trigger ===
7:- `refactor-campaign` - load before planning or executing a large multi-PR refactor or realignment campaign.

=== 2. The trigger name resolves to a real agent-loaded skill file ===
100644 19c6365fbe2d3e1845e6364481ab5a06608a1468 0	.agents/skills/refactor-campaign/SKILL.md

=== 3. Frontmatter marks it agent-only + internal, mirroring the neighbouring internal skill ===
---
name: refactor-campaign
description: >-
  Agent-only method for large multi-PR refactor or realignment campaigns.
  Load before planning or executing a campaign that will span many pull requests, several waves of crew, and more than one delivery day.
  Owns adversarial planning, authoring fresh at final vocabulary, validate-whole-then-drip delivery, written campaign law with one decision authority, and the operational patterns a stacked campaign needs.
user-invocable: false
metadata:
  internal: true
--- neighbour for comparison: diagnostic-reasoning ---
---
name: diagnostic-reasoning
description: >-
user-invocable: false
metadata:
  internal: true
---

=== 4. Section 13 triggers and the agent-only (user-invocable: false) skill set agree exactly ===
OK: 15 section-13 triggers == 15 agent-only skills; refactor-campaign present in both

=== 5. AGENTS.md grew by exactly one line (size discipline) ===
1	0	AGENTS.md

=== 6. Section headings the skill actually delivers ===
12:# refactor-campaign
17:## Scope
23:## When not to use this
29:## 1. Plan first, adversarially
49:## 2. Author fresh at final vocabulary
60:## 3. Validate whole, then drip
77:## 4. Written law and one decision authority
88:## 5. Operational patterns

=== 7. Scope note: composes with, does not restate, per-PR / in-task skills ===
## Scope

This skill owns campaign-level orchestration only: how the whole body of work is planned, sliced, proven, and sequenced.
It deliberately owns nothing about how one pull request is shepherded to landing, and nothing about the quality loop a worker runs inside a single task.
Those are separate altitudes with their own owners; compose with whichever ones this fleet has installed and never restate their procedure here.

## When not to use this
```
</details>
<details>
<summary>Evidence: Generalization scan: no project-, host-, or home-specific residue</summary>

<code>clean /home/ clean /Users/ clean /tmp/&#10;clean &lt;username&gt; clean &lt;employer&gt; clean &lt;product&gt;&#10;clean &lt;upstream-owner&gt; clean &lt;sibling-tool&gt; clean localhost&#10;clean http clean @ clean #[0-9]&#10;clean ~/ clean ../ clean domains clean dates&#10;&#10;=== Only in-repo references it makes (all must exist here) ===&#10;line 85 `ask-user-authority` -&gt; .agents/skills/ask-user-authority/SKILL.md EXISTS&#10;line 45 `decision-hold-lifecycle` -&gt; .agents/skills/decision-hold-lifecycle/SKILL.md EXISTS&#10;&#10;=== Cross-reference to the ordinary lifecycle resolves ===&#10;SKILL.md:15 ... the ordinary task lifecycle in `AGENTS.md` section 7 ...&#10;AGENTS.md:235 ## 7. Task lifecycle</code>

```text
=== Residue scan on .agents/skills/refactor-campaign/SKILL.md (must be free of project-, host-, and home-specific detail) ===
clean /home/                      
clean /Users/                     
clean /tmp/                       
clean griswald                    
clean picknik                     
clean moveit                      
clean kunchenguid                 
clean herdr                       
clean localhost                   
clean http                        
clean @                           
clean #[0-9]                      
clean ~/                          
clean \.\./                       
clean [A-Za-z0-9_]+\.(ros|com|net|io)\b
clean 20[0-9][0-9]-[0-9][0-9]-    

=== Only in-repo references it makes (all must exist here) ===
line 85   `ask-user-authority` -> .agents/skills/ask-user-authority/SKILL.md EXISTS
line 45   `decision-hold-lifecycle` -> .agents/skills/decision-hold-lifecycle/SKILL.md EXISTS

=== Cross-reference to the ordinary lifecycle resolves ===
15:It is the single owner of Firstmate's campaign shape; the ordinary task lifecycle in `AGENTS.md` section 7 still owns intake, dispatch, supervision, and merge authority for each individual slice inside the campaign.
235:## 7. Task lifecycle
```
</details>
<details>
<summary>Evidence: Targeted test run</summary>

```text
FM_TEST_BEGIN tests/fm-documentation-audiences.test.sh family=pure-contract-unit
ok - documentation inventory classifies every maintained prose surface exactly once
ok - classification, setup routing, and maintained-prose scope fail safely
ok - required documentation owner pointers cannot silently disappear
ok - local links resolve while dates, versions, commands, and incident prose remain semantically reviewed
FM_TEST_END tests/fm-documentation-audiences.test.sh exit=0
...
FM_TEST_SUMMARY total=2 failed=0 skipped_gate=0 duration_ms=435
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 3 issues found → auto-fixed ✅</summary>

- ⚠️ `.agents/skills/refactor-campaign/SKILL.md:46` - .agents/skills/refactor-campaign/SKILL.md:45-46 says captain-owned choices surface as decision items &#34;with a stated default the plan proceeds on until overridden&#34; and claims this &#34;follows the durable unresolved-decision contract in decision-hold-lifecycle&#34;. The cited owner is stricter for the same situation: a campaign planning investigation is a scout, and .agents/skills/decision-hold-lifecycle/SKILL.md:17 requires every unresolved captain decision to become a registered hold before the investigation may be treated as complete, with :24 and operating-sequence step 6 requiring dependent work to be created and blocked by that hold identity until the captain answers. Campaign slices authored on a stated default are exactly that dependent work, so the two cannot both be satisfied for one decision: the campaign skill authorizes executing dependent work while the hold is open. Either narrow the claim (defaults apply only to choices that create no hold under decision-hold-lifecycle:25) or state the campaign exception explicitly instead of asserting conformance.
- ⚠️ `.agents/skills/refactor-campaign/SKILL.md:94` - .agents/skills/refactor-campaign/SKILL.md:94 restates supervision policy for declared external waits (&#34;supervision leaves the waiting worker alone instead of treating it as stuck&#34;) without citing its owner, and states it more absolutely than the actual policy: .agents/skills/afk/SKILL.md:161-162 has bin/fm-classify-lib.sh self-handle a declared `paused:` wait but resurface one awaiting-external recheck after FM_PAUSE_RESURFACE_SECS (default 3600s). This contradicts the skill&#39;s own Scope rule at line 21 (&#34;never restate their procedure here&#34;) and the one-owner rule in .agents/skills/firstmate-coding-guidelines/SKILL.md:43-46, and the second copy will drift when the resurface behavior changes. Replace the bullet with a one-line cross-reference to the declared-pause owner.
- ℹ️ `.agents/skills/refactor-campaign/SKILL.md:56` - .agents/skills/refactor-campaign/SKILL.md:56 reads &#34;Authoring fresh also removes compatibility shims from existing&#34; - the clause is truncated (apparently intended as &#34;from existence&#34;), leaving the sentence&#39;s main claim incomplete in a file whose entire deliverable is prose an agent reads as instruction.

🔧 Fix: scope campaign decision defaults to planning and cite owners
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bin/fm-test-run.sh tests/fm-documentation-audiences.test.sh tests/fm-ensure-agents-md.test.sh` - 13 assertions ok; the first wraps `bin/fm-doc-audience-check.sh`, proving the new `.agents/skills/refactor-campaign/SKILL.md` inventory entry classifies the surface exactly once and its local links resolve</code>
- <code>`bin/fm-test-run.sh --list --changed --base ef2c3a2499ba19c14380e52c42e2fb09f79b7e96` - used the repo&#39;s own changed-file map to confirm all three changed paths select `pure-contract-unit`, then ran only the two scripts in that family that actually exercise the changed docs surfaces instead of all 28</code>
- <code>Manual end-to-end fleet path: sandbox clone parked on the base commit, fast-forwarded onto the target via `ff_target` from `bin/fm-ff-lib.sh`, producing the real crew-visible line `crew-home: updated ef2c3a2..de9fca0 (instructions changed: AGENTS.md, .agents/skills)`, then read section 13 and the skill body from that updated home</code>
- <code>Manual trigger-resolution check: `awk &#39;/^## 13\./,/^## 14\./&#39; AGENTS.md | grep -oP &#39;^- `\K[a-z0-9-]+&#39;` diffed against every skill with `user-invocable: false` - 15 == 15, identical sets, `refactor-campaign` in both</code>
- <code>Manual frontmatter conformance: compared `.agents/skills/refactor-campaign/SKILL.md` head against `.agents/skills/diagnostic-reasoning/SKILL.md` (name, folded description, `user-invocable: false`, `metadata.internal: true`)</code>
- <code>Manual generalization scan: 16 grep patterns over the skill for home/user paths, host names, private repo or project names, issue/PR refs, URLs, emails and dates - all clean; the only in-repo references (`decision-hold-lifecycle`, `ask-user-authority`, AGENTS.md section 7) all resolve</code>
- <code>`git diff --numstat ef2c3a2..de9fca0 -- AGENTS.md` - confirmed the AGENTS.md size-discipline constraint (1 line added, 0 removed)</code>
- <code>`git log ef2c3a2..de9fca0` co-author scan - no agent co-author trailer on any of the four commits</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 127)

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
