### PR TITLE
feat(bin): add guarded GitLab merge-request parity to fm-pr-merge

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ Firstmate's skills live in two separate places with different audiences:
 - [docs/cmux-backend.md](docs/cmux-backend.md) - current setup, socket security, and limits for the experimental cmux backend.
 - [docs/codex-app-backend.md](docs/codex-app-backend.md) - the current blocked Codex App backend boundary and rollout contract.
 - [docs/verification/runtime-backends.md](docs/verification/runtime-backends.md) - active maintainer verification for runtime backend guarantees.
-- [docs/gitlab-merge-watch.md](docs/gitlab-merge-watch.md) - maintainer verification for GitLab merge watching on arbitrary instances.
+- [docs/gitlab-merge-watch.md](docs/gitlab-merge-watch.md) - maintainer verification for GitLab merge watching and the guarded merge path on arbitrary instances.
 - [docs/turnend-guard.md](docs/turnend-guard.md) - the primary session's current "no turn ends blind" backstop, scope, loop safety, and compatibility limits.
 - [docs/verification/supervision.md](docs/verification/supervision.md) - active maintainer verification for session-start, guard, continuity, and wedge integrations.
 - [docs/supervision-protocols/](docs/supervision-protocols/) - rendered primary-harness watcher protocols for Claude, Codex, OpenCode, Pi and `pi-signed`, Grok, and unknown harness fallback.

--- a/bin/fm-pr-lib.sh
+++ b/bin/fm-pr-lib.sh
@@ -161,10 +161,9 @@ fm_pr_gitlab_path_valid() {
 # unchanged, and GitLab gets its own host and namespace rules rather than a
 # loosened GitHub rule.
 #
-# FM_PR_OWNER and FM_PR_REPO are additionally set for github because
-# bin/fm-pr-merge.sh addresses GitHub by owner/repository. A gitlab URL leaves
-# them empty; teaching the merge path about GitLab is a separate change, and
-# until then it refuses a GitLab URL rather than merging anything.
+# FM_PR_OWNER and FM_PR_REPO are additionally set for github because GitHub is
+# addressed by owner/repository. GitLab consumers use FM_PR_HOST and the full
+# FM_PR_PATH because nested namespaces and self-hosted instances are supported.
 fm_pr_url_parse() {
   local raw=${1-} pattern host path
   local LC_ALL=C

--- a/bin/fm-pr-merge.sh
+++ b/bin/fm-pr-merge.sh
@@ -1,13 +1,19 @@
 #!/usr/bin/env bash
 # Merge a task's PR after recording pr= and any available pr_head= through
 # bin/fm-pr-check.sh, so teardown can verify landed work after squash merges.
-# The full canonical GitHub PR URL is parsed by bin/fm-pr-lib.sh and the derived
-# owner/repository and PR number are passed to gh-axi as separate arguments.
+# The full canonical PR/MR URL is parsed by bin/fm-pr-lib.sh.
+# GitHub is addressed by the derived owner/repository and PR number.
+# GitLab is addressed by the derived full project URL and MR number; a lookup
+# must report the exact canonical MR URL before glab is allowed to merge it.
 #
 # Merge method defaults to --squash when the caller passes none of --squash,
-# --merge, --rebase, or --method after the optional -- separator. Extra args
-# must not include --repo or -R because the repository comes only from the URL.
-# Usage: fm-pr-merge.sh <task-id> <pr-url> [-- <extra gh-axi pr merge args>]
+# --merge, --rebase, or --method after the optional -- separator for GitHub,
+# or neither --squash/-s nor --rebase/-r for GitLab. GitHub extra arguments
+# retain their existing forwarding behavior. GitLab extra arguments are
+# limited to the merge flags documented by `glab mr merge --help`. Neither
+# forge accepts caller-supplied --repo/-R selectors because the target comes
+# only from the validated URL.
+# Usage: fm-pr-merge.sh <task-id> <pr-or-mr-url> [-- <safe forge merge args>]
 set -eu
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -24,15 +30,14 @@ if [ "$#" -lt 2 ]; then
 fi
 ID=$1
 RAW_URL=$2
-# bin/fm-pr-lib.sh parses GitLab merge request URLs so the watcher can follow
-# them, but this path still addresses only GitHub by owner/repository. The
-# provider check holds that refusal exactly as it was until merge parity lands.
-if ! fm_pr_task_id_valid "$ID" || ! fm_pr_url_parse "$RAW_URL" \
-  || [ "$FM_PR_PROVIDER" != github ]; then
+if ! fm_pr_task_id_valid "$ID" || ! fm_pr_url_parse "$RAW_URL"; then
   echo "error: invalid PR merge request" >&2
   exit 2
 fi
 URL=$FM_PR_URL
+PROVIDER=$FM_PR_PROVIDER
+PR_HOST=$FM_PR_HOST
+PR_PATH=$FM_PR_PATH
 PR_OWNER=$FM_PR_OWNER
 PR_REPO=$FM_PR_REPO
 PR_NUMBER=$FM_PR_NUMBER
@@ -44,6 +49,16 @@ caller_has_merge_method() {
   for arg in "$@"; do
     case "$arg" in
       --squash|--merge|--rebase|--method|--method=*) return 0 ;;
+    esac
+  done
+  return 1
+}
+
+caller_has_gitlab_merge_method() {
+  local arg
+  for arg in "$@"; do
+    case "$arg" in
+      --squash|-s|--rebase|-r) return 0 ;;
     esac
   done
   return 1
@@ -61,7 +76,31 @@ reject_repo_overrides() {
   done
 }
 
+validate_gitlab_args() {
+  local expect_value=0 arg
+  for arg in "$@"; do
+    if [ "$expect_value" -eq 1 ]; then
+      expect_value=0
+      continue
+    fi
+    case "$arg" in
+      --squash|-s|--rebase|-r|--remove-source-branch|-d|--yes|-y|--auto-merge|--auto-merge=*) ;;
+      --message|-m|--sha|--squash-message) expect_value=1 ;;
+      --message=*|--sha=*|--squash-message=*) ;;
+      *)
+        echo "error: unsupported GitLab merge argument: $arg" >&2
+        return 1
+        ;;
+    esac
+  done
+  if [ "$expect_value" -eq 1 ]; then
+    echo "error: GitLab merge argument requires a value" >&2
+    return 1
+  fi
+}
+
 reject_repo_overrides "$@" || exit 1
