### PR TITLE
Make filed work reach the captain by name, not just the record

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,6 +103,7 @@ state/               volatile runtime signals; gitignored
   .pr-check-migration.log  private per-task outcomes distinguishing rebuilt or canonically registered replacement polls, quarantined unarmed polls, and incomplete migrations
   .pr-check-migration-scan-v1  private marker proving the non-executing scan disabled every unsafe legacy check; .pr-check-migration-v1 separately records completed private repairs
   x-watch.check.sh   generated Relay poll shim; present only when opted in (section 14)
+  capture-receipts/  derived ledger of filed work the captain has not yet been given a name for, plus the baseline it is derived from; written only by bin/fm-capture-receipt.sh (section 9)
   pending-replies/   parent-owned secondmate pending-reply records (correlation id, delivery vs reply, recovery, escalation); fm-pending-reply-lib.sh
   procevent/         registered process-to-event sources, one private record per canonical source id; written only by bin/fm-procevent.sh, and their presence alone keeps supervision required (section 13)
   procevent-inbox/   private captured results and their durable handled-acknowledgement markers; source output lives here and never in an event line
@@ -419,6 +420,13 @@ The skill owns the daemon procedure; these safety facts remain inline:
 Load `stuck-crewmate-recovery` after a stale wake, looping or confused pane, answered-by-brief question, unresponsive worker, or failed steer.
 
 ## 9. Escalation and captain etiquette
+
+**Every instruction gets a named receipt in the same reply.**
+Anything the captain asks for has exactly two acceptable outcomes, and the reply must say which one happened: it is being done now, or it is filed under an identity they can quote back.
+Name that identity in the same reply, as "Filed as `apex-loading-copy`", never as "filed as its own work", "recorded", or "noted".
+A record the captain cannot name reads to them as no record at all, so this holds even when storage plainly worked.
+`bin/fm-capture-receipt.sh` owns the receipt ledger: the obligation follows from the filing itself, the ledger hands over the exact sentence, and the turn-end guard raises anything still unpaid.
+Never lead an answer about tracking with an absence when the thing exists; asked whether something is captured, the first clause answers that question and any nuance about identifiers follows it.
 
 **Talk in outcomes, not mechanics.**
 Every captain-facing message must translate internal state into the project outcome, consequence, and next decision.

