### PR TITLE
fix(brief): start no-mistakes without firstmate handoff

### DIFF
--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -382,9 +382,8 @@ EOF
     IFS= read -r -d '' DOD <<EOF || true
 # Definition of done
 Delivery contract: mode=no-mistakes
-The task is complete only when committed on your branch.
-When you believe it is complete, append \`done: {summary}\` to the status file and stop.
-Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.
+After implementation is committed on your branch \`fm/$ID\`, immediately start \`no-mistakes axi run --intent "<accepted task contract>"\` using the intent contract below; do not stop or wait for firstmate between the commit and validation.
+If you report this phase transition, append \`working: starting no-mistakes\`, never a terminal \`done:\` before CI is green.
 
 You drive no-mistakes by responding to its gates, not by implementing fixes.
 Follow the guidance no-mistakes itself provides for the mechanics: it loads when you invoke /no-mistakes, and \`no-mistakes axi run --help\` plus the \`help\` lines in each \`axi\` response are authoritative and version-matched to the installed binary.

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -256,8 +256,8 @@ test_ship_mode_is_explicit_not_registry() {
   brief="$home/data/brief-explicit-a5/brief.md"
   grep -qx "Delivery contract: mode=no-mistakes" "$brief" \
     || fail "registered direct-PR posture overrode the explicit --mode"
-  assert_grep "Firstmate will then instruct you to run /no-mistakes" "$brief" \
-    "explicit no-mistakes brief did not render the pipeline definition of done"
+  assert_grep "immediately start \`no-mistakes axi run --intent" "$brief" \
+    "explicit no-mistakes brief did not render the self-starting pipeline definition of done"
 
   # An unregistered project is not a blocker either, because nothing is looked up.
   FM_HOME="$home" "$ROOT/bin/fm-brief.sh" brief-explicit-a6 never-registered --mode local-only >/dev/null 2>&1 \
@@ -331,6 +331,16 @@ test_no_mistakes_dod_wording() {
   assert_present "$brief" "brief was not scaffolded"
   assert_grep "no-mistakes itself provides for the mechanics" "$brief" \
     "no-mistakes DOD lost its guidance-reference sentence"
+  assert_grep "immediately start \`no-mistakes axi run --intent \"<accepted task contract>\"\`" "$brief" \
+    "no-mistakes DOD must make the implementation worker start validation immediately"
+  assert_grep "do not stop or wait for firstmate between the commit and validation" "$brief" \
+    "no-mistakes DOD retained a supervisor handoff between implementation and validation"
+  assert_grep "append \`working: starting no-mistakes\`, never a terminal \`done:\` before CI is green" "$brief" \
+    "no-mistakes DOD must keep the validation transition nonterminal"
+  assert_no_grep "Firstmate will then instruct you to run /no-mistakes" "$brief" \
+    "no-mistakes DOD retained the obsolete firstmate-triggered handoff"
+  assert_no_grep "append \`done: {summary}\`" "$brief" \
+    "no-mistakes DOD must not report terminal done before validation"
   # shellcheck disable=SC2016  # single quotes are deliberate: the backticks must stay literal
   assert_grep '`no-mistakes axi run --help`' "$brief" \
     "no-mistakes DOD must render literal backticks around the help command"


### PR DESCRIPTION
## Intent

Collapse the no-mistakes ship brief two-phase handoff in Firstmate shared tracked material. Update bin/fm-brief.sh no-mistakes Definition of done so that after implementation is committed on fm/<id>, the worker immediately starts no-mistakes axi run with a proper --intent and does not stop or wait for firstmate. Intermediate status may use working: starting no-mistakes, and there must be no terminal done: before CI is green; final remains done: PR {url} checks green only after no-mistakes reports CI green. Preserve ask-user escalation, the prohibition on --yes, the intent-contract rules, and all other safety text. Update tests/fm-brief.test.sh by replacing the old Firstmate-will-instruct assertion and adding generated-brief assertions for self-start behavior. Edit AGENTS.md only if it contradicts the brief; otherwise leave it unchanged, with firstmate retaining backup re-steer for a stalled worker. Do not change direct-PR or local-only behavior beyond necessary consistency. The implementation worker must be Codex gpt-5.6-sol at xhigh reasoning, must review a short plan covering files, DOD wording, test assertions, and AGENTS.md before implementation, and must self-review that plan for ask-user safety, no --yes, intent preservation, and no premature terminal done. Drive the full no-mistakes review, test, docs, lint, push, PR, and CI pipeline to a green PR. Do not merge the PR.

## What Changed
- Update the no-mistakes Definition of Done in `bin/fm-brief.sh` so that after implementation is committed on `fm/<id>`, the worker immediately runs `no-mistakes axi run --intent "..."` instead of stopping for a Firstmate handoff.
- Require intermediate status as `working: starting no-mistakes` and forbid a terminal `done:` before CI is green.
- Replace the old Firstmate-will-instruct assertion in `tests/fm-brief.test.sh` and add generated-brief checks for self-start wording and nonterminal transition status.

## Risk Assessment

✅ Low: Minimal, intent-aligned wording change to the no-mistakes DOD plus matching generated-brief assertions; safety text and other ship modes are preserved.

## Testing

Ran the focused fm-brief suite successfully, generated live no-mistakes/direct-PR/local-only briefs, and captured before/after Definition of done plus behavioral checks showing self-start axi run, nonterminal working status, preserved ask-user/--yes/intent safety text, no premature terminal done, and unchanged faster paths.

<details>
<summary>Evidence: Before/after no-mistakes Definition of done</summary>

```text
# Before/After: no-mistakes Definition of done contract