+[ "$PROVIDER" != gitlab ] || validate_gitlab_args "$@" || exit 1
 
 # Task-derived paths are constructed only after the canonical ID validation.
 META="$STATE/$ID.meta"
@@ -76,9 +115,39 @@ grep -qxF "pr=$URL" "$META" || {
   exit 1
 }
 
-merge_args=()
-if ! caller_has_merge_method "$@"; then
-  merge_args=(--squash)
-fi
+fm_pr_metadata_identity_parse "$META" || {
+  echo "error: PR metadata recording failed" >&2
+  exit 1
+}
+[ "$FM_PR_META_PROVIDER" = "$PROVIDER" ] && [ "$FM_PR_META_URL" = "$URL" ] \
+  && [ "$FM_PR_META_HOST" = "$PR_HOST" ] && [ "$FM_PR_META_PATH" = "$PR_PATH" ] \
+  && [ "$FM_PR_META_NUMBER" = "$PR_NUMBER" ] || {
+  echo "error: PR metadata recording failed" >&2
+  exit 1
+}
 
-gh-axi pr merge "$PR_NUMBER" --repo "$PR_OWNER/$PR_REPO" "${merge_args[@]+"${merge_args[@]}"}" "$@"
+merge_args=()
+case "$PROVIDER" in
+  github)
+    if ! caller_has_merge_method "$@"; then
+      merge_args=(--squash)
+    fi
+    gh-axi pr merge "$PR_NUMBER" --repo "$PR_OWNER/$PR_REPO" "${merge_args[@]+"${merge_args[@]}"}" "$@"
+    ;;
+  gitlab)
+    PROJECT_URL="https://$PR_HOST/$PR_PATH"
+    LOOKUP=$(glab mr view "$PR_NUMBER" -R "$PROJECT_URL" 2>/dev/null) || {
+      echo "error: GitLab merge request lookup failed" >&2
+      exit 1
+    }
+    LOOKUP_URL=$(printf '%s\n' "$LOOKUP" | sed -n '/^--$/q; s/^url:[[:space:]]*//p')
+    [ "$LOOKUP_URL" = "$URL" ] || {
+      echo "error: GitLab merge request target could not be verified" >&2
+      exit 1
+    }
+    if ! caller_has_gitlab_merge_method "$@"; then
+      merge_args=(--squash)
+    fi
+    glab mr merge "$PR_NUMBER" -R "$PROJECT_URL" "${merge_args[@]+"${merge_args[@]}"}" --yes "$@"
+    ;;
+esac

--- a/bin/fm-pr-merge.sh
+++ b/bin/fm-pr-merge.sh
@@ -55,10 +55,15 @@ caller_has_merge_method() {
 }
 
 caller_has_gitlab_merge_method() {
-  local arg
+  local expect_value=0 arg
   for arg in "$@"; do
+    if [ "$expect_value" -eq 1 ]; then
+      expect_value=0
+      continue
+    fi
     case "$arg" in
       --squash|-s|--rebase|-r) return 0 ;;
+      --message|-m|--sha|--squash-message) expect_value=1 ;;
     esac
   done
   return 1

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -225,8 +225,10 @@ A ship brief records its mode as a fixed machine-readable line and the spawn ref
 When a selected delivery path calls for a diff, `bin/fm-review-diff.sh` refreshes the authoritative base and, when task meta records `pr=`, always fetches and compares against `refs/pull/<n>/head` by default (recorded `pr_head=` is only an offline fallback) before falling back to the local branch with a warning.
 For target project repos shipped through their own no-mistakes pipeline, commits under `.no-mistakes/evidence/` are the pipeline's PR-viewable validation evidence and are expected to stay in the crew branch until the evidence-hosting design changes.
 The firstmate repo itself is the exception: its `.no-mistakes/` directory is local state, stays gitignored, and is rejected by CI if tracked.
-PR-based task merges go through `bin/fm-pr-merge.sh`, which records `pr=` and any available `pr_head=` through `bin/fm-pr-check.sh` before calling `gh-axi pr merge`.
-The helper requires a full `https://github.com/<owner>/<repo>/pull/<n>` URL, invokes `gh-axi pr merge <n> --repo <owner>/<repo>`, defaults to `--squash`, preserves explicit merge-method flags, and rejects malformed URLs or repo override flags before recording merge state; a well-formed GitLab merge request URL (see [docs/gitlab-merge-watch.md](gitlab-merge-watch.md)) is refused too, explicitly, rather than sent to the wrong forge.
+PR-based task merges go through `bin/fm-pr-merge.sh`, which records the exact canonical `pr=` and any available `pr_head=` through `bin/fm-pr-check.sh` before calling the selected forge's merge command.
+The helper accepts the canonical GitHub and GitLab URL forms owned by `bin/fm-pr-lib.sh`, defaults to squash, preserves safe forge-appropriate explicit merge options, and rejects malformed URLs or caller-supplied repository selectors before recording merge state.
+GitHub keeps its `gh-axi pr merge <n> --repo <owner>/<repo>` path.
+GitLab derives `https://<host>/<full-project-path>` and the MR number only from the validated identity, verifies that `glab mr view` reports the exact canonical MR URL, and then invokes `glab mr merge` with that explicit project target; [docs/gitlab-merge-watch.md](gitlab-merge-watch.md) records the CLI boundary and regression evidence.
 Teardown is fail-closed for ship worktrees: dirty worktrees refuse, and committed work must be landed before the worktree is returned.
 [`bin/fm-teardown.sh`](../bin/fm-teardown.sh)'s header owns the landed-work proofs, PR-discovery fallback, and stale-lock recovery procedure.
 

