### PR TITLE
fix(herdr): make the herdr adapter usable on Windows

### DIFF
--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -501,18 +501,30 @@ fm_backend_herdr_presentation_lock_namespace_valid() {
 # it would turn JSON null into the literal string "null"). Canonicalizes the
 # parent directory when that directory exists so symlink parents such as /tmp
 # -> /private/tmp cannot yield two lock identities for the same socket.
-# fm_backend_herdr_canonical_socket_path: normalize one absolute Unix-socket
-# path so two spellings of the same socket compare equal. Refuses a relative
-# or empty path. An unresolvable directory is left as-is rather than treated as
-# a failure, so a socket whose directory was removed still compares by its own
+# fm_backend_herdr_canonical_socket_path: normalize one absolute socket path so
+# two spellings of the same socket compare equal. Refuses a relative or empty
+# path. An unresolvable directory is left as-is rather than treated as a
+# failure, so a socket whose directory was removed still compares by its own
 # literal path. Single owner for every socket-identity comparison in this
 # adapter (the presentation session lock and the launcher-identity same-session
 # proof both use it).
+#
+# Two absolute spellings are accepted: a POSIX path, and a Windows drive-letter
+# path such as "C:\Users\me\AppData\Roaming\herdr\herdr.sock". Herdr on Windows
+# reports the drive-letter form in both HERDR_SOCKET_PATH and `session list
+# --json`, so rejecting it refused every spawn on that platform with an
+# unusable-socket error. Backslashes are folded to forward slashes first, which
+# both makes the two Windows spellings compare equal and lets dirname/basename
+# and the directory canonicalization below treat the path uniformly; on a Git
+# Bash host that canonicalization then yields the POSIX form (/c/Users/...).
+# The path is only ever an identity token compared against another value from
+# this same function - it is never opened - so folding separators is safe.
 fm_backend_herdr_canonical_socket_path() {  # <socket-path>
   local socket=$1 sock_dir sock_base
   [ -n "$socket" ] || return 1
   case "$socket" in
     /*) ;;
+    [A-Za-z]:[\\/]*) socket=$(printf '%s' "$socket" | tr '\\' '/') ;;
     *) return 1 ;;
   esac
   sock_dir=$(dirname "$socket")
@@ -1275,8 +1287,17 @@ fm_backend_herdr_workspace_find_all() {  # <session>
   # compile error that `2>/dev/null` would silently swallow, making this find
   # ALWAYS return empty and every spawn mint a fresh "firstmate" workspace
   # (the workspace leak).
+  # fm_backend_herdr_strip_cr: jq on Windows opens stdout in text mode and ends
+  # every record with CRLF. A command substitution drops only the TRAILING
+  # carriage return, so a single-value read comes back clean while a multi-line
+  # read keeps an interior CR on every line but the last. Any consumer that
+  # splits such a capture then carries a stray CR into an id it passes back to
+  # herdr, or into an operator-facing message. Every multi-line jq capture in
+  # this adapter is stripped at its source for that reason; single-value reads
+  # need no strip and are deliberately left alone.
   printf '%s' "$list" | jq -r --arg want "$label" \
-    '.result.workspaces[]? | select(.label == $want) | .workspace_id' 2>/dev/null
+    '.result.workspaces[]? | select(.label == $want) | .workspace_id' 2>/dev/null \
+    | tr -d '\r'
 }
 
 # fm_backend_herdr_workspace_find: this HOME's own workspace id inside
@@ -1791,6 +1812,9 @@ fm_backend_herdr_create_task() {  # <container> <label> <cwd> <seeded_default_ta
     echo "error: could not parse herdr tab list output for workspace $wsid (session $session)" >&2
     return 1
   }
+  # Stripped after capture, not through a pipe, so jq's own exit status above
+  # still decides the parse failure. See fm_backend_herdr_workspace_find_all.
+  dup_tabs=${dup_tabs//$'\r'/}
   dup_tab_ids=""
   if [ -n "$dup_tabs" ]; then
     while IFS= read -r dup; do
@@ -1830,6 +1854,7 @@ EOF
     fi
     remaining_dup_tabs=$(printf '%s' "$list" | jq -r --arg want "$label" --arg replacement "$tab_id" \
       '.result.tabs[]? | select(.label == $want and .tab_id != $replacement) | .tab_id' 2>/dev/null)
+    remaining_dup_tabs=${remaining_dup_tabs//$'\r'/}
     remaining_dup_tabs=${remaining_dup_tabs//$'\n'/ }
     if [ -n "$remaining_dup_tabs" ]; then
       echo "error: failed to remove preexisting herdr tab(s) $remaining_dup_tabs for label '$label' in workspace $wsid (session $session)" >&2

--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -487,13 +487,53 @@ fm_backend_herdr_presentation_lock_namespace_uid() {
   fi
 }
 
+# fm_backend_herdr_presentation_lock_namespace_modes_representable: true when
+# <parent> is on a filesystem that can actually store POSIX permission bits.
+#
+# Probed, not inferred from platform or mount options: create a directory, ask
+# for 0700, and read back what was stored. A filesystem that silently discards
+# the request answers for itself. The probe directory is removed either way.
+#
+# This exists because Git Bash mounts NTFS `noacl` by default, where chmod is a
+# silent no-op and every directory reads 755. Asserting an exact mode there is
+# asserting something the filesystem cannot express.
+fm_backend_herdr_presentation_lock_namespace_modes_representable() {  # <parent>
+  local parent=$1 probe mode
+  [ -d "$parent" ] || return 1
+  probe=$(mktemp -d "$parent/.fm-modeprobe.XXXXXX" 2>/dev/null) || return 1
+  chmod 700 "$probe" 2>/dev/null
+  mode=$(fm_backend_herdr_presentation_lock_namespace_mode "$probe")
+  rmdir "$probe" 2>/dev/null
+  [ "$mode" = 700 ]
+}
+
+# Ownership is the load-bearing assertion and is never relaxed: the namespace
+# must be a real directory, not a symlink, owned by this user.
+#
+# The exact-700 assertion additionally requires that no OTHER user can reach the
+# lock files. Where the filesystem can express that, it is still required
+# verbatim. Where it provably cannot - Git Bash's `noacl` NTFS mount, which
+# reports 755 for every directory and discards chmod - requiring it made the
+# namespace permanently unobtainable, which took teardown down with no manual
+# recovery rather than making anything safer.
+#
+# On that mount Git Bash maps /tmp to the user's own profile temp directory
+# (`usertemp`), so the namespace is not in a shared location and Windows' own
+# access control, not the emulated mode bits, is what actually guards it.
 fm_backend_herdr_presentation_lock_namespace_valid() {
   local dir=$1 expected_uid owner mode
   [ -d "$dir" ] && [ ! -L "$dir" ] || return 1
   expected_uid=$(id -u 2>/dev/null) || return 1
   owner=$(fm_backend_herdr_presentation_lock_namespace_uid "$dir") || return 1
   mode=$(fm_backend_herdr_presentation_lock_namespace_mode "$dir") || return 1
-  [ "$owner" = "$expected_uid" ] && [ "$mode" = 700 ]
+  [ "$owner" = "$expected_uid" ] || return 1
+  [ "$mode" = 700 ] && return 0
+  # Not 700: only acceptable when this filesystem cannot store modes at all.
+  fm_backend_herdr_presentation_lock_namespace_modes_representable "$(dirname "$dir")"
+  case $? in
+    0) return 1 ;;  # modes work here, so 755 is a real permission problem
+    *) return 0 ;;  # modes are unrepresentable; ownership is the guarantee
+  esac
 }
 
 # Resolve the one verified running named-session socket path as an absolute

--- a/tests/fm-backend-herdr.test.sh
+++ b/tests/fm-backend-herdr.test.sh
@@ -2225,6 +2225,70 @@ SH
   pass "herdr presentation ordering: missing owning parent is warning-only and read-only"
 }
 
+canon_socket() {  # <socket-path> -> canonical form on stdout, adapter's exit code
+  bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_canonical_socket_path "$1"' "$ROOT" "$1"
+}
+
+test_canonical_socket_path_accepts_a_windows_drive_letter_path() {
+  local dir back fwd status
+  # Herdr on Windows reports a drive-letter socket path in BOTH
+  # HERDR_SOCKET_PATH and `session list --json`. Refusing it made the
+  # launcher-identity same-session proof fail, which refused every spawn on
+  # that platform with "reports an unusable socket path".
+  dir="$TMP_ROOT/canon-windows"; mkdir -p "$dir"
+
+  back=$(canon_socket 'C:\Users\me\AppData\Roaming\herdr\herdr.sock') \
+    || fail "a Windows drive-letter socket path must be accepted, not refused"
+  [ -n "$back" ] || fail "a Windows socket path canonicalised to the empty string"
+
+  # The two Windows spellings of one socket must compare equal, which is the
+  # whole contract of this function.
+  fwd=$(canon_socket 'C:/Users/me/AppData/Roaming/herdr/herdr.sock') \
+    || fail "a forward-slash Windows socket path must be accepted"
+  [ "$back" = "$fwd" ] \
+    || fail "two spellings of one Windows socket must compare equal: $back vs $fwd"
+
+  # A drive letter is not a licence to accept a relative path after it.
+  status=0; canon_socket 'C:relative\herdr.sock' >/dev/null 2>&1 || status=$?
+  expect_code 1 "$status" "a drive-relative path must still be refused"
+
+  pass "fm_backend_herdr_canonical_socket_path: accepts a Windows drive-letter socket path"
+}
+
+test_canonical_socket_path_still_refuses_and_canonicalises_posix() {
+  local dir out status
+  dir="$TMP_ROOT/canon-posix"; mkdir -p "$dir/sockdir"
+  : > "$dir/sockdir/fmtest.sock"
+
+  out=$(canon_socket "$dir/sockdir/fmtest.sock") || fail "a POSIX socket path must still be accepted"
+  [ "$out" = "$(cd "$dir/sockdir" && pwd -P)/fmtest.sock" ] \
+    || fail "a POSIX socket path must still canonicalise through its parent directory: $out"
+
+  status=0; canon_socket 'relative/herdr.sock' >/dev/null 2>&1 || status=$?
+  expect_code 1 "$status" "a relative socket path must still be refused"
+
+  status=0; canon_socket '' >/dev/null 2>&1 || status=$?
+  expect_code 1 "$status" "an empty socket path must still be refused"
+
+  pass "fm_backend_herdr_canonical_socket_path: POSIX and refusal behaviour unchanged"
+}
+
+test_canonical_socket_path_folds_separators_when_the_directory_is_gone() {
+  local back fwd
+  # An unresolvable directory is left as-is by contract, so the separator fold
+  # is what keeps the two Windows spellings comparing equal in that case too.
+  back=$(canon_socket 'Z:\no\such\dir\herdr.sock') \
+    || fail "a Windows path with a missing directory must not be refused"
+  fwd=$(canon_socket 'Z:/no/such/dir/herdr.sock') \
+    || fail "a forward-slash Windows path with a missing directory must not be refused"
+  [ "$back" = "$fwd" ] \
+    || fail "missing-directory Windows spellings must still compare equal: $back vs $fwd"
+  case "$back" in
+    *\\*) fail "a canonicalised Windows path must not retain backslashes: $back" ;;
+  esac
+  pass "fm_backend_herdr_canonical_socket_path: separators fold when the directory is gone"
+}
+
 test_presentation_session_lock_path_is_shared_across_homes() {
   local dir log resp fb path_a path_b path_other path_tmp path_private
   dir="$TMP_ROOT/presentation-session-lock"; mkdir -p "$dir/responses" "$dir/sockdir"
@@ -4005,6 +4069,9 @@ test_projection_order_ambiguous_existing_block_is_read_only
 test_projection_order_anchors_the_parent_by_exact_id
 test_projection_order_foreign_new_child_before_parent_is_read_only
 test_projection_order_missing_parent_is_read_only
+test_canonical_socket_path_accepts_a_windows_drive_letter_path
+test_canonical_socket_path_still_refuses_and_canonicalises_posix
+test_canonical_socket_path_folds_separators_when_the_directory_is_gone
 test_presentation_session_lock_path_is_shared_across_homes
 test_presentation_session_lock_path_rejects_malformed_socket
 test_projection_order_rejects_malformed_socket

--- a/tests/fm-backend-herdr.test.sh
+++ b/tests/fm-backend-herdr.test.sh
@@ -2273,6 +2273,67 @@ test_canonical_socket_path_still_refuses_and_canonicalises_posix() {
   pass "fm_backend_herdr_canonical_socket_path: POSIX and refusal behaviour unchanged"
 }
 
+ns_valid() {  # <dir> <representable: yes|no> -> adapter's exit code
+  # Stub the filesystem-capability probe so BOTH branches are testable on any
+  # host: this suite must not depend on whether the runner's own filesystem can
+  # store POSIX mode bits.
+  bash -c '
+    . "$0/bin/backends/herdr.sh"
+    fm_backend_herdr_presentation_lock_namespace_modes_representable() {
+      [ "'"$2"'" = yes ]
+    }
+    fm_backend_herdr_presentation_lock_namespace_valid "$1"
+  ' "$ROOT" "$1"
+}
+
+test_lock_namespace_requires_exact_mode_where_the_filesystem_supports_it() {
+  local dir status
+  dir="$TMP_ROOT/ns-modes-work/ns"; mkdir -p "$dir"
+  chmod 755 "$dir" 2>/dev/null
+
+  # Where modes are real, a non-700 namespace is a genuine permission problem
+  # and must still be refused - this is the property the relaxation must not eat.
+  status=0; ns_valid "$dir" yes || status=$?
+  expect_code 1 "$status" "a 755 namespace on a mode-capable filesystem must still be refused"
+
+  pass "lock namespace: exact mode is still required where the filesystem can store it"
+}
+
+test_lock_namespace_accepts_owned_dir_where_modes_are_unrepresentable() {
+  local dir status
+  dir="$TMP_ROOT/ns-modes-dead/ns"; mkdir -p "$dir"
+  chmod 755 "$dir" 2>/dev/null
+
+  # Git Bash's noacl NTFS mount reports 755 for everything and discards chmod.
+  # Requiring 700 there made the namespace permanently unobtainable, which took
+  # teardown down with it and made nothing safer.
+  status=0; ns_valid "$dir" no || status=$?
+  expect_code 0 "$status" "an owned namespace must be accepted where modes cannot be stored"
+
+  pass "lock namespace: ownership carries it where the filesystem cannot store modes"
+}
+
+test_lock_namespace_never_relaxes_ownership_or_symlink_checks() {
+  local dir link status
+  dir="$TMP_ROOT/ns-guards/ns"; mkdir -p "$dir"
+  link="$TMP_ROOT/ns-guards/link"; ln -sfn "$dir" "$link" 2>/dev/null || true
+
+  # Ownership and the symlink refusal are load-bearing and are relaxed by
+  # NEITHER branch, so both are asserted with the probe forced permissive.
+  if [ -L "$link" ]; then
+    status=0; ns_valid "$link" no || status=$?
+    expect_code 1 "$status" "a symlinked namespace must be refused even where modes cannot be stored"
+  fi
+
+  status=0; ns_valid "$TMP_ROOT/ns-guards/missing" no || status=$?
+  expect_code 1 "$status" "a missing namespace must be refused"
+
+  status=0; ns_valid "$TMP_ROOT/ns-guards/ns/../ns" no || status=$?
+  expect_code 0 "$status" "an owned real directory must still resolve"
+
+  pass "lock namespace: ownership and symlink refusals survive the relaxation"
+}
+
 test_canonical_socket_path_folds_separators_when_the_directory_is_gone() {
   local back fwd
   # An unresolvable directory is left as-is by contract, so the separator fold
@@ -4069,6 +4130,9 @@ test_projection_order_ambiguous_existing_block_is_read_only
 test_projection_order_anchors_the_parent_by_exact_id
 test_projection_order_foreign_new_child_before_parent_is_read_only
 test_projection_order_missing_parent_is_read_only
+test_lock_namespace_requires_exact_mode_where_the_filesystem_supports_it
+test_lock_namespace_accepts_owned_dir_where_modes_are_unrepresentable
+test_lock_namespace_never_relaxes_ownership_or_symlink_checks
 test_canonical_socket_path_accepts_a_windows_drive_letter_path
 test_canonical_socket_path_still_refuses_and_canonicalises_posix
 test_canonical_socket_path_folds_separators_when_the_directory_is_gone


### PR DESCRIPTION
Herdr is the only runtime available on the Windows host these were found on (tmux, zellij, orca and cmux are all absent), so every dispatch goes through it. Three POSIX-only assumptions in the adapter each refused work outright. Two of them are fixed here; both are narrow and independently useful on any platform.

## 1. Socket path assumed POSIX

`fm_backend_herdr_canonical_socket_path` accepted only paths starting with `/`. Herdr on Windows reports `C:\Users\...\AppData\Roaming\herdr\herdr.sock` in both `HERDR_SOCKET_PATH` and `herdr session list --json`, so the launcher-identity check refused every spawn with "reports an unusable socket path". Both sides report the identical value, so accepting the drive-letter spelling is sufficient. Separators fold so the two Windows spellings compare equal, including when the directory no longer resolves.

## 2. jq emits CRLF

jq on that host opens stdout in text mode: `printf '{"a":["x","y"]}' | jq -r '.a[]'` returns `x\r\ny\r\n`. Command substitution strips only the trailing CR, so single-value reads are clean but multi-line reads keep an interior CR on every line but the last. That corrupted ids split out of multi-line captures and operator-facing messages. Three multi-line captures in the adapter now strip at source.

Not audited here: jq is used throughout `bin/`, so other scripts capturing multi-line jq output on Windows may have the same defect.

## 3. `mkdir -m 700` cannot produce mode 700 on NTFS

The presentation lock namespace had to be owned by this user **and** be exactly mode `700`. Git Bash mounts NTFS `noacl` by default, where `chmod` is a silent no-op and every directory reads `755`, so the assertion could never hold. The namespace was permanently unobtainable, and because `teardown_herdr_preflight_target` resolves that lock for every herdr endpoint, teardown refused forever with no manual recovery: a finished task could not be collected, its metadata could not be cleared, and supervision stayed permanently "needed" as a result.

Ownership and the symlink refusal are unchanged. The exact-700 assertion is still required verbatim wherever the filesystem can store it; only where the filesystem provably cannot is ownership accepted as the available guarantee.

Capability is **probed, not inferred**: create a directory, ask for `0700`, read back what was stored. A filesystem that discards the request answers for itself, so no `uname` or `/etc/fstab` parsing decides a security-relevant branch. The relaxation is also narrow in practice: on that mount Git Bash maps `/tmp` to the user's own profile temp directory (`usertemp`), so the namespace is not in a shared location and Windows access control, rather than emulated mode bits, is what actually guards it.

This also repairs `test_presentation_session_lock_path_is_shared_across_homes`, which fails on unmodified `main` on such a host.

## Testing

`tests/fm-backend-herdr.test.sh` against this branch on the Windows host: **169 pass, 0 fail, exit 0** - the full suite runs clean to completion. Unmodified `main` aborts at test 20 on the CRLF fault, so most of the suite was never reached there at all.

New coverage accompanies each fix: drive-letter socket acceptance, unchanged POSIX and refusal behaviour, separator folding when the directory is gone, and the probed-capability namespace check.

Two notes for anyone else running the suite on Windows:
- It is slow, and it emits `dofork: child -1 ... Resource temporarily unavailable` retry noise from Git Bash partway through. That is fork-retry churn, not failure; given enough time the suite completes cleanly. A short timeout will make it look like a hang.
- ShellCheck is not installable on that host, so `bin/fm-lint.sh` could not be run for CI parity. Lint review is worth a close look.

A fourth Windows fault is **not** addressed here: `herdr pane get` reports no `foreground_cwd` field at all, so the worktree-entry poll cannot succeed. A candidate fix exists but is deliberately held back until a real spawn is observed to succeed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F7L1m56txHs7hrNcTeq7AP