### PR TITLE
fix: prevent stalled supervision and zombie session locks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -301,7 +301,7 @@ After an autonomous merge, give the captain a one-line full-URL or local-main ou
 ### Validate
 
 For a no-mistakes ship, trigger validation on the same worker after its implementation commit, using the harness invocation owned by `harness-adapters`.
-The task worker that starts a no-mistakes run drives the pipeline and owns every `no-mistakes axi run` and `no-mistakes axi respond` call through the next gate or outcome.
+The task worker that starts a no-mistakes run drives the pipeline and owns every `no-mistakes axi run` and `no-mistakes axi respond` call until a gate requires firstmate or the run reaches a terminal outcome.
 Firstmate never invokes `no-mistakes axi respond` for a crew-owned run.
 Once validation starts, prefer routing new requirements to follow-up work rather than expanding the current task, unless a new requirement completely invalidates the work being validated; however, the smallest downstream changes needed to keep already accepted product or engineering behavior correct, add behavioral tests where an executable contract exists, or keep documentation accurate remain within the current task even when they touch files not named at intake, and corrections required to satisfy already accepted intent are not new requirements.
 

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -311,6 +311,7 @@ case "$MODE" in
 This project ships **direct-PR**: you raise the PR yourself, without the no-mistakes pipeline.
 The task is complete only when committed on your branch.
 When it is implemented and committed, push your branch and open a PR with \`gh-axi\`, then append \`done: PR {url}\` to the status file and stop.
+Do not end your turn waiting for firstmate to tell you to push or open the PR - those delivery steps are yours.
 Do NOT run /no-mistakes. The configured merge authority decides whether to merge the PR; firstmate relays the outcome.
 EOF
     ;;
@@ -323,6 +324,7 @@ This project ships **local-only**: no remote, no PR, no pipeline.
 The task is complete only when committed on your branch \`fm/$ID\`. Do NOT push, do NOT open a PR, do NOT merge.
 Keep your branch a clean fast-forward onto the current default branch - if \`main\` has advanced, rebase onto it so the eventual merge stays a fast-forward.
 When it is implemented and committed, append \`done: ready in branch fm/$ID\` to the status file and stop.
+Do not end your turn waiting for firstmate to tell you to rebase or report the ready branch - those delivery steps are yours.
 The configured merge authority approves the ready branch, then firstmate merges it into local \`main\` through the guarded fast-forward path.
 EOF
     ;;
@@ -333,8 +335,10 @@ EOF
     IFS= read -r -d '' DOD <<EOF || true
 # Definition of done
 The task is complete only when committed on your branch.
-When you believe it is complete, append \`done: {summary}\` to the status file and stop.
-Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.
+After committing the implementation, invoke /no-mistakes yourself to validate and ship the PR.
+Do not append \`done:\` or end your turn merely because the pipeline is running.
+Poll the run's own status and keep driving it until it reaches a gate that requires firstmate or a terminal outcome.
+"Waiting for the next decision point" is not a valid resting state while the run is active.
 
 You drive no-mistakes by responding to its gates, not by implementing fixes.
 Follow the guidance no-mistakes itself provides for the mechanics: it loads when you invoke /no-mistakes, and \`no-mistakes axi run --help\` plus the \`help\` lines in each \`axi\` response are authoritative and version-matched to the installed binary.

--- a/bin/fm-composer-lib.sh
+++ b/bin/fm-composer-lib.sh
@@ -180,9 +180,32 @@ fm_composer_idle_matches() {
   esac
 }
 
+# Normalize every non-ASCII code point in Unicode's White_Space property to an
+# ASCII space, then trim the result.
+# Bash's locale-sensitive [[:space:]] does not consistently include these code
+# points, including U+00A0 NO-BREAK SPACE in the live Claude idle composer.
+# Normalizing inside the shared classifier keeps tmux, Herdr, Orca, and cmux on
+# one verdict without weakening non-whitespace content checks.
+fm_composer_trim_whitespace() {  # <content>
+  local content=$1 whitespace LC_ALL=C
+  for whitespace in \
+    $'\302\205' $'\302\240' $'\341\232\200' \
+    $'\342\200\200' $'\342\200\201' $'\342\200\202' $'\342\200\203' \
+    $'\342\200\204' $'\342\200\205' $'\342\200\206' $'\342\200\207' \
+    $'\342\200\210' $'\342\200\211' $'\342\200\212' $'\342\200\250' \
+    $'\342\200\251' $'\342\200\257' $'\342\201\237' $'\343\200\200'; do
+    content=${content//"$whitespace"/ }
+  done
+  content="${content#"${content%%[![:space:]]*}"}"
+  content="${content%"${content##*[![:space:]]}"}"
+  printf '%s' "$content"
+}
+
 fm_composer_classify_content() {  # <bordered> <content> [idle_re] [idle_case] [plain_content]
   local bordered=$1 content=$2 idle_re=${3:-} idle_case=${4:-sensitive} plain_content
   plain_content=${5:-$content}
+  content=$(fm_composer_trim_whitespace "$content")
+  plain_content=$(fm_composer_trim_whitespace "$plain_content")
   if [ "$bordered" != 1 ] && [ -z "$content" ] && [ -n "$plain_content" ]; then
     case "$plain_content" in
       '❯'|'›') printf 'empty'; return 0 ;;
@@ -211,8 +234,7 @@ fm_composer_classify_content() {  # <bordered> <content> [idle_re] [idle_case] [
     '❯ '*|'› '*|'> '*|'$ '*|'% '*|'# '*) content=${content#??} ;;
     '❯'*|'›'*|'>'*|'$'*|'%'*|'#'*) content=${content#?} ;;
   esac
-  content="${content#"${content%%[![:space:]]*}"}"
-  content="${content%"${content##*[![:space:]]}"}"
+  content=$(fm_composer_trim_whitespace "$content")
   [ -n "$content" ] || { printf 'empty'; return 0; }
   # Known idle placeholder (matched again after the leading glyph was stripped,
   # e.g. "❯ Type a message...").

--- a/bin/fm-lock.sh
+++ b/bin/fm-lock.sh
@@ -23,13 +23,31 @@ mkdir -p "$STATE" 2>/dev/null || {
 # shellcheck source=bin/fm-session-lock-lib.sh
 . "$SCRIPT_DIR/fm-session-lock-lib.sh"
 
+# Human-readable reason a non-live lock-holder pid $1 was classified stale, for
+# the status command's diagnostic output only; never consulted for acquire
+# decisions, which rely solely on fm_harness_pid_alive.
+fm_stale_reason() {
+  local pid=$1
+  if ! kill -0 "$pid" 2>/dev/null; then
+    echo "dead"
+  elif fm_pid_is_zombie "$pid"; then
+    echo "zombie, never reaped by its parent"
+  else
+    echo "not a harness"
+  fi
+}
+
 if [ "${1:-}" = "status" ]; then
   if [ ! -f "$LOCK" ]; then echo "lock: free"; exit 0; fi
   old=$(cat "$LOCK" 2>/dev/null) || {
     echo "lock: unreadable"
     exit 0
   }
-  if fm_harness_pid_alive "$old"; then echo "lock: held by live harness pid $old"; else echo "lock: stale (pid $old dead or not a harness)"; fi
+  if fm_harness_pid_alive "$old"; then
+    echo "lock: held by live harness pid $old"
+  else
+    echo "lock: stale (pid $old $(fm_stale_reason "$old"))"
+  fi
   exit 0
 fi
 

--- a/bin/fm-session-lock-lib.sh
+++ b/bin/fm-session-lock-lib.sh
@@ -129,10 +129,32 @@ EOF
   printf '%s\n' "$outermost"
 }
 
-# True if $1 is a live process that looks like a verified harness.
+# True if $1 is a zombie: exited but not yet reaped by its parent. A zombie
+# still passes `kill -0` and `ps` still reports its original comm/args, so a
+# lock holder pid must be checked for this before anything else - otherwise a
+# dead harness whose parent never reaped it reads as a live lock holder
+# forever, with no way to reclaim the lock short of deleting it by hand.
+#
+# The single-character process state is the portable signal: Linux procps'
+# "state" keyword and BSD/macOS ps's "state" (documented as an alias for
+# "stat") both report a leading Z for a zombie, though BSD appends extra flag
+# characters after it (e.g. "Z+"), hence the prefix match rather than an exact
+# comparison.
+fm_pid_is_zombie() {
+  local pid=$1 state
+  state=$(ps -o state= -p "$pid" 2>/dev/null | tr -d '[:space:]')
+  case "$state" in
+    Z*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# True if $1 is a live process that looks like a verified harness. A zombie
+# pid is never alive: see fm_pid_is_zombie.
 fm_harness_pid_alive() {
   local pid=$1 comm args
   kill -0 "$pid" 2>/dev/null || return 1
+  fm_pid_is_zombie "$pid" && return 1
   comm=$(ps -o comm= -p "$pid" 2>/dev/null) || return 1
   args=$(ps -o args= -p "$pid" 2>/dev/null)
   fm_harness_process_matches "$comm" "$args"

--- a/bin/fm-supervise-daemon.sh
+++ b/bin/fm-supervise-daemon.sh
@@ -109,9 +109,9 @@
 #                                   active-alert directive for that wedge alarm
 #                                   (off|auto|osascript|herdr|command:<cmd>). An
 #                                   absent file/var means auto: on macOS that is
-#                                   an OS-level notification, so the alarm is
-#                                   never silent. See wedge_alarm_notify below
-#                                   and docs/configuration.md.
+#                                   an OS-level notification. See
+#                                   wedge_alarm_notify below and
+#                                   docs/configuration.md.
 #          FM_WEDGE_ALARM_EXEC      notifier seam: when set, every notifier
 #                                   channel routes through this command as
 #                                   `<cmd> <channel> <summary>` instead of
@@ -580,16 +580,31 @@ fm_daemon_primary_harness() {
   printf '%s' "$FM_DAEMON_PRIMARY_HARNESS"
 }
 
-pane_is_busy() {  # <target> [backend]
-  local target=$1 backend=${2:-tmux} native tail40 harness
+pane_busy_observation() {  # <target> [backend]
+  local target=$1 backend=${2:-tmux} native tail40 harness rendered=idle
   harness=$(fm_daemon_primary_harness)
   native=$(fm_backend_busy_state "$backend" "$target" 2>/dev/null)
   case "$native" in
-    busy) return 0 ;;
+    busy) printf 'harness=%s native=busy rendered=not-read' "$harness"; return 0 ;;
   esac
-  tail40=$(fm_backend_capture "$backend" "$target" 40 2>/dev/null) || return 1
-  printf '%s' "$tail40" | grep -v '^[[:space:]]*$' | tail -12 \
-    | fm_busy_lines_match "$harness"
+  if ! tail40=$(fm_backend_capture "$backend" "$target" 40 2>/dev/null); then
+    printf 'harness=%s native=%s rendered=capture-failed' "$harness" "${native:-unknown}"
+    return 1
+  fi
+  if printf '%s' "$tail40" | grep -v '^[[:space:]]*$' | tail -12 | fm_busy_lines_match "$harness"; then
+    rendered=busy
+  fi
+  printf 'harness=%s native=%s rendered=%s' "$harness" "${native:-unknown}" "$rendered"
+  [ "$rendered" = busy ]
+}
+
+PANE_BUSY_OBSERVATION=
+pane_is_busy() {  # <target> [backend]
+  local observation status
+  observation=$(pane_busy_observation "$@")
+  status=$?
+  PANE_BUSY_OBSERVATION=$observation
+  return "$status"
 }
 
 # pane_input_pending dispatches through fm_backend_composer_state and treats
@@ -655,8 +670,8 @@ escalate_flush() {  # <state>
 }
 
 # --- backend-independent active wedge alert ---------------------------------
-# The tmux status-line flash in inject_wedge_alarm below is a cosmetic,
-# client-side OSD with no cross-backend equivalent, so a wedged non-tmux primary
+# The tmux status overlay in inject_wedge_alarm below is an on-host signal with
+# no cross-backend equivalent, so a wedged non-tmux primary
 # (the 2026-07-10 overnight incident: a claude-on-herdr primary) got NO active
 # signal - only the passive state/.subsuper-inject-wedged marker, which nothing
 # surfaces until the next fleet action (that night, 20 escalations sat buffered
@@ -665,13 +680,13 @@ escalate_flush() {  # <state>
 # herdr notification, or a captain-supplied command (push to a phone, etc.).
 # Every channel is best-effort - a missing or failing channel logs and is
 # skipped, never crashing the daemon loop - and the durable marker plus the tmux
-# flash stay exactly as before.
+# overlay stay available on the tmux path.
 #
 # Config: config/wedge-alarm (local, gitignored), one channel directive per
 # non-empty, non-comment line. FM_WEDGE_ALARM_CHANNEL overrides the file with a
 # single directive. Directives:
 #   off              disable the active alert entirely, regardless of position
-#                    (marker + flash remain)
+#                    (marker + tmux overlay remain)
 #   auto | default   platform default: macOS -> osascript; otherwise none
 #   osascript        macOS Notification Center banner (backend-independent)
 #   herdr            herdr UI notification (herdr notification show)
@@ -703,10 +718,10 @@ wedge_alarm_configured_channels() {
   [ -n "$found" ] || printf 'auto\n'
 }
 
-# Resolve the platform's default OS-level channel for `auto`. macOS reaches the
-# captain via an osascript Notification Center banner; other platforms have no
-# built-in OS channel (the captain wires a command: directive), so this prints
-# nothing and wedge_alarm_notify logs that the marker is the only signal.
+# Resolve the platform's default OS-level channel for `auto`.
+# macOS reaches the captain via an osascript Notification Center banner.
+# Other platforms have no built-in out-of-band channel, so this prints nothing
+# and wedge_alarm_notify logs that the marker is the only signal.
 wedge_alarm_platform_default() {
   case "$(uname)" in
     Darwin) command -v osascript >/dev/null 2>&1 && printf 'osascript' ;;
@@ -893,7 +908,7 @@ wedge_alarm_notify() {  # <summary> <marker>
 # is lost - the buffer and the
 # wake-queue both survive - but the stall stops being invisible.
 inject_wedge_alarm() {  # <state> <age-seconds>
-  local state=$1 age=$2 marker target backend max_defer now notify=1
+  local state=$1 age=$2 marker target backend max_defer display_ms now notify=1
   marker="$state/.subsuper-inject-wedged"
   max_defer="${FM_MAX_DEFER_SECS:-$MAX_DEFER_SECS_DEFAULT}"
   # Re-alarm at most once per max-defer window so a long wedge does not spam.
@@ -914,14 +929,19 @@ inject_wedge_alarm() {  # <state> <age-seconds>
   } 2>/dev/null > "$marker" || true
   target="${FM_SUPERVISOR_TARGET:-$FM_SUPERVISOR_TARGET_DEFAULT}"
   backend="${FM_SUPERVISOR_BACKEND:-$FM_SUPERVISOR_BACKEND_DEFAULT}"
-  # Best-effort status-line flash. tmux's display-message is a client-side OSD
-  # with no herdr equivalent; the log line + durable marker above are already
-  # the primary, backend-independent signal, so a non-tmux backend just skips
-  # this cosmetic extra rather than attempting an unsupported call.
+  # Best-effort persistent status overlay.
+  # tmux has no out-of-band alert channel, but this on-host signal stays visible
+  # until the next rate-limited refresh.
+  # A non-tmux backend skips it because there is no equivalent primitive.
   if [ "$backend" = tmux ]; then
-    tmux display-message -t "$target" "fm: away-mode escalations WEDGED ${age}s — see $marker" 2>/dev/null || true
+    # Keep the status overlay visible until the next rate-limited alarm refresh.
+    # Unlike wall or terminal output, display-message never writes into an agent
+    # pane or its composer.
+    display_ms=$(((max_defer + ${FM_HOUSEKEEPING_TICK:-$HOUSEKEEPING_TICK_DEFAULT} + 1) * 1000))
+    tmux display-message -d "$display_ms" -t "$target" \
+      "fm: away-mode escalations WEDGED ${age}s - see $marker" 2>/dev/null || true
   fi
-  # Backend-independent active alert. Unlike the tmux flash above (skipped on
+  # Backend-independent active alert. Unlike the tmux overlay above (skipped on
   # every non-tmux backend), this can reach the captain even when every pane and
   # its backend status-line is unreadable - the gap the 2026-07-10 overnight
   # incident fell through. Configurable and best-effort; the marker above stays
@@ -1112,12 +1132,12 @@ window_for_task() {  # <task-key> [state]
 #     line, or a previous injection's unsent text), defer entirely - injecting
 #     would merge with the human's text.
 inject_msg() {  # <message> [state]
-  local msg=$1 state target backend retries sleep_s verdict composer encoded
+  local msg=$1 state target backend retries sleep_s verdict composer encoded busy_observation override_set=no
   state="${2:-$(_state_root)}"
   # (1) Presence-gate: inject ONLY when afk is active. When afk is off, the
   # daemon self-handles and stays quiet; firstmate drives the normal always-on
   # watcher triage. Escalations buffer and survive for the next catch-up flush.
-  afk_active "$state" || { log "inject deferred: afk inactive"; return 1; }
+  afk_active "$state" || { log "inject deferred: gate=presence verdict=afk-inactive"; return 1; }
   # (2) Single-line digest: collapse any embedded newlines so submission via
   # send-keys + Enter is unambiguous regardless of how the TUI composer treats
   # them. Then use the canonical typed envelope so downstream consumers retain
@@ -1132,12 +1152,18 @@ inject_msg() {  # <message> [state]
   # when unset (sourced/test contexts that never ran fm_super_main's startup
   # discovery), matching this function's pre-existing default assumption.
   backend="${FM_SUPERVISOR_BACKEND:-tmux}"
-  fm_backend_target_exists "$backend" "$target" || return 1
-  # (3) Busy-guard: never inject into an in-use supervisor pane.
-  if pane_is_busy "$target" "$backend"; then
-    log "inject deferred: supervisor pane busy (agent mid-turn)"
+  if ! fm_backend_target_exists "$backend" "$target"; then
+    log "inject deferred: gate=target backend=$backend verdict=missing"
     return 1
   fi
+  # (3) Busy-guard: never inject into an in-use supervisor pane.
+  PANE_BUSY_OBSERVATION=
+  if pane_is_busy "$target" "$backend"; then
+    busy_observation=${PANE_BUSY_OBSERVATION:-harness=unknown native=unknown rendered=busy}
+    log "inject deferred: gate=busy backend=$backend $busy_observation"
+    return 1
+  fi
+  busy_observation=${PANE_BUSY_OBSERVATION:-harness=unknown native=unknown rendered=idle}
   #   b) Composer-guard: inject ONLY into a confirmed-empty GENUINE agent
   #      composer. The shared classifier (fm_backend_composer_state ->
   #      fm_composer_classify_content, bin/fm-composer-lib.sh) reports 'pending'
@@ -1148,8 +1174,9 @@ inject_msg() {  # <message> [state]
   #      on anything that is not affirmatively 'empty'. A deferred escalation
   #      stays buffered for the next cycle or the catch-up flush.
   composer=$(fm_backend_composer_state "$backend" "$target" 2>/dev/null)
+  [ -n "${FM_COMPOSER_IDLE_RE+x}" ] && override_set=yes
   if [ "$composer" != empty ]; then
-    log "inject deferred: supervisor composer not confirmed-empty (state=${composer:-unknown}: pending input, dead-shell prompt, or unreadable pane)"
+    log "inject deferred: gate=composer backend=$backend $busy_observation verdict=${composer:-unknown} idle_override=$override_set"
     return 1
   fi
   # (4) Type the digest ONCE, then submit with Enter (retry Enter only, never
@@ -1165,7 +1192,7 @@ inject_msg() {  # <message> [state]
   if [ "$verdict" = empty ]; then
     return 0  # Backend confirmed the submit.
   fi
-  log "inject failed: submit unconfirmed after $retries retries (verdict=$verdict, text may be in composer)"
+  log "inject failed: gate=submit-ack backend=$backend $busy_observation composer=empty idle_override=$override_set verdict=${verdict:-unknown} retries=$retries text_may_be_in_composer=yes"
   return 1
 }
 

--- a/bin/fm-tmux-lib.sh
+++ b/bin/fm-tmux-lib.sh
@@ -66,8 +66,9 @@
 # shellcheck source=bin/fm-composer-lib.sh
 . "$(dirname -- "${BASH_SOURCE[0]}")/fm-composer-lib.sh"
 
-# Delivery-only rendered busy footers per harness. claude/codex: "esc to
-# interrupt"; opencode: "esc interrupt"; pi: "Working..."; grok: "Ctrl+c:cancel".
+# Delivery-only rendered busy signatures per harness.
+# Claude uses its elapsed spinner because its idle footer also says "esc to interrupt".
+# Codex uses "esc to interrupt"; opencode uses "esc interrupt"; Pi uses "Working..."; Grok uses "Ctrl+c:cancel".
 # Claude's current spinner has a rotating glyph and word, but every active-turn
 # line has an ellipsis followed by a parenthesized elapsed duration. Keep this
 # signature separate from the shared default because that shape is not generic
@@ -83,7 +84,7 @@
 # The full moon-phase set remains locale- and emoji-font-sensitive because Kimi
 # exposes no stable ASCII busy token.
 FM_TMUX_BUSY_REGEX_DEFAULT='esc (to )?interrupt|Working\.\.\.|Ctrl\+c:cancel'
-FM_TMUX_CLAUDE_BUSY_REGEX_DEFAULT='esc to interrupt|…[[:space:]]+\([0-9]+[smh]'
+FM_TMUX_CLAUDE_BUSY_REGEX_DEFAULT='…[[:space:]]+\([0-9]+[smh]'
 FM_TMUX_CODEX_BUSY_REGEX_DEFAULT='esc to interrupt'
 FM_TMUX_OPENCODE_BUSY_REGEX_DEFAULT='esc interrupt'
 FM_TMUX_PI_BUSY_REGEX_DEFAULT='Working\.\.\.'

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -108,13 +108,9 @@ Selecting any other supervisor backend, including `zellij`, `orca`, or `cmux`, r
 ## Away-mode wedge alarm channels (config/wedge-alarm)
 
 When away-mode injection wedges past `FM_MAX_DEFER_SECS`, the sub-supervisor raises a loud, rate-limited alarm.
-Beyond the durable `state/.subsuper-inject-wedged` marker and the tmux status-line flash, it attempts a configured backend-independent active alert that can reach the captain even when every pane and its backend status-line is unreadable.
-`config/wedge-alarm` (local, gitignored) lists channel directives, one per non-empty, non-comment line; every listed non-`off` channel fires, best-effort.
-`FM_WEDGE_ALARM_CHANNEL` overrides the file with a single directive.
-Directives are `off` (a position-independent kill switch that disables every active alert), `auto`/`default`, `osascript` (macOS Notification Center banner), `herdr` (herdr UI notification), and `command:<cmd>` (run `<cmd>` via `sh -c`, summary on `$1` and stdin).
-An absent file means `auto`, i.e. default-on on macOS: the alarm exists precisely so a wedged away-mode primary is never silent, and it fires at most once per max-defer window after a genuine wedge.
-A missing or failing channel logs and falls through to the next, never crashing the daemon.
-See [`wedge-alarm.md`](wedge-alarm.md) for the current channel reference, [`verification/supervision.md`](verification/supervision.md#wedge-alarm-channels) for active evidence, and [`examples/wedge-alarm`](examples/wedge-alarm) for a copyable config.
+`config/wedge-alarm` is local and gitignored, and `FM_WEDGE_ALARM_CHANNEL` overrides it for focused operation or testing.
+[`wedge-alarm.md`](wedge-alarm.md) owns the channel directives, platform defaults, delivery timing, and failure behavior.
+[`verification/supervision.md`](verification/supervision.md#wedge-alarm-channels) records active evidence, and [`examples/wedge-alarm`](examples/wedge-alarm) is the copyable config.
 
 ## Gate defaults (.no-mistakes.yaml)
 
@@ -551,9 +547,9 @@ FM_SUPERVISOR_TARGET=              # optional supervisor pane target override; t
 FM_INJECT_SKIP=heartbeat           # |-prefixes force-self-handled bypassing classification; empty disables
 FM_ESCALATE_BATCH_SECS=90          # buffer window for batched escalation digests; 0 = flush immediately
 FM_MAX_DEFER_SECS=300              # max buffered escalation age before retry plus wedge alarm; 0 disables
-FM_WEDGE_ALARM_CHANNEL=            # override config/wedge-alarm with one active-alert directive for the wedge alarm; off|auto|osascript|herdr|command:<cmd>; absent = auto (macOS -> an OS notification)
-FM_WEDGE_ALARM_EXEC=              # notifier seam: route every channel (osascript, herdr, command:) through this command as `<cmd> <channel> <summary>`; "discard" fires nothing; unset in production; the daemon defaults it to "discard" when sourced so no test posts a real notification (docs/wedge-alarm.md)
-FM_WEDGE_ALARM_TIMEOUT_SECS=10    # maximum seconds for each osascript, herdr, override, or command: notifier before its watchdog terminates it and continues to the next channel; invalid or zero values use 10
+FM_WEDGE_ALARM_CHANNEL=            # override config/wedge-alarm with one active-alert directive; see docs/wedge-alarm.md
+FM_WEDGE_ALARM_EXEC=              # test-only notifier seam; see docs/wedge-alarm.md
+FM_WEDGE_ALARM_TIMEOUT_SECS=10    # maximum notifier runtime before fallback; see docs/wedge-alarm.md
 FM_INJECT_FAIL_SLEEP=30            # seconds to back off when the supervisor pane is unavailable
 FM_INJECT_CONFIRM_RETRIES=3        # daemon Enter-retry attempts after typing a digest once
 FM_INJECT_CONFIRM_SLEEP=0.5        # seconds between daemon submit checks

--- a/docs/examples/wedge-alarm
+++ b/docs/examples/wedge-alarm
@@ -5,16 +5,16 @@
 #
 # Directives:
 #   off              position-independent kill switch: disable every active
-#                    alert (the durable marker and tmux status-line flash remain)
+#                    alert (the durable marker and tmux status overlay remain)
 #   auto | default   platform default: macOS -> osascript; other platforms have
-#                    no built-in OS channel (configure a command: line instead)
+#                    no built-in out-of-band channel
 #   osascript        macOS Notification Center banner (backend-independent)
 #   herdr            herdr UI notification (herdr notification show)
 #   command:<cmd>    run <cmd> via `sh -c`; the alarm summary is passed as $1 and
 #                    on stdin, so it can reach a phone/pager while you are away
 #
-# An ABSENT config/wedge-alarm behaves as `auto` (default-on on macOS): the
-# alarm exists precisely so a wedged away-mode primary is never silent.
+# An ABSENT config/wedge-alarm behaves as `auto` on macOS when osascript is
+# installed.
 #
 # Example: a macOS banner plus a push to a phone via ntfy.sh, so a wedge that
 # happens overnight reaches you even away from the machine.

--- a/docs/verification/supervision.md
+++ b/docs/verification/supervision.md
@@ -243,6 +243,126 @@ tests/fm-turnend-guard.test.sh
 
 ## Wedge-alarm channels
 
+Unicode composer whitespace and the Linux on-host wedge path were verified on 2026-08-05 with Claude Code 2.1.222, tmux 3.4, and util-linux 2.39.3 on Linux.
+
+The live idle Claude row and public classifier were read with:
+
+```sh
+claude --version
+tmux -V
+wall --version | head -1
+cy=$(tmux display-message -p -t %0 '#{cursor_y}')
+tmux capture-pane -p -t %0 -S "$cy" -E "$cy" | od -An -t u1
+(. bin/fm-backend.sh; fm_backend_composer_state tmux %0)
+```
+
+Exact output:
+
+```text
+2.1.222 (Claude Code)
+tmux 3.4
+wall from util-linux 2.39.3
+ 226 157 175 194 160  10
+empty
+```
+
+The bytes are U+276F followed by U+00A0 and a newline.
+The shared classifier now normalizes every non-ASCII code point in Unicode's `White_Space` property before deciding emptiness.
+Real text after Unicode whitespace remains `pending`, a bare shell prompt followed by Unicode whitespace remains `unknown`, and ghost-only text remains `empty`.
+Before the fix, the exact U+276F plus U+00A0 empty-row regression returned `pending` instead of `empty`, and the NBSP bare-shell precision check returned `pending` instead of `unknown`.
+The pre-fix real-text safety control already returned `pending`, and the pre-fix ghost safety control already returned `empty`; neither control failed before the fix.
+
+Claude and Codex reach the shared classifier from their bare prompt rows on tmux and Herdr.
+OpenCode and Kimi reach it from bordered `>` composers.
+Pi and pi-signed share the Pi renderer and reach it from bordered tmux composers or Herdr's identity-corroborated separator structure.
+Grok reaches it from its bordered prompt after dark truecolor placeholder removal.
+All seven tmux harness names are exercised by `tests/fm-composer-ghost.test.sh`, and the Herdr public dispatch is exercised by `tests/fm-backend-herdr.test.sh` with the exact U+276F plus U+00A0 regression and both safety controls.
+
+The focused suites ran with:
+
+```sh
+bin/fm-test-run.sh tests/fm-composer-ghost.test.sh tests/fm-backend-herdr.test.sh tests/fm-daemon.test.sh | grep -E '^FM_TEST_(END|SUMMARY)'
+```
+
+Exact summary:
+
+```text
+FM_TEST_END 2026-08-05T22:58:29Z tests/fm-composer-ghost.test.sh exit=0 duration_ms=4257 gate_skip=false
+FM_TEST_END 2026-08-05T22:58:55Z tests/fm-backend-herdr.test.sh exit=0 duration_ms=25477 gate_skip=false
+FM_TEST_END 2026-08-05T22:59:14Z tests/fm-daemon.test.sh exit=0 duration_ms=19668 gate_skip=false
+FM_TEST_SUMMARY total=3 failed=0 skipped_gate=0 duration_ms=49557
+FM_TEST_SUMMARY_FAMILY family=backend-dispatch count=1 duration_ms=25477 failed=0
+FM_TEST_SUMMARY_FAMILY family=pure-contract-unit count=1 duration_ms=4257 failed=0
+FM_TEST_SUMMARY_FAMILY family=watcher-wake-lock count=1 duration_ms=19668 failed=0
+```
+
+`wall` was tested and rejected as a Linux alarm channel because its message entered live agent panes.
+
+```sh
+probe='FIRSTMATE_HARMLESS_WALL_PROBE_20260805T2250Z'
+printf '%s\n' "$probe" | wall
+sleep 1
+for pane in $(tmux list-panes -a -F '#{pane_id}'); do
+  command_name=$(tmux display-message -p -t "$pane" '#{pane_current_command}')
+  cursor_y=$(tmux display-message -p -t "$pane" '#{cursor_y}')
+  hits=$(tmux capture-pane -p -J -t "$pane" -S -20 | grep -cF "$probe" || true)
+  composer=$(. bin/fm-backend.sh; fm_backend_composer_state tmux "$pane")
+  printf '%s\tcommand=%s\tcursor=%s\tprobe_hits=%s\tcomposer=%s\n' "$pane" "$command_name" "$cursor_y" "$hits" "$composer"
+done
+```
+
+Exact relevant output:
+
+```text
+%58	command=claude	cursor=49	probe_hits=1	composer=empty
+%0	command=claude	cursor=49	probe_hits=1	composer=empty
+```
+
+The same probe through a three-second tmux status overlay did not enter either pane and preserved both empty composers:
+
+```sh
+probe='FIRSTMATE_HARMLESS_TMUX_STATUS_PROBE_20260805T2251Z'
+tmux display-message -d 3000 -t %0 "$probe"
+sleep 1
+for pane in %0 %58; do
+  hits=$(tmux capture-pane -p -J -t "$pane" -S -20 | grep -cF "$probe" || true)
+  composer=$(. bin/fm-backend.sh; fm_backend_composer_state tmux "$pane")
+  printf '%s\tprobe_hits=%s\tcomposer=%s\n' "$pane" "$hits" "$composer"
+done
+```
+
+Exact output:
+
+```text
+%0	probe_hits=0	composer=empty
+%58	probe_hits=0	composer=empty
+```
+
+The production tmux overlay lasts through `FM_MAX_DEFER_SECS`, the following housekeeping interval, and one additional second of scheduling slack, then refreshes on the next alarm.
+At defaults, a future unpredicted false `pending` therefore costs at most 315 seconds, or 5.25 minutes, before a persistent on-host warning appears.
+This Linux host has no verified default off-host alert, so remote notification still requires an explicit `command:` channel.
+Content stability does not authorize forced injection because a real half-typed line can remain byte-identical indefinitely.
+
+A 2026-08-05 live incident left an away digest buffered for 1558 seconds while each daemon retry passed the rendered busy guard and then reported `composer=pending` despite the same daemon environment's `FM_COMPOSER_IDLE_RE` and a direct public classifier call both reporting `empty`.
+Claude Code 2.1.221 also rendered `esc to interrupt` while idle, so Claude's delivery-only busy guard now relies on its live-verified elapsed spinner instead of that ambiguous footer.
+Each delivery defer now records its exact gate, backend, detected harness, native and rendered busy verdicts, composer verdict, idle-override presence, or post-submit acknowledgement without recording composer content.
+Busy detection remains independent of `FM_COMPOSER_IDLE_RE`; the override applies only to the inject-time composer proof and the post-submit acknowledgement.
+
+The real-tmux delivery path is exercised with:
+
+```sh
+bin/fm-test-run.sh tests/fm-daemon.test.sh | grep -F 'real tmux away delivery'
+```
+
+Exact output:
+
+```text
+ok - real tmux away delivery handles exact Claude bytes, safety guards, busy state, and idle overrides
+```
+
+The disposable pane renders the captured octal bytes `342 235 257 302 240`, followed by Claude's idle `esc to interrupt` footer, then reads the submitted operational digest.
+The same public `escalate_add` and `escalate_flush` path proves the digest reaches the pane and clears the buffer, while a half-typed line and bare shell prompt remain byte-identical, an elapsed Claude spinner remains busy, and `FM_COMPOSER_IDLE_RE` governs both composer checks around submission.
+
 The two real notification channels were bounded manually on 2026-07-10 on macOS 26.5.2 with Herdr 0.7.3.
 Automated suites never execute these real notification commands.
 

--- a/docs/watcher-continuity.md
+++ b/docs/watcher-continuity.md
@@ -11,7 +11,7 @@ A failed follow-up never cancels continuity restoration.
 Pi same-process session replacement follows the generation-owner contract in `.pi/extensions/fm-primary-pi-watch.ts`.
 Claude's `.claude/settings.json` Stop `asyncRewake` hook (`bin/fm-claude-stop-autoarm.sh`) owns routine tokenless re-arm.
 The hook fires on every Stop, and an eligible primary with supervision need admits one home-scoped owner that foregrounds `bin/fm-watch-arm.sh` inside the hook-owned process tree.
-A numeric session-lock owner that fails the shared `fm_harness_pid_alive` predicate is reclaimed through `bin/fm-lock.sh` before auto-arm state changes, while a live owner, absent lock, or malformed lock keeps the competing hook inert.
+A numeric session-lock owner that fails the shared `fm_harness_pid_alive` predicate, including an exited harness left as a zombie, is reclaimed through `bin/fm-lock.sh` before auto-arm state changes, while a live owner, absent lock, or malformed lock keeps the competing hook inert.
 The stale-owner claim occurs only after the existing AFK and supervision-need gates pass.
 After each non-actionable arm close, the hook rechecks the identity-matched watcher lock and fresh beacon before retrying a bounded number of times.
 A cycle-end failure is benign when that live-watcher predicate is true, and the hook suppresses the arm output and continues silently.
@@ -65,6 +65,7 @@ The same suite covers ordinary same-process session replacement for `/new`, `/re
 `tests/fm-watcher-lock.test.sh` covers verified-successor attach, the typed self-eviction failure, bounded and successor-linked lifecycle rows, and a SIGSTOP counterfactual that distinguishes a live PID from a stale beacon before classifying termination.
 `tests/fm-subagent-pretool-check.test.sh` proves Claude retains only the non-status Bash seatbelts.
 `tests/fm-claude-stop-autoarm.test.sh` covers the auto-arm's scope, stale and live session owners, unchanged AFK and need boundaries, single-flight, bounded failure retries, benign live-watcher cycle ends, one-notice failure episodes, and exit-2 translation.
