### PR TITLE
test: enforce brief scaffolding under stock macOS Bash

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -347,6 +347,14 @@ jobs:
           done < "$shell_inventory"
           [ "$parse_fail" -eq 0 ] || { echo "::error::stock macOS Bash 3.2 parse sweep failed"; exit 1; }
 
+          brief_output=$(/bin/bash tests/fm-brief.test.sh)
+          printf '%s\n' "$brief_output"
+          brief_count=$(printf '%s\n' "$brief_output" | grep -c '^ok - ')
+          [ "$brief_count" -eq 21 ] || {
+            echo "::error::expected 21 fm-brief tests, got $brief_count"
+            exit 1
+          }
+
           snapshot_output=$(/bin/bash tests/fm-fleet-snapshot-view.test.sh)
           printf '%s\n' "$snapshot_output"
           snapshot_count=$(printf '%s\n' "$snapshot_output" | grep -c '^ok - ')

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -11,8 +11,9 @@
 # use `IFS= read -r -d '' VAR <<EOF || true` instead, which removes the `$(...)`
 # wrapper and eliminates the whole defect class regardless of future prose.
 # test_no_heredoc_in_command_substitution guards that structure directly.
-# Ambient `bash -n` here is Bash 5 and cannot see the bug, so the real
-# cross-version enforcement lives in the macos-stock-bash CI job.
+# The syntax and ordinary-task scaffold checks below invoke `/bin/bash`
+# explicitly. The macos-stock-bash CI job runs this suite and proves that path
+# is the stock Bash 3.2 runtime rather than a newer Bash selected through PATH.
 set -u
 
 # shellcheck source=tests/lib.sh
@@ -22,16 +23,15 @@ TMP_ROOT=$(fm_test_tmproot fm-brief)
 BRIEF_HOME="$TMP_ROOT/home"
 mkdir -p "$BRIEF_HOME/data"
 
-# The script itself must always parse under the ambient bash. That is Bash 5 in
-# CI and locally, where the issue #958/#1069 parser bug does not fire, so this
-# is a weak guard on its own; test_no_heredoc_in_command_substitution and the
-# macos-stock-bash CI job carry the real cross-version enforcement.
+# The script itself must always parse through `/bin/bash`. The macOS CI job
+# pins that executable to stock Bash 3.2.57; the structural guard below keeps
+# the defect class visible on platforms where `/bin/bash` is newer.
 test_script_parses() {
   local out rc
-  out=$(bash -n "$ROOT/bin/fm-brief.sh" 2>&1); rc=$?
-  expect_code 0 "$rc" "bash -n bin/fm-brief.sh must parse cleanly (got: $out)"
-  [ -z "$out" ] || fail "bash -n bin/fm-brief.sh emitted unexpected output: $out"
-  pass "fm-brief.sh: bash -n succeeds"
+  out=$(/bin/bash -n "$ROOT/bin/fm-brief.sh" 2>&1); rc=$?
+  expect_code 0 "$rc" "/bin/bash -n bin/fm-brief.sh must parse cleanly (got: $out)"
+  [ -z "$out" ] || fail "/bin/bash -n bin/fm-brief.sh emitted unexpected output: $out"
+  pass "fm-brief.sh: /bin/bash -n succeeds"
 }
 
 # Structural class guard (issues #166, #958, #1069): never build a variable by
