### PR TITLE
fix(bin): bound the bootstrap gh auth probe and report unfinished probes as indeterminate

### DIFF
--- a/.agents/skills/bootstrap-diagnostics/SKILL.md
+++ b/.agents/skills/bootstrap-diagnostics/SKILL.md
@@ -29,7 +29,7 @@ When any diagnostic needs captain attention, report the plain consequence and re
   Treat GitHub auth as unproven rather than broken: do not dispatch work that needs it, and do not ask the captain to re-authenticate on this evidence alone.
   Ask the captain to run `! gh auth status` themselves to settle the state, since a wedged credential helper, an unreachable network, or a blocking keychain prompt are the usual causes.
   `FM_GH_AUTH_TIMEOUT_SECS` raises the 10 second bound when the home is merely slow rather than stuck.
-  The reported seconds are that bound, not the elapsed wall clock: a probe that ignores SIGTERM is escalated to SIGKILL after a further 2 second grace, and that escalated kill still reports indeterminate rather than unauthenticated.
+  The reported seconds are that bound, not the elapsed wall clock, so a probe held past it by a SIGKILL escalation still reports indeterminate rather than unauthenticated; `docs/configuration.md` "Toolchain" owns the escalation grace and worst-case timing.
 - `GH_AUTH: indeterminate (probe terminated abnormally with status <n>)` - the preflight was killed before it answered, so the credential state is unknown for the same reason the timeout case is.
   The status is reported raw because it cannot say whether the kill grace escalated to SIGKILL, the OOM killer fired, or something external killed the probe.
   Handle it exactly like the timeout case above, and treat a repeat across sessions as a sign the home itself is unhealthy rather than a GitHub auth problem.

--- a/.agents/skills/bootstrap-diagnostics/SKILL.md
+++ b/.agents/skills/bootstrap-diagnostics/SKILL.md
@@ -29,6 +29,7 @@ When any diagnostic needs captain attention, report the plain consequence and re
   Treat GitHub auth as unproven rather than broken: do not dispatch work that needs it, and do not ask the captain to re-authenticate on this evidence alone.
   Ask the captain to run `! gh auth status` themselves to settle the state, since a wedged credential helper, an unreachable network, or a blocking keychain prompt are the usual causes.
   `FM_GH_AUTH_TIMEOUT_SECS` raises the 10 second bound when the home is merely slow rather than stuck.
+  The reported seconds are that bound, not the elapsed wall clock: a probe that ignores SIGTERM is escalated to SIGKILL after a further 2 second grace, and that escalated kill still reports indeterminate rather than unauthenticated.
 - `GH_AUTH: indeterminate (no bounded-probe tool: install coreutils or perl)` - the home has none of `timeout`, `gtimeout`, or `perl`, so bootstrap skipped the auth check entirely rather than risk hanging session start on it.
   Report the missing bounding tool and the printed coreutils-or-perl remediation, then rerun session start once one is installed.
   The credential state stays unknown until then, so treat it exactly like the timeout case above and do not dispatch work that needs GitHub auth.

--- a/.agents/skills/bootstrap-diagnostics/SKILL.md
+++ b/.agents/skills/bootstrap-diagnostics/SKILL.md
@@ -29,7 +29,8 @@ When any diagnostic needs captain attention, report the plain consequence and re
   Treat GitHub auth as unproven rather than broken: do not dispatch work that needs it, and do not ask the captain to re-authenticate on this evidence alone.
   Ask the captain to run `! gh auth status` themselves to settle the state, since a wedged credential helper, an unreachable network, or a blocking keychain prompt are the usual causes.
   `FM_GH_AUTH_TIMEOUT_SECS` raises the 10 second bound when the home is merely slow rather than stuck.
-  The reported seconds are that bound, not the elapsed wall clock, so a probe held past it by a SIGKILL escalation still reports indeterminate rather than unauthenticated; `docs/configuration.md` "Toolchain" owns the escalation grace and worst-case timing.
+  The reported seconds are that bound, not the elapsed wall clock: a probe that honours the bound's SIGTERM slowly can die up to the kill grace later and still report this line, while one that never honours it reports the killed line below instead.
+  `docs/configuration.md` "Toolchain" owns that grace and the worst-case timing.
 - `GH_AUTH: indeterminate (probe was killed before it answered, status <n>)` - the preflight was killed before it answered, so the credential state is unknown for the same reason the timeout case is.
   The line names no culprit on purpose: the status alone cannot say whether the kill grace escalated to SIGKILL, the OOM killer fired, or something external killed the probe, so do not report a cause the captain would have to unlearn.
   Handle it exactly like the timeout case above, and treat a repeat across sessions as a sign the home itself is unhealthy rather than a GitHub auth problem.

--- a/.agents/skills/bootstrap-diagnostics/SKILL.md
+++ b/.agents/skills/bootstrap-diagnostics/SKILL.md
@@ -30,8 +30,8 @@ When any diagnostic needs captain attention, report the plain consequence and re
   Ask the captain to run `! gh auth status` themselves to settle the state, since a wedged credential helper, an unreachable network, or a blocking keychain prompt are the usual causes.
   `FM_GH_AUTH_TIMEOUT_SECS` raises the 10 second bound when the home is merely slow rather than stuck.
   The reported seconds are that bound, not the elapsed wall clock, so a probe held past it by a SIGKILL escalation still reports indeterminate rather than unauthenticated; `docs/configuration.md` "Toolchain" owns the escalation grace and worst-case timing.
-- `GH_AUTH: indeterminate (probe terminated abnormally with status <n>)` - the preflight was killed before it answered, so the credential state is unknown for the same reason the timeout case is.
-  The status is reported raw because it cannot say whether the kill grace escalated to SIGKILL, the OOM killer fired, or something external killed the probe.
+- `GH_AUTH: indeterminate (probe was killed before it answered, status <n>)` - the preflight was killed before it answered, so the credential state is unknown for the same reason the timeout case is.
+  The line names no culprit on purpose: the status alone cannot say whether the kill grace escalated to SIGKILL, the OOM killer fired, or something external killed the probe, so do not report a cause the captain would have to unlearn.
   Handle it exactly like the timeout case above, and treat a repeat across sessions as a sign the home itself is unhealthy rather than a GitHub auth problem.
 - `GH_AUTH: indeterminate (no bounded-probe tool: install coreutils or perl)` - the home has none of `timeout`, `gtimeout`, or `perl`, so bootstrap skipped the auth check entirely rather than risk hanging session start on it.
   Report the missing bounding tool and the printed coreutils-or-perl remediation, then rerun session start once one is installed.

--- a/.agents/skills/bootstrap-diagnostics/SKILL.md
+++ b/.agents/skills/bootstrap-diagnostics/SKILL.md
@@ -2,7 +2,7 @@
 name: bootstrap-diagnostics
 description: >-
   Agent-only handling playbook for session-start bootstrap diagnostics.
-  Use whenever the session-start digest's bootstrap section prints an actionable diagnostic line - MISSING, MISSING_MANUAL, BACKEND_INVALID, NEEDS_GH_AUTH, TANGLE, STARTUP_MEMORY_BUDGET, CREW_DISPATCH invalid, FLEET_SYNC, PR_CHECK_MIGRATION, SECONDMATE_SYNC, SECONDMATE_LIVENESS, SECONDMATE_HANDOFF, NUDGE_SECONDMATES, or FMX - or when a standalone bin/fm-bootstrap.sh run prints one of those lines.
+  Use whenever the session-start digest's bootstrap section prints an actionable diagnostic line - MISSING, MISSING_MANUAL, BACKEND_INVALID, NEEDS_GH_AUTH, GH_AUTH, TANGLE, STARTUP_MEMORY_BUDGET, CREW_DISPATCH invalid, FLEET_SYNC, PR_CHECK_MIGRATION, SECONDMATE_SYNC, SECONDMATE_LIVENESS, SECONDMATE_HANDOFF, NUDGE_SECONDMATES, or FMX - or when a standalone bin/fm-bootstrap.sh run prints one of those lines.
   A silent bootstrap section, or a BOOTSTRAP_INFO fact, means no skill load.
 user-invocable: false
 metadata:
@@ -25,6 +25,15 @@ When any diagnostic needs captain attention, report the plain consequence and re
 - `MISSING_MANUAL: <tool> (instructions: <url>)` - tell the captain why the tool is required and give them the printed instructions URL, but do not pass the tool to `bin/fm-bootstrap.sh install`; wait for the captain to complete the manual installation, then rerun session start to confirm the dependency is present.
 - `BACKEND_INVALID: <name> (known: <names>)` - the resolved runtime backend has no verified dependency or lifecycle contract, so do not dispatch work until the invalid `FM_BACKEND` or `config/backend` value is corrected to one of the listed backends.
 - `NEEDS_GH_AUTH` - ask the captain to run `! gh auth login` (interactive; you cannot run it for them).
+- `GH_AUTH: indeterminate (probe timed out after <seconds>s)` - the single bounded `gh auth status` preflight did not finish, so the GitHub credential state is unknown and is deliberately NOT reported as unauthenticated.
+  Treat GitHub auth as unproven rather than broken: do not dispatch work that needs it, and do not ask the captain to re-authenticate on this evidence alone.
+  Ask the captain to run `! gh auth status` themselves to settle the state, since a wedged credential helper, an unreachable network, or a blocking keychain prompt are the usual causes.
+  `FM_GH_AUTH_TIMEOUT_SECS` raises the 10 second bound when the home is merely slow rather than stuck.
+- `GH_AUTH: indeterminate (no bounded-probe tool: install coreutils or perl)` - the home has none of `timeout`, `gtimeout`, or `perl`, so bootstrap skipped the auth check entirely rather than risk hanging session start on it.
+  Report the missing bounding tool and the printed coreutils-or-perl remediation, then rerun session start once one is installed.
+  The credential state stays unknown until then, so treat it exactly like the timeout case above and do not dispatch work that needs GitHub auth.
+- `GH_AUTH: authenticated` / `GH_AUTH: not authenticated` - opt-in confirmations printed only under `FM_BOOTSTRAP_GH_AUTH_DIAGNOSTICS=1`, never by default.
+  Neither needs its own handling: `authenticated` is a no-action fact, and `not authenticated` always accompanies the `NEEDS_GH_AUTH` line that owns the response.
 - `TANGLE: <remediation>` - the primary checkout is stranded on a feature branch instead of its default branch; `AGENTS.md` section 8 explains why this guard exists and what it protects.
   The work is safe on that branch ref; restore the primary to its default branch with the printed `git -C <root> checkout <default>`, then re-validate that branch in a proper worktree.
   This is the only sanctioned firstmate-initiated git write to the primary, and it is a non-destructive branch switch that strands nothing.

--- a/.agents/skills/bootstrap-diagnostics/SKILL.md
+++ b/.agents/skills/bootstrap-diagnostics/SKILL.md
@@ -30,6 +30,9 @@ When any diagnostic needs captain attention, report the plain consequence and re
   Ask the captain to run `! gh auth status` themselves to settle the state, since a wedged credential helper, an unreachable network, or a blocking keychain prompt are the usual causes.
   `FM_GH_AUTH_TIMEOUT_SECS` raises the 10 second bound when the home is merely slow rather than stuck.
   The reported seconds are that bound, not the elapsed wall clock: a probe that ignores SIGTERM is escalated to SIGKILL after a further 2 second grace, and that escalated kill still reports indeterminate rather than unauthenticated.
+- `GH_AUTH: indeterminate (probe terminated abnormally with status <n>)` - the preflight was killed before it answered, so the credential state is unknown for the same reason the timeout case is.
+  The status is reported raw because it cannot say whether the kill grace escalated to SIGKILL, the OOM killer fired, or something external killed the probe.
+  Handle it exactly like the timeout case above, and treat a repeat across sessions as a sign the home itself is unhealthy rather than a GitHub auth problem.
 - `GH_AUTH: indeterminate (no bounded-probe tool: install coreutils or perl)` - the home has none of `timeout`, `gtimeout`, or `perl`, so bootstrap skipped the auth check entirely rather than risk hanging session start on it.
   Report the missing bounding tool and the printed coreutils-or-perl remediation, then rerun session start once one is installed.
   The credential state stays unknown until then, so treat it exactly like the timeout case above and do not dispatch work that needs GitHub auth.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -498,7 +498,7 @@ It performs guarded fast-forward updates of firstmate and registered secondmate 
 
 These skills are not captain-invocable; load them only at their precise triggers.
 
-- `bootstrap-diagnostics` - load whenever the session-start digest's bootstrap section prints an actionable diagnostic line (`MISSING:`, `MISSING_MANUAL:`, `BACKEND_INVALID:`, `NEEDS_GH_AUTH`, `TANGLE:`, `STARTUP_MEMORY_BUDGET:`, `CREW_DISPATCH: invalid`, `FLEET_SYNC:`, `PR_CHECK_MIGRATION:`, `SECONDMATE_SYNC:`, `SECONDMATE_LIVENESS:`, `SECONDMATE_HANDOFF:`, `NUDGE_SECONDMATES:`, or `FMX:`); silence and `BOOTSTRAP_INFO:` need no load.
+- `bootstrap-diagnostics` - load whenever the session-start digest's bootstrap section prints an actionable diagnostic line (`MISSING:`, `MISSING_MANUAL:`, `BACKEND_INVALID:`, `NEEDS_GH_AUTH`, `GH_AUTH:`, `TANGLE:`, `STARTUP_MEMORY_BUDGET:`, `CREW_DISPATCH: invalid`, `FLEET_SYNC:`, `PR_CHECK_MIGRATION:`, `SECONDMATE_SYNC:`, `SECONDMATE_LIVENESS:`, `SECONDMATE_HANDOFF:`, `NUDGE_SECONDMATES:`, or `FMX:`); silence and `BOOTSTRAP_INFO:` need no load.
 - `diagnostic-reasoning` - load before scoping a reported bug and before acting on a diagnostic report.
 - `ask-user-authority` - load before deciding any ask-user finding, regardless of the project's `yolo` posture.
 - `quota-array-dispatch` - load before choosing among a matched crew-dispatch profile array from current quota-axi output.

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -87,6 +87,9 @@
 #          credential helper can never hang startup. FM_GH_AUTH_TIMEOUT_SECS
 #          overrides the 10s bound; non-numeric values, zero, and zero-padded
 #          zeros such as 00 all reset to 10 so the bound can never be disabled.
