### PR TITLE
Guard .claude hooks against exit-127 under non-Claude harnesses

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -17,11 +17,11 @@
         "hooks": [
           {
             "type": "command",
-            "command": "\"$CLAUDE_PROJECT_DIR\"/bin/fm-arm-pretool-check.sh --claude"
+            "command": "[ -n \"${CLAUDE_PROJECT_DIR:-}\" ] || exit 0; \"$CLAUDE_PROJECT_DIR\"/bin/fm-arm-pretool-check.sh --claude"
           },
           {
             "type": "command",
-            "command": "\"$CLAUDE_PROJECT_DIR\"/bin/fm-cd-pretool-check.sh --claude"
+            "command": "[ -n \"${CLAUDE_PROJECT_DIR:-}\" ] || exit 0; \"$CLAUDE_PROJECT_DIR\"/bin/fm-cd-pretool-check.sh --claude"
           }
         ]
       },
@@ -30,7 +30,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "\"$CLAUDE_PROJECT_DIR\"/bin/fm-subagent-pretool-check.sh --claude"
+            "command": "[ -n \"${CLAUDE_PROJECT_DIR:-}\" ] || exit 0; \"$CLAUDE_PROJECT_DIR\"/bin/fm-subagent-pretool-check.sh --claude"
           }
         ]
       }
@@ -40,11 +40,11 @@
         "hooks": [
           {
             "type": "command",
-            "command": "[ -z \"${GROK_AGENT:-}\" ] || exit 0; exec \"$CLAUDE_PROJECT_DIR\"/bin/fm-turnend-guard.sh --claude"
+            "command": "[ -n \"${CLAUDE_PROJECT_DIR:-}\" ] || exit 0; [ -z \"${GROK_AGENT:-}\" ] || exit 0; exec \"$CLAUDE_PROJECT_DIR\"/bin/fm-turnend-guard.sh --claude"
           },
           {
             "type": "command",
-            "command": "[ -z \"${GROK_AGENT:-}\" ] || exit 0; exec \"$CLAUDE_PROJECT_DIR\"/bin/fm-claude-stop-autoarm.sh",
+            "command": "[ -n \"${CLAUDE_PROJECT_DIR:-}\" ] || exit 0; [ -z \"${GROK_AGENT:-}\" ] || exit 0; exec \"$CLAUDE_PROJECT_DIR\"/bin/fm-claude-stop-autoarm.sh",
             "asyncRewake": true,
             "timeout": 28800
           }


### PR DESCRIPTION
## Problem

`.claude/settings.json` hook commands are written as `"$CLAUDE_PROJECT_DIR"/bin/fm-*.sh`. Codex and Kimi also load Claude-compatible project settings, but they do not set `$CLAUDE_PROJECT_DIR`, so the command resolves to `/bin/fm-*.sh` (nonexistent) and exits **127** on every `PreToolUse` / `Stop` hook. Any firstmate home running a non-Claude harness (a common secondmate/crewmate configuration) then prints a 127 error on every tool call.

Reproduced: with `CLAUDE_PROJECT_DIR` unset the hook command exits 127; with it set it exits 0. The `Stop` hooks already skip under `GROK_AGENT`, but the `PreToolUse` hooks have no guard, and codex/kimi have no skip at all.

This is cosmetic — those harnesses still get the equivalent guards via their own `.codex/hooks.json` — but it is noisy on every action.

## Fix

Prepend `[ -n "${CLAUDE_PROJECT_DIR:-}" ] || exit 0;` to each hook command that references `$CLAUDE_PROJECT_DIR`, so a foreign harness loading these Claude-compatible settings no-ops cleanly instead of hitting a missing `/bin/...` path. Real Claude Code is unchanged (the variable is always set there), and the existing `GROK_AGENT` skips remain.

Verified:
- `CLAUDE_PROJECT_DIR` unset → hook exits 0 (was 127).
- `CLAUDE_PROJECT_DIR` set → hook runs the guard as before (exit 0).

5-line change, `.claude/settings.json` only.