The after block matches the live generated brief from `FM_HOME=... ./bin/fm-brief.sh demo-self-start sample-repo --mode no-mistakes`.

## Before (base 345de4e)

# Definition of done
Delivery contract: mode=no-mistakes
The task is complete only when committed on your branch.
When you believe it is complete, append `done: {summary}` to the status file and stop.
Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.

You drive no-mistakes by responding to its gates, not by implementing fixes.
Follow the guidance no-mistakes itself provides for the mechanics: it loads when you invoke /no-mistakes, and `no-mistakes axi run --help` plus the `help` lines in each `axi` response are authoritative and version-matched to the installed binary.
When starting no-mistakes, make `--intent` preserve all relevant content from this brief's `# Task` section plus every later accepted Firstmate requirement, clarification, constraint, exclusion, and supersession, carrying only each requirement's current accepted form; retain direct requirements instead of substituting a diff summary, and exclude generic operational, status, delivery, and other scaffold boilerplate unless it is task-specific.
Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix.

Two firstmate-specific rules layer on top of that guidance:
- ask-user findings are never yours to answer: escalate to firstmate (rule 6) and stop.
  Firstmate applies the authority contract in its `AGENTS.md` and obtains any required captain decision.
  When the decision comes back, feed it to the gate with `no-mistakes axi respond` and let the pipeline apply it - do not route the question to "the user" or implement the fix yourself.
- Avoid `--yes`: it would silently bypass firstmate's authority check and any required captain escalation.

After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append `done: PR {url} checks green` and stop. You are finished.

## After (target 0ca94fb / generated brief)

# Definition of done
Delivery contract: mode=no-mistakes
After implementation is committed on your branch `fm/demo-self-start`, immediately start `no-mistakes axi run --intent "<accepted task contract>"` using the intent contract below; do not stop or wait for firstmate between the commit and validation.
If you report this phase transition, append `working: starting no-mistakes`, never a terminal `done:` before CI is green.

You drive no-mistakes by responding to its gates, not by implementing fixes.
Follow the guidance no-mistakes itself provides for the mechanics: it loads when you invoke /no-mistakes, and `no-mistakes axi run --help` plus the `help` lines in each `axi` response are authoritative and version-matched to the installed binary.
When starting no-mistakes, make `--intent` preserve all relevant content from this brief's `# Task` section plus every later accepted Firstmate requirement, clarification, constraint, exclusion, and supersession, carrying only each requirement's current accepted form; retain direct requirements instead of substituting a diff summary, and exclude generic operational, status, delivery, and other scaffold boilerplate unless it is task-specific.
Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix.

