### PR TITLE
feat(skills): bring current curation discipline to public stow

### DIFF
--- a/skills/stow/SKILL.md
+++ b/skills/stow/SKILL.md
@@ -1,16 +1,16 @@
 ---
 name: stow
-description: Sweep the current conversation for durable knowledge - user preferences, project facts, operational gotchas, and unfinished next steps - and file each through explicit instructions, existing local conventions, or the private `.stow-notes.md` fallback, so nothing is lost when the session ends. Use when the user invokes /stow, asks to save or write down what was learned this session, or before a context reset or long break.
+description: Sweep the current conversation for durable knowledge - user preferences, project facts, operational gotchas, standing decisions, and unfinished next steps - and file each through explicit instructions, existing local conventions, or the private `.stow-notes.md` fallback, curating the destination files as it writes. Use when the user invokes /stow, asks to save or write down what was learned this session, or before a context reset or long break.
 user-invocable: true
 ---
 
-<!-- maintainers: this is the public, installer-facing skill. Keep it standalone, with no private project paths, tool assumptions, or environment branching. -->
+<!-- maintainers: this is the public, installer-facing skill. Keep it standalone, with no private project paths, tool assumptions, or environment branching. The firstmate-internal counterpart lives at .agents/skills/stow/SKILL.md - deliberately a separate file with no shared code. Keep them independent. -->
 
 # stow
 
-Sweep this conversation for durable knowledge that only exists in chat right now, and write it through the user's explicit instructions, this project's existing local conventions, or the private `.stow-notes.md` fallback in the current directory.
-The goal is a conversation that is safe to end, reset, or hand off because everything durable has already been captured on disk, not left stranded in the transcript.
-Everything this skill files goes to a local file by default; it only ever reaches an external system such as an issue tracker when you have explicitly said to use one.
+Sweep this conversation for durable knowledge that only exists in chat right now, and file it through the user's explicit instructions, the project's existing local conventions, or the private `.stow-notes.md` fallback in the current directory.
+The goal is to leave the next session a compact, current operating map, not an accumulating journal: every durable finding lands on disk, and every file this skill touches comes out more accurate, not merely longer.
+Everything files to a local destination by default; an external system such as an issue tracker is reached only through the explicit-instruction rule in step 3.
 
 ## What it does
 
@@ -19,63 +19,69 @@ Everything this skill files goes to a local file by default; it only ever reache
    - User preferences: a working-style, tooling, formatting, or approval preference the user stated in passing rather than through a config file.
    - Project facts: build, test, deploy, architecture, or convention facts about the current project that would help anyone (or any agent) working in it later.
    - Operational gotchas: a sharp edge, workaround, recurring mistake, or non-obvious cause discovered while working here.
+   - Standing decisions: a choice made this session that should outlive it, such as an approach settled on, an option ruled out, or a convention agreed to.
    - Undone next steps: anything left open or agreed to that has not yet been written down anywhere.
+   Before filing any finding, check whether it already lives authoritatively somewhere - a README, a config file, existing docs, the code itself.
+   If it does, record a one-line pointer to that owner instead of a copy, so the stowed note cannot go stale independently of its source.
 
 2. **Discover the host's existing conventions before deciding where anything goes.**
    Don't assume a destination - look for what's actually there, roughly in this order:
    - A project-level memory file, such as `CLAUDE.md`, `AGENTS.md`, or an equivalent at the repo root or nearby.
    - A user-level (global) memory file the running agent reads across projects, if one exists and is readable.
    - A `TODO`, `BACKLOG`, `NOTES`, or similarly named plain file already tracked in the project.
-   This step is about local files only, not remote systems.
-   Do not scan for or infer an issue tracker here - see the priority order in step 3.
+   This step is about local files only; do not scan for or infer an issue tracker here - step 3 owns external routing.
 
 3. **Route each finding using this fixed priority order, local-first.**
