### PR TITLE
feat(brief): add context-discipline guidance to crewmate scaffold

### DIFF
--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -49,6 +49,13 @@
 # declared-external-wait verb (FM_CLASSIFY_PAUSED_VERB, default "paused") from
 # "blocked:": pause for a known external wait expected to clear on its own,
 # blocked when firstmate must act.
+# Ship and scout scaffolds carry context-discipline rules: the worker compacts
+# itself only past a token threshold AND at a phase boundary, never mid-validation
+# or mid-gate. Compaction stays worker-owned because firstmate cannot see from
+# outside whether a worker is mid-write, mid-gate, or holding pipeline ownership,
+# so nothing here or in firstmate injects a compact into a running worker. The
+# secondmate charter omits both rules: it is a persistent home, not a short-lived
+# task worker with phase boundaries to compact at.
 # Ship tasks include a project-memory section so durable project-intrinsic
 # learnings can be committed to AGENTS.md through the project's delivery path;
 # it carries the AGENTS.md authoring bar (widely useful knowledge only, pointers

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -317,6 +317,10 @@ The report is the only thing that survives, so anything worth keeping must be in
 1. Never push to any remote and never open a PR.
 2. Stay inside this worktree; the only files you may write outside it are the report and the status file below.
 3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
+   This is a cost rule, not a style preference: the axi tools (https://axi.md) hold MCP-grade
+   reliability at CLI token cost. A previous fleet worker skipped this line for browser work and
+   used the MCP browser path instead, burning 662k tokens - the largest single context cost
+   measured in that run, paid again on every turn it kept running.
 4. Report status by appending one line:
    \`echo "{state}: {one short line}" >> $STATUS_FILE\`
    States: working, needs-decision, blocked, $PAUSED_VERB, done, failed.
@@ -335,6 +339,15 @@ The report is the only thing that survives, so anything worth keeping must be in
 7. Never stop, restart, or update the shared \`no-mistakes\` daemon - it is one instance serving
    every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
    daemon error, append \`blocked: {the daemon error}\` and stop; only firstmate manages the daemon.
+8. Manage your own context deliberately - it is billed every turn, not once. Once you are past
+   roughly 150k tokens of context AND you reach a natural phase boundary (a finding confirmed, a
+   section of the report drafted), write it down durably in the report or a working file - not
+   memory - then compact yourself, naming the report's open findings and the task's acceptance
+   criteria as what to preserve. Firstmate never injects a compact into your session; the
+   threshold is yours to act on.
+9. Read files with offset and limit rather than whole files, especially large specs and reports.
+   Do not re-read a file you already read unless it changed. Keep browser captures and tool output
+   targeted - a narrow query beats a broad dump.
 
 # Definition of done
 Write your findings to \`$DATA/$ID/report.md\`.
@@ -430,6 +443,10 @@ If the top-level path is the primary checkout or not the worktree you were launc
 $RULE1
 2. Stay inside this worktree; modify nothing outside it.
 3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
+   This is a cost rule, not a style preference: the axi tools (https://axi.md) hold MCP-grade
+   reliability at CLI token cost. A previous fleet worker skipped this line for browser work and
+   used the MCP browser path instead, burning 662k tokens - the largest single context cost
+   measured in that run, paid again on every turn it kept running.
 4. Report status by appending one line:
    \`echo "{state}: {one short line}" >> $STATUS_FILE\`
    States: working, needs-decision, blocked, $PAUSED_VERB, done, failed.
@@ -451,6 +468,16 @@ $RULE1
 7. Never stop, restart, or update the shared \`no-mistakes\` daemon - it is one instance serving
    every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
    daemon error, append \`blocked: {the daemon error}\` and stop; only firstmate manages the daemon.
+8. Manage your own context deliberately - it is billed every turn, not once. Once you are past
+   roughly 150k tokens of context AND you reach a natural phase boundary (setup complete, a
+   component built, validation passed), write down where you are - durably, in the task's own
+   notes or working files, not memory - then compact yourself, naming the brief's acceptance
+   criteria, any open findings or decisions, and the delivery contract as what to preserve. Never
+   compact mid-validation-run or while holding a gate open: finding IDs and gate state must stay
+   stable. Firstmate never injects a compact into your session; the threshold is yours to act on.
+9. Read files with offset and limit rather than whole files, especially large specs and reports.
+   Do not re-read a file you already read unless it changed. Keep browser captures and tool output
+   targeted - a narrow query beats a broad dump.
 
 # Project memory
 If \`AGENTS.md\` or \`CLAUDE.md\` already exists, or if this task produced durable project-intrinsic knowledge, run \`$FM_ROOT/bin/fm-ensure-agents-md.sh .\` in the worktree.


### PR DESCRIPTION
## Summary

Adds context-discipline guidance to the crewmate brief scaffold (`bin/fm-brief.sh`) so future workers manage their own context window deliberately instead of accumulating until the runtime compacts for them.

Two short additions to the generated ship and scout Rules sections:

- **Worker-owned compaction at phase boundaries** (new rule 8): once a worker is past roughly 150k tokens of context *and* reaches a natural phase boundary (setup complete, a component built, validation passed - the same boundaries the status protocol already recognizes), it writes its state down durably, then compacts itself with explicit preservation instructions.
  It never compacts mid-validation-run or while holding a gate open. Firstmate still never injects `/compact` into a worker from outside - it cannot see whether a worker is mid-write, mid-gate, or holding pipeline ownership, so the threshold stays the worker's own to act on.
- **Intake discipline** (new rule 9): read with offset/limit rather than whole files, don't re-read an unchanged file, keep browser captures and tool output targeted.

Also strengthens the existing "Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations" rule into a stated cost rule, since it was measurably ignored: a previous fleet worker drove browser work through the MCP browser path instead of `chrome-devtools-axi` and burned 662,300 tokens doing it - the single largest context consumer measured in that run.

## Why the evidence pointed this way

A live crewmate (Sonnet 5, a long multi-phase build) was measured mid-task at 61% context, not in distress, with the runtime's own compaction buffer already reserved. But its cumulative per-tool token costs (662.3k for browser batching, 406k for file reads) **exceeded the live context window**, meaning that material was paid for, compacted away, and in several cases read again. Intake cost, not conversation sprawl, was the dominant cost.

A separate `/usage` reading on the captain's account showed context is billed **per turn, not once**: 76% of usage was at >150k context, and a worker sitting at high context pays a multiple of that cost on every single turn for as long as it runs.

## External threshold-triggered compaction was considered and rejected

An earlier draft omitted a specific token number, reasoning that a number invites compacting on a schedule rather than at a safe moment. That's addressed here by requiring *both* the ~150k condition and the phase-boundary condition together - one names when it's overdue, the other says when it's safe to act.

Separately, firstmate itself never injects `/compact` into a worker: firstmate cannot see whether a worker is mid-file-write, mid-validation-gate, or holding pipeline ownership, so an externally triggered compaction risks landing mid-thought. Only the worker knows where its own phase boundaries are, so compaction stays worker-owned rather than becoming external machinery - consistent with AGENTS.md section 7's bar that machinery needs a demonstrated blocker, and no such blocker exists here since the runtime's own compaction already works.

## Scope

Only the generated brief text changed - no new script logic, flags, configuration, or
context-inspecting machinery. The worktree-isolation assertion, status protocol, paused/blocked distinction, no-mistakes delivery contract, and ask-user escalation rule are untouched. The secondmate charter scaffold is deliberately untouched too: it's a persistent home, not a short-lived task worker with phase boundaries to compact at. `AGENTS.md` is untouched (owned by a separate task).

## Test plan

- [x] `bash -n bin/fm-brief.sh` syntax check
- [x] `bin/fm-lint.sh bin/fm-brief.sh` (ShellCheck 0.11.0, pinned) clean
- [x] Generated all six scaffold variants (no-mistakes, direct-PR, local-only, `--scout`,
      `--herdr-lab`, `--secondmate`) into a temp `FM_HOME` - all generate without error, and the new guidance reads naturally in place in the ship and scout output
- [x] Validated end-to-end through the no-mistakes pipeline (review/test/document/lint, zero findings)
