### PR TITLE
fix(teardown): gate the herdr presentation lock on the projection being on

### DIFF
--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -1893,6 +1893,7 @@ teardown_herdr_require_prerequisites() {  # <task-id>
     fm_backend_herdr_workspace_presence_state \
     fm_backend_herdr_endpoint_confirmed_gone \
     fm_backend_herdr_explicit_close_pane_confirmed \
+    fm_backend_herdr_presentation_enabled \
     fm_backend_herdr_presentation_session_lock_path; do
     if ! declare -F "$prerequisite" >/dev/null 2>&1; then
       echo "error: herdr teardown prerequisites are unavailable for $task_id; nothing was changed - restore the adapter and rerun teardown" >&2
@@ -1927,6 +1928,16 @@ teardown_herdr_preflight_target() {  # <target> <task-id>
       return 1
       ;;
   esac
+  # The session lock exists to serialize the presentation projection's workspace
+  # reordering and focus restoration across concurrent pane closes. A home that
+  # opted out of the projection has no projection to serialize, so requiring the
+  # lock made teardown depend on a feature that is switched off - and an
+  # unobtainable lock then refused teardown outright with no manual recovery.
+  # fm-spawn.sh already gates its projection work on this same predicate; this
+  # is the matching gate on the teardown side.
+  if ! fm_backend_herdr_presentation_enabled "$CONFIG"; then
+    return 0
+  fi
   if ! lock_path=$(fm_backend_herdr_presentation_session_lock_path "$session"); then
     echo "error: herdr session presentation lock could not be resolved for $task_id; nothing was changed - rerun teardown once the session is reachable and unambiguous" >&2
     return 1
@@ -2293,6 +2304,14 @@ if [ "$HERDR_PRESENTATION_RETIRE_CANDIDATE" = 1 ]; then
   fi
 elif [ "$BACKEND" = herdr ]; then
   if teardown_herdr_session_lock_held "$TEARDOWN_HERDR_SESSION"; then
+    fm_backend_herdr_kill_serialized "$TEARDOWN_HERDR_SESSION" "$TEARDOWN_HERDR_PANE" 2>/dev/null || true
+  elif ! fm_backend_herdr_presentation_enabled "$CONFIG"; then
+    # The home opted out of the projection, so nothing here manages workspace
+    # ordering and there is no projection work to serialize against. The
+    # focus-preserving close still runs; it just no longer demands a lock whose
+    # only purpose is ordering a projection this home does not have. Without
+    # this arm an unobtainable lock skipped every close, and the confirm-gone
+    # check below then refused teardown forever with no manual recovery.
     fm_backend_herdr_kill_serialized "$TEARDOWN_HERDR_SESSION" "$TEARDOWN_HERDR_PANE" 2>/dev/null || true
   else
     echo "warning: herdr session presentation lock path is unavailable; skipping the pane close rather than closing unlocked" >&2

--- a/tests/fm-teardown.test.sh
+++ b/tests/fm-teardown.test.sh
@@ -1498,6 +1498,81 @@ SH
   pass "herdr flat teardown refuses before returning the isolated copy under lock contention and the retry completes cleanly"
 }
 
+# A home that opted out of the presentation projection has no projection to
+# serialize, so the session lock is not its concern. Before this gate, teardown
+# resolved and acquired that lock unconditionally, which made cleanup depend on
+# a feature that was switched off - and on a host where the lock namespace can
+# never satisfy its own validity check (Git Bash over a noacl NTFS mount cannot
+# produce mode 700), that turned into a permanent refusal with no manual
+# recovery. fm-spawn.sh already gates its projection work on the same predicate.
+# test_herdr_flat_teardown_refuses_orphaning_records_then_retry_completes above
+# is the negative control: with the projection left at its default (on), a
+# contended lock must still refuse.
+test_herdr_flat_teardown_opted_out_of_presentation_ignores_the_session_lock() {
+  local case_dir log closed lock ready release holder_pid thlog waited
+  case_dir=$(make_case herdr-presentation-opt-out)
+  write_meta "$case_dir" local-only ship
+  configure_flat_herdr_teardown_case "$case_dir"
+  log="$case_dir/herdr.log"; : > "$log"
+  closed="$case_dir/closed"
+  : > "$case_dir/state/task-x1.status"
+  : > "$case_dir/state/task-x1.turn-ended"
+  thlog="$case_dir/treehouse.log"; : > "$thlog"
+  cat > "$case_dir/fakebin/treehouse" <<SH
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> "$thlog"
+exit 0
+SH
+  chmod +x "$case_dir/fakebin/treehouse"
+  printf 'off\n' > "$case_dir/config/herdr-presentation-spaces"
+
+  # Make the lock genuinely unavailable, so that a teardown which still reached
+  # for it would fail. Two ways to be unavailable, and both must be tolerated:
+  #   - the namespace resolves and another holder owns it (POSIX hosts), or
+  #   - the namespace cannot be validated at all, so no path resolves. That is
+  #     the Windows case this gate exists for: a noacl NTFS mount cannot produce
+  #     mode 700, so fm_backend_herdr_presentation_lock_namespace_valid can never
+  #     pass and the lock is permanently unobtainable.
+  holder_pid=""
+  release="$case_dir/lock-release"
+  if lock=$(FM_FAKE_HERDR_LOG="$log" FM_FAKE_HERDR_CLOSED="$closed" PATH="$case_dir/fakebin:$PATH" \
+    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_presentation_session_lock_path default' "$ROOT"); then
+    ready="$case_dir/lock-ready"
+    ROOT="$ROOT" LOCK="$lock" READY="$ready" RELEASE="$release" bash -c '
+      . "$ROOT/bin/fm-wake-lib.sh"
+      fm_lock_try_acquire "$LOCK" || exit 1
+      : > "$READY"
+      while [ ! -e "$RELEASE" ]; do sleep 0.1; done
+      fm_lock_release "$LOCK"
+    ' &
+    holder_pid=$!
+    waited=0
+    while [ ! -e "$ready" ] && [ "$waited" -lt 50 ]; do sleep 0.1; waited=$((waited + 1)); done
+    [ -e "$ready" ] || { : > "$release"; fail "herdr-presentation-opt-out: the contending lock holder never started"; }
+  fi
+
+  # The lock is unavailable for the whole run: an opted-out teardown must never
+  # reach for it, so this completing at all is the proof.
+  FM_FAKE_HERDR_LOG="$log" FM_FAKE_HERDR_CLOSED="$closed" FM_BACKEND_HERDR_IDLE_SHELL_PROOF_POLLS=1 \
+    run_teardown "$case_dir" --force > "$case_dir/stdout" 2> "$case_dir/stderr" \
+    || { : > "$release"; fail "herdr-presentation-opt-out: teardown refused while the projection was off: $(cat "$case_dir/stderr")"; }
+  : > "$release"
+  [ -z "$holder_pid" ] || wait "$holder_pid" 2>/dev/null || true
+
+  if grep -q "presentation lock" "$case_dir/stderr"; then
+    fail "herdr-presentation-opt-out: an opted-out teardown still reported a presentation lock problem: $(cat "$case_dir/stderr")"
+  fi
+  [ -e "$closed" ] || fail "herdr-presentation-opt-out: the pane was never closed"
+  [ -s "$thlog" ] || fail "herdr-presentation-opt-out: the isolated copy was never returned"
+  [ ! -e "$case_dir/state/task-x1.meta" ] \
+    || fail "herdr-presentation-opt-out: the completed teardown left the metadata behind"
+  [ ! -e "$case_dir/state/task-x1.status" ] \
+    || fail "herdr-presentation-opt-out: the completed teardown left the status record behind"
+  grep -q "teardown task-x1 complete" "$case_dir/stdout" \
+    || fail "herdr-presentation-opt-out: teardown did not report completion"
+  pass "herdr flat teardown ignores the session lock when the home opted out of the presentation projection"
+}
+
 test_herdr_flat_teardown_refuses_records_on_unparseable_presence() {
   local case_dir log closed rc
   case_dir=$(make_case herdr-garbage-presence)
@@ -2486,6 +2561,7 @@ test_local_only_force_overrides_unpushed
 test_teardown_missing_busy_sidecar_completes
 test_herdr_teardown_clears_escalation_marker
 test_herdr_flat_teardown_refuses_orphaning_records_then_retry_completes
+test_herdr_flat_teardown_opted_out_of_presentation_ignores_the_session_lock
 test_herdr_flat_teardown_refuses_records_on_unparseable_presence
 test_herdr_flat_teardown_preflight_refuses_before_changes
 test_forced_secondmate_herdr_child_preflight_refuses_before_changes


### PR DESCRIPTION
`fm-spawn.sh` already gates its projection work on `fm_backend_herdr_presentation_enabled`, but teardown reached for the presentation session lock **unconditionally**, at two sites: the endpoint preflight (`teardown_herdr_preflight_target`) and the plain pane close.

So a home that wrote `off` to `config/herdr-presentation-spaces` still had its cleanup depend on a feature it had switched off. That is an inconsistency on any platform - spawn honours the opt-out, teardown ignored it.

Where the lock namespace cannot satisfy its own validity check the consequence is worse than cosmetic. Teardown refuses, the task's state files are retained by design, supervision stays permanently "needed", and there is no manual recovery. `--force` does not help: it skips only the dirty and landed-work checks, and the same preflight runs in both branches.

Both sites now consult the same predicate. **Default behaviour is unchanged** - the projection is on unless a home opts out, so a contended lock still refuses exactly as before.

The focus-preserving close itself is kept in the opted-out path; it simply no longer demands a lock whose only purpose is ordering a projection this home does not have.

## Relationship to #1790

#1790 fixes the underlying reason the namespace can be unobtainable on Windows, and is the more important of the two. This one is independent: it is a real inconsistency in its own right, and it is what lets an opted-out home tear down cleanly regardless of why the lock is unavailable. Neither depends on the other, and they touch disjoint files.

## Testing

New `test_herdr_flat_teardown_opted_out_of_presentation_ignores_the_session_lock` makes the lock unavailable in both ways it can be unavailable - held by a contending process, or unresolvable because the namespace cannot be validated - and asserts teardown still completes, closes the pane, returns the isolated copy, and clears its records. The existing `test_herdr_flat_teardown_refuses_orphaning_records_then_retry_completes` is the negative control: with the projection at its default, a contended lock must still refuse.

Verified end to end against a real stuck task on the affected host: a finished task that had been uncollectable for a day tore down cleanly, state files cleared, worktree returned to the pool, and the delivered work intact on its branch.

`tests/fm-teardown.test.sh` reaches the same point on this branch as on unmodified `main` on that host (9 ok, then a pre-existing failure caused by the namespace fault that #1790 addresses), so this introduces no regression there.

ShellCheck is not installable on that host, so `bin/fm-lint.sh` could not be run for CI parity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F7L1m56txHs7hrNcTeq7AP