### PR TITLE
docs(cmux): BRIDGE war-room recipe, live cleanup, and CCA builder receipt

### DIFF
--- a/bin/fm-cmux-war-room.sh
+++ b/bin/fm-cmux-war-room.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+# fm-cmux-war-room.sh - thin operator helpers for a cmux war-room session.
+#
+# These are manual convenience wrappers around the cmux CLI for an operator
+# running a multi-pane war-room (docs/cmux-war-room.md). They are NOT part of
+# the fm-spawn.sh crewmate lifecycle and do not change the 1:1 task-workspace
+# backend contract owned by docs/cmux-backend.md and bin/backends/cmux.sh.
+#
+# Usage:
+#   fm-cmux-war-room.sh banner --surface <ref> --label <text> [--color <name-or-hex>]
+#   fm-cmux-war-room.sh color-for-harness <harness>
+#   fm-cmux-war-room.sh teardown-surfaces --workspace <ref> [--keep <surface-ref>] [--close-workspace]
+#   fm-cmux-war-room.sh --help
+#
+# banner            renames the pane tab and writes a colored ANSI banner line
+#                    into the surface so a war-room grid stays scannable.
+# color-for-harness  prints the workspace color configured for one harness in
+#                    local config/harness-visual.json, or a fallback default
+#                    when the file or the harness key is absent.
+# teardown-surfaces  closes every surface in one named workspace except an
+#                    optionally kept one, scoped to exactly that workspace's
+#                    own list-panes response; never a broad close. Pass
+#                    --close-workspace to also close the now-single-surface
+#                    workspace afterward (cmux refuses to close a last surface
+#                    directly - see docs/cmux-backend.md "Current operation
+#                    and safety").
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
+CONFIG="${FM_CONFIG_OVERRIDE:-$FM_HOME/config}"
+FM_CMUX_WAR_ROOM_BUNDLE_BIN="${FM_CMUX_WAR_ROOM_BUNDLE_BIN:-/Applications/cmux.app/Contents/Resources/bin/cmux}"
+
+fm_cmux_war_room_usage() {
+  sed -n '2,26p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+}
+
+fm_cmux_war_room_bin() {
+  if command -v cmux >/dev/null 2>&1; then
+    printf '%s\n' "cmux"
+    return 0
+  fi
+  if [ -x "$FM_CMUX_WAR_ROOM_BUNDLE_BIN" ]; then
+    printf '%s\n' "$FM_CMUX_WAR_ROOM_BUNDLE_BIN"
+    return 0
+  fi
+  echo "fm-cmux-war-room: cmux CLI not found on PATH or at $FM_CMUX_WAR_ROOM_BUNDLE_BIN" >&2
+  return 1
+}
+
+fm_cmux_war_room_require_jq() {
+  command -v jq >/dev/null 2>&1 || {
+    echo "fm-cmux-war-room: jq is required" >&2
+    return 1
+  }
+}
+
+fm_cmux_war_room_banner() {
+  local surface="" label="" color="36" cmux_bin
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --surface) surface=${2:-}; shift 2 ;;
+      --label) label=${2:-}; shift 2 ;;
+      --color) color=${2:-}; shift 2 ;;
+      *) echo "fm-cmux-war-room banner: unknown argument: $1" >&2; return 1 ;;
+    esac
+  done
+  [ -n "$surface" ] || { echo "fm-cmux-war-room banner: --surface is required" >&2; return 1; }
+  cmux_bin=$(fm_cmux_war_room_bin) || return 1
+  if [ -n "$label" ]; then
+    "$cmux_bin" rename-tab --surface "$surface" "$label"
+  fi
+  "$cmux_bin" send --surface "$surface" "printf '\\033[1;97;${color}m\\n  ${label:-WAR ROOM}  \\n\\033[0m\\n'"
+  "$cmux_bin" send-key --surface "$surface" enter
+}
+
+fm_cmux_war_room_color_for_harness() {
+  local harness="${1:-}" file="$CONFIG/harness-visual.json" color=""
+  [ -n "$harness" ] || { echo "fm-cmux-war-room color-for-harness: a harness name is required" >&2; return 1; }
+  if [ -f "$file" ]; then
+    fm_cmux_war_room_require_jq || return 1
+    color=$(jq -r --arg h "$harness" '.workspace_colors[$h] // empty' "$file")
+  fi
+  if [ -z "$color" ]; then
+    echo "fm-cmux-war-room: no color configured for '$harness' in $file, using default Grey" >&2
+    color="Grey"
+  fi
+  printf '%s\n' "$color"
+}
+
+fm_cmux_war_room_teardown_surfaces() {
+  local workspace="" keep="" close_workspace=0 cmux_bin surface
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --workspace) workspace=${2:-}; shift 2 ;;
+      --keep) keep=${2:-}; shift 2 ;;
+      --close-workspace) close_workspace=1; shift ;;
+      *) echo "fm-cmux-war-room teardown-surfaces: unknown argument: $1" >&2; return 1 ;;
+    esac
+  done
+  [ -n "$workspace" ] || { echo "fm-cmux-war-room teardown-surfaces: --workspace is required" >&2; return 1; }
+  cmux_bin=$(fm_cmux_war_room_bin) || return 1
+  fm_cmux_war_room_require_jq || return 1
+
+  local surfaces
+  surfaces=$("$cmux_bin" list-panes --workspace "$workspace" --json --id-format both \
+    | jq -r '[.panes[].surface_ids[]?, .panes[].surface_refs[]?] | unique | .[]')
+
+  while IFS= read -r surface; do
+    [ -n "$surface" ] || continue
+    [ "$surface" = "$keep" ] && continue
+    "$cmux_bin" close-surface --surface "$surface"
+  done <<EOF
+$surfaces
+EOF
+
+  if [ "$close_workspace" -eq 1 ]; then
+    "$cmux_bin" close-workspace --workspace "$workspace"
+  fi
+}
+
+main() {
+  local cmd="${1:-}"
+  [ $# -gt 0 ] && shift
+  case "$cmd" in
+    banner) fm_cmux_war_room_banner "$@" ;;
+    color-for-harness) fm_cmux_war_room_color_for_harness "$@" ;;
+    teardown-surfaces) fm_cmux_war_room_teardown_surfaces "$@" ;;
+    -h|--help|"") fm_cmux_war_room_usage ;;
+    *) echo "fm-cmux-war-room: unknown subcommand: $cmd" >&2; fm_cmux_war_room_usage >&2; return 1 ;;
+  esac
+}
+
+main "$@"

