### PR TITLE
Declare what a directing session is working on

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -242,6 +242,8 @@ The delivery lifecycle is an always-loaded operational contract; referenced scri
 Resolve the project independently for every request.
 An explicit project wins, a clear follow-up inherits its referent, and otherwise match the request against the registry, work under way, and project code or README.
 Proceed on one confident match while naming the project in plain language; ask one concise question when multiple or no projects plausibly match.
+Once resolved, run `bin/fm-declare-work.sh` so a time-capture tool can attribute the captain's own directing time to the work it directs rather than to the firstmate home he types in; it is inert when no such tool is installed, never fails a caller, and its header owns the arguments.
+Re-run it whenever the work in hand changes, because the declaration expires rather than persisting.
 
 Route by the nature of the work against each registered secondmate scope, not by a non-exclusive clone list.
 Keep `local-only` work in the main home.

--- a/bin/fm-declare-work.sh
+++ b/bin/fm-declare-work.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+# Declare, to any time-capture tool watching, what the CURRENT session is working on.
+#
+# Usage:
+#   fm-declare-work.sh <work-item> [--repo <path>] [--remote <host/owner/name>] [--label <text>]
+#   fm-declare-work.sh --project <path> <work-item> [--label <text>]
+#   fm-declare-work.sh --clear
+#   fm-declare-work.sh --help
+#
+# Why this exists.
+#   Firstmate is a control plane. The captain types in the firstmate home and
+#   the work happens somewhere else entirely - a treehouse worktree, a pipeline
+#   lane, another repository. A capture tool watching the keyboard sees only the
+#   firstmate home, so the captain's real, typed, human time on a client's work
+#   is recorded against firstmate itself and bills as internal.
+#
+#   Measured over one month on the captain's machine: on the day he moved from
+#   typing in the client's repository to directing work from here, his billable
+#   time for that client fell to zero, while fifty hours of that client's work
+#   was produced. Ten and a half hours of genuine direction filed as internal.
+#
+#   The environment cannot carry the fact. A directing session is long-lived and
+#   serves several pieces of work in turn, while an exported variable is fixed
+#   when the process starts - which is why a spawned lane can be labelled by its
+#   environment and the session that spawned it cannot.
+#
+# What it writes.
+#   One small JSON file per harness session, under the capture tool's
+#   declarations directory, naming the work item and the repository that work
+#   belongs to. It never names a client, an engagement, or a rate: who a
+#   repository bills to is the operator's own configuration to decide, and
+#   firstmate has no business asserting it.
+#
+# Safety contract.
+#   - Writes nothing and exits 0 when no capture tool is configured, so this is
+#     inert on a machine that does not use one.
+#   - Writes nothing and exits 0 when the session id is unknown, rather than
+#     guessing an owner for the declaration.
+#   - Never fails a caller. Firstmate's own work must not stop because a
+#     bookkeeping file could not be written.
+#   - Refuses a session id that is not a plain filename component, rather than
+#     sanitising one, because a silently rewritten path names a file nobody meant.
+#
+# The declaration is deliberately short-lived at the reader's end: it expires
+# unless rewritten. Re-run this whenever the work in hand changes. Stale is
+# expected and safe - it falls back to location-based attribution, which
+# under-attributes rather than mis-attributes.
+
+set -u
+
+usage() {
+  sed -n '2,46p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+}
+
+# Where the capture tool reads declarations from. Resolution order matches
+# worklog's own: an explicit override, then the store location, then its
+# default. Absent every one of them, there is no capture tool to talk to.
+declarations_dir() {
+  if [ -n "${WORKLOG_DECLARATIONS_DIR:-}" ]; then
+    printf '%s\n' "$WORKLOG_DECLARATIONS_DIR"
+    return 0
+  fi
+  if [ -n "${WORKLOG_STORE_DIR:-}" ]; then
+    printf '%s/declarations\n' "$WORKLOG_STORE_DIR"
+    return 0
+  fi
+  local state="${XDG_STATE_HOME:-$HOME/.local/state}"
+  if [ -d "$state/worklog" ]; then
+    printf '%s/worklog/declarations\n' "$state"
+    return 0
+  fi
+  return 1
+}
+
+# A session id that is safe to use as a filename. Refused, never repaired.
+usable_session_id() {
+  case "$1" in
+    '' | '.' | '..') return 1 ;;
+    */* | *\\*) return 1 ;;
+    *) return 0 ;;
+  esac
+}
+
+# Minimal JSON string escaping for the fields written below.
+json_escape() {
+  printf '%s' "$1" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g' -e 's/\t/\\t/g' | tr -d '\000-\010\013\014\016-\037'
+}
+
+# The normalised remote of a repository, in the host/owner/name shape a capture
+# tool compares against. Prints nothing when there is no usable remote.
+remote_of_repo() {
+  local repo=$1 url
+  url=$(git -C "$repo" config --get remote.origin.url 2>/dev/null) || return 1
+  [ -n "$url" ] || return 1
+  printf '%s\n' "$url" |
+    sed -e 's#^[a-z+]*://##' -e 's#^[^@]*@##' -e 's#:#/#' -e 's#\.git$##' -e 's#/*$##'
+}
+
+WORK_ITEM=''
+REPO=''
+REMOTE=''
+LABEL=''
+CLEAR=0
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --help | -h)
+      usage
+      exit 0
+      ;;
+    --clear) CLEAR=1 ;;
+    --project | --repo)
+      REPO=${2:-}
+      shift
+      ;;
+    --project=* | --repo=*) REPO=${1#*=} ;;
+    --remote)
+      REMOTE=${2:-}
+      shift
+      ;;
+    --remote=*) REMOTE=${1#*=} ;;
+    --label)
+      LABEL=${2:-}
+      shift
+      ;;
+    --label=*) LABEL=${1#*=} ;;
+    -*)
+      echo "fm-declare-work.sh: unknown option: $1" >&2
+      exit 2
+      ;;
+    *) [ -n "$WORK_ITEM" ] || WORK_ITEM=$1 ;;
+  esac
+  shift
+done
+
+SESSION_ID="${CLAUDE_CODE_SESSION_ID:-}"
+usable_session_id "$SESSION_ID" || exit 0
+
+DIR=$(declarations_dir) || exit 0
+FILE="$DIR/$SESSION_ID.json"
+
+if [ "$CLEAR" -eq 1 ]; then
+  rm -f "$FILE" 2>/dev/null || true
+  exit 0
+fi
+
+[ -n "$WORK_ITEM" ] || {
+  echo "fm-declare-work.sh: a work item is required (or --clear)" >&2
+  exit 2
+}
+
+if [ -n "$REPO" ] && [ -z "$REMOTE" ]; then
+  REMOTE=$(remote_of_repo "$REPO" 2>/dev/null) || REMOTE=''
+fi
+
+mkdir -p "$DIR" 2>/dev/null || exit 0
+
+NOW_MS=$(( $(date +%s) * 1000 ))
+
+{
+  printf '{"sessionId":"%s","workItem":"%s"' \
+    "$(json_escape "$SESSION_ID")" "$(json_escape "$WORK_ITEM")"
+  [ -n "$LABEL" ] && printf ',"label":"%s"' "$(json_escape "$LABEL")"
+  [ -n "$REPO" ] && printf ',"repoRoot":"%s"' "$(json_escape "$REPO")"
+  [ -n "$REMOTE" ] && printf ',"remote":"%s"' "$(json_escape "$REMOTE")"
+  printf ',"at":%s}\n' "$NOW_MS"
+} >"$FILE.tmp.$$" 2>/dev/null || exit 0
+
+# Atomic replace, so a reader never sees a half-written declaration.
+mv -f "$FILE.tmp.$$" "$FILE" 2>/dev/null || {
+  rm -f "$FILE.tmp.$$" 2>/dev/null || true
+  exit 0
+}
+
+exit 0

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -856,6 +856,7 @@ launch_template() {
 case "$ARG3" in
   *' '*)  # raw launch command (unverified-adapter escape hatch)
     LAUNCH=$ARG3
+    LAUNCH_IS_RAW=1
     HARNESS=""
     for word in $LAUNCH; do
       case "$word" in [A-Za-z_]*=*) continue ;; *) HARNESS=$(basename "$word"); break ;; esac
@@ -2101,6 +2102,26 @@ LAUNCH=${LAUNCH//__OPINPUT__/$sq_opinput}
 # an unset value is the single-store default and needs no prefix.
 if [ "$HARNESS" = claude ] && [ -n "${CLAUDE_CONFIG_DIR:-}" ]; then
   LAUNCH="CLAUDE_CONFIG_DIR=$(shell_quote "$CLAUDE_CONFIG_DIR") $LAUNCH"
+fi
+# Name the task in the lane's own environment.
+#
+# A spawned lane exists to do exactly one named thing for its whole life, which
+# is what makes a fixed environment variable the right carrier here - and why
+# the session that SPAWNED it needs the separate, rewritable declaration that
+# bin/fm-declare-work.sh writes instead.
+#
+# A time-capture tool reading this labels the lane's hours with the task rather
+# than with whatever branch the worktree happens to sit on, so the captain's own
+# direction and the work it produced share one identifier and can be reported
+# against each other. Nothing firstmate does depends on it; a tool that does not
+# read it is unaffected.
+#
+# Deliberately skipped for a raw launch command. That escape hatch's guarantee
+# is that the operator's command is used exactly as given, and a lane attributed
+# by task is not worth weakening it. Such a lane simply binds by its worktree,
+# as every lane did before this.
+if [ "${LAUNCH_IS_RAW:-0}" != 1 ]; then
+  LAUNCH="FM_TASK=$(shell_quote "$ID") $LAUNCH"
 fi
 if [ "$KIND" = secondmate ]; then
   sq_home=$(shell_quote "$PROJ_ABS")

--- a/tests/fm-declare-work.test.sh
+++ b/tests/fm-declare-work.test.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+# Behavioral regressions for the work declaration firstmate writes for capture tools.
+#
+# The value of this script is almost entirely in what it REFUSES to write. A
+# declaration outranks every other signal a capture tool has, so a wrong or
+# careless one moves the captain's hours onto the wrong client's invoice.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+DECLARE="$ROOT/bin/fm-declare-work.sh"
+TMP_ROOT=$(fm_test_tmproot fm-declare-work)
+
+SESSION='sess-decl-1'
+
+# How many declarations exist in a directory.
+count_json() {
+  find "$1" -name '*.json' 2>/dev/null | wc -l | tr -d ' '
+}
+
+test_writes_a_declaration_for_this_session() {
+  local dir file body
+  dir="$TMP_ROOT/decls-basic"
+
+  WORKLOG_DECLARATIONS_DIR="$dir" CLAUDE_CODE_SESSION_ID="$SESSION" \
+    "$DECLARE" 'fm:login-burst-security' --label 'login-burst-security'
+
+  file="$dir/$SESSION.json"
+  assert_present "$file" "no declaration was written for the current session"
+  body=$(cat "$file")
+  assert_contains "$body" '"workItem":"fm:login-burst-security"' \
+    "declaration does not name the work item"
+  assert_contains "$body" "\"sessionId\":\"$SESSION\"" \
+    "declaration does not name the session it belongs to"
+  assert_contains "$body" '"label":"login-burst-security"' \
+    "declaration dropped the human-readable label"
+  # A reader that cannot date a declaration cannot expire it, and a declaration
+  # that never expires bills forever.
+  grep -Eq '"at":[0-9]{10,}' "$file" ||
+    fail "declaration carries no usable timestamp, so a reader cannot judge staleness"
+  pass "a declaration names the work, the session and when it was made"
+}
+
+test_never_names_a_client() {
+  local dir body
+  dir="$TMP_ROOT/decls-noclient"
+
+  WORKLOG_DECLARATIONS_DIR="$dir" CLAUDE_CODE_SESSION_ID="$SESSION" \
+    "$DECLARE" 'fm:some-task' --label 'some task'
+
+  # Who a repository bills to is the operator's configuration to decide.
+  # Firstmate asserting it here would put a client name into tracked tooling
+  # and make the capture tool's own rules unfalsifiable.
+  body=$(cat "$dir/$SESSION.json")
+  assert_not_contains "$body" '"engagement"' "declaration asserted an engagement"
+  assert_not_contains "$body" '"client"' "declaration asserted a client"
+  assert_not_contains "$body" '"rate"' "declaration asserted a rate"
+  pass "a declaration carries work, never a client or a rate"
+}
+
+test_records_the_repository_the_work_belongs_to() {
+  local dir repo body
+  dir="$TMP_ROOT/decls-repo"
+  repo="$TMP_ROOT/work-repo"
+  mkdir -p "$repo"
+  git -C "$repo" init --quiet
+  git -C "$repo" remote add origin 'https://github.com/acme/app.git'
+
+  WORKLOG_DECLARATIONS_DIR="$dir" CLAUDE_CODE_SESSION_ID="$SESSION" \
+    "$DECLARE" 'fm:task' --project "$repo"
+
+  body=$(cat "$dir/$SESSION.json")
+  # The normalised host/owner/name shape, which is what a capture tool's
+  # engagement rules compare against. A raw clone URL would match nothing.
+  assert_contains "$body" '"remote":"github.com/acme/app"' \
+    "the declared remote is not the normalised identity rules compare against"
+  assert_contains "$body" '"repoRoot"' "declaration dropped the repository root"
+  pass "a declaration carries the repository the directed work belongs to"
+}
+
+test_inert_without_a_capture_tool() {
+  local dir code
+  dir="$TMP_ROOT/absent"
+  mkdir -p "$TMP_ROOT/empty-home"
+
+  # No override and no store present: nothing is watching, so there is nothing
+  # to say. This must be silent and successful on every machine that does not
+  # use a capture tool.
+  HOME="$TMP_ROOT/empty-home" XDG_STATE_HOME="$dir" WORKLOG_DECLARATIONS_DIR='' \
+    WORKLOG_STORE_DIR='' CLAUDE_CODE_SESSION_ID="$SESSION" \
+    "$DECLARE" 'fm:task'
+  code=$?
+
+  expect_code 0 "$code" "declaring on a machine with no capture tool"
+  assert_absent "$dir/worklog/declarations/$SESSION.json" \
+    "a declaration was written where no capture tool is installed"
+  pass "declaring is inert when nothing is watching"
+}
+
+test_refuses_to_guess_an_owner() {
+  local dir code
+  dir="$TMP_ROOT/decls-nosession"
+  mkdir -p "$dir"
+
+  # No session id means the declaration would have no owner. Guessing one would
+  # apply this work item to somebody else's hours.
+  WORKLOG_DECLARATIONS_DIR="$dir" CLAUDE_CODE_SESSION_ID='' "$DECLARE" 'fm:task'
+  code=$?
+
+  expect_code 0 "$code" "declaring without a session id"
+  [ "$(count_json "$dir")" = '0' ] ||
+    fail "a declaration was written with no session to own it"
+  pass "an unknown session produces no declaration rather than a guessed one"
+}
+
+test_refuses_a_session_id_that_escapes_the_directory() {
+  local dir bad code
+  dir="$TMP_ROOT/decls-escape"
+  mkdir -p "$dir"
+
+  for bad in '../escaped' 'a/b' '..' '.'; do
+    WORKLOG_DECLARATIONS_DIR="$dir" CLAUDE_CODE_SESSION_ID="$bad" "$DECLARE" 'fm:task'
+    code=$?
+    expect_code 0 "$code" "a refused session id ($bad)"
+  done
+
+  assert_absent "$TMP_ROOT/escaped.json" \
+    "a session id escaped the declarations directory"
+  [ "$(count_json "$dir")" = '0' ] ||
+    fail "an unusable session id still produced a declaration"
+  pass "a session id that is not a plain filename is refused, not sanitised"
+}
+
+test_clearing_removes_the_declaration() {
+  local dir file
+  dir="$TMP_ROOT/decls-clear"
+
+  WORKLOG_DECLARATIONS_DIR="$dir" CLAUDE_CODE_SESSION_ID="$SESSION" "$DECLARE" 'fm:task'
+  file="$dir/$SESSION.json"
+  assert_present "$file" "setup failed: no declaration to clear"
+
+  WORKLOG_DECLARATIONS_DIR="$dir" CLAUDE_CODE_SESSION_ID="$SESSION" "$DECLARE" --clear
+  assert_absent "$file" "clearing left the declaration in place"
+  pass "clearing removes this session's declaration"
+}
+
+test_rewriting_replaces_rather_than_accumulates() {
+  local dir body
+  dir="$TMP_ROOT/decls-rewrite"
+
+  WORKLOG_DECLARATIONS_DIR="$dir" CLAUDE_CODE_SESSION_ID="$SESSION" "$DECLARE" 'fm:first'
+  WORKLOG_DECLARATIONS_DIR="$dir" CLAUDE_CODE_SESSION_ID="$SESSION" "$DECLARE" 'fm:second'
+
+  body=$(cat "$dir/$SESSION.json")
+  assert_contains "$body" '"workItem":"fm:second"' "rewriting did not take effect"
+  assert_not_contains "$body" 'fm:first' "the superseded work item survived a rewrite"
+  [ "$(count_json "$dir")" = '1' ] ||
+    fail "rewriting accumulated files instead of replacing one"
+  [ "$(find "$dir" -name '*.tmp.*' | wc -l | tr -d ' ')" = '0' ] ||
+    fail "a temporary file was left behind"
+  pass "the current work item replaces the last one"
+}
+
+test_writes_a_declaration_for_this_session
+test_never_names_a_client
+test_records_the_repository_the_work_belongs_to
+test_inert_without_a_capture_tool
+test_refuses_to_guess_an_owner
+test_refuses_a_session_id_that_escapes_the_directory
+test_clearing_removes_the_declaration
+test_rewriting_replaces_rather_than_accumulates

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -129,7 +129,10 @@ test_no_profile_keeps_claude_profile_defaults() {
   assert_meta_profile "$HOME_DIR/state/$id.meta" claude default default
 
   launch=$(cat "$LAUNCH_LOG")
-  expected="CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions \"\$('${ROOT}/bin/fm-operational-input.sh' encode launch-brief < '$HOME_DIR/data/$id/brief.md')\""
+  # FM_TASK names the lane's one piece of work for any time-capture tool
+  # reading the environment. A lane exists to do exactly one named thing for
+  # its whole life, which is what makes a fixed variable the right carrier.
+  expected="FM_TASK='$id' CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions \"\$('${ROOT}/bin/fm-operational-input.sh' encode launch-brief < '$HOME_DIR/data/$id/brief.md')\""
   [ "$launch" = "$expected" ] || fail "no-profile claude launch did not use the canonical launch kind"$'\n'"expected: $expected"$'\n'"actual:   $launch"
   pass "no --model/--effort records defaults and types the claude launch instructions"
 }


### PR DESCRIPTION
## The problem

Firstmate is a control plane. The operator types in the firstmate home while the work happens somewhere else entirely - a treehouse worktree, a pipeline lane, another repository.

Any time-capture or reporting tool watching the keyboard therefore sees only the firstmate home. An operator's real, typed time spent directing a project's work is recorded against firstmate itself rather than against the work it produced. The fleet's output is attributed correctly, because lanes run in the project's own worktree; the operator's own contribution is the part that goes missing.

This cannot be reconstructed afterwards with any confidence. Most directing turns reference no worktree at all - they are planning, decisions, questions - and `state/<id>.meta` is removed on cleanup while the backlog retains only recent Done entries. The fact has to be recorded when it is known.

## The change

Two halves, deliberately independent, either of which is useful alone.

**`bin/fm-declare-work.sh`** writes a small per-session declaration naming the work in hand.

The environment cannot carry this fact. A directing session is long-lived and serves several pieces of work in turn, while an exported variable is fixed when the process starts. That asymmetry is the whole reason a separate mechanism is needed.

**`fm-spawn`** now names the task in each lane's own environment as `FM_TASK`. A lane exists to do exactly one named thing for its whole life, which is precisely where a fixed variable is the right carrier. This half needs no cooperating tool change at all.

Together they give one identifier shared by the operator's direction and the work it produced, which is what makes "how much was the operator, how much was the fleet" answerable per task rather than per directory.

## What it does not do

**A declaration never names a client, an engagement, or a rate.** It carries a work item and at most a repository. Who that repository bills to stays a question for the operator's own configuration, and there is a test asserting the declaration cannot assert it.

## Safety

- Inert where no capture tool is installed - writes nothing, exits 0. This is a no-op for anyone not using one.
- Never fails a caller. Firstmate's work must not stop because a bookkeeping file could not be written.
- Refuses rather than sanitises a session id that is not a plain filename component, because a silently rewritten path names a file nobody meant.
- Refuses to guess an owner when the session id is unknown.
- Atomic replace, so a reader never sees a half-written declaration.
- `FM_TASK` is deliberately **skipped for a raw launch command**. That escape hatch's guarantee is that the operator's command is used exactly as given, and task attribution is not worth weakening it. `tests/fm-spawn-dispatch-profile.test.sh` covers both paths.

## Verification

- New `tests/fm-declare-work.test.sh`, 8 cases, mostly about what it refuses to write. Confirmed against a negative control: removing the session-id guard makes it fail.
- `bin/fm-lint.sh` clean, `bin/fm-doc-audience-check.sh` clean.
- `fm-spawn-dispatch-profile`, `fm-spawn-batch`, `fm-trace-context-spawn`, `fm-ask-user-authority`, `fm-brief`, `fm-session-start` all pass.
- Proven end to end against a real capture store: a turn in the firstmate home resolved to the firstmate repository before a declaration and to the directed project's repository after, with the record still naming truthfully where the turn ran.

`AGENTS.md` gains two lines at the point where the project is already resolved; the mechanics live in the script header and `--help`, per the knowledge-placement tree.