### PR TITLE
Use task branch prefix

### DIFF
--- a/bin/fm-bearings-snapshot.sh
+++ b/bin/fm-bearings-snapshot.sh
@@ -63,6 +63,8 @@ FLEET="$SCRIPT_DIR/fm-fleet-snapshot.sh"
 # shellcheck source=bin/fm-timeout-lib.sh
 # shellcheck disable=SC1091
 . "$SCRIPT_DIR/fm-timeout-lib.sh"
+# shellcheck source=bin/fm-branch-lib.sh
+. "$SCRIPT_DIR/fm-branch-lib.sh"
 
 # Bounds (overridable for tests / large fleets).
 FM_BEARINGS_LANDED=${FM_BEARINGS_LANDED:-6}
@@ -232,11 +234,16 @@ EOF
         --json number,title,url,headRefName,reviewDecision,mergeable,statusCheckRollup 2>/dev/null) \
         || { nwarn=$((nwarn + 1)); continue; }
       [ -n "$out" ] || out='[]'
-      repo_result=$(printf '%s' "$out" | jq --arg repo "$repo" --argjson limit "$FM_BEARINGS_PR_LIMIT" '
+      repo_result=$(printf '%s' "$out" | jq --arg repo "$repo" --arg prefix "$FM_BRANCH_PREFIX" --arg legacy_prefix "$FM_BRANCH_LEGACY_PREFIX" --arg unticketed "$FM_BRANCH_UNTICKETED_MARKER" --argjson limit "$FM_BEARINGS_PR_LIMIT" '
         [ .[] | {
           num:(.number|tostring),
           repo:$repo,
-          task:(if (.headRefName // "" | startswith("fm/")) then (.headRefName | ltrimstr("fm/")) else "-" end),
+          task:(
+            if (.headRefName // "" | startswith($prefix)) then
+              (.headRefName | ltrimstr($prefix)) as $slug
+              | if ($slug | startswith($unticketed)) then ($slug | ltrimstr($unticketed)) else $slug end
+            elif (.headRefName // "" | startswith($legacy_prefix)) then (.headRefName | ltrimstr($legacy_prefix))
+            else "-" end),
           url:(.url // "-"),
           review:(.reviewDecision // "none"),
           mergeable:(.mergeable // "UNKNOWN"),

--- a/bin/fm-branch-lib.sh
+++ b/bin/fm-branch-lib.sh
@@ -1,0 +1,53 @@
+# shellcheck shell=bash
+# Shared branch naming for Firstmate ship tasks.
+# Usage: . bin/fm-branch-lib.sh
+#
+# FM_BRANCH_PREFIX is the single owner of the prefix for newly created branches.
+# Ticketed task ids already carry their Linear marker and remain unchanged.
+# Unticketed task ids gain the repository's documented dev-000 marker.
+# The legacy prefix remains readable so existing branches and open PRs continue
+# through review, local merge, teardown, and fleet reporting without migration.
+
+FM_BRANCH_PREFIX='ivannovak/'
+FM_BRANCH_LEGACY_PREFIX='fm/'
+FM_BRANCH_UNTICKETED_MARKER='dev-000-'
+
+fm_branch_task_slug() {
+  local id=$1 ticket
+  case "$id" in
+    dev-[0-9]*)
+      ticket=${id#dev-}
+      ticket=${ticket%%-*}
+      case "$ticket" in
+        ''|*[!0-9]*) ;;
+        *) printf '%s\n' "$id"; return 0 ;;
+      esac
+      ;;
+  esac
+  printf '%s%s\n' "$FM_BRANCH_UNTICKETED_MARKER" "$id"
+}
+
+fm_branch_name() {
+  printf '%s%s\n' "$FM_BRANCH_PREFIX" "$(fm_branch_task_slug "$1")"
+}
+
+fm_branch_legacy_name() {
+  printf '%s%s\n' "$FM_BRANCH_LEGACY_PREFIX" "$1"
+}
+
+# Echo the current or legacy local branch for a task, preferring the current
+# convention when both exist.
+fm_branch_resolve_local() {
+  local repo=$1 id=$2 branch
+  branch=$(fm_branch_name "$id")
+  if git -C "$repo" rev-parse --verify --quiet "refs/heads/$branch" >/dev/null; then
+    printf '%s\n' "$branch"
+    return 0
+  fi
+  branch=$(fm_branch_legacy_name "$id")
+  if git -C "$repo" rev-parse --verify --quiet "refs/heads/$branch" >/dev/null; then
+    printf '%s\n' "$branch"
+    return 0
+  fi
+  return 1
+}

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -75,6 +75,8 @@ esac
 . "$SCRIPT_DIR/fm-marker-lib.sh"
 # shellcheck source=bin/fm-classify-lib.sh
 . "$SCRIPT_DIR/fm-classify-lib.sh"
+# shellcheck source=bin/fm-branch-lib.sh
+. "$SCRIPT_DIR/fm-branch-lib.sh"
 PAUSED_VERB=${FM_CLASSIFY_PAUSED_VERB:-$FM_CLASSIFY_PAUSED_VERB_DEFAULT}
 
 resolve_directory_input() {
@@ -349,10 +351,11 @@ fi
 # delivery mode, validated above. The generated DOD opens with the fixed
 # "Delivery contract: mode=<mode>" line that bin/fm-spawn.sh checks against its own
 # explicit --mode before launching.
+BRANCH=$(fm_branch_name "$ID")
 case "$MODE" in
   direct-PR)
     SETUP2=""
-    RULE1='1. Never push to the default branch (push only your `fm/'"$ID"'` branch). Never merge a PR.'
+    RULE1='1. Never push to the default branch (push only your `'"$BRANCH"'` branch). Never merge a PR.'
     IFS= read -r -d '' DOD <<EOF || true
 # Definition of done
 Delivery contract: mode=direct-PR
@@ -364,14 +367,14 @@ EOF
     ;;
   local-only)
     SETUP2=""
-    RULE1="1. Never push to any remote and never open a PR. Work only on your \`fm/$ID\` branch; firstmate handles the merge into local \`main\`."
+    RULE1="1. Never push to any remote and never open a PR. Work only on your \`$BRANCH\` branch; firstmate handles the merge into local \`main\`."
     IFS= read -r -d '' DOD <<EOF || true
 # Definition of done
 Delivery contract: mode=local-only
 This task ships **local-only**: no remote, no PR, no pipeline.
-The task is complete only when committed on your branch \`fm/$ID\`. Do NOT push, do NOT open a PR, do NOT merge.
+The task is complete only when committed on your branch \`$BRANCH\`. Do NOT push, do NOT open a PR, do NOT merge.
 Keep your branch a clean fast-forward onto the current default branch - if \`main\` has advanced, rebase onto it so the eventual merge stays a fast-forward.
-When it is implemented and committed, append \`done: ready in branch fm/$ID\` to the status file and stop.
+When it is implemented and committed, append \`done: ready in branch $BRANCH\` to the status file and stop.
 The configured merge authority approves the ready branch, then firstmate merges it into local \`main\` through the guarded fast-forward path.
 EOF
     ;;
@@ -422,7 +425,7 @@ You are in a disposable git worktree of $REPO, at a detached HEAD on a clean def
 The path check is authoritative: \`git rev-parse --git-dir\` and \`git rev-parse --git-common-dir\` can help inspect the repo, but they do not prove you are outside the primary checkout.
 If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not branch or commit here - append \`blocked: launched in primary checkout, not an isolated worktree\` to the status file and stop.
 
-1. First action: create your branch: \`git checkout -b fm/$ID\`$SETUP2
+1. First action: create your branch: \`git checkout -b $BRANCH\`$SETUP2
 
 # Rules
 $RULE1

--- a/bin/fm-merge-local.sh
+++ b/bin/fm-merge-local.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Perform the approved local merge for a local-only ship task: fast-forward the
-# project's default branch to the crewmate's fm/<id> branch.
+# project's default branch to the crewmate's task branch.
 #
 # This is firstmate's merge gate-action (the captain's merge authority applied
 # locally instead of via a GitHub PR). It is the one sanctioned exception to hard
@@ -16,6 +16,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
 FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
 STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
+# shellcheck source=bin/fm-branch-lib.sh
+. "$SCRIPT_DIR/fm-branch-lib.sh"
 "$FM_ROOT/bin/fm-guard.sh" || true
 ID=${1:?usage: fm-merge-local.sh <task-id>}
 META="$STATE/$ID.meta"
@@ -41,8 +43,10 @@ default_branch() {
   return 1
 }
 
-BRANCH="fm/$ID"
-git -C "$PROJ" rev-parse --verify --quiet "refs/heads/$BRANCH" >/dev/null || { echo "error: branch $BRANCH does not exist in $PROJ" >&2; exit 1; }
+BRANCH=$(fm_branch_resolve_local "$PROJ" "$ID") || {
+  echo "error: branch $(fm_branch_name "$ID") does not exist in $PROJ" >&2
+  exit 1
+}
 
 DEFAULT=$(default_branch) || { echo "error: cannot determine default branch for $PROJ; expected origin/HEAD, main, or master" >&2; exit 1; }
 

--- a/bin/fm-promote.sh
+++ b/bin/fm-promote.sh
@@ -4,7 +4,7 @@
 # state/<task-id>.meta so fm-teardown.sh applies the full ship-task teardown protection
 # again. After promoting, send the crewmate its ship instructions via fm-send.sh
 # (inventory scratch state, reset to a clean default-branch base, carry over only
-# intended fix changes, create branch fm/<task-id>, implement, then report done
+# intended fix changes, create the task branch, implement, then report done
 # according to this task's delivery mode).
 # A scout records no delivery posture, so promotion is where this task's delivery
 # contract is decided: --mode and --yolo are REQUIRED and written into the meta
@@ -19,6 +19,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
 FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
 STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
+# shellcheck source=bin/fm-branch-lib.sh
+. "$SCRIPT_DIR/fm-branch-lib.sh"
 
 MODE=
 YOLO=
@@ -84,5 +86,6 @@ grep -v -e '^kind=' -e '^mode=' -e '^yolo=' "$META" > "$TMP"
 mv "$TMP" "$META"
 
 HOME_Q=$(printf '%q' "$FM_HOME")
+BRANCH=$(fm_branch_name "$ID")
 echo "promoted $ID to ship mode=$MODE yolo=$YOLO (teardown protection restored)"
-echo "next: FM_HOME=$HOME_Q bin/fm-send.sh fm-$ID '<ship instructions for mode=$MODE: review scratch state with git status and git log; reset to a clean default-branch base; carry over only intended fix changes; create branch fm/$ID; implement; report done>'"
+echo "next: FM_HOME=$HOME_Q bin/fm-send.sh fm-$ID '<ship instructions for mode=$MODE: review scratch state with git status and git log; reset to a clean default-branch base; carry over only intended fix changes; create branch $BRANCH; implement; report done>'"

--- a/bin/fm-review-diff.sh
+++ b/bin/fm-review-diff.sh
@@ -18,6 +18,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
 FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
 STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
+# shellcheck source=bin/fm-branch-lib.sh
+. "$SCRIPT_DIR/fm-branch-lib.sh"
 "$FM_ROOT/bin/fm-guard.sh" || true
 
 usage() {
@@ -67,10 +69,11 @@ default_branch() {
 
 DEFAULT=$(default_branch) || { echo "error: cannot determine default branch for $PROJ; expected origin/HEAD, main, or master" >&2; exit 1; }
 
-BRANCH="fm/$ID"
-if ! git -C "$WT" rev-parse --verify --quiet "refs/heads/$BRANCH" >/dev/null; then
+EXPECTED_BRANCH=$(fm_branch_name "$ID")
+BRANCH=$(fm_branch_resolve_local "$WT" "$ID" || true)
+if [ -z "$BRANCH" ]; then
   BRANCH=$(git -C "$WT" symbolic-ref --quiet --short HEAD 2>/dev/null || true)
-  [ -n "$BRANCH" ] || { echo "error: branch fm/$ID does not exist and worktree $WT is detached" >&2; exit 1; }
+  [ -n "$BRANCH" ] || { echo "error: branch $EXPECTED_BRANCH does not exist and worktree $WT is detached" >&2; exit 1; }
   git -C "$WT" rev-parse --verify --quiet "refs/heads/$BRANCH" >/dev/null || { echo "error: branch $BRANCH does not exist in $WT" >&2; exit 1; }
 fi
 

--- a/bin/fm-tangle-lib.sh
+++ b/bin/fm-tangle-lib.sh
@@ -8,7 +8,7 @@
 # on a real branch - normally the default branch, main. The "worktree tangle"
 # failure mode is a crewmate spawned to work on firstmate ITSELF branching and
 # committing in the primary checkout instead of its own disposable worktree,
-# stranding the primary on a feature branch (e.g. fm/readme-restructure-d3).
+# stranding the primary on a feature branch (for example, an active task branch).
 #
 # fm_primary_tangle_branch detects exactly that and nothing else: a NAMED,
 # non-default branch checked out in the given root. It is deliberately silent for

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -145,7 +145,8 @@ Only a named non-default branch checked out in `FM_ROOT` is a worktree tangle.
 `fm-tangle-lib.sh` resolves the default branch from `origin/HEAD`, then local `main` or `master`, and classifies that named non-default primary branch as the tangle.
 `fm-guard.sh` prints the repair command on the next mutable fleet action, while `bin/fm-session-start.sh` reports the same condition through bootstrap as a `TANGLE:` line at session start.
 If another live session holds the fleet lock, both surfaces keep the alarm but switch to read-only wording with no repair command.
-Ship briefs also tell the crewmate to verify `pwd -P` and `git rev-parse --show-toplevel` before creating `fm/<id>`, then stop with a blocked status if it landed in the primary checkout.
+Ship briefs also tell the crewmate to verify `pwd -P` and `git rev-parse --show-toplevel` before creating the branch named by `bin/fm-branch-lib.sh`, then stop with a blocked status if it landed in the primary checkout.
+New task branches use `ivannovak/dev-<ticket>` for ticketed task ids and `ivannovak/dev-000-<task-id>` for unticketed work; existing `fm/` branches remain readable and are not migrated.
 
 ## No-mistakes gate authority boundary
 

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -59,6 +59,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-project-mode.sh`     | Resolve a project's registered delivery posture from `data/projects.md` for fleet sync and home seeding |
 | `fm-merge-local.sh`      | Fast-forward a `local-only` project's local default branch after approval            |
 | `fm-review-diff.sh`      | Review a crewmate branch or resolved PR head against the authoritative base          |
+| `fm-branch-lib.sh`       | Shared new-task branch naming and legacy-branch resolution                           |
 | `fm-marker-lib.sh`       | Compatibility entry point for the from-firstmate carrier owned by `fm-operational-input.sh` |
 | `fm-pending-reply-lib.sh` | Parent-owned secondmate pending-reply expectations, recovery, and one-shot escalation |
 | `fm-secondmate-report.sh` | Optional helper to append a correlated parent status or document-pointer report       |

--- a/tests/fm-bearings-snapshot.test.sh
+++ b/tests/fm-bearings-snapshot.test.sh
@@ -51,7 +51,7 @@ JSON
   exit 0
 fi
 cat <<'JSON'
-[{"number":9,"title":"Ship the thing","url":"https://github.com/kunchenguid/firstmate/pull/9","headRefName":"fm/ship-task","reviewDecision":"APPROVED","mergeable":"MERGEABLE","statusCheckRollup":[{"conclusion":"SUCCESS","status":"COMPLETED"}]}]
+[{"number":9,"title":"Ship the thing","url":"https://github.com/kunchenguid/firstmate/pull/9","headRefName":"ivannovak/dev-000-ship-task","reviewDecision":"APPROVED","mergeable":"MERGEABLE","statusCheckRollup":[{"conclusion":"SUCCESS","status":"COMPLETED"}]}]
 JSON
 SH
   cat > "$fb/gh-axi" <<'SH'

--- a/tests/fm-branch.test.sh
+++ b/tests/fm-branch.test.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Behavioral coverage for shared Firstmate branch naming and compatibility.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+# shellcheck source=bin/fm-branch-lib.sh
+. "$ROOT/bin/fm-branch-lib.sh"
+
+TMP_ROOT=$(fm_test_tmproot fm-branch)
+
+test_names_follow_project_convention() {
+  [ "$(fm_branch_name dev-5579)" = "ivannovak/dev-5579" ] \
+    || fail "ticketed task branch did not preserve its Linear id"
+  [ "$(fm_branch_name sample-generated-seeder-collision)" = "ivannovak/dev-000-sample-generated-seeder-collision" ] \
+    || fail "unticketed task branch did not gain the dev-000 marker"
+  pass "shared branch naming follows the handle and Linear conventions"
+}
+
+test_briefs_use_shared_names() {
+  local home ticketed unticketed
+  home="$TMP_ROOT/brief-home"
+  mkdir -p "$home/data"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" dev-5579 firstmate --mode no-mistakes >/dev/null
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" sample-generated-seeder-collision firstmate --mode local-only >/dev/null
+  ticketed="$home/data/dev-5579/brief.md"
+  unticketed="$home/data/sample-generated-seeder-collision/brief.md"
+  assert_grep 'git checkout -b ivannovak/dev-5579' "$ticketed" \
+    "ticketed ship brief did not use the shared branch name"
+  assert_grep 'git checkout -b ivannovak/dev-000-sample-generated-seeder-collision' "$unticketed" \
+    "unticketed ship brief did not use the shared branch name"
+  assert_grep 'ready in branch ivannovak/dev-000-sample-generated-seeder-collision' "$unticketed" \
+    "local-only completion contract did not use the shared branch name"
+  pass "ship briefs use shared ticketed and unticketed branch names"
+}
+
+test_current_and_legacy_branches_resolve() {
+  local repo
+  repo="$TMP_ROOT/resolve-repo"
+  fm_git_init_commit "$repo"
+  git -C "$repo" branch ivannovak/dev-000-current-task
+  git -C "$repo" branch fm/legacy-task
+  [ "$(fm_branch_resolve_local "$repo" current-task)" = "ivannovak/dev-000-current-task" ] \
+    || fail "current task branch did not resolve"
+  [ "$(fm_branch_resolve_local "$repo" legacy-task)" = "fm/legacy-task" ] \
+    || fail "legacy task branch did not remain resolvable"
+  pass "current and legacy task branches both resolve"
+}
+
+test_promote_instruction_uses_shared_name() {
+  local home out
+  home="$TMP_ROOT/promote-home"
+  mkdir -p "$home/state"
+  touch "$home/state/.last-watcher-beat"
+  fm_write_meta "$home/state/sample-generated-seeder-collision.meta" \
+    "window=fm-sample-generated-seeder-collision" \
+    "worktree=$TMP_ROOT/promote-worktree" \
+    "project=$TMP_ROOT/promote-project" \
+    "harness=codex" \
+    "kind=scout"
+  out=$(FM_HOME="$home" FM_ROOT_OVERRIDE="$ROOT" \
+    "$ROOT/bin/fm-promote.sh" sample-generated-seeder-collision --mode no-mistakes --yolo off)
+  assert_contains "$out" 'create branch ivannovak/dev-000-sample-generated-seeder-collision' \
+    "promotion handoff did not use the shared branch name"
+  pass "promotion handoff uses the shared branch name"
+}
+
+test_names_follow_project_convention
+test_briefs_use_shared_names
+test_current_and_legacy_branches_resolve
+test_promote_instruction_uses_shared_name

--- a/tests/fm-tangle-guard.test.sh
+++ b/tests/fm-tangle-guard.test.sh
@@ -139,7 +139,7 @@ test_brief_assertion_precedes_branch() {
   assert_no_grep "they are identical in the primary checkout" "$brief" \
     "brief must not claim the primary checkout has identical git dirs"
   iso=$(grep -n 'launched in primary checkout, not an isolated worktree' "$brief" | head -1 | cut -d: -f1)
-  br=$(grep -n 'git checkout -b fm/' "$brief" | head -1 | cut -d: -f1)
+  br=$(grep -n 'git checkout -b ivannovak/' "$brief" | head -1 | cut -d: -f1)
   if [ -z "$iso" ] || [ -z "$br" ]; then
     fail "brief missing assertion ($iso) or branch step ($br)"
   fi


### PR DESCRIPTION
## Summary

- Give new Firstmate task branches a single naming owner in `bin/fm-branch-lib.sh`.
- Generate `ivannovak/dev-5579` for ticketed task ids and `ivannovak/dev-000-<task-id>` for unticketed work.
- Keep existing `fm/` branches readable for review, local merge, teardown, and fleet PR inventory; no existing branch or PR is renamed.
- Update branch-generation, promotion, parsing, reporting, tests, and maintained documentation together.

Ticketed descriptions are intentionally omitted. Adding them would require new backlog-title lookup machinery, so this keeps the correct smaller change requested; unticketed task ids already provide the description after `dev-000-`.

## Validation

- `bin/fm-lint.sh`
- `bin/fm-doc-audience-check.sh`
- Focused six-test selection: 6 passed, 0 failed (`fm-branch`, `fm-brief`, `fm-review-diff`, `fm-bearings-snapshot`, `fm-tangle-guard`, `fm-task-delivery`).
- Single-owner mutation proof: temporarily changed `FM_BRANCH_PREFIX` to `throwaway/`; the unchanged consumer test failed with unpiped `UNPIPED_EXIT_CODE=1`, then the owner was restored to `ivannovak/`.
- Broad changed-file selection: 53 of 59 passed; six unrelated host/harness tests failed (`fm-calm-pi-extension`, `fm-kimi-harness`, `fm-muse-harness`, `fm-teardown` Herdr preflight, `fm-gotmp`, and `fm-backend-herdr-focus-flash-e2e`).

## CI status

CI did not run. This is a fork PR, and GitHub Actions requires the captain to approve workflow runs. An empty check set must not be interpreted as checks green.