--- a/docs/cmux-backend.md
+++ b/docs/cmux-backend.md
@@ -129,3 +129,7 @@ tests/fm-backend-cmux-smoke.test.sh
 ```
 
 [`verification/runtime-backends.md`](verification/runtime-backends.md#cmux) records the active source and live evidence, including socket modes and last-in-window cleanup.
+
+## Operator war room (manual)
+
+For a multi-pane side-by-side watch layout that does **not** change the 1:1 task spawn contract, see [`cmux-war-room.md`](cmux-war-room.md) and `bin/fm-cmux-war-room.sh`.

--- a/docs/cmux-war-room.md
+++ b/docs/cmux-war-room.md
@@ -1,0 +1,123 @@
+# cmux war room
+
+A war room is one cmux workspace laid out as a multi-pane grid so an operator can see a lead and its workers side by side, at a glance, instead of hunting through sidebar tabs.
+This page gives concrete command recipes for building, labeling, observing, and safely tearing one down.
+It is an operator recipe sheet, not a backend change: [`cmux-backend.md`](cmux-backend.md) remains the single owner of firstmate's cmux task-spawn contract.
+
+## The 1:1 invariant is unchanged
+
+firstmate's supervised crewmate spawn keeps one cmux workspace with one surface per task, exactly as documented in [`cmux-backend.md`](cmux-backend.md#task-shape-and-metadata).
+Nothing on this page changes that default, and none of it runs inside `bin/fm-spawn.sh` or the recovery path.
+A war room is a manual, operator-driven session for watching several already-running panes at once, built with the same `cmux` CLI firstmate already depends on.
+`bin/fm-cmux-war-room.sh` is a thin standalone helper for that manual session; it is never invoked by spawn or recovery.
+
+## Prerequisites
+
+Same as [`cmux-backend.md`](cmux-backend.md#setup): cmux 0.64 or newer, `jq`, and a socket control mode of `automation` or `password`.
+`bin/fm-cmux-war-room.sh` resolves the `cmux` binary the same way the adapter does: prefer `PATH`, otherwise fall back to `/Applications/cmux.app/Contents/Resources/bin/cmux`.
+
+## Build the grid
+
+Capture every ref returned at creation time and never guess a short `surface:N` handle later; short refs renumber as panes open and close.
+
+Stepwise splits:
+
+```sh
+WS=$(cmux new-workspace --name war-room --cwd "$PWD" --focus false --json | jq -r '.workspace_id // .ref')
+A=$(cmux list-panes --workspace "$WS" --json --id-format both | jq -r '.panes[0].surface_ids[0] // .panes[0].surface_refs[0]')
+
+B=$(cmux new-split right --workspace "$WS" --surface "$A" --json | jq -r '.surface_id // .ref')
+C=$(cmux new-split down  --workspace "$WS" --surface "$A" --json | jq -r '.surface_id // .ref')
+D=$(cmux new-split down  --workspace "$WS" --surface "$B" --json | jq -r '.surface_id // .ref')
+```
+
+Declarative equivalent, one call instead of four:
+
+```sh
+cmux new-workspace --name war-room --cwd "$PWD" --focus false --layout '{
+  "direction": "horizontal",
+  "split": 0.5,
+  "children": [
+    {"pane": {"surfaces": [{"type": "terminal", "name": "lead"}]}},
+    {"direction": "vertical", "split": 0.5, "children": [
+      {"pane": {"surfaces": [{"type": "terminal", "name": "build"}]}},
+      {"pane": {"surfaces": [{"type": "terminal", "name": "review"}]}}
+    ]}
+  ]
+}'
+```
+
+Always scope splits with `--workspace` when more than one workspace exists, so a split never lands in the wrong window.
+
+## Label and color the fleet
+
+Workspace color is first-class on the CLI; individual surfaces are not, so pane identity comes from the tab name and an in-pane banner instead.
+
+```sh
+cmux workspace-action --action set-color --workspace "$WS" --color Purple
+cmux workspace-action --action set-description --workspace "$WS" --description "ORCH - mission-slug"
+cmux rename-tab --workspace "$WS" --surface "$A" "lead"
+```
+
+`bin/fm-cmux-war-room.sh banner` wraps the tab-rename-plus-in-pane-banner pattern into one call:
+
+```sh
+bin/fm-cmux-war-room.sh banner --surface "$B" --label "A01 BUILD" --color 44
+```
+
+### Harness color usage
+
+A local, gitignored `config/harness-visual.json` can hold a `workspace_colors` map keyed by harness name (`claude`, `codex`, `kimi`, and so on).
+This file is a captain-private convention, not something firstmate ships or reads for spawn; the war-room helper is the one place it is consulted.
+
+```sh
+bin/fm-cmux-war-room.sh color-for-harness claude
+```
+
+Prints the configured color for that harness, or `Grey` with a stderr note when the file or the key is absent, so a missing config never blocks the war room.
+That output is a cmux workspace color name (or hex), the same value `workspace-action --action set-color` accepts, not the raw ANSI SGR number `banner --color` writes into the pane; the two commands color two different surfaces (sidebar workspace versus in-pane text) and do not share a value.
+
+## Observe
+
+```sh
+cmux tree --all --json
+cmux list-panes --workspace "$WS" --json --id-format both
+cmux read-screen --surface "$A" --scrollback --lines 80
+```
+
+`read-screen` returns an internal error against a genuinely fresh surface until something has been written to it; re-tree with `list-panes` for structural readiness instead of retrying a content read.
+
+## Capture UUIDs, never cache short refs
+
+```sh
+cmux identify --json
+cmux list-workspaces --json --id-format both
+```
+
+Short refs like `surface:3` renumber as the tree changes.
+Re-run `list-panes` or `tree` before any close instead of reusing a ref captured earlier in the session.
+
+## Tear down without stale shells
+
+Close owned surfaces first, then the workspace; never broad-close.
+`bin/fm-cmux-war-room.sh teardown-surfaces` re-reads the named workspace's own `list-panes` response so it only ever closes surfaces that workspace actually owns:
+
+```sh
+bin/fm-cmux-war-room.sh teardown-surfaces --workspace "$WS" --keep "$A" --close-workspace
+```
+
+`--keep` leaves one surface open; cmux refuses to close a workspace's last surface directly, so leaving one (or omitting `--close-workspace` and closing the workspace yourself afterward) avoids that refusal.
+Without `--keep`, every surface in the workspace closes, matching the [`cmux-backend.md`](cmux-backend.md#current-operation-and-safety) "last surface" and "only workspace in window" behavior that `close-workspace` already handles.
+
+Manual equivalent, for reference:
+
+```sh
+cmux list-panes --workspace "$WS" --json --id-format both \
+  | jq -r '[.panes[].surface_ids[]?, .panes[].surface_refs[]?] | unique | .[]' \
+  | while read -r S; do cmux close-surface --surface "$S"; done
+cmux close-workspace --workspace "$WS"
+```
+
+## Regression entry points
+
+`bin/fm-cmux-war-room.sh` has no automated test in this pass; it is exercised manually against a live cmux app the same way [`cmux-backend.md`](cmux-backend.md#regression-entry-points) documents for the backend adapter.

--- a/docs/documentation-audiences.json
+++ b/docs/documentation-audiences.json
@@ -225,6 +225,10 @@
       "audience": "operator-current"
     },
     {
+      "path": "docs/cmux-war-room.md",
+      "audience": "operator-current"
+    },
+    {
       "path": "docs/codex-app-backend.md",
       "audience": "operator-current"
     },


### PR DESCRIPTION
## Summary

- CCA competitor A (builder) task: make BRIDGE (`workspace:1`) look like the Disler learning-cmux video - a live labeled multi-pane war room, no zombie shells.
- Recreates and commits `docs/cmux-war-room.md`, `bin/fm-cmux-war-room.sh`, and a one-paragraph `docs/cmux-backend.md` pointer that already existed uncommitted in the primary checkout, plus the required `docs/documentation-audiences.json` classification entry for the new doc. No spawn/teardown code was touched - the 1:1 task/workspace backend contract is unchanged.
- Executed the live cleanup against the real BRIDGE cmux workspace (see receipt below): inventoried 5 panes / 10 surfaces, confirmed 8 were idle corpse shells from already-finished sessions (read each with `read-screen` before closing, never the default/focused surface), closed exactly those, moved the one live named worker still running (`oz-gauntlet-v02`, currently mid-task) into its own visible BRIDGE pane, and labeled every live surface with `rename-tab` only (no text injection into any live foreground app). BRIDGE is now 3 panes, each live and labeled, color-coded Indigo with a colored sidebar "mission wall" for the sibling live tasks.
- `hooks-mastery` does not currently exist as a live workspace, so nothing was moved for it.
- Flagged, not fixed (out of scope): the primary firstmate surface's grok backend is currently returning a 403 "out of credits" error.

## Receipt (full command log and reasoning)

`data/war-room-cca-builder/receipt.md` is gitignored in this worktree, so its full content is inlined here for review:

<details>
<summary>Click to expand full receipt</summary>

```markdown
# war-room-cca-builder receipt