+#          A probe that ignores SIGTERM is escalated to SIGKILL after a further
+#          2s grace, so worst-case wall clock is the bound plus that grace rather
+#          than a flat 10s, and the escalated kill still reports indeterminate.
 #          An expired bound, or a home carrying none of those three bounding
 #          tools, reports GH_AUTH: indeterminate and never NEEDS_GH_AUTH, because
 #          an unfinished probe proves nothing about the credential; the two
@@ -243,7 +246,7 @@ GH_AUTH_INDETERMINATE_CAUSE=timeout
 # Return 0 for authenticated, 1 for an ordinary unauthenticated/error result,
 # and 124 when the bounded probe could not determine a result.
 gh_auth_probe() {
-  local bounder="" candidate
+  local bounder="" candidate status
   GH_AUTH_INDETERMINATE_CAUSE=timeout
   for candidate in timeout gtimeout; do
     if command -v "$candidate" >/dev/null 2>&1; then
@@ -255,6 +258,13 @@ gh_auth_probe() {
     GH_PROMPT_DISABLED=1 GH_NO_UPDATE_NOTIFIER=1 \
       "$bounder" -k "$GH_AUTH_KILL_GRACE_SECS" "$FM_GH_AUTH_TIMEOUT_SECS" \
       gh auth status >/dev/null 2>&1
+    status=$?
+    # A bounder reports a plain expiry as 124, but the SIGKILL its kill grace
+    # escalates to arrives as 137 and other implementations report the SIGTERM
+    # as 143. Every 128+N outcome means the probe was killed rather than
+    # answered, so it is indeterminate and never a confident unauthenticated.
+    [ "$status" -lt 128 ] || status=124
+    return "$status"
   elif command -v perl >/dev/null 2>&1; then
     GH_PROMPT_DISABLED=1 GH_NO_UPDATE_NOTIFIER=1 perl -e '
       my $t = shift;

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -8,6 +8,7 @@
 #          Lines: "MISSING: <tool> (install: <command>)",
 #                 "MISSING_MANUAL: <tool> (instructions: <url>)", "NEEDS_GH_AUTH",
 #                 "GH_AUTH: indeterminate (probe timed out after <seconds>s)",
+#                 "GH_AUTH: indeterminate (probe terminated abnormally with status <n>)",
 #                 "GH_AUTH: indeterminate (no bounded-probe tool: install coreutils or perl)",
 #                 "GH_AUTH: authenticated" / "GH_AUTH: not authenticated" (opt-in only),
 #                 "BACKEND_INVALID: <name> (known: <names>)",
@@ -90,10 +91,14 @@
 #          A probe that ignores SIGTERM is escalated to SIGKILL after a further
 #          2s grace, so worst-case wall clock is the bound plus that grace rather
 #          than a flat 10s, and the escalated kill still reports indeterminate.
-#          An expired bound, or a home carrying none of those three bounding
-#          tools, reports GH_AUTH: indeterminate and never NEEDS_GH_AUTH, because
-#          an unfinished probe proves nothing about the credential; the two
-#          causes carry distinct wording so the remediation is discoverable.
+#          An expired bound, a probe killed before it answered, or a home
+#          carrying none of those three bounding tools all report GH_AUTH:
+#          indeterminate and never NEEDS_GH_AUTH, because an unfinished probe
+#          proves nothing about the credential; the three causes carry distinct
+#          wording so the remediation is discoverable. Every bounding
+#          implementation classifies its result through one shared mapping, so a
+#          killed probe reads the same on stock macOS and on a coreutils host
+#          rather than depending on which bounding tool the home happens to have.
 #          The typed authenticated/not authenticated states print only under
 #          FM_BOOTSTRAP_GH_AUTH_DIAGNOSTICS=1, so default output for those two
 #          cases stays byte-identical for existing consumers.
@@ -238,9 +243,10 @@ fleet_sync() {
 # Seconds the bounding tool waits after SIGTERM before escalating to SIGKILL, so
 # a `gh` or credential helper that ignores SIGTERM cannot outlive the bound.
 GH_AUTH_KILL_GRACE_SECS=2
-# Why a 124 came back, so the report can tell an expired bound apart from a home
-# that never had a bounding tool to expire.
+# Why a 124 came back, so the report can tell an expired bound from a killed
+# probe and from a home that never had a bounding tool to expire.
 GH_AUTH_INDETERMINATE_CAUSE=timeout
+GH_AUTH_INDETERMINATE_STATUS=0
 
 # Runs only `gh auth status` with prompting and update notifications disabled.
 # Return 0 for authenticated, 1 for an ordinary unauthenticated/error result,
@@ -248,6 +254,7 @@ GH_AUTH_INDETERMINATE_CAUSE=timeout
 gh_auth_probe() {
   local bounder="" candidate status
   GH_AUTH_INDETERMINATE_CAUSE=timeout
+  GH_AUTH_INDETERMINATE_STATUS=0
   for candidate in timeout gtimeout; do
     if command -v "$candidate" >/dev/null 2>&1; then
       bounder=$candidate
@@ -259,12 +266,6 @@ gh_auth_probe() {
       "$bounder" -k "$GH_AUTH_KILL_GRACE_SECS" "$FM_GH_AUTH_TIMEOUT_SECS" \
       gh auth status >/dev/null 2>&1
     status=$?
-    # A bounder reports a plain expiry as 124, but the SIGKILL its kill grace
-    # escalates to arrives as 137 and other implementations report the SIGTERM
-    # as 143. Every 128+N outcome means the probe was killed rather than
-    # answered, so it is indeterminate and never a confident unauthenticated.
-    [ "$status" -lt 128 ] || status=124
-    return "$status"
   elif command -v perl >/dev/null 2>&1; then
     GH_PROMPT_DISABLED=1 GH_NO_UPDATE_NOTIFIER=1 perl -e '
       my $t = shift;
@@ -282,14 +283,27 @@ gh_auth_probe() {
       my $st = $?;
       exit(127) if $st == -1;
       # A signal-killed child leaves 0 in the high byte, so reporting $? >> 8
-      # alone would read a crashed probe as authenticated. Map it the way the
-      # shell does, keeping it non-zero and distinct from the 124 timeout.
+      # alone would read a crashed probe as authenticated. Reporting it the way
+      # the shell does hands the caller the same 128+N every bounder uses.
       exit($st & 127 ? 128 + ($st & 127) : $st >> 8);
     ' "$FM_GH_AUTH_TIMEOUT_SECS" gh auth status >/dev/null 2>&1
+    status=$?
   else
     GH_AUTH_INDETERMINATE_CAUSE=no-bounding-tool
     return 124
   fi
+  # One owner for what a status means, so every bounding implementation answers
+  # identically. A plain expiry arrives as 124; anything at or above 128 means
+  # the probe was killed rather than answered, whether that was the kill grace
+  # escalating to SIGKILL or an external kill, and a killed probe carries no
+  # information about the credential. Reporting either as unauthenticated is the
+  # exact failure this check exists to remove, so both collapse to indeterminate.
+  if [ "$status" -ge 128 ]; then
+    GH_AUTH_INDETERMINATE_CAUSE=abnormal
+    GH_AUTH_INDETERMINATE_STATUS=$status
+    status=124
+  fi
+  return "$status"
 }
 
 # The typed authenticated/not-authenticated states are opt-in so default output
@@ -310,6 +324,9 @@ gh_auth_report() {
       case "$GH_AUTH_INDETERMINATE_CAUSE" in
         no-bounding-tool)
           echo "GH_AUTH: indeterminate (no bounded-probe tool: install coreutils or perl)"
+          ;;
+        abnormal)
+          echo "GH_AUTH: indeterminate (probe terminated abnormally with status ${GH_AUTH_INDETERMINATE_STATUS})"
           ;;
         *)
           echo "GH_AUTH: indeterminate (probe timed out after ${FM_GH_AUTH_TIMEOUT_SECS}s)"

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -7,7 +7,9 @@
 #          Silent = all good.
 #          Lines: "MISSING: <tool> (install: <command>)",
 #                 "MISSING_MANUAL: <tool> (instructions: <url>)", "NEEDS_GH_AUTH",
-#                 "GH_AUTH: authenticated|not authenticated|indeterminate (probe timed out after <seconds>s)"
+#                 "GH_AUTH: indeterminate (probe timed out after <seconds>s)",
+#                 "GH_AUTH: indeterminate (no bounded-probe tool: install coreutils or perl)",
+#                 "GH_AUTH: authenticated" / "GH_AUTH: not authenticated" (opt-in only),
 #                 "BACKEND_INVALID: <name> (known: <names>)",
 #                 "STARTUP_MEMORY_BUDGET: invalid config/startup-memory-budget - <reason>",
 #                 "CREW_DISPATCH: invalid config/crew-dispatch.json - <reason>",
@@ -80,6 +82,18 @@
 #          refresh relays any completed fm-fleet-sync.sh output before the
 #          aggregate timeout skip line with timeout and elapsed seconds.
 #          Set FM_FLEET_PRUNE=0 to skip branch pruning during that refresh.
+#          The GitHub auth preflight issues exactly one `gh auth status`, bounded
+#          by timeout, gtimeout, or a Perl process-group alarm, so a wedged
+#          credential helper can never hang startup. FM_GH_AUTH_TIMEOUT_SECS
+#          overrides the 10s bound; non-numeric values, zero, and zero-padded
+#          zeros such as 00 all reset to 10 so the bound can never be disabled.
+#          An expired bound, or a home carrying none of those three bounding
+#          tools, reports GH_AUTH: indeterminate and never NEEDS_GH_AUTH, because
+#          an unfinished probe proves nothing about the credential; the two
+#          causes carry distinct wording so the remediation is discoverable.
+#          The typed authenticated/not authenticated states print only under
+#          FM_BOOTSTRAP_GH_AUTH_DIAGNOSTICS=1, so default output for those two
+#          cases stays byte-identical for existing consumers.
 #          Set FM_BOOTSTRAP_DETECT_ONLY=1 to skip the six MUTATING sweeps
 #          (PR-check migration, secondmate_sync, secondmate_liveness_sweep,
 #          secondmate_handoff_resume, x_mode_setup, fleet_sync) while still
@@ -105,7 +119,14 @@ STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
 DATA="${FM_DATA_OVERRIDE:-$FM_HOME/data}"
 FM_GH_AUTH_TIMEOUT_SECS=${FM_GH_AUTH_TIMEOUT_SECS:-10}
 case "$FM_GH_AUTH_TIMEOUT_SECS" in
-  ''|*[!0-9]*|0) FM_GH_AUTH_TIMEOUT_SECS=10 ;;
+  ''|*[!0-9]*) FM_GH_AUTH_TIMEOUT_SECS=10 ;;
+  *)
+    # Compare numerically, not textually: 00 and 000 are zero values too, and a
+    # zero bound disables both `timeout` and Perl's alarm outright. Forcing base
+    # 10 also keeps a padded 007 from being read as octal.
+    FM_GH_AUTH_TIMEOUT_SECS=$((10#$FM_GH_AUTH_TIMEOUT_SECS))
+    [ "$FM_GH_AUTH_TIMEOUT_SECS" -gt 0 ] || FM_GH_AUTH_TIMEOUT_SECS=10
+    ;;
 esac
 # shellcheck source=bin/fm-tasks-axi-lib.sh disable=SC1091
 . "$SCRIPT_DIR/fm-tasks-axi-lib.sh"
@@ -211,22 +232,35 @@ fleet_sync() {
   rm -f "$tmp"
 }
 
+# Seconds the bounding tool waits after SIGTERM before escalating to SIGKILL, so
+# a `gh` or credential helper that ignores SIGTERM cannot outlive the bound.
+GH_AUTH_KILL_GRACE_SECS=2
+# Why a 124 came back, so the report can tell an expired bound apart from a home
+# that never had a bounding tool to expire.
+GH_AUTH_INDETERMINATE_CAUSE=timeout
+
 # Runs only `gh auth status` with prompting and update notifications disabled.
 # Return 0 for authenticated, 1 for an ordinary unauthenticated/error result,
 # and 124 when the bounded probe could not determine a result.
 gh_auth_probe() {
-  if command -v timeout >/dev/null 2>&1; then
+  local bounder="" candidate
+  GH_AUTH_INDETERMINATE_CAUSE=timeout
+  for candidate in timeout gtimeout; do
+    if command -v "$candidate" >/dev/null 2>&1; then
+      bounder=$candidate
+      break
+    fi
+  done
+  if [ -n "$bounder" ]; then
     GH_PROMPT_DISABLED=1 GH_NO_UPDATE_NOTIFIER=1 \
-      timeout "$FM_GH_AUTH_TIMEOUT_SECS" gh auth status >/dev/null 2>&1
-  elif command -v gtimeout >/dev/null 2>&1; then
-    GH_PROMPT_DISABLED=1 GH_NO_UPDATE_NOTIFIER=1 \
-      gtimeout "$FM_GH_AUTH_TIMEOUT_SECS" gh auth status >/dev/null 2>&1
+      "$bounder" -k "$GH_AUTH_KILL_GRACE_SECS" "$FM_GH_AUTH_TIMEOUT_SECS" \
+      gh auth status >/dev/null 2>&1
   elif command -v perl >/dev/null 2>&1; then
     GH_PROMPT_DISABLED=1 GH_NO_UPDATE_NOTIFIER=1 perl -e '
       my $t = shift;
       my $pid = fork;
       die "fork failed" unless defined $pid;
-      if (!$pid) { setpgrp(0, 0); exec @ARGV }
+      if (!$pid) { setpgrp(0, 0); exec @ARGV; exit 127 }
       local $SIG{ALRM} = sub {
         kill "TERM", -$pid;
         select undef, undef, undef, 0.2;
@@ -235,11 +269,23 @@ gh_auth_probe() {
       };
       alarm $t;
       waitpid $pid, 0;
-      exit($? >> 8);
+      my $st = $?;
+      exit(127) if $st == -1;
+      # A signal-killed child leaves 0 in the high byte, so reporting $? >> 8
+      # alone would read a crashed probe as authenticated. Map it the way the
+      # shell does, keeping it non-zero and distinct from the 124 timeout.
+      exit($st & 127 ? 128 + ($st & 127) : $st >> 8);
     ' "$FM_GH_AUTH_TIMEOUT_SECS" gh auth status >/dev/null 2>&1
   else
+    GH_AUTH_INDETERMINATE_CAUSE=no-bounding-tool
     return 124
   fi
+}
+
+# The typed authenticated/not-authenticated states are opt-in so default output
+# stays byte-identical for consumers that only read NEEDS_GH_AUTH.
+gh_auth_diagnostic() {
+  [ "${FM_BOOTSTRAP_GH_AUTH_DIAGNOSTICS:-0}" != 1 ] || echo "GH_AUTH: $1"
 }
 
 gh_auth_report() {
@@ -248,16 +294,21 @@ gh_auth_report() {
   status=$?
   case "$status" in
     0)
-      [ "${FM_BOOTSTRAP_GH_AUTH_DIAGNOSTICS:-0}" != 1 ] \
-        || echo "GH_AUTH: authenticated"
+      gh_auth_diagnostic authenticated
       ;;
     124)
-      echo "GH_AUTH: indeterminate (probe timed out after ${FM_GH_AUTH_TIMEOUT_SECS}s)"
+      case "$GH_AUTH_INDETERMINATE_CAUSE" in
+        no-bounding-tool)
+          echo "GH_AUTH: indeterminate (no bounded-probe tool: install coreutils or perl)"
+          ;;
+        *)
+          echo "GH_AUTH: indeterminate (probe timed out after ${FM_GH_AUTH_TIMEOUT_SECS}s)"
+          ;;
+      esac
       ;;
     *)
       echo "NEEDS_GH_AUTH"
