### PR TITLE
feat(bin): prevent cross-kernel localhost shadowing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -311,6 +311,8 @@ After an autonomous merge, give the captain a one-line full-URL or local-main ou
 
 ### Validate
 
+Before accepting localhost or browser QA on a Windows/WSL host, run `bin/fm-localhost.py verify` for the project/port/expected-SHA tuple; its `--help` is the single owner of inspection and narrowly proven recovery.
+
 For a no-mistakes ship, trigger validation on the same worker after its implementation commit, using the harness invocation owned by `harness-adapters`.
 The task worker that starts a no-mistakes run drives the pipeline and owns every `no-mistakes axi run` and `no-mistakes axi respond` call through the next gate or outcome.
 Firstmate never invokes `no-mistakes axi respond` for a crew-owned run.

--- a/bin/fm-localhost.py
+++ b/bin/fm-localhost.py
@@ -1,0 +1,981 @@
+#!/usr/bin/env python3
+"""Inspect and narrowly recover cross-kernel localhost ownership.
+
+The --help text is the authoritative operator contract.  Keep implementation
+details out of AGENTS.md and maintained prose so this safety procedure has one
+owner.
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import datetime as dt
+import hashlib
+import json
+import os
+from pathlib import Path
+import re
+import shlex
+import shutil
+import subprocess
+import sys
+import time
+import urllib.request
+from urllib.parse import urlsplit
+
+
+SCHEMA = "fm-localhost.v1"
+INSPECT_PS = r"""
+$ErrorActionPreference = 'Stop'
+$OutputEncoding = [Console]::OutputEncoding = [System.Text.UTF8Encoding]::new($false)
+$Port = [int]$args[0]
+$Rows = @()
+$Connections = @(Get-NetTCPConnection -State Listen -ErrorAction Stop | Where-Object { [int]$_.LocalPort -eq $Port } | Sort-Object LocalAddress, OwningProcess)
+foreach ($Connection in $Connections) {
+  $Process = $null
+  try { $Process = Get-CimInstance Win32_Process -Filter "ProcessId = $($Connection.OwningProcess)" -ErrorAction Stop } catch {}
+  $Rows += [pscustomobject]@{
+    address = [string]$Connection.LocalAddress
+    port = [int]$Connection.LocalPort
+    pid = [int]$Connection.OwningProcess
+    process = if ($null -ne $Process) { [string]$Process.Name } else { $null }
+    executable = if ($null -ne $Process) { [string]$Process.ExecutablePath } else { $null }
+    command = if ($null -ne $Process) { [string]$Process.CommandLine } else { $null }
+  }
+}
+ConvertTo-Json -InputObject @($Rows) -Compress -Depth 3
+"""
+
+TERMINATE_PS = r"""
+$ErrorActionPreference = 'Stop'
+$OutputEncoding = [Console]::OutputEncoding = [System.Text.UTF8Encoding]::new($false)
+$Port = [int]$args[0]
+$PidToStop = [int]$args[1]
+$ExpectedCommandHash = [string]$args[2]
+$Connections = @(Get-NetTCPConnection -State Listen -ErrorAction Stop | Where-Object { [int]$_.LocalPort -eq $Port })
+if ($Connections.Count -lt 1) { throw 'reserved port has no Windows listener' }
+foreach ($Connection in $Connections) {
+  if ([int]$Connection.OwningProcess -ne $PidToStop) { throw 'reserved port ownership changed' }
+}
+$Process = Get-CimInstance Win32_Process -Filter "ProcessId = $PidToStop" -ErrorAction Stop
+if ($null -eq $Process -or [string]$Process.Name -ieq 'wslrelay.exe') { throw 'wslrelay.exe is never a termination target' }
+if ([string]$Process.Name -ine 'node.exe' -or [IO.Path]::GetFileName([string]$Process.ExecutablePath) -ine 'node.exe') { throw 'target is not native Windows node.exe' }
+$Command = [string]$Process.CommandLine
+if ([string]::IsNullOrWhiteSpace($Command)) { throw 'target command is unavailable' }
+$Bytes = [Text.Encoding]::UTF8.GetBytes($Command)
+$Hash = ([BitConverter]::ToString([Security.Cryptography.SHA256]::Create().ComputeHash($Bytes))).Replace('-', '').ToLowerInvariant()
+if ($Hash -ne $ExpectedCommandHash) { throw 'target command changed' }
+if ($Command -notmatch '(?i)astro' -or $Command -notmatch '(?i)(^|\s)dev(\s|$)') { throw 'target is not an Astro development server' }
+if ($Command -match '(?i)(^|\s)(preview|build)(\s|$)' -or $Command -match '(?i)(node_env\s*=\s*production|--mode(?:=|\s+)production)') { throw 'target looks production-like' }
+Stop-Process -Id $PidToStop -ErrorAction Stop
+for ($i = 0; $i -lt 100; $i++) {
+  if ($null -eq (Get-Process -Id $PidToStop -ErrorAction SilentlyContinue)) { 'terminated'; exit 0 }
+  Start-Sleep -Milliseconds 100
+}
+throw 'exact PID did not exit after termination'
+"""
+
+ROUTE_PS = r"""
+$ErrorActionPreference = 'Stop'
+$OutputEncoding = [Console]::OutputEncoding = [System.Text.UTF8Encoding]::new($false)
+$Url = [string]$args[0]
+Add-Type -AssemblyName System.Net.Http
+$Handler = [System.Net.Http.HttpClientHandler]::new()
+$Handler.UseProxy = $false
+$Client = [System.Net.Http.HttpClient]::new($Handler)
+$Client.MaxResponseContentBufferSize = 8388609
+$Client.Timeout = [TimeSpan]::FromSeconds(10)
+$Client.DefaultRequestHeaders.TryAddWithoutValidation('User-Agent', 'Mozilla/5.0 FirstmateLocalhost/1') | Out-Null
+$Client.DefaultRequestHeaders.TryAddWithoutValidation('Accept', 'text/html,application/xhtml+xml') | Out-Null
+try {
+  $Response = $Client.GetAsync($Url).GetAwaiter().GetResult()
+  $Body = $Response.Content.ReadAsByteArrayAsync().GetAwaiter().GetResult()
+  $Hash = ([BitConverter]::ToString([Security.Cryptography.SHA256]::Create().ComputeHash($Body))).Replace('-', '').ToLowerInvariant()
+  [pscustomobject]@{status = [int]$Response.StatusCode; sha256 = $Hash; length = [int64]$Body.Length} | ConvertTo-Json -Compress
+} finally {
+  $Client.Dispose()
+  $Handler.Dispose()
+}
+"""
+
+
+@dataclasses.dataclass(frozen=True)
+class GitInfo:
+    checkout: str = "unknown"
+    branch: str = "unknown"
+    sha: str = "unknown"
+    dirty: str = "unknown"
+    source: str = "unknown"
+    default_branch: str = "unknown"
+    error: str = ""
+
+
+@dataclasses.dataclass(frozen=True)
+class Listener:
+    kernel: str
+    address: str
+    pid: int
+    process: str
+    command: str
+    command_raw: str
+    executable_raw: str
+    git: GitInfo
+    tasks: tuple[str, ...]
+    classification: str
+
+
+@dataclasses.dataclass
+class Inspection:
+    windows: list[Listener]
+    wsl: list[Listener]
+    windows_error: str = ""
+    wsl_error: str = ""
+
+
+class SafeRefusal(RuntimeError):
+    pass
+
+
+def command_output(argv: list[str], *, cwd: Path | None = None, timeout: float = 15) -> str:
+    completed = subprocess.run(
+        argv,
+        cwd=str(cwd) if cwd else None,
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        timeout=timeout,
+        check=False,
+    )
+    if completed.returncode != 0:
+        raise SafeRefusal(f"command failed with exit {completed.returncode}")
+    return completed.stdout
+
+
+def git_output(path: Path, *args: str) -> str:
+    return command_output(["git", "-C", str(path), *args]).strip()
+
+
+def normalize_source(raw: str) -> str:
+    raw = raw.strip()
+    if not raw:
+        return "unknown"
+    if raw.startswith("file://"):
+        parsed = urlsplit(raw)
+        return f"file:{Path(parsed.path).resolve()}".removesuffix(".git")
+    scp = re.fullmatch(r"(?:[^@/]+@)?([^:/]+):(.+)", raw)
+    if scp and "://" not in raw:
+        host, path = scp.groups()
+        return f"{host.lower()}/{path.strip('/')}".removesuffix(".git")
+    parsed = urlsplit(raw)
+    if parsed.scheme and parsed.hostname:
+        path = parsed.path.strip("/")
+        return f"{parsed.hostname.lower()}/{path}".removesuffix(".git")
+    if Path(raw).is_absolute():
+        try:
+            return f"file:{Path(raw).resolve()}".removesuffix(".git")
+        except OSError:
+            pass
+    return "unknown"
+
+
+def git_info(path: Path) -> GitInfo:
+    try:
+        top = Path(git_output(path, "rev-parse", "--show-toplevel")).resolve()
+        sha = git_output(top, "rev-parse", "HEAD")
+        branch = git_output(top, "branch", "--show-current") or "detached"
+        status = command_output(["git", "-C", str(top), "status", "--porcelain=v1", "--untracked-files=all"])
+        source = normalize_source(git_output(top, "remote", "get-url", "origin"))
+        default_branch = "unknown"
+        try:
+            remote_head = git_output(top, "symbolic-ref", "--quiet", "--short", "refs/remotes/origin/HEAD")
+            if remote_head.startswith("origin/"):
+                default_branch = remote_head.removeprefix("origin/")
+        except (SafeRefusal, subprocess.TimeoutExpired):
+            for candidate in ("main", "master"):
+                try:
+                    git_output(top, "show-ref", "--verify", f"refs/heads/{candidate}")
+                    default_branch = candidate
+                    break
+                except (SafeRefusal, subprocess.TimeoutExpired):
+                    continue
+        return GitInfo(
+            checkout=str(top),
+            branch=branch,
+            sha=sha,
+            dirty="dirty" if status else "clean",
+            source=source,
+            default_branch=default_branch,
+        )
+    except (OSError, SafeRefusal, subprocess.TimeoutExpired) as exc:
+        return GitInfo(error=type(exc).__name__)
+
+
+def windows_mount_root() -> Path:
+    override = os.environ.get("FM_LOCALHOST_WINDOWS_MOUNT_ROOT")
+    if override and os.environ.get("FM_LOCALHOST_TESTING") == "1":
+        return Path(override).resolve()
+    return Path("/mnt")
+
+
+def windows_to_wsl(raw: str) -> Path | None:
+    value = raw.strip().strip('"\'')
+    drive = re.match(r"^([A-Za-z]):[\\/](.*)$", value)
+    if drive:
+        tail = [piece for piece in re.split(r"[\\/]+", drive.group(2)) if piece]
+        return windows_mount_root() / drive.group(1).lower() / Path(*tail)
+    unc = value.replace("\\", "/")
+    match = re.match(r"^//(?:wsl\.localhost|wsl\$)/([^/]+)(/.*)?$", unc, re.IGNORECASE)
+    if match:
+        distro = os.environ.get("WSL_DISTRO_NAME")
+        if not distro or match.group(1).lower() != distro.lower():
+            return None
+        return Path(match.group(2) or "/")
+    if value.startswith("/"):
+        return Path(value)
+    return None
+
+
+def wsl_to_windows(path: Path) -> str:
+    resolved = path.resolve()
+    mount = windows_mount_root()
+    try:
+        relative = resolved.relative_to(mount)
+        parts = relative.parts
+        if len(parts) >= 2 and len(parts[0]) == 1 and parts[0].isalpha():
+            suffix = "\\".join(parts[1:])
+            return f"{parts[0].upper()}:\\{suffix}"
+    except ValueError:
+        pass
+    distro = os.environ.get("WSL_DISTRO_NAME")
+    if not distro:
+        return "unknown"
+    return f"\\\\wsl.localhost\\{distro}\\{str(resolved).lstrip('/').replace('/', '\\')}"
+
+
+def redact_command(raw: str) -> str:
+    value = re.sub(r"[\x00-\x1f\x7f]+", " ", raw or "").strip()
+    if not value:
+        return "unknown"
+    value = re.sub(r"(?i)(https?://)[^/@\s]+@", r"\1<redacted>@", value)
+    sensitive = r"(?:token|secret|password|passwd|api[-_]?key|authorization|credential|cookie|session)"
+    value = re.sub(rf"(?i)({sensitive}\s*=\s*)(?:\"[^\"]*\"|'[^']*'|[^\s]+)", r"\1<redacted>", value)
+    value = re.sub(rf"(?i)(--?{sensitive}(?:=|\s+))(?:\"[^\"]*\"|'[^']*'|[^\s]+)", r"\1<redacted>", value)
+    value = re.sub(r"(?i)(bearer\s+)[A-Za-z0-9._~+/=-]+", r"\1<redacted>", value)
+    value = re.sub(r"(?i)\{?[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\}?", "<redacted-id>", value)
+    value = re.sub(r"\b[A-Za-z0-9_-]{48,}\b", "<redacted>", value)
+    if len(value) > 512:
+        value = value[:500] + " <truncated>"
+    return value
+
+
+def command_paths(command: str, executable: str) -> list[Path]:
+    values: list[str] = []
+    combined = f"{command} {executable}"
+    values.extend(re.findall(r'["\']((?:[A-Za-z]:[\\/]|\\\\(?:wsl\.localhost|wsl\$)\\)[^"\']+)["\']', combined, re.IGNORECASE))
+    values.extend(re.findall(r"(?<![A-Za-z0-9_])([A-Za-z]:[\\/][^\s\"]+)", combined))
+    values.extend(re.findall(r"(\\\\(?:wsl\.localhost|wsl\$)\\[^\s\"]+)", combined, re.IGNORECASE))
+    result: list[Path] = []
+    for value in values:
+        converted = windows_to_wsl(value.rstrip(",;"))
+        if converted and converted not in result:
+            result.append(converted)
+    return result
+
+
+def checkout_from_windows_command(command: str, executable: str) -> Path | None:
+    found: set[Path] = set()
+    for candidate in command_paths(command, executable):
+        parts = list(candidate.parts)
+        if "node_modules" in parts:
+            candidate = Path(*parts[: parts.index("node_modules")])
+        probe = candidate if candidate.is_dir() else candidate.parent
+        while probe != probe.parent:
+            if (probe / ".git").exists():
+                info = git_info(probe)
+                if info.checkout != "unknown":
+                    found.add(Path(info.checkout))
+                    break
+            probe = probe.parent
+    return next(iter(found)) if len(found) == 1 else None
+
+
+def classify_windows(process: str, command: str, executable: str) -> str:
+    lower_name = Path(process).name.lower()
+    lower_executable = re.split(r"[\\/]", executable)[-1].lower() if executable else ""
+    lower_command = command.lower()
+    if lower_name == "wslrelay.exe":
+        return "wslrelay"
+    if not command.strip():
+        return "unknown-command"
+    if lower_name != "node.exe" or lower_executable != "node.exe":
+        return "unrelated-process"
+    if re.search(r"(?:^|\s)(?:preview|build)(?:\s|$)", lower_command) or re.search(
+        r"node_env\s*=\s*production|--mode(?:=|\s+)production", lower_command
+    ):
+        return "production-like"
+    if "astro" in lower_command and re.search(r"(?:^|\s)dev(?:\s|$)", lower_command):
+        return "native-windows-node-astro-dev"
+    return "unknown-node"
+
+
+def classify_wsl(process: str, command: str) -> str:
+    lower = command.lower()
+    if Path(process).name.lower() in {"node", "nodejs"} and "astro" in lower and re.search(r"(?:^|\s)dev(?:\s|$)", lower):
+        return "wsl-node-astro-dev"
+    return "unknown-wsl-process"
+
+
+def task_associations(state: Path, checkout: str, pid: int) -> tuple[str, ...]:
+    if checkout == "unknown":
+        checkout_path = None
+    else:
+        checkout_path = Path(checkout).resolve()
+    matches: list[str] = []
+    for meta in sorted(state.glob("*.meta")):
+        try:
+            fields: dict[str, list[str]] = {}
+            for line in meta.read_text(encoding="utf-8", errors="replace").splitlines():
+                key, separator, value = line.partition("=")
+                if separator:
+                    fields.setdefault(key, []).append(value)
+            associated = False
+            if checkout_path:
+                for key in ("worktree", "project"):
+                    for raw_path in fields.get(key, []):
+                        converted = windows_to_wsl(raw_path)
+                        if converted is None:
+                            converted = Path(raw_path)
+                        try:
+                            if converted.resolve() == checkout_path:
+                                associated = True
+                        except OSError:
+                            continue
+            for key in ("pid", "process_pid", "windows_pid"):
+                if str(pid) in fields.get(key, []):
+                    associated = True
+            if associated:
+                matches.append(meta.stem)
+        except OSError:
+            matches.append(f"{meta.stem}:unreadable")
+    return tuple(matches)
+
+
+def powershell() -> str:
+    if os.environ.get("FM_LOCALHOST_TESTING") == "1":
+        found = shutil.which("powershell.exe")
+        if found:
+            return found
+    standard = Path("/mnt/c/Windows/System32/WindowsPowerShell/v1.0/powershell.exe")
+    if standard.is_file():
+        return str(standard)
+    raise SafeRefusal("Windows inspection unavailable")
+
+
+def run_powershell(script: str, *args: str, timeout: float = 20) -> str:
+    literals = ", ".join("'" + value.replace("'", "''") + "'" for value in args)
+    command = f"$FmArgs = @({literals})\n" + script.replace("$args[", "$FmArgs[")
+    try:
+        return command_output(
+            [powershell(), "-NoLogo", "-NoProfile", "-NonInteractive", "-Command", command],
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise SafeRefusal("Windows inspection timed out") from exc
+    except SafeRefusal as exc:
+        if str(exc) == "Windows inspection unavailable":
+            raise
+        raise SafeRefusal("Windows inspection failed") from exc
+
+
+def windows_listeners(port: int, state: Path) -> list[Listener]:
+    raw = run_powershell(INSPECT_PS, str(port))
+    try:
+        payload = json.loads(raw.lstrip("\ufeff").strip() or "[]")
+    except json.JSONDecodeError as exc:
+        raise SafeRefusal("Windows listener output was invalid") from exc
+    if isinstance(payload, dict):
+        payload = [payload]
+    if not isinstance(payload, list):
+        raise SafeRefusal("Windows listener output was invalid")
+    listeners: list[Listener] = []
+    for row in payload:
+        if not isinstance(row, dict):
+            raise SafeRefusal("Windows listener row was invalid")
+        try:
+            row_port = int(row.get("port"))
+            pid = int(row.get("pid"))
+        except (TypeError, ValueError) as exc:
+            raise SafeRefusal("Windows listener identity was incomplete") from exc
+        if row_port != port or pid <= 0:
+            raise SafeRefusal("Windows listener identity was inconsistent")
+        process = str(row.get("process") or "unknown")
+        command = str(row.get("command") or "")
+        executable = str(row.get("executable") or "")
+        checkout = checkout_from_windows_command(command, executable)
+        info = git_info(checkout) if checkout else GitInfo()
+        listeners.append(
+            Listener(
+                kernel="windows",
+                address=f"{row.get('address') or 'unknown'}:{port}",
+                pid=pid,
+                process=process,
+                command=redact_command(command),
+                command_raw=command,
+                executable_raw=executable,
+                git=info,
+                tasks=task_associations(state, info.checkout, pid),
+                classification=classify_windows(process, command, executable),
+            )
+        )
+    return listeners
+
+
+def proc_root() -> Path:
+    override = os.environ.get("FM_LOCALHOST_PROC_ROOT")
+    if override and os.environ.get("FM_LOCALHOST_TESTING") == "1":
+        return Path(override)
+    return Path("/proc")
+
+
+def wsl_listeners(port: int, state: Path) -> list[Listener]:
+    try:
+        output = command_output(["ss", "-H", "-ltnp", f"sport = :{port}"])
+    except (SafeRefusal, subprocess.TimeoutExpired) as exc:
+        raise SafeRefusal("WSL listener inspection failed") from exc
+    found: dict[tuple[int, str], tuple[str, str]] = {}
+    for line in output.splitlines():
+        address_match = re.search(r"\s([^\s]+:%s)\s" % port, line)
+        process_matches = re.findall(r'\("([^"\n]+)",pid=(\d+),fd=\d+\)', line)
+        if not address_match or not process_matches:
+            if line.strip():
+                raise SafeRefusal("WSL listener output was incomplete")
+            continue
+        for process, pid_text in process_matches:
+            found[(int(pid_text), address_match.group(1))] = (process, line)
+    listeners: list[Listener] = []
+    root = proc_root()
+    for (pid, address), (ss_process, _line) in sorted(found.items()):
+        pid_root = root / str(pid)
+        try:
+            command_raw = (pid_root / "cmdline").read_bytes().replace(b"\0", b" ").decode("utf-8", "replace").strip()
+            process = (pid_root / "comm").read_text(encoding="utf-8", errors="replace").strip() or ss_process
+            cwd = (pid_root / "cwd").resolve(strict=True)
+            info = git_info(cwd)
+        except OSError:
+            command_raw = ""
+            process = ss_process or "unknown"
+            info = GitInfo()
+        listeners.append(
+            Listener(
+                kernel="wsl",
+                address=address,
+                pid=pid,
+                process=process,
+                command=redact_command(command_raw),
+                command_raw=command_raw,
+                executable_raw="",
+                git=info,
+                tasks=task_associations(state, info.checkout, pid),
+                classification=classify_wsl(process, command_raw),
+            )
+        )
+    return listeners
+
+
+def inspect_system(port: int, state: Path) -> Inspection:
+    result = Inspection(windows=[], wsl=[])
+    try:
+        result.windows = windows_listeners(port, state)
+    except SafeRefusal as exc:
+        result.windows_error = str(exc)
+    try:
+        result.wsl = wsl_listeners(port, state)
+    except SafeRefusal as exc:
+        result.wsl_error = str(exc)
+    return result
+
+
+def source_state(info: GitInfo, expected: GitInfo, expected_sha: str) -> str:
+    if info.checkout == "unknown" or info.source == "unknown":
+        return "unknown"
+    if info.source != expected.source:
+        return "unrelated"
+    if info.dirty == "dirty":
+        return "dirty"
+    if info.sha != expected_sha or info.branch != expected.default_branch:
+        return "divergent"
+    if info.dirty == "clean":
+        return "canonical"
+    return "noncanonical"
+
+
+def expected_checkout_verdict(expected: GitInfo, expected_sha: str) -> str:
+    if expected.checkout == "unknown" or expected.source == "unknown":
+        return "refuse:expected-checkout-identity-unavailable"
+    if expected.dirty != "clean":
+        return "refuse:expected-checkout-dirty"
+    if expected.default_branch == "unknown" or expected.branch != expected.default_branch:
+        return "refuse:expected-checkout-not-current-main"
+    if expected.sha != expected_sha:
+        return "refuse:expected-checkout-sha-mismatch"
+    return "ready"
+
+
+def same_listener_identity(before: list[Listener], after: list[Listener]) -> bool:
+    def identity(items: list[Listener]) -> list[tuple[object, ...]]:
+        return sorted(
+            (
+                item.address,
+                item.pid,
+                item.process.lower(),
+                hashlib.sha256(item.command_raw.encode("utf-8")).hexdigest(),
+                item.executable_raw.lower(),
+                item.git.checkout,
+                item.git.sha,
+                item.git.dirty,
+                item.tasks,
+                item.classification,
+            )
+            for item in items
+        )
+
+    return identity(before) == identity(after)
+
+
+def recovery_verdict(inspection: Inspection, expected: GitInfo, expected_sha: str) -> str:
+    expected_verdict = expected_checkout_verdict(expected, expected_sha)
+    if expected_verdict != "ready":
+        return expected_verdict
+    if inspection.windows_error:
+        return "refuse:windows-inspection-unavailable"
+    if inspection.wsl_error:
+        return "refuse:wsl-inspection-unavailable"
+    if not inspection.windows:
+        return "refuse:no-windows-listener"
+    pids = {listener.pid for listener in inspection.windows}
+    if len(pids) != 1:
+        return "refuse:ambiguous-windows-ownership"
+    if any(listener.classification == "wslrelay" for listener in inspection.windows):
+        return "refuse:wslrelay-is-never-terminated"
+    if any(listener.classification != "native-windows-node-astro-dev" for listener in inspection.windows):
+        return "refuse:windows-process-is-not-proven-node-astro-dev"
+    checkouts = {listener.git.checkout for listener in inspection.windows}
+    if len(checkouts) != 1 or "unknown" in checkouts:
+        return "refuse:windows-checkout-identity-unavailable"
+    states = {source_state(listener.git, expected, expected_sha) for listener in inspection.windows}
+    if "unrelated" in states:
+        return "refuse:windows-process-is-unrelated"
+    if "unknown" in states or "canonical" in states:
+        return "refuse:windows-source-is-not-proven-stale"
+    tasks = sorted({task for listener in inspection.windows for task in listener.tasks})
+    if tasks:
+        return "refuse:active-firstmate-task-associated"
+    for listener in inspection.wsl:
+        if (
+            listener.classification != "wsl-node-astro-dev"
+            or listener.git.checkout != expected.checkout
+            or listener.git.sha != expected_sha
+            or listener.git.dirty != "clean"
+            or listener.git.source != expected.source
+        ):
+            return "refuse:wsl-port-owned-by-unexpected-process"
+    return "eligible"
+
+
+def sanitize(value: object) -> str:
+    return re.sub(r"[\t\r\n\x00-\x1f\x7f]+", " ", str(value)).strip() or "unknown"
+
+
+def emit(kind: str, **fields: object) -> str:
+    line = "\t".join([kind, *(f"{key}={sanitize(value)}" for key, value in fields.items())])
+    print(line)
+    return line
+
+
+def render_inspection(mode: str, project: Path, port: int, expected_sha: str, expected: GitInfo, inspection: Inspection) -> list[str]:
+    lines = [
+        emit("schema", value=SCHEMA),
+        emit("request", mode=mode, project=project, port=port, expected_sha=expected_sha),
+        emit(
+            "expected",
+            owner_kernel="wsl",
+            address=f"localhost:{port}",
+            pid="not-running",
+            process="project-launcher",
+            command="npm run dev -- --host 0.0.0.0 --port <port>",
+            checkout=expected.checkout,
+            checkout_windows=wsl_to_windows(project),
+            branch=expected.branch,
+            sha=expected.sha,
+            dirty=expected.dirty,
+            git_source=expected.source,
+            task_association="none",
+            recovery_verdict=expected_checkout_verdict(expected, expected_sha),
+        ),
+    ]
+    if inspection.windows_error:
+        lines.append(emit("inspection", owner_kernel="windows", status="unavailable", error=inspection.windows_error))
+    if inspection.wsl_error:
+        lines.append(emit("inspection", owner_kernel="wsl", status="unavailable", error=inspection.wsl_error))
+    for listener in [*inspection.windows, *inspection.wsl]:
+        lines.append(
+            emit(
+                "listener",
+                owner_kernel=listener.kernel,
+                address=listener.address,
+                pid=listener.pid,
+                process=listener.process,
+                command=listener.command,
+                checkout=listener.git.checkout,
+                branch=listener.git.branch,
+                sha=listener.git.sha,
+                dirty=listener.git.dirty,
+                git_source=listener.git.source,
+                task_association=",".join(listener.tasks) or "none",
+                classification=listener.classification,
+                recovery_verdict=(
+                    "never-terminate"
+                    if listener.classification == "wslrelay"
+                    else source_state(listener.git, expected, expected_sha)
+                ),
+            )
+        )
+    lines.append(emit("recovery", verdict=recovery_verdict(inspection, expected, expected_sha)))
+    return lines
+
+
+def evidence_root(state: Path) -> Path:
+    root = state / "localhost-evidence"
+    root.mkdir(mode=0o700, parents=True, exist_ok=True)
+    os.chmod(root, 0o700)
+    return root
+
+
+def write_evidence(state: Path, project: Path, port: int, pid: int, lines: list[str]) -> Path:
+    stamp = dt.datetime.now(dt.timezone.utc).strftime("%Y%m%dT%H%M%S.%fZ")
+    slug = re.sub(r"[^A-Za-z0-9_.-]+", "-", project.name)[:64] or "project"
+    path = evidence_root(state) / f"{stamp}-{slug}-{port}-{pid}.evidence"
+    content = "\n".join(["private=true", f"created_utc={stamp}", *lines, "action=terminate-exact-windows-pid"]) + "\n"
+    descriptor = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+        handle.write(content)
+        handle.flush()
+        os.fsync(handle.fileno())
+    return path
+
+
+def launcher_command(project: Path, port: int) -> list[str]:
+    package = project / "package.json"
+    try:
+        payload = json.loads(package.read_text(encoding="utf-8"))
+        script = payload["scripts"]["dev"]
+    except (OSError, KeyError, TypeError, json.JSONDecodeError) as exc:
+        raise SafeRefusal("verified Astro dev launcher is unavailable") from exc
+    try:
+        tokens = shlex.split(script) if isinstance(script, str) else []
+    except ValueError as exc:
+        raise SafeRefusal("project dev launcher is not proven to be Astro dev") from exc
+    if any(token in {";", "&&", "||", "|", ">", ">>", "<"} for token in tokens):
+        raise SafeRefusal("project dev launcher is not proven to be Astro dev")
+    command_tokens = tokens[1:] if tokens[:1] == ["npx"] else tokens
+    is_astro_dev = (
+        len(command_tokens) >= 2
+        and Path(command_tokens[0]).name in {"astro", "astro.js", "astro.mjs"}
+        and command_tokens[1] == "dev"
+    )
+    if not is_astro_dev:
+        raise SafeRefusal("project dev launcher is not proven to be Astro dev")
+    npm = shutil.which("npm")
+    if not npm:
+        raise SafeRefusal("npm is unavailable for the verified project launcher")
+    return [npm, "run", "dev", "--", "--host", "0.0.0.0", "--port", str(port)]
+
+
+def launch_expected(project: Path, port: int, evidence: Path) -> int:
+    argv = launcher_command(project, port)
+    log_path = evidence.with_suffix(".launcher.log")
+    descriptor = os.open(log_path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    log = os.fdopen(descriptor, "wb", buffering=0)
+    process = subprocess.Popen(
+        argv,
+        cwd=project,
+        stdin=subprocess.DEVNULL,
+        stdout=log,
+        stderr=subprocess.STDOUT,
+        start_new_session=True,
+        close_fds=True,
+    )
+    log.close()
+    return process.pid
+
+
+def wsl_route_fingerprint(url: str) -> dict[str, object]:
+    test_fixture = os.environ.get("FM_LOCALHOST_TEST_WSL_ROUTE_JSON")
+    if test_fixture and os.environ.get("FM_LOCALHOST_TESTING") == "1":
+        try:
+            return json.loads(Path(test_fixture).read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            raise SafeRefusal("WSL route fingerprint fixture failed") from exc
+    opener = urllib.request.build_opener(urllib.request.ProxyHandler({}))
+    request = urllib.request.Request(
+        url,
+        headers={
+            "User-Agent": "Mozilla/5.0 FirstmateLocalhost/1",
+            "Accept": "text/html,application/xhtml+xml",
+        },
+    )
+    try:
+        with opener.open(request, timeout=10) as response:
+            body = response.read(8 * 1024 * 1024 + 1)
+            if len(body) > 8 * 1024 * 1024:
+                raise SafeRefusal("WSL route response exceeds 8 MiB fingerprint bound")
+            return {"status": int(response.status), "sha256": hashlib.sha256(body).hexdigest(), "length": len(body)}
+    except SafeRefusal:
+        raise
+    except Exception as exc:  # urllib has several transport-specific exception types.
+        raise SafeRefusal("WSL route fingerprint failed") from exc
+
+
+def windows_route_fingerprint(url: str) -> dict[str, object]:
+    raw = run_powershell(ROUTE_PS, url)
+    try:
+        payload = json.loads(raw.lstrip("\ufeff").strip())
+        status = int(payload["status"])
+        sha = str(payload["sha256"])
+        length = int(payload["length"])
+    except (json.JSONDecodeError, KeyError, TypeError, ValueError) as exc:
+        raise SafeRefusal("Windows route fingerprint was invalid") from exc
+    if status < 100 or not re.fullmatch(r"[0-9a-fA-F]{64}", sha) or length < 0:
+        raise SafeRefusal("Windows route fingerprint was invalid")
+    return {"status": status, "sha256": sha.lower(), "length": length}
+
+
+def verified_pair(inspection: Inspection, expected: GitInfo, expected_sha: str) -> tuple[bool, str]:
+    if inspection.windows_error:
+        return False, "windows-inspection-unavailable"
+    if inspection.wsl_error:
+        return False, "wsl-inspection-unavailable"
+    if not inspection.windows or any(item.classification != "wslrelay" for item in inspection.windows):
+        return False, "windows-owner-is-not-wslrelay"
+    if not inspection.wsl:
+        return False, "expected-wsl-listener-missing"
+    for item in inspection.wsl:
+        if (
+            item.classification != "wsl-node-astro-dev"
+            or item.git.checkout != expected.checkout
+            or item.git.sha != expected_sha
+            or item.git.dirty != "clean"
+            or item.git.source != expected.source
+        ):
+            return False, "wsl-listener-identity-mismatch"
+    return True, "pair-proven"
+
+
+def verify(project: Path, port: int, expected_sha: str, expected: GitInfo, state: Path, *, render: bool = True) -> bool:
+    if expected_checkout_verdict(expected, expected_sha) != "ready":
+        inspection = inspect_system(port, state)
+        if render:
+            render_inspection("verify", project, port, expected_sha, expected, inspection)
+            emit("verification", verdict="refuse", reason=expected_checkout_verdict(expected, expected_sha))
+        return False
+    url = f"http://localhost:{port}/"
+    try:
+        wsl_fingerprint = wsl_route_fingerprint(url)
+        windows_fingerprint = windows_route_fingerprint(url)
+    except SafeRefusal as exc:
+        inspection = inspect_system(port, state)
+        if render:
+            render_inspection("verify", project, port, expected_sha, expected, inspection)
+            emit("verification", verdict="refuse", reason=str(exc))
+        return False
+    inspection = inspect_system(port, state)
+    pair_ok, reason = verified_pair(inspection, expected, expected_sha)
+    fingerprints_match = (
+        wsl_fingerprint == windows_fingerprint
+        and 200 <= int(wsl_fingerprint["status"]) < 400
+    )
+    if render:
+        render_inspection("verify", project, port, expected_sha, expected, inspection)
+        emit("route", origin_kernel="wsl", **wsl_fingerprint)
+        emit("route", origin_kernel="windows", **windows_fingerprint)
+        emit(
+            "verification",
+            verdict="pass" if pair_ok and fingerprints_match else "refuse",
+            reason="pair-and-route-fingerprints-match" if pair_ok and fingerprints_match else (reason if not pair_ok else "route-fingerprint-mismatch"),
+        )
+    return pair_ok and fingerprints_match
+
+
+def terminate_exact(listener: Listener, port: int) -> None:
+    if listener.classification != "native-windows-node-astro-dev" or Path(listener.process).name.lower() != "node.exe":
+        raise SafeRefusal("exact PID target is no longer a proven native Windows Astro dev server")
+    if Path(listener.process).name.lower() == "wslrelay.exe":
+        raise SafeRefusal("wslrelay.exe is never a termination target")
+    command_hash = hashlib.sha256(listener.command_raw.encode("utf-8")).hexdigest()
+    output = run_powershell(TERMINATE_PS, str(port), str(listener.pid), command_hash, timeout=20).strip()
+    if output != "terminated":
+        raise SafeRefusal("exact PID termination was not confirmed")
+
+
+def recover(project: Path, port: int, expected_sha: str, expected: GitInfo, state: Path) -> bool:
+    before = inspect_system(port, state)
+    before_lines = render_inspection("recover", project, port, expected_sha, expected, before)
+    verdict = recovery_verdict(before, expected, expected_sha)
+    if verdict != "eligible":
+        emit("recovery-result", verdict=verdict, mutated="no")
+        return False
+    target = before.windows[0]
+    launcher_command(project, port)  # Prove the only allowed restart command before mutation.
+    immediate = inspect_system(port, state)
+    immediate_verdict = recovery_verdict(immediate, expected, expected_sha)
+    if immediate_verdict != "eligible" or not same_listener_identity(before.windows, immediate.windows):
+        emit("recovery-result", verdict="refuse:pid-or-command-reresolution-changed", mutated="no")
+        return False
+    evidence_lines = [*before_lines, emit("immediate-recheck", verdict=immediate_verdict, pid=target.pid, identity="unchanged")]
+    try:
+        evidence = write_evidence(state, project, port, target.pid, evidence_lines)
+    except OSError:
+        emit("recovery-result", verdict="refuse:private-evidence-write-failed", mutated="no")
+        return False
+    try:
+        terminate_exact(immediate.windows[0], port)
+    except SafeRefusal as exc:
+        emit(
+            "recovery-result",
+            verdict=f"refuse:{str(exc)}",
+            mutated="unknown-after-exact-pid-termination-attempt",
+            evidence=evidence,
+        )
+        return False
+    post_stop = inspect_system(port, state)
+    expected_running = bool(post_stop.wsl) and all(
+        item.classification == "wsl-node-astro-dev"
+        and item.git.checkout == expected.checkout
+        and item.git.sha == expected_sha
+        and item.git.dirty == "clean"
+        and item.git.source == expected.source
+        for item in post_stop.wsl
+    )
+    launcher_pid: int | str = "already-running"
+    if not expected_running:
+        try:
+            launcher_pid = launch_expected(project, port, evidence)
+        except (OSError, SafeRefusal) as exc:
+            emit("recovery-result", verdict=f"failed:{str(exc)}", mutated="windows-pid-terminated", evidence=evidence)
+            return False
+    timeout = os.environ.get("FM_LOCALHOST_START_TIMEOUT", "20")
+    try:
+        timeout_seconds = max(1, min(120, int(timeout)))
+    except ValueError:
+        timeout_seconds = 20
+    deadline = time.monotonic() + timeout_seconds
+    while time.monotonic() < deadline:
+        if verify(project, port, expected_sha, expected, state, render=False):
+            final = inspect_system(port, state)
+            render_inspection("recover-post-verify", project, port, expected_sha, expected, final)
+            emit(
+                "recovery-result",
+                verdict="recovered-and-verified",
+                mutated=f"terminated-exact-pid:{target.pid}",
+                launcher_pid=launcher_pid,
+                evidence=evidence,
+            )
+            return True
+        time.sleep(0.2)
+    verify(project, port, expected_sha, expected, state, render=True)
+    emit(
+        "recovery-result",
+        verdict="failed:post-recovery-verification",
+        mutated=f"terminated-exact-pid:{target.pid}",
+        launcher_pid=launcher_pid,
+        evidence=evidence,
+    )
+    return False
+
+
+def parser() -> argparse.ArgumentParser:
+    description = "Inspect or narrowly recover localhost ownership across native Windows and WSL."
+    epilog = """mechanics (authoritative):
+  The tuple is <project> <port> <expected-sha>. <project> must be the intended
+  clean WSL default-branch checkout, and <expected-sha> must be its full 40-hex
+  canonical commit. inspect reports every Windows and WSL listener with owner
+  kernel, address, PID, process, redacted command, checkout, branch, SHA, dirty
+  state, normalized Git source, task association, classification, and recovery
+  verdict. It reads Windows listeners and process identity through fixed
+  non-interactive PowerShell, WSL listeners through ss and /proc, and task
+  associations from this Firstmate home's state/*.meta. It never reads a
+  process environment, credentials, production data, or hosted data.
+
+  recover is deliberately narrower than inspect. It may stop exactly one PID
+  only after two complete observations independently prove that the same PID
+  still owns every native-Windows binding of the reserved port; the unchanged
+  process is node.exe running `astro ... dev`; its command path resolves to a
+  checkout of the same normalized Git source; that checkout is dirty,
+  divergent, or otherwise noncanonical; no task record names that checkout or
+  PID; WSL has no unrelated port owner; and the requested replacement is clean,
+  on the repository default branch, at expected-sha. Unknown commands, changed
+  PIDs or commands, multiple Windows owners, unrelated sources, task records,
+  missing identity, Windows inspection failure, canonical Windows source,
+  production-like commands, and every wslrelay.exe owner refuse recovery.
+  Recovery never kills by process name or port and never targets wslrelay.exe.
+
+  Immediately before mutation, recover re-resolves listener, PID, command,
+  checkout, Git, and task evidence. It writes a mode-0600 record beneath
+  $FM_HOME/state/localhost-evidence before invoking fixed PowerShell that again
+  requires the exact PID, port, node.exe identity, unchanged command hash, and
+  Astro dev classification. After the exact PID exits, it runs only the
+  project's package.json `scripts.dev` when that script is proven to be Astro,
+  using `npm run dev -- --host 0.0.0.0 --port <port>`; an already-running
+  expected WSL server is reused rather than duplicated.
+
+  verify sends the same bounded browser-like request to http://localhost:<port>/
+  from WSL and native Windows, compares status/body-length/SHA-256 fingerprints,
+  and passes only when Windows reports wslrelay.exe, WSL reports the clean
+  expected Astro server, and both route fingerprints match. A nonzero exit means
+  inspection, recovery, or verification did not prove the requested safe state.
+"""
+    result = argparse.ArgumentParser(
+        prog="fm-localhost.py",
+        description=description,
+        epilog=epilog,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    result.add_argument("mode", choices=("inspect", "recover", "verify"))
+    result.add_argument("project")
+    result.add_argument("port", type=int)
+    result.add_argument("expected_sha")
+    return result
+
+
+def main() -> int:
+    args = parser().parse_args()
+    project = Path(args.project).resolve()
+    if not project.is_dir():
+        print("fm-localhost: project must be an existing directory", file=sys.stderr)
+        return 2
+    if not 1 <= args.port <= 65535:
+        print("fm-localhost: port must be between 1 and 65535", file=sys.stderr)
+        return 2
+    if not re.fullmatch(r"[0-9a-fA-F]{40}", args.expected_sha):
+        print("fm-localhost: expected-sha must be a full 40-hex commit", file=sys.stderr)
+        return 2
+    expected_sha = args.expected_sha.lower()
+    expected = git_info(project)
+    root = Path(__file__).resolve().parent.parent
+    home = Path(os.environ.get("FM_HOME", os.environ.get("FM_ROOT_OVERRIDE", str(root)))).resolve()
+    state = Path(os.environ.get("FM_STATE_OVERRIDE", str(home / "state"))).resolve()
+    if args.mode == "inspect":
+        inspection = inspect_system(args.port, state)
+        render_inspection("inspect", project, args.port, expected_sha, expected, inspection)
+        return 1 if inspection.windows_error or inspection.wsl_error else 0
+    if args.mode == "verify":
+        return 0 if verify(project, args.port, expected_sha, expected, state) else 1
+    return 0 if recover(project, args.port, expected_sha, expected, state) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/bin/fm-localhost.py
+++ b/bin/fm-localhost.py
@@ -150,6 +150,55 @@ class SafeRefusal(RuntimeError):
     pass
 
 
+class TaskStateBoundary:
+    def __init__(self, state: Path):
+        self.state = state
+        self.process: subprocess.Popen[str] | None = None
+
+    def __enter__(self) -> "TaskStateBoundary":
+        if not self.state.is_dir():
+            raise SafeRefusal("firstmate-task-state-inspection-unavailable")
+        helper = Path(__file__).resolve().with_name("fm-task-state-lock.sh")
+        try:
+            self.process = subprocess.Popen(
+                ["bash", str(helper), str(self.state)],
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.DEVNULL,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+            )
+            ready = self.process.stdout.readline().strip() if self.process.stdout else ""
+        except OSError as exc:
+            self.close()
+            raise SafeRefusal("Firstmate task-state boundary unavailable") from exc
+        if ready != "locked":
+            self.close()
+            raise SafeRefusal("Firstmate task-state boundary unavailable")
+        return self
+
+    def close(self) -> None:
+        if self.process is None:
+            return
+        if self.process.stdin:
+            try:
+                self.process.stdin.close()
+            except OSError:
+                pass
+        try:
+            self.process.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            self.process.kill()
+            self.process.wait()
+        if self.process.stdout:
+            self.process.stdout.close()
+        self.process = None
+
+    def __exit__(self, exc_type: object, exc_value: object, traceback: object) -> None:
+        self.close()
+
+
 def command_output(argv: list[str], *, cwd: Path | None = None, timeout: float = 15) -> str:
     completed = subprocess.run(
         argv,
@@ -356,7 +405,7 @@ def classify_windows(process: str, command: str, executable: str, checkout: str 
     lower_name = Path(process).name.lower()
     lower_executable = re.split(r"[\\/]", executable)[-1].lower() if executable else ""
     lower_command = command.lower()
-    if lower_name == "wslrelay.exe":
+    if canonical_wslrelay_identity(process, executable):
         return "wslrelay"
     if not command.strip():
         return "unknown-command"
@@ -616,6 +665,37 @@ def same_listener_identity(before: list[Listener], after: list[Listener]) -> boo
         )
 
     return identity(before) == identity(after)
+
+
+def listener_owner_identity(listener: Listener) -> tuple[object, ...]:
+    return (
+        listener.pid,
+        listener.process.casefold(),
+        listener.command_raw,
+        listener.executable_raw.casefold(),
+        listener.git.checkout,
+        listener.git.branch,
+        listener.git.sha,
+        listener.git.dirty,
+        listener.git.source,
+        listener.tasks,
+        listener.classification,
+    )
+
+
+def consistent_listener_owner(listeners: list[Listener]) -> list[Listener] | None:
+    if not listeners or len({listener.pid for listener in listeners}) != 1:
+        return None
+    identities = {listener_owner_identity(listener) for listener in listeners}
+    return listeners if len(identities) == 1 else None
+
+
+def canonical_wslrelay_identity(process: str, executable: str) -> bool:
+    process_name = Path(process).name.casefold()
+    normalized = executable.strip().replace("/", "\\")
+    return process_name == "wslrelay.exe" and bool(
+        re.fullmatch(r"[A-Za-z]:\\(?:[^\\/:*?\"<>|\r\n]+\\)+wslrelay\.exe", normalized, re.IGNORECASE)
+    )
 
 
 def recovery_verdict(inspection: Inspection, expected: GitInfo, expected_sha: str) -> str:
@@ -880,11 +960,17 @@ def verified_pair(inspection: Inspection, expected: GitInfo, expected_sha: str) 
         return False, "windows-inspection-unavailable"
     if inspection.wsl_error:
         return False, "wsl-inspection-unavailable"
-    if len(inspection.windows) != 1 or inspection.windows[0].classification != "wslrelay":
+    windows = consistent_listener_owner(inspection.windows)
+    if windows is None or any(not canonical_wslrelay_identity(item.process, item.executable_raw) for item in windows):
         return False, "windows-owner-is-not-wslrelay"
-    if len(inspection.wsl) != 1:
+    wsl = consistent_listener_owner(inspection.wsl)
+    if wsl is None:
+        if not inspection.wsl:
+            return False, "expected-wsl-listener-missing"
+        return False, "wsl-listener-identity-mismatch"
+    if not wsl:
         return False, "expected-wsl-listener-missing"
-    item = inspection.wsl[0]
+    item = wsl[0]
     if (
         item.classification != "wsl-node-astro-dev"
         or item.git.checkout != expected.checkout
@@ -906,7 +992,10 @@ def post_stop_restart_verdict(inspection: Inspection, expected: GitInfo, expecte
     if inspection.wsl:
         pair_ok, reason = verified_pair(inspection, expected, expected_sha)
         return "already-verified" if pair_ok else f"refuse:post-stop-reserved-port-not-safe:{reason}"
-    if len(inspection.windows) > 1 or any(item.classification != "wslrelay" for item in inspection.windows):
+    windows = consistent_listener_owner(inspection.windows)
+    if inspection.windows and (
+        windows is None or any(not canonical_wslrelay_identity(item.process, item.executable_raw) for item in windows)
+    ):
         return "refuse:post-stop-reserved-port-not-safe:windows-owner-is-not-wslrelay"
     return "restart-safe"
 
@@ -963,9 +1052,10 @@ def termination_boundary_listener(
     boundary = inspect_system(port, state)
     if recovery_verdict(boundary, expected, expected_sha) != "eligible":
         raise SafeRefusal("pid-or-command-reresolution-changed")
-    if len(boundary.windows) != 1 or not same_listener_identity([listener], boundary.windows):
+    boundary_windows = consistent_listener_owner(boundary.windows)
+    if boundary_windows is None or any(listener_owner_identity(item) != listener_owner_identity(listener) for item in boundary_windows):
         raise SafeRefusal("pid-or-command-reresolution-changed")
-    return boundary.windows[0]
+    return boundary_windows[0]
 
 
 def terminate_exact(listener: Listener, port: int, expected: GitInfo, expected_sha: str, state: Path) -> None:
@@ -988,7 +1078,7 @@ def terminate_exact(listener: Listener, port: int, expected: GitInfo, expected_s
         raise SafeRefusal("exact PID termination was not confirmed")
 
 
-def recover(project: Path, port: int, expected_sha: str, expected: GitInfo, state: Path) -> bool:
+def recover_locked(project: Path, port: int, expected_sha: str, expected: GitInfo, state: Path) -> bool:
     before = inspect_system(port, state)
     before_lines = render_inspection("recover", project, port, expected_sha, expected, before)
     verdict = recovery_verdict(before, expected, expected_sha)
@@ -1082,6 +1172,15 @@ def recover(project: Path, port: int, expected_sha: str, expected: GitInfo, stat
     return False
 
 
+def recover(project: Path, port: int, expected_sha: str, expected: GitInfo, state: Path) -> bool:
+    try:
+        with TaskStateBoundary(state):
+            return recover_locked(project, port, expected_sha, expected, state)
+    except SafeRefusal as exc:
+        emit("recovery-result", verdict=f"refuse:{str(exc)}", mutated="no")
+        return False
+
+
 def parser() -> argparse.ArgumentParser:
     description = "Inspect or narrowly recover localhost ownership across native Windows and WSL."
     epilog = """mechanics (authoritative):
