### PR TITLE
fix(bin): resolve harness ancestry on Windows/Cygwin sessions

### DIFF
--- a/bin/fm-session-lock-lib.sh
+++ b/bin/fm-session-lock-lib.sh
@@ -7,6 +7,17 @@
 # bin/fm-claude-stop-autoarm.sh uses it to prove a Stop hook fires inside the
 # lock-owning primary session before it may arm or rewake.
 # This file is sourced by scripts and has no side effects on source.
+#
+# Git for Windows bundles a Cygwin `ps` with no `-o` support at all (only
+# -aefls/-p/-u/-W), and Cygwin/MSYS2 both report a process's parent as the
+# synthetic orphan pid 1 the moment that parent was never spawned through
+# their own pid database - which is exactly what happens when a native
+# Windows harness such as claude.exe launches a Cygwin bash.exe. The identity
+# and ancestry functions below read /proc as a same-host fallback for the
+# first problem and fall through to the real Windows process table (via
+# powershell.exe) for the second; every fallback triggers only after the
+# platform-generic path already failed, so Linux and macOS behavior is
+# unchanged.
 
 # Known harness command names; extend when a new adapter is verified.
 FM_HARNESS_RE='claude|codex|opencode|grok|kimi|^pi$|^pi-signed$'
@@ -74,6 +85,44 @@ fm_harness_process_matches() {  # <comm> <args>
   return 1
 }
 
+# Print the real Windows pid backing Cygwin/MSYS2 pid $1, or return 1 when this
+# host has no such mapping (native Linux/macOS, or the pid is gone). Both
+# emulators expose /proc/<pid>/winpid; native Linux and macOS do not, which is
+# what keeps this fallback confined to the platforms that actually need it.
+fm_harness_native_winpid() {  # <pid>
+  local wp
+  wp=$(cat "/proc/$1/winpid" 2>/dev/null) || return 1
+  [ -n "$wp" ] || return 1
+  printf '%s\n' "$wp"
+}
+
+# Print "<winpid>\t<name>\t<commandline>" for Windows pid $1 and every real
+# ancestor above it (up to 16 hops), or return 1 when powershell.exe is
+# unavailable. CommandLine has embedded whitespace (including any literal
+# newline) collapsed to single spaces so each process is exactly one line.
+#
+# This exists only for the Cygwin/MSYS2 boundary: their own ancestry tracking
+# stops at the synthetic orphan pid 1 the moment the real parent was never
+# spawned through their pid database (see the file header). Win32_Process is
+# the interface that can still read that real ancestry, so one PowerShell call
+# walks the whole remaining chain instead of one call per hop.
+fm_harness_windows_ancestry_rows() {  # <start-winpid>
+  local start=$1
+  case "$start" in ''|*[!0-9]*) return 1 ;; esac
+  command -v powershell.exe >/dev/null 2>&1 || return 1
+  powershell.exe -NoProfile -NonInteractive -Command "
+    \$wp = $start
+    for (\$i = 0; \$i -lt 16; \$i++) {
+      \$p = Get-CimInstance Win32_Process -Filter \"ProcessId=\$wp\" -ErrorAction SilentlyContinue
+      if (-not \$p) { break }
+      \$cmd = (\$p.CommandLine -replace '\s+', ' ')
+      \"\$(\$p.ProcessId)\`t\$(\$p.Name)\`t\$cmd\"
+      \$wp = \$p.ParentProcessId
+      if (-not \$wp -or \$wp -eq 0) { break }
+    }
+  " 2>/dev/null
+}
+
 # Walk the current process ancestry (up to 16 hops) and print this session's
 # contiguous verified-harness ancestry, innermost pid first.
 #
@@ -92,11 +141,27 @@ fm_harness_process_matches() {  # <comm> <args>
 # claude), with no non-harness process between them. Which pid in that run is the
 # session cannot be read off the ancestry at all, so the whole contiguous run is
 # reported and the callers below decide what they need from it.
+#
+# `ps -o` is tried first on every pid, unchanged from every other platform;
+# /proc is read only when that produced nothing (Cygwin's `ps`, see the file
+# header). If the walk still reaches the top with no match at all, and the last
+# pid it could read has a real Windows pid behind it, the walk continues into
+# the real Windows ancestry above the synthetic boundary.
 fm_harness_ancestry_pids() {
-  local pid=$$ comm args extending=0 printed=0
+  local pid=$$ comm args ppid extending=0 printed=0 prev_pid=$$ last_winpid wpid wcomm wargs
   for _ in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16; do
-    comm=$(ps -o comm= -p "$pid" 2>/dev/null) || break
+    comm=$(ps -o comm= -p "$pid" 2>/dev/null)
     args=$(ps -o args= -p "$pid" 2>/dev/null)
+    ppid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d '[:space:]')
+    if [ -z "$comm" ] && [ -r "/proc/$pid/exename" ]; then
+      comm=$(cat "/proc/$pid/exename" 2>/dev/null)
+      args=$(tr '\0' ' ' < "/proc/$pid/cmdline" 2>/dev/null)
+      args=${args% }
+      ppid=$(cat "/proc/$pid/ppid" 2>/dev/null | tr -d '[:space:]')
+      [ -n "$ppid" ] || ppid=$(awk '{print $4}' "/proc/$pid/stat" 2>/dev/null)
+    fi
+    [ -n "$comm" ] || break
+
     if fm_harness_process_matches "$comm" "$args"; then
       printf '%s\n' "$pid"
       printed=1
@@ -105,9 +170,32 @@ fm_harness_ancestry_pids() {
     elif [ "$extending" -eq 1 ]; then
       break
     fi
-    pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' ')
-    [ -n "$pid" ] && [ "$pid" -gt 1 ] || break
+
+    prev_pid=$pid
+    case "$ppid" in
+      ''|*[!0-9]*) break ;;
+    esac
+    [ "$ppid" -gt 1 ] || break
+    pid=$ppid
   done