-   1. **Highest - an explicit instruction wins.** If the user has explicitly said, earlier in this conversation or as a standing choice previously recorded in the discovered user-level memory file (see step 4), to use a particular system for this kind of finding - including an external tracker - route it there.
-      This is the *only* path to an external or public system: an issue tracker, a hosted project board, a ticketing system, or similar.
-      A configured git host remote, a `.github/`/`.gitlab/` folder, or any other signal that a tracker probably exists is never by itself grounds to file anything there - never route externally on inference.
-   2. **Otherwise - the local system the user already uses.** Route to whatever local memory/backlog convention this project or user already has for that kind of finding: the discovered project memory file (`CLAUDE.md`/`AGENTS.md`) for project facts and operational gotchas, an existing `TODO`/`BACKLOG`/`NOTES` file for undone next steps, or a discovered user-level memory file for user preferences *when one happens to be accessible* - a global memory file is a bonus if the running agent can reach one, never an assumption or a requirement.
-      Among local durable-finding writes, this tier is the only one that writes findings into a tracked, shared file, and the only one that may write outside the current directory - it only fires when that destination was already an established convention the user (or their agent) already has access to, never a path this skill invents itself.
-   3. **Fallback - the default prescribed private file, in the current directory.** If no existing local convention fits, don't improvise a location or invent an ad hoc filename.
-      Before writing it in a git worktree, verify that `.stow-notes.md` is not already tracked in the index.
-      If it is tracked, do not append private findings there, do not describe it as private, and report that the tier-3 fallback is blocked until the user chooses a safe destination.
-      In a non-git directory, treat this as a local private file by filesystem scope.
-      After the tracked-file check passes, create or append to `.stow-notes.md` in the current directory, for every finding-kind including user preferences.
-      This file always lives inside the current working directory, never a user-level or home-directory path, so the fallback works even for agents sandboxed to the current directory.
-      Then keep it out of git: create or append a `.stow-notes.md` line in a `.gitignore` file **in the current directory** - an ordinary file at that path, so this stays fully in-directory even inside a linked worktree, unlike git's internal exclude mechanism, which can resolve outside the working directory there.
+   1. **Highest - an explicit instruction wins.** If the user has explicitly said, earlier in this conversation or as a standing choice previously recorded in the discovered user-level memory file (see step 4), to use a particular system for this kind of finding, route it there.
+      This is the *only* path to an external or public system such as an issue tracker, hosted project board, or ticketing system.
+      A configured git host remote, a `.github`/`.gitlab` folder, or any other signal that a tracker probably exists is never by itself grounds to file anything there - never route externally on inference.
+   2. **Otherwise - the local convention the project or user already has.** The discovered project memory file for project facts, operational gotchas, and standing decisions; an existing `TODO`/`BACKLOG`/`NOTES` file for undone next steps; a discovered user-level memory file for user preferences *when one happens to be accessible* - a bonus if reachable, never an assumption or a requirement.
+      This is the only tier that writes findings into a tracked, shared file or outside the current directory, and only because the user already established that destination.
+   3. **Fallback - `.stow-notes.md` in the current directory, for every finding-kind.** When no existing convention fits, don't improvise a location or invent an ad hoc filename.
+      In a git worktree, first verify `.stow-notes.md` is not already tracked in the index; if it is tracked, do not write private findings there - report that the fallback is blocked until the user chooses a safe destination.
+      Otherwise create or update `.stow-notes.md` in the current working directory - never a user-level or home-directory path, so the fallback works even for agents sandboxed to the current directory.
+      Then keep it out of git: add a `.stow-notes.md` line to a `.gitignore` file in the current directory - an ordinary file at that path, not git's internal exclude mechanism, which can resolve outside the working directory in a linked worktree.
       Leave staging or committing that `.gitignore` line to the user, same as everything else this skill writes.
-      If even the `.gitignore` write fails, don't block or error - still create `.stow-notes.md` and tell the user to ignore it manually.
-   Tiers 2 and 3 are always local; only tier 1 - an explicit instruction - ever reaches an external or public system.
-   Tier 2 is the only tier that lands durable findings in a tracked/shared file; tier 3 keeps stowed findings in the private `.stow-notes.md` file only after confirming it is not already tracked, and confines any optional `.gitignore` metadata edit to the current directory.
+      If even the `.gitignore` write fails, don't block or error - still write `.stow-notes.md` and tell the user to ignore it manually.
 
 4. **When it's genuinely ambiguous between two existing conventions, ask once - then remember the answer.**
    If more than one discovered local convention plausibly fits a finding, ask the user once, plainly, which one they want that kind of note to live in going forward.
