### PR TITLE
docs(cmux): add operator war-room recipe and thin helper (CMUX-001)

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ Firstmate's skills live in two separate places with different audiences:
 - [docs/zellij-backend.md](docs/zellij-backend.md) - current setup and limits for the experimental Zellij backend.
 - [docs/orca-backend.md](docs/orca-backend.md) - current setup and limits for the experimental Orca backend.
 - [docs/cmux-backend.md](docs/cmux-backend.md) - current setup, socket security, and limits for the experimental cmux backend.
+- [docs/cmux-war-room.md](docs/cmux-war-room.md) - operator recipes for a labeled, multi-pane cmux war room and its standalone helper.
 - [docs/codex-app-backend.md](docs/codex-app-backend.md) - the current blocked Codex App backend boundary and rollout contract.
 - [docs/verification/runtime-backends.md](docs/verification/runtime-backends.md) - active maintainer verification for runtime backend guarantees.
 - [docs/gitlab-merge-watch.md](docs/gitlab-merge-watch.md) - maintainer verification for GitLab merge watching on arbitrary instances.

--- a/bin/fm-cmux-war-room.sh
+++ b/bin/fm-cmux-war-room.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+# fm-cmux-war-room.sh - thin operator helpers for a cmux war-room session.
+#
+# These are manual convenience wrappers around the cmux CLI for an operator
+# running a multi-pane war-room (docs/cmux-war-room.md). They are NOT part of
+# the fm-spawn.sh crewmate lifecycle and do not change the 1:1 task-workspace
+# backend contract owned by docs/cmux-backend.md and bin/backends/cmux.sh.
+#
+# Usage:
+#   fm-cmux-war-room.sh banner --surface <ref> --label <text> [--color <name-or-hex>]
+#   fm-cmux-war-room.sh color-for-harness <harness>
+#   fm-cmux-war-room.sh teardown-surfaces --workspace <ref> [--keep <surface-ref>] [--close-workspace]
+#   fm-cmux-war-room.sh --help
+#
+# banner            renames the pane tab and writes a colored ANSI banner line
+#                    into the surface so a war-room grid stays scannable.
+# color-for-harness  prints the workspace color configured for one harness in
+#                    local config/harness-visual.json, or a fallback default
+#                    when the file or the harness key is absent.
+# teardown-surfaces  closes every surface in one named workspace except an
+#                    optionally kept one, scoped to exactly that workspace's
+#                    own list-panes response; never a broad close. Pass
+#                    --close-workspace to also close the now-single-surface
+#                    workspace afterward (cmux refuses to close a last surface
+#                    directly - see docs/cmux-backend.md "Current operation
+#                    and safety").
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
+CONFIG="${FM_CONFIG_OVERRIDE:-$FM_HOME/config}"
+FM_CMUX_WAR_ROOM_BUNDLE_BIN="${FM_CMUX_WAR_ROOM_BUNDLE_BIN:-/Applications/cmux.app/Contents/Resources/bin/cmux}"
+
+fm_cmux_war_room_usage() {
+  sed -n '2,26p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+}
+
+fm_cmux_war_room_bin() {
+  if command -v cmux >/dev/null 2>&1; then
+    printf '%s\n' "cmux"
+    return 0
+  fi
+  if [ -x "$FM_CMUX_WAR_ROOM_BUNDLE_BIN" ]; then
+    printf '%s\n' "$FM_CMUX_WAR_ROOM_BUNDLE_BIN"
+    return 0
+  fi
+  echo "fm-cmux-war-room: cmux CLI not found on PATH or at $FM_CMUX_WAR_ROOM_BUNDLE_BIN" >&2
+  return 1
+}
+
+fm_cmux_war_room_require_jq() {
+  command -v jq >/dev/null 2>&1 || {
+    echo "fm-cmux-war-room: jq is required" >&2
+    return 1
+  }
+}
+
+fm_cmux_war_room_banner() {
+  local surface="" label="" color="36" cmux_bin
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --surface) surface=${2:-}; shift 2 ;;
+      --label) label=${2:-}; shift 2 ;;
+      --color) color=${2:-}; shift 2 ;;
+      *) echo "fm-cmux-war-room banner: unknown argument: $1" >&2; return 1 ;;
+    esac
+  done
+  [ -n "$surface" ] || { echo "fm-cmux-war-room banner: --surface is required" >&2; return 1; }
+  cmux_bin=$(fm_cmux_war_room_bin) || return 1
+  if [ -n "$label" ]; then
+    "$cmux_bin" rename-tab --surface "$surface" "$label"
+  fi
+  "$cmux_bin" send --surface "$surface" "printf '\\033[1;97;${color}m\\n  ${label:-WAR ROOM}  \\n\\033[0m\\n'"
+  "$cmux_bin" send-key --surface "$surface" enter
+}
+
+fm_cmux_war_room_color_for_harness() {
+  local harness="${1:-}" file="$CONFIG/harness-visual.json" color=""
+  [ -n "$harness" ] || { echo "fm-cmux-war-room color-for-harness: a harness name is required" >&2; return 1; }
+  if [ -f "$file" ]; then
+    fm_cmux_war_room_require_jq || return 1
+    color=$(jq -r --arg h "$harness" '.workspace_colors[$h] // empty' "$file")
+  fi
+  if [ -z "$color" ]; then
+    echo "fm-cmux-war-room: no color configured for '$harness' in $file, using default Grey" >&2
+    color="Grey"
+  fi
+  printf '%s\n' "$color"
+}
+
+fm_cmux_war_room_teardown_surfaces() {
+  local workspace="" keep="" close_workspace=0 cmux_bin surface
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --workspace) workspace=${2:-}; shift 2 ;;
+      --keep) keep=${2:-}; shift 2 ;;
+      --close-workspace) close_workspace=1; shift ;;
+      *) echo "fm-cmux-war-room teardown-surfaces: unknown argument: $1" >&2; return 1 ;;
+    esac
+  done
+  [ -n "$workspace" ] || { echo "fm-cmux-war-room teardown-surfaces: --workspace is required" >&2; return 1; }
+  cmux_bin=$(fm_cmux_war_room_bin) || return 1
+  fm_cmux_war_room_require_jq || return 1
+
+  local surfaces
+  surfaces=$("$cmux_bin" list-panes --workspace "$workspace" --json --id-format both \
+    | jq -r '[.panes[].surface_ids[]?, .panes[].surface_refs[]?] | unique | .[]')
+
+  while IFS= read -r surface; do
+    [ -n "$surface" ] || continue
+    [ "$surface" = "$keep" ] && continue
+    "$cmux_bin" close-surface --surface "$surface"
+  done <<EOF
+$surfaces
+EOF
+
+  if [ "$close_workspace" -eq 1 ]; then
+    "$cmux_bin" close-workspace --workspace "$workspace"
+  fi
+}
+
+main() {
+  local cmd="${1:-}"
+  [ $# -gt 0 ] && shift
+  case "$cmd" in
+    banner) fm_cmux_war_room_banner "$@" ;;
+    color-for-harness) fm_cmux_war_room_color_for_harness "$@" ;;
+    teardown-surfaces) fm_cmux_war_room_teardown_surfaces "$@" ;;
+    -h|--help|"") fm_cmux_war_room_usage ;;
+    *) echo "fm-cmux-war-room: unknown subcommand: $cmd" >&2; fm_cmux_war_room_usage >&2; return 1 ;;
+  esac
+}
+
+main "$@"

