### PR TITLE
test: isolate spawn batch fixtures from live config

### DIFF
--- a/tests/fm-spawn-batch.test.sh
+++ b/tests/fm-spawn-batch.test.sh
@@ -1,12 +1,11 @@
 #!/usr/bin/env bash
 # Behavior tests for fm-spawn.sh batch dispatch (`id=repo` pairs).
 #
-# These exercise argument routing only: each spawn attempt fails fast at the
-# missing-brief check, which is reached before any tmux/treehouse side effect, so
-# the tests create no windows or worktrees. FM_SPAWN_NO_GUARD=1 keeps them off the
-# live watcher guard / state. Parser and path-scoping cases are table-driven; the
-# only behavior asserted on its own is "a multi-pair batch does not stop after the
-# first failure".
+# These exercise argument routing only: each spawn attempt fails before endpoint
+# creation, so the tests create no windows or worktrees. FM_SPAWN_NO_GUARD=1 keeps
+# them off the live watcher guard, and every home-local path points into TMP_ROOT.
+# Parser and path-scoping cases are table-driven; the only behavior asserted on
+# its own is "a multi-pair batch does not stop after the first failure".
 set -u
 
 # shellcheck source=tests/lib.sh
@@ -14,18 +13,26 @@ set -u
 
 SPAWN="$ROOT/bin/fm-spawn.sh"
 TMP_ROOT=$(fm_test_tmproot fm-spawn-batch)
+TEST_HOME="$TMP_ROOT/home"
+mkdir -p "$TEST_HOME/state" "$TEST_HOME/data" "$TEST_HOME/projects" "$TEST_HOME/config"
 export FM_BACKEND=tmux
 