-   The same applies if the user gives an explicit instruction to use a tracker or other non-local system going forward rather than just for one item right now.
-   Once they answer, offer to remember it for next time: with their explicit permission, record a short standing note of that choice in the discovered (or newly agreed) user-level memory file, so the same question - or the same tracker instruction - doesn't need to be repeated in this project.
-   Always ask before adding that note - never establish the convention silently on your own judgment.
-   When nothing existing fits at all (not merely ambiguous), that's tier 3, not this step - use the `.stow-notes.md` fallback from step 3 instead of asking, for any finding-kind.
+   The same applies when the user gives an explicit instruction to use a tracker or other non-local system going forward rather than just for one item.
+   Once they answer, offer to remember it: with their explicit permission, record a short standing note of that choice in the discovered (or newly agreed) user-level memory file, so the same question doesn't need repeating in this project.
+   Always ask before adding that note - never establish a convention silently.
+   When nothing existing fits at all (not merely ambiguous), that's the step-3 fallback, not a question.
 
-5. **Write only into locations that already exist as a real convention, the `.stow-notes.md` fallback from step 3 (plus its line in a current-directory `.gitignore`), or a destination the user just approved in step 4.**
-   Do not invent new shared files, new folders, or new tracker categories the project doesn't already have, and do not pick an ad hoc filename or location for the fallback - `.stow-notes.md` in the current directory is the one prescribed default.
-   If even that fallback is unwritable and the user doesn't want to establish a new convention, say so plainly and leave that finding unfiled rather than fabricate a destination for it.
+5. **Write only into locations that already exist as a real convention, the step-3 fallback (plus its `.gitignore` line), or a destination the user just approved in step 4.**
+   Do not invent new shared files, new folders, or new tracker categories the project doesn't already have.
+   Never store, create, or edit a skill as a destination for a finding: there is no "graduate this to a skill" move, even in a repo whose existing `.claude/skills/` or `skills/` directory makes one look like a convention.
+   If the fallback is unwritable and the user doesn't want a new convention, say so plainly and leave that finding unfiled rather than fabricate a destination.
 
-6. **Curate, don't just append.**
-   When a finding overlaps or supersedes something already recorded, prefer editing or replacing the existing note over piling on a duplicate.
+6. **Read the destination before writing: inspect-then-update, never blind-append.**
+   Before writing any finding, read the destination file's current contents in full.
+   Then ask, for each finding: which existing entry does it supersede; can it be a one-sentence rewrite of an existing entry instead of a new one; and should a stale entry now be deleted or replaced in the same pass?
+   For an existing `TODO`/`BACKLOG`/`NOTES` item, inspect the full item, classify the change as new, duplicate, superseding, or obsolete, then write a considered replacement body rather than appending to it.
+   File each undone next step with what it is waiting on, when it is genuinely blocked on something.
 
-7. **Finish with an honest safe-to-end verdict and a resume pointer for the next session.**
-   Tell the user, in plain language, what was captured and where, what could not be captured (and why), and whether the conversation is now safe to end or reset - i.e. whether every durable finding from this sweep now lives on disk or in an explicitly requested tracker rather than only in this chat.
+7. **Curate every memory file this pass has open, not only the one a finding routes to.**
+   Prune what is no longer current: completed chronology, stale versions and paths, transient task state, resolved alternatives, old metrics, superseded claims, duplicates, and report-sized procedures that belong in a report or doc.
+   Prefer one concise current rule, or a pointer to the authoritative source, over duplicate prose.
+   The counterweight: never remove a unique current fact unless it is preserved elsewhere by a stronger owner.
+   This is an accuracy discipline, not a length target - a stale entry misleads the next session; a current one earns its place.
+   A `.stow-notes.md` note has exactly three exits: promotion into a shared, tracked file the user approves, folding into a discovered user-level memory file, or deletion as stale - do not invent another.
+
+8. **Finish with an honest safe-to-end verdict and a resume pointer for the next session.**
+   Report one action per file this sweep touched or considered: `unchanged`, `added`, `rewritten`, `pruned`, or `routed` (the finding went to a different owner).
+   Then tell the user, in plain language, what was captured and where, what could not be captured (and why), and whether the conversation is now safe to end or reset - that is, whether every durable finding from this sweep now lives on disk or in an explicitly requested tracker rather than only in this chat.
    If something could not be captured yet, say so explicitly instead of reporting the session fully safe.
