### PR TITLE
Add-herdr-skill-to-tracked-skills

### DIFF
--- a/.agents/skills/herdr/SKILL.md
+++ b/.agents/skills/herdr/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: herdr
+description: Use when the user explicitly mentions Herdr and wants to control terminal panes, tabs, or workspaces for coding agents — open/split panes, launch codex/claude/pi/opencode/omp interactively, inspect or read neighboring work, manage git worktrees, or send the workspace to Plannotator for review. Also use whenever the user wants to delegate, dispatch, or run a task "through reasonix" (Google DeepSeek-native coding agent) — as a subagent, for a second/independent opinion, or an adversarial review — regardless of whether Herdr is running; this skill picks visible-pane vs headless dispatch automatically. Also use for browser automation driven through a visible Herdr pane — "open a browser session in Herdr", "drive the browser through Herdr", "run browser-harness in a pane".
+allowed-tools: Bash
+metadata:
+  internal: true
+---
+
+# herdr
+
+## Overview
+
+One contract, one primary engine, three tasks. Modeled on [cyberuni/cyber-mux](https://github.com/cyberuni/cyber-mux)'s "one contract over terminal multiplexers" idea: detect what's running the session, then drive it through a single vocabulary instead of hardcoding one multiplexer's commands into every downstream tool.
+
+This skill implements the **Herdr** engine, plus the headless no-multiplexer fallback for reasonix. It does not implement a tmux driver — cyber-mux itself already covers tmux; this skill borrows its contract shape, not its code.
+
+Herdr isn't limited to the local machine — `herdr --remote <ssh-target>` attaches through SSH to a Herdr server running on a different host (see `references/herdr-panes.md`'s "Attach to a Herdr server running on another machine" section — **interactive, hand it to the user, don't run it as a blocking tool call**, confirmed live 2026-07-31). Whenever a task involves a remote box that already has Herdr on it (e.g. `orca-ubuntu-vm`), pane-control still routes through this same skill — only the target changes, not the vocabulary. `agentbox-remote` is the separate skill for provisioning a brand-new isolated box; this skill is for reaching a host's own already-running Herdr server.
+
+## Step 1 — Which task is this?
+
+IF the user explicitly mentions Herdr and wants pane/tab/workspace control that is NOT specifically about dispatching reasonix or browser-harness (starting an interactive agent, running an ordinary command in another pane, inspecting/reading a pane, managing a worktree, sending the workspace to Plannotator):
+→ task = **pane-control**. Go to Step 2.
+
+ELSE IF the user wants to delegate, dispatch, or run something "through reasonix" — as a subagent, for a second/independent opinion, or an adversarial review — regardless of whether Herdr was mentioned:
+→ task = **reasonix-dispatch**. Go to Step 2.
+
+ELSE IF the user wants browser automation (navigate, click, scrape, test a site) driven through a visible, status-tracked Herdr pane, or wants to continue an already-open browser-harness pane from a previous message:
+→ task = **browser-harness-dispatch**. Go to Step 2.
+
+ELSE:
+→ this skill does not apply. Stop.
+
+## Step 2 — Detect the engine
+
+Run:
+
+```bash
+echo "$HERDR_ENV"
+echo "$TMUX"
+```
+
+IF `HERDR_ENV` is `1`:
+→ engine = **herdr**. Go to Step 3.
+
+ELSE IF `TMUX` is set (a tmux session, no Herdr):
+→ IF task = pane-control OR task = browser-harness-dispatch: STOP. No verified tmux command path exists in this skill — it borrows cyber-mux's *contract*, not its tmux driver. Tell the user to use cyber-mux directly for tmux pane control, or run the task without pane isolation.
+→ ELSE (task = reasonix-dispatch): engine = **none**. Go to Step 3 — reasonix has a headless path independent of any multiplexer.
+
+ELSE (no multiplexer detected):
+→ IF task = browser-harness-dispatch: STOP. This branch only works inside a Herdr-managed pane and has no headless fallback. Tell the user, and use `browser-use` or `claude-in-chrome` instead.
+→ ELSE: engine = **none**. Go to Step 3.
+
+## Step 3 — Dispatch to the right branch
+
+IF task = pane-control (Step 2 already stopped unless engine = herdr):
+→ Read [`references/herdr-panes.md`](references/herdr-panes.md) and follow it.
+
+ELSE IF task = reasonix-dispatch AND engine = herdr:
+→ Read [`references/reasonix-herdr.md`](references/reasonix-herdr.md) and follow it — decides `dispatch` (visible, interactive PTY) vs `watch` (visible, status-only) mode.
+
+ELSE IF task = reasonix-dispatch AND engine = none:
+→ Read [`references/reasonix-headless.md`](references/reasonix-headless.md) and follow it — no visible pane, plain `reasonix-axi` calls. Also read [`references/reasonix-tools-and-mcp.md`](references/reasonix-tools-and-mcp.md) before any dispatch that needs read-only profiles or MCP tools.
+
+ELSE (task = browser-harness-dispatch, Step 2 already stopped unless engine = herdr):
+→ Read [`references/browser-harness-herdr.md`](references/browser-harness-herdr.md) and follow it — session-shaped: `open` once, `run` as many scripts as needed, `close` explicitly when done.
+
+## Step 4 — Learning review
+
+After the task, ask:
+
+| Question | Action |
+|---|---|
+| A branch fired on the wrong task/engine combination? | Sharpen Step 1 or Step 2's condition |
+| tmux pane-control actually got requested? | Consider building a real tmux driver (`references/tmux-panes.md`) instead of the current STOP-and-redirect |
+| New failure mode inside a branch? | Add it to that branch's reference file, not here |
+| A reference file grew past what one branch needs? | Split further per the branch it doesn't serve |
+
+If anything changed, snapshot + bump:
+
+```bash
+cp SKILL.md SKILL.v<N+1>.md
+# add a row to VERSIONING.md
+```
+
+## Checklist
+
+- [ ] Task identified (pane-control vs reasonix-dispatch vs browser-harness-dispatch)
+- [ ] Engine detected (herdr / tmux / none)
+- [ ] Correct reference file loaded and followed
+- [ ] Result verified before acting on it
+- [ ] Learning review done

--- a/.agents/skills/herdr/SKILL.v1.md
+++ b/.agents/skills/herdr/SKILL.v1.md
@@ -1,0 +1,80 @@
+---
+name: cyber-mux
+description: Use when the user explicitly mentions Herdr or cyber-mux and wants to control terminal panes, tabs, or workspaces for coding agents — open/split panes, launch codex/claude/pi/opencode/omp interactively, inspect or read neighboring work, manage git worktrees, or send the workspace to Plannotator for review. Also use whenever the user wants to delegate, dispatch, or run a task "through reasonix" (Google DeepSeek-native coding agent) — as a subagent, for a second/independent opinion, or an adversarial review — regardless of whether Herdr is running; this skill picks visible-pane vs headless dispatch automatically.
+allowed-tools: Bash
+---
+
+# cyber-mux
+
+## Overview
+
+One contract, two engines, three tasks. Modeled on [cyberuni/cyber-mux](https://github.com/cyberuni/cyber-mux)'s "one contract over terminal multiplexers" idea: detect what's running the session, then drive it through a single vocabulary instead of hardcoding one multiplexer's commands into every downstream tool.
+
+This skill implements the **Herdr** engine and the headless no-multiplexer fallback for reasonix. It does not implement a tmux driver — cyber-mux itself already covers tmux; this skill borrows its contract shape, not its code.
+
+## Step 1 — Which task is this?
+
+IF the user explicitly mentions Herdr and wants pane/tab/workspace control that is NOT specifically about dispatching a reasonix task (starting an interactive agent, running an ordinary command in another pane, inspecting/reading a pane, managing a worktree, sending the workspace to Plannotator):
+→ task = **pane-control**. Go to Step 2.
+
+ELSE IF the user wants to delegate, dispatch, or run something "through reasonix" — as a subagent, for a second/independent opinion, or an adversarial review — regardless of whether Herdr was mentioned:
+→ task = **reasonix-dispatch**. Go to Step 2.
+
+ELSE:
+→ this skill does not apply. Stop.
+
+## Step 2 — Detect the engine
+
+Run:
+
+```bash
+echo "$HERDR_ENV"
+echo "$TMUX"
+```
+
+IF `HERDR_ENV` is `1`:
+→ engine = **herdr**. Go to Step 3.
+
+ELSE IF `TMUX` is set (a tmux session, no Herdr):
+→ IF task = pane-control: STOP. No verified tmux command path exists in this skill — it borrows cyber-mux's *contract*, not its tmux driver. Tell the user to use cyber-mux directly for tmux pane control, or run the task without pane isolation.
+→ ELSE (task = reasonix-dispatch): engine = **none**. Go to Step 3 — reasonix has a headless path independent of any multiplexer.
+
+ELSE (no multiplexer detected):
+→ engine = **none**. Go to Step 3.
+
+## Step 3 — Dispatch to the right branch
+
+IF task = pane-control (Step 2 already stopped unless engine = herdr):
+→ Read [`references/herdr-panes.md`](references/herdr-panes.md) and follow it.
+
+ELSE IF task = reasonix-dispatch AND engine = herdr:
+→ Read [`references/reasonix-herdr.md`](references/reasonix-herdr.md) and follow it — decides `dispatch` (visible, interactive PTY) vs `watch` (visible, status-only) mode.
+
+ELSE (task = reasonix-dispatch AND engine = none):
+→ Read [`references/reasonix-headless.md`](references/reasonix-headless.md) and follow it — no visible pane, plain `reasonix-axi` calls. Also read [`references/reasonix-tools-and-mcp.md`](references/reasonix-tools-and-mcp.md) before any dispatch that needs read-only profiles or MCP tools.
+
+## Step 4 — Learning review
+
+After the task, ask:
+
+| Question | Action |
+|---|---|
+| A branch fired on the wrong task/engine combination? | Sharpen Step 1 or Step 2's condition |
+| tmux pane-control actually got requested? | Consider building a real tmux driver (`references/tmux-panes.md`) instead of the current STOP-and-redirect |
+| New failure mode inside a branch? | Add it to that branch's reference file, not here |
+| A reference file grew past what one branch needs? | Split further per the branch it doesn't serve |
+
+If anything changed, snapshot + bump:
+
+```bash
+cp SKILL.md SKILL.v<N+1>.md
+# add a row to VERSIONING.md
+```
+
+## Checklist
+
+- [ ] Task identified (pane-control vs reasonix-dispatch)
+- [ ] Engine detected (herdr / tmux / none)
+- [ ] Correct reference file loaded and followed
+- [ ] Result verified before acting on it
+- [ ] Learning review done

--- a/.agents/skills/herdr/SKILL.v2.md
+++ b/.agents/skills/herdr/SKILL.v2.md
@@ -1,0 +1,87 @@
+---
+name: herdr
+description: Use when the user explicitly mentions Herdr and wants to control terminal panes, tabs, or workspaces for coding agents — open/split panes, launch codex/claude/pi/opencode/omp interactively, inspect or read neighboring work, manage git worktrees, or send the workspace to Plannotator for review. Also use whenever the user wants to delegate, dispatch, or run a task "through reasonix" (Google DeepSeek-native coding agent) — as a subagent, for a second/independent opinion, or an adversarial review — regardless of whether Herdr is running; this skill picks visible-pane vs headless dispatch automatically. Also use for browser automation driven through a visible Herdr pane — "open a browser session in Herdr", "drive the browser through Herdr", "run browser-harness in a pane".
+allowed-tools: Bash
+---
+
+# herdr
+
+## Overview
+
+One contract, one primary engine, three tasks. Modeled on [cyberuni/cyber-mux](https://github.com/cyberuni/cyber-mux)'s "one contract over terminal multiplexers" idea: detect what's running the session, then drive it through a single vocabulary instead of hardcoding one multiplexer's commands into every downstream tool.
+
+This skill implements the **Herdr** engine, plus the headless no-multiplexer fallback for reasonix. It does not implement a tmux driver — cyber-mux itself already covers tmux; this skill borrows its contract shape, not its code.
+
+## Step 1 — Which task is this?
+
+IF the user explicitly mentions Herdr and wants pane/tab/workspace control that is NOT specifically about dispatching reasonix or browser-harness (starting an interactive agent, running an ordinary command in another pane, inspecting/reading a pane, managing a worktree, sending the workspace to Plannotator):
+→ task = **pane-control**. Go to Step 2.
+
+ELSE IF the user wants to delegate, dispatch, or run something "through reasonix" — as a subagent, for a second/independent opinion, or an adversarial review — regardless of whether Herdr was mentioned:
+→ task = **reasonix-dispatch**. Go to Step 2.
+
+ELSE IF the user wants browser automation (navigate, click, scrape, test a site) driven through a visible, status-tracked Herdr pane, or wants to continue an already-open browser-harness pane from a previous message:
+→ task = **browser-harness-dispatch**. Go to Step 2.
+
+ELSE:
+→ this skill does not apply. Stop.
+
+## Step 2 — Detect the engine
+
+Run:
+
+```bash
+echo "$HERDR_ENV"
+echo "$TMUX"
+```
+
+IF `HERDR_ENV` is `1`:
+→ engine = **herdr**. Go to Step 3.
+
+ELSE IF `TMUX` is set (a tmux session, no Herdr):
+→ IF task = pane-control OR task = browser-harness-dispatch: STOP. No verified tmux command path exists in this skill — it borrows cyber-mux's *contract*, not its tmux driver. Tell the user to use cyber-mux directly for tmux pane control, or run the task without pane isolation.
+→ ELSE (task = reasonix-dispatch): engine = **none**. Go to Step 3 — reasonix has a headless path independent of any multiplexer.
+
+ELSE (no multiplexer detected):
+→ IF task = browser-harness-dispatch: STOP. This branch only works inside a Herdr-managed pane and has no headless fallback. Tell the user, and use `browser-use` or `claude-in-chrome` instead.
+→ ELSE: engine = **none**. Go to Step 3.
+
+## Step 3 — Dispatch to the right branch
+
+IF task = pane-control (Step 2 already stopped unless engine = herdr):
+→ Read [`references/herdr-panes.md`](references/herdr-panes.md) and follow it.
+
+ELSE IF task = reasonix-dispatch AND engine = herdr:
+→ Read [`references/reasonix-herdr.md`](references/reasonix-herdr.md) and follow it — decides `dispatch` (visible, interactive PTY) vs `watch` (visible, status-only) mode.
+
+ELSE IF task = reasonix-dispatch AND engine = none:
+→ Read [`references/reasonix-headless.md`](references/reasonix-headless.md) and follow it — no visible pane, plain `reasonix-axi` calls. Also read [`references/reasonix-tools-and-mcp.md`](references/reasonix-tools-and-mcp.md) before any dispatch that needs read-only profiles or MCP tools.
+
+ELSE (task = browser-harness-dispatch, Step 2 already stopped unless engine = herdr):
+→ Read [`references/browser-harness-herdr.md`](references/browser-harness-herdr.md) and follow it — session-shaped: `open` once, `run` as many scripts as needed, `close` explicitly when done.
+
+## Step 4 — Learning review
+
+After the task, ask:
+
+| Question | Action |
+|---|---|
+| A branch fired on the wrong task/engine combination? | Sharpen Step 1 or Step 2's condition |
+| tmux pane-control actually got requested? | Consider building a real tmux driver (`references/tmux-panes.md`) instead of the current STOP-and-redirect |
+| New failure mode inside a branch? | Add it to that branch's reference file, not here |
+| A reference file grew past what one branch needs? | Split further per the branch it doesn't serve |
+
+If anything changed, snapshot + bump:
+
+```bash
+cp SKILL.md SKILL.v<N+1>.md
+# add a row to VERSIONING.md
+```
+
+## Checklist
+
+- [ ] Task identified (pane-control vs reasonix-dispatch vs browser-harness-dispatch)
+- [ ] Engine detected (herdr / tmux / none)
+- [ ] Correct reference file loaded and followed
+- [ ] Result verified before acting on it
+- [ ] Learning review done

--- a/.agents/skills/herdr/SKILL.v3.md
+++ b/.agents/skills/herdr/SKILL.v3.md
@@ -1,0 +1,89 @@
+---
+name: herdr
+description: Use when the user explicitly mentions Herdr and wants to control terminal panes, tabs, or workspaces for coding agents — open/split panes, launch codex/claude/pi/opencode/omp interactively, inspect or read neighboring work, manage git worktrees, or send the workspace to Plannotator for review. Also use whenever the user wants to delegate, dispatch, or run a task "through reasonix" (Google DeepSeek-native coding agent) — as a subagent, for a second/independent opinion, or an adversarial review — regardless of whether Herdr is running; this skill picks visible-pane vs headless dispatch automatically. Also use for browser automation driven through a visible Herdr pane — "open a browser session in Herdr", "drive the browser through Herdr", "run browser-harness in a pane".
+allowed-tools: Bash
+---
+
+# herdr
+
+## Overview
+
+One contract, one primary engine, three tasks. Modeled on [cyberuni/cyber-mux](https://github.com/cyberuni/cyber-mux)'s "one contract over terminal multiplexers" idea: detect what's running the session, then drive it through a single vocabulary instead of hardcoding one multiplexer's commands into every downstream tool.
+
+This skill implements the **Herdr** engine, plus the headless no-multiplexer fallback for reasonix. It does not implement a tmux driver — cyber-mux itself already covers tmux; this skill borrows its contract shape, not its code.
+
+Herdr isn't limited to the local machine — `herdr --remote <ssh-target>` attaches through SSH to a Herdr server running on a different host (see `references/herdr-panes.md`'s "Attach to a Herdr server running on another machine" section — **interactive, hand it to the user, don't run it as a blocking tool call**, confirmed live 2026-07-31). Whenever a task involves a remote box that already has Herdr on it (e.g. `orca-ubuntu-vm`), pane-control still routes through this same skill — only the target changes, not the vocabulary. `agentbox-remote` is the separate skill for provisioning a brand-new isolated box; this skill is for reaching a host's own already-running Herdr server.
+
+## Step 1 — Which task is this?
+
+IF the user explicitly mentions Herdr and wants pane/tab/workspace control that is NOT specifically about dispatching reasonix or browser-harness (starting an interactive agent, running an ordinary command in another pane, inspecting/reading a pane, managing a worktree, sending the workspace to Plannotator):
+→ task = **pane-control**. Go to Step 2.
+
+ELSE IF the user wants to delegate, dispatch, or run something "through reasonix" — as a subagent, for a second/independent opinion, or an adversarial review — regardless of whether Herdr was mentioned:
+→ task = **reasonix-dispatch**. Go to Step 2.
+
+ELSE IF the user wants browser automation (navigate, click, scrape, test a site) driven through a visible, status-tracked Herdr pane, or wants to continue an already-open browser-harness pane from a previous message:
+→ task = **browser-harness-dispatch**. Go to Step 2.
+
+ELSE:
+→ this skill does not apply. Stop.
+
+## Step 2 — Detect the engine
+
+Run:
+
+```bash
+echo "$HERDR_ENV"
+echo "$TMUX"
+```
+
+IF `HERDR_ENV` is `1`:
+→ engine = **herdr**. Go to Step 3.
+
+ELSE IF `TMUX` is set (a tmux session, no Herdr):
+→ IF task = pane-control OR task = browser-harness-dispatch: STOP. No verified tmux command path exists in this skill — it borrows cyber-mux's *contract*, not its tmux driver. Tell the user to use cyber-mux directly for tmux pane control, or run the task without pane isolation.
+→ ELSE (task = reasonix-dispatch): engine = **none**. Go to Step 3 — reasonix has a headless path independent of any multiplexer.
+
+ELSE (no multiplexer detected):
+→ IF task = browser-harness-dispatch: STOP. This branch only works inside a Herdr-managed pane and has no headless fallback. Tell the user, and use `browser-use` or `claude-in-chrome` instead.
+→ ELSE: engine = **none**. Go to Step 3.
+
+## Step 3 — Dispatch to the right branch
+
+IF task = pane-control (Step 2 already stopped unless engine = herdr):
+→ Read [`references/herdr-panes.md`](references/herdr-panes.md) and follow it.
+
+ELSE IF task = reasonix-dispatch AND engine = herdr:
+→ Read [`references/reasonix-herdr.md`](references/reasonix-herdr.md) and follow it — decides `dispatch` (visible, interactive PTY) vs `watch` (visible, status-only) mode.
+
+ELSE IF task = reasonix-dispatch AND engine = none:
+→ Read [`references/reasonix-headless.md`](references/reasonix-headless.md) and follow it — no visible pane, plain `reasonix-axi` calls. Also read [`references/reasonix-tools-and-mcp.md`](references/reasonix-tools-and-mcp.md) before any dispatch that needs read-only profiles or MCP tools.
+
+ELSE (task = browser-harness-dispatch, Step 2 already stopped unless engine = herdr):
+→ Read [`references/browser-harness-herdr.md`](references/browser-harness-herdr.md) and follow it — session-shaped: `open` once, `run` as many scripts as needed, `close` explicitly when done.
+
+## Step 4 — Learning review
+
+After the task, ask:
+
+| Question | Action |
+|---|---|
+| A branch fired on the wrong task/engine combination? | Sharpen Step 1 or Step 2's condition |
+| tmux pane-control actually got requested? | Consider building a real tmux driver (`references/tmux-panes.md`) instead of the current STOP-and-redirect |
+| New failure mode inside a branch? | Add it to that branch's reference file, not here |
+| A reference file grew past what one branch needs? | Split further per the branch it doesn't serve |
+
+If anything changed, snapshot + bump:
+
+```bash
+cp SKILL.md SKILL.v<N+1>.md
+# add a row to VERSIONING.md
+```
+
+## Checklist
+
+- [ ] Task identified (pane-control vs reasonix-dispatch vs browser-harness-dispatch)
+- [ ] Engine detected (herdr / tmux / none)
+- [ ] Correct reference file loaded and followed
+- [ ] Result verified before acting on it
+- [ ] Learning review done

--- a/.agents/skills/herdr/SKILL.v4.md
+++ b/.agents/skills/herdr/SKILL.v4.md
@@ -1,0 +1,89 @@
+---
+name: herdr
+description: Use when the user explicitly mentions Herdr and wants to control terminal panes, tabs, or workspaces for coding agents — open/split panes, launch codex/claude/pi/opencode/omp interactively, inspect or read neighboring work, manage git worktrees, or send the workspace to Plannotator for review. Also use whenever the user wants to delegate, dispatch, or run a task "through reasonix" (Google DeepSeek-native coding agent) — as a subagent, for a second/independent opinion, or an adversarial review — regardless of whether Herdr is running; this skill picks visible-pane vs headless dispatch automatically. Also use for browser automation driven through a visible Herdr pane — "open a browser session in Herdr", "drive the browser through Herdr", "run browser-harness in a pane".
+allowed-tools: Bash
+---
+
+# herdr
+
+## Overview
+
+One contract, one primary engine, three tasks. Modeled on [cyberuni/cyber-mux](https://github.com/cyberuni/cyber-mux)'s "one contract over terminal multiplexers" idea: detect what's running the session, then drive it through a single vocabulary instead of hardcoding one multiplexer's commands into every downstream tool.
+
+This skill implements the **Herdr** engine, plus the headless no-multiplexer fallback for reasonix. It does not implement a tmux driver — cyber-mux itself already covers tmux; this skill borrows its contract shape, not its code.
+
+Herdr isn't limited to the local machine — `herdr --remote <ssh-target>` attaches through SSH to a Herdr server running on a different host (see `references/herdr-panes.md`'s "Attach to a Herdr server running on another machine" section — **interactive, hand it to the user, don't run it as a blocking tool call**, confirmed live 2026-07-31). Whenever a task involves a remote box that already has Herdr on it (e.g. `orca-ubuntu-vm`), pane-control still routes through this same skill — only the target changes, not the vocabulary. `agentbox-remote` is the separate skill for provisioning a brand-new isolated box; this skill is for reaching a host's own already-running Herdr server.
+
+## Step 1 — Which task is this?
+
+IF the user explicitly mentions Herdr and wants pane/tab/workspace control that is NOT specifically about dispatching reasonix or browser-harness (starting an interactive agent, running an ordinary command in another pane, inspecting/reading a pane, managing a worktree, sending the workspace to Plannotator):
+→ task = **pane-control**. Go to Step 2.
+
+ELSE IF the user wants to delegate, dispatch, or run something "through reasonix" — as a subagent, for a second/independent opinion, or an adversarial review — regardless of whether Herdr was mentioned:
+→ task = **reasonix-dispatch**. Go to Step 2.
+
+ELSE IF the user wants browser automation (navigate, click, scrape, test a site) driven through a visible, status-tracked Herdr pane, or wants to continue an already-open browser-harness pane from a previous message:
+→ task = **browser-harness-dispatch**. Go to Step 2.
+
+ELSE:
+→ this skill does not apply. Stop.
+
+## Step 2 — Detect the engine
+
+Run:
+
+```bash
+echo "$HERDR_ENV"
+echo "$TMUX"
+```
+
+IF `HERDR_ENV` is `1`:
+→ engine = **herdr**. Go to Step 3.
+
+ELSE IF `TMUX` is set (a tmux session, no Herdr):
+→ IF task = pane-control OR task = browser-harness-dispatch: STOP. No verified tmux command path exists in this skill — it borrows cyber-mux's *contract*, not its tmux driver. Tell the user to use cyber-mux directly for tmux pane control, or run the task without pane isolation.
+→ ELSE (task = reasonix-dispatch): engine = **none**. Go to Step 3 — reasonix has a headless path independent of any multiplexer.
+
+ELSE (no multiplexer detected):
+→ IF task = browser-harness-dispatch: STOP. This branch only works inside a Herdr-managed pane and has no headless fallback. Tell the user, and use `browser-use` or `claude-in-chrome` instead.
+→ ELSE: engine = **none**. Go to Step 3.
+
+## Step 3 — Dispatch to the right branch
+
+IF task = pane-control (Step 2 already stopped unless engine = herdr):
+→ Read [`references/herdr-panes.md`](references/herdr-panes.md) and follow it.
+
+ELSE IF task = reasonix-dispatch AND engine = herdr:
+→ Read [`references/reasonix-herdr.md`](references/reasonix-herdr.md) and follow it — decides `dispatch` (visible, interactive PTY) vs `watch` (visible, status-only) mode.
+
+ELSE IF task = reasonix-dispatch AND engine = none:
+→ Read [`references/reasonix-headless.md`](references/reasonix-headless.md) and follow it — no visible pane, plain `reasonix-axi` calls. Also read [`references/reasonix-tools-and-mcp.md`](references/reasonix-tools-and-mcp.md) before any dispatch that needs read-only profiles or MCP tools.
+
+ELSE (task = browser-harness-dispatch, Step 2 already stopped unless engine = herdr):
+→ Read [`references/browser-harness-herdr.md`](references/browser-harness-herdr.md) and follow it — session-shaped: `open` once, `run` as many scripts as needed, `close` explicitly when done.
+
+## Step 4 — Learning review
+
+After the task, ask:
+
+| Question | Action |
+|---|---|
+| A branch fired on the wrong task/engine combination? | Sharpen Step 1 or Step 2's condition |
+| tmux pane-control actually got requested? | Consider building a real tmux driver (`references/tmux-panes.md`) instead of the current STOP-and-redirect |
+| New failure mode inside a branch? | Add it to that branch's reference file, not here |
+| A reference file grew past what one branch needs? | Split further per the branch it doesn't serve |
+
+If anything changed, snapshot + bump:
+
+```bash
+cp SKILL.md SKILL.v<N+1>.md
+# add a row to VERSIONING.md
+```
+
+## Checklist
+
+- [ ] Task identified (pane-control vs reasonix-dispatch vs browser-harness-dispatch)
+- [ ] Engine detected (herdr / tmux / none)
+- [ ] Correct reference file loaded and followed
+- [ ] Result verified before acting on it
+- [ ] Learning review done

--- a/.agents/skills/herdr/VERSIONING.md
+++ b/.agents/skills/herdr/VERSIONING.md
@@ -1,0 +1,63 @@
+# herdr — Versioning
+
+## Active skill
+
+`SKILL.md` is the live version. Snapshots are read-only history.
+
+## Version history
+
+| File        | Date       | What changed    |
+| ----------- | ---------- | --------------- |
+| SKILL.v1.md | 2026-07-28 | Initial merge (named `cyber-mux` at this point): replaces `herdr`, `reasonix-herdr-axi`, and `reasonix-orchestrator` with one router skill. Modeled on cyberuni/cyber-mux's engine-detection contract (env var → `$TMUX`/`$HERDR_ENV` fallback). Router decides task (pane-control vs reasonix-dispatch) and engine (herdr/tmux/none), then hands off to `references/herdr-panes.md`, `references/reasonix-herdr.md`, or `references/reasonix-headless.md`. tmux pane-control is a documented STOP, not implemented — no verified tmux command surface existed in any source skill. |
+| SKILL.v2.md | 2026-07-28 | Renamed `cyber-mux` → `herdr` (matches the established trigger word and what the skill actually implements — no tmux driver exists, so the cyber-mux name overclaimed a multi-engine contract). Folded in `browser-harness-herdr-axi` as a third task branch (`browser-harness-dispatch`), Herdr-only with no headless fallback → `references/browser-harness-herdr.md`. |
+| SKILL.v3.md | 2026-07-31 | Overview now mentions remote machines: `herdr --remote <ssh-target>` reaches a Herdr server on another host (e.g. `orca-ubuntu-vm`, set up the same day for Moshi phone access) — pane-control still routes through this same skill, only the target changes. Points to `references/herdr-panes.md`'s new remote-attach section and cross-references `agentbox-remote` (provisioning a new box) as the distinct concern. Battle-tested same day: `--remote` confirmed interactive (hangs with no server-side connection when run as a blocking Bash tool call, same as `agentbox claude`/`attach`) — Overview and reference both flag it as hand-to-the-user only. |
+| SKILL.v4.md | 2026-08-07 | SKILL.md text unchanged; bump covers a `references/herdr-panes.md` addition (per the "reference-file changes covered by parent bump" convention): a new `binox-axi` step in "Start agents interactively" instructing the caller to inventory the target path (skills, orphaned tmp/ scripts, tool scripts, available AXI CLIs) before writing the task brief, so briefs name a skill path that actually exists on that target instead of guessing. Not yet globally installed at write time (PR #4 on subagent-factory awaiting merge) — see the dated note in the reference file. |
+
+## Automatic activation (hooks, not skill-file changes)
+
+Two hooks in `~/.claude/settings.json` make this skill's coverage automatic inside a Herdr session, added 2026-07-28 — deliberately as hooks, not by loosening the skill's own trigger wording (pane-control still requires an explicit "Herdr" mention by design):
+
+- `SessionStart` → `~/.claude/hooks/herdr-skill-awareness.sh`: when `HERDR_ENV=1`, injects a context note naming this skill and its three branches, so the agent doesn't need the user to say "Herdr" before considering it.
+- `PreToolUse` (matcher `Agent`) → `~/.claude/hooks/herdr-default-reasonix.sh`: when `HERDR_ENV=1`, denies Agent-tool dispatches with a reason pointing at `references/reasonix-herdr.md` instead. Global policy — every Agent tool call inside Herdr redirects to reasonix by default, including built-in specialized subagents (debugger, security-auditor, etc.), confirmed live 2026-07-28. Not a hard OS-level block: Claude reads the deny reason and can still explain/ask the user to override for a specifically-named subagent.
+
+Both scripts live in `~/.claude/hooks/`, not inside this skill folder, since hooks are wired through `settings.json` regardless of where the script file sits. If either policy needs to change, edit the script directly — no version bump needed here unless the *skill's* own branching logic changes as a result.
+
+## How to update
+
+**Snapshot convention (A):** `SKILL.v<N>.md` always holds the content of version N. Edit `SKILL.md` first, then snapshot — so the version label matches what's inside it. Rollback to a prior version = `cp SKILL.v<N>.md SKILL.md`.
+
+```bash
+# 1. Find current version
+ls SKILL.v*.md | sort -V | tail -1        # e.g. SKILL.v4.md
+
+# 2. Edit SKILL.md (it becomes v5)
+
+# 3. Snapshot the NEW content with the NEW number
+cp SKILL.md SKILL.v5.md
+
+# 4. Add a row to the table above
+```
+
+Reference-file changes (`references/*.md`) don't get their own version numbers — they're covered by the parent `SKILL.md` bump per the "Notes for future updates" section at the bottom of each reference file.
+
+## What deserves a version bump
+
+- New patterns/symptoms found during real use
+- Corrected commands or API changes
+- New workflow branches
+- Step reordering from operational experience
+- A real tmux driver landing in `references/tmux-panes.md`
+
+## What does NOT need a bump
+
+- Typos, formatting, link fixes
+- Placeholder updates (`<date>`, `<server-name>`)
+
+## Predecessor skills
+
+Archived at `~/.claude/skills-archive/2026-07-28-cyber-mux-merge/` (not scanned as active skills — safe reference-only history):
+
+- `herdr` (full generic pane-control vocabulary → now `references/herdr-panes.md`)
+- `reasonix-herdr-axi` (Herdr-visible reasonix dispatch → now `references/reasonix-herdr.md`)
+- `reasonix-orchestrator` (headless reasonix dispatch → now `references/reasonix-headless.md`, `tools-and-mcp.md` → `references/reasonix-tools-and-mcp.md`)
+- `browser-harness-herdr-axi` (Herdr-visible browser automation → now `references/browser-harness-herdr.md`)

--- a/.agents/skills/herdr/references/browser-harness-herdr.md
+++ b/.agents/skills/herdr/references/browser-harness-herdr.md
@@ -1,0 +1,80 @@
+# browser-harness-herdr — browser automation through a visible Herdr pane
+
+Reached from [`../SKILL.md`](../SKILL.md) when task = browser-harness-dispatch and engine = herdr.
+
+## Overview
+
+`browser-harness-herdr-axi` (`/home/adrian/dev/subagent-factory/tools/browser-harness-herdr-axi`) bridges `browser-harness` (direct CDP browser control, no LLM of its own) and Herdr: it opens an isolated, visible Herdr pane, connects `browser-harness` to the local Chrome CDP endpoint, reports Herdr agent status (`working` → `idle`), and leaves the pane's daemon alive across multiple `run` calls so page/tab state persists for the length of a task.
+
+Unlike `references/reasonix-herdr.md` (one-shot dispatch, closes immediately after), this is session-shaped: `open` once, `run` as many scripts as the task needs, `close` explicitly when done. `run` does not auto-close the pane — you must call `close` yourself.
+
+Facts to keep in mind:
+
+- `browser-harness` scripts are Python, with helpers pre-imported (`page_info()`, `new_tab(url)`, `click_at_xy(x, y)`, `js(...)`, `cdp(...)`). First navigation is `new_tab(url)`, not `goto_url(url)`.
+- Local Chrome requires `chrome://inspect/#remote-debugging` to be enabled with "Allow remote debugging for this browser instance" ticked, and the user must click Allow on Chrome's own permission popup — this cannot be done by the agent, only the user.
+- If that permission is missing, `browser-harness` doesn't fail fast — it blocks/hangs waiting for the daemon rather than exiting. Don't assume a stuck pane is a code bug; check `close <pane_id> --force` is the way out, not a longer timeout.
+- This tool never installs or auto-triggers itself outside Herdr — it does not compete with `browser-use`/`claude-in-chrome` for general web tasks.
+
+## Step 1 — Open a session
+
+Run: `browser-harness-herdr-axi open --purpose "<short label>"`
+
+This creates/reuses the shared `browser-harness` tab, opens a new pane in it, and immediately checks the CDP connection with `page_info()`.
+
+IF `open.status` is `"connected"`:
+→ save the returned `pane_id`. Proceed to Step 2.
+
+ELSE IF `open.status` is `"connect_failed"` or `"timeout"`:
+→ go to Step 4 (Chrome permission).
+
+## Step 2 — Drive the browser
+
+Run: `browser-harness-herdr-axi run <pane_id> "<script>"` for each script — the daemon keeps page/tab state between calls, so a multi-step task (navigate, then click, then extract) is several `run` calls against the same `pane_id`, not one big script.
+
+IF `run.status` is `"success"`:
+→ treat the relayed output as the result. Continue with more `run` calls, or proceed to Step 3 when the task is done.
+
+ELSE IF `run.status` is `"error"`:
+→ read the relayed output and `exit_code` for why (a Python traceback from the script is normal here — fix the script and re-run, same pane).
+
+ELSE IF `run.status` is `"timeout"`:
+→ check `still_running`. If `true`, the browser task may just be slow (e.g. waiting on a real page load) — check again later with `status <pane_id>`. If `false`, the command already returned but the completion signal was missed — safe to just `run` a follow-up in the same pane.
+
+### Navigating
+
+IF this is the first navigation in the session:
+→ `run <pane_id> "new_tab('<url>')\nwait_for_load()\nprint(page_info())"` — opens a new tab. `goto_url` has no tab to navigate yet at this point.
+
+ELSE (a tab is already open from an earlier `run` call in this same pane):
+→ `run <pane_id> "goto_url('<url>')\nwait_for_load()\nprint(page_info())"` — navigates within the already-open tab, keeping the same session/state. Verified 2026-07-20: `new_tab` then `goto_url` in the same pane correctly landed on two different pages in the same tab, confirmed each time via `page_info()`'s returned `url`/`title`.
+
+Always call `wait_for_load()` after navigating, then confirm with `page_info()` before acting on the page — don't assume a navigation call succeeded just because `run.status` was `"success"`.
+
+## Step 3 — Clean up
+
+Run: `browser-harness-herdr-axi close <pane_id>` once the task is fully done. Always do this — leaving the pane open leaves the `browser-harness` process (and the Chrome CDP connection) running indefinitely.
+
+IF `close.status` is `"closed"`:
+→ done. If this was the last pane in the `browser-harness` tab, Herdr auto-closed the tab too.
+
+ELSE IF `close.status` is `"still_running"`:
+→ a script looks like it's still active in that pane. Don't force it if it might genuinely be doing real work (e.g. waiting on a slow page). If you're sure it's just hung (see Step 4's hang note), re-run with `--force`.
+
+## Step 4 — Chrome permission blocks the connection
+
+IF `open` or `run` reports a connection failure, or a pane looks stuck with no output progressing:
+→ tell the user, in plain terms: open `chrome://inspect/#remote-debugging` in Chrome, tick "Allow remote debugging for this browser instance", and click Allow on the popup if one appears. This step requires the user — it cannot be automated.
+→ STOP and wait for the user to confirm it's done.
+
+ELSE (permission already confirmed enabled):
+→ run `browser-harness --doctor` for a fuller diagnostic (`chrome running` / `daemon alive` / `active browser connections`), or read `https://github.com/browser-use/browser-harness/blob/main/install.md` for other failure modes (remote/cloud browser setup, `--doctor` output meanings).
+
+## Notes for future updates
+
+| Question | Action |
+|---|---|
+| New failure mode not covered? | Add it to Step 2 or Step 4 |
+| Chrome permission flow changed upstream? | Update Step 4 |
+| Cost, timing, or hang behavior different than documented? | Update the Overview |
+
+If anything changed, snapshot the parent skill (`../SKILL.md` → `../SKILL.v<N+1>.md`) and add a row to `../VERSIONING.md`.

--- a/.agents/skills/herdr/references/herdr-panes.md
+++ b/.agents/skills/herdr/references/herdr-panes.md
@@ -1,0 +1,257 @@
+# herdr-panes — generic pane, tab, and workspace control
+
+Reached from [`SKILL.md`](../SKILL.md) when task = pane-control. Herdr is a terminal multiplexer and runtime for coding agents. It organizes terminals into workspaces, tabs, and panes, detects agent identity and status, and exposes the running session through the `herdr` CLI.
+
+The `herdr` binary in `PATH` talks to the running session. Use it to inspect neighboring work, create isolated terminal contexts, start agents and commands, read their output, and wait for state changes.
+
+## Learn the current CLI
+
+The installed binary is the authority for command syntax. Begin with:
+
+```bash
+herdr --help
+```
+
+Then print the relevant command group by running it without a subcommand:
+
+```bash
+herdr pane
+herdr workspace
+herdr worktree
+herdr tab
+herdr agent
+herdr notification
+herdr integration
+herdr session
+```
+
+There is no top-level `herdr wait` command (confirmed against `herdr --help`, 2026-07-28) despite it appearing that way in older guidance. Status waits live under `herdr agent wait <target> --until <status> [--timeout MS]`; output waits live under `herdr pane wait-output <pane_id> (--match TEXT|--regex PATTERN) [--timeout MS]`.
+
+Do not run bare `herdr` for discovery; it launches or attaches the TUI. Do not probe a mutating nested command by omitting arguments; some commands, including `herdr workspace create`, are valid with defaults and will execute. Use the command-group output above instead.
+
+Most control commands print JSON. Read identifiers and state from those responses instead of predicting either one.
+
+## Attach to a Herdr server running on another machine
+
+`herdr --remote <ssh-target>` opens a live client here, attached over SSH to a Herdr server running on a **different host** — not a separate copy, the same live panes, tabs, and sessions that host's own local client (or any other remote client, e.g. a phone via Moshi's Herdr integration) is looking at. Confirmed live 2026-07-31: installed Herdr on `orca-ubuntu-vm` and attached to it from a laptop session with `herdr --remote adrian@orca-ubuntu-vm`.
+
+```bash
+herdr --remote <user>@<host>
+herdr --remote <user>@<host> --session <name>   # jump straight into a specific named session there
+```
+
+- `--remote-keybindings <local|server>` — whose keybindings apply during the remote attach. Default `local` (your own machine's config, not the remote host's).
+- `--handoff` — opt into live handoff for the remote attach (same flag used for update handoff).
+- Requires the target host to have Herdr installed and reachable over plain SSH — no cloud provisioning involved. This is a different concern from spinning up a whole new isolated box (see the `agentbox-remote` skill for that); this is for reaching an existing host's own already-running Herdr server.
+- All the pane/tab/workspace vocabulary below applies unchanged once attached remotely — IDs, `--current`, focus rules, everything is identical, just addressed at the remote server instead of the local one.
+
+**CRITICAL — `herdr --remote` is interactive like `agentbox claude`/`attach`; never run it as a blocking tool call.** Confirmed live 2026-07-31: from an agent's Bash tool, `herdr --remote <target>` hangs indefinitely with zero connection reaching the remote server's log — tried both a plain redirect and a `script`-wrapped fake pty, neither got past local startup. This isn't a bug; it's a full-screen TUI client that needs a real terminal, same as every other interactive Herdr/agentbox command. Give the user the exact command to run themselves in their own terminal — don't try to shell it out and don't loop retrying it.
+
+## Controlling a remote host's panes without `--remote` (the agent-usable path)
+
+Everything in this section is what an agent should actually use instead of `--remote` — no TTY required anywhere. Confirmed end-to-end live 2026-07-31 against `orca-ubuntu-vm`.
+
+**Direct control over plain SSH, no mirror plugin needed:** `herdr workspace create`, `herdr pane run`, `herdr pane read`, etc. are ordinary socket-API calls, not the TUI — they work fine run over SSH against a remote host's own `herdr` binary, as long as that host's Herdr server is running (start it headlessly if nothing's attached: `ssh <host> "nohup herdr server > /tmp/herdr-server.log 2>&1 & disown"`, confirmed live). Example, run from here:
+
+```bash
+ssh <user>@<host> "herdr workspace create --cwd /some/path --label mytask"
+ssh <user>@<host> "herdr pane run <returned-pane-id> 'some command'"
+ssh <user>@<host> "herdr pane read <returned-pane-id> --source visible --lines 30"
+```
+
+**If the `herdr-mirror` plugin (nikok6/herdr-mirror) is installed and configured** for that host in `~/.config/herdr-mirror/hosts.toml`, its workspaces/panes also mirror automatically into the **local** `herdr workspace list` as `<host>: <label>` with ordinary local pane IDs. Confirmed bidirectional: a `herdr pane run <mirrored-pane-id> "<cmd>"` issued locally against the mirrored ID actually executes on the real remote pane — verified by reading the real pane directly over SSH afterward and seeing the same output. This means once something is already running remotely and mirrored, no SSH command construction is needed at all — just address the mirrored pane ID like any other local pane.
+
+`herdr pane read <mirrored-pane-id> --source recent-unwrapped` can transiently return blank right after a write lands (a scrollback-pointer timing artifact, not data loss) — retry with `--source visible` or a moment later if a read looks unexpectedly empty right after an action.
+
+## IDs and current context
+
+Public IDs are short stable handles:
+
+- workspace: `w1`
+- tab: `w1:t1`
+- pane: `w1:p1`
+- terminal: `term_...`
+
+The encoded suffix can contain letters and can grow beyond one character. Treat every ID as an opaque string.
+
+Closed tab and pane IDs are not reused and do not retarget later resources. A pane moved into another workspace receives a new public pane ID. Re-read create, split, move, list, or get responses after mutations; never construct an ID from a workspace or display number.
+
+Herdr injects the caller's stable context into every managed pane:
+
+```bash
+printf '%s\n' "$HERDR_WORKSPACE_ID" "$HERDR_TAB_ID" "$HERDR_PANE_ID"
+```
+
+Prefer `--current` when a pane command should target the calling pane. Omitting a target can use the UI-focused pane, which may belong to the user or another client.
+
+Discover live state with:
+
+```bash
+herdr workspace list
+herdr tab list --workspace "$HERDR_WORKSPACE_ID"
+herdr pane current --current
+herdr pane list --workspace "$HERDR_WORKSPACE_ID"
+```
+
+## Control agents through panes
+
+An agent runs inside a pane. Use the pane ID as the control target for agents, shells, servers, tests, and logs. This keeps spawning, input, reads, waits, and cleanup on one stable control surface.
+
+Use workspace and tab commands for organization. Use worktree commands only when you intentionally want Herdr to create, open, or remove a Git checkout.
+
+Pane records expose `agent`, `agent_status`, and native session metadata when available. Agent status is `idle`, `working`, `blocked`, `done`, or `unknown`.
+
+`idle` and `done` are the same underlying semantic state with different attention state:
+
+- `idle`: the agent is waiting and its result is considered seen.
+- `done`: the agent finished and its result has not been seen.
+
+An agent that first opens at its prompt reports `idle`, including in a background pane. After a working or blocked agent completes, it reports `done` when its tab or workspace is in the background. It reports `idle` when it completes in the active tab while the foreground client is focused. If the foreground client is explicitly unfocused, completion can become `done` even in the active tab.
+
+Focusing a pane, switching to its tab, or regaining outer terminal focus marks the visible tab as seen, so `done` becomes `idle`. Switching away does not turn an existing `idle` status into `done`; `done` is created by a later completion while the pane is unseen. With no foreground client, a new completion in the globally active tab is treated as seen while completions in background tabs still become `done`.
+
+## Start agents interactively
+
+Default to a sibling pane in the current tab and current working directory. Do not create a workspace, tab, worktree, or different cwd unless the user explicitly requests that topology or location.
+
+Honor a direction requested by the user. Otherwise inspect the caller pane's current rectangle:
+
+```bash
+herdr pane layout --pane "$HERDR_PANE_ID"
+```
+
+Split a wide pane to the right and a narrow or tall pane down. Avoid repeated same-direction splits that would create unusably narrow columns or short rows. Keep the user's focus in the calling pane:
+
+```bash
+herdr pane split --current --direction right --no-focus
+```
+
+Replace `right` with `down` when the layout calls for it.
+
+Read `result.pane.pane_id` from the JSON response. Give the pane a useful label, then start the requested agent by running only its normal executable so its interactive TUI opens:
+
+```bash
+herdr pane rename <returned-pane-id> "reviewer"
+herdr pane run <returned-pane-id> "codex"
+```
+
+Use the executable that belongs to the requested agent:
+
+- Codex: `codex`
+- Claude Code: `claude`
+- pi: `pi`
+- OpenCode: `opencode`
+- OMP: `omp`
+
+Do not pass the task as an argv prompt by default. Do not add non-interactive flags. Only change the normal interactive launch when the user explicitly asks for a different launch mode or command.
+
+**Ground the brief with `binox-axi` before you write the task text.** `binox-axi <path>` (from `subagent-factory/tools/binox-axi`) is a read-only AXI CLI that inventories a target path — project clone, secondmate home, or task worktree — before dispatch: it lists the skills actually present (`.claude/skills/`, `.agents/skills/`, `skills/`, with name+description), scripts sitting orphaned in `tmp/`/scratch dirs, `bin/`/`package.json` tool scripts, and which known AXI tools resolve on `PATH` there. Run it against the target worktree/home right after the pane launches and before composing the task message, so the brief names the LOCAL skill path that actually exists there instead of guessing at a server copy or a different clone's path (`binox-axi --short <path>` for a fast skills+tmp_scripts-only pass). Never treats it as a substitute for reading a skill's own content — it only tells you what exists and where.
+
+Inspect the pane after launch. If `agent_status` is not yet `idle`, wait for the idle transition. Once it is idle, submit the task with `pane run`:
+
+```bash
+herdr pane get <returned-pane-id>
+herdr agent wait <returned-pane-id> --until idle --timeout 30000
+herdr pane run <returned-pane-id> "Review the current diff and report only actionable findings."
+```
+
+Status waits match the current status immediately or wait for a future matching transition.
+
+`pane run` is documented to send the text and Enter together, but confirmed unreliable in practice (2026-07-28): the text can land in the input box without the Enter actually submitting it, leaving the agent sitting idle indefinitely on an unsent message. After any `pane run`, verify it actually submitted — `herdr agent wait <id> --until working --timeout <short>` and check for a timeout, or `pane read` and look for the text still sitting after an unsent `❯ ` prompt. If it didn't submit, send the Enter explicitly: `herdr pane send-keys <id> Enter`.
+
+For normal background work, wait for the agent to start working. If the pane remains in a background tab or workspace, wait for `done` before reading its transcript:
+
+```bash
+herdr agent wait <returned-pane-id> --until working --timeout 30000
+herdr agent wait <returned-pane-id> --until done --timeout 120000
+herdr pane read <returned-pane-id> --source recent-unwrapped --lines 120
+```
+
+If the user is watching that tab, completion reports `idle` instead, so wait for `idle`. Always treat either `idle` or `done` as completed when inspecting `pane get`; the difference is whether the result has been seen.
+
+If a wait times out, inspect `herdr pane get <returned-pane-id>` and `pane read` before deciding what to do. A `blocked` agent needs input; an `unknown` pane may not yet contain a detected or integrated agent.
+
+Submit follow-ups the same way:
+
+```bash
+herdr pane run <returned-pane-id> "Now check the failing test."
+```
+
+## Run an ordinary command in another pane
+
+Split the calling pane using the same geometry rule without moving the user's focus:
+
+```bash
+herdr pane split --current --direction right --no-focus
+```
+
+Read the new `pane_id` from the JSON response, then run and inspect the command:
+
+```bash
+herdr pane run <returned-pane-id> "just test"
+herdr pane wait-output <returned-pane-id> --match "test result" --timeout 120000
+herdr pane read <returned-pane-id> --source recent-unwrapped --lines 120
+```
+
+Inspect existing output before waiting for future output. A wait timeout exits with status `1`.
+
+Use the read source that matches the task:
+
+- `visible`: the current rendered viewport
+- `recent`: recent scrollback as rendered, including soft wraps
+- `recent-unwrapped`: recent scrollback with soft wraps joined; prefer it for logs and transcripts
+- `detection`: the bottom-buffer snapshot used by agent detection
+
+Use `--format ansi` when colors and terminal styling are evidence. Otherwise use text.
+
+**A long single assistant message can hide behind the TUI's own internal scroll boundary, independent of scrollback.** Confirmed 2026-07-28: a Claude Code pane's response was cut off mid-message with a "Jump to bottom" hint visible in the render, and increasing `--lines` all the way to 2000 on `recent-unwrapped` returned the identical truncated text every time — the terminal was genuinely rendering that boundary, not scrollback running out. If a read looks suspiciously cut off right at an interesting point (a heading with no content under it, a "jump to bottom" affordance visible in the captured text), don't trust more `--lines` to fix it. For a Claude Code pane specifically, read the session transcript directly instead: find the session id from `herdr pane list` (`agent_session.value`), then read the newest matching file under `~/.claude/projects/<escaped-cwd>/<session-id>.jsonl` and extract the last assistant message's `message.content[].text` — this bypasses terminal rendering entirely and is authoritative.
+
+If the user explicitly asks for another tab, workspace, or worktree, discover that command group and use returned IDs. Do not infer a larger topology from a request to start an agent or command.
+
+## Plannotator: send the workspace to browser review
+
+Use when the user asks to "annotate this in Plannotator", "send this for review", "open in Plannotator", or wants human feedback on a plan, diff, or PR through Plannotator's browser-based review UI.
+
+Requires the `adrian.plannotator` plugin to be linked. Check first:
+
+```bash
+herdr plugin list --json
+```
+
+If it is missing, link it (manifest lives at `~/dev/herdr/herdr-plannotator-plugin/herdr-plugin.toml`):
+
+```bash
+herdr plugin link ~/dev/herdr/herdr-plannotator-plugin
+```
+
+Invocation is fire-and-forget. `herdr plugin action invoke` returns immediately with a `log_id`; the underlying `plannotator` process opens a local server and a real browser tab, then blocks until a human closes out the review. Do not wait on it and do not poll immediately after invoking — tell the user to check their browser, and only re-check once they report the review is done or is taking unexpectedly long.
+
+```bash
+herdr plugin action invoke annotate --plugin adrian.plannotator   # annotate the current workspace's markdown/text/html files
+herdr plugin action invoke review --plugin adrian.plannotator     # review the current git diff/PR
+```
+
+Check the outcome afterward with:
+
+```bash
+herdr plugin log list --plugin adrian.plannotator
+```
+
+`status` is `running` while the browser review is open, `succeeded` or `failed` once `plannotator` exits. A `failed` log whose `stderr` says "No markdown, text, or HTML files found" or reports no diff just means there was nothing to review in that workspace — not a bug in the plugin.
+
+## Safety and coordination rules
+
+- Use `--no-focus` for background work unless the user asked to switch context.
+- Use `--current` or an explicit ID. Do not rely on another client's focused pane.
+- Parse IDs from JSON responses. Do not derive them from sidebar order or examples.
+- Inspect before waiting. Read current output first, then wait for the next state or output you expect.
+- Do not close workspaces, tabs, panes, or sessions you did not create unless the user explicitly asked.
+- Never run `herdr server stop` from an active session unless the user explicitly intends to stop the server and its pane processes.
+- Never kill the main Herdr process. Use named test sessions for experiments that need an isolated server.
+
+## Notes for future updates
+
+- **2026-08-07**: added the `binox-axi` step before task submission in "Start agents interactively", after a session where firstmate and its secondmates repeatedly briefed a crewmate with the wrong skill path (server copy vs. local clone vs. main-home copy) with no cheap way to check first. `binox-axi <path>` (AXI-standard, read-only, `subagent-factory/tools/binox-axi`) inventories a target's actual skills, orphaned `tmp/` scripts, tool scripts, and available AXI CLIs before the brief is written. Not yet globally installed as of this note — PR https://github.com/blazingbunny/subagent-factory/pull/4 was still awaiting merge when this was written; confirm `binox-axi` resolves on `PATH` before relying on it, and fall back to manual inspection if it isn't installed yet.
+- **2026-07-31**: added remote-attach coverage (`herdr --remote <ssh-target>`, confirmed against `herdr --help`) after installing Herdr on `orca-ubuntu-vm` for Moshi phone access. Not previously documented anywhere in this skill. Battle-tested the same day: confirmed `--remote` cannot be run as a blocking Bash tool call (hangs with no server-side connection, same as other interactive Herdr/agentbox commands) — must be handed to the user's own terminal, never executed directly by an agent.
+- **2026-07-31**: proved the agent-usable alternative to `--remote` end-to-end: plain socket-API commands (`herdr workspace create`, `herdr pane run`, `herdr pane read`) work fine over SSH against a remote host's own headless server, and once `herdr-mirror` mirrors a remote workspace locally, running commands against the *local mirrored pane ID* actually drives the real remote pane — verified by reading the real remote pane directly afterward. This is the answer whenever a task needs an agent (not a human) to control something on a remote Herdr host.
+- **2026-07-28**: three fixes confirmed live against a real installed `herdr` binary (checked with `herdr --help`, not assumed from prior doc text): no top-level `herdr wait` command exists, real syntax is `herdr agent wait <target> --until <status> [--timeout MS]`; output waits are `herdr pane wait-output`, not `herdr wait output`; `pane run` does not reliably submit (Enter can fail to register, leaving a message sitting unsent in the input box) — always verify submission and fall back to an explicit `herdr pane send-keys <id> Enter` if it didn't. Also added: a long assistant message can hide behind the TUI's own internal scroll boundary, not scrollback — reading the pane's own Claude Code session JSONL directly (`~/.claude/projects/<escaped-cwd>/<session-id>.jsonl`) is the reliable fallback.

--- a/.agents/skills/herdr/references/reasonix-headless.md
+++ b/.agents/skills/herdr/references/reasonix-headless.md
@@ -1,0 +1,96 @@
+# reasonix-headless — dispatching reasonix with no multiplexer active
+
+Reached from [`SKILL.md`](../SKILL.md) when task = reasonix-dispatch and engine = none (no Herdr session, or a tmux-only session — see `../SKILL.md` Step 2). No visible pane; this is a plain foreground/background CLI call.
+
+## Overview
+
+reasonix is a separate Go-based coding agent (DeepSeek-native, installed at `~/go/bin/reasonix`), not a Claude subagent. This branch lets Claude act as **orchestrator**, dispatching discrete tasks to reasonix as an independent delegate — same relationship the `Agent` tool has with a subagent, except the worker is a different process and a different model, billed separately.
+
+Dispatch happens through the `reasonix-axi` CLI (`/home/adrian/dev/subagent-factory/tools/reasonix-axi`), which wraps `reasonix run` / `reasonix subagent run` and returns compact, structured results (cost, tokens, session id, output text) instead of raw reasonix JSON.
+
+Facts to keep in mind while orchestrating:
+
+- Every dispatch costs real money (DeepSeek pricing) and returns `cost_usd` in the response. This is not free parallelism — don't fan out dispatches without a reason.
+- Verified empirically: one-shot `reasonix run` calls do not hang waiting for interactive tool-approval, even for tasks that need file reads/writes/bash. Safe to call headlessly.
+- Each dispatch prompt must be self-contained. reasonix has none of the current conversation's context — name files, symbols, and constraints explicitly, the same discipline used when writing an `Agent` tool prompt.
+
+**For reasonix's built-in tools, subagent profiles, MCP server capabilities, and the failure modes discovered while using them — see [`reasonix-tools-and-mcp.md`](reasonix-tools-and-mcp.md) in this folder.** Read it before any dispatch that needs read-only profiles or MCP tools (web search, docs lookup, browser automation).
+
+## Step 1 — Confirm reasonix-axi is available
+
+IF `which reasonix-axi` returns nothing:
+→ STOP. Tell the user reasonix-axi isn't installed or linked. Point them at `cd /home/adrian/dev/subagent-factory/tools/reasonix-axi && npm run build && npm link`. Do not proceed.
+
+ELSE:
+→ proceed to Step 2.
+
+## Step 2 — Decide: delegate to reasonix, or do it yourself?
+
+IF the task is something Claude can do directly in the current session with equal or better context (the current conversation already has the relevant files open, or the task is small):
+→ STOP delegating. Do it directly — reasonix costs real money per call and adds a process hop for no benefit here.
+
+ELSE IF the user explicitly asked for reasonix, or the task needs a genuinely independent second opinion (cross-checking Claude's own code, an adversarial review):
+→ proceed to Step 3.
+
+ELSE IF the task is read-only investigation (survey a codebase, research a library, review/security-review a diff) and running it in parallel with Claude's own work saves wall-clock time:
+→ proceed to Step 3.
+
+ELSE:
+→ do the task directly instead of delegating.
+
+## Step 3 — Pick the dispatch shape
+
+IF the task is read-only investigation and fits one of the built-in profiles:
+→ run `reasonix-axi profiles --dir <path>` first — do not assume a profile is available (see `reasonix-tools-and-mcp.md` for why visibility is workspace-gated).
+→ IF the profile is listed: dispatch with `reasonix-axi task <profile> "<self-contained task>" --dir <path>`
+→ ELSE: fall through to the general-purpose dispatch below.
+
+IF the task needs writes, shell commands, MCP tools, or doesn't fit a built-in profile:
+→ dispatch with `reasonix-axi run "<self-contained prompt>" --dir <path> [--model <name>]`
+→ Do NOT pass `--profile delivery` for an investigation/opinion/review-style ask. `delivery` engages reasonix's capability-gate discipline (formal review/test/security sign-off before it will call a task "complete") — built for actual ship-a-change work. Passed on a "review this and tell me what you found" task, it burns tokens producing a sign-off summary ("all tasks signed off...") instead of the findings. Leave `--profile` unset (defaults to `balanced`) unless the task is genuinely deliver-a-change scoped.
+
+IF the expected answer is more than a few short paragraphs (a design scope, an audit, a detailed report):
+→ Dispatch with `reasonix-axi run`, not `reasonix-axi task <profile>`, and instruct it to write its full findings to a file (e.g. `tmp/<topic>.md`) instead of relying on its inline chat answer, then Read that file yourself. Read-only profiles (`explore` etc.) have no write tool at all and cannot save to a file no matter how they're asked — see `reasonix-tools-and-mcp.md`. This is the default for any design scope, audit, or multi-section report, not just a fallback after hitting truncation once.
+
+IF you need more out of an existing reasonix session (e.g. "write your last answer to a file"):
+→ `--continue` resumes reasonix's newest saved session, which is **not always the one you expect** — verified it can resume an unrelated earlier session and reasonix will report having no memory of the task you meant. Treat `--continue` as best-effort, not reliable session targeting. If it resumes the wrong thing, don't fight it — just redispatch a fresh, fully self-contained prompt instead (this is exactly why prompts must be self-contained in the first place).
+
+## Step 4 — Long dispatches: don't block on the harness's own background runner
+
+Some host environments kill a harness-backgrounded shell call (e.g. Claude Code's `run_in_background`) well before a long `reasonix-axi run` finishes — sometimes within seconds, with no error, no partial output captured, and no relation to the `--timeout` you passed reasonix itself. Confirmed repeatedly in one session: identical dispatches sometimes ran to completion under `run_in_background` and sometimes got killed at ~30s-2min for no visible reason.
+
+→ For any dispatch you expect to take more than ~1-2 minutes, detach it as a real background shell job instead of relying on the harness's backgrounding: `reasonix-axi run "..." --dir <path> > /tmp/some.log 2>&1 &` (note the trailing `&`, and redirect to a file since you lose the tool-call's own stdout capture this way). Then use a `Monitor`/polling tool to watch for the process PID to exit (`while kill -0 <pid> 2>/dev/null; do sleep 10; done`) and read the log file for the result — don't block a single tool call waiting on it.
+→ If a dispatch does get killed anyway (via the harness's own backgrounding), check the working tree before redispatching — reasonix often leaves real, usable partial work uncommitted (confirmed: a full multi-file feature was ~90% done, fully coherent, just missing the final commit and one small integration step). Inspect with `git status`/`git diff` first; finishing the last small piece yourself or committing what's there is usually cheaper and more correct than a blind full redispatch, which pays for the same work twice and can diverge from the first attempt.
+
+## Step 5 — Preflight before dispatching, and before a new no-mistakes step
+
+The established cycle in this codebase is: sync `main` → branch → dispatch reasonix → verify → run `no-mistakes` → merge → repeat for the next unit of work. Two checks belong at the start of every cycle, before either dispatching reasonix or starting a fresh `no-mistakes axi run`:
+
+1. **Confirm you're on a feature branch, not `main`/`master`.** `git branch --show-current` — if it returns `main` or `master`, STOP: sync and branch first (`git checkout main && git pull --ff-only && git checkout -b <name>`). Never dispatch reasonix, or start a `no-mistakes` run, directly on the default branch — `no-mistakes` itself will refuse (it validates committed history on a non-default branch), and reasonix has no branch awareness of its own to catch this for you.
+2. **Kill leftover monitoring from the previous cycle before arming new monitoring for this one.** A prior phase's background watchers (a `Monitor`-tool poll loop on `no-mistakes axi status`, a detached `tmp/no-mistakes-load-watch.sh` instance, a `Monitor` tailing its log) have no reason to still be running once that phase reached a terminal outcome (merged/failed/cancelled) — leaving them alive wastes background slots and, worse, can deliver a stale phase's notifications interleaved with the new phase's, which reads as confusing or contradictory status. Before starting a new `no-mistakes axi run`: check `pgrep -af "no-mistakes-load-watch"` and kill any instance whose log path doesn't match the phase you're about to start; check your own list of active background tasks (however your harness exposes it — e.g. Claude Code's task list) for any `Monitor` still polling a **different, already-terminal** run id and stop it. A monitor still watching the *current* in-flight run is fine to leave running across a preflight check — only stop ones left over from a run that's already done.
+
+## Step 6 — Interpret the result
+
+IF the response's `status` field is `error`:
+→ read the returned text for the reason. Do not retry blindly — either fix the prompt and redispatch once, or fall back to doing the task directly. See `reasonix-tools-and-mcp.md`'s "Why a dispatch can fail mid-flight" section first — reasonix has no automatic retry/backoff on transient provider errors (confirmed not implemented), so a redispatch is often the right call for what looks like a transient failure, not a sign the task itself is broken.
+
+ELSE:
+→ treat the returned text as a subagent's final answer — verify anything load-bearing before acting on it, same discipline as any other subagent report. Do not assume it's correct just because it succeeded.
+
+IF a dispatch reports an MCP tool as failed/blocked/still-initializing:
+→ see `reasonix-tools-and-mcp.md` for the three known failure modes and their fixes before concluding a tool is genuinely broken.
+
+IF `cost_usd` is non-trivial (roughly > $0.01, or the user is running multiple dispatches in one session):
+→ report the cost back to the user — they track spend and appreciate the recap.
+
+## Notes for future updates
+
+| Question | Action |
+|---|---|
+| New failure mode not covered above? | Add it to Step 6 |
+| A profile behaved differently than documented (e.g. gating rules)? | Update Step 3 (or `reasonix-tools-and-mcp.md` if it's about the profile/tool itself) |
+| A flag or command shape changed (`reasonix-axi --help` drifted)? | Update the dispatch commands here |
+| Delegation was the wrong call in hindsight? | Sharpen the decision criteria in Step 2 |
+| A tool, MCP server, or profile behaved unexpectedly? | Update `reasonix-tools-and-mcp.md`, not this file |
+
+If anything changed, snapshot the parent skill (`../SKILL.md` → `../SKILL.v<N+1>.md`) and add a row to `../VERSIONING.md`.

--- a/.agents/skills/herdr/references/reasonix-herdr.md
+++ b/.agents/skills/herdr/references/reasonix-herdr.md
@@ -1,0 +1,68 @@
+# reasonix-herdr — dispatching reasonix through a visible Herdr pane
+
+Reached from [`SKILL.md`](../SKILL.md) when task = reasonix-dispatch and engine = herdr.
+
+## Overview
+
+The underlying tool (`/home/adrian/dev/subagent-factory/tools/reasonix-herdr-axi`) bridges `reasonix` and Herdr. It has two modes, both opening a new visible Herdr pane, since reasonix isn't in Herdr's native agent-detection list (`codex`/`claude`/`pi`/`opencode`/`omp`):
+
+- **`dispatch` (default for real work, as of 2026-07-22)** — runs plain `reasonix-axi run` in the pane with a shell sentinel to detect completion. This is a genuine, interactive-capable foreground CLI process attached to a real PTY — if it ever asks a question live, you can answer it directly (see "Answering a live question" below). It correctly respects `[permissions] mode = "allow"` for ordinary tool calls, so most real work (file writes, migrations, actual coding tasks) sails through without stopping. Blind to `blocked` state in Herdr's own status field (nothing reports it), but that matters less than it used to since dispatch-mode tasks rarely actually block.
+- **`watch`** — runs `reasonix serve` (its HTTP+SSE mode) in the pane, submits the prompt over `POST /submit`, and consumes the `GET /events` SSE stream to drive Herdr's status in real time: `turn_started`→`working`, `approval_request`/`ask_request`→`blocked` (pending question surfaced via `--state-label`), `turn_done`→`idle`. Good for live status visibility on read-mostly/research tasks. **Structural dead end for anything that can trigger an approval/ask request**: `reasonix serve` is a headless HTTP+SSE server — there is no CLI in this tool (or apparently in `reasonix serve` itself) to POST an actual approval decision back to it. A `watch` that goes `blocked` will sit there, correctly reporting `blocked`, until the full `--timeout` elapses and it's abandoned — the accurate status doesn't help you unblock it. Confirmed live 2026-07-22: a task hit `blocked: "approve: explore -"` (likely a subagent/profile-launch gate, not a plain reader tool call, since `[permissions] mode = "allow"` should cover plain readers) with no way to answer it short of closing the pane.
+
+Facts to keep in mind:
+
+- Every call costs real money (same per-call cost as `reasonix-axi`) **and** creates a real, visible Herdr pane. Don't reach for this when the user doesn't actually want to watch the task — use `references/reasonix-headless.md` (headless) when visibility doesn't matter.
+- Default timeout is 600s for both commands.
+- **`dispatch`'s `--timeout` bug (found + FIXED 2026-07-22): it never reached `reasonix-axi run`.** `dispatch`'s `--timeout` only ever bounded how long `reasonix-herdr-axi` itself waited for the pane's completion sentinel — `reasonix-axi run` has its own separate `--timeout` (default 600s) that was never receiving the forwarded value. A task bigger than 10 minutes would get silently killed by that internal default regardless of what you passed to `dispatch`. Confirmed live: a 12-file migration task died at `duration_ms: 600002` with `status: error` despite `--timeout 3600` on the `dispatch` call. **A `status: error` whose `duration_ms` lands suspiciously close to 600000 (or your last-known-good default) is very likely this exact failure mode, not a real task error** — check before treating it as a genuine failure. Fixed in `src/commands/dispatch.ts` (now forwards the same seconds value as `--timeout` to `reasonix-axi run`), rebuilt, live-verified.
+- **Answering a live question in a `dispatch` pane**: since it's a real PTY, use `herdr pane read <pane_id> --source recent-unwrapped` to see what it's asking, then `herdr pane send-text <pane_id> "<answer>"` followed by `herdr pane send-keys <pane_id> Enter` to respond — same as typing into the terminal yourself. This does NOT work for `watch` panes (see above — headless server, nothing reads stdin).
+- **`watch` mode's `--custom-status` bug (found 2026-07-21) is FIXED (2026-07-22).** It failed immediately against herdr 0.7.4 with `error: "herdr pane report-metadata failed: unknown option: --custom-status", code: HERDR_FAILED` — that version of `herdr pane report-metadata` only accepts `--state-label STATUS=TEXT`, no free-standing `--custom-status` flag. Fixed in `src/herdr.ts`'s `reportCustomStatus` (now takes a `state: AgentState` param, calls `--state-label ${state}=${text}`), rebuilt, live-verified. Unrelated to the approval-gate dead-end above — that's a design limitation, not a bug, and isn't fixed by this.
+- **Long dispatches must be detached**, same lesson as `references/reasonix-headless.md`'s Step 3.5: running `reasonix-herdr-axi dispatch "..."` as a plain foreground Bash tool call is subject to the harness's own timeout (confirmed: a 10-minute call died mid-task with no reasonix-side error, `--timeout 900` passed to the CLI notwithstanding — the harness's own limit killed it first). For anything expected to take more than a couple minutes, background the call (`... > /tmp/some.log 2>&1 &` or the harness's own background-run option) and poll `reasonix-herdr-axi status <pane_id>` / tail the log instead of blocking a single tool call on it.
+- **Long or special-character-heavy prompts: load from a file, don't inline a double-quoted string.** Confirmed live 2026-07-22: wrapping a long prompt in double quotes inside a Bash tool call, where the prompt itself contains backtick-quoted code spans (e.g. `` `npm run dev` `` for markdown formatting), makes the shell perform command substitution on those backticks *before* the string ever reaches `reasonix-herdr-axi` — actually executing `npm run dev` and hanging on it for as long as that command runs (a dev server never exits, so this hung indefinitely; zero reasonix cost was incurred since the dispatch never actually started). Fix: write the prompt to a file, then pass it as `"$(cat /path/to/prompt.txt)"` — command substitution output is inserted verbatim and is never re-parsed for further expansion, so backticks/quotes/dollar-signs inside the file are always safe regardless of content.
+- **A killed `dispatch` (or `watch`) can still leave real, coherent work uncommitted** — same as a killed headless dispatch. Confirmed twice: once from a harness-level kill (7-file implementation, uncommitted), once from the `--timeout` bug above (a 9-file panel-shell architecture, uncommitted, cut off mid-migration). Always `git status`/`git diff` and review before redispatching. **To resume a killed session, prefer `--resume <exact-session-path>` over `--continue`** — `--continue` resumes the *newest* saved session, which can silently be the wrong one if any other reasonix call (even an unrelated verification ping) happened afterward. Find the right file with `find ~/.reasonix/projects/-<project-path-with-dashes>/sessions -iname "*<timestamp-or-session-id>*"` (the session id is in the failed/timed-out run's own JSON output, e.g. `session_id: 20260722-062827.338351146-deepseek-flash` → look for `.jsonl` under `~/.reasonix/projects/.../sessions/`), then `reasonix-herdr-axi dispatch "<followup prompt telling it what's already done and what's left>" --resume <path> --copy --dir <path> --timeout <seconds>`.
+- The prompt must be self-contained, same discipline as any subagent dispatch — reasonix has none of the conversation's context.
+
+## Step 1 — Dispatch or watch?
+
+IF the task does or might do real work (file writes, edits, running commands, an actual implementation task) — i.e. most dispatches:
+→ Use `reasonix-herdr-axi dispatch "<self-contained prompt>" [--dir <path>] [--model <name>] [--timeout <seconds>]` (load the prompt from a file via `"$(cat ...)"` if it's long or has backticks/quotes — see Overview). This is the default now: `--timeout` correctly reaches `reasonix-axi run` (fixed 2026-07-22), it respects `[permissions] mode = "allow"` for ordinary tool calls so it rarely actually blocks, and if it *does* ask something live you can answer it directly via `herdr pane send-text`/`send-keys` (see Overview) — unlike `watch`, which cannot be answered at all.
+
+ELSE IF the task is read-only/research-flavored and you specifically want live Herdr status visibility (working/blocked/idle) while it runs, AND it's genuinely unlikely to need any approval:
+→ `reasonix-herdr-axi watch "<self-contained prompt>" [--dir <path>] [--model <name>] [--timeout <seconds>]`. If it goes `blocked`, there is currently no way to unblock it — close the pane and redispatch via `dispatch` instead rather than waiting out the timeout.
+
+IF the response's `watch.status`/`dispatch.status` is `"success"`:
+→ treat the relayed text as the answer — verify anything load-bearing before acting on it, same discipline as any subagent report. Don't assume it's correct just because it succeeded.
+
+**Don't rely solely on either mode's own self-reported status.** Independently confirm via plain `herdr` commands when it matters — `herdr pane list`/`herdr pane get <id>` for status, `herdr pane read <id> --source recent-unwrapped` to read the pane's actual terminal output — before ever deciding to redispatch a task whose outcome seems unclear. This matters most on ambiguous outcomes (a timeout, an unexpected error, a harness-level kill) where trusting the wrapper's own report at face value risks double-paying for a task that's actually still running or already finished. `watch` mode's real-time `reportAgentState` calls DO make `herdr`'s own `agent_status` field trustworthy now that the bug is fixed (it's explicitly set via the herdr API, not inferred from TUI pattern-matching reasonix isn't in Herdr's native detection list for) — but a fresh direct pane read costs nothing and removes any doubt.
+
+ELSE IF `"error"`:
+→ read the relayed text/`error` field for why. Don't retry blindly — fix the prompt and redispatch once, or fall back to doing the task directly.
+
+ELSE IF `"timeout"`:
+→ go to Step 3.
+
+## Step 2 — Check on a pane later
+
+Run: `reasonix-herdr-axi status <pane_id>` for one pane, or `reasonix-herdr-axi list` to see every reasonix pane in the current Herdr workspace.
+
+`agent_status` will be `working` (still running), `idle` (finished, pane currently focused/seen), or `done` (finished, pane was in the background when it completed) — `idle` and `done` are the same underlying state, just seen vs. unseen. Neither `status` nor `list` currently surfaces the task's final `exit_code` — only `dispatch`'s own immediate return does (see Step 3's limitation).
+
+## Step 3 — A dispatch or watch timed out
+
+IF it was a `watch` timeout:
+→ check `status <pane_id>` — the Herdr status is trustworthy here (unlike `dispatch`): `working` means genuinely still running, `blocked` means it's sitting on an approval/question you haven't answered (read `custom_status` for what it's asking). Either way, the `reasonix serve` process is still alive with the port still bound — there is currently no CLI command to reconnect and submit a follow-up or re-subscribe, so treat it as unrecoverable *through this tool* for now, but don't tell the user the outcome is unknown — the status IS known, just not resumable yet. Offer to dispatch a fresh, standalone task instead.
+
+ELSE (it was a `dispatch` timeout, OR a `status: error` whose `duration_ms` looks like a disguised timeout — see Overview):
+→ Check the working tree first (`git status`/`git diff`) — real, coherent work is often already there uncommitted.
+→ Find the exact session file rather than trusting `--continue` (which resumes the *newest* session, not necessarily this one): the failed run's own output includes `session_id: <timestamp>-<model>`; find its `.jsonl` under `~/.reasonix/projects/-<project-path-with-dashes>/sessions/`.
+→ Redispatch with `reasonix-herdr-axi dispatch "<followup prompt describing what's already done and what's left>" --resume <exact-path> --copy --dir <path> --timeout <bigger seconds>` in a fresh pane, rather than starting from scratch.
+
+## Notes for future updates
+
+| Question | Action |
+|---|---|
+| New failure mode not covered? | Add it to Step 1 or Step 3 |
+| A `watch resume`-style command landed (reconnect to a still-running `reasonix serve` after timeout)? | Update Step 3's `watch` branch and the Overview's known-limitation note with the real usage |
+| Cost or timing behaved differently than documented? | Update the Overview |
+| SSE event schema changed upstream (new/renamed `kind` values)? | Update the Overview's event→state mapping |
+
+If anything changed, snapshot the parent skill (`../SKILL.md` → `../SKILL.v<N+1>.md`) and add a row to `../VERSIONING.md`.

--- a/.agents/skills/herdr/references/reasonix-tools-and-mcp.md
+++ b/.agents/skills/herdr/references/reasonix-tools-and-mcp.md
@@ -1,0 +1,72 @@
+# reasonix — Tools, Profiles & MCP
+
+Reference detail for what reasonix can actually do at the tool level, and the failure modes discovered while using it. `SKILL.md` stays focused on the orchestration decision flow (delegate/dispatch/interpret/learn) and points here for anything about reasonix's own capabilities.
+
+## Built-in tools
+
+reasonix's complete built-in toolset (confirmed from source, `docs/SPEC.md`):
+
+```
+read_file / write_file / edit_file / move_file / bash / ls / glob / grep
+```
+
+That's it — no native web search, no fetch, no browser. Any research capability beyond the local repo comes entirely from MCP servers (below).
+
+**No worktree or container isolation of any kind.** Confirmed from source — zero mentions of "worktree", no Docker/containerization. Its only isolation is an OS-level bash sandbox (bubblewrap on Linux, Seatbelt on macOS) that jails *commands*, not filesystem/branch state. Every dispatch operates directly on the real working tree at `--dir`. If a task genuinely needs isolation, the orchestrator must create a git worktree itself (e.g. Claude Code's own `EnterWorktree`) and point `--dir` at that path — there is no reasonix-native equivalent.
+
+## Subagent profiles
+
+4 built-in read-only profiles: `explore`, `research`, `review`, `security_review`, plus any custom ones the user created with `reasonix subagent create`. Built-in visibility is **workspace-gated** — e.g. `review`/`security_review` need a git diff to review. Always run `reasonix-axi profiles --dir <path>` first; never assume a profile is available just because it's one of the 4 named ones.
+
+**Read-only means literally no write tool.** `explore` (confirmed; likely the same for `research`/`review`/`security_review`) only has `glob`/`grep`/`ls`/`read_file`/`code_index` — no `write_file`. A `task explore` dispatch **cannot** write its findings to a file no matter how explicitly it's asked to — it'll say so and paste the report inline instead, which then hits the inline-truncation cap below with no workaround available at that dispatch. If a long report needs to land in a file (which it usually does — see below), dispatch via `reasonix-axi run` instead of `reasonix-axi task <profile>`, even for a read-only investigation task. `run` has full tool access including `write_file`.
+
+## MCP servers
+
+reasonix can have MCP servers configured exactly like Claude Code — `reasonix mcp list` / `reasonix mcp add <name> <command> [args...] [--env K=V]` / `reasonix mcp remove <name>` (persisted to `reasonix.toml`; remote transports via `--http <url>` or `--sse <url>`). This is how web search (e.g. Tavily), docs lookup (context7), and browser automation (Playwright) get added.
+
+**Never enter an API key yourself** when running `reasonix mcp add ... --env KEY=value` — same "never type credentials into any field" rule that governs everything else, even when the user pastes the key directly in chat and asks you to run it anyway. Give the user the exact command and have them run it themselves (a `!`-prefixed message works from any device that can send a chat message, including mobile — it's not a desktop-only mechanism, though it does require the client to actually support command execution; if a `!`-prefixed message comes back with no execution and no tool result, the client doesn't support it and the user needs a real terminal or SSH session instead).
+
+### Three real MCP failure modes (all confirmed live, none are user error)
+
+1. **Cold-start false-negative** — a freshly-added server can report `MCP server "<name>" is still initializing — call this tool again on the next turn` on its first real dispatch. Usually just `npx` downloading the package for the first time, exceeding the tool-call retry window within one turn — not a real config problem. Fix: pre-warm once outside reasonix (`npx -y <package> --help`) so the package is cached, or instruct the dispatch to wait-and-retry (`sleep 5` then try again, up to ~6 times) instead of giving up after one quick attempt.
+
+2. **Permission-classifier block — RESOLVED, fix confirmed working.** reasonix's own internal tool-classification layer can silently block an MCP tool *before it ever dispatches*, independent of the general `[permissions] mode = "allow"` setting:
+   > `MCP server "<name>" no longer classifies tool "<tool>" as an allowed reader; the call was blocked before dispatch — retry from a parent session or update the explicit read-only policy`
+
+   Root cause (confirmed from `docs/SPEC.md` in reasonix's own source): a tool's MCP `annotations.readOnlyHint` maps to reasonix's internal `Tool.ReadOnly()` and **defaults to `false`** — a remote MCP tool is opaque to reasonix, so it only trusts a tool as a safe reader if the server itself declares `readOnlyHint: true` in `tools/list`. `@upstash/context7-mcp` and some of `@playwright/mcp`'s tools (`browser_snapshot`, `browser_find`) don't declare this, so they get blocked by default even though they're genuinely read-only.
+
+   **Do not try to fix it by passing `--permission-mode bypassPermissions`/`auto` on the dispatch call** — that gets blocked by Claude Code's *own* safety classifier (an orchestrator overriding a subagent's permission posture mid-dispatch is correctly flagged as too risky to do on judgment alone). Don't fight that block.
+
+   **The actual fix**: add a per-plugin `trusted_read_only_tools = ["tool-a", "tool-b"]` line to the relevant `[[plugins]]` block in `~/.reasonix/config.toml` (documented in `docs/SPEC.md`'s global-config example, near `default_tools_approval_mode`). This is a persistent, repo-independent config edit — the user's own machine config, not a per-dispatch override, so it's a normal edit to make directly (not the same category as the blocked `--permission-mode` flag). Example, verified working:
+   ```toml
+   [[plugins]]
+   name    = "context7"
+   command = "npx"
+   args    = ["-y", "@upstash/context7-mcp"]
+   trusted_read_only_tools = ["resolve-library-id", "query-docs"]
+   ```
+   **Get the exact tool names from the installed package's own source, not from web search or training data.** A web search for context7's tool names confidently returned `get-library-docs` — wrong for the actually-installed version (3.2.4); the real tool is `query-docs`, confirmed by grepping `registerTool(` calls in the cached package source under `~/.reasonix/mcp-state/<hash>/<plugin>/cache/npm/_npx/<hash>/node_modules/<package>/dist/index.js` (reasonix caches the resolved npx package there after first use). If a dispatch itself reports the tool names back to you (e.g. "the only tools I have are X and Y"), that live introspection is also authoritative — trust it over a web search that disagrees.
+
+   After adding `trusted_read_only_tools`, verify with a real dispatch calling the tool directly (skip any implied connect step, see failure mode 3) — confirmed this fully resolves the block with zero further errors.
+
+3. **Unnecessary-connect-step red herring** — a dispatch can try an implied "connect" tool-call before the real tool, report failure on *that* step, and never actually attempt the real tool. Observed with Tavily: reported as broken/still-initializing, but a redispatch instructed to call `tavily_search` directly (skip any connect/handshake step) succeeded immediately with 0 retries. When an MCP tool comes back "failed", one retry that explicitly skips any implied setup step is worth doing before concluding it's genuinely broken.
+
+## Inline output truncation (not MCP-specific, but discovered via MCP-tool dispatches)
+
+`reasonix-axi`'s own CLI caps how much inline text it displays/captures, even when the underlying response is much longer — it self-reports the true length ("...truncated, 8849 chars total") while only delivering a fraction of that to the calling shell. This happens *inside* `reasonix-axi` before the text ever reaches Claude Code — it is not something `wc -c` or reading the captured output file harder works around.
+
+**For any report longer than a few short paragraphs, instruct the dispatch to write its full findings to a file** (e.g. `tmp/<topic>.md`) instead of relying on the inline chat answer, then `Read` that file directly. Treat this as the default for design scopes, audits, or anything multi-section — not just a fallback after hitting truncation once.
+
+## Why a dispatch can fail mid-flight, and how to reduce the odds
+
+Confirmed from source (`docs/SPEC.md §6, §3.6`) and from empirically checking `~/.reasonix/sessions/` — none of these are speculation:
+
+1. **No automatic retry/backoff on transient API errors.** `docs/SPEC.md §6` states outright: *"Network layer should apply bounded exponential backoff on 429 / 5xx (interface reserved; implementation may follow)."* This is not implemented yet — a single rate-limit response or transient server error from the model provider can kill the entire dispatch with zero built-in resilience. **Mitigation:** the orchestrator has to be the retry layer reasonix doesn't have yet — if a dispatch errors out with what looks like a transient network/provider issue (not a permission block, not a real logic error), redispatch once before concluding the task itself is broken.
+
+2. **Multiple stacked timeouts, any one of which kills the dispatch.** `reasonix-axi run --timeout <seconds>` (default 600s, caps the whole dispatch) sits on top of `bash_timeout_seconds` (120s, per foreground bash call) and `mcp_call_timeout_seconds`/`call_timeout_seconds` (300-600s, per MCP call). A dispatch doing something genuinely slow (a big install, a slow crawl, a large build) can get killed by whichever cap hits first, producing a truncated/incomplete result rather than a clean error message explaining why. **Mitigation:** pass an explicit `--timeout <seconds>` well above 600 for any task expected to run long, and say so in the dispatch prompt so it isn't a silent surprise.
+
+3. **Context-window compaction can silently degrade very long/broad dispatches.** Long tasks with lots of large tool outputs trigger automatic summarization (`agent.compact_ratio`, default 0.8) that folds older tool results into short placeholders to keep the prompt under budget. This isn't a crash, but a dispatch that reads dozens of files or produces huge intermediate output can lose access to earlier detail by the time it writes its final answer — the final report may quietly be based on compacted/summarized context rather than the original full reads. **Mitigation:** keep individual dispatch scope focused rather than one sprawling investigation; split a genuinely large audit into 2-3 narrower dispatches instead of one giant one.
+
+4. **Dispatch sessions are not reliably persisted the way interactive sessions are.** Confirmed empirically: after ~10 `reasonix-axi` dispatches in one session, `~/.reasonix/sessions/` still only contained stale sessions from months earlier — none of the dispatch session IDs reported back (`20260720-...-deepseek-v4-flash` etc.) showed up there. This is consistent with the earlier-documented `--continue` unreliability (it resumed an unrelated old session, not any recent dispatch). **Practical implication:** if a dispatch fails mid-flight, there is likely no session to `--resume`/`--continue` into to recover partial progress — treat each dispatch as closer to fire-and-forget than a resumable session, and for anything expensive/long, have it write partial progress to a file as it goes rather than relying on session continuity as a safety net.
+
+5. **Some tools are hard-refused in headless/non-interactive dispatches, not just permission-classified.** `docs/SPEC.md §3.6` notes that `remember`/`forget` calls specifically "are refused rather than auto-approved" in non-interactive headless runs or sub-agents, regardless of permission mode — a different, stricter mechanism than the MCP permission-classifier block above. If a dispatch's own plan happens to depend on a tool that's hard-refused this way, it can't complete that step cleanly. Unlikely to matter for typical orchestrator dispatches (research/code tasks rarely need `remember`/`forget`), but worth knowing this class of hard refusal exists beyond MCP tools specifically.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -524,6 +524,7 @@ These skills are not captain-invocable; load them only at their precise triggers
 - `fmx-respond` - load on an `x-mention <request_id>` `check:` wake to handle the mention, on an `x-mode-error ...` `check:` wake to report the Relay configuration blocker, on a `public-followup ...` `check:` wake or a startup-surfaced public commitment, and on any milestone or terminal wake for a Relay-linked task before posting its completion follow-up; relevant only when Relay is on.
 - `firstmate-codexapp` - load before coordinating a visible Codex Desktop thread, evaluating a Codex App backend request, or reconciling Codex Desktop host-tool smoke evidence for Firstmate work.
 - `firstmate-coding-guidelines` - load before changing firstmate's shared, tracked material, as defined by section 1's list, whether editing directly or briefing a crewmate for a firstmate-repo task.
+- `herdr` - load when the captain mentions Herdr and firstmate needs terminal pane control, reasonix dispatch (visible or headless), or browser-harness dispatch through a visible Herdr pane.
 
 ## 14. Relay
 


### PR DESCRIPTION
## What

Copy the herdr pane-control/reasonix-dispatch/browser-harness-dispatch skill from ~/.claude/skills/herdr into firstmate's own tracked .agents/skills/herdr/. The skill previously lived only as a global Claude Code user-level skill outside any git repo; firstmate now has its own durable, tracked copy.

## Changes

- 11 files copied verbatim from ~/.claude/skills/herdr/: SKILL.md, SKILL.v1.md through SKILL.v4.md, VERSIONING.md, and 5 reference files (browser-harness-herdr.md, herdr-panes.md, reasonix-headless.md, reasonix-herdr.md, reasonix-tools-and-mcp.md).
- metadata.internal=true added to SKILL.md frontmatter only (the live version), per AGENTS.md's .agents/skills/ convention for firstmate-loaded internal skills.
- Version snapshots (SKILL.v1-v4.md) left without the metadata flag: they are read-only history (per VERSIONING.md), v1 was named cyber-mux and never carried it, and installers discover the live SKILL.md only. Adding it would be anachronistic and unfaithful.
- One trigger line added to AGENTS.md section 13 (agent-only reference skills): herdr - load when the captain mentions Herdr and firstmate needs terminal pane control, reasonix dispatch (visible or headless), or browser-harness dispatch through a visible Herdr pane.

## Verification

- diff -r confirms byte-for-byte fidelity: the only difference from source is the two-line metadata block in SKILL.md.
- All 10 other files are identical to source.
- The global ~/.claude/skills/herdr copy is untouched and keeps working via Claude Code's own skill discovery; this is a tracked copy, not a migration or removal.

## Out of scope

- No changes to references/herdr-panes.md's binox-axi content (brought in as-is).
- No binox-axi installation or testing (separate work on subagent-factory).