@@ -215,6 +215,78 @@ test_ship_modes_generate_clean_briefs() {
     assert_no_grep "EOF" "$brief" "$id: brief leaked a heredoc EOF marker (unterminated heredoc)"
   done
   pass "fm-brief.sh: no-mistakes/direct-PR/local-only briefs generate cleanly"
+}
+
+# Execute every ordinary-task scaffold through `/bin/bash` with apostrophes in
+# both an interpolated repository name and a shell-quoted status path. Exact
+# line assertions pin the byte-sensitive quoting boundary, literal commands,
+# task placeholder, and mode-specific sections. On macOS CI this is Bash 3.2.
+test_stock_bash_apostrophe_fixture_scaffolds_every_ordinary_mode() {
+  local home kind mode id brief status_file_quoted
+  home="$TMP_ROOT/captain's fixtures"
+  mkdir -p "$home/data"
+
+  while IFS='|' read -r kind mode id; do
+    case "$kind" in
+      ship)
+        FM_HOME="$home" /bin/bash "$ROOT/bin/fm-brief.sh" \
+          "$id" "captain's repo" --mode "$mode" >/dev/null 2>&1 \
+          || fail "$kind/$mode: stock-Bash scaffold failed with apostrophe fixture"
+        ;;
+      scout)
+        FM_HOME="$home" /bin/bash "$ROOT/bin/fm-brief.sh" \
+          "$id" "captain's repo" --scout >/dev/null 2>&1 \
+          || fail "$kind: stock-Bash scaffold failed with apostrophe fixture"
+        ;;
+    esac
+
+    brief="$home/data/$id/brief.md"
+    assert_present "$brief" "$kind/$mode: apostrophe fixture did not produce a brief"
+    grep -Fqx "You are in a disposable git worktree of captain's repo, at a detached HEAD on a clean default branch." "$brief" \
+      || fail "$kind/$mode: interpolated apostrophe-bearing repository line changed"
+    grep -Fqx '{TASK}' "$brief" \
+      || fail "$kind/$mode: literal task placeholder was expanded or changed"
+
+    status_file_quoted="'$(printf '%s' "$home/state/$id.status" | sed "s/'/'\\\\''/g")'"
+    grep -Fqx "   \`echo \"{state}: {one short line}\" >> $status_file_quoted\`" "$brief" \
+      || fail "$kind/$mode: shell-quoted apostrophe-bearing status command changed"
+
+    case "$kind:$mode" in
+      ship:no-mistakes)
+        grep -Fqx 'Delivery contract: mode=no-mistakes' "$brief" \
+          || fail "no-mistakes: delivery section changed"
+        assert_grep '`no-mistakes axi run --help`' "$brief" \
+          "no-mistakes: literal pipeline help command changed"
+        assert_grep "firstmate's authority check" "$brief" \
+          "no-mistakes: apostrophe-bearing pipeline prose changed"
+        ;;
+      ship:direct-PR)
+        grep -Fqx 'Delivery contract: mode=direct-PR' "$brief" \
+          || fail "direct-PR: delivery section changed"
+        assert_grep 'open a PR with `gh-axi`' "$brief" \
+          "direct-PR: literal PR command changed"
+        ;;
+      ship:local-only)
+        grep -Fqx 'Delivery contract: mode=local-only' "$brief" \
+          || fail "local-only: delivery section changed"
+        assert_grep "branch \`fm/$id\`" "$brief" \
+          "local-only: literal task branch changed"
+        ;;
+      scout:scout)
+        grep -Fqx 'This is a SCOUT task: the deliverable is a written report, not a PR.' "$brief" \
+          || fail "scout: task-mode section changed"
+        grep -Fqx "Write your findings to \`$home/data/$id/report.md\`." "$brief" \
+          || fail "scout: literal report path changed"
+        ;;
+    esac
+    assert_no_grep 'EOF' "$brief" "$kind/$mode: heredoc terminator leaked into generated bytes"
+  done <<'ROWS'
+ship|no-mistakes|apostrophe-nm
+ship|direct-PR|apostrophe-direct
+ship|local-only|apostrophe-local
+scout|scout|apostrophe-scout
+ROWS
+  pass "fm-brief.sh: /bin/bash scaffolds apostrophe fixtures in every ordinary-task mode"
 }
 
 # A ship task's delivery mode is firstmate's per-task decision, so a missing or
@@ -714,6 +786,7 @@ test_script_parses
 test_no_heredoc_in_command_substitution
 test_help_includes_entire_header
 test_ship_modes_generate_clean_briefs
+test_stock_bash_apostrophe_fixture_scaffolds_every_ordinary_mode
 test_ship_mode_is_required_and_closed_set
 test_ship_mode_is_explicit_not_registry
 test_delivery_flags_are_refused_where_they_do_not_apply


### PR DESCRIPTION
## Intent

Fix Firstmate execution card FM-BRIEF-001 so bin/fm-brief.sh reliably scaffolds ship and scout briefs under stock macOS Bash 3.2 when generated prose, interpolated repository names, or quoted paths contain apostrophes. Reproduce the historical heredoc-inside-command-substitution parse failure, use the smallest style-consistent solution, preserve generated brief bytes and all no-mistakes, direct-PR, local-only, and scout behavior, and add focused regression coverage that explicitly runs /bin/bash syntax and scaffolding checks for every ordinary-task mode with exact assertions for literal commands, paths, variables, placeholders, quoting, and mode-specific sections. Do not change dispatch policy, task lifecycle semantics, unrelated scaffolding text, or authoritative docs unless the implementation contract changes, and never merge the PR. Investigation established that the structural implementation fix is already present on the current default branch from prior work, so this branch must add the missing explicit Bash 3.2 runtime enforcement without churning generated production bytes.

