### PR TITLE
fix(harness): resolve conflicting env markers by process ancestry

### DIFF
--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -39,7 +39,7 @@ If the captain asks for a new harness, propose verifying it first: spawn a trivi
 
 ## Detection
 
-`bin/fm-harness.sh` prints firstmate's own harness, using verified env markers first and then process ancestry; conflicting ambient markers (e.g. a shell-profile `CLAUDECODE=1` leaked into a Pi session) are resolved by ancestry because no env marker alone is then trustworthy — ancestry settles the family, so the Pi-family signed selection below still applies.
+`bin/fm-harness.sh` prints firstmate's own harness, using verified env markers first and then process ancestry; conflicting ambient markers (e.g. a shell-profile `CLAUDECODE=1` leaked into a Pi session) are resolved by ancestry because no env marker alone is then trustworthy - ancestry settles the family, so the Pi-family signed selection below still applies.
 Within the Pi family, only the exact launch-boundary marker `FM_PI_HARNESS=pi-signed` alongside `PI_CODING_AGENT=true` selects the signed identity; unmarked shared launcher ancestry remains `pi`.
 `bin/fm-harness.sh crew` resolves the effective crewmate harness from `config/crew-harness` (absent or `default` -> own).
 `bin/fm-harness.sh secondmate` resolves the secondmate-launch harness through the chain `config/secondmate-harness` -> `config/crew-harness` -> own, so an unset `config/secondmate-harness` matches the crew harness.

--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -39,7 +39,7 @@ If the captain asks for a new harness, propose verifying it first: spawn a trivi
 
 ## Detection
 
-`bin/fm-harness.sh` prints firstmate's own harness, using verified env markers first and then process ancestry.
+`bin/fm-harness.sh` prints firstmate's own harness, using verified env markers first and then process ancestry; conflicting ambient markers (e.g. a shell-profile `CLAUDECODE=1` leaked into a Pi session) are resolved by ancestry because no env marker alone is then trustworthy.
 Within the Pi family, only the exact launch-boundary marker `FM_PI_HARNESS=pi-signed` alongside `PI_CODING_AGENT=true` selects the signed identity; unmarked shared launcher ancestry remains `pi`.
 `bin/fm-harness.sh crew` resolves the effective crewmate harness from `config/crew-harness` (absent or `default` -> own).
 `bin/fm-harness.sh secondmate` resolves the secondmate-launch harness through the chain `config/secondmate-harness` -> `config/crew-harness` -> own, so an unset `config/secondmate-harness` matches the crew harness.

--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -39,7 +39,7 @@ If the captain asks for a new harness, propose verifying it first: spawn a trivi
 
 ## Detection
 
-`bin/fm-harness.sh` prints firstmate's own harness, using verified env markers first and then process ancestry; conflicting ambient markers (e.g. a shell-profile `CLAUDECODE=1` leaked into a Pi session) are resolved by ancestry because no env marker alone is then trustworthy.
+`bin/fm-harness.sh` prints firstmate's own harness, using verified env markers first and then process ancestry; conflicting ambient markers (e.g. a shell-profile `CLAUDECODE=1` leaked into a Pi session) are resolved by ancestry because no env marker alone is then trustworthy — ancestry settles the family, so the Pi-family signed selection below still applies.
 Within the Pi family, only the exact launch-boundary marker `FM_PI_HARNESS=pi-signed` alongside `PI_CODING_AGENT=true` selects the signed identity; unmarked shared launcher ancestry remains `pi`.
 `bin/fm-harness.sh crew` resolves the effective crewmate harness from `config/crew-harness` (absent or `default` -> own).
 `bin/fm-harness.sh secondmate` resolves the secondmate-launch harness through the chain `config/secondmate-harness` -> `config/crew-harness` -> own, so an unset `config/secondmate-harness` matches the crew harness.

--- a/bin/fm-harness.sh
+++ b/bin/fm-harness.sh
@@ -21,7 +21,9 @@
 # Detection layers: verified environment markers first, then process ancestry.
 # A single unambiguous marker wins immediately; when several markers conflict
 # (e.g. a shell profile exporting CLAUDECODE=1 inside a Pi session), no env
