### PR TITLE
fix(bin): enforce draft PR delivery in generated briefs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -296,6 +296,9 @@ The path's worker, automated gates, and captain approval remain authoritative:
 - **direct-PR** has the worker push and open a PR without the no-mistakes pipeline, then waits for the configured merge authority.
 - **local-only** has the worker stop with a clean ready branch, then waits for the configured merge authority before firstmate uses the guarded fast-forward merge path.
 
+Every PR a worker raises is a draft, and only the captain promotes one to ready for review.
+The pipeline opens its PR ready, so a no-mistakes worker converts it back to draft; `bin/fm-brief.sh` carries the concrete instruction for each mode.
+
 Delivery mode and `yolo` are orthogonal.
 With `yolo` off, the captain owns ask-user findings, PR merges, and local-only merge approval.
 With `yolo` on, firstmate decides routine gates only within the captain's original request and accepted task criteria, and merges only green work.

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -30,8 +30,8 @@
 # For ship tasks, --mode is REQUIRED and shapes the definition of done. Firstmate
 # resolves it per task at intake (AGENTS.md section 7); data/projects.md holds the
 # captain's standing posture as context, and this script never reads it:
-#   no-mistakes  implement -> /no-mistakes pipeline -> PR -> configured merge authority
-#   direct-PR    implement -> push + open PR via gh-axi (no pipeline) -> configured merge authority
+#   no-mistakes  implement -> /no-mistakes pipeline -> demote its PR to draft -> configured merge authority
+#   direct-PR    implement -> push + open a draft PR via gh-axi pr create --draft (no pipeline) -> configured merge authority
 #   local-only   implement on branch, stop and report "ready in branch" (no push/PR);
 #                the configured merge authority approves, firstmate merges to local main
 # no-mistakes-prod-only is a registry policy, not a task mode; resolve it to one of

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -358,7 +358,8 @@ case "$MODE" in
 Delivery contract: mode=direct-PR
 This task ships **direct-PR**: you raise the PR yourself, without the no-mistakes pipeline.
 The task is complete only when committed on your branch.
