### PR TITLE
fix(bin): prevent remote polls from blocking session startup

### DIFF
--- a/bin/fm-remote-delta-read.sh
+++ b/bin/fm-remote-delta-read.sh
@@ -9,6 +9,11 @@
 # available, returns at most 65536 payload bytes, and never truncates or consumes
 # the source. A shortened or changed prefix returns a structured continuity-break
 # result instead of silently rebasing the cursor.
+#
+# Exit 75 means the wait window closed with no complete line. SIGTERM exits the
+# same way after cleanup, because the remote job worker preempts this read-only
+# poll to unblock queued short commands (bin/fm-remote-job-lib.sh owns that
+# contract) and a preempted read is indistinguishable from an empty window.
 set -eu
 
 FM_HOME=${FM_HOME:?FM_HOME is required}
@@ -120,6 +125,7 @@ case "$MAX_BYTES" in ''|*[!0-9]*|0) die "FM_REMOTE_DELTA_MAX_BYTES must be a pos
 LOG=$(resolve_log "$REL")
 TMP=$(mktemp -d "${TMPDIR:-/tmp}/fm-remote-delta.XXXXXX") || die "cannot create delta staging directory"
 trap 'rm -rf -- "$TMP"' EXIT
+trap 'exit 75' TERM
 : > "$TMP/empty"
 EMPTY_HASH=$(sha256_file "$TMP/empty")
 START=$(date +%s)

--- a/bin/fm-remote-delta-read.sh
+++ b/bin/fm-remote-delta-read.sh
@@ -11,9 +11,10 @@
 # result instead of silently rebasing the cursor.
 #
 # Exit 75 means the wait window closed with no complete line. SIGTERM exits the
-# same way after cleanup, because the remote job worker preempts this read-only
-# poll to unblock queued short commands (bin/fm-remote-job-lib.sh owns that
-# contract) and a preempted read is indistinguishable from an empty window.
+# same way after cleanup. The remote job worker preempts this read-only poll to
+# unblock any queued command other than another reply long-poll. The
+# bin/fm-remote-job-lib.sh header owns that contract, and a preempted read is
+# indistinguishable from an empty window.
 set -eu
 
 FM_HOME=${FM_HOME:?FM_HOME is required}

--- a/bin/fm-remote-job-lib.sh
+++ b/bin/fm-remote-job-lib.sh
@@ -15,6 +15,16 @@
 # for done, relay stdout and stderr separately, then reap only their completed
 # record. Input, argv, stdout, and stderr are each capped at 1048576 bytes.
 #
+# The worker executes one job at a time, so a deliberately long-blocking poll
+# would serialize every short interactive command behind its wait window.
+# fm_remote_job_command_preemptible names the read-only long-poll class
+# (fm-remote-delta-read.sh, the reply-log delta read). The worker preempts a
+# running preemptible job as soon as a non-preemptible job is queued and
+# publishes exit 75 with emptied stdout and stderr, identical to the poll's own
+# elapsed-window-with-no-data result. The delta read is non-destructive and
+# cursor-anchored, so the caller's normal re-arm re-reads the same data and a
+# preempted poll loses nothing.
+#
 # The worker accepts only a tracked, non-symlink executable named fm-*.sh below
 # its configured FM_ROOT/bin. Every child receives env -i with the composed
 # PATH, HOME, FM_HOME, FM_ROOT_OVERRIDE, and FM_REMOTE_JOB_ACTIVE=1. The PATH
