### PR TITLE
fix: Windows ARM64 (Git Bash/MSYS) compatibility for locks, hooks, and the herdr backend

### DIFF
--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash -lc 'payload=$(cat 2>/dev/null || true); [ -n \"$payload\" ] || exit 0; command -v jq >/dev/null 2>&1 || exit 0; root=$(pwd -P) || exit 0; [ -x \"$root/bin/fm-sessionstart-run.sh\" ] || exit 0; [ -f \"$root/AGENTS.md\" ] || exit 0; [ -f \"$root/.codex/hooks.json\" ] || exit 0; jq -e \"any(.hooks.SessionStart[]?.hooks[]?.command?; type == \\\"string\\\" and contains(\\\"fm-sessionstart-run.sh\\\"))\" \"$root/.codex/hooks.json\" >/dev/null 2>&1 || exit 0; printf \"%s\" \"$payload\" | \"$root/bin/fm-sessionstart-run.sh\"'",
+            "command": "node bin/fm-codex-hook.mjs fm-sessionstart-run.sh",
             "timeout": 180
           }
         ]
@@ -17,12 +17,12 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash -lc 'payload=$(cat 2>/dev/null || true); [ -n \"$payload\" ] || exit 0; command -v jq >/dev/null 2>&1 || exit 0; root=$(pwd -P) || exit 0; [ -x \"$root/bin/fm-arm-pretool-check.sh\" ] || exit 0; [ -f \"$root/AGENTS.md\" ] || exit 0; [ -f \"$root/.codex/hooks.json\" ] || exit 0; jq -e \"any(.hooks.PreToolUse[]?.hooks[]?.command?; type == \\\"string\\\" and contains(\\\"fm-arm-pretool-check.sh\\\"))\" \"$root/.codex/hooks.json\" >/dev/null 2>&1 || exit 0; printf \"%s\" \"$payload\" | \"$root/bin/fm-arm-pretool-check.sh\"'",
+            "command": "node bin/fm-codex-hook.mjs fm-arm-pretool-check.sh",
             "timeout": 10
           },
           {
             "type": "command",
-            "command": "bash -lc 'payload=$(cat 2>/dev/null || true); [ -n \"$payload\" ] || exit 0; command -v jq >/dev/null 2>&1 || exit 0; root=$(pwd -P) || exit 0; [ -x \"$root/bin/fm-cd-pretool-check.sh\" ] || exit 0; [ -f \"$root/AGENTS.md\" ] || exit 0; [ -f \"$root/.codex/hooks.json\" ] || exit 0; jq -e \"any(.hooks.PreToolUse[]?.hooks[]?.command?; type == \\\"string\\\" and contains(\\\"fm-cd-pretool-check.sh\\\"))\" \"$root/.codex/hooks.json\" >/dev/null 2>&1 || exit 0; printf \"%s\" \"$payload\" | \"$root/bin/fm-cd-pretool-check.sh\"'",
+            "command": "node bin/fm-codex-hook.mjs fm-cd-pretool-check.sh",
             "timeout": 10
           }
         ]
@@ -33,7 +33,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash -lc 'payload=$(cat 2>/dev/null || true); [ -n \"$payload\" ] || exit 0; command -v jq >/dev/null 2>&1 || exit 0; root=$(pwd -P) || exit 0; [ -x \"$root/bin/fm-turnend-guard.sh\" ] || exit 0; [ -f \"$root/AGENTS.md\" ] || exit 0; [ -f \"$root/.codex/hooks.json\" ] || exit 0; jq -e \"any(.hooks.Stop[]?.hooks[]?.command?; type == \\\"string\\\" and contains(\\\"fm-turnend-guard.sh\\\"))\" \"$root/.codex/hooks.json\" >/dev/null 2>&1 || exit 0; printf \"%s\" \"$payload\" | \"$root/bin/fm-turnend-guard.sh\"'",
+            "command": "node bin/fm-codex-hook.mjs fm-turnend-guard.sh",
             "timeout": 30
           }
         ]

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+* text=auto
+*.sh text eol=lf
+*.bash text eol=lf
+*.json text eol=lf
+*.js text eol=lf
+*.ts text eol=lf
+*.yml text eol=lf
+*.yaml text eol=lf
+*.md text eol=lf

--- a/.pi/extensions/fm-primary-pi-watch.ts
+++ b/.pi/extensions/fm-primary-pi-watch.ts
@@ -110,8 +110,17 @@ function positiveInteger(name: string, fallback: number): number {
   return Math.floor(value);
 }
 
