### PR TITLE
fix: use evidence-based primary scope detection

### DIFF
--- a/.opencode/plugins/fm-primary-watch-arm.js
+++ b/.opencode/plugins/fm-primary-watch-arm.js
@@ -1,5 +1,5 @@
 import { spawn } from "node:child_process";
-import { existsSync, readFileSync, readdirSync, realpathSync } from "node:fs";
+import { existsSync, readFileSync, realpathSync } from "node:fs";
 import { resolve } from "node:path";
 import { encodeFirstmateOperationalInput } from "./lib/fm-operational-input.js";
 
@@ -22,7 +22,6 @@ let launchInFlight = null;
 let restorationInFlight = null;
 let armClose = new WeakMap();
 let armReadiness = new WeakMap();
-let notPrimaryReported = false;
 
 function positiveInteger(name, fallback) {
   const value = Number(process.env[name]);
@@ -90,39 +89,20 @@ function effectivePaths(root) {
   return { root: fmRoot, home: fmHome, state, config };
 }
 
-function hasTaskMetadata(state) {
-  try {
-    return readdirSync(state).some((name) => name.endsWith(".meta"));
-  } catch {
-    return false;
-  }
-}
-
-function hasSecondmateMarker(root) {
-  try {
-    const id = readFileSync(`${root}/.fm-secondmate-home`, "utf8")
-      .split(/\r?\n/, 1)[0]
-      .replace(/\s/g, "");
-    return /^[A-Za-z0-9._-]+$/.test(id);
-  } catch {
-    return false;
-  }
-}
-
-async function isPrimaryRoot(root, home, state) {
-  if (!root) return false;
-  if (!existsSync(`${root}/AGENTS.md`) || !existsSync(`${root}/bin`)) return false;
-  if (!existsSync(`${root}/.opencode/plugins`) && !existsSync(`${root}/bin/fm-watch-arm.sh`)) return false;
-  if (existsSync(`${root}/.fm-secondmate-home`) && !hasSecondmateMarker(root)) return false;
-  if (home && home !== root && existsSync(`${home}/.fm-secondmate-home`)) return false;
-  if (!state || !hasTaskMetadata(state)) return false;
-  return sessionOwnsLock({ state });
+async function isPrimaryRoot(paths) {
+  const result = await runProcess("bash", [
+    "-c",
+    '. "$1"; fm_primary_scope_matches "$2" "$3"',
+    "fm-primary-scope",
+    `${paths.root}/bin/fm-primary-scope-lib.sh`,
+    paths.root,
+    paths.state,
+  ]);
+  return result.code === 0 && (await sessionOwnsLock(paths));
 }
 
 function shouldArm(paths) {
-  if (existsSync(`${paths.state}/.afk`)) return false;
-  if (existsSync(`${paths.config}/x-mode.env`)) return true;
-  return hasTaskMetadata(paths.state);
+  return !existsSync(`${paths.state}/.afk`);
 }
 
 async function sessionOwnsLock(paths) {
@@ -217,17 +197,6 @@ function surfaceFailure(paths, client, sessionID, reason) {
   });
 }
 
-function reportNotPrimary(paths, client, sessionID) {
-  if (notPrimaryReported) return;
-  notPrimaryReported = true;
-  surfaceFailure(
-    paths,
-    client,
-    sessionID,
-    "watcher: FAILED - OpenCode primary scope is not-primary; session no longer owns the lock or primary evidence is incomplete; verify session lock ownership, primary hook paths, state metadata, and marker validity",
-  );
-}
-
 function retryDelay(attempt) {
   return Math.min(REARM_RETRY_MAX_MS, REARM_RETRY_BASE_MS * 2 ** Math.max(0, attempt - 1));
 }
@@ -255,9 +224,6 @@ async function retireArm(armChild) {
 }
 
 function restorationFailure(status) {
-  if (status === "read-only") {
-    return "watcher: FAILED - OpenCode cannot restore continuity because this session no longer owns the lock";
-  }
   return `watcher: FAILED - OpenCode could not verify a ready successor watcher (${status || "idle"})`;
 }
 
@@ -274,7 +240,7 @@ async function restoreAfterActionableClose(paths, sessionID, client, predecessor
       setArmStatus("failed");
       return `${failure}\nwatcher: FAILED - OpenCode could not restore watcher continuity because the unready successor arm did not exit within ${ARM_RETIRE_TIMEOUT_MS}ms`;
     }
-    if (status === "read-only" || status === "not-primary" || status === "skipped") break;
+    if (status === "not-primary" || status === "skipped") break;
     if (attempt === REARM_RETRY_LIMIT) break;
     await waitForRetry(attempt + 1);
   }
