### PR TITLE
fix(tests): stop three suites deciding on host properties instead of behavior

### DIFF
--- a/.agents/skills/firstmate-coding-guidelines/SKILL.md
+++ b/.agents/skills/firstmate-coding-guidelines/SKILL.md
@@ -121,6 +121,10 @@ Run `bin/fm-doc-audience-check.sh`; it enforces classification, README setup rou
 - Run `bin/fm-lint.sh` before treating a script change as done; it is the single owner of the lint definition (file set, config, and pinned shellcheck version) that CI and the no-mistakes pre-push gate both invoke, and it refuses to run under any other shellcheck version.
 - Colocate tests with the existing pattern in `tests/`, name them `<subject>.test.sh`, and extend an existing script rather than inventing a new runner.
 - Tests must exercise behavior through an executable or public interface and must never assert implementation-source bytes, including through parsers, regexes, snapshots, or indirect wrappers.
+- A test must own every precondition it depends on rather than borrow one from the host, because a borrowed precondition makes the result a report about the machine.
+  A case that needs a tool absent forces it absent with `fm_fake_absent_env`, since no fakebin entry can express absence and hosts do ship gated names - `/usr/bin/orca` is the GNOME screen reader.
+  A case that needs a real host tool under a fixture path uses `fm_fake_passthrough`, because a packaged CLI resolves its own package relative to `$0` and a symlink breaks it.
+  A case that waits on concurrent work waits on the settled result, and where only a wall-clock bound is possible sets it far above real startup - the arm plugins spawn through `bash -lc`, and a login shell alone costs hundreds of milliseconds.
 - A maintainer-verification record under `docs/verification/` records active empirical facts, not assumptions or task chronology.
 - Include the date, version, exact commands run, and exact output needed to support the current guarantee.
 - Keep incident chronology and delivery evidence in private task reports or PR evidence unless a concise rationale is required to maintain a current safety boundary.

