### PR TITLE
fix(spawn): gate worktree isolation on filesystem identity, not path strings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -363,6 +363,29 @@ jobs:
             exit 1
           }
 
+      # The spawn isolation gate's case-spelling regression needs a
+      # case-insensitive filesystem, which the Linux lanes cannot provide. macOS
+      # runners can, so require it here: FM_TEST_REQUIRE_CASE_INSENSITIVE=1 turns
+      # the skip into a failure, and the run doubles as stock-Bash 3.2 coverage
+      # for the gate itself.
+      - name: Require the spawn isolation case-spelling regression
+        shell: /bin/bash {0}
+        env:
+          PATH: /bin:/usr/bin:/usr/sbin:/sbin:/usr/local/bin:/opt/homebrew/bin
+          FM_TEST_REQUIRE_CASE_INSENSITIVE: '1'
+        run: |
+          set -eu
+          isolation_output=$(/bin/bash tests/fm-spawn-isolation.test.sh)
+          printf '%s\n' "$isolation_output"
+          if printf '%s\n' "$isolation_output" | grep -q '^skip:'; then
+            echo "::error::spawn isolation coverage skipped on a runner that must exercise it"
+            exit 1
+          fi
+          if ! printf '%s\n' "$isolation_output" | grep -q 'never accepted as the worktree'; then
+            echo "::error::case-spelling regression did not run"
+            exit 1
+          fi
+
   invariants:
     name: Repo invariants
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,6 +98,7 @@ CI owns broad regression across required portable parallel shards, the portable 
 Use `bin/fm-test-run.sh --list-lanes` for exact lane names and `--help` for `--jobs` rules and required gate-skip flags when reproducing a lane locally.
 Discover tests by listing `tests/*.test.sh`: each is a self-contained bash script named `<subject>.test.sh`, and its header comment describes what it covers, so pass one to `bin/fm-test-run.sh` to focus on a subject with canonical timing output.
 Tests that need a real optional backend or an explicit opt-in (real herdr/zellij/cmux smoke tests, the live Pi regression) skip themselves and print the tool or environment gate needed to enable them, so the portable suite remains safe on machines without those tools.
