### PR TITLE
fix(bin): run session start deterministically from hooks

### DIFF
--- a/.agents/skills/ahoy/SKILL.md
+++ b/.agents/skills/ahoy/SKILL.md
@@ -12,7 +12,7 @@ Give the captain a concise session-only recap without gathering fresh state.
 
 0. Before anything else, check whether this session has already taken the helm: a `SESSION START` digest for this home must be visible in the session history.
    If it is not, run `bin/fm-session-start.sh` once and read its digest before producing any recap.
-   Hook-capable harnesses run it automatically at session open, so this step is normally already satisfied and costs one glance; it is the safety net for harnesses that cannot run it on a hook, and for any path where a skill would otherwise act first.
+   Run-tier harness surfaces run it automatically at session open, so this step is normally already satisfied and costs one glance; it is the safety net for surfaces that cannot run it on a hook, and for any path where a skill would otherwise act first.
    Taking the helm always precedes this skill's own logic, and the digest it produces is operational input, never a captain message or a recap event.
 
 1. Inspect only conversation or session history already visible to the current first mate.

--- a/.agents/skills/ahoy/SKILL.md
+++ b/.agents/skills/ahoy/SKILL.md
@@ -10,6 +10,11 @@ metadata:
 
 Give the captain a concise session-only recap without gathering fresh state.
 
+0. Before anything else, check whether this session has already taken the helm: a `SESSION START` digest for this home must be visible in the session history.
+   If it is not, run `bin/fm-session-start.sh` once and read its digest before producing any recap.
+   Hook-capable harnesses run it automatically at session open, so this step is normally already satisfied and costs one glance; it is the safety net for harnesses that cannot run it on a hook, and for any path where a skill would otherwise act first.
+   Taking the helm always precedes this skill's own logic, and the digest it produces is operational input, never a captain message or a recap event.
+
 1. Inspect only conversation or session history already visible to the current first mate.
 2. Find the most recent real captain-authored message before the current `/ahoy` invocation.
    A captain boundary is an ordinary user-role message unless it matches one of the narrow operational exclusions below.
@@ -32,7 +37,7 @@ Give the captain a concise session-only recap without gathering fresh state.
    A later unrelated captain message establishes a recap boundary but does not close an earlier decision.
    Treat a decision as closed only when a later visible response substantively resolves it, chooses an option, declines it, grants or denies the requested approval, or otherwise directly addresses that decision.
    Include every visibly supported open decision once, and deduplicate by the decision's substance when the ordinary interval recap already represents it or its wording differs.
-6. The normal recap branch is session-history-only.
+6. The normal recap branch is session-history-only, apart from the step 0 helm check.
    Do not call Bearings, shell commands, fleet snapshots, status readers, GitHub or browser APIs, tools, or file reads or writes.
    Create no report, persist nothing, and do not guess current live state beyond the last visible event.
 7. If no ordinary events occurred after the previous captain message but an older visibly open decision exists, report that decision instead of claiming nothing happened.

--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -89,7 +89,8 @@ Tier assignment, source routing, the runtime bound, and fail-open behavior live 
 `docs/verification/supervision.md` "Native session-start delivery" owns active dated commands, payloads, and evidence.
 
 - `claude`: run tier; verified native `SessionStart` stdout injection, with one unmatched hook whose payload `source` drives the routing.
-- `codex`: run tier; the `SessionStart` payload carries the same `startup|resume|clear|compact` `source` vocabulary as Claude, and wrapper stdout reaches model context.
+- `codex exec`: run tier; the `SessionStart` payload carries the same `startup|resume|clear|compact` `source` vocabulary as Claude, and wrapper stdout reaches model context.
+- `codex` interactive TUI: nudge tier through the tracked session-start instruction; Codex 0.146.0 does not fire the project `SessionStart` hook there, and Firstmate ships no global replacement.
 - `opencode`: nudge tier; verified on 1.17.18, `session.created` plus `client.session.promptAsync` starts the nudge turn in the TUI, while `opencode run` can exit before that turn, which is also why it cannot run the digest in the hook.
 - `pi` and `pi-signed`: run tier; the primary extension maps `session_start` reasons `startup`, `new`, `resume`, and `fork` onto wrapper sources, handles `session_compact`, and uses `pi.sendMessage` to inject context without racing a positional launch prompt; because that is a message rather than hook stdout, the extension gives an unencoded digest `session-start` operational provenance first.
 - `grok`: nudge tier; the 0.2.103 project `SessionStart` event fires with `source=new`, but stdout does not reach model context, so it cannot run the digest either; the tracked project hook remains fail-open, and a global token-guarded fallback requires a captain decision.

--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -84,16 +84,8 @@ The subagent tool presents to the model as `Agent`, and on Claude Code 2.1.217 b
 ## Primary session start
 
 AGENTS.md section 3 remains the behavioral owner for session start, while tracked native adapters enforce it idempotently at session open through one of two tiers.
-Run-tier adapters invoke `bin/fm-sessionstart-run.sh`, which executes `bin/fm-session-start.sh` so the digest is in model context before the first turn; nudge-tier adapters invoke `bin/fm-sessionstart-nudge.sh`, which only prints one canonically typed `session-start` instruction and never runs the digest, wake drain, bootstrap sweeps, lock, or supervision arm itself.
-Tier assignment, source routing, the runtime bound, and fail-open behavior live in `docs/sessionstart-nudge.md`.
+Before inspecting or changing session-open behavior, read `docs/sessionstart-nudge.md`, the single owner of tier assignment, per-surface transports, source routing, the runtime bound, and fail-open behavior.
 `docs/verification/supervision.md` "Native session-start delivery" owns active dated commands, payloads, and evidence.
-
-- `claude`: run tier; verified native `SessionStart` stdout injection, with one unmatched hook whose payload `source` drives the routing.
-- `codex exec`: run tier; the `SessionStart` payload carries the same `startup|resume|clear|compact` `source` vocabulary as Claude, and wrapper stdout reaches model context.
-- `codex` interactive TUI: nudge tier through the tracked session-start instruction; Codex 0.146.0 does not fire the project `SessionStart` hook there, and Firstmate ships no global replacement.
-- `opencode`: nudge tier; verified on 1.17.18, `session.created` plus `client.session.promptAsync` starts the nudge turn in the TUI, while `opencode run` can exit before that turn, which is also why it cannot run the digest in the hook.
-- `pi` and `pi-signed`: run tier; the primary extension maps `session_start` reasons `startup`, `new`, `resume`, and `fork` onto wrapper sources, handles `session_compact`, and uses `pi.sendMessage` to inject context without racing a positional launch prompt; because that is a message rather than hook stdout, the extension gives an unencoded digest `session-start` operational provenance first.
-- `grok`: nudge tier; the 0.2.103 project `SessionStart` event fires with `source=new`, but stdout does not reach model context, so it cannot run the digest either; the tracked project hook remains fail-open, and a global token-guarded fallback requires a captain decision.
 
 ## Primary watcher supervision
 

--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -81,18 +81,18 @@ Two verified facts worth pinning here.
 The subagent tool presents to the model as `Agent`, and on Claude Code 2.1.217 both `Agent` and `Task` work as `permissions.deny` keys, verified by an A/B with a nonsense-name control.
 `permissions.allow` is a pre-approval list rather than an availability list, so there is no fail-closed positive allowlist.
 
-## Primary session-start nudge
+## Primary session start
 
-AGENTS.md section 3 remains the behavioral owner for session start, while tracked native adapters invoke `bin/fm-sessionstart-nudge.sh` as an idempotent enforcement layer.
-The wrapper prints one canonically typed `session-start` instruction to run `bin/fm-session-start.sh`; it never runs the digest, wake drain, bootstrap sweeps, lock, or supervision arm itself.
-Full mechanics, scoping, and fail-open behavior live in `docs/sessionstart-nudge.md`.
+AGENTS.md section 3 remains the behavioral owner for session start, while tracked native adapters enforce it idempotently at session open through one of two tiers.
+Run-tier adapters invoke `bin/fm-sessionstart-run.sh`, which executes `bin/fm-session-start.sh` so the digest is in model context before the first turn; nudge-tier adapters invoke `bin/fm-sessionstart-nudge.sh`, which only prints one canonically typed `session-start` instruction and never runs the digest, wake drain, bootstrap sweeps, lock, or supervision arm itself.
+Tier assignment, source routing, the runtime bound, and fail-open behavior live in `docs/sessionstart-nudge.md`.
 `docs/verification/supervision.md` "Native session-start delivery" owns active dated commands, payloads, and evidence.
 
-- `claude`: verified native `SessionStart` stdout injection; `.claude/settings.json` matches `startup`, `resume`, and `clear`, but not `compact`.
-- `codex`: verified on 0.144.4; `.codex/hooks.json` receives `source=startup`, and wrapper stdout reaches model context.
-- `opencode`: verified on 1.17.18; `session.created` plus `client.session.promptAsync` starts the nudge turn in the TUI, while `opencode run` remains fail-open headless.
-- `pi` and `pi-signed`: verified native `session_start`; the existing primary extension handles `startup`, `new`, and `resume` and uses `pi.sendMessage` to inject context without racing a positional launch prompt.
-- `grok`: the 0.2.103 project `SessionStart` event fires with `source=new`, but stdout does not reach model context; the tracked project hook remains fail-open, and a global token-guarded fallback requires a captain decision.
+- `claude`: run tier; verified native `SessionStart` stdout injection, with one unmatched hook whose payload `source` drives the routing.
+- `codex`: run tier; the `SessionStart` payload carries the same `startup|resume|clear|compact` `source` vocabulary as Claude, and wrapper stdout reaches model context.
+- `opencode`: nudge tier; verified on 1.17.18, `session.created` plus `client.session.promptAsync` starts the nudge turn in the TUI, while `opencode run` can exit before that turn, which is also why it cannot run the digest in the hook.
+- `pi` and `pi-signed`: run tier; the primary extension maps `session_start` reasons `startup`, `new`, `resume`, and `fork` onto wrapper sources, handles `session_compact`, and uses `pi.sendMessage` to inject context without racing a positional launch prompt; because that is a message rather than hook stdout, the extension gives an unencoded digest `session-start` operational provenance first.
+- `grok`: nudge tier; the 0.2.103 project `SessionStart` event fires with `source=new`, but stdout does not reach model context, so it cannot run the digest either; the tracked project hook remains fail-open, and a global token-guarded fallback requires a captain decision.
 
 ## Primary watcher supervision
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,11 +2,11 @@
   "hooks": {
     "SessionStart": [
       {
-        "matcher": "startup|resume|clear",
         "hooks": [
           {
             "type": "command",
-            "command": "\"$CLAUDE_PROJECT_DIR\"/bin/fm-sessionstart-nudge.sh"
+            "command": "\"$CLAUDE_PROJECT_DIR\"/bin/fm-sessionstart-run.sh",
+            "timeout": 180
           }
         ]
       }

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -5,8 +5,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash -lc 'payload=$(cat 2>/dev/null || true); [ -n \"$payload\" ] || exit 0; command -v jq >/dev/null 2>&1 || exit 0; root=$(pwd -P) || exit 0; [ -x \"$root/bin/fm-sessionstart-nudge.sh\" ] || exit 0; [ -f \"$root/AGENTS.md\" ] || exit 0; [ -f \"$root/.codex/hooks.json\" ] || exit 0; jq -e \"any(.hooks.SessionStart[]?.hooks[]?.command?; type == \\\"string\\\" and contains(\\\"fm-sessionstart-nudge.sh\\\"))\" \"$root/.codex/hooks.json\" >/dev/null 2>&1 || exit 0; exec \"$root/bin/fm-sessionstart-nudge.sh\"'",
-            "timeout": 10
+            "command": "bash -lc 'payload=$(cat 2>/dev/null || true); [ -n \"$payload\" ] || exit 0; command -v jq >/dev/null 2>&1 || exit 0; root=$(pwd -P) || exit 0; [ -x \"$root/bin/fm-sessionstart-run.sh\" ] || exit 0; [ -f \"$root/AGENTS.md\" ] || exit 0; [ -f \"$root/.codex/hooks.json\" ] || exit 0; jq -e \"any(.hooks.SessionStart[]?.hooks[]?.command?; type == \\\"string\\\" and contains(\\\"fm-sessionstart-run.sh\\\"))\" \"$root/.codex/hooks.json\" >/dev/null 2>&1 || exit 0; printf \"%s\" \"$payload\" | \"$root/bin/fm-sessionstart-run.sh\"'",
+            "timeout": 180
           }
         ]
       }

--- a/.pi/extensions/fm-primary-turnend-guard.ts
+++ b/.pi/extensions/fm-primary-turnend-guard.ts
@@ -4,7 +4,10 @@ import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
-import { encodeFirstmateOperationalInput } from "./lib/fm-operational-input.ts";
+import {
+  classifyFirstmateCurrentOperationalText,
+  encodeFirstmateOperationalInput,
+} from "./lib/fm-operational-input.ts";
 
 let guardFollowupActive = false;
 
@@ -55,10 +58,40 @@ function markLoaded(): void {
   writeFileSync(marker, `${extensionVersion}\n${process.pid}\n`);
 }
 