+`tests/fm-session-lock-zombie.test.sh` uses real zombie processes to prove stale-lock reclamation while retaining the live-harness refusal boundary.
 `FM_CLAUDE_LIVE_E2E=1 tests/fm-claude-stop-autoarm-live-e2e.test.sh` starts with the reproduced stale-lock state, runs session start first, completes two tokenless cycles, and checks the competing-live-owner negative control.
 `tests/fm-turnend-guard.test.sh` covers the cooperative `--claude` guard, including monotonic failed-epoch progression, the integrated bounded fail-open, post-alarm continuation suppression, and positive recovery reset.
 

--- a/docs/wedge-alarm.md
+++ b/docs/wedge-alarm.md
@@ -2,8 +2,8 @@
 
 The away-mode sub-supervisor (`bin/fm-supervise-daemon.sh`) buffers escalations and injects them into Firstmate's own pane.
 When injection cannot confirm a submit past `FM_MAX_DEFER_SECS`, `inject_wedge_alarm` raises a loud, rate-limited alarm so the stall never stays invisible.
-The active alert is pane-independent because a tmux status-line flash has no cross-backend equivalent and cannot reach an unattended captain reliably.
-The durable marker and tmux flash remain as additional signals.
+Configured active alerts are pane-independent because a tmux status overlay has no cross-backend equivalent and cannot reach an unattended captain off-host.
+On tmux, the durable marker and status overlay remain additional on-host signals.
 
 ## Channels
 
