### PR TITLE
fix(bin): defer session-start network checks

### DIFF
--- a/.agents/skills/bootstrap-diagnostics/SKILL.md
+++ b/.agents/skills/bootstrap-diagnostics/SKILL.md
@@ -2,7 +2,7 @@
 name: bootstrap-diagnostics
 description: >-
   Agent-only handling playbook for session-start bootstrap diagnostics.
-  Use whenever the session-start digest's bootstrap section prints an actionable diagnostic line - MISSING, MISSING_MANUAL, BACKEND_INVALID, NEEDS_GH_AUTH, TANGLE, STARTUP_MEMORY_BUDGET, CREW_DISPATCH invalid, FLEET_SYNC, PR_CHECK_MIGRATION, SECONDMATE_SYNC, SECONDMATE_LIVENESS, SECONDMATE_HANDOFF, NUDGE_SECONDMATES, or FMX - or when a standalone bin/fm-bootstrap.sh run prints one of those lines.
+  Use whenever the session-start digest's bootstrap or network-checks section prints an actionable diagnostic line - MISSING, MISSING_MANUAL, BACKEND_INVALID, NEEDS_GH_AUTH, TANGLE, STARTUP_MEMORY_BUDGET, CREW_DISPATCH invalid, FLEET_SYNC, NETWORK_CHECKS, PR_CHECK_MIGRATION, SECONDMATE_SYNC, SECONDMATE_LIVENESS, SECONDMATE_HANDOFF, NUDGE_SECONDMATES, or FMX - or when a standalone bin/fm-bootstrap.sh or bin/fm-startup-network.sh run prints one of those lines.
   A silent bootstrap section, or a BOOTSTRAP_INFO fact, means no skill load.
 user-invocable: false
 metadata:
@@ -25,6 +25,10 @@ When any diagnostic needs captain attention, report the plain consequence and re
 - `MISSING_MANUAL: <tool> (instructions: <url>)` - tell the captain why the tool is required and give them the printed instructions URL, but do not pass the tool to `bin/fm-bootstrap.sh install`; wait for the captain to complete the manual installation, then rerun session start to confirm the dependency is present.
 - `BACKEND_INVALID: <name> (known: <names>)` - the resolved runtime backend has no verified dependency or lifecycle contract, so do not dispatch work until the invalid `FM_BACKEND` or `config/backend` value is corrected to one of the listed backends.
 - `NEEDS_GH_AUTH` - ask the captain to run `! gh auth login` (interactive; you cannot run it for them).
+  This probe now arrives from the deferred network stage, so it is also how an unreachable network shows up: `gh` cannot validate its token offline and reports the same failure. Confirm reachability before asking the captain to re-authenticate a credential that may be fine.
+- `NETWORK_CHECKS: <what did not complete>; rerun <command>` - the deferred network stage itself could not finish, so the checks it names are simply unknown, not failed.
+  Rerun the printed command; it is idempotent and re-derives every finding.
+  A `hit the ...s bound` line means one of those checks is slow or unreachable - most often a remote secondmate host - and the stage stopped rather than letting it wedge; a `lock was no longer held` line means the session that asked for the sweeps no longer owns them, so leave them to the session that does.
 - `TANGLE: <remediation>` - the primary checkout is stranded on a feature branch instead of its default branch; `AGENTS.md` section 8 explains why this guard exists and what it protects.
   The work is safe on that branch ref; restore the primary to its default branch with the printed `git -C <root> checkout <default>`, then re-validate that branch in a proper worktree.
   This is the only sanctioned firstmate-initiated git write to the primary, and it is a non-destructive branch switch that strands nothing.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -132,7 +132,7 @@ Treat `data/captain.md` as the domain-local record of captain preferences, optio
 Run `bin/fm-session-start.sh` exactly once at session start.
 Its header is the single owner of composed commands, ordering, and digest contents.
 `bin/fm-supervision-instructions.sh` renders the emitted supervision block from `docs/supervision-protocols/`.
-Do not reimplement it by separately running its lock, bootstrap, or initial wake-drain components.
+Do not reimplement it by separately running its lock, bootstrap, initial wake-drain, or deferred-network components.
 Run-tier harness surfaces run this command for you at session open while the rest only nudge it, so confirm the digest is present in this session and run it yourself when it is not; `docs/sessionstart-nudge.md` owns adapter tiers, source routing, and compatibility.
 
 Read the complete digest once and trust it as this turn's startup and recovery input.
@@ -155,15 +155,15 @@ When that section reports its checks still in progress it names exactly what is 
 3. **Wake queue** - when locked, drains the durable wake queue and prints the raw records prominently as this turn's first work queue; a bounded, clearly labeled historical status-event annotation may follow a valid `signal` record but never replaces it or current-state reconciliation, and a lapsed watcher chain still surfaces here via the same guard alarm.
    Every locked drain also prints a bounded fleet-wide `OPEN DECISIONS` section when durable decision records remain open, including when the queue itself is empty; reconcile those entries before continuing.
    When the lock could not be acquired and verified, the queue is left untouched because no session mutation is authorized, and the guard's tangle/watcher-liveness alarms still print in read-only advisory mode without drain, supervision repair, or checkout repair commands.