Two firstmate-specific rules layer on top of that guidance:
- ask-user findings are never yours to answer: escalate to firstmate (rule 6) and stop.
  Firstmate applies the authority contract in its `AGENTS.md` and obtains any required captain decision.
  When the decision comes back, feed it to the gate with `no-mistakes axi respond` and let the pipeline apply it - do not route the question to "the user" or implement the fix yourself.
- Avoid `--yes`: it would silently bypass firstmate's authority check and any required captain escalation.

After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append `done: PR {url} checks green` and stop. You are finished.

## Observable contract deltas

- obsolete firstmate handoff present before: yes
- obsolete firstmate handoff present after: no
- self-start axi run present before: no
- self-start axi run present after: yes
- nonterminal working transition present before: no
- nonterminal working transition present after: yes
- premature done:{summary} present before: yes
- premature done:{summary} present after: no
- final done after CI green present before: yes
- final done after CI green present after: yes
- ask-user escalation preserved after: yes
- Avoid --yes preserved after: yes
- intent-contract rules preserved after: yes
```
</details>
<details>
<summary>Evidence: Generated no-mistakes brief (full)</summary>

```text
You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.

# Task
{TASK}

# Herdr lifecycle declaration - NOT ENABLED
**HARD SAFETY GATE:** this scaffold cannot inspect the task text that replaces `{TASK}` later.
If the task will start, stop, delete, restart, profile, or otherwise drive Herdr lifecycle behavior, stop and regenerate the brief with `--herdr-lab` before dispatch.
Do not add Herdr lifecycle commands to this unguarded brief by hand.

# Setup
You are in a disposable git worktree of sample-repo, at a detached HEAD on a clean default branch.

**Verify isolation before anything else.** Run `pwd -P` and `git rev-parse --show-toplevel`; both must resolve to the disposable task worktree you were launched in, such as a treehouse pool path or an Orca-managed worktree, not the primary checkout firstmate operates from.
The path check is authoritative: `git rev-parse --git-dir` and `git rev-parse --git-common-dir` can help inspect the repo, but they do not prove you are outside the primary checkout.
If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not branch or commit here - append `blocked: launched in primary checkout, not an isolated worktree` to the status file and stop.

1. First action: create your branch: `git checkout -b fm/demo-self-start`
2. Run `no-mistakes doctor`; if it reports the repo is not initialized here, run `no-mistakes init`.

# Rules
1. Never push to the default branch. Never merge a PR.
2. Stay inside this worktree; modify nothing outside it.
3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
4. Report status by appending one line:
   `echo "{state}: {one short line}" >> '/var/folders/p3/95t2_00n2jl3r2cn79bfn18h0000gp/T/no-mistakes-evidence/01KZCE9WZBGF1R6GAFD280X5XW/demo-fm-home/state/demo-self-start.status'`
   States: working, needs-decision, blocked, paused, done, failed.
   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
   would act on (setup done, bug reproduced, fix implemented, validation passed) and the
   needs-decision/blocked/paused/done/failed states. No step-by-step FYI progress lines;
   firstmate reads your pane for that.
   A mid-task `working:` line (including setup complete) is nonterminal: do not end the
   turn after it; continue the same stage until a defined `done:` gate under Definition of done.
   Use `paused: {why}` - distinct from `blocked:` - ONLY when you are deliberately idling on a
   known external wait you expect to clear on its own (an upstream release, a rate-limit reset,
   a scheduled window): firstmate then leaves your idle pane alone and rechecks it on a long
   cadence instead of treating it as a possible wedge. Use `blocked:` when you are stuck and need help.