@@ -11,15 +11,22 @@ The durable marker and tmux flash remain as additional signals.
 It lists channel directives, one per non-empty, non-comment line, and every listed non-`off` channel fires best-effort.
 `FM_WEDGE_ALARM_CHANNEL` overrides the file with one directive for focused testing.
 
-- `off` disables every active alert while retaining the durable marker and tmux flash.
+- `off` disables every active alert while retaining the durable marker and tmux status overlay.
 - `auto` or `default` resolves to `osascript` on macOS.
-  Other platforms have no built-in OS channel, so configure `command:` when a durable marker alone is insufficient.
+  Other platforms have no built-in out-of-band channel, so configure `command:` when one is available.
 - `osascript` posts a macOS Notification Center banner outside the terminal pane.
 - `herdr` calls `herdr notification show` outside the supervised pane.
 - `command:<cmd>` runs `<cmd>` through `sh -c` with the alarm summary as `$1` and on stdin, allowing delivery to a phone or pager service.
 
 An absent `config/wedge-alarm` behaves as `auto`, which is default-on on macOS.
 This is deliberate because the alarm fires only after a genuine max-defer wedge and is rate-limited to at most once per max-defer window.
+
+The max-defer escape never force-injects over byte-stable `pending` content.
+A real half-typed human line can remain byte-identical indefinitely, so content stability cannot safely distinguish it from a future classifier fault.
+With the default 300-second max defer and 15-second housekeeping tick, an unpredicted false `pending` reaches the tmux status overlay within 315 seconds while the buffered digest remains preserved.
+The overlay duration includes one housekeeping interval plus one second of scheduling slack beyond max-defer, and it is refreshed at the next alarm, so it does not disappear between checks.
+Linux hosts have no reliable default off-host notification channel, and operators who need one must configure `command:`.
+`wall` is intentionally not a channel because it writes into logged-in agent terminals and can corrupt or confuse their displays.
 
 Each channel is best-effort.
 A missing binary or non-zero exit logs a warning and continues to the next channel without crashing the daemon loop.