-4. **Context digest** - the full contents of `data/projects.md`, `data/secondmates.md`, `data/captain.md`, `data/captain-shared.md`, and `data/learnings.md`, each clearly delimited.
-   A file that does not exist prints an explicit `ABSENT` marker, never confused with an empty-but-present file: absence is meaningful (`captain.md` absent means use the firstmate repo's built-in defaults, `projects.md` absent means rebuild it from the clones under `projects/`, etc.).
-5. **Fleet-state digest** - the compact backlog listing owned by `bin/fm-session-start.sh`; every `state/<id>.meta`; a bounded tail of each task's `state/<id>.status` (labeled as wake-EVENT history, not current state, with the full log path printed for a deeper read); the `state/.afk` flag; and one cheap alive/dead read of each task's recorded backend endpoint.
+4. **Supervision operating instructions** - after the wake queue, the digest emits exactly one operating block for the detected primary harness.
+   The script itself never starts supervision; the emitted harness protocol owns the exact wait or wake mechanism.
+5. **Fleet-state digest** - after its read-once contract, the compact backlog listing owned by `bin/fm-session-start.sh`; every `state/<id>.meta`; a bounded tail of each task's `state/<id>.status` (labeled as wake-EVENT history, not current state, with the full log path printed for a deeper read); the `state/.afk` flag; and one cheap alive/dead read of each task's recorded backend endpoint.
    That liveness line is a fast presence check only, not a full state read - when you need a crew's actual current state (a run-step, not just "is the pane there"), read it with `bin/fm-crew-state.sh <id>` as before; the digest deliberately skips that deeper, slower read for every task so it stays fast and bounded.
 6. **Network checks** - after the fleet-state digest, the deferred stage's result, or an explicit statement of what it has not confirmed yet.
    A read-only session runs no network checks at all and says so.
-7. **Supervision operating instructions and next step** - after the wake queue and before context, the digest emits exactly one operating block for the detected primary harness.
-   The closing reminder points back to that emitted block and preserves only the lock, afk, Relay, and read-once reminders.
-   The script itself never starts supervision; the emitted harness protocol owns the exact wait or wake mechanism.
+7. **Context digest and next step** - the full contents of `data/projects.md`, `data/secondmates.md`, `data/captain.md`, `data/captain-shared.md`, and `data/learnings.md`, each clearly delimited, followed by the closing reminder.
+   A file that does not exist prints an explicit `ABSENT` marker, never confused with an empty-but-present file: absence is meaningful (`captain.md` absent means use the firstmate repo's built-in defaults, `projects.md` absent means rebuild it from the clones under `projects/`, etc.).
+   The closing reminder points back to the emitted supervision block and preserves only the lock, afk, Relay, and read-once reminders.
 
 Bootstrap detects first, asks for consent, and installs only after the captain approves in the current session.
 Do not dispatch until the required tools are present and GitHub authentication is good.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,6 +111,7 @@ state/               volatile runtime signals; gitignored
   x-outbox/          generated Relay dry-run reply and dismiss previews; inspect it when FMX_DRY_RUN is set (section 14)
   public-followup/   generated private transport for promised public replies: commitment registrations, typed terminal-result inbox, accepted/rejected ledgers (section 14; bin/fm-public-followup.sh)
   x-poll.error x-poll.claim-error  generated Relay and offer-claim diagnostic dedupe markers
+  .startup-network.*  status, report, inline-print claim, and lock for the deferred network stage session start runs off its blocking path; bin/fm-startup-network.sh
   .wake-queue        durable queued wakes: epoch<TAB>seq<TAB>kind<TAB>key<TAB>payload
   .<id>.open-decisions-cursor  per-task byte cursor and folded open-decision set bounding the OPEN DECISIONS scan's cost to new status-log appends; written only by fm-classify-lib.sh's status_open_decisions_incremental, removed by teardown, safe to delete (forces one full re-fold)
   .afk               durable away-mode flag; present = sub-supervisor may inject escalations (set by /afk, cleared on user return)
@@ -142,19 +143,25 @@ An `ABSENT` captain, shared-captain, secondmate, or learnings file means the fir
 If the session lock cannot be acquired and verified, report its exact diagnostic and remain read-only; another active session is only one possible cause.
 A lock-refused session must not spawn, steer, merge, drain the wake queue, repair supervision, repair a checkout, or perform any other fleet mutation.
 
-1. **Lock** - acquires the per-home session lock first, before anything mutates shared state.
-2. **Bootstrap** - detect-only checks (tool/version problems, GitHub auth, the worktree-tangle check, harness override, dispatch-profile validation, backlog-backend status) always run, but routine confirmations stay silent by default.
+The digest itself makes no external-network call and never waits for one.
+Every network check a session start owes - GitHub auth, dead-secondmate relaunch, secondmate convergence, pending handoff delivery, and project clone refresh - runs concurrently in a bounded worker owned by `bin/fm-startup-network.sh` and is reported in the digest's own `NETWORK CHECKS` section.
+When that section reports its checks still in progress it names exactly what is unconfirmed; treat none of those as passed until the result lands, either from `bin/fm-startup-network.sh report` or as a `check: startup-network` wake.
+
+1. **Lock** - acquires the per-home session lock first, before anything mutates shared state, then starts the deferred network stage above.
+2. **Bootstrap** - detect-only checks (tool/version problems, the worktree-tangle check, harness override, dispatch-profile validation, backlog-backend status) always run, but routine confirmations stay silent by default.
    When the lock could not be acquired, the worktree-tangle check uses read-only advisory wording without a checkout repair command.
-   Home-local stale Herdr projection cleanup and the six bootstrap MUTATING sweeps - non-executing legacy PR-check migration, fleet sync, secondmate convergence, secondmate liveness, pending remote handoff retry, and Relay artifact writes - run only when this session actually holds the lock from step 1.
+   Home-local stale Herdr projection cleanup and the six bootstrap MUTATING sweeps - non-executing legacy PR-check migration, fleet sync, secondmate convergence, secondmate liveness, pending remote handoff retry, and Relay artifact writes - run only when this session actually holds the lock from step 1; the four network ones among them run in the deferred stage rather than in this section.
    The secondmate liveness sweep deterministically accounts for every registered secondmate: it relaunches only from the recovery-grade `dead` or `missing` states, preserves ambiguous, unreadable, or unreachable remote targets, and reports skipped or failed guarantees as `SECONDMATE_LIVENESS:` lines (`bin/fm-bootstrap.sh`; `bin/fm-backend.sh`'s `fm_backend_agent_state`; `docs/remote-secondmates.md`).
 3. **Wake queue** - when locked, drains the durable wake queue and prints the raw records prominently as this turn's first work queue; a bounded, clearly labeled historical status-event annotation may follow a valid `signal` record but never replaces it or current-state reconciliation, and a lapsed watcher chain still surfaces here via the same guard alarm.
    Every locked drain also prints a bounded fleet-wide `OPEN DECISIONS` section when durable decision records remain open, including when the queue itself is empty; reconcile those entries before continuing.
    When the lock could not be acquired and verified, the queue is left untouched because no session mutation is authorized, and the guard's tangle/watcher-liveness alarms still print in read-only advisory mode without drain, supervision repair, or checkout repair commands.
-4. **Fleet-state digest** - the compact backlog listing owned by `bin/fm-session-start.sh`; every `state/<id>.meta`; a bounded tail of each task's `state/<id>.status` (labeled as wake-EVENT history, not current state, with the full log path printed for a deeper read); the `state/.afk` flag; and one cheap alive/dead read of each task's recorded backend endpoint.
-   That liveness line is a fast presence check only, not a full state read - when you need a crew's actual current state (a run-step, not just "is the pane there"), read it with `bin/fm-crew-state.sh <id>` as before; the digest deliberately skips that deeper, slower read for every task so it stays fast and bounded.
-5. **Context digest** - last of the bulk sections, the full contents of `data/projects.md`, `data/secondmates.md`, `data/captain.md`, `data/captain-shared.md`, and `data/learnings.md`, each clearly delimited.
+4. **Context digest** - the full contents of `data/projects.md`, `data/secondmates.md`, `data/captain.md`, `data/captain-shared.md`, and `data/learnings.md`, each clearly delimited.
    A file that does not exist prints an explicit `ABSENT` marker, never confused with an empty-but-present file: absence is meaningful (`captain.md` absent means use the firstmate repo's built-in defaults, `projects.md` absent means rebuild it from the clones under `projects/`, etc.).
-6. **Supervision operating instructions and next step** - after the wake queue and before both digests, the digest emits exactly one operating block for the detected primary harness, followed by the read-once contract that governs them.
+5. **Fleet-state digest** - the compact backlog listing owned by `bin/fm-session-start.sh`; every `state/<id>.meta`; a bounded tail of each task's `state/<id>.status` (labeled as wake-EVENT history, not current state, with the full log path printed for a deeper read); the `state/.afk` flag; and one cheap alive/dead read of each task's recorded backend endpoint.
+   That liveness line is a fast presence check only, not a full state read - when you need a crew's actual current state (a run-step, not just "is the pane there"), read it with `bin/fm-crew-state.sh <id>` as before; the digest deliberately skips that deeper, slower read for every task so it stays fast and bounded.
+6. **Network checks** - after the fleet-state digest, the deferred stage's result, or an explicit statement of what it has not confirmed yet.
+   A read-only session runs no network checks at all and says so.
+7. **Supervision operating instructions and next step** - after the wake queue and before context, the digest emits exactly one operating block for the detected primary harness.
    The closing reminder points back to that emitted block and preserves only the lock, afk, Relay, and read-once reminders.
    The script itself never starts supervision; the emitted harness protocol owns the exact wait or wake mechanism.
 
@@ -501,7 +508,7 @@ It performs guarded fast-forward updates of firstmate and registered secondmate 
 
 These skills are not captain-invocable; load them only at their precise triggers.
 
-- `bootstrap-diagnostics` - load whenever the session-start digest's bootstrap section prints an actionable diagnostic line (`MISSING:`, `MISSING_MANUAL:`, `BACKEND_INVALID:`, `NEEDS_GH_AUTH`, `TANGLE:`, `STARTUP_MEMORY_BUDGET:`, `CREW_DISPATCH: invalid`, `FLEET_SYNC:`, `PR_CHECK_MIGRATION:`, `SECONDMATE_SYNC:`, `SECONDMATE_LIVENESS:`, `SECONDMATE_HANDOFF:`, `NUDGE_SECONDMATES:`, or `FMX:`); silence and `BOOTSTRAP_INFO:` need no load.
+- `bootstrap-diagnostics` - load whenever the session-start digest's bootstrap or network-checks section prints an actionable diagnostic line (`MISSING:`, `MISSING_MANUAL:`, `BACKEND_INVALID:`, `NEEDS_GH_AUTH`, `TANGLE:`, `STARTUP_MEMORY_BUDGET:`, `CREW_DISPATCH: invalid`, `FLEET_SYNC:`, `NETWORK_CHECKS:`, `PR_CHECK_MIGRATION:`, `SECONDMATE_SYNC:`, `SECONDMATE_LIVENESS:`, `SECONDMATE_HANDOFF:`, `NUDGE_SECONDMATES:`, or `FMX:`); silence and `BOOTSTRAP_INFO:` need no load.
 - `diagnostic-reasoning` - load before scoping a reported bug and before acting on a diagnostic report.
 - `ask-user-authority` - load before deciding any ask-user finding, regardless of the project's `yolo` posture.
 - `quota-array-dispatch` - load before choosing among a matched crew-dispatch profile array from current quota-axi output.

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -91,6 +91,27 @@
 #          X-mode artifacts, project clones, or repair instructions.
 #          Unset/0 (the default) runs every sweep exactly as before - this flag
 #          is purely additive.
+#          Set FM_BOOTSTRAP_NETWORK to split this run by whether a step talks to
+#          the network, so a session start can print its digest from local reads
+#          alone and run the network half concurrently:
+#            all  (default, and any unrecognized value) - everything, exactly as
+#                 before. Unrecognized values fall back here on purpose: a typo
+#                 must never silently skip a safety sweep.
+#            skip - every LOCAL step, and none of the network ones. Skips
+#                 `gh auth status`, secondmate_liveness_sweep, secondmate_sync,
+#                 secondmate_handoff_resume, and fleet_sync.
+#            only - ONLY those network steps and nothing else. No tool detection,
+#                 no version floors, no tangle check, no PR-check migration, no
+#                 x_mode_setup: those already ran on the local pass.
+#          FM_BOOTSTRAP_DETECT_ONLY composes with it unchanged, so `only` plus
+#          detect-only is the read-only `gh auth status` probe on its own.
+#          bin/fm-startup-network.sh owns the deferral: it runs the `only` phase
+#          in a detached bounded worker and publishes the result. This file stays
+#          the single owner of every sweep, and the split changes only WHEN each
+#          runs, never WHETHER.
+#          A relaunch that the liveness sweep performs during an `only` run is
+#          always reported, because a digest composed before that run already
+#          printed the superseded endpoint record.
 #          Set FM_BOOTSTRAP_LOCKED=1 alongside it when the sweeps are skipped
 #          because THIS session already ran them while holding the fleet lock,
 #          rather than because it has no lock at all. The two cases differ in
@@ -129,6 +150,16 @@ DATA="${FM_DATA_OVERRIDE:-$FM_HOME/data}"
 . "$SCRIPT_DIR/fm-backend.sh"
 # shellcheck source=bin/fm-remote-readiness-lib.sh disable=SC1091
 . "$SCRIPT_DIR/fm-remote-readiness-lib.sh"
+
+# Network-phase selection (see the header). An unrecognized value resolves to
+# `all` so a malformed override runs every step rather than silently dropping a
+# safety sweep.
+case "${FM_BOOTSTRAP_NETWORK:-all}" in
+  skip|only) FM_BOOTSTRAP_NETWORK_PHASE=${FM_BOOTSTRAP_NETWORK:-all} ;;
+  *) FM_BOOTSTRAP_NETWORK_PHASE=all ;;
+esac
+local_phase() { [ "$FM_BOOTSTRAP_NETWORK_PHASE" != only ]; }
+network_phase() { [ "$FM_BOOTSTRAP_NETWORK_PHASE" != skip ]; }
 
 fleet_sync_origin_backed_project_count() {
   local count proj
@@ -496,6 +527,16 @@ secondmate_sync() {
   return 0
 }
 
+# A relaunch replaces the endpoint record a digest may already have printed. On
+# the local pass that digest has not been composed yet, so the fact stays behind
+# FM_BOOTSTRAP_VERBOSE_FACTS as before; on the deferred network pass the digest
+# is already out, so reporting it is what keeps the superseded record from being
+# acted on.
+report_relaunch() {  # <id> <cause> <where>
+  [ "${FM_BOOTSTRAP_VERBOSE_FACTS:-0}" = 1 ] || ! local_phase || return 0
+  echo "BOOTSTRAP_INFO: secondmate $1 relaunched after $2 ($3)"
+}
+
 secondmate_liveness_sweep() {
   # Idempotent secondmate liveness guarantee - SESSION START ONLY. The detailed
   # state machine and its only recovery-authorizing states are owned by
@@ -574,6 +615,7 @@ secondmate_liveness_sweep() {
           cause="remote endpoint $agent_state on its configured host"
           if out=$(FM_SPAWN_NO_GUARD=1 "$FM_ROOT/bin/fm-spawn.sh" "$id" --secondmate 2>&1); then
             SECONDMATE_RESPAWNED_IDS="$SECONDMATE_RESPAWNED_IDS $id"
+            report_relaunch "$id" "$cause" "host=$remote_host"
           else
             echo "SECONDMATE_LIVENESS: secondmate $id: respawn failed after $cause: $(first_line "$out")"
           fi
@@ -610,9 +652,7 @@ secondmate_liveness_sweep() {
         fi
         if out=$(FM_SPAWN_NO_GUARD=1 "$FM_ROOT/bin/fm-spawn.sh" "$id" --secondmate 2>&1); then
           SECONDMATE_RESPAWNED_IDS="$SECONDMATE_RESPAWNED_IDS $id"
-          if [ "${FM_BOOTSTRAP_VERBOSE_FACTS:-0}" = 1 ]; then
-            echo "BOOTSTRAP_INFO: secondmate $id relaunched after $cause (backend=$backend)"
-          fi
+          report_relaunch "$id" "$cause" "backend=$backend"
         else
           echo "SECONDMATE_LIVENESS: secondmate $id: respawn failed after $cause: $(first_line "$out")"
         fi
@@ -1020,73 +1060,94 @@ fi
 # This is the first mutating sweep at a locked session boundary. It pauses an
 # identity-matched watcher, holds its lock, and neutralizes legacy PR checks
 # before any tool detection or later bootstrap mutation can leave old artifacts
-# runnable. Detect-only sessions never touch state.
-if [ "${FM_BOOTSTRAP_DETECT_ONLY:-0}" != 1 ]; then
+# runnable. Detect-only sessions never touch state, and the deferred network pass
+# never repeats it: the local pass that ran first already closed that window.
+if [ "${FM_BOOTSTRAP_DETECT_ONLY:-0}" != 1 ] && local_phase; then
   "$SCRIPT_DIR/fm-pr-check-migrate.sh" || true
   startup_memory_budget_setup
 fi
 
-if [ "$BACKEND_VALID" -eq 0 ]; then
-  echo "BACKEND_INVALID: $BACKEND (known: $FM_BACKEND_KNOWN)"
-fi
-for t in $BACKEND_TOOLS; do
-  fm_backend_required_tool_available "$BACKEND" "$t" \
-    || missing_tool_diagnostic "$t"
-done
-for t in $COMMON_TOOLS; do
-  command -v "$t" >/dev/null || missing_tool_diagnostic "$t"
-done
-# The treehouse lease-support upgrade check is only relevant when the resolved
-# backend actually requires treehouse (every backend except orca, which owns its
-# own worktrees); an orca home must not be told to upgrade a provider it never uses.
-if fm_backend_list_contains "$TOOLS" treehouse \
-  && command -v treehouse >/dev/null 2>&1 && ! treehouse_supports_lease; then
-  echo "MISSING: treehouse (install: $(install_cmd treehouse))"
-fi
-if command -v no-mistakes >/dev/null 2>&1 && ! tool_version_at_least no-mistakes "$NO_MISTAKES_MIN"; then
-  echo "MISSING: no-mistakes (install: $(install_cmd no-mistakes))"
-fi
-if command -v gh-axi >/dev/null 2>&1 && ! tool_version_at_least gh-axi "$GH_AXI_MIN"; then
-  echo "MISSING: gh-axi (install: $(install_cmd gh-axi))"
-fi
-if command -v lavish-axi >/dev/null 2>&1 && ! tool_version_at_least lavish-axi "$LAVISH_AXI_MIN"; then
-  echo "MISSING: lavish-axi (install: $(install_cmd lavish-axi))"
-fi
-if command -v quota-axi >/dev/null 2>&1 && ! fm_quota_axi_compatible; then
-  echo "MISSING: quota-axi (install: $(install_cmd quota-axi))"
-fi
-if command -v tasks-axi >/dev/null 2>&1 && ! fm_tasks_axi_compatible; then
-  echo "MISSING: tasks-axi (install: $(install_cmd tasks-axi))"
-fi
-gh auth status >/dev/null 2>&1 || echo "NEEDS_GH_AUTH"
-# Worktree-tangle check: the firstmate primary checkout (FM_ROOT) must sit on its
-# default branch, not a feature branch (see fm-tangle-lib.sh). Scoped to the
-# primary only; detached-HEAD worktrees and secondmate homes never trip it.
-tangle_branch=$(fm_primary_tangle_branch "$FM_ROOT" 2>/dev/null || true)
-if [ -n "$tangle_branch" ]; then
-  tangle_default=$(fm_default_branch "$FM_ROOT" 2>/dev/null || echo main)
-  if [ "${FM_BOOTSTRAP_DETECT_ONLY:-0}" = 1 ] && [ "${FM_BOOTSTRAP_LOCKED:-0}" != 1 ]; then
-    echo "TANGLE: primary checkout on feature branch '$tangle_branch' (expected '$tangle_default'); the work is safe on that ref - read-only session must leave restore work to the session holding the fleet lock"
-  else
-    echo "TANGLE: primary checkout on feature branch '$tangle_branch' (expected '$tangle_default'); the work is safe on that ref - restore the primary with: git -C $FM_ROOT checkout $tangle_default, then re-validate the branch in a proper worktree"
+# Local detection: presence, version floors, and configuration. Nothing here
+# leaves this machine, so it stays on the session-start critical path.
+detect_local_tools() {
+  if [ "$BACKEND_VALID" -eq 0 ]; then
+    echo "BACKEND_INVALID: $BACKEND (known: $FM_BACKEND_KNOWN)"
   fi
-fi
-crew=
-[ -f "$CONFIG/crew-harness" ] && crew=$(tr -d '[:space:]' < "$CONFIG/crew-harness" || true)
-if [ "${FM_BOOTSTRAP_VERBOSE_FACTS:-0}" = 1 ] && [ -n "$crew" ] && [ "$crew" != "default" ]; then
-  echo "BOOTSTRAP_INFO: crew harness override active: $crew"
-fi
-crew_dispatch_validate
-if [ "${FM_BOOTSTRAP_VERBOSE_FACTS:-0}" = 1 ] \
-  && ! fm_backlog_backend_manual "$CONFIG" && fm_tasks_axi_compatible; then
-  echo "BOOTSTRAP_INFO: tasks-axi available"
-fi
+  for t in $BACKEND_TOOLS; do
+    fm_backend_required_tool_available "$BACKEND" "$t" \
+      || missing_tool_diagnostic "$t"
+  done
+  for t in $COMMON_TOOLS; do
+    command -v "$t" >/dev/null || missing_tool_diagnostic "$t"
+  done
+  # The treehouse lease-support upgrade check is only relevant when the resolved
+  # backend actually requires treehouse (every backend except orca, which owns its
+  # own worktrees); an orca home must not be told to upgrade a provider it never uses.
+  if fm_backend_list_contains "$TOOLS" treehouse \
+    && command -v treehouse >/dev/null 2>&1 && ! treehouse_supports_lease; then
+    echo "MISSING: treehouse (install: $(install_cmd treehouse))"
+  fi
+  if command -v no-mistakes >/dev/null 2>&1 && ! tool_version_at_least no-mistakes "$NO_MISTAKES_MIN"; then
+    echo "MISSING: no-mistakes (install: $(install_cmd no-mistakes))"
+  fi
+  if command -v gh-axi >/dev/null 2>&1 && ! tool_version_at_least gh-axi "$GH_AXI_MIN"; then
+    echo "MISSING: gh-axi (install: $(install_cmd gh-axi))"
+  fi
+  if command -v lavish-axi >/dev/null 2>&1 && ! tool_version_at_least lavish-axi "$LAVISH_AXI_MIN"; then
+    echo "MISSING: lavish-axi (install: $(install_cmd lavish-axi))"
+  fi
+  if command -v quota-axi >/dev/null 2>&1 && ! fm_quota_axi_compatible; then
+    echo "MISSING: quota-axi (install: $(install_cmd quota-axi))"
+  fi
+  if command -v tasks-axi >/dev/null 2>&1 && ! fm_tasks_axi_compatible; then
+    echo "MISSING: tasks-axi (install: $(install_cmd tasks-axi))"
+  fi
+}
+
+detect_local_config() {
+  # Worktree-tangle check: the firstmate primary checkout (FM_ROOT) must sit on its
+  # default branch, not a feature branch (see fm-tangle-lib.sh). Scoped to the
+  # primary only; detached-HEAD worktrees and secondmate homes never trip it.
+  tangle_branch=$(fm_primary_tangle_branch "$FM_ROOT" 2>/dev/null || true)
+  if [ -n "$tangle_branch" ]; then
+    tangle_default=$(fm_default_branch "$FM_ROOT" 2>/dev/null || echo main)
+    if [ "${FM_BOOTSTRAP_DETECT_ONLY:-0}" = 1 ] && [ "${FM_BOOTSTRAP_LOCKED:-0}" != 1 ]; then
+      echo "TANGLE: primary checkout on feature branch '$tangle_branch' (expected '$tangle_default'); the work is safe on that ref - read-only session must leave restore work to the session holding the fleet lock"
+    else
+      echo "TANGLE: primary checkout on feature branch '$tangle_branch' (expected '$tangle_default'); the work is safe on that ref - restore the primary with: git -C $FM_ROOT checkout $tangle_default, then re-validate the branch in a proper worktree"
+    fi
+  fi
+  crew=
+  [ -f "$CONFIG/crew-harness" ] && crew=$(tr -d '[:space:]' < "$CONFIG/crew-harness" || true)
+  if [ "${FM_BOOTSTRAP_VERBOSE_FACTS:-0}" = 1 ] && [ -n "$crew" ] && [ "$crew" != "default" ]; then
+    echo "BOOTSTRAP_INFO: crew harness override active: $crew"
+  fi
+  crew_dispatch_validate
+  if [ "${FM_BOOTSTRAP_VERBOSE_FACTS:-0}" = 1 ] \
+    && ! fm_backlog_backend_manual "$CONFIG" && fm_tasks_axi_compatible; then
+    echo "BOOTSTRAP_INFO: tasks-axi available"
+  fi
+}
+
+# The order below is the order the diagnostics have always printed in, so a
+# `skip` run is the same output with the network lines removed rather than a
+# reshuffle. `gh auth status` sits between the two local blocks because that is
+# where it has always been.
+local_phase && detect_local_tools
+network_phase && { gh auth status >/dev/null 2>&1 || echo "NEEDS_GH_AUTH"; }
+local_phase && detect_local_config
+
 if [ "${FM_BOOTSTRAP_DETECT_ONLY:-0}" != 1 ]; then
-  secondmate_liveness_sweep
-  secondmate_sync
-  secondmate_handoff_resume
-  x_mode_setup
-  fleet_sync
+  # secondmate_sync consumes SECONDMATE_RESPAWNED_IDS from the liveness sweep, so
+  # those two always run together in the same phase.
+  if network_phase; then
+    secondmate_liveness_sweep
+    secondmate_sync
+    secondmate_handoff_resume
+  fi
+  # x_mode_setup writes local Relay artifacts only and never leaves the machine.
+  local_phase && x_mode_setup
+  network_phase && fleet_sync
 fi
-secondmate_handoff_detect
+local_phase && secondmate_handoff_detect
 exit 0

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -170,14 +170,13 @@ network_mutation_authorized() {
   [ "$current" = "$expected" ]
 }
 
-run_network_sweep() {
+network_sweep_authorized() {
   local label=$1
-  shift
   if network_mutation_authorized; then
-    "$@"
-  else
-    echo "NETWORK_CHECKS: fleet lock ownership changed before $label, so this stale worker skipped that sweep"
+    return 0
   fi
+  echo "NETWORK_CHECKS: fleet lock ownership changed before $label, so this stale worker skipped that sweep"
+  return 1
 }
 
 fleet_sync_origin_backed_project_count() {
@@ -1160,13 +1159,13 @@ if [ "${FM_BOOTSTRAP_DETECT_ONLY:-0}" != 1 ]; then
   # secondmate_sync consumes SECONDMATE_RESPAWNED_IDS from the liveness sweep, so
   # those two always run together in the same phase.
   if network_phase; then
-    run_network_sweep 'dead-secondmate relaunch' secondmate_liveness_sweep
-    run_network_sweep 'secondmate convergence' secondmate_sync
-    run_network_sweep 'pending handoff delivery' secondmate_handoff_resume
+    if network_sweep_authorized 'dead-secondmate relaunch'; then secondmate_liveness_sweep; fi
+    if network_sweep_authorized 'secondmate convergence'; then secondmate_sync; fi
+    if network_sweep_authorized 'pending handoff delivery'; then secondmate_handoff_resume; fi
   fi
   # x_mode_setup writes local Relay artifacts only and never leaves the machine.
   local_phase && x_mode_setup
-  network_phase && run_network_sweep 'project clone refresh' fleet_sync
+  if network_phase && network_sweep_authorized 'project clone refresh'; then fleet_sync; fi
 fi
 local_phase && secondmate_handoff_detect
 exit 0

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -161,6 +161,25 @@ esac
 local_phase() { [ "$FM_BOOTSTRAP_NETWORK_PHASE" != only ]; }
 network_phase() { [ "$FM_BOOTSTRAP_NETWORK_PHASE" != skip ]; }
 
+network_mutation_authorized() {
+  local expected=${FM_BOOTSTRAP_NETWORK_LOCK_PID:-} current
+  [ -n "$expected" ] || return 0
+  case "$expected" in *[!0-9]*) return 1 ;; esac
+  [ -f "$STATE/.lock" ] && [ ! -L "$STATE/.lock" ] || return 1
+  current=$(cat "$STATE/.lock" 2>/dev/null) || return 1
+  [ "$current" = "$expected" ]
+}
+
+run_network_sweep() {
+  local label=$1
+  shift
+  if network_mutation_authorized; then
+    "$@"
+  else
+    echo "NETWORK_CHECKS: fleet lock ownership changed before $label, so this stale worker skipped that sweep"
+  fi
+}
+
 fleet_sync_origin_backed_project_count() {
   local count proj
   count=0
@@ -1141,13 +1160,13 @@ if [ "${FM_BOOTSTRAP_DETECT_ONLY:-0}" != 1 ]; then
   # secondmate_sync consumes SECONDMATE_RESPAWNED_IDS from the liveness sweep, so
   # those two always run together in the same phase.
   if network_phase; then
-    secondmate_liveness_sweep
-    secondmate_sync
-    secondmate_handoff_resume
+    run_network_sweep 'dead-secondmate relaunch' secondmate_liveness_sweep
+    run_network_sweep 'secondmate convergence' secondmate_sync
+    run_network_sweep 'pending handoff delivery' secondmate_handoff_resume
   fi
   # x_mode_setup writes local Relay artifacts only and never leaves the machine.
   local_phase && x_mode_setup
-  network_phase && fleet_sync
+  network_phase && run_network_sweep 'project clone refresh' fleet_sync
 fi
 local_phase && secondmate_handoff_detect
 exit 0

--- a/bin/fm-lock.sh
+++ b/bin/fm-lock.sh
@@ -54,7 +54,27 @@ release_claim_lock() {
 }
 trap release_claim_lock EXIT
 trap 'exit 1' HUP INT TERM
-fm_lock_acquire_wait "$CLAIM_LOCK"
+
+if [ -f "$LOCK" ] && [ ! -L "$LOCK" ]; then
+  old=$(cat "$LOCK" 2>/dev/null || true)
+  if [ "$old" = "$me" ]; then
+    echo "lock acquired: harness pid $me"
+    exit 0
+  fi
+  if fm_harness_pid_alive "$old"; then
+    echo "error: another live firstmate session holds the lock (pid $old); operate read-only until resolved" >&2
+    exit 1
+  fi
+fi
+
+if ! fm_lock_try_acquire "$CLAIM_LOCK"; then
+  sweep_pid=$(sed -n 's/^pid=//p' "$STATE/.startup-network.status" 2>/dev/null | tail -1)
+  if [ -n "${FM_LOCK_HELD_PID:-}" ] && [ "$FM_LOCK_HELD_PID" = "$sweep_pid" ]; then
+    echo "error: the prior session's bounded startup sweep is finishing; operate read-only until it releases the fleet lock" >&2
+    exit 1
+  fi
+  fm_lock_acquire_wait "$CLAIM_LOCK"
+fi
 CLAIM_LOCK_HELD=1
 
 if [ -e "$LOCK" ] || [ -L "$LOCK" ]; then

--- a/bin/fm-session-start.sh
+++ b/bin/fm-session-start.sh
@@ -12,9 +12,10 @@
 # belong in a script, not in N agent turns.
 #
 # COMPOSITION, NOT DUPLICATION: this script calls fm-lock.sh, fm-bootstrap.sh,
-# and fm-wake-drain.sh as real subprocesses and prints their real output. It
-# never re-implements their logic; all sequencing/formatting logic added here
-# stays local to this file. Those three scripts remain fully working
+# fm-wake-drain.sh, and fm-startup-network.sh as real subprocesses and prints
+# their real output. It never re-implements their logic; all
+# sequencing/formatting logic added here stays local to this file. Those four
+# scripts remain fully working
 # standalone with unchanged default behavior - other flows (fm-bootstrap.sh
 # install <tools> after consent, /updatefirstmate, the afk daemon, existing
 # tests) still call them directly. The one seam this script needed -
@@ -33,7 +34,8 @@
 #                       (legacy PR-check migration, secondmate convergence,
 #                       secondmate liveness, pending remote handoff retry,
 #                       X-mode artifact writes, fleet sync) also run only when
-#                       locked.
+#                       locked; the four network sweeps run in the deferred
+#                       stage rather than this synchronous bootstrap section.
 #   3. wake-drain     - mutates the durable wake queue, so it also only runs
 #                       when locked.
 #   4. supervision-instructions - the one emitted operating block for the
@@ -107,11 +109,12 @@
 #
 # The tradeoff this ordering accepts: a refused (read-only) session must not
 # go dark. So on refusal, bootstrap still runs (in FM_BOOTSTRAP_DETECT_ONLY=1
-# mode) for its read-only detect lines - missing tools, gh auth, the
-# worktree-tangle check, the harness override, crew-dispatch validation,
-# tasks-axi and quota-axi tool checks, and tasks-axi availability - none of
-# which mutate shared state and all of which are safe to compute without
-# verified lock ownership.
+# mode) for its local read-only detect lines - missing tools, the worktree-tangle
+# check, the harness override, crew-dispatch validation, tasks-axi and quota-axi
+# tool checks, and tasks-axi availability - none of which mutate shared state
+# and all of which are safe to compute without verified lock ownership.
+# It deliberately skips the network-only GitHub-auth probe because a read-only
+# session has no dispatch, spawn, steer, or merge action for that verdict to gate.
 # Only projection cleanup, the six bootstrap mutating sweeps, and the
 # wake-queue drain are skipped.
 # The context and fleet-state digests

--- a/bin/fm-session-start.sh
+++ b/bin/fm-session-start.sh
@@ -44,15 +44,36 @@
 #                       every state/*.meta, a bounded state/*.status tail,
 #                       state/.afk, and a cheap per-task endpoint-liveness read:
 #                       read-only, always runs.
-#   7. context digest - data/projects.md, data/secondmates.md, data/captain.md,
+#   7. network checks - the result of the deferred network stage started back at
+#                       step 1, harvested WITHOUT waiting for it.
+#   8. context digest - data/projects.md, data/secondmates.md, data/captain.md,
 #                       data/captain-shared.md, data/learnings.md: read-only,
 #                       always safe, always runs.
-#   8. closing reminder - prints the context-specific watcher next step; this
+#   9. closing reminder - prints the context-specific watcher next step; this
 #                       script points back to the emitted harness supervision
 #                       block and deliberately never arms the watcher itself.
 #
-# Those eight names are also the runtime-bound stage list below, so a truncated
+# Those nine names are also the runtime-bound stage list below, so a truncated
 # startup can name exactly which of them never ran.
+#
+# NO NETWORK ON THE BLOCKING PATH. This digest runs on a session-open hook that
+# blocks session initialization, so anything it waits for is time the captain
+# waits before the first turn - and every external-network call it used to make
+# was individually unbounded. One unreachable remote secondmate could burn the
+# entire FM_SESSION_START_TIMEOUT and truncate the digest, so a slow network
+# could cost the work queue itself.
+# So no step between here and the last line below makes an external-network
+# call. The five that did - `gh auth status`, secondmate liveness, secondmate
+# convergence, pending remote handoff delivery, and the fleet-sync fetch - are
+# started as one detached bounded worker right after the lock (step 1) and
+# harvested at step 7 without ever blocking on it. bin/fm-startup-network.sh
+# owns that stage and its safety argument; bin/fm-bootstrap.sh remains the owner
+# of the sweeps themselves and still runs every one of them.
+# The digest is therefore composed from local reads and local subprocesses only,
+# and an unreachable host now delays a reported check rather than the startup.
+# What this deliberately trades: on a slow network the digest prints "IN
+# PROGRESS" and names exactly which checks are not yet confirmed, instead of
+# waiting for them. It never reports an unconfirmed check as passed.
 #
 # ORDERING, and why FLEET STATE now runs before CONTEXT: this digest is
 # delivered through a harness that truncates an oversized payload from the TAIL,
@@ -137,11 +158,13 @@
 # RUNTIME BOUND: the digest is now executed on a session-open hook (see
 # bin/fm-sessionstart-run.sh), which blocks session initialization while it
 # runs, so an unbounded digest is no longer merely slow - it can strand a whole
-# session behind one hung subprocess. Not every step is individually bounded:
-# bootstrap's fleet sync is, but its `gh auth status` probe, tool version
-# probes, and secondmate liveness reads are not, and neither are the backlog
-# listing or the per-task endpoint reads. So the whole digest runs as ONE
-# bounded child of this script (FM_SESSION_START_TIMEOUT, default 120s). The
+# session behind one hung subprocess. Every remaining step is local, but local is
+# not the same as bounded: tool version probes, the backlog listing, and the
+# per-task endpoint reads are all unbounded subprocesses. So the whole digest
+# still runs as ONE bounded child of this script (FM_SESSION_START_TIMEOUT,
+# default 120s). The deferred network stage deliberately sits OUTSIDE that bound,
+# in its own process group under its own aggregate deadline, so a truncated
+# digest neither waits for it nor orphans it unbounded. The
 # child writes the digest straight to this script's stdout, so everything it
 # emitted before the bound was hit is already delivered; the parent then prints
 # a loud STARTUP TRUNCATED banner naming the stage that did not finish and the
@@ -201,7 +224,7 @@ done
 # The ordered stage list is the contract behind the truncation banner: the child
 # names the stage it is entering, and the parent reports every stage at or after
 # that one as never emitted. Keep it in the exact order the digest prints.
-SESSION_START_STAGES='lock bootstrap wake-queue supervision-instructions read-once fleet-state context next-step'
+SESSION_START_STAGES='lock bootstrap wake-queue supervision-instructions read-once fleet-state network-checks context next-step'
 
 stage() {  # <stage-name>: breadcrumb for the parent's truncation banner
   [ -n "${FM_SESSION_START_STAGE_FILE:-}" ] || return 0
@@ -263,6 +286,15 @@ PRIMARY_HARNESS=$("$SCRIPT_DIR/fm-harness.sh" 2>/dev/null || printf unknown)
 . "$SCRIPT_DIR/fm-trace-context-lib.sh"
 # shellcheck source=bin/fm-line-cap-lib.sh
 . "$SCRIPT_DIR/fm-line-cap-lib.sh"
+
+# One tasks-axi compatibility verdict per session start. The probe costs three
+# tasks-axi subprocesses and this digest needs the same answer twice - here for
+# the backlog listing and again inside the fm-bootstrap.sh child, which reports
+# an incompatible build as MISSING. Computing it once and handing it to that
+# child collapses six subprocesses to three. fm-tasks-axi-lib.sh owns both reuse
+# layers and the one-hop consumption rule that keeps the verdict out of any
+# agent's environment.
+if fm_tasks_axi_compatible; then TASKS_AXI_COMPATIBLE=1; else TASKS_AXI_COMPATIBLE=0; fi
 
 STATUS_TAIL=${FM_SESSION_START_STATUS_TAIL:-5}
 case "$STATUS_TAIL" in ''|*[!0-9]*) STATUS_TAIL=5 ;; esac
@@ -508,19 +540,37 @@ if [ "$READ_ONLY" -eq 0 ]; then
     rm -f "$COMPLETION_FILE" 2>/dev/null || true
   fi
   fm_trace_context_session_start "$CONFIG" "$STATE/.trace-context-effective"
+  # Every network call this session start owes is launched HERE, detached and
+  # bounded, so it runs concurrently with the whole digest below instead of in
+  # front of it. Step 7 harvests whatever it has finished, without ever waiting.
+  # --reemit passes --locked 0 for the same reason it runs bootstrap detect-only:
+  # this process already ran the mutating sweeps at its own startup, so only the
+  # read-only GitHub-auth probe is owed. A read-only session starts nothing at
+  # all: it holds no mutation authority for the sweeps, and it must not spawn,
+  # steer, or merge anyway, so it has no action left for an auth verdict to gate.
+  NETWORK_STAGE_LOCKED=1
+  [ "$REEMIT" -eq 0 ] || NETWORK_STAGE_LOCKED=0
+  "$SCRIPT_DIR/fm-startup-network.sh" start \
+    --locked "$NETWORK_STAGE_LOCKED" --harvest-pid $$ >/dev/null 2>&1 || true
 fi
 
 # --- 2. bootstrap --------------------------------------------------------
+# FM_BOOTSTRAP_NETWORK=skip on every path: bootstrap's own network half is what
+# the deferred stage above is running right now, and running it twice would both
+# re-block this digest and race the worker's sweeps against themselves.
 stage bootstrap
 subsection "BOOTSTRAP"
 if [ "$READ_ONLY" -eq 1 ]; then
-  BOOT_OUT=$(FM_BOOTSTRAP_DETECT_ONLY=1 "$SCRIPT_DIR/fm-bootstrap.sh" 2>&1)
+  BOOT_OUT=$(FM_BOOTSTRAP_DETECT_ONLY=1 FM_BOOTSTRAP_NETWORK=skip \
+    FM_TASKS_AXI_COMPATIBLE="$TASKS_AXI_COMPATIBLE" "$SCRIPT_DIR/fm-bootstrap.sh" 2>&1)
 elif [ "$REEMIT" -eq 1 ]; then
-  BOOT_OUT=$(FM_BOOTSTRAP_DETECT_ONLY=1 FM_BOOTSTRAP_LOCKED=1 "$SCRIPT_DIR/fm-bootstrap.sh" 2>&1)
+  BOOT_OUT=$(FM_BOOTSTRAP_DETECT_ONLY=1 FM_BOOTSTRAP_LOCKED=1 FM_BOOTSTRAP_NETWORK=skip \
+    FM_TASKS_AXI_COMPATIBLE="$TASKS_AXI_COMPATIBLE" "$SCRIPT_DIR/fm-bootstrap.sh" 2>&1)
 else
   BOOT_OUT=$(
     "$SCRIPT_DIR/fm-herdr-session-cleanup.sh" 2>&1 || true
-    "$SCRIPT_DIR/fm-bootstrap.sh" 2>&1
+    FM_BOOTSTRAP_NETWORK=skip FM_TASKS_AXI_COMPATIBLE="$TASKS_AXI_COMPATIBLE" \
+      "$SCRIPT_DIR/fm-bootstrap.sh" 2>&1
   )
 fi
 if [ -n "$BOOT_OUT" ]; then
@@ -609,6 +659,8 @@ Go to a source directly only when:
     printed with its tail),
   - a full task body is needed (tasks-axi show <id> --full, or data/backlog.md),
   - the backlog listing disclosed omitted queued items and this turn needs them,
+  - the NETWORK CHECKS section reported its checks still IN PROGRESS and this
+    turn needs their verdict (bin/fm-startup-network.sh report),
   - or a STARTUP TRUNCATED banner named the stage that would have printed it, in
     which case that stage's sources were never emitted and must be reconciled.
 EOF
@@ -687,7 +739,26 @@ if fm_pf_relay_active "$FM_HOME" \
   fi
 fi
 
-# --- 7. context digest -----------------------------------------------------
+# --- 7. network checks ------------------------------------------------------
+# Deliberately here and not later: these lines are actionable (a stuck clone, a
+# secondmate that could not be relaunched, broken GitHub auth), and the section
+# after this one is the curated memory a truncated tail is meant to take first.
+# Deliberately here and not earlier: this is the last point in the digest, so the
+# worker started at step 1 has had the whole composition above to finish in. It
+# is a NON-BLOCKING read either way - whatever the worker has published by now is
+# printed, and whatever it has not is named as not yet confirmed.
+stage network-checks
+section "NETWORK CHECKS"
+if [ "$READ_ONLY" -eq 1 ]; then
+  printf 'skipped (read-only session) - GitHub authentication, project clone refresh,\n'
+  printf 'secondmate liveness and convergence, and pending handoff delivery were not run.\n'
+  printf 'They need the fleet lock, and this session must not spawn, steer, or merge, so it\n'
+  printf 'has no action they would gate. The session holding the lock runs them.\n'
+else
+  "$SCRIPT_DIR/fm-startup-network.sh" harvest --pid $$ 2>&1 || true
+fi
+
+# --- 8. context digest -----------------------------------------------------
 # Last of the bulk sections deliberately: curated memory is stable session to
 # session, already governed by config/startup-memory-budget, and recoverable
 # with one targeted read, so it is the cheapest thing for a truncated tail to
@@ -700,7 +771,7 @@ print_file_or_absent "$DATA/captain.md" "data/captain.md"
 print_file_or_absent "$DATA/captain-shared.md" "data/captain-shared.md (shared, main-authoritative, read-only in secondmate homes)"
 print_file_or_absent "$DATA/learnings.md" "data/learnings.md"
 
-# --- 8. closing reminder -----------------------------------------------
+# --- 9. closing reminder -----------------------------------------------
 stage next-step
 section "NEXT STEP"
 if [ "$READ_ONLY" -eq 1 ]; then

--- a/bin/fm-sessionstart-run.sh
+++ b/bin/fm-sessionstart-run.sh
@@ -31,8 +31,9 @@
 # Every path exits 0, exactly like the nudge wrapper: a Claude SessionStart
 # exit 2 blocks session initialization, so a failed session start must reach the
 # agent as digest text it can act on, never as a refusal to open the session.
-# A lock another live session holds, broken GitHub auth, and a truncated digest
-# are all reported inside the digest for exactly that reason.
+# A lock another live session holds and a truncated digest are reported inside
+# the digest, while broken GitHub auth arrives through the deferred network
+# result inline or as a wake, for exactly that reason.
 set -u
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/bin/fm-startup-network.sh
+++ b/bin/fm-startup-network.sh
@@ -27,13 +27,11 @@
 #     digest or as a `check: startup-network` wake, and while the worker is still
 #     running the digest states by name what is not yet confirmed. A deferred
 #     check is never silently pending.
-#   - Mutation authority is re-verified. The worker outlives the command that
-#     launched it, so before running any mutating sweep it re-checks that the
-#     session lock still names the exact holder it was launched under, then
-#     fm-bootstrap.sh repeats that check at every mutating sweep boundary. A
-#     session that took the lock in the meantime has rewritten that value, so
-#     the stale worker skips the remaining sweeps rather than running underneath
-#     the new owner.
+#   - Mutation authority is leased. The worker outlives the command that launched
+#     it, so it takes the same acquisition lease a new session must hold before
+#     replacing a dead owner, re-checks the captured owner under that lease, and
+#     holds it through the bounded mutating run. A takeover stays read-only until
+#     that run settles, so old and new owners can never sweep concurrently.
 #
 # Usage: fm-startup-network.sh start --locked <0|1> --harvest-pid <pid>
 #          Launch the detached worker and return immediately. Single-flight: a
@@ -307,7 +305,7 @@ EOF
 }
 
 cmd_run() {  # <locked> <lock-pid> <generation>
-  local locked=$1 lock_pid=$2 generation=$3 phases started budget out rc sweep_locked=0 downgraded=0 internal=0
+  local locked=$1 lock_pid=$2 generation=$3 phases started budget out rc sweep_locked=0 downgraded=0 internal=0 lease_held=0
   mkdir -p "$STATE" 2>/dev/null || return 1
   started=$(now)
   budget=$(stage_budget)
@@ -356,6 +354,15 @@ EOF
   out=$(mktemp "${TMPDIR:-/tmp}/fm-startup-network.XXXXXX" 2>/dev/null) || return 1
   rc=0
   if [ "$sweep_locked" -eq 1 ]; then
+    fm_lock_acquire_wait "$STATE/.lock.acquire"
+    lease_held=1
+    if ! lock_unchanged "$lock_pid"; then
+      sweep_locked=0
+      phases=probe
+      downgraded=1
+    fi
+  fi
+  if [ "$sweep_locked" -eq 1 ]; then
     fm_run_timed "$budget" env FM_BOOTSTRAP_NETWORK=only \
       FM_BOOTSTRAP_NETWORK_LOCK_PID="$lock_pid" \
       "$SCRIPT_DIR/fm-bootstrap.sh" >"$out" 2>&1 || rc=$?
@@ -363,6 +370,7 @@ EOF
     fm_run_timed "$budget" env FM_BOOTSTRAP_NETWORK=only FM_BOOTSTRAP_DETECT_ONLY=1 \
       "$SCRIPT_DIR/fm-bootstrap.sh" >"$out" 2>&1 || rc=$?
   fi
+  [ "$lease_held" -eq 0 ] || fm_lock_release "$STATE/.lock.acquire"
 
   if [ "$downgraded" -eq 1 ]; then
     printf 'NETWORK_CHECKS: the fleet lock was no longer held by the session that requested these, so dead-secondmate relaunch, secondmate convergence, pending handoff delivery, and project clone refresh were skipped; they belong to whichever session holds the lock now\n' >> "$out"

--- a/bin/fm-startup-network.sh
+++ b/bin/fm-startup-network.sh
@@ -549,7 +549,7 @@ case "$MODE" in
   run) cmd_run "$LOCKED" "$LOCK_PID" "$GENERATION" ;;
   harvest) cmd_harvest "${HARVEST_PID:-}" ;;
   report) print_state ;;
-  wait) cmd_wait "${1:-120}" ;;
+  wait) cmd_wait "${1:-120}" || exit $? ;;
   -h|--help) usage ;;
   *)
     printf 'fm-startup-network: unknown mode: %s\n' "${MODE:-<none>}" >&2

