### PR TITLE
fix: read persisted session digest before acting

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -135,6 +135,7 @@ Do not reimplement it by separately running its lock, bootstrap, or initial wake
 Run-tier harness surfaces run this command for you at session open while the rest only nudge it, so confirm the digest is present in this session and run it yourself when it is not; `docs/sessionstart-nudge.md` owns adapter tiers, source routing, and compatibility.
 
 Read the complete digest once and trust it as this turn's startup and recovery input.
+If the harness shows only a preview and persists the full output to a file, read that file before acting.
 Do not separately re-read the context, backlog, metadata, or bulk status inputs it just printed unless a source was reported absent or corrupt, older history is specifically needed, or a targeted workflow must inspect before writing.
 An `ABSENT` captain, shared-captain, secondmate, or learnings file means the firstmate repo's built-in defaults, no shared captain preferences, no registered secondmates, or no captured learnings; rebuild an absent or stale project registry from the clones before dispatch.
 


### PR DESCRIPTION
## Intent

Add the smallest possible instruction so a firstmate session whose session-start digest was persisted/truncated to a preview reads the full persisted digest before acting.

Problem: bin/fm-session-start.sh runs at session open via the SessionStart hook and prints the full digest. It can exceed the harness inline-display limit - observed at ~70KB, where Claude Code persisted the hook output to a file and showed only a ~2KB inline preview. AGENTS.md section 3 already requires reading the COMPLETE digest once and trusting it. A session that treats the short preview as the digest silently misses the drained wake queue, OPEN DECISIONS, context, and fleet state.

Fix - MINIMAL instruction change ONLY. This is firstmate shared, tracked material, and the captain's explicit constraint is: do NOT bloat instructions.

Hard constraints from the captain (deliberate, already decided - not open questions):
- Do NOT add broad new prose, do NOT restate the existing contract, do NOT expand scope.
- The smallest surgical edit that closes the gap - ideally one clause or one short sentence folded into the existing section 3 read-once instruction, not a new subsection.
- Follow the firstmate-coding-guidelines size-discipline and one-owner rules: if exact truncation/persistence mechanics belong anywhere fuller, point to the owner rather than describing them inline. Deliberately NO new doc, NO new skill, NO cross-reference paragraph, NO test - the change is a single natural-language instruction sentence in an always-loaded instruction file whose only consumer is the reading agent.

Scope boundary (explicit exclusion): this is ONLY the truncation-safety instruction. It is independent of a separate scout task assessing whether the digest should be smaller - do NOT shrink the digest or change bin/fm-session-start.sh output here.

Implementation delivered: one sentence added to AGENTS.md section 3 immediately after the existing 'Read the complete digest once and trust it as this turn's startup and recovery input.' line: 'If the harness shows only a preview and persists the full output to a file, read that file before acting.' CLAUDE.md is a symlink to AGENTS.md, so it changes with it.

Acceptance criteria: AGENTS.md instructs the session to read the full persisted digest file when the digest is truncated/persisted rather than shown in full; the edit is minimal (a clause/sentence, not a new block); no restated contract, no scope creep; negligible AGENTS.md line growth; bin/fm-doc-audience-check.sh passes (verified: ok surfaces=65 local_links=204) and Markdown style is obeyed (one sentence per line, plain dash, no em dash).

## What Changed

- Instruct sessions to read the full persisted session-start digest before acting when the harness displays only a preview.

## Risk Assessment

✅ Low: The single-sentence instruction is minimal, correctly placed beside the authoritative read-once contract, closes the persisted-preview gap, and introduces no scope or ownership conflicts.

## Testing

Validated the instruction end to end with Claude Code 2.1.223 against a truncated SessionStart preview and persisted digest; the agent read the file and recovered the hidden decision and wake. The documentation check returned `ok surfaces=65 local_links=204`, `CLAUDE.md` targets `AGENTS.md`, the change adds exactly one line, evidence was captured, and the worktree is clean.

<details>
<summary>Evidence: Persisted digest end-to-end transcript</summary>

<code>Claude Code 2.1.223 called `Read` on the persisted digest before answering and recovered `decision-7` and `wake-42`, which were absent from the preview.</code>

```text
Focused live Claude Code evaluation (Claude Code 2.1.223, claude-haiku-4-5)

Scenario supplied to the real agent:
  SessionStart hook result: output exceeded the inline display limit.
  Preview: SESSION START DIGEST; routine bootstrap details only.
  The harness persisted the full output to persisted-session-start-digest.txt.
  What operational items must you handle before acting?

Observed agent action before answering:
  Read(/var/folders/0k/bf8mwt2n5qddzk24r20gfk0c0000gn/T/no-mistakes-evidence/01KZB45KW3XXYS3XJS9SPH1A7E/persisted-session-start-digest.txt)

The persisted-only items returned by the agent:
  decision-7: Captain approval required before retiring secondmate atlas.
  wake-42: Review the blocked atlas handoff before starting unrelated work.

Result: the real harness-loaded instruction caused the agent to read the full persisted digest before answering, recovering both an OPEN DECISION and a wake absent from the inline preview.
```
</details>
<details>
<summary>Evidence: Persisted digest fixture</summary>

`Synthetic full digest containing an OPEN DECISION and wake hidden from the inline preview.`

```text
SESSION START DIGEST

PREVIEW-COVERED CONTEXT:
Routine bootstrap details omitted from this test fixture.

OPEN DECISIONS:
decision-7: Captain approval is required before retiring secondmate atlas.

WAKE QUEUE:
wake-42: Review the blocked atlas handoff before starting unrelated work.

END SESSION START DIGEST
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `claude -p --model haiku --effort low --no-session-persistence --permission-mode dontAsk --allowedTools Read --add-dir /var/folders/0k/bf8mwt2n5qddzk24r20gfk0c0000gn/T/no-mistakes-evidence/01KZB45KW3XXYS3XJS9SPH1A7E --output-format stream-json --verbose '<simulated truncated SessionStart preview with persisted full-output path>'`
- `bin/fm-doc-audience-check.sh`
- <code>`readlink CLAUDE.md` and `git diff --numstat 8387039e0996fb27763f1191bed3596f61bed913..a60ca937fbb54e1f0d47cec70e57b492c334003a -- AGENTS.md`</code>
- `git status --short`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