Role: CCA competitor A - BUILDER.
Objective: make BRIDGE (`workspace:1`) look like the Disler learning-cmux video - live labeled multi-pane war room, no zombie shells.
This file is written inside the disposable task worktree (`data/` is gitignored there too, so it is a local record); the same content is also in the PR body since a gitignored file is not visible in the diff.

## Baseline artifacts

Shared reference material was already staged uncommitted in the primary checkout (`~/Repos/firstmate`), read-only, never touched:

- `docs/cmux-war-room.md` (untracked)
- `bin/fm-cmux-war-room.sh` (untracked)
- `docs/cmux-backend.md` (modified, one pointer paragraph)
- `config/harness-visual.json` (gitignored, local)
- `data/smelt-learning-cmux/report.md`, `data/smelt-disler-audit/report.md` (gitignored, local)

I recreated the three tracked files verbatim in my own isolated worktree (lowercasing "Firstmate" -> "firstmate" in new prose per the CCA brief constraint), added the `docs/documentation-audiences.json` classification entry the new doc needed, ran `bin/fm-lint.sh` (shellcheck 0.11.0 pinned, clean) and `bin/fm-doc-audience-check.sh` (`ok surfaces=66 local_links=218`), and committed that baseline on `fm/war-room-cca-builder` before touching live cmux state.