@@ -1112,7 +1211,9 @@ def parser() -> argparse.ArgumentParser:
 
   Immediately before mutation, recover re-resolves listener, PID, command,
   checkout, Git, and task evidence. The termination boundary repeats that
-  complete proof after the evidence is fsynced. It writes a mode-0600 record beneath
+  complete proof after the evidence is fsynced while holding the shared
+  Firstmate task-state publication boundary; task creation and metadata
+  publication use that same boundary. It writes a mode-0600 record beneath
   $FM_HOME/state/localhost-evidence before invoking fixed PowerShell that again
   requires the exact PID, port, node.exe identity, unchanged command hash, and
   exact Astro script path followed by `dev`. After the exact PID exits, it
@@ -1161,7 +1262,7 @@ def main() -> int:
     if args.mode == "inspect":
         inspection = inspect_system(args.port, state)
         render_inspection("inspect", project, args.port, expected_sha, expected, inspection)
-        return 1 if inspection.windows_error or inspection.wsl_error else 0
+        return 1 if inspection.task_error or inspection.windows_error or inspection.wsl_error else 0
     if args.mode == "verify":
         return 0 if verify(project, args.port, expected_sha, expected, state) else 1
     return 0 if recover(project, args.port, expected_sha, expected, state) else 1

--- a/bin/fm-localhost.py
+++ b/bin/fm-localhost.py
@@ -16,6 +16,7 @@ import json
 import os
 from pathlib import Path
 import re
+import select
 import signal
 import shlex
 import shutil
@@ -159,9 +160,15 @@ class TaskStateBoundary:
         if not self.state.is_dir():
             raise SafeRefusal("firstmate-task-state-inspection-unavailable")
         helper = Path(__file__).resolve().with_name("fm-task-state-lock.sh")
+        attempts = 50
+        if os.environ.get("FM_LOCALHOST_TESTING") == "1":
+            try:
+                attempts = max(1, min(50, int(os.environ.get("FM_LOCALHOST_TEST_LOCK_ATTEMPTS", "50"))))
+            except ValueError:
+                attempts = 50
         try:
             self.process = subprocess.Popen(
-                ["bash", str(helper), str(self.state)],
+                ["bash", str(helper), str(self.state), str(attempts)],
                 stdin=subprocess.PIPE,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.DEVNULL,
@@ -169,13 +176,17 @@ class TaskStateBoundary:
                 encoding="utf-8",
                 errors="replace",
             )
-            ready = self.process.stdout.readline().strip() if self.process.stdout else ""
+            if self.process.stdout is None:
+                raise OSError("task-state boundary stdout is unavailable")
+            readable, _, _ = select.select([self.process.stdout], [], [], attempts * 0.1 + 1)
+            ready = self.process.stdout.readline().strip() if readable else ""
         except OSError as exc:
             self.close()
             raise SafeRefusal("Firstmate task-state boundary unavailable") from exc
         if ready != "locked":
             self.close()
-            raise SafeRefusal("Firstmate task-state boundary unavailable")
+            reason = "firstmate-task-state-boundary-timeout" if ready in {"", "timeout"} else "firstmate-task-state-boundary-unavailable"
+            raise SafeRefusal(reason)
         return self
 
     def close(self) -> None:
@@ -693,9 +704,22 @@ def consistent_listener_owner(listeners: list[Listener]) -> list[Listener] | Non
 def canonical_wslrelay_identity(process: str, executable: str) -> bool:
     process_name = Path(process).name.casefold()
     normalized = executable.strip().replace("/", "\\")