@@ -405,10 +371,7 @@ function spawnArm(paths, sessionID, client, predecessorArmPid = "") {
 
 async function beginArm(paths, sessionID, client, predecessorArmPid) {
   if (!sessionID) return { status: "skipped", armChild: null };
-  if (!(await isPrimaryRoot(paths.root, paths.home, paths.state))) {
-    reportNotPrimary(paths, client, sessionID);
-    return { status: "not-primary", armChild: null };
-  }
+  if (!(await isPrimaryRoot(paths))) return { status: "not-primary", armChild: null };
   if (child) return { status: "existing", armChild: child };
   if (retryTimer) return { status: "retrying", armChild: null };
   if (!shouldArm(paths)) return { status: "not-needed", armChild: null };

--- a/.opencode/plugins/fm-primary-watch-arm.js
+++ b/.opencode/plugins/fm-primary-watch-arm.js
@@ -22,6 +22,7 @@ let launchInFlight = null;
 let restorationInFlight = null;
 let armClose = new WeakMap();
 let armReadiness = new WeakMap();
+let notPrimaryReported = false;
 
 function positiveInteger(name, fallback) {
   const value = Number(process.env[name]);
@@ -195,6 +196,17 @@ function wakePrompt(reason) {
 function surfaceFailure(paths, client, sessionID, reason) {
   void sendPrompt(paths, client, sessionID, wakePrompt(reason)).catch(() => {
   });
+}
+
+function reportNotPrimary(paths, client, sessionID) {
+  if (notPrimaryReported) return;
+  notPrimaryReported = true;
+  surfaceFailure(
+    paths,
+    client,
+    sessionID,
+    "watcher: FAILED - OpenCode primary scope is not-primary; session no longer owns the lock or primary evidence is incomplete; verify session lock ownership, primary hook paths, state metadata, and marker validity",
+  );
 }
 
 function retryDelay(attempt) {
@@ -371,7 +383,10 @@ function spawnArm(paths, sessionID, client, predecessorArmPid = "") {
 
 async function beginArm(paths, sessionID, client, predecessorArmPid) {
   if (!sessionID) return { status: "skipped", armChild: null };
-  if (!(await isPrimaryRoot(paths))) return { status: "not-primary", armChild: null };
+  if (!(await isPrimaryRoot(paths))) {
+    reportNotPrimary(paths, client, sessionID);
+    return { status: "not-primary", armChild: null };
+  }
   if (child) return { status: "existing", armChild: child };
   if (retryTimer) return { status: "retrying", armChild: null };
   if (!shouldArm(paths)) return { status: "not-needed", armChild: null };

--- a/.opencode/plugins/fm-primary-watch-arm.js
+++ b/.opencode/plugins/fm-primary-watch-arm.js
@@ -22,6 +22,7 @@ let launchInFlight = null;
 let restorationInFlight = null;
 let armClose = new WeakMap();
 let armReadiness = new WeakMap();
+let notPrimaryReported = false;
 
 function positiveInteger(name, fallback) {
   const value = Number(process.env[name]);
@@ -89,25 +90,39 @@ function effectivePaths(root) {
   return { root: fmRoot, home: fmHome, state, config };
 }
 
-async function isPrimaryRoot(root, home) {
+function hasTaskMetadata(state) {
+  try {
+    return readdirSync(state).some((name) => name.endsWith(".meta"));
+  } catch {
+    return false;
+  }
+}
+
+function hasSecondmateMarker(root) {
+  try {
+    const id = readFileSync(`${root}/.fm-secondmate-home`, "utf8")
+      .split(/\r?\n/, 1)[0]
+      .replace(/\s/g, "");
+    return /^[A-Za-z0-9._-]+$/.test(id);
+  } catch {
+    return false;
+  }
+}
+
+async function isPrimaryRoot(root, home, state) {
   if (!root) return false;
   if (!existsSync(`${root}/AGENTS.md`) || !existsSync(`${root}/bin`)) return false;
-  if (existsSync(`${root}/.fm-secondmate-home`)) return false;
+  if (!existsSync(`${root}/.opencode/plugins`) && !existsSync(`${root}/bin/fm-watch-arm.sh`)) return false;
+  if (existsSync(`${root}/.fm-secondmate-home`) && !hasSecondmateMarker(root)) return false;
   if (home && home !== root && existsSync(`${home}/.fm-secondmate-home`)) return false;
-  const gitDir = await runProcess("git", ["-C", root, "rev-parse", "--git-dir"]);
-  const commonDir = await runProcess("git", ["-C", root, "rev-parse", "--git-common-dir"]);
-  if (gitDir.code !== 0 || commonDir.code !== 0) return false;
-  return gitDir.stdout.trim() === commonDir.stdout.trim();
+  if (!state || !hasTaskMetadata(state)) return false;
+  return sessionOwnsLock({ state });
 }
 
 function shouldArm(paths) {
   if (existsSync(`${paths.state}/.afk`)) return false;
   if (existsSync(`${paths.config}/x-mode.env`)) return true;
-  try {
-    return readdirSync(paths.state).some((name) => name.endsWith(".meta"));
-  } catch {
-    return false;
-  }
+  return hasTaskMetadata(paths.state);
 }
 
 async function sessionOwnsLock(paths) {
@@ -200,6 +215,17 @@ function wakePrompt(reason) {
 function surfaceFailure(paths, client, sessionID, reason) {
   void sendPrompt(paths, client, sessionID, wakePrompt(reason)).catch(() => {
   });
+}
+
+function reportNotPrimary(paths, client, sessionID) {
+  if (notPrimaryReported) return;
+  notPrimaryReported = true;
+  surfaceFailure(
+    paths,
+    client,
+    sessionID,
+    "watcher: FAILED - OpenCode primary scope is not-primary; session no longer owns the lock or primary evidence is incomplete; verify session lock ownership, primary hook paths, state metadata, and marker validity",
+  );
 }
 
 function retryDelay(attempt) {
@@ -379,8 +405,10 @@ function spawnArm(paths, sessionID, client, predecessorArmPid = "") {
 
 async function beginArm(paths, sessionID, client, predecessorArmPid) {
   if (!sessionID) return { status: "skipped", armChild: null };
-  if (!(await isPrimaryRoot(paths.root, paths.home))) return { status: "not-primary", armChild: null };
-  if (!(await sessionOwnsLock(paths))) return { status: "read-only", armChild: null };
+  if (!(await isPrimaryRoot(paths.root, paths.home, paths.state))) {
+    reportNotPrimary(paths, client, sessionID);
+    return { status: "not-primary", armChild: null };
+  }
   if (child) return { status: "existing", armChild: child };
   if (retryTimer) return { status: "retrying", armChild: null };
   if (!shouldArm(paths)) return { status: "not-needed", armChild: null };

--- a/bin/fm-claude-stop-autoarm.sh
+++ b/bin/fm-claude-stop-autoarm.sh
@@ -7,9 +7,10 @@
 # deduplication across firings. It owns routine tokenless watcher continuity
 # for Claude primaries (main home and marked secondmate homes):
 #
-#   - Scope: only a genuine primary checkout (plain checkout or validly marked
-#     secondmate home) with AGENTS.md, bin/, and the effective state dir - the
-#     exact fm-turnend-guard.sh scope. Child crew/scout worktrees stay inert.
+#   - Scope: only a genuine primary home with AGENTS.md, bin/, a session lock,
+#     active state evidence, and valid marker state - the exact
+#     fm-turnend-guard.sh scope. Linked primary homes are allowed; child
+#     crew/scout worktrees stay inert without positive evidence.
 #   - Identity: only when THIS session's harness ancestor holds state/.lock.
 #     When an existing numeric owner fails the shared harness-liveness predicate,
 #     the hook delegates guarded recovery to bin/fm-lock.sh and then re-verifies

--- a/bin/fm-primary-scope-lib.sh
+++ b/bin/fm-primary-scope-lib.sh
@@ -53,9 +53,10 @@ fm_primary_scope_matches() {
     fi
     return 0
   fi
-  [ -f "$state/.lock" ] || return 1
+  [ -f "$state/.lock" ] && [ ! -L "$state/.lock" ] || return 1
   lock_pid=$(cat "$state/.lock" 2>/dev/null) || return 1
   case "$lock_pid" in ''|*[!0-9]*) return 1 ;; esac
+  ((10#$lock_pid > 1)) || return 1
   for meta in "$state"/*.meta; do
     [ -f "$meta" ] && return 0
   done

--- a/bin/fm-primary-scope-lib.sh
+++ b/bin/fm-primary-scope-lib.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# Shared marker-or-plain-checkout predicate for tracked hooks that must act only
-# in a genuine firstmate primary home.
+# Shared positive-evidence predicate for tracked hooks that must act only in a
+# genuine firstmate primary home.
 # This file is sourced by hook entrypoints and has no side effects on source.
 
 # Return 0 when $1 carries a genuine secondmate-home marker.
@@ -18,16 +18,41 @@ fm_root_is_secondmate_home() {
 }
 
 # Return 0 when $1 is a genuine primary root whose effective state dir is $2.
-# A valid secondmate marker force-includes a linked secondmate home.
-# Otherwise only a plain checkout is primary, never a linked task worktree.
+# Runtime callers require a session lock, tracked hook surface, and active
+# state evidence from task metadata, X-mode polling, or a process-event source.
+# A valid secondmate marker is an explicit primary-home signal.
+# --prelock is only for startup wrappers that run before the session lock and
+# active state evidence exist.
 fm_primary_scope_matches() {
-  local root=$1 state=$2 git_dir git_common_dir
-  if ! fm_root_is_secondmate_home "$root"; then
-    git_dir=$(git -C "$root" rev-parse --git-dir 2>/dev/null) || return 1
-    git_common_dir=$(git -C "$root" rev-parse --git-common-dir 2>/dev/null) || return 1
-    [ "$git_dir" = "$git_common_dir" ] || return 1
+  local root=$1 state=$2 home meta lock_pid git_dir git_common_dir prelock=0
+  [ "${3:-}" = --prelock ] && prelock=1
+  home=${state%/state}
+  if [ -e "$root/.fm-secondmate-home" ] && ! fm_root_is_secondmate_home "$root"; then
+    return 1
+  fi
+  if [ -e "$home/.fm-secondmate-home" ] && [ "$home" != "$root" ]; then
+    return 1
   fi
   [ -f "$root/AGENTS.md" ] || return 1
   [ -d "$root/bin" ] || return 1
   [ -d "$state" ] || return 1
+  if [ "$prelock" -eq 1 ]; then
+    if ! fm_root_is_secondmate_home "$root" && ! fm_root_is_secondmate_home "$home"; then
+      git_dir=$(git -C "$root" rev-parse --git-dir 2>/dev/null) || return 1
+      git_common_dir=$(git -C "$root" rev-parse --git-common-dir 2>/dev/null) || return 1
+      [ "$git_dir" = "$git_common_dir" ] || return 1
+    fi
+    return 0
+  fi
+  [ -f "$state/.lock" ] || return 1
+  lock_pid=$(cat "$state/.lock" 2>/dev/null) || return 1
+  case "$lock_pid" in ''|*[!0-9]*) return 1 ;; esac
+  for meta in "$state"/*.meta; do
+    [ -f "$meta" ] && return 0
+  done
+  [ -f "$state/x-watch.check.sh" ] && return 0
+  for meta in "$state"/procevent/*.source; do
+    [ -f "$meta" ] && return 0
+  done
+  return 1
 }

--- a/bin/fm-primary-scope-lib.sh
+++ b/bin/fm-primary-scope-lib.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# Shared positive-evidence predicate for tracked hooks that must act only in a
-# genuine firstmate primary home.
+# Shared positive-evidence predicate for primary-scoped entrypoints that must
+# act only in a genuine firstmate primary home.
 # This file is sourced by hook entrypoints and has no side effects on source.
 
 # Return 0 when $1 carries a genuine secondmate-home marker.
@@ -18,8 +18,8 @@ fm_root_is_secondmate_home() {
 }
 
 # Return 0 when $1 is a genuine primary root whose effective state dir is $2.
-# Runtime callers require a session lock, tracked hook surface, and active
-# state evidence from task metadata, X-mode polling, or a process-event source.
+# Runtime callers require a session lock and active state evidence from task
+# metadata, X-mode polling, or a process-event source.
 # A valid secondmate marker is an explicit primary-home signal.
 # --prelock is only for startup wrappers that run before the session lock and
 # active state evidence exist.
@@ -36,6 +36,15 @@ fm_primary_scope_matches() {
   [ -f "$root/AGENTS.md" ] || return 1
   [ -d "$root/bin" ] || return 1
   [ -d "$state" ] || return 1
+  # A linked root with a different effective home is a child worktree unless
+  # the root carries its own explicit home marker. Keep separate operational
+  # homes valid for a plain authoritative checkout, but reject inherited state
+  # from that checkout in its linked children.
+  if [ "$prelock" -eq 0 ] && [ "$root" != "$home" ] && ! fm_root_is_secondmate_home "$root"; then
+    git_dir=$(git -C "$root" rev-parse --git-dir 2>/dev/null) || return 1
+    git_common_dir=$(git -C "$root" rev-parse --git-common-dir 2>/dev/null) || return 1
+    [ "$git_dir" = "$git_common_dir" ] || return 1
+  fi
   if [ "$prelock" -eq 1 ]; then
     if ! fm_root_is_secondmate_home "$root" && ! fm_root_is_secondmate_home "$home"; then
       git_dir=$(git -C "$root" rev-parse --git-dir 2>/dev/null) || return 1

--- a/bin/fm-sessionstart-nudge.sh
+++ b/bin/fm-sessionstart-nudge.sh
@@ -18,7 +18,7 @@ STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
 . "$SCRIPT_DIR/fm-operational-input.sh"
 
 fm_is_gate_agent "$FM_ROOT" && exit 0
-fm_primary_scope_matches "$FM_ROOT" "$STATE" || exit 0
+fm_primary_scope_matches "$FM_ROOT" "$STATE" --prelock || exit 0
 
 lock_is_in_ancestry() {
   local lock_pid pid=$$ _

--- a/bin/fm-sessionstart-run.sh
+++ b/bin/fm-sessionstart-run.sh
@@ -67,7 +67,7 @@ done
 # agent and an unmarked task worktree can never run a session start for a home
 # they do not own.
 fm_is_gate_agent "$FM_ROOT" && exit 0
-fm_primary_scope_matches "$FM_ROOT" "$STATE" || exit 0
+fm_primary_scope_matches "$FM_ROOT" "$STATE" --prelock || exit 0
 
 session_start_completed() {
   local lock_pid completion_pid

--- a/bin/fm-subagent-pretool-check.sh
+++ b/bin/fm-subagent-pretool-check.sh
@@ -176,8 +176,8 @@ FM_HOME=${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}
 STATE=${FM_STATE_OVERRIDE:-$FM_HOME/state}
 
 # Scope to a genuine primary home, exactly as the turn-end guard does.
-# fm_primary_scope_matches uses positive lock, hook, and active-state evidence,
-# with a valid secondmate marker as an explicit home signal.
+# fm_primary_scope_matches uses positive lock and active-state evidence, with a
+# valid secondmate marker as an explicit home signal.
 # A crewmate using delegation tools inside its own task worktree has no such
 # evidence and stays allowed.
 # Any failure to confirm the home is inert (exit 0), never a block, so a broken

--- a/bin/fm-subagent-pretool-check.sh
+++ b/bin/fm-subagent-pretool-check.sh
@@ -175,13 +175,13 @@ FM_ROOT=${FM_ROOT_OVERRIDE:-$(CDPATH='' cd -- "$SCRIPT_DIR/.." 2>/dev/null && pw
 FM_HOME=${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}
 STATE=${FM_STATE_OVERRIDE:-$FM_HOME/state}
 
-# Scope to a genuine primary home, exactly as the session-start nudge and the
-# turn-end guard do. fm_primary_scope_matches accepts a plain checkout or a
-# marked secondmate home - both operate a fleet and must dispatch through it -
-# and rejects a linked task worktree, which is the shape bin/fm-spawn.sh always
-# hands a crewmate. A crewmate using delegation tools inside its own task
-# worktree is legitimate and stays allowed. Any failure to confirm the home is
-# inert (exit 0), never a block, so a broken environment never denies a call.
+# Scope to a genuine primary home, exactly as the turn-end guard does.
+# fm_primary_scope_matches uses positive lock, hook, and active-state evidence,
+# with a valid secondmate marker as an explicit home signal.
+# A crewmate using delegation tools inside its own task worktree has no such
+# evidence and stays allowed.
+# Any failure to confirm the home is inert (exit 0), never a block, so a broken
+# environment never denies a call.
 # shellcheck source=bin/fm-primary-scope-lib.sh
 . "$SCRIPT_DIR/fm-primary-scope-lib.sh"
 fm_primary_scope_matches "$FM_ROOT" "$STATE" || exit 0

--- a/bin/fm-turnend-guard.sh
+++ b/bin/fm-turnend-guard.sh
@@ -111,9 +111,9 @@ if [ "$CLAUDE_MODE" -eq 0 ] && [ "$STOP_HOOK_ACTIVE" = "true" ]; then
 fi
 
 # --- scope precisely to a PRIMARY checkout ----------------------------------
-# The shared predicate accepts linked homes on positive runtime evidence instead
-# of inferring crew scope from git-dir topology: lock, tracked hook paths, active
-# state, and a valid secondmate marker when present.
+# The shared predicate accepts linked homes only with authoritative root/home
+# identity plus positive runtime evidence: lock, active state, and a valid
+# secondmate marker when present.
 # A crewmate worktree has no home lock or active state evidence, so it remains
 # inert while a linked primary home reaches the same guard.
 fm_primary_scope_matches "$FM_ROOT" "$STATE" || exit 0

--- a/bin/fm-turnend-guard.sh
+++ b/bin/fm-turnend-guard.sh
@@ -111,17 +111,11 @@ if [ "$CLAUDE_MODE" -eq 0 ] && [ "$STOP_HOOK_ACTIVE" = "true" ]; then
 fi
 
 # --- scope precisely to a PRIMARY checkout ----------------------------------
-# A genuinely-marked secondmate home runs its OWN primary firstmate session, so
-# force-INCLUDE it as a guarded primary whether treehouse leased it as a linked
-# worktree (git-dir != git-common-dir) or it is a git-cloned plain checkout. This
-# mirrors the cd-guard's intent that a secondmate's own session is a guarded
-# primary. Only an UNMARKED checkout (or one with an invalid marker) falls
-# through to the linked-worktree exemption: firstmate hands out crewmate/scout
-# task worktrees as genuine linked `git worktree`s (bin/fm-spawn.sh aborts
-# otherwise), whose git-dir lives under the parent repo's .git/worktrees/<name>
-# and differs from the common (shared) git-dir, while a main, non-worktree
-# checkout has the two equal. Child worktrees never carry the gitignored marker,
-# so this exempts them while guarding every real secondmate home.
+# The shared predicate accepts linked homes on positive runtime evidence instead
+# of inferring crew scope from git-dir topology: lock, tracked hook paths, active
+# state, and a valid secondmate marker when present.
+# A crewmate worktree has no home lock or active state evidence, so it remains
+# inert while a linked primary home reaches the same guard.
 fm_primary_scope_matches "$FM_ROOT" "$STATE" || exit 0
 
 # --- the actual predicate ----------------------------------------------------

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -34,7 +34,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-test-isolation-proof.sh` | Concurrent isolation proof and proven-isolated candidate set owner |
 | `fm-ensure-agents-md.sh` | Ensure a project's real `AGENTS.md`, its `CLAUDE.md` symlink, and the canonical self-governance section |
 | `fm-guard.sh`            | Warn on primary-checkout tangles, pending queued wakes, and unhealthy supervision    |
-| `fm-primary-scope-lib.sh` | Shared marker-or-plain-checkout primary-home predicate for tracked hooks             |
+| `fm-primary-scope-lib.sh` | Shared positive-evidence primary-home predicate for tracked hooks             |
 | `fm-session-lock-lib.sh` | Shared session-lock harness identity (ancestry walk and holder liveness) for fm-lock.sh and the Claude Stop auto-arm |
 | `fm-claude-stop-autoarm.sh` | Claude Stop `asyncRewake` hook owning tokenless watcher continuity with single-flight exit-2 rewake (docs/watcher-continuity.md) |
 | `fm-turnend-guard.sh`    | Shared primary turn-end guard predicate so no turn ends blind (docs/turnend-guard.md) |

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -34,7 +34,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-test-isolation-proof.sh` | Concurrent isolation proof and proven-isolated candidate set owner |
 | `fm-ensure-agents-md.sh` | Ensure a project's real `AGENTS.md`, its `CLAUDE.md` symlink, and the canonical self-governance section |
 | `fm-guard.sh`            | Warn on primary-checkout tangles, pending queued wakes, and unhealthy supervision    |
-| `fm-primary-scope-lib.sh` | Shared positive-evidence primary-home predicate for tracked hooks             |
+| `fm-primary-scope-lib.sh` | Shared positive-evidence primary-home predicate for primary-scoped entrypoints |
 | `fm-session-lock-lib.sh` | Shared session-lock harness identity (ancestry walk and holder liveness) for fm-lock.sh and the Claude Stop auto-arm |
 | `fm-claude-stop-autoarm.sh` | Claude Stop `asyncRewake` hook owning tokenless watcher continuity with single-flight exit-2 rewake (docs/watcher-continuity.md) |
 | `fm-turnend-guard.sh`    | Shared primary turn-end guard predicate so no turn ends blind (docs/turnend-guard.md) |

--- a/docs/sessionstart-nudge.md
+++ b/docs/sessionstart-nudge.md
@@ -52,8 +52,8 @@ The deferred network stage deliberately runs in its own process group under its 
 `bin/fm-sessionstart-run.sh` and `bin/fm-sessionstart-nudge.sh` share the same two eligibility owners.
 They source `bin/fm-gate-refuse-lib.sh` and stay silent for a no-mistakes gate agent identified by `NO_MISTAKES_GATE` or a `.no-mistakes/repos/*.git` git-common-dir.
 They share `bin/fm-primary-scope-lib.sh` with `bin/fm-turnend-guard.sh`, so every hook uses one primary-detection owner.
-The Guard Predicates section of [`turnend-guard.md`](turnend-guard.md#guard-predicates) owns marker validation, runtime positive evidence, and required Firstmate-shaped paths.
-Startup wrappers pass the shared predicate's `--prelock` mode because session lock and active state evidence do not exist before the first session-start command runs.
+The Guard Predicates section of [`turnend-guard.md`](turnend-guard.md#guard-predicates) owns marker validation, root/home identity, runtime positive evidence, and required Firstmate-shaped paths.
+Startup wrappers pass the shared predicate's `--prelock` mode because session lock and active state evidence do not exist before the first session-start command runs; `--prelock` uses git topology, while runtime uses lock and active-state evidence.
 
 The nudge payload starts with U+2063 and the stable `FIRSTMATE_OP: ` label, carries the current `session-start` protocol kind, and retains exactly ``Run `bin/fm-session-start.sh` now, exactly once, before executing any other instructions.`` as its body.
 The Ahoy skill owns the rule that this marked operational input is never a captain-authored session boundary, including its narrow legacy compatibility cases, and its own step 0 helm check is the fallback that protects a nudge-tier harness whose first command is a skill.

--- a/docs/sessionstart-nudge.md
+++ b/docs/sessionstart-nudge.md
@@ -52,7 +52,8 @@ The deferred network stage deliberately runs in its own process group under its 
 `bin/fm-sessionstart-run.sh` and `bin/fm-sessionstart-nudge.sh` share the same two eligibility owners.
 They source `bin/fm-gate-refuse-lib.sh` and stay silent for a no-mistakes gate agent identified by `NO_MISTAKES_GATE` or a `.no-mistakes/repos/*.git` git-common-dir.
 They share `bin/fm-primary-scope-lib.sh` with `bin/fm-turnend-guard.sh`, so every hook uses one primary-detection owner.
-The Guard Predicates section of [`turnend-guard.md`](turnend-guard.md#guard-predicates) owns marker validation, plain-checkout detection, and required Firstmate-shaped paths.
+The Guard Predicates section of [`turnend-guard.md`](turnend-guard.md#guard-predicates) owns marker validation, runtime positive evidence, and required Firstmate-shaped paths.
+Startup wrappers pass the shared predicate's `--prelock` mode because session lock and active state evidence do not exist before the first session-start command runs.
 
 The nudge payload starts with U+2063 and the stable `FIRSTMATE_OP: ` label, carries the current `session-start` protocol kind, and retains exactly ``Run `bin/fm-session-start.sh` now, exactly once, before executing any other instructions.`` as its body.
 The Ahoy skill owns the rule that this marked operational input is never a captain-authored session boundary, including its narrow legacy compatibility cases, and its own step 0 helm check is the fallback that protects a nudge-tier harness whose first command is a skill.

--- a/docs/subagent-guard.md
+++ b/docs/subagent-guard.md
@@ -136,7 +136,8 @@ It costs one line and removes the failure mode where a rename or a rollback sile
 The shipped hook fires only in a genuine firstmate primary home, using the shared predicate `fm_primary_scope_matches` from `bin/fm-primary-scope-lib.sh`.
 This is the same predicate `bin/fm-sessionstart-nudge.sh` and `bin/fm-turnend-guard.sh` use, so the three tracked primary-scoped hooks cannot drift apart.
 
-A home is in scope when it has `AGENTS.md`, a `bin/` directory, an existing state directory, and either a plain checkout where git-dir equals git-common-dir or a valid `.fm-secondmate-home` marker.
+A home is in scope when it has `AGENTS.md`, a `bin/` directory, a numeric session lock, and active state evidence from task metadata, X-mode polling, or a process-event source.
+A valid `.fm-secondmate-home` marker is an explicit primary-home signal, including for a linked secondmate home.
 A marked secondmate home is in scope on purpose: it operates its own fleet and must dispatch through it for the same durability reasons.
 
 A crewmate's disposable task worktree is a linked git worktree, which is the shape `bin/fm-spawn.sh` always hands out, so it is out of scope.

--- a/docs/subagent-guard.md
+++ b/docs/subagent-guard.md
@@ -133,12 +133,9 @@ It costs one line and removes the failure mode where a rename or a rollback sile
 
 ## Scope
 
-The shipped hook fires only in a genuine firstmate primary home, using the shared predicate `fm_primary_scope_matches` from `bin/fm-primary-scope-lib.sh`.
-This is the same predicate `bin/fm-sessionstart-nudge.sh` and `bin/fm-turnend-guard.sh` use, so the three tracked primary-scoped hooks cannot drift apart.
-
-A home is in scope when it has `AGENTS.md`, a `bin/` directory, a numeric session lock, and active state evidence from task metadata, X-mode polling, or a process-event source.
-A valid `.fm-secondmate-home` marker is an explicit primary-home signal, including for a linked secondmate home.
-A marked secondmate home is in scope on purpose: it operates its own fleet and must dispatch through it for the same durability reasons.
+The shipped hook uses the shared predicate `fm_primary_scope_matches` from `bin/fm-primary-scope-lib.sh`.
+The Guard Predicates section of [`turnend-guard.md`](turnend-guard.md#guard-predicates) owns marker validation, root/home identity, runtime evidence, and required Firstmate-shaped paths.
+Session-start wrappers use that predicate's `--prelock` topology path before runtime lock and active-state evidence exist.
 
 A crewmate's disposable task worktree is a linked git worktree, which is the shape `bin/fm-spawn.sh` always hands out, so it is out of scope.
 A crewmate using delegation tools inside its own task worktree is legitimate and stays allowed.

--- a/docs/turnend-guard.md
+++ b/docs/turnend-guard.md
@@ -20,11 +20,11 @@ The guard remains a backstop; [`watcher-continuity.md`](watcher-continuity.md) o
 ## Guard predicates
 
 The guard first calls the shared primary scope.
-A secondmate home runs its own primary Firstmate session, so a genuine `.fm-secondmate-home` marker includes it whether the home is a linked worktree or plain clone.
+A secondmate home runs its own primary Firstmate session, so a valid `.fm-secondmate-home` marker remains an explicit primary-home signal whether the home is linked or cloned.
 The marker must be a regular non-symlink file whose whitespace-stripped first line is a non-empty identifier containing only letters, digits, dots, underscores, and dashes.
-An unmarked checkout or invalid marker falls through to the git-dir check.
-That check keeps crewmate and scout linked worktrees inert because their git dir differs from their git common dir.
-It also requires `AGENTS.md`, `bin/`, and the effective state directory.
+An unmarked home no longer falls out of scope merely because its git dir differs from its git common dir.
+Runtime scope requires `AGENTS.md`, `bin/`, a numeric `state/.lock`, and active state evidence from `state/*.meta`, `state/x-watch.check.sh`, or `state/procevent/*.source`.
+This keeps crewmate and scout linked worktrees inert without excluding a linked primary home that owns the session lock.
 
 For an in-scope primary, the guard counts in-flight work from `state/*.meta`.
 Registered `state/procevent/*.source` records also require supervision even though they have no task metadata.
@@ -105,7 +105,7 @@ That warning uses `bin/fm-supervision-instructions.sh --repair-line`, so it alwa
 
 ## Regression coverage
 
-`tests/fm-turnend-guard.test.sh` covers the predicate, main and secondmate primary scope, child-worktree exclusion, `FM_HOME` and `FM_STATE_OVERRIDE` precedence, the live-lock and fresh-beacon guard predicate, the cooperative `--claude` claim wait, monotonic failed-epoch progression, bounded attended fail-open, post-alarm continuation suppression, positive recovery reset, Pi logical-run latching, missing-`jq` behavior, all five primary registrations, Grok native and legacy selection, typed field precedence, malformed input, and exactly-one-path safety.
+`tests/fm-turnend-guard.test.sh` covers the positive linked-primary predicate, main and secondmate primary scope, child-worktree exclusion, `FM_HOME` and `FM_STATE_OVERRIDE` precedence, the live-lock and fresh-beacon guard predicate, the cooperative `--claude` claim wait, monotonic failed-epoch progression, bounded attended fail-open, post-alarm continuation suppression, positive recovery reset, Pi logical-run latching, missing-`jq` behavior, all five primary registrations, Grok native and legacy selection, typed field precedence, malformed input, and exactly-one-path safety.
 `tests/fm-guard-stale-banner.test.sh` covers the pull-guard predicate, including the persistent-model fresh-leftover-beacon negative control, the auto-arm model's healthy fresh-beacon-without-a-watcher case and its stale-beacon alarm, the true-reason banner wording, and the reason-keyed episode dedup surviving a beacon mtime change.
 `tests/fm-kimi-harness.test.sh` covers the separate Kimi crew hook's format preservation, idempotence, refusal cases, token guard, spawn registration, and teardown cleanup.
 `tests/fm-supervision-instructions.test.sh` covers recovery-line ownership and pi-signed's identity-preserving reuse of Pi's protocol.

--- a/docs/turnend-guard.md
+++ b/docs/turnend-guard.md
@@ -22,9 +22,12 @@ The guard remains a backstop; [`watcher-continuity.md`](watcher-continuity.md) o
 The guard first calls the shared primary scope.
 A secondmate home runs its own primary Firstmate session, so a valid `.fm-secondmate-home` marker remains an explicit primary-home signal whether the home is linked or cloned.
 The marker must be a regular non-symlink file whose whitespace-stripped first line is a non-empty identifier containing only letters, digits, dots, underscores, and dashes.
-An unmarked home no longer falls out of scope merely because its git dir differs from its git common dir.
+An unmarked root that is its effective home no longer falls out of scope merely because its git dir differs from its git common dir.
 Runtime scope requires `AGENTS.md`, `bin/`, a numeric `state/.lock`, and active state evidence from `state/*.meta`, `state/x-watch.check.sh`, or `state/procevent/*.source`.
+When effective state home differs from root, an unmarked linked root is out of scope, so a child worktree cannot inherit its parent's home state.
 This keeps crewmate and scout linked worktrees inert without excluding a linked primary home that owns the session lock.
+Startup wrappers use the shared predicate's `--prelock` mode before lock and active-state evidence exist; that mode uses git topology, while runtime scope uses the positive evidence above.
+An unmarked linked home therefore remains out of session-start scope until runtime evidence exists.
 
 For an in-scope primary, the guard counts in-flight work from `state/*.meta`.
 Registered `state/procevent/*.source` records also require supervision even though they have no task metadata.

--- a/tests/fm-claude-stop-autoarm.test.sh
+++ b/tests/fm-claude-stop-autoarm.test.sh
@@ -41,6 +41,7 @@ make_primary_dir() {
   git init -q "$dir"
   git -C "$dir" commit -q --allow-empty -m init
   : > "$dir/AGENTS.md"
+  printf '%s\n' "$$" > "$dir/state/.lock"
   install_autoarm_scripts "$dir"
   printf '%s\n' "$dir"
 }
@@ -183,7 +184,7 @@ test_inert_in_child_worktree() {
   make_crewmate_worktree_dir "$base" "$dir" >/dev/null
   : > "$dir/state/task.meta"
   write_arm_fixture "$dir" actionable
-  out=$(run_autoarm "$dir" 2>/dev/null); status=$?
+  out=$(printf '%s\n' '{"session_id":"s"}' | FM_HOME="$dir" bash "$dir/bin/fm-claude-stop-autoarm.sh" 2>/dev/null); status=$?
   expect_code 0 "$status" "hook must stay inert in a child task worktree"
   [ ! -e "$dir/state/arm-ran" ] || fail "hook armed inside a child worktree"
   [ ! -e "$dir/state/.claude-autoarm-epoch" ] || fail "hook wrote an epoch inside a child worktree"
@@ -194,6 +195,7 @@ test_inert_without_session_lock() {
   local dir out status
   dir=$(make_primary_dir "$TMP_ROOT/no-lock")
   : > "$dir/state/task.meta"
+  rm -f "$dir/state/.lock"
   write_arm_fixture "$dir" actionable
   # No state/.lock: run the hook directly (no fake harness, no lock file).
   out=$(printf '%s\n' '{"session_id":"s"}' | FM_HOME="$dir" bash "$dir/bin/fm-claude-stop-autoarm.sh" 2>&1); status=$?

--- a/tests/fm-pi-watch-extension.test.sh
+++ b/tests/fm-pi-watch-extension.test.sh
@@ -1326,7 +1326,16 @@ import { pathToFileURL } from "node:url";
 
 const mod = await import(pathToFileURL(process.env.PLUGIN).href);
 let prompts = 0;
-const client = { session: { promptAsync: async () => { prompts += 1; } } };
+const client = {
+  session: {
+    promptAsync: async (request) => {
+      prompts += 1;
+      if (!request.body.parts[0].text.includes("primary scope is not-primary")) {
+        throw new Error(`unexpected diagnostic: ${request.body.parts[0].text}`);
+      }
+    },
+  },
+};
 await mod.FmPrimaryWatchArm({
   client,
   directory: process.env.WORKTREE,
@@ -1342,6 +1351,15 @@ if (existsSync(process.env.FM_ARM_LOG)) {
   console.error("watch arm ran without owning the session lock");
   process.exit(1);
 }
+const repeat = await globalThis.__firstmateOpenCodeWatchArm.ensureArmed("session-test", client);
+if (repeat !== "not-primary") {
+  console.error(`expected repeated not-primary without lock ownership, got ${repeat}`);
+  process.exit(1);
+}
+if (prompts !== 1) {
+  console.error(`expected one not-primary diagnostic before lock, got ${prompts}`);
+  process.exit(1);
+}
 writeFileSync(`${process.env.FM_HOME}/state/.lock`, `${process.pid}\n`);
 const second = await globalThis.__firstmateOpenCodeWatchArm.ensureArmed("session-test", client);
 if (second !== "armed") {
@@ -1355,8 +1373,8 @@ if (!existsSync(process.env.FM_ARM_LOG)) {
   console.error("watch arm did not run after the session lock matched");
   process.exit(1);
 }
-if (prompts !== 0) {
-  console.error(`expected no not-primary diagnostic, got ${prompts}`);
+if (prompts !== 1) {
+  console.error(`expected one not-primary diagnostic, got ${prompts}`);
   process.exit(1);
 }
 EOF

--- a/tests/fm-pi-watch-extension.test.sh
+++ b/tests/fm-pi-watch-extension.test.sh
@@ -1255,6 +1255,7 @@ test_opencode_primary_watch_plugin_sources_effective_config() {
   mkdir -p "$repo/bin" "$home/state" "$home/config"
   git init -q "$repo"
   : > "$repo/AGENTS.md"
+  : > "$home/state/task.meta"
   printf 'export FM_POLL=7\n' > "$home/config/x-mode.env"
   cat > "$repo/bin/fm-watch-arm.sh" <<'SH'
 #!/usr/bin/env bash
@@ -1308,7 +1309,7 @@ test_opencode_primary_watch_plugin_requires_session_lock() {
   cat > "$repo/bin/fm-watch-arm.sh" <<'SH'
 #!/usr/bin/env bash
 printf 'arm\n' >> "${FM_ARM_LOG:?}"
-printf 'watcher: healthy pid=1 (beacon 0s)\n'
+printf 'watcher: started pid=%s (beacon fresh)\n' "$$"
 SH
   chmod +x "$repo/bin/fm-watch-arm.sh"
   out=$(PLUGIN="$plugin" WORKTREE="$repo" FM_HOME="$home" FM_ARM_LOG="$log" node 2>&1 <<'EOF'
@@ -1316,27 +1317,47 @@ import { existsSync, writeFileSync } from "node:fs";
 import { pathToFileURL } from "node:url";
 
 const mod = await import(pathToFileURL(process.env.PLUGIN).href);
-const client = { session: { promptAsync: async () => {} } };
+let prompts = 0;
+const client = {
+  session: {
+    promptAsync: async (request) => {
+      prompts += 1;
+      if (!request.body.parts[0].text.includes("primary scope is not-primary")) {
+        throw new Error(`unexpected diagnostic: ${request.body.parts[0].text}`);
+      }
+    },
+  },
+};
 const hooks = await mod.FmPrimaryWatchArm({
   client,
   directory: process.env.WORKTREE,
   worktree: process.env.WORKTREE,
 });
-const event = { event: { type: "session.idle", properties: { sessionID: "session-test" } } };
 writeFileSync(`${process.env.FM_HOME}/state/.lock`, "999999\n");
-await hooks.event(event);
-await new Promise((resolve) => setTimeout(resolve, 120));
+const first = await globalThis.__firstmateOpenCodeWatchArm.ensureArmed("session-test", client);
+if (first !== "not-primary") {
+  console.error(`expected not-primary without lock ownership, got ${first}`);
+  process.exit(1);
+}
 if (existsSync(process.env.FM_ARM_LOG)) {
   console.error("watch arm ran without owning the session lock");
   process.exit(1);
 }
 writeFileSync(`${process.env.FM_HOME}/state/.lock`, `${process.pid}\n`);
-await hooks.event(event);
+const second = await globalThis.__firstmateOpenCodeWatchArm.ensureArmed("session-test", client);
+if (second !== "armed") {
+  console.error(`expected armed after the session lock matched, got ${second}`);
+  process.exit(1);
+}
 for (let i = 0; i < 250 && !existsSync(process.env.FM_ARM_LOG); i += 1) {
   await new Promise((resolve) => setTimeout(resolve, 20));
 }
 if (!existsSync(process.env.FM_ARM_LOG)) {
   console.error("watch arm did not run after the session lock matched");
+  process.exit(1);
+}
+if (prompts !== 1) {
+  console.error(`expected one not-primary diagnostic, got ${prompts}`);
   process.exit(1);
 }
 EOF
@@ -1347,13 +1368,14 @@ EOF
   pass "OpenCode watcher plugin requires session lock ownership"
 }
 
-test_opencode_watch_arm_coordinator_respects_primary_scope() {
-  local plugin base repo home log out status
+test_opencode_watch_arm_coordinator_accepts_linked_primary_scope() {
+  local plugin base repo home log stop out status
   plugin="$ROOT/.opencode/plugins/fm-primary-watch-arm.js"
   base="$TMP_ROOT/opencode-coordinator-base"
   repo="$TMP_ROOT/opencode-coordinator-wt"
   home="$TMP_ROOT/opencode-coordinator-home"
   log="$TMP_ROOT/opencode-coordinator.log"
+  stop="$TMP_ROOT/opencode-coordinator.stop"
   fm_git_worktree "$base" "$repo" fm/opencode-coordinator
   mkdir -p "$repo/bin" "$home/state" "$home/config"
   : > "$repo/AGENTS.md"
@@ -1361,37 +1383,53 @@ test_opencode_watch_arm_coordinator_respects_primary_scope() {
   cat > "$repo/bin/fm-watch-arm.sh" <<'SH'
 #!/usr/bin/env bash
 printf 'arm\n' >> "${FM_ARM_LOG:?}"
-printf 'watcher: healthy pid=1 (beacon 0s)\n'
+printf 'watcher: started pid=%s (beacon fresh)\n' "$$"
+trap 'exit 0' TERM INT
+while [ ! -e "${FM_STOP_FILE:?}" ]; do sleep 0.02; done
 SH
   chmod +x "$repo/bin/fm-watch-arm.sh"
-  out=$(PLUGIN="$plugin" WORKTREE="$repo" FM_HOME="$home" FM_ARM_LOG="$log" node 2>&1 <<'EOF'
+  out=$(PLUGIN="$plugin" WORKTREE="$repo" FM_HOME="$home" FM_ARM_LOG="$log" FM_STOP_FILE="$stop" node 2>&1 <<'EOF'
 import { existsSync, writeFileSync } from "node:fs";
 import { pathToFileURL } from "node:url";
 
 const mod = await import(pathToFileURL(process.env.PLUGIN).href);
-const client = { session: { promptAsync: async () => {} } };
+let prompts = 0;
+const client = { session: { promptAsync: async () => { prompts += 1; } } };
 await mod.FmPrimaryWatchArm({
   client,
   directory: process.env.WORKTREE,
   worktree: process.env.WORKTREE,
 });
-writeFileSync(`${process.env.FM_HOME}/state/.lock`, `${process.pid}\n`);
-const status = await globalThis.__firstmateOpenCodeWatchArm.ensureArmed("session-test", client);
-await new Promise((resolve) => setTimeout(resolve, 120));
-if (status !== "not-primary") {
-  console.error(`expected not-primary, got ${status}`);
+const beforeLock = await globalThis.__firstmateOpenCodeWatchArm.ensureArmed("session-test", client);
+if (beforeLock !== "not-primary") {
+  console.error(`expected not-primary without lock, got ${beforeLock}`);
   process.exit(1);
 }
 if (existsSync(process.env.FM_ARM_LOG)) {
-  console.error("coordinator armed from a linked worktree");
+  console.error("watch arm ran from a linked worktree without primary evidence");
   process.exit(1);
 }
+writeFileSync(`${process.env.FM_HOME}/state/.lock`, `${process.pid}\n`);
+const status = await globalThis.__firstmateOpenCodeWatchArm.ensureArmed("session-test", client);
+if (status !== "armed") {
+  console.error(`expected armed, got ${status}`);
+  process.exit(1);
+}
+if (!existsSync(process.env.FM_ARM_LOG)) {
+  console.error("watch arm did not run from a linked primary worktree");
+  process.exit(1);
+}
+if (prompts !== 1) {
+  console.error(`expected one not-primary diagnostic, got ${prompts}`);
+  process.exit(1);
+}
+writeFileSync(process.env.FM_STOP_FILE, "stop\n");
 EOF
-)
+  )
   status=$?
-  expect_code 0 "$status" "OpenCode watch coordinator must keep primary scope checks in the shared arm path"
-  [ -z "$out" ] || fail "OpenCode coordinator-scope test printed output: $out"
-  pass "OpenCode watcher coordinator respects primary scope"
+  expect_code 0 "$status" "OpenCode watch coordinator must accept positive primary evidence in a linked worktree"
+  [ -z "$out" ] || fail "OpenCode coordinator linked-primary test printed output: $out"
+  pass "OpenCode watcher coordinator accepts a linked primary worktree"
 }
 
 test_opencode_primary_watch_plugin_rearms_after_wake() {
@@ -2143,7 +2181,7 @@ test_opencode_plugin_package_boundary_is_explicit_esm
 test_opencode_primary_watch_plugin_uses_effective_state_home
 test_opencode_primary_watch_plugin_sources_effective_config
 test_opencode_primary_watch_plugin_requires_session_lock
-test_opencode_watch_arm_coordinator_respects_primary_scope
+test_opencode_watch_arm_coordinator_accepts_linked_primary_scope
 test_opencode_primary_watch_plugin_rearms_after_wake
 test_opencode_pre_ready_actionable_close_preserves_its_successor
 test_opencode_hung_successor_falls_back_to_typed_wake

--- a/tests/fm-pi-watch-extension.test.sh
+++ b/tests/fm-pi-watch-extension.test.sh
@@ -59,6 +59,11 @@ export const Type = {
 JS
 }
 
+install_opencode_scope_fixture() {
+  local repo=$1
+  cp "$ROOT/bin/fm-primary-scope-lib.sh" "$repo/bin/fm-primary-scope-lib.sh"
+}
+
 test_pi_extension_reports_external_healthy_watcher() {
   local repo home plugin out status
   repo="$TMP_ROOT/pi-external-healthy-root"
@@ -1205,6 +1210,7 @@ test_opencode_primary_watch_plugin_uses_effective_state_home() {
   mkdir -p "$repo/bin" "$home/state" "$home/config"
   git init -q "$repo"
   : > "$repo/AGENTS.md"
+  install_opencode_scope_fixture "$repo"
   : > "$home/state/task.meta"
   cat > "$repo/bin/fm-watch-arm.sh" <<'SH'
 #!/usr/bin/env bash
@@ -1255,6 +1261,7 @@ test_opencode_primary_watch_plugin_sources_effective_config() {
   mkdir -p "$repo/bin" "$home/state" "$home/config"
   git init -q "$repo"
   : > "$repo/AGENTS.md"
+  install_opencode_scope_fixture "$repo"
   : > "$home/state/task.meta"
   printf 'export FM_POLL=7\n' > "$home/config/x-mode.env"
   cat > "$repo/bin/fm-watch-arm.sh" <<'SH'
@@ -1305,6 +1312,7 @@ test_opencode_primary_watch_plugin_requires_session_lock() {
   mkdir -p "$repo/bin" "$home/state" "$home/config"
   git init -q "$repo"
   : > "$repo/AGENTS.md"
+  install_opencode_scope_fixture "$repo"
   : > "$home/state/task.meta"
   cat > "$repo/bin/fm-watch-arm.sh" <<'SH'
 #!/usr/bin/env bash
@@ -1318,17 +1326,8 @@ import { pathToFileURL } from "node:url";
 
 const mod = await import(pathToFileURL(process.env.PLUGIN).href);
 let prompts = 0;
-const client = {
-  session: {
-    promptAsync: async (request) => {
-      prompts += 1;
-      if (!request.body.parts[0].text.includes("primary scope is not-primary")) {
-        throw new Error(`unexpected diagnostic: ${request.body.parts[0].text}`);
-      }
-    },
-  },
-};
-const hooks = await mod.FmPrimaryWatchArm({
+const client = { session: { promptAsync: async () => { prompts += 1; } } };
+await mod.FmPrimaryWatchArm({
   client,
   directory: process.env.WORKTREE,
   worktree: process.env.WORKTREE,
@@ -1356,8 +1355,8 @@ if (!existsSync(process.env.FM_ARM_LOG)) {
   console.error("watch arm did not run after the session lock matched");
   process.exit(1);
 }
-if (prompts !== 1) {
-  console.error(`expected one not-primary diagnostic, got ${prompts}`);
+if (prompts !== 0) {
+  console.error(`expected no not-primary diagnostic, got ${prompts}`);
   process.exit(1);
 }
 EOF
@@ -1373,12 +1372,13 @@ test_opencode_watch_arm_coordinator_accepts_linked_primary_scope() {
   plugin="$ROOT/.opencode/plugins/fm-primary-watch-arm.js"
   base="$TMP_ROOT/opencode-coordinator-base"
   repo="$TMP_ROOT/opencode-coordinator-wt"
-  home="$TMP_ROOT/opencode-coordinator-home"
+  home="$TMP_ROOT/opencode-coordinator-wt"
   log="$TMP_ROOT/opencode-coordinator.log"
   stop="$TMP_ROOT/opencode-coordinator.stop"
   fm_git_worktree "$base" "$repo" fm/opencode-coordinator
   mkdir -p "$repo/bin" "$home/state" "$home/config"
   : > "$repo/AGENTS.md"
+  install_opencode_scope_fixture "$repo"
   : > "$home/state/task.meta"
   cat > "$repo/bin/fm-watch-arm.sh" <<'SH'
 #!/usr/bin/env bash
@@ -1393,22 +1393,12 @@ import { existsSync, writeFileSync } from "node:fs";
 import { pathToFileURL } from "node:url";
 
 const mod = await import(pathToFileURL(process.env.PLUGIN).href);
-let prompts = 0;
-const client = { session: { promptAsync: async () => { prompts += 1; } } };
+const client = { session: { promptAsync: async () => {} } };
 await mod.FmPrimaryWatchArm({
   client,
   directory: process.env.WORKTREE,
   worktree: process.env.WORKTREE,
 });
-const beforeLock = await globalThis.__firstmateOpenCodeWatchArm.ensureArmed("session-test", client);
-if (beforeLock !== "not-primary") {
-  console.error(`expected not-primary without lock, got ${beforeLock}`);
-  process.exit(1);
-}
-if (existsSync(process.env.FM_ARM_LOG)) {
-  console.error("watch arm ran from a linked worktree without primary evidence");
-  process.exit(1);
-}
 writeFileSync(`${process.env.FM_HOME}/state/.lock`, `${process.pid}\n`);
 const status = await globalThis.__firstmateOpenCodeWatchArm.ensureArmed("session-test", client);
 if (status !== "armed") {
@@ -1419,10 +1409,6 @@ if (!existsSync(process.env.FM_ARM_LOG)) {
   console.error("watch arm did not run from a linked primary worktree");
   process.exit(1);
 }
-if (prompts !== 1) {
-  console.error(`expected one not-primary diagnostic, got ${prompts}`);
-  process.exit(1);
-}
 writeFileSync(process.env.FM_STOP_FILE, "stop\n");
 EOF
   )
@@ -1430,6 +1416,66 @@ EOF
   expect_code 0 "$status" "OpenCode watch coordinator must accept positive primary evidence in a linked worktree"
   [ -z "$out" ] || fail "OpenCode coordinator linked-primary test printed output: $out"
   pass "OpenCode watcher coordinator accepts a linked primary worktree"
+}
+
+test_opencode_watch_arm_accepts_bash_active_state_evidence() {
+  local plugin repo evidence home log stop out status
+  plugin="$ROOT/.opencode/plugins/fm-primary-watch-arm.js"
+  repo="$TMP_ROOT/opencode-evidence-root"
+  mkdir -p "$repo/bin"
+  git init -q "$repo"
+  : > "$repo/AGENTS.md"
+  install_opencode_scope_fixture "$repo"
+  cat > "$repo/bin/fm-watch-arm.sh" <<'SH'
+#!/usr/bin/env bash
+printf 'arm\n' >> "$FM_ARM_LOG"
+printf 'watcher: started pid=%s (beacon fresh)\n' "$$"
+trap 'exit 0' TERM INT
+while [ ! -e "$FM_STOP_FILE" ]; do sleep 0.02; done
+SH
+  chmod +x "$repo/bin/fm-watch-arm.sh"
+  for evidence in metadata relay source; do
+    home="$TMP_ROOT/opencode-evidence-$evidence-home"
+    log="$TMP_ROOT/opencode-evidence-$evidence.log"
+    stop="$TMP_ROOT/opencode-evidence-$evidence.stop"
+    mkdir -p "$home/state" "$home/config"
+    case "$evidence" in
+      metadata) : > "$home/state/task.meta" ;;
+      relay) : > "$home/state/x-watch.check.sh" ;;
+      source) mkdir -p "$home/state/procevent"; : > "$home/state/procevent/test.source" ;;
+    esac
+    out=$(PLUGIN="$plugin" WORKTREE="$repo" FM_HOME="$home" FM_ARM_LOG="$log" FM_STOP_FILE="$stop" node 2>&1 <<'EOF'
+import { existsSync, writeFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+
+const mod = await import(pathToFileURL(process.env.PLUGIN).href);
+const client = { session: { promptAsync: async () => {} } };
+await mod.FmPrimaryWatchArm({
+  client,
+  directory: process.env.WORKTREE,
+  worktree: process.env.WORKTREE,
+});
+writeFileSync(process.env.FM_HOME + "/state/.lock", process.pid + "\n");
+const status = await globalThis.__firstmateOpenCodeWatchArm.ensureArmed("session-test", client);
+if (status !== "armed") {
+  console.error("expected armed, got " + status);
+  process.exit(1);
+}
+for (let i = 0; i < 250 && !existsSync(process.env.FM_ARM_LOG); i += 1) {
+  await new Promise((resolve) => setTimeout(resolve, 20));
+}
+if (!existsSync(process.env.FM_ARM_LOG)) {
+  console.error("watch arm did not run");
+  process.exit(1);
+}
+writeFileSync(process.env.FM_STOP_FILE, "stop\n");
+EOF
+    )
+    status=$?
+    expect_code 0 "$status" "OpenCode must accept bash active-state evidence: $evidence"
+    [ -z "$out" ] || fail "OpenCode $evidence evidence test printed output: $out"
+  done
+  pass "OpenCode watcher accepts metadata, Relay, and process-event evidence from the bash scope owner"
 }
 
 test_opencode_primary_watch_plugin_rearms_after_wake() {
@@ -1442,6 +1488,7 @@ test_opencode_primary_watch_plugin_rearms_after_wake() {
   mkdir -p "$repo/bin" "$home/state" "$home/config"
   git init -q "$repo"
   : > "$repo/AGENTS.md"
+  install_opencode_scope_fixture "$repo"
   : > "$home/state/task.meta"
   cat > "$repo/bin/fm-watch-arm.sh" <<'SH'
 #!/usr/bin/env bash
@@ -1523,6 +1570,7 @@ test_opencode_pre_ready_actionable_close_preserves_its_successor() {
   mkdir -p "$repo/bin" "$home/state" "$home/config"
   git init -q "$repo"
   : > "$repo/AGENTS.md"
+  install_opencode_scope_fixture "$repo"
   : > "$home/state/task.meta"
   cat > "$repo/bin/fm-watch-arm.sh" <<'SH'
 #!/usr/bin/env bash
@@ -1603,6 +1651,7 @@ test_opencode_hung_successor_falls_back_to_typed_wake() {
   mkdir -p "$repo/bin" "$home/state" "$home/config"
   git init -q "$repo"
   : > "$repo/AGENTS.md"
+  install_opencode_scope_fixture "$repo"
   : > "$home/state/task.meta"
   cat > "$repo/bin/fm-watch-arm.sh" <<'SH'
 #!/usr/bin/env bash
@@ -1672,6 +1721,7 @@ test_opencode_unretired_successor_falls_back_without_retry() {
   mkdir -p "$repo/bin" "$home/state" "$home/config"
   git init -q "$repo"
   : > "$repo/AGENTS.md"
+  install_opencode_scope_fixture "$repo"
   : > "$home/state/task.meta"
   cat > "$repo/bin/fm-watch-arm.sh" <<'SH'
 #!/usr/bin/env bash
@@ -1749,6 +1799,7 @@ test_opencode_late_unretired_close_resumes_supervision() {
     mkdir -p "$repo/bin" "$home/state" "$home/config"
     git init -q "$repo"
     : > "$repo/AGENTS.md"
+    install_opencode_scope_fixture "$repo"
     : > "$home/state/task.meta"
     cat > "$repo/bin/fm-watch-arm.sh" <<'SH'
 #!/usr/bin/env bash
@@ -1844,6 +1895,7 @@ test_opencode_empty_close_retries_instead_of_disappearing() {
   mkdir -p "$repo/bin" "$home/state" "$home/config"
   git init -q "$repo"
   : > "$repo/AGENTS.md"
+  install_opencode_scope_fixture "$repo"
   : > "$home/state/task.meta"
   cat > "$repo/bin/fm-watch-arm.sh" <<'SH'
 #!/usr/bin/env bash
@@ -1903,6 +1955,7 @@ test_opencode_established_empty_close_honors_retry_limit() {
   mkdir -p "$repo/bin" "$home/state" "$home/config"
   git init -q "$repo"
   : > "$repo/AGENTS.md"
+  install_opencode_scope_fixture "$repo"
   : > "$home/state/task.meta"
   cat > "$repo/bin/fm-watch-arm.sh" <<'SH'
 #!/usr/bin/env bash
@@ -1957,6 +2010,7 @@ test_opencode_actionable_close_rechecks_session_lock() {
   mkdir -p "$repo/bin" "$home/state" "$home/config"
   git init -q "$repo"
   : > "$repo/AGENTS.md"
+  install_opencode_scope_fixture "$repo"
   : > "$home/state/task.meta"
   cat > "$repo/bin/fm-watch-arm.sh" <<'SH'
 #!/usr/bin/env bash
@@ -1995,12 +2049,12 @@ try {
   writeFileSync(lock, `${other.pid}\n`);
   writeFileSync(process.env.FM_RELEASE_FILE, "release\n");
   await eventPromise;
-  for (let i = 0; i < 250 && !prompt.includes("no longer owns the lock"); i += 1) {
+  for (let i = 0; i < 250 && !prompt.includes("could not verify a ready successor watcher (not-primary)"); i += 1) {
     await new Promise((resolve) => setTimeout(resolve, 10));
   }
   const rows = readFileSync(process.env.FM_ARM_LOG, "utf8").trim().split("\n");
   if (rows.length !== 1) throw new Error(`successor launched after lock loss: ${rows.join(" | ")}`);
-  if (!prompt.includes("no longer owns the lock")) throw new Error(`missing lock-loss failure: ${prompt}`);
+  if (!prompt.includes("could not verify a ready successor watcher (not-primary)")) throw new Error(`missing lock-loss failure: ${prompt}`);
 } finally {
   other.kill("SIGTERM");
 }
@@ -2023,6 +2077,7 @@ test_opencode_watch_arm_coordinates_with_turnend_guard() {
   mkdir -p "$repo/bin" "$home/state" "$home/config"
   git init -q "$repo"
   : > "$repo/AGENTS.md"
+  install_opencode_scope_fixture "$repo"
   : > "$home/state/task.meta"
   cat > "$repo/bin/fm-watch-arm.sh" <<'SH'
 #!/usr/bin/env bash
@@ -2096,6 +2151,7 @@ test_opencode_healthy_arm_output_does_not_suppress_guard() {
   mkdir -p "$repo/bin" "$home/state" "$home/config"
   git init -q "$repo"
   : > "$repo/AGENTS.md"
+  install_opencode_scope_fixture "$repo"
   : > "$home/state/task.meta"
   cat > "$repo/bin/fm-watch-arm.sh" <<'SH'
 #!/usr/bin/env bash
@@ -2182,6 +2238,7 @@ test_opencode_primary_watch_plugin_uses_effective_state_home
 test_opencode_primary_watch_plugin_sources_effective_config
 test_opencode_primary_watch_plugin_requires_session_lock
 test_opencode_watch_arm_coordinator_accepts_linked_primary_scope
+test_opencode_watch_arm_accepts_bash_active_state_evidence
 test_opencode_primary_watch_plugin_rearms_after_wake
 test_opencode_pre_ready_actionable_close_preserves_its_successor
 test_opencode_hung_successor_falls_back_to_typed_wake

--- a/tests/fm-subagent-pretool-check.test.sh
+++ b/tests/fm-subagent-pretool-check.test.sh
@@ -16,6 +16,8 @@ ERR="$TMP_ROOT/err"
 mkdir -p "$PRIMARY/bin" "$STATE"
 printf '# fixture\n' > "$PRIMARY/AGENTS.md"
 git -C "$PRIMARY" init -q
+printf '%s\n' "$$" > "$STATE/.lock"
+: > "$STATE/task.meta"
 
 BRIEF_ONLY_ROUTE='first classify the work under the AGENTS.md intake contract, then use bin/fm-brief.sh followed by bin/fm-spawn.sh for dispatched work'
 SCOUT_ROUTE='first classify the work under the AGENTS.md intake contract: work already classified as a scout goes to bin/fm-scout.sh "<question>" [project], while authorized ship work and its bounded research go to bin/fm-brief.sh then bin/fm-spawn.sh'
@@ -211,6 +213,8 @@ test_secondmate_home_is_in_scope() {
   mkdir -p "$second/bin" "$second/state"
   printf '# fixture\n' > "$second/AGENTS.md"
   printf 'sm-fixture\n' > "$second/.fm-secondmate-home"
+  printf '%s\n' "$$" > "$second/state/.lock"
+  : > "$second/state/task.meta"
   FM_ROOT_OVERRIDE="$second" FM_HOME="$second" FM_STATE_OVERRIDE="$second/state" \
     "$CHECK" --claude --tool Agent > "$OUT" 2> "$ERR" || rc=$?
   [ "$rc" -eq 2 ] || fail "a marked secondmate home operates a fleet and must be guarded, got exit $rc"

--- a/tests/fm-turnend-guard.test.sh
+++ b/tests/fm-turnend-guard.test.sh
@@ -134,6 +134,7 @@ make_primary_dir() {
   git init -q "$dir"
   git -C "$dir" commit -q --allow-empty -m init
   : > "$dir/AGENTS.md"
+  printf '%s\n' "$$" > "$dir/state/.lock"
   install_guard_scripts "$dir"
   printf '%s\n' "$dir"
 }
@@ -185,6 +186,7 @@ make_secondmate_linked_home_dir() {
   : > "$dir/AGENTS.md"
   install_guard_scripts "$dir"
   printf 'sm-linked-1\n' > "$dir/.fm-secondmate-home"
+  printf '%s\n' "$$" > "$dir/state/.lock"
   printf '%s\n' "$dir"
 }
 
@@ -367,6 +369,7 @@ test_hook_blocks_from_fm_home_state() {
   dir=$(make_primary_dir "$TMP_ROOT/hook-fm-home")
   home="$TMP_ROOT/hook-fm-home-op"
   mkdir -p "$home/state"
+  printf '%s\n' "$$" > "$home/state/.lock"
   : > "$home/state/task1.meta"
   out=$(printf '{"stop_hook_active":false}' | CLAUDECODE=1 FM_HOME="$home" bash "$dir/bin/fm-turnend-guard.sh" 2>&1); status=$?
   expect_code 2 "$status" "hook must inspect the active FM_HOME state dir"
@@ -415,6 +418,7 @@ test_hook_uses_state_override() {
   home="$TMP_ROOT/hook-state-override-home"
   state="$TMP_ROOT/hook-state-override-active"
   mkdir -p "$home/state" "$state"
+  printf '%s\n' "$$" > "$state/.lock"
   : > "$state/task1.meta"
   out=$(printf '{"stop_hook_active":false}' | CLAUDECODE=1 FM_HOME="$home" FM_STATE_OVERRIDE="$state" bash "$dir/bin/fm-turnend-guard.sh" 2>&1); status=$?
   expect_code 2 "$status" "hook must let FM_STATE_OVERRIDE win over FM_HOME/state"
@@ -517,7 +521,8 @@ test_hook_secondmate_reinvoke_recovery_loop() {
 # The marker force-include must guard only the secondmate's OWN home, never its
 # children: a secondmate's linked crew/scout worktree carries no marker, so it
 # stays exempt by the same git-dir/git-common-dir test that exempts the main
-# home's children.
+# home's children. An inherited secondmate FM_HOME must not make that child
+# primary either.
 test_hook_silent_in_secondmate_child_worktree() {
   local home dir out status
   home=$(make_secondmate_dir "$TMP_ROOT/hook-sm-child-home")
@@ -527,7 +532,27 @@ test_hook_silent_in_secondmate_child_worktree() {
   out=$(run_hook "$dir" false); status=$?
   expect_code 0 "$status" "hook must stay exempt in a secondmate's own child crew/scout worktree"
   [ -z "$out" ] || fail "hook produced output inside a secondmate's child worktree: $out"
+  : > "$home/state/task1.meta"
+  out=$(printf '{"stop_hook_active":false}' | CLAUDECODE=1 FM_HOME="$home" bash "$dir/bin/fm-turnend-guard.sh" 2>&1); status=$?
+  expect_code 0 "$status" "a child worktree must stay exempt when it inherits its secondmate parent's FM_HOME"
+  [ -z "$out" ] || fail "inherited secondmate FM_HOME spoofed primary scope in child worktree: $out"
   pass "fm-turnend-guard: inert in a secondmate's own child worktree (linked git worktree) even when unhealthy"
+}
+
+test_primary_scope_accepts_linked_primary_home() {
+  local base dir out
+  base="$TMP_ROOT/scope-linked-primary-base"
+  dir="$TMP_ROOT/scope-linked-primary-home"
+  fm_git_worktree "$base" "$dir" fm/turnend-linked-primary
+  mkdir -p "$dir/state"
+  : > "$dir/AGENTS.md"
+  install_guard_scripts "$dir"
+  printf '%s\n' "$$" > "$dir/state/.lock"
+  : > "$dir/state/task1.meta"
+  out=$(bash -c '. "$1"; fm_primary_scope_matches "$2" "$3" && printf matched' _ \
+    "$dir/bin/fm-primary-scope-lib.sh" "$dir" "$dir/state")
+  [ "$out" = matched ] || fail "linked primary scope rejected positive evidence: $out"
+  pass "fm-primary-scope-lib: accepts a linked primary home from lock, hooks, and task metadata"
 }
 
 # THE regression the plain git-init fixtures masked: a treehouse-leased secondmate
@@ -1561,6 +1586,7 @@ test_hook_silent_in_idle_secondmate_home
 test_hook_secondmate_loop_guard_allows_retry
 test_hook_secondmate_reinvoke_recovery_loop
 test_hook_silent_in_secondmate_child_worktree
+test_primary_scope_accepts_linked_primary_home
 test_hook_blocks_in_treehouse_leased_secondmate_home
 test_hook_exempts_linked_worktree_with_stray_marker
 test_hook_exempts_linked_worktree_with_non_ascii_marker

--- a/tests/fm-turnend-guard.test.sh
+++ b/tests/fm-turnend-guard.test.sh
@@ -161,10 +161,9 @@ make_crewmate_worktree_dir() {
 }
 
 # A secondmate home's OWN child crew/scout worktree: a genuine linked git
-# worktree of the secondmate home, so git-dir != git-common-dir exactly as for a
-# main-home child worktree. A child worktree never carries the gitignored
-# .fm-secondmate-home marker, so the marker force-include never fires for it and
-# it stays exempt through the linked-worktree git-dir test.
+# worktree of the secondmate home. A child worktree never carries the gitignored
+# .fm-secondmate-home marker, so the child cannot inherit its parent's primary
+# scope.
 make_secondmate_child_worktree_dir() {
   local home=$1 dir=$2
   git -C "$home" worktree add --quiet -b fm/turnend-secondmate-child "$dir"
@@ -520,9 +519,8 @@ test_hook_secondmate_reinvoke_recovery_loop() {
 
 # The marker force-include must guard only the secondmate's OWN home, never its
 # children: a secondmate's linked crew/scout worktree carries no marker, so it
-# stays exempt by the same git-dir/git-common-dir test that exempts the main
-# home's children. An inherited secondmate FM_HOME must not make that child
-# primary either.
+# stays exempt from primary scope. An inherited secondmate FM_HOME must not make
+# that child primary either.
 test_hook_silent_in_secondmate_child_worktree() {
   local home dir out status
   home=$(make_secondmate_dir "$TMP_ROOT/hook-sm-child-home")
@@ -539,6 +537,18 @@ test_hook_silent_in_secondmate_child_worktree() {
   pass "fm-turnend-guard: inert in a secondmate's own child worktree (linked git worktree) even when unhealthy"
 }
 
+test_hook_silent_in_main_child_worktree_with_inherited_home() {
+  local home dir out status
+  home=$(make_primary_dir "$TMP_ROOT/hook-main-child-home")
+  dir="$TMP_ROOT/hook-main-child-wt"
+  make_crewmate_worktree_dir "$home" "$dir" >/dev/null
+  : > "$home/state/task1.meta"
+  out=$(printf '{"stop_hook_active":false}' | CLAUDECODE=1 FM_HOME="$home" bash "$dir/bin/fm-turnend-guard.sh" 2>&1); status=$?
+  expect_code 0 "$status" "a main primary FM_HOME must not widen scope into its child worktree"
+  [ -z "$out" ] || fail "inherited main FM_HOME spoofed primary scope in child worktree: $out"
+  pass "fm-turnend-guard: inert in a main home's child worktree with inherited FM_HOME"
+}
+
 test_primary_scope_accepts_linked_primary_home() {
   local base dir out
   base="$TMP_ROOT/scope-linked-primary-base"
@@ -552,7 +562,7 @@ test_primary_scope_accepts_linked_primary_home() {
   out=$(bash -c '. "$1"; fm_primary_scope_matches "$2" "$3" && printf matched' _ \
     "$dir/bin/fm-primary-scope-lib.sh" "$dir" "$dir/state")
   [ "$out" = matched ] || fail "linked primary scope rejected positive evidence: $out"
-  pass "fm-primary-scope-lib: accepts a linked primary home from lock, hooks, and task metadata"
+  pass "fm-primary-scope-lib: accepts a linked primary home from lock and active task metadata"
 }
 
 # THE regression the plain git-init fixtures masked: a treehouse-leased secondmate
@@ -596,7 +606,7 @@ test_hook_exempts_linked_worktree_with_stray_marker() {
 # Anti-spoof under any locale: a NON-ASCII marker id must be REJECTED by the
 # ASCII-only (C-collation) allowlist, so it can never force-include a linked
 # worktree even where the ambient locale's collation would treat it as a letter.
-# Rejection -> git-dir exemption -> the linked worktree stays exempt.
+# Rejection -> no root/home identity -> the linked worktree stays exempt.
 test_hook_exempts_linked_worktree_with_non_ascii_marker() {
   local base dir out status
   base="$TMP_ROOT/hook-nonascii-marker-base"
@@ -1586,6 +1596,7 @@ test_hook_silent_in_idle_secondmate_home
 test_hook_secondmate_loop_guard_allows_retry
 test_hook_secondmate_reinvoke_recovery_loop
 test_hook_silent_in_secondmate_child_worktree
+test_hook_silent_in_main_child_worktree_with_inherited_home
 test_primary_scope_accepts_linked_primary_home
 test_hook_blocks_in_treehouse_leased_secondmate_home
 test_hook_exempts_linked_worktree_with_stray_marker

--- a/tests/fm-turnend-guard.test.sh
+++ b/tests/fm-turnend-guard.test.sh
@@ -565,6 +565,25 @@ test_primary_scope_accepts_linked_primary_home() {
   pass "fm-primary-scope-lib: accepts a linked primary home from lock and active task metadata"
 }
 
+test_primary_scope_rejects_unsafe_lock_evidence() {
+  local dir target out
+  dir=$(make_primary_dir "$TMP_ROOT/scope-unsafe-lock")
+  : > "$dir/state/task1.meta"
+  target="$TMP_ROOT/scope-unsafe-lock-target"
+  printf '%s\n' "$$" > "$target"
+  rm "$dir/state/.lock"
+  ln -s "$target" "$dir/state/.lock"
+  out=$(bash -c '. "$1"; fm_primary_scope_matches "$2" "$3" && printf matched' _ \
+    "$dir/bin/fm-primary-scope-lib.sh" "$dir" "$dir/state")
+  [ -z "$out" ] || fail "linked lock evidence spoofed primary scope: $out"
+  rm "$dir/state/.lock"
+  printf '1\n' > "$dir/state/.lock"
+  out=$(bash -c '. "$1"; fm_primary_scope_matches "$2" "$3" && printf matched' _ \
+    "$dir/bin/fm-primary-scope-lib.sh" "$dir" "$dir/state")
+  [ -z "$out" ] || fail "PID 1 lock evidence spoofed primary scope: $out"
+  pass "fm-primary-scope-lib: rejects symlinked and PID 1 lock evidence"
+}
+
 # THE regression the plain git-init fixtures masked: a treehouse-leased secondmate
 # home is a genuine LINKED worktree (git-dir != git-common-dir), which the
 # remove-only form wrongly exempted. With the marker force-include, its own
@@ -1598,6 +1617,7 @@ test_hook_secondmate_reinvoke_recovery_loop
 test_hook_silent_in_secondmate_child_worktree
 test_hook_silent_in_main_child_worktree_with_inherited_home
 test_primary_scope_accepts_linked_primary_home
+test_primary_scope_rejects_unsafe_lock_evidence
 test_hook_blocks_in_treehouse_leased_secondmate_home
 test_hook_exempts_linked_worktree_with_stray_marker
 test_hook_exempts_linked_worktree_with_non_ascii_marker


### PR DESCRIPTION
## Intent

Prepare the upstream PR for issue #1809: OpenCode linked-worktree primary supervision. Replace git-topology-only primary detection (`gitDir == commonDir`) with evidence-based primary scope so a real primary home that lives in a linked git worktree arms supervision instead of silently returning `not-primary`.

Keep the change scoped to the evidence-based predicate, the once-only not-primary diagnostic, and their direct callers, tests, and docs. Align OpenCode watcher arming with the shared shell primary-scope contract (session-lock ownership, primary-shaped home layout, active state such as task metadata / Relay / procevent, rejection of secondmate and inherited-child homes). Ordinary task worktrees must stay out of primary scope.

Validate with the focused primary-scope coverage in `tests/fm-turnend-guard.test.sh` and `tests/fm-pi-watch-extension.test.sh`, shell lint on changed bin scripts, and documentation checks. Open the upstream PR against `kunchenguid/firstmate`; do not merge or push the default branch.

This is a linked-worktree primary-home fix, not an OpenCode headless / `opencode run` limitation. Sibling precedent: #582 (secondmate homes and `.fm-secondmate-home`).

## What Changed

- Replaced git topology-only primary detection with shared lock and active-state evidence, including `--prelock` handling for session-start callers and inherited-home rejection for child worktrees.
- Updated OpenCode watcher supervision with shared scope checks and once-only not-primary diagnostics.
- Updated focused tests and primary-scope documentation.

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>
</details>
<details>
<summary>✅ **Rebase** - passed</summary>
</details>
<details>
<summary>✅ **Review** - completed</summary>
</details>
<details>
<summary>✅ **Test** - passed</summary>
</details>
<details>
<summary>✅ **Document** - passed</summary>
</details>
<details>
<summary>✅ **Lint** - passed</summary>
</details>
<details>
<summary>✅ **Push** - passed</summary>
</details>