## Live inventory of BRIDGE (`workspace:1`)

```sh
cmux tree --workspace workspace:1 --json
cmux top --processes --format tsv
CMUX_QUIET=1 cmux list-workspaces --json --id-format both
```

Before state: 5 panes / 10 surfaces in BRIDGE.

| Pane | Surfaces | Verdict |
|---|---|---|
| pane:1 | surface:11 ("pi - firstmate") | live - primary firstmate, running grok CLI (status line showed `(xai) grok-4.5`) |
| pane:10 | surface:21, surface:27 | corpse - idle zsh, leftover `treehouse` prompts and a finished "Smelt Fusion-Harness" session |
| pane:11 | surface:20, surface:28 | corpse - idle zsh, one showing "Worktree returned to pool", one a finished grok session |
| pane:12 | surface:22, surface:29, surface:45 | mixed - surface:22/29 idle zsh (one is the just-finished `smelt-learning-cmux` session itself); surface:45 is a live Kimi Code webview (type=browser, ~7% CPU) |
| pane:13 | surface:23, surface:32 | corpse - idle zsh, one a finished claude session, one a terminated codex session with a stale "clean worktree and return to pool? [Y/n]" prompt |

I read every corpse candidate with `cmux read-screen --surface <ref> --lines 6` before closing anything, to confirm each was sitting at a bare shell prompt with no foreground process, not mid-decision.
Two showed a stale `treehouse` "clean worktree?" prompt suspended on tty input; closing the surface only kills that idle shell, it does not touch the underlying worktree files or answer the prompt, so no unlanded work was discarded.