@@ -36,4 +43,4 @@ When the daemon is sourced as a library, that seam defaults to `discard`, so a t
 Production leaves the seam unset and uses the configured real channels.
 
 `tests/fm-daemon.test.sh` covers directive parsing, rate limiting, timeout and process-group cleanup, argv-safe dispatch, channel fallback, and safe `command:` summary delivery.
-[`verification/supervision.md`](verification/supervision.md#wedge-alarm-channels) records the bounded manual macOS and Herdr channel proof.
+[`verification/supervision.md`](verification/supervision.md#wedge-alarm-channels) records the active classifier, tmux-overlay, and notification-channel evidence.

--- a/tests/fm-backend-herdr.test.sh
+++ b/tests/fm-backend-herdr.test.sh
@@ -2672,6 +2672,31 @@ test_composer_state_real_text_is_pending() {
   pass "fm_backend_herdr_composer_state: real composer text reads pending"
 }
 
+test_composer_state_unicode_whitespace_through_public_interface() {
+  local dir log resp fb out
+  dir="$TMP_ROOT/composer-unicode-whitespace"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
+  printf '\xe2\x9d\xaf\xc2\xa0\n' > "$resp/1.out"
+  printf '\xe2\x9d\xaf\xc2\xa0deploy\n' > "$resp/2.out"
+  printf '$\xc2\xa0\n' > "$resp/3.out"
+  fb=$(make_herdr_fakebin "$dir")
+
+  out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
+    bash -c '. "$0/bin/fm-backend.sh"; fm_backend_composer_state herdr default:w1:p2' "$ROOT" )
+  [ "$out" = empty ] \
+    || fail "Claude's exact U+276F + U+00A0 idle row should be empty through Herdr, got '$out'"
+
+  out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
+    bash -c '. "$0/bin/fm-backend.sh"; fm_backend_composer_state herdr default:w1:p2' "$ROOT" )
+  [ "$out" = pending ] \
+    || fail "real Herdr text after U+00A0 must stay pending, got '$out'"
+
+  out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
+    bash -c '. "$0/bin/fm-backend.sh"; fm_backend_composer_state herdr default:w1:p2' "$ROOT" )
+  [ "$out" = unknown ] \
+    || fail "a Herdr bare shell prompt followed by U+00A0 must stay unknown, got '$out'"
+  pass "fm_backend_composer_state (herdr): Unicode whitespace preserves empty, pending, and dead-shell verdicts"
+}
+
 # Live-verified incident (2026-07-03, real grok 0.2.82 on herdr, isolated
 # session): typing "/compact" opens the completion popup; the FIRST Enter
 # closes the popup and EXPANDS the composer into an argument-hint placeholder
