### PR TITLE
fix(bin): keep internal role vocabulary out of worker-published text

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ Address the user as "captain" at least once in every response.
 This is mandatory respectful address, not performance: it applies even when delivering bad news or relaying serious findings, such as "Captain, the build broke - ...".
 Do not force it into every sentence, but never send a response with zero direct address.
 Use light nautical seasoning only when it fits: the occasional "aye", "on deck", "shipshape", "under way", or "ahoy" may land naturally.
-Keep that seasoning optional and never let it obscure technical content; never use it in commits, briefs, PRs, or anything crewmates or other tools read; drop the playful flavor entirely when delivering bad news or relaying serious findings.
+Keep that seasoning optional and never let it obscure technical content; never let it, or firstmate's role vocabulary - captain, first mate, crewmate, crew, scout, second mate - reach a commit, a pull request title or body, a review comment, an issue, or any other file or text that leaves the fleet, whether firstmate or a crewmate writes it; drop the playful flavor entirely when delivering bad news or relaying serious findings.
 For captain-facing escalation style and outcome phrasing, see section 9.
 
 ## 1. Identity and prime directives

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ Address the user as "captain" at least once in every response.
 This is mandatory respectful address, not performance: it applies even when delivering bad news or relaying serious findings, such as "Captain, the build broke - ...".
 Do not force it into every sentence, but never send a response with zero direct address.
 Use light nautical seasoning only when it fits: the occasional "aye", "on deck", "shipshape", "under way", or "ahoy" may land naturally.
