### PR TITLE
fix(skills): reconcile inherited secondmate plans with shipped state

### DIFF
--- a/.agents/skills/secondmate-provisioning/SKILL.md
+++ b/.agents/skills/secondmate-provisioning/SKILL.md
@@ -157,15 +157,15 @@ For `no-mistakes` projects, seeding initializes only projects newly cloned into 
 ## Record intake for an existing or inherited domain
 
 Classify the domain before seeding, because this step applies to only one of the two cases.
-A greenfield domain has no delivered work yet: no merged history in its projects, no live deployment, and no predecessor records to import.
+A greenfield domain has no delivered domain work yet: nothing already shipped in its projects, no live deployment, and no predecessor records to import.
 Seed a greenfield domain normally; there is nothing to reconcile and this section adds no work to it.
 An existing or inherited domain is any domain whose product is already in development, and any predecessor's domain a new mate takes over, including a consolidation after a retirement.
 Both of those cases require record intake before the new mate acts on any inherited plan.
 
 For an existing or inherited domain, the creating agent must:
 
-1. Reconcile every inherited plan against the domain's authoritative shipped state, which is `origin/main` for each owned project plus the live deployment.
-   A fetched clone of each owned project is a precondition of that reconciliation, so wire the home to its projects before reconciling rather than on first task.
+1. Reconcile every inherited plan against the domain's authoritative shipped state, which is `origin/main` for each relevant project plus the live deployment.
+   A fetched clone of each relevant project is a precondition of that reconciliation, so wire the home to its projects before reconciling rather than on first task.
    The imported backlog, the predecessor's own notes, instruction-surface prose, and an absent or unfetched local view are all inadmissible as shipped-state evidence.
 2. Seed the new home with only genuinely open work plus the domain's durable knowledge, meaning the learnings, decisions, and delivery posture that are still live.
 3. Never inherit a plan backlog blind.

--- a/.agents/skills/secondmate-provisioning/SKILL.md
+++ b/.agents/skills/secondmate-provisioning/SKILL.md
@@ -3,7 +3,7 @@ name: secondmate-provisioning
 description: >-
   Agent-only reference for persistent secondmate setup and retirement.
   Use when creating, seeding, validating, launching, recovering, handing backlog to, pushing inherited local material into, or retiring a secondmate home, or when editing data/secondmates.md.
-  Covers local leases, whole-home remote routes, transactional seeding, project clone restrictions, secondmate harness pins, inherited local-material push, idle charter, handoff helper, and teardown safety.
+  Covers local leases, whole-home remote routes, transactional seeding, record intake for an existing or inherited domain, project clone restrictions, secondmate harness pins, inherited local-material push, idle charter, handoff helper, and teardown safety.
 user-invocable: false
 metadata:
   internal: true
@@ -154,6 +154,26 @@ Secondmate project lists may include `no-mistakes` and `direct-PR` projects only
 `local-only` projects stay with the main firstmate.
 For `no-mistakes` projects, seeding initializes only projects newly cloned into a secondmate home and refuses to mutate a preexisting clone that is not already initialized.
 
+## Record intake for an existing or inherited domain
+
+Classify the domain before seeding, because this step applies to only one of the two cases.
+A greenfield domain has no delivered work yet: no merged history in its projects, no live deployment, and no predecessor records to import.
+Seed a greenfield domain normally; there is nothing to reconcile and this section adds no work to it.
+An existing or inherited domain is any domain whose product is already in development, and any predecessor's domain a new mate takes over, including a consolidation after a retirement.
+Both of those cases require record intake before the new mate acts on any inherited plan.
+
+For an existing or inherited domain, the creating agent must:
+
+1. Reconcile every inherited plan against the domain's authoritative shipped state, which is `origin/main` for each owned project plus the live deployment.
+   A fetched clone of each owned project is a precondition of that reconciliation, so wire the home to its projects before reconciling rather than on first task.
+   The imported backlog, the predecessor's own notes, instruction-surface prose, and an absent or unfetched local view are all inadmissible as shipped-state evidence.
+2. Seed the new home with only genuinely open work plus the domain's durable knowledge, meaning the learnings, decisions, and delivery posture that are still live.
+3. Never inherit a plan backlog blind.
+   A plan row whose work is already shipped is dropped, or recorded as done with the merged evidence that settles it, and is never carried forward as open.
+
+A live backlog keeps only the configured recent Done entries by design, so an inherited queue structurally over-represents plans and under-represents deliveries.
+Treat an inherited queue that carries plans with no matching delivery record as unreconciled rather than as open work, and record whatever could not be reconciled as an explicit residual-uncertainty list in the new home rather than leaving that gap silent.
+
 ## Backlog handoff
 
 Apply `AGENTS.md` section 10's work-items-only backlog contract before creation or handoff.