--- a/bin/fm-capture-receipt.sh
+++ b/bin/fm-capture-receipt.sh
@@ -1,0 +1,335 @@
+#!/usr/bin/env bash
+# fm-capture-receipt.sh - the captain's named-receipt ledger.
+#
+# THE PROBLEM THIS SOLVES: the captain gives an instruction, firstmate files it,
+# and the reply says "filed as its own work" or nothing at all. Storage worked;
+# the captain still cannot name the thing, so to them it was never captured. A
+# record whose identity the captain cannot quote back is indistinguishable from
+# no record. AGENTS.md section 9 owns the obligation; this script owns its
+# mechanics.
+#
+# WHY THE OBLIGATION IS DERIVED, NOT DECLARED. Nothing here asks firstmate to
+# register a receipt, because "remember to declare it" is the same class of step
+# that already failed. The ledger reads this home's own data/backlog.md and
+# compares its identity set against a durable baseline: an identity that was not
+# there before is a receipt the captain is owed, whoever filed it and however.
+# That makes incurring the debt a side effect of filing, the same shape as
+# fm-send.sh's --resolve-key closing a decision at answer time instead of hoping
+# the worker appends a matching line later.
+#
+# WHAT THIS CANNOT DO. Captain-facing chat has no tool boundary, so no hook can
+# confirm the sentence actually reached the captain. `delivered` is an
+# attestation: running it while not having named the identity in the reply is a
+# false statement to the captain, not a shortcut. The guard closes the much
+# larger hole - a receipt that was never composed at all - and the durable record
+# closes the one after it, a receipt lost to compaction or a restart.
+#
+# NO MTIME FAST PATH, DELIBERATELY. Skipping the parse when data/backlog.md
+# looks unchanged is the obvious optimisation and it is wrong here: a filing
+# whose write lands in the same whole second as the previous reconcile leaves
+# mtime identical, so the receipt would be silently skipped until some later
+# edit happened to move the clock. A missed receipt is the exact failure this
+# script exists to prevent, and one awk pass over a backlog is negligible
+# against a turn, so the check always reads the file. A home with no
+# data/backlog.md still returns before doing anything at all.
+#
+# Usage:
+#   fm-capture-receipt.sh pending
+#       One block per owed receipt, each carrying the exact sentence to send.
+#       Silent when nothing is owed. Read-only apart from reconciling the
+#       ledger against the current backlog.
+#
+#   fm-capture-receipt.sh delivered <identity>...
+#       Attest that the reply named these identities to the captain, clearing
+#       them. An identity that is not owed is refused before anything is
+#       cleared, so a mistyped or half-remembered name cannot silently retire
+#       the wrong debt.
+#
+#   fm-capture-receipt.sh active
+#       Silent probe. Exit 0 when this home owes at least one receipt, 1
+#       otherwise. Reconciles first, so a session start is authoritative even
+#       when the turn that filed the work never reached a turn end. Safe to call
+#       unconditionally; used to gate the session-start subsection.
+#
+#   fm-capture-receipt.sh guard
+#       Turn-end check, invoked by bin/fm-turnend-guard.sh inside an already
+#       scoped primary home. Exit 2 with the owed sentences on stderr when a
+#       receipt has never been surfaced; exit 0 otherwise.
+#
+#   fm-capture-receipt.sh reconcile
+#       Fold the current backlog into the ledger without printing. Exposed for
+#       tests and for establishing the baseline by hand.
+#
+# LOOP SAFETY. The guard blocks AT MOST ONCE PER IDENTITY, ever, recorded in the
+# owed record itself rather than in a per-session counter. N newly filed items
+# can therefore cost at most N forced continuations across the whole life of the
+# home, and a firstmate that ignores the block cannot be wedged by it: the debt
+# stays owed and resurfaces in the session-start digest instead. That bound is
+# independent of every harness loop-guard field, so it holds identically on each
+# supported primary. Marking the block happens BEFORE the block is emitted, and
+# a failure to mark allows the turn end, so an unwritable state directory can
+# never trap a session.
+#
+# SCOPE. Receipts are a MAIN-HOME concern. A secondmate never addresses the
+# captain (AGENTS.md hard rule 4), and its backlog receives handed-off items it
+# must not receipt, so bin/fm-turnend-guard.sh skips this check in a marked
+# secondmate home. Nothing here reads or writes another home's state.
+#
+# STATE, all under state/capture-receipts/ (0700):
+#   baseline         the backlog identity set at the last reconcile, one per line
+#   owed/<identity>  one owed receipt: title=, first_seen=, blocked=
+# The FIRST reconcile in a home establishes the baseline and owes nothing, so
+# adopting this script never claims the whole existing backlog as unpaid debt.
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
+STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
+DATA="${FM_DATA_OVERRIDE:-$FM_HOME/data}"
+
+BACKLOG="$DATA/backlog.md"
+LEDGER="$STATE/capture-receipts"
+BASELINE="$LEDGER/baseline"
+OWED="$LEDGER/owed"
+
+TITLE_CAP=120
+TAB=$(printf '\t')
+
+usage() {
+  awk '
+    NR == 1 { next }
+    /^#/ { sub(/^# ?/, ""); print; next }
+    { exit }
+  ' "$0"
+}
+
+# Identities are backlog slugs. Anything else is skipped rather than sanitized,
+# because an identity is also a path component here and a permissive rule is how
+# a crafted backlog line would reach outside the ledger.
+receipt_valid_id() {  # <identity>
+  case "${1:-}" in
+    '' | . | ..) return 1 ;;
+    *[!A-Za-z0-9._-]*) return 1 ;;
+  esac
+  return 0
+}
+
+# Emit "<identity><TAB><title>" for every item line in the backlog, in file
+# order, first occurrence wins. Accepts the tasks-axi markdown backend's
+# "- [ ] <id> - <title>" and the manual backend's unchecked "- <id> - <title>",
+# and anchors at column 0 so indented task bodies (which contain their own
+# bullets) are never mistaken for items - the same anchoring
+# bin/fm-session-start.sh's manual listing uses.
+receipt_parse_backlog() {
+  awk -v cap="$TITLE_CAP" '
+    /^[-*][ \t]+/ {
+      line = $0
+      sub(/^[-*][ \t]+/, "", line)
+      sub(/^\[[ xX]\][ \t]+/, "", line)
+      idx = index(line, " - ")
+      if (idx == 0) next
+      id = substr(line, 1, idx - 1)
+      if (id !~ /^[A-Za-z0-9._-]+$/) next
+      if (id in seen) next
+      seen[id] = 1
+      title = substr(line, idx + 3)
+      # Trailing "(kind: ship)" / "(since 2026-08-07)" metadata groups are the
+      # backend rendering, not the captain-facing title.
+      while (match(title, /[ \t]+\((since [^()]*|[A-Za-z_][A-Za-z0-9_ -]*:[^()]*)\)[ \t]*$/)) {
+        title = substr(title, 1, RSTART - 1)
+      }
+      sub(/[ \t]+$/, "", title)
+      if (length(title) > cap) title = substr(title, 1, cap - 3) "..."
+      printf "%s\t%s\n", id, title
+    }
+  ' "$BACKLOG" 2>/dev/null
+}
+
+# Owed identities, one per line. Every temporary file this script writes lives
+# in the ledger root rather than in owed/, so nothing transient can be read back
+# as a receipt; the validity filter is defence in depth for a hand-dropped file.
+receipt_owed_ids() {
+  local record id
+  [ -d "$OWED" ] || return 0
+  for record in "$OWED"/*; do
+    [ -f "$record" ] || continue
+    id=${record##*/}
+    receipt_valid_id "$id" || continue
+    printf '%s\n' "$id"
+  done
+}
+
+receipt_field() {  # <record> <field>
+  sed -n "s/^$2=//p" "$1" 2>/dev/null | head -1
+}
+
+# The captain-facing sentence, with no trailing newline: every caller reads it
+# through a command substitution, which would strip one anyway.
+# The backticks are literal markdown: the captain's terminal renders the reply,
+# so the identity arrives as inline code and reads as something to quote back.
+# shellcheck disable=SC2016 # Backticks are literal output, not a substitution.
+receipt_sentence() {  # <identity> <title>
+  if [ -n "${2:-}" ]; then
+    printf 'Filed as `%s` - %s.' "$1" "$2"
+  else
+    printf 'Filed as `%s`.' "$1"
+  fi
+}
+
+# Fold the current backlog into the ledger. Never fails the caller: a home that
+# cannot write its own state must not lose a turn to this.
+receipt_reconcile() {
+  local current id cid title record present tmp
+  [ -f "$BACKLOG" ] || return 0
+
+  mkdir -p "$OWED" 2>/dev/null || return 0
+  chmod 700 "$LEDGER" 2>/dev/null || true
+
+  current=$(receipt_parse_backlog) || return 0
+
+  if [ ! -f "$BASELINE" ]; then
+    # First reconcile in this home: adopt the whole backlog as already known so
+    # nothing pre-existing is claimed as an unpaid receipt.
+    receipt_write_baseline "$current"
+    return 0
+  fi
+
+  while IFS="$TAB" read -r id title; do
+    [ -n "$id" ] || continue
+    receipt_valid_id "$id" || continue
+    grep -Fxq "$id" "$BASELINE" 2>/dev/null && continue
+    record="$OWED/$id"
+    [ -e "$record" ] && continue
+    tmp="$LEDGER/.write.$$"
+    if printf 'title=%s\nfirst_seen=%s\nblocked=0\n' "$title" "$(date +%s)" > "$tmp" 2>/dev/null; then
+      mv -f "$tmp" "$record" 2>/dev/null || true
+    fi
+    rm -f "$tmp" 2>/dev/null || true
+  done <<EOF
+$current
+EOF
+
+  # An identity that has left the backlog entirely (removed, or archived out of
+  # the Done tail) is no longer a debt worth carrying.
+  for id in $(receipt_owed_ids); do
+    present=0
+    while IFS="$TAB" read -r cid _; do
+      [ "$cid" = "$id" ] && { present=1; break; }
+    done <<EOF
+$current
+EOF
+    [ "$present" -eq 1 ] || rm -f "$OWED/$id" 2>/dev/null || true
+  done
+
+  receipt_write_baseline "$current"
+}
+
+receipt_write_baseline() {  # <parsed>
+  local tmp
+  tmp="$LEDGER/.baseline.$$"
+  if printf '%s\n' "$1" | cut -f1 | grep -v '^$' > "$tmp" 2>/dev/null || [ -f "$tmp" ]; then
+    mv -f "$tmp" "$BASELINE" 2>/dev/null || true
+  fi
+  rm -f "$tmp" 2>/dev/null || true
+}
+
+cmd_pending() {
+  local id record title blocked
+  receipt_reconcile
+  for id in $(receipt_owed_ids); do
+    record="$OWED/$id"
+    title=$(receipt_field "$record" title)
+    blocked=$(receipt_field "$record" blocked)
+    printf 'owed: %s\n' "$id"
+    printf '  say: %s\n' "$(receipt_sentence "$id" "$title")"
+    [ "$blocked" = 1 ] && printf '  (already surfaced once at a turn end)\n'
+    printf '  clear: %s/bin/fm-capture-receipt.sh delivered %s\n' "$FM_ROOT" "$id"
+  done
+}
+
+cmd_delivered() {
+  local id missing=0
+  [ "$#" -gt 0 ] || { echo "usage: fm-capture-receipt.sh delivered <identity>..." >&2; return 2; }
+  receipt_reconcile
+  for id in "$@"; do
+    if ! receipt_valid_id "$id" || [ ! -f "$OWED/$id" ]; then
+      printf 'error: no receipt is owed for %s\n' "$id" >&2
+      missing=1
+    fi
+  done
+  if [ "$missing" -eq 1 ]; then
+    # shellcheck disable=SC2016 # Backticks are literal output, not a substitution.
+    printf 'refusing before clearing anything; run `%s/bin/fm-capture-receipt.sh pending` for what is actually owed\n' \
+      "$FM_ROOT" >&2
+    return 1
+  fi
+  for id in "$@"; do
+    rm -f "$OWED/$id" 2>/dev/null || true
+    printf 'receipt delivered: %s\n' "$id"
+  done
+}
+
+cmd_active() {
+  local id
+  # Reconciles first so a session start is authoritative even when the turn
+  # that filed the work never reached a turn end.
+  receipt_reconcile
+  for id in $(receipt_owed_ids); do
+    [ -n "$id" ] && return 0
+  done
+  return 1
+}
+
+cmd_guard() {
+  local id record title blocked pending_ids='' tmp rule
+  receipt_reconcile
+  for id in $(receipt_owed_ids); do
+    blocked=$(receipt_field "$OWED/$id" blocked)
+    [ "$blocked" = 1 ] && continue
+    pending_ids="$pending_ids $id"
+  done
+  [ -n "$pending_ids" ] || return 0
+
+  # Mark first: a receipt that cannot be marked must not block, or an unwritable
+  # state dir would refuse every turn end from here on.
+  tmp="$LEDGER/.write.$$"
+  for id in $pending_ids; do
+    record="$OWED/$id"
+    if ! sed 's/^blocked=0$/blocked=1/' "$record" > "$tmp" 2>/dev/null \
+      || ! mv -f "$tmp" "$record" 2>/dev/null; then
+      rm -f "$tmp" 2>/dev/null || true
+      return 0
+    fi
+  done
+  rm -f "$tmp" 2>/dev/null || true
+
+  rule='━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━'
+  {
+    printf '●%s\n' "$rule"
+    printf '●  THE CAPTAIN HAS NOT BEEN TOLD WHAT THIS WAS FILED AS\n'
+    printf '●  Work was filed this turn and the captain cannot name it. A record they\n'
+    printf '●  cannot quote back reads to them as nothing captured (AGENTS.md section 9).\n'
+    printf '●  Send these exact sentences before ending the turn:\n'
+    for id in $pending_ids; do
+      title=$(receipt_field "$OWED/$id" title)
+      printf '●    %s\n' "$(receipt_sentence "$id" "$title")"
+    done
+    printf '●  Then attest delivery:\n'
+    printf '●    %s/bin/fm-capture-receipt.sh delivered%s\n' "$FM_ROOT" "$pending_ids"
+    printf '●  If the captain already has a name for one, attest it and move on. This\n'
+    printf '●  block is raised once per item; after that the debt only shows at session start.\n'
+    printf '●%s\n' "$rule"
+  } >&2
+  return 2
+}
+
+case "${1:-}" in
+  pending) shift; cmd_pending "$@" ;;
+  delivered) shift; cmd_delivered "$@" ;;
+  active) shift; cmd_active "$@" ;;
+  guard) shift; cmd_guard "$@" ;;
+  reconcile) shift; receipt_reconcile ;;
+  -h | --help | help) usage ;;
+  *) usage >&2; exit 2 ;;
+esac