5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
6. If a decision belongs above the implementation worker (product choices, destructive actions, ask-user findings),
   append `needs-decision: {summary of options}` and stop. Firstmate will apply the configured authority and reply with the decision.
   When firstmate replies or a blocker clears and you resume, append `resolved: {how it was decided or unblocked}` (add the same `[key=<slug>]` if you opened it with one) so the decision or blocker is durably closed and does not keep resurfacing.
7. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving
   every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
   daemon error, append `blocked: {the daemon error}` and stop; only firstmate manages the daemon.

# Project memory
If `AGENTS.md` or `CLAUDE.md` already exists, or if this task produced durable project-intrinsic knowledge, run `/Users/AI/.no-mistakes/worktrees/edb446952c22/01KZCE9WZBGF1R6GAFD280X5XW/bin/fm-ensure-agents-md.sh .` in the worktree.
Record only project knowledge useful to almost every future session.
For anything the codebase already shows, prefer a pointer to the authoritative file, command, or doc over copying the detail.
If you touch a project `AGENTS.md` that lacks `## Maintaining this file`, add that short self-governance section from `/Users/AI/.no-mistakes/worktrees/edb446952c22/01KZCE9WZBGF1R6GAFD280X5XW/bin/fm-ensure-agents-md.sh` in the same pass.
Keep it proportionate: skip `AGENTS.md` edits for trivial tasks that produced no durable project knowledge.

# Definition of done
Delivery contract: mode=no-mistakes
After implementation is committed on your branch `fm/demo-self-start`, immediately start `no-mistakes axi run --intent "<accepted task contract>"` using the intent contract below; do not stop or wait for firstmate between the commit and validation.
If you report this phase transition, append `working: starting no-mistakes`, never a terminal `done:` before CI is green.

You drive no-mistakes by responding to its gates, not by implementing fixes.
Follow the guidance no-mistakes itself provides for the mechanics: it loads when you invoke /no-mistakes, and `no-mistakes axi run --help` plus the `help` lines in each `axi` response are authoritative and version-matched to the installed binary.
When starting no-mistakes, make `--intent` preserve all relevant content from this brief's `# Task` section plus every later accepted Firstmate requirement, clarification, constraint, exclusion, and supersession, carrying only each requirement's current accepted form; retain direct requirements instead of substituting a diff summary, and exclude generic operational, status, delivery, and other scaffold boilerplate unless it is task-specific.
Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix.

Two firstmate-specific rules layer on top of that guidance:
- ask-user findings are never yours to answer: escalate to firstmate (rule 6) and stop.
  Firstmate applies the authority contract in its `AGENTS.md` and obtains any required captain decision.
  When the decision comes back, feed it to the gate with `no-mistakes axi respond` and let the pipeline apply it - do not route the question to "the user" or implement the fix yourself.
- Avoid `--yes`: it would silently bypass firstmate's authority check and any required captain escalation.

After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append `done: PR {url} checks green` and stop. You are finished.
```
</details>
<details>
<summary>Evidence: Generated no-mistakes DOD excerpt</summary>

```text
# Definition of done
Delivery contract: mode=no-mistakes
After implementation is committed on your branch `fm/demo-self-start`, immediately start `no-mistakes axi run --intent "<accepted task contract>"` using the intent contract below; do not stop or wait for firstmate between the commit and validation.
If you report this phase transition, append `working: starting no-mistakes`, never a terminal `done:` before CI is green.

You drive no-mistakes by responding to its gates, not by implementing fixes.
Follow the guidance no-mistakes itself provides for the mechanics: it loads when you invoke /no-mistakes, and `no-mistakes axi run --help` plus the `help` lines in each `axi` response are authoritative and version-matched to the installed binary.
When starting no-mistakes, make `--intent` preserve all relevant content from this brief's `# Task` section plus every later accepted Firstmate requirement, clarification, constraint, exclusion, and supersession, carrying only each requirement's current accepted form; retain direct requirements instead of substituting a diff summary, and exclude generic operational, status, delivery, and other scaffold boilerplate unless it is task-specific.
Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix.

