### PR TITLE
fix(bin): prevent failed misread when newer same-branch run owns the pipeline head

### DIFF
--- a/bin/fm-crew-state.sh
+++ b/bin/fm-crew-state.sh
@@ -21,8 +21,10 @@
 # Logic, in order:
 #   1. Resolve worktree + backend target + kind from state/<id>.meta.
 #   2. Matching no-mistakes run for this crew's branch AND current code identity,
-#      active or terminal (from `axi status`, or the coarse `no-mistakes runs`
-#      fallback)? Branch name alone is not enough: a historical run on a reused
+#      active or terminal (from `axi status`, re-resolved through the `axi` home
+#      surface when the bare answer is a stale same-branch terminal run, or
+#      falling back to the coarse `no-mistakes runs` list when no exact ID is
+#      exposed)? Branch name alone is not enough: a historical run on a reused
 #      branch whose head was rewritten or diverged must not be attributed.
 #      A run matches when its head equals the worktree HEAD, or the worktree HEAD
 #      is an ancestor of the run head (pipeline fix commits advanced the run on

--- a/bin/fm-crew-state.sh
+++ b/bin/fm-crew-state.sh
@@ -50,6 +50,7 @@
 # Read-only and side-effect free. Always exits 0 on a successful read regardless
 # of state; exit 2 only on a usage error (no id).
 set -u
+[ "${FM_CREW_STATE_DEBUG:-0}" = 1 ] && set -x
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
@@ -304,38 +305,144 @@ nm_ci_checks_state() {
     *) printf 'unknown' ;;
   esac
 }
+# A bare `axi status` normally resolves the active run for the current branch,
+# but it can return an older terminal run while a newer same-branch run owns the
+# pipeline head (for example, during a gate-fix round after a prior run failed).
+# The `axi` home surface carries run IDs, so the helpers below use it to recover
+# the newest code-matching active run and inspect that exact run by ID.
+nm_axi_active_run_id_for_branch() {  # <branch> <axi-home-output>
+  local branch=$1 home=$2 line trimmed in_active=0 id='' br='' head=''
+  while IFS= read -r line; do
+    trimmed=$(trim "$line")
+    if [ "$trimmed" = active_run: ]; then
+      in_active=1
+      id=''
+      br=''
+      head=''
+      continue
+    fi
+    if [ "$in_active" = 1 ]; then
+      case "$line" in
+        [![:space:]]*) break ;;
+      esac
+      case "$trimmed" in
+        id:*)     id=$(strip_quotes "${trimmed#id:}") ;;
+        branch:*) br=$(strip_quotes "${trimmed#branch:}") ;;
+        head:*)   head=$(strip_quotes "${trimmed#head:}") ;;
+      esac
+    fi
+  done <<EOF
+$home
+EOF
+  [ "$br" = "$branch" ] || return 1
+  [ -n "$id" ] || return 1
+  fm_nm_head_matches_worktree "$WT" "$head" || return 1
+  printf '%s' "$id"
+}
+
+# Parse the optional `runs[N]{id,branch,status,head,pr}:` table from `axi` home.
+# Prefer the first code-matching active row over every terminal row, regardless
+# of table ordering, so an old failed run cannot shadow a live replacement.
+nm_axi_run_id_for_branch_from_table() {  # <branch> <axi-home-output>
+  local branch=$1 home=$2 line trimmed row id rest br st head
+  local in_runs=0 active_id='' terminal_id=''
+  while IFS= read -r line; do
+    trimmed=$(trim "$line")
+    if [ "$in_runs" = 0 ]; then
+      if printf '%s\n' "$trimmed" | grep -Eq '^runs\[[0-9]+\]\{.*\}:$'; then
+        in_runs=1
+      fi
+      continue
+    fi
+    case "$line" in
+      '') continue ;;
+      [[:space:]]*) ;;
+      *) break ;;
+    esac
+    row=$trimmed
+    case "$row" in *,*) ;; *) continue ;; esac
+    id=${row%%,*}
+    id=$(strip_quotes "$id")
+    rest=${row#*,}
+    br=${rest%%,*}
+    br=$(strip_quotes "$br")
+    rest=${rest#*,}
+    st=${rest%%,*}
+    st=$(strip_quotes "$st")
+    rest=${rest#*,}
+    head=${rest%%,*}
+    head=$(strip_quotes "$head")
+    [ "$br" = "$branch" ] || continue
+    nm_coarse_head_matches_worktree "$head" || continue
+    case "$st" in
+      pending|running)
+        [ -n "$active_id" ] || active_id=$id
+        ;;
+      completed|failed|cancelled)
+        [ -n "$terminal_id" ] || terminal_id=$id
+        ;;
+    esac
+  done <<EOF
+$home
+EOF
+  if [ -n "$active_id" ]; then
+    printf '%s' "$active_id"
+  elif [ -n "$terminal_id" ]; then
+    printf '%s' "$terminal_id"
+  else
+    return 1
+  fi
+}
+
+# Resolve an exact current-branch run ID from the optional `axi` home output.
+# The active_run block is authoritative when present; the bounded recent-runs
+# table is the compatible fallback on surfaces that omit that block.
+nm_axi_run_id_for_branch() {  # <branch> <axi-home-output>
+  local branch=$1 home=$2 id
+  id=$(nm_axi_active_run_id_for_branch "$branch" "$home" || true)
+  [ -n "$id" ] && { printf '%s' "$id"; return 0; }
+  nm_axi_run_id_for_branch_from_table "$branch" "$home"
+}
+
+# 0 when an axi status object is terminal, so an ambiguous terminal answer can
+# be cross-checked against the newer exact-ID run before it becomes authoritative.
+nm_run_output_is_terminal() {
+  local outcome status
+  outcome=$(strip_quotes "$(nm_field outcome)")
+  case "$outcome" in
+    passed|checks-passed|failed|cancelled) return 0 ;;
+  esac
+  status=$(strip_quotes "$(nm_field status)")
+  case "$status" in
+    completed|failed|cancelled) return 0 ;;
+  esac
+  return 1
+}
+
+# Replace RUN_OUT with a verified exact-ID status for this branch, if the axi
+# home surface exposes one. A mismatched ID, branch, or code head is rejected.
+nm_refresh_run_from_axi_home() {  # <branch> <axi-home-output>
+  local branch=$1 home=$2 run_id candidate candidate_id candidate_branch
+  run_id=$(nm_axi_run_id_for_branch "$branch" "$home" || true)
+  [ -n "$run_id" ] || return 1
+  candidate=$(nm_run axi status --run "$run_id")
+  [ -n "$candidate" ] || return 1
+  RUN_OUT=$candidate
+  candidate_id=$(strip_quotes "$(nm_field id)")
+  candidate_branch=$(strip_quotes "$(nm_field branch)")
+  [ "$candidate_id" = "$run_id" ] || return 1
+  [ "$candidate_branch" = "$branch" ] || return 1
+  nm_run_head_matches_worktree || return 1
+  return 0
+}
+
 # Coarse fallback for cross-branch attribution. `no-mistakes axi status` (bare)