@@ -166,6 +186,7 @@ bin/fm-backlog-handoff.sh <secondmate-id> <item-key>...
 ```
 
 After seeding, run this handoff for the new secondmate's in-scope queued items.
+For an existing or inherited domain, complete record intake first so no already-shipped plan row is handed off as open work.
 For a local route, the helper resolves and validates the secondmate home from `data/secondmates.md`, then delegates the item move to `tasks-axi mv` (the single owner of the backlog format), which moves each named item - and a whole connected set, blocker plus dependents, atomically - from the main `data/backlog.md` into the secondmate home's `data/backlog.md`.
 For a remote route, the same helper first moves the dependency-closed set atomically from the main backlog into `data/handoff/<id>.outbox.md`, then transfers that backlog-format outbox through `fm-on.sh` and lets the remote home's `fm-backlog-receive.sh` move every not-already-present key under the destination lock.
 The outbox is the whole recovery record: its presence means delivery is unfinished, `--resume-pending` safely re-delivers it, and confirmed receipt removes it.


### PR DESCRIPTION
## Intent

Add a small record-intake instruction to the secondmate CREATION/seed path in firstmate's secondmate-provisioning skill, so a new mate that takes over an existing or inherited domain reconciles against authoritative shipped-state instead of inheriting a plan backlog blind.

WHY (captain's chosen safeguard, 2026-08-06): fix for a stale-record recurrence forensically diagnosed in two scout reports. A predecessor secondmate home shipped 21+ merged PRs; when retired into a successor, the handover carried backlog.md, captain.md, learnings.md and a brief, but NOT done-archive.md. Because .tasks.toml sets done_keep = 10, a live backlog structurally cannot hold more than ten completions, so the successor inherited 49 open plan rows and zero record of 21 shipped PRs. Already-delivered work therefore resurfaced as 'open'. Verified gap: creation/seeding pulls in charter + inherited config + captain-shared + project clones + (separately) QUEUED backlog only, with ZERO instruction about shipped/done history, so it assumes a greenfield mate.

CAPTAIN'S REFRAME: do NOT build a bespoke retirement/consolidation export process - retirement is too rare. Strengthen secondmate CREATION, which every transfer relies on. This fixes BOTH the rare retirement/consolidation case AND the common case of creating a mate for an in-progress project. Accepted tradeoff: reconciliation cost is paid at every inherited-domain creation rather than once at handover, because creation-side reconciliation works even when the predecessor's export was poor or its home is gone.

THE FIX: a RECORD-INTAKE instruction requiring that, when a new mate takes over an EXISTING or INHERITED domain (a project already in development, or a predecessor's domain), the creating agent MUST (1) reconcile inherited plans against authoritative SHIPPED-state - origin/main plus the live deployment - NOT the imported backlog and NOT an absent/fresh local view; (2) pull in only genuinely-open work plus durable knowledge (learnings/decisions still live); (3) NEVER inherit a plan backlog blind. The greenfield-vs-inherited distinction must be explicit so a genuinely new domain is not burdened.

SCOPE EXCLUSIONS: record-intake creation instruction ONLY. The separate fix to close open-decisions by construction on the decision key and de-overload the 'resolved' verb is its own queued ship (fm-decision-key-close-by-construction-r1) and must NOT be implemented here. Also out of scope: a mechanical export gate at retirement (captain ruled retirement too rare).

DESIGN DECISIONS (per firstmate-coding-guidelines, loaded first):
- ONE-OWNER RULE: the procedure lives entirely in the secondmate-provisioning skill, which owns secondmate creation/seeding. New '## Record intake for an existing or inherited domain' section placed after 'Charter and seed', before 'Backlog handoff'. git grep confirms no second copy.
- AGENTS.md DELIBERATELY UNTOUCHED, and this is correct, not an omission. AGENTS.md section 6 already carries the load trigger, which fires on exactly this path. AGENTS.md size discipline is a first-class repo rule (it grew 585 -> 958 lines from inline conditional detail); its token cost is paid by every session of every fleet member, so conditional detail belongs in the skill. The captain explicitly said 'Do not bloat AGENTS.md.'
- One single-line reinforcement added in 'Backlog handoff' at the point where plan rows physically move between homes. The guidelines permit exactly one deliberate one-line reinforcement at a genuine risk point; this is a pointer, not a restatement.
- Frontmatter 'Covers' list gained 'record intake for an existing or inherited domain' for load-time discoverability.
- The fetched-clone precondition is folded into obligation 1 as one clause, because an unfetched or missing clone is precisely the 'absent/fresh local view' trap.
- The inadmissible-evidence list names the imported backlog, predecessor notes, instruction-surface prose, and an absent/unfetched local view, because the forensic proved the failure was judging 'already shipped' from Firstmate's own prose with not one origin/main commit, PR, or deployment cited.
- The done_keep causal fact is stated once as the non-obvious reason the rule exists.
- A prior pipeline round improved wording from 'owned project' to 'relevant project', matching this skill's own rule that the projects: field is a non-exclusive clone list and not ownership. That correction is retained as the second commit on this branch.

NO TEST ADDED, deliberately. Repo guidelines and no-mistakes' own test-quality rule forbid a test whose only evidence is greping/parsing/snapshotting instruction source text for strings. Asserting this skill's Markdown contains the intake step would be exactly that anti-pattern. There is no executable consumer of agent-skill prose. The applicable gate, bin/fm-doc-audience-check.sh, passes (65 surfaces, 205 local links).

STYLE: one full sentence per line in tracked Markdown, plain dash never em dash, no agent co-author.

BRANCH CONTEXT: this is a fresh branch deliberately created from the clean pre-#1842 base 345de4e, superseding PR #1837 which hit an unrecoverable pipeline custody divergence. It contains ONLY the one Markdown file change (+22/-1) and the pipeline wording fix. It excludes #1842, which carries a known order-dependent fixture bug in tests/fm-backend.test.sh ('fm-send --key: old vs new exit code') being fixed separately in PR #1851. That failure is not attributable to this change: this diff is one Markdown file touching no shell, bin/, or test code, and the secondmate test family passed 6/6 when it ran.

Firstmate shared, tracked material, mode=no-mistakes, yolo off.

## What Changed

- Add record-intake guidance that distinguishes greenfield domains from existing or inherited secondmate domains.
- Require inherited plans to be reconciled against fetched `origin/main` state and live deployments before seeding only genuinely open work and durable knowledge.
- Reinforce backlog handoff ordering so already-shipped plan rows are not transferred as open work.

## Risk Assessment

✅ Low: The narrow instruction-only change satisfies the stated intake contract, lives in the existing provisioning owner, explicitly exempts greenfield domains, and reinforces the backlog transfer boundary without introducing conflicting behavior.

## Testing

The author-supplied baseline reported the secondmate test family passing 6/6; this focused phase confirmed the exact one-file scope, exercised the maintained-prose consumer successfully across 65 surfaces and 210 local links, manually verified runtime loading, ownership, and all intake scenarios, and captured reviewer-visible evidence. No executable prompt consumer exists, so no prohibited source-string test or unrelated secondmate suite was added or run.

<details>
<summary>Evidence: Secondmate record-intake reviewer evidence</summary>

```text
# Secondmate record-intake test evidence

