### PR TITLE
feat: add Muse Code crewmate adapter

### DIFF
--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -410,7 +410,7 @@ Muse Code is a CREWMATE and SCOUT adapter only.
 | Skill invocation | `/<skill>`, the claude/grok form. |
 | Autonomy | `--yolo`, which disables approval, disables the sandbox, and trusts the workspace for the run. |
 | Trust dialog | `Do you trust this workspace?` with `1 Trust and continue` preselected, accepted by Enter. `--yolo` suppresses it entirely, which is what firstmate relies on because every task gets a fresh worktree path. |
-| Environment marker | None. Detection is process ancestry on the anchored prefix `muse-bin*`. `MUSE_CURRENT_SESSION_LOG` is a session-log PATH rather than an identity, and its export to tool subprocesses is unverified. |
+| Environment marker | None. Detection is process ancestry on the anchored prefix `muse-bin-*`. `MUSE_CURRENT_SESSION_LOG` is a session-log PATH rather than an identity, and its export to tool subprocesses is unverified. |
 | Composer | Bordered box whose prompt glyph is `⟩` (U+27E9) in truecolor `38;2;90;160;255`, luminance ~149.9 - the narrowest margin over the 128 ghost threshold in the fleet. Typed text is `38;2;204;211;219` (~209.8). No idle placeholder or ghost text was observed. |
 | Effort | `--reasoning-effort`, default `high`; see the launch-profile table above for the mapping. |
 | Resume | `muse resume --last` or `muse resume <session-uuid>`; bare `muse resume` opens a picker. |
@@ -418,7 +418,9 @@ Muse Code is a CREWMATE and SCOUT adapter only.
 ### Credentials are a spawn preflight, not a screen check
 
 muse reads `META_API_KEY` (which always wins) or a stored credential at `${XDG_CONFIG_HOME:-$HOME/.config}/muse/auth.json`, written by `muse login` (an OIDC device-code flow) or `muse auth set --api-key-stdin`.
-`bin/fm-spawn.sh` refuses the launch when neither is present, because an unauthenticated pane does NOT exit: it sits on `Sign in at this page: https://auth.meta.com/oauth/device/?code=XXXX-XXXX` / `Waiting for approval…` indefinitely, which supervision would read as a wedged worker rather than a missing credential.
+`bin/fm-spawn.sh` accepts `META_API_KEY` only when it can prove the backend worker already has it, because a command-scoped caller variable does not cross a long-lived backend daemon and the secret must never enter launch argv.
+The supported fleet path is the stored credential, and `fm-spawn` forwards only the resolved non-secret `XDG_CONFIG_HOME` and `XDG_DATA_HOME` roots to keep authentication and session-log binding aligned with the worker.
+`bin/fm-spawn.sh` refuses the launch when neither worker-reachable path is present, because an unauthenticated pane does NOT exit: it sits on `Sign in at this page: https://auth.meta.com/oauth/device/?code=XXXX-XXXX` / `Waiting for approval…` indefinitely, which supervision would read as a wedged worker rather than a missing credential.
 Escalate that refusal to the captain as a needed credential.
 
 ### Foreign personal context is a real privacy boundary
@@ -440,8 +442,7 @@ Two traps the fold already handles, which any change here must preserve.
 muse also emits nested `"record":{"kind":"terminal"}` cleanup-effect payloads that are NOT run terminals, so the match is anchored on the full structural prefix rather than a `"kind":"terminal"` search.
 muse's own native sub-agents write independent run lifecycles one directory deeper under `subagent/<child-session-id>/session.jsonl`, so the resolver is depth-bounded and folds only the main log.
 
-The recorded sessions root is whatever `XDG_DATA_HOME` resolved to in firstmate's own environment at spawn time.
-If a pane ends up with a different `XDG_DATA_HOME` - a session provider that does not inherit firstmate's environment could do this - the binding simply resolves nothing and the task classifies `unknown`, never a wrong `busy` or `idle`; keep the variable consistent rather than widening the search.
+The recorded sessions root is the resolved `XDG_DATA_HOME` that `fm-spawn` also forwards to the worker launch, so the binding and pane remain aligned across a long-lived backend daemon.
 
 The IDLE half is gated behind `fm_busy_muse_idle_verified` in `bin/fm-busy-lib.sh` and is currently CLOSED, so a settled log reads `unknown`, never `idle`.
 Busy needs no gate because an open run is positive proof a turn is in flight.

--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -431,7 +431,7 @@ It was verified to drop the foreign `rules_file` context block while KEEPING a p
 
 ### Session event log and the busy fold
 
-Sessions persist to `${XDG_DATA_HOME:-$HOME/.local/share}/muse/sessions/YYYY/MM/DD/<session-uuid>/session.jsonl`, and `fm-spawn` writes `state/<id>.muse-session` pinning that root plus the task worktree so the classifier binds a pane to its own log.
+Sessions persist to `${XDG_DATA_HOME:-$HOME/.local/share}/muse/sessions/YYYY/MM/DD/<session-uuid>/session.jsonl`, and `fm-spawn` writes `state/<id>.muse-session` pinning that root, the task worktree, and every pre-existing matching main log so the classifier binds a pane to its one new log.
 Each submitted turn is bracketed by `{"payload":{"kind":"run","run_id":"<uuid>","event":{"kind":"started"` and a matching `"event":{"kind":"terminal"`, whose `terminal` value was observed as `completed` and `cancelled`.
 Because the interrupt path produces a real terminal, this source covers interruption, which Claude's `Stop` hook does not.
 Never use `--no-session-log` for a crewmate: it disables the only busy source muse has.

--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -433,7 +433,8 @@ It was verified to drop the foreign `rules_file` context block while KEEPING a p
 
 ### Session event log and the busy fold
 
-Sessions persist to `${XDG_DATA_HOME:-$HOME/.local/share}/muse/sessions/YYYY/MM/DD/<session-uuid>/session.jsonl`, and `fm-spawn` writes `state/<id>.muse-session` pinning that root, the task worktree, and every pre-existing matching main log so the classifier binds a pane to its one new log.
+Sessions persist to `${XDG_DATA_HOME:-$HOME/.local/share}/muse/sessions/YYYY/MM/DD/<session-uuid>/session.jsonl`, and `fm-spawn` writes `state/<id>.muse-session` pinning that root, the task worktree, its binding incarnation, and every pre-existing matching main log so the classifier binds a pane to its one new log.
+After unique resolution, the classifier persists the exact main log in `state/<id>.muse-session-current` and folds that path directly until it disappears or a new spawn binding marks it as belonging to the prior incarnation.
 Each submitted turn is bracketed by `{"payload":{"kind":"run","run_id":"<uuid>","event":{"kind":"started"` and a matching `"event":{"kind":"terminal"`, whose `terminal` value was observed as `completed` and `cancelled`.
 Because the interrupt path produces a real terminal, this source covers interruption, which Claude's `Stop` hook does not.
 Never use `--no-session-log` for a crewmate: it disables the only busy source muse has.

--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -410,7 +410,7 @@ Muse Code is a CREWMATE and SCOUT adapter only.
 | Skill invocation | `/<skill>`, the claude/grok form. |
 | Autonomy | `--yolo`, which disables approval, disables the sandbox, and trusts the workspace for the run. |
 | Trust dialog | `Do you trust this workspace?` with `1 Trust and continue` preselected, accepted by Enter. `--yolo` suppresses it entirely, which is what firstmate relies on because every task gets a fresh worktree path. |
-| Environment marker | None. Detection is process ancestry on the anchored prefix `muse-bin-*`. `MUSE_CURRENT_SESSION_LOG` is a session-log PATH rather than an identity, and its export to tool subprocesses is unverified. |
+| Environment marker | None. Detection is process ancestry on the anchored prefix `muse-bin-*`. The launch clears foreign primary markers before Muse starts so their higher detection precedence cannot override that ancestry. `MUSE_CURRENT_SESSION_LOG` is a session-log PATH rather than an identity, and its export to tool subprocesses is unverified. |
 | Composer | Bordered box whose prompt glyph is `⟩` (U+27E9) in truecolor `38;2;90;160;255`, luminance ~149.9 - the narrowest margin over the 128 ghost threshold in the fleet. Typed text is `38;2;204;211;219` (~209.8). No idle placeholder or ghost text was observed. |
 | Effort | `--reasoning-effort`, default `high`; see the launch-profile table above for the mapping. |
 | Resume | `muse resume --last` or `muse resume <session-uuid>`; bare `muse resume` opens a picker. |

--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: harness-adapters
-description: Agent-only reference for firstmate harness operations. Use before spawning or recovering a crewmate or secondmate, handling a trust dialog, sending a harness-specific skill invocation, interrupting or exiting an agent, resuming an exited agent, or verifying a new harness adapter. Contains verified facts for claude, codex, opencode, pi, pi-signed, grok, and kimi.
+description: Agent-only reference for firstmate harness operations. Use before spawning or recovering a crewmate or secondmate, handling a trust dialog, sending a harness-specific skill invocation, interrupting or exiting an agent, resuming an exited agent, or verifying a new harness adapter. Contains verified facts for claude, codex, opencode, pi, pi-signed, grok, kimi, and muse.
 user-invocable: false
 metadata:
   internal: true
@@ -58,6 +58,8 @@ The primary integrations for `claude`, `codex`, `opencode`, `pi`, `pi-signed`, a
 `opencode`, `pi`, and `pi-signed` expose passive lifecycle callbacks and force one bounded follow-up when the shared predicate blocks.
 Grok selects native blocking or its pre-native bounded resume fallback from the exact running Stop payload; [`docs/turnend-guard.md`](../../../docs/turnend-guard.md) owns that contract.
 Kimi is outside the primary turn-end guard scope, while `docs/turnend-guard.md` owns its separate guarded global hook for crew wake signals.
+muse is CREWMATE/SCOUT ONLY and has no primary integration at all: its plugin engine (its only hook surface) is disabled in the default build, and its Claude-compatible hook dialect names `asyncRewake` and model reawakening as explicitly unsupported, which is exactly what a firstmate primary's turn-end supervision needs.
+`bin/fm-spawn.sh` refuses a `--secondmate` launch on muse for that reason.
 The exact hook files, commands, scoping rules, and fail-open tradeoffs are owned by `docs/turnend-guard.md`.
 `docs/verification/supervision.md` "Turn-end guard" owns active validation evidence.
 When changing any primary turn-end hook, validate the real harness behavior in a scratch project or throwaway home before trusting it, then update that doc and the relevant concise fact below.
@@ -120,6 +122,7 @@ The supported launch-profile flags below are verified locally; each row records 
 | pi / pi-signed | `--model <model>` | `--thinking <low\|medium\|high\|xhigh\|max>` | Verified 2026-07-27 on Pi and pi-signed 0.82.0. Both expose the same accepted thinking levels and completed the same model-qualified max-thinking smoke. |
 | opencode | `--model <provider/model>` | none for firstmate's interactive launch | Verified on opencode 1.17.6. `opencode run` has `--variant`, but firstmate launches the interactive `opencode --prompt` path, which has no verified effort flag. |
 | kimi | `--model <model>` | none | Verified 2026-07-25 on Kimi Code CLI 0.29.1. |
+| muse | `--model <model>` | `--reasoning-effort <low\|medium\|high\|xhigh>`, and `ultra` only for an explicit `max` | Verified 2026-08-05 on Muse Code 0.1.0-R708.1. The flag accepts `none\|minimal\|low\|medium\|high\|xhigh\|ultra` and defaults to `high`. `ultra` is muse's max-class level, so it is reachable only through an explicit captain `max`, never from the generic fallback; `none` and `minimal` sit below the shared vocabulary and stay unreachable. |
 
 The concrete `harness` field owns adapter identity independently of the model provider: `harness=pi` with `model=xai/grok-*` is Pi using xAI, not `harness=grok`, and does not require Grok CLI login; `harness=grok` remains the standalone Grok Build CLI adapter.
 No script resolves that split for you: establish which credential store a tuple reads from the discovery surfaces below plus `quota-axi auth --json`'s per-provider sources, and show that reasoning rather than inferring it from a harness, model, or source name.
@@ -390,3 +393,69 @@ The delivery-only spinner match covers the full moon-phase glyph set rather than
 Each Kimi crew worktree receives a gitignored `.fm-kimi-turnend` token pointer, and the global hook touches that task's `state/<id>.turn-ended` only when the Stop payload's `cwd`, pointer, and registry entry all agree.
 A guarded silent hook cannot be verified from absence of effect, so prove invocation with an unguarded probe before concluding that the hook did not fire.
 The guarded turn-end signal remains a wake notification; standalone Kimi has no busy-state source until one is live-verified.
+
+## muse (VERIFIED 2026-08-05, Muse Code 0.1.0-R708.1, build sha 427a430436)
+
+Muse Code is a CREWMATE and SCOUT adapter only.
+`bin/fm-spawn.sh` refuses `--secondmate` on muse, and muse has no supervision protocol under `docs/supervision-protocols/`, so a firstmate primary detected as muse falls back to the `unknown` protocol.
+
+| Fact | Value |
+|---|---|
+| Binary | Executable `muse` from `PATH`, resolved to an absolute path; spawning refuses if it is absent. The installed launcher `~/.local/bin/muse` `exec`s `~/.local/bin/muse-bin-<version>`, so the LIVE process name carries the version and changes on every auto-update. |
+| Launch | Positional prompt, the Grok/Pi shape, so the brief rides the launch command. |
+| Models | `--model <model>`; the only provider is `meta`. |
+| Busy state | Its own durable session event log, folded on demand by `bin/fm-busy-lib.sh`. There is no hook or plugin writer, so nothing is armed and no busy record is ever seeded. |
+| Exit command | `/exit` (the popup shows `/exit  Quit when idle`); one Enter submits it, and the pane prints `To continue this session, run muse resume <session-uuid>`. |
+| Interrupt | Single Escape. It closes the run with `terminal: cancelled` AND restores the interrupted prompt into the composer as real bright text, so `fm-send.sh` follows Escape with `C-u` to clear it. |
+| Skill invocation | `/<skill>`, the claude/grok form. |
+| Autonomy | `--yolo`, which disables approval, disables the sandbox, and trusts the workspace for the run. |
+| Trust dialog | `Do you trust this workspace?` with `1 Trust and continue` preselected, accepted by Enter. `--yolo` suppresses it entirely, which is what firstmate relies on because every task gets a fresh worktree path. |
+| Environment marker | None. Detection is process ancestry on the anchored prefix `muse-bin*`. `MUSE_CURRENT_SESSION_LOG` is a session-log PATH rather than an identity, and its export to tool subprocesses is unverified. |
+| Composer | Bordered box whose prompt glyph is `⟩` (U+27E9) in truecolor `38;2;90;160;255`, luminance ~149.9 - the narrowest margin over the 128 ghost threshold in the fleet. Typed text is `38;2;204;211;219` (~209.8). No idle placeholder or ghost text was observed. |
+| Effort | `--reasoning-effort`, default `high`; see the launch-profile table above for the mapping. |
+| Resume | `muse resume --last` or `muse resume <session-uuid>`; bare `muse resume` opens a picker. |
+
+### Credentials are a spawn preflight, not a screen check
+
+muse reads `META_API_KEY` (which always wins) or a stored credential at `${XDG_CONFIG_HOME:-$HOME/.config}/muse/auth.json`, written by `muse login` (an OIDC device-code flow) or `muse auth set --api-key-stdin`.
+`bin/fm-spawn.sh` refuses the launch when neither is present, because an unauthenticated pane does NOT exit: it sits on `Sign in at this page: https://auth.meta.com/oauth/device/?code=XXXX-XXXX` / `Waiting for approval…` indefinitely, which supervision would read as a wedged worker rather than a missing credential.
+Escalate that refusal to the captain as a needed credential.
+
+### Foreign personal context is a real privacy boundary
+
+muse loads the OPERATOR's foreign personal rules from `~/.claude` into every run and ships them to Meta-hosted inference, printing `Including your Claude Code personal rules — manage with /settings.` on first launch.
+An isolated `XDG_CONFIG_HOME` does NOT prevent this, and the notice is shown only once per config (`tui.foreign_context_notice_shown` in `settings.json`), so a silent later launch is still loading them.
+`--no-foreign-personal-context` is `muse exec` ONLY: the interactive TUI rejects it with `unexpected argument`.
+The control that reaches a pane worker is `MUSE_EXPERIMENTAL_FOREIGN_PERSONAL_CONTEXT_KILL=on`, which `fm-spawn` sets on every muse launch.
+It was verified to drop the foreign `rules_file` context block while KEEPING a project's own `AGENTS.md` rules, which the crewmate contract depends on.
+
+### Session event log and the busy fold
+
+Sessions persist to `${XDG_DATA_HOME:-$HOME/.local/share}/muse/sessions/YYYY/MM/DD/<session-uuid>/session.jsonl`, and `fm-spawn` writes `state/<id>.muse-session` pinning that root plus the task worktree so the classifier binds a pane to its own log.
+Each submitted turn is bracketed by `{"payload":{"kind":"run","run_id":"<uuid>","event":{"kind":"started"` and a matching `"event":{"kind":"terminal"`, whose `terminal` value was observed as `completed` and `cancelled`.
+Because the interrupt path produces a real terminal, this source covers interruption, which Claude's `Stop` hook does not.
+Never use `--no-session-log` for a crewmate: it disables the only busy source muse has.
+
+Two traps the fold already handles, which any change here must preserve.
+muse also emits nested `"record":{"kind":"terminal"}` cleanup-effect payloads that are NOT run terminals, so the match is anchored on the full structural prefix rather than a `"kind":"terminal"` search.
+muse's own native sub-agents write independent run lifecycles one directory deeper under `subagent/<child-session-id>/session.jsonl`, so the resolver is depth-bounded and folds only the main log.
+
+The recorded sessions root is whatever `XDG_DATA_HOME` resolved to in firstmate's own environment at spawn time.
+If a pane ends up with a different `XDG_DATA_HOME` - a session provider that does not inherit firstmate's environment could do this - the binding simply resolves nothing and the task classifies `unknown`, never a wrong `busy` or `idle`; keep the variable consistent rather than widening the search.
+
+The IDLE half is gated behind `fm_busy_muse_idle_verified` in `bin/fm-busy-lib.sh` and is currently CLOSED, so a settled log reads `unknown`, never `idle`.
+Busy needs no gate because an open run is positive proof a turn is in flight.
+[`docs/verification/muse.md`](../../../docs/verification/muse.md) owns the evidence and the exact deferred credentialed smoke that opens the gate.
+
+### Native sub-agents and worktrees
+
+muse fans out to its own sub-agents, but worktree isolation is per-child and opt-in: `--subagent-worktree-isolation` is a compatibility flag whose capability "defaults on" while "omission stays shared", and no nested git worktree appeared in any verified lab run.
+Firstmate deliberately does NOT exclude any muse path from `fm-teardown.sh`'s uncommitted-work check.
+Firstmate writes `.claude/settings.local.json` itself, which is why that path is excluded for claude; it does not write muse's, so a nested muse worktree or leftover scratch is the agent's own work product and MUST be able to refuse teardown.
+A teardown refusal naming muse scratch is therefore correct behavior: inspect it rather than forcing past it.
+
+### Maturity caveats
+
+muse is a day-0 `0.1.0` beta whose launcher polls a release channel hourly and can replace the running binary underneath the fleet, changing the process name with it.
+The captain accepted that risk, so firstmate does NOT set `MUSE_NO_AUTO_UPDATE=1`; a fleet that later wants stability can set it in the launch environment without any adapter change.
+Its plugin/hook engine reports `plugins are not available in this build` unless `MUSE_EXPERIMENTAL_PLUGINS=on`, which is why the busy source reads the session log instead of installing a hook.

--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -425,7 +425,7 @@ Escalate that refusal to the captain as a needed credential.
 
 ### Foreign personal context is a real privacy boundary
 
-muse loads the OPERATOR's foreign personal rules from `~/.claude` into every run and ships them to Meta-hosted inference, printing `Including your Claude Code personal rules — manage with /settings.` on first launch.
+muse loads the OPERATOR's foreign personal rules from `~/.claude` into every run and ships them to Meta-hosted inference, printing a first-launch notice that names the included Claude Code personal rules and `/settings` control.
 An isolated `XDG_CONFIG_HOME` does NOT prevent this, and the notice is shown only once per config (`tui.foreign_context_notice_shown` in `settings.json`), so a silent later launch is still loading them.
 `--no-foreign-personal-context` is `muse exec` ONLY: the interactive TUI rejects it with `unexpected argument`.
 The control that reaches a pane worker is `MUSE_EXPERIMENTAL_FOREIGN_PERSONAL_CONTEXT_KILL=on`, which `fm-spawn` sets on every muse launch.

--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -419,7 +419,7 @@ Muse Code is a CREWMATE and SCOUT adapter only.
 
 muse reads `META_API_KEY` (which always wins) or a stored credential at `${XDG_CONFIG_HOME:-$HOME/.config}/muse/auth.json`, written by `muse login` (an OIDC device-code flow) or `muse auth set --api-key-stdin`.
 `bin/fm-spawn.sh` accepts `META_API_KEY` only when it can prove the backend worker already has it, because a command-scoped caller variable does not cross a long-lived backend daemon and the secret must never enter launch argv.
-The supported fleet path is the stored credential, and `fm-spawn` forwards only the resolved non-secret `XDG_CONFIG_HOME` and `XDG_DATA_HOME` roots to keep authentication and session-log binding aligned with the worker.
+The supported fleet path is the stored credential, and `fm-spawn` resolves the non-secret `XDG_CONFIG_HOME` and `XDG_DATA_HOME` roots to absolute paths before preflight and forwarding to keep authentication and session-log binding aligned with the worker.
 `bin/fm-spawn.sh` refuses the launch when neither worker-reachable path is present, because an unauthenticated pane does NOT exit: it sits on `Sign in at this page: https://auth.meta.com/oauth/device/?code=XXXX-XXXX` / `Waiting for approval…` indefinitely, which supervision would read as a wedged worker rather than a missing credential.
 Escalate that refusal to the captain as a needed credential.
 
@@ -434,7 +434,7 @@ It was verified to drop the foreign `rules_file` context block while KEEPING a p
 ### Session event log and the busy fold
 
 Sessions persist to `${XDG_DATA_HOME:-$HOME/.local/share}/muse/sessions/YYYY/MM/DD/<session-uuid>/session.jsonl`, and `fm-spawn` writes `state/<id>.muse-session` pinning that root, the task worktree, its binding incarnation, and every pre-existing matching main log so the classifier binds a pane to its one new log.
-After unique resolution, the classifier persists the exact main log in `state/<id>.muse-session-current` and folds that path directly until it disappears or a new spawn binding marks it as belonging to the prior incarnation.
+After unique resolution, the classifier persists the exact main log in `state/<id>.muse-session-current`, folds that path directly while the bounded current-day main-session namespace is unchanged, and requires unique resolution again when that namespace changes, the path disappears, or a new spawn binding supersedes the incarnation.
 Each submitted turn is bracketed by `{"payload":{"kind":"run","run_id":"<uuid>","event":{"kind":"started"` and a matching `"event":{"kind":"terminal"`, whose `terminal` value was observed as `completed` and `cancelled`.
 Because the interrupt path produces a real terminal, this source covers interruption, which Claude's `Stop` hook does not.
 Never use `--no-session-log` for a crewmate: it disables the only busy source muse has.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,6 +91,7 @@ state/               volatile runtime signals; gitignored
   <id>.turn-ended    touched by turn-end hooks
   <id>.grok-turnend-token   firstmate-owned grok hook registry token for the task; removed by teardown
   <id>.kimi-turnend-token   firstmate-owned Kimi hook registry token for the task; removed by teardown
+  <id>.muse-session  muse busy-source binding (sessions root plus task worktree) written by fm-spawn; removed by teardown
   <id>.meta          written by fm-spawn: window=, endpoint_task_id=, worktree=, project=, harness=, model=, effort=, kind=, mode=, yolo=, tasktmp=; an optional traceparent= only when trace context is enabled (docs/configuration.md "Trace context propagation"); kind=secondmate also records home= and projects=, plus remote_host=/remote_root=/remote_backend=/remote_herdr_session=/remote_target= for a remote route; a non-default runtime backend records further backend-specific fields (docs/configuration.md "Runtime backend"; bin/fm-backend.sh, section 8); fm-pr-check, including through fm-pr-merge, records one canonical pr= and the forge's pr_head= when available (GitHub pull requests and GitLab merge requests; docs/gitlab-merge-watch.md); fm-x-link appends x_request=, x_request_ts=, x_followups=, and optional x_platform=/x_reply_max_chars= for a Relay-originated task (section 14)
   <id>.herdr-presentation  quarantinable attempt and restart-binding journal for Herdr's optional visual projection; never task or endpoint authority; see docs/herdr-backend.md "Presentation spaces"
   <id>.check.sh      authenticated slow poll; the watcher dispatches validated PR data and the byte-identified Relay shim through trusted repository scripts, runs registered custom checks from hash-validated private snapshots, and rejects every other state check without execution
@@ -166,7 +167,7 @@ A silent bootstrap section needs no action; for any printed actionable diagnosti
 ## 4. Harness and runtime dispatch
 
 Load `harness-adapters` before every spawn or recovery and before trust handling, skill invocation, interrupt, exit, resume, or adapter verification.
-The verified harnesses are `claude`, `codex`, `opencode`, `pi`, `pi-signed`, `grok`, and `kimi`; never dispatch on an unverified adapter.
+The verified harnesses are `claude`, `codex`, `opencode`, `pi`, `pi-signed`, `grok`, and `kimi`, plus `muse` for crewmates and scouts only; never dispatch on an unverified adapter.
 If static `config/crew-harness` or `config/secondmate-harness` names an unverified adapter, report it and fall back only to a verified adapter rather than launching it.
 
 `docs/configuration.md` owns dispatch-profile and runtime-backend schemas, `bin/fm-harness.sh` owns static resolution, and `bin/fm-spawn.sh` owns launch flags and fail-closed validation.

--- a/bin/backends/cmux.sh
+++ b/bin/backends/cmux.sh
@@ -488,6 +488,9 @@ fm_backend_cmux_normalize_key() {  # <key>
     Enter|enter) printf 'enter' ;;
     Escape|escape|Esc|esc) printf 'escape' ;;
     C-c|c-c|ctrl+c|Ctrl+c|Ctrl+C|ctrl-c) printf 'ctrl-c' ;;
+    # C-u clears a composer line. fm-send.sh's muse interrupt path needs it to
+    # drop the prompt muse restores into the composer after Escape.
+    C-u|c-u|ctrl+u|Ctrl+u|Ctrl+U|ctrl-u) printf 'ctrl-u' ;;
     *) printf '%s' "$1" ;;
   esac
 }

--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -2350,6 +2350,9 @@ fm_backend_herdr_normalize_key() {  # <key>
     Enter|enter) printf 'enter' ;;
     Escape|escape|Esc|esc) printf 'escape' ;;
     C-c|c-c|ctrl+c|Ctrl+C) printf 'ctrl+c' ;;
+    # C-u clears a composer line. fm-send.sh's muse interrupt path needs it to
+    # drop the prompt muse restores into the composer after Escape.
+    C-u|c-u|ctrl+u|Ctrl+U) printf 'ctrl+u' ;;
     *) printf '%s' "$1" ;;
   esac
 }

--- a/bin/backends/tmux.sh
+++ b/bin/backends/tmux.sh
@@ -167,7 +167,7 @@ fm_backend_tmux_classify_process_name() {  # <path> [argv0] -> agent|shell|other
     # would classify musescore or amuse as a live agent pane. The install path
     # cannot carry it either: ~/.local/bin/muse-bin-<version> has no `muse` path
     # COMPONENT, so the fm_harness_path_name fallback below never fires for it.
-    muse|muse-bin*) printf 'agent' ;;
+    muse|muse-bin-*) printf 'agent' ;;
     *claude*|*codex*|*opencode*|*grok*|*kimi*|pi|pi-signed|pi-launcher|Pi) printf 'agent' ;;
     zsh|bash|sh|dash|ash|ksh|mksh|tcsh|csh|fish) printf 'shell' ;;
     *)

--- a/bin/backends/tmux.sh
+++ b/bin/backends/tmux.sh
@@ -160,6 +160,14 @@ fm_backend_tmux_classify_process_name() {  # <path> [argv0] -> agent|shell|other
   base=${path##*/}
   base=${base#-}
   case "$base" in
+    # muse is anchored rather than globbed like its neighbours: its installed
+    # binary is muse-bin-<version> (the launcher execs it, so the version is the
+    # live process name and changes on every auto-update), and unlike `claude` or
+    # `codex` the substring `muse` is a common English fragment - a *muse* glob
+    # would classify musescore or amuse as a live agent pane. The install path
+    # cannot carry it either: ~/.local/bin/muse-bin-<version> has no `muse` path
+    # COMPONENT, so the fm_harness_path_name fallback below never fires for it.
+    muse|muse-bin*) printf 'agent' ;;
     *claude*|*codex*|*opencode*|*grok*|*kimi*|pi|pi-signed|pi-launcher|Pi) printf 'agent' ;;
     zsh|bash|sh|dash|ash|ksh|mksh|tcsh|csh|fish) printf 'shell' ;;
     *)

--- a/bin/backends/zellij.sh
+++ b/bin/backends/zellij.sh
@@ -446,6 +446,9 @@ fm_backend_zellij_normalize_key() {  # <key>
     Enter|enter) printf 'Enter' ;;
     Escape|escape|Esc|esc) printf 'Esc' ;;
     C-c|c-c|ctrl+c|Ctrl+c|Ctrl+C|'Ctrl c'|'ctrl c') printf 'Ctrl c' ;;
