### PR TITLE
fix(bin): restore project-less remote seeding on macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -321,12 +321,12 @@ jobs:
           if-no-files-found: warn
 
   macos-stock-bash:
-    name: Stock macOS Bash snapshot compatibility
+    name: Stock macOS Bash compatibility
     runs-on: macos-latest
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
-      - name: Run snapshot consumers with stock Bash
+      - name: Run compatibility paths with stock Bash
         shell: /bin/bash {0}
         env:
           PATH: /bin:/usr/bin:/usr/sbin:/sbin:/usr/local/bin:/opt/homebrew/bin
@@ -346,6 +346,14 @@ jobs:
             /bin/bash -n "$f" || { echo "::error::stock macOS Bash 3.2 failed to parse $f"; parse_fail=1; }
           done < "$shell_inventory"
           [ "$parse_fail" -eq 0 ] || { echo "::error::stock macOS Bash 3.2 parse sweep failed"; exit 1; }
+
+          remote_seed_output=$(FM_TEST_SEED_ONLY=1 /bin/bash tests/fm-remote-secondmate-lifecycle-e2e.test.sh)
+          printf '%s\n' "$remote_seed_output"
+          remote_seed_count=$(printf '%s\n' "$remote_seed_output" | grep -c '^ok - ')
+          [ "$remote_seed_count" -eq 2 ] || {
+            echo "::error::expected 2 remote project-less seed tests, got $remote_seed_count"
+            exit 1
+          }
 
           snapshot_output=$(/bin/bash tests/fm-fleet-snapshot-view.test.sh)
           printf '%s\n' "$snapshot_output"

--- a/bin/fm-remote-home-seed.sh
+++ b/bin/fm-remote-home-seed.sh
@@ -157,7 +157,9 @@ done < "$BRIEF" > "$TMP/charter.remote"
 PROJECTS_CSV=
 : > "$TMP/project.records"
 PROJECT_INDEX=0
-for project in "${PROJECT_NAMES[@]}"; do
+# Stock macOS Bash 3.2 treats an empty array expansion as unbound under set -u.
+# The + form keeps --no-projects as zero iterations without weakening nounset.
+for project in ${PROJECT_NAMES[@]+"${PROJECT_NAMES[@]}"}; do
   ORIGIN=${PROJECT_ORIGINS[$PROJECT_INDEX]}
   PROJECT_INDEX=$((PROJECT_INDEX + 1))
   MODE_LINE=$(FM_HOME="$FM_HOME" FM_DATA_OVERRIDE="$DATA" "$SCRIPT_DIR/fm-project-mode.sh" "$project")

--- a/docs/remote-secondmates.md
+++ b/docs/remote-secondmates.md
@@ -226,7 +226,7 @@ No generic remote delete or write surface exists: remote writes are confined to 
 ## Verification
 
 The portable tests use the real entrypoint protocol, real git repositories, a deterministic SSH boundary, a stateful host-local Herdr CLI fixture, and a controlled account fixture for the readiness gate.
