### PR TITLE
feat(bin): add fm-verify so an unobserved result cannot read as a pass

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,9 @@ Hard rules, in priority order:
    Treat direct captain intervention in a crewmate window as authoritative and reconcile it at the next supervision review.
 5. **Report outcomes faithfully.**
    If work failed, say so plainly with the evidence.
+   Every observation carries three values, never two: observed-good, observed-bad, and could-not-observe.
+   An empty result set, an unreadable record, an absent artifact, an unreachable tool, a silent verifier, and an exit code covering both a failure and a refusal are all could-not-observe, and narrowing one into either of the others needs an explicit recorded decision.
+   `bin/fm-verify.sh` owns that contract and its consumer rules.
 
 You may maintain this repo's private operational state directly.
 Shared tracked material is `AGENTS.md`, `README.md`, `CONTRIBUTING.md`, `.tasks.toml`, `.github/workflows/`, `bin/`, `.agents/skills/`, and public `skills/`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,7 +38,7 @@ Hard rules, in priority order:
    If work failed, say so plainly with the evidence.
    Every observation carries three values, never two: observed-good, observed-bad, and could-not-observe.
    An empty result set, an unreadable record, an absent artifact, an unreachable tool, a silent verifier, and an exit code covering both a failure and a refusal are all could-not-observe, and narrowing one into either of the others needs an explicit recorded decision.
-   `bin/fm-verify.sh` owns that contract and its consumer rules.
+   `bin/fm-verify.sh` runs a declared verifier and returns that result; `bin/fm-verify-lib.sh` owns the type itself and its consumer and coercion rules.
 
 You may maintain this repo's private operational state directly.
 Shared tracked material is `AGENTS.md`, `README.md`, `CONTRIBUTING.md`, `.tasks.toml`, `.github/workflows/`, `bin/`, `.agents/skills/`, and public `skills/`.

--- a/bin/fm-bearings-snapshot.sh
+++ b/bin/fm-bearings-snapshot.sh
@@ -63,6 +63,9 @@ FLEET="$SCRIPT_DIR/fm-fleet-snapshot.sh"
 # shellcheck source=bin/fm-timeout-lib.sh
 # shellcheck disable=SC1091
 . "$SCRIPT_DIR/fm-timeout-lib.sh"
+# shellcheck source=bin/fm-verify-lib.sh
+# shellcheck disable=SC1091
+. "$SCRIPT_DIR/fm-verify-lib.sh"
 
 # Bounds (overridable for tests / large fleets).
 FM_BEARINGS_LANDED=${FM_BEARINGS_LANDED:-6}
@@ -232,6 +235,9 @@ EOF
         --json number,title,url,headRefName,reviewDecision,mergeable,statusCheckRollup 2>/dev/null) \
         || { nwarn=$((nwarn + 1)); continue; }
       [ -n "$out" ] || out='[]'