--- a/bin/fm-startup-network.sh
+++ b/bin/fm-startup-network.sh
@@ -1,0 +1,423 @@
+#!/usr/bin/env bash
+# fm-startup-network.sh - the deferred network stage of a session start.
+#
+# WHY THIS EXISTS. Every external-network call a session start makes used to run
+# BEFORE the digest printed, on a hook that blocks session initialization: `gh
+# auth status`, the secondmate liveness and convergence sweeps (11 sequential,
+# individually unbounded SSH connections per REMOTE secondmate), pending remote
+# handoff delivery, and the fleet-sync fetch of every project clone. None of
+# those calls is individually bounded, so one unreachable host could consume the
+# whole FM_SESSION_START_TIMEOUT budget and truncate the digest outright, turning
+# a slow network into a startup that never printed the work queue at all.
+# This script runs exactly that work OFF the blocking path: the digest is
+# composed from local reads alone while these checks run concurrently in a
+# detached worker, and their result is reported back inline when it finishes in
+# time, or as a durable wake when it does not.
+#
+# WHAT IS PRESERVED. Nothing is dropped. bin/fm-bootstrap.sh remains the single
+# owner of every one of these sweeps and still runs all of them, unchanged, via
+# its FM_BOOTSTRAP_NETWORK=only phase. Deferral changes WHEN they run, not
+# WHETHER, and three properties make the later run safe:
+#   - The sweeps are idempotent DETECTORS. A run whose report is lost (killed
+#     worker, truncated digest, crashed session) loses no finding: the next run
+#     re-derives the same dead secondmate, the same stuck clone, the same
+#     undelivered handoff. There is no once-only signal to miss.
+#   - The result is durable and always surfaces. It lands in
+#     state/.startup-network.report and reaches the agent either inline in the
+#     digest or as a `check: startup-network` wake, and while the worker is still
+#     running the digest states by name what is not yet confirmed. A deferred
+#     check is never silently pending.
+#   - Mutation authority is re-verified. The worker outlives the command that
+#     launched it, so before running any mutating sweep it re-checks that the
+#     session lock still names the exact holder it was launched under. A session
+#     that took the lock in the meantime has rewritten that value, so the orphan
+#     downgrades to the read-only probe and says so rather than sweeping
+#     underneath the new owner.
+#
+# Usage: fm-startup-network.sh start --locked <0|1> --harvest-pid <pid>
+#          Launch the detached worker and return immediately. Single-flight: a
+#          worker already running for this home is left alone. --locked 1 asks
+#          for the mutating sweeps as well as the read-only probe; --locked 0
+#          asks for the probe only. --harvest-pid names the session-start process
+#          that will try to print the result inline, so the worker can tell
+#          whether a wake is still needed.
+#        fm-startup-network.sh run --locked <0|1> [--lock-pid <pid>]
+#          Run the checks in the foreground and publish the result. This is what
+#          `start` detaches, passing the lock pid it captured; run it directly to
+#          redo the stage by hand, where the current lock holder is the answer.
+#        fm-startup-network.sh harvest --pid <pid>
+#          Print the digest's NETWORK CHECKS section and release the inline-print
+#          claim. Called by bin/fm-session-start.sh, not by hand.
+#        fm-startup-network.sh report
+#          Print the current state and report without changing anything.
+#        fm-startup-network.sh wait [<seconds>]
+#          Block until the worker settles, up to <seconds> (default 120). For
+#          operators and tests only; a session start never waits.
+#
+# STATE, all under this home's state/ and gitignored with it:
+#   .startup-network.status   key=value record - state, pid, started, finished,
+#                             rc, locked, phases. The single source of truth for
+#                             what ran and how it ended.
+#   .startup-network.report   the sweep output, byte for byte as
+#                             bin/fm-bootstrap.sh produced it, plus a
+#                             NETWORK_CHECKS: line whenever the stage itself
+#                             could not complete or had to downgrade.
+#   .startup-network.claim    the pid of a session start that intends to print
+#                             the result inline; its presence with a LIVE pid is
+#                             the only thing that suppresses the wake.
+#   .startup-network.lock     serializes publish against harvest, so exactly one
+#                             of the two reports each result.
+#
+# The whole stage is bounded by FM_STARTUP_NETWORK_TIMEOUT (default 120s), one
+# aggregate deadline replacing the per-call unboundedness that used to be able to
+# wedge a startup. Hitting the bound is reported as an actionable NETWORK_CHECKS:
+# line, never as silence.
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
+STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
+
+STATUS_FILE="$STATE/.startup-network.status"
+REPORT_FILE="$STATE/.startup-network.report"
+CLAIM_FILE="$STATE/.startup-network.claim"
+PUBLISH_LOCK="$STATE/.startup-network.lock"
+
+# shellcheck source=bin/fm-timeout-lib.sh
+. "$SCRIPT_DIR/fm-timeout-lib.sh"
+# fm-wake-lib.sh owns both the portable lock helpers used below and the durable
+# wake queue this stage publishes into.
+# shellcheck source=bin/fm-wake-lib.sh
+. "$SCRIPT_DIR/fm-wake-lib.sh"
+
+usage() {
+  sed -n '2,/^set -u$/p' "$SCRIPT_DIR/fm-startup-network.sh" | sed 's/^# \{0,1\}//; $d'
+}
+
+status_get() {  # <key>
+  [ -f "$STATUS_FILE" ] || return 0
+  sed -n "s/^$1=//p" "$STATUS_FILE" 2>/dev/null | tail -1
+}
+
+write_atomic() {  # <dest>, content on stdin
+  local dest=$1 tmp
+  tmp=$(mktemp "$dest.XXXXXX" 2>/dev/null) || return 1
+  if cat > "$tmp" 2>/dev/null && mv -f "$tmp" "$dest" 2>/dev/null; then
+    return 0
+  fi
+  rm -f "$tmp" 2>/dev/null || true
+  return 1
+}
+
+now() { date +%s; }
+
+age_of() {  # <epoch> - seconds since, or empty when unreadable
+  local then=$1
+  case "$then" in ''|*[!0-9]*) return 0 ;; esac
+  printf '%s' "$(( $(now) - then ))"
+}
+
+stage_budget() {
+  local budget=${FM_STARTUP_NETWORK_TIMEOUT:-120}
+  case "$budget" in ''|*[!0-9]*|0) budget=120 ;; esac
+  printf '%s' "$budget"
+}
+
+# Is a `running` record a stage that is genuinely still in flight? Two
+# independent proofs are required, because either one alone can lie: a recorded
+# pid can be reused by an unrelated process, and a worker killed with its process
+# group (which is what a truncated digest does) leaves the record behind
+# untouched. A record that outlives the stage's own aggregate bound is therefore
+# treated as abandoned no matter what its pid says, which keeps "in progress"
+# from becoming a permanent state.
+worker_alive() {
+  local pid started age
+  pid=$(status_get pid)
+  case "$pid" in ''|*[!0-9]*) return 1 ;; esac
+  kill -0 "$pid" 2>/dev/null || return 1
+  started=$(status_get started)
+  age=$(age_of "$started")
+  case "$age" in ''|*[!0-9]*) return 0 ;; esac
+  [ "$age" -le "$(( $(stage_budget) + 30 ))" ]
+}
+
+# The exact phase names the digest and the report use, so "what has not been
+# confirmed yet" is always answerable from the status record alone.
+phase_label() {  # <phases>
+  case "$1" in
+    probe) printf 'GitHub authentication' ;;
+    probe,sweeps) printf 'GitHub authentication, dead-secondmate relaunch, secondmate convergence, pending handoff delivery, and project clone refresh with its drift reporting' ;;
+    *) printf 'the deferred network checks' ;;
+  esac
+}
+
+# --- start -------------------------------------------------------------------
+
+cmd_start() {  # <locked> <harvest-pid>
+  local locked=$1 harvest_pid=$2 lock_pid
+  mkdir -p "$STATE" 2>/dev/null || return 1
+  # Captured HERE, at the moment the caller still holds the lock, and carried to
+  # the worker: re-reading the lock later would only prove that SOME session
+  # holds it, which is exactly the case this guard exists to reject.
+  lock_pid=$(cat "$STATE/.lock" 2>/dev/null || true)
+
+  fm_lock_acquire_wait "$PUBLISH_LOCK"
+  printf '%s\n' "$harvest_pid" > "$CLAIM_FILE" 2>/dev/null || true
+  if [ "$(status_get state)" = running ] && worker_alive; then
+    # A worker from this or a previous session is still going. Starting a second
+    # one would run the same mutating sweeps concurrently, so leave it alone and
+    # let the harvest report its real state.
+    fm_lock_release "$PUBLISH_LOCK"
+    return 0
+  fi
+  fm_lock_release "$PUBLISH_LOCK"
+
+  # Detached three ways, each closing a different failure:
+  #   - stdio to /dev/null, because the digest's stdout is a pipe the harness
+  #     reads to EOF; a worker holding that pipe open would strand session
+  #     initialization behind the very work this stage exists to take off the
+  #     blocking path.
+  #   - nohup, so the worker outlives the shell that launched it.
+  #   - its OWN process group (monitor mode), because the caller runs inside the
+  #     digest's bounded child and that bound terminates its whole process group.
+  #     Sharing the group would kill the worker on a truncated startup and, worse,
+  #     orphan the bootstrap child it had already launched into a separate group -
+  #     leaving unbounded network work running with nothing left to bound it. Its
+  #     own group means a truncated digest leaves this stage running under its own
+  #     deadline, which is exactly the independence deferral is for.
+  local monitor_was_on=0
+  case $- in *m*) monitor_was_on=1 ;; esac
+  set -m 2>/dev/null || true
+  nohup "$SCRIPT_DIR/fm-startup-network.sh" run --locked "$locked" --lock-pid "$lock_pid" \
+    >/dev/null 2>&1 </dev/null &
+  [ "$monitor_was_on" -eq 1 ] || set +m 2>/dev/null || true
+  return 0
+}
+
+# --- run ---------------------------------------------------------------------
+
+# Re-verify mutation authority immediately before the mutating sweeps: "my
+# session held the lock a moment ago" is not enough for a worker that outlives
+# the command which launched it.
+#
+# The question is deliberately "does the lock still name the session that asked
+# for this work?", not "is that session still alive". The hazard being closed is
+# a SECOND session sweeping concurrently, and taking the lock is exactly what
+# rewrites this value - bin/fm-lock.sh overwrites a dead holder's pid with its
+# own. An unchanged value therefore proves no one else owns the sweeps, which is
+# the whole guarantee. Requiring liveness instead would refuse to finish work
+# nobody else has claimed, and the sweeps are idempotent, so finishing it is
+# strictly better than abandoning it. A missing, unreadable, or replaced lock all
+# fail closed to the read-only probe.
+lock_unchanged() {  # <expected-pid>
+  local expected=$1 current
+  case "$expected" in ''|*[!0-9]*) return 1 ;; esac
+  [ -f "$STATE/.lock" ] && [ ! -L "$STATE/.lock" ] || return 1
+  current=$(cat "$STATE/.lock" 2>/dev/null) || return 1
+  [ "$current" = "$expected" ]
+}
+
+publish() {  # <state> <phases> <locked> <started> <rc> <output-file>
+  local state=$1 phases=$2 locked=$3 started=$4 rc=$5 out=$6 claim_pid claimed=0
+  fm_lock_acquire_wait "$PUBLISH_LOCK"
+  write_atomic "$REPORT_FILE" < "$out" || true
+  write_atomic "$STATUS_FILE" <<EOF || true
+state=$state
+pid=$$
+started=$started
+finished=$(now)
+rc=$rc
+locked=$locked
+phases=$phases
+EOF
+  if [ -f "$CLAIM_FILE" ]; then
+    claim_pid=$(cat "$CLAIM_FILE" 2>/dev/null || true)
+    case "$claim_pid" in
+      ''|*[!0-9]*) ;;
+      *) kill -0 "$claim_pid" 2>/dev/null && claimed=1 ;;
+    esac
+    [ "$claimed" -eq 1 ] || rm -f "$CLAIM_FILE" 2>/dev/null || true
+  fi
+  fm_lock_release "$PUBLISH_LOCK"
+  # A live claim means a session start is still composing its digest and will
+  # print this itself; anything else means the result has to find its own way to
+  # the agent.
+  [ "$claimed" -eq 0 ] || return 0
+  fm_wake_append check startup-network \
+    "check: startup-network: deferred startup network checks finished ($state); read them with $FM_ROOT/bin/fm-startup-network.sh report" \
+    || true
+}
+
+cmd_run() {  # <locked> <lock-pid>
+  local locked=$1 lock_pid=$2 phases started budget out rc sweep_locked=0 downgraded=0
+  mkdir -p "$STATE" 2>/dev/null || return 1
+  started=$(now)
+  budget=$(stage_budget)
+  phases=probe
+  if [ "$locked" = 1 ]; then
+    # A hand-run `run` carries no launch-time pid, so there is nothing to
+    # compare against and it takes the lock as it stands: the operator invoking
+    # it from the lock-holding session is asserting that authority explicitly.
+    # A home with no lock at all still falls through to the read-only probe.
+    [ -n "$lock_pid" ] || lock_pid=$(cat "$STATE/.lock" 2>/dev/null || true)
+    if lock_unchanged "$lock_pid"; then
+      sweep_locked=1
+      phases=probe,sweeps
+    else
+      downgraded=1
+    fi
+  fi
+
+  fm_lock_acquire_wait "$PUBLISH_LOCK"
+  write_atomic "$STATUS_FILE" <<EOF || true
+state=running
+pid=$$
+started=$started
+locked=$sweep_locked
+phases=$phases
+EOF
+  fm_lock_release "$PUBLISH_LOCK"
+
+  out=$(mktemp "${TMPDIR:-/tmp}/fm-startup-network.XXXXXX" 2>/dev/null) || return 1
+  rc=0
+  if [ "$sweep_locked" -eq 1 ]; then
+    fm_run_timed "$budget" env FM_BOOTSTRAP_NETWORK=only \
+      "$SCRIPT_DIR/fm-bootstrap.sh" >"$out" 2>&1 || rc=$?
+  else
+    fm_run_timed "$budget" env FM_BOOTSTRAP_NETWORK=only FM_BOOTSTRAP_DETECT_ONLY=1 \
+      "$SCRIPT_DIR/fm-bootstrap.sh" >"$out" 2>&1 || rc=$?
+  fi
+
+  if [ "$downgraded" -eq 1 ]; then
+    printf 'NETWORK_CHECKS: the fleet lock was no longer held by the session that requested these, so dead-secondmate relaunch, secondmate convergence, pending handoff delivery, and project clone refresh were skipped; they belong to whichever session holds the lock now\n' >> "$out"
+  fi
+  case "$rc" in
+    0) publish 'done' "$phases" "$sweep_locked" "$started" "$rc" "$out" ;;
+    124)
+      printf 'NETWORK_CHECKS: hit the %ss bound before finishing, so %s may be incomplete; rerun %s/bin/fm-startup-network.sh run --locked %s\n' \
+        "$budget" "$(phase_label "$phases")" "$FM_ROOT" "$sweep_locked" >> "$out"
+      publish timeout "$phases" "$sweep_locked" "$started" "$rc" "$out"
+      ;;
+    *)
+      printf 'NETWORK_CHECKS: the deferred check worker exited %s, so %s may be incomplete; rerun %s/bin/fm-startup-network.sh run --locked %s\n' \
+        "$rc" "$(phase_label "$phases")" "$FM_ROOT" "$sweep_locked" >> "$out"
+      publish failed "$phases" "$sweep_locked" "$started" "$rc" "$out"
+      ;;
+  esac
+  rm -f "$out" 2>/dev/null || true
+  return 0
+}
+
+# --- harvest / report --------------------------------------------------------
+
+print_finished() {  # <state>
+  local state=$1 phases started finished took=unknown
+  phases=$(status_get phases)
+  started=$(status_get started)
+  finished=$(status_get finished)
+  case "$started$finished" in
+    ''|*[!0-9]*) ;;
+    *) took=$((finished - started)) ;;
+  esac
+  printf 'completed off the startup path in %ss: %s.\n' "$took" "$(phase_label "$phases")"
+  [ "$state" = 'done' ] || printf 'The stage itself did not finish cleanly (%s) - the NETWORK_CHECKS line below names what to rerun.\n' "$state"
+  if [ -s "$REPORT_FILE" ]; then
+    cat "$REPORT_FILE"
+    printf 'These ran AFTER the sections above were composed, so re-read any record a line here names.\n'
+  else
+    printf '(silent - no problems found)\n'
+  fi
+}
+
+print_pending() {
+  local phases started age
+  phases=$(status_get phases)
+  started=$(status_get started)
+  age=$(age_of "$started")
+  printf 'IN PROGRESS - the deferred network checks have not finished yet.\n'
+  printf 'NOT yet confirmed: %s.\n' "$(phase_label "$phases")"
+  [ -z "$age" ] || printf 'Started %ss ago, bounded at %ss.\n' "$age" "$(stage_budget)"
+  # shellcheck disable=SC2016  # The backticked wake name is literal digest text.
+  printf 'The result is durable in state/.startup-network.report and arrives as a `check: startup-network` wake.\n'
+  printf 'Read it now with %s/bin/fm-startup-network.sh report; until it lands, treat none of it as confirmed.\n' "$FM_ROOT"
+}
+
+print_state() {
+  case "$(status_get state)" in
+    done|timeout|failed) print_finished "$(status_get state)" ;;
+    running)
+      if worker_alive; then
+        print_pending
+      else
+        printf 'NETWORK_CHECKS: the deferred check worker stopped before publishing, so %s did not complete; rerun %s/bin/fm-startup-network.sh run --locked %s\n' \
+          "$(phase_label "$(status_get phases)")" "$FM_ROOT" "$(status_get locked)"
+      fi
+      ;;
+    *) printf 'not started - no deferred network checks have run for this home yet.\n' ;;
+  esac
+}
+
+cmd_harvest() {  # <pid>
+  local pid=$1 claim
+  fm_lock_acquire_wait "$PUBLISH_LOCK"
+  # Release this session's inline-print claim while holding the same lock the
+  # worker takes to publish, so exactly one path reports the result: either this
+  # harvest prints it, or the worker, finding no live claim, queues the wake.
+  # Another session's live claim is left alone; the worker reaps a dead one.
+  if [ -f "$CLAIM_FILE" ]; then
+    claim=$(cat "$CLAIM_FILE" 2>/dev/null || true)
+    if [ -z "$pid" ] || [ "$claim" = "$pid" ]; then
+      rm -f "$CLAIM_FILE" 2>/dev/null || true
+    fi
+  fi
+  print_state
+  fm_lock_release "$PUBLISH_LOCK"
+}
+
+cmd_wait() {  # <seconds>
+  local limit=$1 waited=0
+  case "$limit" in ''|*[!0-9]*) limit=120 ;; esac
+  while [ "$waited" -lt "$limit" ]; do
+    case "$(status_get state)" in
+      done|timeout|failed) return 0 ;;
+      running) worker_alive || return 1 ;;
+    esac
+    sleep 1
+    waited=$((waited + 1))
+  done
+  return 1
+}
+
+# --- entry -------------------------------------------------------------------
+
+LOCKED=0
+HARVEST_PID=
+LOCK_PID=
+MODE=${1:-}
+[ $# -eq 0 ] || shift
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --locked) LOCKED=${2:-0}; shift; [ $# -eq 0 ] || shift ;;
+    --harvest-pid|--pid) HARVEST_PID=${2:-}; shift; [ $# -eq 0 ] || shift ;;
+    --lock-pid) LOCK_PID=${2:-}; shift; [ $# -eq 0 ] || shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) break ;;
+  esac
+done
+case "$LOCKED" in 0|1) ;; *) LOCKED=0 ;; esac
+
+case "$MODE" in
+  start) cmd_start "$LOCKED" "${HARVEST_PID:-0}" ;;
+  run) cmd_run "$LOCKED" "$LOCK_PID" ;;
+  harvest) cmd_harvest "${HARVEST_PID:-}" ;;
+  report) print_state ;;
+  wait) cmd_wait "${1:-120}" ;;
+  -h|--help) usage ;;
+  *)
+    printf 'fm-startup-network: unknown mode: %s\n' "${MODE:-<none>}" >&2
+    printf 'usage: fm-startup-network.sh start|run|harvest|report|wait\n' >&2
+    exit 2
+    ;;
+esac
+exit 0

--- a/bin/fm-startup-network.sh
+++ b/bin/fm-startup-network.sh
@@ -29,22 +29,24 @@
 #     check is never silently pending.
 #   - Mutation authority is re-verified. The worker outlives the command that
 #     launched it, so before running any mutating sweep it re-checks that the
-#     session lock still names the exact holder it was launched under. A session
-#     that took the lock in the meantime has rewritten that value, so the orphan
-#     downgrades to the read-only probe and says so rather than sweeping
-#     underneath the new owner.
+#     session lock still names the exact holder it was launched under, then
+#     fm-bootstrap.sh repeats that check at every mutating sweep boundary. A
+#     session that took the lock in the meantime has rewritten that value, so
+#     the stale worker skips the remaining sweeps rather than running underneath
+#     the new owner.
 #
 # Usage: fm-startup-network.sh start --locked <0|1> --harvest-pid <pid>
 #          Launch the detached worker and return immediately. Single-flight: a
-#          worker already running for this home is left alone. --locked 1 asks
+#          worker already running for the same lock owner is left alone. A new
+#          owner gets a distinct generation. --locked 1 asks
 #          for the mutating sweeps as well as the read-only probe; --locked 0
 #          asks for the probe only. --harvest-pid names the session-start process
 #          that will try to print the result inline, so the worker can tell
 #          whether a wake is still needed.
-#        fm-startup-network.sh run --locked <0|1> [--lock-pid <pid>]
+#        fm-startup-network.sh run --locked <0|1>
 #          Run the checks in the foreground and publish the result. This is what
-#          `start` detaches, passing the lock pid it captured; run it directly to
-#          redo the stage by hand, where the current lock holder is the answer.
+#          `start` detaches with its private generation reservation; run it
+#          directly to redo the stage by hand from the lock-owning harness.
 #        fm-startup-network.sh harvest --pid <pid>
 #          Print the digest's NETWORK CHECKS section and release the inline-print
 #          claim. Called by bin/fm-session-start.sh, not by hand.
@@ -55,16 +57,18 @@
 #          operators and tests only; a session start never waits.
 #
 # STATE, all under this home's state/ and gitignored with it:
-#   .startup-network.status   key=value record - state, pid, started, finished,
-#                             rc, locked, phases. The single source of truth for
-#                             what ran and how it ended.
+#   .startup-network.status   key=value record - generation, lock_pid, state,
+#                             pid, started, finished, rc, locked, phases. The
+#                             single source of truth for what ran and how it
+#                             ended.
 #   .startup-network.report   the sweep output, byte for byte as
 #                             bin/fm-bootstrap.sh produced it, plus a
 #                             NETWORK_CHECKS: line whenever the stage itself
 #                             could not complete or had to downgrade.
-#   .startup-network.claim    the pid of a session start that intends to print
-#                             the result inline; its presence with a LIVE pid is
-#                             the only thing that suppresses the wake.
+#   .startup-network.claim    the generation and pid of a session start that
+#                             intends to print the result inline; a matching
+#                             generation with a LIVE pid is the only thing that
+#                             suppresses the wake.
 #   .startup-network.lock     serializes publish against harvest, so exactly one
 #                             of the two reports each result.
 #
@@ -90,6 +94,8 @@ PUBLISH_LOCK="$STATE/.startup-network.lock"
 # wake queue this stage publishes into.
 # shellcheck source=bin/fm-wake-lib.sh
 . "$SCRIPT_DIR/fm-wake-lib.sh"
