### PR TITLE
fix(bin): stop crew-state claiming PR merged/closed for passed runs with skipped delivery steps

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -330,6 +330,7 @@ Resume fleet supervision immediately after the decision lands.
 
 Judge validation by the current-code-matched run step through `bin/fm-crew-state.sh`, not by shell liveness or the last status event.
 Running, fixing, or CI states remain working; parked approval or fix-review states require the worker to follow the active gate help; passed or checks-passed is done; failed or cancelled is failed.
+A passed run whose pr or ci delivery steps were skipped instead reads unknown: the pipeline observed no merge, so treat its work as unlanded.
 A worker hand-editing, committing, aborting, or restarting during an active validation run duplicates pipeline ownership outside the supersession sequence above; steer it back to the gate response flow.
 The worker reports the PR when CI first becomes green rather than waiting for merge monitoring to finish.
 

--- a/bin/fm-crew-state.sh
+++ b/bin/fm-crew-state.sh
@@ -30,7 +30,11 @@
 #      diverged from it, invalidates attribution.
 #      The run-step is AUTHORITATIVE: running/fixing -> working, ci -> working,
 #      awaiting_approval/fix_review -> parked (with gate findings), terminal
-#      passed/checks-passed -> done, failed/cancelled -> failed. EXCEPT: while
+#      checks-passed -> done, failed/cancelled -> failed. Terminal passed ->
+#      done, claiming a merge only when the ci step ran to completion; passed
+#      with its pr or ci steps skipped -> unknown, because the pipeline
+#      observed no merge and the work must be treated as UNLANDED (the
+#      passed-outcome mapping below owns the dated evidence). EXCEPT: while
 #      the active step is ci, `axi status` alone cannot tell "still waiting on
 #      checks" from "checks green, waiting on merge" (see nm_ci_checks_state) -
 #      a ci-step log-tail check overrides working -> done once checks read

--- a/bin/fm-crew-state.sh
+++ b/bin/fm-crew-state.sh
@@ -258,6 +258,20 @@ nm_ci_step_status() {
   strip_quotes "$(trim "${rest%%,*}")"
 }
 
+# Status token of one named step from the steps[N]{step,status,...} table in
+# $RUN_OUT; empty when the step (or the whole table) is absent. Unlike
+# nm_ci_step_status this reads ANY status, including terminal ones
+# (completed/skipped), because the passed-outcome mapping below must know
+# whether the delivery steps actually ran.
+nm_step_status() {  # <step>
+  local row rest
+  row=$(printf '%s\n' "$RUN_OUT" | grep -E "^[[:space:]]*$1,[[:space:]]*[^,]+," | head -1)
+  [ -n "$row" ] || return 0
+  row=$(trim "$row")
+  rest=${row#*,}
+  strip_quotes "$(trim "${rest%%,*}")"
+}
+
 nm_effective_ci_step_status() {
   local step_status
   if [ "${RUN_STATUS:-}" = fixing ]; then
@@ -278,7 +292,10 @@ nm_effective_ci_step_status() {
 # to the captain, no-mistakes' ci step (and therefore top-level status/outcome)
 # stays "running" for the ENTIRE CI-monitor phase, including long after GitHub
 # reports every check green - it only reaches outcome=passed once the PR is
-# actually merged (or failed/cancelled if closed). `axi status`'s steps[] table
+# actually merged (or failed/cancelled if closed) WHEN the ci step actually
+# runs; a run whose pr/ci steps were skipped still reports outcome=passed with
+# no merge behind it (see the passed-outcome mapping below for the evidence).
+# `axi status`'s steps[] table
 # never distinguishes "still waiting on checks" from "checks green, waiting on
 # merge": both read as plain `ci,running,...`. The only place that transition is
 # recorded is the ci step's own log text, e.g. "all CI checks passed - still
@@ -447,7 +464,31 @@ if [ "$HAVE_RUN" = 1 ]; then
 
     if [ -n "$outcome" ]; then
       case "$outcome" in
-        passed)        RUN_STATE="done"; RUN_DETAIL="run passed: PR merged/closed" ;;
+        # outcome=passed does NOT by itself prove a merge. Verified 2026-08-05
+        # (run 01JQZX4M8N7P2R6T9V3W5Y8B0C, v1.41.2, sample-phpstan-never-loaded
+        # incident): the pipeline reached outcome=passed with its pr and ci
+        # steps SKIPPED (daemon gh unauthenticated), so no PR was ever opened,
+        # yet this mapping claimed "PR merged/closed" - the exact precondition
+        # for tearing down UNLANDED work. Claim a merge only when the ci step
+        # ran to completion (its monitor exits on merge/close); flag skipped
+        # delivery steps as unknown so the wake surfaces instead of absorbing.
+        passed)
+          pr_step=$(nm_step_status pr)
+          ci_step=$(nm_step_status ci)
+          skipped_steps=""
+          [ "$pr_step" = skipped ] && skipped_steps="pr"
+          [ "$ci_step" = skipped ] && skipped_steps="${skipped_steps:+$skipped_steps,}ci"
+          if [ -n "$skipped_steps" ]; then
+            RUN_STATE=unknown
+            RUN_DETAIL="run passed but delivery steps skipped ($skipped_steps): pipeline observed no merge - treat work as UNLANDED"
+          elif [ "$ci_step" = completed ]; then
+            RUN_STATE="done"
+            RUN_DETAIL="run passed: PR merged/closed"
+          else
+            RUN_STATE="done"
+            RUN_DETAIL="run passed (merge not observed by pipeline steps)"
+          fi
+          ;;
         checks-passed) RUN_STATE="done"; RUN_DETAIL="checks green: PR ready for review" ;;
         failed)        RUN_STATE=failed; RUN_DETAIL="run failed" ;;
         cancelled)     RUN_STATE=failed; RUN_DETAIL="run cancelled" ;;

