### PR TITLE
feat(bin): add advisory workspace-busy pre-read check

### DIFF
--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -144,7 +144,7 @@ family_for_basename() {
     fm-subagent-pretool-check.test.sh|\
     fm-supervision-instructions.test.sh|fm-task-delivery.test.sh|\
     fm-tmux-submit-busy.test.sh|fm-trace-context-lib.test.sh|\
-    fm-transition-lib.test.sh|\
+    fm-transition-lib.test.sh|fm-workspace-busy.test.sh|\
     fm-test-run.test.sh|fm-test-isolation-proof.test.sh)
       printf '%s\n' pure-contract-unit
       ;;
@@ -946,7 +946,7 @@ families_for_changed_path() {
     bin/fm-tmux-lib.sh|bin/fm-marker-lib.sh|bin/fm-operational-input.sh|bin/fm-tasks-axi-lib.sh|\
     bin/fm-vendor-auth-probe.sh|\
     bin/fm-primary-scope-lib.sh|bin/fm-project-mode.sh|bin/fm-promote.sh|\
-    bin/fm-ff-lib.sh|bin/fm-gotmp*|bin/*pretool*)
+    bin/fm-ff-lib.sh|bin/fm-gotmp*|bin/*pretool*|bin/fm-workspace-busy.sh)
       printf '%s\n' pure-contract-unit
       ;;
     .agents/skills/quota-array-dispatch/SKILL.md)

--- a/bin/fm-workspace-busy.sh
+++ b/bin/fm-workspace-busy.sh
@@ -28,6 +28,15 @@
 #      counted as foreign activity. Requires lsof; when lsof is absent the
 #      process check is skipped and documented as unavailable, not half-done.
 #
+# Checks 1 to 3 answer for the whole work tree, not just <dir>: git status and
+# the git op markers are repo-wide by nature, and the mtime scan is listed from
+# the work-tree root to match them. Passing a subdirectory therefore narrows
+# nothing; it only names which tree to ask about.
+#
+# When a check cannot read git state (git exits non-zero, the mtime scan
+# fails), the answer is busy with its own reason, never quiet. A quiet result
+# must mean "the checks ran and saw nothing", not "a check could not run".
+#
 # Performance: does not walk the whole tree naively. Dirty and lock checks use
 # git (index-backed). The mtime scan iterates only paths git reports as tracked
 # or untracked-and-not-ignored (`git ls-files --cached --others --exclude-standard`),
@@ -42,17 +51,21 @@
 #
 # Usage:
 #   fm-workspace-busy.sh <dir> [--window SECS] [--process] [--no-process]
+#   fm-workspace-busy.sh [--window SECS] -- <dir>
 #   fm-workspace-busy.sh -h | --help
 #
 # Flags:
 #   --window SECS   recent-mtime window (default: FM_WORKSPACE_BUSY_WINDOW_SECS or 180)
 #   --process       also treat a foreign live cwd under <dir> as busy
 #   --no-process    explicit default: skip the process scan
+#   --              end of flags; the next argument is <dir>, even if it
+#                   starts with a dash
 set -eu
 
 usage() {
   cat <<'EOF' >&2
 usage: fm-workspace-busy.sh <dir> [--window SECS] [--process] [--no-process]
+       fm-workspace-busy.sh [--window SECS] -- <dir>
 
 Advisory, read-only: print one short reason line and exit 1 when <dir> looks
 mid-work; print nothing and exit 0 when it looks quiet; exit 2 on usage errors
@@ -63,6 +76,7 @@ This is not a lock. Same-user agents can still write at any time.
   --window SECS   recent-mtime window (default 180, or FM_WORKSPACE_BUSY_WINDOW_SECS)
   --process       also scan for a live process cwd under <dir> (needs lsof)
   --no-process    skip the process scan (default)
+  --              end of flags; the next argument is <dir>
 EOF
 }
 
@@ -111,11 +125,17 @@ while [ $# -gt 0 ]; do
   esac
 done
 
-if [ $# -gt 0 ]; then
-  echo "error: unexpected argument: $1" >&2
-  usage
-  exit 2
-fi
+# Anything left came after `--`: the first such operand is <dir> (this is the
+# only way to name a directory whose own name starts with a dash).
+while [ $# -gt 0 ]; do
+  if [ -n "$DIR" ]; then
+    echo "error: unexpected argument: $1" >&2
+    usage
+    exit 2
+  fi
+  DIR=$1
+  shift
+done
 
 [ -n "$DIR" ] || { usage; exit 2; }
 
@@ -200,14 +220,25 @@ for marker in "${git_ops_markers[@]}"; do
 done
 
 # --- 2. uncommitted changes -------------------------------------------------
-# Porcelain is index-backed and skips ignored paths by design.
-if [ -n "$(git -C "$DIR" status --porcelain --untracked-files=normal 2>/dev/null | head -1)" ]; then
+# Porcelain is index-backed and skips ignored paths by design. The output is
+# captured whole rather than piped through `head`, so a git failure stays
+# distinguishable from a clean tree: empty output would otherwise read as
+# "nothing to report" for a git that never reported anything.
+status_out=$(git -C "$DIR" status --porcelain --untracked-files=normal 2>/dev/null) ||
+  busy "could not read git state (status failed)"
+
+if [ -n "$status_out" ]; then
   busy "uncommitted changes"
 fi
 
 # --- 3. recent non-ignored file mtime ---------------------------------------
 # Iterate only paths git cares about: tracked files and untracked files that
 # are not ignored. Never walks ignored bulk directories.
+#
+# `git ls-files` prints paths relative to its own working directory, so it is
+# listed from $ROOT and joined against $ROOT. Listing from a subdirectory would
+# yield paths that do not resolve against the root, every stat would miss, and
+# the scan would report quiet on a tree written to seconds ago.
 #
 # A per-file `stat` fork is too slow on multi-thousand-file trees (tens of
 # seconds). Prefer one python3 process over the null-delimited path list; fall
@@ -231,14 +262,20 @@ file_mtime() {
   return 1
 }
 
+# Both paths report failure through the substitution's exit status: a non-zero
+# `git ls-files` (PIPESTATUS[0]) or a crashed reader means the scan could not
+# establish a result, which is not the same as finding nothing. Note that a
+# found path wins over a failed status on purpose: the shell reader breaks out
+# early, which can hand `git ls-files` a SIGPIPE it did not deserve.
 recent_rel=
+scan_failed=0
 if command -v python3 >/dev/null 2>&1; then
   # Prints the first relative path with mtime >= cutoff, or nothing.
-  # Exit 0 always from python; empty stdout means no recent non-ignored file.
+  # Reads stdin to EOF before deciding, so git is never handed a SIGPIPE here.
   recent_rel=$(
-    git -C "$DIR" ls-files -z --cached --others --exclude-standard 2>/dev/null \
+    git -C "$ROOT" ls-files -z --cached --others --exclude-standard 2>/dev/null \
       | FM_WB_ROOT="$ROOT" FM_WB_CUTOFF="$cutoff" python3 -c '
-import os, sys
+import os, stat, sys
 root = os.environ["FM_WB_ROOT"]
 cutoff = float(os.environ["FM_WB_CUTOFF"])
 data = sys.stdin.buffer.read().split(b"\0")
@@ -252,30 +289,43 @@ for raw in data:
         st = os.stat(path)
     except OSError:
         continue
-    if not os.path.isfile(path):
+    if not stat.S_ISREG(st.st_mode):
         continue
     if st.st_mtime >= cutoff:
         sys.stdout.write(rel)
         break
 '
-  ) || recent_rel=
+    scan_st=("${PIPESTATUS[@]}")
+    [ "${scan_st[0]}" -eq 0 ] && [ "${scan_st[1]}" -eq 0 ]
+  ) || scan_failed=1
 else
   # Slow path: one stat(1) per path. Acceptable on small trees only.
-  while IFS= read -r -d '' rel; do
-    [ -n "$rel" ] || continue
-    full="$ROOT/$rel"
-    [ -f "$full" ] || continue
-    mtime=$(file_mtime "$full") || continue
-    case "$mtime" in ''|*[!0-9]*) continue ;; esac
-    if [ "$mtime" -ge "$cutoff" ]; then
-      recent_rel=$rel
-      break
-    fi
-  done < <(git -C "$DIR" ls-files -z --cached --others --exclude-standard 2>/dev/null)
+  recent_rel=$(
+    git -C "$ROOT" ls-files -z --cached --others --exclude-standard 2>/dev/null \
+      | {
+        while IFS= read -r -d '' rel; do
+          [ -n "$rel" ] || continue
+          full="$ROOT/$rel"
+          [ -f "$full" ] || continue
+          mtime=$(file_mtime "$full") || continue
+          case "$mtime" in ''|*[!0-9]*) continue ;; esac
+          if [ "$mtime" -ge "$cutoff" ]; then
+            printf '%s' "$rel"
+            break
+          fi
+        done
+      }
+    scan_st=("${PIPESTATUS[@]}")
+    [ "${scan_st[0]}" -eq 0 ] && [ "${scan_st[1]}" -eq 0 ]
+  ) || scan_failed=1
 fi
 
-if [ -n "${recent_rel:-}" ]; then
+if [ -n "$recent_rel" ]; then
   busy "recent write: $recent_rel"
+fi
+
+if [ "$scan_failed" -eq 1 ]; then
+  busy "could not read git state (recent-write scan failed)"
 fi
 
 # --- 4. optional live process cwd -------------------------------------------

--- a/bin/fm-workspace-busy.sh
+++ b/bin/fm-workspace-busy.sh
@@ -1,0 +1,320 @@
+#!/usr/bin/env bash
+# fm-workspace-busy.sh - advisory, read-only check: does this directory look
+# actively mid-work right now?
+#
+# WHY: A verifier that reads a tree while a writer is mid-edit can report
+# confident nonsense from half-written files. This check lets a reader stand
+# down and wait, or report "someone is working here", instead of trusting a
+# momentarily inconsistent record.
+#
+# HONEST BOUNDARY: ADVISORY ONLY.
+# Every agent on a shared Mac typically runs as the same OS user, so nothing
+# here can prevent another process from writing, and a quiet result is not
+# exclusive access. This protects against reading mid-write; it does not lock,
+# serialize, or exclude a determined or ignorant writer. Never describe this
+# tool as a lock or a guarantee of exclusive use.
+#
+# This script never writes anywhere: no lock file, no marker, no state, no
+# temp file under the target tree. It only reads git metadata, file mtimes,
+# and (when requested) process working directories.
+#
+# CHECKS, in order (first match wins and prints one short reason line):
+#   1. A git operation in progress (index.lock, MERGE_HEAD, REBASE_HEAD, ...)
+#   2. Uncommitted changes in the working tree (git status --porcelain)
+#   3. A recent non-ignored file mtime within --window seconds (default 180)
+#   4. Optional (--process): a live process whose cwd is inside the tree,
+#      via one bounded `lsof -a -d cwd` scan (same approach as fm-teardown).
+#      Off by default so a reader whose own shell sits in the tree is not
+#      counted as foreign activity. Requires lsof; when lsof is absent the
+#      process check is skipped and documented as unavailable, not half-done.
+#
+# Performance: does not walk the whole tree naively. Dirty and lock checks use
+# git (index-backed). The mtime scan iterates only paths git reports as tracked
+# or untracked-and-not-ignored (`git ls-files --cached --others --exclude-standard`),
+# so ignored bulk (caches, build products) never contributes cost or a false
+# busy. Measured cost lives in docs/workspace-busy.md.
+#
+# CONTRACT:
+#   stdout: one short reason line when busy; empty when quiet
+#   exit 0: looks quiet
+#   exit 1: looks busy (reason on stdout)
+#   exit 2: usage error (bad args, missing path, not a directory, not a git work tree)
+#
+# Usage:
+#   fm-workspace-busy.sh <dir> [--window SECS] [--process] [--no-process]
+#   fm-workspace-busy.sh -h | --help
+#
+# Flags:
+#   --window SECS   recent-mtime window (default: FM_WORKSPACE_BUSY_WINDOW_SECS or 180)
+#   --process       also treat a foreign live cwd under <dir> as busy
+#   --no-process    explicit default: skip the process scan
+set -eu
+
+usage() {
+  cat <<'EOF' >&2
+usage: fm-workspace-busy.sh <dir> [--window SECS] [--process] [--no-process]
+
+Advisory, read-only: print one short reason line and exit 1 when <dir> looks
+mid-work; print nothing and exit 0 when it looks quiet; exit 2 on usage errors
+(missing path, not a directory, not a git work tree).
+
+This is not a lock. Same-user agents can still write at any time.
+
+  --window SECS   recent-mtime window (default 180, or FM_WORKSPACE_BUSY_WINDOW_SECS)
+  --process       also scan for a live process cwd under <dir> (needs lsof)
+  --no-process    skip the process scan (default)
+EOF
+}
+
+DIR=
+WINDOW=${FM_WORKSPACE_BUSY_WINDOW_SECS:-180}
+WANT_PROCESS=0
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    --window)
+      shift
+      [ $# -gt 0 ] || { echo "error: --window needs a seconds argument" >&2; exit 2; }
+      WINDOW=$1
+      shift
+      ;;
+    --process)
+      WANT_PROCESS=1
+      shift
+      ;;
+    --no-process)
+      WANT_PROCESS=0
+      shift
+      ;;
+    --)
+      shift
+      break
+      ;;
+    -*)
+      echo "error: unknown flag: $1" >&2
+      usage
+      exit 2
+      ;;
+    *)
+      if [ -n "$DIR" ]; then
+        echo "error: unexpected argument: $1" >&2
+        usage
+        exit 2
+      fi
+      DIR=$1
+      shift
+      ;;
+  esac
+done
+
+if [ $# -gt 0 ]; then
+  echo "error: unexpected argument: $1" >&2
+  usage
+  exit 2
+fi
+
+[ -n "$DIR" ] || { usage; exit 2; }
+
+case "$WINDOW" in
+  ''|*[!0-9]*)
+    echo "error: --window must be a non-negative integer (seconds), got: $WINDOW" >&2
+    exit 2
+    ;;
+esac
+
+if [ ! -e "$DIR" ]; then
+  echo "error: path does not exist: $DIR" >&2
+  exit 2
+fi
+if [ ! -d "$DIR" ]; then
+  echo "error: not a directory: $DIR" >&2
+  exit 2
+fi
+
+# Resolve to a physical path so later prefix checks are stable. Read-only.
+if ! DIR=$(cd "$DIR" && pwd -P); then
+  echo "error: cannot resolve directory: $DIR" >&2
+  exit 2
+fi
+
+if ! git -C "$DIR" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  echo "error: not a git work tree: $DIR" >&2
+  exit 2
+fi
+
+# Work-tree root (physical) for path reporting and cwd prefix checks.
+ROOT=$(git -C "$DIR" rev-parse --show-toplevel) || {
+  echo "error: not a git work tree: $DIR" >&2
+  exit 2
+}
+ROOT=$(cd "$ROOT" && pwd -P) || {
+  echo "error: cannot resolve work tree root: $DIR" >&2
+  exit 2
+}
+
+busy() {
+  # One short reason line on stdout; exit 1.
+  printf '%s\n' "$1"
+  exit 1
+}
+
+# Resolve a `git rev-parse --git-path` result to an absolute path. Git often
+# returns a relative spelling such as `.git/index.lock`; without this, a
+# caller whose cwd is not the work tree would miss in-progress markers.
+abs_git_path() {
+  local p=$1
+  case "$p" in
+    /*) printf '%s' "$p" ;;
+    *) printf '%s/%s' "$DIR" "$p" ;;
+  esac
+}
+
+# --- 1. git operation in progress -------------------------------------------
+# Named markers git leaves while a multi-step operation holds the repo.
+# Paths come from `git rev-parse --git-path` so linked worktrees resolve
+# correctly (index.lock may live under .git/worktrees/<name>/).
+
+git_ops_markers=(
+  index.lock
+  MERGE_HEAD
+  CHERRY_PICK_HEAD
+  REVERT_HEAD
+  REBASE_HEAD
+  BISECT_LOG
+  AUTO_MERGE
+  rebase-merge
+  rebase-apply
+  sequencer/todo
+)
+
+for marker in "${git_ops_markers[@]}"; do
+  path=$(git -C "$DIR" rev-parse --git-path "$marker" 2>/dev/null) || continue
+  path=$(abs_git_path "$path")
+  if [ -e "$path" ]; then
+    busy "git operation in progress ($marker)"
+  fi
+done
+
+# --- 2. uncommitted changes -------------------------------------------------
+# Porcelain is index-backed and skips ignored paths by design.
+if [ -n "$(git -C "$DIR" status --porcelain --untracked-files=normal 2>/dev/null | head -1)" ]; then
+  busy "uncommitted changes"
+fi
+
+# --- 3. recent non-ignored file mtime ---------------------------------------
+# Iterate only paths git cares about: tracked files and untracked files that
+# are not ignored. Never walks ignored bulk directories.
+#
+# A per-file `stat` fork is too slow on multi-thousand-file trees (tens of
+# seconds). Prefer one python3 process over the null-delimited path list; fall
+# back to a pure-shell loop only when python3 is absent.
+
+now=$(date +%s)
+# WINDOW=0 means "only future or exact-now mtimes count"; still valid.
+cutoff=$((now - WINDOW))
+
+file_mtime() {
+  # Portable epoch seconds. Prefer BSD stat (macOS), then GNU.
+  local f=$1 m
+  if m=$(stat -f %m "$f" 2>/dev/null); then
+    printf '%s' "$m"
+    return 0
+  fi
+  if m=$(stat -c %Y "$f" 2>/dev/null); then
+    printf '%s' "$m"
+    return 0
+  fi
+  return 1
+}
+
+recent_rel=
+if command -v python3 >/dev/null 2>&1; then
+  # Prints the first relative path with mtime >= cutoff, or nothing.
+  # Exit 0 always from python; empty stdout means no recent non-ignored file.
+  recent_rel=$(
+    git -C "$DIR" ls-files -z --cached --others --exclude-standard 2>/dev/null \
+      | FM_WB_ROOT="$ROOT" FM_WB_CUTOFF="$cutoff" python3 -c '
+import os, sys
+root = os.environ["FM_WB_ROOT"]
+cutoff = float(os.environ["FM_WB_CUTOFF"])
+data = sys.stdin.buffer.read().split(b"\0")
+enc = sys.getfilesystemencoding() or "utf-8"
+for raw in data:
+    if not raw:
+        continue
+    rel = raw.decode(enc, "surrogateescape")
+    path = os.path.join(root, rel)
+    try:
+        st = os.stat(path)
+    except OSError:
+        continue
+    if not os.path.isfile(path):
+        continue
+    if st.st_mtime >= cutoff:
+        sys.stdout.write(rel)
+        break
+'
+  ) || recent_rel=
+else
+  # Slow path: one stat(1) per path. Acceptable on small trees only.
+  while IFS= read -r -d '' rel; do
+    [ -n "$rel" ] || continue
+    full="$ROOT/$rel"
+    [ -f "$full" ] || continue
+    mtime=$(file_mtime "$full") || continue
+    case "$mtime" in ''|*[!0-9]*) continue ;; esac
+    if [ "$mtime" -ge "$cutoff" ]; then
+      recent_rel=$rel
+      break
+    fi
+  done < <(git -C "$DIR" ls-files -z --cached --others --exclude-standard 2>/dev/null)
+fi
+
+if [ -n "${recent_rel:-}" ]; then
+  busy "recent write: $recent_rel"
+fi
+
+# --- 4. optional live process cwd -------------------------------------------
+# Same bounded system-wide scan fm-teardown uses (lsof -a -d cwd), never the
+# recursive +D tree walk. Excludes this script's own pid. When lsof is missing
+# or the scan fails, skip rather than invent a half-answer.
+
+if [ "$WANT_PROCESS" -eq 1 ]; then
+  if ! command -v lsof >/dev/null 2>&1; then
+    # Availability is documented; quiet is still a valid advisory result for
+    # the checks that did run. Do not pretend a process scan happened.
+    :
+  else
+    # lsof -Fpn: p<pid>, fcwd, n<path> records. Failures skip the check.
+    if out=$(lsof -a -d cwd -Fpn 2>/dev/null); then
+      pid=
+      while IFS= read -r line; do
+        case "$line" in
+          p*)
+            pid=${line#p}
+            case "$pid" in ''|*[!0-9]*) pid= ;; esac
+            ;;
+          n*)
+            [ -n "$pid" ] || continue
+            [ "$pid" = "$$" ] && continue
+            path=${line#n}
+            case "$path" in
+              "$ROOT"|"$ROOT"/*)
+                busy "live process cwd under tree (pid $pid)"
+                ;;
+            esac
+            ;;
+        esac
+      done <<EOF
+$out
+EOF
+    fi
+  fi
+fi
+
+# Quiet: no stdout, exit 0.
+exit 0

--- a/docs/documentation-audiences.json
+++ b/docs/documentation-audiences.json
@@ -361,6 +361,10 @@
       "audience": "operator-current"
     },
     {
+      "path": "docs/workspace-busy.md",
+      "audience": "operator-current"
+    },
+    {
       "path": "docs/zellij-backend.md",
       "audience": "operator-current"
     },

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -91,6 +91,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-send.sh`             | Send one verified literal line or supported key through the target's recorded backend |
 | `fm-busy-lib.sh`         | Single owner of the semantic busy-state contract: verdicts, source attribution, and per-harness sources |
 | `fm-busy-event.sh`       | The only writer of a task's semantic busy-state record; arms an incarnation and applies lifecycle events |
+| `fm-workspace-busy.sh`   | Advisory read-only probe: does a git work tree look mid-work (docs/workspace-busy.md) |
 | `fm-tmux-lib.sh`         | Shared tmux pane primitives for composer capture, verified submit, and the submit-time busy check |
 | `fm-peek.sh`             | Print a bounded tail of a crewmate endpoint                                          |
 | `fm-check-register.sh`   | Bind an intentional custom watcher check to its current bytes                       |

--- a/docs/workspace-busy.md
+++ b/docs/workspace-busy.md
@@ -24,7 +24,7 @@ Do not add a daemon, a marker file, or a charter change that pretends this is ex
 | --- | --- | --- |
 | Looks quiet | empty | 0 |
 | Looks busy | one short reason line | 1 |
-| Missing path, not a directory, or not a git work tree | error on stderr | 2 |
+| Usage error: bad flag or `--window` value, missing path, not a directory, not a git work tree | error on stderr | 2 |
 
 Callers branch on exit status.
 Print nothing when quiet so the tool is safe in `if bin/fm-workspace-busy.sh "$dir"; then ...`.
@@ -111,7 +111,6 @@ Commands run from a disposable firstmate worktree on this machine.
 Times are wall-clock from `/usr/bin/time -p` (real seconds); each figure is the median of seven runs after a warm cache.
 The mtime scan uses one `python3` process over the git path list when available (a per-file `stat` fork is deliberately avoided).
 
-These figures were re-measured after the scan moved to listing from the work-tree root.
 Other agents were active on the machine during the run, so read every number as an upper bound rather than a floor.
 
 | Target | Signal | real (s) |
@@ -124,8 +123,8 @@ Other agents were active on the machine during the run, so read every number as 
 | Synthetic tree: 5_000 tracked files plus ignored `cache/` with 2_000 hot files | quiet (ignored) | 0.28 |
 | Synthetic tree: 5_000 tracked files with one dirty file | busy: uncommitted changes | 0.24 |
 
-The quiet 5_000-file case is the worst one, because quiet is the only verdict that has to stat every candidate path.
-Both the current and the previous spelling of the scan were measured on the same fixtures in the same run, and neither showed a material cost difference.
+Quiet is the costliest verdict, because it is the only one that has to stat every candidate path; a busy verdict stops at the first signal.
+The two quiet 5_000-file rows differ by more than the effect they measure, so treat sub-second gaps at this scale as run-to-run noise on a shared machine, not as a ranking.
 
 Re-measure after material changes to the scan:
 

--- a/docs/workspace-busy.md
+++ b/docs/workspace-busy.md
@@ -1,0 +1,120 @@
+# Workspace busy check (advisory)
+
+`bin/fm-workspace-busy.sh` is a cheap, read-only probe that tells a reader whether a git work tree looks mid-work right now.
+Its job is to help a second mate (or any other agent) stand down instead of reading a half-written corporate record and reporting confident nonsense.
+
+The script header owns exact flags, exit codes, and check order.
+This page owns how to use the check and what it is not.
+
+## What it is not
+
+This is **advisory**.
+It is not a lock, a mutex, a lease, or exclusive access.
+
+On a typical Mac every agent runs as the same OS user, so nothing in this tool can prevent another process from writing.
+A quiet result means "no cheap signal of current activity," not "you alone own this tree."
+A busy result means "something looks mid-work; do not trust a full read yet," not "the other writer is malicious or blocked."
+
+Do not build a locking protocol on top of this script.
+Do not add a daemon, a marker file, or a charter change that pretends this is exclusion.
+
+## Contract
+
+| Situation | stdout | exit |
+| --- | --- | --- |
+| Looks quiet | empty | 0 |
+| Looks busy | one short reason line | 1 |
+| Missing path, not a directory, or not a git work tree | error on stderr | 2 |
+
+Callers branch on exit status.
+Print nothing when quiet so the tool is safe in `if bin/fm-workspace-busy.sh "$dir"; then ...`.
+
+## What it checks
+
+In order, first match wins:
+
+1. **Git operation in progress** - presence of `index.lock`, `MERGE_HEAD`, `REBASE_HEAD`, and related multi-step markers (resolved via `git rev-parse --git-path`, so linked worktrees are correct).
+2. **Uncommitted changes** - any `git status --porcelain` line (tracked or untracked).
+3. **Recent non-ignored file mtime** - any tracked or non-ignored untracked file whose mtime falls inside `--window` seconds (default 180, overridable with `FM_WORKSPACE_BUSY_WINDOW_SECS`).
+4. **Optional live process cwd** - only with `--process`, via one bounded `lsof -a -d cwd` scan (never a recursive tree walk). Off by default so a reader whose own shell sits in the tree is not counted as foreign activity. When `lsof` is missing, the process scan is skipped rather than half-implemented.
+
+Ignored paths never contribute a busy reason: porcelain and `git ls-files --exclude-standard` both skip them, so a cache write under an ignored directory does not look like activity.
+
+The script **writes nothing**, anywhere, ever: no lock file, no state, no marker under the target tree or elsewhere.
+
+## How a second mate should use it
+
+A second mate whose job is to **verify** that a corporate record is true and current, while another agent may **edit** the same repository in a different copy of the tree, should treat this check as a pre-read gate:
+
+```sh
+if reason=$(bin/fm-workspace-busy.sh /path/to/record-repo 2>&1); then
+  # quiet: safe to read and verify
+  verify_record /path/to/record-repo
+else
+  status=$?
+  if [ "$status" -eq 1 ]; then
+    # busy: stand down. This is a correct, useful result - not a failure.
+    echo "paused: someone is working here ($reason)"
+    exit 0
+  fi
+  # usage error (missing path / not a git repo): real problem
+  echo "blocked: workspace-busy check failed: $reason" >&2
+  exit 1
+fi
+```
+
+Standing down with "someone is working here" is a **successful** verification outcome for that turn.
+It is better than a false confident verdict on a momentarily inconsistent tree.
+Retry later on a normal cadence, or surface the busy reason to the parent as a deliberate wait, depending on the charter.
+
+Recommended habits:
+
+- Call the check **immediately before** the read that would produce a verdict, not once at session start.
+- Prefer the default (no `--process`) unless you know writers keep their cwd inside the tree and your own shell does not.
+- Keep the window short (a few minutes). After a clean commit, file mtimes can still look "recent" for that window; that bias is intentional and temporary.
+- Never invent a side channel (touch a `BUSY` file, take a flock) from this advisory signal.
+
+## Performance
+
+The check is meant to run before every read on trees that may hold hundreds of megabytes.
+
+It does **not** walk the whole filesystem tree for ignored bulk.
+Dirty and lock checks use git's index.
+The mtime scan iterates only paths from:
+
+```text
+git ls-files --cached --others --exclude-standard
+```
+
+so cost scales with tracked plus non-ignored untracked files, not with `node_modules` or other ignored caches.
+
+### Measured cost (2026-08-07, macOS)
+
+Commands run from a disposable firstmate worktree on this machine.
+Times are wall-clock from `/usr/bin/time -p` (real seconds); each figure is the median of five runs after a warm cache.
+The mtime scan uses one `python3` process over the git path list when available (a per-file `stat` fork is deliberately avoided).
+
+| Target | Signal | real (s) |
+| --- | --- | --- |
+| Small quiet fixture (1 tracked file, aged mtime) | quiet | 0.11 |
+| Same small tree with a dirty file | busy: uncommitted changes | 0.08 |
+| Same small tree with a fresh `touch` on a tracked file (clean porcelain) | busy: recent write | 0.11 |
+| This firstmate worktree (~370 tracked files; dirty during measurement) | busy: uncommitted changes | 0.09 |
+| Synthetic tree: 5_000 tracked files, quiet, aged mtimes | quiet | 0.17 |
+| Synthetic tree: 5_000 tracked files plus ignored `cache/` with 2_000 hot files | quiet (ignored) | 0.17 |
+| Synthetic tree: 5_000 tracked files with one dirty file | busy: uncommitted changes | 0.09 |
+
+Re-measure after material changes to the scan:
+
+```sh
+/usr/bin/time -p bin/fm-workspace-busy.sh /path/to/tree --window 180
+```
+
+If a future tree is large enough that the mtime scan dominates, keep fixing the scan; do not replace this tool with a daemon or a write-side lock.
+
+## Related
+
+- Script header and `--help`: `bin/fm-workspace-busy.sh`
+- Toolbelt index: [scripts.md](scripts.md)
+- Behavior tests: `tests/fm-workspace-busy.test.sh`
+- Semantic **agent** busy-state (turn lifecycle for crewmates) is a different contract: `bin/fm-busy-lib.sh`. Do not confuse the two.

--- a/docs/workspace-busy.md
+++ b/docs/workspace-busy.md
@@ -29,6 +29,12 @@ Do not add a daemon, a marker file, or a charter change that pretends this is ex
 Callers branch on exit status.
 Print nothing when quiet so the tool is safe in `if bin/fm-workspace-busy.sh "$dir"; then ...`.
 
+A path that starts with a dash is passed after `--`: `bin/fm-workspace-busy.sh --window 60 -- "$dir"`.
+
+One busy reason is not about the other agent at all: `could not read git state (...)` means a check itself could not run (git exited non-zero, the mtime scan failed).
+Uncertainty is reported as busy rather than quiet, because a check that could not run is not evidence that nothing is happening.
+A caller that retries on busy should therefore cap its retries: a genuinely broken repository stays busy forever, and that reason line is the signal to escalate instead of spinning.
+
 ## What it checks
 
 In order, first match wins:
@@ -39,6 +45,10 @@ In order, first match wins:
 4. **Optional live process cwd** - only with `--process`, via one bounded `lsof -a -d cwd` scan (never a recursive tree walk). Off by default so a reader whose own shell sits in the tree is not counted as foreign activity. When `lsof` is missing, the process scan is skipped rather than half-implemented.
 
 Ignored paths never contribute a busy reason: porcelain and `git ls-files --exclude-standard` both skip them, so a cache write under an ignored directory does not look like activity.
+
+Checks 1 to 3 answer for the **whole work tree**, not only for the directory you pass.
+`git status` and the git operation markers are repo-wide by nature, and the mtime scan is listed from the work-tree root so it agrees with them.
+Passing a subdirectory therefore narrows nothing; it only names which tree to ask about, and the path in `recent write: <path>` is relative to the work-tree root.
 
 The script **writes nothing**, anywhere, ever: no lock file, no state, no marker under the target tree or elsewhere.
 
@@ -53,6 +63,13 @@ if reason=$(bin/fm-workspace-busy.sh /path/to/record-repo 2>&1); then
 else
   status=$?
   if [ "$status" -eq 1 ]; then
+    case "$reason" in
+      'could not read git state'*)
+        # a check could not run: not a peaceful wait, escalate
+        echo "blocked: workspace-busy check could not answer: $reason" >&2
+        exit 1
+        ;;
+    esac
     # busy: stand down. This is a correct, useful result - not a failure.
     echo "paused: someone is working here ($reason)"
     exit 0
@@ -91,18 +108,24 @@ so cost scales with tracked plus non-ignored untracked files, not with `node_mod
 ### Measured cost (2026-08-07, macOS)
 
 Commands run from a disposable firstmate worktree on this machine.
-Times are wall-clock from `/usr/bin/time -p` (real seconds); each figure is the median of five runs after a warm cache.
+Times are wall-clock from `/usr/bin/time -p` (real seconds); each figure is the median of seven runs after a warm cache.
 The mtime scan uses one `python3` process over the git path list when available (a per-file `stat` fork is deliberately avoided).
+
+These figures were re-measured after the scan moved to listing from the work-tree root.
+Other agents were active on the machine during the run, so read every number as an upper bound rather than a floor.
 
 | Target | Signal | real (s) |
 | --- | --- | --- |
-| Small quiet fixture (1 tracked file, aged mtime) | quiet | 0.11 |
-| Same small tree with a dirty file | busy: uncommitted changes | 0.08 |
-| Same small tree with a fresh `touch` on a tracked file (clean porcelain) | busy: recent write | 0.11 |
-| This firstmate worktree (~370 tracked files; dirty during measurement) | busy: uncommitted changes | 0.09 |
-| Synthetic tree: 5_000 tracked files, quiet, aged mtimes | quiet | 0.17 |
-| Synthetic tree: 5_000 tracked files plus ignored `cache/` with 2_000 hot files | quiet (ignored) | 0.17 |
-| Synthetic tree: 5_000 tracked files with one dirty file | busy: uncommitted changes | 0.09 |
+| Small quiet fixture (1 tracked file, aged mtime) | quiet | 0.17 |
+| Same small tree with a dirty file | busy: uncommitted changes | 0.18 |
+| Same small tree with a fresh `touch` on a tracked file (clean porcelain) | busy: recent write | 0.22 |
+| This firstmate worktree (~370 tracked files; dirty during measurement) | busy: uncommitted changes | 0.21 |
+| Synthetic tree: 5_000 tracked files, quiet, aged mtimes | quiet | 0.43 |
+| Synthetic tree: 5_000 tracked files plus ignored `cache/` with 2_000 hot files | quiet (ignored) | 0.28 |
+| Synthetic tree: 5_000 tracked files with one dirty file | busy: uncommitted changes | 0.24 |
+
+The quiet 5_000-file case is the worst one, because quiet is the only verdict that has to stat every candidate path.
+Both the current and the previous spelling of the scan were measured on the same fixtures in the same run, and neither showed a material cost difference.
 
 Re-measure after material changes to the scan:
 

--- a/tests/fm-workspace-busy.test.sh
+++ b/tests/fm-workspace-busy.test.sh
@@ -1,0 +1,316 @@
+#!/usr/bin/env bash
+# Behavior tests for bin/fm-workspace-busy.sh: advisory read-only workspace
+# activity check. Hermetic over temp git fixtures; never touches a real home.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+BUSY="$ROOT/bin/fm-workspace-busy.sh"
+TMP_ROOT=$(fm_test_tmproot fm-workspace-busy)
+
+# --- fixture helpers --------------------------------------------------------
+
+make_repo() {  # <name> -> prints path
+  local d="$TMP_ROOT/$1"
+  mkdir -p "$d"
+  git -C "$d" init -q
+  git -C "$d" config user.email "test@example.com"
+  git -C "$d" config user.name "test"
+  printf 'seed\n' >"$d/README"
+  git -C "$d" add README
+  git -C "$d" commit -q -m seed
+  # Normalize mtimes into the past so a just-created fixture is not "recent"
+  # under the default window. touch -t is portable on macOS and GNU.
+  touch -t 202001011200 "$d/README" 2>/dev/null || true
+  printf '%s' "$d"
+}
+
+run_busy() {  # <dir> [extra args...] -> sets RC, OUT, ERR
+  local dir=$1
+  shift
+  OUT=$("$BUSY" "$dir" "$@" 2>"$TMP_ROOT/err") && RC=0 || RC=$?
+  ERR=$(cat "$TMP_ROOT/err" 2>/dev/null || true)
+}
+
+expect_quiet() {  # <label>
+  [ "$RC" -eq 0 ] || fail "$1: expected quiet exit 0, got $RC (out='$OUT' err='$ERR')"
+  [ -z "$OUT" ] || fail "$1: expected empty stdout when quiet, got '$OUT'"
+}
+
+expect_busy() {  # <label> <substring of reason>
+  local label=$1 want=$2
+  [ "$RC" -eq 1 ] || fail "$label: expected busy exit 1, got $RC (out='$OUT' err='$ERR')"
+  [ -n "$OUT" ] || fail "$label: expected a reason line on stdout"
+  case "$OUT" in
+    *"$want"*) ;;
+    *) fail "$label: expected reason containing '$want', got '$OUT'" ;;
+  esac
+}
+
+expect_usage() {  # <label>
+  [ "$RC" -eq 2 ] || fail "$1: expected usage exit 2, got $RC (out='$OUT' err='$ERR')"
+}
+
+# Snapshot the target tree's non-.git paths so we can prove the script wrote nothing.
+tree_fingerprint() {  # <dir>
+  # List every path under dir except .git, with type and size only (no mtime),
+  # so a pure read cannot look like a write.
+  (cd "$1" && find . -path './.git' -prune -o -print | LC_ALL=C sort | while IFS= read -r p; do
+    if [ -f "$p" ]; then
+      # size only
+      wc -c <"$p" | tr -d ' '
+      printf ' F %s\n' "$p"
+    elif [ -d "$p" ]; then
+      printf 'D %s\n' "$p"
+    else
+      printf 'O %s\n' "$p"
+    fi
+  done)
+}
+
+# --- usage errors -----------------------------------------------------------
+
+test_missing_path() {
+  run_busy "$TMP_ROOT/does-not-exist-$$"
+  expect_usage "missing path"
+  case "$ERR" in
+    *'does not exist'*) ;;
+    *) fail "missing path: expected 'does not exist' on stderr, got '$ERR'" ;;
+  esac
+  pass "missing path exits 2"
+}
+
+test_not_a_repo() {
+  local d="$TMP_ROOT/not-a-repo"
+  mkdir -p "$d"
+  printf 'x\n' >"$d/file"
+  run_busy "$d"
+  expect_usage "not a repo"
+  case "$ERR" in
+    *'not a git work tree'*) ;;
+    *) fail "not a repo: expected work-tree error, got '$ERR'" ;;
+  esac
+  pass "non-repository exits 2"
+}
+
+test_no_args() {
+  OUT=$("$BUSY" 2>"$TMP_ROOT/err") && RC=0 || RC=$?
+  ERR=$(cat "$TMP_ROOT/err")
+  expect_usage "no args"
+  pass "missing <dir> exits 2"
+}
+
+# --- quiet clean tree -------------------------------------------------------
+
+test_clean_quiet() {
+  local d before after
+  d=$(make_repo clean-quiet)
+  # Age the only file well outside the default window.
+  touch -t 202001011200 "$d/README"
+  before=$(tree_fingerprint "$d")
+  run_busy "$d" --window 60
+  expect_quiet "clean quiet"
+  after=$(tree_fingerprint "$d")
+  [ "$before" = "$after" ] || fail "clean quiet: script mutated the tree"
+  pass "clean quiet tree prints nothing and exits 0"
+}
+
+# --- uncommitted changes ----------------------------------------------------
+
+test_uncommitted_tracked() {
+  local d
+  d=$(make_repo dirty-tracked)
+  printf 'edited\n' >"$d/README"
+  run_busy "$d" --window 60
+  expect_busy "dirty tracked" "uncommitted changes"
+  pass "uncommitted tracked edit reports busy"
+}
+
+test_uncommitted_untracked() {
+  local d
+  d=$(make_repo dirty-untracked)
+  printf 'new\n' >"$d/newfile.txt"
+  run_busy "$d" --window 60
+  expect_busy "dirty untracked" "uncommitted changes"
+  pass "untracked non-ignored file reports busy"
+}
+
+# --- recent mtime (clean index, file touched) -------------------------------
+
+test_recent_mtime() {
+  local d
+  d=$(make_repo recent-mtime)
+  # Content-identical rewrite so porcelain stays clean, but mtime is now.
+  # git status is clean when content matches HEAD; touch updates mtime only.
+  touch "$d/README"
+  run_busy "$d" --window 300
+  expect_busy "recent mtime" "recent write"
+  pass "recent mtime on a clean tree reports busy"
+}
+
+test_old_mtime_quiet() {
+  local d
+  d=$(make_repo old-mtime)
+  touch -t 202001011200 "$d/README"
+  run_busy "$d" --window 60
+  expect_quiet "old mtime"
+  pass "aged mtime outside the window is quiet"
+}
+
+# --- ignored paths do not false-busy ----------------------------------------
+
+test_ignored_path_not_busy() {
+  local d
+  d=$(make_repo ignored-path)
+  printf 'cache/\n' >"$d/.gitignore"
+  git -C "$d" add .gitignore
+  git -C "$d" commit -q -m 'ignore cache'
+  touch -t 202001011200 "$d/README" "$d/.gitignore"
+  mkdir -p "$d/cache"
+  # Fresh write under an ignored path must not count.
+  printf 'blob\n' >"$d/cache/hot.bin"
+  touch "$d/cache/hot.bin"
+  run_busy "$d" --window 300
+  expect_quiet "ignored recent write"
+  pass "ignored path writes do not trigger busy"
+}
+
+# --- git operation in progress ----------------------------------------------
+
+# git rev-parse --git-path often returns a relative path; tests must resolve
+# it against the fixture root (mirrors abs_git_path in the script).
+fixture_git_path() {  # <repo> <name>
+  local repo=$1 name=$2 p
+  p=$(git -C "$repo" rev-parse --git-path "$name")
+  case "$p" in
+    /*) printf '%s' "$p" ;;
+    *) printf '%s/%s' "$repo" "$p" ;;
+  esac
+}
+
+test_index_lock_busy() {
+  local d lock
+  d=$(make_repo index-lock)
+  touch -t 202001011200 "$d/README"
+  lock=$(fixture_git_path "$d" index.lock)
+  # Create a fake lock file (read-only check; we do not hold a real git lock).
+  printf 'fake\n' >"$lock"
+  run_busy "$d" --window 60
+  expect_busy "index.lock" "git operation in progress"
+  # Clean up the fixture lock so temp cleanup is tidy.
+  rm -f "$lock"
+  pass "index.lock reports git operation in progress"
+}
+
+test_merge_head_busy() {
+  local d path
+  d=$(make_repo merge-head)
+  touch -t 202001011200 "$d/README"
+  path=$(fixture_git_path "$d" MERGE_HEAD)
+  # A plausible 40-hex placeholder; content is irrelevant, presence is the signal.
+  printf 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n' >"$path"
+  run_busy "$d" --window 60
+  expect_busy "MERGE_HEAD" "git operation in progress"
+  rm -f "$path"
+  pass "MERGE_HEAD reports git operation in progress"
+}
+
+test_rebase_head_busy() {
+  local d path
+  d=$(make_repo rebase-head)
+  touch -t 202001011200 "$d/README"
+  path=$(fixture_git_path "$d" REBASE_HEAD)
+  printf 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\n' >"$path"
+  run_busy "$d" --window 60
+  expect_busy "REBASE_HEAD" "git operation in progress"
+  rm -f "$path"
+  pass "REBASE_HEAD reports git operation in progress"
+}
+
+# --- writes nothing ---------------------------------------------------------
+
+test_writes_nothing() {
+  local d before after
+  d=$(make_repo no-write)
+  touch -t 202001011200 "$d/README"
+  before=$(tree_fingerprint "$d")
+  # Run every interesting path shape against the same tree.
+  run_busy "$d" --window 60
+  expect_quiet "writes-nothing quiet"
+  printf 'edit\n' >"$d/README"
+  run_busy "$d" --window 60
+  expect_busy "writes-nothing dirty" "uncommitted changes"
+  # Restore clean content and age it so a second quiet run is possible.
+  git -C "$d" checkout -q -- README
+  touch -t 202001011200 "$d/README"
+  after=$(tree_fingerprint "$d")
+  # The edit we made for the dirty case is restored; fingerprint should match
+  # the pre-check clean tree (README size may match seed).
+  before=$(tree_fingerprint "$d")
+  run_busy "$d" --window 60 --no-process
+  expect_quiet "writes-nothing final"
+  after=$(tree_fingerprint "$d")
+  [ "$before" = "$after" ] || fail "writes-nothing: tree changed across a quiet check"
+  # No lock / state / marker files of our own naming.
+  if find "$d" -name '*workspace-busy*' -o -name '*.fm-busy*' 2>/dev/null | grep -q .; then
+    fail "writes-nothing: found a workspace-busy marker under the tree"
+  fi
+  pass "script writes nothing under the target tree"
+}
+
+# --- process scan opt-in shape ----------------------------------------------
+
+test_process_flag_accepted() {
+  local d
+  d=$(make_repo process-flag)
+  touch -t 202001011200 "$d/README"
+  # --process must not crash; with only this script's pid in the tree scan
+  # path (excluded as $$), a clean aged tree stays quiet when no foreign
+  # cwd is present.
+  run_busy "$d" --window 60 --process
+  # Either quiet (no foreign cwd) or busy with a live-process reason if some
+  # ambient agent has cwd here (unlikely under TMP_ROOT). Both are valid
+  # exit shapes for the flag; only a usage error (2) is wrong.
+  [ "$RC" -eq 0 ] || [ "$RC" -eq 1 ] || fail "process flag: unexpected exit $RC err='$ERR'"
+  if [ "$RC" -eq 1 ]; then
+    case "$OUT" in
+      *'live process cwd'*|*'uncommitted'*|*'recent write'*|*'git operation'*) ;;
+      *) fail "process flag: unexpected busy reason '$OUT'" ;;
+    esac
+  fi
+  pass "--process is accepted and returns quiet or a concrete busy reason"
+}
+
+# --- help -------------------------------------------------------------------
+
+test_help() {
+  OUT=$("$BUSY" --help 2>"$TMP_ROOT/err") && RC=0 || RC=$?
+  ERR=$(cat "$TMP_ROOT/err")
+  [ "$RC" -eq 0 ] || fail "help: expected exit 0, got $RC"
+  case "$ERR" in
+    *'usage: fm-workspace-busy.sh'*) ;;
+    *) fail "help: expected usage on stderr, got '$ERR'" ;;
+  esac
+  pass "--help prints usage and exits 0"
+}
+
+# --- run --------------------------------------------------------------------
+
+test_missing_path
+test_not_a_repo
+test_no_args
+test_clean_quiet
+test_uncommitted_tracked
+test_uncommitted_untracked
+test_recent_mtime
+test_old_mtime_quiet
+test_ignored_path_not_busy
+test_index_lock_busy
+test_merge_head_busy
+test_rebase_head_busy
+test_writes_nothing
+test_process_flag_accepted
+test_help
+
+echo "# fm-workspace-busy.test.sh: all assertions passed"

--- a/tests/fm-workspace-busy.test.sh
+++ b/tests/fm-workspace-busy.test.sh
@@ -304,6 +304,21 @@ test_merge_head_busy() {
   pass "MERGE_HEAD reports git operation in progress"
 }
 
+# The marker checks are otherwise only asked from the work-tree root, so the
+# same relative-path trap the recent-write scan hit stays untested: abs_git_path
+# joins a relative `git rev-parse --git-path` answer against <dir>, and a
+# subdirectory target must still find a marker that lives at the repo root.
+test_index_lock_busy_from_subdir() {
+  local d lock
+  d=$(make_multi_dir_repo index-lock-subdir)
+  lock=$(fixture_git_path "$d" index.lock)
+  printf 'fake\n' >"$lock"
+  run_busy "$d/sub" --window 60
+  expect_busy "index.lock from subdir" "git operation in progress"
+  rm -f "$lock"
+  pass "a repo-root git marker is seen from a subdirectory target"
+}
+
 test_rebase_head_busy() {
   local d path
   d=$(make_repo rebase-head)
@@ -345,6 +360,52 @@ test_writes_nothing() {
     fail "writes-nothing: found a workspace-busy marker under the tree"
   fi
   pass "script writes nothing under the target tree"
+}
+
+# The fingerprint above prunes .git on purpose (git's own bookkeeping is not
+# the target tree's content), which leaves the one write this script could
+# plausibly make invisible: `git status` can refresh the index stat cache and
+# rewrite .git/index, taking .git/index.lock to do it. That would contradict
+# the header's "no lock file, no state" claim, and two concurrent checks could
+# then see each other's transient lock and report a git operation in progress.
+test_git_dir_untouched() {
+  local d before after out rc i
+  d=$(make_repo git-dir-untouched)
+  mkdir -p "$d/sub"
+  printf 'a\n' >"$d/sub/a.txt"
+  git -C "$d" add sub/a.txt
+  git -C "$d" commit -q -m sub
+  # Fresh mtimes with unchanged content: the index stat cache is now stale,
+  # which is exactly the state a tree is left in by another agent's writes.
+  touch "$d/README" "$d/sub/a.txt"
+
+  # Hash with git itself: the one hasher this whole file already depends on,
+  # so there is no fallback branch that could leave both sides empty and pass
+  # vacuously on a runner without shasum.
+  before=$(git -C "$d" hash-object -t blob -- "$d/.git/index")
+  run_busy "$d" --window 300
+  expect_busy "git-dir untouched" "recent write"
+  run_busy "$d" --window 0
+  after=$(git -C "$d" hash-object -t blob -- "$d/.git/index")
+  [ -n "$before" ] || fail "git-dir untouched: could not hash .git/index"
+  [ "$before" = "$after" ] || fail "git-dir untouched: the check rewrote .git/index"
+
+  # Nothing lock-shaped may survive a run either.
+  if [ -e "$d/.git/index.lock" ]; then
+    fail "git-dir untouched: the check left .git/index.lock behind"
+  fi
+
+  # Concurrent checks on one repo must not observe each other as a git op.
+  touch -t 202001011200 "$d/README" "$d/sub/a.txt"
+  for i in 1 2 3 4 5 6; do
+    "$BUSY" "$d" --window 60 >"$TMP_ROOT/conc.$i" 2>&1 &
+  done
+  wait
+  for i in 1 2 3 4 5 6; do
+    out=$(cat "$TMP_ROOT/conc.$i")
+    [ -z "$out" ] || fail "git-dir untouched: concurrent check $i reported '$out'"
+  done
+  pass "the check leaves .git untouched and concurrent runs do not false-busy"
 }
 
 # --- process scan opt-in shape ----------------------------------------------
@@ -445,9 +506,11 @@ test_status_failure_is_busy
 test_ls_files_failure_is_busy
 test_ignored_path_not_busy
 test_index_lock_busy
+test_index_lock_busy_from_subdir
 test_merge_head_busy
 test_rebase_head_busy
 test_writes_nothing
+test_git_dir_untouched
 test_process_flag_accepted
 test_end_of_options
 test_shell_fallback_scan

--- a/tests/fm-workspace-busy.test.sh
+++ b/tests/fm-workspace-busy.test.sh
@@ -33,6 +33,32 @@ run_busy() {  # <dir> [extra args...] -> sets RC, OUT, ERR
   ERR=$(cat "$TMP_ROOT/err" 2>/dev/null || true)
 }
 
+run_raw() {  # <args...> -> sets RC, OUT, ERR (no implied <dir>)
+  OUT=$("$BUSY" "$@" 2>"$TMP_ROOT/err") && RC=0 || RC=$?
+  ERR=$(cat "$TMP_ROOT/err" 2>/dev/null || true)
+}
+
+# A git shim that fails one subcommand and delegates everything else to the
+# real git. Blanket failure is useless here: rev-parse runs first and would
+# turn every case into a usage error.
+make_failing_git() {  # <subcommand> -> prints a dir to prepend to PATH
+  local sub=$1 dir="$TMP_ROOT/shim-git-$1" real
+  real=$(command -v git)
+  mkdir -p "$dir"
+  cat >"$dir/git" <<EOF
+#!/usr/bin/env bash
+for arg in "\$@"; do
+  if [ "\$arg" = "$sub" ]; then
+    echo "shim: forced $sub failure" >&2
+    exit 1
+  fi
+done
+exec "$real" "\$@"
+EOF
+  chmod +x "$dir/git"
+  printf '%s' "$dir"
+}
+
 expect_quiet() {  # <label>
   [ "$RC" -eq 0 ] || fail "$1: expected quiet exit 0, got $RC (out='$OUT' err='$ERR')"
   [ -z "$OUT" ] || fail "$1: expected empty stdout when quiet, got '$OUT'"
@@ -156,6 +182,68 @@ test_old_mtime_quiet() {
   run_busy "$d" --window 60
   expect_quiet "old mtime"
   pass "aged mtime outside the window is quiet"
+}
+
+# --- subdirectory target ----------------------------------------------------
+
+# git ls-files prints paths relative to its own working directory. A scan
+# listed from <dir> but joined against the work-tree root resolves to nothing
+# when <dir> is a subdirectory, and every recent write reads as quiet.
+make_multi_dir_repo() {  # <name> -> prints path
+  local d
+  d=$(make_repo "$1")
+  mkdir -p "$d/sub" "$d/other"
+  printf 'a\n' >"$d/sub/a.txt"
+  printf 'b\n' >"$d/other/b.txt"
+  git -C "$d" add sub/a.txt other/b.txt
+  git -C "$d" commit -q -m 'two dirs'
+  touch -t 202001011200 "$d/README" "$d/sub/a.txt" "$d/other/b.txt"
+  printf '%s' "$d"
+}
+
+test_subdir_recent_write_busy() {
+  local d
+  d=$(make_multi_dir_repo subdir-recent)
+  touch "$d/sub/a.txt"
+  run_busy "$d/sub" --window 300
+  expect_busy "subdir recent write" "recent write"
+  case "$OUT" in
+    *sub/a.txt*) ;;
+    *) fail "subdir recent write: expected the touched path in '$OUT'" ;;
+  esac
+  pass "recent write under a subdirectory target reports busy"
+}
+
+test_subdir_quiet() {
+  local d
+  d=$(make_multi_dir_repo subdir-quiet)
+  run_busy "$d/sub" --window 60
+  expect_quiet "subdir quiet"
+  pass "aged subdirectory target is quiet"
+}
+
+# --- unreadable git state is busy, never quiet ------------------------------
+
+test_status_failure_is_busy() {
+  local d shim
+  d=$(make_repo status-failure)
+  touch -t 202001011200 "$d/README"
+  shim=$(make_failing_git status)
+  OUT=$(PATH="$shim:$PATH" "$BUSY" "$d" --window 60 2>"$TMP_ROOT/err") && RC=0 || RC=$?
+  ERR=$(cat "$TMP_ROOT/err" 2>/dev/null || true)
+  expect_busy "status failure" "could not read git state"
+  pass "a failing git status reports busy, not quiet"
+}
+
+test_ls_files_failure_is_busy() {
+  local d shim
+  d=$(make_repo ls-files-failure)
+  touch -t 202001011200 "$d/README"
+  shim=$(make_failing_git ls-files)
+  OUT=$(PATH="$shim:$PATH" "$BUSY" "$d" --window 60 2>"$TMP_ROOT/err") && RC=0 || RC=$?
+  ERR=$(cat "$TMP_ROOT/err" 2>/dev/null || true)
+  expect_busy "ls-files failure" "could not read git state"
+  pass "a failing mtime scan reports busy, not quiet"
 }
 
 # --- ignored paths do not false-busy ----------------------------------------
@@ -282,6 +370,52 @@ test_process_flag_accepted() {
   pass "--process is accepted and returns quiet or a concrete busy reason"
 }
 
+# --- end of options ---------------------------------------------------------
+
+test_end_of_options() {
+  local d
+  d=$(make_repo end-of-options)
+  touch -t 202001011200 "$d/README"
+  run_raw --window 60 -- "$d"
+  expect_quiet "-- <dir> quiet"
+  printf 'edit\n' >"$d/README"
+  run_raw --window 60 -- "$d"
+  expect_busy "-- <dir> busy" "uncommitted changes"
+  run_raw --
+  expect_usage "-- with no operand"
+  run_raw -- "$d" "$d"
+  expect_usage "-- with two operands"
+  pass "-- consumes the following argument as <dir>"
+}
+
+# --- shell fallback when python3 is absent ----------------------------------
+
+test_shell_fallback_scan() {
+  local d shim tool p
+  d=$(make_multi_dir_repo fallback-scan)
+  shim="$TMP_ROOT/shim-nopython"
+  mkdir -p "$shim"
+  for tool in bash git date stat; do
+    p=$(command -v "$tool") || continue
+    ln -sf "$p" "$shim/$tool"
+  done
+  if PATH="$shim" bash -c 'command -v git >/dev/null && git --version >/dev/null' 2>/dev/null; then
+    OUT=$(PATH="$shim" "$BUSY" "$d/sub" --window 60 2>"$TMP_ROOT/err") && RC=0 || RC=$?
+    ERR=$(cat "$TMP_ROOT/err" 2>/dev/null || true)
+    expect_quiet "fallback quiet"
+    # README sorts first in ls-files order, so the reader breaks out with paths
+    # still unread and hands git a SIGPIPE. A found path must still win over
+    # that failed status.
+    touch "$d/README"
+    OUT=$(PATH="$shim" "$BUSY" "$d/sub" --window 300 2>"$TMP_ROOT/err") && RC=0 || RC=$?
+    ERR=$(cat "$TMP_ROOT/err" 2>/dev/null || true)
+    expect_busy "fallback recent" "recent write: README"
+    pass "the no-python3 shell scan agrees with the python scan"
+  else
+    pass "skipped: git does not run under a minimal PATH on this machine"
+  fi
+}
+
 # --- help -------------------------------------------------------------------
 
 test_help() {
@@ -305,12 +439,18 @@ test_uncommitted_tracked
 test_uncommitted_untracked
 test_recent_mtime
 test_old_mtime_quiet
+test_subdir_recent_write_busy
+test_subdir_quiet
+test_status_failure_is_busy
+test_ls_files_failure_is_busy
 test_ignored_path_not_busy
 test_index_lock_busy
 test_merge_head_busy
 test_rebase_head_busy
 test_writes_nothing
 test_process_flag_accepted
+test_end_of_options
+test_shell_fallback_scan
 test_help
 
 echo "# fm-workspace-busy.test.sh: all assertions passed"

--- a/tests/fm-workspace-busy.test.sh
+++ b/tests/fm-workspace-busy.test.sh
@@ -369,7 +369,7 @@ test_writes_nothing() {
 # the header's "no lock file, no state" claim, and two concurrent checks could
 # then see each other's transient lock and report a git operation in progress.
 test_git_dir_untouched() {
-  local d before after out rc i
+  local d before after out i
   d=$(make_repo git-dir-untouched)
   mkdir -p "$d/sub"
   printf 'a\n' >"$d/sub/a.txt"


### PR DESCRIPTION
## Intent

Build bin/fm-workspace-busy.sh: a cheap, read-only advisory check that tells an agent whether somebody else is actively working in a directory, so a verifier can stand down instead of reading half-written state.

Problem: a second mate verifies that a corporate record is true and current while a separate agent edits the same repository in a different copy. Mid-write files make the record momentarily inconsistent; a verifier that reads then reports confident nonsense. This check lets the reader notice and wait.

Honest boundary: ADVISORY only. Every agent on this Mac runs as the same user, so nothing here can prevent another process from writing. It protects against reading mid-write, not against a determined or ignorant writer. Say that plainly in the script header and docs. Do not use the words fail-closed or fail-open in captain-facing output.

Checks (cheap, write nothing ever):
- Uncommitted changes in the working tree
- Recent modification time on non-ignored files within a configurable window (default a few minutes); skip ignored and .git paths so cache writes do not read as activity
- Git operation in progress: index.lock, MERGE_HEAD, REBASE_HEAD and friends
- Optionally, a live process whose cwd is inside the tree if that can be determined cheaply and portably; if not, document rather than half-doing it

Contract: print one short line naming the concrete reason when busy, print nothing when quiet; exit status for branching. Missing path or non-git-repo is a usage error distinguishable from busy and quiet. Fast enough to call before every read on large trees; do not walk the whole tree naively; measure cost and document it.

Also document how a second mate should USE it in docs/, including that standing down and reporting "someone is working here" is a correct useful result, not a failure.

Acceptance: correct verdict for clean quiet, uncommitted changes, tree touched seconds ago, git op in flight, non-repository, missing path; ignored paths do not false-busy; writes nothing; behavioral tests; measured cost in docs.

Do not build a locking mechanism, daemon, or change any second mate charter. One small read-only utility. Load firstmate-coding-guidelines; acceptable upstream to kunchenguid/firstmate. Delivery mode no-mistakes.

## What Changed

- Adds `bin/fm-workspace-busy.sh`, a read-only advisory probe that reports whether a git work tree looks mid-work: a git operation in progress (`index.lock`, `MERGE_HEAD`, `REBASE_HEAD` and friends), uncommitted changes, or a non-ignored file modified inside a configurable window (default 180s, `--window`). An opt-in `--process` scan also counts a live process whose cwd is under the tree. Busy prints one short reason line and exits 1, quiet prints nothing and exits 0, and a missing path or non-repository exits 2; when a git call cannot be read the answer is busy with its own reason rather than quiet. The mtime scan iterates only paths git reports as tracked or untracked-and-not-ignored, so ignored bulk never costs time or reads as activity, and the script writes nothing anywhere.
- Documents the probe in `docs/workspace-busy.md`: the advisory-only boundary (it does not lock or exclude a writer), the exit-status contract, how a second mate should use it (standing down and reporting "someone is working here" is a correct result), and measured cost on large trees. Registers it in `docs/scripts.md` and `docs/documentation-audiences.json`.
- Adds `tests/fm-workspace-busy.test.sh` covering the verdict, usage-error, and writes-nothing behavior, and routes both the new script and the new suite into the `pure-contract-unit` family in `bin/fm-test-run.sh`.

## Risk Assessment

✅ Low: The round-1 false-quiet bug and the silent-degradation paths are genuinely fixed and each has a matching new test, the change remains one self-contained read-only script that alters no existing behavior beyond two test-classification lines, and docs including the re-measured cost table are in sync with the new behavior.

## Testing

This is a CLI utility, so the CLI transcripts ARE the end-user surface and no screenshot or rendered-HTML artifact applies. I ran the three targeted suites the diff touches (fm-workspace-busy, fm-test-run for its family-table edits, fm-documentation-audiences for the docs edits) and confirmed the new script routes to its test through fm-test-run's changed-file selection. Since unit passes alone prove little here, I drove the tool by hand over disposable git fixtures for all six required verdicts plus ignored-path quiet and both subdirectory shapes, using a genuine conflicted merge rather than a fabricated marker so the check ordering is visible. I closed the two gaps the suite left open: --process was only asserted to not crash, so I demonstrated it actually detecting a live foreign cwd and going quiet again after the kill; and the git-op markers were only ever asked from the repo root, so I verified a root-level index.lock is still found from a subdirectory target and mutation-checked that the assertion bites. The writes-nothing claim needed strengthening because the existing fingerprint prunes .git, hiding the one write a git-backed check could plausibly make: with every .git directory made non-writable, both verdicts still came back correct, and eight concurrent checks on one repo all stayed quiet, so the tool never takes index.lock and cannot false-busy itself. Measured cost lands at or under the published table (worst case, 5000 tracked files quiet: 0.25 s median against 0.43 s documented, with 2000 ignored hot files adding nothing), so the docs are accurate. The documented second-mate caller snippet was run verbatim across all four branches including the two escalation paths. I added two assertions to tests/fm-workspace-busy.test.sh (git-dir untouched plus concurrency, and the subdirectory marker case); they are uncommitted in the worktree, which is the only reason the tree is not clean. All temp fixtures and driver scripts were removed. No linters or formatters were run, and no findings are outstanding.

<details>
<summary>Evidence: Acceptance walkthrough: all six required verdicts plus ignored-quiet and subdirectory shapes</summary>

<code>### 1. clean quiet tree (nothing printed, exit 0)&#10;$ fm-workspace-busy.sh .../clean --window 60&#10;$ echo $? -&gt; 0&#10;&#10;### 2. uncommitted changes (another agent mid-edit)&#10;uncommitted changes&#10;$ echo $? -&gt; 1&#10;&#10;### 3. tracked file touched seconds ago, porcelain clean&#10;recent write: RECORD.md&#10;$ echo $? -&gt; 1&#10;&#10;(a real &#39;git merge other&#39; left the repo conflicted: MERGE_HEAD present AND the tree dirty)&#10;porcelain: UU RECORD.md&#10;### 4. git operation in flight (ordering: git-op wins over dirty)&#10;git operation in progress (MERGE_HEAD)&#10;$ echo $? -&gt; 1&#10;&#10;### 5. ignored cache write does not read as activity&#10;$ echo $? -&gt; 0&#10;&#10;### 6. not a git work tree (usage error, exit 2)&#10;error: not a git work tree: .../plain&#10;$ echo $? -&gt; 2&#10;&#10;### 7. missing path (usage error, exit 2)&#10;error: path does not exist: .../no-such-dir&#10;$ echo $? -&gt; 2&#10;&#10;### 8. git op marker seen from a subdirectory target&#10;git operation in progress (index.lock)&#10;$ echo $? -&gt; 1&#10;&#10;### 9. recent write under a subdirectory target&#10;recent write: sub/a.txt&#10;$ echo $? -&gt; 1&#10;&#10;=== second mate usage shape: standing down is a result ===&#10;[quiet-tree] quiet -&gt; verifying the corporate record now&#10;[tree-being-edited] paused: someone is working here (uncommitted changes)</code>

```text
======================================================================
fm-workspace-busy.sh - acceptance walkthrough (exit 0 quiet / 1 busy / 2 usage)
======================================================================

### 1. clean quiet tree (nothing printed, exit 0)
$ fm-workspace-busy.sh /var/folders/0d/jhgr3px15y17yxr3ykhr9bdc0000gn/T//wb-accept.rGiYg1/clean --window 60
$ echo $?  ->  0

### 2. uncommitted changes (another agent mid-edit)
$ fm-workspace-busy.sh /var/folders/0d/jhgr3px15y17yxr3ykhr9bdc0000gn/T//wb-accept.rGiYg1/dirty --window 60
uncommitted changes
$ echo $?  ->  1

### 3. tracked file touched seconds ago, porcelain clean
$ fm-workspace-busy.sh /var/folders/0d/jhgr3px15y17yxr3ykhr9bdc0000gn/T//wb-accept.rGiYg1/touched --window 300
recent write: RECORD.md
$ echo $?  ->  1

(a real 'git merge other' left the repo conflicted: MERGE_HEAD present AND the tree dirty)
    porcelain: UU RECORD.md
### 4. git operation in flight (ordering: git-op wins over dirty)
$ fm-workspace-busy.sh /var/folders/0d/jhgr3px15y17yxr3ykhr9bdc0000gn/T//wb-accept.rGiYg1/merging --window 60
git operation in progress (MERGE_HEAD)
$ echo $?  ->  1

(just wrote /var/folders/0d/jhgr3px15y17yxr3ykhr9bdc0000gn/T//wb-accept.rGiYg1/ignored/cache/blob.bin, matched by .gitignore)
### 5. ignored cache write does not read as activity
$ fm-workspace-busy.sh /var/folders/0d/jhgr3px15y17yxr3ykhr9bdc0000gn/T//wb-accept.rGiYg1/ignored --window 300
$ echo $?  ->  0

### 6. not a git work tree (usage error, exit 2)
$ fm-workspace-busy.sh /var/folders/0d/jhgr3px15y17yxr3ykhr9bdc0000gn/T//wb-accept.rGiYg1/plain
error: not a git work tree: /private/var/folders/0d/jhgr3px15y17yxr3ykhr9bdc0000gn/T/wb-accept.rGiYg1/plain
$ echo $?  ->  2

### 7. missing path (usage error, exit 2)
$ fm-workspace-busy.sh /var/folders/0d/jhgr3px15y17yxr3ykhr9bdc0000gn/T//wb-accept.rGiYg1/no-such-dir
error: path does not exist: /var/folders/0d/jhgr3px15y17yxr3ykhr9bdc0000gn/T//wb-accept.rGiYg1/no-such-dir
$ echo $?  ->  2

(index.lock present at repo root; target is the SUBDIRECTORY /var/folders/0d/jhgr3px15y17yxr3ykhr9bdc0000gn/T//wb-accept.rGiYg1/subdir-op/sub)
### 8. git op marker seen from a subdirectory target
$ fm-workspace-busy.sh /var/folders/0d/jhgr3px15y17yxr3ykhr9bdc0000gn/T//wb-accept.rGiYg1/subdir-op/sub --window 60
git operation in progress (index.lock)
$ echo $?  ->  1

### 9. recent write under a subdirectory target
$ fm-workspace-busy.sh /var/folders/0d/jhgr3px15y17yxr3ykhr9bdc0000gn/T//wb-accept.rGiYg1/subdir-write/sub --window 300
recent write: sub/a.txt
$ echo $?  ->  1

======================================================================
second mate usage shape (docs/workspace-busy.md): standing down is a result
======================================================================
[quiet-tree] quiet -> verifying the corporate record now
[tree-being-edited] paused: someone is working here (uncommitted changes)
```
</details>
<details>
<summary>Evidence: --process actually detects a live foreign cwd (the suite only asserted it does not crash)</summary>

<code>### baseline: aged clean tree, --process, no foreign cwd inside&#10;(no output)&#10;exit: 0&#10;&#10;### now start a foreign process whose cwd is inside the tree&#10;started pid 20621 with cwd .../repo/work&#10;live process cwd under tree (pid 20621)&#10;exit: 1&#10;&#10;### same tree WITHOUT --process (default): the process is not consulted&#10;(no output, quiet)&#10;exit: 0&#10;&#10;### after killing pid 20621, --process is quiet again&#10;(no output, quiet)&#10;exit: 0</code>

```text
### baseline: aged clean tree, --process, no foreign cwd inside
(no output)
exit: 0

### now start a foreign process whose cwd is inside the tree
started pid 20621 with cwd /var/folders/0d/jhgr3px15y17yxr3ykhr9bdc0000gn/T//wb-proc.u55zkR/repo/work
live process cwd under tree (pid 20621)
exit: 1

### same tree WITHOUT --process (default): the process is not consulted
(no output, quiet)
exit: 0

### after killing pid 20621, --process is quiet again
(no output, quiet)
exit: 0
```
</details>
<details>
<summary>Evidence: .git never touched: read-only .git test plus 8-way concurrency</summary>

<code>== subject: fm-workspace-busy.sh on a stale stat cache, 3 consecutive runs ==&#10;RESULT: .git/index byte-identical and same mtime. The check wrote nothing.&#10;&#10;== concurrency: 8 checks at once on one repo must not false-busy each other ==&#10;RESULT: all 8 concurrent checks reported quiet; no self-inflicted index.lock busy.&#10;&#10;git version: git version 2.42.0&#10;--- staleness shape: past --- subject fm-workspace-busy.sh (exit 0) : no write&#10;--- staleness shape: now --- subject fm-workspace-busy.sh (exit 1) : no write&#10;--- staleness shape: rewrite --- subject fm-workspace-busy.sh (exit 1) : no write&#10;&#10;Decisive test: make every .git directory non-writable, so creating index.lock&#10;or rewriting .git/index would fail. Then ask for both verdicts.&#10;dr-xr-xr-x@ 10 gustavocarriconde staff 320 .../fresh/.git&#10;fresh-mtime tree -&gt; exit 1 output=&#39;recent write: src/f0.txt&#39;&#10;aged-mtime tree -&gt; exit 0 output=&#39;&#39;&#10;&#10;Both verdicts are correct on a read-only .git, so the check never needed&#10;index.lock or an index rewrite.</code>

```text
== control: a plain 'git status' on a stale stat cache DOES rewrite .git/index ==
   before 8140cf06a90257c16202fdfad6e17103ed560735e385ab941d5b08744b1a9d26|1786121717
   after  8140cf06a90257c16202fdfad6e17103ed560735e385ab941d5b08744b1a9d26|1786121717
   -> unchanged (fixture is not actually stale; this control is inconclusive)

== subject: fm-workspace-busy.sh on the same kind of stale tree, 3 consecutive runs ==
   before e8aa1aa6f6d320d396f874dc98489fdcdbffa40bc9a85489d2a277a3c9e20faf|1786121717
   run 1 -> exit 0    index now e8aa1aa6f6d320d396f874dc98489fdcdbffa40bc9a85489d2a277a3c9e20faf|1786121717
   run 2 -> exit 0    index now e8aa1aa6f6d320d396f874dc98489fdcdbffa40bc9a85489d2a277a3c9e20faf|1786121717
   run 3 -> exit 0    index now e8aa1aa6f6d320d396f874dc98489fdcdbffa40bc9a85489d2a277a3c9e20faf|1786121717
   RESULT: .git/index byte-identical and same mtime. The check wrote nothing.

== concurrency: 8 checks at once on one repo must not false-busy each other ==
   RESULT: all 8 concurrent checks reported quiet; no self-inflicted index.lock busy.

git version: git version 2.42.0

--- staleness shape: past ---
  control  plain `git status`            : no write
  subject  fm-workspace-busy.sh (exit 0) : no write
--- staleness shape: now ---
  control  plain `git status`            : no write
  subject  fm-workspace-busy.sh (exit 1) : no write
--- staleness shape: rewrite ---
  control  plain `git status`            : no write
  subject  fm-workspace-busy.sh (exit 1) : no write

Decisive test: make every .git directory non-writable, so creating index.lock
or rewriting .git/index would fail. Then ask for both verdicts.

  dr-xr-xr-x@ 10 gustavocarriconde  staff  320 Aug  7 13:55 /var/folders/0d/jhgr3px15y17yxr3ykhr9bdc0000gn/T//wb-idx4.5voaaI/fresh/.git

  fresh-mtime tree  -> exit 1 output='recent write: src/f0.txt'
  aged-mtime tree   -> exit 0 output=''

Both verdicts are correct (busy with a named path / quiet with no output) on a
read-only .git, so the check never needed index.lock or an index rewrite.
```
</details>
<details>
<summary>Evidence: Measured cost vs the table published in docs/workspace-busy.md</summary>

<code>re-measure, 11 runs each, machine shared with other agents (Darwin arm64, python3 present)&#10;&#10;small quiet (1 tracked file) min 0.12 median 0.13 max 0.24 (n=11)&#10;5000 tracked, one dirty file (busy) min 0.19 median 0.23 max 0.53 (n=11)&#10;5000 tracked, quiet (worst case: stats every path) min 0.22 median 0.25 max 0.33 (n=11)&#10;&#10;docs/workspace-busy.md publishes 0.17 / 0.24 / 0.43 for the same rows and frames them as&#10;upper bounds. Measured medians sit at or under every published figure.&#10;&#10;5000 tracked + ignored cache/ with 2000 hot files -&gt; quiet in 0.28 s: ignored bulk written&#10;seconds earlier neither costs time nor reads as activity.</code>

```text
NOTE: the first table below was taken while other agents were busy on this Mac and
contains two obvious outliers (0.67 s for the 1-file tree, 0.73 s for the 5000-file
dirty tree). The re-measurement at the bottom (11 runs, min/median/max) is the one to
read; every figure there sits at or under the numbers published in docs/workspace-busy.md,
which the doc already frames as upper bounds.

measurement host: Darwin 25.5.0 arm64, python3: /opt/homebrew/bin/python3
each figure = median real seconds of 7 runs (/usr/bin/time -p), warm cache

TARGET                                                         SIGNAL                           real (s)
------                                                         ------                           --------
Small quiet fixture (1 tracked file, aged mtime)               quiet                            0.67
Same small tree with a dirty file                              busy: uncommitted changes        0.18
Same small tree, fresh touch on a tracked file                 busy: recent write               0.14
This firstmate worktree (372 tracked files)                                                     0.16
Synthetic: 5000 tracked files, quiet, aged mtimes              quiet                            0.26
Synthetic: 5000 tracked + ignored cache/ with 2000 hot files   quiet (ignored)                  0.28
Synthetic: 5000 tracked files with one dirty file              busy: uncommitted changes        0.73

sanity: the ignored 2000 hot files were written just now and the tree still reads quiet:
  exit 0 output=''
re-measure of the two noisy rows, 11 runs each, machine shared with other agents
small quiet (1 tracked file)                         min 0.12  median 0.13  max 0.24  (n=11)
5000 tracked, one dirty file (busy)                  min 0.19  median 0.23  max 0.53  (n=11)
5000 tracked, quiet (worst case: stats every path)   min 0.22  median 0.25  max 0.33  (n=11)
```
</details>
<details>
<summary>Evidence: The documented second-mate caller snippet, all four branches</summary>

<code>branch 1 - quiet tree&#10;quiet: safe to read and verify the record&#10;(snippet exit: 0)&#10;branch 2 - another agent editing&#10;paused: someone is working here (uncommitted changes)&#10;(snippet exit: 0)&#10;branch 3 - usage error (not a git work tree)&#10;blocked: workspace-busy check failed: error: not a git work tree: .../plain&#10;(snippet exit: 1)&#10;branch 4 - a check itself could not run (git status broken)&#10;blocked: workspace-busy check could not answer: could not read git state (status failed)&#10;(snippet exit: 1)</code>

```text
branch 1 - quiet tree
  quiet: safe to read and verify the record
  (snippet exit: 0)
branch 2 - another agent editing
  paused: someone is working here (uncommitted changes)
  (snippet exit: 0)
branch 3 - usage error (not a git work tree)
  blocked: workspace-busy check failed: error: not a git work tree: /private/var/folders/0d/jhgr3px15y17yxr3ykhr9bdc0000gn/T/wb-doc.mrYYLz/plain
  (snippet exit: 1)
branch 4 - a check itself could not run (git status broken)
  blocked: workspace-busy check could not answer: could not read git state (status failed)
  (snippet exit: 1)
```
</details>
<details>
<summary>Evidence: Tree content unchanged across every verdict shape, no marker files left behind</summary>

```text
NOTE: this file proves the TREE CONTENT is unchanged; it deliberately settles git's
index first so the driver's own git commands cannot be mistaken for the script's writes.
The stronger claim - that .git itself is never touched and no index.lock is taken - is
proved separately in git-index-untouched.txt.

== A. QUIET shapes only (no other git command in between) ==
fingerprint: 18 files, .git included (sha256 + size + mtime)
  --window 60              -> exit 0 
  --window 300             -> exit 0 
  --window 60 --process    -> exit 0 
  --window 0               -> exit 0 
  --window 60              -> exit 0 
  OK: identical, nothing written

== B. BUSY shapes (dirty tree + fake index.lock), repeated ==
  run 1 -> exit 1 (uncommitted changes)
  run 2 -> exit 1 (uncommitted changes)
  run 3 -> exit 1 (uncommitted changes)
  OK: identical, nothing written

== C. no marker/lock/state file of this tool's own naming anywhere under the tree ==
  OK: none
```
</details>
<details>
<summary>Evidence: Targeted test log for the three suites the diff touches, plus selection routing</summary>

```text
=== bash tests/fm-workspace-busy.test.sh (after adding 2 assertions) ===
ok - missing path exits 2
ok - non-repository exits 2
ok - missing <dir> exits 2
ok - clean quiet tree prints nothing and exits 0
ok - uncommitted tracked edit reports busy
ok - untracked non-ignored file reports busy
ok - recent mtime on a clean tree reports busy
ok - aged mtime outside the window is quiet
ok - recent write under a subdirectory target reports busy
ok - aged subdirectory target is quiet
ok - a failing git status reports busy, not quiet
ok - a failing mtime scan reports busy, not quiet
ok - ignored path writes do not trigger busy
ok - index.lock reports git operation in progress
ok - a repo-root git marker is seen from a subdirectory target
ok - MERGE_HEAD reports git operation in progress
ok - REBASE_HEAD reports git operation in progress
ok - script writes nothing under the target tree
ok - the check leaves .git untouched and concurrent runs do not false-busy
ok - --process is accepted and returns quiet or a concrete busy reason
ok - -- consumes the following argument as <dir>
ok - the no-python3 shell scan agrees with the python scan
ok - --help prints usage and exits 0
# fm-workspace-busy.test.sh: all assertions passed

=== bash tests/fm-test-run.test.sh (tail) ===
ok - portable serial shard lanes refuse mismatched, out-of-range, and countless names
ok - --jobs refuses non-proven / stateful selections
ok - jobs scheduler runs proven scripts; failure propagates; non-proven refused
ok - aggregate-json merges lane timing artifacts

=== bash tests/fm-documentation-audiences.test.sh ===
ok - documentation inventory classifies every maintained prose surface exactly once
ok - classification, setup routing, and maintained-prose scope fail safely
ok - required documentation owner pointers cannot silently disappear
ok - local links resolve while dates, versions, commands, and incident prose remain semantically reviewed

=== routing: fm-test-run.sh --list --changed --base 70aeba8 | grep workspace ===
tests/fm-workspace-busy.test.sh
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 2 infos</summary>

- 🚨 `bin/fm-workspace-busy.sh:239` - The recent-mtime scan runs `git -C &#34;$DIR&#34; ls-files -z --cached --others --exclude-standard` but joins each result against `$ROOT` (the work-tree top level). `git ls-files` prints paths relative to its own cwd and only lists files under it, so whenever `&lt;dir&gt;` is a subdirectory of the repo every joined path is wrong. Verified on this repo: from `bin/`, `git ls-files` prints `backends/cmux.sh`, so the script stats `&lt;root&gt;/backends/cmux.sh`, which does not exist. Both the python3 path (line 239) and the shell fallback (line 274, `full=&#34;$ROOT/$rel&#34;`) have it. Every stat raises OSError and is skipped, so `recent_rel` stays empty and the script reports quiet with exit 0 even though a tracked file under `&lt;dir&gt;` was written seconds ago - the exact acceptance case &#34;tree touched seconds ago&#34;, failing in the dangerous direction (false quiet lets the reader trust a mid-write tree). Checks 1 and 2 are already repo-wide, so the consistent fix is to run `ls-files` from `$ROOT` (`git -C &#34;$ROOT&#34; ls-files ...`) in both paths. No test covers a subdirectory target, which is why this survived; tests/fm-workspace-busy.test.sh only ever passes a repo root.
- ⚠️ `bin/fm-workspace-busy.sh:204` - Two internal failures are indistinguishable from a clean answer and fall through to `exit 0`. Line 204: `git -C &#34;$DIR&#34; status --porcelain --untracked-files=normal 2&gt;/dev/null | head -1` produces empty output both when the tree is clean and when git failed, so a git error reads as &#34;no uncommitted changes&#34;. Line 261: `recent_rel=$(...) || recent_rel=` turns a failed `git ls-files` or a python3 crash into &#34;no recent write&#34;. A reachable case is exactly the scenario this tool exists for: the other agent is mid-`git add`, git exits non-zero against a transiently locked/unreadable index, and this check answers quiet - the verifier then reads the half-written tree. This also diverges from the sibling convention the script cites: bin/fm-lock-lib.sh:14 states any uncertainty (missing lsof, lsof error, unreadable mtime) yields a non-answer, and fm-teardown.sh&#39;s `pids_with_cwd_under` returns failure because &#34;failure means the scan could not establish a safe result&#34;, yet this script&#39;s header claims the &#34;same bounded system-wide scan fm-teardown uses&#34;. Cheapest fix inside the existing two-outcome contract: when git or the scan cannot answer, report busy with a concrete reason such as &#34;could not read git state&#34; rather than reporting quiet. (The `--process` lsof skip is explicitly authorized in the header and documented, so it is not part of this finding. Do not add `-o pipefail` as a fix: it would convert the deliberate `| head -1` and `| python3` SIGPIPE exits into more silent quiets.)
- ℹ️ `bin/fm-workspace-busy.sh:93` - The `--)` case does `shift; break`, but the post-loop guard at line 115 rejects anything left: `if [ $# -gt 0 ]; then echo &#34;error: unexpected argument: $1&#34;; exit 2`. So `fm-workspace-busy.sh -- /path/to/tree` exits 2 with &#34;unexpected argument: /path/to/tree&#34;, and because the `-*` case also errors, a directory whose name begins with `-` cannot be passed at all. Either consume the post-`--` operand as `DIR` before the trailing-argument guard, or drop the `--` case so the flag does not advertise support it does not have.
- ℹ️ `bin/fm-workspace-busy.sh:255` - The python scan calls `os.stat(path)` and then `os.path.isfile(path)`, which issues a second stat syscall for every path on the one hot loop the performance section is built around (5_000-file trees per docs/workspace-busy.md). Reuse the stat already taken: `import stat` and test `stat.S_ISREG(st.st_mode)` instead of `os.path.isfile(path)`. Same semantics (both follow symlinks), half the syscalls.
- ℹ️ `bin/fm-workspace-busy.sh:204` - The header states &#34;This script never writes anywhere: no lock file, no marker, no state, no temp file&#34;, which is broader than what is verified. git documents that `git status` refreshes the index as a side effect and takes an optional lock for it (`git(1)`: GIT_OPTIONAL_LOCKS &#34;will prevent git status from refreshing the index as a side effect ... useful for processes running in the background which do not want to cause lock contention with other operations on the repository&#34;). I probed five configurations on git 2.42 (plain vs --porcelain, with and without core.untrackedCache, hash and mtime of .git/index, and a chmod a-w .git repo) and could not make it rewrite the index, so this is a hardening note, not a demonstrated violation - and note tests/fm-workspace-busy.test.sh:59 prunes `.git` from the fingerprint, so it would not catch one either. Running the status call as `git -C &#34;$DIR&#34; --no-optional-locks status --porcelain ...` (or with GIT_OPTIONAL_LOCKS=0) costs nothing and makes the absolute claim airtight for a probe intended to run before every read on a repo another agent is writing.

🔧 Fix: fix workspace-busy subdir scan and unreadable-git-state quiet
2 infos still open:
- ℹ️ `bin/fm-workspace-busy.sh:215` - The header now states an invariant at lines 36-38: &#34;When a check cannot read git state (git exits non-zero, the mtime scan fails), the answer is busy with its own reason, never quiet. A quiet result must mean &#39;the checks ran and saw nothing&#39;, not &#39;a check could not run&#39;.&#34; The git-op marker loop is the one git call still outside it: `path=$(git -C &#34;$DIR&#34; rev-parse --git-path &#34;$marker&#34; 2&gt;/dev/null) || continue` skips the marker silently on a git failure. No reachable false quiet follows, because `git rev-parse --git-path` only concatenates gitdir and name and therefore fails only on a global git failure, which the `git status` call at line 227 hits one check later and converts to `busy &#34;could not read git state (status failed)&#34;`. Noting it so the stated invariant and the code stay in agreement if the check order ever changes; no fix needed as the code stands.
- ℹ️ `tests/fm-workspace-busy.test.sh:395` - `test_shell_fallback_scan` guards on `if PATH=&#34;$shim&#34; bash -c &#39;command -v git &gt;/dev/null &amp;&amp; git --version &gt;/dev/null&#39;` and otherwise falls through to `pass &#34;skipped: git does not run under a minimal PATH on this machine&#34;`. The guard is honest, but on any machine where git cannot resolve its exec-path through a symlink in a temp dir, the whole `else` branch of the scan goes unexercised - the `{ }` group pipeline, its `PIPESTATUS` capture, and the deliberate ordering that lets a found path beat the SIGPIPE the early `break` hands `git ls-files` - while the suite still prints &#34;all assertions passed&#34;. That is the newest and most intricate code in the change sitting behind a self-skip that reads as coverage in the pipeline&#39;s test step. Worth knowing when interpreting a green run; not worth adding a testability flag to the script for.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash tests/fm-workspace-busy.test.sh` - 23 assertions, all pass, including the two I added</code>
- <code>`bash tests/fm-test-run.test.sh` - covers the family-table edits this change made to bin/fm-test-run.sh</code>
- <code>`bash tests/fm-documentation-audiences.test.sh` - covers the docs/documentation-audiences.json and docs/scripts.md edits</code>
- <code>`bin/fm-test-run.sh --list --changed --base 70aeba8 | grep workspace` - confirms the new script routes to the new test file and to the pure-contract-unit family</code>
- <code>Manual acceptance walkthrough over nine disposable git fixtures: clean quiet, uncommitted changes, tracked file touched seconds ago with clean porcelain, a REAL conflicted `git merge` (proves git-op ordering wins over dirty), ignored cache write staying quiet, non-repository, missing path, index.lock seen from a subdirectory target, recent write seen from a subdirectory target</code>
- <code>Manual `--process` demonstration from a cwd outside the fixture: baseline quiet, then a backgrounded process with cwd inside the tree reported `live process cwd under tree (pid N)`, quiet again by default without the flag, quiet again after the kill</code>
- `Writes-nothing proof: sha256 + size + mtime of every file INCLUDING .git, snapshotted across quiet, --process, --window 0 and busy shapes, byte-identical; plus no marker/lock file of this tool's naming anywhere under the tree`
- <code>`.git` untouched proof: `chmod a-w` on every .git directory so index.lock could not be created, then both verdicts still correct; plus 8 concurrent checks on one repo all quiet (no self-inflicted `git operation in progress`)</code>
- <code>Cost re-measurement with `/usr/bin/time -p`, 7 and 11 run medians, on synthetic 5000-tracked-file trees with and without 2000 ignored hot files, compared against the table in docs/workspace-busy.md</code>
- <code>The caller snippet from docs/workspace-busy.md run verbatim across all four branches: quiet, busy, exit 2 usage error, and exit 1 `could not read git state` via a git shim that fails only `status`</code>
- <code>Mutation check: a copy of the script with `abs_git_path` joining against `$ROOT` instead of `$DIR` misses a repo-root index.lock from a subdirectory and reports quiet, proving the new regression test bites</code>
- <code>`grep -rniE &#39;fail[- _]?(closed|open)&#39;` over bin/fm-workspace-busy.sh, docs/workspace-busy.md and the test file - forbidden vocabulary absent</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Lint** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ linter found issues (exit code 1)

🔧 Fix: remove unused rc local in workspace-busy test
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
