### PR TITLE
fix(supervision): keep Codex guarded through terminal catch-up

### DIFF
--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -191,7 +191,7 @@ That styled capture is internal to the boolean detector only.
 **Primary-session guard fact (verified 2026-07-04, Claude Code 2.1.201; preserved 2026-07-08, Claude Code 2.1.204; Stop-owned auto-arm revalidated 2026-07-24, Claude Code 2.1.219).**
 This is separate from the per-task crewmate turn-end hook above (that one just `touch`es a marker file in a task's own `.claude/settings.local.json`).
 The firstmate PRIMARY's own `.claude/settings.json` registers two Stop hooks: `bin/fm-turnend-guard.sh --claude` and the Stop-owned auto-arm `bin/fm-claude-stop-autoarm.sh` (`asyncRewake: true`, `timeout: 28800`), and exiting the guard with status 2 plus stderr reliably forces the model to continue.
-Claude Code's stdin payload to a Stop hook carries a `stop_hook_active` boolean that is `true` when the current stop attempt follows ANY stop-hook-driven continuation, including `asyncRewake` rewakes; the primary guard therefore ignores it in `--claude` mode and uses the cooperative claim/epoch check plus a bounded re-block budget instead, while the codex-mode default still treats it as a one-block loop guard.
+Claude Code's stdin payload to a Stop hook carries a `stop_hook_active` boolean that is `true` when the current stop attempt follows ANY stop-hook-driven continuation, including `asyncRewake` rewakes; the primary guard therefore ignores it in `--claude` mode and uses the cooperative claim/epoch check plus a bounded re-block budget instead.
 A project-level `.claude/settings.json` only takes effect when Claude Code's project root is that exact directory - it does not walk up from a subdirectory looking for one, so firstmate launches the primary from the repo root.
 After those settings are loaded, hook command resolution is still cwd-sensitive because Claude Code runs commands through `/bin/sh` against the session's current cwd; keep the tracked commands anchored through `"$CLAUDE_PROJECT_DIR"/bin/...` and see `docs/turnend-guard.md` for the verified Stop-hook details.
 Claude Code's primary watcher protocol is Stop-owned: the auto-arm hook fires on every Stop and foregrounds `bin/fm-watch-arm.sh` when the home is eligible and still needs supervision, and its exit-2 `asyncRewake` rewake is the wake; the model drains and handles wakes but never runs a routine re-arm command.
@@ -220,7 +220,8 @@ The session id is printed on quit.
 
 **Primary-session guard fact (verified 2026-07-08, codex-cli 0.142.1).**
 The firstmate PRIMARY's own `.codex/hooks.json` registers a Stop hook that pipes Codex's Stop payload to `bin/fm-turnend-guard.sh`.
-Codex Stop hooks block on exit 2 and expose `stop_hook_active` for the same one-block loop safety Claude uses.
+Codex Stop hooks block on exit 2 and expose `stop_hook_active` as continuation history rather than recovery proof.
+The shared guard re-checks the live supervision predicate on every Codex Stop, so repeated foreground checkpoints remain bounded individually without reopening a blind interval between them.
 Codex's Stop payload includes `cwd`, but the tracked primary hook does not use it to choose the guard executable.
 Verified on 2026-07-08: Codex runs the Stop hook command with process PWD set to the hook-loaded project root, and no `CODEX_PROJECT_DIR`, `CODEX_WORKSPACE_ROOT`, or `CODEX_CWD` root variable is set.
 The tracked hook anchors to `pwd -P`, verifies that root is firstmate-shaped and hook-bearing, and then invokes `bin/fm-turnend-guard.sh` with the original payload.

--- a/bin/fm-turnend-guard-grok.sh
+++ b/bin/fm-turnend-guard-grok.sh
@@ -50,7 +50,7 @@ ROOT=${ROOT%/}
 [ -x "$ROOT/bin/fm-turnend-guard.sh" ] || exit 0
 
 if [ "$CAPABILITY" = native ]; then
-  printf '%s' "$PAYLOAD" | "$ROOT/bin/fm-turnend-guard.sh"
+  printf '%s' "$PAYLOAD" | "$ROOT/bin/fm-turnend-guard.sh" --grok
   RC=$?
   case "$RC" in
     0|2) exit "$RC" ;;
@@ -68,7 +68,7 @@ command -v grok >/dev/null 2>&1 || exit 0
 ERR=$(mktemp "${TMPDIR:-/tmp}/fm-turnend-grok.XXXXXX") || exit 0
 trap 'rm -f "$ERR"' EXIT
 
