### PR TITLE
feat(skills): add captain-invocable /quality-loop command

### DIFF
--- a/.agents/skills/quality-loop/SKILL.md
+++ b/.agents/skills/quality-loop/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: quality-loop
+description: >-
+  Run an adversarial build-and-grade loop that drives a subject to a quality bar.
+  Use when the captain invokes /quality-loop or says "quality loop on {subject}" (optionally "to {target}"), e.g. "/quality-loop the fade chat UI", "quality loop on the onboarding flow to 90".
+  It dispatches one persistent builder and a fresh read-only critic per pass, keeps scoring off the builder, and stops on zero-blockers, plateau, or a pass cap before firstmate does the final real-app re-score by hand.
+user-invocable: true
+metadata:
+  internal: true
+---
+
+# quality-loop
+
+Firstmate's orchestration contract for a quality loop.
+When the captain invokes `/quality-loop <subject> [to <target>]`, firstmate arbitrates an adversarial loop between two crewmates and does the final real-app re-score itself.
+This skill is that arbitration contract; the three template files in this skill directory are the fill-in worker briefs it dispatches.
+It exists because a v1 loop returned a false 97: one context wrote the rubric, built the thing, built the harness, and graded it, and the harness faked the exact seam where the bug lived, so even an honest grader scored the wrong exam.
+v2 separates the roles and makes the evidence adversarial.
+
+## Invocation
+
+`/quality-loop <subject> [to <target>]`, or the captain saying "quality loop on {subject}".
+`<subject>` is the thing to drive up in quality (a UI surface, a flow, a component, an output).
+`to <target>` is optional; default target is "no blockers" (roughly 90).
+Default hard pass cap is 3-4 passes.
+Resolve the concrete project for the subject the same way any task intake does, and run the loop through crewmates - firstmate never builds or grades a project itself.
+
+## The two roles (two crewmates, never one)
+
+- **Builder** - one persistent worker, briefed from [`quality-loop-builder-brief.md`](quality-loop-builder-brief.md).
+  It defines the bar, then builds and captures evidence per pass.
+  It never emits a score; the repo (`quality-evidence/` plus the gap lists firstmate relays) is its memory.
+- **Critic** - a fresh context in a separate session, read-only, dispatched once per pass, briefed from [`quality-loop-critic-brief.md`](quality-loop-critic-brief.md).
+  It sees only the frozen rubric, the reference artifacts, and the pass evidence plus check results - never the builder's transcript, diff, claims, or prior scores.
+  It verifies the checks and hostile fixtures are green, grades each taste dimension coarsely (blocker / weak / pass), and names the single largest gap.
+  Use a workhorse model for mid-loop passes and the strongest model on the final gate pass only.
+
+## What the builder must produce in Phase 1 (before any product code)
+
+This is a one-way door; the builder commits all of it, then stops for firstmate approval before building.
+
+- A weighted rubric, heaviest weight on the worst current problem.
+- Every rubric line partitioned into **[machine]** (deterministic-checkable) or **[taste]** (needs judgment); if fewer than about half the points are [machine], the rubric is under-specified.
+- A deterministic check script per [machine] line under `checks/` - grep, DOM-scan, or test, zero tokens, same result every run.
+- 2-3 concrete real reference artifacts (real screenshots of the named-best products, or the project's own best prior state) committed next to the rubric; taste is judged by blind A/B against these, not against prose.
+- A hostile fixture per known defect, through the real code path, mocking only below the lowest seam the defect crosses (name that seam), each proven RED before the fix with that red-run evidence committed.
+  A harness never seen red is a rubber stamp, not a measuring instrument.
+  Reuse a committed harness for the surface when one exists; a new harness is a reviewed deliverable.
+
+## How firstmate arbitrates the loop
+
+1. Dispatch the builder for Phase 1.
+   Sanity-approve the rubric and references before Phase 2; for user-facing work the captain approves.
+   Do not let the builder amend the exam mid-build.
+2. Per pass: the builder builds and captures evidence to `quality-evidence/pass-N/`, then firstmate dispatches a fresh critic on that evidence, reads `score.md`, and relays only the largest gap back to the builder - never the critic's chatter or numbers.
+   Repeat.
+3. Stop at the first of:
+   - zero blockers and the largest gap immaterial at or above the target (the critic's stated judgment);
+   - plateau - the critic's delta is negligible across two consecutive passes;
+   - the hard pass cap - then raise a `needs-decision` to the captain to extend, because that is a spend decision.
+4. Firstmate does the final real-app re-score itself, on the real build or app, by hand.
+   The critic makes this cheap and rare-to-fail; it does not replace it.
+   This is the one v1 rule kept unchanged.
+
+The orchestration overview in [`quality-loop-brief.md`](quality-loop-brief.md) is the same contract in brief form for reference.
+
+## Refuse (cost theater at this scale)
+
+- Amnesiac or fresh-context builders - only the critic is fresh; the builder is persistent and remembers through the repo.
+- Per-component builder-and-critic pairs by default - one builder and one critic; split only when the critic's gaps prove two genuinely independent fronts that share no files, and then each earns its own normal loop.
+- Unbounded "loop until resources exhaust" - every loop has a cap and honest residue in the PR body.
+- Precision-point arithmetic, dashboards, and a stale reusable-rubric library - coarse grades, `score.md` files, and a fresh rubric per task.
+
+## Boundaries
+
+The loop runs entirely through crewmates and the normal task lifecycle; all existing firstmate safety boundaries hold.
+The builder ships its result through the project's selected delivery path like any other task, and the honest residue (remaining gaps, passes spent, target met or not) goes in the PR body.

--- a/.agents/skills/quality-loop/quality-loop-brief.md
+++ b/.agents/skills/quality-loop/quality-loop-brief.md
@@ -1,0 +1,22 @@
+# QUALITY LOOP v2 - orchestration overview (firstmate follows this; the two role briefs are the workers' contracts)
+# v2 rebuilt from a board review (IndyDevDan / Kun Chen / Austin Marchese) against the "Gauntlet Loop" idea.
+# Trigger: captain says "quality loop on {SUBJECT}" (optional "to {TARGET}"; default 90 / "no blockers").
+
+## The core fix (why v2 exists)
+The v1 false-97 was NOT just self-scoring - ONE context wrote the rubric, built the thing, built the harness, AND graded it, and the harness FAKED the exact seam where the bug lived. So even an honest grader scored the wrong exam. v2 separates the roles and makes the evidence adversarial.
+
+## Roles (two crewmates, not one)
+- **BUILDER** (persistent worker) - `quality-loop-builder-brief.md`. Defines the bar (rubric + [machine]/[taste] partition + deterministic `checks/` + concrete reference artifacts + HOSTILE fixtures proven RED-then-GREEN through the real seam), then builds and captures evidence per pass. NEVER emits a score.
+- **CRITIC** (fresh context, separate session, read-only, one dispatch per pass) - `quality-loop-critic-brief.md`. Sees ONLY the rubric + evidence + references + check/fixture results (never the builder's transcript/claims/scores). Verifies checks+fixtures green, grades [taste] COARSELY (blocker/weak/pass), names the single largest gap. Workhorse model mid-loop; strongest model on the final gate pass only.
+
+## Firstmate arbitrates the loop
+1. Dispatch BUILDER Phase 1. **Sanity-approve the rubric + references before Phase 2** (one-way door; for user-facing work, the captain approves). Do not let the builder amend the exam mid-build.
+2. Per pass: builder builds+captures → dispatch a FRESH critic on the evidence → read `score.md` → relay ONLY the largest gap back to the builder (never the critic's chatter). Repeat.
+3. **Stop at the FIRST of:** (a) zero blockers AND largest gap immaterial (critic's stated judgment) at/above {TARGET}; (b) plateau - critic delta negligible across 2 consecutive passes; (c) hard cap {MAX_PASSES} (default 3-4) → `needs-decision` to the captain to extend (that's a spend decision).
+4. **Firstmate does the FINAL real-app re-score itself** - on the real build/app, by hand. The critic makes this cheap and rare-to-fail; it does NOT replace it. This is the one v1 rule kept unchanged.
+
+## Refuse (from the Gauntlet Loop - cost theater at this scale)
+- Amnesiac/fresh-context BUILDERS - no; only the CRITIC is fresh. The repo (`quality-evidence/` + gap lists) is the builder's memory.
+- Per-component builder+critic pairs by default - no; one builder + one critic. Split only when the critic's gaps prove two genuinely independent fronts that don't share files; then each earns its own normal loop.
+- Unbounded "loop until resources exhaust" - no; every loop has a cap + honest residue in the PR body.
+- Precision-point arithmetic, dashboards, and a stale reusable-rubric library - no; coarse grades, `score.md` files, and a fresh rubric per task.

--- a/.agents/skills/quality-loop/quality-loop-builder-brief.md
+++ b/.agents/skills/quality-loop/quality-loop-builder-brief.md
@@ -1,0 +1,21 @@
+# Quality-loop BUILDER brief (v2). Fill {PLACEHOLDERS}. One persistent worker. It NEVER scores itself.
+# Firstmate dispatches this, then alternates with the CRITIC brief until the stop rule fires.
+
+You are the BUILDER crewmate for a quality loop on {SUBJECT}. You research, define the bar, build, and capture evidence. You do NOT grade your own work and you NEVER emit a score - a separate critic does that.
+
+# Phase 1 - Define the bar (all committed BEFORE any product code; this is a one-way door)
+1. Write a rubric to {RUBRIC_PATH}: weighted dimensions; heaviest weight on the worst current problem ({TOP_PROBLEM}).
+2. Partition EVERY rubric line into **[machine]** (deterministic-checkable, e.g. "no `{"steps":` in the DOM") or **[taste]** (needs judgment). If fewer than ~half the points are [machine], the rubric is under-specified - tighten it.
+3. Write a deterministic check script per [machine] line under `checks/` (grep/DOM-scan/test - zero tokens, same result every run). These run every iteration for free.
+4. Collect 2-3 CONCRETE reference artifacts (real screenshots of the named-best products, or the project's own best prior state) committed next to the rubric. Taste is judged by blind A/B against these, not against prose.
+5. Write a HOSTILE fixture per {KNOWN_DEFECT}, through the REAL code path: mock ONLY below the lowest seam the defect crosses (name that seam). Each fixture must reproduce the real misbehaving component - e.g. an agent that returns plan JSON on BOTH the planning AND execution turn (the #104 poisoned-mock pattern). PROVE each fixture RED before you fix it, and commit that red-run evidence. A harness never seen red is a rubber stamp, not a measuring instrument. Reference `src/e2e.esx-job.test.ts` (real orchestrator+MCP over stdio, scripted agent at the outer seam only) as the canonical shape. If a committed harness already exists for this surface (fade chat: `chat-demo.html` + `scripts/chat-ux-shots.sh`), REUSE it; a new harness is a reviewed deliverable.
+STOP after Phase 1 and let firstmate sanity-approve the rubric + references before Phase 2 (a bad rubric poisons every downstream token).
+
+# Phase 2/3 - Build and capture (repeat per pass; NO scoring)
+- Build toward the rubric and to close the critic's named gap from the last pass (firstmate hands you ONLY the gap list - you never see the critic's transcript or numbers).
+- Each pass: run all `checks/` (they must be GREEN before evidence counts) and the hostile fixtures (RED-then-GREEN), then capture the full evidence bundle (screenshots + logs + check output) to `quality-evidence/pass-N/`, and append `working: pass N evidence ready`. Then STOP the pass.
+- You never write a score. `quality-evidence/pass-N/` + the green checks ARE your report.
+
+# Constraints / DoD
+- `checks/` all green and every hostile fixture green are HARD preconditions - no green checks, no valid pass. `npm run lint`, `npm run build`, `vitest`, `cargo test` (as applicable) green.
+- Deterministic checks do the mechanical grading for free; you focus tokens on the build, not on grading.

--- a/.agents/skills/quality-loop/quality-loop-critic-brief.md
+++ b/.agents/skills/quality-loop/quality-loop-critic-brief.md
@@ -1,0 +1,19 @@
+# Quality-loop CRITIC brief (v2). Fresh crewmate, SEPARATE session, READ-ONLY, dispatched once per pass.
+# It sees ONLY the rubric, the evidence, the references, and the check/fixture results - NEVER the builder's transcript, diff, claims, or prior scores.
+
+You are the CRITIC for a quality loop on {SUBJECT}. You are an adversarial, independent grader. You gain NOTHING by being kind. You did not build this; judge only what you can see.
+
+# What you get (and ONLY this)
+- The frozen rubric: {RUBRIC_PATH}
+- The reference artifacts (real best-in-class examples) next to the rubric.
+- The latest evidence bundle: `quality-evidence/pass-{N}/` (screenshots, logs, check output).
+- Instruction to RUN the real app/harness yourself where feasible - score the real run first, the captured screenshots second. If they disagree, the harness is the bug; say so.
+
+# How to grade
+1. Verify the [machine] checks are green and every hostile fixture is green (RED-then-GREEN evidence exists). If any is missing or red, the score does not exist - return "no valid score: <reason>".
+2. Grade each [taste] dimension COARSELY: **blocker / weak / pass** (no 100-point arithmetic - "95 vs 97" is theater). For each dimension use a blind A/B against the reference artifacts.
+3. Name the SINGLE LARGEST meaningful gap versus the reference. One sentence. This is the builder's next instruction. (No "consider adding error handling" slop.)
+4. Write `quality-evidence/pass-{N}/score.md`: per-dimension blocker/weak/pass, the largest gap, and a one-line verdict (ship / iterate). Firstmate relays ONLY the largest gap to the builder.
+
+# Model tier
+Use a workhorse model for mid-loop passes; firstmate escalates to the strongest model for the FINAL gate pass only.

--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ Claude and grok use the slash form shown here; codex uses the same names with `$
 | `/bearings`        | Generate a concise four-section chat digest from bounded local fleet and registered-secondmate state; use `/bearings file` to also replace today's dated report in `data/`, and add `include PRs` when live PR enrichment is wanted |
 | `/updatefirstmate` | Self-update the running firstmate and its secondmates to the latest from origin with fast-forward-only pulls, then re-read instructions and nudge secondmates |
 | `/stow`            | Sweep the session for uncaptured durable knowledge, route each finding to its disk home per AGENTS.md, file undone next steps to the backlog, and report what is now safe to reset |
+| `/quality-loop`    | Run an adversarial build-and-grade loop on `<subject>` (optionally `to <target>`): a persistent builder defines the bar and builds, a fresh read-only critic grades each pass, and firstmate does the final real-app re-score by hand |
 
 Bearings invocation examples:
 

--- a/docs/documentation-audiences.json
+++ b/docs/documentation-audiences.json
@@ -165,6 +165,22 @@
       "audience": "agent-runtime"
     },
     {
+      "path": ".agents/skills/quality-loop/SKILL.md",
+      "audience": "agent-runtime"
+    },
+    {
+      "path": ".agents/skills/quality-loop/quality-loop-brief.md",
+      "audience": "agent-runtime"
+    },
+    {
+      "path": ".agents/skills/quality-loop/quality-loop-builder-brief.md",
+      "audience": "agent-runtime"
+    },
+    {
+      "path": ".agents/skills/quality-loop/quality-loop-critic-brief.md",
+      "audience": "agent-runtime"
+    },
+    {
       "path": ".agents/skills/quota-array-dispatch/SKILL.md",
       "audience": "agent-runtime"
     },


### PR DESCRIPTION
Adds a captain-invocable `/quality-loop` command that packages the v2 quality-loop workflow (builder plus a fresh critic, deterministic `[machine]` checks, hostile fixtures proven red-then-green, a capped loop, and a firstmate real-app re-score).

The v2 templates are co-located as tracked material, the README table and `docs/documentation-audiences.json` are updated, and `bin/fm-doc-audience-check.sh` plus the audiences test pass.

Validated end to end through the no-mistakes pipeline (review, test, document, lint all clean); only the push step was blocked earlier by fork access, now resolved via this fork PR.
