### PR TITLE
fix: require lavish-axi 0.1.46 during bootstrap

### DIFF
--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -763,7 +763,7 @@ NO_MISTAKES_MIN=1.31.2
 # tasks-axi feature probes are an independent defense-in-depth concern, not part
 # of its floor.
 GH_AXI_MIN=0.1.29
-LAVISH_AXI_MIN=0.1.45
+LAVISH_AXI_MIN=0.1.46
 
 treehouse_supports_lease() {
   treehouse get --help 2>&1 | grep -Eq '(^|[^[:alnum:]_-])--lease([^[:alnum:]_-]|$)'

--- a/tests/fm-bootstrap.test.sh
+++ b/tests/fm-bootstrap.test.sh
@@ -45,7 +45,7 @@ make_fake_toolchain() {
   local dir=$1 fakebin
   fakebin=$(fm_fakebin "$dir")
   fm_fake_exit0 "$fakebin" tmux node chrome-devtools-axi
-  fm_fake_version_tool "$fakebin" lavish-axi FM_FAKE_LAVISH_AXI_VERSION 0.1.45
+  fm_fake_version_tool "$fakebin" lavish-axi FM_FAKE_LAVISH_AXI_VERSION 0.1.46
   cat > "$fakebin/gh-axi" <<'SH'
 #!/usr/bin/env bash
 if [ "${1:-}" = --version ]; then
@@ -392,11 +392,11 @@ test_lavish_axi_min_version() {
         [ "$out" = "$missing" ] || fail "$label: expected '$missing', got: $out" ;;
     esac
   done <<'ROWS'
-minimum lavish-axi version is accepted^0.1.45^empty
-newer lavish-axi patch is accepted^0.1.46^empty
+minimum lavish-axi version is accepted^0.1.46^empty
+newer lavish-axi patch is accepted^0.1.47^empty
 newer lavish-axi minor is accepted^0.2.0^empty
 newer lavish-axi major is accepted^1.0.0^empty
-the patch just below the floor reports an upgrade^0.1.44^missing
+the patch just below the floor reports an upgrade^0.1.45^missing
 much older lavish-axi minor reports an upgrade^0.0.9^missing
 unparseable lavish-axi version reports an upgrade^lavish-axi development build^missing
 ROWS

--- a/tests/fm-secondmate-harness.test.sh
+++ b/tests/fm-secondmate-harness.test.sh
@@ -981,7 +981,7 @@ make_fake_toolchain() {
   fakebin="$dir/fakebin"
   mkdir -p "$fakebin"
   fm_fake_exit0 "$fakebin" node chrome-devtools-axi
-  fm_fake_version_tool "$fakebin" lavish-axi FM_FAKE_LAVISH_AXI_VERSION 0.1.45
+  fm_fake_version_tool "$fakebin" lavish-axi FM_FAKE_LAVISH_AXI_VERSION 0.1.46
   cat > "$fakebin/gh-axi" <<'SH'
 #!/usr/bin/env bash
 if [ "${1:-}" = --version ]; then

--- a/tests/fm-secondmate-liveness.test.sh
+++ b/tests/fm-secondmate-liveness.test.sh
@@ -207,7 +207,7 @@ make_toolchain() {
   local dir=$1 fakebin
   fakebin=$(fm_fakebin "$dir")
   fm_fake_exit0 "$fakebin" node chrome-devtools-axi pi-signed
-  fm_fake_version_tool "$fakebin" lavish-axi FM_FAKE_LAVISH_AXI_VERSION 0.1.45
+  fm_fake_version_tool "$fakebin" lavish-axi FM_FAKE_LAVISH_AXI_VERSION 0.1.46
   cat > "$fakebin/gh-axi" <<'SH'
 #!/usr/bin/env bash
 if [ "${1:-}" = --version ]; then

--- a/tests/fm-secondmate-sync.test.sh
+++ b/tests/fm-secondmate-sync.test.sh
@@ -292,7 +292,7 @@ make_fake_toolchain() {
   fakebin="$dir/fakebin"
   mkdir -p "$fakebin"
   fm_fake_exit0 "$fakebin" node chrome-devtools-axi
-  fm_fake_version_tool "$fakebin" lavish-axi FM_FAKE_LAVISH_AXI_VERSION 0.1.45
+  fm_fake_version_tool "$fakebin" lavish-axi FM_FAKE_LAVISH_AXI_VERSION 0.1.46
   cat > "$fakebin/gh-axi" <<'SH'
 #!/usr/bin/env bash
 if [ "${1:-}" = --version ]; then

--- a/tests/fm-session-start.test.sh
+++ b/tests/fm-session-start.test.sh
@@ -71,7 +71,7 @@ new_world() {
 make_fake_toolchain() {
   local fakebin=$1
   fm_fake_exit0 "$fakebin" tmux node chrome-devtools-axi
-  fm_fake_version_tool "$fakebin" lavish-axi FM_FAKE_LAVISH_AXI_VERSION 0.1.45
+  fm_fake_version_tool "$fakebin" lavish-axi FM_FAKE_LAVISH_AXI_VERSION 0.1.46
   cat > "$fakebin/gh-axi" <<'SH'
 #!/usr/bin/env bash
 if [ "${1:-}" = --version ]; then

--- a/tests/fm-shared-captain-inheritance.test.sh
+++ b/tests/fm-shared-captain-inheritance.test.sh
@@ -220,7 +220,7 @@ SH
 add_bootstrap_compatible_tools() {
   local fakebin=$1
   fm_fake_exit0 "$fakebin" node chrome-devtools-axi gh treehouse
-  fm_fake_version_tool "$fakebin" lavish-axi FM_FAKE_LAVISH_AXI_VERSION 0.1.45
+  fm_fake_version_tool "$fakebin" lavish-axi FM_FAKE_LAVISH_AXI_VERSION 0.1.46
   cat > "$fakebin/gh-axi" <<'SH'
 #!/usr/bin/env bash
 if [ "${1:-}" = --version ]; then

--- a/tests/fm-startup-memory-budget.test.sh
+++ b/tests/fm-startup-memory-budget.test.sh
@@ -16,7 +16,7 @@ make_fake_toolchain() {
   local dir=$1 fakebin
   fakebin=$(fm_fakebin "$dir")
   fm_fake_exit0 "$fakebin" node chrome-devtools-axi
-  fm_fake_version_tool "$fakebin" lavish-axi FM_FAKE_LAVISH_AXI_VERSION 0.1.45
+  fm_fake_version_tool "$fakebin" lavish-axi FM_FAKE_LAVISH_AXI_VERSION 0.1.46
   cat > "$fakebin/gh-axi" <<'SH'
 #!/usr/bin/env bash
 if [ "${1:-}" = --version ]; then

--- a/tests/fm-x-mode.test.sh
+++ b/tests/fm-x-mode.test.sh
@@ -722,7 +722,7 @@ test_bootstrap_reports_missing_x_dependency() {
   home="$TMP_ROOT/boot-missing-x"; mkdir -p "$home"
   fakebin=$(fm_fakebin "$home")
   fm_fake_exit0 "$fakebin" tmux node no-mistakes chrome-devtools-axi curl
-  fm_fake_version_tool "$fakebin" lavish-axi FM_FAKE_LAVISH_AXI_VERSION 0.1.45
+  fm_fake_version_tool "$fakebin" lavish-axi FM_FAKE_LAVISH_AXI_VERSION 0.1.46
   cat > "$fakebin/gh-axi" <<'SH'
 #!/usr/bin/env bash
 if [ "${1:-}" = --version ]; then


### PR DESCRIPTION
## Intent

Bump one version-floor constant in firstmate's bin/fm-bootstrap.sh: change LAVISH_AXI_MIN=0.1.45 to LAVISH_AXI_MIN=0.1.46, because lavish-axi 0.1.46 is now published and is current-latest per the floor policy (floors track newest axi tools, not the minimum feature-introduced version).

Scope is deliberately minimal and constrained by the requester:
- Change ONLY the LAVISH_AXI_MIN constant. Do NOT touch any other version floor (GH_AXI_MIN, CHROME_DEVTOOLS_AXI_MIN, etc.); other floors will be handled separately.
- Do not refactor surrounding code. This is a single-constant bump.
- If a test or doc pins the old 0.1.45 value and must move in lockstep to stay correct, update only that exact pin; otherwise change nothing else.

Decisions made while doing the work: the fake-toolchain default lavish-axi version in eight test files (fm-bootstrap, fm-session-start, fm-startup-memory-budget, fm-secondmate-sync, fm-secondmate-liveness, fm-secondmate-harness, fm-shared-captain-inheritance, fm-x-mode) had to move 0.1.45 -> 0.1.46 or those suites would have started reporting an upgrade instead of staying silent. The fm-bootstrap floor table rows were shifted one patch each so the boundary cases still mean the same thing: minimum accepted 0.1.45->0.1.46, newer patch 0.1.46->0.1.47, just-below-floor 0.1.44->0.1.45. Deliberately left alone: the historical 'verified against 0.1.45' comment in bin/fm-procevent-lavish.sh and the dated 0.1.45 empirical record in docs/verification/process-event-sources.md, since both record past verification facts rather than pinning the floor.

Acceptance: LAVISH_AXI_MIN=0.1.46 in bin/fm-bootstrap.sh with no other floor changed; bin/fm-lint.sh clean; existing floor tests pass. Delivery is a PR for the captain to merge - no self-merge.

## What Changed

- Raise the bootstrap `lavish-axi` version floor from 0.1.45 to 0.1.46.
- Update bootstrap boundary cases and compatible fake-toolchain fixtures to reflect the new floor.

## Risk Assessment

✅ Low: The change is narrowly scoped to the requested lavish-axi floor bump and updates only the behavioral fixtures needed to preserve their intended semantics; no other tool floors or unrelated historical records changed.

## Testing

The focused existing floor test passed and an end-user CLI transcript proves 0.1.45 prompts for upgrade while 0.1.46 and 0.1.47 are accepted silently. Whole-suite attempts exceeded this phase runner's per-command window, and lint was not run because the assigned test phase explicitly forbids linters.

<details>
<summary>Evidence: Bootstrap lavish-axi floor behavior</summary>

<code>Installed lavish-axi: 0.1.45&#10;fm-bootstrap output: MISSING: lavish-axi (install: npm install -g lavish-axi &amp;&amp; lavish-axi setup hooks)&#10;&#10;Installed lavish-axi: 0.1.46&#10;fm-bootstrap output: &lt;silent&gt;&#10;&#10;Installed lavish-axi: 0.1.47&#10;fm-bootstrap output: &lt;silent&gt;</code>

```text
Installed lavish-axi: 0.1.45
fm-bootstrap output: MISSING: lavish-axi (install: npm install -g lavish-axi && lavish-axi setup hooks)

Installed lavish-axi: 0.1.46
fm-bootstrap output: <silent>

Installed lavish-axi: 0.1.47
fm-bootstrap output: <silent>
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>Inspected `git diff d8bb074f9f9a5ab4e21d243e8c172f03faff74ac..49c92d1f6bbd1b787b67e740fc06f0c8103de29d` for scope and test ownership.</code>
- <code>`bin/fm-test-run.sh tests/fm-bootstrap.test.sh` - the whole-suite attempt exceeded the phase runner&#39;s execution window before reaching the lavish cases.</code>
- <code>`bash tests/fm-bootstrap.test.sh` - the direct whole-suite retry likewise exceeded the execution window.</code>
- <code>Executed `test_lavish_axi_min_version` from `tests/fm-bootstrap.test.sh` against the real `bin/fm-bootstrap.sh`; all boundary rows passed.</code>
- <code>Ran the real `bin/fm-bootstrap.sh` with hermetic lavish-axi versions 0.1.45, 0.1.46, and 0.1.47 and captured the user-facing output.</code>
- <code>Verified `git status --short` remained clean after testing.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