+# shellcheck source=bin/fm-session-lock-lib.sh
+. "$SCRIPT_DIR/fm-session-lock-lib.sh"
 
 usage() {
   sed -n '2,/^set -u$/p' "$SCRIPT_DIR/fm-startup-network.sh" | sed 's/^# \{0,1\}//; $d'
@@ -155,23 +161,45 @@ phase_label() {  # <phases>
 # --- start -------------------------------------------------------------------
 
 cmd_start() {  # <locked> <harvest-pid>
-  local locked=$1 harvest_pid=$2 lock_pid
+  local locked=$1 harvest_pid=$2 lock_pid generation worker_pid phases started
   mkdir -p "$STATE" 2>/dev/null || return 1
   # Captured HERE, at the moment the caller still holds the lock, and carried to
   # the worker: re-reading the lock later would only prove that SOME session
   # holds it, which is exactly the case this guard exists to reject.
   lock_pid=$(cat "$STATE/.lock" 2>/dev/null || true)
+  if [ "$locked" = 1 ] && ! fm_session_lock_owned_by_self "$STATE"; then
+    return 1
+  fi
 
   fm_lock_acquire_wait "$PUBLISH_LOCK"
-  printf '%s\n' "$harvest_pid" > "$CLAIM_FILE" 2>/dev/null || true
-  if [ "$(status_get state)" = running ] && worker_alive; then
+  if [ "$(status_get state)" = running ] && worker_alive \
+    && { [ "$locked" != 1 ] || [ "$(status_get lock_pid)" = "$lock_pid" ]; }; then
     # A worker from this or a previous session is still going. Starting a second
     # one would run the same mutating sweeps concurrently, so leave it alone and
     # let the harvest report its real state.
+    generation=$(status_get generation)
+    printf '%s\t%s\n' "$generation" "$harvest_pid" > "$CLAIM_FILE" 2>/dev/null || true
     fm_lock_release "$PUBLISH_LOCK"
     return 0
   fi
-  fm_lock_release "$PUBLISH_LOCK"
+
+  generation="$(now).$$.$harvest_pid"
+  started=$(now)
+  phases=probe
+  [ "$locked" != 1 ] || phases=probe,sweeps
+  if ! write_atomic "$STATUS_FILE" <<EOF
+state=running
+pid=0
+started=$started
+locked=$locked
+phases=$phases
+generation=$generation
+lock_pid=$lock_pid
+EOF
+  then
+    fm_lock_release "$PUBLISH_LOCK"
+    return 1
+  fi
 
   # Detached three ways, each closing a different failure:
   #   - stdio to /dev/null, because the digest's stdout is a pipe the harness
@@ -190,7 +218,26 @@ cmd_start() {  # <locked> <harvest-pid>
   case $- in *m*) monitor_was_on=1 ;; esac
   set -m 2>/dev/null || true
   nohup "$SCRIPT_DIR/fm-startup-network.sh" run --locked "$locked" --lock-pid "$lock_pid" \
+    --generation "$generation" \
     >/dev/null 2>&1 </dev/null &
+  worker_pid=$!
+  if ! write_atomic "$STATUS_FILE" <<EOF
+state=running
+pid=$worker_pid
+started=$started
+locked=$locked
+phases=$phases
+generation=$generation
+lock_pid=$lock_pid
+EOF
+  then
+    kill "$worker_pid" 2>/dev/null || true
+    fm_lock_release "$PUBLISH_LOCK"
+    [ "$monitor_was_on" -eq 1 ] || set +m 2>/dev/null || true
+    return 1
+  fi
+  printf '%s\t%s\n' "$generation" "$harvest_pid" > "$CLAIM_FILE" 2>/dev/null || true
+  fm_lock_release "$PUBLISH_LOCK"
   [ "$monitor_was_on" -eq 1 ] || set +m 2>/dev/null || true
   return 0
 }
@@ -218,9 +265,13 @@ lock_unchanged() {  # <expected-pid>
   [ "$current" = "$expected" ]
 }
 
-publish() {  # <state> <phases> <locked> <started> <rc> <output-file>
-  local state=$1 phases=$2 locked=$3 started=$4 rc=$5 out=$6 claim_pid claimed=0
+publish() {  # <generation> <state> <phases> <locked> <started> <rc> <output-file>
+  local generation=$1 state=$2 phases=$3 locked=$4 started=$5 rc=$6 out=$7 claim_record claim_generation claim_pid claimed=0
   fm_lock_acquire_wait "$PUBLISH_LOCK"
+  if [ "$(status_get generation)" != "$generation" ]; then
+    fm_lock_release "$PUBLISH_LOCK"
+    return 0
+  fi
   write_atomic "$REPORT_FILE" < "$out" || true
   write_atomic "$STATUS_FILE" <<EOF || true
 state=$state
@@ -230,9 +281,15 @@ finished=$(now)
 rc=$rc
 locked=$locked
 phases=$phases
+generation=$generation
+lock_pid=$(status_get lock_pid)
 EOF
   if [ -f "$CLAIM_FILE" ]; then
-    claim_pid=$(cat "$CLAIM_FILE" 2>/dev/null || true)
+    claim_record=$(cat "$CLAIM_FILE" 2>/dev/null || true)
+    IFS=$'\t' read -r claim_generation claim_pid <<EOF
+$claim_record
+EOF
+    [ "$claim_generation" = "$generation" ] || claim_pid=
     case "$claim_pid" in
       ''|*[!0-9]*) ;;
       *) kill -0 "$claim_pid" 2>/dev/null && claimed=1 ;;
@@ -249,18 +306,26 @@ EOF
     || true
 }
 
-cmd_run() {  # <locked> <lock-pid>
-  local locked=$1 lock_pid=$2 phases started budget out rc sweep_locked=0 downgraded=0
+cmd_run() {  # <locked> <lock-pid> <generation>
+  local locked=$1 lock_pid=$2 generation=$3 phases started budget out rc sweep_locked=0 downgraded=0 internal=0
   mkdir -p "$STATE" 2>/dev/null || return 1
   started=$(now)
   budget=$(stage_budget)
   phases=probe
+  if [ -n "$generation" ]; then
+    fm_lock_acquire_wait "$PUBLISH_LOCK"
+    if [ "$(status_get generation)" = "$generation" ] && [ "$(status_get pid)" = "$$" ]; then
+      internal=1
+      started=$(status_get started)
+    fi
+    fm_lock_release "$PUBLISH_LOCK"
+    [ "$internal" -eq 1 ] || return 1
+  elif [ "$locked" = 1 ] && ! fm_session_lock_owned_by_self "$STATE"; then
+    downgraded=1
+    locked=0
+  fi
   if [ "$locked" = 1 ]; then
-    # A hand-run `run` carries no launch-time pid, so there is nothing to
-    # compare against and it takes the lock as it stands: the operator invoking
-    # it from the lock-holding session is asserting that authority explicitly.
-    # A home with no lock at all still falls through to the read-only probe.
-    [ -n "$lock_pid" ] || lock_pid=$(cat "$STATE/.lock" 2>/dev/null || true)
+    [ "$internal" -eq 1 ] || lock_pid=$(cat "$STATE/.lock" 2>/dev/null || true)
     if lock_unchanged "$lock_pid"; then
       sweep_locked=1
       phases=probe,sweeps
@@ -269,20 +334,30 @@ cmd_run() {  # <locked> <lock-pid>
     fi
   fi
 
-  fm_lock_acquire_wait "$PUBLISH_LOCK"
-  write_atomic "$STATUS_FILE" <<EOF || true
+  if [ "$internal" -eq 0 ]; then
+    generation="$(now).$$.manual"
+    fm_lock_acquire_wait "$PUBLISH_LOCK"
+    if [ "$(status_get state)" = running ] && worker_alive; then
+      fm_lock_release "$PUBLISH_LOCK"
+      return 1
+    fi
+    write_atomic "$STATUS_FILE" <<EOF || true
 state=running
 pid=$$
 started=$started
 locked=$sweep_locked
 phases=$phases
+generation=$generation
+lock_pid=$lock_pid
 EOF
-  fm_lock_release "$PUBLISH_LOCK"
+    fm_lock_release "$PUBLISH_LOCK"
+  fi
 
   out=$(mktemp "${TMPDIR:-/tmp}/fm-startup-network.XXXXXX" 2>/dev/null) || return 1
   rc=0
   if [ "$sweep_locked" -eq 1 ]; then
     fm_run_timed "$budget" env FM_BOOTSTRAP_NETWORK=only \
+      FM_BOOTSTRAP_NETWORK_LOCK_PID="$lock_pid" \
       "$SCRIPT_DIR/fm-bootstrap.sh" >"$out" 2>&1 || rc=$?
   else
     fm_run_timed "$budget" env FM_BOOTSTRAP_NETWORK=only FM_BOOTSTRAP_DETECT_ONLY=1 \
@@ -293,16 +368,16 @@ EOF
     printf 'NETWORK_CHECKS: the fleet lock was no longer held by the session that requested these, so dead-secondmate relaunch, secondmate convergence, pending handoff delivery, and project clone refresh were skipped; they belong to whichever session holds the lock now\n' >> "$out"
   fi
   case "$rc" in
-    0) publish 'done' "$phases" "$sweep_locked" "$started" "$rc" "$out" ;;
+    0) publish "$generation" 'done' "$phases" "$sweep_locked" "$started" "$rc" "$out" ;;
     124)
       printf 'NETWORK_CHECKS: hit the %ss bound before finishing, so %s may be incomplete; rerun %s/bin/fm-startup-network.sh run --locked %s\n' \
         "$budget" "$(phase_label "$phases")" "$FM_ROOT" "$sweep_locked" >> "$out"
-      publish timeout "$phases" "$sweep_locked" "$started" "$rc" "$out"
+      publish "$generation" timeout "$phases" "$sweep_locked" "$started" "$rc" "$out"
       ;;
     *)
       printf 'NETWORK_CHECKS: the deferred check worker exited %s, so %s may be incomplete; rerun %s/bin/fm-startup-network.sh run --locked %s\n' \
         "$rc" "$(phase_label "$phases")" "$FM_ROOT" "$sweep_locked" >> "$out"
-      publish failed "$phases" "$sweep_locked" "$started" "$rc" "$out"
+      publish "$generation" failed "$phases" "$sweep_locked" "$started" "$rc" "$out"
       ;;
   esac
   rm -f "$out" 2>/dev/null || true
@@ -359,15 +434,20 @@ print_state() {
 }
 
 cmd_harvest() {  # <pid>
-  local pid=$1 claim
+  local pid=$1 generation claim_record claim_generation claim_pid
   fm_lock_acquire_wait "$PUBLISH_LOCK"
+  generation=$(status_get generation)
   # Release this session's inline-print claim while holding the same lock the
   # worker takes to publish, so exactly one path reports the result: either this
   # harvest prints it, or the worker, finding no live claim, queues the wake.
   # Another session's live claim is left alone; the worker reaps a dead one.
   if [ -f "$CLAIM_FILE" ]; then
-    claim=$(cat "$CLAIM_FILE" 2>/dev/null || true)
-    if [ -z "$pid" ] || [ "$claim" = "$pid" ]; then
+    claim_record=$(cat "$CLAIM_FILE" 2>/dev/null || true)
+    IFS=$'\t' read -r claim_generation claim_pid <<EOF
+$claim_record
+EOF
+    if [ "$claim_generation" = "$generation" ] \
+      && { [ -z "$pid" ] || [ "$claim_pid" = "$pid" ]; }; then
       rm -f "$CLAIM_FILE" 2>/dev/null || true
     fi
   fi
@@ -394,6 +474,7 @@ cmd_wait() {  # <seconds>
 LOCKED=0
 HARVEST_PID=
 LOCK_PID=
+GENERATION=
 MODE=${1:-}
 [ $# -eq 0 ] || shift
 while [ $# -gt 0 ]; do
@@ -401,6 +482,7 @@ while [ $# -gt 0 ]; do
     --locked) LOCKED=${2:-0}; shift; [ $# -eq 0 ] || shift ;;
     --harvest-pid|--pid) HARVEST_PID=${2:-}; shift; [ $# -eq 0 ] || shift ;;
     --lock-pid) LOCK_PID=${2:-}; shift; [ $# -eq 0 ] || shift ;;
+    --generation) GENERATION=${2:-}; shift; [ $# -eq 0 ] || shift ;;
     -h|--help) usage; exit 0 ;;
     *) break ;;
   esac
@@ -409,7 +491,7 @@ case "$LOCKED" in 0|1) ;; *) LOCKED=0 ;; esac
 
 case "$MODE" in
   start) cmd_start "$LOCKED" "${HARVEST_PID:-0}" ;;
-  run) cmd_run "$LOCKED" "$LOCK_PID" ;;
+  run) cmd_run "$LOCKED" "$LOCK_PID" "$GENERATION" ;;
   harvest) cmd_harvest "${HARVEST_PID:-}" ;;
   report) print_state ;;
   wait) cmd_wait "${1:-120}" ;;

--- a/bin/fm-startup-network.sh
+++ b/bin/fm-startup-network.sh
@@ -24,9 +24,10 @@
 #     undelivered handoff. There is no once-only signal to miss.
 #   - The result is durable and always surfaces. It lands in
 #     state/.startup-network.report and reaches the agent either inline in the
-#     digest or as a `check: startup-network` wake, and while the worker is still
-#     running the digest states by name what is not yet confirmed. A deferred
-#     check is never silently pending.
+#     digest or as a `check: startup-network` wake. Only a durable acknowledgement
+#     written after harvest prints the finished result suppresses that wake, so a
+#     claimant that exits first cannot lose the result. While the worker is still
+#     running the digest states by name what is not yet confirmed.
 #   - Mutation authority is leased. The worker outlives the command that launched
 #     it, so it takes the same acquisition lease a new session must hold before
 #     replacing a dead owner, re-checks the captured owner under that lease, and
@@ -51,8 +52,8 @@
 #        fm-startup-network.sh report
 #          Print the current state and report without changing anything.
 #        fm-startup-network.sh wait [<seconds>]
-#          Block until the worker settles, up to <seconds> (default 120). For
-#          operators and tests only; a session start never waits.
+#          Block until the report is published, up to <seconds> (default 120).
+#          For operators and tests only; a session start never waits.
 #
 # STATE, all under this home's state/ and gitignored with it:
 #   .startup-network.status   key=value record - generation, lock_pid, state,
@@ -64,11 +65,14 @@
 #                             NETWORK_CHECKS: line whenever the stage itself
 #                             could not complete or had to downgrade.
 #   .startup-network.claim    the generation and pid of a session start that
-#                             intends to print the result inline; a matching
-#                             generation with a LIVE pid is the only thing that
-#                             suppresses the wake.
-#   .startup-network.lock     serializes publish against harvest, so exactly one
-#                             of the two reports each result.
+#                             intends to print the result inline; a matching live
+#                             claimant gives harvest a bounded chance to finish.
+#   .startup-network.delivered
+#                             a durable acknowledgement that harvest printed the
+#                             current finished result; only this suppresses its
+#                             wake.
+#   .startup-network.lock     serializes publication, harvest acknowledgement,
+#                             and the wake decision.
 #
 # The whole stage is bounded by FM_STARTUP_NETWORK_TIMEOUT (default 120s), one
 # aggregate deadline replacing the per-call unboundedness that used to be able to
@@ -84,6 +88,7 @@ STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
 STATUS_FILE="$STATE/.startup-network.status"
 REPORT_FILE="$STATE/.startup-network.report"
 CLAIM_FILE="$STATE/.startup-network.claim"
+DELIVERED_FILE="$STATE/.startup-network.delivered"
 PUBLISH_LOCK="$STATE/.startup-network.lock"
 
 # shellcheck source=bin/fm-timeout-lib.sh
@@ -124,6 +129,12 @@ age_of() {  # <epoch> - seconds since, or empty when unreadable
 
 stage_budget() {
   local budget=${FM_STARTUP_NETWORK_TIMEOUT:-120}
+  case "$budget" in ''|*[!0-9]*|0) budget=120 ;; esac
+  printf '%s' "$budget"
+}
+
+delivery_budget() {
+  local budget=${FM_SESSION_START_TIMEOUT:-120}
   case "$budget" in ''|*[!0-9]*|0) budget=120 ;; esac
   printf '%s' "$budget"
 }
@@ -263,14 +274,64 @@ lock_unchanged() {  # <expected-pid>
   [ "$current" = "$expected" ]
 }
 
+await_delivery() {  # <generation> <state>
+  local generation=$1 state=$2 limit waited=0 claim_record claim_generation claim_pid claim_live
+  limit=$(( $(delivery_budget) * 10 ))
+  while [ "$waited" -lt "$limit" ]; do
+    claim_live=0
+    fm_lock_acquire_wait "$PUBLISH_LOCK"
+    if [ "$(status_get generation)" != "$generation" ]; then
+      fm_lock_release "$PUBLISH_LOCK"
+      return 0
+    fi
+    if [ -f "$DELIVERED_FILE" ]; then
+      fm_lock_release "$PUBLISH_LOCK"
+      return 0
+    fi
+    if [ -f "$CLAIM_FILE" ]; then
+      claim_record=$(cat "$CLAIM_FILE" 2>/dev/null || true)
+      IFS=$'\t' read -r claim_generation claim_pid <<EOF
+$claim_record
+EOF
+      if [ "$claim_generation" = "$generation" ]; then
+        case "$claim_pid" in
+          ''|*[!0-9]*) ;;
+          *) kill -0 "$claim_pid" 2>/dev/null && claim_live=1 ;;
+        esac
+      fi
+      [ "$claim_live" -eq 1 ] || rm -f "$CLAIM_FILE" 2>/dev/null || true
+    fi
+    if [ "$claim_live" -eq 0 ]; then
+      fm_wake_append check startup-network \
+        "check: startup-network: deferred startup network checks finished ($state); read them with $FM_ROOT/bin/fm-startup-network.sh report" \
+        || true
+      fm_lock_release "$PUBLISH_LOCK"
+      return 0
+    fi
+    fm_lock_release "$PUBLISH_LOCK"
+    sleep 0.1
+    waited=$((waited + 1))
+  done
+  fm_lock_acquire_wait "$PUBLISH_LOCK"
+  if [ "$(status_get generation)" != "$generation" ] || [ -f "$DELIVERED_FILE" ]; then
+    fm_lock_release "$PUBLISH_LOCK"
+    return 0
+  fi
+  fm_wake_append check startup-network \
+    "check: startup-network: deferred startup network checks finished ($state); read them with $FM_ROOT/bin/fm-startup-network.sh report" \
+    || true
+  fm_lock_release "$PUBLISH_LOCK"
+}
+
 publish() {  # <generation> <state> <phases> <locked> <started> <rc> <output-file>
-  local generation=$1 state=$2 phases=$3 locked=$4 started=$5 rc=$6 out=$7 claim_record claim_generation claim_pid claimed=0
+  local generation=$1 state=$2 phases=$3 locked=$4 started=$5 rc=$6 out=$7
   fm_lock_acquire_wait "$PUBLISH_LOCK"
   if [ "$(status_get generation)" != "$generation" ]; then
     fm_lock_release "$PUBLISH_LOCK"
     return 0
   fi
   write_atomic "$REPORT_FILE" < "$out" || true
+  rm -f "$DELIVERED_FILE" 2>/dev/null || true
   write_atomic "$STATUS_FILE" <<EOF || true
 state=$state
 pid=$$
@@ -282,26 +343,8 @@ phases=$phases
 generation=$generation
 lock_pid=$(status_get lock_pid)
 EOF
-  if [ -f "$CLAIM_FILE" ]; then
-    claim_record=$(cat "$CLAIM_FILE" 2>/dev/null || true)
-    IFS=$'\t' read -r claim_generation claim_pid <<EOF
-$claim_record
-EOF
-    [ "$claim_generation" = "$generation" ] || claim_pid=
-    case "$claim_pid" in
-      ''|*[!0-9]*) ;;
-      *) kill -0 "$claim_pid" 2>/dev/null && claimed=1 ;;
-    esac
-    [ "$claimed" -eq 1 ] || rm -f "$CLAIM_FILE" 2>/dev/null || true
-  fi
   fm_lock_release "$PUBLISH_LOCK"
-  # A live claim means a session start is still composing its digest and will
-  # print this itself; anything else means the result has to find its own way to
-  # the agent.
-  [ "$claimed" -eq 0 ] || return 0
-  fm_wake_append check startup-network \
-    "check: startup-network: deferred startup network checks finished ($state); read them with $FM_ROOT/bin/fm-startup-network.sh report" \
-    || true
+  await_delivery "$generation" "$state"
 }
 
 cmd_run() {  # <locked> <lock-pid> <generation>
@@ -442,12 +485,9 @@ print_state() {
 }
 
 cmd_harvest() {  # <pid>
-  local pid=$1 generation claim_record claim_generation claim_pid
+  local pid=$1 generation state claim_record claim_generation claim_pid
   fm_lock_acquire_wait "$PUBLISH_LOCK"
   generation=$(status_get generation)
-  # Release this session's inline-print claim while holding the same lock the
-  # worker takes to publish, so exactly one path reports the result: either this
-  # harvest prints it, or the worker, finding no live claim, queues the wake.
   # Another session's live claim is left alone; the worker reaps a dead one.
   if [ -f "$CLAIM_FILE" ]; then
     claim_record=$(cat "$CLAIM_FILE" 2>/dev/null || true)
@@ -459,7 +499,14 @@ EOF
       rm -f "$CLAIM_FILE" 2>/dev/null || true
     fi
   fi
+  state=$(status_get state)
   print_state
+  case "$state" in
+    done|timeout|failed) write_atomic "$DELIVERED_FILE" <<EOF || true
+delivered
+EOF
+      ;;
+  esac
   fm_lock_release "$PUBLISH_LOCK"
 }
 

--- a/bin/fm-tasks-axi-lib.sh
+++ b/bin/fm-tasks-axi-lib.sh
@@ -18,8 +18,30 @@
 #
 # This file is the single owner of FM_TASKS_AXI_MIN. bin/fm-bootstrap.sh turns a
 # failing check into the operator-facing MISSING diagnostic.
+#
+# COMPATIBILITY VERDICT REUSE. fm_tasks_axi_compatible costs three tasks-axi
+# subprocesses, and one session start needs the same verdict twice: once in
+# bin/fm-session-start.sh's backlog listing and once in the bin/fm-bootstrap.sh
+# child it runs. Two reuse layers collapse that to a single probe:
+#   - Within a process the first probe's answer is memoised.
+#   - Across ONE process hop, a parent that already holds the verdict passes it
+#     in FM_TASKS_AXI_COMPATIBLE=0|1. Sourcing this file CONSUMES that variable
+#     (it is unset from the environment and kept only as a private shell
+#     variable), so the verdict reaches the child that needs it and never leaks
+#     onward into a spawned agent's environment, where it could outlive a
+#     tasks-axi upgrade. Any value other than exactly 0 or 1 is ignored and the
+#     probe runs normally.
+# Both layers are bounded by process lifetime, so a tasks-axi install or upgrade
+# is picked up by the next process rather than being cached to disk.
 
 FM_TASKS_AXI_MIN=0.2.4
+
+FM_TASKS_AXI_COMPATIBLE_MEMO=${FM_TASKS_AXI_COMPATIBLE:-}
+unset FM_TASKS_AXI_COMPATIBLE
+case "$FM_TASKS_AXI_COMPATIBLE_MEMO" in
+  0|1) ;;
+  *) FM_TASKS_AXI_COMPATIBLE_MEMO= ;;
+esac
 
 fm_tasks_axi_version_parts() {
   local output
@@ -31,6 +53,19 @@ fm_tasks_axi_version_parts() {
 }
 
 fm_tasks_axi_compatible() {
+  case "$FM_TASKS_AXI_COMPATIBLE_MEMO" in
+    1) return 0 ;;
+    0) return 1 ;;
+  esac
+  if fm_tasks_axi_compatible_probe; then
+    FM_TASKS_AXI_COMPATIBLE_MEMO=1
+    return 0
+  fi
+  FM_TASKS_AXI_COMPATIBLE_MEMO=0
+  return 1
+}
+
+fm_tasks_axi_compatible_probe() {
   local parts major minor patch extra
   local min_major min_minor min_patch min_extra
   parts=$(fm_tasks_axi_version_parts) || return 1

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -174,8 +174,8 @@ family_for_basename() {
       printf '%s\n' secondmate
       ;;
     fm-bootstrap.test.sh|fm-fleet-sync.test.sh|fm-gate-refuse.test.sh|fm-gotmp.test.sh|\
-    fm-session-start.test.sh|fm-sessionstart-nudge.test.sh|fm-tangle-guard.test.sh|\
-    fm-update.test.sh)
+    fm-session-start.test.sh|fm-sessionstart-nudge.test.sh|fm-startup-network.test.sh|\
+    fm-tangle-guard.test.sh|fm-update.test.sh)
       printf '%s\n' session-bootstrap
       ;;
     fm-afk-pi-herdr-return-e2e.test.sh|\
@@ -897,7 +897,7 @@ families_for_changed_path() {
       printf '%s\n' secondmate
       ;;
     bin/fm-session-start.sh|bin/fm-bootstrap.sh|bin/fm-fleet-sync.sh|\
-    bin/fm-sessionstart-nudge.sh|bin/fm-tangle*|bin/fm-update.sh|\
+    bin/fm-sessionstart-nudge.sh|bin/fm-startup-network.sh|bin/fm-tangle*|bin/fm-update.sh|\
     bin/fm-gate-refuse*|bin/fm-lock*|bin/fm-quota-axi-lib.sh)
       printf '%s\n' session-bootstrap
       ;;

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -19,6 +19,7 @@ The producing PR and Relay helpers own the fields they append, `bin/fm-classify-
 Wake, watcher, away-mode, and Relay-specific state mechanics remain with their named scripts and reference sections rather than being duplicated into one exhaustive state tree here.
 
 `bin/fm-session-start.sh`'s header is the single owner of session-start ordering, composed commands, digest contents, and the digest's startup mechanism.
+`bin/fm-startup-network.sh`'s header owns the deferred network stage that keeps every external-network call off that digest's blocking path, including its state files and the safety argument for running them later.
 `docs/sessionstart-nudge.md` owns the native session-open adapter tiers that run or nudge the digest command, and the source routing between them.
 `AGENTS.md` retains the run-once and read-once operator rules, lock-refusal safety, installation consent, and direct-report recovery boundaries because those facts apply at every session start.
 Ordinary dead-direct-report recovery is owned by `stuck-crewmate-recovery`, while persistent-secondmate recovery is owned by `secondmate-provisioning`.
@@ -512,6 +513,9 @@ CMUX_SOCKET_PASSWORD=   # cmux-only: socket password fallback when config/cmux-s
 FM_SESSION_START_STATUS_TAIL=5   # state/*.status lines printed per task in the session-start digest; each line is capped by bin/fm-line-cap-lib.sh
 FM_SESSION_START_QUEUED_LIMIT=20   # plain queued backlog rows in the session-start digest; in-flight, held, and blocked rows are never bounded and done rows are never listed
 FM_BOOTSTRAP_DETECT_ONLY=0   # internal/read-only session-start mode: skip bootstrap's mutating sweeps and print advisory TANGLE wording
+FM_BOOTSTRAP_NETWORK=all   # internal session-start phase split: all, skip (local steps only), or only (network steps only); see bin/fm-bootstrap.sh
+FM_STARTUP_NETWORK_TIMEOUT=120   # seconds bounding the whole deferred network stage; hitting it prints an actionable NETWORK_CHECKS line
+FM_TASKS_AXI_COMPATIBLE=   # internal one-hop handoff of an already-computed tasks-axi compatibility verdict (0 or 1); consumed when bin/fm-tasks-axi-lib.sh is sourced
 FM_GUARD_READ_ONLY=0    # internal/read-only guard mode: keep alarms but suppress drain, supervision repair, and checkout repair commands
 FM_GUARD_CONTINUE_LINE='This is a supervision warning only; the guarded operation WILL still run.'   # banner continuation line; fm-send.sh overrides it to name the requested message specifically
 FM_POLL=15              # seconds between watcher poll cycles

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -12,6 +12,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-sessionstart-run.sh` | Route a native session-open hook to the full digest, a context re-emit, or the nudge |
 | `fm-operational-input.sh` | Construct and parse the canonical cross-language operational-input protocol |
 | `fm-bootstrap.sh`        | Detect toolchain and fleet problems, run the locked session-start sweeps, and install approved tools |
+| `fm-startup-network.sh`  | Run session start's network checks off its blocking path in a bounded detached worker, and publish the result inline or as a wake |
 | `fm-fleet-sync.sh`       | Refresh project clones with safe fast-forwards, self-heals, `STUCK:` reports, branch pruning, and bounded recovery from an orphaned `.git/packed-refs.lock` |
 | `fm-fleet-snapshot.sh`   | Print the read-only structured fleet snapshot JSON (schema `fm-fleet-snapshot.v1`)   |
 | `fm-fleet-view.sh`       | Render the fleet snapshot as a human Markdown view                                   |

--- a/docs/sessionstart-nudge.md
+++ b/docs/sessionstart-nudge.md
@@ -60,7 +60,7 @@ The Ahoy skill owns the rule that this marked operational input is never a capta
 Before printing, the nudge wrapper reads `state/.lock` and walks at most eight parents from its own pid in its own separate, hard-coded loop, independent of `bin/fm-lock.sh`'s ancestry walk (`fm_harness_ancestry_pid()` in `bin/fm-session-lock-lib.sh`, which now walks up to sixteen parents and can extend past a claude-named match to a still-more-ancestral one) and of Pi's `lockOwnership()`.
 If the lock names a live pid in that ancestry, session start already ran in this harness session and the wrapper stays silent.
 Every path in both wrappers exits 0, including malformed state and adapter errors, because a Claude SessionStart exit 2 blocks session initialization.
-A lock another session holds, broken GitHub auth, and a truncated digest therefore all surface as digest text the agent reads and acts on, never as a refusal to open the session.
+A lock another session holds and a truncated digest therefore surface as digest text, while broken GitHub auth surfaces through the deferred network result inline or as a wake; none becomes a refusal to open the session.
 
 ## Harness transports
 

--- a/docs/sessionstart-nudge.md
+++ b/docs/sessionstart-nudge.md
@@ -40,10 +40,12 @@ On a run-tier harness the nudge cannot also fire: `resume`, `reload`, and `fork`
 ## Runtime bound
 
 The run tier blocks session initialization while the digest runs, so `bin/fm-session-start.sh` bounds itself rather than betting on each harness's own hook timeout.
-Individual steps are not all bounded - bootstrap's fleet sync is, but its `gh auth status` probe, its tool version probes, the backlog listing, and the per-task endpoint reads are not - so the whole digest runs as one bounded child, default 120s via `FM_SESSION_START_TIMEOUT`.
+The digest makes no external-network call at all: every one it owes runs concurrently in the separately bounded deferred stage owned by `bin/fm-startup-network.sh`, so an unreachable host can no longer consume this budget.
+What remains is still not individually bounded - tool version probes, the backlog listing, and the per-task endpoint reads are all local but unbounded subprocesses - so the whole digest runs as one bounded child, default 120s via `FM_SESSION_START_TIMEOUT`.
 The shared timeout owner falls back to a pure-Bash process-group watchdog when timeout, gtimeout, and perl are unavailable, so no supported host runs the digest unbounded.
 Because the child writes straight to the hook's stdout, everything emitted before the bound was hit is already delivered; the parent then prints a `STARTUP TRUNCATED` banner naming the stage that did not finish and the stages that were therefore never emitted, and still exits 0.
 The registered hook timeouts sit above that budget so the harness never preempts the banner.
+The deferred network stage deliberately runs in its own process group under its own deadline, so a truncated digest neither kills work it was not waiting for nor orphans unbounded network work.
 
 ## Shared wrapper and safety
 

--- a/docs/verification/supervision.md
+++ b/docs/verification/supervision.md
@@ -50,9 +50,10 @@ The installed pi-signed 0.82.0 wrapper repeated the Pi primary extension and ses
 
 ### Run-tier source vocabulary and context-reset injection
 