## What Changed

- Run `fm-brief.sh` syntax and scaffolding checks explicitly through `/bin/bash`.
- Add apostrophe-bearing fixtures with exact assertions across no-mistakes, direct-PR, local-only, and scout briefs.
- Execute the 21-check brief suite in the stock macOS Bash 3.2 CI job.

## Risk Assessment

✅ Low: The change is test-only, preserves production brief bytes, and adds explicit stock Bash 3.2 syntax and apostrophe-bearing scaffolding coverage for all ordinary-task modes.

## Testing

No prior baseline results were supplied. Stock macOS `/bin/bash` 3.2.57 reproduced the historical heredoc/apostrophe parse failure, then passed the focused suite and exact CI count contract; all four ordinary-task modes scaffolded correctly with apostrophes while preserving literal placeholders, quoting, commands, paths, and mode sections. One initial CI-wrapper attempt inherited zsh and failed before testing because `BASH_VERSION` was unset; rerunning with the configured `/bin/bash` succeeded. The worktree remained clean. This is CLI-generated Markdown, so reviewer-visible brief artifacts were captured instead of screenshots.

<details>
<summary>Evidence: Historical Bash 3.2 failure reproduction</summary>

<code>GNU Bash 3.2.57 reports “unexpected EOF while looking for matching `&#39;`” and exits 2, reproducing the historical parser defect.</code>

```text
#!/bin/bash

brief=$(cat <<EOF
Firstmate's authority check must remain intact.
EOF
)

printf '%s\n' "$brief"
```
</details>
<details>
<summary>Evidence: No-mistakes brief</summary>

`Generated with an apostrophe-bearing repository and FM_HOME; SHA-256 d495afdf116593d3109884070989adaad5274e6fe65c234ae721cd74e191b9d1.`

```text
You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.

# Task
{TASK}

# Herdr lifecycle declaration - NOT ENABLED
**HARD SAFETY GATE:** this scaffold cannot inspect the task text that replaces `{TASK}` later.
If the task will start, stop, delete, restart, profile, or otherwise drive Herdr lifecycle behavior, stop and regenerate the brief with `--herdr-lab` before dispatch.
Do not add Herdr lifecycle commands to this unguarded brief by hand.

# Setup
You are in a disposable git worktree of captain's repo, at a detached HEAD on a clean default branch.

**Verify isolation before anything else.** Run `pwd -P` and `git rev-parse --show-toplevel`; both must resolve to the disposable task worktree you were launched in, such as a treehouse pool path or an Orca-managed worktree, not the primary checkout firstmate operates from.
The path check is authoritative: `git rev-parse --git-dir` and `git rev-parse --git-common-dir` can help inspect the repo, but they do not prove you are outside the primary checkout.
If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not branch or commit here - append `blocked: launched in primary checkout, not an isolated worktree` to the status file and stop.

1. First action: create your branch: `git checkout -b fm/apostrophe-nm`
2. Run `no-mistakes doctor`; if it reports the repo is not initialized here, run `no-mistakes init`.

# Rules
1. Never push to the default branch. Never merge a PR.
2. Stay inside this worktree; modify nothing outside it.
3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
4. Report status by appending one line:
   `echo "{state}: {one short line}" >> '/var/folders/s8/0_mzgfjj34v2wr0gvxxh64n80000gn/T/no-mistakes-evidence/01KZDMV5V39SJNJY8MCBNBE59Z/captain'\''s evidence/state/apostrophe-nm.status'`
   States: working, needs-decision, blocked, paused, done, failed.
   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
   would act on (setup done, bug reproduced, fix implemented, validation passed) and the
   needs-decision/blocked/paused/done/failed states. No step-by-step FYI progress lines;
   firstmate reads your pane for that.
   A mid-task `working:` line (including setup complete) is nonterminal: do not end the
   turn after it; continue the same stage until a defined `done:` gate under Definition of done.
   Use `paused: {why}` - distinct from `blocked:` - ONLY when you are deliberately idling on a
   known external wait you expect to clear on its own (an upstream release, a rate-limit reset,
   a scheduled window): firstmate then leaves your idle pane alone and rechecks it on a long
   cadence instead of treating it as a possible wedge. Use `blocked:` when you are stuck and need help.