+    # C-u clears a composer line. fm-send.sh's muse interrupt path needs it to
+    # drop the prompt muse restores into the composer after Escape.
+    C-u|c-u|ctrl+u|Ctrl+u|Ctrl+U|'Ctrl u'|'ctrl u') printf 'Ctrl u' ;;
     *) printf '%s' "$1" ;;
   esac
 }

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -904,7 +904,7 @@ crew_dispatch_validate() {
     return 0
   fi
   err=$(jq -r '
-    def verified($h): ["claude","codex","opencode","pi","pi-signed","grok","kimi"] | index($h);
+    def verified($h): ["claude","codex","opencode","pi","pi-signed","grok","kimi","muse"] | index($h);
     def effort_ok($h; $e):
       if $e == null then true
       elif ($e | type) != "string" then false
@@ -912,6 +912,7 @@ crew_dispatch_validate() {
       elif $h == "codex" then (["low","medium","high","xhigh"] | index($e))
       elif $h == "grok" then (["low","medium","high"] | index($e))
       elif $h == "pi" or $h == "pi-signed" then (["low","medium","high","xhigh","max"] | index($e))
+      elif $h == "muse" then (["low","medium","high","xhigh","max"] | index($e))
       elif $h == "opencode" or $h == "kimi" then false
       else true
       end;

--- a/bin/fm-busy-lib.sh
+++ b/bin/fm-busy-lib.sh
@@ -432,18 +432,51 @@ fm_busy_muse_main_log_path_valid() {  # <sessions-root> <session-log>
     && [ "$leaf" = session.jsonl ]
 }
 
+fm_busy_muse_namespace_day() {  # <sessions-root>
+  printf '%s/%s' "${1%/}" "$(date '+%Y/%m/%d')"
+}
+
+fm_busy_muse_namespace_signature() {  # <day-directory>
+  local first first_signature manifest='' path paths signature
+  if [ ! -d "$1" ]; then
+    printf '%s' missing
+    return 0
+  fi
+  paths=$(find "$1" -mindepth 2 -maxdepth 2 -type f -name session.jsonl -print 2>/dev/null) \
+    || return 1
+  paths=$(printf '%s\n' "$paths" | LC_ALL=C sort) || return 1
+  while IFS= read -r path; do
+    [ -n "$path" ] || continue
+    first=$(sed -n '1p' "$path") || return 1
+    first_signature=$(printf '%s' "$first" | cksum | awk '{ print $1 ":" $2 }') || return 1
+    manifest="${manifest}${path}:${first_signature}
+"
+  done <<EOF
+$paths
+EOF
+  signature=$(printf '%s' "$manifest" | cksum | awk '{ print $1 ":" $2 }') || return 1
+  [ -n "$signature" ] || return 1
+  printf '%s' "$signature"
+}
+
 fm_busy_muse_cached_session_log() {  # <state-dir> <id> <root> <binding-id>
-  local cache_binding log
+  local cache_binding log cache_day cache_signature day signature
   [ -n "$4" ] || return 1
   cache_binding=$(fm_busy_muse_cache_field "$1" "$2" binding_id) || return 1
   [ "$cache_binding" = "$4" ] || return 1
   log=$(fm_busy_muse_cache_field "$1" "$2" session_log) || return 1
   fm_busy_muse_main_log_path_valid "$3" "$log" || return 1
   fm_busy_muse_binding_has_prior_log "$1" "$2" "$log" && return 1
+  cache_day=$(fm_busy_muse_cache_field "$1" "$2" namespace_day) || return 1
+  cache_signature=$(fm_busy_muse_cache_field "$1" "$2" namespace_signature) || return 1
+  day=$(fm_busy_muse_namespace_day "$3") || return 1
+  [ "$cache_day" = "$day" ] || return 1
+  signature=$(fm_busy_muse_namespace_signature "$day") || return 1
+  [ "$cache_signature" = "$signature" ] || return 1
   printf '%s' "$log"
 }
 
-fm_busy_muse_cache_session_log() {  # <state-dir> <id> <binding-id> <session-log>
+fm_busy_muse_cache_session_log() {  # <state-dir> <id> <binding-id> <session-log> <namespace-day> <namespace-signature>
   local cache tmp current
   [ -n "$3" ] || return 0
   current=$(fm_busy_muse_binding_field "$1" "$2" binding_id) || return 1
@@ -453,6 +486,8 @@ fm_busy_muse_cache_session_log() {  # <state-dir> <id> <binding-id> <session-log
   {
     printf 'binding_id=%s\n' "$3"
     printf 'session_log=%s\n' "$4"
+    printf 'namespace_day=%s\n' "$5"
+    printf 'namespace_signature=%s\n' "$6"
   } > "$tmp" || { rm -f "$tmp"; return 1; }
   mv -f -- "$tmp" "$cache"
 }
@@ -461,7 +496,7 @@ fm_busy_muse_cache_session_log() {  # <state-dir> <id> <binding-id> <session-log
 # exist when fm-spawn created this pane's binding. Multiple candidates are
 # ambiguous and fail closed rather than guessing which pane owns either log.
 fm_busy_muse_session_log() {  # <state-dir> <id>
-  local root ws binding_id='' candidate selected='' cache
+  local root ws binding_id='' candidate selected='' cache namespace_day namespace_before namespace_after
   root=$(fm_busy_muse_binding_field "$1" "$2" sessions_root) || return 1
   ws=$(fm_busy_muse_binding_field "$1" "$2" workspace_root) || return 1
   binding_id=$(fm_busy_muse_binding_field "$1" "$2" binding_id 2>/dev/null || true)
@@ -470,6 +505,8 @@ fm_busy_muse_session_log() {  # <state-dir> <id>
     return 0
   fi
   rm -f "$(fm_busy_muse_cache_path "$1" "$2")"
+  namespace_day=$(fm_busy_muse_namespace_day "$root") || return 1
+  namespace_before=$(fm_busy_muse_namespace_signature "$namespace_day") || return 1
   while IFS= read -r candidate; do
     [ -n "$candidate" ] || continue
     fm_busy_muse_binding_has_prior_log "$1" "$2" "$candidate" && continue
@@ -479,7 +516,10 @@ fm_busy_muse_session_log() {  # <state-dir> <id>
 $(fm_busy_muse_matching_logs "$root" "$ws")
 EOF
   [ -n "$selected" ] || return 1
-  fm_busy_muse_cache_session_log "$1" "$2" "$binding_id" "$selected" || return 1
+  namespace_after=$(fm_busy_muse_namespace_signature "$namespace_day") || return 1
+  [ "$namespace_before" = "$namespace_after" ] || return 1
+  fm_busy_muse_cache_session_log "$1" "$2" "$binding_id" "$selected" \
+    "$namespace_day" "$namespace_after" || return 1
   printf '%s' "$selected"
 }
 

--- a/bin/fm-busy-lib.sh
+++ b/bin/fm-busy-lib.sh
@@ -326,18 +326,57 @@ fm_busy_muse_binding_field() {  # <state-dir> <id> <key>
 # lifecycle - folding a child's log would report the parent busy long after the
 # parent's turn ended.
 fm_busy_muse_matching_logs() {  # <sessions-root> <workspace-root>
-  local root=$1 ws=$2 candidate first
+  local root=$1 ws=$2
   [ -d "$root" ] || return 1
-  while IFS= read -r candidate; do
-    [ -n "$candidate" ] || continue
-    IFS= read -r first < "$candidate" 2>/dev/null || continue
-    case "$first" in
-      *"\"workspace_root\":\"$ws\""*) printf '%s\n' "$candidate" ;;
-      *) continue ;;
-    esac
-  done <<EOF
-$(find "$root" -mindepth 5 -maxdepth 5 -name session.jsonl -type f 2>/dev/null)
-EOF
+  command -v node >/dev/null 2>&1 || return 1
+  node - "$root" "$ws" <<'NODE'
+const fs = require("fs");
+const path = require("path");
+const [root, workspace] = process.argv.slice(2);
+
+function directories(parent) {
+  try {
+    return fs.readdirSync(parent, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => path.join(parent, entry.name));
+  } catch {
+    return [];
+  }
+}
+
+function metadataWorkspace(file) {
+  let descriptor;
+  try {
+    descriptor = fs.openSync(file, "r");
+    const buffer = Buffer.alloc(65536);
+    const length = fs.readSync(descriptor, buffer, 0, buffer.length, 0);
+    const newline = buffer.indexOf(10, 0);
+    if (newline < 0 || newline >= length) return null;
+    const record = JSON.parse(buffer.subarray(0, newline).toString("utf8"));
+    return record?.payload?.record?.workspace_root ?? null;
+  } catch {
+    return null;
+  } finally {
+    if (descriptor !== undefined) fs.closeSync(descriptor);
+  }
+}
+
+for (const year of directories(root)) {
+  for (const month of directories(year)) {
+    for (const day of directories(month)) {
+      for (const session of directories(day)) {
+        const file = path.join(session, "session.jsonl");
+        try {
+          if (!fs.lstatSync(file).isFile()) continue;
+        } catch {
+          continue;
+        }
+        if (metadataWorkspace(file) === workspace) process.stdout.write(`${file}\n`);
+      }
+    }
+  }
+}
+NODE
 }
 
 fm_busy_muse_binding_has_prior_log() {  # <state-dir> <id> <session-log>

--- a/bin/fm-busy-lib.sh
+++ b/bin/fm-busy-lib.sh
@@ -295,7 +295,8 @@ fm_busy_muse_idle_verified() {
 
 # fm_busy_muse_binding_path: the per-task sidecar fm-spawn writes so the
 # classifier binds a pane to its session log without re-deriving muse's data
-# directory. Two lines: sessions_root=<abs> and workspace_root=<abs>.
+# directory. It records sessions_root=<abs>, workspace_root=<abs>, and one
+# prior_log=<abs> for each matching main log that predates this pane.
 fm_busy_muse_binding_path() {  # <state-dir> <id>
   printf '%s/%s.muse-session' "$1" "$2"
 }
@@ -318,41 +319,54 @@ fm_busy_muse_binding_field() {  # <state-dir> <id> <key>
   return 1
 }
 
-# fm_busy_file_mtime: epoch mtime, BSD and GNU stat, else fail.
-fm_busy_file_mtime() {  # <path>
-  stat -f %m "$1" 2>/dev/null || stat -c %Y "$1" 2>/dev/null || return 1
-}
-
-# fm_busy_muse_session_log: the newest MAIN session log whose recorded
+# fm_busy_muse_matching_logs: every MAIN session log whose recorded
 # workspace_root is this task's worktree. The depth bounds are what exclude
 # muse's own native sub-agent logs, which live one directory deeper under
 # subagent/<child-session-id>/session.jsonl and carry their own independent run
 # lifecycle - folding a child's log would report the parent busy long after the
-# parent's turn ended. Prints the path, or fails when nothing matches.
-fm_busy_muse_session_log() {  # <state-dir> <id>
-  local root ws candidate first mtime
-  local best='' best_mtime=''
-  root=$(fm_busy_muse_binding_field "$1" "$2" sessions_root) || return 1
-  ws=$(fm_busy_muse_binding_field "$1" "$2" workspace_root) || return 1
+# parent's turn ended.
+fm_busy_muse_matching_logs() {  # <sessions-root> <workspace-root>
+  local root=$1 ws=$2 candidate first
   [ -d "$root" ] || return 1
   while IFS= read -r candidate; do
     [ -n "$candidate" ] || continue
-    # The metadata record is the log's first line and carries workspace_root.
     IFS= read -r first < "$candidate" 2>/dev/null || continue
     case "$first" in
-      *"\"workspace_root\":\"$ws\""*) : ;;
+      *"\"workspace_root\":\"$ws\""*) printf '%s\n' "$candidate" ;;
       *) continue ;;
     esac
-    mtime=$(fm_busy_file_mtime "$candidate") || continue
-    if [ -z "$best_mtime" ] || [ "$mtime" -gt "$best_mtime" ]; then
-      best=$candidate
-      best_mtime=$mtime
-    fi
   done <<EOF
 $(find "$root" -mindepth 5 -maxdepth 5 -name session.jsonl -type f 2>/dev/null)
 EOF
-  [ -n "$best" ] || return 1
-  printf '%s' "$best"
+}
+
+fm_busy_muse_binding_has_prior_log() {  # <state-dir> <id> <session-log>
+  local path line
+  path=$(fm_busy_muse_binding_path "$1" "$2")
+  [ -f "$path" ] || return 1
+  while IFS= read -r line || [ -n "$line" ]; do
+    [ "$line" = "prior_log=$3" ] && return 0
+  done < "$path"
+  return 1
+}
+
+# fm_busy_muse_session_log: the one matching MAIN session log that did not
+# exist when fm-spawn created this pane's binding. Multiple candidates are
+# ambiguous and fail closed rather than guessing which pane owns either log.
+fm_busy_muse_session_log() {  # <state-dir> <id>
+  local root ws candidate selected=''
+  root=$(fm_busy_muse_binding_field "$1" "$2" sessions_root) || return 1
+  ws=$(fm_busy_muse_binding_field "$1" "$2" workspace_root) || return 1
+  while IFS= read -r candidate; do
+    [ -n "$candidate" ] || continue
+    fm_busy_muse_binding_has_prior_log "$1" "$2" "$candidate" && continue
+    [ -z "$selected" ] || return 1
+    selected=$candidate
+  done <<EOF
+$(fm_busy_muse_matching_logs "$root" "$ws")
+EOF
+  [ -n "$selected" ] || return 1
+  printf '%s' "$selected"
 }
 
 # fm_busy_muse_run_state: fold one session log to busy|settled|none.

--- a/bin/fm-busy-lib.sh
+++ b/bin/fm-busy-lib.sh
@@ -34,14 +34,16 @@
 #   codex-hook, codex-appserver  reserved: Codex, gated by
 #                    fm_busy_codex_semantic_source
 #   kimi-wire, kimi-hook  reserved: standalone Kimi, gated by fm_busy_kimi_verified
+#   muse-session-log  classifier-only: muse's own durable session event log
+#                     (see the muse arm below); never written into a record
 # Firstmate-owned sources accepted for every converted adapter:
 #   fm-spawn         the launch-brief turn seeded at spawn
 #   fm-interrupt     a firstmate-controlled interruption of the worker
 #   fm-recovery      a documented recovery reset after relaunch
 # Classifier-only sources (never written into a record):
-#   endpoint-gone, herdr-native, grok-regex, missing, malformed,
-#   gen-mismatch, source-mismatch, kimi-unverified, codex-unverified,
-#   capture-failed, no-target
+#   endpoint-gone, herdr-native, grok-regex, muse-session-log, missing,
+#   malformed, gen-mismatch, source-mismatch, kimi-unverified,
+#   codex-unverified, capture-failed, no-target
 #
 # Classification (fm_busy_classify): busy | idle | unknown | dead, always
 # with the producing source as the second token. Precedence:
@@ -50,8 +52,8 @@
 #   3. a valid, gen-matching, source-trusted record -> its state and source
 #   4. no record at all: herdr's native busy verdict is trusted as busy
 #      (generation state is sufficient for busy, not for idle), then the
-#      Grok-only temporary regex fallback classifies a grok task from its
-#      rendered tail, then unknown missing
+#      muse session-log arm, then the Grok-only temporary regex fallback
+#      classifies a grok task from its rendered tail, then unknown missing
 #   5. malformed, stale, or untrusted records -> unknown, never a fallback
 # The Grok arm is the ONLY rendered-text classification that survives the
 # redesign, because Grok's structured lifecycle was not credited-live-verified
@@ -59,6 +61,14 @@
 # another adapter. The delivery guards in bin/fm-tmux-lib.sh match rendered
 # footers for submit acknowledgement and away-mode supervisor injection only;
 # neither is a recorded worker state source.
+#
+# The muse arm is semantic, not rendered: it folds muse's own durable session
+# event log. It is a PULL source with no writer, no arm, and no gen, because
+# muse's default build ships no hook or plugin surface that could push events
+# (its plugin engine reports "plugins are not available in this build" without
+# MUSE_EXPERIMENTAL_PLUGINS). Nothing is armed for muse for the same reason
+# standalone Kimi is not: a seeded record with no writer could never be
+# cleared. See fm_busy_muse_run_state for the fold and its verification gate.
 #
 # Codex negotiation (fm_busy_codex_appserver_observable,
 # fm_busy_codex_hooks_verified): the approved contract prefers Codex's
@@ -161,8 +171,11 @@ fm_busy_current_gen() {  # <state-dir> <id>
 # fm_busy_sources_for_harness: the semantic sources trusted to classify a
 # task recorded with <harness>. One line, space-separated, possibly empty.
 # The firstmate-owned sources are appended for every converted adapter.
-# Grok deliberately trusts nothing: it has no semantic writer yet, and its
-# temporary rendered-tail fallback lives in the classifier, not in records.
+# Grok and muse deliberately trust nothing: neither has a semantic WRITER, so
+# neither is armed, and both classify through a classifier arm that reads the
+# live source on demand (grok's rendered tail, muse's session log) rather than
+# through a stored record. Listing a source here without a writer that can
+# clear it would seed a busy record nothing could ever settle.
 fm_busy_sources_for_harness() {  # <harness>
   local adapter=
   case "${1:-}" in
@@ -246,6 +259,139 @@ fm_busy_record_read() {  # <state-dir> <id>
   printf '%s %s %s %s' "$r_state" "$r_source" "$r_event" "$r_seq"
 }
 
+# ---------------------------------------------------------------------------
+# muse session-log busy source
+#
+# muse persists an append-only session event log per session at
+# <sessions-root>/YYYY/MM/DD/<session-uuid>/session.jsonl, and brackets every
+# submitted turn with one run lifecycle pair. Verified live on muse
+# 0.1.0-R708.1 across completed, interrupted, and killed-mid-turn turns:
+#   {"payload":{"kind":"run","run_id":"<uuid>","event":{"kind":"started",...
+#   {"payload":{"kind":"run","run_id":"<uuid>","event":{"kind":"terminal",
+#     "terminal":"completed"|"cancelled",...
+# An Escape interrupt closes its run with terminal=cancelled, so unlike Claude's
+# Stop hook this source covers the interrupt path itself. Any later
+# run_retracted records follow the terminal rather than replacing it.
+#
+# fm_busy_muse_idle_verified is the gate on the IDLE half only. Busy needs no
+# gate: an open run is positive proof a turn is in flight. Idle does, because a
+# settled log only proves no run is open RIGHT NOW, and the multi-step,
+# real-model tool loop that would show whether one turn stays inside one run is
+# unverified - the credentialed smoke is deferred (docs/verification/muse.md).
+# If it turned out a real turn spans several runs, an ungated idle would report
+# a working crewmate as finished; reporting unknown instead is the safe
+# direction, because unknown is never promoted to either boolean pole.
+#
+# To open the gate: run a real multi-step tool-loop turn on a
+# firstmate-launched muse worker with META_API_KEY set, confirm exactly one
+# started/terminal pair brackets the whole turn (not one pair per model step),
+# record the version, exact commands, and observed output in
+# docs/verification/muse.md, and add the verified version string(s) here.
+FM_BUSY_MUSE_IDLE_VERIFIED_VERSIONS=""
+
+fm_busy_muse_idle_verified() {
+  [ -n "$FM_BUSY_MUSE_IDLE_VERIFIED_VERSIONS" ]
+}
+
+# fm_busy_muse_binding_path: the per-task sidecar fm-spawn writes so the
+# classifier binds a pane to its session log without re-deriving muse's data
+# directory. Two lines: sessions_root=<abs> and workspace_root=<abs>.
+fm_busy_muse_binding_path() {  # <state-dir> <id>
+  printf '%s/%s.muse-session' "$1" "$2"
+}
+
+# fm_busy_muse_binding_field: read one field from the sidecar, or fail.
+fm_busy_muse_binding_field() {  # <state-dir> <id> <key>
+  local path line key=$3
+  path=$(fm_busy_muse_binding_path "$1" "$2")
+  [ -f "$path" ] || return 1
+  while IFS= read -r line || [ -n "$line" ]; do
+    case "$line" in
+      "$key="*)
+        line=${line#"$key="}
+        [ -n "$line" ] || return 1
+        printf '%s' "$line"
+        return 0
+        ;;
+    esac
+  done < "$path"
+  return 1
+}
+
+# fm_busy_file_mtime: epoch mtime, BSD and GNU stat, else fail.
+fm_busy_file_mtime() {  # <path>
+  stat -f %m "$1" 2>/dev/null || stat -c %Y "$1" 2>/dev/null || return 1
+}
+
+# fm_busy_muse_session_log: the newest MAIN session log whose recorded
+# workspace_root is this task's worktree. The depth bounds are what exclude
+# muse's own native sub-agent logs, which live one directory deeper under
+# subagent/<child-session-id>/session.jsonl and carry their own independent run
+# lifecycle - folding a child's log would report the parent busy long after the
+# parent's turn ended. Prints the path, or fails when nothing matches.
+fm_busy_muse_session_log() {  # <state-dir> <id>
+  local root ws candidate first mtime
+  local best='' best_mtime=''
+  root=$(fm_busy_muse_binding_field "$1" "$2" sessions_root) || return 1
+  ws=$(fm_busy_muse_binding_field "$1" "$2" workspace_root) || return 1
+  [ -d "$root" ] || return 1
+  while IFS= read -r candidate; do
+    [ -n "$candidate" ] || continue
+    # The metadata record is the log's first line and carries workspace_root.
+    IFS= read -r first < "$candidate" 2>/dev/null || continue
+    case "$first" in
+      *"\"workspace_root\":\"$ws\""*) : ;;
+      *) continue ;;
+    esac
+    mtime=$(fm_busy_file_mtime "$candidate") || continue
+    if [ -z "$best_mtime" ] || [ "$mtime" -gt "$best_mtime" ]; then
+      best=$candidate
+      best_mtime=$mtime
+    fi
+  done <<EOF
+$(find "$root" -mindepth 5 -maxdepth 5 -name session.jsonl -type f 2>/dev/null)
+EOF
+  [ -n "$best" ] || return 1
+  printf '%s' "$best"
+}
+
+# fm_busy_muse_run_state: fold one session log to busy|settled|none.
+#   busy     at least one run started with no matching terminal
+#   settled  every started run reached a terminal
+#   none     the log holds no run lifecycle records at all
+# The match is anchored on the exact structural prefix rather than a bare
+# "kind":"terminal" search, because muse also emits nested "record":{"kind":
+# "terminal"} cleanup-effect payloads that are NOT run terminals and would
+# otherwise close a run that is still in flight.
+fm_busy_muse_run_state() {  # <session-log>
+  [ -f "$1" ] || return 1
+  LC_ALL=C awk '
+    BEGIN { pre = "\"payload\":{\"kind\":\"run\",\"run_id\":\"" }
+    {
+      p = index($0, pre)
+      if (p == 0) next
+      rest = substr($0, p + length(pre))
+      q = index(rest, "\"")
+      if (q == 0) next
+      rid = substr(rest, 1, q - 1)
+      rest = substr(rest, q)
+      head = "\",\"event\":{\"kind\":\""
+      if (substr(rest, 1, length(head)) != head) next
+      rest = substr(rest, length(head) + 1)
+      q = index(rest, "\"")
+      if (q == 0) next
+      ev = substr(rest, 1, q - 1)
+      if (ev == "started") { open[rid] = 1; seen = 1 }
+      else if (ev == "terminal") { open[rid] = 0 }
+    }
+    END {
+      if (!seen) { print "none"; exit }
+      for (r in open) if (open[r] == 1) { print "busy"; exit }
+      print "settled"
+    }
+  ' "$1"
+}
+
 # fm_busy_grok_tail_busy: the Grok-only temporary rendered-tail fallback.
 # Consumes the tail on stdin; 0 when Grok's verified busy signature matches.
 # FM_BUSY_REGEX still globally overrides the signature, mirroring the
@@ -263,7 +409,7 @@ fm_busy_grok_tail_busy() {
 # if available, else reports unknown capture-failed.
 fm_busy_classify() {  # <backend> <target> <harness> <id> <state-dir> [tail40]
   local backend=$1 target=$2 harness=$3 id=$4 state=$5 tail40=${6-}
-  local out rc r_state r_source native
+  local out rc r_state r_source native log
   case "$harness" in
     kimi*)
       if ! fm_busy_kimi_verified; then
@@ -308,6 +454,29 @@ fm_busy_classify() {  # <backend> <target> <harness> <id> <state-dir> [tail40]
     fi
   fi
   case "$harness" in
+    muse*)
+      # Semantic, on demand: fold this task's bound session log. An open run is
+      # positive proof of a turn in flight; a settled log only classifies idle
+      # once fm_busy_muse_idle_verified opens on a credentialed multi-step run.
+      # Every other outcome - no sidecar, no matching log, an unreadable or
+      # run-free log - is unknown, never idle.
+      if ! log=$(fm_busy_muse_session_log "$state" "$id"); then
+        printf 'unknown muse-session-log'
+        return 0
+      fi
+      case "$(fm_busy_muse_run_state "$log" 2>/dev/null)" in
+        busy) printf 'busy muse-session-log' ;;
+        settled)
+          if fm_busy_muse_idle_verified; then
+            printf 'idle muse-session-log'
+          else
+            printf 'unknown muse-session-log'
+          fi
+          ;;
+        *) printf 'unknown muse-session-log' ;;
+      esac
+      return 0
+      ;;
     grok*)
       if [ -z "$tail40" ]; then
         if command -v fm_backend_capture >/dev/null 2>&1; then

--- a/bin/fm-busy-lib.sh
+++ b/bin/fm-busy-lib.sh
@@ -34,8 +34,6 @@
 #   codex-hook, codex-appserver  reserved: Codex, gated by
 #                    fm_busy_codex_semantic_source
 #   kimi-wire, kimi-hook  reserved: standalone Kimi, gated by fm_busy_kimi_verified
-#   muse-session-log  classifier-only: muse's own durable session event log
-#                     (see the muse arm below); never written into a record
 # Firstmate-owned sources accepted for every converted adapter:
 #   fm-spawn         the launch-brief turn seeded at spawn
 #   fm-interrupt     a firstmate-controlled interruption of the worker
@@ -52,7 +50,7 @@
 #   3. a valid, gen-matching, source-trusted record -> its state and source
 #   4. no record at all: herdr's native busy verdict is trusted as busy
 #      (generation state is sufficient for busy, not for idle), then the
-#      muse session-log arm, then the Grok-only temporary regex fallback
+#      muse session-log pull source, then the Grok-only temporary regex fallback
 #      classifies a grok task from its rendered tail, then unknown missing
 #   5. malformed, stale, or untrusted records -> unknown, never a fallback
 # The Grok arm is the ONLY rendered-text classification that survives the
@@ -62,8 +60,8 @@
 # footers for submit acknowledgement and away-mode supervisor injection only;
 # neither is a recorded worker state source.
 #
-# The muse arm is semantic, not rendered: it folds muse's own durable session
-# event log. It is a PULL source with no writer, no arm, and no gen, because
+# The muse pull source is semantic, not rendered: it folds muse's own durable
+# session event log. It has no writer, no arm, and no gen, because
 # muse's default build ships no hook or plugin surface that could push events
 # (its plugin engine reports "plugins are not available in this build" without
 # MUSE_EXPERIMENTAL_PLUGINS). Nothing is armed for muse for the same reason
@@ -172,10 +170,10 @@ fm_busy_current_gen() {  # <state-dir> <id>
 # task recorded with <harness>. One line, space-separated, possibly empty.
 # The firstmate-owned sources are appended for every converted adapter.
 # Grok and muse deliberately trust nothing: neither has a semantic WRITER, so
-# neither is armed, and both classify through a classifier arm that reads the
-# live source on demand (grok's rendered tail, muse's session log) rather than
-# through a stored record. Listing a source here without a writer that can
-# clear it would seed a busy record nothing could ever settle.
+# neither is armed, and both read their live source on demand in the classifier
+# (grok's rendered tail, muse's session log) rather than through a stored
+# record. Listing a source here without a writer that can clear it would seed a
+# busy record nothing could ever settle.
 fm_busy_sources_for_harness() {  # <harness>
   local adapter=
   case "${1:-}" in

--- a/bin/fm-busy-lib.sh
+++ b/bin/fm-busy-lib.sh
@@ -295,10 +295,15 @@ fm_busy_muse_idle_verified() {
 
 # fm_busy_muse_binding_path: the per-task sidecar fm-spawn writes so the
 # classifier binds a pane to its session log without re-deriving muse's data
-# directory. It records sessions_root=<abs>, workspace_root=<abs>, and one
-# prior_log=<abs> for each matching main log that predates this pane.
+# directory. It records sessions_root=<abs>, workspace_root=<abs>, one
+# binding_id=<token>, and one prior_log=<abs> for each matching main log that
+# predates this pane.
 fm_busy_muse_binding_path() {  # <state-dir> <id>
   printf '%s/%s.muse-session' "$1" "$2"
+}
+
+fm_busy_muse_cache_path() {  # <state-dir> <id>
+  printf '%s/%s.muse-session-current' "$1" "$2"
 }
 
 # fm_busy_muse_binding_field: read one field from the sidecar, or fail.
@@ -389,13 +394,82 @@ fm_busy_muse_binding_has_prior_log() {  # <state-dir> <id> <session-log>
   return 1
 }
 
+fm_busy_muse_cache_field() {  # <state-dir> <id> <key>
+  local path line key=$3
+  path=$(fm_busy_muse_cache_path "$1" "$2")
+  [ -f "$path" ] || return 1
+  while IFS= read -r line || [ -n "$line" ]; do
+    case "$line" in
+      "$key="*)
+        line=${line#"$key="}
+        [ -n "$line" ] || return 1
+        printf '%s' "$line"
+        return 0
+        ;;
+    esac
+  done < "$path"
+  return 1
+}
+
+fm_busy_muse_main_log_path_valid() {  # <sessions-root> <session-log>
+  local root=${1%/} log=$2 rel year month day session leaf
+  while :; do
+    case "$root" in
+      *'//'*) root=${root//\/\//\/} ;;
+      *) break ;;
+    esac
+  done
+  [ -n "$root" ] && [ -f "$log" ] && [ ! -L "$log" ] || return 1
+  case "$log" in
+    "$root"/*) rel=${log#"$root"/} ;;
+    *) return 1 ;;
+  esac
+  year=${rel%%/*}; rel=${rel#*/}
+  month=${rel%%/*}; rel=${rel#*/}
+  day=${rel%%/*}; rel=${rel#*/}
+  session=${rel%%/*}; leaf=${rel#*/}
+  [ -n "$year" ] && [ -n "$month" ] && [ -n "$day" ] && [ -n "$session" ] \
+    && [ "$leaf" = session.jsonl ]
+}
+
+fm_busy_muse_cached_session_log() {  # <state-dir> <id> <root> <binding-id>
+  local cache_binding log
+  [ -n "$4" ] || return 1
+  cache_binding=$(fm_busy_muse_cache_field "$1" "$2" binding_id) || return 1
+  [ "$cache_binding" = "$4" ] || return 1
+  log=$(fm_busy_muse_cache_field "$1" "$2" session_log) || return 1
+  fm_busy_muse_main_log_path_valid "$3" "$log" || return 1
+  fm_busy_muse_binding_has_prior_log "$1" "$2" "$log" && return 1
+  printf '%s' "$log"
+}
+
+fm_busy_muse_cache_session_log() {  # <state-dir> <id> <binding-id> <session-log>
+  local cache tmp current
+  [ -n "$3" ] || return 0
+  current=$(fm_busy_muse_binding_field "$1" "$2" binding_id) || return 1
+  [ "$current" = "$3" ] || return 1
+  cache=$(fm_busy_muse_cache_path "$1" "$2")
+  tmp="$cache.tmp.$$"
+  {
+    printf 'binding_id=%s\n' "$3"
+    printf 'session_log=%s\n' "$4"
+  } > "$tmp" || { rm -f "$tmp"; return 1; }
+  mv -f -- "$tmp" "$cache"
+}
+
 # fm_busy_muse_session_log: the one matching MAIN session log that did not
 # exist when fm-spawn created this pane's binding. Multiple candidates are
 # ambiguous and fail closed rather than guessing which pane owns either log.
 fm_busy_muse_session_log() {  # <state-dir> <id>
-  local root ws candidate selected=''
+  local root ws binding_id='' candidate selected='' cache
   root=$(fm_busy_muse_binding_field "$1" "$2" sessions_root) || return 1
   ws=$(fm_busy_muse_binding_field "$1" "$2" workspace_root) || return 1
+  binding_id=$(fm_busy_muse_binding_field "$1" "$2" binding_id 2>/dev/null || true)
+  if cache=$(fm_busy_muse_cached_session_log "$1" "$2" "$root" "$binding_id"); then
+    printf '%s' "$cache"
+    return 0
+  fi
+  rm -f "$(fm_busy_muse_cache_path "$1" "$2")"
   while IFS= read -r candidate; do
     [ -n "$candidate" ] || continue
     fm_busy_muse_binding_has_prior_log "$1" "$2" "$candidate" && continue
@@ -405,6 +479,7 @@ fm_busy_muse_session_log() {  # <state-dir> <id>
 $(fm_busy_muse_matching_logs "$root" "$ws")
 EOF
   [ -n "$selected" ] || return 1
+  fm_busy_muse_cache_session_log "$1" "$2" "$binding_id" "$selected" || return 1
   printf '%s' "$selected"
 }
 

--- a/bin/fm-composer-lib.sh
+++ b/bin/fm-composer-lib.sh
@@ -19,8 +19,12 @@
 # container - a bordered composer box, where the harness draws its own prompt
 # glyph (e.g. claude's older `| > ... |`). On a bare, unstructured row it is a
 # dead-shell prompt and is NEVER "empty"; it classifies as `unknown` (not a safe
-# injection target). The AGENT prompt glyphs `❯` (claude) and `›` (codex) are a
-# genuine empty agent composer either way, bordered or bare.
+# injection target). The AGENT prompt glyphs `❯` (claude), `›` (codex), and
+# `⟩` (U+27E9, muse) are a genuine empty agent composer either way, bordered or
+# bare. Every agent glyph must be listed in ALL THREE places below - the
+# ghost-stripped-to-empty fallback, the bare-row case, and the leading-glyph
+# strip - because a glyph present in only some of them classifies inconsistently
+# depending on how its harness happens to colour the row.
 #
 # GHOST/PLACEHOLDER TEXT is the other half of this owner (task
 # afk-herdr-false-pending): a harness fills an otherwise-empty composer with
@@ -80,6 +84,11 @@ fm_composer_strip_ansi() {
 #     no fleet harness uses it for ghost text, so it is kept (real text wins:
 #     under-stripping merely defers, which the max-defer alarm surfaces, while
 #     over-stripping would inject over real input).
+# Raising FM_COMPOSER_GHOST_LUMA_MAX is not free: muse draws its `⟩` prompt glyph
+# in truecolor 38;2;90;160;255, luminance ~149.9 (verified, muse 0.1.0-R708.1),
+# the tightest margin over the 128 default in the fleet. Above ~150 that glyph is
+# stripped as ghost text, which is why the bare-glyph fallback below must also
+# recognise every agent glyph from the UNSTRIPPED plain row.
 # The dim/faint and dark-foreground states are tracked together as "de-emphasis";
 # codes are processed left to right within a sequence, so "ESC[0;2m" reads as dim.
 # LC_ALL=C makes awk walk bytes, so multibyte glyphs (e.g. ❯) and de-emphasised
@@ -185,13 +194,13 @@ fm_composer_classify_content() {  # <bordered> <content> [idle_re] [idle_case] [
   plain_content=${5:-$content}
   if [ "$bordered" != 1 ] && [ -z "$content" ] && [ -n "$plain_content" ]; then
     case "$plain_content" in
-      '❯'|'›') printf 'empty'; return 0 ;;
+      '❯'|'›'|'⟩') printf 'empty'; return 0 ;;
       *) printf 'unknown'; return 0 ;;
     esac
   fi
   # A bare prompt glyph on its own row.
   case "$content" in
-    '❯'|'›')
+    '❯'|'›'|'⟩')
       # Agent prompt glyph: a genuine empty agent composer, bordered or bare.
       printf 'empty'; return 0 ;;
     '>'|'$'|'%'|'#')
@@ -208,8 +217,8 @@ fm_composer_classify_content() {  # <bordered> <content> [idle_re] [idle_case] [
   fi
   # Strip a leading prompt glyph, then re-judge the remainder.
   case "$content" in
-    '❯ '*|'› '*|'> '*|'$ '*|'% '*|'# '*) content=${content#??} ;;
-    '❯'*|'›'*|'>'*|'$'*|'%'*|'#'*) content=${content#?} ;;
+    '❯ '*|'› '*|'⟩ '*|'> '*|'$ '*|'% '*|'# '*) content=${content#??} ;;
+    '❯'*|'›'*|'⟩'*|'>'*|'$'*|'%'*|'#'*) content=${content#?} ;;
   esac
   content="${content#"${content%%[![:space:]]*}"}"
   content="${content%"${content##*[![:space:]]}"}"

--- a/bin/fm-harness.sh
+++ b/bin/fm-harness.sh
@@ -66,7 +66,7 @@ detect_own() {
       # name carries the version and CHANGES on every auto-update. Match the stable
       # prefix rather than any exact name. Deliberately anchored, never *muse*, so
       # unrelated commands (musescore, amuse) cannot be misread as this harness.
-      muse|muse-bin*) echo muse; return ;;
+      muse|muse-bin-*) echo muse; return ;;
       pi-signed) echo pi; return ;;
       pi) echo pi; return ;;
       node*|python*)

