### PR TITLE
feat: sync configured env into task worktrees

### DIFF
--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1868,6 +1868,13 @@ if [ "$KIND" != secondmate ] && [ "$BACKEND" != orca ]; then
   validate_spawn_worktree "treehouse get" "$T"
 fi
 
+# Task-specific local environment files are copied only after every backend has produced and validated an isolated worktree.
+# The helper makes an absent mapping a silent no-op.
+# Unsafe or unavailable configured inputs become warnings, so environment synchronization cannot block a ship or scout launch.
+if [ "$KIND" != secondmate ] && ! "$SCRIPT_DIR/fm-worktree-env-sync.sh" "$CONFIG" "$PROJ_ABS" "$WT"; then
+  echo "warning: worktree environment synchronization could not complete; continuing without a copied environment file" >&2
+fi
+
 # Per-task temp root: /tmp/fm-<id>/ with Go's build temp nested at gotmp/. Go won't
 # create GOTMPDIR, so mkdir before it is used; fm-teardown removes the whole root.
 # Nested (not a bare /tmp/fm-<id>/gotmp) so other per-task temp can live alongside

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -193,7 +193,7 @@ family_for_basename() {
     fm-herdr-session-cleanup.test.sh|fm-send-strict.test.sh|fm-spawn-batch.test.sh|\
     fm-spawn-dispatch-profile.test.sh|\
     fm-trace-context-spawn.test.sh|fm-spawn-worktree-settle.test.sh|\
-    fm-teardown-endpoint-safety.test.sh)
+    fm-worktree-env-sync.test.sh|fm-teardown-endpoint-safety.test.sh)
       printf '%s\n' backend-dispatch
       ;;
     fm-pr-check-security.test.sh|fm-pr-merge.test.sh|fm-review-diff.test.sh|\
@@ -926,7 +926,7 @@ families_for_changed_path() {
       printf '%s\n' pure-contract-unit
       printf '%s\n' pr-forge
       ;;
-    bin/fm-spawn.sh|bin/fm-send.sh|bin/fm-harness.sh|\
+    bin/fm-spawn.sh|bin/fm-worktree-env-sync.sh|bin/fm-send.sh|bin/fm-harness.sh|\
     bin/fm-peek.sh|bin/fm-composer*)
       printf '%s\n' backend-dispatch
       printf '%s\n' pure-contract-unit