5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
6. If a decision belongs above the implementation worker (product choices, destructive actions, ask-user findings),
   append `needs-decision: {summary of options}` and stop. Firstmate will apply the configured authority and reply with the decision.
   A decision or blocker you opened stays open until a `resolved` line carrying its exact key lands; a later `done:` or `working:` line never closes it, even when the answer is what started that work.
   Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append `resolved: {how it cleared}` yourself (same `[key=<slug>]` if you opened it with one) as you resume.
7. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving
   every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
   daemon error, append `blocked: {the daemon error}` and stop; only firstmate manages the daemon.

# Project memory
If `AGENTS.md` or `CLAUDE.md` already exists, or if this task produced durable project-intrinsic knowledge, run `/Users/mohammedameen/.no-mistakes/worktrees/ac543050f1c8/01KZDMV5V39SJNJY8MCBNBE59Z/bin/fm-ensure-agents-md.sh .` in the worktree.
Record only project knowledge useful to almost every future session.
For anything the codebase already shows, prefer a pointer to the authoritative file, command, or doc over copying the detail.
If you touch a project `AGENTS.md` that lacks `## Maintaining this file`, add that short self-governance section from `/Users/mohammedameen/.no-mistakes/worktrees/ac543050f1c8/01KZDMV5V39SJNJY8MCBNBE59Z/bin/fm-ensure-agents-md.sh` in the same pass.
Keep it proportionate: skip `AGENTS.md` edits for trivial tasks that produced no durable project knowledge.

# Definition of done
Delivery contract: mode=no-mistakes
The task is complete only when committed on your branch.
When you believe it is complete, append `done: {summary}` to the status file and stop.
Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.

You drive no-mistakes by responding to its gates, not by implementing fixes.
Follow the guidance no-mistakes itself provides for the mechanics: it loads when you invoke /no-mistakes, and `no-mistakes axi run --help` plus the `help` lines in each `axi` response are authoritative and version-matched to the installed binary.
When starting no-mistakes, make `--intent` preserve all relevant content from this brief's `# Task` section plus every later accepted Firstmate requirement, clarification, constraint, exclusion, and supersession, carrying only each requirement's current accepted form; retain direct requirements instead of substituting a diff summary, and exclude generic operational, status, delivery, and other scaffold boilerplate unless it is task-specific.
Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix.

Two firstmate-specific rules layer on top of that guidance:
- ask-user findings are never yours to answer: escalate to firstmate (rule 6) and stop.
  Firstmate applies the authority contract in its `AGENTS.md` and obtains any required captain decision.
  When the decision comes back, feed it to the gate with `no-mistakes axi respond` and let the pipeline apply it - do not route the question to "the user" or implement the fix yourself.
- Avoid `--yes`: it would silently bypass firstmate's authority check and any required captain escalation.

After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append `done: PR {url} checks green` and stop. You are finished.
```
</details>
<details>
<summary>Evidence: Direct-PR brief</summary>

`Generated with an apostrophe-bearing repository and FM_HOME; SHA-256 2251d81e7e2e7a2a12fd9c6ec0ac8b0ac769e7df3aba400ad274e2509f825956.`

```text
You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.

# Task
{TASK}

# Herdr lifecycle declaration - NOT ENABLED
**HARD SAFETY GATE:** this scaffold cannot inspect the task text that replaces `{TASK}` later.
If the task will start, stop, delete, restart, profile, or otherwise drive Herdr lifecycle behavior, stop and regenerate the brief with `--herdr-lab` before dispatch.
Do not add Herdr lifecycle commands to this unguarded brief by hand.

# Setup
You are in a disposable git worktree of captain's repo, at a detached HEAD on a clean default branch.

**Verify isolation before anything else.** Run `pwd -P` and `git rev-parse --show-toplevel`; both must resolve to the disposable task worktree you were launched in, such as a treehouse pool path or an Orca-managed worktree, not the primary checkout firstmate operates from.
The path check is authoritative: `git rev-parse --git-dir` and `git rev-parse --git-common-dir` can help inspect the repo, but they do not prove you are outside the primary checkout.
If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not branch or commit here - append `blocked: launched in primary checkout, not an isolated worktree` to the status file and stop.