--- a/bin/fm-session-start.sh
+++ b/bin/fm-session-start.sh
@@ -725,6 +725,23 @@ else
   printf 'absent\n'
 fi
 
+# Work the captain has been given no name for. The turn-end guard raises each
+# one once, so a receipt that outlived that block - because the session ended,
+# compacted, or restarted - would otherwise be silently unpaid forever. Read
+# from disk here for the same reason public commitments are.
+# bin/fm-capture-receipt.sh owns the ledger; a home with nothing owed prints no
+# subsection and never reaches the second call.
+if [ -x "$SCRIPT_DIR/fm-capture-receipt.sh" ] \
+  && "$SCRIPT_DIR/fm-capture-receipt.sh" active 2>/dev/null; then
+  CAPTURE_RECEIPTS=$("$SCRIPT_DIR/fm-capture-receipt.sh" pending 2>/dev/null) || CAPTURE_RECEIPTS=
+  if [ -n "$CAPTURE_RECEIPTS" ]; then
+    subsection "Captain receipts owed"
+    printf '%s\n' "$CAPTURE_RECEIPTS"
+    printf '\nEach is filed work the captain cannot name yet. Send its sentence in your next\n'
+    printf 'reply, then attest with %s/bin/fm-capture-receipt.sh delivered <identity>.\n' "$FM_ROOT"
+  fi
+fi
+
 # Public commitments made through the myfirstmate relay. A promise to reply in a
 # public thread must survive compaction and restart, so it is surfaced from disk
 # here rather than from conversation memory. fm-public-followup-lib.sh owns both

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -567,6 +567,11 @@ select_lane() {
   [ "$found" -eq 1 ] || die "lane '$want' selected no tests"
 }
 
