### PR TITLE
fix(bin): accept opencode/kimi effort as documentation in dispatch validator

### DIFF
--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -742,7 +742,7 @@ crew_dispatch_validate() {
       elif $h == "codex" then (["low","medium","high","xhigh"] | index($e))
       elif $h == "grok" then (["low","medium","high"] | index($e))
       elif $h == "pi" or $h == "pi-signed" then (["low","medium","high","xhigh","max"] | index($e))
-      elif $h == "opencode" or $h == "kimi" then false
+      elif $h == "opencode" or $h == "kimi" then true
       else true
       end;
     def profiles($value):

--- a/tests/fm-bootstrap.test.sh
+++ b/tests/fm-bootstrap.test.sh
@@ -811,9 +811,9 @@ unsupported grok max effort is flagged^{"rules":[{"when":"deep current work","us
 unsupported grok xhigh effort is flagged^{"rules":[{"when":"deep current work","use":{"harness":"grok","model":"grok-4","effort":"xhigh"}}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - invalid effort: grok:xhigh
 pi max effort is accepted^{"rules":[{"when":"deep coding","use":{"harness":"pi","model":"openai-codex/gpt-5.6-sol","effort":"max"}}]}^empty^
 pi-signed max effort is accepted^{"rules":[{"when":"signed coding","use":{"harness":"pi-signed","model":"openai-codex/gpt-5.6-sol","effort":"max"}}]}^empty^
-unsupported opencode effort is flagged^{"rules":[{"when":"opencode work","use":{"harness":"opencode","model":"anthropic/claude-sonnet-4-5","effort":"high"}}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - invalid effort: opencode:high
+opencode effort is accepted as documentation^{"rules":[{"when":"opencode work","use":{"harness":"opencode","model":"anthropic/claude-sonnet-4-5","effort":"high"}}]}^empty^
 kimi model profile is accepted^{"rules":[{"when":"kimi work","use":{"harness":"kimi","model":"kimi-code/k3"}}]}^empty^
-unsupported kimi effort is flagged^{"rules":[{"when":"kimi work","use":{"harness":"kimi","model":"kimi-code/k3","effort":"high"}}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - invalid effort: kimi:high
+kimi effort is accepted as documentation^{"rules":[{"when":"kimi work","use":{"harness":"kimi","model":"kimi-code/k3","effort":"high"}}]}^empty^
 array use with quota-balanced is accepted^{"rules":[{"when":"big feature","use":[{"harness":"claude","model":"claude-sonnet-5","effort":"high"},{"harness":"codex","model":"gpt-5.5","effort":"high"}],"select":"quota-balanced"}]}^empty^
 array use without select is accepted^{"rules":[{"when":"big feature","use":[{"harness":"claude"},{"harness":"codex"}]}]}^empty^
 one-element array use is accepted^{"rules":[{"when":"focused feature","use":[{"harness":"claude"}]}]}^empty^


### PR DESCRIPTION
## Problem

The crew-dispatch.json validator in `fm-bootstrap.sh` rejected any `effort` field on an opencode or kimi profile, even though `fm-spawn.sh` already accepts it: `effort_flag_for_harness` records the requested `effort=` in task meta and emits no flag for harnesses without a verified effort knob (`harness-adapters` confirms opencode's interactive launch has none).

The validator was the outlier, forcing operators to drop effort fields from their routing rules to unblock dispatch, losing the recorded intent.

## Fix

Align the validator with `fm-spawn`'s behavior: any string effort value on an opencode or kimi profile is accepted as documentation. The two test rows that expected rejection now expect acceptance.

## Blast radius

Low. The change only relaxes validation to match existing spawn behavior; no new code paths, no behavior change for other harnesses.