--- a/docs/gitlab-merge-watch.md
+++ b/docs/gitlab-merge-watch.md
@@ -1,13 +1,14 @@
 # GitLab merge request watch verification
 
 Empirical record for the merge watch on GitLab, alongside the existing GitHub watch.
-Every command below was run on 2026-07-21 and its output is reproduced exactly.
+The watch evidence commands below were run on 2026-07-21 and their output is reproduced exactly.
+The guarded merge interface and regression evidence were refreshed on 2026-08-05.
 
 ## Versions
 
 ```
 $ glab --version
-Current glab version: 1.53.0
+glab 1.108.0 (5de20850)
 
 $ bash --version | head -1
 GNU bash, version 5.3.9(1)-release (x86_64-pc-linux-gnu)
@@ -190,10 +191,31 @@ merged
 
 No armed watch is lost by upgrading.
 
-## What this change does not cover
+## Guarded merge path
 
-`bin/fm-pr-merge.sh` still addresses GitHub only, by owner and repository.
-It refuses a GitLab merge request URL rather than sending it to the wrong forge, so merging a merge request stays a deliberate manual step until merge parity lands separately.
+`bin/fm-pr-merge.sh` accepts the same canonical GitLab MR identity as the watcher.
+It runs `bin/fm-pr-check.sh` and verifies the exact `pr=` metadata before any forge merge command.
+For GitLab, it passes the derived MR number and `https://<host>/<full-project-path>` to `glab mr view`, requires the reported MR URL to equal the canonical input exactly, and only then calls `glab mr merge` with the same explicit project target.
+This keeps self-hosted instances and nested group paths out of ambient repository or glab configuration.
+
+The current `glab mr merge --help` interface exposes `-R, --repo` as its project selector.
+The wrapper rejects `-R`, attached `-R<value>`, `--repo`, and `--repo=<value>` in caller arguments, and forwards only the documented non-target merge options it explicitly recognizes.
+Squash remains the default when the caller supplies neither GitLab's squash nor rebase option.
+Missing `glab`, a failed lookup, a target mismatch, unavailable metadata, an unsafe URL, an unsupported argument, or a failed merge command produces a nonzero result without trying another target.
+
+This is only a guarded mechanism.
+It does not grant merge authority, infer approval, or replace Firstmate's captain-approval and yolo decision boundary.
+The regression suite uses hermetic command mocks and never merges a real MR.
+
+The merge interface and its public regression were refreshed with these commands:
+
+```
+$ glab mr merge --help | sed -n 's/^[[:space:]]*//; /-R --repo/p'
+-R --repo                  Select another repository. You can use either OWNER/REPO or GROUP/NAMESPACE/REPO. The full URL or Git URL is also accepted.
+
+$ bin/fm-test-run.sh tests/fm-pr-merge.test.sh 2>&1 | sed -n 's/ duration_ms=.*//; /^FM_TEST_SUMMARY /p'
+FM_TEST_SUMMARY total=1 failed=0 skipped_gate=0
+```
 
 A GitLab task records no `pr_head=`.
 `gh` exposes the head commit as a selectable field, while plain `glab` exposes it only inside its JSON output, which would need a JSON processor firstmate does not require.

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -95,7 +95,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-pr-poll.sh`          | Provide the byte-static watcher program for validated PR/MR-poll sidecars           |
 | `fm-pr-check-migrate.sh` | Quarantine older task polls without execution and rebuild only canonical polls       |
 | `fm-pr-check.sh`         | Record validated `pr=` and `pr_head=` values, then atomically arm a static merge poll |
-| `fm-pr-merge.sh`         | Record PR metadata, then merge a task's canonical full GitHub URL                    |
+| `fm-pr-merge.sh`         | Record PR metadata, verify its target, then merge a canonical GitHub PR or GitLab MR |
 | `fm-promote.sh`          | Promote a scout task in place to a protected ship task with an explicit delivery mode |
 | `fm-teardown.sh`         | Fail-closed teardown: return landed ship worktrees, require completed scout deliverables, retire secondmate homes |
 | `fm-harness.sh`          | Detect the running harness and resolve crew or secondmate harness, model, and effort |

--- a/tests/fm-pr-check-security.test.sh
+++ b/tests/fm-pr-check-security.test.sh
@@ -85,7 +85,21 @@ SH
 printf '%s\n' "$*" >> "$FM_TEST_GLAB_LOG"
 [ "${FM_TEST_GLAB_FAIL:-0}" = 0 ] || exit 1
 [ "${FM_TEST_GLAB_SLEEP:-0}" = 0 ] || sleep "$FM_TEST_GLAB_SLEEP"
-printf 'title:\tfixture merge request\nstate:\t%s\nauthor:\tsomeone\n' "${FM_TEST_GLAB_STATE:-opened}"
+case "${1:-} ${2:-}" in
+  "mr view")
+    project=
+    previous=
+    for arg in "$@"; do
+      if [ "$previous" = -R ]; then
+        project=$arg
+        break
+      fi
+      previous=$arg
+    done
+    printf 'title:\tfixture merge request\nstate:\t%s\nauthor:\tsomeone\nurl:\t%s/-/merge_requests/%s\n' \
+      "${FM_TEST_GLAB_STATE:-opened}" "$project" "${3:-}"
+    ;;
+esac
 SH
   chmod +x "$fakebin/gh" "$fakebin/gh-axi" "$fakebin/glab"
   : > "$dir/gh.log"
@@ -2872,15 +2886,13 @@ EOF
   esac
   [ ! -e "$state/task-b.check.sh" ] || fail "refused GitLab arming left a poll armed"
 
-  # The merge path still addresses GitHub only, so it refuses rather than
-  # sending a merge request to the wrong forge.
+  # The merge path derives the same exact host, nested project, and MR number.
   write_task_meta "$dir" task-c
-  set +e
-  run_merge_entry "$dir" task-c "$url" >/dev/null 2>&1
-  rc=$?
-  set -e
-  [ "$rc" -eq 2 ] || fail "merge wrapper did not refuse a GitLab merge request URL"
+  run_merge_entry "$dir" task-c "$url" >/dev/null 2>&1 \
+    || fail "merge wrapper refused a canonical GitLab merge request URL"
   [ ! -s "$dir/gh-axi.log" ] || fail "merge wrapper reached the GitHub CLI for a GitLab URL"
+  grep -qxF 'mr merge 7 -R https://gitlab.example/group/subgroup/project --squash --yes' "$dir/glab.log" \
+    || fail "merge wrapper did not preserve the canonical GitLab target"
 
   pass "GitLab merge requests are followed on any instance and never wake falsely"
 }

--- a/tests/fm-pr-merge.test.sh
+++ b/tests/fm-pr-merge.test.sh
@@ -11,9 +11,11 @@
 #   (c) extra gh-axi pr merge args are forwarded after number and --repo
 #   (d) merge is refused before gh-axi when task meta is missing
 #   (e) PR URL is parsed to number + --repo for gh-axi (defaults to --squash)
-#   (f) malformed PR URL fails fast without calling gh-axi
+#   (f) malformed PR/MR URLs fail fast without calling either forge
 #   (g) explicit merge method is not overridden by the default --squash
-#   (h) repo override args fail fast because the repo comes from the URL
+#   (h) repo override args fail fast because the target comes from the URL
+#   (i) GitLab.com and self-hosted nested projects use the exact derived target
+#   (j) GitLab lookup, metadata, CLI, argument, and merge failures fail closed
 set -u
 
 # shellcheck source=tests/lib.sh
@@ -84,11 +86,33 @@ SH
   chmod +x "$case_dir/fakebin/gh-axi" "$case_dir/fakebin/gh"
 }
 
+add_glab_mock() {
+  local case_dir=$1
+  cat > "$case_dir/fakebin/glab" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$FM_TEST_GLAB_LOG"
+case "${1:-} ${2:-}" in
+  "mr view")
+    [ "${FM_TEST_GLAB_LOOKUP_FAIL:-0}" = 0 ] || exit 1
+    printf 'title:\tfixture\nstate:\topened\nurl:\t%s\n--\nfixture body\n' "$FM_TEST_GLAB_URL"
+    ;;
+  "mr merge")
+    [ "${FM_TEST_GLAB_MERGE_FAIL:-0}" = 0 ] || exit 1
+    ;;
+esac
+SH
+  chmod +x "$case_dir/fakebin/glab"
+}
+
 run_pr_merge() {
   local case_dir=$1 rc; shift
   FM_ROOT_OVERRIDE="$ROOT" \
   FM_STATE_OVERRIDE="$case_dir/state" \
   FM_TEST_GH_AXI_LOG="$case_dir/gh-axi.log" \
+  FM_TEST_GLAB_LOG="$case_dir/glab.log" \
+  FM_TEST_GLAB_URL="${FM_TEST_GLAB_URL:-}" \
+  FM_TEST_GLAB_LOOKUP_FAIL="${FM_TEST_GLAB_LOOKUP_FAIL:-0}" \
+  FM_TEST_GLAB_MERGE_FAIL="${FM_TEST_GLAB_MERGE_FAIL:-0}" \
   PATH="$case_dir/fakebin:$PATH" \
     "$PR_MERGE" "$@"
   rc=$?
@@ -187,21 +211,200 @@ test_malformed_url_refuses_before_merge() {
   : > "$case_dir/gh-axi.log"
 
   set +e
-  run_pr_merge "$case_dir" task-x1 'https://gitlab.com/example/repo/-/merge_requests/1' \
+  run_pr_merge "$case_dir" task-x1 'https://gitlab.com/example/repo/-/merge_requests/01' \
     > "$case_dir/stdout" 2> "$case_dir/stderr"
   rc=$?
   set -e
 
-  expect_code 2 "$rc" "malformed-url: fm-pr-merge should refuse a non-GitHub PR URL"
+  expect_code 2 "$rc" "malformed-url: fm-pr-merge should refuse a malformed MR URL"
   assert_grep 'error: invalid PR merge request' "$case_dir/stderr" \
     "malformed-url: refusal was not fixed and non-probing"
-  assert_no_grep 'pr=https://gitlab.com/example/repo/-/merge_requests/1' "$case_dir/state/task-x1.meta" \
+  assert_no_grep 'pr=https://gitlab.com/example/repo/-/merge_requests/01' "$case_dir/state/task-x1.meta" \
     "malformed-url: malformed PR URL was recorded in meta"
   assert_absent "$case_dir/state/task-x1.check.sh" \
     "malformed-url: malformed PR URL armed a merge poll"
   assert_no_grep 'pr merge' "$case_dir/gh-axi.log" \
     "malformed-url: gh-axi pr merge was invoked for a malformed URL"
   pass "fm-pr-merge refuses malformed PR URLs before calling gh-axi"
+}
+
+test_gitlab_com_success_records_exact_metadata() {
+  local case_dir url
+  case_dir=$(make_case gitlab-com-success)
+  url=https://gitlab.com/example/repo/-/merge_requests/31
+  mkdir -p "$case_dir/wt"
+  add_glab_mock "$case_dir"
+  : > "$case_dir/glab.log"
+
+  FM_TEST_GLAB_URL="$url" run_pr_merge "$case_dir" task-x1 "$url" \
+    > "$case_dir/stdout" 2> "$case_dir/stderr" || fail "gitlab-com-success: merge failed"
+
+  [ "$(grep -c '^pr=' "$case_dir/state/task-x1.meta")" -eq 1 ] \
+    || fail "gitlab-com-success: metadata did not contain exactly one pr= line"
+  grep -qxF "pr=$url" "$case_dir/state/task-x1.meta" \
+    || fail "gitlab-com-success: canonical MR metadata was not exact"
+  assert_no_grep '^pr_head=' "$case_dir/state/task-x1.meta" \
+    "gitlab-com-success: GitLab unexpectedly recorded pr_head="
+  grep -qxF 'mr view 31 -R https://gitlab.com/example/repo' "$case_dir/glab.log" \
+    || fail "gitlab-com-success: lookup target was not exact"
+  grep -qxF 'mr merge 31 -R https://gitlab.com/example/repo --squash --yes' "$case_dir/glab.log" \
+    || fail "gitlab-com-success: default squash merge target was not exact"
+  pass "fm-pr-merge records exact GitLab metadata and defaults to squash"
+}
+
+test_self_hosted_nested_project_and_explicit_method() {
+  local case_dir url
+  case_dir=$(make_case gitlab-self-hosted)
+  url=https://gitlab.corp.example/platform/payments/runtime/service/-/merge_requests/42
+  mkdir -p "$case_dir/wt"
+  add_glab_mock "$case_dir"
+  : > "$case_dir/glab.log"
+
+  FM_TEST_GLAB_URL="$url" run_pr_merge "$case_dir" task-x1 "$url" -- --rebase --remove-source-branch \
+    > "$case_dir/stdout" 2> "$case_dir/stderr" || fail "gitlab-self-hosted: merge failed"
+
+  grep -qxF 'mr view 42 -R https://gitlab.corp.example/platform/payments/runtime/service' "$case_dir/glab.log" \
+    || fail "gitlab-self-hosted: lookup lost host or nested project path"
+  grep -qxF 'mr merge 42 -R https://gitlab.corp.example/platform/payments/runtime/service --yes --rebase --remove-source-branch' "$case_dir/glab.log" \
+    || fail "gitlab-self-hosted: explicit rebase merge was not forwarded exactly"
+  assert_no_grep 'mr merge .*--squash' "$case_dir/glab.log" \
+    "gitlab-self-hosted: explicit rebase received default squash"
+  pass "fm-pr-merge supports self-hosted nested GitLab projects and explicit methods"
+}
+
+test_gitlab_missing_cli_refuses_before_recording() {
+  local case_dir rc url
+  case_dir=$(make_case gitlab-missing-cli)
+  url=https://gitlab.com/example/repo/-/merge_requests/43
+  mkdir -p "$case_dir/wt"
+
+  set +e
+  FM_ROOT_OVERRIDE="$ROOT" FM_STATE_OVERRIDE="$case_dir/state" \
+    PATH="$case_dir/fakebin:/usr/bin:/bin" \
+    "$PR_MERGE" task-x1 "$url" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 1 "$rc" "gitlab-missing-cli: fm-pr-merge should refuse"
+  assert_grep 'requires glab on PATH' "$case_dir/stderr" \
+    "gitlab-missing-cli: refusal did not name glab"
+  assert_no_grep '^pr=' "$case_dir/state/task-x1.meta" \
+    "gitlab-missing-cli: MR metadata was recorded without glab"
+  pass "fm-pr-merge refuses GitLab merge when glab is missing"
+}
+
+test_gitlab_lookup_and_target_verification_fail_closed() {
+  local case_dir rc url
+  case_dir=$(make_case gitlab-lookup-failure)
+  url=https://gitlab.com/example/repo/-/merge_requests/44
+  mkdir -p "$case_dir/wt"
+  add_glab_mock "$case_dir"
+  : > "$case_dir/glab.log"
+
+  set +e
+  FM_TEST_GLAB_URL="$url" FM_TEST_GLAB_LOOKUP_FAIL=1 \
+    run_pr_merge "$case_dir" task-x1 "$url" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+  expect_code 1 "$rc" "gitlab-lookup-failure: lookup failure should refuse"
+  assert_grep 'GitLab merge request lookup failed' "$case_dir/stderr" \
+    "gitlab-lookup-failure: refusal was unclear"
+  assert_no_grep '^mr merge ' "$case_dir/glab.log" \
+    "gitlab-lookup-failure: merge ran after lookup failure"
+
+  case_dir=$(make_case gitlab-target-mismatch)
+  mkdir -p "$case_dir/wt"
+  add_glab_mock "$case_dir"
+  : > "$case_dir/glab.log"
+  set +e
+  FM_TEST_GLAB_URL=https://gitlab.com/example/other/-/merge_requests/44 \
+    run_pr_merge "$case_dir" task-x1 "$url" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+  expect_code 1 "$rc" "gitlab-target-mismatch: target mismatch should refuse"
+  assert_grep 'target could not be verified' "$case_dir/stderr" \
+    "gitlab-target-mismatch: refusal was unclear"
+  assert_no_grep '^mr merge ' "$case_dir/glab.log" \
+    "gitlab-target-mismatch: merge ran against an unverified target"
+  pass "fm-pr-merge fails closed on GitLab lookup or canonical-target failure"
+}
+
+test_gitlab_merge_failure_propagates() {
+  local case_dir rc url
+  case_dir=$(make_case gitlab-merge-failure)
+  url=https://gitlab.com/example/repo/-/merge_requests/45
+  mkdir -p "$case_dir/wt"
+  add_glab_mock "$case_dir"
+  : > "$case_dir/glab.log"
+
+  set +e
+  FM_TEST_GLAB_URL="$url" FM_TEST_GLAB_MERGE_FAIL=1 \
+    run_pr_merge "$case_dir" task-x1 "$url" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 1 "$rc" "gitlab-merge-failure: merge failure should propagate"
+  grep -qxF "pr=$url" "$case_dir/state/task-x1.meta" \
+    || fail "gitlab-merge-failure: exact metadata was not recorded first"
+  grep -qxF 'mr merge 45 -R https://gitlab.com/example/repo --squash --yes' "$case_dir/glab.log" \
+    || fail "gitlab-merge-failure: merge command was not exact"
+  pass "fm-pr-merge propagates GitLab merge-command failure"
+}
+
+test_gitlab_target_override_spellings_refuse() {
+  local spelling name case_dir rc url
+  url=https://gitlab.com/right/repo/-/merge_requests/46
+  for spelling in '--repo wrong/repo' '--repo=wrong/repo' '-R wrong/repo' '-Rwrong/repo'; do
+    name=$(printf '%s' "$spelling" | tr -c 'A-Za-z0-9' '_')
+    case_dir=$(make_case "gitlab-override-$name")
+    mkdir -p "$case_dir/wt"
+    add_glab_mock "$case_dir"
+    : > "$case_dir/glab.log"
+    set +e
+    # Word splitting is deliberate: each fixture models the CLI spelling shown.
+    # shellcheck disable=SC2086
+    FM_TEST_GLAB_URL="$url" run_pr_merge "$case_dir" task-x1 "$url" -- $spelling \
+      > "$case_dir/stdout" 2> "$case_dir/stderr"
+    rc=$?
+    set -e
+    expect_code 1 "$rc" "gitlab-override-$name: override should refuse"
+    assert_grep 'must not override the repository' "$case_dir/stderr" \
+      "gitlab-override-$name: refusal was unclear"
+    assert_no_grep '^pr=' "$case_dir/state/task-x1.meta" \
+      "gitlab-override-$name: metadata changed before argument refusal"
+    [ ! -s "$case_dir/glab.log" ] || fail "gitlab-override-$name: glab ran despite override"
+  done
+  pass "fm-pr-merge rejects every documented glab repository-selector spelling"
+}
+
+test_gitlab_argument_injection_is_data_and_unknown_flags_refuse() {
+  local case_dir rc url marker
+  case_dir=$(make_case gitlab-argument-injection)
+  url=https://gitlab.com/example/repo/-/merge_requests/47
+  marker="$case_dir/injected"
+  mkdir -p "$case_dir/wt"
+  add_glab_mock "$case_dir"
+  : > "$case_dir/glab.log"
+
+  FM_TEST_GLAB_URL="$url" run_pr_merge "$case_dir" task-x1 "$url" -- \
+    --squash-message "\$(touch $marker)" > "$case_dir/stdout" 2> "$case_dir/stderr" \
+    || fail "gitlab-argument-injection: safe message was rejected"
+  [ ! -e "$marker" ] || fail "gitlab-argument-injection: argument bytes executed"
+
+  case_dir=$(make_case gitlab-unknown-target-flag)
+  mkdir -p "$case_dir/wt"
+  add_glab_mock "$case_dir"
+  : > "$case_dir/glab.log"
+  set +e
+  FM_TEST_GLAB_URL="$url" run_pr_merge "$case_dir" task-x1 "$url" -- --hostname evil.example \
+    > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+  expect_code 1 "$rc" "gitlab-unknown-target-flag: unknown target flag should refuse"
+  assert_grep 'unsupported GitLab merge argument' "$case_dir/stderr" \
+    "gitlab-unknown-target-flag: refusal was unclear"
+  [ ! -s "$case_dir/glab.log" ] || fail "gitlab-unknown-target-flag: glab ran"
+  pass "fm-pr-merge keeps safe GitLab values as data and rejects unknown flags"
 }
 
 test_rejects_unsafe_url_segments_before_recording() {
@@ -311,3 +514,10 @@ test_repo_override_args_refuse_before_recording
 test_explicit_merge_method_not_overridden
 test_method_equals_merge_method_not_overridden
 test_parses_pr_url_for_gh_axi
+test_gitlab_com_success_records_exact_metadata
+test_self_hosted_nested_project_and_explicit_method
+test_gitlab_missing_cli_refuses_before_recording
+test_gitlab_lookup_and_target_verification_fail_closed
+test_gitlab_merge_failure_propagates
+test_gitlab_target_override_spellings_refuse
+test_gitlab_argument_injection_is_data_and_unknown_flags_refuse

--- a/tests/fm-pr-merge.test.sh
+++ b/tests/fm-pr-merge.test.sh
@@ -272,6 +272,22 @@ test_self_hosted_nested_project_and_explicit_method() {
   pass "fm-pr-merge supports self-hosted nested GitLab projects and explicit methods"
 }
 
+test_gitlab_option_value_not_read_as_merge_method() {
+  local case_dir url
+  case_dir=$(make_case gitlab-value-not-method)
+  url=https://gitlab.com/example/repo/-/merge_requests/47
+  mkdir -p "$case_dir/wt"
+  add_glab_mock "$case_dir"
+  : > "$case_dir/glab.log"
+
+  FM_TEST_GLAB_URL="$url" run_pr_merge "$case_dir" task-x1 "$url" -- --squash-message '-r' -m '-s' \
+    > "$case_dir/stdout" 2> "$case_dir/stderr" || fail "gitlab-value-not-method: merge failed"
+
+  grep -qxF 'mr merge 47 -R https://gitlab.com/example/repo --squash --yes --squash-message -r -m -s' "$case_dir/glab.log" \
+    || fail "gitlab-value-not-method: literal -r/-s option values suppressed the default --squash"
+  pass "fm-pr-merge keeps default squash when option values look like merge methods"
+}
+
 test_gitlab_missing_cli_refuses_before_recording() {
   local case_dir rc url
   case_dir=$(make_case gitlab-missing-cli)
@@ -516,6 +532,7 @@ test_method_equals_merge_method_not_overridden
 test_parses_pr_url_for_gh_axi
 test_gitlab_com_success_records_exact_metadata
 test_self_hosted_nested_project_and_explicit_method
+test_gitlab_option_value_not_read_as_merge_method
 test_gitlab_missing_cli_refuses_before_recording
 test_gitlab_lookup_and_target_verification_fail_closed
 test_gitlab_merge_failure_propagates


### PR DESCRIPTION
## Intent

Add guarded GitLab merge-request parity to Firstmate's canonical merge path so an explicitly authorized GitLab task MR can be merged without bypassing metadata, target-validation, or teardown guarantees. Extend bin/fm-pr-merge.sh to accept canonical GitLab MR URLs already validated by fm_pr_url_parse, including self-hosted hosts and nested group paths, deriving host, full project path, and MR number only from that validated identity. Use glab's documented merge interface with explicit non-redirectable host and project targeting; fail closed before merge for missing glab, auth or lookup failure, unverifiable canonical target, unavailable metadata, unsafe or malformed URLs, and caller attempts to override host, project, repository, or target. Run fm-pr-check first and require the exact canonical pr= URL in metadata before either forge merge command. Preserve GitHub behavior where practical, default to squash without an explicit method, and forward only safe forge-appropriate arguments. Do not broaden merge authority and do not merge a real PR or MR; test with hermetic mocks. Add public-interface regressions for unchanged GitHub behavior, GitLab.com and self-hosted nested projects, default and explicit methods, exact metadata recording, missing glab, merge failure, malformed and unsafe URLs, argument injection, and every CLI-supported host/project/repository override spelling. Update authoritative script help/header and the classified GitLab merge-watch documentation under the documentation-audience one-owner rule. Inspect all supported harness and runtime integration surfaces and mark not applicable only after inspection. Validate with relevant tests, fm-doc-audience-check, fm-lint, and the repository's complete branch validation. Ship through no-mistakes to a PR with green CI, but do not merge it.

## What Changed
- `bin/fm-pr-merge.sh` now merges canonical GitLab MR URLs (GitLab.com and self-hosted hosts with nested group paths) via glab, deriving host, project path, and MR number only from the `fm_pr_url_parse`-validated identity, requiring the exact canonical `pr=` metadata and a passing fm-pr-check before merge, defaulting to squash, and failing closed on missing glab, lookup/merge failure, unverifiable targets, unsafe arguments, and any host/project/repository override attempt.
- `bin/fm-pr-lib.sh` and `tests/` add explicit-method detection that skips option values plus regression coverage for GitHub parity, GitLab.com and self-hosted merges, metadata exactness, override refusals, and argument injection (18 cases in `fm-pr-merge.test.sh`, all passing).
- Updated `docs/gitlab-merge-watch.md`, `docs/architecture.md`, `docs/scripts.md`, and the README pointer to document the guarded GitLab merge path.

## Risk Assessment

✅ Low: The change is a well-bounded, fail-closed extension of an existing guarded merge path: target identity comes only from the already-validated canonical URL, every required refusal (missing glab, lookup failure, target mismatch, metadata mismatch, repo-override spellings, unknown arguments, malformed URLs) is enforced in source and covered by hermetic public-interface regressions, and GitHub behavior is unchanged.

## Testing

Ran the targeted fm-pr-merge and fm-pr-check-security suites (all pass) and demonstrated the guarded GitLab merge path end-to-end with hermetic mocks: a captured CLI transcript shows exact `glab mr view`/`glab mr merge` invocations derived only from the canonical MR URL, exact pr= metadata recording, default-squash and explicit-method handling, unchanged GitHub behavior, and fail-closed refusals for missing glab, malformed URLs, target mismatch, repo overrides, and argument injection; no real PR or MR was touched. No UI surface is involved, so a CLI transcript is the appropriate evidence.

<details>
<summary>Evidence: GitLab merge parity end-to-end CLI transcript (8 mocked scenarios)</summary>

```text

