### PR TITLE
fix(bin): classify settled Muse session logs as idle

### DIFF
--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -446,8 +446,7 @@ muse's own native sub-agents write independent run lifecycles one directory deep
 The recorded sessions root is the resolved `XDG_DATA_HOME` that `fm-spawn` also forwards to the worker launch, so the binding and pane remain aligned across a long-lived backend daemon.
 
 Both halves of the fold are trusted with no opt-in: an open run reads `busy`, a settled log reads `idle`, and only a resolution failure - no binding, no matching log, an unreadable or run-free log - reads `unknown`.
-The credentialed multi-step smoke established the idle half by confirming that one real 75-second tool-loop turn stays inside exactly one run pair, and that an Escape mid tool loop closes that run as `cancelled` rather than leaving it open.
-[`docs/verification/muse.md`](../../../docs/verification/muse.md) owns that evidence and the commands that re-check it after a muse upgrade.
+[`docs/verification/muse.md`](../../../docs/verification/muse.md) owns the credentialed evidence for trusting idle and the post-upgrade refresh procedure.
 
 ### Native sub-agents and worktrees
 

--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -445,9 +445,9 @@ muse's own native sub-agents write independent run lifecycles one directory deep
 
 The recorded sessions root is the resolved `XDG_DATA_HOME` that `fm-spawn` also forwards to the worker launch, so the binding and pane remain aligned across a long-lived backend daemon.
 
-The IDLE half is gated behind `fm_busy_muse_idle_verified` in `bin/fm-busy-lib.sh` and is currently CLOSED, so a settled log reads `unknown`, never `idle`.
-Busy needs no gate because an open run is positive proof a turn is in flight.
-[`docs/verification/muse.md`](../../../docs/verification/muse.md) owns the evidence and the exact deferred credentialed smoke that opens the gate.
+Both halves of the fold are trusted with no opt-in: an open run reads `busy`, a settled log reads `idle`, and only a resolution failure - no binding, no matching log, an unreadable or run-free log - reads `unknown`.
+The credentialed multi-step smoke established the idle half by confirming that one real 75-second tool-loop turn stays inside exactly one run pair, and that an Escape mid tool loop closes that run as `cancelled` rather than leaving it open.
+[`docs/verification/muse.md`](../../../docs/verification/muse.md) owns that evidence and the commands that re-check it after a muse upgrade.
 
 ### Native sub-agents and worktrees
 

--- a/bin/fm-busy-lib.sh
+++ b/bin/fm-busy-lib.sh
@@ -271,26 +271,13 @@ fm_busy_record_read() {  # <state-dir> <id>
 # Stop hook this source covers the interrupt path itself. Any later
 # run_retracted records follow the terminal rather than replacing it.
 #
-# fm_busy_muse_idle_verified is the gate on the IDLE half only. Busy needs no
-# gate: an open run is positive proof a turn is in flight. Idle does, because a
-# settled log only proves no run is open RIGHT NOW, and the multi-step,
-# real-model tool loop that would show whether one turn stays inside one run is
-# unverified - the credentialed smoke is deferred (docs/verification/muse.md).
-# If it turned out a real turn spans several runs, an ungated idle would report
-# a working crewmate as finished; reporting unknown instead is the safe
-# direction, because unknown is never promoted to either boolean pole.
-#
-# To open the gate: run a real multi-step tool-loop turn on a
-# firstmate-launched muse worker with META_API_KEY set, confirm exactly one
-# started/terminal pair brackets the whole turn (not one pair per model step),
-# record the version, exact commands, and observed output in
-# docs/verification/muse.md, and add the verified version string(s) here.
-FM_BUSY_MUSE_IDLE_VERIFIED_VERSIONS=""
-
-fm_busy_muse_idle_verified() {
-  [ -n "$FM_BUSY_MUSE_IDLE_VERIFIED_VERSIONS" ]
-}
-
+# Both halves of the fold are trusted. An open run is positive proof a turn is
+# in flight, and a settled log is idle: the credentialed multi-step smoke showed
+# one 75-second real-model turn with 23 tool batches stays inside exactly one
+# started/terminal pair, so a settled log is a finished turn rather than a pause
+# between the runs of one turn (docs/verification/muse.md). Resolution failures -
+# no sidecar, no matching log, an unreadable or run-free log - remain unknown,
+# because those prove nothing about the turn either way.
 # fm_busy_muse_binding_path: the per-task sidecar fm-spawn writes so the
 # classifier binds a pane to its session log without re-deriving muse's data
 # directory. It records sessions_root=<abs>, workspace_root=<abs>, one
@@ -622,8 +609,7 @@ fm_busy_classify() {  # <backend> <target> <harness> <id> <state-dir> [tail40]
   case "$harness" in
     muse*)
       # Semantic, on demand: fold this task's bound session log. An open run is
-      # positive proof of a turn in flight; a settled log only classifies idle
-      # once fm_busy_muse_idle_verified opens on a credentialed multi-step run.
+      # positive proof of a turn in flight and a settled log is a finished turn.
       # Every other outcome - no sidecar, no matching log, an unreadable or
       # run-free log - is unknown, never idle.
       if ! log=$(fm_busy_muse_session_log "$state" "$id"); then
@@ -632,13 +618,7 @@ fm_busy_classify() {  # <backend> <target> <harness> <id> <state-dir> [tail40]
       fi
       case "$(fm_busy_muse_run_state "$log" 2>/dev/null)" in
         busy) printf 'busy muse-session-log' ;;
-        settled)
-          if fm_busy_muse_idle_verified; then
-            printf 'idle muse-session-log'
-          else
-            printf 'unknown muse-session-log'
-          fi
-          ;;
+        settled) printf 'idle muse-session-log' ;;
         *) printf 'unknown muse-session-log' ;;
       esac
       return 0