-   If anything landed in the `.stow-notes.md` private fallback, say so explicitly - note that it is private and confined to this project, and that it can be promoted into a shared, tracked file later if the user wants it more widely visible.
-   In a git repo, report the ignore protection according to what actually happened: if the `.gitignore` write succeeded, say that a `.stow-notes.md` line was added to a current-directory `.gitignore` to keep it out of git, awaiting the user's own commit; if the `.gitignore` write failed, say that `.stow-notes.md` was still written but the user must ignore it manually before relying on git to hide it from status or commits.
-   If the tier-3 fallback was blocked because `.stow-notes.md` was already tracked, say that no private fallback was written and that the session is not fully safe to reset until the user chooses another destination or confirms that tracked file is acceptable.
-   If a user preference specifically landed there because no user-level memory file was discovered, add the one extra caveat: it now applies to this project only; this skill's own tier-3 default never writes outside the current directory, so if the user wants that preference to follow them across every project, they need to copy it into their own global/user-level memory file themselves.
-   The real payoff of stowing is not this session, it's the next one: close with a short, copy-pasteable RESUME POINTER naming exactly which files a fresh session should load to pick this back up cold, e.g. `To pick this back up in a new session, load: CLAUDE.md (project conventions), .stow-notes.md (private notes, not shared)`.
+   If anything landed in `.stow-notes.md`, say so - note that it is private and confined to this project, and name its promotion exit from step 7 if the user wants it more widely visible.
+   In a git repo, report the ignore protection as it actually happened: either the `.gitignore` line was added and awaits the user's own commit, or the write failed and the user must ignore `.stow-notes.md` manually before relying on git to hide it.
+   If the fallback was blocked because `.stow-notes.md` was already tracked, say that no private fallback was written and the session is not fully safe to reset until the user chooses another destination or accepts that tracked file.
+   If a user preference landed in `.stow-notes.md` because no user-level memory file was discovered, add one caveat: it now applies to this project only, and the user must copy it into their own global memory file themselves if they want it to follow them across projects.
+   The real payoff of stowing is not this session but the next one: close with a short, copy-pasteable RESUME POINTER naming exactly which files a fresh session should load to pick this back up cold, e.g. `To pick this back up in a new session, load: CLAUDE.md (project conventions), .stow-notes.md (private notes, not shared)`.
    List only the files this sweep actually wrote or updated; skip the pointer if nothing was written.
 
 ## What this skill does not do
 
-It does not invent a new note-taking system, initialize version control, or commit/push anything on the user's behalf beyond editing a file the discovered convention already made writable, creating the `.stow-notes.md` fallback from step 3 and its line in a current-directory `.gitignore`, or using a destination the user explicitly approved.
-It never stages or commits that `.gitignore` line itself - the edit lands in the working tree only, for the user to review and commit like any other change.
-Its own tier-3 default never writes durable findings outside the current working directory, and its optional `.gitignore` metadata edit is also confined to that directory.
-Among local durable-finding writes, tier 2 is the only exception, and only because it targets a destination the user's own existing convention already established, never one this skill invents.
+It does not invent a new note-taking system, initialize version control, or stage, commit, or push anything on the user's behalf - every write, including the `.gitignore` line, lands in the working tree for the user to review and commit like any other change.
 It never files credentials, secrets, or other sensitive material - only knowledge that's safe to keep in plain text wherever it lands.
-It never files anything to an issue tracker, hosted board, or other external/public system on its own inference - that only ever happens on the user's explicit say-so, per the hard rule in step 3.
+It never files anything to an issue tracker, hosted board, or other external or public system on its own inference - that only ever happens on the user's explicit say-so, per the hard rule in step 3.


