### PR TITLE
fix: prevent fleet snapshot argv overflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -350,8 +350,8 @@ jobs:
           snapshot_output=$(/bin/bash tests/fm-fleet-snapshot-view.test.sh)
           printf '%s\n' "$snapshot_output"
           snapshot_count=$(printf '%s\n' "$snapshot_output" | grep -c '^ok - ')
-          [ "$snapshot_count" -eq 15 ] || {
-            echo "::error::expected 15 snapshot/fleet-view tests, got $snapshot_count"
+          [ "$snapshot_count" -eq 18 ] || {
+            echo "::error::expected 18 snapshot/fleet-view tests, got $snapshot_count"
             exit 1
           }
 

--- a/bin/fm-fleet-snapshot.sh
+++ b/bin/fm-fleet-snapshot.sh
@@ -177,6 +177,37 @@ esac
 
 command -v jq >/dev/null 2>&1 || { echo "fm-fleet-snapshot: jq not found" >&2; exit 1; }
 
+# Bind serialized JSON through stdin instead of argv. Each document is framed as
+# a JSON string first so empty, malformed, missing, or multi-value producer output
+# is rejected independently by fromjson rather than shifting later inputs.
+jq_with_json_inputs() {  # <count> <json>... [<jq-option>... <filter>]
+  local input_count=$1 i=0
+  local -a documents=()
+  shift
+  case "$input_count" in
+    ''|*[!0-9]*)
+      echo "fm-fleet-snapshot: internal JSON input count is invalid" >&2
+      return 2
+      ;;
+  esac
+  while [ "$i" -lt "$input_count" ]; do
+    if [ "$#" -eq 0 ]; then
+      echo "fm-fleet-snapshot: internal JSON input is missing" >&2
+      return 2
+    fi
+    documents[$i]=$1
+    shift
+    i=$((i + 1))
+  done
+  {
+    i=0
+    while [ "$i" -lt "$input_count" ]; do
+      printf '%s\0' "${documents[$i]}"
+      i=$((i + 1))
+    done
+  } | jq -Rsc 'split("\u0000")[:-1][]' | jq -n "$@"
+}
+
 bool_json() {
   if [ "$1" = 1 ]; then printf 'true'; else printf 'false'; fi
 }
