### PR TITLE
fix(afk): harden away-mode delivery and wedge alerting

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -301,7 +301,7 @@ After an autonomous merge, give the captain a one-line full-URL or local-main ou
 ### Validate
 
 For a no-mistakes ship, trigger validation on the same worker after its implementation commit, using the harness invocation owned by `harness-adapters`.
-The task worker that starts a no-mistakes run drives the pipeline and owns every `no-mistakes axi run` and `no-mistakes axi respond` call through the next gate or outcome.
+The task worker that starts a no-mistakes run drives the pipeline and owns every `no-mistakes axi run` and `no-mistakes axi respond` call until a gate requires firstmate or the run reaches a terminal outcome.
 Firstmate never invokes `no-mistakes axi respond` for a crew-owned run.
 Once validation starts, prefer routing new requirements to follow-up work rather than expanding the current task, unless a new requirement completely invalidates the work being validated; however, the smallest downstream changes needed to keep already accepted product or engineering behavior correct, add behavioral tests where an executable contract exists, or keep documentation accurate remain within the current task even when they touch files not named at intake, and corrections required to satisfy already accepted intent are not new requirements.
 

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -311,6 +311,7 @@ case "$MODE" in
 This project ships **direct-PR**: you raise the PR yourself, without the no-mistakes pipeline.
 The task is complete only when committed on your branch.
 When it is implemented and committed, push your branch and open a PR with \`gh-axi\`, then append \`done: PR {url}\` to the status file and stop.
+Do not end your turn waiting for firstmate to tell you to push or open the PR - those delivery steps are yours.
 Do NOT run /no-mistakes. The configured merge authority decides whether to merge the PR; firstmate relays the outcome.
 EOF
     ;;
@@ -323,6 +324,7 @@ This project ships **local-only**: no remote, no PR, no pipeline.
 The task is complete only when committed on your branch \`fm/$ID\`. Do NOT push, do NOT open a PR, do NOT merge.
 Keep your branch a clean fast-forward onto the current default branch - if \`main\` has advanced, rebase onto it so the eventual merge stays a fast-forward.
 When it is implemented and committed, append \`done: ready in branch fm/$ID\` to the status file and stop.
+Do not end your turn waiting for firstmate to tell you to rebase or report the ready branch - those delivery steps are yours.
 The configured merge authority approves the ready branch, then firstmate merges it into local \`main\` through the guarded fast-forward path.
 EOF
     ;;
@@ -333,8 +335,10 @@ EOF
     IFS= read -r -d '' DOD <<EOF || true
 # Definition of done
 The task is complete only when committed on your branch.
-When you believe it is complete, append \`done: {summary}\` to the status file and stop.
-Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.
+After committing the implementation, invoke /no-mistakes yourself to validate and ship the PR.
+Do not append \`done:\` or end your turn merely because the pipeline is running.
+Poll the run's own status and keep driving it until it reaches a gate that requires firstmate or a terminal outcome.
+"Waiting for the next decision point" is not a valid resting state while the run is active.
 
 You drive no-mistakes by responding to its gates, not by implementing fixes.
 Follow the guidance no-mistakes itself provides for the mechanics: it loads when you invoke /no-mistakes, and \`no-mistakes axi run --help\` plus the \`help\` lines in each \`axi\` response are authoritative and version-matched to the installed binary.

--- a/bin/fm-composer-lib.sh
+++ b/bin/fm-composer-lib.sh
@@ -180,9 +180,32 @@ fm_composer_idle_matches() {
   esac
 }
 
+# Normalize every non-ASCII code point in Unicode's White_Space property to an
+# ASCII space, then trim the result.
+# Bash's locale-sensitive [[:space:]] does not consistently include these code
+# points, including U+00A0 NO-BREAK SPACE in the live Claude idle composer.
+# Normalizing inside the shared classifier keeps tmux, Herdr, Orca, and cmux on
+# one verdict without weakening non-whitespace content checks.
+fm_composer_trim_whitespace() {  # <content>
+  local content=$1 whitespace LC_ALL=C
+  for whitespace in \
+    $'\302\205' $'\302\240' $'\341\232\200' \
+    $'\342\200\200' $'\342\200\201' $'\342\200\202' $'\342\200\203' \
+    $'\342\200\204' $'\342\200\205' $'\342\200\206' $'\342\200\207' \
+    $'\342\200\210' $'\342\200\211' $'\342\200\212' $'\342\200\250' \
+    $'\342\200\251' $'\342\200\257' $'\342\201\237' $'\343\200\200'; do
+    content=${content//"$whitespace"/ }
+  done
+  content="${content#"${content%%[![:space:]]*}"}"
+  content="${content%"${content##*[![:space:]]}"}"
+  printf '%s' "$content"
+}
+
 fm_composer_classify_content() {  # <bordered> <content> [idle_re] [idle_case] [plain_content]
   local bordered=$1 content=$2 idle_re=${3:-} idle_case=${4:-sensitive} plain_content
   plain_content=${5:-$content}
+  content=$(fm_composer_trim_whitespace "$content")
+  plain_content=$(fm_composer_trim_whitespace "$plain_content")
   if [ "$bordered" != 1 ] && [ -z "$content" ] && [ -n "$plain_content" ]; then
     case "$plain_content" in
       '❯'|'›') printf 'empty'; return 0 ;;
@@ -211,8 +234,7 @@ fm_composer_classify_content() {  # <bordered> <content> [idle_re] [idle_case] [
     '❯ '*|'› '*|'> '*|'$ '*|'% '*|'# '*) content=${content#??} ;;
     '❯'*|'›'*|'>'*|'$'*|'%'*|'#'*) content=${content#?} ;;
   esac
-  content="${content#"${content%%[![:space:]]*}"}"
-  content="${content%"${content##*[![:space:]]}"}"
+  content=$(fm_composer_trim_whitespace "$content")
   [ -n "$content" ] || { printf 'empty'; return 0; }
   # Known idle placeholder (matched again after the leading glyph was stripped,
   # e.g. "❯ Type a message...").

--- a/bin/fm-supervise-daemon.sh
+++ b/bin/fm-supervise-daemon.sh
@@ -580,16 +580,26 @@ fm_daemon_primary_harness() {
   printf '%s' "$FM_DAEMON_PRIMARY_HARNESS"
 }
 
-pane_is_busy() {  # <target> [backend]
-  local target=$1 backend=${2:-tmux} native tail40 harness
+pane_busy_observation() {  # <target> [backend]
+  local target=$1 backend=${2:-tmux} native tail40 harness rendered=idle
   harness=$(fm_daemon_primary_harness)
   native=$(fm_backend_busy_state "$backend" "$target" 2>/dev/null)
   case "$native" in
-    busy) return 0 ;;
+    busy) printf 'harness=%s native=busy rendered=not-read' "$harness"; return 0 ;;
   esac
-  tail40=$(fm_backend_capture "$backend" "$target" 40 2>/dev/null) || return 1
-  printf '%s' "$tail40" | grep -v '^[[:space:]]*$' | tail -12 \
-    | fm_busy_lines_match "$harness"
+  if ! tail40=$(fm_backend_capture "$backend" "$target" 40 2>/dev/null); then
+    printf 'harness=%s native=%s rendered=capture-failed' "$harness" "${native:-unknown}"
+    return 1
+  fi
+  if printf '%s' "$tail40" | grep -v '^[[:space:]]*$' | tail -12 | fm_busy_lines_match "$harness"; then
+    rendered=busy
+  fi
+  printf 'harness=%s native=%s rendered=%s' "$harness" "${native:-unknown}" "$rendered"
+  [ "$rendered" = busy ]
+}
+
+pane_is_busy() {  # <target> [backend]
+  pane_busy_observation "$@" >/dev/null
 }
 
 # pane_input_pending dispatches through fm_backend_composer_state and treats
@@ -922,7 +932,7 @@ inject_wedge_alarm() {  # <state> <age-seconds>
     # Keep the status overlay visible until the next rate-limited alarm refresh.
     # Unlike wall or terminal output, display-message never writes into an agent
     # pane or its composer.
-    display_ms=$((max_defer * 1000))
+    display_ms=$(((max_defer + ${FM_HOUSEKEEPING_TICK:-$HOUSEKEEPING_TICK_DEFAULT} + 1) * 1000))
     tmux display-message -d "$display_ms" -t "$target" \
       "fm: away-mode escalations WEDGED ${age}s - see $marker" 2>/dev/null || true
   fi
@@ -1117,12 +1127,12 @@ window_for_task() {  # <task-key> [state]
 #     line, or a previous injection's unsent text), defer entirely - injecting
 #     would merge with the human's text.
 inject_msg() {  # <message> [state]
-  local msg=$1 state target backend retries sleep_s verdict composer encoded
+  local msg=$1 state target backend retries sleep_s verdict composer encoded busy_observation override_set=no
   state="${2:-$(_state_root)}"
   # (1) Presence-gate: inject ONLY when afk is active. When afk is off, the
   # daemon self-handles and stays quiet; firstmate drives the normal always-on
   # watcher triage. Escalations buffer and survive for the next catch-up flush.
-  afk_active "$state" || { log "inject deferred: afk inactive"; return 1; }
+  afk_active "$state" || { log "inject deferred: gate=presence verdict=afk-inactive"; return 1; }
   # (2) Single-line digest: collapse any embedded newlines so submission via
   # send-keys + Enter is unambiguous regardless of how the TUI composer treats
   # them. Then use the canonical typed envelope so downstream consumers retain
@@ -1137,10 +1147,14 @@ inject_msg() {  # <message> [state]
   # when unset (sourced/test contexts that never ran fm_super_main's startup
   # discovery), matching this function's pre-existing default assumption.
   backend="${FM_SUPERVISOR_BACKEND:-tmux}"
-  fm_backend_target_exists "$backend" "$target" || return 1
+  if ! fm_backend_target_exists "$backend" "$target"; then
+    log "inject deferred: gate=target backend=$backend verdict=missing"
+    return 1
+  fi
   # (3) Busy-guard: never inject into an in-use supervisor pane.
-  if pane_is_busy "$target" "$backend"; then
-    log "inject deferred: supervisor pane busy (agent mid-turn)"
+  busy_observation=$(pane_busy_observation "$target" "$backend")
+  if [ $? -eq 0 ]; then
+    log "inject deferred: gate=busy backend=$backend $busy_observation"
     return 1
   fi
   #   b) Composer-guard: inject ONLY into a confirmed-empty GENUINE agent
@@ -1153,8 +1167,9 @@ inject_msg() {  # <message> [state]
   #      on anything that is not affirmatively 'empty'. A deferred escalation
   #      stays buffered for the next cycle or the catch-up flush.
   composer=$(fm_backend_composer_state "$backend" "$target" 2>/dev/null)
+  [ -n "${FM_COMPOSER_IDLE_RE+x}" ] && override_set=yes
   if [ "$composer" != empty ]; then
-    log "inject deferred: supervisor composer not confirmed-empty (state=${composer:-unknown}: pending input, dead-shell prompt, or unreadable pane)"
+    log "inject deferred: gate=composer backend=$backend $busy_observation verdict=${composer:-unknown} idle_override=$override_set"
     return 1
   fi
   # (4) Type the digest ONCE, then submit with Enter (retry Enter only, never
@@ -1170,7 +1185,7 @@ inject_msg() {  # <message> [state]
   if [ "$verdict" = empty ]; then
     return 0  # Backend confirmed the submit.
   fi
-  log "inject failed: submit unconfirmed after $retries retries (verdict=$verdict, text may be in composer)"
+  log "inject failed: gate=submit-ack backend=$backend $busy_observation composer=empty idle_override=$override_set verdict=${verdict:-unknown} retries=$retries text_may_be_in_composer=yes"
   return 1
 }
 

--- a/bin/fm-supervise-daemon.sh
+++ b/bin/fm-supervise-daemon.sh
@@ -109,9 +109,9 @@
 #                                   active-alert directive for that wedge alarm
 #                                   (off|auto|osascript|herdr|command:<cmd>). An
 #                                   absent file/var means auto: on macOS that is
-#                                   an OS-level notification, so the alarm is
-#                                   never silent. See wedge_alarm_notify below
-#                                   and docs/configuration.md.
+#                                   an OS-level notification. See
+#                                   wedge_alarm_notify below and
+#                                   docs/configuration.md.
 #          FM_WEDGE_ALARM_EXEC      notifier seam: when set, every notifier
 #                                   channel routes through this command as
 #                                   `<cmd> <channel> <summary>` instead of
@@ -655,8 +655,8 @@ escalate_flush() {  # <state>
 }
 
 # --- backend-independent active wedge alert ---------------------------------
-# The tmux status-line flash in inject_wedge_alarm below is a cosmetic,
-# client-side OSD with no cross-backend equivalent, so a wedged non-tmux primary
+# The tmux status overlay in inject_wedge_alarm below is an on-host signal with
+# no cross-backend equivalent, so a wedged non-tmux primary
 # (the 2026-07-10 overnight incident: a claude-on-herdr primary) got NO active
 # signal - only the passive state/.subsuper-inject-wedged marker, which nothing
 # surfaces until the next fleet action (that night, 20 escalations sat buffered
@@ -665,13 +665,13 @@ escalate_flush() {  # <state>
 # herdr notification, or a captain-supplied command (push to a phone, etc.).
 # Every channel is best-effort - a missing or failing channel logs and is
 # skipped, never crashing the daemon loop - and the durable marker plus the tmux
-# flash stay exactly as before.
+# overlay stay available on the tmux path.
 #
 # Config: config/wedge-alarm (local, gitignored), one channel directive per
 # non-empty, non-comment line. FM_WEDGE_ALARM_CHANNEL overrides the file with a
 # single directive. Directives:
 #   off              disable the active alert entirely, regardless of position
-#                    (marker + flash remain)
+#                    (marker + tmux overlay remain)
 #   auto | default   platform default: macOS -> osascript; otherwise none
 #   osascript        macOS Notification Center banner (backend-independent)
 #   herdr            herdr UI notification (herdr notification show)
@@ -703,10 +703,10 @@ wedge_alarm_configured_channels() {
   [ -n "$found" ] || printf 'auto\n'
 }
 
-# Resolve the platform's default OS-level channel for `auto`. macOS reaches the
-# captain via an osascript Notification Center banner; other platforms have no
-# built-in OS channel (the captain wires a command: directive), so this prints
-# nothing and wedge_alarm_notify logs that the marker is the only signal.
+# Resolve the platform's default OS-level channel for `auto`.
+# macOS reaches the captain via an osascript Notification Center banner.
+# Other platforms have no built-in out-of-band channel, so this prints nothing
+# and wedge_alarm_notify logs that the marker is the only signal.
 wedge_alarm_platform_default() {
   case "$(uname)" in
     Darwin) command -v osascript >/dev/null 2>&1 && printf 'osascript' ;;
@@ -893,7 +893,7 @@ wedge_alarm_notify() {  # <summary> <marker>
 # is lost - the buffer and the
 # wake-queue both survive - but the stall stops being invisible.
 inject_wedge_alarm() {  # <state> <age-seconds>
-  local state=$1 age=$2 marker target backend max_defer now notify=1
+  local state=$1 age=$2 marker target backend max_defer display_ms now notify=1
   marker="$state/.subsuper-inject-wedged"
   max_defer="${FM_MAX_DEFER_SECS:-$MAX_DEFER_SECS_DEFAULT}"
   # Re-alarm at most once per max-defer window so a long wedge does not spam.
@@ -914,14 +914,19 @@ inject_wedge_alarm() {  # <state> <age-seconds>
   } 2>/dev/null > "$marker" || true
   target="${FM_SUPERVISOR_TARGET:-$FM_SUPERVISOR_TARGET_DEFAULT}"
   backend="${FM_SUPERVISOR_BACKEND:-$FM_SUPERVISOR_BACKEND_DEFAULT}"
-  # Best-effort status-line flash. tmux's display-message is a client-side OSD
-  # with no herdr equivalent; the log line + durable marker above are already
-  # the primary, backend-independent signal, so a non-tmux backend just skips
-  # this cosmetic extra rather than attempting an unsupported call.
+  # Best-effort persistent status overlay.
+  # tmux has no out-of-band alert channel, but this on-host signal stays visible
+  # until the next rate-limited refresh.
+  # A non-tmux backend skips it because there is no equivalent primitive.
   if [ "$backend" = tmux ]; then
-    tmux display-message -t "$target" "fm: away-mode escalations WEDGED ${age}s — see $marker" 2>/dev/null || true
+    # Keep the status overlay visible until the next rate-limited alarm refresh.
+    # Unlike wall or terminal output, display-message never writes into an agent
+    # pane or its composer.
+    display_ms=$((max_defer * 1000))
+    tmux display-message -d "$display_ms" -t "$target" \
+      "fm: away-mode escalations WEDGED ${age}s - see $marker" 2>/dev/null || true
   fi
-  # Backend-independent active alert. Unlike the tmux flash above (skipped on
+  # Backend-independent active alert. Unlike the tmux overlay above (skipped on
   # every non-tmux backend), this can reach the captain even when every pane and
   # its backend status-line is unreadable - the gap the 2026-07-10 overnight
   # incident fell through. Configurable and best-effort; the marker above stays

--- a/bin/fm-supervise-daemon.sh
+++ b/bin/fm-supervise-daemon.sh
@@ -598,8 +598,13 @@ pane_busy_observation() {  # <target> [backend]
   [ "$rendered" = busy ]
 }
 
+PANE_BUSY_OBSERVATION=
 pane_is_busy() {  # <target> [backend]
-  pane_busy_observation "$@" >/dev/null
+  local observation status
+  observation=$(pane_busy_observation "$@")
+  status=$?
+  PANE_BUSY_OBSERVATION=$observation
+  return "$status"
 }
 
 # pane_input_pending dispatches through fm_backend_composer_state and treats
@@ -1152,11 +1157,13 @@ inject_msg() {  # <message> [state]
     return 1
   fi
   # (3) Busy-guard: never inject into an in-use supervisor pane.
-  busy_observation=$(pane_busy_observation "$target" "$backend")
-  if [ $? -eq 0 ]; then
+  PANE_BUSY_OBSERVATION=
+  if pane_is_busy "$target" "$backend"; then
+    busy_observation=${PANE_BUSY_OBSERVATION:-harness=unknown native=unknown rendered=busy}
     log "inject deferred: gate=busy backend=$backend $busy_observation"
     return 1
   fi
+  busy_observation=${PANE_BUSY_OBSERVATION:-harness=unknown native=unknown rendered=idle}
   #   b) Composer-guard: inject ONLY into a confirmed-empty GENUINE agent
   #      composer. The shared classifier (fm_backend_composer_state ->
   #      fm_composer_classify_content, bin/fm-composer-lib.sh) reports 'pending'

--- a/bin/fm-tmux-lib.sh
+++ b/bin/fm-tmux-lib.sh
@@ -66,8 +66,9 @@
 # shellcheck source=bin/fm-composer-lib.sh
 . "$(dirname -- "${BASH_SOURCE[0]}")/fm-composer-lib.sh"
 
-# Delivery-only rendered busy footers per harness. claude/codex: "esc to
-# interrupt"; opencode: "esc interrupt"; pi: "Working..."; grok: "Ctrl+c:cancel".
+# Delivery-only rendered busy signatures per harness.
+# Claude uses its elapsed spinner because its idle footer also says "esc to interrupt".
+# Codex uses "esc to interrupt"; opencode uses "esc interrupt"; Pi uses "Working..."; Grok uses "Ctrl+c:cancel".
 # Claude's current spinner has a rotating glyph and word, but every active-turn
 # line has an ellipsis followed by a parenthesized elapsed duration. Keep this
 # signature separate from the shared default because that shape is not generic
@@ -83,7 +84,7 @@
 # The full moon-phase set remains locale- and emoji-font-sensitive because Kimi
 # exposes no stable ASCII busy token.
 FM_TMUX_BUSY_REGEX_DEFAULT='esc (to )?interrupt|Working\.\.\.|Ctrl\+c:cancel'
-FM_TMUX_CLAUDE_BUSY_REGEX_DEFAULT='esc to interrupt|…[[:space:]]+\([0-9]+[smh]'
+FM_TMUX_CLAUDE_BUSY_REGEX_DEFAULT='…[[:space:]]+\([0-9]+[smh]'
 FM_TMUX_CODEX_BUSY_REGEX_DEFAULT='esc to interrupt'
 FM_TMUX_OPENCODE_BUSY_REGEX_DEFAULT='esc interrupt'
 FM_TMUX_PI_BUSY_REGEX_DEFAULT='Working\.\.\.'

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -108,13 +108,9 @@ Selecting any other supervisor backend, including `zellij`, `orca`, or `cmux`, r
 ## Away-mode wedge alarm channels (config/wedge-alarm)
 
 When away-mode injection wedges past `FM_MAX_DEFER_SECS`, the sub-supervisor raises a loud, rate-limited alarm.
-Beyond the durable `state/.subsuper-inject-wedged` marker and the tmux status-line flash, it attempts a configured backend-independent active alert that can reach the captain even when every pane and its backend status-line is unreadable.
-`config/wedge-alarm` (local, gitignored) lists channel directives, one per non-empty, non-comment line; every listed non-`off` channel fires, best-effort.
-`FM_WEDGE_ALARM_CHANNEL` overrides the file with a single directive.
-Directives are `off` (a position-independent kill switch that disables every active alert), `auto`/`default`, `osascript` (macOS Notification Center banner), `herdr` (herdr UI notification), and `command:<cmd>` (run `<cmd>` via `sh -c`, summary on `$1` and stdin).
-An absent file means `auto`, i.e. default-on on macOS: the alarm exists precisely so a wedged away-mode primary is never silent, and it fires at most once per max-defer window after a genuine wedge.
-A missing or failing channel logs and falls through to the next, never crashing the daemon.
-See [`wedge-alarm.md`](wedge-alarm.md) for the current channel reference, [`verification/supervision.md`](verification/supervision.md#wedge-alarm-channels) for active evidence, and [`examples/wedge-alarm`](examples/wedge-alarm) for a copyable config.
+`config/wedge-alarm` is local and gitignored, and `FM_WEDGE_ALARM_CHANNEL` overrides it for focused operation or testing.
+[`wedge-alarm.md`](wedge-alarm.md) owns the channel directives, platform defaults, delivery timing, and failure behavior.
+[`verification/supervision.md`](verification/supervision.md#wedge-alarm-channels) records active evidence, and [`examples/wedge-alarm`](examples/wedge-alarm) is the copyable config.
 
 ## Gate defaults (.no-mistakes.yaml)
 
@@ -551,9 +547,9 @@ FM_SUPERVISOR_TARGET=              # optional supervisor pane target override; t
 FM_INJECT_SKIP=heartbeat           # |-prefixes force-self-handled bypassing classification; empty disables
 FM_ESCALATE_BATCH_SECS=90          # buffer window for batched escalation digests; 0 = flush immediately
 FM_MAX_DEFER_SECS=300              # max buffered escalation age before retry plus wedge alarm; 0 disables
-FM_WEDGE_ALARM_CHANNEL=            # override config/wedge-alarm with one active-alert directive for the wedge alarm; off|auto|osascript|herdr|command:<cmd>; absent = auto (macOS -> an OS notification)
-FM_WEDGE_ALARM_EXEC=              # notifier seam: route every channel (osascript, herdr, command:) through this command as `<cmd> <channel> <summary>`; "discard" fires nothing; unset in production; the daemon defaults it to "discard" when sourced so no test posts a real notification (docs/wedge-alarm.md)
-FM_WEDGE_ALARM_TIMEOUT_SECS=10    # maximum seconds for each osascript, herdr, override, or command: notifier before its watchdog terminates it and continues to the next channel; invalid or zero values use 10
+FM_WEDGE_ALARM_CHANNEL=            # override config/wedge-alarm with one active-alert directive; see docs/wedge-alarm.md
+FM_WEDGE_ALARM_EXEC=              # test-only notifier seam; see docs/wedge-alarm.md
+FM_WEDGE_ALARM_TIMEOUT_SECS=10    # maximum notifier runtime before fallback; see docs/wedge-alarm.md
 FM_INJECT_FAIL_SLEEP=30            # seconds to back off when the supervisor pane is unavailable
 FM_INJECT_CONFIRM_RETRIES=3        # daemon Enter-retry attempts after typing a digest once
 FM_INJECT_CONFIRM_SLEEP=0.5        # seconds between daemon submit checks

--- a/docs/examples/wedge-alarm
+++ b/docs/examples/wedge-alarm
@@ -5,16 +5,16 @@
 #
 # Directives:
 #   off              position-independent kill switch: disable every active
-#                    alert (the durable marker and tmux status-line flash remain)
+#                    alert (the durable marker and tmux status overlay remain)
 #   auto | default   platform default: macOS -> osascript; other platforms have
-#                    no built-in OS channel (configure a command: line instead)
+#                    no built-in out-of-band channel
 #   osascript        macOS Notification Center banner (backend-independent)
 #   herdr            herdr UI notification (herdr notification show)
 #   command:<cmd>    run <cmd> via `sh -c`; the alarm summary is passed as $1 and
 #                    on stdin, so it can reach a phone/pager while you are away
 #
-# An ABSENT config/wedge-alarm behaves as `auto` (default-on on macOS): the
-# alarm exists precisely so a wedged away-mode primary is never silent.
+# An ABSENT config/wedge-alarm behaves as `auto` on macOS when osascript is
+# installed.
 #
 # Example: a macOS banner plus a push to a phone via ntfy.sh, so a wedge that
 # happens overnight reaches you even away from the machine.

--- a/docs/verification/supervision.md
+++ b/docs/verification/supervision.md
@@ -250,6 +250,7 @@ The live idle Claude row and public classifier were read with:
 ```sh
 claude --version
 tmux -V