-When it is implemented and committed, push your branch and open a PR with \`gh-axi\`, then append \`done: PR {url}\` to the status file and stop.
+When it is implemented and committed, push your branch and open a DRAFT PR with \`gh-axi pr create --draft\`, then append \`done: PR {url}\` to the status file and stop.
+Never open a PR ready for review: ready pulls in reviewers, and only the captain promotes a draft.
 Do NOT run /no-mistakes. The configured merge authority decides whether to merge the PR; firstmate relays the outcome.
 EOF
     ;;
@@ -397,7 +398,10 @@ Two firstmate-specific rules layer on top of that guidance:
   When the decision comes back, feed it to the gate with \`no-mistakes axi respond\` and let the pipeline apply it - do not route the question to "the user" or implement the fix yourself.
 - Avoid \`--yes\`: it would silently bypass firstmate's authority check and any required captain escalation.
 
-After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append \`done: PR {url} checks green\` and stop. You are finished.
+The pipeline opens the PR ready for review and exposes no draft option, so convert it yourself with \`gh pr ready --undo {number}\` as soon as the run reports the PR.
+Never leave a PR ready for review: ready pulls in reviewers, and only the captain promotes a draft.
+
+After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), confirm the PR is a draft, then append \`done: PR {url} checks green\` and stop. You are finished.
 EOF
     ;;
 esac

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -354,6 +354,42 @@ test_no_mistakes_dod_wording() {
   pass "fm-brief.sh: no-mistakes DOD keeps its apostrophe prose, now parse-safe"
 }
 
+# Every PR-raising mode must carry the draft instruction structurally, so the
+# rule cannot depend on a supervisor remembering to add it by hand.
+test_ship_pr_modes_require_draft() {
+  local home id brief
+  home="$TMP_ROOT/pr-mode-home"
+  mkdir -p "$home/data"
+
+  id="brief-prmode-d1"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --mode direct-PR >/dev/null 2>&1
+  brief="$home/data/$id/brief.md"
+  assert_present "$brief" "direct-PR brief was not scaffolded"
+  # shellcheck disable=SC2016  # single quotes are deliberate: the backticks must stay literal
+  assert_grep 'open a DRAFT PR with `gh-axi pr create --draft`' "$brief" \
+    "direct-PR brief must name the concrete draft flag"
+  assert_grep "only the captain promotes a draft" "$brief" \
+    "direct-PR brief must forbid opening ready for review"
+
+  id="brief-prmode-d2"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --mode no-mistakes >/dev/null 2>&1
+  brief="$home/data/$id/brief.md"
+  assert_present "$brief" "no-mistakes brief was not scaffolded"
+  # shellcheck disable=SC2016  # single quotes are deliberate: the backticks must stay literal
+  assert_grep 'convert it yourself with `gh pr ready --undo {number}`' "$brief" \
+    "no-mistakes brief must name the concrete demote command for the pipeline-opened PR"
+  assert_grep "only the captain promotes a draft" "$brief" \
+    "no-mistakes brief must forbid leaving a PR ready for review"
+
+  id="brief-prmode-d3"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --mode local-only >/dev/null 2>&1
+  brief="$home/data/$id/brief.md"
+  assert_present "$brief" "local-only brief was not scaffolded"
+  assert_no_grep "draft" "$brief" \
+    "local-only brief raises no PR and must stay free of draft wording"
+  pass "fm-brief.sh: every PR-raising mode instructs a draft PR"
+}
+
 test_ship_project_memory_wording() {
   local home id brief
   home="$TMP_ROOT/project-memory-home"
@@ -717,6 +753,7 @@ test_ship_mode_is_explicit_not_registry
 test_delivery_flags_are_refused_where_they_do_not_apply
 test_faster_paths_use_configured_authority_without_stacked_review
 test_no_mistakes_dod_wording
+test_ship_pr_modes_require_draft
 test_ship_project_memory_wording
 test_herdr_lab_contract_is_explicit_and_complete
 test_herdr_lab_contract_quotes_foreign_firstmate_path


### PR DESCRIPTION
## Intent

Make "every PR is opened as a draft" a structural property of firstmate's brief scaffold, so it cannot depend on the supervisor remembering it.

Standing rule from Julius, 2026-08-05, after he had to demote three fleet-raised PRs in one evening: "Don't forget the rule to create all PRs as drafts and never as ready to review. I will first look at the draft and I manually promote for ready to review because ready to review means other colleagues will look at it." Marking a PR ready for review pulls his colleagues in; that is his call, never the fleet's. Before this change the scaffold's direct-PR definition of done said only "push your branch and open a PR with gh-axi", with no draft instruction, so every crewmate was free to open a ready PR and several did.

Scope accepted for this change:
1. bin/fm-brief.sh - every generated mode that raises a PR must instruct a draft PR explicitly, with the concrete flag, covering direct-PR and no-mistakes both. local-only already forbids PRs entirely and was deliberately left alone.
2. AGENTS.md section 7 delivery-mode contract - state the draft requirement once, in minimum wording, with no restatement elsewhere (the repo's one-owner rule).
3. Any other tracked surface that tells a worker to open a PR was checked by grep over bin/, .agents/skills/ and AGENTS.md; the only remaining hits are display strings in bin/fm-crew-state.sh and README.md meaning "ready for the captain to review", not instructions to open a PR, so they were intentionally not changed.

Decisions and findings made while doing the work, which a reviewer reading only the diff would not know:
- The concrete flags were verified against current help rather than assumed: gh-axi pr create supports --draft, and gh pr ready supports --undo to convert a PR to draft.
- Verified finding about no-mistakes itself (v1.40.0): the pipeline opens its own PR ready for review and exposes no draft option. no-mistakes axi run --help has no draft flag, ~/.no-mistakes/config.yaml has no draft key, and the binary's gh pr create invocation carries only --repo, --head and --base with no --draft string present anywhere in it. The brief therefore cannot make the pipeline open a draft. Julius's explicit instruction was to open it and then immediately demote it with gh pr ready --undo, and to record the limitation plainly rather than stop before delivering. That is why the no-mistakes definition of done instructs a post-hoc demotion instead of an open-time flag; this leaves a deliberate, known exposure window for the duration of the pipeline run, and a proper fix belongs upstream in no-mistakes.
- Constraints accepted: do not touch data/captain.md; do not weaken or reword any existing safety clause in the scaffold; keep the diff tight as a wording-and-flag change, not a redesign of the brief system.
- Separate finding, deliberately not fixed here because captain.md was out of scope: this home's data/captain.md still says "PRs open ready-for-review, NOT draft. Draft-on-open is a saidot-only rule", which the later 2026-08-05 fleet-wide instruction supersedes.
- Regression protection was required by the task: tests/fm-brief.test.sh gained test_ship_pr_modes_require_draft, asserting the concrete draft instruction in both PR-raising modes and its absence from local-only. Its fixture home directory and task ids deliberately avoid the substring "draft" because generated briefs echo both back, which would make the negative local-only assertion vacuously fail.
- bin/fm-lint.sh and bin/fm-doc-audience-check.sh were run clean before commit.

## What Changed

- Updated generated direct-PR and no-mistakes briefs to require draft PR handling with concrete CLI commands.
- Added the delivery-mode contract stating that only the captain promotes drafts to ready for review; local-only remains unchanged.
- Added regression coverage for draft requirements across PR-raising modes.

## Risk Assessment

✅ Low: The change is narrowly scoped and satisfies the requested draft-PR instructions for direct-PR and no-mistakes scaffolds without weakening existing safety contracts.

## Testing

Focused tests passed under default and stock Bash, end-to-end briefs matched the required behavior, CLI flags were verified, evidence was captured, and the worktree remained clean. Linters were not run per instruction.

<details>
<summary>Evidence: Brief scaffold evidence</summary>

`Generated briefs demonstrate draft behavior for direct-PR and no-mistakes, with local-only remaining PR-free.`

```text
# End-to-end generated brief evidence