-function runSessionstartNudge(): string {
-  const result = spawnSync(`${root}/bin/fm-sessionstart-nudge.sh`, [], { encoding: "utf8" });
+// Pi's session_start reasons are startup | reload | new | resume | fork, and a
+// separate session_compact event fires after a compaction. "new" is Pi's /clear
+// (a fresh session in the SAME process, so the fleet lock is still ours), while
+// reload, resume, and fork all keep prior context. bin/fm-sessionstart-run.sh
+// owns what each source means; this maps Pi's vocabulary onto its --source
+// names and injects whatever it prints.
+function runSessionstartHook(source: string): string {
+  const result = spawnSync(`${root}/bin/fm-sessionstart-run.sh`, ["--source", source], {
+    encoding: "utf8",
+  });
   if (result.status !== 0) return "";
   return result.stdout.trim();
+}
+
+function injectSessionstart(pi: ExtensionAPI, source: string): void {
+  const raw = runSessionstartHook(source);
+  if (!raw) return;
+  try {
+    // Pi is the only adapter that injects a MESSAGE rather than hook stdout, so
+    // whatever it injects must carry operational provenance or the Ahoy skill
+    // would have to guess whether it was captain-authored. The wrapper already
+    // returns an encoded nudge on a context-preserving open, so only an
+    // unencoded digest needs the marker added here.
+    const content = classifyFirstmateCurrentOperationalText(raw)
+      ? raw
+      : encodeFirstmateOperationalInput("session-start", raw);
+    pi.sendMessage({
+      customType: "firstmate-sessionstart-nudge",
+      content,
+      display: false,
+      details: { kind: "session-start" },
+    });
+  } catch {
+  }
 }
 
 function runGuard(): Promise<{ code: number; stderr: string }> {
@@ -108,18 +141,16 @@ function runCdCheck(command: string): Promise<{ code: number; stderr: string }> 
 export default function (pi: ExtensionAPI) {
   pi.on?.("session_start", (event) => {
     const reason = String((event as { reason?: unknown }).reason ?? "");
-    const nudge = ["startup", "new", "resume"].includes(reason) ? runSessionstartNudge() : "";
+    const source = { startup: "startup", new: "clear", resume: "resume", fork: "fork" }[reason];
     markLoaded();
-    if (!nudge) return;
-    try {
-      pi.sendMessage({
-        customType: "firstmate-sessionstart-nudge",
-        content: nudge,
-        display: false,
-        details: { kind: "session-start" },
-      });
-    } catch {
-    }
+    if (!source) return;
+    injectSessionstart(pi, source);
+  });
+
+  // Pi's compaction equivalent. The digest is what a compacted session has just
+  // lost, so re-emitting it here is the point rather than a side effect.
+  pi.on?.("session_compact", () => {
+    injectSessionstart(pi, "compact");
   });
 
   pi.on("tool_call", async (event) => {

--- a/.pi/extensions/fm-primary-turnend-guard.ts
+++ b/.pi/extensions/fm-primary-turnend-guard.ts
@@ -64,16 +64,44 @@ function markLoaded(): void {
 // reload, resume, and fork all keep prior context. bin/fm-sessionstart-run.sh
 // owns what each source means; this maps Pi's vocabulary onto its --source
 // names and injects whatever it prints.
-function runSessionstartHook(source: string): string {
-  const result = spawnSync(`${root}/bin/fm-sessionstart-run.sh`, ["--source", source], {
-    encoding: "utf8",
+const sessionstartDeliveryBytes = 512 * 1024;
+const sessionstartTruncatedMarker =
+  "\n\nPI SESSION-START DELIVERY TRUNCATED - the digest exceeded 512 KiB. " +
+  "Treat omitted context as unread and inspect the named files directly before acting on it.";
+
+function runSessionstartHook(source: string): Promise<string> {
+  return new Promise((resolveResult) => {
+    const child = spawn(`${root}/bin/fm-sessionstart-run.sh`, ["--source", source], {
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+    const chunks: Buffer[] = [];
+    let retainedBytes = 0;
+    let truncated = false;
+    child.stdout.on("data", (chunk: Buffer) => {
+      if (retainedBytes >= sessionstartDeliveryBytes) {
+        truncated = true;
+        return;
+      }
+      const remaining = sessionstartDeliveryBytes - retainedBytes;
+      const retained = chunk.length <= remaining ? chunk : chunk.subarray(0, remaining);
+      chunks.push(retained);
+      retainedBytes += retained.length;
+      if (retained.length !== chunk.length) truncated = true;
+    });
+    child.on("error", () => resolveResult(""));
+    child.on("close", (code) => {
+      if (code !== 0) {
+        resolveResult("");
+        return;
+      }
+      const raw = Buffer.concat(chunks).toString("utf8").trim();
+      resolveResult(truncated ? `${raw}${sessionstartTruncatedMarker}` : raw);
+    });
   });
-  if (result.status !== 0) return "";
-  return result.stdout.trim();
 }
 
-function injectSessionstart(pi: ExtensionAPI, source: string): void {
-  const raw = runSessionstartHook(source);
+async function injectSessionstart(pi: ExtensionAPI, source: string): Promise<void> {
+  const raw = await runSessionstartHook(source);
   if (!raw) return;
   try {
     // Pi is the only adapter that injects a MESSAGE rather than hook stdout, so
@@ -139,18 +167,18 @@ function runCdCheck(command: string): Promise<{ code: number; stderr: string }> 
 }
 
 export default function (pi: ExtensionAPI) {
-  pi.on?.("session_start", (event) => {
+  pi.on?.("session_start", async (event) => {
     const reason = String((event as { reason?: unknown }).reason ?? "");
     const source = { startup: "startup", new: "clear", resume: "resume", fork: "fork" }[reason];
     markLoaded();
     if (!source) return;
-    injectSessionstart(pi, source);
+    await injectSessionstart(pi, source);
   });
 
   // Pi's compaction equivalent. The digest is what a compacted session has just
   // lost, so re-emitting it here is the point rather than a side effect.
-  pi.on?.("session_compact", () => {
-    injectSessionstart(pi, "compact");
+  pi.on?.("session_compact", async () => {
+    await injectSessionstart(pi, "compact");
   });
 
   pi.on("tool_call", async (event) => {

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -131,7 +131,7 @@ Run `bin/fm-session-start.sh` exactly once at session start.
 Its header is the single owner of composed commands, ordering, and digest contents.
 `bin/fm-supervision-instructions.sh` renders the emitted supervision block from `docs/supervision-protocols/`.
 Do not reimplement it by separately running its lock, bootstrap, or initial wake-drain components.
-Tracked native session-open adapters only nudge this command; `docs/sessionstart-nudge.md` owns their current behavior and compatibility.
+Hook-capable harnesses run this command for you at session open while the rest only nudge it, so confirm the digest is present in this session and run it yourself when it is not; `docs/sessionstart-nudge.md` owns adapter tiers, source routing, and compatibility.
 
 Read the complete digest once and trust it as this turn's startup and recovery input.
 Do not separately re-read the context, backlog, metadata, or bulk status inputs it just printed unless a source was reported absent or corrupt, older history is specifically needed, or a targeted workflow must inspect before writing.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -131,7 +131,7 @@ Run `bin/fm-session-start.sh` exactly once at session start.
 Its header is the single owner of composed commands, ordering, and digest contents.
 `bin/fm-supervision-instructions.sh` renders the emitted supervision block from `docs/supervision-protocols/`.
 Do not reimplement it by separately running its lock, bootstrap, or initial wake-drain components.
-Hook-capable harnesses run this command for you at session open while the rest only nudge it, so confirm the digest is present in this session and run it yourself when it is not; `docs/sessionstart-nudge.md` owns adapter tiers, source routing, and compatibility.
+Run-tier harness surfaces run this command for you at session open while the rest only nudge it, so confirm the digest is present in this session and run it yourself when it is not; `docs/sessionstart-nudge.md` owns adapter tiers, source routing, and compatibility.
 
 Read the complete digest once and trust it as this turn's startup and recovery input.
 Do not separately re-read the context, backlog, metadata, or bulk status inputs it just printed unless a source was reported absent or corrupt, older history is specifically needed, or a targeted workflow must inspect before writing.

--- a/bin/fm-bearings-snapshot.sh
+++ b/bin/fm-bearings-snapshot.sh
@@ -60,6 +60,9 @@ set -u
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 FLEET="$SCRIPT_DIR/fm-fleet-snapshot.sh"
+# shellcheck source=bin/fm-timeout-lib.sh
+# shellcheck disable=SC1091
+. "$SCRIPT_DIR/fm-timeout-lib.sh"
 
 # Bounds (overridable for tests / large fleets).
 FM_BEARINGS_LANDED=${FM_BEARINGS_LANDED:-6}
@@ -190,16 +193,10 @@ repo_slug() {  # <url>
 }
 
 # Bounded gh call; prints stdout, non-zero on timeout/failure. gh only.
+# bin/fm-timeout-lib.sh owns the bound itself.
 gh_bounded() {  # <args...>
-  if command -v timeout >/dev/null 2>&1; then
-    GH_PROMPT_DISABLED=1 GH_NO_UPDATE_NOTIFIER=1 timeout "$FM_BEARINGS_PR_TIMEOUT" gh "$@"
-  elif command -v gtimeout >/dev/null 2>&1; then
-    GH_PROMPT_DISABLED=1 GH_NO_UPDATE_NOTIFIER=1 gtimeout "$FM_BEARINGS_PR_TIMEOUT" gh "$@"
-  elif command -v perl >/dev/null 2>&1; then
-    GH_PROMPT_DISABLED=1 GH_NO_UPDATE_NOTIFIER=1 perl -e 'my $t = shift; my $pid = fork; die "fork failed" unless defined $pid; if (!$pid) { setpgrp(0, 0); exec @ARGV } local $SIG{ALRM} = sub { kill "TERM", -$pid; select undef, undef, undef, 0.2; kill "KILL", -$pid; exit 124 }; alarm $t; waitpid $pid, 0; exit($? >> 8)' "$FM_BEARINGS_PR_TIMEOUT" gh "$@"
-  else
-    return 124
-  fi
+  fm_run_timed "$FM_BEARINGS_PR_TIMEOUT" \
+    env GH_PROMPT_DISABLED=1 GH_NO_UPDATE_NOTIFIER=1 gh "$@"
 }
 
 if [ "$INCLUDE_PRS" = 1 ]; then

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -91,6 +91,13 @@
 #          X-mode artifacts, project clones, or repair instructions.
 #          Unset/0 (the default) runs every sweep exactly as before - this flag
 #          is purely additive.
+#          Set FM_BOOTSTRAP_LOCKED=1 alongside it when the sweeps are skipped
+#          because THIS session already ran them while holding the fleet lock,
+#          rather than because it has no lock at all. The two cases differ in
+#          exactly one place: repair ownership. A locked session is told to
+#          restore a tangled primary checkout itself, while an unlocked one is
+#          told to leave that work to the lock holder. Unset/0 (the default)
+#          keeps detect-only meaning unlocked, exactly as before.
 #        fm-bootstrap.sh install <tool>...
 #          Install the named tools (only ones the captain approved).
 set -u
@@ -1057,7 +1064,7 @@ gh auth status >/dev/null 2>&1 || echo "NEEDS_GH_AUTH"
 tangle_branch=$(fm_primary_tangle_branch "$FM_ROOT" 2>/dev/null || true)
 if [ -n "$tangle_branch" ]; then
   tangle_default=$(fm_default_branch "$FM_ROOT" 2>/dev/null || echo main)
-  if [ "${FM_BOOTSTRAP_DETECT_ONLY:-0}" = 1 ]; then
+  if [ "${FM_BOOTSTRAP_DETECT_ONLY:-0}" = 1 ] && [ "${FM_BOOTSTRAP_LOCKED:-0}" != 1 ]; then
     echo "TANGLE: primary checkout on feature branch '$tangle_branch' (expected '$tangle_default'); the work is safe on that ref - read-only session must leave restore work to the session holding the fleet lock"
   else
     echo "TANGLE: primary checkout on feature branch '$tangle_branch' (expected '$tangle_default'); the work is safe on that ref - restore the primary with: git -C $FM_ROOT checkout $tangle_default, then re-validate the branch in a proper worktree"

--- a/bin/fm-fleet-snapshot.sh
+++ b/bin/fm-fleet-snapshot.sh
@@ -134,6 +134,9 @@ validate_positive_bound FM_SNAPSHOT_REGISTRY_TIMEOUT "$FM_SNAPSHOT_REGISTRY_TIME
 # shellcheck source=bin/fm-ff-lib.sh
 # shellcheck disable=SC1091
 . "$SCRIPT_DIR/fm-ff-lib.sh"  # validate_secondmate_home: shared seeded-home boundary checks
+# shellcheck source=bin/fm-timeout-lib.sh
+# shellcheck disable=SC1091
+. "$SCRIPT_DIR/fm-timeout-lib.sh"  # fm_run_timed: the shared hard bound
 
 usage() {
   cat <<'EOF'
@@ -480,7 +483,7 @@ task_json_lines() {
     endpoint_exists=null
     agent_alive=not_checked
     if [ -n "$remote_host" ]; then
-      if remote_state=$(run_timed "$FM_SNAPSHOT_SECONDMATE_TIMEOUT" \
+      if remote_state=$(fm_run_timed "$FM_SNAPSHOT_SECONDMATE_TIMEOUT" \
         "$SCRIPT_DIR/fm-on.sh" "$id" fm-remote-secondmate-control.sh state "$id" < /dev/null 2>/dev/null); then
         remote_rc=0
       else
@@ -785,20 +788,6 @@ secondmate_home_summary_json() {  # <backlog-json> <tasks-json>
 FM_SNAPSHOT_SECONDMATE_LANDED_PER_HOME=${FM_SNAPSHOT_SECONDMATE_LANDED_PER_HOME:-10}
 case "$FM_SNAPSHOT_SECONDMATE_LANDED_PER_HOME" in ''|*[!0-9]*) FM_SNAPSHOT_SECONDMATE_LANDED_PER_HOME=10 ;; esac
 
-run_timed() {  # <seconds> <command...>
-  local seconds=$1
-  shift
-  if command -v timeout >/dev/null 2>&1; then
-    timeout "$seconds" "$@"
-  elif command -v gtimeout >/dev/null 2>&1; then
-    gtimeout "$seconds" "$@"
-  elif command -v perl >/dev/null 2>&1; then
-    perl -e 'my $t = shift; my $pid = fork; die "fork failed" unless defined $pid; if (!$pid) { setpgrp(0, 0); exec @ARGV } local $SIG{ALRM} = sub { kill "TERM", -$pid; select undef, undef, undef, 0.2; kill "KILL", -$pid; exit 124 }; alarm $t; waitpid $pid, 0; exit($? >> 8)' "$seconds" "$@"
-  else
-    return 124
-  fi
-}
-
 # GNU stat treats -f as a filesystem-report command, so a BSD-first fallback can
 # pollute arithmetic input before failing. Select the platform syntax once.
 if [ "$(uname 2>/dev/null || true)" = Darwin ]; then
@@ -904,7 +893,7 @@ JQ
        ],lines_in_window:$lines_in_window,records_in_window:$records_in_window}
 JQ
   )
-  out=$(run_timed "$FM_SNAPSHOT_REGISTRY_TIMEOUT" bash -c "$script" \
+  out=$(fm_run_timed "$FM_SNAPSHOT_REGISTRY_TIMEOUT" bash -c "$script" \
     fm-secondmate-registry "$reg" "$FM_SNAPSHOT_REGISTRY_LINES" \
     "$FM_SNAPSHOT_REGISTRY_BYTES" "$FM_SNAPSHOT_REGISTRY_RECORDS" "$reg" "$SNAPSHOT_NOW" \
     "$parse_filter" "$output_filter" 2>/dev/null)
@@ -991,7 +980,7 @@ bounded_parent_activities_json() {  # <status-file>
          records_in_window:$records_in_window}'
 BASH
   )
-  out=$(run_timed "$FM_SNAPSHOT_PARENT_ACTIVITY_TIMEOUT" bash -c "$script" \
+  out=$(fm_run_timed "$FM_SNAPSHOT_PARENT_ACTIVITY_TIMEOUT" bash -c "$script" \
     fm-parent-activities "$SCRIPT_DIR/fm-classify-lib.sh" "$f" \
     "$FM_SNAPSHOT_PARENT_ACTIVITY_LINES" "$FM_SNAPSHOT_PARENT_ACTIVITY_BYTES" \
     "$FM_SNAPSHOT_PARENT_ACTIVITIES" "$SNAPSHOT_STAT_STYLE" 2>/dev/null)
@@ -1026,7 +1015,7 @@ terminal_evidence_json() {  # <parent-task-json> <event-note> <evidence-contradi
     return 0
   fi
   # shellcheck disable=SC2016 # Positional parameters expand inside the child bash, not here.
-  out=$(run_timed "$FM_SNAPSHOT_TERMINAL_TIMEOUT" bash -c \
+  out=$(fm_run_timed "$FM_SNAPSHOT_TERMINAL_TIMEOUT" bash -c \
     '. "$1"; fm_backend_capture "$2" "$3" "$4" "$5" | LC_ALL=C head -c "$6"; rc=${PIPESTATUS[0]}; [ "$rc" -eq 141 ] && rc=0; exit "$rc"' \
     fm-terminal-capture "$SCRIPT_DIR/fm-backend.sh" "$backend" "$target" "$FM_SNAPSHOT_TERMINAL_LINES" "$expected" "$FM_SNAPSHOT_TERMINAL_BYTES" 2>/dev/null)
   rc=$?
@@ -1199,11 +1188,11 @@ secondmate_current_json() {  # <parent-tasks-json>
     fi
     if [ -z "$reason" ]; then
       if [ "$remote" = true ]; then
-        summary=$(run_timed "$FM_SNAPSHOT_SECONDMATE_TIMEOUT" \
+        summary=$(fm_run_timed "$FM_SNAPSHOT_SECONDMATE_TIMEOUT" \
           "$SCRIPT_DIR/fm-on.sh" "$id" fm-fleet-snapshot.sh --secondmate-home-summary < /dev/null 2>/dev/null)
         summary_rc=$?
       else
-        summary=$(run_timed "$FM_SNAPSHOT_SECONDMATE_TIMEOUT" env \
+        summary=$(fm_run_timed "$FM_SNAPSHOT_SECONDMATE_TIMEOUT" env \
           FM_ROOT_OVERRIDE="$FM_ROOT" \
           FM_HOME="$home" \
           FM_STATE_OVERRIDE="$home/state" \

--- a/bin/fm-session-start.sh
+++ b/bin/fm-session-start.sh
@@ -105,8 +105,8 @@
 # sections that were therefore never emitted, and still exits 0. The child
 # records its progress in FM_SESSION_START_STAGE_FILE, which is also the flag
 # that tells a child it is the child - the parent never recurses.
-# A host with no bounding mechanism at all (no timeout, gtimeout, or perl) runs
-# the digest unbounded rather than emitting nothing, and says so in the digest.
+# Hosts without timeout, gtimeout, or perl use the shared pure-Bash watchdog, so
+# the digest never runs without the same hard bound and process-group cleanup.
 #
 # Usage: fm-session-start.sh [--reemit]
 #   Prints the full ordered digest to stdout and always exits 0: this is a
@@ -168,52 +168,44 @@ stage() {  # <stage-name>: breadcrumb for the parent's truncation banner
 # shellcheck source=bin/fm-timeout-lib.sh
 . "$SCRIPT_DIR/fm-timeout-lib.sh"
 
-SESSION_START_UNBOUNDED=0
 if [ -z "${FM_SESSION_START_STAGE_FILE:-}" ]; then
   SESSION_START_BUDGET=${FM_SESSION_START_TIMEOUT:-120}
   # A non-positive or non-numeric budget is not a budget (`timeout 0` disables
   # the deadline outright), so an unusable value falls back to the default
   # rather than silently removing the bound.
   case "$SESSION_START_BUDGET" in ''|*[!0-9]*|0) SESSION_START_BUDGET=120 ;; esac
-  if [ "$(fm_timeout_mechanism)" = none ]; then
-    # No bounding mechanism on this host. Running unbounded in-process is
-    # strictly better than emitting no digest at all, and the digest says so
-    # inline so the fact reaches the agent instead of only this comment.
-    SESSION_START_UNBOUNDED=1
-  else
-    SESSION_START_STAGE_FILE=$(mktemp "${TMPDIR:-/tmp}/fm-session-start-stage.XXXXXX" 2>/dev/null) || SESSION_START_STAGE_FILE=
-    if [ -z "$SESSION_START_STAGE_FILE" ]; then
-      # Without a breadcrumb the bound still holds; only the banner's precision
-      # is lost, so the child still runs bounded.
-      SESSION_START_STAGE_FILE=/dev/null
-    fi
-    fm_run_timed "$SESSION_START_BUDGET" \
-      env FM_SESSION_START_STAGE_FILE="$SESSION_START_STAGE_FILE" \
-      "$SCRIPT_DIR/fm-session-start.sh" "$@"
-    SESSION_START_RC=$?
-    if [ "$SESSION_START_RC" -eq 124 ]; then
-      SESSION_START_LAST_STAGE=$(cat "$SESSION_START_STAGE_FILE" 2>/dev/null) || SESSION_START_LAST_STAGE=
-      [ -n "$SESSION_START_LAST_STAGE" ] || SESSION_START_LAST_STAGE=unknown
-      SESSION_START_PENDING=$(
-        printf '%s\n' "$SESSION_START_STAGES" | tr ' ' '\n' |
-          awk -v from="$SESSION_START_LAST_STAGE" '$0 == from {seen = 1} seen' | tr '\n' ' '
-      )
-      [ -n "${SESSION_START_PENDING# }" ] || SESSION_START_PENDING='(unknown - the digest may be incomplete anywhere)'
-      BAR='●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━'
-      printf '\n%s\n' "$BAR"
-      printf '●  STARTUP TRUNCATED - SESSION START HIT ITS %ss RUNTIME BOUND\n' "$SESSION_START_BUDGET"
-      printf '●  It stopped during the "%s" stage, so everything above is COMPLETE\n' "$SESSION_START_LAST_STAGE"
-      printf '●  only up to that point.\n'
-      printf '●  RECONCILE these stages before acting on anything they would have shown:\n'
-      printf '●    %s\n' "${SESSION_START_PENDING% }"
-      printf '●  Rerun bin/fm-session-start.sh now to finish taking the helm. If it truncates\n'
-      printf '●  again, raise FM_SESSION_START_TIMEOUT and report the slow stage - a stage that\n'
-      printf '●  cannot finish inside the bound is a fleet problem, not a reporting detail.\n'
-      printf '%s\n' "$BAR"
-    fi
-    rm -f "$SESSION_START_STAGE_FILE" 2>/dev/null || true
-    exit 0
+  SESSION_START_STAGE_FILE=$(mktemp "${TMPDIR:-/tmp}/fm-session-start-stage.XXXXXX" 2>/dev/null) || SESSION_START_STAGE_FILE=
+  if [ -z "$SESSION_START_STAGE_FILE" ]; then
+    # Without a breadcrumb the bound still holds; only the banner's precision
+    # is lost, so the child still runs bounded.
+    SESSION_START_STAGE_FILE=/dev/null
   fi
+  fm_run_timed "$SESSION_START_BUDGET" \
+    env FM_SESSION_START_STAGE_FILE="$SESSION_START_STAGE_FILE" \
+    "$SCRIPT_DIR/fm-session-start.sh" "$@"
+  SESSION_START_RC=$?
+  if [ "$SESSION_START_RC" -eq 124 ]; then
+    SESSION_START_LAST_STAGE=$(cat "$SESSION_START_STAGE_FILE" 2>/dev/null) || SESSION_START_LAST_STAGE=
+    [ -n "$SESSION_START_LAST_STAGE" ] || SESSION_START_LAST_STAGE=unknown
+    SESSION_START_PENDING=$(
+      printf '%s\n' "$SESSION_START_STAGES" | tr ' ' '\n' |
+        awk -v from="$SESSION_START_LAST_STAGE" '$0 == from {seen = 1} seen' | tr '\n' ' '
+    )
+    [ -n "${SESSION_START_PENDING# }" ] || SESSION_START_PENDING='(unknown - the digest may be incomplete anywhere)'
+    BAR='●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━'
+    printf '\n%s\n' "$BAR"
+    printf '●  STARTUP TRUNCATED - SESSION START HIT ITS %ss RUNTIME BOUND\n' "$SESSION_START_BUDGET"
+    printf '●  It stopped during the "%s" stage, so everything above is COMPLETE\n' "$SESSION_START_LAST_STAGE"
+    printf '●  only up to that point.\n'
+    printf '●  RECONCILE these stages before acting on anything they would have shown:\n'
+    printf '●    %s\n' "${SESSION_START_PENDING% }"
+    printf '●  Rerun bin/fm-session-start.sh now to finish taking the helm. If it truncates\n'
+    printf '●  again, raise FM_SESSION_START_TIMEOUT and report the slow stage - a stage that\n'
+    printf '●  cannot finish inside the bound is a fleet problem, not a reporting detail.\n'
+    printf '%s\n' "$BAR"
+  fi
+  rm -f "$SESSION_START_STAGE_FILE" 2>/dev/null || true
+  exit 0
 fi
 
 PRIMARY_HARNESS=$("$SCRIPT_DIR/fm-harness.sh" 2>/dev/null || printf unknown)
@@ -375,11 +367,6 @@ if [ "$REEMIT" -eq 1 ]; then
 else
   section "SESSION START - $FM_HOME"
 fi
-if [ "$SESSION_START_UNBOUNDED" -eq 1 ]; then
-  printf 'NOTICE: this host has no timeout, gtimeout, or perl, so the digest ran with no\n'
-  printf 'runtime bound. If it ever hangs, kill it and install coreutils.\n'
-fi
-
 # --- 1. lock -----------------------------------------------------------
 stage lock
 subsection "LOCK"

--- a/bin/fm-session-start.sh
+++ b/bin/fm-session-start.sh
@@ -36,16 +36,21 @@
 #                       locked.
 #   3. wake-drain     - mutates the durable wake queue, so it also only runs
 #                       when locked.
-#   4. context digest - data/projects.md, data/secondmates.md, data/captain.md,
+#   4. supervision-instructions - the one emitted operating block for the
+#                       detected primary harness.
+#   5. context digest - data/projects.md, data/secondmates.md, data/captain.md,
 #                       data/captain-shared.md, data/learnings.md: read-only,
 #                       always safe, always runs.
-#   5. fleet digest   - a compact data/backlog.md identity/metadata listing,
+#   6. fleet digest   - a compact data/backlog.md identity/metadata listing,
 #                       every state/*.meta, a bounded state/*.status tail,
 #                       state/.afk, and a cheap per-task endpoint-liveness read:
 #                       read-only, always runs.
-#   6. closing reminder - prints the context-specific watcher next step; this
+#   7. closing reminder - prints the context-specific watcher next step; this
 #                       script points back to the emitted harness supervision
 #                       block and deliberately never arms the watcher itself.
+#
+# Those seven names are also the runtime-bound stage list below, so a truncated
+# startup can name exactly which of them never ran.
 #
 # On a Pi primary, the supervision-block step also checks whether Pi's two
 # tracked primary extensions are loaded and prints a PI_WATCH_EXTENSION
@@ -86,11 +91,43 @@
 # compatible tasks-axi is available, or `data/backlog.md` when the file body is
 # truly needed.
 #
-# Usage: fm-session-start.sh
+# RUNTIME BOUND: the digest is now executed on a session-open hook (see
+# bin/fm-sessionstart-run.sh), which blocks session initialization while it
+# runs, so an unbounded digest is no longer merely slow - it can strand a whole
+# session behind one hung subprocess. Not every step is individually bounded:
+# bootstrap's fleet sync is, but its `gh auth status` probe, tool version
+# probes, and secondmate liveness reads are not, and neither are the backlog
+# listing or the per-task endpoint reads. So the whole digest runs as ONE
+# bounded child of this script (FM_SESSION_START_TIMEOUT, default 120s). The
+# child writes the digest straight to this script's stdout, so everything it
+# emitted before the bound was hit is already delivered; the parent then prints
+# a loud STARTUP TRUNCATED banner naming the stage that did not finish and the
+# sections that were therefore never emitted, and still exits 0. The child
+# records its progress in FM_SESSION_START_STAGE_FILE, which is also the flag
+# that tells a child it is the child - the parent never recurses.
+# A host with no bounding mechanism at all (no timeout, gtimeout, or perl) runs
+# the digest unbounded rather than emitting nothing, and says so in the digest.
+#
+# Usage: fm-session-start.sh [--reemit]
 #   Prints the full ordered digest to stdout and always exits 0: this is a
 #   reporting command, not a gate. A lock refusal is reported as a loud
 #   banner inline, never a silent failure or a non-zero exit that would make
 #   an agent skip the rest of the digest.
+#
+#   --reemit  This process ALREADY took the helm at its own startup and has
+#             only lost its context (a /clear or a compaction). Skip the
+#             mutating sweeps that startup already reconciled - the stale Herdr
+#             projection cleanup and bootstrap's six mutating sweeps (fleet
+#             sync, secondmate convergence and liveness, PR-check migration,
+#             pending remote handoff retry, X-mode artifact writes) - and
+#             re-emit the rest. The wake-queue drain is NOT skipped: queued
+#             records are this turn's work queue, they arrived after startup,
+#             and a session that owns the lock is exactly the session that must
+#             take them. Lock acquisition still runs, because ownership must be
+#             re-verified rather than assumed: fm-lock.sh already treats a lock
+#             this session's own harness holds as its own, so the re-emit
+#             proceeds, while a lock another live session took meanwhile still
+#             produces the ordinary read-only path.
 set -u
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -99,6 +136,85 @@ FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
 STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
 DATA="${FM_DATA_OVERRIDE:-$FM_HOME/data}"
 CONFIG="${FM_CONFIG_OVERRIDE:-$FM_HOME/config}"
+
+REEMIT=0
+for arg in "$@"; do
+  case "$arg" in
+    --reemit) REEMIT=1 ;;
+    -h|--help)
+      sed -n '2,/^set -u$/p' "$SCRIPT_DIR/fm-session-start.sh" | sed 's/^# \{0,1\}//; $d'
+      exit 0
+      ;;
+    *)
+      printf 'fm-session-start: unknown argument: %s\n' "$arg" >&2
+      printf 'usage: fm-session-start.sh [--reemit]\n' >&2
+      exit 2
+      ;;
+  esac
+done
+
+# --- 0. runtime bound ---------------------------------------------------------
+# The ordered stage list is the contract behind the truncation banner: the child
+# names the stage it is entering, and the parent reports every stage at or after
+# that one as never emitted. Keep it in the exact order the digest prints.
+SESSION_START_STAGES='lock bootstrap wake-queue supervision-instructions context fleet-state next-step'
+
+stage() {  # <stage-name>: breadcrumb for the parent's truncation banner
+  [ -n "${FM_SESSION_START_STAGE_FILE:-}" ] || return 0
+  printf '%s\n' "$1" > "$FM_SESSION_START_STAGE_FILE" 2>/dev/null || true
+}
+
+# shellcheck source=bin/fm-timeout-lib.sh
+. "$SCRIPT_DIR/fm-timeout-lib.sh"
+
+SESSION_START_UNBOUNDED=0
+if [ -z "${FM_SESSION_START_STAGE_FILE:-}" ]; then
+  SESSION_START_BUDGET=${FM_SESSION_START_TIMEOUT:-120}
+  # A non-positive or non-numeric budget is not a budget (`timeout 0` disables
+  # the deadline outright), so an unusable value falls back to the default
+  # rather than silently removing the bound.
+  case "$SESSION_START_BUDGET" in ''|*[!0-9]*|0) SESSION_START_BUDGET=120 ;; esac
+  if [ "$(fm_timeout_mechanism)" = none ]; then
+    # No bounding mechanism on this host. Running unbounded in-process is
+    # strictly better than emitting no digest at all, and the digest says so
+    # inline so the fact reaches the agent instead of only this comment.
+    SESSION_START_UNBOUNDED=1
+  else
+    SESSION_START_STAGE_FILE=$(mktemp "${TMPDIR:-/tmp}/fm-session-start-stage.XXXXXX" 2>/dev/null) || SESSION_START_STAGE_FILE=
+    if [ -z "$SESSION_START_STAGE_FILE" ]; then
+      # Without a breadcrumb the bound still holds; only the banner's precision
+      # is lost, so the child still runs bounded.
+      SESSION_START_STAGE_FILE=/dev/null
+    fi
+    fm_run_timed "$SESSION_START_BUDGET" \
+      env FM_SESSION_START_STAGE_FILE="$SESSION_START_STAGE_FILE" \
+      "$SCRIPT_DIR/fm-session-start.sh" "$@"
+    SESSION_START_RC=$?
+    if [ "$SESSION_START_RC" -eq 124 ]; then
+      SESSION_START_LAST_STAGE=$(cat "$SESSION_START_STAGE_FILE" 2>/dev/null) || SESSION_START_LAST_STAGE=
+      [ -n "$SESSION_START_LAST_STAGE" ] || SESSION_START_LAST_STAGE=unknown
+      SESSION_START_PENDING=$(
+        printf '%s\n' "$SESSION_START_STAGES" | tr ' ' '\n' |
+          awk -v from="$SESSION_START_LAST_STAGE" '$0 == from {seen = 1} seen' | tr '\n' ' '
+      )
+      [ -n "${SESSION_START_PENDING# }" ] || SESSION_START_PENDING='(unknown - the digest may be incomplete anywhere)'
+      BAR='●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━'
+      printf '\n%s\n' "$BAR"
+      printf '●  STARTUP TRUNCATED - SESSION START HIT ITS %ss RUNTIME BOUND\n' "$SESSION_START_BUDGET"
+      printf '●  It stopped during the "%s" stage, so everything above is COMPLETE\n' "$SESSION_START_LAST_STAGE"
+      printf '●  only up to that point.\n'
+      printf '●  RECONCILE these stages before acting on anything they would have shown:\n'
+      printf '●    %s\n' "${SESSION_START_PENDING% }"
+      printf '●  Rerun bin/fm-session-start.sh now to finish taking the helm. If it truncates\n'
+      printf '●  again, raise FM_SESSION_START_TIMEOUT and report the slow stage - a stage that\n'
+      printf '●  cannot finish inside the bound is a fleet problem, not a reporting detail.\n'
+      printf '%s\n' "$BAR"
+    fi
+    rm -f "$SESSION_START_STAGE_FILE" 2>/dev/null || true
+    exit 0
+  fi
+fi
+
 PRIMARY_HARNESS=$("$SCRIPT_DIR/fm-harness.sh" 2>/dev/null || printf unknown)
 
 # shellcheck source=bin/fm-backend.sh
@@ -247,9 +363,24 @@ pi_extension_loaded() {
   [ "$marker_version" = "$expected_version" ] && [ "$marker_pid" = "$lock_pid" ]
 }
 
-section "SESSION START - $FM_HOME"
+if [ "$REEMIT" -eq 1 ]; then
+  section "SESSION START (CONTEXT RE-EMIT) - $FM_HOME"
+  printf 'This session already took the helm at its own startup and has only lost its\n'
+  printf 'context. Lock ownership is re-verified and the durable records below are\n'
+  printf 'reprinted, but the sweeps startup already reconciled - project clone refresh,\n'
+  printf 'secondmate convergence and liveness, PR-check migration, pending remote handoff\n'
+  printf 'retry, X-mode artifact writes, and stale Herdr child cleanup - are NOT repeated.\n'
+  printf 'Queued wakes ARE still drained: they arrived after startup and are this turn work.\n'
+else
+  section "SESSION START - $FM_HOME"
+fi
+if [ "$SESSION_START_UNBOUNDED" -eq 1 ]; then
+  printf 'NOTICE: this host has no timeout, gtimeout, or perl, so the digest ran with no\n'
+  printf 'runtime bound. If it ever hangs, kill it and install coreutils.\n'
+fi
 
 # --- 1. lock -----------------------------------------------------------
+stage lock
 subsection "LOCK"
 LOCK_OUT=$("$SCRIPT_DIR/fm-lock.sh" 2>&1)
 LOCK_RC=$?
@@ -276,9 +407,12 @@ if [ "$READ_ONLY" -eq 0 ]; then
 fi
 
 # --- 2. bootstrap --------------------------------------------------------
+stage bootstrap
 subsection "BOOTSTRAP"
 if [ "$READ_ONLY" -eq 1 ]; then
   BOOT_OUT=$(FM_BOOTSTRAP_DETECT_ONLY=1 "$SCRIPT_DIR/fm-bootstrap.sh" 2>&1)
+elif [ "$REEMIT" -eq 1 ]; then
+  BOOT_OUT=$(FM_BOOTSTRAP_DETECT_ONLY=1 FM_BOOTSTRAP_LOCKED=1 "$SCRIPT_DIR/fm-bootstrap.sh" 2>&1)
 else
   BOOT_OUT=$(
     "$SCRIPT_DIR/fm-herdr-session-cleanup.sh" 2>&1 || true
@@ -301,6 +435,7 @@ fi
 # authority, and another session may be actively draining it. It still runs
 # fm-guard.sh directly with non-mutating advisory text, so the same alarms
 # surface without repair commands.
+stage wake-queue
 subsection "WAKE QUEUE"
 if [ "$READ_ONLY" -eq 1 ]; then
   QLEN=0
@@ -318,6 +453,7 @@ else
 fi
 
 # --- 4. supervision operating instructions ----------------------------------
+stage supervision-instructions
 AFK_PRESENT=0
 [ -e "$STATE/.afk" ] && AFK_PRESENT=1
 X_MODE_PRESENT=0
@@ -344,7 +480,8 @@ fi
   --afk "$AFK_PRESENT" \
   --x-mode "$X_MODE_PRESENT"
 
-# --- 4. context digest -----------------------------------------------------
+# --- 5. context digest -----------------------------------------------------
+stage context
 section "CONTEXT"
 print_file_or_absent "$DATA/projects.md" "data/projects.md"
 print_file_or_absent "$DATA/secondmates.md" "data/secondmates.md"
@@ -352,7 +489,8 @@ print_file_or_absent "$DATA/captain.md" "data/captain.md"
 print_file_or_absent "$DATA/captain-shared.md" "data/captain-shared.md (shared, main-authoritative, read-only in secondmate homes)"
 print_file_or_absent "$DATA/learnings.md" "data/learnings.md"
 
-# --- 5. fleet-state digest ---------------------------------------------
+# --- 6. fleet-state digest ---------------------------------------------
+stage fleet-state
 section "FLEET STATE"
 print_backlog_compact "$DATA/backlog.md" "data/backlog.md"
 
@@ -423,7 +561,8 @@ if fm_pf_relay_active "$FM_HOME" \
   fi
 fi
 
-# --- 6. closing reminder -----------------------------------------------
+# --- 7. closing reminder -----------------------------------------------
+stage next-step
 section "NEXT STEP"
 if [ "$READ_ONLY" -eq 1 ]; then
   cat <<'EOF'

--- a/bin/fm-session-start.sh
+++ b/bin/fm-session-start.sh
@@ -136,6 +136,7 @@ FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
 STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
 DATA="${FM_DATA_OVERRIDE:-$FM_HOME/data}"
 CONFIG="${FM_CONFIG_OVERRIDE:-$FM_HOME/config}"
+COMPLETION_FILE="$STATE/.session-start-complete"
 
 REEMIT=0
 for arg in "$@"; do
@@ -403,6 +404,9 @@ if [ "$LOCK_RC" -ne 0 ]; then
   }
 fi
 if [ "$READ_ONLY" -eq 0 ]; then
+  if [ "$REEMIT" -eq 0 ]; then
+    rm -f "$COMPLETION_FILE" 2>/dev/null || true
+  fi
   fm_trace_context_session_start "$CONFIG" "$STATE/.trace-context-effective"
 fi
 
@@ -606,5 +610,21 @@ of this command. Re-read a file only if this digest flagged it ABSENT (then
 rebuild or create it per AGENTS.md), its contents looked unparseable/corrupt,
 or an individual full status log is needed for older wake-event history.
 EOF
+
+if [ "$READ_ONLY" -eq 0 ] && [ "$REEMIT" -eq 0 ]; then
+  COMPLETION_PID=$(cat "$STATE/.lock" 2>/dev/null || true)
+  case "$COMPLETION_PID" in
+    ''|*[!0-9]*) COMPLETION_PID= ;;
+  esac
+  COMPLETION_TMP=$(mktemp "$STATE/.session-start-complete.XXXXXX" 2>/dev/null || true)
+  if [ -n "$COMPLETION_PID" ] && [ -n "$COMPLETION_TMP" ] \
+    && printf '%s\n' "$COMPLETION_PID" > "$COMPLETION_TMP" 2>/dev/null \
+    && mv -f "$COMPLETION_TMP" "$COMPLETION_FILE" 2>/dev/null; then
+    :
+  else
+    [ -z "$COMPLETION_TMP" ] || rm -f "$COMPLETION_TMP" 2>/dev/null || true
+    printf '\nSESSION_START_COMPLETION: not recorded - the next clear or compact will run a full startup.\n'
+  fi
+fi
 
 exit 0

--- a/bin/fm-session-start.sh
+++ b/bin/fm-session-start.sh
@@ -72,7 +72,7 @@
 # tasks-axi and quota-axi tool checks, and tasks-axi availability - none of
 # which mutate shared state and all of which are safe to compute without
 # verified lock ownership.
-# Only projection cleanup, the five bootstrap mutating sweeps, and the
+# Only projection cleanup, the six bootstrap mutating sweeps, and the
 # wake-queue drain are skipped.
 # The context and fleet-state digests
 # below are always read-only, so they run unconditionally in both modes.

--- a/bin/fm-sessionstart-run.sh
+++ b/bin/fm-sessionstart-run.sh
@@ -5,11 +5,10 @@
 # the full digest, a context re-emit, or nothing at all.
 #
 # Why running beats nudging: bin/fm-sessionstart-nudge.sh can only ASK the agent
-# to take the helm, and an agent can defer that. Observed 2026-08-01: an
-# /ahoy-first session followed the recap path and did not acquire the lock or
-# print a digest until a later request forced it. When the harness injects hook
-# stdout into model context, running the digest here removes that discretion -
-# the helm is taken before the model's first turn, whatever the first turn is.
+# to take the helm, and an agent can defer that, including when a first-command
+# skill has its own read-only path. When the harness injects hook stdout into
+# model context, running the digest here removes that discretion - the helm is
+# taken before the model's first turn, whatever the first turn is.
 #
 # Usage: fm-sessionstart-run.sh [--source <source>]
 #   --source  The harness's own session-open source. When omitted, the source is

--- a/bin/fm-sessionstart-run.sh
+++ b/bin/fm-sessionstart-run.sh
@@ -20,9 +20,9 @@
 #
 # Source routing (see docs/sessionstart-nudge.md for the per-harness names):
 #   startup, new            full digest - this process has not taken the helm
-#   clear, compact          `--reemit` digest - this process HAS the helm and
-#                           only lost its context, so the sweeps it already ran
-#                           are skipped (bin/fm-session-start.sh owns which)
+#   clear, compact          `--reemit` digest only when this lock owner recorded
+#                           a completed full startup; otherwise a full digest,
+#                           so a startup killed mid-sweep is finished first
 #   resume, reload, fork    delegate to the nudge wrapper. Prior context is
 #                           restored on these, so re-running is redundant when
 #                           this process still holds the lock (the nudge stays
@@ -40,6 +40,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
 FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
 STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
+COMPLETION_FILE="$STATE/.session-start-complete"
 
 # shellcheck source=bin/fm-gate-refuse-lib.sh
 . "$SCRIPT_DIR/fm-gate-refuse-lib.sh"
@@ -66,6 +67,16 @@ done
 fm_is_gate_agent "$FM_ROOT" && exit 0
 fm_primary_scope_matches "$FM_ROOT" "$STATE" || exit 0
 
+session_start_completed() {
+  local lock_pid completion_pid
+  [ -f "$STATE/.lock" ] && [ ! -L "$STATE/.lock" ] || return 1
+  [ -f "$COMPLETION_FILE" ] && [ ! -L "$COMPLETION_FILE" ] || return 1
+  lock_pid=$(cat "$STATE/.lock" 2>/dev/null) || return 1
+  completion_pid=$(cat "$COMPLETION_FILE" 2>/dev/null) || return 1
+  case "$lock_pid" in ''|*[!0-9]*) return 1 ;; esac
+  [ "$completion_pid" = "$lock_pid" ]
+}
+
 if [ -z "$SOURCE" ] && [ ! -t 0 ]; then
   # Claude and Codex both deliver a JSON SessionStart payload on stdin whose
   # `source` field carries startup|resume|clear|compact. Parsed without jq so a
@@ -90,7 +101,11 @@ case "$SOURCE" in
     exec "$SCRIPT_DIR/fm-sessionstart-nudge.sh"
     ;;
   clear|compact)
-    "$SCRIPT_DIR/fm-session-start.sh" --reemit || true
+    if session_start_completed; then
+      "$SCRIPT_DIR/fm-session-start.sh" --reemit || true
+    else
+      "$SCRIPT_DIR/fm-session-start.sh" || true
+    fi
     ;;
   *)
     "$SCRIPT_DIR/fm-session-start.sh" || true

--- a/bin/fm-sessionstart-run.sh
+++ b/bin/fm-sessionstart-run.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# Session-open entry point for harnesses that RUN the digest instead of asking
+# the agent to. It is the one command those harnesses' session-open adapters
+# invoke, and it decides, from the session-open source, whether this open needs
+# the full digest, a context re-emit, or nothing at all.
+#
+# Why running beats nudging: bin/fm-sessionstart-nudge.sh can only ASK the agent
+# to take the helm, and an agent can defer that. Observed 2026-08-01: an
+# /ahoy-first session followed the recap path and did not acquire the lock or
+# print a digest until a later request forced it. When the harness injects hook
+# stdout into model context, running the digest here removes that discretion -
+# the helm is taken before the model's first turn, whatever the first turn is.
+#
+# Usage: fm-sessionstart-run.sh [--source <source>]
+#   --source  The harness's own session-open source. When omitted, the source is
+#             read from a Claude/Codex-shaped JSON hook payload on stdin
+#             (the `source` field). An unreadable or unrecognized source is
+#             treated as `startup`, because taking the helm redundantly is
+#             cheap and idempotent while not taking it is the whole bug.
+#
+# Source routing (see docs/sessionstart-nudge.md for the per-harness names):
+#   startup, new            full digest - this process has not taken the helm
+#   clear, compact          `--reemit` digest - this process HAS the helm and
+#                           only lost its context, so the sweeps it already ran
+#                           are skipped (bin/fm-session-start.sh owns which)
+#   resume, reload, fork    delegate to the nudge wrapper. Prior context is
+#                           restored on these, so re-running is redundant when
+#                           this process still holds the lock (the nudge stays
+#                           silent) and a plain instruction is enough when a new
+#                           process resumed an old session (the nudge fires).
+#
+# Every path exits 0, exactly like the nudge wrapper: a Claude SessionStart
+# exit 2 blocks session initialization, so a failed session start must reach the
+# agent as digest text it can act on, never as a refusal to open the session.
+# A lock another live session holds, broken GitHub auth, and a truncated digest
+# are all reported inside the digest for exactly that reason.
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
+STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
+
+# shellcheck source=bin/fm-gate-refuse-lib.sh
+. "$SCRIPT_DIR/fm-gate-refuse-lib.sh"
+# shellcheck source=bin/fm-primary-scope-lib.sh
+. "$SCRIPT_DIR/fm-primary-scope-lib.sh"
+
+SOURCE=
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --source)
+      SOURCE=${2:-}
+      # A bare trailing --source leaves the source empty rather than aborting,
+      # so a malformed call still falls through to taking the helm.
+      if [ $# -ge 2 ]; then shift 2; else shift; fi
+      ;;
+    --source=*) SOURCE=${1#--source=}; shift ;;
+    *) shift ;;
+  esac
+done
+
+# The same two eligibility owners the nudge wrapper uses, so a no-mistakes gate
+# agent and an unmarked task worktree can never run a session start for a home
+# they do not own.
+fm_is_gate_agent "$FM_ROOT" && exit 0
+fm_primary_scope_matches "$FM_ROOT" "$STATE" || exit 0
+
+if [ -z "$SOURCE" ] && [ ! -t 0 ]; then
+  # Claude and Codex both deliver a JSON SessionStart payload on stdin whose
+  # `source` field carries startup|resume|clear|compact. Parsed without jq so a
+  # host missing it still gets correct routing rather than silent full runs.
+  # A terminal stdin is skipped outright: a hook always pipes its payload, and
+  # an operator running this by hand must not be left waiting on a read.
+  # Splitting on the quote character finds the FIRST "source" key and its value
+  # without depending on greedy-regex luck, and it cannot mistake a string VALUE
+  # of "source" for the key, because only a key is followed by a bare colon.
+  PAYLOAD=$(cat 2>/dev/null || true)
+  SOURCE=$(printf '%s' "$PAYLOAD" | awk '
+    BEGIN { RS = "\"" }
+    seen == 2 { print; exit }
+    seen == 1 && $0 ~ /^[[:space:]]*:[[:space:]]*$/ { seen = 2; next }
+    seen == 1 { seen = 0 }
+    $0 == "source" { seen = 1 }
+  ')
+fi
+
+case "$SOURCE" in
+  resume|reload|fork)
+    exec "$SCRIPT_DIR/fm-sessionstart-nudge.sh"
+    ;;
+  clear|compact)
+    "$SCRIPT_DIR/fm-session-start.sh" --reemit || true
+    ;;
+  *)
+    "$SCRIPT_DIR/fm-session-start.sh" || true
+    ;;
+esac
+exit 0

--- a/bin/fm-sessionstart-run.sh
+++ b/bin/fm-sessionstart-run.sh
@@ -46,6 +46,8 @@ COMPLETION_FILE="$STATE/.session-start-complete"
 . "$SCRIPT_DIR/fm-gate-refuse-lib.sh"
 # shellcheck source=bin/fm-primary-scope-lib.sh
 . "$SCRIPT_DIR/fm-primary-scope-lib.sh"
+# shellcheck source=bin/fm-session-lock-lib.sh
+. "$SCRIPT_DIR/fm-session-lock-lib.sh"
 
 SOURCE=
 while [ $# -gt 0 ]; do
@@ -71,6 +73,7 @@ session_start_completed() {
   local lock_pid completion_pid
   [ -f "$STATE/.lock" ] && [ ! -L "$STATE/.lock" ] || return 1
   [ -f "$COMPLETION_FILE" ] && [ ! -L "$COMPLETION_FILE" ] || return 1
+  fm_session_lock_owned_by_self "$STATE" || return 1
   lock_pid=$(cat "$STATE/.lock" 2>/dev/null) || return 1
   completion_pid=$(cat "$COMPLETION_FILE" 2>/dev/null) || return 1
   case "$lock_pid" in ''|*[!0-9]*) return 1 ;; esac

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -182,6 +182,7 @@ family_for_basename() {
     fm-codex-continuity-live-e2e.test.sh|fm-grok-continuity-live-e2e.test.sh|\
     fm-grok-stop-live-e2e.test.sh|fm-harness-liveness-drift-live-e2e.test.sh|\
     fm-opencode-primary-live-e2e.test.sh|fm-pi-primary-live-e2e.test.sh|\
+    fm-sessionstart-hook-live-e2e.test.sh|\
     fm-quota-array-dispatch-live-e2e.test.sh|fm-send-secondmate-marker-herdr-e2e.test.sh)
       printf '%s\n' live-harness-optin
       ;;
@@ -897,6 +898,20 @@ families_for_changed_path() {
     bin/fm-sessionstart-nudge.sh|bin/fm-tangle*|bin/fm-update.sh|\
     bin/fm-gate-refuse*|bin/fm-lock*|bin/fm-quota-axi-lib.sh)
       printf '%s\n' session-bootstrap
+      ;;
+    bin/fm-sessionstart-run.sh|.claude/settings.json|.codex/hooks.json|\
+    .pi/extensions/fm-primary-turnend-guard.ts)
+      # The run tier's two harness-supplied facts (source vocabulary and
+      # context-reset stdout injection) only show up against a real harness.
+      printf '%s\n' session-bootstrap
+      printf '%s\n' live-harness-optin
+      ;;
+    bin/fm-timeout-lib.sh)
+      # The shared hard bound: session start's runtime bound, the fleet/bearings
+      # snapshots, and the vendor auth probe all depend on it.
+      printf '%s\n' session-bootstrap
+      printf '%s\n' snapshot-bearings
+      printf '%s\n' pure-contract-unit
       ;;
     bin/fm-pr-*|bin/fm-merge-local.sh|bin/fm-teardown.sh|bin/fm-review-diff.sh|\
     bin/fm-x-*|bin/fm-check*)

--- a/bin/fm-timeout-lib.sh
+++ b/bin/fm-timeout-lib.sh
@@ -90,6 +90,7 @@ fm_run_external_timeout() {
   local runner=$1 seconds=$2 status_file runner_rc command_rc
   shift 2
   status_file=$(mktemp "${TMPDIR:-/tmp}/fm-timeout-status.XXXXXX" 2>/dev/null) || return 124
+  # shellcheck disable=SC2016  # Expansion is deliberately deferred to the child shell.
   if "$runner" -k 1 "$seconds" bash -c '
     status_file=$1
     shift

--- a/bin/fm-timeout-lib.sh
+++ b/bin/fm-timeout-lib.sh
@@ -7,38 +7,83 @@
 #
 #   fm_timeout_mechanism
 #       Prints the mechanism fm_run_timed will use on this host: "timeout",
-#       "gtimeout", "perl", or "none". A caller that must not silently lose its
-#       work when no bound is available inspects this FIRST and decides; a
-#       caller for whom an unbounded call is worse than no call at all can
-#       ignore it and treat fm_run_timed's 124 as the refusal.
+#       "gtimeout", "perl", or "bash". Set FM_TIMEOUT_MECHANISM_OVERRIDE=bash
+#       to force the dependency-free fallback.
 #
 #   fm_run_timed <seconds> <command> [args...]
 #       Runs the command with a hard bound. Exit status is the command's own,
 #       except 124, which means the bound was hit (GNU timeout's convention,
-#       reproduced by the perl fallback). Returns 124 WITHOUT running anything
-#       when this host has no bounding mechanism at all - see
-#       fm_timeout_mechanism above.
+#       reproduced by the perl and bash fallbacks).
 #
 # A non-positive bound is not a bound: `timeout 0` and the perl fallback's
 # `alarm 0` both disable the deadline, so callers must reject 0 before calling.
 #
-# All three mechanisms terminate the whole process GROUP, not just the direct
+# All four mechanisms terminate the whole process GROUP, not just the direct
 # child, so a hung grandchild (a vendor CLI spawned by a wrapper script, a git
 # fetch spawned by a sweep) cannot outlive the bound. GNU/BSD `timeout` does
 # this by default because it does not run the command in the foreground process
-# group; the perl fallback does it explicitly with setpgrp plus a negative pid.
+# group; the perl fallback does it explicitly with setpgrp plus a negative pid,
+# and the bash fallback uses monitor mode to give the bounded child its own
+# process group before signaling its negative pid.
 set -u
 
 fm_timeout_mechanism() {
-  if command -v timeout >/dev/null 2>&1; then
+  if [ "${FM_TIMEOUT_MECHANISM_OVERRIDE:-}" = bash ]; then
+    printf 'bash\n'
+  elif command -v timeout >/dev/null 2>&1; then
     printf 'timeout\n'
   elif command -v gtimeout >/dev/null 2>&1; then
     printf 'gtimeout\n'
   elif command -v perl >/dev/null 2>&1; then
     printf 'perl\n'
   else
-    printf 'none\n'
+    printf 'bash\n'
   fi
+}
+
+fm_run_bash_timeout() {
+  local seconds=$1 command_status deadline_status child_pid watchdog_pid command_rc recorded_rc monitor_was_on=0
+  shift
+  command_status=$(mktemp "${TMPDIR:-/tmp}/fm-bash-timeout-command.XXXXXX" 2>/dev/null) || return 124
+  deadline_status="${command_status}.deadline"
+  case $- in *m*) monitor_was_on=1 ;; esac
+  set -m
+  (
+    set +m
+    "$@"
+    command_rc=$?
+    printf '%s\n' "$command_rc" > "$command_status"
+    exit "$command_rc"
+  ) &
+  child_pid=$!
+  (
+    set +m
+    sleep "$seconds"
+    printf 'expired\n' > "$deadline_status"
+    kill -TERM -- "-$child_pid" 2>/dev/null || true
+    sleep 0.2
+    kill -KILL -- "-$child_pid" 2>/dev/null || true
+    exit 124
+  ) &
+  watchdog_pid=$!
+  [ "$monitor_was_on" -eq 1 ] || set +m
+
+  if wait "$child_pid" 2>/dev/null; then
+    command_rc=0
+  else
+    command_rc=$?
+  fi
+  if [ -s "$deadline_status" ]; then
+    wait "$watchdog_pid" 2>/dev/null || true
+    command_rc=124
+  else
+    kill -TERM -- "-$watchdog_pid" 2>/dev/null || kill "$watchdog_pid" 2>/dev/null || true
+    wait "$watchdog_pid" 2>/dev/null || true
+    recorded_rc=$(cat "$command_status" 2>/dev/null || true)
+    case "$recorded_rc" in ''|*[!0-9]*) ;; *) command_rc=$recorded_rc ;; esac
+  fi
+  rm -f "$command_status" "$deadline_status" 2>/dev/null || true
+  return "$command_rc"
 }
 
 fm_run_external_timeout() {
@@ -79,6 +124,7 @@ fm_run_timed() {  # <seconds> <command...>
       perl -e 'my $t = shift; my $pid = fork; die "fork failed" unless defined $pid; if (!$pid) { setpgrp(0, 0); exec @ARGV } local $SIG{ALRM} = sub { kill "TERM", -$pid; select undef, undef, undef, 0.2; kill "KILL", -$pid; exit 124 }; alarm $t; waitpid $pid, 0; exit($? >> 8)' \
         "$seconds" "$@"
       ;;
+    bash) fm_run_bash_timeout "$seconds" "$@" ;;
     *) return 124 ;;
   esac
 }

--- a/bin/fm-timeout-lib.sh
+++ b/bin/fm-timeout-lib.sh
@@ -45,8 +45,8 @@ fm_run_timed() {  # <seconds> <command...>
   local seconds=$1
   shift
   case "$(fm_timeout_mechanism)" in
-    timeout) timeout --kill-after=1 "$seconds" "$@" ;;
-    gtimeout) gtimeout --kill-after=1 "$seconds" "$@" ;;
+    timeout) timeout -k 1 "$seconds" "$@" ;;
+    gtimeout) gtimeout -k 1 "$seconds" "$@" ;;
     perl)
       perl -e 'my $t = shift; my $pid = fork; die "fork failed" unless defined $pid; if (!$pid) { setpgrp(0, 0); exec @ARGV } local $SIG{ALRM} = sub { kill "TERM", -$pid; select undef, undef, undef, 0.2; kill "KILL", -$pid; exit 124 }; alarm $t; waitpid $pid, 0; exit($? >> 8)' \
         "$seconds" "$@"

--- a/bin/fm-timeout-lib.sh
+++ b/bin/fm-timeout-lib.sh
@@ -41,12 +41,40 @@ fm_timeout_mechanism() {
   fi
 }
 
+fm_run_external_timeout() {
+  local runner=$1 seconds=$2 status_file runner_rc command_rc
+  shift 2
+  status_file=$(mktemp "${TMPDIR:-/tmp}/fm-timeout-status.XXXXXX" 2>/dev/null) || return 124
+  if "$runner" -k 1 "$seconds" bash -c '
+    status_file=$1
+    shift
+    "$@"
+    command_rc=$?
+    printf "%s\n" "$command_rc" > "$status_file"
+    exit "$command_rc"
+  ' _ "$status_file" "$@"; then
+    runner_rc=0
+  else
+    runner_rc=$?
+  fi
+  command_rc=$(cat "$status_file" 2>/dev/null || true)
+  rm -f "$status_file" 2>/dev/null || true
+  case "$command_rc" in
+    ''|*[!0-9]*) ;;
+    *) [ "$command_rc" -le 255 ] && return "$command_rc" ;;
+  esac
+  case "$runner_rc" in
+    124|137) return 124 ;;
+    *) return "$runner_rc" ;;
+  esac
+}
+
 fm_run_timed() {  # <seconds> <command...>
   local seconds=$1
   shift
   case "$(fm_timeout_mechanism)" in
-    timeout) timeout -k 1 "$seconds" "$@" ;;
-    gtimeout) gtimeout -k 1 "$seconds" "$@" ;;
+    timeout) fm_run_external_timeout timeout "$seconds" "$@" ;;
+    gtimeout) fm_run_external_timeout gtimeout "$seconds" "$@" ;;
     perl)
       perl -e 'my $t = shift; my $pid = fork; die "fork failed" unless defined $pid; if (!$pid) { setpgrp(0, 0); exec @ARGV } local $SIG{ALRM} = sub { kill "TERM", -$pid; select undef, undef, undef, 0.2; kill "KILL", -$pid; exit 124 }; alarm $t; waitpid $pid, 0; exit($? >> 8)' \
         "$seconds" "$@"