@@ -53,6 +63,10 @@ fm_remote_job_die() {
 
 fm_remote_job_safe_id() {
   case "$1" in ''|*[!A-Za-z0-9._-]*) return 1 ;; esac
+}
+
+fm_remote_job_command_preemptible() { # <staged argv command>
+  case "${1:-}" in fm-remote-delta-read.sh) return 0 ;; *) return 1 ;; esac
 }
 
 fm_remote_job_validate_settings() {

--- a/bin/fm-remote-job-worker.sh
+++ b/bin/fm-remote-job-worker.sh
@@ -27,6 +27,8 @@ WORKER_LOCK=
 WORKER_LOCK_HELD=0
 WORKER_RELEASE_OWNERSHIP=1
 WORKER_SUPERVISED_PID=
+WORKER_PREEMPTIBLE=0
+WORKER_PREEMPTED=0
 
 worker_error() { printf 'remote-job-worker: %s\n' "$1" >&2; }
 
@@ -354,8 +356,9 @@ worker_publish_result() { # <job-dir> <exit>
 }
 
 worker_run_with_timeout() { # <job-dir> <seconds> <command> [args...]
-  local job=$1 timeout=$2 group_file armed_file group_pid rc tmp deadline next_heartbeat
+  local job=$1 timeout=$2 group_file armed_file group_pid rc tmp deadline next_heartbeat attempt
   local timed_out=0 heartbeat_failed=0
+  WORKER_PREEMPTED=0
   shift 2
   group_file="$job/.claim/group"
   armed_file="$job/.claim/armed"
@@ -421,6 +424,17 @@ worker_run_with_timeout() { # <job-dir> <seconds> <command> [args...]
         heartbeat_failed=1
         break
       fi
+      if [ "$WORKER_PREEMPTIBLE" -eq 1 ] && worker_preempting_waiter_exists; then
+        worker_signal_process_or_group group TERM "$group_pid"
+        attempt=0
+        while worker_process_or_group_alive group "$group_pid" && [ "$attempt" -lt 20 ]; do
+          attempt=$((attempt + 1))
+          sleep 0.05
+        done
+        worker_signal_process_or_group group KILL "$group_pid"
+        WORKER_PREEMPTED=1
+        break
+      fi
       next_heartbeat=$((SECONDS + 1))
     fi
     sleep "$FM_REMOTE_JOB_POLL_SECONDS"
@@ -431,7 +445,27 @@ worker_run_with_timeout() { # <job-dir> <seconds> <command> [args...]
   WORKER_ACTIVE_JOB=
   [ "$timed_out" -eq 0 ] || return 124
   [ "$heartbeat_failed" -eq 0 ] || return 125
+  [ "$WORKER_PREEMPTED" -eq 0 ] || return 75
   return "$rc"
+}
+
+worker_job_command() { # <job-dir>; the first argv element of a staged record
+  local job=$1 first=
+  fm_remote_job_regular_bounded "$job/argv" "$FM_REMOTE_JOB_MAX_BYTES" || return 1
+  IFS= read -r -d '' first < "$job/argv" || [ -n "$first" ] || return 1
+  printf '%s\n' "$first"
+}
+
+worker_preempting_waiter_exists() {
+  local job state command
+  for job in "$FM_REMOTE_JOB_JOBS"/job-*; do
+    [ -d "$job" ] && [ ! -L "$job" ] || continue
+    state=$(fm_remote_job_read_state "$job" 2>/dev/null || true)
+    [ "$state" = queued ] || continue
+    command=$(worker_job_command "$job" 2>/dev/null || true)
+    fm_remote_job_command_preemptible "$command" || return 0
+  done
+  return 1
 }
 
 worker_cleanup_output_capture() { # <job-dir> <stdout-reader> <stderr-reader>
@@ -452,7 +486,7 @@ worker_capture_output() { # <fifo> <destination>
 
 worker_run_job() { # <account-home> <job-dir>
   local account_home=$1 job=$2 root home command command_path git_bin rc deadline remaining
-  local stdout_pipe stderr_pipe stdout_reader stderr_reader
+  local stdout_pipe stderr_pipe stdout_reader stderr_reader preemptible=0
   local -a argv child_env
   root=$(worker_read_text "$job" root 8192) || { worker_publish_result "$job" 126; return; }
   home=$(worker_read_text "$job" home 8192) || { worker_publish_result "$job" 126; return; }
@@ -472,6 +506,7 @@ worker_run_job() { # <account-home> <job-dir>
   command=${argv[0]}
   case "$command" in fm-*.sh) ;; *) worker_publish_result "$job" 126; return ;; esac
   case "$command" in */*|*..*) worker_publish_result "$job" 126; return ;; esac
+  if fm_remote_job_command_preemptible "$command"; then preemptible=1; fi
   command_path="$root/bin/$command"
   [ -f "$command_path" ] && [ ! -L "$command_path" ] && [ -x "$command_path" ] || {
     worker_publish_result "$job" 126
@@ -531,13 +566,19 @@ worker_run_job() { # <account-home> <job-dir>
     return
   }
   set +e
+  WORKER_PREEMPTIBLE=$preemptible
   worker_run_with_timeout "$job" "$remaining" "${child_env[@]}" \
     "$command_path" "${argv[@]:1}" < "$job/stdin" > "$stdout_pipe" 2> "$stderr_pipe"
   rc=$?
+  WORKER_PREEMPTIBLE=0
   wait "$stdout_reader"
   wait "$stderr_reader"
   rm -f -- "$stdout_pipe" "$stderr_pipe"
   set -e
+  if [ "$WORKER_PREEMPTED" -eq 1 ]; then
+    : > "$job/stdout"
+    : > "$job/stderr"
+  fi
   worker_publish_result "$job" "$rc" || worker_error "could not publish result for ${job##*/}"
 }
 

--- a/docs/remote-secondmates.md
+++ b/docs/remote-secondmates.md
@@ -32,7 +32,7 @@ The entrypoint authorizes that bootstrap with normal git tracking when git resol
 After setup, every other command verifies Firstmate's account-owned remote job worker, stages the encoded argv and stdin bytes, waits for its result, and relays stdout, stderr, and the exit status separately.
 On macOS the worker is `dev.firstmate.remote-job`, an Aqua-scoped LaunchAgent at `~/Library/LaunchAgents/dev.firstmate.remote-job.plist` with logs under `~/Library/Logs/`.
 After that bootstrap every non-doctor `fm-on.sh` target runs through that worker in the remote account's GUI session, never in the SSH process or a Herdr pane.
-The worker runs one staged job at a time and preempts a running reply long-poll as soon as a short command is queued, so interactive commands and startup checks are never serialized behind a poll window.
+The worker runs one staged job at a time and preempts a running reply long-poll as soon as any command other than another reply long-poll is queued, so interactive commands and startup checks are never serialized behind a poll window.
 `bin/fm-remote-job-lib.sh` owns that preemption contract, and a preempted poll is indistinguishable from one whose wait window closed with no data, so the re-armed poll loses nothing.
 Linux uses the same queue and worker protocol without the Aqua-session requirement.
 The remote account must provide the required toolchain, the selected worker runtime, the selected session backend, and credentials that work on that host.

--- a/docs/remote-secondmates.md
+++ b/docs/remote-secondmates.md
@@ -32,6 +32,8 @@ The entrypoint authorizes that bootstrap with normal git tracking when git resol
 After setup, every other command verifies Firstmate's account-owned remote job worker, stages the encoded argv and stdin bytes, waits for its result, and relays stdout, stderr, and the exit status separately.
 On macOS the worker is `dev.firstmate.remote-job`, an Aqua-scoped LaunchAgent at `~/Library/LaunchAgents/dev.firstmate.remote-job.plist` with logs under `~/Library/Logs/`.
 After that bootstrap every non-doctor `fm-on.sh` target runs through that worker in the remote account's GUI session, never in the SSH process or a Herdr pane.
+The worker runs one staged job at a time and preempts a running reply long-poll as soon as a short command is queued, so interactive commands and startup checks are never serialized behind a poll window.
+`bin/fm-remote-job-lib.sh` owns that preemption contract, and a preempted poll is indistinguishable from one whose wait window closed with no data, so the re-armed poll loses nothing.
 Linux uses the same queue and worker protocol without the Aqua-session requirement.
 The remote account must provide the required toolchain, the selected worker runtime, the selected session backend, and credentials that work on that host.
 Project origin URLs recorded by the primary must be reachable from the remote account because projects are cloned on that host rather than copied from the primary.

--- a/tests/fm-remote-job.test.sh
+++ b/tests/fm-remote-job.test.sh
@@ -21,7 +21,8 @@ RECOVERY_WORKER_PID=
 mkdir -p "$REMOTE_ROOT/bin" "$REMOTE_HOME" "$ACCOUNT_HOME" "$RUNTIME_BIN"
 trap 'if [ -n "$OTHER_PID" ]; then kill "$OTHER_PID" 2>/dev/null || true; fi; if [ -n "$RECOVERY_WORKER_PID" ]; then kill "$RECOVERY_WORKER_PID" 2>/dev/null || true; fi; if [ -f "$STATE_ROOT/worker.pid" ]; then kill "$(cat "$STATE_ROOT/worker.pid")" 2>/dev/null || true; fi; rm -rf -- "$TMP_ROOT"' EXIT
 
-cp "$ROOT/bin/fm-remote-job-lib.sh" "$ROOT/bin/fm-remote-job-worker.sh" "$REMOTE_ROOT/bin/"
+cp "$ROOT/bin/fm-remote-job-lib.sh" "$ROOT/bin/fm-remote-job-worker.sh" \
+  "$ROOT/bin/fm-remote-delta-read.sh" "$REMOTE_ROOT/bin/"
 printf 'fixture\n' > "$REMOTE_ROOT/AGENTS.md"
 cat > "$REMOTE_ROOT/bin/fm-probe-job.sh" <<'SH'
 #!/bin/bash
@@ -322,6 +323,83 @@ assert_present "$SECOND_DELAYED_SIDE_EFFECT" "the queued job did not receive its
 fm_remote_job_reap "$ACCOUNT_HOME" "$FIRST_JOB_ID" || fail "the first delayed job could not be reaped"
 fm_remote_job_reap "$ACCOUNT_HOME" "$JOB_ID" || fail "the second delayed job could not be reaped"
 pass "queued jobs receive a fresh bounded execution window"
+
+if command -v shasum >/dev/null 2>&1; then
+  EMPTY_SHA=$(: | shasum -a 256 | awk '{print $1}')
+else
+  EMPTY_SHA=$(: | sha256sum | awk '{print $1}')
+fi
+mkdir -p "$REMOTE_HOME/state"
+REPLY_LOG_REL=state/parent-replies.status
+PREEMPT_SIDE_EFFECT="$TMP_ROOT/preempt-side-effect"
+FM_REMOTE_JOB_QUEUE_TIMEOUT=60
+FM_REMOTE_JOB_TIMEOUT=40
+fm_remote_job_stage "$ACCOUNT_HOME" "$REMOTE_ROOT" "$REMOTE_HOME" \
+  fm-remote-delta-read.sh "$REPLY_LOG_REL" 0 "$EMPTY_SHA" 30 < /dev/null > /dev/null
+POLL_JOB_ID=$FM_REMOTE_JOB_ID
+POLL_JOB_DIR="$STATE_ROOT/jobs/$POLL_JOB_ID"
+for _ in $(seq 1 100); do
+  [ "$(fm_remote_job_read_state "$POLL_JOB_DIR" 2>/dev/null || true)" = running ] && break
+  sleep 0.05
+done
+[ "$(fm_remote_job_read_state "$POLL_JOB_DIR" 2>/dev/null || true)" = running ] \
+  || fail "the long-poll job did not begin running"
+PREEMPT_BEGAN=$(date +%s)
+fm_remote_job_stage "$ACCOUNT_HOME" "$REMOTE_ROOT" "$REMOTE_HOME" \
+  fm-touch-job.sh "$PREEMPT_SIDE_EFFECT" < /dev/null > /dev/null
+JOB_ID=$FM_REMOTE_JOB_ID
+fm_remote_job_wait "$ACCOUNT_HOME" "$JOB_ID" || fail "$FM_REMOTE_JOB_ERROR"
+PREEMPT_ELAPSED=$(( $(date +%s) - PREEMPT_BEGAN ))
+[ "$FM_REMOTE_JOB_EXIT" -eq 0 ] || fail "the short command behind a long poll did not complete"
+assert_present "$PREEMPT_SIDE_EFFECT" "the short command behind a long poll did not run"
+[ "$PREEMPT_ELAPSED" -le 10 ] || fail "a queued short command waited a full poll window behind the long poll"
+fm_remote_job_wait "$ACCOUNT_HOME" "$POLL_JOB_ID" || fail "$FM_REMOTE_JOB_ERROR"
+[ "$FM_REMOTE_JOB_EXIT" -eq 75 ] || fail "a preempted long poll did not publish its elapsed-window result"
+[ ! -s "$FM_REMOTE_JOB_STDOUT" ] || fail "a preempted long poll published partial stdout"
+[ ! -s "$FM_REMOTE_JOB_STDERR" ] || fail "a preempted long poll published partial stderr"
+fm_remote_job_reap "$ACCOUNT_HOME" "$JOB_ID" || fail "the short command could not be reaped"
+fm_remote_job_reap "$ACCOUNT_HOME" "$POLL_JOB_ID" || fail "the preempted poll could not be reaped"
+pass "a queued short command preempts a running long poll instead of waiting its window"
+
+printf 'hello after preemption\n' > "$REMOTE_HOME/$REPLY_LOG_REL"
+FM_REMOTE_JOB_TIMEOUT=10
+fm_remote_job_stage "$ACCOUNT_HOME" "$REMOTE_ROOT" "$REMOTE_HOME" \
+  fm-remote-delta-read.sh "$REPLY_LOG_REL" 0 "$EMPTY_SHA" 5 < /dev/null > /dev/null
+JOB_ID=$FM_REMOTE_JOB_ID
+fm_remote_job_wait "$ACCOUNT_HOME" "$JOB_ID" || fail "$FM_REMOTE_JOB_ERROR"
+[ "$FM_REMOTE_JOB_EXIT" -eq 0 ] || fail "the re-armed poll after preemption did not complete"
+OUT=$(<"$FM_REMOTE_JOB_STDOUT")
+assert_contains "$OUT" 'status=delta' "the re-armed poll did not return a delta from the preserved cursor"
+assert_contains "$OUT" 'hello after preemption' "the re-armed poll lost data appended around the preemption"
+fm_remote_job_reap "$ACCOUNT_HOME" "$JOB_ID" || fail "the re-armed poll could not be reaped"
+rm -f -- "$REMOTE_HOME/$REPLY_LOG_REL"
+pass "a poll re-armed after preemption reads the same cursor with nothing lost"
+
+FM_REMOTE_JOB_TIMEOUT=15
+fm_remote_job_stage "$ACCOUNT_HOME" "$REMOTE_ROOT" "$REMOTE_HOME" \
+  fm-remote-delta-read.sh "$REPLY_LOG_REL" 0 "$EMPTY_SHA" 6 < /dev/null > /dev/null
+FIRST_JOB_ID=$FM_REMOTE_JOB_ID
+FIRST_JOB_DIR="$STATE_ROOT/jobs/$FIRST_JOB_ID"
+for _ in $(seq 1 100); do
+  [ "$(fm_remote_job_read_state "$FIRST_JOB_DIR" 2>/dev/null || true)" = running ] && break
+  sleep 0.05
+done
+[ "$(fm_remote_job_read_state "$FIRST_JOB_DIR" 2>/dev/null || true)" = running ] \
+  || fail "the first sibling poll did not begin running"
+POLL_PAIR_BEGAN=$(date +%s)
+fm_remote_job_stage "$ACCOUNT_HOME" "$REMOTE_ROOT" "$REMOTE_HOME" \
+  fm-remote-delta-read.sh "$REPLY_LOG_REL" 0 "$EMPTY_SHA" 1 < /dev/null > /dev/null
+JOB_ID=$FM_REMOTE_JOB_ID
+fm_remote_job_wait "$ACCOUNT_HOME" "$FIRST_JOB_ID" || fail "$FM_REMOTE_JOB_ERROR"
+POLL_PAIR_ELAPSED=$(( $(date +%s) - POLL_PAIR_BEGAN ))
+[ "$FM_REMOTE_JOB_EXIT" -eq 75 ] || fail "the first sibling poll did not close its own window"
+[ "$POLL_PAIR_ELAPSED" -ge 4 ] || fail "a queued sibling poll preempted a running poll"
+fm_remote_job_wait "$ACCOUNT_HOME" "$JOB_ID" || fail "$FM_REMOTE_JOB_ERROR"
+[ "$FM_REMOTE_JOB_EXIT" -eq 75 ] || fail "the queued sibling poll did not run after the first window"
+fm_remote_job_reap "$ACCOUNT_HOME" "$FIRST_JOB_ID" || fail "the first sibling poll could not be reaped"
+fm_remote_job_reap "$ACCOUNT_HOME" "$JOB_ID" || fail "the queued sibling poll could not be reaped"
+FM_REMOTE_JOB_QUEUE_TIMEOUT=5
+pass "sibling polls never preempt each other into a re-arm churn loop"
 
 STARTED="$TMP_ROOT/shutdown-started"
 SHUTDOWN_SIDE_EFFECT="$TMP_ROOT/shutdown-side-effect"


### PR DESCRIPTION
## Intent

Fix the end-user failure mode where Firstmate session start appears wedged for many minutes (or until external ~2/8/15-minute timeouts) on a home with live remote second mates, even though those remotes are healthy. Expected behavior: session start on a home with remote second mates finishes in a bounded, operator-reasonable time and either completes its remote checks or fails closed with a clear diagnostic, never sitting silently looking hung. Root cause established by end-to-end reproduction: all non-doctor remote commands share one serial per-account Aqua job worker (shipped #1660), and the parent remote-reply monitors keep a blocking fm-remote-delta-read.sh long-poll (default 55s window) continuously occupying that lane, so bootstrap's short sync/inherit/state/route round-trips queue behind full poll windows with non-FIFO glob-order pickup; a measured probe showed a trivial short job taking 31s behind one 30s poll window, and 1s after the fix. The shipped fix: the worker preempts a running preemptible job as soon as a non-preemptible job is queued; fm_remote_job_command_preemptible in bin/fm-remote-job-lib.sh names the read-only long-poll class, deliberately containing only fm-remote-delta-read.sh, which is non-destructive and cursor-anchored; a preempted poll publishes exit 75 with deliberately emptied stdout and stderr, byte-identical to the poll's own elapsed-window-with-no-data result, so the parent procevent runner takes its existing benign no-result path and the watcher re-arms from the same cursor with nothing lost; fm-remote-delta-read.sh gains a TERM trap that exits 75 after cleaning its staging directory; sibling polls deliberately never preempt each other so two armed monitors cannot enter a re-arm churn loop. Constraints from the requester: do not weaken remote security boundaries, doctor readiness semantics, or the non-destructive remote-reply log contract (all preserved: doctor still bypasses the queue over plain SSH, command authorization and env -i execution are unchanged, the reply log is never truncated or consumed); destructive/irreversible remote host changes are out of scope; the reproduction had to become a regression test where an executable contract exists - three regressions were added to tests/fm-remote-job.test.sh using the real worker and the real delta-read (preemption latency bound, cursor equivalence after preemption with no data loss, and no poll-on-poll preemption); docs/remote-secondmates.md documents the preemption behavior with the lib header as the single contract owner per Firstmate's one-owner rule. Deliberate choices a diff-only reviewer might question: keying the preemptible class on the staged argv command name is intentional and safe because the worker already validates commands as tracked non-symlink fm-*.sh in the configured root, and the class is defined remote-side, never caller-declared; publishing exit 75 with emptied output for a preempted poll is intentional semantic mapping, not result falsification, because the read is stateless and re-armed re-reads lose nothing; the fabricated-75 mapping is scoped strictly to the preempted case and never applied to non-preemptible commands. Repo conventions: shellcheck-clean bin scripts, one sentence per line in tracked Markdown, plain dashes, colocated tests extending the existing suite, no agent co-author on commits.

## What Changed

- Preempt running remote reply long-polls when a non-poll command is queued, preventing startup and interactive checks from waiting behind a poll window while avoiding poll-on-poll churn.
- Map preempted delta reads to the existing empty-window exit 75 result with cleared output and cursor-preserving re-arming.
- Document and test preemption latency, cursor continuity with no data loss, and sibling poll behavior.

## Risk Assessment

✅ Low: The change is narrowly scoped and preserves the queue, security, cursor, output, and benign no-result invariants while behaviorally covering preemption latency, cursor continuity, and sibling-poll stability.

## Testing

Inspected the target change, then exercised the real serial worker and real delta reader end-to-end: short jobs preempted a 30-second poll within the bounded threshold, preemption produced benign empty exit 75, re-arming from the same cursor preserved appended data, sibling polls did not churn, and the parent reply flow retained its append-only non-destructive contract. Both focused suites passed and transcripts were captured; no visual artifact was applicable because this is a shell worker and protocol change with no rendered UI.

<details>
<summary>Evidence: Remote job worker transcript</summary>

`Shows bounded short-command preemption, cursor-safe re-arm, and no poll-on-poll preemption.`

```text
ok - default queue and execution bounds independently cover long polls
ok - operator PATH excludes a symlinked local bin
ok - operator PATH honors nvm defaults with a deterministic fallback
ok - operator PATH resolves the authorized Nix profile bin link
ok - the worker preserves bounded argv and stdin in an empty environment
ok - active jobs keep the worker ready for concurrent requests
ok - ensure replaces a live worker after its code changes
ok - worker identity binds the canonical configured code root
ok - stale ownership is reclaimed without signaling a reused pid
ok - the worker enforces the job timeout and publishes its result
ok - the worker expires queued jobs before they can mutate
ok - queued jobs receive a fresh bounded execution window
ok - a queued short command preempts a running long poll instead of waiting its window
ok - a poll re-armed after preemption reads the same cursor with nothing lost
ok - sibling polls never preempt each other into a re-arm churn loop
ok - worker shutdown terminates the active command tree before replacement
ok - Linux supervision recovers crashes and stops orphaned commands
ok - pre-execution validation obeys the job timeout
ok - the worker drains bounded output without changing command results
ok - the worker refuses symlinked job fields before command execution
ok - failed shutdown quarantines ownership against replacement workers
ok - quarantine clears only after recorded execution has stopped
ALL TESTS PASSED
```
</details>
<details>
<summary>Evidence: Remote reply contract transcript</summary>

`Shows the reply log remains non-destructive, cursor-based, deduplicated, and continuity-safe.`

```text
ok - a blocking non-destructive remote delta reaches durable process-event capture
ok - ingest appends one validated line, fetches its document, and advances the cursor
ok - replayed capture has one deduplicated append and one durable handling identity
ok - later generations cannot invalidate an unacknowledged ingested result
ok - ingest rejects uncorrelated payload even when its transport digest is valid
ok - truncation is detected, escalated once, and not silently rebased
ok - remote reply retirement quiesces and refuses unhandled captured results
ALL TESTS PASSED
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>Inspected `git diff --unified=80 bf01a423efb899aa82e776412ae3df9b169f827d..cef7040c02ddb82ce8ebef5000e4c0d505d9a0e6` for the worker, delta reader, regression tests, and contract documentation.</code>
- `bash tests/fm-remote-job.test.sh`
- `bash tests/fm-remote-reply.test.sh`
- `git status --short`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