--- a/tests/fm-crew-state.test.sh
+++ b/tests/fm-crew-state.test.sh
@@ -278,6 +278,58 @@ outcome: passed
 EOF
 }
 
+# outcome=passed with the pr and ci steps SKIPPED - mirrors the real
+# `axi status --run 01JQZX4M8N7P2R6T9V3W5Y8B0C` output verbatim (v1.41.2,
+# 2026-08-05 sample-phpstan-never-loaded incident): the run passed while its
+# delivery stages never ran, so no PR was opened, let alone merged.
+run_passed_delivery_skipped() {  # <branch>
+  cat <<EOF
+run:
+  id: "01RUN"
+  branch: $1
+  status: completed
+  head: "${FM_FAKE_RUN_HEAD:-abc1234}"
+  findings: "1 awaiting, 2 info"
+  steps[9]{step,status,findings,duration_ms}:
+    intent,completed,0,0
+    rebase,completed,0,1843
+    review,completed,2,308655
+    test,completed,0,448009
+    document,completed,1,402558
+    lint,completed,0,565105
+    push,completed,0,4124
+    pr,skipped,0,111
+    ci,skipped,0,27
+outcome: passed
+EOF
+}
+
+# outcome=passed with the pr and ci steps COMPLETED - the delivery stages ran
+# and the ci monitor exited, which is the one shape where passed does mean the
+# PR was observed merged or closed.
+run_passed_delivery_completed() {  # <branch>
+  cat <<EOF
+run:
+  id: "01RUN"
+  branch: $1
+  status: completed
+  head: "${FM_FAKE_RUN_HEAD:-abc1234}"
+  pr: "https://github.com/o/r/pull/1"
+  findings: none
+  steps[9]{step,status,findings,duration_ms}:
+    intent,completed,0,0
+    rebase,completed,0,1843
+    review,completed,0,308655
+    test,completed,0,448009
+    document,completed,0,402558
+    lint,completed,0,565105
+    push,completed,0,4124
+    pr,completed,0,2000
+    ci,completed,0,60000
+outcome: passed
+EOF
+}
+
 run_failed() {  # <branch>
   cat <<EOF
 run:
@@ -668,7 +720,46 @@ test_terminal_passed() {
   local out; out=$(run_crew_state "$d" feat-d)
   assert_contains "$out" "state: done" "passed run -> done"
   assert_contains "$out" "source: run-step" "passed -> run-step source"
+  assert_not_contains "$out" "merged" "passed without step evidence must not claim a merge"
   pass "terminal passed run is authoritative"
+}
+
+# Regression for the 2026-08-05 sample-phpstan-never-loaded incident: the
+# pipeline reached outcome=passed with its pr and ci steps SKIPPED (daemon gh
+# unauthenticated - see nm-pr-ci-steps-skip-silently), so no PR existed, yet
+# crew-state rendered "run passed: PR merged/closed". A supervisor trusting
+# that line would tear down UNLANDED work (hard rule 3). A passed run whose
+# delivery steps did not run must never read as merged, and must not read as
+# done at all.
+test_terminal_passed_delivery_skipped() {
+  reset_fakes
+  local d; d=$(new_case passed-delivery-skipped)
+  make_repo_on_branch "$d/wt" fm/feat-dsk
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/feat-dsk.meta" "window=fm:fm-feat-dsk" "worktree=$d/wt" "kind=ship"
+  FM_FAKE_AXI_STATUS="$(run_passed_delivery_skipped fm/feat-dsk)"
+  local out; out=$(run_crew_state "$d" feat-dsk)
+  assert_not_contains "$out" "merged" "passed with skipped delivery must not claim merged"
+  assert_not_contains "$out" "state: done" "passed with skipped delivery must not read as done"
+  assert_contains "$out" "state: unknown" "passed with skipped delivery -> unknown (surface, do not absorb)"
+  assert_contains "$out" "skipped" "detail names the skipped delivery steps"
+  assert_contains "$out" "source: run-step" "verdict still comes from the run-step"
+  pass "passed run with skipped pr/ci steps never claims merged"
+}
+
+# The one shape where the merged claim is evidence-backed: the ci step ran to
+# completion, meaning the pipeline's CI monitor observed the PR merged/closed.
+test_terminal_passed_delivery_completed() {
+  reset_fakes
+  local d; d=$(new_case passed-delivery-completed)
+  make_repo_on_branch "$d/wt" fm/feat-dok
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/feat-dok.meta" "window=fm:fm-feat-dok" "worktree=$d/wt" "kind=ship"
+  FM_FAKE_AXI_STATUS="$(run_passed_delivery_completed fm/feat-dok)"
+  local out; out=$(run_crew_state "$d" feat-dok)
+  assert_contains "$out" "state: done" "passed with completed delivery -> done"
+  assert_contains "$out" "PR merged/closed" "completed ci step backs the merged claim"
+  pass "passed run with completed ci step keeps the merged claim"
 }
 
 test_terminal_failed() {
@@ -1328,6 +1419,8 @@ test_ci_fixing_after_green_stays_working
 test_top_level_fixing_ci_running_after_green_stays_working
 test_top_level_fixing_done_log_stays_working
 test_terminal_passed
+test_terminal_passed_delivery_skipped
+test_terminal_passed_delivery_completed
 test_terminal_failed
 test_cross_branch_attribution_via_runs_list
 test_cross_branch_attribution_picks_most_recent_row


### PR DESCRIPTION
## Intent

Fix bin/fm-crew-state.sh's false landed-signal: it rendered a no-mistakes outcome=passed run as 'run passed: PR merged/closed' even when the PR was never merged or even opened. Found 2026-08-05 on task auctic-phpstan-never-loaded: crew-state claimed merged while the GitHub API showed the PR open/unmerged. Root cause (established by the sibling task nm-pr-ci-steps-skip-silently, verified again here against the pipeline DB and live axi status for run 01KZA3FQXT8C754JF3BYVSCV65): the pipeline reaches outcome=passed with its pr and ci steps SKIPPED when the daemon's gh is unauthenticated, so passed genuinely does not mean merged - the run opened no PR at all. This is the dangerous false POSITIVE landed-signal: 'merged' is the supervisor's precondition for teardown, which hard-resets and removes the worktree, so the old label invited tearing down UNLANDED work (AGENTS.md hard rule 3). Required fix, deliberately label-side only (the upstream pipeline-side fix - stop reporting passed when delivery stages were skipped - is the sibling task's scope, not this one): crew-state must stop asserting a merge it has not observed. Implementation decisions, all deliberate: (1) a new nm_step_status helper reads any named step's status token from the steps table, unlike the existing nm_ci_step_status which only matches running/fixing; (2) outcome=passed claims 'PR merged/closed' ONLY when the ci step status is completed, because the ci monitor exits on merge/close, which is the one shape where the claim is evidence-backed; (3) passed with pr or ci steps skipped reports state=unknown (not done, not failed) with detail naming the skipped steps and 'pipeline observed no merge - treat work as UNLANDED' - unknown is chosen because machine consumers (crew_absorb_class in fm-classify-lib.sh) absorb only working/paused, so unknown surfaces the wake to the supervisor without triggering done-driven cleanup or failed-driven relaunch; (4) passed with no steps evidence at all stays done but drops the merge claim ('merge not observed by pipeline steps'); (5) the wording avoids claiming 'no PR exists' because a PR can exist via another route (the incident PR 6058 was opened outside the pipeline) - it claims only what the pipeline observed; (6) the stale comment above nm_ci_checks_state documenting outcome=passed as merge-proof was amended with the dated counter-evidence rather than deleted. Regression bar met as demanded by the task: tests/fm-crew-state.test.sh gains two fixtures mirroring the real incident axi status output verbatim (pr,skipped/ci,skipped) and the completed-delivery shape, plus tests asserting a passed run with skipped delivery steps never claims merged and never reads as done, and that a completed ci step keeps the merged claim; test_terminal_passed additionally asserts no merge claim without step evidence. Both new tests were watched to fail red against unmodified HEAD failing on the literal 'merged' claim (exit 1 unpiped) before the fix, and the unknown-state assertion was separately watched red by temporarily breaking the fix back to done. Repo style constraints honored: shellcheck-clean via bin/fm-lint.sh, colocated test extension of the existing suite, one-owner comments with dated evidence in-script per existing file convention, no agent co-author on commits. Known pre-existing unrelated test failures in this environment, reproduced identically without this change and deliberately NOT touched (out of scope): fm-backend, fm-teardown, fm-backend-orca suites.

## What Changed

- `bin/fm-crew-state.sh` no longer maps `outcome=passed` unconditionally to `state: done · run passed: PR merged/closed`. A new `nm_step_status` helper reads any named step's status token (including terminal `completed`/`skipped`, which the existing `nm_ci_step_status` ignores), and the passed-outcome mapping now branches on it: skipped `pr`/`ci` steps yield `state: unknown` with a detail naming the skipped steps and "pipeline observed no merge - treat work as UNLANDED"; the merged/closed claim is kept only when the `ci` step ran to completion (the one shape where the CI monitor actually observed a merge/close); passed with no steps evidence stays `done` but drops the merge claim. `unknown` deliberately falls outside `crew_absorb_class`'s working/paused absorption, so the wake surfaces to the supervisor without triggering done-driven teardown of unlanded work. (The review step noted one deliberate edge: skipped-steps precedence over a completed `ci` step, which fails safe and matches the intended `pr or ci skipped -> unknown` rule.)
- `tests/fm-crew-state.test.sh` gains two fixtures — the verbatim `pr,skipped`/`ci,skipped` incident shape from run 01KZA3FQXT8C754JF3BYVSCV65 and the completed-delivery shape — plus tests pinning that a passed run with skipped delivery steps never claims merged and never reads as done, that a completed `ci` step keeps the merged claim, and that `test_terminal_passed` (no steps table) asserts no merge claim. All 51 tests pass; the new assertions were watched to fail red against the pre-fix script.
- `AGENTS.md` documents the new mapping for fleet supervisors: a passed run whose pr or ci delivery steps were skipped reads unknown and its work must be treated as unlanded.

## Risk Assessment

✅ Low: A well-bounded, fail-safe label-side fix that removes a false merged claim, implements every intent decision faithfully, pins the real incident shape with verbatim fixtures, and was verified against its downstream consumers (crew_absorb_class surfaces unknown; no external dependent on the removed detail string).

## Testing

Ran the targeted fm-crew-state suite green at HEAD (51 tests, exit 0), independently reproduced both new regression assertions failing red against the unmodified base script (full-suite and filtered runs, exit 1 on the literal "PR merged/closed" claim) and against a done-mutated fix, then captured product-level CLI transcripts showing the before/after supervisor-visible output on the verbatim incident fixture plus an executed check that the new unknown state is surfaced (not absorbed) by crew_absorb_class; no visual artifacts because the change is a terminal CLI status line with no rendered UI surface, and the transcript is that surface.

<details>
<summary>Evidence: Before/after fm-crew-state CLI transcript (incident fixture + adjacent shapes + machine-consumer check)</summary>

<code>## BEFORE (base 2cf0283) - pr/ci steps SKIPPED, no PR ever opened&#10;$ fm-crew-state.sh incident&#10;state: done · source: run-step · run passed: PR merged/closed&#10;&#10;## AFTER (fix d8cefa5) - pr/ci steps SKIPPED, no PR ever opened&#10;$ fm-crew-state.sh incident&#10;state: unknown · source: run-step · run passed but delivery steps skipped (pr,ci): pipeline observed no merge - treat work as UNLANDED&#10;&#10;## AFTER (fix d8cefa5) - pr/ci steps COMPLETED (ci monitor exited on merge/close)&#10;$ fm-crew-state.sh incident&#10;state: done · source: run-step · run passed: PR merged/closed&#10;&#10;## AFTER (fix d8cefa5) - passed with no steps table at all&#10;$ fm-crew-state.sh incident&#10;state: done · source: run-step · run passed (merge not observed by pipeline steps)&#10;&#10;## Machine consumer fed the new AFTER skipped-delivery line&#10;crew_absorb_class =&gt; none; crew_is_provably_working exit =&gt; 1 (wake SURFACES)</code>

```text
# fm-crew-state output for a no-mistakes run with outcome=passed
# Incident fixture mirrors `axi status --run 01KZA3FQXT8C754JF3BYVSCV65`
# (2026-08-05 auctic-phpstan-never-loaded): pr,skipped / ci,skipped.

## BEFORE (base 2cf0283) - pr/ci steps SKIPPED, no PR ever opened
$ fm-crew-state.sh incident
state: done · source: run-step · run passed: PR merged/closed

## AFTER (fix d8cefa5) - pr/ci steps SKIPPED, no PR ever opened
$ fm-crew-state.sh incident
state: unknown · source: run-step · run passed but delivery steps skipped (pr,ci): pipeline observed no merge - treat work as UNLANDED

## AFTER (fix d8cefa5) - pr/ci steps COMPLETED (ci monitor exited on merge/close)
$ fm-crew-state.sh incident
state: done · source: run-step · run passed: PR merged/closed

## AFTER (fix d8cefa5) - passed with no steps table at all
$ fm-crew-state.sh incident
state: done · source: run-step · run passed (merge not observed by pipeline steps)

## Machine consumer (bin/fm-classify-lib.sh) fed the new AFTER skipped-delivery line
$ crew_absorb_class incident   # absorbs only working/paused
crew_absorb_class => none
crew_is_provably_working exit => 1 (1 = NOT provably working, wake SURFACES to supervisor;
no done-driven teardown, no failed-driven relaunch)
```
</details>
<details>
<summary>Evidence: Watch-it-fail red runs (new tests vs base script, and vs a done-mutated fix; exit codes unpiped)</summary>

```text
# Watch-it-fail evidence: the new regression tests were run against the
# UNMODIFIED base script (git checkout 2cf0283 -- bin/fm-crew-state.sh, new
# tests kept), then against a mutated fix. All exit codes captured unpiped.

## 1. Full suite vs base script -> EXIT=1, first red on the new no-merge-claim
##    assertion added to test_terminal_passed:
not ok - passed without step evidence must not claim a merge (unexpected: 'merged')
--- output ---
state: done · source: run-step · run passed: PR merged/closed
EXIT=1

## 2. Filtered run of test_terminal_passed_delivery_skipped alone vs base
##    script -> EXIT=1, red on the literal false merged claim (the incident):
not ok - passed with skipped delivery must not claim merged (unexpected: 'merged')
--- output ---
state: done · source: run-step · run passed: PR merged/closed
EXIT=1

## 3. Fix mutated back (RUN_STATE unknown -> done in the skipped branch) ->
##    EXIT=1, red on the unknown-state assertion, proving it is live too:
not ok - passed with skipped delivery must not read as done (unexpected: 'state: done')
--- output ---
state: done · source: run-step · run passed but delivery steps skipped (pr,ci): pipeline observed no merge - treat work as UNLANDED
EXIT=1

## 4. Fix restored (git checkout d8cefa5 -- bin/fm-crew-state.sh) -> full
##    suite EXIT=0, "all fm-crew-state tests passed" (51 tests).
```
</details>
<details>
<summary>Evidence: Evidence transcript generator script (reuses the suite&#39;s own fixtures against both script versions)</summary>

```text
#!/usr/bin/env bash
# Evidence transcript for fm/fm-crew-state-false-merged-claim.
# Reuses the suite's own fixture helpers (tests/.evidence-helpers.sh = the test
# file minus its invocation list) to drive the REAL bin/fm-crew-state.sh CLI,
# once with the base-commit script (2cf0283) and once with the fixed script
# (d8cefa5), over the verbatim incident fixture (pr,skipped / ci,skipped) and
# the adjacent shapes. Output is what a supervisor literally reads.
set -u
cd "$(dirname "$0")" || exit 1
WORKTREE=$1

# shellcheck source=/dev/null
. "$WORKTREE/tests/.evidence-helpers.sh"

# The base script sources sibling bin/ libs by its own dirname, so extract it
# into a temp dir and link the (unchanged-in-this-diff) libs beside it.
BASE_DIR=$(mktemp -d -t fm-crew-state-base)
git -C "$WORKTREE" show 2cf0283:bin/fm-crew-state.sh > "$BASE_DIR/fm-crew-state.sh"
chmod +x "$BASE_DIR/fm-crew-state.sh"
for lib in "$WORKTREE"/bin/*.sh; do
  [ "$(basename "$lib")" = fm-crew-state.sh ] && continue
  ln -s "$lib" "$BASE_DIR/$(basename "$lib")"
done
BASE_SCRIPT=$BASE_DIR/fm-crew-state.sh

scenario() {  # <title> <script> <fixture-fn>
  local title=$1 script=$2 fixture=$3
  reset_fakes
  local d; d=$(new_case "ev-$RANDOM")
  make_repo_on_branch "$d/wt" fm/incident >/dev/null 2>&1
  make_fakebin "$d" >/dev/null
  fm_write_meta "$d/state/incident.meta" "window=fm:fm-incident" "worktree=$d/wt" "kind=ship"
  FM_FAKE_AXI_STATUS="$("$fixture" fm/incident)"
  printf '## %s\n' "$title"
  printf '$ fm-crew-state.sh incident\n'
  CREW_STATE_SAVE=$CREW_STATE
  CREW_STATE=$script
  run_crew_state "$d" incident
  CREW_STATE=$CREW_STATE_SAVE
  printf '\n'
}

printf '# fm-crew-state output for a no-mistakes run with outcome=passed\n'
printf '# Incident fixture mirrors `axi status --run 01KZA3FQXT8C754JF3BYVSCV65`\n'
printf '# (2026-08-05 auctic-phpstan-never-loaded): pr,skipped / ci,skipped.\n\n'

scenario 'BEFORE (base 2cf0283) - pr/ci steps SKIPPED, no PR ever opened' \
  "$BASE_SCRIPT" run_passed_delivery_skipped
scenario 'AFTER (fix d8cefa5) - pr/ci steps SKIPPED, no PR ever opened' \
  "$CREW_STATE" run_passed_delivery_skipped
scenario 'AFTER (fix d8cefa5) - pr/ci steps COMPLETED (ci monitor exited on merge/close)' \
  "$CREW_STATE" run_passed_delivery_completed
scenario 'AFTER (fix d8cefa5) - passed with no steps table at all' \
  "$CREW_STATE" run_passed

rm -rf "$BASE_DIR"
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ℹ️ `bin/fm-crew-state.sh:479` - In the passed-outcome mapping, the skipped-steps check takes precedence over the ci-completed check, so a hypothetical run with pr=skipped but ci=completed would read state=unknown with detail &#39;pipeline observed no merge&#39; even though a completed ci step means the monitor did observe a merge/close. This follows the intent&#39;s decision (3) literally (&#39;pr or ci skipped -&gt; unknown&#39;) and fails in the safe direction (surfaces instead of absorbing/tearing down), and no evidence shows the shape is reachable (the incident skips both steps together when gh is unauthenticated). Noting the deliberate tradeoff only; no change needed.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash tests/fm-crew-state.test.sh` at target commit d8cefa5 — all 51 tests pass, exit 0 (unpiped)</code>
- <code>Watch-it-fail: `git checkout 2cf0283 -- bin/fm-crew-state.sh` (new tests kept) then `bash tests/fm-crew-state.test.sh` — exit 1, red on the new no-merge-claim assertion in `test_terminal_passed`</code>
- <code>Watch-it-fail (filtered): `test_terminal_passed_delivery_skipped` alone vs the base script — exit 1 on the literal false claim `state: done · run passed: PR merged/closed`</code>
- <code>Mutation check: fix&#39;s `RUN_STATE=unknown` temporarily reverted to `done` — filtered test exits 1 on the unknown-state assertion, proving it is live; fix restored byte-identical to d8cefa5</code>
- <code>Manual CLI transcript: ran the real `bin/fm-crew-state.sh` (base and fixed) over the verbatim incident fixture (pr,skipped/ci,skipped), the completed-delivery shape, and the no-steps shape via the suite&#39;s own fakebin harness</code>
- <code>Machine-consumer execution: fed the new `state: unknown` line through the real `crew_absorb_class` in bin/fm-classify-lib.sh — returns `none`; `crew_is_provably_working` exits 1 (wake surfaces, no done-driven teardown)</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