--- a/docs/cmux-backend.md
+++ b/docs/cmux-backend.md
@@ -121,6 +121,11 @@ Real tests share the captain's running app rather than creating an isolated cmux
 - Label lookup and recovery are currently scoped to the current cmux window, so a task moved to a non-current window is a known recovery blind spot.
 - Workspace ids do not survive app relaunch and are never recovery authority.
 
+## Multi-pane war rooms
+
+The one-task-one-surface shape above stays the spawn default.
+An operator who wants a labeled, multi-pane view of several already-running panes at once can build one manually with the same CLI; see [`cmux-war-room.md`](cmux-war-room.md) for the recipes and the standalone `bin/fm-cmux-war-room.sh` helper.
+
 ## Regression entry points
 
 ```sh

--- a/docs/cmux-war-room.md
+++ b/docs/cmux-war-room.md
@@ -1,0 +1,123 @@
+# cmux war room
+
+A war room is one cmux workspace laid out as a multi-pane grid so an operator can see a lead and its workers side by side, at a glance, instead of hunting through sidebar tabs.
+This page gives concrete command recipes for building, labeling, observing, and safely tearing one down.
+It is an operator recipe sheet, not a backend change: [`cmux-backend.md`](cmux-backend.md) remains the single owner of Firstmate's cmux task-spawn contract.
+
+## The 1:1 invariant is unchanged
+
+Firstmate's supervised crewmate spawn keeps one cmux workspace with one surface per task, exactly as documented in [`cmux-backend.md`](cmux-backend.md#task-shape-and-metadata).
+Nothing on this page changes that default, and none of it runs inside `bin/fm-spawn.sh` or the recovery path.
+A war room is a manual, operator-driven session for watching several already-running panes at once, built with the same `cmux` CLI Firstmate already depends on.
+`bin/fm-cmux-war-room.sh` is a thin standalone helper for that manual session; it is never invoked by spawn or recovery.
+
+## Prerequisites
+
+Same as [`cmux-backend.md`](cmux-backend.md#setup): cmux 0.64 or newer, `jq`, and a socket control mode of `automation` or `password`.
+`bin/fm-cmux-war-room.sh` resolves the `cmux` binary the same way the adapter does: prefer `PATH`, otherwise fall back to `/Applications/cmux.app/Contents/Resources/bin/cmux`.
+
+## Build the grid
+
+Capture every ref returned at creation time and never guess a short `surface:N` handle later; short refs renumber as panes open and close.
+
+Stepwise splits:
+
+```sh
+WS=$(cmux new-workspace --name war-room --cwd "$PWD" --focus false --json | jq -r '.workspace_id // .ref')
+A=$(cmux list-panes --workspace "$WS" --json --id-format both | jq -r '.panes[0].surface_ids[0] // .panes[0].surface_refs[0]')
+
+B=$(cmux new-split right --workspace "$WS" --surface "$A" --json | jq -r '.surface_id // .ref')
+C=$(cmux new-split down  --workspace "$WS" --surface "$A" --json | jq -r '.surface_id // .ref')
+D=$(cmux new-split down  --workspace "$WS" --surface "$B" --json | jq -r '.surface_id // .ref')
+```
+
+Declarative equivalent, one call instead of four:
+
+```sh
+cmux new-workspace --name war-room --cwd "$PWD" --focus false --layout '{
+  "direction": "horizontal",
+  "split": 0.5,
+  "children": [
+    {"pane": {"surfaces": [{"type": "terminal", "name": "lead"}]}},
+    {"direction": "vertical", "split": 0.5, "children": [
+      {"pane": {"surfaces": [{"type": "terminal", "name": "build"}]}},
+      {"pane": {"surfaces": [{"type": "terminal", "name": "review"}]}}
+    ]}
+  ]
+}'
+```
+
+Always scope splits with `--workspace` when more than one workspace exists, so a split never lands in the wrong window.
+
+## Label and color the fleet
+
+Workspace color is first-class on the CLI; individual surfaces are not, so pane identity comes from the tab name and an in-pane banner instead.
+
+```sh
+cmux workspace-action --action set-color --workspace "$WS" --color Purple
+cmux workspace-action --action set-description --workspace "$WS" --description "ORCH - mission-slug"
+cmux rename-tab --workspace "$WS" --surface "$A" "lead"
+```
+
+`bin/fm-cmux-war-room.sh banner` wraps the tab-rename-plus-in-pane-banner pattern into one call:
+
+```sh
+bin/fm-cmux-war-room.sh banner --surface "$B" --label "A01 BUILD" --color 44
+```
+
+### Harness color usage
+
+A local, gitignored `config/harness-visual.json` can hold a `workspace_colors` map keyed by harness name (`claude`, `codex`, `kimi`, and so on).
+This file is a captain-private convention, not something Firstmate ships or reads for spawn; the war-room helper is the one place it is consulted.
+
+```sh
+bin/fm-cmux-war-room.sh color-for-harness claude
+```
+
+Prints the configured color for that harness, or `Grey` with a stderr note when the file or the key is absent, so a missing config never blocks the war room.
+That output is a cmux workspace color name (or hex), the same value `workspace-action --action set-color` accepts, not the raw ANSI SGR number `banner --color` writes into the pane; the two commands color two different surfaces (sidebar workspace versus in-pane text) and do not share a value.
+
+## Observe
+
+```sh
+cmux tree --all --json
+cmux list-panes --workspace "$WS" --json --id-format both
+cmux read-screen --surface "$A" --scrollback --lines 80
+```
+
+`read-screen` returns an internal error against a genuinely fresh surface until something has been written to it; re-tree with `list-panes` for structural readiness instead of retrying a content read.
+
+## Capture UUIDs, never cache short refs
+
+```sh
+cmux identify --json
+cmux list-workspaces --json --id-format both
+```
+
+Short refs like `surface:3` renumber as the tree changes.
+Re-run `list-panes` or `tree` before any close instead of reusing a ref captured earlier in the session.
+
+## Tear down without stale shells
+
+Close owned surfaces first, then the workspace; never broad-close.
+`bin/fm-cmux-war-room.sh teardown-surfaces` re-reads the named workspace's own `list-panes` response so it only ever closes surfaces that workspace actually owns:
+
+```sh
+bin/fm-cmux-war-room.sh teardown-surfaces --workspace "$WS" --keep "$A" --close-workspace
+```
+
+`--keep` leaves one surface open; cmux refuses to close a workspace's last surface directly, so leaving one (or omitting `--close-workspace` and closing the workspace yourself afterward) avoids that refusal.
+Without `--keep`, every surface in the workspace closes, matching the [`cmux-backend.md`](cmux-backend.md#current-operation-and-safety) "last surface" and "only workspace in window" behavior that `close-workspace` already handles.
+
+Manual equivalent, for reference:
+
+```sh
+cmux list-panes --workspace "$WS" --json --id-format both \
+  | jq -r '[.panes[].surface_ids[]?, .panes[].surface_refs[]?] | unique | .[]' \
+  | while read -r S; do cmux close-surface --surface "$S"; done
+cmux close-workspace --workspace "$WS"
+```
+
+## Regression entry points
+
+`bin/fm-cmux-war-room.sh` has no automated test in this pass; it is exercised manually against a live cmux app the same way [`cmux-backend.md`](cmux-backend.md#regression-entry-points) documents for the backend adapter.

--- a/docs/documentation-audiences.json
+++ b/docs/documentation-audiences.json
@@ -225,6 +225,10 @@
       "audience": "operator-current"
     },
     {
+      "path": "docs/cmux-war-room.md",
+      "audience": "operator-current"
+    },
+    {
       "path": "docs/codex-app-backend.md",
       "audience": "operator-current"
     },


### PR DESCRIPTION
## Summary

- Adds `docs/cmux-war-room.md`: concrete cmux CLI recipes for a labeled, multi-pane war-room view (new-workspace/layout, new-split, set-color, capture UUIDs, read-screen, scoped close-surface before close-workspace). States that the 1:1 task-workspace backend invariant remains the spawn default.
- Adds a thin standalone `bin/fm-cmux-war-room.sh` helper (`banner`, `color-for-harness`, `teardown-surfaces`), shellcheck-clean, exercised manually against a mock `cmux` CLI (not wired into `fm-spawn.sh` or recovery).
- Adds one short pointer section + link from `docs/cmux-backend.md` to the new doc, without rewriting the backend doc.
- Documents usage of the local, gitignored `config/harness-visual.json` harness color map via the new `color-for-harness` subcommand.
- Registers the new doc in `docs/documentation-audiences.json` (`operator-current`) and links it from `README.md`.

Sourced from `data/smelt-learning-cmux/report.md` and `data/smelt-disler-audit/report.md` (ticket CMUX-001).

## Test plan

- [x] `bin/fm-lint.sh` (shellcheck-clean)
- [x] `bin/fm-doc-audience-check.sh`
- [x] `tests/fm-documentation-audiences.test.sh`
- [x] Manual dry run of all three `fm-cmux-war-room.sh` subcommands against a mock `cmux` CLI