@@ -528,7 +559,9 @@ task_json_lines() {
       home_json=$(jq -n '{path:null,present:false}')
     fi
 
-    jq -n \
+    jq_with_json_inputs 7 \
+      "$current_json" "$meta_json" "$status_json" "$report_json" \
+      "$worktree_json" "$home_json" "$open_decisions_json" \
       --arg id "$id" \
       --arg kind "$kind" \
       --arg harness "$harness" \
@@ -547,18 +580,18 @@ task_json_lines() {
       --arg agent_alive "$agent_alive" \
       --arg observed_at "$SNAPSHOT_NOW" \
       --arg last_event_raw "$last_event_raw" \
-      --argjson current_state "$current_json" \
-      --argjson meta_path "$meta_json" \
-      --argjson status_log "$status_json" \
-      --argjson report "$report_json" \
-      --argjson worktree_path "$worktree_json" \
-      --argjson home_path "$home_json" \
       --argjson endpoint_exists "$endpoint_exists" \
-      --argjson open_decisions "$open_decisions_json" \
       --argjson pending_decision "$(bool_json "$pending_decision")" \
       --argjson blocked_event "$(bool_json "$blocked_event")" \
       --argjson report_present "$(bool_json "$report_present")" \
-      '{
+      '(input | fromjson) as $current_state
+      | (input | fromjson) as $meta_path
+      | (input | fromjson) as $status_log
+      | (input | fromjson) as $report
+      | (input | fromjson) as $worktree_path
+      | (input | fromjson) as $home_path
+      | (input | fromjson) as $open_decisions
+      | {
         id:$id,
         kind:$kind,
         harness:($harness // ""),
@@ -608,10 +641,10 @@ task_json_lines() {
 # Meta inventory remains the sole source of live workers; this object only
 # discloses backlog↔task inconsistency for renderers (Bearings omitted/gates).
 main_inventory_json() {  # <backlog-json> <tasks-json>
-  jq -n \
-    --argjson backlog "$1" \
-    --argjson tasks "$2" '
-    ([ $backlog.records[]?
+  jq_with_json_inputs 2 "$1" "$2" '
+    (input | fromjson) as $backlog
+    | (input | fromjson) as $tasks
+    | ([ $backlog.records[]?
        | select((.state == "in_flight" or .state == "queued") and (.structured | not)) ]) as $unstructured_current
     | ([ $backlog.records[]?
          | select(.state == "in_flight" and .structured and .requires_child_metadata) ]) as $owned_in_flight
@@ -636,16 +669,16 @@ main_inventory_json() {  # <backlog-json> <tasks-json>
 # This mode never reads parent events or terminal text and never aggregates
 # nested secondmates.
 secondmate_home_summary_json() {  # <backlog-json> <tasks-json>
-  jq -n \
+  jq_with_json_inputs 2 "$1" "$2" \
     --arg generated "$SNAPSHOT_NOW" \
     --arg home "$FM_HOME" \
     --argjson child_n "$FM_SNAPSHOT_SECONDMATE_CHILDREN" \
     --argjson queued_n "$FM_SNAPSHOT_SECONDMATE_QUEUED" \
     --argjson decisions_n "$FM_SNAPSHOT_SECONDMATE_DECISIONS" \
-    --argjson landed_n "$FM_SNAPSHOT_SECONDMATE_LANDED_PER_HOME" \
-    --argjson backlog "$1" \
-    --argjson tasks "$2" '
-    def trunc($n):
+    --argjson landed_n "$FM_SNAPSHOT_SECONDMATE_LANDED_PER_HOME" '
+    (input | fromjson) as $backlog
+    | (input | fromjson) as $tasks
+    | def trunc($n):
       tostring | gsub("\\s+"; " ")
       | if length > $n then .[:$n] + "…" else . end;
     ([ $backlog.records[]?
@@ -1051,8 +1084,11 @@ terminal_evidence_json() {  # <parent-task-json> <event-note> <evidence-contradi
 }
 
 parent_evidence_reconciliation_json() {  # <summary-json> <activities-json> <decisions-json>
-  jq -n --argjson summary "$1" --argjson activities "$2" --argjson decisions "$3" '
-    def keyed: . != null and . != "" and . != "default";
+  jq_with_json_inputs 3 "$1" "$2" "$3" '
+    (input | fromjson) as $summary
+    | (input | fromjson) as $activities
+    | (input | fromjson) as $decisions
+    | def keyed: . != null and . != "" and . != "default";
     def result($e; $matches; $complete; $surface):
       $e + {
         verdict:(if ($e.key | keyed | not) then "inconclusive"
@@ -1116,8 +1152,10 @@ secondmate_current_json() {  # <parent-tasks-json>
   local activity_scan activities decisions reconciliation provenance freshness reason summary summary_rc summary_bytes summary_valid summary_reason summary_invalidity state current_reason terminal terminal_contradiction contradiction
   local records='[]' seen_homes=''
   registry=$(registry_secondmates_json) || return 1
-  union=$(jq -n --argjson registry "$registry" --argjson tasks "$tasks" '
-    ($registry.records // []) as $registered
+  union=$(jq_with_json_inputs 2 "$registry" "$tasks" '
+    (input | fromjson) as $registry
+    | (input | fromjson) as $tasks
+    | ($registry.records // []) as $registered
     | (($registered | map(.id)) // []) as $registered_ids
     | ([ $registered[] as $r
          | $r + {parent_task:([$tasks[] | select(.id == $r.id)][0] // null)} ]
@@ -1255,13 +1293,18 @@ secondmate_current_json() {  # <parent-tasks-json>
           '{provenance:"parent-direct-report-terminal",trust:"untrusted-supplement",captured:false,observed_at:$observed,freshness:"not-collected",reason:"no useful contradiction check",lines:0,bytes:0,event_note_seen:false,contradiction:false}')
       fi
       if printf '%s' "$terminal" | jq -e '.contradiction == true' >/dev/null; then contradiction=true; fi
-      record=$(jq -n \
+      record=$(jq_with_json_inputs 6 \
+        "$summary" "$decisions" "$activities" "$activity_scan" "$reconciliation" "$terminal" \
         --arg id "$id" --arg home "$home" --arg host "$host" --argjson remote "$remote" --arg state "$state" --arg current_reason "$current_reason" --arg observed "$SNAPSHOT_NOW" \
-        --argjson registered "$registered" --argjson summary "$summary" --argjson summary_valid "$summary_valid" --argjson decisions "$decisions" \
-        --argjson activities "$activities" --argjson activity_scan "$activity_scan" \
-        --argjson reconciliation "$reconciliation" --argjson terminal "$terminal" --argjson contradiction "$contradiction" \
+        --argjson registered "$registered" --argjson summary_valid "$summary_valid" --argjson contradiction "$contradiction" \
         --arg event_raw "$event_raw" --arg event_note "$event_note" --argjson event_age "$event_age" '
-        {id:$id,home:$home,host:($host | if . == "" then null else . end),remote:$remote,registered:$registered,
+        (input | fromjson) as $summary
+        | (input | fromjson) as $decisions
+        | (input | fromjson) as $activities
+        | (input | fromjson) as $activity_scan
+        | (input | fromjson) as $reconciliation
+        | (input | fromjson) as $terminal
+        | {id:$id,home:$home,host:($host | if . == "" then null else . end),remote:$remote,registered:$registered,
          current:{state:$state,reason:($current_reason | if . == "" then null else . end)},invalidity:$summary.invalidity,
          provenance:{selected:"structured-home",structured_home:$home,summary_valid:$summary_valid,
            trust:(if $summary_valid then "complete" else "partial-structured" end),parent_event_role:"historical-only"},
@@ -1285,12 +1328,15 @@ secondmate_current_json() {  # <parent-tasks-json>
         terminal=$(jq -n --arg observed "$SNAPSHOT_NOW" \
           '{provenance:"parent-direct-report-terminal",trust:"untrusted-supplement",captured:false,observed_at:$observed,freshness:"not-collected",reason:"no parent event to compare",lines:0,bytes:0,event_note_seen:false,contradiction:false}')
       fi
-      record=$(jq -n \
+      record=$(jq_with_json_inputs 4 "$activities" "$activity_scan" "$decisions" "$terminal" \
         --arg id "$id" --arg home "$home" --arg host "$host" --argjson remote "$remote" --arg reason "$reason" --arg observed "$SNAPSHOT_NOW" \
         --arg provenance "$provenance" --arg freshness "$freshness" --arg event_raw "$event_raw" --arg event_note "$event_note" \
-        --argjson registered "$registered" --argjson event_age "$event_age" --argjson activities "$activities" --argjson activity_scan "$activity_scan" \
-        --argjson decisions "$decisions" --argjson terminal "$terminal" '
-        {id:$id,home:($home | if . == "" then null else . end),host:($host | if . == "" then null else . end),remote:$remote,registered:$registered,
+        --argjson registered "$registered" --argjson event_age "$event_age" '
+        (input | fromjson) as $activities
+        | (input | fromjson) as $activity_scan
+        | (input | fromjson) as $decisions
+        | (input | fromjson) as $terminal
+        | {id:$id,home:($home | if . == "" then null else . end),host:($host | if . == "" then null else . end),remote:$remote,registered:$registered,
          current:{state:"unknown",reason:$reason},invalidity:null,
          provenance:{selected:$provenance,structured_home:($home | if . == "" then null else . end),parent_event_role:"fallback-only-not-current"},
          freshness:{status:$freshness,observed_at:$observed,age_seconds:$event_age},
@@ -1298,23 +1344,27 @@ secondmate_current_json() {  # <parent-tasks-json>
          parent_event:{raw:$event_raw,note:$event_note,age_seconds:$event_age,open_activities:$activities,open_decisions:$decisions,activity_scan:$activity_scan},
          terminal_evidence:$terminal,contradiction:false}')
     fi
-    records=$(jq -n --argjson records "$records" --argjson record "$record" '$records + [$record]')
+    records=$(jq_with_json_inputs 2 "$records" "$record" '
+      (input | fromjson) as $records
+      | (input | fromjson) as $record
+      | $records + [$record]')
   done <<EOF
 $rows
 EOF
-  jq -n \
-    --argjson registry "$(printf '%s' "$union" | jq '.registry')" \
-    --argjson records "$records" \
+  jq_with_json_inputs 2 "$(printf '%s' "$union" | jq '.registry')" "$records" \
     --argjson total_registered "$total_registered" \
     --argjson total "$total" \
     --argjson shown "$shown" \
-    --argjson truncated "$truncated" \
-    '{registry:$registry,records:$records,total_registered:$total_registered,total:$total,shown:$shown,truncated:$truncated}'
+    --argjson truncated "$truncated" '
+    (input | fromjson) as $registry
+    | (input | fromjson) as $records
+    | {registry:$registry,records:$records,total_registered:$total_registered,total:$total,shown:$shown,truncated:$truncated}'
 }
 
 secondmate_landed_from_current_json() {  # <secondmate-current-json>
-  jq -n --argjson current "$1" '
-    {records:[ $current.records[]
+  jq_with_json_inputs 1 "$1" '
+    (input | fromjson) as $current
+    | {records:[ $current.records[]
       | select(.provenance.selected == "structured-home") as $mate
       | $mate.landed[]
       | . + {home:$mate.home,home_id:$mate.id}],
@@ -1362,7 +1412,9 @@ SECONDMATE_CURRENT_JSON=$(secondmate_current_json "$TASKS_JSON") \
 SECONDMATE_LANDED_JSON=$(secondmate_landed_from_current_json "$SECONDMATE_CURRENT_JSON") \
   || { echo "fm-fleet-snapshot: secondmate landed projection failed" >&2; exit 1; }
 
-jq -n \
+jq_with_json_inputs 6 \
+  "$BACKLOG_JSON" "$TASKS_JSON" "$MAIN_INVENTORY_JSON" \
+  "$SCOUT_REPORTS_JSON" "$SECONDMATE_CURRENT_JSON" "$SECONDMATE_LANDED_JSON" \
   --arg generated "$SNAPSHOT_NOW" \
   --arg fm_home "$FM_HOME" \
   --arg fm_root "$FM_ROOT" \
@@ -1370,13 +1422,13 @@ jq -n \
   --arg data "$DATA" \
   --arg config "$CONFIG" \
   --arg projects "$PROJECTS" \
-  --argjson backlog "$BACKLOG_JSON" \
-  --argjson tasks "$TASKS_JSON" \
-  --argjson main_inventory "$MAIN_INVENTORY_JSON" \
-  --argjson scout_reports "$SCOUT_REPORTS_JSON" \
-  --argjson secondmate_current "$SECONDMATE_CURRENT_JSON" \
-  --argjson secondmate_landed "$SECONDMATE_LANDED_JSON" \
-  'def backlog_by_id($id): ($backlog.records[]? | select(.structured == true and .id == $id) | .) // null;
+  '(input | fromjson) as $backlog
+   | (input | fromjson) as $tasks
+   | (input | fromjson) as $main_inventory
+   | (input | fromjson) as $scout_reports
+   | (input | fromjson) as $secondmate_current
+   | (input | fromjson) as $secondmate_landed
+   | def backlog_by_id($id): ($backlog.records[]? | select(.structured == true and .id == $id) | .) // null;
    def task_by_id($id): ($tasks[]? | select(.id == $id) | .) // null;
    def report_kind($id): (task_by_id($id).kind // backlog_by_id($id).kind // "scout");
    {

--- a/bin/fm-fleet-snapshot.sh
+++ b/bin/fm-fleet-snapshot.sh
@@ -195,7 +195,7 @@ jq_with_json_inputs() {  # <count> <json>... [<jq-option>... <filter>]
       echo "fm-fleet-snapshot: internal JSON input is missing" >&2
       return 2
     fi
-    documents[$i]=$1
+    documents[i]=$1
     shift
     i=$((i + 1))
   done
@@ -559,6 +559,7 @@ task_json_lines() {
       home_json=$(jq -n '{path:null,present:false}')
     fi
 
+    # shellcheck disable=SC2016 # Dollar expressions belong to jq, not the shell.
     jq_with_json_inputs 7 \
       "$current_json" "$meta_json" "$status_json" "$report_json" \
       "$worktree_json" "$home_json" "$open_decisions_json" \
@@ -641,6 +642,7 @@ task_json_lines() {
 # Meta inventory remains the sole source of live workers; this object only
 # discloses backlog↔task inconsistency for renderers (Bearings omitted/gates).
 main_inventory_json() {  # <backlog-json> <tasks-json>
+  # shellcheck disable=SC2016 # Dollar expressions belong to jq, not the shell.
   jq_with_json_inputs 2 "$1" "$2" '
     (input | fromjson) as $backlog
     | (input | fromjson) as $tasks
@@ -669,6 +671,7 @@ main_inventory_json() {  # <backlog-json> <tasks-json>
 # This mode never reads parent events or terminal text and never aggregates
 # nested secondmates.
 secondmate_home_summary_json() {  # <backlog-json> <tasks-json>
+  # shellcheck disable=SC2016 # Dollar expressions belong to jq, not the shell.
   jq_with_json_inputs 2 "$1" "$2" \
     --arg generated "$SNAPSHOT_NOW" \
     --arg home "$FM_HOME" \
@@ -1084,6 +1087,7 @@ terminal_evidence_json() {  # <parent-task-json> <event-note> <evidence-contradi
 }
 
 parent_evidence_reconciliation_json() {  # <summary-json> <activities-json> <decisions-json>
+  # shellcheck disable=SC2016 # Dollar expressions belong to jq, not the shell.
   jq_with_json_inputs 3 "$1" "$2" "$3" '
     (input | fromjson) as $summary
     | (input | fromjson) as $activities
@@ -1152,6 +1156,7 @@ secondmate_current_json() {  # <parent-tasks-json>
   local activity_scan activities decisions reconciliation provenance freshness reason summary summary_rc summary_bytes summary_valid summary_reason summary_invalidity state current_reason terminal terminal_contradiction contradiction
   local records='[]' seen_homes=''
   registry=$(registry_secondmates_json) || return 1
+  # shellcheck disable=SC2016 # Dollar expressions belong to jq, not the shell.
   union=$(jq_with_json_inputs 2 "$registry" "$tasks" '
     (input | fromjson) as $registry
     | (input | fromjson) as $tasks
@@ -1293,6 +1298,7 @@ secondmate_current_json() {  # <parent-tasks-json>
           '{provenance:"parent-direct-report-terminal",trust:"untrusted-supplement",captured:false,observed_at:$observed,freshness:"not-collected",reason:"no useful contradiction check",lines:0,bytes:0,event_note_seen:false,contradiction:false}')
       fi
       if printf '%s' "$terminal" | jq -e '.contradiction == true' >/dev/null; then contradiction=true; fi
+      # shellcheck disable=SC2016 # Dollar expressions belong to jq, not the shell.
       record=$(jq_with_json_inputs 6 \
         "$summary" "$decisions" "$activities" "$activity_scan" "$reconciliation" "$terminal" \
         --arg id "$id" --arg home "$home" --arg host "$host" --argjson remote "$remote" --arg state "$state" --arg current_reason "$current_reason" --arg observed "$SNAPSHOT_NOW" \
@@ -1328,6 +1334,7 @@ secondmate_current_json() {  # <parent-tasks-json>
         terminal=$(jq -n --arg observed "$SNAPSHOT_NOW" \
           '{provenance:"parent-direct-report-terminal",trust:"untrusted-supplement",captured:false,observed_at:$observed,freshness:"not-collected",reason:"no parent event to compare",lines:0,bytes:0,event_note_seen:false,contradiction:false}')
       fi
+      # shellcheck disable=SC2016 # Dollar expressions belong to jq, not the shell.
       record=$(jq_with_json_inputs 4 "$activities" "$activity_scan" "$decisions" "$terminal" \
         --arg id "$id" --arg home "$home" --arg host "$host" --argjson remote "$remote" --arg reason "$reason" --arg observed "$SNAPSHOT_NOW" \
         --arg provenance "$provenance" --arg freshness "$freshness" --arg event_raw "$event_raw" --arg event_note "$event_note" \
@@ -1344,6 +1351,7 @@ secondmate_current_json() {  # <parent-tasks-json>
          parent_event:{raw:$event_raw,note:$event_note,age_seconds:$event_age,open_activities:$activities,open_decisions:$decisions,activity_scan:$activity_scan},
          terminal_evidence:$terminal,contradiction:false}')
     fi
+    # shellcheck disable=SC2016 # Dollar expressions belong to jq, not the shell.
     records=$(jq_with_json_inputs 2 "$records" "$record" '
       (input | fromjson) as $records
       | (input | fromjson) as $record
@@ -1351,6 +1359,7 @@ secondmate_current_json() {  # <parent-tasks-json>
   done <<EOF
 $rows
 EOF
+  # shellcheck disable=SC2016 # Dollar expressions belong to jq, not the shell.
   jq_with_json_inputs 2 "$(printf '%s' "$union" | jq '.registry')" "$records" \
     --argjson total_registered "$total_registered" \
     --argjson total "$total" \
@@ -1362,6 +1371,7 @@ EOF
 }
 
 secondmate_landed_from_current_json() {  # <secondmate-current-json>
+  # shellcheck disable=SC2016 # Dollar expressions belong to jq, not the shell.
   jq_with_json_inputs 1 "$1" '
     (input | fromjson) as $current
     | {records:[ $current.records[]
@@ -1412,6 +1422,7 @@ SECONDMATE_CURRENT_JSON=$(secondmate_current_json "$TASKS_JSON") \
 SECONDMATE_LANDED_JSON=$(secondmate_landed_from_current_json "$SECONDMATE_CURRENT_JSON") \
   || { echo "fm-fleet-snapshot: secondmate landed projection failed" >&2; exit 1; }
 
+# shellcheck disable=SC2016 # Dollar expressions belong to jq, not the shell.
 jq_with_json_inputs 6 \
   "$BACKLOG_JSON" "$TASKS_JSON" "$MAIN_INVENTORY_JSON" \
   "$SCOUT_REPORTS_JSON" "$SECONDMATE_CURRENT_JSON" "$SECONDMATE_LANDED_JSON" \

--- a/tests/fm-fleet-snapshot-view.test.sh
+++ b/tests/fm-fleet-snapshot-view.test.sh
@@ -7,10 +7,12 @@ set -u
 . "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
 
 SNAPSHOT="$ROOT/bin/fm-fleet-snapshot.sh"
+BEARINGS="$ROOT/bin/fm-bearings-snapshot.sh"
 VIEW="$ROOT/bin/fm-fleet-view.sh"
 TMP_ROOT=$(fm_test_tmproot fm-fleet-snapshot)
 
 command -v jq >/dev/null 2>&1 || { echo "skip: jq not found"; exit 0; }
+REAL_JQ=$(command -v jq)
 
 make_fakebin() {  # <dir>
   local fb
@@ -54,6 +56,29 @@ exit 0
 SH
   chmod +x "$fb/no-mistakes" "$fb/tmux"
   printf '%s\n' "$fb"
+}
+
+install_producer_fault_jq() {  # <fakebin>
+  cat > "$1/jq" <<'SH'
+#!/usr/bin/env bash
+set -u
+mode=${FM_TEST_PRODUCER_MODE:-}
+if [ "${1:-}" = -Rn ]; then
+  case "$mode" in
+    malformed-backlog) printf '{malformed'; exit 0 ;;
+    extra-values-backlog) printf '[] []'; exit 0 ;;
+    failed-backlog) exit 47 ;;
+  esac
+fi
+if [ "${1:-}" = -s ] && [ "${2:-}" = 'sort_by(.id)' ]; then
+  case "$mode" in
+    malformed-tasks) printf '{malformed'; exit 0 ;;
+    failed-tasks) exit 48 ;;
+  esac
+fi
+exec "${FM_TEST_REAL_JQ:?}" "$@"
+SH
+  chmod +x "$1/jq"
 }
 
 make_home() {  # <name>
@@ -133,7 +158,7 @@ EOF
 }
 
 test_empty_fleet_json() {
-  local home out view
+  local home out summary view
   home=$(make_home empty)
   out=$(FM_HOME="$home" "$SNAPSHOT" --json)
   printf '%s' "$out" | jq -e '
@@ -146,9 +171,206 @@ test_empty_fleet_json() {
       and .main_inventory.unstructured_current_count == 0
   ' >/dev/null \
     || fail "empty snapshot schema or absence markers wrong: $out"
+  summary=$(FM_HOME="$home" "$SNAPSHOT" --secondmate-home-summary)
+  printf '%s' "$summary" | jq -e '
+    .schema == "fm-secondmate-home-summary.v1"
+      and .valid == false
+      and .invalidity.kind == "missing_backlog"
+      and .active_children == []
+      and .decisions_open == []
+      and .holds == []
+      and .queued == []
+      and .landed == []
+      and .endpoints == []
+  ' >/dev/null || fail "empty secondmate summary arrays or absence markers wrong: $summary"
   view=$(FM_HOME="$home" "$VIEW")
   assert_contains "$view" "No live task metadata found." "empty fleet view should say no live metadata"
-  pass "empty fleet snapshot and view use explicit absence markers"
+  pass "empty fleet snapshot, summary, and view use explicit absence markers"
+}
+
+# Small canonical inputs prove stdin binding preserves schema, ordering, and nulls
+# before the oversized case exercises the same public interfaces.
+test_json_transport_small_semantic_equivalence() {
+  local home snapshot summary
+  home=$(make_home json-transport-small)
+  cat > "$home/data/backlog.md" <<'EOF'
+## In flight
+
+## Queued
+
+## Done
+- [x] alpha - Alpha release (repo: firstmate) (kind: ship) (done 2026-01-01)
+- [x] beta - Beta release (repo: firstmate) (kind: ship) (done 2026-01-01)
+EOF
+  snapshot="$home/snapshot.json"
+  summary="$home/summary.json"
+  FM_SNAPSHOT_NOW=2026-01-02T00:00:00Z FM_HOME="$home" "$SNAPSHOT" --json > "$snapshot" \
+    || fail "small canonical snapshot failed"
+  FM_SNAPSHOT_NOW=2026-01-02T00:00:00Z FM_HOME="$home" \
+    FM_SNAPSHOT_SECONDMATE_LANDED_PER_HOME=0 \
+    "$SNAPSHOT" --secondmate-home-summary > "$summary" \
+    || fail "small canonical secondmate summary failed"
+  jq -s -e --arg home "$home" '
+    .[0] as $snapshot | .[1] as $summary
+    | $snapshot.schema == "fm-fleet-snapshot.v1"
+      and $snapshot.generated == "2026-01-02T00:00:00Z"
+      and $snapshot.fm_home == $home
+      and $snapshot.tasks == []
+      and [$snapshot.backlog.records[].id] == ["alpha", "beta"]
+      and $snapshot.main_inventory == {
+        valid:true,
+        reason:null,
+        orphan_in_flight:[],
+        unstructured_current_count:0
+      }
+      and $summary.schema == "fm-secondmate-home-summary.v1"
+      and $summary.generated == $snapshot.generated
+      and $summary.home == $snapshot.fm_home
+      and $summary.valid == true
+      and $summary.landed == [
+        {id:"beta",title:"Beta release",pr_url:null,report_path:null,local_note:null,
+         completion:{verb:"done",date:"2026-01-01"}},
+        {id:"alpha",title:"Alpha release",pr_url:null,report_path:null,local_note:null,
+         completion:{verb:"done",date:"2026-01-01"}}
+      ]
+      and $summary.counts == {
+        active_children:0,
+        decisions_open:0,
+        holds:0,
+        queued:0,
+        landed:2,
+        endpoints:0
+      }
+  ' "$snapshot" "$summary" >/dev/null \
+    || fail "small snapshot and secondmate summary changed canonical semantics"
+  pass "small snapshot and secondmate summary preserve canonical JSON semantics"
+}
+
+# The fixture crosses the OS argv ceiling, proves a shell variable can hold the
+# serialized data, demonstrates that the former jq argv transport cannot execute,
+# and then requires every operator-facing read-only interface to succeed.
+test_oversized_json_transport_avoids_argv_limit() {
+  local home fakebin arg_max title row_bytes rows input_bytes serialized serialized_bytes
+  local legacy_rc snapshot summary bearings bearings_bytes
+  home=$(make_home json-transport-oversized)
+  fakebin=$(make_fakebin "$home")
+  arg_max=$(getconf ARG_MAX 2>/dev/null || printf '2097152')
+  title=$(printf '%0800d' 0 | tr 0 x)
+  row_bytes=$(printf -- '- [x] item-00001 - %s (repo: firstmate) (kind: ship) (done 2026-01-01)\n' "$title" \
+    | LC_ALL=C wc -c | tr -d ' ')
+  rows=$(((arg_max + 131072) / row_bytes + 2))
+  awk -v rows="$rows" -v title="$title" 'BEGIN {
+    print "## In flight\n\n## Queued\n\n## Done"
+    for (i = 1; i <= rows; i++)
+      printf "- [x] item-%05d - %s (repo: firstmate) (kind: ship) (done 2026-01-01)\n", i, title
+  }' > "$home/data/backlog.md"
+  input_bytes=$(LC_ALL=C wc -c < "$home/data/backlog.md" | tr -d ' ')
+  [ "$input_bytes" -gt "$arg_max" ] \
+    || fail "oversized backlog fixture did not exceed ARG_MAX: $input_bytes <= $arg_max"
+
+  serialized=$(jq -Rn '[inputs]' < "$home/data/backlog.md") \
+    || fail "oversized shell-expansion control could not serialize its input"
+  serialized_bytes=$(printf '%s' "$serialized" | LC_ALL=C wc -c | tr -d ' ')
+  [ "$serialized_bytes" -gt "$arg_max" ] \
+    || fail "serialized shell variable did not exceed ARG_MAX: $serialized_bytes <= $arg_max"
+  printf '%s' "$serialized" | jq -e --argjson rows "$rows" 'length == $rows + 5' >/dev/null \
+    || fail "oversized shell variable was not valid JSON before jq invocation"
+  set +e
+  jq -n --argjson payload "$serialized" '$payload | length' \
+    > "$home/legacy-argv.out" 2> "$home/legacy-argv.err"
+  legacy_rc=$?
+  set -e
+  [ "$legacy_rc" -ne 0 ] || fail "legacy jq argv control unexpectedly accepted an over-ARG_MAX document"
+  grep -qi 'argument list too long' "$home/legacy-argv.err" \
+    || fail "legacy jq argv control did not prove the expected exec failure"
+  serialized=
+
+  snapshot="$home/snapshot.json"
+  summary="$home/summary.json"
+  bearings="$home/bearings.json"
+  PATH="$fakebin:$PATH" FM_SNAPSHOT_NOW=2026-01-02T00:00:00Z FM_HOME="$home" \
+    "$SNAPSHOT" --json > "$snapshot" 2> "$home/snapshot.err" \
+    || fail "oversized public fleet snapshot failed: $(tail -n 2 "$home/snapshot.err")"
+  PATH="$fakebin:$PATH" FM_SNAPSHOT_NOW=2026-01-02T00:00:00Z FM_HOME="$home" \
+    FM_SNAPSHOT_SECONDMATE_LANDED_PER_HOME=0 \
+    "$SNAPSHOT" --secondmate-home-summary > "$summary" 2> "$home/summary.err" \
+    || fail "oversized public secondmate summary failed: $(tail -n 2 "$home/summary.err")"
+  PATH="$fakebin:$PATH" FM_BEARINGS_NOW=2026-01-02T00:00:00Z FM_HOME="$home" \
+    "$BEARINGS" --json > "$bearings" 2> "$home/bearings.err" \
+    || fail "oversized public bearings snapshot failed: $(tail -n 2 "$home/bearings.err")"
+  if grep -qi 'argument list too long' "$home/snapshot.err" "$home/summary.err" "$home/bearings.err"; then
+    fail "an oversized public snapshot path still exposed an argv failure"
+  fi
+  bearings_bytes=$(LC_ALL=C wc -c < "$bearings" | tr -d ' ')
+  [ "$bearings_bytes" -lt 65536 ] \
+    || fail "oversized fleet produced an unbounded bearings summary: $bearings_bytes bytes"
+  jq -s -e --argjson rows "$rows" '
+    def trunc($n):
+      tostring | gsub("\\s+"; " ")
+      | if length > $n then .[:$n] + "…" else . end;
+    .[0] as $snapshot | .[1] as $summary | .[2] as $bearings
+    | ([ $snapshot.backlog.records[]
+         | select(.state == "done" and .structured and .kind != "captain")
+         | {id:(.id | trunc(120)),title:(.title | trunc(120)),
+            pr_url:((.pr_url // null) | if . == null then null else trunc(500) end),
+            report_path:((.report_path // null) | if . == null then null else trunc(500) end),
+            local_note:((.local_note // null) | if . == null then null else trunc(120) end),
+            completion} ]
+       | sort_by([(.completion.date // ""), .id]) | reverse) as $expected_landed
+    | $snapshot.schema == "fm-fleet-snapshot.v1"
+      and ($snapshot.backlog.records | length) == $rows
+      and $snapshot.tasks == []
+      and $snapshot.main_inventory == {
+        valid:true,
+        reason:null,
+        orphan_in_flight:[],
+        unstructured_current_count:0
+      }
+      and $summary.schema == "fm-secondmate-home-summary.v1"
+      and $summary.valid == true
+      and $summary.counts.landed == $rows
+      and $summary.landed == $expected_landed
+      and $summary.active_children == []
+      and $summary.endpoints == []
+      and $bearings.schema == "fm-bearings.v1"
+      and ($bearings.landed | length) == 6
+      and ($bearings.omitted | any(.surface | test("landed per-home capped at 6")))
+  ' "$snapshot" "$summary" "$bearings" >/dev/null \
+    || fail "oversized snapshot paths changed records, ordering, nulls, or bounds"
+  pass "oversized snapshot, secondmate summary, and bearings avoid argv while preserving records"
+}
+
+# Fault injection stays at the executable boundary and proves malformed, extra,
+# and failed backlog/task producers retain the public failure diagnostics.
+test_json_transport_rejects_malformed_and_failed_producers() {
+  local home fakebin mode interface expected rc err
+  home=$(make_home json-transport-faults)
+  printf '## Done\n- [x] one - One (repo: firstmate) (kind: ship) (done 2026-01-01)\n' \
+    > "$home/data/backlog.md"
+  fakebin=$(make_fakebin "$home")
+  install_producer_fault_jq "$fakebin"
+  while IFS='|' read -r mode interface expected; do
+    set +e
+    PATH="$fakebin:$PATH" FM_HOME="$home" FM_TEST_REAL_JQ="$REAL_JQ" \
+      FM_TEST_PRODUCER_MODE="$mode" "$SNAPSHOT" "$interface" \
+      > "$home/fault.out" 2> "$home/fault.err"
+    rc=$?
+    set -e
+    err=$(< "$home/fault.err")
+    [ "$rc" -ne 0 ] || fail "$mode $interface unexpectedly succeeded"
+    [ ! -s "$home/fault.out" ] || fail "$mode $interface emitted a partial snapshot"
+    assert_contains "$err" "$expected" "$mode $interface lost its failure diagnostic"
+    assert_not_contains "$err" "Argument list too long" "$mode $interface regressed to argv transport"
+  done <<'EOF'
+malformed-backlog|--json|fm-fleet-snapshot: main inventory summary failed
+malformed-backlog|--secondmate-home-summary|fm-fleet-snapshot: secondmate home summary failed
+extra-values-backlog|--json|fm-fleet-snapshot: main inventory summary failed
+failed-backlog|--json|fm-fleet-snapshot: backlog read failed
+malformed-tasks|--json|fm-fleet-snapshot: main inventory summary failed
+malformed-tasks|--secondmate-home-summary|fm-fleet-snapshot: secondmate home summary failed
+failed-tasks|--json|fm-fleet-snapshot: task snapshot failed
+EOF
+  pass "snapshot interfaces reject malformed, extra, and failed JSON producers safely"
 }
 
 test_fixture_snapshot_json() {
@@ -780,6 +1002,9 @@ test_parked_scout_decision_stays_pending() {
 }
 
 test_empty_fleet_json
+test_json_transport_small_semantic_equivalence
+test_oversized_json_transport_avoids_argv_limit
+test_json_transport_rejects_malformed_and_failed_producers
 test_fixture_snapshot_json
 test_main_inventory_orphan_and_unstructured_disclosure
 test_normalized_roles_and_plural_blocker_readiness


### PR DESCRIPTION
## Intent

Repair Firstmate's fleet snapshot and operator-facing bearings path so large real fleets cannot fail with `/usr/bin/jq: Argument list too long`, preserving the supplied evidence `/root/kun-agent-workspace/bin/fm-fleet-snapshot.sh: line 608: /usr/bin/jq: Argument list too long` followed by `fm-fleet-snapshot: main inventory summary failed`. Establish the earliest failing public path against a proven small fleet and add a deterministic end-to-end reproduction independent of private backlog, clones, or live worker records that separates source input size, shell expansion, the jq exec boundary, and the visible interface result. Make the smallest shared data-transport correction by streaming or file-binding unbounded JSON aggregates into jq rather than argv, while retaining bounded scalar options and reusing one owner for main-home and second-mate summaries. Preserve canonical schema, sorting, null behavior, all required records, existing diagnostics, read-only semantics, per-home isolation, remote second-mate boundaries, no terminal/chat scraping, and bounded output fields; never solve the failure by truncating required records. Safely reject empty, malformed, multi-value, missing, or failed producer output, handle interruption and cleanup without unsafe temporary state, and use private collision-safe non-symlink-following temporary state only if stdin or owned files cannot avoid it. Add executable public-interface regressions for empty/small semantic equivalence, oversized fleet snapshot and bearings output beyond practical argv capacity, and malformed/failed input controls, asserting semantic JSON equivalence and absence of argv failure rather than implementation bytes. Run focused snapshot and bearings tests, the full applicable test runner, the repository lint owner, and documentation audience checks where applicable; safely rerun the formerly failing path with bounded non-private evidence. Preserve and report verified pre-existing suite failures. Do not stop, restart, or update watcher/daemon processes, change backlog semantics, contact project hardware/services, install or update tools, or read project-private data beyond existing snapshot authorization. Validate committed head 90b8311 through every synchronous no-mistakes gate, push and open a PR with current green checks, do not merge, and stop only for a genuine decision or blocker.

## What Changed

- Stream serialized fleet snapshot aggregates into `jq` through validated stdin framing instead of command-line arguments, preventing oversized fleets from exceeding argv limits.
- Preserve fleet snapshot, second-mate summary, and bounded bearings semantics while rejecting malformed, multi-value, missing, or failed JSON producer output.
- Add public-interface regressions covering empty and small semantic equivalence, oversized fleet and bearings output, and producer failure controls.

## Risk Assessment

✅ Low: The change is well-bounded and consistently replaces unbounded jq argv bindings with validated stdin transport while preserving schemas, diagnostics, ordering, bounds, and public snapshot/bearings behavior.

## Testing

Validated the committed head through focused snapshot and bearings checks, the changed-test runner, and the complete 130-script test runner; direct CLI evidence confirms semantic equivalence, safe producer rejection, and oversized snapshot/bearings success without argv failure, while the full suite preserved 22 unrelated existing/environment-sensitive failures and 16 expected gate skips.

<details>
<summary>Evidence: Oversized fleet public-interface evidence</summary>

```text
ok - empty fleet snapshot, summary, and view use explicit absence markers
ok - small snapshot and secondmate summary preserve canonical JSON semantics
ok - oversized snapshot, secondmate summary, and bearings avoid argv while preserving records
ok - snapshot interfaces reject malformed, extra, and failed JSON producers safely
ok - fixture snapshot covers task rows, backlog rows, pointers, and stable ordering
ok - main_inventory discloses orphan/unstructured and clears when inventory is consistent
ok - backlog normalization preserves strict roles and resolves every blocker compatibly
ok - snapshot event hints follow reconciled current state
ok - durable fold keeps an open decision past a later unrelated event
ok - a live secondmate endpoint preserves unrelated open decisions
ok - durable captain-held transfer closes the duplicate live status decision
ok - durable fold clears a decision only on a keyed resolution
ok - a completed scout's stale decision surfaces as a report pointer, not pending
ok - a scout still parked at a decision stays pending (terminal clear does not over-fire)
ok - snapshot includes durable scout reports after teardown
ok - snapshot parses tasks-axi rows and respects operational overrides
ok - fleet view renders the snapshot without secondmate peek guidance
ok - fleet view renders secondmate agent liveness
```
</details>
<details>
<summary>Evidence: Focused bearings transcript</summary>

```text
ok - Domain Alpha structured state overrides a stale parent Phase 7 event
ok - GNU stat file reads select -c without BSD filesystem-report pollution
ok - parent activity evidence is bounded and disclosed
ok - Bearings excludes a status-only child decision
ok - a structured child captain hold reaches Captain's Call
not ok - bad home outcomes revived stale work or lacked provenance: {
  "schema": "fm-bearings.v1",
  "home": "fm-bearings.cAgRSN/bad-homes",
  "generated": "2026-07-11T18:00:00Z",
  "prs": "not_requested (run: /bearings include PRs)",
  "in_flight": [],
  "secondmates": [
    {
      "id": "invalid",
      "state": "unknown",
      "doing": "invalid home: marked for secondmate someone-else, expected invalid",
      "provenance": "parent-event-fallback",
      "freshness": "historical-event",
      "age_seconds": 0,
      "contradiction": false,
      "reason": "invalid home: marked for secondmate someone-else, expected invalid"
    },
    {
      "id": "malformed",
      "state": "unknown",
      "doing": "structured home state invalid: unstructured current backlog row",
      "provenance": "parent-event-fallback",
      "freshness": "historical-event",
      "age_seconds": 0,
      "contradiction": false,
      "reason": "structured home state invalid: unstructured current backlog row"
    },
    {
      "id": "missing",
      "state": "unknown",
      "doing": "invalid home: not a directory",
      "provenance": "unknown",
      "freshness": "unknown",
      "age_seconds": null,
      "contradiction": false,
      "reason": "invalid home: not a directory"
    },
    {
      "id": "timedout",
      "state": "unknown",
      "doing": "structured home snapshot timed out",
      "provenance": "parent-event-fallback",
      "freshness": "historical-event",
      "age_seconds": 0,
      "contradiction": false,
      "reason": "structured home snapshot timed out"
    },
    {
      "id": "unreadable",
      "state": "no_active_work",
      "doing": "No active child work",
      "provenance": "structured-home",
      "freshness": "fresh",
      "age_seconds": 0,
      "contradiction": true,
      "reason": "-"
    }
  ],
  "decisions_open": [],
  "landed": [],
  "gates": [],
  "reports": [],
  "recorded_prs": [],
  "unhealthy_endpoints": [
    {
      "id": "invalid",
      "backend": "tmux",
      "target": "firstmate:fm-invalid",
      "exists": true,
      "agent": "dead"
    },
    {
      "id": "malformed",
      "backend": "tmux",
      "target": "firstmate:fm-malformed",
      "exists": true,
      "agent": "dead"
    },
    {
      "id": "timedout",
      "backend": "tmux",
      "target": "firstmate:fm-timedout",
      "exists": true,
      "agent": "dead"
    },
    {
      "id": "unreadable",
      "backend": "tmux",
      "target": "firstmate:fm-unreadable",
      "exists": true,
      "agent": "dead"
    }
  ],
  "omitted": [
    {
      "surface": "backlog item bodies",
      "reveal": "--fields bodies"
    },
    {
      "surface": "task paths",
      "reveal": "--fields paths"
    },
    {
      "surface": "watch/steer actions",
      "reveal": "--fields actions"
    },
    {
      "surface": "healthy endpoint detail",
      "reveal": "--fields endpoints"
    },
    {
      "surface": "full scout-report inventory",
      "reveal": "--all-reports"
    },
    {
      "surface": "superseded queued items",
      "reveal": "--all-queued"
    },
    {
      "surface": "secondmate home(s) with unreadable backlog: 4",
      "reveal": "inspect the listed secondmate home backlogs"
    },
    {
      "surface": "live PR discovery + checks",
      "reveal": "--include-prs"
    }
  ]
}
```
</details>
<details>
<summary>Evidence: Changed-test runner transcript</summary>

```text
FM_TEST_BEGIN 2026-08-07T09:17:25Z tests/fm-bearings-snapshot.test.sh family=snapshot-bearings expected_gate_skip=optional-binary
ok - Domain Alpha structured state overrides a stale parent Phase 7 event
ok - GNU stat file reads select -c without BSD filesystem-report pollution
ok - parent activity evidence is bounded and disclosed
ok - Bearings excludes a status-only child decision
ok - a structured child captain hold reaches Captain's Call
not ok - bad home outcomes revived stale work or lacked provenance: {
  "schema": "fm-bearings.v1",
  "home": "fm-bearings.Gr4MVp/bad-homes",
  "generated": "2026-07-11T18:00:00Z",
  "prs": "not_requested (run: /bearings include PRs)",
  "in_flight": [],
  "secondmates": [
    {
      "id": "invalid",
      "state": "unknown",
      "doing": "invalid home: marked for secondmate someone-else, expected invalid",
      "provenance": "parent-event-fallback",
      "freshness": "historical-event",
      "age_seconds": 0,
      "contradiction": false,
      "reason": "invalid home: marked for secondmate someone-else, expected invalid"
    },
    {
      "id": "malformed",
      "state": "unknown",
      "doing": "structured home state invalid: unstructured current backlog row",
      "provenance": "parent-event-fallback",
      "freshness": "historical-event",
      "age_seconds": 0,
      "contradiction": false,
      "reason": "structured home state invalid: unstructured current backlog row"
    },
    {
      "id": "missing",
      "state": "unknown",
      "doing": "invalid home: not a directory",
      "provenance": "unknown",
      "freshness": "unknown",
      "age_seconds": null,
      "contradiction": false,
      "reason": "invalid home: not a directory"
    },
    {
      "id": "timedout",
      "state": "unknown",
      "doing": "structured home snapshot timed out",
      "provenance": "parent-event-fallback",
      "freshness": "historical-event",
      "age_seconds": 0,
      "contradiction": false,
      "reason": "structured home snapshot timed out"
    },
    {
      "id": "unreadable",
      "state": "no_active_work",
      "doing": "No active child work",
      "provenance": "structured-home",
      "freshness": "fresh",
      "age_seconds": 0,
      "contradiction": true,
      "reason": "-"
    }
  ],
  "decisions_open": [],
  "landed": [],
  "gates": [],
  "reports": [],
  "recorded_prs": [],
  "unhealthy_endpoints": [
    {
      "id": "invalid",
      "backend": "tmux",
      "target": "firstmate:fm-invalid",
      "exists": true,
      "agent": "dead"
    },
    {
      "id": "malformed",
      "backend": "tmux",
      "target": "firstmate:fm-malformed",
      "exists": true,
      "agent": "dead"
    },
    {
      "id": "timedout",
      "backend": "tmux",
      "target": "firstmate:fm-timedout",
      "exists": true,
      "agent": "dead"
    },
    {
      "id": "unreadable",
      "backend": "tmux",
      "target": "firstmate:fm-unreadable",
      "exists": true,
      "agent": "dead"
    }
  ],
  "omitted": [
    {
      "surface": "backlog item bodies",
      "reveal": "--fields bodies"
    },
    {
      "surface": "task paths",
      "reveal": "--fields paths"
    },
    {
      "surface": "watch/steer actions",
      "reveal": "--fields actions"
    },
    {
      "surface": "healthy endpoint detail",
      "reveal": "--fields endpoints"
    },
    {
      "surface": "full scout-report inventory",
      "reveal": "--all-reports"
    },
    {
      "surface": "superseded queued items",
      "reveal": "--all-queued"
    },
    {
      "surface": "secondmate home(s) with unreadable backlog: 4",
      "reveal": "inspect the listed secondmate home backlogs"
    },
    {
      "surface": "live PR discovery + checks",
      "reveal": "--include-prs"
    }
  ]
}
FM_TEST_END 2026-08-07T09:17:39Z tests/fm-bearings-snapshot.test.sh exit=1 duration_ms=14300 gate_skip=false
FM_TEST_BEGIN 2026-08-07T09:17:39Z tests/fm-fleet-snapshot-view.test.sh family=snapshot-bearings expected_gate_skip=optional-binary
ok - empty fleet snapshot, summary, and view use explicit absence markers
ok - small snapshot and secondmate summary preserve canonical JSON semantics
ok - oversized snapshot, secondmate summary, and bearings avoid argv while preserving records
ok - snapshot interfaces reject malformed, extra, and failed JSON producers safely
ok - fixture snapshot covers task rows, backlog rows, pointers, and stable ordering
ok - main_inventory discloses orphan/unstructured and clears when inventory is consistent
ok - backlog normalization preserves strict roles and resolves every blocker compatibly
ok - snapshot event hints follow reconciled current state
ok - durable fold keeps an open decision past a later unrelated event
ok - a live secondmate endpoint preserves unrelated open decisions
ok - durable captain-held transfer closes the duplicate live status decision
ok - durable fold clears a decision only on a keyed resolution
ok - a completed scout's stale decision surfaces as a report pointer, not pending
ok - a scout still parked at a decision stays pending (terminal clear does not over-fire)
ok - snapshot includes durable scout reports after teardown
ok - snapshot parses tasks-axi rows and respects operational overrides
ok - fleet view renders the snapshot without secondmate peek guidance
ok - fleet view renders secondmate agent liveness
FM_TEST_END 2026-08-07T09:18:16Z tests/fm-fleet-snapshot-view.test.sh exit=0 duration_ms=37131 gate_skip=false
FM_TEST_SUMMARY total=2 failed=1 skipped_gate=0 duration_ms=51517
FM_TEST_SUMMARY_FAMILY family=snapshot-bearings count=2 duration_ms=51431 failed=1
FM_TEST_SLOWEST rank=1 script=tests/fm-fleet-snapshot-view.test.sh duration_ms=37131
FM_TEST_SLOWEST rank=2 script=tests/fm-bearings-snapshot.test.sh duration_ms=14300
```
</details>
<details>
<summary>Evidence: Full test-suite transcript</summary>

```text
FM_TEST_BEGIN 2026-08-07T09:18:26Z tests/fm-afk-inject-e2e.test.sh family=afk expected_gate_skip=none
ok - Scenario A: partial input defers injection; digest arrives clean after idle
ok - Scenario B: swallowed Enter produces exactly one clean digest
ok - Scenario C: a normal captain status injects exactly one clean single-line sentinel digest
all e2e injection tests passed
FM_TEST_END 2026-08-07T09:19:03Z tests/fm-afk-inject-e2e.test.sh exit=0 duration_ms=36514 gate_skip=false
FM_TEST_BEGIN 2026-08-07T09:19:03Z tests/fm-afk-inject-herdr-e2e.test.sh family=real-herdr-gated expected_gate_skip=herdr
ok - real herdr Scenario A: partial input defers injection; digest arrives clean after idle
ok - real herdr Scenario B: swallowed Enter (via the herdr shim) produces exactly one clean digest
ok - real herdr Scenario C: a normal captain status injects exactly one clean single-line sentinel digest
ok - real herdr Scenario D: a persistently pending composer raises the max-defer wedge alarm, preserves the buffer, and never crashes the daemon
all real-herdr afk injection e2e tests passed
FM_TEST_END 2026-08-07T09:20:07Z tests/fm-afk-inject-herdr-e2e.test.sh exit=0 duration_ms=64126 gate_skip=false
FM_TEST_BEGIN 2026-08-07T09:20:07Z tests/fm-afk-launch.test.sh family=real-herdr-gated expected_gate_skip=herdr
ok - clear-stale: removes escalations buffer, sidecar, and wedge marker
ok - clear-stale: leaves the durable wake-queue intact (no pending work dropped)
ok - launcher paths: relative home and state ignore CDPATH before daemon command construction
ok - launcher paths: absolute symlink spellings are preserved
ok - launcher paths: unresolved relative FM_HOME fails loudly
ok - launcher paths: unresolved relative FM_STATE_OVERRIDE fails loudly
ok - refresh: daemon already alive - stale artifacts preserved (current session's buffer kept)
ok - stop-ordering: daemon SIGTERM'd while .afk still present (flush is not a no-op)
ok - stop-ordering: .afk cleared last
ok - stop-ordering: daemon-terminal record removed
ok - stop identity: stale lock cannot signal an unrelated live process
ok - failed start: away flag and delivery artifacts roll back
ok - concurrent start: one serialized daemon terminal remains tracked
ok - launcher lock: incomplete publication receives initialization grace
ok - launcher signal: TERM exits and releases the lifecycle lock
fm-afk-launch: daemon launched in non-visible herdr workspace ws-partial (pane lab:pane-exact), supervising lab:captain
ok - herdr create: malformed response recovers durable exact ownership
fm-afk-launch: herdr create failed after returning exact ids; closing lab:pane-exact
fm-afk-launch: recorded terminal teardown is unconfirmed; preserving exact id
ok - herdr create error: unconfirmed exact id is persisted for reconciliation
fm-afk-launch: failed to run daemon in herdr pane lab:pane-exact; closing it
fm-afk-launch: recorded terminal teardown is unconfirmed; preserving exact id
ok - herdr run failure: unconfirmed exact id remains reconcilable
fm-afk-launch: failed to persist daemon terminal record; closing tmux:exact-session
ok - record failure: newly created terminal is closed by exact id
fm-afk-launch: daemon did not become ready; closing tmux:exact-session
ok - readiness failure: exact terminal and durable record roll back
fm-afk-launch: daemon did not become ready; closing tmux:exact-session
fm-afk-launch: recorded terminal teardown is unconfirmed; preserving exact id
ok - readiness failure: unconfirmed terminal retains its reconciliation id
ok - tmux absence: clean missing differs from transport probe failure
ok - native lifecycle: launcher owns state with no terminal
ok - native lifecycle: uniform stop clears state without closing a terminal
ok - native entry: launcher-prepared lifecycle state is not rewritten
fm-afk-launch: reconciling leaked daemon terminal tmux:exact-session
fm-afk-launch: recorded terminal teardown is unconfirmed; preserving exact id
ok - teardown failure: exact terminal record is preserved
ok - record publication: failed atomic rename preserves the complete prior record
fm-afk-launch: daemon terminal record is malformed; refusing to act on it
ok - record read: malformed record fails closed without acting on a partial id
fm-afk-launch: daemon terminal record is malformed; refusing to act on it
fm-afk-launch: malformed daemon terminal record; refusing to stop away mode
ok - stop: malformed terminal record preserves away state and fails closed
fm-afk-launch: failed to create detached tmux daemon session 'fm-afk-daemon-3483790959-2407534-254-1786094440'
ok - tmux launch: planned exact target is recorded before creation and removed on failure
fm-afk-launch: failed to create detached tmux daemon session 'fm-afk-daemon-2933635826-2407610-21837-1786094440'
ok - tmux launch: unique names eliminate collision teardown
ok - stop validation: malformed record causes no daemon or state side effects
ok - launcher lock: incomplete metadata fails acquisition and releases lock
fm-afk-launch: failed to clear away-mode flag
fm-afk-launch: away mode stopped; terminal teardown remains recorded for retry
ok - stop state: away-flag removal failure is surfaced
fm-afk-launch: away-mode daemon did not exit after SIGTERM; preserving lifecycle state
ok - stop liveness: captured live daemon preserves lifecycle state after lock release
fm-afk-launch: daemon terminal record is malformed; refusing to act on it
fm-afk-launch: daemon terminal record is malformed; refusing to act on it
ok - refresh record: malformed terminal identity fails closed
fm-afk-launch: failed to clear stale away-mode artifacts
ok - clear failure: native entry aborts and restores prior state
fm-afk-launch: reconciling leaked daemon terminal tmux:exact-session
fm-afk-launch: terminal close command failed, but exact absence was confirmed
ok - confirmed absence: cleanup succeeds and removes the stale record
fm-afk-launch: rollback restoration incomplete; backup retained at /tmp/fm-afk-restore-fail.JnlxZX/state/.afk-launch-backup.oDD3bv
ok - rollback restore: incomplete restoration retains its recovery backup
ok - flag failure: lifecycle aborts without active state
ok - herdr e2e: captain tab pane count unchanged after start (no split)
ok - herdr e2e: daemon launched in a separate non-visible workspace
ok - herdr e2e: daemon pane is NOT in the captain's tab
ok - herdr e2e: daemon terminal scoped to the lab session
ok - herdr e2e: captain tab pane count restored after stop
ok - herdr e2e: daemon workspace removed by exact id on stop
ok - herdr e2e: record + .afk cleared on stop
ok - tmux e2e: captain window pane count unchanged after start (no split-window)
ok - tmux e2e: daemon launched in a separate detached session
ok - tmux e2e: captain window pane count unchanged after stop
ok - tmux e2e: daemon session killed by exact id on stop
ok - tmux e2e: record + .afk cleared on stop
FM_TEST_END 2026-08-07T09:20:42Z tests/fm-afk-launch.test.sh exit=0 duration_ms=34901 gate_skip=false
FM_TEST_BEGIN 2026-08-07T09:20:42Z tests/fm-afk-pi-herdr-return-e2e.test.sh family=live-harness-optin expected_gate_skip=optin-env
skip: set FM_AFK_PI_HERDR_E2E=1 to run the real Pi/Herdr away-return regression
FM_TEST_END 2026-08-07T09:20:42Z tests/fm-afk-pi-herdr-return-e2e.test.sh exit=0 duration_ms=149 gate_skip=true
FM_TEST_BEGIN 2026-08-07T09:20:42Z tests/fm-afk-return.test.sh family=afk expected_gate_skip=none
ok - return catch-up precedes Bearings, owns live blocker remediation, preserves evidence once, and clears idempotently
ok - tmux and Herdr blockers require the same explicit durable reclassification before ordinary work
ok - needs-decision remains reportable without masquerading as a firstmate-actionable blocker
ok - away-mode re-entry fails closed while the prior return catch-up is pending
ok - check retries recorded terminal teardown and keeps catch-up gated until success
FM_TEST_END 2026-08-07T09:20:45Z tests/fm-afk-return.test.sh exit=0 duration_ms=2166 gate_skip=false
FM_TEST_BEGIN 2026-08-07T09:20:45Z tests/fm-arm-pretool-check.test.sh family=pure-contract-unit expected_gate_skip=none
ok - matrix A01: allow through all five entry forms
ok - matrix A02: allo

... [229789 bytes truncated] ...

private guarded artifacts
ok - fmx_split_thread: word-boundary, fence-aware, within-limit, numbered, lossless, capped
ok - fm-x-reply keeps a concise reply as a single unnumbered tweet
ok - fm-x-reply auto-splits a long reply into a numbered thread (texts[])
ok - fm-x-reply uses the Discord inbox platform budget instead of the X tweet budget
ok - fm-x-reply keeps numeric X requests on the X tweet budget
ok - fm-x-reply prefers an explicit relay-provided reply limit
ok - fm-x-reply rejects unsafe inbox context artifacts
ok - fm-x-reply clamps a below-floor max to 50 characters
ok - fm-x-reply posts a thread payload (texts[]) to the relay
ok - fm-x-reply --image posts an image object on answer
ok - fm-x-reply streams large image payloads outside curl argv
ok - fm-x-reply dry-run records compact image metadata for threaded replies
ok - fm-x-reply cleans image and payload temp files
ok - fm-x-reply --image rejects missing and unsupported image paths clearly
ok - fm-x-reply --followup posts to /connector/followup with the same request-bound body
ok - fm-x-reply maps a followup_unavailable follow-up 409 to exit 9
ok - fm-x-reply maps every follow-up 409 to exit 9 even without the marker
ok - fm-x-reply treats answer-endpoint 409 as a generic failure
ok - fm-x-reply --followup --image posts an image object
ok - fm-x-reply --followup is accepted in any position and leaves the answer path default
ok - fm-x-reply --followup dry-run marks the endpoint without changing the answer path
ok - fm-x-reply --followup auto-splits a long follow-up into a marked thread
ok - fm-x-reply followup dry-run keeps endpoint marker and compact image metadata
ok - fm-x-poll records the durable per-request reply context from the relay payload
ok - context registry publishes records only through private guarded artifacts
ok - context registry reads only private single-link artifacts
ok - private artifact publisher is compatible with the system bash path
ok - context registry retention is bounded to the seven-day follow-up window
ok - context registry rewrites preserve the first-seen timestamp
ok - context retention starts only when a live initial answer succeeds
ok - a delayed Discord follow-up stays one message after inbox cleanup via the durable registry
ok - an X follow-up over 280 still splits correctly after inbox cleanup
ok - every unresolved follow-up is refused before posting
ok - a partial registry platform combines with the relay's authoritative budget
ok - concurrent requests each recover their own platform/budget with no cross-overwrite
ok - fm-x-dismiss clears the durable per-request context (a dismissed mention gets no follow-up)
ok - fm-x-dismiss posts a request-bound dismiss and echoes only the request_id
ok - fm-x-dismiss dry-run records the would-be body and never posts
ok - fm-x-dismiss dry-run works without a token
ok - fm-x-dismiss dry-run publishes outbox records only through private guarded artifacts
ok - fm-x-dismiss exits non-zero on a non-2xx relay response
ok - fm-x-dismiss exits non-zero on a transport failure
ok - fm-x-dismiss rejects an unsafe request_id (path-traversal guard)
ok - fm-x-dismiss rejects missing or extra arguments with a usage error
ok - fm-x-link records and refreshes the X-request link without disturbing meta
ok - fm-x-link records Discord platform context so follow-ups keep the Discord budget
ok - fm-x-link resolves the platform by request_id so a post-cleanup link keeps the Discord budget
ok - fm-x-link warns loudly and the follow-up is held (not wrongly split) when the platform is unknown
ok - fm-x-link paired carry flags preserve a prior task's follow-up binding onto a successor
ok - fm-x-link recovery relink preserves Discord platform context after inbox drain
ok - fm-x-link rejects malformed or unpaired carry flags
ok - meta rewrites are independent of TMPDIR
ok - fm-x-link rejects unsafe ids, missing meta, and missing arguments
ok - fm-x-followup --check reports postable / not-linked correctly
ok - fm-x-followup --check prunes a link past the 7-day window
ok - fm-x-followup --check prunes a link that already reached the follow-up cap
ok - fm-x-followup posts a follow-up, increments the counter, and keeps the link under the cap
ok - fm-x-followup --final clears the link after one post regardless of the remaining count
ok - fm-x-followup clears the link once the third follow-up reaches the cap
ok - fm-x-followup --image forwards the attachment through fm-x-reply --followup
ok - fm-x-followup keeps the link and counter when the post fails
ok - fm-x-followup tombstones the link when a post-success counter write fails
ok - fm-x-followup treats a relay cap/window rejection as an already-exhausted link, not a retry
ok - fm-x-followup skips silently and clears the link past the 7-day window
ok - fm-x-followup is a no-op for a task with no X link
ok - fm-x-followup dry-run records the follow-up and increments the counter, keeping the link
ok - fm-x-followup dry-run --final clears the link just as a live post would
ok - fm-x-followup rejects malformed invocations
ok - bootstrap activates X mode from an .env token, idempotently
ok - bootstrap ignores CDPATH when writing absolute FM_HOME into the durable X-mode poll shim
ok - bootstrap reports missing X-mode dependencies before arming
ok - bootstrap does not report X mode on when activation artifacts cannot be written
ok - bootstrap rejects linked X artifacts without touching their targets
ok - bootstrap is inert without a non-empty .env token (non-X users unaffected)
ok - bootstrap cleans up X artifacts on opt-out and is silent once off
ok - bootstrap reports failed X artifact cleanup on opt-out
FM_TEST_END 2026-08-07T10:20:54Z tests/fm-x-mode.test.sh exit=0 duration_ms=69778 gate_skip=false
FM_TEST_SUMMARY total=130 failed=22 skipped_gate=16 duration_ms=3748000
FM_TEST_SUMMARY_FAMILY family=afk count=2 duration_ms=38680 failed=0
FM_TEST_SUMMARY_FAMILY family=backend-dispatch count=12 duration_ms=190959 failed=2
FM_TEST_SUMMARY_FAMILY family=cmux count=2 duration_ms=4876 failed=0
FM_TEST_SUMMARY_FAMILY family=live-harness-optin count=12 duration_ms=518 failed=0
FM_TEST_SUMMARY_FAMILY family=orca count=1 duration_ms=14943 failed=1
FM_TEST_SUMMARY_FAMILY family=pr-forge count=5 duration_ms=785798 failed=1
FM_TEST_SUMMARY_FAMILY family=pure-contract-unit count=29 duration_ms=298945 failed=2
FM_TEST_SUMMARY_FAMILY family=real-herdr-gated count=11 duration_ms=295889 failed=1
FM_TEST_SUMMARY_FAMILY family=secondmate count=16 duration_ms=937086 failed=6
FM_TEST_SUMMARY_FAMILY family=session-bootstrap count=9 duration_ms=257471 failed=4
FM_TEST_SUMMARY_FAMILY family=snapshot-bearings count=2 duration_ms=52630 failed=1
FM_TEST_SUMMARY_FAMILY family=unclassified count=15 duration_ms=367258 failed=1
FM_TEST_SUMMARY_FAMILY family=watcher-wake-lock count=12 duration_ms=490411 failed=2
FM_TEST_SUMMARY_FAMILY family=zellij count=2 duration_ms=6004 failed=1
FM_TEST_SLOWEST rank=1 script=tests/fm-remote-secondmate-lifecycle-e2e.test.sh duration_ms=380235
FM_TEST_SLOWEST rank=2 script=tests/fm-pr-check-security.test.sh duration_ms=373906
FM_TEST_SLOWEST rank=3 script=tests/fm-teardown.test.sh duration_ms=323535
FM_TEST_SLOWEST rank=4 script=tests/fm-secondmate-harness.test.sh duration_ms=236548
FM_TEST_SLOWEST rank=5 script=tests/fm-watch-triage.test.sh duration_ms=180644
FM_TEST_SLOWEST rank=6 script=tests/fm-sessionstart-nudge.test.sh duration_ms=94925
FM_TEST_SLOWEST rank=7 script=tests/fm-public-followup.test.sh duration_ms=93559
FM_TEST_SLOWEST rank=8 script=tests/fm-backend-herdr-presentation-e2e.test.sh duration_ms=87679
FM_TEST_SLOWEST rank=9 script=tests/fm-remote-secondmate-trace-context.test.sh duration_ms=84633
FM_TEST_SLOWEST rank=10 script=tests/fm-watcher-lock.test.sh duration_ms=80275
FM_TEST_SLOWEST rank=11 script=tests/fm-procevent.test.sh duration_ms=70648
FM_TEST_SLOWEST rank=12 script=tests/fm-x-mode.test.sh duration_ms=69778
FM_TEST_SLOWEST rank=13 script=tests/fm-afk-inject-herdr-e2e.test.sh duration_ms=64126
FM_TEST_SLOWEST rank=14 script=tests/fm-remote-reply.test.sh duration_ms=62527
FM_TEST_SLOWEST rank=15 script=tests/fm-claude-stop-autoarm.test.sh duration_ms=61277
```
</details>
- Outcome: ⚠️ 2 warnings across 1 run (1h5m24s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Test** - 2 warnings</summary>

- ⚠️ The full suite retained 22 failures unrelated to the two changed files. Several are environment-sensitive permission checks running as root; others involve live Herdr/Orca/Zellij, remote fixtures, watcher timing, and existing harness tests. Exact failures and diagnostics are preserved in the full-suite artifact.
- ⚠️ `tests/fm-bearings-snapshot.test.sh` - The focused bearings suite&#39;s unreadable-home fixture fails under root because chmod cannot make the fixture unreadable. The changed end-to-end regression independently exercised oversized bearings successfully and preserved all generated records.
- <code>Inspected `git diff 70aeba855527f7693082f6dd1bc731e334d0269f..90b83111d48e43858014f0019adbb74e891b6dba`</code>
- `/bin/bash tests/fm-fleet-snapshot-view.test.sh`
- `/bin/bash tests/fm-bearings-snapshot.test.sh`
- `bin/fm-test-run.sh --changed --base 70aeba855527f7693082f6dd1bc731e334d0269f`
- `bin/fm-test-run.sh --all`
- `git status --short`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Lint** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ linter found issues (exit code 1)

🔧 Fix: Captain, fix fleet snapshot ShellCheck findings
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
