### PR TITLE
fix(herdr): stabilize pane cwd detection

### DIFF
--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -13,7 +13,8 @@
 #
 # Default container shape (D4, decided empirically - see
 # herdr-verification-p2.md "Task container shape", refined by
-# docs/herdr-backend.md "Default task container shape"): ONE herdr workspace PER
+# docs/herdr-backend.md "Watching and task containers" and
+# "Pane-directory semantics on Herdr 0.8.0 / protocol 19"): ONE herdr workspace PER
 # FIRSTMATE HOME (the primary, and each secondmate, gets its own), ONE herdr TAB
 # per task inside its home's workspace. The default-on presentation projection
 # creates a disposable workspace for a clean fresh task instead unless the home
@@ -99,6 +100,10 @@ FM_BACKEND_HERDR_MIN_EVENTS_PROTOCOL=16
 # presentation path uses one narrowly whitelisted raw-socket request after
 # verifying the exact method and parameter schema.
 FM_BACKEND_HERDR_MIN_WORKSPACE_MOVE_PROTOCOL=16
+# pane.process_info first shipped at protocol 19 (verified: herdr 0.8.0).
+# It distinguishes the pane's persistent shell from a foreground command or
+# nested interactive shell, which is required for tmux-compatible cwd reads.
+FM_BACKEND_HERDR_MIN_PROCESS_INFO_PROTOCOL=19
 # Per-pane escalation dedupe marker prefix, under the state dir. One marker per
 # window (keyed like the watcher's own .stale-<key>): set when a ->blocked edge
 # is enqueued, cleared on any working edge, so exactly one wake fires per
@@ -203,8 +208,9 @@ fm_backend_herdr_tool_check() {
 }
 
 # fm_backend_herdr_version_check: refuse loudly on a missing/incompatible