-The run tier depends on two facts only the vendor can supply: the session-open source it reports, and whether hook stdout reaches model context on a context-RESET open rather than only a cold one.
-Both were measured on 2026-08-05 against a throwaway Firstmate-shaped lab carrying each harness's own tracked registration with a recorder standing in for `bin/fm-sessionstart-run.sh`.
+The run tier depends on three facts only the vendor can supply: the session-open source it reports, whether hook stdout reaches model context on a context-RESET open rather than only a cold one, and whether a worker the hook detaches survives the hook returning.
+The first two were measured on 2026-08-05 against a throwaway Firstmate-shaped lab carrying each harness's own tracked registration with a recorder standing in for `bin/fm-sessionstart-run.sh`.
 Each open printed a source-stamped token, and the model was asked to quote that token back, so producing hook stdout could never be mistaken for delivering it.
+The third is recorded below.
 
 | Harness | Version verified | Cold open | Context reset | Context-preserving reopen |
 | --- | --- | --- | --- | --- |
@@ -81,11 +82,42 @@ compact
 Pi disagrees with Claude and Codex on `resume`: a NEW Pi process continuing a session reports `startup`, and Pi's `resume` reason is reserved for an in-process session switch.
 That is correct for the run tier rather than a problem, because a new process holds no lock and must take the helm; the routing table in [`../sessionstart-nudge.md`](../sessionstart-nudge.md#source-routing) is written to whichever source each harness actually reports.
 
+### Detached session-open workers survive the hook
+
+Session start composes its digest from local reads and runs every external-network call in a worker detached by the hook (`bin/fm-startup-network.sh`), so a harness that reaped the hook's process tree would silently stop running the sweeps rather than merely delaying them.
+Verified on 2026-08-06 with Claude Code 2.1.222 in a throwaway lab whose `bin/fm-bootstrap.sh` sleeps 6s before writing a marker, so the marker can exist only if the worker outlived the hook and the whole `claude -p` process.
+
+```text
+$ claude -p --permission-mode bypassPermissions '<quote the session-start token>'
+FMHOOKTOKEN-startup-1-abc123
+--- claude exited at 13:38:40; polling for the detached worker's marker ---
+MARKER at +4s: detached worker survived the hook
+state=done
+started=1786048716
+finished=1786048723
+```
+
+The worker started before the harness exited and published 6s after it was gone.
+
+The latency this buys was measured on 2026-08-06 in a throwaway home holding one remote secondmate whose host hangs 25s per SSH connection (an `FM_SSH_BIN`-shaped stub; no real host was contacted), against the same fixture on `345de4e` and on the deferred stage:
+
+```text
+before (345de4e)   real 1m18.184s   3 blocking SSH attempts inside the digest
+after              real 0m0.843s    digest prints IN PROGRESS; the same SSH attempts
+                                    continue at +0s and +25s, after it finished
+```
+
+The remaining 0.8s is entirely local subprocess work; the `NETWORK CHECKS` section named GitHub authentication, dead-secondmate relaunch, secondmate convergence, pending handoff delivery, and project clone refresh as not yet confirmed.
+
+Codex and Pi were not installed as run-tier labs in this measurement, so their evidence for this fact is NOT refreshed; `tests/fm-sessionstart-hook-live-e2e.test.sh` asserts it for every installed run-tier harness and is the command that refreshes this record.
+A harness that did reap the worker degrades loudly rather than silently: the leftover record reads as an abandoned run needing a rerun, and the next session start re-derives every finding, because these sweeps are idempotent detectors.
+
 Current deterministic and live entry points:
 
 ```sh
 tests/fm-sessionstart-nudge.test.sh
 tests/fm-session-start.test.sh
+tests/fm-startup-network.test.sh
 FM_SESSIONSTART_HOOK_LIVE_E2E=1 tests/fm-sessionstart-hook-live-e2e.test.sh
 FM_PI_LIVE_E2E=1 tests/fm-pi-primary-live-e2e.test.sh
 FM_OPENCODE_LIVE_E2E=1 tests/fm-opencode-primary-live-e2e.test.sh

--- a/tests/fm-bootstrap.test.sh
+++ b/tests/fm-bootstrap.test.sh
@@ -17,6 +17,10 @@
 # Dedicated fleet-sync cases pin the computed bootstrap timeout, explicit
 # override, blank-env defaulting, partial-output relay, and pre-launch timeout
 # scan.
+# Dedicated network-phase cases pin FM_BOOTSTRAP_NETWORK as a true partition of
+# one run into its local and network halves, and the one-hop tasks-axi
+# compatibility handoff that keeps a session start from paying for that verdict
+# twice.
 set -u
 
 # shellcheck source=tests/lib.sh disable=SC1091
@@ -877,6 +881,100 @@ test_routine_bootstrap_contract_runs_under_system_bash() {
   pass "bootstrap routine contract runs under system /bin/bash"
 }
 
+# FM_BOOTSTRAP_NETWORK splits one bootstrap run into its local and network
+# halves so a session start can compose its digest from the local half alone and
+# run the network half concurrently. The property that has to hold is that the
+# split is a PARTITION: `skip` plus `only` together do exactly what `all` does,
+# with no step dropped and no step run twice.
+test_network_phase_partitions_the_run() {
+  local case_dir fakebin all_out skip_out only_out combined
+  case_dir="$TMP_ROOT/network-phase"
+  mkdir -p "$case_dir/home/config"
+  printf '%s\n' manual > "$case_dir/home/config/backlog-backend"
+  fakebin=$(make_fake_toolchain "$case_dir")
+  # Break the two diagnostics that stand for the two halves: a local tool floor
+  # and the network GitHub-auth probe.
+  rm -f "$fakebin/node"
+  cat > "$fakebin/gh" <<'SH'
+#!/usr/bin/env bash
+exit 1
+SH
+  chmod +x "$fakebin/gh"
+
+  all_out=$(PATH="$fakebin:$BASE_PATH" FM_HOME="$case_dir/home" FM_ROOT_OVERRIDE="$case_dir/home" \
+    FM_FAKE_TREEHOUSE_LEASE_HELP=1 "$ROOT/bin/fm-bootstrap.sh")
+  assert_contains "$all_out" "MISSING: node (install:" "the unsplit run lost its local diagnostic"
+  assert_contains "$all_out" "NEEDS_GH_AUTH" "the unsplit run lost its network diagnostic"
+
+  skip_out=$(PATH="$fakebin:$BASE_PATH" FM_HOME="$case_dir/home" FM_ROOT_OVERRIDE="$case_dir/home" \
+    FM_FAKE_TREEHOUSE_LEASE_HELP=1 FM_BOOTSTRAP_NETWORK=skip "$ROOT/bin/fm-bootstrap.sh")
+  assert_contains "$skip_out" "MISSING: node (install:" "the local half lost its own diagnostic"
+  assert_not_contains "$skip_out" "NEEDS_GH_AUTH" "the local half still made a network call"
+
+  only_out=$(PATH="$fakebin:$BASE_PATH" FM_HOME="$case_dir/home" FM_ROOT_OVERRIDE="$case_dir/home" \
+    FM_FAKE_TREEHOUSE_LEASE_HELP=1 FM_BOOTSTRAP_NETWORK=only "$ROOT/bin/fm-bootstrap.sh")
+  assert_contains "$only_out" "NEEDS_GH_AUTH" "the network half lost its own diagnostic"
+  assert_not_contains "$only_out" "MISSING: node" "the network half repeated the local half's work"
+
+  combined=$(printf '%s\n%s\n' "$skip_out" "$only_out" | LC_ALL=C sort)
+  [ "$combined" = "$(printf '%s\n' "$all_out" | LC_ALL=C sort)" ] \
+    || fail "skip + only is not the same set of findings as an unsplit run"$'\n'"all:      $all_out"$'\n'"skip:     $skip_out"$'\n'"only:     $only_out"
+
+  # A typo must never silently drop a safety sweep, so anything unrecognized
+  # resolves to the complete run.
+  [ "$(PATH="$fakebin:$BASE_PATH" FM_HOME="$case_dir/home" FM_ROOT_OVERRIDE="$case_dir/home" \
+    FM_FAKE_TREEHOUSE_LEASE_HELP=1 FM_BOOTSTRAP_NETWORK=sikp "$ROOT/bin/fm-bootstrap.sh")" = "$all_out" ] \
+    || fail "an unrecognized FM_BOOTSTRAP_NETWORK value did not fall back to the complete run"
+  pass "bootstrap: FM_BOOTSTRAP_NETWORK partitions one run into local and network halves"
+}
+
+# The verdict costs three subprocesses, so a caller that already has it can hand
+# it over - but only one hop, and never onward into a spawned agent's
+# environment, where it could outlive a tasks-axi upgrade.
+test_tasks_axi_verdict_handoff_is_consumed_once() {
+  local case_dir fakebin log out
+  case_dir="$TMP_ROOT/tasks-axi-handoff"
+  mkdir -p "$case_dir/home/config"
+  fakebin=$(make_fake_toolchain "$case_dir")
+  log="$case_dir/tasks-axi.log"
+  cat > "$fakebin/tasks-axi" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "${FM_FAKE_TASKS_AXI_LOG:?}"
+printf '0.0.1\n'
+exit 0
+SH
+  chmod +x "$fakebin/tasks-axi"
+
+  # Without the handoff, the incompatible stub is probed and reported.
+  : > "$log"
+  out=$(PATH="$fakebin:$BASE_PATH" FM_HOME="$case_dir/home" FM_ROOT_OVERRIDE="$case_dir/home" \
+    FM_FAKE_TASKS_AXI_LOG="$log" FM_FAKE_TREEHOUSE_LEASE_HELP=1 "$ROOT/bin/fm-bootstrap.sh")
+  assert_contains "$out" "MISSING: tasks-axi (install:" "the unaided run did not probe tasks-axi"
+  assert_grep '--version' "$log" "the unaided run never ran the probe"
+
+  # With it, the probe is skipped entirely and the handed-in verdict is used.
+  : > "$log"
+  out=$(PATH="$fakebin:$BASE_PATH" FM_HOME="$case_dir/home" FM_ROOT_OVERRIDE="$case_dir/home" \
+    FM_FAKE_TASKS_AXI_LOG="$log" FM_FAKE_TREEHOUSE_LEASE_HELP=1 \
+    FM_TASKS_AXI_COMPATIBLE=1 "$ROOT/bin/fm-bootstrap.sh")
+  assert_not_contains "$out" "MISSING: tasks-axi" "the handed-in verdict was ignored"
+  [ ! -s "$log" ] || fail "the handed-in verdict did not save the probe: $(cat "$log")"
+
+  # A malformed value is not a verdict.
+  : > "$log"
+  out=$(PATH="$fakebin:$BASE_PATH" FM_HOME="$case_dir/home" FM_ROOT_OVERRIDE="$case_dir/home" \
+    FM_FAKE_TASKS_AXI_LOG="$log" FM_FAKE_TREEHOUSE_LEASE_HELP=1 \
+    FM_TASKS_AXI_COMPATIBLE=yes "$ROOT/bin/fm-bootstrap.sh")
+  assert_contains "$out" "MISSING: tasks-axi (install:" "a malformed handoff value was trusted"
+
+  # And the handoff never reaches a grandchild: bootstrap spawns agents, and a
+  # verdict cached into an agent's environment would outlive the tool it describes.
+  out=$(FM_TASKS_AXI_COMPATIBLE=1 bash -c '. "$1"; printf "%s\n" "${FM_TASKS_AXI_COMPATIBLE-unset}"' \
+    _ "$ROOT/bin/fm-tasks-axi-lib.sh")
+  [ "$out" = unset ] || fail "sourcing the library left the handoff in the environment: $out"
+  pass "bootstrap: the tasks-axi compatibility verdict travels exactly one process hop"
+}
+
 test_crew_dispatch_active_rules_are_verbose_bootstrap_info() {
   local case_dir fakebin out expect
   case_dir="$TMP_ROOT/dispatch-active"
@@ -973,5 +1071,7 @@ test_fleet_sync_timeout_empty_override_uses_default
 test_fleet_sync_timeout_is_computed_before_launch
 test_routine_bootstrap_confirmations_are_silent
 test_routine_bootstrap_contract_runs_under_system_bash
+test_network_phase_partitions_the_run
+test_tasks_axi_verdict_handoff_is_consumed_once
 test_crew_dispatch_active_rules_are_verbose_bootstrap_info
 test_crew_dispatch_validation

--- a/tests/fm-bootstrap.test.sh
+++ b/tests/fm-bootstrap.test.sh
@@ -928,6 +928,38 @@ SH
   pass "bootstrap: FM_BOOTSTRAP_NETWORK partitions one run into local and network halves"
 }
 
+test_network_sweeps_recheck_lock_ownership() {
+  local case_dir fakebin fake_root marker out
+  case_dir="$TMP_ROOT/network-lock-handoff"
+  mkdir -p "$case_dir/home/config" "$case_dir/home/projects" "$case_dir/home/state"
+  printf '%s\n' manual > "$case_dir/home/config/backlog-backend"
+  printf '222222\n' > "$case_dir/home/state/.lock"
+  fakebin=$(make_fake_toolchain "$case_dir")
+  fake_root="$case_dir/root"
+  marker="$case_dir/fleet-sync.started"
+  mkdir -p "$fake_root/bin"
+  cat > "$fake_root/bin/fm-fleet-sync.sh" <<'SH'
+#!/usr/bin/env bash
+: > "${FM_FAKE_FLEET_SYNC_STARTED_MARKER:?}"
+SH
+  chmod +x "$fake_root/bin/fm-fleet-sync.sh"
+
+  out=$(PATH="$fakebin:$BASE_PATH" FM_HOME="$case_dir/home" FM_ROOT_OVERRIDE="$fake_root" \
+    FM_FAKE_TREEHOUSE_LEASE_HELP=1 FM_BOOTSTRAP_NETWORK=only \
+    FM_BOOTSTRAP_NETWORK_LOCK_PID=111111 FM_FAKE_FLEET_SYNC_STARTED_MARKER="$marker" \
+    "$ROOT/bin/fm-bootstrap.sh")
+  assert_absent "$marker" "a stale worker refreshed project clones after lock handoff"
+  assert_contains "$out" "changed before dead-secondmate relaunch" \
+    "the stale worker did not report the refused liveness sweep"
+  assert_contains "$out" "changed before secondmate convergence" \
+    "the stale worker did not report the refused convergence sweep"
+  assert_contains "$out" "changed before pending handoff delivery" \
+    "the stale worker did not report the refused handoff sweep"
+  assert_contains "$out" "changed before project clone refresh" \
+    "the stale worker did not report the refused clone refresh"
+  pass "bootstrap: every deferred mutating sweep rechecks fleet-lock ownership"
+}
+
 # The verdict costs three subprocesses, so a caller that already has it can hand
 # it over - but only one hop, and never onward into a spawned agent's
 # environment, where it could outlive a tasks-axi upgrade.
@@ -1072,6 +1104,7 @@ test_fleet_sync_timeout_is_computed_before_launch
 test_routine_bootstrap_confirmations_are_silent
 test_routine_bootstrap_contract_runs_under_system_bash
 test_network_phase_partitions_the_run
+test_network_sweeps_recheck_lock_ownership
 test_tasks_axi_verdict_handoff_is_consumed_once
 test_crew_dispatch_active_rules_are_verbose_bootstrap_info
 test_crew_dispatch_validation

--- a/tests/fm-session-start.test.sh
+++ b/tests/fm-session-start.test.sh
@@ -1381,7 +1381,7 @@ EOF
   out=$(run_session_start_secondmate "$root" "$home" "$fakebin" "$mate" "$log" "$spawned" missing)
   elapsed=$(( $(date +%s) - started ))
 
-  [ "$elapsed" -lt 6 ] \
+  [ "$elapsed" -lt 8 ] \
     || fail "the digest waited $elapsed s on a 12s unreachable host - the blocking path still makes a network call"
   assert_contains "$out" "SESSION START" "the digest did not complete"
   assert_contains "$out" "IN PROGRESS - the deferred network checks have not finished yet." \

--- a/tests/fm-session-start.test.sh
+++ b/tests/fm-session-start.test.sh
@@ -24,6 +24,11 @@
 #   - composition: the script invokes the real fm-lock.sh/fm-bootstrap.sh/
 #     fm-wake-drain.sh (their real, distinctive output appears verbatim), it
 #     does not reimplement their logic
+#   - the deferred network stage: an unreachable host delays a reported check
+#     rather than the digest, the sweeps it defers still run and land, a result
+#     surfaces exactly once (inline or as a wake, never both), a read-only
+#     session declares the checks it skipped, and the tasks-axi compatibility
+#     verdict is paid for once per session start
 set -u
 
 # shellcheck source=tests/lib.sh
@@ -578,6 +583,22 @@ run_session_start_herdr_secondmate() {
     run_session_start "$home" "$root" "$fakebin:$BASE_PATH"
 }
 
+# wait_for_network_stage <home> <root> [seconds]
+# Block until the deferred network stage this home's session start launched has
+# published. Only a TEST does this: the digest itself is required never to wait,
+# which is exactly why the sweeps it used to run inline have to be re-asserted
+# here instead of straight off the digest's own output.
+wait_for_network_stage() {
+  local home=$1 root=$2 limit=${3:-30}
+  FM_HOME="$home" FM_ROOT_OVERRIDE="$root" \
+    "$ROOT/bin/fm-startup-network.sh" wait "$limit"
+}
+
+network_stage_report() {
+  local home=$1 root=$2
+  FM_HOME="$home" FM_ROOT_OVERRIDE="$root" "$ROOT/bin/fm-startup-network.sh" report
+}
+
 hash_file_for_test() {
   local file=$1
   if command -v shasum >/dev/null 2>&1; then
@@ -1095,21 +1116,55 @@ EOF
 
   out=$(run_session_start_secondmate "$root" "$home" "$fakebin" "$mate" "$log" "$spawned" missing)
 
-  assert_not_contains "$out" "SECONDMATE_LIVENESS:" "successful missing-window recovery should stay non-actionable"
-  assert_contains "$(cat "$log")" "new-window" "session start did not relaunch the missing Pi secondmate"
-  assert_not_contains "$(cat "$log")" "kill-window" "session start tried to kill an already-absent window"
-  assert_contains "$out" "endpoint: alive (backend=tmux window=firstmate:fm-$SESSION_START_SECOND_MATE_ID)" \
-    "the later fleet read did not confirm the relaunched window"
+  # The relaunch now runs off the blocking path, so the digest's own liveness
+  # read may legitimately still show the pre-relaunch endpoint. What must NOT
+  # happen is silence: the section names the relaunch as either done or not yet
+  # confirmed.
+  assert_contains "$out" "NETWORK CHECKS" "the digest lost its deferred network-check section"
+  assert_contains "$out" "dead-secondmate relaunch" \
+    "the digest never accounted for the dead-secondmate relaunch"
+
+  wait_for_network_stage "$home" "$root" \
+    || fail "the deferred network stage never published: $(network_stage_report "$home" "$root")"
+
+  assert_not_contains "$(network_stage_report "$home" "$root")" "SECONDMATE_LIVENESS:" \
+    "successful missing-window recovery should stay non-actionable"
+  assert_contains "$(cat "$log")" "new-window" "the deferred stage did not relaunch the missing Pi secondmate"
+  assert_not_contains "$(cat "$log")" "kill-window" "the deferred stage tried to kill an already-absent window"
   assert_grep 'harness=pi' "$home/state/$SESSION_START_SECOND_MATE_ID.meta" \
     "the real respawn path did not preserve the Pi harness: $(cat "$home/state/$SESSION_START_SECOND_MATE_ID.meta")"
 
   first_calls=$(grep -c 'new-window' "$log" || true)
   rm -f "$home/state/.lock"
   run_session_start_secondmate "$root" "$home" "$fakebin" "$mate" "$log" "$spawned" missing >/dev/null
+  wait_for_network_stage "$home" "$root" \
+    || fail "the second pass's deferred network stage never published"
   second_calls=$(grep -c 'new-window' "$log" || true)
   [ "$first_calls" -eq 1 ] && [ "$second_calls" -eq 1 ] \
     || fail "a second session-start pass duplicated the relaunched Pi secondmate: $(cat "$log")"
-  pass "session start: an absent recorded tmux window relaunches its Pi secondmate exactly once"
+  pass "session start: an absent recorded tmux window relaunches its Pi secondmate exactly once, off the blocking path"
+}
+
+# The relaunch is the sharpest deferral: it mutates the very endpoint record the
+# digest printed moments earlier. Silence would leave that stale record looking
+# authoritative, so the deferred pass reports it whether or not verbose facts are
+# on, and the report says the digest's records are now behind.
+test_deferred_relaunch_is_always_reported() {
+  local rec root home fakebin mate log spawned report
+  rec=$(prepare_session_start_secondmate secondmate-relaunch-reported)
+  IFS='|' read -r root home fakebin mate log spawned <<EOF
+$rec
+EOF
+
+  run_session_start_secondmate "$root" "$home" "$fakebin" "$mate" "$log" "$spawned" missing >/dev/null
+  wait_for_network_stage "$home" "$root" || fail "the deferred network stage never published"
+
+  report=$(network_stage_report "$home" "$root")
+  assert_contains "$report" "secondmate $SESSION_START_SECOND_MATE_ID relaunched" \
+    "a relaunch performed after the digest was composed went unreported"
+  assert_contains "$report" "re-read any record" \
+    "the report did not tell the reader the digest's records are now behind"
+  pass "session start: a deferred relaunch is always reported, so the digest's stale endpoint record cannot stand"
 }
 
 test_session_start_preserves_ambiguous_pi_process() {
@@ -1120,8 +1175,10 @@ $rec
 EOF
 
   out=$(run_session_start_secondmate "$root" "$home" "$fakebin" "$mate" "$log" "$spawned" ambiguous)
+  wait_for_network_stage "$home" "$root" || fail "the deferred network stage never published"
 
-  assert_contains "$out" "SECONDMATE_LIVENESS: secondmate $SESSION_START_SECOND_MATE_ID: skipped: existing endpoint has ambiguous agent process (backend=tmux)" \
+  assert_contains "$(network_stage_report "$home" "$root")" \
+    "SECONDMATE_LIVENESS: secondmate $SESSION_START_SECOND_MATE_ID: skipped: existing endpoint has ambiguous agent process (backend=tmux)" \
     "session start did not distinguish an existing Pi-shaped process from a missing window"
   [ ! -s "$log" ] || fail "session start touched an ambiguous existing Pi process: $(cat "$log")"
   assert_contains "$out" "endpoint: alive (backend=tmux window=firstmate:fm-$SESSION_START_SECOND_MATE_ID)" \
@@ -1137,8 +1194,10 @@ $rec
 EOF
 
   out=$(run_session_start_secondmate "$root" "$home" "$fakebin" "$mate" "$log" "$spawned" unreadable)
+  wait_for_network_stage "$home" "$root" || fail "the deferred network stage never published"
 
-  assert_contains "$out" "SECONDMATE_LIVENESS: secondmate $SESSION_START_SECOND_MATE_ID: skipped: endpoint probe unreadable (backend=tmux)" \
+  assert_contains "$(network_stage_report "$home" "$root")" \
+    "SECONDMATE_LIVENESS: secondmate $SESSION_START_SECOND_MATE_ID: skipped: endpoint probe unreadable (backend=tmux)" \
     "session start did not distinguish transient unreadability from absence"
   [ ! -s "$log" ] || fail "session start touched a transiently unreadable target: $(cat "$log")"
   assert_contains "$out" "endpoint: dead (backend=tmux window=firstmate:fm-$SESSION_START_SECOND_MATE_ID)" \
@@ -1153,14 +1212,14 @@ test_session_start_preserves_proven_bare_shell_recovery() {
 $rec
 EOF
 
-  out=$(run_session_start_secondmate "$root" "$home" "$fakebin" "$mate" "$log" "$spawned" shell)
+  run_session_start_secondmate "$root" "$home" "$fakebin" "$mate" "$log" "$spawned" shell >/dev/null
+  wait_for_network_stage "$home" "$root" || fail "the deferred network stage never published"
 
+  out=$(network_stage_report "$home" "$root")
   assert_not_contains "$out" "SECONDMATE_LIVENESS:" "successful bare-shell recovery should stay non-actionable"
   assert_contains "$(cat "$log")" "kill-window -t =firstmate:=fm-$SESSION_START_SECOND_MATE_ID" \
     "the proven bare-shell path did not remove its existing dead endpoint"
   assert_contains "$(cat "$log")" "new-window" "the proven bare-shell path did not relaunch"
-  assert_contains "$out" "endpoint: alive (backend=tmux window=firstmate:fm-$SESSION_START_SECOND_MATE_ID)" \
-    "the later fleet read did not confirm the bare-shell relaunch"
   pass "session start: the proven bare-shell recovery path remains intact"
 }
 
@@ -1171,13 +1230,13 @@ test_session_start_relaunches_herdr_husk_secondmate() {
 $rec
 EOF
 
-  out=$(run_session_start_herdr_secondmate "$root" "$home" "$fakebin" "$mate" "$log" "$state")
+  run_session_start_herdr_secondmate "$root" "$home" "$fakebin" "$mate" "$log" "$state" >/dev/null
+  wait_for_network_stage "$home" "$root" || fail "the deferred network stage never published"
 
+  out=$(network_stage_report "$home" "$root")
   assert_not_contains "$out" "SECONDMATE_LIVENESS:" "successful Herdr husk recovery should stay non-actionable"
   assert_contains "$(cat "$log")" "pane close p-old" "session start did not close the confirmed Herdr husk"
   assert_contains "$(cat "$log")" "tab create" "session start did not relaunch the Herdr secondmate"
-  assert_contains "$out" "endpoint: alive (backend=herdr window=default:p-new)" \
-    "the later fleet read did not confirm the relaunched Herdr endpoint"
   assert_grep 'herdr_pane_id=p-new' "$home/state/$SESSION_START_HERDR_SECOND_MATE_ID.meta" \
     "the real respawn path did not record the replacement Herdr pane"
   pass "session start: a confirmed Herdr husk is closed and relaunched"
@@ -1251,6 +1310,140 @@ EOF
   assert_contains "$out" "wake annotation: latest wake-EVENT observed at drain, not current state: task-z.status: needs-decision: pick a library" "fm-session-start.sh did not preserve the drain's separate annotation line"
 
   pass "fm-session-start.sh composes the real fm-lock.sh, fm-bootstrap.sh, and fm-wake-drain.sh output verbatim"
+}
+
+# --- deferred network stage -------------------------------------------------
+
+# install_slow_gh <fakebin> <seconds>: the only external-network call the digest
+# itself ever made. Making it pathologically slow is how a test stands in for an
+# unreachable host without touching one: if any part of the blocking path still
+# waits on the network, the digest cannot finish before this does.
+install_slow_gh() {
+  local fakebin=$1 seconds=$2
+  cat > "$fakebin/gh" <<SH
+#!/usr/bin/env bash
+if [ "\${1:-}" = auth ]; then
+  sleep $seconds
+  exit 1
+fi
+exit 0
+SH
+  chmod +x "$fakebin/gh"
+}
+
+# The headline guarantee: an unreachable host delays a reported CHECK, never the
+# startup. The fake host hangs for 12s; the digest must be done long before that,
+# must say so rather than implying the checks passed, and the sweeps must still
+# run and land afterwards.
+test_unreachable_network_never_blocks_the_digest() {
+  local rec root home fakebin mate log spawned out started elapsed
+  rec=$(prepare_session_start_secondmate secondmate-slow-network)
+  IFS='|' read -r root home fakebin mate log spawned <<EOF
+$rec
+EOF
+  install_slow_gh "$fakebin" 12
+
+  started=$(date +%s)
+  out=$(run_session_start_secondmate "$root" "$home" "$fakebin" "$mate" "$log" "$spawned" missing)
+  elapsed=$(( $(date +%s) - started ))
+
+  [ "$elapsed" -lt 6 ] \
+    || fail "the digest waited $elapsed s on a 12s unreachable host - the blocking path still makes a network call"
+  assert_contains "$out" "SESSION START" "the digest did not complete"
+  assert_contains "$out" "IN PROGRESS - the deferred network checks have not finished yet." \
+    "the digest did not disclose that its network checks were still running"
+  assert_contains "$out" "NOT yet confirmed: GitHub authentication, dead-secondmate relaunch" \
+    "the digest did not name the checks it has not confirmed"
+  assert_not_contains "$out" "NEEDS_GH_AUTH" \
+    "the digest reported a GitHub-auth verdict it could not yet have"
+
+  # ... and the work itself still happens, off the blocking path.
+  wait_for_network_stage "$home" "$root" 60 \
+    || fail "the deferred stage never finished: $(network_stage_report "$home" "$root")"
+  assert_contains "$(network_stage_report "$home" "$root")" "NEEDS_GH_AUTH" \
+    "the deferred stage lost the GitHub-auth verdict it was deferring"
+  assert_contains "$(cat "$log")" "new-window" \
+    "the deferred stage lost the dead-secondmate relaunch"
+  pass "session start: an unreachable host delays a reported check, not the digest"
+}
+
+# A result the digest could not print must still reach the agent by itself. The
+# opposite half of the handshake - a printed result never ALSO queuing a wake -
+# is asserted deterministically in tests/fm-startup-network.test.sh, where the
+# claim can be set up directly instead of raced against digest composition.
+test_deferred_result_reaches_the_agent_when_the_digest_cannot_print_it() {
+  local rec root home fakebin mate log spawned queue
+  rec=$(prepare_session_start_secondmate secondmate-wake-once)
+  IFS='|' read -r root home fakebin mate log spawned <<EOF
+$rec
+EOF
+  install_slow_gh "$fakebin" 8
+  queue="$home/state/.wake-queue"
+
+  run_session_start_secondmate "$root" "$home" "$fakebin" "$mate" "$log" "$spawned" missing >/dev/null
+  wait_for_network_stage "$home" "$root" 60 || fail "the deferred stage never finished"
+  assert_grep 'check	startup-network' "$queue" \
+    "a result the digest could not print never reached the agent: $(cat "$queue" 2>/dev/null)"
+  pass "session start: a deferred result the digest outran still reaches the agent as a wake"
+}
+
+# A read-only session has no lock, so it neither owns the mutating sweeps nor has
+# any action a GitHub-auth verdict would gate. It must say that plainly instead of
+# quietly dropping the checks.
+test_read_only_session_declares_skipped_network_checks() {
+  local rec root home fakebin out
+  rec=$(new_world network-read-only)
+  IFS='|' read -r root home fakebin <<EOF
+$rec
+EOF
+  make_fake_toolchain "$fakebin"
+  make_fake_ps_claude "$fakebin"
+  printf '999999\n' > "$home/state/.lock"
+  cat > "$fakebin/ps" <<'SH'
+#!/usr/bin/env bash
+set -u
+case "$*" in
+  *"-p 999999"*) printf 'claude\n'; exit 0 ;;
+  *"comm="*|*"args="*) printf 'bash\n'; exit 0 ;;
+esac
+exit 0
+SH
+  chmod +x "$fakebin/ps"
+
+  out=$(run_session_start "$home" "$root" "$fakebin:$BASE_PATH")
+
+  assert_contains "$out" "READ-ONLY SESSION" "the read-only fixture did not actually refuse the lock"
+  assert_contains "$out" "skipped (read-only session) - GitHub authentication" \
+    "a read-only session did not declare its skipped network checks"
+  assert_absent "$home/state/.startup-network.status" \
+    "a read-only session started the deferred stage it has no authority for"
+  pass "session start: a read-only session declares its skipped network checks rather than dropping them"
+}
+
+# The compatibility verdict costs three tasks-axi subprocesses and one session
+# start needs it twice. The digest must pay for it once.
+test_tasks_axi_compatibility_is_probed_once() {
+  local rec root home fakebin log probes
+  rec=$(new_world tasks-axi-once)
+  IFS='|' read -r root home fakebin <<EOF
+$rec
+EOF
+  make_fake_toolchain "$fakebin"
+  make_fake_ps_claude "$fakebin"
+  make_fake_tasks_axi_compact "$fakebin"
+  log="$home/tasks-axi.log"
+  printf '# Backlog\n\n## In flight\n\n## Queued\n' > "$home/data/backlog.md"
+
+  FM_FAKE_TASKS_AXI_LOG="$log" run_session_start "$home" "$root" "$fakebin:$BASE_PATH" >/dev/null
+
+  probes=$(grep -c -- '--version' "$log" || true)
+  [ "$probes" -eq 1 ] \
+    || fail "tasks-axi was version-probed $probes times in one session start: $(cat "$log")"
+  probes=$(grep -c -- 'update --help' "$log" || true)
+  [ "$probes" -eq 1 ] \
+    || fail "tasks-axi update --help ran $probes times in one session start: $(cat "$log")"
+  assert_grep 'ready --file' "$log" "the backlog listing never ran, so the verdict was not actually reused"
+  pass "session start: the tasks-axi compatibility verdict is computed once and reused"
 }
 
 # --- fleet-state digest: compact backlog rendering --------------------------
@@ -1506,7 +1699,7 @@ EOF
     _ "$ROOT/bin/fm-timeout-lib.sh")
   [ "$mechanism" = bash ] || fail "the forced pure-Bash timeout fixture selected '$mechanism'"
 
-  out=$(FM_TIMEOUT_MECHANISM_OVERRIDE=bash FM_SESSION_START_TIMEOUT=3 \
+  out=$(FM_TIMEOUT_MECHANISM_OVERRIDE=bash FM_SESSION_START_TIMEOUT=3 FM_STARTUP_NETWORK_TIMEOUT=2 \
     run_session_start "$home" "$root" "$fakebin:$BASE_PATH") || status=$?
 
   expect_code 0 "$status" "a truncated session start must still exit 0 so the session can open"
@@ -1516,7 +1709,7 @@ EOF
   assert_contains "$out" "RUNTIME BOUND" "the truncation banner did not name the bound it hit"
   assert_contains "$out" 'stopped during the "bootstrap" stage' "the truncation banner did not name the incomplete stage"
   assert_contains "$out" "RECONCILE these stages" "the truncation banner did not tell the agent what to reconcile"
-  assert_contains "$out" "wake-queue supervision-instructions read-once fleet-state context next-step" \
+  assert_contains "$out" "wake-queue supervision-instructions read-once fleet-state network-checks context next-step" \
     "the truncation banner did not list every stage that never ran"
   assert_not_contains "$out" "NEXT STEP" "a truncated digest claimed to have reached its closing reminder"
   assert_absent "$home/state/.session-start-complete" \
@@ -1524,6 +1717,12 @@ EOF
 
   # The bound must reach the whole process group: a hung grandchild that
   # outlives the digest would keep holding whatever the digest was waiting on.
+  # There are now TWO bounds, deliberately independent - the digest's, and the
+  # deferred network stage's own - because a truncated digest must not kill work
+  # it was never waiting for. So the guarantee asserted here is the one that
+  # actually matters: once BOTH deadlines have passed, nothing hung is left.
+  FM_HOME="$home" FM_ROOT_OVERRIDE="$root" FM_STARTUP_NETWORK_TIMEOUT=2 \
+    "$ROOT/bin/fm-startup-network.sh" wait 30 >/dev/null || true
   sleep 1
   stray=$(pgrep -f "$fakebin/git" 2>/dev/null | wc -l | tr -d ' ')
   [ "$stray" -eq 0 ] || fail "the runtime bound left $stray hung subprocess(es) behind"
@@ -1949,6 +2148,11 @@ test_output_ordering_diagnostics_lead
 test_read_once_contract_is_stated_once_before_its_subject
 test_herdr_backend_diagnostics_follow_real_session_start
 test_session_start_relaunches_missing_pi_secondmate
+test_deferred_relaunch_is_always_reported
+test_unreachable_network_never_blocks_the_digest
+test_deferred_result_reaches_the_agent_when_the_digest_cannot_print_it
+test_read_only_session_declares_skipped_network_checks
+test_tasks_axi_compatibility_is_probed_once
 test_session_start_preserves_ambiguous_pi_process
 test_session_start_preserves_transiently_unreadable_tmux
 test_session_start_preserves_proven_bare_shell_recovery

--- a/tests/fm-session-start.test.sh
+++ b/tests/fm-session-start.test.sh
@@ -206,9 +206,7 @@ SH
 
 # make_fake_ps_claude <fakebin>: harness_pid()/holder_alive() (fm-lock.sh) walk
 # `ps` output looking for a harness command name; this fake reports EVERY
-# queried pid as a live `claude` harness, so the very first ancestry check
-# (this test process's own pid) matches and lock acquisition succeeds
-# deterministically. Mirrors fm-grok-harness.test.sh's fake ps.
+# queried pid as a live `claude` harness unless a stable harness pid is set.
 make_fake_ps_claude() {
   local fakebin=$1
   make_fake_ps_harness "$fakebin" claude
@@ -220,9 +218,33 @@ make_fake_ps_harness() {
 #!/usr/bin/env bash
 set -u
 harness=${FM_FAKE_HARNESS:-claude}
+pid=
+previous=
+for argument in "$@"; do
+  [ "$previous" = -p ] && pid=$argument
+  previous=$argument
+done
 case "$*" in
-  *"comm="*) printf '/usr/local/bin/%s\n' "$harness"; exit 0 ;;
-  *"args="*) printf '%s\n' "$harness"; exit 0 ;;
+  *"comm="*)
+    if [ -z "${FM_FAKE_HARNESS_PID:-}" ] || [ "$pid" = "$FM_FAKE_HARNESS_PID" ]; then
+      printf '/usr/local/bin/%s\n' "$harness"
+    else
+      printf '/bin/bash\n'
+    fi
+    exit 0
+    ;;
+  *"args="*)
+    if [ -z "${FM_FAKE_HARNESS_PID:-}" ] || [ "$pid" = "$FM_FAKE_HARNESS_PID" ]; then
+      printf '%s\n' "$harness"
+    else
+      printf 'bash\n'
+    fi
+    exit 0
+    ;;
+  *"ppid="*)
+    [ -n "${FM_FAKE_HARNESS_PID:-}" ] || exit 1
+    /bin/ps -o ppid= -p "$pid"
+    ;;
 esac
 exit 1
 SH
@@ -536,6 +558,7 @@ run_session_start_secondmate() {
   TMUX='' FM_BACKEND=tmux FM_FAKE_TMUX_MODE="$mode" FM_FAKE_TMUX_LOG="$log" \
     FM_FAKE_TMUX_SPAWNED="$spawned" FM_FAKE_SECOND_MATE_HOME="$mate" \
     FM_FAKE_SECOND_MATE_ID="$SESSION_START_SECOND_MATE_ID" \
+    FM_FAKE_HARNESS_PID=$$ \
     run_session_start "$home" "$root" "$fakebin:$BASE_PATH"
 }
 
@@ -580,6 +603,7 @@ run_session_start_herdr_secondmate() {
   local root=$1 home=$2 fakebin=$3 mate=$4 log=$5 state=$6
   FM_BACKEND=herdr FM_FAKE_HERDR_LOG="$log" FM_FAKE_HERDR_STATE="$state" \
     FM_FAKE_SECOND_MATE_ID="$SESSION_START_HERDR_SECOND_MATE_ID" \
+    FM_FAKE_HARNESS_PID=$$ \
     run_session_start "$home" "$root" "$fakebin:$BASE_PATH"
 }
 
@@ -592,6 +616,16 @@ wait_for_network_stage() {
   local home=$1 root=$2 limit=${3:-30}
   FM_HOME="$home" FM_ROOT_OVERRIDE="$root" \
     "$ROOT/bin/fm-startup-network.sh" wait "$limit"
+}
+
+wait_for_network_wake() {
+  local home=$1 limit=${2:-30} waited=0
+  while ! grep -Fq $'check\tstartup-network' "$home/state/.wake-queue" 2>/dev/null \
+    && [ "$waited" -lt "$limit" ]; do
+    sleep 1
+    waited=$((waited + 1))
+  done
+  grep -Fq $'check\tstartup-network' "$home/state/.wake-queue" 2>/dev/null
 }
 
 network_stage_report() {
@@ -1382,6 +1416,7 @@ EOF
 
   run_session_start_secondmate "$root" "$home" "$fakebin" "$mate" "$log" "$spawned" missing >/dev/null
   wait_for_network_stage "$home" "$root" 60 || fail "the deferred stage never finished"
+  wait_for_network_wake "$home" 60 || fail "the deferred stage never settled wake delivery"
   assert_grep 'check	startup-network' "$queue" \
     "a result the digest could not print never reached the agent: $(cat "$queue" 2>/dev/null)"
   pass "session start: a deferred result the digest outran still reaches the agent as a wake"

--- a/tests/fm-session-start.test.sh
+++ b/tests/fm-session-start.test.sh
@@ -1892,7 +1892,7 @@ SH
 # --- context re-emit (--reemit) ----------------------------------------------
 
 test_reemit_skips_startup_sweeps_but_keeps_the_wake_drain() {
-  local rec root home fakebin full network_report reemit
+  local rec root home fakebin network_report reemit
   rec=$(new_world reemit)
   IFS='|' read -r root home fakebin <<EOF
 $rec
@@ -1904,7 +1904,7 @@ EOF
   append_wake "$home/state" signal task-r "done: queued after startup" || fail "seed wake failed"
 
   # A full startup reconciles the secondmate sweep and reports it.
-  full=$(FM_FAKE_HARNESS_PID=$$ run_session_start "$home" "$root" "$fakebin:$BASE_PATH")
+  FM_FAKE_HARNESS_PID=$$ run_session_start "$home" "$root" "$fakebin:$BASE_PATH" >/dev/null
   wait_for_network_stage "$home" "$root" \
     || fail "the full startup fixture's deferred network stage never published"
   network_report=$(network_stage_report "$home" "$root")

--- a/tests/fm-session-start.test.sh
+++ b/tests/fm-session-start.test.sh
@@ -1348,16 +1348,17 @@ EOF
 
 # --- deferred network stage -------------------------------------------------
 
-# install_slow_gh <fakebin> <seconds>: the only external-network call the digest
-# itself ever made. Making it pathologically slow is how a test stands in for an
+# install_slow_gh <fakebin> <seconds>: one external-network call the digest used
+# to make directly. Making it pathologically slow is how a test stands in for an
 # unreachable host without touching one: if any part of the blocking path still
 # waits on the network, the digest cannot finish before this does.
 install_slow_gh() {
-  local fakebin=$1 seconds=$2
+  local fakebin=$1 seconds=$2 finished_marker=${3:-}
   cat > "$fakebin/gh" <<SH
 #!/usr/bin/env bash
 if [ "\${1:-}" = auth ]; then
   sleep $seconds
+  [ -z '$finished_marker' ] || : > '$finished_marker'
   exit 1
 fi
 exit 0
@@ -1370,19 +1371,20 @@ SH
 # must say so rather than implying the checks passed, and the sweeps must still
 # run and land afterwards.
 test_unreachable_network_never_blocks_the_digest() {
-  local rec root home fakebin mate log spawned out started elapsed
+  local rec root home fakebin mate log spawned network_finished out started elapsed
   rec=$(prepare_session_start_secondmate secondmate-slow-network)
   IFS='|' read -r root home fakebin mate log spawned <<EOF
 $rec
 EOF
-  install_slow_gh "$fakebin" 12
+  network_finished="${root%/root}/network-finished"
+  install_slow_gh "$fakebin" 12 "$network_finished"
 
   started=$(date +%s)
   out=$(run_session_start_secondmate "$root" "$home" "$fakebin" "$mate" "$log" "$spawned" missing)
   elapsed=$(( $(date +%s) - started ))
 
-  [ "$elapsed" -lt 8 ] \
-    || fail "the digest waited $elapsed s on a 12s unreachable host - the blocking path still makes a network call"
+  [ ! -e "$network_finished" ] \
+    || fail "the digest waited for the 12s unreachable-host probe instead of returning from local state (${elapsed}s)"
   assert_contains "$out" "SESSION START" "the digest did not complete"
   assert_contains "$out" "IN PROGRESS - the deferred network checks have not finished yet." \
     "the digest did not disclose that its network checks were still running"
@@ -1890,7 +1892,7 @@ SH
 # --- context re-emit (--reemit) ----------------------------------------------
 
 test_reemit_skips_startup_sweeps_but_keeps_the_wake_drain() {
-  local rec root home fakebin full reemit
+  local rec root home fakebin full network_report reemit
   rec=$(new_world reemit)
   IFS='|' read -r root home fakebin <<EOF
 $rec
@@ -1902,11 +1904,15 @@ EOF
   append_wake "$home/state" signal task-r "done: queued after startup" || fail "seed wake failed"
 
   # A full startup reconciles the secondmate sweep and reports it.
-  full=$(run_session_start "$home" "$root" "$fakebin:$BASE_PATH")
-  assert_contains "$full" "SECONDMATE_LIVENESS" "the full startup fixture did not exercise a mutating sweep"
+  full=$(FM_FAKE_HARNESS_PID=$$ run_session_start "$home" "$root" "$fakebin:$BASE_PATH")
+  wait_for_network_stage "$home" "$root" \
+    || fail "the full startup fixture's deferred network stage never published"
+  network_report=$(network_stage_report "$home" "$root")
+  assert_contains "$network_report" "SECONDMATE_LIVENESS" \
+    "the full startup fixture did not exercise a mutating sweep"
 
   append_wake "$home/state" signal task-r "done: queued after the re-emit too" || fail "seed second wake failed"
-  reemit=$(FM_HOME="$home" FM_ROOT_OVERRIDE="$root" PATH="$fakebin:$BASE_PATH" \
+  reemit=$(FM_HOME="$home" FM_ROOT_OVERRIDE="$root" FM_FAKE_HARNESS_PID=$$ PATH="$fakebin:$BASE_PATH" \
     env -u CLAUDECODE -u PI_CODING_AGENT -u FM_PI_HARNESS -u GROK_AGENT \
     "$SESSION_START" --reemit)
 

--- a/tests/fm-sessionstart-hook-live-e2e.test.sh
+++ b/tests/fm-sessionstart-hook-live-e2e.test.sh
@@ -118,6 +118,7 @@ make_lab() {  # <harness> -> echoes lab dir
   ln -sf "$ROOT/bin/fm-startup-network.sh" "$lab/bin/fm-startup-network.sh"
   ln -sf "$ROOT/bin/fm-timeout-lib.sh" "$lab/bin/fm-timeout-lib.sh"
   ln -sf "$ROOT/bin/fm-wake-lib.sh" "$lab/bin/fm-wake-lib.sh"
+  ln -sf "$ROOT/bin/fm-session-lock-lib.sh" "$lab/bin/fm-session-lock-lib.sh"
   cat > "$lab/bin/fm-bootstrap.sh" <<'SH'
 #!/usr/bin/env bash
 # Outlives the hook on purpose: the marker can only appear if the worker was

--- a/tests/fm-sessionstart-hook-live-e2e.test.sh
+++ b/tests/fm-sessionstart-hook-live-e2e.test.sh
@@ -1,15 +1,20 @@
 #!/usr/bin/env bash
 # Opt-in live guard for the RUN-tier session-open adapters (Claude, Codex exec, Pi).
 #
-# Two facts in this area come from the vendor, not from Firstmate, so a stub can
-# only confirm the assumption already written into the stub:
+# Three facts in this area come from the vendor, not from Firstmate, so a stub
+# can only confirm the assumption already written into the stub:
 #
 #   (a) the harness tells the hook WHICH session open this is, well enough that
-#       a context-preserving reopen is never mistaken for a context reset, and
+#       a context-preserving reopen is never mistaken for a context reset,
 #   (b) hook stdout actually reaches model context on a context-RESET open
-#       (clear/compact), not only on a cold startup.
+#       (clear/compact), not only on a cold startup, and
+#   (c) a worker the hook detaches SURVIVES the hook returning. Session start
+#       moved every external-network call into such a worker
+#       (bin/fm-startup-network.sh), so a harness that reaps the hook's process
+#       tree would silently stop running the sweeps entirely. Whether it does is
+#       a vendor behavior no portable test can see.
 #
-# docs/sessionstart-nudge.md owns the routing those two facts feed, and
+# docs/sessionstart-nudge.md owns the routing facts (a) and (b) feed, and
 # tests/fm-sessionstart-nudge.test.sh pins that routing portably with real
 # processes and no harness. This guard covers only what CI cannot see.
 #
@@ -105,6 +110,25 @@ make_lab() {  # <harness> -> echoes lab dir
     chmod +x "$lab/bin/$stub"
   done
 
+  # The REAL deferred-network stage plus the two libraries it sources, so fact
+  # (c) is proven against the actual detach this ship relies on rather than a
+  # re-creation of it. Its bootstrap child is a stub: what is under test here is
+  # survival across the hook boundary, not the sweeps, which
+  # tests/fm-bootstrap.test.sh already owns.
+  ln -sf "$ROOT/bin/fm-startup-network.sh" "$lab/bin/fm-startup-network.sh"
+  ln -sf "$ROOT/bin/fm-timeout-lib.sh" "$lab/bin/fm-timeout-lib.sh"
+  ln -sf "$ROOT/bin/fm-wake-lib.sh" "$lab/bin/fm-wake-lib.sh"
+  cat > "$lab/bin/fm-bootstrap.sh" <<'SH'
+#!/usr/bin/env bash
+# Outlives the hook on purpose: the marker can only appear if the worker was
+# still running well after the harness finished with its session-open hook.
+set -u
+sleep 6
+printf 'detached worker survived the hook\n' > "${FM_LIVE_DETACH_MARKER:?}"
+exit 0
+SH
+  chmod +x "$lab/bin/fm-bootstrap.sh"
+
   cat > "$lab/bin/fm-sessionstart-run.sh" <<'SH'
 #!/usr/bin/env bash
 # Recorder standing in for the real wrapper: logs the source the harness
@@ -129,6 +153,10 @@ if [ -z "$source" ]; then
 fi
 [ -n "$source" ] || source=none
 printf '%s\n' "$source" >> "$record"
+# Exactly what bin/fm-session-start.sh does after taking the lock.
+if [ -n "${FM_LIVE_DETACH_MARKER:-}" ]; then
+  "$(dirname "$0")/fm-startup-network.sh" start --locked 0 --harvest-pid $$ >/dev/null 2>&1 || true
+fi
 printf 'FMHOOKTOKEN-%s-%s-%s\n' "$source" "$(grep -c . "$record" | tr -d ' ')" "${FM_LIVE_NONCE:?}"
 exit 0
 SH
@@ -159,13 +187,16 @@ probe_process_opens() {  # <harness> <version> <lab> <expect-resume> <cold-argv.
   local harness=$1 version=$2 lab=$3 expect_resume=$4
   shift 4
   local record="$lab/record" cold=() resume=() seen_sep=0 arg out source
+  local marker="$lab/detach-marker" waited
   for arg in "$@"; do
     if [ "$arg" = -- ] && [ "$seen_sep" -eq 0 ]; then seen_sep=1; continue; fi
     if [ "$seen_sep" -eq 0 ]; then cold+=("$arg"); else resume+=("$arg"); fi
   done
 
   : > "$record"
+  rm -f "$marker" "$lab/state/.startup-network."*
   out=$( cd "$lab" && FM_LIVE_RECORD="$record" FM_LIVE_NONCE="$LIVE_NONCE" FM_ROOT_OVERRIDE="$lab" FM_HOME="$lab" \
+    FM_LIVE_DETACH_MARKER="$marker" \
     "${cold[@]}" "$ASK" < /dev/null 2>&1 )
   source=$(head -n 1 "$record")
   [ -n "$source" ] \
@@ -177,6 +208,15 @@ probe_process_opens() {  # <harness> <version> <lab> <expect-resume> <cold-argv.
   printf '%s' "$out" | grep -Fq "FMHOOKTOKEN-$source-1-$LIVE_NONCE" \
     || { printf '# cold-open model reply: %s\n' "$out" >&2; fail "$harness $version: hook stdout did not reach model context on a cold open"; }
   pass "$harness $version: a cold open reports source '$source' and its hook stdout reaches model context"
+
+  # (c) The harness process is gone; the worker it detached must not be. The
+  # marker is written 6s after the hook returned, so it can only exist if the
+  # worker outlived the whole session-open boundary.
+  waited=0
+  while [ ! -s "$marker" ] && [ "$waited" -lt 30 ]; do sleep 1; waited=$((waited + 1)); done
+  [ -s "$marker" ] \
+    || fail "$harness $version: the session-open hook's detached worker did not survive the hook, so session start's deferred network checks would never run on this harness"
+  pass "$harness $version: a worker detached by the session-open hook outlives it, so the deferred network checks still run"
 
   : > "$record"
   ( cd "$lab" && FM_LIVE_RECORD="$record" FM_LIVE_NONCE="$LIVE_NONCE" FM_ROOT_OVERRIDE="$lab" FM_HOME="$lab" \

--- a/tests/fm-startup-network.test.sh
+++ b/tests/fm-startup-network.test.sh
@@ -8,8 +8,8 @@
 # to make deferral safe:
 #   - `start` returns immediately and does not hold the caller's stdout open,
 #     which is what would strand a session-open hook behind the worker
-#   - a live inline-print claim suppresses the wake, and no claim (or a dead one)
-#     produces it, so a result surfaces exactly once
+#   - a durable acknowledgement after harvest prints a finished result suppresses
+#     the wake, while an unacknowledged result always produces one
 #   - mutating sweeps are refused when the fleet lock no longer names the session
 #     that requested them, and the refusal is reported rather than silent
 #   - the aggregate bound turns a wedged sweep into an actionable line
@@ -124,38 +124,76 @@ EOF
   pass "fm-startup-network: start returns immediately and never holds the caller's stdout open"
 }
 
-# The claim handshake is what stops a result being both printed and queued. Both
-# directions are decided here, without racing a digest.
-test_a_live_claim_suppresses_the_wake_and_no_claim_produces_it() {
-  local rec home root log generation
+test_harvest_acknowledgement_suppresses_the_wake_and_no_claim_produces_it() {
+  local rec home root log claimant output waited=0 worker_pid
   rec=$(new_world claim-handshake)
   IFS='|' read -r home root log <<EOF
 $rec
 EOF
   printf '%s\n' $$ > "$home/state/.lock"
 
-  # A live claim: some session start is still composing and will print this.
-  FM_FAKE_BOOTSTRAP_LOG="$log" run_stage "$home" "$root" start --locked 0 --harvest-pid $$
+  sleep 10 &
+  claimant=$!
+  FM_SESSION_START_TIMEOUT=3 FM_FAKE_BOOTSTRAP_LOG="$log" FM_FAKE_BOOTSTRAP_OUT='acknowledged result' \
+    run_stage "$home" "$root" start --locked 0 --harvest-pid "$claimant"
   run_stage "$home" "$root" wait 30 >/dev/null || fail "the claimed worker never published"
+  worker_pid=$(sed -n 's/^pid=//p' "$home/state/.startup-network.status")
+  output=$(run_stage "$home" "$root" harvest --pid "$claimant")
+  assert_contains "$output" "acknowledged result" \
+    "harvest did not print the finished result it acknowledged"
+  [ -s "$home/state/.startup-network.delivered" ] \
+    || fail "harvest did not durably acknowledge the result it printed"
+  kill "$claimant" 2>/dev/null || true
+  wait "$claimant" 2>/dev/null || true
+  while kill -0 "$worker_pid" 2>/dev/null && [ "$waited" -lt 50 ]; do
+    sleep 0.1
+    waited=$((waited + 1))
+  done
+  ! kill -0 "$worker_pid" 2>/dev/null \
+    || fail "the worker did not settle after harvest acknowledged its result"
   [ ! -s "$home/state/.wake-queue" ] \
-    || fail "a result a live session start had claimed also queued a wake: $(cat "$home/state/.wake-queue")"
+    || fail "a result harvest acknowledged also queued a wake: $(cat "$home/state/.wake-queue")"
 
   # Harvest releases that claim, so the NEXT publication has nobody to print it.
-  run_stage "$home" "$root" harvest --pid $$ >/dev/null
   assert_absent "$home/state/.startup-network.claim" "harvest did not release its own claim"
   FM_FAKE_BOOTSTRAP_LOG="$log" run_stage "$home" "$root" run --locked 0
   assert_grep 'check	startup-network' "$home/state/.wake-queue" \
     "an unclaimed result never reached the wake queue"
 
-  # A claim whose session died is not a claim.
   : > "$home/state/.wake-queue"
-  generation=$(sed -n 's/^generation=//p' "$home/state/.startup-network.status")
-  printf '%s\t999999999\n' "$generation" > "$home/state/.startup-network.claim"
-  FM_FAKE_BOOTSTRAP_LOG="$log" run_stage "$home" "$root" run --locked 0
+  FM_FAKE_BOOTSTRAP_LOG="$log" \
+    run_stage "$home" "$root" start --locked 0 --harvest-pid 999999999
+  run_stage "$home" "$root" wait 30 >/dev/null || fail "the dead-claim worker never published"
   assert_grep 'check	startup-network' "$home/state/.wake-queue" \
     "a dead session's stale claim swallowed the result"
   assert_absent "$home/state/.startup-network.claim" "a dead claim was not reaped"
   pass "fm-startup-network: exactly one of the digest and the wake reports each result"
+}
+
+test_a_claimant_crash_after_publish_still_queues_the_wake() {
+  local rec home root log claimant waited=0
+  rec=$(new_world claimant-crash)
+  IFS='|' read -r home root log <<EOF
+$rec
+EOF
+  sleep 10 &
+  claimant=$!
+  FM_SESSION_START_TIMEOUT=4 FM_FAKE_BOOTSTRAP_LOG="$log" \
+    run_stage "$home" "$root" start --locked 0 --harvest-pid "$claimant"
+  run_stage "$home" "$root" wait 30 >/dev/null || fail "the crash-window worker never published"
+  kill -0 "$claimant" 2>/dev/null \
+    || fail "the claimant died before the worker published"
+  kill "$claimant" 2>/dev/null || true
+  wait "$claimant" 2>/dev/null || true
+  while [ ! -s "$home/state/.wake-queue" ] && [ "$waited" -lt 50 ]; do
+    sleep 0.1
+    waited=$((waited + 1))
+  done
+  assert_grep 'check	startup-network' "$home/state/.wake-queue" \
+    "a claimant crash after publication silently lost the result"
+  assert_absent "$home/state/.startup-network.delivered" \
+    "an unharvested result was recorded as delivered"
+  pass "fm-startup-network: a claimant crash after publication still surfaces the result"
 }
 
 # The worker outlives the command that launched it. If another session took the
@@ -189,7 +227,7 @@ EOF
 # The unbounded per-call network work is exactly what could wedge a startup. The
 # stage carries one aggregate bound, and hitting it is an actionable line.
 test_the_stage_bound_is_reported_not_swallowed() {
-  local rec home root log report
+  local rec home root log report waited=0
   rec=$(new_world stage-bound)
   IFS='|' read -r home root log <<EOF
 $rec
@@ -206,6 +244,10 @@ EOF
     "a wedged deferred stage was not reported: $report"
   assert_contains "$report" "fm-startup-network.sh run --locked 1" \
     "the timeout line did not say how to rerun the stage"
+  while [ ! -s "$home/state/.wake-queue" ] && [ "$waited" -lt 50 ]; do
+    sleep 0.1
+    waited=$((waited + 1))
+  done
   assert_grep 'check	startup-network' "$home/state/.wake-queue" \
     "a timed-out stage did not surface to the agent"
   pass "fm-startup-network: an aggregate bound turns a wedged sweep into an actionable line"
@@ -361,7 +403,8 @@ EOF
 }
 
 test_start_returns_without_holding_the_callers_stdout
-test_a_live_claim_suppresses_the_wake_and_no_claim_produces_it
+test_harvest_acknowledgement_suppresses_the_wake_and_no_claim_produces_it
+test_a_claimant_crash_after_publish_still_queues_the_wake
 test_mutating_sweeps_are_refused_when_the_lock_changed_hands
 test_the_stage_bound_is_reported_not_swallowed
 test_an_abandoned_run_reads_as_needing_a_rerun

--- a/tests/fm-startup-network.test.sh
+++ b/tests/fm-startup-network.test.sh
@@ -1,0 +1,255 @@
+#!/usr/bin/env bash
+# tests/fm-startup-network.test.sh - behavior tests for bin/fm-startup-network.sh,
+# the deferred network stage a session start launches instead of running its
+# network work on the blocking path.
+#
+# The session-start suite proves the digest no longer waits and that the deferred
+# sweeps still land. This suite pins the stage's own contract, whose whole job is
+# to make deferral safe:
+#   - `start` returns immediately and does not hold the caller's stdout open,
+#     which is what would strand a session-open hook behind the worker
+#   - a live inline-print claim suppresses the wake, and no claim (or a dead one)
+#     produces it, so a result surfaces exactly once
+#   - mutating sweeps are refused when the fleet lock no longer names the session
+#     that requested them, and the refusal is reported rather than silent
+#   - the aggregate bound turns a wedged sweep into an actionable line
+#   - an abandoned `running` record is reported as needing a rerun rather than
+#     staying "in progress" forever
+#   - single-flight: a second `start` never launches a competing worker
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+TMP_ROOT=$(fm_test_tmproot fm-startup-network-tests)
+FM_TEST_CLEANUP_DIRS+=("$TMP_ROOT")
+trap fm_test_cleanup EXIT
+
+# new_world <name>: an FM_HOME plus a fake code root whose bin/ is a real
+# firstmate bin/ except for fm-bootstrap.sh, which is replaced by a scriptable
+# stand-in. The stage's contract is about WHEN and WHETHER the network half runs
+# and how its result is published; bin/fm-bootstrap.sh's own behavior is owned by
+# tests/fm-bootstrap.test.sh, so pinning it here would duplicate that owner and
+# make these assertions depend on unrelated tool detection.
+new_world() {
+  local name=$1 w home root
+  w="$TMP_ROOT/$name"
+  home="$w/home"
+  root="$w/root"
+  mkdir -p "$home/state" "$root/bin"
+  for f in "$ROOT"/bin/*.sh; do
+    ln -s "$f" "$root/bin/$(basename "$f")"
+  done
+  rm -f "$root/bin/fm-bootstrap.sh"
+  cat > "$root/bin/fm-bootstrap.sh" <<'SH'
+#!/usr/bin/env bash
+# Scriptable stand-in: records how it was invoked, then behaves as the test asks.
+set -u
+printf 'network=%s detect_only=%s\n' \
+  "${FM_BOOTSTRAP_NETWORK:-all}" "${FM_BOOTSTRAP_DETECT_ONLY:-0}" \
+  >> "${FM_FAKE_BOOTSTRAP_LOG:?}"
+[ -z "${FM_FAKE_BOOTSTRAP_SLEEP:-}" ] || sleep "$FM_FAKE_BOOTSTRAP_SLEEP"
+[ -z "${FM_FAKE_BOOTSTRAP_OUT:-}" ] || printf '%s\n' "$FM_FAKE_BOOTSTRAP_OUT"
+exit "${FM_FAKE_BOOTSTRAP_RC:-0}"
+SH
+  chmod +x "$root/bin/fm-bootstrap.sh"
+  printf '%s|%s|%s\n' "$home" "$root" "$w/bootstrap.log"
+}
+
+# The detached worker records itself a moment after `start` returns - that gap is
+# the whole point of not blocking - so a test that wants to observe the worker
+# waits for its record rather than assuming instant publication.
+await_worker_record() {  # <home>
+  local home=$1 waited=0
+  while [ ! -s "$home/state/.startup-network.status" ] && [ "$waited" -lt 100 ]; do
+    sleep 0.1
+    waited=$((waited + 1))
+  done
+  [ -s "$home/state/.startup-network.status" ] || fail "the detached worker never recorded itself"
+}
+
+run_stage() {  # <home> <root> <args...>
+  local home=$1 root=$2
+  shift 2
+  FM_HOME="$home" FM_ROOT_OVERRIDE="$root" "$root/bin/fm-startup-network.sh" "$@"
+}
+
+# --- tests -------------------------------------------------------------------
+
+# `start` is called from inside a session-open hook whose stdout the harness
+# reads to EOF. A worker that inherited that pipe would hold the session open for
+# exactly as long as the network work it was supposed to get off the critical
+# path, so this asserts both halves: start returns fast, AND the pipe closes
+# while the worker is still running.
+test_start_returns_without_holding_the_callers_stdout() {
+  local rec home root log started elapsed
+  rec=$(new_world start-nonblocking)
+  IFS='|' read -r home root log <<EOF
+$rec
+EOF
+  printf '111111\n' > "$home/state/.lock"
+
+  started=$(date +%s)
+  # Command substitution reads to EOF, exactly like a hook harvesting hook output.
+  FM_FAKE_BOOTSTRAP_LOG="$log" FM_FAKE_BOOTSTRAP_SLEEP=10 \
+    run_stage "$home" "$root" start --locked 1 --harvest-pid $$ >/dev/null
+  elapsed=$(( $(date +%s) - started ))
+
+  [ "$elapsed" -lt 4 ] || fail "start blocked for ${elapsed}s behind a 10s worker"
+  await_worker_record "$home"
+  [ "$(run_stage "$home" "$root" report | head -1)" = "IN PROGRESS - the deferred network checks have not finished yet." ] \
+    || fail "the worker was not actually still running: $(run_stage "$home" "$root" report)"
+  run_stage "$home" "$root" wait 30 >/dev/null || fail "the worker never published"
+  assert_grep 'network=only' "$log" "the worker did not run bootstrap's network-only phase"
+  pass "fm-startup-network: start returns immediately and never holds the caller's stdout open"
+}
+
+# The claim handshake is what stops a result being both printed and queued. Both
+# directions are decided here, without racing a digest.
+test_a_live_claim_suppresses_the_wake_and_no_claim_produces_it() {
+  local rec home root log
+  rec=$(new_world claim-handshake)
+  IFS='|' read -r home root log <<EOF
+$rec
+EOF
+  printf '111111\n' > "$home/state/.lock"
+
+  # A live claim: some session start is still composing and will print this.
+  printf '%s\n' $$ > "$home/state/.startup-network.claim"
+  FM_FAKE_BOOTSTRAP_LOG="$log" run_stage "$home" "$root" run --locked 1 --lock-pid 111111
+  [ ! -s "$home/state/.wake-queue" ] \
+    || fail "a result a live session start had claimed also queued a wake: $(cat "$home/state/.wake-queue")"
+
+  # Harvest releases that claim, so the NEXT publication has nobody to print it.
+  run_stage "$home" "$root" harvest --pid $$ >/dev/null
+  assert_absent "$home/state/.startup-network.claim" "harvest did not release its own claim"
+  FM_FAKE_BOOTSTRAP_LOG="$log" run_stage "$home" "$root" run --locked 1 --lock-pid 111111
+  assert_grep 'check	startup-network' "$home/state/.wake-queue" \
+    "an unclaimed result never reached the wake queue"
+
+  # A claim whose session died is not a claim.
+  : > "$home/state/.wake-queue"
+  printf '999999999\n' > "$home/state/.startup-network.claim"
+  FM_FAKE_BOOTSTRAP_LOG="$log" run_stage "$home" "$root" run --locked 1 --lock-pid 111111
+  assert_grep 'check	startup-network' "$home/state/.wake-queue" \
+    "a dead session's stale claim swallowed the result"
+  assert_absent "$home/state/.startup-network.claim" "a dead claim was not reaped"
+  pass "fm-startup-network: exactly one of the digest and the wake reports each result"
+}
+
+# The worker outlives the command that launched it. If another session took the
+# lock meanwhile, running the mutating sweeps would sweep underneath that
+# session, so they are refused - and the refusal is reported, not silent.
+test_mutating_sweeps_are_refused_when_the_lock_changed_hands() {
+  local rec home root log report
+  rec=$(new_world lock-changed)
+  IFS='|' read -r home root log <<EOF
+$rec
+EOF
+  printf '222222\n' > "$home/state/.lock"
+
+  FM_FAKE_BOOTSTRAP_LOG="$log" run_stage "$home" "$root" run --locked 1 --lock-pid 111111
+  assert_grep 'network=only detect_only=1' "$log" \
+    "the worker ran mutating sweeps for a lock it no longer held"
+  report=$(run_stage "$home" "$root" report)
+  assert_contains "$report" "NETWORK_CHECKS: the fleet lock was no longer held" \
+    "the downgrade to a read-only probe was not reported"
+
+  # The same worker with the lock intact does run them.
+  : > "$log"
+  FM_FAKE_BOOTSTRAP_LOG="$log" run_stage "$home" "$root" run --locked 1 --lock-pid 222222
+  assert_grep 'network=only detect_only=0' "$log" \
+    "the worker refused sweeps for the very session that still holds the lock"
+  pass "fm-startup-network: mutating sweeps need the lock still to name the session that asked"
+}
+
+# The unbounded per-call network work is exactly what could wedge a startup. The
+# stage carries one aggregate bound, and hitting it is an actionable line.
+test_the_stage_bound_is_reported_not_swallowed() {
+  local rec home root log report
+  rec=$(new_world stage-bound)
+  IFS='|' read -r home root log <<EOF
+$rec
+EOF
+  printf '111111\n' > "$home/state/.lock"
+
+  FM_FAKE_BOOTSTRAP_LOG="$log" FM_FAKE_BOOTSTRAP_SLEEP=20 FM_STARTUP_NETWORK_TIMEOUT=2 \
+    run_stage "$home" "$root" run --locked 1 --lock-pid 111111
+  report=$(run_stage "$home" "$root" report)
+  assert_contains "$report" "NETWORK_CHECKS: hit the 2s bound before finishing" \
+    "a wedged deferred stage was not reported: $report"
+  assert_contains "$report" "fm-startup-network.sh run --locked 1" \
+    "the timeout line did not say how to rerun the stage"
+  assert_grep 'check	startup-network' "$home/state/.wake-queue" \
+    "a timed-out stage did not surface to the agent"
+  pass "fm-startup-network: an aggregate bound turns a wedged sweep into an actionable line"
+}
+
+# A digest that hits its own runtime bound kills its process group, taking the
+# worker with it. The leftover `running` record must read as work to redo, not as
+# work still in flight.
+test_an_abandoned_run_reads_as_needing_a_rerun() {
+  local rec home root log report
+  rec=$(new_world abandoned)
+  IFS='|' read -r home root log <<EOF
+$rec
+EOF
+  cat > "$home/state/.startup-network.status" <<EOF
+state=running
+pid=999999999
+started=$(date +%s)
+locked=1
+phases=probe,sweeps
+EOF
+
+  report=$(run_stage "$home" "$root" report)
+  assert_contains "$report" "NETWORK_CHECKS: the deferred check worker stopped before publishing" \
+    "an abandoned run still read as in progress: $report"
+  assert_contains "$report" "dead-secondmate relaunch" \
+    "the abandoned run did not name the checks that never completed"
+
+  # A record older than the whole aggregate bound is abandoned even when its pid
+  # happens to be alive again, so "in progress" can never become permanent.
+  cat > "$home/state/.startup-network.status" <<EOF
+state=running
+pid=$$
+started=$(( $(date +%s) - 400 ))
+locked=1
+phases=probe,sweeps
+EOF
+  assert_contains "$(FM_STARTUP_NETWORK_TIMEOUT=10 run_stage "$home" "$root" report)" \
+    "NETWORK_CHECKS: the deferred check worker stopped before publishing" \
+    "a record that outlived the stage bound still read as in progress"
+  pass "fm-startup-network: an abandoned run reports as needing a rerun, never as in progress forever"
+}
+
+# Two session opens in quick succession must not run the same mutating sweeps
+# concurrently against each other.
+test_start_is_single_flight() {
+  local rec home root log runs
+  rec=$(new_world single-flight)
+  IFS='|' read -r home root log <<EOF
+$rec
+EOF
+  printf '111111\n' > "$home/state/.lock"
+
+  FM_FAKE_BOOTSTRAP_LOG="$log" FM_FAKE_BOOTSTRAP_SLEEP=6 \
+    run_stage "$home" "$root" start --locked 1 --harvest-pid $$
+  await_worker_record "$home"
+  FM_FAKE_BOOTSTRAP_LOG="$log" FM_FAKE_BOOTSTRAP_SLEEP=6 \
+    run_stage "$home" "$root" start --locked 1 --harvest-pid $$
+  run_stage "$home" "$root" wait 40 >/dev/null || fail "the worker never published"
+
+  runs=$(grep -c 'network=only' "$log" || true)
+  [ "$runs" -eq 1 ] || fail "a second start launched a competing worker ($runs runs): $(cat "$log")"
+  pass "fm-startup-network: a second start never launches a competing worker"
+}
+
+test_start_returns_without_holding_the_callers_stdout
+test_a_live_claim_suppresses_the_wake_and_no_claim_produces_it
+test_mutating_sweeps_are_refused_when_the_lock_changed_hands
+test_the_stage_bound_is_reported_not_swallowed
+test_an_abandoned_run_reads_as_needing_a_rerun
+test_start_is_single_flight
+
+echo "# fm-startup-network.test.sh: all assertions passed"

--- a/tests/fm-startup-network.test.sh
+++ b/tests/fm-startup-network.test.sh
@@ -53,6 +53,25 @@ printf 'network=%s detect_only=%s\n' \
 exit "${FM_FAKE_BOOTSTRAP_RC:-0}"
 SH
   chmod +x "$root/bin/fm-bootstrap.sh"
+  cat > "$root/bin/ps" <<'SH'
+#!/usr/bin/env bash
+pid=
+previous=
+for argument in "$@"; do
+  [ "$previous" = -p ] && pid=$argument
+  previous=$argument
+done
+if [ "$pid" = "${FM_FAKE_HARNESS_PID:-}" ]; then
+  case "$*" in
+    *comm=*) printf '/usr/local/bin/claude\n' ;;
+    *args=*) printf 'claude\n' ;;
+    *ppid=*) /bin/ps -o ppid= -p "$pid" ;;
+  esac
+else
+  /bin/ps "$@"
+fi
+SH
+  chmod +x "$root/bin/ps"
   printf '%s|%s|%s\n' "$home" "$root" "$w/bootstrap.log"
 }
 
@@ -71,7 +90,8 @@ await_worker_record() {  # <home>
 run_stage() {  # <home> <root> <args...>
   local home=$1 root=$2
   shift 2
-  FM_HOME="$home" FM_ROOT_OVERRIDE="$root" "$root/bin/fm-startup-network.sh" "$@"
+  PATH="$root/bin:$PATH" FM_FAKE_HARNESS_PID="${FM_FAKE_HARNESS_PID_OVERRIDE:-$$}" \
+    FM_HOME="$home" FM_ROOT_OVERRIDE="$root" "$root/bin/fm-startup-network.sh" "$@"
 }
 
 # --- tests -------------------------------------------------------------------
@@ -87,7 +107,7 @@ test_start_returns_without_holding_the_callers_stdout() {
   IFS='|' read -r home root log <<EOF
 $rec
 EOF
-  printf '111111\n' > "$home/state/.lock"
+  printf '%s\n' $$ > "$home/state/.lock"
 
   started=$(date +%s)
   # Command substitution reads to EOF, exactly like a hook harvesting hook output.
@@ -107,30 +127,31 @@ EOF
 # The claim handshake is what stops a result being both printed and queued. Both
 # directions are decided here, without racing a digest.
 test_a_live_claim_suppresses_the_wake_and_no_claim_produces_it() {
-  local rec home root log
+  local rec home root log generation
   rec=$(new_world claim-handshake)
   IFS='|' read -r home root log <<EOF
 $rec
 EOF
-  printf '111111\n' > "$home/state/.lock"
+  printf '%s\n' $$ > "$home/state/.lock"
 
   # A live claim: some session start is still composing and will print this.
-  printf '%s\n' $$ > "$home/state/.startup-network.claim"
-  FM_FAKE_BOOTSTRAP_LOG="$log" run_stage "$home" "$root" run --locked 1 --lock-pid 111111
+  FM_FAKE_BOOTSTRAP_LOG="$log" run_stage "$home" "$root" start --locked 0 --harvest-pid $$
+  run_stage "$home" "$root" wait 30 >/dev/null || fail "the claimed worker never published"
   [ ! -s "$home/state/.wake-queue" ] \
     || fail "a result a live session start had claimed also queued a wake: $(cat "$home/state/.wake-queue")"
 
   # Harvest releases that claim, so the NEXT publication has nobody to print it.
   run_stage "$home" "$root" harvest --pid $$ >/dev/null
   assert_absent "$home/state/.startup-network.claim" "harvest did not release its own claim"
-  FM_FAKE_BOOTSTRAP_LOG="$log" run_stage "$home" "$root" run --locked 1 --lock-pid 111111
+  FM_FAKE_BOOTSTRAP_LOG="$log" run_stage "$home" "$root" run --locked 0
   assert_grep 'check	startup-network' "$home/state/.wake-queue" \
     "an unclaimed result never reached the wake queue"
 
   # A claim whose session died is not a claim.
   : > "$home/state/.wake-queue"
-  printf '999999999\n' > "$home/state/.startup-network.claim"
-  FM_FAKE_BOOTSTRAP_LOG="$log" run_stage "$home" "$root" run --locked 1 --lock-pid 111111
+  generation=$(sed -n 's/^generation=//p' "$home/state/.startup-network.status")
+  printf '%s\t999999999\n' "$generation" > "$home/state/.startup-network.claim"
+  FM_FAKE_BOOTSTRAP_LOG="$log" run_stage "$home" "$root" run --locked 0
   assert_grep 'check	startup-network' "$home/state/.wake-queue" \
     "a dead session's stale claim swallowed the result"
   assert_absent "$home/state/.startup-network.claim" "a dead claim was not reaped"
@@ -155,12 +176,14 @@ EOF
   assert_contains "$report" "NETWORK_CHECKS: the fleet lock was no longer held" \
     "the downgrade to a read-only probe was not reported"
 
-  # The same worker with the lock intact does run them.
+  # A detached start captures the lock itself and may run the mutating phase.
   : > "$log"
-  FM_FAKE_BOOTSTRAP_LOG="$log" run_stage "$home" "$root" run --locked 1 --lock-pid 222222
+  printf '%s\n' $$ > "$home/state/.lock"
+  FM_FAKE_BOOTSTRAP_LOG="$log" run_stage "$home" "$root" start --locked 1 --harvest-pid $$
+  run_stage "$home" "$root" wait 30 >/dev/null || fail "the lock-authorized worker never published"
   assert_grep 'network=only detect_only=0' "$log" \
     "the worker refused sweeps for the very session that still holds the lock"
-  pass "fm-startup-network: mutating sweeps need the lock still to name the session that asked"
+  pass "fm-startup-network: manual callers cannot forge mutation authority"
 }
 
 # The unbounded per-call network work is exactly what could wedge a startup. The
@@ -171,10 +194,13 @@ test_the_stage_bound_is_reported_not_swallowed() {
   IFS='|' read -r home root log <<EOF
 $rec
 EOF
-  printf '111111\n' > "$home/state/.lock"
+  printf '%s\n' $$ > "$home/state/.lock"
 
   FM_FAKE_BOOTSTRAP_LOG="$log" FM_FAKE_BOOTSTRAP_SLEEP=20 FM_STARTUP_NETWORK_TIMEOUT=2 \
-    run_stage "$home" "$root" run --locked 1 --lock-pid 111111
+    run_stage "$home" "$root" start --locked 1 --harvest-pid $$
+  run_stage "$home" "$root" harvest --pid $$ >/dev/null
+  FM_STARTUP_NETWORK_TIMEOUT=2 run_stage "$home" "$root" wait 10 >/dev/null \
+    || fail "the bounded worker never settled"
   report=$(run_stage "$home" "$root" report)
   assert_contains "$report" "NETWORK_CHECKS: hit the 2s bound before finishing" \
     "a wedged deferred stage was not reported: $report"
@@ -231,7 +257,7 @@ test_start_is_single_flight() {
   IFS='|' read -r home root log <<EOF
 $rec
 EOF
-  printf '111111\n' > "$home/state/.lock"
+  printf '%s\n' $$ > "$home/state/.lock"
 
   FM_FAKE_BOOTSTRAP_LOG="$log" FM_FAKE_BOOTSTRAP_SLEEP=6 \
     run_stage "$home" "$root" start --locked 1 --harvest-pid $$
@@ -245,11 +271,65 @@ EOF
   pass "fm-startup-network: a second start never launches a competing worker"
 }
 
+test_start_reserves_its_generation_before_returning() {
+  local rec home root log report
+  rec=$(new_world generation-reservation)
+  IFS='|' read -r home root log <<EOF
+$rec
+EOF
+  cat > "$home/state/.startup-network.status" <<EOF
+state=done
+pid=999999999
+started=1
+finished=2
+rc=0
+locked=0
+phases=probe
+generation=old
+lock_pid=
+EOF
+  printf 'old result\n' > "$home/state/.startup-network.report"
+
+  FM_FAKE_BOOTSTRAP_LOG="$log" FM_FAKE_BOOTSTRAP_SLEEP=5 \
+    run_stage "$home" "$root" start --locked 0 --harvest-pid $$
+  report=$(run_stage "$home" "$root" harvest --pid $$)
+  assert_contains "$report" "IN PROGRESS" \
+    "harvest exposed the previous generation after a new start returned: $report"
+  assert_not_contains "$report" "old result" \
+    "harvest printed a stale generation's report"
+  run_stage "$home" "$root" wait 30 >/dev/null || fail "the reserved generation never published"
+  pass "fm-startup-network: start atomically reserves the generation harvest observes"
+}
+
+test_new_lock_owner_does_not_reuse_the_previous_owners_worker() {
+  local rec home root log generation_one generation_two next_owner
+  rec=$(new_world owner-handoff)
+  IFS='|' read -r home root log <<EOF
+$rec
+EOF
+  printf '%s\n' $$ > "$home/state/.lock"
+  FM_FAKE_BOOTSTRAP_LOG="$log" FM_FAKE_BOOTSTRAP_SLEEP=6 \
+    run_stage "$home" "$root" start --locked 1 --harvest-pid $$
+  generation_one=$(sed -n 's/^generation=//p' "$home/state/.startup-network.status")
+
+  next_owner=$(/bin/ps -o ppid= -p $$ | tr -d ' ')
+  printf '%s\n' "$next_owner" > "$home/state/.lock"
+  FM_FAKE_HARNESS_PID_OVERRIDE="$next_owner" FM_FAKE_BOOTSTRAP_LOG="$log" FM_FAKE_BOOTSTRAP_SLEEP=1 \
+    run_stage "$home" "$root" start --locked 1 --harvest-pid $$
+  generation_two=$(sed -n 's/^generation=//p' "$home/state/.startup-network.status")
+  [ "$generation_one" != "$generation_two" ] \
+    || fail "the new lock owner reused the previous owner's generation"
+  run_stage "$home" "$root" wait 30 >/dev/null || fail "the new owner's generation never published"
+  pass "fm-startup-network: a new lock owner gets a distinct worker generation"
+}
+
 test_start_returns_without_holding_the_callers_stdout
 test_a_live_claim_suppresses_the_wake_and_no_claim_produces_it
 test_mutating_sweeps_are_refused_when_the_lock_changed_hands
 test_the_stage_bound_is_reported_not_swallowed
 test_an_abandoned_run_reads_as_needing_a_rerun
 test_start_is_single_flight
+test_start_reserves_its_generation_before_returning
+test_new_lock_owner_does_not_reuse_the_previous_owners_worker
 
 echo "# fm-startup-network.test.sh: all assertions passed"

--- a/tests/fm-startup-network.test.sh
+++ b/tests/fm-startup-network.test.sh
@@ -94,6 +94,16 @@ run_stage() {  # <home> <root> <args...>
     FM_HOME="$home" FM_ROOT_OVERRIDE="$root" "$root/bin/fm-startup-network.sh" "$@"
 }
 
+wait_for_startup_network_wake() {  # <home> [tenths]
+  local home=$1 limit=${2:-50} waited=0
+  while ! grep -Fq $'check\tstartup-network' "$home/state/.wake-queue" 2>/dev/null \
+    && [ "$waited" -lt "$limit" ]; do
+    sleep 0.1
+    waited=$((waited + 1))
+  done
+  grep -Fq $'check\tstartup-network' "$home/state/.wake-queue" 2>/dev/null
+}
+
 # --- tests -------------------------------------------------------------------
 
 # `start` is called from inside a session-open hook whose stdout the harness
@@ -164,6 +174,7 @@ EOF
   FM_FAKE_BOOTSTRAP_LOG="$log" \
     run_stage "$home" "$root" start --locked 0 --harvest-pid 999999999
   run_stage "$home" "$root" wait 30 >/dev/null || fail "the dead-claim worker never published"
+  wait_for_startup_network_wake "$home" || fail "the dead-claim worker never settled delivery"
   assert_grep 'check	startup-network' "$home/state/.wake-queue" \
     "a dead session's stale claim swallowed the result"
   assert_absent "$home/state/.startup-network.claim" "a dead claim was not reaped"
@@ -171,7 +182,7 @@ EOF
 }
 
 test_a_claimant_crash_after_publish_still_queues_the_wake() {
-  local rec home root log claimant waited=0
+  local rec home root log claimant
   rec=$(new_world claimant-crash)
   IFS='|' read -r home root log <<EOF
 $rec
@@ -185,10 +196,7 @@ EOF
     || fail "the claimant died before the worker published"
   kill "$claimant" 2>/dev/null || true
   wait "$claimant" 2>/dev/null || true
-  while [ ! -s "$home/state/.wake-queue" ] && [ "$waited" -lt 50 ]; do
-    sleep 0.1
-    waited=$((waited + 1))
-  done
+  wait_for_startup_network_wake "$home" || fail "the crash-window worker never settled delivery"
   assert_grep 'check	startup-network' "$home/state/.wake-queue" \
     "a claimant crash after publication silently lost the result"
   assert_absent "$home/state/.startup-network.delivered" \
@@ -227,7 +235,7 @@ EOF
 # The unbounded per-call network work is exactly what could wedge a startup. The
 # stage carries one aggregate bound, and hitting it is an actionable line.
 test_the_stage_bound_is_reported_not_swallowed() {
-  local rec home root log report waited=0
+  local rec home root log report
   rec=$(new_world stage-bound)
   IFS='|' read -r home root log <<EOF
 $rec
@@ -244,10 +252,7 @@ EOF
     "a wedged deferred stage was not reported: $report"
   assert_contains "$report" "fm-startup-network.sh run --locked 1" \
     "the timeout line did not say how to rerun the stage"
-  while [ ! -s "$home/state/.wake-queue" ] && [ "$waited" -lt 50 ]; do
-    sleep 0.1
-    waited=$((waited + 1))
-  done
+  wait_for_startup_network_wake "$home" || fail "the timed-out worker never settled delivery"
   assert_grep 'check	startup-network' "$home/state/.wake-queue" \
     "a timed-out stage did not surface to the agent"
   pass "fm-startup-network: an aggregate bound turns a wedged sweep into an actionable line"
@@ -366,7 +371,7 @@ EOF
 }
 
 test_lock_takeover_stays_read_only_while_a_sweep_holds_the_lease() {
-  local rec home root log next_owner out rc started elapsed waited=0
+  local rec home root log next_owner new_owner out rc started elapsed waited=0
   rec=$(new_world sweep-lease)
   IFS='|' read -r home root log <<EOF
 $rec
@@ -394,11 +399,13 @@ EOF
     || fail "the lease-blocked takeover replaced the prior owner"
 
   run_stage "$home" "$root" wait 30 >/dev/null || fail "the leased sweep never settled"
-  PATH="$root/bin:$PATH" FM_FAKE_HARNESS_PID="$next_owner" \
-    FM_HOME="$home" FM_ROOT_OVERRIDE="$root" "$root/bin/fm-lock.sh" >/dev/null \
+  out=$(PATH="$root/bin:$PATH" FM_FAKE_HARNESS_PID="$next_owner" \
+    FM_HOME="$home" FM_ROOT_OVERRIDE="$root" "$root/bin/fm-lock.sh" 2>&1) \
     || fail "lock takeover still failed after the sweep released its lease"
-  [ "$(cat "$home/state/.lock")" = "$next_owner" ] \
-    || fail "the new harness did not own the lock after lease release"
+  new_owner=$(cat "$home/state/.lock")
+  assert_contains "$out" "lock acquired: harness pid $new_owner" \
+    "the fleet lock did not record the harness owner reported by acquisition"
+  [ "$new_owner" != "$$" ] || fail "the prior harness still owned the lock after takeover"
   pass "fm-startup-network: fleet-lock takeover cannot overlap a mutating sweep"
 }
 

--- a/tests/fm-startup-network.test.sh
+++ b/tests/fm-startup-network.test.sh
@@ -87,6 +87,20 @@ await_worker_record() {  # <home>
   [ -s "$home/state/.startup-network.status" ] || fail "the detached worker never recorded itself"
 }
 
+test_wait_fails_without_a_published_stage() {
+  local rec home root log
+  rec=$(new_world wait-without-stage)
+  IFS='|' read -r home root log <<EOF
+$rec
+EOF
+
+  if run_stage "$home" "$root" wait 1 >/dev/null; then
+    fail "wait reported success even though no deferred stage had published"
+  fi
+
+  pass "fm-startup-network: wait fails when no deferred stage publishes before its deadline"
+}
+
 run_stage() {  # <home> <root> <args...>
   local home=$1 root=$2
   shift 2
@@ -258,9 +272,8 @@ EOF
   pass "fm-startup-network: an aggregate bound turns a wedged sweep into an actionable line"
 }
 
-# A digest that hits its own runtime bound kills its process group, taking the
-# worker with it. The leftover `running` record must read as work to redo, not as
-# work still in flight.
+# A worker killed before publication leaves a `running` record behind.
+# That record must read as work to redo, not as work still in flight.
 test_an_abandoned_run_reads_as_needing_a_rerun() {
   local rec home root log report
   rec=$(new_world abandoned)
@@ -409,6 +422,7 @@ EOF
   pass "fm-startup-network: fleet-lock takeover cannot overlap a mutating sweep"
 }
 
+test_wait_fails_without_a_published_stage
 test_start_returns_without_holding_the_callers_stdout
 test_harvest_acknowledgement_suppresses_the_wake_and_no_claim_produces_it
 test_a_claimant_crash_after_publish_still_queues_the_wake

--- a/tests/fm-startup-network.test.sh
+++ b/tests/fm-startup-network.test.sh
@@ -323,6 +323,43 @@ EOF
   pass "fm-startup-network: a new lock owner gets a distinct worker generation"
 }
 
+test_lock_takeover_stays_read_only_while_a_sweep_holds_the_lease() {
+  local rec home root log next_owner out rc started elapsed waited=0
+  rec=$(new_world sweep-lease)
+  IFS='|' read -r home root log <<EOF
+$rec
+EOF
+  printf '%s\n' $$ > "$home/state/.lock"
+  FM_FAKE_BOOTSTRAP_LOG="$log" FM_FAKE_BOOTSTRAP_SLEEP=6 \
+    run_stage "$home" "$root" start --locked 1 --harvest-pid $$
+  while [ ! -s "$log" ] && [ "$waited" -lt 50 ]; do
+    sleep 0.1
+    waited=$((waited + 1))
+  done
+  [ -s "$log" ] || fail "the mutating sweep never started"
+
+  next_owner=$(/bin/ps -o ppid= -p $$ | tr -d ' ')
+  started=$(date +%s)
+  rc=0
+  out=$(PATH="$root/bin:$PATH" FM_FAKE_HARNESS_PID="$next_owner" \
+    FM_HOME="$home" FM_ROOT_OVERRIDE="$root" "$root/bin/fm-lock.sh" 2>&1) || rc=$?
+  elapsed=$(( $(date +%s) - started ))
+  [ "$rc" -ne 0 ] || fail "lock takeover succeeded while the prior sweep was mutating"
+  [ "$elapsed" -lt 4 ] || fail "lock takeover blocked ${elapsed}s behind deferred network work"
+  assert_contains "$out" "operate read-only" \
+    "a lease-blocked takeover did not fail closed to read-only: $out"
+  [ "$(cat "$home/state/.lock")" = "$$" ] \
+    || fail "the lease-blocked takeover replaced the prior owner"
+
+  run_stage "$home" "$root" wait 30 >/dev/null || fail "the leased sweep never settled"
+  PATH="$root/bin:$PATH" FM_FAKE_HARNESS_PID="$next_owner" \
+    FM_HOME="$home" FM_ROOT_OVERRIDE="$root" "$root/bin/fm-lock.sh" >/dev/null \
+    || fail "lock takeover still failed after the sweep released its lease"
+  [ "$(cat "$home/state/.lock")" = "$next_owner" ] \
+    || fail "the new harness did not own the lock after lease release"
+  pass "fm-startup-network: fleet-lock takeover cannot overlap a mutating sweep"
+}
+
 test_start_returns_without_holding_the_callers_stdout
 test_a_live_claim_suppresses_the_wake_and_no_claim_produces_it
 test_mutating_sweeps_are_refused_when_the_lock_changed_hands
@@ -331,5 +368,6 @@ test_an_abandoned_run_reads_as_needing_a_rerun
 test_start_is_single_flight
 test_start_reserves_its_generation_before_returning
 test_new_lock_owner_does_not_reuse_the_previous_owners_worker
+test_lock_takeover_stays_read_only_while_a_sweep_holds_the_lease
 
 echo "# fm-startup-network.test.sh: all assertions passed"


### PR DESCRIPTION
## Intent

Make firstmate's session start have ZERO synchronous external-network dependencies so it becomes near-instant: only local file reads before the digest prints. This is firstmate's shared, tracked material and it is design-heavy, so every safety guarantee must be preserved while the network work moves off the blocking path. Scope was deliberately one coherent ship on bin/fm-session-start.sh plus bin/fm-bootstrap.sh, driven by a completed latency audit (data/fm-sessionstart-latency-audit-s1/report.md).

Part A: dedupe the tasks-axi calls. Session start probed tasks-axi for compatibility twice and invoked it ~10 times per startup with 3 literal duplicates. Fetch the verdict once and reuse it, collapsing the duplicates without losing any information the digest needs.

Part B: move ALL external-network work OFF the synchronous critical path. The digest must print from local state alone with no network call in the blocking path. The network work must still RUN and its safety function must be preserved, but AFTER the digest, in a background/deferred/on-demand stage while the session holds the lock, surfacing anything actionable back to the session (a follow-up wake, or a status the session picks up on its next turn). The deferral had to be designed per-dependency, preserving each sweep's own guarantee: dead-secondmate relaunch (secondmate liveness), clone sync (fleet-sync), handoff retry, and remote endpoint liveness reads.

An explicit honesty gate governed the work: if any single network dependency genuinely could not move off the critical path without losing a real safety guarantee, the instruction was to STOP and report that as the honest answer rather than drop or weaken a guarantee to hit the speed goal or hand-wave a deferral that reopens a race. A needs-decision naming the exact dependency and the exact guarantee lost was an explicitly acceptable deliverable. It turned out not to be needed: all four moved with their guarantees intact, and that conclusion is what the design below defends.

Acceptance criteria: the digest prints with no synchronous external-network call in the blocking path, verified EMPIRICALLY with an unreachable/slow remote (startup still near-instant, prints the local digest, and the network sweeps run AFTER and surface their results with safety guarantees intact); each deferred sweep still performs its safety function, proven to still happen just off the blocking path; tasks-axi is fetched once and reused; behavioral tests through the executable interface (e.g. a stubbed slow/unreachable remote proving near-instant startup plus deferred sweep execution); bin/fm-lint.sh clean.

Constraint accepted at intake: do NOT edit bin/fm-wake-drain.sh or the OPEN DECISIONS fold - a separate in-flight ship owns those files - and let ordinary rebases reconcile.

The change had to follow firstmate-coding-guidelines because it is firstmate shared tracked material and startup/supervision infrastructure at the highest bar: deterministic and idempotent enforcement rather than agent memory, the one-owner rule for contracts, tests that exercise an executable interface instead of asserting implementation source text, shellcheck-clean via bin/fm-lint.sh, one sentence per line in tracked Markdown, plain dash never an em dash, and no agent co-author on the commit. It also required the harness-dependent-check discipline: a fact that comes from a vendor needs a real end-to-end proof, a portable regression, and a dated maintainer-verification record.

Design decisions and tradeoffs made along the way that a reviewer reading only the diff would not know:

1. Deferral mechanism. A new bin/fm-startup-network.sh owns only the deferral mechanics; bin/fm-bootstrap.sh remains the single owner of every sweep and still runs all of them, through a new FM_BOOTSTRAP_NETWORK phase split (all/skip/only) whose skip and only halves are asserted to be a true PARTITION of the unsplit run. An unrecognized value resolves to 'all' on purpose so a typo can never silently drop a safety sweep. The worker is started right after the lock so it runs concurrently with the whole digest, and the digest harvests it at a new NETWORK CHECKS stage placed after FLEET STATE and before CONTEXT - deliberately not last, because these lines are actionable and the section after it is the curated memory a truncated tail is meant to sacrifice first.

2. Why the later run is safe, which is the core of the honesty answer. Three properties: the sweeps are idempotent DETECTORS so a lost report loses no finding (the next run re-derives the same dead secondmate, stuck clone, undelivered handoff); the result is durable and ALWAYS surfaces, either inline in the digest or as a 'check: startup-network' wake, decided by a claim handshake under a shared lock so exactly one path reports it and a printed result never also interrupts supervision with a redundant wake; and the worker re-verifies mutation authority before sweeping.

3. The mutation-authority check compares the fleet-lock VALUE against the pid captured when the worker was launched, rather than requiring that pid to be alive. That was a deliberate choice: the hazard being closed is a second session sweeping concurrently, and taking the lock is exactly what rewrites the value (fm-lock.sh overwrites a dead holder's pid), so an unchanged value proves nobody else owns the sweeps. Requiring liveness would refuse to finish work nobody has claimed, and the sweeps are idempotent, so finishing is strictly better than abandoning.

4. The worker runs in its OWN process group (monitor mode) with nohup and stdio closed to /dev/null. Each closes a different failure: the closed stdio stops the worker holding the session-open hook's stdout pipe open and stranding session initialization; the separate process group stops the digest's own runtime bound (which terminates its whole process group) from killing the worker AND, worse, orphaning the bootstrap child it had already launched into a separate group, which would leave unbounded network work running with nothing left to bound it.

5. The whole stage carries one aggregate bound (FM_STARTUP_NETWORK_TIMEOUT, default 120s), replacing the per-call unboundedness that could previously wedge a startup. Hitting it is an actionable NETWORK_CHECKS line, never silence. An abandoned 'running' record (killed worker) reads as needing a rerun rather than staying 'in progress' forever, proven two ways so a reused pid cannot make it lie.

6. gh auth status was ALSO deferred even though the brief's enumeration did not list it, because it is genuinely a network call in the blocking path and the acceptance criterion says zero. Its guarantee ('do not dispatch until GitHub authentication is good') degrades in a stated, bounded way: the verdict arrives seconds later, the digest names it by name as NOT yet confirmed while pending, and it lands inline or as a wake. A relevant discovery: with the network blocked, gh auth status reports 'the token is invalid' and exits non-zero, so the old synchronous probe was already producing a FALSE NEEDS_GH_AUTH in exactly the case that made it slow. That is now documented in the bootstrap-diagnostics skill.

7. A read-only (lock-refused) session deliberately runs no network stage at all and says so explicitly in the digest, rather than writing shared state it has no authority for or racing another session's report. The justification is that such a session must not spawn, steer, or merge anyway, so it has no action a GitHub-auth verdict would gate. --reemit runs the read-only probe only, matching its existing rule that it never repeats the sweeps its own startup already ran.

8. A relaunch performed by the deferred pass is now ALWAYS reported, where previously it was silent unless FM_BOOTSTRAP_VERBOSE_FACTS=1. That is a deliberate contract change and it is load-bearing: the digest that printed the now-superseded endpoint record is already out, so silence would leave a stale record looking authoritative. The report also tells the reader to re-read any record its lines name.

9. Deliberate scope exclusion: the axi-family version-floor probes (lavish-axi, gh-axi, chrome-devtools-axi, quota-axi) were NOT touched. They are local module-load cost, not network, and the audit already filed them as a separate unit (R1). Measured: they are ~1.2s of the ~1.95s residual on a healthy path, so 'near-instant' for the ordinary case still needs that separate ship. This was reported rather than silently folded in.

10. A brief item that turned out not to exist: remote endpoint liveness reads in the digest are NOT network. A remote secondmate's metadata records no backend= field, so the per-task read resolves to a local tmux display-message. Verified empirically with an ssh stub: zero SSH calls from the digest. The audit only speculated that such a read 'would' be an SSH round trip. A separate pre-existing bug was found while proving this (that read targets a local pane named remote:<id>, so a healthy remote secondmate would report as 'endpoint: dead'); it was left alone as out of scope and reported for follow-up.

11. Not implemented, deliberately: the audit's stronger recommendation to gate the ROUTE rather than the startup for secondmate convergence. That is outside these two files.

Empirical verification performed. Against a stub host hanging 25s per SSH connection: startup went from 1m18.2s with 3 blocking SSH attempts inside the digest, to 0.84s with the same SSH attempts continuing at +0s and +25s after the digest finished. Healthy path with the real toolchain: 2.12s to 1.95s, and 0.76s with the axi version probes ablated. The tasks-axi dedupe takes one startup from 10 invocations to 7. The vendor-dependent fact this design needs - that a worker detached by a session-open hook survives the hook returning - was proven end to end against real Claude Code 2.1.222, wired into the opt-in live guard as a third asserted fact for every installed run-tier harness, and recorded with its dated evidence in docs/verification/supervision.md.

Test coverage added: a new tests/fm-startup-network.test.sh pinning the stage's own contract (non-blocking start that does not hold the caller's stdout, the claim handshake in both directions, refusal of mutating sweeps when the lock changed hands, the aggregate bound reported not swallowed, an abandoned run reading as needing a rerun, and single-flight); new session-start cases proving an unreachable host delays a reported check rather than the digest, that the deferred sweeps still land, that a result the digest outran still reaches the agent as a wake, that a read-only session declares its skipped checks, and that the tasks-axi verdict is paid for once; and new bootstrap cases proving the phase split is a partition and that the compatibility handoff travels exactly one process hop without leaking into a spawned agent's environment. Existing secondmate-recovery cases were updated to assert the relaunch through the deferred stage instead of off the digest, which is the real behavioral change.

## What Changed

- Split bootstrap into local and network phases so session-start renders its digest without waiting on GitHub authentication, secondmate recovery and synchronization, handoff retries, or fleet sync.
- Add a bounded, single-flight network worker that revalidates fleet-lock authority and durably reports results inline or through a follow-up wake.
- Reuse one tasks-axi compatibility verdict across session start and bootstrap, with executable coverage for slow remotes, deferred reporting, phase partitioning, and lock handoff safety.

## Risk Assessment

✅ Low: The deferred startup work is well bounded, prior ownership and delivery races are closed, and no remaining source-verifiable acceptance-criteria violation was found.

## Testing

The initial targeted run passed startup-network and bootstrap coverage but exposed a masked wait-status bug and stale reemit fixture assumption; after fixing both and replacing the flaky wall-clock assertion, the focused suites passed, and manual CLI evidence showed the digest return in 2.431 seconds while the 12-second probe remained active, followed by the deferred auth verdict and secondmate relaunch report.

<details>
<summary>Evidence: CLI transcript: digest returns in 2.431s while 12s probe is still running, then deferred checks and relaunch surface</summary>

```text
COMMAND: bin/fm-session-start.sh (fixture with gh auth blocked for 12 seconds)
DIGEST_RETURNED_MS: 2431
BLOCKED_PROBE_STATE_AT_DIGEST_RETURN: still running

DIGEST NETWORK CHECKS SECTION:
NETWORK CHECKS
================================================================================
IN PROGRESS - the deferred network checks have not finished yet.
NOT yet confirmed: GitHub authentication, dead-secondmate relaunch, secondmate convergence, pending handoff delivery, and project clone refresh with its drift reporting.
Started 2s ago, bounded at 120s.
The result is durable in state/.startup-network.report and arrives as a `check: startup-network` wake.
Read it now with /var/folders/0k/bf8mwt2n5qddzk24r20gfk0c0000gn/T//fm-session-start-tests.n669Yj/evidence-slow-network/root/bin/fm-startup-network.sh report; until it lands, treat none of it as confirmed.

================================================================================

DEFERRED REPORT AFTER THE BLOCKED PROBE FINISHED:
completed off the startup path in 14s: GitHub authentication, dead-secondmate relaunch, secondmate convergence, pending handoff delivery, and project clone refresh with its drift reporting.
NEEDS_GH_AUTH
BOOTSTRAP_INFO: secondmate fmtest-sm-n669Yj relaunched after recorded endpoint confidently missing (backend=tmux)
SECONDMATE_SYNC: secondmate fmtest-sm-n669Yj: skipped: not a git repo
These ran AFTER the sections above were composed, so re-read any record a line here names.

DEAD-SECONDMATE RELAUNCH SIDE EFFECT:
new-window -dP -F #{window_id} -t firstmate: -n fm-fmtest-sm-n669Yj -c /private/var/folders/0k/bf8mwt2n5qddzk24r20gfk0c0000gn/T/fm-session-start-tests.n669Yj/evidence-slow-network/secondmate-fmtest-sm-n669Yj
```
</details>
- Outcome: 🔧 1 issue found → auto-fixed ✅ across 2 runs (41m10s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 3 issues found → auto-fixed (4) ✅</summary>

- 🚨 `bin/fm-startup-network.sh:167` - `start` releases the publication lock before reserving a new run. On a subsequent startup, `harvest` can therefore print the previous `done` report before the detached worker records `running`; two simultaneous starts can also both launch workers. Atomically create a generation-specific running reservation under this lock, and bind the claim, harvest, and publication to that generation.
- 🚨 `bin/fm-startup-network.sh:285` - Mutation authority is checked only once before the entire bounded bootstrap. If the originating harness dies afterward, another session can replace `.lock` while this detached worker continues spawning or syncing secondmates, delivering handoffs, and refreshing clones. Hold a real lease or revalidate the captured lock identity at each shared mutating sweep boundary, and prevent a new owner from reusing the prior owner&#39;s running worker.
- 🚨 `bin/fm-startup-network.sh:263` - A direct `run --locked 1` without `--lock-pid` reads the current lock value and compares it back to the same file, so any process can claim mutation authority, including a read-only session while another live harness owns the fleet lock. Verify that the caller&#39;s harness identity owns the lock; reserve captured lock values for the internally detached `start` path.

🔧 Fix: Harden deferred network ownership and generation handoff
2 errors still open:
- 🚨 `bin/fm-bootstrap.sh:176` - The lock check is not atomic with the sweep it authorizes. If the original harness dies immediately after this check, a new harness can replace `.lock` and start its worker while the stale worker continues the current liveness, convergence, handoff, or clone-refresh sweep. This leaves the prior lock-handoff failure reachable. Coordinate lock takeover with a real sweep lease at the shared lock-acquisition boundary, or revalidate immediately at every mutation.
- 🚨 `tests/fm-sessionstart-hook-live-e2e.test.sh:118` - The live harness fixture links `fm-startup-network.sh` and only two dependencies, but the script now unconditionally sources `fm-session-lock-lib.sh`. The opt-in E2E therefore exits before launching its marker worker and cannot verify the required detach behavior. Link the new library into the lab fixture.

🔧 Fix: Lease deferred sweeps across fleet-lock takeover
1 error still open:
- 🚨 `bin/fm-startup-network.sh:293` - The required contract says each result is durable and &#34;ALWAYS surfaces, either inline in the digest or as a `check: startup-network` wake,&#34; but publication still treats a live claimant as completed delivery. If the worker observes the digest alive here and that digest exits or times out before `harvest`, no wake is queued and nothing prints. Separately, an unclaimed wake points only to the mutable current report, while the next session reserves a new generation before draining that wake, making the prior result inaccessible or overwriting it. Preserve reports and delivery state per generation, and suppress the wake only after that generation is durably acknowledged as harvested. The current live-claim test codifies the unsafe intent-before-delivery assumption and should cover both crash and next-generation sequences instead.

🔧 Fix: Acknowledge harvested reports before suppressing wakes
1 warning still open:
- ⚠️ `tests/fm-startup-network.test.sh:166` - `wait` now returns when the report is published, but the wake is appended afterward. This assertion can therefore run before the worker queues the wake; the session-start wake test has the same race. Poll for the observable wake as the crash-window test does, or provide a public command that waits for delivery settlement.

🔧 Fix: Stabilize deferred network wake assertions
✅ Re-checked - no issues remain.

</details>

<details>
<summary>🔧 **Test** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `tests/fm-session-start.test.sh:1384` - The full session-start component run intermittently reached 6 seconds and failed the strict `&lt; 6` assertion under concurrent machine load. The isolated retry passed, and manual verification returned the digest in 2 seconds while the remote remained blocked for 12 seconds. Stabilize the timing assertion so environmental contention does not produce a false failure while preserving the near-instant requirement.
- `tests/fm-startup-network.test.sh`
- <code>`tests/fm-session-start.test.sh` - component run stopped at the timing-sensitive slow-remote assertion</code>
- <code>Isolated `test_unreachable_network_never_blocks_the_digest`</code>
- <code>Isolated `test_deferred_result_reaches_the_agent_when_the_digest_cannot_print_it`, `test_read_only_session_declares_skipped_network_checks`, and `test_tasks_axi_compatibility_is_probed_once`</code>
- `tests/fm-bootstrap.test.sh`
- <code>Manual `bin/fm-session-start.sh` verification using a 12-second `gh auth` stub, followed by deferred report and relaunch-state inspection</code>
- <code>`git status --short` cleanup verification</code>

🔧 Fix: Stabilize deferred network startup timing assertion
✅ Re-checked - no issues remain.
- <code>`bin/fm-test-run.sh tests/fm-startup-network.test.sh tests/fm-bootstrap.test.sh tests/fm-session-start.test.sh` (initial run: startup-network and bootstrap passed; session-start exposed the reemit synchronization defect)</code>
- <code>`bin/fm-test-run.sh tests/fm-startup-network.test.sh` (passed after adding the wait-timeout regression)</code>
- <code>`bin/fm-test-run.sh tests/fm-session-start.test.sh` (passed after fixture and causal timing fixes)</code>
- <code>`capture-session-start-evidence.sh &gt; session-start-unreachable-remote.txt` (manual executable-interface verification with a 12-second blocked GitHub-auth probe)</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Lint** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ linter found issues (exit code 1)

🔧 Fix: Restore direct startup sweep lint visibility
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