-# reports the active-or-most-recent run for the CURRENT branch when one
-# exists, else falls back to some other branch's run purely as informational
-# display (verified empirically: querying a worktree with its own active run
-# reliably returns that run, even under concurrent load from several other
-# validating crews on the same underlying repo). A crew whose branch genuinely
-# has no run yet therefore sees another branch's answer here.
-#
-# This fallback used to shell out to `no-mistakes axi` (bare, no subcommand)
-# expecting a `runs[N]{id,branch,status,...}:` TOON table and re-query the
-# matched id via `axi status --run <id>`. Verified against the real installed
-# CLI (v1.32.2): the `axi` surface exposes only abort/logs/respond/run/status -
-# there is no runs-listing subcommand under `axi` at all, so that table never
-# appears and the lookup was silently dead code; whenever the bare `axi
-# status` answer was not this crew's own branch, attribution always failed and
-# the caller fell straight through to the pane/log fallback below. (The
-# PRIMARY cause of the 2026-07 herdr false-surface incidents turned out to be
-# a separate bug in bin/fm-watch.sh's stale_is_terminal precedence - see that
-# file's history - but this cross-branch path was independently confirmed
-# dead code and is worth having actually work.)
-#
-# The real run-listing command is the top-level `no-mistakes runs` (verified:
-# `no-mistakes --help` lists it separately from `axi`). It is plain, human-
-# oriented text - no run id, no JSON/TOON, newest-first, columns
-# "<status> <branch> <short-sha> <date> [<pr-url>]" separated by runs of
-# spaces (verified: no quoting, so splitting on the first two whitespace runs
-# is exact) - but branch + coarse status is exactly what this predicate needs:
-# is a run for THIS branch active right now. Echoes the first (most recent)
-# matching row's status word (running/completed/cancelled/failed), or empty
-# when the branch has no run within FM_CREW_STATE_RUNS_LIMIT rows.
+# may answer another branch, so the top-level `no-mistakes runs` listing supplies
+# a branch-filtered status when the exact-ID surface is unavailable.
+# It returns an active status if ANY matching code identity is active, otherwise
+# the first matching terminal status, preserving genuine failed/cancelled reads.
 nm_runs_status_for_branch() {  # <branch>
-  local branch=$1 out row st rest br sha
+  local branch=$1 out row st rest br sha active='' terminal=''
   out=$(nm_run runs --limit "$FM_CREW_STATE_RUNS_LIMIT")
   [ -n "$out" ] || return 0
   while IFS= read -r row; do
@@ -348,17 +455,26 @@ nm_runs_status_for_branch() {  # <branch>
     rest=${rest#* }
     rest=$(trim "$rest")
     sha=${rest%% *}
-    if [ "$br" = "$branch" ]; then
-      # Same code-identity rule as axi status: skip a same-branch row whose
-      # short-sha does not match this worktree (rewritten or advanced tip).
-      if ! nm_coarse_head_matches_worktree "$sha"; then
-        continue
-      fi
-      printf '%s' "$st"
-      return 0
-    fi
-  done <<< "$out"
-  return 0
+    [ "$br" = "$branch" ] || continue
+    # Same code-identity rule as axi status: skip a same-branch row whose
+    # short-sha does not match this worktree (rewritten or advanced tip).
+    nm_coarse_head_matches_worktree "$sha" || continue
+    case "$st" in
+      pending|running)
+        [ -n "$active" ] || active=$st
+        ;;
+      completed|failed|cancelled)
+        [ -n "$terminal" ] || terminal=$st
+        ;;
+    esac
+  done <<EOF
+$out
+EOF
+  if [ -n "$active" ]; then
+    printf '%s' "$active"
+  elif [ -n "$terminal" ]; then
+    printf '%s' "$terminal"
+  fi
 }
 
 # CREW_BRANCH is empty at detached HEAD (a just-spawned crew, or a scout's