+wall --version | head -1
 cy=$(tmux display-message -p -t %0 '#{cursor_y}')
 tmux capture-pane -p -t %0 -S "$cy" -E "$cy" | od -An -t u1
 (. bin/fm-backend.sh; fm_backend_composer_state tmux %0)
@@ -260,6 +261,7 @@ Exact output:
 ```text
 2.1.222 (Claude Code)
 tmux 3.4
+wall from util-linux 2.39.3
  226 157 175 194 160  10
 empty
 ```

--- a/docs/verification/supervision.md
+++ b/docs/verification/supervision.md
@@ -267,6 +267,8 @@ empty
 The bytes are U+276F followed by U+00A0 and a newline.
 The shared classifier now normalizes every non-ASCII code point in Unicode's `White_Space` property before deciding emptiness.
 Real text after Unicode whitespace remains `pending`, a bare shell prompt followed by Unicode whitespace remains `unknown`, and ghost-only text remains `empty`.
+Before the fix, the exact U+276F plus U+00A0 empty-row regression returned `pending` instead of `empty`, and the NBSP bare-shell precision check returned `pending` instead of `unknown`.
+The pre-fix real-text safety control already returned `pending`, and the pre-fix ghost safety control already returned `empty`; neither control failed before the fix.
 
 Claude and Codex reach the shared classifier from their bare prompt rows on tmux and Herdr.
 OpenCode and Kimi reach it from bordered `>` composers.