-# marker is trustworthy alone and the process-ancestry layer decides.
+# marker is trustworthy alone and the process-ancestry layer decides the
+# family; a pi verdict still honors the launch-boundary selector
+# FM_PI_HARNESS=pi-signed when Pi's own PI_CODING_AGENT marker is present.
 # Record each newly verified env marker here.
 set -u
 
@@ -29,6 +31,19 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
 FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
 CONFIG="${FM_CONFIG_OVERRIDE:-$FM_HOME/config}"
+
+# Print the Pi-family identity for a pi ancestry verdict ($1 = pi_marker).
+# FM_PI_HARNESS=pi-signed is firstmate's own launch-boundary selector, set only
+# by fm-spawn and never by an ambient shell profile, so once ancestry confirms
+# the Pi family it stays authoritative - but only alongside PI_CODING_AGENT;
+# without Pi's family marker the selector is inert.
+emit_pi_family() {
+  if [ "$1" = 1 ] && [ "${FM_PI_HARNESS:-}" = pi-signed ]; then
+    echo pi-signed
+  else
+    echo pi
+  fi
+}
 
 detect_own() {
   # Layer 1: environment markers for verified harnesses.
@@ -42,7 +57,8 @@ detect_own() {
   # exports CLAUDECODE=1 leaks it into a Pi session, which would misidentify the
   # session as claude. A marker is therefore trusted only when it is the sole one
   # present; when several conflict, no env marker is trustworthy alone and this
-  # layer falls through to the process-ancestry layer below to decide.
+  # layer falls through to the process-ancestry layer below to decide the
+  # family (see emit_pi_family for the Pi-family signed selection).
   local claude_marker=0 pi_marker=0 grok_marker=0 marker_count=0
   [ "${CLAUDECODE:-}" = "1" ] && { claude_marker=1; marker_count=$((marker_count + 1)); }
   [ "${PI_CODING_AGENT:-}" = "true" ] && { pi_marker=1; marker_count=$((marker_count + 1)); }
@@ -87,8 +103,8 @@ detect_own() {
       # prefix rather than any exact name. Deliberately anchored, never *muse*, so
       # unrelated commands (musescore, amuse) cannot be misread as this harness.
       muse|muse-bin-*) echo muse; return ;;
-      pi-signed) echo pi; return ;;
-      pi) echo pi; return ;;
+      pi-signed) emit_pi_family "$pi_marker"; return ;;
+      pi) emit_pi_family "$pi_marker"; return ;;
       node*|python*)
         # Bare interpreter: match the harness name in its script path.
         args=$(ps -o args= -p "$pid" 2>/dev/null)
@@ -97,7 +113,7 @@ detect_own() {
           *codex*) echo codex; return ;;
           *opencode*) echo opencode; return ;;
           *grok*) echo grok; return ;;
-          *" pi "*|*/pi) echo pi; return ;;
+          *" pi "*|*/pi) emit_pi_family "$pi_marker"; return ;;
         esac ;;
     esac
     pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' ')

--- a/bin/fm-harness.sh
+++ b/bin/fm-harness.sh
@@ -19,6 +19,9 @@
 # Model/effort come ONLY from this file - config/crew-harness stays a bare adapter
 # name and is never parsed for a model.
 # Detection layers: verified environment markers first, then process ancestry.
+# A single unambiguous marker wins immediately; when several markers conflict
+# (e.g. a shell profile exporting CLAUDECODE=1 inside a Pi session), no env
+# marker is trustworthy alone and the process-ancestry layer decides.
 # Record each newly verified env marker here.
 set -u
 