-Keep that seasoning optional and never let it obscure technical content; never let it, or firstmate's role vocabulary - captain, first mate, crewmate, crew, scout, second mate - reach a commit, a pull request title or body, a review comment, an issue, or any other file or text that leaves the fleet, whether firstmate or a crewmate writes it; drop the playful flavor entirely when delivering bad news or relaying serious findings.
+Keep that seasoning optional and never let it obscure technical content; never let it, or firstmate's role vocabulary - captain, first mate, crewmate, crew, scout, second mate - reach a commit message, a pull request title or body, a review comment, an issue, or any other file committed to the project, whether firstmate or a crewmate writes it; drop the playful flavor entirely when delivering bad news or relaying serious findings.
 For captain-facing escalation style and outcome phrasing, see section 9.
 
 ## 1. Identity and prime directives

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -403,6 +403,7 @@ Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.
 You drive no-mistakes by responding to its gates, not by implementing fixes.
 Follow the guidance no-mistakes itself provides for the mechanics: it loads when you invoke /no-mistakes, and \`no-mistakes axi run --help\` plus the \`help\` lines in each \`axi\` response are authoritative and version-matched to the installed binary.
 When starting no-mistakes, make \`--intent\` preserve all relevant content from this brief's \`# Task\` section plus every later accepted Firstmate requirement, clarification, constraint, exclusion, and supersession, carrying only each requirement's current accepted form; retain direct requirements instead of substituting a diff summary, and exclude generic operational, status, delivery, and other scaffold boilerplate unless it is task-specific.
+\`--intent\` is published text: the pipeline derives the pull request title, body, and commit text from it, so apply \`# What you publish\` to the intent you compose. Keep every requirement's substance, but rewrite any mention of firstmate's role vocabulary - captain, first mate, crewmate, crew, scout, second mate - and its nautical flavor into \`the repository owner\` or task-specific plain language rather than dropping the requirement.
 Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix.
 
 Two firstmate-specific rules layer on top of that guidance:

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -170,6 +170,16 @@ BRIEF="$DATA/$ID/brief.md"
 [ -e "$BRIEF" ] && { echo "error: $BRIEF already exists" >&2; exit 1; }
 mkdir -p "$DATA/$ID"
 
+# Every generated variant (ship, scout, secondmate charter) carries this section.
+# It governs only what the worker PUBLISHES, never how this brief addresses the
+# worker or how the worker is meant to read this brief; do not rename the
+# in-brief instructional uses of these same words below.
+PUBLISH_SECTION=$(printf '%s\n' \
+'# What you publish' \
+'Never let a pull request title or body, a commit message, a review comment, an issue, or any file committed to the project carry firstmate'\''s internal role vocabulary - captain, first mate, crewmate, crew, scout, second mate - or its nautical flavor.' \
+'Write "the repository owner" or "the owner of the pull request" instead.' \
+'This is about what you publish outside the fleet, not about how this brief addresses you or how you should read it.')
+
 shell_quote() {
   printf "'"
   printf '%s' "$1" | sed "s/'/'\\\\''/g"
@@ -201,6 +211,8 @@ else
 fi
 cat > "$BRIEF" <<EOF
 You are a persistent second mate managed by the main firstmate. Work on your own; do not wait for a human.
+
+$PUBLISH_SECTION
 
 # Charter
 $SECONDMATE_CHARTER
@@ -300,6 +312,8 @@ fi
 if [ "$KIND" = scout ]; then
 cat > "$BRIEF" <<EOF
 You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.
+
+$PUBLISH_SECTION
 
 # Task
 {TASK}
@@ -409,6 +423,8 @@ DOD=${DOD%$'\n'}
 
 cat > "$BRIEF" <<EOF
 You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.
+
+$PUBLISH_SECTION
 
 # Task
 {TASK}

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -45,6 +45,11 @@
 # report rather than a merge, and a charter is not a delivery contract.
 # There is no --yolo flag here. The worker never owns approval decisions, so yolo is
 # a spawn-time and firstmate-side input only (AGENTS.md section 7).
+# Every scaffold opens with a "What you publish" section, before Task or Charter,
+# that forbids firstmate's internal role vocabulary and nautical flavor in anything
+# the worker publishes outside the fleet (PR title or body, commit message, review
+# comment, issue, committed file) and gives "the repository owner" as the wording to
+# use instead. It governs published text only, not how the brief addresses the worker.
 # Every scaffold's status protocol distinguishes the configured
 # declared-external-wait verb (FM_CLASSIFY_PAUSED_VERB, default "paused") from
 # "blocked:": pause for a known external wait expected to clear on its own,

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -708,6 +708,33 @@ test_scout_and_secondmate_scaffold() {
   pass "fm-brief: scout and secondmate code paths still scaffold well-formed briefs"
 }
 
+test_publish_rule_covers_all_variants() {
+  local home ship scout charter
+  home="$TMP_ROOT/publish-rule-home"
+  mkdir -p "$home/data"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" brief-publish-ship firstmate --mode no-mistakes >/dev/null 2>&1
+  ship="$home/data/brief-publish-ship/brief.md"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" brief-publish-scout firstmate --scout >/dev/null 2>&1
+  scout="$home/data/brief-publish-scout/brief.md"
+  FM_HOME="$home" FM_SECONDMATE_CHARTER='sample charter' \
+    "$ROOT/bin/fm-brief.sh" brief-publish-secondmate --secondmate --no-projects >/dev/null 2>&1
+  charter="$home/data/brief-publish-secondmate/brief.md"
+
+  local brief kind
+  for kind_brief in "ship:$ship" "scout:$scout" "secondmate:$charter"; do
+    kind=${kind_brief%%:*}
+    brief=${kind_brief#*:}
+    assert_present "$brief" "$kind: brief was not scaffolded"
+    assert_grep "# What you publish" "$brief" \
+      "$kind: brief missing the publish-vocabulary section"
+    assert_grep "captain, first mate, crewmate, crew, scout, second mate" "$brief" \
+      "$kind: brief did not name the covered role vocabulary"
+    assert_grep "the repository owner" "$brief" \
+      "$kind: brief did not give the substitution to use instead"
+  done
+  pass "fm-brief.sh: every generated variant forbids publishing firstmate's role vocabulary"
+}
+
 test_script_parses
 test_no_heredoc_in_command_substitution
 test_help_includes_entire_header
@@ -728,3 +755,4 @@ test_secondmate_directory_paths_are_absolute_and_output_is_stable
 test_pause_verb_override_renders_all_brief_scaffolds
 test_scout_and_secondmate_load_decision_hold_policy
 test_scout_and_secondmate_scaffold
+test_publish_rule_covers_all_variants

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -345,6 +345,10 @@ test_no_mistakes_dod_wording() {
     "no-mistakes DOD must keep direct requirements and exclude generic scaffold boilerplate from --intent"
   assert_grep "exclude generic operational, status, delivery, and other scaffold boilerplate unless it is task-specific" "$brief" \
     "no-mistakes DOD must exclude non-task-specific scaffold boilerplate from --intent"
+  assert_grep "apply \`# What you publish\` to the intent you compose" "$brief" \
+    "no-mistakes DOD must subject the composed --intent to the publish rule"
+  assert_grep "Keep every requirement's substance" "$brief" \
+    "no-mistakes DOD must require rewriting role vocabulary in --intent without dropping requirements"
   # The apostrophe in "firstmate's authority check" is now structurally safe
   # (no `$(...)` wrapper around the heredoc), so it renders verbatim instead of
   # being reworded or escaped away. test_no_heredoc_in_command_substitution
@@ -720,10 +724,12 @@ test_publish_rule_covers_all_variants() {
     "$ROOT/bin/fm-brief.sh" brief-publish-secondmate --secondmate --no-projects >/dev/null 2>&1
   charter="$home/data/brief-publish-secondmate/brief.md"
 
-  local brief kind
-  for kind_brief in "ship:$ship" "scout:$scout" "secondmate:$charter"; do
+  local brief kind heading publish_line heading_line
+  for kind_brief in "ship:$ship:# Task" "scout:$scout:# Task" "secondmate:$charter:# Charter"; do
     kind=${kind_brief%%:*}
     brief=${kind_brief#*:}
+    heading=${brief#*:}
+    brief=${brief%%:*}
     assert_present "$brief" "$kind: brief was not scaffolded"
     assert_grep "# What you publish" "$brief" \
       "$kind: brief missing the publish-vocabulary section"
@@ -731,6 +737,12 @@ test_publish_rule_covers_all_variants() {
       "$kind: brief did not name the covered role vocabulary"
     assert_grep "the repository owner" "$brief" \
       "$kind: brief did not give the substitution to use instead"
+    publish_line=$(grep -n '^# What you publish$' "$brief" | head -n 1 | cut -d: -f1)
+    heading_line=$(grep -n "^$heading\$" "$brief" | head -n 1 | cut -d: -f1)
+    [ -n "$publish_line" ] && [ -n "$heading_line" ] \
+      || fail "$kind: could not locate the publish section or the $heading heading"
+    [ "$publish_line" -lt "$heading_line" ] \
+      || fail "$kind: publish section (line $publish_line) must precede $heading (line $heading_line)"
   done
   pass "fm-brief.sh: every generated variant forbids publishing firstmate's role vocabulary"
 }


### PR DESCRIPTION
## Intent

Fix a structural leak: firstmate's brief scaffold (bin/fm-brief.sh) puts firstmate's internal role vocabulary (captain, first mate, crewmate, crew, scout, second mate) throughout every worker-facing brief, so a spawned worker reads 'captain' repeatedly in its own instructions and then writes it into the pull requests, commits, and review comments it authors for outside projects. This role vocabulary leaked into at least eighteen real pull requests across ten repositories on 2026-08-05, already hand-corrected; the scaffold itself was unpatched and would keep reproducing the leak on every future dispatch.

Fix: add an explicit 'What you publish' rule to every generated brief variant (ship, scout, secondmate charter) in bin/fm-brief.sh, inserted near the top of each generated document (right after the opening role-declaration line, before the Task/Charter section) so it applies uniformly regardless of delivery mode or Herdr-lab flag. The rule states that nothing the worker publishes outside the fleet - pull request titles/bodies, commit messages, review comments, issues, or any file committed to the project - may contain firstmate's role vocabulary or nautical flavor, and instructs using 'the repository owner' or 'the owner of the pull request' instead. Deliberately preserve every existing internal, worker-facing use of 'captain' elsewhere in the scaffold (e.g. addressing the worker, describing escalation and approval authority) - the rule governs only what the worker writes to external surfaces, not how the brief itself talks to the worker, so no renaming/rewording of the surrounding scaffold text was done.

Also tightened the one AGENTS.md sentence that already gestured at this (in the identity/greeting section) so it explicitly names the same role nouns as covered, rather than reading as being only about playful nautical flavor - edited the existing sentence in place rather than adding a new paragraph, per this repo's size-discipline convention for AGENTS.md.

Swept bin/ and .agents/skills/ for any other place that generates text a worker publishes to an external surface (PR templates, commit-message helpers, status/report scaffolds). Found nothing else to patch: bin/fm-ensure-agents-md.sh's generated AGENTS.md skeleton and the public-followup/X-reply helpers do not inject firstmate's role vocabulary into any generated content.

Extended tests/fm-brief.test.sh with a new test (test_publish_rule_covers_all_variants) asserting all three generated brief kinds contain the new section, name the covered vocabulary, and give the repository-owner substitution. Ran bin/fm-lint.sh (shellcheck 0.11.0, clean) and bin/fm-doc-audience-check.sh (clean) in addition to the full tests/fm-brief.test.sh suite (all pass).

## What Changed

- `bin/fm-brief.sh` now emits a shared `# What you publish` section into every generated brief variant (secondmate charter, scout, ship), placed right after the opening role-declaration line and before `# Task`/`# Charter` so it applies regardless of delivery mode or Herdr-lab flag. It forbids firstmate's internal role vocabulary (captain, first mate, crewmate, crew, scout, second mate) and nautical flavor in PR titles/bodies, commit messages, review comments, issues, and committed files, and directs the worker to write "the repository owner" instead. Existing worker-facing uses of that vocabulary elsewhere in the scaffold are deliberately left intact.
- The ship brief's no-mistakes guidance now treats `--intent` as published text — since the pipeline derives PR title, body, and commit text from it — instructing the worker to rewrite role vocabulary into plain language while preserving each requirement's substance.
- Tightened the AGENTS.md identity/greeting sentence to name the same role nouns explicitly, scoped to committed artifacts; added `test_publish_rule_covers_all_variants` in `tests/fm-brief.test.sh` asserting the section's presence, covered vocabulary, substitution wording, and its placement ahead of the Task/Charter heading in all three variants.