+      # The check-set rule is bin/fm-verify-lib.sh's, spliced in rather than
+      # restated: "none" here and NO_VERIFIER_RAN in bin/fm-verify.sh are the
+      # same empty set, and one copy of that rule is the point.
       repo_result=$(printf '%s' "$out" | jq --arg repo "$repo" --argjson limit "$FM_BEARINGS_PR_LIMIT" '
         [ .[] | {
           num:(.number|tostring),
@@ -240,12 +246,7 @@ EOF
           url:(.url // "-"),
           review:(.reviewDecision // "none"),
           mergeable:(.mergeable // "UNKNOWN"),
-          checks:(
-            (.statusCheckRollup // []) as $c
-            | if ($c|length) == 0 then "none"
-              elif any($c[]; (.conclusion // .state // "") as $s | ($s=="FAILURE" or $s=="ERROR" or $s=="TIMED_OUT" or $s=="CANCELLED" or $s=="ACTION_REQUIRED")) then "failing"
-              elif any($c[]; ((.status // "") != "COMPLETED") and ((.state // "") != "SUCCESS")) then "pending"
-              else "passing" end)
+          checks:('"$FM_VERIFY_CHECK_ROLLUP_EXPR"')
         } ] as $rows | {returned:($rows | length), rows:$rows[:$limit]}') || { nwarn=$((nwarn + 1)); continue; }
       returned=$(printf '%s' "$repo_result" | jq '.returned')
       repo_rows=$(printf '%s' "$repo_result" | jq '.rows')

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -308,6 +308,7 @@ The third is a real result, not a missing one.
 An empty result set, an unreadable file, an absent artifact, an unreachable tool, a silent verifier, and an exit code that covers both a failure and a refusal are all could-not-observe, and none of them is a pass.
 Never narrow one into the other two: an empty violations log, no output, and no failures found are never success on their own, and a missing expected artifact is could-not-observe at collection time rather than work still in progress.
 Run a verifier through \`$FM_ROOT/bin/fm-verify.sh\` (\`--help\` lists the declared verifiers) and act on the \`PASS\` / \`FAIL\` / \`NO_VERIFIER_RAN\` result it returns, rather than interpreting a tool's exit status yourself.
+When the observation you need has no declared verifier, apply the same three-valued rule by hand: name which of the three values you reached and the evidence you reached it on, and report the undeclared verifier as a gap - never infer a pass from an exit status.
 Before trusting a success reported only by absence, run a negative control, watch that same check go red, and only then run the real check.
 EOF
 VERIFICATION_DISCIPLINE=${VERIFICATION_DISCIPLINE%$'\n'}
@@ -330,7 +331,7 @@ The report is the only thing that survives, so anything worth keeping must be in
 # Rules
 1. Never push to any remote and never open a PR.
 2. Stay inside this worktree; the only files you may write outside it are the report and the status file below.
-3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations, and run either through \`$FM_ROOT/bin/fm-verify.sh\` whenever its answer is evidence you will act on.
+3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations. Most of that is action - opening a pull request, commenting, listing issues - and an action has no observation type; when you are instead making an OBSERVATION whose answer you will act on, run it through \`$FM_ROOT/bin/fm-verify.sh\` (\`--list\` names the declared verifiers) rather than reading the tool's exit status.
 4. Report status by appending one line:
    \`echo "{state}: {one short line}" >> $STATUS_FILE\`
    States: working, needs-decision, blocked, $PAUSED_VERB, done, failed.
@@ -444,7 +445,7 @@ If the top-level path is the primary checkout or not the worktree you were launc
 # Rules
 $RULE1
 2. Stay inside this worktree; modify nothing outside it.
-3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations, and run either through \`$FM_ROOT/bin/fm-verify.sh\` whenever its answer is evidence you will act on.
+3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations. Most of that is action - opening a pull request, commenting, listing issues - and an action has no observation type; when you are instead making an OBSERVATION whose answer you will act on, run it through \`$FM_ROOT/bin/fm-verify.sh\` (\`--list\` names the declared verifiers) rather than reading the tool's exit status.
 4. Report status by appending one line:
    \`echo "{state}: {one short line}" >> $STATUS_FILE\`
    States: working, needs-decision, blocked, $PAUSED_VERB, done, failed.

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -297,6 +297,21 @@ EOF
 HERDR_SECTION=${HERDR_SECTION%$'\n'}
 fi
 
+# The type rule, not a slogan. "An absent result is not a pass" was already
+# written down and produced ten instances of the same defect anyway, because it
+# names the symptom without naming the mechanism: a call that can fail to
+# OBSERVE returning the same type as one that observed a negative result.
+IFS= read -r -d '' VERIFICATION_DISCIPLINE <<EOF || true
+# Verification discipline
+An observation has three values, never two: observed-good, observed-bad, and could-not-observe.
+The third is a real result, not a missing one.
+An empty result set, an unreadable file, an absent artifact, an unreachable tool, a silent verifier, and an exit code that covers both a failure and a refusal are all could-not-observe, and none of them is a pass.
+Never narrow one into the other two: an empty violations log, no output, and no failures found are never success on their own, and a missing expected artifact is could-not-observe at collection time rather than work still in progress.
+Run a verifier through \`$FM_ROOT/bin/fm-verify.sh\` (\`--help\` lists the declared verifiers) and act on the \`PASS\` / \`FAIL\` / \`NO_VERIFIER_RAN\` result it returns, rather than interpreting a tool's exit status yourself.
+Before trusting a success reported only by absence, run a negative control, watch that same check go red, and only then run the real check.
+EOF
+VERIFICATION_DISCIPLINE=${VERIFICATION_DISCIPLINE%$'\n'}
+
 if [ "$KIND" = scout ]; then
 cat > "$BRIEF" <<EOF
 You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.
@@ -315,7 +330,7 @@ The report is the only thing that survives, so anything worth keeping must be in
 # Rules
 1. Never push to any remote and never open a PR.
 2. Stay inside this worktree; the only files you may write outside it are the report and the status file below.
-3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
+3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations, and run either through \`$FM_ROOT/bin/fm-verify.sh\` whenever its answer is evidence you will act on.
 4. Report status by appending one line:
    \`echo "{state}: {one short line}" >> $STATUS_FILE\`
    States: working, needs-decision, blocked, $PAUSED_VERB, done, failed.
@@ -333,6 +348,8 @@ The report is the only thing that survives, so anything worth keeping must be in
 7. Never stop, restart, or update the shared \`no-mistakes\` daemon - it is one instance serving
    every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
    daemon error, append \`blocked: {the daemon error}\` and stop; only firstmate manages the daemon.
+
+$VERIFICATION_DISCIPLINE
 
 # Definition of done
 Write your findings to \`$DATA/$ID/report.md\`.
@@ -427,7 +444,7 @@ If the top-level path is the primary checkout or not the worktree you were launc
 # Rules
 $RULE1
 2. Stay inside this worktree; modify nothing outside it.
-3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
+3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations, and run either through \`$FM_ROOT/bin/fm-verify.sh\` whenever its answer is evidence you will act on.
 4. Report status by appending one line:
    \`echo "{state}: {one short line}" >> $STATUS_FILE\`
    States: working, needs-decision, blocked, $PAUSED_VERB, done, failed.
@@ -448,6 +465,8 @@ $RULE1
 7. Never stop, restart, or update the shared \`no-mistakes\` daemon - it is one instance serving
    every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
    daemon error, append \`blocked: {the daemon error}\` and stop; only firstmate manages the daemon.
+
+$VERIFICATION_DISCIPLINE
 
 # Project memory
 If \`AGENTS.md\` or \`CLAUDE.md\` already exists, or if this task produced durable project-intrinsic knowledge, run \`$FM_ROOT/bin/fm-ensure-agents-md.sh .\` in the worktree.

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -915,6 +915,13 @@ families_for_changed_path() {
       printf '%s\n' snapshot-bearings
       printf '%s\n' pure-contract-unit
       ;;
+    bin/fm-verify-lib.sh)
+      # The shared three-valued observation type and check-set rule: the
+      # wrapper's own suite, and the bearings snapshot, which splices that same
+      # rule and asserts on the label it produces.
+      printf '%s\n' pure-contract-unit
+      printf '%s\n' snapshot-bearings
+      ;;
     bin/fm-pr-*|bin/fm-merge-local.sh|bin/fm-teardown.sh|bin/fm-review-diff.sh|\
     bin/fm-x-*|bin/fm-check*)
       printf '%s\n' pr-forge

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -144,7 +144,7 @@ family_for_basename() {
     fm-subagent-pretool-check.test.sh|\
     fm-supervision-instructions.test.sh|fm-task-delivery.test.sh|\
     fm-tmux-submit-busy.test.sh|fm-trace-context-lib.test.sh|\
-    fm-transition-lib.test.sh|\
+    fm-transition-lib.test.sh|fm-verify.test.sh|\
     fm-test-run.test.sh|fm-test-isolation-proof.test.sh)
       printf '%s\n' pure-contract-unit
       ;;

--- a/bin/fm-verify-lib.sh
+++ b/bin/fm-verify-lib.sh
@@ -33,31 +33,43 @@
 # request object carrying GitHub's statusCheckRollup field. It produces exactly
 # one of:
 #
-#   none      no check ran at all - the empty set. NOT green, ever. A pull
-#             request whose checks were never created, whose workflow file is
-#             broken, or whose runs were pruned looks exactly like a pull
-#             request that passed, unless the empty set is named separately.
-#   failing   at least one check reached a failing conclusion.
-#   pending   checks exist but at least one has not completed. No verdict yet.
-#   passing   the set is non-empty and every member completed successfully.
+#   none          no check ran at all - the empty set. NOT green, ever. A pull
+#                 request whose checks were never created, whose workflow file
+#                 is broken, or whose runs were pruned looks exactly like a
+#                 pull request that passed, unless the empty set is named
+#                 separately.
+#   failing       at least one check reached a failing conclusion.
+#   pending       checks exist but at least one has not completed. No verdict
+#                 yet, and one may still arrive.
+#   inconclusive  every check completed, none failed, and at least one ended
+#                 without earning a verdict - SKIPPED, STALE, NEUTRAL, an
+#                 absent conclusion, or a conclusion this rule does not know.
+#                 A check skipped by a path filter proves nothing about the
+#                 pull request, so folding it into "passing" is the empty set's
+#                 defect one level down. No verdict, and none is coming.
+#   passing       the set is non-empty and EVERY member completed successfully.
 #
 # It lives here rather than inside either caller because it is a contract, and
 # two copies of a contract drift the moment only one is edited. Consumers map
-# these four labels onto their own vocabulary and must never collapse "none" or
-# "pending" into a pass:
-#   - bin/fm-verify.sh maps none/pending to NO_VERIFIER_RAN and passing to PASS.
+# these five labels onto their own vocabulary and must never collapse "none",
+# "pending", or "inconclusive" into a pass:
+#   - bin/fm-verify.sh maps none/pending/inconclusive to NO_VERIFIER_RAN and
+#     passing to PASS.
 #   - bin/fm-bearings-snapshot.sh renders them as a per-pull-request label.
 #
 # The expression takes no jq arguments, so a caller splices it into a larger
 # single-quoted program without disturbing that program's own jq variables.
 
-# shellcheck disable=SC2034  # consumed by sourcing scripts, not by this file.
+# shellcheck disable=SC2034,SC2016  # consumed by sourcing scripts, not by this
+# file, and the $-prefixed names inside are jq variables that must reach jq
+# unexpanded - the single quotes are the point.
 FM_VERIFY_CHECK_ROLLUP_EXPR='
   (.statusCheckRollup // []) as $c
   | if ($c|length) == 0 then "none"
     elif any($c[]; (.conclusion // .state // "") as $s | ($s=="FAILURE" or $s=="ERROR" or $s=="TIMED_OUT" or $s=="CANCELLED" or $s=="ACTION_REQUIRED")) then "failing"
     elif any($c[]; ((.status // "") != "COMPLETED") and ((.state // "") != "SUCCESS")) then "pending"
-    else "passing" end'
+    elif all($c[]; (.conclusion // .state // "") == "SUCCESS") then "passing"
+    else "inconclusive" end'
 
 # --- the three-valued observation type --------------------------------------
 
@@ -68,26 +80,34 @@ FM_VERIFY_CHECK_ROLLUP_EXPR='
 # could-not-observe, and a consumer that treated it as an empty PASS would be
 # the very defect this file exists to prevent.
 fm_verify_parse() {
-  local record=$1 row rest
+  local record=$1 row rest verifier result reason evidence
   FM_VERIFY_VERIFIER=''
   FM_VERIFY_RESULT=''
   FM_VERIFY_REASON=''
   FM_VERIFY_EVIDENCE=''
   row=$(printf '%s\n' "$record" | sed -n 's/^  //p' | head -1)
   [ -n "$row" ] || return 1
-  FM_VERIFY_VERIFIER=${row%%,*}
+  verifier=${row%%,*}
   rest=${row#*,}
   [ "$rest" != "$row" ] || return 1
-  FM_VERIFY_RESULT=${rest%%,*}
+  result=${rest%%,*}
   rest=${rest#*,}
-  FM_VERIFY_REASON=${rest%%,*}
+  reason=${rest%%,*}
   rest=${rest#*,}
-  FM_VERIFY_EVIDENCE=$rest
-  case "$FM_VERIFY_RESULT" in
+  evidence=$rest
+  case "$result" in
     PASS|FAIL|NO_VERIFIER_RAN) ;;
     *) return 1 ;;
   esac
-  [ -n "$FM_VERIFY_VERIFIER" ] && [ -n "$FM_VERIFY_REASON" ] || return 1
+  [ -n "$verifier" ] && [ -n "$reason" ] || return 1
+  # Published only once every field has been accepted: a record rejected on its
+  # last field must leave nothing behind either, or a consumer reading the
+  # globals without the status still sees a result extracted from a record this
+  # function just refused.
+  FM_VERIFY_VERIFIER=$verifier
+  FM_VERIFY_RESULT=$result
+  FM_VERIFY_REASON=$reason
+  FM_VERIFY_EVIDENCE=$evidence
   return 0
 }
 

--- a/bin/fm-verify-lib.sh
+++ b/bin/fm-verify-lib.sh
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+# fm-verify-lib.sh - single owner of firstmate's three-valued observation type
+# and of the check-set classification rule that depends on it.
+#
+# Source it; it defines and runs nothing on its own:
+#   # shellcheck source=bin/fm-verify-lib.sh
+#   . "$SCRIPT_DIR/fm-verify-lib.sh"
+#
+# THE TYPE RULE
+#
+# An observation returns three values, never two:
+#   PASS             observed, and the subject is good
+#   FAIL             observed, and the subject is bad
+#   NO_VERIFIER_RAN  the observation did not happen
+#
+# The measured root cause of ten separate defects in this fleet was one type
+# error: a function that can fail to OBSERVE returning the same type as one that
+# observed a NEGATIVE result. "I looked and found nothing" and "I could not
+# look" collapse into one value - empty, zero, false, absent - and that value
+# then reads as fine.
+#
+# The third value never dies by being forgotten. It dies at a conversion: an
+# exit code narrowing, an empty collection counting as zero failures, an
+# unreadable file counting as no findings, a missing check set counting as a
+# clean one. So this library gives consumers exactly one way to read a result -
+# fm_verify_case, which refuses a consumer that does not handle all three - and
+# exactly one way to narrow it - fm_verify_coerce, which is loud and logged.
+#
+# A caller who wants a two-branch read has to say so in writing, and the saying
+# is the record.
+#
+# FM_VERIFY_CHECK_ROLLUP_EXPR is a jq expression evaluated against ONE pull
+# request object carrying GitHub's statusCheckRollup field. It produces exactly
+# one of:
+#
+#   none      no check ran at all - the empty set. NOT green, ever. A pull
+#             request whose checks were never created, whose workflow file is
+#             broken, or whose runs were pruned looks exactly like a pull
+#             request that passed, unless the empty set is named separately.
+#   failing   at least one check reached a failing conclusion.
+#   pending   checks exist but at least one has not completed. No verdict yet.
+#   passing   the set is non-empty and every member completed successfully.
+#
+# It lives here rather than inside either caller because it is a contract, and
+# two copies of a contract drift the moment only one is edited. Consumers map
+# these four labels onto their own vocabulary and must never collapse "none" or
+# "pending" into a pass:
+#   - bin/fm-verify.sh maps none/pending to NO_VERIFIER_RAN and passing to PASS.
+#   - bin/fm-bearings-snapshot.sh renders them as a per-pull-request label.
+#
+# The expression takes no jq arguments, so a caller splices it into a larger
+# single-quoted program without disturbing that program's own jq variables.
+
+# shellcheck disable=SC2034  # consumed by sourcing scripts, not by this file.
+FM_VERIFY_CHECK_ROLLUP_EXPR='
+  (.statusCheckRollup // []) as $c
+  | if ($c|length) == 0 then "none"
+    elif any($c[]; (.conclusion // .state // "") as $s | ($s=="FAILURE" or $s=="ERROR" or $s=="TIMED_OUT" or $s=="CANCELLED" or $s=="ACTION_REQUIRED")) then "failing"
+    elif any($c[]; ((.status // "") != "COMPLETED") and ((.state // "") != "SUCCESS")) then "pending"
+    else "passing" end'
+
+# --- the three-valued observation type --------------------------------------
+
+# fm_verify_parse <record>: read one bin/fm-verify.sh record and export its
+# fields as FM_VERIFY_VERIFIER / FM_VERIFY_RESULT / FM_VERIFY_REASON /
+# FM_VERIFY_EVIDENCE. Returns non-zero for anything it cannot parse, and leaves
+# no partially-populated fields behind: an unparseable record is itself a
+# could-not-observe, and a consumer that treated it as an empty PASS would be
+# the very defect this file exists to prevent.
+fm_verify_parse() {
+  local record=$1 row rest
+  FM_VERIFY_VERIFIER=''
+  FM_VERIFY_RESULT=''
+  FM_VERIFY_REASON=''
+  FM_VERIFY_EVIDENCE=''
+  row=$(printf '%s\n' "$record" | sed -n 's/^  //p' | head -1)
+  [ -n "$row" ] || return 1
+  FM_VERIFY_VERIFIER=${row%%,*}
+  rest=${row#*,}
+  [ "$rest" != "$row" ] || return 1
+  FM_VERIFY_RESULT=${rest%%,*}
+  rest=${rest#*,}
+  FM_VERIFY_REASON=${rest%%,*}
+  rest=${rest#*,}
+  FM_VERIFY_EVIDENCE=$rest
+  case "$FM_VERIFY_RESULT" in
+    PASS|FAIL|NO_VERIFIER_RAN) ;;
+    *) return 1 ;;
+  esac
+  [ -n "$FM_VERIFY_VERIFIER" ] && [ -n "$FM_VERIFY_REASON" ] || return 1
+  return 0
+}
+
+# fm_verify_case <record> <on_pass> <on_fail> <on_unverified>: the only
+# supported way to consume a result. Each handler is the name of a defined
+# function and is called with no arguments; the parsed fields are available to
+# it as the FM_VERIFY_* variables above.
+#
+# It refuses, with a stable token on stderr and status 3, when:
+#   - fewer or more than three handlers are named (consumer exhaustiveness: a
+#     consumer that branches on pass-versus-not-pass reintroduces the defect
+#     against a perfectly correct producer);
+#   - a named handler is not a defined function;
+#   - the unverified handler is the same function as the pass or fail handler,
+#     which is coercion written as a consumer. Use fm_verify_coerce for that,
+#     where it is recorded.
+# An unparseable record is reported the same way rather than dropped.
+fm_verify_case() {
+  local record=${1:-} on_pass=${2:-} on_fail=${3:-} on_unverified=${4:-} handler
+  if [ "$#" -ne 4 ]; then
+    printf 'fm-verify: consumer must handle all three results\n' >&2
+    return 3
+  fi
+  for handler in "$on_pass" "$on_fail" "$on_unverified"; do
+    if ! declare -F "$handler" >/dev/null 2>&1; then
+      printf 'fm-verify: consumer must handle all three results\n' >&2
+      return 3
+    fi
+  done
+  if [ "$on_unverified" = "$on_pass" ] || [ "$on_unverified" = "$on_fail" ]; then
+    printf 'fm-verify: NO_VERIFIER_RAN is not coercible; use fm_verify_coerce\n' >&2
+    return 3
+  fi
+  if ! fm_verify_parse "$record"; then
+    printf 'fm-verify: unreadable result record\n' >&2
+    return 3
+  fi
+  case "$FM_VERIFY_RESULT" in
+    PASS) "$on_pass" ;;
+    FAIL) "$on_fail" ;;
+    *) "$on_unverified" ;;
+  esac
+}
+
+# fm_verify_coerce <record> <PASS|FAIL> <reason>: the one sanctioned narrowing
+# of NO_VERIFIER_RAN, for the case where a caller genuinely decides to proceed
+# without the observation. It prints the coerced result on stdout and writes the
+# decision to stderr always, plus FM_VERIFY_COERCION_LOG or
+# $FM_HOME/state/verify-coercions.log when either is writable. A coercion with
+# no reason, or of an already-observed result, is refused: only the missing
+# observation is a decision anyone gets to make.
+fm_verify_coerce() {
+  local record=${1:-} target=${2:-} reason=${3:-} log=
+  if [ "$#" -ne 3 ] || [ -z "$reason" ]; then
+    printf 'fm-verify: coercion needs a target and a reason\n' >&2
+    return 3
+  fi
+  case "$target" in
+    PASS|FAIL) ;;
+    *)
+      printf 'fm-verify: coercion target must be PASS or FAIL\n' >&2
+      return 3
+      ;;
+  esac
+  if ! fm_verify_parse "$record"; then
+    printf 'fm-verify: unreadable result record\n' >&2
+    return 3
+  fi
+  if [ "$FM_VERIFY_RESULT" != NO_VERIFIER_RAN ]; then
+    printf 'fm-verify: only NO_VERIFIER_RAN is coercible\n' >&2
+    return 3
+  fi
+  printf 'fm-verify: COERCED %s -> %s (%s): %s reason=%s evidence=%s\n' \
+    NO_VERIFIER_RAN "$target" "$reason" "$FM_VERIFY_VERIFIER" \
+    "$FM_VERIFY_REASON" "$FM_VERIFY_EVIDENCE" >&2
+  if [ -n "${FM_VERIFY_COERCION_LOG:-}" ]; then
+    log=$FM_VERIFY_COERCION_LOG
+  elif [ -n "${FM_HOME:-}" ] && [ -d "$FM_HOME/state" ] && [ -w "$FM_HOME/state" ]; then
+    log=$FM_HOME/state/verify-coercions.log
+  fi
+  if [ -n "$log" ]; then
+    printf '%s\t%s\t%s\t%s\t%s\n' \
+      "$FM_VERIFY_VERIFIER" "$target" "$FM_VERIFY_REASON" \
+      "$FM_VERIFY_EVIDENCE" "$reason" >>"$log" 2>/dev/null || true
+  fi
+  FM_VERIFY_RESULT=$target
+  printf '%s\n' "$target"
+}

--- a/bin/fm-verify-lib.sh
+++ b/bin/fm-verify-lib.sh
@@ -38,16 +38,31 @@
 #                 is broken, or whose runs were pruned looks exactly like a
 #                 pull request that passed, unless the empty set is named
 #                 separately.
-#   failing       at least one check reached a failing conclusion.
+#   failing       at least one check reached a terminal negative verdict:
+#                 FAILURE, STARTUP_FAILURE, or ERROR. A workflow that failed to
+#                 start never clears by waiting and re-running reproduces it
+#                 until someone fixes the workflow, so it is a verdict and not
+#                 a could-not-observe.
 #   pending       checks exist but at least one has not completed. No verdict
 #                 yet, and one may still arrive.
 #   inconclusive  every check completed, none failed, and at least one ended
-#                 without earning a verdict - SKIPPED, STALE, NEUTRAL, an
-#                 absent conclusion, or a conclusion this rule does not know.
-#                 A check skipped by a path filter proves nothing about the
-#                 pull request, so folding it into "passing" is the empty set's
-#                 defect one level down. No verdict, and none is coming.
+#                 without earning a verdict - TIMED_OUT, CANCELLED,
+#                 ACTION_REQUIRED, SKIPPED, STALE, NEUTRAL, an absent
+#                 conclusion, or any conclusion this rule does not know, which
+#                 reaches this label by design rather than by omission. None of
+#                 them observed the pull request: a run cancelled by a
+#                 superseding push or killed by a timeout says nothing about
+#                 the code, and ACTION_REQUIRED completed only to say a human
+#                 must act. Folding any of them into "passing" is the empty
+#                 set's defect one level down, and folding them into "failing"
+#                 asserts a verdict nothing earned. No verdict, and none is
+#                 coming.
 #   passing       the set is non-empty and EVERY member completed successfully.
+#
+# Two GitHub vocabularies meet here, which is why the rule reads
+# .conclusion // .state: FAILURE, TIMED_OUT, CANCELLED, ACTION_REQUIRED,
+# STARTUP_FAILURE, NEUTRAL, SKIPPED, STALE and SUCCESS are check-run
+# conclusions, while ERROR belongs to the older commit-status state vocabulary.
 #
 # It lives here rather than inside either caller because it is a contract, and
 # two copies of a contract drift the moment only one is edited. Consumers map
@@ -66,7 +81,7 @@
 FM_VERIFY_CHECK_ROLLUP_EXPR='
   (.statusCheckRollup // []) as $c
   | if ($c|length) == 0 then "none"
-    elif any($c[]; (.conclusion // .state // "") as $s | ($s=="FAILURE" or $s=="ERROR" or $s=="TIMED_OUT" or $s=="CANCELLED" or $s=="ACTION_REQUIRED")) then "failing"
+    elif any($c[]; (.conclusion // .state // "") as $s | ($s=="FAILURE" or $s=="STARTUP_FAILURE" or $s=="ERROR")) then "failing"
     elif any($c[]; ((.status // "") != "COMPLETED") and ((.state // "") != "SUCCESS")) then "pending"
     elif all($c[]; (.conclusion // .state // "") == "SUCCESS") then "passing"
     else "inconclusive" end'

--- a/bin/fm-verify.sh
+++ b/bin/fm-verify.sh
@@ -61,8 +61,9 @@
 #   empty_result_set          the verifier returned no results at all
 #   verification_incomplete   results exist but no verdict has been reached yet
 #   no_verdict_reached        the verifier finished and reached no verdict, and
-#                             none is coming: checks that completed SKIPPED,
-#                             STALE, NEUTRAL, or with no conclusion at all
+#                             none is coming: checks that completed TIMED_OUT,
+#                             CANCELLED, ACTION_REQUIRED, SKIPPED, STALE,
+#                             NEUTRAL, or with no conclusion at all
 #   no_evidence               the verifier's output could not be captured
 #   usage_error               the call itself was malformed
 #

--- a/bin/fm-verify.sh
+++ b/bin/fm-verify.sh
@@ -28,7 +28,11 @@
 # rather than run, because a name this script cannot interpret is a name whose
 # output it cannot judge):
 #   browser <subcommand> [args...]
-#       Runs chrome-devtools-axi with the given arguments.
+#       Runs chrome-devtools-axi with the given arguments. This adapter never
+#       returns FAIL, and that is deliberate rather than an omission:
+#       chrome-devtools-axi is a control tool, not an assertion tool, so it has
+#       no way to report "the page is bad" - only "here is what I saw" or a
+#       failure to see it. The verdict on what it saw belongs to the caller.
 #   pr-checks <pr-url>
 #       Reads the pull request's check-run set through gh and classifies it with
 #       bin/fm-verify-lib.sh.
@@ -56,6 +60,9 @@
 #                             (ruling D3's token for the unreachable browser)
 #   empty_result_set          the verifier returned no results at all
 #   verification_incomplete   results exist but no verdict has been reached yet
+#   no_verdict_reached        the verifier finished and reached no verdict, and
+#                             none is coming: checks that completed SKIPPED,
+#                             STALE, NEUTRAL, or with no conclusion at all
 #   no_evidence               the verifier's output could not be captured
 #   usage_error               the call itself was malformed
 #
@@ -205,6 +212,15 @@ run_verifier() {
   return 0
 }
 
+# require_tool <name>: one availability guard for every adapter, so that a
+# missing tool always reports the same reason and a new adapter cannot get the
+# token wrong. Used as `require_tool <name> || return 0`.
+require_tool() {
+  command -v "$1" >/dev/null 2>&1 && return 0
+  set_result NO_VERIFIER_RAN verifier_unavailable
+  return 1
+}
+
 # --- browser ----------------------------------------------------------------
 
 # Transport failures chrome-devtools-axi reports while exiting 0. See the
@@ -237,10 +253,7 @@ EOF
 
 verify_browser() {
   [ "$#" -ge 1 ] || refuse usage_error
-  command -v chrome-devtools-axi >/dev/null 2>&1 || {
-    set_result NO_VERIFIER_RAN verifier_unavailable
-    return 0
-  }
+  require_tool chrome-devtools-axi || return 0
   run_verifier chrome-devtools-axi "$@" || {
     set_result NO_VERIFIER_RAN no_evidence
     return 0
@@ -251,8 +264,14 @@ verify_browser() {
     set_result NO_VERIFIER_RAN verification_unreachable
     return 0
   fi
+  # A non-zero exit for a reason no signature names - a chrome crash, a
+  # page-load timeout, a DNS failure - is could-not-observe, the same as the
+  # unreachable forge in verify_pr_checks below. chrome-devtools-axi is a
+  # control tool, not an assertion tool, so it has no failing page to report:
+  # calling this FAIL would assert a verdict the evidence never earned and
+  # would hide a broken verifier among real failures.
   if [ "$VERIFIER_STATUS" -ne 0 ]; then
-    set_result FAIL verifier_reported_failure
+    set_result NO_VERIFIER_RAN verification_unreachable
     return 0
   fi
   if [ -z "$VERIFIER_ALL" ]; then
@@ -267,14 +286,8 @@ verify_browser() {
 verify_pr_checks() {
   local label
   [ "$#" -eq 1 ] || refuse usage_error
-  command -v gh >/dev/null 2>&1 || {
-    set_result NO_VERIFIER_RAN verifier_unavailable
-    return 0
-  }
-  command -v jq >/dev/null 2>&1 || {
-    set_result NO_VERIFIER_RAN verifier_unavailable
-    return 0
-  }
+  require_tool gh || return 0
+  require_tool jq || return 0
   run_verifier gh pr view "$1" --json statusCheckRollup || {
     set_result NO_VERIFIER_RAN no_evidence
     return 0
@@ -290,6 +303,7 @@ verify_pr_checks() {
     passing) set_result PASS verified ;;
     failing) set_result FAIL verifier_reported_failure ;;
     pending) set_result NO_VERIFIER_RAN verification_incomplete ;;
+    inconclusive) set_result NO_VERIFIER_RAN no_verdict_reached ;;
     none) set_result NO_VERIFIER_RAN empty_result_set ;;
     *) set_result NO_VERIFIER_RAN verification_unreachable ;;
   esac
@@ -305,10 +319,7 @@ verify_merge_clean() {
   local repo first
   [ "$#" -ge 2 ] && [ "$#" -le 3 ] || refuse usage_error
   repo=${3:-.}
-  command -v git >/dev/null 2>&1 || {
-    set_result NO_VERIFIER_RAN verifier_unavailable
-    return 0
-  }
+  require_tool git || return 0
   run_verifier git -C "$repo" merge-tree --write-tree "$1" "$2" || {
     set_result NO_VERIFIER_RAN no_evidence
     return 0

--- a/bin/fm-verify.sh
+++ b/bin/fm-verify.sh
@@ -1,0 +1,343 @@
+#!/usr/bin/env bash
+# fm-verify.sh - run a declared verifier and return a three-valued result, so
+# that no verifier's silence, error, or absent result can be read as a pass.
+#
+# Exit status alone cannot carry a verification result, because it cannot
+# distinguish "the verifier ran and reached a verdict" from "the verifier never
+# reached one". Three real instances in this fleet:
+#   - an empty GitHub check-run set read as green, because zero failing checks
+#     looks exactly like all checks passing;
+#   - chrome-devtools-axi printing "Protocol error (Target.setDiscoverTargets):
+#     Target closed" and exiting 0, so a caller branching on exit status
+#     concludes the page is fine;
+#   - git merge-tree exiting 1 both for a real conflict and for a ref it cannot
+#     resolve, so one exit status covers a verdict and a non-verdict.
+#
+# Usage:
+#   fm-verify.sh [--evidence <path>] <verifier> [args...]
+#   fm-verify.sh --list
+#   fm-verify.sh -h | --help
+#
+# Options:
+#   --evidence <path>  write the verifier's captured output here instead of a
+#                      generated temporary file. The path must contain no comma
+#                      and no newline, because it is a field of the emitted
+#                      record.
+#
+# Declared verifiers (the registry is closed; an undeclared name is refused
+# rather than run, because a name this script cannot interpret is a name whose
+# output it cannot judge):
+#   browser <subcommand> [args...]
+#       Runs chrome-devtools-axi with the given arguments.
+#   pr-checks <pr-url>
+#       Reads the pull request's check-run set through gh and classifies it with
+#       bin/fm-verify-lib.sh.
+#   merge-clean <base-ref> <head-ref> [repo-dir]
+#       Runs git merge-tree --write-tree in <repo-dir> (default: the current
+#       directory).
+#
+# Output is exactly one record on stdout, in every case:
+#
+#   verify[1]{verifier,result,reason,evidence_ref}:
+#     browser,NO_VERIFIER_RAN,verification_unreachable,/tmp/fm-verify-browser.abc123.log
+#
+# result is one of:
+#   PASS            the verifier ran, reached a verdict, and the verdict is good
+#   FAIL            the verifier ran and reached a verdict, and it is bad
+#   NO_VERIFIER_RAN no verdict was reached. Never a pass, never a failure of the
+#                   subject, and never skippable.
+#
+# reason is one of this closed vocabulary:
+#   verified                  PASS
+#   verifier_reported_failure FAIL
+#   verifier_undeclared       the verifier name is not in the registry
+#   verifier_unavailable      the underlying tool is not installed
+#   verification_unreachable  the verifier ran but could not reach its subject
+#                             (ruling D3's token for the unreachable browser)
+#   empty_result_set          the verifier returned no results at all
+#   verification_incomplete   results exist but no verdict has been reached yet
+#   no_evidence               the verifier's output could not be captured
+#   usage_error               the call itself was malformed
+#
+# Exit status: 0 for PASS and ONLY for PASS; 1 for FAIL; 2 for NO_VERIFIER_RAN.
+# That mapping is the enforcement, not a convenience: a caller writing
+# `if fm-verify.sh ...; then` gets the fail-closed answer by construction, so
+# NO_VERIFIER_RAN cannot reach a pass terminal even in a caller that reads
+# nothing but the status.
+#
+# TOOLING_GAP - chrome-devtools-axi reports transport failures on stdout while
+# exiting 0. Until it exits non-zero, the browser adapter has to recognize those
+# failures by their text, and the signature list below is deliberately biased:
+# a false NO_VERIFIER_RAN costs one re-run, a false PASS is the defect this
+# script exists to prevent. The durable fix belongs upstream in that tool, not
+# in a longer list here.
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# shellcheck source=bin/fm-verify-lib.sh
+. "$SCRIPT_DIR/fm-verify-lib.sh"
+
+usage() {
+  awk '
+    NR == 1 { next }
+    /^#/ { sub(/^# ?/, ""); print; next }
+    { exit }
+  ' "$0"
+}
+
+VERIFIERS=(browser pr-checks merge-clean)
+
+RESULT=
+REASON=
+EVIDENCE=-
+VERIFIER=-
+
+set_result() {
+  RESULT=$1
+  REASON=$2
+}
+
+emit_and_exit() {
+  printf 'verify[1]{verifier,result,reason,evidence_ref}:\n  %s,%s,%s,%s\n' \
+    "$VERIFIER" "$RESULT" "$REASON" "$EVIDENCE"
+  case "$RESULT" in
+    PASS) exit 0 ;;
+    FAIL) exit 1 ;;
+    *) exit 2 ;;
+  esac
+}
+
+# A refusal is still a result, so it goes out through the same record.
+refuse() {
+  VERIFIER=${VERIFIER:--}
+  set_result NO_VERIFIER_RAN "$1"
+  emit_and_exit
+}
+
+EVIDENCE_PATH=
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    --list)
+      printf '%s\n' "${VERIFIERS[@]}"
+      exit 0
+      ;;
+    --evidence)
+      [ "$#" -ge 2 ] || refuse usage_error
+      EVIDENCE_PATH=$2
+      shift 2
+      ;;
+    --evidence=*)
+      EVIDENCE_PATH=${1#--evidence=}
+      shift
+      ;;
+    --)
+      shift
+      break
+      ;;
+    -*)
+      refuse usage_error
+      ;;
+    *)
+      break
+      ;;
+  esac
+done
+
+[ "$#" -ge 1 ] || refuse usage_error
+VERIFIER=$1
+shift
+
+# The registry closes before anything runs. A name this script cannot interpret
+# is a name whose output it cannot judge, so it is refused rather than executed.
+declared=1
+for known in "${VERIFIERS[@]}"; do
+  [ "$VERIFIER" = "$known" ] && declared=0 && break
+done
+[ "$declared" -eq 0 ] || refuse verifier_undeclared
+
+if [ -n "$EVIDENCE_PATH" ]; then
+  case "$EVIDENCE_PATH" in
+    *,*) refuse usage_error ;;
+  esac
+  [[ $EVIDENCE_PATH != *$'\n'* ]] || refuse usage_error
+fi
+
+WORKDIR=$(mktemp -d "${TMPDIR:-/tmp}/fm-verify.XXXXXX") || refuse no_evidence
+# shellcheck disable=SC2329  # invoked by the EXIT trap below.
+cleanup() {
+  rm -rf "$WORKDIR"
+}
+trap cleanup EXIT
+
+if [ -n "$EVIDENCE_PATH" ]; then
+  EVIDENCE=$EVIDENCE_PATH
+else
+  EVIDENCE=$(mktemp "${TMPDIR:-/tmp}/fm-verify-$VERIFIER.XXXXXX") || refuse no_evidence
+fi
+: > "$EVIDENCE" 2>/dev/null || refuse no_evidence
+
+VERIFIER_STATUS=0
+VERIFIER_OUT=
+VERIFIER_ALL=
+
+# run_verifier <command...>: run the command, capture its streams into the
+# evidence file, and leave the status and stdout available for the adapter.
+# Evidence is written before any judgement so that every result - including a
+# refusal - points at what was actually observed.
+run_verifier() {
+  "$@" >"$WORKDIR/stdout" 2>"$WORKDIR/stderr"
+  VERIFIER_STATUS=$?
+  {
+    printf 'fm-verify evidence\nverifier: %s\ncommand:' "$VERIFIER"
+    printf ' %q' "$@"
+    printf '\nexit_status: %s\n--- stdout ---\n' "$VERIFIER_STATUS"
+    cat "$WORKDIR/stdout"
+    printf -- '--- stderr ---\n'
+    cat "$WORKDIR/stderr"
+  } >>"$EVIDENCE" 2>/dev/null || return 1
+  VERIFIER_OUT=$(cat "$WORKDIR/stdout")
+  VERIFIER_ALL=$(cat "$WORKDIR/stdout" "$WORKDIR/stderr")
+  return 0
+}
+
+# --- browser ----------------------------------------------------------------
+
+# Transport failures chrome-devtools-axi reports while exiting 0. See the
+# TOOLING_GAP note in this file's header.
+BROWSER_UNREACHABLE_SIGNATURES='protocol error
+target closed
+target.setdiscovertargets
+no active session
+econnrefused
+could not connect
+failed to connect
+cannot connect to
+browser not found
+chrome not found
+session not found'
+
+output_is_unreachable() {
+  local haystack signature
+  haystack=$(printf '%s' "$VERIFIER_ALL" | tr '[:upper:]' '[:lower:]')
+  while IFS= read -r signature; do
+    [ -n "$signature" ] || continue
+    case "$haystack" in
+      *"$signature"*) return 0 ;;
+    esac
+  done <<EOF
+$BROWSER_UNREACHABLE_SIGNATURES
+EOF
+  return 1
+}
+
+verify_browser() {
+  [ "$#" -ge 1 ] || refuse usage_error
+  command -v chrome-devtools-axi >/dev/null 2>&1 || {
+    set_result NO_VERIFIER_RAN verifier_unavailable
+    return 0
+  }
+  run_verifier chrome-devtools-axi "$@" || {
+    set_result NO_VERIFIER_RAN no_evidence
+    return 0
+  }
+  # Order matters: the transport check runs BEFORE the status check, because
+  # the whole defect is a transport failure carrying a successful status.
+  if output_is_unreachable; then
+    set_result NO_VERIFIER_RAN verification_unreachable
+    return 0
+  fi
+  if [ "$VERIFIER_STATUS" -ne 0 ]; then
+    set_result FAIL verifier_reported_failure
+    return 0
+  fi
+  if [ -z "$VERIFIER_ALL" ]; then
+    set_result NO_VERIFIER_RAN empty_result_set
+    return 0
+  fi
+  set_result PASS verified
+}
+
+# --- pr-checks --------------------------------------------------------------
+
+verify_pr_checks() {
+  local label
+  [ "$#" -eq 1 ] || refuse usage_error
+  command -v gh >/dev/null 2>&1 || {
+    set_result NO_VERIFIER_RAN verifier_unavailable
+    return 0
+  }
+  command -v jq >/dev/null 2>&1 || {
+    set_result NO_VERIFIER_RAN verifier_unavailable
+    return 0
+  }
+  run_verifier gh pr view "$1" --json statusCheckRollup || {
+    set_result NO_VERIFIER_RAN no_evidence
+    return 0
+  }
+  # An unreachable forge is not a failing pull request. Reporting FAIL here
+  # would be a verdict this script never earned.
+  if [ "$VERIFIER_STATUS" -ne 0 ]; then
+    set_result NO_VERIFIER_RAN verification_unreachable
+    return 0
+  fi
+  label=$(printf '%s' "$VERIFIER_OUT" | jq -r "$FM_VERIFY_CHECK_ROLLUP_EXPR" 2>/dev/null) || label=
+  case "$label" in
+    passing) set_result PASS verified ;;
+    failing) set_result FAIL verifier_reported_failure ;;
+    pending) set_result NO_VERIFIER_RAN verification_incomplete ;;
+    none) set_result NO_VERIFIER_RAN empty_result_set ;;
+    *) set_result NO_VERIFIER_RAN verification_unreachable ;;
+  esac
+}
+
+# --- merge-clean ------------------------------------------------------------
+
+# git merge-tree --write-tree exits 1 for a conflict AND for a ref it cannot
+# resolve. The tree object it writes on the conflict path is what separates
+# them: a conflict is a verdict about the merge, an unresolvable ref is no
+# verdict at all.
+verify_merge_clean() {
+  local repo first
+  [ "$#" -ge 2 ] && [ "$#" -le 3 ] || refuse usage_error
+  repo=${3:-.}
+  command -v git >/dev/null 2>&1 || {
+    set_result NO_VERIFIER_RAN verifier_unavailable
+    return 0
+  }
+  run_verifier git -C "$repo" merge-tree --write-tree "$1" "$2" || {
+    set_result NO_VERIFIER_RAN no_evidence
+    return 0
+  }
+  first=$(printf '%s\n' "$VERIFIER_OUT" | head -1)
+  case "$first" in
+    *[!0-9a-f]*) first= ;;
+  esac
+  # A full object name, not an abbreviation: git resolves short names, and this
+  # check exists to prove merge-tree wrote a tree rather than printed a message.
+  [ "${#first}" -eq 40 ] || [ "${#first}" -eq 64 ] || first=
+  if [ -z "$first" ] || [ "$(git -C "$repo" cat-file -t "$first" 2>/dev/null)" != tree ]; then
+    set_result NO_VERIFIER_RAN verification_unreachable
+    return 0
+  fi
+  if [ "$VERIFIER_STATUS" -eq 0 ]; then
+    set_result PASS verified
+  else
+    set_result FAIL verifier_reported_failure
+  fi
+}
+
+# --- dispatch ---------------------------------------------------------------
+
+case "$VERIFIER" in
+  browser) verify_browser "$@" ;;
+  pr-checks) verify_pr_checks "$@" ;;
+  merge-clean) verify_merge_clean "$@" ;;
+  *) refuse verifier_undeclared ;;
+esac
+
+emit_and_exit

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -76,6 +76,8 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-nm-run-lib.sh`       | Shared branch-and-code-identity attribution for no-mistakes runs                    |
 | `fm-tangle-lib.sh`       | Shared default-branch resolution and primary-checkout tangle classification          |
 | `fm-timeout-lib.sh`      | Single owner of hard-bounded command execution and its fallback watchdog |
+| `fm-verify.sh`           | Run one declared verifier and return `PASS`, `FAIL`, or `NO_VERIFIER_RAN`, with exit 0 reserved for `PASS` alone |
+| `fm-verify-lib.sh`       | Single owner of the three-valued observation type, its consumer and coercion rules, and the check-set classification rule |
 | `fm-supervision-lib.sh`  | Shared in-flight-work-without-fresh-watcher-beacon predicate                         |
 | `fm-ff-lib.sh`           | Shared guarded fast-forward helper for origin pulls and local secondmate syncs       |
 | `fm-lock-lib.sh`         | Shared "is this git lock provably abandoned?" proof used by teardown and fleet-sync   |

--- a/tests/fm-bearings-snapshot.test.sh
+++ b/tests/fm-bearings-snapshot.test.sh
@@ -44,6 +44,12 @@ SH
 echo "gh $*" >> "$NET_LOG"
 if [ "${FAKE_GH_FAIL:-0}" = 1 ]; then exit 1; fi
 if [ "${FAKE_GH_SLEEP:-0}" = 1 ]; then sleep 30; fi
+if [ "${FAKE_GH_SKIPPED:-0}" = 1 ]; then
+  cat <<'JSON'
+[{"number":9,"title":"Ship the thing","url":"https://github.com/kunchenguid/firstmate/pull/9","headRefName":"fm/ship-task","reviewDecision":"APPROVED","mergeable":"MERGEABLE","statusCheckRollup":[{"conclusion":"SKIPPED","status":"COMPLETED"}]}]
+JSON
+  exit 0
+fi
 if [ "${FAKE_GH_MANY:-0}" = 1 ]; then
   cat <<'JSON'
 [{"number":1,"title":"One","url":"https://github.com/acme/repo/pull/1","headRefName":"fm/one","reviewDecision":"","mergeable":"MERGEABLE","statusCheckRollup":[]},{"number":2,"title":"Two","url":"https://github.com/acme/repo/pull/2","headRefName":"fm/two","reviewDecision":"","mergeable":"MERGEABLE","statusCheckRollup":[]},{"number":3,"title":"Three","url":"https://github.com/acme/repo/pull/3","headRefName":"fm/three","reviewDecision":"","mergeable":"MERGEABLE","statusCheckRollup":[]}]
@@ -979,6 +985,21 @@ test_include_prs_is_the_only_fetch_path() {
     .candidate_prs | any(.[]; .num == "9" and .task == "ship-task" and .checks == "passing" and .review == "APPROVED")
   ' >/dev/null || fail "candidate_prs must carry the fetched PR cross-referenced to its task: $json"
   pass "--include-prs is the only path that fetches, and it enriches correctly"
+}
+
+# The checks label comes from bin/fm-verify-lib.sh, so the label a completed but
+# unconcluded check earns here is the same one the wrapper turns into
+# NO_VERIFIER_RAN. A check skipped by a path filter says nothing about the pull
+# request, and rendering it as "passing" would tell the captain the opposite.
+test_unconcluded_checks_are_not_rendered_as_passing() {
+  local home fakebin json
+  home=$(make_home skipped-checks); write_fixture "$home"
+  fakebin=$(make_fakebin "$home"); : > "$home/net.log"
+  json=$(FAKE_GH_SKIPPED=1 run "$home" "$fakebin" --include-prs --json)
+  printf '%s' "$json" | jq -e '
+    .candidate_prs | any(.[]; .num == "9" and .checks == "inconclusive")
+  ' >/dev/null || fail "a completed-but-unconcluded check set must not render as passing: $json"
+  pass "a check set that completed without a verdict renders as inconclusive, not passing"
 }
 
 test_partial_github_failure_degrades() {
@@ -1924,6 +1945,7 @@ test_open_decision_surfaces_end_to_end
 test_report_pointers_surface
 test_superseded_queued_item_dropped_by_default
 test_include_prs_is_the_only_fetch_path
+test_unconcluded_checks_are_not_rendered_as_passing
 test_partial_github_failure_degrades
 test_perl_fallback_bounds_github_call
 test_section_caps_and_expansion_flags

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -708,6 +708,40 @@ test_scout_and_secondmate_scaffold() {
   pass "fm-brief: scout and secondmate code paths still scaffold well-formed briefs"
 }
 
+# The verification-discipline block carries the TYPE rule, not the slogan that
+# already failed: ten instances of the same defect landed while "an absent
+# result is not a pass" was written into the shared instructions. It also keeps
+# the negative-control instruction, which fm-verify.sh deliberately does NOT
+# retire - a wrapper cannot run the control for you.
+test_verification_discipline_is_the_type_rule() {
+  local home id brief kind
+  home="$TMP_ROOT/verify-discipline-home"
+  mkdir -p "$home/data"
+  for kind in ship scout; do
+    id="brief-verify-$kind"
+    if [ "$kind" = ship ]; then
+      FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --mode no-mistakes >/dev/null 2>&1
+    else
+      FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --scout >/dev/null 2>&1
+    fi
+    brief="$home/data/$id/brief.md"
+    assert_present "$brief" "$kind brief was not scaffolded"
+    assert_grep "An observation has three values, never two" "$brief" \
+      "$kind brief lost the three-valued observation type rule"
+    assert_grep "none of them is a pass" "$brief" \
+      "$kind brief lost the enumeration of could-not-observe conditions"
+    assert_grep "bin/fm-verify.sh" "$brief" \
+      "$kind brief must route verifiers through the wrapper"
+    assert_grep "rather than interpreting a tool's exit status yourself" "$brief" \
+      "$kind brief must retire self-interpreted exit statuses"
+    assert_grep "run a negative control, watch that same check go red" "$brief" \
+      "$kind brief lost the negative-control instruction, which is not retired"
+    assert_no_grep "never process names" "$brief" \
+      "$kind brief still carries the exhortation the wrapper replaces"
+  done
+  pass "fm-brief.sh: briefs carry the three-valued type rule and the wrapper call site"
+}
+
 test_script_parses
 test_no_heredoc_in_command_substitution
 test_help_includes_entire_header
@@ -728,3 +762,4 @@ test_secondmate_directory_paths_are_absolute_and_output_is_stable
 test_pause_verb_override_renders_all_brief_scaffolds
 test_scout_and_secondmate_load_decision_hold_policy
 test_scout_and_secondmate_scaffold
+test_verification_discipline_is_the_type_rule

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -734,6 +734,16 @@ test_verification_discipline_is_the_type_rule() {
       "$kind brief must route verifiers through the wrapper"
     assert_grep "rather than interpreting a tool's exit status yourself" "$brief" \
       "$kind brief must retire self-interpreted exit statuses"
+    # Rule 3 routes OBSERVATIONS, not tool use: opening a pull request is an
+    # action, and an action has no observation type to report.
+    assert_grep "making an OBSERVATION whose answer you will act on" "$brief" \
+      "$kind brief must scope the wrapper to observations rather than to tool use"
+    # And the registry is closed, so the undeclared observation needs a stated
+    # path of its own instead of leaving the worker with no sanctioned move.
+    assert_grep "has no declared verifier, apply the same three-valued rule by hand" "$brief" \
+      "$kind brief must say what to do when the observation has no declared verifier"
+    assert_grep "report the undeclared verifier as a gap" "$brief" \
+      "$kind brief must have an undeclared verifier reported rather than inferred past"
     assert_grep "run a negative control, watch that same check go red" "$brief" \
       "$kind brief lost the negative-control instruction, which is not retired"
     assert_no_grep "never process names" "$brief" \

--- a/tests/fm-verify.test.sh
+++ b/tests/fm-verify.test.sh
@@ -1,0 +1,387 @@
+#!/usr/bin/env bash
+# Behavior tests for bin/fm-verify.sh and bin/fm-verify-lib.sh - the three-valued
+# observation type.
+#
+# Every case here is a measured instance, not a hypothetical:
+#   - chrome-devtools-axi printing "Protocol error (Target.setDiscoverTargets):
+#     Target closed" and exiting 0 against a control site;
+#   - a pull request whose check-run set is empty being read as green;
+#   - git merge-tree exiting 1 both for a real conflict and for a ref it cannot
+#     resolve, so one exit status covers a verdict and a non-verdict.
+#
+# Each is run against the wrappers fm-verify replaces, and the replaced wrapper
+# is asserted to get it WRONG. A test that only goes green after the fix proves
+# nothing; these assert the negative control first. Three such wrappers exist,
+# because "naive" is not one shape:
+#   naive_exit_strict     exit 0 -> PASS, anything else -> FAIL
+#   naive_exit_lenient    exit 0 -> PASS, anything else -> NO_VERIFIER_RAN
+#   naive_output_presence any output -> PASS, no output -> FAIL
+#
+# The suite also pins the four properties the wrapper exists to hold:
+#   1. each value is produced for its own condition and never borrows another's;
+#   2. NO_VERIFIER_RAN reaches a consumer AS NO_VERIFIER_RAN (non-coercion);
+#   3. a consumer that handles only two of the three is refused;
+#   4. PASS still means pass - a verifier that never passes is as useless as one
+#      that always does.
+#
+# Finally, the conformance obligation: every verifier the registry declares must
+# have an unobservable-case control in this file. Adding a verifier without one
+# fails this suite.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+# shellcheck source=bin/fm-verify-lib.sh
+. "$ROOT/bin/fm-verify-lib.sh"
+
+VERIFY="$ROOT/bin/fm-verify.sh"
+TMP=$(fm_test_tmproot fm-verify)
+fm_git_identity fmtest fmtest@example.invalid
+
+# --- harness ----------------------------------------------------------------
+
+OUT=''
+CODE=''
+RESULT=''
+REASON=''
+
+# run_verify <args...>: run fm-verify and parse its record.
+run_verify() {
+  OUT=$("$VERIFY" "$@" 2>&1)
+  CODE=$?
+  if fm_verify_parse "$OUT"; then
+    RESULT=$FM_VERIFY_RESULT
+    REASON=$FM_VERIFY_REASON
+  else
+    RESULT=UNPARSEABLE
+    REASON=-
+  fi
+}
+
+# expect_verify <expected-result> <expected-reason> <label> -- <args...>
+expect_verify() {
+  local want=$1 want_reason=$2 label=$3
+  shift 4
+  run_verify "$@"
+  [ "$RESULT" = "$want" ] || fail "$label: expected $want, got $RESULT"$'\n'"$OUT"
+  [ "$want_reason" = - ] || [ "$REASON" = "$want_reason" ] ||
+    fail "$label: expected reason $want_reason, got $REASON"$'\n'"$OUT"
+  # Exit 0 for PASS and only for PASS: the structural half of non-coercion, so
+  # that even a caller reading nothing but the status cannot land on a pass.
+  case "$want" in
+    PASS) expect_code 0 "$CODE" "$label exit" ;;
+    FAIL) expect_code 1 "$CODE" "$label exit" ;;
+    *) expect_code 2 "$CODE" "$label exit" ;;
+  esac
+}
+
+# The wrappers fm-verify replaces. Each takes a command and prints its verdict.
+naive_exit_strict() {
+  if "$@" >/dev/null 2>&1; then printf 'PASS\n'; else printf 'FAIL\n'; fi
+}
+
+naive_exit_lenient() {
+  if "$@" >/dev/null 2>&1; then printf 'PASS\n'; else printf 'NO_VERIFIER_RAN\n'; fi
+}
+
+naive_output_presence() {
+  local out
+  out=$("$@" 2>/dev/null)
+  if [ -n "$out" ]; then printf 'PASS\n'; else printf 'FAIL\n'; fi
+}
+
+# expect_naive_wrong <naive-fn> <wrong-verdict> <label> -- <command...>
+# Witnesses the control red before the real check is trusted.
+expect_naive_wrong() {
+  local fn=$1 wrong=$2 label=$3 got
+  shift 4
+  got=$("$fn" "$@")
+  [ "$got" = "$wrong" ] ||
+    fail "$label: control did not reproduce the defect (expected $wrong, got $got)"
+}
+
+# minimal_path <dir>: a PATH holding only the tools fm-verify itself needs, so a
+# case can prove a verifier is genuinely absent rather than merely unused.
+minimal_path() {
+  local dir=$1 tool src
+  mkdir -p "$dir"
+  for tool in env bash sh mktemp cat head sed tr rm ln git jq awk dirname basename; do
+    src=$(command -v "$tool" 2>/dev/null) || continue
+    ln -sf "$src" "$dir/$tool"
+  done
+  printf '%s\n' "$dir"
+}
+
+# with_path <path> <command...>: run with PATH replaced and restore it after.
+# A bare `PATH=... some_function` would leave the assignment in effect once the
+# function returns, which is how a later case ends up running without coreutils.
+with_path() {
+  local want=$1 saved=$PATH rc
+  shift
+  PATH=$want
+  "$@"
+  rc=$?
+  PATH=$saved
+  return $rc
+}
+
+# --- fixture: the browser that reports a transport failure and exits 0 -------
+
+BROWSER_BIN=$(fm_fakebin "$TMP/browser")
+cat >"$BROWSER_BIN/chrome-devtools-axi" <<'SH'
+#!/usr/bin/env bash
+# The exact observed shape: the failure goes to stdout, the status says fine.
+printf 'Protocol error (Target.setDiscoverTargets): Target closed\n'
+exit 0
+SH
+chmod +x "$BROWSER_BIN/chrome-devtools-axi"
+
+BROWSER_OK_BIN=$(fm_fakebin "$TMP/browser-ok")
+cat >"$BROWSER_OK_BIN/chrome-devtools-axi" <<'SH'
+#!/usr/bin/env bash
+printf 'snapshot: <h1>Control site</h1>\n'
+exit 0
+SH
+chmod +x "$BROWSER_OK_BIN/chrome-devtools-axi"
+
+BROWSER_SILENT_BIN=$(fm_fakebin "$TMP/browser-silent")
+cat >"$BROWSER_SILENT_BIN/chrome-devtools-axi" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+chmod +x "$BROWSER_SILENT_BIN/chrome-devtools-axi"
+
+expect_naive_wrong naive_exit_strict PASS \
+  'browser protocol error, exit-status wrapper' -- \
+  "$BROWSER_BIN/chrome-devtools-axi" open https://example.invalid
+expect_naive_wrong naive_output_presence PASS \
+  'browser protocol error, output-presence wrapper' -- \
+  "$BROWSER_BIN/chrome-devtools-axi" open https://example.invalid
+
+with_path "$BROWSER_BIN:$PATH" expect_verify NO_VERIFIER_RAN verification_unreachable \
+  'browser protocol error' -- browser open https://example.invalid
+pass "browser transport failure with exit 0 is NO_VERIFIER_RAN, not PASS"
+
+with_path "$BROWSER_OK_BIN:$PATH" expect_verify PASS verified \
+  'browser reachable' -- browser open https://example.invalid
+pass "browser that actually answers still passes"
+
+with_path "$BROWSER_SILENT_BIN:$PATH" expect_verify NO_VERIFIER_RAN empty_result_set \
+  'browser silent' -- browser open https://example.invalid
+pass "silent browser is NO_VERIFIER_RAN, not PASS"
+
+BARE_PATH=$(minimal_path "$TMP/bare-bin")
+with_path "$BARE_PATH" expect_verify NO_VERIFIER_RAN verifier_unavailable \
+  'browser absent' -- browser open https://example.invalid
+pass "absent browser tool is NO_VERIFIER_RAN, not PASS"
+
+# --- fixture: the empty check-run set ---------------------------------------
+
+make_gh() {
+  local dir=$1 body=$2 status=${3:-0} bin
+  bin=$(fm_fakebin "$dir")
+  cat >"$bin/gh" <<SH
+#!/usr/bin/env bash
+printf '%s\n' '$body'
+exit $status
+SH
+  chmod +x "$bin/gh"
+  printf '%s\n' "$bin"
+}
+
+GH_EMPTY=$(make_gh "$TMP/gh-empty" '{"statusCheckRollup":[]}')
+GH_PASSING=$(make_gh "$TMP/gh-passing" \
+  '{"statusCheckRollup":[{"status":"COMPLETED","conclusion":"SUCCESS"}]}')
+GH_FAILING=$(make_gh "$TMP/gh-failing" \
+  '{"statusCheckRollup":[{"status":"COMPLETED","conclusion":"FAILURE"}]}')
+GH_PENDING=$(make_gh "$TMP/gh-pending" \
+  '{"statusCheckRollup":[{"status":"IN_PROGRESS","conclusion":null}]}')
+GH_DOWN=$(make_gh "$TMP/gh-down" 'gh: could not reach api.github.com' 1)
+
+PR=https://github.com/example/repo/pull/1
+
+expect_naive_wrong naive_exit_strict PASS \
+  'empty check set, exit-status wrapper' -- \
+  "$GH_EMPTY/gh" pr view "$PR" --json statusCheckRollup
+expect_naive_wrong naive_output_presence PASS \
+  'empty check set, output-presence wrapper' -- \
+  "$GH_EMPTY/gh" pr view "$PR" --json statusCheckRollup
+
+with_path "$GH_EMPTY:$PATH" expect_verify NO_VERIFIER_RAN empty_result_set \
+  'empty check set' -- pr-checks "$PR"
+pass "empty check-run set is NO_VERIFIER_RAN, not PASS"
+
+with_path "$GH_PASSING:$PATH" expect_verify PASS verified \
+  'passing checks' -- pr-checks "$PR"
+pass "a non-empty all-successful check set still passes"
+
+with_path "$GH_FAILING:$PATH" expect_verify FAIL verifier_reported_failure \
+  'failing checks' -- pr-checks "$PR"
+pass "a failing check set is FAIL, and never borrows NO_VERIFIER_RAN"
+
+with_path "$GH_PENDING:$PATH" expect_verify NO_VERIFIER_RAN verification_incomplete \
+  'pending checks' -- pr-checks "$PR"
+pass "a pending check set is NO_VERIFIER_RAN, not PASS and not FAIL"
+
+# An unreachable forge is not a failing pull request. The exit-status wrapper
+# calls it FAIL, which is a verdict nobody earned.
+expect_naive_wrong naive_exit_strict FAIL \
+  'unreachable forge, exit-status wrapper' -- \
+  "$GH_DOWN/gh" pr view "$PR" --json statusCheckRollup
+with_path "$GH_DOWN:$PATH" expect_verify NO_VERIFIER_RAN verification_unreachable \
+  'unreachable forge' -- pr-checks "$PR"
+pass "unreachable forge is NO_VERIFIER_RAN, not a failing pull request"
+
+# --- fixture: git merge-tree, one exit code over two different answers -------
+
+REPO="$TMP/merge"
+git init -q -b main "$REPO"
+git -C "$REPO" config user.email fmtest@example.invalid
+git -C "$REPO" config user.name fmtest
+printf 'a\n' >"$REPO/f"
+git -C "$REPO" add f
+git -C "$REPO" commit -qm base
+git -C "$REPO" checkout -q -b conflicting
+printf 'b\n' >"$REPO/f"
+git -C "$REPO" commit -qam conflicting
+git -C "$REPO" checkout -q -b clean main
+printf 'z\n' >"$REPO/g"
+git -C "$REPO" add g
+git -C "$REPO" commit -qm clean
+git -C "$REPO" checkout -q main
+printf 'c\n' >"$REPO/f"
+git -C "$REPO" commit -qam main
+
+# The conflict still prints a written tree object, which is what fooled the
+# output-presence wrapper. It exits 1, which is what the lenient exit-status
+# wrapper misreads as "we could not look".
+expect_naive_wrong naive_output_presence PASS \
+  'merge conflict, output-presence wrapper' -- \
+  git -C "$REPO" merge-tree --write-tree main conflicting
+expect_naive_wrong naive_exit_lenient NO_VERIFIER_RAN \
+  'merge conflict, lenient exit-status wrapper' -- \
+  git -C "$REPO" merge-tree --write-tree main conflicting
+expect_verify FAIL verifier_reported_failure \
+  'merge conflict' -- merge-clean main conflicting "$REPO"
+pass "merge conflict is FAIL even though a tree object was printed"
+
+# The unresolvable ref exits 1 TOO. No exit-status-only mapping can get both
+# this and the conflict right, which is the whole argument for the third value.
+expect_naive_wrong naive_exit_strict FAIL \
+  'unresolvable ref, strict exit-status wrapper' -- \
+  git -C "$REPO" merge-tree --write-tree main nosuchref
+# The output-presence wrapper reads stdout, where the unresolvable ref leaves
+# nothing, so it lands on FAIL: a different wrong answer, not a right one.
+expect_naive_wrong naive_output_presence FAIL \
+  'unresolvable ref, output-presence wrapper' -- \
+  git -C "$REPO" merge-tree --write-tree main nosuchref
+expect_verify NO_VERIFIER_RAN verification_unreachable \
+  'unresolvable ref' -- merge-clean main nosuchref "$REPO"
+pass "unresolvable ref is NO_VERIFIER_RAN, sharing an exit code with a real verdict"
+
+expect_verify PASS verified 'clean merge' -- merge-clean main clean "$REPO"
+pass "a clean merge still passes"
+
+# --- refusals ---------------------------------------------------------------
+
+expect_verify NO_VERIFIER_RAN verifier_undeclared \
+  'undeclared verifier' -- not-a-verifier arg
+pass "an undeclared verifier is refused rather than run"
+
+expect_verify NO_VERIFIER_RAN usage_error 'no verifier named' --
+pass "a malformed call is NO_VERIFIER_RAN, never a pass"
+
+expect_verify NO_VERIFIER_RAN usage_error 'comma in evidence path' -- \
+  --evidence "$TMP/a,b.log" merge-clean main clean "$REPO"
+pass "an evidence path that would corrupt the record is refused"
+
+# --- evidence ---------------------------------------------------------------
+
+EV="$TMP/evidence.log"
+with_path "$BROWSER_BIN:$PATH" run_verify --evidence "$EV" browser open https://example.invalid
+[ "$RESULT" = NO_VERIFIER_RAN ] || fail "evidence case: expected NO_VERIFIER_RAN, got $RESULT"
+[ "$FM_VERIFY_EVIDENCE" = "$EV" ] || fail "record must point at the evidence file"
+assert_grep 'Target closed' "$EV" "evidence must hold what was actually observed"
+assert_grep 'exit_status: 0' "$EV" "evidence must record the misleading exit status"
+pass "every result points at captured evidence, including a refusal"
+
+# --- property 2: NO_VERIFIER_RAN is not coercible ---------------------------
+
+UNVERIFIED_RECORD=$(printf 'verify[1]{verifier,result,reason,evidence_ref}:\n  browser,NO_VERIFIER_RAN,verification_unreachable,/tmp/e.log\n')
+PASS_RECORD=$(printf 'verify[1]{verifier,result,reason,evidence_ref}:\n  browser,PASS,verified,/tmp/e.log\n')
+
+saw() { printf 'saw:%s\n' "$FM_VERIFY_RESULT"; }
+on_pass() { printf 'pass-branch\n'; }
+on_fail() { printf 'fail-branch\n'; }
+on_unverified() { printf 'unverified-branch\n'; }
+
+got=$(fm_verify_case "$UNVERIFIED_RECORD" on_pass on_fail saw)
+[ "$got" = "saw:NO_VERIFIER_RAN" ] ||
+  fail "NO_VERIFIER_RAN must reach the consumer as itself, got '$got'"
+pass "an unobservable case reaches the consumer as NO_VERIFIER_RAN, not downgraded en route"
+
+got=$(fm_verify_case "$PASS_RECORD" on_pass on_fail on_unverified)
+[ "$got" = pass-branch ] || fail "PASS must still reach the pass branch, got '$got'"
+pass "PASS still means pass"
+
+err=$(fm_verify_case "$UNVERIFIED_RECORD" on_pass on_fail 2>&1)
+code=$?
+expect_code 3 "$code" "two-handler consumer"
+assert_contains "$err" 'must handle all three results' "two-handler consumer refusal"
+pass "a consumer handling only two of the three results is refused"
+
+err=$(fm_verify_case "$UNVERIFIED_RECORD" on_pass on_fail on_pass 2>&1)
+code=$?
+expect_code 3 "$code" "unverified aliased to pass"
+assert_contains "$err" 'not coercible' "aliasing refusal"
+err=$(fm_verify_case "$UNVERIFIED_RECORD" on_pass on_fail on_fail 2>&1)
+code=$?
+expect_code 3 "$code" "unverified aliased to fail"
+assert_contains "$err" 'not coercible' "aliasing refusal"
+pass "handling NO_VERIFIER_RAN as pass or fail is refused, not silently accepted"
+
+err=$(fm_verify_case "$UNVERIFIED_RECORD" on_pass on_fail no_such_function 2>&1)
+code=$?
+expect_code 3 "$code" "undefined handler"
+pass "a consumer naming a handler it never defined is refused"
+
+err=$(fm_verify_case 'not a record' on_pass on_fail on_unverified 2>&1)
+code=$?
+expect_code 3 "$code" "unparseable record"
+assert_contains "$err" 'unreadable result record' "unparseable record refusal"
+pass "an unreadable record is refused, never read as an empty pass"
+
+# --- the one sanctioned narrowing, which is loud and logged ------------------
+
+LOG="$TMP/coercions.log"
+out=$(FM_VERIFY_COERCION_LOG="$LOG" fm_verify_coerce "$UNVERIFIED_RECORD" PASS \
+  'captain accepted the risk for this smoke run' 2>"$TMP/coerce.err")
+code=$?
+expect_code 0 "$code" "sanctioned coercion"
+[ "$out" = PASS ] || fail "coercion must return its target, got '$out'"
+assert_grep 'captain accepted the risk' "$LOG" "coercion must be logged"
+assert_grep 'COERCED' "$TMP/coerce.err" "coercion must also be loud on stderr"
+pass "narrowing NO_VERIFIER_RAN is possible only as an explicit, logged decision"
+
+err=$(FM_VERIFY_COERCION_LOG="$LOG" fm_verify_coerce "$UNVERIFIED_RECORD" PASS '' 2>&1)
+code=$?
+expect_code 3 "$code" "coercion without a reason"
+err=$(FM_VERIFY_COERCION_LOG="$LOG" fm_verify_coerce "$PASS_RECORD" FAIL 'because' 2>&1)
+code=$?
+expect_code 3 "$code" "coercion of an observed result"
+assert_contains "$err" 'only NO_VERIFIER_RAN is coercible' "observed-result coercion refusal"
+pass "a coercion with no reason, or of a result that was actually observed, is refused"
+
+# --- the conformance obligation ---------------------------------------------
+#
+# Every declared verifier ships with a control proving its unobservable case is
+# distinct. Adding one without such a control fails here rather than shipping a
+# verifier that cannot say "I could not look".
+COVERED='browser merge-clean pr-checks'
+declared=$("$VERIFY" --list | LC_ALL=C sort | tr '\n' ' ')
+declared=${declared% }
+[ "$declared" = "$COVERED" ] ||
+  fail "every declared verifier needs an unobservable-case control here; registry is '$declared', covered is '$COVERED'"
+pass "each declared verifier has a witnessed unobservable-case control"
+
+pass "fm-verify: three-valued observation contract holds"

--- a/tests/fm-verify.test.sh
+++ b/tests/fm-verify.test.sh
@@ -170,6 +170,28 @@ with_path "$BROWSER_SILENT_BIN:$PATH" expect_verify NO_VERIFIER_RAN empty_result
   'browser silent' -- browser open https://example.invalid
 pass "silent browser is NO_VERIFIER_RAN, not PASS"
 
+BROWSER_CRASH_BIN=$(fm_fakebin "$TMP/browser-crash")
+cat >"$BROWSER_CRASH_BIN/chrome-devtools-axi" <<'SH'
+#!/usr/bin/env bash
+# A non-zero exit for a reason no signature names: a crash, a page-load
+# timeout, a DNS failure. None of them is a statement about the page.
+printf 'chrome exited unexpectedly while loading the page\n' >&2
+exit 3
+SH
+chmod +x "$BROWSER_CRASH_BIN/chrome-devtools-axi"
+
+# chrome-devtools-axi is a control tool, not an assertion tool: it has no way to
+# report a bad page, so an exit status nobody can interpret is could-not-observe.
+# The exit-status wrapper calls it FAIL, which is a verdict about the page that
+# nothing in the evidence earned - and it hides a broken verifier among real
+# failures.
+expect_naive_wrong naive_exit_strict FAIL \
+  'uninterpretable browser exit, exit-status wrapper' -- \
+  "$BROWSER_CRASH_BIN/chrome-devtools-axi" open https://example.invalid
+with_path "$BROWSER_CRASH_BIN:$PATH" expect_verify NO_VERIFIER_RAN verification_unreachable \
+  'uninterpretable browser exit' -- browser open https://example.invalid
+pass "a browser exit matching no signature is NO_VERIFIER_RAN, not a verdict about the page"
+
 BARE_PATH=$(minimal_path "$TMP/bare-bin")
 with_path "$BARE_PATH" expect_verify NO_VERIFIER_RAN verifier_unavailable \
   'browser absent' -- browser open https://example.invalid
@@ -196,6 +218,12 @@ GH_FAILING=$(make_gh "$TMP/gh-failing" \
   '{"statusCheckRollup":[{"status":"COMPLETED","conclusion":"FAILURE"}]}')
 GH_PENDING=$(make_gh "$TMP/gh-pending" \
   '{"statusCheckRollup":[{"status":"IN_PROGRESS","conclusion":null}]}')
+GH_SKIPPED=$(make_gh "$TMP/gh-skipped" \
+  '{"statusCheckRollup":[{"status":"COMPLETED","conclusion":"SKIPPED"}]}')
+GH_NO_CONCLUSION=$(make_gh "$TMP/gh-no-conclusion" \
+  '{"statusCheckRollup":[{"status":"COMPLETED","conclusion":null}]}')
+GH_ONE_STALE=$(make_gh "$TMP/gh-one-stale" \
+  '{"statusCheckRollup":[{"status":"COMPLETED","conclusion":"SUCCESS"},{"status":"COMPLETED","conclusion":"STALE"}]}')
 GH_DOWN=$(make_gh "$TMP/gh-down" 'gh: could not reach api.github.com' 1)
 
 PR=https://github.com/example/repo/pull/1
@@ -222,6 +250,29 @@ pass "a failing check set is FAIL, and never borrows NO_VERIFIER_RAN"
 with_path "$GH_PENDING:$PATH" expect_verify NO_VERIFIER_RAN verification_incomplete \
   'pending checks' -- pr-checks "$PR"
 pass "a pending check set is NO_VERIFIER_RAN, not PASS and not FAIL"
+
+# The empty set's defect one level down, inside the rule that owns the PASS
+# verdict: a check skipped by a path filter, or gone stale, completed without
+# earning a verdict, and zero failing checks still looks exactly like every
+# check passing. Both naive wrappers read the same gh success and say PASS.
+expect_naive_wrong naive_exit_strict PASS \
+  'skipped checks, exit-status wrapper' -- \
+  "$GH_SKIPPED/gh" pr view "$PR" --json statusCheckRollup
+expect_naive_wrong naive_output_presence PASS \
+  'skipped checks, output-presence wrapper' -- \
+  "$GH_SKIPPED/gh" pr view "$PR" --json statusCheckRollup
+
+with_path "$GH_SKIPPED:$PATH" expect_verify NO_VERIFIER_RAN no_verdict_reached \
+  'skipped checks' -- pr-checks "$PR"
+pass "a check set that only skipped is NO_VERIFIER_RAN, not PASS"
+
+with_path "$GH_NO_CONCLUSION:$PATH" expect_verify NO_VERIFIER_RAN no_verdict_reached \
+  'completed with no conclusion' -- pr-checks "$PR"
+pass "a completed check carrying no conclusion is NO_VERIFIER_RAN, not PASS"
+
+with_path "$GH_ONE_STALE:$PATH" expect_verify NO_VERIFIER_RAN no_verdict_reached \
+  'one stale check among successes' -- pr-checks "$PR"
+pass "passing means EVERY member succeeded, so one unconcluded check withholds it"
 
 # An unreachable forge is not a failing pull request. The exit-status wrapper
 # calls it FAIL, which is a verdict nobody earned.
@@ -350,6 +401,17 @@ code=$?
 expect_code 3 "$code" "unparseable record"
 assert_contains "$err" 'unreadable result record' "unparseable record refusal"
 pass "an unreadable record is refused, never read as an empty pass"
+
+# Rejecting a record is only half the promise. A record refused on its LAST
+# field must leave nothing behind either, or a consumer that reads the fields
+# without the status sees a PASS extracted from a record just refused - the
+# unparseable record read as an empty pass, one layer in.
+REJECTED_RECORD=$(printf 'verify[1]{verifier,result,reason,evidence_ref}:\n  browser,PASS,,/tmp/e.log\n')
+! fm_verify_parse "$REJECTED_RECORD" || fail "a record with an empty reason must be rejected"
+[ -z "$FM_VERIFY_RESULT" ] && [ -z "$FM_VERIFY_VERIFIER" ] &&
+  [ -z "$FM_VERIFY_REASON" ] && [ -z "$FM_VERIFY_EVIDENCE" ] ||
+  fail "a rejected record left fields behind: verifier='$FM_VERIFY_VERIFIER' result='$FM_VERIFY_RESULT' reason='$FM_VERIFY_REASON' evidence='$FM_VERIFY_EVIDENCE'"
+pass "a rejected record leaves no partially-populated fields behind"
 
 # --- the one sanctioned narrowing, which is loud and logged ------------------
 

--- a/tests/fm-verify.test.sh
+++ b/tests/fm-verify.test.sh
@@ -266,13 +266,84 @@ with_path "$GH_SKIPPED:$PATH" expect_verify NO_VERIFIER_RAN no_verdict_reached \
   'skipped checks' -- pr-checks "$PR"
 pass "a check set that only skipped is NO_VERIFIER_RAN, not PASS"
 
-with_path "$GH_NO_CONCLUSION:$PATH" expect_verify NO_VERIFIER_RAN no_verdict_reached \
-  'completed with no conclusion' -- pr-checks "$PR"
-pass "a completed check carrying no conclusion is NO_VERIFIER_RAN, not PASS"
-
 with_path "$GH_ONE_STALE:$PATH" expect_verify NO_VERIFIER_RAN no_verdict_reached \
   'one stale check among successes' -- pr-checks "$PR"
 pass "passing means EVERY member succeeded, so one unconcluded check withholds it"
+
+# --- the conclusion partition, one conclusion at a time ----------------------
+#
+# The partition is what the three values are worth: a conclusion in the wrong
+# list produces a value for a condition that never earned it. Each conclusion is
+# asserted on its own so a misplacement names itself instead of hiding inside an
+# aggregate.
+
+# gh_with_conclusion <json-conclusion> <slug>: a gh whose pull request carries
+# exactly one COMPLETED check with that conclusion.
+gh_with_conclusion() {
+  make_gh "$TMP/gh-conclusion-$2" \
+    "{\"statusCheckRollup\":[{\"status\":\"COMPLETED\",\"conclusion\":$1}]}"
+}
+
+while read -r conclusion want; do
+  [ -n "$conclusion" ] || continue
+  bin=$(gh_with_conclusion "\"$conclusion\"" "$(printf '%s' "$conclusion" | tr '[:upper:]' '[:lower:]')")
+  with_path "$bin:$PATH" expect_verify "$want" - "conclusion $conclusion" -- pr-checks "$PR"
+  pass "a check concluding $conclusion is $want"
+done <<'EOF'
+SUCCESS PASS
+FAILURE FAIL
+STARTUP_FAILURE FAIL
+TIMED_OUT NO_VERIFIER_RAN
+CANCELLED NO_VERIFIER_RAN
+ACTION_REQUIRED NO_VERIFIER_RAN
+SKIPPED NO_VERIFIER_RAN
+STALE NO_VERIFIER_RAN
+NEUTRAL NO_VERIFIER_RAN
+EOF
+
+with_path "$GH_NO_CONCLUSION:$PATH" expect_verify NO_VERIFIER_RAN no_verdict_reached \
+  'absent conclusion' -- pr-checks "$PR"
+pass "a check completing with no conclusion at all is NO_VERIFIER_RAN"
+
+# ERROR is not a check-run conclusion: it comes from the older commit-status
+# state vocabulary, which is why the rule reads .conclusion // .state. Asserted
+# in its own shape so repartitioning cannot quietly drop one vocabulary.
+GH_STATE_ERROR=$(make_gh "$TMP/gh-state-error" \
+  '{"statusCheckRollup":[{"state":"ERROR"}]}')
+with_path "$GH_STATE_ERROR:$PATH" expect_verify FAIL verifier_reported_failure \
+  'commit status ERROR' -- pr-checks "$PR"
+pass "a commit status in the ERROR state is FAIL, so both GitHub vocabularies stay live"
+
+# A cancelled or timed-out run observed nothing: a superseding push killed it,
+# or the clock did. Calling either FAIL asserts a verdict about the pull request
+# that nothing earned, and hides a broken verifier among real failures.
+for conclusion in TIMED_OUT CANCELLED; do
+  bin=$(gh_with_conclusion "\"$conclusion\"" "notfail-$conclusion")
+  with_path "$bin:$PATH" run_verify pr-checks "$PR"
+  [ "$RESULT" != FAIL ] ||
+    fail "$conclusion must not read as FAIL: nothing about the pull request was observed"
+  with_path "$bin:$PATH" expect_verify NO_VERIFIER_RAN no_verdict_reached \
+    "$conclusion is not a verdict" -- pr-checks "$PR"
+done
+pass "a cancelled or timed-out run is NO_VERIFIER_RAN, never a FAIL it did not earn"
+
+# The mirror: a workflow that failed to start is terminal. Reporting it as
+# could-not-observe sends the reader to "wait or re-run", the one action that
+# cannot help, and the failure never resolves.
+GH_STARTUP=$(gh_with_conclusion '"STARTUP_FAILURE"' notunverified-startup)
+with_path "$GH_STARTUP:$PATH" run_verify pr-checks "$PR"
+[ "$RESULT" != NO_VERIFIER_RAN ] ||
+  fail "STARTUP_FAILURE must not read as could-not-observe: it is terminal and re-running reproduces it"
+with_path "$GH_STARTUP:$PATH" expect_verify FAIL verifier_reported_failure \
+  'startup failure' -- pr-checks "$PR"
+pass "a workflow that failed to start is FAIL, not parked as unobservable"
+
+# The default branch fails closed: a conclusion this rule has never heard of
+# cannot fall into a verdict on its way past the last elif.
+GH_UNKNOWN=$(gh_with_conclusion '"QUANTUM_INDETERMINATE"' unknown)
+with_path "$GH_UNKNOWN:$PATH" expect_verify NO_VERIFIER_RAN no_verdict_reached \
+  'unknown conclusion' -- pr-checks "$PR"
+pass "a conclusion the rule does not know is NO_VERIFIER_RAN by design, not by omission"
 
 # An unreachable forge is not a failing pull request. The exit-status wrapper
 # calls it FAIL, which is a verdict nobody earned.


### PR DESCRIPTION
## Intent

Implement CFVC-07 from the approved CFVC remediation plan, then execute the captain-approved scope widening issued mid-task.

CFVC-07 goal: no verifier's silence, error, or absent result can be read as a pass, anywhere. Rationale is three dated, real instances: an empty check-run set read as checks-passed; chrome-devtools-axi open|snapshot|eval against a control site returning "Protocol error (Target.setDiscoverTargets): Target closed" AND exiting 0 every time; git merge-tree exiting 1 on conflict while still printing a tree object. Every brief in this fleet instructs workers to use chrome-devtools-axi, and a worker branching on exit status concludes the page is fine. Ruling D3 already decided the policy: "Fail closed. Unreachable browser yields verification_unreachable, never pass/green/skipped. Regression coverage required."

Prior state was PARTIALLY IMPLEMENTED: the law was stated per-LoopSpec and in prose in every brief, but no wrapper enforced it. Target state: bin/fm-verify.sh <verifier> [args] returning exactly one of PASS, FAIL, NO_VERIFIER_RAN, refusing to map exit-0-with-error-output to PASS. Owner is the new bin/fm-verify.sh. Ultimate value creator is CODE. Changed components: new bin/fm-verify.sh plus call sites in briefs and LoopSpec verification. AXI shape: verify[1]{verifier,result,reason,evidence_ref}. Schema is the three-valued result with NO stored verification_level - declare the verifier, derive the level.

Required tests: all three dated instances as fixtures - the browser protocol error must yield NO_VERIFIER_RAN not PASS; git merge-tree's exit-1-with-output must yield FAIL; an empty check set must yield NO_VERIFIER_RAN. Each must be red-capable against a naive exit-status wrapper. Certification: the wrapper must itself be tested with a verifier that exits 0 and prints an error - the exact chrome-devtools-axi shape - or it certifies nothing. Completion criteria: (a) three fixtures each red against an exit-status-only wrapper and green against fm-verify; (b) NO_VERIFIER_RAN cannot reach a PASS terminal in any consumer; (c) ruling D3's required regression coverage is present. Migration: wrap opportunistically, every wrap is independently valuable. Rollback: call sites revert to direct invocation.

Retirement obligation for CFVC-07: it retires the per-brief exhortation "wait on completion artifacts, never process names". It explicitly does NOT retire the negative-control instruction, which stays in the brief - and saying so is what keeps this increment honest.

CAPTAIN-APPROVED SCOPE WIDENING (accepted mid-task, folded in here). Ten instances of the same defect were measured across ten subsystems on 2026-08-06. Root cause is one type error: a function that can fail to OBSERVE returns the same type as one that observed a negative result, so "I looked and found nothing" and "I could not look" collapse into a single value - empty, zero, false, absent - and that value then reads as fine. Vigilance already failed: the slogan "an absent result is not a pass" was written into the commission and produced ten instances anyway, because it names the symptom without naming the mechanism. Hence a type discipline rather than a rule to remember. This increment now owns three properties: (1) three values are the minimum for any observation, never a boolean, and NO_VERIFIER_RAN becomes the fleet-wide contract rather than one wrapper's private convention; (2) the unverified value must be non-coercible - it must be unrepresentable as pass or fail without an explicit, logged decision, because every measured instance died at a conversion (exit-code narrowing, an empty collection counting as zero failures, an unreadable file counting as no findings, a missing set counting as a clean set); (3) consumers must handle all three, because a consumer branching on pass-versus-not-pass reintroduces the defect against a perfectly correct producer. Newly in scope: a bounded audit enumerating conversion points where the third value can die - exit-code narrowing, empty collections treated as no failures, empty strings treated as no output, missing or unreadable files treated as nothing found, absent check sets treated as checks passed, unreachable remotes or tools treated as nothing to do - reporting findings even where not fixed. Explicitly ruled out: do not build a runtime checker or a new validation subsystem; stop at the first rung that removes the measured defect, which is a type discipline plus a test obligation. Prevention carried: a conformance obligation that any verifier touched or added ships with a control proving its unobservable case is distinct, witnessed red; and the mechanism (not the slogan) written into the shared instructions. Required controls, witnessed red: each of the three values produced for its own condition and never borrowing another's; an unobservable case reaching a consumer AS unverified rather than silently downgraded en route; a consumer handling only two of the three failing the check; and PASS still meaning pass, because a verifier that returns unverified for everything is as useless as one that returns PASS for everything. Widened retirement: any two-valued observation replaced goes away in the same change - do not leave a boolean path beside the three-valued one.

Commission-wide binding constraints that shaped the work. Verify live state before building rather than trusting the report snapshot. Retirement is mandatory: no increment may introduce a name or mechanism without stating what it replaces, and the replacement must actually retire in the same increment; transitional compatibility only for a bounded migration carrying an explicit deletion condition. Certification uses red-capable tests only: a test that only passes after the implementation is not sufficient evidence - run the negative control, witness it fail, then run the real check; absence is never evidence. If a completion criterion has become stale because the implementation changed, replace it with an equally strong or stronger red-capable criterion and document why in the commit body. Three reliability laws: an absent result is not a pass; a claim is not a verdict; delivered is not landed. Value-creator law: CODE when the result follows from structured state plus an established rule, AGENT only for semantic residue, ENGINEER only for goals and policy and non-delegable risk; do not convert natural-language judgment into brittle regex merely to remove an agent turn, and record a broken reader as TOOLING_GAP rather than treating it as legitimate reasoning demand. Do not build new machinery - no new scheduler, daemon, wake queue, private LoopSpec runner, or project-management status system. Do not conflate Fractal Node, LoopSpec, ExecutionUnit, Skill, Agent, Runtime. Landing authority is NOT expanded: ruling B4 stands, autonomous landing authority was not authorized. Work identity has one owner: the deterministic Runtime owns canonical bounded-work identity.

DECISIONS AND TRADEOFFS MADE WHILE DOING THE WORK, which a reviewer reading only the diff would not know.

The contribution base (2cf0283, upstream firstmate main) differs from the running fleet code (ed376cf) that the report was written against. Deliberate consequences: (1) loopspecs/ does not exist at the contribution base, so the LoopSpec verification call sites the spec names could not be touched, and none were invented; (2) the per-brief exhortation "wait on completion artifacts, never process names" exists only in the fleet's local copy of bin/fm-brief.sh, not upstream, so its retirement lands as "not introduced" - the new verification block carries its irreducible safety content in type-rule form (a missing expected artifact is could-not-observe at collection time rather than work still in progress) and a test asserts the exhortation itself never reappears.

Registry design: the verifier registry is deliberately CLOSED (browser, pr-checks, merge-clean) with no generic escape hatch, because a generic adapter that guesses at an unknown tool's output is the defect itself. An undeclared name is refused rather than run. Adding a verifier requires adding an adapter, and the test suite enforces that every declared verifier ships with an unobservable-case control.

Exit-code mapping is deliberate and load-bearing: exit 0 for PASS and only PASS, 1 for FAIL, 2 for NO_VERIFIER_RAN. That is the structural half of non-coercion - a caller reading nothing but the status still cannot land on a pass.

The browser adapter recognizes transport failures by their text, and this is deliberately recorded in the script header as a TOOLING_GAP rather than presented as good design: chrome-devtools-axi reports transport failures on stdout while exiting 0, so until it exits non-zero there is no structural signal. The signature list is deliberately biased toward false NO_VERIFIER_RAN (costs one re-run) over false PASS (the defect). The durable fix belongs upstream in that tool.

merge-clean distinguishes a conflict from an unresolvable ref by whether merge-tree wrote a real tree object (validated with cat-file, full 40/64-char object name required), because git merge-tree exits 1 for BOTH.

Consumer contract: fm_verify_case is the only supported read path and refuses a consumer that does not name three DISTINCT defined handlers - including one that aliases the unverified branch onto pass or fail, which is coercion written as a consumer. fm_verify_coerce is the single sanctioned narrowing: requires a reason, refuses an already-observed result, is loud on stderr and logged.

Retirements actually performed in this change: bin/fm-bearings-snapshot.sh's inline copy of the check-set classification rule, now spliced from the shared owner bin/fm-verify-lib.sh so "none" there and NO_VERIFIER_RAN in the wrapper stay the same empty set; and the brief instruction telling workers to read gh-axi and chrome-devtools-axi exit status directly, replaced in both scout and ship scaffolds by the wrapper call site. The negative-control instruction is deliberately retained and asserted present by test.

Completion criterion (a) was deliberately replaced with a stronger criterion and this is documented in the commit body: the spec said each fixture must be red against an exit-status-only wrapper, which is exact for the browser and the empty check set but stale for the merge conflict, where a strict exit-status wrapper happens to agree. The replacement criterion, which the suite asserts, is that git merge-tree exits 1 both for a real conflict and for an unresolvable ref, so NO exit-status-only mapping can get both right - the strict mapping misreads the unresolvable ref as a verdict, the lenient mapping misreads the conflict as a non-verdict, and only the third value separates them.

Nine negative controls were witnessed red before the tests were trusted, and are listed in the commit body: browser transport check removed, empty check set mapped to PASS, merge-tree tree-object check bypassed, handler aliasing permitted, third handler defaulted to on_fail, a fourth verifier added to the registry without a control, coercion made silent, verification block removed from briefs, and the retired exhortation re-added to briefs.

Deliberately NOT fixed, and reported instead in the bounded audit in the commit body: bin/fm-teardown.sh work_is_landed/content_in_default/pr_is_merged collapses unreachable forge, unresolvable ref, merge conflict and genuinely unlanded into "not landed" - the collapse is currently safe because every non-landed value refuses, so it was left alone rather than risked against the never-tear-down-unlanded-work rule, and it is named as the highest-value follow-up; bin/fm-crew-state.sh's checks-passed claim becoming a done terminal reading "checks green" belongs to the typed status-event increment, not this one; bin/fm-pr-merge.sh merges with no check verification at this base but upstream PR 1614 owns that fix and the commission requires one owner only, so nothing was added there. bin/fm-pr-poll.sh and bin/fm-busy-lib.sh were audited and found already correct, and are cited as the existing models.

AGENTS.md gained four lines under hard rule 5 stating the type rule itself with a pointer to bin/fm-verify.sh, kept deliberately short because AGENTS.md token cost is paid by every session of every fleet member.

The new test is registered in bin/fm-test-run.sh's pure-contract-unit family and lands in the portable serial lane; the coverage guard passes. bin/fm-lint.sh is clean with no warnings or errors, and bin/fm-doc-audience-check.sh passes.

## What Changed

- Added `bin/fm-verify.sh`, a wrapper that runs one declared verifier (`browser`, `pr-checks`, `merge-clean` — the registry is closed, an undeclared name is refused rather than run) and emits a single `verify[1]{verifier,result,reason,evidence_ref}` record whose result is `PASS`, `FAIL`, or `NO_VERIFIER_RAN`, with exit 0 reserved for `PASS` alone (1 for `FAIL`, 2 for `NO_VERIFIER_RAN`). It recognizes the three measured cases directly: chrome-devtools-axi printing a transport error while exiting 0, an empty GitHub check-run set, and `git merge-tree` exiting 1 for both a real conflict and an unresolvable ref (separated by whether a tree object was actually written). Added `bin/fm-verify-lib.sh` as the single owner of the three-valued type: `fm_verify_parse`, `fm_verify_case` (refuses any consumer that does not supply three distinct handlers, including one aliased onto pass or fail), and `fm_verify_coerce` as the only sanctioned narrowing — reason required, already-observed results refused, loud on stderr and logged.
- Moved the check-rollup classification rule into `bin/fm-verify-lib.sh` and spliced it into `bin/fm-bearings-snapshot.sh`, retiring that script's inline copy. The shared rule adds an `inconclusive` label so checks that completed without earning a verdict (`TIMED_OUT`, `CANCELLED`, `ACTION_REQUIRED`, `SKIPPED`, `STALE`, `NEUTRAL`, an absent conclusion, or any unknown conclusion) no longer fall through to `passing`, and moves `STARTUP_FAILURE` into `failing`; the captain-facing bearings `checks` value changes accordingly.
- Rewrote rule 3 in both the scout and ship brief scaffolds to route observations through the wrapper instead of reading gh-axi/chrome-devtools-axi exit status, and added a Verification-discipline block stating the mechanism rather than the slogan; the negative-control instruction is deliberately retained and asserted present by test. `AGENTS.md` hard rule 5 gained three lines carrying the same type rule, `docs/scripts.md` documents both new scripts, and `bin/fm-test-run.sh` registers `tests/fm-verify.test.sh` in the pure-contract-unit family and maps `bin/fm-verify-lib.sh` changes onto both that family and snapshot-bearings. New coverage lands in `tests/fm-verify.test.sh` plus additions to the brief and bearings-snapshot suites.

## Risk Assessment

✅ Low: All seven findings from the two prior rounds are now resolved and independently verified, the repartitioned rule matches its documented prose across every GitHub conclusion and both status vocabularies, and each new behavior carries an individually-named control that would go red if its member were misplaced.

## Testing

Ran the four targeted suites (fm-verify, fm-brief, fm-bearings-snapshot, fm-documentation-audiences) plus the runner's coverage/lane/changed-selection checks, all green, then demonstrated the intent end-to-end at the product level: the live real chrome-devtools-axi reproduced the exact dated defect (transport error with exit 0) and fm-verify.sh returned NO_VERIFIER_RAN at exit 2, two live GitHub PRs with genuinely empty check sets returned empty_result_set instead of green, and git merge-tree's shared exit 1 was separated into FAIL and NO_VERIFIER_RAN while a clean merge still passed. Because the completion criteria demand red-capable proof, I mutated the implementation nine ways and witnessed each named negative control fail for the right reason, restoring the worktree clean after each; a 17-case stress over malformed and degraded invocations confirmed nothing but a real observed verdict reaches exit 0, and the consumer contract refused both a two-handler consumer and one aliasing unverified onto pass. This change ships no rendered UI, so its end-user surfaces are CLI records, the generated crewmate brief, and the captain's Bearings row, all captured as transcripts and a rendered brief markdown file rather than screenshots. No actionable findings; the items the author deliberately left unfixed are reported in the commit body's bounded audit rather than being test failures.

<details>
<summary>Evidence: Three dated instances, end-to-end through fm-verify.sh (instance 1 against the LIVE real chrome-devtools-axi)</summary>

<code>INSTANCE 1 - chrome-devtools-axi (LIVE, real tool, no fixture)&#10;--- what a worker branching on exit status sees today ---&#10;naive wrapper verdict: PASS (exit 0)&#10;actual tool output:&#10;page:&#10;refs: 0&#10;snapshot:&#10;Protocol error (Target.setDiscoverTargets): Target closed&#10;--- through bin/fm-verify.sh ---&#10;verify[1]{verifier,result,reason,evidence_ref}:&#10;browser,NO_VERIFIER_RAN,verification_unreachable,.../browser-live-evidence.log&#10;exit status: 2&#10;&#10;INSTANCE 2 - empty GitHub check-run set&#10;naive wrapper verdict: PASS (exit 0, zero failing checks == checks green)&#10;pr-checks,NO_VERIFIER_RAN,empty_result_set,/tmp/fm-verify-pr-checks.S9uCNA&#10;exit status: 2&#10;&#10;INSTANCE 3 - git merge-tree: exit 1 for a conflict AND for an unresolvable ref&#10;--- REAL CONFLICT (a verdict) --- raw git exit status: 1 &lt;-- SAME for both&#10;merge-clean,FAIL,verifier_reported_failure exit status: 1&#10;--- UNRESOLVABLE REF (no verdict) --- raw git exit status: 1 &lt;-- SAME for both&#10;merge-clean,NO_VERIFIER_RAN,verification_unreachable exit status: 2&#10;--- and PASS still means pass ---&#10;merge-clean,PASS,verified exit status: 0</code>

```text

================================================================
INSTANCE 1 - chrome-devtools-axi (LIVE, real tool, no fixture)
================================================================
--- what a worker branching on exit status sees today ---
naive wrapper verdict: PASS (exit 0)
actual tool output:
    page:
      refs: 0
    snapshot:
    Protocol error (Target.setDiscoverTargets): Target closed
    Cause:
    help[1]:
      Use `chrome-devtools-axi eval <expr>` for JS expressions. For multi-statement code, pass a function: `eval "() => { ...; return result }"`

--- through bin/fm-verify.sh ---
verify[1]{verifier,result,reason,evidence_ref}:
  browser,NO_VERIFIER_RAN,verification_unreachable,/tmp/no-mistakes-evidence/01KZBZTV5BJNF7R4DGN2MXZ93X/browser-live-evidence.log
exit status: 2

================================================================
INSTANCE 2 - empty GitHub check-run set
================================================================
--- what a worker branching on exit status sees today ---
naive wrapper verdict: PASS (exit 0, zero failing checks == checks green)

--- through bin/fm-verify.sh ---
verify[1]{verifier,result,reason,evidence_ref}:
  pr-checks,NO_VERIFIER_RAN,empty_result_set,/tmp/fm-verify-pr-checks.S9uCNA
exit status: 2

================================================================
INSTANCE 3 - git merge-tree: exit 1 for a conflict AND for an unresolvable ref
================================================================
--- REAL CONFLICT (a verdict): git merge-tree --write-tree main conflicting ---
raw git exit status: 1   <-- SAME for both
raw stdout first line: 964d6c2cc0d245d62535aa92dfd9e444c423ca84
through fm-verify.sh:
    verify[1]{verifier,result,reason,evidence_ref}:
      merge-clean,FAIL,verifier_reported_failure,/tmp/fm-verify-merge-clean.4OWhKg
    exit status: 1

--- UNRESOLVABLE REF (no verdict): git merge-tree --write-tree main nosuchref ---
raw git exit status: 1   <-- SAME for both
raw stdout first line: 
through fm-verify.sh:
    verify[1]{verifier,result,reason,evidence_ref}:
      merge-clean,NO_VERIFIER_RAN,verification_unreachable,/tmp/fm-verify-merge-clean.Jka7UC
    exit status: 2

--- and PASS still means pass ---
verify[1]{verifier,result,reason,evidence_ref}:
  merge-clean,PASS,verified,/tmp/fm-verify-merge-clean.xdvG2s
exit status: 0
```
</details>
<details>
<summary>Evidence: Nine negative controls witnessed RED (implementation mutated, suite re-run, worktree restored)</summary>

<code>control 1: browser transport check removed&#10;not ok - browser protocol error: expected NO_VERIFIER_RAN, got PASS&#10;control 2: empty check set mapped to PASS&#10;not ok - empty check set: expected NO_VERIFIER_RAN, got PASS&#10;control 3: merge-tree tree-object check bypassed&#10;not ok - unresolvable ref: expected NO_VERIFIER_RAN, got FAIL&#10;control 4: handler aliasing permitted&#10;not ok - unverified aliased to pass: expected exit 3, got 0&#10;control 5: third handler defaulted to on_fail&#10;not ok - two-handler consumer refusal (missing: &#39;must handle all three results&#39;)&#10;control 6: fourth verifier added without a control&#10;not ok - every declared verifier needs an unobservable-case control here; registry is &#39;browser merge-clean pr-checks smoke-test&#39;&#10;control 7: coercion made silent&#10;not ok - coercion must also be loud on stderr&#10;control 8: verification block removed from briefs&#10;not ok - ship brief lost the three-valued observation type rule&#10;control 9 (redone): retired exhortation re-added BESIDE the type rule&#10;not ok - ship brief still carries the exhortation the wrapper replaces</code>

```text
Each control breaks the implementation one way and re-runs the suite.
A test that only goes green after the fix proves nothing; these prove the suite can go RED.


--- control 1: browser transport check removed ---
suite went RED:
    not ok - browser protocol error: expected NO_VERIFIER_RAN, got PASS

--- control 2: empty check set mapped to PASS ---
suite went RED:
    not ok - empty check set: expected NO_VERIFIER_RAN, got PASS

--- control 3: merge-tree tree-object check bypassed ---
suite went RED:
    not ok - unresolvable ref: expected NO_VERIFIER_RAN, got FAIL

--- control 4: handler aliasing permitted ---
suite went RED:
    not ok - unverified aliased to pass: expected exit 3, got 0

--- control 5: third handler defaulted to on_fail ---
suite went RED:
    not ok - two-handler consumer refusal (missing: 'must handle all three results')

--- control 6: fourth verifier added without a control ---
suite went RED:
    not ok - every declared verifier needs an unobservable-case control here; registry is 'browser merge-clean pr-checks smoke-test', covered is 'browser merge-clean pr-checks'

--- control 7: coercion made silent ---
suite went RED:
    not ok - coercion must also be loud on stderr

--- control 8: verification block removed from briefs ---
suite went RED:
    not ok - ship brief lost the three-valued observation type rule

--- control 9: retired exhortation re-added to briefs ---
suite went RED:
    not ok - ship brief lost the three-valued observation type rule

--- worktree restored ---

--- control 9 (redone): retired exhortation re-added BESIDE the type rule ---
mutation: inserted "Wait on completion artifacts, never process names." into the brief
suite went RED:
    not ok - ship brief still carries the exhortation the wrapper replaces
```
</details>
<details>
<summary>Evidence: Live pr-checks on real PRs + consumer contract (aliasing refused, coercion logged)</summary>

<code>=== LIVE pr-checks against real open PRs on kunchenguid/firstmate ===&#10;--- PR #1825 --- {&#34;count&#34;:0,&#34;members&#34;:[]}&#10;pr-checks,NO_VERIFIER_RAN,empty_result_set exit status: 2&#10;&#10;=== CONSUMER CONTRACT: NO_VERIFIER_RAN cannot reach a PASS terminal ===&#10;1. correct three-handler consumer:&#10;-&gt; refused: NO_VERIFIER_RAN (verification_unreachable) - re-run or escalate status: 0&#10;2. consumer that handles only two of the three:&#10;fm-verify: consumer must handle all three results status: 3 &lt;- refused&#10;3. consumer that aliases the unverified branch onto pass:&#10;fm-verify: NO_VERIFIER_RAN is not coercible; use fm_verify_coerce status: 3 &lt;- refused&#10;4. the ONE sanctioned narrowing - loud on stderr and logged:&#10;fm-verify: COERCED NO_VERIFIER_RAN -&gt; PASS (captain accepted the risk for this smoke run)&#10;logged: pr-checks PASS verification_unreachable ... captain accepted the risk&#10;5. coercion with no reason / of an already-observed result: both refused (status 3)</code>

```text
=== LIVE pr-checks against a real open PR on kunchenguid/firstmate ===
--- PR #1825 ---
{"count":0,"members":[]}
verify[1]{verifier,result,reason,evidence_ref}:
  pr-checks,NO_VERIFIER_RAN,empty_result_set,/tmp/fm-verify-pr-checks.sfWIzm
exit status: 2

--- PR #1826 ---
{"count":0,"members":[]}
verify[1]{verifier,result,reason,evidence_ref}:
  pr-checks,NO_VERIFIER_RAN,empty_result_set,/tmp/fm-verify-pr-checks.ql5VrB
exit status: 2

=== CONSUMER CONTRACT: NO_VERIFIER_RAN cannot reach a PASS terminal ===
record under test:
    verify[1]{verifier,result,reason,evidence_ref}:
      pr-checks,NO_VERIFIER_RAN,verification_unreachable,/tmp/fm-verify-pr-checks.eWYYFt

1. correct three-handler consumer:
    -> refused: NO_VERIFIER_RAN (verification_unreachable) - re-run or escalate
    fm_verify_case status: 0

2. consumer that handles only two of the three (pass vs not-pass):
fm-verify: consumer must handle all three results
    fm_verify_case status: 3 <- refused

3. consumer that aliases the unverified branch onto pass (coercion written as a consumer):
fm-verify: NO_VERIFIER_RAN is not coercible; use fm_verify_coerce
    fm_verify_case status: 3 <- refused

4. the ONE sanctioned narrowing - loud on stderr and logged:
fm-verify: COERCED NO_VERIFIER_RAN -> PASS (captain accepted the risk for this smoke run): pr-checks reason=verification_unreachable evidence=/tmp/fm-verify-pr-checks.eWYYFt
PASS
    coerce status: 0
    logged: pr-checks	PASS	verification_unreachable	/tmp/fm-verify-pr-checks.eWYYFt	captain accepted the risk for this smoke run

5. coercion with no reason, and coercion of an already-observed result:
fm-verify: coercion needs a target and a reason
    status: 3 <- refused
fm-verify: only NO_VERIFIER_RAN is coercible
    status: 3 <- refused
```
</details>
<details>
<summary>Evidence: Captain-facing Bearings row + before/after label table (retired inline rule vs shared rule)</summary>

<code>--- the row the captain reads (one check: COMPLETED / SKIPPED) ---&#10;[ { &#34;num&#34;: &#34;9&#34;, &#34;repo&#34;: &#34;kunchenguid/firstmate&#34;, &#34;review&#34;: &#34;APPROVED&#34;,&#10;&#34;mergeable&#34;: &#34;MERGEABLE&#34;, &#34;checks&#34;: &#34;inconclusive&#34; } ]&#10;&#10;PR check set BEFORE AFTER fm-verify.sh result&#10;one SKIPPED check passing inconclusive NO_VERIFIER_RAN (exit 2) &lt;-- changed&#10;one STALE check passing inconclusive NO_VERIFIER_RAN (exit 2) &lt;-- changed&#10;one NEUTRAL check passing inconclusive NO_VERIFIER_RAN (exit 2) &lt;-- changed&#10;COMPLETED, no conclusion passing inconclusive NO_VERIFIER_RAN (exit 2) &lt;-- changed&#10;success + one STALE passing inconclusive NO_VERIFIER_RAN (exit 2) &lt;-- changed&#10;CANCELLED by a newer push failing inconclusive NO_VERIFIER_RAN (exit 2) &lt;-- changed&#10;TIMED_OUT failing inconclusive NO_VERIFIER_RAN (exit 2) &lt;-- changed&#10;STARTUP_FAILURE passing failing FAIL (exit 1) &lt;-- changed&#10;empty check set none none NO_VERIFIER_RAN (exit 2)&#10;all SUCCESS passing passing PASS (exit 0)&#10;one FAILURE failing failing FAIL (exit 1)</code>

```text
ok - Domain Alpha structured state overrides a stale parent Phase 7 event
ok - GNU stat file reads select -c without BSD filesystem-report pollution
ok - parent activity evidence is bounded and disclosed
ok - Bearings excludes a status-only child decision
ok - a structured child captain hold reaches Captain's Call
ok - missing, invalid, unreadable, malformed, and timed-out homes stay explicit unknowns
ok - an oversized secondmate summary retains the strict empty unknown fallback
ok - secondmate and per-home child counts are bounded, disclosed, and explicitly expandable
ok - parent decisions remain untrusted contradiction evidence
ok - parent evidence reconciliation distinguishes matching holds, blocks, and decisions
ok - nonprogressing child states are explicit and inconsistent terminal rows invalidate
ok - registry unavailability and bounded truncation remain explicit
ok - repeated snapshots keep the same current landed baseline and ignore prior reports
ok - default output is bounded, local-only, and marks omitted surfaces
ok - TOON and JSON are parity representations of the same model
ok - landed includes secondmate-managed merges alongside main-home merges
ok - default landed selection balances one dominant home with sparse homes
ok - landed selection refills capacity after sparse homes exhaust
ok - landed selection uses deterministic home order when homes exceed the cap
ok - landed selection preserves deterministic home and internal tie ordering
ok - landed selection handles no landed items
ok - --all-landed keeps the complete global landed output
ok - landed stays bounded with per-home + overall caps and omitted[] disclosure
ok - Bearings keeps a live blocker in structured live state and never converts it to Charted Next queue work
ok - action-free items (working/done/queued/landed) do not leak into Captain's Call
ok - main orphan in-flight stays out of Underway and is disclosed in omitted/gates
ok - main unstructured current is disclosed while structured siblings still project
ok - counterfactual meta clears main inventory warning and projects the live task
ok - mixed secondmate roles, partial state, and captain readiness project independently
ok - main and secondmate captain actionability use the same blocker readiness
ok - a completed scout with decision-like report prose is a pointer, not pending
ok - an authoritative captain hold surfaces end-to-end
ok - current report pointers surface
ok - superseded queued items are dropped by default and restored with --all-queued
ok - --include-prs is the only path that fetches, and it enriches correctly
ok - a check set that completed without a verdict renders as inconclusive, not passing
ok - a partial GitHub failure degrades gracefully
ok - Perl fallback bounds stalled GitHub calls without coreutils timeout
ok - all fleet-sized sections are capped with counted opt-in expansion
ok - live PR enrichment caps repositories with counted expansion
ok - per-repository open-PR caps are disclosed with an expansion knob
=== CAPTAIN-FACING BEARINGS OUTPUT (bin/fm-bearings-snapshot.sh --include-prs) ===
The one open PR has exactly one check: COMPLETED, conclusion SKIPPED.
A check skipped by a path filter observed NOTHING about the pull request,
and zero failing checks looks exactly like every check passing.

--- the row the captain reads ---
[
  {
    "num": "9",
    "repo": "kunchenguid/firstmate",
    "task": "ship-task",
    "url": "https://github.com/kunchenguid/firstmate/pull/9",
    "review": "APPROVED",
    "mergeable": "MERGEABLE",
    "checks": "inconclusive"
  }
]

=== BEFORE / AFTER on the captain-facing "checks" label ===
BEFORE = the inline rule at base commit 2cf0283 (now retired)
AFTER  = the shared rule in bin/fm-verify-lib.sh, spliced into both consumers

PR check set                       BEFORE       AFTER          fm-verify.sh result
---------------------------------- ------------ -------------- -------------------
one SKIPPED check                  passing      inconclusive   NO_VERIFIER_RAN (exit 2)   <-- changed
one STALE check                    passing      inconclusive   NO_VERIFIER_RAN (exit 2)   <-- changed
one NEUTRAL check                  passing      inconclusive   NO_VERIFIER_RAN (exit 2)   <-- changed
COMPLETED, no conclusion           passing      inconclusive   NO_VERIFIER_RAN (exit 2)   <-- changed
success + one STALE                passing      inconclusive   NO_VERIFIER_RAN (exit 2)   <-- changed
CANCELLED by a newer push          failing      inconclusive   NO_VERIFIER_RAN (exit 2)   <-- changed
TIMED_OUT                          failing      inconclusive   NO_VERIFIER_RAN (exit 2)   <-- changed
STARTUP_FAILURE                    passing      failing        FAIL (exit 1)   <-- changed
empty check set                    none         none           NO_VERIFIER_RAN (exit 2)
all SUCCESS                        passing      passing        PASS (exit 0)
one FAILURE                        failing      failing        FAIL (exit 1)
```
</details>
<details>
<summary>Evidence: Exit-0 stress: 17 malformed/degraded invocations, none reached a pass terminal</summary>

<code>invocation result exit&#10;no arguments NO_VERIFIER_RAN/usage_error 2&#10;undeclared verifier NO_VERIFIER_RAN/verifier_undeclared 2&#10;declared name with trailing space NO_VERIFIER_RAN/verifier_undeclared 2&#10;unknown flag NO_VERIFIER_RAN/usage_error 2&#10;evidence path containing a comma NO_VERIFIER_RAN/usage_error 2&#10;evidence path in an unwritable dir NO_VERIFIER_RAN/no_evidence 2&#10;merge-clean, both refs unresolvable NO_VERIFIER_RAN/verification_unreachable 2&#10;merge-clean in a non-repo dir NO_VERIFIER_RAN/verification_unreachable 2&#10;browser open x (no tool on PATH) NO_VERIFIER_RAN/verifier_unavailable 2&#10;pr-checks ... (no tool on PATH) NO_VERIFIER_RAN/verifier_unavailable 2&#10;&#10;No row reached exit 0. PASS is reachable only through a real observed verdict.</code>

```text
=== STRESS: can any malformed / degraded invocation reach exit 0 (a pass terminal)? ===
Every row must be exit 2 (NO_VERIFIER_RAN). Exit 0 here would be the defect.

invocation                                                 result             exit
---------------------------------------------------------- ------------------ ----
no arguments                                               NO_VERIFIER_RAN/usage_error 2
undeclared verifier                                        NO_VERIFIER_RAN/verifier_undeclared 2
declared name with trailing space                          NO_VERIFIER_RAN/verifier_undeclared 2
uppercase verifier name                                    NO_VERIFIER_RAN/verifier_undeclared 2
unknown flag                                               NO_VERIFIER_RAN/usage_error 2
--evidence with no value                                   NO_VERIFIER_RAN/usage_error 2
evidence path containing a comma                           NO_VERIFIER_RAN/usage_error 2
evidence path in an unwritable dir                         NO_VERIFIER_RAN/no_evidence 2
browser with no subcommand                                 NO_VERIFIER_RAN/usage_error 2
pr-checks with no url                                      NO_VERIFIER_RAN/usage_error 2
pr-checks with too many args                               NO_VERIFIER_RAN/usage_error 2
merge-clean with one ref                                   NO_VERIFIER_RAN/usage_error 2
merge-clean with four args                                 NO_VERIFIER_RAN/usage_error 2
merge-clean, both refs unresolvable                        NO_VERIFIER_RAN/verification_unreachable 2
merge-clean in a non-repo dir                              NO_VERIFIER_RAN/verification_unreachable 2

--- and the tools genuinely absent (PATH stripped to a minimal set) ---
browser open x (no tool on PATH)                           NO_VERIFIER_RAN/verifier_unavailable 2
pr-checks https://x/y/pull/1 (no tool on PATH)             NO_VERIFIER_RAN/verifier_unavailable 2

No row reached exit 0. PASS is reachable only through a real observed verdict.
```
</details>
<details>
<summary>Evidence: Rendered crewmate brief - the Verification-discipline block a worker actually reads</summary>

<code># Verification discipline&#10;An observation has three values, never two: observed-good, observed-bad, and could-not-observe.&#10;The third is a real result, not a missing one.&#10;An empty result set, an unreadable file, an absent artifact, an unreachable tool, a silent verifier, and an exit code that covers both a failure and a refusal are all could-not-observe, and none of them is a pass.&#10;Never narrow one into the other two: an empty violations log, no output, and no failures found are never success on their own, and a missing expected artifact is could-not-observe at collection time rather than work still in progress.&#10;Run a verifier through `.../bin/fm-verify.sh` (`--help` lists the declared verifiers) and act on the `PASS` / `FAIL` / `NO_VERIFIER_RAN` result it returns, rather than interpreting a tool&#39;s exit status yourself.&#10;When the observation you need has no declared verifier, apply the same three-valued rule by hand ... report the undeclared verifier as a gap - never infer a pass from an exit status.&#10;Before trusting a success reported only by absence, run a negative control, watch that same check go red, and only then run the real check.&#10;&#10;--- retirement check --- occurrences of &#34;never process names&#34;: 0&#10;--- deliberately RETAINED: the negative-control instruction --- present at line 53</code>

```text
=== THE BRIEF A CREWMATE ACTUALLY READS (bin/fm-brief.sh, ship scaffold) ===

--- Rule 3, retired form -> wrapper call site ---
24:3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations. Most of that 
is action - opening a pull request, commenting, listing issues - and an action has no observation 
type; when you are instead making an OBSERVATION whose answer you will act on, run it through 
`/home/shane/.no-mistakes/worktrees/5f306883d81c/01KZBZTV5BJNF7R4DGN2MXZ93X/bin/fm-verify.sh` 
(`--list` names the declared verifiers) rather than reading the tool's exit status.

--- The new "Verification discipline" section ---
# Verification discipline
An observation has three values, never two: observed-good, observed-bad, and could-not-observe.
The third is a real result, not a missing one.
An empty result set, an unreadable file, an absent artifact, an unreachable tool, a silent 
verifier, and an exit code that covers both a failure and a refusal are all could-not-observe, and 
none of them is a pass.
Never narrow one into the other two: an empty violations log, no output, and no failures found are 
never success on their own, and a missing expected artifact is could-not-observe at collection time 
rather than work still in progress.
Run a verifier through 
`/home/shane/.no-mistakes/worktrees/5f306883d81c/01KZBZTV5BJNF7R4DGN2MXZ93X/bin/fm-verify.sh` 
(`--help` lists the declared verifiers) and act on the `PASS` / `FAIL` / `NO_VERIFIER_RAN` result 
it returns, rather than interpreting a tool's exit status yourself.
When the observation you need has no declared verifier, apply the same three-valued rule by hand: 
name which of the three values you reached and the evidence you reached it on, and report the 
undeclared verifier as a gap - never infer a pass from an exit status.
Before trusting a success reported only by absence, run a negative control, watch that same check 
go red, and only then run the real check.


--- retirement check: the replaced exhortation is absent ---
occurrences of "never process names": 0
--- deliberately RETAINED: the negative-control instruction ---
53:Before trusting a success reported only by absence, run a negative control, watch that same 
check go red, and only then run the real check.
```
</details>
<details>
<summary>Evidence: Full rendered ship brief (generated by bin/fm-brief.sh)</summary>

```text
You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.

# Task
{TASK}

# Herdr lifecycle declaration - NOT ENABLED
**HARD SAFETY GATE:** this scaffold cannot inspect the task text that replaces `{TASK}` later.
If the task will start, stop, delete, restart, profile, or otherwise drive Herdr lifecycle behavior, stop and regenerate the brief with `--herdr-lab` before dispatch.
Do not add Herdr lifecycle commands to this unguarded brief by hand.

# Setup
You are in a disposable git worktree of some-proj, at a detached HEAD on a clean default branch.

**Verify isolation before anything else.** Run `pwd -P` and `git rev-parse --show-toplevel`; both must resolve to the disposable task worktree you were launched in, such as a treehouse pool path or an Orca-managed worktree, not the primary checkout firstmate operates from.
The path check is authoritative: `git rev-parse --git-dir` and `git rev-parse --git-common-dir` can help inspect the repo, but they do not prove you are outside the primary checkout.
If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not branch or commit here - append `blocked: launched in primary checkout, not an isolated worktree` to the status file and stop.

1. First action: create your branch: `git checkout -b fm/evidence-ship-task`
2. Run `no-mistakes doctor`; if it reports the repo is not initialized here, run `no-mistakes init`.

# Rules
1. Never push to the default branch. Never merge a PR.
2. Stay inside this worktree; modify nothing outside it.
3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations. Most of that is action - opening a pull request, commenting, listing issues - and an action has no observation type; when you are instead making an OBSERVATION whose answer you will act on, run it through `/home/shane/.no-mistakes/worktrees/5f306883d81c/01KZBZTV5BJNF7R4DGN2MXZ93X/bin/fm-verify.sh` (`--list` names the declared verifiers) rather than reading the tool's exit status.
4. Report status by appending one line:
   `echo "{state}: {one short line}" >> '/tmp/tmp.3A73kQZO9G/state/evidence-ship-task.status'`
   States: working, needs-decision, blocked, paused, done, failed.
   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
   would act on (setup done, bug reproduced, fix implemented, validation passed) and the
   needs-decision/blocked/paused/done/failed states. No step-by-step FYI progress lines;
   firstmate reads your pane for that.
   A mid-task `working:` line (including setup complete) is nonterminal: do not end the
   turn after it; continue the same stage until a defined `done:` gate under Definition of done.
   Use `paused: {why}` - distinct from `blocked:` - ONLY when you are deliberately idling on a
   known external wait you expect to clear on its own (an upstream release, a rate-limit reset,
   a scheduled window): firstmate then leaves your idle pane alone and rechecks it on a long
   cadence instead of treating it as a possible wedge. Use `blocked:` when you are stuck and need help.
5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
6. If a decision belongs above the implementation worker (product choices, destructive actions, ask-user findings),
   append `needs-decision: {summary of options}` and stop. Firstmate will apply the configured authority and reply with the decision.
   When firstmate replies or a blocker clears and you resume, append `resolved: {how it was decided or unblocked}` (add the same `[key=<slug>]` if you opened it with one) so the decision or blocker is durably closed and does not keep resurfacing.
7. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving
   every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
   daemon error, append `blocked: {the daemon error}` and stop; only firstmate manages the daemon.

# Verification discipline
An observation has three values, never two: observed-good, observed-bad, and could-not-observe.
The third is a real result, not a missing one.
An empty result set, an unreadable file, an absent artifact, an unreachable tool, a silent verifier, and an exit code that covers both a failure and a refusal are all could-not-observe, and none of them is a pass.
Never narrow one into the other two: an empty violations log, no output, and no failures found are never success on their own, and a missing expected artifact is could-not-observe at collection time rather than work still in progress.
Run a verifier through `/home/shane/.no-mistakes/worktrees/5f306883d81c/01KZBZTV5BJNF7R4DGN2MXZ93X/bin/fm-verify.sh` (`--help` lists the declared verifiers) and act on the `PASS` / `FAIL` / `NO_VERIFIER_RAN` result it returns, rather than interpreting a tool's exit status yourself.
When the observation you need has no declared verifier, apply the same three-valued rule by hand: name which of the three values you reached and the evidence you reached it on, and report the undeclared verifier as a gap - never infer a pass from an exit status.
Before trusting a success reported only by absence, run a negative control, watch that same check go red, and only then run the real check.

# Project memory
If `AGENTS.md` or `CLAUDE.md` already exists, or if this task produced durable project-intrinsic knowledge, run `/home/shane/.no-mistakes/worktrees/5f306883d81c/01KZBZTV5BJNF7R4DGN2MXZ93X/bin/fm-ensure-agents-md.sh .` in the worktree.
Record only project knowledge useful to almost every future session.
For anything the codebase already shows, prefer a pointer to the authoritative file, command, or doc over copying the detail.
If you touch a project `AGENTS.md` that lacks `## Maintaining this file`, add that short self-governance section from `/home/shane/.no-mistakes/worktrees/5f306883d81c/01KZBZTV5BJNF7R4DGN2MXZ93X/bin/fm-ensure-agents-md.sh` in the same pass.
Keep it proportionate: skip `AGENTS.md` edits for trivial tasks that produced no durable project knowledge.

# Definition of done
Delivery contract: mode=no-mistakes
The task is complete only when committed on your branch.
When you believe it is complete, append `done: {summary}` to the status file and stop.
Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.

You drive no-mistakes by responding to its gates, not by implementing fixes.
Follow the guidance no-mistakes itself provides for the mechanics: it loads when you invoke /no-mistakes, and `no-mistakes axi run --help` plus the `help` lines in each `axi` response are authoritative and version-matched to the installed binary.
When starting no-mistakes, make `--intent` preserve all relevant content from this brief's `# Task` section plus every later accepted Firstmate requirement, clarification, constraint, exclusion, and supersession, carrying only each requirement's current accepted form; retain direct requirements instead of substituting a diff summary, and exclude generic operational, status, delivery, and other scaffold boilerplate unless it is task-specific.
Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix.

Two firstmate-specific rules layer on top of that guidance:
- ask-user findings are never yours to answer: escalate to firstmate (rule 6) and stop.
  Firstmate applies the authority contract in its `AGENTS.md` and obtains any required captain decision.
  When the decision comes back, feed it to the gate with `no-mistakes axi respond` and let the pipeline apply it - do not route the question to "the user" or implement the fix yourself.
- Avoid `--yes`: it would silently bypass firstmate's authority check and any required captain escalation.

After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append `done: PR {url} checks green` and stop. You are finished.
```
</details>
<details>
<summary>Evidence: Captured evidence file from the live browser run (proves the record points at what was observed)</summary>

<code>fm-verify evidence&#10;verifier: browser&#10;command: chrome-devtools-axi snapshot&#10;exit_status: 0&#10;--- stdout ---&#10;page:&#10;refs: 0&#10;snapshot:&#10;Protocol error (Target.setDiscoverTargets): Target closed&#10;Cause:&#10;--- stderr ---</code>

```text
fm-verify evidence
verifier: browser
command: chrome-devtools-axi snapshot
exit_status: 0
--- stdout ---
page:
  refs: 0
snapshot:
Protocol error (Target.setDiscoverTargets): Target closed
Cause:
help[1]:
  Use `chrome-devtools-axi eval <expr>` for JS expressions. For multi-statement code, pass a function: `eval "() => { ...; return result }"`
--- stderr ---
```
</details>
<details>
<summary>Evidence: Worker discovery surface: fm-verify.sh --list and --help</summary>

```text
=== the worker-facing discovery surface the brief points at ===
$ bin/fm-verify.sh --list
  browser
  pr-checks
  merge-clean
exit: 0

$ bin/fm-verify.sh --help  (first 40 lines)
  fm-verify.sh - run a declared verifier and return a three-valued result, so
  that no verifier's silence, error, or absent result can be read as a pass.
  
  Exit status alone cannot carry a verification result, because it cannot
  distinguish "the verifier ran and reached a verdict" from "the verifier never
  reached one". Three real instances in this fleet:
    - an empty GitHub check-run set read as green, because zero failing checks
      looks exactly like all checks passing;
    - chrome-devtools-axi printing "Protocol error (Target.setDiscoverTargets):
      Target closed" and exiting 0, so a caller branching on exit status
      concludes the page is fine;
    - git merge-tree exiting 1 both for a real conflict and for a ref it cannot
      resolve, so one exit status covers a verdict and a non-verdict.
  
  Usage:
    fm-verify.sh [--evidence <path>] <verifier> [args...]
    fm-verify.sh --list
    fm-verify.sh -h | --help
  
  Options:
    --evidence <path>  write the verifier's captured output here instead of a
                       generated temporary file. The path must contain no comma
                       and no newline, because it is a field of the emitted
                       record.
  
  Declared verifiers (the registry is closed; an undeclared name is refused
  rather than run, because a name this script cannot interpret is a name whose
  output it cannot judge):
    browser <subcommand> [args...]
        Runs chrome-devtools-axi with the given arguments. This adapter never
        returns FAIL, and that is deliberate rather than an omission:
        chrome-devtools-axi is a control tool, not an assertion tool, so it has
        no way to report "the page is bad" - only "here is what I saw" or a
        failure to see it. The verdict on what it saw belongs to the caller.
    pr-checks <pr-url>
        Reads the pull request's check-run set through gh and classifies it with
        bin/fm-verify-lib.sh.
    merge-clean <base-ref> <head-ref> [repo-dir]
        Runs git merge-tree --write-tree in <repo-dir> (default: the current
        directory).
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 6 issues found → auto-fixed (2) ✅</summary>

- ⚠️ `bin/fm-verify-lib.sh:60` - The shared rollup rule&#39;s `else &#34;passing&#34;` branch only excludes explicitly-failing and not-yet-COMPLETED checks, so any COMPLETED check whose conclusion is not SUCCESS falls through to `passing`. Verified directly: `{&#34;status&#34;:&#34;COMPLETED&#34;,&#34;conclusion&#34;:&#34;SKIPPED&#34;}`, `&#34;STALE&#34;`, `&#34;NEUTRAL&#34;`, and `null` all evaluate to `passing`. A pull request whose checks were all skipped by path filters, or whose runs went stale, therefore makes `fm-verify.sh pr-checks` return PASS/exit 0 — the same &#39;absence reads as green&#39; defect as the empty set, one level down, inside the rule that now owns the PASS verdict. The header at line 42 documents this label as &#39;the set is non-empty and every member completed successfully&#39;, which the implementation does not enforce. Note this also changes the user-visible `checks` label in bearings, so the fix is a product decision, not a mechanical one.
- ⚠️ `bin/fm-verify.sh:254` - When chrome-devtools-axi exits non-zero with a message that matches no signature in BROWSER_UNREACHABLE_SIGNATURES, the browser adapter sets FAIL/verifier_reported_failure — a verdict about the page. That is exit-code narrowing, the conversion this change exists to remove, and it is the opposite of what verify_pr_checks does at line 284 for the structurally identical condition (&#39;An unreachable forge is not a failing pull request. Reporting FAIL here would be a verdict this script never earned.&#39;). chrome-devtools-axi is a control tool, not an assertion tool, so a non-zero exit for an unlisted reason (chrome crash, page-load timeout, DNS failure) is far more often could-not-observe than page-is-bad. It is fail-closed, so it cannot produce a false PASS, but it borrows FAIL for a could-not-observe condition, which the acceptance criteria explicitly require a control against (&#39;each of the three values produced for its own condition and never borrowing another&#39;s&#39;). The branch has no fixture at all: the suite&#39;s three browser stubs all exit 0.
- ⚠️ `bin/fm-verify-lib.sh:88` - fm_verify_parse&#39;s header (lines 66-67) promises it &#39;leaves no partially-populated fields behind&#39;, but the two late failure paths return 1 with FM_VERIFY_VERIFIER/RESULT/REASON/EVIDENCE already assigned from the malformed record. A record of `  browser,PASS,,` (empty reason) returns 1 while leaving FM_VERIFY_RESULT=PASS set, so a consumer that reads the globals without checking the status sees a PASS extracted from a record the library just rejected — precisely the &#39;unparseable record treated as an empty PASS&#39; the comment says is prevented. Re-clear the four globals before each `return 1`, or parse into locals and publish only on success.
- ⚠️ `bin/fm-test-run.sh:911` - bin/fm-verify-lib.sh gets no explicit case in families_for_changed_path, so it falls through to the `bin/*` reference scan, which greps the test files for the basename. Only tests/fm-verify.test.sh names it, so a change to FM_VERIFY_CHECK_ROLLUP_EXPR selects pure-contract-unit and never snapshot-bearings — even though bin/fm-bearings-snapshot.sh splices that exact expression and tests/fm-bearings-snapshot.test.sh:979 asserts on its output. That silently under-selects, against the map&#39;s stated &#39;Over-selects rather than under-selects&#39; policy. bin/fm-timeout-lib.sh has an explicit multi-family entry here for exactly this reason; add the analogous entry listing pure-contract-unit and snapshot-bearings.
- ⚠️ `bin/fm-brief.sh:333` - Rule 3 in both scaffolds (also line 447) now reads &#39;Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations, and run either through bin/fm-verify.sh whenever its answer is evidence you will act on.&#39; The wrapper never invokes gh-axi at all (pr-checks shells out to `gh`), and its closed registry refuses every name outside browser/pr-checks/merge-clean with verifier_undeclared. A worker following rule 3 for any GitHub operation other than reading a PR&#39;s check set — or any browser question the three verifiers don&#39;t cover — gets NO_VERIFIER_RAN, which the verification-discipline block just told them is a real could-not-observe result, while that same block&#39;s blanket &#39;rather than interpreting a tool&#39;s exit status yourself&#39; leaves no sanctioned alternative. Every brief in the fleet carries this text, so the wording should either scope rule 3 to the declared verifiers or state what a worker does when the operation is undeclared.
- ℹ️ `bin/fm-verify.sh:240` - The same four-line `command -v &lt;tool&gt; &gt;/dev/null 2&gt;&amp;1 || { set_result NO_VERIFIER_RAN verifier_unavailable; return 0; }` block is repeated four times (chrome-devtools-axi at 240, gh at 270, jq at 274, git at 308). A single `require_tool &lt;name&gt; || return 0` helper next to run_verifier would collapse them without changing behavior, and would keep a future adapter from getting the reason token wrong.

🔧 Fix: give unconcluded checks their own label and stop FAIL borrowing
1 warning still open:
- ⚠️ `bin/fm-verify-lib.sh:69` - The new `inconclusive` label makes the failing-conclusion list load-bearing, but that list was carried over unchanged and now misplaces members in both directions. Verified against the rule as written: `STARTUP_FAILURE` — a real CheckConclusionState, emitted when a workflow fails to start, i.e. exactly the &#39;workflow file is broken&#39; case this file&#39;s own header cites — falls through to `inconclusive`, so a genuinely failed check reports NO_VERIFIER_RAN/no_verdict_reached and reads as &#39;wait or re-run&#39; instead of &#39;this failed&#39;. In the other direction `CANCELLED` and `TIMED_OUT` are listed as failing, so a run cancelled by a superseding push reports FAIL/verifier_reported_failure — a verdict about the pull request that nothing earned, which is the same borrow just corrected in verify_browser (&#39;calling this FAIL would assert a verdict the evidence never earned and would hide a broken verifier among real failures&#39;). Neither direction can produce a false PASS, so this is fail-closed and a follow-up: move STARTUP_FAILURE into the failing list, and decide whether CANCELLED/TIMED_OUT belong in `inconclusive` now that a label exists for &#39;completed without earning a verdict&#39;. Both are also user-visible bearings labels, so the membership call is the author&#39;s.

🔧 Fix: repartition check conclusions between failing and inconclusive
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bin/fm-test-run.sh tests/fm-verify.test.sh` - 44 assertions green, covering all three dated fixtures, the conclusion partition one conclusion at a time, the consumer contract, coercion, and the conformance obligation</code>
- <code>`bin/fm-test-run.sh tests/fm-brief.test.sh` - green, including the new `test_verification_discipline_is_the_type_rule`</code>
- <code>`bin/fm-test-run.sh tests/fm-bearings-snapshot.test.sh` - green, including the new `test_unconcluded_checks_are_not_rendered_as_passing`</code>
- <code>`bin/fm-test-run.sh tests/fm-documentation-audiences.test.sh` - green (selected because AGENTS.md changed)</code>
- <code>LIVE instance 1: `chrome-devtools-axi snapshot` with no session reproduced `Protocol error (Target.setDiscoverTargets): Target closed` at exit 0, then `bin/fm-verify.sh browser snapshot` -&gt; NO_VERIFIER_RAN/verification_unreachable, exit 2</code>
- <code>LIVE instance 2: `bin/fm-verify.sh pr-checks https://github.com/kunchenguid/firstmate/pull/1825` and `/1826` -&gt; NO_VERIFIER_RAN/empty_result_set; confirmed real via `gh pr checks 1825` (&#34;no checks reported&#34;) and non-empty rollup on #1794 (13 checks) to rule out an auth artifact</code>
- <code>Instance 3: `git merge-tree --write-tree main conflicting` and `... main nosuchref` both exit 1; `bin/fm-verify.sh merge-clean` separates them into FAIL (exit 1) and NO_VERIFIER_RAN (exit 2), with `merge-clean main clean` still PASS (exit 0)</code>
- `Nine negative controls witnessed RED by mutating the implementation and re-running the suite: browser transport check removed; empty check set mapped to PASS; merge-tree tree-object check bypassed; handler aliasing permitted; third handler defaulted to on_fail; fourth verifier added without a control; coercion made silent; verification block removed from briefs; retired exhortation re-added beside the type rule`
- <code>Consumer contract exercised directly: `fm_verify_case` with three handlers routes NO_VERIFIER_RAN to its own branch; two-handler and pass-aliased consumers both refused at status 3; `fm_verify_coerce` logs and prints to stderr, and refuses a missing reason or an already-observed result</code>
- `Exit-0 stress: 17 malformed/degraded invocations (undeclared name, bad flags, comma in evidence path, unwritable evidence dir, arity errors, unresolvable refs, non-repo dir, tools stripped from PATH) - every one landed on exit 2, none reached a pass terminal`
- <code>Rendered a real ship brief via `FM_HOME=... bin/fm-brief.sh &lt;id&gt; &lt;proj&gt; --mode no-mistakes` and inspected the Verification-discipline section, rule 3 wrapper call site, retained negative-control line, and absence of the retired exhortation</code>
- <code>Rendered the captain-facing Bearings row via the suite&#39;s own fixture harness with `FAKE_GH_SKIPPED=1 --include-prs --json` -&gt; `&#34;checks&#34;: &#34;inconclusive&#34;`, plus a before/after table applying the retired base-commit inline rule and the new shared rule to 11 realistic check payloads</code>
- <code>Retirement audit: `grep` confirms one copy of the check-set rule (bin/fm-verify-lib.sh), no `if fm-verify.sh` two-branch consumer, and &#34;never process names&#34; present only in the test asserting its absence</code>
- <code>`bin/fm-test-run.sh --check-coverage` (FM_TEST_COVERAGE ok total=128), `--list --lane portable-serial` confirms fm-verify.test.sh placement, and `--list --changed --base 2cf0283` selects exactly the three suites run</code>

</details>

<details>
<summary>⚠️ **Document** - 1 info</summary>

- ℹ️ `docs/scripts.md:8` - Out-of-scope follow-up, not caused by this change: the bin/ toolbelt table has drifted from bin/ and is missing 24 other scripts (fm-lint.sh, fm-doc-audience-check.sh, fm-procevent.sh, fm-transition-lib.sh, fm-trace-context-lib.sh, the fm-remote-* and fm-secondmate-*-lib.sh families, fm-startup-memory-budget*.sh, and others), and nothing checks the table against the directory it inventories. I added rows only for this change&#39;s two new scripts. A worthwhile follow-up is one pass reconciling the table with bin/*.sh plus a coverage assertion in bin/fm-doc-audience-check.sh, so the operator-current toolbelt owner cannot silently fall behind again.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
