### PR TITLE
Require context-companion filing after product scouts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -233,7 +233,9 @@ Route durable knowledge to its most specific owner:
 - Home-domain captain preferences and working style belong in `data/captain.md` after inspect-then-update.
 - Captain preferences shared across secondmate domains belong in the primary home's `data/captain-shared.md` under the `secondmate-provisioning` contract.
 - Fleet-local operational facts belong in curated, home-local `data/learnings.md`.
-- Task-scoped notes belong with the backlog item, and investigation findings belong in the scout report.
+- Task-scoped working notes belong with the backlog item.
+- A scout's intermediate write-up may live at `data/<id>/report.md` (survives teardown as a working copy).
+- Durable product investigation findings, audits, and goals belong in that product's context companion (or project `AGENTS.md` when that is the right surface) - not as the permanent home under firstmate `data/`.
 - Knowledge useful to almost every contributor to one project belongs in that project's committed `AGENTS.md`.
 - Knowledge general to every firstmate user belongs in this repo's shared tracked surface.
 
@@ -263,7 +265,8 @@ Before commissioning an investigation, consult existing reports and established 
 Classify the deliverable:
 
 - **Ship** is the default and produces a project change through the selected delivery mode; once implementation is authorized, dispatch a ship and keep any remaining bounded research inside it unless unresolved uncertainty could materially change whether or what to build.
-- **Scout** produces knowledge in `data/<id>/report.md`, never a PR, and is appropriate for investigation, diagnosis, planning, reproduction, or audit work when the captain explicitly requests a separate knowledge or design deliverable or unresolved uncertainty could materially change whether or what to build.
+- **Scout** produces an intermediate write-up at `data/<id>/report.md`, never a product PR for code, and is appropriate for investigation, diagnosis, planning, reproduction, or audit work when the captain explicitly requests a separate knowledge or design deliverable or unresolved uncertainty could materially change whether or what to build.
+- For product-scoped scouts, that report is intermediate; firstmate must continue with context-companion filing per Scout outcome below.
 
 If established evidence already answers an informational question, relay it without a design-only scout; when implementation intent is unclear, answer and ask one concise implementation question when useful rather than dispatching speculative design work.
 Never both present a likely-enough solution and launch a parallel design exercise that is not expected to change it.
@@ -359,9 +362,12 @@ Retire one only on an explicit captain or main-firstmate decision, after loading
 
 ### Scout outcome and promotion
 
-A completed scout must leave a self-contained report before its scratch worktree can be discarded; read and relay its findings, record the report as the Done artifact, and re-evaluate the queue.
+A completed scout must leave a self-contained intermediate report at `data/<id>/report.md` before its scratch worktree can be discarded; read and relay its findings, and re-evaluate the queue.
 A report may recommend implementation but does not authorize it.
 Before treating the investigation or any visual review as complete, load `decision-hold-lifecycle`; teardown enforces that shared completion gate.
+When the scout is product-scoped and a context companion is registered (or clearly applicable), firstmate must dispatch a context-companion ship to fold durable findings into living CURRENT/GOALS-style docs (fold and prune; do not dump the full novel) before treating the investigation as complete for the captain, unless the captain explicitly said intermediate-only for that task.
+Relaying findings to the captain must not present `data/<id>/report.md` as the place future agents should re-read for product truth.
+Fleet-only or firstmate-template scouts without a product remain intermediate-report-only; record that report as the Done artifact.
 When implementation is separately authorized, promote the existing scout through `bin/fm-promote.sh` rather than creating a duplicate task.
 The promoted worker must inventory scratch state, return to a clean default-branch base, carry over only intended fix changes, create the ship branch, and follow the project's selected delivery path while leaving scratch commits and debug edits behind and turning a reproduced bug into the regression test.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,7 +84,7 @@ data/                personal fleet records; LOCAL, gitignored as a whole
   projects.md        thin fleet navigation registry recording each project's standing delivery posture; firstmate-private, parsed for mechanical sync and seeding by fm-project-mode.sh (section 6)
   secondmates.md      local and remote secondmate routing table; firstmate-private, maintained by the secondmate seed helpers (section 6)
   <id>/brief.md      per-task crewmate brief, or per-secondmate charter brief when kind=secondmate
-  <id>/report.md     scout task deliverable, written by the crewmate; survives teardown
+  <id>/report.md     scout intermediate working copy, written by the crewmate; survives teardown
 projects/            cloned repos; gitignored; read-only except under hard rule 1's concrete captain-approved project operation exception
 state/               volatile runtime signals; gitignored
   <id>.status        appended by crewmates: "<state>: <note>" wake-event lines, not current-state truth

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ You can run one coding agent easily.
 But the moment you want three project tasks done in parallel - fixes, investigations, plans, audits - you become a tab-juggler: babysitting sessions, copy-pasting context between repos, forgetting which terminal had the failing test.
 
 firstmate flips the model.
-You talk to a single agent - the first mate - and it runs the crew for you: spawning autonomous agents in a visible session backend, giving each a clean git worktree, supervising them to completion, and handing you finished PRs, approved local merges, or standalone investigation reports.
+You talk to a single agent - the first mate - and it runs the crew for you: spawning autonomous agents in a visible session backend, giving each a clean git worktree, supervising them to completion, and handing you finished PRs, approved local merges, or investigation outcomes.
 For larger fleets, you can opt in to persistent secondmates: second mates that are still ordinary direct reports, but run from their own isolated firstmate homes on this machine or another SSH-reachable host.
 
 firstmate is not a model, not a harness, not a skill, not an MCP server, and not a CLI.