--- a/bin/fm-harness.sh
+++ b/bin/fm-harness.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Detect the agent harness this process tree runs on.
-# Usage: fm-harness.sh                  print own harness: claude|codex|opencode|pi|pi-signed|grok|kimi|unknown
+# Usage: fm-harness.sh                  print own harness: claude|codex|opencode|pi|pi-signed|grok|kimi|muse|unknown
 #        fm-harness.sh crew             print the effective CREWMATE harness
 #                                        (config/crew-harness; "default" resolves to own)
 #        fm-harness.sh secondmate       print the harness the PRIMARY uses to launch
@@ -31,7 +31,7 @@ detect_own() {
   # Layer 1: environment markers for verified harnesses.
   # Keep marker detection before ancestry detection as an explicit precedence rule.
   # Only claude, pi, and grok set verified markers of their own; codex, opencode,
-  # and kimi are markerless, so a foreign marker retained in a terminal
+  # kimi, and muse are markerless, so a foreign marker retained in a terminal
   # multiplexer's stored environment can silently misidentify one of them before
   # ancestry is consulted. This is a precedence hazard, not evidence that
   # CLAUDECODE inheritance into a kimi child was observed; it was not observed.
@@ -44,6 +44,13 @@ detect_own() {
   # It does NOT set CLAUDECODE despite being Claude-Code-compatible, so this marker
   # is unambiguous when firstmate runs natively on grok.
   [ "${GROK_AGENT:-}" = "1" ] && { echo grok; return; }
+  # muse (Muse Code) publishes no harness-identity marker of its own. The only
+  # MUSE_* variable it is documented to hand a child is MUSE_CURRENT_SESSION_LOG,
+  # a per-session log PATH rather than an identity, and its export to tool
+  # subprocesses is unverified (verified: muse 0.1.0-R708.1), so muse is detected
+  # by ancestry alone below. Do NOT promote MUSE_CURRENT_SESSION_LOG to a marker
+  # without verifying it reaches children AND that it cannot survive in a
+  # multiplexer's stored environment, which is the precedence hazard above.
   # Layer 2: walk the parent chain and match the command name.
   local pid=$$ comm args
   for _ in 1 2 3 4 5 6 7 8; do
@@ -54,6 +61,12 @@ detect_own() {
       *opencode*) echo opencode; return ;;
       *grok*) echo grok; return ;;
       kimi) echo kimi; return ;;
+      # muse's installed launcher ~/.local/bin/muse execs ~/.local/bin/muse-bin-<version>
+      # (verified in the published launcher, muse 0.1.0-R708.1), so the live process
+      # name carries the version and CHANGES on every auto-update. Match the stable
+      # prefix rather than any exact name. Deliberately anchored, never *muse*, so
+      # unrelated commands (musescore, amuse) cannot be misread as this harness.
+      muse|muse-bin*) echo muse; return ;;
       pi-signed) echo pi; return ;;
       pi) echo pi; return ;;
       node*|python*)

--- a/bin/fm-send.sh
+++ b/bin/fm-send.sh
@@ -103,6 +103,13 @@ fm_send_clear_after_interrupt() {  # <key>
   fi
 }
 
+fm_send_normalize_key() {  # <key>
+  case "$1" in
+    Escape|escape|Esc|esc) printf '%s' Escape ;;
+    *) printf '%s' "$1" ;;
+  esac
+}
+
 fm_send_record_interrupt() {  # <key>
   local key=$1 id gen
   [ "$key" = Escape ] || return 0
@@ -279,17 +286,19 @@ fi
 # error with the attempted resolution attached.
 
 if [ "${1:-}" = "--key" ]; then
+  key=$2
+  semantic_key=$(fm_send_normalize_key "$key")
   if [ "$TARGET_BACKEND" = remote ]; then
-    if ! "$SCRIPT_DIR/fm-on.sh" "$TARGET_REMOTE_ID" fm-remote-secondmate-control.sh key "$TARGET_REMOTE_ID" "$2" < /dev/null; then
-      echo "error: key '$2' not sent to remote secondmate $TARGET_REMOTE_ID; completion may be unknown" >&2
+    if ! "$SCRIPT_DIR/fm-on.sh" "$TARGET_REMOTE_ID" fm-remote-secondmate-control.sh key "$TARGET_REMOTE_ID" "$key" < /dev/null; then
+      echo "error: key '$key' not sent to remote secondmate $TARGET_REMOTE_ID; completion may be unknown" >&2
       exit 1
     fi
-  elif ! fm_backend_send_key "$TARGET_BACKEND" "$T" "$2" "$EXPECTED_LABEL"; then
-    echo "error: key '$2' not sent to $T ($TARGET_BACKEND send failed; tried $RESOLUTION_TRIED)" >&2
+  elif ! fm_backend_send_key "$TARGET_BACKEND" "$T" "$key" "$EXPECTED_LABEL"; then
+    echo "error: key '$key' not sent to $T ($TARGET_BACKEND send failed; tried $RESOLUTION_TRIED)" >&2
     exit 1
   fi
-  fm_send_clear_after_interrupt "$2" || exit 1
-  fm_send_record_interrupt "$2" || exit 1
+  fm_send_clear_after_interrupt "$semantic_key" || exit 1
+  fm_send_record_interrupt "$semantic_key" || exit 1
 else
   MESSAGE=$*
   if [ "$MARK_FROM_FIRSTMATE" = 1 ]; then

--- a/bin/fm-send.sh
+++ b/bin/fm-send.sh
@@ -84,6 +84,25 @@ fm_send_id_from_meta() {  # <meta-file>
   printf '%s' "${base%.meta}"
 }
 
+# fm_send_clear_after_interrupt: muse RESTORES the interrupted prompt back into
+# the composer when Escape cancels a turn, as real bright text (verified: fg
+# 38;2;204;211;219, luminance ~210, muse 0.1.0-R708.1), not de-emphasised ghost
+# text. Classifying that as pending input is correct - the text really is
+# unsubmitted - but leaving it there means the NEXT steer types onto the end of
+# it and submits both as one garbled message. Ctrl-U clears the composer
+# (verified), so the interrupt is not complete until it has been sent. A failed
+# clear is loud rather than silent, because the alternative is a corrupted steer.
+fm_send_clear_after_interrupt() {  # <key>
+  local key=$1
+  [ "$key" = Escape ] || return 0
+  case "$TARGET_HARNESS" in muse*) : ;; *) return 0 ;; esac
+  [ "$TARGET_BACKEND" != remote ] || return 0
+  if ! fm_backend_send_key "$TARGET_BACKEND" "$T" C-u "$EXPECTED_LABEL"; then
+    echo "error: Escape reached $T, but the muse composer could not be cleared; it still holds the restored prompt. Clear it before sending the next message." >&2
+    return 1
+  fi
+}
+
 fm_send_record_interrupt() {  # <key>
   local key=$1 id gen
   [ "$key" = Escape ] || return 0
@@ -269,6 +288,7 @@ if [ "${1:-}" = "--key" ]; then
     echo "error: key '$2' not sent to $T ($TARGET_BACKEND send failed; tried $RESOLUTION_TRIED)" >&2
     exit 1
   fi
+  fm_send_clear_after_interrupt "$2" || exit 1
   fm_send_record_interrupt "$2" || exit 1
 else
   MESSAGE=$*

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -134,8 +134,8 @@
 # grok uses a firstmate-owned global hook under ${GROK_HOME:-$HOME/.grok}/hooks
 # plus a gitignored .fm-grok-turnend worktree pointer and a state token.
 # muse installs no hook at all - its plugin engine is off in the default build - so
-# it writes only state/<id>.muse-session, the sidecar binding the pane to muse's own
-# session event log; muse is crewmate/scout only and is refused for --secondmate.
+# it writes state/<id>.muse-session to bind the pane to muse's own session event
+# log; muse is crewmate/scout only and is refused for --secondmate.
 # On success prints: spawned <id> harness=<name> kind=<ship|scout|secondmate> [mode=<mode> yolo=<on|off>] window=<backend-target> worktree=<path>
 # A ship task records the explicit mode/yolo it was passed; a secondmate spawn records
 # mode=secondmate, yolo=off, home=, and projects=; a scout records neither, and both the
@@ -2094,16 +2094,19 @@ EOF
       # source with no writer, so nothing is armed and no record is seeded -
       # exactly the reason standalone Kimi is not armed either.
       # This sidecar is the whole binding: it pins the sessions root, the
-      # workspace root that muse records in each log's metadata, and every
-      # matching main log that predates this pane. The classifier then accepts
-      # only one new matching log, so it never guesses between pane
-      # incarnations. Recording the resolved root here also means a later
-      # change to XDG_DATA_HOME cannot silently re-point an already-running
-      # task at a different log tree.
+      # workspace root that muse records in each log's metadata, this pane's
+      # binding identity, and every matching main log that predates this pane.
+      # The classifier then accepts only one new matching log, so it never
+      # guesses between pane incarnations. Recording the resolved root here
+      # also means a later change to XDG_DATA_HOME cannot silently re-point an
+      # already-running task at a different log tree.
       MUSE_SESSIONS_ROOT="${MUSE_DATA_HOME:-${XDG_DATA_HOME:-$HOME/.local/share}}/muse/sessions"
+      MUSE_BINDING_ID="$$.$RANDOM.$(date +%s)"
+      rm -f "$STATE/$ID.muse-session-current"
       {
         printf 'sessions_root=%s\n' "$MUSE_SESSIONS_ROOT"
         printf 'workspace_root=%s\n' "$WT"
+        printf 'binding_id=%s\n' "$MUSE_BINDING_ID"
         while IFS= read -r MUSE_PRIOR_LOG; do
           [ -n "$MUSE_PRIOR_LOG" ] && printf 'prior_log=%s\n' "$MUSE_PRIOR_LOG"
         done <<EOF

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -83,7 +83,7 @@
 #   profile consultation. A --secondmate spawn is exempt and resolves the SECONDMATE
 #   harness (config/secondmate-harness -> config/crew-harness -> own), so the
 #   secondmate-vs-crewmate split is DURABLE across every respawn (recovery,
-#   /updatefirstmate, restart). A bare adapter name (claude|codex|opencode|pi|pi-signed|grok|kimi)
+#   /updatefirstmate, restart). A bare adapter name (claude|codex|opencode|pi|pi-signed|grok|kimi|muse)
 #   overrides it for this spawn (either kind). A non-flag string containing
 #   whitespace is treated as a RAW launch command - the escape hatch for verifying
 #   new adapters. pi-signed launches that exact executable name from PATH and
@@ -133,6 +133,9 @@
 # a firstmate-owned global hook and registry, and a gitignored per-task pointer.
 # grok uses a firstmate-owned global hook under ${GROK_HOME:-$HOME/.grok}/hooks
 # plus a gitignored .fm-grok-turnend worktree pointer and a state token.
+# muse installs no hook at all - its plugin engine is off in the default build - so
+# it writes only state/<id>.muse-session, the sidecar binding the pane to muse's own
+# session event log; muse is crewmate/scout only and is refused for --secondmate.
 # On success prints: spawned <id> harness=<name> kind=<ship|scout|secondmate> [mode=<mode> yolo=<on|off>] window=<backend-target> worktree=<path>
 # A ship task records the explicit mode/yolo it was passed; a secondmate spawn records
 # mode=secondmate, yolo=off, home=, and projects=; a scout records neither, and both the
@@ -849,6 +852,27 @@ launch_template() {
     # Its turn-end signal is a globally configured Stop hook plus a guarded
     # per-task worktree token, so no launch placeholder belongs here.
     kimi) printf '%s' '__KIMIBIN__ __MODELFLAG__--auto' ;;
+    # muse (Muse Code): a positional prompt starts the supervised interactive
+    # session. --yolo is the single flag that makes a crewmate pane viable: muse
+    # ships approval prompts AND a filesystem/network sandbox ON by default
+    # (--sandbox-network defaults to proxy-only, which refuses outright without a
+    # managed proxy), and it gates a fresh workspace behind a trust dialog. One
+    # --yolo disables approval, disables the sandbox so git and network work, and
+    # trusts the workspace for the run, so no dialog appears on the fresh
+    # per-task worktree (verified, muse 0.1.0-R708.1).
+    # MUSE_EXPERIMENTAL_FOREIGN_PERSONAL_CONTEXT_KILL=on is the privacy control:
+    # muse otherwise loads the OPERATOR's foreign personal rules from ~/.claude
+    # into every run and ships them to Meta-hosted inference, even under an
+    # isolated XDG_CONFIG_HOME. exec mode's --no-foreign-personal-context flag is
+    # NOT accepted by the interactive TUI (it exits with "unexpected argument"),
+    # so this env var is the only control that reaches a pane worker. Verified to
+    # drop the foreign rules_file context block while KEEPING the project's own
+    # AGENTS.md rules, which the crewmate contract depends on.
+    # muse's turn-end signal rides neither the launch command nor a hook: its
+    # plugin engine is off in the default build, so firstmate folds muse's own
+    # session event log instead (bin/fm-busy-lib.sh), bound by the sidecar
+    # written below. Nothing to place in the template for it.
+    muse) printf '%s' 'MUSE_EXPERIMENTAL_FOREIGN_PERSONAL_CONTEXT_KILL=on __MUSEBIN__ --yolo __MODELFLAG____EFFORTFLAG__"$(__OPINPUT__ encode launch-brief < __BRIEF__)"' ;;
     *) return 1 ;;
   esac
 }
@@ -892,6 +916,17 @@ esac
 case "$HARNESS" in
   pi|pi-signed) LAUNCH="FM_PI_HARNESS=$HARNESS $LAUNCH" ;;
 esac
+
+# muse is verified as a CREWMATE/SCOUT adapter only. A secondmate is a firstmate
+# instance, so it needs a primary supervision protocol; muse has none, and its
+# Claude-compatible hook dialect explicitly rejects the model-reawakening and
+# asyncRewake handlers that firstmate's primary turn-end supervision is built on
+# (muse 0.1.0-R708.1). Refusing here keeps that gap loud instead of standing up a
+# secondmate whose supervision cycle could never be armed.
+if [ "$KIND" = secondmate ] && [ "$HARNESS" = muse ]; then
+  echo "error: muse is a verified crewmate/scout adapter only and cannot run a secondmate; it has no primary supervision protocol. Select a harness verified for secondmates." >&2
+  exit 1
+fi
 
 # pi-signed is an explicitly selected executable identity, not an alias that may
 # silently fall back to pi. Resolve it from PATH before creating an endpoint and
@@ -957,11 +992,46 @@ resolve_kimi_binary() {
   return 1
 }
 
+resolve_muse_binary() {
+  local candidate dir
+  candidate=$(command -v muse 2>/dev/null || true)
+  if [ -n "$candidate" ] && [ -x "$candidate" ]; then
+    case "$candidate" in
+      /*) printf '%s\n' "$candidate"; return 0 ;;
+      *)
+        dir=$(cd "$(dirname "$candidate")" 2>/dev/null && pwd -P) || dir=
+        if [ -n "$dir" ]; then
+          printf '%s/%s\n' "$dir" "$(basename "$candidate")"
+          return 0
+        fi
+        ;;
+    esac
+  fi
+  echo "error: muse executable not found on PATH; install Muse Code or select a different verified harness" >&2
+  return 1
+}
+
+# muse_credential_present: 0 when a launched muse pane can reach its provider
+# without an interactive login. muse offers exactly two credential paths
+# (verified, muse 0.1.0-R708.1): the META_API_KEY environment variable, which
+# always takes priority, and a stored credential written by `muse auth set` or
+# `muse login` into <config>/muse/auth.json. This is a PREFLIGHT rather than a
+# rendered-screen check because an unauthenticated pane does not exit - it sits
+# on an OAuth device-code prompt ("Sign in at this page ... Waiting for
+# approval...") waiting for a human who is not there, which would look to
+# supervision like a wedged worker rather than a missing credential.
+muse_credential_present() {
+  local auth
+  [ -z "${META_API_KEY:-}" ] || return 0
+  auth="${XDG_CONFIG_HOME:-${HOME:-}/.config}/muse/auth.json"
+  [ -s "$auth" ]
+}
+
 model_flag_for_harness() {
   local harness=$1 model=$2
   [ -n "$model" ] && [ "$model" != default ] || return 0
   case "$harness" in
-    claude|codex|opencode|pi|pi-signed|grok|kimi)
+    claude|codex|opencode|pi|pi-signed|grok|kimi|muse)
       printf -- '--model %s ' "$(shell_quote "$model")"
       ;;
   esac
@@ -1000,6 +1070,20 @@ effort_flag_for_harness() {
         low|medium|high|xhigh|max) printf -- '--thinking %s ' "$(shell_quote "$effort")" ;;
       esac
       ;;
+    muse)
+      # muse 0.1.0-R708.1 --reasoning-effort accepts none|minimal|low|medium|
+      # high|xhigh|ultra and defaults to high, so low..xhigh map straight across.
+      # ultra is muse's max-CLASS level, so firstmate's max maps onto it - but
+      # only ever as an EXPLICIT captain choice, never as a fallback, because
+      # AGENTS.md section 4 forbids selecting max without captain preference and
+      # the omitted effort here leaves muse on its own high default. muse's extra
+      # none/minimal levels sit below firstmate's shared vocabulary and are
+      # deliberately unreachable rather than remapped onto low.
+      case "$effort" in
+        low|medium|high|xhigh) printf -- '--reasoning-effort %s ' "$(shell_quote "$effort")" ;;
+        max) printf -- '--reasoning-effort %s ' "$(shell_quote ultra)" ;;
+      esac
+      ;;
     # opencode's interactive `opencode --prompt` launch has a verified --model
     # flag but no verified effort flag. Its `opencode run --variant` flag belongs
     # to a different, non-interactive launch mode, so fm-spawn does not pass it.
@@ -1007,6 +1091,17 @@ effort_flag_for_harness() {
     # task metadata but never reaches the launch command.
   esac
 }
+
+case "$LAUNCH" in
+  *__MUSEBIN__*)
+    MUSE_BIN=$(resolve_muse_binary) || exit 1
+    if ! muse_credential_present; then
+      echo "error: muse has no usable credential; an unauthenticated pane stops on an interactive sign-in prompt instead of working. Set META_API_KEY for the spawn, or run 'muse login' once so the credential is stored." >&2
+      exit 1
+    fi
+    LAUNCH=${LAUNCH//__MUSEBIN__/$(shell_quote "$MUSE_BIN")}
+    ;;
+esac
 
 case "$LAUNCH" in
   *__KIMIBIN__*)
@@ -1967,6 +2062,25 @@ EOF
       printf '{"hooks":{"Stop":[{"hooks":[{"type":"command","command":"%s"}]}]}}\n' "$hook_command" > "$GROK_HOOKS_DIR/fm-turn-end.json"
       printf 'token=%s\n' "${auth_file##*/}" > "$WT/.fm-grok-turnend"
       exclude_path '.fm-grok-turnend'
+      ;;
+    muse*)
+      # muse's turn lifecycle is neither a hook nor a launch flag: its plugin
+      # engine (the only hook surface) is disabled in the default build, so
+      # firstmate reads muse's own durable session event log instead
+      # (bin/fm-busy-lib.sh owns the fold and the idle gate). That is a PULL
+      # source with no writer, so nothing is armed and no record is seeded -
+      # exactly the reason standalone Kimi is not armed either.
+      # This sidecar is the whole binding: it pins the sessions root and the
+      # workspace root that muse records in each log's metadata, so the
+      # classifier never has to re-derive muse's data directory or guess which
+      # of several session logs belongs to this pane. Recording the resolved
+      # root here also means a later change to XDG_DATA_HOME cannot silently
+      # re-point an already-running task at a different log tree.
+      MUSE_SESSIONS_ROOT="${XDG_DATA_HOME:-$HOME/.local/share}/muse/sessions"
+      {
+        printf 'sessions_root=%s\n' "$MUSE_SESSIONS_ROOT"
+        printf 'workspace_root=%s\n' "$WT"
+      } > "$STATE/$ID.muse-session"
       ;;
     kimi*)
       # Kimi's Stop hook is global, but it is inert unless cwd contains this

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -872,7 +872,8 @@ launch_template() {
     # plugin engine is off in the default build, so firstmate folds muse's own
     # session event log instead (bin/fm-busy-lib.sh), bound by the sidecar
     # written below. Nothing to place in the template for it.
-    muse) printf '%s' 'XDG_CONFIG_HOME=__MUSECONFIG__ XDG_DATA_HOME=__MUSEDATA__ MUSE_EXPERIMENTAL_FOREIGN_PERSONAL_CONTEXT_KILL=on __MUSEBIN__ --yolo __MODELFLAG____EFFORTFLAG__"$(__OPINPUT__ encode launch-brief < __BRIEF__)"' ;;
+    # codex, opencode, and kimi are also markerless and share this inherited-marker hazard; changing their verified launch boundaries belongs in follow-up work.
+    muse) printf '%s' 'env -u CLAUDECODE -u PI_CODING_AGENT -u GROK_AGENT -u FM_PI_HARNESS XDG_CONFIG_HOME=__MUSECONFIG__ XDG_DATA_HOME=__MUSEDATA__ MUSE_EXPERIMENTAL_FOREIGN_PERSONAL_CONTEXT_KILL=on __MUSEBIN__ --yolo __MODELFLAG____EFFORTFLAG__"$(__OPINPUT__ encode launch-brief < __BRIEF__)"' ;;
     *) return 1 ;;
   esac
 }

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -786,7 +786,7 @@ FIRSTMATE_HOME=
 
 if [ "$KIND" = secondmate ]; then
   case "${POS[1]:-}" in
-    ''|claude|codex|opencode|pi|pi-signed|grok|kimi)
+    ''|claude|codex|opencode|pi|pi-signed|grok|kimi|muse)
       ARG3=${POS[1]:-}
       ;;
     *' '*)
@@ -872,7 +872,7 @@ launch_template() {
     # plugin engine is off in the default build, so firstmate folds muse's own
     # session event log instead (bin/fm-busy-lib.sh), bound by the sidecar
     # written below. Nothing to place in the template for it.
-    muse) printf '%s' 'MUSE_EXPERIMENTAL_FOREIGN_PERSONAL_CONTEXT_KILL=on __MUSEBIN__ --yolo __MODELFLAG____EFFORTFLAG__"$(__OPINPUT__ encode launch-brief < __BRIEF__)"' ;;
+    muse) printf '%s' 'XDG_CONFIG_HOME=__MUSECONFIG__ XDG_DATA_HOME=__MUSEDATA__ MUSE_EXPERIMENTAL_FOREIGN_PERSONAL_CONTEXT_KILL=on __MUSEBIN__ --yolo __MODELFLAG____EFFORTFLAG__"$(__OPINPUT__ encode launch-brief < __BRIEF__)"' ;;
     *) return 1 ;;
   esac
 }