Target commit: `b5ce265a1ccc8f88a5f36b25d669513ddbefc521`

## End-user runtime surface

The runtime load trigger in `AGENTS.md` says:

> Load `secondmate-provisioning` before creating, seeding, validating, launching, handing backlog to, recovering, pushing inherited local material into, or retiring a secondmate home, and before editing `data/secondmates.md`.

The loaded `secondmate-provisioning` skill now presents the creating agent with this decision and required outcome before backlog handoff:

| Domain presented to the creating agent | Required behavior |
| --- | --- |
| Greenfield, with no delivered project work, live deployment, or predecessor records | Seed normally, with no reconciliation burden. |
| Existing product already in development | Fetch each relevant project, reconcile every inherited plan against `origin/main` plus the live deployment, and seed only genuinely open work plus still-live durable knowledge. |
| Inherited predecessor domain, including consolidation after retirement | Apply the same shipped-state reconciliation before acting on or handing off any inherited plan. |
| Plan with proof it already shipped | Drop it or record it done with merged evidence, never carry it forward as open. |
| Plan with no matching delivery record | Mark it as unreconciled residual uncertainty, not silently open work. |

The skill explicitly rejects the imported backlog, predecessor notes, instruction prose, and an absent or unfetched local clone as shipped-state evidence. It also reinforces at the physical handoff step that record intake must finish before already-shipped rows can move as open work.

## Focused consumer result

Command:

`` `text
bin/fm-doc-audience-check.sh
`` `

Result:

`` `text
fm-doc-audience-check: ok surfaces=65 local_links=210
`` `

The documentation inventory classifies `.agents/skills/secondmate-provisioning/SKILL.md` as an `agent-runtime` surface. Manual single-owner inspection found the record-intake heading and its two distinctive obligations only in that skill.

## Evidence limitation

This change is natural-language agent guidance. The repository has no executable consumer that turns this skill prose into a deterministic creation transcript, and a source-string assertion would violate the repository's test-quality rule. The reviewer-visible artifact therefore records the actual loaded runtime contract, its scenario outcomes, and the real maintained-prose consumer result; no synthetic source-grep test was added.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `git diff --stat --name-status fb368dcc6380bfba5b4ba35722106692f3e789b3..b5ce265a1ccc8f88a5f36b25d669513ddbefc521`
- <code>Manual review of the complete committed diff for `.agents/skills/secondmate-provisioning/SKILL.md`</code>
- `bin/fm-doc-audience-check.sh`
- <code>Manual load-path and audience inspection of `AGENTS.md` and `docs/documentation-audiences.json`</code>
- <code>Manual single-owner inspection with `rg --hidden -n &#34;Record intake for an existing or inherited domain|Never inherit a plan backlog blind|authoritative shipped state&#34; . --glob &#39;!.git/**&#39; --glob &#39;!data/**&#39;`</code>
- `Manual scenario review covering greenfield, existing-product, inherited-predecessor, already-shipped, and unreconciled-plan outcomes`
- <code>Verified the evidence artifact and confirmed `git status --short` remained clean</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