@@ -44,7 +44,7 @@ Launching a supported harness inside it instantiates your first mate - and makes
 - **One liaison** - you talk only to the first mate; it dispatches, supervises, escalates only real decisions, and reports plain outcomes.
 - **A visible crew** - every crewmate works in its own tmux window, experimental herdr/zellij tab, cmux workspace, or Orca terminal you can watch or type into; the first mate reconciles.
 - **Disposable worktrees** - each task runs in a clean [treehouse](https://github.com/kunchenguid/treehouse) git worktree, or an Orca-managed worktree when `backend=orca`, so parallel work on one repo never collides.
-- **Two task shapes** - ship tasks deliver authorized changes; scout tasks leave standalone investigation reports when the intake contract warrants separate research.
+- **Two task shapes** - ship tasks deliver authorized changes; scout tasks leave intermediate investigation reports when the intake contract warrants separate research, with durable product findings filed into the product's context companion under the lifecycle contract.
 - **Explicit project modes** - each project ships via `no-mistakes`, `direct-PR`, or `local-only`, with an optional `+yolo` autonomy flag.
 - **Optional secondmates** - opt in to persistent second mates that run from isolated firstmate homes with their own `FM_HOME`, state, projects, and session lock, either locally or as a whole home on an SSH-reachable host, with guarded updates and recovery that never turns an unavailable remote route into a local replacement.
 - **Event-driven, zero-token supervision** - a bash watcher sleeps on the fleet and wakes the first mate only when something needs you; verified primary harnesses also get a turn-end backstop that blocks or follows up on a blind stop when work is under way and supervision is not live.
@@ -152,7 +152,7 @@ Setup guides for tmux (the default) and every other supported backend (herdr, ze
      │
      ├─ ship: project mode ► PR/local merge ► teardown
      │
-     └─ scout: report at data/<id>/report.md ► decision inventory ► relay findings ► teardown
+     └─ scout: intermediate report ► decision inventory ► product-context filing when applicable ► relay findings ► teardown
 ```
 
 You chat with the first mate.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -158,7 +158,8 @@ The helper's header owns the exact signal detection, relocated-home limitation, 
 
 ## Two task shapes
 
-Ship tasks change projects and ship by project mode (`no-mistakes`, `direct-PR`, or `local-only`); scout tasks leave standalone investigation reports at `data/<id>/report.md` and never push.
+Ship tasks change projects and ship by project mode (`no-mistakes`, `direct-PR`, or `local-only`); scout tasks leave intermediate investigation reports at `data/<id>/report.md` and never push a product code PR.
+Durable product findings file to the product's context companion per `AGENTS.md` section 7.
 The intake and authority contract in `AGENTS.md` owns when separate scout research is warranted.
 
 ## Dispatch profiles

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -10,7 +10,7 @@ The shared orchestrator behavior lives in [`AGENTS.md`](../AGENTS.md) - edit it 
 
 This section is the single owner of the top-level operational-home layout; producer script headers and their help own exact child-file fields and mutation contracts.
 The tracked code root contains the shared instruction, skill, documentation, workflow, and `bin/` surfaces, while each effective `FM_HOME` contains private operational directories.
-`data/` holds durable private fleet records such as the project and secondmate registries, captain preferences, optional shared captain preferences, learnings, backlog, briefs, and scout reports.
+`data/` holds durable private fleet records such as the project and secondmate registries, captain preferences, optional shared captain preferences, learnings, backlog, and briefs, plus intermediate scout report working copies.
 `state/` holds volatile runtime records such as task metadata, append-only status events, endpoint signals, watcher and wake-queue coordination, away-mode state, generated Relay artifacts, private secondmate config-reread generations with their retry and quarantine state, and parent-owned secondmate pending-reply records under `state/pending-replies/` (`bin/fm-pending-reply-lib.sh`).
 `config/` holds local gitignored operating choices, and `projects/` holds the local project clones that Firstmate reads but changes only through the narrow guarded and concrete captain-approved exceptions in `AGENTS.md`.
 


### PR DESCRIPTION
## Summary

Hardens firstmate's always-loaded scout lifecycle so product investigation findings are not treated as complete when only `data/<id>/report.md` exists. Durable product truth must file into the product's context companion.

## Changes

- **AGENTS.md section 6:** Intermediate scout write-ups may live at `data/<id>/report.md`; durable product findings, audits, and goals belong in the product's context companion (or project `AGENTS.md`), not as the permanent home under firstmate `data/`.
- **AGENTS.md section 7 (classify):** Scout remains intermediate / never a product code PR; product-scoped scouts continue to context-companion filing.
- **AGENTS.md section 7 (Scout outcome):** Product-scoped scouts with an applicable context companion must dispatch a context-companion ship (fold/prune into CURRENT/GOALS-style docs) before the investigation is complete for the captain, unless intermediate-only was requested. Do not present the intermediate report as product truth. Fleet-only / firstmate-template scouts remain intermediate-report-only.
- **docs/architecture.md:** One-line pointer that durable product findings file to the context companion per AGENTS section 7.
- **README.md / docs/configuration.md:** Document-step clarifications that scout reports are intermediate working copies.

## Test plan

- [x] no-mistakes review, test, document, lint (ShellCheck missing in local gate env; approved as docs-only)
- [ ] CI green on this PR against kunchenguid/firstmate

Note: Active GitHub identity `du-ev` has only READ on `kunchenguid/firstmate`, so this PR is from the writable fork `du-ev/firstmate`.
