### PR TITLE
feat(brief): require crewmates to read project instructions first

### DIFF
--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -313,6 +313,12 @@ This is a SCOUT task: the deliverable is a written report, not a PR.
 The worktree is your laboratory - install, run, edit, and make scratch commits freely; all of it is discarded at teardown.
 The report is the only thing that survives, so anything worth keeping must be in it.
 
+**Before your first edit or command, read the project's own instructions in full and follow them.**
+Look for \`CLAUDE.md\` and \`AGENTS.md\` at the repo root; read every one that exists.
+They carry conventions no diff will teach you - required tooling, logging and redaction rules, banned commands - and violating them is how work gets sent back in review.
+This applies to every task, including one-line fixes and comment-only changes; you are never too small a task to read them.
+If the project's instructions conflict with anything below, say so in your report rather than silently choosing one.
+
 # Rules
 1. Never push to any remote and never open a PR.
 2. Stay inside this worktree; the only files you may write outside it are the report and the status file below.
@@ -423,6 +429,12 @@ You are in a disposable git worktree of $REPO, at a detached HEAD on a clean def
 **Verify isolation before anything else.** Run \`pwd -P\` and \`git rev-parse --show-toplevel\`; both must resolve to the disposable task worktree you were launched in, such as a treehouse pool path or an Orca-managed worktree, not the primary checkout firstmate operates from.
 The path check is authoritative: \`git rev-parse --git-dir\` and \`git rev-parse --git-common-dir\` can help inspect the repo, but they do not prove you are outside the primary checkout.
 If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not branch or commit here - append \`blocked: launched in primary checkout, not an isolated worktree\` to the status file and stop.
+
+**Before your first edit, read the project's own instructions in full and follow them.**
+Look for \`CLAUDE.md\` and \`AGENTS.md\` at the repo root; read every one that exists.
+They carry conventions no diff will teach you - required tooling, logging and redaction rules, banned commands - and violating them is how work gets sent back in review.
+This applies to every task, including one-line fixes and comment-only changes; you are never too small a task to read them.
+If the project's instructions conflict with anything below, say so via the status file rather than silently choosing one.
 
 1. First action: create your branch: \`git checkout -b fm/$ID\`$SETUP2
 


### PR DESCRIPTION
## Problem

`bin/fm-brief.sh` mentions `AGENTS.md`/`CLAUDE.md` eleven times, and every one of them is about *writing* project memory at the end of a task.
Nothing in the scaffold tells a worker to *read* the project's own instructions before starting.

That gap has already cost review cycles: shipped code violated documented project conventions because the worker never opened the project's `CLAUDE.md`.
Those files carry rules no diff teaches - banned commands, required tooling, logging and redaction rules that exist to keep credentials and PII out of logs.
Until now the instruction only reached a worker when firstmate remembered to type it into a brief by hand.

## Change

The same short imperative block is added to both setup sections, so it is part of the scaffold contract rather than per-brief discipline:

- **Ship** briefs get it after the worktree-isolation assertion and before the branch step, phrased "Before your first edit", routing conflicts to the status file.
- **Scout** briefs get it at the end of the setup section, phrased "Before your first edit or command", routing conflicts to the report, since a scout has no status-file decision loop in the same way.

Both keep the clause that no task is too small to read them, which is the point of the change: the failure mode is a worker deciding a one-line fix does not warrant it.

The existing "# Project memory" section is untouched - it is about writing project memory and is correct as it stands.

## Verification

- `bash -n bin/fm-brief.sh` passes.
- `tests/fm-brief.test.sh` passes in full (all cases ok).
- Scaffolded throwaway briefs for all three ship modes plus a scout into a temporary data/state root, then diffed each against a brief generated by the pre-change script. The only differences are the new block and the task-id substitutions: the worktree-isolation assertion, the rules block, the project-memory section, and every delivery-mode definition of done render byte-identical.
- Confirmed the rendered output keeps its backticks and leaks no literal backslashes, so the heredoc escaping survived.
- ShellCheck is **not installed** in this environment - `bin/fm-lint.sh` reports "ShellCheck not found; install ShellCheck 0.11.0 for CI parity" and exits without linting. That check is unverified locally and is left to CI; the change is prose inside an existing heredoc and adds no shell syntax.

## Scope note

The task was scoped to `bin/fm-brief.sh` only, so no test was added to `tests/fm-brief.test.sh` asserting the new block.
Worth a follow-up if this instruction should be regression-pinned like the project-memory wording already is.