-# Clear ambient firstmate overrides so the behavior test owns its environment.
-run_spawn() {
+# Drive the public spawn interface against one fully isolated Firstmate home.
+run_spawn_in_home() {
+  local home=$1
+  shift
   FM_ROOT_OVERRIDE='' \
-    FM_HOME='' \
-    FM_STATE_OVERRIDE='' \
-    FM_DATA_OVERRIDE='' \
-    FM_PROJECTS_OVERRIDE='' \
-    FM_CONFIG_OVERRIDE='' \
+    FM_HOME="$home" \
+    FM_STATE_OVERRIDE="$home/state" \
+    FM_DATA_OVERRIDE="$home/data" \
+    FM_PROJECTS_OVERRIDE="$home/projects" \
+    FM_CONFIG_OVERRIDE="$home/config" \
     FM_SPAWN_NO_GUARD=1 \
     "$SPAWN" "$@" 2>&1
+}
+
+run_spawn() {
+  run_spawn_in_home "$TEST_HOME" "$@"
 }
 
 # Ship spawns carry an explicit delivery contract (AGENTS.md section 7); the
@@ -46,6 +53,35 @@ test_batch_dispatches_every_pair() {
   printf '%s\n' "$out" | grep -F 'batch: FAILED to spawn nope-batch-b-z2 (projects/none-b)' >/dev/null \
     || fail "second pair was not dispatched/reported (loop stopped early?)"
   pass "batch dispatch re-execs and reports every id=repo pair"
+}
+
+# A real home may carry dispatch profiles, but that local state must never leak
+# into the argument-routing fixture above. Pin the production backstop separately:
+# it refuses a profile-aware batch without a resolved harness, while adding that
+# one shared input reaches and reports every pair.
+test_batch_honors_active_dispatch_profile() {
+  local home out status
+  home="$TMP_ROOT/profile-home"
+  mkdir -p "$home/state" "$home/data" "$home/projects" "$home/config"
+  printf '%s\n' '{"default":{"harness":"codex","model":"gpt-5","effort":"medium"}}' \
+    > "$home/config/crew-dispatch.json"
+
+  out=$(run_spawn_in_home "$home" nope-batch-profile-a-z13=projects/none-a nope-batch-profile-b-z14=projects/none-b --mode no-mistakes --yolo off)
+  status=$?
+  [ "$status" -ne 0 ] || fail "active dispatch profile should require an explicit harness"
+  printf '%s\n' "$out" | grep -F 'config/crew-dispatch.json is active - pass an explicit harness' >/dev/null \
+    || fail "active dispatch profile refusal was not reported"
+  printf '%s\n' "$out" | grep -F 'batch:' >/dev/null \
+    && fail "active dispatch profile reached pair dispatch without an explicit harness"
+
+  out=$(run_spawn_in_home "$home" nope-batch-profile-a-z13=projects/none-a nope-batch-profile-b-z14=projects/none-b --harness codex --mode no-mistakes --yolo off)
+  status=$?
+  [ "$status" -ne 0 ] || fail "profile-aware batch with missing projects should exit non-zero"
+  printf '%s\n' "$out" | grep -F 'batch: FAILED to spawn nope-batch-profile-a-z13 (projects/none-a)' >/dev/null \
+    || fail "explicit shared harness did not dispatch/report the first profile-aware pair"
+  printf '%s\n' "$out" | grep -F 'batch: FAILED to spawn nope-batch-profile-b-z14 (projects/none-b)' >/dev/null \
+    || fail "explicit shared harness did not dispatch/report the second profile-aware pair"
+  pass "batch dispatch isolates local config and honors the active-profile harness backstop"
 }
 
 # Boundary cases for batch detection. Each row:
@@ -142,6 +178,7 @@ test_scout_batch_refuses_delivery_flags() {
 }
 
 test_batch_dispatches_every_pair
+test_batch_honors_active_dispatch_profile
 test_batch_mode_boundaries
 test_batch_requires_the_shared_delivery_contract
 test_scout_batch_refuses_delivery_flags

--- a/tests/fm-spawn-batch.test.sh
+++ b/tests/fm-spawn-batch.test.sh
@@ -4,8 +4,9 @@
 # These exercise argument routing only: each spawn attempt fails before endpoint
 # creation, so the tests create no windows or worktrees. FM_SPAWN_NO_GUARD=1 keeps
 # them off the live watcher guard, and every home-local path points into TMP_ROOT.
-# Parser and path-scoping cases are table-driven; the only behavior asserted on
-# its own is "a multi-pair batch does not stop after the first failure".
+# Parser and path-scoping cases are table-driven.
+# Standalone regressions pin both multi-pair completion and the active-profile
+# explicit-harness backstop.
 set -u
 
 # shellcheck source=tests/lib.sh


### PR DESCRIPTION
## Intent

Diagnose and fix the reproducible current-base tests/fm-spawn-batch.test.sh failure that blocked the captain-approved Firstmate update, based exactly on upstream 6f0f87f4ce62a31cf36bf6afb5c56aa818c6fe6b. Reproduce the maintainer-visible failure through the public test invocation with full assertion context; distinguish the initiating trigger, masking condition, and visible symptom; compare the failing two-pair path with proven single-task and successful batch dispatch across inputs, environment, parsing, subprocess behavior, state transitions, and reporting; inspect history for the earliest meaningful divergence; and verify the leading explanation with a one-variable counterfactual plus deliberate disconfirming evidence, separating observations from hypotheses. Apply only the narrow correction justified by that evidence: fix production only if its executable contract is wrong, otherwise fix the stale or invalid test. Preserve explicit --mode and --yolo inputs, batch isolation, per-pair reporting, and every supported runtime backend and harness surface. Convert the faithful reproduction into behavioral regression coverage through fm-spawn public invocations without asserting source bytes. Do not alter live configuration, active AXI launchers, secondmate homes, parked work, the update evidence report, or Herdr lifecycle state. Run the focused regression, relevant neighboring batch and dispatch tests, documentation audience checks if maintained prose changes, and canonical bin/fm-lint.sh. Commit the diagnosis-backed implementation and tests, publish only through the full no-mistakes review path, and do not merge any PR. The evidence established that production correctly refuses a profile-aware batch lacking an explicit resolved harness; the defect is test isolation because empty FM_HOME and path overrides fall back to the real Firstmate home. The accepted correction therefore isolates every test home-local path and pins the active-profile refusal plus explicit-harness counterfactual through the public interface.

## What Changed

- Isolate spawn batch fixtures by directing every Firstmate home-local path to temporary test directories, preventing live configuration from leaking into tests.
- Add public-interface regression coverage for active-profile refusal without an explicit harness and successful per-pair dispatch reporting with `--harness codex`.
- Clarify the batch test’s documented isolation and behavioral guarantees.

## Risk Assessment

✅ Low: Captain, this is a narrow test-isolation correction; production is untouched, all home-local paths use temporary fixtures, and public-invocation coverage verifies both profile refusal and explicit-harness batch dispatch.

## Testing

No prior baseline result was supplied. Targeted batch, dispatch-profile/harness, delivery-contract, and implemented-backend tests passed; direct public invocations demonstrated the intended refusal and counterfactual behavior in the attached transcript. The initial manual attempt hit the expected validation guard and passed after using the repository’s test-only bypass; lint was not run because this assigned test phase explicitly forbids it.

<details>
<summary>Evidence: Public fm-spawn counterfactual transcript</summary>

<code>Active profile without harness refused; adding `--harness codex` dispatched and reported both pairs; a clean home also dispatched both pairs. No runtime state was created.</code>

```text
Public fm-spawn batch behavior at target commit 9faa7bb129e803e68663fe4c4664c76780a35d03
All homes and home-local paths below are isolated under the evidence directory.
FM_GATE_REFUSE_BYPASS=1 is the repository test-only exemption required inside a no-mistakes validation worktree.

=== Active profile, no explicit harness: production refuses before pair dispatch ===
FM_HOME=/tmp/no-mistakes-evidence/01KZA8WJJZSHCFTVH6ZVXYQ2BZ/manual-profile-home bin/fm-spawn.sh evidence-profile-a=projects/none-a evidence-profile-b=projects/none-b --mode no-mistakes --yolo off
error: config/crew-dispatch.json is active - pass an explicit harness resolved from the dispatch rules (the consultation backstop, so the rules are never silently skipped).
[exit=1]

=== Same active profile, adding only --harness codex: both pairs are dispatched and reported ===
FM_HOME=/tmp/no-mistakes-evidence/01KZA8WJJZSHCFTVH6ZVXYQ2BZ/manual-profile-home bin/fm-spawn.sh evidence-profile-a=projects/none-a evidence-profile-b=projects/none-b --harness codex --mode no-mistakes --yolo off
/home/anthony/.no-mistakes/worktrees/709ca3db2d35/01KZA8WJJZSHCFTVH6ZVXYQ2BZ/bin/fm-spawn.sh: line 1204: cd: /tmp/no-mistakes-evidence/01KZA8WJJZSHCFTVH6ZVXYQ2BZ/manual-profile-home/projects/none-a: No such file or directory
batch: FAILED to spawn evidence-profile-a (projects/none-a)
/home/anthony/.no-mistakes/worktrees/709ca3db2d35/01KZA8WJJZSHCFTVH6ZVXYQ2BZ/bin/fm-spawn.sh: line 1204: cd: /tmp/no-mistakes-evidence/01KZA8WJJZSHCFTVH6ZVXYQ2BZ/manual-profile-home/projects/none-b: No such file or directory
batch: FAILED to spawn evidence-profile-b (projects/none-b)
[exit=1]

=== Clean isolated home, no profile and no explicit harness: both pairs still reach batch dispatch ===
FM_HOME=/tmp/no-mistakes-evidence/01KZA8WJJZSHCFTVH6ZVXYQ2BZ/manual-clean-home bin/fm-spawn.sh evidence-clean-a=projects/none-a evidence-clean-b=projects/none-b --mode no-mistakes --yolo off
/home/anthony/.no-mistakes/worktrees/709ca3db2d35/01KZA8WJJZSHCFTVH6ZVXYQ2BZ/bin/fm-spawn.sh: line 1204: cd: /tmp/no-mistakes-evidence/01KZA8WJJZSHCFTVH6ZVXYQ2BZ/manual-clean-home/projects/none-a: No such file or directory
batch: FAILED to spawn evidence-clean-a (projects/none-a)
/home/anthony/.no-mistakes/worktrees/709ca3db2d35/01KZA8WJJZSHCFTVH6ZVXYQ2BZ/bin/fm-spawn.sh: line 1204: cd: /tmp/no-mistakes-evidence/01KZA8WJJZSHCFTVH6ZVXYQ2BZ/manual-clean-home/projects/none-b: No such file or directory
batch: FAILED to spawn evidence-clean-b (projects/none-b)
[exit=1]

=== Side-effect check ===
No task metadata or runtime state files were created.

EVIDENCE RESULT: all public-interface expectations satisfied.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>Inspected the base-to-target diff and relevant `git log`/`git blame` history</code>
- `bash tests/fm-spawn-batch.test.sh`
- `bash tests/fm-spawn-dispatch-profile.test.sh`
- `bash tests/fm-task-delivery.test.sh`
- `bash tests/fm-backend.test.sh`
- <code>Direct isolated-home `bin/fm-spawn.sh` matrix without the test bypass (expected validation-environment guard intercepted it)</code>
- <code>Retried the direct matrix with `FM_GATE_REFUSE_BYPASS=1`, covering active-profile refusal, `--harness codex` counterfactual, clean-home disconfirmation, per-pair reporting, and state-file absence</code>
- `git status --short`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
