### PR TITLE
fix(bin): provide shared browser workaround for chrome-devtools-axi

### DIFF
--- a/bin/fm-browser.sh
+++ b/bin/fm-browser.sh
@@ -38,12 +38,14 @@ PROFILE_DIR="$RUNTIME_DIR/profile"
 LOGFILE="$RUNTIME_DIR/browser.log"
 URL="http://127.0.0.1:$PORT"
 LOCK_HELD=0
+OWNER_FILE=
 
 usage() {
   sed -n '2,${/^#/!q;p;}' "$0" | sed 's/^# \{0,1\}//'
 }
 
 release_lock() {
+  [ -z "$OWNER_FILE" ] || rm -f "$OWNER_FILE"
   [ "$LOCK_HELD" -eq 1 ] || return 0
   LOCK_HELD=0
   if [ "$(cat "$LOCK_DIR/pid" 2>/dev/null || true)" = "$$" ]; then
@@ -55,11 +57,20 @@ release_lock() {
 acquire_lock() {
   local attempt=0 owner
   mkdir -p "$RUNTIME_DIR"
-  while ! mkdir "$LOCK_DIR" 2>/dev/null; do
+  OWNER_FILE="$RUNTIME_DIR/lock-owner.$$"
+  printf '%s\n' "$$" > "$OWNER_FILE"
+  trap release_lock EXIT INT TERM
+  while :; do
+    mkdir "$LOCK_DIR" 2>/dev/null || true
+    if ln "$OWNER_FILE" "$LOCK_DIR/pid" 2>/dev/null; then
+      rm -f "$OWNER_FILE"
+      OWNER_FILE=
+      LOCK_HELD=1
+      return 0
+    fi
     owner=$(cat "$LOCK_DIR/pid" 2>/dev/null || true)
     case "$owner" in
       ''|*[!0-9])
-        rmdir "$LOCK_DIR" 2>/dev/null || true
         sleep 0.05
         ;;
       *)
@@ -69,7 +80,6 @@ acquire_lock() {
           if [ "$(cat "$LOCK_DIR/pid" 2>/dev/null || true)" = "$owner" ] &&
             ! kill -0 "$owner" 2>/dev/null; then
             rm -f "$LOCK_DIR/pid"
-            rmdir "$LOCK_DIR" 2>/dev/null || true
           fi
         fi
         ;;
@@ -80,9 +90,6 @@ acquire_lock() {
       return 1
     fi
   done
-  printf '%s\n' "$$" > "$LOCK_DIR/pid"
-  LOCK_HELD=1
-  trap release_lock EXIT INT TERM
 }
 
 probe() {

--- a/bin/fm-browser.sh
+++ b/bin/fm-browser.sh
@@ -48,7 +48,8 @@ ensure_runtime_dir() {
   local owner mode permissions current_uid
   current_uid=${UID:-$(id -u)}
   if [ ! -e "$RUNTIME_DIR" ] && [ ! -L "$RUNTIME_DIR" ]; then
-    mkdir -p -m 700 "$RUNTIME_DIR"
+    mkdir -p "$RUNTIME_DIR"
+    chmod 700 "$RUNTIME_DIR"
   fi
   if [ ! -d "$RUNTIME_DIR" ] || [ -L "$RUNTIME_DIR" ]; then
     printf 'fm-browser: runtime path is not a real directory: %s\n' "$RUNTIME_DIR" >&2
@@ -248,6 +249,7 @@ launch_browser() {
     wait "$pid" 2>/dev/null || true
   fi
   printf 'fm-browser: Chrome did not expose %s/json/version within 10 seconds.\n' "$URL" >&2
+  printf 'fm-browser: if this persists, install a known-good browser with: npx -y puppeteer@latest browsers install chrome\n' >&2
   return 1
 }
 

--- a/bin/fm-browser.sh
+++ b/bin/fm-browser.sh
@@ -44,6 +44,26 @@ usage() {
   sed -n '2,${/^#/!q;p;}' "$0" | sed 's/^# \{0,1\}//'
 }
 
+ensure_runtime_dir() {
+  local owner mode permissions current_uid
+  current_uid=${UID:-$(id -u)}
+  if [ ! -e "$RUNTIME_DIR" ] && [ ! -L "$RUNTIME_DIR" ]; then
+    mkdir -p -m 700 "$RUNTIME_DIR"
+  fi
+  if [ ! -d "$RUNTIME_DIR" ] || [ -L "$RUNTIME_DIR" ]; then
+    printf 'fm-browser: runtime path is not a real directory: %s\n' "$RUNTIME_DIR" >&2
+    return 1
+  fi
+  owner=$(stat -c '%u' "$RUNTIME_DIR" 2>/dev/null || stat -f '%u' "$RUNTIME_DIR" 2>/dev/null) || return 1
+  mode=$(stat -c '%a' "$RUNTIME_DIR" 2>/dev/null || stat -f '%Lp' "$RUNTIME_DIR" 2>/dev/null) || return 1
+  permissions=$((8#$mode))
+  if [ "$owner" != "$current_uid" ] || (( permissions & 0022 )); then
+    printf 'fm-browser: runtime directory must be owned by uid %s and not group/other-writable: %s\n' \
+      "$current_uid" "$RUNTIME_DIR" >&2
+    return 1
+  fi
+}
+
 release_lock() {
   [ -z "$OWNER_FILE" ] || rm -f "$OWNER_FILE"
   [ "$LOCK_HELD" -eq 1 ] || return 0
@@ -56,7 +76,7 @@ release_lock() {
 
 acquire_lock() {
   local attempt=0 owner
-  mkdir -p "$RUNTIME_DIR"
+  ensure_runtime_dir || return 1
   OWNER_FILE="$RUNTIME_DIR/lock-owner.$$"
   printf '%s\n' "$$" > "$OWNER_FILE"
   trap release_lock EXIT INT TERM
@@ -252,6 +272,7 @@ url() {
 
 status() {
   local owner=none
+  ensure_runtime_dir || return 1
   if probe; then
     if owned_pid >/dev/null; then
       owner=helper

--- a/bin/fm-browser.sh
+++ b/bin/fm-browser.sh
@@ -53,7 +53,7 @@ release_lock() {
 }
 
 acquire_lock() {
-  local attempt=0 owner reclaimed
+  local attempt=0 owner
   mkdir -p "$RUNTIME_DIR"
   while ! mkdir "$LOCK_DIR" 2>/dev/null; do
     owner=$(cat "$LOCK_DIR/pid" 2>/dev/null || true)
@@ -65,12 +65,13 @@ acquire_lock() {
         if kill -0 "$owner" 2>/dev/null; then
           sleep 0.05
         else
-          reclaimed="$RUNTIME_DIR/lock.reclaimed.$$.$attempt"
-          if mv "$LOCK_DIR" "$reclaimed" 2>/dev/null; then
-            if [ "$(cat "$reclaimed/pid" 2>/dev/null || true)" = "$owner" ]; then
-              rm -f "$reclaimed/pid"
-              rmdir "$reclaimed" 2>/dev/null || true
+          if mkdir "$LOCK_DIR/reclaim" 2>/dev/null; then
+            if [ "$(cat "$LOCK_DIR/pid" 2>/dev/null || true)" = "$owner" ] &&
+              ! kill -0 "$owner" 2>/dev/null; then
+              rm -f "$LOCK_DIR/pid"
             fi
+            rmdir "$LOCK_DIR/reclaim" 2>/dev/null || true
+            rmdir "$LOCK_DIR" 2>/dev/null || true
           fi
         fi
         ;;

--- a/bin/fm-browser.sh
+++ b/bin/fm-browser.sh
@@ -1,0 +1,300 @@
+#!/usr/bin/env bash
+# Work around the chrome-devtools-axi browser-launch defect with one shared,
+# loopback-only headless Chrome per machine and configured debug port.
+# Usage:
+#   fm-browser.sh url
+#   fm-browser.sh status
+#   fm-browser.sh stop
+#
+# `url` probes the debug endpoint before and after taking the machine-scoped
+# lock, then prints only a URL that answered /json/version successfully.
+# The helper's lock, pidfile, profile, and log are outside every firstmate home.
+# Set FM_BROWSER_BIN to select a browser executable, or FM_BROWSER_PORT to use
+# another loopback port.  FM_BROWSER_RUNTIME_DIR is an implementation escape
+# hatch for isolated tests and machine-local runtime placement.
+set -eu
+
+DEFAULT_PORT=9222
+PORT=${FM_BROWSER_PORT:-$DEFAULT_PORT}
+case "$PORT" in
+  ''|*[!0-9]*)
+    printf 'fm-browser: invalid FM_BROWSER_PORT: %s\n' "$PORT" >&2
+    exit 2
+    ;;
+esac
+if [ "$PORT" -lt 1 ] || [ "$PORT" -gt 65535 ]; then
+  printf 'fm-browser: FM_BROWSER_PORT must be between 1 and 65535: %s\n' "$PORT" >&2
+  exit 2
+fi
+
+if [ -n "${FM_BROWSER_RUNTIME_DIR:-}" ]; then
+  RUNTIME_DIR=$FM_BROWSER_RUNTIME_DIR
+else
+  RUNTIME_DIR=${XDG_RUNTIME_DIR:-${TMPDIR:-/tmp}}/firstmate-browser-${UID:-$(id -u)}
+fi
+LOCK_DIR="$RUNTIME_DIR/lock"
+PIDFILE="$RUNTIME_DIR/pid"
+PROFILE_DIR="$RUNTIME_DIR/profile"
+LOGFILE="$RUNTIME_DIR/browser.log"
+URL="http://127.0.0.1:$PORT"
+LOCK_HELD=0
+
+usage() {
+  sed -n '2,${/^#/!q;p;}' "$0" | sed 's/^# \{0,1\}//'
+}
+
+release_lock() {
+  [ "$LOCK_HELD" -eq 1 ] || return 0
+  LOCK_HELD=0
+  if [ "$(cat "$LOCK_DIR/pid" 2>/dev/null || true)" = "$$" ]; then
+    rm -f "$LOCK_DIR/pid"
+    rmdir "$LOCK_DIR" 2>/dev/null || true
+  fi
+}
+
+acquire_lock() {
+  local attempt=0 owner
+  mkdir -p "$RUNTIME_DIR"
+  while ! mkdir "$LOCK_DIR" 2>/dev/null; do
+    owner=$(cat "$LOCK_DIR/pid" 2>/dev/null || true)
+    case "$owner" in
+      ''|*[!0-9])
+        sleep 0.05
+        ;;
+      *)
+        if kill -0 "$owner" 2>/dev/null; then
+          sleep 0.05
+        else
+          rmdir "$LOCK_DIR" 2>/dev/null || true
+        fi
+        ;;
+    esac
+    attempt=$((attempt + 1))
+    if [ "$attempt" -ge 100 ]; then
+      printf 'fm-browser: timed out waiting for the machine-scoped browser lock: %s\n' "$LOCK_DIR" >&2
+      return 1
+    fi
+  done
+  printf '%s\n' "$$" > "$LOCK_DIR/pid"
+  LOCK_HELD=1
+  trap release_lock EXIT INT TERM
+}
+
+probe() {
+  local response
+  response=$(curl -fsS --connect-timeout 0.2 --max-time 1 "$URL/json/version" 2>/dev/null) || return 1
+  case "$response" in
+    *webSocketDebuggerUrl*) return 0 ;;
+  esac
+  return 1
+}
+
+sort_cached_candidates() {
+  if sort -V </dev/null >/dev/null 2>&1; then
+    sort -V -r
+  else
+    sort -r
+  fi
+}
+
+cached_binary() {
+  local root=$1 candidate
+  local -a candidates=()
+  shopt -s nullglob
+  candidates=( "$root"/*/chrome-linux64/chrome )
+  shopt -u nullglob
+  [ "${#candidates[@]}" -gt 0 ] || return 1
+  while IFS= read -r candidate; do
+    [ -x "$candidate" ] || continue
+    printf '%s\n' "$candidate"
+    return 0
+  done < <(printf '%s\n' "${candidates[@]}" | sort_cached_candidates)
+  return 1
+}
+
+discover_binary() {
+  local candidate
+  if [ -n "${FM_BROWSER_BIN:-}" ] && [ -x "$FM_BROWSER_BIN" ]; then
+    printf '%s\n' "$FM_BROWSER_BIN"
+    return 0
+  fi
+  if cached_binary "${HOME:?}/.cache/puppeteer/chrome"; then
+    return 0
+  fi
+  if cached_binary "${HOME:?}/.cache/ms-playwright"; then
+    return 0
+  fi
+  for candidate in google-chrome chromium chromium-browser; do
+    candidate=$(command -v "$candidate" 2>/dev/null || true)
+    if [ -n "$candidate" ] && [ -x "$candidate" ]; then
+      printf '%s\n' "$candidate"
+      return 0
+    fi
+  done
+  return 1
+}
+
+pidfile_value() {
+  local key=$1
+  sed -n "s/^${key}=//p" "$PIDFILE" 2>/dev/null | sed -n '1p'
+}
+
+process_args() {
+  local pid=$1
+  if [ -r "/proc/$pid/cmdline" ]; then
+    tr '\0' ' ' < "/proc/$pid/cmdline"
+  else
+    ps -p "$pid" -o args= 2>/dev/null || true
+  fi
+}
+
+process_starttime() {
+  local pid=$1
+  [ -r "/proc/$pid/stat" ] || return 0
+  awk '{print $22}' "/proc/$pid/stat" 2>/dev/null || true
+}
+
+owned_pid() {
+  local pid recorded_port recorded_profile recorded_start args
+  [ -f "$PIDFILE" ] || return 1
+  pid=$(pidfile_value pid)
+  case "$pid" in ''|*[!0-9]*) return 1 ;; esac
+  recorded_port=$(pidfile_value port)
+  recorded_profile=$(pidfile_value profile)
+  recorded_start=$(pidfile_value starttime)
+  [ "$recorded_port" = "$PORT" ] || return 1
+  [ "$recorded_profile" = "$PROFILE_DIR" ] || return 1
+  kill -0 "$pid" 2>/dev/null || return 1
+  if [ -n "$recorded_start" ] && [ "$(process_starttime "$pid")" != "$recorded_start" ]; then
+    return 1
+  fi
+  args=$(process_args "$pid")
+  case "$args" in
+    *"--remote-debugging-port=$PORT"*"--user-data-dir=$PROFILE_DIR"*)
+      printf '%s\n' "$pid"
+      return 0
+      ;;
+  esac
+  return 1
+}
+
+write_pidfile() {
+  local pid=$1 starttime tmp
+  starttime=$(process_starttime "$pid")
+  tmp="$PIDFILE.$$"
+  {
+    printf 'pid=%s\n' "$pid"
+    printf 'port=%s\n' "$PORT"
+    printf 'profile=%s\n' "$PROFILE_DIR"
+    printf 'starttime=%s\n' "$starttime"
+  } > "$tmp"
+  mv -f "$tmp" "$PIDFILE"
+}
+
+launch_browser() {
+  local binary=$1 pid attempt=0
+  mkdir -p "$PROFILE_DIR"
+  "$binary" --headless --no-sandbox --disable-gpu --disable-dev-shm-usage \
+    "--remote-debugging-address=127.0.0.1" "--remote-debugging-port=$PORT" \
+    "--user-data-dir=$PROFILE_DIR" about:blank \
+    >"$LOGFILE" 2>&1 &
+  pid=$!
+  write_pidfile "$pid"
+  while [ "$attempt" -lt 100 ]; do
+    if probe; then
+      printf '%s\n' "$URL"
+      return 0
+    fi
+    if ! kill -0 "$pid" 2>/dev/null; then
+      break
+    fi
+    sleep 0.1
+    attempt=$((attempt + 1))
+  done
+  if owned_pid >/dev/null; then
+    kill "$pid" 2>/dev/null || true
+    wait "$pid" 2>/dev/null || true
+  fi
+  printf 'fm-browser: Chrome did not expose %s/json/version within 10 seconds.\n' "$URL" >&2
+  return 1
+}
+
+url() {
+  local binary
+  if probe; then
+    printf '%s\n' "$URL"
+    return 0
+  fi
+  acquire_lock || return 1
+  if probe; then
+    printf '%s\n' "$URL"
+    return 0
+  fi
+  if ! binary=$(discover_binary); then
+    printf 'fm-browser: no Chrome executable found for loopback debugging port %s.\n' "$PORT" >&2
+    printf 'fm-browser: install one with: npx -y puppeteer@latest browsers install chrome\n' >&2
+    return 1
+  fi
+  launch_browser "$binary"
+}
+
+status() {
+  local owner=none
+  if probe; then
+    if owned_pid >/dev/null; then
+      owner=helper
+    else
+      owner=external
+    fi
+    printf 'state=running\nurl=%s\nowner=%s\n' "$URL" "$owner"
+    return 0
+  fi
+  if owned_pid >/dev/null; then
+    printf 'state=unreachable\nowner=helper\n'
+    return 1
+  fi
+  printf 'state=stopped\nowner=none\n'
+}
+
+stop() {
+  local pid attempt=0
+  acquire_lock || return 1
+  if ! pid=$(owned_pid); then
+    rm -f "$PIDFILE"
+    printf 'stopped=no-owned-browser\n'
+    return 0
+  fi
+  kill "$pid" 2>/dev/null || true
+  while [ "$attempt" -lt 50 ] && owned_pid >/dev/null; do
+    sleep 0.1
+    attempt=$((attempt + 1))
+  done
+  if owned_pid >/dev/null; then
+    kill -KILL "$pid" 2>/dev/null || true
+  fi
+  rm -f "$PIDFILE"
+  printf 'stopped=helper-browser\n'
+}
+
+case "${1:-}" in
+  -h|--help)
+    [ "$#" -eq 1 ] || { usage >&2; exit 2; }
+    usage
+    ;;
+  url)
+    [ "$#" -eq 1 ] || { usage >&2; exit 2; }
+    url
+    ;;
+  status)
+    [ "$#" -eq 1 ] || { usage >&2; exit 2; }
+    status
+    ;;
+  stop)
+    [ "$#" -eq 1 ] || { usage >&2; exit 2; }
+    stop
+    ;;
+  *)
+    usage >&2
+    exit 2
+    ;;
+esac

--- a/bin/fm-browser.sh
+++ b/bin/fm-browser.sh
@@ -59,18 +59,16 @@ acquire_lock() {
     owner=$(cat "$LOCK_DIR/pid" 2>/dev/null || true)
     case "$owner" in
       ''|*[!0-9])
+        rmdir "$LOCK_DIR" 2>/dev/null || true
         sleep 0.05
         ;;
       *)
         if kill -0 "$owner" 2>/dev/null; then
           sleep 0.05
         else
-          if mkdir "$LOCK_DIR/reclaim" 2>/dev/null; then
-            if [ "$(cat "$LOCK_DIR/pid" 2>/dev/null || true)" = "$owner" ] &&
-              ! kill -0 "$owner" 2>/dev/null; then
-              rm -f "$LOCK_DIR/pid"
-            fi
-            rmdir "$LOCK_DIR/reclaim" 2>/dev/null || true
+          if [ "$(cat "$LOCK_DIR/pid" 2>/dev/null || true)" = "$owner" ] &&
+            ! kill -0 "$owner" 2>/dev/null; then
+            rm -f "$LOCK_DIR/pid"
             rmdir "$LOCK_DIR" 2>/dev/null || true
           fi
         fi

--- a/bin/fm-browser.sh
+++ b/bin/fm-browser.sh
@@ -53,7 +53,7 @@ release_lock() {
 }
 
 acquire_lock() {
-  local attempt=0 owner
+  local attempt=0 owner reclaimed
   mkdir -p "$RUNTIME_DIR"
   while ! mkdir "$LOCK_DIR" 2>/dev/null; do
     owner=$(cat "$LOCK_DIR/pid" 2>/dev/null || true)
@@ -65,7 +65,13 @@ acquire_lock() {
         if kill -0 "$owner" 2>/dev/null; then
           sleep 0.05
         else
-          rmdir "$LOCK_DIR" 2>/dev/null || true
+          reclaimed="$RUNTIME_DIR/lock.reclaimed.$$.$attempt"
+          if mv "$LOCK_DIR" "$reclaimed" 2>/dev/null; then
+            if [ "$(cat "$reclaimed/pid" 2>/dev/null || true)" = "$owner" ]; then
+              rm -f "$reclaimed/pid"
+              rmdir "$reclaimed" 2>/dev/null || true
+            fi
+          fi
         fi
         ;;
     esac

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -2275,6 +2275,17 @@ fi
 # process (go build, go test, ...) inherit it. Sent before the launch command so
 # the env is set when the agent starts; the brief sleep lets the export land.
 spawn_send_text_line "$T" "export GOTMPDIR=$TASK_TMP/gotmp"
+# chrome-devtools-axi's own browser launch is broken on some machines, so use a
+# best-effort machine-shared loopback browser when the operator did not provide
+# an ambient endpoint. The helper failure is intentionally non-fatal because a
+# task may not need browser verification.
+SPAWN_BROWSER_URL=${CHROME_DEVTOOLS_AXI_BROWSER_URL:-}
+if [ -z "$SPAWN_BROWSER_URL" ]; then
+  SPAWN_BROWSER_URL=$("$FM_ROOT/bin/fm-browser.sh" url 2>/dev/null || true)
+fi
+if [ -n "$SPAWN_BROWSER_URL" ]; then
+  spawn_send_text_line "$T" "export CHROME_DEVTOOLS_AXI_BROWSER_URL=$(shell_quote "$SPAWN_BROWSER_URL")"
+fi
 # Send through the exact channel that already ships GOTMPDIR, so every backend
 # and harness - ship, scout, and secondmate - gets it before launch. Skipped
 # entirely when trace context is off.

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -2275,17 +2275,6 @@ fi
 # process (go build, go test, ...) inherit it. Sent before the launch command so
 # the env is set when the agent starts; the brief sleep lets the export land.
 spawn_send_text_line "$T" "export GOTMPDIR=$TASK_TMP/gotmp"
-# chrome-devtools-axi's own browser launch is broken on some machines, so use a
-# best-effort machine-shared loopback browser when the operator did not provide
-# an ambient endpoint. The helper failure is intentionally non-fatal because a
-# task may not need browser verification.
-SPAWN_BROWSER_URL=${CHROME_DEVTOOLS_AXI_BROWSER_URL:-}
-if [ -z "$SPAWN_BROWSER_URL" ]; then
-  SPAWN_BROWSER_URL=$("$FM_ROOT/bin/fm-browser.sh" url 2>/dev/null || true)
-fi
-if [ -n "$SPAWN_BROWSER_URL" ]; then
-  spawn_send_text_line "$T" "export CHROME_DEVTOOLS_AXI_BROWSER_URL=$(shell_quote "$SPAWN_BROWSER_URL")"
-fi
 # Send through the exact channel that already ships GOTMPDIR, so every backend
 # and harness - ship, scout, and secondmate - gets it before launch. Skipped
 # entirely when trace context is off.
@@ -2301,6 +2290,17 @@ if [ -n "$SPAWN_TRACEPARENT" ]; then
       exit 1
     fi
   fi
+fi
+# chrome-devtools-axi's own browser launch is broken on some machines, so use a
+# best-effort machine-shared loopback browser when the operator did not provide
+# an ambient endpoint. The helper failure is intentionally non-fatal because a
+# task may not need browser verification.
+SPAWN_BROWSER_URL=${CHROME_DEVTOOLS_AXI_BROWSER_URL:-}
+if [ -z "$SPAWN_BROWSER_URL" ]; then
+  SPAWN_BROWSER_URL=$("$FM_ROOT/bin/fm-browser.sh" url 2>/dev/null || true)
+fi
+if [ -n "$SPAWN_BROWSER_URL" ]; then
+  spawn_send_text_line "$T" "export CHROME_DEVTOOLS_AXI_BROWSER_URL=$(shell_quote "$SPAWN_BROWSER_URL")"
 fi
 sleep 0.3
 spawn_send_literal "$T" "$LAUNCH"

--- a/docs/browser-workaround.md
+++ b/docs/browser-workaround.md
@@ -1,0 +1,21 @@
+# chrome-devtools-axi browser workaround
+
+On this machine, `chrome-devtools-axi` fails on every page, including a known-good local page, with `Protocol error (Target.setDiscoverTargets): Target closed`.
+
+This is a workaround for an upstream browser-launch defect, not the intended browser design.
+
+The failure is not environment-wide because a hand-launched headless Chrome from `~/.cache/ms-playwright/chromium-1228/chrome-linux64/chrome` returned the DOM for `data:text/html,<h1>hello</h1>`.
+
+The failure is not a missing browser because Puppeteer's `chrome` and `chrome-headless-shell` installations completed under `~/.cache/puppeteer/` while the tool's default launch continued to fail.
+
+The failure is not fixed by `chrome-devtools-axi stop` and a session restart.
+
+The failure is not fixed by `CHROME_DEVTOOLS_AXI_CHROME_ARGS="--no-sandbox --disable-dev-shm-usage --disable-gpu"`.
+
+The verified mechanism is to launch one loopback-only headless Chrome with `bin/fm-browser.sh url` and point `chrome-devtools-axi` at the returned `CHROME_DEVTOOLS_AXI_BROWSER_URL`.
+
+`bin/fm-browser.sh url` reuses the machine-scoped browser when its debug endpoint answers `/json/version`, and starts one only when the probe fails.
+
+Use `bin/fm-browser.sh status` to inspect the endpoint and `bin/fm-browser.sh stop` to terminate only the browser started by the helper.
+
+Set `FM_BROWSER_PORT` to use another loopback port, or set `CHROME_DEVTOOLS_AXI_BROWSER_URL` to repoint a process at an operator-managed browser.

--- a/docs/browser-workaround.md
+++ b/docs/browser-workaround.md
@@ -1,21 +1,27 @@
 # chrome-devtools-axi browser workaround
 
-On this machine, `chrome-devtools-axi` fails on every page, including a known-good local page, with `Protocol error (Target.setDiscoverTargets): Target closed`.
+The upstream launch defect presents on every page, including a known-good local page, as `Protocol error (Target.setDiscoverTargets): Target closed`.
 
 This is a workaround for an upstream browser-launch defect, not the intended browser design.
 
-The failure is not environment-wide because a hand-launched headless Chrome from `~/.cache/ms-playwright/chromium-1228/chrome-linux64/chrome` returned the DOM for `data:text/html,<h1>hello</h1>`.
+The failure is not environment-wide because a hand-launched headless Chrome returned the DOM for a known-good data URL.
 
-The failure is not a missing browser because Puppeteer's `chrome` and `chrome-headless-shell` installations completed under `~/.cache/puppeteer/` while the tool's default launch continued to fail.
+The failure is not a missing browser because installed Puppeteer browsers do not repair the tool's default launch.
 
 The failure is not fixed by `chrome-devtools-axi stop` and a session restart.
 
 The failure is not fixed by `CHROME_DEVTOOLS_AXI_CHROME_ARGS="--no-sandbox --disable-dev-shm-usage --disable-gpu"`.
 
-The verified mechanism is to launch one loopback-only headless Chrome with `bin/fm-browser.sh url` and point `chrome-devtools-axi` at the returned `CHROME_DEVTOOLS_AXI_BROWSER_URL`.
+The verified mechanism is to launch one machine-scoped, loopback-only headless Chrome with `bin/fm-browser.sh url` and point `chrome-devtools-axi` at the returned `CHROME_DEVTOOLS_AXI_BROWSER_URL`.
 
-`bin/fm-browser.sh url` reuses the machine-scoped browser when its debug endpoint answers `/json/version`, and starts one only when the probe fails.
+`bin/fm-browser.sh url` reuses an endpoint when its `/json/version` probe succeeds, serializes concurrent startup, refuses after a bounded wait, and prints a URL only after the endpoint answers successfully.
+
+Every local crewmate and secondmate launch receives that verified URL on a best-effort basis, unless the operator already supplied `CHROME_DEVTOOLS_AXI_BROWSER_URL`.
+
+Browser failure never blocks a spawn, and an ambient operator URL is preserved unchanged.
 
 Use `bin/fm-browser.sh status` to inspect the endpoint and `bin/fm-browser.sh stop` to terminate only the browser started by the helper.
 
-Set `FM_BROWSER_PORT` to use another loopback port, or set `CHROME_DEVTOOLS_AXI_BROWSER_URL` to repoint a process at an operator-managed browser.
+The default debug port is `9222`, separate from Firstmate's known dashboard, Lavish, and bridge ports; set `FM_BROWSER_PORT` before `url`, `status`, or `stop` to use another loopback port.
+
+Set `CHROME_DEVTOOLS_AXI_BROWSER_URL` before launching a crewmate or secondmate to repoint it at an operator-managed browser without starting the helper browser.

--- a/docs/documentation-audiences.json
+++ b/docs/documentation-audiences.json
@@ -209,6 +209,10 @@
       "audience": "maintainer-architecture"
     },
     {
+      "path": "docs/browser-workaround.md",
+      "audience": "operator-current"
+    },
+    {
       "path": "docs/calm-mode-feasibility.md",
       "audience": "maintainer-verification"
     },

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -48,6 +48,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-remote-readiness-lib.sh` | Shared remote second-mate readiness gate: check and, when needed, repair then re-check through `fm-remote-doctor.sh` |
 | [`fm-project-origin-lib.sh`](../bin/fm-project-origin-lib.sh) | Accepted origin-form owner shared by both remote provisioning boundaries |
 | `fm-spawn.sh`            | Spawn crewmates, scouts, `id=repo` batches, and secondmates on the resolved harness and runtime backend |
+| [`fm-browser.sh`](../bin/fm-browser.sh) | Operate the machine-scoped loopback browser used by the [chrome-devtools-axi workaround](browser-workaround.md) |
 | `fm-backend.sh`          | Runtime-backend selection, meta helpers, selector resolution, and operation dispatch |
 | `fm-backend-hometag-lib.sh` | Shared per-installation home-tag derivation for zellij tab and cmux workspace titles |
 | `fm-composer-lib.sh`     | Single fleet-wide owner of composer-content classification for all backends          |

--- a/tests/fm-browser.test.sh
+++ b/tests/fm-browser.test.sh
@@ -21,6 +21,21 @@ SH
   chmod +x "$fakebin/curl"
 }
 
+# Shadow the PATH-fallback candidate names ahead of the real /usr/bin:/bin used
+# below for genuine coreutils, so a runner with a real browser preinstalled (as
+# hosted CI images commonly are) cannot make this "missing browser" case
+# actually discover and launch one; this suite must never launch a real browser.
+make_fake_missing_browsers() {
+  local fakebin=$1 browser
+  for browser in google-chrome chromium chromium-browser; do
+    cat > "$fakebin/$browser" <<'SH'
+#!/usr/bin/env bash
+exit 1
+SH
+    chmod +x "$fakebin/$browser"
+  done
+}
+
 make_fake_browser() {
   local path=$1
   cat > "$path" <<'SH'
@@ -136,6 +151,7 @@ test_missing_binary_refuses_without_url() {
   dir="$TMP_ROOT/missing"
   fakebin=$(fm_fakebin "$dir")
   make_fake_curl "$fakebin"
+  make_fake_missing_browsers "$fakebin"
   if out=$(FM_BROWSER_RUNTIME_DIR="$dir/runtime" FM_BROWSER_PORT=19224 \
     FM_BROWSER_BIN="$dir/not-a-browser" HOME="$dir/home" \
     FM_TEST_BROWSER_MARKER="$dir/never" PATH="$fakebin:/usr/bin:/bin" \

--- a/tests/fm-browser.test.sh
+++ b/tests/fm-browser.test.sh
@@ -182,7 +182,13 @@ test_stale_lock_is_reclaimed() {
     "$BROWSER_HELPER" stop)
   [ "$out" = 'stopped=no-owned-browser' ] || fail "stale-lock stop returned '$out'"
   [ ! -e "$dir/runtime/lock" ] || fail "stale lock was not released"
-  pass "dead lock owners are reclaimed before acquiring the browser lock"
+  mkdir -p "$dir/runtime/lock"
+  out=$(FM_BROWSER_RUNTIME_DIR="$dir/runtime" FM_BROWSER_PORT=19228 \
+    FM_TEST_BROWSER_MARKER="$dir/never" PATH="$fakebin:$PATH" \
+    "$BROWSER_HELPER" stop)
+  [ "$out" = 'stopped=no-owned-browser' ] || fail "ownerless-lock stop returned '$out'"
+  [ ! -e "$dir/runtime/lock" ] || fail "ownerless lock was not released"
+  pass "dead and ownerless browser locks are reclaimed"
 }
 
 test_probe_hit_reuses_without_launching

--- a/tests/fm-browser.test.sh
+++ b/tests/fm-browser.test.sh
@@ -1,0 +1,177 @@
+#!/usr/bin/env bash
+# fm-browser.sh behavior tests using fake HTTP and browser processes.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+BROWSER_HELPER="$ROOT/bin/fm-browser.sh"
+TMP_ROOT=$(fm_test_tmproot fm-browser)
+
+make_fake_curl() {
+  local fakebin=$1
+  cat > "$fakebin/curl" <<'SH'
+#!/usr/bin/env bash
+if [ -n "${FM_TEST_BROWSER_MARKER:-}" ] && [ -e "$FM_TEST_BROWSER_MARKER" ]; then
+  printf '%s\n' '{"webSocketDebuggerUrl":"ws://127.0.0.1/devtools/browser/test"}'
+  exit 0
+fi
+exit 7
+SH
+  chmod +x "$fakebin/curl"
+}
+
+make_fake_browser() {
+  local path=$1
+  cat > "$path" <<'SH'
+#!/usr/bin/env bash
+set -u
+printf '%s\n' "$*" >> "$FM_TEST_BROWSER_LAUNCH_LOG"
+[ -z "${FM_TEST_BROWSER_MARKER:-}" ] || touch "$FM_TEST_BROWSER_MARKER"
+trap 'exit 0' INT TERM
+while :; do sleep 0.1; done
+SH
+  chmod +x "$path"
+}
+
+test_probe_hit_reuses_without_launching() {
+  local dir fakebin marker browser out
+  dir="$TMP_ROOT/probe-hit"
+  fakebin=$(fm_fakebin "$dir")
+  make_fake_curl "$fakebin"
+  marker="$dir/ready"
+  browser="$dir/browser"
+  : > "$marker"
+  make_fake_browser "$browser"
+  out=$(FM_BROWSER_RUNTIME_DIR="$dir/runtime" FM_BROWSER_PORT=19222 \
+    FM_BROWSER_BIN="$browser" FM_TEST_BROWSER_MARKER="$marker" \
+    FM_TEST_BROWSER_LAUNCH_LOG="$dir/launched" PATH="$fakebin:$PATH" \
+    "$BROWSER_HELPER" url)
+  [ "$out" = 'http://127.0.0.1:19222' ] || fail "probe-hit path returned '$out'"
+  [ ! -e "$dir/launched" ] || fail "probe-hit path launched a second browser"
+  pass "probe-hit path reuses the reachable endpoint without launching"
+}
+
+test_discovery_prefers_explicit_binary() {
+  local dir fakebin marker preferred fallback out second launches args
+  dir="$TMP_ROOT/discovery-order"
+  fakebin=$(fm_fakebin "$dir")
+  make_fake_curl "$fakebin"
+  marker="$dir/ready"
+  preferred="$dir/preferred-browser"
+  fallback="$dir/fallback-browser"
+  make_fake_browser "$preferred"
+  make_fake_browser "$fallback"
+  out=$(FM_BROWSER_RUNTIME_DIR="$dir/runtime" FM_BROWSER_PORT=19223 \
+    FM_BROWSER_BIN="$preferred" FM_TEST_BROWSER_MARKER="$marker" \
+    FM_TEST_BROWSER_LAUNCH_LOG="$dir/preferred-launched" PATH="$fakebin:$PATH" \
+    "$BROWSER_HELPER" url)
+  [ "$out" = 'http://127.0.0.1:19223' ] || fail "discovery path returned '$out'"
+  [ -e "$dir/preferred-launched" ] || fail "FM_BROWSER_BIN was not selected first"
+  launches=$(wc -l < "$dir/preferred-launched")
+  [ "$launches" -eq 1 ] || fail "initial helper launch count was '$launches'"
+  second=$(FM_BROWSER_RUNTIME_DIR="$dir/runtime" FM_BROWSER_PORT=19223 \
+    FM_BROWSER_BIN="$fallback" FM_TEST_BROWSER_MARKER="$marker" \
+    FM_TEST_BROWSER_LAUNCH_LOG="$dir/fallback-launched" PATH="$fakebin:$PATH" \
+    "$BROWSER_HELPER" url)
+  [ "$second" = 'http://127.0.0.1:19223' ] || fail "repeat url returned '$second'"
+  launches=$(wc -l < "$dir/preferred-launched")
+  [ "$launches" -eq 1 ] || fail "repeat url launched a second browser"
+  args=$(sed -n '1p' "$dir/preferred-launched")
+  assert_contains "$args" '--headless --no-sandbox --disable-gpu --disable-dev-shm-usage --remote-debugging-address=127.0.0.1' \
+    "browser launch omitted required flags"
+  assert_contains "$args" '--remote-debugging-port=19223' \
+    "browser launch omitted the configured debug port"
+  assert_contains "$args" "--user-data-dir=$dir/runtime/profile" \
+    "browser launch omitted the dedicated profile"
+  FM_BROWSER_RUNTIME_DIR="$dir/runtime" FM_BROWSER_PORT=19223 \
+    FM_TEST_BROWSER_MARKER="$marker" PATH="$fakebin:$PATH" \
+    "$BROWSER_HELPER" stop >/dev/null 2>&1 || fail "failed to stop the fake browser"
+  pass "discovery order selects FM_BROWSER_BIN before cached or PATH browsers"
+}
+
+test_concurrent_urls_start_one_browser() {
+  local dir fakebin marker browser out_a out_b pid_a pid_b launches
+  dir="$TMP_ROOT/concurrent"
+  fakebin=$(fm_fakebin "$dir")
+  make_fake_curl "$fakebin"
+  marker="$dir/ready"
+  browser="$dir/browser"
+  make_fake_browser "$browser"
+  : > "$dir/launch-a"
+  : > "$dir/launch-b"
+  (
+    FM_BROWSER_RUNTIME_DIR="$dir/runtime" FM_BROWSER_PORT=19227 \
+      FM_BROWSER_BIN="$browser" FM_TEST_BROWSER_MARKER="$marker" \
+      FM_TEST_BROWSER_LAUNCH_LOG="$dir/shared-launches" PATH="$fakebin:$PATH" \
+      "$BROWSER_HELPER" url >"$dir/out-a"
+  ) &
+  pid_a=$!
+  (
+    FM_BROWSER_RUNTIME_DIR="$dir/runtime" FM_BROWSER_PORT=19227 \
+      FM_BROWSER_BIN="$browser" FM_TEST_BROWSER_MARKER="$marker" \
+      FM_TEST_BROWSER_LAUNCH_LOG="$dir/shared-launches" PATH="$fakebin:$PATH" \
+      "$BROWSER_HELPER" url >"$dir/out-b"
+  ) &
+  pid_b=$!
+  wait "$pid_a" || fail "first concurrent url call failed"
+  wait "$pid_b" || fail "second concurrent url call failed"
+  out_a=$(cat "$dir/out-a")
+  out_b=$(cat "$dir/out-b")
+  [ "$out_a" = 'http://127.0.0.1:19227' ] || fail "first concurrent call returned '$out_a'"
+  [ "$out_b" = 'http://127.0.0.1:19227' ] || fail "second concurrent call returned '$out_b'"
+  launches=$(wc -l < "$dir/shared-launches")
+  [ "$launches" -eq 1 ] || fail "concurrent calls launched '$launches' browsers"
+  FM_BROWSER_RUNTIME_DIR="$dir/runtime" FM_BROWSER_PORT=19227 \
+    FM_TEST_BROWSER_MARKER="$marker" PATH="$fakebin:$PATH" \
+    "$BROWSER_HELPER" stop >/dev/null 2>&1 || fail "failed to stop the concurrent fake browser"
+  pass "concurrent callers share one machine-scoped browser lock and launch once"
+}
+
+test_missing_binary_refuses_without_url() {
+  local dir fakebin out err status
+  dir="$TMP_ROOT/missing"
+  fakebin=$(fm_fakebin "$dir")
+  make_fake_curl "$fakebin"
+  if out=$(FM_BROWSER_RUNTIME_DIR="$dir/runtime" FM_BROWSER_PORT=19224 \
+    FM_BROWSER_BIN="$dir/not-a-browser" HOME="$dir/home" \
+    FM_TEST_BROWSER_MARKER="$dir/never" PATH="$fakebin:/usr/bin:/bin" \
+    "$BROWSER_HELPER" url 2>"$dir/error"); then
+    status=0
+  else
+    status=$?
+  fi
+  err=$(cat "$dir/error")
+  [ "$status" -ne 0 ] || fail "missing browser unexpectedly succeeded"
+  [ -z "$out" ] || fail "missing browser printed a URL: $out"
+  assert_contains "$err" 'npx -y puppeteer@latest browsers install chrome' \
+    "missing browser error omitted the installation command"
+  pass "missing browser refuses with no URL and an actionable installation message"
+}
+
+test_stop_does_not_signal_unowned_pid() {
+  local dir fakebin out
+  dir="$TMP_ROOT/unowned-stop"
+  fakebin=$(fm_fakebin "$dir")
+  make_fake_curl "$fakebin"
+  mkdir -p "$dir/runtime"
+  {
+    printf 'pid=%s\n' "$$"
+    printf 'port=19225\n'
+    printf 'profile=%s\n' "$dir/not-owned-profile"
+  } > "$dir/runtime/pid"
+  out=$(FM_BROWSER_RUNTIME_DIR="$dir/runtime" FM_BROWSER_PORT=19225 \
+    FM_TEST_BROWSER_MARKER="$dir/never" PATH="$fakebin:$PATH" \
+    "$BROWSER_HELPER" stop)
+  [ "$out" = 'stopped=no-owned-browser' ] || fail "unowned stop returned '$out'"
+  kill -0 "$$" 2>/dev/null || fail "stop signaled the test process"
+  pass "stop refuses to signal a PID that is not the helper-owned browser"
+}
+
+test_probe_hit_reuses_without_launching
+test_discovery_prefers_explicit_binary
+test_concurrent_urls_start_one_browser
+test_missing_binary_refuses_without_url
+test_stop_does_not_signal_unowned_pid
+
+echo "# all fm-browser tests passed"

--- a/tests/fm-browser.test.sh
+++ b/tests/fm-browser.test.sh
@@ -99,6 +99,7 @@ test_concurrent_urls_start_one_browser() {
   browser="$dir/browser"
   make_fake_browser "$browser"
   mkdir -p "$dir/runtime/lock"
+  chmod 700 "$dir/runtime"
   printf '99999999\n' > "$dir/runtime/lock/pid"
   : > "$dir/launch-a"
   : > "$dir/launch-b"
@@ -157,6 +158,7 @@ test_stop_does_not_signal_unowned_pid() {
   fakebin=$(fm_fakebin "$dir")
   make_fake_curl "$fakebin"
   mkdir -p "$dir/runtime"
+  chmod 700 "$dir/runtime"
   {
     printf 'pid=%s\n' "$$"
     printf 'port=19225\n'
@@ -176,6 +178,7 @@ test_stale_lock_is_reclaimed() {
   fakebin=$(fm_fakebin "$dir")
   make_fake_curl "$fakebin"
   mkdir -p "$dir/runtime/lock"
+  chmod 700 "$dir/runtime"
   printf '99999999\n' > "$dir/runtime/lock/pid"
   out=$(FM_BROWSER_RUNTIME_DIR="$dir/runtime" FM_BROWSER_PORT=19228 \
     FM_TEST_BROWSER_MARKER="$dir/never" PATH="$fakebin:$PATH" \
@@ -191,11 +194,34 @@ test_stale_lock_is_reclaimed() {
   pass "dead and ownerless browser locks are claimed atomically"
 }
 
+test_insecure_runtime_dir_is_refused() {
+  local dir fakebin err status
+  dir="$TMP_ROOT/insecure-runtime"
+  fakebin=$(fm_fakebin "$dir")
+  make_fake_curl "$fakebin"
+  mkdir -p "$dir/runtime"
+  chmod 777 "$dir/runtime"
+  if FM_BROWSER_RUNTIME_DIR="$dir/runtime" FM_BROWSER_PORT=19229 \
+    FM_TEST_BROWSER_MARKER="$dir/never" PATH="$fakebin:$PATH" \
+    "$BROWSER_HELPER" stop >"$dir/output" 2>"$dir/error"; then
+    status=0
+  else
+    status=$?
+  fi
+  err=$(cat "$dir/error")
+  [ "$status" -ne 0 ] || fail "insecure runtime directory unexpectedly succeeded"
+  assert_contains "$err" 'not group/other-writable' \
+    "insecure runtime refusal omitted the permissions requirement"
+  [ ! -e "$dir/runtime/lock" ] || fail "insecure runtime directory was modified"
+  pass "group/other-writable runtime directories are refused"
+}
+
 test_probe_hit_reuses_without_launching
 test_discovery_prefers_explicit_binary
 test_concurrent_urls_start_one_browser
 test_missing_binary_refuses_without_url
 test_stop_does_not_signal_unowned_pid
 test_stale_lock_is_reclaimed
+test_insecure_runtime_dir_is_refused
 
 echo "# all fm-browser tests passed"

--- a/tests/fm-browser.test.sh
+++ b/tests/fm-browser.test.sh
@@ -98,6 +98,8 @@ test_concurrent_urls_start_one_browser() {
   marker="$dir/ready"
   browser="$dir/browser"
   make_fake_browser "$browser"
+  mkdir -p "$dir/runtime/lock"
+  printf '99999999\n' > "$dir/runtime/lock/pid"
   : > "$dir/launch-a"
   : > "$dir/launch-b"
   (

--- a/tests/fm-browser.test.sh
+++ b/tests/fm-browser.test.sh
@@ -168,10 +168,26 @@ test_stop_does_not_signal_unowned_pid() {
   pass "stop refuses to signal a PID that is not the helper-owned browser"
 }
 
+test_stale_lock_is_reclaimed() {
+  local dir fakebin out
+  dir="$TMP_ROOT/stale-lock"
+  fakebin=$(fm_fakebin "$dir")
+  make_fake_curl "$fakebin"
+  mkdir -p "$dir/runtime/lock"
+  printf '99999999\n' > "$dir/runtime/lock/pid"
+  out=$(FM_BROWSER_RUNTIME_DIR="$dir/runtime" FM_BROWSER_PORT=19228 \
+    FM_TEST_BROWSER_MARKER="$dir/never" PATH="$fakebin:$PATH" \
+    "$BROWSER_HELPER" stop)
+  [ "$out" = 'stopped=no-owned-browser' ] || fail "stale-lock stop returned '$out'"
+  [ ! -e "$dir/runtime/lock" ] || fail "stale lock was not released"
+  pass "dead lock owners are reclaimed before acquiring the browser lock"
+}
+
 test_probe_hit_reuses_without_launching
 test_discovery_prefers_explicit_binary
 test_concurrent_urls_start_one_browser
 test_missing_binary_refuses_without_url
 test_stop_does_not_signal_unowned_pid
+test_stale_lock_is_reclaimed
 
 echo "# all fm-browser tests passed"

--- a/tests/fm-browser.test.sh
+++ b/tests/fm-browser.test.sh
@@ -188,7 +188,7 @@ test_stale_lock_is_reclaimed() {
     "$BROWSER_HELPER" stop)
   [ "$out" = 'stopped=no-owned-browser' ] || fail "ownerless-lock stop returned '$out'"
   [ ! -e "$dir/runtime/lock" ] || fail "ownerless lock was not released"
-  pass "dead and ownerless browser locks are reclaimed"
+  pass "dead and ownerless browser locks are claimed atomically"
 }
 
 test_probe_hit_reuses_without_launching

--- a/tests/fm-trace-context-spawn.test.sh
+++ b/tests/fm-trace-context-spawn.test.sh
@@ -110,6 +110,10 @@ run_spawn() {
   shift 4
   : > "$launchlog"
   env -u FM_TRACE_CONTEXT \
+    HOME="$TMP_ROOT/no-browser-home" \
+    FM_BROWSER_PORT=19226 FM_BROWSER_BIN="$TMP_ROOT/no-browser-bin" \
+    FM_BROWSER_RUNTIME_DIR="$TMP_ROOT/spawn-browser-runtime" \
+    CHROME_DEVTOOLS_AXI_BROWSER_URL="${CHROME_DEVTOOLS_AXI_BROWSER_URL:-}" \
     FM_ROOT_OVERRIDE='' FM_HOME="$home" \
     FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
     FM_PROJECTS_OVERRIDE="$home/projects" FM_CONFIG_OVERRIDE="$home/config" \
@@ -128,6 +132,9 @@ run_spawn_tc() {
   shift 5
   : > "$launchlog"
   env FM_TRACE_CONTEXT="$tc" \
+    HOME="$TMP_ROOT/no-browser-home" \
+    FM_BROWSER_PORT=19226 FM_BROWSER_BIN="$TMP_ROOT/no-browser-bin" \
+    FM_BROWSER_RUNTIME_DIR="$TMP_ROOT/spawn-browser-runtime" \
     FM_ROOT_OVERRIDE='' FM_HOME="$home" \
     FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
     FM_PROJECTS_OVERRIDE="$home/projects" FM_CONFIG_OVERRIDE="$home/config" \
@@ -196,6 +203,9 @@ run_two_level() {
   smfake=$(make_spawn_fakebin "$base/sm-fake")
   : > "$smlog"
   env FM_TRACE_CONTEXT="$penv" \
+    HOME="$TMP_ROOT/no-browser-home" \
+    FM_BROWSER_PORT=19226 FM_BROWSER_BIN="$TMP_ROOT/no-browser-bin" \
+    FM_BROWSER_RUNTIME_DIR="$TMP_ROOT/spawn-browser-runtime" \
     FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$prim" \
     FM_STATE_OVERRIDE="$prim/state" FM_DATA_OVERRIDE="$prim/data" \
     FM_PROJECTS_OVERRIDE="$prim/projects" FM_CONFIG_OVERRIDE="$prim/config" \
@@ -222,6 +232,9 @@ run_two_level() {
   wfake=$(make_spawn_fakebin "$base/w-fake")
   : > "$wlog"
   env FM_TRACE_CONTEXT="$TL_ENV_TC" TRACEPARENT="$TL_CARRIER" \
+    HOME="$TMP_ROOT/no-browser-home" \
+    FM_BROWSER_PORT=19226 FM_BROWSER_BIN="$TMP_ROOT/no-browser-bin" \
+    FM_BROWSER_RUNTIME_DIR="$TMP_ROOT/spawn-browser-runtime" \
     FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$sm" \
     FM_STATE_OVERRIDE="$sm/state" FM_DATA_OVERRIDE="$sm/data" \
     FM_PROJECTS_OVERRIDE="$sm/projects" FM_CONFIG_OVERRIDE="$sm/config" \
@@ -560,6 +573,36 @@ test_secondmate_carrier_and_snapshot_share_one_decision() {
   pass "secondmate carrier and FM_TRACE_CONTEXT snapshot always agree, both derived from one frozen decision (file-decided path)"
 }
 
+test_missing_browser_does_not_fail_spawn() {
+  local rec out status
+  rec=$(make_spawn_case browser-missing)
+  read_case_record "$rec"
+  out=$(HOME="$TMP_ROOT/no-browser-home" \
+    FM_BROWSER_RUNTIME_DIR="$TMP_ROOT/no-browser-runtime" \
+    FM_BROWSER_BIN="$TMP_ROOT/no-browser-bin" \
+    run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$CASE_ID" "$PROJ_DIR")
+  status=$?
+  expect_code 0 "$status" "a missing browser must not fail spawn"
+  assert_contains "$out" "spawned $CASE_ID" "spawn should succeed without a browser"
+  ! grep -q '^export CHROME_DEVTOOLS_AXI_BROWSER_URL=' "$LAUNCH_LOG" \
+    || fail "spawn exported a browser URL after the helper refused"
+  pass "a missing browser is best-effort and leaves the spawn successful with no URL export"
+}
+
+test_ambient_browser_url_is_preserved() {
+  local rec out status
+  rec=$(make_spawn_case browser-ambient)
+  read_case_record "$rec"
+  out=$(CHROME_DEVTOOLS_AXI_BROWSER_URL='http://127.0.0.1:19999' \
+    run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$CASE_ID" "$PROJ_DIR")
+  status=$?
+  expect_code 0 "$status" "an ambient browser URL must not fail spawn"
+  assert_contains "$out" "spawned $CASE_ID" "ambient URL spawn should report success"
+  grep -q "^export CHROME_DEVTOOLS_AXI_BROWSER_URL='http://127.0.0.1:19999'$" "$LAUNCH_LOG" \
+    || fail "spawn did not preserve the ambient browser URL"
+  pass "spawn preserves an operator-provided CHROME_DEVTOOLS_AXI_BROWSER_URL"
+}
+
 test_enabled_records_and_injects_identical_carrier_before_launch
 test_disabled_writes_and_injects_neither
 test_failed_delivery_omits_metadata_and_still_launches
@@ -572,5 +615,7 @@ test_secondmate_env_on_file_absent_keeps_nested_worker_enabled
 test_secondmate_env_off_file_present_keeps_nested_worker_disabled
 test_two_routed_tasks_through_one_secondmate_root_distinct_traces
 test_secondmate_carrier_and_snapshot_share_one_decision
+test_missing_browser_does_not_fail_spawn
+test_ambient_browser_url_is_preserved
 
 echo "# all fm-trace-context-spawn tests passed"

--- a/tests/fm-trace-context-spawn.test.sh
+++ b/tests/fm-trace-context-spawn.test.sh
@@ -79,6 +79,21 @@ exit 0
 SH
   chmod +x "$fakebin/tmux"
   fm_fake_exit0 "$fakebin" treehouse
+  # This file never wants a real browser touched (browser discovery itself is
+  # covered by tests/fm-browser.test.sh). Every run_spawn/run_spawn_tc call
+  # points FM_BROWSER_BIN at a path that does not exist so fm-browser.sh's PATH
+  # fallback is what is actually exercised; shadow the candidate names here,
+  # ahead of the real PATH, so a runner with a real browser preinstalled (as
+  # hosted CI images commonly are) cannot make that fallback launch a genuine
+  # browser and defeat the missing-browser simulation.
+  local browser
+  for browser in google-chrome chromium chromium-browser; do
+    cat > "$fakebin/$browser" <<'SH'
+#!/usr/bin/env bash
+exit 1
+SH
+    chmod +x "$fakebin/$browser"
+  done
   printf '%s\n' "$fakebin"
 }
 


### PR DESCRIPTION
## Summary

chrome-devtools-axi's own browser launch fails on this machine with `Protocol error (Target.setDiscoverTargets): Target closed`, even for known-good local pages.

This adds `bin/fm-browser.sh`, a machine-scoped, singleton, loopback-only headless Chrome helper with probe-first reuse, ordered browser discovery, bounded startup failure, configurable port, status, and ownership-safe stop.

`fm-spawn.sh` now exports the verified `CHROME_DEVTOOLS_AXI_BROWSER_URL` to crewmate and secondmate launches on a best-effort basis, while preserving an operator-provided ambient value and allowing spawns to proceed when no browser is available.

## Verification

- Focused browser tests cover probe reuse, explicit binary precedence, concurrent singleton startup, missing-binary refusal, required loopback launch flags, and ownership-safe stop.
- Spawn tests cover browser refusal without task failure and ambient URL preservation.
- Documentation audience validation passed.
- Real Chrome verification passed on loopback port 19325: `chrome-devtools-axi open` returned the expected accessibility snapshot, and `screenshot` produced a valid PNG image (900 x 1000, 23099 bytes).
- The no-mistakes pipeline completed review, tests, and documentation; ShellCheck was unavailable in the environment, and push through the upstream remote was denied, so this PR is opened from the authorized public fork.