+# Every list below is written with `LC_ALL=C sort`, so every comparison must
+# read it back under the same collation. Without LC_ALL=C, comm applies the
+# ambient locale's rules to C-collated input: it warns that the input is
+# unsorted and its set arithmetic stops being trustworthy, which is how a guard
+# reports a wrong missing/extra set instead of failing honestly.
 run_coverage_guard() {
   local tmp missing extra a b shard
   local -a saved_scripts=()
@@ -585,8 +590,8 @@ run_coverage_guard() {
     return 1
   fi
   cat "$tmp/s1" "$tmp/s2" | LC_ALL=C sort -u >"$tmp/shards_union"
-  missing=$(comm -23 "$tmp/proven" "$tmp/shards_union" || true)
-  extra=$(comm -13 "$tmp/proven" "$tmp/shards_union" || true)
+  missing=$(LC_ALL=C comm -23 "$tmp/proven" "$tmp/shards_union" || true)
+  extra=$(LC_ALL=C comm -13 "$tmp/proven" "$tmp/shards_union" || true)
   if [ -n "$missing" ] || [ -n "$extra" ]; then
     log "coverage guard: portable shards must equal the proven-isolated set"
     [ -z "$missing" ] || { log "missing from shards:"; printf '%s\n' "$missing" >&2; }
@@ -630,8 +635,8 @@ run_coverage_guard() {
     return 1
   fi
   LC_ALL=C sort -u "$tmp/serial_shards_raw" >"$tmp/serial_shards"
-  missing=$(comm -23 "$tmp/serial" "$tmp/serial_shards" || true)
-  extra=$(comm -13 "$tmp/serial" "$tmp/serial_shards" || true)
+  missing=$(LC_ALL=C comm -23 "$tmp/serial" "$tmp/serial_shards" || true)
+  extra=$(LC_ALL=C comm -13 "$tmp/serial" "$tmp/serial_shards" || true)
   if [ -n "$missing" ] || [ -n "$extra" ]; then
     log "coverage guard: portable serial shards must equal the portable serial lane"
     [ -z "$missing" ] || { log "missing from serial shards:"; printf '%s\n' "$missing" >&2; }
@@ -643,7 +648,7 @@ run_coverage_guard() {
   for pair in "shards_union:serial" "shards_union:herdr" "serial:herdr"; do
     a=${pair%%:*}
     b=${pair#*:}
-    comm -12 "$tmp/$a" "$tmp/$b" >"$tmp/overlap"
+    LC_ALL=C comm -12 "$tmp/$a" "$tmp/$b" >"$tmp/overlap"
     if [ -s "$tmp/overlap" ]; then
       log "coverage guard: overlap between $a and $b:"
       cat "$tmp/overlap" >&2
@@ -661,8 +666,8 @@ run_coverage_guard() {
     return 1
   fi
   LC_ALL=C sort -u "$tmp/union_raw" >"$tmp/union"
-  missing=$(comm -23 "$tmp/all" "$tmp/union" || true)
-  extra=$(comm -13 "$tmp/all" "$tmp/union" || true)
+  missing=$(LC_ALL=C comm -23 "$tmp/all" "$tmp/union" || true)
+  extra=$(LC_ALL=C comm -13 "$tmp/all" "$tmp/union" || true)
   if [ -n "$missing" ] || [ -n "$extra" ]; then
     log "coverage guard: union of portable shards + portable serial + Herdr must equal tests/*.test.sh"
     [ -z "$missing" ] || { log "missing from union:"; printf '%s\n' "$missing" >&2; }
@@ -675,7 +680,7 @@ run_coverage_guard() {
     "$ROOT/bin/fm-test-isolation-proof.sh" --list | LC_ALL=C sort -u >"$tmp/proof_list"
     if ! cmp -s "$tmp/proven" "$tmp/proof_list"; then
       log "coverage guard: embedded proven-isolated set diverges from bin/fm-test-isolation-proof.sh --list"
-      comm -3 "$tmp/proven" "$tmp/proof_list" >&2 || true
+      LC_ALL=C comm -3 "$tmp/proven" "$tmp/proof_list" >&2 || true
       rm -rf "$tmp"
       return 1
     fi

--- a/bin/fm-turnend-guard.sh
+++ b/bin/fm-turnend-guard.sh
@@ -124,6 +124,27 @@ fi
 # so this exempts them while guarding every real secondmate home.
 fm_primary_scope_matches "$FM_ROOT" "$STATE" || exit 0
 
+# --- second block reason: an unpaid captain capture receipt -------------------
+# Independent of everything below it. Work filed this turn that the captain
+# cannot name reads to them as nothing captured, so the turn boundary is the
+# last honest moment to hand over the identity (AGENTS.md section 9;
+# bin/fm-capture-receipt.sh owns the ledger and its once-per-item bound).
+# Deliberately BEFORE the supervision predicate so it needs no edit to any of
+# that path's exit points, which the Claude block-budget accounting depends on.
+# It costs supervision nothing: the receipt block forces a model continuation
+# whose own turn end re-runs this script, and under Claude the Stop-owned
+# auto-arm fires on the same event regardless of what this hook returns.
+# Skipped in a secondmate home, which never addresses the captain (hard rule 4)
+# and whose backlog receives handed-off items it must not receipt. An older home
+# without the script simply has no second block reason.
+if [ -x "$SCRIPT_DIR/fm-capture-receipt.sh" ] && ! fm_root_is_secondmate_home "$FM_ROOT"; then
+  RECEIPT_STATUS=0
+  "$SCRIPT_DIR/fm-capture-receipt.sh" guard || RECEIPT_STATUS=$?
+  if [ "$RECEIPT_STATUS" -eq 2 ]; then
+    exit 2
+  fi
+fi
+
 # --- the actual predicate ----------------------------------------------------
 # shellcheck source=bin/fm-wake-lib.sh
 . "$SCRIPT_DIR/fm-wake-lib.sh"

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -38,6 +38,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-session-lock-lib.sh` | Shared session-lock harness identity (ancestry walk and holder liveness) for fm-lock.sh and the Claude Stop auto-arm |
 | `fm-claude-stop-autoarm.sh` | Claude Stop `asyncRewake` hook owning tokenless watcher continuity with single-flight exit-2 rewake (docs/watcher-continuity.md) |
 | `fm-turnend-guard.sh`    | Shared primary turn-end guard predicate so no turn ends blind (docs/turnend-guard.md) |
+| `fm-capture-receipt.sh`  | Derive, surface, and clear the captain's named receipts for filed work (AGENTS.md section 9) |
 | `fm-turnend-guard-grok.sh` | Grok Stop-hook adapter for the primary turn-end guard                              |
 | `fm-kimi-turnend-hook.sh` | Surgically install or remove Kimi's guarded global crew turn-end hook                |
 | `fm-arm-pretool-check.sh` | Stable PreToolUse transport for the watcher-arm command policy (docs/arm-pretool-check.md) |

--- a/docs/turnend-guard.md
+++ b/docs/turnend-guard.md
@@ -41,6 +41,20 @@ Its banner names the true failing condition, either a missing live watcher proce
 `FM_GUARD_GRACE` controls beacon freshness and defaults to 300 seconds.
 If `jq` is missing or hook stdin is empty, the guard exits 0 because it cannot safely read loop-guard fields.
 
+## Second block reason: an unpaid captain capture receipt
+
+The hook has two independent reasons to block, and this doc owns only their boundary.
+Supervision is the first; the second is filed work the captain has not been given a name for, whose contract is `AGENTS.md` section 9 and whose mechanics are owned by `bin/fm-capture-receipt.sh`.
+Placing it in this script rather than in each harness integration is deliberate: every enabled primary already routes its turn end here, so one call reaches all of them and no adapter changes.
+
+The receipt check runs immediately after the shared primary scope and before the supervision predicate, which leaves every exit path of the Claude block-budget accounting untouched.
+It is skipped in a genuine secondmate home, which never addresses the captain and whose backlog receives handed-off items it must not receipt.
+A checkout without the script has no second block reason at all, so an older home degrades to supervision-only behavior.
+
+Ordering costs supervision nothing.
+A receipt block forces a model continuation whose own turn end re-runs this script, and under Claude the Stop-owned auto-arm fires on the same event regardless of what this hook returns, so recovery is never deferred by it.
+The receipt check is bounded independently of every harness loop-guard field: it blocks at most once per identity for the life of the home, recorded in the owed record itself, and a receipt it cannot mark allows the turn end rather than repeating.
+
 ## Harness integrations
 
 - Claude registers two `Stop` hooks in `.claude/settings.json`, both anchored through `CLAUDE_PROJECT_DIR`: `bin/fm-turnend-guard.sh --claude`, and `bin/fm-claude-stop-autoarm.sh` with `asyncRewake: true` and `timeout: 28800`.

--- a/tests/fm-capture-receipt.test.sh
+++ b/tests/fm-capture-receipt.test.sh
@@ -1,0 +1,321 @@
+#!/usr/bin/env bash
+# Behavior tests for the captain capture-receipt ledger (bin/fm-capture-receipt.sh).
+#
+# The contract under test is AGENTS.md section 9's receipt obligation: work the
+# captain cannot name is work they will reasonably conclude was never captured.
+# Every assertion drives the real executable over a temp home and reads its
+# public output or its observable state transitions; none inspect source text.
+#
+#   1. The obligation is DERIVED from the backlog, not declared, so filing by any
+#      route incurs it, and the first reconcile in a home owes nothing.
+#   2. Parsing is exact: indented task bodies are not items, the tasks-axi and
+#      manual item renderings both resolve, and a non-slug identity is refused
+#      rather than sanitized into a path.
+#   3. The turn-end guard blocks at most once per identity, ever, so it can nag
+#      but never wedge.
+#   4. Attestation validates every identity before clearing any, so a mistype
+#      cannot retire the wrong debt.
+#   5. An unwritable ledger allows the turn end rather than trapping the session.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+RECEIPT="$ROOT/bin/fm-capture-receipt.sh"
+TMP_ROOT=$(fm_test_tmproot fm-capture-receipt)
+
+# A home is just state/ + data/; the ledger never needs a checkout of its own.
+make_home() {  # <dir> [backlog-body] -> echoes dir
+  local dir=$1
+  mkdir -p "$dir/state" "$dir/data"
+  printf '%s' "${2-}" > "$dir/data/backlog.md"
+  printf '%s\n' "$dir"
+}
+
+receipt() {  # <home> <verb...>
+  local home=$1
+  shift
+  FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
+    bash "$RECEIPT" "$@"
+}
+
+# File an item the way any backlog write does. No mtime manipulation: the ledger
+# deliberately has no mtime fast path to defeat, so a same-second append is a
+# real case these tests exercise rather than paper over.
+file_item() {  # <home> <line>
+  printf '%s\n' "$2" >> "$1/data/backlog.md"
+}
+
+# Rewrite the backlog through an awk program. A failing program would empty the
+# backlog and turn several assertions into false passes, so it fails loudly.
+rewrite_backlog() {  # <home> <awk-program>
+  local home=$1 program=$2
+  awk "$program" "$home/data/backlog.md" > "$home/data/backlog.md.new" \
+    || fail "test helper: awk program failed: $program"
+  [ -s "$home/data/backlog.md.new" ] \
+    || fail "test helper: awk program emptied the backlog: $program"
+  mv -f "$home/data/backlog.md.new" "$home/data/backlog.md"
+}
+
+SEED_BACKLOG='# Backlog
+
+## In flight
+- [ ] apex-auth-ws-strand - Reconnect the websocket strand (repo: apex) (kind: ship) (since 2026-08-05)
+  A body paragraph that belongs to the item above.
+  - a bullet inside that body, which is prose and never an item
+
+## Queued
+- [ ] ci-no-pr-gate - Pull requests merge with no checks at all (repo: the-shop-shop)
+
+## Done
+- [x] deploy-routine-prompt-stale - Deploy prompt drifted from the repo copy (repo: the-shop-shop)
+'
+
+# --- 1. the obligation is derived, and adoption owes nothing ----------------
+
+test_first_reconcile_adopts_without_owing() {
+  local home out
+  home=$(make_home "$TMP_ROOT/adopt" "$SEED_BACKLOG")
+  out=$(receipt "$home" pending)
+  [ -z "$out" ] || fail "first reconcile in a home must owe nothing, got:"$'\n'"$out"
+  receipt "$home" active && fail "a freshly adopted home must not report an owed receipt"
+  pass "adoption: the whole pre-existing backlog is taken as already known"
+}
+
+test_new_item_becomes_an_owed_receipt() {
+  local home out
+  home=$(make_home "$TMP_ROOT/new-item" "$SEED_BACKLOG")
+  receipt "$home" reconcile
+  file_item "$home" '- [ ] apex-loading-copy - The shop front should say it is opening (repo: the-shop-shop) (kind: ship)'
+  out=$(receipt "$home" pending)
+  assert_contains "$out" 'owed: apex-loading-copy' "a newly filed item must be owed"
+  # shellcheck disable=SC2016 # Backticks are literal expected output.
+  assert_contains "$out" 'Filed as `apex-loading-copy` - The shop front should say it is opening.' \
+    "pending must hand over the exact captain-facing sentence"
+  assert_not_contains "$out" '(repo:' "the backend metadata rendering is not part of the captain's sentence"
+  assert_not_contains "$out" 'owed: ci-no-pr-gate' "an already-adopted item must not be re-owed"
+  receipt "$home" active || fail "active must report the owed receipt"
+  pass "derivation: filing an item incurs the receipt with no registration step"
+}
+
+test_done_transition_is_not_a_new_receipt() {
+  local home out
+  home=$(make_home "$TMP_ROOT/done-move" "$SEED_BACKLOG")
+  receipt "$home" reconcile
+  # The same identity moving Queued -> Done is a state change, not new work.
+  rewrite_backlog "$home" '{ sub(/^- \[ \] ci-no-pr-gate/, "- [x] ci-no-pr-gate"); print }'
+  out=$(receipt "$home" pending)
+  [ -z "$out" ] || fail "a checkbox transition must not owe a receipt, got:"$'\n'"$out"
+  pass "derivation: completing an item is not filing a new one"
+}
+
+test_departed_item_stops_being_a_debt() {
+  local home out
+  home=$(make_home "$TMP_ROOT/departed" "$SEED_BACKLOG")
+  receipt "$home" reconcile
+  file_item "$home" '- [ ] transient-item - Filed then withdrawn'
+  out=$(receipt "$home" pending)
+  assert_contains "$out" 'owed: transient-item' "precondition: the item must first be owed"
+  rewrite_backlog "$home" '!/^- \[ \] transient-item/ { print }'
+  out=$(receipt "$home" pending)
+  [ -z "$out" ] || fail "an item that left the backlog must stop being a debt, got:"$'\n'"$out"
+  pass "prune: work removed from the backlog carries no residual receipt"
+}
+
+# --- 2. parsing is exact ----------------------------------------------------
+
+test_body_bullets_are_never_items() {
+  local home out
+  home=$(make_home "$TMP_ROOT/body" "$SEED_BACKLOG")
+  out=$(receipt "$home" pending)
+  # Adoption is silent, so prove the body bullet never became a tracked identity
+  # by checking it is absent from the baseline the adoption just wrote.
+  assert_no_grep 'a bullet inside that body' "$home/state/capture-receipts/baseline" \
+    "an indented body bullet must never be parsed as a backlog item"
+  assert_grep 'apex-auth-ws-strand' "$home/state/capture-receipts/baseline" \
+    "the real in-flight item must be adopted"
+  assert_grep 'deploy-routine-prompt-stale' "$home/state/capture-receipts/baseline" \
+    "a Done item must be adopted so it can never be re-owed later"
+  pass "parse: only column-0 item lines are items"
+}
+
+test_manual_backend_rendering_resolves() {
+  local home out
+  home=$(make_home "$TMP_ROOT/manual" "$SEED_BACKLOG")
+  receipt "$home" reconcile
+  # The manual backlog path writes items without a checkbox.
+  file_item "$home" '- manual-filed-item - Written by hand rather than by the tool'
+  out=$(receipt "$home" pending)
+  assert_contains "$out" 'owed: manual-filed-item' \
+    "an unchecked manual item line must resolve to an identity"
+  pass "parse: the manual backend's unchecked rendering is an item too"
+}
+
+test_non_slug_identities_are_refused() {
+  local home out
+  home=$(make_home "$TMP_ROOT/slug" "$SEED_BACKLOG")
+  receipt "$home" reconcile
+  file_item "$home" '- [ ] ../../escape - a traversal attempt'
+  printf -- '- [ ] two words - a spaced identity\n' >> "$home/data/backlog.md"
+  out=$(receipt "$home" pending)
+  [ -z "$out" ] || fail "a non-slug identity must be refused, got:"$'\n'"$out"
+  assert_absent "$TMP_ROOT/slug/state/capture-receipts/owed/../../escape" \
+    "a traversal identity must never resolve to a path outside owed/"
+  [ "$(find "$home/state/capture-receipts/owed" -type f | wc -l)" -eq 0 ] \
+    || fail "no owed record may be created from a refused identity"
+  pass "parse: an identity that is not a slug is skipped, never sanitized"
+}
+
+# --- 3. the guard nags but cannot wedge -------------------------------------
+
+test_guard_blocks_once_per_identity() {
+  local home out status
+  home=$(make_home "$TMP_ROOT/guard-once" "$SEED_BACKLOG")
+  receipt "$home" reconcile
+
+  out=$(receipt "$home" guard 2>&1); status=$?
+  expect_code 0 "$status" "guard with nothing owed"
+  [ -z "$out" ] || fail "guard must be silent with nothing owed, got:"$'\n'"$out"
+
+  file_item "$home" '- [ ] apex-loading-copy - The shop front should say it is opening'
+  out=$(receipt "$home" guard 2>&1); status=$?
+  expect_code 2 "$status" "guard with an unsurfaced receipt"
+  assert_contains "$out" 'THE CAPTAIN HAS NOT BEEN TOLD WHAT THIS WAS FILED AS' \
+    "the block must name the failure in the captain's terms"
+  # shellcheck disable=SC2016 # Backticks are literal expected output.
+  assert_contains "$out" 'Filed as `apex-loading-copy`' \
+    "the block must hand over the sentence, not ask firstmate to compose one"
+  assert_contains "$out" 'fm-capture-receipt.sh delivered apex-loading-copy' \
+    "the block must carry the exact command that clears it"
+
+  out=$(receipt "$home" guard 2>&1); status=$?
+  expect_code 0 "$status" "second turn end for the same identity"
+  [ -z "$out" ] || fail "the same identity must never block twice, got:"$'\n'"$out"
+
+  receipt "$home" active || fail "an ignored block must leave the debt owed, not clear it"
+  pass "guard: blocks once per identity, then leaves the debt to the session digest"
+}
+
+test_guard_blocks_each_identity_once() {
+  local home out status
+  home=$(make_home "$TMP_ROOT/guard-many" "$SEED_BACKLOG")
+  receipt "$home" reconcile
+  file_item "$home" '- [ ] first-thing - The first thing'
+  out=$(receipt "$home" guard 2>&1); status=$?
+  expect_code 2 "$status" "first identity blocks"
+  file_item "$home" '- [ ] second-thing - The second thing'
+  out=$(receipt "$home" guard 2>&1); status=$?
+  expect_code 2 "$status" "a later, separate filing blocks on its own"
+  assert_contains "$out" 'second-thing' "the new identity must be named"
+  assert_not_contains "$out" 'first-thing' \
+    "an already-surfaced identity must not be repeated in a later block"
+  pass "guard: a fresh filing still blocks, an already-surfaced one never repeats"
+}
+
+test_pending_marks_an_already_surfaced_receipt() {
+  local home out
+  home=$(make_home "$TMP_ROOT/surfaced" "$SEED_BACKLOG")
+  receipt "$home" reconcile
+  file_item "$home" '- [ ] apex-loading-copy - The shop front should say it is opening'
+  receipt "$home" guard >/dev/null 2>&1
+  out=$(receipt "$home" pending)
+  assert_contains "$out" 'already surfaced once at a turn end' \
+    "the digest must distinguish a debt that has already had its one block"
+  pass "pending: an already-surfaced debt is disclosed as such"
+}
+
+# --- 4. attestation is all-or-nothing ---------------------------------------
+
+test_mistyped_identity_clears_nothing() {
+  local home out status
+  home=$(make_home "$TMP_ROOT/mistype" "$SEED_BACKLOG")
+  receipt "$home" reconcile
+  file_item "$home" '- [ ] apex-loading-copy - The shop front should say it is opening'
+  receipt "$home" pending >/dev/null
+
+  out=$(receipt "$home" delivered apex-loading-copy apex-loading-copyy 2>&1); status=$?
+  expect_code 1 "$status" "attesting a mix of real and mistyped identities"
+  assert_contains "$out" 'no receipt is owed for apex-loading-copyy' \
+    "the refusal must name the identity it could not find"
+  receipt "$home" active \
+    || fail "a refused attestation must clear nothing, including the valid identity"
+
+  out=$(receipt "$home" delivered apex-loading-copy 2>&1); status=$?
+  expect_code 0 "$status" "attesting the real identity"
+  receipt "$home" active && fail "a correct attestation must clear the debt"
+  out=$(receipt "$home" guard 2>&1); status=$?
+  expect_code 0 "$status" "guard after a delivered receipt"
+  pass "delivered: validates every identity before clearing any"
+}
+
+test_delivered_requires_an_identity() {
+  local status
+  local home
+  home=$(make_home "$TMP_ROOT/no-arg" "$SEED_BACKLOG")
+  receipt "$home" delivered >/dev/null 2>&1; status=$?
+  expect_code 2 "$status" "delivered with no identity"
+  pass "delivered: refuses a bare invocation rather than clearing everything"
+}
+
+# --- 5. failure direction ---------------------------------------------------
+
+test_absent_backlog_is_inert() {
+  local home out status
+  home=$(mktemp -d "$TMP_ROOT/no-backlog.XXXX")
+  mkdir -p "$home/state"
+  out=$(receipt "$home" guard 2>&1); status=$?
+  expect_code 0 "$status" "guard in a home with no backlog at all"
+  [ -z "$out" ] || fail "a home with no backlog must be silent, got:"$'\n'"$out"
+  assert_absent "$home/state/capture-receipts" \
+    "a home with no backlog must not have a ledger created for it"
+  pass "inert: a home with no backlog costs nothing and creates nothing"
+}
+
+test_unwritable_ledger_allows_the_turn_end() {
+  local home out status
+  if [ "$(id -u)" -eq 0 ]; then
+    pass "fail direction: unwritable-ledger case skipped (root ignores mode bits)"
+    return 0
+  fi
+  home=$(make_home "$TMP_ROOT/readonly" "$SEED_BACKLOG")
+  receipt "$home" reconcile
+  file_item "$home" '- [ ] apex-loading-copy - The shop front should say it is opening'
+  receipt "$home" reconcile
+  assert_present "$home/state/capture-receipts/owed/apex-loading-copy" \
+    "precondition: the receipt must exist before the ledger is frozen"
+  chmod 500 "$home/state/capture-receipts" "$home/state/capture-receipts/owed"
+  out=$(receipt "$home" guard 2>&1); status=$?
+  chmod 700 "$home/state/capture-receipts" "$home/state/capture-receipts/owed"
+  expect_code 0 "$status" "guard against a ledger it cannot mark"
+  [ -z "$out" ] || fail "an unmarkable block must stay silent rather than repeat forever"
+  pass "fail direction: a ledger that cannot record the block never traps the session"
+}
+
+test_first_reconcile_after_adoption_survives_a_restart() {
+  local home out
+  home=$(make_home "$TMP_ROOT/restart" "$SEED_BACKLOG")
+  receipt "$home" reconcile
+  file_item "$home" '- [ ] apex-loading-copy - The shop front should say it is opening'
+  receipt "$home" guard >/dev/null 2>&1
+  # A new session reads the same disk; the debt is durable, not conversational.
+  out=$(receipt "$home" pending)
+  assert_contains "$out" 'owed: apex-loading-copy' \
+    "an unpaid receipt must survive the session that incurred it"
+  pass "durability: an unpaid receipt outlives the turn and the session"
+}
+
+test_first_reconcile_adopts_without_owing
+test_new_item_becomes_an_owed_receipt
+test_done_transition_is_not_a_new_receipt
+test_departed_item_stops_being_a_debt
+test_body_bullets_are_never_items
+test_manual_backend_rendering_resolves
+test_non_slug_identities_are_refused
+test_guard_blocks_once_per_identity
+test_guard_blocks_each_identity_once
+test_pending_marks_an_already_surfaced_receipt
+test_mistyped_identity_clears_nothing
+test_delivered_requires_an_identity
+test_absent_backlog_is_inert
+test_unwritable_ledger_allows_the_turn_end
+test_first_reconcile_after_adoption_survives_a_restart

--- a/tests/fm-session-start.test.sh
+++ b/tests/fm-session-start.test.sh
@@ -713,6 +713,41 @@ EOF
   pass "context digest distinguishes ABSENT, empty-but-present, and populated files"
 }
 
+# --- captain receipts owed ---------------------------------------------------
+# The turn-end guard surfaces each unpaid receipt exactly once, so a receipt that
+# outlived that block - the session ended, compacted, or restarted - has only the
+# digest left to raise it. bin/fm-capture-receipt.sh owns the ledger itself;
+# this covers the digest's gate and its rendering.
+
+test_captain_receipts_owed_subsection() {
+  local rec root home fakebin out
+  rec=$(new_world captain-receipts)
+  IFS='|' read -r root home fakebin <<EOF
+$rec
+EOF
+  make_fake_toolchain "$fakebin"
+  make_fake_ps_claude "$fakebin"
+  printf '%s\n' manual > "$home/config/backlog-backend"
+
+  printf '# Backlog\n\n## Queued\n- [ ] already-known - Filed long ago\n' > "$home/data/backlog.md"
+  out=$(run_session_start "$home" "$root" "$fakebin:$BASE_PATH")
+  assert_not_contains "$out" "Captain receipts owed" \
+    "an adopted backlog owes nothing, so the subsection must not render"
+
+  printf -- '- [ ] apex-loading-copy - The shop front should say it is opening\n' \
+    >> "$home/data/backlog.md"
+  out=$(run_session_start "$home" "$root" "$fakebin:$BASE_PATH")
+  assert_contains "$out" "Captain receipts owed" \
+    "an unpaid receipt must surface in the digest"
+  # shellcheck disable=SC2016 # Backticks are literal expected output.
+  assert_contains "$out" 'Filed as `apex-loading-copy`' \
+    "the digest must carry the sentence, not just the identity"
+  assert_contains "$out" "fm-capture-receipt.sh delivered" \
+    "the digest must name how to clear the debt"
+
+  pass "session start: unpaid captain receipts surface, an adopted backlog stays silent"
+}
+
 # --- lock refusal: read-only path --------------------------------------------
 
 test_lock_refusal_read_only_path() {
@@ -2181,6 +2216,7 @@ EOF
 }
 
 test_context_digest_absent_empty_present
+test_captain_receipts_owed_subsection
 test_lock_refusal_read_only_path
 test_lock_write_failure_read_only_path
 test_trace_context_effective_state_is_frozen_after_lock

--- a/tests/fm-turnend-guard.test.sh
+++ b/tests/fm-turnend-guard.test.sh
@@ -115,9 +115,26 @@ install_guard_scripts() {
   cp "$ROOT/bin/fm-primary-scope-lib.sh" "$dir/bin/fm-primary-scope-lib.sh"
   cp "$ROOT/bin/fm-supervision-lib.sh" "$dir/bin/fm-supervision-lib.sh"
   cp "$ROOT/bin/fm-wake-lib.sh" "$dir/bin/fm-wake-lib.sh"
+  cp "$ROOT/bin/fm-capture-receipt.sh" "$dir/bin/fm-capture-receipt.sh"
   mkdir -p "$dir/docs"
   cp -R "$ROOT/docs/supervision-protocols" "$dir/docs/supervision-protocols"
-  chmod +x "$dir/bin/fm-turnend-guard.sh" "$dir/bin/fm-turnend-guard-grok.sh" "$dir/bin/fm-operational-input.sh" "$dir/bin/fm-supervision-instructions.sh" "$dir/bin/fm-harness.sh"
+  chmod +x "$dir/bin/fm-turnend-guard.sh" "$dir/bin/fm-turnend-guard-grok.sh" "$dir/bin/fm-operational-input.sh" "$dir/bin/fm-supervision-instructions.sh" "$dir/bin/fm-harness.sh" "$dir/bin/fm-capture-receipt.sh"
+}
+
+# Give a fixture home a backlog whose items are already adopted, so only what a
+# test files afterwards can owe a receipt. Every fixture WITHOUT this call has no
+# data/backlog.md at all, which is why the capture-receipt check stays inert
+# across the whole supervision suite.
+seed_adopted_backlog() {  # <dir>
+  local dir=$1
+  mkdir -p "$dir/data"
+  printf '# Backlog\n\n## Queued\n- [ ] already-known - Filed long before this turn\n' \
+    > "$dir/data/backlog.md"
+  FM_HOME="$dir" bash "$dir/bin/fm-capture-receipt.sh" reconcile
+}
+
+file_backlog_item() {  # <dir> <identity> <title>
+  printf -- '- [ ] %s - %s\n' "$2" "$3" >> "$1/data/backlog.md"
 }
 
 mark_codex_hook_root() {
@@ -360,6 +377,76 @@ test_hook_blocks_when_unhealthy_in_primary() {
   assert_contains "$out" "$REQUIRED_REASON" "block reason must contain the exact required instruction"
   assert_contains "$out" "TURN WOULD END BLIND" "block banner must read as an alarm"
   pass "fm-turnend-guard: blocks with the exact required reason in the primary when unhealthy"
+}
+
+# --- second block reason: unpaid captain capture receipts -------------------
+# The ledger's own behavior is owned by tests/fm-capture-receipt.test.sh; these
+# cover only what the hook adds - that the check reaches the same scoped primary
+# the supervision predicate does, and that neither reason weakens the other.
+
+test_hook_blocks_on_unpaid_capture_receipt() {
+  local dir out status
+  dir=$(make_primary_dir "$TMP_ROOT/hook-receipt")
+  seed_adopted_backlog "$dir"
+  out=$(run_hook "$dir" false); status=$?
+  expect_code 0 "$status" "an adopted backlog with no supervision need must not block"
+
+  file_backlog_item "$dir" apex-loading-copy 'The shop front should say it is opening'
+  out=$(run_hook "$dir" false); status=$?
+  expect_code 2 "$status" "hook must block when filed work has no captain receipt"
+  assert_contains "$out" "THE CAPTAIN HAS NOT BEEN TOLD WHAT THIS WAS FILED AS" \
+    "receipt block banner must read as its own alarm"
+  # shellcheck disable=SC2016 # Backticks are literal expected output.
+  assert_contains "$out" 'Filed as `apex-loading-copy`' \
+    "the block must hand over the captain-facing sentence"
+  assert_not_contains "$out" "TURN WOULD END BLIND" \
+    "a receipt block must not masquerade as a supervision block"
+
+  out=$(run_hook "$dir" false); status=$?
+  expect_code 0 "$status" "the same receipt must never block a second turn end"
+  pass "fm-turnend-guard: blocks once on an unpaid capture receipt, in a healthy primary"
+}
+
+test_hook_receipt_block_does_not_displace_supervision() {
+  local dir out status
+  dir=$(make_primary_dir "$TMP_ROOT/hook-receipt-and-supervision")
+  seed_adopted_backlog "$dir"
+  : > "$dir/state/task1.meta"
+  file_backlog_item "$dir" apex-loading-copy 'The shop front should say it is opening'
+
+  # Both reasons are live. The receipt block comes first and forces a
+  # continuation; supervision is not skipped, only deferred to that turn's end.
+  out=$(run_hook "$dir" false); status=$?
+  expect_code 2 "$status" "the receipt must block while it is still unsurfaced"
+  assert_contains "$out" "THE CAPTAIN HAS NOT BEEN TOLD WHAT THIS WAS FILED AS" \
+    "the receipt is the first of the two reasons to fire"
+
+  out=$(run_hook "$dir" false); status=$?
+  expect_code 2 "$status" "supervision must still block once the receipt has been surfaced"
+  assert_contains "$out" "TURN WOULD END BLIND" "the supervision alarm must follow, not be lost"
+  assert_contains "$out" "$REQUIRED_REASON" "supervision's exact required instruction must survive"
+  pass "fm-turnend-guard: a receipt block defers the supervision block, never replaces it"
+}
+
+test_hook_never_owes_captain_receipts_in_secondmate_home() {
+  local dir out status
+  dir=$(make_secondmate_dir "$TMP_ROOT/hook-receipt-secondmate")
+  seed_adopted_backlog "$dir"
+  file_backlog_item "$dir" handed-off-item 'Routed in from the main home'
+  out=$(run_hook "$dir" false); status=$?
+  expect_code 0 "$status" "a secondmate home must not block on a captain receipt"
+  [ -z "$out" ] || fail "secondmate receipt check must be silent, got:"$'\n'"$out"
+  pass "fm-turnend-guard: a secondmate never owes the captain a receipt (hard rule 4)"
+}
+
+test_hook_capture_receipt_inert_without_a_backlog() {
+  local dir out status
+  dir=$(make_primary_dir "$TMP_ROOT/hook-receipt-no-backlog")
+  out=$(run_hook "$dir" false); status=$?
+  expect_code 0 "$status" "a primary with no backlog must not block"
+  assert_absent "$dir/state/capture-receipts" \
+    "no ledger may be created in a home that has no backlog"
+  pass "fm-turnend-guard: the receipt check creates nothing in a home with no backlog"
 }
 
 test_hook_blocks_from_fm_home_state() {
@@ -1556,6 +1643,10 @@ test_hook_x_mode_only_blocks_in_default_mode
 test_hook_ignores_repo_state_when_fm_home_set
 test_hook_uses_state_override
 test_hook_loop_guard_allows_retry
+test_hook_blocks_on_unpaid_capture_receipt
+test_hook_receipt_block_does_not_displace_supervision
+test_hook_never_owes_captain_receipts_in_secondmate_home
+test_hook_capture_receipt_inert_without_a_backlog
 test_hook_blocks_in_secondmate_own_home
 test_hook_silent_in_idle_secondmate_home
 test_hook_secondmate_loop_guard_allows_retry


### PR DESCRIPTION
## The failure this fixes is not storage

On 2026-08-06 the captain answered four decisions. All four were recorded, routed and filed, one carrying their verbatim wording into a decision record on disk. Storage worked perfectly. The captain still concluded, reasonably, that nothing had been captured.

Twice in two days, the same shape:

1. Firstmate stated three options once inside a long message, then referred to "A, B and C" for two hours as though the captain had them in view. The terminal had scrolled; they did not.
2. Asked "what's the task number for this piece of work", firstmate led with "it has no number yet" and explained two numbering systems. The task existed, had existed since the previous day, and carried the captain's own words.

Both times the information existed. Both times firstmate answered from **its own view of state**, which the captain cannot see, and the answer made a present thing look absent.

So this PR adds nothing that writes another record. It makes the record's **name** reach the captain.

## Candidates considered, and why the chosen one holds

The task offered three shapes. All three are here, but only one of them is load-bearing, and the ordering matters.

**A stated obligation in `AGENTS.md` section 9 (added).** Necessary as the discovery layer - without it nothing tells firstmate the tool exists - but insufficient on its own, and it is the weakest class of fix available. An equivalent rule already exists in one home's private preferences, and a rule that lives only there is exactly the drift this repo keeps paying for. It cannot be the answer by itself.

**A captain-facing rendering (`/bearings` - deliberately unchanged).** The task asked whether the gap is the tool or the pointing. **It is neither: it is the moment.** `/bearings` is already good and already renders newly filed work under Charted Next, so there is nothing to rebuild. But it is invoked *by the captain*, and the captain's requirement is that they not have to ask - asking is the step that failed. `/bearings` serves catch-up after a break. It cannot serve the instant an instruction is given, which is where both failures happened. No changes made to it.

**A turn-end check (added, but not in the form proposed).** The proposed form compares "captain-instruction content in the turn" against backlog mutations. That would be a natural-language classifier at a safety boundary: unprovable, and it would fire on every conversational turn until firstmate learned to dismiss it. The predicate here is deterministic instead - *a backlog identity exists now that did not exist before* - so it fires only when a receipt is genuinely owed and never on a turn that filed nothing.

### What actually carries the fix

The strongest prior art in this repo is `fm-send --resolve-key`: it closes a decision *at answer time* rather than relying on the worker to remember a closing line afterwards. Bookkeeping as a side effect of the action, not a separate skippable step. The task rightly warns that a receipt firstmate must remember to type is the weakest class of fix.

So the obligation is **derived, never declared**. `bin/fm-capture-receipt.sh` reads the home's own `data/backlog.md` and compares its identity set against a durable baseline. An identity that was not there before is a receipt the captain is owed - whoever filed it, and however. There is no `register` verb, deliberately: "remember to declare it" is the same class of step that already failed.

Three parts, each closing a hole the others leave:

| Part | Closes |
| --- | --- |
| The ledger hands over the exact sentence | Firstmate pastes a name instead of composing one from its own view of state |
| The turn-end guard blocks while a receipt is unsurfaced | A receipt that was never composed at all |
| Session start re-surfaces what is still owed | A receipt lost to compaction, a restart, or an ignored block |

## What this cannot do, stated plainly

Captain-facing chat has no tool boundary, so **no hook can confirm the sentence actually reached the captain**. `delivered <identity>` is an attestation, and running it without having named the identity is a false statement to the captain rather than a shortcut. Verifying the last mile would mean parsing a harness transcript format - vendor-specific across the six supported primaries and fragile - so it is deliberately not attempted. The guard closes the much larger hole; this residue is named rather than papered over.

## Safety properties

- **Cannot wedge a session.** The guard blocks *at most once per identity, ever*, recorded in the owed record rather than a session counter. N filings cost at most N forced continuations across the life of the home. A firstmate that ignores the block is not re-blocked; the debt stays owed and resurfaces at session start.
- **Independent of harness loop-guard semantics.** That bound holds identically on every primary without relying on `stop_hook_active` or its variants.
- **No new harness-dependent signal.** The check lives inside `bin/fm-turnend-guard.sh`, which every enabled primary already routes its turn end through, and reuses the existing proven exit-2 contract. One integration point reaches all six harnesses; no adapter changed.
- **Supervision is untouched.** The check sits before the supervision predicate precisely so no exit path of the Claude block-budget accounting is edited. A receipt block defers the supervision block by one model turn and never replaces it - and under Claude the Stop-owned auto-arm fires on the same event regardless, so recovery is not delayed at all. All 63 pre-existing turn-end cases pass unchanged.
- **Fails in the safe direction.** A ledger it cannot mark allows the turn end rather than refusing every turn from then on. A mistyped identity is refused *before* anything is cleared, so it cannot retire the wrong debt.
- **Scoped to the main home.** A secondmate never addresses the captain and its backlog receives handed-off items it must not receipt, so the check is skipped there. A home with no `data/backlog.md` creates nothing.
- **Adoption owes nothing.** The first reconcile in a home takes the whole existing backlog as already known, so this never lands claiming an entire backlog as unpaid debt - which matters because the delivery posture is upstream-PR-only and homes adopt this whenever they next pull.

## Deliberate non-optimisation

There is no mtime fast path. Skipping the parse when the backlog "looks unchanged" is the obvious optimisation and it is wrong here: a filing whose write lands in the same whole second as the previous reconcile leaves mtime identical, so the receipt would be silently skipped until some later edit happened to move the clock. A missed receipt is the exact failure this exists to prevent. This was caught by a test, not by review.

## Incidental fix: the test coverage guard was broken

`bin/fm-test-run.sh --check-coverage` fails on the pristine base commit (verified by stashing all changes and re-running at `70aeba8`). Every list is written with `LC_ALL=C sort`, but every `comm` ran in the ambient locale, so the set arithmetic compared C-collated input under different collation rules - reporting a wrong missing/extra set rather than failing honestly. Fixed by running `comm` under the same collation. It is included here rather than split out because it is the guard that verifies this PR's own new test file is covered by a lane; with it broken, that could not be checked. The guard now passes and reports `total=131 parallel=24 serial=96 serial_shards=4 herdr=11`.

## Verification

- `tests/fm-capture-receipt.test.sh` - 15 new cases: derivation, adoption owing nothing, exact parsing (indented task bodies are not items; both backend renderings resolve; a non-slug identity is refused rather than sanitized into a path), once-per-identity blocking, all-or-nothing attestation, and the unwritable-ledger fail direction.
- `tests/fm-turnend-guard.test.sh` - 4 new integration cases, 67 total passing. Explicitly covers that a receipt block defers the supervision block rather than replacing it.
- `tests/fm-session-start.test.sh` - 1 new case, 44 total passing.
- Portable parallel lanes 1 and 2: pass, no failures.
- Portable serial lane: all 96 suites ran; `tests/fm-capture-receipt.test.sh` passed inside it (`exit=0`). Three suites failed, all pre-existing - see below.
- `bin/fm-lint.sh`: clean. `bin/fm-doc-audience-check.sh`: `ok surfaces=65 local_links=212`.

### Three pre-existing failures, reported rather than folded in

Each was re-run standalone on this branch and then on the pristine base commit `70aeba8` with no changes present. All three fail identically on untouched main, at the same assertion, so none is a regression from this work:

| Suite | Failing assertion | Reproduces on `70aeba8` |
| --- | --- | --- |
| `fm-bootstrap` | `backend=orca should require only the Orca-specific missing tool` | yes |
| `fm-pi-watch-extension` | `OpenCode watch plugin must arm only when this session owns the fleet lock` | yes |
| `fm-remote-backlog-handoff` | `remote atomic receipt did not deliver ios-a before the dropped acknowledgement` | yes |

The `fm-bootstrap` one has a clear host-dependent cause worth recording: the case asserts bootstrap reports `MISSING: orca`, but it relies on the host having no binary called `orca`. On this machine `/usr/bin/orca` exists and is the **GNOME screen reader**, unrelated to the Orca runtime backend, so bootstrap correctly reports nothing missing and the assertion sees empty output. Any Linux desktop with the accessibility tool installed reproduces it; the case should stub an absent `orca` rather than depend on the host lacking that name.

None is fixed here. They belong to the bootstrap, OpenCode-watcher, and remote-handoff surfaces respectively, and folding unrelated repairs into a captain-etiquette change would obscure both.

## Propagation

This reaches a running home only when upstream merges and that home pulls, which is why the interim rule already lives in `data/captain.md`. Nothing here assumes instant propagation: a home without the script simply has no second block reason, and adopting it is silent.
