### PR TITLE
fix(bin): canonicalize watcher lock owner paths

### DIFF
--- a/bin/fm-wake-lib.sh
+++ b/bin/fm-wake-lib.sh
@@ -124,21 +124,27 @@ fm_watcher_canonical_path() {
   return 1
 }
 
-FM_WATCHER_MATCHED_IDENTITY=
-fm_watcher_lock_matches_pid() {
-  local state=$1 watch_path=$2 pid=$3 home=${4:-$FM_HOME} lockdir lock_home lock_path lock_identity current_identity
+fm_watcher_lock_matches_owner() {
+  local state=$1 watch_path=$2 home=${3:-$FM_HOME} lockdir lock_home lock_path
   local canonical_home canonical_watch canonical_lock_home canonical_lock_path
-  FM_WATCHER_MATCHED_IDENTITY=
   lockdir="$state/.watch.lock"
   lock_home=$(cat "$lockdir/fm-home" 2>/dev/null || true)
   lock_path=$(cat "$lockdir/watcher-path" 2>/dev/null || true)
-  lock_identity=$(cat "$lockdir/pid-identity" 2>/dev/null || true)
   canonical_home=$(fm_watcher_canonical_path "$home") || return 1
   canonical_watch=$(fm_watcher_canonical_path "$watch_path") || return 1
   canonical_lock_home=$(fm_watcher_canonical_path "$lock_home") || return 1
   canonical_lock_path=$(fm_watcher_canonical_path "$lock_path") || return 1
   [ "$canonical_lock_home" = "$canonical_home" ] || return 1
   [ "$canonical_lock_path" = "$canonical_watch" ] || return 1
+}
+
+FM_WATCHER_MATCHED_IDENTITY=
+fm_watcher_lock_matches_pid() {
+  local state=$1 watch_path=$2 pid=$3 home=${4:-$FM_HOME} lockdir lock_identity current_identity
+  FM_WATCHER_MATCHED_IDENTITY=
+  lockdir="$state/.watch.lock"
+  fm_watcher_lock_matches_owner "$state" "$watch_path" "$home" || return 1
+  lock_identity=$(cat "$lockdir/pid-identity" 2>/dev/null || true)
   [ -n "$lock_identity" ] || return 1
   current_identity=$(fm_pid_identity "$pid") || return 1
   [ "$current_identity" = "$lock_identity" ] || return 1
@@ -149,16 +155,13 @@ FM_WATCHER_HEALTHY_PID=
 FM_WATCHER_HEALTHY_IDENTITY=
 fm_watcher_healthy() {
   local state=$1 watch_path=$2 grace=${3:-${FM_GUARD_GRACE:-300}} home=${4:-$FM_HOME} lockdir beat pid identity age
-  local canonical_home canonical_watch
   FM_WATCHER_HEALTHY_PID=
   FM_WATCHER_HEALTHY_IDENTITY=
   lockdir="$state/.watch.lock"
   beat="$state/.last-watcher-beat"
   pid=$(cat "$lockdir/pid" 2>/dev/null || true)
   fm_pid_alive "$pid" || return 1
-  canonical_home=$(fm_watcher_canonical_path "$home") || return 1
-  canonical_watch=$(fm_watcher_canonical_path "$watch_path") || return 1
-  fm_watcher_lock_matches_pid "$state" "$canonical_watch" "$pid" "$canonical_home" || return 1
+  fm_watcher_lock_matches_pid "$state" "$watch_path" "$pid" "$home" || return 1
   identity=$FM_WATCHER_MATCHED_IDENTITY
   age=$(fm_path_age "$beat")
   [ "$age" -lt "$grace" ] || return 1

--- a/bin/fm-wake-lib.sh
+++ b/bin/fm-wake-lib.sh
@@ -78,16 +78,67 @@ fm_path_age() {
   echo $(( $(date +%s) - m ))
 }
 
+fm_watcher_canonical_path() {
+  local path=$1 dir base link hops=0
+  [ -n "$path" ] || return 1
+  if [ ! -e "$path" ] && [ ! -L "$path" ]; then
+    dir=$(dirname -- "$path")
+    base=$(basename -- "$path")
+    [ -d "$dir" ] || return 1
+    if command -v realpath >/dev/null 2>&1; then
+      dir=$(realpath -- "$dir" 2>/dev/null) || return 1
+    else
+      dir=$(CDPATH='' cd -P -- "$dir" 2>/dev/null && pwd -P) || return 1
+    fi
+    printf '%s/%s\n' "$dir" "$base"
+    return
+  fi
+  if command -v realpath >/dev/null 2>&1; then
+    realpath -- "$path" 2>/dev/null
+    return
+  fi
+  # Portable fallback for environments without realpath. Physical parent
+  # resolution handles case-normalized directory components and intermediate
+  # symlinks; the bounded loop resolves a symlink in the final component.
+  while [ "$hops" -lt 40 ]; do
+    if [ -d "$path" ]; then
+      CDPATH='' cd -P -- "$path" 2>/dev/null && pwd -P
+      return
+    fi
+    { [ -e "$path" ] || [ -L "$path" ]; } || return 1
+    dir=$(dirname -- "$path")
+    base=$(basename -- "$path")
+    dir=$(CDPATH='' cd -P -- "$dir" 2>/dev/null && pwd -P) || return 1
+    path="$dir/$base"
+    if [ ! -L "$path" ]; then
+      printf '%s\n' "$path"
+      return
+    fi
+    link=$(readlink "$path" 2>/dev/null) || return 1
+    case "$link" in
+      /*) path=$link ;;
+      *) path="$dir/$link" ;;
+    esac
+    hops=$((hops + 1))
+  done
+  return 1
+}
+
 FM_WATCHER_MATCHED_IDENTITY=
 fm_watcher_lock_matches_pid() {
   local state=$1 watch_path=$2 pid=$3 home=${4:-$FM_HOME} lockdir lock_home lock_path lock_identity current_identity
+  local canonical_home canonical_watch canonical_lock_home canonical_lock_path
   FM_WATCHER_MATCHED_IDENTITY=
   lockdir="$state/.watch.lock"
   lock_home=$(cat "$lockdir/fm-home" 2>/dev/null || true)
   lock_path=$(cat "$lockdir/watcher-path" 2>/dev/null || true)
   lock_identity=$(cat "$lockdir/pid-identity" 2>/dev/null || true)
-  [ "$lock_home" = "$home" ] || return 1
-  [ "$lock_path" = "$watch_path" ] || return 1
+  canonical_home=$(fm_watcher_canonical_path "$home") || return 1
+  canonical_watch=$(fm_watcher_canonical_path "$watch_path") || return 1
+  canonical_lock_home=$(fm_watcher_canonical_path "$lock_home") || return 1
+  canonical_lock_path=$(fm_watcher_canonical_path "$lock_path") || return 1
+  [ "$canonical_lock_home" = "$canonical_home" ] || return 1
+  [ "$canonical_lock_path" = "$canonical_watch" ] || return 1
   [ -n "$lock_identity" ] || return 1
   current_identity=$(fm_pid_identity "$pid") || return 1
   [ "$current_identity" = "$lock_identity" ] || return 1
@@ -98,13 +149,16 @@ FM_WATCHER_HEALTHY_PID=
 FM_WATCHER_HEALTHY_IDENTITY=
 fm_watcher_healthy() {
   local state=$1 watch_path=$2 grace=${3:-${FM_GUARD_GRACE:-300}} home=${4:-$FM_HOME} lockdir beat pid identity age
+  local canonical_home canonical_watch
   FM_WATCHER_HEALTHY_PID=
   FM_WATCHER_HEALTHY_IDENTITY=
   lockdir="$state/.watch.lock"
   beat="$state/.last-watcher-beat"
   pid=$(cat "$lockdir/pid" 2>/dev/null || true)
   fm_pid_alive "$pid" || return 1
-  fm_watcher_lock_matches_pid "$state" "$watch_path" "$pid" "$home" || return 1
+  canonical_home=$(fm_watcher_canonical_path "$home") || return 1
+  canonical_watch=$(fm_watcher_canonical_path "$watch_path") || return 1
+  fm_watcher_lock_matches_pid "$state" "$canonical_watch" "$pid" "$canonical_home" || return 1
   identity=$FM_WATCHER_MATCHED_IDENTITY
   age=$(fm_path_age "$beat")
   [ "$age" -lt "$grace" ] || return 1

--- a/bin/fm-watch-arm.sh
+++ b/bin/fm-watch-arm.sh
@@ -223,12 +223,9 @@ cycle_mark_predecessor_successor() {
 }
 
 clear_stale_recorded_watcher_lock() {
-  local lock_home lock_path lock_identity
-  lock_home=$(cat "$WATCH_LOCK/fm-home" 2>/dev/null || true)
-  lock_path=$(cat "$WATCH_LOCK/watcher-path" 2>/dev/null || true)
+  local lock_identity
+  fm_watcher_lock_matches_owner "$STATE" "$WATCH" "$FM_HOME" || return 0
   lock_identity=$(cat "$WATCH_LOCK/pid-identity" 2>/dev/null || true)
-  [ "$lock_home" = "$FM_HOME" ] || return 0
-  [ "$lock_path" = "$WATCH" ] || return 0
   [ -n "$lock_identity" ] || return 0
   fm_recovery_transition "$STATE/.watcher-down" clear-stale-lock "$WATCH_LOCK" downtime
 }

--- a/docs/watcher-continuity.md
+++ b/docs/watcher-continuity.md
@@ -71,6 +71,8 @@ The file is size-capped through `FM_WATCH_CYCLE_LOG_MAX_BYTES` and `FM_WATCH_CYC
 
 The default 300-second grace is unchanged.
 Only the watcher process touches `state/.last-watcher-beat`; no helper process can make a wedged watcher appear healthy.
+Watcher health and restart ownership compare the lock's home and watcher path by canonical physical identity, so filesystem-case and symlink aliases share one owner while different homes and unresolvable paths remain isolated.
+An absent final watcher leaf is compared beneath its canonical existing parent, and the separate live-PID and PID-identity checks remain fail-closed.
 
 ## Regression coverage
 

--- a/tests/fm-watcher-lock.test.sh
+++ b/tests/fm-watcher-lock.test.sh
@@ -190,6 +190,91 @@ test_guard_warnings() {
   pass "guard banner leads when down with pending wakes (repair-after-drain) and stays silent when live and fresh"
 }
 
+test_watcher_health_canonicalizes_owner_paths() {
+  local dir state canonical_home canonical_watch case_home case_watch alias_home alias_watch absent_watch
+  local other_home pid identity dead
+  dir=$(make_case watcher-owner-paths)
+  state="$dir/state"
+  canonical_home="$dir/GitHub/firstmate"
+  canonical_watch="$canonical_home/bin/fm-watch.sh"
+  other_home="$dir/GitHub/other-firstmate"
+  mkdir -p "$canonical_home/bin" "$other_home"
+  printf '#!/usr/bin/env bash\n' > "$canonical_watch"
+  chmod +x "$canonical_watch"
+  sleep 300 &
+  pid=$!
+  identity=$(FM_STATE_OVERRIDE="$state" bash -c '. "$1"; fm_pid_identity "$2"' _ "$LIB" "$pid") \
+    || fail "could not identify watcher path fixture pid"
+  mkdir "$state/.watch.lock"
+  printf '%s\n' "$pid" > "$state/.watch.lock/pid"
+  printf '%s\n' "$canonical_home" > "$state/.watch.lock/fm-home"
+  printf '%s\n' "$canonical_watch" > "$state/.watch.lock/watcher-path"
+  printf '%s\n' "$identity" > "$state/.watch.lock/pid-identity"
+  touch "$state/.last-watcher-beat"
+
+  case_home="$dir/github/firstmate"
+  case_watch="$case_home/bin/fm-watch.sh"
+  if [ -d "$case_home" ]; then
+    FM_HOME="$case_home" FM_STATE_OVERRIDE="$state" bash -c \
+      '. "$1"; fm_watcher_lock_matches_pid "$2" "$3" "$4" "$5"' \
+      _ "$LIB" "$state" "$case_watch" "$pid" "$case_home" \
+      || fail "standalone lock owner check rejected case-differing GitHub/github spellings"
+    FM_HOME="$case_home" FM_STATE_OVERRIDE="$state" bash -c \
+      '. "$1"; fm_watcher_healthy "$2" "$3" 300 "$4"' \
+      _ "$LIB" "$state" "$case_watch" "$case_home" \
+      || fail "case-differing GitHub/github spellings did not resolve to one watcher owner"
+  else
+    printf 'skip: watcher GitHub/github case fixture requires a case-insensitive filesystem\n'
+  fi
+
+  alias_home="$dir/home-link"
+  alias_watch="$canonical_home/bin/watch-link"
+  ln -s "$canonical_home" "$alias_home"
+  ln -s "$canonical_watch" "$alias_watch"
+  FM_HOME="$alias_home" FM_STATE_OVERRIDE="$state" bash -c \
+    '. "$1"; fm_watcher_lock_matches_pid "$2" "$3" "$4" "$5"' \
+    _ "$LIB" "$state" "$alias_watch" "$pid" "$alias_home" \
+    || fail "standalone lock owner check rejected symlinked home and watcher paths"
+  FM_HOME="$alias_home" FM_STATE_OVERRIDE="$state" bash -c \
+    '. "$1"; fm_watcher_healthy "$2" "$3" 300 "$4"' \
+    _ "$LIB" "$state" "$alias_watch" "$alias_home" \
+    || fail "symlinked home and watcher paths did not resolve to the recorded owner"
+
+  absent_watch="$canonical_home/bin/not-yet-started.sh"
+  printf '%s\n' "$absent_watch" > "$state/.watch.lock/watcher-path"
+  FM_HOME="$alias_home" FM_STATE_OVERRIDE="$state" bash -c \
+    '. "$1"; fm_watcher_lock_matches_pid "$2" "$3" "$4" "$5"' \
+    _ "$LIB" "$state" "$alias_home/bin/not-yet-started.sh" "$pid" "$alias_home" \
+    || fail "owner check stopped canonicalizing an absent watcher leaf under an existing parent"
+  printf '%s\n' "$canonical_watch" > "$state/.watch.lock/watcher-path"
+
+  if FM_HOME="$other_home" FM_STATE_OVERRIDE="$state" bash -c \
+    '. "$1"; fm_watcher_healthy "$2" "$3" 300 "$4"' \
+    _ "$LIB" "$state" "$canonical_watch" "$other_home"; then
+    fail "canonical owner comparison accepted a different Firstmate home"
+  fi
+
+  printf '%s\n' "$$" > "$state/.watch.lock/pid"
+  if FM_HOME="$canonical_home" FM_STATE_OVERRIDE="$state" bash -c \
+    '. "$1"; fm_watcher_healthy "$2" "$3" 300 "$4"' \
+    _ "$LIB" "$state" "$canonical_watch" "$canonical_home"; then
+    fail "canonical owner comparison accepted the wrong live watcher pid"
+  fi
+
+  dead=$(dead_pid)
+  printf '%s\n' "$dead" > "$state/.watch.lock/pid"
+  printf '%s\n' "$identity" > "$state/.watch.lock/pid-identity"
+  if FM_HOME="$canonical_home" FM_STATE_OVERRIDE="$state" bash -c \
+    '. "$1"; fm_watcher_healthy "$2" "$3" 300 "$4"' \
+    _ "$LIB" "$state" "$canonical_watch" "$canonical_home"; then
+    fail "canonical owner comparison accepted a dead watcher pid"
+  fi
+
+  kill "$pid" 2>/dev/null || true
+  wait "$pid" 2>/dev/null || true
+  pass "watcher health canonicalizes owner paths while PID and cross-home guards stay fail-closed"
+}
+
 test_lock_single_winner_under_concurrency() {
   local dir state lockdir marker i pids pid wins
   dir=$(make_case lock-concurrency)
@@ -1106,6 +1191,7 @@ test_stale_watch_lock_reclaimed
 test_stale_watch_reclaim_publishes_before_clear
 test_live_stale_watch_lock_is_actionable
 test_guard_warnings
+test_watcher_health_canonicalizes_owner_paths
 test_lock_single_winner_under_concurrency
 test_lock_steals_dead_pid_lock
 test_lock_stale_steal_single_winner_under_concurrency

--- a/tests/fm-watcher-lock.test.sh
+++ b/tests/fm-watcher-lock.test.sh
@@ -537,6 +537,47 @@ test_watch_restart_rejects_reused_pid() {
   pass "watch restart preserves recovery without signaling a reused pid"
 }
 
+test_watch_restart_reclaims_aliased_reused_pid_lock() {
+  local dir canonical_home alias_home state fakebin out live pid i lock_pid
+  dir=$(make_case restart-aliased-reused-pid)
+  canonical_home="$dir/GitHub/firstmate"
+  alias_home="$dir/github/firstmate"
+  state="$canonical_home/state"
+  fakebin="$dir/fakebin"
+  out="$dir/restart.out"
+  mkdir -p "$state"
+  if [ ! -d "$alias_home" ]; then
+    alias_home="$dir/home-link"
+    ln -s "$canonical_home" "$alias_home"
+    printf 'skip: restart GitHub/github case fixture requires a case-insensitive filesystem; exercising symlink alias\n'
+  fi
+  mark_pr_check_migration_complete "$state"
+  sleep 300 &
+  live=$!
+  mkdir "$state/.watch.lock"
+  printf '%s\n' "$live" > "$state/.watch.lock/pid"
+  printf '%s\n' "$canonical_home" > "$state/.watch.lock/fm-home"
+  printf '%s\n' "$WATCH" > "$state/.watch.lock/watcher-path"
+  printf '%s\n' "stale watcher identity" > "$state/.watch.lock/pid-identity"
+  PATH="$fakebin:$PATH" FM_HOME="$alias_home" FM_POLL=5 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH_ARM" --restart > "$out" &
+  pid=$!
+  i=0
+  while [ "$i" -lt 80 ]; do
+    grep -qF 'watcher: started pid=' "$out" 2>/dev/null && break
+    sleep 0.1
+    i=$((i + 1))
+  done
+  lock_pid=$(cat "$state/.watch.lock/pid" 2>/dev/null || true)
+  { [ -n "$lock_pid" ] && [ "$lock_pid" != "$live" ] && kill -0 "$lock_pid" 2>/dev/null; } \
+    || fail "restart did not replace aliased reused-pid lock with a live watcher (got '$lock_pid')"
+  grep -F "watcher: started pid=$lock_pid" "$out" >/dev/null || fail "restart did not report the fresh watcher it confirmed"
+  is_live_non_zombie "$live" || fail "restart killed a reused unrelated pid through an owner alias"
+  kill "$pid" "$lock_pid" "$live" 2>/dev/null || true
+  wait "$pid" 2>/dev/null || true
+  wait "$live" 2>/dev/null || true
+  pass "watch restart reclaims an aliased reused-pid lock without signaling its pid"
+}
+
 test_watch_restart_attaches_to_healthy_peer() {
   local dir state fakebin out peer_ready peer identity armpid status i
   dir=$(make_case restart-healthy-peer)
@@ -1201,6 +1242,7 @@ test_lock_empty_pid_uses_minimum_grace
 test_lock_late_claim_loses_after_recreate
 test_lock_paused_mid_acquire_claim_fails_during_steal
 test_watch_restart_rejects_reused_pid
+test_watch_restart_reclaims_aliased_reused_pid_lock
 test_watch_restart_attaches_to_healthy_peer
 test_watcher_self_evicts_on_lock_takeover
 test_arm_self_eviction_is_loud_without_successor

--- a/tests/fm-watcher-lock.test.sh
+++ b/tests/fm-watcher-lock.test.sh
@@ -538,7 +538,7 @@ test_watch_restart_rejects_reused_pid() {
 }
 
 test_watch_restart_reclaims_aliased_reused_pid_lock() {
-  local dir canonical_home alias_home state fakebin out live pid i lock_pid
+  local dir canonical_home alias_home state fakebin out live pid i
   dir=$(make_case restart-aliased-reused-pid)
   canonical_home="$dir/GitHub/firstmate"
   alias_home="$dir/github/firstmate"
@@ -562,20 +562,21 @@ test_watch_restart_reclaims_aliased_reused_pid_lock() {
   PATH="$fakebin:$PATH" FM_HOME="$alias_home" FM_POLL=5 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH_ARM" --restart > "$out" &
   pid=$!
   i=0
-  while [ "$i" -lt 80 ]; do
-    grep -qF 'watcher: started pid=' "$out" 2>/dev/null && break
+  while [ "$i" -lt 80 ] && is_live_non_zombie "$pid"; do
     sleep 0.1
     i=$((i + 1))
   done
-  lock_pid=$(cat "$state/.watch.lock/pid" 2>/dev/null || true)
-  { [ -n "$lock_pid" ] && [ "$lock_pid" != "$live" ] && kill -0 "$lock_pid" 2>/dev/null; } \
-    || fail "restart did not replace aliased reused-pid lock with a live watcher (got '$lock_pid')"
-  grep -F "watcher: started pid=$lock_pid" "$out" >/dev/null || fail "restart did not report the fresh watcher it confirmed"
-  is_live_non_zombie "$live" || fail "restart killed a reused unrelated pid through an owner alias"
-  kill "$pid" "$lock_pid" "$live" 2>/dev/null || true
+  is_live_non_zombie "$pid" \
+    && fail "restart did not surface recovery after replacing an aliased reused-pid lock"
   wait "$pid" 2>/dev/null || true
+  grep -F 'check: rearm-resurface' "$out" >/dev/null \
+    || fail "restart replaced aliased reused-pid lock without surfacing recovery: $(cat "$out")"
+  { [ ! -e "$state/.watch.lock" ] && [ ! -L "$state/.watch.lock" ]; } \
+    || fail "restart retained an aliased reused-pid lock after surfacing recovery"
+  is_live_non_zombie "$live" || fail "restart killed a reused unrelated pid through an owner alias"
+  kill "$live" 2>/dev/null || true
   wait "$live" 2>/dev/null || true
-  pass "watch restart reclaims an aliased reused-pid lock without signaling its pid"
+  pass "watch restart preserves recovery for an aliased reused-pid lock without signaling its pid"
 }
 
 test_watch_restart_attaches_to_healthy_peer() {


### PR DESCRIPTION
## Intent

Fix Firstmate queue item fix-guard-path-casing (FM-GUARD-001): watcher health and lock ownership must compare canonical Firstmate home and watcher paths so macOS case-insensitive GitHub/github spellings identify the same healthy watcher. Preserve fail-closed PID and identity validation, exact per-home isolation, cross-home safety boundaries, absent final watcher-leaf and symlink/realpath owner behavior, and all existing watcher lifecycle semantics. Add focused regressions for case-differing paths, cross-home mismatch, wrong live PID, dead PID, symlink paths, and the existing absent-leaf contract. Limit changes to bin/fm-wake-lib.sh and its directly relevant tests. Preserve evidence that tests/fm-pi-watch-extension.test.sh has an unrelated timing flake in its TypeScript-only hung-successor fixture; do not weaken or skip relevant watcher, wake, lock, guard, shell, or CI validation. Push a feature branch, create a PR, drive CI green, and never merge.

## What Changed

- Canonicalize watcher home and executable paths across filesystem-case aliases, symlinks, and absent watcher leaves while preserving fail-closed and cross-home checks.
- Reuse canonical owner matching during health checks and stale-lock cleanup so restarts can replace aliased reused-PID locks without signaling unrelated processes.
- Add focused regressions for path aliases, missing leaves, cross-home isolation, wrong or dead PIDs, and restart recovery, and document the ownership contract.

## Risk Assessment

✅ Low: The correction is well bounded: restart cleanup now uses the shared canonical owner boundary, strict PID/identity validation and cross-home isolation remain intact, and redundant polling canonicalization was removed.

## Testing

Baseline inspection confirmed the supplied target and changed-file set; focused watcher-lock, watch-arm, turn-end guard, and Claude auto-arm tests passed, and an evidence-producing case-insensitive CLI restart confirmed canonical ownership, safe stale-lock replacement, and persisted state end to end. The supplied unrelated TypeScript-only Pi hung-successor timing flake was not rerun in this targeted phase, and its test remains unchanged; broad CI remains owned by the outer pipeline.

<details>
<summary>Evidence: Case-alias CLI end-to-end transcript</summary>

<code>`watcher: started pid=70871 (beacon fresh)`; the stale lock was replaced while the unrelated live PID remained alive, and both lowercase owner paths resolved to their canonical counterparts.</code>

```text
filesystem_case_alias: GitHub/github and FmHome/fmhome resolve to the same directories
operator_command: FM_HOME=/var/folders/s8/0_mzgfjj34v2wr0gvxxh64n80000gn/T/no-mistakes-evidence/01KZE7T1DEATFDSH3D504NSNHE/case-alias-cli-fixture/github/fmhome /var/folders/s8/0_mzgfjj34v2wr0gvxxh64n80000gn/T/no-mistakes-evidence/01KZE7T1DEATFDSH3D504NSNHE/case-alias-cli-fixture/github/firstmate/bin/fm-watch-arm.sh --restart
cli_output: watcher: started pid=70871 (beacon fresh)
unrelated_live_pid_preserved: yes (pid=70814)
stale_lock_replaced_with_live_watcher: yes (pid=70871)
persisted_lock_fm_home: /var/folders/s8/0_mzgfjj34v2wr0gvxxh64n80000gn/T/no-mistakes-evidence/01KZE7T1DEATFDSH3D504NSNHE/case-alias-cli-fixture/github/fmhome
persisted_lock_watcher_path: /var/folders/s8/0_mzgfjj34v2wr0gvxxh64n80000gn/T/no-mistakes-evidence/01KZE7T1DEATFDSH3D504NSNHE/case-alias-cli-fixture/github/firstmate/bin/fm-watch.sh
canonical_home_owner_match: yes (/private/var/folders/s8/0_mzgfjj34v2wr0gvxxh64n80000gn/T/no-mistakes-evidence/01KZE7T1DEATFDSH3D504NSNHE/case-alias-cli-fixture/GitHub/FmHome)
canonical_watcher_owner_match: yes (/Users/mohammedameen/.no-mistakes/worktrees/ac543050f1c8/01KZE7T1DEATFDSH3D504NSNHE/bin/fm-watch.sh)
```
</details>
<details>
<summary>Evidence: Focused watcher-lock regressions</summary>

```text
ok - simultaneous watcher starts leave exactly one live process
ok - fm_pid_identity real ps fallback is locale-invariant
ok - fm_pid_identity is locale-invariant across LC_ALL/LC_TIME
ok - /proc process identity ignores simulated btime changes
ok - /proc process identity detects pid reuse
ok - MSYS /proc process identity regression skipped on non-Windows host
ok - killed watcher stale lock is reclaimed
ok - live watcher lock with stale heartbeat is actionable
ok - guard banner leads when down with pending wakes (repair-after-drain) and stays silent when live and fresh
ok - watcher health canonicalizes owner paths while PID and cross-home guards stay fail-closed
ok - concurrent fm_lock_try_acquire yields exactly one winner
ok - dead-pid stale lock is reclaimed by a single acquirer
ok - concurrent stale-lock steal yields exactly one winner
ok - live steal mutex is not reclaimed
ok - live-held lock is not stolen
ok - empty mid-acquire lock keeps a minimum grace
ok - late original claimant cannot claim a recreated lock
ok - paused mid-acquire claimant backs off to active stealer
ok - watch restart refuses to signal a reused pid
ok - watch restart reclaims an aliased reused-pid lock without signaling its pid
ok - watch restart attaches to a verified healthy peer and later surfaces a successor gap
ok - watcher self-evicts when the lock pid no longer names it
ok - arm turns clean self-eviction without a successor into a typed failure
ok - arm attaches to a live fresh watcher and fails loudly when that cycle has no successor
ok - attached arm signals record a classified lifecycle entry
ok - arm starts+confirms a fresh watcher on a clean lock and self-heals a dead-pid lock (never healthy off a dead pid)
ok - arm cleans child watcher and temp output on HUP
ok - arm propagates an immediate watcher wake before confirmation
ok - arm attaches to a peer watcher after child stands down and surfaces a missing successor
watcher: lock held by live pid 37218 but heartbeat is stale for 839466581s (>300s); inspect or stop that watcher before re-arming.
ok - arm reports FAILED and exits non-zero when no fresh watcher can be confirmed
ok - cycle-exit ledger links a verified successor and remains size-capped
ok - SIGSTOP distinguishes live PID from stale beacon and termination records the exit class
```
</details>
<details>
<summary>Evidence: Watch-arm lifecycle regressions</summary>

```text
ok - watch-arm: an attached arm reports the wake its cycle delivered instead of a false failure
ok - watch-arm: a delivered wake consumed by the handling turn still closes the attached arm cleanly
ok - watch-arm: a cycle that delivered no wake of its own still fails loudly
```
</details>
<details>
<summary>Evidence: Turn-end guard regressions</summary>

```text
ok - fm_supervision_unhealthy: false with no state/*.meta at all
ok - fm_supervision_unhealthy: true with in-flight task and no beacon ever
ok - fm_supervision_unhealthy: true with in-flight task and a beacon far outside the grace window
ok - fm_supervision_unhealthy: false with in-flight task and a fresh beacon
ok - fm_supervision_status: FM_SUP_QUEUE_PENDING tracks state/.wake-queue
ok - fm_supervision_needed: X-mode relay poll needs supervision
ok - fm_supervision_unhealthy: source-only home needs supervision
ok - fm-turnend-guard: silent no-op with nothing in flight
ok - fm-turnend-guard: blocks when a fresh beacon has no live watcher lock
ok - fm-turnend-guard: non-Claude path blocks a source-only home
ok - fm-turnend-guard: blocks on a dead watcher lock even when the beacon is fresh
ok - fm-turnend-guard: silent no-op with a live watcher lock and fresh beacon
ok - fm-turnend-guard: healthy non-Claude harness paths ignore Claude episode contention
ok - fm-turnend-guard: blocks on a live watcher lock with an ancient beacon
ok - fm-turnend-guard: blocks with the exact required reason in the primary when unhealthy
ok - fm-turnend-guard: blocks from active FM_HOME state, not only repo-root state
ok - fm-turnend-guard: X-mode repair reason sources the cadence config
ok - fm-turnend-guard: X-mode-only supervision remains guarded in default mode
ok - fm-turnend-guard: ignores stale repo-root state when FM_HOME is set
ok - fm-turnend-guard: uses FM_STATE_OVERRIDE ahead of FM_HOME/state
ok - fm-turnend-guard: stop_hook_active=true always allows the stop (never blocks twice in one turn)
ok - fm-turnend-guard: blocks a blind turn end in a secondmate's own home (.fm-secondmate-home no longer excludes it)
ok - fm-turnend-guard: idle-by-default - silent in a secondmate home with nothing in flight
ok - fm-turnend-guard: stop_hook_active=true allows the stop in a secondmate home (never blocks twice in one turn)
ok - fm-turnend-guard: secondmate deferred-death recovery - silent while watched, forces re-arm once the watcher exits
ok - fm-turnend-guard: inert in a secondmate's own child worktree (linked git worktree) even when unhealthy
ok - fm-turnend-guard: blocks a blind turn end in a treehouse-leased LINKED secondmate home (marker force-include)
ok - fm-turnend-guard: an invalid (empty) marker cannot spoof inclusion; linked worktree stays exempt
ok - fm-turnend-guard: a non-ASCII marker cannot spoof inclusion; linked worktree stays exempt
ok - fm-turnend-guard: inert in a crewmate/scout task worktree (linked git worktree) even when unhealthy
ok - fm-turnend-guard: fails open (never blocks) when jq is missing
ok - fm-turnend-guard: silent no-op on empty stdin
ok - fm-turnend-guard: runs well under the generous timing margin (0s)
ok - fm-turnend-guard-grok: forces one explicitly marked same-session resume when the shared predicate blocks
ok - fm-turnend-guard-grok: legacy environment loop guard prevents a nested resume loop
ok - fm-turnend-guard-grok: native false delegates blocking feedback with zero resume processes
ok - fm-turnend-guard-grok: native true remains bounded and starts no resume process
ok - fm-turnend-guard-grok: both spellings are typed and camelCase has deterministic precedence
ok - fm-turnend-guard-grok: malformed, invalidly typed, and missing-prerequisite payloads start neither path
ok - fm-turnend-guard-grok: missing jq and no-supervision-needed stops stay silent and bounded
ok - .codex/hooks.json: Stop hook uses hook process root when payload cwd is outside
ok - .codex/hooks.json: Stop hook ignores nested git root guard scripts
ok - .opencode primary plugin: guard path is anchored to worktree, not directory
ok - .pi primary extension: no-tool and multi-tool runs each inject exactly one guard follow-up
ok - .pi primary extension: delivery failure resets the logical-run latch
ok - fm-turnend-guard --claude: re-blocks a loop-guarded stop while unhealthy and unclaimed (incident regression)
ok - fm-turnend-guard --claude: X-mode-only homes re-block when auto-arm recovery is absent
ok - fm-turnend-guard --claude: a live arming epoch advances once and repeated observation is idempotent
ok - fm-turnend-guard --claude: repeated failed-to-arming races make bounded monotonic progress
ok - fm-turnend-guard --claude: terminal owner boundary excludes a concurrent start without deadlock
ok - fm-turnend-guard --claude: fresh rewake epoch prevents a duplicate continuation for the same event
ok - fm-turnend-guard --claude: fresh failed epochs preserve and advance monotonic fail-open progression
ok - fm-turnend-guard --claude: integrated fresh failures reach one bounded fail-open, stop continuation, and reset on recovery
ok - fm-turnend-guard --claude: reset contention preserves all episode state until retry
ok - fm-turnend-guard --claude: concurrent auto-arm and guard resets are idempotent and deadlock-free
ok - fm-turnend-guard --claude: stale rewake epoch does not allow a blind stop
ok - fm-turnend-guard --claude: budget exhaustion alone cannot permit a blind stop
ok - fm-turnend-guard --claude: verified fail-open is loud, bounded, attended, and non-repeating
ok - fm-turnend-guard --claude: fail-open requires both exhausted retries and consumed notice
ok - fm-turnend-guard --claude: away ownership excludes the Stop-autoarm fail-open
ok - fm-turnend-guard --claude: positive watcher recovery resets failure episode state
ok - fm-turnend-guard --claude: bounded claim wait avoids a token-consuming forced continuation
ok - fm-turnend-guard --claude: secondmate home re-blocks unclaimed and allows auto-arm-claimed stops
```
</details>
<details>
<summary>Evidence: Claude Stop auto-arm regressions</summary>

```text
ok - auto-arm: inert in a linked child worktree even when in-flight
ok - auto-arm: inert with no session lock
ok - auto-arm: a demonstrably dead recorded session owner is reclaimed through fm-lock.sh before arming
ok - auto-arm: inert without arm, rewake, or lock replacement when another live harness owns the home
ok - auto-arm: inert while AFK owns supervision
ok - auto-arm: stale-owner recovery leaves the AFK and supervision-need gates unchanged
ok - auto-arm: resolves the outermost pid of a nested contiguous claude ancestry (bg-spare chain)
ok - auto-arm: inert with nothing in flight and no X-mode need
ok - auto-arm: actionable close translates to exactly one exit-2 rewake with reason
ok - auto-arm: actionable close survives a healthy successor without duplicate delivery
ok - auto-arm: bounded failure verification emits one automatic-mechanism alarm
ok - auto-arm: consecutive failures keep Stop-owned retry without repeating notice
ok - auto-arm: unverified clean close exhausts retries and fails closed
ok - auto-arm: post-alarm actionable outcomes cannot continue or reset failure state
ok - auto-arm: benign cycle end with a live watcher and fresh beacon stays silent across the next cycle
ok - auto-arm: budget contention preserves the episode and forces a reset retry
ok - auto-arm: X-mode poll need arms the cycle even with no tasks in flight
ok - auto-arm: concurrent firings admit one owner and one rewake translation
ok - auto-arm: need vanishing mid-cycle closes without a rewake
ok - auto-arm: mid-cycle AFK hands triage to the daemon with no rewake
ok - auto-arm: active in a marked secondmate home
ok - fm-lock: shared session-lock lib preserves the status path
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed ✅</summary>

- 🚨 `bin/fm-wake-lib.sh:136` - The requirement to “Preserve … all existing watcher lifecycle semantics” remains unmet for `--restart`. Canonical ownership is confined to this identity-strict helper: with case-differing spellings and a reused/wrong live PID, it correctly returns false, but `fm-watch-arm.sh` then calls `clear_stale_recorded_watcher_lock`, whose raw home/path comparisons reject the alias. The stale lock remains, so the replacement watcher cannot start—unlike the existing same-spelling reused-PID recovery. The new wrong-PID test checks only health rejection. Fixing this durably requires approval to exceed “Limit changes to bin/fm-wake-lib.sh…” by adding a shared path-only owner matcher used by restart cleanup, plus an end-to-end regression.
- ⚠️ `bin/fm-wake-lib.sh:159` - `fm_watcher_healthy` canonicalizes home and watcher here, then `fm_watcher_lock_matches_pid` immediately canonicalizes both again. In the arm’s 0.2-second confirmation and 0.5-second attachment loops, this adds two redundant `realpath` processes per iteration on a path whose MSYS fork cost is explicitly documented as significant. Pass the original arguments directly and let the matcher own canonicalization.

🔧 Fix: Fix aliased watcher restart recovery
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`git status --short --branch` and `git diff --stat --name-status 70aeba855527f7693082f6dd1bc731e334d0269f..5c9f4d0ff1502ffe3f1e1f1e1f18141c130cb79b`</code>
- `bash tests/fm-watcher-lock.test.sh`
- `bash tests/fm-watch-arm.test.sh`
- `bash tests/fm-turnend-guard.test.sh`
- `bash tests/fm-claude-stop-autoarm.test.sh`
- <code>Case-insensitive APFS end-to-end check: seeded canonical `GitHub/FmHome` lock metadata with an unrelated live PID and stale identity, then ran `FM_HOME=.../github/fmhome .../github/firstmate/bin/fm-watch-arm.sh --restart`</code>
- <code>Verified the CLI-reported watcher PID was live and persisted, the unrelated PID remained alive, and `realpath` matched both stored owner paths to their canonical home and watcher</code>
- <code>Rechecked `git status --short --branch`, evidence-file integrity, and cleanup with `kill -0 70814` / `kill -0 70871`</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 127)

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
