### PR TITLE
feat(bin): encode bead-closure delivery discipline in doctrine and ship briefs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -350,6 +350,8 @@ A captain instruction to merge is explicit authority; `yolo` is the only standin
 For any custom `state/<id>.check.sh` you write yourself, keep it an ordinary single-link mode-`0700` file, print one line only when firstmate should wake, print nothing otherwise, finish before `FM_CHECK_TIMEOUT`, then bind its current bytes with `bin/fm-check-register.sh <id>` before the watcher may execute it.
 
 Tear down a ship task only after landing is confirmed.
+For bead-backed work, a merged PR is not delivery completion: before cleanup, attach the project's required Closure-Receipt and run its canonical bead close command.
+Land any tracker-serialization work in the same attended shift as the work it records; never leave closure truth solely on an unlanded branch.
 A teardown refusal for uncommitted or unlanded work is a stop-and-investigate result, never an obstacle to bypass.
 Never force teardown without explicit discard authority.
 After successful teardown, record completion, retain only the configured recent Done history, and re-evaluate queued work whose blockers and time gates have cleared.

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -451,6 +451,8 @@ $RULE1
 7. Never stop, restart, or update the shared \`no-mistakes\` daemon - it is one instance serving
    every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
    daemon error, append \`blocked: {the daemon error}\` and stop; only firstmate manages the daemon.
+8. For a bead-backed project, include this task's bead ID in the PR title.
+   If the project is not bead-backed, do not introduce a \`br\` workflow.
 
 # Project memory
 If \`AGENTS.md\` or \`CLAUDE.md\` already exists, or if this task produced durable project-intrinsic knowledge, run \`$FM_ROOT/bin/fm-ensure-agents-md.sh .\` in the worktree.

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -371,6 +371,21 @@ test_ship_project_memory_wording() {
   pass "fm-brief.sh: ship project-memory wording carries the AGENTS.md authoring bar"
 }
 
+test_bead_pr_title_rule_is_conditional_for_ship_briefs() {
+  local home id brief
+  home="$TMP_ROOT/bead-title-home"
+  mkdir -p "$home/data"
+  id="brief-bead-title-c2"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --mode direct-PR >/dev/null 2>&1
+  brief="$home/data/$id/brief.md"
+  assert_present "$brief" "ship brief was not scaffolded"
+  assert_grep "For a bead-backed project, include this task's bead ID in the PR title." "$brief" \
+    "ship brief lost the conditional bead ID PR-title rule"
+  assert_grep "If the project is not bead-backed, do not introduce a \`br\` workflow." "$brief" \
+    "ship brief imposed the bead workflow on projects that do not use it"
+  pass "fm-brief.sh: ship briefs condition PR-title bead IDs on bead-backed projects"
+}
+
 test_herdr_lab_contract_is_explicit_and_complete() {
   local home id brief
   home="$TMP_ROOT/herdr-lab-home"
@@ -720,6 +735,7 @@ test_delivery_flags_are_refused_where_they_do_not_apply
 test_faster_paths_use_configured_authority_without_stacked_review
 test_no_mistakes_dod_wording
 test_ship_project_memory_wording
+test_bead_pr_title_rule_is_conditional_for_ship_briefs
 test_herdr_lab_contract_is_explicit_and_complete
 test_herdr_lab_contract_quotes_foreign_firstmate_path
 test_herdr_lab_omission_is_loud_for_ship_and_scout


### PR DESCRIPTION
## Intent

Encode the permanent bead-delivery discipline in Firstmate shared lifecycle doctrine and generated ship instructions so it survives restarts and reaches future workers. Amend the existing authoritative delivery lifecycle in AGENTS.md without duplicating contracts: bead-backed work is not complete merely because its PR merged; before cleanup Firstmate must attach the project required Closure-Receipt and run the canonical bead close command. Tracker-serialization work must land in the same attended shift as the work it records and closure truth must never live solely on an unlanded branch. Amend the generated ship contract in bin/fm-brief.sh so workers on bead-backed tasks include the bead ID in the PR title, while keeping the rule conditional and introducing no br workflow for projects that are not bead-backed. Add executable generated-brief coverage through the existing public interface, never brittle source-byte assertions. Keep the change concise in existing owner locations; do not change project files, captain-private files, merge authority, or unrelated behavior. Verify documentation ownership and audience checks plus relevant brief and lint tests, then ship through no-mistakes to a green PR. Acceptance evidence must identify bin/fm-brief.sh as owner of the bead-ID PR-title rule and AGENTS.md as owner of both Closure-Receipt plus bead close delivery completion and same-shift tracker landing.

## What Changed
- AGENTS.md's delivery lifecycle now states that for bead-backed work a merged PR is not completion: before cleanup, Firstmate must attach the project's required Closure-Receipt and run the canonical bead close command, and tracker-serialization work must land in the same attended shift rather than living only on an unlanded branch.
- `bin/fm-brief.sh` adds rule 8 to generated ship briefs: on bead-backed projects, workers include the task's bead ID in the PR title; projects that are not bead-backed must not have a `br` workflow imposed on them.
- `tests/fm-brief.test.sh` gains `test_bead_pr_title_rule_is_conditional_for_ship_briefs`, which generates a real ship brief through the public interface and asserts both the conditional bead-ID rule and the no-imposition guard are present.

## Risk Assessment

✅ Low: A 20-line additive doctrine/brief change that satisfies every required intent constraint in the correct owner locations, avoids all forbidden behaviors, and includes a correctly wired public-interface test.

## Testing

Ran the targeted brief, documentation-audience, and lint test suites (all pass, including the new conditional bead-ID brief test), then generated a real ship brief end-to-end to capture the rendered worker-facing rule and the AGENTS.md doctrine excerpt; evidence identifies bin/fm-brief.sh as owner of the bead-ID PR-title rule and AGENTS.md as owner of Closure-Receipt/bead-close completion and same-shift tracker landing.

<details>
<summary>Evidence: Generated ship brief showing conditional bead-ID PR-title rule (rule 8)</summary>

<code>8. For a bead-backed project, include this task&#39;s bead ID in the PR title.&#10;If the project is not bead-backed, do not introduce a `br` workflow.</code>

```text
=== Generated ship brief (bin/fm-brief.sh evidence-bead-demo some-proj --mode direct-PR), PR-discipline section ===
# Rules
1. Never push to the default branch (push only your `fm/evidence-bead-demo` branch). Never merge a PR.
2. Stay inside this worktree; modify nothing outside it.
3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
4. Report status by appending one line:
   `echo "{state}: {one short line}" >> '/tmp/tmp.RZYkKce7Aj/state/evidence-bead-demo.status'`
   States: working, needs-decision, blocked, paused, done, failed.
   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
   would act on (setup done, bug reproduced, fix implemented, validation passed) and the
   needs-decision/blocked/paused/done/failed states. No step-by-step FYI progress lines;
   firstmate reads your pane for that.
   A mid-task `working:` line (including setup complete) is nonterminal: do not end the
   turn after it; continue the same stage until a defined `done:` gate under Definition of done.
   Use `paused: {why}` - distinct from `blocked:` - ONLY when you are deliberately idling on a
   known external wait you expect to clear on its own (an upstream release, a rate-limit reset,
   a scheduled window): firstmate then leaves your idle pane alone and rechecks it on a long
   cadence instead of treating it as a possible wedge. Use `blocked:` when you are stuck and need help.