Notable non-actionable finding, flagged for firstmate/captain rather than acted on: the primary firstmate surface (`surface:11`) is currently showing `Error: OpenAI API error (403): You have run out of credits or need a Grok subscription` from its grok backend. Out of this task's scope; not touched.

Also found live in the same window but in separate workspaces: `oz-gauntlet-v02` (`workspace:21`, claude, mid-task at an interactive AGENTS.md-edit permission prompt, PID 25563) and the two war-room CCA tasks themselves (`workspace:24` = this task, `workspace:25` = nemesis).
`hooks-mastery` was searched for across `cmux tree --all` / `cmux workspace list` and does not currently exist as a live workspace - nothing to move.

## Live mutations (exact commands, in order)

```sh
# 1. Move the one live named worker (oz-gauntlet-v02) into BRIDGE.
cmux move-surface --surface surface:35 --workspace workspace:1 --focus false
# -> landed stacked into pane:1 alongside surface:11 (tabbed, not side-by-side)
cmux split-off --surface surface:35 --workspace workspace:1 right --focus false
# -> now its own visible pane:38, side by side with pane:1

# Verified before/after each step: PID 25563 stayed alive (`cmux top --processes`),
# and `cmux read-screen --surface surface:35` showed the same live session
# continuing its own work (not restarted, not interrupted).

# 2. Label the three live surfaces (rename-tab only - metadata, no keystrokes sent).
cmux rename-tab --workspace workspace:1 --surface surface:11 --title "FIRSTMATE - grok"
cmux rename-tab --workspace workspace:1 --surface surface:35 --title "OZ-GAUNTLET-V02 - claude - live"
cmux rename-tab --workspace workspace:1 --surface surface:45 --title "KIMI - live"

# 3. Scoped close of the 8 confirmed corpse surfaces (explicit --surface every time,
#    never the focused-surface default).
cmux close-surface --surface surface:21 --workspace workspace:1
cmux close-surface --surface surface:27 --workspace workspace:1
cmux close-surface --surface surface:20 --workspace workspace:1
cmux close-surface --surface surface:28 --workspace workspace:1
cmux close-surface --surface surface:22 --workspace workspace:1
cmux close-surface --surface surface:29 --workspace workspace:1
cmux close-surface --surface surface:23 --workspace workspace:1
cmux close-surface --surface surface:32 --workspace workspace:1

# 4. Color/describe BRIDGE and the sidebar "mission wall" (workspace metadata only).
cmux workspace-action --action set-color --workspace workspace:1 --color Indigo
cmux workspace-action --action set-description --workspace workspace:1 \
  --description "war room: lead(grok) + oz-gauntlet-v02(claude,live) + kimi(live) - corpses cleared"
cmux workspace-action --action set-color --workspace workspace:21 --color Charcoal
cmux workspace-action --action set-description --workspace workspace:21 \
  --description "empty: surface moved into BRIDGE war room"
cmux workspace-action --action set-color --workspace workspace:24 --color Amber
cmux workspace-action --action set-description --workspace workspace:24 \
  --description "CCA builder (this task) - claude - live"
cmux workspace-action --action set-color --workspace workspace:25 --color Rose
cmux workspace-action --action set-description --workspace workspace:25 \
  --description "CCA nemesis (auditor) - claude - live"
```