@@ -35,12 +38,15 @@ detect_own() {
   # multiplexer's stored environment can silently misidentify one of them before
   # ancestry is consulted. This is a precedence hazard, not evidence that
   # CLAUDECODE inheritance into a kimi child was observed; it was not observed.
-  [ "${CLAUDECODE:-}" = "1" ] && { echo claude; return; }
-  if [ "${PI_CODING_AGENT:-}" = "true" ]; then
-    if [ "${FM_PI_HARNESS:-}" = pi-signed ]; then echo pi-signed; else echo pi; fi
-    return
-  fi
-  # grok set GROK_AGENT=1 for its child/tool processes (verified, grok 0.2.73).
+  # A verified marker can also be AMBIENT rather than live: a shell profile that
+  # exports CLAUDECODE=1 leaks it into a Pi session, which would misidentify the
+  # session as claude. A marker is therefore trusted only when it is the sole one
+  # present; when several conflict, no env marker is trustworthy alone and this
+  # layer falls through to the process-ancestry layer below to decide.
+  local claude_marker=0 pi_marker=0 grok_marker=0 marker_count=0
+  [ "${CLAUDECODE:-}" = "1" ] && { claude_marker=1; marker_count=$((marker_count + 1)); }
+  [ "${PI_CODING_AGENT:-}" = "true" ] && { pi_marker=1; marker_count=$((marker_count + 1)); }
+  # grok sets GROK_AGENT=1 for its child/tool processes (verified, grok 0.2.73).
   # It does NOT set CLAUDECODE despite being Claude-Code-compatible, so the marker
   # is unambiguous WHEN PRESENT - but it is not guaranteed present. A grok 1.0.0
   # hook process carries GROK_HOOK_EVENT, GROK_HOOK_NAME, GROK_SESSION_ID, and
@@ -49,7 +55,15 @@ detect_own() {
   # a fast path only; the ancestry walk below is what actually guarantees grok is
   # identified, and any rule that must be RELIABLE under grok has to test the hook
   # markers too (see .claude/settings.json Stop entries, docs/turnend-guard.md).
-  [ "${GROK_AGENT:-}" = "1" ] && { echo grok; return; }
+  [ "${GROK_AGENT:-}" = "1" ] && { grok_marker=1; marker_count=$((marker_count + 1)); }
+  if [ "$marker_count" -le 1 ]; then
+    [ "$claude_marker" = 1 ] && { echo claude; return; }
+    if [ "$pi_marker" = 1 ]; then
+      if [ "${FM_PI_HARNESS:-}" = pi-signed ]; then echo pi-signed; else echo pi; fi
+      return
+    fi
+    [ "$grok_marker" = 1 ] && { echo grok; return; }
+  fi
   # muse (Muse Code) publishes no harness-identity marker of its own. The only
   # MUSE_* variable it is documented to hand a child is MUSE_CURRENT_SESSION_LOG,
   # a per-session log PATH rather than an identity, and its export to tool

--- a/tests/fm-secondmate-harness.test.sh
+++ b/tests/fm-secondmate-harness.test.sh
@@ -192,15 +192,20 @@ SH
   # Conflicting ambient markers: a shell profile exporting CLAUDECODE=1 leaks
   # into a real Pi session, so both markers are present at once. No env marker
   # is trustworthy alone then, so process ancestry (the faked ps tree above,
-  # a Pi.app ancestor) must decide the family. Any pairing of conflicting
-  # markers must behave the same way; ambient markers from the suite's own
-  # harness cannot change the verdict because every conflict falls to ancestry.
+  # a Pi.app ancestor) must decide the family. Within the Pi family,
+  # FM_PI_HARNESS=pi-signed (fm-spawn's launch-boundary selector, never an
+  # ambient shell export) still selects the signed identity once
+  # PI_CODING_AGENT confirms the family, and stays inert without it. The suite
+  # unset every ambient marker above, so these verdicts do not depend on the
+  # launching harness.
   got=$(PATH="$fakebin:$BASE_PATH" CLAUDECODE=1 PI_CODING_AGENT=true "$ROOT/bin/fm-harness.sh")
   [ "$got" = pi ] || fail "conflicting claude+pi markers resolved '$got', expected pi by ancestry"
   got=$(PATH="$fakebin:$BASE_PATH" CLAUDECODE=1 PI_CODING_AGENT=true FM_PI_HARNESS=pi-signed "$ROOT/bin/fm-harness.sh")
-  [ "$got" = pi ] || fail "conflicting markers with signed selection resolved '$got', expected pi by ancestry"
+  [ "$got" = pi-signed ] || fail "conflicting markers with signed selection resolved '$got', expected pi-signed"
   got=$(PATH="$fakebin:$BASE_PATH" CLAUDECODE=1 GROK_AGENT=1 "$ROOT/bin/fm-harness.sh")
   [ "$got" = pi ] || fail "conflicting claude+grok markers resolved '$got', expected pi by ancestry"
+  got=$(PATH="$fakebin:$BASE_PATH" CLAUDECODE=1 GROK_AGENT=1 FM_PI_HARNESS=pi-signed "$ROOT/bin/fm-harness.sh")
+  [ "$got" = pi ] || fail "signed selector without Pi family marker resolved '$got', expected pi"
   got=$(PATH="$fakebin:$BASE_PATH" PI_CODING_AGENT=true GROK_AGENT=1 "$ROOT/bin/fm-harness.sh")
   [ "$got" = pi ] || fail "conflicting pi+grok markers resolved '$got', expected pi by ancestry"
 

--- a/tests/fm-secondmate-harness.test.sh
+++ b/tests/fm-secondmate-harness.test.sh
@@ -52,11 +52,11 @@ set -u
 
 # The harness-detection cases below fake `ps` so process ancestry is fully
 # controlled, but bin/fm-harness.sh checks verified ENV markers before ancestry.
-# A suite run from inside one of those harnesses inherits its marker, and the
-# highest-precedence one wins over everything these cases set up: with an
-# ambient CLAUDECODE=1, the pi-signed ancestry case resolves "claude". Drop the
-# ambient markers so what this suite asserts does not depend on which harness it
-# was launched from; every case states the marker it means to test.
+# A SINGLE ambient marker (e.g. a suite run inside claude inherits CLAUDECODE=1)
+# would override the ancestry these cases set up, while two conflicting ambient
+# markers now fall through to ancestry by design. Drop the ambient markers so
+# what this suite asserts does not depend on which harness it was launched from;
+# every case states the marker it means to test.
 unset CLAUDECODE PI_CODING_AGENT FM_PI_HARNESS GROK_AGENT
 
 BASE_PATH=${FM_TEST_BASE_PATH:-/usr/bin:/bin:/usr/sbin:/sbin}
@@ -188,6 +188,21 @@ SH
   [ "$got" = pi ] || fail "plain Pi marker resolved '$got', expected pi"
   got=$(env -u CLAUDECODE -u GROK_AGENT PATH="$fakebin:$BASE_PATH" PI_CODING_AGENT=true FM_TEST_SIGNED_SHAPE=helper "$ROOT/bin/fm-harness.sh")
   [ "$got" = pi ] || fail "unrelated pi-signed-helper ancestry resolved '$got', expected pi"
+
+  # Conflicting ambient markers: a shell profile exporting CLAUDECODE=1 leaks
+  # into a real Pi session, so both markers are present at once. No env marker
+  # is trustworthy alone then, so process ancestry (the faked ps tree above,
+  # a Pi.app ancestor) must decide the family. Any pairing of conflicting
+  # markers must behave the same way; ambient markers from the suite's own
+  # harness cannot change the verdict because every conflict falls to ancestry.
+  got=$(PATH="$fakebin:$BASE_PATH" CLAUDECODE=1 PI_CODING_AGENT=true "$ROOT/bin/fm-harness.sh")
+  [ "$got" = pi ] || fail "conflicting claude+pi markers resolved '$got', expected pi by ancestry"
+  got=$(PATH="$fakebin:$BASE_PATH" CLAUDECODE=1 PI_CODING_AGENT=true FM_PI_HARNESS=pi-signed "$ROOT/bin/fm-harness.sh")
+  [ "$got" = pi ] || fail "conflicting markers with signed selection resolved '$got', expected pi by ancestry"
+  got=$(PATH="$fakebin:$BASE_PATH" CLAUDECODE=1 GROK_AGENT=1 "$ROOT/bin/fm-harness.sh")
+  [ "$got" = pi ] || fail "conflicting claude+grok markers resolved '$got', expected pi by ancestry"
+  got=$(PATH="$fakebin:$BASE_PATH" PI_CODING_AGENT=true GROK_AGENT=1 "$ROOT/bin/fm-harness.sh")
+  [ "$got" = pi ] || fail "conflicting pi+grok markers resolved '$got', expected pi by ancestry"
 
   got=$(PATH="$fakebin:$BASE_PATH" bash -c \
     '. "$0/bin/fm-session-lock-lib.sh"; fm_harness_ancestry_pid' "$ROOT")


### PR DESCRIPTION
## What Changed
- `bin/fm-harness.sh` no longer trusts a verified env marker (`CLAUDECODE`, `PI_CODING_AGENT`, `GROK_AGENT`) when more than one is present: detection counts the markers and falls through to the process-ancestry layer when they conflict, so an ambient shell-profile export (e.g. `CLAUDECODE=1` leaked into a Pi session) can no longer misidentify the harness.
- Added an `emit_pi_family` helper so a pi ancestry verdict still honors the `FM_PI_HARNESS=pi-signed` launch-boundary selector — but only when `PI_CODING_AGENT` confirms the Pi family; without it the selector is inert and the verdict stays `pi`.
- Extended `tests/fm-secondmate-harness.test.sh` with five conflicting-marker cases (claude+pi, claude+grok, pi+grok, with and without the signed selector) and updated the detection notes in `.agents/skills/harness-adapters/SKILL.md` to document the new resolution rule.

## Risk Assessment

✅ Low: The fix round correctly implements the prescribed pi-signed conflict resolution at every Pi ancestry verdict, preserves all single-marker and unmarked-ancestry invariants, has no sibling marker-consuming site that reintroduces the failure, and is covered by behavioral tests that would fail without the fix.

## Testing

Demonstrated the fix end-to-end with a before/after CLI transcript: under a faked Pi process ancestry with a leaked ambient CLAUDECODE=1, the base-commit fm-harness.sh misreports "claude" while the fixed script reports "pi" (and "pi-signed" only when fm-spawn's selector accompanies Pi's family marker, staying inert without it); single markers still resolve immediately. Then ran the changed test suite (fm-secondmate-harness, containing the five new conflicting-marker assertions) plus the kimi and muse harness-detection suites that share the refactored marker layer — all pass, and the worktree is clean with no transient artifacts left behind.

<details>
<summary>Evidence: Before/after CLI transcript: conflicting env markers resolved by ancestry</summary>

<code>$ # A real Pi session whose shell profile leaked CLAUDECODE=1 (both env markers present).&#10;$ # Process ancestry (faked ps): this shell -&gt; Pi engine (Pi.app/bin/pi) -&gt; pi-signed wrapper.&#10;&#10;--- BASE (2cf0283, before fix) ---&#10;CLAUDECODE=1 PI_CODING_AGENT=true fm-harness.sh -&gt; claude&#10;CLAUDECODE=1 PI_CODING_AGENT=true FM_PI_HARNESS=pi-signed fm-harness.sh -&gt; claude&#10;&#10;--- TARGET (64a12d9, after fix) ---&#10;CLAUDECODE=1 PI_CODING_AGENT=true fm-harness.sh -&gt; pi&#10;CLAUDECODE=1 PI_CODING_AGENT=true FM_PI_HARNESS=pi-signed fm-harness.sh -&gt; pi-signed&#10;CLAUDECODE=1 GROK_AGENT=1 FM_PI_HARNESS=pi-signed fm-harness.sh (no Pi family marker) -&gt; pi&#10;&#10;--- TARGET: single markers still win immediately (no ancestry needed) ---&#10;CLAUDECODE=1 fm-harness.sh -&gt; claude&#10;GROK_AGENT=1 fm-harness.sh -&gt; grok&#10;PI_CODING_AGENT=true FM_PI_HARNESS=pi-signed fm-harness.sh -&gt; pi-signed</code>

```text
$ # A real Pi session whose shell profile leaked CLAUDECODE=1 (both env markers present).
$ # Process ancestry (faked ps): this shell -> Pi engine (Pi.app/bin/pi) -> pi-signed wrapper.

--- BASE (2cf0283, before fix) ---
CLAUDECODE=1 PI_CODING_AGENT=true            fm-harness.sh               -> claude
CLAUDECODE=1 PI_CODING_AGENT=true FM_PI_HARNESS=pi-signed fm-harness.sh  -> claude

--- TARGET (64a12d9, after fix) ---
CLAUDECODE=1 PI_CODING_AGENT=true            fm-harness.sh               -> pi
CLAUDECODE=1 PI_CODING_AGENT=true FM_PI_HARNESS=pi-signed fm-harness.sh  -> pi-signed
CLAUDECODE=1 GROK_AGENT=1 FM_PI_HARNESS=pi-signed fm-harness.sh (no Pi family marker) -> pi

--- TARGET: single markers still win immediately (no ancestry needed) ---
CLAUDECODE=1                                 fm-harness.sh               -> claude
GROK_AGENT=1                                 fm-harness.sh               -> grok
PI_CODING_AGENT=true FM_PI_HARNESS=pi-signed fm-harness.sh               -> pi-signed
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>⏭️ **intent** - skipped</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed ✅</summary>

- ⚠️ `bin/fm-harness.sh:56` - Under conflicting markers, a genuine pi-signed session is demoted to &#39;pi&#39;: ancestry can never yield pi-signed (bin/fm-harness.sh:84 maps a pi-signed ancestor to pi), so the exact leak scenario this commit fixes (ambient CLAUDECODE=1 in a real Pi session) returns &#39;pi&#39; even when FM_PI_HARNESS=pi-signed + PI_CODING_AGENT=true are present. This is reachable beyond shell profiles: fm-spawn.sh:921 sets FM_PI_HARNESS=pi-signed at the launch boundary, and a pi-signed crewmate spawned from a claude-based firstmate inherits CLAUDECODE=1, producing exactly this conflict. Since FM_PI_HARNESS is firstmate&#39;s own launch-boundary selector (not an ambient third-party marker), honoring the signed selection once ancestry confirms the Pi family would preserve the SKILL.md invariant that the marker pair selects the signed identity. The demotion is fail-safe and explicitly asserted in tests/fm-secondmate-harness.test.sh:200-201, so it appears deliberate — asking rather than auto-fixing.
- ℹ️ `bin/fm-harness.sh:53` - When markers conflict AND the real harness is not within the 8-hop ancestry walk (e.g. stale markers retained in a multiplexer&#39;s stored environment), detection now returns &#39;unknown&#39; where the old precedence order returned the highest-precedence marker&#39;s harness; &#39;unknown&#39; then fails fm-spawn.sh&#39;s verified-adapter validation with a loud error. This trades a silent possible misidentification for an honest failure, which matches the change&#39;s stated design — noted for awareness only.

🔧 Fix: honor pi-signed selector when conflict ancestry confirms Pi family
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>Manual before/after demo: ran `git show 2cf0283:bin/fm-harness.sh` (base) and the target `bin/fm-harness.sh` under a faked `ps` Pi.app ancestry with conflicting markers `CLAUDECODE=1 PI_CODING_AGENT=true` (± `FM_PI_HARNESS=pi-signed`, ± `GROK_AGENT=1`) and with single markers alone; base printed `claude` (the bug), target printed `pi`/`pi-signed` per the intended rules</code>
- <code>`bash tests/fm-secondmate-harness.test.sh` — the changed suite, including the new conflicting-marker cases in `test_pi_signed_detection_and_session_lock_identity` (all 47 cases pass)</code>
- <code>`bash tests/fm-kimi-harness.test.sh` — kimi detection relies on the refactored env-marker layer falling through to ancestry (passes)</code>
- <code>`bash tests/fm-muse-harness.test.sh` — muse detection likewise depends on marker-layer fallthrough (passes)</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