Two firstmate-specific rules layer on top of that guidance:
- ask-user findings are never yours to answer: escalate to firstmate (rule 6) and stop.
  Firstmate applies the authority contract in its `AGENTS.md` and obtains any required captain decision.
  When the decision comes back, feed it to the gate with `no-mistakes axi respond` and let the pipeline apply it - do not route the question to "the user" or implement the fix yourself.
- Avoid `--yes`: it would silently bypass firstmate's authority check and any required captain escalation.

After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append `done: PR {url} checks green` and stop. You are finished.
```
</details>
<details>
<summary>Evidence: Generated direct-PR DOD (unchanged faster path)</summary>

```text
# Definition of done
Delivery contract: mode=direct-PR
This task ships **direct-PR**: you raise the PR yourself, without the no-mistakes pipeline.
The task is complete only when committed on your branch.
When it is implemented and committed, push your branch and open a PR with `gh-axi`, then append `done: PR {url}` to the status file and stop.
Do NOT run /no-mistakes. The configured merge authority decides whether to merge the PR; firstmate relays the outcome.
```
</details>
<details>
<summary>Evidence: Generated local-only DOD (unchanged faster path)</summary>

```text
# Definition of done
Delivery contract: mode=local-only
This task ships **local-only**: no remote, no PR, no pipeline.
The task is complete only when committed on your branch `fm/demo-local`. Do NOT push, do NOT open a PR, do NOT merge.
Keep your branch a clean fast-forward onto the current default branch - if `main` has advanced, rebase onto it so the eventual merge stays a fast-forward.
When it is implemented and committed, append `done: ready in branch fm/demo-local` to the status file and stop.
The configured merge authority approves the ready branch, then firstmate merges it into local `main` through the guarded fast-forward path.
```
</details>
<details>
<summary>Evidence: CLI transcript of brief scaffold + DOD</summary>

```text
# End-user path: firstmate scaffolds a no-mistakes ship brief

$ FM_HOME="$EVIDENCE_DIR/demo-fm-home" ./bin/fm-brief.sh demo-self-start sample-repo --mode no-mistakes
scaffolded: /var/folders/p3/95t2_00n2jl3r2cn79bfn18h0000gp/T/no-mistakes-evidence/01KZCE9WZBGF1R6GAFD280X5XW/demo-fm-home/data/demo-self-start/brief.md (ship, mode=no-mistakes; replace {TASK})

# Worker-facing Definition of done from generated brief.md:

# Definition of done
Delivery contract: mode=no-mistakes
After implementation is committed on your branch `fm/demo-self-start`, immediately start `no-mistakes axi run --intent "<accepted task contract>"` using the intent contract below; do not stop or wait for firstmate between the commit and validation.
If you report this phase transition, append `working: starting no-mistakes`, never a terminal `done:` before CI is green.

You drive no-mistakes by responding to its gates, not by implementing fixes.
Follow the guidance no-mistakes itself provides for the mechanics: it loads when you invoke /no-mistakes, and `no-mistakes axi run --help` plus the `help` lines in each `axi` response are authoritative and version-matched to the installed binary.
When starting no-mistakes, make `--intent` preserve all relevant content from this brief's `# Task` section plus every later accepted Firstmate requirement, clarification, constraint, exclusion, and supersession, carrying only each requirement's current accepted form; retain direct requirements instead of substituting a diff summary, and exclude generic operational, status, delivery, and other scaffold boilerplate unless it is task-specific.
Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix.

Two firstmate-specific rules layer on top of that guidance:
- ask-user findings are never yours to answer: escalate to firstmate (rule 6) and stop.
  Firstmate applies the authority contract in its `AGENTS.md` and obtains any required captain decision.
  When the decision comes back, feed it to the gate with `no-mistakes axi respond` and let the pipeline apply it - do not route the question to "the user" or implement the fix yourself.
- Avoid `--yes`: it would silently bypass firstmate's authority check and any required captain escalation.

After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append `done: PR {url} checks green` and stop. You are finished.