@@ -1020,11 +1020,25 @@ resolve_muse_binary() {
 # on an OAuth device-code prompt ("Sign in at this page ... Waiting for
 # approval...") waiting for a human who is not there, which would look to
 # supervision like a wedged worker rather than a missing credential.
+muse_worker_meta_api_key_present() {
+  local session worker_env
+  [ "$BACKEND" = tmux ] || return 1
+  if [ -n "${TMUX:-}" ]; then
+    session=$(tmux display-message -p '#S' 2>/dev/null) || return 1
+  else
+    tmux has-session -t firstmate 2>/dev/null || return 1
+    session=firstmate
+  fi
+  worker_env=$(tmux show-environment -t "$session" META_API_KEY 2>/dev/null) || return 1
+  case "$worker_env" in
+    META_API_KEY=?*) return 0 ;;
+  esac
+  return 1
+}
+
 muse_credential_present() {
-  local auth
-  [ -z "${META_API_KEY:-}" ] || return 0
-  auth="${XDG_CONFIG_HOME:-${HOME:-}/.config}/muse/auth.json"
-  [ -s "$auth" ]
+  local auth=$1
+  [ -s "$auth" ] || muse_worker_meta_api_key_present
 }
 
 model_flag_for_harness() {
@@ -1095,11 +1109,20 @@ effort_flag_for_harness() {
 case "$LAUNCH" in
   *__MUSEBIN__*)
     MUSE_BIN=$(resolve_muse_binary) || exit 1
-    if ! muse_credential_present; then
-      echo "error: muse has no usable credential; an unauthenticated pane stops on an interactive sign-in prompt instead of working. Set META_API_KEY for the spawn, or run 'muse login' once so the credential is stored." >&2
+    MUSE_CONFIG_HOME=${XDG_CONFIG_HOME:-${HOME:-}/.config}
+    MUSE_DATA_HOME=${XDG_DATA_HOME:-${HOME:-}/.local/share}
+    MUSE_AUTH_FILE="$MUSE_CONFIG_HOME/muse/auth.json"
+    if ! muse_credential_present "$MUSE_AUTH_FILE"; then
+      if [ -n "${META_API_KEY:-}" ]; then
+        echo "error: muse has no worker-reachable credential; META_API_KEY is set for fm-spawn but cannot be proven present in the $BACKEND worker environment. Store the fleet credential at '$MUSE_AUTH_FILE' with 'muse login' or 'muse auth set --api-key-stdin'. The secret will not be copied into the launch command." >&2
+      else
+        echo "error: muse has no worker-reachable credential; META_API_KEY cannot be proven present in the $BACKEND worker environment and '$MUSE_AUTH_FILE' is absent or empty. Store the fleet credential with 'muse login' or 'muse auth set --api-key-stdin'." >&2
+      fi
       exit 1
     fi
     LAUNCH=${LAUNCH//__MUSEBIN__/$(shell_quote "$MUSE_BIN")}
+    LAUNCH=${LAUNCH//__MUSECONFIG__/$(shell_quote "$MUSE_CONFIG_HOME")}
+    LAUNCH=${LAUNCH//__MUSEDATA__/$(shell_quote "$MUSE_DATA_HOME")}
     ;;
 esac
 
@@ -2077,7 +2100,7 @@ EOF
       # incarnations. Recording the resolved root here also means a later
       # change to XDG_DATA_HOME cannot silently re-point an already-running
       # task at a different log tree.
-      MUSE_SESSIONS_ROOT="${XDG_DATA_HOME:-$HOME/.local/share}/muse/sessions"
+      MUSE_SESSIONS_ROOT="${MUSE_DATA_HOME:-${XDG_DATA_HOME:-$HOME/.local/share}}/muse/sessions"
       {
         printf 'sessions_root=%s\n' "$MUSE_SESSIONS_ROOT"
         printf 'workspace_root=%s\n' "$WT"

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -2070,16 +2070,22 @@ EOF
       # (bin/fm-busy-lib.sh owns the fold and the idle gate). That is a PULL
       # source with no writer, so nothing is armed and no record is seeded -
       # exactly the reason standalone Kimi is not armed either.
-      # This sidecar is the whole binding: it pins the sessions root and the
-      # workspace root that muse records in each log's metadata, so the
-      # classifier never has to re-derive muse's data directory or guess which
-      # of several session logs belongs to this pane. Recording the resolved
-      # root here also means a later change to XDG_DATA_HOME cannot silently
-      # re-point an already-running task at a different log tree.
+      # This sidecar is the whole binding: it pins the sessions root, the
+      # workspace root that muse records in each log's metadata, and every
+      # matching main log that predates this pane. The classifier then accepts
+      # only one new matching log, so it never guesses between pane
+      # incarnations. Recording the resolved root here also means a later
+      # change to XDG_DATA_HOME cannot silently re-point an already-running
+      # task at a different log tree.
       MUSE_SESSIONS_ROOT="${XDG_DATA_HOME:-$HOME/.local/share}/muse/sessions"
       {
         printf 'sessions_root=%s\n' "$MUSE_SESSIONS_ROOT"
         printf 'workspace_root=%s\n' "$WT"
+        while IFS= read -r MUSE_PRIOR_LOG; do
+          [ -n "$MUSE_PRIOR_LOG" ] && printf 'prior_log=%s\n' "$MUSE_PRIOR_LOG"
+        done <<EOF
+$(fm_busy_muse_matching_logs "$MUSE_SESSIONS_ROOT" "$WT" || true)
+EOF
       } > "$STATE/$ID.muse-session"
       ;;
     kimi*)

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1110,8 +1110,8 @@ effort_flag_for_harness() {
 case "$LAUNCH" in
   *__MUSEBIN__*)
     MUSE_BIN=$(resolve_muse_binary) || exit 1
-    MUSE_CONFIG_HOME=${XDG_CONFIG_HOME:-${HOME:-}/.config}
-    MUSE_DATA_HOME=${XDG_DATA_HOME:-${HOME:-}/.local/share}
+    MUSE_CONFIG_HOME=$(resolve_directory_input XDG_CONFIG_HOME "${XDG_CONFIG_HOME:-${HOME:-}/.config}") || exit 1
+    MUSE_DATA_HOME=$(resolve_directory_input XDG_DATA_HOME "${XDG_DATA_HOME:-${HOME:-}/.local/share}") || exit 1
     MUSE_AUTH_FILE="$MUSE_CONFIG_HOME/muse/auth.json"
     if ! muse_credential_present "$MUSE_AUTH_FILE"; then
       if [ -n "${META_API_KEY:-}" ]; then

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -2080,7 +2080,7 @@ cleanup_firstmate_home_children() {
     rm -f "$sub_state/$child_id.status" "$sub_state/$child_id.turn-ended" \
       "$sub_state/$child_id.meta" "$sub_state/$child_id.pi-ext.ts" \
       "$sub_state/$child_id.grok-turnend-token" "$sub_state/$child_id.kimi-turnend-token" \
-      "$sub_state/$child_id.muse-session"
+      "$sub_state/$child_id.muse-session" "$sub_state/$child_id.muse-session-current"
   done
 }
 
@@ -2344,6 +2344,7 @@ retire_busy_state "$STATE" "$ID" "$BUSY_GEN" || exit 1
 rm -f "$STATE/$ID.status" "$STATE/$ID.turn-ended" "$STATE/$ID.meta" \
   "$STATE/$ID.pi-ext.ts" "$STATE/$ID.grok-turnend-token" \
   "$STATE/$ID.kimi-turnend-token" "$STATE/$ID.muse-session" \
+  "$STATE/$ID.muse-session-current" \
   "$STATE/.$ID.open-decisions-cursor"
 if [ "$KIND" != scout ] && [ "$KIND" != secondmate ] && [ "$MODE" != local-only ]; then
   "$FM_ROOT/bin/fm-fleet-sync.sh" "$PROJ" || true

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -2079,7 +2079,8 @@ cleanup_firstmate_home_children() {
     retire_busy_state "$sub_state" "$child_id" "$child_busy_gen" || return 1
     rm -f "$sub_state/$child_id.status" "$sub_state/$child_id.turn-ended" \
       "$sub_state/$child_id.meta" "$sub_state/$child_id.pi-ext.ts" \
-      "$sub_state/$child_id.grok-turnend-token" "$sub_state/$child_id.kimi-turnend-token"
+      "$sub_state/$child_id.grok-turnend-token" "$sub_state/$child_id.kimi-turnend-token" \
+      "$sub_state/$child_id.muse-session"
   done
 }
 
@@ -2342,7 +2343,8 @@ remove_pr_poll_artifacts "$STATE" "$ID" || exit 1
 retire_busy_state "$STATE" "$ID" "$BUSY_GEN" || exit 1
 rm -f "$STATE/$ID.status" "$STATE/$ID.turn-ended" "$STATE/$ID.meta" \
   "$STATE/$ID.pi-ext.ts" "$STATE/$ID.grok-turnend-token" \
-  "$STATE/$ID.kimi-turnend-token" "$STATE/.$ID.open-decisions-cursor"
+  "$STATE/$ID.kimi-turnend-token" "$STATE/$ID.muse-session" \
+  "$STATE/.$ID.open-decisions-cursor"
 if [ "$KIND" != scout ] && [ "$KIND" != secondmate ] && [ "$MODE" != local-only ]; then
   "$FM_ROOT/bin/fm-fleet-sync.sh" "$PROJ" || true
 fi

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -181,6 +181,7 @@ family_for_basename() {
     fm-afk-pi-herdr-return-e2e.test.sh|\
     fm-codex-continuity-live-e2e.test.sh|fm-grok-continuity-live-e2e.test.sh|\
     fm-grok-stop-live-e2e.test.sh|fm-harness-liveness-drift-live-e2e.test.sh|\
+    fm-muse-signals-live-e2e.test.sh|\
     fm-opencode-primary-live-e2e.test.sh|fm-pi-primary-live-e2e.test.sh|\
     fm-sessionstart-hook-live-e2e.test.sh|\
     fm-quota-array-dispatch-live-e2e.test.sh|fm-send-secondmate-marker-herdr-e2e.test.sh)

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -138,7 +138,7 @@ family_for_basename() {
     fm-composer-ghost.test.sh|fm-composer-lib.test.sh|\
     fm-crew-state.test.sh|fm-decision-hold-lifecycle.test.sh|\
     fm-documentation-audiences.test.sh|fm-ensure-agents-md.test.sh|fm-grok-harness.test.sh|\
-    fm-kimi-harness.test.sh|fm-herdr-lab.test.sh|fm-lint.test.sh|\
+    fm-kimi-harness.test.sh|fm-muse-harness.test.sh|fm-herdr-lab.test.sh|fm-lint.test.sh|\
     fm-operational-input.test.sh|fm-pi-primary-types.test.sh|\
     fm-send-popup-settle.test.sh|fm-send-settle.test.sh|\
     fm-subagent-pretool-check.test.sh|\

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -169,7 +169,7 @@ The session-start bootstrap step keeps valid dispatch configuration silent unles
 When the file exists, `fm-spawn.sh` refuses crewmate and scout launches without an explicit harness, so `config/crew-harness` is only automatic when no dispatch profile file is active.
 Secondmate launches are exempt because they resolve the secondmate harness and any optional secondmate model or effort tokens instead.
 Unsupported effort values are still recorded in task meta when passed to `fm-spawn.sh`, but the launch template omits any effort flag that the selected harness does not accept.
-That keeps spawn launch compatible across claude, codex, grok, pi, opencode, and kimi while preserving the requested profile for later audit.
+That keeps spawn launch compatible across claude, codex, opencode, pi, pi-signed, grok, kimi, and muse while preserving the requested profile for later audit.
 
 ## Optional secondmates
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -206,6 +206,8 @@ The full cmux home label also includes a short hash of the resolved `FM_ROOT` pa
 ## Harness support
 
 claude, codex, opencode, pi, pi-signed, grok, and kimi are empirically verified for crewmate and secondmate launches; [README requirements](../README.md#requirements) own the set supported for the primary session.
+muse is verified for crewmate and scout launches ONLY, and `fm-spawn.sh` refuses it for a secondmate, because muse ships no usable hook surface for a primary session's turn-end supervision; [`docs/verification/muse.md`](verification/muse.md) owns that evidence.
+muse also needs a credential before a spawn is attempted, either `META_API_KEY` in the launch environment or a stored credential from `muse login`, because an unauthenticated muse pane waits on an interactive sign-in prompt instead of exiting.
 New harnesses get verified through a supervised trial task before joining the set.
 The verified adapter knowledge - each harness's busy-state source, interrupt and exit commands, skill-invocation syntax, and per-harness quirks - lives in [`.agents/skills/harness-adapters/SKILL.md`](../.agents/skills/harness-adapters/SKILL.md).
 Launch mechanics, including the verified command templates, live in [`bin/fm-spawn.sh`](../bin/fm-spawn.sh).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -207,7 +207,7 @@ The full cmux home label also includes a short hash of the resolved `FM_ROOT` pa
 
 claude, codex, opencode, pi, pi-signed, grok, and kimi are empirically verified for crewmate and secondmate launches; [README requirements](../README.md#requirements) own the set supported for the primary session.
 muse is verified for crewmate and scout launches ONLY, and `fm-spawn.sh` refuses it for a secondmate, because muse ships no usable hook surface for a primary session's turn-end supervision; [`docs/verification/muse.md`](verification/muse.md) owns that evidence.
-muse also needs a credential before a spawn is attempted, either `META_API_KEY` in the launch environment or a stored credential from `muse login`, because an unauthenticated muse pane waits on an interactive sign-in prompt instead of exiting.
+muse also needs a worker-reachable credential before spawning, and the portable fleet path is the `<config>/muse/auth.json` credential stored by `muse login`, because a caller-only `META_API_KEY` does not cross a long-lived backend daemon.
 New harnesses get verified through a supervised trial task before joining the set.
 The verified adapter knowledge - each harness's busy-state source, interrupt and exit commands, skill-invocation syntax, and per-harness quirks - lives in [`.agents/skills/harness-adapters/SKILL.md`](../.agents/skills/harness-adapters/SKILL.md).
 Launch mechanics, including the verified command templates, live in [`bin/fm-spawn.sh`](../bin/fm-spawn.sh).

--- a/docs/documentation-audiences.json
+++ b/docs/documentation-audiences.json
@@ -325,6 +325,10 @@
       "audience": "maintainer-verification"
     },
     {
+      "path": "docs/verification/muse.md",
+      "audience": "maintainer-verification"
+    },
+    {
       "path": "docs/verification/process-event-sources.md",
       "audience": "maintainer-verification"
     },

--- a/docs/tmux-backend.md
+++ b/docs/tmux-backend.md
@@ -48,7 +48,7 @@ Verify setup by spawning a small task and confirming its `fm-<id>` window appear
 
 A target-existence check proves only that the pane exists.
 The deeper tmux agent-liveness probe first verifies exact window membership, then reads process names to distinguish a running harness from a bare idle shell.
-It classifies recognized Claude, Codex, OpenCode, Pi, pi-signed, Grok, and Kimi process names as `alive`, common shells as `dead`, an authoritatively absent window as `missing`, unreadable state as `unreadable`, and every other process as `ambiguous`.
+It classifies recognized Claude, Codex, OpenCode, Pi, pi-signed, Grok, Kimi, and Muse process names as `alive`, common shells as `dead`, an authoritatively absent window as `missing`, unreadable state as `unreadable`, and every other process as `ambiguous`.
 Only `dead` and `missing` authorize recovery because a false dead result could launch a duplicate agent.
 
 For positive attribution, the probe combines two independent name sources rather than making either one load-bearing.
@@ -59,6 +59,7 @@ Either source naming a verified harness is enough for `alive`, because a false `
 Scoping the second source to the foreground process group rather than to the pane's descendants is deliberate: a harness-named process left running in the background of an otherwise idle pane must not read as an agent.
 The same scoping covers multi-process launchers without a special case, so the Pi Launcher path is attributed through its `pi-signed` wrapper and `pi` engine even though its title is the exact foreground command `pi-launcher`.
 Direct executable identities `pi`, `pi-signed`, and `Pi` remain accepted exactly, and similar or prefixed process names are not accepted through those exact Pi-family entries.
+Muse is likewise anchored to the exact `muse` launcher identity or the installed `muse-bin-<version>` prefix, so unrelated names such as `musescore` and `amuse` remain ambiguous.
 
 The CI-enforced portable regression and opt-in real-harness drift guard follow the split owned by `.agents/skills/firstmate-coding-guidelines/SKILL.md`.
 Run the real-harness guard after any harness upgrade and before trusting refreshed evidence.
@@ -101,6 +102,7 @@ tests/fm-tmux-agent-liveness.test.sh
 tests/fm-harness-liveness-drift-live-e2e.test.sh
 tests/fm-composer-ghost.test.sh
 tests/fm-kimi-harness.test.sh
+tests/fm-muse-harness.test.sh
 tests/fm-tmux-submit-busy.test.sh
 tests/fm-bootstrap.test.sh
 ```

--- a/docs/trace-context.md
+++ b/docs/trace-context.md
@@ -23,7 +23,8 @@ When enabled, for each spawn Firstmate resolves one W3C `traceparent` carrier fo
 This feature parents no SDK span by itself.
 
 Because the injected carrier and the recorded carrier are the same string, an observer that reads the metadata reconstructs exactly the identity the child received.
-The injection sits at the unconditional pre-launch export site, so it covers ship, scout, and Secondmate spawns and is identical across every harness (`claude`, `codex`, `opencode`, `pi`, `grok`, `kimi`) - the same coverage `GOTMPDIR` already has, with no `launch_template()` change.
+The injection sits at the unconditional pre-launch export site, so it covers ship and scout spawns across `claude`, `codex`, `opencode`, `pi`, `pi-signed`, `grok`, `kimi`, and `muse`, plus Secondmate spawns across that same set except the deliberately crewmate-only `muse` adapter.
+This is the same coverage `GOTMPDIR` already has and requires no trace-specific `launch_template()` behavior.
 Ship and scout spawns reach that site on every spawn backend (`tmux`, `herdr`, `zellij`, `orca`, `cmux`); a Secondmate reaches it on every backend that accepts a Secondmate spawn (`tmux`, `herdr`, `zellij`), because `bin/fm-spawn.sh` rejects a Secondmate on `orca` and `cmux`.
 
 ### Remote Secondmate routes

--- a/docs/verification/muse.md
+++ b/docs/verification/muse.md
@@ -47,6 +47,7 @@ $ grep -nE 'muse-bin|exec ' launcher.sh
 
 `ps -o comm= -p <pid>` returns the full executable path, whose basename is `muse-bin-<version>`.
 That is why both `bin/fm-harness.sh` and `bin/backends/tmux.sh` match the anchored prefix `muse-bin-*` rather than an exact name, and why neither can rely on an install-path component: `~/.local/bin/muse-bin-<version>` contains no `muse` path component.
+The Muse launch clears `CLAUDECODE`, `PI_CODING_AGENT`, `GROK_AGENT`, and `FM_PI_HARNESS` before the worker starts so foreign primary markers cannot override the versioned ancestry.
 
 Live tmux liveness against the real binary renamed to its installed form:
 

--- a/docs/verification/muse.md
+++ b/docs/verification/muse.md
@@ -93,7 +93,7 @@ T+30s fold=settled
 
 Two decoys were observed in real logs and are pinned by regressions in `tests/fm-muse-harness.test.sh`:
 a nested `"record":{"kind":"terminal"}` cleanup-effect payload that is not a run terminal, and independent sub-agent run lifecycles under `subagent/<child-session-id>/session.jsonl`.
-The same regression suite verifies that unique resolution is cached, a replacement spawn binding selects its fresh main log, missing cached logs fail closed, and cached sub-agent paths are rejected.
+The same regression suite verifies that unique resolution is cached, a changed current-day main-session namespace restores ambiguity to unknown, a replacement spawn binding selects its fresh main log, missing cached logs fail closed, and cached sub-agent paths are rejected.
 
 ### Autonomy, trust, and sandbox
 
@@ -122,7 +122,7 @@ An unauthenticated launch does not exit; it waits indefinitely:
 ```
 
 That is why `bin/fm-spawn.sh` preflights worker-reachable `META_API_KEY` or `<config>/muse/auth.json` and refuses before creating an endpoint.
-A caller-only `META_API_KEY` is refused because a long-lived backend daemon does not inherit it, while the non-secret resolved `XDG_CONFIG_HOME` and `XDG_DATA_HOME` roots are forwarded so the stored credential and session-log binding reach the same worker environment.
+A caller-only `META_API_KEY` is refused because a long-lived backend daemon does not inherit it, while the non-secret `XDG_CONFIG_HOME` and `XDG_DATA_HOME` roots are resolved to absolute paths before preflight and forwarding so the stored credential and session-log binding reach the same worker environment.
 
 ### Foreign personal context
 
@@ -193,6 +193,6 @@ FM_MUSE_SIGNALS_LIVE=1 bin/fm-test-run.sh tests/fm-muse-signals-live-e2e.test.sh
 ```
 
 The Muse signals guard requires a real `muse` binary and tmux but uses `--provider echo`, so it does not require `META_API_KEY` and does not open the deferred real-model idle gate.
-The guard follows SGR state through the final prompt glyph and runs a bright-then-dark negative control before accepting that glyph's effective luminance.
+The guard follows SGR state through the final prompt glyph and rejects both bright-then-dark and malformed-RGB negative controls before accepting that glyph's effective luminance.
 
 The portable counterparts that run in ordinary CI are `tests/fm-muse-harness.test.sh`, `tests/fm-tmux-agent-liveness.test.sh`, `tests/fm-composer-lib.test.sh`, and `tests/fm-composer-ghost.test.sh`.

--- a/docs/verification/muse.md
+++ b/docs/verification/muse.md
@@ -1,0 +1,191 @@
+# Verification: the muse (Muse Code) crewmate adapter
+
+Active empirical evidence for firstmate's muse adapter.
+[`.agents/skills/harness-adapters/SKILL.md`](../../.agents/skills/harness-adapters/SKILL.md) owns the operating facts; this record owns how they were established and what is still unproven.
+
+## Subject
+
+| Field | Value |
+|---|---|
+| Version | `Muse Code 0.1.0 (0.1.0-R708.1)`, build sha `427a430436` |
+| Verified | 2026-08-05 |
+| Artifact | `muse-aarch64-macos`, sha256 `4290bfafa5bbb81a6fd493aaea12f848c789b1d22edfa0c4b849151deba3e70c` |
+| Platform | macOS arm64 (Darwin 25.5.0) |
+
+The binary was fetched from the published channel and its checksum matched the published manifest before any run:
+
+```
+$ curl -sS 'https://api.meta.ai/muse-code/channels/muse-stable'
+{"channel":"muse-stable","version":"0.1.0-R708.1",...,"state":"public","min_version":null}
+
+$ shasum -a 256 muse-bin
+4290bfafa5bbb81a6fd493aaea12f848c789b1d22edfa0c4b849151deba3e70c  muse-bin
+```
+
+Every run below used an isolated `XDG_CONFIG_HOME` and `XDG_DATA_HOME` in a scratch directory and a throwaway git workspace, driven through tmux the way firstmate drives a crewmate pane.
+`install.sh` was deliberately bypassed, so no shell profile and no `~/.local/bin` entry on the host was touched.
+
+## What the model provider limits
+
+All live behavior below was observed against the built-in `--provider echo` startup provider.
+Turn-boundary structure, the trust dialog, interrupt, exit, composer rendering, credential behavior, and the event-log schema are real and verified.
+**Busy-state behavior under a genuine multi-step, real-model tool loop is NOT verified** and is the deferred item below.
+
+## Verified facts
+
+### Process identity
+
+The published launcher `exec`s a version-suffixed binary, so the live process name changes on every auto-update:
+
+```
+$ grep -nE 'muse-bin|exec ' launcher.sh
+969:  candidate="$work/muse-bin"
+977:  target="$dir/muse-bin-$version"
+1035:  printf '%s/muse-bin-%s\n' "$dir" "$version"
+1135:  exec "$binary" "$@"
+```
+
+`ps -o comm= -p <pid>` returns the full executable path, whose basename is `muse-bin-<version>`.
+That is why both `bin/fm-harness.sh` and `bin/backends/tmux.sh` match the anchored prefix `muse-bin*` rather than an exact name, and why neither can rely on an install-path component: `~/.local/bin/muse-bin-<version>` contains no `muse` path component.
+
+Live tmux liveness against the real binary renamed to its installed form:
+
+```
+foreground comms:
+  zsh
+  .../instbin/muse-bin-0.1.0-R708.1
+classify each:
+  zsh                            -> shell
+  muse-bin-0.1.0-R708.1          -> agent
+$ fm_backend_agent_state tmux museliv:zsh
+alive
+```
+
+### Turn lifecycle
+
+A two-turn session produced exactly two run brackets, the second closed by an Escape interrupt:
+
+```
+9  {"kind":"run","run_id":"d352a097-...","event":{"kind":"started","prompt":"hello from firstmate"}}
+45 {"kind":"run","run_id":"d352a097-...","event":{"kind":"terminal","terminal":"completed","turn_duration_ms":8152}}
+49 {"kind":"run","run_id":"b50dac92-...","event":{"kind":"started","prompt":"second turn to interrupt"}}
+78 {"kind":"run","run_id":"b50dac92-...","event":{"kind":"terminal","terminal":"cancelled","reason":"cancelled during model step"}}
+```
+
+The log's first record carries the binding key:
+
+```
+"payload_type": "runtime.session.metadata",
+"payload": {"kind":"metadata","record":{"workspace_root":".../muselab/ws1","provider_id":"echo",...}}
+```
+
+The fold transitions live, sampled during a 25-second in-flight turn:
+
+```
+T+ 5s fold=busy
+T+10s fold=busy
+T+15s fold=busy
+T+20s fold=busy
+T+25s fold=busy
+T+30s fold=settled
+```
+
+Two decoys were observed in real logs and are pinned by regressions in `tests/fm-muse-harness.test.sh`:
+a nested `"record":{"kind":"terminal"}` cleanup-effect payload that is not a run terminal, and independent sub-agent run lifecycles under `subagent/<child-session-id>/session.jsonl`.
+
+### Autonomy, trust, and sandbox
+
+A fresh untrusted workspace shows the trust dialog with option 1 preselected:
+
+```
+Do you trust this workspace?
+> 1  Trust and continue
+  2  Quit
+Use Up/Down or 1/2, then Enter. Esc quits.
+```
+
+`--yolo` suppresses it entirely and the status bar reports `echo · <workspace> · YOLO`.
+This matters because approval and the sandbox are ON by default and `--sandbox-network` defaults to `proxy-only`, which the binary reports as requiring managed shell sandboxing - a crewmate needs ordinary git and network access.
+
+### Credentials
+
+`muse auth set --provider` accepts only `meta`.
+An unauthenticated launch does not exit; it waits indefinitely:
+
+```
+  Sign in at this page:
+    https://auth.meta.com/oauth/device/?code=DGXZ-NRPR
+  Waiting for approval…
+  Esc cancel
+```
+
+That is why `bin/fm-spawn.sh` preflights `META_API_KEY` or `<config>/muse/auth.json` and refuses before creating an endpoint.
+
+### Foreign personal context
+
+The interactive TUI rejects the `exec`-only flag:
+
+```
+$ muse --no-foreign-personal-context --provider echo hi
+invalid TUI options: error: unexpected argument '--no-foreign-personal-context' found
+  tip: a similar argument exists: '--no-session-log'
+```
+
+`MUSE_EXPERIMENTAL_FOREIGN_PERSONAL_CONTEXT_KILL` is the control that works in TUI mode.
+Comparing the `context_block_diagnostic` block ids emitted by otherwise identical runs, with the operator's real `~/.claude` rules present and no project `AGENTS.md`:
+
+```
+base     blocks=rules_file,workspace_identity,security_mode,skills_catalog,session_identity,subagent_delegation
+killon   blocks=workspace_identity,security_mode,skills_catalog,session_identity,subagent_delegation
+kill1    blocks=workspace_identity,security_mode,skills_catalog,session_identity,subagent_delegation
+```
+
+Repeating the comparison with a project `AGENTS.md` present confirms the kill switch drops only the FOREIGN rules:
+
+```
+a4base   blocks=rules_file,workspace_identity,security_mode,skills_catalog,session_identity,subagent_delegation
+a4kill   blocks=rules_file,workspace_identity,security_mode,skills_catalog,session_identity,subagent_delegation
+```
+
+The `tui.foreign_context_notice_shown` flag in `settings.json` suppresses only the notice, never the loading, so a quiet later launch is not evidence of a clean context.
+
+### Composer rendering
+
+Captured with `tmux capture-pane -p -e`:
+
+```
+^[[38;2;90;160;255m^[[48;2;38;56;84m⟩ ^[[38;2;204;211;219mhello from firstmate^[[39m
+^[[0m^[[38;2;90;160;255m⟩ ^[[39m
+```
+
+Prompt glyph `⟩` (U+27E9) at luminance ~149.9 against the 128 default ghost threshold; typed text at ~209.8.
+After a single Escape the interrupted prompt is restored into the composer at the same bright ~209.8, and `C-u` clears it.
+
+## Deferred: the credentialed multi-step smoke
+
+This is the one item the captain deferred until a `META_API_KEY` is available, and it is the only thing standing between the current adapter and a full busy-state signal.
+
+Until it lands, `fm_busy_muse_idle_verified` in `bin/fm-busy-lib.sh` stays closed: an open run classifies `busy`, and everything else classifies `unknown`, never `idle`.
+Busy needs no gate because an open run is positive proof of a turn in flight.
+Idle does, because a settled log only proves no run is open at that instant; if a real turn turned out to span several runs, an ungated idle would report a working crewmate as finished.
+
+To open the gate:
+
+1. Set `META_API_KEY` and spawn a real muse crewmate through `bin/fm-spawn.sh` on a task whose first turn makes several tool calls.
+2. While that turn runs, sample `fm_busy_muse_run_state` on the bound log repeatedly and confirm it stays `busy` for the whole turn.
+3. Confirm the finished turn produced exactly ONE `started`/`terminal` pair, not one pair per model step:
+   `grep -c '"event":{"kind":"started"' <log>` and the same for `terminal`.
+4. Confirm an Escape interrupt mid-tool-loop still yields `terminal` with `cancelled`.
+5. Record the version, exact commands, and observed counts in this file, then add the verified version string to `FM_BUSY_MUSE_IDLE_VERIFIED_VERSIONS`.
+
+`tests/fm-muse-harness.test.sh` already pins that opening the gate flips exactly the settled verdict and nothing else, so this is a one-line landing rather than a redesign.
+
+## Refreshing this record
+
+Run the opt-in live guard after any muse upgrade, because the version-suffixed process name is the surface most likely to drift:
+
+```
+FM_HARNESS_LIVENESS_DRIFT=1 bin/fm-test-run.sh tests/fm-harness-liveness-drift-live-e2e.test.sh
+```
+
+The portable counterparts that run in ordinary CI are `tests/fm-muse-harness.test.sh`, `tests/fm-tmux-agent-liveness.test.sh`, `tests/fm-composer-lib.test.sh`, and `tests/fm-composer-ghost.test.sh`.

--- a/docs/verification/muse.md
+++ b/docs/verification/muse.md
@@ -193,5 +193,6 @@ FM_MUSE_SIGNALS_LIVE=1 bin/fm-test-run.sh tests/fm-muse-signals-live-e2e.test.sh
 ```
 
 The Muse signals guard requires a real `muse` binary and tmux but uses `--provider echo`, so it does not require `META_API_KEY` and does not open the deferred real-model idle gate.
+The guard follows SGR state through the final prompt glyph and runs a bright-then-dark negative control before accepting that glyph's effective luminance.
 
 The portable counterparts that run in ordinary CI are `tests/fm-muse-harness.test.sh`, `tests/fm-tmux-agent-liveness.test.sh`, `tests/fm-composer-lib.test.sh`, and `tests/fm-composer-ghost.test.sh`.

--- a/docs/verification/muse.md
+++ b/docs/verification/muse.md
@@ -92,6 +92,7 @@ T+30s fold=settled
 
 Two decoys were observed in real logs and are pinned by regressions in `tests/fm-muse-harness.test.sh`:
 a nested `"record":{"kind":"terminal"}` cleanup-effect payload that is not a run terminal, and independent sub-agent run lifecycles under `subagent/<child-session-id>/session.jsonl`.
+The same regression suite verifies that unique resolution is cached, a replacement spawn binding selects its fresh main log, missing cached logs fail closed, and cached sub-agent paths are rejected.
 
 ### Autonomy, trust, and sandbox
 

--- a/docs/verification/muse.md
+++ b/docs/verification/muse.md
@@ -72,7 +72,7 @@ A two-turn session produced exactly two run brackets, the second closed by an Es
 78 {"kind":"run","run_id":"b50dac92-...","event":{"kind":"terminal","terminal":"cancelled","reason":"cancelled during model step"}}
 ```
 
-The log's first record carries the binding key:
+The log's first record carries the workspace binding key:
 
 ```
 "payload_type": "runtime.session.metadata",

--- a/docs/verification/muse.md
+++ b/docs/verification/muse.md
@@ -27,7 +27,8 @@ Every run below used an isolated `XDG_CONFIG_HOME` and `XDG_DATA_HOME` in a scra
 
 ## What the model provider limits
 
-All live behavior below was observed against the built-in `--provider echo` startup provider.
+Live TUI and session behavior below was observed against the built-in `--provider echo` startup provider, except for the provider-authentication prompt.
+The credential paths and unauthenticated wait were probed separately against the default `meta` provider.
 Turn-boundary structure, the trust dialog, interrupt, exit, composer rendering, credential behavior, and the event-log schema are real and verified.
 **Busy-state behavior under a genuine multi-step, real-model tool loop is NOT verified** and is the deferred item below.
 
@@ -49,18 +50,7 @@ $ grep -nE 'muse-bin|exec ' launcher.sh
 That is why both `bin/fm-harness.sh` and `bin/backends/tmux.sh` match the anchored prefix `muse-bin-*` rather than an exact name, and why neither can rely on an install-path component: `~/.local/bin/muse-bin-<version>` contains no `muse` path component.
 The Muse launch clears `CLAUDECODE`, `PI_CODING_AGENT`, `GROK_AGENT`, and `FM_PI_HARNESS` before the worker starts so foreign primary markers cannot override the versioned ancestry.
 
-Live tmux liveness against the real binary renamed to its installed form:
-
-```
-foreground comms:
-  zsh
-  .../instbin/muse-bin-0.1.0-R708.1
-classify each:
-  zsh                            -> shell
-  muse-bin-0.1.0-R708.1          -> agent
-$ fm_backend_agent_state tmux museliv:zsh
-alive
-```
+[`runtime-backends.md`](runtime-backends.md#agent-liveness-name-sources) owns the resulting tmux liveness verdict and its relationship to the portable decoy regression.
 
 ### Turn lifecycle
 

--- a/docs/verification/muse.md
+++ b/docs/verification/muse.md
@@ -46,7 +46,7 @@ $ grep -nE 'muse-bin|exec ' launcher.sh
 ```
 
 `ps -o comm= -p <pid>` returns the full executable path, whose basename is `muse-bin-<version>`.
-That is why both `bin/fm-harness.sh` and `bin/backends/tmux.sh` match the anchored prefix `muse-bin*` rather than an exact name, and why neither can rely on an install-path component: `~/.local/bin/muse-bin-<version>` contains no `muse` path component.
+That is why both `bin/fm-harness.sh` and `bin/backends/tmux.sh` match the anchored prefix `muse-bin-*` rather than an exact name, and why neither can rely on an install-path component: `~/.local/bin/muse-bin-<version>` contains no `muse` path component.
 
 Live tmux liveness against the real binary renamed to its installed form:
 
@@ -119,7 +119,8 @@ An unauthenticated launch does not exit; it waits indefinitely:
   Esc cancel
 ```
 
-That is why `bin/fm-spawn.sh` preflights `META_API_KEY` or `<config>/muse/auth.json` and refuses before creating an endpoint.
+That is why `bin/fm-spawn.sh` preflights worker-reachable `META_API_KEY` or `<config>/muse/auth.json` and refuses before creating an endpoint.
+A caller-only `META_API_KEY` is refused because a long-lived backend daemon does not inherit it, while the non-secret resolved `XDG_CONFIG_HOME` and `XDG_DATA_HOME` roots are forwarded so the stored credential and session-log binding reach the same worker environment.
 
 ### Foreign personal context
 
@@ -182,10 +183,13 @@ To open the gate:
 
 ## Refreshing this record
 
-Run the opt-in live guard after any muse upgrade, because the version-suffixed process name is the surface most likely to drift:
+Run both opt-in live guards after any muse upgrade, because the version-suffixed process name, session protocol, and styled composer are vendor-controlled surfaces:
 
 ```
 FM_HARNESS_LIVENESS_DRIFT=1 bin/fm-test-run.sh tests/fm-harness-liveness-drift-live-e2e.test.sh
+FM_MUSE_SIGNALS_LIVE=1 bin/fm-test-run.sh tests/fm-muse-signals-live-e2e.test.sh
 ```
+
+The Muse signals guard requires a real `muse` binary and tmux but uses `--provider echo`, so it does not require `META_API_KEY` and does not open the deferred real-model idle gate.
 
 The portable counterparts that run in ordinary CI are `tests/fm-muse-harness.test.sh`, `tests/fm-tmux-agent-liveness.test.sh`, `tests/fm-composer-lib.test.sh`, and `tests/fm-composer-ghost.test.sh`.

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -35,7 +35,7 @@ Pi and pi-signed 0.82.0 were reverified on 2026-07-27 through real isolated `fm-
 The earlier record that every harness is observed under its own `#{pane_current_command}` no longer holds and has been replaced by the per-harness evidence below.
 In this macOS run that reading reflected a rewritable process title rather than stable executable identity, so it is now one of two independent name sources rather than the sole basis of a verdict.
 
-All seven verified adapters were relaunched on 2026-08-03 with tmux 3.6a on macOS 26.5.2 arm64, each on a private socket in an isolated lab.
+The seven primary-capable adapters were relaunched on 2026-08-03 with tmux 3.6a on macOS 26.5.2 arm64, each on a private socket in an isolated lab.
 
 ```sh
 tmux -L "$socket" new-window -d -t "$session:" -n "$harness" -c "$wt" -- "$bin"
@@ -58,6 +58,23 @@ Observed identities, and the resulting verdict:
 Claude Code is the harness whose title no longer attributes it at all; every other adapter is currently attributed by both sources.
 Codex reported `codex-aarch64-a` at 0.145.0 and `codex` at 0.146.0, and Kimi Code reported `kimi-code` as its foreground `comm` at 0.29.1 and `kimi` at 0.31.1, so these identities move between ordinary patch releases in both directions.
 That is the evidence for treating any single process name as a surface under vendor control rather than a stable contract.
+
+The crewmate-only Muse Code 0.1.0-R708.1 adapter was verified separately on 2026-08-05 against tmux on macOS arm64.
+Its installed `muse-bin-0.1.0-R708.1` foreground identity classified `alive`, while `musescore`, `amuse`, `muse-binary`, and `muse-bind` remained ambiguous in the portable regression.
+[`muse.md`](muse.md#process-identity) owns the artifact identity and launcher evidence for that verification.
+
+Bounded observed output:
+
+```text
+foreground comms:
+  zsh
+  .../instbin/muse-bin-0.1.0-R708.1
+classify each:
+  zsh                            -> shell
+  muse-bin-0.1.0-R708.1          -> agent
+fm_backend_agent_state tmux museliv:zsh
+alive
+```
 
 `#{pane_current_command}` and foreground `ps -o comm=` read different name fields, but which one preserves executable identity is platform-dependent.
 On macOS the pane command reflected the rewritable title while the full install path could survive in `ps -o comm=`; in the Linux portable regression those roles reversed for the version-named native executable, with the identifying path retained in argv[0].
@@ -161,7 +178,7 @@ ok - fm-teardown: dedicated-socket invalid cleanup preserves target/control and 
 The dedicated tmux cell removed ambient tmux variables, required a socket-bound wrapper, kept one target and one independent control window, and proved the wrapper was not called for invalid metadata or a direct empty target.
 Valid cleanup removed only the exact task-bound target and left the control window live.
 The metadata-only validation covers tmux, Herdr, Zellij, Orca, and cmux before backend dispatch.
-Claude, Codex, OpenCode, Pi, pi-signed, Grok, and Kimi share that backend cleanup boundary; their harness-specific hook files and token cleanup run only after it, so no harness needs a separate endpoint parser.
+Claude, Codex, OpenCode, Pi, pi-signed, Grok, Kimi, and Muse share that backend cleanup boundary; their harness-specific hook files, tokens, and session-log sidecars are cleaned only after it, so no harness needs a separate endpoint parser.
 
 ## Herdr
 

--- a/tests/fm-bootstrap.test.sh
+++ b/tests/fm-bootstrap.test.sh
@@ -928,6 +928,8 @@ unsupported grok max effort is flagged^{"rules":[{"when":"deep current work","us
 unsupported grok xhigh effort is flagged^{"rules":[{"when":"deep current work","use":{"harness":"grok","model":"grok-4","effort":"xhigh"}}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - invalid effort: grok:xhigh
 pi max effort is accepted^{"rules":[{"when":"deep coding","use":{"harness":"pi","model":"openai-codex/gpt-5.6-sol","effort":"max"}}]}^empty^
 pi-signed max effort is accepted^{"rules":[{"when":"signed coding","use":{"harness":"pi-signed","model":"openai-codex/gpt-5.6-sol","effort":"max"}}]}^empty^
+muse shared efforts are accepted^{"rules":[{"when":"muse low","use":{"harness":"muse","effort":"low"}},{"when":"muse medium","use":{"harness":"muse","effort":"medium"}},{"when":"muse high","use":{"harness":"muse","effort":"high"}},{"when":"muse xhigh","use":{"harness":"muse","effort":"xhigh"}},{"when":"muse max","use":{"harness":"muse","effort":"max"}}]}^empty^
+unsupported muse ultra effort is flagged^{"rules":[{"when":"muse ultra","use":{"harness":"muse","effort":"ultra"}}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - invalid effort: muse:ultra
 unsupported opencode effort is flagged^{"rules":[{"when":"opencode work","use":{"harness":"opencode","model":"anthropic/claude-sonnet-4-5","effort":"high"}}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - invalid effort: opencode:high
 kimi model profile is accepted^{"rules":[{"when":"kimi work","use":{"harness":"kimi","model":"kimi-code/k3"}}]}^empty^
 unsupported kimi effort is flagged^{"rules":[{"when":"kimi work","use":{"harness":"kimi","model":"kimi-code/k3","effort":"high"}}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - invalid effort: kimi:high

--- a/tests/fm-composer-ghost.test.sh
+++ b/tests/fm-composer-ghost.test.sh
@@ -154,6 +154,34 @@ test_strip_ghost_drops_dark_truecolor_ghost() {
   pass "fm_tmux_strip_ghost drops a dark/muted truecolor foreground (grok placeholder)"
 }
 
+# --- muse's composer sits closest to the ghost threshold ---------------------
+
+# These are muse 0.1.0-R708.1's real captured composer rows. Its prompt glyph
+# `⟩` is truecolor 38;2;90;160;255 (luminance ~149.9) and its typed text is
+# 38;2;204;211;219 (~209.8), so the glyph clears the 128 default by the
+# narrowest margin in the fleet - roughly a fifth of grok's real-input margin.
+# Both must survive stripping: dropping the glyph would empty an idle composer's
+# plain row, and dropping the typed text would read a pending pane as empty and
+# make it an injection target.
+test_strip_ghost_keeps_muse_composer_colors() {
+  local out glyph
+  glyph=$(printf '\xe2\x9f\xa9')
+  out=$(printf '\033[0m\033[38;2;90;160;255m\xe2\x9f\xa9 \033[39m\n' | fm_tmux_strip_ghost)
+  [ "$out" = "$(printf '%s ' "$glyph")" ] \
+    || fail "muse's idle composer glyph was stripped as ghost text: '$out'"
+  # The submitted-prompt row carries a background colour too; an SGR 48 payload
+  # must not be luminance-tested as if it were the foreground.
+  out=$(printf '\033[38;2;90;160;255m\033[48;2;38;56;84m\xe2\x9f\xa9 \033[38;2;204;211;219mhello from firstmate\033[39m\n' | fm_tmux_strip_ghost)
+  [ "$out" = "$(printf '%s hello from firstmate' "$glyph")" ] \
+    || fail "muse's typed text or background-coloured glyph row was stripped: '$out'"
+  # The restored prompt muse puts back into the composer after an Escape
+  # interrupt is real bright text and must stay visible as pending input.
+  out=$(printf '\033[0m\033[38;2;90;160;255m\xe2\x9f\xa9 \033[38;2;204;211;219msecond turn to interrupt\033[39m\n' | fm_tmux_strip_ghost)
+  [ "$out" = "$(printf '%s second turn to interrupt' "$glyph")" ] \
+    || fail "muse's restored post-interrupt prompt was stripped as ghost text: '$out'"
+  pass "fm_tmux_strip_ghost keeps muse's near-threshold glyph and its typed text"
+}
+
 # --- fm_pane_input_pending: dim ghost is not pending ------------------------
 
 test_dim_ghost_only_composer_is_not_pending() {
@@ -600,6 +628,7 @@ test_strip_ghost_drops_dim_keeps_normal
 test_strip_ghost_handles_combined_and_boundary_codes
 test_strip_ghost_keeps_colored_text_with_2_payloads
 test_strip_ghost_drops_dark_truecolor_ghost
+test_strip_ghost_keeps_muse_composer_colors
 test_dim_ghost_only_composer_is_not_pending
 test_dim_ghost_inside_bordered_composer_is_not_pending
 test_normal_text_still_pending

--- a/tests/fm-composer-lib.test.sh
+++ b/tests/fm-composer-lib.test.sh
@@ -9,7 +9,7 @@
 #      (unsafe-for-injection), never `empty`. This is the safety fix.
 #   2. The SAME shell glyph INSIDE a bordered composer box is the harness's own
 #      prompt and still reads `empty` (existing behavior preserved).
-#   3. The AGENT prompt glyphs `❯` (claude) and `›` (codex) are a genuine empty
+#   3. The AGENT prompt glyphs `❯` (claude), `›` (codex), and `⟩` (muse) are a genuine empty
 #      agent composer either way, bordered or bare.
 #   4. Real unsubmitted text reads `pending`; a known idle placeholder reads
 #      `empty`.
@@ -43,7 +43,10 @@ test_stripped_unbordered_content_uses_plain_content() {
     [ "$out" = unknown ] \
       || fail "stripped unbordered content '$plain' must retain its unknown safety verdict, got '$out'"
   done
-  for plain in '❯' '›'; do
+  # muse draws `⟩` at luminance ~150, the tightest margin over the 128 ghost
+  # threshold in the fleet, so a raised threshold really can strip it to empty
+  # and leave only the plain row. This branch is what keeps that pane readable.
+  for plain in '❯' '›' '⟩'; do
     out=$(classify 0 '' '' sensitive "$plain")
     [ "$out" = empty ] \
       || fail "a stripped agent glyph '$plain' must remain empty, got '$out'"
@@ -79,7 +82,9 @@ test_agent_glyphs_are_empty_bordered_and_bare() {
   out=$(classify 0 '›'); [ "$out" = empty ] || fail "bare codex '›' should read empty, got '$out'"
   out=$(classify 1 '❯'); [ "$out" = empty ] || fail "bordered claude '❯' should read empty, got '$out'"
   out=$(classify 1 '›'); [ "$out" = empty ] || fail "bordered codex '›' should read empty, got '$out'"
-  pass "fm_composer_classify_content: agent prompt glyphs (❯ claude, › codex) read empty bordered or bare"
+  out=$(classify 0 '⟩'); [ "$out" = empty ] || fail "bare muse '⟩' should read empty, got '$out'"
+  out=$(classify 1 '⟩'); [ "$out" = empty ] || fail "bordered muse '⟩' should read empty, got '$out'"
+  pass "fm_composer_classify_content: agent prompt glyphs (❯ claude, › codex, ⟩ muse) read empty bordered or bare"
 }
 
 # --- Empty content and idle placeholder -------------------------------------
@@ -120,6 +125,9 @@ test_real_text_is_pending() {
   local out
   out=$(classify 0 '❯ fix findings 1 and 3'); [ "$out" = pending ] || fail "bare '❯ <text>' should be pending, got '$out'"
   out=$(classify 1 '> deploy staging now'); [ "$out" = pending ] || fail "bordered '> <text>' should be pending, got '$out'"
+  # muse restores the interrupted prompt into its composer after Escape, as real
+  # bright text. Reading that as pending is correct - it really is unsubmitted.
+  out=$(classify 0 '⟩ second turn to interrupt'); [ "$out" = pending ] || fail "bare '⟩ <text>' should be pending, got '$out'"
   # A slash-command popup argument-hint placeholder is still unsubmitted text.
   out=$(classify 1 '/compact compaction instructions'); [ "$out" = pending ] || fail "a popup placeholder fill should be pending, got '$out'"
   pass "fm_composer_classify_content: real unsubmitted text reads pending (including a popup argument-hint fill)"

--- a/tests/fm-harness-liveness-drift-live-e2e.test.sh
+++ b/tests/fm-harness-liveness-drift-live-e2e.test.sh
@@ -82,7 +82,11 @@ SKIPPED=
 
 # The verified adapters, in the order .agents/skills/harness-adapters/SKILL.md
 # records them. An adapter that gains a verified launch path belongs here too.
-for harness in claude codex opencode pi pi-signed grok kimi; do
+# muse matters most of all here: its launcher execs a VERSION-SUFFIXED binary,
+# so the live process name changes on every auto-update and its install path
+# carries no `muse` component to fall back on. That is precisely the drift this
+# guard exists to catch, and only a real muse release can produce it.
+for harness in claude codex opencode pi pi-signed grok kimi muse; do
   if ! bin_path=$(resolve_harness_binary "$harness"); then
     SKIPPED="$SKIPPED $harness"
     note "skip: $harness is not installed on this machine, so its classification is unverified here"

--- a/tests/fm-muse-harness.test.sh
+++ b/tests/fm-muse-harness.test.sh
@@ -347,11 +347,13 @@ EOF
   # No busy record is armed for muse: the source is pull-only with no writer, so
   # a seeded busy record could never be settled.
   assert_absent "$home/state/$id.busy-gen" "muse spawn armed a busy record it can never clear"
+  printf 'binding_id=retired\nsession_log=%s\n' "$prior" > "$home/state/$id.muse-session-current"
 
   FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" \
     PATH="$fakebin:$PATH" "$TEARDOWN" "$id" --force >/dev/null 2>&1 \
     || fail "muse teardown failed"
   assert_absent "$binding" "muse session binding survived teardown"
+  assert_absent "$home/state/$id.muse-session-current" "muse session cache survived teardown"
   pass "muse spawn writes a session binding that teardown removes"
 }
 
@@ -618,6 +620,63 @@ EOF
   pass "spawn-time exclusions select the current session across equal mtimes"
 }
 
+test_session_log_cache_reuses_and_refreshes_binding() {
+  local dir state id root old fresh verdict fakebin
+  dir="$TMP_ROOT/cache"
+  state="$dir/state"
+  root="$dir/sessions"
+  id=cachetask
+  mkdir -p "$state"
+
+  old=$(write_session_log "$root" 2026 08 05 old "$dir/ws" <<EOF
+$(muse_log_run_started old-run)
+EOF
+)
+  old=$(printf '%s\n' "$old" | sed 's://*:/:g')
+  printf 'sessions_root=%s\nworkspace_root=%s\nbinding_id=incarnation-one\n' \
+    "$root" "$dir/ws" > "$state/$id.muse-session"
+  verdict=$(classify_muse "$state" "$id")
+  [ "$verdict" = "busy muse-session-log" ] \
+    || fail "the initial session did not resolve before caching: got '$verdict'"
+
+  fakebin=$(fm_fakebin "$dir/fake")
+  cat > "$fakebin/node" <<'SH'
+#!/usr/bin/env bash
+exit 97
+SH
+  chmod +x "$fakebin/node"
+  verdict=$(PATH="$fakebin:$PATH" classify_muse "$state" "$id")
+  [ "$verdict" = "busy muse-session-log" ] \
+    || fail "a cached session triggered another tree resolution: got '$verdict'"
+
+  muse_log_run_terminal old-run completed >> "$old"
+  fresh=$(write_session_log "$root" 2026 08 05 fresh "$dir/ws" <<EOF
+$(muse_log_run_started fresh-run)
+EOF
+)
+  printf 'sessions_root=%s\nworkspace_root=%s\nbinding_id=incarnation-two\nprior_log=%s\n' \
+    "$root" "$dir/ws" "$old" > "$state/$id.muse-session"
+  verdict=$(classify_muse "$state" "$id")
+  [ "$verdict" = "busy muse-session-log" ] \
+    || fail "a fresh session did not supersede the prior cached session: got '$verdict'"
+
+  rm -f "$fresh"
+  verdict=$(classify_muse "$state" "$id")
+  [ "$verdict" = "unknown muse-session-log" ] \
+    || fail "a missing cached session produced '$verdict' instead of unknown"
+
+  write_session_log "$root" 2026 08 05 ambiguous-a "$dir/ws" >/dev/null <<EOF
+$(muse_log_run_started ambiguous-a)
+EOF
+  write_session_log "$root" 2026 08 05 ambiguous-b "$dir/ws" >/dev/null <<EOF
+$(muse_log_run_started ambiguous-b)
+EOF
+  verdict=$(classify_muse "$state" "$id")
+  [ "$verdict" = "unknown muse-session-log" ] \
+    || fail "ambiguous replacement sessions produced '$verdict' instead of unknown"
+  pass "the Muse session cache avoids rescans and refreshes safely across incarnations"
+}
+
 # muse's own native sub-agents write independent run lifecycles one directory
 # deeper, under subagent/<child-session-id>/. Folding a child's log would report
 # the parent busy long after the parent's turn ended.
@@ -649,7 +708,8 @@ EOF
   [ "$(run_state "$child/session.jsonl")" = busy ] \
     || fail "the sub-agent fixture is not an open run, so the exclusion case would be vacuous"
 
-  printf 'sessions_root=%s\nworkspace_root=%s\n' "$root" "$dir/ws" > "$state/$id.muse-session"
+  printf 'sessions_root=%s\nworkspace_root=%s\nbinding_id=subagent-incarnation\n' \
+    "$root" "$dir/ws" > "$state/$id.muse-session"
   verdict=$(classify_muse "$state" "$id")
   [ "$verdict" != "busy muse-session-log" ] \
     || fail "a sub-agent's open run was folded as the parent task's busy state"
@@ -657,6 +717,11 @@ EOF
   # the exclusion working rather than the binding silently failing.
   [ "$(run_state "$root/2026/08/05/parent/session.jsonl")" = settled ] \
     || fail "the parent fixture did not fold as settled"
+  printf 'binding_id=subagent-incarnation\nsession_log=%s\n' \
+    "$child/session.jsonl" > "$state/$id.muse-session-current"
+  verdict=$(classify_muse "$state" "$id")
+  [ "$verdict" != "busy muse-session-log" ] \
+    || fail "a cached sub-agent log was folded as the parent task's busy state"
   pass "sub-agent session logs are excluded from the parent's busy fold"
 }
 
@@ -761,6 +826,7 @@ test_nested_terminal_record_does_not_settle_a_run
 test_binding_selects_the_matching_main_log
 test_workspace_binding_treats_glob_characters_literally
 test_binding_excludes_preexisting_log_when_mtimes_tie
+test_session_log_cache_reuses_and_refreshes_binding
 test_subagent_logs_are_excluded
 test_missing_and_unreadable_bindings_are_unknown_never_idle
 test_settled_log_stays_unknown_while_the_idle_gate_is_closed

--- a/tests/fm-muse-harness.test.sh
+++ b/tests/fm-muse-harness.test.sh
@@ -69,6 +69,11 @@ case "$*" in
   *"#{pane_current_path}"*) printf '%s\n' "${FM_FAKE_PANE_PATH:-}"; exit 0 ;;
 esac
 case "${1:-}" in
+  show-environment)
+    [ "${FM_FAKE_WORKER_META_KEY:-}" = present ] || exit 1
+    printf 'META_API_KEY=worker-key\n'
+    exit 0
+    ;;
   display-message) printf 'firstmate\n'; exit 0 ;;
   list-windows) exit 0 ;;
   has-session|new-session|new-window|kill-window) exit 0 ;;
@@ -118,8 +123,10 @@ run_muse_spawn() {  # <home> <proj> <wt> <fakebin> <id> [extra args...]
     FM_PROJECTS_OVERRIDE="$home/projects" FM_CONFIG_OVERRIDE="$home/config" \
     FM_SPAWN_NO_GUARD=1 FM_FAKE_PANE_PATH="$wt" TMUX="fake,1,0" \
     FM_FAKE_LAUNCH_LOG="$home/launch.log" \
+    FM_FAKE_WORKER_META_KEY="${FM_TEST_MUSE_WORKER_KEY-present}" \
     META_API_KEY="${FM_TEST_MUSE_KEY-test-key}" \
     XDG_CONFIG_HOME="$home/xdgconfig" \
+    XDG_DATA_HOME="${FM_TEST_MUSE_DATA_HOME-$home/xdgdata}" \
     PATH="$fakebin:$PATH" \
     "$SPAWN" "$id" "$proj" muse "$@" 2>&1
 }
@@ -143,7 +150,7 @@ test_detects_versioned_process_ancestor() {
   local dir bin out
   dir="$TMP_ROOT/detect"
   mkdir -p "$dir"
-  for bin in muse-bin-0.1.0-R708.1 muse-bin-9.9.9-RZZZ.9 muse-bin muse; do
+  for bin in muse-bin-0.1.0-R708.1 muse-bin-9.9.9-RZZZ.9 muse; do
     cp "$(command -v bash)" "$dir/$bin"
     out=$(env -u CLAUDECODE -u PI_CODING_AGENT -u GROK_AGENT \
       "$dir/$bin" -c "r=\$(\"$HARNESS\"); printf '%s' \"\$r\"")
@@ -158,7 +165,7 @@ test_detection_is_anchored() {
   local dir bin out
   dir="$TMP_ROOT/detect-neg"
   mkdir -p "$dir"
-  for bin in musescore amuse notmuse-bin; do
+  for bin in musescore amuse notmuse-bin muse-binary muse-bind; do
     cp "$(command -v bash)" "$dir/$bin"
     out=$(env -u CLAUDECODE -u PI_CODING_AGENT -u GROK_AGENT \
       "$dir/$bin" -c "r=\$(\"$HARNESS\"); printf '%s' \"\$r\"")
@@ -194,6 +201,12 @@ EOF
   # The captain accepted muse's self-update risk, so firstmate must not pin it.
   assert_not_contains "$launch" 'MUSE_NO_AUTO_UPDATE' \
     "muse launch pinned auto-update, which the captain declined"
+  assert_contains "$launch" "XDG_CONFIG_HOME='$home/xdgconfig'" \
+    "muse launch did not forward its non-secret config root"
+  assert_contains "$launch" "XDG_DATA_HOME='$home/xdgdata'" \
+    "muse launch did not forward its non-secret data root"
+  assert_not_contains "$launch" 'META_API_KEY' "muse launch exposed META_API_KEY in worker argv"
+  assert_not_contains "$launch" 'test-key' "muse launch exposed the credential value in worker argv"
   assert_contains "$launch" 'encode launch-brief' "muse launch did not deliver the brief positionally"
   assert_grep 'harness=muse' "$home/state/$id.meta" "muse harness was not recorded in meta"
   pass "muse spawn launches with autonomy, privacy control, and a positional brief"
@@ -246,13 +259,31 @@ test_spawn_refuses_without_credential() {
 $rec
 EOF
   mkdir -p "$home/xdgconfig/muse"
-  out=$(FM_TEST_MUSE_KEY='' run_muse_spawn "$home" "$proj" "$wt" "$fakebin" "$id" \
+  out=$(FM_TEST_MUSE_KEY='' FM_TEST_MUSE_WORKER_KEY='' run_muse_spawn "$home" "$proj" "$wt" "$fakebin" "$id" \
     --mode no-mistakes --yolo off)
   status=$?
   [ "$status" -ne 0 ] || fail "muse spawn succeeded with no credential available"
-  assert_contains "$out" "no usable credential" "muse spawn did not name the missing credential"
+  assert_contains "$out" "no worker-reachable credential" "muse spawn did not name the missing credential"
   assert_absent "$home/state/$id.meta" "refused muse spawn still published task metadata"
   pass "muse spawn refuses when no credential can reach the provider"
+}
+
+test_spawn_refuses_caller_only_environment_credential() {
+  local rec case_dir home proj wt fakebin id out status
+  rec=$(make_spawn_case caller-only-cred)
+  IFS='|' read -r case_dir home proj wt fakebin id <<EOF
+$rec
+EOF
+  out=$(FM_TEST_MUSE_KEY='caller-only-secret' FM_TEST_MUSE_WORKER_KEY='' \
+    run_muse_spawn "$home" "$proj" "$wt" "$fakebin" "$id" --mode no-mistakes --yolo off)
+  status=$?
+  [ "$status" -ne 0 ] || fail "muse spawn accepted a caller-only META_API_KEY"
+  assert_contains "$out" "set for fm-spawn but cannot be proven present" \
+    "muse spawn did not explain that the caller credential cannot reach the worker"
+  assert_contains "$out" "$home/xdgconfig/muse/auth.json" \
+    "muse spawn did not name the supported stored credential path"
+  assert_absent "$home/launch.log" "caller-only credential refusal created an endpoint"
+  pass "muse spawn refuses a META_API_KEY that cannot reach the worker"
 }
 
 test_spawn_accepts_stored_credential() {
@@ -263,7 +294,8 @@ $rec
 EOF
   mkdir -p "$home/xdgconfig/muse"
   printf '{"schema_version":1}\n' > "$home/xdgconfig/muse/auth.json"
-  FM_TEST_MUSE_KEY='' run_muse_spawn "$home" "$proj" "$wt" "$fakebin" "$id" \
+  FM_TEST_MUSE_KEY='' FM_TEST_MUSE_WORKER_KEY='' \
+    run_muse_spawn "$home" "$proj" "$wt" "$fakebin" "$id" \
     --mode no-mistakes --yolo off >/dev/null
   status=$?
   expect_code 0 "$status" "muse spawn should accept a stored credential"
@@ -279,14 +311,14 @@ test_spawn_refuses_secondmate() {
   home="$case_dir/home"
   fakebin=$(make_spawn_fakebin "$case_dir/fake")
   id="muse-secondmate-x1"
-  mkdir -p "$home/data/$id" "$home/projects" "$home/state" "$home/config" "$case_dir/subhome"
+  mkdir -p "$home/data/$id" "$home/projects" "$home/state" "$home/config" "$case_dir/muse"
   printf 'charter\n' > "$home/data/$id/brief.md"
-  out=$(FM_ROOT_OVERRIDE='' FM_HOME="$home" \
+  out=$(cd "$case_dir" && FM_ROOT_OVERRIDE='' FM_HOME="$home" \
     FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
     FM_PROJECTS_OVERRIDE="$home/projects" FM_CONFIG_OVERRIDE="$home/config" \
     FM_SPAWN_NO_GUARD=1 TMUX="fake,1,0" META_API_KEY=test-key \
     PATH="$fakebin:$PATH" \
-    "$SPAWN" "$id" "$case_dir/subhome" muse --secondmate 2>&1)
+    "$SPAWN" "$id" muse --secondmate 2>&1)
   status=$?
   [ "$status" -ne 0 ] || fail "muse was accepted as a secondmate harness"
   assert_contains "$out" "crewmate/scout adapter only" "muse secondmate refusal did not explain the boundary"
@@ -301,7 +333,7 @@ $rec
 EOF
   prior=$(write_session_log "$case_dir/xdgdata/muse/sessions" 2026 08 05 prior "$wt" </dev/null)
   prior=$(printf '%s\n' "$prior" | sed 's://*:/:g')
-  XDG_DATA_HOME="$case_dir/xdgdata" \
+  FM_TEST_MUSE_DATA_HOME="$case_dir/xdgdata" \
     run_muse_spawn "$home" "$proj" "$wt" "$fakebin" "$id" --mode no-mistakes --yolo off >/dev/null \
     || fail "muse spawn failed"
 
@@ -717,6 +749,7 @@ test_detection_is_anchored
 test_spawn_launch_shape
 test_spawn_maps_effort_and_model
 test_spawn_refuses_without_credential
+test_spawn_refuses_caller_only_environment_credential
 test_spawn_accepts_stored_credential
 test_spawn_refuses_secondmate
 test_spawn_writes_busy_binding_and_teardown_removes_it

--- a/tests/fm-muse-harness.test.sh
+++ b/tests/fm-muse-harness.test.sh
@@ -80,7 +80,15 @@ case "${1:-}" in
   send-keys)
     prev=
     for arg in "$@"; do
-      if [ "$prev" = -l ]; then printf '%s\n' "$arg" >> "$FM_FAKE_LAUNCH_LOG"; break; fi
+      if [ "$prev" = -l ]; then
+        printf '%s\n' "$arg" >> "$FM_FAKE_LAUNCH_LOG"
+        if [ "${FM_FAKE_EXECUTE_MUSE_LAUNCH:-}" = 1 ]; then
+          case "$arg" in
+            *"$FM_FAKE_MUSE_EXECUTABLE"*) (cd "$FM_FAKE_PANE_PATH" && bash -c "$arg") ;;
+          esac
+        fi
+        break
+      fi
       prev=$arg
     done
     exit 0
@@ -89,11 +97,12 @@ esac
 exit 0
 SH
   chmod +x "$fakebin/tmux"
-  # A real executable named `muse` on PATH: fm-spawn resolves and absolutises it
-  # rather than trusting the bare name, so a stub file is what the code needs.
+  cp "$(command -v bash)" "$fakebin/muse-bin-test-version"
   cat > "$fakebin/muse" <<'SH'
 #!/usr/bin/env bash
-exit 0
+set -u
+[ -n "${FM_FAKE_HARNESS_RESULT:-}" ] || exit 0
+exec "$FM_FAKE_MUSE_VERSIONED" -c 'result=$($FM_FAKE_HARNESS_PROBE); printf "%s" "$result" > "$FM_FAKE_HARNESS_RESULT"'
 SH
   chmod +x "$fakebin/muse"
   fm_fake_exit0 "$fakebin" treehouse gh-axi gh
@@ -123,6 +132,11 @@ run_muse_spawn() {  # <home> <proj> <wt> <fakebin> <id> [extra args...]
     FM_PROJECTS_OVERRIDE="$home/projects" FM_CONFIG_OVERRIDE="$home/config" \
     FM_SPAWN_NO_GUARD=1 FM_FAKE_PANE_PATH="$wt" TMUX="fake,1,0" \
     FM_FAKE_LAUNCH_LOG="$home/launch.log" \
+    FM_FAKE_MUSE_EXECUTABLE="$fakebin/muse" \
+    FM_FAKE_MUSE_VERSIONED="$fakebin/muse-bin-test-version" \
+    FM_FAKE_HARNESS_PROBE="$HARNESS" \
+    FM_FAKE_EXECUTE_MUSE_LAUNCH="${FM_FAKE_EXECUTE_MUSE_LAUNCH:-}" \
+    FM_FAKE_HARNESS_RESULT="${FM_FAKE_HARNESS_RESULT:-}" \
     FM_FAKE_WORKER_META_KEY="${FM_TEST_MUSE_WORKER_KEY-present}" \
     META_API_KEY="${FM_TEST_MUSE_KEY-test-key}" \
     XDG_CONFIG_HOME="$home/xdgconfig" \
@@ -172,6 +186,24 @@ test_detection_is_anchored() {
     [ "$out" != muse ] || fail "fm-harness.sh misdetected unrelated process '$bin' as muse"
   done
   pass "muse detection does not claim unrelated muse-containing commands"
+}
+
+test_spawn_clears_inherited_foreign_harness_markers() {
+  local rec case_dir home proj wt fakebin id result out status
+  rec=$(make_spawn_case inherited-markers)
+  IFS='|' read -r case_dir home proj wt fakebin id <<EOF
+$rec
+EOF
+  result="$case_dir/harness-result"
+  out=$(CLAUDECODE=1 PI_CODING_AGENT=true GROK_AGENT=1 FM_PI_HARNESS=pi-signed \
+    FM_FAKE_EXECUTE_MUSE_LAUNCH=1 FM_FAKE_HARNESS_RESULT="$result" \
+    run_muse_spawn "$home" "$proj" "$wt" "$fakebin" "$id" --mode no-mistakes --yolo off)
+  status=$?
+  expect_code 0 "$status" "muse spawn from a marked backend should succeed: $out"
+  [ -f "$result" ] || fail "the generated muse launch never executed its harness probe"
+  [ "$(cat "$result")" = muse ] \
+    || fail "muse worker inherited a foreign harness identity: $(cat "$result")"
+  pass "muse launch clears foreign harness markers before ancestry detection"
 }
 
 # --- spawn ------------------------------------------------------------------
@@ -399,24 +431,26 @@ run_send_key() {  # <home> <fakebin> <id> <key> <keylog>
     "$ROOT/bin/fm-send.sh" "$3" --key "$4" 2>&1
 }
 
-test_muse_escape_clears_the_composer() {
-  local rec case_dir home fakebin id keylog out status
-  rec=$(make_send_case muse muse)
-  IFS='|' read -r case_dir home fakebin id <<EOF
+test_muse_escape_aliases_clear_the_composer() {
+  local entry name key rec case_dir home fakebin id keylog out status
+  for entry in exact:Escape lower:escape short:Esc short-lower:esc; do
+    name=${entry%%:*}
+    key=${entry#*:}
+    rec=$(make_send_case "muse-$name" muse)
+    IFS='|' read -r case_dir home fakebin id <<EOF
 $rec
 EOF
-  keylog="$case_dir/keys.log"
-  : > "$keylog"
-  out=$(run_send_key "$home" "$fakebin" "$id" Escape "$keylog")
-  status=$?
-  expect_code 0 "$status" "muse Escape send should succeed: $out"
-  assert_grep 'Escape' "$keylog" "Escape never reached the muse pane"
-  assert_grep 'C-u' "$keylog" "muse Escape did not clear the restored composer"
-  # Ordering matters: clearing before the interrupt lands would wipe nothing and
-  # leave the restored prompt behind.
-  [ "$(grep -c . "$keylog")" -ge 2 ] || fail "expected both the interrupt and the clear"
-  head -1 "$keylog" | grep -q 'Escape' || fail "the clear was sent before the interrupt"
-  pass "a muse interrupt clears the prompt muse restores into the composer"
+    keylog="$case_dir/keys.log"
+    : > "$keylog"
+    out=$(run_send_key "$home" "$fakebin" "$id" "$key" "$keylog")
+    status=$?
+    expect_code 0 "$status" "muse $key send should succeed: $out"
+    assert_grep "$key" "$keylog" "$key never reached the muse pane"
+    assert_grep 'C-u' "$keylog" "muse $key did not clear the restored composer"
+    [ "$(grep -c . "$keylog")" -ge 2 ] || fail "expected both the interrupt and the clear for $key"
+    head -1 "$keylog" | grep -q "$key" || fail "the clear was sent before the $key interrupt"
+  done
+  pass "every accepted muse Escape alias clears the restored composer"
 }
 
 test_non_muse_escape_does_not_clear() {
@@ -811,6 +845,7 @@ test_muse_trusts_no_record_sources() {
 
 test_detects_versioned_process_ancestor
 test_detection_is_anchored
+test_spawn_clears_inherited_foreign_harness_markers
 test_spawn_launch_shape
 test_spawn_maps_effort_and_model
 test_spawn_refuses_without_credential
@@ -818,7 +853,7 @@ test_spawn_refuses_caller_only_environment_credential
 test_spawn_accepts_stored_credential
 test_spawn_refuses_secondmate
 test_spawn_writes_busy_binding_and_teardown_removes_it
-test_muse_escape_clears_the_composer
+test_muse_escape_aliases_clear_the_composer
 test_non_muse_escape_does_not_clear
 test_failed_clear_is_reported
 test_run_fold_tracks_open_and_settled_turns

--- a/tests/fm-muse-harness.test.sh
+++ b/tests/fm-muse-harness.test.sh
@@ -294,11 +294,12 @@ test_spawn_refuses_secondmate() {
 }
 
 test_spawn_writes_busy_binding_and_teardown_removes_it() {
-  local rec case_dir home proj wt fakebin id binding
+  local rec case_dir home proj wt fakebin id binding prior
   rec=$(make_spawn_case binding)
   IFS='|' read -r case_dir home proj wt fakebin id <<EOF
 $rec
 EOF
+  prior=$(write_session_log "$case_dir/xdgdata/muse/sessions" 2026 08 05 prior "$wt" </dev/null)
   XDG_DATA_HOME="$case_dir/xdgdata" \
     run_muse_spawn "$home" "$proj" "$wt" "$fakebin" "$id" --mode no-mistakes --yolo off >/dev/null \
     || fail "muse spawn failed"
@@ -308,6 +309,7 @@ EOF
   assert_grep "sessions_root=$case_dir/xdgdata/muse/sessions" "$binding" \
     "muse binding did not record the resolved sessions root"
   assert_grep "workspace_root=$wt" "$binding" "muse binding did not record the task worktree"
+  assert_grep "prior_log=$prior" "$binding" "muse binding did not exclude the pre-existing session"
   # No busy record is armed for muse: the source is pull-only with no writer, so
   # a seeded busy record could never be settled.
   assert_absent "$home/state/$id.busy-gen" "muse spawn armed a busy record it can never clear"
@@ -527,6 +529,35 @@ EOF
   pass "the session binding folds only the log matching this task's worktree"
 }
 
+test_binding_excludes_preexisting_log_when_mtimes_tie() {
+  local dir state id root old current verdict
+  dir="$TMP_ROOT/mtime-tie"
+  state="$dir/state"
+  root="$dir/sessions"
+  id=tietask
+  mkdir -p "$state"
+
+  old=$(write_session_log "$root" 2026 08 05 aaaa-old "$dir/ws" <<EOF
+$(muse_log_run_started old-run)
+$(muse_log_run_terminal old-run completed)
+EOF
+)
+  current=$(write_session_log "$root" 2026 08 05 zzzz-current "$dir/ws" <<EOF
+$(muse_log_run_started current-run)
+EOF
+)
+  touch -t 202608050101.01 "$old" "$current"
+  { [ ! "$old" -nt "$current" ] && [ ! "$current" -nt "$old" ]; } \
+    || fail "the session-selection regression does not reproduce equal mtimes"
+
+  printf 'sessions_root=%s\nworkspace_root=%s\nprior_log=%s\n' \
+    "$root" "$dir/ws" "$old" > "$state/$id.muse-session"
+  verdict=$(classify_muse "$state" "$id")
+  [ "$verdict" = "busy muse-session-log" ] \
+    || fail "the current open session lost an mtime tie to the prior settled session: got '$verdict'"
+  pass "spawn-time exclusions select the current session across equal mtimes"
+}
+
 # muse's own native sub-agents write independent run lifecycles one directory
 # deeper, under subagent/<child-session-id>/. Folding a child's log would report
 # the parent busy long after the parent's turn ended.
@@ -667,6 +698,7 @@ test_failed_clear_is_reported
 test_run_fold_tracks_open_and_settled_turns
 test_nested_terminal_record_does_not_settle_a_run
 test_binding_selects_the_matching_main_log
+test_binding_excludes_preexisting_log_when_mtimes_tie
 test_subagent_logs_are_excluded
 test_missing_and_unreadable_bindings_are_unknown_never_idle
 test_settled_log_stays_unknown_while_the_idle_gate_is_closed

--- a/tests/fm-muse-harness.test.sh
+++ b/tests/fm-muse-harness.test.sh
@@ -1,0 +1,673 @@
+#!/usr/bin/env bash
+# Behavior tests for the muse (Muse Code) crewmate adapter: harness detection,
+# spawn launch shape and credential preflight, the secondmate refusal, the
+# session-log busy source, and teardown cleanup of the busy binding.
+#
+# The session-log fixtures below reproduce muse 0.1.0-R708.1's real record
+# shapes, including the nested "record":{"kind":"terminal"} cleanup payload that
+# is NOT a run terminal. That decoy is the whole reason the fold matches an
+# anchored structural prefix instead of searching for "kind":"terminal", so a
+# fixture without it would let a naive implementation pass.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+SPAWN="$ROOT/bin/fm-spawn.sh"
+TEARDOWN="$ROOT/bin/fm-teardown.sh"
+HARNESS="$ROOT/bin/fm-harness.sh"
+TMP_ROOT=$(fm_test_tmproot fm-muse-harness)
+
+# --- session-log fixtures ---------------------------------------------------
+
+# muse_log_metadata <workspace-root>: the first record of every session log,
+# which is what binds a log to a task worktree.
+muse_log_metadata() {
+  printf '{"schema_version":1,"id":"d77de583","stream":{"kind":"session","id":"52f21aea"},"sequence":1,"record_type":"event","durability":"durable","payload_type":"runtime.session.metadata","payload":{"kind":"metadata","record":{"workspace_root":"%s","provider_id":"meta","build":{"sha":"427a430436","semver":"0.1.0"}}}}\n' "$1"
+}
+
+muse_log_run_started() {  # <run-id>
+  printf '{"schema_version":1,"payload_type":"runtime.session","payload":{"kind":"run","run_id":"%s","event":{"kind":"started","prompt":"launch brief"}}}\n' "$1"
+}
+
+muse_log_run_terminal() {  # <run-id> <completed|cancelled>
+  printf '{"schema_version":1,"payload_type":"runtime.session","payload":{"kind":"run","run_id":"%s","event":{"kind":"terminal","terminal":"%s","reason":null,"turn_duration_ms":8152}}}\n' "$1" "$2"
+}
+
+# The decoy: a cleanup-effect payload whose NESTED record is "terminal". It is
+# not a run lifecycle terminal and must not settle an open run.
+muse_log_cleanup_terminal_decoy() {  # <run-id>
+  printf '{"schema_version":1,"payload_type":"runtime.session","payload":{"kind":"reminder_cleanup_effect","run_id":"%s","record":{"kind":"terminal","cleanup_effect_id":1,"outcome":{"kind":"applied"}}}}\n' "$1"
+}
+
+muse_log_noise() {  # <run-id>
+  printf '{"schema_version":1,"payload_type":"runtime.session","payload":{"kind":"run","run_id":"%s","event":{"kind":"context_block_diagnostic","block_id":"rules_file","message":"mentions kind terminal and kind started in prose"}}}\n' "$1"
+}
+
+# write_session_log <sessions-root> <yyyy> <mm> <dd> <uuid> <workspace-root>
+# Body records are read from stdin. Writes the log at muse's real depth
+# (<root>/YYYY/MM/DD/<uuid>/session.jsonl) and echoes the path.
+write_session_log() {
+  local root=$1 y=$2 m=$3 d=$4 uuid=$5 ws=$6 dir path
+  dir="$root/$y/$m/$d/$uuid"
+  mkdir -p "$dir"
+  path="$dir/session.jsonl"
+  muse_log_metadata "$ws" > "$path"
+  cat >> "$path"
+  printf '%s\n' "$path"
+}
+
+# --- spawn scaffolding ------------------------------------------------------
+
+make_spawn_fakebin() {
+  local dir=$1 fakebin
+  fakebin=$(fm_fakebin "$dir")
+  cat > "$fakebin/tmux" <<'SH'
+#!/usr/bin/env bash
+set -u
+case "$*" in
+  *"#{pane_current_path}"*) printf '%s\n' "${FM_FAKE_PANE_PATH:-}"; exit 0 ;;
+esac
+case "${1:-}" in
+  display-message) printf 'firstmate\n'; exit 0 ;;
+  list-windows) exit 0 ;;
+  has-session|new-session|new-window|kill-window) exit 0 ;;
+  send-keys)
+    prev=
+    for arg in "$@"; do
+      if [ "$prev" = -l ]; then printf '%s\n' "$arg" >> "$FM_FAKE_LAUNCH_LOG"; break; fi
+      prev=$arg
+    done
+    exit 0
+    ;;
+esac
+exit 0
+SH
+  chmod +x "$fakebin/tmux"
+  # A real executable named `muse` on PATH: fm-spawn resolves and absolutises it
+  # rather than trusting the bare name, so a stub file is what the code needs.
+  cat > "$fakebin/muse" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+  chmod +x "$fakebin/muse"
+  fm_fake_exit0 "$fakebin" treehouse gh-axi gh
+  printf '%s\n' "$fakebin"
+}
+
+make_spawn_case() {
+  local name=$1 case_dir home proj wt fakebin id
+  case_dir="$TMP_ROOT/$name"
+  home="$case_dir/home"
+  proj="$case_dir/project"
+  wt="$case_dir/wt"
+  fakebin=$(make_spawn_fakebin "$case_dir/fake")
+  id="muse-$name-x1"
+  mkdir -p "$home/data/$id" "$home/projects" "$home/state" "$home/config"
+  printf 'brief\n' > "$home/data/$id/brief.md"
+  fm_git_worktree "$proj" "$wt" "fm/$id"
+  touch "$home/state/.last-watcher-beat"
+  printf '%s\n' "$case_dir|$home|$proj|$wt|$fakebin|$id"
+}
+
+run_muse_spawn() {  # <home> <proj> <wt> <fakebin> <id> [extra args...]
+  local home=$1 proj=$2 wt=$3 fakebin=$4 id=$5
+  shift 5
+  FM_ROOT_OVERRIDE='' FM_HOME="$home" \
+    FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
+    FM_PROJECTS_OVERRIDE="$home/projects" FM_CONFIG_OVERRIDE="$home/config" \
+    FM_SPAWN_NO_GUARD=1 FM_FAKE_PANE_PATH="$wt" TMUX="fake,1,0" \
+    FM_FAKE_LAUNCH_LOG="$home/launch.log" \
+    META_API_KEY="${FM_TEST_MUSE_KEY-test-key}" \
+    XDG_CONFIG_HOME="$home/xdgconfig" \
+    PATH="$fakebin:$PATH" \
+    "$SPAWN" "$id" "$proj" muse "$@" 2>&1
+}
+
+# --- detection --------------------------------------------------------------
+
+# The installed muse launcher execs a VERSION-SUFFIXED binary
+# (~/.local/bin/muse-bin-<version>), so the name in the process tree changes on
+# every auto-update. Detection must follow a real running process rather than a
+# string, so each case launches an actual renamed executable and asks
+# fm-harness.sh from a child of it.
+#
+# The foreign env markers are cleared because muse is markerless and the marker
+# layer deliberately outranks ancestry: with one retained, these cases would
+# assert the marker's verdict instead of the ancestry match they exist to pin.
+# The command substitution around the probe is load-bearing: a bare `-c <cmd>`
+# lets the shell exec the probe in place, which REPLACES the muse-bin-* process
+# name the walk is supposed to find. Real muse keeps its TUI process alive and
+# runs tools as children, so forcing a fork is what reproduces that shape.
+test_detects_versioned_process_ancestor() {
+  local dir bin out
+  dir="$TMP_ROOT/detect"
+  mkdir -p "$dir"
+  for bin in muse-bin-0.1.0-R708.1 muse-bin-9.9.9-RZZZ.9 muse-bin muse; do
+    cp "$(command -v bash)" "$dir/$bin"
+    out=$(env -u CLAUDECODE -u PI_CODING_AGENT -u GROK_AGENT \
+      "$dir/$bin" -c "r=\$(\"$HARNESS\"); printf '%s' \"\$r\"")
+    [ "$out" = muse ] || fail "fm-harness.sh under process '$bin' reported '$out', expected muse"
+  done
+  pass "muse is detected through any versioned muse-bin ancestor"
+}
+
+# The match must be anchored: an unrelated command whose name merely CONTAINS
+# muse is a different program and must not be claimed by this adapter.
+test_detection_is_anchored() {
+  local dir bin out
+  dir="$TMP_ROOT/detect-neg"
+  mkdir -p "$dir"
+  for bin in musescore amuse notmuse-bin; do
+    cp "$(command -v bash)" "$dir/$bin"
+    out=$(env -u CLAUDECODE -u PI_CODING_AGENT -u GROK_AGENT \
+      "$dir/$bin" -c "r=\$(\"$HARNESS\"); printf '%s' \"\$r\"")
+    [ "$out" != muse ] || fail "fm-harness.sh misdetected unrelated process '$bin' as muse"
+  done
+  pass "muse detection does not claim unrelated muse-containing commands"
+}
+
+# --- spawn ------------------------------------------------------------------
+
+test_spawn_launch_shape() {
+  local rec case_dir home proj wt fakebin id out status launch
+  rec=$(make_spawn_case launch)
+  IFS='|' read -r case_dir home proj wt fakebin id <<EOF
+$rec
+EOF
+  out=$(run_muse_spawn "$home" "$proj" "$wt" "$fakebin" "$id" --mode no-mistakes --yolo off)
+  status=$?
+  expect_code 0 "$status" "muse spawn should succeed"
+  assert_contains "$out" "spawned $id harness=muse" "muse spawn did not report success"
+
+  launch=$(cat "$home/launch.log")
+  # --yolo is what makes a crewmate pane viable at all: without it muse holds
+  # every tool call for approval and sandboxes the network to proxy-only.
+  assert_contains "$launch" ' --yolo ' "muse launch omitted --yolo"
+  # The privacy control. Its absence would ship the operator's foreign personal
+  # rules to Meta-hosted inference on every crewmate turn.
+  assert_contains "$launch" 'MUSE_EXPERIMENTAL_FOREIGN_PERSONAL_CONTEXT_KILL=on' \
+    "muse launch omitted the foreign-personal-context kill"
+  # exec-only flag: the interactive TUI exits with "unexpected argument" on it.
+  assert_not_contains "$launch" '--no-foreign-personal-context' \
+    "muse launch passed the exec-only foreign-context flag to the TUI"
+  # The captain accepted muse's self-update risk, so firstmate must not pin it.
+  assert_not_contains "$launch" 'MUSE_NO_AUTO_UPDATE' \
+    "muse launch pinned auto-update, which the captain declined"
+  assert_contains "$launch" 'encode launch-brief' "muse launch did not deliver the brief positionally"
+  assert_grep 'harness=muse' "$home/state/$id.meta" "muse harness was not recorded in meta"
+  pass "muse spawn launches with autonomy, privacy control, and a positional brief"
+}
+
+test_spawn_maps_effort_and_model() {
+  local rec case_dir home proj wt fakebin id launch
+  local -a cases=(
+    "low|--reasoning-effort 'low'"
+    "medium|--reasoning-effort 'medium'"
+    "high|--reasoning-effort 'high'"
+    "xhigh|--reasoning-effort 'xhigh'"
+    "max|--reasoning-effort 'ultra'"
+  )
+  local entry effort expect
+  for entry in "${cases[@]}"; do
+    effort=${entry%%|*}
+    expect=${entry#*|}
+    rec=$(make_spawn_case "effort-$effort")
+    IFS='|' read -r case_dir home proj wt fakebin id <<EOF
+$rec
+EOF
+    run_muse_spawn "$home" "$proj" "$wt" "$fakebin" "$id" \
+      --mode no-mistakes --yolo off --model muse-spark-1.2 --effort "$effort" >/dev/null \
+      || fail "muse spawn with effort $effort failed"
+    launch=$(cat "$home/launch.log")
+    assert_contains "$launch" "$expect" "muse effort $effort did not map to '$expect'"
+    assert_contains "$launch" "--model 'muse-spark-1.2'" "muse spawn dropped the model axis"
+  done
+  # ultra is muse's max-class level and must be reachable ONLY through an
+  # explicit max, never as the fallback when no effort was chosen.
+  rec=$(make_spawn_case effort-default)
+  IFS='|' read -r case_dir home proj wt fakebin id <<EOF
+$rec
+EOF
+  run_muse_spawn "$home" "$proj" "$wt" "$fakebin" "$id" --mode no-mistakes --yolo off >/dev/null \
+    || fail "muse spawn without an effort axis failed"
+  launch=$(cat "$home/launch.log")
+  assert_not_contains "$launch" '--reasoning-effort' "muse spawn invented an effort when none was chosen"
+  pass "muse maps the shared effort vocabulary and reaches ultra only via explicit max"
+}
+
+# An unauthenticated muse pane does not exit: it sits on an OAuth device-code
+# prompt forever, which supervision would read as a wedged worker rather than a
+# missing credential. The spawn must refuse before an endpoint exists.
+test_spawn_refuses_without_credential() {
+  local rec case_dir home proj wt fakebin id out status
+  rec=$(make_spawn_case no-cred)
+  IFS='|' read -r case_dir home proj wt fakebin id <<EOF
+$rec
+EOF
+  mkdir -p "$home/xdgconfig/muse"
+  out=$(FM_TEST_MUSE_KEY='' run_muse_spawn "$home" "$proj" "$wt" "$fakebin" "$id" \
+    --mode no-mistakes --yolo off)
+  status=$?
+  [ "$status" -ne 0 ] || fail "muse spawn succeeded with no credential available"
+  assert_contains "$out" "no usable credential" "muse spawn did not name the missing credential"
+  assert_absent "$home/state/$id.meta" "refused muse spawn still published task metadata"
+  pass "muse spawn refuses when no credential can reach the provider"
+}
+
+test_spawn_accepts_stored_credential() {
+  local rec case_dir home proj wt fakebin id status
+  rec=$(make_spawn_case stored-cred)
+  IFS='|' read -r case_dir home proj wt fakebin id <<EOF
+$rec
+EOF
+  mkdir -p "$home/xdgconfig/muse"
+  printf '{"schema_version":1}\n' > "$home/xdgconfig/muse/auth.json"
+  FM_TEST_MUSE_KEY='' run_muse_spawn "$home" "$proj" "$wt" "$fakebin" "$id" \
+    --mode no-mistakes --yolo off >/dev/null
+  status=$?
+  expect_code 0 "$status" "muse spawn should accept a stored credential"
+  pass "muse spawn accepts a stored credential without META_API_KEY"
+}
+
+# muse has no primary supervision protocol, and its Claude-compatible hook
+# dialect rejects the model-reawakening handlers a firstmate primary needs, so a
+# secondmate on muse could never arm a supervision cycle.
+test_spawn_refuses_secondmate() {
+  local case_dir home fakebin id out status
+  case_dir="$TMP_ROOT/secondmate"
+  home="$case_dir/home"
+  fakebin=$(make_spawn_fakebin "$case_dir/fake")
+  id="muse-secondmate-x1"
+  mkdir -p "$home/data/$id" "$home/projects" "$home/state" "$home/config" "$case_dir/subhome"
+  printf 'charter\n' > "$home/data/$id/brief.md"
+  out=$(FM_ROOT_OVERRIDE='' FM_HOME="$home" \
+    FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
+    FM_PROJECTS_OVERRIDE="$home/projects" FM_CONFIG_OVERRIDE="$home/config" \
+    FM_SPAWN_NO_GUARD=1 TMUX="fake,1,0" META_API_KEY=test-key \
+    PATH="$fakebin:$PATH" \
+    "$SPAWN" "$id" "$case_dir/subhome" muse --secondmate 2>&1)
+  status=$?
+  [ "$status" -ne 0 ] || fail "muse was accepted as a secondmate harness"
+  assert_contains "$out" "crewmate/scout adapter only" "muse secondmate refusal did not explain the boundary"
+  pass "muse is refused as a secondmate harness"
+}
+
+test_spawn_writes_busy_binding_and_teardown_removes_it() {
+  local rec case_dir home proj wt fakebin id binding
+  rec=$(make_spawn_case binding)
+  IFS='|' read -r case_dir home proj wt fakebin id <<EOF
+$rec
+EOF
+  XDG_DATA_HOME="$case_dir/xdgdata" \
+    run_muse_spawn "$home" "$proj" "$wt" "$fakebin" "$id" --mode no-mistakes --yolo off >/dev/null \
+    || fail "muse spawn failed"
+
+  binding="$home/state/$id.muse-session"
+  assert_present "$binding" "muse spawn did not write the session binding"
+  assert_grep "sessions_root=$case_dir/xdgdata/muse/sessions" "$binding" \
+    "muse binding did not record the resolved sessions root"
+  assert_grep "workspace_root=$wt" "$binding" "muse binding did not record the task worktree"
+  # No busy record is armed for muse: the source is pull-only with no writer, so
+  # a seeded busy record could never be settled.
+  assert_absent "$home/state/$id.busy-gen" "muse spawn armed a busy record it can never clear"
+
+  FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" \
+    PATH="$fakebin:$PATH" "$TEARDOWN" "$id" --force >/dev/null 2>&1 \
+    || fail "muse teardown failed"
+  assert_absent "$binding" "muse session binding survived teardown"
+  pass "muse spawn writes a session binding that teardown removes"
+}
+
+# --- interrupt --------------------------------------------------------------
+
+# muse RESTORES the interrupted prompt into the composer after Escape, as real
+# bright text. Left there, the next steer types onto the end of it and submits
+# both as one garbled message, so the interrupt is not complete until the
+# composer is cleared.
+make_send_case() {  # <name> <harness>
+  local name=$1 harness=$2 case_dir home fakebin id
+  case_dir="$TMP_ROOT/send-$name"
+  home="$case_dir/home"
+  fakebin=$(fm_fakebin "$case_dir/fake")
+  id="send-$name"
+  mkdir -p "$home/state"
+  cat > "$fakebin/tmux" <<'SH'
+#!/usr/bin/env bash
+set -u
+case "${1:-}" in
+  display-message) printf 'fakepane\n'; exit 0 ;;
+  has-session) exit 0 ;;
+  list-panes|list-windows) printf 'fm-send:0\n'; exit 0 ;;
+  send-keys)
+    shift
+    printf '%s\n' "$*" >> "$FM_FAKE_KEY_LOG"
+    [ "${FM_FAKE_KEY_FAIL:-}" = "$*" ] && exit 1
+    exit 0
+    ;;
+esac
+exit 0
+SH
+  chmod +x "$fakebin/tmux"
+  fm_write_meta "$home/state/$id.meta" \
+    "window=fm-send:0" "endpoint_task_id=$id" "worktree=$case_dir" \
+    "project=$case_dir" "harness=$harness" "kind=ship" "mode=no-mistakes" "yolo=off"
+  printf '%s\n' "$case_dir|$home|$fakebin|$id"
+}
+
+run_send_key() {  # <home> <fakebin> <id> <key> <keylog>
+  FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$1" FM_STATE_OVERRIDE="$1/state" \
+    FM_FAKE_KEY_LOG="$5" PATH="$2:$PATH" \
+    "$ROOT/bin/fm-send.sh" "$3" --key "$4" 2>&1
+}
+
+test_muse_escape_clears_the_composer() {
+  local rec case_dir home fakebin id keylog out status
+  rec=$(make_send_case muse muse)
+  IFS='|' read -r case_dir home fakebin id <<EOF
+$rec
+EOF
+  keylog="$case_dir/keys.log"
+  : > "$keylog"
+  out=$(run_send_key "$home" "$fakebin" "$id" Escape "$keylog")
+  status=$?
+  expect_code 0 "$status" "muse Escape send should succeed: $out"
+  assert_grep 'Escape' "$keylog" "Escape never reached the muse pane"
+  assert_grep 'C-u' "$keylog" "muse Escape did not clear the restored composer"
+  # Ordering matters: clearing before the interrupt lands would wipe nothing and
+  # leave the restored prompt behind.
+  [ "$(grep -c . "$keylog")" -ge 2 ] || fail "expected both the interrupt and the clear"
+  head -1 "$keylog" | grep -q 'Escape' || fail "the clear was sent before the interrupt"
+  pass "a muse interrupt clears the prompt muse restores into the composer"
+}
+
+test_non_muse_escape_does_not_clear() {
+  local rec case_dir home fakebin id keylog
+  rec=$(make_send_case codex codex)
+  IFS='|' read -r case_dir home fakebin id <<EOF
+$rec
+EOF
+  keylog="$case_dir/keys.log"
+  : > "$keylog"
+  run_send_key "$home" "$fakebin" "$id" Escape "$keylog" >/dev/null
+  assert_grep 'Escape' "$keylog" "Escape never reached the codex pane"
+  assert_no_grep 'C-u' "$keylog" "a non-muse interrupt sent a composer clear it does not need"
+  pass "the composer clear is scoped to muse and does not touch other adapters"
+}
+
+# A silent clear failure would leave the restored prompt in place and corrupt
+# the next steer, so the failure has to be loud.
+test_failed_clear_is_reported() {
+  local rec case_dir home fakebin id keylog out status
+  rec=$(make_send_case clearfail muse)
+  IFS='|' read -r case_dir home fakebin id <<EOF
+$rec
+EOF
+  keylog="$case_dir/keys.log"
+  : > "$keylog"
+  out=$(FM_FAKE_KEY_FAIL='-t fm-send:0 C-u' run_send_key "$home" "$fakebin" "$id" Escape "$keylog")
+  status=$?
+  [ "$status" -ne 0 ] || fail "a failed muse composer clear was reported as success"
+  assert_contains "$out" "could not be cleared" "the failed clear did not explain the pane state"
+  pass "a failed muse composer clear fails loudly instead of leaving stale input"
+}
+
+# --- busy source ------------------------------------------------------------
+
+classify_muse() {  # <state-dir> <id>
+  (
+    # shellcheck source=bin/fm-busy-lib.sh
+    . "$ROOT/bin/fm-busy-lib.sh"
+    fm_busy_classify tmux fake:0 muse "$2" "$1"
+  )
+}
+
+run_state() {  # <log>
+  (
+    # shellcheck source=bin/fm-busy-lib.sh
+    . "$ROOT/bin/fm-busy-lib.sh"
+    fm_busy_muse_run_state "$1"
+  )
+}
+
+test_run_fold_tracks_open_and_settled_turns() {
+  local dir log out
+  dir="$TMP_ROOT/fold"
+  mkdir -p "$dir"
+
+  log=$(write_session_log "$dir/open" 2026 08 05 aaaa "$dir/ws" <<EOF
+$(muse_log_run_started run-1)
+$(muse_log_noise run-1)
+EOF
+)
+  out=$(run_state "$log")
+  [ "$out" = busy ] || fail "an open run folded to '$out', expected busy"
+
+  log=$(write_session_log "$dir/settled" 2026 08 05 bbbb "$dir/ws" <<EOF
+$(muse_log_run_started run-1)
+$(muse_log_run_terminal run-1 completed)
+EOF
+)
+  out=$(run_state "$log")
+  [ "$out" = settled ] || fail "a completed run folded to '$out', expected settled"
+
+  # An Escape interrupt closes its run with terminal=cancelled, so unlike a
+  # Stop-hook adapter this source covers the interrupt path itself.
+  log=$(write_session_log "$dir/cancelled" 2026 08 05 cccc "$dir/ws" <<EOF
+$(muse_log_run_started run-1)
+$(muse_log_run_terminal run-1 cancelled)
+EOF
+)
+  out=$(run_state "$log")
+  [ "$out" = settled ] || fail "an interrupted run folded to '$out', expected settled"
+
+  # A second turn reopens the fold after the first settled.
+  log=$(write_session_log "$dir/second" 2026 08 05 dddd "$dir/ws" <<EOF
+$(muse_log_run_started run-1)
+$(muse_log_run_terminal run-1 completed)
+$(muse_log_run_started run-2)
+EOF
+)
+  out=$(run_state "$log")
+  [ "$out" = busy ] || fail "a reopened second turn folded to '$out', expected busy"
+
+  # A log with no run lifecycle at all (an unauthenticated pane stuck on the
+  # sign-in prompt produces exactly this) is not a settled turn.
+  log=$(write_session_log "$dir/none" 2026 08 05 eeee "$dir/ws" </dev/null)
+  out=$(run_state "$log")
+  [ "$out" = none ] || fail "a run-free log folded to '$out', expected none"
+  pass "the run fold tracks open, settled, interrupted, reopened, and run-free logs"
+}
+
+test_nested_terminal_record_does_not_settle_a_run() {
+  local dir log out
+  dir="$TMP_ROOT/decoy"
+  mkdir -p "$dir"
+  log=$(write_session_log "$dir/root" 2026 08 05 ffff "$dir/ws" <<EOF
+$(muse_log_run_started run-1)
+$(muse_log_cleanup_terminal_decoy run-1)
+$(muse_log_noise run-1)
+EOF
+)
+  out=$(run_state "$log")
+  [ "$out" = busy ] \
+    || fail "a nested cleanup 'terminal' record settled an open run (folded '$out', expected busy)"
+  pass "a nested terminal record never settles an in-flight run"
+}
+
+test_binding_selects_the_matching_main_log() {
+  local dir state id verdict root
+  dir="$TMP_ROOT/bind"
+  state="$dir/state"
+  root="$dir/sessions"
+  id=bindtask
+  mkdir -p "$state"
+
+  # Another task's log lives in the same root and must never be folded here.
+  write_session_log "$root" 2026 08 05 other "$dir/other-ws" >/dev/null <<EOF
+$(muse_log_run_started other-run)
+EOF
+
+  write_session_log "$root" 2026 08 05 mine "$dir/my-ws" >/dev/null <<EOF
+$(muse_log_run_started my-run)
+$(muse_log_run_terminal my-run completed)
+EOF
+
+  printf 'sessions_root=%s\nworkspace_root=%s\n' "$root" "$dir/my-ws" > "$state/$id.muse-session"
+  verdict=$(classify_muse "$state" "$id")
+  # This task's own log is settled; the OTHER task's open run must not leak in
+  # as busy. With the idle half still gated, settled reads unknown.
+  [ "$verdict" = "unknown muse-session-log" ] \
+    || fail "binding leaked another workspace's run state: got '$verdict'"
+
+  printf 'sessions_root=%s\nworkspace_root=%s\n' "$root" "$dir/other-ws" > "$state/$id.muse-session"
+  verdict=$(classify_muse "$state" "$id")
+  [ "$verdict" = "busy muse-session-log" ] \
+    || fail "binding did not fold the workspace it was pointed at: got '$verdict'"
+  pass "the session binding folds only the log matching this task's worktree"
+}
+
+# muse's own native sub-agents write independent run lifecycles one directory
+# deeper, under subagent/<child-session-id>/. Folding a child's log would report
+# the parent busy long after the parent's turn ended.
+test_subagent_logs_are_excluded() {
+  local dir state id root verdict child
+  dir="$TMP_ROOT/subagent"
+  state="$dir/state"
+  root="$dir/sessions"
+  id=subtask
+  mkdir -p "$state"
+
+  write_session_log "$root" 2026 08 05 parent "$dir/ws" >/dev/null <<EOF
+$(muse_log_run_started parent-run)
+$(muse_log_run_terminal parent-run completed)
+EOF
+
+  child="$root/2026/08/05/parent/subagent/child-session"
+  mkdir -p "$child"
+  {
+    muse_log_metadata "$dir/ws"
+    muse_log_run_started child-run
+  } > "$child/session.jsonl"
+  # Make the child log strictly newer, so a depth-blind resolver that also
+  # ranks by mtime would pick it.
+  touch "$child/session.jsonl"
+
+  # Prove the child fixture really is an open run, so the exclusion below is
+  # doing work rather than passing on an inert file.
+  [ "$(run_state "$child/session.jsonl")" = busy ] \
+    || fail "the sub-agent fixture is not an open run, so the exclusion case would be vacuous"
+
+  printf 'sessions_root=%s\nworkspace_root=%s\n' "$root" "$dir/ws" > "$state/$id.muse-session"
+  verdict=$(classify_muse "$state" "$id")
+  [ "$verdict" != "busy muse-session-log" ] \
+    || fail "a sub-agent's open run was folded as the parent task's busy state"
+  # And prove the parent log was genuinely resolved, so the non-busy verdict is
+  # the exclusion working rather than the binding silently failing.
+  [ "$(run_state "$root/2026/08/05/parent/session.jsonl")" = settled ] \
+    || fail "the parent fixture did not fold as settled"
+  pass "sub-agent session logs are excluded from the parent's busy fold"
+}
+
+# Every path with no positive proof of an in-flight turn must be unknown, never
+# idle: unknown is not promoted to either boolean pole, while a wrong idle would
+# report a working crewmate as finished.
+test_missing_and_unreadable_bindings_are_unknown_never_idle() {
+  local dir state id verdict root
+  dir="$TMP_ROOT/unknowns"
+  state="$dir/state"
+  root="$dir/sessions"
+  id=unk
+  mkdir -p "$state"
+
+  verdict=$(classify_muse "$state" "$id")
+  [ "$verdict" = "unknown muse-session-log" ] || fail "absent binding classified '$verdict'"
+
+  printf 'sessions_root=%s\nworkspace_root=%s\n' "$root/missing" "$dir/ws" > "$state/$id.muse-session"
+  verdict=$(classify_muse "$state" "$id")
+  [ "$verdict" = "unknown muse-session-log" ] || fail "missing sessions root classified '$verdict'"
+
+  write_session_log "$root" 2026 08 05 nomatch "$dir/somewhere-else" >/dev/null <<EOF
+$(muse_log_run_started r1)
+EOF
+  printf 'sessions_root=%s\nworkspace_root=%s\n' "$root" "$dir/ws" > "$state/$id.muse-session"
+  verdict=$(classify_muse "$state" "$id")
+  [ "$verdict" = "unknown muse-session-log" ] || fail "unmatched workspace classified '$verdict'"
+
+  printf 'garbage\n' > "$state/$id.muse-session"
+  verdict=$(classify_muse "$state" "$id")
+  [ "$verdict" = "unknown muse-session-log" ] || fail "malformed binding classified '$verdict'"
+  pass "every unproven muse binding classifies unknown rather than idle"
+}
+
+# The idle half stays gated until a credentialed multi-step run proves one turn
+# stays inside one run. Until then a settled log must not read idle.
+test_settled_log_stays_unknown_while_the_idle_gate_is_closed() {
+  local dir state id root verdict gate
+  dir="$TMP_ROOT/idlegate"
+  state="$dir/state"
+  root="$dir/sessions"
+  id=gatetask
+  mkdir -p "$state"
+  write_session_log "$root" 2026 08 05 settled "$dir/ws" >/dev/null <<EOF
+$(muse_log_run_started r1)
+$(muse_log_run_terminal r1 completed)
+EOF
+  printf 'sessions_root=%s\nworkspace_root=%s\n' "$root" "$dir/ws" > "$state/$id.muse-session"
+
+  verdict=$(classify_muse "$state" "$id")
+  [ "$verdict" = "unknown muse-session-log" ] \
+    || fail "a settled log classified '$verdict' while the idle gate is closed"
+
+  gate=$(
+    # shellcheck source=bin/fm-busy-lib.sh
+    . "$ROOT/bin/fm-busy-lib.sh"
+    fm_busy_muse_idle_verified && printf open || printf closed
+  )
+  [ "$gate" = closed ] \
+    || fail "the muse idle gate is open; docs/verification/muse.md must carry the credentialed evidence"
+
+  # Opening the gate must flip exactly this verdict and nothing else, so the
+  # deferred smoke has a one-line landing point rather than a redesign.
+  verdict=$(
+    # shellcheck source=bin/fm-busy-lib.sh
+    . "$ROOT/bin/fm-busy-lib.sh"
+    FM_BUSY_MUSE_IDLE_VERIFIED_VERSIONS='0.1.0-R708.1'
+    fm_busy_classify tmux fake:0 muse "$id" "$state"
+  )
+  [ "$verdict" = "idle muse-session-log" ] \
+    || fail "opening the idle gate did not make a settled log idle: got '$verdict'"
+  pass "a settled log stays unknown until the idle gate opens, then reads idle"
+}
+
+# muse records nothing, so it must trust no record source. A trusted source with
+# no writer would seed a busy record that nothing could ever settle.
+test_muse_trusts_no_record_sources() {
+  local out
+  out=$(
+    # shellcheck source=bin/fm-busy-lib.sh
+    . "$ROOT/bin/fm-busy-lib.sh"
+    fm_busy_sources_for_harness muse
+  )
+  [ -z "$out" ] || fail "muse trusts record sources it has no writer for: '$out'"
+  pass "muse trusts no busy record source"
+}
+
+test_detects_versioned_process_ancestor
+test_detection_is_anchored
+test_spawn_launch_shape
+test_spawn_maps_effort_and_model
+test_spawn_refuses_without_credential
+test_spawn_accepts_stored_credential
+test_spawn_refuses_secondmate
+test_spawn_writes_busy_binding_and_teardown_removes_it
+test_muse_escape_clears_the_composer
+test_non_muse_escape_does_not_clear
+test_failed_clear_is_reported
+test_run_fold_tracks_open_and_settled_turns
+test_nested_terminal_record_does_not_settle_a_run
+test_binding_selects_the_matching_main_log
+test_subagent_logs_are_excluded
+test_missing_and_unreadable_bindings_are_unknown_never_idle
+test_settled_log_stays_unknown_while_the_idle_gate_is_closed
+test_muse_trusts_no_record_sources

--- a/tests/fm-muse-harness.test.sh
+++ b/tests/fm-muse-harness.test.sh
@@ -300,6 +300,7 @@ test_spawn_writes_busy_binding_and_teardown_removes_it() {
 $rec
 EOF
   prior=$(write_session_log "$case_dir/xdgdata/muse/sessions" 2026 08 05 prior "$wt" </dev/null)
+  prior=$(printf '%s\n' "$prior" | sed 's://*:/:g')
   XDG_DATA_HOME="$case_dir/xdgdata" \
     run_muse_spawn "$home" "$proj" "$wt" "$fakebin" "$id" --mode no-mistakes --yolo off >/dev/null \
     || fail "muse spawn failed"
@@ -309,7 +310,8 @@ EOF
   assert_grep "sessions_root=$case_dir/xdgdata/muse/sessions" "$binding" \
     "muse binding did not record the resolved sessions root"
   assert_grep "workspace_root=$wt" "$binding" "muse binding did not record the task worktree"
-  assert_grep "prior_log=$prior" "$binding" "muse binding did not exclude the pre-existing session"
+  assert_grep "prior_log=$prior" "$binding" \
+    "muse binding did not exclude the pre-existing session: $(tr '\n' ';' < "$binding")"
   # No busy record is armed for muse: the source is pull-only with no writer, so
   # a seeded busy record could never be settled.
   assert_absent "$home/state/$id.busy-gen" "muse spawn armed a busy record it can never clear"
@@ -529,6 +531,30 @@ EOF
   pass "the session binding folds only the log matching this task's worktree"
 }
 
+test_workspace_binding_treats_glob_characters_literally() {
+  local dir state id root verdict
+  dir="$TMP_ROOT/workspace-literal"
+  state="$dir/state"
+  root="$dir/sessions"
+  id=literal-task
+  mkdir -p "$state"
+
+  write_session_log "$root" 2026 08 05 own "$dir/ws[1]" >/dev/null <<EOF
+$(muse_log_run_started own-run)
+$(muse_log_run_terminal own-run completed)
+EOF
+  write_session_log "$root" 2026 08 05 decoy "$dir/ws1" >/dev/null <<EOF
+$(muse_log_run_started decoy-run)
+EOF
+
+  printf 'sessions_root=%s\nworkspace_root=%s\n' \
+    "$root" "$dir/ws[1]" > "$state/$id.muse-session"
+  verdict=$(classify_muse "$state" "$id")
+  [ "$verdict" = "unknown muse-session-log" ] \
+    || fail "a bracketed workspace imported another session's busy state: got '$verdict'"
+  pass "workspace bindings compare decoded paths literally"
+}
+
 test_binding_excludes_preexisting_log_when_mtimes_tie() {
   local dir state id root old current verdict
   dir="$TMP_ROOT/mtime-tie"
@@ -546,6 +572,8 @@ EOF
 $(muse_log_run_started current-run)
 EOF
 )
+  old=$(printf '%s\n' "$old" | sed 's://*:/:g')
+  current=$(printf '%s\n' "$current" | sed 's://*:/:g')
   touch -t 202608050101.01 "$old" "$current"
   { [ ! "$old" -nt "$current" ] && [ ! "$current" -nt "$old" ]; } \
     || fail "the session-selection regression does not reproduce equal mtimes"
@@ -698,6 +726,7 @@ test_failed_clear_is_reported
 test_run_fold_tracks_open_and_settled_turns
 test_nested_terminal_record_does_not_settle_a_run
 test_binding_selects_the_matching_main_log
+test_workspace_binding_treats_glob_characters_literally
 test_binding_excludes_preexisting_log_when_mtimes_tie
 test_subagent_logs_are_excluded
 test_missing_and_unreadable_bindings_are_unknown_never_idle

--- a/tests/fm-muse-harness.test.sh
+++ b/tests/fm-muse-harness.test.sh
@@ -117,7 +117,8 @@ make_spawn_case() {
   wt="$case_dir/wt"
   fakebin=$(make_spawn_fakebin "$case_dir/fake")
   id="muse-$name-x1"
-  mkdir -p "$home/data/$id" "$home/projects" "$home/state" "$home/config"
+  mkdir -p "$home/data/$id" "$home/projects" "$home/state" "$home/config" \
+    "$home/xdgconfig" "$home/xdgdata"
   printf 'brief\n' > "$home/data/$id/brief.md"
   fm_git_worktree "$proj" "$wt" "fm/$id"
   touch "$home/state/.last-watcher-beat"
@@ -139,7 +140,7 @@ run_muse_spawn() {  # <home> <proj> <wt> <fakebin> <id> [extra args...]
     FM_FAKE_HARNESS_RESULT="${FM_FAKE_HARNESS_RESULT:-}" \
     FM_FAKE_WORKER_META_KEY="${FM_TEST_MUSE_WORKER_KEY-present}" \
     META_API_KEY="${FM_TEST_MUSE_KEY-test-key}" \
-    XDG_CONFIG_HOME="$home/xdgconfig" \
+    XDG_CONFIG_HOME="${FM_TEST_MUSE_CONFIG_HOME-$home/xdgconfig}" \
     XDG_DATA_HOME="${FM_TEST_MUSE_DATA_HOME-$home/xdgdata}" \
     PATH="$fakebin:$PATH" \
     "$SPAWN" "$id" "$proj" muse "$@" 2>&1
@@ -332,6 +333,32 @@ EOF
   status=$?
   expect_code 0 "$status" "muse spawn should accept a stored credential"
   pass "muse spawn accepts a stored credential without META_API_KEY"
+}
+
+test_spawn_resolves_relative_xdg_roots() {
+  local rec case_dir home proj wt fakebin id caller resolved_caller launch binding out status
+  rec=$(make_spawn_case relative-xdg)
+  IFS='|' read -r case_dir home proj wt fakebin id <<EOF
+$rec
+EOF
+  caller="$case_dir/caller"
+  mkdir -p "$caller/cfg/muse" "$caller/data"
+  resolved_caller=$(cd "$caller" && pwd -P)
+  printf '{"schema_version":1}\n' > "$caller/cfg/muse/auth.json"
+  out=$(cd "$caller" && FM_TEST_MUSE_KEY='' FM_TEST_MUSE_WORKER_KEY='' \
+    FM_TEST_MUSE_CONFIG_HOME=cfg FM_TEST_MUSE_DATA_HOME=data \
+    run_muse_spawn "$home" "$proj" "$wt" "$fakebin" "$id" --mode no-mistakes --yolo off)
+  status=$?
+  expect_code 0 "$status" "muse spawn with relative XDG roots should succeed: $out"
+  launch=$(cat "$home/launch.log")
+  assert_contains "$launch" "XDG_CONFIG_HOME='$resolved_caller/cfg'" \
+    "muse launch did not forward the resolved config root"
+  assert_contains "$launch" "XDG_DATA_HOME='$resolved_caller/data'" \
+    "muse launch did not forward the resolved data root"
+  binding="$home/state/$id.muse-session"
+  assert_grep "sessions_root=$resolved_caller/data/muse/sessions" "$binding" \
+    "muse busy binding did not use the worker's resolved data root"
+  pass "muse resolves relative XDG roots before preflight and launch"
 }
 
 # muse has no primary supervision protocol, and its Claude-compatible hook
@@ -711,6 +738,44 @@ EOF
   pass "the Muse session cache avoids rescans and refreshes safely across incarnations"
 }
 
+test_cached_session_revalidates_after_namespace_change() {
+  local dir state id root second_log verdict today year month day
+  dir="$TMP_ROOT/cache-ambiguity"
+  state="$dir/state"
+  root="$dir/sessions"
+  id=cacheambiguity
+  mkdir -p "$state"
+  today=$(date '+%Y/%m/%d')
+  year=${today%%/*}
+  today=${today#*/}
+  month=${today%%/*}
+  day=${today#*/}
+
+  write_session_log "$root" "$year" "$month" "$day" first "$dir/ws" >/dev/null <<EOF
+$(muse_log_run_started first-run)
+EOF
+  printf 'sessions_root=%s\nworkspace_root=%s\nbinding_id=cache-ambiguity\n' \
+    "$root" "$dir/ws" > "$state/$id.muse-session"
+  verdict=$(classify_muse "$state" "$id")
+  [ "$verdict" = "busy muse-session-log" ] \
+    || fail "the first session did not resolve before the ambiguity check: got '$verdict'"
+
+  second_log="$root/$year/$month/$day/second/session.jsonl"
+  mkdir -p "${second_log%/*}"
+  : > "$second_log"
+  verdict=$(classify_muse "$state" "$id")
+  [ "$verdict" = "busy muse-session-log" ] \
+    || fail "an uninitialized second session changed the resolved verdict to '$verdict'"
+
+  write_session_log "$root" "$year" "$month" "$day" second "$dir/ws" >/dev/null <<EOF
+$(muse_log_run_started second-run)
+EOF
+  verdict=$(classify_muse "$state" "$id")
+  [ "$verdict" = "unknown muse-session-log" ] \
+    || fail "a second concurrent main session left the cached verdict at '$verdict'"
+  pass "a changed Muse namespace revalidates cached session uniqueness"
+}
+
 # muse's own native sub-agents write independent run lifecycles one directory
 # deeper, under subagent/<child-session-id>/. Folding a child's log would report
 # the parent busy long after the parent's turn ended.
@@ -851,6 +916,7 @@ test_spawn_maps_effort_and_model
 test_spawn_refuses_without_credential
 test_spawn_refuses_caller_only_environment_credential
 test_spawn_accepts_stored_credential
+test_spawn_resolves_relative_xdg_roots
 test_spawn_refuses_secondmate
 test_spawn_writes_busy_binding_and_teardown_removes_it
 test_muse_escape_aliases_clear_the_composer
@@ -862,6 +928,7 @@ test_binding_selects_the_matching_main_log
 test_workspace_binding_treats_glob_characters_literally
 test_binding_excludes_preexisting_log_when_mtimes_tie
 test_session_log_cache_reuses_and_refreshes_binding
+test_cached_session_revalidates_after_namespace_change
 test_subagent_logs_are_excluded
 test_missing_and_unreadable_bindings_are_unknown_never_idle
 test_settled_log_stays_unknown_while_the_idle_gate_is_closed

--- a/tests/fm-muse-signals-live-e2e.test.sh
+++ b/tests/fm-muse-signals-live-e2e.test.sh
@@ -1,11 +1,6 @@
 #!/usr/bin/env bash
 set -u
 
-if [ "${FM_MUSE_SIGNALS_LIVE:-0}" != 1 ]; then
-  echo "skip: set FM_MUSE_SIGNALS_LIVE=1 to run the real Muse signal drift guard"
-  exit 0
-fi
-
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 MUSE_BIN=$(command -v muse 2>/dev/null || true)
 REAL_TMUX=$(command -v tmux 2>/dev/null || true)
@@ -28,6 +23,82 @@ fail() {
 pass() {
   printf 'ok - %s\n' "$1"
 }
+
+muse_prompt_glyph_is_bright() {  # <capture-path|--self-test>
+  node - "$1" <<'NODE'
+const fs = require("fs");
+
+function applySgr(foreground, raw) {
+  const params = raw === "" ? [0] : raw.split(";").map((value) => Number(value));
+  for (let index = 0; index < params.length; index += 1) {
+    const code = params[index];
+    if (code === 0 || code === 39) {
+      foreground = null;
+    } else if ((code >= 30 && code <= 37) || (code >= 90 && code <= 97)) {
+      foreground = { kind: "indexed" };
+    } else if (code === 38 && params[index + 1] === 2 && params.slice(index + 2, index + 5).every(Number.isFinite)) {
+      foreground = { kind: "rgb", values: params.slice(index + 2, index + 5) };
+      index += 4;
+    } else if (code === 38 && params[index + 1] === 5 && Number.isFinite(params[index + 2])) {
+      foreground = { kind: "indexed" };
+      index += 2;
+    }
+  }
+  return foreground;
+}
+
+function lastGlyphForeground(pane) {
+  const tokens = /\x1b\[([0-9;]*)m|⟩/gu;
+  let foreground = null;
+  let glyphForeground;
+  for (const match of pane.matchAll(tokens)) {
+    if (match[0] === "⟩") {
+      glyphForeground = foreground;
+    } else {
+      foreground = applySgr(foreground, match[1]);
+    }
+  }
+  return glyphForeground;
+}
+
+function isBrightTruecolor(pane) {
+  const foreground = lastGlyphForeground(pane);
+  if (!foreground || foreground.kind !== "rgb") return false;
+  const [r, g, b] = foreground.values;
+  return (r * 299 + g * 587 + b * 114) / 1000 >= 128;
+}
+
+const positive = "\x1b[38;2;90;160;255m\x1b[48;2;38;56;84m⟩";
+const brightThenDark = "\x1b[38;2;204;211;219mearlier bright\x1b[38;2;30;30;30m⟩";
+if (!isBrightTruecolor(positive) || isBrightTruecolor(brightThenDark)) process.exit(2);
+if (process.argv[2] === "--self-test") process.exit(0);
+
+const pane = fs.readFileSync(process.argv[2], "utf8");
+const foreground = lastGlyphForeground(pane);
+if (!foreground || foreground.kind !== "rgb") {
+  console.error("the final Muse prompt glyph has no effective truecolor foreground");
+  process.exit(1);
+}
+const [r, g, b] = foreground.values;
+const luminance = (r * 299 + g * 587 + b * 114) / 1000;
+if (luminance < 128) {
+  console.error(`the final Muse prompt glyph foreground is dark: ${r};${g};${b}, luminance ${luminance}`);
+  process.exit(1);
+}
+NODE
+}
+
+if [ "${1:-}" = --ansi-self-test ]; then
+  command -v node >/dev/null 2>&1 || fail "node is required to test Muse prompt glyph ANSI state"
+  muse_prompt_glyph_is_bright --self-test || fail "Muse glyph color parser accepted a bright-then-dark negative control"
+  pass "Muse glyph color parser follows effective foreground state"
+  exit 0
+fi
+
+if [ "${FM_MUSE_SIGNALS_LIVE:-0}" != 1 ]; then
+  echo "skip: set FM_MUSE_SIGNALS_LIVE=1 to run the real Muse signal drift guard"
+  exit 0
+fi
 
 [ -x "$MUSE_BIN" ] || fail "FM_MUSE_SIGNALS_LIVE=1 but no real muse executable is installed on PATH"
 [ -x "$REAL_TMUX" ] || fail "FM_MUSE_SIGNALS_LIVE=1 but tmux is not installed"
@@ -105,14 +176,8 @@ done
 CAPTURE="$LAB/muse-pane.ansi"
 tmux capture-pane -e -p -t "$TARGET" -S 0 -E - > "$CAPTURE" \
   || fail "could not capture Muse's styled pane"
-node - "$CAPTURE" <<'NODE' || fail "Muse's real prompt glyph is missing a bright truecolor foreground"
-const fs = require("fs");
-const pane = fs.readFileSync(process.argv[2], "utf8");
-const match = pane.match(/\x1b\[38;2;(\d+);(\d+);(\d+)m[^\n]*?⟩/);
-if (!match) process.exit(1);
-const [r, g, b] = match.slice(1).map(Number);
-if ((r * 299 + g * 587 + b * 114) / 1000 < 128) process.exit(1);
-NODE
+muse_prompt_glyph_is_bright "$CAPTURE" \
+  || fail "Muse's real prompt glyph is missing a bright effective truecolor foreground"
 pass "Muse's real bright prompt glyph classifies as an empty composer"
 
 cleanup

--- a/tests/fm-muse-signals-live-e2e.test.sh
+++ b/tests/fm-muse-signals-live-e2e.test.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+set -u
+
+if [ "${FM_MUSE_SIGNALS_LIVE:-0}" != 1 ]; then
+  echo "skip: set FM_MUSE_SIGNALS_LIVE=1 to run the real Muse signal drift guard"
+  exit 0
+fi
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+MUSE_BIN=$(command -v muse 2>/dev/null || true)
+REAL_TMUX=$(command -v tmux 2>/dev/null || true)
+LAB=
+SOCKET="fm-muse-signals-$$"
+SESSION=muse-signals
+TARGET="$SESSION:muse"
+
+cleanup() {
+  [ -n "$REAL_TMUX" ] && "$REAL_TMUX" -L "$SOCKET" kill-server >/dev/null 2>&1 || true
+  [ -z "$LAB" ] || rm -rf -- "$LAB"
+}
+
+fail() {
+  printf 'not ok - %s\n' "$1" >&2
+  cleanup
+  exit 1
+}
+
+pass() {
+  printf 'ok - %s\n' "$1"
+}
+
+[ -x "$MUSE_BIN" ] || fail "FM_MUSE_SIGNALS_LIVE=1 but no real muse executable is installed on PATH"
+[ -x "$REAL_TMUX" ] || fail "FM_MUSE_SIGNALS_LIVE=1 but tmux is not installed"
+command -v node >/dev/null 2>&1 || fail "node is required to inspect Muse's serialized session protocol"
+
+LAB=$(mktemp -d "${TMPDIR:-/tmp}/fm-muse-signals.XXXXXX") || fail "could not create the isolated Muse lab"
+trap cleanup EXIT
+mkdir -p "$LAB/bin" "$LAB/config" "$LAB/data" "$LAB/workspace"
+git -C "$LAB/workspace" init -q || fail "could not initialize the isolated Muse workspace"
+WORKSPACE=$(cd "$LAB/workspace" && pwd -P) || fail "could not resolve the isolated Muse workspace"
+
+cat > "$LAB/bin/tmux" <<SH
+#!/usr/bin/env bash
+exec "$REAL_TMUX" -L "$SOCKET" "\$@"
+SH
+chmod +x "$LAB/bin/tmux"
+PATH="$LAB/bin:$PATH"
+export PATH
+
+# shellcheck source=bin/fm-busy-lib.sh
+. "$ROOT/bin/fm-busy-lib.sh"
+# shellcheck source=bin/fm-tmux-lib.sh
+. "$ROOT/bin/fm-tmux-lib.sh"
+
+"$REAL_TMUX" -L "$SOCKET" new-session -d -s "$SESSION" -n control -c "$WORKSPACE" \
+  || fail "could not start the isolated tmux server"
+"$REAL_TMUX" -L "$SOCKET" new-window -d -t "$SESSION:" -n muse -c "$WORKSPACE" -- \
+  env XDG_CONFIG_HOME="$LAB/config" XDG_DATA_HOME="$LAB/data" \
+  MUSE_EXPERIMENTAL_FOREIGN_PERSONAL_CONTEXT_KILL=on \
+  "$MUSE_BIN" --provider echo --yolo "firstmate Muse signal drift guard" \
+  || fail "could not launch Muse with the echo provider"
+
+SESSION_LOG=
+for _ in $(seq 1 150); do
+  SESSION_LOG=$(fm_busy_muse_matching_logs "$LAB/data/muse/sessions" "$WORKSPACE" 2>/dev/null | head -1)
+  [ -z "$SESSION_LOG" ] || break
+  sleep 0.2
+done
+[ -n "$SESSION_LOG" ] || fail "real Muse produced no workspace-bound session.jsonl"
+
+RUN_STATE=
+for _ in $(seq 1 150); do
+  RUN_STATE=$(fm_busy_muse_run_state "$SESSION_LOG" 2>/dev/null || true)
+  [ "$RUN_STATE" = busy ] && break
+  sleep 0.2
+done
+[ "$RUN_STATE" = busy ] || fail "fm_busy_muse_run_state never observed the real echo turn in flight"
+pass "Muse's real session protocol classifies busy in flight"
+
+for _ in $(seq 1 300); do
+  RUN_STATE=$(fm_busy_muse_run_state "$SESSION_LOG" 2>/dev/null || true)
+  [ "$RUN_STATE" = settled ] && break
+  sleep 0.2
+done
+[ "$RUN_STATE" = settled ] || fail "fm_busy_muse_run_state did not settle the real echo turn"
+
+node - "$SESSION_LOG" <<'NODE' || fail "real Muse did not emit exactly one matched started and terminal run pair"
+const fs = require("fs");
+const records = fs.readFileSync(process.argv[2], "utf8").trim().split("\n").filter(Boolean).map(JSON.parse);
+const lifecycle = records.filter((record) => record?.payload_type === "runtime.session" && record?.payload?.kind === "run" && ["started", "terminal"].includes(record?.payload?.event?.kind));
+const started = lifecycle.filter((record) => record.payload.event.kind === "started");
+const terminal = lifecycle.filter((record) => record.payload.event.kind === "terminal");
+if (started.length !== 1 || terminal.length !== 1 || started[0].payload.run_id !== terminal[0].payload.run_id) process.exit(1);
+NODE
+pass "Muse's real session protocol emits one matched run bracket"
+
+COMPOSER_STATE=
+for _ in $(seq 1 100); do
+  COMPOSER_STATE=$(fm_tmux_composer_state "$TARGET")
+  [ "$COMPOSER_STATE" = empty ] && break
+  sleep 0.2
+done
+[ "$COMPOSER_STATE" = empty ] || fail "the shared classifier read Muse's real idle composer as '$COMPOSER_STATE'"
+
+CAPTURE="$LAB/muse-pane.ansi"
+tmux capture-pane -e -p -t "$TARGET" -S 0 -E - > "$CAPTURE" \
+  || fail "could not capture Muse's styled pane"
+node - "$CAPTURE" <<'NODE' || fail "Muse's real prompt glyph is missing a bright truecolor foreground"
+const fs = require("fs");
+const pane = fs.readFileSync(process.argv[2], "utf8");
+const match = pane.match(/\x1b\[38;2;(\d+);(\d+);(\d+)m[^\n]*?⟩/);
+if (!match) process.exit(1);
+const [r, g, b] = match.slice(1).map(Number);
+if ((r * 299 + g * 587 + b * 114) / 1000 < 128) process.exit(1);
+NODE
+pass "Muse's real bright prompt glyph classifies as an empty composer"
+
+cleanup
+trap - EXIT

--- a/tests/fm-muse-signals-live-e2e.test.sh
+++ b/tests/fm-muse-signals-live-e2e.test.sh
@@ -29,19 +29,38 @@ muse_prompt_glyph_is_bright() {  # <capture-path|--self-test>
 const fs = require("fs");
 
 function applySgr(foreground, raw) {
-  const params = raw === "" ? [0] : raw.split(";").map((value) => Number(value));
+  const fields = raw === "" ? ["0"] : raw.split(";");
+  const params = fields.map((value) => value === "" ? 0 : Number(value));
   for (let index = 0; index < params.length; index += 1) {
     const code = params[index];
     if (code === 0 || code === 39) {
       foreground = null;
     } else if ((code >= 30 && code <= 37) || (code >= 90 && code <= 97)) {
       foreground = { kind: "indexed" };
-    } else if (code === 38 && params[index + 1] === 2 && params.slice(index + 2, index + 5).every(Number.isFinite)) {
-      foreground = { kind: "rgb", values: params.slice(index + 2, index + 5) };
-      index += 4;
-    } else if (code === 38 && params[index + 1] === 5 && Number.isFinite(params[index + 2])) {
-      foreground = { kind: "indexed" };
-      index += 2;
+    } else if (code === 48 || code === 58) {
+      const mode = params[index + 1];
+      const channels = params.slice(index + 2, index + 5);
+      const channelFields = fields.slice(index + 2, index + 5);
+      if (mode === 2 && channels.length === 3 && channelFields.every((value) => /^[0-9]+$/.test(value)) && channels.every((value) => Number.isInteger(value) && value >= 0 && value <= 255)) {
+        index += 4;
+      } else if (mode === 5 && /^[0-9]+$/.test(fields[index + 2] ?? "") && Number.isInteger(params[index + 2]) && params[index + 2] >= 0 && params[index + 2] <= 255) {
+        index += 2;
+      } else {
+        break;
+      }
+    } else if (code === 38) {
+      const mode = params[index + 1];
+      const channels = params.slice(index + 2, index + 5);
+      const channelFields = fields.slice(index + 2, index + 5);
+      if (mode === 2 && channels.length === 3 && channelFields.every((value) => /^[0-9]+$/.test(value)) && channels.every((value) => Number.isInteger(value) && value >= 0 && value <= 255)) {
+        foreground = { kind: "rgb", values: channels };
+        index += 4;
+      } else if (mode === 5 && /^[0-9]+$/.test(fields[index + 2] ?? "") && Number.isInteger(params[index + 2]) && params[index + 2] >= 0 && params[index + 2] <= 255) {
+        foreground = { kind: "indexed" };
+        index += 2;
+      } else {
+        foreground = { kind: "invalid" };
+      }
     }
   }
   return foreground;
@@ -70,7 +89,9 @@ function isBrightTruecolor(pane) {
 
 const positive = "\x1b[38;2;90;160;255m\x1b[48;2;38;56;84m⟩";
 const brightThenDark = "\x1b[38;2;204;211;219mearlier bright\x1b[38;2;30;30;30m⟩";
-if (!isBrightTruecolor(positive) || isBrightTruecolor(brightThenDark)) process.exit(2);
+const brightThenMalformed = "\x1b[38;2;204;211;219mearlier bright\x1b[38;2m⟩";
+const brightThenOutOfRange = "\x1b[38;2;204;211;219mearlier bright\x1b[38;2;256;160;255m⟩";
+if (!isBrightTruecolor(positive) || isBrightTruecolor(brightThenDark) || isBrightTruecolor(brightThenMalformed) || isBrightTruecolor(brightThenOutOfRange)) process.exit(2);
 if (process.argv[2] === "--self-test") process.exit(0);
 
 const pane = fs.readFileSync(process.argv[2], "utf8");
@@ -90,7 +111,7 @@ NODE
 
 if [ "${1:-}" = --ansi-self-test ]; then
   command -v node >/dev/null 2>&1 || fail "node is required to test Muse prompt glyph ANSI state"
-  muse_prompt_glyph_is_bright --self-test || fail "Muse glyph color parser accepted a bright-then-dark negative control"
+  muse_prompt_glyph_is_bright --self-test || fail "Muse glyph color parser accepted a dark or malformed negative control"
   pass "Muse glyph color parser follows effective foreground state"
   exit 0
 fi

--- a/tests/fm-tmux-agent-liveness.test.sh
+++ b/tests/fm-tmux-agent-liveness.test.sh
@@ -54,6 +54,15 @@ export PATH
 ln -s "$SLEEP_BIN" "$LAB/bin/claude-link"
 ln -s "$SLEEP_BIN" "$LAB/bin/pi"
 ln -s "$SLEEP_BIN" "$LAB/bin/notaharness"
+# muse's installed binary is muse-bin-<version>: the launcher execs it, so the
+# version is the LIVE process name and it changes on every auto-update. Unlike
+# Claude Code's version-named binary there is no `muse` path component to fall
+# back on (~/.local/bin/muse-bin-<version>), so the executable name is the ONLY
+# signal, and `muse` alone is a common English fragment that must not widen into
+# a substring match. The last two names are the decoys that would be misread.
+ln -s "$SLEEP_BIN" "$LAB/bin/muse-bin-0.1.0-R708.1"
+ln -s "$SLEEP_BIN" "$LAB/bin/musescore"
+ln -s "$SLEEP_BIN" "$LAB/bin/amuse"
 
 # A launcher whose own process identity is a bare shell, running the harness as
 # a child in the same foreground process group - the shape the real Pi Launcher
@@ -143,6 +152,23 @@ new_window agent "$LAB/bin/claude-link" 900
 wait_for_state "$SESSION:agent" alive \
   || fail "a running harness-named foreground process must classify alive"
 pass "tmux liveness: a harness-named foreground process classifies alive"
+
+# --- muse's version-suffixed binary name ------------------------------------
+# A muse crewmate pane misclassified here reads as a dead endpoint, so a healthy
+# worker would be torn down or relaunched. The decoys below are what keep the
+# fix from being a substring match that claims unrelated programs.
+
+new_window muse "$LAB/bin/muse-bin-0.1.0-R708.1" 900
+wait_for_state "$SESSION:muse" alive \
+  || fail "muse's version-suffixed binary name must classify alive"
+pass "tmux liveness: muse's version-suffixed muse-bin-<version> classifies alive"
+
+for decoy in musescore amuse; do
+  new_window "decoy-$decoy" "$LAB/bin/$decoy" 900
+  wait_for_state "$SESSION:decoy-$decoy" ambiguous \
+    || fail "'$decoy' merely contains 'muse' and must not classify as a live agent pane"
+done
+pass "tmux liveness: unrelated muse-containing command names stay ambiguous"
 
 # --- a version name blinds one source ---------------------------------------
 # Giving a genuine harness-named executable the version-string argv[0] that

--- a/tests/fm-tmux-agent-liveness.test.sh
+++ b/tests/fm-tmux-agent-liveness.test.sh
@@ -63,6 +63,8 @@ ln -s "$SLEEP_BIN" "$LAB/bin/notaharness"
 ln -s "$SLEEP_BIN" "$LAB/bin/muse-bin-0.1.0-R708.1"
 ln -s "$SLEEP_BIN" "$LAB/bin/musescore"
 ln -s "$SLEEP_BIN" "$LAB/bin/amuse"
+ln -s "$SLEEP_BIN" "$LAB/bin/muse-binary"
+ln -s "$SLEEP_BIN" "$LAB/bin/muse-bind"
 
 # A launcher whose own process identity is a bare shell, running the harness as
 # a child in the same foreground process group - the shape the real Pi Launcher
@@ -163,7 +165,7 @@ wait_for_state "$SESSION:muse" alive \
   || fail "muse's version-suffixed binary name must classify alive"
 pass "tmux liveness: muse's version-suffixed muse-bin-<version> classifies alive"
 
-for decoy in musescore amuse; do
+for decoy in musescore amuse muse-binary muse-bind; do
   new_window "decoy-$decoy" "$LAB/bin/$decoy" 900
   wait_for_state "$SESSION:decoy-$decoy" ambiguous \
     || fail "'$decoy' merely contains 'muse' and must not classify as a live agent pane"


### PR DESCRIPTION
## Intent

Ship a verified Muse Code crewmate harness adapter for Firstmate. Muse Code is CREWMATE/SCOUT ONLY, deliberately not a firstmate primary and not a secondmate.

Captain decisions that shaped this work:
- ADOPT NOW: implement as far as possible WITHOUT a META_API_KEY. The real-model multi-step credentialed smoke is DEFERRED until the captain provides the key, and must be documented clearly rather than treated as missing work. The scout report recommended WAIT; the captain overrode that and chose to adopt now.
- Do NOT force-disable muse's auto-update. The captain explicitly accepts the beta/self-update risk, so MUSE_NO_AUTO_UPDATE is optional documentation and must NOT be a mandatory spawn env var. Its absence from the launch command is deliberate, not an oversight.
- yolo on for this ship.
- The authoritative investigation is the scout report at data/muse-code-crewmate-harness-s1/report.md (private to the firstmate home, not in this repo).

Required work, in the scout's implementation order:
1. Detection in bin/fm-harness.sh via prefix match on muse-bin-*, because muse's installed launcher execs a version-suffixed binary whose name changes on every auto-update.
2. Spawn in bin/fm-spawn.sh: positional brief (the Grok/Pi shape), autonomy flags, --model, --reasoning-effort mapped from firstmate's shared effort vocabulary, trust-dialog handling, detection/escalation of an unauthenticated login hang, and a deliberate sandbox/network posture because a crewmate needs git and network.
3. Busy source in bin/fm-busy-lib.sh from muse's session JSONL run lifecycle, explicitly NOT the experimental plugin/hook system.
4. Composer glyph U+27E9 added to bin/fm-composer-lib.sh.
5. Interrupt path clears the composer after Escape, because muse restores the interrupted prompt as live text.
6. A deliberate posture on muse's native sub-agents and nested worktrees, including the teardown interaction.
7. Verified facts recorded in .agents/skills/harness-adapters/SKILL.md, mechanics in fm-spawn; never dispatch on an unverified adapter.
8. Portable regressions plus a live opt-in guard where applicable.

Constraints: this is firstmate's own shared tracked material, so the firstmate-coding-guidelines skill governs it (one-owner rule, AGENTS.md size discipline, one sentence per line in tracked Markdown, plain dash never em dash, shellcheck-clean bin scripts, colocated tests named <subject>.test.sh, no test may assert implementation source bytes, and harness-dependent checks need both a portable regression and a live opt-in guard).

Decisions and findings made while doing the work, which a reviewer reading only the diff would not know:

- SUPERSESSION, privacy control. The brief and scout both said to pass --no-foreign-personal-context by default. Live verification proved that flag is 'muse exec' ONLY: the interactive TUI rejects it with 'unexpected argument'. The accepted replacement, verified live, is MUSE_EXPERIMENTAL_FOREIGN_PERSONAL_CONTEXT_KILL=on, which drops muse's loading of the operator's foreign ~/.claude personal rules while KEEPING the project's own AGENTS.md rules. So the absence of --no-foreign-personal-context and the presence of that env var are both deliberate and load-bearing, not a substitution error.
- Login-prompt handling is a SPAWN PREFLIGHT (META_API_KEY, else <config>/muse/auth.json), not a rendered-screen check, because an unauthenticated muse pane never exits: it waits forever on an OAuth device-code prompt, which supervision would misread as a wedged worker.
- Effort mapping: low/medium/high/xhigh map straight across; firstmate's max maps to muse's 'ultra' ONLY as an explicit captain choice, never as a fallback default, per the brief's 'never select ultra as default max'. muse's none/minimal sit below the shared vocabulary and are deliberately unreachable.
- Busy state is a PULL source with no writer, no arm, and no gen, because muse's default build ships no usable hook surface. Nothing is armed for muse for the same reason standalone Kimi is not: a seeded busy record with no writer could never be cleared. This deliberately mirrors the existing grok and kimi precedents in bin/fm-busy-lib.sh.
- The IDLE half of the busy source is intentionally GATED CLOSED behind fm_busy_muse_idle_verified. An open run proves busy, but a settled log only proves no run is open at that instant, and the deferred credentialed smoke is what would prove one real turn stays inside one run. Reporting unknown instead of idle is the safe direction. This dead-looking gate is the deferred smoke's one-line landing point, not incomplete work.
- The fold is anchored on the full structural run-lifecycle prefix rather than a '"kind":"terminal"' search because muse also emits nested cleanup-effect payloads containing that string which are NOT run terminals, and it is depth-bounded because muse's native sub-agents write independent run lifecycles one directory deeper under subagent/<child-session-id>/.
- SCOPE ADDITION found during verification: bin/backends/tmux.sh's liveness classifier did not recognise muse either, so a healthy muse crewmate pane would have classified as a dead endpoint and been torn down or relaunched. Fixing that was required for the adapter to work at all. The muse pattern there is anchored (muse|muse-bin*) rather than globbed like its neighbours because 'muse' is a common English fragment and a *muse* glob would claim musescore or amuse.
- C-u was added to the herdr, zellij, and cmux key vocabularies so the interrupt clear works on every spawn-capable backend; Orca deliberately keeps refusing unsupported keys.
- muse is refused for --secondmate in fm-spawn, because a secondmate is a firstmate instance needing a primary supervision protocol that muse has no hook surface for.
- Firstmate deliberately does NOT exclude any muse path from fm-teardown.sh's uncommitted-work check. The existing .claude exclusion exists because firstmate writes that file itself; it does not write muse's, so nested muse scratch is the agent's own work product and MUST be able to refuse teardown.
- Deferred work is documented, not omitted: docs/verification/muse.md carries the dated evidence and the exact credentialed-smoke checklist that opens the idle gate.

## What Changed

- Add Muse Code detection and crewmate/scout spawning with credential preflight, foreign personal-context suppression, model and effort mapping, and explicit secondmate refusal.
- Derive Muse busy state from workspace-bound session lifecycle logs, recognize Muse pane liveness, and clear restored composer text after interrupts across supported backends.
- Document verified adapter boundaries and deferred credentialed validation, with portable regressions and a live opt-in signal guard.

## Risk Assessment

⚠️ Medium: The adapter spans security-sensitive spawn, liveness, interruption, and supervision paths, but the reviewed implementation is fail-closed and no remaining material source defect was substantiated.

## Testing

No baseline results were supplied. All targeted adapter, composer, bootstrap, and real-tmux process checks passed and CLI evidence was captured; the ANSI parser passed its negative-control self-test. The opt-in real Muse guard skipped as designed, and Muse is not installed on this machine, so no new real-harness run or visual artifact was possible. This is a CLI-only change, and the accepted credentialed multi-step smoke remains deliberately deferred with the idle gate closed.

<details>
<summary>Evidence: Targeted Muse adapter behavior transcript</summary>

```text
FM_TEST_BEGIN 2026-08-06T06:57:05Z tests/fm-muse-harness.test.sh family=pure-contract-unit expected_gate_skip=none
ok - muse is detected through any versioned muse-bin ancestor
ok - muse detection does not claim unrelated muse-containing commands
ok - muse launch clears foreign harness markers before ancestry detection
ok - muse spawn launches with autonomy, privacy control, and a positional brief
ok - muse maps the shared effort vocabulary and reaches ultra only via explicit max
ok - muse spawn refuses when no credential can reach the provider
ok - muse spawn refuses a META_API_KEY that cannot reach the worker
ok - muse spawn accepts a stored credential without META_API_KEY
ok - muse resolves relative XDG roots before preflight and launch
ok - muse is refused as a secondmate harness
ok - muse spawn writes a session binding that teardown removes
ok - every accepted muse Escape alias clears the restored composer
ok - the composer clear is scoped to muse and does not touch other adapters
ok - a failed muse composer clear fails loudly instead of leaving stale input
ok - the run fold tracks open, settled, interrupted, reopened, and run-free logs
ok - a nested terminal record never settles an in-flight run
ok - the session binding folds only the log matching this task's worktree
ok - workspace bindings compare decoded paths literally
ok - spawn-time exclusions select the current session across equal mtimes
ok - the Muse session cache avoids rescans and refreshes safely across incarnations
ok - a changed Muse namespace revalidates cached session uniqueness
ok - sub-agent session logs are excluded from the parent's busy fold
ok - every unproven muse binding classifies unknown rather than idle
ok - a settled log stays unknown until the idle gate opens, then reads idle
ok - muse trusts no busy record source
FM_TEST_END 2026-08-06T06:57:55Z tests/fm-muse-harness.test.sh exit=0 duration_ms=50920 gate_skip=false
FM_TEST_BEGIN 2026-08-06T06:57:56Z tests/fm-tmux-agent-liveness.test.sh family=backend-dispatch expected_gate_skip=none
ok - tmux liveness: a harness-named foreground process classifies alive
ok - tmux liveness: muse's version-suffixed muse-bin-<version> classifies alive
ok - tmux liveness: unrelated muse-containing command names stay ambiguous
ok - tmux liveness: a version-named executable under a harness install path classifies alive
ok - tmux liveness: a version-named executable under a decoy path stays ambiguous
ok - tmux liveness: a process neither name source attributes stays ambiguous rather than inventing an agent
ok - tmux liveness: a launcher whose own identity reads as a bare shell classifies alive from its harness child
ok - tmux liveness: an idle shell pane classifies dead
ok - tmux liveness: a harness-named background process in an idle pane still classifies dead
ok - tmux liveness: an absent window classifies missing rather than inheriting tmux's active-window fallback
FM_TEST_END 2026-08-06T06:58:02Z tests/fm-tmux-agent-liveness.test.sh exit=0 duration_ms=6784 gate_skip=false
FM_TEST_BEGIN 2026-08-06T06:58:02Z tests/fm-composer-lib.test.sh family=pure-contract-unit expected_gate_skip=none
ok - fm_composer_classify_content: a bare shell prompt glyph (>/$/%/#) reads unknown, never empty
ok - fm_composer_classify_content: stripped unbordered content is unknown except verified agent glyphs
ok - fm_composer_classify_content: a bare shell prompt carrying a command is not empty
ok - fm_composer_classify_content: a bare prompt glyph inside a bordered composer box reads empty (claude's own idle composer)
ok - fm_composer_classify_content: agent prompt glyphs (❯ claude, › codex, ⟩ muse) read empty bordered or bare
ok - fm_composer_classify_content: an empty composer reads empty
ok - fm_composer_classify_content: a known idle placeholder reads empty, before and after glyph stripping
ok - fm_composer_classify_content: idle matching preserves the caller's case mode
ok - fm_composer_classify_content: real unsubmitted text reads pending (including a popup argument-hint fill)
FM_TEST_END 2026-08-06T06:58:03Z tests/fm-composer-lib.test.sh exit=0 duration_ms=566 gate_skip=false
FM_TEST_BEGIN 2026-08-06T06:58:03Z tests/fm-composer-ghost.test.sh family=pure-contract-unit expected_gate_skip=none
ok - fm_tmux_strip_ghost drops dim/faint runs, keeps normal and bold text
ok - fm_tmux_strip_ghost handles combined SGR, ESC[22m, and reset-then-dim
ok - fm_tmux_strip_ghost keeps bright colored text with 2 payloads
ok - fm_tmux_strip_ghost drops a dark/muted truecolor foreground (grok placeholder)
ok - fm_tmux_strip_ghost keeps muse's near-threshold glyph and its typed text
ok - fm_pane_input_pending: a dim ghost-only composer is NOT pending
ok - fm_pane_input_pending: dim ghost inside a bordered composer is NOT pending
ok - fm_pane_input_pending: normal-intensity typed text is still pending
ok - fm_pane_input_pending: bright colored text with 2 payloads is still pending
ok - fm_pane_input_pending: a dark truecolor ghost-only composer (grok placeholder) is NOT pending
ok - fm_tmux_composer_state: dark truecolor shell prompts read unknown
ok - fm_pane_input_pending: real text plus a trailing ghost run is still pending
ok - fm_tmux_composer_state: text above an empty cursor row is pending
ok - fm_tmux_composer_state: a message wrapped across three rows is pending
ok - fm_tmux_composer_state: Grok's bottom-border cursor quirk reads an empty box structurally
ok - fm_tmux_composer_state: typed Pi and Grok busy signatures inside a box are pending
ok - fm_tmux_composer_state: non-bordered busy footers retain compatibility behavior
ok - fm_tmux_composer_state: an unbounded bordered box fails closed as unknown
ok - fm_tmux_composer_state: clipped and asymmetric composer edges fail closed
ok - fm_tmux_composer_state: inconsistent box geometry fails closed
ok - fm_tmux_composer_state: misaligned box bounds fail closed
ok - fm_tmux_composer_state: unproved ghost, idle, and border geometry stays unknown
ok - fm_tmux_composer_state: differing widths prefer pending or unknown, never empty
ok - fm_tmux_composer_state: emoji and CJK text remain pending under the C locale
ok - fm_tmux_composer_state: all tmux harnesses share empty and pending classification
ok - fm_pane_input_pending: unrecognized states defer by default
ok - fm_tmux_composer_state: fallback capture races cannot admit unbounded edges
ok - fm_tmux_composer_state: only proven structural and non-bordered empty routes stay empty
ok - fm_tmux_composer_state: panes without bordered structure retain compatibility fallback
ok - fm_tmux_composer_state: interior edge glyphs retain non-bordered fallback
ok - fm-peek output is escape-free (no raw -e bytes reach firstmate context)
FM_TEST_END 2026-08-06T06:58:14Z tests/fm-composer-ghost.test.sh exit=0 duration_ms=10992 gate_skip=false
FM_TEST_BEGIN 2026-08-06T06:58:14Z tests/fm-bootstrap.test.sh family=session-bootstrap expected_gate_skip=none
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git

... [5459 bytes truncated] ...

y of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
ok - bootstrap: backend=orca gates the Orca CLI without requiring it on the default backend
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
ok - bootstrap: session-provider backends require their own CLI + jq + treehouse, never tmux
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
ok - bootstrap: a session-provider backend gates its own CLI, never a false tmux requirement
ok - bootstrap: Herdr manual-install guidance is never executed as a shell command
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
ok - bootstrap: the bundled cmux CLI satisfies the active backend dependency
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
ok - bootstrap: unknown resolved backends fail closed with an actionable diagnostic
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
ok - bootstrap: JSON-emitting backends require jq (their genuine dep), never tmux
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
ok - bootstrap: the treehouse lease check follows the resolved backend's worktree provider
ok - bootstrap computes a fleet-size-aware default timeout and preserves partial fleet-sync output
ok - bootstrap keeps the quick 20s default for small fleets
ok - bootstrap preserves FM_FLEET_SYNC_BOOTSTRAP_TIMEOUT as an explicit override
ok - bootstrap treats a blank timeout override as unset
ok - bootstrap computes the timeout before launching fleet sync
ok - bootstrap keeps routine tasks-axi, harness, dispatch, and already-live liveness confirmations silent
ok - bootstrap routine contract runs under system /bin/bash
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
ok - bootstrap surfaces active crew-dispatch rules only as verbose BOOTSTRAP_INFO
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
ok - bootstrap validates crew-dispatch.json and reports malformed or unverified configs
FM_TEST_END 2026-08-06T07:01:55Z tests/fm-bootstrap.test.sh exit=0 duration_ms=221089 gate_skip=false
FM_TEST_SUMMARY total=5 failed=0 skipped_gate=0 duration_ms=290725
FM_TEST_SUMMARY_FAMILY family=backend-dispatch count=1 duration_ms=6784 failed=0
FM_TEST_SUMMARY_FAMILY family=pure-contract-unit count=3 duration_ms=62478 failed=0
FM_TEST_SUMMARY_FAMILY family=session-bootstrap count=1 duration_ms=221089 failed=0
FM_TEST_SLOWEST rank=1 script=tests/fm-bootstrap.test.sh duration_ms=221089
FM_TEST_SLOWEST rank=2 script=tests/fm-muse-harness.test.sh duration_ms=50920
FM_TEST_SLOWEST rank=3 script=tests/fm-composer-ghost.test.sh duration_ms=10992
FM_TEST_SLOWEST rank=4 script=tests/fm-tmux-agent-liveness.test.sh duration_ms=6784
FM_TEST_SLOWEST rank=5 script=tests/fm-composer-lib.test.sh duration_ms=566
fm-test-run: wrote timing artifact: /var/folders/0k/bf8mwt2n5qddzk24r20gfk0c0000gn/T/no-mistakes-evidence/01KZAQJJ13KHPAVCA5QEZKZQC5/muse-targeted-tests.json
```
</details>
<details>
<summary>Evidence: Muse live-guard skip transcript</summary>

```text
FM_TEST_BEGIN 2026-08-06T07:02:20Z tests/fm-muse-signals-live-e2e.test.sh family=live-harness-optin expected_gate_skip=optin-env
skip: set FM_MUSE_SIGNALS_LIVE=1 to run the real Muse signal drift guard
FM_TEST_END 2026-08-06T07:02:20Z tests/fm-muse-signals-live-e2e.test.sh exit=0 duration_ms=57 gate_skip=true
FM_TEST_SUMMARY total=1 failed=0 skipped_gate=1 duration_ms=192
FM_TEST_SUMMARY_FAMILY family=live-harness-optin count=1 duration_ms=57 failed=0
FM_TEST_SLOWEST rank=1 script=tests/fm-muse-signals-live-e2e.test.sh duration_ms=57
fm-test-run: wrote timing artifact: /var/folders/0k/bf8mwt2n5qddzk24r20gfk0c0000gn/T/no-mistakes-evidence/01KZAQJJ13KHPAVCA5QEZKZQC5/muse-live-guard.json
```
</details>
<details>
<summary>Evidence: Muse ANSI signal parser self-test</summary>

`ok - Muse glyph color parser follows effective foreground state`

```text
ok - Muse glyph color parser follows effective foreground state
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed (8) ✅</summary>

- 🚨 `bin/fm-spawn.sh:1025` - The required &#34;SPAWN PREFLIGHT (META_API_KEY, else &lt;config&gt;/muse/auth.json)&#34; checks the fm-spawn process environment, but the worker is created by a long-lived backend daemon and the launch command forwards neither META_API_KEY nor XDG_CONFIG_HOME. A command-scoped key or credential in a custom config root therefore passes preflight, then the pane sees no credential and hangs on OAuth. Make the preflight evaluate the worker-effective environment or securely hand the credential/config root across the spawn boundary.
- 🚨 `bin/fm-bootstrap.sh:900` - Muse is documented and launched as verified, but the dispatch-profile validator still omits it from verified($h), so any crew-dispatch.json profile selecting muse is rejected as &#34;unverified harness.&#34; Add muse to this registry and validate its supported effort set low|medium|high|xhigh|max.

🔧 Fix: Accept Muse dispatch profiles and shared efforts
2 errors still open:
- 🚨 `bin/fm-spawn.sh:1025` - The required &#34;SPAWN PREFLIGHT (META_API_KEY, else &lt;config&gt;/muse/auth.json)&#34; still checks fm-spawn&#39;s environment, although the pane is created by a long-lived backend daemon that does not inherit it (as fm-spawn itself documents at line 2209). Neither META_API_KEY nor XDG_CONFIG_HOME is forwarded in the launch command. A command-scoped key or custom config root therefore passes preflight, then the worker hangs on OAuth. XDG_DATA_HOME has the same split, causing the busy sidecar to point at a log root the worker does not use. Evaluate credentials against the worker-effective environment or securely hand the credential and XDG roots across the launch boundary.
- 🚨 `bin/fm-busy-lib.sh:347` - Session selection ranks matching logs using integer-second mtime and retains the first path on ties. If a restarted Muse session creates its active log in the same second as an older settled log, find may return the old log first and the strict `&gt;` comparison keeps it. The active turn then reports unknown instead of busy, allowing stale/wedge escalation; once the idle gate opens it can report false idle. Bind the task to the exact main session log during spawn readiness, or use a collision-free ordering backed by Muse session metadata.

🔧 Fix: Bind Muse busy state to current session
3 errors still open:
- 🚨 `bin/fm-spawn.sh:1025` - The credential preflight still checks fm-spawn&#39;s environment, but the long-lived backend daemon does not inherit it and the launch command forwards neither META_API_KEY nor XDG_CONFIG_HOME. A command-scoped key or custom credential root therefore passes preflight, then Muse waits indefinitely for OAuth. XDG_DATA_HOME has the same split, leaving busy-state binding pointed at the wrong session root. Evaluate the worker-effective environment or securely transfer the credential and XDG roots across the spawn boundary.
- 🚨 `bin/fm-busy-lib.sh:335` - Workspace matching interpolates the worktree path into a shell case pattern, so valid glob characters are interpreted rather than compared literally. For example, a task at `ws[1]` can miss its own log and match another session at `ws1`, potentially importing that session&#39;s busy state. Decode the metadata workspace_root and compare it literally at this binding boundary.
- 🚨 `docs/verification/muse.md:185` - The required constraint says harness-dependent checks need both a portable regression and a live opt-in guard, but the documented Muse refresh command validates only process liveness. The new busy fold and composer classifier depend on vendor-controlled JSONL structure, glyphs, and colors, with only fixtures covering them. Add an env-gated real-Muse echo-provider guard for those signals while keeping the explicitly deferred credentialed real-model idle smoke separate.

🔧 Fix: Compare Muse workspace bindings literally
4 issues (3 errors, 1 warning) still open:
- 🚨 `bin/fm-spawn.sh:1025` - The Muse preflight checks META_API_KEY and XDG_CONFIG_HOME in fm-spawn&#39;s environment, but the long-lived backend daemon does not inherit them and the launch command forwards neither. A command-scoped key or custom credential root therefore passes preflight, then the worker waits on OAuth; XDG_DATA_HOME likewise points the busy binding at a different session root. Evaluate the worker-effective environment or securely transfer the credential and XDG roots across the launch boundary.
- 🚨 `bin/fm-spawn.sh:926` - The new Muse secondmate guard is bypassed by the documented positional harness form: the parser at line 789 omits muse, so `fm-spawn &lt;id&gt; muse --secondmate` treats `muse` as a home path. If that directory exists, the command can launch a secondmate with the configured harness instead of refusing the requested Muse adapter. Recognize muse as a positional adapter so this guard receives and rejects it.
- ⚠️ `bin/fm-harness.sh:69` - The required installed-binary prefix is `muse-bin-*`, but `muse-bin*` also claims unrelated names such as `muse-binary` and `muse-bind`. Such a foreground process is misidentified as Muse and as a healthy agent endpoint. Narrow this pattern and the sibling tmux classifier to `muse-bin-*`, retaining exact `muse` only if needed.
- 🚨 `docs/verification/muse.md:185` - The required harness-dependent verification includes portable regressions plus a live opt-in guard, but the documented guard exercises only process liveness. The busy fold and composer classifier depend on vendor-controlled JSONL structure, glyphs, and colors and currently have fixture coverage only. Add an env-gated real-Muse echo-provider guard for those signals while keeping the explicitly deferred credentialed real-model idle smoke separate.

🔧 Fix: Harden Muse worker credentials and live signal verification
2 warnings still open:
- ⚠️ `docs/configuration.md:210` - This user-facing guidance says a caller launch environment is sufficient, but fm-spawn now deliberately rejects caller-only META_API_KEY values unless the backend worker already has the key. Document the worker-reachable requirement and identify the stored credential as the portable fleet path.
- ⚠️ `bin/fm-busy-lib.sh:364` - Every Muse busy classification starts Node, traverses the entire unbounded historical sessions tree, and opens every main log&#39;s metadata before folding one file. Watch and supervision paths call this synchronously, so accumulated Muse history can increasingly delay fleet supervision. Persist the uniquely resolved current session log at the binding boundary, then fold that exact path on subsequent checks.

🔧 Fix: Cache Muse session bindings and clarify worker credentials
2 issues (1 error, 1 warning) still open:
- 🚨 `bin/fm-spawn.sh:875` - The Muse launch inherits foreign primary-harness markers even though fm-harness checks CLAUDECODE, PI_CODING_AGENT, and GROK_AGENT before process ancestry. For example, a native Claude firstmate starting the tmux server passes CLAUDECODE=1 into Muse, so Muse tool children report claude instead of muse despite the muse-bin-* ancestor. Clear foreign harness markers at the worker launch boundary or provide an authoritative Muse marker.
- ⚠️ `bin/fm-send.sh:97` - The post-interrupt clear recognizes only the exact key spelling Escape, while every backend accepts aliases such as Esc and escape. Sending an accepted alias interrupts Muse but skips C-u, leaving the restored prompt to corrupt the next steer. Normalize the key before applying Muse&#39;s post-interrupt behavior.

🔧 Fix: Clear Muse marker inheritance and normalize interrupt aliases
1 error still open:
- 🚨 `tests/fm-muse-signals-live-e2e.test.sh:111` - The required live guard does not actually prove the prompt glyph&#39;s effective foreground color. Its regex permits another `38;2` foreground escape between the captured RGB and `⟩`, so Muse could change the glyph to a dark color and this guard would still pass using an earlier bright color on the same row. Parse the ANSI state through the glyph, or reject intervening foreground/reset escapes, then assert the color active at `⟩`.

🔧 Fix: Verify Muse glyph effective foreground color
3 errors still open:
- 🚨 `bin/fm-spawn.sh:1113` - Relative XDG roots are checked from fm-spawn&#39;s cwd but forwarded unchanged to a worker running in the task worktree. Thus `XDG_CONFIG_HOME=cfg` can pass on `cfg/muse/auth.json` and then leave Muse unauthenticated, while relative XDG_DATA_HOME similarly splits busy-state binding. Require absolute roots or resolve them before preflight and launch.
- 🚨 `bin/fm-busy-lib.sh:468` - Once a log is cached, the resolver never checks whether another non-prior main session for the same workspace has appeared. Starting a second Muse session after initial resolution therefore bypasses the required ambiguity-to-UNKNOWN invariant and can retain stale busy state from the old log. Invalidate or revalidate the cache when the relevant session namespace changes, then require unique resolution again.
- 🚨 `tests/fm-muse-signals-live-e2e.test.sh:39` - The live glyph parser accepts incomplete truecolor sequences because `[].every(Number.isFinite)` is true. For example, `ESC[38;2m⟩` records an empty RGB tuple, computes NaN luminance, and passes because `NaN &lt; 128` is false. Require exactly three integer channels in 0-255 and add this malformed sequence to the negative controls.

🔧 Fix: Harden Muse XDG paths, session cache, and glyph parsing
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bin/fm-test-run.sh tests/fm-muse-harness.test.sh tests/fm-tmux-agent-liveness.test.sh tests/fm-composer-lib.test.sh tests/fm-composer-ghost.test.sh tests/fm-bootstrap.test.sh --json /var/folders/0k/bf8mwt2n5qddzk24r20gfk0c0000gn/T/no-mistakes-evidence/01KZAQJJ13KHPAVCA5QEZKZQC5/muse-targeted-tests.json`
- `bin/fm-test-run.sh tests/fm-muse-signals-live-e2e.test.sh --json /var/folders/0k/bf8mwt2n5qddzk24r20gfk0c0000gn/T/no-mistakes-evidence/01KZAQJJ13KHPAVCA5QEZKZQC5/muse-live-guard.json`
- `tests/fm-muse-signals-live-e2e.test.sh --ansi-self-test`
- `command -v muse || true`
- `git status --short`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