@@ -394,20 +510,38 @@ if [ "$KIND" = ship ] && [ -n "$CREW_BRANCH" ] && command -v no-mistakes >/dev/n
   RUN_OUT=$(nm_run axi status)
   if [ -n "$RUN_OUT" ]; then
     run_branch=$(strip_quotes "$(nm_field branch)")
+    run_matches=0
     if [ -n "$run_branch" ] && [ "$run_branch" = "$CREW_BRANCH" ] && nm_run_head_matches_worktree; then
+      run_matches=1
+    fi
+
+    if [ "$run_matches" = 1 ]; then
+      # A terminal bare answer may be an older run left behind by a rerun on
+      # the same branch. Re-resolve through axi's exact run-ID surface before
+      # allowing that terminal state to outrank a newer active gate.
       HAVE_RUN=1
+      if nm_run_output_is_terminal; then
+        original_run_out=$RUN_OUT
+        axi_home_out=$(nm_run axi)
+        if [ -n "$axi_home_out" ] && ! nm_refresh_run_from_axi_home "$CREW_BRANCH" "$axi_home_out"; then
+          RUN_OUT=$original_run_out
+        fi
+      fi
     else
       # The active-or-most-recent run is for another branch, or same branch with
-      # a rewritten/diverged head (the CLI is alive and answered; only the
-      # attribution missed) - try the coarse fallback.
-      # Deliberately nested inside `[ -n "$RUN_OUT" ]`: an empty/timed-out
-      # primary call means the CLI itself did not respond, so retrying it
-      # immediately with a second bounded call would just double the wait
-      # for no better answer.
-      COARSE_STATUS=$(nm_runs_status_for_branch "$CREW_BRANCH")
-      if [ -n "$COARSE_STATUS" ]; then
+      # a rewritten/diverged head. Try the exact-ID home surface first, then
+      # the coarse branch/status fallback.
+      original_run_out=$RUN_OUT
+      axi_home_out=$(nm_run axi)
+      if [ -n "$axi_home_out" ] && nm_refresh_run_from_axi_home "$CREW_BRANCH" "$axi_home_out"; then
         HAVE_RUN=1