--- a/bin/fm-busy-lib.sh
+++ b/bin/fm-busy-lib.sh
@@ -277,12 +277,11 @@ fm_busy_record_read() {  # <state-dir> <id>
 # closes the run with terminal=cancelled instead of continuing the turn in
 # another run. This gives the settled log the same idle trust as the Claude and
 # Pi push sources. A version allowlist would be false precision and a maintenance
-# treadmill for an auto-updating vendor binary: the running process identifies
-# itself only as muse-bin-*, while session metadata records semver 0.1.0 plus a
-# build SHA that the process identity cannot be matched against. Resolution
+# treadmill for an auto-updating vendor binary: busy classification receives
+# only the normalized muse harness identity, while session metadata records
+# semver 0.1.0 plus a build SHA that cannot be matched against it. Resolution
 # failures - no sidecar, no matching log, an unreadable or run-free log - remain
-# unknown,
-# because those prove nothing about the turn either way. See
+# unknown because those prove nothing about the turn either way. See
 # docs/verification/muse.md for the evidence.
 # fm_busy_muse_binding_path: the per-task sidecar fm-spawn writes so the
 # classifier binds a pane to its session log without re-deriving muse's data

--- a/bin/fm-busy-lib.sh
+++ b/bin/fm-busy-lib.sh
@@ -66,7 +66,7 @@
 # (its plugin engine reports "plugins are not available in this build" without
 # MUSE_EXPERIMENTAL_PLUGINS). Nothing is armed for muse for the same reason
 # standalone Kimi is not: a seeded record with no writer could never be
-# cleared. See fm_busy_muse_run_state for the fold and its verification gate.
+# cleared. See fm_busy_muse_run_state for the fold.
 #
 # Codex negotiation (fm_busy_codex_appserver_observable,
 # fm_busy_codex_hooks_verified): the approved contract prefers Codex's
@@ -273,11 +273,17 @@ fm_busy_record_read() {  # <state-dir> <id>
 #
 # Both halves of the fold are trusted. An open run is positive proof a turn is
 # in flight, and a settled log is idle: the credentialed multi-step smoke showed
-# one 75-second real-model turn with 23 tool batches stays inside exactly one
-# started/terminal pair, so a settled log is a finished turn rather than a pause
-# between the runs of one turn (docs/verification/muse.md). Resolution failures -
-# no sidecar, no matching log, an unreadable or run-free log - remain unknown,
-# because those prove nothing about the turn either way.
+# one run pair spans a whole multi-step turn, including an Escape interrupt that
+# closes the run with terminal=cancelled instead of continuing the turn in
+# another run. This gives the settled log the same idle trust as the Claude and
+# Pi push sources. A version allowlist would be false precision and a maintenance
+# treadmill for an auto-updating vendor binary: the running process identifies
+# itself only as muse-bin-*, while session metadata records semver 0.1.0 plus a
+# build SHA that the process identity cannot be matched against. Resolution
+# failures - no sidecar, no matching log, an unreadable or run-free log - remain
+# unknown,
+# because those prove nothing about the turn either way. See
+# docs/verification/muse.md for the evidence.
 # fm_busy_muse_binding_path: the per-task sidecar fm-spawn writes so the
 # classifier binds a pane to its session log without re-deriving muse's data
 # directory. It records sessions_root=<abs>, workspace_root=<abs>, one

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -2091,7 +2091,7 @@ EOF
       # muse's turn lifecycle is neither a hook nor a launch flag: its plugin
       # engine (the only hook surface) is disabled in the default build, so
       # firstmate reads muse's own durable session event log instead
-      # (bin/fm-busy-lib.sh owns the fold and the idle gate). That is a PULL
+      # (bin/fm-busy-lib.sh owns the fold). That is a PULL
       # source with no writer, so nothing is armed and no record is seeded -
       # exactly the reason standalone Kimi is not armed either.
       # This sidecar is the whole binding: it pins the sessions root, the

--- a/docs/verification/muse.md
+++ b/docs/verification/muse.md
@@ -160,7 +160,7 @@ This was the one item deferred until a `META_API_KEY` was available, because it 
 An open run was always positive proof of a turn in flight, but a settled log only proves no run is open at that instant, so the classifier held idle behind an opt-in in case a real turn spanned several runs.
 The smoke below answered that: one run brackets a whole multi-step turn, and an Escape interrupt closes that run with `terminal=cancelled` rather than leaving the turn to continue in another run.
 The credentialed result gives a settled Muse log the same idle trust as the Claude and Pi push sources, so the opt-in was removed and `bin/fm-busy-lib.sh` classifies a settled log `idle` outright.
-Muse auto-updates its vendor binary underneath the fleet, the running process identifies itself only as `muse-bin-*`, and the session log's own metadata carries semver `0.1.0` plus a build SHA that cannot be matched to that process identity.
+Muse auto-updates its vendor binary underneath the fleet, firstmate normalizes the versioned process identity to the `muse` harness before busy classification, and the session log's own metadata carries semver `0.1.0` plus a build SHA that cannot be matched to that normalized identity.
 A verified-build allowlist against this coarse identity would be false precision because it could not distinguish the running build, as well as a maintenance treadmill against the auto-updating binary.
 
 Both runs below used the default `meta` provider with model `muse-spark-1.2-contributor`, on a real firstmate-launched crewmate pane, authenticated through the stored `~/.config/muse/auth.json` written by `muse auth set --provider meta --api-key-stdin` so the key never entered `argv`.

--- a/docs/verification/muse.md
+++ b/docs/verification/muse.md
@@ -158,8 +158,10 @@ After a single Escape the interrupted prompt is restored into the composer at th
 
 This was the one item deferred until a `META_API_KEY` was available, because it is what decides whether a settled log may classify `idle`.
 An open run was always positive proof of a turn in flight, but a settled log only proves no run is open at that instant, so the classifier held idle behind an opt-in in case a real turn spanned several runs.
-The smoke below answered that: one turn stays inside one run, and even an interrupt closes its run rather than leaving the turn to continue in another.
-The opt-in was therefore removed rather than pinned to a version, and `bin/fm-busy-lib.sh` classifies a settled log `idle` outright.
+The smoke below answered that: one run brackets a whole multi-step turn, and an Escape interrupt closes that run with `terminal=cancelled` rather than leaving the turn to continue in another run.
+The credentialed result gives a settled Muse log the same idle trust as the Claude and Pi push sources, so the opt-in was removed and `bin/fm-busy-lib.sh` classifies a settled log `idle` outright.
+Muse auto-updates its vendor binary underneath the fleet, the running process identifies itself only as `muse-bin-*`, and the session log's own metadata carries semver `0.1.0` plus a build SHA that cannot be matched to that process identity.
+A verified-build allowlist against this coarse identity would be false precision because it could not distinguish the running build, as well as a maintenance treadmill against the auto-updating binary.
 
 Both runs below used the default `meta` provider with model `muse-spark-1.2-contributor`, on a real firstmate-launched crewmate pane, authenticated through the stored `~/.config/muse/auth.json` written by `muse auth set --provider meta --api-key-stdin` so the key never entered `argv`.
 

--- a/docs/verification/muse.md
+++ b/docs/verification/muse.md
@@ -8,7 +8,7 @@ Active empirical evidence for firstmate's muse adapter.
 | Field | Value |
 |---|---|
 | Version | `Muse Code 0.1.0 (0.1.0-R708.1)`, build sha `427a430436` |
-| Verified | 2026-08-05 |
+| Verified | 2026-08-05, extended 2026-08-06 with the credentialed multi-step smoke |
 | Artifact | `muse-aarch64-macos`, sha256 `4290bfafa5bbb81a6fd493aaea12f848c789b1d22edfa0c4b849151deba3e70c` |
 | Platform | macOS arm64 (Darwin 25.5.0) |
 
@@ -30,7 +30,7 @@ Every run below used an isolated `XDG_CONFIG_HOME` and `XDG_DATA_HOME` in a scra
 Live TUI and session behavior below was observed against the built-in `--provider echo` startup provider, except for the provider-authentication prompt.
 The credential paths and unauthenticated wait were probed separately against the default `meta` provider.
 Turn-boundary structure, the trust dialog, interrupt, exit, composer rendering, credential behavior, and the event-log schema are real and verified.
-**Busy-state behavior under a genuine multi-step, real-model tool loop is NOT verified** and is the deferred item below.
+Busy-state behavior under a genuine multi-step, real-model tool loop was verified separately on 2026-08-06 against the default `meta` provider with a live model, and is recorded under [the credentialed multi-step smoke](#the-credentialed-multi-step-smoke-verified-2026-08-06).
 
 ## Verified facts
 
@@ -154,24 +154,51 @@ Captured with `tmux capture-pane -p -e`:
 Prompt glyph `⟩` (U+27E9) at luminance ~149.9 against the 128 default ghost threshold; typed text at ~209.8.
 After a single Escape the interrupted prompt is restored into the composer at the same bright ~209.8, and `C-u` clears it.
 
-## Deferred: the credentialed multi-step smoke
+## The credentialed multi-step smoke (verified 2026-08-06)
 
-This is the one item the captain deferred until a `META_API_KEY` is available, and it is the only thing standing between the current adapter and a full busy-state signal.
+This was the one item deferred until a `META_API_KEY` was available, because it is what decides whether a settled log may classify `idle`.
+An open run was always positive proof of a turn in flight, but a settled log only proves no run is open at that instant, so the classifier held idle behind an opt-in in case a real turn spanned several runs.
+The smoke below answered that: one turn stays inside one run, and even an interrupt closes its run rather than leaving the turn to continue in another.
+The opt-in was therefore removed rather than pinned to a version, and `bin/fm-busy-lib.sh` classifies a settled log `idle` outright.
 
-Until it lands, `fm_busy_muse_idle_verified` in `bin/fm-busy-lib.sh` stays closed: an open run classifies `busy`, and everything else classifies `unknown`, never `idle`.
-Busy needs no gate because an open run is positive proof of a turn in flight.
-Idle does, because a settled log only proves no run is open at that instant; if a real turn turned out to span several runs, an ungated idle would report a working crewmate as finished.
+Both runs below used the default `meta` provider with model `muse-spark-1.2-contributor`, on a real firstmate-launched crewmate pane, authenticated through the stored `~/.config/muse/auth.json` written by `muse auth set --provider meta --api-key-stdin` so the key never entered `argv`.
 
-To open the gate:
+### One turn stays inside one run
 
-1. Set `META_API_KEY` and spawn a real muse crewmate through `bin/fm-spawn.sh` on a task whose first turn makes several tool calls.
-2. While that turn runs, sample `fm_busy_muse_run_state` on the bound log repeatedly and confirm it stays `busy` for the whole turn.
-3. Confirm the finished turn produced exactly ONE `started`/`terminal` pair, not one pair per model step:
-   `grep -c '"event":{"kind":"started"' <log>` and the same for `terminal`.
-4. Confirm an Escape interrupt mid-tool-loop still yields `terminal` with `cancelled`.
-5. Record the version, exact commands, and observed counts in this file, then add the verified version string to `FM_BUSY_MUSE_IDLE_VERIFIED_VERSIONS`.
+A single 8-step tool loop (shell, file reads, a file write, a shell append) ran as one submitted turn in session `629b3bc1-5dd7-4a0d-a901-69701850922c`, log `~/.local/share/muse/sessions/2026/08/06/629b3bc1-5dd7-4a0d-a901-69701850922c/session.jsonl`.
+The whole 828-record turn is bracketed by exactly one run pair, 23 tool batches deep:
 
-`tests/fm-muse-harness.test.sh` already pins that opening the gate flips exactly the settled verdict and nothing else, so this is a one-line landing rather than a redesign.
+```
+$ grep -cE '"kind":"run","run_id":"[^"]*","event":\{"kind":"started"' session.jsonl
+1
+$ grep -cE '"kind":"run","run_id":"[^"]*","event":\{"kind":"terminal"' session.jsonl
+1
+$ grep -c '"payload_type":"tool_batch.effect.started"' session.jsonl
+23
+
+10  {"kind":"run","run_id":"db5869ed-...","event":{"kind":"started","prompt":"...launch-brief..."
+827 {"kind":"run","run_id":"db5869ed-...","event":{"kind":"terminal","terminal":"completed",
+      "reason":null,"turn_duration_ms":75243,"time_to_first_token_ms":69583,"eot_gate_ms":3907}
+```
+
+Scope the count to `"kind":"run"` as above.
+A bare `grep -c '"event":{"kind":"started"'` returns 56 on the same log, because every tool batch effect reuses that inner event shape.
+
+### Busy sampling and interrupt
+
+Session `e4e0b4f4-38d0-46dc-b669-dfb5de92e0e0` sampled the fold while a multi-step turn was in flight, then interrupted it with Escape mid tool loop.
+Five consecutive samples of `fm_busy_muse_run_state` on the bound log returned `busy`, and `fm_busy_classify` returned `busy muse-session-log` for the same samples; the fold settled immediately after the interrupt.
+Its run closed as cancelled rather than staying open:
+
+```
+10  {"kind":"run","run_id":"a098d532-...","event":{"kind":"started","prompt":"...launch-brief..."
+103 {"kind":"run","run_id":"a098d532-...","event":{"kind":"terminal","terminal":"cancelled",
+      "reason":"cancelled during model step","turn_duration_ms":7849}
+```
+
+That is the same terminal shape the `echo`-provider interrupt produced, now confirmed against a live model mid tool loop.
+
+`tests/fm-muse-harness.test.sh` pins the resulting classifier behavior: a log settled by either terminal reads `idle`, an open run reads `busy`, and only a resolution failure reads `unknown`.
 
 ## Refreshing this record
 
@@ -182,7 +209,11 @@ FM_HARNESS_LIVENESS_DRIFT=1 bin/fm-test-run.sh tests/fm-harness-liveness-drift-l
 FM_MUSE_SIGNALS_LIVE=1 bin/fm-test-run.sh tests/fm-muse-signals-live-e2e.test.sh
 ```
 
-The Muse signals guard requires a real `muse` binary and tmux but uses `--provider echo`, so it does not require `META_API_KEY` and does not open the deferred real-model idle gate.
+The Muse signals guard requires a real `muse` binary and tmux but uses `--provider echo`, so it does not require `META_API_KEY` and cannot re-check the real-model turn-to-run relationship on its own.
 The guard follows SGR state through the final prompt glyph and rejects both bright-then-dark and malformed-RGB negative controls before accepting that glyph's effective luminance.
+
+muse's launcher can replace the running binary underneath the fleet, so an upgrade that changes the session protocol also invalidates the credentialed evidence above.
+Repeat that smoke after a protocol-affecting upgrade: run one real multi-step tool-loop turn with credentials in place, confirm the run-scoped `started`/`terminal` counts are still exactly one each, and confirm an Escape still yields `terminal` with `cancelled`.
+A build that ever split one turn across several runs would make a settled log ambiguous, which is a classifier change rather than a note in this file.
 
 The portable counterparts that run in ordinary CI are `tests/fm-muse-harness.test.sh`, `tests/fm-tmux-agent-liveness.test.sh`, `tests/fm-composer-lib.test.sh`, and `tests/fm-composer-ghost.test.sh`.

--- a/tests/fm-muse-harness.test.sh
+++ b/tests/fm-muse-harness.test.sh
@@ -615,8 +615,8 @@ EOF
   printf 'sessions_root=%s\nworkspace_root=%s\n' "$root" "$dir/my-ws" > "$state/$id.muse-session"
   verdict=$(classify_muse "$state" "$id")
   # This task's own log is settled; the OTHER task's open run must not leak in
-  # as busy. With the idle half still gated, settled reads unknown.
-  [ "$verdict" = "unknown muse-session-log" ] \
+  # as busy. With the idle half verified, this task's settled log reads idle.
+  [ "$verdict" = "idle muse-session-log" ] \
     || fail "binding leaked another workspace's run state: got '$verdict'"
 
   printf 'sessions_root=%s\nworkspace_root=%s\n' "$root" "$dir/other-ws" > "$state/$id.muse-session"
@@ -645,7 +645,7 @@ EOF
   printf 'sessions_root=%s\nworkspace_root=%s\n' \
     "$root" "$dir/ws[1]" > "$state/$id.muse-session"
   verdict=$(classify_muse "$state" "$id")
-  [ "$verdict" = "unknown muse-session-log" ] \
+  [ "$verdict" = "idle muse-session-log" ] \
     || fail "a bracketed workspace imported another session's busy state: got '$verdict'"
   pass "workspace bindings compare decoded paths literally"
 }
@@ -855,44 +855,30 @@ EOF
   pass "every unproven muse binding classifies unknown rather than idle"
 }
 
-# The idle half stays gated until a credentialed multi-step run proves one turn
-# stays inside one run. Until then a settled log must not read idle.
-test_settled_log_stays_unknown_while_the_idle_gate_is_closed() {
-  local dir state id root verdict gate
-  dir="$TMP_ROOT/idlegate"
+# The credentialed multi-step smoke proved one real turn stays inside one run
+# pair, so a settled log is a finished turn and reads idle with no opt-in. Both
+# terminal shapes settle: a completed turn and an interrupted one.
+test_settled_log_reads_idle() {
+  local dir state id root verdict terminal
+  dir="$TMP_ROOT/idle"
   state="$dir/state"
   root="$dir/sessions"
-  id=gatetask
   mkdir -p "$state"
-  write_session_log "$root" 2026 08 05 settled "$dir/ws" >/dev/null <<EOF
+
+  for terminal in completed cancelled; do
+    id="idle-$terminal"
+    write_session_log "$root" 2026 08 05 "settled-$terminal" "$dir/ws-$terminal" >/dev/null <<EOF
 $(muse_log_run_started r1)
-$(muse_log_run_terminal r1 completed)
+$(muse_log_run_terminal r1 "$terminal")
 EOF
-  printf 'sessions_root=%s\nworkspace_root=%s\n' "$root" "$dir/ws" > "$state/$id.muse-session"
+    printf 'sessions_root=%s\nworkspace_root=%s\n' \
+      "$root" "$dir/ws-$terminal" > "$state/$id.muse-session"
 
-  verdict=$(classify_muse "$state" "$id")
-  [ "$verdict" = "unknown muse-session-log" ] \
-    || fail "a settled log classified '$verdict' while the idle gate is closed"
-
-  gate=$(
-    # shellcheck source=bin/fm-busy-lib.sh
-    . "$ROOT/bin/fm-busy-lib.sh"
-    fm_busy_muse_idle_verified && printf open || printf closed
-  )
-  [ "$gate" = closed ] \
-    || fail "the muse idle gate is open; docs/verification/muse.md must carry the credentialed evidence"
-
-  # Opening the gate must flip exactly this verdict and nothing else, so the
-  # deferred smoke has a one-line landing point rather than a redesign.
-  verdict=$(
-    # shellcheck source=bin/fm-busy-lib.sh
-    . "$ROOT/bin/fm-busy-lib.sh"
-    FM_BUSY_MUSE_IDLE_VERIFIED_VERSIONS='0.1.0-R708.1'
-    fm_busy_classify tmux fake:0 muse "$id" "$state"
-  )
-  [ "$verdict" = "idle muse-session-log" ] \
-    || fail "opening the idle gate did not make a settled log idle: got '$verdict'"
-  pass "a settled log stays unknown until the idle gate opens, then reads idle"
+    verdict=$(classify_muse "$state" "$id")
+    [ "$verdict" = "idle muse-session-log" ] \
+      || fail "a log settled by a '$terminal' terminal classified '$verdict'"
+  done
+  pass "a settled session log reads idle for both completed and interrupted turns"
 }
 
 # muse records nothing, so it must trust no record source. A trusted source with
@@ -931,5 +917,5 @@ test_session_log_cache_reuses_and_refreshes_binding
 test_cached_session_revalidates_after_namespace_change
 test_subagent_logs_are_excluded
 test_missing_and_unreadable_bindings_are_unknown_never_idle
-test_settled_log_stays_unknown_while_the_idle_gate_is_closed
+test_settled_log_reads_idle
 test_muse_trusts_no_record_sources


### PR DESCRIPTION
## Intent

Open up muse (Muse Code) crewmate idle busy-state detection now that the credentialed smoke evidence exists, and - per an explicit later captain decision that supersedes the original task text - REMOVE the idle gate entirely rather than opening it as a version allowlist.

Original task: the muse busy-state classifier in bin/fm-busy-lib.sh folds muse's durable session event log. Its BUSY half was always trusted (an open run is positive proof a turn is in flight), but its IDLE half was held behind an opt-in, fm_busy_muse_idle_verified / FM_BUSY_MUSE_IDLE_VERIFIED_VERSIONS, because a settled log only proves no run is open at that instant. If a real multi-step turn had spanned several runs, an ungated idle would have reported a working crewmate as finished, so a settled log classified 'unknown'. The credentialed multi-step smoke that would settle the question was deferred until a META_API_KEY was available. It has now been run.

Evidence already collected (do not re-run the smoke): on Muse Code 0.1.0-R708.1, model muse-spark-1.2-contributor, provider meta, authenticated through stored ~/.config/muse/auth.json so the key never entered argv. Multi-step turn, session log ~/.local/share/muse/sessions/2026/08/06/629b3bc1-5dd7-4a0d-a901-69701850922c/session.jsonl: exactly ONE run started/terminal pair brackets the whole 828-record turn, terminal=completed, turn_duration_ms=75243, 23 tool batches inside it. Interrupt turn, session log .../e4e0b4f4-38d0-46dc-b669-dfb5de92e0e0/session.jsonl: five consecutive in-flight samples read busy, and an Escape mid tool loop closed the run with terminal=cancelled reason='cancelled during model step' rather than leaving it open.

Captain decision driving this change: do NOT keep the gate as a version list or boolean. Delete fm_busy_muse_idle_verified and FM_BUSY_MUSE_IDLE_VERIFIED_VERSIONS and every branch that treated a settled log as unknown, so a settled session log classifies 'idle muse-session-log' unconditionally. Busy is unchanged (open run => busy). Resolution failures - no sidecar binding, no matching log, an unreadable or run-free log - deliberately stay 'unknown', because those prove nothing about the turn either way.

Supporting rationale recorded in the code comment and docs: a version allowlist would have been false precision, because the session log's own metadata carries only semver 0.1.0 and a build sha and cannot distinguish this build from another 0.1.0 release.

Accompanying deliverables, all deliberate: docs/verification/muse.md replaces its 'Deferred: the credentialed multi-step smoke' section with dated 2026-08-06 completed evidence (log paths, exact commands and observed counts, the interrupt result) and explains the gate's removal, while keeping post-upgrade refresh guidance because muse auto-updates its binary underneath the fleet. That doc also records a correction found while verifying: the previously suggested command grep -c '"event":{"kind":"started"' returns 56 on that log rather than 1, because every tool batch effect reuses the same inner event shape, so the count must be scoped to '"kind":"run"'. .agents/skills/harness-adapters/SKILL.md updates the muse busy/idle facts to state idle is trusted from a settled session log with no version allowlist. bin/fm-spawn.sh drops a now-stale 'and the idle gate' cross-reference in a comment. tests/fm-muse-harness.test.sh replaces the gate open/closed test with one asserting default-on idle for BOTH completed and cancelled terminals, and two neighbouring tests that previously asserted 'unknown' only as a weak proxy for 'did not leak another session's state' now assert 'idle' directly, which is a strictly stronger assertion.

This is firstmate's own shared tracked material, so firstmate-coding-guidelines applies: one sentence per line in tracked Markdown, plain dash never an em dash, no agent name as commit co-author, bin/*.sh shellcheck-clean via bin/fm-lint.sh, tests colocated in tests/ exercising behavior through the executable interface rather than asserting implementation source text, and docs/verification records carrying dated commands and output rather than task chronology.

Delivery: no-mistakes pipeline to a PR. Do not merge it.

## What Changed

- Remove the Muse idle gate so settled completed or cancelled session logs classify as idle, while open runs remain busy and resolution failures remain unknown.
- Record the credentialed multi-step and interrupt evidence, corrected run-scoped counting command, and post-upgrade refresh guidance.
- Update harness guidance and executable tests for default-on idle detection and session isolation.

## Risk Assessment

✅ Low: The change is narrowly scoped, preserves unresolved Muse states as unknown, and conforms to the authoritative requirement to trust settled logs without any idle gate or version allowlist.

## Testing

Two broad subject-script attempts were interrupted before reaching the changed cases; the focused executable slice passed, and direct before/after evidence showed completed and cancelled logs changed from unknown to idle while open remains busy and run-free or unresolved inputs remain unknown.

<details>
<summary>Evidence: Before/after Muse classifier transcript</summary>

<code>base completed: unknown muse-session-log&#10;target completed: idle muse-session-log&#10;target cancelled: idle muse-session-log&#10;target open: busy muse-session-log&#10;target run-free: unknown muse-session-log&#10;target unbound: unknown muse-session-log</code>

```text
Muse supervision classifier transcript
======================================
base completed:   unknown muse-session-log
target completed: idle muse-session-log
target cancelled: idle muse-session-log
target open:      busy muse-session-log
target run-free:  unknown muse-session-log
target unbound:   unknown muse-session-log
```
</details>
<details>
<summary>Evidence: Focused Muse regression output</summary>

`Six focused executable behavior cases passed, covering lifecycle folding, nested decoys, binding isolation, literal workspace matching, unresolved inputs, and completed/cancelled idle.`

```text
ok - the run fold tracks open, settled, interrupted, reopened, and run-free logs
ok - a nested terminal record never settles an in-flight run
ok - the session binding folds only the log matching this task's worktree
ok - workspace bindings compare decoded paths literally
ok - every unproven muse binding classifies unknown rather than idle
ok - a settled session log reads idle for both completed and interrupted turns
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- 🚨 `bin/fm-busy-lib.sh:274` - The required criterion says the code comment and docs must explain that a version allowlist would be false precision because Muse records only semver 0.1.0 and a build SHA. This new comment records only the smoke result, docs merely say the opt-in was not pinned, and line 69 still references a nonexistent &#34;verification gate.&#34; Add the required rationale to both owners and remove the stale gate reference.

🔧 Fix: Document Muse idle trust and remove stale gate reference
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash tests/fm-muse-harness.test.sh` attempted twice; the execution harness interrupted both broad runs before the changed busy-state cases, so they were not treated as passing evidence.</code>
- <code>Executed focused cases `test_run_fold_tracks_open_and_settled_turns`, `test_nested_terminal_record_does_not_settle_a_run`, `test_binding_selects_the_matching_main_log`, `test_workspace_binding_treats_glob_characters_literally`, `test_missing_and_unreadable_bindings_are_unknown_never_idle`, and `test_settled_log_reads_idle` against the checked-out classifier.</code>
- <code>Built Muse-format session logs and invoked `fm_busy_classify` at base `930ca7627a30124ec22951b0e12daf80f2e19e6b` and target `03466672187f97ba1a1d676c0a61dc6f04a2d5df` for completed, cancelled, open, run-free, and unbound states.</code>
- <code>Verified `git status --short` remained empty after testing.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
