### PR TITLE
fix(bin): lease a task worktree when spawning from a bare-flagged clone

### DIFF
--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -134,6 +134,12 @@
 #   origin, resolves the current remote default branch, and resets to its tip.
 #   An unreachable origin, unresolved default branch, or non-clean worktree
 #   refuses the spawn rather than risking a PR based on stale history.
+#   A project clone whose main checkout deliberately carries core.bare=true (a
+#   harness's ref-host pattern, as in fm-fleet-sync.sh's matching refresh path)
+#   makes git refuse the work-tree operation `treehouse get` starts with, so its
+#   worktree is leased by this script instead and the pane is only told to cd into
+#   it - see lease_bare_clone_worktree. The clone's configuration is never written,
+#   and both paths converge on the same settle loop and isolation assertion.
 # Batch dispatch: pass one or more `id=repo` pairs instead of a single <id> <project>, e.g.
 #     fm-spawn.sh fix-a-k3=projects/foo add-b-q7=projects/bar [--scout]
 #   Each pair re-execs this script in single-task mode, so the single path stays the only
@@ -1693,6 +1699,61 @@ freshen_spawn_worktree_base() {  # <worktree>
   fi
 }
 
+# True when the project clone carries core.bare=true on its main checkout. A
+# harness may set that flag deliberately so the checkout can double as a ref host
+# that advances its own branches with a ref-only `git fetch origin <b>:<b>`, which
+# git permits on a checked-out branch only while the flag is set. The files stay on
+# disk, but git then refuses every work-tree operation against the clone. Same
+# signal and naming as fm-fleet-sync.sh's bare=yes check, which fixed the matching
+# refresh failure.
+project_is_bare_flagged() {
+  [ "$(git -C "$PROJ_ABS" rev-parse --is-bare-repository 2>/dev/null)" = true ]
+}
+
+# Lease a pool worktree for a bare-flagged clone and print its path.
+#
+# `treehouse get` starts by resolving the repo from its working directory with
+# `git rev-parse --show-toplevel`, which is a work-tree operation, so against a
+# bare-flagged clone it dies with "this operation must be run in a work tree"
+# before any worktree exists. GIT_WORK_TREE is the only override that reaches
+# that resolution: git decides bare-ness during repository discovery, before
+# -c/GIT_CONFIG_* injected config is applied, so a scoped core.bare=false
+# override is silently ignored while GIT_WORK_TREE is honoured. Nothing here
+# writes to the clone's configuration, so the deliberate flag survives untouched.
+#
+# GIT_WORK_TREE must be RELATIVE. An absolute path pins every git process
+# treehouse spawns to the clone's work tree, including the per-worktree
+# cleanliness checks it runs as `git -C <pool-tree> status`; those then report
+# the CLONE's dirt, every pooled tree reads dirty, and treehouse refuses to reuse
+# any of them once the pool is full. `.` resolves against each invocation's own
+# directory, so discovery in the clone succeeds while treehouse's per-tree checks
+# still see the pool tree.
+#
+# --lease is what keeps the override off the worker's shell. Plain `treehouse
+# get` execs an interactive subshell that would inherit GIT_WORK_TREE, and inside
+# the worktree that variable silently redirects git at another directory - a
+# leaked absolute value makes `git status` there report the primary checkout's
+# files. Leasing acquires the worktree in this process and prints its path, so
+# the pane is only ever told to cd into a ready worktree with a clean
+# environment. The lease is durable and released by fm-teardown.sh's existing
+# `treehouse return --force`, which needs no work tree of its own.
+lease_bare_clone_worktree() {
+  local wt
+  if ! treehouse get --help 2>&1 | grep -Eq '(^|[^[:alnum:]_-])--lease([^[:alnum:]_-]|$)'; then
+    echo "error: project $PROJ_ABS has core.bare=true, which needs 'treehouse get --lease' to acquire a worktree, but the installed treehouse does not support --lease. Upgrade treehouse (bin/fm-install-treehouse.sh) and retry." >&2
+    return 1
+  fi
+  wt=$(cd "$PROJ_ABS" && GIT_WORK_TREE=. treehouse get --lease --lease-holder "$ID") || {
+    echo "error: treehouse get --lease failed to lease a worktree from bare-flagged clone $PROJ_ABS" >&2
+    return 1
+  }
+  [ -n "$wt" ] || {
+    echo "error: treehouse get --lease did not report a worktree for bare-flagged clone $PROJ_ABS" >&2
+    return 1
+  }
+  printf '%s\n' "$wt"
+}
+
 herdr_projection_meta_field_exact() {  # <meta> <key>
   local meta=$1 key=$2 count
   [ -f "$meta" ] && [ ! -L "$meta" ] || return 1
@@ -2136,7 +2197,21 @@ if [ "$RELAUNCH" -eq 1 ]; then
   fi
   [ "$KIND" = secondmate ] || validate_spawn_worktree "relaunch" "$T"
 elif [ "$KIND" != secondmate ] && [ "$BACKEND" != orca ]; then
-  spawn_send_text_line "$WT_TARGET" 'treehouse get'
+  # An ordinary clone lets the pane run `treehouse get` itself, which acquires a
+  # worktree and cd's the pane into it. A bare-flagged clone cannot: see
+  # lease_bare_clone_worktree for why the acquire has to happen here instead, with
+  # the pane only told to cd into the worktree that call already leased. Both
+  # branches converge on the same settle loop and isolation assertion below, so
+  # neither the transient-stale-path guard nor validate_spawn_worktree is skipped
+  # for a leased worktree.
+  ACQUIRE_SOURCE='treehouse get'
+  if project_is_bare_flagged; then
+    ACQUIRE_SOURCE='treehouse get --lease'
+    LEASED_WT=$(lease_bare_clone_worktree) || exit 1
+    spawn_send_text_line "$WT_TARGET" "cd $(shell_quote "$LEASED_WT")"
+  else
+    spawn_send_text_line "$WT_TARGET" 'treehouse get'
+  fi
 
   # Wait for the treehouse subshell: the pane's cwd moves from the project to the worktree.
   # Target the stable window id, not the name: if the name is ever lost (e.g. an
@@ -2178,11 +2253,11 @@ elif [ "$KIND" != secondmate ] && [ "$BACKEND" != orca ]; then
     sleep 1
   done
   if [ -z "$WT" ]; then
-    echo "error: treehouse get did not enter a worktree within 60s; inspect window $T" >&2
+    echo "error: $ACQUIRE_SOURCE did not enter a worktree within 60s; inspect window $T" >&2
     exit 1
   fi
 
-  validate_spawn_worktree "treehouse get" "$T"
+  validate_spawn_worktree "$ACQUIRE_SOURCE" "$T"
 fi
 if [ "$RELAUNCH" -eq 0 ] && [ "$KIND" != secondmate ]; then
   freshen_spawn_worktree_base "$WT" || exit 1

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -689,6 +689,7 @@ parse_orca_worktree_result() {
 spawn_abort_cleanup() {
   local status=$?
   local leased_wt=
+  local -a release_args
   if [ "$RELAUNCH_REPLACEMENT_PENDING" = 1 ] \
      && [ "$SPAWN_META_PUBLISH_STARTED" = 1 ] \
      && [ -n "$SPAWN_META_TMP" ] \
@@ -763,8 +764,19 @@ spawn_abort_cleanup() {
     leased_wt=$LEASED_WT
     LEASED_WT=
     # --if-lease-holder makes the release a no-op unless this task still owns the
-    # lease, so a concurrent re-lease of the same pool tree cannot be stolen.
-    if ! ( cd "$PROJ_ABS" && treehouse return --force --if-lease-holder "$ID" "$leased_wt" ) >/dev/null 2>&1; then
+    # lease, so a concurrent re-lease of the same pool tree cannot be stolen. It
+    # postdates the treehouse this repo pins, so capability-detect it the same way
+    # the --lease support above is detected. On a binary without it the release
+    # still has to happen unguarded - a skipped release burns the pool slot, which
+    # is the leak this cleanup exists to close - and holder identity simply cannot
+    # be verified there.
+    release_args=(--force)
+    if treehouse return --help 2>&1 \
+       | grep -Eq '(^|[^[:alnum:]_-])--if-lease-holder([^[:alnum:]_-]|$)'; then
+      release_args+=(--if-lease-holder "$ID")
+    fi
+    release_args+=("$leased_wt")
+    if ! ( cd "$PROJ_ABS" && treehouse return "${release_args[@]}" ) >/dev/null 2>&1; then
       echo "warning: could not release the worktree leased for $ID; the pool slot stays leased until you run 'treehouse return --force $leased_wt' from $PROJ_ABS" >&2
     fi
   fi

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -139,7 +139,9 @@
 #   makes git refuse the work-tree operation `treehouse get` starts with, so its
 #   worktree is leased by this script instead and the pane is only told to cd into
 #   it - see lease_bare_clone_worktree. The clone's configuration is never written,
-#   and both paths converge on the same settle loop and isolation assertion.
+#   and both paths converge on the same settle loop and isolation assertion; the
+#   leased path additionally pins the settled path to the worktree it leased, and
+#   any abort before the meta write returns that durable lease to the pool.
 # Batch dispatch: pass one or more `id=repo` pairs instead of a single <id> <project>, e.g.
 #     fm-spawn.sh fix-a-k3=projects/foo add-b-q7=projects/bar [--scout]
 #   Each pair re-execs this script in single-task mode, so the single path stays the only
@@ -635,6 +637,13 @@ BACKEND=
 ORCA_ABORT_CLEANUP=0
 ORCA_WORKTREE_ID=
 ORCA_TERMINAL=
+# Set only while this process holds a durable treehouse lease that no state file
+# records yet. `treehouse get --lease` hands out a worktree that is never pruned
+# and never handed to a later get, and fm-teardown.sh can only release a task
+# that has a state/<id>.meta, so every abort between the lease and the meta write
+# would otherwise burn a pool slot with no firstmate command able to free it.
+LEASED_WT=
+LEASED_WT_REAL=
 HERDR_PROJECTION_ABORT_CLEANUP=0
 HERDR_PROJECTION_ABORT_SESSION=
 HERDR_PROJECTION_ABORT_TASK_PANE=
@@ -679,6 +688,7 @@ parse_orca_worktree_result() {
 
 spawn_abort_cleanup() {
   local status=$?
+  local leased_wt=
   if [ "$RELAUNCH_REPLACEMENT_PENDING" = 1 ] \
      && [ "$SPAWN_META_PUBLISH_STARTED" = 1 ] \
      && [ -n "$SPAWN_META_TMP" ] \
@@ -747,6 +757,15 @@ spawn_abort_cleanup() {
           } > "$STATE/$ID.meta" 2>/dev/null || true
         fi
       fi
+    fi
+  fi
+  if [ -n "${LEASED_WT:-}" ]; then
+    leased_wt=$LEASED_WT
+    LEASED_WT=
+    # --if-lease-holder makes the release a no-op unless this task still owns the
+    # lease, so a concurrent re-lease of the same pool tree cannot be stolen.
+    if ! ( cd "$PROJ_ABS" && treehouse return --force --if-lease-holder "$ID" "$leased_wt" ) >/dev/null 2>&1; then
+      echo "warning: could not release the worktree leased for $ID; the pool slot stays leased until you run 'treehouse return --force $leased_wt' from $PROJ_ABS" >&2
     fi
   fi
   if [ "$SPAWN_TASK_LOCK_HELD" = 1 ]; then
@@ -2208,6 +2227,7 @@ elif [ "$KIND" != secondmate ] && [ "$BACKEND" != orca ]; then
   if project_is_bare_flagged; then
     ACQUIRE_SOURCE='treehouse get --lease'
     LEASED_WT=$(lease_bare_clone_worktree) || exit 1
+    LEASED_WT_REAL=$(real_path_or_raw "$LEASED_WT")
     spawn_send_text_line "$WT_TARGET" "cd $(shell_quote "$LEASED_WT")"
   else
     spawn_send_text_line "$WT_TARGET" 'treehouse get'
@@ -2255,6 +2275,22 @@ elif [ "$KIND" != secondmate ] && [ "$BACKEND" != orca ]; then
   if [ -z "$WT" ]; then
     echo "error: $ACQUIRE_SOURCE did not enter a worktree within 60s; inspect window $T" >&2
     exit 1
+  fi
+
+  # On the leased path the correct worktree is already known, so pin the settled
+  # path to it. The two-consecutive-reads guard above makes a transient stale
+  # pane path unlikely, not impossible, and such a path resolves to a real,
+  # distinct worktree root that validate_spawn_worktree accepts - which would
+  # record a worktree treehouse never leased for this task while the leased one
+  # stayed leased with nobody to return it. Fail closed instead; the abort
+  # cleanup releases the lease. The ordinary path has no such expectation and
+  # keeps its existing behaviour.
+  if [ -n "$LEASED_WT" ]; then
+    SETTLED_WT_REAL=$(real_path_or_raw "$WT")
+    if [ "$SETTLED_WT_REAL" != "$LEASED_WT_REAL" ]; then
+      echo "error: $ACQUIRE_SOURCE leased '$LEASED_WT' (resolved '$LEASED_WT_REAL') for $ID but window $T settled in '$WT' (resolved '$SETTLED_WT_REAL'); refusing to launch in a worktree that was never leased for this task. Inspect window $T" >&2
+      exit 1
+    fi
   fi
 
   validate_spawn_worktree "$ACQUIRE_SOURCE" "$T"
@@ -2678,6 +2714,9 @@ if [ "$SPAWN_TASK_SET_LOCK_HELD" = 1 ]; then
   fm_lock_release "$SPAWN_TASK_SET_LOCK"
 fi
 [ "$BACKEND" = orca ] && ORCA_ABORT_CLEANUP=0
+# From here the task's meta records the worktree, so fm-teardown.sh owns the
+# lease and a later abort must not return it out from under a live task.
+LEASED_WT=
 
 sq_brief=$(shell_quote "$BRIEF")
 sq_turnend=$(shell_quote "$TURNEND")

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -2234,9 +2234,11 @@ elif [ "$KIND" != secondmate ] && [ "$BACKEND" != orca ]; then
   # worktree and cd's the pane into it. A bare-flagged clone cannot: see
   # lease_bare_clone_worktree for why the acquire has to happen here instead, with
   # the pane only told to cd into the worktree that call already leased. Both
-  # branches converge on the same settle loop and isolation assertion below, so
-  # neither the transient-stale-path guard nor validate_spawn_worktree is skipped
-  # for a leased worktree.
+  # branches share the settle loop and the isolation assertion below, but they
+  # wait differently: the leased path waits for the pane to reach the worktree it
+  # already holds and accepts nothing else, while the ordinary path, which learns
+  # its destination only from the pane, keeps the two-consecutive-reads guard
+  # against a transient stale path. validate_spawn_worktree runs on both.
   ACQUIRE_SOURCE='treehouse get'
   if project_is_bare_flagged; then
     ACQUIRE_SOURCE='treehouse get --lease'
@@ -2271,6 +2273,11 @@ elif [ "$KIND" != secondmate ] && [ "$BACKEND" != orca ]; then
   # leased worktree and the last path the pane reported so the two are
   # distinguishable. The abort cleanup releases the lease.
   #
+  # The resolved comparison only decides that the pane arrived; what gets
+  # recorded is treehouse's own spelling of the leased path, not the pane's
+  # physically-resolved cwd, because `treehouse return` matches the path it
+  # recorded literally and rejects an equivalent spelling as unmanaged.
+  #
   # On the ordinary path the destination is not known in advance, so a single
   # read that already differs from PROJ_ABS_REAL is not proof the pane settled
   # there. Require two consecutive reads to agree on the same non-project path
@@ -2289,7 +2296,7 @@ elif [ "$KIND" != secondmate ] && [ "$BACKEND" != orca ]; then
         last_seen="$p"
         last_seen_real="$p_real"
         if [ "$p_real" = "$LEASED_WT_REAL" ]; then
-          WT="$p"
+          WT="$LEASED_WT"
           break
         fi
       elif [ "$p_real" != "$PROJ_ABS_REAL" ]; then

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -134,14 +134,15 @@
 #   origin, resolves the current remote default branch, and resets to its tip.
 #   An unreachable origin, unresolved default branch, or non-clean worktree
 #   refuses the spawn rather than risking a PR based on stale history.
-#   A project clone whose main checkout deliberately carries core.bare=true (a
-#   harness's ref-host pattern, as in fm-fleet-sync.sh's matching refresh path)
-#   makes git refuse the work-tree operation `treehouse get` starts with, so its
-#   worktree is leased by this script instead and the pane is only told to cd into
-#   it - see lease_bare_clone_worktree. The clone's configuration is never written,
-#   and both paths converge on the same settle loop and isolation assertion; the
-#   leased path additionally pins the settled path to the worktree it leased, and
-#   any abort before the meta write returns that durable lease to the pool.
+#   A project clone whose main checkout deliberately carries core.bare=true (the
+#   flag lets one checkout double as a ref host that advances its own branches
+#   with a ref-only fetch) makes git refuse the work-tree operation `treehouse
+#   get` starts with, so its worktree is leased by this script instead and the
+#   pane is only told to cd into it - see lease_bare_clone_worktree. The clone's
+#   configuration is never written, and both paths converge on the same settle
+#   loop and isolation assertion; the leased path waits for the pane to reach the
+#   worktree it leased and accepts nothing else, and any abort before the meta
+#   write returns that durable lease to the pool.
 # Batch dispatch: pass one or more `id=repo` pairs instead of a single <id> <project>, e.g.
 #     fm-spawn.sh fix-a-k3=projects/foo add-b-q7=projects/bar [--scout]
 #   Each pair re-execs this script in single-task mode, so the single path stays the only
@@ -1734,9 +1735,10 @@ freshen_spawn_worktree_base() {  # <worktree>
 # harness may set that flag deliberately so the checkout can double as a ref host
 # that advances its own branches with a ref-only `git fetch origin <b>:<b>`, which
 # git permits on a checked-out branch only while the flag is set. The files stay on
-# disk, but git then refuses every work-tree operation against the clone. Same
-# signal and naming as fm-fleet-sync.sh's bare=yes check, which fixed the matching
-# refresh failure.
+# disk, but git then refuses every work-tree operation against the clone.
+# `rev-parse --is-bare-repository` is the signal rather than a `config --get
+# core.bare` read because it reports git's own discovery-time verdict - the very
+# state that makes those operations fail - however the flag was arrived at.
 project_is_bare_flagged() {
   [ "$(git -C "$PROJ_ABS" rev-parse --is-bare-repository 2>/dev/null)" = true ]
 }
@@ -2254,23 +2256,43 @@ elif [ "$KIND" != secondmate ] && [ "$BACKEND" != orca ]; then
   # prefix would otherwise make the pane's OS-level cwd read differ from
   # PROJ_ABS on the very first poll, before the pane has actually moved.
   #
-  # A single read that already differs from PROJ_ABS_REAL is not proof the pane
-  # settled there: on some tmux/WSL setups a brand-new window's pane_current_path
-  # transiently reports an unrelated stale path (seen live as another real git
-  # checkout entirely) before the shell catches up with treehouse get's cd. That
-  # stale path still passes the PROJ_ABS_REAL comparison and validate_spawn_worktree
-  # below (it resolves to a real, distinct worktree top-level too), so accepting it
-  # on one read alone silently records the wrong worktree= in state/<id>.meta. Require
-  # two consecutive reads to agree on the same non-project path before accepting it;
-  # a mismatch just becomes the new candidate rather than resetting the wait, so a
-  # pane that is already settled by the first real read only costs the one existing
-  # inter-poll sleep as confirmation, not a whole extra cycle on top.
+  # A brand-new window's pane_current_path can transiently report an unrelated
+  # stale path (seen live on some tmux/WSL setups as another real git checkout
+  # entirely) before the shell catches up with the cd. Such a path passes the
+  # PROJ_ABS_REAL comparison and validate_spawn_worktree below, because it
+  # resolves to a real, distinct worktree top-level too, so accepting it would
+  # silently record the wrong worktree= in state/<id>.meta.
+  #
+  # On the leased path the destination is already known, so wait for that exact
+  # path and accept nothing else: a stale reading can never be mistaken for the
+  # destination however often it repeats. Never reaching it inside the wait is
+  # the terminal failure - fail closed, because launching in an unleased tree
+  # would leave the leased one held with nobody to return it, and name both the
+  # leased worktree and the last path the pane reported so the two are
+  # distinguishable. The abort cleanup releases the lease.
+  #
+  # On the ordinary path the destination is not known in advance, so a single
+  # read that already differs from PROJ_ABS_REAL is not proof the pane settled
+  # there. Require two consecutive reads to agree on the same non-project path
+  # before accepting it; a mismatch just becomes the new candidate rather than
+  # resetting the wait, so a pane that is already settled by the first real read
+  # only costs the one existing inter-poll sleep as confirmation, not a whole
+  # extra cycle on top.
   candidate=""
+  last_seen=""
+  last_seen_real=""
   for _ in $(seq 1 60); do
     p=$(spawn_current_path "$WT_TARGET" || true)
     if [ -n "$p" ]; then
       p_real=$(real_path_or_raw "$p")
-      if [ "$p_real" != "$PROJ_ABS_REAL" ]; then
+      if [ -n "$LEASED_WT" ]; then
+        last_seen="$p"
+        last_seen_real="$p_real"
+        if [ "$p_real" = "$LEASED_WT_REAL" ]; then
+          WT="$p"
+          break
+        fi
+      elif [ "$p_real" != "$PROJ_ABS_REAL" ]; then
         if [ -n "$candidate" ] && [ "$p_real" = "$candidate" ]; then
           WT="$p"
           break
@@ -2282,27 +2304,15 @@ elif [ "$KIND" != secondmate ] && [ "$BACKEND" != orca ]; then
     else
       candidate=""
     fi
-    sleep 1
+    sleep "${FM_SPAWN_SETTLE_INTERVAL:-1}"
   done
   if [ -z "$WT" ]; then
-    echo "error: $ACQUIRE_SOURCE did not enter a worktree within 60s; inspect window $T" >&2
-    exit 1
-  fi
-
-  # On the leased path the correct worktree is already known, so pin the settled
-  # path to it. The two-consecutive-reads guard above makes a transient stale
-  # pane path unlikely, not impossible, and such a path resolves to a real,
-  # distinct worktree root that validate_spawn_worktree accepts - which would
-  # record a worktree treehouse never leased for this task while the leased one
-  # stayed leased with nobody to return it. Fail closed instead; the abort
-  # cleanup releases the lease. The ordinary path has no such expectation and
-  # keeps its existing behaviour.
-  if [ -n "$LEASED_WT" ]; then
-    SETTLED_WT_REAL=$(real_path_or_raw "$WT")
-    if [ "$SETTLED_WT_REAL" != "$LEASED_WT_REAL" ]; then
-      echo "error: $ACQUIRE_SOURCE leased '$LEASED_WT' (resolved '$LEASED_WT_REAL') for $ID but window $T settled in '$WT' (resolved '$SETTLED_WT_REAL'); refusing to launch in a worktree that was never leased for this task. Inspect window $T" >&2
+    if [ -n "$LEASED_WT" ]; then
+      echo "error: $ACQUIRE_SOURCE leased '$LEASED_WT' (resolved '$LEASED_WT_REAL') for $ID but window $T never settled there (last observed '${last_seen:-none}', resolved '${last_seen_real:-none}'); refusing to launch in a worktree that was never leased for this task. Inspect window $T" >&2
       exit 1
     fi
+    echo "error: $ACQUIRE_SOURCE did not enter a worktree within 60s; inspect window $T" >&2
+    exit 1
   fi
 
   validate_spawn_worktree "$ACQUIRE_SOURCE" "$T"

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -149,6 +149,11 @@ For ship and scout work, `fm-spawn.sh` refuses to launch unless the resolved tas
 `fm-spawn.sh` also owns the base-freshness boundary for every fresh ship and scout: no worker starts until its clean task worktree matches the fetched tip of origin's resolved default branch, and any unsafe or unverifiable base stops the spawn.
 Its header owns the exact refusal mechanics, while `tests/fm-spawn-pool-base-freshen.test.sh` owns the portable regression coverage.
 
+A project clone whose main checkout deliberately carries `core.bare=true` makes git refuse the work-tree operation the pane's own `treehouse get` starts with, so for those clones `fm-spawn.sh` leases the pooled task worktree itself and only tells the pane to `cd` into it; the clone's configuration is never written, and the isolation assertion above still runs.
+That per-task lease is distinct from the secondmate home lease below: `fm-spawn.sh`'s abort cleanup returns it until `state/<id>.meta` records the worktree, after which `fm-teardown.sh` owns its release.
+A pane that never settles in the leased worktree fails the spawn rather than launching in a worktree that was never leased for the task.
+`bin/fm-spawn.sh`'s header owns the exact acquisition mechanism, its treehouse version requirement, and the environment scoping that keeps the override off the crewmate's shell.
+
 The firstmate repo has one extra exposure because it can dispatch crewmates to work on itself.
 Its operating checkout (`FM_ROOT`) and the disposable crewmate worktrees are all linked git worktrees of the same repository, so the valid discriminator is branch state, not whether the checkout is linked.
 The primary checkout is healthy on its default branch, and linked worktrees or secondmate homes are healthy at detached HEAD.

--- a/tests/fm-spawn-bare-clone.test.sh
+++ b/tests/fm-spawn-bare-clone.test.sh
@@ -58,11 +58,14 @@ case "${1:-}" in
     # bare `treehouse get` line is the pane acquiring one itself. Either way the
     # simulated pane's reported cwd becomes the worktree, exactly as the real
     # pane's would.
+    # FM_FAKE_PANE_SETTLE stands in for a pane that settles somewhere other than
+    # the path it was sent to, which is the transient stale pane_current_path the
+    # settle loop guards against.
     case "$*" in
       *"cd "*)
-        printf '%s\n' "${FM_FAKE_LEASE_PATH:-}" > "$FM_FAKE_PANE_PATHFILE" ;;
+        printf '%s\n' "${FM_FAKE_PANE_SETTLE:-${FM_FAKE_LEASE_PATH:-}}" > "$FM_FAKE_PANE_PATHFILE" ;;
       *"treehouse get"*)
-        printf '%s\n' "${FM_FAKE_LEASE_PATH:-}" > "$FM_FAKE_PANE_PATHFILE" ;;
+        printf '%s\n' "${FM_FAKE_PANE_SETTLE:-${FM_FAKE_LEASE_PATH:-}}" > "$FM_FAKE_PANE_PATHFILE" ;;
     esac
     exit 0
     ;;
@@ -116,6 +119,12 @@ if [ "${1:-}" = get ]; then
   printf '%s\n' "$FM_FAKE_LEASE_PATH"
   exit 0
 fi
+if [ "${1:-}" = return ]; then
+  # Real `treehouse return` takes an explicit path and needs no work tree of its
+  # own, so it resolves against a bare-flagged clone too. The argv log above is
+  # what the test asserts on.
+  exit 0
+fi
 exit 0
 SH
   chmod +x "$fakebin/treehouse"
@@ -128,16 +137,22 @@ SH
 # the untracked file is what makes an absolute GIT_WORK_TREE override visibly
 # corrupt the pool-cleanliness check above.
 make_bare_case() {
-  local name=$1 id=$2 bare=$3 lease_support=$4 case_dir home proj wt fakebin
+  local name=$1 id=$2 bare=$3 lease_support=$4 case_dir home proj wt stale fakebin
   case_dir="$TMP_ROOT/$name"
   home="$case_dir/home"
   proj="$case_dir/project"
   wt="$case_dir/pool-worktree"
+  stale="$case_dir/stale-worktree"
   fakebin=$(make_bare_fakebin "$case_dir/fake" "$lease_support")
   mkdir -p "$home/data" "$home/projects" "$home/state" "$home/config"
   printf 'codex\n' > "$home/config/crew-harness"
   fm_git_worktree "$proj" "$wt" "pool-$name"
   git -C "$wt" checkout --detach -q
+  # A second real, isolated worktree: the stale pane path that passes both the
+  # non-project comparison and validate_spawn_worktree, so only the lease pin can
+  # catch it.
+  git -C "$proj" worktree add --quiet -b "stale-$name" "$stale"
+  git -C "$stale" checkout --detach -q
   if [ "$bare" = yes ]; then
     printf 'max_trees = 1\n' > "$proj/treehouse.toml"
     git -C "$proj" config core.bare true
@@ -145,16 +160,17 @@ make_bare_case() {
   mkdir -p "$home/data/$id"
   printf 'brief for %s\n' "$id" > "$home/data/$id/brief.md"
   touch "$home/state/.last-watcher-beat"
-  printf '%s\n' "$case_dir|$home|$proj|$wt|$fakebin"
+  printf '%s\n' "$case_dir|$home|$proj|$wt|$stale|$fakebin"
 }
 
 read_bare_record() {
-  IFS='|' read -r CASE_DIR HOME_DIR PROJ_DIR WT_DIR FAKEBIN_DIR <<EOF
+  IFS='|' read -r CASE_DIR HOME_DIR PROJ_DIR WT_DIR STALE_DIR FAKEBIN_DIR <<EOF
 $1
 EOF
   SENDKEYS_LOG="$CASE_DIR/sendkeys.log"
   TREEHOUSE_LOG="$CASE_DIR/treehouse.log"
   PANE_PATHFILE="$CASE_DIR/pane-path"
+  PANE_SETTLE=""
   : > "$SENDKEYS_LOG"
   : > "$TREEHOUSE_LOG"
   rm -f "$PANE_PATHFILE"
@@ -167,6 +183,7 @@ run_bare_spawn() {
     FM_PROJECTS_OVERRIDE="$HOME_DIR/projects" FM_CONFIG_OVERRIDE="$HOME_DIR/config" \
     FM_SPAWN_NO_GUARD=1 TMUX="fake,1,0" \
     FM_FAKE_LEASE_PATH="$WT_DIR" FM_FAKE_PANE_PROJECT="$PROJ_DIR" \
+    FM_FAKE_PANE_SETTLE="$PANE_SETTLE" \
     FM_FAKE_PANE_PATHFILE="$PANE_PATHFILE" FM_FAKE_SENDKEYS_LOG="$SENDKEYS_LOG" \
     FM_FAKE_TREEHOUSE_LOG="$TREEHOUSE_LOG" \
     PATH="$FAKEBIN_DIR:$PATH" \
@@ -195,7 +212,45 @@ test_bare_flagged_clone_spawns() {
   # inherit the GIT_WORK_TREE override into the worker's own environment.
   assert_grep "get --lease" "$TREEHOUSE_LOG" \
     "worktree was not acquired with treehouse get --lease"
+  # Once the meta records the worktree, fm-teardown.sh owns the lease: a spawn
+  # that reached that point must not hand the pool slot back under the live task.
+  assert_no_grep "return --force" "$TREEHOUSE_LOG" \
+    "successful spawn returned the lease out from under the live task"
   pass "a bare-flagged clone yields an isolated worktree leased by firstmate"
+}
+
+# A pane that settles somewhere other than the leased worktree must not be
+# accepted: the leased tree would stay leased with nobody to return it and the
+# task would run in a tree treehouse never handed to it.
+test_settled_path_must_be_the_leased_worktree() {
+  local rec id out status
+  id='bare-stale-pane-b5'
+  rec=$(make_bare_case bare-stale "$id" yes yes)
+  read_bare_record "$rec"
+  PANE_SETTLE="$STALE_DIR"
+
+  out=$(run_bare_spawn "$id")
+  status=$?
+  [ "$status" -ne 0 ] || fail "spawn accepted a settled path that was never leased for the task"
+  assert_contains "$out" "$WT_DIR" "refusal did not name the leased worktree"
+  assert_contains "$out" "$STALE_DIR" "refusal did not name the observed worktree"
+  assert_absent "$HOME_DIR/state/$id.meta" "refused spawn still recorded task metadata"
+  pass "a settled path other than the leased worktree is refused by name"
+}
+
+# Every abort before the meta write has to give the pool slot back: no state file
+# records the lease yet, so fm-teardown.sh can never release it.
+test_abort_before_meta_releases_the_lease() {
+  local rec id
+  id='bare-lease-release-b6'
+  rec=$(make_bare_case bare-release "$id" yes yes)
+  read_bare_record "$rec"
+  PANE_SETTLE="$STALE_DIR"
+
+  run_bare_spawn "$id" >/dev/null
+  assert_grep "return --force --if-lease-holder $id $WT_DIR" "$TREEHOUSE_LOG" \
+    "aborted spawn did not release the worktree it had leased"
+  pass "an abort before the meta write releases the durable lease"
 }
 
 # The deliberate flag is the whole reason this path exists: it must survive.
@@ -260,5 +315,7 @@ test_bare_flagged_clone_spawns
 test_bare_flag_survives_the_spawn
 test_non_bare_clone_path_is_unchanged
 test_bare_without_lease_support_refuses
+test_settled_path_must_be_the_leased_worktree
+test_abort_before_meta_releases_the_lease
 
 echo "# all fm-spawn-bare-clone tests passed"

--- a/tests/fm-spawn-bare-clone.test.sh
+++ b/tests/fm-spawn-bare-clone.test.sh
@@ -191,6 +191,10 @@ EOF
   TREEHOUSE_LOG="$CASE_DIR/treehouse.log"
   PANE_PATHFILE="$CASE_DIR/pane-path"
   PANE_SETTLE=""
+  # The spelling treehouse hands back, which is also the only spelling its own
+  # `return` accepts. It is the pooled tree's own path unless a case points it at
+  # an equivalent-but-differently-spelled route to the same directory.
+  LEASE_PATH="$WT_DIR"
   : > "$SENDKEYS_LOG"
   : > "$TREEHOUSE_LOG"
   rm -f "$PANE_PATHFILE"
@@ -203,7 +207,7 @@ run_bare_spawn() {
     FM_PROJECTS_OVERRIDE="$HOME_DIR/projects" FM_CONFIG_OVERRIDE="$HOME_DIR/config" \
     FM_SPAWN_NO_GUARD=1 TMUX="fake,1,0" \
     FM_SPAWN_SETTLE_INTERVAL=0.02 \
-    FM_FAKE_LEASE_PATH="$WT_DIR" FM_FAKE_PANE_PROJECT="$PROJ_DIR" \
+    FM_FAKE_LEASE_PATH="$LEASE_PATH" FM_FAKE_PANE_PROJECT="$PROJ_DIR" \
     FM_FAKE_PANE_SETTLE="$PANE_SETTLE" \
     FM_FAKE_PANE_PATHFILE="$PANE_PATHFILE" FM_FAKE_SENDKEYS_LOG="$SENDKEYS_LOG" \
     FM_FAKE_TREEHOUSE_LOG="$TREEHOUSE_LOG" \
@@ -258,6 +262,31 @@ test_settled_path_must_be_the_leased_worktree() {
   assert_contains "$out" "$STALE_DIR" "refusal did not name the observed worktree"
   assert_absent "$HOME_DIR/state/$id.meta" "refused spawn still recorded task metadata"
   pass "a settled path other than the leased worktree is refused by name"
+}
+
+# `treehouse return` matches the path treehouse recorded literally: an equivalent
+# spelling of the same directory is rejected as unmanaged. The pane reports its
+# physically-resolved cwd, so with a symlink anywhere above the pool the two
+# spellings differ, and recording the pane's would leave fm-teardown.sh passing a
+# path treehouse refuses - burning the pool slot for good, since a leased tree is
+# never pruned and never handed to a later get.
+test_meta_records_the_treehouse_spelling_of_the_lease() {
+  local rec id out status
+  id='bare-lease-spelling-b8'
+  rec=$(make_bare_case bare-spelling "$id" yes yes)
+  read_bare_record "$rec"
+  ln -s "$WT_DIR" "$CASE_DIR/pool-link"
+  LEASE_PATH="$CASE_DIR/pool-link"
+  PANE_SETTLE="$WT_DIR"
+
+  out=$(run_bare_spawn "$id")
+  status=$?
+  expect_code 0 "$status" "spawn should accept a pane that resolves to the leased worktree"
+  assert_grep "worktree=$LEASE_PATH" "$HOME_DIR/state/$id.meta" \
+    "meta did not record treehouse's own spelling of the leased worktree"
+  assert_no_grep "worktree=$WT_DIR" "$HOME_DIR/state/$id.meta" \
+    "meta recorded the pane's spelling, which treehouse return rejects as unmanaged"
+  pass "the meta records the spelling treehouse leased, not the pane's resolved cwd"
 }
 
 # Every abort before the meta write has to give the pool slot back: no state file
@@ -360,6 +389,7 @@ test_bare_flag_survives_the_spawn
 test_non_bare_clone_path_is_unchanged
 test_bare_without_lease_support_refuses
 test_settled_path_must_be_the_leased_worktree
+test_meta_records_the_treehouse_spelling_of_the_lease
 test_abort_before_meta_releases_the_lease
 test_abort_releases_the_lease_without_holder_guard
 

--- a/tests/fm-spawn-bare-clone.test.sh
+++ b/tests/fm-spawn-bare-clone.test.sh
@@ -22,7 +22,11 @@ set -u
 SPAWN="$ROOT/bin/fm-spawn.sh"
 TMP_ROOT=$(fm_test_tmproot fm-spawn-bare-clone)
 
-# make_bare_fakebin <dir> <lease_support> builds the fake tmux and fake treehouse.
+# make_bare_fakebin <dir> <lease_support> [holder_guard_support] builds the fake
+# tmux and fake treehouse. <holder_guard_support> defaults to yes and stands for
+# `treehouse return --if-lease-holder`, which the version this repo pins does not
+# have: the fake rejects the flag as unknown when it is no, exactly as that binary
+# does, so a release that assumes the flag visibly fails to free the pool slot.
 #
 # The fake treehouse mirrors the two real behaviours that matter:
 #   * `get` resolves the repo from its cwd with `git rev-parse --show-toplevel`,
@@ -36,7 +40,7 @@ TMP_ROOT=$(fm_test_tmproot fm-spawn-bare-clone)
 # Every send-keys line is appended to FM_FAKE_SENDKEYS_LOG so the test can assert
 # which acquire command each path actually put in the pane.
 make_bare_fakebin() {
-  local dir=$1 lease_support=$2 fakebin
+  local dir=$1 lease_support=$2 holder_guard_support=${3:-yes} fakebin
   fakebin=$(fm_fakebin "$dir")
   cat > "$fakebin/tmux" <<'SH'
 #!/usr/bin/env bash
@@ -81,6 +85,7 @@ SH
 #!/usr/bin/env bash
 set -u
 LEASE_SUPPORT=$lease_support
+HOLDER_GUARD_SUPPORT=$holder_guard_support
 SH
   cat >> "$fakebin/treehouse" <<'SH'
 printf '%s\n' "$*" >> "${FM_FAKE_TREEHOUSE_LOG:?FM_FAKE_TREEHOUSE_LOG unset}"
@@ -123,6 +128,20 @@ if [ "${1:-}" = return ]; then
   # Real `treehouse return` takes an explicit path and needs no work tree of its
   # own, so it resolves against a bare-flagged clone too. The argv log above is
   # what the test asserts on.
+  if [ "${2:-}" = --help ]; then
+    printf 'Terminate lingering processes and return a worktree\n'
+    printf 'Flags:\n      --force   Clean, reset, and return without prompting\n'
+    [ "$HOLDER_GUARD_SUPPORT" = yes ] \
+      && printf '      --if-lease-holder string   Return only if the current lease has this holder\n'
+    exit 0
+  fi
+  case " $* " in
+    *" --if-lease-holder "*)
+      # The pinned treehouse has no such flag and rejects the whole command, so a
+      # release that assumes it never frees the pool slot.
+      [ "$HOLDER_GUARD_SUPPORT" = yes ] || { echo "unknown flag: --if-lease-holder" >&2; exit 1; }
+      ;;
+  esac
   exit 0
 fi
 exit 0
@@ -131,19 +150,20 @@ SH
   printf '%s\n' "$fakebin"
 }
 
-# make_bare_case <name> <id> <bare> <lease_support> builds a home plus a project
-# clone with a real linked worktree standing in for the pooled tree. When <bare>
-# is yes the clone gets core.bare=true AND an untracked file in its work tree -
-# the untracked file is what makes an absolute GIT_WORK_TREE override visibly
-# corrupt the pool-cleanliness check above.
+# make_bare_case <name> <id> <bare> <lease_support> [holder_guard_support] builds
+# a home plus a project clone with a real linked worktree standing in for the
+# pooled tree. When <bare> is yes the clone gets core.bare=true AND an untracked
+# file in its work tree - the untracked file is what makes an absolute
+# GIT_WORK_TREE override visibly corrupt the pool-cleanliness check above.
 make_bare_case() {
-  local name=$1 id=$2 bare=$3 lease_support=$4 case_dir home proj wt stale fakebin
+  local name=$1 id=$2 bare=$3 lease_support=$4 holder_guard_support=${5:-yes}
+  local case_dir home proj wt stale fakebin
   case_dir="$TMP_ROOT/$name"
   home="$case_dir/home"
   proj="$case_dir/project"
   wt="$case_dir/pool-worktree"
   stale="$case_dir/stale-worktree"
-  fakebin=$(make_bare_fakebin "$case_dir/fake" "$lease_support")
+  fakebin=$(make_bare_fakebin "$case_dir/fake" "$lease_support" "$holder_guard_support")
   mkdir -p "$home/data" "$home/projects" "$home/state" "$home/config"
   printf 'codex\n' > "$home/config/crew-harness"
   fm_git_worktree "$proj" "$wt" "pool-$name"
@@ -253,6 +273,28 @@ test_abort_before_meta_releases_the_lease() {
   pass "an abort before the meta write releases the durable lease"
 }
 
+# --if-lease-holder postdates the treehouse version this repo pins, which rejects
+# the whole command as an unknown flag. The release still has to happen there:
+# skipping it burns the pool slot, which is the leak the cleanup exists to close.
+test_abort_releases_the_lease_without_holder_guard() {
+  local rec id out
+  id='bare-lease-release-b7'
+  rec=$(make_bare_case bare-release-noguard "$id" yes yes no)
+  read_bare_record "$rec"
+  PANE_SETTLE="$STALE_DIR"
+
+  out=$(run_bare_spawn "$id")
+  assert_grep "return --force $WT_DIR" "$TREEHOUSE_LOG" \
+    "aborted spawn did not fall back to a plain release when treehouse lacks --if-lease-holder"
+  assert_no_grep "--if-lease-holder" "$TREEHOUSE_LOG" \
+    "aborted spawn passed --if-lease-holder to a treehouse that does not support it"
+  case "$out" in
+    *"could not release the worktree leased for $id"*)
+      fail "the lease release failed against a treehouse without --if-lease-holder" ;;
+  esac
+  pass "an abort releases the lease unguarded when treehouse lacks --if-lease-holder"
+}
+
 # The deliberate flag is the whole reason this path exists: it must survive.
 test_bare_flag_survives_the_spawn() {
   local rec id status
@@ -317,5 +359,6 @@ test_non_bare_clone_path_is_unchanged
 test_bare_without_lease_support_refuses
 test_settled_path_must_be_the_leased_worktree
 test_abort_before_meta_releases_the_lease
+test_abort_releases_the_lease_without_holder_guard
 
 echo "# all fm-spawn-bare-clone tests passed"

--- a/tests/fm-spawn-bare-clone.test.sh
+++ b/tests/fm-spawn-bare-clone.test.sh
@@ -169,8 +169,8 @@ make_bare_case() {
   fm_git_worktree "$proj" "$wt" "pool-$name"
   git -C "$wt" checkout --detach -q
   # A second real, isolated worktree: the stale pane path that passes both the
-  # non-project comparison and validate_spawn_worktree, so only the lease pin can
-  # catch it.
+  # non-project comparison and validate_spawn_worktree, so only waiting for the
+  # leased path itself can reject it.
   git -C "$proj" worktree add --quiet -b "stale-$name" "$stale"
   git -C "$stale" checkout --detach -q
   if [ "$bare" = yes ]; then
@@ -202,6 +202,7 @@ run_bare_spawn() {
     FM_STATE_OVERRIDE="$HOME_DIR/state" FM_DATA_OVERRIDE="$HOME_DIR/data" \
     FM_PROJECTS_OVERRIDE="$HOME_DIR/projects" FM_CONFIG_OVERRIDE="$HOME_DIR/config" \
     FM_SPAWN_NO_GUARD=1 TMUX="fake,1,0" \
+    FM_SPAWN_SETTLE_INTERVAL=0.02 \
     FM_FAKE_LEASE_PATH="$WT_DIR" FM_FAKE_PANE_PROJECT="$PROJ_DIR" \
     FM_FAKE_PANE_SETTLE="$PANE_SETTLE" \
     FM_FAKE_PANE_PATHFILE="$PANE_PATHFILE" FM_FAKE_SENDKEYS_LOG="$SENDKEYS_LOG" \
@@ -239,9 +240,10 @@ test_bare_flagged_clone_spawns() {
   pass "a bare-flagged clone yields an isolated worktree leased by firstmate"
 }
 
-# A pane that settles somewhere other than the leased worktree must not be
-# accepted: the leased tree would stay leased with nobody to return it and the
-# task would run in a tree treehouse never handed to it.
+# A pane that never reaches the leased worktree must not be accepted: the leased
+# tree would stay leased with nobody to return it and the task would run in a
+# tree treehouse never handed to it. The stand-in path here is a second real,
+# isolated worktree, so only the wait-for-the-leased-path rule can reject it.
 test_settled_path_must_be_the_leased_worktree() {
   local rec id out status
   id='bare-stale-pane-b5'

--- a/tests/fm-spawn-bare-clone.test.sh
+++ b/tests/fm-spawn-bare-clone.test.sh
@@ -1,0 +1,264 @@
+#!/usr/bin/env bash
+# Regression test for fm-spawn.sh acquiring an isolated task worktree from a
+# project clone whose main checkout deliberately carries core.bare=true
+# (bin/fm-spawn.sh, project_is_bare_flagged and lease_bare_clone_worktree).
+#
+# A harness may set that flag on purpose so the checkout can double as a ref host
+# that advances its own branches with a ref-only fetch. git then refuses every
+# work-tree operation against the clone, including the `git rev-parse
+# --show-toplevel` that `treehouse get` starts with, so the spawn used to die
+# before any worker existed. The flag is deliberate and must survive the spawn
+# untouched.
+#
+# The fake treehouse here is a thin pool wrapper only: its repo resolution and
+# its per-worktree cleanliness check are REAL git commands run against a real
+# bare-flagged fixture clone, so git itself - not a hardcoded assumption - is
+# what enforces the constraints under test.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+SPAWN="$ROOT/bin/fm-spawn.sh"
+TMP_ROOT=$(fm_test_tmproot fm-spawn-bare-clone)
+
+# make_bare_fakebin <dir> <lease_support> builds the fake tmux and fake treehouse.
+#
+# The fake treehouse mirrors the two real behaviours that matter:
+#   * `get` resolves the repo from its cwd with `git rev-parse --show-toplevel`,
+#     which is a work-tree operation and so fails against a bare-flagged clone
+#     unless the caller scoped a GIT_WORK_TREE override around the invocation.
+#   * before handing back a pooled worktree it checks that worktree is clean with
+#     `git -C <tree> status --porcelain`. An ABSOLUTE GIT_WORK_TREE pins that
+#     check to the clone's work tree instead, so the clone's own untracked files
+#     make every pooled tree read dirty and the real treehouse then refuses to
+#     hand any of them out. Only a relative override keeps this check honest.
+# Every send-keys line is appended to FM_FAKE_SENDKEYS_LOG so the test can assert
+# which acquire command each path actually put in the pane.
+make_bare_fakebin() {
+  local dir=$1 lease_support=$2 fakebin
+  fakebin=$(fm_fakebin "$dir")
+  cat > "$fakebin/tmux" <<'SH'
+#!/usr/bin/env bash
+set -u
+case "$*" in
+  *"#{pane_current_path}"*)
+    if [ -f "${FM_FAKE_PANE_PATHFILE:?FM_FAKE_PANE_PATHFILE unset}" ]; then
+      cat "$FM_FAKE_PANE_PATHFILE"
+    else
+      printf '%s\n' "${FM_FAKE_PANE_PROJECT:-}"
+    fi
+    exit 0
+    ;;
+esac
+case "${1:-}" in
+  send-keys)
+    printf '%s\n' "$*" >> "${FM_FAKE_SENDKEYS_LOG:?FM_FAKE_SENDKEYS_LOG unset}"
+    # A `cd <path>` line is the pane moving into an already-leased worktree; a
+    # bare `treehouse get` line is the pane acquiring one itself. Either way the
+    # simulated pane's reported cwd becomes the worktree, exactly as the real
+    # pane's would.
+    case "$*" in
+      *"cd "*)
+        printf '%s\n' "${FM_FAKE_LEASE_PATH:-}" > "$FM_FAKE_PANE_PATHFILE" ;;
+      *"treehouse get"*)
+        printf '%s\n' "${FM_FAKE_LEASE_PATH:-}" > "$FM_FAKE_PANE_PATHFILE" ;;
+    esac
+    exit 0
+    ;;
+  display-message) printf 'firstmate\n'; exit 0 ;;
+  list-windows) exit 0 ;;
+  has-session|new-session|new-window|kill-window) exit 0 ;;
+esac
+exit 0
+SH
+  chmod +x "$fakebin/tmux"
+
+  cat > "$fakebin/treehouse" <<SH
+#!/usr/bin/env bash
+set -u
+LEASE_SUPPORT=$lease_support
+SH
+  cat >> "$fakebin/treehouse" <<'SH'
+printf '%s\n' "$*" >> "${FM_FAKE_TREEHOUSE_LOG:?FM_FAKE_TREEHOUSE_LOG unset}"
+if [ "${1:-}" = get ] && [ "${2:-}" = --help ]; then
+  printf 'Acquire a worktree from the pool and open a subshell in it.\n'
+  printf 'Flags:\n  -h, --help  help for get\n'
+  [ "$LEASE_SUPPORT" = yes ] && printf '      --lease     Durably lease a worktree\n'
+  exit 0
+fi
+if [ "${1:-}" = get ]; then
+  # Real repo resolution: refuses on a bare-flagged clone with no work tree.
+  if ! git rev-parse --show-toplevel >/dev/null 2>&1; then
+    echo "not in a git repository: git rev-parse --show-toplevel: fatal: this operation must be run in a work tree" >&2
+    exit 1
+  fi
+  case " $* " in
+    *" --lease "*)
+      [ "$LEASE_SUPPORT" = yes ] || { echo "unknown flag: --lease" >&2; exit 1; }
+      ;;
+    *)
+      # Real `treehouse get` without --lease execs an INTERACTIVE SUBSHELL in the
+      # worktree and prints no path to stdout. Modelling that faithfully is what
+      # makes --lease load-bearing in this test rather than decorative: it is the
+      # only form that hands the path back to the caller, and so the only form
+      # that keeps the GIT_WORK_TREE override off the worker's own shell.
+      echo "🌳 Setting up worktree..." >&2
+      exit 0
+      ;;
+  esac
+  # Real pool-cleanliness check on the worktree about to be handed out.
+  if [ -n "$(git -C "${FM_FAKE_LEASE_PATH:?}" status --porcelain 2>&1)" ]; then
+    echo "all worktrees are in use or dirty (max_trees = 1)" >&2
+    exit 1
+  fi
+  echo "🌳 Setting up worktree..." >&2
+  printf '%s\n' "$FM_FAKE_LEASE_PATH"
+  exit 0
+fi
+exit 0
+SH
+  chmod +x "$fakebin/treehouse"
+  printf '%s\n' "$fakebin"
+}
+
+# make_bare_case <name> <id> <bare> <lease_support> builds a home plus a project
+# clone with a real linked worktree standing in for the pooled tree. When <bare>
+# is yes the clone gets core.bare=true AND an untracked file in its work tree -
+# the untracked file is what makes an absolute GIT_WORK_TREE override visibly
+# corrupt the pool-cleanliness check above.
+make_bare_case() {
+  local name=$1 id=$2 bare=$3 lease_support=$4 case_dir home proj wt fakebin
+  case_dir="$TMP_ROOT/$name"
+  home="$case_dir/home"
+  proj="$case_dir/project"
+  wt="$case_dir/pool-worktree"
+  fakebin=$(make_bare_fakebin "$case_dir/fake" "$lease_support")
+  mkdir -p "$home/data" "$home/projects" "$home/state" "$home/config"
+  printf 'codex\n' > "$home/config/crew-harness"
+  fm_git_worktree "$proj" "$wt" "pool-$name"
+  git -C "$wt" checkout --detach -q
+  if [ "$bare" = yes ]; then
+    printf 'max_trees = 1\n' > "$proj/treehouse.toml"
+    git -C "$proj" config core.bare true
+  fi
+  mkdir -p "$home/data/$id"
+  printf 'brief for %s\n' "$id" > "$home/data/$id/brief.md"
+  touch "$home/state/.last-watcher-beat"
+  printf '%s\n' "$case_dir|$home|$proj|$wt|$fakebin"
+}
+
+read_bare_record() {
+  IFS='|' read -r CASE_DIR HOME_DIR PROJ_DIR WT_DIR FAKEBIN_DIR <<EOF
+$1
+EOF
+  SENDKEYS_LOG="$CASE_DIR/sendkeys.log"
+  TREEHOUSE_LOG="$CASE_DIR/treehouse.log"
+  PANE_PATHFILE="$CASE_DIR/pane-path"
+  : > "$SENDKEYS_LOG"
+  : > "$TREEHOUSE_LOG"
+  rm -f "$PANE_PATHFILE"
+}
+
+run_bare_spawn() {
+  local id=$1
+  FM_ROOT_OVERRIDE='' FM_HOME="$HOME_DIR" \
+    FM_STATE_OVERRIDE="$HOME_DIR/state" FM_DATA_OVERRIDE="$HOME_DIR/data" \
+    FM_PROJECTS_OVERRIDE="$HOME_DIR/projects" FM_CONFIG_OVERRIDE="$HOME_DIR/config" \
+    FM_SPAWN_NO_GUARD=1 TMUX="fake,1,0" \
+    FM_FAKE_LEASE_PATH="$WT_DIR" FM_FAKE_PANE_PROJECT="$PROJ_DIR" \
+    FM_FAKE_PANE_PATHFILE="$PANE_PATHFILE" FM_FAKE_SENDKEYS_LOG="$SENDKEYS_LOG" \
+    FM_FAKE_TREEHOUSE_LOG="$TREEHOUSE_LOG" \
+    PATH="$FAKEBIN_DIR:$PATH" \
+    "$SPAWN" "$id" "$PROJ_DIR" --mode no-mistakes --yolo off 2>&1
+}
+
+# The headline case: a bare-flagged clone must still yield an isolated worktree.
+test_bare_flagged_clone_spawns() {
+  local rec id out status
+  id='bare-clone-spawn-b1'
+  rec=$(make_bare_case bare-spawn "$id" yes yes)
+  read_bare_record "$rec"
+
+  out=$(run_bare_spawn "$id")
+  status=$?
+  expect_code 0 "$status" "spawn should succeed against a bare-flagged clone"
+  assert_contains "$out" "spawned $id" "spawn did not report success"
+  assert_grep "worktree=$WT_DIR" "$HOME_DIR/state/$id.meta" \
+    "meta did not record the leased worktree"
+  # The pane must be moved into an already-leased worktree, never asked to run
+  # `treehouse get` itself - that is the call that cannot work here.
+  assert_grep "cd " "$SENDKEYS_LOG" "pane was not sent a cd into the leased worktree"
+  assert_no_grep "treehouse get" "$SENDKEYS_LOG" \
+    "pane was told to run treehouse get against a bare-flagged clone"
+  # --lease is what hands the path back instead of exec'ing a subshell that would
+  # inherit the GIT_WORK_TREE override into the worker's own environment.
+  assert_grep "get --lease" "$TREEHOUSE_LOG" \
+    "worktree was not acquired with treehouse get --lease"
+  pass "a bare-flagged clone yields an isolated worktree leased by firstmate"
+}
+
+# The deliberate flag is the whole reason this path exists: it must survive.
+test_bare_flag_survives_the_spawn() {
+  local rec id status
+  id='bare-clone-flag-b2'
+  rec=$(make_bare_case bare-flag "$id" yes yes)
+  read_bare_record "$rec"
+
+  run_bare_spawn "$id" >/dev/null
+  status=$?
+  expect_code 0 "$status" "spawn should succeed against a bare-flagged clone"
+  [ "$(git -C "$PROJ_DIR" config --get core.bare)" = true ] \
+    || fail "spawn cleared the clone's deliberate core.bare=true flag"
+  [ "$(git -C "$PROJ_DIR" rev-parse --is-bare-repository)" = true ] \
+    || fail "clone no longer reports as bare after the spawn"
+  pass "the clone's deliberate core.bare=true survives the spawn unchanged"
+}
+
+# An ordinary clone must keep acquiring its worktree exactly as before: the pane
+# runs `treehouse get` itself and no lease is taken.
+test_non_bare_clone_path_is_unchanged() {
+  local rec id out status
+  id='non-bare-clone-b3'
+  rec=$(make_bare_case non-bare "$id" no yes)
+  read_bare_record "$rec"
+
+  out=$(run_bare_spawn "$id")
+  status=$?
+  expect_code 0 "$status" "spawn should succeed against an ordinary clone"
+  assert_contains "$out" "spawned $id" "spawn did not report success"
+  assert_grep "worktree=$WT_DIR" "$HOME_DIR/state/$id.meta" \
+    "meta did not record the worktree"
+  assert_grep "treehouse get" "$SENDKEYS_LOG" \
+    "ordinary clone no longer has the pane run treehouse get"
+  # The lease is a subprocess of fm-spawn.sh, never a pane command, so the pane
+  # log cannot witness it either way - the treehouse argv log is the real signal
+  # that no lease was taken and the ordinary path is untouched.
+  assert_no_grep "--lease" "$TREEHOUSE_LOG" \
+    "ordinary clone wrongly took the bare-clone lease path"
+  pass "an ordinary clone still acquires its worktree through the pane's own treehouse get"
+}
+
+# A bare-flagged clone with no --lease support cannot be isolated safely, so the
+# spawn must refuse by name rather than fall back to the call that corrupts.
+test_bare_without_lease_support_refuses() {
+  local rec id out status
+  id='bare-no-lease-b4'
+  rec=$(make_bare_case bare-no-lease "$id" yes no)
+  read_bare_record "$rec"
+
+  out=$(run_bare_spawn "$id")
+  status=$?
+  [ "$status" -ne 0 ] || fail "spawn should refuse a bare-flagged clone when treehouse lacks --lease"
+  assert_contains "$out" "core.bare=true" "refusal did not name the bare-flagged clone"
+  assert_contains "$out" "--lease" "refusal did not name the missing treehouse capability"
+  assert_absent "$HOME_DIR/state/$id.meta" "refused spawn still recorded task metadata"
+  pass "a bare-flagged clone refuses by name when treehouse cannot lease"
+}
+
+test_bare_flagged_clone_spawns
+test_bare_flag_survives_the_spawn
+test_non_bare_clone_path_is_unchanged
+test_bare_without_lease_support_refuses
+
+echo "# all fm-spawn-bare-clone tests passed"


### PR DESCRIPTION
## What Changed

- `fm-spawn.sh` now detects a project clone whose main checkout carries `core.bare=true` (via `git rev-parse --is-bare-repository`) and leases the pooled task worktree itself with a scoped, relative `GIT_WORK_TREE=.` and `treehouse get --lease --lease-holder <id>`, telling the pane only to `cd` into the ready worktree instead of running `treehouse get` there; the clone's configuration is never written, and the ordinary-clone path is unchanged.
- Added lease-leak protection around that durable lease: `spawn_abort_cleanup` returns it on any abort before `state/<id>.meta` is written, capability-detecting `treehouse return --if-lease-holder` and falling back to an unguarded `--force` return on older binaries, then clears `LEASED_WT` at the meta write so `fm-teardown.sh` owns the release from that point on.
- Split the pane-settle wait: the leased path polls for the exact leased worktree and fails closed if the pane never arrives (naming both the leased path and the last observed one), while the ordinary path keeps the two-consecutive-reads stale-path guard; the recorded `worktree=` uses treehouse's own spelling of the leased path, and `validate_spawn_worktree` still runs on both. Covered by a new `tests/fm-spawn-bare-clone.test.sh` and a bare-clone section in `docs/architecture.md`.

## Risk Assessment

✅ Low: The ordinary-clone path is semantically untouched and the leased path is now the more constrained of the two - it waits for an exact match against the worktree it already holds, records treehouse's own canonical spelling so fm-teardown.sh's return can always match it, and releases the durable lease on every abort before the meta write - with every downstream consumer of that path verified spelling-agnostic.

## Testing

Ran the new colocated suite (tests/fm-spawn-bare-clone.test.sh, 8/8) plus tests/fm-spawn-worktree-settle.test.sh, which guards the ordinary-clone settle loop this diff rewrote in place, and confirmed the new script is selected by the portable-serial CI lane; then, because passing unit tests use a fake treehouse, I drove the real product path: a fixture git clone with core.bare=true and an untracked file, the real treehouse binary, and real tmux 3.7b on a dedicated `-L fm-bareclone-e2e` socket. The base commit's fm-spawn.sh reproducibly failed there (pane stuck in the clone with git's "this operation must be run in a work tree", no state meta), the target commit leased a worktree and spawned successfully, and probing the spawned worker's own shell showed GIT_WORK_TREE unset with `git status --porcelain` empty rather than reporting the clone's untracked file - the leak the --lease design exists to prevent. I also confirmed with the real binary that an absolute GIT_WORK_TREE makes a free clean pool tree read dirty while the relative one leases it, that `treehouse return --force --if-lease-holder` refuses a wrong holder and succeeds for the right one, that the clone's core.bare=true survived unchanged, and that an ordinary clone still has the pane run `treehouse get` itself with no lease taken. No screenshot, GIF, or rendered HTML: the end-user surface here is a CLI invocation and a tmux worker pane, so the `tmux capture-pane` transcripts and command transcripts in the artifacts are the rendered surface a reviewer would see. All checks passed; the fixture, its treehouse leases, and the isolated tmux server were cleaned up and the repo worktree is clean.

<details>
<summary>Evidence: E2E summary: bare-flagged clone spawn, before/after with real treehouse + tmux</summary>

<code># fm-spawn.sh: spawning a task worktree from a bare-flagged clone&#10;&#10;End-to-end run with the REAL `treehouse` (--lease + --if-lease-holder) and REAL `tmux 3.7b`&#10;on an isolated socket, against a real git clone whose main checkout carries the deliberate&#10;`core.bare=true` ref-host flag and has an untracked file in its work tree.&#10;&#10;## Before (base commit 6f0f87f) - spawn dies, no worker exists&#10;&#10;$ fm-spawn.sh bare-e2e-base-a1 &lt;bare-flagged clone&gt; --mode no-mistakes --yolo off&#10;error: treehouse get did not enter a worktree within 60s; inspect window firstmate:fm-bare-e2e-base-a1&#10;exit=1&#10;&#10;# tmux pane firstmate:fm-bare-e2e-base-a1&#10;oscarmuhlbauer@Oscars-MBP-2 project % treehouse get&#10;not in a git repository: git rev-parse --show-toplevel: fatal: this operation must be run in a work tree&#10;# pane cwd: /private/tmp/.../project &lt;- never left the clone&#10;# state/: no bare-e2e-base-a1.meta&#10;&#10;## After (target commit cffe671) - the worktree is leased and the pane cd&#39;s into it&#10;&#10;$ fm-spawn.sh bare-e2e-fix-a2 &lt;bare-flagged clone&gt; --mode no-mistakes --yolo off&#10;🌳 Setting up worktree...&#10;🌳 Leased worktree at .../pool/.treehouse/project-b3cbf4/1/project. Run &#39;treehouse return ...&#39; to release it.&#10;spawned bare-e2e-fix-a2 harness=codex kind=ship mode=no-mistakes yolo=off&#10;window=firstmate:fm-bare-e2e-fix-a2 worktree=.../pool/.treehouse/project-b3cbf4/1/project&#10;exit=0&#10;&#10;# state/bare-e2e-fix-a2.meta&#10;worktree=/tmp/fm-bareclone-e2e.JUy4Y7/pool/.treehouse/project-b3cbf4/1/project&#10;project=/tmp/fm-bareclone-e2e.JUy4Y7/project&#10;&#10;## The worker&#39;s shell is clean - no GIT_WORK_TREE leak&#10;&#10;Probed inside the spawned pane, in the leased worktree:&#10;&#10;GIT_WORK_TREE=[&lt;unset&gt;]&#10;pwd = /private/tmp/.../pool/.treehouse/project-b3cbf4/1/project&#10;toplevel = /private/tmp/.../pool/.treehouse/project-b3cbf4/1/project&#10;gitdir = /private/tmp/.../project/.git/worktrees/project&#10;git status --porcelain -&gt; (empty) &lt;- NOT the clone&#39;s untracked-scratch.txt&#10;&#10;## The deliberate flag survives untouched&#10;&#10;core.bare = true&#10;rev-parse --is-bare-repository = true&#10;&#10;## Why the override has to be relative (real treehouse, one free clean pool tree)&#10;&#10;ABSOLUTE GIT_WORK_TREE=&lt;clone&gt; -&gt; &#34;all 2 worktrees are in use or dirty (max_trees = 2)&#34; exit=1&#10;RELATIVE GIT_WORK_TREE=. -&gt; 🌳 Leased worktree at .../2/project exit=0&#10;&#10;## The abort-cleanup release shapes, against the real binary&#10;&#10;treehouse return --force --if-lease-holder some-other-task &lt;tree&gt;&#10;-&gt; lease precondition failed: lease holder does not match exit=1 (cannot steal a re-lease)&#10;treehouse return --force --if-lease-holder rel-probe &lt;tree&gt;&#10;-&gt; 🌳 Worktree returned to pool. exit=0&#10;&#10;## Ordinary clone is unchanged&#10;&#10;spawned plain-e2e-a3 ... worktree=.../plainpool/.treehouse/plain-8aaaa8/1/plain&#10;# pane ran `treehouse get` itself; no &#34;Leased worktree&#34; line, no lease taken&#10;&#10;NOTE: the /tmp/fm-bareclone-e2e.JUy4Y7 paths in these transcripts are historical; the fixture&#10;clone, its treehouse pool, and the isolated tmux server were cleaned up after the run.</code>

```text
# fm-spawn.sh: spawning a task worktree from a bare-flagged clone

End-to-end run with the REAL `treehouse` (v with `--lease` + `--if-lease-holder`) and REAL
`tmux 3.7b` on an isolated socket (`tmux -L fm-bareclone-e2e`), against a real git clone
whose main checkout carries the deliberate `core.bare=true` ref-host flag and has an
untracked file in its work tree.

## Before (base commit 6f0f87f) — spawn dies, no worker exists

    $ fm-spawn.sh bare-e2e-base-a1 <bare-flagged clone> --mode no-mistakes --yolo off
    error: treehouse get did not enter a worktree within 60s; inspect window firstmate:fm-bare-e2e-base-a1
    exit=1

    # tmux pane firstmate:fm-bare-e2e-base-a1
    oscarmuhlbauer@Oscars-MBP-2 project % treehouse get
    not in a git repository: git rev-parse --show-toplevel: fatal: this operation must be run in a work tree
    # pane cwd: /private/tmp/.../project   <- never left the clone
    # state/: no bare-e2e-base-a1.meta

## After (target commit cffe671) — the worktree is leased and the pane cd's into it

    $ fm-spawn.sh bare-e2e-fix-a2 <bare-flagged clone> --mode no-mistakes --yolo off
    🌳 Setting up worktree...
    🌳 Leased worktree at .../pool/.treehouse/project-b3cbf4/1/project. Run 'treehouse return ...' to release it.
    spawned bare-e2e-fix-a2 harness=codex kind=ship mode=no-mistakes yolo=off
      window=firstmate:fm-bare-e2e-fix-a2 worktree=.../pool/.treehouse/project-b3cbf4/1/project
    exit=0

    # state/bare-e2e-fix-a2.meta
    worktree=/tmp/fm-bareclone-e2e.JUy4Y7/pool/.treehouse/project-b3cbf4/1/project
    project=/tmp/fm-bareclone-e2e.JUy4Y7/project

## The worker's shell is clean — no GIT_WORK_TREE leak

Probed inside the spawned pane, in the leased worktree:

    GIT_WORK_TREE=[<unset>]
    pwd      = /private/tmp/.../pool/.treehouse/project-b3cbf4/1/project
    toplevel = /private/tmp/.../pool/.treehouse/project-b3cbf4/1/project
    gitdir   = /private/tmp/.../project/.git/worktrees/project
    git status --porcelain -> (empty)      <- NOT the clone's untracked-scratch.txt

## The deliberate flag survives untouched

    core.bare = true
    rev-parse --is-bare-repository = true

## Why the override has to be relative (real treehouse, one free clean pool tree)

    ABSOLUTE GIT_WORK_TREE=<clone>  -> "all 2 worktrees are in use or dirty (max_trees = 2)"   exit=1
    RELATIVE GIT_WORK_TREE=.        -> 🌳 Leased worktree at .../2/project                     exit=0

## The abort-cleanup release shapes, against the real binary

    treehouse return --force --if-lease-holder some-other-task <tree>
      -> lease precondition failed: lease holder does not match   exit=1  (cannot steal a re-lease)
    treehouse return --force --if-lease-holder rel-probe <tree>
      -> 🌳 Worktree returned to pool.                            exit=0

## Ordinary clone is unchanged

    spawned plain-e2e-a3 ... worktree=.../plainpool/.treehouse/plain-8aaaa8/1/plain
    # pane ran `treehouse get` itself; no "Leased worktree" line, no lease taken

NOTE: the /tmp/fm-bareclone-e2e.JUy4Y7 paths in these transcripts are historical;
the fixture clone, its treehouse pool, and the isolated tmux server were cleaned up
after the run. Nothing outside the evidence directory survives.
```
</details>
<details>
<summary>Evidence: Base commit: spawn fails against the bare-flagged clone</summary>

```text
warning: /tmp/fm-bareclone-e2e.JUy4Y7/home/data/bare-e2e-base-a1/brief.md records no delivery contract line (scaffolded before ship briefs recorded one); launching on the explicit --mode no-mistakes - confirm its definition of done matches
error: treehouse get did not enter a worktree within 60s; inspect window firstmate:fm-bare-e2e-base-a1
```
</details>
<details>
<summary>Evidence: Base commit: tmux pane capture showing git&#39;s refusal and the pane stuck in the clone</summary>

```text
=== pane contents of firstmate:fm-bare-e2e-base-a1 (base commit) ===
treehouse get
oscarmuhlbauer@Oscars-MBP-2 project % treehouse get
not in a git repository: git rev-parse --show-toplevel: fatal: this operation mu
st be run in a work tree
oscarmuhlbauer@Oscars-MBP-2 project %
--- pane cwd ---
/private/tmp/fm-bareclone-e2e.JUy4Y7/project
```
</details>
<details>
<summary>Evidence: Target commit: successful spawn transcript with the leased worktree</summary>

```text
warning: /tmp/fm-bareclone-e2e.JUy4Y7/home/data/bare-e2e-fix-a2/brief.md records no delivery contract line (scaffolded before ship briefs recorded one); launching on the explicit --mode no-mistakes - confirm its definition of done matches
🌳 Setting up worktree...
🌳 Leased worktree at /tmp/fm-bareclone-e2e.JUy4Y7/pool/.treehouse/project-b3cbf4/1/project. Run 'treehouse return /tmp/fm-bareclone-e2e.JUy4Y7/pool/.treehouse/project-b3cbf4/1/project' to release it.
spawned bare-e2e-fix-a2 harness=codex kind=ship mode=no-mistakes yolo=off window=firstmate:fm-bare-e2e-fix-a2 worktree=/tmp/fm-bareclone-e2e.JUy4Y7/pool/.treehouse/project-b3cbf4/1/project
```
</details>
<details>
<summary>Evidence: Target commit: persisted state/&lt;id&gt;.meta recording the leased worktree</summary>

```text
=== state/bare-e2e-fix-a2.meta ===
window=firstmate:fm-bare-e2e-fix-a2
endpoint_task_id=bare-e2e-fix-a2
worktree=/tmp/fm-bareclone-e2e.JUy4Y7/pool/.treehouse/project-b3cbf4/1/project
project=/tmp/fm-bareclone-e2e.JUy4Y7/project
harness=codex
kind=ship
mode=no-mistakes
yolo=off
tasktmp=/tmp/fm-bare-e2e-fix-a2
model=default
effort=default

=== treehouse status (real pool) ===
not in a git repository: git rev-parse --show-toplevel: fatal: this operation must be run in a work tree
```
</details>
<details>
<summary>Evidence: Worker pane environment inside the leased worktree (GIT_WORK_TREE unset, clean git status)</summary>

```text
=== worker pane environment inside the leased worktree ===
GIT_WORK_TREE=[<unset>]
pwd=/private/tmp/fm-bareclone-e2e.JUy4Y7/pool/.treehouse/project-b3cbf4/1/projec
t
toplevel=/private/tmp/fm-bareclone-e2e.JUy4Y7/pool/.treehouse/project-b3cbf4/1/p
roject
gitdir=/private/tmp/fm-bareclone-e2e.JUy4Y7/project/.git/worktrees/project
branch=HEAD
status:
status-end
oscarmuhlbauer@Oscars-MBP-2 project %
```
</details>
<details>
<summary>Evidence: The clone&#39;s deliberate core.bare=true survives the spawn</summary>

```text
=== the clone's deliberate ref-host flag after the spawn ===
core.bare = true
rev-parse --is-bare-repository = true
clone work tree still on disk, still dirty:
README.md
treehouse.toml
untracked-scratch.txt

=== the ref-host pattern this flag exists for still works ===
true
```
</details>
<details>
<summary>Evidence: Absolute vs relative GIT_WORK_TREE against the real treehouse pool</summary>

```text
=== why the GIT_WORK_TREE override must be RELATIVE (real treehouse, real bare-flagged clone) ===
Pool: tree 1 leased by task bare-e2e-fix-a2; tree 2 free and clean.
The clone's own work tree is dirty (untracked-scratch.txt).

--- ABSOLUTE GIT_WORK_TREE (the wrong shape) ---
🌳 Setting up worktree...
all 2 worktrees are in use or dirty (max_trees = 2). Run 'treehouse status' to see details, or increase max_trees in treehouse.toml
exit=1

--- RELATIVE GIT_WORK_TREE=. (what fm-spawn.sh uses) ---
🌳 Setting up worktree...
🌳 Leased worktree at /tmp/fm-bareclone-e2e.JUy4Y7/pool/.treehouse/project-b3cbf4/2/project. Run 'treehouse return /tmp/fm-bareclone-e2e.JUy4Y7/pool/.treehouse/project-b3cbf4/2/project' to release it.
/tmp/fm-bareclone-e2e.JUy4Y7/pool/.treehouse/project-b3cbf4/2/project
exit=0
```
</details>
<details>
<summary>Evidence: Holder-guarded lease release shapes against the real treehouse</summary>

```text
=== the exact release shapes fm-spawn.sh's abort cleanup uses, against the REAL treehouse ===
tree 2 is leased by holder 'rel-probe'.

--- wrong holder: must NOT steal a concurrently re-leased tree ---
failed to return worktree: lease precondition failed: lease holder does not match worktree /tmp/fm-bareclone-e2e.JUy4Y7/pool/.treehouse/project-b3cbf4/2/project
exit=1

--- right holder: releases the pool slot ---
🌳 Worktree returned to pool.
exit=0
```
</details>
<details>
<summary>Evidence: Ordinary (non-bare) clone still acquires its worktree via the pane&#39;s own treehouse get</summary>

```text
=== ordinary (non-bare) clone: the pane still runs 'treehouse get' itself, no lease taken ===
warning: /tmp/fm-bareclone-e2e.JUy4Y7/home/data/plain-e2e-a3/brief.md records no delivery contract line (scaffolded before ship briefs recorded one); launching on the explicit --mode no-mistakes - confirm its definition of done matches
spawned plain-e2e-a3 harness=codex kind=ship mode=no-mistakes yolo=off window=firstmate:fm-plain-e2e-a3 worktree=/private/tmp/fm-bareclone-e2e.JUy4Y7/plainpool/.treehouse/plain-8aaaa8/1/plain
exit=0

--- state/plain-e2e-a3.meta ---
window=firstmate:fm-plain-e2e-a3
endpoint_task_id=plain-e2e-a3
worktree=/private/tmp/fm-bareclone-e2e.JUy4Y7/plainpool/.treehouse/plain-8aaaa8/1/plain
project=/tmp/fm-bareclone-e2e.JUy4Y7/plain
harness=codex
kind=ship
mode=no-mistakes
yolo=off
tasktmp=/tmp/fm-plain-e2e-a3
model=default
effort=default

--- pane firstmate:fm-plain-e2e-a3 (ordinary clone: pane ran 'treehouse get' itself) ---
treehouse get
oscarmuhlbauer@Oscars-MBP-2 plain % treehouse get
🌳 Setting up worktree...
🌳 Entered worktree at /tmp/fm-bareclone-e2e.JUy4Y7/plainpool/.treehouse/plain-8
aaaa8/1/plain. Type 'exit' to return.
oscarmuhlbauer@Oscars-MBP-2 plain % export GOTMPDIR=/tmp/fm-plain-e2e-a3/gotmp
oscarmuhlbauer@Oscars-MBP-2 plain % codex --dangerously-bypass-approvals-and-san
dbox -c "notify=[\"bash\",\"-c\",\"touch '/private/tmp/fm-bareclone-e2e.JUy4Y7/h
```
</details>
- Outcome: ⚠️ 1 info across 1 run (11m54s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>⏭️ **intent** - skipped</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed (2) ✅</summary>

- ℹ️ `bin/fm-spawn.sh:1336` - Both new comments cite a precedent that does not exist. Line 1336 says the bare detection uses the &#34;Same signal and naming as fm-fleet-sync.sh&#39;s bare=yes check, which fixed the matching refresh failure&#34;, and line 113 says the ref-host pattern is &#34;as in fm-fleet-sync.sh&#39;s matching refresh path&#34;. `grep -rn &#39;is-bare-repository|core.bare&#39;` and `grep -rn &#39;bare=yes&#39;` across bin/, tests/ and docs/ match only fm-spawn.sh itself, and `git log -S&#39;is-bare-repository&#39; -- bin/fm-fleet-sync.sh` is empty; fm-fleet-sync.sh has no bare handling at all. This is the stated justification for the chosen detection signal, so a maintainer following the pointer finds nothing and cannot tell whether the signal was picked deliberately. Drop the cross-reference or point it at the real precedent.
- ℹ️ `bin/fm-spawn.sh:1858` - On the leased path the correct worktree is already known before the settle loop runs, but the loop still accepts any non-project path confirmed by two consecutive reads and only afterwards compares it to LEASED_WT_REAL, aborting on mismatch. The surrounding comment documents that a brand-new pane&#39;s pane_current_path can transiently report an unrelated real checkout; if that stale path happens to be reported on two consecutive 1s polls while the sent `cd` has not yet taken effect, the spawn aborts with &#34;refusing to launch in a worktree that was never leased for this task&#34; even though the pane settles correctly a moment later. Polling for `p_real = &#34;$LEASED_WT_REAL&#34;` directly on the leased branch (still erroring out on the existing 60s timeout) would keep the fail-closed guarantee while removing that false-abort window. This is an improvement, not a regression: the code as written is strictly safer than the ordinary path, which silently records the wrong worktree in the same scenario. Flagged rather than changed because &#34;Fail closed instead&#34; is a deliberate stated choice.

🔧 Fix: wait for the leased worktree; drop stale comment references
2 issues (1 warning, 1 info) still open:
- ⚠️ `bin/fm-spawn.sh:1850` - On the leased branch the match test proves `p_real = LEASED_WT_REAL`, then `WT=&#34;$p&#34;` keeps the pane&#39;s spelling and discards treehouse&#39;s own `$LEASED_WT`. tmux&#39;s pane_current_path is the physically-resolved cwd, while `$LEASED_WT` is the string treehouse printed and recorded. I verified against the real binary that `treehouse return` does not canonicalize: returning an equivalent-but-differently-spelled path exits 1 with &#34;worktree &lt;path&gt; is not managed by treehouse&#34;. Concrete sequence, if any component of the treehouse root is a symlink (the same divergence class PROJ_ABS_REAL exists to absorb, e.g. a relocated or automounted $HOME): the settle wait matches on resolved paths, line 2171 writes the pane&#39;s physical spelling as `worktree=`, `fm-teardown.sh:380` reads it back and `fm-teardown.sh:2258` passes it verbatim to `treehouse return --force`, which exits 1, so teardown aborts with &#34;treehouse return failed for worktree ...; teardown aborted&#34; and the lease is never released. Because a leased worktree is never pruned and never handed to a later `get`, the pool slot is burned permanently with no firstmate command able to free it - the exact leak the abort cleanup was added to close. Setting `WT=&#34;$LEASED_WT&#34;` on this branch fixes it in one line. Verified safe at that point: `validate_spawn_worktree` compares only `cd &amp;&amp; pwd -P` forms of `$WT` and its git toplevel, so it is spelling-agnostic, and every other pre-meta use of `$WT` (line 1896 `git -C`, 1947/1960 `mkdir -p`, 1954/1961/2101/2116 redirects) resolves the same directory either way. The ordinary path cannot be fixed here because it never learns a canonical path.
- ℹ️ `bin/fm-spawn.sh:1796` - The comment above the acquire branch still claims &#34;Both branches converge on the same settle loop and isolation assertion below, so neither the transient-stale-path guard nor validate_spawn_worktree is skipped for a leased worktree.&#34; This commit made the leased branch skip that guard: the two-consecutive-reads check now lives in the `elif` at line 1853 and runs only when LEASED_WT is empty, replaced on the leased path by the stricter exact-match wait. The block comment 40 lines below already states the new split correctly, so the two adjacent comments contradict each other about the control flow directly beneath them. Drop or reword the &#34;neither ... is skipped&#34; clause; validate_spawn_worktree genuinely still runs on both paths.

🔧 Fix: record treehouse&#39;s own spelling of the leased worktree
✅ Re-checked - no issues remain.

</details>

<details>
<summary>⚠️ **Test** - 1 info</summary>

- ℹ️ `bin/fm-spawn.sh:715` - Observed against the real treehouse binary while validating the abort-cleanup release shapes: when `treehouse return --if-lease-holder` correctly refuses because another task now holds the lease, the release exits non-zero and fm-spawn.sh:715 prints `warning: could not release the worktree leased for &lt;id&gt;; the pool slot stays leased until you run &#39;treehouse return --force &lt;path&gt;&#39; from &lt;proj&gt;`. Following that instruction in exactly the case the guard fired for would force-return a worktree a live task is using. The window is narrow (it requires the tree to be returned and re-leased between this task&#39;s lease and its abort) and the guard itself behaves correctly, so this is a message-wording note rather than a test failure - no fix applied from this phase.
- <code>`bash bin/fm-test-run.sh tests/fm-spawn-bare-clone.test.sh` - 8/8 pass, including the bare-flagged spawn, flag survival, ordinary-clone path, no-lease refusal, non-leased-settle refusal, meta lease spelling, and both abort-release variants</code>
- <code>`bash bin/fm-test-run.sh tests/fm-spawn-worktree-settle.test.sh` - 2/2 pass, guards the ordinary-clone two-consecutive-reads settle loop the diff rewrote</code>
- <code>`bash bin/fm-test-run.sh --check-coverage` - FM_TEST_COVERAGE ok total=124</code>
- <code>`bash bin/fm-test-run.sh --list --lane &lt;each lane&gt; | grep -c bare-clone` - new script is in portable-serial / portable-serial-1of4, so CI runs it</code>
- <code>Manual E2E fixture: real `git init` clone with `git config core.bare true`, an untracked work-tree file, a treehouse.toml pool, an isolated FM_HOME, and a `tmux -L fm-bareclone-e2e` shim so the user&#39;s real fleet session was never touched</code>
- <code>`(cd &lt;bare clone&gt; &amp;&amp; treehouse get)` with the REAL treehouse - reproduced the underlying failure: `fatal: this operation must be run in a work tree`</code>
- <code>BASE commit fm-spawn.sh (only bin/fm-spawn.sh reverted to 6f0f87f in a copied tree) against the bare-flagged clone - failed with `error: treehouse get did not enter a worktree within 60s`, pane still in the clone, no state/&lt;id&gt;.meta</code>
- <code>TARGET commit `bin/fm-spawn.sh bare-e2e-fix-a2 &lt;bare clone&gt; --mode no-mistakes --yolo off` - exit 0, `🌳 Leased worktree at ...`, `spawned bare-e2e-fix-a2 ... worktree=...`, meta records the leased path</code>
- <code>`tmux send-keys` probe inside the spawned worker pane - `GIT_WORK_TREE=[&lt;unset&gt;]`, `git rev-parse --show-toplevel` = leased worktree, `git status --porcelain` empty (not the clone&#39;s untracked-scratch.txt)</code>
- <code>`git -C &lt;clone&gt; config --get core.bare` and `rev-parse --is-bare-repository` after the spawn - both still true, flag untouched</code>
- <code>`GIT_WORK_TREE=&lt;abs clone&gt; treehouse get --lease` vs `GIT_WORK_TREE=. treehouse get --lease` with one free clean pool tree - absolute reports &#34;all 2 worktrees are in use or dirty&#34; (exit 1), relative leases the tree (exit 0)</code>
- <code>`treehouse return --force --if-lease-holder &lt;wrong&gt; &lt;tree&gt;` and `--if-lease-holder &lt;right&gt; &lt;tree&gt;` against the real binary - refuses with &#34;lease holder does not match&#34;, then returns the tree</code>
- <code>TARGET commit spawn against an ordinary (non-bare) fixture clone - exit 0, pane ran `treehouse get` itself, no lease line in the transcript</code>
- <code>Cleanup verification: both pool leases returned, isolated tmux server killed, fixture removed, `git status --porcelain` clean in the repo worktree</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