=== 1. GitLab.com MR: default squash merge via canonical URL ===
$ fm-pr-merge.sh task-x1 https://gitlab.com/example/repo/-/merge_requests/31
●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
●  WATCHER DOWN - SUPERVISION IS OFF
●  1 task(s) in flight, but no watcher has a fresh beacon (last beat: never, grace 300s).
●  Trust the emitted supervision protocol for this harness; do not use shell & for watcher repair.
●  This is a supervision warning only; the guarded operation WILL still run.
●  watcher supervision needs Stop-owned automatic recovery; inspect the hook registration and startup status before ending the turn.
●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
armed: state/task-x1.check.sh
exit=0
--- forge commands issued ---
glab mr view 31 -R https://gitlab.com/example/repo
glab mr merge 31 -R https://gitlab.com/example/repo --squash --yes
--- recorded task metadata ---
window=fm-task-x1
worktree=/tmp/fm-merge-demo.Lfe3GA/wt
project=/tmp/fm-merge-demo.Lfe3GA/project
kind=ship
mode=no-mistakes
pr=https://gitlab.com/example/repo/-/merge_requests/31

=== 2. Self-hosted nested-group MR: explicit --rebase ===
$ fm-pr-merge.sh task-x1 https://gitlab.corp.example/platform/payments/runtime/service/-/merge_requests/42 -- --rebase --remove-source-branch
PR_CHECK_MIGRATION: quarantined polls remain unarmed; review state/.pr-check-migration.log before rearming
WARNING: watcher still down (same stale episode; last beat: never, grace 300s) - full banner already printed this episode.
armed: state/task-x1.check.sh
exit=0
--- forge commands issued ---
glab mr view 42 -R https://gitlab.corp.example/platform/payments/runtime/service
glab mr merge 42 -R https://gitlab.corp.example/platform/payments/runtime/service --yes --rebase --remove-source-branch