@@ -3960,6 +3985,7 @@ test_busy_state_unknown_on_no_agent
 test_composer_state_bare_prompt_is_empty
 test_composer_state_ghost_placeholder_is_empty
 test_composer_state_real_text_is_pending
+test_composer_state_unicode_whitespace_through_public_interface
 test_composer_state_popup_placeholder_fill_is_pending
 test_composer_state_unknown_on_capture_failure
 test_composer_state_unknown_when_no_composer_row_found

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -269,6 +269,14 @@ test_no_mistakes_dod_wording() {
     "no-mistakes DOD must keep direct requirements and exclude generic scaffold boilerplate from --intent"
   assert_grep "exclude generic operational, status, delivery, and other scaffold boilerplate unless it is task-specific" "$brief" \
     "no-mistakes DOD must exclude non-task-specific scaffold boilerplate from --intent"
+  assert_grep "After committing the implementation, invoke /no-mistakes yourself to validate and ship the PR." "$brief" \
+    "no-mistakes DOD must require the worker to start its own validation run"
+  assert_grep "Do not append \`done:\` or end your turn merely because the pipeline is running." "$brief" \
+    "no-mistakes DOD must forbid ending the turn while the pipeline is active"
+  assert_grep "Poll the run's own status and keep driving it until it reaches a gate that requires firstmate or a terminal outcome." "$brief" \
+    "no-mistakes DOD must require polling through a gate or terminal outcome"
+  assert_grep '"Waiting for the next decision point" is not a valid resting state while the run is active.' "$brief" \
+    "no-mistakes DOD must reject waiting for a decision while the pipeline runs"
   # The apostrophe in "firstmate's authority check" is now structurally safe
   # (no `$(...)` wrapper around the heredoc), so it renders verbatim instead of
   # being reworded or escaped away. test_no_heredoc_in_command_substitution
@@ -276,6 +284,26 @@ test_no_mistakes_dod_wording() {
   assert_grep "firstmate's authority check" "$brief" \
     "no-mistakes DOD lost the apostrophe prose that the structural fix makes parse-safe"
   pass "fm-brief.sh: no-mistakes DOD keeps its apostrophe prose, now parse-safe"
+}
+
+test_faster_delivery_modes_do_not_wait_for_firstmate() {
+  local home id brief
+  home="$TMP_ROOT/faster-delivery-self-drive-home"
+  write_registry "$home"
+
+  id="brief-direct-self-drive-b2"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" direct-proj >/dev/null 2>&1
+  brief="$home/data/$id/brief.md"
+  assert_grep "Do not end your turn waiting for firstmate to tell you to push or open the PR - those delivery steps are yours." "$brief" \
+    "direct-PR brief must make the worker drive its own push and PR creation"
+
+  id="brief-local-self-drive-b2"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" local-proj >/dev/null 2>&1
+  brief="$home/data/$id/brief.md"
+  assert_grep "Do not end your turn waiting for firstmate to tell you to rebase or report the ready branch - those delivery steps are yours." "$brief" \
+    "local-only brief must make the worker drive its own rebase and ready report"
+
+  pass "fm-brief.sh: each faster delivery mode owns its steps without waiting for firstmate"
 }
 
 test_ship_project_memory_wording() {
@@ -638,6 +666,7 @@ test_help_includes_entire_header
 test_ship_modes_generate_clean_briefs
 test_faster_paths_use_configured_authority_without_stacked_review
 test_no_mistakes_dod_wording
+test_faster_delivery_modes_do_not_wait_for_firstmate
 test_ship_project_memory_wording
 test_herdr_lab_contract_is_explicit_and_complete
 test_herdr_lab_contract_quotes_foreign_firstmate_path

--- a/tests/fm-composer-ghost.test.sh
+++ b/tests/fm-composer-ghost.test.sh
@@ -22,10 +22,14 @@ set -u
 . "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
 
 LIB="$ROOT/bin/fm-tmux-lib.sh"
+BACKEND="$ROOT/bin/fm-backend.sh"
 PEEK="$ROOT/bin/fm-peek.sh"
 
 # shellcheck source=/dev/null
 . "$LIB"
+
+# shellcheck source=/dev/null
+. "$BACKEND"
 
 TMP_ROOT=$(fm_test_tmproot fm-ghost-tests)
 
@@ -266,6 +270,73 @@ test_real_text_with_trailing_ghost_is_pending() {
   pass "fm_pane_input_pending: real text plus a trailing ghost run is still pending"
 }
 
+test_unicode_whitespace_through_public_composer_interface() {
+  local dir fb capture out label escaped whitespace nbsp
+  dir="$TMP_ROOT/unicode-whitespace"; mkdir -p "$dir"
+  fb=$(make_fake_tmux "$dir")
+  capture="$dir/styled.txt"
+  nbsp=$(printf '\xc2\xa0')
+
+  printf '\xe2\x9d\xaf%sdeploy\n' "$nbsp" > "$capture"
+  out=$(PATH="$fb:$PATH" FM_FAKE_STYLED="$capture" FM_FAKE_CY=0 \
+    fm_backend_composer_state tmux fakepane)
+  [ "$out" = pending ] \
+    || fail "real typed text after Unicode whitespace must stay pending, got '$out'"
+  pass "fm_backend_composer_state: real typed text after Unicode whitespace stays pending"
+
+  printf '$%s\n' "$nbsp" > "$capture"
+  out=$(PATH="$fb:$PATH" FM_FAKE_STYLED="$capture" FM_FAKE_CY=0 \
+    fm_backend_composer_state tmux fakepane)
+  [ "$out" = unknown ] \
+    || fail "a bare shell prompt followed by Unicode whitespace must stay unknown, got '$out'"
+  pass "fm_backend_composer_state: a bare shell prompt followed by Unicode whitespace stays unknown"
+
+  printf '\xe2\x9d\xaf %s\n' "$(printf '\033[2mplaceholder\033[0m')" > "$capture"
+  out=$(PATH="$fb:$PATH" FM_FAKE_STYLED="$capture" FM_FAKE_CY=0 \
+    fm_backend_composer_state tmux fakepane)
+  [ "$out" = empty ] \
+    || fail "ghost-only placeholder text must stay empty, got '$out'"
+  pass "fm_backend_composer_state: ghost-only placeholder text stays empty"
+
+  # U+00A0 is built from the exact bytes captured from a live idle Claude pane.
+  printf '\xe2\x9d\xaf\xc2\xa0\n' > "$capture"
+  out=$(PATH="$fb:$PATH" FM_FAKE_STYLED="$capture" FM_FAKE_CY=0 \
+    fm_backend_composer_state tmux fakepane)
+  [ "$out" = empty ] \
+    || fail "Claude's exact idle composer bytes (U+276F + U+00A0) should be empty, got '$out'"
+
+  # Cover every non-ASCII code point in Unicode's White_Space property.
+  while IFS=' ' read -r label escaped; do
+    whitespace=$(printf '%b' "$escaped")
+    printf '\xe2\x9d\xaf%s\n' "$whitespace" > "$capture"
+    out=$(PATH="$fb:$PATH" FM_FAKE_STYLED="$capture" FM_FAKE_CY=0 \
+      fm_backend_composer_state tmux fakepane)
+    [ "$out" = empty ] \
+      || fail "Claude prompt followed by Unicode whitespace $label should be empty, got '$out'"
+  done <<'EOF'
+U+0085 \xc2\x85
+U+00A0 \xc2\xa0
+U+1680 \xe1\x9a\x80
+U+2000 \xe2\x80\x80
+U+2001 \xe2\x80\x81
+U+2002 \xe2\x80\x82
+U+2003 \xe2\x80\x83
+U+2004 \xe2\x80\x84
+U+2005 \xe2\x80\x85
+U+2006 \xe2\x80\x86
+U+2007 \xe2\x80\x87
+U+2008 \xe2\x80\x88
+U+2009 \xe2\x80\x89
+U+200A \xe2\x80\x8a
+U+2028 \xe2\x80\xa8
+U+2029 \xe2\x80\xa9
+U+202F \xe2\x80\xaf
+U+205F \xe2\x81\x9f
+U+3000 \xe3\x80\x80
+EOF
+  pass "fm_backend_composer_state: Unicode whitespace is empty without weakening typed-text, dead-shell, or ghost guards"
+}
+
 # --- fm_tmux_composer_state: structural multi-row box scan ------------------
 
 test_two_row_composer_reads_text_above_empty_cursor_row() {
@@ -473,11 +544,11 @@ test_all_tmux_harness_composers_share_classification() {
   dir="$TMP_ROOT/all-harness-composers"; mkdir -p "$dir"
   fb=$(make_fake_tmux "$dir")
   capture="$dir/styled.txt"
-  for harness in claude codex opencode pi pi-signed grok; do
+  for harness in claude codex opencode pi pi-signed grok kimi; do
     case "$harness" in
       claude) printf '╭────────────╮\n│ ❯ \033[2mtry\033[0m      │\n╰────────────╯\n' > "$capture" ;;
       codex) printf '╭────────────╮\n│ › \033[2mtip\033[0m      │\n╰────────────╯\n' > "$capture" ;;
-      opencode) printf '╭────────────╮\n│ >          │\n╰────────────╯\n' > "$capture" ;;
+      opencode|kimi) printf '╭────────────╮\n│ >          │\n╰────────────╯\n' > "$capture" ;;
       pi|pi-signed) printf '╭────────────╮\n│            │\n╰────────────╯\n' > "$capture" ;;
       grok) printf '╭────────────╮\n│ ❯ \033[38;2;50;47;70mType\033[0m     │\n╰────────────╯\n' > "$capture" ;;
     esac
