### PR TITLE
fix(tests): restore reliable fm-send backend parity coverage

### DIFF
--- a/tests/fm-backend-herdr-focus-flash-e2e.test.sh
+++ b/tests/fm-backend-herdr-focus-flash-e2e.test.sh
@@ -243,17 +243,28 @@ lab pane send-keys "$C_DOOMED_PANE" enter >/dev/null \
   || fail 'could not submit the Part C persistent-child command'
 C_SHELL_PID=
 C_CHILD_ATTEMPT=0
+C_CHILD_STABLE=0
 while [ "$C_CHILD_ATTEMPT" -lt 100 ]; do
   C_SHELL_PID=$(lab pane process-info --pane "$C_DOOMED_PANE" 2>/dev/null \
     | jq -r '.result.process_info.shell_pid // empty' 2>/dev/null) || C_SHELL_PID=
-  if [ -n "$C_SHELL_PID" ] && ps -axo ppid= | tr -d ' ' | grep -qx "$C_SHELL_PID"; then
-    break
+  if [ -n "$C_SHELL_PID" ] && ps -axo ppid=,comm= | awk -v parent="$C_SHELL_PID" '
+    $1 == parent {
+      command = $2
+      sub(/^.*\//, "", command)
+      if (command == "sleep") found = 1
+    }
+    END { exit(found ? 0 : 1) }
+  '; then
+    C_CHILD_STABLE=$((C_CHILD_STABLE + 1))
+    [ "$C_CHILD_STABLE" -ge 2 ] && break
+  else
+    C_CHILD_STABLE=0
+    C_SHELL_PID=
   fi
-  C_SHELL_PID=
   sleep 0.1
   C_CHILD_ATTEMPT=$((C_CHILD_ATTEMPT + 1))
 done
-[ -n "$C_SHELL_PID" ] || fail 'the Part C doomed pane never acquired a persistent child process'
+[ "$C_CHILD_STABLE" -ge 2 ] || fail 'the Part C doomed pane never acquired a stable persistent sleep child process'
 
 C_CALL_LOG="$TMP_ROOT/call-c.log"
 C_FOCUS_SAMPLES="$TMP_ROOT/focus-c.samples"

--- a/tests/fm-backend.test.sh
+++ b/tests/fm-backend.test.sh
@@ -135,13 +135,19 @@ resolve_permissive_tmux_kill_ref() {
 # `. "$SCRIPT_DIR/<sibling>"` under set -eu, so one sibling missing from the
 # synthetic tree aborts the old script during its sourcing prologue, before it
 # parses a single argument.
+# The old-vs-new cases below then compare a crashed process against a working
+# one and report a behavior divergence that never happened, which is why the
+# sibling set is copied WHOLE rather than enumerated: an enumerated list has to
+# be extended by hand every time an entrypoint gains a dependency and is the
+# only thing that knows, while a whole-tree copy has nothing to forget.
 # Copies keep BASH_SOURCE-based sibling resolution inside the synthetic tree on
 # both macOS and Linux; symlinks make that resolution shell/platform-dependent.
 # FM_ROOT_OVERRIDE pointed at this dir's root makes
 # "$FM_ROOT/bin/fm-project-mode.sh" (etc.) resolve correctly.
-# Only the refactored entrypoints and the bin/backends/tmux.sh adapter are
-# extracted from BASE_REF, so conformance tests retain the exact historical
-# behavior even when this branch changes tmux dispatch semantics.
+# Siblings come from this checkout because they are the versions BASE_REF would
+# have used too; only the refactored entrypoints and the bin/backends/tmux.sh
+# adapter are extracted from BASE_REF, so conformance tests retain the exact
+# historical behavior even when this branch changes tmux dispatch semantics.
 OLD_BIN_REFACTORED="fm-send.sh fm-peek.sh fm-watch.sh fm-spawn.sh fm-teardown.sh fm-marker-lib.sh"
 
 build_old_bin() {  # <name> -> echoes root dir (root/bin/<script> is the entry point)

--- a/tests/fm-backend.test.sh
+++ b/tests/fm-backend.test.sh
@@ -127,42 +127,27 @@ resolve_permissive_tmux_kill_ref() {
 
 # --- shared: a pre-refactor bin/ shim --------------------------------------
 #
-# build_old_bin echoes a directory whose bin/ subdir holds the PRE-REFACTOR
-# fm-send.sh, fm-peek.sh, fm-watch.sh, fm-spawn.sh, fm-teardown.sh, and
-# fm-marker-lib.sh, all extracted from BASE_REF, laid over a whole copy of this
-# checkout's bin/ tree.
-# Every one of those entrypoints resolves its dependencies as
-# `. "$SCRIPT_DIR/<sibling>"` under set -eu, so one sibling missing from the
-# synthetic tree aborts the old script during its sourcing prologue, before it
-# parses a single argument.
-# The old-vs-new cases below then compare a crashed process against a working
-# one and report a behavior divergence that never happened, which is why the
-# sibling set is copied WHOLE rather than enumerated: an enumerated list has to
-# be extended by hand every time an entrypoint gains a dependency and is the
-# only thing that knows, while a whole-tree copy has nothing to forget.
-# Copies keep BASH_SOURCE-based sibling resolution inside the synthetic tree on
-# both macOS and Linux; symlinks make that resolution shell/platform-dependent.
+# build_old_bin echoes a directory whose bin/ subdir is the complete bin/ tree
+# from BASE_REF.
+# Materializing the whole historical tree keeps every entrypoint and sourced
+# sibling on the same revision, while avoiding a hand-maintained dependency
+# list that can omit a newly sourced helper and make the old process abort
+# before it reaches the behavior under test.
 # FM_ROOT_OVERRIDE pointed at this dir's root makes
 # "$FM_ROOT/bin/fm-project-mode.sh" (etc.) resolve correctly.
-# Siblings come from this checkout because they are the versions BASE_REF would
-# have used too; only the refactored entrypoints and the bin/backends/tmux.sh
-# adapter are extracted from BASE_REF, so conformance tests retain the exact
-# historical behavior even when this branch changes tmux dispatch semantics.
-OLD_BIN_REFACTORED="fm-send.sh fm-peek.sh fm-watch.sh fm-spawn.sh fm-teardown.sh fm-marker-lib.sh"
+# The teardown conformance case applies its explicitly historical tmux adapter
+# after this complete baseline has been materialized.
 
 build_old_bin() {  # <name> -> echoes root dir (root/bin/<script> is the entry point)
-  local name=$1 root bin f
+  local name=$1 root archive
   root="$TMP_ROOT/$name"
-  bin="$root/bin"
-  mkdir -p "$bin"
-  cp -R "$ROOT/bin/." "$bin/"
-  git -C "$ROOT" show "$BASE_REF:bin/backends/tmux.sh" > "$bin/backends/tmux.sh" \
-    || fail "old-bin shim: $BASE_REF has no bin/backends/tmux.sh"
-  for f in $OLD_BIN_REFACTORED; do
-    git -C "$ROOT" show "$BASE_REF:bin/$f" > "$bin/$f" \
-      || fail "old-bin shim: $BASE_REF has no bin/$f"
-    chmod +x "$bin/$f"
-  done
+  archive="$root/bin.tar"
+  mkdir -p "$root"
+  git -C "$ROOT" archive --format=tar "$BASE_REF" bin > "$archive" \
+    || fail "old-bin shim: could not archive bin/ from $BASE_REF"
+  tar -xf "$archive" -C "$root" \
+    || fail "old-bin shim: could not extract bin/ from $BASE_REF"
+  rm -f "$archive"
   printf '%s\n' "$root"
 }
 

--- a/tests/fm-send-strict.test.sh
+++ b/tests/fm-send-strict.test.sh
@@ -32,6 +32,12 @@ case "${1:-}" in
       esac
     done
     printf 'send-keys target=%s literal=%s arg=%s\n' "$target" "$literal" "${1:-}" >> "$FM_TMUX_LOG"
+    # FM_FAKE_TMUX_SEND_KEY_FAIL names one key whose delivery fails, so the
+    # --key exit contract can be driven both ways from the same stub.
+    if [ "$literal" = 0 ] && [ -n "${FM_FAKE_TMUX_SEND_KEY_FAIL:-}" ] \
+      && [ "${1:-}" = "$FM_FAKE_TMUX_SEND_KEY_FAIL" ]; then
+      exit 1
+    fi
     exit 0 ;;
   display-message)
     target=
@@ -190,7 +196,36 @@ test_healthy_fm_id_send_still_works() {
   pass "fm-send strict: healthy fm-<id> sends still type once and submit"
 }
 
+# A --key send is how firstmate interrupts a worker, so its exit status is the
+# only signal that the interrupt actually landed.
+# Reporting success for a key that was never delivered would leave supervision
+# believing a runaway worker had been stopped, so the failing case must exit
+# nonzero and name the key.
+# Both directions are asserted from one stub so the failing case cannot go
+# quietly vacuous if the key ever stops being delivered at all.
+test_key_send_exit_status_follows_delivery() {
+  local dir fb home err log rc
+  dir="$TMP_ROOT/key-exit"; mkdir -p "$dir"
+  fb=$(make_stubs "$dir"); home=$(setup_home keyexit); err="$dir/send.err"; log="$dir/tmux.log"; : > "$log"
+  fm_write_meta "$home/state/lane-key.meta" "window=sess:fm-lane-key" "kind=ship"
+
+  PATH="$fb:$PATH" FM_HOME="$home" FM_ROOT_OVERRIDE="$home" FM_TMUX_LOG="$log" FM_SEND_SETTLE=0 \
+    "$SEND" lane-key --key Escape >/dev/null 2>"$err"; rc=$?
+  expect_code 0 "$rc" "a delivered --key interrupt should report success"
+  assert_contains "$(cat "$log")" "target=sess:fm-lane-key literal=0 arg=Escape" "the delivered case should send the named key"
+
+  : > "$log"
+  PATH="$fb:$PATH" FM_HOME="$home" FM_ROOT_OVERRIDE="$home" FM_TMUX_LOG="$log" FM_SEND_SETTLE=0 \
+    FM_FAKE_TMUX_SEND_KEY_FAIL=Escape \
+    "$SEND" lane-key --key Escape >/dev/null 2>"$err"; rc=$?
+  [ "$rc" -ne 0 ] || fail "an undelivered --key interrupt reported success"
+  assert_contains "$(cat "$err")" "key 'Escape' not sent" "the undelivered case should name the key that failed"
+  assert_contains "$(cat "$log")" "target=sess:fm-lane-key literal=0 arg=Escape" "the undelivered case should still have attempted the send"
+  pass "fm-send --key: exit status follows delivery, and an undelivered key never reports success"
+}
+
 test_exact_lane_id_send_still_works
+test_key_send_exit_status_follows_delivery
 test_unset_fm_home_fails
 test_unresolvable_target_does_not_tmux_fallback
 test_prefixless_herdr_pane_id_fails

--- a/tests/fm-send-strict.test.sh
+++ b/tests/fm-send-strict.test.sh
@@ -1,10 +1,11 @@
 #!/usr/bin/env bash
-# fm-send strict target resolution.
+# fm-send strict target resolution and key delivery reporting.
 #
 # A send that cannot be tied to a recorded task/lane or to an explicit
 # well-formed backend target must fail loudly. These tests pin the historical
 # silent-fallback failures: missing FM_HOME, unresolved selectors, prefixless
 # herdr pane ids, dead explicit endpoints, and the healthy exact/fm-id paths.
+# They also verify that a key send reports whether delivery actually succeeded.
 set -u
 
 # shellcheck source=tests/lib.sh


### PR DESCRIPTION
## Intent

Fix firstmate's RED main. Main head 6c206ed (#1842, 'feat(send): close answered decisions at answer time via --resolve-key') fails CI on tests/fm-backend.test.sh, case 'Behavior portable serial 3': 'fm-send --key: old vs new exit code: expected exit 1, got 0'. Every PR rebasing onto main inherits the failure.

Required work: (1) reproduce the assertion directly against the pinned old and current fm-send binaries and confirm the divergence before changing anything; (2) diagnose whether the CODE regressed (the --resolve-key addition altering fm-send's --key arg parsing or exit path so it no longer fails closed) or the TEST expectation is genuinely stale, biasing strongly toward restoring the fail-closed contract because fm-send exit behavior is load-bearing for supervision and a silent success on a failed send is dangerous; (3) fix forward so fm-send --key has its correct fail-closed exit contract while KEEPING the --resolve-key feature intact - do not revert #1842's feature; (4) determine whether main had a separate pre-existing red (the prior #1798 run also showed failure) and report rather than silently expand scope if it is a distinct unrelated failure; (5) turn the reproduction into durable confidence - tests/fm-backend.test.sh must pass for the right reason, adding coverage if the exit contract needs an explicit behavioral assertion beyond old-vs-new parity.

Additional accepted requirement from firstmate mid-task: local validation must actually reproduce this class, not only the GitHub runner. The corrected old-vs-new parity harness and its regression must fail locally pre-fix and pass locally post-fix, and the regression must genuinely exercise real behavior locally so a future divergence of this class is caught by the local suite.

Findings established by the reproduction: root cause is the TEST FIXTURE, not a code regression. tests/fm-backend.test.sh's build_old_bin enumerated by hand the sibling scripts copied into the synthetic pre-refactor tree; #1842 made bin/fm-send.sh source bin/fm-line-cap-lib.sh (added by #1798) and that list was never updated, so the pinned old fm-send.sh aborted at sourcing fm-line-cap-lib.sh under set -eu and exited 1 before parsing any argument, while current fm-send delivered the key and exited 0. Because BASE_REF collapses to HEAD on main, both sides ran byte-identical source, so a genuine behavior divergence was impossible. fm-send's --key exit path is unchanged and its fail-closed contract is intact; --resolve-key is untouched (its ten-case suite passes, including the refusal to combine with --key). Main had no second real red: the #1798 run's twelve jobs were all cancelled, which surfaces as a failed conclusion.

Fix delivered: build_old_bin copies the bin/ tree whole instead of enumerating it, so a missing sibling can no longer produce a bogus divergence, and extracting a refactored entrypoint the baseline lacks now fails loudly instead of writing an empty file; tests/fm-send-strict.test.sh gains a direct behavioral assertion that fm-send --key exit status follows delivery and an undelivered key exits nonzero naming the key. Verified locally: pre-fix harness fails locally, post-fix passes; mutating fm-send to send a wrong key fails the parity diff; mutating it to swallow the fail-closed exit fails the new regression; the full portable-serial-3of4 lane (the exact CI shard that was red) is green at total=25 failed=0.

Acceptance criteria: fm-send --key exit contract fail-closed and correct with --resolve-key still working; tests/fm-backend.test.sh passes for the right reason; bin/fm-lint.sh clean; behavioral tests through the executable interface only, never asserting implementation source bytes; this is firstmate shared tracked material so firstmate-coding-guidelines applies (one sentence per line in tracked Markdown, plain dash never em dash, no agent co-author, colocated tests extending existing runners). Deliver a main-targeted PR reaching a GENUINE full-matrix green, reported for the captain's merge. yolo off, no self-merge.

## What Changed

- Materialize the complete historical `bin/` tree for old-vs-new backend parity tests, preventing missing sourced helpers from producing false divergences.
- Add executable coverage proving `fm-send --key` exits nonzero and names the key when delivery fails.
- Stabilize the Herdr focus-flash E2E fixture by waiting for a persistent `sleep` child across consecutive process samples.

## Risk Assessment

✅ Low: The fixture now materializes a dependency-consistent baseline, and the executable regression directly verifies successful and fail-closed key delivery without affecting --resolve-key behavior.

## Testing

Focused CLI tests demonstrated delivered keys succeed, undelivered keys fail nonzero while naming the key, old-vs-new parity is real, and all `--resolve-key` behavior remains intact; an unrelated Herdr fixture race found by the first exact-shard run was fixed and passed five stress runs, then the complete formerly-red shard passed at 25/25. No visual artifact was applicable because this is CLI-only behavior.

<details>
<summary>Evidence: Focused fm-send behavior transcript</summary>

```text
$ tests/fm-backend.test.sh
ok - fm_backend_name: FM_BACKEND env > config/backend > default tmux
ok - fm_backend_detect: no markers -> undetected, HERDR_ENV=1 -> herdr, $TMUX -> tmux, CMUX_WORKSPACE_ID -> cmux, nested combinations resolve innermost-first
ok - fm_backend_detect: falls back to __CFBundleIdentifier=com.cmuxterm.app when CMUX_WORKSPACE_ID is absent (signal bundle-id; foreign bundle ids rejected)
ok - fm_backend_detect: the cmux fallback signals are macOS-only (inert on a non-Darwin uname)
ok - fm_backend_detect: an inherited cmux bundle id never outranks $TMUX or HERDR_ENV (tmux/herdr-inside-cmux false positive absorbed)
ok - fm_backend_detect: ancestry fallback matches the lsappinfo-resolved (bundle-id) cmux app pid in the parent chain
ok - fm_backend_detect: ancestry fallback matches a bundle-shaped cmux comm path at any install location when lsappinfo cannot resolve a pid
ok - fm_backend_detect: ancestry fallback stops undetected at launchd (a reparented tmux server never reaches cmux)
ok - fm_backend_name: a fallback-detected cmux prints a NOTICE naming the fallback signal; the primary-marker notice is unchanged
ok - fm_backend_name: auto-detect selects herdr or cmux (loud notice) or tmux (silent, including nested tmux-in-herdr/tmux-in-cmux)
ok - fm_backend_name: an explicit FM_BACKEND or config/backend setting always wins over runtime auto-detection, including an ambient cmux marker
ok - fm_backend_validate: implemented adapters accepted, unknown and blocked codex-app backends refused loudly
ok - zsh: fm_backend_source recognizes known backends and rejects unknown ones
ok - bash: fm_backend_source recognizes known backends and rejects unknown ones
ok - fm_backend_validate_spawn: all implemented lifecycle backends are spawn-supported
ok - fm_meta_get / fm_backend_of_meta: read key=value, default backend to tmux
ok - fm_backend_resolve_selector: session:window literal, exact task id first, legacy fm-<id> label fallback, ad hoc bare name via tmux list-windows
ok - fm_backend_of_selector: exact task ids, legacy fm-<id> labels, and matching explicit targets inherit metadata backend
ok - fm-send.sh: explicit tmux targets are verified, while --key/plain/slash send command shape stays old-compatible
ok - fm-peek.sh: capture-pane invocation and output are byte-identical old vs new
ok - fm-spawn.sh: a project reached through a symlinked prefix (e.g. macOS /tmp -> /private/tmp) does not trip the isolation guard's false refusal
ok - fm-teardown.sh: treehouse return remains compatible while tmux cleanup uses exact selectors
ok - fm-spawn.sh --backend bogus is refused loudly
ok - fm-spawn.sh --backend codex-app is refused
ok - fm-spawn.sh honors FM_BACKEND and refuses an unimplemented value loudly
ok - fm-spawn.sh: an explicit --backend tmux resolves silently and writes no backend= (missing means tmux)
ok - fm-spawn.sh: explicit --backend tmux wins over an ambient HERDR_ENV=1 auto-detect marker
ok - fm-spawn.sh: auto-detect resolves nested tmux-in-herdr to tmux and stays silent end to end
$ tests/fm-send-strict.test.sh
ok - fm-send strict: exact task/lane ids resolve through home metadata
ok - fm-send --key: exit status follows delivery, and an undelivered key never reports success
ok - fm-send strict: unset FM_HOME fails before target resolution
ok - fm-send strict: unresolvable selectors do not fall back to tmux
ok - fm-send strict: prefixless herdr pane ids are rejected before tmux fallback
ok - fm-send strict: unmatched single-colon explicit targets must verify live before sending
ok - fm-send strict: fm-prefixed Herdr sessions remain explicit backend targets
ok - fm-send strict: healthy fm-<id> sends still type once and submit
$ tests/fm-send-resolve-key.test.sh
ok - fm-send --resolve-key: the answer send itself closes the open decision
ok - fm-send --resolve-key: an answer that starts a workstream leaves no orphaned decision
ok - fm-send: a send without --resolve-key never closes a decision, and working/done still cannot
ok - fm-send --resolve-key: a key that is not open refuses loudly before anything is sent
ok - fm-send --resolve-key: a failed send never closes the decision
ok - fm-send --resolve-key: one answer closes each named key and only those
ok - fm-send --resolve-key: a marked local-secondmate answer closes with the plain answer text
ok - fm-send --resolve-key: a remote-secondmate answer closes the same local ledger, transport-only difference
ok - fm-send --resolve-key: a failed remote transport never closes the decision
ok - fm-send --resolve-key: --key, empty message, explicit targets, and malformed keys refuse loudly
```
</details>
<details>
<summary>Evidence: Herdr post-fix stress transcript</summary>

```text
$ tests/fm-backend-herdr-focus-flash-e2e.test.sh (post-fix run 1/5)
ok - old path note: this Herdr release preserves focus across the explicit close; continuing with outcome-only assertions
ok - mitigation: every in-operation sample preserved exact focus while the doomed workspace was removed
ok - fallback: a doomed pane holding a persistent child exhausts the proof and takes the plain explicit close
ok - fallback on a focus-preserving release: the plain explicit close preserved exact focus throughout
ok - version floor: herdr 0.8.0 protocol 19 is at or above the floor and preserves focus
ok - version floor: an unconfigured home stays projected on herdr 0.8.0 and the explicit opt-in agrees
evidence: herdr=0.8.0 protocol=19 steal_live=0 floor_verdict=0 default-session-tripwire=armed
$ tests/fm-backend-herdr-focus-flash-e2e.test.sh (post-fix run 2/5)
ok - old path note: this Herdr release preserves focus across the explicit close; continuing with outcome-only assertions
ok - mitigation: every in-operation sample preserved exact focus while the doomed workspace was removed
ok - fallback: a doomed pane holding a persistent child exhausts the proof and takes the plain explicit close
ok - fallback on a focus-preserving release: the plain explicit close preserved exact focus throughout
ok - version floor: herdr 0.8.0 protocol 19 is at or above the floor and preserves focus
ok - version floor: an unconfigured home stays projected on herdr 0.8.0 and the explicit opt-in agrees
evidence: herdr=0.8.0 protocol=19 steal_live=0 floor_verdict=0 default-session-tripwire=armed
$ tests/fm-backend-herdr-focus-flash-e2e.test.sh (post-fix run 3/5)
ok - old path note: this Herdr release preserves focus across the explicit close; continuing with outcome-only assertions
ok - mitigation: every in-operation sample preserved exact focus while the doomed workspace was removed
ok - fallback: a doomed pane holding a persistent child exhausts the proof and takes the plain explicit close
ok - fallback on a focus-preserving release: the plain explicit close preserved exact focus throughout
ok - version floor: herdr 0.8.0 protocol 19 is at or above the floor and preserves focus
ok - version floor: an unconfigured home stays projected on herdr 0.8.0 and the explicit opt-in agrees
evidence: herdr=0.8.0 protocol=19 steal_live=0 floor_verdict=0 default-session-tripwire=armed
$ tests/fm-backend-herdr-focus-flash-e2e.test.sh (post-fix run 4/5)
ok - old path note: this Herdr release preserves focus across the explicit close; continuing with outcome-only assertions
ok - mitigation: every in-operation sample preserved exact focus while the doomed workspace was removed
ok - fallback: a doomed pane holding a persistent child exhausts the proof and takes the plain explicit close
ok - fallback on a focus-preserving release: the plain explicit close preserved exact focus throughout
ok - version floor: herdr 0.8.0 protocol 19 is at or above the floor and preserves focus
ok - version floor: an unconfigured home stays projected on herdr 0.8.0 and the explicit opt-in agrees
evidence: herdr=0.8.0 protocol=19 steal_live=0 floor_verdict=0 default-session-tripwire=armed
$ tests/fm-backend-herdr-focus-flash-e2e.test.sh (post-fix run 5/5)
ok - old path note: this Herdr release preserves focus across the explicit close; continuing with outcome-only assertions
ok - mitigation: every in-operation sample preserved exact focus while the doomed workspace was removed
ok - fallback: a doomed pane holding a persistent child exhausts the proof and takes the plain explicit close
ok - fallback on a focus-preserving release: the plain explicit close preserved exact focus throughout
ok - version floor: herdr 0.8.0 protocol 19 is at or above the floor and preserves focus
ok - version floor: an unconfigured home stays projected on herdr 0.8.0 and the explicit opt-in agrees
evidence: herdr=0.8.0 protocol=19 steal_live=0 floor_verdict=0 default-session-tripwire=armed
```
</details>
<details>
<summary>Evidence: Final portable serial 3-of-4 transcript</summary>

```text
FM_TEST_BEGIN 2026-08-07T00:43:05Z tests/fm-watcher-lock.test.sh family=watcher-wake-lock expected_gate_skip=none
ok - simultaneous watcher starts leave exactly one live process
ok - fm_pid_identity real ps fallback is locale-invariant
ok - fm_pid_identity is locale-invariant across LC_ALL/LC_TIME
ok - /proc process identity ignores simulated btime changes
ok - /proc process identity detects pid reuse
ok - MSYS /proc process identity regression skipped on non-Windows host
ok - killed watcher stale lock is reclaimed
ok - live watcher lock with stale heartbeat is actionable
ok - guard banner leads when down with pending wakes (repair-after-drain) and stays silent when live and fresh
ok - concurrent fm_lock_try_acquire yields exactly one winner
ok - dead-pid stale lock is reclaimed by a single acquirer
ok - concurrent stale-lock steal yields exactly one winner
ok - live steal mutex is not reclaimed
ok - live-held lock is not stolen
ok - empty mid-acquire lock keeps a minimum grace
ok - late original claimant cannot claim a recreated lock
ok - paused mid-acquire claimant backs off to active stealer
ok - watch restart refuses to signal a reused pid
ok - watch restart attaches to a verified healthy peer and later surfaces a successor gap
ok - watcher self-evicts when the lock pid no longer names it
ok - arm turns clean self-eviction without a successor into a typed failure
ok - arm attaches to a live fresh watcher and fails loudly when that cycle has no successor
ok - attached arm signals record a classified lifecycle entry
ok - arm starts+confirms a fresh watcher on a clean lock and self-heals a dead-pid lock (never healthy off a dead pid)
ok - arm cleans child watcher and temp output on HUP
ok - arm propagates an immediate watcher wake before confirmation
ok - arm attaches to a peer watcher after child stands down and surfaces a missing successor
watcher: lock held by live pid 57070 but heartbeat is stale for 839349850s (>300s); inspect or stop that watcher before re-arming.
ok - arm reports FAILED and exits non-zero when no fresh watcher can be confirmed
ok - cycle-exit ledger links a verified successor and remains size-capped
ok - SIGSTOP distinguishes live PID from stale beacon and termination records the exit class
FM_TEST_END 2026-08-07T00:44:55Z tests/fm-watcher-lock.test.sh exit=0 duration_ms=110038 gate_skip=false
FM_TEST_BEGIN 2026-08-07T00:44:55Z tests/fm-bearings-snapshot.test.sh family=snapshot-bearings expected_gate_skip=optional-binary
ok - Domain Alpha structured state overrides a stale parent Phase 7 event
ok - GNU stat file reads select -c without BSD filesystem-report pollution
ok - parent activity evidence is bounded and disclosed
ok - Bearings excludes a status-only child decision
ok - a structured child captain hold reaches Captain's Call
ok - missing, invalid, unreadable, malformed, and timed-out homes stay explicit unknowns
ok - an oversized secondmate summary retains the strict empty unknown fallback
ok - secondmate and per-home child counts are bounded, disclosed, and explicitly expandable
ok - parent decisions remain untrusted contradiction evidence
ok - parent evidence reconciliation distinguishes matching holds, blocks, and decisions
ok - nonprogressing child states are explicit and inconsistent terminal rows invalidate
ok - registry unavailability and bounded truncation remain explicit
ok - repeated snapshots keep the same current landed baseline and ignore prior reports
ok - default output is bounded, local-only, and marks omitted surfaces
ok - TOON and JSON are parity representations of the same model
ok - landed includes secondmate-managed merges alongside main-home merges
ok - default landed selection balances one dominant home with sparse homes
ok - landed selection refills capacity after sparse homes exhaust
ok - landed selection uses deterministic home order when homes exceed the cap
ok - landed selection preserves deterministic home and internal tie ordering
ok - landed selection handles no landed items
ok - --all-landed keeps the complete global landed output
ok - landed stays bounded with per-home + overall caps and omitted[] disclosure
ok - Bearings keeps a live blocker in structured live state and never converts it to Charted Next queue work
ok - action-free items (working/done/queued/landed) do not leak into Captain's Call
ok - main orphan in-flight stays out of Underway and is disclosed in omitted/gates
ok - main unstructured current is disclosed while structured siblings still project
ok - counterfactual meta clears main inventory warning and projects the live task
ok - mixed secondmate roles, partial state, and captain readiness project independently
ok - main and secondmate captain actionability use the same blocker readiness
ok - a completed scout with decision-like report prose is a pointer, not pending
ok - an authoritative captain hold surfaces end-to-end
ok - current report pointers surface
ok - superseded queued items are dropped by default and restored with --all-queued
ok - --include-prs is the only path that fetches, and it enriches correctly
ok - a partial GitHub failure degrades gracefully
ok - Perl fallback bounds stalled GitHub calls without coreutils timeout
ok - all fleet-sized sections are capped with counted opt-in expansion
ok - live PR enrichment caps repositories with counted expansion
ok - per-repository open-PR caps are disclosed with an expansion knob
ok - projection and TOON rendering failures exit nonzero with diagnostics
FM_TEST_END 2026-08-07T00:47:06Z tests/fm-bearings-snapshot.test.sh exit=0 duration_ms=131182 gate_skip=false
FM_TEST_BEGIN 2026-08-07T00:47:06Z tests/fm-session-start.test.sh family=session-bootstrap expected_gate_skip=none
ok - context digest distinguishes ABSENT, empty-but-present, and populated files
ok - a lock refusal prints a loud read-only banner, skips every mutating step, and still completes the digest
ok - session start stays read-only when lock ownership cannot be published
ok - locked session start freezes trace context and lock refusal leaves it unchanged
ok - concurrent session-lock acquisition admits exactly one live harness
ok - digest sections are ordered safety-preamble first, live fleet state before curated memory
ok - the read-once contract is stated once, ahead of the sources it governs
ok - session start: configured and auto-detected Herdr homes never require tmux
ok - session start: an absent recorded tmux window relaunches its Pi secondmate exactly once
ok - session start: an existing ambiguous Pi process prevents duplicate recovery
ok - session start: transient tmux unreadability never licenses a relaunch
ok - session start: the proven bare-shell recovery path remains intact
ok - session start: a confirmed Herdr husk is closed and relaunched
ok - status tail is bounded to the configured line count, with the full log path always printed
ok - status tail lines are capped with a truncation marker while the full log stays reachable
ok - orphan status logs are printed once with bounded tails
ok - tmux endpoint liveness is reported per task: alive for a live window, dead for a gone one
ok - herdr endpoint liveness is reported per task: alive for a live pane, dead for a gone one
ok - fm-session-start.sh composes the real fm-lock.sh, fm-bootstrap.sh, and fm-wake-drain.sh output verbatim
ok - compatible tasks-axi backlog rendering drops done rows and keeps every in-flight, held, and blocked row
ok - the startup backlog bound cuts only dispatchable queued rows and discloses the remainder exactly
ok - manual backlog rendering drops done rows, keeps every held or blocked title line, and bounds the rest
ok - unavailable or incompatible tasks-axi falls back to compact manual backlog rendering
ok - an empty fleet reports (none) for in-flight tasks and an absent AFK flag
ok - session start emits X-mode cadence guidance in the harness supervision block
ok - next step delegates watcher ownership to the AFK daemon
ok - session start emits exactly one detected harness block and reports Pi extension load state
ok - session start preserves pi-signed primary identity while applying Pi extension guarantees
ok - session start rejects stale Pi loaded ma

... [26662 bytes truncated] ...

n.test.sh family=afk expected_gate_skip=none
ok - return catch-up precedes Bearings, owns live blocker remediation, preserves evidence once, and clears idempotently
ok - tmux and Herdr blockers require the same explicit durable reclassification before ordinary work
ok - needs-decision remains reportable without masquerading as a firstmate-actionable blocker
ok - away-mode re-entry fails closed while the prior return catch-up is pending
ok - check retries recorded terminal teardown and keeps catch-up gated until success
FM_TEST_END 2026-08-07T00:59:51Z tests/fm-afk-return.test.sh exit=0 duration_ms=5455 gate_skip=false
FM_TEST_BEGIN 2026-08-07T00:59:51Z tests/fm-documentation-audiences.test.sh family=pure-contract-unit expected_gate_skip=none
ok - documentation inventory classifies every maintained prose surface exactly once
ok - classification, setup routing, and maintained-prose scope fail safely
ok - required documentation owner pointers cannot silently disappear
ok - local links resolve while dates, versions, commands, and incident prose remain semantically reviewed
FM_TEST_END 2026-08-07T00:59:53Z tests/fm-documentation-audiences.test.sh exit=0 duration_ms=1048 gate_skip=false
FM_TEST_BEGIN 2026-08-07T00:59:53Z tests/fm-calm-pi-extension.test.sh family=pure-contract-unit expected_gate_skip=none
ok - Pi calm resolves its persistent home independently of Pi's launch directory
ok - Pi calm compatibility evidence never rejects a Pi version for being newer than 0.82.0, and still fails closed on a missing or malformed version
ok - a missing collapsed-thinking presentation API degrades only that Calm adapter with a clear skip reason, while the rest of Calm still registers
ok - missing Pi presentation class exports reach the independent adapter degradation path
ok - Calm registers none of its 7 built-in tool wrappers at load while config/calm is off, and all 7 synchronously at load while config/calm is on
ok - Calm's first same-session /calm activation claims every uncontested built-in, leaves a foreign bash tool fully intact and callable, warns prominently and logs the contested name, and only rows constructed before that activation - the documented bound - fail to retroactively collapse
ok - Pi calm centralizes transcript visibility, preserves execution/export data, keeps Pi's stock working row visible while no run is active, and persists its choice across session starts
ok - Pi operational follow-up E2E processes exact user-role notifications once while Calm hides current and adjacent rows, Calm off and absent render them, and restart preserves semantics
ok - Pi Calm native /skill:ahoy geometry keeps every collapsed thinking and tool block at zero height while preserving expansion, history, restart, and Calm-off rendering
ok - Pi Calm working ship moves on a slow independent cadence over faster fixed-cell blue water, paints the complete boat standard yellow with balanced resets, keeps ANSI-stripped width exact, flips the directional sail on the exact bounce at both edges and every width, clamps visible and hidden resizes, falls back deterministically when narrow, freezes and resumes column/direction across settle/start without hidden-time jumps or duplicate timers, resets only on a fresh session, and installs and removes one scheduler-owning widget across starts, settle, abort, failure, shutdown, reload, replacement, and Calm toggles while leaving Calm-off visibility untouched
ok - Pi calm native E2E replaces the stock working row with a moving, resize-clamped working ship that freezes and resumes across two working periods in one Pi session, clears on abort, keeps captain turns visible, hides exact operational user rows without changing persistence, restores stock rendering Calm-off, survives restart, and preserves export plus Ctrl+O behavior
FM_TEST_END 2026-08-07T01:01:10Z tests/fm-calm-pi-extension.test.sh exit=0 duration_ms=77752 gate_skip=false
FM_TEST_BEGIN 2026-08-07T01:01:10Z tests/fm-afk-pi-herdr-return-e2e.test.sh family=live-harness-optin expected_gate_skip=optin-env
skip: set FM_AFK_PI_HERDR_E2E=1 to run the real Pi/Herdr away-return regression
FM_TEST_END 2026-08-07T01:01:11Z tests/fm-afk-pi-herdr-return-e2e.test.sh exit=0 duration_ms=160 gate_skip=true
FM_TEST_BEGIN 2026-08-07T01:01:11Z tests/fm-backend-cmux-smoke.test.sh family=cmux expected_gate_skip=optional-binary
skip: cmux CLI not found on PATH or at the bundle path
FM_TEST_END 2026-08-07T01:01:11Z tests/fm-backend-cmux-smoke.test.sh exit=0 duration_ms=43 gate_skip=true
FM_TEST_BEGIN 2026-08-07T01:01:11Z tests/fm-backend-herdr-focus-flash-e2e.test.sh family=unclassified expected_gate_skip=none
ok - old path note: this Herdr release preserves focus across the explicit close; continuing with outcome-only assertions
ok - mitigation: every in-operation sample preserved exact focus while the doomed workspace was removed
ok - fallback: a doomed pane holding a persistent child exhausts the proof and takes the plain explicit close
ok - fallback on a focus-preserving release: the plain explicit close preserved exact focus throughout
ok - version floor: herdr 0.8.0 protocol 19 is at or above the floor and preserves focus
ok - version floor: an unconfigured home stays projected on herdr 0.8.0 and the explicit opt-in agrees
evidence: herdr=0.8.0 protocol=19 steal_live=0 floor_verdict=0 default-session-tripwire=armed
FM_TEST_END 2026-08-07T01:01:18Z tests/fm-backend-herdr-focus-flash-e2e.test.sh exit=0 duration_ms=7047 gate_skip=false
FM_TEST_BEGIN 2026-08-07T01:01:18Z tests/fm-codex-continuity-live-e2e.test.sh family=live-harness-optin expected_gate_skip=optin-env
skip: set FM_CODEX_LIVE_E2E=1 to run the Codex continuity regression
FM_TEST_END 2026-08-07T01:01:18Z tests/fm-codex-continuity-live-e2e.test.sh exit=0 duration_ms=56 gate_skip=true
FM_TEST_BEGIN 2026-08-07T01:01:18Z tests/fm-pi-primary-live-e2e.test.sh family=live-harness-optin expected_gate_skip=optin-env
skip: set FM_PI_LIVE_E2E=1 to run the isolated interactive Pi regression
FM_TEST_END 2026-08-07T01:01:18Z tests/fm-pi-primary-live-e2e.test.sh exit=0 duration_ms=61 gate_skip=true
FM_TEST_SUMMARY total=25 failed=0 skipped_gate=4 duration_ms=1092950
FM_TEST_SUMMARY_FAMILY family=afk count=1 duration_ms=5455 failed=0
FM_TEST_SUMMARY_FAMILY family=backend-dispatch count=2 duration_ms=79135 failed=0
FM_TEST_SUMMARY_FAMILY family=cmux count=1 duration_ms=43 failed=0
FM_TEST_SUMMARY_FAMILY family=live-harness-optin count=3 duration_ms=277 failed=0
FM_TEST_SUMMARY_FAMILY family=pure-contract-unit count=3 duration_ms=83980 failed=0
FM_TEST_SUMMARY_FAMILY family=secondmate count=6 duration_ms=428024 failed=0
FM_TEST_SUMMARY_FAMILY family=session-bootstrap count=2 duration_ms=168106 failed=0
FM_TEST_SUMMARY_FAMILY family=snapshot-bearings count=2 duration_ms=146676 failed=0
FM_TEST_SUMMARY_FAMILY family=unclassified count=1 duration_ms=7047 failed=0
FM_TEST_SUMMARY_FAMILY family=watcher-wake-lock count=4 duration_ms=172852 failed=0
FM_TEST_SLOWEST rank=1 script=tests/fm-secondmate-safety.test.sh duration_ms=179053
FM_TEST_SLOWEST rank=2 script=tests/fm-session-start.test.sh duration_ms=132572
FM_TEST_SLOWEST rank=3 script=tests/fm-bearings-snapshot.test.sh duration_ms=131182
FM_TEST_SLOWEST rank=4 script=tests/fm-remote-secondmate-trace-context.test.sh duration_ms=112025
FM_TEST_SLOWEST rank=5 script=tests/fm-watcher-lock.test.sh duration_ms=110038
FM_TEST_SLOWEST rank=6 script=tests/fm-calm-pi-extension.test.sh duration_ms=77752
FM_TEST_SLOWEST rank=7 script=tests/fm-remote-job.test.sh duration_ms=64196
FM_TEST_SLOWEST rank=8 script=tests/fm-wake-queue.test.sh duration_ms=48701
FM_TEST_SLOWEST rank=9 script=tests/fm-trace-context-spawn.test.sh duration_ms=48452
FM_TEST_SLOWEST rank=10 script=tests/fm-secondmate-sync.test.sh duration_ms=44233
FM_TEST_SLOWEST rank=11 script=tests/fm-fleet-sync.test.sh duration_ms=35534
FM_TEST_SLOWEST rank=12 script=tests/fm-backend.test.sh duration_ms=30683
FM_TEST_SLOWEST rank=13 script=tests/fm-on.test.sh duration_ms=22842
FM_TEST_SLOWEST rank=14 script=tests/fm-fleet-snapshot-view.test.sh duration_ms=15494
FM_TEST_SLOWEST rank=15 script=tests/fm-guard-stale-banner.test.sh duration_ms=7265
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `tests/fm-backend.test.sh:158` - The old fixture now copies every dependency from the current checkout, so it is not a faithful BASE_REF binary. For example, a future change to fm-line-cap-lib.sh would be loaded by both the BASE_REF fm-send entrypoint and the current entrypoint, allowing helper-induced behavior divergence to pass parity. Materialize the whole bin tree from BASE_REF, then apply only the explicitly required historical adapter override.

🔧 Fix: Materialize historical fixture dependencies from baseline
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>Inspected `git diff 6c206edd235e81872f67f0e6434283cc854ce246..84d7aaba6d5b0b443f9c658d6f3d1807e8a61261 -- tests/fm-backend.test.sh tests/fm-send-strict.test.sh`</code>
- `tests/fm-backend.test.sh`
- `tests/fm-send-strict.test.sh`
- `tests/fm-send-resolve-key.test.sh`
- `bin/fm-test-run.sh --list --lane portable-serial-3of4`
- <code>`bin/fm-test-run.sh --lane portable-serial-3of4` - initial run passed all fm-send cases but exposed the unrelated Herdr fixture race</code>
- <code>`tests/fm-backend-herdr-focus-flash-e2e.test.sh` - immediate pre-fix retry confirmed timing sensitivity</code>
- <code>`tests/fm-backend-herdr-focus-flash-e2e.test.sh` - five consecutive post-fix E2E runs</code>
- <code>`bin/fm-test-run.sh --lane portable-serial-3of4` - final post-fix result: `total=25 failed=0 skipped_gate=4`</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