## Risk Assessment

✅ Low: The round-2 delta is two additive, well-bounded changes — one static instruction line inside an existing brief heredoc and an ordering assertion in the existing test — that close the previously reported intent-handoff gap and placement gap with no change to any code path.

## Testing

Ran the full tests/fm-brief.test.sh suite (all pass, including the new test_publish_rule_covers_all_variants), then verified the intent end-to-end the way a dispatched worker would experience it: generated real briefs for all seven variant combinations (ship × no-mistakes/direct-PR/local-only, ±--herdr-lab, scout ±--herdr-lab, secondmate charter) and confirmed the `# What you publish` rule appears at line 3 of each — right after the role-declaration line and before Task/Charter. A base-vs-target diff of a generated brief shows the change is purely additive, with the pre-existing internal `captain` references (authority contract, escalation) intact, matching the intent's explicit preserve-internal-uses constraint. The new test is non-vacuous: it fails against the base scaffold. No screenshots apply — the end-user surface here is a generated markdown brief, so the rendered brief text itself is the reviewer-visible artifact.

<details>
<summary>Evidence: Generated briefs (ship / scout / secondmate) — first 14 lines each, showing the new section in place</summary>

<code>You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.&#10;&#10;# What you publish&#10;Never let a pull request title or body, a commit message, a review comment, an issue, or any file committed to the project carry firstmate&#39;s internal role vocabulary - captain, first mate, crewmate, crew, scout, second mate - or its nautical flavor.&#10;Write &#34;the repository owner&#34; or &#34;the owner of the pull request&#34; instead.&#10;This is about what you publish outside the fleet, not about how this brief addresses you or how you should read it.&#10;&#10;# Task&#10;{TASK}&#10;&#10;(same section, same position, in the scout brief and in the secondmate charter before &#34;# Charter&#34;)</code>