1. First action: create your branch: `git checkout -b fm/apostrophe-direct`

# Rules
1. Never push to the default branch (push only your `fm/apostrophe-direct` branch). Never merge a PR.
2. Stay inside this worktree; modify nothing outside it.
3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
4. Report status by appending one line:
   `echo "{state}: {one short line}" >> '/var/folders/s8/0_mzgfjj34v2wr0gvxxh64n80000gn/T/no-mistakes-evidence/01KZDMV5V39SJNJY8MCBNBE59Z/captain'\''s evidence/state/apostrophe-direct.status'`
   States: working, needs-decision, blocked, paused, done, failed.
   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
   would act on (setup done, bug reproduced, fix implemented, validation passed) and the
   needs-decision/blocked/paused/done/failed states. No step-by-step FYI progress lines;
   firstmate reads your pane for that.
   A mid-task `working:` line (including setup complete) is nonterminal: do not end the
   turn after it; continue the same stage until a defined `done:` gate under Definition of done.
   Use `paused: {why}` - distinct from `blocked:` - ONLY when you are deliberately idling on a
   known external wait you expect to clear on its own (an upstream release, a rate-limit reset,
   a scheduled window): firstmate then leaves your idle pane alone and rechecks it on a long
   cadence instead of treating it as a possible wedge. Use `blocked:` when you are stuck and need help.
5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
6. If a decision belongs above the implementation worker (product choices, destructive actions, ask-user findings),
   append `needs-decision: {summary of options}` and stop. Firstmate will apply the configured authority and reply with the decision.
   A decision or blocker you opened stays open until a `resolved` line carrying its exact key lands; a later `done:` or `working:` line never closes it, even when the answer is what started that work.
   Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append `resolved: {how it cleared}` yourself (same `[key=<slug>]` if you opened it with one) as you resume.
7. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving
   every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
   daemon error, append `blocked: {the daemon error}` and stop; only firstmate manages the daemon.

# Project memory
If `AGENTS.md` or `CLAUDE.md` already exists, or if this task produced durable project-intrinsic knowledge, run `/Users/mohammedameen/.no-mistakes/worktrees/ac543050f1c8/01KZDMV5V39SJNJY8MCBNBE59Z/bin/fm-ensure-agents-md.sh .` in the worktree.
Record only project knowledge useful to almost every future session.
For anything the codebase already shows, prefer a pointer to the authoritative file, command, or doc over copying the detail.
If you touch a project `AGENTS.md` that lacks `## Maintaining this file`, add that short self-governance section from `/Users/mohammedameen/.no-mistakes/worktrees/ac543050f1c8/01KZDMV5V39SJNJY8MCBNBE59Z/bin/fm-ensure-agents-md.sh` in the same pass.
Keep it proportionate: skip `AGENTS.md` edits for trivial tasks that produced no durable project knowledge.

# Definition of done
Delivery contract: mode=direct-PR
This task ships **direct-PR**: you raise the PR yourself, without the no-mistakes pipeline.
The task is complete only when committed on your branch.
When it is implemented and committed, push your branch and open a PR with `gh-axi`, then append `done: PR {url}` to the status file and stop.
Do NOT run /no-mistakes. The configured merge authority decides whether to merge the PR; firstmate relays the outcome.
```
</details>
<details>
<summary>Evidence: Local-only brief</summary>

`Generated with an apostrophe-bearing repository and FM_HOME; SHA-256 2db9b6320f47c11409d1f8836c484aafeb58c534b1dc545a41afb7ce61aac3d7.`

```text
You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.

# Task
{TASK}

# Herdr lifecycle declaration - NOT ENABLED
**HARD SAFETY GATE:** this scaffold cannot inspect the task text that replaces `{TASK}` later.
If the task will start, stop, delete, restart, profile, or otherwise drive Herdr lifecycle behavior, stop and regenerate the brief with `--herdr-lab` before dispatch.
Do not add Herdr lifecycle commands to this unguarded brief by hand.

# Setup
You are in a disposable git worktree of captain's repo, at a detached HEAD on a clean default branch.

