### PR TITLE
feat(bin): generate the operator status board from fleet state

### DIFF
--- a/.github/workflows/no-mistakes-required.yml
+++ b/.github/workflows/no-mistakes-required.yml
@@ -9,6 +9,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 # GitHub concurrency groups retain at most one pending run, replacing older
 # pending runs even when cancel-in-progress is false. Give body-bearing events
@@ -26,15 +27,23 @@ jobs:
       github.event.pull_request.user.login != 'github-actions[bot]' &&
       github.event.pull_request.user.login != 'dependabot[bot]'
     steps:
+      # The event payload freezes the PR body at event time, but cross-fork
+      # deliveries append the Pipeline section in a follow-up edit and
+      # first-time-fork approval can delay the opened run past that edit, so
+      # the stale snapshot fails permanently even though the live body
+      # complies. Fetch the current body so every run (and re-run) judges the
+      # PR as it is now.
       - name: Verify no-mistakes signature in PR body
         env:
-          PR_BODY: ${{ github.event.pull_request.body }}
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
           PR_AUTHOR: ${{ github.event.pull_request.user.login }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           set -eu
           marker='Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)'
-          if printf '%s' "${PR_BODY:-}" | grep -qF -- "$marker"; then
+          pr_body="$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq '.body // empty')"
+          if printf '%s' "$pr_body" | grep -qF -- "$marker"; then
             echo "Found no-mistakes signature in PR #${PR_NUMBER} body."
             exit 0
           fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -397,6 +397,7 @@ Do not surface automatic fixes, retries, routine progress, or internal supervisi
 When a routine operational update's specific event requires no action but a response must be sent, reply exactly `Captain, shipshape.` without characterizing the visible session's unrelated decisions.
 Batch non-urgent updates into the next natural reply.
 Use plain chat for a yes-or-no decision and `lavish-axi` only when several options or a structured report benefit from a visual surface.
+When that surface is the whole fleet's status board, generate it with `bin/fm-board.sh` and pass the judgment half in as authored cards rather than writing the page by hand.
 Whenever a PR is mentioned, include its full `https://...` URL before any shorthand reference.
 Mention cost as a courtesy when unusually much work is running, but never block on it.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,74 +54,19 @@ Each secondmate has a persistent isolated `FM_HOME`, including its own state, ba
 Tracked files hold shared instructions and tooling; `data/` holds durable private fleet records; `state/` holds volatile runtime records and append-only status events; `config/` holds local operating choices; and `projects/` contains clones that are read-only to firstmate except under hard rule 1's concrete captain-approved project operation exception.
 
 ```
-AGENTS.md            this file (CLAUDE.md is a symlink to it)
-CONTRIBUTING.md      contributor workflow and repo conventions
-README.md            public overview and development notes
-.github/workflows/   shared CI and PR enforcement, committed
-.tasks.toml          tracked tasks-axi markdown backend config for the default backlog backend (section 10)
-.agents/skills/      firstmate-loaded internal skills, committed; each carries metadata.internal=true for installers
-.claude/skills       symlink to .agents/skills for claude compatibility
-skills/              standalone public installer-facing skills, committed; not loaded by firstmate
-bin/                 helper scripts, committed; read each script's header before first use
-.env                 optional Relay pairing token; LOCAL, gitignored; presence-gates section 14
-config/crew-harness  crewmate harness override; LOCAL, gitignored; absent or "default" = same as firstmate. Inherited as the literal file: a concrete primary adapter value also controls a secondmate home's own crewmates (section 4)
-config/crew-dispatch.json  optional crewmate dispatch profiles; LOCAL, gitignored; firstmate-maintained but human-editable natural-language rules that choose a per-task harness/model/effort profile (section 4). Inherited by secondmate homes
-config/secondmate-harness  harness the PRIMARY uses to launch SECONDMATE agents, optionally followed by a model and effort token on the same line ("<harness> [<model>] [<effort>]"; section 4); LOCAL, gitignored; absent or "default" harness falls back to config/crew-harness then firstmate's own. The primary's own setting; NOT inherited into secondmate homes (secondmates do not spawn secondmates)
-config/backlog-backend  backlog backend override; LOCAL, gitignored; absent or "tasks-axi" = default tasks-axi backend, "manual" = force routine backlog updates to hand-editing; inherited by secondmate homes (section 10)
-config/backend  runtime session-provider backend override for new tasks; LOCAL, gitignored; absent = falls through to runtime auto-detection (the runtime firstmate itself is executing inside), then tmux; tmux is the verified reference backend (docs/tmux-backend.md), while herdr, zellij, orca, and cmux are experimental spawn backends (docs/herdr-backend.md, docs/zellij-backend.md, docs/orca-backend.md, docs/cmux-backend.md) - herdr and cmux can also be selected by runtime auto-detection, zellij and orca never are (always explicit), and codex-app is not accepted; see docs/codex-app-backend.md; inherited by secondmate homes under the primary-authoritative contract in secondmate-provisioning
-config/calm     Pi Calm presentation preference; LOCAL, gitignored, and not inherited; see docs/configuration.md "Pi Calm preference"
-config/startup-memory-budget     primary-authoritative per-home startup-memory budget; LOCAL, gitignored, materialized as 7,500 estimated tokens by locked primary bootstrap and inherited into secondmate homes; see docs/configuration.md "Startup memory budget"
-config/herdr-presentation-spaces  optional "off" opt-out from, or "on" opt-in to, Herdr's default-on disposable single-task visual projection, which is unconfigured-default-on only at or above a Herdr version floor; LOCAL, gitignored; inherited by secondmate homes; see docs/herdr-backend.md "Presentation spaces"
-config/trace-context  optional presence flag enabling default-off native W3C trace-context propagation to spawned agents; LOCAL, gitignored; inherited by secondmate homes; see docs/configuration.md "Trace context propagation" and docs/trace-context.md
-config/cmux-socket-password  optional cmux control-socket password; LOCAL, gitignored; read fresh on every cmux CLI call and passed through without ever overriding an operator's own ambient CMUX_SOCKET_PASSWORD when absent (docs/cmux-backend.md "Setup")
-config/wedge-alarm  optional away-mode wedge-alarm active-alert directives; LOCAL, gitignored; absent means auto (macOS Notification Center when available); see docs/wedge-alarm.md
-config/x-mode.env    generated Relay watcher cadence; LOCAL, gitignored; source before arming watcher when present
-data/                personal fleet records; LOCAL, gitignored as a whole
-  backlog.md         task queue, dependencies, history
-  captain.md         this home's domain-local captain preferences and working style; LOCAL, gitignored, canonical even if harness memory mirrors it, and updated with inspect-then-update
-  captain-shared.md  main-authoritative shared captain preferences propagated read-only to secondmate homes; LOCAL, gitignored, owned by secondmate-provisioning
-  learnings.md       fleet-local operational facts and gotchas; LOCAL, gitignored; dated, evidence-backed, curated, and updated with inspect-then-update - rewrite and prune rather than append forever, the same contract as captain.md; created lazily, absent until this home has a learning to store
-  projects.md        thin fleet navigation registry recording each project's standing delivery posture; firstmate-private, parsed for mechanical sync and seeding by fm-project-mode.sh (section 6)
-  secondmates.md      local and remote secondmate routing table; firstmate-private, maintained by the secondmate seed helpers (section 6)
-  <id>/brief.md      per-task crewmate brief, or per-secondmate charter brief when kind=secondmate
-  <id>/report.md     scout task deliverable, written by the crewmate; survives teardown
-projects/            cloned repos; gitignored; read-only except under hard rule 1's concrete captain-approved project operation exception
-state/               volatile runtime signals; gitignored
-  <id>.status        appended by crewmates: "<state>: <note>" wake-event lines, not current-state truth
-  <id>.turn-ended    touched by turn-end hooks
-  <id>.grok-turnend-token   firstmate-owned grok hook registry token for the task; removed by teardown
-  <id>.kimi-turnend-token   firstmate-owned Kimi hook registry token for the task; removed by teardown
-  <id>.muse-session  muse busy-source binding (sessions root plus task worktree) written by fm-spawn; removed by teardown
-  <id>.meta          written by fm-spawn: window=, endpoint_task_id=, worktree=, project=, harness=, model=, effort=, kind=, mode=, yolo=, tasktmp=; an optional traceparent= only when trace context is enabled (docs/configuration.md "Trace context propagation"); kind=secondmate also records home= and projects=, plus remote_host=/remote_root=/remote_backend=/remote_herdr_session=/remote_target= for a remote route; a non-default runtime backend records further backend-specific fields (docs/configuration.md "Runtime backend"; bin/fm-backend.sh, section 8); fm-pr-check, including through fm-pr-merge, records one canonical pr= and the forge's pr_head= when available (GitHub pull requests and GitLab merge requests; docs/gitlab-merge-watch.md); fm-x-link appends x_request=, x_request_ts=, x_followups=, and optional x_platform=/x_reply_max_chars= for a Relay-originated task (section 14)
-  <id>.herdr-presentation  quarantinable attempt and restart-binding journal for Herdr's optional visual projection; never task or endpoint authority; see docs/herdr-backend.md "Presentation spaces"
-  <id>.check.sh      authenticated slow poll; the watcher dispatches validated PR data and the byte-identified Relay shim through trusted repository scripts, runs registered custom checks from hash-validated private snapshots, and rejects every other state check without execution
-  <id>.check-trust   private content binding created by fm-check-register.sh for an intentional custom check
-  <id>.pr-poll       private validated data sidecar for the byte-static PR merge poll
-  <id>.pr-poll-registration  private transactional provenance record binding the task, canonical metadata identity, sidecar, and static poll publication
-  <id>.pr-poll-retirement  private identity-bound crash-recovery receipt for one exact validated merged result; removed after its poll artifacts retire
-  .pr-check-quarantine/  private non-runnable storage for checks neutralized by the non-executing migration
-  .pr-check-migration.log  private per-task outcomes distinguishing rebuilt or canonically registered replacement polls, quarantined unarmed polls, and incomplete migrations
-  .pr-check-migration-scan-v1  private marker proving the non-executing scan disabled every unsafe legacy check; .pr-check-migration-v1 separately records completed private repairs
-  x-watch.check.sh   generated Relay poll shim; present only when opted in (section 14)
-  pending-replies/   parent-owned secondmate pending-reply records (correlation id, delivery vs reply, recovery, escalation); fm-pending-reply-lib.sh
-  procevent/         registered process-to-event sources, one private record per canonical source id; written only by bin/fm-procevent.sh, and their presence alone keeps supervision required (section 13)
-  procevent-inbox/   private captured results and their durable handled-acknowledgement markers; source output lives here and never in an event line
-  x-inbox/           generated Relay pending mention payloads; fmx-respond drains it (section 14)
-  x-context/         generated Relay durable per-request reply context and one-wake offer markers, keyed by request_id; survives inbox cleanup and expires within seven days (section 14; bin/fm-x-lib.sh)
-  x-outbox/          generated Relay dry-run reply and dismiss previews; inspect it when FMX_DRY_RUN is set (section 14)
-  public-followup/   generated private transport for promised public replies: commitment registrations, typed terminal-result inbox, accepted/rejected ledgers (section 14; bin/fm-public-followup.sh)
-  x-poll.error x-poll.claim-error  generated Relay and offer-claim diagnostic dedupe markers
-  .wake-queue        durable queued wakes: epoch<TAB>seq<TAB>kind<TAB>key<TAB>payload
-  .<id>.open-decisions-cursor  per-task byte cursor and folded open-decision set bounding the OPEN DECISIONS scan's cost to new status-log appends; written only by fm-classify-lib.sh's status_open_decisions_incremental, removed by teardown, safe to delete (forces one full re-fold)
-  .afk               durable away-mode flag; present = sub-supervisor may inject escalations (set by /afk, cleared on user return)
-  .watch.lock .wake-queue.lock watcher singleton and queue serialization locks
-  .claude-autoarm.lock .claude-autoarm-epoch .claude-autoarm-failure-notified .claude-autoarm-failure-alarmed .turnend-claude-blocks .turnend-claude-blocks.lock   Claude Stop auto-arm single-flight, epoch, failure-episode, attended-alarm, guard-budget, and budget-lock records; never touch
-  .hash-* .count-* .stale-* .stale-since-* .paused-* .wedge-escalations-* .seen-* .hb-surfaced-* .last-* .heartbeat-streak   watcher internals; never touch
-  .watch-triage.log  watcher's absorbed-wake debug log (size-capped); never relied on, safe to delete
-  .last-watcher-beat watcher liveness beacon, touched every poll (including while absorbing benign wakes); guard scripts read it
-  .subsuper-* .supervise-daemon.*   sub-supervisor internals; never touch
-.no-mistakes/        local validation state and evidence; gitignored
+tracked code root  shared instructions, skills, docs, workflows, and bin/ scripts; section 1 lists the shared material
+config/            local operating choices, one small gitignored file per knob
+data/              durable private fleet records: registries, captain preferences, learnings, backlog, briefs, and scout reports
+projects/          cloned project repos; gitignored
+state/             volatile runtime records: task metadata, status events, the wake queue, and watcher, Relay, and supervision artifacts
+.no-mistakes/      local validation state and evidence; gitignored
 ```
+
+Resolve an individual file's meaning through those owners - `docs/configuration.md` for every layout entry and `config/` knob, the producing script's header and help for its own `data/` and `state/` artifacts - rather than from memory.
+`CLAUDE.md` and `.claude/skills` are compatibility symlinks to `AGENTS.md` and `.agents/skills/`; edit the originals.
+Read each `bin/` script's header before first use.
+The dot-prefixed files under `state/` are internals of the watcher, wake-queue, auto-arm, away-mode, and sub-supervisor machinery; never edit them by hand, and act on them only through their owning paths.
+A registered process-to-event source under `state/procevent/` keeps supervision required by its presence alone (section 13).
 
 A `state/<id>.status` line is a wake event, not current-state truth; `bin/fm-crew-state.sh` owns current-state reconciliation.
 Treat `data/captain.md` as the domain-local record of captain preferences, optional `data/captain-shared.md` as the main-authoritative shared captain-preference file for secondmate inheritance, and `data/learnings.md` as curated home-local knowledge, regardless of harness memory.

--- a/bin/fm-board.sh
+++ b/bin/fm-board.sh
@@ -1,0 +1,809 @@
+#!/usr/bin/env bash
+# fm-board.sh - render the operator board as one self-contained HTML artifact.
+#
+# The board is the four-column operator surface: Waiting on you, Under way,
+# Queued, and Landed.
+# It exists because that surface was being hand-written per refresh, which made
+# every board a fresh transcription of state that had already moved.
+#
+# This command does not parse fleet state itself.
+# Like bin/fm-fleet-view.sh it shells out to bin/fm-fleet-snapshot.sh --json and
+# renders that stable structured contract, so the snapshot stays the one owner of
+# what the fleet currently is.
+#
+# THE SEAM. The script owns everything mechanically derivable from durable state
+# and nothing else:
+#   Under way   one card per live direct report, from its recorded metadata plus
+#               the current state bin/fm-crew-state.sh reports, stamped with the
+#               time that state was read.
+#   Queued      queued backlog items with their unresolved blockers and date gates.
+#   Landed      recent completions with their delivery artifact, including the
+#               landings rolled up from delegated homes.
+#   Waiting on you, the mechanical half: work with a locally recorded pull request,
+#               captain-held queued items, and every unresolved decision key folded
+#               out of the durable status logs.
+#
+# The script does NOT derive the judgment half.
+# Option lists, recommendations, the reasoning for preferring one option, and the
+# chores only the operator can do are written per decision and cannot be inferred
+# from a status line, so they arrive through --cards as authored input that is
+# merged into the Waiting-on-you column alongside the mechanical cards.
+# See BOARD CARDS in --help for that format; it is validated, never trusted.
+#
+# A decision key present in the durable logs with no authored card still renders,
+# marked as not yet elaborated. Silence about a pending decision is the one
+# failure this board must not have, so an unelaborated key is never dropped.
+#
+# The artifact is self-contained: one file, no CDN, no sibling assets, so it opens
+# from disk on any device whether or not a viewer is running. Every rendered string
+# is HTML-escaped, and paths under the operator's home are reduced to ~ before
+# rendering; the write is refused outright if the home path survives into the output.
+#
+# Read-only with respect to the fleet: no lock, no wake queue, no mutation, and no
+# network. It writes only its own artifact and prints that path.
+# It never polls: arming the artifact as a wake source is a separate step, owned by
+# bin/fm-procevent.sh and its Lavish adapter.
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
+
+usage() {
+  cat <<'EOF'
+usage: fm-board.sh [options]
+
+Render the operator board from live fleet state and print the artifact path.
+
+Options:
+  --cards <file>     authored Waiting-on-you cards (see BOARD CARDS below)
+  --out <path>       artifact path (default: $FM_HOME/.lavish/board.html)
+  --snapshot <file>  render a saved `fm-fleet-snapshot.sh --json` instead of
+                     taking a fresh snapshot; "-" reads stdin
+  --landed <n>       how many recent landings to show (default: 8)
+  --title <text>     page title (default: The Bridge)
+  --stale-mins <n>   minutes of age after which the board warns it is stale;
+                     twice that marks it too old to trust (default: 30)
+  -h, --help         this help
+
+BOARD CARDS
+
+  A line-oriented text file. Blank lines and lines starting with # are ignored.
+  Each card opens with a type header and is followed by `field: value` lines.
+  Repeatable fields keep the order they are written in. Values are single-line.
+
+    [decision]
+    key: mesh-note                 required, identifies the answer; slug only
+    binds: listen-collapse-a30:default
+                                   optional; the durable decision this elaborates,
+                                   written as <task-id>:<decision-key>
+    title: One word, whenever      required
+    tag: listening screen          optional badge
+    body: A paragraph.             repeatable
+    warn: Three rounds on one theme.
+                                   repeatable; renders as a callout
+    option: ship | **Ship it** - one paragraph recording a measured fact
+                                   repeatable, at least one; `<value> | <label>`
+    recommend: ship                optional; must name one of this card's options
+    footnote: Why not the other one today ...
+                                   repeatable; small print under the options
+
+    [chores]
+    title: Only you can do these   optional
+    item: **Tier-2 listening session.** 22 clips staged.
+                                   repeatable, at least one
+    footnote: No pull request waiting on a merge.
+                                   optional
+
+  Labels, bodies, items, warnings and footnotes take a small inline markup:
+  **bold**, *italic*, and `code`. Everything else is escaped, so authored text
+  can never inject markup of its own. Backticks must be balanced.
+
+  The file is validated as a whole before anything is written: an unknown field,
+  a card missing a required field, a duplicate key, a recommendation that names
+  no option, or a `binds` naming a decision the durable logs do not have all
+  refuse the render rather than producing a partial board.
+EOF
+}
+
+die() { printf 'fm-board: %s\n' "$1" >&2; exit 1; }
+usage_error() { printf 'fm-board: %s\n' "$1" >&2; usage >&2; exit 2; }
+
+CARDS_FILE=""
+OUT=""
+SNAPSHOT_FILE=""
+LANDED=8
+TITLE="The Bridge"
+STALE_MINS=30
+
+require_value() {  # <flag> <count>
+  [ "$2" -gt 1 ] || usage_error "$1 requires a value"
+}
+require_count() {  # <flag> <value>
+  case "$2" in
+    ''|*[!0-9]*) usage_error "$1 must be a non-negative integer" ;;
+  esac
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --cards) require_value --cards "$#"; CARDS_FILE=$2; shift 2 ;;
+    --out) require_value --out "$#"; OUT=$2; shift 2 ;;
+    --snapshot) require_value --snapshot "$#"; SNAPSHOT_FILE=$2; shift 2 ;;
+    --landed) require_value --landed "$#"; require_count --landed "$2"; LANDED=$2; shift 2 ;;
+    --title) require_value --title "$#"; TITLE=$2; shift 2 ;;
+    --stale-mins)
+      require_value --stale-mins "$#"
+      case "$2" in ''|*[!0-9]*|0) usage_error "--stale-mins must be a positive integer" ;; esac
+      STALE_MINS=$2; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    *) usage_error "unknown option: $1" ;;
+  esac
+done
+
+command -v jq >/dev/null 2>&1 || die "jq not found"
+
+[ -n "$OUT" ] || OUT="$FM_HOME/.lavish/board.html"
+
+# --- snapshot ---------------------------------------------------------------
+
+if [ -n "$SNAPSHOT_FILE" ]; then
+  if [ "$SNAPSHOT_FILE" = - ]; then
+    SNAPSHOT=$(cat)
+  else
+    [ -f "$SNAPSHOT_FILE" ] || die "snapshot file not found: $SNAPSHOT_FILE"
+    SNAPSHOT=$(cat "$SNAPSHOT_FILE")
+  fi
+  printf '%s' "$SNAPSHOT" | jq -e 'type == "object" and has("tasks") and has("backlog")' >/dev/null 2>&1 \
+    || die "snapshot file is not an fm-fleet-snapshot object: $SNAPSHOT_FILE"
+else
+  SNAPSHOT=$("$SCRIPT_DIR/fm-fleet-snapshot.sh" --json) || die "fleet snapshot failed"
+fi
+
+# Every durable open decision, as the <task-id>:<key> identifiers an authored
+# card may bind to. Also the validation domain for a card's `binds` field.
+DURABLE_KEYS=$(printf '%s' "$SNAPSHOT" \
+  | jq -r '[.tasks[]? | . as $t | (.hints.open_decisions // [])[] | "\($t.id):\(.key)"] | .[]')
+
+# --- authored cards ---------------------------------------------------------
+#
+# Parsed and validated here, where a problem can name the file and line, then
+# handed to the renderer as structured records. Nothing is written before the
+# whole file validates.
+
+CARDS_ROWS=""
+
+parse_cards() {  # <file>
+  local file=$1 line lineno=0 idx=0 field value type="" rows="" known
+  local -a keys=() opts=() recommends=() reclines=() bindvals=() bindlines=()
+  local -a have_title=() have_option=() have_item=() have_key=() blocklines=()
+
+  card_error() { printf 'fm-board: %s:%s: %s\n' "$file" "$1" "$2" >&2; exit 2; }
+
+  while IFS= read -r line || [ -n "$line" ]; do
+    lineno=$((lineno + 1))
+    line=${line%$'\r'}
+    case "$line" in
+      ''|'#'*) continue ;;
+      '['*']')
+        type=${line#'['}
+        type=${type%']'}
+        case "$type" in
+          decision|chores) ;;
+          *) card_error "$lineno" "unknown card type: [$type] (expected [decision] or [chores])" ;;
+        esac
+        idx=$((idx + 1))
+        keys+=("") ; have_title+=(0) ; have_option+=(0) ; have_item+=(0) ; have_key+=(0)
+        blocklines+=("$lineno")
+        rows+="$idx"$'\t'"type"$'\t'"$type"$'\n'
+        continue
+        ;;
+    esac
+
+    [ "$idx" -gt 0 ] || card_error "$lineno" "field outside any card; open one with [decision] or [chores]"
+
+    case "$line" in
+      *:*) ;;
+      *) card_error "$lineno" "not a field line; expected '<field>: <value>'" ;;
+    esac
+    field=${line%%:*}
+    value=${line#*:}
+    value=${value# }
+    # Trim surrounding whitespace so an authored line's indentation never leaks.
+    value=${value#"${value%%[![:space:]]*}"}
+    value=${value%"${value##*[![:space:]]}"}
+    case "$field" in
+      ''|*[!a-z]*) card_error "$lineno" "not a field name: '$field'" ;;
+    esac
+    [ -n "$value" ] || card_error "$lineno" "field '$field' has an empty value"
+
+    # Inline markup is only ever applied to authored text, so only authored text
+    # has to have balanced backticks.
+    case "$field" in
+      body|warn|option|footnote|item|title)
+        local ticks
+        ticks=${value//[!\`]/}
+        [ $(( ${#ticks} % 2 )) -eq 0 ] || card_error "$lineno" "unbalanced backtick in '$field'"
+        ;;
+    esac
+
+    if [ "$type" = decision ]; then
+      case "$field" in
+        key|binds|title|tag|body|warn|option|recommend|footnote) ;;
+        *) card_error "$lineno" "unknown field for [decision]: '$field'" ;;
+      esac
+    else
+      case "$field" in
+        title|item|footnote) ;;
+        *) card_error "$lineno" "unknown field for [chores]: '$field'" ;;
+      esac
+    fi
+
+    case "$field" in
+      key)
+        [ "${have_key[idx-1]}" = 0 ] || card_error "$lineno" "duplicate 'key' in one card"
+        case "$value" in
+          *[!A-Za-z0-9._-]*|-*|.*) card_error "$lineno" "key must be a slug of letters, digits, '.', '_' or '-': '$value'" ;;
+        esac
+        local seen
+        for seen in "${keys[@]}"; do
+          [ "$seen" = "$value" ] && card_error "$lineno" "duplicate key across cards: '$value'"
+        done
+        keys[idx-1]=$value
+        have_key[idx-1]=1
+        ;;
+      title)
+        [ "${have_title[idx-1]}" = 0 ] || card_error "$lineno" "duplicate 'title' in one card"
+        have_title[idx-1]=1
+        ;;
+      option)
+        case "$value" in
+          *' | '*) ;;
+          *) card_error "$lineno" "option must be '<value> | <label>'" ;;
+        esac
+        local optval optlabel
+        optval=${value%% | *}
+        optlabel=${value#* | }
+        [ -n "$optval" ] || card_error "$lineno" "option has an empty value"
+        [ -n "$optlabel" ] || card_error "$lineno" "option has an empty label"
+        for seen in ${opts[@]+"${opts[@]}"}; do
+          [ "$seen" = "$idx/$optval" ] && card_error "$lineno" "duplicate option value in one card: '$optval'"
+        done
+        opts+=("$idx/$optval")
+        have_option[idx-1]=1
+        ;;
+      recommend)
+        recommends+=("$idx/$value")
+        reclines+=("$lineno")
+        ;;
+      binds)
+        bindvals+=("$value")
+        bindlines+=("$lineno")
+        ;;
+      item)
+        have_item[idx-1]=1
+        ;;
+    esac
+    rows+="$idx"$'\t'"$field"$'\t'"$value"$'\n'
+  done < "$file"
+
+  # Whole-file checks, once every card is known.
+  local i n rec recidx recval bind
+  n=$idx
+  i=1
+  while [ "$i" -le "$n" ]; do
+    if printf '%s' "$rows" | grep -qxF "$i	type	decision"; then
+      [ "${have_key[i-1]}" = 1 ] || card_error "${blocklines[i-1]}" "this [decision] is missing a 'key'"
+      [ "${have_title[i-1]}" = 1 ] || card_error "${blocklines[i-1]}" "[decision] ${keys[i-1]} is missing a 'title'"
+      [ "${have_option[i-1]}" = 1 ] || card_error "${blocklines[i-1]}" "[decision] ${keys[i-1]} has no 'option'"
+    else
+      [ "${have_item[i-1]}" = 1 ] || card_error "${blocklines[i-1]}" "this [chores] card has no 'item'"
+    fi
+    i=$((i + 1))
+  done
+
+  i=0
+  for rec in ${recommends[@]+"${recommends[@]}"}; do
+    i=$((i + 1))
+    recidx=${rec%%/*}
+    recval=${rec#*/}
+    local found=0 seen2
+    for seen2 in ${opts[@]+"${opts[@]}"}; do
+      [ "$seen2" = "$recidx/$recval" ] && found=1
+    done
+    [ "$found" = 1 ] || card_error "${reclines[i-1]}" "recommend names no option of this card: '$recval'"
+  done
+
+  i=0
+  for bind in ${bindvals[@]+"${bindvals[@]}"}; do
+    i=$((i + 1))
+    if ! printf '%s\n' "$DURABLE_KEYS" | grep -qxF "$bind"; then
+      printf 'fm-board: %s:%s: binds names no open decision: %s\n' "$file" "${bindlines[i-1]}" "$bind" >&2
+      if [ -n "$DURABLE_KEYS" ]; then
+        printf 'fm-board: open decisions are:\n' >&2
+        while IFS= read -r known; do
+          [ -n "$known" ] && printf '  %s\n' "$known" >&2
+        done <<EOF
+$DURABLE_KEYS
+EOF
+      else
+        printf 'fm-board: there are no open decisions right now\n' >&2
+      fi
+      exit 2
+    fi
+  done
+
+  printf '%s' "$rows"
+}
+
+if [ -n "$CARDS_FILE" ]; then
+  [ -f "$CARDS_FILE" ] || die "cards file not found: $CARDS_FILE"
+  CARDS_ROWS=$(parse_cards "$CARDS_FILE") || exit $?
+fi
+
+CARDS_JSON=$(printf '%s' "$CARDS_ROWS" | jq -R -s '
+  def rows:
+    split("\n")
+    | map(select(length > 0))
+    | map(capture("^(?<i>[0-9]+)\t(?<f>[a-z]+)\t(?<v>.*)$"));
+  def field($f): (map(select(.f == $f) | .v) | .[0]);
+  def fields($f): (map(select(.f == $f) | .v));
+  rows
+  | group_by(.i | tonumber)
+  | map({
+      type: field("type"),
+      key: field("key"),
+      binds: field("binds"),
+      title: field("title"),
+      tag: field("tag"),
+      body: fields("body"),
+      warn: fields("warn"),
+      footnote: fields("footnote"),
+      item: fields("item"),
+      recommend: field("recommend"),
+      options: (fields("option") | map({
+        value: (. | split(" | ") | .[0]),
+        label: (. | sub("^[^|]* \\| "; ""))
+      }))
+    })
+') || die "could not assemble the authored cards"
+
+# --- render -----------------------------------------------------------------
+
+REDACT_HOME=${HOME:-}
+case "$REDACT_HOME" in ''|/) REDACT_HOME="" ;; esac
+SNAPSHOT_HOME=$(printf '%s' "$SNAPSHOT" | jq -r '.fm_home // ""')
+
+# The renderer is a quoted heredoc rather than an inline argument: the emitted
+# page carries JavaScript full of single quotes, which no single-quoted shell
+# string can hold.
+RENDER=$(cat <<'JQ_RENDER'
+
+# --- text safety ------------------------------------------------------------
+# Absolute paths under the operator home are reduced before anything is escaped,
+# so no rendered string carries the account layout. split/join is a literal
+# replacement, never a pattern.
+def redact:
+  (if . == null then "" else tostring end)
+  | (if ($fmhome | length) > 0 and ($fmhome != $home) then split($fmhome) | join("~/…") else . end)
+  | (if ($home | length) > 0 then split($home) | join("~") else . end);
+
+# Snapshot-derived prose is escaped and never marked up: it was not authored as
+# markup, so an asterisk in it is an asterisk.
+def esc: redact | @html;
+
+def emphasis:
+  gsub("\\*\\*(?<t>[^*]+)\\*\\*"; "<strong>\(.t)</strong>")
+  | gsub("\\*(?<t>[^*]+)\\*"; "<em>\(.t)</em>");
+
+# Authored text takes the documented inline subset. Backticks are balanced by the
+# parser, so odd segments of the split are exactly the code spans, and emphasis
+# is never applied inside one.
+def md:
+  esc
+  | split("`")
+  | to_entries
+  | map(if (.key % 2) == 1 then "<code>" + .value + "</code>" else (.value | emphasis) end)
+  | join("");
+
+def clip($n): if (. | length) > $n then (.[0:$n] | rtrimstr(" ")) + "…" else . end;
+def basename: (. // "") | split("/") | last // "";
+def hhmm: (. // "") | (try (fromdateiso8601 | strflocaltime("%H:%M")) catch "");
+def when($iso): ($iso | hhmm) as $t | (if $t == "" then "" else "state as of " + $t end);
+
+# --- model ------------------------------------------------------------------
+
+. as $s
+| ($s.generated | (try fromdateiso8601 catch 0)) as $gen_epoch
+| [$s.tasks[]? | select(.kind != "secondmate")] as $work
+| [$s.backlog.records[]? | select(.structured)] as $records
+
+# Waiting on you, mechanical half.
+| [ $work[]
+    | . as $t
+    | (.hints.open_decisions // [])[]
+    | { kind: "decision",
+        id: "\($t.id):\(.key)",
+        task: $t.id,
+        task_title: ($t.backlog.title // $t.id),
+        project: ($t.project | basename),
+        verb: .verb,
+        summary: .summary } ] as $durable
+| [ $work[]
+    | select(.pr.url != null)
+    | { id: .id,
+        title: (.backlog.title // .id),
+        project: (.project | basename),
+        url: .pr.url,
+        state: .current_state.state } ] as $prs
+| [ $records[]
+    | select(.state == "queued" and (.captain_actionable == true or .hold_kind == "captain"))
+    | { id: .id, title: .title, reason: .hold_reason } ] as $held
+
+# Authored cards, and which durable decisions they elaborate.
+| [ $cards[] | select(.type == "decision") ] as $authored
+| [ $authored[] | select(.binds != null) | .binds ] as $bound
+| [ $durable[] | select(.id as $d | ($bound | index($d)) | not) ] as $unelaborated
+| [ $cards[] | select(.type == "chores") ] as $chores
+
+# The count that has to be honest: everything actually waiting on the operator.
+| (($authored | length) + ($unelaborated | length)
+   + (if ($prs | length) > 0 then 1 else 0 end)
+   + (if ($held | length) > 0 then 1 else 0 end)) as $waiting_count
+
+# --- fragments --------------------------------------------------------------
+
+| def option_html($card):
+    [ $card.options[]
+      | "<label class=\"opt\">"
+        + "<input type=\"radio\" name=\"\($card.key | esc)\""
+        + " data-question=\"\($card.title | esc)\" value=\"\(.value | esc)\">"
+        + "<span>\(.label | md)"
+        + (if $card.recommend == .value then " <span class=\"pill pill-primary\">my pick</span>" else "" end)
+        + "</span></label>" ] | join("");
+
+  def authored_card($c):
+    "<article class=\"card accent-primary\">"
+    + "<div class=\"card-head\"><h3>\($c.title | md)</h3>"
+    + (if $c.tag != null then "<span class=\"pill\">\($c.tag | esc)</span>" else "" end)
+    + "</div>"
+    + ([$c.body[] | "<p>\(. | md)</p>"] | join(""))
+    + ([$c.warn[] | "<p class=\"callout\">\(. | md)</p>"] | join(""))
+    + "<div class=\"opts\">\(option_html($c))</div>"
+    + ([$c.footnote[] | "<p class=\"fine\">\(. | md)</p>"] | join(""))
+    + "</article>";
+
+  def unelaborated_card($d):
+    "<article class=\"card accent-warning\">"
+    + "<div class=\"card-head\"><h3>\($d.task_title | esc | clip(90))</h3>"
+    + "<span class=\"pill\">\($d.project | esc)</span></div>"
+    + "<p class=\"fine\">Open decision <code>\($d.id | esc)</code> &middot; \($d.verb | esc)</p>"
+    + "<p>\($d.summary | esc | clip(700))</p>"
+    + "<p class=\"callout\">Not written up yet - there are no options on this card. "
+    + "Ask for it to be laid out before answering.</p>"
+    + "</article>";
+
+  def pr_card:
+    "<article class=\"card accent-info\">"
+    + "<div class=\"card-head\"><h3>Waiting for your merge</h3></div>"
+    + "<ul>"
+    + ([ $prs[]
+         | "<li><strong>\(.title | esc | clip(110))</strong> "
+           + "<span class=\"pill\">\(.project | esc)</span><br>"
+           + "<a href=\"\(.url | esc)\">\(.url | esc)</a></li>" ] | join(""))
+    + "</ul>"
+    + "<p class=\"fine\">Recorded locally. This board takes no snapshot of the forge, "
+    + "so it does not know whether one of these has already been merged.</p>"
+    + "</article>";
+
+  def held_card:
+    "<article class=\"card accent-warning\">"
+    + "<div class=\"card-head\"><h3>Held for your word</h3></div>"
+    + "<ul>"
+    + ([ $held[]
+         | "<li><strong>\(.title | esc | clip(140))</strong>"
+           + (if .reason != null then "<span class=\"sub\">\(.reason | esc | clip(160))</span>" else "" end)
+           + "</li>" ] | join(""))
+    + "</ul></article>";
+
+  def chores_card($c):
+    "<article class=\"card accent-warning\">"
+    + "<div class=\"card-head\"><h3>\(($c.title // "Only you can do these") | md)</h3></div>"
+    + "<ul>" + ([$c.item[] | "<li>\(. | md)</li>"] | join("")) + "</ul>"
+    + ([$c.footnote[] | "<p class=\"fine\">\(. | md)</p>"] | join(""))
+    + "</article>";
+
+  def state_class($st):
+    { working: "dot-working", parked: "dot-parked", blocked: "dot-blocked",
+      paused: "dot-paused", done: "dot-done", failed: "dot-failed" }[$st] // "dot-unknown";
+
+  def underway_card($t):
+    "<article class=\"card\">"
+    + "<div class=\"card-head\">"
+    + "<span class=\"dot \(state_class($t.current_state.state))\" title=\"\($t.current_state.state | esc)\"></span>"
+    + "<h3>\(($t.backlog.title // $t.id) | esc | clip(90))</h3>"
+    + "<span class=\"pill\">\(($t.project | basename) | esc)</span></div>"
+    + "<p>\($t.current_state.state | esc)"
+    + (if ($t.current_state.detail // "") != "" then " - \($t.current_state.detail | esc | clip(160))" else "" end)
+    + (if (($t.hints.open_decisions // []) | length) > 0 then " <strong>Holding for your call.</strong>" else "" end)
+    + "</p>"
+    + "<p class=\"fine age\">\(when($t.current_state.observed_at) | esc)"
+    + (if ($t.current_state.freshness // "fresh") != "fresh" then " (stale read)" else "" end)
+    + "</p></article>";
+
+  def queued_item($r):
+    # capture yields nothing when it does not match, which would drop the whole
+    # row; collecting it keeps a gateless item rendering.
+    ([($r.raw // "") | capture("hold-until: (?<d>[0-9-]+)") | .d] | .[0]) as $until
+    | "<div class=\"row\(if $r.hold_reason != null or $until != null then " dim" else "" end)\">"
+      + "<strong>\($r.title | esc | clip(200))</strong>"
+      + (if (($r.unresolved_blocker_ids // []) | length) > 0
+         then "<span class=\"sub\">waits on \(($r.unresolved_blocker_ids | join(", ")) | esc)</span>"
+         else "" end)
+      + (if $until != null
+         then "<span class=\"sub\">held until \($until | esc)</span>"
+         elif $r.hold_reason != null
+         then "<span class=\"sub\">\($r.hold_reason | esc | clip(120))</span>"
+         else "" end)
+      + (if $until != null and $r.hold_reason != null
+         then "<span class=\"sub\">\($r.hold_reason | esc | clip(120))</span>"
+         else "" end)
+      + "</div>";
+
+  def landed_item($r):
+    "<div class=\"row\"><strong>\($r.title | esc | clip(140))</strong>"
+    + (if $r.home_id != null then " <span class=\"pill\">\($r.home_id | esc)</span>" else "" end)
+    + (if $r.pr_url != null
+       then "<span class=\"sub\"><a href=\"\($r.pr_url | esc)\">\($r.pr_url | esc)</a></span>"
+       elif $r.report_path != null
+       then "<span class=\"sub\">findings recorded: \($r.report_path | esc)</span>"
+       else "" end)
+    + (if ($r.completion.verb // null) != null
+       then "<span class=\"sub\">\($r.completion.verb | esc)\(if $r.completion.date != null then " " + ($r.completion.date | esc) else "" end)</span>"
+       else "" end)
+    + "</div>";
+
+# --- page -------------------------------------------------------------------
+
+  [ $records[] | select(.state == "queued")
+    | select((.captain_actionable == true or .hold_kind == "captain") | not) ] as $queued
+| ([ $records[] | select(.state == "done") ]
+   + [ $s.secondmate_landed.records[]? ]) as $landed_all
+| ($landed_all[0:$landed]) as $landed_shown
+
+| "<!doctype html>
+<html lang=\"en\">
+<head>
+<meta charset=\"utf-8\">
+<meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">
+<title>\($title | esc)</title>
+<style>
+*,*::before,*::after{box-sizing:border-box}
+:root{
+  --bg:#eef1f6;--surface:#fff;--ink:#182030;--ink-soft:#333c4d;--muted:#5c6577;--line:#dde2ea;
+  --primary:#4553c8;--primary-soft:#eceefb;--warning:#9a6510;--warning-soft:#fdf3e2;
+  --info:#0d6f84;--info-soft:#e6f3f6;--error:#b02a1f;--ok:#2c7a4f;--shadow:0 1px 2px rgba(20,26,40,.08),0 1px 8px rgba(20,26,40,.05);
+}
+@media (prefers-color-scheme:dark){
+  :root{
+    --bg:#12161f;--surface:#1b212d;--ink:#e6e9f0;--ink-soft:#c8cedb;--muted:#9aa3b4;--line:#2a3140;
+    --primary:#8d9bff;--primary-soft:#232a49;--warning:#e0a95c;--warning-soft:#2e2718;
+    --info:#6fc7d8;--info-soft:#162b31;--error:#f08b80;--ok:#79c79b;--shadow:none;
+  }
+}
+html{-webkit-text-size-adjust:100%}
+body{margin:0;background:var(--bg);color:var(--ink);
+  font:15px/1.5 ui-sans-serif,system-ui,-apple-system,\"Segoe UI\",Roboto,Helvetica,Arial,sans-serif}
+a{color:var(--primary)}
+code{font:12.5px/1.45 ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;
+  background:var(--primary-soft);padding:.1em .35em;border-radius:4px;overflow-wrap:anywhere}
+header{position:sticky;top:0;z-index:20;background:var(--surface);border-bottom:1px solid var(--line)}
+.bar{max-width:1600px;margin:0 auto;padding:12px 20px;display:flex;flex-wrap:wrap;align-items:center;gap:12px}
+.bar h1{margin:0;font-size:17px;font-weight:600;line-height:1.2}
+.bar .meta{margin:2px 0 0;font-size:12px;color:var(--muted)}
+.age{font-variant-numeric:tabular-nums}
+.grow{flex:1;min-width:0}
+#pending{font-size:12px;color:var(--muted)}
+button{font:inherit;font-size:13px;font-weight:600;padding:7px 14px;border-radius:7px;border:1px solid transparent;
+  background:var(--primary);color:#fff;cursor:pointer}
+button[disabled]{opacity:.45;cursor:default}
+main{max-width:1600px;margin:0 auto;padding:20px;display:grid;gap:20px}
+@media (min-width:1080px){main{grid-template-columns:1.5fr 1fr 1fr}}
+section{display:flex;flex-direction:column;gap:12px;min-width:0}
+h2{margin:0;font-size:12px;font-weight:600;letter-spacing:.08em;text-transform:uppercase;color:var(--muted)}
+.head{display:flex;align-items:center;gap:8px;flex-wrap:wrap}
+.card{background:var(--surface);border-radius:10px;box-shadow:var(--shadow);padding:16px;
+  display:flex;flex-direction:column;gap:10px;min-width:0;border:1px solid var(--line)}
+.accent-primary{border-left:4px solid var(--primary)}
+.accent-warning{border-left:4px solid var(--warning)}
+.accent-info{border-left:4px solid var(--info)}
+.card-head{display:flex;align-items:flex-start;gap:8px}
+.card h3{margin:0;font-size:14px;font-weight:600;flex:1;min-width:0;overflow-wrap:anywhere}
+.card p{margin:0;font-size:14px;color:var(--ink-soft);overflow-wrap:anywhere}
+.card ul{margin:0;padding-left:18px;display:flex;flex-direction:column;gap:8px;
+  font-size:14px;color:var(--ink-soft)}
+.card li{overflow-wrap:anywhere}
+.card p.fine,p.fine{font-size:12px;color:var(--muted)}
+.card p.callout,p.callout{font-size:13px;background:var(--warning-soft);color:var(--warning);
+  padding:8px 10px;border-radius:6px}
+.pill{flex:none;font-size:11px;padding:2px 8px;border-radius:999px;background:var(--line);color:var(--muted);white-space:nowrap}
+.pill-primary{background:var(--primary-soft);color:var(--primary)}
+.count{background:var(--primary);color:#fff}
+.dot{flex:none;width:9px;height:9px;border-radius:50%;margin-top:5px;background:var(--muted)}
+.dot-working{background:var(--primary)}.dot-parked{background:var(--warning)}
+.dot-blocked{background:var(--error)}.dot-paused{background:var(--info)}
+.dot-done{background:var(--ok)}.dot-failed{background:var(--error)}
+.opts{display:flex;flex-direction:column;gap:6px}
+.opt{position:relative;display:block;border:1px solid var(--line);border-radius:7px;
+  padding:9px 11px;font-size:13.5px;cursor:pointer;overflow-wrap:anywhere}
+.opt input{position:absolute;opacity:0;pointer-events:none}
+.opt:hover{border-color:var(--primary)}
+.opt.picked{border-color:var(--primary);box-shadow:0 0 0 1px var(--primary);background:var(--primary-soft)}
+.rows{background:var(--surface);border:1px solid var(--line);border-radius:10px;box-shadow:var(--shadow);
+  padding:16px;display:flex;flex-direction:column;gap:12px;font-size:14px;min-width:0}
+.row{display:flex;flex-direction:column;gap:2px;overflow-wrap:anywhere}
+.row.dim{opacity:.6}
+.sub{font-size:12px;color:var(--muted)}
+.empty{font-size:13px;color:var(--muted)}
+.stale .meta{color:var(--warning);font-weight:600}
+.expired .meta{color:var(--error);font-weight:600}
+</style>
+</head>
+<body>
+<header id=\"top\">
+  <div class=\"bar\">
+    <div class=\"grow\">
+      <h1>\($title | esc)</h1>
+      <p class=\"meta\">as of <span class=\"age\">\($s.generated | hhmm)</span> &middot;
+        <span class=\"age\" id=\"age\">just now</span> - a snapshot, not a live feed</p>
+    </div>
+    <div id=\"pending\"></div>
+    <button id=\"send\" disabled>Send answers</button>
+  </div>
+</header>
+
+<main>
+  <section>
+    <div class=\"head\"><h2>Waiting on you</h2>" +
+    (if $waiting_count > 0
+     then "<span class=\"pill count\">\($waiting_count) \(if $waiting_count == 1 then "item" else "items" end)</span>"
+     else "" end) + "</div>" +
+    (if $waiting_count == 0 and ($chores | length) == 0
+     then "<p class=\"empty\">Nothing is waiting on you.</p>" else "" end) +
+    ([$authored[] | authored_card(.)] | join("")) +
+    ([$unelaborated[] | unelaborated_card(.)] | join("")) +
+    (if ($prs | length) > 0 then pr_card else "" end) +
+    (if ($held | length) > 0 then held_card else "" end) +
+    ([$chores[] | chores_card(.)] | join("")) +
+"  </section>
+
+  <section>
+    <h2>Under way</h2>" +
+    (if ($work | length) == 0 then "<p class=\"empty\">Nothing under way.</p>" else "" end) +
+    ([$work[] | underway_card(.)] | join("")) +
+"  </section>
+
+  <section>
+    <h2>Queued</h2>" +
+    (if ($queued | length) == 0
+     then "<p class=\"empty\">Nothing queued.</p>"
+     else "<div class=\"rows\">" + ([$queued[] | queued_item(.)] | join("")) + "</div>" end) +
+"    <h2>Landed</h2>" +
+    (if ($landed_shown | length) == 0
+     then (if ($landed_all | length) == 0
+           then "<p class=\"empty\">Nothing landed yet.</p>"
+           else "<p class=\"empty\">\($landed_all | length) landings, none shown at this setting.</p>" end)
+     else "<div class=\"rows\">" + ([$landed_shown[] | landed_item(.)] | join(""))
+          + (if ($landed_all | length) > ($landed_shown | length)
+             then "<p class=\"fine\">\(($landed_all | length) - ($landed_shown | length)) older landings not shown.</p>"
+             else "" end)
+          + "</div>" end) +
+"  </section>
+</main>
+
+<script>
+(function () {
+  var generated = \($gen_epoch) * 1000;
+  var staleMins = \($stale);
+  var answers = {};
+  var sendBtn = document.getElementById('send');
+  var pending = document.getElementById('pending');
+  var age = document.getElementById('age');
+  var hdr = document.getElementById('top');
+
+  function tick() {
+    var mins = Math.floor((Date.now() - generated) / 60000);
+    age.textContent = mins < 1 ? 'just now'
+      : mins === 1 ? '1 minute old'
+      : mins < 90 ? mins + ' minutes old'
+      : Math.round(mins / 60) + ' hours old';
+    hdr.classList.toggle('stale', mins >= staleMins && mins < staleMins * 2);
+    hdr.classList.toggle('expired', mins >= staleMins * 2);
+    if (mins >= staleMins * 2) {
+      age.textContent += ' - too old to trust, ask for a fresh board';
+    } else if (mins >= staleMins) {
+      age.textContent += ' - going stale';
+    }
+  }
+  tick();
+  setInterval(tick, 20000);
+
+  function refresh() {
+    var n = Object.keys(answers).length;
+    sendBtn.disabled = n === 0;
+    sendBtn.textContent = 'Send answers';
+    pending.textContent = n === 0 ? '' : (n === 1 ? '1 answer ready' : n + ' answers ready');
+  }
+
+  Array.prototype.forEach.call(document.querySelectorAll('.opt input[type=radio]'), function (input) {
+    input.addEventListener('change', function () {
+      var label = input.closest('.opt');
+      Array.prototype.forEach.call(
+        document.querySelectorAll('.opt input[name=\"' + input.name + '\"]'),
+        function (sib) { sib.closest('.opt').classList.remove('picked'); });
+      label.classList.add('picked');
+      answers[input.name] = { question: input.getAttribute('data-question') || input.name, answer: input.value };
+      refresh();
+    });
+  });
+
+  sendBtn.addEventListener('click', function () {
+    var keys = Object.keys(answers);
+    if (!keys.length) return;
+    var lines = keys.map(function (k) { return k + ' (' + answers[k].question + '): ' + answers[k].answer; });
+    var text = lines.join(' | ');
+    var payload = { tag: 'board-answers', text: text, data: { answers: JSON.parse(JSON.stringify(answers)) } };
+    if (window.lavish && typeof window.lavish.queuePrompt === 'function') {
+      window.lavish.queuePrompt('Answers from the board - ' + text, payload);
+      window.lavish.sendQueuedPrompts();
+      pending.textContent = 'on its way';
+    } else {
+      pending.textContent = 'no review session attached - answers copied instead';
+      if (navigator.clipboard) { navigator.clipboard.writeText(text).catch(function () {}); }
+      return;
+    }
+    keys.forEach(function (k) { delete answers[k]; });
+    Array.prototype.forEach.call(document.querySelectorAll('.opt input[type=radio]:checked'), function (i) {
+      i.checked = false;
+      i.closest('.opt').classList.remove('picked');
+    });
+    Array.prototype.forEach.call(document.querySelectorAll('.opt.picked'), function (l) { l.classList.remove('picked'); });
+    sendBtn.disabled = true;
+    sendBtn.textContent = 'Sent - ready for more';
+  });
+
+  refresh();
+})();
+</script>
+</body>
+</html>
+"
+JQ_RENDER
+)
+
+HTML=$(printf '%s' "$SNAPSHOT" | jq -r \
+  --argjson cards "$CARDS_JSON" \
+  --arg title "$TITLE" \
+  --argjson landed "$LANDED" \
+  --argjson stale "$STALE_MINS" \
+  --arg home "$REDACT_HOME" \
+  --arg fmhome "$SNAPSHOT_HOME" \
+  "$RENDER") || die "rendering the board failed"
+
+# --- write ------------------------------------------------------------------
+
+OUT_DIR=$(dirname "$OUT")
+mkdir -p "$OUT_DIR" || die "cannot create the artifact directory: $OUT_DIR"
+
+TMP="$OUT.tmp.$$"
+printf '%s\n' "$HTML" > "$TMP" || { rm -f "$TMP"; die "cannot write: $TMP"; }
+
+# The last guard on the leak boundary: redaction runs per field, so a field that
+# escaped it must never reach the operator's screen or a shared link.
+if [ -n "$REDACT_HOME" ] && grep -qF -- "$REDACT_HOME" "$TMP"; then
+  rm -f "$TMP"
+  die "refusing to write the board: a home path survived redaction"
+fi
+
+mv -f "$TMP" "$OUT" || { rm -f "$TMP"; die "cannot write: $OUT"; }
+printf '%s\n' "$OUT"

--- a/bin/fm-board.sh
+++ b/bin/fm-board.sh
@@ -768,7 +768,8 @@ h2{margin:0;font-size:12px;font-weight:600;letter-spacing:.08em;text-transform:u
   padding:16px;display:flex;flex-direction:column;gap:12px;font-size:14px;min-width:0}
 .row{display:flex;flex-direction:column;gap:2px;overflow-wrap:anywhere}
 .row.dim{opacity:.6}
-.sub{font-size:12px;color:var(--muted)}
+/* block, not inline: a .sub in a list item would otherwise weld onto its title */
+.sub{display:block;font-size:12px;color:var(--muted)}
 .empty{font-size:13px;color:var(--muted)}
 .stale .meta{color:var(--warning);font-weight:600}
 .expired .meta{color:var(--error);font-weight:600}

--- a/bin/fm-board.sh
+++ b/bin/fm-board.sh
@@ -21,7 +21,9 @@
 #               landings rolled up from delegated homes.
 #   Waiting on you, the mechanical half: work with a locally recorded pull request,
 #               captain-held queued items, and every unresolved decision key folded
-#               out of the durable status logs.
+#               out of the durable status logs, here and in every delegated home.
+#               A delegated home the snapshot could not read whole is named rather
+#               than reported as holding nothing.
 #
 # The script does NOT derive the judgment half.
 # Option lists, recommendations, the reasoning for preferring one option, and the
@@ -83,7 +85,9 @@ BOARD CARDS
     warn: Three rounds on one theme.
                                    repeatable; renders as a callout
     option: ship | **Ship it** - one paragraph recording a measured fact
-                                   repeatable, at least one; `<value> | <label>`
+                                   repeatable, at least one; `<value> | <label>`,
+                                   where the value is a slug and the label is
+                                   everything after the first ' | '
     recommend: ship                optional; must name one of this card's options
     footnote: Why not the other one today ...
                                    repeatable; small print under the options
@@ -100,9 +104,10 @@ BOARD CARDS
   can never inject markup of its own. Backticks must be balanced.
 
   The file is validated as a whole before anything is written: an unknown field,
-  a card missing a required field, a duplicate key, a recommendation that names
-  no option, or a `binds` naming a decision the durable logs do not have all
-  refuse the render rather than producing a partial board.
+  a card missing a required field, a duplicate key, an option value that is not a
+  slug, a recommendation that names no option, or a `binds` naming a decision the
+  durable logs do not have all refuse the render rather than producing a partial
+  board. A decision open in a delegated home is bound as <home>/<task-id>:<key>.
 EOF
 }
 
@@ -119,10 +124,20 @@ STALE_MINS=30
 require_value() {  # <flag> <count>
   [ "$2" -gt 1 ] || usage_error "$1 requires a value"
 }
+# Counts reach jq as --argjson, where a leading zero is not valid JSON, so the
+# canonical form is settled here where a complaint can still name the flag.
+COUNT_VALUE=0
 require_count() {  # <flag> <value>
   case "$2" in
     ''|*[!0-9]*) usage_error "$1 must be a non-negative integer" ;;
   esac
+  COUNT_VALUE=$2
+  while [ "${#COUNT_VALUE}" -gt 1 ]; do
+    case "$COUNT_VALUE" in
+      0*) COUNT_VALUE=${COUNT_VALUE#0} ;;
+      *) break ;;
+    esac
+  done
 }
 
 while [ "$#" -gt 0 ]; do
@@ -130,12 +145,14 @@ while [ "$#" -gt 0 ]; do
     --cards) require_value --cards "$#"; CARDS_FILE=$2; shift 2 ;;
     --out) require_value --out "$#"; OUT=$2; shift 2 ;;
     --snapshot) require_value --snapshot "$#"; SNAPSHOT_FILE=$2; shift 2 ;;
-    --landed) require_value --landed "$#"; require_count --landed "$2"; LANDED=$2; shift 2 ;;
+    --landed) require_value --landed "$#"; require_count --landed "$2"; LANDED=$COUNT_VALUE; shift 2 ;;
     --title) require_value --title "$#"; TITLE=$2; shift 2 ;;
     --stale-mins)
       require_value --stale-mins "$#"
-      case "$2" in ''|*[!0-9]*|0) usage_error "--stale-mins must be a positive integer" ;; esac
-      STALE_MINS=$2; shift 2 ;;
+      case "$2" in ''|*[!0-9]*) usage_error "--stale-mins must be a positive integer" ;; esac
+      require_count --stale-mins "$2"
+      [ "$COUNT_VALUE" != 0 ] || usage_error "--stale-mins must be a positive integer"
+      STALE_MINS=$COUNT_VALUE; shift 2 ;;
     -h|--help) usage; exit 0 ;;
     *) usage_error "unknown option: $1" ;;
   esac
@@ -160,10 +177,19 @@ else
   SNAPSHOT=$("$SCRIPT_DIR/fm-fleet-snapshot.sh" --json) || die "fleet snapshot failed"
 fi
 
-# Every durable open decision, as the <task-id>:<key> identifiers an authored
-# card may bind to. Also the validation domain for a card's `binds` field.
-DURABLE_KEYS=$(printf '%s' "$SNAPSHOT" \
-  | jq -r '[.tasks[]? | . as $t | (.hints.open_decisions // [])[] | "\($t.id):\(.key)"] | .[]')
+# Every durable open decision, as the identifiers an authored card may bind to,
+# and the validation domain for a card's `binds` field. A decision held in a
+# delegated home is namespaced by that home so the two sets cannot collide; the
+# renderer folds both into the same column off the same identity.
+DURABLE_KEYS=$(printf '%s' "$SNAPSHOT" | jq -r '
+  ([ .tasks[]? | select(.kind != "secondmate") | . as $t
+     | (.hints.open_decisions // [])[]? | select(.key != null)
+     | "\($t.id):\(.key)" ]
+   + [ .secondmate_current.records[]? | . as $m
+       | (if ((.decisions_open // []) | type) == "array" then .decisions_open else [] end)[]
+       | select(type == "object" and .id != null and .key != null)
+       | "\($m.id)/\(.id):\(.key)" ])
+  | unique | .[]')
 
 # --- authored cards ---------------------------------------------------------
 #
@@ -176,7 +202,7 @@ CARDS_ROWS=""
 parse_cards() {  # <file>
   local file=$1 line lineno=0 idx=0 field value type="" rows="" known
   local -a keys=() opts=() recommends=() reclines=() bindvals=() bindlines=()
-  local -a have_title=() have_option=() have_item=() have_key=() blocklines=()
+  local -a have_title=() have_option=() have_item=() have_key=() blocklines=() types=()
 
   card_error() { printf 'fm-board: %s:%s: %s\n' "$file" "$1" "$2" >&2; exit 2; }
 
@@ -194,7 +220,7 @@ parse_cards() {  # <file>
         esac
         idx=$((idx + 1))
         keys+=("") ; have_title+=(0) ; have_option+=(0) ; have_item+=(0) ; have_key+=(0)
-        blocklines+=("$lineno")
+        blocklines+=("$lineno") ; types+=("$type")
         rows+="$idx"$'\t'"type"$'\t'"$type"$'\n'
         continue
         ;;
@@ -266,6 +292,11 @@ parse_cards() {  # <file>
         optlabel=${value#* | }
         [ -n "$optval" ] || card_error "$lineno" "option has an empty value"
         [ -n "$optlabel" ] || card_error "$lineno" "option has an empty label"
+        # The value is an identifier that has to survive into the answer payload
+        # unchanged, so it is held to the same slug shape as a card key.
+        case "$optval" in
+          *[!A-Za-z0-9._-]*|-*|.*) card_error "$lineno" "option value must be a slug of letters, digits, '.', '_' or '-': '$optval'" ;;
+        esac
         for seen in ${opts[@]+"${opts[@]}"}; do
           [ "$seen" = "$idx/$optval" ] && card_error "$lineno" "duplicate option value in one card: '$optval'"
         done
@@ -292,7 +323,7 @@ parse_cards() {  # <file>
   n=$idx
   i=1
   while [ "$i" -le "$n" ]; do
-    if printf '%s' "$rows" | grep -qxF "$i	type	decision"; then
+    if [ "${types[i-1]}" = decision ]; then
       [ "${have_key[i-1]}" = 1 ] || card_error "${blocklines[i-1]}" "this [decision] is missing a 'key'"
       [ "${have_title[i-1]}" = 1 ] || card_error "${blocklines[i-1]}" "[decision] ${keys[i-1]} is missing a 'title'"
       [ "${have_option[i-1]}" = 1 ] || card_error "${blocklines[i-1]}" "[decision] ${keys[i-1]} has no 'option'"
@@ -361,10 +392,10 @@ CARDS_JSON=$(printf '%s' "$CARDS_ROWS" | jq -R -s '
       footnote: fields("footnote"),
       item: fields("item"),
       recommend: field("recommend"),
-      options: (fields("option") | map({
-        value: (. | split(" | ") | .[0]),
-        label: (. | sub("^[^|]* \\| "; ""))
-      }))
+      options: (fields("option") | map(
+        split(" | ")
+        | { value: .[0], label: (.[1:] | join(" | ")) }
+      ))
     })
 ') || die "could not assemble the authored cards"
 
@@ -373,6 +404,14 @@ CARDS_JSON=$(printf '%s' "$CARDS_ROWS" | jq -R -s '
 REDACT_HOME=${HOME:-}
 case "$REDACT_HOME" in ''|/) REDACT_HOME="" ;; esac
 SNAPSHOT_HOME=$(printf '%s' "$SNAPSHOT" | jq -r '.fm_home // ""')
+case "$SNAPSHOT_HOME" in /) SNAPSHOT_HOME="" ;; esac
+
+# The board now reads delegated state, so a delegated home's path is on the same
+# leak boundary as the operator's own: reduced per field, and refused if it
+# survives.
+MATE_HOMES=$(printf '%s' "$SNAPSHOT" | jq -c '
+  ([ .secondmate_current.records[]? | .home ] + [ .secondmate_landed.records[]? | .home ])
+  | map(select(type == "string" and . != "" and . != "/")) | unique')
 
 # The renderer is a quoted heredoc rather than an inline argument: the emitted
 # page carries JavaScript full of single quotes, which no single-quoted shell
@@ -385,6 +424,7 @@ RENDER=$(cat <<'JQ_RENDER'
 # replacement, never a pattern.
 def redact:
   (if . == null then "" else tostring end)
+  | reduce $mates[] as $m (.; split($m) | join("~/…"))
   | (if ($fmhome | length) > 0 and ($fmhome != $home) then split($fmhome) | join("~/…") else . end)
   | (if ($home | length) > 0 then split($home) | join("~") else . end);
 
@@ -407,6 +447,12 @@ def md:
   | join("");
 
 def clip($n): if (. | length) > $n then (.[0:$n] | rtrimstr(" ")) + "…" else . end;
+
+# Bounded snapshot prose. The cut lands after redaction and before escaping, so
+# it can neither split an entity nor spend the budget on escape expansion, and a
+# home path can never be cut into a fragment the leak guard would not recognise.
+def escn($n): redact | clip($n) | @html;
+
 def basename: (. // "") | split("/") | last // "";
 def hhmm: (. // "") | (try (fromdateiso8601 | strflocaltime("%H:%M")) catch "");
 def when($iso): ($iso | hhmm) as $t | (if $t == "" then "" else "state as of " + $t end);
@@ -419,16 +465,46 @@ def when($iso): ($iso | hhmm) as $t | (if $t == "" then "" else "state as of " +
 | [$s.backlog.records[]? | select(.structured)] as $records
 
 # Waiting on you, mechanical half.
-| [ $work[]
+#
+# A decision held in a delegated home is a pending decision like any other, and
+# the board already reaches into delegated state for its landings, so the two
+# sources are folded into one list off one identity. A delegated entry carries
+# the home it came from; a main-home entry carries no home.
+| ( [ $work[]
     | . as $t
     | (.hints.open_decisions // [])[]
     | { kind: "decision",
         id: "\($t.id):\(.key)",
+        home: null,
         task: $t.id,
         task_title: ($t.backlog.title // $t.id),
         project: ($t.project | basename),
         verb: .verb,
-        summary: .summary } ] as $durable
+        summary: .summary } ]
+  + [ $s.secondmate_current.records[]?
+      | . as $m
+      | (if ((.decisions_open // []) | type) == "array" then .decisions_open else [] end)[]
+      | select(type == "object" and .id != null and .key != null)
+      | { kind: "decision",
+          id: "\($m.id)/\(.id):\(.key)",
+          home: $m.id,
+          task: .id,
+          task_title: ((.summary // .key) | tostring),
+          project: ($m.id | tostring),
+          verb: (.verb // "needs-decision"),
+          summary: ((.reason // "") | tostring) } ] ) as $durable
+
+# A delegated home the snapshot could not read whole cannot be reported as
+# holding no decisions, so what was not read is stated rather than assumed.
+| ( [ $s.secondmate_current.records[]?
+    | select((.provenance.selected // "") != "structured-home")
+    | { id: (.id | tostring), reason: ((.current.reason // "state unavailable") | tostring) } ]
+  + [ $s.secondmate_current.records[]?
+      | . as $m
+      | (if ((.omitted // []) | type) == "array" then .omitted else [] end)[]
+      | select(type == "object" and .surface == "decisions_open")
+      | { id: ($m.id | tostring),
+          reason: "\(.count) more open decisions than this snapshot carries" } ] ) as $unread_homes
 | [ $work[]
     | select(.pr.url != null)
     | { id: .id,
@@ -446,18 +522,15 @@ def when($iso): ($iso | hhmm) as $t | (if $t == "" then "" else "state as of " +
 | [ $durable[] | select(.id as $d | ($bound | index($d)) | not) ] as $unelaborated
 | [ $cards[] | select(.type == "chores") ] as $chores
 
-# The count that has to be honest: everything actually waiting on the operator.
-| (($authored | length) + ($unelaborated | length)
-   + (if ($prs | length) > 0 then 1 else 0 end)
-   + (if ($held | length) > 0 then 1 else 0 end)) as $waiting_count
-
 # --- fragments --------------------------------------------------------------
 
 | def option_html($card):
     [ $card.options[]
       | "<label class=\"opt\">"
         + "<input type=\"radio\" name=\"\($card.key | esc)\""
-        + " data-question=\"\($card.title | esc)\" value=\"\(.value | esc)\">"
+        + " data-question=\"\($card.title | esc)\""
+        + (if $card.binds != null then " data-binds=\"\($card.binds | esc)\"" else "" end)
+        + " value=\"\(.value | esc)\">"
         + "<span>\(.label | md)"
         + (if $card.recommend == .value then " <span class=\"pill pill-primary\">my pick</span>" else "" end)
         + "</span></label>" ] | join("");
@@ -475,12 +548,26 @@ def when($iso): ($iso | hhmm) as $t | (if $t == "" then "" else "state as of " +
 
   def unelaborated_card($d):
     "<article class=\"card accent-warning\">"
-    + "<div class=\"card-head\"><h3>\($d.task_title | esc | clip(90))</h3>"
+    + "<div class=\"card-head\"><h3>\($d.task_title | escn(90))</h3>"
     + "<span class=\"pill\">\($d.project | esc)</span></div>"
-    + "<p class=\"fine\">Open decision <code>\($d.id | esc)</code> &middot; \($d.verb | esc)</p>"
-    + "<p>\($d.summary | esc | clip(700))</p>"
+    + "<p class=\"fine\">Open decision <code>\($d.id | esc)</code> &middot; \($d.verb | esc)"
+    + (if $d.home != null then " &middot; held in delegated home \($d.home | esc)" else "" end)
+    + "</p>"
+    + (if ($d.summary // "") != "" then "<p>\($d.summary | escn(700))</p>" else "" end)
     + "<p class=\"callout\">Not written up yet - there are no options on this card. "
     + "Ask for it to be laid out before answering.</p>"
+    + "</article>";
+
+  def unread_homes_card:
+    "<article class=\"card accent-warning\">"
+    + "<div class=\"card-head\"><h3>Delegated homes this snapshot could not read whole</h3></div>"
+    + "<ul>"
+    + ([ $unread_homes[]
+         | "<li><strong>\(.id | escn(120))</strong>"
+           + "<span class=\"sub\">\(.reason | escn(160))</span></li>" ] | join(""))
+    + "</ul>"
+    + "<p class=\"fine\">These homes are not being reported as holding nothing. "
+    + "Ask for a fresh board once they read cleanly.</p>"
     + "</article>";
 
   def pr_card:
@@ -488,7 +575,7 @@ def when($iso): ($iso | hhmm) as $t | (if $t == "" then "" else "state as of " +
     + "<div class=\"card-head\"><h3>Waiting for your merge</h3></div>"
     + "<ul>"
     + ([ $prs[]
-         | "<li><strong>\(.title | esc | clip(110))</strong> "
+         | "<li><strong>\(.title | escn(110))</strong> "
            + "<span class=\"pill\">\(.project | esc)</span><br>"
            + "<a href=\"\(.url | esc)\">\(.url | esc)</a></li>" ] | join(""))
     + "</ul>"
@@ -501,8 +588,8 @@ def when($iso): ($iso | hhmm) as $t | (if $t == "" then "" else "state as of " +
     + "<div class=\"card-head\"><h3>Held for your word</h3></div>"
     + "<ul>"
     + ([ $held[]
-         | "<li><strong>\(.title | esc | clip(140))</strong>"
-           + (if .reason != null then "<span class=\"sub\">\(.reason | esc | clip(160))</span>" else "" end)
+         | "<li><strong>\(.title | escn(140))</strong>"
+           + (if .reason != null then "<span class=\"sub\">\(.reason | escn(160))</span>" else "" end)
            + "</li>" ] | join(""))
     + "</ul></article>";
 
@@ -521,10 +608,10 @@ def when($iso): ($iso | hhmm) as $t | (if $t == "" then "" else "state as of " +
     "<article class=\"card\">"
     + "<div class=\"card-head\">"
     + "<span class=\"dot \(state_class($t.current_state.state))\" title=\"\($t.current_state.state | esc)\"></span>"
-    + "<h3>\(($t.backlog.title // $t.id) | esc | clip(90))</h3>"
+    + "<h3>\(($t.backlog.title // $t.id) | escn(90))</h3>"
     + "<span class=\"pill\">\(($t.project | basename) | esc)</span></div>"
     + "<p>\($t.current_state.state | esc)"
-    + (if ($t.current_state.detail // "") != "" then " - \($t.current_state.detail | esc | clip(160))" else "" end)
+    + (if ($t.current_state.detail // "") != "" then " - \($t.current_state.detail | escn(160))" else "" end)
     + (if (($t.hints.open_decisions // []) | length) > 0 then " <strong>Holding for your call.</strong>" else "" end)
     + "</p>"
     + "<p class=\"fine age\">\(when($t.current_state.observed_at) | esc)"
@@ -536,22 +623,20 @@ def when($iso): ($iso | hhmm) as $t | (if $t == "" then "" else "state as of " +
     # row; collecting it keeps a gateless item rendering.
     ([($r.raw // "") | capture("hold-until: (?<d>[0-9-]+)") | .d] | .[0]) as $until
     | "<div class=\"row\(if $r.hold_reason != null or $until != null then " dim" else "" end)\">"
-      + "<strong>\($r.title | esc | clip(200))</strong>"
+      + "<strong>\($r.title | escn(200))</strong>"
       + (if (($r.unresolved_blocker_ids // []) | length) > 0
          then "<span class=\"sub\">waits on \(($r.unresolved_blocker_ids | join(", ")) | esc)</span>"
          else "" end)
       + (if $until != null
          then "<span class=\"sub\">held until \($until | esc)</span>"
-         elif $r.hold_reason != null
-         then "<span class=\"sub\">\($r.hold_reason | esc | clip(120))</span>"
          else "" end)
-      + (if $until != null and $r.hold_reason != null
-         then "<span class=\"sub\">\($r.hold_reason | esc | clip(120))</span>"
+      + (if $r.hold_reason != null
+         then "<span class=\"sub\">\($r.hold_reason | escn(120))</span>"
          else "" end)
       + "</div>";
 
   def landed_item($r):
-    "<div class=\"row\"><strong>\($r.title | esc | clip(140))</strong>"
+    "<div class=\"row\"><strong>\($r.title | escn(140))</strong>"
     + (if $r.home_id != null then " <span class=\"pill\">\($r.home_id | esc)</span>" else "" end)
     + (if $r.pr_url != null
        then "<span class=\"sub\"><a href=\"\($r.pr_url | esc)\">\($r.pr_url | esc)</a></span>"
@@ -567,9 +652,29 @@ def when($iso): ($iso | hhmm) as $t | (if $t == "" then "" else "state as of " +
 
   [ $records[] | select(.state == "queued")
     | select((.captain_actionable == true or .hold_kind == "captain") | not) ] as $queued
+
+# The two landed sources arrive ordered differently - the main backlog in file
+# order, a delegated home already newest-first - so the union is put on one
+# deterministic key before it is bounded. Otherwise the bound is a cut through
+# file order and a recent delegated landing falls past it.
 | ([ $records[] | select(.state == "done") ]
-   + [ $s.secondmate_landed.records[]? ]) as $landed_all
+   + [ $s.secondmate_landed.records[]? ]
+   | sort_by([((.completion.date // "") | tostring), ((.id // "") | tostring)])
+   | reverse) as $landed_all
 | ($landed_all[0:$landed]) as $landed_shown
+
+# The Waiting-on-you column, cards and count from one list. The count is what is
+# actually waiting - each authored decision, each unelaborated one, each chore -
+# and the empty state is read off the rendered cards, so it cannot claim nothing
+# is waiting while a card sits under it.
+| ( [ $authored[] | { html: authored_card(.), n: 1 } ]
+  + [ $unelaborated[] | { html: unelaborated_card(.), n: 1 } ]
+  + (if ($prs | length) > 0 then [ { html: pr_card, n: 1 } ] else [] end)
+  + (if ($held | length) > 0 then [ { html: held_card, n: 1 } ] else [] end)
+  + (if ($unread_homes | length) > 0 then [ { html: unread_homes_card, n: 1 } ] else [] end)
+  + [ $chores[] | { html: chores_card(.), n: (.item | length) } ] ) as $waiting
+| ($waiting | map(.html) | join("")) as $waiting_html
+| ($waiting | map(.n) | add // 0) as $waiting_count
 
 | "<!doctype html>
 <html lang=\"en\">
@@ -668,13 +773,9 @@ h2{margin:0;font-size:12px;font-weight:600;letter-spacing:.08em;text-transform:u
     (if $waiting_count > 0
      then "<span class=\"pill count\">\($waiting_count) \(if $waiting_count == 1 then "item" else "items" end)</span>"
      else "" end) + "</div>" +
-    (if $waiting_count == 0 and ($chores | length) == 0
+    (if ($waiting | length) == 0
      then "<p class=\"empty\">Nothing is waiting on you.</p>" else "" end) +
-    ([$authored[] | authored_card(.)] | join("")) +
-    ([$unelaborated[] | unelaborated_card(.)] | join("")) +
-    (if ($prs | length) > 0 then pr_card else "" end) +
-    (if ($held | length) > 0 then held_card else "" end) +
-    ([$chores[] | chores_card(.)] | join("")) +
+    $waiting_html +
 "  </section>
 
   <section>
@@ -742,7 +843,11 @@ h2{margin:0;font-size:12px;font-weight:600;letter-spacing:.08em;text-transform:u
         document.querySelectorAll('.opt input[name=\"' + input.name + '\"]'),
         function (sib) { sib.closest('.opt').classList.remove('picked'); });
       label.classList.add('picked');
-      answers[input.name] = { question: input.getAttribute('data-question') || input.name, answer: input.value };
+      answers[input.name] = {
+        question: input.getAttribute('data-question') || input.name,
+        binds: input.getAttribute('data-binds') || null,
+        answer: input.value
+      };
       refresh();
     });
   });
@@ -750,11 +855,16 @@ h2{margin:0;font-size:12px;font-weight:600;letter-spacing:.08em;text-transform:u
   sendBtn.addEventListener('click', function () {
     var keys = Object.keys(answers);
     if (!keys.length) return;
-    var lines = keys.map(function (k) { return k + ' (' + answers[k].question + '): ' + answers[k].answer; });
-    var text = lines.join(' | ');
+    // One answer per line: a separator an answer can contain would make the
+    // prompt ambiguous, and an ambiguous answer is worse than none.
+    var lines = keys.map(function (k) {
+      var a = answers[k];
+      return k + (a.binds ? ' [' + a.binds + ']' : '') + ' (' + a.question + '): ' + a.answer;
+    });
+    var text = lines.join('\\n');
     var payload = { tag: 'board-answers', text: text, data: { answers: JSON.parse(JSON.stringify(answers)) } };
     if (window.lavish && typeof window.lavish.queuePrompt === 'function') {
-      window.lavish.queuePrompt('Answers from the board - ' + text, payload);
+      window.lavish.queuePrompt('Answers from the board:\\n' + text, payload);
       window.lavish.sendQueuedPrompts();
       pending.textContent = 'on its way';
     } else {
@@ -788,6 +898,7 @@ HTML=$(printf '%s' "$SNAPSHOT" | jq -r \
   --argjson stale "$STALE_MINS" \
   --arg home "$REDACT_HOME" \
   --arg fmhome "$SNAPSHOT_HOME" \
+  --argjson mates "$MATE_HOMES" \
   "$RENDER") || die "rendering the board failed"
 
 # --- write ------------------------------------------------------------------
@@ -799,11 +910,20 @@ TMP="$OUT.tmp.$$"
 printf '%s\n' "$HTML" > "$TMP" || { rm -f "$TMP"; die "cannot write: $TMP"; }
 
 # The last guard on the leak boundary: redaction runs per field, so a field that
-# escaped it must never reach the operator's screen or a shared link.
-if [ -n "$REDACT_HOME" ] && grep -qF -- "$REDACT_HOME" "$TMP"; then
-  rm -f "$TMP"
-  die "refusing to write the board: a home path survived redaction"
-fi
+# escaped it must never reach the operator's screen or a shared link. Every home
+# the render touched is checked, not just the account home: FM_HOME can sit
+# outside it, and a delegated home can sit outside both.
+while IFS= read -r guarded; do
+  [ -n "$guarded" ] || continue
+  if grep -qF -- "$guarded" "$TMP"; then
+    rm -f "$TMP"
+    die "refusing to write the board: a home path survived redaction"
+  fi
+done <<EOF
+$REDACT_HOME
+$SNAPSHOT_HOME
+$(printf '%s' "$MATE_HOMES" | jq -r '.[]')
+EOF
 
 mv -f "$TMP" "$OUT" || { rm -f "$TMP"; die "cannot write: $OUT"; }
 printf '%s\n' "$OUT"

--- a/bin/fm-board.sh
+++ b/bin/fm-board.sh
@@ -478,6 +478,13 @@ def when($iso): ($iso | hhmm) as $t | (if $t == "" then "" else "state as of " +
 # the board already reaches into delegated state for its landings, so the two
 # sources are folded into one list off one identity. A delegated entry carries
 # the home it came from; a main-home entry carries no home.
+# A delegated entry's `summary` carries two different things depending on how the
+# snapshot built it, so which slot it belongs in is read off the entry's own kind
+# rather than guessed from the text. A captain hold carries the item title in
+# `summary` and the hold reason in `reason`; a status decision carries the
+# decision text in `summary` and no reason. Either way the heading names the work
+# and the body carries what is actually being decided, so no card says the same
+# thing twice and nothing the snapshot carried is dropped.
 | ( [ $work[]
     | . as $t
     | ((.hints.open_decisions // []) | if type == "array" then . else [] end)[]
@@ -489,21 +496,21 @@ def when($iso): ($iso | hhmm) as $t | (if $t == "" then "" else "state as of " +
         task_title: ($t.backlog.title // $t.id),
         project: ($t.project | basename),
         verb: .verb,
-        summary: .summary,
-        reason: null } ]
+        summary: .summary } ]
   + [ $s.secondmate_current.records[]?
       | . as $m
       | ((.decisions_open // []) | if type == "array" then . else [] end)[]
       | select(type == "object" and .id != null and .key != null)
+      | . as $e
+      | (($e.source // "") == "backlog" or ($e.verb // "") == "captain-hold") as $held
       | { kind: "decision",
-          id: "\($m.id)/\(.id):\(.key)",
+          id: "\($m.id)/\($e.id):\($e.key)",
           home: $m.id,
-          task: .id,
-          task_title: ((.summary // .key) | tostring),
+          task: $e.id,
+          task_title: (if $held then (($e.summary // $e.id) | tostring) else ($e.id | tostring) end),
           project: ($m.id | tostring),
-          verb: (.verb // "needs-decision"),
-          summary: ((.summary // "") | tostring),
-          reason: (if (.reason // "") == "" then null else (.reason | tostring) end) } ] ) as $durable
+          verb: ($e.verb // "needs-decision"),
+          summary: (if $held then (($e.reason // "") | tostring) else (($e.summary // "") | tostring) end) } ] ) as $durable
 
 # A delegated home the snapshot could not read whole cannot be reported as
 # holding no decisions, so what was not read is stated rather than assumed.
@@ -565,7 +572,6 @@ def when($iso): ($iso | hhmm) as $t | (if $t == "" then "" else "state as of " +
     + (if $d.home != null then " &middot; held in delegated home \($d.home | esc)" else "" end)
     + "</p>"
     + (if ($d.summary // "") != "" then "<p>\($d.summary | escn(700))</p>" else "" end)
-    + (if ($d.reason // "") != "" then "<p>\($d.reason | escn(700))</p>" else "" end)
     + "<p class=\"callout\">Not written up yet - there are no options on this card. "
     + "Ask for it to be laid out before answering.</p>"
     + "</article>";

--- a/bin/fm-board.sh
+++ b/bin/fm-board.sh
@@ -181,15 +181,21 @@ fi
 # and the validation domain for a card's `binds` field. A decision held in a
 # delegated home is namespaced by that home so the two sets cannot collide; the
 # renderer folds both into the same column off the same identity.
+# This read decides what an authored `binds` may name, so it must never fail
+# quietly: an empty domain would turn a genuinely open decision into the refusal
+# "there are no open decisions right now", which is the silence the board exists
+# to prevent, arriving through the error path.
 DURABLE_KEYS=$(printf '%s' "$SNAPSHOT" | jq -r '
   ([ .tasks[]? | select(.kind != "secondmate") | . as $t
-     | (.hints.open_decisions // [])[]? | select(.key != null)
+     | ((.hints.open_decisions // []) | if type == "array" then . else [] end)[]
+     | select(type == "object" and .key != null)
      | "\($t.id):\(.key)" ]
    + [ .secondmate_current.records[]? | . as $m
-       | (if ((.decisions_open // []) | type) == "array" then .decisions_open else [] end)[]
+       | ((.decisions_open // []) | if type == "array" then . else [] end)[]
        | select(type == "object" and .id != null and .key != null)
        | "\($m.id)/\(.id):\(.key)" ])
-  | unique | .[]')
+  | unique | .[]') \
+  || die "could not read the open decisions this snapshot holds, so a card's 'binds' cannot be checked against them"
 
 # --- authored cards ---------------------------------------------------------
 #
@@ -403,7 +409,8 @@ CARDS_JSON=$(printf '%s' "$CARDS_ROWS" | jq -R -s '
 
 REDACT_HOME=${HOME:-}
 case "$REDACT_HOME" in ''|/) REDACT_HOME="" ;; esac
-SNAPSHOT_HOME=$(printf '%s' "$SNAPSHOT" | jq -r '.fm_home // ""')
+SNAPSHOT_HOME=$(printf '%s' "$SNAPSHOT" | jq -r '.fm_home // ""') \
+  || die "could not read the snapshot's own home path, so the leak boundary cannot be enforced"
 case "$SNAPSHOT_HOME" in /) SNAPSHOT_HOME="" ;; esac
 
 # The board now reads delegated state, so a delegated home's path is on the same
@@ -411,7 +418,8 @@ case "$SNAPSHOT_HOME" in /) SNAPSHOT_HOME="" ;; esac
 # survives.
 MATE_HOMES=$(printf '%s' "$SNAPSHOT" | jq -c '
   ([ .secondmate_current.records[]? | .home ] + [ .secondmate_landed.records[]? | .home ])
-  | map(select(type == "string" and . != "" and . != "/")) | unique')
+  | map(select(type == "string" and . != "" and . != "/")) | unique') \
+  || die "could not read the delegated home paths, so the leak boundary cannot be enforced"
 
 # The renderer is a quoted heredoc rather than an inline argument: the emitted
 # page carries JavaScript full of single quotes, which no single-quoted shell
@@ -472,7 +480,8 @@ def when($iso): ($iso | hhmm) as $t | (if $t == "" then "" else "state as of " +
 # the home it came from; a main-home entry carries no home.
 | ( [ $work[]
     | . as $t
-    | (.hints.open_decisions // [])[]
+    | ((.hints.open_decisions // []) | if type == "array" then . else [] end)[]
+    | select(type == "object")
     | { kind: "decision",
         id: "\($t.id):\(.key)",
         home: null,
@@ -480,10 +489,11 @@ def when($iso): ($iso | hhmm) as $t | (if $t == "" then "" else "state as of " +
         task_title: ($t.backlog.title // $t.id),
         project: ($t.project | basename),
         verb: .verb,
-        summary: .summary } ]
+        summary: .summary,
+        reason: null } ]
   + [ $s.secondmate_current.records[]?
       | . as $m
-      | (if ((.decisions_open // []) | type) == "array" then .decisions_open else [] end)[]
+      | ((.decisions_open // []) | if type == "array" then . else [] end)[]
       | select(type == "object" and .id != null and .key != null)
       | { kind: "decision",
           id: "\($m.id)/\(.id):\(.key)",
@@ -492,7 +502,8 @@ def when($iso): ($iso | hhmm) as $t | (if $t == "" then "" else "state as of " +
           task_title: ((.summary // .key) | tostring),
           project: ($m.id | tostring),
           verb: (.verb // "needs-decision"),
-          summary: ((.reason // "") | tostring) } ] ) as $durable
+          summary: ((.summary // "") | tostring),
+          reason: (if (.reason // "") == "" then null else (.reason | tostring) end) } ] ) as $durable
 
 # A delegated home the snapshot could not read whole cannot be reported as
 # holding no decisions, so what was not read is stated rather than assumed.
@@ -501,7 +512,7 @@ def when($iso): ($iso | hhmm) as $t | (if $t == "" then "" else "state as of " +
     | { id: (.id | tostring), reason: ((.current.reason // "state unavailable") | tostring) } ]
   + [ $s.secondmate_current.records[]?
       | . as $m
-      | (if ((.omitted // []) | type) == "array" then .omitted else [] end)[]
+      | ((.omitted // []) | if type == "array" then . else [] end)[]
       | select(type == "object" and .surface == "decisions_open")
       | { id: ($m.id | tostring),
           reason: "\(.count) more open decisions than this snapshot carries" } ] ) as $unread_homes
@@ -554,6 +565,7 @@ def when($iso): ($iso | hhmm) as $t | (if $t == "" then "" else "state as of " +
     + (if $d.home != null then " &middot; held in delegated home \($d.home | esc)" else "" end)
     + "</p>"
     + (if ($d.summary // "") != "" then "<p>\($d.summary | escn(700))</p>" else "" end)
+    + (if ($d.reason // "") != "" then "<p>\($d.reason | escn(700))</p>" else "" end)
     + "<p class=\"callout\">Not written up yet - there are no options on this card. "
     + "Ask for it to be laid out before answering.</p>"
     + "</article>";
@@ -663,15 +675,17 @@ def when($iso): ($iso | hhmm) as $t | (if $t == "" then "" else "state as of " +
    | reverse) as $landed_all
 | ($landed_all[0:$landed]) as $landed_shown
 
-# The Waiting-on-you column, cards and count from one list. The count is what is
-# actually waiting - each authored decision, each unelaborated one, each chore -
-# and the empty state is read off the rendered cards, so it cannot claim nothing
-# is waiting while a card sits under it.
+# The Waiting-on-you column, cards and count from one list. The count is every
+# entry actually waiting, not every card: a card listing five pull requests is
+# five things to do, the same as five chores. The empty state is read off the
+# rendered cards, so it cannot claim nothing is waiting while a card sits under
+# it.
 | ( [ $authored[] | { html: authored_card(.), n: 1 } ]
   + [ $unelaborated[] | { html: unelaborated_card(.), n: 1 } ]
-  + (if ($prs | length) > 0 then [ { html: pr_card, n: 1 } ] else [] end)
-  + (if ($held | length) > 0 then [ { html: held_card, n: 1 } ] else [] end)
-  + (if ($unread_homes | length) > 0 then [ { html: unread_homes_card, n: 1 } ] else [] end)
+  + (if ($prs | length) > 0 then [ { html: pr_card, n: ($prs | length) } ] else [] end)
+  + (if ($held | length) > 0 then [ { html: held_card, n: ($held | length) } ] else [] end)
+  + (if ($unread_homes | length) > 0
+     then [ { html: unread_homes_card, n: ($unread_homes | length) } ] else [] end)
   + [ $chores[] | { html: chores_card(.), n: (.item | length) } ] ) as $waiting
 | ($waiting | map(.html) | join("")) as $waiting_html
 | ($waiting | map(.n) | add // 0) as $waiting_count

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -203,7 +203,7 @@ family_for_basename() {
     fm-afk-inject-e2e.test.sh|fm-afk-return.test.sh)
       printf '%s\n' afk
       ;;
-    fm-bearings-snapshot.test.sh|fm-fleet-snapshot-view.test.sh)
+    fm-bearings-snapshot.test.sh|fm-fleet-snapshot-view.test.sh|fm-board.test.sh)
       printf '%s\n' snapshot-bearings
       ;;
     fm-backend-cmux.test.sh|fm-backend-cmux-smoke.test.sh)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -39,7 +39,7 @@ Decision-only events such as `resolved` never become current state or leak their
 In that status-log fallback, a declared external wait reports the distinct `paused` state with its reason.
 The semantic branch reports working only on an exact busy verdict and names the source that produced it; an unknown verdict never becomes working, never permits the status-log fallback, and never becomes a silent idle.
 For whole-fleet read-only review, `bin/fm-fleet-snapshot.sh --json` emits schema `fm-fleet-snapshot.v1` from the backlog, task metadata, current crew state, endpoint probes, PR/report pointers, scout reports, bounded current summaries from registered secondmate homes, and secondmate return-channel guidance.
-`bin/fm-fleet-view.sh` renders that snapshot as Markdown for humans, while `bin/fm-bearings-snapshot.sh` provides the bounded bearings projection, so both views consume one structured contract instead of reparsing raw fleet files.
+`bin/fm-fleet-view.sh` renders that snapshot as Markdown for humans, `bin/fm-bearings-snapshot.sh` provides the bounded bearings projection, and `bin/fm-board.sh` renders the four-column operator board as a self-contained HTML artifact, so every view consumes one structured contract instead of reparsing raw fleet files.
 The script header owns the exact JSON schema.
 
 ### Registered secondmate current state

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -16,6 +16,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-fleet-snapshot.sh`   | Print the read-only structured fleet snapshot JSON (schema `fm-fleet-snapshot.v1`)   |
 | `fm-fleet-view.sh`       | Render the fleet snapshot as a human Markdown view                                   |
 | `fm-bearings-snapshot.sh` | Project the fleet snapshot to the compact TOON bearings view; local-only unless `--include-prs` |
+| `fm-board.sh`            | Render the fleet snapshot as one self-contained operator-board HTML artifact, merging authored decision cards |
 | `fm-update.sh`           | Fast-forward-only self-update of firstmate and local or remote secondmate homes       |
 | `fm-on.sh`               | Execute one tracked Firstmate command in a configured remote secondmate home, using its job worker except for the doctor bootstrap |
 | `fm-remote-job-lib.sh`   | Shared bounded remote job queue, worker readiness, LaunchAgent contract, and filesystem-composed PATH |

--- a/tests/fm-board.test.sh
+++ b/tests/fm-board.test.sh
@@ -214,6 +214,32 @@ assert_grep "&lt;script&gt;alert(1)&lt;/script&gt;" "$OUT3" "authored markup was
 assert_no_grep "<b>bold</b>" "$OUT3" "authored markup reached the page unescaped"
 pass "authored text cannot inject markup"
 
+# Snapshot prose is bounded on the text a reader sees, not on its escaped form,
+# so a summary dense in characters that expand when escaped is not cut short of
+# its own budget and a cut can never land inside an entity.
+ENTITY_HOME="$TMP_ROOT/entity-home"
+mkdir -p "$ENTITY_HOME/state" "$ENTITY_HOME/data" "$ENTITY_HOME/config" "$ENTITY_HOME/projects/tung"
+printf '## In flight\n- [ ] dense-h - Dense summary (repo: tung) (kind: ship) (since 2026-07-11)\n' \
+  > "$ENTITY_HOME/data/backlog.md"
+fm_write_meta "$ENTITY_HOME/state/dense-h.meta" \
+  "window=firstmate:fm-dense-h" \
+  "worktree=$ENTITY_HOME/projects/tung" \
+  "project=$ENTITY_HOME/projects/tung" \
+  "harness=claude" \
+  "kind=ship" \
+  "mode=no-mistakes"
+record_claude_state "$ENTITY_HOME/state" dense-h idle
+DENSE=$(awk 'BEGIN{for(i=0;i<300;i++) printf "&"}')
+printf 'needs-decision [key=dense]: %s TAILMARK\n' "$DENSE" > "$ENTITY_HOME/state/dense-h.status"
+OUT_DENSE="$TMP_ROOT/board-dense.html"
+PATH="$FAKEBIN:$PATH" FM_HOME="$ENTITY_HOME" "$BOARD" --out "$OUT_DENSE" >/dev/null \
+  || fail "the board did not render an entity-dense summary"
+assert_grep "TAILMARK" "$OUT_DENSE" \
+  "an entity-dense summary was cut short of its own character budget"
+assert_no_grep "&am…" "$OUT_DENSE" "a truncation landed inside an HTML entity"
+assert_no_grep "&amp…" "$OUT_DENSE" "a truncation landed inside an HTML entity"
+pass "snapshot prose is bounded before escaping, so no cut splits an entity"
+
 # --- malformed authored input is refused, never half-rendered ----------------
 
 refuses() {  # <label> <cards-body>
@@ -263,7 +289,26 @@ key: a
 title: t
 option: x | X
 binds: listen-b:no-such-key'
+# The option value is an identifier that has to survive into the answer payload
+# unchanged, so a value the payload could not carry back is refused at parse time
+# rather than mis-rendered.
+refuses "an option value that is not a slug" '[decision]
+key: a
+title: t
+option: a|b | Label'
+refuses "an option value carrying a space" '[decision]
+key: a
+title: t
+option: two words | Label'
 pass "malformed authored input is refused rather than half-rendered"
+
+# A label may itself contain the separator; only the first one splits the line.
+printf '[decision]\nkey: a\ntitle: t\noption: x | left | right\n' > "$TMP_ROOT/pipe.txt"
+render "$TMP_ROOT/pipe.html" --cards "$TMP_ROOT/pipe.txt" >/dev/null \
+  || fail "an option label containing the separator was rejected"
+assert_grep 'value="x"' "$TMP_ROOT/pipe.html" "the option value did not survive a label containing the separator"
+assert_grep ">left | right" "$TMP_ROOT/pipe.html" "the option label lost everything after its own separator"
+pass "an option splits on its first separator and the label keeps the rest"
 
 # A binding that names a real decision is accepted, so the refusal above is about
 # the binding being wrong and not about bindings being rejected wholesale.
@@ -277,6 +322,12 @@ pass "a binding to a real open decision is accepted"
 assert_grep 'name="blind-prose"' "$OUT2" "an answer is not identified by its question key"
 assert_grep 'data-question="Prose above blind clips"' "$OUT2" "an answer carries no readable question"
 assert_grep 'value="audit"' "$OUT2" "an option carries no answer value"
+# The durable decision an answer resolves travels with the click, so the answer
+# maps back to the identity that was validated rather than to a card key alone.
+assert_grep 'data-binds="listen-b:blind-src"' "$OUT2" \
+  "an answer carries no link to the durable decision it answers"
+assert_grep "getAttribute('data-binds')" "$OUT2" \
+  "the answer payload drops the durable decision identity"
 SEND_CONTROLS=$(grep -c 'id="send"' "$OUT2")
 [ "$SEND_CONTROLS" = 1 ] || fail "expected exactly one send control, found $SEND_CONTROLS"
 assert_grep "sendQueuedPrompts" "$OUT2" "the send control queues nothing"
@@ -369,5 +420,148 @@ PATH="$FAKEBIN:$PATH" FM_HOME="$EMPTY" "$BOARD" --out "$OUT7" >/dev/null \
 assert_grep "Nothing is waiting on you." "$OUT7" "an empty board does not say so"
 assert_grep "Nothing under way." "$OUT7" "an empty board does not say so"
 pass "an empty fleet renders an honest empty board"
+
+# --- the empty state cannot outrank a card that is there ---------------------
+#
+# On an otherwise empty fleet the only thing in the column is one authored chores
+# card, so this is exactly the case where a separately kept counter would let the
+# column claim nothing is waiting while a card sits under it. Each chore counts
+# as its own act, so the pill reports items and not cards.
+CHORES_ONLY="$TMP_ROOT/chores-only.txt"
+cat > "$CHORES_ONLY" <<'EOF'
+[chores]
+title: Only you can do these
+item: **Tier-2 listening session.** 22 clips staged.
+item: Sign the release note.
+item: Re-pair the bench radio.
+EOF
+OUT8="$TMP_ROOT/chores-only.html"
+PATH="$FAKEBIN:$PATH" FM_HOME="$EMPTY" "$BOARD" --out "$OUT8" --cards "$CHORES_ONLY" >/dev/null \
+  || fail "the board did not render a chores-only column"
+assert_grep "Only you can do these" "$OUT8" "the only card in the column is missing"
+assert_no_grep "Nothing is waiting on you." "$OUT8" \
+  "the column claimed nothing is waiting while a card was rendered under it"
+assert_grep ">3 items<" "$OUT8" "the count does not report each chore as its own act"
+pass "the empty state cannot render while a card exists, and chores count per item"
+
+# --- delegated homes reach the same column -----------------------------------
+#
+# A decision held in a delegated home is a pending decision like any other. The
+# board already rolls up delegated landings, so reading landings but not pending
+# decisions would leave exactly the silence the unelaborated-key rule exists to
+# prevent. This home is seeded for real and read through one live snapshot.
+MATE="$TMP_ROOT/mate-home"
+mkdir -p "$MATE/state" "$MATE/data" "$MATE/config" "$MATE/projects" "$MATE/bin"
+printf 'sample-mate\n' > "$MATE/.fm-secondmate-home"
+printf '# Agents\n' > "$MATE/AGENTS.md"
+cat > "$MATE/data/backlog.md" <<'EOF'
+## Queued
+- [ ] mesh-note - Ship the mesh accuracy note (repo: tung) (kind: captain) (hold: waiting on the captain's word) (hold-kind: captain)
+
+## Done
+- [x] mate-land - Delegated landing https://github.com/notno/tung/pull/99 (repo: tung) (kind: ship) (merged 2026-07-20)
+EOF
+DELEGATING="$TMP_ROOT/delegating-home"
+mkdir -p "$DELEGATING/state" "$DELEGATING/data" "$DELEGATING/config" "$DELEGATING/projects"
+cat > "$DELEGATING/data/backlog.md" <<'EOF'
+## Done
+- [x] corners-f - Tile mating corners https://github.com/notno/tung/pull/13 (repo: tung) (kind: ship) (merged 2026-07-10)
+EOF
+printf -- '- sample-mate - synthetic scope (home: %s; scope: sample reviews; projects: sample; added 2026-07-14)\n' \
+  "$MATE" > "$DELEGATING/data/secondmates.md"
+fm_write_secondmate_meta "$DELEGATING/state/sample-mate.meta" "$MATE" \
+  "firstmate:fm-sample-mate" sample
+
+SNAP3="$TMP_ROOT/snap-delegated.json"
+PATH="$FAKEBIN:$PATH" FM_HOME="$DELEGATING" "$SNAPSHOT_CMD" --json > "$SNAP3" \
+  || fail "the delegated-home snapshot could not be taken"
+printf '%s' "$(jq -r '.secondmate_current.records[0].provenance.selected' "$SNAP3")" \
+  | grep -qx "structured-home" \
+  || fail "the fixture delegated home was not read as a structured home"
+
+OUT9="$TMP_ROOT/board-delegated.html"
+PATH="$FAKEBIN:$PATH" FM_HOME="$DELEGATING" "$BOARD" --snapshot "$SNAP3" --out "$OUT9" >/dev/null \
+  || fail "the board did not render a fleet with a delegated home"
+assert_grep "sample-mate/mesh-note:mesh-note" "$OUT9" \
+  "a decision open in a delegated home never reached the board"
+assert_grep "held in delegated home sample-mate" "$OUT9" \
+  "a delegated decision is not marked with the home it came from"
+assert_grep "Not written up yet" "$OUT9" \
+  "a delegated decision with no authored card is not marked unelaborated"
+assert_no_grep "Nothing is waiting on you." "$OUT9" \
+  "a delegated decision was rendered under a claim that nothing is waiting"
+pass "a decision held in a delegated home reaches Waiting on you, marked with its home"
+
+# The same identity is bindable, so a delegated decision can be elaborated by an
+# authored card exactly as a main-home one is.
+DELEGATED_CARD="$TMP_ROOT/delegated-card.txt"
+cat > "$DELEGATED_CARD" <<'EOF'
+[decision]
+key: mesh
+binds: sample-mate/mesh-note:mesh-note
+title: The mesh accuracy note
+option: ship | **Ship it** as written.
+option: hold | **Hold** for the next bench pass.
+EOF
+OUT10="$TMP_ROOT/board-delegated-card.html"
+PATH="$FAKEBIN:$PATH" FM_HOME="$DELEGATING" "$BOARD" --snapshot "$SNAP3" --out "$OUT10" \
+  --cards "$DELEGATED_CARD" >/dev/null \
+  || fail "an authored card binding a delegated decision was rejected"
+assert_grep 'data-binds="sample-mate/mesh-note:mesh-note"' "$OUT10" \
+  "the delegated decision identity did not travel with the answer"
+assert_no_grep "Not written up yet" "$OUT10" \
+  "an elaborated delegated decision is still marked unelaborated"
+pass "an authored card binds a delegated decision by its durable identity"
+
+# Landed merges two differently ordered sources - the main backlog in file order,
+# a delegated home already newest-first - so the bound has to cut a sorted union
+# or a recent delegated landing falls past it.
+OUT11="$TMP_ROOT/board-delegated-landed.html"
+PATH="$FAKEBIN:$PATH" FM_HOME="$DELEGATING" "$BOARD" --snapshot "$SNAP3" --out "$OUT11" \
+  --landed 1 >/dev/null || fail "the board did not render a bounded merged Landed column"
+assert_grep "Delegated landing" "$OUT11" \
+  "the newest landing fell past the bound because the merged sources were not sorted"
+assert_no_grep "Tile mating corners" "$OUT11" \
+  "an older landing displaced the newest one in a bounded Landed column"
+assert_grep "older landings not shown" "$OUT11" \
+  "a bounded merged Landed column hides what it dropped"
+pass "merged landings are ordered newest-first before the bound is applied"
+
+# A delegated home the snapshot could not read whole must not render as a home
+# holding nothing.
+UNREADABLE="$TMP_ROOT/unreadable-home"
+mkdir -p "$UNREADABLE/state" "$UNREADABLE/data" "$UNREADABLE/config" "$UNREADABLE/projects"
+printf '## Queued\n' > "$UNREADABLE/data/backlog.md"
+printf -- '- broken-mate - synthetic scope (home: %s; scope: sample reviews; projects: sample; added 2026-07-14)\n' \
+  "$TMP_ROOT/no-such-home" > "$UNREADABLE/data/secondmates.md"
+fm_write_secondmate_meta "$UNREADABLE/state/broken-mate.meta" "$TMP_ROOT/no-such-home" \
+  "firstmate:fm-broken-mate" sample
+OUT12="$TMP_ROOT/board-unreadable.html"
+PATH="$FAKEBIN:$PATH" FM_HOME="$UNREADABLE" "$BOARD" --out "$OUT12" >/dev/null \
+  || fail "the board did not render a fleet with an unreadable delegated home"
+assert_grep "could not read whole" "$OUT12" "an unreadable delegated home was passed over in silence"
+assert_grep "broken-mate" "$OUT12" "the unreadable delegated home is not named"
+assert_no_grep "Nothing is waiting on you." "$OUT12" \
+  "an unreadable delegated home rendered as a fleet with nothing waiting"
+pass "an unreadable delegated home is named rather than reported as holding nothing"
+
+# The delegated homes are on the same leak boundary as the operator's own.
+assert_no_grep "$MATE" "$OUT9" "a delegated home path reached the artifact"
+assert_no_grep "$TMP_ROOT" "$OUT9" "an absolute fixture path reached the artifact"
+assert_no_grep "$TMP_ROOT" "$OUT12" "an absolute fixture path reached the artifact"
+pass "delegated home paths do not reach the artifact"
+
+# --- counts are normalised where the flag is still named ---------------------
+
+OUT13="$TMP_ROOT/board-zeros.html"
+render "$OUT13" --landed 08 --stale-mins 030 >/dev/null \
+  || fail "a zero-padded count was not accepted at the boundary that names the flag"
+pass "zero-padded counts are normalised rather than failing inside the renderer"
+
+BAD_ERR="$TMP_ROOT/badcount.err"
+render "$TMP_ROOT/nope.html" --stale-mins 0 >/dev/null 2>"$BAD_ERR"
+expect_code 2 $? "a zero --stale-mins"
+grep -q -- "--stale-mins" "$BAD_ERR" || fail "the refusal did not name the flag it was about"
+pass "a bad count is refused where the flag is still named"
 
 echo "all fm-board tests passed"

--- a/tests/fm-board.test.sh
+++ b/tests/fm-board.test.sh
@@ -551,33 +551,55 @@ assert_no_grep "$TMP_ROOT" "$OUT9" "an absolute fixture path reached the artifac
 assert_no_grep "$TMP_ROOT" "$OUT12" "an absolute fixture path reached the artifact"
 pass "delegated home paths do not reach the artifact"
 
-# --- a delegated home of an unexpected shape is skipped, not fatal -----------
+# --- an entry of an unexpected shape is skipped, not fatal -------------------
 #
-# `--snapshot <file>` accepts any saved snapshot, so a delegated record from an
-# older schema can carry no decision list at all. Such a home must drop out of
-# the column the way an unreadable one does, rather than killing the render.
-shape_case() {  # <label> <jq-program>
-  local label=$1 program=$2 snap out
+# `--snapshot <file>` accepts any saved snapshot, so a record from an older
+# schema can carry a decision list that is absent, null, or not a list at all.
+# Such an entry must drop out of the column the way an unreadable home does,
+# rather than killing the render. Decisions are read at two independent sites,
+# the main home's tasks and each delegated home's record, so both are covered.
+shape_case() {  # <label> <source-snapshot> <home> <survivor> <jq-program>
+  local label=$1 source=$2 home=$3 survivor=$4 program=$5 snap out
   snap="$TMP_ROOT/snap-shape.json"
   out="$TMP_ROOT/board-shape.html"
   rm -f "$out"
-  jq "$program" "$SNAP3" > "$snap" || fail "$label: the shape fixture could not be built"
-  PATH="$FAKEBIN:$PATH" FM_HOME="$DELEGATING" "$BOARD" --snapshot "$snap" --out "$out" >/dev/null \
-    || fail "$label: the board aborted instead of skipping the home"
+  jq "$program" "$source" > "$snap" || fail "$label: the shape fixture could not be built"
+  PATH="$FAKEBIN:$PATH" FM_HOME="$home" "$BOARD" --snapshot "$snap" --out "$out" >/dev/null \
+    || fail "$label: the board aborted instead of skipping the entry"
   assert_present "$out" "$label: no artifact was written"
-  assert_grep "Tile mating corners" "$out" "$label: the rest of the board was lost with the home"
+  assert_grep "$survivor" "$out" "$label: the rest of the board was lost with the entry"
 }
 shape_case "a delegated home with a null decision list" \
+  "$SNAP3" "$DELEGATING" "Tile mating corners" \
   '.secondmate_current.records[0].decisions_open = null'
 shape_case "a delegated home with no decision list at all" \
+  "$SNAP3" "$DELEGATING" "Tile mating corners" \
   'del(.secondmate_current.records[0].decisions_open)'
 shape_case "a delegated home whose decision list is not a list" \
+  "$SNAP3" "$DELEGATING" "Tile mating corners" \
   '.secondmate_current.records[0].decisions_open = "unavailable"'
 shape_case "a delegated home with a null omission list" \
+  "$SNAP3" "$DELEGATING" "Tile mating corners" \
   '.secondmate_current.records[0].omitted = null'
+
+# The main home has its own guard on the same field, so it needs its own cases
+# against a snapshot whose tasks are actually main-home ones. $SNAP carries
+# ship-a and listen-b, both kind: ship, which the delegated filter keeps.
+jq -e '[.tasks[] | select(.kind != "secondmate")] | length > 0' "$SNAP" >/dev/null \
+  || fail "the main-home shape fixture carries no main-home task to guard"
 shape_case "a main-home task with a null decision list" \
-  '.tasks[0].hints.open_decisions = null'
-pass "a delegated home of an unexpected shape is skipped rather than aborting the render"
+  "$SNAP" "$HOME_DIR" "Ship the mating corners" \
+  '.tasks |= map(.hints.open_decisions = null)'
+shape_case "a main-home task with no decision list at all" \
+  "$SNAP" "$HOME_DIR" "Ship the mating corners" \
+  '.tasks |= map(del(.hints.open_decisions))'
+shape_case "a main-home task whose decision list is not a list" \
+  "$SNAP" "$HOME_DIR" "Ship the mating corners" \
+  '.tasks |= map(.hints.open_decisions = "unavailable")'
+shape_case "a main-home decision list holding something that is not a decision" \
+  "$SNAP" "$HOME_DIR" "Ship the mating corners" \
+  '.tasks |= map(if .kind != "secondmate" then .hints.open_decisions = ["not-an-object"] else . end)'
+pass "an entry of an unexpected shape is skipped rather than aborting the render"
 
 # --- a delegated decision carries its full text ------------------------------
 #
@@ -598,6 +620,27 @@ assert_grep "before the tier-2 session can be staged" "$OUT14" \
 assert_grep "sample-mate/listen-b:blind-src" "$OUT14" \
   "the delegated status decision carries no durable identity"
 pass "a delegated decision's full text reaches the card body, not just its heading"
+
+# Which slot a delegated entry's text belongs in follows from the kind of entry
+# it is, not from comparing rendered strings: the snapshot puts the item title in
+# `summary` for a captain hold and the decision text in `summary` for a status
+# decision. Neither card may say the same thing twice, and a hold's reason has to
+# stay on the card.
+occurrences() {  # <needle> <file>
+  grep -o -- "$1" "$2" | wc -l | tr -d ' '
+}
+HOLD_TITLE="Ship the mesh accuracy note"
+[ "$(occurrences "$HOLD_TITLE" "$OUT9")" = 1 ] \
+  || fail "a delegated captain hold rendered its title $(occurrences "$HOLD_TITLE" "$OUT9") times"
+assert_grep "waiting on the captain" "$OUT9" \
+  "a delegated captain hold dropped the reason it is being held for"
+pass "a delegated captain hold shows its title once and its hold reason beside it"
+
+# The same property for the other kind, whose text is long enough that a heading
+# clip would make two near-copies rather than two identical ones.
+[ "$(occurrences "which of the two sitting surfaces" "$OUT14")" = 1 ] \
+  || fail "a delegated status decision rendered its text more than once"
+pass "a delegated status decision shows its text once, in full"
 
 # --- the count reports entries, not cards ------------------------------------
 #

--- a/tests/fm-board.test.sh
+++ b/tests/fm-board.test.sh
@@ -1,0 +1,373 @@
+#!/usr/bin/env bash
+# Behavior tests for the operator board renderer.
+# Every case runs against fixture state rather than a live fleet: one real
+# fm-fleet-snapshot.sh run over a fixture home produces the snapshot the render
+# cases then consume, so the file-to-artifact path is exercised end to end while
+# each column is asserted from its own source.
+# Covers the four columns and their sources, a blocked and a date-gated queued
+# item, an unelaborated decision key surviving into the board, refusal of
+# malformed authored input, the answer-identification contract, a well-formed
+# and self-contained artifact, and the leak boundary.
+set -u
+
+# shellcheck source=tests/lib.sh
+# shellcheck disable=SC1091
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+BOARD="$ROOT/bin/fm-board.sh"
+SNAPSHOT_CMD="$ROOT/bin/fm-fleet-snapshot.sh"
+TMP_ROOT=$(fm_test_tmproot fm-board)
+
+command -v jq >/dev/null 2>&1 || { echo "skip: jq not found"; exit 0; }
+
+SECRET=fmx-pairing-token-must-not-leak-9d1
+
+# The fixture stubs only what the canonical snapshot reaches for locally; the
+# board itself makes no network or backend call of its own.
+make_fakebin() {  # <dir>
+  local fb
+  fb=$(fm_fakebin "$1")
+  cat > "$fb/no-mistakes" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+  cat > "$fb/tmux" <<'SH'
+#!/usr/bin/env bash
+case "${1:-}" in
+  display-message) printf '%%1\n' ;;
+  capture-pane) printf 'all quiet\n> \n' ;;
+esac
+exit 0
+SH
+  cat > "$fb/gh" <<'SH'
+#!/usr/bin/env bash
+echo "gh must not be called" >&2
+exit 1
+SH
+  chmod +x "$fb/no-mistakes" "$fb/tmux" "$fb/gh"
+  printf '%s\n' "$fb"
+}
+
+record_claude_state() {  # <state-dir> <id> <busy|idle>
+  local state=$1 id=$2 semantic=$3 gen event
+  case "$semantic" in
+    busy) event=user-prompt-submit ;;
+    *) event=stop ;;
+  esac
+  gen=$("$ROOT/bin/fm-busy-event.sh" arm "$state" "$id")
+  "$ROOT/bin/fm-busy-event.sh" apply "$state" "$id" "$semantic" --gen "$gen" \
+    --source claude-hook --event "$event"
+}
+
+# One fixture home carrying, deliberately, one of each thing a column reads:
+# a working ship task with a recorded pull request, a parked task holding an
+# unresolved decision key, a queued item blocked by another item, a queued item
+# behind a date gate, a captain-held queued item, and two landings whose
+# delivery artifacts differ (a pull request and a recorded set of findings).
+write_fixture() {  # <home>
+  local home=$1
+  mkdir -p "$home/state" "$home/data/scout-b" "$home/config" "$home/projects/wt" "$home/projects/tung"
+  printf 'FMX_PAIRING_TOKEN=%s\n' "$SECRET" > "$home/.env"
+  cat > "$home/data/backlog.md" <<'EOF'
+## In flight
+- [ ] ship-a - Ship the mating corners (repo: tung) (kind: ship) (since 2026-07-11)
+- [ ] listen-b - Sitting surface: collapse answered clips (repo: tung) (kind: ship) (since 2026-07-11)
+
+## Queued
+- [ ] carrier-c - Carrier question redesign blocked-by: listen-b (repo: tung) (kind: ship)
+- [ ] winlane-d - Revisit the Windows build lane (repo: litany) (kind: ship) (hold: time gate: revisit on/after 2026-08-20) (hold-until: 2026-08-20)
+- [ ] meshnote-e - Ship the mesh accuracy note (repo: tung) (kind: captain) (hold: waiting on the captain's word) (hold-kind: captain)
+
+## Done
+- [x] corners-f - Tile mating corners https://github.com/notno/tung/pull/13 (repo: tung) (kind: ship) (merged 2026-07-10)
+- [x] scout-b - Grasshopper verdict data/scout-b/report.md (repo: tung) (kind: scout) (reported 2026-07-10)
+EOF
+  printf '# Grasshopper\n' > "$home/data/scout-b/report.md"
+  fm_write_meta "$home/state/ship-a.meta" \
+    "window=firstmate:fm-ship-a" \
+    "worktree=$home/projects/wt" \
+    "project=$home/projects/tung" \
+    "harness=claude" \
+    "kind=ship" \
+    "mode=no-mistakes" \
+    "pr=https://github.com/notno/tung/pull/13"
+  record_claude_state "$home/state" ship-a busy
+  fm_write_meta "$home/state/listen-b.meta" \
+    "window=firstmate:fm-listen-b" \
+    "worktree=$home/projects/wt" \
+    "project=$home/projects/tung" \
+    "harness=claude" \
+    "kind=ship" \
+    "mode=no-mistakes"
+  record_claude_state "$home/state" listen-b idle
+  printf 'needs-decision [key=blind-src]: a filename naming the target renders on a blind row\n' \
+    > "$home/state/listen-b.status"
+}
+
+HOME_DIR="$TMP_ROOT/home"
+FAKEBIN=$(make_fakebin "$TMP_ROOT")
+write_fixture "$HOME_DIR"
+
+SNAP="$TMP_ROOT/snap.json"
+PATH="$FAKEBIN:$PATH" FM_HOME="$HOME_DIR" "$SNAPSHOT_CMD" --json > "$SNAP" \
+  || fail "the fixture snapshot could not be taken"
+
+render() {  # <out> [args...]
+  local out=$1; shift
+  PATH="$FAKEBIN:$PATH" FM_HOME="$HOME_DIR" "$BOARD" --snapshot "$SNAP" --out "$out" "$@"
+}
+
+# --- the four columns render from their sources ------------------------------
+
+OUT="$TMP_ROOT/board.html"
+PRINTED=$(render "$OUT") || fail "the board did not render from fixture state"
+[ "$PRINTED" = "$OUT" ] || fail "the board must print the artifact path it wrote (got '$PRINTED')"
+assert_present "$OUT" "the board wrote no artifact"
+BOARD_HTML=$(cat "$OUT")
+
+assert_contains "$BOARD_HTML" "Waiting on you" "the Waiting-on-you column is missing"
+assert_contains "$BOARD_HTML" "Under way" "the Under-way column is missing"
+assert_contains "$BOARD_HTML" "Queued" "the Queued column is missing"
+assert_contains "$BOARD_HTML" "Landed" "the Landed column is missing"
+pass "the board renders all four columns"
+
+# Under way: one card per live report, carrying the state and the time it was read.
+assert_contains "$BOARD_HTML" "Ship the mating corners" "the working task is missing from Under way"
+assert_contains "$BOARD_HTML" "Sitting surface: collapse answered clips" "the parked task is missing from Under way"
+assert_contains "$BOARD_HTML" "state as of " "an Under-way card does not carry the time its state was read"
+UNDERWAY_CARDS=$(printf '%s' "$BOARD_HTML" | grep -o 'class="dot dot-' | wc -l | tr -d ' ')
+[ "$UNDERWAY_CARDS" = 2 ] || fail "expected one Under-way card per live report, got $UNDERWAY_CARDS"
+pass "Under way renders one stamped card per live report"
+
+# Queued: the blocker and the date gate are both visible, so a reader can see why
+# an item is not moving.
+assert_contains "$BOARD_HTML" "Carrier question redesign" "the queued item is missing"
+assert_contains "$BOARD_HTML" "waits on listen-b" "a blocked queued item does not show its blocker"
+assert_contains "$BOARD_HTML" "held until 2026-08-20" "a date-gated queued item does not show its gate"
+pass "Queued shows blockers and date gates"
+
+# Landed: recent completions with the artifact each one delivered.
+assert_contains "$BOARD_HTML" "Tile mating corners" "the landed item is missing"
+assert_contains "$BOARD_HTML" "https://github.com/notno/tung/pull/13" "a landing does not carry its delivery artifact"
+assert_contains "$BOARD_HTML" "data/scout-b/report.md" "a reported landing does not carry its findings"
+pass "Landed carries each completion's delivery artifact"
+
+# Waiting on you, the mechanical half.
+assert_contains "$BOARD_HTML" "Waiting for your merge" "recorded work awaiting a merge is not surfaced"
+assert_contains "$BOARD_HTML" "Held for your word" "a captain-held queued item is not surfaced"
+pass "the mechanical half of Waiting on you comes from durable state"
+
+# --- an unelaborated decision key still appears ------------------------------
+
+assert_contains "$BOARD_HTML" "listen-b:blind-src" "an unresolved decision key was dropped from the board"
+assert_contains "$BOARD_HTML" "Not written up yet" "an unelaborated decision is not marked as such"
+pass "a decision key with no authored card still appears, marked unelaborated"
+
+# --- authored cards merge into the same column -------------------------------
+
+CARDS="$TMP_ROOT/cards.txt"
+cat > "$CARDS" <<'EOF'
+# authored by hand
+
+[decision]
+key: blind-prose
+binds: listen-b:blind-src
+title: Prose above blind clips
+tag: listening screen
+body: A natural title hands over the *withheld* answer set one line above clean rows.
+warn: Three rounds on one theme.
+option: audit | **A, done properly** - enumerate every authored string with `grep`.
+option: split | **D** - split the two kinds of sitting.
+recommend: audit
+footnote: If you like D I would take A as the interim.
+
+[chores]
+title: Only you can do these
+item: **Tier-2 listening session.** 22 clips staged.
+footnote: Nothing else needs your hands.
+EOF
+
+OUT2="$TMP_ROOT/board-cards.html"
+render "$OUT2" --cards "$CARDS" >/dev/null || fail "the board did not render with authored cards"
+CARD_HTML=$(cat "$OUT2")
+
+assert_contains "$CARD_HTML" "Prose above blind clips" "the authored decision card is missing"
+assert_contains "$CARD_HTML" "<strong>A, done properly</strong>" "authored bold markup did not render"
+assert_contains "$CARD_HTML" "<em>withheld</em>" "authored italic markup did not render"
+assert_contains "$CARD_HTML" "<code>grep</code>" "authored code markup did not render"
+assert_contains "$CARD_HTML" "my pick" "the authored recommendation is not marked"
+assert_contains "$CARD_HTML" "Only you can do these" "the authored chores card is missing"
+assert_contains "$CARD_HTML" "Ship the mating corners" "the mechanical cards were displaced by authored ones"
+assert_not_contains "$CARD_HTML" "Not written up yet" \
+  "a decision with an authored card is still marked unelaborated"
+pass "authored cards merge into Waiting on you beside the mechanical ones"
+
+# Authored text is escaped before markup, so it cannot inject markup of its own.
+INJECT="$TMP_ROOT/inject.txt"
+cat > "$INJECT" <<'EOF'
+[chores]
+item: <script>alert(1)</script> and <b>bold</b>
+EOF
+OUT3="$TMP_ROOT/board-inject.html"
+render "$OUT3" --cards "$INJECT" >/dev/null || fail "the board did not render the escaping case"
+assert_grep "&lt;script&gt;alert(1)&lt;/script&gt;" "$OUT3" "authored markup was not escaped"
+assert_no_grep "<b>bold</b>" "$OUT3" "authored markup reached the page unescaped"
+pass "authored text cannot inject markup"
+
+# --- malformed authored input is refused, never half-rendered ----------------
+
+refuses() {  # <label> <cards-body>
+  local label=$1 body=$2 out="$TMP_ROOT/refused.html" code
+  printf '%s\n' "$body" > "$TMP_ROOT/bad.txt"
+  rm -f "$out"
+  render "$out" --cards "$TMP_ROOT/bad.txt" >/dev/null 2>"$TMP_ROOT/bad.err"
+  code=$?
+  expect_code 2 "$code" "$label"
+  assert_absent "$out" "$label: an artifact was written despite refusing the input"
+  grep -q "$TMP_ROOT/bad.txt:" "$TMP_ROOT/bad.err" || fail "$label: the refusal did not name the file and line"
+}
+
+refuses "an unknown card type" '[whatever]
+title: x'
+refuses "an unknown field" '[decision]
+key: a
+title: t
+option: x | X
+nope: y'
+refuses "a decision with no option" '[decision]
+key: a
+title: t'
+refuses "a decision with no key" '[decision]
+title: t
+option: x | X'
+refuses "a chores card with no item" '[chores]
+title: t'
+refuses "a recommendation naming no option" '[decision]
+key: a
+title: t
+option: x | X
+recommend: zzz'
+refuses "a duplicate key" '[decision]
+key: a
+title: t
+option: x | X
+[decision]
+key: a
+title: u
+option: y | Y'
+refuses "a field outside any card" 'title: orphan'
+refuses "an unbalanced backtick" '[chores]
+item: a `b'
+refuses "a binding to no open decision" '[decision]
+key: a
+title: t
+option: x | X
+binds: listen-b:no-such-key'
+pass "malformed authored input is refused rather than half-rendered"
+
+# A binding that names a real decision is accepted, so the refusal above is about
+# the binding being wrong and not about bindings being rejected wholesale.
+printf '[decision]\nkey: a\ntitle: t\noption: x | X\nbinds: listen-b:blind-src\n' > "$TMP_ROOT/ok.txt"
+render "$TMP_ROOT/ok.html" --cards "$TMP_ROOT/ok.txt" >/dev/null \
+  || fail "a binding to a real open decision was rejected"
+pass "a binding to a real open decision is accepted"
+
+# --- answers arrive identified by question -----------------------------------
+
+assert_grep 'name="blind-prose"' "$OUT2" "an answer is not identified by its question key"
+assert_grep 'data-question="Prose above blind clips"' "$OUT2" "an answer carries no readable question"
+assert_grep 'value="audit"' "$OUT2" "an option carries no answer value"
+SEND_CONTROLS=$(grep -c 'id="send"' "$OUT2")
+[ "$SEND_CONTROLS" = 1 ] || fail "expected exactly one send control, found $SEND_CONTROLS"
+assert_grep "sendQueuedPrompts" "$OUT2" "the send control queues nothing"
+assert_grep "sendBtn.disabled = true" "$OUT2" "the send control does not reset for a further round"
+pass "answers are identified by question and one send control carries them"
+
+# The page's own script has to parse, or none of the interaction above exists.
+if command -v node >/dev/null 2>&1; then
+  awk '/^<script>/{on=1;next} /^<\/script>/{on=0} on' "$OUT2" > "$TMP_ROOT/board.js"
+  [ -s "$TMP_ROOT/board.js" ] || fail "the artifact carries no script"
+  node --check "$TMP_ROOT/board.js" || fail "the artifact's script does not parse"
+  pass "the artifact's script parses"
+else
+  echo "skip: node not found, artifact script not parsed"
+fi
+
+# --- the snapshot's age is visible and honest --------------------------------
+
+assert_grep 'id="age"' "$OUT" "the artifact does not show its age"
+assert_grep "too old to trust" "$OUT" "the artifact never admits to being too stale to trust"
+assert_grep "a snapshot, not a live feed" "$OUT" "the artifact does not say what it is"
+GEN=$(jq -r '.generated | sub("T.*"; "")' "$SNAP")
+[ -n "$GEN" ] || fail "the fixture snapshot recorded no generation time"
+pass "the artifact states its age and when it stops being trustworthy"
+
+# --- well-formed and self-contained ------------------------------------------
+
+balanced() {  # <tag> <file>
+  local tag=$1 file=$2 open close
+  open=$(grep -o "<${tag}[ >]" "$file" | wc -l | tr -d ' ')
+  close=$(grep -o "</$tag>" "$file" | wc -l | tr -d ' ')
+  [ "$open" = "$close" ] || fail "unbalanced <$tag>: $open opened, $close closed"
+}
+for tag in html head body header main section article div ul li p label span code strong em a button style script h1 h2 h3 title; do
+  balanced "$tag" "$OUT2"
+done
+assert_grep "<!doctype html>" "$OUT2" "the artifact has no doctype"
+pass "the emitted HTML is well-formed"
+
+assert_no_grep "<link " "$OUT2" "the artifact loads an external stylesheet"
+assert_no_grep "<script src" "$OUT2" "the artifact loads an external script"
+assert_no_grep "@import" "$OUT2" "the artifact imports an external stylesheet"
+assert_no_grep "url(http" "$OUT2" "the artifact fetches a remote asset"
+assert_no_grep "<img" "$OUT2" "the artifact loads a remote image"
+pass "the artifact is self-contained"
+
+# --- nothing private leaks ---------------------------------------------------
+
+assert_no_grep "$SECRET" "$OUT2" "a token from the home reached the artifact"
+assert_no_grep "$HOME_DIR" "$OUT2" "an absolute private path reached the artifact"
+assert_no_grep "$TMP_ROOT" "$OUT2" "an absolute fixture path reached the artifact"
+assert_no_grep "firstmate:fm-ship-a" "$OUT2" "an internal endpoint address reached the artifact"
+pass "no token or absolute private path reaches the artifact"
+
+# Home-path redaction, proved by rendering with the fixture home AS the operator
+# home: an absolute path carried in state prose comes out reduced.
+cat >> "$HOME_DIR/data/backlog.md" <<EOF
+- [x] pathy-g - Retire $HOME_DIR/projects/tung (repo: tung) (kind: ship) (done 2026-07-10)
+EOF
+SNAP2="$TMP_ROOT/snap2.json"
+PATH="$FAKEBIN:$PATH" FM_HOME="$HOME_DIR" "$SNAPSHOT_CMD" --json > "$SNAP2" \
+  || fail "the redaction snapshot could not be taken"
+OUT4="$TMP_ROOT/board-redact.html"
+PATH="$FAKEBIN:$PATH" HOME="$HOME_DIR" FM_HOME="$HOME_DIR" "$BOARD" \
+  --snapshot "$SNAP2" --landed 20 --out "$OUT4" >/dev/null \
+  || fail "the board did not render the redaction case"
+assert_grep "Retire ~/projects/tung" "$OUT4" "an operator-home path was not reduced"
+assert_no_grep "$HOME_DIR/projects/tung" "$OUT4" "an operator-home path survived into the artifact"
+pass "paths under the operator home are reduced before rendering"
+
+# --- bounds and the live path ------------------------------------------------
+
+OUT5="$TMP_ROOT/board-bounded.html"
+render "$OUT5" --landed 1 >/dev/null || fail "the board did not render with a landing bound"
+assert_grep "older landings not shown" "$OUT5" "a bounded Landed column hides what it dropped"
+pass "a bounded Landed column discloses what it left out"
+
+OUT6="$TMP_ROOT/live.html"
+PATH="$FAKEBIN:$PATH" FM_HOME="$HOME_DIR" "$BOARD" --out "$OUT6" >/dev/null \
+  || fail "the board did not render by taking its own snapshot"
+assert_grep "Ship the mating corners" "$OUT6" "the self-snapshotting path rendered no work"
+pass "the board takes its own snapshot when none is supplied"
+
+# An empty home is a legitimate board, not an error.
+EMPTY="$TMP_ROOT/empty-home"
+mkdir -p "$EMPTY/state" "$EMPTY/data" "$EMPTY/config" "$EMPTY/projects"
+OUT7="$TMP_ROOT/empty.html"
+PATH="$FAKEBIN:$PATH" FM_HOME="$EMPTY" "$BOARD" --out "$OUT7" >/dev/null \
+  || fail "the board refused to render an empty home"
+assert_grep "Nothing is waiting on you." "$OUT7" "an empty board does not say so"
+assert_grep "Nothing under way." "$OUT7" "an empty board does not say so"
+pass "an empty fleet renders an honest empty board"
+
+echo "all fm-board tests passed"

--- a/tests/fm-board.test.sh
+++ b/tests/fm-board.test.sh
@@ -157,6 +157,23 @@ assert_contains "$BOARD_HTML" "Waiting for your merge" "recorded work awaiting a
 assert_contains "$BOARD_HTML" "Held for your word" "a captain-held queued item is not surfaced"
 pass "the mechanical half of Waiting on you comes from durable state"
 
+# --- muted sub-text is legible wherever it appears ---------------------------
+# A held card carries its reason as muted sub-text inside a list item, where
+# nothing stacks it the way the flex column of a Queued row does.
+# An inline .sub therefore welds onto the title it follows and the column reads
+# "Ship the mesh accuracy notewaiting on the captain's word".
+# The property belongs to the class rather than to the two cards that showed it,
+# so it is asserted once against the rule every muted line goes through.
+assert_grep 'class="sub">waiting on the captain' "$OUT" \
+  "a held card does not carry its reason as muted sub-text"
+SUB_RULE=$(grep -oE '\.sub\{[^}]*\}' "$OUT") \
+  || fail "the artifact styles muted sub-text with no .sub rule"
+case "$SUB_RULE" in
+  *display:block*) ;;
+  *) fail "muted sub-text is inline, so it welds onto the title it follows: $SUB_RULE" ;;
+esac
+pass "muted sub-text takes its own line wherever it appears"
+
 # --- an unelaborated decision key still appears ------------------------------
 
 assert_contains "$BOARD_HTML" "listen-b:blind-src" "an unresolved decision key was dropped from the board"

--- a/tests/fm-board.test.sh
+++ b/tests/fm-board.test.sh
@@ -551,6 +551,126 @@ assert_no_grep "$TMP_ROOT" "$OUT9" "an absolute fixture path reached the artifac
 assert_no_grep "$TMP_ROOT" "$OUT12" "an absolute fixture path reached the artifact"
 pass "delegated home paths do not reach the artifact"
 
+# --- a delegated home of an unexpected shape is skipped, not fatal -----------
+#
+# `--snapshot <file>` accepts any saved snapshot, so a delegated record from an
+# older schema can carry no decision list at all. Such a home must drop out of
+# the column the way an unreadable one does, rather than killing the render.
+shape_case() {  # <label> <jq-program>
+  local label=$1 program=$2 snap out
+  snap="$TMP_ROOT/snap-shape.json"
+  out="$TMP_ROOT/board-shape.html"
+  rm -f "$out"
+  jq "$program" "$SNAP3" > "$snap" || fail "$label: the shape fixture could not be built"
+  PATH="$FAKEBIN:$PATH" FM_HOME="$DELEGATING" "$BOARD" --snapshot "$snap" --out "$out" >/dev/null \
+    || fail "$label: the board aborted instead of skipping the home"
+  assert_present "$out" "$label: no artifact was written"
+  assert_grep "Tile mating corners" "$out" "$label: the rest of the board was lost with the home"
+}
+shape_case "a delegated home with a null decision list" \
+  '.secondmate_current.records[0].decisions_open = null'
+shape_case "a delegated home with no decision list at all" \
+  'del(.secondmate_current.records[0].decisions_open)'
+shape_case "a delegated home whose decision list is not a list" \
+  '.secondmate_current.records[0].decisions_open = "unavailable"'
+shape_case "a delegated home with a null omission list" \
+  '.secondmate_current.records[0].omitted = null'
+shape_case "a main-home task with a null decision list" \
+  '.tasks[0].hints.open_decisions = null'
+pass "a delegated home of an unexpected shape is skipped rather than aborting the render"
+
+# --- a delegated decision carries its full text ------------------------------
+#
+# A status-sourced decision carries its text in `summary` and nothing in
+# `reason`. Clipping that text into the heading and dropping the rest would be
+# the same silence in smaller form, so the body has to carry it.
+LONG_SUMMARY="Prose above the blind clips needs a decision about which of the two sitting surfaces the answered set collapses into before the tier-2 session can be staged"
+DELEGATED_LONG="$TMP_ROOT/snap-delegated-long.json"
+jq --arg s "$LONG_SUMMARY" '
+  .secondmate_current.records[0].decisions_open =
+    [{id:"listen-b",key:"blind-src",verb:"needs-decision",summary:$s,reason:null,source:"status"}]
+' "$SNAP3" > "$DELEGATED_LONG" || fail "the long-summary fixture could not be built"
+OUT14="$TMP_ROOT/board-delegated-long.html"
+PATH="$FAKEBIN:$PATH" FM_HOME="$DELEGATING" "$BOARD" --snapshot "$DELEGATED_LONG" --out "$OUT14" >/dev/null \
+  || fail "the board did not render a delegated status decision"
+assert_grep "before the tier-2 session can be staged" "$OUT14" \
+  "a delegated decision's text was clipped into its heading and the rest dropped"
+assert_grep "sample-mate/listen-b:blind-src" "$OUT14" \
+  "the delegated status decision carries no durable identity"
+pass "a delegated decision's full text reaches the card body, not just its heading"
+
+# --- the count reports entries, not cards ------------------------------------
+#
+# Each pull request awaiting a merge and each held item is its own act, the same
+# as each chore, so a card listing several of them counts as several.
+MANY="$TMP_ROOT/many-home"
+mkdir -p "$MANY/state" "$MANY/data" "$MANY/config" "$MANY/projects/tung"
+cat > "$MANY/data/backlog.md" <<'EOF'
+## In flight
+- [ ] pr-one - First merge (repo: tung) (kind: ship) (since 2026-07-11)
+- [ ] pr-two - Second merge (repo: tung) (kind: ship) (since 2026-07-11)
+
+## Queued
+- [ ] held-one - First held item (repo: tung) (kind: captain) (hold: waiting on the captain's word) (hold-kind: captain)
+- [ ] held-two - Second held item (repo: tung) (kind: captain) (hold: waiting on the captain's word) (hold-kind: captain)
+- [ ] held-three - Third held item (repo: tung) (kind: captain) (hold: waiting on the captain's word) (hold-kind: captain)
+EOF
+for id in pr-one pr-two; do
+  fm_write_meta "$MANY/state/$id.meta" \
+    "window=firstmate:fm-$id" \
+    "worktree=$MANY/projects/tung" \
+    "project=$MANY/projects/tung" \
+    "harness=claude" \
+    "kind=ship" \
+    "mode=no-mistakes" \
+    "pr=https://github.com/notno/tung/pull/7"
+  record_claude_state "$MANY/state" "$id" busy
+done
+MANY_CHORES="$TMP_ROOT/many-chores.txt"
+cat > "$MANY_CHORES" <<'EOF'
+[chores]
+item: Sign the release note.
+item: Re-pair the bench radio.
+EOF
+OUT15="$TMP_ROOT/board-many.html"
+PATH="$FAKEBIN:$PATH" FM_HOME="$MANY" "$BOARD" --out "$OUT15" --cards "$MANY_CHORES" >/dev/null \
+  || fail "the board did not render a fleet with several entries per card"
+# Two pull requests, three held items and two chores are seven acts on three cards.
+assert_grep ">7 items<" "$OUT15" \
+  "the count reported cards rather than the entries waiting inside them"
+assert_no_grep "Nothing is waiting on you." "$OUT15" \
+  "the column claimed nothing is waiting while three cards were rendered under it"
+pass "the count reports every waiting entry, not every card"
+
+# --- the decision domain never fails into a false claim ----------------------
+#
+# The bind check is only as honest as the read behind it. If that read fails the
+# refusal must name the read, because reporting "there are no open decisions"
+# for a decision that is genuinely open is the one thing this board cannot say.
+BROKEN_DOMAIN="$TMP_ROOT/snap-broken-domain.json"
+jq '.tasks += ["not-a-task"]' "$SNAP" > "$BROKEN_DOMAIN" \
+  || fail "the broken-domain fixture could not be built"
+jq -e '[.tasks[] | select(type == "object") | (.hints.open_decisions // [])[]] | length > 0' \
+  "$BROKEN_DOMAIN" >/dev/null \
+  || fail "the broken-domain fixture carries no genuinely open decision"
+printf '[decision]\nkey: a\ntitle: t\noption: x | X\nbinds: listen-b:blind-src\n' \
+  > "$TMP_ROOT/genuine.txt"
+DOMAIN_OUT="$TMP_ROOT/board-broken-domain.html"
+DOMAIN_ERR="$TMP_ROOT/broken-domain.err"
+rm -f "$DOMAIN_OUT"
+PATH="$FAKEBIN:$PATH" FM_HOME="$HOME_DIR" "$BOARD" --snapshot "$BROKEN_DOMAIN" \
+  --out "$DOMAIN_OUT" --cards "$TMP_ROOT/genuine.txt" >/dev/null 2>"$DOMAIN_ERR"
+DOMAIN_CODE=$?
+[ "$DOMAIN_CODE" -ne 0 ] || fail "an unreadable decision domain was not a failure at all"
+assert_absent "$DOMAIN_OUT" "an artifact was written from an unreadable decision domain"
+grep -q "could not read the open decisions" "$DOMAIN_ERR" \
+  || fail "the failure does not name what could not be read: $(cat "$DOMAIN_ERR")"
+grep -q "there are no open decisions right now" "$DOMAIN_ERR" \
+  && fail "an unreadable decision domain was reported as a fleet with no open decisions"
+grep -q "binds names no open decision" "$DOMAIN_ERR" \
+  && fail "an unreadable decision domain was blamed on the authored card instead"
+pass "an unreadable decision domain fails loudly instead of claiming nothing is pending"
+
 # --- counts are normalised where the flag is still named ---------------------
 
 OUT13="$TMP_ROOT/board-zeros.html"


### PR DESCRIPTION
## Intent

Ship bin/fm-board.sh: one executable that renders the operator-facing status board as a self-contained Lavish HTML artifact, built from live fleet state instead of by hand.

WHY THIS EXISTS
The board had been hand-written three times in one evening and the columns changed each time. It works - two rounds of operator decisions came back through it - but every refresh cost ~300 lines of hand-authored HTML, and hand-authored means it drifts from reality the moment anything moves. The reference artifact is /home/nathan/firstmate/.lavish/bridge.html; it is the accepted design, not a suggestion: same four columns, same card shapes, same interaction.

THE CENTRAL DESIGN DECISION - what the script owns and what it does not
The script owns everything mechanically derivable from durable state:
- Under way: one card per live direct report, from state/<id>.meta plus the current state bin/fm-crew-state.sh reports. Each card carries the time its state was read.
- Queued: from the backlog, including what each item is blocked by and any date gate, so a reader can see why something is not moving.
- Landed: recent completions with their delivery artifact.
- Waiting on you, the mechanical half: work whose PR is recorded and awaiting a merge, and unresolved decision keys folded from the durable status logs.

The script must NOT try to derive the judgment half. An option list, a recommendation, the reasoning for preferring one option, and the "only you can do these" chores cannot be inferred from a status line - attempting it would produce confident nonsense. Instead the script has a clean seam: an optional input file of authored cards merged into the Waiting-on-you column, rendered alongside the mechanical cards. The input format was mine to design; it must be simple to author by hand and validated rather than trusted.

A decision key present in the durable logs but absent from the authored input must still appear, marked as unelaborated, rather than being silently dropped. Silence about a pending decision is the one failure this board cannot have.

INTERACTION
Reproduce the reference artifact's behaviour: choices update local state only; one send control queues a single prompt carrying every answered question and sends it; the control then resets so a further round can be answered on the same page. Answers must arrive identified by question, unambiguously - the operator's click is the payload, so an ambiguous one is worse than none.

Emit a self-contained artifact with the age of the snapshot visible and honest, including when it has gone stale enough not to be trusted. The script writes the artifact and prints its path; arming it as a wake source stays the operator's separate step, and the script must not run any blocking poll.

TESTS
Colocated per repo pattern, against fixture state rather than a live fleet: each column renders from its source; a blocked queued item shows its blocker; an unelaborated decision key still appears; malformed authored input is refused rather than half-rendered; the emitted HTML is well-formed and self-contained; no secret, token, or absolute private path leaks into the artifact. Shellcheck clean.

DECISIONS AND TRADEOFFS MADE WHILE BUILDING - deliberate, not oversights
- Renderer over bin/fm-fleet-snapshot.sh --json rather than parsing state files again, following bin/fm-fleet-view.sh. The snapshot stays the one owner of fleet truth. jq is therefore a hard dependency, as it already is for fm-fleet-view.
- SELF-CONTAINED MEANS NO CDN. The reference artifact pulls Tailwind and daisyUI from jsdelivr. A required test asserts self-containment, so the same palette, card shapes and left-accent borders are reproduced in hand-written vanilla CSS instead. This is a deliberate deviation from the reference's delivery mechanism, not from its design; it also renders offline and adds dark mode. Do not flag the absent CDN as a regression.
- Captain-held queued items (snapshot captain_actionable / hold_kind=captain) are routed into Waiting on you as a third mechanical source beyond the two named in the brief. Leaving them in Queued would reproduce exactly the silence the unelaborated-key rule exists to prevent.
- The authored-card format is line-oriented [decision] / [chores] blocks with `field: value` lines, chosen over JSON/TOML because a human authors it by hand under time pressure. A small inline markup subset (**bold**, *italic*, `code`) is applied ONLY to authored text and only AFTER HTML escaping, so authored text cannot inject markup. Snapshot-derived prose gets escaping without markup, since an asterisk in a status line is an asterisk.
- Backticks must be balanced in authored lines. This is enforced by the parser because the code-span renderer splits on backticks, and an odd count would silently wrap a trailing fragment as code. Validated rather than tolerated.
- An authored card binds to a durable decision through an explicit `binds: <task-id>:<decision-key>` field validated against the live open-decision set, rather than by key-name coincidence. A typo therefore refuses the render instead of silently degrading into a free-standing card that claims to elaborate something it does not. A binds value naming no open decision is a hard refusal that lists the available identifiers.
- The artifact computes its age from the snapshot's own generation timestamp, not from page load as the reference did, so a reopened page reports honestly. It degrades through "going stale" to "too old to trust, ask for a fresh board".
- Leak boundary: operator-home paths are reduced to ~ per field before escaping, and the write is REFUSED outright if the home path survives into the rendered output. Only project basenames are rendered, never worktrees, endpoints, or metadata paths.
- The jq render program lives in a quoted heredoc rather than an inline single-quoted argument because the emitted page carries JavaScript full of single quotes.
- Empty-array expansions use the repo's ${arr[@]+"${arr[@]}"} idiom for bash 3.2 safety under set -u.
- The test suite runs ONE real fm-fleet-snapshot over a fixture home and renders many boards from it, rather than re-snapshotting per case; the file-to-artifact path is still exercised end to end, including one case that takes its own snapshot.

VERIFICATION ALREADY DONE
bin/fm-lint.sh clean. 20 colocated cases in tests/fm-board.test.sh pass. tests/fm-test-run.test.sh, tests/fm-documentation-audiences.test.sh and tests/fm-fleet-snapshot-view.test.sh still pass. bin/fm-doc-audience-check.sh ok. The test is registered in the snapshot-bearings family in bin/fm-test-run.sh and the runner's coverage guard passes.

KNOWN GAP, deliberately disclosed: browser automation is broken in this worktree - chrome-devtools-axi returns "Target closed" immediately after navigation, and a one-line static HTML page fails identically, so it is the environment and not the artifact. The page has not been seen rendered by a browser or a human. The CSS was reviewed by hand instead, which caught and fixed a specificity bug that rendered all fine print as body text, a missing position:relative on option labels, and missing overflow guards on headings and options. The emitted script is syntax-checked with node --check in the suite.

AGENTS.md gained one line pointing at the new command where it already discusses choosing a visual surface, per the repo's size-discipline and trigger-hygiene rules.

DELIVERY: push and PR must target notno/firstmate, never kunchenguid/firstmate. The shared gate clone's origin was repointed to the fork for exactly this reason. Repo-visible text stays neutral engineering prose and never describes the operating structure or roles.

## What Changed

- New `bin/fm-board.sh` renders the four-column operator board (Under way, Queued, Landed, Waiting on you) as one self-contained HTML artifact over `bin/fm-fleet-snapshot.sh --json`, so the snapshot stays the single owner of fleet truth. Waiting-on-you folds in recorded PRs awaiting merge, unresolved durable decision keys, captain-held queued items, and decisions and landings rolled up from registered delegated homes. The page carries hand-written vanilla CSS with no CDN or external asset, computes its age from the snapshot's own timestamp and degrades through "going stale" to "too old to trust", queues every answered question into a single send control that resets for a further round, and the write is refused outright if an operator-home path survives into the output.
- The judgment half stays authored: an optional `--cards` file of line-oriented `[decision]` / `[chores]` blocks is merged into that column, validated rather than trusted - balanced backticks, slug-shaped keys, and `binds: <task-id>:<decision-key>` checked against the live open-decision set - with malformed input refused at `file:line`, the valid identifiers listed, and no artifact written. A durable decision key with no authored card still renders, marked unelaborated. Inline `**bold**` / `*italic*` / `` `code` `` applies only to authored text and only after escaping.
- Adds `tests/fm-board.test.sh` (37 colocated cases against one fixture snapshot, including per-column sourcing, blocker and date-gate display, refusal paths, self-containment, and leak checks), registers it in the `snapshot-bearings` family in `bin/fm-test-run.sh`, and documents the command in `docs/scripts.md`, `docs/architecture.md`, and `AGENTS.md`. Review and test rounds on the branch hardened snapshot shape guards, made unreadable decision state fail loudly instead of silently reporting nothing pending, widened the waiting count to include chores, and made `.sub` block-level so muted sub-text stops welding onto the title above it.

## Risk Assessment

✅ Low: Every finding raised across four review rounds is now closed and independently verified against the snapshot schema and jq's actual behavior, the change remains purely additive and read-only with respect to the fleet, and the only open item is an informational audit note requiring no action.

## Testing

Ran the smallest relevant automated set - the 37 colocated cases in tests/fm-board.test.sh, all passing - and separately proved the new muted-sub-text case is a real regression test by rendering with the pre-fix bin/fm-board.sh, where it fails, then restoring. Because the defect was invisible to every text assertion in three prior rounds, I drove the actual rendered surface: a fixture fleet seeded to carry all three list-based .sub call sites at once was rendered to HTML and screenshotted in headless Chrome before and after the fix, in dark and light palettes and at both the three-column and single-column breakpoints. The before images reproduce the welded text ("Ship the mesh accuracy notewaiting on the captain's word", "Cut the 0.9 release noteneeds your sign-off on the wording", "broken-mateinvalid home: not a directory"); the after images show each reason on its own muted line, with every pre-existing .sub usage in Queued, Landed and Under way still reading correctly. I also re-exercised the answer-and-send interaction on the current artifact and confirmed one prompt is queued identified by question and binds, sent, and the control resets for a further round. Working tree left clean.

- Evidence: Held-for-your-word and delegated-homes cards BEFORE the fix (dark, three-column) - sub-text welded onto titles (local file: <code>/tmp/no-mistakes-evidence/01KZDCX5PWMJQAXZCH97F25YEH/board-3col-dark-before.png</code>)
- Evidence: Same board AFTER the fix (dark, three-column) - each reason on its own muted line (local file: <code>/tmp/no-mistakes-evidence/01KZDCX5PWMJQAXZCH97F25YEH/board-3col-dark-after.png</code>)
- Evidence: Light palette BEFORE the fix (three-column) (local file: <code>/tmp/no-mistakes-evidence/01KZDCX5PWMJQAXZCH97F25YEH/board-3col-light-before.png</code>)
- Evidence: Light palette AFTER the fix (three-column) - no other .sub usage regressed (local file: <code>/tmp/no-mistakes-evidence/01KZDCX5PWMJQAXZCH97F25YEH/board-3col-light-after.png</code>)
- Evidence: Single-column breakpoint BEFORE the fix (760px, dark) (local file: <code>/tmp/no-mistakes-evidence/01KZDCX5PWMJQAXZCH97F25YEH/board-1col-dark-before.png</code>)
- Evidence: Single-column breakpoint AFTER the fix (760px, dark) - all four columns still read cleanly (local file: <code>/tmp/no-mistakes-evidence/01KZDCX5PWMJQAXZCH97F25YEH/board-1col-dark-after.png</code>)
- Evidence: Answer-and-send interaction on the fixed artifact: one prompt identified by question and binds, then the control resets (local file: <code>/tmp/no-mistakes-evidence/01KZDCX5PWMJQAXZCH97F25YEH/board-send-flow-after.png</code>)
<details>
<summary>Evidence: Rendered board HTML used for the after screenshots (self-contained artifact as an operator would open it)</summary>

```text
<!doctype html>
<html lang="en">
<head>
<meta charset="utf-8">
<meta name="viewport" content="width=device-width, initial-scale=1">
<title>The Bridge</title>
<style>
*,*::before,*::after{box-sizing:border-box}
:root{
  --bg:#eef1f6;--surface:#fff;--ink:#182030;--ink-soft:#333c4d;--muted:#5c6577;--line:#dde2ea;
  --primary:#4553c8;--primary-soft:#eceefb;--warning:#9a6510;--warning-soft:#fdf3e2;
  --info:#0d6f84;--info-soft:#e6f3f6;--error:#b02a1f;--ok:#2c7a4f;--shadow:0 1px 2px rgba(20,26,40,.08),0 1px 8px rgba(20,26,40,.05);
}
@media (prefers-color-scheme:dark){
  :root{
    --bg:#12161f;--surface:#1b212d;--ink:#e6e9f0;--ink-soft:#c8cedb;--muted:#9aa3b4;--line:#2a3140;
    --primary:#8d9bff;--primary-soft:#232a49;--warning:#e0a95c;--warning-soft:#2e2718;
    --info:#6fc7d8;--info-soft:#162b31;--error:#f08b80;--ok:#79c79b;--shadow:none;
  }
}
html{-webkit-text-size-adjust:100%}
body{margin:0;background:var(--bg);color:var(--ink);
  font:15px/1.5 ui-sans-serif,system-ui,-apple-system,"Segoe UI",Roboto,Helvetica,Arial,sans-serif}
a{color:var(--primary)}
code{font:12.5px/1.45 ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;
  background:var(--primary-soft);padding:.1em .35em;border-radius:4px;overflow-wrap:anywhere}
header{position:sticky;top:0;z-index:20;background:var(--surface);border-bottom:1px solid var(--line)}
.bar{max-width:1600px;margin:0 auto;padding:12px 20px;display:flex;flex-wrap:wrap;align-items:center;gap:12px}
.bar h1{margin:0;font-size:17px;font-weight:600;line-height:1.2}
.bar .meta{margin:2px 0 0;font-size:12px;color:var(--muted)}
.age{font-variant-numeric:tabular-nums}
.grow{flex:1;min-width:0}
#pending{font-size:12px;color:var(--muted)}
button{font:inherit;font-size:13px;font-weight:600;padding:7px 14px;border-radius:7px;border:1px solid transparent;
  background:var(--primary);color:#fff;cursor:pointer}
button[disabled]{opacity:.45;cursor:default}
main{max-width:1600px;margin:0 auto;padding:20px;display:grid;gap:20px}
@media (min-width:1080px){main{grid-template-columns:1.5fr 1fr 1fr}}
section{display:flex;flex-direction:column;gap:12px;min-width:0}
h2{margin:0;font-size:12px;font-weight:600;letter-spacing:.08em;text-transform:uppercase;color:var(--muted)}
.head{display:flex;align-items:center;gap:8px;flex-wrap:wrap}
.card{background:var(--surface);border-radius:10px;box-shadow:var(--shadow);padding:16px;
  display:flex;flex-direction:column;gap:10px;min-width:0;border:1px solid var(--line)}
.accent-primary{border-left:4px solid var(--primary)}
.accent-warning{border-left:4px solid var(--warning)}
.accent-info{border-left:4px solid var(--info)}
.card-head{display:flex;align-items:flex-start;gap:8px}
.card h3{margin:0;font-size:14px;font-weight:600;flex:1;min-width:0;overflow-wrap:anywhere}
.card p{margin:0;font-size:14px;color:var(--ink-soft);overflow-wrap:anywhere}
.card ul{margin:0;padding-left:18px;display:flex;flex-direction:column;gap:8px;
  font-size:14px;color:var(--ink-soft)}
.card li{overflow-wrap:anywhere}
.card p.fine,p.fine{font-size:12px;color:var(--muted)}
.card p.callout,p.callout{font-size:13px;background:var(--warning-soft);color:var(--warning);
  padding:8px 10px;border-radius:6px}
.pill{flex:none;font-size:11px;padding:2px 8px;border-radius:999px;background:var(--line);color:var(--muted);white-space:nowrap}
.pill-primary{background:var(--primary-soft);color:var(--primary)}
.count{background:var(--primary);color:#fff}
.dot{flex:none;width:9px;height:9px;border-radius:50%;margin-top:5px;background:var(--muted)}
.dot-working{background:var(--primary)}.dot-parked{background:var(--warning)}
.dot-blocked{background:var(--error)}.dot-paused{background:var(--info)}
.dot-done{background:var(--ok)}.dot-failed{background:var(--error)}
.opts{display:flex;flex-direction:column;gap:6px}
.opt{position:relative;display:block;border:1px solid var(--line);border-radius:7px;
  padding:9px 11px;font-size:13.5px;cursor:pointer;overflow-wrap:anywhere}
.opt input{position:absolute;opacity:0;pointer-events:none}
.opt:hover{border-color:var(--primary)}
.opt.picked{border-color:var(--primary);box-shadow:0 0 0 1px var(--primary);background:var(--primary-soft)}
.rows{background:var(--surface);border:1px solid var(--line);border-radius:10px;box-shadow:var(--shadow);
  padding:16px;display:flex;flex-direction:column;gap:12px;font-size:14px;min-width:0}
.row{display:flex;flex-direction:column;gap:2px;overflow-wrap:anywhere}
.row.dim{opacity:.6}
/* block, not inline: a .sub in a list item would otherwise weld onto its title */
.sub{display:block;font-size:12px;color:var(--muted)}
.empty{font-size:13px;color:var(--muted)}
.stale .meta{color:var(--warning);font-weight:600}
.expired .meta{color:var(--error);font-weight:600}
</style>
</head>
<body>
<header id="top">
  <div class="bar">
    <div class="grow">
      <h1>The Bridge</h1>
      <p class="meta">as of <span class="age">00:13</span> &middot;
        <span class="age" id="age">just now</span> - a snapshot, not a live feed</p>
    </div>
    <div id="pending"></div>
    <button id="send" disabled>Send answers</button>
  </div>
</header>

<main>
  <section>
    <div class="head"><h2>Waiting on you</h2><span class="pill count">6 items</span></div><article class="card accent-primary"><div class="card-head"><h3>Prose above blind clips</h3><span class="pill">listening screen</span></div><p>A natural title hands over the <em>withheld</em> answer set one line above clean rows.</p><p class="callout">Three rounds on one theme.</p><div class="opts"><label class="opt"><input type="radio" name="blind-prose" data-question="Prose above blind clips" data-binds="listen-b:blind-src" value="audit"><span><strong>A, done properly</strong> - enumerate every authored string with <code>grep</code>. <span class="pill pill-primary">my pick</span></span></label><label class="opt"><input type="radio" name="blind-prose" data-question="Prose above blind clips" data-binds="listen-b:blind-src" value="split"><span><strong>D</strong> - split the two kinds of sitting.</span></label></div><p class="fine">If you like D I would take A as the interim.</p></article><article class="card accent-info"><div class="card-head"><h3>Waiting for your merge</h3></div><ul><li><strong>Ship the mating corners</strong> <span class="pill">tung</span><br><a href="https://github.com/notno/tung/pull/13">https://github.com/notno/tung/pull/13</a></li></ul><p class="fine">Recorded locally. This board takes no snapshot of the forge, so it does not know whether one of these has already been merged.</p></article><article class="card accent-warning"><div class="card-head"><h3>Held for your word</h3></div><ul><li><strong>Ship the mesh accuracy note</strong><span class="sub">waiting on the captain&apos;s word</span></li><li><strong>Cut the 0.9 release note</strong><span class="sub">needs your sign-off on the wording</span></li></ul></article><article class="card accent-warning"><div class="card-head"><h3>Delegated homes this snapshot could not read whole</h3></div><ul><li><strong>broken-mate</strong><span class="sub">invalid home: not a directory</span></li></ul><p class="fine">These homes are not being reported as holding nothing. Ask for a fresh board once they read cleanly.</p></article><article class="card accent-warning"><div class="card-head"><h3>Only you can do these</h3></div><ul><li><strong>Tier-2 listening session.</strong> 22 clips staged.</li></ul><p class="fine">Nothing else needs your hands.</p></article>  </section>

  <section>
    <h2>Under way</h2><article class="card"><div class="card-head"><span class="dot dot-parked" title="parked"></span><h3>Sitting surface: collapse answered clips</h3><span class="pill">tung</span></div><p>parked - a filename naming the target renders on a blind row <strong>Holding for your call.</strong></p><p class="fine age">state as of 00:13</p></article><article class="card"><div class="card-head"><span class="dot dot-working" title="working"></span><h3>Ship the mating corners</h3><span class="pill">tung</span></div><p>working - harness busy (claude-hook)</p><p class="fine age">state as of 00:13</p></article>  </section>

  <section>
    <h2>Queued</h2><div class="rows"><div class="row"><strong>Carrier question redesign</strong><span class="sub">waits on listen-b</span></div></div>    <h2>Landed</h2><div class="rows"><div class="row"><strong>Grasshopper verdict</strong><span class="sub">findings recorded: data/scout-b/report.md</span><span class="sub">reported 2026-07-10</span></div><div class="row"><strong>Tile mating corners</strong><span class="sub"><a href="https://github.com/notno/tung/pull/13">https://github.com/notno/tung/pull/13</a></span><span class="sub">merged 2026-07-10</span></div></div>  </section>
</main>

<script>
(function () {
  var generated = 1786086828 * 1000;
  var staleMins = 30;
  var answers = {};
  var sendBtn = document.getElementById('send');
  var pending = document.getElementById('pending');
  var age = document.getElementById('age');
  var hdr = document.getElementById('top');

  function tick() {
    var mins = Math.floor((Date.now() - generated) / 60000);
    age.textContent = mins < 1 ? 'just now'
      : mins === 1 ? '1 minute old'
      : mins < 90 ? mins + ' minutes old'
      : Math.round(mins / 60) + ' hours old';
    hdr.classList.toggle('stale', mins >= staleMins && mins < staleMins * 2);
    hdr.classList.toggle('expired', mins >= staleMins * 2);
    if (mins >= staleMins * 2) {
      age.textContent += ' - too old to trust, ask for a fresh board';
    } else if (mins >= staleMins) {
      age.textContent += ' - going stale';
    }
  }
  tick();
  setInterval(tick, 20000);

  function refresh() {
    var n = Object.keys(answers).length;
    sendBtn.disabled = n === 0;
    sendBtn.textContent = 'Send answers';
    pending.textContent = n === 0 ? '' : (n === 1 ? '1 answer ready' : n + ' answers ready');
  }

  Array.prototype.forEach.call(document.querySelectorAll('.opt input[type=radio]'), function (input) {
    input.addEventListener('change', function () {
      var label = input.closest('.opt');
      Array.prototype.forEach.call(
        document.querySelectorAll('.opt input[name="' + input.name + '"]'),
        function (sib) { sib.closest('.opt').classList.remove('picked'); });
      label.classList.add('picked');
      answers[input.name] = {
        question: input.getAttribute('data-question') || input.name,
        binds: input.getAttribute('data-binds') || null,
        answer: input.value
      };
      refresh();
    });
  });

  sendBtn.addEventListener('click', function () {
    var keys = Object.keys(answers);
    if (!keys.length) return;
    // One answer per line: a separator an answer can contain would make the
    // prompt ambiguous, and an ambiguous answer is worse than none.
    var lines = keys.map(function (k) {
      var a = answers[k];
      return k + (a.binds ? ' [' + a.binds + ']' : '') + ' (' + a.question + '): ' + a.answer;
    });
    var text = lines.join('\n');
    var payload = { tag: 'board-answers', text: text, data: { answers: JSON.parse(JSON.stringify(answers)) } };
    if (window.lavish && typeof window.lavish.queuePrompt === 'function') {
      window.lavish.queuePrompt('Answers from the board:\n' + text, payload);
      window.lavish.sendQueuedPrompts();
      pending.textContent = 'on its way';
    } else {
      pending.textContent = 'no review session attached - answers copied instead';
      if (navigator.clipboard) { navigator.clipboard.writeText(text).catch(function () {}); }
      return;
    }
    keys.forEach(function (k) { delete answers[k]; });
    Array.prototype.forEach.call(document.querySelectorAll('.opt input[type=radio]:checked'), function (i) {
      i.checked = false;
      i.closest('.opt').classList.remove('picked');
    });
    Array.prototype.forEach.call(document.querySelectorAll('.opt.picked'), function (l) { l.classList.remove('picked'); });
    sendBtn.disabled = true;
    sendBtn.textContent = 'Sent - ready for more';
  });

  refresh();
})();
</script>
</body>
</html>
```
</details>
<details>
<summary>Evidence: New regression case fails against the pre-fix renderer</summary>

```text
$ git show HEAD~1:bin/fm-board.sh > bin/fm-board.sh
$ bash tests/fm-board.test.sh
ok - the board renders all four columns
ok - Under way renders one stamped card per live report
ok - Queued shows blockers and date gates
ok - Landed carries each completion's delivery artifact
ok - the mechanical half of Waiting on you comes from durable state
not ok - muted sub-text is inline, so it welds onto the title it follows: .sub{font-size:12px;color:var(--muted)}

$ git checkout -- bin/fm-board.sh
$ bash tests/fm-board.test.sh | tail -1
all fm-board tests passed
```
</details>
<details>
<summary>Evidence: Evidence harness that builds the fixture fleet and renders the board</summary>

```text
#!/usr/bin/env bash
# Evidence harness: render one operator board from a fixture fleet that carries
# every card type whose muted sub-text sits inside a <li> - the captain-held
# card, the awaiting-merge card, and the unreadable-delegated-home card - so a
# screenshot shows all three .sub call sites at once, alongside the .row-based
# .sub usages in Queued/Under way/Landed that must not regress.
#
# Usage: render-evidence.sh <out.html>
set -u

ROOT_REPO=${ROOT_REPO:?set ROOT_REPO to the worktree}
OUT=${1:?out path}

# shellcheck disable=SC1091
. "$ROOT_REPO/tests/lib.sh"

TMP_ROOT=$(fm_test_tmproot fm-board-evidence)

FB=$(fm_fakebin "$TMP_ROOT")
cat > "$FB/no-mistakes" <<'SH'
#!/usr/bin/env bash
exit 0
SH
cat > "$FB/tmux" <<'SH'
#!/usr/bin/env bash
case "${1:-}" in
  display-message) printf '%%1\n' ;;
  capture-pane) printf 'all quiet\n> \n' ;;
esac
exit 0
SH
chmod +x "$FB/no-mistakes" "$FB/tmux"

HOME_DIR="$TMP_ROOT/home"
mkdir -p "$HOME_DIR/state" "$HOME_DIR/data/scout-b" "$HOME_DIR/config" \
  "$HOME_DIR/projects/wt" "$HOME_DIR/projects/tung"

cat > "$HOME_DIR/data/backlog.md" <<'EOF'
## In flight
- [ ] ship-a - Ship the mating corners (repo: tung) (kind: ship) (since 2026-07-11)
- [ ] listen-b - Sitting surface: collapse answered clips (repo: tung) (kind: ship) (since 2026-07-11)

## Queued
- [ ] carrier-c - Carrier question redesign blocked-by: listen-b (repo: tung) (kind: ship)
- [ ] meshnote-e - Ship the mesh accuracy note (repo: tung) (kind: captain) (hold: waiting on the captain's word) (hold-kind: captain)
- [ ] relnote-g - Cut the 0.9 release note (repo: tung) (kind: captain) (hold: needs your sign-off on the wording) (hold-kind: captain)

## Done
- [x] corners-f - Tile mating corners https://github.com/notno/tung/pull/13 (repo: tung) (kind: ship) (merged 2026-07-10)
- [x] scout-b - Grasshopper verdict data/scout-b/report.md (repo: tung) (kind: scout) (reported 2026-07-10)
EOF
printf '# Grasshopper\n' > "$HOME_DIR/data/scout-b/report.md"

fm_write_meta "$HOME_DIR/state/ship-a.meta" \
  "window=firstmate:fm-ship-a" \
  "worktree=$HOME_DIR/projects/wt" \
  "project=$HOME_DIR/projects/tung" \
  "harness=claude" "kind=ship" "mode=no-mistakes" \
  "pr=https://github.com/notno/tung/pull/13"
fm_write_meta "$HOME_DIR/state/listen-b.meta" \
  "window=firstmate:fm-listen-b" \
  "worktree=$HOME_DIR/projects/wt" \
  "project=$HOME_DIR/projects/tung" \
  "harness=claude" "kind=ship" "mode=no-mistakes"
printf 'needs-decision [key=blind-src]: a filename naming the target renders on a blind row\n' \
  > "$HOME_DIR/state/listen-b.status"

# An unreadable delegated home, so the third <li>-based .sub site renders too.
printf -- '- broken-mate - synthetic scope (home: %s; scope: sample reviews; projects: sample; added 2026-07-14)\n' \
  "$TMP_ROOT/no-such-home" > "$HOME_DIR/data/secondmates.md"
fm_write_secondmate_meta "$HOME_DIR/state/broken-mate.meta" "$TMP_ROOT/no-such-home" \
  "firstmate:fm-broken-mate" sample

for id in ship-a listen-b; do
  semantic=idle; event=stop
  [ "$id" = ship-a ] && { semantic=busy; event=user-prompt-submit; }
  gen=$("$ROOT_REPO/bin/fm-busy-event.sh" arm "$HOME_DIR/state" "$id")
  "$ROOT_REPO/bin/fm-busy-event.sh" apply "$HOME_DIR/state" "$id" "$semantic" \
    --gen "$gen" --source claude-hook --event "$event"
done

CARDS="$TMP_ROOT/cards.txt"
cat > "$CARDS" <<'EOF'
[decision]
key: blind-prose
binds: listen-b:blind-src
title: Prose above blind clips
tag: listening screen
body: A natural title hands over the *withheld* answer set one line above clean rows.
warn: Three rounds on one theme.
option: audit | **A, done properly** - enumerate every authored string with `grep`.
option: split | **D** - split the two kinds of sitting.
recommend: audit
footnote: If you like D I would take A as the interim.

[chores]
title: Only you can do these
item: **Tier-2 listening session.** 22 clips staged.
footnote: Nothing else needs your hands.
EOF

PATH="$FB:$PATH" FM_HOME="$HOME_DIR" "$ROOT_REPO/bin/fm-board.sh" \
  --out "$OUT" --cards "$CARDS" >/dev/null || exit 1
printf '%s\n' "$OUT"
```
</details>
- Outcome: 🔧 2 issues found → auto-fixed ✅ across 2 runs (17m0s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ⚠️ `bin/fm-board.sh:570` - Landed concatenates two differently-ordered sources and then slices, so it does not show &#34;recent completions&#34; once both sources are populated. `$records[] | select(.state == &#34;done&#34;)` preserves raw backlog file order (fm-fleet-snapshot.sh:parse_row keeps `order` as read), while `$s.secondmate_landed.records` was already sorted `sort_by(completion.date) | reverse` by fm-fleet-snapshot.sh:1330. The union is never re-sorted, and `[0:$landed]` then takes the first N. With the default `--landed 8` and the live backlog&#39;s 10 `- [x]` rows, every delegated landing falls past the cut and is silently reported as &#34;older landings not shown&#34; no matter how recent it is - contradicting the script&#39;s own header claim (bin/fm-board.sh:20-21, &#34;including the landings rolled up from delegated homes&#34;). Fix: `sort_by([(.completion.date // &#34;&#34;), .id]) | reverse` over the union before slicing, matching what the snapshot already does per home. Currently latent only because `data/secondmates.md` does not exist yet.
- ⚠️ `bin/fm-board.sh:418` - Open decisions held in a delegated home never reach the board. `$work` filters `select(.kind != &#34;secondmate&#34;)`, and `$durable` is folded only from `$work[].hints.open_decisions`, so `secondmate_current.records[].summary.decisions_open` (which the snapshot populates with both `needs-decision` and `captain-hold` entries, fm-fleet-snapshot.sh:706-709) has no reader. The board deliberately reaches into delegated state for `secondmate_landed` but not for their pending decisions, so once a secondmate is registered a captain decision in that home is invisible - the exact silence the unelaborated-key rule exists to prevent (&#34;Silence about a pending decision is the one failure this board cannot have&#34;). A registered secondmate also renders no Under-way card at all. Flagging rather than fixing because the intent names only three mechanical sources, so whether delegated decisions are in scope is your call.
- ⚠️ `bin/fm-board.sh:366` - The option `&lt;value&gt;` is the only authored identifier that is not validated, and the shell parser and the jq renderer disagree about it. The parser accepts `option: a|b | Label` (it contains &#39; | &#39;) and takes `optval=a|b`, but the renderer&#39;s `sub(&#34;^[^|]* \\| &#34;; &#34;&#34;)` is anchored and `[^|]*` cannot cross the pipe, so the substitution does not match and the label renders as the whole line `a|b | Label` while the radio&#39;s value is `a|b` - verified with jq 1.7. Separately, the emitted script joins answers with `lines.join(&#39; | &#39;)` (bin/fm-board.sh:754), so a value or title containing &#39; | &#39; makes the prompt text ambiguous, which the intent calls out as &#34;worse than none&#34;. Validate the option value as a slug the way `key` already is at bin/fm-board.sh:246.
- ℹ️ `bin/fm-board.sh:460` - `binds` is parsed and hard-validated against the live open-decision set, but is never rendered into the artifact - the radio carries only `name=&lt;card key&gt;` and `data-question=&lt;title&gt;`. The answer payload therefore comes back as `blind-prose (Prose above blind clips): audit` with no link to the durable `listen-b:blind-src` identity that was just proved correct. Emitting a `data-binds` attribute and folding it into the `answers[...]` object would make the click map back to the decision it answers without any new validation.
- ℹ️ `bin/fm-board.sh:481` - Every truncation runs `esc | clip($n)`, i.e. it clips the HTML-escaped string. A cut landing inside an entity leaves a fragment (`a &amp;amp; b` clipped at 5 renders literally as `a &amp;am…`), and the character budget is spent on escape expansion, so a summary dense in `&amp;`/`&lt;`/quotes is truncated far shorter than the intended 700. Reversing to `clip($n) | esc` fixes both. Same pattern at lines 478, 492, 504-505, 524, 527, 546, 549, 554.
- ℹ️ `bin/fm-board.sh:803` - The final refusal guard greps only for `$REDACT_HOME` (`$HOME`), not for `$SNAPSHOT_HOME` (the snapshot&#39;s `fm_home`). `redact` reduces both, but the backstop only covers one of them, so when FM_HOME lives outside HOME - which the test suite itself does, FM_HOME=$TMP_ROOT/home - a field that bypassed `esc`/`md` would be written rather than refused. No such field exists today (I checked every interpolation in the render program), so this is defence-in-depth, but the stated boundary is &#34;the write is REFUSED outright if the home path survives&#34;. Add the same `grep -qF` on a non-empty `$SNAPSHOT_HOME`.
- ℹ️ `bin/fm-board.sh:450` - `$waiting_count` counts authored decisions, unelaborated decisions, the PR card (1) and the held card (1), but not chores cards - even though a chores card renders in the same column and is literally &#34;only you can do these&#34;. A board carrying just one chores card shows no count pill and no &#34;Nothing is waiting on you&#34; line, so the pill under-reports against the comment right above it (&#34;the count that has to be honest: everything actually waiting on the operator&#34;). Counting each chores card as 1, consistent with the PR and held cards, would close it - flagged rather than fixed because the omission may be deliberate (chores are not answerable).
- ℹ️ `bin/fm-board.sh:544` - Simplification: the date-gate/hold-reason rendering uses an if/elif plus a follow-up `if $until != null and $r.hold_reason != null` that re-emits the same hold-reason span. The whole three-branch construction is exactly equivalent to two independent conditionals - one emitting `held until` when `$until != null`, one emitting the reason when `hold_reason != null` - with the reason markup written once instead of twice.
- ℹ️ `bin/fm-board.sh:295` - Simplification: the whole-file pass re-greps the entire accumulated `$rows` blob once per card (`printf ... | grep -qxF &#34;$i\ttype\tdecision&#34;`) to recover the card type it already knew when it appended the header. The function already keeps parallel per-card arrays (`keys`, `have_title`, `blocklines`, ...); pushing the type onto one more array at bin/fm-board.sh:196 turns this into an array lookup and drops a subprocess per card.
- ℹ️ `bin/fm-board.sh:124` - `require_count` accepts any digit string, so `--landed 08` or `--stale-mins 030` passes CLI validation and is then handed to `jq --argjson`, where a leading zero is not valid JSON. The failure surfaces as the generic `rendering the board failed` at bin/fm-board.sh:791 rather than a usage error naming the flag. Stripping leading zeros (or rejecting them in `require_count`) keeps the diagnostic at the boundary that knows the flag name.

🔧 Fix: fold delegated decisions into the board and fix column bounds
4 issues (2 warnings, 2 infos) still open:
- ⚠️ `bin/fm-board.sh:486` - The new shape guards do not guard against the one shape they most need to. `(if ((.decisions_open // []) | type) == &#34;array&#34; then .decisions_open else [] end)[]` tests the type of the *defaulted* value but then iterates the *raw* field, so a null or missing `decisions_open` takes the then-branch and yields `null[]`. I confirmed with jq 1.7 that both `{&#34;decisions_open&#34;:null}` and `{}` abort with `Cannot iterate over null` (rc=5) - a non-array such as a string is the only case actually handled. Reachable through the documented `--snapshot &lt;file&gt;` flag, whose validation at bin/fm-board.sh:157 only requires `has(&#34;tasks&#34;) and has(&#34;backlog&#34;)`: a saved or older-schema snapshot with a `secondmate_current.records[]` entry lacking `decisions_open` kills the whole render with the opaque `rendering the board failed`, rather than skipping that home as the surrounding comment (&#34;Keep it defensive about shape&#34;) intends. Same hole at bin/fm-board.sh:189 (DURABLE_KEYS) and bin/fm-board.sh:504 (`omitted`). Fix: `((.decisions_open // []) | if type == &#34;array&#34; then . else [] end)[]`.
- ⚠️ `bin/fm-board.sh:184` - `DURABLE_KEYS=$(... | jq -r &#39;...&#39;)` has no `|| die`, so any failure of that jq leaves the bind-validation domain silently empty and the script continues. Because `parse_cards` runs before the render, the first thing the operator sees is not a render failure but a confident wrong refusal: bin/fm-board.sh:320-332 reports `binds names no open decision: &lt;id&gt;` followed by `there are no open decisions right now` for a decision that is genuinely open. That is the board asserting nothing is pending while something is - the failure the design says it cannot have - delivered as an exit-2 refusal. Combined with the null-hole above it is concretely reachable, but the missing check is worth closing on its own. `MATE_HOMES` at bin/fm-board.sh:412 is likewise unchecked, though its failure is caught downstream by `--argjson` rejecting an empty string.
- ℹ️ `bin/fm-board.sh:492` - Delegated status-sourced decisions render with markedly less text than their main-home equivalents. The mapping is `task_title: (.summary // .key)` and `summary: (.reason // &#34;&#34;)`, but a status decision in the home summary is built as `{..., summary:(.summary | trunc(160)), reason:null}` (fm-fleet-snapshot.sh:708), so `reason` is null, the `&lt;p&gt;` at bin/fm-board.sh:556 is skipped entirely, and the whole decision text sits in the `&lt;h3&gt;` clipped to 90 by `escn(90)` - discarding up to 70 characters the snapshot carried, with nowhere else on the card to read them. A main-home decision gets a 90-char title *and* a 700-char body. Captain-hold entries are unaffected since they populate both fields. Putting `.summary` in the body slot for delegated entries would close it; flagged rather than fixed because the field mapping is deliberate.
- ℹ️ `bin/fm-board.sh:672` - The count now reports chores per item on the reasoning that each chore is a separate act, but the PR and held cards still contribute `n: 1` regardless of how many entries they list. A board with five PRs awaiting merge and five captain-held items shows `2 items` while a three-item chores card shows `3`. The same reasoning that moved chores to per-item applies to `$prs | length` and `$held | length`; leaving them per-card keeps the pill understating exactly the mechanical half it was widened to report honestly.

🔧 Fix: guard snapshot shapes and fail loudly on unreadable decisions
2 infos still open:
- ℹ️ `tests/fm-board.test.sh:578` - The `shape_case &#34;a main-home task with a null decision list&#34;` case does not exercise the main-home guard it names. It mutates `$SNAP3`, whose only task is `sample-mate` - the DELEGATING fixture&#39;s state dir holds just `sample-mate.meta`, written by `fm_write_secondmate_meta` with `kind=secondmate` (tests/lib.sh:245-260), and its backlog has no In-flight rows. Both `DURABLE_KEYS` (bin/fm-board.sh:189) and `$work` (bin/fm-board.sh:471) drop `kind == &#34;secondmate&#34;` before reaching the guards at bin/fm-board.sh:190 and :483, so this case passes identically against the old broken guard. The four delegated cases are real; the main-home guard - one of the two sites this round was opened to fix - is left unpinned. Point the case at `$SNAP` instead, whose `ship-a`/`listen-b` tasks are `kind: ship`, adjusting the surviving-content assertion accordingly.
- ℹ️ `bin/fm-board.sh:568` - Delegated captain-hold cards now print their title twice. The snapshot builds those entries as `{summary:(.title | trunc(160)), reason:(.hold_reason | trunc(160))}` (fm-fleet-snapshot.sh:662-663), and the board maps both `task_title: (.summary // .key)` and `summary: (.summary // &#34;&#34;)` to that same value, so the `&lt;h3&gt;` at bin/fm-board.sh:562 and the new `&lt;p&gt;` at bin/fm-board.sh:567 render identical text before the hold reason appears. For needs-decision entries the new body is exactly right - it restores the text the 90-char heading clip was dropping, which is what was asked for - but for captain-holds, whose `summary` is just the title, it is pure repetition on every such card. Gating the body on `$d.summary != $d.task_title` keeps the fix and drops the echo; flagged rather than fixed since rendering the summary in the body was an explicit instruction.

🔧 Fix: route delegated decision text by entry kind, pin guards
1 info still open:
- ℹ️ `tests/fm-board.test.sh:577` - Audit result for the &#34;must fail against pre-fix code&#34; standard, since it was asked for explicitly. Six of the eight shape cases discriminate; three variants are tolerance coverage rather than regression coverage, and all three still assert real behavior, so no action is needed. I confirmed the pre-fix forms with jq 1.7. Main home, old form `(.hints.open_decisions // [])[]`: null and missing both already returned `[]` because `//` catches null, so those two cases pass identically pre-fix - but `&#34;unavailable&#34;` aborts with `Cannot iterate over string` and `[&#34;not-an-object&#34;]` aborts with `Cannot index string with string &#34;key&#34;`, so the main-home guard and the `select(type == &#34;object&#34;)` added in round 3 are both genuinely pinned now, which was the substance of the round-3 finding. Delegated, old form: null, missing and a null `omitted` all abort with `Cannot iterate over null`, while `&#34;unavailable&#34;` was already handled by the old guard&#39;s else-branch. The other audited cases discriminate: the broken-domain test asserts the absence of the exact `there are no open decisions right now` string the pre-fix path emitted, and the chores-only case carries `&gt;3 items&lt;`, which the pre-fix counter (0, no pill) could not produce.

</details>

<details>
<summary>🔧 **Test** - 2 issues found → auto-fixed ✅</summary>

- ⚠️ `bin/fm-board.sh:610` - Rendered-board defect (now visible, since the page has been screenshotted): in `held_card` (bin/fm-board.sh:609-610) and `unread_homes_card` (bin/fm-board.sh:584-585) the muted `&lt;span class=&#34;sub&#34;&gt;` is concatenated straight onto `&lt;/strong&gt;` with no separator. `.sub` (bin/fm-board.sh:771) sets only font-size and color - it is an inline span with no margin - and unlike every other `.sub` usage these two sit inside `&lt;li&gt;` rather than a `.row` flex column that would stack them. The result renders as run-together text: &#34;Ship the mesh accuracy notewaiting on the captain&#39;s word&#34;, &#34;Cut the 0.9 release noteneeds your sign-off on the wording&#34;, &#34;broken-mateinvalid home: not a directory&#34;. `pr_card` at line 596 inserts a literal space in the same position, so this is an omission rather than an intended layout. Reproduced in two independent renders (board.png, board-held.png). The suite cannot catch it: it asserts the strings are present and that the hold title occurs exactly once, both of which hold true while the words are glued together. Fixing the renderer is outside this test phase&#39;s scope, so the author needs to decide whether to land the one-character/CSS fix and add a colocated case that asserts the separation.
- ℹ️ `bin/fm-board.sh:646` - Pre-existing and outside this change, but newly visible on this surface: the Queued column renders the backlog item `winlane-d` with its raw annotations inside the title - &#34;Revisit the Windows build lane (repo: litany) (kind: ship) (hold: time gate: revisit on/after 2026-08-20) (hold-until: 2026-08-20)&#34; - while its siblings render clean titles. The board is faithful here; `bin/fm-fleet-snapshot.sh` itself emits that string in `.title` for this record (its sibling fields `repo`, `kind` and `hold_reason` all parsed correctly), most likely because the `hold:` value contains its own colons. bin/fm-fleet-snapshot.sh is untouched by this branch, and the same fixture line appears in tests/fm-board.test.sh, so no action is needed for this change - noting it only because it is the one visibly ragged card on an otherwise clean board.
- <code>`bash tests/fm-board.test.sh` - all 36 colocated cases pass against fixture state</code>
- <code>`bash tests/fm-test-run.test.sh` - runner family registration and coverage guard pass after fm-board.test.sh was added to the snapshot-bearings family</code>
- <code>Seeded a realistic operator home (in-flight tasks with a recorded PR, an open decision key, a blocked queued item, a date-gated item, a captain hold, two landings with differing delivery artifacts) and ran `bin/fm-board.sh --cards cards.txt --out board.html --title &#39;The Bridge&#39;` on its own live snapshot - artifact written, path printed</code>
- <code>Screenshotted the rendered artifact with `chrome.exe --headless=new --screenshot` over a `\\wsl.localhost` UNC path, after confirming `chrome-devtools-axi open` fails with `Target closed` and `chrome-devtools-axi screenshot` reports a path it never writes</code>
- <code>Drove the page&#39;s own interaction by appending an evidence-only driver to a copy: stubbed `window.lavish`, clicked an option, clicked the single `#send` control, and screenshotted the captured `queuePrompt` text and payload plus the post-send reset state</code>
- <code>Rewound the emitted `generated` timestamp in two copies to +45min and +3h and screenshotted the header to confirm the honest &#34;going stale&#34; and &#34;too old to trust, ask for a fresh board&#34; degradation</code>
- <code>Captured a CLI refusal transcript: `--cards` with `binds: listen-b:no-such-key` and with an unbalanced backtick both exit 2, name file:line, list the valid identifiers, and write no artifact</code>
- <code>Rendered a second board carrying a captain hold and an unreadable delegated home (`bin/fm-board.sh --out board-held.html`) to confirm the run-together sub-text defect in both affected card types</code>
- <code>Leak boundary on the real artifact: grepped board.html for the fixture token, the absolute home path, the tmux window endpoint, and `&lt;link` / `&lt;script src` / `@import` / `url(http` / `&lt;img` - all absent</code>

🔧 Fix: block-level .sub so list sub-text stops welding onto titles
✅ Re-checked - no issues remain.
- <code>`bash tests/fm-board.test.sh` - all 37 colocated cases pass on the target commit</code>
- <code>Regression proof: `git show HEAD~1:bin/fm-board.sh &gt; bin/fm-board.sh &amp;&amp; bash tests/fm-board.test.sh` fails on `muted sub-text takes its own line wherever it appears` (`not ok - muted sub-text is inline, so it welds onto the title it follows: .sub{font-size:12px;color:var(--muted)}`), then `git checkout -- bin/fm-board.sh` restores and it passes</code>
- <code>Rendered real boards from a fixture fleet seeded with all three `&lt;li&gt;`-based `.sub` sites (captain-held x2, recorded PR, unreadable delegated home) plus authored decision/chores cards, via `bin/fm-board.sh --out ... --cards ...`</code>
- <code>Screenshotted before/after with `chrome.exe --headless=new --screenshot` at `--window-size=1600,1200` (three-column) and `--window-size=760,1500` (single-column, below the 1080px breakpoint)</code>
- <code>Captured the light palette explicitly with `--blink-settings=preferredColorScheme=1` and the dark palette via headless default</code>
- <code>Re-ran the answer/send interaction against the current artifact with the evidence driver: one queued prompt carrying `question` + `binds`, `sendQueuedPrompts` called, control resets to `Sent - ready for more` with radios and `.picked` highlights cleared</code>
- <code>Confirmed `git status --porcelain` clean after all evidence work; removed the Windows temp render directory</code>

</details>

<details>
<summary>⚠️ **Document** - 1 info</summary>

- ℹ️ `docs/scripts.md:3` - docs/scripts.md presents itself as the bin/ toolbelt inventory, but 27 shipped scripts are absent from it, including operator-relevant ones like fm-procevent.sh, fm-procevent-lavish.sh, fm-lint.sh, fm-doc-audience-check.sh, and the fm-remote-* helpers. This predates the change and closing it would mean a broad table rewrite outside this change&#39;s scope, so only the row for the new fm-board.sh was added here. Worth a follow-up that either completes the table or states explicitly that it is a curated subset rather than a full inventory.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