@@ -488,7 +559,7 @@ test_all_tmux_harness_composers_share_classification() {
     case "$harness" in
       claude|grok) printf '╭────────────╮\n│ ❯ fix      │\n╰────────────╯\n' > "$capture" ;;
       codex) printf '╭────────────╮\n│ › fix      │\n╰────────────╯\n' > "$capture" ;;
-      opencode|pi|pi-signed) printf '╭────────────╮\n│ > fix      │\n╰────────────╯\n' > "$capture" ;;
+      opencode|pi|pi-signed|kimi) printf '╭────────────╮\n│ > fix      │\n╰────────────╯\n' > "$capture" ;;
     esac
     out=$(PATH="$fb:$PATH" FM_FAKE_STYLED="$capture" FM_FAKE_CY=1 \
       fm_tmux_composer_state "fakepane")
@@ -607,6 +678,7 @@ test_colored_text_with_2_payload_still_pending
 test_dark_truecolor_ghost_only_composer_is_not_pending
 test_dark_truecolor_bare_shell_prompt_is_unknown
 test_real_text_with_trailing_ghost_is_pending
+test_unicode_whitespace_through_public_composer_interface
 test_two_row_composer_reads_text_above_empty_cursor_row
 test_wrapped_composer_reads_all_content_rows
 test_bottom_border_cursor_reads_ghost_only_box_as_empty

--- a/tests/fm-daemon.test.sh
+++ b/tests/fm-daemon.test.sh
@@ -751,7 +751,7 @@ test_busy_guard_defers_when_supervisor_busy() {
   fakebin="$dir/fakebin"
   sent="$dir/sent.log"; : > "$sent"
   capture="$dir/pane.txt"
-  printf 'esc to interrupt\n' > "$capture"
+  printf '… (6s)\n' > "$capture"
   escalate_add "$state" "done: PR 1"
   afk_enter "$state"
   if PATH="$fakebin:$PATH" FM_FAKE_TMUX_PANE_ALIVE=1 FM_FAKE_TMUX_SENT="$sent" \
@@ -1162,22 +1162,32 @@ test_max_defer_flushes_empty_idle_pane() {
 }
 
 test_max_defer_pending_composer_alarms_without_typing() {
-  local dir state fakebin sent
+  local dir state fakebin sent display_log
   dir=$(make_bordered_case maxdefer-pending-digest)
   state="$dir/state"; fakebin="$dir/fakebin"
-  sent="$dir/sent.log"; : > "$sent"
+  sent="$dir/sent.log"; display_log="$dir/display.log"; : > "$sent"; : > "$display_log"
   printf '╭─────────────────╮\n│ > human draft   │\n╰─────────────────╯\n' > "$dir/composer"
   escalate_add "$state" "needs-decision: pick B"
   echo $(( $(date +%s) - 600 )) > "$state/.subsuper-escalations.since"
   afk_enter "$state"
   PATH="$fakebin:$PATH" FM_FAKE_COMPOSER="$dir/composer" FM_FAKE_SENT="$sent" \
+    FM_FAKE_TMUX_DISPLAY_LOG="$display_log" \
     FM_ESCALATE_BATCH_SECS=99999 FM_MAX_DEFER_SECS=60 FM_INJECT_CONFIRM_SLEEP=0.05 \
     housekeeping "$state"
   [ ! -s "$sent" ] || fail "max-defer typed into a pending composer"
   [ -s "$state/.subsuper-inject-wedged" ] || fail "pending composer did not raise a wedge alarm marker"
   [ -s "$state/.subsuper-escalations" ] || fail "buffer lost while composer was pending"
   grep -F 'human draft' "$dir/composer" >/dev/null || fail "pending composer content changed"
-  pass "max-defer on a pending composer alarms without typing"
+  grep -F 'display-message -d 76000 -t' "$display_log" >/dev/null \
+    || fail "pending composer wedge did not keep the tmux status alarm visible through the next refresh"
+  touch -d '61 seconds ago' "$state/.subsuper-inject-wedged"
+  PATH="$fakebin:$PATH" FM_FAKE_COMPOSER="$dir/composer" FM_FAKE_SENT="$sent" \
+    FM_FAKE_TMUX_DISPLAY_LOG="$display_log" \
+    FM_ESCALATE_BATCH_SECS=99999 FM_MAX_DEFER_SECS=60 FM_INJECT_CONFIRM_SLEEP=0.05 \
+    housekeeping "$state"
+  [ "$(grep -cF 'display-message -d 76000 -t' "$display_log")" -eq 2 ] \
+    || fail "pending composer wedge did not refresh the status alarm before its slackened duration expired"
+  pass "max-defer on a pending composer alarms without typing and refreshes a gap-free tmux status alarm"
 }
 
 test_normal_flush_clears_stale_wedge_marker() {
@@ -1402,7 +1412,7 @@ test_wedge_alarm_off_disables_active_alert_regardless_of_position() {
       wedge_alarm_notify "away-mode WEDGED 900s" "/s/.marker"
     [ ! -s "$log" ] || fail "off did not disable a preceding or following active alert: $(cat "$log")"
   done
-  pass "off disables every active alert regardless of directive position (marker and tmux flash are unaffected)"
+  pass "off disables every active alert regardless of directive position (marker and tmux overlay are unaffected)"
 }
 
 test_wedge_alarm_auto_darwin_selects_osascript() {
@@ -1420,7 +1430,7 @@ test_wedge_alarm_auto_non_darwin_has_no_os_channel() {
   PATH="$dir/fakebin:$PATH" FM_WEDGE_ALARM_LOG="$log" FM_FAKE_UNAME=Linux FM_WEDGE_ALARM_CHANNEL=auto \
     wedge_alarm_notify "away-mode WEDGED 900s" "/s/.marker"
   [ ! -s "$log" ] || fail "auto selected a built-in OS channel on a non-macOS platform: $(cat "$log")"
-  pass "auto on a non-macOS platform selects no built-in OS channel (the marker or a configured command carries it)"
+  pass "auto on a non-macOS platform selects no built-in OS channel"
 }
 
 test_wedge_alarm_config_file_multi_channel() {
@@ -1827,6 +1837,85 @@ test_inject_msg_defers_on_unrecognized_composer_state() {
   pass "inject_msg: unrecognized composer states defer by default"
 }
 
+test_real_tmux_away_delivery_and_guards() {
+  local dir state helper session target received before after log row_hex
+  command -v tmux >/dev/null 2>&1 || { pass "real tmux away delivery skipped: tmux unavailable"; return; }
+  dir=$(make_supercase real-tmux-away-delivery)
+  state="$dir/state"; helper="$dir/render.sh"; received="$dir/received"; log="$state/.supervise-daemon.log"; LOG="$log"
+  session="fm-daemon-e2e-$$-$RANDOM"
+  cat > "$helper" <<'SH'
+#!/usr/bin/env bash
+set -u
+mode=$1 out=$2
+render() {
+  case "$mode" in
+    idle) printf 'esc to interrupt\n\342\235\257\302\240' ;;
+    draft) printf 'esc to interrupt\nhuman draft' ;;
+    shell) printf '$ ' ;;
+    spinner) printf 'esc to interrupt\n\342\200\246 (6s)' ;;
+    custom) printf 'custom idle>' ;;
+  esac
+}
+render
+if [ "$mode" = idle ] || [ "$mode" = custom ]; then
+  while IFS= read -r line; do
+    printf '%s' "$line" > "$out"
+    printf '\n'
+    render
+  done
+else
+  sleep 30
+fi
+SH
+  chmod +x "$helper"
+  tmux new-session -d -s "$session" -x 100 -y 20 "$helper idle '$received'"
+  target=$(tmux list-panes -t "$session" -F '#{pane_id}')
+  sleep 0.2
+  row_hex=$(tmux display-message -p -t "$target" '#{cursor_y}' | {
+    read -r cursor_y
+    tmux capture-pane -p -t "$target" -S "$cursor_y" -E "$cursor_y" | od -An -t u1 | tr -s ' ' | sed 's/^ //;s/ $//'
+  })
+  [ "$row_hex" = '226 157 175 194 160 10' ] \
+    || fail "real tmux idle Claude row bytes drifted: $row_hex"
+  escalate_add "$state" "needs-decision: exact tmux delivery"
+  afk_enter "$state"
+  FM_SUPERVISOR_BACKEND=tmux FM_SUPERVISOR_TARGET="$target" FM_DAEMON_PRIMARY_HARNESS=claude \
+    FM_INJECT_CONFIRM_SLEEP=0.05 escalate_flush "$state" \
+    || fail "real tmux idle Claude row did not accept the buffered digest"
+  grep -F 'Supervisor escalate (1 event(s)): needs-decision: exact tmux delivery' "$received" >/dev/null \
+    || fail "real tmux pane did not receive the operational digest"
+  [ ! -s "$state/.subsuper-escalations" ] || fail "real tmux delivery did not clear the escalation buffer"
+
+  for mode in draft shell spinner; do
+    tmux respawn-pane -k -t "$target" "$helper $mode '$received'"
+    sleep 0.2
+    before=$(tmux capture-pane -p -t "$target")
+    : > "$received"
+    escalate_add "$state" "needs-decision: must remain buffered"
+    if FM_SUPERVISOR_BACKEND=tmux FM_SUPERVISOR_TARGET="$target" FM_DAEMON_PRIMARY_HARNESS=claude \
+      FM_INJECT_CONFIRM_SLEEP=0.05 escalate_flush "$state"; then
+      fail "real tmux $mode guard allowed injection"
+    fi
+    after=$(tmux capture-pane -p -t "$target")
+    [ "$before" = "$after" ] || fail "real tmux $mode guard modified the pane"
+    [ ! -s "$received" ] || fail "real tmux $mode guard delivered text"
+    : > "$state/.subsuper-escalations"
+  done
+
+  tmux respawn-pane -k -t "$target" "$helper custom '$received'"
+  sleep 0.2
+  escalate_add "$state" "needs-decision: override delivery"
+  FM_SUPERVISOR_BACKEND=tmux FM_SUPERVISOR_TARGET="$target" FM_DAEMON_PRIMARY_HARNESS=claude \
+    FM_COMPOSER_IDLE_RE='^custom idle>$' FM_INJECT_CONFIRM_SLEEP=0.05 escalate_flush "$state" \
+    || fail "FM_COMPOSER_IDLE_RE did not propagate through real tmux guard and submit acknowledgement"
+  grep -F 'needs-decision: override delivery' "$received" >/dev/null \
+    || fail "real tmux override delivery did not reach the target pane"
+  tmux kill-session -t "$session"
+  grep -F 'gate=busy backend=tmux harness=claude' "$log" >/dev/null \
+    || fail "real tmux active-spinner defer did not log its delivery-boundary verdict"
+  pass "real tmux away delivery handles exact Claude bytes, safety guards, busy state, and idle overrides"
+}
+
 test_afk_start_refuses_when_flag_cannot_be_written
 test_afk_start_ignores_stale_pidfile_without_lock
 test_afk_start_reclaims_stale_daemon_lock_reused_pid
