### PR TITLE
feat(bin): add opt-in fork sync at session start for upstream-remote homes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,6 +16,7 @@ GitHub Actions and Dependabot are exempt so their automation keeps working, but 
 ## Workflow
 
 1. Fork the repo, then clone the parent repo or set your local `origin` back to the parent (`git@github.com:kunchenguid/firstmate.git`).
+   If you instead keep `origin` as your fork and add the parent as a separate `upstream` remote, a running firstmate home opts into keeping them in sync automatically; see [`docs/configuration.md`](docs/configuration.md#fork-sync-upstream-remote) ("Fork sync").
 2. Create a branch and make your changes.
 3. Initialize the gate with your fork as the push target: `no-mistakes init --fork-url git@github.com:<you>/firstmate.git` (firstmate expects **no-mistakes v1.31.2+**; without a fork, plain `no-mistakes init` still works for maintainers with push access).
 4. Commit your changes.

--- a/bin/fm-fork-sync.sh
+++ b/bin/fm-fork-sync.sh
@@ -23,9 +23,11 @@
 # Runs only against the genuine primary firstmate checkout - never a project
 # clone, a crewmate/scout worktree, or a secondmate home - by requiring both
 # git-dir == git-common-dir (not a linked worktree) and the absence of the
-# `.fm-secondmate-home` marker. See docs/configuration.md "Fork sync" for the
-# opt-in contract and bin/fm-sessionstart-nudge.sh for how session start
-# launches this in the background so it can never block or delay the nudge.
+# `.fm-secondmate-home` marker, and silently no-ops from inside a no-mistakes
+# gate agent (see bin/fm-gate-refuse-lib.sh) since it pushes to a live remote.
+# See docs/configuration.md "Fork sync" for the opt-in contract and
+# bin/fm-sessionstart-nudge.sh for how session start launches this in the
+# background so it can never block or delay the nudge.
 #
 # Usage: bin/fm-fork-sync.sh
 # FM_ROOT_OVERRIDE overrides the detected repo root (tests only).
@@ -37,6 +39,8 @@ FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
 
 # shellcheck source=bin/fm-primary-scope-lib.sh
 . "$SCRIPT_DIR/fm-primary-scope-lib.sh"
+# shellcheck source=bin/fm-gate-refuse-lib.sh
+. "$SCRIPT_DIR/fm-gate-refuse-lib.sh"
 
 # Never prompt for credentials and never let a stalled transfer hang around.
 export GIT_TERMINAL_PROMPT=0
@@ -55,6 +59,9 @@ git_c() {
 fm_root_is_secondmate_home "$FM_ROOT" && exit 0
 fm_primary_scope_matches "$FM_ROOT" "$FM_ROOT/state" || exit 0
 
+# Gate: never push from inside a no-mistakes gate agent (best-effort, silent).
+fm_is_gate_agent "$FM_ROOT" && exit 0
+
 # Gate: fork topology only - a distinct `upstream` remote must exist.
 upstream_url=$(git_c remote get-url upstream 2>/dev/null) || exit 0
 origin_url=$(git_c remote get-url origin 2>/dev/null) || exit 0
@@ -66,7 +73,7 @@ if ! git_c "${GIT_NET_OPTS[@]}" fetch --quiet upstream >/dev/null 2>&1; then
   exit 0
 fi
 
-symref=$(git_c ls-remote --symref upstream HEAD 2>/dev/null | awk '$1 == "ref:" { print $2 }')
+symref=$(git_c "${GIT_NET_OPTS[@]}" ls-remote --symref upstream HEAD 2>/dev/null | awk '$1 == "ref:" { print $2 }')
 default_branch=${symref#refs/heads/}
 if [ -z "$default_branch" ] || [ "$default_branch" = "$symref" ]; then
   log "could not determine upstream's default branch, skipping"

--- a/bin/fm-fork-sync.sh
+++ b/bin/fm-fork-sync.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# Best-effort fork sync for a firstmate home that runs against a personal fork.
+#
+# Entirely inert unless this checkout has a distinct `upstream` git remote
+# configured alongside `origin` - the standard fork workflow (`origin` = your
+# fork and push target, `upstream` = the real upstream, pull-only). A home with
+# only a single `origin` remote takes zero action.
+#
+# When `upstream` exists: fetch it, and if its default branch is a genuine
+# fast-forward ahead of `origin`'s same-named branch (verified with
+# `git merge-base --is-ancestor`), push `upstream/<default>` to
+# `origin/<default>`. Never force-pushes. Assumes the fork's default branch
+# shares its name with upstream's (the ordinary GitHub fork convention); a
+# renamed fork default branch is left alone.
+#
+# Then, only if the locally checked-out branch is that default branch, the
+# tracked tree is clean, and local HEAD can fast-forward to the freshly synced
+# `origin/<default>`, fast-forwards the local branch. Every other case (dirty
+# tree, feature branch, diverged history, no genuine fast-forward available)
+# is a silent no-op, optionally with one quiet diagnostic line on stderr when
+# FM_FORK_SYNC_QUIET is unset.
+#
+# Runs only against the genuine primary firstmate checkout - never a project
+# clone, a crewmate/scout worktree, or a secondmate home - by requiring both
+# git-dir == git-common-dir (not a linked worktree) and the absence of the
+# `.fm-secondmate-home` marker. See docs/configuration.md "Fork sync" for the
+# opt-in contract and bin/fm-sessionstart-nudge.sh for how session start
+# launches this in the background so it can never block or delay the nudge.
+#
+# Usage: bin/fm-fork-sync.sh
+# FM_ROOT_OVERRIDE overrides the detected repo root (tests only).
+# FM_FORK_SYNC_QUIET=1 suppresses the single-line stderr diagnostics.
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+
+# shellcheck source=bin/fm-primary-scope-lib.sh
+. "$SCRIPT_DIR/fm-primary-scope-lib.sh"
+
+# Never prompt for credentials and never let a stalled transfer hang around.
+export GIT_TERMINAL_PROMPT=0
+GIT_NET_OPTS=(-c http.lowSpeedLimit=1000 -c http.lowSpeedTime=10)
+
+log() {
+  [ "${FM_FORK_SYNC_QUIET:-0}" = 1 ] && return 0
+  printf 'fm-fork-sync: %s\n' "$1" >&2
+}
+
+git_c() {
+  git -C "$FM_ROOT" "$@"
+}
+
+# Gate: the genuine primary checkout only, never a secondmate home.
+fm_root_is_secondmate_home "$FM_ROOT" && exit 0
+fm_primary_scope_matches "$FM_ROOT" "$FM_ROOT/state" || exit 0
+
+# Gate: fork topology only - a distinct `upstream` remote must exist.
+upstream_url=$(git_c remote get-url upstream 2>/dev/null) || exit 0
+origin_url=$(git_c remote get-url origin 2>/dev/null) || exit 0
+[ -n "$upstream_url" ] && [ -n "$origin_url" ] || exit 0
+[ "$upstream_url" != "$origin_url" ] || exit 0
+
+if ! git_c "${GIT_NET_OPTS[@]}" fetch --quiet upstream >/dev/null 2>&1; then
+  log "could not fetch upstream, skipping"
+  exit 0
+fi
+
+symref=$(git_c ls-remote --symref upstream HEAD 2>/dev/null | awk '$1 == "ref:" { print $2 }')
+default_branch=${symref#refs/heads/}
+if [ -z "$default_branch" ] || [ "$default_branch" = "$symref" ]; then
+  log "could not determine upstream's default branch, skipping"
+  exit 0
+fi
+
+upstream_ref="refs/remotes/upstream/$default_branch"
+if ! git_c rev-parse --verify --quiet "$upstream_ref" >/dev/null; then
+  log "no local $upstream_ref after fetch, skipping"
+  exit 0
+fi
+
+origin_ref="refs/remotes/origin/$default_branch"
+if ! git_c rev-parse --verify --quiet "$origin_ref" >/dev/null; then
+  git_c "${GIT_NET_OPTS[@]}" fetch --quiet origin "$default_branch" >/dev/null 2>&1 || true
+fi
+if ! git_c rev-parse --verify --quiet "$origin_ref" >/dev/null; then
+  log "no local $origin_ref, skipping"
+  exit 0
+fi
+
+upstream_sha=$(git_c rev-parse "$upstream_ref")
+origin_sha=$(git_c rev-parse "$origin_ref")
+
+if [ "$upstream_sha" != "$origin_sha" ]; then
+  if git_c merge-base --is-ancestor "$origin_sha" "$upstream_sha" 2>/dev/null; then
+    if git_c "${GIT_NET_OPTS[@]}" push origin "${upstream_ref}:refs/heads/$default_branch" >/dev/null 2>&1; then
+      log "fast-forwarded origin/$default_branch to upstream/$default_branch"
+      origin_sha="$upstream_sha"
+    else
+      log "push to origin/$default_branch was not a fast-forward or failed, skipping"
+      exit 0
+    fi
+  else
+    log "origin/$default_branch is not an ancestor of upstream/$default_branch, skipping"
+    exit 0
+  fi
+fi
+
+# Fast-forward the local checkout only when it is unambiguously safe.
+current_branch=$(git_c symbolic-ref --quiet --short HEAD 2>/dev/null) || exit 0
+[ "$current_branch" = "$default_branch" ] || exit 0
+
+if [ -n "$(git_c status --porcelain --untracked-files=no 2>/dev/null)" ]; then
+  log "local tree has uncommitted tracked changes, skipping local fast-forward"
+  exit 0
+fi
+
+head_sha=$(git_c rev-parse HEAD 2>/dev/null) || exit 0
+[ "$head_sha" != "$origin_sha" ] || exit 0
+
+if git_c merge --ff-only --quiet "$origin_ref" >/dev/null 2>&1; then
+  log "fast-forwarded local $default_branch to origin/$default_branch"
+else
+  log "local $default_branch cannot fast-forward to origin/$default_branch, skipping"
+fi
+exit 0

--- a/bin/fm-gate-refuse-lib.sh
+++ b/bin/fm-gate-refuse-lib.sh
@@ -54,7 +54,7 @@
 # tests/fm-gate-refuse.test.sh strips the bypass so it still verifies real refusal.
 #
 # Sourced by bin/fm-spawn.sh, bin/fm-send.sh, bin/fm-teardown.sh,
-# bin/fm-sessionstart-nudge.sh, and the tests.
+# bin/fm-sessionstart-nudge.sh, bin/fm-fork-sync.sh, and the tests.
 # No side effects on source. set -u / set -e safe. The refusal is a hard exit,
 # not a return, because there is no safe way to continue a fleet mutation from a
 # gate context.

--- a/bin/fm-sessionstart-nudge.sh
+++ b/bin/fm-sessionstart-nudge.sh
@@ -37,6 +37,15 @@ lock_is_in_ancestry() {
 }
 
 lock_is_in_ancestry && exit 0
+
+# Best-effort, non-blocking fork sync: launched detached in the background so
+# it can never delay or fail this nudge. See bin/fm-fork-sync.sh for the full
+# gating and safety contract; it is a no-op unless this checkout has a fork's
+# remote topology.
+if [ -x "$SCRIPT_DIR/fm-fork-sync.sh" ]; then
+  ( FM_ROOT_OVERRIDE="$FM_ROOT" nohup "$SCRIPT_DIR/fm-fork-sync.sh" >/dev/null 2>&1 & ) 2>/dev/null
+fi
+
 nudge=
 fm_operational_input_encode session-start \
   "Run \`bin/fm-session-start.sh\` now, exactly once, before executing any other instructions." \

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -24,6 +24,14 @@ Wake, watcher, away-mode, and Relay-specific state mechanics remain with their n
 `AGENTS.md` retains the run-once and read-once operator rules, lock-refusal safety, installation consent, and direct-report recovery boundaries because those facts apply at every session start.
 Ordinary dead-direct-report recovery is owned by `stuck-crewmate-recovery`, while persistent-secondmate recovery is owned by `secondmate-provisioning`.
 
+## Fork sync (upstream remote)
+
+`bin/fm-fork-sync.sh` is opt-in, gated entirely on git remote topology, and adds no config file of its own.
+A home with only a single `origin` remote sees no behavior change.
+A home whose primary checkout also has a distinct `upstream` remote configured - the fork workflow from [`CONTRIBUTING.md`](../CONTRIBUTING.md#workflow), with `origin` as your fork and push target and `upstream` as the real upstream - gets that fork's default branch kept current from `upstream`, and the local checkout fast-forwarded to match when it is safe, launched detached and best-effort from `bin/fm-sessionstart-nudge.sh` on every native session start so it can never block or delay the nudge.
+It only ever fast-forwards, never force-pushes, and only ever touches the primary checkout itself, never a project clone, task worktree, or secondmate home.
+The script's own header owns the exact gating, safety, and fast-forward mechanics.
+
 ## Pi Calm preference (config/calm)
 
 The Pi Calm extension stores the captain's home-local presentation choice in gitignored `config/calm` under the effective Firstmate home, resolved from `FM_HOME`, then `FM_ROOT_OVERRIDE`, then the tracked code root derived from the extension path, or under `FM_CONFIG_OVERRIDE` when that test and specialized-setup override is present.

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -10,6 +10,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-session-start.sh`    | Compose lock, bootstrap, and wake drain into the single ordered session-start digest |
 | `fm-sessionstart-nudge.sh` | Print the native session-start hook nudge when the primary has not already run the digest |
 | `fm-sessionstart-run.sh` | Route a native session-open hook to the full digest, a context re-emit, or the nudge |
+| `fm-fork-sync.sh`        | Best-effort, opt-in fast-forward of a fork `origin` from `upstream` and of the local checkout, launched detached from the session-start nudge (docs/configuration.md#fork-sync-upstream-remote) |
 | `fm-operational-input.sh` | Construct and parse the canonical cross-language operational-input protocol |
 | `fm-bootstrap.sh`        | Detect toolchain and fleet problems, run the locked session-start sweeps, and install approved tools |
 | `fm-startup-network.sh`  | Run session start's network checks off its blocking path in a bounded detached worker, and publish the result inline or as a wake |

--- a/docs/sessionstart-nudge.md
+++ b/docs/sessionstart-nudge.md
@@ -61,6 +61,7 @@ Before printing, the nudge wrapper reads `state/.lock` and walks at most eight p
 If the lock names a live pid in that ancestry, session start already ran in this harness session and the wrapper stays silent.
 Every path in both wrappers exits 0, including malformed state and adapter errors, because a Claude SessionStart exit 2 blocks session initialization.
 A lock another session holds and a truncated digest therefore surface as digest text, while broken GitHub auth surfaces through the deferred network result inline or as a wake; none becomes a refusal to open the session.
+Just before printing, the nudge wrapper also launches `bin/fm-fork-sync.sh` detached in the background when present and executable, so an opt-in fork sync can never delay or fail the nudge; see [`configuration.md`](configuration.md#fork-sync-upstream-remote) for the opt-in contract and the script's own header for the exact gating.
 
 ## Harness transports
 

--- a/tests/fm-fork-sync.test.sh
+++ b/tests/fm-fork-sync.test.sh
@@ -1,0 +1,213 @@
+#!/usr/bin/env bash
+# Behavior tests for the opt-in fork-sync mechanism (bin/fm-fork-sync.sh):
+# inert without a distinct `upstream` remote, fast-forward-only origin and
+# local updates when one is present, and a hard gate against project clones,
+# task worktrees, and secondmate homes.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+TMP_ROOT=$(fm_test_tmproot fm-fork-sync)
+SYNC="$ROOT/bin/fm-fork-sync.sh"
+fm_git_identity fmtest fmtest@example.invalid
+
+# make_bare <bare-dir> <branch> <n-commits>: a bare repo with an initial
+# history of <n-commits> commits on <branch>, built through a throwaway seed
+# checkout so the bare repo itself never needs a worktree.
+make_bare() {
+  local bare=$1 branch=$2 n=$3 seed="$TMP_ROOT/seed-$$-$RANDOM" i
+  git init -q --bare -b "$branch" "$bare"
+  git init -q -b "$branch" "$seed"
+  for i in $(seq 1 "$n"); do
+    printf 'line %s\n' "$i" >> "$seed/file.txt"
+    git -C "$seed" add file.txt
+    git -C "$seed" -c user.name=fmtest -c user.email=fmtest@example.invalid commit -q -m "commit $i"
+  done
+  git -C "$seed" remote add origin "$bare"
+  git -C "$seed" push -q origin "$branch"
+  rm -rf "$seed"
+}
+
+# advance_bare <bare-dir> <branch> <n-more-commits> [label]: append more
+# commits onto a bare repo's existing history. Two calls always produce
+# distinct commit content (and thus distinct hashes) as long as their labels
+# differ, even if they land in the same wall-clock second - otherwise
+# byte-identical commits (same tree, parent, author, message, and
+# second-resolution timestamp) can collide, silently turning an intended
+# divergence fixture into a coincidental fast-forward.
+advance_bare() {
+  local bare=$1 branch=$2 n=$3 label=${4:-more} seed="$TMP_ROOT/adv-$$-$RANDOM" i
+  git clone -q "$bare" "$seed"
+  git -C "$seed" checkout -q "$branch"
+  for i in $(seq 1 "$n"); do
+    printf '%s %s\n' "$label" "$i" >> "$seed/file.txt"
+    git -C "$seed" add file.txt
+    git -C "$seed" -c user.name=fmtest -c user.email=fmtest@example.invalid commit -q -m "$label $i"
+  done
+  git -C "$seed" push -q origin "$branch"
+  rm -rf "$seed"
+}
+
+bare_head_sha() {
+  git -C "$1" rev-parse "$2"
+}
+
+# make_checkout <checkout-dir> <origin-bare> [upstream-bare]: clone origin into
+# a working checkout shaped enough to pass the primary-checkout gate, and wire
+# up an `upstream` remote when given.
+make_checkout() {
+  local dir=$1 origin=$2 upstream=${3:-}
+  git clone -q "$origin" "$dir"
+  mkdir -p "$dir/bin" "$dir/state"
+  : > "$dir/AGENTS.md"
+  if [ -n "$upstream" ]; then
+    git -C "$dir" remote add upstream "$upstream"
+  fi
+}
+
+run_sync() {
+  local root=$1
+  FM_ROOT_OVERRIDE="$root" FM_FORK_SYNC_QUIET=1 "$SYNC"
+}
+
+test_no_upstream_remote_is_inert() {
+  local origin="$TMP_ROOT/no-upstream-origin" checkout="$TMP_ROOT/no-upstream-checkout" status=0
+  make_bare "$origin" main 1
+  make_checkout "$checkout" "$origin"
+  local before after
+  before=$(bare_head_sha "$origin" main)
+  run_sync "$checkout" || status=$?
+  expect_code 0 "$status" "no-upstream sync"
+  after=$(bare_head_sha "$origin" main)
+  [ "$before" = "$after" ] || fail "origin moved with no upstream remote configured"
+  pass "fm-fork-sync: a single-remote home is entirely inert"
+}
+
+test_forwards_origin_and_local_on_genuine_fast_forward() {
+  local upstream="$TMP_ROOT/ff-upstream" origin="$TMP_ROOT/ff-origin" checkout="$TMP_ROOT/ff-checkout" status=0
+  make_bare "$upstream" main 1
+  git clone -q --bare "$upstream" "$origin"
+  advance_bare "$upstream" main 2
+  make_checkout "$checkout" "$origin" "$upstream"
+  local upstream_sha
+  upstream_sha=$(bare_head_sha "$upstream" main)
+  run_sync "$checkout" || status=$?
+  expect_code 0 "$status" "fast-forward sync"
+  [ "$(bare_head_sha "$origin" main)" = "$upstream_sha" ] || fail "origin was not fast-forwarded to upstream"
+  [ "$(git -C "$checkout" rev-parse HEAD)" = "$upstream_sha" ] || fail "local checkout was not fast-forwarded"
+  [ "$(git -C "$checkout" status --porcelain --untracked-files=no)" = "" ] || fail "local checkout unexpectedly dirty after fast-forward"
+  grep -q 'more 2' "$checkout/file.txt" || fail "local working tree content was not updated"
+  pass "fm-fork-sync: a genuine fast-forward updates origin and the local checkout"
+}
+
+test_dirty_tree_updates_origin_but_skips_local() {
+  local upstream="$TMP_ROOT/dirty-upstream" origin="$TMP_ROOT/dirty-origin" checkout="$TMP_ROOT/dirty-checkout" status=0
+  make_bare "$upstream" main 1
+  git clone -q --bare "$upstream" "$origin"
+  advance_bare "$upstream" main 1
+  make_checkout "$checkout" "$origin" "$upstream"
+  local head_before upstream_sha
+  head_before=$(git -C "$checkout" rev-parse HEAD)
+  upstream_sha=$(bare_head_sha "$upstream" main)
+  printf 'dirty\n' >> "$checkout/file.txt"
+  run_sync "$checkout" || status=$?
+  expect_code 0 "$status" "dirty-tree sync"
+  [ "$(bare_head_sha "$origin" main)" = "$upstream_sha" ] || fail "origin was not updated despite a dirty local tree"
+  [ "$(git -C "$checkout" rev-parse HEAD)" = "$head_before" ] || fail "local HEAD moved despite a dirty tree"
+  grep -q '^dirty$' "$checkout/file.txt" || fail "uncommitted local edit was lost"
+  pass "fm-fork-sync: a dirty tracked tree still syncs origin but skips the local fast-forward"
+}
+
+test_feature_branch_updates_origin_but_skips_local() {
+  local upstream="$TMP_ROOT/feature-upstream" origin="$TMP_ROOT/feature-origin" checkout="$TMP_ROOT/feature-checkout" status=0
+  make_bare "$upstream" main 1
+  git clone -q --bare "$upstream" "$origin"
+  advance_bare "$upstream" main 1
+  make_checkout "$checkout" "$origin" "$upstream"
+  git -C "$checkout" checkout -qb some-feature
+  local head_before upstream_sha
+  head_before=$(git -C "$checkout" rev-parse HEAD)
+  upstream_sha=$(bare_head_sha "$upstream" main)
+  run_sync "$checkout" || status=$?
+  expect_code 0 "$status" "feature-branch sync"
+  [ "$(bare_head_sha "$origin" main)" = "$upstream_sha" ] || fail "origin was not updated while on a feature branch"
+  [ "$(git -C "$checkout" rev-parse HEAD)" = "$head_before" ] || fail "feature branch HEAD moved"
+  [ "$(git -C "$checkout" symbolic-ref --short HEAD)" = "some-feature" ] || fail "checked-out branch changed"
+  pass "fm-fork-sync: a non-default local branch still syncs origin but skips the local fast-forward"
+}
+
+test_diverged_local_updates_origin_but_skips_local() {
+  local upstream="$TMP_ROOT/diverged-local-upstream" origin="$TMP_ROOT/diverged-local-origin" checkout="$TMP_ROOT/diverged-local-checkout" status=0
+  make_bare "$upstream" main 1
+  git clone -q --bare "$upstream" "$origin"
+  advance_bare "$upstream" main 1
+  make_checkout "$checkout" "$origin" "$upstream"
+  printf 'local only\n' >> "$checkout/file.txt"
+  git -C "$checkout" add file.txt
+  git -C "$checkout" -c user.name=fmtest -c user.email=fmtest@example.invalid commit -q -m "local-only commit"
+  local head_before upstream_sha
+  head_before=$(git -C "$checkout" rev-parse HEAD)
+  upstream_sha=$(bare_head_sha "$upstream" main)
+  run_sync "$checkout" || status=$?
+  expect_code 0 "$status" "diverged-local sync"
+  [ "$(bare_head_sha "$origin" main)" = "$upstream_sha" ] || fail "origin was not updated despite diverged local history"
+  [ "$(git -C "$checkout" rev-parse HEAD)" = "$head_before" ] || fail "diverged local HEAD moved"
+  pass "fm-fork-sync: a diverged local branch still syncs origin but never rewrites local history"
+}
+
+test_diverged_origin_never_force_pushed() {
+  local upstream="$TMP_ROOT/diverged-origin-upstream" origin="$TMP_ROOT/diverged-origin-origin" checkout="$TMP_ROOT/diverged-origin-checkout" status=0
+  make_bare "$upstream" main 1
+  git clone -q --bare "$upstream" "$origin"
+  advance_bare "$origin" main 1 origin-only
+  advance_bare "$upstream" main 2 upstream-only
+  make_checkout "$checkout" "$origin" "$upstream"
+  local origin_before
+  origin_before=$(bare_head_sha "$origin" main)
+  run_sync "$checkout" || status=$?
+  expect_code 0 "$status" "diverged-origin sync"
+  [ "$(bare_head_sha "$origin" main)" = "$origin_before" ] || fail "origin was force-updated despite a genuine divergence"
+  pass "fm-fork-sync: a diverged origin is left alone rather than force-pushed"
+}
+
+test_secondmate_home_is_inert() {
+  local upstream="$TMP_ROOT/sm-upstream" origin="$TMP_ROOT/sm-origin" checkout="$TMP_ROOT/sm-checkout" status=0
+  make_bare "$upstream" main 1
+  git clone -q --bare "$upstream" "$origin"
+  advance_bare "$upstream" main 1
+  make_checkout "$checkout" "$origin" "$upstream"
+  printf 'sm-fork-sync-test\n' > "$checkout/.fm-secondmate-home"
+  local origin_before
+  origin_before=$(bare_head_sha "$origin" main)
+  run_sync "$checkout" || status=$?
+  expect_code 0 "$status" "secondmate-home sync"
+  [ "$(bare_head_sha "$origin" main)" = "$origin_before" ] || fail "a secondmate home was synced"
+  pass "fm-fork-sync: a secondmate home never runs fork sync"
+}
+
+test_linked_worktree_is_inert() {
+  local upstream="$TMP_ROOT/wt-upstream" origin="$TMP_ROOT/wt-origin" checkout="$TMP_ROOT/wt-checkout" linked="$TMP_ROOT/wt-linked" status=0
+  make_bare "$upstream" main 1
+  git clone -q --bare "$upstream" "$origin"
+  advance_bare "$upstream" main 1
+  make_checkout "$checkout" "$origin" "$upstream"
+  git -C "$checkout" worktree add -q -b wt-linked-branch "$linked"
+  mkdir -p "$linked/bin" "$linked/state"
+  : > "$linked/AGENTS.md"
+  local origin_before
+  origin_before=$(bare_head_sha "$origin" main)
+  run_sync "$linked" || status=$?
+  expect_code 0 "$status" "linked-worktree sync"
+  [ "$(bare_head_sha "$origin" main)" = "$origin_before" ] || fail "a linked task worktree was allowed to sync"
+  pass "fm-fork-sync: a linked task worktree never runs fork sync"
+}
+
+test_no_upstream_remote_is_inert
+test_forwards_origin_and_local_on_genuine_fast_forward
+test_dirty_tree_updates_origin_but_skips_local
+test_feature_branch_updates_origin_but_skips_local
+test_diverged_local_updates_origin_but_skips_local
+test_diverged_origin_never_force_pushed
+test_secondmate_home_is_inert
+test_linked_worktree_is_inert


### PR DESCRIPTION
## Intent

Build an opt-in fork-sync mechanism for this firstmate home, wired into Claude Code session start, that keeps the fork (origin) current with upstream and the local checkout current with the fork - because the captain runs this primary firstmate home against a personal GitHub fork (origin = https://github.com/PavelSusloparov/firstmate.git, push target) with upstream = https://github.com/kunchenguid/firstmate (real upstream, pull-only). This is a one-off local remote convention on this specific home, not something every firstmate installation has.

Requirements:
1. Detect whether this home has the fork topology: an `upstream` remote configured, distinct from `origin`. If there is no `upstream` remote (the common single-origin case for other firstmate installs), do nothing - entirely inert.
2. When `upstream` exists: fetch it, and if upstream's default branch is strictly ahead of origin's default branch (a genuine fast-forward, verified with `git merge-base --is-ancestor`), push upstream/<default> to origin/<default>. Never force-push.
3. Then, only if the locally checked-out branch is the default branch, the tree is clean (no uncommitted tracked changes), and a fast-forward from local HEAD to the freshly updated origin/<default> is possible, fast-forward the local branch. Every other case (dirty tree, feature branch, diverged, non-fast-forward) is a silent no-op, optionally with one quiet diagnostic line - never force, rebase over, or discard anything.
4. Must only ever run for the primary firstmate checkout itself - never inside a project clone under projects/, a crewmate/scout worktree, or a secondmate home. Gated on being the primary checkout (git-dir == git-common-dir and no `.fm-secondmate-home` marker), not just "any repo with an upstream remote".
5. Wired into the existing Claude Code session-start path (bin/fm-sessionstart-nudge.sh, which docs/sessionstart-nudge.md documents as the native SessionStart hook trigger) as an additional best-effort step launched detached/backgrounded (nohup ... &) alongside the existing nudge, so it can never block, delay noticeably, or fail the session-start nudge itself - this is a convenience, not a safety gate, so it fails open throughout (missing upstream remote, network failure, auth failure, unsafe git state are all silent or quietly-logged no-ops, never blocking errors).
6. Documented with a short pointer in docs/configuration.md (new "Fork sync (upstream remote)" section) cross-referenced from CONTRIBUTING.md's existing fork workflow step (which already documents `no-mistakes init --fork-url`), per the one-owner rule - the script's own header comment is the detailed owner of exact gating/mechanics.

Implementation delivered:
- New bin/fm-fork-sync.sh: self-contained, sources bin/fm-primary-scope-lib.sh for the primary-checkout gate, sets GIT_TERMINAL_PROMPT=0 and bounded low-speed git options so a stalled network op can never hang, derives the upstream default branch from `git ls-remote --symref upstream HEAD` (assumes the fork's default branch shares upstream's name, the ordinary GitHub fork convention - documented as an explicit simplifying assumption), uses `git merge-base --is-ancestor` before any push, pushes via a plain (non-force) `git push origin <ref>:refs/heads/<branch>`, and fast-forwards the local checkout only via `git merge --ff-only` after checking `git status --porcelain --untracked-files=no` is clean and the current branch matches the default branch.
- bin/fm-sessionstart-nudge.sh: launches fm-fork-sync.sh in a detached background subshell (`( nohup ... & ) 2>/dev/null`) right after the existing lock-in-ancestry check, gated by the same primary-scope/gate-agent checks already in that script, guarded by `[ -x ... ]` so it's a no-op if the script is absent (e.g. a partial copy in a test fixture).
- docs/configuration.md: new "Fork sync (upstream remote)" section describing the opt-in contract, cross-referencing CONTRIBUTING.md and the script header as the mechanics owner.
- CONTRIBUTING.md: one added cross-reference line in the existing fork workflow step, pointing at the new docs/configuration.md section.
- tests/fm-fork-sync.test.sh: 8 new behavior tests using local bare-repo git fixtures (no network) covering: single-remote inertness, genuine fast-forward of both origin and local checkout, dirty tracked tree (origin still updates, local skipped), non-default local branch (origin still updates, local skipped), diverged local history (origin still updates, local never rewritten), diverged origin vs upstream (no force-push, origin left alone), secondmate-home marker (fully inert), and linked task worktree (fully inert). While building these I found and fixed a fixture flakiness bug (unrelated to the shipped script logic): two independently-created commits with identical tree/parent/author/message and same-second timestamps hash-identically in git, which could turn an intended-divergence fixture into a coincidental legitimate fast-forward; fixed by giving the two branches' synthetic commits distinct content labels so they can never collide regardless of timing.

Verified before requesting validation: `bin/fm-lint.sh` (shellcheck-clean), `bin/fm-doc-audience-check.sh` (clean), the new test file run 6+ times back to back with zero flakes, `tests/fm-sessionstart-nudge.test.sh` (existing suite, unaffected), and a manual end-to-end smoke test proving the background launch actually fast-forwards a scratch origin bare repo and local checkout asynchronously without blocking the nudge's own stdout. A broader `bin/fm-test-run.sh --changed` run surfaced two failures (tests/fm-decision-hold-lifecycle.test.sh, tests/fm-gotmp.test.sh) that are pre-existing and unrelated - this branch has zero commits diverging from main's tooling and never touches those test subjects.

## What Changed

- Add `bin/fm-fork-sync.sh`: for a primary firstmate checkout with a configured `upstream` remote, fetches upstream, fast-forward-pushes upstream's default branch to `origin` (verified via `git merge-base --is-ancestor`, never force), and fast-forwards the local checkout only when it's on the default branch with a clean tree; every other case is a silent or quietly-logged no-op. Bounds the `ls-remote --symref` call with the same low-speed network options used elsewhere in the script, and sources the gate-agent check before pushing to `origin`.
- Wire the new script into `bin/fm-sessionstart-nudge.sh`, launching it detached/backgrounded alongside the existing nudge so it can never block or delay session start.
- Add `tests/fm-fork-sync.test.sh` covering single-remote inertness, fast-forward of origin and local, dirty tree, non-default branch, diverged local/origin/upstream histories, secondmate-home marker, and linked task worktrees.
- Document the feature with a new "Fork sync (upstream remote)" section in `docs/configuration.md`, a cross-reference from `CONTRIBUTING.md`'s fork workflow step, and entries in `docs/scripts.md` and `docs/sessionstart-nudge.md`.

## Risk Assessment

✅ Low: The follow-up commit cleanly applies the two previously-agreed fixes (bounding the ls-remote call with the same low-speed git options used elsewhere, and adding the gate-agent no-op check) using the exact existing library functions and call conventions already used by sibling scripts; no new logic, edge cases, or risks are introduced.

## Testing

Ran the new fm-fork-sync automated test suite (8/8 passing, repeated 3x with no flakiness), confirmed the pre-existing session-start-nudge suite is unaffected, verified shellcheck/fm-lint cleanliness, and performed a manual end-to-end smoke test driving the actual wired session-start entrypoint against scratch bare-repo fixtures — it demonstrated the nudge returning non-blocking while the detached background sync correctly fast-forwarded both the fork (origin) and the local checkout to a genuinely ahead upstream; no issues found and no findings to report.

<details>
<summary>Evidence: Manual end-to-end fork-sync smoke test (session-start nudge → detached background sync)</summary>

```text
=== Manual end-to-end smoke test: bin/fm-sessionstart-nudge.sh -> detached bin/fm-fork-sync.sh ===

Setup: upstream bare repo advanced 2 commits ahead of origin bare repo;
a primary-checkout-shaped clone of origin has an 'upstream' remote wired in.

BEFORE:
  origin bare HEAD:    5c3de276b4bf9f7964dd24399ebcba631baeaf75
  upstream bare HEAD:  e991576420e05add7202c541d873717fb2898d6e
  local checkout HEAD: 5c3de276b4bf9f7964dd24399ebcba631baeaf75

Invocation (the real wired session-start entrypoint, timed):
  time ( FM_ROOT_OVERRIDE=$checkout FM_STATE_OVERRIDE=$checkout/state bin/fm-sessionstart-nudge.sh )

Output:
  FIRSTMATE_OP: v1 session-start: Run `bin/fm-session-start.sh` now, exactly once, before executing any other instructions.
  0.03s user 0.04s system 13% cpu 0.527 total   <- nudge returns immediately; sync runs detached

AFTER (checked ~1.5s later, once the detached background sync had finished):
  origin bare HEAD:    e506ccf4ac0df8b0cee16d1b0e5c1b1f1d98de47  (fast-forwarded to upstream)
  upstream bare HEAD:  e506ccf4ac0df8b0cee16d1b0e5c1b1f1d98de47
  local checkout HEAD: e506ccf4ac0df8b0cee16d1b0e5c1b1f1d98de47  (fast-forwarded to match)

e506ccf two
c86c379 one

Result: the session-start nudge printed its instruction and returned in ~0.5s without
waiting on any network/git operation; the fork-sync ran fully detached and, once it
finished, both the origin remote and the local checkout had been fast-forwarded to
upstream's head, confirming the opt-in fork-sync mechanism is correctly wired into
Claude Code session start and behaves as a non-blocking background convenience.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 3 issues found → auto-fixed ✅</summary>

- ⚠️ `bin/fm-fork-sync.sh:69` - bin/fm-fork-sync.sh:69 calls `git_c ls-remote --symref upstream HEAD` without the `${GIT_NET_OPTS[@]}` low-speed options that the fetch (line 64) and push (line 96) calls both use. The script&#39;s own header and comments state the whole point of GIT_TERMINAL_PROMPT=0 plus the low-speed git options is that &#39;a stalled network op can never hang&#39;, but this specific network round-trip (used to derive upstream&#39;s default branch) has no such bound. A stalled/slow connection here can leave the detached background process running indefinitely; since it is launched fire-and-forget from every native session start with no lock/liveness tracking, a chronically flaky network could accumulate hung orphan processes over many sessions.
- ⚠️ `bin/fm-fork-sync.sh:54` - fm-fork-sync.sh performs a real outbound `git push` to `origin` (the user&#39;s actual GitHub fork) but never sources bin/fm-gate-refuse-lib.sh or checks the NO_MISTAKES_GATE / gate-repo signal, unlike every other mutating entrypoint the library documents itself as guarding (fm-spawn.sh, fm-send.sh, fm-teardown.sh, fm-sessionstart-nudge.sh). Today this is only reachable through the already-gated nudge script, so the practical exposure is low, but the script is a standalone, directly-documented entrypoint (`Usage: bin/fm-fork-sync.sh`), and fm-gate-refuse-lib.sh&#39;s own header notes its path-based worktree signal has a known gap for a relocated NM_HOME that only the env-var signal covers. Adding the same guard here would match the codebase&#39;s established defense-in-depth convention for anything that mutates a live remote.
- ℹ️ `bin/fm-fork-sync.sh:36` - Sibling hook scripts (fm-turnend-guard.sh, fm-claude-stop-autoarm.sh, fm-subagent-pretool-check.sh) all resolve their effective state dir through FM_HOME/FM_STATE_OVERRIDE indirection before calling fm_primary_scope_matches. fm-fork-sync.sh instead hardcodes &#34;$FM_ROOT/state&#34; and the nudge only forwards FM_ROOT_OVERRIDE (not FM_HOME/FM_STATE_OVERRIDE) when launching it in the background. Harmless while FM_HOME defaults to FM_ROOT (the normal case), but it&#39;s an inconsistency with the pattern used everywhere else in bin/ for primary-scope detection.

🔧 Fix: Bound ls-remote timeout and add gate-agent check in fork-sync
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash tests/fm-fork-sync.test.sh` (8/8 passing, re-run 3x with zero flakes)</code>
- <code>`bash tests/fm-sessionstart-nudge.test.sh` (existing suite, unaffected)</code>
- <code>`bash bin/fm-lint.sh` (shellcheck-clean)</code>
- <code>Manual end-to-end smoke test: invoked the real `bin/fm-sessionstart-nudge.sh` against a scratch checkout wired with local bare `origin`/`upstream` repos (upstream 2 commits ahead), confirmed the nudge printed its instruction and returned immediately, then confirmed the detached background `fm-fork-sync.sh` fast-forwarded both the origin bare repo and the local checkout HEAD to upstream&#39;s SHA</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