-The lifecycle test covers seeding a registered project that this machine has never cloned, asserts that the local project tree is unchanged afterwards, and carries Bitbucket, self-hosted, and scp-like origins through to the remote clone:
+The lifecycle test covers project-less readiness, transactional rollback and serialized publication under stock macOS Bash, plus seeding a registered project that this machine has never cloned without changing the local project tree and carrying Bitbucket, self-hosted, and scp-like origins through to the remote clone:
 
 ```sh
 bin/fm-test-run.sh tests/fm-on.test.sh

--- a/tests/fm-remote-secondmate-lifecycle-e2e.test.sh
+++ b/tests/fm-remote-secondmate-lifecycle-e2e.test.sh
@@ -302,6 +302,7 @@ seed_env() {
 }
 
 REAL_GIT=$(command -v git)
+REAL_SLEEP=$(command -v sleep)
 cat > "$FAKEBIN/git" <<SH
 #!/usr/bin/env bash
 if [ "\${1:-}" = clone ] && [ "\${!#}" = "$TMP_ROOT/concurrent-home" ]; then
@@ -314,6 +315,14 @@ fi
 exec "$REAL_GIT" "\$@"
 SH
 chmod +x "$FAKEBIN/git"
+cat > "$FAKEBIN/sleep" <<SH
+#!/usr/bin/env bash
+if [ "\${1:-}" = 0.1 ] && [ -n "\${FM_TEST_LOCK_WAIT_MARKER:-}" ]; then
+  : > "\$FM_TEST_LOCK_WAIT_MARKER"
+fi
+exec "$REAL_SLEEP" "\$@"
+SH
+chmod +x "$FAKEBIN/sleep"
 printf 'schema=fm-remote-home-provision.v1\nid_b64=%s\ncharter_b64=%s\nproject_count=0\n' \
   "$(printf ios | base64 | tr -d '\n')" \
   "$(printf 'Concurrent provisioning charter.\n' | base64 | tr -d '\n')" \
@@ -362,12 +371,23 @@ while [ ! -f "$TMP_ROOT/seed.entered" ]; do
   [ "$seed_wait" -le 250 ] || fail "failing seed never reached remote provisioning"
   sleep 0.02
 done
+[ "$(cat "$DOCTOR_LOG")" = 'provision-block-fail -' ] \
+  || fail "project-less seed reached provisioning without one successful readiness check"
 FM_SECONDMATE_CHARTER='Successful seed charter.' FM_SECONDMATE_SCOPE='successful seed' \
+  FM_TEST_LOCK_WAIT_MARKER="$TMP_ROOT/seed-lock-waiting" PATH="$FAKEBIN:$PATH" \
   seed_env "$ROOT/bin/fm-remote-home-seed.sh" seed-keep remote-mac "$REMOTE_ROOT" \
   "$TMP_ROOT/seed-keep-home" --no-projects > "$TMP_ROOT/seed-keep.out" 2>&1 &
 seed_keep_pid=$!
-sleep 0.2
-kill -0 "$seed_keep_pid" 2>/dev/null || fail "competing seed bypassed the shared registry transaction"
+seed_lock_wait=0
+while [ ! -f "$TMP_ROOT/seed-lock-waiting" ]; do
+  kill -0 "$seed_keep_pid" 2>/dev/null \
+    || fail "competing seed exited before waiting on the shared registry transaction"
+  seed_lock_wait=$((seed_lock_wait + 1))
+  [ "$seed_lock_wait" -le 250 ] || fail "competing seed never waited on the shared registry transaction"
+  sleep 0.02
+done
+[ "$(cat "$DOCTOR_LOG")" = 'provision-block-fail -' ] \
+  || fail "competing seed passed readiness before acquiring the shared registry transaction"
 touch "$TMP_ROOT/seed.release"
 if wait "$seed_fail_pid"; then
   fail "known-failing seed unexpectedly succeeded"
@@ -377,6 +397,10 @@ assert_no_grep '- seed-fail ' "$TMP_ROOT/seed-parent/data/secondmates.md" "faile
 assert_grep '- seed-keep ' "$TMP_ROOT/seed-parent/data/secondmates.md" "failed seed rollback removed a competing successful route"
 assert_present "$TMP_ROOT/seed-keep-home/.fm-secondmate-home" "serialized seed lost its published remote home"
 pass "remote seed rollback preserves serialized competing routes"
+if [ "${FM_TEST_SEED_ONLY:-0}" = 1 ]; then
+  echo "ALL TESTS PASSED"
+  exit 0
+fi
 
 : > "$DOCTOR_LOG"
 if FM_SECONDMATE_CHARTER='Unknown readiness charter.' FM_SECONDMATE_SCOPE='unknown readiness' \


### PR DESCRIPTION
## Intent

Repair Firstmate's remote project-less secondmate provisioning regression. The operator-facing path bin/fm-remote-home-seed.sh ... --no-projects must pass readiness, reach remote provisioning, and either publish a valid project-less home or roll back according to the injected remote outcome. Diagnose before assigning cause by separating the initiating trigger, any timing or fixture masking condition, and the visible early-exit symptom; compare with a successful project-bearing or equivalent remote seed path, inspect relevant history, test the smallest causal counterfactual, and seek disconfirming evidence rather than blaming the recently added parent binding. Implement the narrowest robust correction in the authoritative owner while preserving transactionality, remote unknown-completion handling, supplied-origin behavior, durable parent-binding publication order, and non-mutation of the local project tree. Turn the faithful lifecycle reproduction into executable regression coverage, including deterministic timing and concurrency assertions without sleeps that hide races. Validate the full remote lifecycle and parent-binding suites, all directly affected tests, shell lint, and documentation checks. Do not modify or rely on private secondmate-home parent records in the primary fleet. Drive no-mistakes through CI green and report the full PR URL.

## What Changed

- Make project-less remote home seeding compatible with stock macOS Bash 3.2 by safely iterating an empty project array.
- Add deterministic lifecycle coverage for readiness, transactional rollback, and concurrent registry publication without timing sleeps that mask races.
- Exercise the project-less seed regression in the macOS compatibility CI job and document the expanded lifecycle coverage.

## Risk Assessment

✅ Low: The Bash 3.2-safe empty-array expansion narrowly restores the project-less path while preserving project-bearing behavior, transactionality, readiness ordering, rollback semantics, and unknown-completion handling; the focused lifecycle coverage also replaces the affected race-masking delay with observable lock-wait synchronization.

## Testing

Under Apple Bash 3.2, the operator-facing `--no-projects` path passed readiness and reached remote provisioning; deterministic contention exercised rollback and successful publication, while the full remote lifecycle, supplied-origin/non-mutation behavior, unknown-completion handling, durable parent-binding order, and trace-context suites all passed. CLI transcripts provide end-user evidence; no UI artifact applies to this shell-only change.

<details>
<summary>Evidence: Full remote secondmate lifecycle</summary>

```text
ok - overlapping remote home provisioning serializes through publication and rollback
ok - remote seed rollback preserves serialized competing routes
ok - unknown readiness preserves its route and brief for reconciliation
ok - remote seeding checks, repairs, and re-checks readiness, then stops on a remaining gap
ok - remote seeding proceeds once the repair closes every gap
ok - remote seeding provisions a supplied origin without touching the primary project tree
ok - remote provisioning re-validates a supplied origin at the receiving host
ok - seeding carries bitbucket, self-hosted, and scp-like origins through to the remote clone
ok - remote seed registers the route and provisions the whole home and project clone on that host
ok - remote inheritance rejects incomplete and superseded payload generations
ok - mixed local and remote routes validate without migration
ok - remote spawn launches on the remote-local backend and records a host-qualified route
ok - legacy and mismatched remote endpoints fail closed before backend access
ok - non-herdr remote endpoints are refused without changing either route
ok - remote spawn serializes inheritance through launch publication
ok - marked send and routed reply complete through the existing parent correlation owner
PR_CHECK_MIGRATION: watcher ownership is ambiguous; review state/.watch.lock before rearming polls
ok - partial remote inheritance retains reread intent through bootstrap convergence
ok - config push and bootstrap serialize remote inheritance convergence
WARNING: watcher still down (same stale episode; last beat: 58s ago, grace 300s) - full banner already printed this episode.
WARNING: queued wakes pending - drain them with bin/fm-wake-drain.sh before anything else.
ok - remote inherited config retains and retries a failed live reread nudge
ok - fleet snapshot projects mixed local and remote structured state
ok - remote update imports and fast-forwards the persistent home on its configured host
PR_CHECK_MIGRATION: watcher ownership is ambiguous; review state/.watch.lock before rearming polls
ok - startup repairs remote readiness before probing without relaunching
PR_CHECK_MIGRATION: watcher ownership is ambiguous; review state/.watch.lock before rearming polls
ok - startup reports alive legacy backends without changing their routes
ok - unreachable remote state remains unknown with no local respawn or failover
ok - remote retirement refuses child work, then removes only its own endpoint while a shared-session sibling survives
ALL TESTS PASSED
```
</details>
<details>
<summary>Evidence: Project-less seed lifecycle</summary>

```text
ok - overlapping remote home provisioning serializes through publication and rollback
ok - remote seed rollback preserves serialized competing routes
ALL TESTS PASSED
```
</details>
<details>
<summary>Evidence: Parent-binding lifecycle</summary>

```text
ok - remote provisioning publishes durable parent state before its completion marker
ok - a remote secondmate's finished worker cleans up when the remote code root's own .env looked relay-active
ok - a remote secondmate's finished worker cleans up when only an ambient exported token looked relay-active
ok - a remote secondmate's finished worker cleans up with no relay signal anywhere
ok - a remote secondmate's own committed relay token still refuses cleanup
ALL TESTS PASSED
```
</details>
<details>
<summary>Evidence: Project-less trace-context lifecycle</summary>

```text
ok - disabled: a remote-routed second mate records and receives no carrier and stays enabled-off end to end
ok - enabled: a remote-routed second mate receives one carrier in its pane, identical to the parent's recorded identity, before launch
ok - relaunch: a remote-routed second mate keeps one stable identity across restarts
ok - boundary: each remote-routed second mate roots its own trace and never adopts the spawning environment's carrier
ok - allowlist: the remote receiver accepts exactly the declared inherited-material set, including the enablement flag
ok - delivery: a parent-supplied carrier is accepted only for a secondmate launch and only as a strict W3C value
ALL TESTS PASSED
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>Inspected `git diff 70aeba855527f7693082f6dd1bc731e334d0269f..b4f97c5eb92d21694559810c5ab97916e1c0f768` and relevant history.</code>
- <code>Confirmed `/bin/bash` is Apple Bash 3.2.57, reproducing the affected runtime.</code>
- `FM_TEST_SEED_ONLY=1 /bin/bash tests/fm-remote-secondmate-lifecycle-e2e.test.sh`
- `/bin/bash tests/fm-remote-secondmate-lifecycle-e2e.test.sh`
- `/bin/bash tests/fm-remote-secondmate-parent-binding.test.sh`
- `/bin/bash tests/fm-remote-secondmate-trace-context.test.sh`
- <code>Verified `git status --short` remained empty after testing.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
