### PR TITLE
fix(bin): bound the bootstrap gh auth status probe

### DIFF
--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -7,6 +7,7 @@
 #          Silent = all good.
 #          Lines: "MISSING: <tool> (install: <command>)",
 #                 "MISSING_MANUAL: <tool> (instructions: <url>)", "NEEDS_GH_AUTH",
+#                 "GH_AUTH: authenticated|not authenticated|indeterminate (probe timed out after <seconds>s)"
 #                 "BACKEND_INVALID: <name> (known: <names>)",
 #                 "STARTUP_MEMORY_BUDGET: invalid config/startup-memory-budget - <reason>",
 #                 "CREW_DISPATCH: invalid config/crew-dispatch.json - <reason>",
@@ -102,6 +103,10 @@ PROJECTS="${FM_PROJECTS_OVERRIDE:-$FM_HOME/projects}"
 CONFIG="${FM_CONFIG_OVERRIDE:-$FM_HOME/config}"
 STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
 DATA="${FM_DATA_OVERRIDE:-$FM_HOME/data}"
+FM_GH_AUTH_TIMEOUT_SECS=${FM_GH_AUTH_TIMEOUT_SECS:-10}
+case "$FM_GH_AUTH_TIMEOUT_SECS" in
+  ''|*[!0-9]*|0) FM_GH_AUTH_TIMEOUT_SECS=10 ;;
+esac
 # shellcheck source=bin/fm-tasks-axi-lib.sh disable=SC1091
 . "$SCRIPT_DIR/fm-tasks-axi-lib.sh"
 # shellcheck source=bin/fm-quota-axi-lib.sh disable=SC1091
@@ -202,6 +207,57 @@ fleet_sync() {
 
   fleet_sync_relay_filtered_output "$tmp"
   rm -f "$tmp"
+}
+
+# Runs only `gh auth status` with prompting and update notifications disabled.
+# Return 0 for authenticated, 1 for an ordinary unauthenticated/error result,
+# and 124 when the bounded probe could not determine a result.
+gh_auth_probe() {
+  if command -v timeout >/dev/null 2>&1; then
+    GH_PROMPT_DISABLED=1 GH_NO_UPDATE_NOTIFIER=1 \
+      timeout "$FM_GH_AUTH_TIMEOUT_SECS" gh auth status >/dev/null 2>&1
+  elif command -v gtimeout >/dev/null 2>&1; then
+    GH_PROMPT_DISABLED=1 GH_NO_UPDATE_NOTIFIER=1 \
+      gtimeout "$FM_GH_AUTH_TIMEOUT_SECS" gh auth status >/dev/null 2>&1
+  elif command -v perl >/dev/null 2>&1; then
+    GH_PROMPT_DISABLED=1 GH_NO_UPDATE_NOTIFIER=1 perl -e '
+      my $t = shift;
+      my $pid = fork;
+      die "fork failed" unless defined $pid;
+      if (!$pid) { setpgrp(0, 0); exec @ARGV }
+      local $SIG{ALRM} = sub {
+        kill "TERM", -$pid;
+        select undef, undef, undef, 0.2;
+        kill "KILL", -$pid;
+        exit 124;
+      };
+      alarm $t;
+      waitpid $pid, 0;
+      exit($? >> 8);
+    ' "$FM_GH_AUTH_TIMEOUT_SECS" gh auth status >/dev/null 2>&1
+  else
+    return 124
+  fi
+}
+
+gh_auth_report() {
+  local status
+  gh_auth_probe
+  status=$?
+  case "$status" in
+    0)
+      [ "${FM_BOOTSTRAP_GH_AUTH_DIAGNOSTICS:-0}" != 1 ] \
+        || echo "GH_AUTH: authenticated"
+      ;;
+    124)
+      echo "GH_AUTH: indeterminate (probe timed out after ${FM_GH_AUTH_TIMEOUT_SECS}s)"
+      ;;
+    *)
+      echo "NEEDS_GH_AUTH"
+      [ "${FM_BOOTSTRAP_GH_AUTH_DIAGNOSTICS:-0}" != 1 ] \
+        || echo "GH_AUTH: not authenticated"
+      ;;
+  esac
 }
 
 secondmate_sync() {
@@ -1001,7 +1057,7 @@ fi
 if command -v tasks-axi >/dev/null 2>&1 && ! fm_tasks_axi_compatible; then
   echo "MISSING: tasks-axi (install: $(install_cmd tasks-axi))"
 fi
-gh auth status >/dev/null 2>&1 || echo "NEEDS_GH_AUTH"
+gh_auth_report
 # Worktree-tangle check: the firstmate primary checkout (FM_ROOT) must sit on its
 # default branch, not a feature branch (see fm-tangle-lib.sh). Scoped to the
 # primary only; detached-HEAD worktrees and secondmate homes never trip it.

--- a/tests/fm-bootstrap.test.sh
+++ b/tests/fm-bootstrap.test.sh
@@ -74,6 +74,98 @@ SH
   printf '%s\n' "$fakebin"
 }
 