-        RUN_SOURCE=coarse
+      else
+        RUN_OUT=$original_run_out
+        COARSE_STATUS=$(nm_runs_status_for_branch "$CREW_BRANCH")
+        if [ -n "$COARSE_STATUS" ]; then
+          HAVE_RUN=1
+          RUN_SOURCE=coarse
+        fi
       fi
     fi
   fi

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -524,6 +524,7 @@ FM_CODEX_WATCH_CHECKPOINT=180   # seconds per foreground watcher checkpoint in C
 FM_CREW_STATE_NM_TIMEOUT=10   # seconds allowed per no-mistakes query inside fm-crew-state.sh
 FM_TEARDOWN_NM_TIMEOUT=10    # seconds allowed per no-mistakes query or abort inside fm-teardown.sh
 FM_CREW_STATE_RUNS_LIMIT=200  # recent no-mistakes run rows scanned when axi status cannot be attributed to the current code
+FM_CREW_STATE_DEBUG=0        # set to 1 to enable xtrace inside fm-crew-state.sh for run-attribution diagnosis
 FM_CREW_STATE_BIN=bin/fm-crew-state.sh   # test override for the current-state reader used by working/paused watcher triage
 FMX_PAIRING_TOKEN=      # Relay pairing token; .env opt-in authorizes replies and eligible lifecycle actions
 FMX_RELAY_URL=https://myfirstmate.io   # optional Relay endpoint override, mainly for local relay development

--- a/tests/fm-crew-state.test.sh
+++ b/tests/fm-crew-state.test.sh
@@ -49,13 +49,9 @@ make_repo_on_branch() {  # <dir> <branch>
   export FM_FAKE_RUN_HEAD
 }
 
-# A fakebin with a fake `no-mistakes` (serves the env-driven run output) and a
-# fake `tmux` (serves a busy or idle pane). The fake no-mistakes mirrors the real
-# command surface the helper uses: `axi status`, `axi status --run <id>` (the
-# `axi` surface - no runs-listing subcommand exists under it, verified against
-# the real CLI), and the actual top-level run-listing command, `no-mistakes
-# runs --limit N`, which is plain text - no run id, no quoting - serving
-# FM_FAKE_RUNS_LIST verbatim.
+# A fake `axi` home includes run IDs, matching the current no-mistakes surface.
+# Keep this separate from the top-level `runs` fixture because the repair must
+# inspect the exact newer run rather than trust a branch-only terminal row.
 make_fakebin() {  # <dir> -> echoes fakebin path
   local dir=$1 fb="$1/fakebin"
   mkdir -p "$fb"
@@ -70,6 +66,7 @@ case "${1:-}" in
         shift
         if [ "${1:-}" = --run ]; then printf '%s\n' "${FM_FAKE_AXI_STATUS_RUN:-}"
         else printf '%s\n' "${FM_FAKE_AXI_STATUS:-}"; fi ;;
+      '') printf '%s\n' "${FM_FAKE_AXI_HOME:-}" ;;
       logs)
         printf '%s\n' "${FM_FAKE_CI_LOGS:-}" ;;
     esac