-      [ "${FM_BOOTSTRAP_GH_AUTH_DIAGNOSTICS:-0}" != 1 ] \
-        || echo "GH_AUTH: not authenticated"
+      gh_auth_diagnostic "not authenticated"
       ;;
   esac
 }

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -89,16 +89,22 @@
 #          overrides the 10s bound; non-numeric values, zero, and zero-padded
 #          zeros such as 00 all reset to 10 so the bound can never be disabled.
 #          A probe that ignores SIGTERM is escalated to SIGKILL after a further
-#          2s grace, so worst-case wall clock is the bound plus that grace rather
-#          than a flat 10s, and the escalated kill still reports indeterminate.
+#          grace - 2s on the timeout/gtimeout branch, 0.2s in the Perl fallback -
+#          so worst-case wall clock is the bound plus at most 2s rather than a
+#          flat 10s, and the escalated kill still reports indeterminate.
 #          An expired bound, a probe killed before it answered, or a home
 #          carrying none of those three bounding tools all report GH_AUTH:
 #          indeterminate and never NEEDS_GH_AUTH, because an unfinished probe
 #          proves nothing about the credential; the three causes carry distinct
 #          wording so the remediation is discoverable. Every bounding
 #          implementation classifies its result through one shared mapping, so a
-#          killed probe reads the same on stock macOS and on a coreutils host
-#          rather than depending on which bounding tool the home happens to have.
+#          probe killed from outside reads the same on stock macOS and on a
+#          coreutils host rather than depending on which bounding tool the home
+#          happens to have. Only the bound's own escalation is worded per branch:
+#          timeout/gtimeout can surface just the 137 it exited with, so it takes
+#          the abnormal-status line, while the Perl alarm knows the bound expired
+#          and takes the timed-out line. Both stay indeterminate, so neither
+#          branch ever turns an unfinished probe into a credential claim.
 #          The typed authenticated/not authenticated states print only under
 #          FM_BOOTSTRAP_GH_AUTH_DIAGNOSTICS=1, so default output for those two
 #          cases stays byte-identical for existing consumers.
@@ -292,12 +298,15 @@ gh_auth_probe() {
     GH_AUTH_INDETERMINATE_CAUSE=no-bounding-tool
     return 124
   fi
-  # One owner for what a status means, so every bounding implementation answers
-  # identically. A plain expiry arrives as 124; anything at or above 128 means
-  # the probe was killed rather than answered, whether that was the kill grace
-  # escalating to SIGKILL or an external kill, and a killed probe carries no
-  # information about the credential. Reporting either as unauthenticated is the
-  # exact failure this check exists to remove, so both collapse to indeterminate.
+  # One owner for what a status means, so a given status answers the same
+  # whichever bounding implementation returned it. A plain expiry arrives as 124;
+  # anything at or above 128 means the probe was killed rather than answered,
+  # whether that was the kill grace escalating to SIGKILL or an external kill,
+  # and a killed probe carries no information about the credential. Reporting
+  # either as unauthenticated is the exact failure this check exists to remove,
+  # so both collapse to indeterminate. Only the timeout/gtimeout branch can reach
+  # here after its own escalation; the Perl alarm exits 124 from its handler, so
+  # that branch words a self-escalated kill as an expiry instead.
   if [ "$status" -ge 128 ]; then
     GH_AUTH_INDETERMINATE_CAUSE=abnormal
     GH_AUTH_INDETERMINATE_STATUS=$status

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -7,6 +7,7 @@
 #          Silent = all good.
 #          Lines: "MISSING: <tool> (install: <command>)",
 #                 "MISSING_MANUAL: <tool> (instructions: <url>)", "NEEDS_GH_AUTH",
+#                 "GH_AUTH: authenticated|not authenticated|indeterminate (probe timed out after <seconds>s)"
 #                 "BACKEND_INVALID: <name> (known: <names>)",
 #                 "STARTUP_MEMORY_BUDGET: invalid config/startup-memory-budget - <reason>",
 #                 "CREW_DISPATCH: invalid config/crew-dispatch.json - <reason>",
@@ -102,6 +103,10 @@ PROJECTS="${FM_PROJECTS_OVERRIDE:-$FM_HOME/projects}"
 CONFIG="${FM_CONFIG_OVERRIDE:-$FM_HOME/config}"
 STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
 DATA="${FM_DATA_OVERRIDE:-$FM_HOME/data}"
+FM_GH_AUTH_TIMEOUT_SECS=${FM_GH_AUTH_TIMEOUT_SECS:-10}
+case "$FM_GH_AUTH_TIMEOUT_SECS" in
+  ''|*[!0-9]*|0) FM_GH_AUTH_TIMEOUT_SECS=10 ;;
+esac
 # shellcheck source=bin/fm-tasks-axi-lib.sh disable=SC1091
 . "$SCRIPT_DIR/fm-tasks-axi-lib.sh"
 # shellcheck source=bin/fm-quota-axi-lib.sh disable=SC1091