=== 3. Caller tries to override the project with -R (refused, nothing runs) ===
$ fm-pr-merge.sh task-x1 https://gitlab.com/example/repo/-/merge_requests/31 -- -R attacker/repo
error: extra merge arguments must not override the repository
exit=1
--- no forge command issued ---

=== 4. Unsupported/unsafe GitLab argument (refused, nothing runs) ===
$ fm-pr-merge.sh task-x1 https://gitlab.com/example/repo/-/merge_requests/31 -- --web
error: unsupported GitLab merge argument: --web
exit=1
--- no forge command issued ---

=== 5. Malformed MR URL (refused before any state change) ===
$ fm-pr-merge.sh task-x1 https://gitlab.com/example/repo/-/merge_requests/01
error: invalid PR merge request
exit=2
--- no forge command issued ---

=== 6. Lookup reports a different MR than the canonical URL (fail closed before merge) ===
$ fm-pr-merge.sh task-x1 https://gitlab.com/example/repo/-/merge_requests/31
PR_CHECK_MIGRATION: quarantined polls remain unarmed; review state/.pr-check-migration.log before rearming
WARNING: watcher still down (same stale episode; last beat: never, grace 300s) - full banner already printed this episode.
armed: state/task-x1.check.sh
error: GitLab merge request target could not be verified
exit=1
--- forge commands issued ---
glab mr view 31 -R https://gitlab.com/example/repo