+set_fake_gh_auth_status() {  # <fakebin> <authenticated|unauthenticated|hung>
+  local fakebin=$1 mode=$2
+  cat > "$fakebin/gh" <<SH
+#!/usr/bin/env bash
+if [ "\${1:-}" = auth ] && [ "\${2:-}" = status ]; then
+  case '$mode' in
+    authenticated) exit 0 ;;
+    unauthenticated) exit 1 ;;
+    hung) sleep 300 ;;
+  esac
+fi
+exit 0
+SH
+  chmod +x "$fakebin/gh"
+}
+
+test_bounded_gh_auth_probe_reports_typed_states() {
+  local case_dir fakebin out start elapsed
+  case_dir="$TMP_ROOT/gh-auth-probe"
+  mkdir -p "$case_dir/home/config"
+  printf '%s\n' manual > "$case_dir/home/config/backlog-backend"
+  fakebin=$(make_fake_toolchain "$case_dir")
+
+  set_fake_gh_auth_status "$fakebin" authenticated
+  out=$(PATH="$fakebin:$BASE_PATH" FM_HOME="$case_dir/home" FM_ROOT_OVERRIDE="$case_dir/home" \
+    FM_BOOTSTRAP_DETECT_ONLY=1 FM_BOOTSTRAP_GH_AUTH_DIAGNOSTICS=1 \
+    FM_FAKE_TREEHOUSE_LEASE_HELP=1 "$ROOT/bin/fm-bootstrap.sh")
+  [ "$out" = "GH_AUTH: authenticated" ] \
+    || fail "authenticated probe should report its typed state, got: $out"
+
+  set_fake_gh_auth_status "$fakebin" unauthenticated
+  out=$(PATH="$fakebin:$BASE_PATH" FM_HOME="$case_dir/home" FM_ROOT_OVERRIDE="$case_dir/home" \
+    FM_BOOTSTRAP_DETECT_ONLY=1 FM_BOOTSTRAP_GH_AUTH_DIAGNOSTICS=1 \
+    FM_FAKE_TREEHOUSE_LEASE_HELP=1 "$ROOT/bin/fm-bootstrap.sh")
+  [ "$out" = $'NEEDS_GH_AUTH\nGH_AUTH: not authenticated' ] \
+    || fail "unauthenticated probe should remain distinct from a timeout, got: $out"
+
+  set_fake_gh_auth_status "$fakebin" hung
+  start=$SECONDS
+  out=$(PATH="$fakebin:$BASE_PATH" FM_HOME="$case_dir/home" FM_ROOT_OVERRIDE="$case_dir/home" \
+    FM_BOOTSTRAP_DETECT_ONLY=1 FM_BOOTSTRAP_GH_AUTH_DIAGNOSTICS=1 \
+    FM_GH_AUTH_TIMEOUT_SECS=1 FM_FAKE_TREEHOUSE_LEASE_HELP=1 "$ROOT/bin/fm-bootstrap.sh")
+  elapsed=$((SECONDS - start))
+  [ "$out" = "GH_AUTH: indeterminate (probe timed out after 1s)" ] \
+    || fail "hung probe should report indeterminate rather than unauthenticated, got: $out"
+  [ "$elapsed" -lt 5 ] || fail "hung auth probe exceeded its 1s bound (elapsed ${elapsed}s)"
+  pass "bootstrap bounds gh auth status and reports authenticated, unauthenticated, and indeterminate states"
+}
+
+run_preflight_bootstrap_capture() {  # <bootstrap command...>
+  local bootstrap_output preflight_result
+  bootstrap_output=$(FM_BOOTSTRAP_DETECT_ONLY=1 "$@")
+  if [ -n "$bootstrap_output" ]; then
+    printf '%s\n' "$bootstrap_output"
+    preflight_result=PASS_WITH_REPORTED_TOOLCHAIN_GAPS
+  else
+    preflight_result=PASS
+  fi
+  printf 'PREFLIGHT_RESULT: %s\n' "$preflight_result"
+}
+
+test_pilot_preflight_reaches_result_for_all_auth_states() {
+  local case_dir fakebin out start elapsed
+  case_dir="$TMP_ROOT/pilot-preflight-auth"
+  mkdir -p "$case_dir/home/config"
+  printf '%s\n' manual > "$case_dir/home/config/backlog-backend"
+  fakebin=$(make_fake_toolchain "$case_dir")
+
+  set_fake_gh_auth_status "$fakebin" authenticated
+  out=$(PATH="$fakebin:$BASE_PATH" FM_HOME="$case_dir/home" FM_ROOT_OVERRIDE="$case_dir/home" \
+    FM_FAKE_TREEHOUSE_LEASE_HELP=1 run_preflight_bootstrap_capture "$ROOT/bin/fm-bootstrap.sh")
+  [ "$out" = "PREFLIGHT_RESULT: PASS" ] \
+    || fail "authenticated preflight should reach PASS, got: $out"
+
+  set_fake_gh_auth_status "$fakebin" unauthenticated
+  out=$(PATH="$fakebin:$BASE_PATH" FM_HOME="$case_dir/home" FM_ROOT_OVERRIDE="$case_dir/home" \
+    FM_FAKE_TREEHOUSE_LEASE_HELP=1 run_preflight_bootstrap_capture "$ROOT/bin/fm-bootstrap.sh")
+  [ "$out" = $'NEEDS_GH_AUTH\nPREFLIGHT_RESULT: PASS_WITH_REPORTED_TOOLCHAIN_GAPS' ] \
+    || fail "unauthenticated preflight should reach a reported-gap result, got: $out"
+
+  set_fake_gh_auth_status "$fakebin" hung
+  start=$SECONDS
+  out=$(PATH="$fakebin:$BASE_PATH" FM_HOME="$case_dir/home" FM_ROOT_OVERRIDE="$case_dir/home" \
+    FM_GH_AUTH_TIMEOUT_SECS=1 FM_FAKE_TREEHOUSE_LEASE_HELP=1 \
+    run_preflight_bootstrap_capture "$ROOT/bin/fm-bootstrap.sh")
+  elapsed=$((SECONDS - start))
+  [ "$out" = $'GH_AUTH: indeterminate (probe timed out after 1s)\nPREFLIGHT_RESULT: PASS_WITH_REPORTED_TOOLCHAIN_GAPS' ] \
+    || fail "indeterminate auth preflight should reach a reported-gap result, got: $out"
+  [ "$elapsed" -lt 5 ] || fail "indeterminate preflight exceeded its 1s auth bound (elapsed ${elapsed}s)"
+  pass "pilot preflight reaches PREFLIGHT_RESULT for authenticated, unauthenticated, and indeterminate auth states"
+}
+
 add_quota_axi() {
   local fakebin=$1
   cat > "$fakebin/quota-axi" <<'SH'
@@ -833,6 +925,8 @@ ROWS
 }
 
 test_bootstrap_reporting