-    return process_name == "wslrelay.exe" and bool(
-        re.fullmatch(r"[A-Za-z]:\\(?:[^\\/:*?\"<>|\r\n]+\\)+wslrelay\.exe", normalized, re.IGNORECASE)
+    return process_name == "wslrelay.exe" and normalized.casefold() == r"c:\windows\system32\wslrelay.exe"
+
+
+def expected_wsl_listener_identity(listener: Listener, expected: GitInfo, expected_sha: str) -> bool:
+    return (
+        listener.classification == "wsl-node-astro-dev"
+        and listener.git.checkout == expected.checkout
+        and listener.git.branch == expected.default_branch
+        and listener.git.sha == expected_sha
+        and listener.git.dirty == "clean"
+        and listener.git.source == expected.source
     )
+
+
+def associated_tasks(*listener_groups: list[Listener]) -> list[str]:
+    return sorted({task for listeners in listener_groups for listener in listeners for task in listener.tasks})
 
 
 def recovery_verdict(inspection: Inspection, expected: GitInfo, expected_sha: str) -> str:
@@ -725,17 +749,13 @@ def recovery_verdict(inspection: Inspection, expected: GitInfo, expected_sha: st
         return "refuse:windows-process-is-unrelated"
     if "unknown" in states or "canonical" in states:
         return "refuse:windows-source-is-not-proven-stale"
-    tasks = sorted({task for listener in inspection.windows for task in listener.tasks})
-    if tasks:
+    if associated_tasks(inspection.windows, inspection.wsl):
         return "refuse:active-firstmate-task-associated"
-    for listener in inspection.wsl:
-        if (
-            listener.classification != "wsl-node-astro-dev"
-            or listener.git.checkout != expected.checkout
-            or listener.git.sha != expected_sha
-            or listener.git.dirty != "clean"
-            or listener.git.source != expected.source
-        ):
+    wsl = consistent_listener_owner(inspection.wsl) if inspection.wsl else []
+    if inspection.wsl and wsl is None:
+        return "refuse:ambiguous-wsl-ownership"
+    for listener in wsl or []:
+        if not expected_wsl_listener_identity(listener, expected, expected_sha):
             return "refuse:wsl-port-owned-by-unexpected-process"
     return "eligible"
 
@@ -960,6 +980,8 @@ def verified_pair(inspection: Inspection, expected: GitInfo, expected_sha: str) 
         return False, "windows-inspection-unavailable"
     if inspection.wsl_error:
         return False, "wsl-inspection-unavailable"
+    if associated_tasks(inspection.windows, inspection.wsl):
+        return False, "active-firstmate-task-associated"
     windows = consistent_listener_owner(inspection.windows)
     if windows is None or any(not canonical_wslrelay_identity(item.process, item.executable_raw) for item in windows):
         return False, "windows-owner-is-not-wslrelay"
@@ -970,14 +992,7 @@ def verified_pair(inspection: Inspection, expected: GitInfo, expected_sha: str) 
         return False, "wsl-listener-identity-mismatch"
     if not wsl:
         return False, "expected-wsl-listener-missing"
-    item = wsl[0]
-    if (
-        item.classification != "wsl-node-astro-dev"
-        or item.git.checkout != expected.checkout
-        or item.git.sha != expected_sha
-        or item.git.dirty != "clean"
-        or item.git.source != expected.source
-    ):
+    if any(not expected_wsl_listener_identity(item, expected, expected_sha) for item in wsl):
         return False, "wsl-listener-identity-mismatch"
     return True, "pair-proven"
 
@@ -1202,18 +1217,21 @@ def parser() -> argparse.ArgumentParser:
   node_modules/astro/astro.js or astro.mjs and is followed immediately by `dev`;
   that checkout is dirty,
   divergent, or otherwise noncanonical; no task record names that checkout or
-  PID; WSL has no unrelated port owner; and the requested replacement is clean,
-  on the repository default branch, at expected-sha. Unknown commands, changed
-  PIDs or commands, multiple Windows owners, unrelated sources, task records,
-  missing identity, Windows inspection failure, canonical Windows source,
-  production-like commands, and every wslrelay.exe owner refuse recovery.
+  PID for either kernel; every existing WSL binding has one consistent task-free
+  owner at the requested checkout, repository default branch, source, and SHA;
+  and the requested replacement is clean, on that branch, at expected-sha.
+  Unknown commands, changed PIDs or commands, distinct Windows or WSL owners,
+  unrelated sources, task records, missing identity, Windows inspection failure,
+  canonical Windows source, production-like commands, and every wslrelay.exe
+  owner refuse recovery.
   Recovery never kills by process name or port and never targets wslrelay.exe.
 
   Immediately before mutation, recover re-resolves listener, PID, command,
   checkout, Git, and task evidence. The termination boundary repeats that
-  complete proof after the evidence is fsynced while holding the shared
-  Firstmate task-state publication boundary; task creation and metadata
-  publication use that same boundary. It writes a mode-0600 record beneath
+  complete proof after the evidence is fsynced while holding the shared,
+  bounded-wait Firstmate task-state publication boundary; task creation and
+  metadata publication use that same boundary. Lock contention refuses without
+  mutation. It writes a mode-0600 record beneath
   $FM_HOME/state/localhost-evidence before invoking fixed PowerShell that again
   requires the exact PID, port, node.exe identity, unchanged command hash, and
   exact Astro script path followed by `dev`. After the exact PID exits, it
@@ -1225,8 +1243,9 @@ def parser() -> argparse.ArgumentParser:
   verify sends the same bounded browser-like request to http://localhost:<port>/
   from WSL and native Windows, compares status/body-length/SHA-256 fingerprints,
   then repeats the listener-pair inspection. It passes only when Windows reports
-  wslrelay.exe, WSL reports the clean expected Astro server, and both route
-  fingerprints match the post-route pair. A nonzero exit means
+  wslrelay.exe at C:\\Windows\\System32\\wslrelay.exe, WSL reports one consistent,
+  task-free clean expected Astro owner on the repository default branch, and both
+  route fingerprints match the post-route pair. A nonzero exit means
   inspection, recovery, or verification did not prove the requested safe state.
 """
     result = argparse.ArgumentParser(

--- a/bin/fm-localhost.py
+++ b/bin/fm-localhost.py
@@ -16,6 +16,7 @@ import json
 import os
 from pathlib import Path
 import re
+import signal
 import shlex
 import shutil
 import subprocess
@@ -53,6 +54,7 @@ $OutputEncoding = [Console]::OutputEncoding = [System.Text.UTF8Encoding]::new($f
 $Port = [int]$args[0]
 $PidToStop = [int]$args[1]
 $ExpectedCommandHash = [string]$args[2]
+$ExpectedAstroScript = [string]$args[3]
 $Connections = @(Get-NetTCPConnection -State Listen -ErrorAction Stop | Where-Object { [int]$_.LocalPort -eq $Port })
 if ($Connections.Count -lt 1) { throw 'reserved port has no Windows listener' }
 foreach ($Connection in $Connections) {
@@ -66,7 +68,11 @@ if ([string]::IsNullOrWhiteSpace($Command)) { throw 'target command is unavailab
 $Bytes = [Text.Encoding]::UTF8.GetBytes($Command)
 $Hash = ([BitConverter]::ToString([Security.Cryptography.SHA256]::Create().ComputeHash($Bytes))).Replace('-', '').ToLowerInvariant()
 if ($Hash -ne $ExpectedCommandHash) { throw 'target command changed' }
-if ($Command -notmatch '(?i)astro' -or $Command -notmatch '(?i)(^|\s)dev(\s|$)') { throw 'target is not an Astro development server' }
+$NormalizedCommand = $Command.Replace('\', '/')
+$NormalizedScript = $ExpectedAstroScript.Replace('\', '/')
+$NodePattern = '(?i)^\s*(?:"[^"]*/node\.exe"|(?:[^"\s]+/)?node\.exe)\s+'
+$AstroDevPattern = $NodePattern + '"?' + [regex]::Escape($NormalizedScript) + '"?\s+dev(?:\s|$)'
+if ($NormalizedCommand -notmatch $AstroDevPattern) { throw 'target is not the verified Astro development launcher' }
 if ($Command -match '(?i)(^|\s)(preview|build)(\s|$)' -or $Command -match '(?i)(node_env\s*=\s*production|--mode(?:=|\s+)production)') { throw 'target looks production-like' }
 Stop-Process -Id $PidToStop -ErrorAction Stop
 for ($i = 0; $i -lt 100; $i++) {
@@ -131,6 +137,12 @@ class Inspection:
     wsl: list[Listener]
     windows_error: str = ""
     wsl_error: str = ""
+
+
+@dataclasses.dataclass(frozen=True)
+class OwnedLaunch:
+    process: subprocess.Popen
+    pgid: int
 
 
 class SafeRefusal(RuntimeError):
@@ -264,12 +276,48 @@ def redact_command(raw: str) -> str:
     sensitive = r"(?:token|secret|password|passwd|api[-_]?key|authorization|credential|cookie|session)"
     value = re.sub(rf"(?i)({sensitive}\s*=\s*)(?:\"[^\"]*\"|'[^']*'|[^\s]+)", r"\1<redacted>", value)
     value = re.sub(rf"(?i)(--?{sensitive}(?:=|\s+))(?:\"[^\"]*\"|'[^']*'|[^\s]+)", r"\1<redacted>", value)
+    value = re.sub(
+        rf'''(?i)(["']?{sensitive}["']?\s*:\s*)("(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|[^,\s}}]+)''',
+        r"\1<redacted>",
+        value,
+    )
     value = re.sub(r"(?i)(bearer\s+)[A-Za-z0-9._~+/=-]+", r"\1<redacted>", value)
     value = re.sub(r"(?i)\{?[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\}?", "<redacted-id>", value)
     value = re.sub(r"\b[A-Za-z0-9_-]{48,}\b", "<redacted>", value)
     if len(value) > 512:
         value = value[:500] + " <truncated>"
     return value
+
+
+def command_tokens(raw: str) -> list[str]:
+    if not raw or raw.count('"') % 2:
+        return []
+    return [
+        match.group(1) if match.group(1) is not None else match.group(2)
+        for match in re.finditer(r'"([^"]*)"|([^\s]+)', raw)
+    ]
+
+
+def astro_dev_script(command: str, executable: str, checkout: str) -> Path | None:
+    tokens = command_tokens(command)
+    executable_name = re.split(r"[\\/]", executable)[-1].lower() if executable else ""
+    first_name = re.split(r"[\\/]", tokens[0])[-1].lower() if tokens else ""
+    if len(tokens) < 3 or first_name not in {"node", "node.exe"} or (executable and executable_name != "node.exe"):
+        return None
+    script = windows_to_wsl(tokens[1])
+    if script is None or checkout == "unknown":
+        return None
+    try:
+        script = script.resolve(strict=True)
+        relative = script.relative_to(Path(checkout).resolve())
+    except (OSError, ValueError):
+        return None
+    parts = tuple(part.casefold() for part in relative.parts)
+    if parts[:2] != ("node_modules", "astro") or parts[2:] not in (("astro.js",), ("astro.mjs",)):
+        return None
+    if tokens[2].casefold() != "dev":
+        return None
+    return script
 
 
 def command_paths(command: str, executable: str) -> list[Path]:
@@ -303,7 +351,7 @@ def checkout_from_windows_command(command: str, executable: str) -> Path | None:
     return next(iter(found)) if len(found) == 1 else None
 
 
-def classify_windows(process: str, command: str, executable: str) -> str:
+def classify_windows(process: str, command: str, executable: str, checkout: str = "unknown") -> str:
     lower_name = Path(process).name.lower()
     lower_executable = re.split(r"[\\/]", executable)[-1].lower() if executable else ""
     lower_command = command.lower()
@@ -317,14 +365,13 @@ def classify_windows(process: str, command: str, executable: str) -> str:
         r"node_env\s*=\s*production|--mode(?:=|\s+)production", lower_command
     ):
         return "production-like"
-    if "astro" in lower_command and re.search(r"(?:^|\s)dev(?:\s|$)", lower_command):
+    if astro_dev_script(command, executable, checkout):
         return "native-windows-node-astro-dev"
     return "unknown-node"
 
 
-def classify_wsl(process: str, command: str) -> str:
-    lower = command.lower()
-    if Path(process).name.lower() in {"node", "nodejs"} and "astro" in lower and re.search(r"(?:^|\s)dev(?:\s|$)", lower):
+def classify_wsl(process: str, command: str, checkout: str = "unknown") -> str:
+    if Path(process).name.lower() in {"node", "nodejs"} and astro_dev_script(command, "", checkout):
         return "wsl-node-astro-dev"
     return "unknown-wsl-process"
 
@@ -385,6 +432,8 @@ def run_powershell(script: str, *args: str, timeout: float = 20) -> str:
         )
     except subprocess.TimeoutExpired as exc:
         raise SafeRefusal("Windows inspection timed out") from exc
+    except OSError as exc:
+        raise SafeRefusal("Windows inspection unavailable") from exc
     except SafeRefusal as exc:
         if str(exc) == "Windows inspection unavailable":
             raise
@@ -428,7 +477,7 @@ def windows_listeners(port: int, state: Path) -> list[Listener]:
                 executable_raw=executable,
                 git=info,
                 tasks=task_associations(state, info.checkout, pid),
-                classification=classify_windows(process, command, executable),
+                classification=classify_windows(process, command, executable, info.checkout),
             )
         )
     return listeners
@@ -444,8 +493,8 @@ def proc_root() -> Path:
 def wsl_listeners(port: int, state: Path) -> list[Listener]:
     try:
         output = command_output(["ss", "-H", "-ltnp", f"sport = :{port}"])
-    except (SafeRefusal, subprocess.TimeoutExpired) as exc:
-        raise SafeRefusal("WSL listener inspection failed") from exc
+    except (OSError, SafeRefusal, subprocess.TimeoutExpired) as exc:
+        raise SafeRefusal("WSL listener inspection unavailable") from exc
     found: dict[tuple[int, str], tuple[str, str]] = {}
     for line in output.splitlines():
         address_match = re.search(r"\s([^\s]+:%s)\s" % port, line)
@@ -480,7 +529,7 @@ def wsl_listeners(port: int, state: Path) -> list[Listener]:
                 executable_raw="",
                 git=info,
                 tasks=task_associations(state, info.checkout, pid),
-                classification=classify_wsl(process, command_raw),
+                classification=classify_wsl(process, command_raw, info.checkout),
             )
         )
     return listeners
@@ -492,10 +541,14 @@ def inspect_system(port: int, state: Path) -> Inspection:
         result.windows = windows_listeners(port, state)
     except SafeRefusal as exc:
         result.windows_error = str(exc)
+    except OSError:
+        result.windows_error = "Windows inspection unavailable"
     try:
         result.wsl = wsl_listeners(port, state)
     except SafeRefusal as exc:
         result.wsl_error = str(exc)
+    except OSError:
+        result.wsl_error = "WSL listener inspection unavailable"
     return result
 
 
@@ -679,7 +732,7 @@ def launcher_command(project: Path, port: int) -> list[str]:
         tokens = shlex.split(script) if isinstance(script, str) else []
     except ValueError as exc:
         raise SafeRefusal("project dev launcher is not proven to be Astro dev") from exc
-    if any(token in {";", "&&", "||", "|", ">", ">>", "<"} for token in tokens):
+    if not isinstance(script, str) or re.search(r"[\x00-\x1f\x7f;&|<>$`\\]", script):
         raise SafeRefusal("project dev launcher is not proven to be Astro dev")
     command_tokens = tokens[1:] if tokens[:1] == ["npx"] else tokens
     is_astro_dev = (
@@ -695,22 +748,49 @@ def launcher_command(project: Path, port: int) -> list[str]:
     return [npm, "run", "dev", "--", "--host", "0.0.0.0", "--port", str(port)]
 
 
-def launch_expected(project: Path, port: int, evidence: Path) -> int:
+def launch_expected(project: Path, port: int, evidence: Path) -> OwnedLaunch:
     argv = launcher_command(project, port)
     log_path = evidence.with_suffix(".launcher.log")
     descriptor = os.open(log_path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
     log = os.fdopen(descriptor, "wb", buffering=0)
-    process = subprocess.Popen(
-        argv,
-        cwd=project,
-        stdin=subprocess.DEVNULL,
-        stdout=log,
-        stderr=subprocess.STDOUT,
-        start_new_session=True,
-        close_fds=True,
-    )
-    log.close()
-    return process.pid
+    try:
+        process = subprocess.Popen(
+            argv,
+            cwd=project,
+            stdin=subprocess.DEVNULL,
+            stdout=log,
+            stderr=subprocess.STDOUT,
+            start_new_session=True,
+            close_fds=True,
+        )
+    finally:
+        log.close()
+    try:
+        pgid = os.getpgid(process.pid)
+    except OSError:
+        process.kill()
+        process.wait()
+        raise
+    if pgid != process.pid:
+        process.kill()
+        process.wait()
+        raise SafeRefusal("owned launcher process group was not isolated")
+    return OwnedLaunch(process=process, pgid=pgid)
+
+
+def cleanup_owned_launch(launch: OwnedLaunch) -> None:
+    try:
+        os.killpg(launch.pgid, signal.SIGTERM)
+    except (OSError, ProcessLookupError):
+        return
+    try:
+        launch.process.wait(timeout=2)
+    except subprocess.TimeoutExpired:
+        pass
+    try:
+        os.killpg(launch.pgid, signal.SIGKILL)
+    except (OSError, ProcessLookupError):
+        pass
 
 
 def wsl_route_fingerprint(url: str) -> dict[str, object]:
@@ -759,20 +839,33 @@ def verified_pair(inspection: Inspection, expected: GitInfo, expected_sha: str) 
         return False, "windows-inspection-unavailable"
     if inspection.wsl_error:
         return False, "wsl-inspection-unavailable"
-    if not inspection.windows or any(item.classification != "wslrelay" for item in inspection.windows):
+    if len(inspection.windows) != 1 or inspection.windows[0].classification != "wslrelay":
         return False, "windows-owner-is-not-wslrelay"
-    if not inspection.wsl:
+    if len(inspection.wsl) != 1:
         return False, "expected-wsl-listener-missing"
-    for item in inspection.wsl:
-        if (
-            item.classification != "wsl-node-astro-dev"
-            or item.git.checkout != expected.checkout
-            or item.git.sha != expected_sha
-            or item.git.dirty != "clean"
-            or item.git.source != expected.source
-        ):
-            return False, "wsl-listener-identity-mismatch"
+    item = inspection.wsl[0]
+    if (
+        item.classification != "wsl-node-astro-dev"
+        or item.git.checkout != expected.checkout
+        or item.git.sha != expected_sha
+        or item.git.dirty != "clean"
+        or item.git.source != expected.source
+    ):
+        return False, "wsl-listener-identity-mismatch"
     return True, "pair-proven"
+
+
+def post_stop_restart_verdict(inspection: Inspection, expected: GitInfo, expected_sha: str) -> str:
+    if inspection.windows_error:
+        return "refuse:windows-inspection-unavailable"
+    if inspection.wsl_error:
+        return "refuse:wsl-inspection-unavailable"
+    if inspection.wsl:
+        pair_ok, reason = verified_pair(inspection, expected, expected_sha)
+        return "already-verified" if pair_ok else f"refuse:post-stop-reserved-port-not-safe:{reason}"
+    if len(inspection.windows) > 1 or any(item.classification != "wslrelay" for item in inspection.windows):
+        return "refuse:post-stop-reserved-port-not-safe:windows-owner-is-not-wslrelay"
+    return "restart-safe"
 
 
 def verify(project: Path, port: int, expected_sha: str, expected: GitInfo, state: Path, *, render: bool = True) -> bool:
@@ -782,18 +875,22 @@ def verify(project: Path, port: int, expected_sha: str, expected: GitInfo, state
             render_inspection("verify", project, port, expected_sha, expected, inspection)
             emit("verification", verdict="refuse", reason=expected_checkout_verdict(expected, expected_sha))
         return False
+    inspection = inspect_system(port, state)
+    pair_ok, reason = verified_pair(inspection, expected, expected_sha)
+    if not pair_ok:
+        if render:
+            render_inspection("verify", project, port, expected_sha, expected, inspection)
+            emit("verification", verdict="refuse", reason=reason)
+        return False
     url = f"http://localhost:{port}/"
     try:
         wsl_fingerprint = wsl_route_fingerprint(url)
         windows_fingerprint = windows_route_fingerprint(url)
     except SafeRefusal as exc:
-        inspection = inspect_system(port, state)
         if render:
             render_inspection("verify", project, port, expected_sha, expected, inspection)
             emit("verification", verdict="refuse", reason=str(exc))
         return False
-    inspection = inspect_system(port, state)
-    pair_ok, reason = verified_pair(inspection, expected, expected_sha)
     fingerprints_match = (
         wsl_fingerprint == windows_fingerprint
         and 200 <= int(wsl_fingerprint["status"]) < 400
@@ -815,8 +912,16 @@ def terminate_exact(listener: Listener, port: int) -> None:
         raise SafeRefusal("exact PID target is no longer a proven native Windows Astro dev server")
     if Path(listener.process).name.lower() == "wslrelay.exe":
         raise SafeRefusal("wslrelay.exe is never a termination target")
+    if listener.git.checkout == "unknown":
+        raise SafeRefusal("exact PID target checkout is unavailable")
+    astro_script = astro_dev_script(listener.command_raw, listener.executable_raw, listener.git.checkout)
+    if astro_script is None:
+        raise SafeRefusal("exact PID target Astro script path is unavailable")
+    expected_script = wsl_to_windows(astro_script)
+    if expected_script == "unknown":
+        raise SafeRefusal("exact PID target Astro script path is unavailable")
     command_hash = hashlib.sha256(listener.command_raw.encode("utf-8")).hexdigest()
-    output = run_powershell(TERMINATE_PS, str(port), str(listener.pid), command_hash, timeout=20).strip()
+    output = run_powershell(TERMINATE_PS, str(port), str(listener.pid), command_hash, expected_script, timeout=20).strip()
     if output != "terminated":
         raise SafeRefusal("exact PID termination was not confirmed")
 
@@ -829,20 +934,33 @@ def recover(project: Path, port: int, expected_sha: str, expected: GitInfo, stat
         emit("recovery-result", verdict=verdict, mutated="no")
         return False
     target = before.windows[0]
-    launcher_command(project, port)  # Prove the only allowed restart command before mutation.
+    try:
+        launcher_command(project, port)
+    except SafeRefusal as exc:
+        emit("recovery-result", verdict=f"refuse:{str(exc)}", mutated="no")
+        return False
     immediate = inspect_system(port, state)
     immediate_verdict = recovery_verdict(immediate, expected, expected_sha)
     if immediate_verdict != "eligible" or not same_listener_identity(before.windows, immediate.windows):
         emit("recovery-result", verdict="refuse:pid-or-command-reresolution-changed", mutated="no")
         return False
-    evidence_lines = [*before_lines, emit("immediate-recheck", verdict=immediate_verdict, pid=target.pid, identity="unchanged")]
+    mutation = inspect_system(port, state)
+    mutation_verdict = recovery_verdict(mutation, expected, expected_sha)
+    if mutation_verdict != "eligible" or not same_listener_identity(immediate.windows, mutation.windows):
+        emit("recovery-result", verdict="refuse:pid-or-command-reresolution-changed", mutated="no")
+        return False
+    evidence_lines = [
+        *before_lines,
+        emit("immediate-recheck", verdict=immediate_verdict, pid=target.pid, identity="unchanged"),
+        emit("mutation-recheck", verdict=mutation_verdict, pid=target.pid, identity="unchanged"),
+    ]
     try:
         evidence = write_evidence(state, project, port, target.pid, evidence_lines)
     except OSError:
         emit("recovery-result", verdict="refuse:private-evidence-write-failed", mutated="no")
         return False
     try:
-        terminate_exact(immediate.windows[0], port)
+        terminate_exact(mutation.windows[0], port)
     except SafeRefusal as exc:
         emit(
             "recovery-result",
@@ -852,18 +970,17 @@ def recover(project: Path, port: int, expected_sha: str, expected: GitInfo, stat
         )
         return False
     post_stop = inspect_system(port, state)
-    expected_running = bool(post_stop.wsl) and all(
-        item.classification == "wsl-node-astro-dev"
-        and item.git.checkout == expected.checkout
-        and item.git.sha == expected_sha
-        and item.git.dirty == "clean"
-        and item.git.source == expected.source
-        for item in post_stop.wsl
-    )
+    post_stop_verdict = post_stop_restart_verdict(post_stop, expected, expected_sha)
+    render_inspection("recover-post-stop", project, port, expected_sha, expected, post_stop)
+    if post_stop_verdict not in {"restart-safe", "already-verified"}:
+        emit("recovery-result", verdict=f"failed:{post_stop_verdict.removeprefix('refuse:')}", mutated="windows-pid-terminated", evidence=evidence)
+        return False
     launcher_pid: int | str = "already-running"
-    if not expected_running:
+    launcher_process = None
+    if post_stop_verdict == "restart-safe":
         try:
-            launcher_pid = launch_expected(project, port, evidence)
+            launcher_process = launch_expected(project, port, evidence)
+            launcher_pid = launcher_process.process.pid
         except (OSError, SafeRefusal) as exc:
             emit("recovery-result", verdict=f"failed:{str(exc)}", mutated="windows-pid-terminated", evidence=evidence)
             return False
@@ -887,6 +1004,8 @@ def recover(project: Path, port: int, expected_sha: str, expected: GitInfo, stat
             return True
         time.sleep(0.2)
     verify(project, port, expected_sha, expected, state, render=True)
+    if launcher_process is not None:
+        cleanup_owned_launch(launcher_process)
     emit(
         "recovery-result",
         verdict="failed:post-recovery-verification",
@@ -911,10 +1030,12 @@ def parser() -> argparse.ArgumentParser:
   process environment, credentials, production data, or hosted data.
 
   recover is deliberately narrower than inspect. It may stop exactly one PID
-  only after two complete observations independently prove that the same PID
-  still owns every native-Windows binding of the reserved port; the unchanged
-  process is node.exe running `astro ... dev`; its command path resolves to a
-  checkout of the same normalized Git source; that checkout is dirty,
+  only after complete observations, including a fresh mutation-boundary
+  recheck, independently prove that the same PID still owns every
+  native-Windows binding of the reserved port; the unchanged
+  process is node.exe whose first script argument resolves to that checkout's
+  node_modules/astro/astro.js or astro.mjs and is followed immediately by `dev`;
+  that checkout is dirty,
   divergent, or otherwise noncanonical; no task record names that checkout or
   PID; WSL has no unrelated port owner; and the requested replacement is clean,
   on the repository default branch, at expected-sha. Unknown commands, changed
@@ -927,7 +1048,7 @@ def parser() -> argparse.ArgumentParser:
   checkout, Git, and task evidence. It writes a mode-0600 record beneath
   $FM_HOME/state/localhost-evidence before invoking fixed PowerShell that again
   requires the exact PID, port, node.exe identity, unchanged command hash, and
-  Astro dev classification. After the exact PID exits, it runs only the
+  exact Astro script path followed by `dev`. After the exact PID exits, it runs only the
   project's package.json `scripts.dev` when that script is proven to be Astro,
   using `npm run dev -- --host 0.0.0.0 --port <port>`; an already-running
   expected WSL server is reused rather than duplicated.

--- a/bin/fm-localhost.py
+++ b/bin/fm-localhost.py
@@ -36,7 +36,9 @@ $Rows = @()
 $Connections = @(Get-NetTCPConnection -State Listen -ErrorAction Stop | Where-Object { [int]$_.LocalPort -eq $Port } | Sort-Object LocalAddress, OwningProcess)
 foreach ($Connection in $Connections) {
   $Process = $null
+  $NativeProcess = $null
   try { $Process = Get-CimInstance Win32_Process -Filter "ProcessId = $($Connection.OwningProcess)" -ErrorAction Stop } catch {}
+  try { $NativeProcess = Get-Process -Id $Connection.OwningProcess -ErrorAction Stop } catch {}
   $Rows += [pscustomobject]@{
     address = [string]$Connection.LocalAddress
     port = [int]$Connection.LocalPort
@@ -44,7 +46,7 @@ foreach ($Connection in $Connections) {
     process = if ($null -ne $Process) { [string]$Process.Name } else { $null }
     executable = if ($null -ne $Process) { [string]$Process.ExecutablePath } else { $null }
     command = if ($null -ne $Process) { [string]$Process.CommandLine } else { $null }
-    creation = if ($null -ne $Process -and $null -ne $Process.CreationDate) { ([datetime]$Process.CreationDate).ToUniversalTime().Ticks } else { $null }
+    creation = if ($null -ne $NativeProcess) { ([datetime]$NativeProcess.StartTime).ToUniversalTime().Ticks } else { $null }
   }
 }
 ConvertTo-Json -InputObject @($Rows) -Compress -Depth 3
@@ -66,9 +68,10 @@ foreach ($Connection in $Connections) {
 $Process = Get-CimInstance Win32_Process -Filter "ProcessId = $PidToStop" -ErrorAction Stop
 if ($null -eq $Process -or [string]$Process.Name -ieq 'wslrelay.exe') { throw 'wslrelay.exe is never a termination target' }
 if ([string]$Process.Name -ine 'node.exe' -or [IO.Path]::GetFileName([string]$Process.ExecutablePath) -ine 'node.exe') { throw 'target is not native Windows node.exe' }
+$BoundProcess = Get-Process -Id $PidToStop -ErrorAction Stop
 $Command = [string]$Process.CommandLine
 if ([string]::IsNullOrWhiteSpace($Command)) { throw 'target command is unavailable' }
-$Creation = ([datetime]$Process.CreationDate).ToUniversalTime().Ticks
+$Creation = ([datetime]$BoundProcess.StartTime).ToUniversalTime().Ticks
 if ([string]$Creation -ne $ExpectedCreation) { throw 'target process identity changed' }
 $Bytes = [Text.Encoding]::UTF8.GetBytes($Command)
 $Hash = ([BitConverter]::ToString([Security.Cryptography.SHA256]::Create().ComputeHash($Bytes))).Replace('-', '').ToLowerInvariant()
@@ -78,11 +81,11 @@ $NormalizedScript = $ExpectedAstroScript.Replace('\', '/')
 $NodePattern = '(?i)^\s*(?:"[^"]*/node\.exe"|(?:[^"\s]+/)?node\.exe)\s+'
 $AstroDevPattern = $NodePattern + '"?' + [regex]::Escape($NormalizedScript) + '"?\s+dev(?:\s|$)'
 if ($NormalizedCommand -notmatch $AstroDevPattern) { throw 'target is not the verified Astro development launcher' }
-if ($Command -match '(?i)(^|\s)(preview|build)(\s|$)' -or $Command -match '(?i)(node_env\s*=\s*production|--mode(?:=|\s+)production)') { throw 'target looks production-like' }
-$BoundProcess = Get-Process -Id $PidToStop -ErrorAction Stop
-$BoundCreation = ([datetime]$BoundProcess.StartTime).ToUniversalTime().Ticks
-if ([string]$BoundCreation -ne $ExpectedCreation) { throw 'target process identity changed' }
-Stop-Process -InputObject $BoundProcess -ErrorAction Stop
+if ($Command -match '(?i)(^|\s)(preview|build)(\s|$)' -or $Command -match '(?i)(node_env\s*=\s*[''"]?production[''"]?(?:\s|$)|--mode(?:=|\s+)[''"]?production[''"]?(?:\s|$))') { throw 'target looks production-like' }
+$FinalProcess = Get-Process -Id $PidToStop -ErrorAction Stop
+$FinalCreation = ([datetime]$FinalProcess.StartTime).ToUniversalTime().Ticks
+if ([string]$FinalCreation -ne $ExpectedCreation) { throw 'target process identity changed' }
+Stop-Process -InputObject $FinalProcess -ErrorAction Stop
 for ($i = 0; $i -lt 100; $i++) {
   if ($null -eq (Get-Process -Id $PidToStop -ErrorAction SilentlyContinue)) { 'terminated'; exit 0 }
   Start-Sleep -Milliseconds 100
@@ -97,6 +100,7 @@ $Url = [string]$args[0]
 Add-Type -AssemblyName System.Net.Http
 $Handler = [System.Net.Http.HttpClientHandler]::new()
 $Handler.UseProxy = $false
+$Handler.AllowAutoRedirect = $false
 $Client = [System.Net.Http.HttpClient]::new($Handler)
 $Client.MaxResponseContentBufferSize = 8388609
 $Client.Timeout = [TimeSpan]::FromSeconds(10)
@@ -436,10 +440,14 @@ def classify_windows(process: str, command: str, executable: str, checkout: str 
     return "unknown-node"
 
 
-def classify_wsl(process: str, command: str, checkout: str = "unknown") -> str:
+def classify_wsl(process: str, command: str, executable: str, checkout: str = "unknown") -> str:
     if production_like_command(command):
         return "production-like"
-    if Path(process).name.lower() in {"node", "nodejs"} and astro_dev_script(command, "", checkout):
+    if (
+        Path(process).name.casefold() in {"node", "nodejs"}
+        and Path(executable).name.casefold() in {"node", "nodejs"}
+        and astro_dev_script(command, "", checkout)
+    ):
         return "wsl-node-astro-dev"
     return "unknown-wsl-process"
 
@@ -573,6 +581,15 @@ def proc_root() -> Path:
     return Path("/proc")
 
 
+def proc_start_identity(pid_root: Path) -> str:
+    raw = (pid_root / "stat").read_text(encoding="utf-8", errors="replace").strip()
+    closing = raw.rfind(")")
+    fields = raw[closing + 1 :].split() if closing >= 0 else []
+    if len(fields) <= 19 or not fields[19].isdigit():
+        raise OSError("process start identity is unavailable")
+    return f"proc-start:{fields[19]}"
+
+
 def wsl_listeners(port: int, state: Path) -> list[Listener]:
     try:
         output = command_output(["ss", "-H", "-ltnp", f"sport = :{port}"])
@@ -595,25 +612,29 @@ def wsl_listeners(port: int, state: Path) -> list[Listener]:
         try:
             command_raw = (pid_root / "cmdline").read_bytes().replace(b"\0", b" ").decode("utf-8", "replace").strip()
             process = (pid_root / "comm").read_text(encoding="utf-8", errors="replace").strip() or ss_process
+            executable = str((pid_root / "exe").resolve(strict=True))
+            creation = proc_start_identity(pid_root)
             cwd = (pid_root / "cwd").resolve(strict=True)
             info = git_info(cwd)
         except OSError:
             command_raw = ""
             process = ss_process or "unknown"
+            executable = ""
+            creation = "unknown"
             info = GitInfo()
         listeners.append(
             Listener(
                 kernel="wsl",
                 address=address,
                 pid=pid,
-                creation="unknown",
+                creation=creation,
                 process=process,
                 command=redact_command(command_raw),
                 command_raw=command_raw,
-                executable_raw="",
+                executable_raw=executable,
                 git=info,
                 tasks=task_associations(state, info.checkout, pid),
-                classification=classify_wsl(process, command_raw, info.checkout),
+                classification=classify_wsl(process, command_raw, executable, info.checkout),
             )
         )
     return listeners
@@ -670,7 +691,11 @@ def expected_checkout_verdict(expected: GitInfo, expected_sha: str) -> str:
 def production_like_command(command: str) -> bool:
     if re.search(r"(?:^|\s)(?:preview|build)(?:\s|$)", command, re.IGNORECASE):
         return True
-    if re.search(r"node_env\s*=\s*production|--mode(?:=|\s+)production", command, re.IGNORECASE):
+    if re.search(
+        r"node_env\s*=\s*['\"]?production['\"]?(?:\s|$)|--mode(?:=|\s+)['\"]?production['\"]?(?:\s|$)",
+        command,
+        re.IGNORECASE,
+    ):
         return True
     tokens = command_tokens(command)
     lowered = [token.casefold() for token in tokens]
@@ -701,6 +726,10 @@ def same_listener_identity(before: list[Listener], after: list[Listener]) -> boo
         )
 
     return identity(before) == identity(after)
+
+
+def same_inspection_identity(before: Inspection, after: Inspection) -> bool:
+    return same_listener_identity(before.windows, after.windows) and same_listener_identity(before.wsl, after.wsl)
 
 
 def listener_owner_identity(listener: Listener) -> tuple[object, ...]:
@@ -736,6 +765,8 @@ def canonical_wslrelay_identity(process: str, executable: str) -> bool:
 def expected_wsl_listener_identity(listener: Listener, expected: GitInfo, expected_sha: str) -> bool:
     return (
         listener.classification == "wsl-node-astro-dev"
+        and listener.creation != "unknown"
+        and Path(listener.executable_raw).name.casefold() in {"node", "nodejs"}
         and listener.git.checkout == expected.checkout
         and listener.git.branch == expected.default_branch
         and listener.git.sha == expected_sha
@@ -886,7 +917,9 @@ def launcher_command(project: Path, port: int) -> list[str]:
         raise SafeRefusal("project dev launcher is not proven to be Astro dev") from exc
     if not isinstance(script, str) or re.search(r"[\x00-\x1f\x7f;&|<>$`\\]", script) or production_like_command(script):
         raise SafeRefusal("project dev launcher is not proven to be Astro dev")
-    command_tokens = tokens[1:] if tokens[:1] == ["npx"] else tokens
+    if tokens and Path(tokens[0]).name.casefold() in {"npx", "npx.cmd"}:
+        raise SafeRefusal("project dev launcher is not proven to be Astro dev")
+    command_tokens = tokens
     is_astro_dev = (
         len(command_tokens) >= 2
         and Path(command_tokens[0]).name in {"astro", "astro.js", "astro.mjs"}
@@ -968,7 +1001,11 @@ def wsl_route_fingerprint(url: str) -> dict[str, object]:
             return json.loads(Path(test_fixture).read_text(encoding="utf-8"))
         except (OSError, json.JSONDecodeError) as exc:
             raise SafeRefusal("WSL route fingerprint fixture failed") from exc
-    opener = urllib.request.build_opener(urllib.request.ProxyHandler({}))
+    class NoRedirect(urllib.request.HTTPRedirectHandler):
+        def redirect_request(self, req, fp, code, msg, headers, newurl):  # type: ignore[no-untyped-def]
+            return None
+
+    opener = urllib.request.build_opener(urllib.request.ProxyHandler({}), NoRedirect())
     request = urllib.request.Request(
         url,
         headers={
@@ -1078,12 +1115,13 @@ def verify(project: Path, port: int, expected_sha: str, expected: GitInfo, state
         return False
     fingerprints_match = (
         wsl_fingerprint == windows_fingerprint
-        and 200 <= int(wsl_fingerprint["status"]) < 400
+        and 200 <= int(wsl_fingerprint["status"]) < 300
     )
     final = inspect_system(port, state)
     final_pair_ok, final_reason = verified_pair(final, expected, expected_sha)
+    listeners_stable = same_inspection_identity(inspection, final)
     _, final_checkout_verdict = revalidated_expected_checkout(project, expected, expected_sha)
-    verification_ok = pair_ok and final_pair_ok and fingerprints_match and final_checkout_verdict == "ready"
+    verification_ok = pair_ok and final_pair_ok and listeners_stable and fingerprints_match and final_checkout_verdict == "ready"
     if render:
         render_inspection("verify", project, port, expected_sha, expected, final)
         emit("route", origin_kernel="wsl", **wsl_fingerprint)
@@ -1094,7 +1132,7 @@ def verify(project: Path, port: int, expected_sha: str, expected: GitInfo, state
             reason=(
                 "pair-and-route-fingerprints-match"
                 if verification_ok
-                else (final_checkout_verdict.removeprefix("refuse:") if final_checkout_verdict != "ready" else (final_reason if not final_pair_ok else (reason if not pair_ok else "route-fingerprint-mismatch")))
+                else (final_checkout_verdict.removeprefix("refuse:") if final_checkout_verdict != "ready" else (final_reason if not final_pair_ok else ("listener-identity-changed" if not listeners_stable else (reason if not pair_ok else "route-fingerprint-mismatch"))))
             ),
         )
     return verification_ok
@@ -1102,7 +1140,7 @@ def verify(project: Path, port: int, expected_sha: str, expected: GitInfo, state
 
 def termination_boundary_listener(
     project: Path,
-    listener: Listener,
+    inspection: Inspection,
     port: int,
     expected: GitInfo,
     expected_sha: str,
@@ -1115,13 +1153,13 @@ def termination_boundary_listener(
     if recovery_verdict(boundary, current, expected_sha) != "eligible":
         raise SafeRefusal("pid-or-command-reresolution-changed")
     boundary_windows = consistent_listener_owner(boundary.windows)
-    if boundary_windows is None or any(listener_owner_identity(item) != listener_owner_identity(listener) for item in boundary_windows):
+    if boundary_windows is None or not same_inspection_identity(inspection, boundary):
         raise SafeRefusal("pid-or-command-reresolution-changed")
     return boundary_windows[0]
 
 
-def terminate_exact(project: Path, listener: Listener, port: int, expected: GitInfo, expected_sha: str, state: Path) -> None:
-    listener = termination_boundary_listener(project, listener, port, expected, expected_sha, state)
+def terminate_exact(project: Path, inspection: Inspection, port: int, expected: GitInfo, expected_sha: str, state: Path) -> None:
+    listener = termination_boundary_listener(project, inspection, port, expected, expected_sha, state)
     if listener.classification != "native-windows-node-astro-dev" or Path(listener.process).name.lower() != "node.exe":
         raise SafeRefusal("exact PID target is no longer a proven native Windows Astro dev server")
     if Path(listener.process).name.lower() == "wslrelay.exe":
@@ -1161,12 +1199,12 @@ def recover_locked(project: Path, port: int, expected_sha: str, expected: GitInf
         return False
     immediate = inspect_system(port, state)
     immediate_verdict = recovery_verdict(immediate, expected, expected_sha)
-    if immediate_verdict != "eligible" or not same_listener_identity(before.windows, immediate.windows):
+    if immediate_verdict != "eligible" or not same_inspection_identity(before, immediate):
         emit("recovery-result", verdict="refuse:pid-or-command-reresolution-changed", mutated="no")
         return False
     mutation = inspect_system(port, state)
     mutation_verdict = recovery_verdict(mutation, expected, expected_sha)
-    if mutation_verdict != "eligible" or not same_listener_identity(immediate.windows, mutation.windows):
+    if mutation_verdict != "eligible" or not same_inspection_identity(immediate, mutation):
         emit("recovery-result", verdict="refuse:pid-or-command-reresolution-changed", mutated="no")
         return False
     evidence_lines = [
@@ -1184,7 +1222,7 @@ def recover_locked(project: Path, port: int, expected_sha: str, expected: GitInf
         emit("recovery-result", verdict="refuse:private-evidence-write-failed", mutated="no")
         return False
     try:
-        terminate_exact(project, mutation.windows[0], port, expected, expected_sha, state)
+        terminate_exact(project, mutation, port, expected, expected_sha, state)
     except SafeRefusal as exc:
         emit(
             "recovery-result",
@@ -1262,9 +1300,10 @@ def parser() -> argparse.ArgumentParser:
   kernel, address, PID, process, redacted command, checkout, branch, SHA, dirty
   state, normalized Git source, task association, classification, and recovery
   verdict. It reads Windows listeners and process identity through fixed
-  non-interactive PowerShell, WSL listeners through ss and /proc, and task
-  associations from this Firstmate home's state/*.meta. It never reads a
-  process environment, credentials, production data, or hosted data.
+  non-interactive PowerShell, WSL listeners through ss plus /proc executable and
+  start identity, and task associations from this Firstmate home's state/*.meta.
+  It never reads a process environment, credentials, production data, or hosted
+  data.
 
   recover is deliberately narrower than inspect. It may stop exactly one PID
   only after complete observations, including a fresh mutation-boundary
@@ -1277,10 +1316,10 @@ def parser() -> argparse.ArgumentParser:
   PID for either kernel; every existing WSL binding has one consistent task-free
   owner at the requested checkout, repository default branch, source, and SHA;
   and the requested replacement is clean, on that branch, at expected-sha.
-  Unknown commands, changed PIDs or commands, distinct Windows or WSL owners,
-  unrelated sources, task records, missing identity, Windows inspection failure,
-  canonical Windows source, production-like commands, and every wslrelay.exe
-  owner refuse recovery.
+  Unknown commands, changed PIDs, process starts, or commands, distinct Windows
+  or WSL owners, unrelated sources, task records, missing identity, Windows
+  inspection failure, canonical Windows source, production-like commands, and
+  every wslrelay.exe owner refuse recovery.
   Recovery never kills by process name or port and never targets wslrelay.exe.
 
   Immediately before mutation, recover re-resolves listener, PID, command,
@@ -1294,15 +1333,16 @@ def parser() -> argparse.ArgumentParser:
   exact Astro script path followed by `dev`. After the exact PID exits, it
   re-resolves the clean expected checkout and runs only that project's package.json
   `scripts.dev` when that script is proven to be Astro, using `npm run dev --
-  --host 0.0.0.0 --port <port>`; an already-running expected WSL server is reused
-  rather than duplicated.
+  --host 0.0.0.0 --port <port>`; installer-capable npx scripts refuse recovery,
+  and an already-running expected WSL server is reused rather than duplicated.
 
   verify sends the same bounded browser-like request to http://localhost:<port>/
-  from WSL and native Windows, compares status/body-length/SHA-256 fingerprints,
-  then repeats the listener-pair inspection. It passes only when Windows reports
-  wslrelay.exe at C:\\Windows\\System32\\wslrelay.exe, WSL reports one consistent,
-  task-free clean expected Astro owner on the repository default branch, and both
-  route fingerprints match the post-route pair. A nonzero exit means
+  from WSL and native Windows without following redirects, compares successful
+  status/body-length/SHA-256 fingerprints, then repeats the listener-pair
+  inspection. It passes only when Windows reports wslrelay.exe at
+  C:\\Windows\\System32\\wslrelay.exe, WSL reports one consistent, task-free clean
+  expected Astro owner with unchanged executable/start identity on the repository
+  default branch, and both route fingerprints match the post-route pair. A nonzero exit means
   inspection, recovery, or verification did not prove the requested safe state.
 """
     result = argparse.ArgumentParser(

--- a/bin/fm-localhost.py
+++ b/bin/fm-localhost.py
@@ -135,6 +135,7 @@ class Listener:
 class Inspection:
     windows: list[Listener]
     wsl: list[Listener]
+    task_error: str = ""
     windows_error: str = ""
     wsl_error: str = ""
 
@@ -376,13 +377,26 @@ def classify_wsl(process: str, command: str, checkout: str = "unknown") -> str:
     return "unknown-wsl-process"
 
 
+def task_state_files(state: Path) -> list[Path]:
+    try:
+        if not state.is_dir():
+            raise SafeRefusal("Firstmate task-state inspection unavailable")
+        files = sorted(state.glob("*.meta"))
+        for meta in files:
+            with meta.open("rb"):
+                pass
+        return files
+    except OSError as exc:
+        raise SafeRefusal("Firstmate task-state inspection unavailable") from exc
+
+
 def task_associations(state: Path, checkout: str, pid: int) -> tuple[str, ...]:
     if checkout == "unknown":
         checkout_path = None
     else:
         checkout_path = Path(checkout).resolve()
     matches: list[str] = []
-    for meta in sorted(state.glob("*.meta")):
+    for meta in task_state_files(state):
         try:
             fields: dict[str, list[str]] = {}
             for line in meta.read_text(encoding="utf-8", errors="replace").splitlines():
@@ -538,6 +552,11 @@ def wsl_listeners(port: int, state: Path) -> list[Listener]:
 def inspect_system(port: int, state: Path) -> Inspection:
     result = Inspection(windows=[], wsl=[])
     try:
+        task_state_files(state)
+    except SafeRefusal as exc:
+        result.task_error = str(exc)
+        return result
+    try:
         result.windows = windows_listeners(port, state)
     except SafeRefusal as exc:
         result.windows_error = str(exc)
@@ -603,6 +622,8 @@ def recovery_verdict(inspection: Inspection, expected: GitInfo, expected_sha: st
     expected_verdict = expected_checkout_verdict(expected, expected_sha)
     if expected_verdict != "ready":
         return expected_verdict
+    if inspection.task_error:
+        return "refuse:firstmate-task-state-inspection-unavailable"
     if inspection.windows_error:
         return "refuse:windows-inspection-unavailable"
     if inspection.wsl_error:
@@ -670,6 +691,8 @@ def render_inspection(mode: str, project: Path, port: int, expected_sha: str, ex
             recovery_verdict=expected_checkout_verdict(expected, expected_sha),
         ),
     ]
+    if inspection.task_error:
+        lines.append(emit("inspection", owner_kernel="firstmate", status="unavailable", error=inspection.task_error))
     if inspection.windows_error:
         lines.append(emit("inspection", owner_kernel="windows", status="unavailable", error=inspection.windows_error))
     if inspection.wsl_error:
@@ -748,8 +771,24 @@ def launcher_command(project: Path, port: int) -> list[str]:
     return [npm, "run", "dev", "--", "--host", "0.0.0.0", "--port", str(port)]
 
 
-def launch_expected(project: Path, port: int, evidence: Path) -> OwnedLaunch:
+def revalidated_expected_checkout(project: Path, expected: GitInfo, expected_sha: str) -> str:
+    current = git_info(project)
+    verdict = expected_checkout_verdict(current, expected_sha)
+    if verdict != "ready":
+        return verdict
+    if current.checkout != expected.checkout or current.source != expected.source:
+        return "refuse:expected-checkout-identity-changed"
+    return "ready"
+
+
+def launch_expected(project: Path, port: int, expected: GitInfo, expected_sha: str, evidence: Path) -> OwnedLaunch:
+    verdict = revalidated_expected_checkout(project, expected, expected_sha)
+    if verdict != "ready":
+        raise SafeRefusal(verdict.removeprefix("refuse:"))
     argv = launcher_command(project, port)
+    verdict = revalidated_expected_checkout(project, expected, expected_sha)
+    if verdict != "ready":
+        raise SafeRefusal(verdict.removeprefix("refuse:"))
     log_path = evidence.with_suffix(".launcher.log")
     descriptor = os.open(log_path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
     log = os.fdopen(descriptor, "wb", buffering=0)
@@ -835,6 +874,8 @@ def windows_route_fingerprint(url: str) -> dict[str, object]:
 
 
 def verified_pair(inspection: Inspection, expected: GitInfo, expected_sha: str) -> tuple[bool, str]:
+    if inspection.task_error:
+        return False, "firstmate-task-state-inspection-unavailable"
     if inspection.windows_error:
         return False, "windows-inspection-unavailable"
     if inspection.wsl_error:
@@ -856,6 +897,8 @@ def verified_pair(inspection: Inspection, expected: GitInfo, expected_sha: str) 
 
 
 def post_stop_restart_verdict(inspection: Inspection, expected: GitInfo, expected_sha: str) -> str:
+    if inspection.task_error:
+        return "refuse:firstmate-task-state-inspection-unavailable"
     if inspection.windows_error:
         return "refuse:windows-inspection-unavailable"
     if inspection.wsl_error:
@@ -895,19 +938,38 @@ def verify(project: Path, port: int, expected_sha: str, expected: GitInfo, state
         wsl_fingerprint == windows_fingerprint
         and 200 <= int(wsl_fingerprint["status"]) < 400
     )
+    final = inspect_system(port, state)
+    final_pair_ok, final_reason = verified_pair(final, expected, expected_sha)
+    verification_ok = pair_ok and final_pair_ok and fingerprints_match
     if render:
-        render_inspection("verify", project, port, expected_sha, expected, inspection)
+        render_inspection("verify", project, port, expected_sha, expected, final)
         emit("route", origin_kernel="wsl", **wsl_fingerprint)
         emit("route", origin_kernel="windows", **windows_fingerprint)
         emit(
             "verification",
-            verdict="pass" if pair_ok and fingerprints_match else "refuse",
-            reason="pair-and-route-fingerprints-match" if pair_ok and fingerprints_match else (reason if not pair_ok else "route-fingerprint-mismatch"),
+            verdict="pass" if verification_ok else "refuse",
+            reason="pair-and-route-fingerprints-match" if verification_ok else (final_reason if not final_pair_ok else (reason if not pair_ok else "route-fingerprint-mismatch")),
         )
-    return pair_ok and fingerprints_match
+    return verification_ok
 
 
-def terminate_exact(listener: Listener, port: int) -> None:
+def termination_boundary_listener(
+    listener: Listener,
+    port: int,
+    expected: GitInfo,
+    expected_sha: str,
+    state: Path,
+) -> Listener:
+    boundary = inspect_system(port, state)
+    if recovery_verdict(boundary, expected, expected_sha) != "eligible":
+        raise SafeRefusal("pid-or-command-reresolution-changed")
+    if len(boundary.windows) != 1 or not same_listener_identity([listener], boundary.windows):
+        raise SafeRefusal("pid-or-command-reresolution-changed")
+    return boundary.windows[0]
+
+
+def terminate_exact(listener: Listener, port: int, expected: GitInfo, expected_sha: str, state: Path) -> None:
+    listener = termination_boundary_listener(listener, port, expected, expected_sha, state)
     if listener.classification != "native-windows-node-astro-dev" or Path(listener.process).name.lower() != "node.exe":
         raise SafeRefusal("exact PID target is no longer a proven native Windows Astro dev server")
     if Path(listener.process).name.lower() == "wslrelay.exe":
@@ -960,7 +1022,7 @@ def recover(project: Path, port: int, expected_sha: str, expected: GitInfo, stat
         emit("recovery-result", verdict="refuse:private-evidence-write-failed", mutated="no")
         return False
     try:
-        terminate_exact(mutation.windows[0], port)
+        terminate_exact(mutation.windows[0], port, expected, expected_sha, state)
     except SafeRefusal as exc:
         emit(
             "recovery-result",
@@ -979,7 +1041,7 @@ def recover(project: Path, port: int, expected_sha: str, expected: GitInfo, stat
     launcher_process = None
     if post_stop_verdict == "restart-safe":
         try:
-            launcher_process = launch_expected(project, port, evidence)
+            launcher_process = launch_expected(project, port, expected, expected_sha, evidence)
             launcher_pid = launcher_process.process.pid
         except (OSError, SafeRefusal) as exc:
             emit("recovery-result", verdict=f"failed:{str(exc)}", mutated="windows-pid-terminated", evidence=evidence)
@@ -993,7 +1055,11 @@ def recover(project: Path, port: int, expected_sha: str, expected: GitInfo, stat
     while time.monotonic() < deadline:
         if verify(project, port, expected_sha, expected, state, render=False):
             final = inspect_system(port, state)
+            final_pair_ok, _ = verified_pair(final, expected, expected_sha)
             render_inspection("recover-post-verify", project, port, expected_sha, expected, final)
+            if not final_pair_ok:
+                time.sleep(0.2)
+                continue
             emit(
                 "recovery-result",
                 verdict="recovered-and-verified",
@@ -1045,18 +1111,21 @@ def parser() -> argparse.ArgumentParser:
   Recovery never kills by process name or port and never targets wslrelay.exe.
 
   Immediately before mutation, recover re-resolves listener, PID, command,
-  checkout, Git, and task evidence. It writes a mode-0600 record beneath
+  checkout, Git, and task evidence. The termination boundary repeats that
+  complete proof after the evidence is fsynced. It writes a mode-0600 record beneath
   $FM_HOME/state/localhost-evidence before invoking fixed PowerShell that again
   requires the exact PID, port, node.exe identity, unchanged command hash, and
-  exact Astro script path followed by `dev`. After the exact PID exits, it runs only the
-  project's package.json `scripts.dev` when that script is proven to be Astro,
-  using `npm run dev -- --host 0.0.0.0 --port <port>`; an already-running
-  expected WSL server is reused rather than duplicated.
+  exact Astro script path followed by `dev`. After the exact PID exits, it
+  re-resolves the clean expected checkout and runs only that project's package.json
+  `scripts.dev` when that script is proven to be Astro, using `npm run dev --
+  --host 0.0.0.0 --port <port>`; an already-running expected WSL server is reused
+  rather than duplicated.
 
   verify sends the same bounded browser-like request to http://localhost:<port>/
   from WSL and native Windows, compares status/body-length/SHA-256 fingerprints,
-  and passes only when Windows reports wslrelay.exe, WSL reports the clean
-  expected Astro server, and both route fingerprints match. A nonzero exit means
+  then repeats the listener-pair inspection. It passes only when Windows reports
+  wslrelay.exe, WSL reports the clean expected Astro server, and both route
+  fingerprints match the post-route pair. A nonzero exit means
   inspection, recovery, or verification did not prove the requested safe state.
 """
     result = argparse.ArgumentParser(

--- a/bin/fm-localhost.py
+++ b/bin/fm-localhost.py
@@ -44,6 +44,7 @@ foreach ($Connection in $Connections) {
     process = if ($null -ne $Process) { [string]$Process.Name } else { $null }
     executable = if ($null -ne $Process) { [string]$Process.ExecutablePath } else { $null }
     command = if ($null -ne $Process) { [string]$Process.CommandLine } else { $null }
+    creation = if ($null -ne $Process -and $null -ne $Process.CreationDate) { ([datetime]$Process.CreationDate).ToUniversalTime().Ticks } else { $null }
   }
 }
 ConvertTo-Json -InputObject @($Rows) -Compress -Depth 3
@@ -56,6 +57,7 @@ $Port = [int]$args[0]
 $PidToStop = [int]$args[1]
 $ExpectedCommandHash = [string]$args[2]
 $ExpectedAstroScript = [string]$args[3]
+$ExpectedCreation = [string]$args[4]
 $Connections = @(Get-NetTCPConnection -State Listen -ErrorAction Stop | Where-Object { [int]$_.LocalPort -eq $Port })
 if ($Connections.Count -lt 1) { throw 'reserved port has no Windows listener' }
 foreach ($Connection in $Connections) {
@@ -66,6 +68,8 @@ if ($null -eq $Process -or [string]$Process.Name -ieq 'wslrelay.exe') { throw 'w
 if ([string]$Process.Name -ine 'node.exe' -or [IO.Path]::GetFileName([string]$Process.ExecutablePath) -ine 'node.exe') { throw 'target is not native Windows node.exe' }
 $Command = [string]$Process.CommandLine
 if ([string]::IsNullOrWhiteSpace($Command)) { throw 'target command is unavailable' }
+$Creation = ([datetime]$Process.CreationDate).ToUniversalTime().Ticks
+if ([string]$Creation -ne $ExpectedCreation) { throw 'target process identity changed' }
 $Bytes = [Text.Encoding]::UTF8.GetBytes($Command)
 $Hash = ([BitConverter]::ToString([Security.Cryptography.SHA256]::Create().ComputeHash($Bytes))).Replace('-', '').ToLowerInvariant()
 if ($Hash -ne $ExpectedCommandHash) { throw 'target command changed' }
@@ -75,7 +79,10 @@ $NodePattern = '(?i)^\s*(?:"[^"]*/node\.exe"|(?:[^"\s]+/)?node\.exe)\s+'
 $AstroDevPattern = $NodePattern + '"?' + [regex]::Escape($NormalizedScript) + '"?\s+dev(?:\s|$)'
 if ($NormalizedCommand -notmatch $AstroDevPattern) { throw 'target is not the verified Astro development launcher' }
 if ($Command -match '(?i)(^|\s)(preview|build)(\s|$)' -or $Command -match '(?i)(node_env\s*=\s*production|--mode(?:=|\s+)production)') { throw 'target looks production-like' }
-Stop-Process -Id $PidToStop -ErrorAction Stop
+$BoundProcess = Get-Process -Id $PidToStop -ErrorAction Stop
+$BoundCreation = ([datetime]$BoundProcess.StartTime).ToUniversalTime().Ticks
+if ([string]$BoundCreation -ne $ExpectedCreation) { throw 'target process identity changed' }
+Stop-Process -InputObject $BoundProcess -ErrorAction Stop
 for ($i = 0; $i -lt 100; $i++) {
   if ($null -eq (Get-Process -Id $PidToStop -ErrorAction SilentlyContinue)) { 'terminated'; exit 0 }
   Start-Sleep -Milliseconds 100
@@ -123,6 +130,7 @@ class Listener:
     kernel: str
     address: str
     pid: int
+    creation: str
     process: str
     command: str
     command_raw: str
@@ -415,16 +423,13 @@ def checkout_from_windows_command(command: str, executable: str) -> Path | None:
 def classify_windows(process: str, command: str, executable: str, checkout: str = "unknown") -> str:
     lower_name = Path(process).name.lower()
     lower_executable = re.split(r"[\\/]", executable)[-1].lower() if executable else ""
-    lower_command = command.lower()
     if canonical_wslrelay_identity(process, executable):
         return "wslrelay"
     if not command.strip():
         return "unknown-command"
     if lower_name != "node.exe" or lower_executable != "node.exe":
         return "unrelated-process"
-    if re.search(r"(?:^|\s)(?:preview|build)(?:\s|$)", lower_command) or re.search(
-        r"node_env\s*=\s*production|--mode(?:=|\s+)production", lower_command
-    ):
+    if production_like_command(command):
         return "production-like"
     if astro_dev_script(command, executable, checkout):
         return "native-windows-node-astro-dev"
@@ -432,6 +437,8 @@ def classify_windows(process: str, command: str, executable: str, checkout: str 
 
 
 def classify_wsl(process: str, command: str, checkout: str = "unknown") -> str:
+    if production_like_command(command):
+        return "production-like"
     if Path(process).name.lower() in {"node", "nodejs"} and astro_dev_script(command, "", checkout):
         return "wsl-node-astro-dev"
     return "unknown-wsl-process"
@@ -535,6 +542,7 @@ def windows_listeners(port: int, state: Path) -> list[Listener]:
             raise SafeRefusal("Windows listener identity was incomplete") from exc
         if row_port != port or pid <= 0:
             raise SafeRefusal("Windows listener identity was inconsistent")
+        creation = str(row.get("creation") or "unknown")
         process = str(row.get("process") or "unknown")
         command = str(row.get("command") or "")
         executable = str(row.get("executable") or "")
@@ -545,6 +553,7 @@ def windows_listeners(port: int, state: Path) -> list[Listener]:
                 kernel="windows",
                 address=f"{row.get('address') or 'unknown'}:{port}",
                 pid=pid,
+                creation=creation,
                 process=process,
                 command=redact_command(command),
                 command_raw=command,
@@ -597,6 +606,7 @@ def wsl_listeners(port: int, state: Path) -> list[Listener]:
                 kernel="wsl",
                 address=address,
                 pid=pid,
+                creation="unknown",
                 process=process,
                 command=redact_command(command_raw),
                 command_raw=command_raw,
@@ -657,12 +667,27 @@ def expected_checkout_verdict(expected: GitInfo, expected_sha: str) -> str:
     return "ready"
 
 
+def production_like_command(command: str) -> bool:
+    if re.search(r"(?:^|\s)(?:preview|build)(?:\s|$)", command, re.IGNORECASE):
+        return True
+    if re.search(r"node_env\s*=\s*production|--mode(?:=|\s+)production", command, re.IGNORECASE):
+        return True
+    tokens = command_tokens(command)
+    lowered = [token.casefold() for token in tokens]
+    return any(
+        token in {"preview", "build", "node_env=production", "--mode=production"}
+        or (token == "--mode" and index + 1 < len(lowered) and lowered[index + 1] == "production")
+        for index, token in enumerate(lowered)
+    )
+
+
 def same_listener_identity(before: list[Listener], after: list[Listener]) -> bool:
     def identity(items: list[Listener]) -> list[tuple[object, ...]]:
         return sorted(
             (
                 item.address,
                 item.pid,
+                item.creation,
                 item.process.lower(),
                 hashlib.sha256(item.command_raw.encode("utf-8")).hexdigest(),
                 item.executable_raw.lower(),
@@ -681,6 +706,7 @@ def same_listener_identity(before: list[Listener], after: list[Listener]) -> boo
 def listener_owner_identity(listener: Listener) -> tuple[object, ...]:
     return (
         listener.pid,
+        listener.creation,
         listener.process.casefold(),
         listener.command_raw,
         listener.executable_raw.casefold(),
@@ -737,6 +763,8 @@ def recovery_verdict(inspection: Inspection, expected: GitInfo, expected_sha: st
     pids = {listener.pid for listener in inspection.windows}
     if len(pids) != 1:
         return "refuse:ambiguous-windows-ownership"
+    if any(listener.creation == "unknown" for listener in inspection.windows):
+        return "refuse:windows-process-identity-unavailable"
     if any(listener.classification == "wslrelay" for listener in inspection.windows):
         return "refuse:wslrelay-is-never-terminated"
     if any(listener.classification != "native-windows-node-astro-dev" for listener in inspection.windows):
@@ -804,6 +832,7 @@ def render_inspection(mode: str, project: Path, port: int, expected_sha: str, ex
                 owner_kernel=listener.kernel,
                 address=listener.address,
                 pid=listener.pid,
+                creation=listener.creation,
                 process=listener.process,
                 command=listener.command,
                 checkout=listener.git.checkout,
@@ -855,7 +884,7 @@ def launcher_command(project: Path, port: int) -> list[str]:
         tokens = shlex.split(script) if isinstance(script, str) else []
     except ValueError as exc:
         raise SafeRefusal("project dev launcher is not proven to be Astro dev") from exc
-    if not isinstance(script, str) or re.search(r"[\x00-\x1f\x7f;&|<>$`\\]", script):
+    if not isinstance(script, str) or re.search(r"[\x00-\x1f\x7f;&|<>$`\\]", script) or production_like_command(script):
         raise SafeRefusal("project dev launcher is not proven to be Astro dev")
     command_tokens = tokens[1:] if tokens[:1] == ["npx"] else tokens
     is_astro_dev = (
@@ -871,22 +900,22 @@ def launcher_command(project: Path, port: int) -> list[str]:
     return [npm, "run", "dev", "--", "--host", "0.0.0.0", "--port", str(port)]
 
 
-def revalidated_expected_checkout(project: Path, expected: GitInfo, expected_sha: str) -> str:
+def revalidated_expected_checkout(project: Path, expected: GitInfo, expected_sha: str) -> tuple[GitInfo, str]:
     current = git_info(project)
     verdict = expected_checkout_verdict(current, expected_sha)
     if verdict != "ready":
-        return verdict
+        return current, verdict
     if current.checkout != expected.checkout or current.source != expected.source:
-        return "refuse:expected-checkout-identity-changed"
-    return "ready"
+        return current, "refuse:expected-checkout-identity-changed"
+    return current, "ready"
 
 
 def launch_expected(project: Path, port: int, expected: GitInfo, expected_sha: str, evidence: Path) -> OwnedLaunch:
-    verdict = revalidated_expected_checkout(project, expected, expected_sha)
+    _, verdict = revalidated_expected_checkout(project, expected, expected_sha)
     if verdict != "ready":
         raise SafeRefusal(verdict.removeprefix("refuse:"))
     argv = launcher_command(project, port)
-    verdict = revalidated_expected_checkout(project, expected, expected_sha)
+    _, verdict = revalidated_expected_checkout(project, expected, expected_sha)
     if verdict != "ready":
         raise SafeRefusal(verdict.removeprefix("refuse:"))
     log_path = evidence.with_suffix(".launcher.log")
@@ -982,6 +1011,8 @@ def verified_pair(inspection: Inspection, expected: GitInfo, expected_sha: str) 
         return False, "wsl-inspection-unavailable"
     if associated_tasks(inspection.windows, inspection.wsl):
         return False, "active-firstmate-task-associated"
+    if any(item.creation == "unknown" for item in inspection.windows):
+        return False, "windows-process-identity-unavailable"
     windows = consistent_listener_owner(inspection.windows)
     if windows is None or any(not canonical_wslrelay_identity(item.process, item.executable_raw) for item in windows):
         return False, "windows-owner-is-not-wslrelay"
@@ -1016,11 +1047,12 @@ def post_stop_restart_verdict(inspection: Inspection, expected: GitInfo, expecte
 
 
 def verify(project: Path, port: int, expected_sha: str, expected: GitInfo, state: Path, *, render: bool = True) -> bool:
-    if expected_checkout_verdict(expected, expected_sha) != "ready":
+    _, checkout_verdict = revalidated_expected_checkout(project, expected, expected_sha)
+    if checkout_verdict != "ready":
         inspection = inspect_system(port, state)
         if render:
             render_inspection("verify", project, port, expected_sha, expected, inspection)
-            emit("verification", verdict="refuse", reason=expected_checkout_verdict(expected, expected_sha))
+            emit("verification", verdict="refuse", reason=checkout_verdict)
         return False
     inspection = inspect_system(port, state)
     pair_ok, reason = verified_pair(inspection, expected, expected_sha)
@@ -1028,6 +1060,12 @@ def verify(project: Path, port: int, expected_sha: str, expected: GitInfo, state
         if render:
             render_inspection("verify", project, port, expected_sha, expected, inspection)
             emit("verification", verdict="refuse", reason=reason)
+        return False
+    _, checkout_verdict = revalidated_expected_checkout(project, expected, expected_sha)
+    if checkout_verdict != "ready":
+        if render:
+            render_inspection("verify", project, port, expected_sha, expected, inspection)
+            emit("verification", verdict="refuse", reason=checkout_verdict)
         return False
     url = f"http://localhost:{port}/"
     try:
@@ -1044,7 +1082,8 @@ def verify(project: Path, port: int, expected_sha: str, expected: GitInfo, state
     )
     final = inspect_system(port, state)
     final_pair_ok, final_reason = verified_pair(final, expected, expected_sha)
-    verification_ok = pair_ok and final_pair_ok and fingerprints_match
+    _, final_checkout_verdict = revalidated_expected_checkout(project, expected, expected_sha)
+    verification_ok = pair_ok and final_pair_ok and fingerprints_match and final_checkout_verdict == "ready"
     if render:
         render_inspection("verify", project, port, expected_sha, expected, final)
         emit("route", origin_kernel="wsl", **wsl_fingerprint)
@@ -1052,12 +1091,17 @@ def verify(project: Path, port: int, expected_sha: str, expected: GitInfo, state
         emit(
             "verification",
             verdict="pass" if verification_ok else "refuse",
-            reason="pair-and-route-fingerprints-match" if verification_ok else (final_reason if not final_pair_ok else (reason if not pair_ok else "route-fingerprint-mismatch")),
+            reason=(
+                "pair-and-route-fingerprints-match"
+                if verification_ok
+                else (final_checkout_verdict.removeprefix("refuse:") if final_checkout_verdict != "ready" else (final_reason if not final_pair_ok else (reason if not pair_ok else "route-fingerprint-mismatch")))
+            ),
         )
     return verification_ok
 
 
 def termination_boundary_listener(
+    project: Path,
     listener: Listener,
     port: int,
     expected: GitInfo,
@@ -1065,7 +1109,10 @@ def termination_boundary_listener(
     state: Path,
 ) -> Listener:
     boundary = inspect_system(port, state)
-    if recovery_verdict(boundary, expected, expected_sha) != "eligible":
+    current, checkout_verdict = revalidated_expected_checkout(project, expected, expected_sha)
+    if checkout_verdict != "ready":
+        raise SafeRefusal(checkout_verdict.removeprefix("refuse:"))
+    if recovery_verdict(boundary, current, expected_sha) != "eligible":
         raise SafeRefusal("pid-or-command-reresolution-changed")
     boundary_windows = consistent_listener_owner(boundary.windows)
     if boundary_windows is None or any(listener_owner_identity(item) != listener_owner_identity(listener) for item in boundary_windows):
@@ -1073,14 +1120,16 @@ def termination_boundary_listener(
     return boundary_windows[0]
 
 
-def terminate_exact(listener: Listener, port: int, expected: GitInfo, expected_sha: str, state: Path) -> None:
-    listener = termination_boundary_listener(listener, port, expected, expected_sha, state)
+def terminate_exact(project: Path, listener: Listener, port: int, expected: GitInfo, expected_sha: str, state: Path) -> None:
+    listener = termination_boundary_listener(project, listener, port, expected, expected_sha, state)
     if listener.classification != "native-windows-node-astro-dev" or Path(listener.process).name.lower() != "node.exe":
         raise SafeRefusal("exact PID target is no longer a proven native Windows Astro dev server")
     if Path(listener.process).name.lower() == "wslrelay.exe":
         raise SafeRefusal("wslrelay.exe is never a termination target")
     if listener.git.checkout == "unknown":
         raise SafeRefusal("exact PID target checkout is unavailable")
+    if listener.creation == "unknown":
+        raise SafeRefusal("exact PID target process identity is unavailable")
     astro_script = astro_dev_script(listener.command_raw, listener.executable_raw, listener.git.checkout)
     if astro_script is None:
         raise SafeRefusal("exact PID target Astro script path is unavailable")
@@ -1088,12 +1137,16 @@ def terminate_exact(listener: Listener, port: int, expected: GitInfo, expected_s
     if expected_script == "unknown":
         raise SafeRefusal("exact PID target Astro script path is unavailable")
     command_hash = hashlib.sha256(listener.command_raw.encode("utf-8")).hexdigest()
-    output = run_powershell(TERMINATE_PS, str(port), str(listener.pid), command_hash, expected_script, timeout=20).strip()
+    output = run_powershell(TERMINATE_PS, str(port), str(listener.pid), command_hash, expected_script, listener.creation, timeout=20).strip()
     if output != "terminated":
         raise SafeRefusal("exact PID termination was not confirmed")
 
 
 def recover_locked(project: Path, port: int, expected_sha: str, expected: GitInfo, state: Path) -> bool:
+    _, checkout_verdict = revalidated_expected_checkout(project, expected, expected_sha)
+    if checkout_verdict != "ready":
+        emit("recovery-result", verdict=checkout_verdict, mutated="no")
+        return False
     before = inspect_system(port, state)
     before_lines = render_inspection("recover", project, port, expected_sha, expected, before)
     verdict = recovery_verdict(before, expected, expected_sha)
@@ -1121,13 +1174,17 @@ def recover_locked(project: Path, port: int, expected_sha: str, expected: GitInf
         emit("immediate-recheck", verdict=immediate_verdict, pid=target.pid, identity="unchanged"),
         emit("mutation-recheck", verdict=mutation_verdict, pid=target.pid, identity="unchanged"),
     ]
+    _, checkout_verdict = revalidated_expected_checkout(project, expected, expected_sha)
+    if checkout_verdict != "ready":
+        emit("recovery-result", verdict=checkout_verdict, mutated="no")
+        return False
     try:
         evidence = write_evidence(state, project, port, target.pid, evidence_lines)
     except OSError:
         emit("recovery-result", verdict="refuse:private-evidence-write-failed", mutated="no")
         return False
     try:
-        terminate_exact(mutation.windows[0], port, expected, expected_sha, state)
+        terminate_exact(project, mutation.windows[0], port, expected, expected_sha, state)
     except SafeRefusal as exc:
         emit(
             "recovery-result",

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -220,6 +220,18 @@ SUB_HOME_MARKER=".fm-secondmate-home"
 # Fail closed before any fleet mutation: a no-mistakes gate agent must never spawn
 # a direct report (see bin/fm-gate-refuse-lib.sh).
 fm_refuse_if_gate_agent
+TASK_STATE_LOCK="$STATE/.task-state.lock"
+TASK_STATE_LOCK_HELD=0
+task_state_lock_acquire() {
+  fm_lock_acquire_wait "$TASK_STATE_LOCK"
+  TASK_STATE_LOCK_HELD=1
+}
+task_state_lock_release() {
+  if [ "$TASK_STATE_LOCK_HELD" -eq 1 ]; then
+    TASK_STATE_LOCK_HELD=0
+    fm_lock_release "$TASK_STATE_LOCK"
+  fi
+}
 # Skip the watcher guard when re-exec'd for one pair of a batch (FM_SPAWN_NO_GUARD is
 # set by the batch loop below), so the guard runs once for the batch, not once per pair.
 [ -n "${FM_SPAWN_NO_GUARD:-}" ] || "$FM_ROOT/bin/fm-guard.sh" || true
@@ -584,11 +596,14 @@ spawn_remote_secondmate() {
 }
 
 if [ "$KIND" = secondmate ]; then
+  task_state_lock_acquire
   if spawn_remote_secondmate "${POS[0]:-}"; then
+    task_state_lock_release
     exit 0
   else
     remote_spawn_rc=$?
   fi
+  task_state_lock_release
   [ "$remote_spawn_rc" -eq 3 ] || exit "$remote_spawn_rc"
 fi
 
@@ -700,6 +715,7 @@ spawn_abort_cleanup() {
     SPAWN_TASK_LOCK_HELD=0
     fm_lock_release "$SPAWN_TASK_LOCK" || true
   fi
+  task_state_lock_release
   if [ "$CONFIG_INHERIT_LOCK_HELD" = 1 ]; then
     CONFIG_INHERIT_LOCK_HELD=0
     fm_lock_release "$CONFIG_INHERIT_LOCK" || true
@@ -783,6 +799,7 @@ if ! fm_lock_try_acquire "$SPAWN_TASK_LOCK"; then
   exit 1
 fi
 SPAWN_TASK_LOCK_HELD=1
+task_state_lock_acquire
 PROJ=
 ARG3=
 FIRSTMATE_HOME=
@@ -2291,6 +2308,7 @@ if [ -n "$SPAWN_TRACEPARENT" ]; then
     fi
   fi
 fi
+task_state_lock_release
 sleep 0.3
 spawn_send_literal "$T" "$LAUNCH"
 sleep 0.3

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -223,8 +223,21 @@ fm_refuse_if_gate_agent
 TASK_STATE_LOCK="$STATE/.task-state.lock"
 TASK_STATE_LOCK_HELD=0
 task_state_lock_acquire() {
-  fm_lock_acquire_wait "$TASK_STATE_LOCK"
-  TASK_STATE_LOCK_HELD=1
+  local attempt=0
+  mkdir -p "$STATE" || {
+    echo "error: could not create task-state directory" >&2
+    return 1
+  }
+  while [ "$attempt" -lt 50 ]; do
+    if fm_lock_try_acquire "$TASK_STATE_LOCK"; then
+      TASK_STATE_LOCK_HELD=1
+      return 0
+    fi
+    sleep 0.1
+    attempt=$((attempt + 1))
+  done
+  echo "error: task-state publication lock timed out" >&2
+  return 1
 }
 task_state_lock_release() {
   if [ "$TASK_STATE_LOCK_HELD" -eq 1 ]; then

--- a/bin/fm-task-state-lock.sh
+++ b/bin/fm-task-state-lock.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+STATE=${1:?state directory is required}
+[ -d "$STATE" ] || exit 1
+FM_STATE_OVERRIDE=$STATE
+export FM_STATE_OVERRIDE
+. "$SCRIPT_DIR/fm-wake-lib.sh"
+LOCK="$STATE/.task-state.lock"
+fm_lock_acquire_wait "$LOCK"
+cleanup() { fm_lock_release "$LOCK"; }
+trap cleanup EXIT
+trap 'exit 1' HUP INT TERM
+printf 'locked\n'
+IFS= read -r _ || true

--- a/bin/fm-task-state-lock.sh
+++ b/bin/fm-task-state-lock.sh
@@ -3,12 +3,26 @@ set -eu
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 STATE=${1:?state directory is required}
+ATTEMPTS=${2:-50}
 [ -d "$STATE" ] || exit 1
+case "$ATTEMPTS" in
+  ''|*[!0-9]*) exit 1 ;;
+esac
+[ "$ATTEMPTS" -ge 1 ] && [ "$ATTEMPTS" -le 50 ] || exit 1
 FM_STATE_OVERRIDE=$STATE
 export FM_STATE_OVERRIDE
+# shellcheck source=bin/fm-wake-lib.sh
 . "$SCRIPT_DIR/fm-wake-lib.sh"
 LOCK="$STATE/.task-state.lock"
-fm_lock_acquire_wait "$LOCK"
+attempt=0
+while ! fm_lock_try_acquire "$LOCK"; do
+  attempt=$((attempt + 1))
+  if [ "$attempt" -ge "$ATTEMPTS" ]; then
+    printf 'timeout\n'
+    exit 2
+  fi
+  sleep 0.1
+done
 cleanup() { fm_lock_release "$LOCK"; }
 trap cleanup EXIT
 trap 'exit 1' HUP INT TERM

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -940,11 +940,15 @@ families_for_changed_path() {
       # lane's contract coverage re-runs.
       printf '%s\n' real-herdr-gated
       ;;
+    bin/fm-localhost.py|bin/fm-task-state-lock.sh)
+      printf '%s\n' pure-contract-unit
+      printf '%s\n' __script__:fm-localhost.test.sh
+      ;;
     bin/fm-lint.sh|bin/fm-install-shellcheck.sh|\
     bin/fm-brief.sh|bin/fm-ensure-agents-md.sh|bin/fm-crew-state.sh|\
     bin/fm-decision-hold.sh|bin/fm-supervision*|bin/fm-transition-lib.sh|\
     bin/fm-tmux-lib.sh|bin/fm-marker-lib.sh|bin/fm-operational-input.sh|bin/fm-tasks-axi-lib.sh|\
-    bin/fm-vendor-auth-probe.sh|bin/fm-localhost.py|bin/fm-task-state-lock.sh|\
+    bin/fm-vendor-auth-probe.sh|\
     bin/fm-primary-scope-lib.sh|bin/fm-project-mode.sh|bin/fm-promote.sh|\
     bin/fm-ff-lib.sh|bin/fm-gotmp*|bin/*pretool*)
       printf '%s\n' pure-contract-unit

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -944,7 +944,7 @@ families_for_changed_path() {
     bin/fm-brief.sh|bin/fm-ensure-agents-md.sh|bin/fm-crew-state.sh|\
     bin/fm-decision-hold.sh|bin/fm-supervision*|bin/fm-transition-lib.sh|\
     bin/fm-tmux-lib.sh|bin/fm-marker-lib.sh|bin/fm-operational-input.sh|bin/fm-tasks-axi-lib.sh|\
-    bin/fm-vendor-auth-probe.sh|bin/fm-localhost.py|\
+    bin/fm-vendor-auth-probe.sh|bin/fm-localhost.py|bin/fm-task-state-lock.sh|\
     bin/fm-primary-scope-lib.sh|bin/fm-project-mode.sh|bin/fm-promote.sh|\
     bin/fm-ff-lib.sh|bin/fm-gotmp*|bin/*pretool*)
       printf '%s\n' pure-contract-unit

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -138,7 +138,7 @@ family_for_basename() {
     fm-composer-ghost.test.sh|fm-composer-lib.test.sh|\
     fm-crew-state.test.sh|fm-decision-hold-lifecycle.test.sh|\
     fm-documentation-audiences.test.sh|fm-ensure-agents-md.test.sh|fm-grok-harness.test.sh|\
-    fm-kimi-harness.test.sh|fm-muse-harness.test.sh|fm-herdr-lab.test.sh|fm-lint.test.sh|\
+    fm-kimi-harness.test.sh|fm-muse-harness.test.sh|fm-herdr-lab.test.sh|fm-lint.test.sh|fm-localhost.test.sh|\
     fm-operational-input.test.sh|fm-pi-primary-types.test.sh|\
     fm-send-popup-settle.test.sh|fm-send-settle.test.sh|\
     fm-subagent-pretool-check.test.sh|\
@@ -944,7 +944,7 @@ families_for_changed_path() {
     bin/fm-brief.sh|bin/fm-ensure-agents-md.sh|bin/fm-crew-state.sh|\
     bin/fm-decision-hold.sh|bin/fm-supervision*|bin/fm-transition-lib.sh|\
     bin/fm-tmux-lib.sh|bin/fm-marker-lib.sh|bin/fm-operational-input.sh|bin/fm-tasks-axi-lib.sh|\
-    bin/fm-vendor-auth-probe.sh|\
+    bin/fm-vendor-auth-probe.sh|bin/fm-localhost.py|\
     bin/fm-primary-scope-lib.sh|bin/fm-project-mode.sh|bin/fm-promote.sh|\
     bin/fm-ff-lib.sh|bin/fm-gotmp*|bin/*pretool*)
       printf '%s\n' pure-contract-unit

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -59,6 +59,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-project-mode.sh`     | Resolve a project's registered delivery posture from `data/projects.md` for fleet sync and home seeding |
 | `fm-merge-local.sh`      | Fast-forward a `local-only` project's local default branch after approval            |
 | `fm-review-diff.sh`      | Review a crewmate branch or resolved PR head against the authoritative base          |
+| `fm-localhost.py`        | Inspect, narrowly recover, and verify cross-kernel localhost ownership ([verification](verification/runtime-backends.md#cross-kernel-localhost-routing)) |
 | `fm-marker-lib.sh`       | Compatibility entry point for the from-firstmate carrier owned by `fm-operational-input.sh` |
 | `fm-pending-reply-lib.sh` | Parent-owned secondmate pending-reply expectations, recovery, and one-shot escalation |
 | `fm-secondmate-report.sh` | Optional helper to append a correlated parent status or document-pointer report       |

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -1,7 +1,7 @@
 # The bin/ toolbelt
 
 The first mate drives these; interactive entrypoints work by hand too, while `*-lib.sh` files are sourced helpers.
-Each row is one purpose clause only: the script's own header comment is the authoritative description of its behavior, flags, and contracts, so read the header before first use.
+Each row is one purpose clause only: the script's own header or `--help` output is the authoritative description of its behavior, flags, and contracts, so read it before first use.
 If you have changed away from the firstmate home in an interactive shell, invoke these scripts by absolute path through the repo's `bin/` directory; the scripts self-locate internally after they start.
 The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarized in [architecture.md](architecture.md#no-mistakes-gate-authority-boundary), while `docs/sessionstart-nudge.md` covers the silent session-open hook use; `fm-gate-refuse-lib.sh`'s header owns its exact contract.
 

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -697,12 +697,16 @@ ok - node worker commands containing Astro words refuse exact-PID recovery
 ok - unknown commands and unrelated Windows repositories refuse without termination
 ok - unavailable Windows inspection refuses recovery without mutation
 ok - unavailable WSL inspection refuses recovery without mutation
+ok - unavailable Firstmate task-state inspection refuses recovery without termination
 ok - verify proves the listener pair before contacting localhost
 ok - fresh mutation-boundary source and task proof blocks termination
+ok - termination-boundary task proof blocks exact-PID termination
 ok - post-stop inspection failure blocks any restart
 ok - Astro launcher scripts with shell metacharacters refuse recovery
 ok - post-recovery Windows/WSL route fingerprint mismatch fails verification
+ok - post-route listener-pair changes fail verification
+ok - dirty expected checkout refuses restart after exact-PID termination
 ```
 
-The suite covers Windows listener JSON parsing, Windows drive and WSL UNC conversion, WSL-to-Windows conversion, exact Astro script/dev classification, Git source classification, command redaction, exact PID and full mutation-boundary re-resolution, unavailable inspection, route-proof ordering, unrelated, unknown, or production-like processes, active task association, the never-terminate relay boundary, the healthy relay pair, the stale native Astro recovery path, launcher shell validation and cleanup, and mismatched post-recovery route fingerprints.
+The suite covers Windows listener JSON parsing, Windows drive and WSL UNC conversion, WSL-to-Windows conversion, exact Astro script/dev classification, Git source classification, command redaction, exact PID and full mutation-boundary re-resolution, unavailable Windows, WSL, and Firstmate task-state inspection, route-proof ordering, unrelated, unknown, or production-like processes, active task association, the never-terminate relay boundary, the healthy relay pair, the stale native Astro recovery path, launcher shell validation and cleanup, post-route listener-pair changes, mismatched post-recovery route fingerprints, and expected-checkout revalidation before restart.
 Host-specific acceptance still requires `verify` against the actual project/port/expected-SHA tuple; private evidence remains under the active Firstmate home's gitignored `state/` tree rather than this maintained record.

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -691,10 +691,14 @@ Observed output:
 ok - localhost inspect parses listeners, converts Windows/WSL paths, classifies Git source, and redacts commands
 ok - stale native Windows Astro shadow recovers by exact PID to wslrelay plus clean WSL and matching routes
 ok - healthy wslrelay plus clean WSL server passes with matching browser-like route fingerprints
-ok - relay verification requires complete canonical executable identity
+ok - relay verification requires the trusted canonical Windows system identity
 ok - same-owner multiple listener bindings remain a verified relay pair
 ok - same-owner multiple stale Windows bindings recover by one exact PID
 ok - active Firstmate task ownership refuses recovery without termination
+ok - active WSL task ownership refuses recovery and verification
+ok - multiple WSL owners refuse recovery before mutation
+ok - WSL listener verification requires the default branch
+ok - task-state publication lock contention refuses within a fixed bound
 ok - PID or command change between observations refuses exact-PID recovery
 ok - node worker commands containing Astro words refuse exact-PID recovery
 ok - unknown commands and unrelated Windows repositories refuse without termination
@@ -711,5 +715,5 @@ ok - post-route listener-pair changes fail verification
 ok - dirty expected checkout refuses restart after exact-PID termination
 ```
 
-The suite covers Windows listener JSON parsing, Windows drive and WSL UNC conversion, WSL-to-Windows conversion, exact Astro script/dev classification, Git source classification, command redaction, exact PID and full mutation-boundary re-resolution, unavailable Windows, WSL, and Firstmate task-state inspection, route-proof ordering, unrelated, unknown, or production-like processes, active task association and the shared task-state publication boundary, canonical relay identity, same-owner multiple bindings, the never-terminate relay boundary, the healthy relay pair, the stale native Astro recovery path, launcher shell validation and cleanup, post-route listener-pair changes, mismatched post-recovery route fingerprints, and expected-checkout revalidation before restart.
+The suite covers Windows listener JSON parsing, Windows drive and WSL UNC conversion, WSL-to-Windows conversion, exact Astro script/dev classification, Git source classification, command redaction, exact PID and full mutation-boundary re-resolution, unavailable Windows, WSL, and Firstmate task-state inspection, route-proof ordering, unrelated, unknown, or production-like processes, task associations on both kernels, bounded shared task-state publication locking, trusted Windows system relay identity, same-owner multiple bindings, distinct WSL-owner ambiguity, WSL default-branch identity, the never-terminate relay boundary, the healthy relay pair, the stale native Astro recovery path, launcher shell validation and cleanup, post-route listener-pair changes, mismatched post-recovery route fingerprints, and expected-checkout revalidation before restart.
 Host-specific acceptance still requires `verify` against the actual project/port/expected-SHA tuple; private evidence remains under the active Firstmate home's gitignored `state/` tree rather than this maintained record.

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -698,8 +698,10 @@ ok - active Firstmate task ownership refuses recovery without termination
 ok - active WSL task ownership refuses recovery and verification
 ok - multiple WSL owners refuse recovery before mutation
 ok - WSL listener verification requires the default branch
+ok - production-like WSL owners and project launchers refuse recovery
 ok - task-state publication lock contention refuses within a fixed bound
 ok - PID or command change between observations refuses exact-PID recovery
+ok - verify revalidates the expected checkout after route inspection
 ok - node worker commands containing Astro words refuse exact-PID recovery
 ok - unknown commands and unrelated Windows repositories refuse without termination
 ok - unavailable Windows inspection refuses recovery without mutation

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -693,10 +693,16 @@ ok - stale native Windows Astro shadow recovers by exact PID to wslrelay plus cl
 ok - healthy wslrelay plus clean WSL server passes with matching browser-like route fingerprints
 ok - active Firstmate task ownership refuses recovery without termination
 ok - PID or command change between observations refuses exact-PID recovery
+ok - node worker commands containing Astro words refuse exact-PID recovery
 ok - unknown commands and unrelated Windows repositories refuse without termination
 ok - unavailable Windows inspection refuses recovery without mutation
+ok - unavailable WSL inspection refuses recovery without mutation
+ok - verify proves the listener pair before contacting localhost
+ok - fresh mutation-boundary source and task proof blocks termination
+ok - post-stop inspection failure blocks any restart
+ok - Astro launcher scripts with shell metacharacters refuse recovery
 ok - post-recovery Windows/WSL route fingerprint mismatch fails verification
 ```
 
-The suite covers Windows listener JSON parsing, Windows drive and WSL UNC conversion, WSL-to-Windows conversion, Git source classification, command redaction, exact PID and command re-resolution, unavailable inspection, unrelated, unknown, or production-like processes, active task association, the never-terminate relay boundary, the healthy relay pair, the stale native Astro recovery path, and mismatched post-recovery route fingerprints.
+The suite covers Windows listener JSON parsing, Windows drive and WSL UNC conversion, WSL-to-Windows conversion, exact Astro script/dev classification, Git source classification, command redaction, exact PID and full mutation-boundary re-resolution, unavailable inspection, route-proof ordering, unrelated, unknown, or production-like processes, active task association, the never-terminate relay boundary, the healthy relay pair, the stale native Astro recovery path, launcher shell validation and cleanup, and mismatched post-recovery route fingerprints.
 Host-specific acceptance still requires `verify` against the actual project/port/expected-SHA tuple; private evidence remains under the active Firstmate home's gitignored `state/` tree rather than this maintained record.

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -678,7 +678,7 @@ App-server partial methods and raw socket experiments do not satisfy that bridge
 `bin/fm-localhost.py --help` is the single procedural owner for cross-kernel inspection, exact-PID recovery, launcher selection, and route verification.
 This section carries only the repeatable evidence for that active runtime guarantee.
 
-On 2026-08-05, the behavior suite passed with Python 3.12.3, GNU Bash 5.2.21, and Git 2.43.0.
+On 2026-08-06, the behavior suite passed with Python 3.12.3, GNU Bash 5.2.21, and Git 2.43.0.
 It uses real Git repositories and executable fake Windows/WSL kernel boundaries, so no host process is inspected or terminated while the parser, classifier, re-resolution, evidence, launcher, and refusal paths remain deterministic.
 
 ```sh
@@ -711,5 +711,5 @@ ok - post-route listener-pair changes fail verification
 ok - dirty expected checkout refuses restart after exact-PID termination
 ```
 
-The suite covers Windows listener JSON parsing, Windows drive and WSL UNC conversion, WSL-to-Windows conversion, exact Astro script/dev classification, Git source classification, command redaction, exact PID and full mutation-boundary re-resolution, unavailable Windows, WSL, and Firstmate task-state inspection, route-proof ordering, unrelated, unknown, or production-like processes, active task association, canonical relay identity, same-owner multiple bindings, the never-terminate relay boundary, the healthy relay pair, the stale native Astro recovery path, launcher shell validation and cleanup, post-route listener-pair changes, mismatched post-recovery route fingerprints, and expected-checkout revalidation before restart.
+The suite covers Windows listener JSON parsing, Windows drive and WSL UNC conversion, WSL-to-Windows conversion, exact Astro script/dev classification, Git source classification, command redaction, exact PID and full mutation-boundary re-resolution, unavailable Windows, WSL, and Firstmate task-state inspection, route-proof ordering, unrelated, unknown, or production-like processes, active task association and the shared task-state publication boundary, canonical relay identity, same-owner multiple bindings, the never-terminate relay boundary, the healthy relay pair, the stale native Astro recovery path, launcher shell validation and cleanup, post-route listener-pair changes, mismatched post-recovery route fingerprints, and expected-checkout revalidation before restart.
 Host-specific acceptance still requires `verify` against the actual project/port/expected-SHA tuple; private evidence remains under the active Firstmate home's gitignored `state/` tree rather than this maintained record.

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -672,3 +672,31 @@ The host-tool sequence was:
 Observed guarantee: a Desktop-owned thread can write Firstmate lifecycle files when the prompt provides an authorized absolute path, and create, send, read, and archive work at the Desktop host-tool layer.
 The missing guarantee remains a supported shell-callable bridge that lets Firstmate perform those operations against the same visible Desktop endpoint.
 App-server partial methods and raw socket experiments do not satisfy that bridge contract.
+
+## Cross-kernel localhost routing
+
+`bin/fm-localhost.py --help` is the single procedural owner for cross-kernel inspection, exact-PID recovery, launcher selection, and route verification.
+This section carries only the repeatable evidence for that active runtime guarantee.
+
+On 2026-08-05, the behavior suite passed with Python 3.12.3, GNU Bash 5.2.21, and Git 2.43.0.
+It uses real Git repositories and executable fake Windows/WSL kernel boundaries, so no host process is inspected or terminated while the parser, classifier, re-resolution, evidence, launcher, and refusal paths remain deterministic.
+
+```sh
+bash tests/fm-localhost.test.sh
+```
+
+Observed output:
+
+```text
+ok - localhost inspect parses listeners, converts Windows/WSL paths, classifies Git source, and redacts commands
+ok - stale native Windows Astro shadow recovers by exact PID to wslrelay plus clean WSL and matching routes
+ok - healthy wslrelay plus clean WSL server passes with matching browser-like route fingerprints
+ok - active Firstmate task ownership refuses recovery without termination
+ok - PID or command change between observations refuses exact-PID recovery
+ok - unknown commands and unrelated Windows repositories refuse without termination
+ok - unavailable Windows inspection refuses recovery without mutation
+ok - post-recovery Windows/WSL route fingerprint mismatch fails verification
+```
+
+The suite covers Windows listener JSON parsing, Windows drive and WSL UNC conversion, WSL-to-Windows conversion, Git source classification, command redaction, exact PID and command re-resolution, unavailable inspection, unrelated, unknown, or production-like processes, active task association, the never-terminate relay boundary, the healthy relay pair, the stale native Astro recovery path, and mismatched post-recovery route fingerprints.
+Host-specific acceptance still requires `verify` against the actual project/port/expected-SHA tuple; private evidence remains under the active Firstmate home's gitignored `state/` tree rather than this maintained record.

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -691,6 +691,9 @@ Observed output:
 ok - localhost inspect parses listeners, converts Windows/WSL paths, classifies Git source, and redacts commands
 ok - stale native Windows Astro shadow recovers by exact PID to wslrelay plus clean WSL and matching routes
 ok - healthy wslrelay plus clean WSL server passes with matching browser-like route fingerprints
+ok - relay verification requires complete canonical executable identity
+ok - same-owner multiple listener bindings remain a verified relay pair
+ok - same-owner multiple stale Windows bindings recover by one exact PID
 ok - active Firstmate task ownership refuses recovery without termination
 ok - PID or command change between observations refuses exact-PID recovery
 ok - node worker commands containing Astro words refuse exact-PID recovery
@@ -708,5 +711,5 @@ ok - post-route listener-pair changes fail verification
 ok - dirty expected checkout refuses restart after exact-PID termination
 ```
 
-The suite covers Windows listener JSON parsing, Windows drive and WSL UNC conversion, WSL-to-Windows conversion, exact Astro script/dev classification, Git source classification, command redaction, exact PID and full mutation-boundary re-resolution, unavailable Windows, WSL, and Firstmate task-state inspection, route-proof ordering, unrelated, unknown, or production-like processes, active task association, the never-terminate relay boundary, the healthy relay pair, the stale native Astro recovery path, launcher shell validation and cleanup, post-route listener-pair changes, mismatched post-recovery route fingerprints, and expected-checkout revalidation before restart.
+The suite covers Windows listener JSON parsing, Windows drive and WSL UNC conversion, WSL-to-Windows conversion, exact Astro script/dev classification, Git source classification, command redaction, exact PID and full mutation-boundary re-resolution, unavailable Windows, WSL, and Firstmate task-state inspection, route-proof ordering, unrelated, unknown, or production-like processes, active task association, canonical relay identity, same-owner multiple bindings, the never-terminate relay boundary, the healthy relay pair, the stale native Astro recovery path, launcher shell validation and cleanup, post-route listener-pair changes, mismatched post-recovery route fingerprints, and expected-checkout revalidation before restart.
 Host-specific acceptance still requires `verify` against the actual project/port/expected-SHA tuple; private evidence remains under the active Firstmate home's gitignored `state/` tree rather than this maintained record.

--- a/tests/fm-localhost.test.sh
+++ b/tests/fm-localhost.test.sh
@@ -24,10 +24,12 @@ case "$joined" in
     printf 'terminated\n'
     ;;
   *HttpClient*)
+    printf 'route\n' >> "${FM_ROUTE_LOG:?}"
     cat "${FM_WIN_ROUTE_JSON:?}"
     ;;
   *Get-NetTCPConnection*)
     [ "${FM_WINDOWS_INSPECTION_FAIL:-0}" != 1 ] || exit 1
+    [ ! -f "${FM_KILLED_MARKER:?}" ] || [ "${FM_POST_STOP_WINDOWS_FAIL:-0}" != 1 ] || exit 1
     if [ -f "${FM_KILLED_MARKER:?}" ] || [ "${FM_WIN_ALWAYS_RELAY:-0}" = 1 ]; then
       cat "${FM_WIN_RELAY_JSON:?}"
       exit 0
@@ -36,7 +38,12 @@ case "$joined" in
     [ ! -f "${FM_INSPECT_COUNT:?}" ] || count=$(cat "$FM_INSPECT_COUNT")
     count=$((count + 1))
     printf '%s\n' "$count" > "$FM_INSPECT_COUNT"
-    if [ "$count" -ge 2 ] && [ -n "${FM_WIN_SECOND_JSON:-}" ]; then
+    if [ "$count" -ge 3 ] && [ -n "${FM_WIN_THIRD_JSON:-}" ]; then
+      if [ -n "${FM_THIRD_TASK_FILE:-}" ]; then
+        printf 'project=%s\n' "${FM_THIRD_TASK_PROJECT:?}" > "$FM_THIRD_TASK_FILE"
+      fi
+      cat "$FM_WIN_THIRD_JSON"
+    elif [ "$count" -ge 2 ] && [ -n "${FM_WIN_SECOND_JSON:-}" ]; then
       cat "$FM_WIN_SECOND_JSON"
     else
       cat "${FM_WIN_INITIAL_JSON:?}"
@@ -54,6 +61,8 @@ case "${FM_WSL_MODE:-none}" in
   always) show=1 ;;
   after-launch) [ -f "${FM_LAUNCH_MARKER:?}" ] && show=1 ;;
 esac
+[ "${FM_WSL_INSPECTION_FAIL:-0}" != 1 ] || exit 1
+[ ! -f "${FM_KILLED_MARKER:?}" ] || [ "${FM_POST_STOP_WSL_FAIL:-0}" != 1 ] || exit 1
 if [ "$show" -eq 1 ]; then
   printf 'LISTEN 0 4096 0.0.0.0:%s 0.0.0.0:* users:(("node",pid=%s,fd=20))\n' \
     "${FM_TEST_PORT:?}" "${FM_WSL_PID:?}"
@@ -65,6 +74,10 @@ cat > "$FAKEBIN/npm" <<'SH'
 set -u
 printf '%s\n' "$*" > "${FM_NPM_LOG:?}"
 : > "${FM_LAUNCH_MARKER:?}"
+if [ "${FM_NPM_STAY_ALIVE:-0}" = 1 ]; then
+  trap 'exit 0' TERM INT
+  while :; do sleep 1; done
+fi
 SH
 
 chmod +x "$FAKEBIN/powershell.exe" "$FAKEBIN/ss" "$FAKEBIN/npm"
@@ -115,7 +128,7 @@ JSON
 
   write_listener_json "$dir/win-initial.json" 43123 127.0.0.1 4100 node.exe \
     'C:\Program Files\nodejs\node.exe' \
-    '"C:\Program Files\nodejs\node.exe" "C:\repos\stale checkout\node_modules\astro\astro.js" dev --token super-secret-value --vm-id {1f662e3a-0323-4e37-a59f-304f0161cf55}'
+    '"C:\Program Files\nodejs\node.exe" "C:\repos\stale checkout\node_modules\astro\astro.js" dev --token super-secret-value --header "X-Api-Key: header-secret" --json {"token":"json-secret"} --vm-id {1f662e3a-0323-4e37-a59f-304f0161cf55}'
   write_listener_json "$dir/win-relay.json" 43123 0.0.0.0 5100 wslrelay.exe \
     'C:\Windows\System32\wslrelay.exe' ''
   git -C "$dir/expected" rev-parse HEAD > "$dir/expected.sha"
@@ -126,6 +139,7 @@ run_case() {
   local dir=$1 mode=$2 out=$3
   shift 3
   rm -f "$dir/inspect-count" "$dir/killed" "$dir/launched" "$dir/npm.log"
+  rm -f "$dir/route.log"
   : > "$dir/stop.log"
   env \
     PATH="$FAKEBIN:$PATH" \
@@ -142,10 +156,17 @@ run_case() {
     FM_WIN_INITIAL_JSON="$dir/win-initial.json" \
     FM_WIN_RELAY_JSON="$dir/win-relay.json" \
     FM_WIN_ROUTE_JSON="$dir/win-route.json" \
+    FM_ROUTE_LOG="$dir/route.log" \
     FM_KILLED_MARKER="$dir/killed" \
     FM_STOP_LOG="$dir/stop.log" \
     FM_LAUNCH_MARKER="$dir/launched" \
     FM_NPM_LOG="$dir/npm.log" \
+    FM_NPM_STAY_ALIVE="${FM_NPM_STAY_ALIVE:-0}" \
+    FM_WIN_THIRD_JSON="${FM_WIN_THIRD_JSON:-}" \
+    FM_THIRD_TASK_FILE="${FM_THIRD_TASK_FILE:-}" \
+    FM_THIRD_TASK_PROJECT="${FM_THIRD_TASK_PROJECT:-}" \
+    FM_POST_STOP_WINDOWS_FAIL="${FM_POST_STOP_WINDOWS_FAIL:-0}" \
+    FM_POST_STOP_WSL_FAIL="${FM_POST_STOP_WSL_FAIL:-0}" \
     "$@" \
     "$HELPER" "$mode" "$dir/expected" 43123 "$(cat "$dir/expected.sha")" > "$out" 2>&1
 }
@@ -162,6 +183,9 @@ test_listener_parsing_path_conversion_source_and_redaction() {
   assert_grep 'classification=native-windows-node-astro-dev' "$out" "Astro development server was not classified"
   assert_grep '--token <redacted>' "$out" "sensitive command flag was not redacted"
   assert_no_grep 'super-secret-value' "$out" "raw command secret reached output"
+  assert_grep 'X-Api-Key: <redacted>' "$out" "header credential was not redacted"
+  assert_no_grep 'header-secret' "$out" "header credential reached output"
+  assert_no_grep 'json-secret' "$out" "JSON credential reached output"
   assert_no_grep '1f662e3a-0323-4e37-a59f-304f0161cf55' "$out" "raw local process identifier reached output"
 
   local unc_command
@@ -241,6 +265,21 @@ test_pid_or_command_change_refuses_on_immediate_reresolution() {
   pass "PID or command change between observations refuses exact-PID recovery"
 }
 
+test_worker_with_astro_words_refuses() {
+  local dir out
+  dir=$(make_case worker)
+  out="$dir/out"
+  write_listener_json "$dir/win-initial.json" 43123 127.0.0.1 4100 node.exe \
+    'C:\Program Files\nodejs\node.exe' \
+    '"C:\Program Files\nodejs\node.exe" "C:\repos\stale checkout\worker.js" --name astro dev'
+  if FM_WSL_MODE=none run_case "$dir" recover "$out"; then
+    fail "worker command containing Astro words was accepted"
+  fi
+  assert_grep 'refuse:windows-process-is-not-proven-node-astro-dev' "$out" "worker command did not refuse"
+  [ ! -s "$dir/stop.log" ] || fail "worker command refusal still called termination"
+  pass "node worker commands containing Astro words refuse exact-PID recovery"
+}
+
 test_unknown_and_unrelated_windows_processes_refuse() {
   local dir out unrelated
   dir=$(make_case unknown)
@@ -287,17 +326,89 @@ test_windows_inspection_failure_is_safe() {
   pass "unavailable Windows inspection refuses recovery without mutation"
 }
 
+test_wsl_inspection_failure_is_safe() {
+  local dir out
+  dir=$(make_case wsl-inspection-failure)
+  out="$dir/out"
+  if FM_WSL_MODE=none FM_WSL_INSPECTION_FAIL=1 run_case "$dir" recover "$out"; then
+    fail "WSL inspection failure was accepted"
+  fi
+  assert_grep 'refuse:wsl-inspection-unavailable' "$out" "WSL inspection failure did not produce a safe refusal"
+  [ ! -s "$dir/stop.log" ] || fail "WSL inspection failure still called termination"
+  pass "unavailable WSL inspection refuses recovery without mutation"
+}
+
+test_verify_proves_pair_before_route_requests() {
+  local dir out
+  dir=$(make_case verify-order)
+  out="$dir/out"
+  if FM_WSL_MODE=none run_case "$dir" verify "$out"; then
+    fail "unverified localhost route passed"
+  fi
+  [ ! -s "$dir/route.log" ] || fail "verify fingerprinted localhost before proving ownership"
+  assert_grep 'reason=windows-owner-is-not-wslrelay' "$out" "verify did not report the unverified owner"
+  pass "verify proves the listener pair before contacting localhost"
+}
+
+test_mutation_recheck_refuses_new_task() {
+  local dir out
+  dir=$(make_case mutation-task)
+  out="$dir/out"
+  if FM_WSL_MODE=none FM_WIN_THIRD_JSON="$dir/win-initial.json" \
+    FM_THIRD_TASK_FILE="$dir/state/live.meta" FM_THIRD_TASK_PROJECT="$dir/mount/c/repos/stale checkout" \
+    run_case "$dir" recover "$out"; then
+    fail "active task appearing at mutation boundary was accepted"
+  fi
+  assert_grep 'refuse:pid-or-command-reresolution-changed' "$out" "mutation-boundary task was not refused"
+  [ ! -s "$dir/stop.log" ] || fail "mutation-boundary task refusal still called termination"
+  pass "fresh mutation-boundary source and task proof blocks termination"
+}
+
+test_post_stop_inspection_failure_blocks_restart() {
+  local dir out
+  dir=$(make_case post-stop-failure)
+  out="$dir/out"
+  if FM_WSL_MODE=after-launch FM_POST_STOP_WINDOWS_FAIL=1 run_case "$dir" recover "$out"; then
+    fail "post-stop inspection failure was accepted"
+  fi
+  assert_grep 'failed:windows-inspection-unavailable' "$out" "post-stop inspection failure was not reported"
+  [ ! -e "$dir/npm.log" ] || fail "post-stop inspection failure launched npm"
+  [ "$(wc -l < "$dir/stop.log" | tr -d ' ')" = 1 ] || fail "post-stop inspection failure did not preserve exact termination"
+  pass "post-stop inspection failure blocks any restart"
+}
+
+test_launcher_script_rejects_shell_metacharacters() {
+  local dir out
+  dir=$(make_case launcher-shell)
+  out="$dir/out"
+  printf '%s\n' '{"scripts":{"dev":"astro dev $(touch injected-file)"}}' > "$dir/expected/package.json"
+  git -C "$dir/expected" add package.json
+  git -C "$dir/expected" commit -qm malicious-launcher
+  git -C "$dir/expected" rev-parse HEAD > "$dir/expected.sha"
+  if FM_WSL_MODE=none run_case "$dir" recover "$out"; then
+    fail "shell metacharacters in the launcher were accepted"
+  fi
+  assert_grep 'refuse:project dev launcher is not proven to be Astro dev' "$out" "launcher shell metacharacters did not refuse"
+  assert_no_grep 'Traceback' "$out" "launcher refusal escaped as a traceback"
+  [ ! -s "$dir/stop.log" ] || fail "launcher refusal still called termination"
+  pass "Astro launcher scripts with shell metacharacters refuse recovery"
+}
+
 test_post_recovery_fingerprint_mismatch_fails() {
   local dir out
   dir=$(make_case route-mismatch)
   out="$dir/out"
   printf '{"status":200,"sha256":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","length":4}\n' > "$dir/win-route.json"
-  if FM_WSL_MODE=after-launch run_case "$dir" recover "$out"; then
+  if FM_WSL_MODE=after-launch FM_NPM_STAY_ALIVE=1 run_case "$dir" recover "$out"; then
     fail "post-recovery route mismatch passed"
   fi
   assert_grep 'failed:post-recovery-verification' "$out" "post-recovery mismatch was not reported"
   assert_grep 'route-fingerprint-mismatch' "$out" "route mismatch reason was not reported"
   [ "$(wc -l < "$dir/stop.log" | tr -d ' ')" = 1 ] || fail "mismatch case did not preserve exact single-PID termination"
+  local launcher_pid
+  launcher_pid=$(sed -n 's/.*launcher_pid=\([0-9][0-9]*\).*/\1/p' "$out" | tail -1)
+  [ -n "$launcher_pid" ] || fail "failed recovery did not report the owned launcher PID"
+  ! kill -0 "$launcher_pid" 2>/dev/null || fail "failed recovery left the owned launcher running"
   pass "post-recovery Windows/WSL route fingerprint mismatch fails verification"
 }
 
@@ -306,6 +417,12 @@ test_native_stale_windows_shadow_recovers_to_verified_pair
 test_healthy_relay_and_clean_wsl_verify
 test_active_task_refuses_without_termination
 test_pid_or_command_change_refuses_on_immediate_reresolution
+test_worker_with_astro_words_refuses
 test_unknown_and_unrelated_windows_processes_refuse
 test_windows_inspection_failure_is_safe
+test_wsl_inspection_failure_is_safe
+test_verify_proves_pair_before_route_requests
+test_mutation_recheck_refuses_new_task
+test_post_stop_inspection_failure_blocks_restart
+test_launcher_script_rejects_shell_metacharacters
 test_post_recovery_fingerprint_mismatch_fails

--- a/tests/fm-localhost.test.sh
+++ b/tests/fm-localhost.test.sh
@@ -108,7 +108,7 @@ PY
 }
 
 make_case() {
-  local name=$1 dir="$TMP_ROOT/$1" seed="$TMP_ROOT/$1/seed"
+  local dir="$TMP_ROOT/$1" seed="$TMP_ROOT/$1/seed"
   mkdir -p "$dir" "$seed"
   git -C "$seed" init -q -b main
   cat > "$seed/package.json" <<'JSON'
@@ -198,7 +198,7 @@ test_listener_parsing_path_conversion_source_and_redaction() {
   assert_grep 'owner_kernel=windows' "$out" "inspect omitted the Windows owner"
   assert_grep "checkout=$dir/mount/c/repos/stale checkout" "$out" "Windows drive path did not resolve to its checkout"
   assert_grep 'dirty=dirty' "$out" "inspect did not classify the stale source as dirty"
-  assert_contains "$(cat "$out")" 'checkout_windows=\\wsl.localhost\TestDistro\' "WSL checkout did not convert to its Windows UNC path"
+  assert_contains "$(cat "$out")" "checkout_windows=\\\\wsl.localhost\TestDistro\\" "WSL checkout did not convert to its Windows UNC path"
   assert_grep 'classification=native-windows-node-astro-dev' "$out" "Astro development server was not classified"
   assert_grep '--token <redacted>' "$out" "sensitive command flag was not redacted"
   assert_no_grep 'super-secret-value' "$out" "raw command secret reached output"
@@ -427,7 +427,9 @@ test_launcher_script_rejects_shell_metacharacters() {
   local dir out
   dir=$(make_case launcher-shell)
   out="$dir/out"
-  printf '%s\n' '{"scripts":{"dev":"astro dev $(touch injected-file)"}}' > "$dir/expected/package.json"
+  cat > "$dir/expected/package.json" <<'JSON'
+{"scripts":{"dev":"astro dev $(touch injected-file)"}}
+JSON
   git -C "$dir/expected" add package.json
   git -C "$dir/expected" commit -qm malicious-launcher
   git -C "$dir/expected" rev-parse HEAD > "$dir/expected.sha"

--- a/tests/fm-localhost.test.sh
+++ b/tests/fm-localhost.test.sh
@@ -1,0 +1,311 @@
+#!/usr/bin/env bash
+# Behavior coverage for the cross-kernel localhost owner. The suite drives the
+# public inspect/recover/verify interface through fake Windows kernel probes and
+# real Git repositories; it never calls internal Python functions.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+fm_git_identity localhost-tests localhost-tests@example.invalid
+
+HELPER="$ROOT/bin/fm-localhost.py"
+TMP_ROOT=$(fm_test_tmproot fm-localhost-tests)
+FAKEBIN=$(fm_fakebin "$TMP_ROOT")
+
+cat > "$FAKEBIN/powershell.exe" <<'SH'
+#!/usr/bin/env bash
+set -u
+joined=$*
+case "$joined" in
+  *Stop-Process*)
+    [ "${FM_WINDOWS_STOP_FAIL:-0}" != 1 ] || exit 1
+    printf 'stop\n' >> "${FM_STOP_LOG:?}"
+    : > "${FM_KILLED_MARKER:?}"
+    printf 'terminated\n'
+    ;;
+  *HttpClient*)
+    cat "${FM_WIN_ROUTE_JSON:?}"
+    ;;
+  *Get-NetTCPConnection*)
+    [ "${FM_WINDOWS_INSPECTION_FAIL:-0}" != 1 ] || exit 1
+    if [ -f "${FM_KILLED_MARKER:?}" ] || [ "${FM_WIN_ALWAYS_RELAY:-0}" = 1 ]; then
+      cat "${FM_WIN_RELAY_JSON:?}"
+      exit 0
+    fi
+    count=0
+    [ ! -f "${FM_INSPECT_COUNT:?}" ] || count=$(cat "$FM_INSPECT_COUNT")
+    count=$((count + 1))
+    printf '%s\n' "$count" > "$FM_INSPECT_COUNT"
+    if [ "$count" -ge 2 ] && [ -n "${FM_WIN_SECOND_JSON:-}" ]; then
+      cat "$FM_WIN_SECOND_JSON"
+    else
+      cat "${FM_WIN_INITIAL_JSON:?}"
+    fi
+    ;;
+  *) exit 2 ;;
+esac
+SH
+
+cat > "$FAKEBIN/ss" <<'SH'
+#!/usr/bin/env bash
+set -u
+show=0
+case "${FM_WSL_MODE:-none}" in
+  always) show=1 ;;
+  after-launch) [ -f "${FM_LAUNCH_MARKER:?}" ] && show=1 ;;
+esac
+if [ "$show" -eq 1 ]; then
+  printf 'LISTEN 0 4096 0.0.0.0:%s 0.0.0.0:* users:(("node",pid=%s,fd=20))\n' \
+    "${FM_TEST_PORT:?}" "${FM_WSL_PID:?}"
+fi
+SH
+
+cat > "$FAKEBIN/npm" <<'SH'
+#!/usr/bin/env bash
+set -u
+printf '%s\n' "$*" > "${FM_NPM_LOG:?}"
+: > "${FM_LAUNCH_MARKER:?}"
+SH
+
+chmod +x "$FAKEBIN/powershell.exe" "$FAKEBIN/ss" "$FAKEBIN/npm"
+
+write_listener_json() {
+  local path=$1 port=$2 address=$3 pid=$4 process=$5 executable=$6 command=$7
+  python3 - "$path" "$port" "$address" "$pid" "$process" "$executable" "$command" <<'PY'
+import json, sys
+path, port, address, pid, process, executable, command = sys.argv[1:]
+with open(path, "w", encoding="utf-8") as handle:
+    json.dump([{"address": address, "port": int(port), "pid": int(pid),
+                "process": process, "executable": executable or None,
+                "command": command or None}], handle)
+PY
+}
+
+make_case() {
+  local name=$1 dir="$TMP_ROOT/$1" seed="$TMP_ROOT/$1/seed"
+  mkdir -p "$dir" "$seed"
+  git -C "$seed" init -q -b main
+  cat > "$seed/package.json" <<'JSON'
+{"scripts":{"dev":"astro dev"}}
+JSON
+  printf 'node_modules/\n' > "$seed/.gitignore"
+  printf 'canonical\n' > "$seed/page.txt"
+  git -C "$seed" add package.json .gitignore page.txt
+  git -C "$seed" commit -qm canonical
+  git clone -q --bare "$seed" "$dir/origin.git"
+  git -C "$dir/origin.git" symbolic-ref HEAD refs/heads/main
+
+  mkdir -p "$dir/mount/c/repos"
+  git clone -q "$dir/origin.git" "$dir/mount/c/repos/stale checkout"
+  git clone -q "$dir/origin.git" "$dir/expected"
+  mkdir -p "$dir/mount/c/repos/stale checkout/node_modules/astro"
+  mkdir -p "$dir/expected/node_modules/astro"
+  : > "$dir/mount/c/repos/stale checkout/node_modules/astro/astro.js"
+  : > "$dir/expected/node_modules/astro/astro.js"
+  printf 'stale local edit\n' >> "$dir/mount/c/repos/stale checkout/page.txt"
+
+  mkdir -p "$dir/state" "$dir/proc/9200"
+  printf 'node\n' > "$dir/proc/9200/comm"
+  printf 'node\0%s\0dev\0--port\0%s\0' \
+    "$dir/expected/node_modules/astro/astro.js" 43123 > "$dir/proc/9200/cmdline"
+  ln -s "$dir/expected" "$dir/proc/9200/cwd"
+  printf '{"status":200,"sha256":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","length":4}\n' > "$dir/wsl-route.json"
+  cp "$dir/wsl-route.json" "$dir/win-route.json"
+  : > "$dir/stop.log"
+
+  write_listener_json "$dir/win-initial.json" 43123 127.0.0.1 4100 node.exe \
+    'C:\Program Files\nodejs\node.exe' \
+    '"C:\Program Files\nodejs\node.exe" "C:\repos\stale checkout\node_modules\astro\astro.js" dev --token super-secret-value --vm-id {1f662e3a-0323-4e37-a59f-304f0161cf55}'
+  write_listener_json "$dir/win-relay.json" 43123 0.0.0.0 5100 wslrelay.exe \
+    'C:\Windows\System32\wslrelay.exe' ''
+  git -C "$dir/expected" rev-parse HEAD > "$dir/expected.sha"
+  printf '%s\n' "$dir"
+}
+
+run_case() {
+  local dir=$1 mode=$2 out=$3
+  shift 3
+  rm -f "$dir/inspect-count" "$dir/killed" "$dir/launched" "$dir/npm.log"
+  : > "$dir/stop.log"
+  env \
+    PATH="$FAKEBIN:$PATH" \
+    WSL_DISTRO_NAME=TestDistro \
+    FM_LOCALHOST_TESTING=1 \
+    FM_STATE_OVERRIDE="$dir/state" \
+    FM_LOCALHOST_WINDOWS_MOUNT_ROOT="$dir/mount" \
+    FM_LOCALHOST_PROC_ROOT="$dir/proc" \
+    FM_LOCALHOST_TEST_WSL_ROUTE_JSON="$dir/wsl-route.json" \
+    FM_LOCALHOST_START_TIMEOUT=1 \
+    FM_TEST_PORT=43123 \
+    FM_WSL_PID=9200 \
+    FM_INSPECT_COUNT="$dir/inspect-count" \
+    FM_WIN_INITIAL_JSON="$dir/win-initial.json" \
+    FM_WIN_RELAY_JSON="$dir/win-relay.json" \
+    FM_WIN_ROUTE_JSON="$dir/win-route.json" \
+    FM_KILLED_MARKER="$dir/killed" \
+    FM_STOP_LOG="$dir/stop.log" \
+    FM_LAUNCH_MARKER="$dir/launched" \
+    FM_NPM_LOG="$dir/npm.log" \
+    "$@" \
+    "$HELPER" "$mode" "$dir/expected" 43123 "$(cat "$dir/expected.sha")" > "$out" 2>&1
+}
+
+test_listener_parsing_path_conversion_source_and_redaction() {
+  local dir out
+  dir=$(make_case inspect)
+  out="$dir/out"
+  FM_WSL_MODE=none run_case "$dir" inspect "$out" || fail "inspect should complete: $(cat "$out")"
+  assert_grep 'owner_kernel=windows' "$out" "inspect omitted the Windows owner"
+  assert_grep "checkout=$dir/mount/c/repos/stale checkout" "$out" "Windows drive path did not resolve to its checkout"
+  assert_grep 'dirty=dirty' "$out" "inspect did not classify the stale source as dirty"
+  assert_contains "$(cat "$out")" 'checkout_windows=\\wsl.localhost\TestDistro\' "WSL checkout did not convert to its Windows UNC path"
+  assert_grep 'classification=native-windows-node-astro-dev' "$out" "Astro development server was not classified"
+  assert_grep '--token <redacted>' "$out" "sensitive command flag was not redacted"
+  assert_no_grep 'super-secret-value' "$out" "raw command secret reached output"
+  assert_no_grep '1f662e3a-0323-4e37-a59f-304f0161cf55' "$out" "raw local process identifier reached output"
+
+  local unc_command
+  unc_command="node.exe \"\\\\wsl.localhost\\TestDistro${dir//\//\\}\\mount\\c\\repos\\stale checkout\\node_modules\\astro\\astro.js\" dev"
+  write_listener_json "$dir/win-initial.json" 43123 127.0.0.1 4100 node.exe 'C:\Program Files\nodejs\node.exe' "$unc_command"
+  FM_WSL_MODE=none run_case "$dir" inspect "$out" || fail "UNC inspect should complete: $(cat "$out")"
+  assert_grep "checkout=$dir/mount/c/repos/stale checkout" "$out" "WSL UNC path did not resolve to its checkout"
+  pass "localhost inspect parses listeners, converts Windows/WSL paths, classifies Git source, and redacts commands"
+}
+
+test_native_stale_windows_shadow_recovers_to_verified_pair() {
+  local dir out
+  dir=$(make_case recover)
+  out="$dir/out"
+  FM_WSL_MODE=after-launch run_case "$dir" recover "$out" || fail "eligible recovery failed: $(cat "$out")"
+  [ "$(wc -l < "$dir/stop.log" | tr -d ' ')" = 1 ] || fail "recovery did not issue exactly one termination"
+  assert_grep 'recovered-and-verified' "$out" "recovery did not verify the final pair"
+  assert_grep 'terminated-exact-pid:4100' "$out" "recovery did not report the exact PID"
+  assert_grep 'run dev -- --host 0.0.0.0 --port 43123' "$dir/npm.log" "recovery used an unexpected launcher"
+  local evidence
+  evidence=$(find "$dir/state/localhost-evidence" -type f -name '*.evidence' -print -quit)
+  [ -n "$evidence" ] || fail "recovery did not write private evidence"
+  [ "$(stat -c %a "$evidence")" = 600 ] || fail "private evidence mode is not 0600"
+  pass "stale native Windows Astro shadow recovers by exact PID to wslrelay plus clean WSL and matching routes"
+}
+
+test_healthy_relay_and_clean_wsl_verify() {
+  local dir out
+  dir=$(make_case healthy)
+  out="$dir/out"
+  FM_WSL_MODE=always FM_WIN_ALWAYS_RELAY=1 run_case "$dir" verify "$out" || fail "healthy pair did not verify: $(cat "$out")"
+  assert_grep $'verification\tverdict=pass' "$out" "healthy verification did not pass"
+  [ ! -s "$dir/stop.log" ] || fail "verify attempted termination"
+  if FM_WSL_MODE=always FM_WIN_ALWAYS_RELAY=1 run_case "$dir" recover "$out"; then
+    fail "wslrelay owner was accepted as a recovery target"
+  fi
+  assert_grep 'refuse:wslrelay-is-never-terminated' "$out" "wslrelay recovery refusal was not reported"
+  [ ! -s "$dir/stop.log" ] || fail "wslrelay refusal still called termination"
+  pass "healthy wslrelay plus clean WSL server passes with matching browser-like route fingerprints"
+}
+
+test_active_task_refuses_without_termination() {
+  local dir out
+  dir=$(make_case active-task)
+  out="$dir/out"
+  printf 'window=fm-live\nworktree=%s\nproject=%s\n' \
+    "$dir/mount/c/repos/stale checkout" "$dir/mount/c/repos/stale checkout" > "$dir/state/live.meta"
+  if FM_WSL_MODE=none run_case "$dir" recover "$out"; then
+    fail "active task checkout was terminated"
+  fi
+  assert_grep 'refuse:active-firstmate-task-associated' "$out" "active task refusal was not reported"
+  [ ! -s "$dir/stop.log" ] || fail "active task refusal still called termination"
+  pass "active Firstmate task ownership refuses recovery without termination"
+}
+
+test_pid_or_command_change_refuses_on_immediate_reresolution() {
+  local dir out
+  dir=$(make_case reresolve)
+  out="$dir/out"
+  write_listener_json "$dir/win-second.json" 43123 127.0.0.1 4100 node.exe \
+    'C:\Program Files\nodejs\node.exe' \
+    '"C:\Program Files\nodejs\node.exe" "C:\repos\stale checkout\node_modules\astro\astro.js" dev --host 127.0.0.1'
+  if FM_WSL_MODE=none FM_WIN_SECOND_JSON="$dir/win-second.json" run_case "$dir" recover "$out"; then
+    fail "PID reuse/change was accepted"
+  fi
+  assert_grep 'refuse:pid-or-command-reresolution-changed' "$out" "PID change refusal was not reported"
+  [ ! -s "$dir/stop.log" ] || fail "PID change refusal still called termination"
+
+  write_listener_json "$dir/win-second.json" 43123 127.0.0.1 4101 node.exe \
+    'C:\Program Files\nodejs\node.exe' \
+    '"C:\Program Files\nodejs\node.exe" "C:\repos\stale checkout\node_modules\astro\astro.js" dev'
+  if FM_WSL_MODE=none FM_WIN_SECOND_JSON="$dir/win-second.json" run_case "$dir" recover "$out"; then
+    fail "changed PID was accepted"
+  fi
+  assert_grep 'refuse:pid-or-command-reresolution-changed' "$out" "changed PID refusal was not reported"
+  [ ! -s "$dir/stop.log" ] || fail "changed PID refusal still called termination"
+  pass "PID or command change between observations refuses exact-PID recovery"
+}
+
+test_unknown_and_unrelated_windows_processes_refuse() {
+  local dir out unrelated
+  dir=$(make_case unknown)
+  out="$dir/out"
+  write_listener_json "$dir/win-initial.json" 43123 127.0.0.1 4100 python.exe 'C:\Python\python.exe' ''
+  if FM_WSL_MODE=none run_case "$dir" recover "$out"; then
+    fail "unknown Windows command was accepted"
+  fi
+  assert_grep 'refuse:windows-process-is-not-proven-node-astro-dev' "$out" "unknown command refusal was not reported"
+  [ ! -s "$dir/stop.log" ] || fail "unknown command refusal still called termination"
+
+  write_listener_json "$dir/win-initial.json" 43123 127.0.0.1 4100 node.exe \
+    'C:\Program Files\nodejs\node.exe' \
+    '"C:\Program Files\nodejs\node.exe" "C:\repos\stale checkout\node_modules\astro\astro.js" preview'
+  if FM_WSL_MODE=none run_case "$dir" recover "$out"; then
+    fail "production-like Astro preview process was accepted"
+  fi
+  assert_grep 'refuse:windows-process-is-not-proven-node-astro-dev' "$out" "production-like refusal was not reported"
+  [ ! -s "$dir/stop.log" ] || fail "production-like refusal still called termination"
+
+  unrelated="$dir/unrelated.git"
+  git clone -q --bare "$dir/seed" "$unrelated"
+  git -C "$dir/mount/c/repos/stale checkout" remote set-url origin "$unrelated"
+  write_listener_json "$dir/win-initial.json" 43123 127.0.0.1 4100 node.exe \
+    'C:\Program Files\nodejs\node.exe' \
+    '"C:\Program Files\nodejs\node.exe" "C:\repos\stale checkout\node_modules\astro\astro.js" dev'
+  if FM_WSL_MODE=none run_case "$dir" recover "$out"; then
+    fail "unrelated Windows repository was accepted"
+  fi
+  assert_grep 'refuse:windows-process-is-unrelated' "$out" "unrelated repository refusal was not reported"
+  [ ! -s "$dir/stop.log" ] || fail "unrelated repository refusal still called termination"
+  pass "unknown commands and unrelated Windows repositories refuse without termination"
+}
+
+test_windows_inspection_failure_is_safe() {
+  local dir out
+  dir=$(make_case inspection-failure)
+  out="$dir/out"
+  if FM_WSL_MODE=none FM_WINDOWS_INSPECTION_FAIL=1 run_case "$dir" recover "$out"; then
+    fail "Windows inspection failure was accepted"
+  fi
+  assert_grep 'refuse:windows-inspection-unavailable' "$out" "Windows inspection failure did not produce a safe refusal"
+  [ ! -s "$dir/stop.log" ] || fail "inspection failure still called termination"
+  pass "unavailable Windows inspection refuses recovery without mutation"
+}
+
+test_post_recovery_fingerprint_mismatch_fails() {
+  local dir out
+  dir=$(make_case route-mismatch)
+  out="$dir/out"
+  printf '{"status":200,"sha256":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","length":4}\n' > "$dir/win-route.json"
+  if FM_WSL_MODE=after-launch run_case "$dir" recover "$out"; then
+    fail "post-recovery route mismatch passed"
+  fi
+  assert_grep 'failed:post-recovery-verification' "$out" "post-recovery mismatch was not reported"
+  assert_grep 'route-fingerprint-mismatch' "$out" "route mismatch reason was not reported"
+  [ "$(wc -l < "$dir/stop.log" | tr -d ' ')" = 1 ] || fail "mismatch case did not preserve exact single-PID termination"
+  pass "post-recovery Windows/WSL route fingerprint mismatch fails verification"
+}
+
+test_listener_parsing_path_conversion_source_and_redaction
+test_native_stale_windows_shadow_recovers_to_verified_pair
+test_healthy_relay_and_clean_wsl_verify
+test_active_task_refuses_without_termination
+test_pid_or_command_change_refuses_on_immediate_reresolution
+test_unknown_and_unrelated_windows_processes_refuse
+test_windows_inspection_failure_is_safe
+test_post_recovery_fingerprint_mismatch_fails

--- a/tests/fm-localhost.test.sh
+++ b/tests/fm-localhost.test.sh
@@ -21,15 +21,23 @@ case "$joined" in
     [ "${FM_WINDOWS_STOP_FAIL:-0}" != 1 ] || exit 1
     printf 'stop\n' >> "${FM_STOP_LOG:?}"
     : > "${FM_KILLED_MARKER:?}"
+    if [ -n "${FM_MUTATE_EXPECTED_AFTER_STOP:-}" ]; then
+      printf 'concurrent edit\n' >> "$FM_MUTATE_EXPECTED_AFTER_STOP"
+    fi
     printf 'terminated\n'
     ;;
   *HttpClient*)
     printf 'route\n' >> "${FM_ROUTE_LOG:?}"
+    : > "${FM_ROUTE_DONE_MARKER:?}"
     cat "${FM_WIN_ROUTE_JSON:?}"
     ;;
   *Get-NetTCPConnection*)
     [ "${FM_WINDOWS_INSPECTION_FAIL:-0}" != 1 ] || exit 1
     [ ! -f "${FM_KILLED_MARKER:?}" ] || [ "${FM_POST_STOP_WINDOWS_FAIL:-0}" != 1 ] || exit 1
+    if [ -f "${FM_ROUTE_DONE_MARKER:?}" ] && [ -n "${FM_WIN_POST_ROUTE_JSON:-}" ]; then
+      cat "$FM_WIN_POST_ROUTE_JSON"
+      exit 0
+    fi
     if [ -f "${FM_KILLED_MARKER:?}" ] || [ "${FM_WIN_ALWAYS_RELAY:-0}" = 1 ]; then
       cat "${FM_WIN_RELAY_JSON:?}"
       exit 0
@@ -38,7 +46,12 @@ case "$joined" in
     [ ! -f "${FM_INSPECT_COUNT:?}" ] || count=$(cat "$FM_INSPECT_COUNT")
     count=$((count + 1))
     printf '%s\n' "$count" > "$FM_INSPECT_COUNT"
-    if [ "$count" -ge 3 ] && [ -n "${FM_WIN_THIRD_JSON:-}" ]; then
+    if [ "$count" -ge 4 ] && [ -n "${FM_WIN_FOURTH_JSON:-}" ]; then
+      if [ -n "${FM_FOURTH_TASK_FILE:-}" ]; then
+        printf 'project=%s\n' "${FM_FOURTH_TASK_PROJECT:?}" > "$FM_FOURTH_TASK_FILE"
+      fi
+      cat "$FM_WIN_FOURTH_JSON"
+    elif [ "$count" -ge 3 ] && [ -n "${FM_WIN_THIRD_JSON:-}" ]; then
       if [ -n "${FM_THIRD_TASK_FILE:-}" ]; then
         printf 'project=%s\n' "${FM_THIRD_TASK_PROJECT:?}" > "$FM_THIRD_TASK_FILE"
       fi
@@ -139,7 +152,7 @@ run_case() {
   local dir=$1 mode=$2 out=$3
   shift 3
   rm -f "$dir/inspect-count" "$dir/killed" "$dir/launched" "$dir/npm.log"
-  rm -f "$dir/route.log"
+  rm -f "$dir/route.log" "$dir/route-done"
   : > "$dir/stop.log"
   env \
     PATH="$FAKEBIN:$PATH" \
@@ -157,14 +170,20 @@ run_case() {
     FM_WIN_RELAY_JSON="$dir/win-relay.json" \
     FM_WIN_ROUTE_JSON="$dir/win-route.json" \
     FM_ROUTE_LOG="$dir/route.log" \
+    FM_ROUTE_DONE_MARKER="$dir/route-done" \
     FM_KILLED_MARKER="$dir/killed" \
     FM_STOP_LOG="$dir/stop.log" \
     FM_LAUNCH_MARKER="$dir/launched" \
     FM_NPM_LOG="$dir/npm.log" \
     FM_NPM_STAY_ALIVE="${FM_NPM_STAY_ALIVE:-0}" \
     FM_WIN_THIRD_JSON="${FM_WIN_THIRD_JSON:-}" \
+    FM_WIN_FOURTH_JSON="${FM_WIN_FOURTH_JSON:-}" \
     FM_THIRD_TASK_FILE="${FM_THIRD_TASK_FILE:-}" \
     FM_THIRD_TASK_PROJECT="${FM_THIRD_TASK_PROJECT:-}" \
+    FM_FOURTH_TASK_FILE="${FM_FOURTH_TASK_FILE:-}" \
+    FM_FOURTH_TASK_PROJECT="${FM_FOURTH_TASK_PROJECT:-}" \
+    FM_WIN_POST_ROUTE_JSON="${FM_WIN_POST_ROUTE_JSON:-}" \
+    FM_MUTATE_EXPECTED_AFTER_STOP="${FM_MUTATE_EXPECTED_AFTER_STOP:-}" \
     FM_POST_STOP_WINDOWS_FAIL="${FM_POST_STOP_WINDOWS_FAIL:-0}" \
     FM_POST_STOP_WSL_FAIL="${FM_POST_STOP_WSL_FAIL:-0}" \
     "$@" \
@@ -338,6 +357,19 @@ test_wsl_inspection_failure_is_safe() {
   pass "unavailable WSL inspection refuses recovery without mutation"
 }
 
+test_task_state_inspection_failure_is_safe() {
+  local dir out
+  dir=$(make_case task-state-inspection-failure)
+  out="$dir/out"
+  rmdir "$dir/state"
+  if FM_WSL_MODE=none run_case "$dir" recover "$out"; then
+    fail "missing Firstmate task state was accepted"
+  fi
+  assert_grep 'refuse:firstmate-task-state-inspection-unavailable' "$out" "missing task state did not produce a safe refusal"
+  [ ! -s "$dir/stop.log" ] || fail "missing task state still called termination"
+  pass "unavailable Firstmate task-state inspection refuses recovery without termination"
+}
+
 test_verify_proves_pair_before_route_requests() {
   local dir out
   dir=$(make_case verify-order)
@@ -362,6 +394,20 @@ test_mutation_recheck_refuses_new_task() {
   assert_grep 'refuse:pid-or-command-reresolution-changed' "$out" "mutation-boundary task was not refused"
   [ ! -s "$dir/stop.log" ] || fail "mutation-boundary task refusal still called termination"
   pass "fresh mutation-boundary source and task proof blocks termination"
+}
+
+test_termination_boundary_refuses_new_task() {
+  local dir out
+  dir=$(make_case termination-boundary-task)
+  out="$dir/out"
+  if FM_WSL_MODE=none FM_WIN_FOURTH_JSON="$dir/win-initial.json" \
+    FM_FOURTH_TASK_FILE="$dir/state/live.meta" FM_FOURTH_TASK_PROJECT="$dir/mount/c/repos/stale checkout" \
+    run_case "$dir" recover "$out"; then
+    fail "active task appearing at termination boundary was accepted"
+  fi
+  assert_grep 'refuse:pid-or-command-reresolution-changed' "$out" "termination-boundary task was not refused"
+  [ ! -s "$dir/stop.log" ] || fail "termination-boundary task refusal still called termination"
+  pass "termination-boundary task proof blocks exact-PID termination"
 }
 
 test_post_stop_inspection_failure_blocks_restart() {
@@ -412,6 +458,33 @@ test_post_recovery_fingerprint_mismatch_fails() {
   pass "post-recovery Windows/WSL route fingerprint mismatch fails verification"
 }
 
+test_post_route_pair_change_fails_verification() {
+  local dir out
+  dir=$(make_case post-route-pair-change)
+  out="$dir/out"
+  if FM_WSL_MODE=after-launch FM_NPM_STAY_ALIVE=1 FM_WIN_POST_ROUTE_JSON="$dir/win-initial.json" \
+    run_case "$dir" recover "$out"; then
+    fail "post-route listener-pair change passed verification"
+  fi
+  assert_grep 'failed:post-recovery-verification' "$out" "post-route listener-pair change was not reported"
+  assert_grep 'windows-owner-is-not-wslrelay' "$out" "post-route listener-pair reason was not reported"
+  [ "$(wc -l < "$dir/stop.log" | tr -d ' ')" = 1 ] || fail "post-route pair change did not preserve exact single-PID termination"
+  pass "post-route listener-pair changes fail verification"
+}
+
+test_checkout_revalidation_blocks_dirty_restart() {
+  local dir out
+  dir=$(make_case checkout-revalidation)
+  out="$dir/out"
+  if FM_WSL_MODE=none FM_MUTATE_EXPECTED_AFTER_STOP="$dir/expected/page.txt" run_case "$dir" recover "$out"; then
+    fail "dirty expected checkout was launched"
+  fi
+  assert_grep 'failed:expected-checkout-dirty' "$out" "dirty expected checkout was not refused before restart"
+  [ ! -e "$dir/npm.log" ] || fail "dirty expected checkout still launched npm"
+  [ "$(wc -l < "$dir/stop.log" | tr -d ' ')" = 1 ] || fail "checkout revalidation did not preserve exact single-PID termination"
+  pass "dirty expected checkout refuses restart after exact-PID termination"
+}
+
 test_listener_parsing_path_conversion_source_and_redaction
 test_native_stale_windows_shadow_recovers_to_verified_pair
 test_healthy_relay_and_clean_wsl_verify
@@ -421,8 +494,12 @@ test_worker_with_astro_words_refuses
 test_unknown_and_unrelated_windows_processes_refuse
 test_windows_inspection_failure_is_safe
 test_wsl_inspection_failure_is_safe
+test_task_state_inspection_failure_is_safe
 test_verify_proves_pair_before_route_requests
 test_mutation_recheck_refuses_new_task
+test_termination_boundary_refuses_new_task
 test_post_stop_inspection_failure_blocks_restart
 test_launcher_script_rejects_shell_metacharacters
 test_post_recovery_fingerprint_mismatch_fails
+test_post_route_pair_change_fails_verification
+test_checkout_revalidation_blocks_dirty_restart

--- a/tests/fm-localhost.test.sh
+++ b/tests/fm-localhost.test.sh
@@ -19,6 +19,11 @@ joined=$*
 case "$joined" in
   *Stop-Process*)
     [ "${FM_WINDOWS_STOP_FAIL:-0}" != 1 ] || exit 1
+    case "$joined" in
+      *Process.CreationDate*) exit 1 ;;
+      *StartTime*) ;;
+      *) exit 1 ;;
+    esac
     printf 'stop\n' >> "${FM_STOP_LOG:?}"
     : > "${FM_KILLED_MARKER:?}"
     if [ -n "${FM_MUTATE_EXPECTED_AFTER_STOP:-}" ]; then
@@ -29,6 +34,17 @@ case "$joined" in
   *HttpClient*)
     printf 'route\n' >> "${FM_ROUTE_LOG:?}"
     : > "${FM_ROUTE_DONE_MARKER:?}"
+    if [ -n "${FM_MUTATE_WSL_START_DURING_ROUTE:-}" ] && [ ! -f "${FM_WSL_START_MUTATION_MARKER:?}" ]; then
+      python3 - "${FM_MUTATE_WSL_START_DURING_ROUTE}" <<'PY'
+from pathlib import Path
+import sys
+
+path = Path(sys.argv[1])
+pid = path.parent.name
+path.write_text(f"{pid} (node) S " + " ".join(["0"] * 18 + ["999999"]) + "\n", encoding="utf-8")
+PY
+      : > "$FM_WSL_START_MUTATION_MARKER"
+    fi
     if [ -n "${FM_MUTATE_EXPECTED_DURING_ROUTE:-}" ] && [ ! -f "${FM_ROUTE_MUTATION_MARKER:?}" ]; then
       printf 'concurrent route edit\n' >> "$FM_MUTATE_EXPECTED_DURING_ROUTE"
       : > "$FM_ROUTE_MUTATION_MARKER"
@@ -120,6 +136,26 @@ with open(path, "w", encoding="utf-8") as handle:
 PY
 }
 
+write_proc_stat() {
+  local path=$1 pid=$2 name=$3 start=$4
+  python3 - "$path" "$pid" "$name" "$start" <<'PY'
+from pathlib import Path
+import sys
+
+path, pid, name, start = sys.argv[1:]
+Path(path).write_text(f"{pid} ({name}) S " + " ".join(["0"] * 18 + [start]) + "\n", encoding="utf-8")
+PY
+}
+
+write_wsl_process_identity() {
+  local dir=$1 pid=$2 name=${3:-node} start=${4:-$2}
+  mkdir -p "$dir/proc/$pid" "$dir/node-bin"
+  : > "$dir/node-bin/$name"
+  printf '%s\n' "$name" > "$dir/proc/$pid/comm"
+  ln -sf "$dir/node-bin/$name" "$dir/proc/$pid/exe"
+  write_proc_stat "$dir/proc/$pid/stat" "$pid" "$name" "$start"
+}
+
 append_listener_json() {
   local path=$1 port=$2 address=$3 pid=$4 process=$5 executable=$6 command=$7 creation=${8:-creation-$4}
   python3 - "$path" "$port" "$address" "$pid" "$process" "$executable" "$command" "$creation" <<'PY'
@@ -159,8 +195,8 @@ JSON
   : > "$dir/expected/node_modules/astro/astro.js"
   printf 'stale local edit\n' >> "$dir/mount/c/repos/stale checkout/page.txt"
 
-  mkdir -p "$dir/state" "$dir/proc/9200"
-  printf 'node\n' > "$dir/proc/9200/comm"
+  mkdir -p "$dir/state"
+  write_wsl_process_identity "$dir" 9200 node 9200
   printf 'node\0%s\0dev\0--port\0%s\0' \
     "$dir/expected/node_modules/astro/astro.js" 43123 > "$dir/proc/9200/cmdline"
   ln -s "$dir/expected" "$dir/proc/9200/cwd"
@@ -178,7 +214,7 @@ JSON
 }
 
 run_case() {
-  local dir=$1 mode=$2 out=$3
+  local dir=$1 mode=$2 out=$3 port=${FM_CASE_PORT:-43123}
   shift 3
   rm -f "$dir/inspect-count" "$dir/killed" "$dir/launched" "$dir/npm.log"
   rm -f "$dir/route.log" "$dir/route-done"
@@ -190,9 +226,9 @@ run_case() {
     FM_STATE_OVERRIDE="$dir/state" \
     FM_LOCALHOST_WINDOWS_MOUNT_ROOT="$dir/mount" \
     FM_LOCALHOST_PROC_ROOT="$dir/proc" \
-    FM_LOCALHOST_TEST_WSL_ROUTE_JSON="$dir/wsl-route.json" \
+    FM_LOCALHOST_TEST_WSL_ROUTE_JSON="${FM_WSL_ROUTE_FIXTURE-$dir/wsl-route.json}" \
     FM_LOCALHOST_START_TIMEOUT=1 \
-    FM_TEST_PORT=43123 \
+    FM_TEST_PORT="$port" \
     FM_WSL_PID=9200 \
     FM_WSL_SECOND_PID="${FM_WSL_SECOND_PID:-}" \
     FM_LOCALHOST_TEST_LOCK_ATTEMPTS="${FM_LOCALHOST_TEST_LOCK_ATTEMPTS:-50}" \
@@ -219,10 +255,12 @@ run_case() {
     FM_MUTATE_EXPECTED_AFTER_STOP="${FM_MUTATE_EXPECTED_AFTER_STOP:-}" \
     FM_MUTATE_EXPECTED_DURING_ROUTE="${FM_MUTATE_EXPECTED_DURING_ROUTE:-}" \
     FM_ROUTE_MUTATION_MARKER="$dir/route-mutated" \
+    FM_MUTATE_WSL_START_DURING_ROUTE="${FM_MUTATE_WSL_START_DURING_ROUTE:-}" \
+    FM_WSL_START_MUTATION_MARKER="$dir/wsl-start-mutated" \
     FM_POST_STOP_WINDOWS_FAIL="${FM_POST_STOP_WINDOWS_FAIL:-0}" \
     FM_POST_STOP_WSL_FAIL="${FM_POST_STOP_WSL_FAIL:-0}" \
     "$@" \
-    "$HELPER" "$mode" "$dir/expected" 43123 "$(cat "$dir/expected.sha")" > "$out" 2>&1
+    "$HELPER" "$mode" "$dir/expected" "$port" "$(cat "$dir/expected.sha")" > "$out" 2>&1
 }
 
 test_listener_parsing_path_conversion_source_and_redaction() {
@@ -363,8 +401,7 @@ test_multiple_wsl_owners_refuse_before_termination() {
   local dir out
   dir=$(make_case multiple-wsl-owners)
   out="$dir/out"
-  mkdir -p "$dir/proc/9300"
-  printf 'node\n' > "$dir/proc/9300/comm"
+  write_wsl_process_identity "$dir" 9300 node 9300
   printf 'node\0%s\0dev\0--port\0%s\0' \
     "$dir/expected/node_modules/astro/astro.js" 43123 > "$dir/proc/9300/cmdline"
   ln -s "$dir/expected" "$dir/proc/9300/cwd"
@@ -389,11 +426,43 @@ test_wsl_listener_must_remain_on_default_branch() {
   pass "WSL listener verification requires the default branch"
 }
 
+test_wsl_process_identity_is_required_and_stable() {
+  local dir out
+  dir=$(make_case wsl-process-identity)
+  out="$dir/out"
+  rm "$dir/proc/9200/exe"
+  if FM_WSL_MODE=always FM_WIN_ALWAYS_RELAY=1 run_case "$dir" verify "$out"; then
+    fail "WSL listener without executable identity passed verification"
+  fi
+  assert_grep 'reason=wsl-listener-identity-mismatch' "$out" "missing WSL executable identity did not refuse"
+  [ ! -s "$dir/route.log" ] || fail "missing WSL executable identity reached route verification"
+
+  ln -s "$dir/node-bin/node" "$dir/proc/9200/exe"
+  if FM_WSL_MODE=always FM_WIN_ALWAYS_RELAY=1 \
+    FM_MUTATE_WSL_START_DURING_ROUTE="$dir/proc/9200/stat" run_case "$dir" verify "$out"; then
+    fail "WSL PID reused after route inspection passed verification"
+  fi
+  assert_grep 'reason=listener-identity-changed' "$out" "changed WSL start identity did not refuse"
+}
+
 test_production_like_wsl_and_launcher_refuse() {
   local dir out
   dir=$(make_case production-like)
   out="$dir/out"
-  printf 'node\0%s\0dev\0--mode\0production\0' \
+
+  write_listener_json "$dir/win-initial.json" 43123 127.0.0.1 4100 node.exe \
+    'C:\Program Files\nodejs\node.exe' \
+    '"C:\Program Files\nodejs\node.exe" "C:\repos\stale checkout\node_modules\astro\astro.js" dev --mode '\''production'\'''
+  if FM_WSL_MODE=none run_case "$dir" recover "$out"; then
+    fail "quoted production-like Windows Astro command was accepted"
+  fi
+  assert_grep 'refuse:windows-process-is-not-proven-node-astro-dev' "$out" "quoted production-like Windows command did not refuse"
+  [ ! -s "$dir/stop.log" ] || fail "quoted production-like Windows command still called termination"
+
+  write_listener_json "$dir/win-initial.json" 43123 127.0.0.1 4100 node.exe \
+    'C:\Program Files\nodejs\node.exe' \
+    '"C:\Program Files\nodejs\node.exe" "C:\repos\stale checkout\node_modules\astro\astro.js" dev'
+  printf "node\0%s\0dev\0--mode='production'\0" \
     "$dir/expected/node_modules/astro/astro.js" > "$dir/proc/9200/cmdline"
   if FM_WSL_MODE=always run_case "$dir" recover "$out"; then
     fail "production-like WSL Astro command was accepted"
@@ -402,7 +471,7 @@ test_production_like_wsl_and_launcher_refuse() {
   [ ! -s "$dir/stop.log" ] || fail "production-like WSL command still called termination"
 
   cat > "$dir/expected/package.json" <<'JSON'
-{"scripts":{"dev":"astro dev --mode production"}}
+{"scripts":{"dev":"astro dev --mode 'production'"}}
 JSON
   git -C "$dir/expected" add package.json
   git -C "$dir/expected" commit -qm production-like
@@ -412,6 +481,18 @@ JSON
   fi
   assert_grep 'refuse:project dev launcher is not proven to be Astro dev' "$out" "production-like project launcher did not refuse"
   [ ! -s "$dir/stop.log" ] || fail "production-like project launcher still called termination"
+
+  cat > "$dir/expected/package.json" <<'JSON'
+{"scripts":{"dev":"npx astro dev"}}
+JSON
+  git -C "$dir/expected" add package.json
+  git -C "$dir/expected" commit -qm npx-launcher
+  git -C "$dir/expected" rev-parse HEAD > "$dir/expected.sha"
+  if FM_WSL_MODE=none run_case "$dir" recover "$out"; then
+    fail "installer-capable npx project launcher was accepted"
+  fi
+  assert_grep 'refuse:project dev launcher is not proven to be Astro dev' "$out" "npx project launcher did not refuse"
+  [ ! -s "$dir/stop.log" ] || fail "npx project launcher still called termination"
   pass "production-like WSL owners and project launchers refuse recovery"
 }
 
@@ -585,6 +666,64 @@ test_verify_proves_pair_before_route_requests() {
   pass "verify proves the listener pair before contacting localhost"
 }
 
+test_verify_refuses_route_redirects() {
+  local dir out port server_pid verified
+  dir=$(make_case route-redirect)
+  out="$dir/out"
+  python3 - "$dir/server-port" > "$dir/server.log" 2>&1 <<'PY' &
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+import sys
+
+class Handler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        if self.path == "/":
+            self.send_response(302)
+            self.send_header("Location", "/final")
+            self.end_headers()
+            return
+        body = b"final-body"
+        self.send_response(200)
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, _format, *_args):
+        return
+
+server = HTTPServer(("127.0.0.1", 0), Handler)
+server.timeout = 1
+Path(sys.argv[1]).write_text(str(server.server_address[1]), encoding="utf-8")
+server.handle_request()
+server.handle_request()
+PY
+  server_pid=$!
+  while [ ! -s "$dir/server-port" ]; do
+    kill -0 "$server_pid" 2>/dev/null || fail "redirect fixture server failed to start"
+    sleep 0.05
+  done
+  port=$(cat "$dir/server-port")
+  python3 - "$dir/win-route.json" <<'PY'
+import hashlib
+import json
+from pathlib import Path
+import sys
+
+body = b"final-body"
+Path(sys.argv[1]).write_text(json.dumps({"status": 200, "sha256": hashlib.sha256(body).hexdigest(), "length": len(body)}) + "\n", encoding="utf-8")
+PY
+  write_listener_json "$dir/win-relay.json" "$port" 0.0.0.0 5100 wslrelay.exe \
+    'C:\Windows\System32\wslrelay.exe' ''
+  verified=0
+  if FM_CASE_PORT="$port" FM_WSL_ROUTE_FIXTURE='' FM_WSL_MODE=always FM_WIN_ALWAYS_RELAY=1 \
+    run_case "$dir" verify "$out"; then
+    verified=1
+  fi
+  wait "$server_pid" || fail "redirect fixture server exited unsuccessfully"
+  [ "$verified" -eq 0 ] || fail "redirected localhost route passed verification"
+  assert_grep 'reason=WSL route fingerprint failed' "$out" "redirected WSL route did not refuse"
+}
+
 test_mutation_recheck_refuses_new_task() {
   local dir out
   dir=$(make_case mutation-task)
@@ -700,6 +839,7 @@ test_active_task_refuses_without_termination
 test_active_wsl_task_refuses_recovery_and_verification
 test_multiple_wsl_owners_refuse_before_termination
 test_wsl_listener_must_remain_on_default_branch
+test_wsl_process_identity_is_required_and_stable
 test_production_like_wsl_and_launcher_refuse
 test_task_state_lock_wait_is_bounded
 test_pid_or_command_change_refuses_on_immediate_reresolution
@@ -710,6 +850,7 @@ test_windows_inspection_failure_is_safe
 test_wsl_inspection_failure_is_safe
 test_task_state_inspection_failure_is_safe
 test_verify_proves_pair_before_route_requests
+test_verify_refuses_route_redirects
 test_mutation_recheck_refuses_new_task
 test_termination_boundary_refuses_new_task
 test_post_stop_inspection_failure_blocks_restart

--- a/tests/fm-localhost.test.sh
+++ b/tests/fm-localhost.test.sh
@@ -107,6 +107,21 @@ with open(path, "w", encoding="utf-8") as handle:
 PY
 }
 
+append_listener_json() {
+  local path=$1 port=$2 address=$3 pid=$4 process=$5 executable=$6 command=$7
+  python3 - "$path" "$port" "$address" "$pid" "$process" "$executable" "$command" <<'PY'
+import json, sys
+path, port, address, pid, process, executable, command = sys.argv[1:]
+with open(path, encoding="utf-8") as handle:
+    rows = json.load(handle)
+rows.append({"address": address, "port": int(port), "pid": int(pid),
+             "process": process, "executable": executable or None,
+             "command": command or None})
+with open(path, "w", encoding="utf-8") as handle:
+    json.dump(rows, handle)
+PY
+}
+
 make_case() {
   local dir="$TMP_ROOT/$1" seed="$TMP_ROOT/$1/seed"
   mkdir -p "$dir" "$seed"
@@ -246,6 +261,43 @@ test_healthy_relay_and_clean_wsl_verify() {
   pass "healthy wslrelay plus clean WSL server passes with matching browser-like route fingerprints"
 }
 
+test_relay_identity_requires_canonical_executable() {
+  local dir out
+  dir=$(make_case relay-identity)
+  out="$dir/out"
+  write_listener_json "$dir/win-relay.json" 43123 0.0.0.0 5100 wslrelay.exe '' ''
+  if FM_WSL_MODE=always FM_WIN_ALWAYS_RELAY=1 run_case "$dir" verify "$out"; then
+    fail "relay with missing executable identity passed verification"
+  fi
+  assert_grep 'reason=windows-owner-is-not-wslrelay' "$out" "missing relay executable identity did not refuse"
+  [ ! -s "$dir/route.log" ] || fail "missing relay executable identity reached route verification"
+  pass "relay verification requires complete canonical executable identity"
+}
+
+test_same_owner_multiple_bindings_verify() {
+  local dir out
+  dir=$(make_case multiple-bindings)
+  out="$dir/out"
+  append_listener_json "$dir/win-relay.json" 43123 :: 5100 wslrelay.exe \
+    'C:\Windows\System32\wslrelay.exe' ''
+  FM_WSL_MODE=always FM_WIN_ALWAYS_RELAY=1 run_case "$dir" verify "$out" || fail "same-owner multiple bindings did not verify: $(cat "$out")"
+  assert_grep $'verification\tverdict=pass' "$out" "same-owner multiple bindings did not pass"
+  pass "same-owner multiple listener bindings remain a verified relay pair"
+}
+
+test_same_owner_multiple_bindings_recover() {
+  local dir out
+  dir=$(make_case multiple-bindings-recover)
+  out="$dir/out"
+  append_listener_json "$dir/win-initial.json" 43123 :: 4100 node.exe \
+    'C:\Program Files\nodejs\node.exe' \
+    '"C:\Program Files\nodejs\node.exe" "C:\repos\stale checkout\node_modules\astro\astro.js" dev --token super-secret-value --header "X-Api-Key: header-secret" --json {"token":"json-secret"} --vm-id {1f662e3a-0323-4e37-a59f-304f0161cf55}'
+  FM_WSL_MODE=after-launch run_case "$dir" recover "$out" || fail "same-owner multiple stale bindings did not recover: $(cat "$out")"
+  [ "$(wc -l < "$dir/stop.log" | tr -d ' ')" = 1 ] || fail "same-owner multiple bindings did not issue one exact termination"
+  assert_grep 'recovered-and-verified' "$out" "same-owner multiple stale bindings did not verify"
+  pass "same-owner multiple stale Windows bindings recover by one exact PID"
+}
+
 test_active_task_refuses_without_termination() {
   local dir out
   dir=$(make_case active-task)
@@ -367,6 +419,10 @@ test_task_state_inspection_failure_is_safe() {
   fi
   assert_grep 'refuse:firstmate-task-state-inspection-unavailable' "$out" "missing task state did not produce a safe refusal"
   [ ! -s "$dir/stop.log" ] || fail "missing task state still called termination"
+  if FM_WSL_MODE=none run_case "$dir" inspect "$out"; then
+    fail "inspect accepted missing Firstmate task state"
+  fi
+  assert_grep $'owner_kernel=firstmate\tstatus=unavailable' "$out" "inspect did not report missing task state"
   pass "unavailable Firstmate task-state inspection refuses recovery without termination"
 }
 
@@ -490,6 +546,9 @@ test_checkout_revalidation_blocks_dirty_restart() {
 test_listener_parsing_path_conversion_source_and_redaction
 test_native_stale_windows_shadow_recovers_to_verified_pair
 test_healthy_relay_and_clean_wsl_verify
+test_relay_identity_requires_canonical_executable
+test_same_owner_multiple_bindings_verify
+test_same_owner_multiple_bindings_recover
 test_active_task_refuses_without_termination
 test_pid_or_command_change_refuses_on_immediate_reresolution
 test_worker_with_astro_words_refuses

--- a/tests/fm-localhost.test.sh
+++ b/tests/fm-localhost.test.sh
@@ -34,6 +34,10 @@ case "$joined" in
   *Get-NetTCPConnection*)
     [ "${FM_WINDOWS_INSPECTION_FAIL:-0}" != 1 ] || exit 1
     [ ! -f "${FM_KILLED_MARKER:?}" ] || [ "${FM_POST_STOP_WINDOWS_FAIL:-0}" != 1 ] || exit 1
+    if [ -n "${FM_MUTATE_WSL_BRANCH_ON_INSPECT:-}" ] && [ ! -f "${FM_BRANCH_MUTATION_MARKER:?}" ]; then
+      git -C "$FM_MUTATE_WSL_BRANCH_ON_INSPECT" switch -q -c feature
+      : > "$FM_BRANCH_MUTATION_MARKER"
+    fi
     if [ -f "${FM_ROUTE_DONE_MARKER:?}" ] && [ -n "${FM_WIN_POST_ROUTE_JSON:-}" ]; then
       cat "$FM_WIN_POST_ROUTE_JSON"
       exit 0
@@ -79,6 +83,10 @@ esac
 if [ "$show" -eq 1 ]; then
   printf 'LISTEN 0 4096 0.0.0.0:%s 0.0.0.0:* users:(("node",pid=%s,fd=20))\n' \
     "${FM_TEST_PORT:?}" "${FM_WSL_PID:?}"
+  if [ -n "${FM_WSL_SECOND_PID:-}" ]; then
+    printf 'LISTEN 0 4096 [::]:%s [::]:* users:(("node",pid=%s,fd=21))\n' \
+      "${FM_TEST_PORT:?}" "$FM_WSL_SECOND_PID"
+  fi
 fi
 SH
 
@@ -180,6 +188,10 @@ run_case() {
     FM_LOCALHOST_START_TIMEOUT=1 \
     FM_TEST_PORT=43123 \
     FM_WSL_PID=9200 \
+    FM_WSL_SECOND_PID="${FM_WSL_SECOND_PID:-}" \
+    FM_LOCALHOST_TEST_LOCK_ATTEMPTS="${FM_LOCALHOST_TEST_LOCK_ATTEMPTS:-50}" \
+    FM_MUTATE_WSL_BRANCH_ON_INSPECT="${FM_MUTATE_WSL_BRANCH_ON_INSPECT:-}" \
+    FM_BRANCH_MUTATION_MARKER="$dir/branch-mutated" \
     FM_INSPECT_COUNT="$dir/inspect-count" \
     FM_WIN_INITIAL_JSON="$dir/win-initial.json" \
     FM_WIN_RELAY_JSON="$dir/win-relay.json" \
@@ -271,7 +283,15 @@ test_relay_identity_requires_canonical_executable() {
   fi
   assert_grep 'reason=windows-owner-is-not-wslrelay' "$out" "missing relay executable identity did not refuse"
   [ ! -s "$dir/route.log" ] || fail "missing relay executable identity reached route verification"
-  pass "relay verification requires complete canonical executable identity"
+
+  write_listener_json "$dir/win-relay.json" 43123 0.0.0.0 5100 wslrelay.exe \
+    'C:\Users\x\wslrelay.exe' ''
+  if FM_WSL_MODE=always FM_WIN_ALWAYS_RELAY=1 run_case "$dir" verify "$out"; then
+    fail "relay outside the trusted Windows system path passed verification"
+  fi
+  assert_grep 'reason=windows-owner-is-not-wslrelay' "$out" "untrusted relay path did not refuse"
+  [ ! -s "$dir/route.log" ] || fail "untrusted relay path reached route verification"
+  pass "relay verification requires the trusted canonical Windows system identity"
 }
 
 test_same_owner_multiple_bindings_verify() {
@@ -310,6 +330,77 @@ test_active_task_refuses_without_termination() {
   assert_grep 'refuse:active-firstmate-task-associated' "$out" "active task refusal was not reported"
   [ ! -s "$dir/stop.log" ] || fail "active task refusal still called termination"
   pass "active Firstmate task ownership refuses recovery without termination"
+}
+
+test_active_wsl_task_refuses_recovery_and_verification() {
+  local dir out
+  dir=$(make_case active-wsl-task)
+  out="$dir/out"
+  printf 'window=fm-live\nworktree=%s\nproject=%s\n' \
+    "$dir/expected" "$dir/expected" > "$dir/state/live.meta"
+  if FM_WSL_MODE=always run_case "$dir" recover "$out"; then
+    fail "active WSL task ownership allowed Windows termination"
+  fi
+  assert_grep 'refuse:active-firstmate-task-associated' "$out" "active WSL task did not refuse recovery"
+  [ ! -s "$dir/stop.log" ] || fail "active WSL task refusal still called termination"
+  if FM_WSL_MODE=always FM_WIN_ALWAYS_RELAY=1 run_case "$dir" verify "$out"; then
+    fail "active WSL task ownership passed verification"
+  fi
+  assert_grep 'reason=active-firstmate-task-associated' "$out" "active WSL task did not refuse verification"
+  [ ! -s "$dir/route.log" ] || fail "active WSL task reached route verification"
+  pass "active WSL task ownership refuses recovery and verification"
+}
+
+test_multiple_wsl_owners_refuse_before_termination() {
+  local dir out
+  dir=$(make_case multiple-wsl-owners)
+  out="$dir/out"
+  mkdir -p "$dir/proc/9300"
+  printf 'node\n' > "$dir/proc/9300/comm"
+  printf 'node\0%s\0dev\0--port\0%s\0' \
+    "$dir/expected/node_modules/astro/astro.js" 43123 > "$dir/proc/9300/cmdline"
+  ln -s "$dir/expected" "$dir/proc/9300/cwd"
+  if FM_WSL_MODE=always FM_WSL_SECOND_PID=9300 run_case "$dir" recover "$out"; then
+    fail "multiple WSL owners allowed Windows termination"
+  fi
+  assert_grep 'refuse:ambiguous-wsl-ownership' "$out" "multiple WSL owners did not refuse recovery"
+  [ ! -s "$dir/stop.log" ] || fail "ambiguous WSL ownership still called termination"
+  pass "multiple WSL owners refuse recovery before mutation"
+}
+
+test_wsl_listener_must_remain_on_default_branch() {
+  local dir out
+  dir=$(make_case wsl-feature-branch)
+  out="$dir/out"
+  if FM_WSL_MODE=always FM_WIN_ALWAYS_RELAY=1 FM_MUTATE_WSL_BRANCH_ON_INSPECT="$dir/expected" \
+    run_case "$dir" verify "$out"; then
+    fail "feature-branch WSL listener passed current-main verification"
+  fi
+  assert_grep 'reason=wsl-listener-identity-mismatch' "$out" "feature-branch WSL listener did not refuse"
+  [ ! -s "$dir/route.log" ] || fail "feature-branch WSL listener reached route verification"
+  pass "WSL listener verification requires the default branch"
+}
+
+test_task_state_lock_wait_is_bounded() {
+  local dir out holder
+  dir=$(make_case task-state-lock-timeout)
+  out="$dir/out"
+  mkfifo "$dir/lock-input"
+  bash "$ROOT/bin/fm-task-state-lock.sh" "$dir/state" 50 < "$dir/lock-input" > "$dir/lock-output" &
+  holder=$!
+  exec 9>"$dir/lock-input"
+  while ! grep -qx locked "$dir/lock-output" 2>/dev/null; do
+    kill -0 "$holder" 2>/dev/null || fail "task-state lock holder exited before acquiring the lock"
+    sleep 0.05
+  done
+  if FM_WSL_MODE=none FM_LOCALHOST_TEST_LOCK_ATTEMPTS=2 run_case "$dir" recover "$out"; then
+    fail "contended task-state lock was accepted"
+  fi
+  assert_grep 'refuse:firstmate-task-state-boundary-timeout' "$out" "lock timeout did not produce a safe refusal"
+  [ ! -s "$dir/stop.log" ] || fail "lock timeout still called termination"
+  exec 9>&-
+  wait "$holder" || fail "task-state lock holder did not release cleanly"
+  pass "task-state publication lock contention refuses within a fixed bound"
 }
 
 test_pid_or_command_change_refuses_on_immediate_reresolution() {
@@ -550,6 +641,10 @@ test_relay_identity_requires_canonical_executable
 test_same_owner_multiple_bindings_verify
 test_same_owner_multiple_bindings_recover
 test_active_task_refuses_without_termination
+test_active_wsl_task_refuses_recovery_and_verification
+test_multiple_wsl_owners_refuse_before_termination
+test_wsl_listener_must_remain_on_default_branch
+test_task_state_lock_wait_is_bounded
 test_pid_or_command_change_refuses_on_immediate_reresolution
 test_worker_with_astro_words_refuses
 test_unknown_and_unrelated_windows_processes_refuse

--- a/tests/fm-localhost.test.sh
+++ b/tests/fm-localhost.test.sh
@@ -29,6 +29,10 @@ case "$joined" in
   *HttpClient*)
     printf 'route\n' >> "${FM_ROUTE_LOG:?}"
     : > "${FM_ROUTE_DONE_MARKER:?}"
+    if [ -n "${FM_MUTATE_EXPECTED_DURING_ROUTE:-}" ] && [ ! -f "${FM_ROUTE_MUTATION_MARKER:?}" ]; then
+      printf 'concurrent route edit\n' >> "$FM_MUTATE_EXPECTED_DURING_ROUTE"
+      : > "$FM_ROUTE_MUTATION_MARKER"
+    fi
     cat "${FM_WIN_ROUTE_JSON:?}"
     ;;
   *Get-NetTCPConnection*)
@@ -104,25 +108,27 @@ SH
 chmod +x "$FAKEBIN/powershell.exe" "$FAKEBIN/ss" "$FAKEBIN/npm"
 
 write_listener_json() {
-  local path=$1 port=$2 address=$3 pid=$4 process=$5 executable=$6 command=$7
-  python3 - "$path" "$port" "$address" "$pid" "$process" "$executable" "$command" <<'PY'
+  local path=$1 port=$2 address=$3 pid=$4 process=$5 executable=$6 command=$7 creation=${8:-creation-$4}
+  python3 - "$path" "$port" "$address" "$pid" "$process" "$executable" "$command" "$creation" <<'PY'
 import json, sys
-path, port, address, pid, process, executable, command = sys.argv[1:]
+path, port, address, pid, process, executable, command, creation = sys.argv[1:]
 with open(path, "w", encoding="utf-8") as handle:
     json.dump([{"address": address, "port": int(port), "pid": int(pid),
+                "creation": creation,
                 "process": process, "executable": executable or None,
                 "command": command or None}], handle)
 PY
 }
 
 append_listener_json() {
-  local path=$1 port=$2 address=$3 pid=$4 process=$5 executable=$6 command=$7
-  python3 - "$path" "$port" "$address" "$pid" "$process" "$executable" "$command" <<'PY'
+  local path=$1 port=$2 address=$3 pid=$4 process=$5 executable=$6 command=$7 creation=${8:-creation-$4}
+  python3 - "$path" "$port" "$address" "$pid" "$process" "$executable" "$command" "$creation" <<'PY'
 import json, sys
-path, port, address, pid, process, executable, command = sys.argv[1:]
+path, port, address, pid, process, executable, command, creation = sys.argv[1:]
 with open(path, encoding="utf-8") as handle:
     rows = json.load(handle)
 rows.append({"address": address, "port": int(port), "pid": int(pid),
+             "creation": creation,
              "process": process, "executable": executable or None,
              "command": command or None})
 with open(path, "w", encoding="utf-8") as handle:
@@ -211,6 +217,8 @@ run_case() {
     FM_FOURTH_TASK_PROJECT="${FM_FOURTH_TASK_PROJECT:-}" \
     FM_WIN_POST_ROUTE_JSON="${FM_WIN_POST_ROUTE_JSON:-}" \
     FM_MUTATE_EXPECTED_AFTER_STOP="${FM_MUTATE_EXPECTED_AFTER_STOP:-}" \
+    FM_MUTATE_EXPECTED_DURING_ROUTE="${FM_MUTATE_EXPECTED_DURING_ROUTE:-}" \
+    FM_ROUTE_MUTATION_MARKER="$dir/route-mutated" \
     FM_POST_STOP_WINDOWS_FAIL="${FM_POST_STOP_WINDOWS_FAIL:-0}" \
     FM_POST_STOP_WSL_FAIL="${FM_POST_STOP_WSL_FAIL:-0}" \
     "$@" \
@@ -381,6 +389,32 @@ test_wsl_listener_must_remain_on_default_branch() {
   pass "WSL listener verification requires the default branch"
 }
 
+test_production_like_wsl_and_launcher_refuse() {
+  local dir out
+  dir=$(make_case production-like)
+  out="$dir/out"
+  printf 'node\0%s\0dev\0--mode\0production\0' \
+    "$dir/expected/node_modules/astro/astro.js" > "$dir/proc/9200/cmdline"
+  if FM_WSL_MODE=always run_case "$dir" recover "$out"; then
+    fail "production-like WSL Astro command was accepted"
+  fi
+  assert_grep 'refuse:wsl-port-owned-by-unexpected-process' "$out" "production-like WSL command did not refuse"
+  [ ! -s "$dir/stop.log" ] || fail "production-like WSL command still called termination"
+
+  cat > "$dir/expected/package.json" <<'JSON'
+{"scripts":{"dev":"astro dev --mode production"}}
+JSON
+  git -C "$dir/expected" add package.json
+  git -C "$dir/expected" commit -qm production-like
+  git -C "$dir/expected" rev-parse HEAD > "$dir/expected.sha"
+  if FM_WSL_MODE=none run_case "$dir" recover "$out"; then
+    fail "production-like project launcher was accepted"
+  fi
+  assert_grep 'refuse:project dev launcher is not proven to be Astro dev' "$out" "production-like project launcher did not refuse"
+  [ ! -s "$dir/stop.log" ] || fail "production-like project launcher still called termination"
+  pass "production-like WSL owners and project launchers refuse recovery"
+}
+
 test_task_state_lock_wait_is_bounded() {
   local dir out holder
   dir=$(make_case task-state-lock-timeout)
@@ -424,7 +458,29 @@ test_pid_or_command_change_refuses_on_immediate_reresolution() {
   fi
   assert_grep 'refuse:pid-or-command-reresolution-changed' "$out" "changed PID refusal was not reported"
   [ ! -s "$dir/stop.log" ] || fail "changed PID refusal still called termination"
+
+  write_listener_json "$dir/win-second.json" 43123 127.0.0.1 4100 node.exe \
+    'C:\Program Files\nodejs\node.exe' \
+    '"C:\Program Files\nodejs\node.exe" "C:\repos\stale checkout\node_modules\astro\astro.js" dev' \
+    creation-reused
+  if FM_WSL_MODE=none FM_WIN_SECOND_JSON="$dir/win-second.json" run_case "$dir" recover "$out"; then
+    fail "reused PID with a different creation identity was accepted"
+  fi
+  assert_grep 'refuse:pid-or-command-reresolution-changed' "$out" "creation identity change was not reported"
+  [ ! -s "$dir/stop.log" ] || fail "creation identity change still called termination"
   pass "PID or command change between observations refuses exact-PID recovery"
+}
+
+test_verify_revalidates_expected_checkout() {
+  local dir out
+  dir=$(make_case verify-checkout-revalidation)
+  out="$dir/out"
+  if FM_WSL_MODE=always FM_WIN_ALWAYS_RELAY=1 FM_MUTATE_EXPECTED_DURING_ROUTE="$dir/expected/page.txt" \
+    run_case "$dir" verify "$out"; then
+    fail "verify accepted a checkout changed during route fingerprinting"
+  fi
+  assert_grep 'reason=expected-checkout-dirty' "$out" "verify did not report the changed expected checkout"
+  pass "verify revalidates the expected checkout after route inspection"
 }
 
 test_worker_with_astro_words_refuses() {
@@ -644,8 +700,10 @@ test_active_task_refuses_without_termination
 test_active_wsl_task_refuses_recovery_and_verification
 test_multiple_wsl_owners_refuse_before_termination
 test_wsl_listener_must_remain_on_default_branch
+test_production_like_wsl_and_launcher_refuse
 test_task_state_lock_wait_is_bounded
 test_pid_or_command_change_refuses_on_immediate_reresolution
+test_verify_revalidates_expected_checkout
 test_worker_with_astro_words_refuses
 test_unknown_and_unrelated_windows_processes_refuse
 test_windows_inspection_failure_is_safe

--- a/tests/fm-spawn-batch.test.sh
+++ b/tests/fm-spawn-batch.test.sh
@@ -141,8 +141,36 @@ test_scout_batch_refuses_delivery_flags() {
   pass "scout batch refuses ship delivery flags instead of ignoring them"
 }
 
+test_task_state_publication_lock_wait_is_bounded() {
+  local dir state home holder out status
+  dir="$TMP_ROOT/task-state-lock"
+  state="$dir/state"
+  home="$dir/home"
+  mkdir -p "$state" "$home/data" "$home/config"
+  mkfifo "$dir/lock-input"
+  bash "$ROOT/bin/fm-task-state-lock.sh" "$state" 50 < "$dir/lock-input" > "$dir/lock-output" &
+  holder=$!
+  exec 9>"$dir/lock-input"
+  while ! grep -qx locked "$dir/lock-output" 2>/dev/null; do
+    kill -0 "$holder" 2>/dev/null || fail "task-state lock holder exited before acquiring the lock"
+    sleep 0.05
+  done
+  out=$(timeout 8s env \
+    FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" FM_STATE_OVERRIDE="$state" \
+    FM_DATA_OVERRIDE="$home/data" FM_CONFIG_OVERRIDE="$home/config" FM_SPAWN_NO_GUARD=1 \
+    "$SPAWN" lock-timeout-q1 "$home" claude --mode no-mistakes --yolo off 2>&1)
+  status=$?
+  [ "$status" -ne 0 ] || fail "contended task-state publication lock was accepted"
+  printf '%s\n' "$out" | grep -F 'task-state publication lock timed out' >/dev/null \
+    || fail "contended task-state publication lock did not refuse with a bounded timeout"
+  exec 9>&-
+  wait "$holder" || fail "task-state lock holder did not release cleanly"
+  pass "task-state publication lock contention refuses within a fixed bound"
+}
+
 test_batch_dispatches_every_pair
 test_batch_mode_boundaries
 test_batch_requires_the_shared_delivery_contract
 test_scout_batch_refuses_delivery_flags
 test_projects_path_scoping
+test_task_state_publication_lock_wait_is_bounded

--- a/tests/fm-test-run.test.sh
+++ b/tests/fm-test-run.test.sh
@@ -104,6 +104,7 @@ init_changed_fixture_repo() {
     fm-afk-pi-herdr-return-e2e.test.sh \
     fm-backend.test.sh \
     fm-pr-merge.test.sh \
+    fm-localhost.test.sh \
     fm-pi-watch-extension.test.sh \
     fm-afk-return.test.sh \
     fm-bearings-snapshot.test.sh \
@@ -116,6 +117,7 @@ init_changed_fixture_repo() {
   : >"$repo/tests/lib.sh"
   : >"$repo/tests/fm-backend-herdr-eventwait.test.py"
   : >"$repo/bin/fm-supervisor-target-lib.sh"
+  : >"$repo/bin/fm-task-state-lock.sh"
   : >"$repo/bin/unmapped-source.sh"
   printf '# .claude/settings.json\n# .pi/extensions/fm-primary-turnend-guard.ts\n' \
     >>"$repo/tests/fm-cd-pretool-check.test.sh"
@@ -158,6 +160,12 @@ test_changed_dependency_selection_and_unmapped_failure() {
   assert_contains "$listed" "tests/fm-afk-return.test.sh" "supervisor target selects afk coverage"
   git -C "$repo" add bin/fm-supervisor-target-lib.sh
   git -C "$repo" -c user.name=test -c user.email=test@example.invalid commit -qm supervisor-change
+
+  printf '\n' >>"$repo/bin/fm-task-state-lock.sh"
+  listed=$(cd "$repo" && bin/fm-test-run.sh --list --changed --base HEAD)
+  assert_contains "$listed" "tests/fm-localhost.test.sh" "task-state lock selects localhost coverage"
+  git -C "$repo" add bin/fm-task-state-lock.sh
+  git -C "$repo" -c user.name=test -c user.email=test@example.invalid commit -qm task-state-lock-change
 
   printf '\n' >>"$repo/.agents/skills/example/SKILL.md"
   printf '\n' >>"$repo/.claude/settings.json"


### PR DESCRIPTION
## Intent

Implement Firstmate-wide prevention and closure for cross-kernel localhost shadowing. Provide one reusable inspect/recover/verify helper for a project, reserved port, and expected canonical SHA, with its --help as the single mechanics owner. Inspect Windows and WSL listener/process/Git/task identity and report redacted ownership evidence. Permit automatic mutation only for an independently proven stale native-Windows Node/Astro dev PID from the same repository, with an immediate identity recheck, no active Firstmate task, a private pre-mutation evidence record, and a clean expected current-main WSL replacement; refuse every ambiguous, changed, unrelated, production-like, unavailable-inspection, missing-identity, active-task, or wslrelay case, and never use process-name or port-wide kills. After exact-PID termination, restart only the verified project Astro launcher and require the expected wslrelay/WSL pair plus matching Windows- and WSL-origin browser-context fingerprints. Include deterministic tests, a concise AGENTS trigger, maintained documentation and verification evidence, and the test-family mapping. The separate global iteration-sandbox skill edit is intentionally excluded from this repository commit. Deliver as a draft PR, do not merge.

## What Changed

- Added a reusable localhost inspect/recover/verify helper covering Windows and WSL listener, process, Git, and task identity evidence.
- Added guarded exact-PID recovery for stale native-Windows development processes, task-state locking, deterministic localhost tests, and changed-path test-family mapping.
- Updated AGENTS.md, runtime-backend documentation, and verification evidence for cross-kernel localhost protection.

## Risk Assessment

🚨 High: Required safety invariants remain reachable through active WSL tasks, ambiguous WSL ownership, and non-main or unrelated relay identities, while the new lock helper also breaks changed-test selection until mapped.

## Testing

Validated the localhost inspect/recover/verify contract and deterministic refusal/recovery paths, ran the focused localhost and test-runner suites, confirmed changed-file selection includes the localhost tests, captured CLI evidence, and found no remaining actionable issues.

<details>
<summary>Evidence: Localhost helper contract</summary>

```text
usage: fm-localhost.py [-h] {inspect,recover,verify} project port expected_sha

Inspect or narrowly recover localhost ownership across native Windows and WSL.

positional arguments:
  {inspect,recover,verify}
  project
  port
  expected_sha

options:
  -h, --help            show this help message and exit

mechanics (authoritative):
  The tuple is <project> <port> <expected-sha>. <project> must be the intended
  clean WSL default-branch checkout, and <expected-sha> must be its full 40-hex
  canonical commit. inspect reports every Windows and WSL listener with owner
  kernel, address, PID, process, redacted command, checkout, branch, SHA, dirty
  state, normalized Git source, task association, classification, and recovery
  verdict. It reads Windows listeners and process identity through fixed
  non-interactive PowerShell, WSL listeners through ss and /proc, and task
  associations from this Firstmate home's state/*.meta. It never reads a
  process environment, credentials, production data, or hosted data.

  recover is deliberately narrower than inspect. It may stop exactly one PID
  only after complete observations, including a fresh mutation-boundary
  recheck, independently prove that the same PID still owns every
  native-Windows binding of the reserved port; the unchanged
  process is node.exe whose first script argument resolves to that checkout's
  node_modules/astro/astro.js or astro.mjs and is followed immediately by `dev`;
  that checkout is dirty,
  divergent, or otherwise noncanonical; no task record names that checkout or
  PID; WSL has no unrelated port owner; and the requested replacement is clean,
  on the repository default branch, at expected-sha. Unknown commands, changed
  PIDs or commands, multiple Windows owners, unrelated sources, task records,
  missing identity, Windows inspection failure, canonical Windows source,
  production-like commands, and every wslrelay.exe owner refuse recovery.
  Recovery never kills by process name or port and never targets wslrelay.exe.

  Immediately before mutation, recover re-resolves listener, PID, command,
  checkout, Git, and task evidence. The termination boundary repeats that
  complete proof after the evidence is fsynced while holding the shared
  Firstmate task-state publication boundary; task creation and metadata
  publication use that same boundary. It writes a mode-0600 record beneath
  $FM_HOME/state/localhost-evidence before invoking fixed PowerShell that again
  requires the exact PID, port, node.exe identity, unchanged command hash, and
  exact Astro script path followed by `dev`. After the exact PID exits, it
  re-resolves the clean expected checkout and runs only that project's package.json
  `scripts.dev` when that script is proven to be Astro, using `npm run dev --
  --host 0.0.0.0 --port <port>`; an already-running expected WSL server is reused
  rather than duplicated.

  verify sends the same bounded browser-like request to http://localhost:<port>/
  from WSL and native Windows, compares status/body-length/SHA-256 fingerprints,
  then repeats the listener-pair inspection. It passes only when Windows reports
  wslrelay.exe, WSL reports the clean expected Astro server, and both route
  fingerprints match the post-route pair. A nonzero exit means
  inspection, recovery, or verification did not prove the requested safe state.
```
</details>
<details>
<summary>Evidence: Localhost behavior suite</summary>

```text
ok - localhost inspect parses listeners, converts Windows/WSL paths, classifies Git source, and redacts commands
ok - stale native Windows Astro shadow recovers by exact PID to wslrelay plus clean WSL and matching routes
ok - healthy wslrelay plus clean WSL server passes with matching browser-like route fingerprints
ok - relay verification requires complete canonical executable identity
ok - same-owner multiple listener bindings remain a verified relay pair
ok - same-owner multiple stale Windows bindings recover by one exact PID
ok - active Firstmate task ownership refuses recovery without termination
ok - PID or command change between observations refuses exact-PID recovery
ok - node worker commands containing Astro words refuse exact-PID recovery
ok - unknown commands and unrelated Windows repositories refuse without termination
ok - unavailable Windows inspection refuses recovery without mutation
ok - unavailable WSL inspection refuses recovery without mutation
ok - unavailable Firstmate task-state inspection refuses recovery without termination
ok - verify proves the listener pair before contacting localhost
ok - fresh mutation-boundary source and task proof blocks termination
ok - termination-boundary task proof blocks exact-PID termination
ok - post-stop inspection failure blocks any restart
ok - Astro launcher scripts with shell metacharacters refuse recovery
ok - post-recovery Windows/WSL route fingerprint mismatch fails verification
ok - post-route listener-pair changes fail verification
ok - dirty expected checkout refuses restart after exact-PID termination
```
</details>
<details>
<summary>Evidence: Test-runner mapping suite</summary>

```text
ok - exact suite coverage: --all lists every tests/*.test.sh once
ok - family selection returns a proper subset of the suite
ok - single-script selection lists exactly that path
ok - changed-file selection stays conservative (never silent full suite)
ok - changed selection covers dependents and fails closed for unmapped source
ok - empty changed selection emits deterministic text and JSON summaries
ok - timing markers and JSON artifact are valid
ok - aggregate exit reflects any script failure
ok - gate-skip accounting is honest and non-failing
ok - fail-on-gate-skip converts herdr-not-found into a hard failure
ok - exclude-family drops the named primary family after selection
ok - portable shard union, disjointness, and coverage guard hold
ok - portable serial shards are a deterministic disjoint cover of the serial lane
ok - portable serial shard lanes refuse mismatched, out-of-range, and countless names
ok - --jobs refuses non-proven / stateful selections
ok - jobs scheduler runs proven scripts; failure propagates; non-proven refused
ok - aggregate-json merges lane timing artifacts
```
</details>
<details>
<summary>Evidence: Changed-file selection</summary>

`tests/fm-localhost.test.sh`

```text
tests/fm-localhost.test.sh
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 6 issues (5 errors, 1 warning)</summary>

- 🚨 `bin/fm-localhost.py:1009` - The intent requires “no active Firstmate task” and says to “refuse every ... active-task ... case.” The changed recovery path snapshots task state at `mutation = inspect_system(...)` (line 1009), then writes evidence and later calls `terminate_exact(...)` (line 1025) without a shared lock or atomic task-metadata publication boundary. A task can become active, or its `.meta` can be observed mid-write, between those operations, so the PID can still be terminated. Make task creation/publication and localhost mutation honor the same shared state boundary.
- 🚨 `bin/fm-localhost.py:359` - The intent requires “refuse every ... missing-identity ... case” and an “expected wslrelay/WSL pair.” `classify_windows` returns `wslrelay` from only `process` name (`if lower_name == &#34;wslrelay.exe&#34;: return &#34;wslrelay&#34;`, lines 359-360), before checking `executable`; `verified_pair` then accepts that classification at line 883. A WMI result with a missing or noncanonical executable identity can therefore pass verification as the relay. Require complete, canonical relay executable identity before classifying it as `wslrelay`.
- ⚠️ `bin/fm-localhost.py:883` - Listener counts are treated as ambiguity even when every binding belongs to the same owner. `verified_pair` requires exactly one Windows and one WSL row (lines 883-885), while `termination_boundary_listener` also rejects `len(boundary.windows) != 1` at line 966. A legitimate Node or wslrelay process with IPv4 and IPv6 bindings is therefore refused despite `recovery_verdict` already proving a single PID owns all bindings. Group and compare the complete listener sets by owner PID, refusing only distinct or inconsistent owners.
- ⚠️ `bin/fm-localhost.py:1164` - The intent requires refusal for “unavailable-inspection” cases. When Firstmate task-state inspection is unavailable, `inspect_system` sets `task_error` and returns, but the changed `inspect` CLI exits success because line 1164 checks only `windows_error` and `wsl_error`. This lets callers treat an incomplete ownership inspection as successful; include `task_error` in the inspect exit condition.

🔧 Fix: Ben harden localhost task and listener proof boundaries
6 issues (5 errors, 1 warning) still open:
- 🚨 `bin/fm-localhost.py:728` - The intent requires “no active Firstmate task” and says to “refuse every ... active-task ... case.” `recovery_verdict` checks task associations only for Windows listeners at lines 728-730; WSL listeners already carry `tasks` but those associations are ignored, and `verified_pair` does not check them either. An active task owning the expected WSL server can therefore still allow exact-PID mutation and verification. Enforce the task-free invariant across both kernels at the shared pair/recovery boundary.
- 🚨 `bin/fm-localhost.py:731` - The intent requires “refuse every ambiguous ... case.” Recovery only rejects multiple Windows PIDs, then accepts any number of WSL listeners if each individually matches the expected source. Two distinct WSL PIDs can therefore pass eligibility, the Windows PID is terminated, and only the post-stop check discovers the ambiguity. Reject a non-empty WSL listener set whose ownership is not consistent before any mutation.
- 🚨 `bin/fm-localhost.py:733` - The intent requires a “clean expected current-main WSL replacement.” Both the recovery WSL checks and `verified_pair` validate checkout, SHA, cleanliness, and source, but never require `listener.git.branch == expected.default_branch`. A clean WSL server on a feature or detached branch at the same SHA can therefore be reused and reported as verified. Add the current-main branch requirement to the shared WSL identity predicate.
- 🚨 `bin/fm-localhost.py:696` - The intent requires an “expected wslrelay/WSL pair” and refusal of “unrelated” or “missing-identity” cases. `canonical_wslrelay_identity` accepts any absolute drive path ending in `wslrelay.exe`, including an unrelated executable such as `C:\Users\x\wslrelay.exe`; `verified_pair` then accepts it as the Windows relay. Require a trusted canonical system identity or equivalent OS-verified executable identity before certifying the pair.
- 🚨 `bin/fm-test-run.sh:947` - The intent requires “the test-family mapping.” The changed mapping explicitly covers `fm-localhost.py` at line 947, but the new source file `bin/fm-task-state-lock.sh` has no explicit family case and no test references its basename, so the changed-path fallback reports it as unmapped and `fm-test-run.sh` aborts selection. Map the new helper to the localhost/pure-contract family (or add an explicit mapped reference).
- ⚠️ `bin/fm-localhost.py:172` - `TaskStateBoundary.__enter__` blocks indefinitely waiting for the helper&#39;s `locked` line, while `fm-task-state-lock.sh` uses the unbounded `fm_lock_acquire_wait`. A stalled or long-running spawn can therefore make `recover` hang instead of returning a safe refusal. Use a bounded lock acquisition and report a refusal on timeout.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bash tests/fm-localhost.test.sh`
- `bash tests/fm-test-run.test.sh`
- `bash bin/fm-test-run.sh --list --changed --base 345de4e7aad1484f46bc5115c9e57640a0b060d9`
- `python3 bin/fm-localhost.py --help`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 127)

🔧 Fix: Ben the required pinned ShellCheck is absent, so I’m using the repository’s verified installer in ephemeral toolchain space, then I’ll lint and edit only reported source issues
1 warning still open:
- ⚠️ linter found issues (exit code 127)

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