+Cases that need a case-insensitive filesystem, such as the spawn isolation gate's case-spelling regression, skip themselves on a case-sensitive one; the macOS CI job runs them with `FM_TEST_REQUIRE_CASE_INSENSITIVE=1`, which turns that skip into a failure where the filesystem can exercise them.
 The [Herdr backend guide](docs/herdr-backend.md#destructive-lab-safety) owns the lane's isolation boundary, while [runtime backend verification](docs/verification/runtime-backends.md#herdr) owns active empirical evidence; live harness credential tests remain opt-in.
 
 ## Questions

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1375,10 +1375,11 @@ BRIEF_REAL="$BRIEF_DIR_REAL/$(basename "$BRIEF")"
 # herdr's foreground_cwd, zellij/cmux's active pwd probe against the live
 # shell) reports the OS-level cwd. PROJ_ABS_REAL is that physical form, kept
 # only so validate_spawn_worktree's refusal message can show the operator both
-# spellings of the project path (docs/herdr-backend.md "Known gaps"). Nothing
-# compares against it to decide whether a path is the project: the settle loop
-# and the isolation gate both ask same_dir below, which answers by filesystem
-# identity rather than by any canonicalized string.
+# spellings of the project path (docs/architecture.md "Worktrees, not branches
+# in your checkout" owns the contract). Nothing compares against it to decide
+# whether a path is the project: the settle loop and the isolation gate both
+# ask same_dir below, which answers by filesystem identity rather than by any
+# canonicalized string.
 PROJ_ABS_REAL=$(cd "$PROJ_ABS" 2>/dev/null && pwd -P) || PROJ_ABS_REAL="$PROJ_ABS"
 
 real_path_or_raw() {  # <path>

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -111,7 +111,10 @@
 #   Before a secondmate launch, the home is locally fast-forwarded to the primary
 #   default-branch commit when safe; skipped syncs warn and launch unchanged.
 #   Ship/scout spawns refuse to launch unless the resolved task path is a real
-#   git worktree root distinct from the primary project checkout.
+#   git worktree root that is not the project checkout itself. "Not the project"
+#   is decided by filesystem identity (device+inode), not by comparing path
+#   strings, so no symlinked or differently-cased spelling of the project can
+#   pass the gate; the gate runs before any hook, metadata, or launch write.
 # Batch dispatch: pass one or more `id=repo` pairs instead of a single <id> <project>, e.g.
 #     fm-spawn.sh fix-a-k3=projects/foo add-b-q7=projects/bar [--scout]
 #   Each pair re-execs this script in single-task mode, so the single path stays the only
@@ -1367,15 +1370,13 @@ BRIEF_DIR_REAL=$(cd "$(dirname "$BRIEF")" && pwd -P)
 BRIEF_REAL="$BRIEF_DIR_REAL/$(basename "$BRIEF")"
 
 # PROJ_ABS can still carry a symlinked path component (e.g. macOS's /tmp ->
-# /private/tmp) when it came from the ship/scout branch's logical `pwd` above.
-# Every backend's own current-path read (tmux's pane_current_path, herdr's
-# foreground_cwd, zellij/cmux's active pwd probe against the live shell) can
-# report the OS-level, physically-resolved cwd, so comparing it against a
-# still-symlinked PROJ_ABS can misfire both ways: false-negative (the poll
-# below never notices the pane left the project) or false-positive (the
-# isolation guard refuses a spawn that never actually tangled). Canonicalize
-# once here so every downstream comparison uses the same physical form
-# (docs/herdr-backend.md "Known gaps").
+# /private/tmp) when it came from the ship/scout branch's logical `pwd` above,
+# while every backend's own current-path read (tmux's pane_current_path,
+# herdr's foreground_cwd, zellij/cmux's active pwd probe against the live
+# shell) reports the OS-level cwd. PROJ_ABS_REAL is that physical form, kept
+# for the settle loop's stability candidate and for operator-facing error text
+# (docs/herdr-backend.md "Known gaps"). It is NOT the authority on whether two
+# paths are the same directory - see same_dir below.
 PROJ_ABS_REAL=$(cd "$PROJ_ABS" 2>/dev/null && pwd -P) || PROJ_ABS_REAL="$PROJ_ABS"
 
 real_path_or_raw() {  # <path>
@@ -1387,6 +1388,31 @@ real_path_or_raw() {  # <path>
   fi
 }
 
+# same_dir answers "are these two paths ONE directory?" by filesystem identity
+# (device + inode via the `-ef` primary), never by comparing path strings.
+#
+# String comparison is not a sound answer to that question and shipping one is
+# what let a scout launch against the shared project checkout: `pwd -P` resolves
+# symlinks but does NOT normalize letter case, so on a case-insensitive
+# filesystem (macOS's default APFS, HFS+, exFAT) a firstmate home typed as
+# .../work/firstmate and the on-disk .../Work/firstmate canonicalize to two
+# different strings naming one directory. The settle loop below then read the
+# backend's canonical-case pane cwd, saw a string that differed from PROJ_ABS,
+# and concluded the pane had left the project - handing the project's own
+# directory to the isolation guard, which compared the same two spellings and
+# also called them distinct. The launch went on to overwrite the project's
+# .claude/settings.local.json with its turn-end hook.
+#
+# `-ef` is false whenever either operand is missing or unreadable, so every
+# caller must ALSO prove the path exists before treating "not the same
+# directory" as "a different directory" - otherwise a vanished path reads as
+# distinct. Callers below do that with an explicit -d test.
+same_dir() {  # <a> <b> -> 0 only when both exist and are one directory
+  [ -n "$1" ] && [ -n "$2" ] || return 1
+  [ -d "$1" ] && [ -d "$2" ] || return 1
+  [ "$1" -ef "$2" ]
+}
+
 # Session-provider container-ensure + task creation. tmux stays exactly as P1
 # left it (same session-name / new-window sequence, see bin/backends/tmux.sh);
 # a herdr spawn goes through the version-gated, workspace-per-HOME,
@@ -1395,22 +1421,30 @@ real_path_or_raw() {  # <path>
 # herdr-sm-spaces-k4). Both branches converge on the same $T ("target") string
 # that every downstream operation (send/capture/kill) already treats as opaque
 # per-backend routing (fm_backend_resolve_selector).
+# The single isolation gate for ship/scout work: $WT must be an existing
+# directory that is the ROOT of a git worktree and is not the shared project
+# checkout. Every test is positive - an unknown answer refuses - and the two
+# directory-identity questions go through same_dir, so no spelling of the
+# project path can pass as an isolated worktree. Idempotent and cheap, so it is
+# also re-asserted immediately before the first write into $WT.
 validate_spawn_worktree() {  # <source> <inspect-target>
-  local source=$1 inspect_target=$2 wt_real proj_real wt_top wt_top_real
-  wt_real=
-  if ! wt_real=$(cd "$WT" 2>/dev/null && pwd -P); then
-    wt_real=
+  local source=$1 inspect_target=$2 wt_real wt_top='' reason=''
+  wt_real=$(real_path_or_raw "${WT:-}")
+  if [ -z "${WT:-}" ] || [ ! -d "$WT" ]; then
+    reason="it is not an existing directory"
+  else
+    wt_top=$(git -C "$WT" rev-parse --show-toplevel 2>/dev/null || true)
+    if [ -z "$wt_top" ] || [ ! -d "$wt_top" ]; then
+      reason="it is not inside a git worktree"
+    elif ! same_dir "$WT" "$wt_top"; then
+      reason="it is not the worktree root"
+    elif same_dir "$WT" "$PROJ_ABS"; then
+      reason="it is the shared project checkout itself"
+    fi
   fi
-  proj_real=$PROJ_ABS_REAL
-  wt_top=$(git -C "$WT" rev-parse --show-toplevel 2>/dev/null || true)
-  wt_top_real=
-  if ! wt_top_real=$(cd "$wt_top" 2>/dev/null && pwd -P); then
-    wt_top_real=
-  fi
-  if [ -z "$wt_real" ] || [ -z "$wt_top_real" ] || [ "$wt_real" != "$wt_top_real" ] || [ "$wt_real" = "$proj_real" ]; then
-    echo "error: $source did not yield an isolated worktree (resolved '$WT'; worktree root '${wt_top:-none}'; primary '$PROJ_ABS'); refusing to launch to avoid tangling the primary checkout. Inspect target $inspect_target" >&2
-    exit 1
-  fi
+  [ -n "$reason" ] || return 0
+  echo "error: $source did not yield an isolated worktree - $reason (resolved '$WT' -> '$wt_real'; worktree root '${wt_top:-none}'; project '$PROJ_ABS' -> '$PROJ_ABS_REAL'); refusing to launch to avoid tangling the primary checkout. Inspect target $inspect_target" >&2
+  exit 1
 }
 
 herdr_projection_meta_field_exact() {  # <meta> <key>
@@ -1826,35 +1860,36 @@ if [ "$KIND" != secondmate ] && [ "$BACKEND" != orca ]; then
   # automatic-rename slips through), display-message -t <bad-name> falls back to the
   # active client's window, which would misread firstmate's OWN pane path as the
   # worktree and tangle a hook into the primary checkout. The window id never lies.
-  # Compare against PROJ_ABS_REAL (physical), not PROJ_ABS: a symlinked project
-  # prefix would otherwise make the pane's OS-level cwd read differ from
-  # PROJ_ABS on the very first poll, before the pane has actually moved.
+  # "Has the pane left the project?" is a directory-identity question, so it goes
+  # through same_dir - a symlinked or differently-cased spelling of the project
+  # is still the project, however far the two strings diverge (see same_dir).
+  # The read must also name an existing directory: `-ef` is false for a path
+  # this process cannot stat, which would otherwise read as "somewhere else".
   #
-  # A single read that already differs from PROJ_ABS_REAL is not proof the pane
-  # settled there: on some tmux/WSL setups a brand-new window's pane_current_path
-  # transiently reports an unrelated stale path (seen live as another real git
-  # checkout entirely) before the shell catches up with treehouse get's cd. That
-  # stale path still passes the PROJ_ABS_REAL comparison and validate_spawn_worktree
-  # below (it resolves to a real, distinct worktree top-level too), so accepting it
-  # on one read alone silently records the wrong worktree= in state/<id>.meta. Require
-  # two consecutive reads to agree on the same non-project path before accepting it;
-  # a mismatch just becomes the new candidate rather than resetting the wait, so a
-  # pane that is already settled by the first real read only costs the one existing
-  # inter-poll sleep as confirmation, not a whole extra cycle on top.
+  # A single read that already names a non-project directory is not proof the
+  # pane settled there: on some tmux/WSL setups a brand-new window's
+  # pane_current_path transiently reports an unrelated stale path (seen live as
+  # another real git checkout entirely) before the shell catches up with
+  # treehouse get's cd. That stale path passes both this check and
+  # validate_spawn_worktree below (it resolves to a real, distinct worktree
+  # top-level too), so accepting it on one read alone silently records the wrong
+  # worktree= in state/<id>.meta. Require two consecutive reads to agree on the
+  # same non-project path - compared in canonical physical form so one settled
+  # directory reported under two spellings still counts as agreement - before
+  # accepting it; a mismatch just becomes the new candidate rather than
+  # resetting the wait, so a pane that is already settled by the first real read
+  # only costs the one existing inter-poll sleep as confirmation, not a whole
+  # extra cycle on top.
   candidate=""
   for _ in $(seq 1 60); do
     p=$(spawn_current_path "$WT_TARGET" || true)
-    if [ -n "$p" ]; then
+    if [ -n "$p" ] && [ -d "$p" ] && ! same_dir "$p" "$PROJ_ABS"; then
       p_real=$(real_path_or_raw "$p")
-      if [ "$p_real" != "$PROJ_ABS_REAL" ]; then
-        if [ -n "$candidate" ] && [ "$p_real" = "$candidate" ]; then
-          WT="$p"
-          break
-        fi
-        candidate="$p_real"
-      else
-        candidate=""
+      if [ -n "$candidate" ] && [ "$p_real" = "$candidate" ]; then
+        WT="$p"
+        break
       fi
+      candidate="$p_real"
     else
       candidate=""
     fi
@@ -1887,10 +1922,25 @@ exclude_path() {
   local rel=$1 EXCL
   EXCL=$(git -C "$WT" rev-parse --git-path info/exclude 2>/dev/null || true)
   [ -n "$EXCL" ] || return 0
+  # `--git-path` answers relative to the REPOSITORY, not to this process's cwd,
+  # and a main checkout answers with a bare ".git/info/exclude". Resolving that
+  # inside $WT is what keeps the write in the task worktree: taken as-is it
+  # lands in whatever directory fm-spawn was invoked from, which is firstmate's
+  # own primary checkout for every ordinary dispatch.
+  case "$EXCL" in
+    /*) ;;
+    *) EXCL="$WT/$EXCL" ;;
+  esac
   mkdir -p "$(dirname "$EXCL")"
   grep -qxF "$rel" "$EXCL" 2>/dev/null || echo "$rel" >> "$EXCL"
 }
 if [ "$KIND" != secondmate ]; then
+  # Structural backstop: no hook, config, or metadata write may precede a
+  # passing isolation gate. Each backend branch already validated $WT before
+  # reaching here, and re-asserting at the write site keeps that true if the
+  # steps above are ever reordered - the resolved worktree cannot change in
+  # between, so a healthy spawn never notices this call.
+  validate_spawn_worktree "the resolved task worktree" "$T"
   # Arm the semantic busy-state contract (bin/fm-busy-lib.sh) for every
   # adapter with a verified semantic source. The launch brief sent below IS a
   # submitted turn, so the seed record is busy/fm-spawn. The minted gen is

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1374,9 +1374,11 @@ BRIEF_REAL="$BRIEF_DIR_REAL/$(basename "$BRIEF")"
 # while every backend's own current-path read (tmux's pane_current_path,
 # herdr's foreground_cwd, zellij/cmux's active pwd probe against the live
 # shell) reports the OS-level cwd. PROJ_ABS_REAL is that physical form, kept
-# for the settle loop's stability candidate and for operator-facing error text
-# (docs/herdr-backend.md "Known gaps"). It is NOT the authority on whether two
-# paths are the same directory - see same_dir below.
+# only so validate_spawn_worktree's refusal message can show the operator both
+# spellings of the project path (docs/herdr-backend.md "Known gaps"). Nothing
+# compares against it to decide whether a path is the project: the settle loop
+# and the isolation gate both ask same_dir below, which answers by filesystem
+# identity rather than by any canonicalized string.
 PROJ_ABS_REAL=$(cd "$PROJ_ABS" 2>/dev/null && pwd -P) || PROJ_ABS_REAL="$PROJ_ABS"
 
 real_path_or_raw() {  # <path>

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -191,7 +191,7 @@ family_for_basename() {
     fm-backend-herdr.test.sh|fm-backend-tmux-smoke.test.sh|fm-backend.test.sh|\
     fm-tmux-agent-liveness.test.sh|\
     fm-herdr-session-cleanup.test.sh|fm-send-resolve-key.test.sh|fm-send-strict.test.sh|fm-spawn-batch.test.sh|\
-    fm-spawn-dispatch-profile.test.sh|\
+    fm-spawn-dispatch-profile.test.sh|fm-spawn-isolation.test.sh|\
     fm-trace-context-spawn.test.sh|fm-spawn-worktree-settle.test.sh|\
     fm-teardown-endpoint-safety.test.sh)
       printf '%s\n' backend-dispatch

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -137,6 +137,9 @@ Codex App support is recorded in `docs/codex-app-backend.md`; it is not selectab
 
 Crewmates never intentionally touch your project clone; [treehouse](https://github.com/kunchenguid/treehouse) pools clean worktrees for tmux, herdr, zellij, and cmux tasks, while Orca creates its own worktrees for `backend=orca`.
 For ship and scout work, `fm-spawn.sh` refuses to launch unless the resolved task path is a real git worktree root that is distinct from the project primary checkout.
+Distinctness is decided by filesystem identity (device and inode), never by comparing path strings: `pwd -P` resolves symlinks but does not normalize letter case, so on a case-insensitive filesystem two spellings of one directory stay two different strings.
+The same identity test decides whether a task pane has actually left the project during worktree discovery, so no symlinked or differently-cased spelling of the project can be accepted as the isolated worktree.
+The gate is re-asserted immediately before the first hook, configuration, or metadata write, so a refusal leaves the project untouched, records no task, and launches no agent.
 
 The firstmate repo has one extra exposure because it can dispatch crewmates to work on itself.
 Its operating checkout (`FM_ROOT`) and the disposable crewmate worktrees are all linked git worktrees of the same repository, so the valid discriminator is branch state, not whether the checkout is linked.

--- a/tests/fm-spawn-isolation.test.sh
+++ b/tests/fm-spawn-isolation.test.sh
@@ -1,0 +1,420 @@
+#!/usr/bin/env bash
+# tests/fm-spawn-isolation.test.sh - regression coverage for bin/fm-spawn.sh's
+# ship/scout isolation gate: the resolved task worktree must be a real git
+# worktree root that is NOT the shared project checkout, proven before any hook,
+# metadata, or launch write.
+#
+# The failure this file exists for: firstmate dispatched a scout for a project
+# whose registered local copy sat under a firstmate home typed as
+# /Users/<u>/work/firstmate while the on-disk directory was /Users/<u>/Work/...
+# On a case-insensitive filesystem (macOS's default APFS, HFS+, exFAT) both
+# spellings name one directory, but `pwd -P` canonicalizes symlinks WITHOUT
+# normalizing case, so the two spellings stayed different strings. fm-spawn
+# compared those strings to decide "has the pane left the project?" and "is this
+# worktree distinct from the project?", answered yes to both, and launched the
+# scout against the shared checkout - overwriting the project's own
+# .claude/settings.local.json with the task's turn-end hook and recording the
+# shared path as the task's worktree.
+#
+# The gate now answers both questions by filesystem identity (device+inode), so
+# no spelling of the project can pass. The cases below pin that, plus the
+# adjacent ordering hazards: nothing may be written into the project before the
+# gate passes, a refusal must publish no task record and launch no agent, and
+# relative and absolute project arguments must behave identically.
+#
+# Case-insensitivity coverage needs a case-insensitive fixture filesystem. It
+# runs natively on macOS; elsewhere it reports a skip line unless
+# FM_TEST_REQUIRE_CASE_INSENSITIVE=1 is set, which CI's macOS job does so the
+# regression can never silently stop being exercised.
+#
+# One case (test_project_only_pane_refuses_and_leaves_the_project_untouched)
+# deliberately pays fm-spawn's full 60s worktree-discovery timeout: it is the
+# exact end-user terminal outcome, and shortening it would stop proving that the
+# project spelling is refused for the whole wait rather than for a few polls.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+SPAWN="$ROOT/bin/fm-spawn.sh"
+TMP_ROOT=$(fm_test_tmproot fm-spawn-isolation)
+
+# The project-owned config the live incident destroyed. Any byte change to this
+# file after a spawn means the shared checkout was written to.
+PROJECT_SETTINGS='{"mcpServers":{"jira":{"command":"jira-mcp","args":["--site","example"]}}}'
+
+# --- fixture builders --------------------------------------------------------
+
+# A fake tmux whose pane_current_path answers come from a script file, one path
+# per poll, with the last line repeating forever. Every invocation is appended to
+# FM_TMUX_LOG so a test can prove no launch command was ever sent.
+make_isolation_fakebin() {  # <dir> -> echoes fakebin dir
+  local dir=$1 fb
+  fb=$(fm_fakebin "$dir")
+  cat > "$fb/tmux" <<'SH'
+#!/usr/bin/env bash
+set -u
+{ printf 'tmux'; for a in "$@"; do printf '\x1f%s' "$a"; done; printf '\n'; } >> "${FM_TMUX_LOG:?}"
+case "$*" in
+  *"#{pane_current_path}"*)
+    n=0
+    if [ -s "${FM_PANE_COUNT:?}" ]; then n=$(cat "$FM_PANE_COUNT"); fi
+    n=$((n + 1))
+    printf '%s\n' "$n" > "$FM_PANE_COUNT"
+    total=$(wc -l < "${FM_PANE_SCRIPT:?}")
+    total=$((total))
+    [ "$n" -le "$total" ] || n=$total
+    [ "$n" -ge 1 ] || n=1
+    sed -n "${n}p" "$FM_PANE_SCRIPT"
+    exit 0
+    ;;
+esac
+case "${1:-}" in
+  display-message) printf 'firstmate\n'; exit 0 ;;
+  new-window) printf '@7\n'; exit 0 ;;
+  list-windows) exit 0 ;;
+esac
+exit 0
+SH
+  chmod +x "$fb/tmux"
+  fm_fake_exit0 "$fb" treehouse
+  printf '%s\n' "$fb"
+}
+
+# setup_case <name> <home-dir-on-disk> <home-dir-as-typed>: build a firstmate
+# home, a registered project holding the captain's own .claude config, a real
+# linked worktree standing in for a treehouse allocation, and an unrelated real
+# git checkout. The two home arguments are the same directory whenever the
+# fixture filesystem is case-insensitive; passing the same string twice gives the
+# ordinary portable fixture.
+setup_case() {  # <name> <home-on-disk> <home-as-typed>
+  CASE_DIR="$TMP_ROOT/$1"
+  HOME_REAL="$CASE_DIR/$2"
+  HOME_TYPED="$CASE_DIR/$3"
+  mkdir -p "$HOME_REAL/data" "$HOME_REAL/state" "$HOME_REAL/config" "$HOME_REAL/projects"
+  touch "$HOME_REAL/state/.last-watcher-beat"
+  PROJ="$HOME_REAL/projects/peo-native"
+  TASK_WT="$CASE_DIR/pool/worktree"
+  OTHER_REPO="$CASE_DIR/other-checkout"
+  mkdir -p "$CASE_DIR/pool"
+  fm_git_worktree "$PROJ" "$TASK_WT" "fm/$1"
+  fm_git_init_commit "$OTHER_REPO"
+  mkdir -p "$PROJ/.claude"
+  printf '%s\n' "$PROJECT_SETTINGS" > "$PROJ/.claude/settings.local.json"
+  FAKEBIN=$(make_isolation_fakebin "$CASE_DIR/fake")
+  TMUX_LOG="$CASE_DIR/tmux.log"
+  PANE_SCRIPT="$CASE_DIR/pane-script"
+  PANE_COUNT="$CASE_DIR/pane-count"
+  : > "$TMUX_LOG"
+  : > "$PANE_COUNT"
+}
+
+# pane_reports <path> [more paths...]: the pane's cwd for poll 1, 2, ... with the
+# final path repeating for every later poll.
+pane_reports() {
+  local p
+  : > "$PANE_SCRIPT"
+  for p in "$@"; do printf '%s\n' "$p" >> "$PANE_SCRIPT"; done
+  : > "$PANE_COUNT"
+  : > "$TMUX_LOG"
+}
+
+run_spawn() {  # <id> <project-arg> [extra fm-spawn args...]
+  local id=$1 proj_arg=$2
+  shift 2
+  mkdir -p "$HOME_REAL/data/$id"
+  printf 'brief for %s\n' "$id" > "$HOME_REAL/data/$id/brief.md"
+  FM_ROOT_OVERRIDE='' FM_HOME="$HOME_TYPED" \
+    FM_STATE_OVERRIDE="$HOME_TYPED/state" FM_DATA_OVERRIDE="$HOME_TYPED/data" \
+    FM_PROJECTS_OVERRIDE="$HOME_TYPED/projects" FM_CONFIG_OVERRIDE="$HOME_TYPED/config" \
+    FM_SPAWN_NO_GUARD=1 TMUX="fake,1,0" \
+    FM_TMUX_LOG="$TMUX_LOG" FM_PANE_SCRIPT="$PANE_SCRIPT" FM_PANE_COUNT="$PANE_COUNT" \
+    PATH="$FAKEBIN:$PATH" \
+    "$SPAWN" "$id" "$proj_arg" --harness claude "$@" 2>&1
+}
+
+# --- assertions --------------------------------------------------------------
+
+# Byte-for-byte content of every tracked-or-untracked file in the project except
+# its .git directory, so any write into the shared checkout shows up as a diff.
+project_fingerprint() {  # <project-dir>
+  (
+    cd "$1" || exit 1
+    find . -path ./.git -prune -o -type f -print | LC_ALL=C sort | while IFS= read -r f; do
+      printf '=== %s\n' "$f"
+      cat "$f"
+    done
+  )
+}
+
+assert_project_untouched() {  # <before> <project> <msg>
+  local after
+  after=$(project_fingerprint "$2")
+  [ "$1" = "$after" ] || fail "$3"$'\n'"--- before ---"$'\n'"$1"$'\n'"--- after ---"$'\n'"$after"
+}
+
+assert_no_agent_launched() {  # <msg>
+  ! grep -qF 'dangerously-skip-permissions' "$TMUX_LOG" \
+    || fail "$1 (a launch command reached the pane; see $TMUX_LOG)"
+}
+
+# --- case-insensitivity probe ------------------------------------------------
+
+# Echo a case-insensitive directory under TMP_ROOT, or nothing when the fixture
+# filesystem distinguishes case.
+case_insensitive_probe() {
+  local probe="$TMP_ROOT/CaseProbe"
+  mkdir -p "$probe" 2>/dev/null || return 0
+  [ -d "$TMP_ROOT/caseprobe" ] || return 0
+  printf 'yes\n'
+}
+
+# --- the exact end-user failure ----------------------------------------------
+
+# fm-spawn must never accept a differently-cased spelling of the project as the
+# task worktree. The pane reports the project under its on-disk case for the
+# first polls while the home is addressed in another case; before the fix that
+# string difference alone was accepted as "the pane left the project", so the
+# project became the worktree, its .claude/settings.local.json was overwritten
+# with the turn-end hook, and worktree= recorded the shared checkout.
+test_case_differing_project_spelling_is_never_the_worktree() {
+  local id out status before proj_canonical
+  if [ -z "$(case_insensitive_probe)" ]; then
+    if [ "${FM_TEST_REQUIRE_CASE_INSENSITIVE:-0}" = 1 ]; then
+      fail "FM_TEST_REQUIRE_CASE_INSENSITIVE=1 but $TMP_ROOT is on a case-sensitive filesystem"
+    fi
+    printf 'skip: case-insensitive filesystem unavailable - case-spelling coverage not exercised here\n'
+    return 0
+  fi
+  id=caseworktreez1
+  setup_case case-worktree Home home
+  proj_canonical=$(cd "$PROJ" && pwd -P)
+  before=$(project_fingerprint "$PROJ")
+  # Polls 1-3 report the project in its on-disk case; the pane only really
+  # reaches the worktree afterwards.
+  pane_reports "$proj_canonical" "$proj_canonical" "$proj_canonical" "$TASK_WT"
+  out=$(run_spawn "$id" projects/peo-native --scout)
+  status=$?
+
+  expect_code 0 "$status" "spawn should succeed once the pane truly reaches the worktree"$'\n'"$out"
+  assert_grep "worktree=$TASK_WT" "$HOME_REAL/state/$id.meta" \
+    "meta did not record the real isolated worktree"
+  assert_no_grep "worktree=$proj_canonical" "$HOME_REAL/state/$id.meta" \
+    "meta recorded the shared project checkout as the task worktree"
+  assert_project_untouched "$before" "$PROJ" \
+    "the shared project checkout was written to while the pane still sat in it"
+  assert_present "$TASK_WT/.claude/settings.local.json" \
+    "the turn-end hook was not installed in the isolated worktree"
+  pass "fm-spawn: a differently-cased spelling of the project is never accepted as the worktree"
+}
+
+# The terminal end-user outcome: a pane that never leaves the project (treehouse
+# never moved it) must exhaust the discovery wait and refuse, with the project
+# byte-identical, no task record published, and no agent launched.
+test_project_only_pane_refuses_and_leaves_the_project_untouched() {
+  local id out status before proj_canonical
+  if [ -z "$(case_insensitive_probe)" ]; then
+    if [ "${FM_TEST_REQUIRE_CASE_INSENSITIVE:-0}" = 1 ]; then
+      fail "FM_TEST_REQUIRE_CASE_INSENSITIVE=1 but $TMP_ROOT is on a case-sensitive filesystem"
+    fi
+    printf 'skip: case-insensitive filesystem unavailable - case-spelling refusal not exercised here\n'
+    return 0
+  fi
+  id=caserefusez2
+  setup_case case-refuse Home home
+  proj_canonical=$(cd "$PROJ" && pwd -P)
+  before=$(project_fingerprint "$PROJ")
+  pane_reports "$proj_canonical"
+  out=$(run_spawn "$id" projects/peo-native --scout)
+  status=$?
+
+  assert_project_untouched "$before" "$PROJ" \
+    "a refused spawn wrote into the shared project checkout"
+  assert_absent "$HOME_REAL/state/$id.meta" \
+    "a refused spawn published a task record"
+  assert_no_agent_launched "a refused spawn still launched an agent"
+  [ "$status" -ne 0 ] || fail "spawn should refuse when the pane never leaves the project"$'\n'"$out"
+  assert_contains "$out" "did not enter a worktree" \
+    "refusal did not explain that no worktree was ever reached"
+  pass "fm-spawn: a pane that never leaves the project refuses, publishes nothing, and launches nothing"
+}
+
+# --- identity, not strings (portable) ----------------------------------------
+
+# A symlinked spelling of the project is the same directory, so it must be
+# treated exactly like the project itself rather than as somewhere the pane moved
+# to. This holds on every filesystem, case-sensitive or not.
+test_symlinked_project_spelling_is_not_an_isolated_worktree() {
+  local id out status before link
+  id=symlinkspellz3
+  setup_case symlink-spelling home home
+  link="$CASE_DIR/project-link"
+  ln -s "$PROJ" "$link"
+  before=$(project_fingerprint "$PROJ")
+  pane_reports "$link" "$link" "$link" "$TASK_WT"
+  out=$(run_spawn "$id" "$PROJ")
+  status=$?
+
+  expect_code 0 "$status" "spawn should succeed once the pane reaches the worktree"$'\n'"$out"
+  assert_grep "worktree=$TASK_WT" "$HOME_REAL/state/$id.meta" \
+    "meta did not record the real isolated worktree"
+  assert_no_grep "worktree=$link" "$HOME_REAL/state/$id.meta" \
+    "meta recorded a symlinked spelling of the project as the task worktree"
+  assert_project_untouched "$before" "$PROJ" \
+    "a symlinked spelling of the project was written to as if it were a worktree"
+  pass "fm-spawn: a symlinked spelling of the project is not an isolated worktree"
+}
+
+# The gate proves a worktree ROOT, not merely "a path inside some repository":
+# a subdirectory of a genuine worktree must refuse rather than become the task
+# worktree.
+test_worktree_subdirectory_refuses() {
+  local id out status before
+  id=subdirrefusez4
+  setup_case subdir-refuse home home
+  mkdir -p "$TASK_WT/nested"
+  before=$(project_fingerprint "$PROJ")
+  pane_reports "$TASK_WT/nested"
+  out=$(run_spawn "$id" "$PROJ")
+  status=$?
+
+  [ "$status" -ne 0 ] || fail "spawn should refuse a subdirectory of a worktree"$'\n'"$out"
+  assert_absent "$HOME_REAL/state/$id.meta" "a refused spawn published a task record"
+  assert_project_untouched "$before" "$PROJ" "a refused spawn wrote into the project"
+  assert_no_agent_launched "a refused spawn still launched an agent"
+  assert_contains "$out" "did not yield an isolated worktree" \
+    "subdirectory refusal lacked the isolation error"
+  assert_contains "$out" "not the worktree root" \
+    "subdirectory refusal did not name the failing condition"
+  pass "fm-spawn: a subdirectory of a worktree refuses and names the failing condition"
+}
+
+# A path that is not inside any repository must refuse, and the refusal must say
+# so rather than silently timing out.
+test_non_repository_path_refuses() {
+  local id out status before
+  id=nonrepoz5
+  setup_case non-repo home home
+  mkdir -p "$CASE_DIR/plain-dir"
+  before=$(project_fingerprint "$PROJ")
+  pane_reports "$CASE_DIR/plain-dir"
+  out=$(run_spawn "$id" "$PROJ" --scout)
+  status=$?
+
+  [ "$status" -ne 0 ] || fail "spawn should refuse a path outside any repository"$'\n'"$out"
+  assert_absent "$HOME_REAL/state/$id.meta" "a refused spawn published a task record"
+  assert_project_untouched "$before" "$PROJ" "a refused spawn wrote into the project"
+  assert_no_agent_launched "a refused spawn still launched an agent"
+  assert_contains "$out" "not inside a git worktree" \
+    "non-repository refusal did not name the failing condition"
+  pass "fm-spawn: a path outside any repository refuses and names the failing condition"
+}
+
+# --- argument-form consistency (portable) ------------------------------------
+
+# The registered project resolves to the same directory whether firstmate passes
+# projects/<name> or the absolute path, so both forms must reach the identical
+# outcome - the same accepted worktree, and the same refusal when the pane stays
+# in the project.
+test_relative_and_absolute_project_arguments_agree() {
+  local out_rel out_abs status_rel status_abs before
+  setup_case arg-forms home home
+  before=$(project_fingerprint "$PROJ")
+
+  pane_reports "$TASK_WT"
+  out_rel=$(run_spawn relformokz6 projects/peo-native)
+  status_rel=$?
+  pane_reports "$TASK_WT"
+  out_abs=$(run_spawn absformokz7 "$PROJ")
+  status_abs=$?
+  expect_code 0 "$status_rel" "relative project argument should spawn"$'\n'"$out_rel"
+  expect_code 0 "$status_abs" "absolute project argument should spawn"$'\n'"$out_abs"
+  assert_grep "worktree=$TASK_WT" "$HOME_REAL/state/relformokz6.meta" \
+    "relative form did not record the isolated worktree"
+  assert_grep "worktree=$TASK_WT" "$HOME_REAL/state/absformokz7.meta" \
+    "absolute form did not record the isolated worktree"
+
+  pane_reports "$PROJ/nested-missing"
+  mkdir -p "$PROJ/nested-missing"
+  out_rel=$(run_spawn relformbadz8 projects/peo-native)
+  status_rel=$?
+  pane_reports "$PROJ/nested-missing"
+  out_abs=$(run_spawn absformbadz9 "$PROJ")
+  status_abs=$?
+  rmdir "$PROJ/nested-missing"
+  [ "$status_rel" -ne 0 ] || fail "relative form should refuse a path inside the project"$'\n'"$out_rel"
+  [ "$status_abs" -ne 0 ] || fail "absolute form should refuse a path inside the project"$'\n'"$out_abs"
+  assert_absent "$HOME_REAL/state/relformbadz8.meta" "refused relative form published a task record"
+  assert_absent "$HOME_REAL/state/absformbadz9.meta" "refused absolute form published a task record"
+  assert_project_untouched "$before" "$PROJ" "an argument-form spawn wrote into the project"
+  assert_contains "$out_rel" "not the worktree root" "relative form gave a different refusal reason"
+  assert_contains "$out_abs" "not the worktree root" "absolute form gave a different refusal reason"
+  pass "fm-spawn: relative and absolute project arguments reach identical outcomes"
+}
+
+# --- scout parity and hook placement (portable) ------------------------------
+
+# A scout is the deliverable that triggered the incident, so it must clear the
+# same gate as a ship and install its hook inside the isolated worktree.
+test_scout_and_ship_share_the_gate_and_hook_placement() {
+  local out status before
+  setup_case scout-parity home home
+  before=$(project_fingerprint "$PROJ")
+
+  pane_reports "$TASK_WT"
+  out=$(run_spawn shipokz10 "$PROJ")
+  status=$?
+  expect_code 0 "$status" "ship spawn should succeed into an isolated worktree"$'\n'"$out"
+  assert_grep "kind=ship" "$HOME_REAL/state/shipokz10.meta" "ship spawn recorded the wrong kind"
+
+  pane_reports "$TASK_WT"
+  out=$(run_spawn scoutokz11 "$PROJ" --scout)
+  status=$?
+  expect_code 0 "$status" "scout spawn should succeed into an isolated worktree"$'\n'"$out"
+  assert_grep "kind=scout" "$HOME_REAL/state/scoutokz11.meta" "scout spawn recorded the wrong kind"
+
+  assert_present "$TASK_WT/.claude/settings.local.json" \
+    "the turn-end hook was not installed in the isolated worktree"
+  assert_project_untouched "$before" "$PROJ" \
+    "a valid isolated spawn still wrote into the shared project checkout"
+  pass "fm-spawn: ship and scout share the isolation gate and hook the worktree, not the project"
+}
+
+# --- hook-exclusion write containment (portable) -----------------------------
+
+# The hook is excluded from git's view through `rev-parse --git-path`, which
+# answers RELATIVE to the repository for a main checkout. Resolving that answer
+# inside the task worktree is what keeps the write contained: taken as-is it
+# lands in whatever directory fm-spawn was invoked from, which is firstmate's own
+# checkout for every ordinary dispatch. The pane here reaches an unrelated main
+# checkout - a genuine worktree root, distinct from the project, so the gate
+# passes - and the spawn runs from a third repository standing in for firstmate's
+# own working directory.
+test_hook_exclusion_write_stays_in_the_task_worktree() {
+  local id out status caller
+  id=excludecontainz12
+  setup_case exclude-containment home home
+  caller="$CASE_DIR/caller-checkout"
+  fm_git_init_commit "$caller"
+  pane_reports "$OTHER_REPO"
+  out=$(cd "$caller" && run_spawn "$id" "$PROJ")
+  status=$?
+
+  expect_code 0 "$status" "spawn should succeed into an unrelated main checkout"$'\n'"$out"
+  assert_grep '.claude/settings.local.json' "$OTHER_REPO/.git/info/exclude" \
+    "the hook exclusion was not recorded in the task worktree's own repository"
+  assert_no_grep '.claude/settings.local.json' "$caller/.git/info/exclude" \
+    "the hook exclusion escaped into the directory fm-spawn was invoked from"
+  pass "fm-spawn: the hook exclusion is written inside the task worktree, never the caller's checkout"
+}
+
+test_case_differing_project_spelling_is_never_the_worktree
+test_symlinked_project_spelling_is_not_an_isolated_worktree
+test_worktree_subdirectory_refuses
+test_non_repository_path_refuses
+test_relative_and_absolute_project_arguments_agree
+test_scout_and_ship_share_the_gate_and_hook_placement
+test_hook_exclusion_write_stays_in_the_task_worktree
+test_project_only_pane_refuses_and_leaves_the_project_untouched
+
+echo "# all fm-spawn-isolation tests passed"

--- a/tests/fm-spawn-isolation.test.sh
+++ b/tests/fm-spawn-isolation.test.sh
@@ -252,7 +252,7 @@ test_symlinked_project_spelling_is_not_an_isolated_worktree() {
   ln -s "$PROJ" "$link"
   before=$(project_fingerprint "$PROJ")
   pane_reports "$link" "$link" "$link" "$TASK_WT"
-  out=$(run_spawn "$id" "$PROJ")
+  out=$(run_spawn "$id" "$PROJ" --mode no-mistakes --yolo off)
   status=$?
 
   expect_code 0 "$status" "spawn should succeed once the pane reaches the worktree"$'\n'"$out"
@@ -275,7 +275,7 @@ test_worktree_subdirectory_refuses() {
   mkdir -p "$TASK_WT/nested"
   before=$(project_fingerprint "$PROJ")
   pane_reports "$TASK_WT/nested"
-  out=$(run_spawn "$id" "$PROJ")
+  out=$(run_spawn "$id" "$PROJ" --mode no-mistakes --yolo off)
   status=$?
 
   [ "$status" -ne 0 ] || fail "spawn should refuse a subdirectory of a worktree"$'\n'"$out"
@@ -322,10 +322,10 @@ test_relative_and_absolute_project_arguments_agree() {
   before=$(project_fingerprint "$PROJ")
 
   pane_reports "$TASK_WT"
-  out_rel=$(run_spawn relformokz6 projects/peo-native)
+  out_rel=$(run_spawn relformokz6 projects/peo-native --mode no-mistakes --yolo off)
   status_rel=$?
   pane_reports "$TASK_WT"
-  out_abs=$(run_spawn absformokz7 "$PROJ")
+  out_abs=$(run_spawn absformokz7 "$PROJ" --mode no-mistakes --yolo off)
   status_abs=$?
   expect_code 0 "$status_rel" "relative project argument should spawn"$'\n'"$out_rel"
   expect_code 0 "$status_abs" "absolute project argument should spawn"$'\n'"$out_abs"
@@ -336,10 +336,10 @@ test_relative_and_absolute_project_arguments_agree() {
 
   pane_reports "$PROJ/nested-missing"
   mkdir -p "$PROJ/nested-missing"
-  out_rel=$(run_spawn relformbadz8 projects/peo-native)
+  out_rel=$(run_spawn relformbadz8 projects/peo-native --mode no-mistakes --yolo off)
   status_rel=$?
   pane_reports "$PROJ/nested-missing"
-  out_abs=$(run_spawn absformbadz9 "$PROJ")
+  out_abs=$(run_spawn absformbadz9 "$PROJ" --mode no-mistakes --yolo off)
   status_abs=$?
   rmdir "$PROJ/nested-missing"
   [ "$status_rel" -ne 0 ] || fail "relative form should refuse a path inside the project"$'\n'"$out_rel"
@@ -362,7 +362,7 @@ test_scout_and_ship_share_the_gate_and_hook_placement() {
   before=$(project_fingerprint "$PROJ")
 
   pane_reports "$TASK_WT"
-  out=$(run_spawn shipokz10 "$PROJ")
+  out=$(run_spawn shipokz10 "$PROJ" --mode no-mistakes --yolo off)
   status=$?
   expect_code 0 "$status" "ship spawn should succeed into an isolated worktree"$'\n'"$out"
   assert_grep "kind=ship" "$HOME_REAL/state/shipokz10.meta" "ship spawn recorded the wrong kind"
@@ -397,7 +397,7 @@ test_hook_exclusion_write_stays_in_the_task_worktree() {
   caller="$CASE_DIR/caller-checkout"
   fm_git_init_commit "$caller"
   pane_reports "$OTHER_REPO"
-  out=$(cd "$caller" && run_spawn "$id" "$PROJ")
+  out=$(cd "$caller" && run_spawn "$id" "$PROJ" --mode no-mistakes --yolo off)
   status=$?
 
   expect_code 0 "$status" "spawn should succeed into an unrelated main checkout"$'\n'"$out"


### PR DESCRIPTION
Withdrawn by the author pending a rewrite. The original description has been removed.