=== 7. Missing glab: fail closed before recording ===
$ fm-pr-merge.sh task-x1 https://gitlab.com/example/repo/-/merge_requests/43   (glab absent from PATH)
error: watching a GitLab merge request requires glab on PATH
exit=1

=== 8. GitHub PR unchanged: default squash via gh-axi ===
$ fm-pr-merge.sh task-x1 https://github.com/example/repo/pull/12
PR_CHECK_MIGRATION: quarantined polls remain unarmed; review state/.pr-check-migration.log before rearming
WARNING: watcher still down (same stale episode; last beat: never, grace 300s) - full banner already printed this episode.
armed: state/task-x1.check.sh
exit=0
--- forge commands issued ---
gh-axi pr merge 12 --repo example/repo --squash
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 2 infos</summary>

- ℹ️ `bin/fm-pr-merge.sh:57` - caller_has_gitlab_merge_method duplicates the option-value-skipping loop of validate_gitlab_args; validate_gitlab_args could record whether an explicit method (--squash/-s/--rebase/-r) was seen during its single pass, eliminating the second walker and keeping the two value-consuming flag lists from drifting apart in future edits.
- ℹ️ `bin/fm-pr-merge.sh:72` - reject_repo_overrides scans all caller args without skipping option values, so a legitimate GitLab message/squash-message value that happens to start with -R or equal --repo (e.g. -m &#39;--repo&#39;) is refused. This is fail-closed over-strictness, not a vulnerability, and is consistent with the intent&#39;s forbid-override posture; noting only so the asymmetry with the value-aware caller_has_gitlab_merge_method (commit 9e95d7e) is understood as deliberate.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash tests/fm-pr-merge.test.sh` — all 18 cases pass, including the 8 new GitLab parity cases (metadata exactness, self-hosted nested project, explicit method, missing glab, lookup/merge failure, selector-override and argument-injection refusals)</code>
- <code>`bash tests/fm-pr-check-security.test.sh` — full suite passes (exit 0), covering the updated GitLab watch/metadata security invariants</code>
- <code>Manual end-to-end run of `bin/fm-pr-merge.sh` with hermetic glab/gh-axi mocks across 8 scenarios: GitLab.com default-squash merge with recorded pr= metadata, self-hosted nested-group MR with explicit --rebase, -R override refusal, unsupported-arg refusal, malformed MR URL refusal, canonical-target mismatch fail-closed, missing-glab fail-closed, and unchanged GitHub gh-axi squash merge</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