+// Windows has no ps; route ancestry lookups through CIM there, keeping ps on
+// every other platform.
 function parentPid(pid: string): string {
-  const result = spawnSync("ps", ["-o", "ppid=", "-p", pid], { encoding: "utf8" });
+  if (!/^[0-9]+$/.test(pid)) return "";
+  const result = process.platform === "win32"
+    ? spawnSync(
+        "powershell",
+        ["-NoProfile", "-Command", `(Get-CimInstance Win32_Process -Filter "ProcessId=${pid}").ParentProcessId`],
+        { encoding: "utf8" },
+      )
+    : spawnSync("ps", ["-o", "ppid=", "-p", pid], { encoding: "utf8" });
   if (result.status !== 0) return "";
   return result.stdout.trim();
 }

--- a/.pi/extensions/fm-primary-turnend-guard.ts
+++ b/.pi/extensions/fm-primary-turnend-guard.ts
@@ -21,8 +21,25 @@ const state = process.env.FM_STATE_OVERRIDE || `${fmHome}/state`;
 const marker = `${state}/.pi-turnend-extension-loaded`;
 const extensionVersion = `sha256:${createHash("sha256").update(readFileSync(extensionFile)).digest("hex")}`;
 
+// Windows cannot exec a .sh directly (spawn EFTYPE) and has no ps; route
+// scripts through Git Bash and ancestry lookups through CIM there, keeping
+// the direct exec on every other platform.
+const isWindows = process.platform === "win32";
+
+function spawnShellScript(script: string, args: string[], options: Parameters<typeof spawn>[2]) {
+  if (isWindows) return spawn("bash", [script.replace(/\\/g, "/"), ...args], options);
+  return spawn(script, args, options);
+}
+
 function parentPid(pid: string): string {
-  const result = spawnSync("ps", ["-o", "ppid=", "-p", pid], { encoding: "utf8" });
+  if (!/^[0-9]+$/.test(pid)) return "";
+  const result = isWindows
+    ? spawnSync(
+        "powershell",
+        ["-NoProfile", "-Command", `(Get-CimInstance Win32_Process -Filter "ProcessId=${pid}").ParentProcessId`],
+        { encoding: "utf8" },
+      )
+    : spawnSync("ps", ["-o", "ppid=", "-p", pid], { encoding: "utf8" });
   if (result.status !== 0) return "";
   return result.stdout.trim();
 }