@@ -204,6 +209,57 @@ fleet_sync() {
 
   fleet_sync_relay_filtered_output "$tmp"
   rm -f "$tmp"
+}
+
+# Runs only `gh auth status` with prompting and update notifications disabled.
+# Return 0 for authenticated, 1 for an ordinary unauthenticated/error result,
+# and 124 when the bounded probe could not determine a result.
+gh_auth_probe() {
+  if command -v timeout >/dev/null 2>&1; then
+    GH_PROMPT_DISABLED=1 GH_NO_UPDATE_NOTIFIER=1 \
+      timeout "$FM_GH_AUTH_TIMEOUT_SECS" gh auth status >/dev/null 2>&1
+  elif command -v gtimeout >/dev/null 2>&1; then
+    GH_PROMPT_DISABLED=1 GH_NO_UPDATE_NOTIFIER=1 \
+      gtimeout "$FM_GH_AUTH_TIMEOUT_SECS" gh auth status >/dev/null 2>&1
+  elif command -v perl >/dev/null 2>&1; then
+    GH_PROMPT_DISABLED=1 GH_NO_UPDATE_NOTIFIER=1 perl -e '
+      my $t = shift;
+      my $pid = fork;
+      die "fork failed" unless defined $pid;
+      if (!$pid) { setpgrp(0, 0); exec @ARGV }
+      local $SIG{ALRM} = sub {
+        kill "TERM", -$pid;
+        select undef, undef, undef, 0.2;
+        kill "KILL", -$pid;
+        exit 124;
+      };
+      alarm $t;
+      waitpid $pid, 0;
+      exit($? >> 8);
+    ' "$FM_GH_AUTH_TIMEOUT_SECS" gh auth status >/dev/null 2>&1
+  else
+    return 124
+  fi
+}
+
+gh_auth_report() {
+  local status
+  gh_auth_probe
+  status=$?
+  case "$status" in
+    0)
+      [ "${FM_BOOTSTRAP_GH_AUTH_DIAGNOSTICS:-0}" != 1 ] \
+        || echo "GH_AUTH: authenticated"
+      ;;
+    124)
+      echo "GH_AUTH: indeterminate (probe timed out after ${FM_GH_AUTH_TIMEOUT_SECS}s)"
+      ;;
+    *)
+      echo "NEEDS_GH_AUTH"
+      [ "${FM_BOOTSTRAP_GH_AUTH_DIAGNOSTICS:-0}" != 1 ] \
+        || echo "GH_AUTH: not authenticated"
+      ;;
+  esac
 }
 
 secondmate_sync() {
@@ -1050,7 +1106,7 @@ fi
 if command -v tasks-axi >/dev/null 2>&1 && ! fm_tasks_axi_compatible; then
   echo "MISSING: tasks-axi (install: $(install_cmd tasks-axi))"
 fi
-gh auth status >/dev/null 2>&1 || echo "NEEDS_GH_AUTH"
+gh_auth_report
 # Worktree-tangle check: the firstmate primary checkout (FM_ROOT) must sit on its
 # default branch, not a feature branch (see fm-tangle-lib.sh). Scoped to the
 # primary only; detached-HEAD worktrees and secondmate homes never trip it.

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -8,7 +8,7 @@
 #          Lines: "MISSING: <tool> (install: <command>)",
 #                 "MISSING_MANUAL: <tool> (instructions: <url>)", "NEEDS_GH_AUTH",
 #                 "GH_AUTH: indeterminate (probe timed out after <seconds>s)",
-#                 "GH_AUTH: indeterminate (probe terminated abnormally with status <n>)",
+#                 "GH_AUTH: indeterminate (probe was killed before it answered, status <n>)",
 #                 "GH_AUTH: indeterminate (no bounded-probe tool: install coreutils or perl)",
 #                 "GH_AUTH: authenticated" / "GH_AUTH: not authenticated" (opt-in only),
 #                 "BACKEND_INVALID: <name> (known: <names>)",
@@ -89,22 +89,19 @@
 #          overrides the 10s bound; non-numeric values, zero, and zero-padded
 #          zeros such as 00 all reset to 10 so the bound can never be disabled.
 #          A probe that ignores SIGTERM is escalated to SIGKILL after a further
-#          grace - 2s on the timeout/gtimeout branch, 0.2s in the Perl fallback -
-#          so worst-case wall clock is the bound plus at most 2s rather than a
-#          flat 10s, and the escalated kill still reports indeterminate.
+#          2s grace, so worst-case wall clock is the bound plus that grace rather
+#          than a flat 10s, and the escalated kill still reports indeterminate.
 #          An expired bound, a probe killed before it answered, or a home
 #          carrying none of those three bounding tools all report GH_AUTH:
 #          indeterminate and never NEEDS_GH_AUTH, because an unfinished probe
 #          proves nothing about the credential; the three causes carry distinct
 #          wording so the remediation is discoverable. Every bounding
-#          implementation classifies its result through one shared mapping, so a
-#          probe killed from outside reads the same on stock macOS and on a
-#          coreutils host rather than depending on which bounding tool the home
-#          happens to have. Only the bound's own escalation is worded per branch:
-#          timeout/gtimeout can surface just the 137 it exited with, so it takes
-#          the abnormal-status line, while the Perl alarm knows the bound expired
-#          and takes the timed-out line. Both stay indeterminate, so neither
-#          branch ever turns an unfinished probe into a credential claim.
+#          implementation enforces the same grace and classifies its result
+#          through one shared mapping, so an unanswered probe reads the same on
+#          stock macOS and on a coreutils host rather than depending on which
+#          bounding tool the home happens to have. The killed wording names no
+#          culprit, because the status alone cannot separate this bound's own
+#          SIGKILL escalation from an external kill.
 #          The typed authenticated/not authenticated states print only under
 #          FM_BOOTSTRAP_GH_AUTH_DIAGNOSTICS=1, so default output for those two
 #          cases stays byte-identical for existing consumers.
@@ -246,8 +243,11 @@ fleet_sync() {
   rm -f "$tmp"
 }
 
-# Seconds the bounding tool waits after SIGTERM before escalating to SIGKILL, so
-# a `gh` or credential helper that ignores SIGTERM cannot outlive the bound.
+# Seconds every bounding branch waits after SIGTERM before escalating to SIGKILL,
+# so a `gh` or credential helper that ignores SIGTERM cannot outlive the bound.
+# One value for both branches on purpose: a per-branch grace would decide which
+# report a slow-but-cooperative probe got purely from which bounder the home
+# ships, which is the divergence the shared status mapping below exists to close.
 GH_AUTH_KILL_GRACE_SECS=2
 # Why a 124 came back, so the report can tell an expired bound from a killed
 # probe and from a home that never had a bounding tool to expire.
@@ -274,15 +274,31 @@ gh_auth_probe() {
     status=$?
   elif command -v perl >/dev/null 2>&1; then
     GH_PROMPT_DISABLED=1 GH_NO_UPDATE_NOTIFIER=1 perl -e '
+      use POSIX ":sys_wait_h";
+      use Time::HiRes qw(time sleep);
       my $t = shift;
+      my $grace = shift;
       my $pid = fork;
       die "fork failed" unless defined $pid;
       if (!$pid) { setpgrp(0, 0); exec @ARGV; exit 127 }
       local $SIG{ALRM} = sub {
         kill "TERM", -$pid;
-        select undef, undef, undef, 0.2;
+        # Mirror what `timeout -k` reports, so the same wedged probe answers the
+        # same on both branches: a child that honours SIGTERM inside the grace is
+        # a plain expiry, and one that has to be SIGKILLed exits 128+SIGKILL.
+        # The wait is polled against a wall-clock deadline rather than counted in
+        # sleep slices because short sleeps overshoot enough on macOS to push the
+        # worst case well past the grace this bound promises.
+        # Only a literal 0 means still running: -1 means the main waitpid below
+        # already reaped it in the instant the bound expired, and escalating on
+        # that would report a kill this bound never made.
+        my $deadline = time + $grace;
+        while (time < $deadline) {
+          exit 124 if waitpid($pid, WNOHANG) != 0;
+          sleep 0.05;
+        }
         kill "KILL", -$pid;
-        exit 124;
+        exit 128 + 9;
       };
       alarm $t;
       waitpid $pid, 0;
@@ -292,7 +308,7 @@ gh_auth_probe() {
       # alone would read a crashed probe as authenticated. Reporting it the way
       # the shell does hands the caller the same 128+N every bounder uses.
       exit($st & 127 ? 128 + ($st & 127) : $st >> 8);
-    ' "$FM_GH_AUTH_TIMEOUT_SECS" gh auth status >/dev/null 2>&1
+    ' "$FM_GH_AUTH_TIMEOUT_SECS" "$GH_AUTH_KILL_GRACE_SECS" gh auth status >/dev/null 2>&1
     status=$?
   else
     GH_AUTH_INDETERMINATE_CAUSE=no-bounding-tool
@@ -301,14 +317,15 @@ gh_auth_probe() {
   # One owner for what a status means, so a given status answers the same
   # whichever bounding implementation returned it. A plain expiry arrives as 124;
   # anything at or above 128 means the probe was killed rather than answered,
-  # whether that was the kill grace escalating to SIGKILL or an external kill,
   # and a killed probe carries no information about the credential. Reporting
-  # either as unauthenticated is the exact failure this check exists to remove,
-  # so both collapse to indeterminate. Only the timeout/gtimeout branch can reach
-  # here after its own escalation; the Perl alarm exits 124 from its handler, so
-  # that branch words a self-escalated kill as an expiry instead.
+  # that as unauthenticated is the exact failure this check exists to remove, so
+  # both collapse to indeterminate. The status deliberately does not name a
+  # culprit: 137 is what this bound's own SIGKILL escalation exits with AND what
+  # an external SIGKILL leaves behind, so the report states only what the status
+  # proves - the probe was killed before it answered - and carries the raw number
+  # for whoever can correlate it with the rest of the home's state.
   if [ "$status" -ge 128 ]; then
-    GH_AUTH_INDETERMINATE_CAUSE=abnormal
+    GH_AUTH_INDETERMINATE_CAUSE=killed
     GH_AUTH_INDETERMINATE_STATUS=$status
     status=124
   fi
@@ -334,8 +351,8 @@ gh_auth_report() {
         no-bounding-tool)
           echo "GH_AUTH: indeterminate (no bounded-probe tool: install coreutils or perl)"
           ;;
-        abnormal)
-          echo "GH_AUTH: indeterminate (probe terminated abnormally with status ${GH_AUTH_INDETERMINATE_STATUS})"
+        killed)
+          echo "GH_AUTH: indeterminate (probe was killed before it answered, status ${GH_AUTH_INDETERMINATE_STATUS})"
           ;;
         *)
           echo "GH_AUTH: indeterminate (probe timed out after ${FM_GH_AUTH_TIMEOUT_SECS}s)"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -303,9 +303,10 @@ An absent or too-old `quota-axi` reports `MISSING: quota-axi (install: npm insta
 The GitHub auth check issues exactly one `gh auth status`, bounded by `timeout`, `gtimeout`, or a Perl process-group alarm so a wedged credential helper cannot hang session start.
 A missing credential still reports `NEEDS_GH_AUTH`, but a probe that could not finish reports `GH_AUTH: indeterminate` instead, because an unfinished probe proves nothing about the credential.
 The three indeterminate causes carry distinct wording: an expired bound names the seconds it waited, a probe killed before it answered names the status it terminated with, and a home carrying none of those three bounding tools names the coreutils or perl install that would restore the check.
-A probe killed by a signal counts as unfinished no matter which bounding tool caught it, so the `timeout` path and the Perl fallback report it identically rather than one of them claiming the credential is missing.
+A probe killed from outside counts as unfinished no matter which bounding tool caught it, so the `timeout` path and the Perl fallback report it with the identical line rather than one of them claiming the credential is missing.
 `FM_GH_AUTH_TIMEOUT_SECS` overrides the 10 second bound, and `FM_BOOTSTRAP_GH_AUTH_DIAGNOSTICS=1` adds the otherwise-silent typed `authenticated` and `not authenticated` lines.
-A probe that ignores SIGTERM is escalated to SIGKILL after a further 2 second grace, so the worst case is the bound plus that grace rather than a flat 10 seconds, and that escalated kill still reports indeterminate rather than unauthenticated.
+A probe that ignores SIGTERM is escalated to SIGKILL after a further grace - 2 seconds on the `timeout` and `gtimeout` path, 0.2 seconds in the Perl fallback - so the worst case is the bound plus at most 2 seconds rather than a flat 10 seconds.
+That escalated kill still reports indeterminate rather than unauthenticated, but the two paths word it differently: `timeout` can surface only the SIGKILL status, so it takes the abnormal-status wording, while the Perl alarm knows the bound expired and takes the timed-out wording.
 Bootstrap also reports a `TANGLE:` line when `FM_ROOT` is on a named non-default branch; follow the printed checkout remediation rather than treating it as an installable tool problem.
 In a read-only session that did not get the fleet lock, the same line is advisory and omits the checkout command.
 The locked session-start bootstrap step also runs a best-effort project clone refresh through `fm-fleet-sync.sh`.
@@ -504,7 +505,7 @@ FM_BACKEND_CMUX_IDLE_RE='^Type a message\.\.\.$'  # cmux-only: empty-composer pl
 CMUX_SOCKET_PASSWORD=   # cmux-only: socket password fallback when config/cmux-socket-password is absent (docs/cmux-backend.md)
 FM_SESSION_START_STATUS_TAIL=5   # state/*.status lines printed per task in the session-start digest
 FM_BOOTSTRAP_DETECT_ONLY=0   # internal/read-only session-start mode: skip bootstrap's mutating sweeps and print advisory TANGLE wording
-FM_GH_AUTH_TIMEOUT_SECS=10   # seconds allowed for bootstrap's single bounded `gh auth status` preflight, plus a 2s SIGKILL grace when the probe ignores SIGTERM; non-numeric, zero, and zero-padded-zero values reset to 10
+FM_GH_AUTH_TIMEOUT_SECS=10   # seconds allowed for bootstrap's single bounded `gh auth status` preflight, plus a SIGKILL grace of at most 2s when the probe ignores SIGTERM; non-numeric, zero, and zero-padded-zero values reset to 10
 FM_BOOTSTRAP_GH_AUTH_DIAGNOSTICS=0   # set to 1 to also print the typed `GH_AUTH: authenticated` / `GH_AUTH: not authenticated` lines; the `GH_AUTH: indeterminate` line always prints
 FM_GUARD_READ_ONLY=0    # internal/read-only guard mode: keep alarms but suppress drain, supervision repair, and checkout repair commands
 FM_GUARD_CONTINUE_LINE='This is a supervision warning only; the guarded operation WILL still run.'   # banner continuation line; fm-send.sh overrides it to name the requested message specifically

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -302,11 +302,11 @@ An absent or incompatible `lavish-axi` reports `MISSING: lavish-axi (install: np
 An absent or too-old `quota-axi` reports `MISSING: quota-axi (install: npm install -g quota-axi)`; firstmate cannot resolve a profile array without a compatible binary.
 The GitHub auth check issues exactly one `gh auth status`, bounded by `timeout`, `gtimeout`, or a Perl process-group alarm so a wedged credential helper cannot hang session start.
 A missing credential still reports `NEEDS_GH_AUTH`, but a probe that could not finish reports `GH_AUTH: indeterminate` instead, because an unfinished probe proves nothing about the credential.
-The three indeterminate causes carry distinct wording: an expired bound names the seconds it waited, a probe killed before it answered names the status it terminated with, and a home carrying none of those three bounding tools names the coreutils or perl install that would restore the check.
-A probe killed from outside counts as unfinished no matter which bounding tool caught it, so the `timeout` path and the Perl fallback report it with the identical line rather than one of them claiming the credential is missing.
+The three indeterminate causes carry distinct wording: an expired bound names the seconds it waited, a probe killed before it answered names the status it was killed with, and a home carrying none of those three bounding tools names the coreutils or perl install that would restore the check.
+An unanswered probe counts as unfinished no matter which bounding tool caught it, so the `timeout` path and the Perl fallback report it with the identical line rather than one of them claiming the credential is missing.
 `FM_GH_AUTH_TIMEOUT_SECS` overrides the 10 second bound, and `FM_BOOTSTRAP_GH_AUTH_DIAGNOSTICS=1` adds the otherwise-silent typed `authenticated` and `not authenticated` lines.
-A probe that ignores SIGTERM is escalated to SIGKILL after a further grace - 2 seconds on the `timeout` and `gtimeout` path, 0.2 seconds in the Perl fallback - so the worst case is the bound plus at most 2 seconds rather than a flat 10 seconds.
-That escalated kill still reports indeterminate rather than unauthenticated, but the two paths word it differently: `timeout` can surface only the SIGKILL status, so it takes the abnormal-status wording, while the Perl alarm knows the bound expired and takes the timed-out wording.
+A probe that ignores SIGTERM is escalated to SIGKILL after a further 2 second grace on every bounding path, so the worst case is the bound plus that grace rather than a flat 10 seconds.
+That escalated kill still reports indeterminate rather than unauthenticated, and the killed wording names no culprit, because the exit status alone cannot separate this bound's own SIGKILL escalation from a kill that came from outside.
 Bootstrap also reports a `TANGLE:` line when `FM_ROOT` is on a named non-default branch; follow the printed checkout remediation rather than treating it as an installable tool problem.
 In a read-only session that did not get the fleet lock, the same line is advisory and omits the checkout command.
 The locked session-start bootstrap step also runs a best-effort project clone refresh through `fm-fleet-sync.sh`.
@@ -505,7 +505,7 @@ FM_BACKEND_CMUX_IDLE_RE='^Type a message\.\.\.$'  # cmux-only: empty-composer pl
 CMUX_SOCKET_PASSWORD=   # cmux-only: socket password fallback when config/cmux-socket-password is absent (docs/cmux-backend.md)
 FM_SESSION_START_STATUS_TAIL=5   # state/*.status lines printed per task in the session-start digest
 FM_BOOTSTRAP_DETECT_ONLY=0   # internal/read-only session-start mode: skip bootstrap's mutating sweeps and print advisory TANGLE wording
-FM_GH_AUTH_TIMEOUT_SECS=10   # seconds allowed for bootstrap's single bounded `gh auth status` preflight, plus a SIGKILL grace of at most 2s when the probe ignores SIGTERM; non-numeric, zero, and zero-padded-zero values reset to 10
+FM_GH_AUTH_TIMEOUT_SECS=10   # seconds allowed for bootstrap's single bounded `gh auth status` preflight, plus a 2s SIGKILL grace when the probe ignores SIGTERM; non-numeric, zero, and zero-padded-zero values reset to 10
 FM_BOOTSTRAP_GH_AUTH_DIAGNOSTICS=0   # set to 1 to also print the typed `GH_AUTH: authenticated` / `GH_AUTH: not authenticated` lines; the `GH_AUTH: indeterminate` line always prints
 FM_GUARD_READ_ONLY=0    # internal/read-only guard mode: keep alarms but suppress drain, supervision repair, and checkout repair commands
 FM_GUARD_CONTINUE_LINE='This is a supervision warning only; the guarded operation WILL still run.'   # banner continuation line; fm-send.sh overrides it to name the requested message specifically

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -304,6 +304,7 @@ The GitHub auth check issues exactly one `gh auth status`, bounded by `timeout`,
 A missing credential still reports `NEEDS_GH_AUTH`, but a probe that could not finish reports `GH_AUTH: indeterminate` instead, because an unfinished probe proves nothing about the credential.
 The two indeterminate causes carry distinct wording: an expired bound names the seconds it waited, while a home carrying none of those three bounding tools names the coreutils or perl install that would restore the check.
 `FM_GH_AUTH_TIMEOUT_SECS` overrides the 10 second bound, and `FM_BOOTSTRAP_GH_AUTH_DIAGNOSTICS=1` adds the otherwise-silent typed `authenticated` and `not authenticated` lines.
+A probe that ignores SIGTERM is escalated to SIGKILL after a further 2 second grace, so the worst case is the bound plus that grace rather than a flat 10 seconds, and that escalated kill still reports indeterminate rather than unauthenticated.
 Bootstrap also reports a `TANGLE:` line when `FM_ROOT` is on a named non-default branch; follow the printed checkout remediation rather than treating it as an installable tool problem.
 In a read-only session that did not get the fleet lock, the same line is advisory and omits the checkout command.
 The locked session-start bootstrap step also runs a best-effort project clone refresh through `fm-fleet-sync.sh`.
@@ -502,7 +503,7 @@ FM_BACKEND_CMUX_IDLE_RE='^Type a message\.\.\.$'  # cmux-only: empty-composer pl
 CMUX_SOCKET_PASSWORD=   # cmux-only: socket password fallback when config/cmux-socket-password is absent (docs/cmux-backend.md)
 FM_SESSION_START_STATUS_TAIL=5   # state/*.status lines printed per task in the session-start digest
 FM_BOOTSTRAP_DETECT_ONLY=0   # internal/read-only session-start mode: skip bootstrap's mutating sweeps and print advisory TANGLE wording
-FM_GH_AUTH_TIMEOUT_SECS=10   # seconds allowed for bootstrap's single bounded `gh auth status` preflight; non-numeric, zero, and zero-padded-zero values reset to 10
+FM_GH_AUTH_TIMEOUT_SECS=10   # seconds allowed for bootstrap's single bounded `gh auth status` preflight, plus a 2s SIGKILL grace when the probe ignores SIGTERM; non-numeric, zero, and zero-padded-zero values reset to 10
 FM_BOOTSTRAP_GH_AUTH_DIAGNOSTICS=0   # set to 1 to also print the typed `GH_AUTH: authenticated` / `GH_AUTH: not authenticated` lines; the `GH_AUTH: indeterminate` line always prints
 FM_GUARD_READ_ONLY=0    # internal/read-only guard mode: keep alarms but suppress drain, supervision repair, and checkout repair commands
 FM_GUARD_CONTINUE_LINE='This is a supervision warning only; the guarded operation WILL still run.'   # banner continuation line; fm-send.sh overrides it to name the requested message specifically

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -302,7 +302,8 @@ An absent or incompatible `lavish-axi` reports `MISSING: lavish-axi (install: np
 An absent or too-old `quota-axi` reports `MISSING: quota-axi (install: npm install -g quota-axi)`; firstmate cannot resolve a profile array without a compatible binary.
 The GitHub auth check issues exactly one `gh auth status`, bounded by `timeout`, `gtimeout`, or a Perl process-group alarm so a wedged credential helper cannot hang session start.
 A missing credential still reports `NEEDS_GH_AUTH`, but a probe that could not finish reports `GH_AUTH: indeterminate` instead, because an unfinished probe proves nothing about the credential.
-The two indeterminate causes carry distinct wording: an expired bound names the seconds it waited, while a home carrying none of those three bounding tools names the coreutils or perl install that would restore the check.
+The three indeterminate causes carry distinct wording: an expired bound names the seconds it waited, a probe killed before it answered names the status it terminated with, and a home carrying none of those three bounding tools names the coreutils or perl install that would restore the check.
+A probe killed by a signal counts as unfinished no matter which bounding tool caught it, so the `timeout` path and the Perl fallback report it identically rather than one of them claiming the credential is missing.
 `FM_GH_AUTH_TIMEOUT_SECS` overrides the 10 second bound, and `FM_BOOTSTRAP_GH_AUTH_DIAGNOSTICS=1` adds the otherwise-silent typed `authenticated` and `not authenticated` lines.
 A probe that ignores SIGTERM is escalated to SIGKILL after a further 2 second grace, so the worst case is the bound plus that grace rather than a flat 10 seconds, and that escalated kill still reports indeterminate rather than unauthenticated.
 Bootstrap also reports a `TANGLE:` line when `FM_ROOT` is on a named non-default branch; follow the printed checkout remediation rather than treating it as an installable tool problem.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -300,6 +300,10 @@ An absent or incompatible `tasks-axi` reports `MISSING: tasks-axi (install: npm 
 An absent or incompatible `gh-axi` reports `MISSING: gh-axi (install: npm install -g gh-axi && gh-axi setup hooks)`.
 An absent or incompatible `lavish-axi` reports `MISSING: lavish-axi (install: npm install -g lavish-axi && lavish-axi setup hooks)`.
 An absent or too-old `quota-axi` reports `MISSING: quota-axi (install: npm install -g quota-axi)`; firstmate cannot resolve a profile array without a compatible binary.
+The GitHub auth check issues exactly one `gh auth status`, bounded by `timeout`, `gtimeout`, or a Perl process-group alarm so a wedged credential helper cannot hang session start.
+A missing credential still reports `NEEDS_GH_AUTH`, but a probe that could not finish reports `GH_AUTH: indeterminate` instead, because an unfinished probe proves nothing about the credential.
+The two indeterminate causes carry distinct wording: an expired bound names the seconds it waited, while a home carrying none of those three bounding tools names the coreutils or perl install that would restore the check.
+`FM_GH_AUTH_TIMEOUT_SECS` overrides the 10 second bound, and `FM_BOOTSTRAP_GH_AUTH_DIAGNOSTICS=1` adds the otherwise-silent typed `authenticated` and `not authenticated` lines.
 Bootstrap also reports a `TANGLE:` line when `FM_ROOT` is on a named non-default branch; follow the printed checkout remediation rather than treating it as an installable tool problem.
 In a read-only session that did not get the fleet lock, the same line is advisory and omits the checkout command.
 The locked session-start bootstrap step also runs a best-effort project clone refresh through `fm-fleet-sync.sh`.
@@ -498,6 +502,8 @@ FM_BACKEND_CMUX_IDLE_RE='^Type a message\.\.\.$'  # cmux-only: empty-composer pl
 CMUX_SOCKET_PASSWORD=   # cmux-only: socket password fallback when config/cmux-socket-password is absent (docs/cmux-backend.md)
 FM_SESSION_START_STATUS_TAIL=5   # state/*.status lines printed per task in the session-start digest
 FM_BOOTSTRAP_DETECT_ONLY=0   # internal/read-only session-start mode: skip bootstrap's mutating sweeps and print advisory TANGLE wording
+FM_GH_AUTH_TIMEOUT_SECS=10   # seconds allowed for bootstrap's single bounded `gh auth status` preflight; non-numeric, zero, and zero-padded-zero values reset to 10
+FM_BOOTSTRAP_GH_AUTH_DIAGNOSTICS=0   # set to 1 to also print the typed `GH_AUTH: authenticated` / `GH_AUTH: not authenticated` lines; the `GH_AUTH: indeterminate` line always prints
 FM_GUARD_READ_ONLY=0    # internal/read-only guard mode: keep alarms but suppress drain, supervision repair, and checkout repair commands
 FM_GUARD_CONTINUE_LINE='This is a supervision warning only; the guarded operation WILL still run.'   # banner continuation line; fm-send.sh overrides it to name the requested message specifically
 FM_POLL=15              # seconds between watcher poll cycles

--- a/tests/fm-bootstrap.test.sh
+++ b/tests/fm-bootstrap.test.sh
@@ -185,12 +185,13 @@ test_gh_auth_probe_forces_every_bounding_branch() {
   # rather than a confident unauthenticated: 137 for the SIGKILL the kill grace
   # escalates to, 143 for implementations reporting the SIGTERM, 139 for a
   # SIGSEGV that the bound never caused. The status cannot say which, so the
-  # wording reports it raw instead of claiming a timeout that may not have run.
+  # wording names no culprit and carries the number raw instead of claiming
+  # either a timeout that may not have run or a kill this bound may not have made.
   for forced in 137 143 139; do
     set_fake_bounding_timeout "$fakebin" "$record" "$forced"
     out=$(PATH="$fakebin:$BASE_PATH" FM_HOME="$case_dir/home" FM_ROOT_OVERRIDE="$case_dir/home" \
       FM_BOOTSTRAP_DETECT_ONLY=1 FM_FAKE_TREEHOUSE_LEASE_HELP=1 "$ROOT/bin/fm-bootstrap.sh")
-    [ "$out" = "GH_AUTH: indeterminate (probe terminated abnormally with status $forced)" ] \
+    [ "$out" = "GH_AUTH: indeterminate (probe was killed before it answered, status $forced)" ] \
       || fail "bounder status $forced is a killed probe, so it must report indeterminate, got: $out"
   done
 
@@ -221,7 +222,7 @@ test_gh_auth_probe_forces_every_bounding_branch() {
     set_fake_gh_auth_status "$fakebin" signal
     out=$(PATH="$fakebin:$probe_path" FM_HOME="$case_dir/home" FM_ROOT_OVERRIDE="$case_dir/home" \
       FM_BOOTSTRAP_DETECT_ONLY=1 FM_FAKE_TREEHOUSE_LEASE_HELP=1 "$ROOT/bin/fm-bootstrap.sh")
-    [ "$out" = "GH_AUTH: indeterminate (probe terminated abnormally with status 139)" ] \
+    [ "$out" = "GH_AUTH: indeterminate (probe was killed before it answered, status 139)" ] \
       || fail "the Perl fallback must report a signal-killed probe exactly as the bounder branch does, got: $out"
 
     set_fake_gh_auth_status "$fakebin" unauthenticated

--- a/tests/fm-bootstrap.test.sh
+++ b/tests/fm-bootstrap.test.sh
@@ -86,6 +86,98 @@ SH
   printf '%s\n' "$fakebin"
 }
 
+set_fake_gh_auth_status() {  # <fakebin> <authenticated|unauthenticated|hung>
+  local fakebin=$1 mode=$2
+  cat > "$fakebin/gh" <<SH
+#!/usr/bin/env bash
+if [ "\${1:-}" = auth ] && [ "\${2:-}" = status ]; then
+  case '$mode' in
+    authenticated) exit 0 ;;
+    unauthenticated) exit 1 ;;
+    hung) sleep 300 ;;
+  esac
+fi
+exit 0
+SH
+  chmod +x "$fakebin/gh"
+}
+
+test_bounded_gh_auth_probe_reports_typed_states() {
+  local case_dir fakebin out start elapsed
+  case_dir="$TMP_ROOT/gh-auth-probe"
+  mkdir -p "$case_dir/home/config"
+  printf '%s\n' manual > "$case_dir/home/config/backlog-backend"
+  fakebin=$(make_fake_toolchain "$case_dir")
+
+  set_fake_gh_auth_status "$fakebin" authenticated
+  out=$(PATH="$fakebin:$BASE_PATH" FM_HOME="$case_dir/home" FM_ROOT_OVERRIDE="$case_dir/home" \
+    FM_BOOTSTRAP_DETECT_ONLY=1 FM_BOOTSTRAP_GH_AUTH_DIAGNOSTICS=1 \
+    FM_FAKE_TREEHOUSE_LEASE_HELP=1 "$ROOT/bin/fm-bootstrap.sh")
+  [ "$out" = "GH_AUTH: authenticated" ] \
+    || fail "authenticated probe should report its typed state, got: $out"
+
+  set_fake_gh_auth_status "$fakebin" unauthenticated
+  out=$(PATH="$fakebin:$BASE_PATH" FM_HOME="$case_dir/home" FM_ROOT_OVERRIDE="$case_dir/home" \
+    FM_BOOTSTRAP_DETECT_ONLY=1 FM_BOOTSTRAP_GH_AUTH_DIAGNOSTICS=1 \
+    FM_FAKE_TREEHOUSE_LEASE_HELP=1 "$ROOT/bin/fm-bootstrap.sh")
+  [ "$out" = $'NEEDS_GH_AUTH\nGH_AUTH: not authenticated' ] \
+    || fail "unauthenticated probe should remain distinct from a timeout, got: $out"
+
+  set_fake_gh_auth_status "$fakebin" hung
+  start=$SECONDS
+  out=$(PATH="$fakebin:$BASE_PATH" FM_HOME="$case_dir/home" FM_ROOT_OVERRIDE="$case_dir/home" \
+    FM_BOOTSTRAP_DETECT_ONLY=1 FM_BOOTSTRAP_GH_AUTH_DIAGNOSTICS=1 \
+    FM_GH_AUTH_TIMEOUT_SECS=1 FM_FAKE_TREEHOUSE_LEASE_HELP=1 "$ROOT/bin/fm-bootstrap.sh")
+  elapsed=$((SECONDS - start))
+  [ "$out" = "GH_AUTH: indeterminate (probe timed out after 1s)" ] \
+    || fail "hung probe should report indeterminate rather than unauthenticated, got: $out"
+  [ "$elapsed" -lt 5 ] || fail "hung auth probe exceeded its 1s bound (elapsed ${elapsed}s)"
+  pass "bootstrap bounds gh auth status and reports authenticated, unauthenticated, and indeterminate states"
+}
+
+run_preflight_bootstrap_capture() {  # <bootstrap command...>
+  local bootstrap_output preflight_result
+  bootstrap_output=$(FM_BOOTSTRAP_DETECT_ONLY=1 "$@")
+  if [ -n "$bootstrap_output" ]; then
+    printf '%s\n' "$bootstrap_output"
+    preflight_result=PASS_WITH_REPORTED_TOOLCHAIN_GAPS
+  else
+    preflight_result=PASS
+  fi
+  printf 'PREFLIGHT_RESULT: %s\n' "$preflight_result"
+}
+
+test_pilot_preflight_reaches_result_for_all_auth_states() {
+  local case_dir fakebin out start elapsed
+  case_dir="$TMP_ROOT/pilot-preflight-auth"
+  mkdir -p "$case_dir/home/config"
+  printf '%s\n' manual > "$case_dir/home/config/backlog-backend"
+  fakebin=$(make_fake_toolchain "$case_dir")
+
+  set_fake_gh_auth_status "$fakebin" authenticated
+  out=$(PATH="$fakebin:$BASE_PATH" FM_HOME="$case_dir/home" FM_ROOT_OVERRIDE="$case_dir/home" \
+    FM_FAKE_TREEHOUSE_LEASE_HELP=1 run_preflight_bootstrap_capture "$ROOT/bin/fm-bootstrap.sh")
+  [ "$out" = "PREFLIGHT_RESULT: PASS" ] \
+    || fail "authenticated preflight should reach PASS, got: $out"
+
+  set_fake_gh_auth_status "$fakebin" unauthenticated
+  out=$(PATH="$fakebin:$BASE_PATH" FM_HOME="$case_dir/home" FM_ROOT_OVERRIDE="$case_dir/home" \
+    FM_FAKE_TREEHOUSE_LEASE_HELP=1 run_preflight_bootstrap_capture "$ROOT/bin/fm-bootstrap.sh")
+  [ "$out" = $'NEEDS_GH_AUTH\nPREFLIGHT_RESULT: PASS_WITH_REPORTED_TOOLCHAIN_GAPS' ] \
+    || fail "unauthenticated preflight should reach a reported-gap result, got: $out"
+
+  set_fake_gh_auth_status "$fakebin" hung
+  start=$SECONDS
+  out=$(PATH="$fakebin:$BASE_PATH" FM_HOME="$case_dir/home" FM_ROOT_OVERRIDE="$case_dir/home" \
+    FM_GH_AUTH_TIMEOUT_SECS=1 FM_FAKE_TREEHOUSE_LEASE_HELP=1 \
+    run_preflight_bootstrap_capture "$ROOT/bin/fm-bootstrap.sh")
+  elapsed=$((SECONDS - start))
+  [ "$out" = $'GH_AUTH: indeterminate (probe timed out after 1s)\nPREFLIGHT_RESULT: PASS_WITH_REPORTED_TOOLCHAIN_GAPS' ] \
+    || fail "indeterminate auth preflight should reach a reported-gap result, got: $out"
+  [ "$elapsed" -lt 5 ] || fail "indeterminate preflight exceeded its 1s auth bound (elapsed ${elapsed}s)"
+  pass "pilot preflight reaches PREFLIGHT_RESULT for authenticated, unauthenticated, and indeterminate auth states"
+}
+
 add_quota_axi() {
   local fakebin=$1
   cat > "$fakebin/quota-axi" <<'SH'
@@ -950,6 +1042,8 @@ ROWS
 }
 
 test_bootstrap_reporting
+test_bounded_gh_auth_probe_reports_typed_states
+test_pilot_preflight_reaches_result_for_all_auth_states
 test_no_mistakes_min_version
 test_gh_axi_min_version
 test_lavish_axi_min_version

--- a/tests/fm-bootstrap.test.sh
+++ b/tests/fm-bootstrap.test.sh
@@ -19,7 +19,9 @@
 # scan.
 # Dedicated gh-auth cases pin the bounded probe's typed states and force each
 # branch of its timeout/gtimeout/perl/no-tool chain, since a host would otherwise
-# exercise only whichever bounding tool it happens to ship.
+# exercise only whichever bounding tool it happens to ship. A killed probe is
+# pinned on both bounding branches to the same line, because which tool caught it
+# must not change the answer a home reports.
 set -u
 
 # shellcheck source=tests/lib.sh disable=SC1091
@@ -172,15 +174,24 @@ test_gh_auth_probe_forces_every_bounding_branch() {
   [ "$(cat "$record")" = "-k 2 7 gh auth status" ] \
     || fail "a zero-padded bound should be read as base 10, got: $(cat "$record")"
 
-  # Every way a bounder can say the bound fired must read as indeterminate: 124
-  # for a plain expiry, 137 for the SIGKILL the kill grace escalates to when the
-  # probe ignores SIGTERM, and 143 for implementations reporting the SIGTERM.
-  for forced in 124 137 143; do
+  # A plain expiry is the one status that provably names the bound.
+  set_fake_bounding_timeout "$fakebin" "$record" 124
+  out=$(PATH="$fakebin:$BASE_PATH" FM_HOME="$case_dir/home" FM_ROOT_OVERRIDE="$case_dir/home" \
+    FM_BOOTSTRAP_DETECT_ONLY=1 FM_FAKE_TREEHOUSE_LEASE_HELP=1 "$ROOT/bin/fm-bootstrap.sh")
+  [ "$out" = "GH_AUTH: indeterminate (probe timed out after 10s)" ] \
+    || fail "a plain bounder expiry should report the bound it waited, got: $out"
+
+  # A killed probe answered nothing, so every 128+N status reports indeterminate
+  # rather than a confident unauthenticated: 137 for the SIGKILL the kill grace
+  # escalates to, 143 for implementations reporting the SIGTERM, 139 for a
+  # SIGSEGV that the bound never caused. The status cannot say which, so the
+  # wording reports it raw instead of claiming a timeout that may not have run.
+  for forced in 137 143 139; do
     set_fake_bounding_timeout "$fakebin" "$record" "$forced"
     out=$(PATH="$fakebin:$BASE_PATH" FM_HOME="$case_dir/home" FM_ROOT_OVERRIDE="$case_dir/home" \
       FM_BOOTSTRAP_DETECT_ONLY=1 FM_FAKE_TREEHOUSE_LEASE_HELP=1 "$ROOT/bin/fm-bootstrap.sh")
-    [ "$out" = "GH_AUTH: indeterminate (probe timed out after 10s)" ] \
-      || fail "bounder status $forced means the bound fired, so it must report indeterminate, got: $out"
+    [ "$out" = "GH_AUTH: indeterminate (probe terminated abnormally with status $forced)" ] \
+      || fail "bounder status $forced is a killed probe, so it must report indeterminate, got: $out"
   done
 
   # An ordinary non-zero status is still a finished probe with a real answer.
@@ -204,11 +215,20 @@ test_gh_auth_probe_forces_every_bounding_branch() {
       || fail "the Perl fallback should bound a hung probe, got: $out"
     [ "$elapsed" -lt 5 ] || fail "Perl fallback exceeded its 1s bound (elapsed ${elapsed}s)"
 
+    # The same SIGSEGV the bounder branch reported above, through the other
+    # implementation: both must produce the identical line, or a home's answer
+    # for an unanswered probe would depend on which bounding tool it ships.
     set_fake_gh_auth_status "$fakebin" signal
     out=$(PATH="$fakebin:$probe_path" FM_HOME="$case_dir/home" FM_ROOT_OVERRIDE="$case_dir/home" \
       FM_BOOTSTRAP_DETECT_ONLY=1 FM_FAKE_TREEHOUSE_LEASE_HELP=1 "$ROOT/bin/fm-bootstrap.sh")
+    [ "$out" = "GH_AUTH: indeterminate (probe terminated abnormally with status 139)" ] \
+      || fail "the Perl fallback must report a signal-killed probe exactly as the bounder branch does, got: $out"
+
+    set_fake_gh_auth_status "$fakebin" unauthenticated
+    out=$(PATH="$fakebin:$probe_path" FM_HOME="$case_dir/home" FM_ROOT_OVERRIDE="$case_dir/home" \
+      FM_BOOTSTRAP_DETECT_ONLY=1 FM_FAKE_TREEHOUSE_LEASE_HELP=1 "$ROOT/bin/fm-bootstrap.sh")
     [ "$out" = "NEEDS_GH_AUTH" ] \
-      || fail "a signal-killed probe must not read as authenticated, got: $out"
+      || fail "a probe that answered should still report NEEDS_GH_AUTH on the Perl fallback, got: $out"
   else
     printf '# skipped Perl fallback branch: no perl under %s\n' "$BASE_PATH"
   fi

--- a/tests/fm-bootstrap.test.sh
+++ b/tests/fm-bootstrap.test.sh
@@ -106,16 +106,20 @@ SH
   chmod +x "$fakebin/gh"
 }
 
-# Records what the bounding tool is asked to enforce, then runs the command it
-# was handed. Shadowing `timeout` from the fakebin pins bootstrap on its primary
-# branch regardless of whether the host ships GNU coreutils at all.
-set_fake_bounding_timeout() {  # <fakebin> <argv record path>
-  local fakebin=$1 record=$2
+# Records what the bounding tool is asked to enforce, then either runs the
+# command it was handed or exits a caller-selected status, so a case can pin the
+# exact result the real bounder would report - 124 for a plain expiry, 137 for
+# the SIGKILL a kill grace escalates to. Shadowing `timeout` from the fakebin
+# pins bootstrap on its primary branch regardless of whether the host ships GNU
+# coreutils at all.
+set_fake_bounding_timeout() {  # <fakebin> <argv record path> [forced exit status]
+  local fakebin=$1 record=$2 forced=${3:-}
   cat > "$fakebin/timeout" <<SH
 #!/usr/bin/env bash
 printf '%s\n' "\$*" > '$record'
 [ "\${1:-}" != -k ] || shift 2
 shift
+[ -z '$forced' ] || exit '$forced'
 exec "\$@"
 SH
   chmod +x "$fakebin/timeout"
@@ -143,7 +147,7 @@ make_path_without() {  # <dir> <tool>...
 }
 
 test_gh_auth_probe_forces_every_bounding_branch() {
-  local case_dir fakebin record out probe_path start elapsed
+  local case_dir fakebin record out probe_path start elapsed forced
   case_dir="$TMP_ROOT/gh-auth-branches"
   mkdir -p "$case_dir/home/config"
   printf '%s\n' manual > "$case_dir/home/config/backlog-backend"
@@ -167,6 +171,24 @@ test_gh_auth_probe_forces_every_bounding_branch() {
     FM_FAKE_TREEHOUSE_LEASE_HELP=1 "$ROOT/bin/fm-bootstrap.sh")
   [ "$(cat "$record")" = "-k 2 7 gh auth status" ] \
     || fail "a zero-padded bound should be read as base 10, got: $(cat "$record")"
+
+  # Every way a bounder can say the bound fired must read as indeterminate: 124
+  # for a plain expiry, 137 for the SIGKILL the kill grace escalates to when the
+  # probe ignores SIGTERM, and 143 for implementations reporting the SIGTERM.
+  for forced in 124 137 143; do
+    set_fake_bounding_timeout "$fakebin" "$record" "$forced"
+    out=$(PATH="$fakebin:$BASE_PATH" FM_HOME="$case_dir/home" FM_ROOT_OVERRIDE="$case_dir/home" \
+      FM_BOOTSTRAP_DETECT_ONLY=1 FM_FAKE_TREEHOUSE_LEASE_HELP=1 "$ROOT/bin/fm-bootstrap.sh")
+    [ "$out" = "GH_AUTH: indeterminate (probe timed out after 10s)" ] \
+      || fail "bounder status $forced means the bound fired, so it must report indeterminate, got: $out"
+  done
+
+  # An ordinary non-zero status is still a finished probe with a real answer.
+  set_fake_bounding_timeout "$fakebin" "$record" 1
+  out=$(PATH="$fakebin:$BASE_PATH" FM_HOME="$case_dir/home" FM_ROOT_OVERRIDE="$case_dir/home" \
+    FM_BOOTSTRAP_DETECT_ONLY=1 FM_FAKE_TREEHOUSE_LEASE_HELP=1 "$ROOT/bin/fm-bootstrap.sh")
+  [ "$out" = "NEEDS_GH_AUTH" ] \
+    || fail "an ordinary non-zero bounder status should still report NEEDS_GH_AUTH, got: $out"
   rm -f "$fakebin/timeout"
 
   # Perl fallback branch, the stock-macOS path this chain exists to serve.

--- a/tests/fm-bootstrap.test.sh
+++ b/tests/fm-bootstrap.test.sh
@@ -17,6 +17,9 @@
 # Dedicated fleet-sync cases pin the computed bootstrap timeout, explicit
 # override, blank-env defaulting, partial-output relay, and pre-launch timeout
 # scan.
+# Dedicated gh-auth cases pin the bounded probe's typed states and force each
+# branch of its timeout/gtimeout/perl/no-tool chain, since a host would otherwise
+# exercise only whichever bounding tool it happens to ship.
 set -u
 
 # shellcheck source=tests/lib.sh disable=SC1091
@@ -86,7 +89,7 @@ SH
   printf '%s\n' "$fakebin"
 }
 
-set_fake_gh_auth_status() {  # <fakebin> <authenticated|unauthenticated|hung>
+set_fake_gh_auth_status() {  # <fakebin> <authenticated|unauthenticated|hung|signal>
   local fakebin=$1 mode=$2
   cat > "$fakebin/gh" <<SH
 #!/usr/bin/env bash
@@ -95,11 +98,108 @@ if [ "\${1:-}" = auth ] && [ "\${2:-}" = status ]; then
     authenticated) exit 0 ;;
     unauthenticated) exit 1 ;;
     hung) sleep 300 ;;
+    signal) kill -SEGV \$\$ ;;
   esac
 fi
 exit 0
 SH
   chmod +x "$fakebin/gh"
+}
+
+# Records what the bounding tool is asked to enforce, then runs the command it
+# was handed. Shadowing `timeout` from the fakebin pins bootstrap on its primary
+# branch regardless of whether the host ships GNU coreutils at all.
+set_fake_bounding_timeout() {  # <fakebin> <argv record path>
+  local fakebin=$1 record=$2
+  cat > "$fakebin/timeout" <<SH
+#!/usr/bin/env bash
+printf '%s\n' "\$*" > '$record'
+[ "\${1:-}" != -k ] || shift 2
+shift
+exec "\$@"
+SH
+  chmod +x "$fakebin/timeout"
+}
+
+# Mirrors BASE_PATH into a directory that omits the named tools, so a case can
+# force bootstrap's bounded-probe chain onto one specific branch. Without it each
+# host exercises only whichever bounding tool it happens to ship: Linux CI always
+# takes `timeout` and never reaches the Perl fallback or the no-tool path, while
+# stock macOS never reaches the `timeout` branch.
+make_path_without() {  # <dir> <tool>...
+  local dir=$1 entry tool
+  shift
+  rm -rf "$dir"
+  mkdir -p "$dir"
+  ( IFS=:
+    for entry in $BASE_PATH; do
+      [ -d "$entry" ] || continue
+      ln -s "$entry"/* "$dir/" 2>/dev/null || true
+    done )
+  for tool in "$@"; do
+    rm -f "$dir/$tool"
+  done
+  printf '%s\n' "$dir"
+}
+
+test_gh_auth_probe_forces_every_bounding_branch() {
+  local case_dir fakebin record out probe_path start elapsed
+  case_dir="$TMP_ROOT/gh-auth-branches"
+  mkdir -p "$case_dir/home/config"
+  printf '%s\n' manual > "$case_dir/home/config/backlog-backend"
+  fakebin=$(make_fake_toolchain "$case_dir")
+  record="$case_dir/timeout-argv"
+
+  # Primary `timeout` branch. A zero-padded zero must reset to the 10s default
+  # exactly as a literal 0 does; leaving it alone would hand the bounding tool a
+  # zero duration, which GNU timeout treats as no bound at all.
+  set_fake_gh_auth_status "$fakebin" authenticated
+  set_fake_bounding_timeout "$fakebin" "$record"
+  out=$(PATH="$fakebin:$BASE_PATH" FM_HOME="$case_dir/home" FM_ROOT_OVERRIDE="$case_dir/home" \
+    FM_BOOTSTRAP_DETECT_ONLY=1 FM_GH_AUTH_TIMEOUT_SECS=00 \
+    FM_FAKE_TREEHOUSE_LEASE_HELP=1 "$ROOT/bin/fm-bootstrap.sh")
+  [ -z "$out" ] || fail "an authenticated probe must stay silent by default, got: $out"
+  [ "$(cat "$record")" = "-k 2 10 gh auth status" ] \
+    || fail "a zero-padded zero bound should reset to 10s and escalate to SIGKILL, got: $(cat "$record")"
+
+  out=$(PATH="$fakebin:$BASE_PATH" FM_HOME="$case_dir/home" FM_ROOT_OVERRIDE="$case_dir/home" \
+    FM_BOOTSTRAP_DETECT_ONLY=1 FM_GH_AUTH_TIMEOUT_SECS=007 \
+    FM_FAKE_TREEHOUSE_LEASE_HELP=1 "$ROOT/bin/fm-bootstrap.sh")
+  [ "$(cat "$record")" = "-k 2 7 gh auth status" ] \
+    || fail "a zero-padded bound should be read as base 10, got: $(cat "$record")"
+  rm -f "$fakebin/timeout"
+
+  # Perl fallback branch, the stock-macOS path this chain exists to serve.
+  probe_path=$(make_path_without "$case_dir/path-without-gnu-timeout" timeout gtimeout)
+  if [ -x "$probe_path/perl" ]; then
+    set_fake_gh_auth_status "$fakebin" hung
+    start=$SECONDS
+    out=$(PATH="$fakebin:$probe_path" FM_HOME="$case_dir/home" FM_ROOT_OVERRIDE="$case_dir/home" \
+      FM_BOOTSTRAP_DETECT_ONLY=1 FM_GH_AUTH_TIMEOUT_SECS=1 \
+      FM_FAKE_TREEHOUSE_LEASE_HELP=1 "$ROOT/bin/fm-bootstrap.sh")
+    elapsed=$((SECONDS - start))
+    [ "$out" = "GH_AUTH: indeterminate (probe timed out after 1s)" ] \
+      || fail "the Perl fallback should bound a hung probe, got: $out"
+    [ "$elapsed" -lt 5 ] || fail "Perl fallback exceeded its 1s bound (elapsed ${elapsed}s)"
+
+    set_fake_gh_auth_status "$fakebin" signal
+    out=$(PATH="$fakebin:$probe_path" FM_HOME="$case_dir/home" FM_ROOT_OVERRIDE="$case_dir/home" \
+      FM_BOOTSTRAP_DETECT_ONLY=1 FM_FAKE_TREEHOUSE_LEASE_HELP=1 "$ROOT/bin/fm-bootstrap.sh")
+    [ "$out" = "NEEDS_GH_AUTH" ] \
+      || fail "a signal-killed probe must not read as authenticated, got: $out"
+  else
+    printf '# skipped Perl fallback branch: no perl under %s\n' "$BASE_PATH"
+  fi
+
+  # No bounding tool at all: still 124, but named as a skipped check rather than
+  # an expired bound, so the coreutils-or-perl remediation is discoverable.
+  probe_path=$(make_path_without "$case_dir/path-without-bounding-tool" timeout gtimeout perl)
+  set_fake_gh_auth_status "$fakebin" authenticated
+  out=$(PATH="$fakebin:$probe_path" FM_HOME="$case_dir/home" FM_ROOT_OVERRIDE="$case_dir/home" \
+    FM_BOOTSTRAP_DETECT_ONLY=1 FM_FAKE_TREEHOUSE_LEASE_HELP=1 "$ROOT/bin/fm-bootstrap.sh")
+  [ "$out" = "GH_AUTH: indeterminate (no bounded-probe tool: install coreutils or perl)" ] \
+    || fail "a home with no bounding tool should name that cause, not claim a timeout, got: $out"
+  pass "bootstrap's bounded gh auth probe behaves correctly on each of its three branches"
 }
 
 test_bounded_gh_auth_probe_reports_typed_states() {
@@ -1043,6 +1143,7 @@ ROWS
 
 test_bootstrap_reporting
 test_bounded_gh_auth_probe_reports_typed_states
+test_gh_auth_probe_forces_every_bounding_branch
 test_pilot_preflight_reaches_result_for_all_auth_states
 test_no_mistakes_min_version
 test_gh_axi_min_version


### PR DESCRIPTION
## Problem

`bin/fm-bootstrap.sh` probed GitHub auth with a bare `gh auth status`. That call is unbounded, so a stalled network or a credential helper waiting on approval hangs session start indefinitely. And because any non-zero result printed `NEEDS_GH_AUTH`, a probe that never answered was indistinguishable from a confirmed logout.

## Change

`gh_auth_report` makes the same single `gh auth status` call, bounded at 10s (`FM_GH_AUTH_TIMEOUT_SECS`; non-numeric, zero, and zero-padded values reset to 10) via `timeout`, `gtimeout`, or a Perl process-group alarm. Stock macOS ships none of the GNU tools, so that fallback chain is load-bearing rather than defensive.

An unfinished probe now reports `GH_AUTH: indeterminate`, with distinct wording for its three causes: the bound expired, the probe was killed before answering, or the home has no bounding tool at all. `AGENTS.md` and `.agents/skills/bootstrap-diagnostics/SKILL.md` register the `GH_AUTH:` prefix, so a session that sees only that line has a defined response.

Default output for the two determinate states is unchanged: authenticated stays silent, unauthenticated still prints exactly `NEEDS_GH_AUTH`. The typed lines are opt-in behind `FM_BOOTSTRAP_GH_AUTH_DIAGNOSTICS=1`.

## Two deliberate behavior changes

Flagging these rather than leaving them in the diff.

Signal-terminated probes now report indeterminate where they previously fell through to `NEEDS_GH_AUTH`. A killed probe proves nothing about the credential. Every status at or above 128 routes through one classifier, so the answer no longer depends on which bounding tool the machine happens to have.

Unifying that message required unifying the kill grace, so both branches now escalate after a shared `GH_AUTH_KILL_GRACE_SECS=2`. The Perl fallback's worst case widens from bound plus 0.2s to bound plus 2s on stock macOS. A per-branch grace would have let the installed bounder decide a slow-but-cooperative probe's wording.

## Tests

Hermetic cases (fake `gh`, no network, no credentials) that shim `PATH` to force each branch of the chain rather than exercising only whichever tool the host ships. Suite: 27 passing. `bin/fm-lint.sh` clean on pinned ShellCheck 0.11.0.

One gap I would rather name than hide: the Perl branch's SIGKILL escalation is verified by hand, not pinned by a test. Reverting that handler to a bare `exit 124` would leave the suite green. A `wedged` fixture closes it, and I am happy to add it here or as a follow-up.

## Follow-up, deliberately out of scope

`bin/fm-bearings-snapshot.sh`, `bin/fm-fleet-snapshot.sh`, and `bin/fm-nm-run-lib.sh` carry the same timeout/gtimeout/Perl chain. All three still end in `exit($? >> 8)`, the signal-status bug fixed here, and none passes `-k`, so the four implementations now disagree about both hardening measures. A shared `fm_bounded_run` helper would give one implementation. Kept out of this PR to keep the diff reviewable; happy to send it separately.

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ⚠️ `bin/fm-bootstrap.sh:108` - Zero-padded zero values bypass the sanitizer and disable the bound entirely. The guard is `&#39;&#39;|*[!0-9]*|0)`, so `FM_GH_AUTH_TIMEOUT_SECS=00` (or `000`) is non-empty, all-digits, and not literally `0`, and passes through unchanged. Verified: `timeout 0 sleep 4` exits 0 after the full 4s (GNU timeout treats 0 as no limit), and perl&#39;s `alarm(&#34;00&#34;)` numifies to 0, which cancels any pending alarm — the probe snippet with t=00 against `sleep 20` was still running after 7s. Both the primary and fallback paths therefore hang unboundedly, reintroducing exactly the failure this change exists to prevent. This contradicts the intent criterion &#34;non-numeric and zero values sanitized back to 10&#34;: `00` is a zero value that is not sanitized. Fix by rejecting all-zero strings (e.g. add `0*` to the case pattern, or compare arithmetically after the digit check).
- ⚠️ `bin/fm-bootstrap.sh:238` - The Perl fallback&#39;s `exit($? &gt;&gt; 8)` discards signal-termination status, so a `gh auth status` killed by a signal is reported as authenticated and bootstrap stays silent. Verified by running the exact snippet against a child that does `kill -SEGV $$`: the probe exits 0, whereas invoking the child directly gives 139. The `timeout`/`gtimeout` branches return 128+N here (-&gt; NEEDS_GH_AUTH), and so did the pre-change direct call, so the fallback silently swallows a real auth failure signal on precisely the stock-macOS path this chain exists to serve. Map signal death to a non-zero, non-124 status, e.g. `my $st = $?; exit($st &amp; 127 ? 128 + ($st &amp; 127) : $st &gt;&gt; 8);`.
- ⚠️ `bin/fm-bootstrap.sh:10` - `GH_AUTH: indeterminate (probe timed out after &lt;n&gt;s)` prints unconditionally but is not registered as an actionable diagnostic anywhere the agent reads. AGENTS.md:501 and .agents/skills/bootstrap-diagnostics/SKILL.md both enumerate the trigger prefixes (MISSING, NEEDS_GH_AUTH, TANGLE, FLEET_SYNC, ...) and neither lists GH_AUTH, and the skill has no per-line handling entry for it. A session whose only bootstrap output is the indeterminate line therefore does not load the playbook and has no defined response, which defeats the point of distinguishing indeterminate from unauthenticated. The header line added here also presents all three GH_AUTH states as if they always print, without noting that `authenticated` and `not authenticated` require FM_BOOTSTRAP_GH_AUTH_DIAGNOSTICS=1.
- ℹ️ `bin/fm-bootstrap.sh:106` - `FM_GH_AUTH_TIMEOUT_SECS` and `FM_BOOTSTRAP_GH_AUTH_DIAGNOSTICS` are absent from the canonical env-var block in docs/configuration.md, which documents sibling bootstrap knobs `FM_FLEET_SYNC_BOOTSTRAP_TIMEOUT` and `FM_FLEET_PRUNE` (lines 550-551), and from the fm-bootstrap.sh header&#39;s own env documentation, which covers FM_BOOTSTRAP_DETECT_ONLY, FM_BOOTSTRAP_VERBOSE_FACTS, and FM_FLEET_PRUNE. Operators have no documented way to discover the 10s default, the override, or the diagnostics opt-in.
- ℹ️ `bin/fm-bootstrap.sh:220` - The `timeout`/`gtimeout` branches send only SIGTERM and then wait for the child indefinitely, while the Perl fallback deliberately escalates TERM -&gt; 0.2s -&gt; KILL. A `gh` (or credential helper) that blocks or ignores SIGTERM keeps the primary path hanging, so the strongest guarantee lives only in the least-used branch. Adding `-k &lt;n&gt;` (e.g. `timeout -k 2 &#34;$FM_GH_AUTH_TIMEOUT_SECS&#34; ...`) makes the primary path match the fallback&#39;s escalation.
- ℹ️ `bin/fm-bootstrap.sh:255` - When none of timeout/gtimeout/perl exist, gh_auth_probe returns 124 without ever invoking gh, yet gh_auth_report prints &#34;probe timed out after 10s&#34;. Nothing ran and nothing timed out; the operator is told a bounded probe expired when in fact the auth check was skipped for lack of a bounding mechanism. Returning 124 there is required by the intent, but the two causes warrant distinguishable wording so the remediation (install coreutils/perl) is discoverable.
- ℹ️ `bin/fm-bootstrap.sh:218` - The timeout and gtimeout branches are byte-identical apart from the binary name, and gh_auth_report repeats the same `[ &#34;${FM_BOOTSTRAP_GH_AUTH_DIAGNOSTICS:-0}&#34; != 1 ] || echo ...` gate twice. Resolving the bounding binary into a variable (`for b in timeout gtimeout; do command -v &#34;$b&#34; ... done`) and factoring the diagnostics gate into a one-line helper removes the duplication without changing behavior; the Perl branch stays separate since its shape genuinely differs.
- ℹ️ `tests/fm-bootstrap.test.sh:104` - The new tests pin PATH to `$fakebin:$BASE_PATH` (/usr/bin:/bin:/usr/sbin:/sbin) but never control which bounding tool is visible, so each host exercises exactly one branch: Linux CI hits `timeout` (/usr/bin/timeout), stock macOS hits the Perl fallback (/usr/bin/perl). The Perl process-group path and the no-tool `return 124` path — the two portability guarantees the change is built around, and where the signal-status bug above lives — are never both covered on any single run. A fakebin shim that shadows/hides `timeout`, `gtimeout`, and `perl` per case would force all three branches deterministically.

🔧 Fix: harden bounded gh auth probe and register its diagnostics
4 issues (2 warnings, 2 infos) still open:
- ⚠️ `bin/fm-bootstrap.sh:256` - The new `-k &#34;$GH_AUTH_KILL_GRACE_SECS&#34;` makes the escalated-kill case report NEEDS_GH_AUTH instead of indeterminate. GNU timeout documents and returns 137 (128+9), not 124, when it has to send SIGKILL after the grace period; verified on coreutils 9.11 that `timeout -k 1 1 bash -c &#39;trap &#34;&#34; TERM; sleep 10&#39;` exits 137 while `timeout -k 1 1 sleep 10` exits 124. 137 misses the `124)` arm at line 299 and falls through `*)` at line 309 to `echo &#34;NEEDS_GH_AUTH&#34;`, so a `gh` or credential helper that ignores SIGTERM - precisely the case `-k` was added to handle - now produces a confident &#34;not authenticated&#34; report from a probe that never finished. That contradicts the intent criterion &#34;stop it reporting an indeterminate probe as unauthenticated&#34;. Fix inside the bounder branch so the Perl and no-tool paths keep shell semantics, e.g. run the bounder, capture its status, and `return 124` for 137 (and 143, which non-GNU `timeout` implementations return on expiry) while leaving other non-zero statuses alone.
- ⚠️ `tests/fm-bootstrap.test.sh:112` - `set_fake_bounding_timeout` records argv and then `exec &#34;$@&#34;` with no bound at all, so the primary branch - the one every coreutils-equipped host and Linux CI actually takes - is only asserted on the argv string (`-k 2 10 gh auth status`). Nothing verifies what `gh_auth_report` does with the bounder&#39;s exit status, which is why the 137-on-SIGKILL misreport above is invisible to the suite even though the same test file now covers the Perl branch&#39;s timeout and signal cases behaviorally. Extend the shim to exit a caller-selected status (124 for a plain expiry, 137 for an escalated kill) and assert both map to `GH_AUTH: indeterminate (probe timed out after 10s)`.
- ℹ️ `bin/fm-bootstrap.sh:258` - `gh_auth_probe` hand-rolls a fourth copy of a timeout/gtimeout/Perl-process-group-alarm chain that already exists in the repo. `bin/fm-bearings-snapshot.sh:194-199` is a near-twin (it bounds a `gh` call with the identical `GH_PROMPT_DISABLED=1 GH_NO_UPDATE_NOTIFIER=1` prefix and the byte-identical Perl one-liner), and `bin/fm-fleet-snapshot.sh:791-796` and `bin/fm-nm-run-lib.sh:17-24` carry the same chain. All three still end in `exit($? &gt;&gt; 8)`, the exact signal-status bug this change just fixed in its own copy, and none passes `-k`, so the four implementations now disagree about both hardening measures. Extracting the hardened version into a shared `bin/fm-*-lib.sh` helper (`fm_bounded_run &lt;secs&gt; &lt;cmd&gt;...`) would give one implementation and propagate the fix; touching the three other scripts expands this change&#39;s scope, so it is the author&#39;s call.
- ℹ️ `bin/fm-bootstrap.sh:237` - With `GH_AUTH_KILL_GRACE_SECS=2` the worst-case wall clock of the bounder branch is `FM_GH_AUTH_TIMEOUT_SECS + 2` (12s by default), but the header at line 88, docs/configuration.md:505, and .agents/skills/bootstrap-diagnostics/SKILL.md:31 all describe a flat 10 second bound, and the printed line still says &#34;timed out after 10s&#34;. The extra 2s only elapses when the probe ignores SIGTERM, so this is an accuracy nuance rather than a behavior problem, and the existing `elapsed -lt 5` assertions against a 1s bound still hold (worst case 3s).

🔧 Fix: report escalated-kill bounder status as indeterminate
1 warning still open:
- ⚠️ `bin/fm-bootstrap.sh:266` - The new `[ &#34;$status&#34; -lt 128 ] || status=124` applies only to the bounder branch, so the two bounding implementations now report a signal-killed probe differently. A `gh auth status` killed by something other than the bound (SIGSEGV, the OOM killer, an external kill) returns 139/137 from `timeout`, is collapsed to 124 at line 266, and prints `GH_AUTH: indeterminate`; the same condition on the Perl fallback is mapped to 128+N at line 287, misses the `124)` arm at line 309, and prints `NEEDS_GH_AUTH`. The suite pins both semantics - tests/fm-bootstrap.test.sh:182 asserts indeterminate for forced 137/143, and tests/fm-bootstrap.test.sh:210 asserts NEEDS_GH_AUTH for the Perl branch&#39;s SEGV case - so a home on stock macOS and a home on Linux give opposite answers for an identical unanswered probe, under an intent that names portability a hard requirement. The bounder branch&#39;s own comment states the principle (&#34;Every 128+N outcome means the probe was killed rather than answered, so it is indeterminate and never a confident unauthenticated&#34;), which the Perl branch contradicts; that branch also still reports an unanswered probe as unauthenticated, the behavior the intent&#39;s headline goal forbids. Note the reverse tradeoff too: on the bounder path a probe that segfaults in 0.1s now prints &#34;probe timed out after 10s&#34;, which is inaccurate wording for a non-timeout kill. Both mappings were separately requested in earlier rounds, so which semantic should win is the author&#39;s call - either extend the collapse to the Perl branch (map 128+N to 124 there too, ideally with cause wording that does not claim a timeout), or narrow the bounder collapse to 124/137/143 only.

🔧 Fix: unify killed-probe reporting across both bounding branches
1 info still open:
- ℹ️ `bin/fm-bootstrap.sh:301` - One residual sub-wording difference survives the unification, by design. A probe that ignores SIGTERM and must be SIGKILLed by its own bound reports `GH_AUTH: indeterminate (probe terminated abnormally with status 137)` on the timeout/gtimeout path, because GNU timeout&#39;s 137 cannot be attributed to the kill grace versus an external kill, but reports `GH_AUTH: indeterminate (probe timed out after 10s)` on the Perl fallback, because that branch&#39;s alarm handler exits 124 at line 279 before waitpid observes the signal and so knows it caused the kill. The classification is identical on both paths, .agents/skills/bootstrap-diagnostics/SKILL.md:34 states the ambiguity explicitly, and the skill&#39;s handling for the two lines is the same, so this is a documented information asymmetry rather than a defect; noting it only so the residual gap against &#34;report identically on every machine&#34; is on record.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `a`

</details>

<details>
<summary>⚠️ **Document** - 2 warnings</summary>

- ⚠️ `bin/fm-bootstrap.sh:310` - The final commit&#39;s stated goal was to &#34;unify killed-probe reporting across both bounding branches&#34;, but the bound&#39;s own escalation is still worded differently depending on which bounding tool the home ships. I measured this: against a SIGTERM-ignoring probe, `timeout -k 2 1` exits 137, which the shared mapping classifies as `abnormal` and reports as &#34;probe terminated abnormally with status 137&#34;; the Perl fallback&#39;s ALRM handler calls `exit 124` itself (line 283-287), so the identical hang reports &#34;probe timed out after 10s&#34;. Only externally-killed probes (the SIGSEGV/139 case the test pins) actually read identically. I documented the divergence rather than hid it, because the safety invariant still holds everywhere -- both wordings are indeterminate and neither becomes NEEDS_GH_AUTH -- and the SKILL.md tells the agent to handle the two lines the same way. But if the author intended literal unification, the fix belongs in the Perl handler (exit a distinguishable status when it had to escalate, or have the handler report the same abnormal cause), not in the prose I just aligned to current behavior. That is an executable-behavior change and therefore outside this task&#39;s scope, so it needs the author&#39;s call.
- ℹ️ `docs/configuration.md:303` - The gh-auth probe mechanism (10s bound, sanitization rules, SIGKILL grace, three indeterminate causes, opt-in diagnostics) is now stated in four places: the `bin/fm-bootstrap.sh` header, the `docs/configuration.md` Toolchain prose, the `docs/configuration.md` env-var block, and `.agents/skills/bootstrap-diagnostics/SKILL.md`. This is exactly the synchronization cost the one-owner rule warns about -- the single wrong &#34;2 second grace&#34; figure had to be chased through all four. I reduced the SKILL.md copy to a pointer as part of this fix, but collapsing the remaining overlap (notably the env-block comment restating the prose two paragraphs above it) is a consolidation beyond what this change made stale. Proposing it as a follow-up rather than multiplying edits here.

🔧 Fix: unify killed-probe wording across both gh auth bounding branches
2 issues (1 warning, 1 info) still open:
- ⚠️ `tests/fm-bootstrap.test.sh:208` - The behavior I just changed has no test pinning it. The Perl fallback now exits 128+SIGKILL when it has to escalate, instead of always exiting 124, and that is what makes a wedged probe read identically on both branches. But the existing Perl-branch hang case uses a fake gh of `sleep 300`, which honours SIGTERM, so it only ever exercises the 124 path; the 137 escalation path is exercised on the `timeout` branch solely through `set_fake_bounding_timeout`&#39;s forced status, which fakes the bounder rather than running one. I verified the parity by hand against the real script (a SIGTERM-ignoring gh reports `probe was killed before it answered, status 137` on both branches, and a cooperative hang reports `probe timed out after 1s` on both), but a manual check does not survive the next refactor: someone could revert the Perl handler to a bare `exit 124` and the whole suite would still pass. Closing this is cheap given the existing fixtures - add a `wedged` mode to `set_fake_gh_auth_status` (`trap &#39;&#39; TERM; sleep 300`) and assert the Perl branch emits the same line the bounder branch does, at a cost of about bound+2s of runtime. I did not write it because this step&#39;s rules forbid changing tests, and the author&#39;s instruction authorized the message unification, not new test authoring. It needs their call on whether it lands in this PR or as a follow-up.
- ℹ️ `bin/fm-bootstrap.sh:243` - Unifying the message required unifying the grace, which widens the Perl fallback&#39;s worst case. It previously waited 0.2s between SIGTERM and SIGKILL; it now takes the shared GH_AUTH_KILL_GRACE_SECS of 2s, so worst-case wall clock on stock macOS goes from bound+0.2s to bound+2s (measured 3.2s with a 1s bound). This was not optional: leaving the graces different would have meant a probe that takes, say, 0.5s to honour SIGTERM reported as killed on the Perl branch and as a timeout on the timeout branch, which is exactly the tool-dependent message the author asked to remove. The bound still cannot hang, the 2s figure now matches what the docs claim on every path, and the suite&#39;s `elapsed &lt; 5` assertion still holds. Flagging it only because it is a timing change on the stock-macOS path that the wording-focused instruction did not explicitly ask for, and the contributor&#39;s intent statement called portability a hard requirement - so if bound+2s is considered too slow for session start, the lever is GH_AUTH_KILL_GRACE_SECS and it should be lowered for both branches together, never for one.

🔧 Fix: drop stale SIGKILL clause from gh auth timeout bullet
2 warnings still open:
- ⚠️ `tests/fm-bootstrap.test.sh:208` - The regression test you approved last round is still not in the tree, and this step is forbidden from editing tests, so I could not add it. The Perl-branch hang case still uses a `sleep 300` fake gh, which honours SIGTERM and therefore only ever exercises the 124 path; the ALRM handler&#39;s escalation to 128+SIGKILL is exercised nowhere. The `signal` fixture at line 222 pins a self-crashing probe (139) rather than a bound that had to escalate, and the 137 case on the `timeout` branch comes from `set_fake_bounding_timeout`&#39;s forced status, which fakes the bounder instead of running one. I re-confirmed the parity by hand against the real bounders this round (bound 1s, grace 2s: a SIGTERM-ignoring probe exits 137 on both branches, a slow-but-cooperative one exits 124 on both), but that is exactly the kind of check a refactor silently voids: reverting the Perl handler to a bare `exit 124` would still leave the whole suite green. The fix is unchanged from what you approved - a `wedged` mode in `set_fake_gh_auth_status` (`trap &#39;&#39; TERM; sleep 300`) plus an assertion that the Perl branch emits the same killed line the bounder branch does, costing about bound+2s of runtime. It needs a step that is allowed to write tests.
- ⚠️ The two behavior-change statements you asked to be stated plainly have no live PR body to land in, and I could not resolve that from the document step. PR kunchenguid/firstmate#1752 is CLOSED and its head (7a4fdc3) predates every commit on this branch, so its body still describes only the original bounded-probe commit - it does not mention the killed or no-bounding-tool causes, and it claims 23 passing tests where the suite is now 27. Editing a closed PR that points at different code would not carry the statements to whatever PR this branch opens, and the body is not a repository file I can fix in place, so the PR step has to author them. The two lines it must include, per your instruction: signal-terminated probes now report `GH_AUTH: indeterminate` where they previously fell through to `NEEDS_GH_AUTH`, because a killed probe proves nothing about the credential and reporting it as unauthenticated is the exact failure this change exists to remove; and unifying the message required unifying the kill grace, so the Perl fallback&#39;s worst case widens from bound plus 0.2 seconds to bound plus 2 seconds on stock macOS, because a per-branch grace would decide a slow-but-cooperative probe&#39;s wording purely from which bounder the home ships. Current-state versions of both facts already live in their owner docs (`docs/configuration.md` &#34;Toolchain&#34; and the `bin/fm-bootstrap.sh` header); only the before-and-after framing belongs in the PR narrative.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>