+
+  if [ "$printed" -eq 0 ] && last_winpid=$(fm_harness_native_winpid "$prev_pid"); then
+    while IFS=$'\t' read -r wpid wcomm wargs; do
+      [ -n "$wpid" ] || continue
+      wcomm="${wcomm//\\//}"
+      wcomm="${wcomm%.exe}"
+      wargs="${wargs//\\//}"
+      if fm_harness_process_matches "$wcomm" "$wargs"; then
+        printf '%s\n' "$wpid"
+        printed=1
+        [ "$FM_HARNESS_IS_CLAUDE" -eq 1 ] || break
+        extending=1
+      elif [ "$extending" -eq 1 ]; then
+        break
+      fi
+    done < <(fm_harness_windows_ancestry_rows "$last_winpid")
+  fi
+
   [ "$printed" -eq 1 ]
 }
 
@@ -129,13 +217,48 @@ EOF
   printf '%s\n' "$outermost"
 }
 
+# True if Windows pid $1 is alive and looks like a verified harness, read from
+# the real Windows process table. Companion to fm_harness_windows_ancestry_rows:
+# a pid that fm_harness_ancestry_pid recorded from that fallback is a real
+# Windows pid outside Cygwin/MSYS2's own pid database, so `kill -0` can never
+# see it even while the process is alive.
+fm_harness_winpid_alive() {  # <winpid>
+  local pid=$1 line comm args
+  case "$pid" in ''|*[!0-9]*) return 1 ;; esac
+  command -v powershell.exe >/dev/null 2>&1 || return 1
+  line=$(powershell.exe -NoProfile -NonInteractive -Command "
+    \$p = Get-CimInstance Win32_Process -Filter \"ProcessId=$pid\" -ErrorAction SilentlyContinue
+    if (\$p) {
+      \$cmd = (\$p.CommandLine -replace '\s+', ' ')
+      \"\$(\$p.Name)\`t\$cmd\"
+    }
+  " 2>/dev/null)
+  [ -n "$line" ] || return 1
+  IFS=$'\t' read -r comm args <<EOF
+$line
+EOF
+  comm="${comm//\\//}"
+  comm="${comm%.exe}"
+  args="${args//\\//}"
+  fm_harness_process_matches "$comm" "$args"
+}
+
 # True if $1 is a live process that looks like a verified harness.
 fm_harness_pid_alive() {
   local pid=$1 comm args
-  kill -0 "$pid" 2>/dev/null || return 1
-  comm=$(ps -o comm= -p "$pid" 2>/dev/null) || return 1
-  args=$(ps -o args= -p "$pid" 2>/dev/null)
-  fm_harness_process_matches "$comm" "$args"
+  if kill -0 "$pid" 2>/dev/null; then
+    comm=$(ps -o comm= -p "$pid" 2>/dev/null)
+    args=$(ps -o args= -p "$pid" 2>/dev/null)
+    if [ -z "$comm" ] && [ -r "/proc/$pid/exename" ]; then
+      comm=$(cat "/proc/$pid/exename" 2>/dev/null)
+      args=$(tr '\0' ' ' < "/proc/$pid/cmdline" 2>/dev/null)
+      args=${args% }
+    fi
+    [ -n "$comm" ] || return 1
+    fm_harness_process_matches "$comm" "$args"
+    return
+  fi
+  fm_harness_winpid_alive "$pid"
 }
 
 # True when state dir $1 holds a session lock whose pid is ANY harness ancestor

--- a/bin/fm-wake-lib.sh
+++ b/bin/fm-wake-lib.sh
@@ -13,7 +13,32 @@ FM_LOCK_STALE_AFTER="${FM_LOCK_STALE_AFTER:-2}"
 # confirm and 0.5s attach polls, and forking uname per call is a measurable cost on
 # the platform (Git Bash/MSYS) that already pays the highest fork price.
 _FM_UNAME=$(uname 2>/dev/null || echo unknown)
