### PR TITLE
watcher: use herdr native idle state for declared-pause cadence

### DIFF
--- a/bin/fm-backend.sh
+++ b/bin/fm-backend.sh
@@ -905,6 +905,25 @@ fm_backend_agent_alive() {  # <backend> <target>
   esac
 }
 
+# fm_backend_agent_is_idle: 0 only when a backend exposes a NATIVE semantic
+# idle state for the agent at <target> and that state is confidently idle.
+# Herdr is the first supported backend: its `agent get` surface reports an
+# explicit "idle" agent_status. Backends without such a primitive (tmux and
+# all others) always return 1, preserving the existing "live means not dead"
+# triage path for them.
+fm_backend_agent_is_idle() {  # <backend> <target>
+  local backend=$1 target=$2 status
+  fm_backend_source "$backend" || return 1
+  case "$backend" in
+    herdr)
+      fm_backend_herdr_parse_target "$target" || return 1
+      status=$(fm_backend_herdr_agent_status_raw "$FM_BACKEND_HERDR_SESSION" "$FM_BACKEND_HERDR_PANE")
+      [ "$status" = idle ]
+      ;;
+    *) return 1 ;;
+  esac
+}
+
 # --- native event push (backend-extensible) ---------------------------------
 #
 # The watcher's event-wait splice (bin/fm-watch.sh) is backend-agnostic: it asks

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -364,7 +364,9 @@ clear_pause_tracking() {  # <window>
 
 # Reconcile a declared pause or captain-held status with authoritative crew state.
 # Only a confidently dead ordinary crew may recover paused classification after
-# fm-crew-state has fallen back to stopped or unknown.
+# fm-crew-state has fallen back to stopped or unknown. A backend that exposes a
+# native semantic idle state (herdr agent_status idle) lets a declared pause keep
+# the bounded pause cadence even though the endpoint itself is still alive.
 pause_state_class() {  # <window> <task>
   local win=$1 task=$2 key last recheck_file class agent_alive
   key=${win//:/_}
@@ -380,6 +382,10 @@ pause_state_class() {  # <window> <task>
   if [ -e "$STATE/.paused-$key" ] && [ "$(age_of "$recheck_file")" -lt "$STALE_ESCALATE_SECS" ]; then
     if [ "$(window_kind "$win")" != secondmate ]; then
       agent_alive=$(fm_backend_agent_alive "$(window_backend "$win")" "$win" 2>/dev/null) || agent_alive=unknown
+      if fm_backend_agent_is_idle "$(window_backend "$win")" "$win" >/dev/null 2>&1; then
+        printf 'paused'
+        return
+      fi
       if [ "$agent_alive" != dead ]; then
         rm -f "$recheck_file"
         printf 'none'
@@ -397,7 +403,9 @@ pause_state_class() {  # <window> <task>
   fi
   if [ "$(window_kind "$win")" != secondmate ]; then
     agent_alive=$(fm_backend_agent_alive "$(window_backend "$win")" "$win" 2>/dev/null) || agent_alive=unknown
-    if [ "$agent_alive" != dead ]; then
+    if fm_backend_agent_is_idle "$(window_backend "$win")" "$win" >/dev/null 2>&1; then
+      class=paused
+    elif [ "$agent_alive" != dead ]; then
       rm -f "$recheck_file"
       printf 'none'
       return

--- a/tests/fm-watch-triage.test.sh
+++ b/tests/fm-watch-triage.test.sh
@@ -991,6 +991,167 @@ test_paused_authoritative_working_preserves_wedge_timer() {
   pass "a paused status overridden by authoritative working preserves its wedge timer and escalates"
 }
 
+# --- herdr native idle state shapes the declared-pause cadence ----------------
+# Regression for the 2026-08-06 p5 noise pattern: a herdr pane whose agent
+# reports `agent_status: idle` is semantically idle even though the endpoint is
+# still alive. A declared pause paired with that native idle signal must use the
+# bounded PAUSE_RESURFACE_SECS cadence instead of firing a bare stale on every
+# new pane hash. Dead-agent and unreadable-liveness cases preserve the existing
+# safety posture.
+
+test_herdr_declared_pause_live_idle_uses_pause_cadence() {
+  local dir state fakebin out capture_file window key pane_hash sig pid
+  dir=$(make_case herdr-paused-live-idle); state="$dir/state"; fakebin="$dir/fakebin"
+  out="$dir/watch.out"; capture_file="$dir/pane.txt"
+  install_fake_herdr "$fakebin"
+  window="default:wA:p5"
+  printf 'idle pi footer render 1' > "$capture_file"
+  printf 'window=%s\nbackend=herdr\nharness=pi\nkind=ship\n' "$window" > "$state/herdr-paused.meta"
+  printf 'paused: holding for upstream after the 2026-08-06 p5 noise pattern\n' > "$state/herdr-paused.status"
+  sig=$(seen_sig "$state/herdr-paused.status"); printf '%s' "$sig" > "$state/.seen-herdr-paused_status"
+  key=$(printf '%s' "$window" | tr ':/.' '___')
+  pane_hash=$(hash_text "idle pi footer render 1")
+  printf '%s' "$pane_hash" > "$state/.hash-$key"
+  printf '1\n' > "$state/.count-$key"
+  export FM_FAKE_CREW_STATE='state: paused · source: status-log · holding for upstream'
+  export FM_FAKE_HERDR_PANE_ALIVE=1
+  export FM_FAKE_HERDR_AGENT_STATUS=idle
+  export FM_FAKE_HERDR_CAPTURE="$capture_file"
+
+  PATH="$fakebin:$PATH" FM_STATE_OVERRIDE="$state" FM_CREW_STATE_BIN="$fakebin/fm-crew-state.sh" \
+    FM_PAUSE_RESURFACE_SECS=999 FM_STALE_ESCALATE_SECS=999 FM_POLL=1 FM_SIGNAL_GRACE=1 \
+    FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$out" &
+  pid=$!
+  if ! wait_live "$pid" 30; then
+    reap "$pid"; fail "watcher exited for a herdr live-idle declared pause (should absorb): $(cat "$out")"
+  fi
+  [ ! -s "$out" ] || fail "herdr live-idle declared pause printed a wake reason: $(cat "$out")"
+  [ ! -s "$state/.wake-queue" ] || fail "herdr live-idle declared pause enqueued a wake"
+  [ -e "$state/.paused-$key" ] || fail "herdr live-idle declared pause did not record the paused marker"
+  [ ! -e "$state/.stale-since-$key" ] || fail "herdr live-idle declared pause started the wedge timer"
+  reap "$pid"
+
+  printf 'idle pi footer render 2' > "$capture_file"
+  : > "$out"
+  pane_hash=$(hash_text "idle pi footer render 2")
+  PATH="$fakebin:$PATH" FM_STATE_OVERRIDE="$state" FM_CREW_STATE_BIN="$fakebin/fm-crew-state.sh" \
+    FM_PAUSE_RESURFACE_SECS=999 FM_STALE_ESCALATE_SECS=999 FM_POLL=1 FM_SIGNAL_GRACE=1 \
+    FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$out" &
+  pid=$!
+  if ! wait_live "$pid" 30; then
+    reap "$pid"; fail "watcher exited on a new hash for a herdr live-idle declared pause: $(cat "$out")"
+  fi
+  [ ! -s "$out" ] || fail "a new pane hash surfaced a bare stale for a herdr live-idle declared pause: $(cat "$out")"
+  [ ! -s "$state/.wake-queue" ] || fail "a new pane hash enqueued a stale wake"
+  [ "$(cat "$state/.stale-$key" 2>/dev/null || true)" = "$pane_hash" ] || fail "new pane hash did not advance the stale suppressor under pause cadence"
+  reap "$pid"
+  unset FM_FAKE_CREW_STATE FM_FAKE_HERDR_PANE_ALIVE FM_FAKE_HERDR_AGENT_STATUS FM_FAKE_HERDR_CAPTURE
+  pass "a herdr live-idle declared pause uses the bounded pause cadence and survives new pane hashes"
+}
+
+test_herdr_declared_pause_dead_agent_unchanged() {
+  local dir state fakebin out capture_file window key pane_hash sig pid back wakes bare
+  dir=$(make_case herdr-paused-dead); state="$dir/state"; fakebin="$dir/fakebin"
+  out="$dir/watch.out"; capture_file="$dir/pane.txt"
+  install_fake_herdr "$fakebin"
+  window="default:wA:p5"
+  printf 'idle after agent exit' > "$capture_file"
+  printf 'window=%s\nbackend=herdr\nharness=pi\nkind=ship\n' "$window" > "$state/herdr-dead.meta"
+  printf 'paused: held while the agent is dead\n' > "$state/herdr-dead.status"
+  back=$(( $(date +%s) - 500 ))
+  if [ "$(uname)" = Darwin ]; then touch -mt "$(date -r "$back" '+%Y%m%d%H%M.%S')" "$state/herdr-dead.status"
+  else touch -m -d "@$back" "$state/herdr-dead.status"; fi
+  sig=$(seen_sig "$state/herdr-dead.status"); printf '%s' "$sig" > "$state/.seen-herdr-dead_status"
+  key=$(printf '%s' "$window" | tr ':/.' '___')
+  pane_hash=$(hash_text "idle after agent exit")
+  printf '%s' "$pane_hash" > "$state/.hash-$key"
+  printf '1\n' > "$state/.count-$key"
+  export FM_FAKE_CREW_STATE='state: stopped · source: pane · bare shell'
+  export FM_FAKE_HERDR_PANE_ALIVE=0
+  export FM_FAKE_HERDR_CAPTURE="$capture_file"
+
+  PATH="$fakebin:$PATH" FM_STATE_OVERRIDE="$state" FM_CREW_STATE_BIN="$fakebin/fm-crew-state.sh" \
+    FM_PAUSE_RESURFACE_SECS=240 FM_POLL=1 FM_SIGNAL_GRACE=1 \
+    FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$out" &
+  pid=$!
+  wait_for_exit "$pid" 40 || fail "watcher did not resurface a herdr dead-agent declared pause"
+  grep -F "awaiting external" "$out" >/dev/null || fail "dead-agent herdr pause did not resurface as a paused recheck"
+  grep -F "possible wedge" "$out" >/dev/null && fail "dead-agent herdr pause was mislabeled a wedge"
+  wakes=$(awk -F '\t' -v w="$window" '$3 == "stale" && $4 == w { n++ } END { print n + 0 }' "$state/.wake-queue")
+  bare=$(awk -F '\t' -v w="$window" '$3 == "stale" && $4 == w && $5 == "stale: " w { n++ } END { print n + 0 }' "$state/.wake-queue")
+  [ "$wakes" -le 1 ] || fail "dead-agent herdr pause flooded $wakes stale wakes"
+  [ "$bare" -eq 0 ] || fail "dead-agent herdr pause surfaced as $bare bare stale wakes"
+  reap "$pid"
+  unset FM_FAKE_CREW_STATE FM_FAKE_HERDR_PANE_ALIVE FM_FAKE_HERDR_CAPTURE
+  pass "a herdr declared pause with a dead agent keeps the bounded pause cadence unchanged"
+}
+
+test_herdr_declared_pause_unreadable_liveness_surfaces() {
+  local dir state fakebin out capture_file window key pane_hash sig pid wakes
+  dir=$(make_case herdr-paused-unreadable); state="$dir/state"; fakebin="$dir/fakebin"
+  out="$dir/watch.out"; capture_file="$dir/pane.txt"
+  install_fake_herdr "$fakebin"
+  window="default:wA:p5"
+  printf 'idle with unreadable liveness' > "$capture_file"
+  printf 'window=%s\nbackend=herdr\nharness=pi\nkind=ship\n' "$window" > "$state/herdr-unreadable.meta"
+  printf 'paused: held while agent liveness is unreadable\n' > "$state/herdr-unreadable.status"
+  sig=$(seen_sig "$state/herdr-unreadable.status"); printf '%s' "$sig" > "$state/.seen-herdr-unreadable_status"
+  key=$(printf '%s' "$window" | tr ':/.' '___')
+  pane_hash=$(hash_text "idle with unreadable liveness")
+  printf '%s' "$pane_hash" > "$state/.hash-$key"
+  printf '1\n' > "$state/.count-$key"
+  export FM_FAKE_CREW_STATE='state: paused · source: status-log · unreadable agent'
+  export FM_FAKE_HERDR_PANE_ALIVE=1
+  export FM_FAKE_HERDR_AGENT_ERROR=server_error
+  export FM_FAKE_HERDR_CAPTURE="$capture_file"
+
+  PATH="$fakebin:$PATH" FM_STATE_OVERRIDE="$state" FM_CREW_STATE_BIN="$fakebin/fm-crew-state.sh" \
+    FM_PAUSE_RESURFACE_SECS=999 FM_STALE_ESCALATE_SECS=999 FM_POLL=1 FM_SIGNAL_GRACE=1 \
+    FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$out" &
+  pid=$!
+  wait_for_exit "$pid" 40 || fail "watcher did not surface a herdr declared pause with unreadable liveness"
+  grep -Fx "stale: $window" "$out" >/dev/null || fail "unreadable liveness did not surface a stale wake"
+  wakes=$(awk -F '\t' -v w="$window" '$3 == "stale" && $4 == w { n++ } END { print n + 0 }' "$state/.wake-queue")
+  [ "$wakes" -ge 1 ] || fail "unreadable liveness did not enqueue a stale wake"
+  reap "$pid"
+  unset FM_FAKE_CREW_STATE FM_FAKE_HERDR_PANE_ALIVE FM_FAKE_HERDR_AGENT_ERROR FM_FAKE_HERDR_CAPTURE
+  pass "a herdr declared pause with unreadable liveness surfaces instead of using the pause cadence"
+}
+
+test_herdr_nonpaused_idle_agent_unchanged() {
+  local dir state fakebin out capture_file window key pane_hash sig pid
+  dir=$(make_case herdr-nonpaused-idle); state="$dir/state"; fakebin="$dir/fakebin"
+  out="$dir/watch.out"; capture_file="$dir/pane.txt"
+  install_fake_herdr "$fakebin"
+  window="default:wA:p5"
+  printf 'idle while working' > "$capture_file"
+  printf 'window=%s\nbackend=herdr\nharness=pi\nkind=ship\n' "$window" > "$state/herdr-working.meta"
+  printf 'working: implementing\n' > "$state/herdr-working.status"
+  sig=$(seen_sig "$state/herdr-working.status"); printf '%s' "$sig" > "$state/.seen-herdr-working_status"
+  key=$(printf '%s' "$window" | tr ':/.' '___')
+  pane_hash=$(hash_text "idle while working")
+  printf '%s' "$pane_hash" > "$state/.hash-$key"
+  printf '1\n' > "$state/.count-$key"
+  export FM_FAKE_CREW_STATE='state: working · source: run-step · validating (running)'
+  export FM_FAKE_HERDR_PANE_ALIVE=1
+  export FM_FAKE_HERDR_AGENT_STATUS=idle
+  export FM_FAKE_HERDR_CAPTURE="$capture_file"
+
+  PATH="$fakebin:$PATH" FM_STATE_OVERRIDE="$state" FM_CREW_STATE_BIN="$fakebin/fm-crew-state.sh" \
+    FM_STALE_ESCALATE_SECS=999 FM_POLL=1 FM_SIGNAL_GRACE=1 \
+    FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$out" &
+  pid=$!
+  if ! wait_live "$pid" 30; then
+    reap "$pid"; fail "watcher exited for a non-paused herdr idle agent (should absorb): $(cat "$out")"
+  fi
+  [ ! -s "$out" ] || fail "non-paused herdr idle agent printed a wake reason: $(cat "$out")"
+  [ ! -e "$state/.paused-$key" ] || fail "non-paused herdr idle agent recorded a paused marker"
+  [ -s "$state/.stale-since-$key" ] || fail "non-paused herdr idle agent did not start wedge tracking"
+  reap "$pid"
+  unset FM_FAKE_CREW_STATE FM_FAKE_HERDR_PANE_ALIVE FM_FAKE_HERDR_AGENT_STATUS FM_FAKE_HERDR_CAPTURE
+  pass "a non-paused herdr idle agent is absorbed as working, not misclassed as paused"
+}
+
 # --- consecutive wedge escalations on the same pane demand deep inspection ----
 # Root cause of the PR #252 incident's ~20 minutes of unnoticed green: each
 # wedge escalation fires, gets classified as "still validating" one poll later
@@ -1832,6 +1993,10 @@ test_secondmate_unpause_clears_pause_tracking
 test_nonterminal_stale_pause_transitions_reclassify_unchanged_hash
 test_nonterminal_paused_rechecks_authoritative_state
 test_paused_authoritative_working_preserves_wedge_timer
+test_herdr_declared_pause_live_idle_uses_pause_cadence
+test_herdr_declared_pause_dead_agent_unchanged
+test_herdr_declared_pause_unreadable_liveness_surfaces
+test_herdr_nonpaused_idle_agent_unchanged
 test_nonterminal_stale_repairs_missing_or_corrupt_timer
 test_triage_log_size_cap_accepts_spaced_wc_counts
 test_procevent_captured_result_surfaces_proactively

--- a/tests/wake-helpers.sh
+++ b/tests/wake-helpers.sh
@@ -85,6 +85,79 @@ SH
   printf '%s\n' "$dir"
 }
 
+# Install a fake `herdr` CLI into <fakebin> so watcher tests can exercise the
+# herdr backend without a real server. The fake honors three environment knobs:
+#   FM_FAKE_HERDR_PANE_ALIVE=1 -> pane get returns a matching pane struct.
+#   FM_FAKE_HERDR_PANE_ALIVE=0 -> pane get returns pane_not_found.
+#   FM_FAKE_HERDR_AGENT_STATUS   -> agent get returns this agent_status.
+#   FM_FAKE_HERDR_AGENT_ERROR    -> agent get returns this error code instead.
+# The fake also answers the `status --json` call used by target_ready and
+# replies to `pane read`/`pane capture` with the contents of FM_FAKE_HERDR_CAPTURE.
+install_fake_herdr() {  # <fakebin>
+  local fakebin=$1
+  cat > "$fakebin/herdr" <<'SH'
+#!/usr/bin/env bash
+set -u
+# Find the first positional subcommand, ignoring flags such as --session.
+sub=""
+for a in "$@"; do
+  case "$a" in
+    --*) continue ;;
+    status|pane|agent|server|api|workspace|tab|session)
+      sub="$a"
+      break
+      ;;
+    *)
+      sub="$a"
+      break
+      ;;
+  esac
+done
+case "$sub" in
+  status)
+    printf '{"client":{"protocol":16,"version":"fake"},"server":{"running":true}}\n'
+    exit 0
+    ;;
+  pane)
+    if [ "${FM_FAKE_HERDR_PANE_ALIVE:-1}" = "1" ]; then
+      pane_id=""
+      found_get=0
+      for a in "$@"; do
+        [ "$found_get" = 1 ] && { pane_id="$a"; break; }
+        [ "$a" = "get" ] && found_get=1
+      done
+      case "$*" in
+        *read*|*capture*)
+          [ -n "${FM_FAKE_HERDR_CAPTURE:-}" ] && cat "$FM_FAKE_HERDR_CAPTURE"
+          exit 0
+          ;;
+      esac
+      printf '{"result":{"pane":{"pane_id":"%s","workspace_id":"w1","tab_id":"t1"}}}\n' "$pane_id"
+    else
+      printf '{"error":{"code":"pane_not_found"}}\n'
+    fi
+    exit 0
+    ;;
+  agent)
+    if [ -n "${FM_FAKE_HERDR_AGENT_ERROR:-}" ]; then
+      printf '{"error":{"code":"%s"}}\n' "$FM_FAKE_HERDR_AGENT_ERROR"
+    else
+      printf '{"result":{"agent":{"agent":"fake-agent","agent_status":"%s"}}}\n' "${FM_FAKE_HERDR_AGENT_STATUS:-idle}"
+    fi
+    exit 0
+    ;;
+  server)
+    exit 0
+    ;;
+  *)
+    printf '{"error":{"code":"unsupported_fake_command"}}\n' >&2
+    exit 1
+    ;;
+esac
+SH
+  chmod +x "$fakebin/herdr"
+}
+
 # Install a hermetic fake fm-crew-state.sh into <fakebin> and echo its path. The
 # watcher's absorb-only-when-provably-working triage calls this (via
 # FM_CREW_STATE_BIN) to read a crew's current state on no-verb signal and stale