-printf '%s' "$PAYLOAD" | "$ROOT/bin/fm-turnend-guard.sh" 2>"$ERR"
+printf '%s' "$PAYLOAD" | "$ROOT/bin/fm-turnend-guard.sh" --grok 2>"$ERR"
 RC=$?
 [ "$RC" -eq 2 ] || exit 0
 

--- a/bin/fm-turnend-guard.sh
+++ b/bin/fm-turnend-guard.sh
@@ -28,15 +28,18 @@
 # primary checkout - the main home or a genuinely marked secondmate home - and
 # stay a silent, fast no-op inside child task worktrees.
 #
-# Loop-guard, codex/Grok (default) mode: never block twice in the same turn.
-# Codex uses stop_hook_active and Grok uses stopHookActive; typed camel-case
-# takes precedence when both spellings are present. A true value means the
-# current stop attempt already follows a block, so this guard always allows it.
-# Passive harness adapters provide their own one-follow-up guard before calling
-# this script.
-# That bounds those harnesses to at most one forced continuation per turn -
-# never a wedged, un-endable session - while still nagging again on a later turn
-# if the problem persists.
+# Codex mode (default): stop_hook_active is not recovery proof. A prior block can
+# force a continuation, but the foreground checkpoint may still be absent or may
+# have already exited while a task remains active. Re-run the same live-watcher
+# predicate on every Stop so the continuation cannot silently end before it has
+# restored the bounded foreground checkpoint protocol and caught any durable
+# terminal event.
+#
+# Grok mode (--grok): never block twice in the same turn. Grok's native Stop
+# adapter already owns one bounded continuation and passes --grok explicitly.
+# A true stopHookActive (or compatible stop_hook_active) therefore allows the
+# retry. Passive harness adapters provide their own one-follow-up guard before
+# calling this script.
 #
 # Loop-guard, --claude mode (Stop-owned auto-arm cooperation): Claude Code
 # marks EVERY stop after ANY stop-hook-driven continuation stop_hook_active=true,
@@ -68,6 +71,7 @@ CONFIG="${FM_CONFIG_OVERRIDE:-$FM_HOME/config}"
 GRACE=${FM_GUARD_GRACE:-300}
 WATCH="$SCRIPT_DIR/fm-watch.sh"
 CLAUDE_MODE=0
+GROK_MODE=0
 SYNC_WAIT_MS=${FM_CLAUDE_AUTOARM_SYNC_WAIT_MS:-800}
 EPOCH_FRESH=${FM_CLAUDE_AUTOARM_EPOCH_FRESH:-15}
 BLOCK_BUDGET=${FM_CLAUDE_TURNEND_BLOCK_BUDGET:-3}
@@ -78,9 +82,14 @@ case "$BLOCK_BUDGET" in ''|*[!0-9]*|0) BLOCK_BUDGET=3 ;; esac
 for arg in "$@"; do
   case "$arg" in
     --claude) CLAUDE_MODE=1 ;;
-    *) echo "usage: $(basename "$0") [--claude]" >&2; exit 2 ;;
+    --grok) GROK_MODE=1 ;;
+    *) echo "usage: $(basename "$0") [--claude|--grok]" >&2; exit 2 ;;
   esac
 done
+[ "$CLAUDE_MODE" -eq 0 ] || [ "$GROK_MODE" -eq 0 ] || {
+  echo "usage: $(basename "$0") [--claude|--grok]" >&2
+  exit 2
+}
 
 # shellcheck source=bin/fm-supervision-lib.sh
 . "$SCRIPT_DIR/fm-supervision-lib.sh"
