### PR TITLE
docs: add Codex CLI quick start alternative

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ pi
 FM_PI_HARNESS=pi-signed pi-signed
 ```
 
-**Codex CLI**
+**Codex CLI (supported alternative)**
 
 ```sh
 codex

--- a/README.md
+++ b/README.md
@@ -104,6 +104,12 @@ pi
 FM_PI_HARNESS=pi-signed pi-signed
 ```
 
+**Codex CLI**
+
+```sh
+codex
+```
+
 For Grok, `--trust` is needed once per clone so project hooks and the turn-end guard load; `/hooks-trust` inside Grok works too.
 For Pi, approve the project trust prompt once per clone on first launch so the tracked `.pi/extensions/*.ts` files auto-load.
 Pi's `/calm` toggle hides supported transcript chrome, including canonically classified Firstmate operational user rows, and uses a Calm-only animated working boat during active runs while preserving all model context and session data.


### PR DESCRIPTION
## Intent

Make one small, accurate README-only improvement to the Quick Start launch examples. Add Codex CLI as a supported launch example alongside the existing Claude Code, Grok, and Pi examples, using only the concise heading and command needed to launch it from this repository. Keep the total documentation diff at six added lines or fewer, make no unrelated edits, and do not expand the surrounding explanation. Follow the firstmate coding guidelines documentation-audience, one-sentence-per-line, and style requirements. Run bin/fm-doc-audience-check.sh plus any directly relevant lightweight documentation check, review the complete diff, and commit the change. Distinguish Codex accurately as a supported alternative rather than a co-primary harness, within the six-line limit. Preserve pipeline fix commit d205d538. Publish the feature branch through the authorized git@github.com:mdrmono/firstmate.git fork and open the pull request against kunchenguid/firstmate. Drive the pipeline through the CI-ready result without using --yes.

## What Changed

- Add a Codex CLI launch example alongside the existing Quick Start commands.
- Label Codex as a supported alternative to distinguish it from the co-primary harnesses.

## Risk Assessment

✅ Low: The branch adds only the requested six-line README launch block, accurately labels Codex as a supported alternative, uses the verified `codex` command, and leaves all other files unchanged.

## Testing

The baseline commit and complete diff were reviewed, focused documentation checks passed, the documented Codex executable resolved successfully, and the rendered Quick Start visibly preserves the co-primary distinction while presenting Codex as a supported alternative. Reviewer-visible HTML and screenshot evidence were captured, browser test processes were stopped, and no worktree files were changed.

- Evidence: Rendered Quick Start with Codex supported-alternative launch example (local file: <code>/tmp/no-mistakes-evidence/01KZ9F3HY8M5PEPFQZB5D19BG1/readme-codex-quickstart.png</code>)
<details>
<summary>Evidence: Standalone rendered README</summary>

```text
<!DOCTYPE html>
<html xmlns="http://www.w3.org/1999/xhtml" lang="" xml:lang="">
<head>
  <meta charset="utf-8" />
  <meta name="generator" content="pandoc" />
  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes" />
  <title>FirstMate README - Codex Quick Start</title>
  <style>
    html {
      color: #1a1a1a;
      background-color: #fdfdfd;
    }
    body {
      margin: 0 auto;
      max-width: 36em;
      padding-left: 50px;
      padding-right: 50px;
      padding-top: 50px;
      padding-bottom: 50px;
      hyphens: auto;
      overflow-wrap: break-word;
      text-rendering: optimizeLegibility;
      font-kerning: normal;
    }
    @media (max-width: 600px) {
      body {
        font-size: 0.9em;
        padding: 12px;
      }
      h1 {
        font-size: 1.8em;
      }
    }
    @media print {
      html {
        background-color: white;
      }
      body {
        background-color: transparent;
        color: black;
        font-size: 12pt;
      }
      p, h2, h3 {
        orphans: 3;
        widows: 3;
      }
      h2, h3, h4 {
        page-break-after: avoid;
      }
    }
    p {
      margin: 1em 0;
    }
    a {
      color: #1a1a1a;
    }
    a:visited {
      color: #1a1a1a;
    }
    img {
      max-width: 100%;
    }
    h1, h2, h3, h4, h5, h6 {
      margin-top: 1.4em;
    }
    h5, h6 {
      font-size: 1em;
      font-style: italic;
    }
    h6 {
      font-weight: normal;
    }
    ol, ul {
      padding-left: 1.7em;
      margin-top: 1em;
    }
    li > ol, li > ul {
      margin-top: 0;
    }
    blockquote {
      margin: 1em 0 1em 1.7em;
      padding-left: 1em;
      border-left: 2px solid #e6e6e6;
      color: #606060;
    }
    code {
      font-family: Menlo, Monaco, Consolas, 'Lucida Console', monospace;
      font-size: 85%;
      margin: 0;
      hyphens: manual;
    }
    pre {
      margin: 1em 0;
      overflow: auto;
    }
    pre code {
      padding: 0;
      overflow: visible;
      overflow-wrap: normal;
    }
    .sourceCode {
     background-color: transparent;
     overflow: visible;
    }
    hr {
      background-color: #1a1a1a;
      border: none;
      height: 1px;
      margin: 1em 0;
    }
    table {
      margin: 1em 0;
      border-collapse: collapse;
      width: 100%;
      overflow-x: auto;
      display: block;
      font-variant-numeric: lining-nums tabular-nums;
    }
    table caption {
      margin-bottom: 0.75em;
    }
    tbody {
      margin-top: 0.5em;
      border-top: 1px solid #1a1a1a;
      border-bottom: 1px solid #1a1a1a;
    }
    th {
      border-top: 1px solid #1a1a1a;
      padding: 0.25em 0.5em 0.25em 0.5em;
    }
    td {
      padding: 0.125em 0.5em 0.25em 0.5em;
    }
    header {
      margin-bottom: 4em;
      text-align: center;
    }
    #TOC li {
      list-style: none;
    }
    #TOC ul {
      padding-left: 1.3em;
    }
    #TOC > ul {
      padding-left: 0;
    }
    #TOC a:not(:hover) {
      text-decoration: none;
    }
    code{white-space: pre-wrap;}
    span.smallcaps{font-variant: small-caps;}
    div.columns{display: flex; gap: min(4vw, 1.5em);}
    div.column{flex: auto; overflow-x: auto;}
    div.hanging-indent{margin-left: 1.5em; text-indent: -1.5em;}
    /* The extra [class] is a hack that increases specificity enough to
       override a similar rule in reveal.js */
    ul.task-list[class]{list-style: none;}
    ul.task-list li input[type="checkbox"] {
      font-size: inherit;
      width: 0.8em;
      margin: 0 0.8em 0.2em -1.6em;
      vertical-align: middle;
    }
    .display.math{display: block; text-align: center; margin: 0.5rem auto;}
    /* CSS for syntax highlighting */
    pre > code.sourceCode { white-space: pre; position: relative; }
    pre > code.sourceCode > span { line-height: 1.25; }
    pre > code.sourceCode > span:empty { height: 1.2em; }
    .sourceCode { overflow: visible; }
    code.sourceCode > span { color: inherit; text-decoration: inherit; }
    div.sourceCode { margin: 1em 0; }
    pre.sourceCode { margin: 0; }
    @media screen {
    div.sourceCode { overflow: auto; }
    }
    @media print {
    pre > code.sourceCode { white-space: pre-wrap; }
    pre > code.sourceCode > span { text-indent: -5em; padding-left: 5em; }
    }
    pre.numberSource code
      { counter-reset: source-line 0; }
    pre.numberSource code > span
      { position: relative; left: -4em; counter-increment: source-line; }
    pre.numberSource code > span > a:first-child::before
      { content: counter(source-line);
        position: relative; left: -1em; text-align: right; vertical-align: baseline;
        border: none; display: inline-block;
        -webkit-touch-callout: none; -webkit-user-select: none;
        -khtml-user-select: none; -moz-user-select: none;
        -ms-user-select: none; user-select: none;
        padding: 0 4px; width: 4em;
        color: #aaaaaa;
      }
    pre.numberSource { margin-left: 3em; border-left: 1px solid #aaaaaa;  padding-left: 4px; }
    div.sourceCode
      {   }
    @media screen {
    pre > code.sourceCode > span > a:first-child::before { text-decoration: underline; }
    }
    code span.al { color: #ff0000; font-weight: bold; } /* Alert */
    code span.an { color: #60a0b0; font-weight: bold; font-style: italic; } /* Annotation */
    code span.at { color: #7d9029; } /* Attribute */
    code span.bn { color: #40a070; } /* BaseN */
    code span.bu { color: #008000; } /* BuiltIn */
    code span.cf { color: #007020; font-weight: bold; } /* ControlFlow */
    code span.ch { color: #4070a0; } /* Char */
    code span.cn { color: #880000; } /* Constant */
    code span.co { color: #60a0b0; font-style: italic; } /* Comment */
    code span.cv { color: #60a0b0; font-weight: bold; font-style: italic; } /* CommentVar */
    code span.do { color: #ba2121; font-style: italic; } /* Documentation */
    code span.dt { color: #902000; } /* DataType */
    code span.dv { color: #40a070; } /* DecVal */
    code span.er { color: #ff0000; font-weight: bold; } /* Error */
    code span.ex { } /* Extension */
    code span.fl { color: #40a070; } /* Float */
    code span.fu { color: #06287e; } /* Function */
    code span.im { color: #008000; font-weight: bold; } /* Import */
    code span.in { color: #60a0b0; font-weight: bold; font-style: italic; } /* Information */
    code span.kw { color: #007020; font-weight: bold; } /* Keyword */
    code span.op { color: #666666; } /* Operator */
    code span.ot { color: #007020; } /* Other */
    code span.pp { color: #bc7a00; } /* Preprocessor */
    code span.sc { color: #4070a0; } /* SpecialChar */
    code span.ss { color: #bb6688; } /* SpecialString */
    code span.st { color: #4070a0; } /* String */
    code span.va { color: #19177c; } /* Variable */
    code span.vs { color: #4070a0; } /* VerbatimString */
    code span.wa { color: #60a0b0; font-weight: bold; font-style: italic; } /* Warning */
  </style>
</head>
<body>
<header id="title-block-header">
<h1 class="title">FirstMate README - Codex Quick Start</h1>
</header>
<h1 align="center">firstmate</h1>
<p align="center">
  <a
    href="https://img.shields.io/badge/platform-macOS%20%7C%20Linux-blue?style=flat-square"
    ><img
      alt="Platform"
      src="https://img.shields.io/badge/platform-macOS%20%7C%20Linux-blue?style=flat-square"
  /></a>
  <a href="https://x.com/kunchenguid"
    ><img
      alt="X"
      src="https://img.shields.io/badge/X-@kunchenguid-black?style=flat-square"
  /></a>
  <a href="https://discord.gg/Wsy2NpnZDu"
    ><img
      alt="Discord"
      src="https://img.shields.io/discord/1439901831038763092?style=flat-square&label=discord"
  /></a>
</p>

<h3 align="center">Talk to one agent. Ship with a crew.</h3>

<p align="center">
  <img alt="firstmate - talk to one agent, ship with a crew" src="assets/banner.png" width="100%" />
</p>

<h2 id="what-it-is">What it is</h2>
<p>You can run one coding agent easily. But the moment you want three
project tasks done in parallel - fixes, investigations, plans, audits -
you become a tab-juggler: babysitting sessions, copy-pasting context
between repos, forgetting which terminal had the failing test.</p>
<p

... [11702 bytes truncated] ...

 PR/local merge ► teardown
     │
     └─ scout: report at data/&lt;id&gt;/report.md ► decision inventory ► relay findings ► teardown</code></pre>
<p>You chat with the first mate. It routes each request to a crewmate in
its own session endpoint and git worktree, supervises the fleet with a
zero-token event-driven watcher, and brings you finished PRs, approved
local merges, or investigation reports. Optional secondmates extend this
to persistent local or whole-home remote second mates, dispatch profiles
let you steer which harness handles which task, and an opt-in X mode
lets the same fleet answer public mentions. <code>codex-app</code> is
not a runtime backend yet; <a
href="docs/codex-app-backend.md">docs/codex-app-backend.md</a> owns the
Codex App boundary.</p>
<p>Full architecture - the supervision engine, worktree isolation,
secondmates, dispatch profiles, project modes, optional X mode, fleet
sync, and self-update - is in <a
href="docs/architecture.md">docs/architecture.md</a>.</p>
<h2 id="built-in-skills">Built-in skills</h2>
<p>Firstmate ships these user-invocable built-in skills. Claude and grok
use the slash form shown here; codex uses the same names with
<code>$</code>, such as <code>$afk</code>.</p>
<table>
<thead>
<tr class="header">
<th>Skill</th>
<th>What it does</th>
</tr>
</thead>
<tbody>
<tr class="odd">
<td><code>/afk</code></td>
<td>Enter away-mode supervision: the sub-supervisor self-handles routine
notifications in bash, escalates captain-relevant events and bounded
declared-external-wait rechecks as batched digests, and actively alerts
if delivery gets stuck while you step away</td>
</tr>
<tr class="even">
<td><code>/ahoy</code></td>
<td>Recap visible session events since the prior real captain message
plus visibly unanswered captain decisions, falling back to Bearings when
invoked as the session's first real captain message</td>
</tr>
<tr class="odd">
<td><code>/bearings</code></td>
<td>Generate a concise four-section chat digest from bounded local fleet
and registered-secondmate state; use <code>/bearings file</code> to also
replace today's dated report in <code>data/</code>, and add
<code>include PRs</code> when live PR enrichment is wanted</td>
</tr>
<tr class="even">
<td><code>/updatefirstmate</code></td>
<td>Self-update the running firstmate and its secondmates to the latest
from origin with fast-forward-only pulls, then re-read instructions and
nudge secondmates</td>
</tr>
<tr class="odd">
<td><code>/stow</code></td>
<td>Sweep the session for uncaptured durable knowledge, route each
finding to its disk home per AGENTS.md, file undone next steps to the
backlog, and report what is now safe to reset</td>
</tr>
</tbody>
</table>
<p>Bearings invocation examples:</p>
<ul>
<li><code>/bearings</code> returns the fresh four-section digest in chat
only.</li>
<li><code>/bearings include PRs</code> keeps chat-only mode and opts
into live PR enrichment.</li>
<li><code>/bearings file</code> replaces today's
<code>data/status-report-&lt;YYYY-MM-DD&gt;.md</code> from scratch and
links it from the four-section chat digest.</li>
<li><code>/bearings file include PRs</code> combines the dated report
with live PR enrichment.</li>
</ul>
<p>Agent-only reference skills live under <code>.agents/skills/</code>
and are loaded by firstmate at the trigger points named in <a
href="AGENTS.md"><code>AGENTS.md</code></a>.</p>
<h3 id="two-tier-skill-layout">Two-tier skill layout</h3>
<p>Firstmate's skills live in two separate places with different
audiences:</p>
<ul>
<li><code>.agents/skills/</code> - agent-loaded skills (this section's
table, plus firstmate's agent-only reference skills). Every one of these
assumes a live firstmate home and is meaningless, or actively
misleading, installed anywhere else, so each carries
<code>metadata.internal: true</code> in its frontmatter. That flag hides
them from installer discovery (tools like the <a
href="https://skills.sh">skills.sh</a> <code>npx skills add</code>
installer) without affecting how firstmate itself loads them -
frontmatter metadata is inert to the agent's own skill loader.</li>
<li><code>skills/</code> - public, installer-facing skills meant to be
installed standalone into any project, independent of firstmate. Each
one is a self-contained skill with no dependency on firstmate's paths,
tools, or vocabulary. Today that is <code>skills/stow</code>, a generic
session-knowledge-sweep skill that routes findings by explicit
instruction first, then existing local conventions, then a private
<code>.stow-notes.md</code> fallback in the current directory, and
closes with a resume pointer for the next session. It intentionally
shares no code with the firstmate-internal
<code>.agents/skills/stow</code> it is named after, so the two can
evolve independently.</li>
</ul>
<h2 id="documentation">Documentation</h2>
<ul>
<li><a href="docs/architecture.md">docs/architecture.md</a> - maintainer
architecture for the crew, supervision, worktrees, secondmates, and
project modes.</li>
<li><a href="docs/configuration.md">docs/configuration.md</a> -
environment variables, <code>FM_HOME</code>, runtime backend selection,
optional X mode, the files you set, and harness support.</li>
<li><a href="docs/remote-secondmates.md">docs/remote-secondmates.md</a>
- current setup, routing, transfer, recovery, and safety behavior for
whole-home remote second mates.</li>
<li><a href="docs/calm.md">docs/calm.md</a> - current Pi
<code>/calm</code> behavior and supported presentation limits.</li>
<li><a href="docs/wedge-alarm.md">docs/wedge-alarm.md</a> - configure
the active alert for an away-mode escalation delivery that gets
stuck.</li>
<li><a href="docs/tmux-backend.md">docs/tmux-backend.md</a> - current
setup and limits for the tmux reference backend.</li>
<li><a href="docs/herdr-backend.md">docs/herdr-backend.md</a> - current
setup, safety boundaries, and limits for the experimental Herdr
backend.</li>
<li><a href="docs/zellij-backend.md">docs/zellij-backend.md</a> -
current setup and limits for the experimental Zellij backend.</li>
<li><a href="docs/orca-backend.md">docs/orca-backend.md</a> - current
setup and limits for the experimental Orca backend.</li>
<li><a href="docs/cmux-backend.md">docs/cmux-backend.md</a> - current
setup, socket security, and limits for the experimental cmux
backend.</li>
<li><a href="docs/codex-app-backend.md">docs/codex-app-backend.md</a> -
the current blocked Codex App backend boundary and rollout
contract.</li>
<li><a
href="docs/verification/runtime-backends.md">docs/verification/runtime-backends.md</a>
- active maintainer verification for runtime backend guarantees.</li>
<li><a href="docs/gitlab-merge-watch.md">docs/gitlab-merge-watch.md</a>
- maintainer verification for GitLab merge watching on arbitrary
instances.</li>
<li><a href="docs/turnend-guard.md">docs/turnend-guard.md</a> - the
primary session's current "no turn ends blind" backstop, scope, loop
safety, and compatibility limits.</li>
<li><a
href="docs/verification/supervision.md">docs/verification/supervision.md</a>
- active maintainer verification for session-start, guard, continuity,
and wedge integrations.</li>
<li><a
href="docs/supervision-protocols/">docs/supervision-protocols/</a> -
rendered primary-harness watcher protocols for Claude, Codex, OpenCode,
Pi and <code>pi-signed</code>, Grok, and unknown harness fallback.</li>
<li><a href="docs/scripts.md">docs/scripts.md</a> - the
<code>bin/</code> toolbelt reference.</li>
<li><a
href="docs/documentation-audiences.md">docs/documentation-audiences.md</a>
- documentation audiences and the machine-checked placement
boundary.</li>
<li><a href="AGENTS.md"><code>AGENTS.md</code></a> - the distro's
always-loaded operating contract and routing index for conditional
procedures.</li>
<li><a href="CONTRIBUTING.md">CONTRIBUTING.md</a> - how to contribute,
including the dev/test commands.</li>
</ul>
<h2 id="contributing">Contributing</h2>
<p>Contributions are welcome - see <a
href="CONTRIBUTING.md">CONTRIBUTING.md</a> for the workflow, repo
conventions, and how to run the tests.</p>
<h2 id="license">License</h2>
<p>MIT - see <a href="LICENSE">LICENSE</a>.</p>
</body>
</html>
```
</details>
<details>
<summary>Evidence: Documented Codex CLI command availability</summary>

```text
/home/manuelin/.nvm/versions/node/v22.21.1/bin/codex
codex-cli 0.146.0
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `git diff --name-status/--numstat/--unified=40 bf01a423efb899aa82e776412ae3df9b169f827d..d205d538dad07a37d07284fac3a2fee1c3f67a49`
- `bin/fm-doc-audience-check.sh`
- `tests/fm-documentation-audiences.test.sh`
- `command -v codex && codex --version`
- <code>Rendered `README.md` with Pandoc, opened it in Chrome at 1440×1000, verified Codex heading/command adjacency, and visually inspected the screenshot</code>
- `Final complete diff and clean-worktree review`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 127)

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