### PR DESCRIPTION
## Intent

Port the internal /stow skill's portable curation disciplines into the PUBLIC /stow skill (skills/stow/SKILL.md only; the internal .agents/skills/stow/SKILL.md must not change), consolidating the public skill's duplicated prose so it stops being a July-2026 fork and gives standalone users the internal skill's current curation behavior. This is a careful adaptation guided by the completed audit report (data/fm-stow-public-vs-internal-audit-s1/report.md), not a rewrite from scratch. Ported per the audit's portable items: (1) read-the-destination-before-writing plus the inspect-then-update triad (which entry does a finding supersede, can it be a one-sentence rewrite, should a stale entry be deleted/replaced now); (2) the concrete prune list (completed chronology, stale versions/paths, transient task state, resolved alternatives, old metrics, superseded claims, duplicates, report-sized procedures) shipped together with its unique-fact guard (never remove a unique current fact unless a stronger owner preserves it); (3) the anti-journal framing (leave a compact, current operating map, not an accumulating journal), replacing the old total-capture thesis; (4) a standing-decisions sweep category; (5) the no-skill-storage scope exclusion (never store, create, or edit a skill as a destination; no 'graduate this to a skill' move); (6) tool-agnostic task-note discipline (inspect the full item, classify new/duplicate/superseding/obsolete, write a considered replacement body, never blind-append) applied to plain TODO/BACKLOG/NOTES files; (7) blocked-on recording for undone next steps; (8) pointer-over-copy and the stronger-owner test before filing; (9) curate every memory file the pass has open, not only the one a finding routes to (curation/accuracy sense only); (10) a closed three-exit graduation model for .stow-notes.md; (11) per-file action verbs (unchanged/added/rewritten/pruned/routed) in the completion receipt, deliberately WITHOUT sizes. EXPLICIT CAPTAIN EXCLUSION: the bounded-memory size-budget machinery is deliberately NOT ported - no byte/size measurement, no numeric or user-set budget/threshold, no re-measuring, no 'never call the session reset-safe while over budget'. The curation prune discipline is intentionally framed as an accuracy discipline, not a length target. Hard requirements: the public skill stays fully standalone and installer-facing (no firstmate internals: no secondmate homes, fm-* scripts, AGENTS.md section references, data/captain-shared.md, tasks-axi, or firstmate pipeline references; the maintainer HTML comment pairing the two independent files is deliberate and mirrors the internal skill's own comment); its existing correct standalone substitutes are preserved (the three-tier local-first routing, the ask-once-then-remember step, the resume pointer, and the no-secrets rule); the duplicated local-vs-external boundary (~6 restatements) and .gitignore behavior (~3 restatements) are consolidated to one owner plus at most a deliberate reinforcement; a second-person voice slip is fixed to third person; and net file size must not grow (it went 11334 -> 11276 bytes). Repo style: one sentence per line in tracked Markdown, plain dash never em dash.

## What Changed

- Teach the public `/stow` skill to inspect and curate destination files, replacing stale or duplicate notes while preserving unique current facts.
- Add standing-decision capture, pointer-over-copy routing, blocked-on context for unfinished work, and closed graduation paths for `.stow-notes.md`.
- Consolidate standalone routing and ignore guidance, exclude skills as storage destinations, and report per-file curation actions in the completion receipt.

## Risk Assessment

✅ Low: The change is limited to the intended public skill, preserves the required standalone behavior, ports all specified curation disciplines, excludes size-budget machinery, leaves the internal skill unchanged, and reduces the file from 11,334 to 11,276 bytes.

## Testing

No pre-existing baseline command was provided. Focused commit checks and two real-agent standalone `/stow` runs passed: curation preserved unique facts, replaced stale and duplicate entries, pruned obsolete history and metrics, recorded the standing decision and blocker, emitted action-based receipts and resume pointers, and correctly used the ignored private fallback without editing the installed skill; all temporary worktree fixtures were removed.

<details>
<summary>Evidence: Standalone curation receipt</summary>

```text
Stow complete.

- `AGENTS.md`: rewritten and pruned. Captured `new-run` version 2, retirement of `old-run`, hosted launch decision, and retained offline support. Removed stale duplicate runtime notes, completed chronology, and retired metric.
- `TODO.md`: rewritten. Release remains pending and blocked on product approval.
- External systems: not accessed.
- Private fallback: not needed.

Every durable finding now lives on disk. The conversation is safe to end or reset.

RESUME POINTER: To pick this back up in a new session, load: `AGENTS.md` (project memory), `TODO.md` (blocked release).
```
</details>
<details>
<summary>Evidence: Standalone curation result diff</summary>

```text
diff --git a/AGENTS.md b/AGENTS.md
index 5b95681..8013e40 100644
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,8 +1,5 @@
 # Project memory
 
 - Current invariant: offline mode remains supported.
-- Runtime command: `old-run` on version 1.
-- Runtime command copy: use `old-run` on version 1.
-- Completed chronology: the preview was opened, checked, and closed last week.
-- Old metric: the retired preview processed 47 records.
-
+- Runtime command: use `new-run` on version 2; `old-run` is retired.
+- Launch decision: use the hosted launch.
diff --git a/TODO.md b/TODO.md
index 44b4af1..8584168 100644
--- a/TODO.md
+++ b/TODO.md
@@ -2,5 +2,4 @@
 
 ## Release the hosted launch
 
-Try either a local-only launch or a hosted launch after the preview work is complete.
-
+Release the hosted launch after product approval; product approval is currently blocking the release.
```
</details>
<details>
<summary>Evidence: Private fallback receipt</summary>

```text
- `.stow-notes.md` - added the `LOCAL_ONLY=1` preview gotcha.
- `.gitignore` - added ignore protection; awaiting your commit.

The private note is confined to this project. Nothing was written externally or placed in the skills directory. The conversation is safe to end or reset.

RESUME POINTER: To pick this back up in a new session, load: `.stow-notes.md` (private project notes, not shared).
```
</details>
<details>
<summary>Evidence: Private fallback files and ignore protection</summary>

```text
=== completion receipt ===
- `.stow-notes.md` - added the `LOCAL_ONLY=1` preview gotcha.
- `.gitignore` - added ignore protection; awaiting your commit.

The private note is confined to this project. Nothing was written externally or placed in the skills directory. The conversation is safe to end or reset.

RESUME POINTER: To pick this back up in a new session, load: `.stow-notes.md` (private project notes, not shared).=== .stow-notes.md ===
# Project Notes

## Operational gotchas

- Preview commands fail when `LOCAL_ONLY=1`; clear or unset `LOCAL_ONLY` before previewing.
=== .gitignore ===
.stow-notes.md
=== observable protections ===
.gitignore:1:.stow-notes.md	.stow-notes.md
installed_skill_unchanged=yes
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`git diff --stat --name-status 345de4e7..d50913ba` and `git diff --quiet 345de4e7..d50913ba -- .agents/skills/stow/SKILL.md`</code>
- <code>`git diff --check 345de4e7..d50913ba` plus focused inspection for forbidden Firstmate, bounded-memory, size-budget, and em dash content</code>
- <code>`wc -c skills/stow/SKILL.md` compared with `git show 345de4e7:skills/stow/SKILL.md | wc -c`</code>
- <code>`codex exec --ephemeral --ignore-user-config --ignore-rules ... -C .stow-public-test-fixture` invoking `/stow` with stale memory, a standing decision, a unique invariant, and a blocked TODO</code>
- <code>Reviewed the live `AGENTS.md` and `TODO.md` result diff and completion receipt</code>
- <code>`codex exec --ephemeral --ignore-user-config --ignore-rules ... -C .stow-public-fallback-fixture` invoking `/stow` without an existing note convention</code>
- <code>Verified `.stow-notes.md` content, `git check-ignore -v .stow-notes.md`, unchanged installed skill bytes, no external routing, and the fallback completion receipt</code>
- <code>`git clean -dffx -- .stow-public-test-fixture .stow-public-fallback-fixture` followed by `git status --short` to confirm transient fixtures were removed</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