--- a/bin/fm-timeout-lib.sh
+++ b/bin/fm-timeout-lib.sh
@@ -45,8 +45,8 @@ fm_run_timed() {  # <seconds> <command...>
   local seconds=$1
   shift
   case "$(fm_timeout_mechanism)" in
-    timeout) timeout "$seconds" "$@" ;;
-    gtimeout) gtimeout "$seconds" "$@" ;;
+    timeout) timeout --kill-after=1 "$seconds" "$@" ;;
+    gtimeout) gtimeout --kill-after=1 "$seconds" "$@" ;;
     perl)
       perl -e 'my $t = shift; my $pid = fork; die "fork failed" unless defined $pid; if (!$pid) { setpgrp(0, 0); exec @ARGV } local $SIG{ALRM} = sub { kill "TERM", -$pid; select undef, undef, undef, 0.2; kill "KILL", -$pid; exit 124 }; alarm $t; waitpid $pid, 0; exit($? >> 8)' \
         "$seconds" "$@"

--- a/bin/fm-timeout-lib.sh
+++ b/bin/fm-timeout-lib.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# fm-timeout-lib.sh - the single owner of bounded command execution.
+#
+# Sourced, never executed. Provides one hard-bound runner so no caller has to
+# re-derive the coreutils/BSD/perl selection, and so every bounded call in this
+# repo agrees on what "the bound was hit" means.
+#
+#   fm_timeout_mechanism
+#       Prints the mechanism fm_run_timed will use on this host: "timeout",
+#       "gtimeout", "perl", or "none". A caller that must not silently lose its
+#       work when no bound is available inspects this FIRST and decides; a
+#       caller for whom an unbounded call is worse than no call at all can
+#       ignore it and treat fm_run_timed's 124 as the refusal.
+#
+#   fm_run_timed <seconds> <command> [args...]
+#       Runs the command with a hard bound. Exit status is the command's own,
+#       except 124, which means the bound was hit (GNU timeout's convention,
+#       reproduced by the perl fallback). Returns 124 WITHOUT running anything
+#       when this host has no bounding mechanism at all - see
+#       fm_timeout_mechanism above.
+#
+# A non-positive bound is not a bound: `timeout 0` and the perl fallback's
+# `alarm 0` both disable the deadline, so callers must reject 0 before calling.
+#
+# All three mechanisms terminate the whole process GROUP, not just the direct
+# child, so a hung grandchild (a vendor CLI spawned by a wrapper script, a git
+# fetch spawned by a sweep) cannot outlive the bound. GNU/BSD `timeout` does
+# this by default because it does not run the command in the foreground process
+# group; the perl fallback does it explicitly with setpgrp plus a negative pid.
+set -u
+
+fm_timeout_mechanism() {
+  if command -v timeout >/dev/null 2>&1; then
+    printf 'timeout\n'
+  elif command -v gtimeout >/dev/null 2>&1; then
+    printf 'gtimeout\n'
+  elif command -v perl >/dev/null 2>&1; then
+    printf 'perl\n'
+  else
+    printf 'none\n'
+  fi
+}
+
+fm_run_timed() {  # <seconds> <command...>
+  local seconds=$1
+  shift
+  case "$(fm_timeout_mechanism)" in
+    timeout) timeout "$seconds" "$@" ;;
+    gtimeout) gtimeout "$seconds" "$@" ;;
+    perl)
+      perl -e 'my $t = shift; my $pid = fork; die "fork failed" unless defined $pid; if (!$pid) { setpgrp(0, 0); exec @ARGV } local $SIG{ALRM} = sub { kill "TERM", -$pid; select undef, undef, undef, 0.2; kill "KILL", -$pid; exit 124 }; alarm $t; waitpid $pid, 0; exit($? >> 8)' \
+        "$seconds" "$@"
+      ;;
+    *) return 124 ;;
+  esac
+}

--- a/bin/fm-vendor-auth-probe.sh
+++ b/bin/fm-vendor-auth-probe.sh
@@ -129,22 +129,12 @@ case "$TIMEOUT" in
   ''|*[!0-9]*|0*) TIMEOUT=20 ;;
 esac
 
-# Bounded execution, mirroring bin/fm-fleet-snapshot.sh's run_timed selection so
-# a macOS host without coreutils still gets a hard bound instead of an unbounded
-# vendor CLI call. Exit 124 means the bound was hit.
-run_timed() {  # <seconds> <command...>
-  local seconds=$1
-  shift
-  if command -v timeout >/dev/null 2>&1; then
-    timeout "$seconds" "$@"
-  elif command -v gtimeout >/dev/null 2>&1; then
-    gtimeout "$seconds" "$@"
-  elif command -v perl >/dev/null 2>&1; then
-    perl -e 'my $t = shift; my $pid = fork; die "fork failed" unless defined $pid; if (!$pid) { setpgrp(0, 0); exec @ARGV } local $SIG{ALRM} = sub { kill "TERM", -$pid; select undef, undef, undef, 0.2; kill "KILL", -$pid; exit 124 }; alarm $t; waitpid $pid, 0; exit($? >> 8)' "$seconds" "$@"
-  else
-    return 124
-  fi
-}
+# Bounded execution is owned by bin/fm-timeout-lib.sh, so a macOS host without
+# coreutils still gets a hard bound instead of an unbounded vendor CLI call.
+# Exit 124 means the bound was hit.
+# shellcheck source=bin/fm-timeout-lib.sh
+# shellcheck disable=SC1091
+. "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/fm-timeout-lib.sh"
 
 STATUS=unavailable
 VERSION=none