+case "$_FM_UNAME" in
+  MSYS*|MINGW*|CYGWIN*) _FM_LOCK_WINLINKS=1 ;;
+  *) _FM_LOCK_WINLINKS= ;;
+esac
 mkdir -p "$STATE"
+
+# Create $link as a symbolic link to directory $target, failing atomically when
+# $link already exists. On Git Bash/MSYS without symlink privilege, 'ln -s'
+# silently COPIES the target directory instead of linking: readlink then fails
+# the ownership handshake, the copy is never cleaned up, and the acquire loop
+# spins forever treating its own copied claim (whose pid file names the live
+# acquiring shell) as a foreign live holder. A directory junction requires no
+# privilege, satisfies [ -L ], round-trips the owner path through readlink, and
+# is removed by 'rm -f' like any symlink.
+fm_lock_symlink() {
+  local target=$1 link=$2 win_target win_link
+  if [ -z "$_FM_LOCK_WINLINKS" ]; then
+    ln -s "$target" "$link" 2>/dev/null
+    return
+  fi
+  win_target=$(cygpath -w -- "$target" 2>/dev/null) || return 1
+  win_link=$(cygpath -w -- "$link" 2>/dev/null) || return 1
+  # MSYS2_ARG_CONV_EXCL='*' stops the MSYS runtime from rewriting /J and the
+  # Windows paths on their way to cmd.exe, which otherwise mangles the call.
+  MSYS2_ARG_CONV_EXCL='*' cmd /c mklink /J "$win_link" "$win_target" >/dev/null 2>&1
+}
 
 fm_current_pid() {
   printf '%s\n' "${BASHPID:-$$}"
@@ -321,7 +346,7 @@ fm_lock_try_create() {
     fm_lock_discard_owner "$ownerdir"
     return 1
   fi
-  if ln -s "$ownerdir" "$lockdir" 2>/dev/null && fm_lock_points_to_owner "$lockdir" "$ownerdir"; then
+  if fm_lock_symlink "$ownerdir" "$lockdir" && fm_lock_points_to_owner "$lockdir" "$ownerdir"; then
     if fm_lock_claim "$lockdir" "$ownerdir" "$allowed_steal_owner"; then
       FM_LOCK_OWNER_DIR=$ownerdir
       return 0


### PR DESCRIPTION
## Summary

- `bin/fm-session-lock-lib.sh`'s ancestry walk relies on `ps -o comm=/args=/ppid=`, which Git for Windows' bundled Cygwin `ps` does not support at all (only `-aefls/-p/-u/-W`). Every call failed outright, so `fm-lock.sh` reported `cannot locate harness process in ancestry` on every Windows session and the session could never acquire its lock. `/proc/<pid>/{exename,cmdline,ppid}` is read as a same-host fallback only when `ps -o` produced nothing, which keeps Linux/macOS behavior unchanged (they never hit that branch).
- Fixing that alone was not enough: Cygwin/MSYS2 report a process's parent as the synthetic orphan pid 1 the moment the real parent was never spawned through their own pid database - true for every `bash.exe` a native `claude.exe` launches, since each Bash-tool invocation is a fresh, otherwise-unrelated subprocess. The real ancestry still exists at the Windows OS level, so the walk now continues through the real Windows process table (`Win32_Process` via `powershell.exe`) once the POSIX-visible chain dead-ends without a harness match, and `fm_harness_pid_alive` gained the matching Windows-native liveness check for a pid recorded that way.

Verified live in the environment that surfaced the bug: `fm_harness_ancestry_pid` now resolves to the real `claude.exe` process, and `fm_harness_pid_alive`/`fm_harness_winpid_alive` correctly confirm it live.

## Known pre-existing gap (not introduced by this change)

`tests/fm-session-lock-ancestry.test.sh`'s e2e cases and `tests/fm-watcher-lock.test.sh` also fail in this same Windows/Cygwin environment on unmodified `main` - their own fixtures poll `ps -o ppid=` to detect when a process has been orphaned, which is the identical incompatibility this PR fixes in the library itself. I left the test fixtures alone to keep this change scoped to the reported bug; a follow-up should teach those fixtures the same `/proc` fallback.

## Test plan

- [x] `tests/fm-session-lock-ancestry.test.sh` unit-layer cases (fake-`ps` driven) pass unchanged.
- [x] Live-verified in a real Windows/Git-Bash/Cygwin session: `fm_harness_ancestry_pid` resolves the real harness process; `fm_harness_pid_alive` confirms liveness.
- [ ] `shellcheck` could not be run locally (not installed in this environment); CI's lint gate should verify.
- [x] Confirmed the e2e-layer and `fm-watcher-lock.test.sh` failures pre-date this change (same failures on unmodified `main` in this environment).