### PR DESCRIPTION
Fix the watcher's declared-pause cadence for live-but-idle herdr agents.

Problem: A crew with a declared paused:/captain-held status and a herdr agent whose agent_status is idle would previously get pause_state_class = none on every new pane hash, because fm_backend_agent_alive returns alive for any registered herdr agent. The watcher then surfaced a bare stale: wake roughly every time the idle pi TUI footer re-rendered.

Fix:
- Add fm_backend_agent_is_idle in bin/fm-backend.sh: for herdr it returns true only when the native agent_status is confidently idle; other backends return false.
- In bin/fm-watch.sh pause_state_class, check native idle before the existing live-agent fallback so that declared-pause + herdr idle keeps the bounded PAUSE_RESURFACE_SECS cadence instead of firing per-hash bare stales.
- Unknown/unreadable liveness still classifies as none; tmux and backends without a native idle semantic keep current behavior; working, terminal, wedge-escalation, secondmate, and afk paths are untouched.

Tests:
- Add install_fake_herdr to tests/wake-helpers.sh.
- Extend tests/fm-watch-triage.test.sh with four herdr cases: declared-pause + live-idle agent uses pause cadence and survives new pane hashes; declared-pause + dead agent unchanged; declared-pause + unreadable liveness surfaces; non-paused + idle agent unchanged.

Motivated by the 2026-08-06 p5 noise pattern observed for task-mctaskface-mvp-p1 on default:wA:p5.