@@ -160,13 +150,13 @@ emit() {
 # reaches the vendor CLI's argv or stdin.
 grok_version() {
   local output
-  output=$(run_timed "$TIMEOUT" grok --version 2>/dev/null </dev/null) || { printf 'none\n'; return 0; }
+  output=$(fm_run_timed "$TIMEOUT" grok --version 2>/dev/null </dev/null) || { printf 'none\n'; return 0; }
   printf '%s\n' "$output" | sed -nE 's/.*[^0-9]([0-9]+\.[0-9]+\.[0-9]+).*/\1/p' | head -n 1 | grep . || printf 'none\n'
 }
 
 probe_grok() {
   local output first rc=0
-  output=$(run_timed "$TIMEOUT" grok models 2>/dev/null </dev/null) || rc=$?
+  output=$(fm_run_timed "$TIMEOUT" grok models 2>/dev/null </dev/null) || rc=$?
   if [ "$rc" -eq 124 ]; then
     printf 'timeout\n'
     return 0

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -19,7 +19,7 @@ The producing PR and X helpers own the fields they append, `bin/fm-classify-lib.
 Wake, watcher, away-mode, and X-specific state mechanics remain with their named scripts and reference sections rather than being duplicated into one exhaustive state tree here.
 
 `bin/fm-session-start.sh`'s header is the single owner of session-start ordering, composed commands, digest contents, and the digest's startup mechanism.
-`docs/sessionstart-nudge.md` owns the native session-open adapter mechanics that nudge the digest command.
+`docs/sessionstart-nudge.md` owns the native session-open adapter tiers that run or nudge the digest command, and the source routing between them.
 `AGENTS.md` retains the run-once and read-once operator rules, lock-refusal safety, installation consent, and direct-report recovery boundaries because those facts apply at every session start.
 Ordinary dead-direct-report recovery is owned by `stuck-crewmate-recovery`, while persistent-secondmate recovery is owned by `secondmate-provisioning`.
 

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -75,7 +75,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-crew-state.sh`       | Print one deterministic current-state line for a crew                                |
 | `fm-nm-run-lib.sh`       | Shared branch-and-code-identity attribution for no-mistakes runs                    |
 | `fm-tangle-lib.sh`       | Shared default-branch resolution and primary-checkout tangle classification          |
-| `fm-timeout-lib.sh`      | Single owner of hard-bounded command execution, including the no-bound-available case |
+| `fm-timeout-lib.sh`      | Single owner of hard-bounded command execution and its fallback watchdog |
 | `fm-supervision-lib.sh`  | Shared in-flight-work-without-fresh-watcher-beacon predicate                         |
 | `fm-ff-lib.sh`           | Shared guarded fast-forward helper for origin pulls and local secondmate syncs       |
 | `fm-lock-lib.sh`         | Shared "is this git lock provably abandoned?" proof used by teardown and fleet-sync   |

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -3,12 +3,13 @@
 The first mate drives these; interactive entrypoints work by hand too, while `*-lib.sh` files are sourced helpers.
 Each row is one purpose clause only: the script's own header comment is the authoritative description of its behavior, flags, and contracts, so read the header before first use.
 If you have changed away from the firstmate home in an interactive shell, invoke these scripts by absolute path through the repo's `bin/` directory; the scripts self-locate internally after they start.
-The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarized in [architecture.md](architecture.md#no-mistakes-gate-authority-boundary), while `docs/sessionstart-nudge.md` covers the silent hook-nudge use; `fm-gate-refuse-lib.sh`'s header owns its exact contract.
+The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarized in [architecture.md](architecture.md#no-mistakes-gate-authority-boundary), while `docs/sessionstart-nudge.md` covers the silent session-open hook use; `fm-gate-refuse-lib.sh`'s header owns its exact contract.
 
 | Script                   | Purpose                                                                              |
 | ------------------------ | ------------------------------------------------------------------------------------ |
 | `fm-session-start.sh`    | Compose lock, bootstrap, and wake drain into the single ordered session-start digest |
 | `fm-sessionstart-nudge.sh` | Print the native session-start hook nudge when the primary has not already run the digest |
+| `fm-sessionstart-run.sh` | Route a native session-open hook to the full digest, a context re-emit, or the nudge |
 | `fm-operational-input.sh` | Construct and parse the canonical cross-language operational-input protocol |
 | `fm-bootstrap.sh`        | Detect toolchain and fleet problems, run the locked session-start sweeps, and install approved tools |
 | `fm-fleet-sync.sh`       | Refresh project clones with safe fast-forwards, self-heals, `STUCK:` reports, branch pruning, and bounded recovery from an orphaned `.git/packed-refs.lock` |
@@ -74,6 +75,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-crew-state.sh`       | Print one deterministic current-state line for a crew                                |
 | `fm-nm-run-lib.sh`       | Shared branch-and-code-identity attribution for no-mistakes runs                    |
 | `fm-tangle-lib.sh`       | Shared default-branch resolution and primary-checkout tangle classification          |
+| `fm-timeout-lib.sh`      | Single owner of hard-bounded command execution, including the no-bound-available case |
 | `fm-supervision-lib.sh`  | Shared in-flight-work-without-fresh-watcher-beacon predicate                         |
 | `fm-ff-lib.sh`           | Shared guarded fast-forward helper for origin pulls and local secondmate syncs       |
 | `fm-lock-lib.sh`         | Shared "is this git lock provably abandoned?" proof used by teardown and fleet-sync   |

--- a/docs/sessionstart-nudge.md
+++ b/docs/sessionstart-nudge.md
@@ -23,15 +23,16 @@ It takes `--source <name>` when the adapter knows the source natively, and other
 | Source | Action | Why |
 | --- | --- | --- |
 | `startup`, `new` | Full digest | This process has not taken the helm. |
-| `clear`, `compact` | `--reemit` digest | This process HAS the helm and lost only its context. |
+| `clear`, `compact` | `--reemit` after a proven complete startup, otherwise full digest | This process normally has the helm and lost only its context, but an earlier hook may have been truncated after acquiring the lock. |
 | `resume`, `reload`, `fork` | Delegate to the nudge wrapper | Prior context is restored, so re-running is redundant when the lock is still ours and an instruction is enough when a new process resumed an old session. |
 | unreadable or unrecognized | Full digest | Taking the helm redundantly is cheap and idempotent; not taking it is the bug this tier exists to fix. |
 
 This deliberately inverts the previous nudge matcher, which fired on `startup|resume|clear` and excluded `compact`.
 Compaction is now covered because a compacted session has lost exactly the digest it needs, and resume is now excluded from the run because it restores that digest instead of losing it.
 
-The lock is the idempotency interlock for the whole scheme.
-`bin/fm-lock.sh` already treats a lock this session's own harness holds as its own, so a `clear` or `compact` re-emit re-verifies ownership and proceeds, while a lock another live session took meanwhile still produces the ordinary read-only digest.
+The lock and `state/.session-start-complete` together are the idempotency interlock for the whole scheme.
+The full digest clears that completion record after acquiring the lock and republishes the lock owner's pid only after every stage completes, so `clear` or `compact` cannot skip startup sweeps after a truncated run.
+`bin/fm-lock.sh` already treats a lock this session's own harness holds as its own, so a proven `clear` or `compact` re-emit re-verifies ownership and proceeds, while a lock another live session took meanwhile still produces the ordinary read-only digest.
 On a run-tier harness the nudge cannot also fire: `resume`, `reload`, and `fork` are the only sources routed to it, and on those its own ancestry check stays silent whenever this process already holds the lock.
 
 `bin/fm-session-start.sh --reemit` owns which work a re-emit skips; its header is the single owner of that list.
@@ -70,6 +71,7 @@ A lock another session holds, broken GitHub auth, and a truncated digest therefo
 
 Pi is the only adapter that injects a message rather than hook stdout, so whatever it injects must carry operational provenance or the Ahoy skill would have to guess whether it was captain-authored.
 The extension therefore encodes an unencoded digest as `session-start` operational input before sending it, and leaves the already-encoded nudge alone.
+It streams the hook to completion and retains at most 512 KiB for message delivery; an oversized digest keeps its prefix and gains a loud `PI SESSION-START DELIVERY TRUNCATED` marker instead of disappearing through Node's synchronous buffer limit.
 
 The OpenCode nudge runs only on `session.created`.
 The watcher-arm and turn-end plugins run later on `session.idle`, and the guard lets the watcher coordinator act first, so the plugins do not race for one lifecycle event.
@@ -80,8 +82,8 @@ That alternative expands trust and writes outside this repository, so Firstmate 
 ## Regression coverage
 
 `tests/fm-sessionstart-nudge.test.sh` proves both wrappers' silence for both gate signals, an unmarked linked worktree, and a missing state directory, plus the nudge wrapper's already-owned-lock silence and its exact U+2063 `FIRSTMATE_OP:`-prefixed, `session-start`-typed one-line output.
-It proves the run wrapper's source routing end to end against a real `fm-session-start.sh`, including argument and stdin-payload sources, the `--reemit` selection, resume delegation, and an unrecognized source falling through to the full digest.
-`tests/fm-session-start.test.sh` proves the runtime bound: a digest that exceeds its budget still emits its completed stages, names the incomplete stage and every stage it never reached, and exits 0.
+It proves the run wrapper's source routing end to end against a real `fm-session-start.sh`, including completion-gated `--reemit` selection, resume delegation, an unrecognized source falling through to the full digest, and bounded loud delivery of an oversized Pi digest.
+`tests/fm-session-start.test.sh` proves the runtime bound: a TERM-resistant digest that exceeds its budget is force-killed, still emits its completed stages, names the incomplete stage and every stage it never reached, leaves no completion proof, and exits 0.
 `tests/fm-pi-primary-live-e2e.test.sh` and `tests/fm-opencode-primary-live-e2e.test.sh` exercise native startup paths with first-message and later-message Ahoy regressions.
 `tests/fm-sessionstart-hook-live-e2e.test.sh` is the opt-in live guard that confirms, per installed run-tier harness, that the hook actually runs the digest and that resume is excluded.
 `tests/fm-turnend-guard.test.sh`, `tests/fm-pi-watch-extension.test.sh`, and `tests/fm-daemon.test.sh` cover marked guard, monitoring, and away-mode delivery.

--- a/docs/sessionstart-nudge.md
+++ b/docs/sessionstart-nudge.md
@@ -1,30 +1,75 @@
-# Native session-start nudge
+# Native session-start adapters
 
 AGENTS.md section 3 is the authoritative behavioral contract for session start.
-The tracked native adapters inject one instruction and never run the digest, acquire the lock, perform bootstrap work, drain notifications, or arm supervision themselves.
-The payload starts with U+2063 and the stable `FIRSTMATE_OP: ` label, carries the current `session-start` protocol kind, and retains exactly ``Run `bin/fm-session-start.sh` now, exactly once, before executing any other instructions.`` as its body.
-The Ahoy skill owns the rule that this marked operational input is never a captain-authored session boundary, including its narrow legacy compatibility cases.
+This file owns how the tracked native session-open adapters deliver it, and the compatibility limits that force two tiers rather than one.
+
+Firstmate ships two session-open tiers, and the tier is a property of the harness, not of the home.
+
+| Tier | What the adapter does | Used by |
+| --- | --- | --- |
+| Run | Executes `bin/fm-session-start.sh` in the hook and lets its full ordered digest land in model context before the first turn. | Claude, Codex, Pi / pi-signed |
+| Nudge | Prints one instruction line asking the agent to run the digest itself. | Grok, OpenCode, and every run-tier harness on a context-preserving open |
+
+The run tier exists because the nudge can only ask.
+An agent can defer an instruction: observed 2026-08-01, an `/ahoy`-first session followed the recap path and did not acquire the lock or print a digest until a later request forced it.
+Running the digest inside the hook removes that discretion, so even a session whose first command is a skill has already taken the helm.
+The nudge tier remains the floor for harnesses that cannot carry hook stdout into model context, and it is never a second contract: both tiers end in the same `bin/fm-session-start.sh`.
+
+## Source routing
+
+`bin/fm-sessionstart-run.sh` is the single owner of what a session-open source means, so no harness matcher string has to encode that policy.
+It takes `--source <name>` when the adapter knows the source natively, and otherwise reads the `source` field from a Claude/Codex-shaped JSON hook payload on stdin.
+
+| Source | Action | Why |
+| --- | --- | --- |
+| `startup`, `new` | Full digest | This process has not taken the helm. |
+| `clear`, `compact` | `--reemit` digest | This process HAS the helm and lost only its context. |
+| `resume`, `reload`, `fork` | Delegate to the nudge wrapper | Prior context is restored, so re-running is redundant when the lock is still ours and an instruction is enough when a new process resumed an old session. |
+| unreadable or unrecognized | Full digest | Taking the helm redundantly is cheap and idempotent; not taking it is the bug this tier exists to fix. |
+
+This deliberately inverts the previous nudge matcher, which fired on `startup|resume|clear` and excluded `compact`.
+Compaction is now covered because a compacted session has lost exactly the digest it needs, and resume is now excluded from the run because it restores that digest instead of losing it.
+
+The lock is the idempotency interlock for the whole scheme.
+`bin/fm-lock.sh` already treats a lock this session's own harness holds as its own, so a `clear` or `compact` re-emit re-verifies ownership and proceeds, while a lock another live session took meanwhile still produces the ordinary read-only digest.
+On a run-tier harness the nudge cannot also fire: `resume`, `reload`, and `fork` are the only sources routed to it, and on those its own ancestry check stays silent whenever this process already holds the lock.
+
+`bin/fm-session-start.sh --reemit` owns which work a re-emit skips; its header is the single owner of that list.
+
+## Runtime bound
+
+The run tier blocks session initialization while the digest runs, so `bin/fm-session-start.sh` bounds itself rather than betting on each harness's own hook timeout.
+Individual steps are not all bounded - bootstrap's fleet sync is, but its `gh auth status` probe, its tool version probes, the backlog listing, and the per-task endpoint reads are not - so the whole digest runs as one bounded child, default 120s via `FM_SESSION_START_TIMEOUT`.
+Because the child writes straight to the hook's stdout, everything emitted before the bound was hit is already delivered; the parent then prints a `STARTUP TRUNCATED` banner naming the stage that did not finish and the stages that were therefore never emitted, and still exits 0.
+The registered hook timeouts sit above that budget so the harness never preempts the banner.
 
 ## Shared wrapper and safety
 
-`bin/fm-sessionstart-nudge.sh` is the single command every harness adapter invokes.
-It sources `bin/fm-gate-refuse-lib.sh` and stays silent for a no-mistakes gate agent identified by `NO_MISTAKES_GATE` or a `.no-mistakes/repos/*.git` git-common-dir.
-It shares `bin/fm-primary-scope-lib.sh` with `bin/fm-turnend-guard.sh`, so the hooks use one primary-detection owner.
+`bin/fm-sessionstart-run.sh` and `bin/fm-sessionstart-nudge.sh` share the same two eligibility owners.
+They source `bin/fm-gate-refuse-lib.sh` and stay silent for a no-mistakes gate agent identified by `NO_MISTAKES_GATE` or a `.no-mistakes/repos/*.git` git-common-dir.
+They share `bin/fm-primary-scope-lib.sh` with `bin/fm-turnend-guard.sh`, so every hook uses one primary-detection owner.
 The Guard Predicates section of [`turnend-guard.md`](turnend-guard.md#guard-predicates) owns marker validation, plain-checkout detection, and required Firstmate-shaped paths.
 
-Before printing, the wrapper reads `state/.lock` and walks at most eight parents from its own pid in its own separate, hard-coded loop, independent of `bin/fm-lock.sh`'s ancestry walk (`fm_harness_ancestry_pid()` in `bin/fm-session-lock-lib.sh`, which now walks up to sixteen parents and can extend past a claude-named match to a still-more-ancestral one) and of Pi's `lockOwnership()`.
+The nudge payload starts with U+2063 and the stable `FIRSTMATE_OP: ` label, carries the current `session-start` protocol kind, and retains exactly ``Run `bin/fm-session-start.sh` now, exactly once, before executing any other instructions.`` as its body.
+The Ahoy skill owns the rule that this marked operational input is never a captain-authored session boundary, including its narrow legacy compatibility cases, and its own step 0 helm check is the fallback that protects a nudge-tier harness whose first command is a skill.
+
+Before printing, the nudge wrapper reads `state/.lock` and walks at most eight parents from its own pid in its own separate, hard-coded loop, independent of `bin/fm-lock.sh`'s ancestry walk (`fm_harness_ancestry_pid()` in `bin/fm-session-lock-lib.sh`, which now walks up to sixteen parents and can extend past a claude-named match to a still-more-ancestral one) and of Pi's `lockOwnership()`.
 If the lock names a live pid in that ancestry, session start already ran in this harness session and the wrapper stays silent.
-Every path exits 0, including malformed state and adapter errors, because a Claude SessionStart exit 2 blocks session initialization.
+Every path in both wrappers exits 0, including malformed state and adapter errors, because a Claude SessionStart exit 2 blocks session initialization.
+A lock another session holds, broken GitHub auth, and a truncated digest therefore all surface as digest text the agent reads and acts on, never as a refusal to open the session.
 
 ## Harness transports
 
-| Harness | Tracked transport | Current compatibility |
-| --- | --- | --- |
-| Claude | `.claude/settings.json` registers `SessionStart` for `startup`, `resume`, and `clear`, excludes `compact`, and invokes the wrapper through `CLAUDE_PROJECT_DIR`. | Native stdout context injection is supported. |
-| Codex | `.codex/hooks.json` anchors to the hook process working directory, verifies a Firstmate-shaped hook-bearing root, and executes the wrapper. | Native stdout context injection is supported. |
-| OpenCode | `.opencode/plugins/fm-primary-sessionstart-nudge.js` listens for `session.created`, runs once per session id, and calls `client.session.promptAsync` only when the wrapper prints a nudge. | Interactive TUI delivery is supported; headless `opencode run` is intentionally fail-open because the process can exit before the queued turn. |
-| Pi / pi-signed | `.pi/extensions/fm-primary-turnend-guard.ts` handles `session_start` reasons `startup`, `new`, and `resume`, then injects the wrapper output with `pi.sendMessage`. | The custom message reaches model context without racing an initial positional prompt. |
-| Grok | `.grok/hooks/fm-primary-sessionstart-nudge.json` registers a project `SessionStart` hook and invokes the wrapper through inline-defaulted `${GROK_WORKSPACE_ROOT:-}`. | The project hook runs when the checkout is trusted, but Grok currently discards hook stdout from model context, so this path is intentionally fail-open. |
+| Harness | Tier | Tracked transport | Current compatibility |
+| --- | --- | --- | --- |
+| Claude | Run | `.claude/settings.json` registers one unmatched `SessionStart` hook, invoked through `CLAUDE_PROJECT_DIR` with a 180s timeout; the wrapper reads `source` from the hook payload. | Native stdout context injection is supported. |
+| Codex | Run | `.codex/hooks.json` anchors to the hook process working directory, verifies a Firstmate-shaped hook-bearing root, and pipes the hook payload into the wrapper with a 180s timeout. | Native stdout context injection is supported under `codex exec`. The tracked PROJECT hook does not fire in Codex's interactive TUI, so a TUI primary reaches its context resets only through a global `~/.codex/hooks.json` registration; see [`verification/supervision.md`](verification/supervision.md#native-session-start-delivery). |
+| Pi / pi-signed | Run | `.pi/extensions/fm-primary-turnend-guard.ts` maps `session_start` reasons `startup`, `new`, `resume`, and `fork` onto wrapper sources, handles `session_compact` as the compaction equivalent, and injects the output with `pi.sendMessage`. | The custom message reaches model context without racing an initial positional prompt. Pi's `reload` reason is deliberately unmapped, as it always was. |
+| OpenCode | Nudge | `.opencode/plugins/fm-primary-sessionstart-nudge.js` listens for `session.created`, runs once per session id, and calls `client.session.promptAsync` only when the wrapper prints a nudge. | Interactive TUI delivery is supported; headless `opencode run` is intentionally fail-open because the process can exit before the queued turn. That early exit is also why OpenCode cannot use the run tier. |
+| Grok | Nudge | `.grok/hooks/fm-primary-sessionstart-nudge.json` registers a project `SessionStart` hook and invokes the wrapper through inline-defaulted `${GROK_WORKSPACE_ROOT:-}`. | The project hook runs when the checkout is trusted, but Grok currently discards hook stdout from model context, so this path is intentionally fail-open and cannot use the run tier. |
+
+Pi is the only adapter that injects a message rather than hook stdout, so whatever it injects must carry operational provenance or the Ahoy skill would have to guess whether it was captain-authored.
+The extension therefore encodes an unencoded digest as `session-start` operational input before sending it, and leaves the already-encoded nudge alone.
 
 The OpenCode nudge runs only on `session.created`.
 The watcher-arm and turn-end plugins run later on `session.idle`, and the guard lets the watcher coordinator act first, so the plugins do not race for one lifecycle event.
@@ -34,9 +79,11 @@ That alternative expands trust and writes outside this repository, so Firstmate 
 
 ## Regression coverage
 
-`tests/fm-sessionstart-nudge.test.sh` proves wrapper silence for both gate signals, an unmarked linked worktree, a missing state directory, and an already-owned lock.
-It proves exact U+2063 `FIRSTMATE_OP:`-prefixed, `session-start`-typed one-line output for a plain primary and a marked linked secondmate primary.
+`tests/fm-sessionstart-nudge.test.sh` proves both wrappers' silence for both gate signals, an unmarked linked worktree, and a missing state directory, plus the nudge wrapper's already-owned-lock silence and its exact U+2063 `FIRSTMATE_OP:`-prefixed, `session-start`-typed one-line output.
+It proves the run wrapper's source routing end to end against a real `fm-session-start.sh`, including argument and stdin-payload sources, the `--reemit` selection, resume delegation, and an unrecognized source falling through to the full digest.
+`tests/fm-session-start.test.sh` proves the runtime bound: a digest that exceeds its budget still emits its completed stages, names the incomplete stage and every stage it never reached, and exits 0.
 `tests/fm-pi-primary-live-e2e.test.sh` and `tests/fm-opencode-primary-live-e2e.test.sh` exercise native startup paths with first-message and later-message Ahoy regressions.
+`tests/fm-sessionstart-hook-live-e2e.test.sh` is the opt-in live guard that confirms, per installed run-tier harness, that the hook actually runs the digest and that resume is excluded.
 `tests/fm-turnend-guard.test.sh`, `tests/fm-pi-watch-extension.test.sh`, and `tests/fm-daemon.test.sh` cover marked guard, monitoring, and away-mode delivery.
 
 [`verification/supervision.md`](verification/supervision.md#native-session-start-delivery) records the active version-scoped transport evidence.

--- a/docs/sessionstart-nudge.md
+++ b/docs/sessionstart-nudge.md
@@ -8,10 +8,10 @@ Firstmate ships two session-open tiers, and the tier is a property of the harnes
 | Tier | What the adapter does | Used by |
 | --- | --- | --- |
 | Run | Executes `bin/fm-session-start.sh` in the hook and lets its ordered digest land in model context before the first turn. | Claude, `codex exec`, Pi / pi-signed |
-| Nudge | Asks the agent to run the digest through the native adapter or the tracked session-start instruction. | Grok, OpenCode, Codex interactive TUI, and every run-tier harness on a context-preserving open |
+| Nudge | Asks the agent to run the digest through the native adapter or the tracked session-start instruction. | Grok, OpenCode, Codex interactive TUI, and run-tier sources routed to the nudge |
 
 The run tier exists because the nudge can only ask.
-An agent can defer an instruction: observed 2026-08-01, an `/ahoy`-first session followed the recap path and did not acquire the lock or print a digest until a later request forced it.
+An agent can defer an instruction, including when a first-command skill has its own read-only path.
 Running the digest inside the hook removes that discretion, so even a session whose first command is a skill has already taken the helm.
 The nudge tier remains the floor for harnesses that cannot carry hook stdout into model context, and it is never a second contract: both tiers end in the same `bin/fm-session-start.sh`.
 
@@ -83,11 +83,13 @@ That alternative expands trust and writes outside this repository, so Firstmate 
 
 ## Regression coverage
 
-`tests/fm-sessionstart-nudge.test.sh` proves both wrappers' silence for both gate signals, an unmarked linked worktree, and a missing state directory, plus the nudge wrapper's already-owned-lock silence and its exact U+2063 `FIRSTMATE_OP:`-prefixed, `session-start`-typed one-line output.
+`tests/fm-sessionstart-nudge.test.sh` proves the nudge wrapper's silence for both gate signals, an unmarked linked worktree, a missing state directory, and an already-owned lock, plus its exact U+2063 `FIRSTMATE_OP:`-prefixed, `session-start`-typed one-line output.
+It separately proves the run wrapper's silence for the gate environment and an unmarked linked worktree.
 It proves the run wrapper's source routing end to end against a real `fm-session-start.sh`, including completion-gated `--reemit` selection, resume delegation, an unrecognized source falling through to the full digest, and bounded loud delivery of an oversized Pi digest.
 `tests/fm-session-start.test.sh` proves the runtime bound through the forced pure-Bash fallback: a TERM-resistant digest that exceeds its budget is force-killed with its grandchild, still emits its completed stages, names the incomplete stage and every stage it never reached, leaves no completion proof, and exits 0.
 `tests/fm-pi-primary-live-e2e.test.sh` and `tests/fm-opencode-primary-live-e2e.test.sh` exercise native startup paths with first-message and later-message Ahoy regressions.
-`tests/fm-sessionstart-hook-live-e2e.test.sh` is the opt-in live guard that confirms, per installed run-tier harness, that the hook actually runs the digest and that resume is excluded.
+`tests/fm-sessionstart-hook-live-e2e.test.sh` is the opt-in live guard that confirms each installed run-tier adapter invokes the run wrapper and delivers its output into context.
+It verifies the context-preserving reopen source for every installed run-tier harness and context-reset delivery wherever the tracked TUI surface is reachable.
 `tests/fm-turnend-guard.test.sh`, `tests/fm-pi-watch-extension.test.sh`, and `tests/fm-daemon.test.sh` cover marked guard, monitoring, and away-mode delivery.
 
 [`verification/supervision.md`](verification/supervision.md#native-session-start-delivery) records the active version-scoped transport evidence.

--- a/docs/sessionstart-nudge.md
+++ b/docs/sessionstart-nudge.md
@@ -3,12 +3,12 @@
 AGENTS.md section 3 is the authoritative behavioral contract for session start.
 This file owns how the tracked native session-open adapters deliver it, and the compatibility limits that force two tiers rather than one.
 
-Firstmate ships two session-open tiers, and the tier is a property of the harness, not of the home.
+Firstmate ships two session-open tiers, and the tier is a property of the harness surface, not of the home.
 
 | Tier | What the adapter does | Used by |
 | --- | --- | --- |
-| Run | Executes `bin/fm-session-start.sh` in the hook and lets its full ordered digest land in model context before the first turn. | Claude, Codex, Pi / pi-signed |
-| Nudge | Prints one instruction line asking the agent to run the digest itself. | Grok, OpenCode, and every run-tier harness on a context-preserving open |
+| Run | Executes `bin/fm-session-start.sh` in the hook and lets its ordered digest land in model context before the first turn. | Claude, `codex exec`, Pi / pi-signed |
+| Nudge | Asks the agent to run the digest through the native adapter or the tracked session-start instruction. | Grok, OpenCode, Codex interactive TUI, and every run-tier harness on a context-preserving open |
 
 The run tier exists because the nudge can only ask.
 An agent can defer an instruction: observed 2026-08-01, an `/ahoy`-first session followed the recap path and did not acquire the lock or print a digest until a later request forced it.
@@ -41,6 +41,7 @@ On a run-tier harness the nudge cannot also fire: `resume`, `reload`, and `fork`
 
 The run tier blocks session initialization while the digest runs, so `bin/fm-session-start.sh` bounds itself rather than betting on each harness's own hook timeout.
 Individual steps are not all bounded - bootstrap's fleet sync is, but its `gh auth status` probe, its tool version probes, the backlog listing, and the per-task endpoint reads are not - so the whole digest runs as one bounded child, default 120s via `FM_SESSION_START_TIMEOUT`.
+The shared timeout owner falls back to a pure-Bash process-group watchdog when timeout, gtimeout, and perl are unavailable, so no supported host runs the digest unbounded.
 Because the child writes straight to the hook's stdout, everything emitted before the bound was hit is already delivered; the parent then prints a `STARTUP TRUNCATED` banner naming the stage that did not finish and the stages that were therefore never emitted, and still exits 0.
 The registered hook timeouts sit above that budget so the harness never preempts the banner.
 
@@ -64,14 +65,15 @@ A lock another session holds, broken GitHub auth, and a truncated digest therefo
 | Harness | Tier | Tracked transport | Current compatibility |
 | --- | --- | --- | --- |
 | Claude | Run | `.claude/settings.json` registers one unmatched `SessionStart` hook, invoked through `CLAUDE_PROJECT_DIR` with a 180s timeout; the wrapper reads `source` from the hook payload. | Native stdout context injection is supported. |
-| Codex | Run | `.codex/hooks.json` anchors to the hook process working directory, verifies a Firstmate-shaped hook-bearing root, and pipes the hook payload into the wrapper with a 180s timeout. | Native stdout context injection is supported under `codex exec`. The tracked PROJECT hook does not fire in Codex's interactive TUI, so a TUI primary reaches its context resets only through a global `~/.codex/hooks.json` registration; see [`verification/supervision.md`](verification/supervision.md#native-session-start-delivery). |
+| Codex exec | Run | `.codex/hooks.json` anchors to the hook process working directory, verifies a Firstmate-shaped hook-bearing root, and pipes the hook payload into the wrapper with a 180s timeout. | Native stdout context injection is supported under `codex exec`. |
+| Codex interactive TUI | Nudge | The tracked `AGENTS.md` session-start instruction and Ahoy step-zero fallback remain visible when the project hook does not fire. | Codex 0.146.0 does not fire the tracked project `SessionStart` hook in its interactive TUI. Firstmate ships no global hook and does not depend on one. |
 | Pi / pi-signed | Run | `.pi/extensions/fm-primary-turnend-guard.ts` maps `session_start` reasons `startup`, `new`, `resume`, and `fork` onto wrapper sources, handles `session_compact` as the compaction equivalent, and injects the output with `pi.sendMessage`. | The custom message reaches model context without racing an initial positional prompt. Pi's `reload` reason is deliberately unmapped, as it always was. |
 | OpenCode | Nudge | `.opencode/plugins/fm-primary-sessionstart-nudge.js` listens for `session.created`, runs once per session id, and calls `client.session.promptAsync` only when the wrapper prints a nudge. | Interactive TUI delivery is supported; headless `opencode run` is intentionally fail-open because the process can exit before the queued turn. That early exit is also why OpenCode cannot use the run tier. |
 | Grok | Nudge | `.grok/hooks/fm-primary-sessionstart-nudge.json` registers a project `SessionStart` hook and invokes the wrapper through inline-defaulted `${GROK_WORKSPACE_ROOT:-}`. | The project hook runs when the checkout is trusted, but Grok currently discards hook stdout from model context, so this path is intentionally fail-open and cannot use the run tier. |
 
 Pi is the only adapter that injects a message rather than hook stdout, so whatever it injects must carry operational provenance or the Ahoy skill would have to guess whether it was captain-authored.
 The extension therefore encodes an unencoded digest as `session-start` operational input before sending it, and leaves the already-encoded nudge alone.
-It streams the hook to completion and retains at most 512 KiB for message delivery; an oversized digest keeps its prefix and gains a loud `PI SESSION-START DELIVERY TRUNCATED` marker instead of disappearing through Node's synchronous buffer limit.
+It streams the hook to completion and retains at most 512 KiB for message delivery; this approved containment keeps the prefix and appends a loud `PI SESSION-START DELIVERY TRUNCATED` marker with direct-inspection guidance whenever the digest is incomplete.
 
 The OpenCode nudge runs only on `session.created`.
 The watcher-arm and turn-end plugins run later on `session.idle`, and the guard lets the watcher coordinator act first, so the plugins do not race for one lifecycle event.
@@ -83,7 +85,7 @@ That alternative expands trust and writes outside this repository, so Firstmate 
 
 `tests/fm-sessionstart-nudge.test.sh` proves both wrappers' silence for both gate signals, an unmarked linked worktree, and a missing state directory, plus the nudge wrapper's already-owned-lock silence and its exact U+2063 `FIRSTMATE_OP:`-prefixed, `session-start`-typed one-line output.
 It proves the run wrapper's source routing end to end against a real `fm-session-start.sh`, including completion-gated `--reemit` selection, resume delegation, an unrecognized source falling through to the full digest, and bounded loud delivery of an oversized Pi digest.
-`tests/fm-session-start.test.sh` proves the runtime bound: a TERM-resistant digest that exceeds its budget is force-killed, still emits its completed stages, names the incomplete stage and every stage it never reached, leaves no completion proof, and exits 0.
+`tests/fm-session-start.test.sh` proves the runtime bound through the forced pure-Bash fallback: a TERM-resistant digest that exceeds its budget is force-killed with its grandchild, still emits its completed stages, names the incomplete stage and every stage it never reached, leaves no completion proof, and exits 0.
 `tests/fm-pi-primary-live-e2e.test.sh` and `tests/fm-opencode-primary-live-e2e.test.sh` exercise native startup paths with first-message and later-message Ahoy regressions.
 `tests/fm-sessionstart-hook-live-e2e.test.sh` is the opt-in live guard that confirms, per installed run-tier harness, that the hook actually runs the digest and that resume is excluded.
 `tests/fm-turnend-guard.test.sh`, `tests/fm-pi-watch-extension.test.sh`, and `tests/fm-daemon.test.sh` cover marked guard, monitoring, and away-mode delivery.

--- a/docs/sessionstart-nudge.md
+++ b/docs/sessionstart-nudge.md
@@ -30,7 +30,7 @@ It takes `--source <name>` when the adapter knows the source natively, and other
 This deliberately inverts the previous nudge matcher, which fired on `startup|resume|clear` and excluded `compact`.
 Compaction is now covered because a compacted session has lost exactly the digest it needs, and resume is now excluded from the run because it restores that digest instead of losing it.
 
-The lock and `state/.session-start-complete` together are the idempotency interlock for the whole scheme.
+Current harness ownership of the lock and its matching `state/.session-start-complete` record together are the idempotency interlock for the whole scheme.
 The full digest clears that completion record after acquiring the lock and republishes the lock owner's pid only after every stage completes, so `clear` or `compact` cannot skip startup sweeps after a truncated run.
 `bin/fm-lock.sh` already treats a lock this session's own harness holds as its own, so a proven `clear` or `compact` re-emit re-verifies ownership and proceeds, while a lock another live session took meanwhile still produces the ordinary read-only digest.
 On a run-tier harness the nudge cannot also fire: `resume`, `reload`, and `fork` are the only sources routed to it, and on those its own ancestry check stays silent whenever this process already holds the lock.

--- a/docs/turnend-guard.md
+++ b/docs/turnend-guard.md
@@ -2,7 +2,7 @@
 
 This is the authoritative current contract for the "no turn ends blind" primary backstop referenced from AGENTS.md section 8.
 The predicate lives in `bin/fm-turnend-guard.sh`.
-Primary scope lives in `bin/fm-primary-scope-lib.sh`, shared with the native session-start nudge in [`sessionstart-nudge.md`](sessionstart-nudge.md).
+Primary scope lives in `bin/fm-primary-scope-lib.sh`, shared with the native session-start adapters in [`sessionstart-nudge.md`](sessionstart-nudge.md).
 Harness hook files adapt each enabled primary harness integration's turn-end mechanism to that shared predicate.
 
 Related PreToolUse guards deny unsafe commands before execution rather than detecting a blind turn end afterward.

--- a/docs/verification/supervision.md
+++ b/docs/verification/supervision.md
@@ -48,13 +48,38 @@ The earlier `sendUserMessage` counterfactual raced the positional prompt; the cu
 The installed pi-signed 0.82.0 wrapper repeated the Pi primary extension and session-start path on 2026-07-27.
 [`runtime-backends.md`](runtime-backends.md#tmux) owns the shared-ancestry evidence and authoritative selection-marker boundary.
 
+### Run-tier source vocabulary and context-reset injection
+
+The run tier depends on two facts only the vendor can supply: the session-open source it reports, and whether hook stdout reaches model context on a context-RESET open rather than only a cold one.
+Both were measured on 2026-08-05 against a throwaway Firstmate-shaped lab carrying each harness's own tracked registration with a recorder standing in for `bin/fm-sessionstart-run.sh`.
+Each open printed a source-stamped token, and the model was asked to quote that token back, so producing hook stdout could never be mistaken for delivering it.
+
+| Harness | Version verified | Cold open | Context reset | Context-preserving reopen |
+| --- | --- | --- | --- | --- |
+| Claude | 2.1.222 (Claude Code) | `source=startup`, token quoted back in both `-p` and the TUI | `/clear` reports `source=clear` and `/compact` reports `source=compact`; both re-injected a fresh token that the model quoted back | `claude --continue` reports `source=resume` |
+| Codex | codex-cli 0.146.0 | `source=startup` under `codex exec`, token quoted back | Not reachable from a tracked project registration; see the limit below | `codex exec resume --last` reports `source=resume` |
+| Pi | 0.82.0 | `source=startup`, token quoted back in both `-p` and the TUI | `/new` raises `session_start` reason `new`, which the extension maps to `clear`; the re-injected token was quoted back. Pi's `session_compact` handler was not reached, because a lab conversation stays under Pi's own compaction threshold (`Nothing to compact (session too small)`) | `pi -c` reports reason `startup`, not `resume` |
+
+Two harness-specific consequences are load-bearing rather than incidental.
+
+Codex's interactive TUI fired no project `SessionStart` hook at all in the same lab where `codex exec` fired it reliably, which matches the earlier 2026-07-28 finding for 0.145.0.
+Codex's run tier is therefore verified for `codex exec`, and a global `~/.codex/hooks.json` registration remains the known working path for its TUI.
+
+Pi disagrees with Claude and Codex on `resume`: a NEW Pi process continuing a session reports `startup`, and Pi's `resume` reason is reserved for an in-process session switch.
+That is correct for the run tier rather than a problem, because a new process holds no lock and must take the helm; the routing table in [`../sessionstart-nudge.md`](../sessionstart-nudge.md#source-routing) is written to whichever source each harness actually reports.
+
 Current deterministic and live entry points:
 
 ```sh
 tests/fm-sessionstart-nudge.test.sh
+tests/fm-session-start.test.sh
+FM_SESSIONSTART_HOOK_LIVE_E2E=1 tests/fm-sessionstart-hook-live-e2e.test.sh
 FM_PI_LIVE_E2E=1 tests/fm-pi-primary-live-e2e.test.sh
 FM_OPENCODE_LIVE_E2E=1 tests/fm-opencode-primary-live-e2e.test.sh
 ```
+
+`tests/fm-sessionstart-hook-live-e2e.test.sh` is the command that refreshes the table above; run it after every run-tier harness upgrade.
+It reports an absent harness and an unreached compaction explicitly rather than passing over them, and refuses to pass when no run-tier harness was installed at all.
 
 The Ahoy first-message boundary was reverified on 2026-07-22 with Pi 0.81.1 and OpenCode 1.17.18.
 Marked current operational input and the two exact legacy compatibility shapes selected Bearings, while genuine near-miss captain messages remained real boundaries.

--- a/docs/verification/supervision.md
+++ b/docs/verification/supervision.md
@@ -58,12 +58,25 @@ Each open printed a source-stamped token, and the model was asked to quote that 
 | --- | --- | --- | --- | --- |
 | Claude | 2.1.222 (Claude Code) | `source=startup`, token quoted back in both `-p` and the TUI | `/clear` reports `source=clear` and `/compact` reports `source=compact`; both re-injected a fresh token that the model quoted back | `claude --continue` reports `source=resume` |
 | Codex | codex-cli 0.146.0 | `source=startup` under `codex exec`, token quoted back | Not reachable from a tracked project registration; see the limit below | `codex exec resume --last` reports `source=resume` |
-| Pi | 0.82.0 | `source=startup`, token quoted back in both `-p` and the TUI | `/new` raises `session_start` reason `new`, which the extension maps to `clear`; the re-injected token was quoted back. Pi's `session_compact` handler was not reached, because a lab conversation stays under Pi's own compaction threshold (`Nothing to compact (session too small)`) | `pi -c` reports reason `startup`, not `resume` |
+| Pi | 0.82.0 | `source=startup`, token quoted back in both `-p` and the TUI | `/new` raises `session_start` reason `new`, which the extension maps to `clear`; `/compact` raises `session_compact`, and both freshly injected source-stamped tokens were quoted back | `pi -c` reports reason `startup`, not `resume` |
 
 Two harness-specific consequences are load-bearing rather than incidental.
 
 Codex's interactive TUI fired no project `SessionStart` hook at all in the same lab where `codex exec` fired it reliably, which matches the earlier 2026-07-28 finding for 0.145.0.
-Codex's run tier is therefore verified for `codex exec`, and a global `~/.codex/hooks.json` registration remains the known working path for its TUI.
+Codex's run tier is therefore verified only for `codex exec`.
+The interactive TUI remains on the tracked nudge floor through `AGENTS.md` and the Ahoy fallback; Firstmate ships no global hook and does not depend on one.
+
+Pi compaction was verified on 2026-08-05 with Pi 0.82.0 in the same throwaway lab after setting `.pi/settings.json` `compaction.keepRecentTokens` to 200 and completing one substantial assistant-prose turn before issuing `/compact`.
+Pi reported `Compacted from 7,697 tokens`, the recorder observed `session_compact`, and the model quoted the freshly injected `source=compact` token back.
+Both preconditions are load-bearing: the stock 20,000-token keep window exceeds a small lab session, and `AgentSession.compact()` aborts an in-flight turn before measuring compactable history, which otherwise discards that turn and reports `Nothing to compact (session too small)`.
+Tool output alone does not grow compactable context; the completed assistant prose does.
+
+Observed compaction output and recorder source:
+
+```text
+Compacted from 7,697 tokens
+compact
+```
 
 Pi disagrees with Claude and Codex on `resume`: a NEW Pi process continuing a session reports `startup`, and Pi's `resume` reason is reserved for an in-process session switch.
 That is correct for the run tier rather than a problem, because a new process holds no lock and must take the helm; the routing table in [`../sessionstart-nudge.md`](../sessionstart-nudge.md#source-routing) is written to whichever source each harness actually reports.
@@ -79,7 +92,7 @@ FM_OPENCODE_LIVE_E2E=1 tests/fm-opencode-primary-live-e2e.test.sh
 ```
 
 `tests/fm-sessionstart-hook-live-e2e.test.sh` is the command that refreshes the table above; run it after every run-tier harness upgrade.
-It reports an absent harness and an unreached compaction explicitly rather than passing over them, and refuses to pass when no run-tier harness was installed at all.
+It reports an absent harness explicitly, asserts Pi compaction rather than noting it, and refuses to pass when no run-tier harness was installed at all.
 
 The Ahoy first-message boundary was reverified on 2026-07-22 with Pi 0.81.1 and OpenCode 1.17.18.
 Marked current operational input and the two exact legacy compatibility shapes selected Bearings, while genuine near-miss captain messages remained real boundaries.
@@ -107,7 +120,7 @@ codex exec --dangerously-bypass-approvals-and-sandbox --dangerously-bypass-hook-
 ```
 
 The daemon refused with `managed standalone Codex install not found`, and an interactive TUI worker neither starts nor attaches to the app-server control socket, so no client can observe its turns.
-Firstmate-written project hooks under `<worktree>/.codex/hooks.json` fired for neither an interactive pane whose directory trust was granted nor `codex exec`, in both cases with `--dangerously-bypass-hook-trust`, while global `~/.codex/hooks.json` `SessionStart` hooks fired in the same runs.
+Firstmate-written project hooks under `<worktree>/.codex/hooks.json` fired for neither an interactive pane whose directory trust was granted nor `codex exec`, in both cases with `--dangerously-bypass-hook-trust`, while an untracked global probe fired in the same runs; Firstmate does not ship, install, recommend, or depend on that global path.
 Codex also exposes no `StopFailure` hook, so an API-error turn end would need separate coverage even after hook discovery works.
 The app-server protocol schema does define the required lifecycle (`turn/started`, plus a `turn/completed` status of `completed`, `interrupted`, `failed`, or `inProgress`), so the gate is a reachability problem rather than a protocol gap.
 

--- a/docs/verification/supervision.md
+++ b/docs/verification/supervision.md
@@ -120,7 +120,7 @@ codex exec --dangerously-bypass-approvals-and-sandbox --dangerously-bypass-hook-
 ```
 
 The daemon refused with `managed standalone Codex install not found`, and an interactive TUI worker neither starts nor attaches to the app-server control socket, so no client can observe its turns.
-Firstmate-written project hooks under `<worktree>/.codex/hooks.json` fired for neither an interactive pane whose directory trust was granted nor `codex exec`, in both cases with `--dangerously-bypass-hook-trust`, while an untracked global probe fired in the same runs; Firstmate does not ship, install, recommend, or depend on that global path.
+In this 2026-07-28 Codex 0.145.0 semantic-busy probe, Firstmate-written lifecycle project hooks under `<worktree>/.codex/hooks.json` fired for neither an interactive pane whose directory trust was granted nor `codex exec`, in both cases with `--dangerously-bypass-hook-trust`, while an untracked global probe fired in the same runs; Firstmate does not ship, install, recommend, or depend on that global path.
 Codex also exposes no `StopFailure` hook, so an API-error turn end would need separate coverage even after hook discovery works.
 The app-server protocol schema does define the required lifecycle (`turn/started`, plus a `turn/completed` status of `completed`, `interrupted`, `failed`, or `inProgress`), so the gate is a reachability problem rather than a protocol gap.
 

--- a/tests/fm-calm-pi-extension.test.sh
+++ b/tests/fm-calm-pi-extension.test.sh
@@ -2862,11 +2862,22 @@ test_interactive_terminal_e2e() {
   cp "$WATCH_EXT" "$project/.pi/extensions/fm-primary-pi-watch.ts"
   cp "$ROOT/.pi/extensions/fm-primary-turnend-guard.ts" "$project/.pi/extensions/fm-primary-turnend-guard.ts"
   cp \
+    "$ROOT/bin/fm-sessionstart-run.sh" \
     "$ROOT/bin/fm-sessionstart-nudge.sh" \
     "$ROOT/bin/fm-primary-scope-lib.sh" \
     "$ROOT/bin/fm-gate-refuse-lib.sh" \
     "$ROOT/bin/fm-operational-input.sh" \
     "$project/bin/"
+  # The real digest is out of scope here: this lab is about how Calm RENDERS the
+  # session-open message and whether it keeps its operational provenance, not
+  # about what session start reports. A stub keeps the run tier's real routing
+  # and the extension's real encoding in the path without dragging a whole
+  # fleet home into a rendering test.
+  cat >"$project/bin/fm-session-start.sh" <<'SH'
+#!/usr/bin/env bash
+printf 'CALM_E2E_SESSION_START_DIGEST\n'
+exit 0
+SH
   chmod +x "$project/bin/"*.sh
   cat >"$project/.pi/extensions/fm-calm-e2e-inject.ts" <<'TS'
 import {

--- a/tests/fm-secondmate-harness.test.sh
+++ b/tests/fm-secondmate-harness.test.sh
@@ -844,9 +844,13 @@ test_spawned_secondmate_uses_its_harness_supervision_model() {
     fm_write_meta "$sm/state/task.meta" "window=firstmate:fm-task" "kind=ship"
     touch "$sm/state/.last-watcher-beat"
     fakebin="$w/tmux-sm/fakebin"
+    # Point the guard at the fixture home, not at whatever checkout this suite
+    # happens to be running from. The guard also reports a tangled primary
+    # checkout, so without this the branch a contributor is working on decides
+    # whether this assertion passes.
     cat > "$fakebin/$harness" <<SH
 #!/usr/bin/env bash
-"$ROOT/bin/fm-guard.sh"
+FM_ROOT_OVERRIDE="$sm" "$ROOT/bin/fm-guard.sh"
 SH
     chmod +x "$fakebin/$harness"
     launch=$(cat "$launchlog")

--- a/tests/fm-session-start.test.sh
+++ b/tests/fm-session-start.test.sh
@@ -1276,15 +1276,16 @@ EOF
   pass "an over-budget session start emits its completed stages, names what it never reached, and exits 0"
 }
 
-test_coreutils_timeout_escalates_term_resistant_process() {
-  local fakebin="$TMP_ROOT/coreutils-kill-after" driver status=0
+test_portable_timeout_escalates_term_resistant_process() {
+  local fakebin="$TMP_ROOT/portable-kill-after" driver status=0
   mkdir -p "$fakebin"
   cat > "$fakebin/timeout" <<'SH'
 #!/usr/bin/env bash
 set -u
 kill_after=
 case "${1:-}" in
-  --kill-after=*) kill_after=${1#--kill-after=}; shift ;;
+  -k) kill_after=${2:-}; shift 2 ;;
+  *) exit 64 ;;
 esac
 seconds=${1:-}
 shift
@@ -1300,7 +1301,7 @@ wait "$child" 2>/dev/null || true
 exit 124
 SH
   chmod +x "$fakebin/timeout"
-  driver="$TMP_ROOT/coreutils-kill-after-driver.sh"
+  driver="$TMP_ROOT/portable-kill-after-driver.sh"
   cat > "$driver" <<'SH'
 #!/usr/bin/env bash
 . "$1"
@@ -1318,8 +1319,8 @@ SH
     exit($? >> 8);
   ' env PATH="$fakebin:$BASE_PATH" "$driver" "$ROOT/bin/fm-timeout-lib.sh" || status=$?
 
-  expect_code 124 "$status" "coreutils timeout TERM-resistant escalation"
-  pass "the coreutils timeout path force-kills a command that ignores TERM"
+  expect_code 124 "$status" "portable timeout TERM-resistant escalation"
+  pass "the portable timeout path force-kills a command that ignores TERM"
 }
 
 test_runtime_bound_leaves_a_healthy_digest_untouched() {
@@ -1721,7 +1722,7 @@ test_pi_diagnostic_accepts_prelock_loaded_marker
 test_pi_diagnostic_rejects_missing_turnend_guard_marker
 test_pi_diagnostic_rejects_previous_session_loaded_marker
 test_runtime_bound_truncates_loudly_and_exits_zero
-test_coreutils_timeout_escalates_term_resistant_process
+test_portable_timeout_escalates_term_resistant_process
 test_runtime_bound_leaves_a_healthy_digest_untouched
 test_runtime_bound_leaves_harness_ancestry_headroom
 test_reemit_skips_startup_sweeps_but_keeps_the_wake_drain

--- a/tests/fm-session-start.test.sh
+++ b/tests/fm-session-start.test.sh
@@ -1242,6 +1242,36 @@ SH
   chmod +x "$fakebin/$name"
 }
 
+make_term_escalating_timeout() {
+  local fakebin=$1
+  cat > "$fakebin/timeout" <<'SH'
+#!/usr/bin/env perl
+use strict;
+use warnings;
+(shift @ARGV) eq '-k' or exit 64;
+my $kill_after = shift @ARGV;
+my $seconds = shift @ARGV;
+my $pid = fork;
+defined $pid or die "fork failed";
+if (!$pid) {
+  setpgrp(0, 0);
+  exec @ARGV;
+}
+local $SIG{ALRM} = sub {
+  kill 'TERM', -$pid;
+  select undef, undef, undef, $kill_after;
+  kill 'KILL', -$pid;
+  waitpid $pid, 0;
+  exit 137;
+};
+alarm $seconds;
+waitpid $pid, 0;
+alarm 0;
+exit($? >> 8);
+SH
+  chmod +x "$fakebin/timeout"
+}
+
 test_runtime_bound_truncates_loudly_and_exits_zero() {
   local rec root home fakebin out status=0 stray
   rec=$(new_world runtime-bound)
@@ -1251,6 +1281,7 @@ EOF
   make_fake_toolchain "$fakebin"
   make_fake_ps_claude "$fakebin"
   make_hanging_tool "$fakebin" git
+  make_term_escalating_timeout "$fakebin"
 
   out=$(FM_SESSION_START_TIMEOUT=3 run_session_start "$home" "$root" "$fakebin:$BASE_PATH") || status=$?
 
@@ -1279,33 +1310,13 @@ EOF
 test_portable_timeout_escalates_term_resistant_process() {
   local fakebin="$TMP_ROOT/portable-kill-after" driver status=0
   mkdir -p "$fakebin"
-  cat > "$fakebin/timeout" <<'SH'
-#!/usr/bin/env bash
-set -u
-kill_after=
-case "${1:-}" in
-  -k) kill_after=${2:-}; shift 2 ;;
-  *) exit 64 ;;
-esac
-seconds=${1:-}
-shift
-"$@" &
-child=$!
-sleep "$seconds"
-kill -TERM "$child" 2>/dev/null || true
-if [ -n "$kill_after" ]; then
-  sleep "$kill_after"
-  kill -KILL "$child" 2>/dev/null || true
-fi
-wait "$child" 2>/dev/null || true
-exit 124
-SH
-  chmod +x "$fakebin/timeout"
+  make_term_escalating_timeout "$fakebin"
   driver="$TMP_ROOT/portable-kill-after-driver.sh"
   cat > "$driver" <<'SH'
 #!/usr/bin/env bash
 . "$1"
-fm_run_timed 1 perl -e '$SIG{TERM} = "IGNORE"; sleep 600'
+shift
+fm_run_timed 1 "$@"
 SH
   chmod +x "$driver"
 
@@ -1317,9 +1328,14 @@ SH
     alarm 5;
     waitpid $pid, 0;
     exit($? >> 8);
-  ' env PATH="$fakebin:$BASE_PATH" "$driver" "$ROOT/bin/fm-timeout-lib.sh" || status=$?
+  ' env PATH="$fakebin:$BASE_PATH" "$driver" "$ROOT/bin/fm-timeout-lib.sh" \
+    perl -e '$SIG{TERM} = "IGNORE"; sleep 600' || status=$?
 
   expect_code 124 "$status" "portable timeout TERM-resistant escalation"
+  status=0
+  env PATH="$fakebin:$BASE_PATH" "$driver" "$ROOT/bin/fm-timeout-lib.sh" \
+    bash -c 'exit 137' || status=$?
+  expect_code 137 "$status" "natural command exit 137"
   pass "the portable timeout path force-kills a command that ignores TERM"
 }
 

--- a/tests/fm-session-start.test.sh
+++ b/tests/fm-session-start.test.sh
@@ -1236,6 +1236,7 @@ make_hanging_tool() {
   local fakebin=$1 name=$2
   cat > "$fakebin/$name" <<'SH'
 #!/usr/bin/env bash
+trap '' TERM
 sleep 600
 SH
   chmod +x "$fakebin/$name"
@@ -1263,6 +1264,8 @@ EOF
   assert_contains "$out" "wake-queue supervision-instructions context fleet-state next-step" \
     "the truncation banner did not list every stage that never ran"
   assert_not_contains "$out" "NEXT STEP" "a truncated digest claimed to have reached its closing reminder"
+  assert_absent "$home/state/.session-start-complete" \
+    "a truncated startup recorded itself as complete"
 
   # The bound must reach the whole process group: a hung grandchild that
   # outlives the digest would keep holding whatever the digest was waiting on.
@@ -1271,6 +1274,52 @@ EOF
   [ "$stray" -eq 0 ] || fail "the runtime bound left $stray hung subprocess(es) behind"
 
   pass "an over-budget session start emits its completed stages, names what it never reached, and exits 0"
+}
+
+test_coreutils_timeout_escalates_term_resistant_process() {
+  local fakebin="$TMP_ROOT/coreutils-kill-after" driver status=0
+  mkdir -p "$fakebin"
+  cat > "$fakebin/timeout" <<'SH'
+#!/usr/bin/env bash
+set -u
+kill_after=
+case "${1:-}" in
+  --kill-after=*) kill_after=${1#--kill-after=}; shift ;;
+esac
+seconds=${1:-}
+shift
+"$@" &
+child=$!
+sleep "$seconds"
+kill -TERM "$child" 2>/dev/null || true
+if [ -n "$kill_after" ]; then
+  sleep "$kill_after"
+  kill -KILL "$child" 2>/dev/null || true
+fi
+wait "$child" 2>/dev/null || true
+exit 124
+SH
+  chmod +x "$fakebin/timeout"
+  driver="$TMP_ROOT/coreutils-kill-after-driver.sh"
+  cat > "$driver" <<'SH'
+#!/usr/bin/env bash
+. "$1"
+fm_run_timed 1 perl -e '$SIG{TERM} = "IGNORE"; sleep 600'
+SH
+  chmod +x "$driver"
+
+  perl -e '
+    my $pid = fork;
+    die "fork failed" unless defined $pid;
+    if (!$pid) { setpgrp(0, 0); exec @ARGV }
+    local $SIG{ALRM} = sub { kill "KILL", -$pid; waitpid $pid, 0; exit 99 };
+    alarm 5;
+    waitpid $pid, 0;
+    exit($? >> 8);
+  ' env PATH="$fakebin:$BASE_PATH" "$driver" "$ROOT/bin/fm-timeout-lib.sh" || status=$?
+
+  expect_code 124 "$status" "coreutils timeout TERM-resistant escalation"
+  pass "the coreutils timeout path force-kills a command that ignores TERM"
 }
 
 test_runtime_bound_leaves_a_healthy_digest_untouched() {
@@ -1672,6 +1721,7 @@ test_pi_diagnostic_accepts_prelock_loaded_marker
 test_pi_diagnostic_rejects_missing_turnend_guard_marker
 test_pi_diagnostic_rejects_previous_session_loaded_marker
 test_runtime_bound_truncates_loudly_and_exits_zero
+test_coreutils_timeout_escalates_term_resistant_process
 test_runtime_bound_leaves_a_healthy_digest_untouched
 test_runtime_bound_leaves_harness_ancestry_headroom
 test_reemit_skips_startup_sweeps_but_keeps_the_wake_drain

--- a/tests/fm-session-start.test.sh
+++ b/tests/fm-session-start.test.sh
@@ -1220,6 +1220,214 @@ EOF
   pass "unavailable or incompatible tasks-axi falls back to compact manual backlog rendering"
 }
 
+# --- runtime bound -----------------------------------------------------------
+#
+# The digest runs on a session-open hook that blocks session initialization, so
+# it must have a guaranteed upper bound. These cases drive REAL processes that
+# really hang, and assert the outcome the hook depends on: whatever the digest
+# already emitted survives, the agent is told exactly what it never saw, and
+# the command still exits 0 so the session can open.
+
+# make_hanging_tool <fakebin> <name>: a real, unkillable-by-timeout-alone
+# subprocess of the digest. `git` is the honest choice - the bootstrap stage
+# shells out to it - and it also proves the bound reaches a GRANDCHILD, because
+# bootstrap runs it inside its own command substitution.
+make_hanging_tool() {
+  local fakebin=$1 name=$2
+  cat > "$fakebin/$name" <<'SH'
+#!/usr/bin/env bash
+sleep 600
+SH
+  chmod +x "$fakebin/$name"
+}
+
+test_runtime_bound_truncates_loudly_and_exits_zero() {
+  local rec root home fakebin out status=0 stray
+  rec=$(new_world runtime-bound)
+  IFS='|' read -r root home fakebin <<EOF
+$rec
+EOF
+  make_fake_toolchain "$fakebin"
+  make_fake_ps_claude "$fakebin"
+  make_hanging_tool "$fakebin" git
+
+  out=$(FM_SESSION_START_TIMEOUT=3 run_session_start "$home" "$root" "$fakebin:$BASE_PATH") || status=$?
+
+  expect_code 0 "$status" "a truncated session start must still exit 0 so the session can open"
+  assert_contains "$out" "SESSION START - $home" "the truncated digest lost the output it had already produced"
+  assert_contains "$out" "LOCK" "the truncated digest lost a stage that had completed"
+  assert_contains "$out" "STARTUP TRUNCATED" "a truncated session start did not say so"
+  assert_contains "$out" "RUNTIME BOUND" "the truncation banner did not name the bound it hit"
+  assert_contains "$out" 'stopped during the "bootstrap" stage' "the truncation banner did not name the incomplete stage"
+  assert_contains "$out" "RECONCILE these stages" "the truncation banner did not tell the agent what to reconcile"
+  assert_contains "$out" "wake-queue supervision-instructions context fleet-state next-step" \
+    "the truncation banner did not list every stage that never ran"
+  assert_not_contains "$out" "NEXT STEP" "a truncated digest claimed to have reached its closing reminder"
+
+  # The bound must reach the whole process group: a hung grandchild that
+  # outlives the digest would keep holding whatever the digest was waiting on.
+  sleep 1
+  stray=$(pgrep -f "$fakebin/git" 2>/dev/null | wc -l | tr -d ' ')
+  [ "$stray" -eq 0 ] || fail "the runtime bound left $stray hung subprocess(es) behind"
+
+  pass "an over-budget session start emits its completed stages, names what it never reached, and exits 0"
+}
+
+test_runtime_bound_leaves_a_healthy_digest_untouched() {
+  local rec root home fakebin out
+  rec=$(new_world runtime-bound-healthy)
+  IFS='|' read -r root home fakebin <<EOF
+$rec
+EOF
+  make_fake_toolchain "$fakebin"
+  make_fake_ps_claude "$fakebin"
+
+  out=$(run_session_start "$home" "$root" "$fakebin:$BASE_PATH")
+
+  assert_not_contains "$out" "STARTUP TRUNCATED" "a digest that finished in time reported itself truncated"
+  assert_contains "$out" "NEXT STEP" "a digest that finished in time lost its closing reminder"
+  assert_absent "${TMPDIR:-/tmp}/fm-session-start-stage" "the stage breadcrumb leaked a fixed-name file"
+
+  pass "a session start inside its budget prints no truncation banner"
+}
+
+test_runtime_bound_leaves_harness_ancestry_headroom() {
+  local rec root home fakebin nest out
+  rec=$(new_world runtime-bound-ancestry)
+  IFS='|' read -r root home fakebin <<EOF
+$rec
+EOF
+  make_fake_toolchain "$fakebin"
+
+  # Only ONE pid in the whole tree is the harness, and it sits at the very top.
+  # fm-session-lock-lib.sh walks a BOUNDED sixteen parents to find it, and the
+  # runtime bound spends some of that budget on its own wrapper processes, so
+  # this pins that the budget still reaches a realistically deep session.
+  cat > "$fakebin/ps" <<'SH'
+#!/usr/bin/env bash
+set -u
+pid=
+previous=
+for argument in "$@"; do
+  [ "$previous" = -p ] && pid=$argument
+  previous=$argument
+done
+case "$*" in
+  *"comm="*)
+    if [ "$pid" = "${FM_FAKE_HARNESS_PID:-}" ]; then printf '%s\n' /usr/local/bin/claude
+    else printf '%s\n' /bin/bash; fi
+    ;;
+  *"args="*)
+    if [ "$pid" = "${FM_FAKE_HARNESS_PID:-}" ]; then printf '%s\n' claude
+    else printf '%s\n' bash; fi
+    ;;
+  *"ppid="*) /bin/ps -o ppid= -p "$pid" ;;
+  *) exit 1 ;;
+esac
+SH
+  chmod +x "$fakebin/ps"
+
+  # Each level forks rather than execs, so the counter really is process depth.
+  nest="$home/nest.sh"
+  cat > "$nest" <<'SH'
+#!/usr/bin/env bash
+set -u
+levels=$1
+shift
+if [ "$levels" -gt 0 ]; then
+  bash "$0" $((levels - 1)) "$@"
+  exit $?
+fi
+exec "$@"
+SH
+  chmod +x "$nest"
+
+  # shellcheck disable=SC2016 # $$ must expand in the launched shell, not here.
+  out=$(env -u CLAUDECODE -u PI_CODING_AGENT -u FM_PI_HARNESS -u GROK_AGENT \
+    FM_HOME="$home" FM_ROOT_OVERRIDE="$root" PATH="$fakebin:$BASE_PATH" \
+    bash -c 'export FM_FAKE_HARNESS_PID=$$; exec "$1" 8 "$2"' _ "$nest" "$SESSION_START")
+
+  assert_contains "$out" "lock acquired: harness pid" \
+    "the runtime bound's wrapper processes pushed the harness out of the bounded ancestry walk"
+  assert_not_contains "$out" "READ-ONLY SESSION" \
+    "a session start eight shells below its harness was wrongly refused the lock"
+
+  pass "the runtime bound leaves enough ancestry headroom for a deeply nested session to take the lock"
+}
+
+# --- context re-emit (--reemit) ----------------------------------------------
+
+test_reemit_skips_startup_sweeps_but_keeps_the_wake_drain() {
+  local rec root home fakebin full reemit
+  rec=$(new_world reemit)
+  IFS='|' read -r root home fakebin <<EOF
+$rec
+EOF
+  make_fake_toolchain "$fakebin"
+  make_fake_ps_claude "$fakebin"
+  mkdir -p "$home/other-secondmate/state"
+  fm_write_secondmate_meta "$home/state/sm-r.meta" "$home/other-secondmate" "firstmate:fm-sm-r" alpha
+  append_wake "$home/state" signal task-r "done: queued after startup" || fail "seed wake failed"
+
+  # A full startup reconciles the secondmate sweep and reports it.
+  full=$(run_session_start "$home" "$root" "$fakebin:$BASE_PATH")
+  assert_contains "$full" "SECONDMATE_LIVENESS" "the full startup fixture did not exercise a mutating sweep"
+
+  append_wake "$home/state" signal task-r "done: queued after the re-emit too" || fail "seed second wake failed"
+  reemit=$(FM_HOME="$home" FM_ROOT_OVERRIDE="$root" PATH="$fakebin:$BASE_PATH" \
+    env -u CLAUDECODE -u PI_CODING_AGENT -u FM_PI_HARNESS -u GROK_AGENT \
+    "$SESSION_START" --reemit)
+
+  assert_contains "$reemit" "SESSION START (CONTEXT RE-EMIT) - $home" "--reemit did not label itself"
+  assert_not_contains "$reemit" "SECONDMATE_LIVENESS" "--reemit repeated a mutating sweep startup already ran"
+  assert_contains "$reemit" "done: queued after the re-emit too" "--reemit did not drain the wake queue"
+  [ ! -s "$home/state/.wake-queue" ] || fail "--reemit left queued wakes behind: $(cat "$home/state/.wake-queue")"
+  assert_contains "$reemit" "CONTEXT" "--reemit dropped the context digest"
+  assert_contains "$reemit" "FLEET STATE" "--reemit dropped the fleet-state digest"
+  assert_contains "$reemit" "NEXT STEP" "--reemit dropped the closing reminder"
+
+  pass "--reemit reprints the digest without repeating startup's mutating sweeps and still drains queued wakes"
+}
+
+test_reemit_keeps_repair_ownership_with_the_lock_holder() {
+  local rec root home fakebin reemit readonly_out holder_pid
+  rec=$(new_world reemit-tangle)
+  IFS='|' read -r root home fakebin <<EOF
+$rec
+EOF
+  make_fake_toolchain "$fakebin"
+  make_fake_ps_claude "$fakebin"
+  git -C "$root" checkout -q -B fm/reemit-tangle
+
+  reemit=$(FM_HOME="$home" FM_ROOT_OVERRIDE="$root" PATH="$fakebin:$BASE_PATH" \
+    env -u CLAUDECODE -u PI_CODING_AGENT -u FM_PI_HARNESS -u GROK_AGENT \
+    "$SESSION_START" --reemit)
+
+  # A re-emit skips the sweeps because it ALREADY ran them, not because it lacks
+  # the lock, so it must still own repair rather than deferring to a lock holder.
+  assert_contains "$reemit" "restore the primary with: git -C $root checkout main" \
+    "--reemit disowned a repair it is entitled to perform"
+  assert_not_contains "$reemit" "must leave restore work to the session holding the fleet lock" \
+    "--reemit misreported itself as an unlocked read-only session"
+
+  rm -f "$home/state/.lock"
+  sleep 300 &
+  holder_pid=$!
+  printf '%s\n' "$holder_pid" > "$home/state/.lock"
+  readonly_out=$(FM_HOME="$home" FM_ROOT_OVERRIDE="$root" PATH="$fakebin:$BASE_PATH" \
+    env -u CLAUDECODE -u PI_CODING_AGENT -u FM_PI_HARNESS -u GROK_AGENT \
+    "$SESSION_START" --reemit)
+  kill "$holder_pid" 2>/dev/null || true
+  wait "$holder_pid" 2>/dev/null || true
+
+  assert_contains "$readonly_out" "READ-ONLY SESSION" \
+    "--reemit assumed lock ownership instead of re-verifying it"
+  assert_contains "$readonly_out" "must leave restore work to the session holding the fleet lock" \
+    "a lock-refused --reemit still claimed repair ownership"
+
+  pass "--reemit re-verifies lock ownership and keeps repair ownership with whoever holds it"
+}
+
 # --- fleet-state digest: no in-flight tasks ----------------------------------
 
 test_fleet_digest_empty_fleet() {
@@ -1463,5 +1671,10 @@ test_pi_diagnostic_rejects_stale_loaded_marker
 test_pi_diagnostic_accepts_prelock_loaded_marker
 test_pi_diagnostic_rejects_missing_turnend_guard_marker
 test_pi_diagnostic_rejects_previous_session_loaded_marker
+test_runtime_bound_truncates_loudly_and_exits_zero
+test_runtime_bound_leaves_a_healthy_digest_untouched
+test_runtime_bound_leaves_harness_ancestry_headroom
+test_reemit_skips_startup_sweeps_but_keeps_the_wake_drain
+test_reemit_keeps_repair_ownership_with_the_lock_holder
 
 echo "# fm-session-start.test.sh: all assertions passed"

--- a/tests/fm-session-start.test.sh
+++ b/tests/fm-session-start.test.sh
@@ -1273,7 +1273,7 @@ SH
 }
 
 test_runtime_bound_truncates_loudly_and_exits_zero() {
-  local rec root home fakebin out status=0 stray
+  local rec root home fakebin out status=0 stray mechanism
   rec=$(new_world runtime-bound)
   IFS='|' read -r root home fakebin <<EOF
 $rec
@@ -1281,9 +1281,13 @@ EOF
   make_fake_toolchain "$fakebin"
   make_fake_ps_claude "$fakebin"
   make_hanging_tool "$fakebin" git
-  make_term_escalating_timeout "$fakebin"
 
-  out=$(FM_SESSION_START_TIMEOUT=3 run_session_start "$home" "$root" "$fakebin:$BASE_PATH") || status=$?
+  mechanism=$(FM_TIMEOUT_MECHANISM_OVERRIDE=bash bash -c '. "$1"; fm_timeout_mechanism' \
+    _ "$ROOT/bin/fm-timeout-lib.sh")
+  [ "$mechanism" = bash ] || fail "the forced pure-Bash timeout fixture selected '$mechanism'"
+
+  out=$(FM_TIMEOUT_MECHANISM_OVERRIDE=bash FM_SESSION_START_TIMEOUT=3 \
+    run_session_start "$home" "$root" "$fakebin:$BASE_PATH") || status=$?
 
   expect_code 0 "$status" "a truncated session start must still exit 0 so the session can open"
   assert_contains "$out" "SESSION START - $home" "the truncated digest lost the output it had already produced"
@@ -1304,7 +1308,12 @@ EOF
   stray=$(pgrep -f "$fakebin/git" 2>/dev/null | wc -l | tr -d ' ')
   [ "$stray" -eq 0 ] || fail "the runtime bound left $stray hung subprocess(es) behind"
 
-  pass "an over-budget session start emits its completed stages, names what it never reached, and exits 0"
+  status=0
+  FM_TIMEOUT_MECHANISM_OVERRIDE=bash bash -c \
+    '. "$1"; fm_run_timed 2 bash -c "exit 137"' _ "$ROOT/bin/fm-timeout-lib.sh" || status=$?
+  expect_code 137 "$status" "pure-Bash natural command exit 137"
+
+  pass "the pure-Bash watchdog bounds session start, kills its hung grandchild, and emits the truncation contract"
 }
 
 test_portable_timeout_escalates_term_resistant_process() {

--- a/tests/fm-sessionstart-hook-live-e2e.test.sh
+++ b/tests/fm-sessionstart-hook-live-e2e.test.sh
@@ -1,0 +1,309 @@
+#!/usr/bin/env bash
+# Opt-in live guard for the RUN-tier session-open adapters (Claude, Codex, Pi).
+#
+# Two facts in this area come from the vendor, not from Firstmate, so a stub can
+# only confirm the assumption already written into the stub:
+#
+#   (a) the harness tells the hook WHICH session open this is, well enough that
+#       a context-preserving reopen is never mistaken for a context reset, and
+#   (b) hook stdout actually reaches model context on a context-RESET open
+#       (clear/compact), not only on a cold startup.
+#
+# docs/sessionstart-nudge.md owns the routing those two facts feed, and
+# tests/fm-sessionstart-nudge.test.sh pins that routing portably with real
+# processes and no harness. This guard covers only what CI cannot see.
+#
+# It swaps a RECORDER in for bin/fm-sessionstart-run.sh inside a throwaway lab
+# checkout, so nothing here touches a real home, lock, or fleet. The recorder
+# logs the source the harness supplied and prints a source-stamped token; the
+# model is then asked to quote that token back, which is the only way to prove
+# the stdout genuinely landed in context rather than merely being produced.
+# The token index advances on every open, so a stale earlier token can never
+# satisfy a later assertion and no case can go quietly vacuous.
+#
+# Run it after every harness upgrade and before trusting refreshed evidence in
+# docs/verification/supervision.md:
+#
+#   FM_SESSIONSTART_HOOK_LIVE_E2E=1 tests/fm-sessionstart-hook-live-e2e.test.sh
+#
+# It costs real model turns on every installed run-tier harness.
+set -u
+
+if [ "${FM_SESSIONSTART_HOOK_LIVE_E2E:-0}" != 1 ]; then
+  echo "skip: set FM_SESSIONSTART_HOOK_LIVE_E2E=1 to run the live session-open hook regression"
+  exit 0
+fi
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+unset NO_MISTAKES_GATE
+
+fail() {
+  printf 'not ok - %s\n' "$1" >&2
+  exit 1
+}
+pass() { printf 'ok - %s\n' "$1"; }
+note() { printf '# %s\n' "$1"; }
+
+command -v tmux >/dev/null 2>&1 || fail "tmux not found; the context-reset checks drive real interactive harnesses"
+
+# Outside the repo on purpose: each lab is its own git repo, and nesting one
+# inside the checkout would show up as an embedded repository in a working tree
+# a maintainer may be committing from while this guard runs.
+LAB="${TMPDIR:-/tmp}/fm-sessionstart-hook-live-e2e.$$"
+SOCKET="fm-ss-hook-$$"
+CHECKED=0
+ABSENT=
+
+cleanup() {
+  tmux -L "$SOCKET" kill-server >/dev/null 2>&1 || true
+  rm -rf "$LAB"
+}
+trap cleanup EXIT INT TERM
+
+capture() { tmux -L "$SOCKET" capture-pane -p -t "$1" -S -400 2>/dev/null || true; }
+
+wait_for_text() {  # <session> <text> [attempts]
+  local session=$1 expected=$2 attempts=${3:-90} i=0
+  while [ "$i" -lt "$attempts" ]; do
+    capture "$session" | grep -Fq "$expected" && return 0
+    sleep 2
+    i=$((i + 1))
+  done
+  return 1
+}
+
+send_line() {  # <session> <text>
+  tmux -L "$SOCKET" send-keys -t "$1" -l "$2"
+  sleep 2
+  tmux -L "$SOCKET" send-keys -t "$1" Enter
+}
+
+ASK='Reply with exactly the FMHOOKTOKEN value from your session-start context and nothing else.'
+
+# --- lab ---------------------------------------------------------------------
+#
+# A Firstmate-shaped checkout carrying the harness's own TRACKED registration,
+# with the wrapper replaced by a recorder, so a registration that stops firing
+# fails this guard. The other hook scripts the tracked configs reference get
+# no-op stubs: only the session-open registration is under test here, and a
+# missing turn-end guard would otherwise spray unrelated errors into the pane.
+make_lab() {  # <harness> -> echoes lab dir
+  local harness=$1
+  local lab="$LAB/$harness" stub
+  mkdir -p "$lab/bin" "$lab/state"
+  git init -q -b main "$lab"
+  git -C "$lab" config user.email fmtest@example.invalid
+  git -C "$lab" config user.name fmtest
+  printf '# Firstmate lab\n' > "$lab/AGENTS.md"
+  git -C "$lab" add -A >/dev/null 2>&1 || true
+  git -C "$lab" commit -q -m init >/dev/null 2>&1 || true
+
+  for stub in fm-turnend-guard.sh fm-claude-stop-autoarm.sh fm-arm-pretool-check.sh \
+    fm-cd-pretool-check.sh fm-subagent-pretool-check.sh; do
+    printf '#!/usr/bin/env bash\nexit 0\n' > "$lab/bin/$stub"
+    chmod +x "$lab/bin/$stub"
+  done
+
+  cat > "$lab/bin/fm-sessionstart-run.sh" <<'SH'
+#!/usr/bin/env bash
+# Recorder standing in for the real wrapper: logs the source the harness
+# supplied and prints a source-stamped token for the model to quote back.
+set -u
+record=${FM_LIVE_RECORD:?}
+source=
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --source) source=${2:-}; shift 2 || exit 0 ;;
+    *) shift ;;
+  esac
+done
+if [ -z "$source" ]; then
+  source=$(cat 2>/dev/null | awk '
+    BEGIN { RS = "\"" }
+    seen == 2 { print; exit }
+    seen == 1 && $0 ~ /^[[:space:]]*:[[:space:]]*$/ { seen = 2; next }
+    seen == 1 { seen = 0 }
+    $0 == "source" { seen = 1 }
+  ')
+fi
+[ -n "$source" ] || source=none
+printf '%s\n' "$source" >> "$record"
+printf 'FMHOOKTOKEN-%s-%s\n' "$source" "$(grep -c . "$record" | tr -d ' ')"
+exit 0
+SH
+  chmod +x "$lab/bin/fm-sessionstart-run.sh"
+
+  case "$harness" in
+    claude) mkdir -p "$lab/.claude"; cp "$ROOT/.claude/settings.json" "$lab/.claude/settings.json" ;;
+    codex) mkdir -p "$lab/.codex"; cp "$ROOT/.codex/hooks.json" "$lab/.codex/hooks.json" ;;
+    pi)
+      mkdir -p "$lab/.pi/extensions/lib"
+      cp "$ROOT/.pi/extensions/fm-primary-turnend-guard.ts" "$lab/.pi/extensions/"
+      cp "$ROOT/.pi/extensions/lib/fm-operational-input.ts" "$lab/.pi/extensions/lib/"
+      ;;
+  esac
+  printf '%s\n' "$lab"
+}
+
+# --- (a) cold open and context-preserving reopen ------------------------------
+#
+# Both run headless, because a cold open and a resume are whole processes and
+# need no TUI driving. The expected resume source is passed per harness rather
+# than assumed uniform: the harnesses genuinely disagree, and what matters is
+# only that a reopen is never reported as a context RESET, which would make the
+# run tier skip sweeps it never ran.
+probe_process_opens() {  # <harness> <version> <lab> <expect-resume> <cold-argv...> -- <resume-argv...>
+  local harness=$1 version=$2 lab=$3 expect_resume=$4
+  shift 4
+  local record="$lab/record" cold=() resume=() seen_sep=0 arg out source
+  for arg in "$@"; do
+    if [ "$arg" = -- ] && [ "$seen_sep" -eq 0 ]; then seen_sep=1; continue; fi
+    if [ "$seen_sep" -eq 0 ]; then cold+=("$arg"); else resume+=("$arg"); fi
+  done
+
+  : > "$record"
+  out=$( cd "$lab" && FM_LIVE_RECORD="$record" FM_ROOT_OVERRIDE="$lab" FM_HOME="$lab" \
+    "${cold[@]}" "$ASK" < /dev/null 2>&1 )
+  source=$(head -n 1 "$record")
+  [ -n "$source" ] \
+    || fail "$harness $version: the tracked session-open registration never invoked the wrapper on a cold open"
+  case "$source" in
+    startup|new) : ;;
+    *) fail "$harness $version: a cold open reported source '$source', which the run tier cannot classify as a startup" ;;
+  esac
+  printf '%s' "$out" | grep -Fq "FMHOOKTOKEN-$source-1" \
+    || fail "$harness $version: hook stdout did not reach model context on a cold open"
+  pass "$harness $version: a cold open reports source '$source' and its hook stdout reaches model context"
+
+  : > "$record"
+  ( cd "$lab" && FM_LIVE_RECORD="$record" FM_ROOT_OVERRIDE="$lab" FM_HOME="$lab" \
+    "${resume[@]}" 'Say only OK.' < /dev/null >/dev/null 2>&1 ) || true
+  source=$(head -n 1 "$record")
+  [ -n "$source" ] \
+    || fail "$harness $version: a context-preserving reopen invoked no session-open hook at all"
+  case "$source" in
+    clear|compact)
+      fail "$harness $version: a context-preserving reopen reported source '$source', so the run tier would skip sweeps that never ran"
+      ;;
+  esac
+  [ "$source" = "$expect_resume" ] \
+    || fail "$harness $version: a context-preserving reopen reported source '$source', not the recorded '$expect_resume'; refresh docs/verification/supervision.md before trusting the routing"
+  pass "$harness $version: a context-preserving reopen reports source '$source', which the run tier routes without a re-emit"
+}
+
+# --- (b) context-reset opens --------------------------------------------------
+#
+# Only reachable through the TUI, so this one drives a real pane.
+probe_context_reset() {  # <harness> <version> <lab> <clear-command> <launch-argv...>
+  local harness=$1 version=$2 lab=$3 clear_cmd=$4
+  shift 4
+  local record="$lab/record" session="fmss-$harness" reset n
+  : > "$record"
+  tmux -L "$SOCKET" new-session -d -s "$session" -c "$lab" -x 200 -y 50 \
+    -e FM_LIVE_RECORD="$record" -e FM_ROOT_OVERRIDE="$lab" -e FM_HOME="$lab" \
+    "$*" \
+    || fail "$harness $version: could not start an interactive lab session"
+
+  # Every run-tier TUI asks whether it trusts a folder it has not seen, and the
+  # session-open hook only fires once that is answered. Each harness's default
+  # selection IS the trusting one, so a bare Enter clears it; the loop keeps
+  # waiting for the recorded open either way, so a harness that stops prompting
+  # costs nothing. harness-adapters owns trust handling outside tests.
+  n=0
+  while [ "$n" -lt 60 ] && ! grep -q . "$record" 2>/dev/null; do
+    if capture "$session" | grep -qiE 'trust (this|the|parent)?[[:space:]]*(folder|project)'; then
+      tmux -L "$SOCKET" send-keys -t "$session" Enter
+      sleep 5
+    fi
+    sleep 2
+    n=$((n + 1))
+  done
+  grep -q . "$record" 2>/dev/null \
+    || { capture "$session" >&2; fail "$harness $version: the interactive session fired no session-open hook"; }
+  sleep 10
+
+  send_line "$session" "$ASK"
+  wait_for_text "$session" "FMHOOKTOKEN-$(head -n 1 "$record")-1" \
+    || { capture "$session" >&2; fail "$harness $version: hook stdout did not reach interactive model context"; }
+
+  send_line "$session" "$clear_cmd"
+  n=0
+  while [ "$n" -lt 20 ] && [ -z "$(sed -n '2p' "$record")" ]; do sleep 2; n=$((n + 1)); done
+  reset=$(sed -n '2p' "$record")
+  [ -n "$reset" ] \
+    || { capture "$session" >&2; fail "$harness $version: '$clear_cmd' fired no session-open event, so a context reset leaves the session blind"; }
+  case "$reset" in
+    clear|compact|new) : ;;
+    *) fail "$harness $version: '$clear_cmd' reported source '$reset', which the run tier would treat as a cold startup" ;;
+  esac
+  send_line "$session" "$ASK"
+  wait_for_text "$session" "FMHOOKTOKEN-$reset-2" \
+    || { capture "$session" >&2; fail "$harness $version: hook stdout did not reach model context after '$clear_cmd'"; }
+  pass "$harness $version: '$clear_cmd' reports source '$reset' and re-injects hook stdout into model context"
+
+  # Compaction is reported, never assumed: a lab conversation is often below the
+  # harness's own compaction threshold, and a skipped check must say so.
+  for n in 1 2 3 4 5; do
+    send_line "$session" "Say only ping$n."
+    wait_for_text "$session" "ping$n" 30 >/dev/null 2>&1 || true
+  done
+  send_line "$session" /compact
+  n=0
+  while [ "$n" -lt 40 ] && ! grep -qx compact "$record"; do sleep 3; n=$((n + 1)); done
+  if grep -qx compact "$record"; then
+    send_line "$session" "$ASK"
+    wait_for_text "$session" "FMHOOKTOKEN-compact-$(grep -c . "$record" | tr -d ' ')" \
+      || { capture "$session" >&2; fail "$harness $version: hook stdout did not reach model context after a compaction"; }
+    pass "$harness $version: a compaction reports source 'compact' and re-injects hook stdout into model context"
+  else
+    note "$harness $version: compaction was NOT reached in this lab (recorded: $(tr '\n' ' ' < "$record")); its compact evidence was not refreshed"
+  fi
+
+  tmux -L "$SOCKET" kill-session -t "$session" >/dev/null 2>&1 || true
+}
+
+# --- per-harness drivers ------------------------------------------------------
+
+for harness in claude codex pi; do
+  if ! command -v "$harness" >/dev/null 2>&1; then
+    ABSENT="$ABSENT $harness"
+    note "$harness: not installed on this host, so its run-tier evidence was NOT refreshed"
+    continue
+  fi
+  version=$("$harness" --version 2>/dev/null | head -n 1)
+  [ -n "$version" ] || version=unknown
+  lab=$(make_lab "$harness")
+
+  case "$harness" in
+    claude)
+      probe_process_opens claude "$version" "$lab" resume \
+        claude -p --permission-mode bypassPermissions \
+        -- claude --continue -p --permission-mode bypassPermissions
+      probe_context_reset claude "$version" "$lab" /clear \
+        claude --permission-mode bypassPermissions
+      ;;
+    codex)
+      probe_process_opens codex "$version" "$lab" resume \
+        codex exec --dangerously-bypass-hook-trust --dangerously-bypass-approvals-and-sandbox --skip-git-repo-check \
+        -- codex exec resume --last --dangerously-bypass-hook-trust --dangerously-bypass-approvals-and-sandbox --skip-git-repo-check
+      # Codex's interactive TUI does not fire PROJECT hooks, so its context-reset
+      # axis is unreachable from a tracked project registration. This is a named
+      # gap, not a silent pass; supervision.md owns the current statement of it.
+      note "codex $version: interactive project hooks do not fire, so its context-reset evidence cannot be refreshed from a tracked project registration"
+      ;;
+    pi)
+      probe_process_opens pi "$version" "$lab" startup \
+        pi -p -e "$lab/.pi/extensions/fm-primary-turnend-guard.ts" --no-context-files --no-session \
+        -- pi -p -c -e "$lab/.pi/extensions/fm-primary-turnend-guard.ts" --no-context-files
+      probe_context_reset pi "$version" "$lab" /new \
+        pi -e "$lab/.pi/extensions/fm-primary-turnend-guard.ts" --no-context-files
+      ;;
+  esac
+  CHECKED=$((CHECKED + 1))
+done
+
+[ "$CHECKED" -gt 0 ] \
+  || fail "no run-tier harness was installed, so this guard verified nothing; install claude, codex, or pi before trusting its evidence"
+[ -z "$ABSENT" ] \
+  || note "run-tier evidence was refreshed for $CHECKED harness(es); still missing:$ABSENT"
+echo "# fm-sessionstart-hook-live-e2e.test.sh: all live assertions passed"

--- a/tests/fm-sessionstart-hook-live-e2e.test.sh
+++ b/tests/fm-sessionstart-hook-live-e2e.test.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Opt-in live guard for the RUN-tier session-open adapters (Claude, Codex, Pi).
+# Opt-in live guard for the RUN-tier session-open adapters (Claude, Codex exec, Pi).
 #
 # Two facts in this area come from the vendor, not from Firstmate, so a stub can
 # only confirm the assumption already written into the stub:
@@ -140,6 +140,7 @@ SH
       mkdir -p "$lab/.pi/extensions/lib"
       cp "$ROOT/.pi/extensions/fm-primary-turnend-guard.ts" "$lab/.pi/extensions/"
       cp "$ROOT/.pi/extensions/lib/fm-operational-input.ts" "$lab/.pi/extensions/lib/"
+      printf '%s\n' '{"compaction":{"keepRecentTokens":200}}' > "$lab/.pi/settings.json"
       ;;
   esac
   printf '%s\n' "$lab"
@@ -197,7 +198,7 @@ probe_process_opens() {  # <harness> <version> <lab> <expect-resume> <cold-argv.
 probe_context_reset() {  # <harness> <version> <lab> <clear-command> <launch-argv...>
   local harness=$1 version=$2 lab=$3 clear_cmd=$4
   shift 4
-  local record="$lab/record" session="fmss-$harness" reset n
+  local record="$lab/record" session="fmss-$harness" reset n compact_seed compact_reply
   : > "$record"
   tmux -L "$SOCKET" new-session -d -s "$session" -c "$lab" -x 200 -y 50 \
     -e FM_LIVE_RECORD="$record" -e FM_ROOT_OVERRIDE="$lab" -e FM_HOME="$lab" \
@@ -241,12 +242,20 @@ probe_context_reset() {  # <harness> <version> <lab> <clear-command> <launch-arg
     || { capture "$session" >&2; fail "$harness $version: hook stdout did not reach model context after '$clear_cmd'"; }
   pass "$harness $version: '$clear_cmd' reports source '$reset' and re-injects hook stdout into model context"
 
-  # Compaction is reported, never assumed: a lab conversation is often below the
-  # harness's own compaction threshold, and a skipped check must say so.
-  for n in 1 2 3 4 5; do
-    send_line "$session" "Say only ping$n."
-    wait_for_text "$session" "ping$n" 30 >/dev/null 2>&1 || true
-  done
+  if [ "$harness" = pi ]; then
+    compact_seed="seed-$session-$$"
+    compact_reply="FMCOMPACTDONE-$compact_seed"
+    printf '%s\n' "$compact_seed" > "$lab/compact-seed.txt"
+    send_line "$session" "Read compact-seed.txt, then write at least 1800 words of substantial varied prose. End the final assistant response with FMCOMPACTDONE- immediately followed by the seed, with no space."
+    wait_for_text "$session" "$compact_reply" 300 \
+      || { capture "$session" >&2; fail "$harness $version: the substantial pre-compaction assistant turn did not complete"; }
+    sleep 5
+  else
+    for n in 1 2 3 4 5; do
+      send_line "$session" "Say only ping$n."
+      wait_for_text "$session" "ping$n" 30 >/dev/null 2>&1 || true
+    done
+  fi
   send_line "$session" /compact
   n=0
   while [ "$n" -lt 40 ] && ! grep -qx compact "$record"; do sleep 3; n=$((n + 1)); done
@@ -255,6 +264,9 @@ probe_context_reset() {  # <harness> <version> <lab> <clear-command> <launch-arg
     wait_for_text "$session" "FMHOOKTOKEN-compact-$(grep -c . "$record" | tr -d ' ')" \
       || { capture "$session" >&2; fail "$harness $version: hook stdout did not reach model context after a compaction"; }
     pass "$harness $version: a compaction reports source 'compact' and re-injects hook stdout into model context"
+  elif [ "$harness" = pi ]; then
+    capture "$session" >&2
+    fail "$harness $version: /compact did not raise session_compact after a completed substantial turn with keepRecentTokens=200"
   else
     note "$harness $version: compaction was NOT reached in this lab (recorded: $(tr '\n' ' ' < "$record")); its compact evidence was not refreshed"
   fi
@@ -286,10 +298,7 @@ for harness in claude codex pi; do
       probe_process_opens codex "$version" "$lab" resume \
         codex exec --dangerously-bypass-hook-trust --dangerously-bypass-approvals-and-sandbox --skip-git-repo-check \
         -- codex exec resume --last --dangerously-bypass-hook-trust --dangerously-bypass-approvals-and-sandbox --skip-git-repo-check
-      # Codex's interactive TUI does not fire PROJECT hooks, so its context-reset
-      # axis is unreachable from a tracked project registration. This is a named
-      # gap, not a silent pass; supervision.md owns the current statement of it.
-      note "codex $version: interactive project hooks do not fire, so its context-reset evidence cannot be refreshed from a tracked project registration"
+      note "codex $version: codex exec run-tier evidence refreshed; the interactive TUI is a documented nudge-tier surface because tracked project hooks do not fire there"
       ;;
     pi)
       probe_process_opens pi "$version" "$lab" startup \

--- a/tests/fm-sessionstart-hook-live-e2e.test.sh
+++ b/tests/fm-sessionstart-hook-live-e2e.test.sh
@@ -79,6 +79,7 @@ send_line() {  # <session> <text>
 }
 
 ASK='Reply with exactly the FMHOOKTOKEN value from your session-start context and nothing else.'
+LIVE_NONCE=$(od -An -N12 -tx1 /dev/urandom | tr -d ' \n')
 
 # --- lab ---------------------------------------------------------------------
 #
@@ -128,7 +129,7 @@ if [ -z "$source" ]; then
 fi
 [ -n "$source" ] || source=none
 printf '%s\n' "$source" >> "$record"
-printf 'FMHOOKTOKEN-%s-%s\n' "$source" "$(grep -c . "$record" | tr -d ' ')"
+printf 'FMHOOKTOKEN-%s-%s-%s\n' "$source" "$(grep -c . "$record" | tr -d ' ')" "${FM_LIVE_NONCE:?}"
 exit 0
 SH
   chmod +x "$lab/bin/fm-sessionstart-run.sh"
@@ -140,6 +141,7 @@ SH
       mkdir -p "$lab/.pi/extensions/lib"
       cp "$ROOT/.pi/extensions/fm-primary-turnend-guard.ts" "$lab/.pi/extensions/"
       cp "$ROOT/.pi/extensions/lib/fm-operational-input.ts" "$lab/.pi/extensions/lib/"
+      cp "$ROOT/bin/fm-operational-input.sh" "$lab/bin/"
       printf '%s\n' '{"compaction":{"keepRecentTokens":200}}' > "$lab/.pi/settings.json"
       ;;
   esac
@@ -163,7 +165,7 @@ probe_process_opens() {  # <harness> <version> <lab> <expect-resume> <cold-argv.
   done
 
   : > "$record"
-  out=$( cd "$lab" && FM_LIVE_RECORD="$record" FM_ROOT_OVERRIDE="$lab" FM_HOME="$lab" \
+  out=$( cd "$lab" && FM_LIVE_RECORD="$record" FM_LIVE_NONCE="$LIVE_NONCE" FM_ROOT_OVERRIDE="$lab" FM_HOME="$lab" \
     "${cold[@]}" "$ASK" < /dev/null 2>&1 )
   source=$(head -n 1 "$record")
   [ -n "$source" ] \
@@ -172,12 +174,12 @@ probe_process_opens() {  # <harness> <version> <lab> <expect-resume> <cold-argv.
     startup|new) : ;;
     *) fail "$harness $version: a cold open reported source '$source', which the run tier cannot classify as a startup" ;;
   esac
-  printf '%s' "$out" | grep -Fq "FMHOOKTOKEN-$source-1" \
-    || fail "$harness $version: hook stdout did not reach model context on a cold open"
+  printf '%s' "$out" | grep -Fq "FMHOOKTOKEN-$source-1-$LIVE_NONCE" \
+    || { printf '# cold-open model reply: %s\n' "$out" >&2; fail "$harness $version: hook stdout did not reach model context on a cold open"; }
   pass "$harness $version: a cold open reports source '$source' and its hook stdout reaches model context"
 
   : > "$record"
-  ( cd "$lab" && FM_LIVE_RECORD="$record" FM_ROOT_OVERRIDE="$lab" FM_HOME="$lab" \
+  ( cd "$lab" && FM_LIVE_RECORD="$record" FM_LIVE_NONCE="$LIVE_NONCE" FM_ROOT_OVERRIDE="$lab" FM_HOME="$lab" \
     "${resume[@]}" 'Say only OK.' < /dev/null >/dev/null 2>&1 ) || true
   source=$(head -n 1 "$record")
   [ -n "$source" ] \
@@ -202,6 +204,7 @@ probe_context_reset() {  # <harness> <version> <lab> <clear-command> <launch-arg
   : > "$record"
   tmux -L "$SOCKET" new-session -d -s "$session" -c "$lab" -x 200 -y 50 \
     -e FM_LIVE_RECORD="$record" -e FM_ROOT_OVERRIDE="$lab" -e FM_HOME="$lab" \
+    -e FM_LIVE_NONCE="$LIVE_NONCE" \
     "$*" \
     || fail "$harness $version: could not start an interactive lab session"
 
@@ -224,7 +227,7 @@ probe_context_reset() {  # <harness> <version> <lab> <clear-command> <launch-arg
   sleep 10
 
   send_line "$session" "$ASK"
-  wait_for_text "$session" "FMHOOKTOKEN-$(head -n 1 "$record")-1" \
+  wait_for_text "$session" "FMHOOKTOKEN-$(head -n 1 "$record")-1-$LIVE_NONCE" \
     || { capture "$session" >&2; fail "$harness $version: hook stdout did not reach interactive model context"; }
 
   send_line "$session" "$clear_cmd"
@@ -238,7 +241,7 @@ probe_context_reset() {  # <harness> <version> <lab> <clear-command> <launch-arg
     *) fail "$harness $version: '$clear_cmd' reported source '$reset', which the run tier would treat as a cold startup" ;;
   esac
   send_line "$session" "$ASK"
-  wait_for_text "$session" "FMHOOKTOKEN-$reset-2" \
+  wait_for_text "$session" "FMHOOKTOKEN-$reset-2-$LIVE_NONCE" \
     || { capture "$session" >&2; fail "$harness $version: hook stdout did not reach model context after '$clear_cmd'"; }
   pass "$harness $version: '$clear_cmd' reports source '$reset' and re-injects hook stdout into model context"
 
@@ -261,7 +264,7 @@ probe_context_reset() {  # <harness> <version> <lab> <clear-command> <launch-arg
   while [ "$n" -lt 40 ] && ! grep -qx compact "$record"; do sleep 3; n=$((n + 1)); done
   if grep -qx compact "$record"; then
     send_line "$session" "$ASK"
-    wait_for_text "$session" "FMHOOKTOKEN-compact-$(grep -c . "$record" | tr -d ' ')" \
+    wait_for_text "$session" "FMHOOKTOKEN-compact-$(grep -c . "$record" | tr -d ' ')-$LIVE_NONCE" \
       || { capture "$session" >&2; fail "$harness $version: hook stdout did not reach model context after a compaction"; }
     pass "$harness $version: a compaction reports source 'compact' and re-injects hook stdout into model context"
   elif [ "$harness" = pi ]; then
@@ -302,8 +305,8 @@ for harness in claude codex pi; do
       ;;
     pi)
       probe_process_opens pi "$version" "$lab" startup \
-        pi -p -e "$lab/.pi/extensions/fm-primary-turnend-guard.ts" --no-context-files --no-session \
-        -- pi -p -c -e "$lab/.pi/extensions/fm-primary-turnend-guard.ts" --no-context-files
+        pi -p -e "$lab/.pi/extensions/fm-primary-turnend-guard.ts" --no-context-files --no-tools --no-session \
+        -- pi -p -c -e "$lab/.pi/extensions/fm-primary-turnend-guard.ts" --no-context-files --no-tools
       probe_context_reset pi "$version" "$lab" /new \
         pi -e "$lab/.pi/extensions/fm-primary-turnend-guard.ts" --no-context-files
       ;;

--- a/tests/fm-sessionstart-nudge.test.sh
+++ b/tests/fm-sessionstart-nudge.test.sh
@@ -8,6 +8,20 @@
 # tier assignment and the source table these pin.
 set -u
 
+# Run the whole suite beneath one long-lived fixture harness, matching the real
+# lifecycle in which startup and later clear/compact hooks share one harness
+# ancestor. This also prevents a developer's ambient harness from making the
+# portable regression pass locally while failing on a harness-free CI runner.
+if [ "${FM_SESSIONSTART_TEST_HARNESS:-0}" != 1 ]; then
+  HARNESS_FIXTURE=$(mktemp -d "${TMPDIR:-/tmp}/fm-sessionstart-harness.XXXXXX") || exit 1
+  ln -s /bin/bash "$HARNESS_FIXTURE/codex" || exit 1
+  FM_SESSIONSTART_TEST_HARNESS=1 "$HARNESS_FIXTURE/codex" \
+    -c '"$@"; rc=$?; :; exit "$rc"' _ "$0" "$@"
+  HARNESS_STATUS=$?
+  rm -rf "$HARNESS_FIXTURE"
+  exit "$HARNESS_STATUS"
+fi
+
 # shellcheck source=tests/lib.sh
 . "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
 
@@ -190,6 +204,8 @@ test_run_startup_runs_the_full_digest() {
   out=$(run_hook "$root" --source startup </dev/null) || status=$?
   expect_code 0 "$status" "run wrapper startup"
   assert_contains "$out" "$FULL_BANNER$root" "startup did not run the full digest"
+  assert_contains "$out" "lock acquired: harness pid" \
+    "the portable startup fixture did not supply a real harness process"
   assert_not_contains "$out" "$REEMIT_BANNER" "startup was misrouted to a context re-emit"
   assert_not_contains "$out" "FIRSTMATE_OP" "a run-tier open also emitted the nudge instruction"
   assert_contains "$out" "NEXT STEP" "the run wrapper did not deliver a complete digest"

--- a/tests/fm-sessionstart-nudge.test.sh
+++ b/tests/fm-sessionstart-nudge.test.sh
@@ -201,6 +201,9 @@ test_run_clear_and_compact_reemit() {
   for source in clear compact; do
     root="$TMP_ROOT/run-$source"
     make_run_primary "$root"
+    run_hook "$root" --source startup </dev/null >/dev/null
+    assert_present "$root/state/.session-start-complete" \
+      "startup did not publish the completion proof needed by $source"
     status=0
     out=$(run_hook "$root" --source "$source" </dev/null) || status=$?
     expect_code 0 "$status" "run wrapper $source"
@@ -210,6 +213,74 @@ test_run_clear_and_compact_reemit() {
     assert_not_contains "$out" "FIRSTMATE_OP" "a $source open also emitted the nudge instruction"
   done
   pass "run wrapper: clear and compact re-emit the digest without repeating startup sweeps"
+}
+
+test_run_clear_without_completion_finishes_startup() {
+  local root="$TMP_ROOT/run-clear-incomplete" out status=0
+  make_run_primary "$root"
+  out=$(run_hook "$root" --source clear </dev/null) || status=$?
+  expect_code 0 "$status" "run wrapper clear without completion proof"
+  assert_contains "$out" "$FULL_BANNER$root" \
+    "clear skipped full startup when no completed startup could be proven"
+  assert_not_contains "$out" "$REEMIT_BANNER" \
+    "clear trusted lock ownership as proof that startup completed"
+  assert_present "$root/state/.session-start-complete" \
+    "the recovery full startup did not publish completion proof"
+  pass "run wrapper: clear falls back to full startup when completion is unproven"
+}
+
+test_pi_large_sessionstart_digest_is_delivered_loudly() {
+  local fixture out status=0
+  command -v node >/dev/null 2>&1 || {
+    echo "skip: node not found for Pi large session-start delivery test"
+    return 0
+  }
+  fixture="$TMP_ROOT/pi-large-digest"
+  mkdir -p "$fixture/.pi/extensions/lib" "$fixture/bin" "$fixture/state" "$fixture/data" "$fixture/config"
+  git init -q -b main "$fixture"
+  git -C "$fixture" commit -q --allow-empty -m init
+  : > "$fixture/AGENTS.md"
+  cp "$ROOT/.pi/extensions/fm-primary-turnend-guard.ts" "$fixture/.pi/extensions/"
+  cp "$ROOT/.pi/extensions/lib/fm-operational-input.ts" "$fixture/.pi/extensions/lib/"
+  cp "$ROOT/bin/fm-sessionstart-run.sh" "$ROOT/bin/fm-sessionstart-nudge.sh" \
+    "$ROOT/bin/fm-primary-scope-lib.sh" "$ROOT/bin/fm-gate-refuse-lib.sh" \
+    "$ROOT/bin/fm-operational-input.sh" "$fixture/bin/"
+  cat > "$fixture/bin/fm-session-start.sh" <<'SH'
+#!/usr/bin/env bash
+printf 'PI_LARGE_DIGEST_PREFIX\n'
+i=0
+while [ "$i" -lt 700 ]; do
+  printf '%01024d' 0
+  i=$((i + 1))
+done
+printf '\nPI_LARGE_DIGEST_SUFFIX\n'
+SH
+  chmod +x "$fixture/bin/"*.sh
+
+  out=$(EXT="$fixture/.pi/extensions/fm-primary-turnend-guard.ts" \
+    FM_HOME="$fixture" FM_ROOT_OVERRIDE="$fixture" FM_GATE_REFUSE_BYPASS=1 \
+    node --input-type=module 2>&1 <<'JS'
+import { pathToFileURL } from "node:url";
+const handlers = new Map();
+const messages = [];
+const pi = {
+  on(event, handler) { handlers.set(event, handler); },
+  sendMessage(message) { messages.push(message); },
+};
+const extension = await import(`${pathToFileURL(process.env.EXT).href}?large=${Date.now()}`);
+extension.default(pi);
+await handlers.get("session_start")({ reason: "startup" });
+if (messages.length !== 1) throw new Error(`expected one message, got ${messages.length}`);
+const content = messages[0].content;
+if (!content.includes("PI_LARGE_DIGEST_PREFIX")) throw new Error("digest prefix was lost");
+if (!content.includes("PI SESSION-START DELIVERY TRUNCATED")) throw new Error("truncation marker was lost");
+if (content.includes("PI_LARGE_DIGEST_SUFFIX")) throw new Error("delivery exceeded its declared bound");
+if (!content.includes("FIRSTMATE_OP: v1 session-start:")) throw new Error("operational provenance was lost");
+JS
+  ) || status=$?
+  expect_code 0 "$status" "Pi large session-start delivery"
+  [ -z "$out" ] || fail "Pi large session-start delivery printed output: $out"
+  pass "Pi retains a bounded digest prefix and loudly marks oversized delivery"
 }
 
 test_run_resume_delegates_to_the_nudge() {
@@ -225,6 +296,7 @@ test_run_resume_delegates_to_the_nudge() {
 test_run_reads_source_from_the_hook_payload() {
   local root="$TMP_ROOT/run-payload" out status=0
   make_run_primary "$root"
+  run_hook "$root" --source startup </dev/null >/dev/null
   out=$(printf '{"session_id":"s1","hook_event_name":"SessionStart","source":"compact"}' |
     run_hook "$root") || status=$?
   expect_code 0 "$status" "run wrapper payload compact"
@@ -292,8 +364,10 @@ test_owned_lock_is_silent
 test_opencode_plugin_delivers_exact_nudge_once
 test_run_startup_runs_the_full_digest
 test_run_clear_and_compact_reemit
+test_run_clear_without_completion_finishes_startup
 test_run_resume_delegates_to_the_nudge
 test_run_reads_source_from_the_hook_payload
 test_run_unknown_source_takes_the_helm
 test_run_gate_and_scope_are_silent
 test_run_reports_a_failed_session_start_as_digest_text
+test_pi_large_sessionstart_digest_is_delivered_loudly

--- a/tests/fm-sessionstart-nudge.test.sh
+++ b/tests/fm-sessionstart-nudge.test.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
-# Behavior and tracked-registration tests for the native session-start nudge.
+# Behavior tests for both native session-open tiers: the nudge wrapper that
+# only asks the agent to take the helm, and the run wrapper that takes it.
+#
+# The run-wrapper cases drive the REAL bin/fm-session-start.sh against a
+# throwaway home, so they prove routing by the digest that actually appears,
+# not by inspecting the wrapper's source. docs/sessionstart-nudge.md owns the
+# tier assignment and the source table these pin.
 set -u
 
 # shellcheck source=tests/lib.sh
@@ -9,6 +15,7 @@ unset NO_MISTAKES_GATE
 
 TMP_ROOT=$(fm_test_tmproot fm-sessionstart-nudge)
 NUDGE="$ROOT/bin/fm-sessionstart-nudge.sh"
+RUN="$ROOT/bin/fm-sessionstart-run.sh"
 # shellcheck source=/dev/null
 . "$ROOT/bin/fm-operational-input.sh"
 NUDGE_TEXT="Run \`bin/fm-session-start.sh\` now, exactly once, before executing any other instructions."
@@ -148,6 +155,133 @@ EOF
   pass "OpenCode session.created delivers the exact wrapper nudge once per session"
 }
 
+# --- run tier ----------------------------------------------------------------
+#
+# make_run_primary builds a primary the run wrapper accepts and the REAL
+# fm-session-start.sh can execute: a git repo on main so the tangle check
+# behaves, plus the home directories the digest reads. The deliberately bare
+# PATH keeps every bootstrap probe fast and hermetic - it reports missing tools
+# instead of reaching the host's real gh/tmux/tasks-axi.
+RUN_PATH=${FM_TEST_BASE_PATH:-/usr/bin:/bin:/usr/sbin:/sbin}
+
+make_run_primary() {
+  local dir=$1
+  mkdir -p "$dir/bin" "$dir/state" "$dir/data" "$dir/config"
+  git init -q -b main "$dir"
+  git -C "$dir" commit -q --allow-empty -m init
+  : > "$dir/AGENTS.md"
+}
+
+run_hook() {  # <root> [args...]
+  local root=$1
+  shift
+  FM_GATE_REFUSE_BYPASS=0 FM_ROOT_OVERRIDE="$root" FM_HOME="$root" PATH="$RUN_PATH" "$RUN" "$@"
+}
+
+# Every run-tier assertion keys off the digest banner, which fm-session-start.sh
+# prints before the lock result, so routing is proven whether or not the lock
+# was won in the test environment.
+FULL_BANNER="SESSION START - "
+REEMIT_BANNER="SESSION START (CONTEXT RE-EMIT) - "
+
+test_run_startup_runs_the_full_digest() {
+  local root="$TMP_ROOT/run-startup" out status=0
+  make_run_primary "$root"
+  out=$(run_hook "$root" --source startup </dev/null) || status=$?
+  expect_code 0 "$status" "run wrapper startup"
+  assert_contains "$out" "$FULL_BANNER$root" "startup did not run the full digest"
+  assert_not_contains "$out" "$REEMIT_BANNER" "startup was misrouted to a context re-emit"
+  assert_not_contains "$out" "FIRSTMATE_OP" "a run-tier open also emitted the nudge instruction"
+  assert_contains "$out" "NEXT STEP" "the run wrapper did not deliver a complete digest"
+  pass "run wrapper: startup runs the full digest and never also nudges"
+}
+
+test_run_clear_and_compact_reemit() {
+  local root out source status
+  for source in clear compact; do
+    root="$TMP_ROOT/run-$source"
+    make_run_primary "$root"
+    status=0
+    out=$(run_hook "$root" --source "$source" </dev/null) || status=$?
+    expect_code 0 "$status" "run wrapper $source"
+    assert_contains "$out" "$REEMIT_BANNER$root" "$source did not re-emit the digest"
+    assert_contains "$out" "are NOT repeated" "$source did not report the skipped startup sweeps"
+    assert_contains "$out" "Queued wakes ARE still drained" "$source did not preserve the wake-queue drain"
+    assert_not_contains "$out" "FIRSTMATE_OP" "a $source open also emitted the nudge instruction"
+  done
+  pass "run wrapper: clear and compact re-emit the digest without repeating startup sweeps"
+}
+
+test_run_resume_delegates_to_the_nudge() {
+  local root="$TMP_ROOT/run-resume" out status=0
+  make_run_primary "$root"
+  out=$(run_hook "$root" --source resume </dev/null) || status=$?
+  expect_code 0 "$status" "run wrapper resume"
+  [ "$out" = "$NUDGE_LINE" ] || fail "resume did not delegate to the exact nudge line, got: $out"
+  assert_absent "$root/state/.lock" "resume acquired the fleet lock instead of delegating"
+  pass "run wrapper: resume delegates to the nudge instead of re-running the digest"
+}
+
+test_run_reads_source_from_the_hook_payload() {
+  local root="$TMP_ROOT/run-payload" out status=0
+  make_run_primary "$root"
+  out=$(printf '{"session_id":"s1","hook_event_name":"SessionStart","source":"compact"}' |
+    run_hook "$root") || status=$?
+  expect_code 0 "$status" "run wrapper payload compact"
+  assert_contains "$out" "$REEMIT_BANNER$root" "a compact hook payload was not routed to a re-emit"
+
+  # A fresh root, because the compact case above legitimately took the lock and
+  # an owned lock is exactly when the nudge is supposed to stay silent.
+  root="$TMP_ROOT/run-payload-resume"
+  make_run_primary "$root"
+  status=0
+  out=$(printf '{"source":"resume","cwd":"/nowhere"}' | run_hook "$root") || status=$?
+  expect_code 0 "$status" "run wrapper payload resume"
+  assert_contains "$out" "FIRSTMATE_OP" "a resume hook payload did not delegate to the nudge"
+  assert_not_contains "$out" "SESSION START" "a resume hook payload still ran the digest"
+  pass "run wrapper: the hook payload's source field drives routing with no explicit argument"
+}
+
+test_run_unknown_source_takes_the_helm() {
+  local root="$TMP_ROOT/run-unknown" out status=0
+  make_run_primary "$root"
+  out=$(run_hook "$root" --source somethingnew </dev/null) || status=$?
+  expect_code 0 "$status" "run wrapper unknown source"
+  assert_contains "$out" "$FULL_BANNER$root" "an unrecognized source did not fall through to the full digest"
+
+  status=0
+  out=$(printf '{"hook_event_name":"SessionStart"}' | run_hook "$root") || status=$?
+  expect_code 0 "$status" "run wrapper sourceless payload"
+  assert_contains "$out" "$FULL_BANNER$root" "a payload with no source did not fall through to the full digest"
+  pass "run wrapper: an unrecognized or absent source takes the helm rather than skipping it"
+}
+
+test_run_gate_and_scope_are_silent() {
+  local root="$TMP_ROOT/run-gate" base="$TMP_ROOT/run-linked-base" linked="$TMP_ROOT/run-linked"
+  make_run_primary "$root"
+  expect_silent_zero "gate env run" env NO_MISTAKES_GATE=1 FM_GATE_REFUSE_BYPASS=0 \
+    FM_ROOT_OVERRIDE="$root" FM_HOME="$root" PATH="$RUN_PATH" "$RUN" --source startup
+  assert_absent "$root/state/.lock" "a gate agent's session open still took the fleet lock"
+
+  fm_git_worktree "$base" "$linked" fm/run-linked
+  mkdir -p "$linked/bin" "$linked/state"
+  : > "$linked/AGENTS.md"
+  expect_silent_zero "linked worktree run" run_hook "$linked" --source startup
+  assert_absent "$linked/state/.lock" "an unmarked task worktree still took the fleet lock"
+  pass "run wrapper: a gate agent and an unmarked task worktree never run a session start"
+}
+
+test_run_reports_a_failed_session_start_as_digest_text() {
+  local root="$TMP_ROOT/run-unwritable" out status=0
+  make_run_primary "$root"
+  chmod 0500 "$root/state"
+  out=$(run_hook "$root" --source startup </dev/null) || status=$?
+  chmod 0700 "$root/state"
+  expect_code 0 "$status" "run wrapper with an unwritable state directory"
+  assert_contains "$out" "READ-ONLY SESSION" "a failed lock did not reach the agent as digest text"
+  pass "run wrapper: a session start that cannot take the lock still opens the session and says so"
+}
+
 test_genuine_primary_nudges
 test_gate_env_is_silent
 test_gate_common_dir_is_silent
@@ -156,3 +290,10 @@ test_linked_secondmate_primary_nudges
 test_missing_state_is_silent
 test_owned_lock_is_silent
 test_opencode_plugin_delivers_exact_nudge_once
+test_run_startup_runs_the_full_digest
+test_run_clear_and_compact_reemit
+test_run_resume_delegates_to_the_nudge
+test_run_reads_source_from_the_hook_payload
+test_run_unknown_source_takes_the_helm
+test_run_gate_and_scope_are_silent
+test_run_reports_a_failed_session_start_as_digest_text

--- a/tests/fm-sessionstart-nudge.test.sh
+++ b/tests/fm-sessionstart-nudge.test.sh
@@ -229,6 +229,26 @@ test_run_clear_without_completion_finishes_startup() {
   pass "run wrapper: clear falls back to full startup when completion is unproven"
 }
 
+test_run_clear_rejects_previous_owner_completion() {
+  local root="$TMP_ROOT/run-clear-previous-owner" out status=0 previous_pid
+  make_run_primary "$root"
+  sleep 0 &
+  previous_pid=$!
+  wait "$previous_pid"
+  printf '%s\n' "$previous_pid" > "$root/state/.lock"
+  printf '%s\n' "$previous_pid" > "$root/state/.session-start-complete"
+
+  out=$(run_hook "$root" --source clear </dev/null) || status=$?
+  expect_code 0 "$status" "run wrapper clear with previous owner completion"
+  assert_contains "$out" "$FULL_BANNER$root" \
+    "clear treated a previous session's completion as current"
+  assert_not_contains "$out" "$REEMIT_BANNER" \
+    "clear skipped startup sweeps completed only by a previous session"
+  [ "$(cat "$root/state/.lock")" != "$previous_pid" ] \
+    || fail "the recovery startup did not replace the previous session's stale lock"
+  pass "run wrapper: clear accepts completion only from the current harness"
+}
+
 test_pi_large_sessionstart_digest_is_delivered_loudly() {
   local fixture out status=0
   command -v node >/dev/null 2>&1 || {
@@ -365,6 +385,7 @@ test_opencode_plugin_delivers_exact_nudge_once
 test_run_startup_runs_the_full_digest
 test_run_clear_and_compact_reemit
 test_run_clear_without_completion_finishes_startup
+test_run_clear_rejects_previous_owner_completion
 test_run_resume_delegates_to_the_nudge
 test_run_reads_source_from_the_hook_payload
 test_run_unknown_source_takes_the_helm

--- a/tests/fm-sessionstart-nudge.test.sh
+++ b/tests/fm-sessionstart-nudge.test.sh
@@ -15,6 +15,7 @@ set -u
 if [ "${FM_SESSIONSTART_TEST_HARNESS:-0}" != 1 ]; then
   HARNESS_FIXTURE=$(mktemp -d "${TMPDIR:-/tmp}/fm-sessionstart-harness.XXXXXX") || exit 1
   ln -s /bin/bash "$HARNESS_FIXTURE/codex" || exit 1
+  # shellcheck disable=SC2016 # Expand in the fixture shell, not this parent.
   FM_SESSIONSTART_TEST_HARNESS=1 "$HARNESS_FIXTURE/codex" \
     -c '"$@"; rc=$?; :; exit "$rc"' _ "$0" "$@"
   HARNESS_STATUS=$?


### PR DESCRIPTION
## Intent

Make firstmate's session start run DETERMINISTICALLY on hook-capable harnesses instead of relying on the agent choosing to run bin/fm-session-start.sh. This is firstmate shared, tracked material, so firstmate-coding-guidelines applies throughout (one-owner rule, inline-stub pattern, AGENTS.md size discipline, harness-dependent-checks two-test rule, one sentence per line in Markdown, plain dash never em dash, shellcheck-clean bin scripts via bin/fm-lint.sh, colocated tests, dated maintainer-verification evidence).

MOTIVATION: session start relied on a native nudge that only instructs the agent to run bin/fm-session-start.sh itself, which an agent can defer. Observed 2026-08-01: an /ahoy-first session followed the ahoy -> Bearings read-only recap path and did not take the helm (no lock, no digest) until a later request forced it. Deterministic execution removes that agent-discretion gap.

DESIGN, implemented in this order:
1. HARD RUNTIME BOUND FIRST, before making the run synchronous. Give bin/fm-session-start.sh a guaranteed upper bound: either confirm every sweep is individually time-bounded and sums to a known ceiling, or add an overall watchdog that on expiry still emits whatever digest it has plus a loud 'startup truncated - reconcile X' marker and exits 0. This closes the 'digest lost/truncated under a hook timeout' edge without betting on the harness's own timeout behavior. The requirement was to VERIFY this against the code rather than assume bounds exist. I verified: bootstrap's fleet sync IS bounded, but its gh auth status probe, its tool version probes, the backlog listing, and the per-task endpoint reads are NOT, so an overall watchdog was genuinely required.
2. On hook-capable harnesses that reliably inject hook stdout into model context (CLAUDE, CODEX, PI), have the session-open hook RUN bin/fm-session-start.sh directly rather than nudging, so its full ordered digest lands in context before the first turn and even an /ahoy-first session has already taken the helm.
3. TRIGGER SCOPE: startup, clear, compact (and each harness's equivalents). Explicitly NOT resume, because resume restores prior context so re-running is redundant and disruptive. This deliberately inverts the previous nudge matcher (startup|resume|clear, excluding compact); both matchers had to be reconciled deliberately rather than left divergent.
4. ALWAYS EXIT 0 on the run path, matching the existing nudge wrapper, so a session-start failure can never block session initialization. Failures surface as digest text the agent reads and acts on (a lock held by another session -> read-only; broken GitHub auth -> escalate), exactly as today.
5. THE LOCK IS THE IDEMPOTENCY INTERLOCK. On startup: acquire and run fully. On clear/compact the same process already holds the lock, so 'held by me' must proceed and re-emit the digest, distinct from today's 'held by another -> refuse read-only'. On clear/compact, skip the mutating sweeps (fleet sync, liveness) that this process already reconciled at its own startup and re-emit the read-only context and fleet digest; this also shrinks runtime for those two events.
6. NUDGE STAYS AS THE UNIVERSAL FLOOR for harnesses that cannot do this: Grok currently drops hook stdout from model context, and headless OpenCode can exit before the injected turn. On hook-run harnesses the existing lock-silence guard must keep the nudge from also firing, so there is no double instruction. The tiering must be EXPLICIT AND DOCUMENTED, not a silent divergence.

AHOY SAFETY NET, part of this work: add an instruction to the ahoy skill that if session start has not run this session, run bin/fm-session-start.sh first, before producing the recap. This is the fallback protecting harnesses that cannot use the hook and any first-command skill path, so taking the helm always precedes a skill's own logic.

FILES IN SCOPE: the native session-start adapters/config, bin/fm-session-start.sh, bin/fm-sessionstart-nudge.sh, docs/sessionstart-nudge.md, and .agents/skills/ahoy.

ACCEPTANCE CRITERIA:
- The runtime bound exists and is proven: a truncated/over-budget startup still emits a digest plus a loud truncation marker and exits 0.
- On Claude, Codex, and Pi the session-open hook runs session start on startup/clear/compact and NOT on resume, and the full digest reaches model context.
- The nudge floor still fires on harnesses that cannot run the hook (Grok, headless OpenCode) and does NOT double-fire on hook-run harnesses, with the lock-silence guard verified.
- The ahoy skill runs session start first when it has not run this session.
- HARNESS-DEPENDENT-CHECK DISCIPLINE: any check whose verdict depends on harness behavior needs BOTH a portable regression in tests/ (real processes, no harness) AND, where applicable, a live opt-in guard. Per capable harness, confirm empirically that (a) source-scoping can exclude resume and (b) hook stdout is injected into context on clear/compact, not only startup. Record the dated per-harness result in the verification evidence and point at the refresh command.
- Colocated tests extend existing patterns in tests/, exercise behavior through the executable interface and never assert implementation-source bytes, and bin/fm-lint.sh passes.

CONSTRAINTS:
- Deterministic and idempotent enforcement over agent memory, since this is critical startup infra: repeated execution must converge safely and unsafe states must fail closed where the runtime can enforce them.
- Review every affected supported harness's integration surface, not only the ones active now; mark an axis not applicable only after inspecting it.
- Keep AGENTS.md additions minimal, routing detail to the right owner (skill/doc/script header) per the decision tree; a one-line trigger inline is the ceiling for situational detail.

DECISIONS AND TRADEOFFS I MADE WHILE DOING THE WORK, which a reviewer reading only the diff would not know:

A. Source routing was centralized in one new wrapper (bin/fm-sessionstart-run.sh) rather than encoded in each harness's matcher string, so 'what a session-open source means' has exactly one owner. Claude's hook is therefore registered UNMATCHED and the wrapper reads the source from the hook payload; that is deliberate, not a lost matcher.

B. Resume is routed to the nudge wrapper rather than to nothing at all. On a resume the process is new, so the old lock names a dead pid and the helm genuinely must be retaken; delegating preserves today's exact behavior on that path while keeping resume excluded from the run, and it makes double-firing structurally impossible because resume/reload/fork are the ONLY sources that reach the nudge.

C. On clear/compact I skip bootstrap's six mutating sweeps and the stale Herdr projection cleanup, but I deliberately KEEP the wake-queue drain. Queued wake records arrived after startup, they are that turn's work queue, and a session that owns the lock is exactly the session that must take them; dropping them would strand records and reintroduce agent discretion right after a context reset. This is a judgment call within the design rather than a departure from it, so I did not escalate it, but it is the one place my reading of 'skip the mutating sweeps' is narrower than the broadest possible reading.

D. bin/fm-bootstrap.sh gained an additive FM_BOOTSTRAP_LOCKED flag because FM_BOOTSTRAP_DETECT_ONLY previously implied 'unlocked' in exactly one place: the worktree-tangle line's repair ownership. A re-emit skips sweeps because it already ran them, not because it lacks the lock, so without this flag it would have wrongly told itself to leave repair work to the lock holder that it is. Default unset keeps every existing caller byte-identical.

E. I added bin/fm-timeout-lib.sh as the single owner of bounded execution and migrated the three pre-existing near-identical run_timed copies (fm-fleet-snapshot.sh, fm-vendor-auth-probe.sh, fm-bearings-snapshot.sh) to it, rather than adding a fourth copy for the watchdog. This is slightly wider than the stated file scope, but adding a fourth copy would have violated the one-owner rule the task explicitly invokes. The lib also adds fm_timeout_mechanism, because the digest must distinguish 'the bound was hit' from 'this host has no bounding mechanism': the existing helpers return 124 for both, which for a whole digest would mean emitting nothing at all. A host with no timeout/gtimeout/perl therefore runs unbounded and says so inline.

F. The watchdog runs the digest as one bounded CHILD writing straight to the parent's stdout, so everything emitted before expiry is already delivered; the parent then appends the truncation banner naming the stalled stage and every stage that never ran. All three bounding mechanisms terminate the whole process group, so a hung grandchild cannot outlive the bound.

G. The watchdog consumes 2 of the 16 levels in fm-session-lock-lib.sh's BOUNDED harness-ancestry walk, so I added a regression that proves a session start eight shells below its harness still acquires the lock. Losing that headroom would silently force every session read-only.

H. Pi's real vocabulary differs from Claude's and Codex's and I wrote the routing to what each harness actually reports rather than assuming uniformity: Pi's session_start reasons are startup|reload|new|resume|fork with a SEPARATE session_compact event, so 'new' is Pi's clear and session_compact is its compaction; Pi's reload stays unmapped exactly as it always was; and a NEW Pi process continuing a session reports startup, not resume, which is correct for the run tier because a new process holds no lock and must take the helm.

I. Pi is the only adapter that injects a MESSAGE rather than hook stdout, so the extension now gives an unencoded digest session-start operational provenance before sending it, leaving the already-encoded nudge alone. Without that, the Ahoy skill would have to guess whether the injected message was captain-authored, and the existing operational-provenance contract would break.

J. Empirical live verification ran on 2026-08-05 and found two honest gaps that are recorded rather than papered over: Codex 0.146.0 fires the tracked PROJECT hook reliably under codex exec but NOT in its interactive TUI, and Pi's compaction threshold is not reachable in a lab session. Claude 2.1.222 was verified end to end on startup, /clear, /compact and resume.

K. While running the full suite I found and fixed one pre-existing environment-sensitive assertion in tests/fm-secondmate-harness.test.sh: it pointed fm-guard.sh at the developer's own checkout, so the branch a contributor happened to be on decided whether the assertion passed. It now points at the fixture home. This is unrelated to the feature but is a real test defect I hit.

## What Changed

- Route Claude, Codex exec, and Pi session-open events through a source-aware runner that executes or re-emits the session-start digest while preserving nudge behavior for context-preserving opens.
- Add a shared process-group timeout that preserves partial startup output, emits a loud reconciliation marker on truncation, and always allows session initialization to continue.
- Retain documented nudge-tier fallbacks for unsupported surfaces, add the Ahoy helm safety net, and expand portable and live harness coverage.

## Risk Assessment

✅ Low: The prior timeout, completion-ownership, Pi delivery, Codex tiering, and Pi compaction concerns are resolved coherently, with no remaining material source-verifiable defect found.

## Testing

The initial direct session-start test invocation yielded only partial streamed output, so it was rerun successfully through the repository’s targeted test runner; portable routing and watchdog regressions passed, live Claude/Codex/Pi probes demonstrated nonce-bearing hook context through the real harnesses, and a captured hung-bootstrap run demonstrated the reviewer-visible truncation contract with exit 0.

<details>
<summary>Evidence: Live Claude, Codex, and Pi hook-context transcript</summary>

```text
ok - claude 2.1.223 (Claude Code): a cold open reports source 'startup' and its hook stdout reaches model context
ok - claude 2.1.223 (Claude Code): a context-preserving reopen reports source 'resume', which the run tier routes without a re-emit
ok - claude 2.1.223 (Claude Code): '/clear' reports source 'clear' and re-injects hook stdout into model context
ok - claude 2.1.223 (Claude Code): a compaction reports source 'compact' and re-injects hook stdout into model context
ok - codex codex-cli 0.146.0: a cold open reports source 'startup' and its hook stdout reaches model context
ok - codex codex-cli 0.146.0: a context-preserving reopen reports source 'resume', which the run tier routes without a re-emit
# codex codex-cli 0.146.0: codex exec run-tier evidence refreshed; the interactive TUI is a documented nudge-tier surface because tracked project hooks do not fire there
ok - pi 0.82.0: a cold open reports source 'startup' and its hook stdout reaches model context
ok - pi 0.82.0: a context-preserving reopen reports source 'startup', which the run tier routes without a re-emit
ok - pi 0.82.0: '/new' reports source 'clear' and re-injects hook stdout into model context
ok - pi 0.82.0: a compaction reports source 'compact' and re-injects hook stdout into model context
# fm-sessionstart-hook-live-e2e.test.sh: all live assertions passed
```
</details>
<details>
<summary>Evidence: User-visible truncated startup digest and zero exit status</summary>

```text

================================================================================
SESSION START - /var/folders/0k/bf8mwt2n5qddzk24r20gfk0c0000gn/T//fm-session-start-tests.grTlvC/runtime-bound-evidence/home
================================================================================

LOCK
--------------------------------------------------------------------------------
lock acquired: harness pid 57502

BOOTSTRAP
--------------------------------------------------------------------------------

●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
●  STARTUP TRUNCATED - SESSION START HIT ITS 3s RUNTIME BOUND
●  It stopped during the "bootstrap" stage, so everything above is COMPLETE
●  only up to that point.
●  RECONCILE these stages before acting on anything they would have shown:
●    bootstrap wake-queue supervision-instructions context fleet-state next-step
●  Rerun bin/fm-session-start.sh now to finish taking the helm. If it truncates
●  again, raise FM_SESSION_START_TIMEOUT and report the slow stage - a stage that
●  cannot finish inside the bound is a fleet problem, not a reporting detail.
●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
SESSION_START_EXIT=0
```
</details>
- Outcome: 🔧 1 issue found → auto-fixed ✅ across 2 runs (1h44m45s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 5 issues found → auto-fixed (4) ✅</summary>

- 🚨 `bin/fm-timeout-lib.sh:48` - The claimed hard bound is not guaranteed with GNU `timeout` or `gtimeout`: without `--kill-after`, a child that ignores TERM can keep the hook blocked indefinitely. Add a short KILL escalation in the shared runner and exercise it with a TERM-resistant process.
- 🚨 `bin/fm-sessionstart-run.sh:92` - A startup truncated after acquiring the lock leaves that lock owned by the current harness, but a later clear/compact unconditionally selects `--reemit`, which skips bootstrap sweeps that may never have completed. Persist successful full-start completion for the owning harness, or fall back to a full run when completion cannot be proven.
- 🚨 `.pi/extensions/fm-primary-turnend-guard.ts:68` - Pi captures the newly unbounded-size digest through `spawnSync`&#39;s default 1 MiB stdout buffer, then passes it through an encoder with the same 1 MiB limit. Large context files can therefore produce ENOBUFS and line 71 silently drops the entire digest after startup already mutated state. Stream the output or define an explicit safely delivered size bound with a loud truncation message.
- 🚨 `docs/verification/supervision.md:65` - The required criterion says Codex must run session start on startup, clear, and compact, but the committed evidence says the interactive TUI fires no tracked project SessionStart hook and depends on an untracked global registration. Either provide a tracked supported path that covers Codex TUI resets or explicitly revise the required criterion.
- 🚨 `docs/verification/supervision.md:61` - The required harness-dependent-check criterion demands empirical clear/compact confirmation per capable harness, but the evidence explicitly says Pi&#39;s `session_compact` handler was not reached. Obtain live compaction evidence or explicitly revise that required acceptance criterion before claiming conformance.

🔧 Fix: Harden session-start completion, timeout, and Pi delivery
6 errors still open:
- 🚨 `bin/fm-sessionstart-run.sh:77` - A completed session A can leave matching lock/completion PIDs; session B starts read-only while A is live, A exits, then B clears and this equality selects `--reemit`. `fm-lock.sh` replaces A&#39;s stale lock with B&#39;s, but the startup sweeps are skipped even though B never ran them. Require the completion PID to belong to the current harness ancestry using the shared session-lock identity boundary.
- 🚨 `bin/fm-timeout-lib.sh:48` - Firstmate supports Linux without requiring GNU coreutils, but BusyBox and BSD `timeout` accept `-k`, not GNU&#39;s `--kill-after`. Because mechanism detection checks only the command name, those hosts fail immediately; session start then ignores the non-124 result and emits no digest. Use the portable short option or verify the implementation before selecting it.
- 🚨 `bin/fm-session-start.sh:178` - The required criterion says the runtime bound must be guaranteed, but this branch deliberately runs unbounded when `timeout`, `gtimeout`, and Perl are absent. On Pi this can block indefinitely, while Claude/Codex can be killed by their 180-second hook timeout before Firstmate emits its truncation marker. Either require a supported bounding dependency or provide a dependency-free fallback; otherwise explicitly approve weaker containment.
- 🚨 `.pi/extensions/fm-primary-turnend-guard.ts:67` - The required criterion says Pi receives the full digest, but the adapter now retains only the first 512 KiB and can omit later context, fleet state, and next-step sections. Stream or chunk the complete digest into Pi context, or explicitly authorize this size-limited containment and its incomplete-digest semantics.
- 🚨 `docs/verification/supervision.md:65` - The required criterion says Codex must run session start on startup, clear, and compact, but the committed evidence says the tracked project hook does not fire in the interactive TUI and relies on an untracked global registration. Provide a tracked supported reset path or explicitly revise the required Codex criterion.
- 🚨 `docs/verification/supervision.md:61` - The required harness-dependent-check criterion demands empirical clear/compact confirmation per capable harness, but the evidence says Pi&#39;s `session_compact` handler was not reached and the live guard treats that as a note rather than a failed verification. Obtain live compaction evidence or explicitly revise the acceptance criterion.

🔧 Fix: Harden completion ownership and portable timeout escalation
5 errors still open:
- 🚨 `bin/fm-session-start.sh:194` - The hard-timeout path still misses TERM-resistant hangs: `fm_run_timed` now uses `timeout -k`, for which GNU timeout returns 137 after KILL, but this branch recognizes only 124. The parent therefore exits 0 without the required truncation marker. Normalize the kill-after outcome at the shared timeout boundary. See [GNU timeout documentation](https://www.gnu.org/software/coreutils/timeout).
- 🚨 `bin/fm-session-start.sh:178` - The required criterion says &#34;The runtime bound exists and is proven,&#34; but this branch explicitly runs the hook unbounded when `timeout`, `gtimeout`, and Perl are absent. Require a bounding mechanism or explicitly authorize weaker containment.
- 🚨 `.pi/extensions/fm-primary-turnend-guard.ts:67` - The required criterion says the &#34;full digest reaches model context&#34; on Pi, but the adapter retains only the first 512 KiB and can omit later context, fleet state, and next-step sections. Deliver the complete digest or explicitly authorize incomplete-digest semantics.
- 🚨 `docs/verification/supervision.md:65` - The required criterion says Codex must run session start on startup, clear, and compact, but the committed evidence says the tracked project hook does not fire in the interactive TUI and relies on an untracked global registration. Provide a tracked supported reset path or explicitly revise the Codex criterion.
- 🚨 `docs/verification/supervision.md:61` - The harness-dependent-check criterion requires empirical clear/compact confirmation per capable harness, but the evidence says Pi&#39;s `session_compact` handler was not reached. Obtain live compaction evidence or explicitly revise the acceptance criterion.

🔧 Fix: Normalize watchdog KILL exits without masking command status
4 errors still open:
- 🚨 `bin/fm-session-start.sh:178` - The required criterion says &#34;The runtime bound exists and is proven,&#34; but this branch explicitly runs session start unbounded when timeout, gtimeout, and Perl are unavailable. Require a bounding mechanism or explicitly authorize this weaker containment.
- 🚨 `.pi/extensions/fm-primary-turnend-guard.ts:67` - The required criterion says the full digest reaches Pi model context, but the adapter retains only the first 512 KiB and explicitly omits the remainder. Deliver the complete digest or explicitly authorize incomplete-digest semantics.
- 🚨 `docs/verification/supervision.md:65` - The required criterion says Codex runs session start on startup, clear, and compact, but the evidence states the tracked project hook does not fire in the interactive TUI and relies on an untracked global registration. Provide a tracked supported reset path or explicitly revise the Codex criterion.
- 🚨 `docs/verification/supervision.md:61` - The harness-dependent-check criterion requires empirical clear and compact confirmation per capable harness, but the evidence says Pi&#39;s session_compact handler was not reached. Obtain live compaction evidence or explicitly revise the acceptance criterion.

🔧 Fix: Guarantee startup bounds and align harness delivery tiers
✅ Re-checked - no issues remain.

</details>

<details>
<summary>🔧 **Test** - 1 issue found → auto-fixed ✅</summary>

- 🚨 `.pi/extensions/fm-primary-turnend-guard.ts:167` - Pi 0.82.0 session-start output could not be demonstrated in model context on cold open. The existing live guard&#39;s prior passes were false positives because the model used tools to reconstruct deterministic tokens from lab files. Random-token, no-tools probes failed across the submitted delivery path and several diagnostic counterfactuals, so the required Pi deterministic context injection remains unsatisfied.
- `tests/fm-session-start.test.sh`
- `tests/fm-sessionstart-nudge.test.sh`
- <code>Real `bin/fm-sessionstart-run.sh` startup, compact, and resume routing against an isolated primary-home fixture</code>
- <code>Forced `FM_SESSION_START_TIMEOUT=1` startup with a hung `gh auth status` fixture</code>
- <code>`FM_SESSIONSTART_HOOK_LIVE_E2E=1 tests/fm-sessionstart-hook-live-e2e.test.sh` against Claude 2.1.223, Codex CLI 0.146.0, and Pi 0.82.0</code>
- `Pi 0.82.0 random-token, no-tools cold-open and compact context probes`

🔧 Fix: Fix Pi session-start live verification fixture
✅ Re-checked - no issues remain.
- `tests/fm-sessionstart-nudge.test.sh`
- `tests/fm-calm-pi-extension.test.sh`
- `bin/fm-test-run.sh tests/fm-session-start.test.sh`
- `FM_SESSIONSTART_HOOK_LIVE_E2E=1 tests/fm-sessionstart-hook-live-e2e.test.sh`
- <code>Ran `bin/fm-session-start.sh` through the existing hanging-git fixture with `FM_TIMEOUT_MECHANISM_OVERRIDE=bash FM_SESSION_START_TIMEOUT=3`, captured its emitted digest, verified the truncation named `bootstrap` and all pending stages, and observed `SESSION_START_EXIT=0`</code>
- <code>Confirmed `git status --short` remained empty after testing</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Lint** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ linter found issues (exit code 1)

🔧 Fix: Silence intentional child-shell expansion lint warning
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