**Verify isolation before anything else.** Run `pwd -P` and `git rev-parse --show-toplevel`; both must resolve to the disposable task worktree you were launched in, such as a treehouse pool path or an Orca-managed worktree, not the primary checkout firstmate operates from.
The path check is authoritative: `git rev-parse --git-dir` and `git rev-parse --git-common-dir` can help inspect the repo, but they do not prove you are outside the primary checkout.
If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not branch or commit here - append `blocked: launched in primary checkout, not an isolated worktree` to the status file and stop.

1. First action: create your branch: `git checkout -b fm/apostrophe-local`

# Rules
1. Never push to any remote and never open a PR. Work only on your `fm/apostrophe-local` branch; firstmate handles the merge into local `main`.
2. Stay inside this worktree; modify nothing outside it.
3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
4. Report status by appending one line:
   `echo "{state}: {one short line}" >> '/var/folders/s8/0_mzgfjj34v2wr0gvxxh64n80000gn/T/no-mistakes-evidence/01KZDMV5V39SJNJY8MCBNBE59Z/captain'\''s evidence/state/apostrophe-local.status'`
   States: working, needs-decision, blocked, paused, done, failed.
   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
   would act on (setup done, bug reproduced, fix implemented, validation passed) and the
   needs-decision/blocked/paused/done/failed states. No step-by-step FYI progress lines;
   firstmate reads your pane for that.
   A mid-task `working:` line (including setup complete) is nonterminal: do not end the
   turn after it; continue the same stage until a defined `done:` gate under Definition of done.
   Use `paused: {why}` - distinct from `blocked:` - ONLY when you are deliberately idling on a
   known external wait you expect to clear on its own (an upstream release, a rate-limit reset,
   a scheduled window): firstmate then leaves your idle pane alone and rechecks it on a long
   cadence instead of treating it as a possible wedge. Use `blocked:` when you are stuck and need help.
5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
6. If a decision belongs above the implementation worker (product choices, destructive actions, ask-user findings),
   append `needs-decision: {summary of options}` and stop. Firstmate will apply the configured authority and reply with the decision.
   A decision or blocker you opened stays open until a `resolved` line carrying its exact key lands; a later `done:` or `working:` line never closes it, even when the answer is what started that work.
   Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append `resolved: {how it cleared}` yourself (same `[key=<slug>]` if you opened it with one) as you resume.
7. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving
   every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
   daemon error, append `blocked: {the daemon error}` and stop; only firstmate manages the daemon.

# Project memory
If `AGENTS.md` or `CLAUDE.md` already exists, or if this task produced durable project-intrinsic knowledge, run `/Users/mohammedameen/.no-mistakes/worktrees/ac543050f1c8/01KZDMV5V39SJNJY8MCBNBE59Z/bin/fm-ensure-agents-md.sh .` in the worktree.
Record only project knowledge useful to almost every future session.
For anything the codebase already shows, prefer a pointer to the authoritative file, command, or doc over copying the detail.
If you touch a project `AGENTS.md` that lacks `## Maintaining this file`, add that short self-governance section from `/Users/mohammedameen/.no-mistakes/worktrees/ac543050f1c8/01KZDMV5V39SJNJY8MCBNBE59Z/bin/fm-ensure-agents-md.sh` in the same pass.
Keep it proportionate: skip `AGENTS.md` edits for trivial tasks that produced no durable project knowledge.

# Definition of done
Delivery contract: mode=local-only
This task ships **local-only**: no remote, no PR, no pipeline.
The task is complete only when committed on your branch `fm/apostrophe-local`. Do NOT push, do NOT open a PR, do NOT merge.
Keep your branch a clean fast-forward onto the current default branch - if `main` has advanced, rebase onto it so the eventual merge stays a fast-forward.
When it is implemented and committed, append `done: ready in branch fm/apostrophe-local` to the status file and stop.
The configured merge authority approves the ready branch, then firstmate merges it into local `main` through the guarded fast-forward path.
```
</details>
<details>
<summary>Evidence: Scout brief</summary>

`Generated with an apostrophe-bearing repository and FM_HOME; SHA-256 cd092eb930349b2b59e368c96c0645ab524096c1543980d7906a72831ddca91a.`

```text
You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.

# Task
{TASK}

# Herdr lifecycle declaration - NOT ENABLED
**HARD SAFETY GATE:** this scaffold cannot inspect the task text that replaces `{TASK}` later.
If the task will start, stop, delete, restart, profile, or otherwise drive Herdr lifecycle behavior, stop and regenerate the brief with `--herdr-lab` before dispatch.
Do not add Herdr lifecycle commands to this unguarded brief by hand.