-# herdr client. Verified locally: v0.7.1, protocol 14 (herdr status --json's
-# .client.protocol; client info is session-independent, unlike .server).
+# herdr client. Verified locally from v0.7.1/protocol 14 through
+# v0.8.0/protocol 19 (herdr status --json's .client.protocol; client info is
+# session-independent, unlike .server).
 fm_backend_herdr_version_check() {
   fm_backend_herdr_tool_check || return 1
   local status protocol version
@@ -2304,22 +2310,78 @@ fm_backend_herdr_target_ready() {  # <target>
   fm_backend_herdr_server_ensure "$FM_BACKEND_HERDR_SESSION" || return 1
 }
 
-# fm_backend_herdr_current_path: the live FOREGROUND process's cwd, or empty on
-# any error. Mirrors tmux's pane_current_path poll used for worktree-path
-# discovery after `treehouse get`.
+# fm_backend_herdr_process_info_path: select the tmux-compatible current path
+# from one protocol-19 pane.get response and one pane.process_info response.
+# The top-level shell's cwd wins while a normal foreground command is running.
+# A nested interactive shell wins instead, which is the shape `treehouse get`
+# leaves behind after it enters the acquired worktree subshell.
+fm_backend_herdr_process_info_path() {  # <pane-json> <process-info-json> <pane-id>
+  local pane_json=$1 process_json=$2 pane_id=$3 parent
+  parent=$(printf '%s' "$pane_json" | jq -r '.result.pane.cwd // empty' 2>/dev/null)
+  printf '%s' "$process_json" | jq -er --arg pane "$pane_id" --arg parent "$parent" '
+    def interactive_shell:
+      (.name // "" | split("/")[-1] | ascii_downcase) as $name
+      | ($name == "sh" or $name == "ash" or $name == "bash"
+         or $name == "csh" or $name == "dash" or $name == "elvish"
+         or $name == "fish" or $name == "ksh" or $name == "mksh"
+         or $name == "nu" or $name == "nushell" or $name == "osh"
+         or $name == "pwsh" or $name == "tcsh" or $name == "xonsh"
+         or $name == "zsh")
+      and ((.argv | type) == "array")
+      and ([.argv[1:][]? | select(. == "--command" or test("^-[^-]*c"))] | length == 0);
+    .result.process_info as $info
+    | select($info.pane_id == $pane)
+    | (($info.foreground_processes // [])
+       | map(select(.pid == $info.foreground_process_group_id))
+       | first) as $leader
+    | if $info.foreground_process_group_id == $info.shell_pid then
+        ($leader.cwd // $parent)
+      elif (($leader // {}) | interactive_shell) then
+        ($leader.cwd // empty)
+      else
+        $parent
+      end
+    | select(type == "string" and length > 0)
+  ' 2>/dev/null
+}
+
+# fm_backend_herdr_current_path: the live shell/subshell cwd, or empty on any
+# error. Mirrors tmux's pane_current_path poll used for worktree-path discovery
+# after `treehouse get`.
 #
-# Verified pitfall: `pane get`'s `.result.pane.cwd` is the pane's cwd AT
-# CREATION TIME - the top-level shell's cwd - and does NOT update when that
-# shell `cd`s or enters a subshell (as `treehouse get` does). Reading it here
-# would make fm-spawn.sh's worktree-discovery poll never see the pane "leave"
-# the project directory, since `cwd` stays frozen at the original path forever.
-# `.result.pane.foreground_cwd` tracks the ACTUALLY RUNNING foreground
-# process's cwd instead, which is what changes when `treehouse get` enters its
-# worktree subshell - confirmed live against a real treehouse acquisition.
+# Herdr 0.7.x exposed only pane.cwd and pane.foreground_cwd. pane.cwd was frozen
+# at pane creation, while foreground_cwd followed the acquired Treehouse
+# subshell, so protocols before 19 retain the foreground_cwd read.
+#
+# Herdr 0.8.0/protocol 19 makes pane.cwd track the persistent parent shell and
+# foreground_cwd track ANY foreground process. That broader signal can briefly
+# report a helper command's own cwd (observed as /Users/walter during
+# `treehouse get`) before the final worktree shell exists. Returning that
+# transient path makes fm-spawn stop polling early and correctly refuse the
+# non-worktree. pane.process_info distinguishes the persistent shell PID from
+# the foreground process group: keep pane.cwd for an ordinary foreground
+# command, and use the group leader's cwd only when it is a nested interactive
+# shell. If protocol 19 process inspection is unreadable, fail closed with an
+# empty path rather than reviving the transient foreground_cwd race.
 fm_backend_herdr_current_path() {  # <target>
+  local pane_out process_out path status protocol foreground
   fm_backend_herdr_target_ready "$1" || return 0
-  fm_backend_herdr_cli "$FM_BACKEND_HERDR_SESSION" pane get "$FM_BACKEND_HERDR_PANE" 2>/dev/null \
-    | jq -r '.result.pane.foreground_cwd // empty' 2>/dev/null
+  pane_out=$(fm_backend_herdr_cli "$FM_BACKEND_HERDR_SESSION" pane get "$FM_BACKEND_HERDR_PANE" 2>/dev/null) || return 0
+  foreground=$(printf '%s' "$pane_out" | jq -r '.result.pane.foreground_cwd // .result.pane.cwd // empty' 2>/dev/null)
+  process_out=$(fm_backend_herdr_cli "$FM_BACKEND_HERDR_SESSION" pane process-info --pane "$FM_BACKEND_HERDR_PANE" 2>/dev/null || true)
+  if path=$(fm_backend_herdr_process_info_path "$pane_out" "$process_out" "$FM_BACKEND_HERDR_PANE"); then
+    printf '%s' "$path"
+    return 0
+  fi
+  status=$(fm_backend_herdr_cli "$FM_BACKEND_HERDR_SESSION" status --json 2>/dev/null || true)
+  protocol=$(printf '%s' "$status" | jq -r '.server.protocol // .client.protocol // empty' 2>/dev/null)
+  case "$protocol" in
+    ''|*[!0-9]*) return 0 ;;
+  esac
+  if [ "$protocol" -ge "$FM_BACKEND_HERDR_MIN_PROCESS_INFO_PROTOCOL" ]; then
+    return 0
+  fi
+  printf '%s' "$foreground"
 }
 
 # fm_backend_herdr_send_text_line: send one line of TEXT then submit,

--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -2363,24 +2363,39 @@ fm_backend_herdr_process_info_path() {  # <pane-json> <process-info-json> <pane-
 # command, and use the group leader's cwd only when it is a nested interactive
 # shell. If protocol 19 process inspection is unreadable, fail closed with an
 # empty path rather than reviving the transient foreground_cwd race.
+#
+# Protocol gate: pane.process_info is protocol-19 only. A server that does not
+# support it may still answer `pane process-info` with a non-process_info shape
+# (e.g. a real pane cwd), which would bypass a caller that armed its abort
+# through pane.foreground_cwd. So issue the call ONLY after confirming protocol
+# >= 19; protocols before 19 retain the established foreground_cwd read and
+# never issue a process-info call. The resolved protocol is cached in
+# _fm_backend_herdr_server_protocol so the fm-spawn poll loop does not re-query
+# `status --json` on every iteration (the protocol is stable for a session).
 fm_backend_herdr_current_path() {  # <target>
   local pane_out process_out path status protocol foreground
   fm_backend_herdr_target_ready "$1" || return 0
+  if [ -z "${_fm_backend_herdr_server_protocol:-}" ]; then
+    status=$(fm_backend_herdr_cli "$FM_BACKEND_HERDR_SESSION" status --json 2>/dev/null || true)
+    protocol=$(printf '%s' "$status" | jq -r '.server.protocol // .client.protocol // empty' 2>/dev/null)
+    case "$protocol" in
+      ''|*[!0-9]*) protocol=0 ;;
+    esac
+    _fm_backend_herdr_server_protocol=$protocol
+  fi
+  protocol=$_fm_backend_herdr_server_protocol
   pane_out=$(fm_backend_herdr_cli "$FM_BACKEND_HERDR_SESSION" pane get "$FM_BACKEND_HERDR_PANE" 2>/dev/null) || return 0
-  foreground=$(printf '%s' "$pane_out" | jq -r '.result.pane.foreground_cwd // .result.pane.cwd // empty' 2>/dev/null)
-  process_out=$(fm_backend_herdr_cli "$FM_BACKEND_HERDR_SESSION" pane process-info --pane "$FM_BACKEND_HERDR_PANE" 2>/dev/null || true)
-  if path=$(fm_backend_herdr_process_info_path "$pane_out" "$process_out" "$FM_BACKEND_HERDR_PANE"); then
-    printf '%s' "$path"
-    return 0
-  fi
-  status=$(fm_backend_herdr_cli "$FM_BACKEND_HERDR_SESSION" status --json 2>/dev/null || true)
-  protocol=$(printf '%s' "$status" | jq -r '.server.protocol // .client.protocol // empty' 2>/dev/null)
-  case "$protocol" in
-    ''|*[!0-9]*) return 0 ;;
-  esac
   if [ "$protocol" -ge "$FM_BACKEND_HERDR_MIN_PROCESS_INFO_PROTOCOL" ]; then
+    process_out=$(fm_backend_herdr_cli "$FM_BACKEND_HERDR_SESSION" pane process-info --pane "$FM_BACKEND_HERDR_PANE" 2>/dev/null || true)
+    if path=$(fm_backend_herdr_process_info_path "$pane_out" "$process_out" "$FM_BACKEND_HERDR_PANE"); then
+      printf '%s' "$path"
+      return 0
+    fi
+    # protocol 19 but process-info unreadable: fail closed with an empty path
+    # rather than reviving the transient foreground_cwd race process_info fixes.
     return 0
   fi
+  foreground=$(printf '%s' "$pane_out" | jq -r '.result.pane.foreground_cwd // .result.pane.cwd // empty' 2>/dev/null)
   printf '%s' "$foreground"
 }
 

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1247,7 +1247,8 @@ BRIEF_REAL="$BRIEF_DIR_REAL/$(basename "$BRIEF")"
 # PROJ_ABS can still carry a symlinked path component (e.g. macOS's /tmp ->
 # /private/tmp) when it came from the ship/scout branch's logical `pwd` above.
 # Every backend's own current-path read (tmux's pane_current_path, herdr's
-# foreground_cwd, zellij/cmux's active pwd probe against the live shell) can
+# process-aware shell-cwd read, zellij/cmux's active pwd probe against the live
+# shell) can
 # report the OS-level, physically-resolved cwd, so comparing it against a
 # still-symlinked PROJ_ABS can misfire both ways: false-negative (the poll
 # below never notices the pane left the project) or false-positive (the

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -2073,7 +2073,11 @@ META_WINDOW=$T
     echo "home=$PROJ_ABS"
     echo "projects=$SECONDMATE_PROJECTS"
   fi
-} > "$STATE/$ID.meta"
+} > "$STATE/$ID.meta" || exit 1
+# The explicit `|| exit 1` matters: bash 3.2 (stock macOS) does not trip
+# `set -e` on a compound command's failed redirection, which would let a
+# failed metadata publication sail on to a false "spawned" success while
+# the abort-cleanup trap stays disarmed forever.
 [ "$BACKEND" = orca ] && ORCA_ABORT_CLEANUP=0
 
 sq_brief=$(shell_quote "$BRIEF")

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -1,7 +1,7 @@
 # Herdr runtime backend
 
 Herdr is an experimental agent-native terminal backend with native per-pane agent state and push events.
-Firstmate requires Herdr protocol 14 or newer; broad backend verification covers versions 0.7.1, 0.7.3, 0.7.4, and 0.7.5, while the presentation-projection suite is additionally verified on 0.8.0 protocol 19 and protocol-16 features remain gated by availability.
+Firstmate requires Herdr protocol 14 or newer; broad backend verification covers versions 0.7.1, 0.7.3, 0.7.4, and 0.7.5, while presentation projection and pane-directory semantics are additionally verified on 0.8.0 protocol 19 and protocol-16 features remain gated by availability.
 Herdr provides the terminal session while Treehouse continues to provide task worktrees.
 [`configuration.md`](configuration.md#runtime-backend-configbackend--fm_backend) owns shared backend selection and metadata semantics.
 
@@ -193,6 +193,53 @@ Workspace and tab ids support verification and cleanup but are not inferred from
 The adapter starts and polls a named server before workspace, tab, pane, or agent calls.
 Every Herdr invocation goes through `fm_backend_herdr_cli`, which sets the environment and passes an explicit trailing `--session <name>`.
 An environment variable alone is not reliable when another Herdr server is running.
+
+### Pane-directory semantics on Herdr 0.8.0 / protocol 19
+
+`fm_backend_herdr_current_path` matches tmux's shell-directory behavior rather than returning raw `pane.foreground_cwd`.
+On Herdr 0.8.0, `pane.cwd` follows the persistent parent shell while `pane.foreground_cwd` follows any process group that owns the terminal.
+The foreground field therefore sees both the nested interactive shell that Treehouse leaves in its acquired worktree and transient ordinary commands that run before that shell exists.
+
+Protocol 19's `pane.process_info` identifies `shell_pid`, `foreground_process_group_id`, and the foreground process records.
+The adapter returns the persistent shell cwd while that shell or an ordinary command owns the terminal, switches to the group leader's cwd only for a nested interactive shell without a command flag, and returns no path when protocol-19 process inspection is unreadable.
+Protocols before 19 retain their verified `foreground_cwd` compatibility path because the 0.7.x `pane.cwd` field was frozen at pane creation and the process-info surface was unavailable.
+
+This fixes two sides of Treehouse discovery without weakening `validate_spawn_worktree`:
+
+- A completed `treehouse get` resolves the nested shell's isolated worktree path.
+- A transient helper cwd such as `/Users/walter` does not become a candidate worktree; the adapter retains the parent shell path so polling continues.
+- A plain shell, including a direct `cd`, continues to resolve its live cwd.
+
+The spawn-side two-consecutive-read settling guard remains useful defense in depth, but it does not replace process-aware semantics because a transient foreground command can outlive two polls.
+
+The guarded real-runtime probe ran on 2026-08-05 in a generated non-`default` session through `bin/fm-herdr-lab.sh`.
+The teardown trap was installed before provisioning, all Herdr calls used the helper's `run` path with a trailing named session, and teardown preserved the default-session fleet snapshot.
+The controlled transition was:
+
+```sh
+HERDR_LAB_HELPER=/Users/walter/Dev/firstmate/bin/fm-herdr-lab.sh
+HERDR_LAB_SESSION=$("$HERDR_LAB_HELPER" name herdr-backend-cwd-fix)
+trap '"$HERDR_LAB_HELPER" teardown "$HERDR_LAB_SESSION"' EXIT
+"$HERDR_LAB_HELPER" provision "$HERDR_LAB_SESSION"
+"$HERDR_LAB_HELPER" run "$HERDR_LAB_SESSION" pane run "$PANE" \
+  "bash -c 'cd /Users/walter && sleep 3 && cd \"$ROOT/tests\" && exec bash --noprofile --norc'"
+```
+
+The adapter was read before the transition, during the transient command, after the nested shell took over, and after a direct `cd` in a separate plain-shell pane.
+Observed output:
+
+```text
+PLAIN_PATH=/Users/walter/.treehouse/firstmate-17c42a/1/firstmate
+TRANSIENT_RAW=/Users/walter
+TRANSIENT_ADAPTER=/Users/walter/.treehouse/firstmate-17c42a/1/firstmate
+FINAL_RAW=/Users/walter/.treehouse/firstmate-17c42a/1/firstmate/tests
+FINAL_ADAPTER=/Users/walter/.treehouse/firstmate-17c42a/1/firstmate/tests
+PLAIN_DIRECT_CD_RAW=/Users/walter/.treehouse/firstmate-17c42a/1/firstmate/tests
+PLAIN_DIRECT_CD_ADAPTER=/Users/walter/.treehouse/firstmate-17c42a/1/firstmate/tests
+{"client_version":"0.8.0","client_protocol":19,"server_version":"0.8.0","server_protocol":19}
+```
+
+`tests/fm-backend-herdr.test.sh` pins nested-Treehouse selection, transient-command rejection, plain-shell behavior, protocol-19 fail-closed behavior, and the pre-19 compatibility path.
 
 Literal text and Enter are separate operations for ordinary steers.
 Spawn-time fixed commands may use Herdr's atomic run primitive.

--- a/tests/fm-backend-herdr.test.sh
+++ b/tests/fm-backend-herdr.test.sh
@@ -48,7 +48,8 @@ next=$(( $(cat "$COUNT_FILE" 2>/dev/null || echo 0) + 1 ))
   printf '\n'
 } >> "$LOG"
 if [ "${1:-}" = status ] && [ "${2:-}" = --json ] && [ "${FM_HERDR_SCRIPT_STATUS:-0}" != 1 ]; then
-  printf '{"client":{"version":"0.7.1","protocol":14},"server":{"running":true}}\n'
+  protocol=${FM_HERDR_FAKE_PROTOCOL:-14}
+  printf '{"client":{"version":"fake","protocol":%s},"server":{"running":true,"protocol":%s}}\n' "$protocol" "$protocol"
   exit 0
 fi
 n=$next
@@ -2642,19 +2643,73 @@ test_kill_is_best_effort() {
   pass "fm_backend_herdr_kill: calls pane close and stays best-effort on failure"
 }
 
-test_current_path_reads_cwd() {
+test_current_path_protocol_19_reads_treehouse_subshell() {
   local dir log resp fb out
-  dir="$TMP_ROOT/cwd"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
-  # Verified pitfall (herdr-verification-p2.md): .result.pane.cwd is frozen at
-  # pane-creation time and never updates; .foreground_cwd tracks the live
-  # running process (e.g. a treehouse get subshell) and is what must be read.
-  printf '{"result":{"pane":{"cwd":"/tmp/pane-creation-dir","foreground_cwd":"/tmp/fake-worktree"}}}\n' > "$resp/1.out"
+  dir="$TMP_ROOT/cwd-treehouse"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
+  printf '{"result":{"pane":{"pane_id":"w1:p2","cwd":"/tmp/project","foreground_cwd":"/tmp/fake-worktree"}}}\n' > "$resp/1.out"
+  printf '{"result":{"process_info":{"pane_id":"w1:p2","shell_pid":100,"foreground_process_group_id":200,"foreground_processes":[{"pid":200,"name":"zsh","argv":["-zsh"],"cwd":"/tmp/fake-worktree"}]}}}\n' > "$resp/2.out"
+  fb=$(make_herdr_fakebin "$dir")
+  out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" FM_HERDR_FAKE_PROTOCOL=19 \
+    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_current_path default:w1:p2' "$ROOT" )
+  [ "$out" = "/tmp/fake-worktree" ] || fail "current_path should resolve the nested Treehouse shell's cwd, got '$out'"
+  assert_contains "$(cat "$log")" $'\x1f''pane'$'\x1f''get'$'\x1f''w1:p2' "current_path did not call pane get"
+  assert_contains "$(cat "$log")" $'\x1f''pane'$'\x1f''process-info'$'\x1f''--pane'$'\x1f''w1:p2' \
+    "current_path did not inspect the protocol-19 foreground process group"
+  pass "fm_backend_herdr_current_path: protocol 19 resolves a nested Treehouse shell's worktree cwd"
+}
+
+test_current_path_protocol_19_ignores_transient_treehouse_cwd() {
+  local dir log resp fb out
+  dir="$TMP_ROOT/cwd-transient"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
+  # Herdr 0.8.0 foreground_cwd follows any foreground process. During the
+  # live refusal it briefly reported /Users/walter while the persistent pane
+  # shell remained in the project. That transient must not make fm-spawn stop
+  # polling and hand the isolation assertion a non-worktree path.
+  printf '{"result":{"pane":{"pane_id":"w1:p2","cwd":"/tmp/project","foreground_cwd":"/Users/walter"}}}\n' > "$resp/1.out"
+  printf '{"result":{"process_info":{"pane_id":"w1:p2","shell_pid":100,"foreground_process_group_id":200,"foreground_processes":[{"pid":200,"name":"treehouse","argv":["treehouse","get"],"cwd":"/Users/walter"}]}}}\n' > "$resp/2.out"
+  fb=$(make_herdr_fakebin "$dir")
+  out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" FM_HERDR_FAKE_PROTOCOL=19 \
+    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_current_path default:w1:p2' "$ROOT" )
+  [ "$out" = "/tmp/project" ] || fail "current_path should hold the parent shell cwd while treehouse itself is foreground, got '$out'"
+  [ "$out" != "/Users/walter" ] || fail "current_path leaked the transient foreground-command cwd into spawn validation"
+  pass "fm_backend_herdr_current_path: protocol 19 cannot promote a transient treehouse command cwd to a worktree"
+}
+
+test_current_path_protocol_19_plain_shell_is_unchanged() {
+  local dir log resp fb out
+  dir="$TMP_ROOT/cwd-plain-shell"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
+  printf '{"result":{"pane":{"pane_id":"w1:p2","cwd":"/tmp/plain-shell","foreground_cwd":"/tmp/plain-shell"}}}\n' > "$resp/1.out"
+  printf '{"result":{"process_info":{"pane_id":"w1:p2","shell_pid":100,"foreground_process_group_id":100,"foreground_processes":[{"pid":100,"name":"zsh","argv":["-zsh"],"cwd":"/tmp/plain-shell"}]}}}\n' > "$resp/2.out"
+  fb=$(make_herdr_fakebin "$dir")
+  out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" FM_HERDR_FAKE_PROTOCOL=19 \
+    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_current_path default:w1:p2' "$ROOT" )
+  [ "$out" = "/tmp/plain-shell" ] || fail "current_path should preserve a plain shell pane's cwd, got '$out'"
+  pass "fm_backend_herdr_current_path: protocol 19 preserves plain-shell pane cwd reads"
+}
+
+test_current_path_protocol_19_unreadable_process_info_fails_closed() {
+  local dir log resp fb out
+  dir="$TMP_ROOT/cwd-process-info-fail"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
+  printf '{"result":{"pane":{"pane_id":"w1:p2","cwd":"/tmp/project","foreground_cwd":"/Users/walter"}}}\n' > "$resp/1.out"
+  printf '1\n' > "$resp/2.exit"
+  fb=$(make_herdr_fakebin "$dir")
+  out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" FM_HERDR_FAKE_PROTOCOL=19 \
+    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_current_path default:w1:p2' "$ROOT" )
+  [ -z "$out" ] || fail "protocol-19 current_path should fail closed when process-info is unreadable, got '$out'"
+  pass "fm_backend_herdr_current_path: protocol 19 never revives raw foreground_cwd when process-info is unreadable"
+}
+
+test_current_path_legacy_protocol_reads_foreground_cwd() {
+  local dir log resp fb out
+  dir="$TMP_ROOT/cwd-legacy"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
+  # Protocols before 19 do not expose pane process-info. Their pane cwd was
+  # frozen at creation, so retain the established foreground_cwd behavior.
+  printf '{"result":{"pane":{"pane_id":"w1:p2","cwd":"/tmp/pane-creation-dir","foreground_cwd":"/tmp/fake-worktree"}}}\n' > "$resp/1.out"
   fb=$(make_herdr_fakebin "$dir")
   out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
     bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_current_path default:w1:p2' "$ROOT" )
-  [ "$out" = "/tmp/fake-worktree" ] || fail "current_path should read foreground_cwd (the live process), not the frozen creation-time cwd, got '$out'"
-  assert_contains "$(cat "$log")" $'\x1f''pane'$'\x1f''get'$'\x1f''w1:p2' "current_path did not call pane get"
-  pass "fm_backend_herdr_current_path: reads pane foreground_cwd (the live running process), not the frozen creation-time cwd"
+  [ "$out" = "/tmp/fake-worktree" ] || fail "legacy current_path should retain foreground_cwd semantics, got '$out'"
+  pass "fm_backend_herdr_current_path: protocols before 19 retain foreground_cwd compatibility"
 }
 
 # --- busy_state (semantic agent state) ---------------------------------------
@@ -4020,7 +4075,11 @@ test_capture_works_around_small_lines_bug
 test_capture_preserves_pane_read_failure
 test_send_key_normalizes_and_targets_pane
 test_kill_is_best_effort
-test_current_path_reads_cwd
+test_current_path_protocol_19_reads_treehouse_subshell
+test_current_path_protocol_19_ignores_transient_treehouse_cwd
+test_current_path_protocol_19_plain_shell_is_unchanged
+test_current_path_protocol_19_unreadable_process_info_fails_closed
+test_current_path_legacy_protocol_reads_foreground_cwd
 test_busy_state_working_maps_to_busy
 test_busy_state_done_and_blocked_map_to_idle
 test_busy_state_unknown_on_no_agent


### PR DESCRIPTION
## Intent

Restore fm-spawn Treehouse detection on the Herdr backend against Herdr 0.8.0/server protocol 19. The adapter must expose the final nested interactive shell cwd while refusing transient foreground-command cwd values such as `/Users/walter`, preserve plain-shell and protocols 14-16 behavior, leave the spawn isolation assertion intact, add colocated regressions, document the verified semantics, and validate real behavior only through a named non-default fm-herdr-lab session.

## What Changed

- Protocol-19 pane cwd reads now combine `pane get` with `pane process-info` to distinguish persistent or nested interactive shells from ordinary foreground commands.
- Nested Treehouse shells resolve their worktree cwd, transient helper cwd values fall back to the stable parent-shell cwd, and unreadable protocol-19 process information fails closed.
- Pre-protocol-19 servers retain `foreground_cwd` compatibility; plain-shell reads are unchanged.
- Regression tests cover Treehouse subshell entry, the stale/transient `/Users/walter` case, plain shells, unreadable process information, and legacy protocols.
- Herdr backend documentation now records the Herdr 0.8.0/server protocol-19 evidence and corrected semantics.
- Pipeline follow-up commits make Bash 3.2 fail on metadata publication errors, deflake the real tmux smoke readiness check, and update cross-backend documentation references.

## Validation

- No-mistakes run `01KZ9TEN1FJRCNEPB53S3Q410C` passed review, the complete repository test suite after its owned fixes, documentation review, and push.
- Real Herdr 0.8.0/server protocol 19 behavior was verified in named non-default fm-herdr-lab sessions. Every teardown confirmed the default fleet state remained unchanged.
- The local lint gate recorded ShellCheck 0.11.0 as unavailable and was approved as an environment warning; GitHub CI installs the pinned version and is authoritative for ShellCheck.

No merge is requested.

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ <strong>Intent</strong> - passed</summary>

✅ Complete task intent recorded.

</details>

<details>
<summary>✅ <strong>Rebase</strong> - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ <strong>Review</strong> - low risk, 4 findings</summary>

- `review-1`: shell-script foreground-leader heuristic edge case; captain approved the current implementation because the trigger is unobserved and the selected behavior is fail-safe.
- Three informational compatibility/performance findings required no changes.

</details>

<details>
<summary>🔧 <strong>Test</strong> - fixed and passed</summary>

- The first full-suite run exposed an existing Bash 3.2 metadata-publication error path and a real tmux smoke timing flake.
- Pipeline fix: `no-mistakes(test): fix orca meta-write abort on bash 3.2, deflake tmux smoke`.
- The complete repository test suite then passed with no `not ok` results.

</details>

<details>
<summary>✅ <strong>Document</strong> - passed</summary>

- Pipeline update: `no-mistakes(document): update herdr cwd cross-references for protocol-19 process-info semantics`.

</details>

<details>
<summary>⚠️ <strong>Lint</strong> - 1 environment warning</summary>

- Local ShellCheck 0.11.0 was unavailable; GitHub CI installs and runs the pinned version.

</details>

<details>
<summary>✅ <strong>Push</strong> - passed</summary>

✅ Pipeline head `134eb87d66b31bc1ec333f3fa53492809a80e335` was published and guarded-sync restored it to the task worktree.

</details>