@@ -71,7 +88,7 @@ const sessionstartTruncatedMarker =
 
 function runSessionstartHook(source: string): Promise<string> {
   return new Promise((resolveResult) => {
-    const child = spawn(`${root}/bin/fm-sessionstart-run.sh`, ["--source", source], {
+    const child = spawnShellScript(`${root}/bin/fm-sessionstart-run.sh`, ["--source", source], {
       stdio: ["ignore", "pipe", "ignore"],
     });
     const chunks: Buffer[] = [];
@@ -124,7 +141,7 @@ async function injectSessionstart(pi: ExtensionAPI, source: string): Promise<voi
 
 function runGuard(): Promise<{ code: number; stderr: string }> {
   return new Promise((resolveResult) => {
-    const child = spawn(`${root}/bin/fm-turnend-guard.sh`, {
+    const child = spawnShellScript(`${root}/bin/fm-turnend-guard.sh`, [], {
       stdio: ["pipe", "ignore", "pipe"],
     });
     let stderr = "";
@@ -146,7 +163,7 @@ function runGuard(): Promise<{ code: number; stderr: string }> {
 // script owns its own decision and is inert outside the real primary checkout.
 function runChecker(script: string, command: string): Promise<{ code: number; stderr: string }> {
   return new Promise((resolveResult) => {
-    const child = spawn(`${root}/bin/${script}`, ["--command", command], {
+    const child = spawnShellScript(`${root}/bin/${script}`, ["--command", command], {
       stdio: ["ignore", "ignore", "pipe"],
     });
     let stderr = "";

--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -701,6 +701,16 @@ fm_backend_herdr_canonical_socket_path() {  # <socket-path>
   [ -n "$socket" ] || return 1
   case "$socket" in
     /*) ;;
+    [A-Za-z]:[\\/]*)
+      # Herdr on Windows injects and reports native drive paths
+      # (C:\...\herdr.sock); fold them into the same POSIX form so both sides
+      # of every socket-identity comparison canonicalize identically.
+      socket=$(cygpath -u "$socket" 2>/dev/null) || return 1
+      case "$socket" in
+        /*) ;;
+        *) return 1 ;;
+      esac
+      ;;
     *) return 1 ;;
   esac
   sock_dir=$(dirname "$socket")

--- a/bin/fm-codex-hook.mjs
+++ b/bin/fm-codex-hook.mjs
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+import { existsSync, readFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const allowed = new Set([
+  "fm-sessionstart-run.sh",
+  "fm-arm-pretool-check.sh",
+  "fm-cd-pretool-check.sh",
+  "fm-turnend-guard.sh",
+]);
+
+const script = process.argv[2] || "";
+if (!allowed.has(script)) process.exit(0);
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const hooksPath = join(root, ".codex", "hooks.json");
+const target = join(root, "bin", script);
+if (!existsSync(join(root, "AGENTS.md")) || !existsSync(hooksPath) || !existsSync(target)) {
+  process.exit(0);
+}
+
+try {
+  const hooks = JSON.parse(readFileSync(hooksPath, "utf8"));
+  if (!JSON.stringify(hooks).includes(script)) process.exit(0);
+} catch {
+  process.exit(0);
+}
+
+const chunks = [];
+for await (const chunk of process.stdin) chunks.push(chunk);
+const payload = Buffer.concat(chunks);
+if (payload.length === 0) process.exit(0);
+
+const candidates = process.platform === "win32"
+  ? [
+      process.env.ProgramFiles && join(process.env.ProgramFiles, "Git", "bin", "bash.exe"),
+      process.env.LOCALAPPDATA && join(process.env.LOCALAPPDATA, "Programs", "Git", "bin", "bash.exe"),
+      "bash.exe",
+    ].filter(Boolean)
+  : ["bash"];
+
+for (const bash of candidates) {
+  const result = spawnSync(bash, [target], {
+    cwd: root,
+    input: payload,
+    encoding: null,
+    windowsHide: true,
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+  if (result.error?.code === "ENOENT") continue;
+  if (result.stdout?.length) process.stdout.write(result.stdout);
+  if (result.stderr?.length) process.stderr.write(result.stderr);
+  process.exit(Number.isInteger(result.status) ? result.status : 0);
+}
+
+// Hook transports are safety belts, not availability dependencies. If no
+// verified Bash runtime is reachable, fail open instead of blocking every tool.
+process.exit(0);

--- a/bin/fm-session-lock-lib.sh
+++ b/bin/fm-session-lock-lib.sh
@@ -74,6 +74,94 @@ fm_harness_process_matches() {  # <comm> <args>
   return 1
 }
 
+# --- Windows (Git Bash / MSYS) ancestry -------------------------------------
+# Git Bash's ps supports no -o format (exits 1) and cannot see native Windows
+# processes at all: a shell spawned by claude.exe reports PPID 1, so the POSIX
+# walk below can never reach the harness. On Windows the real process tree is
+# walked through PowerShell/CIM instead, starting from this shell's WINPID.
+# The session lock therefore stores Windows pids on this platform, and holder
+# liveness goes through CIM as well (kill -0 does not accept Windows pids).
+
+fm_session_lock_on_windows() {
+  case "$(uname -s)" in
+    MINGW*|MSYS*|CYGWIN*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# Print "pid|name|commandline" for each Windows ancestor of this shell,
+# innermost first, up to 16 MSYS hops plus 16 native hops, in one PowerShell
+# invocation.
+#
+# The walk is hybrid because MSYS fork emulation severs the native parent
+# chain: a bash forked by another bash records a transient stub as its Windows
+# parent, dead by the time anyone looks, so a pure CIM walk from this shell
+# stops one hop up. The MSYS pid table (ps PID/PPID/WINPID columns, stable
+# positions before the variable-width STIME) bridges exactly those gaps: climb
+# it to the MSYS root, collect every ancestor's WINPID, then resolve them all
+# through CIM and continue up the native chain from the root - whose Windows
+# parent (the harness that CreateProcess'd it) really is alive.
+#
+# The PowerShell script is fed on stdin as a single line because PowerShell's
+# stdin command mode silently drops multi-line blocks. CommandLine newlines
+# are flattened so each ancestor stays one parseable line; only the first two
+# | are separators, a command line containing | lands intact in the args field.
+fm_win_ancestry_chain() {
+  local table pid=$$ row ppid winpid winpids='' guard=0
+  table=$(ps 2>/dev/null) || return 1
+  while [ "$guard" -lt 16 ]; do
+    guard=$((guard + 1))
+    row=$(printf '%s\n' "$table" | awk -v p="$pid" '$1==p {print $2" "$4; exit}')
+    [ -n "$row" ] || break
+    ppid=${row% *}
+    winpid=${row#* }
+    case "$winpid" in ''|*[!0-9]*) break ;; esac
+    winpids="$winpids,$winpid"
+    case "$ppid" in ''|*[!0-9]*) break ;; esac
+    [ "$ppid" -gt 1 ] || break
+    pid=$ppid
+  done
+  winpids=${winpids#,}
+  [ -n "$winpids" ] || return 1
+  FM_WIN_WALK_PIDS=$winpids powershell.exe -NoProfile -NonInteractive -Command - <<'PSEOF' 2>/dev/null | tr -d '\r'
+$ErrorActionPreference='SilentlyContinue'; $last=$null; foreach($q in ($env:FM_WIN_WALK_PIDS -split ',')){ $proc=Get-CimInstance Win32_Process -Filter "ProcessId=$([int]$q)"; if($proc){ Write-Output ("{0}|{1}|{2}" -f $proc.ProcessId,$proc.Name,($proc.CommandLine -replace "[\r\n]+"," ")); $last=$proc } }; if($last){ $p=$last.ParentProcessId; for($i=0; $i -lt 16 -and $p -gt 4; $i++){ $proc=Get-CimInstance Win32_Process -Filter "ProcessId=$p"; if(-not $proc){break}; Write-Output ("{0}|{1}|{2}" -f $proc.ProcessId,$proc.Name,($proc.CommandLine -replace "[\r\n]+"," ")); $p=$proc.ParentProcessId } }
+PSEOF
+}
+
+# Windows variant of fm_harness_ancestry_pids: identical contiguity contract
+# and fm_harness_process_matches evidence, applied to the CIM chain.
+fm_win_harness_ancestry_pids() {
+  local chain pid name args extending=0 printed=0
+  chain=$(fm_win_ancestry_chain) || return 1
+  [ -n "$chain" ] || return 1
+  while IFS='|' read -r pid name args; do
+    case "$pid" in ''|*[!0-9]*) continue ;; esac
+    if fm_harness_process_matches "$name" "$args"; then
+      printf '%s\n' "$pid"
+      printed=1
+      [ "$FM_HARNESS_IS_CLAUDE" -eq 1 ] || break
+      extending=1
+    elif [ "$extending" -eq 1 ]; then
+      break
+    fi
+  done <<EOF
+$chain
+EOF
+  [ "$printed" -eq 1 ]
+}
+
+# Print "name|commandline" for live Windows pid $1, or fail when it is gone.
+fm_win_process_info() {
+  local pid=$1 info
+  case "$pid" in ''|*[!0-9]*) return 1 ;; esac
+  info=$(FM_WIN_QUERY_PID=$pid powershell.exe -NoProfile -NonInteractive -Command - <<'PSEOF' 2>/dev/null | tr -d '\r'
+$ErrorActionPreference='SilentlyContinue'; $proc=Get-CimInstance Win32_Process -Filter "ProcessId=$([int]$env:FM_WIN_QUERY_PID)"; if($proc){ Write-Output ("{0}|{1}" -f $proc.Name,($proc.CommandLine -replace "[\r\n]+"," ")) }
+PSEOF
+)
+  [ -n "$info" ] || return 1
+  printf '%s\n' "$info"
+}
+
 # Walk the current process ancestry (up to 16 hops) and print this session's
 # contiguous verified-harness ancestry, innermost pid first.
 #
@@ -93,6 +181,10 @@ fm_harness_process_matches() {  # <comm> <args>
 # session cannot be read off the ancestry at all, so the whole contiguous run is
 # reported and the callers below decide what they need from it.
 fm_harness_ancestry_pids() {
+  if fm_session_lock_on_windows; then
+    fm_win_harness_ancestry_pids
+    return
+  fi
   local pid=$$ comm args extending=0 printed=0
   for _ in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16; do
     comm=$(ps -o comm= -p "$pid" 2>/dev/null) || break
@@ -132,6 +224,14 @@ EOF
 # True if $1 is a live process that looks like a verified harness.
 fm_harness_pid_alive() {
   local pid=$1 comm args
+  if fm_session_lock_on_windows; then
+    local info
+    info=$(fm_win_process_info "$pid") || return 1
+    comm=${info%%|*}
+    args=${info#*|}
+    fm_harness_process_matches "$comm" "$args"
+    return
+  fi
   kill -0 "$pid" 2>/dev/null || return 1
   comm=$(ps -o comm= -p "$pid" 2>/dev/null) || return 1
   args=$(ps -o args= -p "$pid" 2>/dev/null)

--- a/bin/fm-wake-lib.sh
+++ b/bin/fm-wake-lib.sh
@@ -13,6 +13,17 @@ FM_LOCK_STALE_AFTER="${FM_LOCK_STALE_AFTER:-2}"
 # confirm and 0.5s attach polls, and forking uname per call is a measurable cost on
 # the platform (Git Bash/MSYS) that already pays the highest fork price.
 _FM_UNAME=$(uname 2>/dev/null || echo unknown)
+# Git for Windows emulates directory symlinks by copying the directory unless
+# winsymlinks is enabled for the child `ln` process. Lock publication relies on
+# `ln -s` plus `readlink` being an atomic owner pointer, so the copy emulation
+# otherwise leaves a plain directory behind and every waiter spins forever.
+case "$_FM_UNAME:${MSYS:-}" in
+  MSYS*:*winsymlinks:*|MINGW*:*winsymlinks:*|CYGWIN*:*winsymlinks:*) ;;
+  MSYS*:*|MINGW*:*|CYGWIN*:*)
+    MSYS="${MSYS:+$MSYS }winsymlinks:nativestrict"
+    export MSYS
+    ;;
+esac
 mkdir -p "$STATE"
 
 fm_current_pid() {
@@ -275,6 +286,7 @@ fm_lock_remove_stray_owner_link() {
 
 fm_lock_claim_blocked_by_steal() {
   local lockdir=$1 allowed_steal_owner=${2:-} steal
+  [ "$allowed_steal_owner" != __fm_no_steal_guard__ ] || return 1
   steal="$lockdir.steal"
   [ -e "$steal" ] || [ -L "$steal" ] || return 1
   if [ -n "$allowed_steal_owner" ] && fm_lock_points_to_owner "$steal" "$allowed_steal_owner"; then
@@ -354,6 +366,15 @@ fm_lock_mid_acquire_is_fresh() {
     ''|*[!0-9]*)
       mid_acquire_stale=$FM_LOCK_STALE_AFTER
       [ "$mid_acquire_stale" -lt 2 ] && mid_acquire_stale=2
+      case "$_FM_UNAME" in
+        MSYS*|MINGW*|CYGWIN*)
+          # Git Bash process startup alone takes 1-3s and one acquire under
+          # contention exceeds 10s on ARM Windows, so a 2s floor lets a live
+          # mid-acquire peer be robbed of its lock. A longer floor only delays
+          # takeover of a crashed mid-acquire, which is rare and benign.
+          [ "$mid_acquire_stale" -lt 10 ] && mid_acquire_stale=10
+          ;;
+      esac
       [ "$(fm_path_age "$lockdir")" -lt "$mid_acquire_stale" ]
       return
       ;;
@@ -379,6 +400,44 @@ fm_lock_recheck_stale_owner() {
   return 0
 }
 
+# Acquire the one steal mutex used to replace a stale primary lock. Recover a
+# stale steal mutex by atomically moving that exact path aside instead of calling
+# fm_lock_try_acquire recursively: recursive "$lockdir.steal" arbitration grows
+# an unbounded .steal.steal... chain after interrupted hook processes and can hit
+# the Windows path limit, leaving every later Stop hook blocked forever.
+fm_lock_try_acquire_steal() {
+  local steal=$1 pid owner reap
+  FM_LOCK_HELD_PID=
+  FM_LOCK_OWNER_DIR=
+
+  if fm_lock_try_create "$steal" __fm_no_steal_guard__; then
+    return 0
+  fi
+
+  pid=$(cat "$steal/pid" 2>/dev/null || true)
+  if fm_pid_alive "$pid" || fm_lock_mid_acquire_is_fresh "$steal" "$pid"; then
+    FM_LOCK_HELD_PID=$pid
+    return 1
+  fi
+  owner=
+  if [ -L "$steal" ]; then
+    owner=$(fm_lock_link_owner "$steal" 2>/dev/null || true)
+  fi
+  fm_lock_recheck_stale_owner "$steal" "$owner" "$pid" || return 1
+
+  reap=$(fm_lock_owner_dir "$steal.reap") || return 1
+  rmdir "$reap" 2>/dev/null || { fm_lock_discard_owner "$reap"; return 1; }
+  if ! mv "$steal" "$reap" 2>/dev/null; then
+    return 1
+  fi
+  if fm_lock_try_create "$steal" __fm_no_steal_guard__; then
+    fm_lock_remove_path "$reap" 2>/dev/null || true
+    return 0
+  fi
+  fm_lock_remove_path "$reap" 2>/dev/null || true
+  return 1
+}
+
 fm_lock_try_acquire() {
   local lockdir=$1 pid steal cur rc steal_owner primary_owner
   FM_LOCK_HELD_PID=
@@ -399,7 +458,7 @@ fm_lock_try_acquire() {
   fi
 
   steal="$lockdir.steal"
-  if ! fm_lock_try_acquire "$steal"; then
+  if ! fm_lock_try_acquire_steal "$steal"; then
     FM_LOCK_HELD_PID=$(cat "$lockdir/pid" 2>/dev/null || true)
     FM_LOCK_OWNER_DIR=
     return 1

--- a/tests/fm-sessionstart-hook-live-e2e.test.sh
+++ b/tests/fm-sessionstart-hook-live-e2e.test.sh
@@ -104,6 +104,7 @@ make_lab() {  # <harness> -> echoes lab dir
     printf '#!/usr/bin/env bash\nexit 0\n' > "$lab/bin/$stub"
     chmod +x "$lab/bin/$stub"
   done
+  cp "$ROOT/bin/fm-codex-hook.mjs" "$lab/bin/fm-codex-hook.mjs"
 
   cat > "$lab/bin/fm-sessionstart-run.sh" <<'SH'
 #!/usr/bin/env bash

--- a/tests/fm-turnend-guard.test.sh
+++ b/tests/fm-turnend-guard.test.sh
@@ -108,6 +108,7 @@ install_guard_scripts() {
   local dir=$1
   mkdir -p "$dir/bin"
   cp "$ROOT/bin/fm-turnend-guard.sh" "$dir/bin/fm-turnend-guard.sh"
+  cp "$ROOT/bin/fm-codex-hook.mjs" "$dir/bin/fm-codex-hook.mjs"
   cp "$ROOT/bin/fm-turnend-guard-grok.sh" "$dir/bin/fm-turnend-guard-grok.sh"
   cp "$ROOT/bin/fm-operational-input.sh" "$dir/bin/fm-operational-input.sh"
   cp "$ROOT/bin/fm-supervision-instructions.sh" "$dir/bin/fm-supervision-instructions.sh"
@@ -601,13 +602,30 @@ test_hook_silent_without_jq() {
   local dir out status fakebin tool tool_path
   dir=$(make_primary_dir "$TMP_ROOT/hook-nojq")
   : > "$dir/state/task1.meta"
-  fakebin=$(fm_fakebin "$TMP_ROOT/hook-nojq-fake")
-  for tool in bash sh git cat printf date uname stat mkdir dirname; do
-    tool_path=$(command -v "$tool") || fail "test host must provide $tool"
-    ln -s "$tool_path" "$fakebin/$tool"
-  done
-  out=$(printf '{"stop_hook_active":false}' | PATH="$fakebin" bash "$dir/bin/fm-turnend-guard.sh" 2>&1)
-  status=$?
+  case "$(uname -s)" in
+    MSYS*|MINGW*|CYGWIN*)
+      # A symlinked bash cannot load msys-2.0.dll on Windows (the loader
+      # resolves DLLs beside the symlink, not the target), so the minimal
+      # symlink fakebin cannot host a live shell here. /usr/bin carries the
+      # core tools but not jq when jq is installed outside it, which is the
+      # native jq-less PATH this assertion needs.
+      [ ! -x /usr/bin/jq ] || {
+        pass "fm-turnend-guard: jq fail-open skipped (jq lives in /usr/bin on this host)"
+        return
+      }
+      out=$(printf '{"stop_hook_active":false}' | PATH=/usr/bin bash "$dir/bin/fm-turnend-guard.sh" 2>&1)
+      status=$?
+      ;;
+    *)
+      fakebin=$(fm_fakebin "$TMP_ROOT/hook-nojq-fake")
+      for tool in bash sh git cat printf date uname stat mkdir dirname; do
+        tool_path=$(command -v "$tool") || fail "test host must provide $tool"
+        ln -s "$tool_path" "$fakebin/$tool"
+      done
+      out=$(printf '{"stop_hook_active":false}' | PATH="$fakebin" bash "$dir/bin/fm-turnend-guard.sh" 2>&1)
+      status=$?
+      ;;
+  esac
   expect_code 0 "$status" "hook must fail open (exit 0) when jq is unavailable"
   [ -z "$out" ] || fail "hook produced output without jq: $out"
   pass "fm-turnend-guard: fails open (never blocks) when jq is missing"

--- a/tests/fm-watcher-lock.test.sh
+++ b/tests/fm-watcher-lock.test.sh
@@ -180,12 +180,14 @@ test_guard_warnings() {
 }
 
 test_lock_single_winner_under_concurrency() {
-  local dir state lockdir marker i pids pid wins
+  local dir state lockdir marker attempts i pids pid wins
   dir=$(make_case lock-concurrency)
   state="$dir/state"
   lockdir="$state/.contend.lock"
   marker="$dir/wins"
+  attempts="$dir/attempts"
   : > "$marker"
+  : > "$attempts"
   pids=
   i=1
   while [ "$i" -le 40 ]; do
@@ -193,11 +195,23 @@ test_lock_single_winner_under_concurrency() {
       . "$1"
       if fm_lock_try_acquire "$2"; then
         printf "%s\n" "$$" >> "$3"
-        # Stay alive so the held lock names a live pid for the whole window;
-        # otherwise a late contender could legitimately reclaim a dead-pid lock.
-        sleep 1
+        printf "%s\n" "$$" >> "$4"
+        # Stay alive so the held lock names a live pid until every contender
+        # has finished its acquisition attempt; otherwise a late contender
+        # could legitimately reclaim a dead-pid lock and look like a second
+        # simultaneous winner. No fixed sleep is a sound bound here: one
+        # acquire under 40-way contention exceeds 10s on ARM Windows Git
+        # Bash, so the winner waits on the attempts ledger instead.
+        n=0
+        while [ "$n" -lt 1200 ]; do
+          [ "$(awk "NF { c++ } END { print c + 0 }" "$4")" -lt 40 ] || break
+          sleep 0.1
+          n=$((n + 1))
+        done
+      else
+        printf "%s\n" "$$" >> "$4"
       fi
-    ' _ "$LIB" "$lockdir" "$marker" &
+    ' _ "$LIB" "$lockdir" "$marker" "$attempts" &
     pids="$pids $!"
     i=$((i + 1))
   done
@@ -259,6 +273,37 @@ test_lock_stale_steal_single_winner_under_concurrency() {
   pass "concurrent stale-lock steal yields exactly one winner"
 }
 
+test_lock_reclaims_stale_steal_mutex_without_recursive_suffixes() {
+  local dir state lockdir stale dead rc newpid i
+  dir=$(make_case lock-stale-steal-mutex)
+  state="$dir/state"
+  lockdir="$state/.contend.lock"
+  dead=$(dead_pid)
+  mkdir "$lockdir"
+  printf '%s\n' "$dead" > "$lockdir/pid"
+  stale=$lockdir
+  i=0
+  while [ "$i" -lt 35 ]; do
+    stale="$stale.steal"
+    mkdir "$stale"
+    printf '%s\n' "$dead" > "$stale/pid"
+    i=$((i + 1))
+  done
+  rc=0
+  # Deep stale trees are renamed atomically, but starting Git Bash and probing
+  # 35 Windows paths can exceed five seconds on ARM Windows under load.
+  newpid=$(FM_LOCK_STALE_AFTER=0 FM_STATE_OVERRIDE="$state" timeout 30 bash -c '
+    . "$1"
+    if fm_lock_try_acquire "$2"; then cat "$2/pid"; else exit 7; fi
+  ' _ "$LIB" "$lockdir") || rc=$?
+  [ "$rc" -eq 0 ] || fail "acquirer did not recover a stale steal mutex promptly (rc=$rc)"
+  [ -n "$newpid" ] && [ "$newpid" != "$dead" ] \
+    || fail "stale steal-mutex recovery did not publish a live owner"
+  [ ! -e "$stale.steal" ] \
+    || fail "stale steal-mutex recovery extended the recursive .steal suffix"
+  pass "stale steal mutex is reclaimed without recursive suffixes"
+}
+
 test_lock_live_steal_mutex_is_not_reclaimed() {
   local dir state lockdir dead holder_file holder out i lockpid stealpid
   dir=$(make_case lock-live-stealer)
@@ -272,7 +317,9 @@ test_lock_live_steal_mutex_is_not_reclaimed() {
     . "$1"
     fm_lock_try_acquire "$2.steal" || exit 7
     printf "%s\n" "${BASHPID:-$$}" > "$3"
-    sleep 2
+    # Keep the steal mutex live while the inspecting Git Bash starts; process
+    # startup alone can exceed two seconds on Windows under load.
+    sleep 10
     fm_lock_release "$2.steal"
   ' _ "$LIB" "$lockdir" "$holder_file" &
   holder=$!
@@ -1032,16 +1079,41 @@ test_msys_pid_identity_uses_proc() {
   pass "MSYS process identity uses compatible /proc fields"
 }
 
+test_msys_lock_enables_real_directory_symlinks() {
+  local dir state lockdir
+  case "$(uname)" in
+    MSYS*|MINGW*|CYGWIN*) ;;
+    *)
+      pass "MSYS directory-symlink lock regression skipped on non-Windows host"
+      return
+      ;;
+  esac
+  dir=$(make_case msys-directory-symlink)
+  state="$dir/state"
+  lockdir="$state/.probe.lock"
+  env -u MSYS FM_STATE_OVERRIDE="$state" bash -c '
+    . "$1"
+    fm_lock_try_acquire "$2" || exit 1
+    [ -L "$2" ] || exit 2
+    readlink "$2" >/dev/null || exit 3
+    fm_lock_release "$2"
+    [ ! -e "$2" ] && [ ! -L "$2" ]
+  ' _ "$LIB" "$lockdir" || fail "MSYS lock library did not publish and release a real directory symlink without ambient MSYS options"
+  pass "MSYS lock library enables real directory symlinks without ambient configuration"
+}
+
 test_singleton_start
 test_pid_identity_is_locale_invariant
 test_proc_pid_identity_ignores_wall_clock_and_detects_pid_reuse
 test_msys_pid_identity_uses_proc
+test_msys_lock_enables_real_directory_symlinks
 test_stale_watch_lock_reclaimed
 test_live_stale_watch_lock_is_actionable
 test_guard_warnings
 test_lock_single_winner_under_concurrency
 test_lock_steals_dead_pid_lock
 test_lock_stale_steal_single_winner_under_concurrency
+test_lock_reclaims_stale_steal_mutex_without_recursive_suffixes
 test_lock_live_steal_mutex_is_not_reclaimed
 test_lock_does_not_steal_live_lock
 test_lock_empty_pid_uses_minimum_grace


### PR DESCRIPTION
## Summary
Makes the firstmate primary operational on Windows 11 ARM64 under Git Bash/MSYS. Six commits, one concern each:

- **.gitattributes**: normalize line endings (the working tree previously showed ~350 phantom CRLF modifications on Windows).
- **fm-session-lock-lib.sh**: Git Bash `ps` cannot see native Windows processes, so harness ancestry + holder liveness go through PowerShell/CIM (`Win32_Process`), bridging MSYS fork-emulation gaps via the ps pid table.
- **fm-wake-lib.sh**: three lock-safety fixes — `MSYS=winsymlinks:nativestrict` so `ln -s` publishes a real owner pointer instead of a copied directory; stale steal-mutex recovery by atomic rename instead of recursive `.steal.steal...` chains that hit the Windows path limit; mid-acquire grace floor raised 2s → 10s on MSYS (measured: process startup alone takes 1–3s, one acquire under 40-way contention exceeds 10s on ARM, so 2s let a live mid-acquire peer be robbed of its lock). The single-winner concurrency test now uses an attempts-ledger barrier instead of a fixed sleep, making it deterministic on slow machines.
- **pi extensions**: `parentPid` via CIM; `.sh` entry points run through `bash` (Windows cannot exec shell scripts directly).
- **codex hooks**: inline `bash -lc` one-liners replaced by `bin/fm-codex-hook.mjs`; the jq fail-open test gets an MSYS variant (a symlinked bash cannot load `msys-2.0.dll`, so the symlink fakebin cannot host a shell there).
- **herdr backend**: canonicalize `C:\...` socket paths via cygpath — Herdr on Windows injects native drive paths, which the launcher-identity check previously refused, blocking every spawn.

## Testing
On Windows 11 ARM64 (Git Bash, Herdr 0.8.0-preview):
- `tests/fm-watcher-lock.test.sh`: 21/22 pass. **Known issue: `test_watch_restart_attaches_to_healthy_peer` still fails on this platform** ("no live watcher with a fresh beacon"); deterministic, diagnosis pending — individual predicates (`fm_pid_identity`, `fm_pid_alive`) verified working, suspicion is the 1s `FM_ARM_CONFIRM_TIMEOUT` vs ~1s per-process spawn cost on this machine.
- `tests/fm-turnend-guard.test.sh`: all pass (including the new MSYS jq variant).
- `tests/fm-sessionstart-hook-live-e2e.test.sh`: not runnable on Windows (requires tmux); Linux CI covers it.

## Delivery note
Shipped as a direct PR without a local no-mistakes pipeline run (deviation from the standing no-mistakes posture, called out per contract): the pipeline tooling was installed as part of this very work session. If CI requires a head-bound attestation, say so and it will be produced as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)