5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
6. If a decision belongs above the implementation worker (product choices, destructive actions, ask-user findings),
   append `needs-decision: {summary of options}` and stop. Firstmate will apply the configured authority and reply with the decision.
   A decision or blocker you opened stays open until a `resolved` line carrying its exact key lands; a later `done:` or `working:` line never closes it, even when the answer is what started that work.
   Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append `resolved: {how it cleared}` yourself (same `[key=<slug>]` if you opened it with one) as you resume.
7. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving
   every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
   daemon error, append `blocked: {the daemon error}` and stop; only firstmate manages the daemon.
8. For a bead-backed project, include this task's bead ID in the PR title.
   If the project is not bead-backed, do not introduce a `br` workflow.

# Project memory
If `AGENTS.md` or `CLAUDE.md` already exists, or if this task produced durable project-intrinsic knowledge, run `/home/holu/.no-mistakes/worktrees/8cb5feef5404/01KZDKD4M30TH8RR51VE67AMM8/bin/fm-ensure-agents-md.sh .` in the worktree.
Record only project knowledge useful to almost every future session.
```
</details>
<details>
<summary>Evidence: AGENTS.md delivery-lifecycle doctrine excerpt (Closure-Receipt + same-shift tracker landing)</summary>

<code>352-Tear down a ship task only after landing is confirmed.&#10;353:For bead-backed work, a merged PR is not delivery completion: before cleanup, attach the project&#39;s required Closure-Receipt and run its canonical bead close command.&#10;354-Land any tracker-serialization work in the same attended shift as the work it records; never leave closure truth solely on an unlanded branch.</code>

```text
=== AGENTS.md delivery-lifecycle doctrine (context around new lines) ===
350-For any custom `state/<id>.check.sh` you write yourself, keep it an ordinary single-link mode-`0700` file, print one line only when firstmate should wake, print nothing otherwise, finish before `FM_CHECK_TIMEOUT`, then bind its current bytes with `bin/fm-check-register.sh <id>` before the watcher may execute it.
351-
352-Tear down a ship task only after landing is confirmed.
353:For bead-backed work, a merged PR is not delivery completion: before cleanup, attach the project's required Closure-Receipt and run its canonical bead close command.
354-Land any tracker-serialization work in the same attended shift as the work it records; never leave closure truth solely on an unlanded branch.
355-A teardown refusal for uncommitted or unlanded work is a stop-and-investigate result, never an obstacle to bypass.
356-Never force teardown without explicit discard authority.
357-After successful teardown, record completion, retain only the configured recent Done history, and re-evaluate queued work whose blockers and time gates have cleared.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash tests/fm-brief.test.sh` — all 20 checks pass, including the new `test_bead_pr_title_rule_is_conditional_for_ship_briefs` exercising the public fm-brief.sh interface</code>
- <code>`bash tests/fm-documentation-audiences.test.sh` — documentation ownership/audience/classification checks pass with the AGENTS.md amendment</code>
- <code>`bash tests/fm-lint.test.sh` — passes (ShellCheck-version-pinned sub-checks skip gracefully in this environment; CI owns the real lint run)</code>
- <code>Manual end-to-end: `bin/fm-brief.sh evidence-bead-demo some-proj --mode direct-PR` generated a real ship brief; verified rendered rule 8 carries the conditional bead-ID PR-title rule and the no-`br`-imposition guard</code>
- <code>Manual: verified AGENTS.md:353-354 doctrine lines sit inside the existing teardown/landing lifecycle section without duplicating contracts; `git status --porcelain` clean after cleanup</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 127)

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