@@ -1926,3 +2015,4 @@ test_inject_msg_herdr_pane_gone_defers
 test_inject_msg_herdr_submits_through_backend_dispatch
 test_inject_msg_defers_on_dead_shell_unknown
 test_inject_msg_defers_on_unrecognized_composer_state
+test_real_tmux_away_delivery_and_guards

--- a/tests/fm-session-lock-zombie.test.sh
+++ b/tests/fm-session-lock-zombie.test.sh
@@ -1,0 +1,211 @@
+#!/usr/bin/env bash
+# tests/fm-session-lock-zombie.test.sh - a zombie lock holder must be reclaimable
+# (bin/fm-session-lock-lib.sh's fm_pid_is_zombie/fm_harness_pid_alive, exercised
+# through the real bin/fm-lock.sh).
+#
+# Reproduces the incident this guards against: a harness process exits but its
+# parent never reaps it, so it lingers as a zombie. `kill -0` still succeeds on a
+# zombie and `ps` still reports its original comm, so before the fix
+# fm_harness_pid_alive read it as a live lock holder forever, with no way to
+# reclaim the home's session lock short of deleting state/.lock by hand.
+#
+# Every fixture here is a REAL process, not a faked ps table: a zombie is
+# constructed by forking a child that execs into a binary literally named
+# "claude" and exits, while its parent deliberately never calls wait() on it.
+# The kernel sets a process's reported comm from the basename of the exec'd
+# pathname, not argv[0], so a "claude"-named symlink stays "claude" even once
+# defunct - this is why the fixture execs a symlink rather than using
+# `exec -a`, which only overrides argv[0] and would not survive as the zombie's
+# reported name.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+TMP_ROOT=$(fm_test_tmproot fm-session-lock-zombie)
+LIB="$ROOT/bin/fm-session-lock-lib.sh"
+
+# --- fixture plumbing --------------------------------------------------------
+
+ZOMBIE_PARENT_PIDS=()
+
+cleanup_zombie_parents() {
+  local pid
+  for pid in "${ZOMBIE_PARENT_PIDS[@]:-}"; do
+    [ -n "$pid" ] && kill "$pid" 2>/dev/null
+  done
+  for pid in "${ZOMBIE_PARENT_PIDS[@]:-}"; do
+    [ -n "$pid" ] && wait "$pid" 2>/dev/null
+  done
+}
+trap 'cleanup_zombie_parents; fm_test_cleanup' EXIT
+
+# make_zombie_pid <name>: exec a symlink named <name> pointing at /bin/true from
+# a forked child, print the child's pid, and never wait() on it from the parent.
+# The parent sleeps so the child stays parented (and thus unreaped) until this
+# suite kills it at exit; a child reparented to init would be reaped instantly.
+make_zombie_pid() {
+  local name=$1 targetdir pidfile parent pid
+  targetdir="$TMP_ROOT/zombie-target-$name-$$-${RANDOM:-0}"
+  mkdir -p "$targetdir"
+  ln -sf /bin/true "$targetdir/$name"
+  pidfile="$TMP_ROOT/zombie-pidfile-$name-$$-${RANDOM:-0}"
+  perl -e '
+    $| = 1;
+    my $pid = fork();
+    if ($pid == 0) {
+      exec($ARGV[0]);
+      exit 1;
+    }
+    print "$pid\n";
+    sleep 30;
+  ' "$targetdir/$name" > "$pidfile" &
+  parent=$!
+  ZOMBIE_PARENT_PIDS+=("$parent")
+  for _ in $(seq 1 50); do
+    [ -s "$pidfile" ] && break
+    sleep 0.1
+  done
+  [ -s "$pidfile" ] || fail "zombie fixture ($name) never reported its child pid"
+  pid=$(tr -d '[:space:]' < "$pidfile")
+  for _ in $(seq 1 50); do
+    [ "$(ps -o state= -p "$pid" 2>/dev/null | tr -d '[:space:]')" = Z ] && break
+    sleep 0.1
+  done
+  [ "$(ps -o state= -p "$pid" 2>/dev/null | tr -d '[:space:]')" = Z ] \
+    || fail "zombie fixture ($name) did not produce a defunct process (pid $pid)"
+  printf '%s\n' "$pid"
+}
+
+# make_live_named_pid <name> <seconds>: background a real, live process whose
+# comm is literally <name> (again via a symlink, so it also matches the harness
+# name regex without any faked ps), and print its pid. The backgrounded process
+# must not inherit this function's own stdout: this runs inside a caller's
+# command substitution, and an inherited stdout pipe stays open for as long as
+# the background job runs, which would block the caller on that pipe's EOF
+# instead of returning the pid immediately.
+make_live_named_pid() {
+  local name=$1 seconds=$2 targetdir pid
+  targetdir="$TMP_ROOT/live-target-$name-$$-${RANDOM:-0}"
+  mkdir -p "$targetdir"
+  ln -sf /bin/sleep "$targetdir/$name"
+  "$targetdir/$name" "$seconds" >/dev/null 2>&1 &
+  pid=$!
+  printf '%s\n' "$pid"
+}
+
+nonexistent_pid() {
+  local pid=999999
+  while kill -0 "$pid" 2>/dev/null; do
+    pid=$((pid + 1))
+  done
+  printf '%s\n' "$pid"
+}
+
+run_lib() {  # <expression>
+  bash -c ". \"\$0\"; $1" "$LIB"
+}
+
+# --- unit layer: fm_pid_is_zombie / fm_harness_pid_alive on real processes ---
+
+test_zombie_harness_pid_is_not_alive() {
+  local zpid
+  zpid=$(make_zombie_pid claude)
+  run_lib "fm_pid_is_zombie $zpid" \
+    || fail "a real zombie process was not classified as a zombie (pid $zpid)"
+  if run_lib "fm_harness_pid_alive $zpid"; then
+    fail "a zombie whose comm is a verified harness name was still read as a live lock holder (pid $zpid)"
+  fi
+  pass "session-lock: a zombie harness process is not classified as a live lock holder"
+}
+
+test_live_harness_pid_is_still_alive() {
+  local lpid
+  lpid=$(make_live_named_pid claude 20)
+  if run_lib "fm_pid_is_zombie $lpid"; then
+    kill "$lpid" 2>/dev/null; wait "$lpid" 2>/dev/null
+    fail "a genuinely running process was misclassified as a zombie (pid $lpid)"
+  fi
+  run_lib "fm_harness_pid_alive $lpid" \
+    || { kill "$lpid" 2>/dev/null; wait "$lpid" 2>/dev/null; fail "a genuinely live harness process was not recognized as alive (pid $lpid) - the fix must not make every lock reclaimable"; }
+  kill "$lpid" 2>/dev/null
+  wait "$lpid" 2>/dev/null
+  pass "session-lock: a genuinely live harness process is still recognized as a live lock holder (negative control)"
+}
+
+test_nonexistent_pid_is_still_not_alive() {
+  local dead
+  dead=$(nonexistent_pid)
+  if run_lib "fm_pid_is_zombie $dead"; then
+    fail "a pid that does not exist at all was classified as a zombie (pid $dead)"
+  fi
+  if run_lib "fm_harness_pid_alive $dead"; then
+    fail "a pid that does not exist at all was classified as a live lock holder (pid $dead)"
+  fi
+  pass "session-lock: a nonexistent pid is unaffected by the zombie check"
+}
+
+test_live_non_harness_pid_is_still_not_a_holder() {
+  local lpid
+  lpid=$(make_live_named_pid sleep 20)
+  if run_lib "fm_harness_pid_alive $lpid"; then
+    kill "$lpid" 2>/dev/null; wait "$lpid" 2>/dev/null
+    fail "a live process with an ordinary (non-harness) name was classified as a lock holder (pid $lpid)"
+  fi
+  kill "$lpid" 2>/dev/null
+  wait "$lpid" 2>/dev/null
+  pass "session-lock: a live non-harness pid is unaffected by the zombie check"
+}
+
+# --- end-to-end layer: the real fm-lock.sh reclaims a zombie-held lock -------
+
+test_e2e_fm_lock_reclaims_a_zombie_held_lock() {
+  local dir fakebin zpid out rc
+  dir="$TMP_ROOT/e2e-zombie"
+  mkdir -p "$dir/state"
+  fakebin="$TMP_ROOT/e2e-zombie-caller/fakebin"
+  mkdir -p "$fakebin"
+  # This test process itself must resolve as a harness ancestor for fm-lock.sh
+  # to identify "me", exactly like the unit fixtures above: exec a
+  # "claude"-named symlink so the real ps-reported comm matches, with no faked
+  # ps table anywhere in this test.
+  ln -sf /bin/bash "$fakebin/claude"
+
+  zpid=$(make_zombie_pid claude)
+  printf '%s\n' "$zpid" > "$dir/state/.lock"
+
+  out=$(FM_HOME="$dir" "$fakebin/claude" "$ROOT/bin/fm-lock.sh" 2>&1)
+  rc=$?
+  [ "$rc" -eq 0 ] || fail "fm-lock.sh refused to reclaim a lock held by a dead zombie (pid $zpid): $out"
+  assert_contains "$out" "lock acquired" "fm-lock.sh did not report acquiring the lock from a zombie holder: $out"
+  pass "session-lock e2e: fm-lock.sh reclaims a lock held by a zombie that was never reaped"
+}
+
+test_e2e_fm_lock_still_refuses_a_live_holder() {
+  local dir fakebin lpid out rc
+  dir="$TMP_ROOT/e2e-live-holder"
+  mkdir -p "$dir/state"
+  fakebin="$TMP_ROOT/e2e-live-caller/fakebin"
+  mkdir -p "$fakebin"
+  ln -sf /bin/bash "$fakebin/claude"
+
+  lpid=$(make_live_named_pid claude 20)
+  printf '%s\n' "$lpid" > "$dir/state/.lock"
+
+  out=$(FM_HOME="$dir" "$fakebin/claude" "$ROOT/bin/fm-lock.sh" 2>&1)
+  rc=$?
+  kill "$lpid" 2>/dev/null
+  wait "$lpid" 2>/dev/null
+  [ "$rc" -ne 0 ] \
+    || fail "fm-lock.sh acquired a lock still held by a genuinely live harness process (pid $lpid): $out - the fix must not make every lock reclaimable"
+  assert_contains "$out" "another live firstmate session holds the lock" \
+    "fm-lock.sh's refusal text changed for a genuinely live holder: $out"
+  pass "session-lock e2e: fm-lock.sh still refuses a lock held by a genuinely live harness process (negative control)"
+}
+
+test_zombie_harness_pid_is_not_alive
+test_live_harness_pid_is_still_alive
+test_nonexistent_pid_is_still_not_alive
+test_live_non_harness_pid_is_still_not_a_holder
+test_e2e_fm_lock_reclaims_a_zombie_held_lock
+test_e2e_fm_lock_still_refuses_a_live_holder