## Deliberate scope decisions

- **Did not banner (text-inject) any live surface.** `fm-cmux-war-room.sh banner` writes a `printf` ANSI line into the pane via `cmux send` + `send-key enter`. That is safe against a blank/idle shell (the fs-team layout use case), but every live surface I touched here (`surface:11` sitting inside a running grok TUI, `surface:35` sitting inside a running claude session mid-permission-prompt) has a foreground raw-mode app, not a shell prompt - typing a stray command into it could have corrupted its input or answered a prompt it never showed me. Used `rename-tab` only (cmux tab metadata, never touches the pty) for every live surface instead.
- **Only moved `oz-gauntlet-v02`, not the two CCA workspaces.** The brief named `hooks-mastery` and `oz-gauntlet-v02` specifically as move candidates; `hooks-mastery` is not live. Moving my own live task surface out from under myself mid-execution, or moving the nemesis auditor's surface, was not requested and adds risk with no visibility benefit, so both were left in place and only labeled via `workspace-action` (non-destructive metadata).
- **Verified before moving.** `docs/cmux-backend.md` (as inherited here) states workspace ids are "never recovery authority" and that label/recovery lookup is scoped to the current cmux window - `oz-gauntlet-v02` stayed in `window:1` throughout, so this move should not affect firstmate's own recovery path for that task. Confirmed empirically anyway: `move-surface` and `split-off` never sent input, and the surface's live content kept progressing on its own (visibly reached a different point in its own work) across every check.
- **No spawn/teardown code changes.** The existing `bin/fm-cmux-war-room.sh` helper plus direct `cmux` CLI calls were sufficient; no change to `bin/fm-spawn.sh` or the recovery path was needed or made.
- **Nothing broad-closed.** Every close and move named an explicit surface/workspace ref; no `close-workspace` was ever called against BRIDGE, and no `pkill`, `--force`, or `allowAll` was used anywhere in this session.

## After state

```sh
cmux tree --workspace workspace:1 --json
```

BRIDGE is now 3 panes / 3 surfaces, each live and labeled:

| Pane | Surface | Label | Harness |
|---|---|---|---|
| pane:1 | surface:11 | FIRSTMATE - grok | grok (primary lead) |
| pane:38 | surface:35 | OZ-GAUNTLET-V02 - claude - live | claude |
| pane:12 | surface:45 | KIMI - live | kimi (browser surface) |

BRIDGE workspace color: Indigo. Sidebar mission wall colored: `oz-gauntlet-v02` source workspace Charcoal ("empty, moved"), this task's workspace Amber, nemesis's workspace Rose.

## Tooling notes

- shellcheck 0.11.0 present and clean on `bin/fm-cmux-war-room.sh` (`bin/fm-lint.sh` exit 0).
- `cmux 0.64.22`, `jq-1.7.1` present; no missing-tool fallback needed this run.
```

</details>

## Test plan

- [x] `bin/fm-lint.sh` (shellcheck 0.11.0 pinned) - clean
- [x] `bin/fm-doc-audience-check.sh` - `ok surfaces=66 local_links=218`
- [x] Live verification: `oz-gauntlet-v02` (PID 25563) confirmed alive and progressing before/after every mutation
- [x] Live verification: `cmux tree --workspace workspace:1` re-read after each destructive step to confirm scoped-only effect
- [ ] No automated test for `bin/fm-cmux-war-room.sh` itself (documented as manual-only in `docs/cmux-war-room.md`, matching `cmux-backend.md`'s own precedent)