Generated by bin/fm-brief.sh in three ship modes.

## direct-PR
# Definition of done
Delivery contract: mode=direct-PR
This task ships **direct-PR**: you raise the PR yourself, without the no-mistakes pipeline.
The task is complete only when committed on your branch.
When it is implemented and committed, push your branch and open a DRAFT PR with `gh-axi pr create --draft`, then append `done: PR {url}` to the status file and stop.
Never open a PR ready for review: ready pulls in reviewers, and only the captain promotes a draft.
Do NOT run /no-mistakes. The configured merge authority decides whether to merge the PR; firstmate relays the outcome.

## no-mistakes
# Definition of done
Delivery contract: mode=no-mistakes
The task is complete only when committed on your branch.
When you believe it is complete, append `done: {summary}` to the status file and stop.
Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.

You drive no-mistakes by responding to its gates, not by implementing fixes.
Follow the guidance no-mistakes itself provides for the mechanics: it loads when you invoke /no-mistakes, and `no-mistakes axi run --help` plus the `help` lines in each `axi` response are authoritative and version-matched to the installed binary.
When starting no-mistakes, make `--intent` preserve all relevant content from this brief's `# Task` section plus every later accepted Firstmate requirement, clarification, constraint, exclusion, and supersession, carrying only each requirement's current accepted form; retain direct requirements instead of substituting a diff summary, and exclude generic operational, status, delivery, and other scaffold boilerplate unless it is task-specific.
Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix.

Two firstmate-specific rules layer on top of that guidance:
- ask-user findings are never yours to answer: escalate to firstmate (rule 6) and stop.
  Firstmate applies the authority contract in its `AGENTS.md` and obtains any required captain decision.
  When the decision comes back, feed it to the gate with `no-mistakes axi respond` and let the pipeline apply it - do not route the question to "the user" or implement the fix yourself.
- Avoid `--yes`: it would silently bypass firstmate's authority check and any required captain escalation.

The pipeline opens the PR ready for review and exposes no draft option, so convert it yourself with `gh pr ready --undo {number}` as soon as the run reports the PR.
Never leave a PR ready for review: ready pulls in reviewers, and only the captain promotes a draft.

After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), confirm the PR is a draft, then append `done: PR {url} checks green` and stop. You are finished.