--- a/tests/fm-session-lock-zombie.test.sh
+++ b/tests/fm-session-lock-zombie.test.sh
@@ -28,6 +28,7 @@ LIB="$ROOT/bin/fm-session-lock-lib.sh"
 # --- fixture plumbing --------------------------------------------------------
 
 ZOMBIE_PARENT_PIDS=()
+ZOMBIE_PID=
 
 cleanup_zombie_parents() {
   local pid
@@ -74,7 +75,7 @@ make_zombie_pid() {
   done
   [ "$(ps -o state= -p "$pid" 2>/dev/null | tr -d '[:space:]')" = Z ] \
     || fail "zombie fixture ($name) did not produce a defunct process (pid $pid)"
-  printf '%s\n' "$pid"
+  ZOMBIE_PID=$pid
 }
 
 # make_live_named_pid <name> <seconds>: background a real, live process whose
@@ -110,7 +111,8 @@ run_lib() {  # <expression>
 
 test_zombie_harness_pid_is_not_alive() {
   local zpid
-  zpid=$(make_zombie_pid claude)
+  make_zombie_pid claude
+  zpid=$ZOMBIE_PID
   run_lib "fm_pid_is_zombie $zpid" \
     || fail "a real zombie process was not classified as a zombie (pid $zpid)"
   if run_lib "fm_harness_pid_alive $zpid"; then
@@ -171,7 +173,8 @@ test_e2e_fm_lock_reclaims_a_zombie_held_lock() {
   # ps table anywhere in this test.
   ln -sf /bin/bash "$fakebin/claude"
 
-  zpid=$(make_zombie_pid claude)
+  make_zombie_pid claude
+  zpid=$ZOMBIE_PID
   printf '%s\n' "$zpid" > "$dir/state/.lock"
 
   out=$(FM_HOME="$dir" "$fakebin/claude" "$ROOT/bin/fm-lock.sh" 2>&1)

--- a/tests/wake-helpers.sh
+++ b/tests/wake-helpers.sh
@@ -218,6 +218,7 @@ write_composer() {
 }
 case "${1:-}" in
   display-message)
+    [ -n "${FM_FAKE_TMUX_DISPLAY_LOG:-}" ] && printf '%s\n' "$*" >> "$FM_FAKE_TMUX_DISPLAY_LOG"
     print=0
     for a in "$@"; do case "$a" in *cursor_y*) printf '1\n'; exit 0 ;; esac; done
     for a in "$@"; do [ "$a" = "-p" ] && print=1; done


### PR DESCRIPTION
## Intent

Stop a dead session from wedging every session that follows it. A firstmate session's harness process exits but its parent tmux server never reaps it, leaving it as a zombie (ps state Zs, [claude] <defunct>). fm_harness_pid_alive in bin/fm-session-lock-lib.sh reads that zombie as a live lock holder because kill -0 succeeds and ps still reports its comm as claude, so bin/fm-lock.sh refuses to reclaim the lock and the home stays permanently read-only until a human deletes state/.lock by hand.

Fix: add fm_pid_is_zombie() to bin/fm-session-lock-lib.sh, checking the portable single-character process state (ps -o state=; both Linux procps and BSD/macOS ps report a leading Z for a zombie, though BSD may append extra flag characters, hence a prefix match). fm_harness_pid_alive now treats a zombie pid as not alive. A genuinely live harness process must still be refused exactly as before - do not make every lock reclaimable, since that would let two sessions mutate one fleet at once. Do not add a --force flag to fm-lock.sh: the bug is misclassification, not a missing override. Do not change the session-lock ownership model or the ancestry walk beyond what liveness classification requires.

Also surfaced the holder's process state in fm-lock.sh's status command diagnostics (dead vs zombie-never-reaped vs not-a-harness) so the next occurrence is diagnosable without a human running ps by hand; this is scoped to the status command's output only and does not change acquire-time decisions.

Testing added in tests/fm-session-lock-zombie.test.sh: constructs REAL zombie processes (fork + exec into a binary literally named claude + exit without the parent reaping it) and asserts fm_pid_is_zombie/fm_harness_pid_alive classify them correctly, plus an end-to-end test that the real bin/fm-lock.sh reclaims a lock held by such a zombie. Mandatory negative control: a genuinely live harness process named claude is still refused by fm-lock.sh and still classified alive. Also covers a pid that does not exist at all and a live pid that is not a harness, confirming their pre-existing behavior is unchanged. No fake ps table is used anywhere in the new test file.

## What Changed

- Reclaim session locks held by zombie harness processes while continuing to reject genuinely live holders, and report precise stale-lock reasons in status output.
- Prevent away-mode injection wedges by recognizing Unicode-only empty composers, tightening Claude busy detection, improving defer diagnostics, and keeping tmux wedge alerts visible between refreshes.
- Update task briefs so agents self-drive their configured validation and delivery workflow, with expanded regression coverage and supervision documentation.

## Risk Assessment

✅ Low: The follow-up correctly keeps zombie fixture parents in the main shell’s cleanup registry, and the production change remains a well-bounded, intent-conformant liveness-classification fix with live-holder refusal preserved.

## Testing

After inspecting the targeted diff, I ran the focused real-process test and manually exercised the actual CLI: zombie-held locks were identified and reclaimed, live harness locks were identified and refused with exit status 1, and non-harness/dead states produced the intended diagnostics; reviewer-visible transcripts were captured and the worktree stayed clean.

<details>
<summary>Evidence: Focused real-process test transcript</summary>

```text
ok - session-lock: a zombie harness process is not classified as a live lock holder
ok - session-lock: a genuinely live harness process is still recognized as a live lock holder (negative control)
ok - session-lock: a nonexistent pid is unaffected by the zombie check
ok - session-lock: a live non-harness pid is unaffected by the zombie check
ok - session-lock e2e: fm-lock.sh reclaims a lock held by a zombie that was never reaped
ok - session-lock e2e: fm-lock.sh still refuses a lock held by a genuinely live harness process (negative control)
```
</details>
<details>
<summary>Evidence: End-user lock status, reclamation, and refusal transcript</summary>

```text
REAL PROCESS FIXTURES
 246366  246363 Z claude
 246392  246349 S claude
 246393  246349 S sleep

STATUS: zombie holder
lock: stale (pid 246366 zombie, never reaped by its parent)
ACQUIRE: zombie holder
lock acquired: harness pid 246413

STATUS: genuinely live harness holder
lock: held by live harness pid 246392
ACQUIRE: genuinely live harness holder
error: another live firstmate session holds the lock (pid 246392); operate read-only until resolved
exit_status=1

STATUS: live non-harness holder
lock: stale (pid 246393 not a harness)
STATUS: nonexistent holder
lock: stale (pid 999999 dead)
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Rebase** - 1 warning</summary>

- ⚠️ `.agents/skills/bootstrap-diagnostics/SKILL.md` - branch carries 3 commit(s) that exist on your local main branch but were never pushed to origin/main; rebasing would bundle this unrelated work (144 file(s)) into the PR:
- 9221162 fix(supervise): end the away-mode injection wedge (#1)
- b2f9836 no-mistakes(document): Align validation ownership documentation
- 56f35bd fix(brief): self-drive validation pipeline

Push main to origin, or rebase your branch onto origin/main, before gating.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `tests/fm-session-lock-zombie.test.sh:113` - `make_zombie_pid` is invoked through command substitution, so it runs in a subshell and its update to `ZOMBIE_PARENT_PIDS` is lost. The EXIT trap therefore cannot terminate or reap the fixture parents as intended, leaving Perl parents and zombies behind until their 30-second sleeps expire. Return the PID through a shared variable/file while invoking the helper in the main shell, or explicitly register the parent PID outside the substitution.

🔧 Fix: Fix zombie fixture parent cleanup
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>Inspected `git diff 33a428773059aa9bbe55865ce73ae51e4334bccc..73b7b9138788e10dbdfe92b1aff492a2cd5a4b4d -- bin/fm-session-lock-lib.sh bin/fm-lock.sh tests/fm-session-lock-zombie.test.sh`</code>
- `bash tests/fm-session-lock-zombie.test.sh | tee /tmp/no-mistakes-evidence/01KZAMK1YP47BSGJXKXQ6REW79/fm-session-lock-zombie-test.log`
- <code>Created real zombie, live-harness, live-non-harness, and nonexistent PID fixtures; exercised `bin/fm-lock.sh status` plus zombie acquisition and live-holder refusal, recording `/tmp/no-mistakes-evidence/01KZAMK1YP47BSGJXKXQ6REW79/fm-lock-user-experience.log`</code>
- `git status --short`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
