### PR TITLE
fix(bin): instruct crew status appends via tee -a

### DIFF
--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -235,7 +235,7 @@ A message with NO marker is the captain typing directly into your pane: treat it
 # Escalation to main firstmate
 Handle routine work yourself.
 Report only true captain-relevant outcomes or a declared external wait by appending one line:
-   \`echo "{state}: {one short line}" >> $STATUS_FILE\`
+   \`echo "{state}: {one short line}" | tee -a $STATUS_FILE\`
 States: working, needs-decision, blocked, $PAUSED_VERB, done, failed.
 Use \`$PAUSED_VERB: {why}\` (distinct from \`blocked:\`) only when your domain is deliberately idling on a known external wait you expect to clear on its own; use \`blocked:\` when you are stuck and need firstmate to act.
 Use this only for material phase changes, a captain decision, a real blocker, a failure, or work ready for review.
@@ -317,7 +317,7 @@ The report is the only thing that survives, so anything worth keeping must be in
 2. Stay inside this worktree; the only files you may write outside it are the report and the status file below.
 3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
 4. Report status by appending one line:
-   \`echo "{state}: {one short line}" >> $STATUS_FILE\`
+   \`echo "{state}: {one short line}" | tee -a $STATUS_FILE\`
    States: working, needs-decision, blocked, $PAUSED_VERB, done, failed.
    Each append wakes firstmate, so report sparingly: only phase changes a supervisor
    would act on and the needs-decision/blocked/paused/done/failed states. No step-by-step
@@ -429,7 +429,7 @@ $RULE1
 2. Stay inside this worktree; modify nothing outside it.
 3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
 4. Report status by appending one line:
-   \`echo "{state}: {one short line}" >> $STATUS_FILE\`
+   \`echo "{state}: {one short line}" | tee -a $STATUS_FILE\`
    States: working, needs-decision, blocked, $PAUSED_VERB, done, failed.
    Each append wakes firstmate, so report sparingly: only phase changes a supervisor
    would act on (setup done, bug reproduced, fix implemented, validation passed) and the

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -551,7 +551,7 @@ test_secondmate_directory_paths_are_absolute_and_output_is_stable() {
   )
   cmp -s "$baseline" "$brief" \
     || fail "relative FM_HOME changed charter bytes compared with the same absolute home"
-  assert_grep ">> '$home/state/relative-home.status'" "$brief" \
+  assert_grep "tee -a '$home/state/relative-home.status'" "$brief" \
     "relative FM_HOME did not render an absolute secondmate status path"
 
   brief="$home/data/relative-state/brief.md"
@@ -567,7 +567,7 @@ test_secondmate_directory_paths_are_absolute_and_output_is_stable() {
   )
   cmp -s "$baseline" "$brief" \
     || fail "relative FM_STATE_OVERRIDE changed charter bytes compared with the same absolute state directory"
-  assert_grep ">> '$state_override/relative-state.status'" "$brief" \
+  assert_grep "tee -a '$state_override/relative-state.status'" "$brief" \
     "relative FM_STATE_OVERRIDE did not render an absolute secondmate status path"
 
   brief="$data_override/relative-data/brief.md"
@@ -583,7 +583,7 @@ test_secondmate_directory_paths_are_absolute_and_output_is_stable() {
   )
   cmp -s "$baseline" "$brief" \
     || fail "relative FM_DATA_OVERRIDE changed charter bytes compared with the same absolute data directory"
-  assert_grep ">> '$home/state/relative-data.status'" "$brief" \
+  assert_grep "tee -a '$home/state/relative-data.status'" "$brief" \
     "relative FM_DATA_OVERRIDE changed the absolute default status path"
 
   err="$root/unresolved.err"

--- a/tests/fm-secondmate-safety.test.sh
+++ b/tests/fm-secondmate-safety.test.sh
@@ -62,16 +62,16 @@ test_fm_home_parameterization() {
   FM_HOME="$home_one" "$ROOT/bin/fm-brief.sh" task-a app --mode no-mistakes >/dev/null || fail "brief scaffold failed under FM_HOME"
   brief="$home_one/data/task-a/brief.md"
   [ -f "$brief" ] || fail "brief was not written under FM_HOME/data"
-  grep -F ">> '$home_one/state/task-a.status'" "$brief" >/dev/null || fail "brief did not shell-quote FM_HOME state path"
+  grep -F "tee -a '$home_one/state/task-a.status'" "$brief" >/dev/null || fail "brief did not shell-quote FM_HOME state path"
 
   FM_HOME="$home_one" "$ROOT/bin/fm-brief.sh" task-b app --scout >/dev/null || fail "scout brief scaffold failed under FM_HOME"
   brief="$home_one/data/task-b/brief.md"
-  grep -F ">> '$home_one/state/task-b.status'" "$brief" >/dev/null || fail "scout brief did not shell-quote FM_HOME state path"
+  grep -F "tee -a '$home_one/state/task-b.status'" "$brief" >/dev/null || fail "scout brief did not shell-quote FM_HOME state path"
 
   FM_HOME="$home_one" FM_SECONDMATE_CHARTER='ops domain' "$ROOT/bin/fm-brief.sh" task-c --secondmate app >/dev/null \
     || fail "secondmate brief scaffold failed under FM_HOME"
   brief="$home_one/data/task-c/brief.md"
-  grep -F ">> '$home_one/state/task-c.status'" "$brief" >/dev/null || fail "secondmate brief did not shell-quote FM_HOME state path"
+  grep -F "tee -a '$home_one/state/task-c.status'" "$brief" >/dev/null || fail "secondmate brief did not shell-quote FM_HOME state path"
 
   printf 'project=x\n' > "$home_one/state/task-a.meta"
   FM_HOME="$home_one" FM_GUARD_GRACE=999999 "$ROOT/bin/fm-pr-check.sh" task-a https://github.com/example/repo/pull/1 >/dev/null 2>/dev/null \


### PR DESCRIPTION
## Summary

Low-risk non-core audit follow-up from `fm-audit-s2`.

1. **Brief status append form** - Generated ship, scout, and secondmate briefs now instruct crews to report status with `echo "{state}: ..." | tee -a $STATUS_FILE` instead of `echo ... >>`. Herdr's sandbox blocks shell redirects, so the old form failed on the first status write (audit learning #1 / A5). Scaffold content only; spawn, teardown, watcher, and backend logic untouched. Path-quoting tests updated to assert `tee -a`.
2. **Docker `--user` hygiene** - Out of scope for this PR. A full-tree search of this repo found **zero** `docker` invocations (including under `bin/`, `tests/`, generated brief text, and tooling). No non-core call site exists to add `--user "$(id -u):$(id -g)"`. Recorded below for the morning session with the teardown/compose half of audit #5.

## Test plan

- [x] `bin/fm-lint.sh` (no-mistakes lint step + local)
- [x] `./bin/fm-test-run.sh tests/fm-brief.test.sh tests/fm-secondmate-safety.test.sh`
- [x] no-mistakes run `01KZA50H2ZAB5RSFTSTFADQPWX`: intent, rebase, review, test, document, lint, push all completed with 0 findings
- [ ] GitHub Actions CI on this PR (see note below)

## Delivery note

no-mistakes push succeeded to `MabezDev:fm/fm-audit-fix-a3`. The pipeline's PR and CI steps were skipped with `skipping PR creation: gh CLI is not authenticated` (daemon cannot use the interactive keyring token). This PR was opened with `gh-axi` after that pass. Upstream Actions for the fork PR are currently `action_required` with zero jobs (maintainer workflow approval for the fork); the opener has pull-only on `kunchenguid/firstmate` and cannot approve or re-run them.

## For the morning interactive session

Hard out of scope for this crew; do not treat this PR as covering them:

1. **Firstmate self-update** (audit setup #1) - use `/updatefirstmate` in an empty-fleet window.
2. **Validation-wait stale churn / watcher** (setup #2, learning #9) - re-measure after update; arm-level `--stale-threshold` or #743-style cadence for alive validating crews if still burning turns.
3. **no-mistakes daemon update** (setup #3) - NEVER restart the shared daemon while lanes are mid-pipeline; empty-fleet only.
4. **`gh auth login` / daemon-visible `gh` token** (setup #4, learning #13) - plain `gh` is unauthenticated from the no-mistakes daemon, so PR/CI steps skip; interactive shell keyring auth does not reach the daemon. Also needed so no-mistakes can open the PR body itself with the Pipeline section.
5. **Docker hygiene - remaining work** (setup #5, learnings #12/#22):
   - Non-core `--user` half: **no call site in this repo** (repo-wide search: zero `docker`/`podman`/`nerdctl` run/build/exec/compose invocations). If root-owned files come from a *project* (e.g. birdied) compose/test containers, fix lives in that project.
   - Teardown/compose-recording half: record compose project in task meta and `docker compose down` on teardown - would touch `bin/fm-teardown.sh` / spawn path, deliberately out of scope here.
6. **Backend decision: herdr vs tmux** (setup #6) - captain call; pin `config/backend` if desired.
7. **treehouse binary update** (setup #7) - live pools tonight; opportunistic later.
8. **captain.md determinism** (setup #8 / upstream #911) - monitor only.
9. **learnings.md curation** - home data; firstmate maintains it directly, not via this PR.
10. **Approve fork workflow runs for this PR** (or grant write) so CI and Require no-mistakes can execute on https://github.com/kunchenguid/firstmate/pull/1765

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

Run id: `01KZA50H2ZAB5RSFTSTFADQPWX` head `b04e6a4a`

<details>
<summary>✅ **intent** - passed</summary>

✅ Intent supplied by the agent; no issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ Already ahead of origin/main.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found. Scope-complete scaffold `tee -a` change; fix 2 out-of-scope claim source-verified.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ `tests/fm-brief.test.sh` and `tests/fm-secondmate-safety.test.sh` green; generated ship/scout/secondmate briefs use `tee -a` only.

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No documentation updates required; `bin/fm-brief.sh` owns status protocol.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ `bin/fm-lint.sh` (ShellCheck 0.11.0 pinned).

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ Pushed to fork `MabezDev/firstmate` branch `fm/fm-audit-fix-a3`.

</details>

<details>
<summary>⚠️ **PR / CI** - skipped by pipeline</summary>

Daemon: `skipping PR creation: gh CLI is not authenticated` / `skipping CI: gh CLI is not authenticated`. PR opened afterward via `gh-axi` as https://github.com/kunchenguid/firstmate/pull/1765.

</details>