@@ -162,6 +159,8 @@ arm_idle_record() {  # <state-dir> <id>
 reset_fakes() {
   FM_FAKE_AXI_STATUS=""
   FM_FAKE_AXI_STATUS_RUN=""
+  FM_FAKE_AXI_HOME=""
+  FM_FAKE_RUN_ID=""
   FM_FAKE_RUNS_LIST=""
   FM_FAKE_BUSY=0
   FM_FAKE_BUSY_TEXT=
@@ -170,7 +169,7 @@ reset_fakes() {
   FM_FAKE_HERDR_MISSING=0
   FM_FAKE_HERDR_AGENT_STATUS=""
   FM_FAKE_CI_LOGS=""
-  export FM_FAKE_AXI_STATUS FM_FAKE_AXI_STATUS_RUN FM_FAKE_RUNS_LIST FM_FAKE_BUSY FM_FAKE_BUSY_TEXT FM_FAKE_TMUX_MISSING
+  export FM_FAKE_AXI_STATUS FM_FAKE_AXI_STATUS_RUN FM_FAKE_AXI_HOME FM_FAKE_RUN_ID FM_FAKE_RUNS_LIST FM_FAKE_BUSY FM_FAKE_BUSY_TEXT FM_FAKE_TMUX_MISSING
   export FM_FAKE_HERDR_BUSY FM_FAKE_HERDR_MISSING FM_FAKE_HERDR_AGENT_STATUS FM_FAKE_CI_LOGS
 }
 
@@ -248,7 +247,7 @@ EOF
 run_parked_in_gate_block() {  # <branch>
   cat <<EOF
 run:
-  id: "01RUN"
+  id: "${FM_FAKE_RUN_ID:-01RUN}"
   branch: $1
   status: running
   head: "${FM_FAKE_RUN_HEAD:-abc1234}"
@@ -684,16 +683,70 @@ test_terminal_failed() {
   pass "terminal failed run is authoritative"
 }
 
+# Regression: an older failed run on the same branch can match the local head
+# while a newer pipeline run has advanced its head and is parked at fix_review.
+# Initiating trigger: bare `axi status` resolves the stale terminal run.
+# Masking condition: both runs share the branch and the local head is an
+# ancestor of the newer run head, so branch/head attribution alone is ambiguous.
+# Visible symptom: the helper emits failed/run failed instead of parked/run-step.
+test_newer_parked_run_beats_older_failed_run() {
+  reset_fakes
+  local d base_head run_head old_run current_run short; d=$(new_case newer-parked)
+  make_repo_on_branch "$d/wt" fm/aura-video-plan3-landing
+  base_head=$(git -C "$d/wt" rev-parse HEAD)
+  git -C "$d/wt" commit -q --allow-empty -m 'pipeline fix commit'
+  run_head=$(git -C "$d/wt" rev-parse HEAD)
+  git -C "$d/wt" reset -q --hard "$base_head"
+  short=$(git -C "$d/wt" rev-parse --short=8 "$run_head")
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/landing.meta" "window=fm:fm-landing" "worktree=$d/wt" "kind=ship"
+
+  FM_FAKE_RUN_ID="01OLD"
+  FM_FAKE_RUN_HEAD="$base_head" old_run=$(run_failed fm/aura-video-plan3-landing)
+  FM_FAKE_RUN_ID="01CURRENT"
+  FM_FAKE_RUN_HEAD="$run_head" current_run=$(run_parked_in_gate_block fm/aura-video-plan3-landing)
+  # The bare query is the stale older run; the exact current run is available
+  # through the run-ID table, as it was in the observed no-mistakes state.
+  FM_FAKE_AXI_STATUS="$old_run"
+  FM_FAKE_AXI_STATUS_RUN="$current_run"
+  FM_FAKE_AXI_HOME="$(cat <<EOF
+runs[2]{id,branch,status,head,pr}:
+  "01CURRENT",fm/aura-video-plan3-landing,running,$short,""
+  "01OLD",fm/aura-video-plan3-landing,failed,${base_head:0:8},""
+EOF
+)"
+
+  local out; out=$(run_crew_state "$d" landing)
+  assert_contains "$out" "state: parked" "newer fix_review run must beat older failed run"
+  assert_contains "$out" "source: run-step" "newer parked run remains authoritative"
+  assert_contains "$out" "parked at review" "current run's gate is preserved"
+  pass "newer parked run beats older failed run on the same branch"
+}
+
+# Smallest counterfactual: remove the older run while keeping the same parked
+# current run and pipeline-head ancestry. The proven path must remain parked.
+test_single_parked_run_counterfactual() {
+  reset_fakes
+  local d base_head run_head current_run; d=$(new_case single-parked)
+  make_repo_on_branch "$d/wt" fm/aura-video-plan3-landing
+  base_head=$(git -C "$d/wt" rev-parse HEAD)
+  git -C "$d/wt" commit -q --allow-empty -m 'pipeline fix commit'
+  run_head=$(git -C "$d/wt" rev-parse HEAD)
+  git -C "$d/wt" reset -q --hard "$base_head"
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/landing.meta" "window=fm:fm-landing" "worktree=$d/wt" "kind=ship"
+  FM_FAKE_RUN_ID=""
+  FM_FAKE_RUN_HEAD="$run_head" current_run=$(run_parked_in_gate_block fm/aura-video-plan3-landing)
+  FM_FAKE_AXI_STATUS="$current_run"
+  local out; out=$(run_crew_state "$d" landing)
+  assert_contains "$out" "state: parked" "single current run -> parked"
+  assert_contains "$out" "source: run-step" "single current run -> run-step"
+  pass "single parked run counterfactual remains parked"
+}
+
 # (e) cross-branch attribution: `axi status` returns ANOTHER branch's run (the
 # routine case once more than one crew validates the same underlying repo
 # concurrently - they share ONE no-mistakes repo registration), so the helper
-# falls back to the real top-level `no-mistakes runs` listing to learn whether
-# THIS branch has an active run of its own. Regression coverage for the
-# 2026-07-02 herdr incident: the old fallback shelled out to `no-mistakes axi`
-# (bare) expecting a `runs[N]{...}:` TOON table that the real CLI never emits
-# (verified against the installed v1.32.2 - the `axi` surface has no
-# runs-listing subcommand at all), so attribution silently failed every time
-# the repo-wide answer was not this crew's own branch.
 test_cross_branch_attribution_via_runs_list() {
   reset_fakes
   local d short; d=$(new_case crossbranch)
@@ -1329,6 +1382,8 @@ test_top_level_fixing_ci_running_after_green_stays_working
 test_top_level_fixing_done_log_stays_working
 test_terminal_passed
 test_terminal_failed
+test_single_parked_run_counterfactual
+test_newer_parked_run_beats_older_failed_run
 test_cross_branch_attribution_via_runs_list
 test_cross_branch_attribution_picks_most_recent_row
 test_coarse_run_does_not_probe_other_branch_ci_log_for_ready_status

--- a/tests/fm-crew-state.test.sh
+++ b/tests/fm-crew-state.test.sh
@@ -25,6 +25,10 @@
 #       This is the direct regression pair for the 2026-07-02 herdr incident,
 #       proving the watcher's own absorb-only-when-provably-working predicate
 #       benefits from the fix in both directions.
+#   (l) same-branch same-code precedence: a newer parked run exposed by the
+#       `axi` home surface beats an older same-branch terminal run that the
+#       bare query would otherwise return; the single-run counterfactual must
+#       still report parked.
 set -u
 
 # shellcheck source=tests/lib.sh


### PR DESCRIPTION
## Intent

Root-cause and fix a dangerous state misread in bin/fm-crew-state.sh: when bare `no-mistakes axi status` returned an older same-branch failed run while a newer pipeline run on the same branch had advanced its head and was parked at `fix_review`, the helper reported `state: failed - source: run-step - run failed` for a healthy parked worker. A failed misread can drive the watcher to relaunch a healthy parked worker, so this must be fixed root-cause not patched at the symptom. Root cause: bare `axi status` branch+head attribution alone cannot distinguish an older same-code terminal run from a newer active run on the same branch. Fix: when the bare answer is a terminal run on this branch, consult the `axi` home surface (active_run block first, runs[N]{id,branch,status,head,pr} table second) to recover the exact current-branch run ID, then re-query `axi status --run <id>`, verify the ID/branch/code head, and only treat the bare answer as authoritative if no exact-ID run is found. The coarse `no-mistakes runs` fallback also now prefers an active row over a same-code terminal row, so a branch without the home surface still gets the right answer. Coverage: test_newer_parked_run_beats_older_failed_run (fails on pre-fix code, passes post-fix) and test_single_parked_run_counterfactual (smallest counterfactual: single current run still reports parked). Diff scope: bin/fm-crew-state.sh helper set + same-branch same-code precedence tweak; tests/fm-crew-state.test.sh fake axi home surface and the two new tests. No public contracts change; fm-lint clean; existing 48 tests unchanged.

## What Changed
- When bare `axi status` returns a terminal same-branch run, re-resolve through the `axi` home surface (active_run block first, then the `runs[N]{id,branch,status,head,pr}` table) to recover the exact current-branch run ID, then re-query `axi status --run <id>` and verify ID/branch/code head match before treating the bare answer as authoritative.
- The coarse `no-mistakes runs` fallback now prefers an active row over a same-code terminal row, so a branch without the home surface still gets the right answer.
- Added regression test `test_newer_parked_run_beats_older_failed_run` (fails pre-fix), smallest counterfactual `test_single_parked_run_counterfactual` (single current run still reports parked), a fake `axi` home surface fixture, and a documented `FM_CREW_STATE_DEBUG` toggle for run-attribution diagnosis.

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>
</details>
<details>
<summary>✅ **Rebase** - passed</summary>
</details>
<details>
<summary>✅ **Review** - completed</summary>
</details>
<details>
<summary>✅ **Test** - passed</summary>
</details>
<details>
<summary>✅ **Document** - passed</summary>
</details>
<details>
<summary>✅ **Lint** - passed</summary>
</details>
<details>
<summary>✅ **Push** - passed</summary>
</details>