### PR TITLE
fix(herdr): scrub inherited pane identity for lab-session calls

### DIFF
--- a/bin/fm-herdr-lab.sh
+++ b/bin/fm-herdr-lab.sh
@@ -49,9 +49,13 @@ fm_herdr_lab_tripwire_path() { # <session>
 }
 
 fm_herdr_lab_raw() { # <session> <herdr arguments...>
+  # The four HERDR_* identity vars are scrubbed from the invoked herdr process
+  # because herdr 0.8.0 refuses a call whose ambient parent pane identity
+  # belongs to a different session than the targeted lab session.
   local name=$1
   shift
-  HERDR_SESSION="$name" herdr "$@" --session "$name"
+  env -u HERDR_PANE_ID -u HERDR_TAB_ID -u HERDR_WORKSPACE_ID -u HERDR_ENV \
+    HERDR_SESSION="$name" herdr "$@" --session "$name"
 }
 
 fm_herdr_lab_session_list() { # <session>


### PR DESCRIPTION
## Intent

- Herdr 0.8.0's launcher-identity guard refuses a spawn whose ambient `HERDR_PANE_ID` belongs to a session different from the one targeted.
  - Any lab-driven Herdr call made from inside a live Herdr pane (e.g. a task worker running under Herdr calling `bin/fm-herdr-lab.sh`) started failing container placement because the child inherited the parent pane's identity env.
- Fix: `fm_herdr_lab_raw` now scrubs the four inherited `HERDR_*` identity vars (`HERDR_PANE_ID`, `HERDR_TAB_ID`, `HERDR_WORKSPACE_ID`, `HERDR_ENV`) before every Herdr invocation, so each lab call carries only the explicit `HERDR_SESSION` it sets itself.
- No behavior change for callers running outside a Herdr pane (those vars are already unset).