## local-only
# Definition of done
Delivery contract: mode=local-only
This task ships **local-only**: no remote, no PR, no pipeline.
The task is complete only when committed on your branch `fm/e2e-local`. Do NOT push, do NOT open a PR, do NOT merge.
Keep your branch a clean fast-forward onto the current default branch - if `main` has advanced, rebase onto it so the eventual merge stays a fast-forward.
When it is implemented and committed, append `done: ready in branch fm/e2e-local` to the status file and stop.
The configured merge authority approves the ready branch, then firstmate merges it into local `main` through the guarded fast-forward path.

## AGENTS.md delivery-mode owner
If fast-path risk needs more rigor, escalate whether to use no-mistakes instead of inventing a manual gate.
The path's worker, automated gates, and captain approval remain authoritative:

- **no-mistakes** runs the full pipeline through a PR, then waits for the configured merge authority.
- **direct-PR** has the worker push and open a PR without the no-mistakes pipeline, then waits for the configured merge authority.
- **local-only** has the worker stop with a clean ready branch, then waits for the configured merge authority before firstmate uses the guarded fast-forward merge path.

Every PR a worker raises is a draft, and only the captain promotes one to ready for review.
The pipeline opens its PR ready, so a no-mistakes worker converts it back to draft; `bin/fm-brief.sh` carries the concrete instruction for each mode.

Delivery mode and `yolo` are orthogonal.
```
</details>
<details>
<summary>Evidence: CLI flag evidence</summary>

<code>CLI help confirms `--draft` and `--undo`; no-mistakes exposes no draft option.</code>

```text
# CLI flag verification

## gh-axi pr create --help
  --state <open|closed|all>, --label, --assignee, --author, --base, --head, --draft, --limit <n> (default 30), --fields <a,b,c>
  --title <text> (required), --body <text> or --body-file <path>, --base, --head, --draft, --assignee, --reviewer, --label <name> (repeatable), --milestone

## gh pr ready --help
If supported by your plan, convert to draft with `--undo`
  --undo   Convert a pull request to "draft"

## no-mistakes axi run --help
no draft option exposed by the installed no-mistakes run command
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bash tests/fm-brief.test.sh`
- <code>`/bin/bash tests/fm-brief.test.sh` under Bash 3.2</code>
- `Generated direct-PR, no-mistakes, and local-only briefs`
- <code>Verified `gh-axi pr create --help` and `gh pr ready --help` flags</code>
- <code>Checked `git status --short`</code>

</details>

<details>
<summary>⚠️ **Document** - 1 warning</summary>

- ⚠️ `data/captain.md` - The separately maintained home data/captain.md still says PRs open ready-for-review, but it was explicitly out of scope and is absent from this worktree.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>


## Draft status of this PR, and the limitation it records

**This PR was not opened as a draft. It was opened ready for review and demoted afterwards.** The no-mistakes pipeline created it ready at 2026-08-05T19:36:39Z and it became a draft at 19:37:44Z, about a minute later. That minute is exactly the exposure this change cannot close from inside a brief: for the duration of it, the PR was visible to colleagues as ready for review.

The limitation, stated plainly: **no-mistakes v1.40.0 cannot open a draft PR natively.** `no-mistakes axi run --help` exposes no draft flag, `~/.no-mistakes/config.yaml` has no draft key, and the binary's own `gh pr create` invocation carries only `--repo`, `--head` and `--base`. Its five preceding PRs on this repo (#1750-#1754) are all ready-for-review, which is the pipeline's normal output. A brief therefore cannot make the pipeline open a draft; it can only instruct a demotion after the fact, which is what the no-mistakes definition of done in this change does.

One honest caveat on the demotion of this particular PR: the `convert_to_draft` event is recorded under the same GitHub identity the pipeline pushes with, and it landed before the explicit `gh pr ready --undo 1755` run against it (which reported the PR was already in draft). So the demotion here was not clearly the manual one. What is certain is the end state and the two facts that matter: the PR was created ready, and the pipeline offers no way to have created it as a draft.

**The durable fix belongs upstream in no-mistakes**, as a draft option on the PR step. Until that exists, every no-mistakes PR carries this short ready-for-review window regardless of what the brief says.