--- a/docs/verification/supervision.md
+++ b/docs/verification/supervision.md
@@ -334,10 +334,30 @@ Exact output:
 %58	probe_hits=0	composer=empty
 ```
 
-The production tmux overlay lasts one full `FM_MAX_DEFER_SECS` interval and refreshes on the next alarm.
+The production tmux overlay lasts through `FM_MAX_DEFER_SECS`, the following housekeeping interval, and one additional second of scheduling slack, then refreshes on the next alarm.
 At defaults, a future unpredicted false `pending` therefore costs at most 315 seconds, or 5.25 minutes, before a persistent on-host warning appears.
 This Linux host has no verified default off-host alert, so remote notification still requires an explicit `command:` channel.
 Content stability does not authorize forced injection because a real half-typed line can remain byte-identical indefinitely.
+
+A 2026-08-05 live incident left an away digest buffered for 1558 seconds while each daemon retry passed the rendered busy guard and then reported `composer=pending` despite the same daemon environment's `FM_COMPOSER_IDLE_RE` and a direct public classifier call both reporting `empty`.
+Claude Code 2.1.221 also rendered `esc to interrupt` while idle, so Claude's delivery-only busy guard now relies on its live-verified elapsed spinner instead of that ambiguous footer.
+Each delivery defer now records its exact gate, backend, detected harness, native and rendered busy verdicts, composer verdict, idle-override presence, or post-submit acknowledgement without recording composer content.
+Busy detection remains independent of `FM_COMPOSER_IDLE_RE`; the override applies only to the inject-time composer proof and the post-submit acknowledgement.
+
+The real-tmux delivery path is exercised with:
+
+```sh
+bin/fm-test-run.sh tests/fm-daemon.test.sh | grep -F 'real tmux away delivery'
+```
+
+Exact output:
+
+```text
+ok - real tmux away delivery handles exact Claude bytes, safety guards, busy state, and idle overrides
+```
+
+The disposable pane renders the captured octal bytes `342 235 257 302 240`, followed by Claude's idle `esc to interrupt` footer, then reads the submitted operational digest.
+The same public `escalate_add` and `escalate_flush` path proves the digest reaches the pane and clears the buffer, while a half-typed line and bare shell prompt remain byte-identical, an elapsed Claude spinner remains busy, and `FM_COMPOSER_IDLE_RE` governs both composer checks around submission.
 
 The two real notification channels were bounded manually on 2026-07-10 on macOS 26.5.2 with Herdr 0.7.3.
 Automated suites never execute these real notification commands.

--- a/docs/verification/supervision.md
+++ b/docs/verification/supervision.md
@@ -243,6 +243,102 @@ tests/fm-turnend-guard.test.sh
 
 ## Wedge-alarm channels
 
+Unicode composer whitespace and the Linux on-host wedge path were verified on 2026-08-05 with Claude Code 2.1.222, tmux 3.4, and util-linux 2.39.3 on Linux.
+
+The live idle Claude row and public classifier were read with:
+
+```sh
+claude --version
+tmux -V
+cy=$(tmux display-message -p -t %0 '#{cursor_y}')
+tmux capture-pane -p -t %0 -S "$cy" -E "$cy" | od -An -t u1
+(. bin/fm-backend.sh; fm_backend_composer_state tmux %0)
+```
+
+Exact output:
+
+```text
+2.1.222 (Claude Code)
+tmux 3.4
+ 226 157 175 194 160  10
+empty
+```
+
+The bytes are U+276F followed by U+00A0 and a newline.
+The shared classifier now normalizes every non-ASCII code point in Unicode's `White_Space` property before deciding emptiness.
+Real text after Unicode whitespace remains `pending`, a bare shell prompt followed by Unicode whitespace remains `unknown`, and ghost-only text remains `empty`.
+
+Claude and Codex reach the shared classifier from their bare prompt rows on tmux and Herdr.
+OpenCode and Kimi reach it from bordered `>` composers.
+Pi and pi-signed share the Pi renderer and reach it from bordered tmux composers or Herdr's identity-corroborated separator structure.
+Grok reaches it from its bordered prompt after dark truecolor placeholder removal.
+All seven tmux harness names are exercised by `tests/fm-composer-ghost.test.sh`, and the Herdr public dispatch is exercised by `tests/fm-backend-herdr.test.sh` with the exact U+276F plus U+00A0 regression and both safety controls.
+
+The focused suites ran with:
+
+```sh
+bin/fm-test-run.sh tests/fm-composer-ghost.test.sh tests/fm-backend-herdr.test.sh tests/fm-daemon.test.sh | grep -E '^FM_TEST_(END|SUMMARY)'
+```
+
+Exact summary:
+
+```text
+FM_TEST_END 2026-08-05T22:58:29Z tests/fm-composer-ghost.test.sh exit=0 duration_ms=4257 gate_skip=false
+FM_TEST_END 2026-08-05T22:58:55Z tests/fm-backend-herdr.test.sh exit=0 duration_ms=25477 gate_skip=false
+FM_TEST_END 2026-08-05T22:59:14Z tests/fm-daemon.test.sh exit=0 duration_ms=19668 gate_skip=false
+FM_TEST_SUMMARY total=3 failed=0 skipped_gate=0 duration_ms=49557
+FM_TEST_SUMMARY_FAMILY family=backend-dispatch count=1 duration_ms=25477 failed=0
+FM_TEST_SUMMARY_FAMILY family=pure-contract-unit count=1 duration_ms=4257 failed=0
+FM_TEST_SUMMARY_FAMILY family=watcher-wake-lock count=1 duration_ms=19668 failed=0
+```
+
+`wall` was tested and rejected as a Linux alarm channel because its message entered live agent panes.
+
+```sh
+probe='FIRSTMATE_HARMLESS_WALL_PROBE_20260805T2250Z'
+printf '%s\n' "$probe" | wall
+sleep 1
+for pane in $(tmux list-panes -a -F '#{pane_id}'); do
+  command_name=$(tmux display-message -p -t "$pane" '#{pane_current_command}')
+  cursor_y=$(tmux display-message -p -t "$pane" '#{cursor_y}')
+  hits=$(tmux capture-pane -p -J -t "$pane" -S -20 | grep -cF "$probe" || true)
+  composer=$(. bin/fm-backend.sh; fm_backend_composer_state tmux "$pane")
+  printf '%s\tcommand=%s\tcursor=%s\tprobe_hits=%s\tcomposer=%s\n' "$pane" "$command_name" "$cursor_y" "$hits" "$composer"
+done
+```
+
+Exact relevant output:
+
+```text
+%58	command=claude	cursor=49	probe_hits=1	composer=empty
+%0	command=claude	cursor=49	probe_hits=1	composer=empty
+```
+
+The same probe through a three-second tmux status overlay did not enter either pane and preserved both empty composers:
+
+```sh
+probe='FIRSTMATE_HARMLESS_TMUX_STATUS_PROBE_20260805T2251Z'
+tmux display-message -d 3000 -t %0 "$probe"
+sleep 1
+for pane in %0 %58; do
+  hits=$(tmux capture-pane -p -J -t "$pane" -S -20 | grep -cF "$probe" || true)
+  composer=$(. bin/fm-backend.sh; fm_backend_composer_state tmux "$pane")
+  printf '%s\tprobe_hits=%s\tcomposer=%s\n' "$pane" "$hits" "$composer"
+done
+```
+
+Exact output:
+
+```text
+%0	probe_hits=0	composer=empty
+%58	probe_hits=0	composer=empty
+```
+
+The production tmux overlay lasts one full `FM_MAX_DEFER_SECS` interval and refreshes on the next alarm.
+At defaults, a future unpredicted false `pending` therefore costs at most 315 seconds, or 5.25 minutes, before a persistent on-host warning appears.
+This Linux host has no verified default off-host alert, so remote notification still requires an explicit `command:` channel.
+Content stability does not authorize forced injection because a real half-typed line can remain byte-identical indefinitely.
+
 The two real notification channels were bounded manually on 2026-07-10 on macOS 26.5.2 with Herdr 0.7.3.
 Automated suites never execute these real notification commands.
 

--- a/docs/wedge-alarm.md
+++ b/docs/wedge-alarm.md
@@ -43,4 +43,4 @@ When the daemon is sourced as a library, that seam defaults to `discard`, so a t
 Production leaves the seam unset and uses the configured real channels.
 
 `tests/fm-daemon.test.sh` covers directive parsing, rate limiting, timeout and process-group cleanup, argv-safe dispatch, channel fallback, and safe `command:` summary delivery.
-[`verification/supervision.md`](verification/supervision.md#wedge-alarm-channels) records the bounded manual macOS and Herdr channel proof.
+[`verification/supervision.md`](verification/supervision.md#wedge-alarm-channels) records the active classifier, tmux-overlay, and notification-channel evidence.

--- a/docs/wedge-alarm.md
+++ b/docs/wedge-alarm.md
@@ -2,8 +2,8 @@
 
 The away-mode sub-supervisor (`bin/fm-supervise-daemon.sh`) buffers escalations and injects them into Firstmate's own pane.
 When injection cannot confirm a submit past `FM_MAX_DEFER_SECS`, `inject_wedge_alarm` raises a loud, rate-limited alarm so the stall never stays invisible.
-The active alert is pane-independent because a tmux status-line flash has no cross-backend equivalent and cannot reach an unattended captain reliably.
-The durable marker and tmux flash remain as additional signals.
+Configured active alerts are pane-independent because a tmux status overlay has no cross-backend equivalent and cannot reach an unattended captain off-host.
+On tmux, the durable marker and status overlay remain additional on-host signals.
 
 ## Channels
 
@@ -11,15 +11,22 @@ The durable marker and tmux flash remain as additional signals.
 It lists channel directives, one per non-empty, non-comment line, and every listed non-`off` channel fires best-effort.
 `FM_WEDGE_ALARM_CHANNEL` overrides the file with one directive for focused testing.
 
-- `off` disables every active alert while retaining the durable marker and tmux flash.
+- `off` disables every active alert while retaining the durable marker and tmux status overlay.
 - `auto` or `default` resolves to `osascript` on macOS.
-  Other platforms have no built-in OS channel, so configure `command:` when a durable marker alone is insufficient.
+  Other platforms have no built-in out-of-band channel, so configure `command:` when one is available.
 - `osascript` posts a macOS Notification Center banner outside the terminal pane.
 - `herdr` calls `herdr notification show` outside the supervised pane.
 - `command:<cmd>` runs `<cmd>` through `sh -c` with the alarm summary as `$1` and on stdin, allowing delivery to a phone or pager service.
 
 An absent `config/wedge-alarm` behaves as `auto`, which is default-on on macOS.
 This is deliberate because the alarm fires only after a genuine max-defer wedge and is rate-limited to at most once per max-defer window.
+
+The max-defer escape never force-injects over byte-stable `pending` content.
+A real half-typed human line can remain byte-identical indefinitely, so content stability cannot safely distinguish it from a future classifier fault.
+With the default 300-second max defer and 15-second housekeeping tick, an unpredicted false `pending` reaches the tmux status overlay within 315 seconds while the buffered digest remains preserved.
+The overlay remains visible for the full max-defer interval and is refreshed at the next alarm, so it does not disappear between checks.
+Linux hosts have no reliable default off-host notification channel, and operators who need one must configure `command:`.
+`wall` is intentionally not a channel because it writes into logged-in agent terminals and can corrupt or confuse their displays.
 
 Each channel is best-effort.
 A missing binary or non-zero exit logs a warning and continues to the next channel without crashing the daemon loop.

--- a/docs/wedge-alarm.md
+++ b/docs/wedge-alarm.md
@@ -24,7 +24,7 @@ This is deliberate because the alarm fires only after a genuine max-defer wedge 
 The max-defer escape never force-injects over byte-stable `pending` content.
 A real half-typed human line can remain byte-identical indefinitely, so content stability cannot safely distinguish it from a future classifier fault.
 With the default 300-second max defer and 15-second housekeeping tick, an unpredicted false `pending` reaches the tmux status overlay within 315 seconds while the buffered digest remains preserved.
-The overlay remains visible for the full max-defer interval and is refreshed at the next alarm, so it does not disappear between checks.
+The overlay duration includes one housekeeping interval plus one second of scheduling slack beyond max-defer, and it is refreshed at the next alarm, so it does not disappear between checks.
 Linux hosts have no reliable default off-host notification channel, and operators who need one must configure `command:`.
 `wall` is intentionally not a channel because it writes into logged-in agent terminals and can corrupt or confuse their displays.
 

--- a/tests/fm-backend-herdr.test.sh
+++ b/tests/fm-backend-herdr.test.sh
@@ -2672,6 +2672,31 @@ test_composer_state_real_text_is_pending() {
   pass "fm_backend_herdr_composer_state: real composer text reads pending"
 }
 
+test_composer_state_unicode_whitespace_through_public_interface() {
+  local dir log resp fb out
+  dir="$TMP_ROOT/composer-unicode-whitespace"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
+  printf '\xe2\x9d\xaf\xc2\xa0\n' > "$resp/1.out"
+  printf '\xe2\x9d\xaf\xc2\xa0deploy\n' > "$resp/2.out"
+  printf '$\xc2\xa0\n' > "$resp/3.out"
+  fb=$(make_herdr_fakebin "$dir")
+
+  out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
+    bash -c '. "$0/bin/fm-backend.sh"; fm_backend_composer_state herdr default:w1:p2' "$ROOT" )
+  [ "$out" = empty ] \
+    || fail "Claude's exact U+276F + U+00A0 idle row should be empty through Herdr, got '$out'"
+
+  out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
+    bash -c '. "$0/bin/fm-backend.sh"; fm_backend_composer_state herdr default:w1:p2' "$ROOT" )
+  [ "$out" = pending ] \
+    || fail "real Herdr text after U+00A0 must stay pending, got '$out'"
+
+  out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
+    bash -c '. "$0/bin/fm-backend.sh"; fm_backend_composer_state herdr default:w1:p2' "$ROOT" )
+  [ "$out" = unknown ] \
+    || fail "a Herdr bare shell prompt followed by U+00A0 must stay unknown, got '$out'"
+  pass "fm_backend_composer_state (herdr): Unicode whitespace preserves empty, pending, and dead-shell verdicts"
+}
+
 # Live-verified incident (2026-07-03, real grok 0.2.82 on herdr, isolated
 # session): typing "/compact" opens the completion popup; the FIRST Enter
 # closes the popup and EXPANDS the composer into an argument-hint placeholder
@@ -3960,6 +3985,7 @@ test_busy_state_unknown_on_no_agent
 test_composer_state_bare_prompt_is_empty
 test_composer_state_ghost_placeholder_is_empty
 test_composer_state_real_text_is_pending
+test_composer_state_unicode_whitespace_through_public_interface
 test_composer_state_popup_placeholder_fill_is_pending
 test_composer_state_unknown_on_capture_failure
 test_composer_state_unknown_when_no_composer_row_found

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -269,6 +269,14 @@ test_no_mistakes_dod_wording() {
     "no-mistakes DOD must keep direct requirements and exclude generic scaffold boilerplate from --intent"
   assert_grep "exclude generic operational, status, delivery, and other scaffold boilerplate unless it is task-specific" "$brief" \
     "no-mistakes DOD must exclude non-task-specific scaffold boilerplate from --intent"
+  assert_grep "After committing the implementation, invoke /no-mistakes yourself to validate and ship the PR." "$brief" \
+    "no-mistakes DOD must require the worker to start its own validation run"
+  assert_grep "Do not append \`done:\` or end your turn merely because the pipeline is running." "$brief" \
+    "no-mistakes DOD must forbid ending the turn while the pipeline is active"
+  assert_grep "Poll the run's own status and keep driving it until it reaches a gate that requires firstmate or a terminal outcome." "$brief" \
+    "no-mistakes DOD must require polling through a gate or terminal outcome"
+  assert_grep '"Waiting for the next decision point" is not a valid resting state while the run is active.' "$brief" \
+    "no-mistakes DOD must reject waiting for a decision while the pipeline runs"
   # The apostrophe in "firstmate's authority check" is now structurally safe
   # (no `$(...)` wrapper around the heredoc), so it renders verbatim instead of
   # being reworded or escaped away. test_no_heredoc_in_command_substitution
@@ -276,6 +284,26 @@ test_no_mistakes_dod_wording() {
   assert_grep "firstmate's authority check" "$brief" \
     "no-mistakes DOD lost the apostrophe prose that the structural fix makes parse-safe"
   pass "fm-brief.sh: no-mistakes DOD keeps its apostrophe prose, now parse-safe"
+}
+
+test_faster_delivery_modes_do_not_wait_for_firstmate() {
+  local home id brief
+  home="$TMP_ROOT/faster-delivery-self-drive-home"
+  write_registry "$home"
+
+  id="brief-direct-self-drive-b2"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" direct-proj >/dev/null 2>&1
+  brief="$home/data/$id/brief.md"
+  assert_grep "Do not end your turn waiting for firstmate to tell you to push or open the PR - those delivery steps are yours." "$brief" \
+    "direct-PR brief must make the worker drive its own push and PR creation"
+
+  id="brief-local-self-drive-b2"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" local-proj >/dev/null 2>&1
+  brief="$home/data/$id/brief.md"
+  assert_grep "Do not end your turn waiting for firstmate to tell you to rebase or report the ready branch - those delivery steps are yours." "$brief" \
+    "local-only brief must make the worker drive its own rebase and ready report"
+
+  pass "fm-brief.sh: each faster delivery mode owns its steps without waiting for firstmate"
 }
 
 test_ship_project_memory_wording() {
@@ -638,6 +666,7 @@ test_help_includes_entire_header
 test_ship_modes_generate_clean_briefs
 test_faster_paths_use_configured_authority_without_stacked_review
 test_no_mistakes_dod_wording
+test_faster_delivery_modes_do_not_wait_for_firstmate
 test_ship_project_memory_wording
 test_herdr_lab_contract_is_explicit_and_complete
 test_herdr_lab_contract_quotes_foreign_firstmate_path

--- a/tests/fm-composer-ghost.test.sh
+++ b/tests/fm-composer-ghost.test.sh
@@ -22,10 +22,14 @@ set -u
 . "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
 
 LIB="$ROOT/bin/fm-tmux-lib.sh"
+BACKEND="$ROOT/bin/fm-backend.sh"
 PEEK="$ROOT/bin/fm-peek.sh"
 
 # shellcheck source=/dev/null
 . "$LIB"
+
+# shellcheck source=/dev/null
+. "$BACKEND"
 
 TMP_ROOT=$(fm_test_tmproot fm-ghost-tests)
 
@@ -266,6 +270,73 @@ test_real_text_with_trailing_ghost_is_pending() {
   pass "fm_pane_input_pending: real text plus a trailing ghost run is still pending"
 }
 
+test_unicode_whitespace_through_public_composer_interface() {
+  local dir fb capture out label escaped whitespace nbsp
+  dir="$TMP_ROOT/unicode-whitespace"; mkdir -p "$dir"
+  fb=$(make_fake_tmux "$dir")
+  capture="$dir/styled.txt"
+  nbsp=$(printf '\xc2\xa0')
+
+  printf '\xe2\x9d\xaf%sdeploy\n' "$nbsp" > "$capture"
+  out=$(PATH="$fb:$PATH" FM_FAKE_STYLED="$capture" FM_FAKE_CY=0 \
+    fm_backend_composer_state tmux fakepane)
+  [ "$out" = pending ] \
+    || fail "real typed text after Unicode whitespace must stay pending, got '$out'"
+  pass "fm_backend_composer_state: real typed text after Unicode whitespace stays pending"
+
+  printf '$%s\n' "$nbsp" > "$capture"
+  out=$(PATH="$fb:$PATH" FM_FAKE_STYLED="$capture" FM_FAKE_CY=0 \
+    fm_backend_composer_state tmux fakepane)
+  [ "$out" = unknown ] \
+    || fail "a bare shell prompt followed by Unicode whitespace must stay unknown, got '$out'"
+  pass "fm_backend_composer_state: a bare shell prompt followed by Unicode whitespace stays unknown"
+
+  printf '\xe2\x9d\xaf %s\n' "$(printf '\033[2mplaceholder\033[0m')" > "$capture"
+  out=$(PATH="$fb:$PATH" FM_FAKE_STYLED="$capture" FM_FAKE_CY=0 \
+    fm_backend_composer_state tmux fakepane)
+  [ "$out" = empty ] \
+    || fail "ghost-only placeholder text must stay empty, got '$out'"
+  pass "fm_backend_composer_state: ghost-only placeholder text stays empty"
+
+  # U+00A0 is built from the exact bytes captured from a live idle Claude pane.
+  printf '\xe2\x9d\xaf\xc2\xa0\n' > "$capture"
+  out=$(PATH="$fb:$PATH" FM_FAKE_STYLED="$capture" FM_FAKE_CY=0 \
+    fm_backend_composer_state tmux fakepane)
+  [ "$out" = empty ] \
+    || fail "Claude's exact idle composer bytes (U+276F + U+00A0) should be empty, got '$out'"
+
+  # Cover every non-ASCII code point in Unicode's White_Space property.
+  while IFS=' ' read -r label escaped; do
+    whitespace=$(printf '%b' "$escaped")
+    printf '\xe2\x9d\xaf%s\n' "$whitespace" > "$capture"
+    out=$(PATH="$fb:$PATH" FM_FAKE_STYLED="$capture" FM_FAKE_CY=0 \
+      fm_backend_composer_state tmux fakepane)
+    [ "$out" = empty ] \
+      || fail "Claude prompt followed by Unicode whitespace $label should be empty, got '$out'"
+  done <<'EOF'
+U+0085 \xc2\x85
+U+00A0 \xc2\xa0
+U+1680 \xe1\x9a\x80
+U+2000 \xe2\x80\x80
+U+2001 \xe2\x80\x81
+U+2002 \xe2\x80\x82
+U+2003 \xe2\x80\x83
+U+2004 \xe2\x80\x84
+U+2005 \xe2\x80\x85
+U+2006 \xe2\x80\x86
+U+2007 \xe2\x80\x87
+U+2008 \xe2\x80\x88
+U+2009 \xe2\x80\x89
+U+200A \xe2\x80\x8a
+U+2028 \xe2\x80\xa8
+U+2029 \xe2\x80\xa9
+U+202F \xe2\x80\xaf
+U+205F \xe2\x81\x9f
+U+3000 \xe3\x80\x80
+EOF
+  pass "fm_backend_composer_state: Unicode whitespace is empty without weakening typed-text, dead-shell, or ghost guards"
+}
+
 # --- fm_tmux_composer_state: structural multi-row box scan ------------------
 
 test_two_row_composer_reads_text_above_empty_cursor_row() {
@@ -473,11 +544,11 @@ test_all_tmux_harness_composers_share_classification() {
   dir="$TMP_ROOT/all-harness-composers"; mkdir -p "$dir"
   fb=$(make_fake_tmux "$dir")
   capture="$dir/styled.txt"
-  for harness in claude codex opencode pi pi-signed grok; do
+  for harness in claude codex opencode pi pi-signed grok kimi; do
     case "$harness" in
       claude) printf '╭────────────╮\n│ ❯ \033[2mtry\033[0m      │\n╰────────────╯\n' > "$capture" ;;
       codex) printf '╭────────────╮\n│ › \033[2mtip\033[0m      │\n╰────────────╯\n' > "$capture" ;;
-      opencode) printf '╭────────────╮\n│ >          │\n╰────────────╯\n' > "$capture" ;;
+      opencode|kimi) printf '╭────────────╮\n│ >          │\n╰────────────╯\n' > "$capture" ;;
       pi|pi-signed) printf '╭────────────╮\n│            │\n╰────────────╯\n' > "$capture" ;;
       grok) printf '╭────────────╮\n│ ❯ \033[38;2;50;47;70mType\033[0m     │\n╰────────────╯\n' > "$capture" ;;
     esac
@@ -488,7 +559,7 @@ test_all_tmux_harness_composers_share_classification() {
     case "$harness" in
       claude|grok) printf '╭────────────╮\n│ ❯ fix      │\n╰────────────╯\n' > "$capture" ;;
       codex) printf '╭────────────╮\n│ › fix      │\n╰────────────╯\n' > "$capture" ;;
-      opencode|pi|pi-signed) printf '╭────────────╮\n│ > fix      │\n╰────────────╯\n' > "$capture" ;;
+      opencode|pi|pi-signed|kimi) printf '╭────────────╮\n│ > fix      │\n╰────────────╯\n' > "$capture" ;;
     esac
     out=$(PATH="$fb:$PATH" FM_FAKE_STYLED="$capture" FM_FAKE_CY=1 \
       fm_tmux_composer_state "fakepane")
@@ -607,6 +678,7 @@ test_colored_text_with_2_payload_still_pending
 test_dark_truecolor_ghost_only_composer_is_not_pending
 test_dark_truecolor_bare_shell_prompt_is_unknown
 test_real_text_with_trailing_ghost_is_pending
+test_unicode_whitespace_through_public_composer_interface
 test_two_row_composer_reads_text_above_empty_cursor_row
 test_wrapped_composer_reads_all_content_rows
 test_bottom_border_cursor_reads_ghost_only_box_as_empty

--- a/tests/fm-daemon.test.sh
+++ b/tests/fm-daemon.test.sh
@@ -1162,22 +1162,25 @@ test_max_defer_flushes_empty_idle_pane() {
 }
 
 test_max_defer_pending_composer_alarms_without_typing() {
-  local dir state fakebin sent
+  local dir state fakebin sent display_log
   dir=$(make_bordered_case maxdefer-pending-digest)
   state="$dir/state"; fakebin="$dir/fakebin"
-  sent="$dir/sent.log"; : > "$sent"
+  sent="$dir/sent.log"; display_log="$dir/display.log"; : > "$sent"; : > "$display_log"
   printf '╭─────────────────╮\n│ > human draft   │\n╰─────────────────╯\n' > "$dir/composer"
   escalate_add "$state" "needs-decision: pick B"
   echo $(( $(date +%s) - 600 )) > "$state/.subsuper-escalations.since"
   afk_enter "$state"
   PATH="$fakebin:$PATH" FM_FAKE_COMPOSER="$dir/composer" FM_FAKE_SENT="$sent" \
+    FM_FAKE_TMUX_DISPLAY_LOG="$display_log" \
     FM_ESCALATE_BATCH_SECS=99999 FM_MAX_DEFER_SECS=60 FM_INJECT_CONFIRM_SLEEP=0.05 \
     housekeeping "$state"
   [ ! -s "$sent" ] || fail "max-defer typed into a pending composer"
   [ -s "$state/.subsuper-inject-wedged" ] || fail "pending composer did not raise a wedge alarm marker"
   [ -s "$state/.subsuper-escalations" ] || fail "buffer lost while composer was pending"
   grep -F 'human draft' "$dir/composer" >/dev/null || fail "pending composer content changed"
-  pass "max-defer on a pending composer alarms without typing"
+  grep -F 'display-message -d 60000 -t' "$display_log" >/dev/null \
+    || fail "pending composer wedge did not keep the tmux status alarm visible through the next refresh"
+  pass "max-defer on a pending composer alarms without typing and keeps the tmux status alarm visible"
 }
 
 test_normal_flush_clears_stale_wedge_marker() {
@@ -1402,7 +1405,7 @@ test_wedge_alarm_off_disables_active_alert_regardless_of_position() {
       wedge_alarm_notify "away-mode WEDGED 900s" "/s/.marker"
     [ ! -s "$log" ] || fail "off did not disable a preceding or following active alert: $(cat "$log")"
   done
-  pass "off disables every active alert regardless of directive position (marker and tmux flash are unaffected)"
+  pass "off disables every active alert regardless of directive position (marker and tmux overlay are unaffected)"
 }
 
 test_wedge_alarm_auto_darwin_selects_osascript() {
@@ -1420,7 +1423,7 @@ test_wedge_alarm_auto_non_darwin_has_no_os_channel() {
   PATH="$dir/fakebin:$PATH" FM_WEDGE_ALARM_LOG="$log" FM_FAKE_UNAME=Linux FM_WEDGE_ALARM_CHANNEL=auto \
     wedge_alarm_notify "away-mode WEDGED 900s" "/s/.marker"
   [ ! -s "$log" ] || fail "auto selected a built-in OS channel on a non-macOS platform: $(cat "$log")"
-  pass "auto on a non-macOS platform selects no built-in OS channel (the marker or a configured command carries it)"
+  pass "auto on a non-macOS platform selects no built-in OS channel"
 }
 
 test_wedge_alarm_config_file_multi_channel() {

--- a/tests/fm-daemon.test.sh
+++ b/tests/fm-daemon.test.sh
@@ -751,7 +751,7 @@ test_busy_guard_defers_when_supervisor_busy() {
   fakebin="$dir/fakebin"
   sent="$dir/sent.log"; : > "$sent"
   capture="$dir/pane.txt"
-  printf 'esc to interrupt\n' > "$capture"
+  printf '… (6s)\n' > "$capture"
   escalate_add "$state" "done: PR 1"
   afk_enter "$state"
   if PATH="$fakebin:$PATH" FM_FAKE_TMUX_PANE_ALIVE=1 FM_FAKE_TMUX_SENT="$sent" \
@@ -1178,9 +1178,16 @@ test_max_defer_pending_composer_alarms_without_typing() {
   [ -s "$state/.subsuper-inject-wedged" ] || fail "pending composer did not raise a wedge alarm marker"
   [ -s "$state/.subsuper-escalations" ] || fail "buffer lost while composer was pending"
   grep -F 'human draft' "$dir/composer" >/dev/null || fail "pending composer content changed"
-  grep -F 'display-message -d 60000 -t' "$display_log" >/dev/null \
+  grep -F 'display-message -d 76000 -t' "$display_log" >/dev/null \
     || fail "pending composer wedge did not keep the tmux status alarm visible through the next refresh"
-  pass "max-defer on a pending composer alarms without typing and keeps the tmux status alarm visible"
+  touch -d '61 seconds ago' "$state/.subsuper-inject-wedged"
+  PATH="$fakebin:$PATH" FM_FAKE_COMPOSER="$dir/composer" FM_FAKE_SENT="$sent" \
+    FM_FAKE_TMUX_DISPLAY_LOG="$display_log" \
+    FM_ESCALATE_BATCH_SECS=99999 FM_MAX_DEFER_SECS=60 FM_INJECT_CONFIRM_SLEEP=0.05 \
+    housekeeping "$state"
+  [ "$(grep -cF 'display-message -d 76000 -t' "$display_log")" -eq 2 ] \
+    || fail "pending composer wedge did not refresh the status alarm before its slackened duration expired"
+  pass "max-defer on a pending composer alarms without typing and refreshes a gap-free tmux status alarm"
 }
 
 test_normal_flush_clears_stale_wedge_marker() {
@@ -1830,6 +1837,85 @@ test_inject_msg_defers_on_unrecognized_composer_state() {
   pass "inject_msg: unrecognized composer states defer by default"
 }
 
+test_real_tmux_away_delivery_and_guards() {
+  local dir state helper session target received before after log row_hex
+  command -v tmux >/dev/null 2>&1 || { pass "real tmux away delivery skipped: tmux unavailable"; return; }
+  dir=$(make_supercase real-tmux-away-delivery)
+  state="$dir/state"; helper="$dir/render.sh"; received="$dir/received"; log="$state/.supervise-daemon.log"; LOG="$log"
+  session="fm-daemon-e2e-$$-$RANDOM"
+  cat > "$helper" <<'SH'
+#!/usr/bin/env bash
+set -u
+mode=$1 out=$2
+render() {
+  case "$mode" in
+    idle) printf 'esc to interrupt\n\342\235\257\302\240' ;;
+    draft) printf 'esc to interrupt\nhuman draft' ;;
+    shell) printf '$ ' ;;
+    spinner) printf 'esc to interrupt\n\342\200\246 (6s)' ;;
+    custom) printf 'custom idle>' ;;
+  esac
+}
+render
+if [ "$mode" = idle ] || [ "$mode" = custom ]; then
+  while IFS= read -r line; do
+    printf '%s' "$line" > "$out"
+    printf '\n'
+    render
+  done
+else
+  sleep 30
+fi
+SH
+  chmod +x "$helper"
+  tmux new-session -d -s "$session" -x 100 -y 20 "$helper idle '$received'"
+  target=$(tmux list-panes -t "$session" -F '#{pane_id}')
+  sleep 0.2
+  row_hex=$(tmux display-message -p -t "$target" '#{cursor_y}' | {
+    read -r cursor_y
+    tmux capture-pane -p -t "$target" -S "$cursor_y" -E "$cursor_y" | od -An -t u1 | tr -s ' ' | sed 's/^ //;s/ $//'
+  })
+  [ "$row_hex" = '226 157 175 194 160 10' ] \
+    || fail "real tmux idle Claude row bytes drifted: $row_hex"
+  escalate_add "$state" "needs-decision: exact tmux delivery"
+  afk_enter "$state"
+  FM_SUPERVISOR_BACKEND=tmux FM_SUPERVISOR_TARGET="$target" FM_DAEMON_PRIMARY_HARNESS=claude \
+    FM_INJECT_CONFIRM_SLEEP=0.05 escalate_flush "$state" \
+    || fail "real tmux idle Claude row did not accept the buffered digest"
+  grep -F 'Supervisor escalate (1 event(s)): needs-decision: exact tmux delivery' "$received" >/dev/null \
+    || fail "real tmux pane did not receive the operational digest"
+  [ ! -s "$state/.subsuper-escalations" ] || fail "real tmux delivery did not clear the escalation buffer"
+
+  for mode in draft shell spinner; do
+    tmux respawn-pane -k -t "$target" "$helper $mode '$received'"
+    sleep 0.2
+    before=$(tmux capture-pane -p -t "$target")
+    : > "$received"
+    escalate_add "$state" "needs-decision: must remain buffered"
+    if FM_SUPERVISOR_BACKEND=tmux FM_SUPERVISOR_TARGET="$target" FM_DAEMON_PRIMARY_HARNESS=claude \
+      FM_INJECT_CONFIRM_SLEEP=0.05 escalate_flush "$state"; then
+      fail "real tmux $mode guard allowed injection"
+    fi
+    after=$(tmux capture-pane -p -t "$target")
+    [ "$before" = "$after" ] || fail "real tmux $mode guard modified the pane"
+    [ ! -s "$received" ] || fail "real tmux $mode guard delivered text"
+    : > "$state/.subsuper-escalations"
+  done
+
+  tmux respawn-pane -k -t "$target" "$helper custom '$received'"
+  sleep 0.2
+  escalate_add "$state" "needs-decision: override delivery"
+  FM_SUPERVISOR_BACKEND=tmux FM_SUPERVISOR_TARGET="$target" FM_DAEMON_PRIMARY_HARNESS=claude \
+    FM_COMPOSER_IDLE_RE='^custom idle>$' FM_INJECT_CONFIRM_SLEEP=0.05 escalate_flush "$state" \
+    || fail "FM_COMPOSER_IDLE_RE did not propagate through real tmux guard and submit acknowledgement"
+  grep -F 'needs-decision: override delivery' "$received" >/dev/null \
+    || fail "real tmux override delivery did not reach the target pane"
+  tmux kill-session -t "$session"
+  grep -F 'gate=busy backend=tmux harness=claude' "$log" >/dev/null \
+    || fail "real tmux active-spinner defer did not log its delivery-boundary verdict"
+  pass "real tmux away delivery handles exact Claude bytes, safety guards, busy state, and idle overrides"
+}
+
 test_afk_start_refuses_when_flag_cannot_be_written
 test_afk_start_ignores_stale_pidfile_without_lock
 test_afk_start_reclaims_stale_daemon_lock_reused_pid
@@ -1929,3 +2015,4 @@ test_inject_msg_herdr_pane_gone_defers
 test_inject_msg_herdr_submits_through_backend_dispatch
 test_inject_msg_defers_on_dead_shell_unknown
 test_inject_msg_defers_on_unrecognized_composer_state
+test_real_tmux_away_delivery_and_guards

--- a/tests/wake-helpers.sh
+++ b/tests/wake-helpers.sh
@@ -218,6 +218,7 @@ write_composer() {
 }
 case "${1:-}" in
   display-message)
+    [ -n "${FM_FAKE_TMUX_DISPLAY_LOG:-}" ] && printf '%s\n' "$*" >> "$FM_FAKE_TMUX_DISPLAY_LOG"
     print=0
     for a in "$@"; do case "$a" in *cursor_y*) printf '1\n'; exit 0 ;; esac; done
     for a in "$@"; do [ "$a" = "-p" ] && print=1; done


### PR DESCRIPTION
## Intent

Fix the away-mode composer classifier so an empty Claude composer consisting of U+276F plus U+00A0 reads empty by treating the full Unicode White_Space property as whitespace, without weakening safety: real unsubmitted text must remain pending, bare shell prompts must remain unknown, and ghost or placeholder text must remain empty. Exercise the regression from the exact captured bytes through the public backend interface, cover the remaining Unicode whitespace set, and preserve compatibility across Claude, Codex, OpenCode, Pi, pi-signed, Grok, and Kimi on both tmux and Herdr. Make a future unpredicted false-pending loud within minutes without modifying daemon classification policy, the wake queue, or durable escalation records. Empirical follow-up proved wall writes into live Claude panes, so wall is disqualified. Keep the safe composer guard, do not force-flush based on byte-stable content because a real half-typed line can remain unchanged, and instead keep the tmux status overlay visible for the full max-defer interval and refresh it while recording the honest residual that this Linux host has no verified default off-host notification channel. State the default future false-pending cost as at most 315 seconds or 5.25 minutes to the persistent on-host warning. Update docs/wedge-alarm.md as the contract owner and docs/verification with date, versions, exact commands, exact output, compatibility evidence, and the wall versus tmux-overlay probes. Extend colocated tests, run bin/fm-lint.sh with pinned ShellCheck, and explain baseline evidence honestly: the exact empty-row regression failed before the fix, the NBSP bare-shell precision check also returned pending instead of unknown, while the real-text and ghost safety controls already passed and must not be falsely described as failures.

## What Changed

- Treat the full Unicode `White_Space` set as empty composer whitespace while preserving pending text, shell-prompt, placeholder, tmux, and Herdr safety behavior across supported harnesses.
- Add structured injection-gate diagnostics and a persistent, refreshed tmux wedge overlay without force-flushing byte-stable composer content.
- Make delegated workers self-drive their configured validation and delivery workflow, and document the classifier baseline, compatibility coverage, and wedge-alarm verification evidence.

## Risk Assessment

✅ Low: The latest fix restores the hermetic busy-guard seam while preserving gate-specific diagnostics, real-tmux delivery coverage, Unicode classifier safety, and gap-free overlay refresh behavior.

## Testing

Focused classifier, Herdr, and daemon suites passed, directly exercising the exact Claude bytes, every Unicode White_Space code point, typed-text/shell/ghost safety controls, seven tmux harnesses, Herdr dispatch, real tmux delivery, and gap-free wedge-overlay refresh; the evidence transcript was saved and no worktree artifacts remained.

<details>
<summary>Evidence: Focused end-to-end test transcript</summary>

```text
FM_TEST_BEGIN 2026-08-05T23:48:00Z tests/fm-composer-ghost.test.sh family=pure-contract-unit expected_gate_skip=none
ok - fm_tmux_strip_ghost drops dim/faint runs, keeps normal and bold text
ok - fm_tmux_strip_ghost handles combined SGR, ESC[22m, and reset-then-dim
ok - fm_tmux_strip_ghost keeps bright colored text with 2 payloads
ok - fm_tmux_strip_ghost drops a dark/muted truecolor foreground (grok placeholder)
ok - fm_pane_input_pending: a dim ghost-only composer is NOT pending
ok - fm_pane_input_pending: dim ghost inside a bordered composer is NOT pending
ok - fm_pane_input_pending: normal-intensity typed text is still pending
ok - fm_pane_input_pending: bright colored text with 2 payloads is still pending
ok - fm_pane_input_pending: a dark truecolor ghost-only composer (grok placeholder) is NOT pending
ok - fm_tmux_composer_state: dark truecolor shell prompts read unknown
ok - fm_pane_input_pending: real text plus a trailing ghost run is still pending
ok - fm_backend_composer_state: real typed text after Unicode whitespace stays pending
ok - fm_backend_composer_state: a bare shell prompt followed by Unicode whitespace stays unknown
ok - fm_backend_composer_state: ghost-only placeholder text stays empty
ok - fm_backend_composer_state: Unicode whitespace is empty without weakening typed-text, dead-shell, or ghost guards
ok - fm_tmux_composer_state: text above an empty cursor row is pending
ok - fm_tmux_composer_state: a message wrapped across three rows is pending
ok - fm_tmux_composer_state: Grok's bottom-border cursor quirk reads an empty box structurally
ok - fm_tmux_composer_state: typed Pi and Grok busy signatures inside a box are pending
ok - fm_tmux_composer_state: non-bordered busy footers retain compatibility behavior
ok - fm_tmux_composer_state: an unbounded bordered box fails closed as unknown
ok - fm_tmux_composer_state: clipped and asymmetric composer edges fail closed
ok - fm_tmux_composer_state: inconsistent box geometry fails closed
ok - fm_tmux_composer_state: misaligned box bounds fail closed
ok - fm_tmux_composer_state: unproved ghost, idle, and border geometry stays unknown
ok - fm_tmux_composer_state: differing widths prefer pending or unknown, never empty
ok - fm_tmux_composer_state: emoji and CJK text remain pending under the C locale
ok - fm_tmux_composer_state: all tmux harnesses share empty and pending classification
ok - fm_pane_input_pending: unrecognized states defer by default
ok - fm_tmux_composer_state: fallback capture races cannot admit unbounded edges
ok - fm_tmux_composer_state: only proven structural and non-bordered empty routes stay empty
ok - fm_tmux_composer_state: panes without bordered structure retain compatibility fallback
ok - fm_tmux_composer_state: interior edge glyphs retain non-bordered fallback
ok - fm-peek output is escape-free (no raw -e bytes reach firstmate context)
FM_TEST_END 2026-08-05T23:48:04Z tests/fm-composer-ghost.test.sh exit=0 duration_ms=3968 gate_skip=false
FM_TEST_BEGIN 2026-08-05T23:48:04Z tests/fm-backend-herdr.test.sh family=backend-dispatch expected_gate_skip=none
ok - fm_backend_herdr_version_check: accepts the current protocol (14)
ok - fm_backend_herdr_version_check: refuses an old protocol loudly
ok - fm_backend_herdr_version_check: refuses loudly when herdr is not installed
ok - fm_backend_herdr_workspace_label: a primary home (no marker) resolves to 'firstmate'
ok - fm_backend_herdr_workspace_label: a secondmate home (.fm-secondmate-home) resolves to '2ndmate-<id>'
ok - fm_backend_herdr_workspace_label: trims whitespace around the marker's secondmate id
ok - fm_backend_herdr_workspace_label: an empty marker file falls back to the primary label 'firstmate'
ok - fm_backend_herdr_workspace_label: two different secondmate homes get two different, non-colliding labels
ok - fm_backend_herdr_cli: sets HERDR_SESSION AND appends a trailing --session flag on every call
ok - fm_backend_herdr_launcher_identity: a firstmate not running inside herdr has no launcher workspace to inherit
ok - fm_backend_herdr_launcher_identity: HERDR_ENV=1 without a pane id selects the backend but binds no parent
ok - fm_backend_herdr_launcher_identity: resolves the launcher's exact workspace even when a same-labeled workspace sorts first
ok - fm_backend_herdr_launcher_identity: refuses a launcher pane that names a different herdr session
ok - fm_backend_herdr_launcher_identity: refuses a claimed pane without exact server identity
ok - fm_backend_herdr_launcher_identity: refuses a launcher pane whose injected socket belongs to another herdr server
ok - fm_backend_herdr_launcher_identity: refuses when the launcher's own pane no longer resolves
ok - fm_backend_herdr_launcher_identity: refuses when the launcher's pane and tab disagree about their workspace
ok - fm_backend_herdr_launcher_identity: refuses when the launcher's workspace is gone from its own session
ok - fm_backend_herdr_workspace_ensure: places a worker in the launcher's exact workspace, not the first same-labeled one
ok - fm_backend_herdr_workspace_ensure: refuses to guess between two same-labeled home workspaces
ok - fm_backend_herdr_workspace_ensure: a --secondmate container resolves that home's own workspace, not the launcher's
ok - fm_backend_herdr_container_ensure: surfaces the exact ambiguous-placement refusal instead of a generic failure
ok - fm_backend_herdr_container_ensure: version-gates, starts the server, ensures the firstmate workspace, echoes session:workspace_id + the seeded default tab id
ok - fm_backend_herdr_container_ensure: reuses an existing firstmate workspace without recreating it, and reports no seeded default tab (adopted, not created)
ok - fm_backend_herdr_container_ensure: workspace create passes --no-focus
ok - fm_backend_herdr_container_ensure: creates the workspace under the SECONDMATE home's own label, not 'firstmate'
ok - fm_backend_herdr_create_task: prunes exactly the seeded default tab container_ensure identified, once the first real task tab exists
ok - herdr repeated spawn/teardown: one persistent firstmate workspace reused, zero orphans, default tab pruned, create ran once
ok - fm_backend_herdr_create_task: an ADOPTED workspace's pre-existing tab is never pruned (the created-vs-adopted gate)
ok - fm_backend_herdr_create_task: the label-collision startup-workspace scenario (2026-07-02 incident) leaves the captain's live tab untouched
ok - fm_backend_herdr_workspace_prune_seeded_default_tab: refuses to close the seeded default tab when its pane reports a working agent (defense in depth)
ok - fm_backend_herdr_create_task: refuses a duplicate tab label (herdr's own tab create has no uniqueness check)
ok - fm_backend_herdr_create_task: a same-labeled tab with a live (even idle) registered agent still refuses exactly as before
ok - fm_backend_herdr_create_task: scans every same-labeled tab and refuses if any duplicate is live
ok - fm_backend_herdr_create_task: closes and replaces a same-labeled tab whose pane is dead (pane_not_found)
ok - fm_backend_herdr_create_task: closes and replaces a same-labeled tab whose pane is alive but hosts no registered agent (a restored plain shell)
ok - fm_backend_herdr_create_task: closes every confirmed same-labeled husk only after creating the replacement
ok - fm_backend_herdr_create_task: refuses success when a preexisting husk tab remains after replacement
ok - fm_backend_herdr_create_task: refuses (fail-safe) rather than guessing when the duplicate's agent state cannot be classified confidently
ok - fm_backend_herdr_create_task: creates the replacement tab BEFORE closing the husk tab, never the reverse
ok - fm_backend_herdr_create_task: creates a tab and parses tab_id/pane_id from the JSON response, prunes nothing when no seeded tab id is given
ok - fm_backend_herdr_create_task: tab create passes --no-focus
ok - herdr presentation journal: atomically publishes one non-authoritative 128-bit correlator and refuses overwrite
ok - herdr presentation journal: version 2 binds exact home/endpoint/parent identities and advances atomically
ok - herdr presentation create: exact response IDs yield one normal task pane with no workspace-close authority
ok - herdr present

... [13221 bytes truncated] ...

by FM_HOME
ok - routine signal self-handles
ok - captain-relevant status verbs escalate
ok - check + unknown escalate; heartbeat self-handles
ok - transient stale self-handles and records a persistence marker
ok - enriched stale wedges bypass status absorption without disturbing busy workers
ok - stale + terminal status escalates immediately
ok - paused reasons with captain phrases remain pause-classified
ok - handle_wake on a paused stale records a pause marker, drops the wedge marker, and does not escalate
ok - handle_wake records a declared pause from a routine signal for long-cadence rechecks
ok - a terminal signal clears pause and stale tracking across both supervisors
ok - housekeeping migrates a normal-watcher's declared pause into daemon tracking
ok - housekeeping clears an already-resumed watcher pause across both supervisors
ok - housekeeping seeds pause tracking from status without a watcher marker
ok - persistent stale escalates after threshold and clears its marker
ok - resumed (busy) stale clears its marker without escalating
ok - housekeeping re-surfaces a stale declared pause on the long cadence and resets its window
ok - housekeeping clears a paused marker whose pane became busy again, without escalating
ok - housekeeping clears a paused marker once the crew is no longer declaring the pause
ok - housekeeping moves an existing stale marker to pause before wedge escalation
ok - housekeeping clears tracking when a crew leaves pause
ok - persistent herdr stale resolves the target from metadata and escalates
ok - herdr idle busy-footer stale clears through capture corroboration
ok - resumed herdr stale clears through backend-aware busy state
ok - persistent Orca stale resolves the terminal from metadata
ok - multiple escalations flush as a single batched digest
ok - batch flush measures max-delay from the first append, not the last
ok - catch-all scan escalates a missed terminal once, not twice
ok - handle_wake routes routine->self and captain->escalate
ok - INJECT_SKIP forces self-handle, bypassing captain-relevant classification
ok - is_wake_reason distinguishes watcher wake reasons from singleton-status stdout
ok - terminal-stale escalate removes its marker so housekeeping does not re-escalate
ok - captain signal escalate marks seen so the catch-all scan does not re-fire
ok - _collapse_newlines replaces newlines with literal separator
ok - afk flag absent: daemon does not inject, buffer preserved
ok - busy-guard defers injection when supervisor pane is busy
ok - marker detection: marker -> stay afk, no marker -> exit afk
ok - /afk invocation is exempt from afk exit (no self-cancel)
ok - should_exit_afk returns false when afk is not active
ok - strip_injection_marker removes the sentinel marker cleanly
ok - pane_input_pending detects partial input on the cursor line
ok - pane_input_pending: blank cursor line is not pending
ok - pane_input_pending: only proven empty agent prompts pass
ok - fm_tmux_composer_state: a bare shell prompt ($/%/#/>) reads unknown, never empty (dead-shell injection safety)
ok - fm_tmux_composer_state: a bordered composer box and bare agent glyphs (❯/›) still read empty
ok - fm_tmux_composer_state: only matching edge borders form a composer box
ok - pane_input_pending honors FM_COMPOSER_IDLE_RE after border stripping
ok - classify_signal dedupes against the catch-all scan seen marker
ok - classify_stale dedupes against the signal path seen marker
ok - AFK nonterminal working:+merged keeps wedge aging and re-escalates at bound
ok - genuine done: and merge-check events still escalate
ok - pane_input_pending: an idle bordered composer is NOT pending (afk-invx-i5)
ok - pane_input_pending: text inside a bordered composer is still pending
ok - submit-ACK confirms a submit when the composer returns to a bordered-empty box
ok - submit-ACK reports pending on a persistently swallowed Enter (type-once)
ok - max-defer on an empty stuck pane types once, alarms, and preserves the buffer
ok - max-defer flushes and clears the buffer on an empty bordered pane
ok - max-defer on a pending composer alarms without typing and refreshes a gap-free tmux status alarm
ok - normal flush clears a stale wedge marker
ok - below MAX_DEFER: no inject, no alarm, buffer preserved
ok - max-defer does not flush or alarm while afk is inactive
ok - library mode: sourcing the daemon defaults FM_WEDGE_ALARM_EXEC to discard (no test can fire a real notification)
ok - wake helpers replace inherited notifier overrides with the safe recorder
ok - the discard seam suppresses every notifier, including command: (fires nothing)
ok - direct notifier helpers honor the discard seam, including command:
ok - osascript channel routes through the notifier seam with the summary (never a real notification)
ok - herdr channel routes through the notifier seam with the summary (never a real notification)
ok - command channel runs the captain command with the summary on $1 and on stdin
ok - command channel failures redact configured commands while logging their exit status
ok - unknown channel directives are redacted while the alarm keeps running
ok - off disables every active alert regardless of directive position (marker and tmux overlay are unaffected)
ok - auto resolves to the macOS osascript notifier on Darwin (default-on)
ok - auto on a non-macOS platform selects no built-in OS channel
ok - config/wedge-alarm selects every configured channel and skips comment and blank lines
ok - a failing channel logs and falls back to the next channel, never crashing the alarm
ok - a hung notifier is bounded, logged, and falls through to the next channel
ok - a backgrounded command notifier remains bounded until its process group is reaped
ok - a hung notifier override is bounded, logged, and proceeds to the next channel
[1]+  Terminated              sh -c 'sleep 30 & printf "%s" "$!" > "$1"; wait' sh "$child_file"
ok - daemon shutdown stops and reaps the active notifier process group
ok - inject_wedge_alarm writes the marker AND emits the active alert even with no tmux status-line (herdr backend)
ok - in-process wedge throttle prevents alert spam when the marker cannot persist
ok - fm-send exits non-zero on a confirmed swallow, zero on a clean submit
ok - fm-send exits non-zero when initial text send fails
ok - fm-send exits non-zero unless delivery is proven empty
ok - discover_supervisor_backend: override > TMUX_PANE > HERDR_ENV+HERDR_PANE_ID > tmux fallback
ok - discover_supervisor_target: override > TMUX_PANE > herdr '<session>:<pane-id>' composition > firstmate:0 fallback
ok - pane_is_busy: herdr native busy_state='busy' short-circuits without a capture fallback
ok - primary busy guard isolates rendered signatures by detected harness
ok - pane_is_busy: omitted backend defaults to tmux for Grok's isolated fallback
ok - pane_input_pending: dispatches through fm_backend_composer_state for backend=herdr
ok - inject_msg: herdr busy-guard defers before ever attempting a submit
ok - inject_msg: herdr composer-guard defers before ever attempting a submit
ok - inject_msg: herdr pane-gone check defers before any busy/composer/submit call
ok - inject_msg: dispatches busy-guard/composer-guard/submit through the herdr backend and succeeds on a confirmed empty composer
ok - inject_msg: defers on a dead-shell/unreadable composer (unknown), never typing the escalation into a shell
ok - inject_msg: unrecognized composer states defer by default
ok - real tmux away delivery handles exact Claude bytes, safety guards, busy state, and idle overrides
FM_TEST_END 2026-08-05T23:48:47Z tests/fm-daemon.test.sh exit=0 duration_ms=19725 gate_skip=false
FM_TEST_SUMMARY total=3 failed=0 skipped_gate=0 duration_ms=47402
FM_TEST_SUMMARY_FAMILY family=backend-dispatch count=1 duration_ms=23567 failed=0
FM_TEST_SUMMARY_FAMILY family=pure-contract-unit count=1 duration_ms=3968 failed=0
FM_TEST_SUMMARY_FAMILY family=watcher-wake-lock count=1 duration_ms=19725 failed=0
FM_TEST_SLOWEST rank=1 script=tests/fm-backend-herdr.test.sh duration_ms=23567
FM_TEST_SLOWEST rank=2 script=tests/fm-daemon.test.sh duration_ms=19725
FM_TEST_SLOWEST rank=3 script=tests/fm-composer-ghost.test.sh duration_ms=3968
```
</details>
<details>
<summary>Evidence: Reviewer-visible behavior summary</summary>

```text
Unicode whitespace remains empty while typed text stays pending and bare shell prompts stay unknown; all tmux harnesses shared classification; Herdr public dispatch preserved verdicts; pending composers triggered a gap-free overlay without typing; real tmux delivery passed exact-byte and safety checks.
```
</details>
- Outcome: 🔧 1 issue found → auto-fixed ✅ across 2 runs (4m33s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Rebase** - 1 warning</summary>

- ⚠️ `.agents/skills/bootstrap-diagnostics/SKILL.md` - branch carries 2 commit(s) that exist on your local main branch but were never pushed to origin/main; rebasing would bundle this unrelated work (137 file(s)) into the PR:
- b2f9836 no-mistakes(document): Align validation ownership documentation
- 56f35bd fix(brief): self-drive validation pipeline

Push main to origin, or rebase your branch onto origin/main, before gating.

🔧 Fix applied.
1 warning still open:
- ⚠️ `.agents/skills/bootstrap-diagnostics/SKILL.md` - branch carries 2 commit(s) that exist on your local main branch but were never pushed to origin/main; rebasing would bundle this unrelated work (137 file(s)) into the PR:
- b2f9836 no-mistakes(document): Align validation ownership documentation
- 56f35bd fix(brief): self-drive validation pipeline

Push main to origin, or rebase your branch onto origin/main, before gating.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed (2) ✅</summary>

- 🚨 `bin/fm-supervise-daemon.sh:925` - The required persistent overlay can disappear before refresh. This hunk sets its lifetime to exactly `FM_MAX_DEFER_SECS`, but housekeeping refreshes only on a later tick after the marker reaches that age (lines 988–994). With defaults, the overlay can therefore vanish for up to roughly 15 seconds; with a small configured max-defer, the gap can be larger relative to its lifetime. This contradicts the required “keep the tmux status overlay visible for the full max-defer interval and refresh it” behavior and the documented claim that it remains persistent. Extend the display duration by at least the housekeeping cadence (including scheduling slack), or refresh it before expiration, and cover the second refresh timing rather than asserting only the initial `-d` argument.

🔧 Fix: Harden away delivery alerts and tmux verification
1 error still open:
- 🚨 `bin/fm-supervise-daemon.sh:1155` - `inject_msg` now calls `pane_busy_observation` directly, bypassing the established `pane_is_busy` wrapper that the colocated injection tests replace. Consequently, the Herdr busy/composer/submit and dead-shell tests still stub `pane_is_busy` but now reach real backend busy/capture logic; for example, the busy test can continue to its deliberately failing composer stub instead of deferring. Keep `inject_msg` routed through an observation-capable wrapper or update every affected test seam to stub `pane_busy_observation` with the intended verdict and diagnostic text so these tests remain isolated and exercise their named gate.

🔧 Fix: Restore hermetic busy observation seam
✅ Re-checked - no issues remain.

</details>

<details>
<summary>🔧 **Test** - 1 issue found → auto-fixed ✅</summary>

- 🚨 `docs/verification/supervision.md:243` - The authoritative intent requires verification documentation to explain baseline results precisely: the exact empty-row regression and NBSP bare-shell check failed before the fix, while real-text and ghost controls already passed. The new verification section documents only post-fix behavior and contains no baseline account, so this required acceptance evidence is missing.
- <code>Inspected `git diff 33a428773059aa9bbe55865ce73ae51e4334bccc..f4d0a62b98977acb54fd2529b1bed0b318f26e64` for the classifier, daemon behavior, colocated tests, and contract documentation.</code>
- <code>Ran `bin/fm-test-run.sh tests/fm-composer-ghost.test.sh tests/fm-backend-herdr.test.sh tests/fm-daemon.test.sh`.</code>
- `Reviewed the generated evidence for exact Unicode whitespace safety, seven-harness tmux compatibility, Herdr public dispatch, persistent overlay refresh, and real-tmux away delivery guards.`
- <code>Searched contract documentation with `rg -n &#34;before|baseline|NBSP|ghost safety|real-text|returned pending|failed before&#34; docs/verification/supervision.md docs/wedge-alarm.md` to verify the required baseline account.</code>

🔧 Fix: Document honest pre-fix composer baseline results
✅ Re-checked - no issues remain.
- <code>`git diff --stat 33a428773059aa9bbe55865ce73ae51e4334bccc..5f3b126adc531c59bf83eb7cb35a79f9b9b7c46f` and targeted diff inspection</code>
- `bin/fm-test-run.sh tests/fm-composer-ghost.test.sh tests/fm-backend-herdr.test.sh tests/fm-daemon.test.sh`
- `Inspected the saved transcript for Unicode-whitespace safety verdicts, seven-harness compatibility, Herdr dispatch, persistent overlay refresh, and real-tmux delivery`
- <code>`git status --short` after testing</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 127)

🔧 Fix: Verify clean lint with pinned ShellCheck
1 warning still open:
- ⚠️ linter found issues (exit code 127)

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
