### PR TITLE
feat: bind Decision OS lanes to the canonical review store (dos-3ndcm)

### DIFF
--- a/bin/fm-decision-os-review-migrate.sh
+++ b/bin/fm-decision-os-review-migrate.sh
@@ -1,0 +1,450 @@
+#!/usr/bin/env bash
+# Inventory and, only with --apply, migrate Decision OS review evidence stranded
+# in Treehouse pool copies into the canonical shared review store.
+#
+# Usage:
+#   fm-decision-os-review-migrate.sh <canonical-project>
+#   fm-decision-os-review-migrate.sh --apply <canonical-project>
+#
+# The default is a non-mutating preflight. The project argument is the sole path
+# authority: Treehouse inventory is queried from that checkout, every pool path
+# must share its git common directory, and data/local/reviews must already expose
+# the Decision OS contract as an in-project symlink to an existing directory.
+#
+# Apply defers every in-use or process-bearing slot. For an available slot it
+# inventories each top-level run, copies an absent destination through a private
+# hash-keyed staging area, verifies exact paths/types/bytes and SHA-256 hashes,
+# syncs and re-verifies, then removes only the verified source entry. Existing
+# identical destinations resume safely; non-identical collisions are never
+# overwritten. A drained source directory is replaced by the same canonical
+# link. Interrupted staging copies are private duplicates and are safely rebuilt
+# on rerun; sources remain authoritative until final verification succeeds.
+set -eu
+
+usage() {
+  sed -n '2,${/^#/!q;p;}' "$0" | sed 's/^# \{0,1\}//'
+}
+
+APPLY=0
+case "${1:-}" in
+  -h|--help) usage; exit 0 ;;
+  --apply) APPLY=1; shift ;;
+esac
+[ "$#" -eq 1 ] || { usage >&2; exit 2; }
+
+PROJECT=$1
+for tool in git jq treehouse find sort cmp cp mv rm sync; do
+  command -v "$tool" >/dev/null 2>&1 || {
+    echo "error: required command not found: $tool" >&2
+    exit 1
+  }
+done
+
+if command -v sha256sum >/dev/null 2>&1; then
+  sha256_file() { sha256sum "$1" | awk '{print $1}'; }
+  sha256_stream() { sha256sum | awk '{print $1}'; }
+elif command -v shasum >/dev/null 2>&1; then
+  sha256_file() { shasum -a 256 "$1" | awk '{print $1}'; }
+  sha256_stream() { shasum -a 256 | awk '{print $1}'; }
+elif command -v openssl >/dev/null 2>&1; then
+  sha256_file() { openssl dgst -sha256 "$1" | awk '{print $NF}'; }
+  sha256_stream() { openssl dgst -sha256 | awk '{print $NF}'; }
+else
+  echo "error: sha256sum, shasum, or openssl is required" >&2
+  exit 1
+fi
+
+resolved_dir() {
+  [ -d "$1" ] || return 1
+  cd "$1" 2>/dev/null && pwd -P
+}
+
+path_is_strict_child() {
+  case "$2" in
+    "$1"/*) [ "$1" != "$2" ] ;;
+    *) return 1 ;;
+  esac
+}
+
+git_common_dir_real() {
+  local repo=$1 common
+  common=$(git -C "$repo" rev-parse --git-common-dir 2>/dev/null) || return 1
+  case "$common" in
+    /*) resolved_dir "$common" ;;
+    *) resolved_dir "$repo/$common" ;;
+  esac
+}
+
+reject_unsafe_text() {
+  case "$1" in
+    *$'\n'*|*$'\t'*) return 1 ;;
+  esac
+  return 0
+}
+
+inventory_path() {  # <root-entry> <manifest-file>
+  local root=$1 manifest=$2 raw path rel target size hash
+  raw="$manifest.raw"
+  : > "$raw"
+  if [ -L "$root" ]; then
+    target=$(readlink "$root")
+    reject_unsafe_text "$target" || return 1
+    hash=$(printf '%s' "$target" | sha256_stream)
+    printf 'L\t.\t%s\t%s\n' "$hash" "$target" >> "$raw"
+  elif [ -f "$root" ]; then
+    size=$(wc -c < "$root" | tr -d '[:space:]')
+    hash=$(sha256_file "$root")
+    printf 'F\t.\t%s\t%s\n' "$size" "$hash" >> "$raw"
+  elif [ -d "$root" ]; then
+    printf 'D\t.\n' >> "$raw"
+    while IFS= read -r -d '' path; do
+      rel=${path#"$root"/}
+      reject_unsafe_text "$rel" || return 1
+      if [ -L "$path" ]; then
+        target=$(readlink "$path")
+        reject_unsafe_text "$target" || return 1
+        hash=$(printf '%s' "$target" | sha256_stream)
+        printf 'L\t%s\t%s\t%s\n' "$rel" "$hash" "$target" >> "$raw"
+      elif [ -f "$path" ]; then
+        size=$(wc -c < "$path" | tr -d '[:space:]')
+        hash=$(sha256_file "$path")
+        printf 'F\t%s\t%s\t%s\n' "$rel" "$size" "$hash" >> "$raw"
+      elif [ -d "$path" ]; then
+        printf 'D\t%s\n' "$rel" >> "$raw"
+      else
+        echo "error: unsupported filesystem entry in review evidence: $path" >&2
+        return 1
+      fi
+    done < <(find "$root" -mindepth 1 -print0)
+  else
+    echo "error: review evidence entry is neither file, directory, nor symlink: $root" >&2
+    return 1
+  fi
+  LC_ALL=C sort "$raw" > "$manifest"
+  rm -f "$raw"
+}
+
+PROJECT_REAL=$(resolved_dir "$PROJECT") || {
+  echo "error: canonical project is missing or not a directory: $PROJECT" >&2
+  exit 1
+}
+PROJECT_TOP=$(git -C "$PROJECT_REAL" rev-parse --show-toplevel 2>/dev/null || true)
+PROJECT_TOP_REAL=$(resolved_dir "$PROJECT_TOP" 2>/dev/null || true)
+if [ -z "$PROJECT_TOP_REAL" ] || [ "$PROJECT_TOP_REAL" != "$PROJECT_REAL" ]; then
+  echo "error: canonical project must be a git checkout root: $PROJECT" >&2
+  exit 1
+fi
+PROJECT_COMMON=$(git_common_dir_real "$PROJECT_REAL") || {
+  echo "error: canonical project identity cannot be resolved: $PROJECT_REAL" >&2
+  exit 1
+}
+
+CANONICAL_LINK="$PROJECT_REAL/data/local/reviews"
+if [ ! -L "$CANONICAL_LINK" ] || [ ! -d "$CANONICAL_LINK" ]; then
+  echo "error: canonical Decision OS review store must be an existing directory symlink: $CANONICAL_LINK" >&2
+  exit 1
+fi
+CANONICAL_TARGET=$(resolved_dir "$CANONICAL_LINK") || {
+  echo "error: canonical Decision OS review store cannot be resolved: $CANONICAL_LINK" >&2
+  exit 1
+}
+if ! path_is_strict_child "$PROJECT_REAL" "$CANONICAL_TARGET"; then
+  echo "error: canonical Decision OS review store resolves outside the project: $CANONICAL_TARGET" >&2
+  exit 1
+fi
+
+TMP_WORK=$(mktemp -d "${TMPDIR:-/tmp}/fm-dos-review-migrate.XXXXXX")
+cleanup() { rm -rf "$TMP_WORK"; }
+trap cleanup EXIT INT TERM
+
+POOL_JSON="$TMP_WORK/pool.json"
+( cd "$PROJECT_REAL" && treehouse status --json ) > "$POOL_JSON" || {
+  echo "error: treehouse pool inventory failed for $PROJECT_REAL" >&2
+  exit 1
+}
+jq -e 'type == "array" and all(.[]; (.name|type)=="string" and (.path|type)=="string" and (.status|type)=="string" and (.processes|type)=="array")' "$POOL_JSON" >/dev/null || {
+  echo "error: treehouse status returned an invalid pool inventory" >&2
+  exit 1
+}
+if [ "$(jq '[.[].name] | length' "$POOL_JSON")" != "$(jq '[.[].name] | unique | length' "$POOL_JSON")" ] \
+  || [ "$(jq '[.[].path] | length' "$POOL_JSON")" != "$(jq '[.[].path] | unique | length' "$POOL_JSON")" ]; then
+  echo "error: treehouse pool inventory is ambiguous (duplicate name or path)" >&2
+  exit 1
+fi
+
+recheck_index=0
+slot_still_available() {  # <slot> <inventory-path>; 0=safe, 1=active/changed, 2=unconfirmed
+  local slot_name=$1 inventory_path=$2 recheck
+  recheck_index=$((recheck_index + 1))
+  recheck="$TMP_WORK/recheck.$recheck_index.json"
+  ( cd "$PROJECT_REAL" && treehouse status --json ) > "$recheck" || return 2
+  jq -e 'type == "array" and all(.[]; (.name|type)=="string" and (.path|type)=="string" and (.status|type)=="string" and (.processes|type)=="array")' \
+    "$recheck" >/dev/null || return 2
+  if jq -e --arg name "$slot_name" --arg path "$inventory_path" \
+    '[.[] | select(.name == $name)] as $matches
+     | ($matches | length) == 1
+       and $matches[0].path == $path
+       and $matches[0].status == "available"
+       and ($matches[0].processes | length) == 0' \
+    "$recheck" >/dev/null; then
+    return 0
+  fi
+  return 1
+}
+
+STAGE_ROOT="$PROJECT_REAL/data/local/.dos-3ndcm-review-migration"
+refused=0
+slot_index=0
+while IFS=$'\t' read -r slot path status process_count; do
+  slot_index=$((slot_index + 1))
+  if ! reject_unsafe_text "$slot" || ! reject_unsafe_text "$path"; then
+    echo "REFUSE unsafe treehouse inventory text at row=$slot_index" >&2
+    refused=1
+    continue
+  fi
+  case "$slot" in
+    ''|*[!A-Za-z0-9._-]*)
+      echo "REFUSE unsafe slot name '$slot'" >&2
+      refused=1
+      continue
+      ;;
+  esac
+  slot_real=$(resolved_dir "$path" 2>/dev/null || true)
+  if [ -z "$slot_real" ]; then
+    echo "REFUSE slot=$slot missing or non-directory path=$path" >&2
+    refused=1
+    continue
+  fi
+  slot_top=$(git -C "$slot_real" rev-parse --show-toplevel 2>/dev/null || true)
+  slot_top_real=$(resolved_dir "$slot_top" 2>/dev/null || true)
+  slot_common=$(git_common_dir_real "$slot_real" 2>/dev/null || true)
+  if [ "$slot_top_real" != "$slot_real" ] || [ -z "$slot_common" ] || [ "$slot_common" != "$PROJECT_COMMON" ]; then
+    echo "REFUSE slot=$slot wrong project path=$slot_real" >&2
+    refused=1
+    continue
+  fi
+
+  reviews="$slot_real/data/local/reviews"
+  if [ -L "$reviews" ]; then
+    reviews_target=$(resolved_dir "$reviews" 2>/dev/null || true)
+    if [ "$reviews_target" = "$CANONICAL_TARGET" ]; then
+      echo "ALREADY-LINKED slot=$slot path=$reviews"
+    else
+      echo "REFUSE slot=$slot noncanonical review link path=$reviews target=${reviews_target:-missing}" >&2
+      refused=1
+    fi
+    continue
+  fi
+  if [ -e "$reviews" ] && [ ! -d "$reviews" ]; then
+    echo "REFUSE slot=$slot review source is not a directory path=$reviews" >&2
+    refused=1
+    continue
+  fi
+  if [ ! -e "$reviews" ]; then
+    echo "EMPTY slot=$slot path=$reviews"
+    if [ "$APPLY" -eq 1 ]; then
+      mkdir -p "$(dirname "$reviews")"
+      ln -s "$CANONICAL_LINK" "$reviews"
+      echo "LINKED slot=$slot target=$CANONICAL_LINK"
+    fi
+    continue
+  fi
+
+  entries="$TMP_WORK/entries.$slot_index"
+  : > "$entries"
+  while IFS= read -r -d '' entry; do
+    run=$(basename "$entry")
+    reject_unsafe_text "$run" || {
+      echo "REFUSE slot=$slot unsafe run id" >&2
+      refused=1
+      continue
+    }
+    printf '%s\n' "$run" >> "$entries"
+  done < <(find "$reviews" -mindepth 1 -maxdepth 1 -print0)
+  LC_ALL=C sort -o "$entries" "$entries"
+
+  if [ ! -s "$entries" ]; then
+    echo "EMPTY slot=$slot path=$reviews"
+    if [ "$APPLY" -eq 1 ]; then
+      rmdir "$reviews"
+      ln -s "$CANONICAL_LINK" "$reviews"
+      echo "LINKED slot=$slot target=$CANONICAL_LINK"
+    fi
+    continue
+  fi
+
+  active=0
+  slot_can_link=1
+  if [ "$status" != available ] || [ "$process_count" -ne 0 ]; then
+    active=1
+    slot_can_link=0
+  fi
+  while IFS= read -r run; do
+    [ -n "$run" ] || continue
+    source_entry="$reviews/$run"
+    source_manifest="$TMP_WORK/source.$slot_index.$(printf '%s' "$run" | sha256_stream)"
+    inventory_path "$source_entry" "$source_manifest" || {
+      echo "REFUSE slot=$slot run=$run could not inventory source" >&2
+      refused=1
+      slot_can_link=0
+      continue
+    }
+    source_hash=$(sha256_file "$source_manifest")
+    source_count=$(wc -l < "$source_manifest" | tr -d '[:space:]')
+    echo "INVENTORY slot=$slot run=$run entries=$source_count hash=$source_hash"
+    if [ "$active" -eq 1 ]; then
+      echo "DEFER active slot=$slot run=$run status=$status processes=$process_count"
+      continue
+    fi
+    if [ "$APPLY" -eq 0 ]; then
+      echo "WOULD-MIGRATE slot=$slot run=$run"
+      continue
+    fi
+
+    destination="$CANONICAL_TARGET/$run"
+    if [ -e "$destination" ] || [ -L "$destination" ]; then
+      destination_manifest="$TMP_WORK/destination.$slot_index.$(printf '%s' "$run" | sha256_stream)"
+      inventory_path "$destination" "$destination_manifest" || {
+        echo "REFUSE collision slot=$slot run=$run destination could not be inventoried" >&2
+        refused=1
+        slot_can_link=0
+        continue
+      }
+      if ! cmp -s "$source_manifest" "$destination_manifest"; then
+        echo "REFUSE collision slot=$slot run=$run source_hash=$source_hash destination_hash=$(sha256_file "$destination_manifest")" >&2
+        refused=1
+        slot_can_link=0
+        continue
+      fi
+      echo "VERIFIED-EXISTING slot=$slot run=$run hash=$source_hash"
+    else
+      run_key=$(printf '%s' "$run" | sha256_stream)
+      stage_parent="$STAGE_ROOT/$slot/$run_key/$source_hash"
+      stage_entry="$stage_parent/item"
+      rm -rf "$stage_parent"
+      mkdir -p "$stage_parent"
+      if ! cp -Rp "$source_entry" "$stage_entry"; then
+        echo "error: copy interrupted for slot=$slot run=$run; source preserved and staging retained at $stage_parent" >&2
+        exit 1
+      fi
+      stage_manifest="$TMP_WORK/stage.$slot_index.$run_key"
+      inventory_path "$stage_entry" "$stage_manifest" || {
+        echo "error: staged copy could not be inventoried for slot=$slot run=$run; source preserved" >&2
+        exit 1
+      }
+      if ! cmp -s "$source_manifest" "$stage_manifest"; then
+        echo "error: staged copy is incomplete for slot=$slot run=$run; source preserved" >&2
+        exit 1
+      fi
+      source_after="$TMP_WORK/source-after.$slot_index.$run_key"
+      inventory_path "$source_entry" "$source_after" || {
+        echo "DEFER changed slot=$slot run=$run source disappeared during copy"
+        slot_can_link=0
+        continue
+      }
+      if ! cmp -s "$source_manifest" "$source_after"; then
+        echo "DEFER changed slot=$slot run=$run source_hash=$source_hash current_hash=$(sha256_file "$source_after")"
+        slot_can_link=0
+        continue
+      fi
+      sync
+      inventory_path "$stage_entry" "$stage_manifest.after"
+      if ! cmp -s "$source_manifest" "$stage_manifest.after"; then
+        echo "error: staged copy changed after sync for slot=$slot run=$run; source preserved" >&2
+        exit 1
+      fi
+      mv -n "$stage_entry" "$destination"
+      if [ -e "$stage_entry" ] || [ -L "$stage_entry" ]; then
+        destination_manifest="$TMP_WORK/destination-race.$slot_index.$run_key"
+        inventory_path "$destination" "$destination_manifest" || true
+        if [ ! -f "$destination_manifest" ] || ! cmp -s "$source_manifest" "$destination_manifest"; then
+          echo "REFUSE collision slot=$slot run=$run destination appeared during publication" >&2
+          refused=1
+          slot_can_link=0
+          continue
+        fi
+        rm -rf "$stage_entry"
+      fi
+      echo "COPIED slot=$slot run=$run hash=$source_hash"
+    fi
+
+    sync
+    source_final="$TMP_WORK/source-final.$slot_index.$(printf '%s' "$run" | sha256_stream)"
+    destination_final="$TMP_WORK/destination-final.$slot_index.$(printf '%s' "$run" | sha256_stream)"
+    inventory_path "$source_entry" "$source_final" || {
+      echo "REFUSE slot=$slot run=$run source changed before removal" >&2
+      refused=1
+      slot_can_link=0
+      continue
+    }
+    inventory_path "$destination" "$destination_final" || {
+      echo "REFUSE slot=$slot run=$run destination changed before removal" >&2
+      refused=1
+      slot_can_link=0
+      continue
+    }
+    if ! cmp -s "$source_manifest" "$source_final" || ! cmp -s "$source_manifest" "$destination_final"; then
+      echo "DEFER changed slot=$slot run=$run during durable verification"
+      slot_can_link=0
+      continue
+    fi
+    if slot_still_available "$slot" "$path"; then
+      :
+    else
+      recheck_rc=$?
+      slot_can_link=0
+      if [ "$recheck_rc" -eq 1 ]; then
+        echo "DEFER active-changed slot=$slot run=$run before source retirement"
+      else
+        echo "REFUSE slot=$slot run=$run could not confirm lane remained available before source retirement" >&2
+        refused=1
+      fi
+      continue
+    fi
+    echo "VERIFIED slot=$slot run=$run hash=$source_hash"
+    retire_dir="$slot_real/data/local/.dos-3ndcm-review-migrated/$run/$source_hash"
+    retire_entry="$retire_dir/item"
+    rm -rf "$retire_dir"
+    mkdir -p "$retire_dir"
+    if ! mv -n "$source_entry" "$retire_entry" || [ -e "$source_entry" ] || [ -L "$source_entry" ]; then
+      echo "REFUSE slot=$slot run=$run source could not be atomically retired after verification" >&2
+      refused=1
+      slot_can_link=0
+      continue
+    fi
+    sync
+    retire_manifest="$TMP_WORK/retired.$slot_index.$(printf '%s' "$run" | sha256_stream)"
+    if ! inventory_path "$retire_entry" "$retire_manifest" \
+      || ! cmp -s "$source_manifest" "$retire_manifest"; then
+      echo "REFUSE slot=$slot run=$run source changed during atomic retirement; retained outside the canonical namespace" >&2
+      if [ ! -e "$source_entry" ] && [ ! -L "$source_entry" ]; then
+        mv -n "$retire_entry" "$source_entry" || true
+      fi
+      refused=1
+      slot_can_link=0
+      continue
+    fi
+    rm -rf "$retire_dir"
+    sync
+    echo "REMOVED slot=$slot run=$run source=$source_entry"
+  done < "$entries"
+
+  if [ "$slot_can_link" -eq 1 ] && [ -d "$reviews" ] \
+    && [ -z "$(find "$reviews" -mindepth 1 -print -quit)" ]; then
+    if [ "$APPLY" -eq 1 ]; then
+      rmdir "$reviews"
+      ln -s "$CANONICAL_LINK" "$reviews"
+      echo "LINKED slot=$slot target=$CANONICAL_LINK"
+    fi
+  fi
+done < <(jq -r '.[] | [.name,.path,.status,(.processes|length)] | @tsv' "$POOL_JSON")
+
+if [ "$refused" -ne 0 ]; then
+  echo "migration refused one or more unsafe pool entries; no refused source was removed" >&2
+  exit 1
+fi
+if [ "$APPLY" -eq 0 ]; then
+  echo "PREFLIGHT complete: no files copied, removed, or linked"
+else
+  echo "APPLY complete: active or changing runs, if any, remain deferred"
+fi

--- a/bin/fm-decision-os-review-migrate.sh
+++ b/bin/fm-decision-os-review-migrate.sh
@@ -224,6 +224,11 @@ while IFS=$'\t' read -r slot path status process_count; do
     continue
   fi
 
+  slot_available=1
+  if [ "$status" != available ] || [ "$process_count" -ne 0 ]; then
+    slot_available=0
+  fi
+
   reviews="$slot_real/data/local/reviews"
   if [ -L "$reviews" ]; then
     reviews_target=$(resolved_dir "$reviews" 2>/dev/null || true)
@@ -243,9 +248,14 @@ while IFS=$'\t' read -r slot path status process_count; do
   if [ ! -e "$reviews" ]; then
     echo "EMPTY slot=$slot path=$reviews"
     if [ "$APPLY" -eq 1 ]; then
-      mkdir -p "$(dirname "$reviews")"
-      ln -s "$CANONICAL_LINK" "$reviews"
-      echo "LINKED slot=$slot target=$CANONICAL_LINK"
+      if [ "$slot_available" -eq 0 ]; then
+        echo "DEFER active slot=$slot path=$reviews status=$status processes=$process_count"
+      elif mkdir -p "$(dirname "$reviews")" && ln -s "$CANONICAL_LINK" "$reviews"; then
+        echo "LINKED slot=$slot target=$CANONICAL_LINK"
+      else
+        echo "REFUSE slot=$slot review link could not be created path=$reviews" >&2
+        refused=1
+      fi
     fi
     continue
   fi
@@ -266,16 +276,21 @@ while IFS=$'\t' read -r slot path status process_count; do
   if [ ! -s "$entries" ]; then
     echo "EMPTY slot=$slot path=$reviews"
     if [ "$APPLY" -eq 1 ]; then
-      rmdir "$reviews"
-      ln -s "$CANONICAL_LINK" "$reviews"
-      echo "LINKED slot=$slot target=$CANONICAL_LINK"
+      if [ "$slot_available" -eq 0 ]; then
+        echo "DEFER active slot=$slot path=$reviews status=$status processes=$process_count"
+      elif rmdir "$reviews" && ln -s "$CANONICAL_LINK" "$reviews"; then
+        echo "LINKED slot=$slot target=$CANONICAL_LINK"
+      else
+        echo "REFUSE slot=$slot empty review directory could not be replaced path=$reviews" >&2
+        refused=1
+      fi
     fi
     continue
   fi
 
   active=0
   slot_can_link=1
-  if [ "$status" != available ] || [ "$process_count" -ne 0 ]; then
+  if [ "$slot_available" -eq 0 ]; then
     active=1
     slot_can_link=0
   fi
@@ -432,9 +447,12 @@ while IFS=$'\t' read -r slot path status process_count; do
   if [ "$slot_can_link" -eq 1 ] && [ -d "$reviews" ] \
     && [ -z "$(find "$reviews" -mindepth 1 -print -quit)" ]; then
     if [ "$APPLY" -eq 1 ]; then
-      rmdir "$reviews"
-      ln -s "$CANONICAL_LINK" "$reviews"
-      echo "LINKED slot=$slot target=$CANONICAL_LINK"
+      if rmdir "$reviews" && ln -s "$CANONICAL_LINK" "$reviews"; then
+        echo "LINKED slot=$slot target=$CANONICAL_LINK"
+      else
+        echo "REFUSE slot=$slot drained review directory could not be linked path=$reviews" >&2
+        refused=1
+      fi
     fi
   fi
 done < <(jq -r '.[] | [.name,.path,.status,(.processes|length)] | @tsv' "$POOL_JSON")

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -112,6 +112,12 @@
 #   default-branch commit when safe; skipped syncs warn and launch unchanged.
 #   Ship/scout spawns refuse to launch unless the resolved task path is a real
 #   git worktree root distinct from the primary project checkout.
+#   A project exposes the Decision OS shared review-store contract by making its
+#   primary data/local/reviews path a symlink to an existing directory inside
+#   that project. After worktree validation and before worker launch, fm-spawn
+#   binds the lane's same path to that canonical store. A missing or external
+#   canonical target and any conflicting lane path fail closed without replacing
+#   or hiding bytes. Projects without that primary symlink remain unchanged.
 # Batch dispatch: pass one or more `id=repo` pairs instead of a single <id> <project>, e.g.
 #     fm-spawn.sh fix-a-k3=projects/foo add-b-q7=projects/bar [--scout]
 #   Each pair re-execs this script in single-task mode, so the single path stays the only
@@ -1413,6 +1419,90 @@ validate_spawn_worktree() {  # <source> <inspect-target>
   fi
 }
 
+git_common_dir_real() {  # <worktree>
+  local worktree=$1 common
+  common=$(git -C "$worktree" rev-parse --git-common-dir 2>/dev/null) || return 1
+  case "$common" in
+    /*) cd "$common" 2>/dev/null && pwd -P ;;
+    *) cd "$worktree/$common" 2>/dev/null && pwd -P ;;
+  esac
+}
+
+bind_project_review_store() {
+  local canonical_link canonical_target wt_real lane_link lane_parent
+  local project_common wt_common lane_target
+  canonical_link="$PROJ_ABS_REAL/data/local/reviews"
+
+  # The canonical checkout's symlink is the existing opt-in contract. An
+  # ordinary project with no such link must retain its historical spawn path.
+  [ -L "$canonical_link" ] || return 0
+  if [ ! -d "$canonical_link" ]; then
+    echo "error: canonical review store is missing or is not a directory: $canonical_link; refusing to launch" >&2
+    return 1
+  fi
+  canonical_target=$(cd "$canonical_link" 2>/dev/null && pwd -P) || {
+    echo "error: canonical review store cannot be resolved: $canonical_link; refusing to launch" >&2
+    return 1
+  }
+  if ! path_is_ancestor_of "$PROJ_ABS_REAL" "$canonical_target"; then
+    echo "error: canonical review store resolves outside its project: $canonical_link -> $canonical_target; refusing to launch" >&2
+    return 1
+  fi
+
+  wt_real=$(cd "$WT" 2>/dev/null && pwd -P) || {
+    echo "error: Decision OS lane cannot be resolved before review-store setup: $WT; refusing to launch" >&2
+    return 1
+  }
+  project_common=$(git_common_dir_real "$PROJ_ABS_REAL") || {
+    echo "error: canonical review-store project identity cannot be resolved: $PROJ_ABS_REAL; refusing to launch" >&2
+    return 1
+  }
+  wt_common=$(git_common_dir_real "$wt_real") || {
+    echo "error: Decision OS lane project identity cannot be resolved: $WT; refusing to launch" >&2
+    return 1
+  }
+  if [ "$project_common" != "$wt_common" ]; then
+    echo "error: Decision OS lane belongs to a different project than canonical review store $canonical_link; refusing to launch" >&2
+    return 1
+  fi
+
+  lane_link="$WT/data/local/reviews"
+  if [ -L "$lane_link" ]; then
+    if [ ! -d "$lane_link" ]; then
+      echo "error: Decision OS lane review link is dangling or not a directory: $lane_link; refusing to launch" >&2
+      return 1
+    fi
+    lane_target=$(cd "$lane_link" 2>/dev/null && pwd -P) || lane_target=
+    if [ "$lane_target" != "$canonical_target" ]; then
+      echo "error: Decision OS lane review link targets '$lane_target', not canonical '$canonical_target'; refusing to launch" >&2
+      return 1
+    fi
+    return 0
+  fi
+  if [ -e "$lane_link" ]; then
+    echo "error: Decision OS lane review path already exists and could contain evidence: $lane_link; refusing to overwrite or hide it" >&2
+    return 1
+  fi
+
+  lane_parent="$WT/data/local"
+  mkdir -p "$lane_parent" || {
+    echo "error: could not create Decision OS lane review parent: $lane_parent; refusing to launch" >&2
+    return 1
+  }
+  lane_parent=$(cd "$lane_parent" 2>/dev/null && pwd -P) || {
+    echo "error: Decision OS lane review parent cannot be resolved; refusing to launch" >&2
+    return 1
+  }
+  if ! path_is_ancestor_of "$wt_real" "$lane_parent"; then
+    echo "error: Decision OS lane review parent resolves outside the lane: $lane_parent; refusing to launch" >&2
+    return 1
+  fi
+  if ! ln -s "$canonical_link" "$lane_link"; then
+    echo "error: could not bind Decision OS lane review store at $lane_link; refusing to launch" >&2
+    return 1
+  fi
+}
+
 herdr_projection_meta_field_exact() {  # <meta> <key>
   local meta=$1 key=$2 count
   [ -f "$meta" ] && [ ! -L "$meta" ] || return 1
@@ -1866,6 +1956,10 @@ if [ "$KIND" != secondmate ] && [ "$BACKEND" != orca ]; then
   fi
 
   validate_spawn_worktree "treehouse get" "$T"
+fi
+
+if [ "$KIND" != secondmate ]; then
+  bind_project_review_store || exit 1
 fi
 
 # Per-task temp root: /tmp/fm-<id>/ with Go's build temp nested at gotmp/. Go won't

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -192,6 +192,7 @@ family_for_basename() {
     fm-tmux-agent-liveness.test.sh|\
     fm-herdr-session-cleanup.test.sh|fm-send-resolve-key.test.sh|fm-send-strict.test.sh|fm-spawn-batch.test.sh|\
     fm-spawn-dispatch-profile.test.sh|\
+    fm-decision-os-review-migrate.test.sh|fm-spawn-decision-os-reviews.test.sh|\
     fm-trace-context-spawn.test.sh|fm-spawn-worktree-settle.test.sh|\
     fm-teardown-endpoint-safety.test.sh)
       printf '%s\n' backend-dispatch
@@ -926,6 +927,7 @@ families_for_changed_path() {
       printf '%s\n' pure-contract-unit
       printf '%s\n' pr-forge
       ;;
+    bin/fm-decision-os-review-migrate.sh|\
     bin/fm-spawn.sh|bin/fm-send.sh|bin/fm-harness.sh|\
     bin/fm-peek.sh|bin/fm-composer*)
       printf '%s\n' backend-dispatch

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -25,6 +25,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-backlog-handoff.sh`  | Validate and delegate queued backlog-item moves into a secondmate home               |
 | `fm-backlog-receive.sh`  | Idempotently ingest one confined remote handoff outbox through tasks-axi             |
 | `fm-decision-hold.sh`    | Create, verify, complete, and resolve durable captain-held decisions                 |
+| `fm-decision-os-review-migrate.sh` | Preflight or guardedly migrate stranded Decision OS Treehouse review evidence |
 | `fm-brief.sh`            | Scaffold ship (explicit `--mode`), scout, secondmate-charter, and Herdr-lab briefs   |
 | `fm-herdr-lab.sh`        | Provision and guardedly operate an isolated, never-default Herdr lab session         |
 | `fm-install-herdr.sh`    | Install CI's exact-version Herdr pin with official asset URL, SHA-256, and protocol checks |

--- a/tests/fm-decision-os-review-migrate.test.sh
+++ b/tests/fm-decision-os-review-migrate.test.sh
@@ -122,6 +122,24 @@ test_dry_run_inventories_every_copy_and_defers_active_lane() {
   pass "migration dry run inventories all pool copies and defers active lanes without mutation"
 }
 
+test_apply_defers_review_link_setup_for_active_lane() {
+  local rec out status
+  rec=$(make_case active-link)
+  read_case "$rec"
+  mkdir -p "$SLOT2/data/local/reviews"
+  write_pool_json in-use in-use
+
+  out=$(run_migrate --apply)
+  status=$?
+  expect_code 0 "$status" "apply with only active lanes should defer without failing"$'\n'"$out"
+  assert_contains "$out" "DEFER active slot=1" "active lane with a missing review path was not deferred"
+  assert_contains "$out" "DEFER active slot=2" "active lane with an empty review directory was not deferred"
+  assert_absent "$SLOT1/data/local/reviews" "apply created a review path for an in-use lane"
+  [ -d "$SLOT2/data/local/reviews" ] && [ ! -L "$SLOT2/data/local/reviews" ] \
+    || fail "apply removed or linked the empty review directory of an in-use lane"
+  pass "apply defers review-path creation, removal, and linking for active lanes"
+}
+
 test_apply_copies_verifies_removes_then_links_and_reruns_idempotently() {
   local rec out status copied verified removed
   rec=$(make_case apply)
@@ -262,6 +280,7 @@ test_wrong_project_and_invalid_canonical_store_refuse() {
 
 test_dry_run_inventories_every_copy_and_defers_active_lane
 test_lane_becoming_active_before_retirement_is_deferred
+test_apply_defers_review_link_setup_for_active_lane
 test_apply_copies_verifies_removes_then_links_and_reruns_idempotently
 test_nonidentical_collision_refuses_and_identical_collision_resumes
 test_changing_source_is_deferred_without_destination_publication

--- a/tests/fm-decision-os-review-migrate.test.sh
+++ b/tests/fm-decision-os-review-migrate.test.sh
@@ -1,0 +1,271 @@
+#!/usr/bin/env bash
+# Public-interface tests for the attended, one-time migration of Decision OS
+# review evidence stranded in Treehouse pool copies.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+MIGRATE="$ROOT/bin/fm-decision-os-review-migrate.sh"
+TMP_ROOT=$(fm_test_tmproot fm-decision-os-review-migrate)
+REAL_CP=$(command -v cp)
+
+make_fakebin() {
+  local dir=$1 fakebin
+  fakebin=$(fm_fakebin "$dir")
+  cat > "$fakebin/treehouse" <<'SH'
+#!/usr/bin/env bash
+set -u
+[ "${1:-}" = status ] && [ "${2:-}" = --json ] || exit 64
+cat "${FM_MIGRATION_POOL_JSON:?}"
+SH
+  chmod +x "$fakebin/treehouse"
+  printf '%s\n' "$fakebin"
+}
+
+make_case() {
+  local name=$1 case_dir project slot1 slot2 fakebin
+  case_dir="$TMP_ROOT/$name"
+  project="$case_dir/decision-os"
+  slot1="$case_dir/pool/1/decision-os"
+  slot2="$case_dir/pool/2/decision-os"
+  fakebin=$(make_fakebin "$case_dir/fake")
+  fm_git_worktree "$project" "$slot1" "slot-1-$name"
+  git -C "$project" worktree add --quiet -b "slot-2-$name" "$slot2"
+  mkdir -p "$project/data/local/.reviews"
+  ln -s .reviews "$project/data/local/reviews"
+  printf '%s\n' "$case_dir|$project|$slot1|$slot2|$fakebin"
+}
+
+read_case() {
+  IFS='|' read -r CASE_DIR PROJECT SLOT1 SLOT2 FAKEBIN_DIR <<EOF
+$1
+EOF
+  POOL_JSON="$CASE_DIR/pool.json"
+}
+
+write_pool_json() {
+  local status1=${1:-available} status2=${2:-available} processes1 processes2
+  processes1='[]'; processes2='[]'
+  [ "$status1" = available ] || processes1='[{"pid":123,"name":"reviewer"}]'
+  [ "$status2" = available ] || processes2='[{"pid":456,"name":"worker"}]'
+  jq -n \
+    --arg p1 "$SLOT1" --arg s1 "$status1" --argjson ps1 "$processes1" \
+    --arg p2 "$SLOT2" --arg s2 "$status2" --argjson ps2 "$processes2" \
+    '[{name:"1",path:$p1,status:$s1,processes:$ps1},{name:"2",path:$p2,status:$s2,processes:$ps2}]' \
+    > "$POOL_JSON"
+}
+
+run_migrate() {
+  FM_MIGRATION_POOL_JSON="$POOL_JSON" PATH="$FAKEBIN_DIR:$PATH" \
+    "$MIGRATE" "$@" "$PROJECT" 2>&1
+}
+
+test_lane_becoming_active_before_retirement_is_deferred() {
+  local rec out status next_json counter
+  rec=$(make_case became-active)
+  read_case "$rec"
+  mkdir -p "$SLOT1/data/local/reviews/run-one"
+  printf 'still live\n' > "$SLOT1/data/local/reviews/run-one/frozen.json"
+  write_pool_json available available
+  next_json="$CASE_DIR/pool-next.json"
+  counter="$CASE_DIR/treehouse-count"
+  jq --argjson ps '[{"pid":789,"name":"late-reviewer"}]' \
+    'map(if .name == "1" then .status="in-use" | .processes=$ps else . end)' \
+    "$POOL_JSON" > "$next_json"
+  cat > "$FAKEBIN_DIR/treehouse" <<'SH'
+#!/usr/bin/env bash
+set -u
+[ "${1:-}" = status ] && [ "${2:-}" = --json ] || exit 64
+count=0
+[ ! -f "${FM_MIGRATION_TREEHOUSE_COUNT:?}" ] || count=$(cat "$FM_MIGRATION_TREEHOUSE_COUNT")
+count=$((count + 1))
+printf '%s\n' "$count" > "$FM_MIGRATION_TREEHOUSE_COUNT"
+if [ "$count" -eq 1 ]; then
+  cat "${FM_MIGRATION_POOL_JSON:?}"
+else
+  cat "${FM_MIGRATION_POOL_JSON_NEXT:?}"
+fi
+SH
+  chmod +x "$FAKEBIN_DIR/treehouse"
+
+  out=$(FM_MIGRATION_POOL_JSON_NEXT="$next_json" \
+    FM_MIGRATION_TREEHOUSE_COUNT="$counter" run_migrate --apply)
+  status=$?
+  expect_code 0 "$status" "a lane becoming active should defer source retirement"$'\n'"$out"
+  assert_contains "$out" "DEFER active-changed" "late activity was not detected"
+  assert_present "$SLOT1/data/local/reviews/run-one/frozen.json" \
+    "late activity allowed source evidence to be retired"
+  pass "migration rechecks lane activity before retiring verified evidence"
+}
+
+test_dry_run_inventories_every_copy_and_defers_active_lane() {
+  local rec out status
+  rec=$(make_case inventory)
+  read_case "$rec"
+  mkdir -p "$SLOT1/data/local/reviews/run-one" "$SLOT2/data/local/reviews/run-two"
+  printf 'one\n' > "$SLOT1/data/local/reviews/run-one/frozen.json"
+  printf 'two\n' > "$SLOT2/data/local/reviews/run-two/frozen.json"
+  write_pool_json available in-use
+
+  out=$(run_migrate)
+  status=$?
+  expect_code 0 "$status" "dry-run inventory should succeed"$'\n'"$out"
+  assert_contains "$out" "slot=1" "inventory omitted available slot"
+  assert_contains "$out" "run=run-one" "inventory omitted available run id"
+  assert_contains "$out" "hash=" "inventory omitted exact manifest hash"
+  assert_contains "$out" "slot=2" "inventory omitted active slot"
+  assert_contains "$out" "DEFER active" "active slot was not explicitly deferred"
+  assert_present "$SLOT1/data/local/reviews/run-one/frozen.json" "dry run changed available evidence"
+  assert_present "$SLOT2/data/local/reviews/run-two/frozen.json" "dry run changed active evidence"
+  assert_absent "$PROJECT/data/local/.reviews/run-one" "dry run copied into canonical store"
+  pass "migration dry run inventories all pool copies and defers active lanes without mutation"
+}
+
+test_apply_copies_verifies_removes_then_links_and_reruns_idempotently() {
+  local rec out status copied verified removed
+  rec=$(make_case apply)
+  read_case "$rec"
+  mkdir -p "$SLOT1/data/local/reviews/run-one/empty-dir"
+  printf 'evidence\n' > "$SLOT1/data/local/reviews/run-one/frozen.json"
+  ln -s frozen.json "$SLOT1/data/local/reviews/run-one/latest"
+  write_pool_json available available
+
+  out=$(run_migrate --apply)
+  status=$?
+  expect_code 0 "$status" "guarded apply should succeed"$'\n'"$out"
+  assert_present "$PROJECT/data/local/.reviews/run-one/frozen.json" "canonical copy is missing"
+  [ "$(cat "$PROJECT/data/local/.reviews/run-one/frozen.json")" = evidence ] \
+    || fail "canonical evidence bytes differ"
+  [ -L "$SLOT1/data/local/reviews" ] || fail "drained lane was not linked to canonical reviews"
+  [ "$(cd "$SLOT1/data/local/reviews" && pwd -P)" = "$(cd "$PROJECT/data/local/reviews" && pwd -P)" ] \
+    || fail "drained lane link does not resolve to canonical reviews"
+  copied=$(printf '%s\n' "$out" | grep -n 'COPIED slot=1 run=run-one' | cut -d: -f1)
+  verified=$(printf '%s\n' "$out" | grep -n 'VERIFIED slot=1 run=run-one' | cut -d: -f1)
+  removed=$(printf '%s\n' "$out" | grep -n 'REMOVED slot=1 run=run-one' | cut -d: -f1)
+  [ -n "$copied" ] && [ "$copied" -lt "$verified" ] && [ "$verified" -lt "$removed" ] \
+    || fail "apply did not report copy-before-verify-before-remove ordering"
+
+  out=$(run_migrate --apply)
+  status=$?
+  expect_code 0 "$status" "idempotent rerun should succeed"$'\n'"$out"
+  assert_contains "$out" "ALREADY-LINKED slot=1" "rerun did not recognize the completed lane"
+  pass "migration copies, durably verifies, removes, links, and reruns idempotently"
+}
+
+test_nonidentical_collision_refuses_and_identical_collision_resumes() {
+  local rec out status
+  rec=$(make_case collision)
+  read_case "$rec"
+  mkdir -p "$SLOT1/data/local/reviews/run-one" "$PROJECT/data/local/.reviews/run-one"
+  printf 'source\n' > "$SLOT1/data/local/reviews/run-one/frozen.json"
+  printf 'different\n' > "$PROJECT/data/local/.reviews/run-one/frozen.json"
+  write_pool_json available available
+
+  out=$(run_migrate --apply)
+  status=$?
+  [ "$status" -ne 0 ] || fail "non-identical collision should refuse the migration"
+  assert_contains "$out" "REFUSE collision" "collision refusal was not explicit"
+  [ "$(cat "$SLOT1/data/local/reviews/run-one/frozen.json")" = source ] \
+    || fail "collision refusal changed source evidence"
+  [ "$(cat "$PROJECT/data/local/.reviews/run-one/frozen.json")" = different ] \
+    || fail "collision refusal overwrote destination evidence"
+
+  printf 'source\n' > "$PROJECT/data/local/.reviews/run-one/frozen.json"
+  out=$(run_migrate --apply)
+  status=$?
+  expect_code 0 "$status" "identical destination should permit safe resume"$'\n'"$out"
+  assert_contains "$out" "VERIFIED-EXISTING slot=1 run=run-one" \
+    "resume did not recognize identical canonical evidence"
+  [ -L "$SLOT1/data/local/reviews" ] || fail "identical resume did not link the drained lane"
+  pass "migration refuses non-identical collisions and safely resumes identical ones"
+}
+
+test_changing_source_is_deferred_without_destination_publication() {
+  local rec out status real_cp=$REAL_CP
+  rec=$(make_case changing)
+  read_case "$rec"
+  mkdir -p "$SLOT1/data/local/reviews/run-one"
+  printf 'before\n' > "$SLOT1/data/local/reviews/run-one/frozen.json"
+  write_pool_json available available
+  cat > "$FAKEBIN_DIR/cp" <<SH
+#!/usr/bin/env bash
+"$real_cp" "\$@" || exit \$?
+printf 'changed during copy\n' >> "${SLOT1}/data/local/reviews/run-one/frozen.json"
+SH
+  chmod +x "$FAKEBIN_DIR/cp"
+
+  out=$(run_migrate --apply)
+  status=$?
+  expect_code 0 "$status" "changing source should be deferred, not destroyed"$'\n'"$out"
+  assert_contains "$out" "DEFER changed" "changing source was not detected"
+  assert_present "$SLOT1/data/local/reviews/run-one/frozen.json" "changing source was removed"
+  assert_absent "$PROJECT/data/local/.reviews/run-one" "changing source was published canonically"
+  pass "migration detects a changing run and leaves source and destination safe"
+}
+
+test_interrupted_copy_is_resumable() {
+  local rec out status real_cp=$REAL_CP
+  rec=$(make_case resume)
+  read_case "$rec"
+  mkdir -p "$SLOT1/data/local/reviews/run-one"
+  printf 'resume me\n' > "$SLOT1/data/local/reviews/run-one/frozen.json"
+  write_pool_json available available
+  cat > "$FAKEBIN_DIR/cp" <<SH
+#!/usr/bin/env bash
+"$real_cp" "\$@"
+exit 75
+SH
+  chmod +x "$FAKEBIN_DIR/cp"
+
+  out=$(run_migrate --apply)
+  status=$?
+  [ "$status" -ne 0 ] || fail "simulated interrupted copy should fail"
+  assert_present "$SLOT1/data/local/reviews/run-one/frozen.json" "interruption removed source evidence"
+  assert_absent "$PROJECT/data/local/.reviews/run-one" "interruption published an unverified destination"
+
+  rm "$FAKEBIN_DIR/cp"
+  out=$(run_migrate --apply)
+  status=$?
+  expect_code 0 "$status" "rerun after interrupted copy should succeed"$'\n'"$out"
+  assert_present "$PROJECT/data/local/.reviews/run-one/frozen.json" "resume did not publish verified evidence"
+  [ -L "$SLOT1/data/local/reviews" ] || fail "resume did not finish linking the lane"
+  pass "migration safely resumes after an interrupted copy"
+}
+
+test_wrong_project_and_invalid_canonical_store_refuse() {
+  local rec out status other
+  rec=$(make_case invalid)
+  read_case "$rec"
+  mkdir -p "$SLOT1/data/local/reviews/run-one"
+  printf 'safe\n' > "$SLOT1/data/local/reviews/run-one/frozen.json"
+  write_pool_json available available
+  rm "$PROJECT/data/local/reviews"
+  ln -s missing "$PROJECT/data/local/reviews"
+  out=$(run_migrate --apply)
+  status=$?
+  [ "$status" -ne 0 ] || fail "dangling canonical store should refuse"
+  assert_contains "$out" "canonical" "canonical refusal should explain the boundary"
+  assert_present "$SLOT1/data/local/reviews/run-one/frozen.json" "canonical refusal changed source"
+
+  rm "$PROJECT/data/local/reviews"
+  ln -s .reviews "$PROJECT/data/local/reviews"
+  other="$CASE_DIR/other-repo"
+  fm_git_init_commit "$other"
+  jq -n --arg path "$other" '[{name:"wrong",path:$path,status:"available",processes:[]}]' > "$POOL_JSON"
+  out=$(run_migrate --apply)
+  status=$?
+  [ "$status" -ne 0 ] || fail "wrong-project pool path should refuse"
+  assert_contains "$out" "wrong project" "wrong-project refusal was not explicit"
+  pass "migration refuses invalid canonical stores and wrong-project pool copies"
+}
+
+test_dry_run_inventories_every_copy_and_defers_active_lane
+test_lane_becoming_active_before_retirement_is_deferred
+test_apply_copies_verifies_removes_then_links_and_reruns_idempotently
+test_nonidentical_collision_refuses_and_identical_collision_resumes
+test_changing_source_is_deferred_without_destination_publication
+test_interrupted_copy_is_resumable
+test_wrong_project_and_invalid_canonical_store_refuse
+
+echo "# all Decision OS review migration tests passed"

--- a/tests/fm-spawn-decision-os-reviews.test.sh
+++ b/tests/fm-spawn-decision-os-reviews.test.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+# Public-interface regressions for the Decision OS review-store contract at the
+# fm-spawn lane-setup boundary.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+SPAWN="$ROOT/bin/fm-spawn.sh"
+TMP_ROOT=$(fm_test_tmproot fm-spawn-decision-os-reviews)
+
+make_fakebin() {
+  local dir=$1 fakebin
+  fakebin=$(fm_fakebin "$dir")
+  cat > "$fakebin/tmux" <<'SH'
+#!/usr/bin/env bash
+set -u
+case "$*" in
+  *"#{pane_current_path}"*) printf '%s\n' "${FM_FAKE_PANE_PATH:?}"; exit 0 ;;
+esac
+case "${1:-}" in
+  display-message) printf 'firstmate\n'; exit 0 ;;
+  list-windows|has-session|new-session|new-window|kill-window|send-keys) exit 0 ;;
+esac
+exit 0
+SH
+  chmod +x "$fakebin/tmux"
+  fm_fake_exit0 "$fakebin" treehouse sleep
+  printf '%s\n' "$fakebin"
+}
+
+make_case() {
+  local name=$1 id=$2 case_dir home proj wt fakebin
+  case_dir="$TMP_ROOT/$name"
+  home="$case_dir/home"
+  proj="$case_dir/decision-os"
+  wt="$case_dir/lane"
+  fakebin=$(make_fakebin "$case_dir/fake")
+  mkdir -p "$home/data/$id" "$home/projects" "$home/state" "$home/config"
+  printf 'codex\n' > "$home/config/crew-harness"
+  printf 'brief for %s\n' "$id" > "$home/data/$id/brief.md"
+  touch "$home/state/.last-watcher-beat"
+  fm_git_worktree "$proj" "$wt" "wt-$name"
+  printf '%s\n' "$case_dir|$home|$proj|$wt|$fakebin"
+}
+
+read_case() {
+  IFS='|' read -r CASE_DIR HOME_DIR PROJ_DIR WT_DIR FAKEBIN_DIR <<EOF
+$1
+EOF
+}
+
+expose_contract() {
+  mkdir -p "$PROJ_DIR/data/local/.reviews"
+  ln -s .reviews "$PROJ_DIR/data/local/reviews"
+}
+
+run_spawn() {
+  local id=$1
+  FM_ROOT_OVERRIDE='' FM_HOME="$HOME_DIR" \
+    FM_STATE_OVERRIDE="$HOME_DIR/state" FM_DATA_OVERRIDE="$HOME_DIR/data" \
+    FM_PROJECTS_OVERRIDE="$HOME_DIR/projects" FM_CONFIG_OVERRIDE="$HOME_DIR/config" \
+    FM_SPAWN_NO_GUARD=1 TMUX="fake,1,0" FM_FAKE_PANE_PATH="$WT_DIR" \
+    PATH="$FAKEBIN_DIR:$PATH" \
+    "$SPAWN" "$id" "$PROJ_DIR" --mode no-mistakes --yolo off 2>&1
+}
+
+assert_correct_link() {
+  local lane_link="$WT_DIR/data/local/reviews" canonical
+  canonical=$(cd "$PROJ_DIR/data/local/reviews" && pwd -P)
+  [ -L "$lane_link" ] || fail "lane review path is not a symlink: $lane_link"
+  [ "$(cd "$lane_link" && pwd -P)" = "$canonical" ] \
+    || fail "lane review link does not resolve to canonical store"
+}
+
+test_clean_setup_and_idempotent_repeat() {
+  local rec out status id=doscleanz1 id2=dosrepeatz2
+  rec=$(make_case clean "$id")
+  read_case "$rec"
+  expose_contract
+
+  out=$(run_spawn "$id")
+  status=$?
+  expect_code 0 "$status" "clean Decision OS spawn should succeed"$'\n'"$out"
+  assert_correct_link
+  mkdir -p "$HOME_DIR/data/$id2"
+  printf 'brief for %s\n' "$id2" > "$HOME_DIR/data/$id2/brief.md"
+  out=$(run_spawn "$id2")
+  status=$?
+  expect_code 0 "$status" "repeated setup should remain idempotent"$'\n'"$out"
+  assert_correct_link
+  pass "Decision OS lane setup creates the canonical review link and repeats idempotently"
+}
+
+test_preexisting_correct_link_is_preserved() {
+  local rec out status id=dosexistingz3 before
+  rec=$(make_case existing "$id")
+  read_case "$rec"
+  expose_contract
+  mkdir -p "$WT_DIR/data/local"
+  ln -s "$PROJ_DIR/data/local/reviews" "$WT_DIR/data/local/reviews"
+  before=$(readlink "$WT_DIR/data/local/reviews")
+
+  out=$(run_spawn "$id")
+  status=$?
+  expect_code 0 "$status" "pre-linked Decision OS spawn should succeed"$'\n'"$out"
+  [ "$(readlink "$WT_DIR/data/local/reviews")" = "$before" ] \
+    || fail "setup rewrote the pre-existing correct link"
+  assert_correct_link
+  pass "Decision OS lane setup preserves a pre-existing correct link"
+}
+
+test_conflicting_evidence_directory_refuses_without_hiding_bytes() {
+  local rec out status id=dosconflictz4 evidence
+  rec=$(make_case conflict "$id")
+  read_case "$rec"
+  expose_contract
+  evidence="$WT_DIR/data/local/reviews/run-a/frozen.json"
+  mkdir -p "$(dirname "$evidence")"
+  printf 'unique evidence\n' > "$evidence"
+
+  out=$(run_spawn "$id")
+  status=$?
+  [ "$status" -ne 0 ] || fail "spawn should refuse a conflicting real review directory"
+  assert_contains "$out" "refusing" "conflict refusal should be explicit"
+  [ "$(cat "$evidence")" = "unique evidence" ] || fail "conflict refusal changed evidence bytes"
+  [ ! -L "$WT_DIR/data/local/reviews" ] || fail "conflict refusal hid evidence behind a symlink"
+  assert_absent "$HOME_DIR/state/$id.meta" "conflict refusal must happen before launch metadata"
+  pass "Decision OS lane setup refuses a conflicting evidence directory without hiding bytes"
+}
+
+test_missing_and_wrong_canonical_targets_refuse() {
+  local rec out status id=dosmissingz5 outside
+  rec=$(make_case missing "$id")
+  read_case "$rec"
+  mkdir -p "$PROJ_DIR/data/local"
+  ln -s .reviews "$PROJ_DIR/data/local/reviews"
+  out=$(run_spawn "$id")
+  status=$?
+  [ "$status" -ne 0 ] || fail "spawn should refuse a dangling canonical review target"
+  assert_contains "$out" "canonical" "missing-target refusal should name the canonical store"
+  assert_absent "$WT_DIR/data/local/reviews" "missing-target refusal should not create a lane link"
+
+  rm "$PROJ_DIR/data/local/reviews"
+  outside="$CASE_DIR/other-project/reviews"
+  mkdir -p "$outside"
+  fm_git_init_commit "$CASE_DIR/other-project/repo"
+  ln -s "$outside" "$PROJ_DIR/data/local/reviews"
+  out=$(run_spawn "$id")
+  status=$?
+  [ "$status" -ne 0 ] || fail "spawn should refuse a canonical target outside the project"
+  assert_contains "$out" "canonical" "wrong-project refusal should name the canonical store"
+  assert_absent "$WT_DIR/data/local/reviews" "wrong-project refusal should not create a lane link"
+  pass "Decision OS lane setup refuses missing and wrong-project canonical targets"
+}
+
+test_non_decision_os_project_is_unchanged() {
+  local rec out status id=ordinaryz6
+  rec=$(make_case ordinary "$id")
+  read_case "$rec"
+
+  out=$(run_spawn "$id")
+  status=$?
+  expect_code 0 "$status" "ordinary project spawn should retain existing behavior"$'\n'"$out"
+  assert_absent "$WT_DIR/data/local/reviews" "ordinary project unexpectedly received a review-store link"
+  pass "projects without the Decision OS review-store contract remain unchanged"
+}
+
+test_clean_setup_and_idempotent_repeat
+test_preexisting_correct_link_is_preserved
+test_conflicting_evidence_directory_refuses_without_hiding_bytes
+test_missing_and_wrong_canonical_targets_refuse
+test_non_decision_os_project_is_unchanged
+
+echo "# all fm-spawn Decision OS review-store tests passed"


### PR DESCRIPTION
## Intent

Implement Decision OS bead dos-3ndcm so every Firstmate-launched Decision OS Treehouse lane writes review evidence directly into the canonical shared data/local/reviews store. Use the canonical project path already owned by Firstmate lane allocation and bind the lane before worker launch; refuse ambiguous or wrong-project paths, missing or non-directory canonical destinations, and any conflicting real lane review directory that may contain evidence, without overwriting or hiding evidence. Preserve all behavior for projects that do not expose the Decision OS review-store symlink contract. Add public-interface regressions for clean setup, idempotent repeat, a pre-existing correct link, conflicting evidence, wrong or missing canonical target, and non-Decision-OS work. Provide the narrowest guarded one-time migration owned by Firstmate: inventory every pool copy, detect active or changing runs including rechecking activity before source retirement, copy first, verify exact path/type/byte completeness and SHA-256 manifests, refuse non-identical collisions, remove sources only after durable verification, and resume safely after interruption. Do not run the real migration during implementation or validation; report the exact guarded command and read-only preflight evidence for Firstmate to execute only after the code lands. Do not modify Decision OS project files, prune branches, broadly clean pool slots, or alter unrelated Firstmate behavior. Validate relevant backend and Treehouse behavior, pinned ShellCheck lint, documentation audiences, tests, and CI. Create a green pull request whose title contains dos-3ndcm. Delivery remains incomplete after merge: Firstmate separately owns executing the migration, verifying canonical gate visibility and reclaimability, appending the Closure-Receipt, closing dos-3ndcm, and landing that tracker close in the same shift.

## What Changed
- `bin/fm-spawn.sh` now binds every Decision OS Treehouse lane to the canonical shared `data/local/reviews` store before worker launch (symlink via the lane's canonical project path), refusing wrong-project or ambiguous paths, missing/non-directory canonical targets, and any conflicting real lane reviews directory that could hold evidence; projects without the Decision OS review-store symlink contract are untouched.
- Added `bin/fm-decision-os-review-migrate.sh`, a guarded one-time migration for existing pool copies: dry-run inventory by default, defers in-use or process-bearing slots (with an activity recheck before source retirement, including the empty/missing-reviews branches per the review pass), copy-first with exact path/type/byte and SHA-256 manifest verification, refuses non-identical collisions, removes sources only after durable verification, and resumes safely after interruption. The real migration was not run; it remains a separate guarded `--apply` step.
- Added regression suites `tests/fm-spawn-decision-os-reviews.test.sh` (5 cases) and `tests/fm-decision-os-review-migrate.test.sh` (8 cases), wired into `bin/fm-test-run.sh`, plus a `docs/scripts.md` entry for the migration script.

## Risk Assessment

✅ Low: The follow-up commit precisely implements the requested guard — active slots are deferred before any review-path mutation, link failures degrade to per-slot refusals instead of set -e aborts, and a new public-interface regression proves --apply leaves in-use slots untouched — with no unrelated behavior changes and all prior concerns either fixed or explicitly waived.

## Testing

Ran both new regression suites (13 tests, all passing) and a manual end-to-end demo driving the real fm-spawn and migration scripts against fixture Decision OS projects; the transcript shows lane evidence landing in the canonical shared store, fail-closed refusals that preserve evidence, unchanged behavior for non-contract projects, a verified mutation-free preflight, and a fixture-only guarded apply — the real migration was not executed, matching the intent's constraint.

<details>
<summary>Evidence: End-to-end CLI transcript: spawn binding, refusals, preflight, and fixture apply</summary>

```text

=== PART A: fm-spawn binds a Decision OS lane to the canonical review store ===
-- canonical project exposes the review-store symlink contract:
$ ls -l /tmp/dos-3ndcm-demo.WdrMrO/a/decision-os/data/local
total 0
lrwxrwxrwx 1 holu holu 8 Aug  7 12:28 reviews -> .reviews
(exit 0)
-- launching a Treehouse lane via the real fm-spawn.sh:
spawn exit: 0 (full log tail below)
warning: /tmp/dos-3ndcm-demo.WdrMrO/a/home/data/demoa1/brief.md records no delivery contract line (scaffolded before ship briefs recorded one); launching on the explicit --mode no-mistakes - confirm its definition of done matches
spawned demoa1 harness=codex kind=ship mode=no-mistakes yolo=off window=firstmate:fm-demoa1 worktree=/tmp/dos-3ndcm-demo.WdrMrO/a/lane
-- lane's data/local/reviews after spawn (bound before worker launch):
$ ls -l /tmp/dos-3ndcm-demo.WdrMrO/a/lane/data/local
total 0
lrwxrwxrwx 1 holu holu 59 Aug  7 12:28 reviews -> /tmp/dos-3ndcm-demo.WdrMrO/a/decision-os/data/local/reviews
(exit 0)
-- a worker writing evidence through the LANE path...
-- ...lands in the CANONICAL shared store (read via the project path):
$ ls -l /tmp/dos-3ndcm-demo.WdrMrO/a/decision-os/data/local/.reviews
total 8
-rw-rw-r-- 1 holu holu 31 Aug  7 12:28 lane-review.md
-rw-rw-r-- 1 holu holu 27 Aug  7 12:28 prior-review.md
(exit 0)
$ cat /tmp/dos-3ndcm-demo.WdrMrO/a/decision-os/data/local/.reviews/lane-review.md
evidence written from the lane
(exit 0)

=== PART B: conflicting real lane review directory refuses without hiding evidence ===
-- spawn against a lane that already has a real reviews dir with evidence:
spawn exit: 1 (refusal expected)
error: Decision OS lane review path already exists and could contain evidence: /tmp/dos-3ndcm-demo.WdrMrO/b/lane/data/local/reviews; refusing to overwrite or hide it
-- stranded evidence is untouched:
$ cat /tmp/dos-3ndcm-demo.WdrMrO/b/lane/data/local/reviews/stranded.md
stranded evidence must not vanish
(exit 0)

=== PART C: non-Decision-OS project (no symlink contract) is unchanged ===
spawn exit: 0
-- lane data/local after spawn (no reviews link created):
ls: cannot access '/tmp/dos-3ndcm-demo.WdrMrO/c/lane/data/local': No such file or directory
(no data/local at all — historical behavior preserved)

=== PART D: guarded migration — read-only preflight on a fixture pool ===
-- read-only preflight (the exact command Firstmate runs, minus --apply):
$ fm-decision-os-review-migrate.sh /tmp/dos-3ndcm-demo.WdrMrO/m/decision-os
INVENTORY slot=1 run=run-2026-08-01 entries=2 hash=75e86ae7d28e7d32762bb6ac8763af236197b980d1ed475223d5be87281666c5
WOULD-MIGRATE slot=1 run=run-2026-08-01
EMPTY slot=2 path=/tmp/dos-3ndcm-demo.WdrMrO/m/pool/2/decision-os/data/local/reviews
PREFLIGHT complete: no files copied, removed, or linked
(exit 0)
-- verified: preflight mutated nothing (pool content hash identical before/after)

=== PART E: guarded --apply on the same fixture (never the real pool) ===
$ fm-decision-os-review-migrate.sh --apply /tmp/dos-3ndcm-demo.WdrMrO/m/decision-os
INVENTORY slot=1 run=run-2026-08-01 entries=2 hash=75e86ae7d28e7d32762bb6ac8763af236197b980d1ed475223d5be87281666c5
COPIED slot=1 run=run-2026-08-01 hash=75e86ae7d28e7d32762bb6ac8763af236197b980d1ed475223d5be87281666c5
VERIFIED slot=1 run=run-2026-08-01 hash=75e86ae7d28e7d32762bb6ac8763af236197b980d1ed475223d5be87281666c5
REMOVED slot=1 run=run-2026-08-01 source=/tmp/dos-3ndcm-demo.WdrMrO/m/pool/1/decision-os/data/local/reviews/run-2026-08-01
LINKED slot=1 target=/tmp/dos-3ndcm-demo.WdrMrO/m/decision-os/data/local/reviews
EMPTY slot=2 path=/tmp/dos-3ndcm-demo.WdrMrO/m/pool/2/decision-os/data/local/reviews
DEFER active slot=2 path=/tmp/dos-3ndcm-demo.WdrMrO/m/pool/2/decision-os/data/local/reviews status=in-use processes=1
APPLY complete: active or changing runs, if any, remain deferred
(exit 0)
-- evidence now in the canonical store; drained slot re-linked; active slot 2 deferred:
$ ls -l /tmp/dos-3ndcm-demo.WdrMrO/m/decision-os/data/local/.reviews
total 4
drwxrwxr-x 2 holu holu 4096 Aug  7 12:28 run-2026-08-01
(exit 0)
$ cat /tmp/dos-3ndcm-demo.WdrMrO/m/decision-os/data/local/.reviews/run-2026-08-01/review.md
stranded pool evidence
(exit 0)
$ ls -l /tmp/dos-3ndcm-demo.WdrMrO/m/pool/1/decision-os/data/local
total 0
lrwxrwxrwx 1 holu holu 59 Aug  7 12:28 reviews -> /tmp/dos-3ndcm-demo.WdrMrO/m/decision-os/data/local/reviews
(exit 0)

=== demo complete ===
```
</details>
<details>
<summary>Evidence: Demo script that produced the transcript (fixture-only, real scripts)</summary>

```text
#!/usr/bin/env bash
# End-to-end demo of the dos-3ndcm canonical review-store change, run against
# fixture projects (never the real Decision OS checkout or real Treehouse pool).
set -u
ROOT=${1:?repo root}
DEMO=$(mktemp -d /tmp/dos-3ndcm-demo.XXXXXX)
trap 'rm -rf "$DEMO"' EXIT

say() { printf '\n=== %s ===\n' "$*"; }
run() { printf '$ %s\n' "$*"; "$@" 2>&1; printf '(exit %s)\n' "$?"; }

mk_fakebin() {
  local fb="$1"; mkdir -p "$fb"
  cat > "$fb/tmux" <<'SH'
#!/usr/bin/env bash
set -u
case "$*" in *"#{pane_current_path}"*) printf '%s\n' "${FM_FAKE_PANE_PATH:?}"; exit 0 ;; esac
case "${1:-}" in display-message) printf 'firstmate\n'; exit 0 ;; esac
exit 0
SH
  cat > "$fb/treehouse" <<'SH'
#!/usr/bin/env bash
set -u
if [ "${1:-}" = status ] && [ "${2:-}" = --json ]; then cat "${FM_MIGRATION_POOL_JSON:?}"; exit 0; fi
exit 0
SH
  cat > "$fb/sleep" <<'SH'
#!/usr/bin/env bash
exit 0
SH
  chmod +x "$fb"/tmux "$fb"/treehouse "$fb"/sleep
}

mk_home() {
  local home="$1" id="$2"
  mkdir -p "$home/data/$id" "$home/projects" "$home/state" "$home/config"
  printf 'codex\n' > "$home/config/crew-harness"
  printf 'brief for %s\n' "$id" > "$home/data/$id/brief.md"
  touch "$home/state/.last-watcher-beat"
}

mk_project() {  # <repo> <lane> <branch>
  local repo="$1" lane="$2" branch="$3"
  mkdir -p "$repo"
  git -C "$repo" init -q -b main
  git -C "$repo" -c user.email=demo@example.com -c user.name=demo commit -q --allow-empty -m init
  git -C "$repo" worktree add --quiet -b "$branch" "$lane"
}

spawn() {  # <home> <lane> <fakebin> <id> <project>
  FM_GATE_REFUSE_BYPASS=1 FM_ROOT_OVERRIDE='' FM_HOME="$1" \
    FM_STATE_OVERRIDE="$1/state" FM_DATA_OVERRIDE="$1/data" \
    FM_PROJECTS_OVERRIDE="$1/projects" FM_CONFIG_OVERRIDE="$1/config" \
    FM_SPAWN_NO_GUARD=1 TMUX="fake,1,0" FM_FAKE_PANE_PATH="$2" \
    PATH="$3:$PATH" \
    "$ROOT/bin/fm-spawn.sh" "$4" "$5" --mode no-mistakes --yolo off
}

FB="$DEMO/fakebin"; mk_fakebin "$FB"

say "PART A: fm-spawn binds a Decision OS lane to the canonical review store"
A="$DEMO/a"; mk_home "$A/home" demoa1
mk_project "$A/decision-os" "$A/lane" lane-a
mkdir -p "$A/decision-os/data/local/.reviews"
ln -s .reviews "$A/decision-os/data/local/reviews"
printf 'earlier canonical evidence\n' > "$A/decision-os/data/local/.reviews/prior-review.md"
echo "-- canonical project exposes the review-store symlink contract:"
run ls -l "$A/decision-os/data/local"
echo "-- launching a Treehouse lane via the real fm-spawn.sh:"
spawn "$A/home" "$A/lane" "$FB" demoa1 "$A/decision-os" >"$DEMO/spawn-a.log" 2>&1
echo "spawn exit: $? (full log tail below)"
tail -3 "$DEMO/spawn-a.log"
echo "-- lane's data/local/reviews after spawn (bound before worker launch):"
run ls -l "$A/lane/data/local"
echo "-- a worker writing evidence through the LANE path..."
printf 'evidence written from the lane\n' > "$A/lane/data/local/reviews/lane-review.md"
echo "-- ...lands in the CANONICAL shared store (read via the project path):"
run ls -l "$A/decision-os/data/local/.reviews"
run cat "$A/decision-os/data/local/.reviews/lane-review.md"

say "PART B: conflicting real lane review directory refuses without hiding evidence"
B="$DEMO/b"; mk_home "$B/home" demob2
mk_project "$B/decision-os" "$B/lane" lane-b
mkdir -p "$B/decision-os/data/local/.reviews"
ln -s .reviews "$B/decision-os/data/local/reviews"
mkdir -p "$B/lane/data/local/reviews"
printf 'stranded evidence must not vanish\n' > "$B/lane/data/local/reviews/stranded.md"
echo "-- spawn against a lane that already has a real reviews dir with evidence:"
spawn "$B/home" "$B/lane" "$FB" demob2 "$B/decision-os" >"$DEMO/spawn-b.log" 2>&1
echo "spawn exit: $? (refusal expected)"
grep -i 'error:' "$DEMO/spawn-b.log"
echo "-- stranded evidence is untouched:"
run cat "$B/lane/data/local/reviews/stranded.md"

say "PART C: non-Decision-OS project (no symlink contract) is unchanged"
C="$DEMO/c"; mk_home "$C/home" democ3
mk_project "$C/plainproj" "$C/lane" lane-c
spawn "$C/home" "$C/lane" "$FB" democ3 "$C/plainproj" >"$DEMO/spawn-c.log" 2>&1
echo "spawn exit: $?"
echo "-- lane data/local after spawn (no reviews link created):"
ls -la "$C/lane/data/local" 2>&1 || echo "(no data/local at all — historical behavior preserved)"

say "PART D: guarded migration — read-only preflight on a fixture pool"
M="$DEMO/m"
mk_project "$M/decision-os" "$M/pool/1/decision-os" slot-1
git -C "$M/decision-os" worktree add --quiet -b slot-2 "$M/pool/2/decision-os"
mkdir -p "$M/decision-os/data/local/.reviews"
ln -s .reviews "$M/decision-os/data/local/reviews"
mkdir -p "$M/pool/1/decision-os/data/local/reviews/run-2026-08-01"
printf 'stranded pool evidence\n' > "$M/pool/1/decision-os/data/local/reviews/run-2026-08-01/review.md"
POOL_JSON="$M/pool.json"
jq -n --arg p1 "$M/pool/1/decision-os" --arg p2 "$M/pool/2/decision-os" \
  '[{name:"1",path:$p1,status:"available",processes:[]},
    {name:"2",path:$p2,status:"in-use",processes:[{"pid":456,"name":"worker"}]}]' > "$POOL_JSON"
BEFORE=$(find "$M/pool" -type f | sort | xargs sha256sum | sha256sum)
echo "-- read-only preflight (the exact command Firstmate runs, minus --apply):"
printf '$ fm-decision-os-review-migrate.sh %s\n' "$M/decision-os"
FM_MIGRATION_POOL_JSON="$POOL_JSON" PATH="$FB:$PATH" \
  "$ROOT/bin/fm-decision-os-review-migrate.sh" "$M/decision-os" 2>&1
echo "(exit $?)"
AFTER=$(find "$M/pool" -type f | sort | xargs sha256sum | sha256sum)
if [ "$BEFORE" = "$AFTER" ]; then
  echo "-- verified: preflight mutated nothing (pool content hash identical before/after)"
else
  echo "-- FAILURE: preflight mutated pool contents"; exit 1
fi

say "PART E: guarded --apply on the same fixture (never the real pool)"
printf '$ fm-decision-os-review-migrate.sh --apply %s\n' "$M/decision-os"
FM_MIGRATION_POOL_JSON="$POOL_JSON" PATH="$FB:$PATH" \
  "$ROOT/bin/fm-decision-os-review-migrate.sh" --apply "$M/decision-os" 2>&1
echo "(exit $?)"
echo "-- evidence now in the canonical store; drained slot re-linked; active slot 2 deferred:"
run ls -l "$M/decision-os/data/local/.reviews"
run cat "$M/decision-os/data/local/.reviews/run-2026-08-01/review.md"
run ls -l "$M/pool/1/decision-os/data/local"

say "demo complete"
```
</details>
<details>
<summary>Evidence: Key transcript excerpt: lane write-through and guarded apply</summary>

```text
$ ls -l a/lane/data/local
reviews -> a/decision-os/data/local/reviews
$ cat a/decision-os/data/local/.reviews/lane-review.md
evidence written from the lane

(conflicting lane dir) error: Decision OS lane review path already exists and could contain evidence: b/lane/data/local/reviews; refusing to overwrite or hide it
$ cat b/lane/data/local/reviews/stranded.md
stranded evidence must not vanish

$ fm-decision-os-review-migrate.sh <project> # read-only preflight
INVENTORY slot=1 run=run-2026-08-01 entries=2 hash=75e86ae7...
WOULD-MIGRATE slot=1 run=run-2026-08-01
PREFLIGHT complete: no files copied, removed, or linked
-- verified: preflight mutated nothing (pool content hash identical before/after)

$ fm-decision-os-review-migrate.sh --apply <project> # fixture pool only
COPIED → VERIFIED → REMOVED → LINKED slot=1; DEFER active slot=2 status=in-use processes=1
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 3 issues found → auto-fixed ✅</summary>

- ⚠️ `bin/fm-decision-os-review-migrate.sh:245` - Under --apply, the reviews-path-missing branch (lines 243–250) and empty-reviews-dir branch (lines 266–274) execute mkdir/rmdir/ln -s before the slot activity check at line 278, so an in-use, process-bearing slot with a missing or empty reviews directory is mutated while its worker runs. This contradicts the script&#39;s own header contract (&#39;Apply defers every in-use or process-bearing slot&#39;), and because rmdir/ln -s are unguarded under set -eu, a racing worker that recreates or populates the directory between the check and the mutation aborts the entire migration mid-run. No evidence can be destroyed (only empty/absent directories are touched), but the deferral invariant and whole-run robustness are compromised. Fix: gate the LINKED action in both branches on the same status==available &amp;&amp; processes==0 condition (or a slot_still_available recheck), and guard the rmdir/ln failures as a per-slot REFUSE instead of a set -e abort.
- ℹ️ `bin/fm-decision-os-review-migrate.sh:195` - Successful migration leaves empty residue directories behind: the staging tree $PROJECT/data/local/.dos-3ndcm-review-migration/&lt;slot&gt;/&lt;run_key&gt;/ (stage entries are moved out but parents never removed, and STAGE_ROOT is never cleaned at exit) and per-slot $slot/data/local/.dos-3ndcm-review-migrated/&lt;run&gt;/ parents after rm -rf of the hash-keyed leaf. Harmless to correctness, but visible clutter during Firstmate&#39;s later canonical-visibility and reclaimability verification.
- ℹ️ `bin/fm-spawn.sh:1500` - bind_project_review_store creates the lane symlink data/local/reviews without adding it to git info/exclude, unlike other spawn-created worktree artifacts that use the exclude_path helper (defined later at line 1980). If the target project does not gitignore data/, the lane worktree gains untracked state that could trip teardown&#39;s dirty checks or leak into a worker commit. Likely moot because the Decision OS contract presumes data/local is local-only (a tracked symlink would resolve lane-locally and refuse every spawn), but excluding it would be cheap hardening.

🔧 Fix: guard empty-lane review linking behind slot activity check
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash tests/fm-spawn-decision-os-reviews.test.sh` — all 5 public-interface regressions pass (clean setup + idempotent repeat, pre-existing correct link, conflicting evidence refusal, missing/wrong canonical target refusal, non-Decision-OS unchanged)</code>
- <code>`bash tests/fm-decision-os-review-migrate.test.sh` — all 8 migration-guard regressions pass (dry-run inventory, active-lane deferral, activity recheck before retirement, copy/verify/remove/link idempotent apply, non-identical collision refusal, changing-source deferral, interrupted-copy resume, wrong-project/invalid-store refusal)</code>
- <code>Manual end-to-end demo (`e2e-demo.sh`) running the real `bin/fm-spawn.sh` and `bin/fm-decision-os-review-migrate.sh` against fixture git worktrees: lane review link created before launch, write-through of lane evidence into the canonical store, refusal transcript for a conflicting lane reviews directory with evidence left intact, non-Decision-OS project untouched, read-only preflight verified mutation-free via before/after content hashing, and a fixture-only guarded `--apply` showing INVENTORY→COPIED→VERIFIED→REMOVED→LINKED with the in-use slot deferred</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 127)

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