+test_bounded_gh_auth_probe_reports_typed_states
+test_pilot_preflight_reaches_result_for_all_auth_states
 test_no_mistakes_min_version
 test_quota_axi_min_version
 test_git_is_required_with_supported_install_instruction


### PR DESCRIPTION
## Problem

`bin/fm-bootstrap.sh` probes GitHub auth with a bare `gh auth status`, which can hang indefinitely (interactive prompt, network stall). A hung probe blocks bootstrap and anything waiting on it, and a timeout is indistinguishable from being unauthenticated.

## Change

- Adds `gh_auth_probe`: the same single `gh auth status` call, but bounded (default 10s, override via `FM_GH_AUTH_TIMEOUT_SECS`, non-numeric/zero values reset to 10), with prompting and update notifications disabled, using `timeout`, `gtimeout`, or a Perl process-group alarm as fallback.
- Adds `gh_auth_report`: exit 0 stays silent by default, ordinary nonzero keeps the legacy `NEEDS_GH_AUTH` line, and 124 reports `GH_AUTH: indeterminate (probe timed out after Ns)` so a timeout is never misreported as unauthenticated. `FM_BOOTSTRAP_GH_AUTH_DIAGNOSTICS=1` opts into explicit typed lines for the authenticated and unauthenticated states too.
- Existing default output is unchanged for the authenticated and unauthenticated cases.

## Tests

Two new hermetic cases in `tests/fm-bootstrap.test.sh` (fake `gh`; no network, no credentials): typed-state reporting for authenticated / unauthenticated / hung probes with a bound-time assertion, and a mirror of the pilot preflight capture proving `PREFLIGHT_RESULT` is reached in all three states. Full suite: 23 ok / 0 not ok, exit 0.

Note: ShellCheck is not installed on the authoring machine, so `bin/fm-lint.sh` was not run locally; relying on CI for lint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)