# Setup
You are in a disposable git worktree of captain's repo, at a detached HEAD on a clean default branch.
This is a SCOUT task: the deliverable is a written report, not a PR.
The worktree is your laboratory - install, run, edit, and make scratch commits freely; all of it is discarded at teardown.
The report is the only thing that survives, so anything worth keeping must be in it.

# Rules
1. Never push to any remote and never open a PR.
2. Stay inside this worktree; the only files you may write outside it are the report and the status file below.
3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
4. Report status by appending one line:
   `echo "{state}: {one short line}" >> '/var/folders/s8/0_mzgfjj34v2wr0gvxxh64n80000gn/T/no-mistakes-evidence/01KZDMV5V39SJNJY8MCBNBE59Z/captain'\''s evidence/state/apostrophe-scout.status'`
   States: working, needs-decision, blocked, paused, done, failed.
   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
   would act on and the needs-decision/blocked/paused/done/failed states. No step-by-step
   FYI progress lines; firstmate reads your pane for that.
   Use `paused: {why}` - distinct from `blocked:` - ONLY when you are deliberately idling on a
   known external wait you expect to clear on its own (an upstream release, a rate-limit reset):
   firstmate then leaves your idle pane alone and rechecks it on a long cadence instead of
   treating it as a possible wedge. Use `blocked:` when you are stuck and need help.
5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
6. If a decision belongs to a human (product choices, destructive actions),
   append `needs-decision: {summary of options}` and stop. Firstmate will reply with the decision.
   A decision or blocker you opened stays open until a `resolved` line carrying its exact key lands; a later `done:` or `working:` line never closes it, even when the answer is what started that work.
   Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append `resolved: {how it cleared}` yourself (same `[key=<slug>]` if you opened it with one) as you resume.
7. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving
   every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
   daemon error, append `blocked: {the daemon error}` and stop; only firstmate manages the daemon.

# Definition of done
Write your findings to `/var/folders/s8/0_mzgfjj34v2wr0gvxxh64n80000gn/T/no-mistakes-evidence/01KZDMV5V39SJNJY8MCBNBE59Z/captain's evidence/data/apostrophe-scout/report.md`.
The report must stand alone: what you did, what you found, the evidence (commands run, output, file:line references), and what you recommend.
Before reporting done, read and follow `/Users/mohammedameen/.no-mistakes/worktrees/ac543050f1c8/01KZDMV5V39SJNJY8MCBNBE59Z/.agents/skills/decision-hold-lifecycle/SKILL.md` and pass its shared completion gate for the report and any visual review.
When the report is complete, append `done: {one-line conclusion}` to the status file and stop.
If your findings reveal work that should ship (e.g. you reproduced a bug and the fix is clear), say so in the report; firstmate may promote this task in place, and you would then receive mode-specific ship instructions as a follow-up message.
```
</details>
<details>
<summary>Evidence: Generator byte preservation</summary>

```text
Base and target both reference generator blob a873c840517af4f45fee49de841d6e6c23b49934, confirming no production-generator byte churn.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `/bin/bash --version | head -1`
- `/bin/bash tests/fm-brief.test.sh`
- <code>CI-equivalent Bash 3.2 wrapper invoking `/bin/bash tests/fm-brief.test.sh` and asserting exactly 21 successful checks</code>
- <code>`/bin/bash -n .../historical-heredoc-apostrophe.sh` (expected historical failure, exit 2)</code>
- `FM_HOME=".../captain's evidence" /bin/bash bin/fm-brief.sh apostrophe-nm "captain's repo" --mode no-mistakes`
- `FM_HOME=".../captain's evidence" /bin/bash bin/fm-brief.sh apostrophe-direct "captain's repo" --mode direct-PR`
- `FM_HOME=".../captain's evidence" /bin/bash bin/fm-brief.sh apostrophe-local "captain's repo" --mode local-only`
- `FM_HOME=".../captain's evidence" /bin/bash bin/fm-brief.sh apostrophe-scout "captain's repo" --scout`
- <code>Compared base and target `bin/fm-brief.sh` Git blob IDs and generated-brief contents, quoting, placeholders, paths, commands, and mode-specific sections.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 127)

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