@@ -106,7 +115,7 @@ STOP_HOOK_ACTIVE=$(printf '%s' "$PAYLOAD" | jq -r '
   else false
   end
 ' 2>/dev/null) || exit 0
-if [ "$CLAUDE_MODE" -eq 0 ] && [ "$STOP_HOOK_ACTIVE" = "true" ]; then
+if [ "$GROK_MODE" -eq 1 ] && [ "$STOP_HOOK_ACTIVE" = "true" ]; then
   exit 0
 fi
 

--- a/docs/turnend-guard.md
+++ b/docs/turnend-guard.md
@@ -52,7 +52,10 @@ If `jq` is missing or hook stdin is empty, the guard exits 0 because it cannot s
 
 Claude and Codex can block a Stop directly with exit status 2 and stderr.
 Both payloads carry `stop_hook_active`.
-In the default Codex mode, a true value lets the second stop finish after one forced continuation.
+In the default Codex mode, `stop_hook_active` records that a prior block forced the current continuation but is not proof that supervision recovered.
+Every Codex Stop therefore re-evaluates the live watcher predicate while supervision is needed, so a continuation that skipped its foreground checkpoint or reached the end of a quiet checkpoint is blocked back into another bounded cycle.
+Once a checkpoint catches a durable terminal signal, the model drains and handles that wake through the ordinary protocol before the task metadata disappears and the Stop can finish.
+This keeps each foreground wait bounded without letting the one-shot payload field silently reopen an unsupervised interval.
 
 Claude runs the guard with `--claude`, which ignores `stop_hook_active` and cooperates with the Stop-owned auto-arm.
 Claude Code sets `stop_hook_active=true` on every stop after any stop-hook continuation, including `asyncRewake` rewakes, which re-opened the 2026-07-21 blind window under the default one-shot behavior.
@@ -81,6 +84,7 @@ Grok makes exactly one typed capability decision from each running Stop payload.
 A boolean `stopHookActive` selects native blocking, including both false on the initial stop and true on the bounded continuation.
 The camel-case field has precedence when both spellings appear; when it is absent, a boolean `stop_hook_active` selects the same native path for compatibility.
 The native path returns the shared guard's status and stderr to the same Grok process and never starts `grok --resume`.
+It invokes the shared guard with `--grok`, preserving Grok's one-block loop guard independently from Codex's repeated supervision check.
 When both capability spellings are absent, the adapter preserves one pre-native `grok --resume` fallback guarded by `GROK_TURNEND_GUARD_ACTIVE` and intentionally omits `--permission-mode`.
 Malformed JSON, a selected field with a non-boolean type, missing `jq`, missing hook prerequisites, or an already-active legacy guard allows the stop without starting either continuation path.
 Grok's project hook requires the checkout to be trusted with `/hooks-trust` or launch-time `--trust`; genuine pre-native builds can run the same tracked hook from an isolated global hook directory.

--- a/docs/verification/supervision.md
+++ b/docs/verification/supervision.md
@@ -183,7 +183,7 @@ The direct and passive mechanisms were validated across all five harnesses on 20
 | Harness | Version verified | Mechanism | Observed result |
 | --- | --- | --- | --- |
 | Claude | 2.1.219 | Cooperative blocking `Stop` guard plus `asyncRewake` auto-arm | A fresh unsupervised session ran session start first, reclaimed a stale dead-owner lock, completed two tokenless rewake cycles with no model arm command or guard continuation, and left a competing live owner unchanged. |
-| Codex | 0.142.1 | Blocking `Stop` hook | Hook process root stayed anchored to the trusted checkout and one continuation ran. |
+| Codex | 0.142.1; repeated-block semantics reverified on 0.147.0 | Blocking `Stop` hook | Hook process root stayed anchored to the trusted checkout; the current live guard honored consecutive exit-2 blocks with payload history false, true, true. |
 | OpenCode | 1.17.6 | Passive `session.idle` callback | Throwing could not block, while `promptAsync` scheduled one TUI follow-up; headless remained fail-open. |
 | Pi | 0.80.5 | Passive `agent_settled` callback | Exactly one guard follow-up ran for an unhealthy cycle, with no recursion across tool turns. |
 | Grok | 0.2.112 native and 0.2.73 pre-native | Running-payload adaptive `Stop` | Native false-to-true continuation stayed in one process with two model turns and zero resume launches; the field-absent pre-native process launched exactly one guarded resume. |
@@ -309,10 +309,22 @@ grok 0.2.103 (89c3d36fb6f1) [stable]
 | Harness | Exact opt-in command | Observed guarantee |
 | --- | --- | --- |
 | Claude | `FM_CLAUDE_LIVE_E2E=1 tests/fm-claude-stop-autoarm-live-e2e.test.sh` | Session start reclaimed a stale owner before two Stop-owned cycles, and a competing live owner prevented arm, rewake, epoch write, or lock replacement. |
-| Codex | `FM_CODEX_LIVE_E2E=1 tests/fm-codex-continuity-live-e2e.test.sh` | The one-second foreground checkpoint returned without switching to the arm wrapper. |
+| Codex | `FM_CODEX_LIVE_E2E=1 tests/fm-codex-continuity-live-e2e.test.sh` | The one-second foreground checkpoint returned without switching to the arm wrapper, and the live Stop hook honored two consecutive exit-2 blocks with `stop_hook_active` progressing from false to true to true. |
 | OpenCode | `FM_OPENCODE_LIVE_E2E=1 tests/fm-opencode-primary-live-e2e.test.sh` | A verified successor existed before prompt handling, with no model re-arm or turn-end fallback. |
 | Pi | `FM_PI_LIVE_E2E=1 tests/fm-pi-primary-live-e2e.test.sh` | One initial tool call led to extension-owned successors and clean child retirement on exit. |
 | Grok | `FM_GROK_LIVE_E2E=1 tests/fm-grok-continuity-live-e2e.test.sh` | Native task completion surfaced the actionable close and the cycle ledger recorded `reason=actionable-signal`. |
+
+The Codex checkpoint and repeated-Stop guarantee was reverified on 2026-08-07 with codex-cli 0.147.0.
+
+```sh
+FM_CODEX_LIVE_E2E=1 tests/fm-codex-continuity-live-e2e.test.sh
+```
+
+Observed output:
+
+```text
+ok - codex-cli 0.147.0 live E2E preserved the foreground checkpoint and honored two consecutive Stop blocks
+```
 
 Pi 0.81.1 repeated the continuity and clean-exit lifecycle on 2026-07-23 after the Calm presentation changes.
 

--- a/tests/fm-codex-continuity-live-e2e.test.sh
+++ b/tests/fm-codex-continuity-live-e2e.test.sh
@@ -19,8 +19,10 @@ command -v codex >/dev/null 2>&1 || fail "codex not found"
 
 LAB="$ROOT/.codex-live-e2e.$$"
 PROJECT="$LAB/project"
+STOP_PROJECT="$LAB/stop-project"
 HOME_DIR="$LAB/fmhome"
 TRANSCRIPT="$LAB/codex.jsonl"
+STOP_TRANSCRIPT="$LAB/codex-stop.jsonl"
 CODEX_VERSION=$(codex --version)
 
 cleanup() {
@@ -52,4 +54,54 @@ if grep -F 'watcher: started pid=' "$TRANSCRIPT" >/dev/null; then
   fail "Codex switched to the background arm path"
 fi
 
-printf 'ok - %s live E2E preserved the one-second foreground checkpoint path\n' "$CODEX_VERSION"
+git clone -q "$ROOT" "$STOP_PROJECT"
+cat > "$STOP_PROJECT/.codex/repeated-stop-e2e.sh" <<'SH'
+#!/usr/bin/env bash
+set -u
+root=$(pwd -P)
+payload=$(cat)
+printf '%s\n' "$payload" >> "$root/.codex/stop-payloads.jsonl"
+count=$(wc -l < "$root/.codex/stop-payloads.jsonl" | tr -d '[:space:]')
+if [ "$count" -lt 3 ]; then
+  printf 'CODEX_REPEAT_STOP_%s: reply with exactly CONTINUATION%s and stop again without tools\n' "$count" "$count" >&2
+  exit 2
+fi
+exit 0
+SH
+chmod +x "$STOP_PROJECT/.codex/repeated-stop-e2e.sh"
+cat > "$STOP_PROJECT/.codex/hooks.json" <<'JSON'
+{
+  "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash -lc 'exec \"$(pwd -P)/.codex/repeated-stop-e2e.sh\"'",
+            "timeout": 30
+          }
+        ]
+      }
+    ]
+  }
+}
+JSON
+
+(
+  cd "$STOP_PROJECT" || exit 1
+  codex exec \
+    --dangerously-bypass-hook-trust \
+    --dangerously-bypass-approvals-and-sandbox \
+    --skip-git-repo-check \
+    -c 'model_reasoning_effort="low"' \
+    --json \
+    'Reply with exactly INITIAL and stop. Follow any Stop hook feedback literally.'
+) > "$STOP_TRANSCRIPT" 2>&1 || fail "Codex repeated Stop-hook turn failed: $(tail -20 "$STOP_TRANSCRIPT")"
+
+[ "$(wc -l < "$STOP_PROJECT/.codex/stop-payloads.jsonl" | tr -d '[:space:]')" = 3 ] \
+  || fail "Codex did not honor exactly two consecutive Stop blocks: $(cat "$STOP_PROJECT/.codex/stop-payloads.jsonl" 2>/dev/null)"
+jq -se 'length == 3 and .[0].stop_hook_active == false and .[1].stop_hook_active == true and .[2].stop_hook_active == true' \
+  "$STOP_PROJECT/.codex/stop-payloads.jsonl" >/dev/null \
+  || fail "Codex Stop payloads did not preserve false -> true -> true continuation history"
+
+printf 'ok - %s live E2E preserved the foreground checkpoint and honored two consecutive Stop blocks\n' "$CODEX_VERSION"