```text
════════════════════════════════════════════════════════
  $ bin/fm-brief.sh demo-ship ...   →  data/demo-ship/brief.md  (first 14 lines)
════════════════════════════════════════════════════════
You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.

# What you publish
Never let a pull request title or body, a commit message, a review comment, an issue, or any file committed to the project carry firstmate's internal role vocabulary - captain, first mate, crewmate, crew, scout, second mate - or its nautical flavor.
Write "the repository owner" or "the owner of the pull request" instead.
This is about what you publish outside the fleet, not about how this brief addresses you or how you should read it.

# Task
{TASK}

# Herdr lifecycle declaration - NOT ENABLED
**HARD SAFETY GATE:** this scaffold cannot inspect the task text that replaces `{TASK}` later.
If the task will start, stop, delete, restart, profile, or otherwise drive Herdr lifecycle behavior, stop and regenerate the brief with `--herdr-lab` before dispatch.
Do not add Herdr lifecycle commands to this unguarded brief by hand.

════════════════════════════════════════════════════════
  $ bin/fm-brief.sh demo-scout ...   →  data/demo-scout/brief.md  (first 14 lines)
════════════════════════════════════════════════════════
You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.

# What you publish
Never let a pull request title or body, a commit message, a review comment, an issue, or any file committed to the project carry firstmate's internal role vocabulary - captain, first mate, crewmate, crew, scout, second mate - or its nautical flavor.
Write "the repository owner" or "the owner of the pull request" instead.
This is about what you publish outside the fleet, not about how this brief addresses you or how you should read it.

# Task
{TASK}

# Herdr lifecycle declaration - NOT ENABLED
**HARD SAFETY GATE:** this scaffold cannot inspect the task text that replaces `{TASK}` later.
If the task will start, stop, delete, restart, profile, or otherwise drive Herdr lifecycle behavior, stop and regenerate the brief with `--herdr-lab` before dispatch.
Do not add Herdr lifecycle commands to this unguarded brief by hand.

════════════════════════════════════════════════════════
  $ bin/fm-brief.sh demo-secondmate ...   →  data/demo-secondmate/brief.md  (first 14 lines)
════════════════════════════════════════════════════════
You are a persistent second mate managed by the main firstmate. Work on your own; do not wait for a human.

# What you publish
Never let a pull request title or body, a commit message, a review comment, an issue, or any file committed to the project carry firstmate's internal role vocabulary - captain, first mate, crewmate, crew, scout, second mate - or its nautical flavor.
Write "the repository owner" or "the owner of the pull request" instead.
This is about what you publish outside the fleet, not about how this brief addresses you or how you should read it.

# Charter
Keep the release branch healthy.

# Routing scope
Keep the release branch healthy.

# Project clones
```
</details>
<details>
<summary>Evidence: Publish-section placement across all 7 variant combinations + preserved internal captain uses</summary>

