### PR TITLE
fix(bin): mirror remote secondmate status streams

### DIFF
--- a/bin/fm-procevent-remote-reply.sh
+++ b/bin/fm-procevent-remote-reply.sh
@@ -164,10 +164,14 @@ write_ingest_receipt() { # <id> <sequence> <result>
 }
 
 result_field() { # <result> <field>
-  local count
-  count=$(grep -c "^$2=" "$1" 2>/dev/null || true)
-  [ "$count" -eq 1 ] || return 1
-  grep "^$2=" "$1" | cut -d= -f2-
+  LC_ALL=C awk -v prefix="$2=" '
+    $0 == "" { exit }
+    index($0, prefix) == 1 { count++; value = substr($0, length(prefix) + 1) }
+    END {
+      if (count != 1) exit 1
+      print value
+    }
+  ' "$1"
 }
 
 classify_result() {
@@ -256,14 +260,14 @@ fetch_document() { # <id> <remote-relative> <result-var>
   printf -v "$result_var" '%s' "$local_rel"
 }
 
-# The one adaptation a machine boundary forces on the mirrored bytes: C0 control
-# characters and DEL become '?' so a transported line cannot make the parent's
-# status file unsafe to read or print. Tab, every printable ASCII byte, and every
-# high byte pass through untouched, so ordinary UTF-8 notes mirror exactly as a
-# local secondmate would have written them. This rewrites bytes and never drops a
-# line: no single line can stop the stream.
-mirror_line() { # <line> -> the exact bytes to append
-  printf '%s' "$1" | LC_ALL=C tr '\1-\10\13-\37\177' '?'
+# The one adaptation a machine boundary forces on the mirrored bytes: NUL and
+# every other C0 control except tab and newline, plus DEL, become '?'. Printable
+# ASCII and every high byte pass through untouched, so ordinary UTF-8 notes
+# mirror exactly as a local secondmate would have written them. Newlines remain
+# framing rather than payload bytes, so this rewrites bytes and never drops a
+# line.
+normalize_payload() { # <source> <destination>
+  LC_ALL=C tr '\000-\010\013-\037\177' '?' < "$1" > "$2"
 }
 
 # The one place a line enters the parent status stream. A captured generation can
@@ -277,7 +281,7 @@ append_status_once() { # <status-file> <line>
 }
 
 cmd_ingest() {
-  local id=${1:-} result=${2:-} seq=${3:-} class blank payload schema status path from to from_hash to_hash payload_hash payload_bytes reason
+  local id=${1:-} result=${2:-} seq=${3:-} class blank payload normalized_payload schema status path from to from_hash to_hash payload_hash payload_bytes reason
   local actual_bytes actual_hash line doc local_doc rewritten appended=0 cursor_already=0 lock status_file tmp
   local fetch_rc append_rc undelivered=''
   validate_id "$id"
@@ -300,7 +304,7 @@ cmd_ingest() {
     case "$hash" in *[!A-Fa-f0-9]*|'') die "result carries an invalid SHA-256 value" ;; esac
     [ "${#hash}" -eq 64 ] || die "result carries an invalid SHA-256 length"
   done
-  blank=$(grep -n -m 1 '^$' "$result" | cut -d: -f1)
+  blank=$(LC_ALL=C awk '$0 == "" { print NR; exit }' "$result")
   case "$blank" in ''|*[!0-9]*) die "result has no payload boundary" ;; esac
   tmp=$(mktemp -d "${TMPDIR:-/tmp}/fm-remote-reply-ingest.XXXXXX") || die "cannot create ingest staging directory"
   trap 'rm -rf -- "$tmp"' EXIT
@@ -310,6 +314,8 @@ cmd_ingest() {
   actual_hash=$(sha256_file "$payload")
   [ "$actual_bytes" -eq "$payload_bytes" ] && [ "$actual_hash" = "$payload_hash" ] \
     || die "result payload bytes do not match its committed digest"
+  normalized_payload="$tmp/normalized-payload"
+  normalize_payload "$payload" "$normalized_payload" || die "cannot normalize remote reply payload"
   status_file="$STATE/$id.status"
   mkdir -p "$STATE" || die "cannot create parent state directory"
   [ ! -L "$status_file" ] || die "parent status log is a symlink"
@@ -333,7 +339,7 @@ cmd_ingest() {
   [ "$status" = delta ] && [ "$payload_bytes" -gt 0 ] || { fm_lock_release "$lock"; die "delta result has no payload"; }
   while IFS= read -r line || [ -n "$line" ]; do
     [ -n "$line" ] || continue
-    rewritten=$(mirror_line "$line")
+    rewritten=$line
     while IFS= read -r doc; do
       [ -n "$doc" ] || continue
       fetch_rc=0
@@ -355,7 +361,7 @@ cmd_ingest() {
     append_status_once "$status_file" "$rewritten" || append_rc=$?
     [ "$append_rc" -ne 2 ] || { fm_lock_release "$lock"; die "cannot append remote reply"; }
     [ "$append_rc" -ne 0 ] || appended=$((appended + 1))
-  done < "$payload"
+  done < "$normalized_payload"
   if [ -n "$undelivered" ]; then
     line="blocked [key=remote-reply-document-$id]: remote documents did not transfer for $id ($undelivered)"
     append_rc=0
@@ -366,7 +372,7 @@ cmd_ingest() {
   while IFS= read -r corr; do
     [ -n "$corr" ] || continue
     fm_pending_reply_try_resolve "$STATE" "$corr" "$status_file" >/dev/null 2>&1 || true
-  done < <(grep -Eo 'corr=[A-Fa-f0-9]{16}' "$payload" | cut -d= -f2- | tr 'A-F' 'a-f' | awk '!seen[$0]++')
+  done < <(grep -Eo 'corr=[A-Fa-f0-9]{16}' "$normalized_payload" | cut -d= -f2- | tr 'A-F' 'a-f' | awk '!seen[$0]++')
   if [ -n "$seq" ]; then
     write_ingest_receipt "$id" "$seq" "$result" \
       || { fm_lock_release "$lock"; die "cannot commit remote reply ingestion receipt"; }

--- a/bin/fm-procevent-remote-reply.sh
+++ b/bin/fm-procevent-remote-reply.sh
@@ -16,10 +16,28 @@
 # ingests it, acknowledges the captured generation, then registers the next
 # cursor-anchored source. A continuity break is escalated and not re-armed.
 #
-# Ingest accepts only bounded, printable status lines with an allowed lifecycle
-# verb and corr=<16hex>. Exact lines are appended at most once to the parent's
-# state/<id>.status. A data/*.md pointer is fetched through the path-confined
-# remote file reader and rewritten to its local private copy before append.
+# This channel is a status-stream MIRROR, not a correlated-reply channel. A local
+# secondmate appends its whole status stream straight into the parent's
+# state/<id>.status, and every parent consumer - the open-decision fold, wake
+# classification, crew-state reconciliation, and pending-reply resolution - reads
+# that one stream. A remote secondmate must present the same model, so ingest
+# reproduces its stream line for line and leaves every semantic judgement to
+# those same shared consumers. Correlation is a per-line property that
+# fm-pending-reply-lib.sh consumes; it is never a gate on the stream. Gating on
+# it here made a remote mate's own progress lines and newly raised decisions -
+# which carry no corr= by contract - unrepresentable, and rejecting one line
+# failed the whole delta, so the cursor could never advance past it.
+#
+# What remains here is only what crossing a machine boundary genuinely adds:
+#   - cursor continuity and identity (offset plus prefix digest)
+#   - data/*.md pointers fetched through the path-confined remote file reader and
+#     rewritten to their local copies, because the parent cannot read the remote
+#     filesystem
+#   - at-most-once append, because a captured generation can be replayed
+#   - control-byte normalization, so bytes from another machine cannot make the
+#     parent's status file unsafe to read; it rewrites bytes, never drops a line
+# Line framing and size bounding belong to bin/fm-remote-delta-read.sh, which
+# delivers only whole lines and breaks continuity on an over-long one.
 set -u
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -30,8 +48,11 @@ DATA="${FM_DATA_OVERRIDE:-$FM_HOME/data}"
 CURSOR_DIR="$STATE/remote-replies"
 REMOTE_LOG='state/parent-replies.status'
 WAIT_SECONDS=${FM_REMOTE_REPLY_WAIT_SECONDS:-55}
-MAX_LINE_BYTES=${FM_REMOTE_REPLY_MAX_LINE_BYTES:-2048}
 MAX_DOC_BYTES=${FM_REMOTE_REPLY_MAX_DOC_BYTES:-262144}
+# fm-on.sh returns ssh's status unchanged, so 255 alone means unavailable
+# transport or unknown remote completion. Any other nonzero status is the remote
+# reader's own refusal and will not change on a retry.
+SSH_UNAVAILABLE=255
 
 # shellcheck source=bin/fm-wake-lib.sh
 . "$SCRIPT_DIR/fm-wake-lib.sh"
@@ -41,7 +62,7 @@ MAX_DOC_BYTES=${FM_REMOTE_REPLY_MAX_DOC_BYTES:-262144}
 . "$SCRIPT_DIR/fm-pending-reply-lib.sh"
 
 die() { printf 'error: %s\n' "$1" >&2; exit 1; }
-usage() { sed -n '2,22p' "$0" | sed 's/^# \{0,1\}//'; exit 2; }
+usage() { sed -n '2,40p' "$0" | sed 's/^# \{0,1\}//'; exit 2; }
 
 sha256_file() {
   if command -v shasum >/dev/null 2>&1; then
@@ -207,8 +228,11 @@ safe_doc_path() {
   return 0
 }
 
+# Fetch one referenced remote document. Returns 0 on success, SSH_UNAVAILABLE
+# when the transport itself was unavailable and a retry is warranted, and 1 when
+# the remote reader refused the path or size, which no retry would change.
 fetch_document() { # <id> <remote-relative> <result-var>
-  local id=$1 rel=$2 result_var=$3 base destination parent parent_real tmp local_rel
+  local id=$1 rel=$2 result_var=$3 base destination parent parent_real tmp local_rel rc=0
   safe_doc_path "$rel" || return 1
   base="$DATA/remote-secondmates/$id"
   destination="$base/$rel"
@@ -219,8 +243,10 @@ fetch_document() { # <id> <remote-relative> <result-var>
   case "$parent_real" in "$base"|"$base"/*) ;; *) return 1 ;; esac
   [ ! -L "$destination" ] || return 1
   tmp=$(umask 077; mktemp "$parent/.remote-doc.XXXXXX") || return 1
-  if ! "$SCRIPT_DIR/fm-on.sh" "$id" fm-remote-file.sh get "$rel" "$MAX_DOC_BYTES" < /dev/null > "$tmp"; then
+  "$SCRIPT_DIR/fm-on.sh" "$id" fm-remote-file.sh get "$rel" "$MAX_DOC_BYTES" < /dev/null > "$tmp" || rc=$?
+  if [ "$rc" -ne 0 ]; then
     rm -f -- "$tmp"
+    [ "$rc" -ne "$SSH_UNAVAILABLE" ] || return "$SSH_UNAVAILABLE"
     return 1
   fi
   chmod 600 "$tmp" || { rm -f -- "$tmp"; return 1; }
@@ -229,19 +255,20 @@ fetch_document() { # <id> <remote-relative> <result-var>
   printf -v "$result_var" '%s' "$local_rel"
 }
 
-line_valid() { # <line>
-  local line=$1 bytes
-  [ -n "$line" ] || return 1
-  bytes=$(printf '%s' "$line" | LC_ALL=C wc -c | tr -d ' ')
-  [ "$bytes" -le "$MAX_LINE_BYTES" ] || return 1
-  [ -z "$(printf '%s' "$line" | LC_ALL=C tr -d '\11\40-\176')" ] || return 1
-  printf '%s' "$line" | grep -Eq '^(working|needs-decision|blocked|paused|done|failed|resolved)([[:space:]]+\[[^]]+\])?:' || return 1
-  printf '%s' "$line" | grep -Eq 'corr=[A-Fa-f0-9]{16}'
+# The one adaptation a machine boundary forces on the mirrored bytes: C0 control
+# characters and DEL become '?' so a transported line cannot make the parent's
+# status file unsafe to read or print. Tab, every printable ASCII byte, and every
+# high byte pass through untouched, so ordinary UTF-8 notes mirror exactly as a
+# local secondmate would have written them. This rewrites bytes and never drops a
+# line: no single line can stop the stream.
+mirror_line() { # <line> -> the exact bytes to append
+  printf '%s' "$1" | LC_ALL=C tr '\1-\10\13-\37\177' '?'
 }
 
 cmd_ingest() {
   local id=${1:-} result=${2:-} seq=${3:-} class blank payload schema status path from to from_hash to_hash payload_hash payload_bytes reason
   local actual_bytes actual_hash line doc local_doc rewritten appended=0 cursor_already=0 lock status_file tmp
+  local fetch_rc undelivered=''
   validate_id "$id"
   [ -f "$result" ] && [ ! -L "$result" ] || die "result file is unavailable or unsafe: $result"
   class=$(classify_result "$result")
@@ -294,11 +321,24 @@ cmd_ingest() {
   fi
   [ "$status" = delta ] && [ "$payload_bytes" -gt 0 ] || { fm_lock_release "$lock"; die "delta result has no payload"; }
   while IFS= read -r line || [ -n "$line" ]; do
-    line_valid "$line" || { fm_lock_release "$lock"; die "delta contains an invalid or uncorrelated status line"; }
-    rewritten=$line
+    [ -n "$line" ] || continue
+    rewritten=$(mirror_line "$line")
     while IFS= read -r doc; do
       [ -n "$doc" ] || continue
-      fetch_document "$id" "$doc" local_doc || { fm_lock_release "$lock"; die "could not fetch referenced remote document: $doc"; }
+      fetch_rc=0
+      fetch_document "$id" "$doc" local_doc || fetch_rc=$?
+      # Transport unavailable is unknown, not a verdict: leave the whole delta
+      # for the runner's existing retry rather than mirroring a pointer whose
+      # document may yet arrive.
+      [ "$fetch_rc" -ne "$SSH_UNAVAILABLE" ] \
+        || { fm_lock_release "$lock"; die "remote transport was unavailable while fetching $doc"; }
+      if [ "$fetch_rc" -ne 0 ]; then
+        # The remote reader refused this document and always will. Mirror the
+        # mate's line with its own pointer intact rather than inventing a local
+        # path or stalling the stream, and name the gap once for this delta.
+        undelivered="${undelivered}${undelivered:+, }$doc"
+        continue
+      fi
       rewritten=${rewritten//"$doc"/"$local_doc"}
     done < <(printf '%s\n' "$line" | grep -Eo 'data/[A-Za-z0-9._/-]+\.md' | awk '!seen[$0]++')
     if ! grep -Fqx -- "$rewritten" "$status_file" 2>/dev/null; then
@@ -306,6 +346,13 @@ cmd_ingest() {
       appended=$((appended + 1))
     fi
   done < "$payload"
+  if [ -n "$undelivered" ]; then
+    line="blocked [key=remote-reply-document-$id]: remote documents did not transfer for $id ($undelivered)"
+    if ! grep -Fqx -- "$line" "$status_file" 2>/dev/null; then
+      printf '%s\n' "$line" >> "$status_file" || { fm_lock_release "$lock"; die "cannot append document escalation"; }
+      appended=$((appended + 1))
+    fi
+  fi
   while IFS= read -r corr; do
     [ -n "$corr" ] || continue
     fm_pending_reply_try_resolve "$STATE" "$corr" "$status_file" >/dev/null 2>&1 || true

--- a/bin/fm-procevent-remote-reply.sh
+++ b/bin/fm-procevent-remote-reply.sh
@@ -265,10 +265,20 @@ mirror_line() { # <line> -> the exact bytes to append
   printf '%s' "$1" | LC_ALL=C tr '\1-\10\13-\37\177' '?'
 }
 
+# The one place a line enters the parent status stream. A captured generation can
+# be replayed, so every append - a mirrored line or an escalation this adapter
+# raises itself - is at most once on exact bytes.
+# Returns 0 appended, 1 already present, 2 the write itself failed.
+append_status_once() { # <status-file> <line>
+  grep -Fqx -- "$2" "$1" 2>/dev/null && return 1
+  printf '%s\n' "$2" >> "$1" || return 2
+  return 0
+}
+
 cmd_ingest() {
   local id=${1:-} result=${2:-} seq=${3:-} class blank payload schema status path from to from_hash to_hash payload_hash payload_bytes reason
   local actual_bytes actual_hash line doc local_doc rewritten appended=0 cursor_already=0 lock status_file tmp
-  local fetch_rc undelivered=''
+  local fetch_rc append_rc undelivered=''
   validate_id "$id"
   [ -f "$result" ] && [ ! -L "$result" ] || die "result file is unavailable or unsafe: $result"
   class=$(classify_result "$result")
@@ -312,9 +322,9 @@ cmd_ingest() {
   fi
   if [ "$class" = continuity-broken ]; then
     line="blocked [key=remote-reply-continuity-$id]: remote reply continuity broke for $id ($reason)"
-    if ! grep -Fqx -- "$line" "$status_file" 2>/dev/null; then
-      printf '%s\n' "$line" >> "$status_file" || { fm_lock_release "$lock"; die "cannot append continuity escalation"; }
-    fi
+    append_rc=0
+    append_status_once "$status_file" "$line" || append_rc=$?
+    [ "$append_rc" -ne 2 ] || { fm_lock_release "$lock"; die "cannot append continuity escalation"; }
     fm_lock_release "$lock"
     printf 'continuity-broken: %s (%s)\n' "$id" "$reason"
     return 3
@@ -341,17 +351,17 @@ cmd_ingest() {
       fi
       rewritten=${rewritten//"$doc"/"$local_doc"}
     done < <(printf '%s\n' "$line" | grep -Eo 'data/[A-Za-z0-9._/-]+\.md' | awk '!seen[$0]++')
-    if ! grep -Fqx -- "$rewritten" "$status_file" 2>/dev/null; then
-      printf '%s\n' "$rewritten" >> "$status_file" || { fm_lock_release "$lock"; die "cannot append remote reply"; }
-      appended=$((appended + 1))
-    fi
+    append_rc=0
+    append_status_once "$status_file" "$rewritten" || append_rc=$?
+    [ "$append_rc" -ne 2 ] || { fm_lock_release "$lock"; die "cannot append remote reply"; }
+    [ "$append_rc" -ne 0 ] || appended=$((appended + 1))
   done < "$payload"
   if [ -n "$undelivered" ]; then
     line="blocked [key=remote-reply-document-$id]: remote documents did not transfer for $id ($undelivered)"
-    if ! grep -Fqx -- "$line" "$status_file" 2>/dev/null; then
-      printf '%s\n' "$line" >> "$status_file" || { fm_lock_release "$lock"; die "cannot append document escalation"; }
-      appended=$((appended + 1))
-    fi
+    append_rc=0
+    append_status_once "$status_file" "$line" || append_rc=$?
+    [ "$append_rc" -ne 2 ] || { fm_lock_release "$lock"; die "cannot append document escalation"; }
+    [ "$append_rc" -ne 0 ] || appended=$((appended + 1))
   fi
   while IFS= read -r corr; do
     [ -n "$corr" ] || continue

--- a/bin/fm-procevent-remote-reply.sh
+++ b/bin/fm-procevent-remote-reply.sh
@@ -21,12 +21,13 @@
 # state/<id>.status, and every parent consumer - the open-decision fold, wake
 # classification, crew-state reconciliation, and pending-reply resolution - reads
 # that one stream. A remote secondmate must present the same model, so ingest
-# reproduces its stream line for line and leaves every semantic judgement to
-# those same shared consumers. Correlation is a per-line property that
-# fm-pending-reply-lib.sh consumes; it is never a gate on the stream. Gating on
-# it here made a remote mate's own progress lines and newly raised decisions -
-# which carry no corr= by contract - unrepresentable, and rejecting one line
-# failed the whole delta, so the cursor could never advance past it.
+# mirrors every content-bearing line at most once, omits blank separators, and
+# leaves every semantic judgement to those same shared consumers. Correlation is
+# a per-line property that fm-pending-reply-lib.sh consumes; it is never a gate
+# on the stream. Gating on it here made a remote mate's own progress lines and
+# newly raised decisions - which carry no corr= by contract - unrepresentable,
+# and rejecting one line failed the whole delta, so the cursor could never
+# advance past it. No single line can stop or wedge the stream.
 #
 # What remains here is only what crossing a machine boundary genuinely adds:
 #   - cursor continuity and identity (offset plus prefix digest)
@@ -34,8 +35,8 @@
 #     rewritten to their local copies, because the parent cannot read the remote
 #     filesystem
 #   - at-most-once append, because a captured generation can be replayed
-#   - control-byte normalization, so bytes from another machine cannot make the
-#     parent's status file unsafe to read; it rewrites bytes, never drops a line
+#   - control-byte normalization, so content-bearing bytes from another machine
+#     cannot make the parent's status file unsafe to read
 # Line framing and size bounding belong to bin/fm-remote-delta-read.sh, which
 # delivers only whole lines and breaks continuity on an over-long one.
 set -u
@@ -264,8 +265,8 @@ fetch_document() { # <id> <remote-relative> <result-var>
 # every other C0 control except tab and newline, plus DEL, become '?'. Printable
 # ASCII and every high byte pass through untouched, so ordinary UTF-8 notes
 # mirror exactly as a local secondmate would have written them. Newlines remain
-# framing rather than payload bytes, so this rewrites bytes and never drops a
-# line.
+# framing rather than payload bytes, and blank separators are not carried into
+# the parent status stream.
 normalize_payload() { # <source> <destination>
   LC_ALL=C tr '\000-\010\013-\037\177' '?' < "$1" > "$2"
 }

--- a/bin/fm-procevent-remote-reply.sh
+++ b/bin/fm-procevent-remote-reply.sh
@@ -53,6 +53,7 @@ MAX_DOC_BYTES=${FM_REMOTE_REPLY_MAX_DOC_BYTES:-262144}
 # transport or unknown remote completion. Any other nonzero status is the remote
 # reader's own refusal and will not change on a retry.
 SSH_UNAVAILABLE=255
+DOCUMENT_LOCAL_FAILURE=2
 
 # shellcheck source=bin/fm-wake-lib.sh
 . "$SCRIPT_DIR/fm-wake-lib.sh"
@@ -228,29 +229,29 @@ safe_doc_path() {
   return 0
 }
 
-# Fetch one referenced remote document. Returns 0 on success, SSH_UNAVAILABLE
-# when the transport itself was unavailable and a retry is warranted, and 1 when
-# the remote reader refused the path or size, which no retry would change.
+# Fetch one referenced remote document. Returns 0 on success, 1 when the remote
+# reader refused the path or size, DOCUMENT_LOCAL_FAILURE when local storage
+# failed, and SSH_UNAVAILABLE when transport completion is unknown.
 fetch_document() { # <id> <remote-relative> <result-var>
   local id=$1 rel=$2 result_var=$3 base destination parent parent_real tmp local_rel rc=0
   safe_doc_path "$rel" || return 1
   base="$DATA/remote-secondmates/$id"
   destination="$base/$rel"
   parent=$(dirname "$destination")
-  mkdir -p "$parent" || return 1
-  [ ! -L "$base" ] && [ ! -L "$parent" ] || return 1
-  parent_real=$(CDPATH='' cd -- "$parent" 2>/dev/null && pwd -P) || return 1
-  case "$parent_real" in "$base"|"$base"/*) ;; *) return 1 ;; esac
-  [ ! -L "$destination" ] || return 1
-  tmp=$(umask 077; mktemp "$parent/.remote-doc.XXXXXX") || return 1
+  mkdir -p "$parent" || return "$DOCUMENT_LOCAL_FAILURE"
+  [ ! -L "$base" ] && [ ! -L "$parent" ] || return "$DOCUMENT_LOCAL_FAILURE"
+  parent_real=$(CDPATH='' cd -- "$parent" 2>/dev/null && pwd -P) || return "$DOCUMENT_LOCAL_FAILURE"
+  case "$parent_real" in "$base"|"$base"/*) ;; *) return "$DOCUMENT_LOCAL_FAILURE" ;; esac
+  [ ! -L "$destination" ] || return "$DOCUMENT_LOCAL_FAILURE"
+  tmp=$(umask 077; mktemp "$parent/.remote-doc.XXXXXX") || return "$DOCUMENT_LOCAL_FAILURE"
   "$SCRIPT_DIR/fm-on.sh" "$id" fm-remote-file.sh get "$rel" "$MAX_DOC_BYTES" < /dev/null > "$tmp" || rc=$?
   if [ "$rc" -ne 0 ]; then
     rm -f -- "$tmp"
     [ "$rc" -ne "$SSH_UNAVAILABLE" ] || return "$SSH_UNAVAILABLE"
     return 1
   fi
-  chmod 600 "$tmp" || { rm -f -- "$tmp"; return 1; }
-  mv -f -- "$tmp" "$destination" || { rm -f -- "$tmp"; return 1; }
+  chmod 600 "$tmp" || { rm -f -- "$tmp"; return "$DOCUMENT_LOCAL_FAILURE"; }
+  mv -f -- "$tmp" "$destination" || { rm -f -- "$tmp"; return "$DOCUMENT_LOCAL_FAILURE"; }
   local_rel="data/remote-secondmates/$id/$rel"
   printf -v "$result_var" '%s' "$local_rel"
 }
@@ -337,18 +338,17 @@ cmd_ingest() {
       [ -n "$doc" ] || continue
       fetch_rc=0
       fetch_document "$id" "$doc" local_doc || fetch_rc=$?
-      # Transport unavailable is unknown, not a verdict: leave the whole delta
-      # for the runner's existing retry rather than mirroring a pointer whose
-      # document may yet arrive.
-      [ "$fetch_rc" -ne "$SSH_UNAVAILABLE" ] \
-        || { fm_lock_release "$lock"; die "remote transport was unavailable while fetching $doc"; }
-      if [ "$fetch_rc" -ne 0 ]; then
+      if [ "$fetch_rc" -eq 1 ]; then
         # The remote reader refused this document and always will. Mirror the
         # mate's line with its own pointer intact rather than inventing a local
         # path or stalling the stream, and name the gap once for this delta.
         undelivered="${undelivered}${undelivered:+, }$doc"
         continue
       fi
+      [ "$fetch_rc" -ne "$SSH_UNAVAILABLE" ] \
+        || { fm_lock_release "$lock"; die "remote transport was unavailable while fetching $doc"; }
+      [ "$fetch_rc" -eq 0 ] \
+        || { fm_lock_release "$lock"; die "could not store referenced remote document: $doc"; }
       rewritten=${rewritten//"$doc"/"$local_doc"}
     done < <(printf '%s\n' "$line" | grep -Eo 'data/[A-Za-z0-9._/-]+\.md' | awk '!seen[$0]++')
     append_rc=0

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -195,7 +195,6 @@ Explicit backend-target sends and direct human typing stay unmarked, so captain 
 After seeding a secondmate, `fm-backlog-handoff.sh` validates the fleet-specific handoff, then atomically delegates already-judged in-scope queued item moves to `tasks-axi mv` so the domain queue starts in the right place.
 Remote routes move that dependency-closed set into a non-dispatchable backlog-format outbox before transfer, then use an idempotent remote receive under the destination backlog's own lock.
 The outbox is the complete retry record, so no two-phase journal or transport-level retry is needed.
-Remote replies travel in the other direction through a non-destructive cursor-anchored log reader and the existing process-event runner, with deduplicated correlated append into the primary status channel.
 An unreachable remote host is unknown rather than dead, preserves its route and durable work, and is never failed over or relaunched locally.
 Idle secondmate panes are healthy; teardown is explicit and refuses while the secondmate home has in-flight work unless the captain has approved discard with `--force`.
 

--- a/docs/remote-secondmates.md
+++ b/docs/remote-secondmates.md
@@ -169,9 +169,9 @@ FM_HOME=<primary-home> bin/fm-send.sh fm-<id> '<request>'
 
 Marked requests keep the existing correlation contract.
 The remote charter appends replies to `state/parent-replies.status` in the remote home.
-A process-event source performs a non-destructive, cursor-anchored delta read, fetches only referenced `data/*.md` documents through the confined reader, and mirrors each line at most once into the primary status channel.
-The channel carries the mate's whole status stream, exactly as a local secondmate writes it: an uncorrelated progress line and a newly raised `needs-decision` travel the same path as a correlated answer, and reach the parent's open-decision fold identically.
-Correlation is a per-line property that settles a pending request; it is never a gate on the stream, so no single line can stop the relay or hold the cursor back.
+A process-event source performs a non-destructive, cursor-anchored delta read, fetches only referenced `data/*.md` documents through the confined reader, mirrors every content-bearing line at most once into the primary status channel, and does not carry blank separators.
+The channel carries the mate's status and decision model: an uncorrelated progress line and a newly raised `needs-decision` travel the same path as a correlated answer, and reach the parent's open-decision fold identically.
+Correlation is a per-line property that settles a pending request; it is never a gate on the stream, so no single line can stop or wedge the relay or hold the cursor back.
 Control characters in a transported line are normalized before the append so the parent's status file stays safe to read, and a document the remote reader refuses is named in one escalation rather than stalling the stream.
 The source log is never truncated or consumed.
 A shortened or changed prefix stops the relay and surfaces a continuity failure instead of silently resetting the cursor.

--- a/docs/remote-secondmates.md
+++ b/docs/remote-secondmates.md
@@ -169,7 +169,10 @@ FM_HOME=<primary-home> bin/fm-send.sh fm-<id> '<request>'
 
 Marked requests keep the existing correlation contract.
 The remote charter appends replies to `state/parent-replies.status` in the remote home.
-A process-event source performs a non-destructive, cursor-anchored delta read, validates bounded correlated status lines, fetches only referenced `data/*.md` documents through the confined reader, and appends each accepted line at most once to the primary status channel.
+A process-event source performs a non-destructive, cursor-anchored delta read, fetches only referenced `data/*.md` documents through the confined reader, and mirrors each line at most once into the primary status channel.
+The channel carries the mate's whole status stream, exactly as a local secondmate writes it: an uncorrelated progress line and a newly raised `needs-decision` travel the same path as a correlated answer, and reach the parent's open-decision fold identically.
+Correlation is a per-line property that settles a pending request; it is never a gate on the stream, so no single line can stop the relay or hold the cursor back.
+Control characters in a transported line are normalized before the append so the parent's status file stays safe to read, and a document the remote reader refuses is named in one escalation rather than stalling the stream.
 The source log is never truncated or consumed.
 A shortened or changed prefix stops the relay and surfaces a continuity failure instead of silently resetting the cursor.
 

--- a/docs/remote-secondmates.md
+++ b/docs/remote-secondmates.md
@@ -172,7 +172,9 @@ The remote charter appends replies to `state/parent-replies.status` in the remot
 A process-event source performs a non-destructive, cursor-anchored delta read, fetches only referenced `data/*.md` documents through the confined reader, mirrors every content-bearing line at most once into the primary status channel, and does not carry blank separators.
 The channel carries the mate's status and decision model: an uncorrelated progress line and a newly raised `needs-decision` travel the same path as a correlated answer, and reach the parent's open-decision fold identically.
 Correlation is a per-line property that settles a pending request; it is never a gate on the stream, so no single line can stop or wedge the relay or hold the cursor back.
-Control characters in a transported line are normalized before the append so the parent's status file stays safe to read, and a document the remote reader refuses is named in one escalation rather than stalling the stream.
+Transport normalization rewrites NUL, every other C0 control except tab and newline, and DEL to `?`, while printable ASCII and all high bytes, including UTF-8, pass through unchanged.
+If the confined remote reader permanently refuses a referenced document, the mate's line is mirrored with its original pointer and the adapter appends one keyed escalation naming the gap instead of stalling the stream.
+An SSH exit status of 255 while fetching a referenced document leaves the delta uncommitted for the process-event runner's normal retry because remote completion is unknown.
 The source log is never truncated or consumed.
 A shortened or changed prefix stops the relay and surfaces a continuity failure instead of silently resetting the cursor.
 

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -63,7 +63,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-marker-lib.sh`       | Compatibility entry point for the from-firstmate carrier owned by `fm-operational-input.sh` |
 | `fm-pending-reply-lib.sh` | Parent-owned secondmate pending-reply expectations, recovery, and one-shot escalation |
 | `fm-secondmate-report.sh` | Optional helper to append a correlated parent status or document-pointer report       |
-| `fm-procevent-remote-reply.sh` | Relay non-destructive correlated remote-secondmate reply deltas through process events |
+| `fm-procevent-remote-reply.sh` | Relay the remote-secondmate status stream through non-destructive process-event deltas |
 | `fm-gate-refuse-lib.sh`  | Shared no-mistakes gate-context refusal for fleet lifecycle entrypoints               |
 | `fm-watch-arm.sh`        | Verified home-scoped watcher arm wrapper with loud cycle endings and bounded lifecycle ledger |
 | `fm-watch-checkpoint.sh` | Run one bounded foreground watcher checkpoint for Codex-style supervision            |

--- a/tests/fm-remote-reply.test.sh
+++ b/tests/fm-remote-reply.test.sh
@@ -242,19 +242,45 @@ assert_grep "offset=$ctl_offset" "$PARENT/state/remote-replies/ios.cursor" \
   "the cursor did not advance past a control-character line"
 pass "transported control bytes are normalized in place and never stop the stream"
 
+printf 'status=delta\n' >> "$REMOTE/state/parent-replies.status"
+remote_env "$ROOT/bin/fm-procevent.sh" start "$SID" >/dev/null \
+  || fail "the header-collision line was not captured"
+RESULT_SIX="$PARENT/state/procevent-inbox/$SID.6.result"
+remote_env "$ADAPTER" handle ios 6 "$RESULT_SIX" >/dev/null 2>&1 \
+  || fail "a payload protocol-field name stopped the stream"
+assert_grep 'status=delta' "$PARENT/state/ios.status" \
+  "the payload protocol-field line did not reach the parent stream"
+collision_offset=$(LC_ALL=C wc -c < "$REMOTE/state/parent-replies.status" | tr -d ' ')
+assert_grep "offset=$collision_offset" "$PARENT/state/remote-replies/ios.cursor" \
+  "the cursor did not advance past a payload protocol-field line"
+pass "payload protocol-field names cannot collide with transport metadata"
+
+printf 'working [key=nul-byte]: before\000after\n' >> "$REMOTE/state/parent-replies.status"
+remote_env "$ROOT/bin/fm-procevent.sh" start "$SID" >/dev/null \
+  || fail "the NUL-bearing line was not captured"
+RESULT_SEVEN="$PARENT/state/procevent-inbox/$SID.7.result"
+remote_env "$ADAPTER" handle ios 7 "$RESULT_SEVEN" >/dev/null 2>&1 \
+  || fail "a NUL byte stopped the stream"
+assert_grep 'working [key=nul-byte]: before?after' "$PARENT/state/ios.status" \
+  "the NUL byte was not normalized in place"
+nul_offset=$(LC_ALL=C wc -c < "$REMOTE/state/parent-replies.status" | tr -d ' ')
+assert_grep "offset=$nul_offset" "$PARENT/state/remote-replies/ios.cursor" \
+  "the cursor did not advance past a NUL-bearing line"
+pass "NUL bytes are normalized in place before shell line processing"
+
 printf '# Retryable remote answer\n' > "$REMOTE/data/reply/retry.md"
 printf 'done [key=retry-document]: retry local storage (data/reply/retry.md)\n' \
   >> "$REMOTE/state/parent-replies.status"
 remote_env "$ROOT/bin/fm-procevent.sh" start "$SID" >/dev/null \
   || fail "the retryable document line was not captured"
-RESULT_SIX="$PARENT/state/procevent-inbox/$SID.6.result"
+RESULT_EIGHT="$PARENT/state/procevent-inbox/$SID.8.result"
 retry_cursor_before=$(cat "$PARENT/state/remote-replies/ios.cursor")
 retry_destination="$PARENT/data/remote-secondmates/ios/data/reply/retry.md"
 retry_decoy="$TMP_ROOT/retry-decoy.md"
 printf 'local decoy\n' > "$retry_decoy"
 ln -s "$retry_decoy" "$retry_destination"
 set +e
-remote_env "$ADAPTER" handle ios 6 "$RESULT_SIX" > "$TMP_ROOT/handle-local-document-failure.out" 2>&1
+remote_env "$ADAPTER" handle ios 8 "$RESULT_EIGHT" > "$TMP_ROOT/handle-local-document-failure.out" 2>&1
 local_document_rc=$?
 set -e
 [ "$local_document_rc" -ne 0 ] || fail "local document storage failure committed the delta"
@@ -267,7 +293,7 @@ assert_no_grep 'done [key=retry-document]' "$PARENT/state/ios.status" \
 assert_no_grep 'blocked [key=remote-reply-document-ios]' "$PARENT/state/ios.status" \
   "local document storage failure raised a permanent remote refusal"
 rm -f "$retry_destination"
-remote_env "$ADAPTER" handle ios 6 "$RESULT_SIX" >/dev/null \
+remote_env "$ADAPTER" handle ios 8 "$RESULT_EIGHT" >/dev/null \
   || fail "the document delta did not succeed after local storage recovered"
 assert_grep 'data/remote-secondmates/ios/data/reply/retry.md' "$PARENT/state/ios.status" \
   "the retried document pointer was not rewritten locally"
@@ -285,23 +311,23 @@ printf 'failed [corr=fedcba9876543210]: source was replaced\n' > "$REMOTE/state/
 remote_env "$ROOT/bin/fm-procevent.sh" start "$SID" > "$TMP_ROOT/start-two.out" 2>&1 &
 RUNNER=$!
 wait "$RUNNER" || fail "continuity break was not captured as a structured result"
-RESULT_SEVEN=$(find "$PARENT/state/procevent-inbox" -name "$SID.7.result" -print -quit)
-[ -n "$RESULT_SEVEN" ] || fail "continuity break produced no durable result"
-[ "$(remote_env "$ADAPTER" classify "$RESULT_SEVEN")" = continuity-broken ] \
+RESULT_NINE=$(find "$PARENT/state/procevent-inbox" -name "$SID.9.result" -print -quit)
+[ -n "$RESULT_NINE" ] || fail "continuity break produced no durable result"
+[ "$(remote_env "$ADAPTER" classify "$RESULT_NINE")" = continuity-broken ] \
   || fail "truncated source was not classified as a continuity break"
 set +e
-remote_env "$ADAPTER" handle ios 7 "$RESULT_SEVEN" > "$TMP_ROOT/handle-seven.out" 2>&1
+remote_env "$ADAPTER" handle ios 9 "$RESULT_NINE" > "$TMP_ROOT/handle-nine.out" 2>&1
 handle_rc=$?
 set -e
 [ "$handle_rc" -eq 3 ] || fail "continuity handling returned an unexpected status: $handle_rc"
 assert_grep 'blocked [key=remote-reply-continuity-ios]' "$PARENT/state/ios.status" "continuity break did not escalate"
 assert_absent "$PARENT/state/procevent/$SID.source" "continuity break was re-armed without an operator rebase"
-remote_env "$ADAPTER" ingest ios "$RESULT_SEVEN" >/dev/null 2>&1 || true
+remote_env "$ADAPTER" ingest ios "$RESULT_NINE" >/dev/null 2>&1 || true
 [ "$(grep -cF 'blocked [key=remote-reply-continuity-ios]' "$PARENT/state/ios.status")" -eq 1 ] \
   || fail "continuity replay duplicated the escalation"
 pass "truncation is detected, escalated once, and not silently rebased"
 
-rm -f "$PARENT/state/procevent-inbox/$SID.7.handled"
+rm -f "$PARENT/state/procevent-inbox/$SID.9.handled"
 if remote_env "$ADAPTER" retire ios > "$TMP_ROOT/retire-pending.out" 2>&1; then
   fail "remote reply retirement accepted an unhandled captured result"
 fi
@@ -309,7 +335,7 @@ assert_grep 'unhandled captured result' "$TMP_ROOT/retire-pending.out" \
   "remote reply retirement did not explain its pending-result refusal"
 assert_absent "$PARENT/state/procevent/$SID.source" \
   "refused retirement left the reply source running past its pending-result check"
-remote_env "$ADAPTER" handle ios 7 "$RESULT_SEVEN" >/dev/null 2>&1 || [ "$?" -eq 3 ] \
+remote_env "$ADAPTER" handle ios 9 "$RESULT_NINE" >/dev/null 2>&1 || [ "$?" -eq 3 ] \
   || fail "pending continuity result could not be acknowledged after retirement refusal"
 remote_env "$ADAPTER" retire ios >/dev/null
 assert_absent "$PARENT/state/remote-replies/ios.cursor" "adapter retirement left its cursor"

--- a/tests/fm-remote-reply.test.sh
+++ b/tests/fm-remote-reply.test.sh
@@ -242,6 +242,42 @@ assert_grep "offset=$ctl_offset" "$PARENT/state/remote-replies/ios.cursor" \
   "the cursor did not advance past a control-character line"
 pass "transported control bytes are normalized in place and never stop the stream"
 
+printf '# Retryable remote answer\n' > "$REMOTE/data/reply/retry.md"
+printf 'done [key=retry-document]: retry local storage (data/reply/retry.md)\n' \
+  >> "$REMOTE/state/parent-replies.status"
+remote_env "$ROOT/bin/fm-procevent.sh" start "$SID" >/dev/null \
+  || fail "the retryable document line was not captured"
+RESULT_SIX="$PARENT/state/procevent-inbox/$SID.6.result"
+retry_cursor_before=$(cat "$PARENT/state/remote-replies/ios.cursor")
+retry_destination="$PARENT/data/remote-secondmates/ios/data/reply/retry.md"
+retry_decoy="$TMP_ROOT/retry-decoy.md"
+printf 'local decoy\n' > "$retry_decoy"
+ln -s "$retry_decoy" "$retry_destination"
+set +e
+remote_env "$ADAPTER" handle ios 6 "$RESULT_SIX" > "$TMP_ROOT/handle-local-document-failure.out" 2>&1
+local_document_rc=$?
+set -e
+[ "$local_document_rc" -ne 0 ] || fail "local document storage failure committed the delta"
+assert_grep 'could not store referenced remote document' "$TMP_ROOT/handle-local-document-failure.out" \
+  "local document storage failure was misclassified as remote refusal"
+[ "$(cat "$PARENT/state/remote-replies/ios.cursor")" = "$retry_cursor_before" ] \
+  || fail "local document storage failure advanced the cursor"
+assert_no_grep 'done [key=retry-document]' "$PARENT/state/ios.status" \
+  "local document storage failure mirrored an undelivered line"
+assert_no_grep 'blocked [key=remote-reply-document-ios]' "$PARENT/state/ios.status" \
+  "local document storage failure raised a permanent remote refusal"
+rm -f "$retry_destination"
+remote_env "$ADAPTER" handle ios 6 "$RESULT_SIX" >/dev/null \
+  || fail "the document delta did not succeed after local storage recovered"
+assert_grep 'data/remote-secondmates/ios/data/reply/retry.md' "$PARENT/state/ios.status" \
+  "the retried document pointer was not rewritten locally"
+cmp -s "$REMOTE/data/reply/retry.md" "$retry_destination" \
+  || fail "the retried remote document was not copied byte-identically"
+retry_offset=$(LC_ALL=C wc -c < "$REMOTE/state/parent-replies.status" | tr -d ' ')
+assert_grep "offset=$retry_offset" "$PARENT/state/remote-replies/ios.cursor" \
+  "the recovered document delta did not advance the cursor"
+pass "local document storage failures remain retryable until delivery succeeds"
+
 # The adapter re-armed at the committed cursor. Truncation is detected from the
 # next blocking source and escalated once; it is never silently treated as a new
 # log or re-armed past the break.
@@ -249,23 +285,23 @@ printf 'failed [corr=fedcba9876543210]: source was replaced\n' > "$REMOTE/state/
 remote_env "$ROOT/bin/fm-procevent.sh" start "$SID" > "$TMP_ROOT/start-two.out" 2>&1 &
 RUNNER=$!
 wait "$RUNNER" || fail "continuity break was not captured as a structured result"
-RESULT_SIX=$(find "$PARENT/state/procevent-inbox" -name "$SID.6.result" -print -quit)
-[ -n "$RESULT_SIX" ] || fail "continuity break produced no durable result"
-[ "$(remote_env "$ADAPTER" classify "$RESULT_SIX")" = continuity-broken ] \
+RESULT_SEVEN=$(find "$PARENT/state/procevent-inbox" -name "$SID.7.result" -print -quit)
+[ -n "$RESULT_SEVEN" ] || fail "continuity break produced no durable result"
+[ "$(remote_env "$ADAPTER" classify "$RESULT_SEVEN")" = continuity-broken ] \
   || fail "truncated source was not classified as a continuity break"
 set +e
-remote_env "$ADAPTER" handle ios 6 "$RESULT_SIX" > "$TMP_ROOT/handle-six.out" 2>&1
+remote_env "$ADAPTER" handle ios 7 "$RESULT_SEVEN" > "$TMP_ROOT/handle-seven.out" 2>&1
 handle_rc=$?
 set -e
 [ "$handle_rc" -eq 3 ] || fail "continuity handling returned an unexpected status: $handle_rc"
 assert_grep 'blocked [key=remote-reply-continuity-ios]' "$PARENT/state/ios.status" "continuity break did not escalate"
 assert_absent "$PARENT/state/procevent/$SID.source" "continuity break was re-armed without an operator rebase"
-remote_env "$ADAPTER" ingest ios "$RESULT_SIX" >/dev/null 2>&1 || true
+remote_env "$ADAPTER" ingest ios "$RESULT_SEVEN" >/dev/null 2>&1 || true
 [ "$(grep -cF 'blocked [key=remote-reply-continuity-ios]' "$PARENT/state/ios.status")" -eq 1 ] \
   || fail "continuity replay duplicated the escalation"
 pass "truncation is detected, escalated once, and not silently rebased"
 
-rm -f "$PARENT/state/procevent-inbox/$SID.6.handled"
+rm -f "$PARENT/state/procevent-inbox/$SID.7.handled"
 if remote_env "$ADAPTER" retire ios > "$TMP_ROOT/retire-pending.out" 2>&1; then
   fail "remote reply retirement accepted an unhandled captured result"
 fi
@@ -273,7 +309,7 @@ assert_grep 'unhandled captured result' "$TMP_ROOT/retire-pending.out" \
   "remote reply retirement did not explain its pending-result refusal"
 assert_absent "$PARENT/state/procevent/$SID.source" \
   "refused retirement left the reply source running past its pending-result check"
-remote_env "$ADAPTER" handle ios 6 "$RESULT_SIX" >/dev/null 2>&1 || [ "$?" -eq 3 ] \
+remote_env "$ADAPTER" handle ios 7 "$RESULT_SEVEN" >/dev/null 2>&1 || [ "$?" -eq 3 ] \
   || fail "pending continuity result could not be acknowledged after retirement refusal"
 remote_env "$ADAPTER" retire ios >/dev/null
 assert_absent "$PARENT/state/remote-replies/ios.cursor" "adapter retirement left its cursor"

--- a/tests/fm-remote-reply.test.sh
+++ b/tests/fm-remote-reply.test.sh
@@ -170,26 +170,77 @@ assert_contains "$out" 'handled: remote-reply-ios 2' "earlier generation remaine
   || fail "earlier generation replay duplicated its parent status"
 pass "later generations cannot invalidate an unacknowledged ingested result"
 
-# A digest-valid but uncorrelated line is still rejected at the public ingest
-# boundary. Recalculate its payload commitment so the behavioral assertion is
-# specifically about status validation, not incidental digest failure.
-BAD_RESULT="$TMP_ROOT/bad.result"
-cp "$RESULT" "$BAD_RESULT"
-boundary=$(grep -n -m 1 '^$' "$BAD_RESULT" | cut -d: -f1)
-tail -n "+$((boundary + 1))" "$BAD_RESULT" \
-  | sed 's/corr=0123456789abcdef/no-correlation/' > "$TMP_ROOT/bad.payload"
-bad_bytes=$(LC_ALL=C wc -c < "$TMP_ROOT/bad.payload" | tr -d ' ')
-bad_hash=$(sha256_file "$TMP_ROOT/bad.payload")
-head -n "$boundary" "$BAD_RESULT" \
-  | sed "s/^payload_sha256=.*/payload_sha256=$bad_hash/;s/^payload_bytes=.*/payload_bytes=$bad_bytes/" \
-  > "$TMP_ROOT/bad.header"
-cat "$TMP_ROOT/bad.header" "$TMP_ROOT/bad.payload" > "$BAD_RESULT"
-if remote_env "$ADAPTER" ingest ios "$BAD_RESULT" >/dev/null 2>&1; then
-  fail "ingest accepted a status line with no correlation token"
-fi
-[ "$(grep -cF 'done [corr=0123456789abcdef]' "$PARENT/state/ios.status")" -eq 1 ] \
-  || fail "invalid ingest disturbed the accepted parent status line"
-pass "ingest rejects uncorrelated payload even when its transport digest is valid"
+# The channel mirrors the remote mate's whole status stream, exactly as a local
+# secondmate writes it. A remote mate's own progress line and a NEWLY raised
+# needs-decision carry no corr= by charter contract, and a delta carrying them
+# alongside a correlated answer must ingest whole: every line reaches the parent
+# stream, the new decision reaches the parent's open-decision fold, the
+# correlated line still settles its pending-reply record, and the cursor
+# advances so the channel cannot wedge on a line it once refused.
+# shellcheck source=bin/fm-pending-reply-lib.sh
+. "$ROOT/bin/fm-pending-reply-lib.sh"
+PENDING_CORR=$(fm_pending_reply_create "$PARENT" "$PARENT/state" ios 'audit the release chain')
+[ -n "$PENDING_CORR" ] || fail "could not create the parent pending-reply record"
+fm_pending_reply_mark_delivered "$PARENT/state" "$PENDING_CORR" \
+  || fail "could not mark the pending-reply request delivered"
+{
+  printf 'working [key=version-audit]: family --version audit complete (data/reply/report.md)\n'
+  printf 'needs-decision [key=rough-cut-version]: implement --version or retire the tool\n'
+  printf 'done [corr=%s]: release chain audited\n' "$PENDING_CORR"
+} >> "$REMOTE/state/parent-replies.status"
+remote_env "$ROOT/bin/fm-procevent.sh" start "$SID" >/dev/null \
+  || fail "the mirrored status stream was not captured"
+RESULT_FOUR="$PARENT/state/procevent-inbox/$SID.4.result"
+remote_env "$ADAPTER" handle ios 4 "$RESULT_FOUR" > "$TMP_ROOT/handle-mirror.out" 2>&1 \
+  || fail "an uncorrelated status line stopped the delta: $(cat "$TMP_ROOT/handle-mirror.out")"
+assert_grep 'working [key=version-audit]' "$PARENT/state/ios.status" "an uncorrelated progress line never reached the parent stream"
+assert_grep 'needs-decision [key=rough-cut-version]' "$PARENT/state/ios.status" "a newly raised remote decision never reached the parent stream"
+assert_grep "done [corr=$PENDING_CORR]" "$PARENT/state/ios.status" "the correlated answer sharing the delta was lost"
+mirror_offset=$(LC_ALL=C wc -c < "$REMOTE/state/parent-replies.status" | tr -d ' ')
+assert_grep "offset=$mirror_offset" "$PARENT/state/remote-replies/ios.cursor" \
+  "the cursor did not advance past an uncorrelated line"
+pass "the whole remote status stream mirrors, correlated or not, and the cursor advances"
+
+# The newly raised decision must be indistinguishable from a local mate's, so the
+# shared fold - not this adapter - decides it is open.
+# shellcheck source=bin/fm-classify-lib.sh
+. "$ROOT/bin/fm-classify-lib.sh"
+OPEN=$(status_open_decisions "$PARENT/state/ios.status")
+printf '%s' "$OPEN" | grep -q '^rough-cut-version	needs-decision	' \
+  || fail "the remote mate's new decision did not surface as open to the parent: $OPEN"
+[ "$(fm_pending_reply_get "$PARENT/state/pending-replies/$PENDING_CORR" phase)" = resolved ] \
+  || fail "the correlated answer in the same delta did not settle its pending-reply record"
+pass "a remote mate's new decision folds open exactly as a local mate's does"
+
+# Ingesting the same generation again is idempotent: no duplicated lines and no
+# cursor movement, so a replay can never wedge or double-count the stream.
+remote_env "$ADAPTER" handle ios 4 "$RESULT_FOUR" >/dev/null 2>&1 || true
+[ "$(grep -cF 'needs-decision [key=rough-cut-version]' "$PARENT/state/ios.status")" -eq 1 ] \
+  || fail "replaying the mirrored delta duplicated the new decision"
+assert_grep "offset=$mirror_offset" "$PARENT/state/remote-replies/ios.cursor" \
+  "replaying the mirrored delta moved the cursor"
+pass "a replayed mirrored delta is idempotent in both the stream and the cursor"
+
+# Bytes crossing a machine boundary are normalized, never dropped: a control
+# character cannot make the parent's status file unsafe and cannot stop the
+# stream either.
+printf 'blocked [key=ctl]: escape \033[31mhere\033[0m bell \007 caf\xc3\xa9 end\n' \
+  >> "$REMOTE/state/parent-replies.status"
+remote_env "$ROOT/bin/fm-procevent.sh" start "$SID" >/dev/null \
+  || fail "the control-character line was not captured"
+RESULT_FIVE="$PARENT/state/procevent-inbox/$SID.5.result"
+remote_env "$ADAPTER" handle ios 5 "$RESULT_FIVE" >/dev/null 2>&1 \
+  || fail "a control character stopped the stream"
+assert_grep 'blocked [key=ctl]: escape ?[31mhere' "$PARENT/state/ios.status" \
+  "the control-character line was not mirrored in normalized form"
+[ -z "$(LC_ALL=C tr -d '\11\12\40-\176\200-\377' < "$PARENT/state/ios.status")" ] \
+  || fail "a control byte reached the parent status file"
+assert_grep "$(printf 'caf\xc3\xa9 end')" "$PARENT/state/ios.status" \
+  "normalization mangled a UTF-8 note a local secondmate could have written"
+ctl_offset=$(LC_ALL=C wc -c < "$REMOTE/state/parent-replies.status" | tr -d ' ')
+assert_grep "offset=$ctl_offset" "$PARENT/state/remote-replies/ios.cursor" \
+  "the cursor did not advance past a control-character line"
+pass "transported control bytes are normalized in place and never stop the stream"
 
 # The adapter re-armed at the committed cursor. Truncation is detected from the
 # next blocking source and escalated once; it is never silently treated as a new
@@ -198,23 +249,23 @@ printf 'failed [corr=fedcba9876543210]: source was replaced\n' > "$REMOTE/state/
 remote_env "$ROOT/bin/fm-procevent.sh" start "$SID" > "$TMP_ROOT/start-two.out" 2>&1 &
 RUNNER=$!
 wait "$RUNNER" || fail "continuity break was not captured as a structured result"
-RESULT_FOUR=$(find "$PARENT/state/procevent-inbox" -name "$SID.4.result" -print -quit)
-[ -n "$RESULT_FOUR" ] || fail "continuity break produced no durable result"
-[ "$(remote_env "$ADAPTER" classify "$RESULT_FOUR")" = continuity-broken ] \
+RESULT_SIX=$(find "$PARENT/state/procevent-inbox" -name "$SID.6.result" -print -quit)
+[ -n "$RESULT_SIX" ] || fail "continuity break produced no durable result"
+[ "$(remote_env "$ADAPTER" classify "$RESULT_SIX")" = continuity-broken ] \
   || fail "truncated source was not classified as a continuity break"
 set +e
-remote_env "$ADAPTER" handle ios 4 "$RESULT_FOUR" > "$TMP_ROOT/handle-four.out" 2>&1
+remote_env "$ADAPTER" handle ios 6 "$RESULT_SIX" > "$TMP_ROOT/handle-six.out" 2>&1
 handle_rc=$?
 set -e
 [ "$handle_rc" -eq 3 ] || fail "continuity handling returned an unexpected status: $handle_rc"
 assert_grep 'blocked [key=remote-reply-continuity-ios]' "$PARENT/state/ios.status" "continuity break did not escalate"
 assert_absent "$PARENT/state/procevent/$SID.source" "continuity break was re-armed without an operator rebase"
-remote_env "$ADAPTER" ingest ios "$RESULT_FOUR" >/dev/null 2>&1 || true
+remote_env "$ADAPTER" ingest ios "$RESULT_SIX" >/dev/null 2>&1 || true
 [ "$(grep -cF 'blocked [key=remote-reply-continuity-ios]' "$PARENT/state/ios.status")" -eq 1 ] \
   || fail "continuity replay duplicated the escalation"
 pass "truncation is detected, escalated once, and not silently rebased"
 
-rm -f "$PARENT/state/procevent-inbox/$SID.4.handled"
+rm -f "$PARENT/state/procevent-inbox/$SID.6.handled"
 if remote_env "$ADAPTER" retire ios > "$TMP_ROOT/retire-pending.out" 2>&1; then
   fail "remote reply retirement accepted an unhandled captured result"
 fi
@@ -222,7 +273,7 @@ assert_grep 'unhandled captured result' "$TMP_ROOT/retire-pending.out" \
   "remote reply retirement did not explain its pending-result refusal"
 assert_absent "$PARENT/state/procevent/$SID.source" \
   "refused retirement left the reply source running past its pending-result check"
-remote_env "$ADAPTER" handle ios 4 "$RESULT_FOUR" >/dev/null 2>&1 || [ "$?" -eq 3 ] \
+remote_env "$ADAPTER" handle ios 6 "$RESULT_SIX" >/dev/null 2>&1 || [ "$?" -eq 3 ] \
   || fail "pending continuity result could not be acknowledged after retirement refusal"
 remote_env "$ADAPTER" retire ios >/dev/null
 assert_absent "$PARENT/state/remote-replies/ios.cursor" "adapter retirement left its cursor"

--- a/tests/fm-remote-reply.test.sh
+++ b/tests/fm-remote-reply.test.sh
@@ -170,13 +170,13 @@ assert_contains "$out" 'handled: remote-reply-ios 2' "earlier generation remaine
   || fail "earlier generation replay duplicated its parent status"
 pass "later generations cannot invalidate an unacknowledged ingested result"
 
-# The channel mirrors the remote mate's whole status stream, exactly as a local
-# secondmate writes it. A remote mate's own progress line and a NEWLY raised
-# needs-decision carry no corr= by charter contract, and a delta carrying them
-# alongside a correlated answer must ingest whole: every line reaches the parent
-# stream, the new decision reaches the parent's open-decision fold, the
-# correlated line still settles its pending-reply record, and the cursor
-# advances so the channel cannot wedge on a line it once refused.
+# The channel mirrors the remote mate's content-bearing status lines at most once
+# while omitting blank separators. A remote mate's own progress line and a NEWLY
+# raised needs-decision carry no corr= by charter contract, and a delta carrying
+# them alongside a correlated answer must ingest whole: every content-bearing
+# line reaches the parent stream, the new decision reaches the parent's
+# open-decision fold, the correlated line still settles its pending-reply record,
+# and the cursor advances so the channel cannot wedge on a line it once refused.
 # shellcheck source=bin/fm-pending-reply-lib.sh
 . "$ROOT/bin/fm-pending-reply-lib.sh"
 PENDING_CORR=$(fm_pending_reply_create "$PARENT" "$PARENT/state" ios 'audit the release chain')
@@ -199,7 +199,7 @@ assert_grep "done [corr=$PENDING_CORR]" "$PARENT/state/ios.status" "the correlat
 mirror_offset=$(LC_ALL=C wc -c < "$REMOTE/state/parent-replies.status" | tr -d ' ')
 assert_grep "offset=$mirror_offset" "$PARENT/state/remote-replies/ios.cursor" \
   "the cursor did not advance past an uncorrelated line"
-pass "the whole remote status stream mirrors, correlated or not, and the cursor advances"
+pass "the remote status and decision model mirrors and the cursor advances"
 
 # The newly raised decision must be indistinguishable from a local mate's, so the
 # shared fold - not this adapter - decides it is open.


### PR DESCRIPTION
## Intent

Fix a remote-secondmate transport bug in firstmate: the remote reply adapter (bin/fm-procevent-remote-reply.sh) fail-closed and wedged the reply channel when a remote secondmate wrote UN-CORRELATED status lines, and a remote secondmate had no first-class way to raise a NEW needs-decision to the parent.

OBSERVED BUG (captain, 2026-08-06): the adapter could not ingest axi-a1 reply seq 5 with 'delta contains an invalid or uncorrelated status line'. The remote mate had written a NEW needs-decision it was raising plus a 'working [key=...]' progress line; neither carries a corr= token, so line_valid rejected the WHOLE delta. Two real problems: (1) an un-correlated line WEDGES the channel because the cursor cannot advance past it, so ingest fails repeatedly and the channel is stuck; (2) a remote secondmate has NO clean path to raise a NEW needs-decision to the parent through the reply channel.

CAPTAIN DESIGN PRINCIPLE (supersedes any 'tolerate/route un-correlated lines' framing): remote vs local secondmates must differ ONLY at the transport layer. Do NOT bespoke-patch the correlated-reply channel. Instead make a REMOTE secondmate present the SAME status/decision model as a LOCAL one - the full status stream including un-correlated progress AND newly raised needs-decisions - just carried over SSH, so raising a decision, folding open-decisions, and reconciling status all work identically local vs remote. Ask WHY local mates do not have this bug (their status stream is written straight into the parent's state/<id>.status and read/folded directly) and adopt that architecture over the transport.

WHAT WAS IMPLEMENTED: the channel is now a status-stream MIRROR rather than a correlated-reply channel. Correlation is restored to what it is locally - a per-line property that fm-pending-reply-lib.sh consumes to settle a pending request - and is no longer a gate on the stream, so no single line can stop ingest or freeze the cursor. The verb allowlist and per-line byte cap were removed as semantic gates with no local analogue; line framing and size bounding already belong to bin/fm-remote-delta-read.sh, which delivers only whole lines and raises a continuity break on an over-long one. What remains is only what crossing a machine boundary genuinely adds: cursor continuity and identity, data/*.md pointers fetched through the path-confined remote reader and rewritten to local copies, at-most-once append, and control-byte normalization that rewrites C0/DEL bytes to '?' while passing tab, printable ASCII and all high bytes (UTF-8) through untouched - it never drops a line. A document the remote reader permanently refuses is named in one keyed escalation and the mate's line is mirrored with its own pointer intact, rather than stalling the stream; an SSH exit 255 stays 'transport unavailable/unknown' and still leaves the delta for the runner's existing retry, per fm-on.sh's documented contract. A later refactor gave the parent status stream ONE at-most-once append owner (append_status_once) used by the mirrored line, the continuity escalation, and the document escalation - the captain asked for this to stay clean and well-factored because follow-on work builds on it.

DELIBERATE: the secondmate charter (bin/fm-brief.sh) was NOT changed. It already tells a mate to report progress phases and raise decisions without a corr token, and only marked from-firstmate requests require correlation. The charter was already correct; the transport was wrong. That no-change is evidence the architecture is right, not an omission.

DIAGNOSIS DELIVERED: reproduced the wedge end to end against the real ingest boundary (three consecutive ingests of a staged delta all failed identically with the cursor never created and the parent status file never written). Pinned the exact mechanism: cmd_ingest's per-line line_valid call dies before write_cursor, so the cursor never advances and every retry replays the same rejection; cmd_handle_locked then returns nonzero, so the generation is never acknowledged and the source is never re-armed. Read-only durable-record finding on the live axi-a1 mate (no SSH, no mutation of the live host or channel): its channel IS currently wedged AND dark - cursor frozen at offset 2088, the seq-5 delta (offsets 2088-4364, three lines including TWO newly raised needs-decisions) never reached state/axi-a1.status (2088 bytes, unchanged since 12:47), no .5.ingested receipt exists although a .5.handled marker does, and no remote-reply-axi-a1 source registration remains, so nothing newer can arrive either. Recovering the live axi-a1 channel is explicitly NOT part of this change and stays with the main firstmate.

SCOPE - EXPLICITLY NARROWED BY THE CAPTAIN: a scope expansion to fold in remote STATE reconciliation (fm-crew-state.sh misreporting 'worktree gone' because it stats the remote worktree path locally, fm-peek.sh failing 'can't find session: remote' because fm_backend_of_meta returns tmux for a remote meta, false pending-reply-missed alarms, and the duplicated inline remote handling in fm-bootstrap.sh and fm-fleet-snapshot.sh) was diagnosed and proposed, and the captain then APPROVED A SPLIT: this change is JUST the reply-channel unwedge. The state-reads reconciliation is a separate follow-on the captain is filing and must NOT be done here. Do not add remote placement resolution, backend dispatch changes, or crew-state/peek changes to this change.

COORDINATION: PR #1831 edits this same adapter (runner auto-ingest, pending-reply resolution, library-owned escalation-format matching) and is not in this branch's base (main). Do not undo it. Its added pending-reply-* decision-key rejection sits inside line_valid, the function this change removes, and on main that rejection is itself whole-delta-fatal; how to reconcile it was raised to the captain as an open decision and deliberately NOT decided in this change.

ACCEPTANCE CRITERIA: a reply delta with an un-correlated needs-decision and/or 'working [key=...]' line ingests without wedging and the cursor advances; correlated replies still resolve their pending-reply records exactly as before; a remote secondmate can raise a NEW needs-decision that surfaces to the parent's decision/hold path through the shared fold; the whole-delta-rejection-on-one-bad-line wedge is gone while validation stays fail-closed where correlation is genuinely required, with no silent security or identity regression (cursor/prefix continuity, confined document fetch, and exact-corr pending-reply resolution are all unchanged); regression and E2E tests added; bin/fm-lint.sh clean.

Firstmate repo conventions apply: one sentence per line in tracked Markdown, plain dash never an em dash, no agent co-author, shellcheck-clean bin scripts via bin/fm-lint.sh, tests colocated in tests/ extending the existing runner, and tests must exercise behavior through an executable interface rather than asserting implementation source text. Delivery is mode=no-mistakes with yolo OFF: the captain merges, no self-merge.

## What Changed

- Mirror every content-bearing remote secondmate status line, including uncorrelated progress and newly raised decisions, while preserving cursor continuity, at-most-once appends, and correlated pending-reply resolution.
- Normalize transported control bytes and isolate transport metadata from payload lines so malformed content cannot wedge cursor advancement.
- Keep confined document transfers retryable for transport or local-storage failures, while mirroring permanently refused pointers with a keyed escalation, and expand behavioral coverage and documentation for the status-stream contract.

## Risk Assessment

🚨 High: A reachable infrastructure failure can still cause permanent document loss and cursor advancement, contradicting the required permanent-refusal-only commit invariant.

## Testing

The focused remote-reply E2E passed and produced a reviewer-visible transcript showing the remote status stream reaches the parent, newly raised decisions fold open, correlated replies resolve pending records, and the cursor advances without wedging; no baseline results were supplied, and lint was not run because this phase expressly forbids static analysis.

<details>
<summary>Evidence: Remote reply E2E transcript</summary>

```text
ok - a blocking non-destructive remote delta reaches durable process-event capture
ok - ingest appends one validated line, fetches its document, and advances the cursor
ok - replayed capture has one deduplicated append and one durable handling identity
ok - later generations cannot invalidate an unacknowledged ingested result
ok - the remote status and decision model mirrors and the cursor advances
ok - a remote mate's new decision folds open exactly as a local mate's does
ok - a replayed mirrored delta is idempotent in both the stream and the cursor
ok - transported control bytes are normalized in place and never stop the stream
ok - payload protocol-field names cannot collide with transport metadata
ok - NUL bytes are normalized in place before shell line processing
ok - local document storage failures remain retryable until delivery succeeds
ok - truncation is detected, escalated once, and not silently rebased
ok - remote reply retirement quiesces and refuses unhandled captured results
ALL TESTS PASSED
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 error</summary>

- 🚨 `bin/fm-procevent-remote-reply.sh:334` - The required invariant says “the whole-delta-rejection-on-one-bad-line wedge is gone,” but accepting every nonempty line exposes the result parser’s whole-file `result_field` scan: a payload line beginning `status=`, `path=`, `reason=`, or another protocol field makes that field ambiguous, so ingest fails before advancing the cursor and retries wedge on the same delta. Parse metadata only from the header before the blank payload boundary.
- 🚨 `bin/fm-procevent-remote-reply.sh:333` - The required normalization “rewrites C0/DEL bytes to &#39;?&#39;”, but Bash `read` stores the payload in `line` before `mirror_line` runs and cannot preserve NUL bytes, so NUL is discarded instead of rewritten. Normalize the staged payload bytewise before reading it into shell variables.
- 🚨 `bin/fm-procevent-remote-reply.sh:345` - Every non-255 `fetch_document` failure is treated as a permanent remote refusal, but the function also returns 1 for local `mkdir`, confinement, `mktemp`, `chmod`, and `mv` failures. A transient local storage failure therefore appends an undelivered escalation and commits the cursor, permanently abandoning the document. Return distinct statuses and advance only for an actual permanent remote-reader refusal; local failures must leave the delta retryable.

🔧 Fix: Keep local document transfer failures retryable
2 errors still open:
- 🚨 `bin/fm-procevent-remote-reply.sh:334` - The required “whole-delta-rejection-on-one-bad-line wedge is gone” invariant remains false: arbitrary mirrored payload may contain a line beginning `schema=`, `status=`, `path=`, or another protocol field, while `result_field` scans the whole result rather than only the header. The field becomes ambiguous before cursor advancement, so every retry wedges on the same delta. Parse metadata only before the blank payload boundary.
- 🚨 `bin/fm-procevent-remote-reply.sh:336` - The required normalization says every C0/DEL byte becomes `?`, but `read` places payload bytes in a Bash variable and `mirror_line` uses command substitution; Bash cannot preserve NUL, and the `tr` range also excludes NUL. A NUL is therefore dropped or can make whole-file header parsing treat the result as binary instead of being rewritten. Normalize the staged payload bytewise before header-safe line processing.

🔧 Fix: Isolate reply headers and normalize payload bytes
1 error still open:
- 🚨 `bin/fm-procevent-remote-reply.sh:341` - The required mirror contract says it “reproduces its stream line for line” and “never drops a line,” but this branch explicitly skips every complete blank payload line. The remote delta reader can deliver blank newline-terminated lines, and the cursor then advances past them, permanently diverging from the local status stream. Mirror the blank line through the shared append owner instead of continuing.

🔧 Fix: Correct remote reply mirror contract wording
2 issues (1 error, 1 warning) still open:
- 🚨 `bin/fm-procevent-remote-reply.sh:255` - `fm-on.sh` can return non-255 failures before the remote reader runs, including remote entrypoint or worker failures with status 64/70. This code treats all of them as permanent document refusals, then mirrors the unresolved pointer and commits the cursor, so a temporary infrastructure failure permanently abandons the document. Preserve provenance at the remote-command boundary and commit only when the reader itself definitively refused the document; keep dispatch and infrastructure failures retryable.
- ⚠️ `docs/scripts.md:65` - The script catalog still describes this adapter as relaying &#34;correlated remote-secondmate reply deltas&#34;, contradicting the changed status-stream mirror contract where correlation is never an ingest gate. Update the catalog entry to describe the remote status stream.

🔧 Fix: Update remote reply script catalog description
1 error still open:
- 🚨 `bin/fm-procevent-remote-reply.sh:255` - `fm-on.sh` can fail before the remote file reader runs, including local route validation and remote entrypoint or worker failures. This code treats every non-255 failure as a permanent document refusal, then mirrors the unresolved pointer and commits the cursor, permanently abandoning a document after transient infrastructure failure. Preserve failure provenance at the remote-command boundary and commit only when the reader itself definitively refused the document; keep dispatch and infrastructure failures retryable.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash tests/fm-remote-reply.test.sh` - exercised fake-SSH process-event capture, uncorrelated progress and new-decision mirroring, shared decision folding, exact-correlation pending-reply settlement, cursor advancement, replay idempotency, control-byte normalization, document delivery recovery, and continuity failure handling</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>


## Known and deferred

These are deliberate captain decisions, not oversights.

**Document-fetch provenance is deferred to `fm-remote-doc-fetch-provenance-r1`.**
`fm-on.sh` returns ssh's status unchanged, so 255 alone means unavailable transport.
This change treats a remaining non-255 remote-command failure as a permanent reader refusal, mirrors the mate's line with its own pointer intact, names the gap in one keyed escalation, and lets the stream continue.
That classification is too coarse in one direction: `bin/fm-remote-file.sh` signals its own definitive refusals through `die` with exit 1, the same status `fm-on.sh` uses for route-validation failure, so exit 1 cannot currently distinguish "the reader refused" from "the reader never ran".
A transient dispatch failure can therefore cost one document copy rather than being retried.
Making that provenance definitive requires exit-code changes in `bin/fm-remote-file.sh` or `bin/fm-on.sh`, which are shared remote transport also used by backlog handoff, so the captain scoped it out of this change rather than widen it.
This is still a strict improvement over the previous behavior, which failed the whole delta on any fetch failure and wedged the channel permanently.
Local storage failures and unavailable transport both remain retryable here.

**Remote state reconciliation is a separate follow-on.**
The same root cause reaches the parent's state reads: `remote` is a real placement that only `bin/fm-send.sh` understands, so `fm_backend_of_meta` resolves a remote secondmate's metadata to tmux and other readers treat `window=remote:<id>` as a local session.
`bin/fm-crew-state.sh` stats the remote worktree path locally and reports it torn down, `bin/fm-peek.sh` dispatches tmux and fails to find session `remote`, and `bin/fm-bootstrap.sh` and `bin/fm-fleet-snapshot.sh` each carry their own inline remote handling.
That work is filed separately and is deliberately absent here.

**PR #1831 reconciliation is unresolved by design.**
That PR edits this same adapter and is not in this branch's base.
Its `pending-reply-*` decision-key rejection sits inside `line_valid`, the function this change removes, and on main that rejection is itself whole-delta-fatal.
Because a local secondmate can write the same line straight into the parent status file, the guard likely belongs in the shared consumer rather than in this transport.
That was raised to the captain as an open decision and is not decided here; no code from #1831 was modified.
