### PR TITLE
feat(bin): forbid ticket refs and decision-narrative in project docs

### DIFF
--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -448,6 +448,9 @@ $RULE1
 7. Never stop, restart, or update the shared \`no-mistakes\` daemon - it is one instance serving
    every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
    daemon error, append \`blocked: {the daemon error}\` and stop; only firstmate manages the daemon.
+8. Never reference an external issue tracker ID (Linear, Jira, GitHub issue numbers, etc.) or narrate
+   decision history (e.g. "originally X, changed to Y", dated correction language) in this project's
+   own code comments or documentation. State only the current, durable technical truth.
 
 # Project memory
 If \`AGENTS.md\` or \`CLAUDE.md\` already exists, or if this task produced durable project-intrinsic knowledge, run \`$FM_ROOT/bin/fm-ensure-agents-md.sh .\` in the worktree.

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -217,6 +217,32 @@ test_ship_modes_generate_clean_briefs() {
   pass "fm-brief.sh: no-mistakes/direct-PR/local-only briefs generate cleanly"
 }
 
+# Rule 8 must reach every ship brief regardless of delivery mode, and must not
+# leak into a scout brief (a scout's deliverable is a report, not project code
+# or docs, so the rule does not apply there).
+test_ship_rule8_forbids_issue_refs_and_decision_narrative() {
+  local home brief
+  home="$TMP_ROOT/rule8-home"
+  write_registry "$home"
+
+  for id_mode in "brief-rule8-a1:no-mistakes" "brief-rule8-a2:direct-PR" "brief-rule8-a3:local-only"; do
+    local id=${id_mode%%:*} mode=${id_mode##*:}
+    FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --mode "$mode" >/dev/null 2>&1
+    brief="$home/data/$id/brief.md"
+    assert_grep '8. Never reference an external issue tracker ID' "$brief" \
+      "$id: ship brief missing numbered rule 8 forbidding issue-tracker IDs"
+    assert_grep 'decision history' "$brief" \
+      "$id: ship brief missing the decision-history-narrative prohibition"
+  done
+
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" brief-rule8-scout some-proj --scout >/dev/null 2>&1
+  brief="$home/data/brief-rule8-scout/brief.md"
+  assert_no_grep 'external issue tracker ID' "$brief" \
+    "scout brief should not carry the ship-only rule 8 (scout delivers a report, not project code/docs)"
+
+  pass "fm-brief.sh: rule 8 forbids issue-tracker IDs and decision-narrative in ship briefs only"
+}
+
 # A ship task's delivery mode is firstmate's per-task decision, so a missing or
 # unusable value must stop the scaffold instead of silently defaulting. The
 # no-mistakes-prod-only row is the conditional registry policy: it is never a task
@@ -712,6 +738,7 @@ test_script_parses
 test_no_heredoc_in_command_substitution
 test_help_includes_entire_header
 test_ship_modes_generate_clean_briefs
+test_ship_rule8_forbids_issue_refs_and_decision_narrative
 test_ship_mode_is_required_and_closed_set
 test_ship_mode_is_explicit_not_registry
 test_delivery_flags_are_refused_where_they_do_not_apply


### PR DESCRIPTION
## Summary
Crewmates were writing external issue-tracker references (Linear, Jira, GitHub issue numbers) and decision-narrative language ("originally X, changed to Y", dated correction language) directly into project code comments and documentation. Both rot: a ticket pointer ties the code's own docs to a mutable external system, and a decision-narrative comment describes how the code got here instead of what is true about it now.

Adds rule 8 to `bin/fm-brief.sh`'s ship brief template, so every future ship task carries this standing rule automatically. Scoped to ship briefs only - scout tasks never write project code/docs, their deliverable is a report.

## Test plan
- [x] `bash tests/fm-brief.test.sh` passes, including a new colocated regression test verifying rule 8 appears in all three ship delivery modes and is absent from scout briefs
- [x] `bin/fm-lint.sh` (ShellCheck 0.11.0) passes clean