--- a/tests/fm-bootstrap.test.sh
+++ b/tests/fm-bootstrap.test.sh
@@ -490,19 +490,7 @@ test_git_is_required_with_supported_install_instruction() {
   mkdir -p "$case_dir/home/config"
   printf '%s\n' manual > "$case_dir/home/config/backlog-backend"
   fakebin=$(make_fake_toolchain "$case_dir")
-  bash_env="$case_dir/no-git.bash"
-  cat > "$bash_env" <<'SH'
-command() {
-  if [ "${1:-}" = -v ] && [ "${2:-}" = git ]; then
-    return 1
-  fi
-  builtin command "$@"
-}
-git() {
-  return 127
-}
-SH
-
+  bash_env=$(fm_fake_absent_env "$case_dir/no-git.bash" git)
   out=$(PATH="$fakebin:$BASE_PATH" BASH_ENV="$bash_env" FM_HOME="$case_dir/home" FM_ROOT_OVERRIDE="$case_dir/home" \
     FM_FAKE_TREEHOUSE_LEASE_HELP=1 "$ROOT/bin/fm-bootstrap.sh")
   expected="MISSING: git (install: brew install git  # or the platform's package manager)"
@@ -511,15 +499,20 @@ SH
 }
 
 test_orca_backend_gates_orca_tool_only_when_selected() {
-  local case_dir fakebin out missing_orca
+  local case_dir fakebin bash_env out missing_orca
   missing_orca="MISSING: orca (install: brew install orca  # or the platform's package manager)"
+  # Orca must be forced absent rather than assumed absent: /usr/bin/orca is the
+  # GNOME screen reader on any Linux desktop with the accessibility tool
+  # installed, and it satisfies the `command -v orca` probe while having nothing
+  # to do with the Orca runtime backend.
 
   case_dir="$TMP_ROOT/orca-backend-selected"
   mkdir -p "$case_dir/home/config"
   printf '%s\n' manual > "$case_dir/home/config/backlog-backend"
   printf '%s\n' orca > "$case_dir/home/config/backend"
   fakebin=$(make_fake_toolchain "$case_dir")
-  out=$(PATH="$fakebin:$BASE_PATH" FM_HOME="$case_dir/home" FM_ROOT_OVERRIDE="$case_dir/home" \
+  bash_env=$(fm_fake_absent_env "$case_dir/no-orca.bash" orca)
+  out=$(PATH="$fakebin:$BASE_PATH" BASH_ENV="$bash_env" FM_HOME="$case_dir/home" FM_ROOT_OVERRIDE="$case_dir/home" \
     FM_FAKE_TREEHOUSE_LEASE_HELP=1 "$ROOT/bin/fm-bootstrap.sh")
   [ "$out" = "$missing_orca" ] || fail "backend=orca should require only the Orca-specific missing tool, got: $out"
 
@@ -527,7 +520,8 @@ test_orca_backend_gates_orca_tool_only_when_selected() {
   mkdir -p "$case_dir/home/config"
   printf '%s\n' manual > "$case_dir/home/config/backlog-backend"
   fakebin=$(make_fake_toolchain "$case_dir")
-  out=$(PATH="$fakebin:$BASE_PATH" FM_HOME="$case_dir/home" FM_ROOT_OVERRIDE="$case_dir/home" \
+  bash_env=$(fm_fake_absent_env "$case_dir/no-orca.bash" orca)
+  out=$(PATH="$fakebin:$BASE_PATH" BASH_ENV="$bash_env" FM_HOME="$case_dir/home" FM_ROOT_OVERRIDE="$case_dir/home" \
     FM_FAKE_TREEHOUSE_LEASE_HELP=1 "$ROOT/bin/fm-bootstrap.sh")
   assert_not_contains "$out" "MISSING: orca" "bootstrap should not require orca unless backend=orca is selected"
   pass "bootstrap: backend=orca gates the Orca CLI without requiring it on the default backend"
@@ -535,9 +529,12 @@ test_orca_backend_gates_orca_tool_only_when_selected() {
 
 # Build a fake toolchain with tmux REMOVED and the named backend session CLI(s)
 # plus jq added, so a backend that must NOT require tmux can be proven silent
-# with tmux absent. Echoes the fakebin dir. The removed tmux is what makes these
+# with tmux absent. Echoes the fakebin dir. The absent tmux is what makes these
 # cases catch the old "everything but orca demands tmux" bug: with the buggy
 # TOOLS list a herdr/zellij/cmux home would report MISSING: tmux here.
+# Removing the stub is not enough to make tmux absent, because /usr/bin/tmux
+# then satisfies the probe and the case goes quietly vacuous, so every caller
+# pairs this with an fm_fake_absent_env BASH_ENV shim naming tmux.
 make_fake_toolchain_no_tmux() {  # <case-dir> <extra-cli...>
   local dir=$1 fakebin
   shift
@@ -548,7 +545,7 @@ make_fake_toolchain_no_tmux() {  # <case-dir> <extra-cli...>
 }
 
 test_session_provider_backends_do_not_require_tmux() {
-  local backend cli case_dir fakebin out
+  local backend cli case_dir fakebin bash_env out
   # herdr/zellij/cmux are session providers only: they require their own CLI, jq,
   # and treehouse, never tmux. With all genuine deps present and tmux absent,
   # bootstrap must be silent.
@@ -559,7 +556,8 @@ test_session_provider_backends_do_not_require_tmux() {
     printf '%s\n' manual > "$case_dir/home/config/backlog-backend"
     printf '%s\n' "$backend" > "$case_dir/home/config/backend"
     fakebin=$(make_fake_toolchain_no_tmux "$case_dir" "$cli")
-    out=$(PATH="$fakebin:$BASE_PATH" FM_HOME="$case_dir/home" FM_ROOT_OVERRIDE="$case_dir/home" \
+    bash_env=$(fm_fake_absent_env "$case_dir/absent.bash" tmux)
+    out=$(PATH="$fakebin:$BASE_PATH" BASH_ENV="$bash_env" FM_HOME="$case_dir/home" FM_ROOT_OVERRIDE="$case_dir/home" \
       FM_FAKE_TREEHOUSE_LEASE_HELP=1 "$ROOT/bin/fm-bootstrap.sh")
     [ -z "$out" ] || fail "backend=$backend with tmux absent but its own deps present should be silent, got: $out"
   done <<'ROWS'
@@ -571,9 +569,11 @@ ROWS
 }
 
 test_session_provider_backends_gate_own_cli_not_tmux() {
-  local backend cli case_dir fakebin out missing
+  local backend cli case_dir fakebin bash_env out missing
   # With the backend's OWN session CLI absent (and tmux also absent), bootstrap
   # must fail closed on the genuine dep and never substitute a false tmux demand.
+  # Both absences are forced rather than assumed: a host that ships either name
+  # would otherwise turn the gate assertion into a report about its own PATH.
   while IFS='^' read -r backend cli; do
     [ -n "$backend" ] || continue
     case_dir="$TMP_ROOT/$backend-missing-cli"
@@ -582,7 +582,8 @@ test_session_provider_backends_gate_own_cli_not_tmux() {
     printf '%s\n' "$backend" > "$case_dir/home/config/backend"
     # Toolchain has jq + treehouse but NOT the session CLI and NOT tmux.
     fakebin=$(make_fake_toolchain_no_tmux "$case_dir")
-    out=$(PATH="$fakebin:$BASE_PATH" FM_HOME="$case_dir/home" FM_ROOT_OVERRIDE="$case_dir/home" \
+    bash_env=$(fm_fake_absent_env "$case_dir/absent.bash" tmux "$cli")
+    out=$(PATH="$fakebin:$BASE_PATH" BASH_ENV="$bash_env" FM_HOME="$case_dir/home" FM_ROOT_OVERRIDE="$case_dir/home" \
       FM_FAKE_TREEHOUSE_LEASE_HELP=1 "$ROOT/bin/fm-bootstrap.sh")
     if [ "$backend" = herdr ]; then
       missing="MISSING_MANUAL: herdr (instructions: https://herdr.dev)"
@@ -614,7 +615,7 @@ test_herdr_install_requires_manual_action() {
 }
 
 test_cmux_bundled_cli_satisfies_dependency() {
-  local case_dir fakebin bundle out
+  local case_dir fakebin bash_env bundle out
   case_dir="$TMP_ROOT/cmux-bundled-cli"
   mkdir -p "$case_dir/home/config" "$case_dir/bundle"
   printf '%s\n' manual > "$case_dir/home/config/backlog-backend"
@@ -622,7 +623,10 @@ test_cmux_bundled_cli_satisfies_dependency() {
   fakebin=$(make_fake_toolchain_no_tmux "$case_dir")
   fm_fake_exit0 "$case_dir/bundle" cmux
   bundle="$case_dir/bundle/cmux"
-  out=$(PATH="$fakebin:$BASE_PATH" FM_HOME="$case_dir/home" FM_ROOT_OVERRIDE="$case_dir/home" \
+  # cmux is forced absent from PATH so the bundle is demonstrably what satisfies
+  # the dependency; a host-installed cmux would pass this case for the wrong reason.
+  bash_env=$(fm_fake_absent_env "$case_dir/absent.bash" tmux cmux)
+  out=$(PATH="$fakebin:$BASE_PATH" BASH_ENV="$bash_env" FM_HOME="$case_dir/home" FM_ROOT_OVERRIDE="$case_dir/home" \
     FM_BACKEND_CMUX_BUNDLE_BIN="$bundle" FM_FAKE_TREEHOUSE_LEASE_HELP=1 "$ROOT/bin/fm-bootstrap.sh")
   [ -z "$out" ] || fail "a usable bundled cmux CLI should satisfy bootstrap without a PATH shim, got: $out"
   pass "bootstrap: the bundled cmux CLI satisfies the active backend dependency"
@@ -646,9 +650,8 @@ test_unknown_backend_reports_invalid_configuration() {
 test_json_backends_require_jq_not_tmux() {
   local backend case_dir fakebin bash_env out
   # herdr/zellij/cmux parse their backend's JSON output, so jq is a genuine dep.
-  # jq lives in a system BASE_PATH dir on many hosts, so force it missing with a
-  # command()/jq() override (the same technique the git-required case uses) to keep
-  # the assertion host-independent.
+  # jq lives in a system BASE_PATH dir on many hosts, so force it missing rather
+  # than assume it, keeping the assertion host-independent.
   while IFS='^' read -r backend; do
     [ -n "$backend" ] || continue
     case_dir="$TMP_ROOT/$backend-missing-jq"
@@ -659,18 +662,7 @@ test_json_backends_require_jq_not_tmux() {
     fakebin=$(make_fake_toolchain "$case_dir")
     rm -f "$fakebin/tmux"
     fm_fake_exit0 "$fakebin" "$backend"
-    bash_env="$case_dir/no-jq.bash"
-    cat > "$bash_env" <<'SH'
-command() {
-  if [ "${1:-}" = -v ] && [ "${2:-}" = jq ]; then
-    return 1
-  fi
-  builtin command "$@"
-}
-jq() {
-  return 127
-}
-SH
+    bash_env=$(fm_fake_absent_env "$case_dir/no-jq.bash" jq tmux)
     out=$(PATH="$fakebin:$BASE_PATH" BASH_ENV="$bash_env" FM_HOME="$case_dir/home" FM_ROOT_OVERRIDE="$case_dir/home" \
       FM_FAKE_TREEHOUSE_LEASE_HELP=1 "$ROOT/bin/fm-bootstrap.sh")
     assert_contains "$out" "MISSING: jq" "backend=$backend must fail closed on missing jq"
@@ -684,7 +676,7 @@ ROWS
 }
 
 test_treehouse_lease_check_follows_resolved_backend() {
-  local case_dir fakebin out
+  local case_dir fakebin bash_env out
   # A treehouse that lacks durable --lease support is only a problem for a backend
   # that actually uses treehouse. Orca owns its own worktrees, so an old treehouse
   # must NOT trip MISSING: treehouse under backend=orca...
@@ -695,8 +687,9 @@ test_treehouse_lease_check_follows_resolved_backend() {
   fakebin=$(make_fake_toolchain "$case_dir")
   rm -f "$fakebin/tmux"
   fm_fake_exit0 "$fakebin" orca
+  bash_env=$(fm_fake_absent_env "$case_dir/absent.bash" tmux)
   # FM_FAKE_TREEHOUSE_LEASE_HELP unset: the fake treehouse advertises NO --lease.
-  out=$(PATH="$fakebin:$BASE_PATH" FM_HOME="$case_dir/home" FM_ROOT_OVERRIDE="$case_dir/home" \
+  out=$(PATH="$fakebin:$BASE_PATH" BASH_ENV="$bash_env" FM_HOME="$case_dir/home" FM_ROOT_OVERRIDE="$case_dir/home" \
     "$ROOT/bin/fm-bootstrap.sh")
   [ -z "$out" ] || fail "backend=orca must not require treehouse (even lease-less) or tmux, got: $out"
 
@@ -707,7 +700,8 @@ test_treehouse_lease_check_follows_resolved_backend() {
   printf '%s\n' manual > "$case_dir/home/config/backlog-backend"
   printf '%s\n' herdr > "$case_dir/home/config/backend"
   fakebin=$(make_fake_toolchain_no_tmux "$case_dir" herdr)
-  out=$(PATH="$fakebin:$BASE_PATH" FM_HOME="$case_dir/home" FM_ROOT_OVERRIDE="$case_dir/home" \
+  bash_env=$(fm_fake_absent_env "$case_dir/absent.bash" tmux)
+  out=$(PATH="$fakebin:$BASE_PATH" BASH_ENV="$bash_env" FM_HOME="$case_dir/home" FM_ROOT_OVERRIDE="$case_dir/home" \
     "$ROOT/bin/fm-bootstrap.sh")
   assert_contains "$out" "MISSING: treehouse" "backend=herdr must still require treehouse with durable lease support"
   assert_not_contains "$out" "MISSING: tmux" "backend=herdr must not demand tmux even when treehouse is too old"

--- a/tests/fm-pi-watch-extension.test.sh
+++ b/tests/fm-pi-watch-extension.test.sh
@@ -12,6 +12,23 @@ EXT="$ROOT/.pi/extensions/fm-primary-pi-watch.ts"
 # unrelated to plugin output, which the assertions intentionally require empty.
 export NODE_NO_WARNINGS=1
 
+# Readiness budget the cases below compress the plugins' production default down
+# to, so a successor that never becomes ready is bounded in test time rather than
+# after twelve seconds. It must clear the cost of starting the arm child: both
+# plugins spawn it through `bash -lc`, and a LOGIN shell sources the system and
+# user profiles before the arm script's first line runs - 200-320ms on an
+# ordinary Linux desktop. A budget near that cost stops timing the successor and
+# starts timing shell startup, and the child is then killed before it records
+# that it ever ran, which reads as the plugin having skipped a retry.
+#
+# The ceiling is the restoration cases' own wait for the wake prompt: they allow
+# 5s for a sequence that spends this budget once per attempt, so a value above
+# ~1500 makes them sample the arm log mid-restoration and see one row too few.
+# Raising it further means retuning that wait and the fourteen sibling bounds
+# with it. Only the deliberately hung cases spend this budget at all; the ones
+# whose successor becomes ready settle early and are unaffected by its value.
+ARM_READY_TIMEOUT_MS=1000
+
 install_pi_watch_extension_fixture() {
   local repo=$1
   mkdir -p \
@@ -417,7 +434,7 @@ trap 'exit 0' TERM INT
 while :; do sleep 0.02; done
 SH
   chmod +x "$repo/bin/fm-watch-arm.sh"
-  out=$(PLUGIN="$plugin" FM_HOME="$home" FM_ROOT_OVERRIDE="$repo" FM_ARM_LOG="$log" FM_PI_ARM_READY_TIMEOUT_MS=250 FM_WATCH_REARM_RETRY_BASE_MS=5 FM_WATCH_REARM_RETRY_MAX_MS=10 FM_WATCH_REARM_RETRY_LIMIT=2 node --input-type=module 2>&1 <<'EOF'
+  out=$(PLUGIN="$plugin" FM_HOME="$home" FM_ROOT_OVERRIDE="$repo" FM_ARM_LOG="$log" FM_PI_ARM_READY_TIMEOUT_MS="$ARM_READY_TIMEOUT_MS" FM_WATCH_REARM_RETRY_BASE_MS=5 FM_WATCH_REARM_RETRY_MAX_MS=10 FM_WATCH_REARM_RETRY_LIMIT=2 node --input-type=module 2>&1 <<'EOF'
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { pathToFileURL } from "node:url";
 
@@ -489,7 +506,7 @@ printf 'arm=%s\n' "$$" >> "${FM_ARM_LOG:?}"
 while [ ! -e "$FM_RELEASE_FILE" ]; do sleep 0.1; done
 SH
   chmod +x "$repo/bin/fm-watch-arm.sh"
-  out=$(PLUGIN="$plugin" FM_HOME="$home" FM_ROOT_OVERRIDE="$repo" FM_ARM_LOG="$log" FM_RELEASE_FILE="$release" FM_PI_ARM_READY_TIMEOUT_MS=250 FM_WATCH_ARM_RETIRE_TIMEOUT_MS=20 FM_WATCH_REARM_RETRY_BASE_MS=5 FM_WATCH_REARM_RETRY_MAX_MS=10 FM_WATCH_REARM_RETRY_LIMIT=2 node --input-type=module 2>&1 <<'EOF'
+  out=$(PLUGIN="$plugin" FM_HOME="$home" FM_ROOT_OVERRIDE="$repo" FM_ARM_LOG="$log" FM_RELEASE_FILE="$release" FM_PI_ARM_READY_TIMEOUT_MS="$ARM_READY_TIMEOUT_MS" FM_WATCH_ARM_RETIRE_TIMEOUT_MS=20 FM_WATCH_REARM_RETRY_BASE_MS=5 FM_WATCH_REARM_RETRY_MAX_MS=10 FM_WATCH_REARM_RETRY_LIMIT=2 node --input-type=module 2>&1 <<'EOF'
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { pathToFileURL } from "node:url";
 
@@ -567,7 +584,7 @@ trap 'exit 0' TERM INT
 while [ ! -e "$FM_STOP_FILE" ]; do sleep 0.02; done
 SH
     chmod +x "$repo/bin/fm-watch-arm.sh"
-    out=$(PLUGIN="$plugin" FM_HOME="$home" FM_ROOT_OVERRIDE="$repo" FM_ARM_LOG="$log" FM_UNRETIRED_READY_FILE="$ready" FM_UNRETIRED_RETIRE_FILE="$retired" FM_RELEASE_FILE="$release" FM_STOP_FILE="$stop" FM_LATE_KIND="$kind" FM_PI_ARM_READY_TIMEOUT_MS=250 FM_WATCH_ARM_RETIRE_TIMEOUT_MS=20 FM_WATCH_REARM_RETRY_BASE_MS=5 FM_WATCH_REARM_RETRY_MAX_MS=10 FM_WATCH_REARM_RETRY_LIMIT=2 node --input-type=module 2>&1 <<'EOF'
+    out=$(PLUGIN="$plugin" FM_HOME="$home" FM_ROOT_OVERRIDE="$repo" FM_ARM_LOG="$log" FM_UNRETIRED_READY_FILE="$ready" FM_UNRETIRED_RETIRE_FILE="$retired" FM_RELEASE_FILE="$release" FM_STOP_FILE="$stop" FM_LATE_KIND="$kind" FM_PI_ARM_READY_TIMEOUT_MS="$ARM_READY_TIMEOUT_MS" FM_WATCH_ARM_RETIRE_TIMEOUT_MS=20 FM_WATCH_REARM_RETRY_BASE_MS=5 FM_WATCH_REARM_RETRY_MAX_MS=10 FM_WATCH_REARM_RETRY_LIMIT=2 node --input-type=module 2>&1 <<'EOF'
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { pathToFileURL } from "node:url";
 
@@ -1323,9 +1340,20 @@ const hooks = await mod.FmPrimaryWatchArm({
   worktree: process.env.WORKTREE,
 });
 const event = { event: { type: "session.idle", properties: { sessionID: "session-test" } } };
+// The refusal is awaited through the coordinator rather than timed out after a
+// fixed sleep. The lock check walks the process ancestry with one `ps` per hop,
+// so its latency scales with how deeply this node process is nested: eight hops
+// to pid 1 takes ~170ms here and two hops takes ~40ms on a shallow CI container.
+// A wall-clock guess therefore both decides the refusal before the plugin has
+// finished deciding it, and leaves that verdict in flight for the arming phase
+// below to inherit. Awaiting the settled status also lets the case assert WHY
+// the plugin refused instead of only that a file did not appear.
 writeFileSync(`${process.env.FM_HOME}/state/.lock`, "999999\n");
-await hooks.event(event);
-await new Promise((resolve) => setTimeout(resolve, 120));
+const refused = await globalThis.__firstmateOpenCodeWatchArm.ensureArmed("session-test", client);
+if (refused !== "read-only") {
+  console.error(`watch arm did not refuse a foreign session lock (status ${refused})`);
+  process.exit(1);
+}
 if (existsSync(process.env.FM_ARM_LOG)) {
   console.error("watch arm ran without owning the session lock");
   process.exit(1);
@@ -1579,7 +1607,7 @@ trap 'exit 0' TERM INT
 while :; do sleep 0.02; done
 SH
   chmod +x "$repo/bin/fm-watch-arm.sh"
-  out=$(PLUGIN="$plugin" WORKTREE="$repo" FM_HOME="$home" FM_ARM_LOG="$log" FM_OPENCODE_ARM_READY_TIMEOUT_MS=250 FM_WATCH_REARM_RETRY_BASE_MS=5 FM_WATCH_REARM_RETRY_MAX_MS=10 FM_WATCH_REARM_RETRY_LIMIT=2 node 2>&1 <<'EOF'
+  out=$(PLUGIN="$plugin" WORKTREE="$repo" FM_HOME="$home" FM_ARM_LOG="$log" FM_OPENCODE_ARM_READY_TIMEOUT_MS="$ARM_READY_TIMEOUT_MS" FM_WATCH_REARM_RETRY_BASE_MS=5 FM_WATCH_REARM_RETRY_MAX_MS=10 FM_WATCH_REARM_RETRY_LIMIT=2 node 2>&1 <<'EOF'
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { pathToFileURL } from "node:url";
 
@@ -1653,7 +1681,7 @@ printf 'arm=%s\n' "$$" >> "${FM_ARM_LOG:?}"
 while [ ! -e "$FM_RELEASE_FILE" ]; do sleep 0.1; done
 SH
   chmod +x "$repo/bin/fm-watch-arm.sh"
-  out=$(PLUGIN="$plugin" WORKTREE="$repo" FM_HOME="$home" FM_ARM_LOG="$log" FM_RELEASE_FILE="$release" FM_OPENCODE_ARM_READY_TIMEOUT_MS=250 FM_WATCH_ARM_RETIRE_TIMEOUT_MS=20 FM_WATCH_REARM_RETRY_BASE_MS=5 FM_WATCH_REARM_RETRY_MAX_MS=10 FM_WATCH_REARM_RETRY_LIMIT=2 node 2>&1 <<'EOF'
+  out=$(PLUGIN="$plugin" WORKTREE="$repo" FM_HOME="$home" FM_ARM_LOG="$log" FM_RELEASE_FILE="$release" FM_OPENCODE_ARM_READY_TIMEOUT_MS="$ARM_READY_TIMEOUT_MS" FM_WATCH_ARM_RETIRE_TIMEOUT_MS=20 FM_WATCH_REARM_RETRY_BASE_MS=5 FM_WATCH_REARM_RETRY_MAX_MS=10 FM_WATCH_REARM_RETRY_LIMIT=2 node 2>&1 <<'EOF'
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { pathToFileURL } from "node:url";
 
@@ -1733,7 +1761,7 @@ trap 'exit 0' TERM INT
 while [ ! -e "$FM_STOP_FILE" ]; do sleep 0.02; done
 SH
     chmod +x "$repo/bin/fm-watch-arm.sh"
-    out=$(PLUGIN="$plugin" WORKTREE="$repo" FM_HOME="$home" FM_ARM_LOG="$log" FM_UNRETIRED_READY_FILE="$ready" FM_UNRETIRED_RETIRE_FILE="$retired" FM_RELEASE_FILE="$release" FM_STOP_FILE="$stop" FM_LATE_KIND="$kind" FM_OPENCODE_ARM_READY_TIMEOUT_MS=250 FM_WATCH_ARM_RETIRE_TIMEOUT_MS=20 FM_WATCH_REARM_RETRY_BASE_MS=5 FM_WATCH_REARM_RETRY_MAX_MS=10 FM_WATCH_REARM_RETRY_LIMIT=2 node 2>&1 <<'EOF'
+    out=$(PLUGIN="$plugin" WORKTREE="$repo" FM_HOME="$home" FM_ARM_LOG="$log" FM_UNRETIRED_READY_FILE="$ready" FM_UNRETIRED_RETIRE_FILE="$retired" FM_RELEASE_FILE="$release" FM_STOP_FILE="$stop" FM_LATE_KIND="$kind" FM_OPENCODE_ARM_READY_TIMEOUT_MS="$ARM_READY_TIMEOUT_MS" FM_WATCH_ARM_RETIRE_TIMEOUT_MS=20 FM_WATCH_REARM_RETRY_BASE_MS=5 FM_WATCH_REARM_RETRY_MAX_MS=10 FM_WATCH_REARM_RETRY_LIMIT=2 node 2>&1 <<'EOF'
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { pathToFileURL } from "node:url";
 

--- a/tests/fm-remote-backlog-handoff.test.sh
+++ b/tests/fm-remote-backlog-handoff.test.sh
@@ -7,6 +7,19 @@ set -u
 
 command -v tasks-axi >/dev/null 2>&1 || { echo "skip: tasks-axi not found"; exit 0; }
 ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)
+# The atomic receipt runs `tasks-axi mv` for real, so an installed-but-too-old
+# tasks-axi cannot satisfy this suite. Gate on the same verdict the receive step
+# applies, so an unsupported host skips honestly instead of reporting a handoff
+# failure that is really a version floor.
+# shellcheck source=bin/fm-tasks-axi-lib.sh
+. "$ROOT/bin/fm-tasks-axi-lib.sh"
+fm_tasks_axi_compatible || { echo "skip: tasks-axi is older than the supported floor"; exit 0; }
+# Iterations of a 0.02s poll each background step gets to reach its marker before
+# the case gives up. These bounds only decide how long a genuine hang takes to
+# report, so they are set well above any real startup: the steps they wait on
+# fork bash, node, and tasks-axi, and a five-second bound turns an oversubscribed
+# host into a spurious failure that reads exactly like a stuck handoff.
+MARKER_WAIT_LIMIT=1500
 TMP_ROOT=$(fm_test_tmproot fm-remote-handoff)
 mkdir -p "$TMP_ROOT"
 TMP_ROOT=$(cd "$TMP_ROOT" && pwd -P)
@@ -23,8 +36,14 @@ cp "$ROOT/bin/fm-remote-entrypoint.sh" "$ROOT/bin/fm-remote-job-lib.sh" \
   "$ROOT/bin/fm-remote-job-worker.sh" "$ROOT/bin/fm-remote-file.sh" \
   "$ROOT/bin/fm-backlog-receive.sh" "$ROOT/bin/fm-tasks-axi-lib.sh" \
   "$ROOT/bin/fm-wake-lib.sh" "$REMOTE_ROOT/bin/"
-ln -s "$(command -v tasks-axi)" "$REMOTE_ROOT/bin/tasks-axi"
-ln -s "$(command -v node)" "$REMOTE_ROOT/bin/node"
+# The remote fixture reaches the host's real tasks-axi through exec wrappers, not
+# symlinks. A packaged JS CLI resolves its own package relative to $0 - pnpm's
+# global shim loads "$(dirname "$0")/global/...", npm's loads "$(dirname "$0")/../lib/..."
+# - so a symlink here sends it looking for its package under the fixture's bin
+# directory. It then fails to load, the receive step reports tasks-axi as
+# incompatible, and the atomic-receipt assertion fails for a reason that has
+# nothing to do with the handoff under test.
+fm_fake_passthrough "$REMOTE_ROOT/bin" tasks-axi node
 chmod +x "$REMOTE_ROOT/bin"/*.sh
 git -C "$REMOTE_ROOT" init -q -b main
 git -C "$REMOTE_ROOT" config user.email test@example.com
@@ -136,7 +155,7 @@ put_wait=0
 while ! find "$REMOTE/state/handoff" -maxdepth 1 -name '.put.*' -print -quit | grep -q .; do
   kill -0 "$put_race_pid" 2>/dev/null || fail "confined put exited before staging input"
   put_wait=$((put_wait + 1))
-  [ "$put_wait" -le 250 ] || fail "confined put never staged input"
+  [ "$put_wait" -le "$MARKER_WAIT_LIMIT" ] || fail "confined put never staged input"
   sleep 0.02
 done
 mv "$REMOTE/state/handoff" "$TMP_ROOT/pinned-handoff"
@@ -231,7 +250,7 @@ wait_for_serialization=0
 while [ ! -f "$TMP_ROOT/serialize.entered" ]; do
   kill -0 "$handoff_a" 2>/dev/null || fail "first serialized handoff exited before receipt"
   wait_for_serialization=$((wait_for_serialization + 1))
-  [ "$wait_for_serialization" -le 250 ] || fail "first serialized handoff never reached receipt"
+  [ "$wait_for_serialization" -le "$MARKER_WAIT_LIMIT" ] || fail "first serialized handoff never reached receipt"
   sleep 0.02
 done
 write_backlog '- [ ] serialized-b - second concurrent handoff (repo: alpha)'
@@ -306,7 +325,7 @@ route_wait=0
 while [ ! -f "$TMP_ROOT/route.entered" ]; do
   kill -0 "$route_holder_pid" 2>/dev/null || fail "route lock holder exited before acquiring lifecycle locks"
   route_wait=$((route_wait + 1))
-  [ "$route_wait" -le 250 ] || fail "route lock holder never acquired lifecycle locks"
+  [ "$route_wait" -le "$MARKER_WAIT_LIMIT" ] || fail "route lock holder never acquired lifecycle locks"
   sleep 0.02
 done
 handoff_env "$ROOT/bin/fm-backlog-handoff.sh" ios route-race \

--- a/tests/lib.sh
+++ b/tests/lib.sh
@@ -151,6 +151,9 @@ fm_test_reap_orphans
 # named tools into a fakebin dir. fm_fake_version_tool drops a stub for a tool
 # whose installed version bootstrap gates, so a fixture cannot be reported as an
 # unparseable build simply for answering `--version` with nothing.
+# fm_fake_absent_env makes a tool absent, which no fakebin entry can express,
+# and fm_fake_passthrough exposes a real host tool under a fixture path without
+# breaking a launcher that resolves its own package relative to `$0`.
 
 fm_fakebin() {
   local dir=$1 fakebin="$1/fakebin"
@@ -167,6 +170,70 @@ fm_fake_exit0() {
 exit 0
 SH
     chmod +x "$fakebin/$tool"
+  done
+}
+
+# fm_fake_absent_env <path> <tool>...: write a BASH_ENV file at <path> that
+# makes each named tool undiscoverable to the script under test, and echo <path>.
+#
+# A fakebin cannot express absence. Dropping a name from it only uncovers
+# whatever the host installed under the same name, and adding a stub makes
+# `command -v <tool>` succeed. Hosts do ship binaries firstmate gates: git, jq,
+# and gh live in system bin dirs on most Linux images, and /usr/bin/orca is the
+# GNOME screen reader, entirely unrelated to the Orca runtime backend. A case
+# that proves absence by trusting the host's PATH therefore reports how the
+# machine was provisioned rather than the behavior under test - it passes on one
+# image and fails on another for reasons the assertion never mentions.
+#
+# Pass the returned path as BASH_ENV when running the script under test. Bash
+# sources it for every non-interactive shell it starts, so the override reaches
+# nested bin/*.sh helpers as well as the entry script. The `command` override
+# answers the `command -v <tool>` probe, and the same-named function makes a
+# direct call fail the way an uninstalled tool would.
+fm_fake_absent_env() {
+  local path=$1 tool
+  shift
+  {
+    cat <<'SH'
+command() {
+  case "${1:-}:${2:-}" in
+SH
+    for tool in "$@"; do
+      printf '    -v:%s) return 1 ;;\n' "$tool"
+    done
+    cat <<'SH'
+  esac
+  builtin command "$@"
+}
+SH
+    for tool in "$@"; do
+      printf '%s() { return 127; }\n' "$tool"
+    done
+  } > "$path"
+  printf '%s\n' "$path"
+}
+
+# fm_fake_passthrough <bindir> <tool>...: put a wrapper for each named tool in
+# <bindir> that execs the copy currently on PATH.
+#
+# Use this instead of `ln -s "$(command -v <tool>)"` whenever a fixture needs a
+# real host tool under a different path. A packaged JS CLI is usually a shim
+# that resolves its own package relative to `$0` - pnpm's global shim computes
+# `basedir=$(dirname "$0")` and then loads `$basedir/global/...` - so a symlink
+# from another directory sends it looking for its package beside the symlink and
+# it fails to load. `exec` sets `$0` to the resolved command, keeping the shim's
+# own path arithmetic correct. Plain compiled binaries tolerate a symlink, but
+# the caller cannot tell which kind a host installed.
+fm_fake_passthrough() {
+  local bindir=$1 tool real
+  shift
+  for tool in "$@"; do
+    real=$(command -v "$tool") || return 1
+    cat > "$bindir/$tool" <<SH
+#!/usr/bin/env bash
+exec "$real" "\$@"
+SH
+    chmod +x "$bindir/$tool"
   done
 }
 


### PR DESCRIPTION
Three of firstmate's own suites failed on an untouched checkout at `70aeba8`, each at the same assertion every run.
All three failed for one reason: the case proved a property of the code by borrowing an unpinned property of the machine, so its verdict reported how the host was provisioned rather than what the code did.

## The three causes

**`fm-bootstrap` - `backend=orca should require only the Orca-specific missing tool`.**
The case asserted `MISSING: orca` while relying on the host having no binary of that name.
`/usr/bin/orca` is the GNOME screen reader, entirely unrelated to the Orca runtime backend, so bootstrap correctly found an `orca`, correctly reported nothing missing, and the assertion read empty output.
This failed for every desktop Linux user with the accessibility tool installed and passed for everyone else.

**`fm-pi-watch-extension` - `OpenCode watch plugin must arm only when this session owns the fleet lock`.**
Not a product defect.
The case gave the plugin a fixed 120ms to refuse a foreign session lock.
That check walks the process ancestry with one `ps` per hop, so its cost scales with how deeply the process is nested: measured at 172ms across eight hops to pid 1 here, and roughly 40ms on a shallow container where node sits two or three hops down.
The sleep expired mid-check, and because the plugin coalesces a launch already in flight, the arming phase then inherited the unfinished `read-only` verdict and never armed.
Awaiting the settled verdict instead, the plugin refuses and then arms correctly.

**`fm-remote-backlog-handoff` - `remote atomic receipt did not deliver ios-a before the dropped acknowledgement`.**
The fixture symlinked the host's `tasks-axi` into its own bin directory.
A packaged JS CLI resolves its own package relative to `$0` - pnpm's global shim loads `$(dirname "$0")/global/...` - so the symlink sent it looking for its package beside the symlink.
It failed to load, the receive step reported `tasks-axi` incompatible, and the handoff assertion failed for a reason unrelated to the handoff.

## What changed

Two shared helpers in `tests/lib.sh` now own the patterns that were being open-coded or missed:

- `fm_fake_absent_env` writes a `BASH_ENV` shim that makes a tool genuinely absent.
  No fakebin entry can express absence: adding a stub makes `command -v` succeed, and omitting the name only uncovers whatever the host installed.
  This replaces the hand-rolled copies the `git` and `jq` cases already carried, so there is one owner rather than three.
- `fm_fake_passthrough` exposes a real host tool under a fixture path via an `exec` wrapper, which keeps `$0` pointing at the resolved command so a launcher's own path arithmetic still works.

The same shape is swept out of the rest of `fm-bootstrap`.
The herdr/zellij/cmux gate cases and the bundled-cmux case all assumed those names were absent from PATH, and the no-tmux premise would have gone **silently vacuous** on any host shipping tmux rather than failing - the buggy `TOOLS` list those cases exist to catch would simply have stopped being detected.

`fm-remote-backlog-handoff` also now gates on the same `tasks-axi` compatibility verdict the receive step applies, so an unsupported host skips honestly instead of reporting a handoff failure that is really a version floor.

## Two further pre-existing failures fixed alongside

Both were confirmed present on the pristine baseline before any change, and both are the same family.

**`Pi must deliver the actionable wake after bounded hung-successor recovery`** failed 3/3 runs on untouched `70aeba8`.
Both watcher plugins spawn the arm child through `bash -lc`, and a **login** shell sources the system and user profiles before the arm script's first line runs - 200-320ms measured on this host.
The 250ms readiness budget was therefore racing shell startup, and the child was killed before it could append the row proving it ran, which reads as the plugin having skipped a retry.
The budget now clears that startup while staying under the restoration cases' own 5s wait for the wake prompt; those two bounds are coupled, and a value above roughly 1500 makes the case sample the arm log mid-restoration and see one row too few.
That coupling is now stated at the constant.

**`first serialized handoff never reached receipt`** was masked: the suite previously died at the atomic-receipt assertion above and never reached it.
Its three marker waits allowed 5s for background steps that fork bash, node and `tasks-axi`.
These bounds only decide how long a genuine hang takes to report, so they cost nothing on the happy path and are now set well above real startup.

## Verification

Two full rounds of all three suites, both entirely green:

```
run 1 fm-bootstrap               exit=0 ok=27  run 2 exit=0 ok=27
run 1 fm-remote-backlog-handoff  exit=0 ok=10  run 2 exit=0 ok=10
run 1 fm-pi-watch-extension      exit=0 ok=30  run 2 exit=0 ok=30
```

Each cause was also confirmed by direct measurement rather than inference: `/usr/bin/orca` identified as the screen reader; the ancestry walk timed at 172ms over eight hops with the plugin arming correctly once its verdict is awaited; the pnpm shim reproduced failing to load through a relocating symlink; and `bash -lc 'true'` timed at 0.20-0.32s.

`shellcheck` 0.11.0 (the pinned version, over `bin/fm-lint.sh`'s exact file set) is clean on all four changed shell files, and `bin/fm-doc-audience-check.sh` passes (65 surfaces, 212 local links).

## Known and deliberately not addressed

`bin/fm-test-run.sh --check-coverage` is still broken on this baseline, comparing `LC_ALL=C` sorted lists under ambient collation.
That is PR #1885, which has not merged yet - `origin/main` is still at `70aeba8` - so it is left alone.

`fm-pi-watch-extension` retains residual load sensitivity beyond the case fixed here.
On a box running at load 60-100 on 16 cores, assertions untouched by this PR intermittently fail (`Pi session transitions must rearm through an explicit generation owner`, `OpenCode watch plugin must not treat external healthy output as an owned arm`); the suite passes cleanly once the machine settles.
That suite carries fifteen hand-tuned wall-clock bounds, several coupled to each other, and making it genuinely load-independent means retuning them as one coherent change rather than adjusting them individually - doing that piecemeal is exactly how a single constant change here broke a different assertion mid-review.
Flagging it as separate work rather than half-tuning it.