--- a/bin/fm-worktree-env-sync.sh
+++ b/bin/fm-worktree-env-sync.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+# Copy a configured local environment file into an isolated task worktree.
+# Usage: fm-worktree-env-sync.sh <config-dir> <project-root> <worktree-root>
+#
+# Reads the optional local, gitignored <config-dir>/worktree-env-sync.tsv file.
+# Each non-empty, non-comment row is exactly:
+#   <project-root><TAB><source-file><TAB><worktree-relative-target>
+#
+# project-root and source-file are absolute paths and are compared after physical
+# resolution. worktree-relative-target is a relative file path below the task
+# worktree. The script never prints configured paths or environment contents.
+# A matching missing source, invalid mapping, non-ignored target, or copy error
+# prints a warning and leaves the spawn able to continue. An absent mapping file
+# is a silent no-op.
+set -u
+
+usage() {
+  sed -n '2,${/^#/!q;p;}' "$0" | sed 's/^# \{0,1\}//'
+}
+
+case "${1:-}" in
+  -h|--help) usage; exit 0 ;;
+esac
+
+[ "$#" -eq 3 ] || {
+  usage >&2
+  exit 2
+}
+
+config_dir=$1
+project_root=$2
+worktree_root=$3
+mapping_file="$config_dir/worktree-env-sync.tsv"
+
+warn() {
+  printf 'warning: worktree environment synchronization: %s\n' "$1" >&2
+}
+
+physical_dir() {  # <directory>
+  CDPATH='' cd -- "$1" 2>/dev/null && pwd -P
+}
+
+is_safe_target() {  # <relative-path>
+  local target=$1 component
+  local IFS=/
+  local -a components
+  case "$target" in
+    ''|/*|.|..|../*|*/../*|*/..|*//*) return 1 ;;
+  esac
+  read -r -a components <<< "$target"
+  for component in "${components[@]}"; do
+    [ -n "$component" ] && [ "$component" != . ] && [ "$component" != .. ] || return 1
+  done
+}
+
+prepare_target_parent() {  # <worktree-root> <relative-target>
+  local root=$1 target=$2 parent_rel current component
+  local IFS=/
+  local -a components
+  parent_rel=${target%/*}
+  [ "$parent_rel" = "$target" ] && parent_rel=
+  current=$root
+  read -r -a components <<< "$parent_rel"
+  for component in "${components[@]}"; do
+    [ -n "$component" ] || continue
+    [ ! -L "$current/$component" ] || return 1
+    if [ ! -e "$current/$component" ]; then
+      mkdir "$current/$component" || return 1
+    fi
+    [ -d "$current/$component" ] || return 1
+    current="$current/$component"
+  done
+  printf '%s\n' "$current"
+}
+
+[ -e "$mapping_file" ] || [ -L "$mapping_file" ] || exit 0
+[ -f "$mapping_file" ] && [ -r "$mapping_file" ] || {
+  warn 'the local mapping file is unreadable; continuing without a copied environment file'
+  exit 0
+}
+
+project_real=$(physical_dir "$project_root") || {
+  warn 'the project root could not be resolved; continuing without a copied environment file'
+  exit 0
+}
+worktree_real=$(physical_dir "$worktree_root") || {
+  warn 'the task worktree could not be resolved; continuing without a copied environment file'
+  exit 0
+}
+
+match_count=0
+source_file=
+target_rel=
+tab=$(printf '\t')
+while IFS="$tab" read -r mapped_project mapped_source mapped_target extra || [ -n "${mapped_project:-}${mapped_source:-}${mapped_target:-}${extra:-}" ]; do
+  case "${mapped_project:-}" in
+    ''|'#'*) continue ;;
+  esac
+  if [ -z "${mapped_source:-}" ] || [ -z "${mapped_target:-}" ] || [ -n "${extra:-}" ]; then
+    warn 'the local mapping file has an invalid row; continuing without that environment file'
+    continue
+  fi
+  mapped_project_real=$(physical_dir "$mapped_project") || continue
+  [ "$mapped_project_real" = "$project_real" ] || continue
+  match_count=$((match_count + 1))
+  source_file=$mapped_source
+  target_rel=$mapped_target
+done < "$mapping_file"
+
+case "$match_count" in
+  0) exit 0 ;;
+  1) ;;
+  *)
+    warn 'the local mapping file has multiple rows for this project; continuing without a copied environment file'
+    exit 0
+    ;;
+esac
+
+case "$source_file" in
+  /*) ;;
+  *)
+    warn 'the configured source file is not an absolute path; continuing without a copied environment file'
+    exit 0
+    ;;
+esac
+is_safe_target "$target_rel" || {
+  warn 'the configured worktree target is unsafe; continuing without a copied environment file'
+  exit 0
+}
+[ -f "$source_file" ] && [ -r "$source_file" ] || {
+  warn 'a local environment file is configured for this project, but its source file is missing; continuing without a copied environment file'
+  exit 0
+}
+
+if git -C "$worktree_real" ls-files --error-unmatch -- "$target_rel" >/dev/null 2>&1; then
+  warn 'the configured worktree target is tracked; refusing to overwrite it'
+  exit 0
+fi
+if ! git -C "$worktree_real" check-ignore -q --no-index -- "$target_rel" 2>/dev/null; then
+  warn 'the configured worktree target is not git-ignored; refusing to copy the environment file'
+  exit 0
+fi
+
+target_parent=$(prepare_target_parent "$worktree_real" "$target_rel") || {
+  warn 'the configured worktree target parent is unsafe; continuing without a copied environment file'
+  exit 0
+}
+target_file="$worktree_real/$target_rel"
+[ ! -L "$target_file" ] || {
+  warn 'the configured worktree target is a symlink; refusing to copy the environment file'
+  exit 0
+}
+[ ! -e "$target_file" ] || [ -f "$target_file" ] || {
+  warn 'the configured worktree target is not a regular file; refusing to copy the environment file'
+  exit 0
+}
+
+old_umask=$(umask)
+umask 077
+temp_file=$(mktemp "$target_parent/.fm-worktree-env.XXXXXXXX") || {
+  umask "$old_umask"
+  warn 'could not prepare the environment-file copy; continuing without it'
+  exit 0
+}
+umask "$old_umask"
+if ! cp "$source_file" "$temp_file" || ! mv -f "$temp_file" "$target_file"; then
+  rm -f "$temp_file"
+  warn 'could not copy the configured environment file; continuing without it'
+  exit 0
+fi
+if ! git -C "$worktree_real" check-ignore -q -- "$target_rel" 2>/dev/null; then
+  rm -f "$target_file"
+  warn 'the copied environment file was not git-ignored; removed it'
+  exit 0
+fi

--- a/bin/fm-worktree-env-sync.sh
+++ b/bin/fm-worktree-env-sync.sh
@@ -48,7 +48,7 @@ is_safe_target() {  # <relative-path>
     ''|/*|.|..|../*|*/../*|*/..|*//*) return 1 ;;
   esac
   read -r -a components <<< "$target"
-  for component in "${components[@]}"; do
+  for component in "${components[@]+"${components[@]}"}"; do
     [ -n "$component" ] && [ "$component" != . ] && [ "$component" != .. ] || return 1
   done
 }
@@ -61,11 +61,11 @@ prepare_target_parent() {  # <worktree-root> <relative-target>
   [ "$parent_rel" = "$target" ] && parent_rel=
   current=$root
   read -r -a components <<< "$parent_rel"
-  for component in "${components[@]}"; do
+  for component in "${components[@]+"${components[@]}"}"; do
     [ -n "$component" ] || continue
     [ ! -L "$current/$component" ] || return 1
     if [ ! -e "$current/$component" ]; then
-      mkdir "$current/$component" || return 1
+      mkdir "$current/$component" 2>/dev/null || return 1
     fi
     [ -d "$current/$component" ] || return 1
     current="$current/$component"
@@ -155,15 +155,22 @@ target_file="$worktree_real/$target_rel"
   exit 0
 }
 
+temp_file=
+cleanup_temp_file() {
+  [ -z "$temp_file" ] || rm -f -- "$temp_file" 2>/dev/null
+}
+trap cleanup_temp_file EXIT
+trap 'cleanup_temp_file; exit 143' HUP INT TERM
+
 old_umask=$(umask)
 umask 077
-temp_file=$(mktemp "$target_parent/.fm-worktree-env.XXXXXXXX") || {
+temp_file=$(mktemp "$target_parent/.fm-worktree-env.XXXXXXXX" 2>/dev/null) || {
   umask "$old_umask"
   warn 'could not prepare the environment-file copy; continuing without it'
   exit 0
 }
 umask "$old_umask"
-if ! cp "$source_file" "$temp_file" || ! mv -f "$temp_file" "$target_file"; then
+if ! cp "$source_file" "$temp_file" 2>/dev/null || ! mv -f "$temp_file" "$target_file" 2>/dev/null; then
   rm -f "$temp_file"
   warn 'could not copy the configured environment file; continuing without it'
   exit 0

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -94,6 +94,18 @@ The caller-facing label remains `fm-<id>`, but the actual cmux workspace title i
 Test cleanup must use the guarded path in [`docs/cmux-backend.md`](cmux-backend.md#current-operation-and-safety), never enumerate-and-close every workspace.
 `config/backend` is inherited into secondmate homes under the primary-authoritative contract owned by [`secondmate-provisioning`](../.agents/skills/secondmate-provisioning/SKILL.md).
 
+## Worktree environment synchronization (config/worktree-env-sync.tsv)
+
+The optional local, gitignored `config/worktree-env-sync.tsv` maps one project root to one local source environment file and one relative target path in a task worktree.
+Each tab-separated row has those three fields in that order, while comments and blank rows are ignored.
+`bin/fm-worktree-env-sync.sh --help` owns the exact row syntax, path validation, and copy mechanics.
+`fm-spawn.sh` runs it only after ship and scout worktrees have been proven isolated, so all supported worktree providers get the same behavior.
+An absent mapping file preserves today's behavior without output.
+A matching missing source, unsafe mapping, unignored target, or copy failure prints a warning without preventing the worker from starting.
+The target must already be ignored in the task worktree before the file is copied, and the helper removes it if a post-copy ignore check fails.
+The helper never prints configured paths or environment-file contents.
+Secondmate homes are not task worktrees and are not affected.
+
 ## Away-mode supervisor backend (FM_SUPERVISOR_BACKEND / FM_SUPERVISOR_TARGET)
 
 The `/afk` sub-supervisor injects escalation digests into firstmate's own pane independently of where new task endpoints are spawned.

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -47,6 +47,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-remote-home-seed.sh` | Register and provision a whole secondmate home on an SSH-reachable host              |
 | `fm-remote-readiness-lib.sh` | Shared remote second-mate readiness gate: check and, when needed, repair then re-check through `fm-remote-doctor.sh` |
 | `fm-spawn.sh`            | Spawn crewmates, scouts, `id=repo` batches, and secondmates on the resolved harness and runtime backend |
+| `fm-worktree-env-sync.sh` | Copy a project's configured local environment file into its isolated task worktree, warning instead of blocking the spawn |
 | `fm-backend.sh`          | Runtime-backend selection, meta helpers, selector resolution, and operation dispatch |
 | `fm-backend-hometag-lib.sh` | Shared per-installation home-tag derivation for zellij tab and cmux workspace titles |
 | `fm-composer-lib.sh`     | Single fleet-wide owner of composer-content classification for all backends          |

--- a/tests/fm-spawn-worktree-settle.test.sh
+++ b/tests/fm-spawn-worktree-settle.test.sh
@@ -128,22 +128,6 @@ test_single_stale_first_read_is_not_accepted() {
 # A pane that reports the real worktree from the very first read still only
 # costs the loop's existing one-second inter-poll sleep to confirm - not an
 # extra full cycle on top of that.
-test_spawn_syncs_a_configured_environment_file() {
-  local rec id out status
-  id=settle-env-sync-z3
-  rec=$(make_settle_case settle-env-sync "$id" 0)
-  read_settle_record "$rec"
-  printf 'test-only-content\n' > "$PROJ_DIR/.env"
-  printf '%s\t%s\t.env\n' "$PROJ_DIR" "$PROJ_DIR/.env" > "$HOME_DIR/config/worktree-env-sync.tsv"
-
-  out=$(run_settle_spawn "$id")
-  status=$?
-  expect_code 0 "$status" "spawn should synchronize a configured environment file"
-  cmp -s "$PROJ_DIR/.env" "$WT_DIR/.env" || fail "spawn did not copy the configured environment file into its worktree"
-  git -C "$WT_DIR" check-ignore -q -- .env || fail "spawn copied an environment file to a non-ignored worktree target"
-  pass "spawn synchronizes configured local environment files after worktree setup"
-}
-
 test_already_settled_pane_costs_one_confirm_sleep() {
   local rec id out status start end elapsed
   id=settle-already-settled-z2
@@ -162,8 +146,24 @@ test_already_settled_pane_costs_one_confirm_sleep() {
   pass "an already-settled pane confirms via the existing inter-poll sleep, not an extra full cycle"
 }
 
+test_spawn_syncs_a_configured_environment_file() {
+  local rec id out status
+  id=settle-env-sync-z3
+  rec=$(make_settle_case settle-env-sync "$id" 0)
+  read_settle_record "$rec"
+  printf 'test-only-content\n' > "$PROJ_DIR/.env"
+  printf '%s\t%s\t.env\n' "$PROJ_DIR" "$PROJ_DIR/.env" > "$HOME_DIR/config/worktree-env-sync.tsv"
+
+  out=$(run_settle_spawn "$id")
+  status=$?
+  expect_code 0 "$status" "spawn should synchronize a configured environment file"
+  cmp -s "$PROJ_DIR/.env" "$WT_DIR/.env" || fail "spawn did not copy the configured environment file into its worktree"
+  git -C "$WT_DIR" check-ignore -q -- .env || fail "spawn copied an environment file to a non-ignored worktree target"
+  pass "spawn synchronizes configured local environment files after worktree setup"
+}
+
 test_single_stale_first_read_is_not_accepted
-test_spawn_syncs_a_configured_environment_file
 test_already_settled_pane_costs_one_confirm_sleep
+test_spawn_syncs_a_configured_environment_file
 
 echo "# all fm-spawn-worktree-settle tests passed"

--- a/tests/fm-spawn-worktree-settle.test.sh
+++ b/tests/fm-spawn-worktree-settle.test.sh
@@ -64,7 +64,7 @@ SH
 # entirely, distinct from both the project and the worktree - mirroring the
 # live incident where the stale read was another real firstmate home).
 make_settle_case() {
-  local name=$1 id=$2 stale_reads=$3 case_dir home proj wt stale fakebin countfile
+  local name=$1 id=$2 stale_reads=$3 case_dir home proj wt stale fakebin countfile project_branch
   case_dir="$TMP_ROOT/$name"
   home="$case_dir/home"
   proj="$case_dir/project"
@@ -75,6 +75,11 @@ make_settle_case() {
   mkdir -p "$home/data" "$home/projects" "$home/state" "$home/config"
   printf 'codex\n' > "$home/config/crew-harness"
   fm_git_worktree "$proj" "$wt" "wt-$name"
+  printf '.env\n' > "$proj/.gitignore"
+  git -C "$proj" add .gitignore
+  git -C "$proj" -c user.name='Firstmate Tests' -c user.email='tests@example.invalid' commit -qm 'ignore environment file'
+  project_branch=$(git -C "$proj" branch --show-current)
+  git -C "$wt" merge --quiet --ff-only "$project_branch"
   fm_git_init_commit "$stale"
   mkdir -p "$home/data/$id"
   printf 'brief for %s\n' "$id" > "$home/data/$id/brief.md"
@@ -123,6 +128,22 @@ test_single_stale_first_read_is_not_accepted() {
 # A pane that reports the real worktree from the very first read still only
 # costs the loop's existing one-second inter-poll sleep to confirm - not an
 # extra full cycle on top of that.
+test_spawn_syncs_a_configured_environment_file() {
+  local rec id out status
+  id=settle-env-sync-z3
+  rec=$(make_settle_case settle-env-sync "$id" 0)
+  read_settle_record "$rec"
+  printf 'test-only-content\n' > "$PROJ_DIR/.env"
+  printf '%s\t%s\t.env\n' "$PROJ_DIR" "$PROJ_DIR/.env" > "$HOME_DIR/config/worktree-env-sync.tsv"
+
+  out=$(run_settle_spawn "$id")
+  status=$?
+  expect_code 0 "$status" "spawn should synchronize a configured environment file"
+  cmp -s "$PROJ_DIR/.env" "$WT_DIR/.env" || fail "spawn did not copy the configured environment file into its worktree"
+  git -C "$WT_DIR" check-ignore -q -- .env || fail "spawn copied an environment file to a non-ignored worktree target"
+  pass "spawn synchronizes configured local environment files after worktree setup"
+}
+
 test_already_settled_pane_costs_one_confirm_sleep() {
   local rec id out status start end elapsed
   id=settle-already-settled-z2
@@ -142,6 +163,7 @@ test_already_settled_pane_costs_one_confirm_sleep() {
 }
 
 test_single_stale_first_read_is_not_accepted
+test_spawn_syncs_a_configured_environment_file
 test_already_settled_pane_costs_one_confirm_sleep
 
 echo "# all fm-spawn-worktree-settle tests passed"

--- a/tests/fm-worktree-env-sync.test.sh
+++ b/tests/fm-worktree-env-sync.test.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# Behavior tests for bin/fm-worktree-env-sync.sh.
+#
+# The mapping fixture is local to each temporary test directory and contains
+# only generated fake paths. It verifies that an absent mapping is silent, a
+# missing configured source warns without stopping the caller, a mapped source
+# is copied, and a non-ignored target is refused before any copy occurs.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+SYNC="$ROOT/bin/fm-worktree-env-sync.sh"
+TMP_ROOT=$(fm_test_tmproot fm-worktree-env-sync)
+
+make_case() {
+  local name=$1 case_dir project worktree config source project_branch
+  case_dir="$TMP_ROOT/$name"
+  project="$case_dir/project"
+  worktree="$case_dir/worktree"
+  config="$case_dir/config"
+  source="$case_dir/source.env"
+  fm_git_worktree "$project" "$worktree" "wt-$name"
+  printf '.env\n' > "$project/.gitignore"
+  git -C "$project" add .gitignore
+  git -C "$project" -c user.name='Firstmate Tests' -c user.email='tests@example.invalid' commit -qm 'ignore environment file'
+  project_branch=$(git -C "$project" branch --show-current)
+  git -C "$worktree" merge --quiet --ff-only "$project_branch"
+  mkdir -p "$config"
+  printf '%s\n' "$project|$worktree|$config|$source"
+}
+
+read_case() {
+  IFS='|' read -r PROJECT WORKTREE CONFIG SOURCE <<EOF
+$1
+EOF
+}
+
+write_mapping() {  # <target>
+  printf '%s\t%s\t%s\n' "$PROJECT" "$SOURCE" "$1" > "$CONFIG/worktree-env-sync.tsv"
+}
+
+run_sync() {
+  "$SYNC" "$CONFIG" "$PROJECT" "$WORKTREE" 2>&1
+}
+
+test_no_mapping_is_silent_noop() {
+  local record out status
+  record=$(make_case no-mapping)
+  read_case "$record"
+  out=$(run_sync)
+  status=$?
+  expect_code 0 "$status" "an absent mapping file should not fail synchronization"
+  [ -z "$out" ] || fail "an absent mapping file should be silent, got: $out"
+  [ ! -e "$WORKTREE/.env" ] || fail "an absent mapping unexpectedly copied an environment file"
+  pass "worktree env sync is a silent no-op without local configuration"
+}
+
+test_missing_source_warns_without_copying() {
+  local record out status
+  record=$(make_case missing-source)
+  read_case "$record"
+  write_mapping .env
+  out=$(run_sync)
+  status=$?
+  expect_code 0 "$status" "a missing source should not fail synchronization"
+  assert_contains "$out" 'source file is missing' "missing source warning was not conspicuous"
+  [ ! -e "$WORKTREE/.env" ] || fail "a missing source unexpectedly created an environment file"
+  pass "a configured missing source warns and leaves the worktree unchanged"
+}
+
+test_copy_places_the_configured_environment_file() {
+  local record out status
+  record=$(make_case copy)
+  read_case "$record"
+  printf 'test-only-content\n' > "$SOURCE"
+  write_mapping .env
+  out=$(run_sync)
+  status=$?
+  expect_code 0 "$status" "a configured source should synchronize"
+  [ -z "$out" ] || fail "a successful synchronization should not expose paths or values: $out"
+  cmp -s "$SOURCE" "$WORKTREE/.env" || fail "the worktree environment file did not match the configured source"
+  git -C "$WORKTREE" check-ignore -q -- .env || fail "the copied environment file is not git-ignored"
+  pass "a configured source is copied into the ignored worktree target"
+}
+
+test_nonignored_target_is_refused_before_copying() {
+  local record out status
+  record=$(make_case gitignore)
+  read_case "$record"
+  printf 'test-only-content\n' > "$SOURCE"
+  write_mapping visible.env
+  out=$(run_sync)
+  status=$?
+  expect_code 0 "$status" "an unsafe target should not fail the caller"
+  assert_contains "$out" 'not git-ignored' "non-ignored target refusal was not conspicuous"
+  [ ! -e "$WORKTREE/visible.env" ] || fail "a non-ignored target received a copied environment file"
+  pass "environment files are copied only to git-ignored worktree targets"
+}
+
+test_no_mapping_is_silent_noop
+test_missing_source_warns_without_copying
+test_copy_places_the_configured_environment_file
+test_nonignored_target_is_refused_before_copying
+
+echo "# all fm-worktree-env-sync tests passed"

--- a/tests/fm-worktree-env-sync.test.sh
+++ b/tests/fm-worktree-env-sync.test.sh
@@ -4,7 +4,8 @@
 # The mapping fixture is local to each temporary test directory and contains
 # only generated fake paths. It verifies that an absent mapping is silent, a
 # missing configured source warns without stopping the caller, a mapped source
-# is copied, and a non-ignored target is refused before any copy occurs.
+# is copied under both the default and the stock system interpreter, and a
+# non-ignored target is refused before any copy occurs.
 set -u
 
 # shellcheck source=tests/lib.sh
@@ -40,8 +41,14 @@ write_mapping() {  # <target>
   printf '%s\t%s\t%s\n' "$PROJECT" "$SOURCE" "$1" > "$CONFIG/worktree-env-sync.tsv"
 }
 
-run_sync() {
-  "$SYNC" "$CONFIG" "$PROJECT" "$WORKTREE" 2>&1
+run_sync() {  # [interpreter]
+  "${1:-bash}" "$SYNC" "$CONFIG" "$PROJECT" "$WORKTREE" 2>&1
+}
+
+assert_no_staging_leftovers() {  # <context>
+  local leftover
+  leftover=$(git -C "$WORKTREE" status --porcelain 2>/dev/null | grep '\.fm-worktree-env\.' || true)
+  [ -z "$leftover" ] || fail "$1 left a commit-visible staging file: $leftover"
 }
 
 test_no_mapping_is_silent_noop() {
@@ -81,7 +88,28 @@ test_copy_places_the_configured_environment_file() {
   [ -z "$out" ] || fail "a successful synchronization should not expose paths or values: $out"
   cmp -s "$SOURCE" "$WORKTREE/.env" || fail "the worktree environment file did not match the configured source"
   git -C "$WORKTREE" check-ignore -q -- .env || fail "the copied environment file is not git-ignored"
+  assert_no_staging_leftovers "a successful synchronization"
   pass "a configured source is copied into the ignored worktree target"
+}
+
+# The worktree-root target is the common mapping and exercises the empty
+# parent-component path. Stock macOS Bash 3.2 aborts an empty array expansion
+# under `set -u`, and CI only parse-checks that interpreter, so run the helper
+# through /bin/bash directly to keep that runtime honest.
+test_worktree_root_target_copies_under_system_bash() {
+  local record out status
+  [ -x /bin/bash ] || { pass "worktree env sync system bash coverage skipped without /bin/bash"; return; }
+  record=$(make_case system-bash)
+  read_case "$record"
+  printf 'test-only-content\n' > "$SOURCE"
+  write_mapping .env
+  out=$(run_sync /bin/bash)
+  status=$?
+  expect_code 0 "$status" "a worktree-root target should synchronize under system bash"
+  [ -z "$out" ] || fail "synchronization under system bash should not warn or expose paths: $out"
+  cmp -s "$SOURCE" "$WORKTREE/.env" || fail "system bash did not copy the configured source to the worktree root"
+  assert_no_staging_leftovers "a system bash synchronization"
+  pass "a worktree-root target is copied under stock system bash"
 }
 
 test_nonignored_target_is_refused_before_copying() {
@@ -101,6 +129,7 @@ test_nonignored_target_is_refused_before_copying() {
 test_no_mapping_is_silent_noop
 test_missing_source_warns_without_copying
 test_copy_places_the_configured_environment_file
+test_worktree_root_target_copies_under_system_bash
 test_nonignored_target_is_refused_before_copying
 
 echo "# all fm-worktree-env-sync tests passed"


### PR DESCRIPTION
## Summary
- Sync a locally configured environment file into newly isolated ship and scout worktrees.
- Refuse unignored targets and keep configured paths and file contents out of output.
- Document the local mapping schema and cover absent mapping, missing source, copying, and ignore enforcement.

## Validation
- no-mistakes review, test, and documentation checks passed.
- Local ShellCheck was unavailable; the approved lint exception is recorded here and CI remains the lint backstop.