### PR TITLE
Exempt Cursor MCP: tool names from subagent guard

### DIFF
--- a/bin/fm-subagent-pretool-check.sh
+++ b/bin/fm-subagent-pretool-check.sh
@@ -150,6 +150,8 @@ LC_ALL=C NORMALIZED=$(printf '%s' "$TOOL" | tr '[:upper:]' '[:lower:]' | tr -cd 
 # blocking it would be a false positive with no bearing on fleet dispatch.
 case "$TOOL" in
   mcp__*) exit 0 ;;
+  # Cursor uses MCP: while Claude Code uses mcp__.
+  [Mm][Cc][Pp]:*) exit 0 ;;
 esac
 
 for allowed in $OBSERVE_ONLY_TOOLS $PLAN_ONLY_TOOLS; do

--- a/tests/fm-subagent-pretool-check.test.sh
+++ b/tests/fm-subagent-pretool-check.test.sh
@@ -139,7 +139,8 @@ test_guard_never_classifies_mcp_tools() {
   # has nothing to do with fleet dispatch.
   local tool
   for tool in mcp__linear__list_issues mcp__tracker__create_task \
-              mcp__acme__spawn_agent mcp__slack__slack_send_message; do
+              mcp__acme__spawn_agent mcp__slack__slack_send_message \
+              MCP:slack_send_message MCP:slack_send_message_draft MCP:agent_run_shell; do
     expect_allow "MCP tool" "$tool"
   done
   pass "MCP tool names are never classified as harness delegation"


### PR DESCRIPTION
## Summary
- Extend the subagent pretool guard MCP exemption to Cursor's `MCP:` prefix (Claude Code uses `mcp__*`)
- Add regression tests for `MCP:slack_send_message`, `MCP:slack_send_message_draft`, and `MCP:agent_run_shell`

## Problem
After normalization, `MCP:slack_send_message` matched the `sendmessage` delegation stem and blocked Slack MCP coordination in primary sessions.

## Test plan
- [x] `bin/fm-lint.sh`
- [x] `bin/fm-test-run.sh tests/fm-subagent-pretool-check.test.sh`