# Consistency: direct-PR and local-only DODs remain non-self-starting
# (see dod-direct-PR.md and dod-local-only.md)
```
</details>
<details>
<summary>Evidence: Behavioral contract checks on generated briefs</summary>

<code>self_start_axi_run: PASS&#10;no_wait_for_firstmate: PASS&#10;working_transition: PASS&#10;final_done_after_ci: PASS&#10;preserves_ask_user: PASS&#10;no_yes_flag: PASS&#10;intent_contract_present: PASS&#10;obsolete_handoff_absent: PASS&#10;premature_done_summary_absent: PASS&#10;complete_only_when_committed_absent: PASS&#10;direct_pr_unchanged_no_self_start: PASS&#10;local_only_unchanged_no_self_start: PASS&#10;direct_pr_still_opens_pr: PASS&#10;local_only_still_local: PASS&#10;ALL: PASS</code>

```text
self_start_axi_run: PASS
no_wait_for_firstmate: PASS
working_transition: PASS
final_done_after_ci: PASS
preserves_ask_user: PASS
no_yes_flag: PASS
intent_contract_present: PASS
obsolete_handoff_absent: PASS
premature_done_summary_absent: PASS
complete_only_when_committed_absent: PASS
direct_pr_unchanged_no_self_start: PASS
local_only_unchanged_no_self_start: PASS
direct_pr_still_opens_pr: PASS
local_only_still_local: PASS
ALL: PASS
```
</details>
<details>
<summary>Evidence: fm-brief.test.sh output</summary>

```text
ok - fm-brief.sh: bash -n succeeds
/var/folders/p3/95t2_00n2jl3r2cn79bfn18h0000gp/T//fm-brief.VEe2Kg/heredoc-in-substitution.sh:2
ok - fm-brief.sh: no heredoc is nested inside a command substitution (Bash 3.2 parse-safe)
ok - fm-brief.sh: --help renders the complete header
ok - fm-brief.sh: no-mistakes/direct-PR/local-only briefs generate cleanly
ok - fm-brief.sh: ship --mode is required and closed-set validated
ok - fm-brief.sh: the explicit ship mode wins over the registered posture
ok - fm-brief.sh: --yolo and scout/secondmate --mode are refused, never silently dropped
ok - fm-brief.sh: faster paths use configured authority without stacked review
ok - fm-brief.sh: no-mistakes DOD keeps its apostrophe prose, now parse-safe
ok - fm-brief.sh: ship project-memory wording carries the AGENTS.md authoring bar
ok - fm-brief.sh: --herdr-lab emits the complete hard safety contract
ok - fm-brief.sh: --herdr-lab uses its quoted Firstmate-owned helper path
ok - fm-brief.sh: ship and scout scaffolds make omitted Herdr intent fail-visible
ok - fm-brief.sh: Herdr lab contract covers scouts and rejects secondmate misuse
ok - fm-brief.sh: --no-projects scaffolds a project-less charter and guards misuse
ok - fm-brief.sh: marked requests avoid generic acknowledgements and preserve material reporting
ok - fm-brief.sh: relative directory inputs ignore CDPATH, render stable absolute charter paths, or fail loudly
ok - fm-brief.sh: custom pause verb renders in every scaffold
ok - fm-brief.sh: investigation and visual-review completions load the shared decision policy
ok - fm-brief: scout and secondmate code paths still scaffold well-formed briefs
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash tests/fm-brief.test.sh` (includes `test_no_mistakes_dod_wording` and `test_ship_mode_is_explicit_not_registry` self-start assertions)</code>
- <code>`FM_HOME=... ./bin/fm-brief.sh demo-self-start sample-repo --mode no-mistakes` and inspected generated `brief.md` Definition of done</code>
- <code>`FM_HOME=... ./bin/fm-brief.sh demo-direct sample-repo --mode direct-PR` and `... demo-local ... --mode local-only` consistency checks</code>
- <code>Before/after DOD comparison against base `345de4e` vs target `0ca94fb`</code>
- <code>Verified `AGENTS.md` unchanged and already aligned with same-worker no-mistakes start</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