<code>ship/no-mistakes publish=L3 heading(# Task)=L8&#10;ship/direct-PR publish=L3 heading(# Task)=L8&#10;ship/local-only publish=L3 heading(# Task)=L8&#10;ship/no-mistakes+herdr-lab publish=L3 heading(# Task)=L8&#10;scout publish=L3 heading(# Task)=L8&#10;scout+herdr-lab publish=L3 heading(# Task)=L8&#10;secondmate/--no-projects publish=L3 heading(# Charter)=L8&#10;&#10;Preserved internal uses in the ship brief:&#10;L72: Firstmate applies the authority contract in its `AGENTS.md` and obtains any required captain decision.&#10;L74: - Avoid `--yes`: it would silently bypass firstmate&#39;s authority check and any required captain escalation.</code>

```text
Publish-section placement across every generated variant (line of '# What you publish' vs first Task/Charter heading):
  ship/no-mistakes             publish=L3  heading(# Task)=L8
  ship/direct-PR               publish=L3  heading(# Task)=L8
  ship/local-only              publish=L3  heading(# Task)=L8
  ship/no-mistakes+herdr-lab   publish=L3  heading(# Task)=L8
  scout                        publish=L3  heading(# Task)=L8
  scout+herdr-lab              publish=L3  heading(# Task)=L8
  secondmate/--no-projects     publish=L3  heading(# Charter)=L8

Internal, worker-facing 'captain' uses preserved in the ship brief (unchanged from base):
4:Never let a pull request title or body, a commit message, a review comment, an issue, or any file committed to the project carry firstmate's internal role vocabulary - captain, first mate, crewmate, crew, scout, second mate - or its nautical flavor.
67:`--intent` is published text: the pipeline derives the pull request title, body, and commit text from it, so apply `# What you publish` to the intent you compose. Keep every requirement's substance, but rewrite any mention of firstmate's role vocabulary - captain, first mate, crewmate, crew, scout, second mate - and its nautical flavor into `the repository owner` or task-specific plain language rather than dropping the requirement.
72:  Firstmate applies the authority contract in its `AGENTS.md` and obtains any required captain decision.
74:- Avoid `--yes`: it would silently bypass firstmate's authority check and any required captain escalation.
```
</details>
<details>
<summary>Evidence: Diff of a real generated brief: base commit ef2c3a2 vs target 509c4ad (additions only)</summary>

```text
diff: ship/no-mistakes brief generated by BASE commit ef2c3a2  vs  TARGET commit 509c4ad
(- base, + target).  Only additions; no existing internal 'captain' line changed.

--- base/brief.md
+++ target/brief.md
@@ -1,5 +1,10 @@
 You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.
 
+# What you publish
+Never let a pull request title or body, a commit message, a review comment, an issue, or any file committed to the project carry firstmate's internal role vocabulary - captain, first mate, crewmate, crew, scout, second mate - or its nautical flavor.
+Write "the repository owner" or "the owner of the pull request" instead.
+This is about what you publish outside the fleet, not about how this brief addresses you or how you should read it.
+
 # Task
 {TASK}
 
@@ -23,7 +28,7 @@
 2. Stay inside this worktree; modify nothing outside it.
 3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
 4. Report status by appending one line:
-   `echo "{state}: {one short line}" >> '/var/folders/pr/xnxhrbwx7lj7lw2d1ymnbprr0000gn/T/tmp.JuPkqe5lXU/state/b.status'`
+   `echo "{state}: {one short line}" >> '/var/folders/pr/xnxhrbwx7lj7lw2d1ymnbprr0000gn/T/tmp.597St9tNMN/state/b.status'`
    States: working, needs-decision, blocked, paused, done, failed.
    Each append wakes firstmate, so report sparingly: only phase changes a supervisor
    would act on (setup done, bug reproduced, fix implemented, validation passed) and the
@@ -44,10 +49,10 @@
    daemon error, append `blocked: {the daemon error}` and stop; only firstmate manages the daemon.
 
 # Project memory
-If `AGENTS.md` or `CLAUDE.md` already exists, or if this task produced durable project-intrinsic knowledge, run `/var/folders/pr/xnxhrbwx7lj7lw2d1ymnbprr0000gn/T/tmp.PoR1xIShd8/bin/fm-ensure-agents-md.sh .` in the worktree.
+If `AGENTS.md` or `CLAUDE.md` already exists, or if this task produced durable project-intrinsic knowledge, run `/Users/dimitri/.no-mistakes/worktrees/8868f3281eff/01KZ952Z0N0SHKCVSQ9JBHAJX1/bin/fm-ensure-agents-md.sh .` in the worktree.
 Record only project knowledge useful to almost every future session.
 For anything the codebase already shows, prefer a pointer to the authoritative file, command, or doc over copying the detail.
-If you touch a project `AGENTS.md` that lacks `## Maintaining this file`, add that short self-governance section from `/var/folders/pr/xnxhrbwx7lj7lw2d1ymnbprr0000gn/T/tmp.PoR1xIShd8/bin/fm-ensure-agents-md.sh` in the same pass.
+If you touch a project `AGENTS.md` that lacks `## Maintaining this file`, add that short self-governance section from `/Users/dimitri/.no-mistakes/worktrees/8868f3281eff/01KZ952Z0N0SHKCVSQ9JBHAJX1/bin/fm-ensure-agents-md.sh` in the same pass.
 Keep it proportionate: skip `AGENTS.md` edits for trivial tasks that produced no durable project knowledge.
 
 # Definition of done
@@ -59,6 +64,7 @@
 You drive no-mistakes by responding to its gates, not by implementing fixes.
 Follow the guidance no-mistakes itself provides for the mechanics: it loads when you invoke /no-mistakes, and `no-mistakes axi run --help` plus the `help` lines in each `axi` response are authoritative and version-matched to the installed binary.
 When starting no-mistakes, make `--intent` preserve all relevant content from this brief's `# Task` section plus every later accepted Firstmate requirement, clarification, constraint, exclusion, and supersession, carrying only each requirement's current accepted form; retain direct requirements instead of substituting a diff summary, and exclude generic operational, status, delivery, and other scaffold boilerplate unless it is task-specific.
+`--intent` is published text: the pipeline derives the pull request title, body, and commit text from it, so apply `# What you publish` to the intent you compose. Keep every requirement's substance, but rewrite any mention of firstmate's role vocabulary - captain, first mate, crewmate, crew, scout, second mate - and its nautical flavor into `the repository owner` or task-specific plain language rather than dropping the requirement.
 Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix.
 
 Two firstmate-specific rules layer on top of that guidance:

grep -c -i captain :  base=2  target=4
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 3 issues found → auto-fixed ✅</summary>

- ⚠️ `bin/fm-brief.sh:405` - The no-mistakes ship brief tells the worker to make `--intent` &#34;preserve all relevant content from this brief&#39;s `# Task` section plus every later accepted Firstmate requirement&#34; and to &#34;retain direct requirements instead of substituting a diff summary&#34; — i.e. carry firstmate-authored text through verbatim. Task text and later steer messages are exactly where firstmate&#39;s role vocabulary lives, and the no-mistakes pipeline derives the published PR title/body (and commit trailer text) from that intent, so a `captain`/`crewmate` mention can still reach an external surface without the worker ever typing it into a PR body itself. The new `# What you publish` section enumerates &#34;a pull request title or body, a commit message, a review comment, an issue, or any file committed to the project&#34; but not the `--intent` handoff, leaving a direct tension between &#34;preserve verbatim&#34; (line 405) and &#34;never let it reach a PR body&#34; (line 179). Suggest naming the intent/hand-off string explicitly in the publish rule, or adding a sanitize-on-transfer clause at line 405.
- ℹ️ `AGENTS.md:11` - The tightened sentence now lists `scout` and `second mate` as vocabulary that must never leave the fleet, while AGENTS.md:416 (section 9, captain etiquette) states &#34;Scout and second mate are accepted Firstmate nautical house vocabulary and do not need translation&#34;. The two are reconcilable — 416 governs captain-facing messages, which stay inside the fleet — but the scoping is implicit and a reader landing on 416 first gets the opposite signal. Noting only; no change required if the audience split is considered clear enough.
- ℹ️ `tests/fm-brief.test.sh:728` - test_publish_rule_covers_all_variants asserts only that the section is present somewhere in each brief, not that it sits near the top (after the role-declaration line, before `# Task`/`# Charter`) — the placement the intent calls out as the reason it applies uniformly. A future edit that moves `$PUBLISH_SECTION` below the Task section, or after the mode-specific Definition of done, would keep the test green while burying the rule. A cheap ordering assertion (publish-section line number &lt; `# Task`/`# Charter` line number) would pin it.

🔧 Fix: scrub role vocabulary from --intent; pin publish-section placement
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash tests/fm-brief.test.sh` — full fm-brief suite including the new `test_publish_rule_covers_all_variants` (all pass)</code>
- <code>Negative control: restored base `bin/fm-brief.sh` (ef2c3a2) and re-ran `bash tests/fm-brief.test.sh` — the new assertions fail as expected, then restored the target file (worktree verified clean via `git status --porcelain`)</code>
- <code>Manual CLI generation of every variant: `bin/fm-brief.sh &lt;id&gt; firstmate --mode no-mistakes|direct-PR|local-only`, `--mode no-mistakes --herdr-lab`, `--scout`, `--scout --herdr-lab`, and `FM_SECONDMATE_CHARTER=... --secondmate --no-projects`; recorded the line number of `# What you publish` vs the first `# Task`/`# Charter` heading in each</code>
- <code>`diff -u` of the ship/no-mistakes brief generated by the base commit vs the target commit, plus `grep -i captain` on both to confirm existing internal uses are preserved</code>
- <code>Sweep spot-check: ran `bin/fm-ensure-agents-md.sh` on a scratch git repo and grepped its generated AGENTS.md skeleton for role vocabulary (no hits), confirming the intent&#39;s claim that nothing else in bin/ needed patching</code>

</details>

<details>
<summary>🔧 **Document** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `AGENTS.md:11` - AGENTS.md:11 now forbids firstmate&#39;s role vocabulary and nautical flavor in &#34;any other file or text that leaves the fleet&#34;, which is broader than the change&#39;s stated scope (work artifacts a worker publishes) and directly contradicts .agents/skills/fmx-respond/SKILL.md:107-110, which deliberately instructs public X replies to address the asker as &#34;captain&#34; in a &#34;lightly nautical first-mate persona&#34;. An X reply is public text that leaves the fleet. Only two resolutions exist and both are policy calls the author must make: narrow the AGENTS.md clause to project/work artifacts (commits, PRs, review comments, issues, committed files), or carve out an explicit exception for the fmx-respond public-voice channel. I did not edit either surface, since narrowing the newly authored rule or adding an exception would weaken a rule the author just tightened on purpose.

🔧 Fix: narrow AGENTS.md publish-vocabulary clause to committed artifacts
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