--- a/tests/fm-turnend-guard.test.sh
+++ b/tests/fm-turnend-guard.test.sh
@@ -422,14 +422,14 @@ test_hook_uses_state_override() {
   pass "fm-turnend-guard: uses FM_STATE_OVERRIDE ahead of FM_HOME/state"
 }
 
-test_hook_loop_guard_allows_retry() {
+test_hook_codex_continuation_rechecks_supervision() {
   local dir out status
   dir=$(make_primary_dir "$TMP_ROOT/hook-loopguard")
   : > "$dir/state/task1.meta"
   out=$(run_hook "$dir" true); status=$?
-  expect_code 0 "$status" "hook must allow the stop when stop_hook_active is already true"
-  [ -z "$out" ] || fail "hook produced output on the loop-guarded retry: $out"
-  pass "fm-turnend-guard: stop_hook_active=true always allows the stop (never blocks twice in one turn)"
+  expect_code 2 "$status" "Codex continuation must re-check supervision when stop_hook_active is true"
+  assert_contains "$out" "$REQUIRED_REASON" "Codex continuation lost the recovery instruction"
+  pass "fm-turnend-guard: Codex stop_hook_active continuation re-checks the live supervision predicate"
 }
 
 # A secondmate's OWN home runs a primary firstmate session and must be guarded
@@ -459,17 +459,17 @@ test_hook_silent_in_idle_secondmate_home() {
   pass "fm-turnend-guard: idle-by-default - silent in a secondmate home with nothing in flight"
 }
 
-# The stop_hook_active loop guard bounds the secondmate to one forced
-# continuation per turn, exactly as it does for the main primary - no wedged,
-# un-endable session.
-test_hook_secondmate_loop_guard_allows_retry() {
+# A Codex secondmate primary must apply the same recovery-proof rule as the main
+# primary: stop_hook_active records a continuation but cannot substitute for a
+# live foreground checkpoint while its own child work remains in flight.
+test_hook_secondmate_codex_continuation_rechecks_supervision() {
   local dir out status
   dir=$(make_secondmate_dir "$TMP_ROOT/hook-secondmate-loopguard")
   : > "$dir/state/task1.meta"
   out=$(run_hook "$dir" true); status=$?
-  expect_code 0 "$status" "hook must allow the stop in a secondmate home when stop_hook_active is already true"
-  [ -z "$out" ] || fail "secondmate loop-guarded retry produced output: $out"
-  pass "fm-turnend-guard: stop_hook_active=true allows the stop in a secondmate home (never blocks twice in one turn)"
+  expect_code 2 "$status" "Codex continuation must re-check supervision in a secondmate home"
+  assert_contains "$out" "$REQUIRED_REASON" "secondmate Codex continuation lost the recovery instruction"
+  pass "fm-turnend-guard: secondmate Codex continuation re-checks the live supervision predicate"
 }
 
 # The guard's half of the deferred-death recovery loop in a secondmate home,
@@ -1555,10 +1555,10 @@ test_hook_x_mode_reason_sources_cadence
 test_hook_x_mode_only_blocks_in_default_mode
 test_hook_ignores_repo_state_when_fm_home_set
 test_hook_uses_state_override
-test_hook_loop_guard_allows_retry
+test_hook_codex_continuation_rechecks_supervision
 test_hook_blocks_in_secondmate_own_home
 test_hook_silent_in_idle_secondmate_home
-test_hook_secondmate_loop_guard_allows_retry
+test_hook_secondmate_codex_continuation_rechecks_supervision
 test_hook_secondmate_reinvoke_recovery_loop
 test_hook_silent_in_secondmate_child_worktree
 test_hook_blocks_in_treehouse_leased_secondmate_home

--- a/tests/fm-watch-checkpoint.test.sh
+++ b/tests/fm-watch-checkpoint.test.sh
@@ -87,7 +87,56 @@ test_existing_singleton_watcher_is_not_success() {
   pass "checkpoint rejects an existing watcher singleton as unowned"
 }
 
+test_late_checkpoint_surfaces_terminal_after_blind_stop_once() {
+  local home out err status drained second_out second_err
+  home=$(make_home terminal-catchup)
+  out="$home/out.txt"
+  err="$home/err.txt"
+
+  fm_git_init_commit "$home"
+  mkdir -p "$home/bin"
+  : > "$home/AGENTS.md"
+  : > "$home/state/demo.meta"
+
+  status=0
+  FM_HOME="$home" FM_POLL=1 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=999999 "$CHECKPOINT" --seconds 1 >"$out" 2>"$err" || status=$?
+  expect_code 124 "$status" "foreground checkpoint must exit before terminal completion"
+
+  status=0
+  printf '%s\n' '{"stop_hook_active":false}' \
+    | FM_ROOT_OVERRIDE="$home" FM_HOME="$home" "$ROOT/bin/fm-turnend-guard.sh" >"$out" 2>"$err" \
+    || status=$?
+  expect_code 2 "$status" "initial blind primary stop must force one continuation"
+
+  printf 'done: synthetic terminal completion\n' > "$home/state/demo.status"
+  : > "$home/state/demo.turn-ended"
+
+  status=0
+  printf '%s\n' '{"stop_hook_active":true}' \
+    | FM_ROOT_OVERRIDE="$home" FM_HOME="$home" "$ROOT/bin/fm-turnend-guard.sh" >"$out" 2>"$err" \
+    || status=$?
+  expect_code 2 "$status" "bounded Codex continuation must not end before terminal catch-up"
+
+  status=0
+  FM_HOME="$home" FM_POLL=1 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=999999 "$CHECKPOINT" --seconds 5 >"$out" 2>"$err" || status=$?
+  expect_code 0 "$status" "late checkpoint terminal catch-up"
+  assert_contains "$(cat "$out")" "signal:" "late checkpoint did not surface the terminal completion"
+  drained=$(FM_HOME="$home" "$ROOT/bin/fm-wake-drain.sh")
+  assert_contains "$drained" $'\tsignal\tdemo.status\t' "terminal status was not durably queued"
+  assert_contains "$drained" $'\tsignal\tdemo.turn-ended\t' "terminal turn-end marker was not durably queued"
+
+  second_out="$home/second.out"
+  second_err="$home/second.err"
+  status=0
+  FM_HOME="$home" FM_POLL=1 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=999999 "$CHECKPOINT" --seconds 1 >"$second_out" 2>"$second_err" || status=$?
+  expect_code 124 "$status" "terminal catch-up replay checkpoint"
+  assert_not_contains "$(cat "$second_out")" "signal:" "terminal completion surfaced more than once"
+  [ ! -s "$home/state/.wake-queue" ] || fail "terminal completion was queued more than once"
+  pass "late checkpoint surfaces a terminal event exactly once after the bounded Codex blind-stop continuation"
+}
+
 test_quiet_checkpoint_exits_124_cleanly
 test_signal_passes_through_and_exits_zero
 test_registered_check_uses_preserved_watcher_environment
 test_existing_singleton_watcher_is_not_success
+test_late_checkpoint_surfaces_terminal_after_blind_stop_once


### PR DESCRIPTION
## Intent

Diagnose and fix the Firstmate supervision regression in which a Codex ship task can complete after the foreground checkpoint has exited and the captain receives no durable callback. Reproduce the end-user sequence: a Codex ship task remains active after the primary returns a final response; the foreground bin/fm-watch-checkpoint.sh cycle has exited; the primary turn attempts to end; the worker then writes terminal done status and state/<task>.turn-ended with no live foreground checkpoint; and a checkpoint started later currently fails to surface that existing completion. The incident evidence is that state/pangle-rta-sampled-logs.turn-ended and terminal status were written at 2026-08-07 14:33 while state/.last-watcher-beat stopped at 14:16, and the captain saw the worker finish in its pane but received no callback or continuation. The Codex Stop hook must prevent a blind primary turn end or force a bounded continuation while tasks remain active. Explicitly separate the initiating trigger, independent masking condition, and captain-visible symptom; compare the failing Codex path with at least one proven guarded primary path and identify the earliest meaningful divergence in control flow or durable state handling; inspect the Stop hook, turn-end guard, checkpoint, wake queue, relevant history and tests without assuming the nearest change is causal; run the smallest counterfactual that should flip the result; name and seek disconfirming evidence, retaining contradiction or uncertainty that could alter scope; and record causal evidence in the commit and PR report without putting incident chronology in maintained product docs. Make terminal task events impossible to miss silently when a Codex foreground checkpoint is not live. Prefer deterministically enforcing the existing Stop-guard and durable catch-up contract over detached background processes. Ensure a late checkpoint or bounded session continuation surfaces a durable terminal event exactly once. Preserve durable queue authentication, primary lock ownership, task-event authentication, exactly-once acknowledgement, and every supported harness/backend protocol. Review every affected supported primary harness and runtime backend integration surface, marking an axis not applicable only after inspection. Do not modify or consume unrelated live task state, private captain data, or another task's durable records. Add executable/public-interface end-to-end coverage for active task -> checkpoint exits -> primary turn attempts to end -> worker writes terminal status and turn-ended -> captain notification durably surfaces exactly once; it must fail before and pass after, or precisely document why a pre-fix assertion cannot safely run and use the closest non-equivalent counterfactual. Run focused tests, bin/fm-lint.sh for shell changes, documentation audience check for maintained prose changes, and the repository no-mistakes pipeline. Open a PR and do not merge. Accepted implementation: Codex treats stop_hook_active as continuation history rather than recovery proof and rechecks the live supervision predicate on every Stop; Grok preserves its one-block behavior via explicit --grok; Claude, OpenCode, Pi, pi-signed, Kimi, and runtime backends retain their existing boundaries; existing watcher late-signal catch-up and authenticated durable queue mechanics remain unchanged. Add or refresh a real Codex live guard proving repeated Stop blocks are honored.

## What Changed

- Recheck live supervision on every Codex Stop, treating `stop_hook_active` as continuation history so terminal events cannot be missed after a foreground checkpoint exits.
- Preserve Grok’s one-block behavior through an explicit `--grok` guard mode while leaving other harness boundaries unchanged.
- Add deterministic and live coverage for repeated Codex Stop blocks and exactly-once late checkpoint catch-up, with corresponding supervision documentation updates.

## Risk Assessment

✅ Low: The change is narrowly scoped and satisfies the accepted Codex repeated-Stop contract while explicitly preserving Grok’s one-block behavior and existing durable wake semantics.

## Testing

Targeted guard and checkpoint tests exercised Codex’s retry-Stop supervision, Grok/Claude/OpenCode/Pi boundaries, and late authenticated terminal catch-up exactly once; a real Codex CLI 0.147.0 session also honored two consecutive Stop blocks, with reviewer-visible CLI logs captured. No screenshot was produced because the affected end-user surface is CLI/hook behavior rather than visual UI.

<details>
<summary>Evidence: Late-checkpoint exactly-once evidence</summary>

`ok - late checkpoint surfaces a terminal event exactly once after the bounded Codex blind-stop continuation`

```text
ok - quiet checkpoint exits 124 with a clean checkpoint line and no live lock
ok - checkpoint passes through a real watcher wake and leaves the queue for drain
ok - checkpoint preserves watcher environment for registered custom checks
ok - checkpoint rejects an existing watcher singleton as unowned
●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
●  WATCHER DOWN - SUPERVISION IS OFF
●  1 task(s) in flight, but no live watcher process holds this home lock (last beat: 1s ago).
●  Trust the emitted supervision protocol for this harness; do not use shell & for watcher repair.
●  This is a supervision warning only; the guarded operation WILL still run.
●  repair missing watcher supervision according to the session-start block for this harness; do not use shell &.
●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
ok - late checkpoint surfaces a terminal event exactly once after the bounded Codex blind-stop continuation
```
</details>
<details>
<summary>Evidence: Real Codex repeated-Stop evidence</summary>

`ok - codex-cli 0.147.0 live E2E preserved the foreground checkpoint and honored two consecutive Stop blocks`

```text
ok - codex-cli 0.147.0 live E2E preserved the foreground checkpoint and honored two consecutive Stop blocks
```
</details>
<details>
<summary>Evidence: Cross-harness turn-end guard evidence</summary>

```text
ok - fm_supervision_unhealthy: false with no state/*.meta at all
ok - fm_supervision_unhealthy: true with in-flight task and no beacon ever
ok - fm_supervision_unhealthy: true with in-flight task and a beacon far outside the grace window
ok - fm_supervision_unhealthy: false with in-flight task and a fresh beacon
ok - fm_supervision_status: FM_SUP_QUEUE_PENDING tracks state/.wake-queue
ok - fm_supervision_needed: X-mode relay poll needs supervision
ok - fm_supervision_unhealthy: source-only home needs supervision
ok - fm-turnend-guard: silent no-op with nothing in flight
ok - fm-turnend-guard: blocks when a fresh beacon has no live watcher lock
ok - fm-turnend-guard: non-Claude path blocks a source-only home
ok - fm-turnend-guard: blocks on a dead watcher lock even when the beacon is fresh
ok - fm-turnend-guard: silent no-op with a live watcher lock and fresh beacon
ok - fm-turnend-guard: healthy non-Claude harness paths ignore Claude episode contention
ok - fm-turnend-guard: blocks on a live watcher lock with an ancient beacon
ok - fm-turnend-guard: blocks with the exact required reason in the primary when unhealthy
ok - fm-turnend-guard: blocks from active FM_HOME state, not only repo-root state
ok - fm-turnend-guard: X-mode repair reason sources the cadence config
ok - fm-turnend-guard: X-mode-only supervision remains guarded in default mode
ok - fm-turnend-guard: ignores stale repo-root state when FM_HOME is set
ok - fm-turnend-guard: uses FM_STATE_OVERRIDE ahead of FM_HOME/state
ok - fm-turnend-guard: Codex stop_hook_active continuation re-checks the live supervision predicate
ok - fm-turnend-guard: blocks a blind turn end in a secondmate's own home (.fm-secondmate-home no longer excludes it)
ok - fm-turnend-guard: idle-by-default - silent in a secondmate home with nothing in flight
ok - fm-turnend-guard: secondmate Codex continuation re-checks the live supervision predicate
ok - fm-turnend-guard: secondmate deferred-death recovery - silent while watched, forces re-arm once the watcher exits
ok - fm-turnend-guard: inert in a secondmate's own child worktree (linked git worktree) even when unhealthy
ok - fm-turnend-guard: blocks a blind turn end in a treehouse-leased LINKED secondmate home (marker force-include)
ok - fm-turnend-guard: an invalid (empty) marker cannot spoof inclusion; linked worktree stays exempt
ok - fm-turnend-guard: a non-ASCII marker cannot spoof inclusion; linked worktree stays exempt
ok - fm-turnend-guard: inert in a crewmate/scout task worktree (linked git worktree) even when unhealthy
ok - fm-turnend-guard: fails open (never blocks) when jq is missing
ok - fm-turnend-guard: silent no-op on empty stdin
ok - fm-turnend-guard: runs well under the generous timing margin (0s)
ok - fm-turnend-guard-grok: forces one explicitly marked same-session resume when the shared predicate blocks
ok - fm-turnend-guard-grok: legacy environment loop guard prevents a nested resume loop
ok - fm-turnend-guard-grok: native false delegates blocking feedback with zero resume processes
ok - fm-turnend-guard-grok: native true remains bounded and starts no resume process
ok - fm-turnend-guard-grok: both spellings are typed and camelCase has deterministic precedence
ok - fm-turnend-guard-grok: malformed, invalidly typed, and missing-prerequisite payloads start neither path
ok - fm-turnend-guard-grok: missing jq and no-supervision-needed stops stay silent and bounded
ok - .codex/hooks.json: Stop hook uses hook process root when payload cwd is outside
ok - .codex/hooks.json: Stop hook ignores nested git root guard scripts
ok - .opencode primary plugin: guard path is anchored to worktree, not directory
ok - .pi primary extension: no-tool and multi-tool runs each inject exactly one guard follow-up
ok - .pi primary extension: delivery failure resets the logical-run latch
ok - fm-turnend-guard --claude: re-blocks a loop-guarded stop while unhealthy and unclaimed (incident regression)
ok - fm-turnend-guard --claude: X-mode-only homes re-block when auto-arm recovery is absent
ok - fm-turnend-guard --claude: a live arming epoch advances once and repeated observation is idempotent
ok - fm-turnend-guard --claude: repeated failed-to-arming races make bounded monotonic progress
ok - fm-turnend-guard --claude: terminal owner boundary excludes a concurrent start without deadlock
ok - fm-turnend-guard --claude: fresh rewake epoch prevents a duplicate continuation for the same event
ok - fm-turnend-guard --claude: fresh failed epochs preserve and advance monotonic fail-open progression
ok - fm-turnend-guard --claude: integrated fresh failures reach one bounded fail-open, stop continuation, and reset on recovery
ok - fm-turnend-guard --claude: reset contention preserves all episode state until retry
ok - fm-turnend-guard --claude: concurrent auto-arm and guard resets are idempotent and deadlock-free
ok - fm-turnend-guard --claude: stale rewake epoch does not allow a blind stop
ok - fm-turnend-guard --claude: budget exhaustion alone cannot permit a blind stop
ok - fm-turnend-guard --claude: verified fail-open is loud, bounded, attended, and non-repeating
ok - fm-turnend-guard --claude: fail-open requires both exhausted retries and consumed notice
ok - fm-turnend-guard --claude: away ownership excludes the Stop-autoarm fail-open
ok - fm-turnend-guard --claude: positive watcher recovery resets failure episode state
ok - fm-turnend-guard --claude: bounded claim wait avoids a token-consuming forced continuation
ok - fm-turnend-guard --claude: secondmate home re-blocks unclaimed and allows auto-arm-claimed stops
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"210efdc5ed22ed85377305511d25e936410164de","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>Inspected `git diff 70aeba855527f7693082f6dd1bc731e334d0269f..210efdc5ed22ed85377305511d25e936410164de` and the target commit’s causal evidence</code>
- `tests/fm-turnend-guard.test.sh`
- `tests/fm-watch-checkpoint.test.sh`
- `FM_CODEX_LIVE_E2E=1 tests/fm-codex-continuity-live-e2e.test.sh`
- <code>`git status --short` after transient test cleanup</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 127)

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
