### PR TITLE
fix(bin): extend worktree-isolation guards to scout briefs and teardown

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -499,7 +499,7 @@ Preserve durable structured identifiers, dependencies, and completion artifact l
 Use its scaffold as the contract, then replace every `{TASK}` placeholder with a clear task description, acceptance criteria, constraints, and necessary context before dispatch or seeding.
 Keep additions task-specific rather than repeating lifecycle instructions, and alter generated sections only when the task genuinely differs from the standard shape.
 
-Every ship brief must retain the worktree-isolation assertion and stop if launched in the primary checkout.
+Every ship and scout brief must retain the worktree-isolation assertion and stop if launched in the primary checkout.
 If a ship task touches firstmate's shared tracked material, explicitly require `firstmate-coding-guidelines` before editing.
 If a task will drive Herdr lifecycle behavior, scaffold with `--herdr-lab`; if that need appears after an unguarded scaffold, stop and regenerate rather than adding commands by hand.
 The generated Herdr contract must use a named non-`default` isolated lab and its guarded helper for every lifecycle action.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -409,7 +409,7 @@ A forced repair must use the home-scoped owner path emitted by supervision instr
 
 Guard warnings do not replace the contract.
 Queued wakes must be presented before other action and acknowledged only after handling, stale liveness must be repaired through the emitted protocol, and the worktree-tangle warning must be resolved without touching unlanded work.
-The spawn assertion and generated ship brief must both enforce that project work starts in an isolated disposable worktree, never the primary checkout.
+The spawn assertion and the generated ship and scout briefs must all enforce that project work starts in an isolated disposable worktree, never the primary checkout, and cleanup refuses when a task's recorded worktree is its project clone.
 Harness-aware turn-end guards are structural backstops, not permission to omit the live cycle.
 
 ### Away-mode stub

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -40,7 +40,8 @@
 # "Delivery contract: mode=<mode>" line. bin/fm-spawn.sh reads that line and refuses
 # to launch a ship task whose explicit --mode disagrees, so an adjusted brief and the
 # recorded task metadata cannot drift apart.
-# Ship briefs begin with a worktree-isolation assertion before the branch step.
+# Ship and scout briefs both begin with the same worktree-isolation assertion,
+# before the ship branch step and before the scout's scratch-worktree invitation.
 # --mode is refused on scout and secondmate scaffolds: a scout's deliverable is a
 # report rather than a merge, and a charter is not a delivery contract.
 # There is no --yolo flag here. The worker never owns approval decisions, so yolo is
@@ -298,6 +299,17 @@ EOF
 HERDR_SECTION=${HERDR_SECTION%$'\n'}
 fi
 
+# One isolation assertion, shared by the ship and scout scaffolds. A scout is
+# invited to install, run, and make scratch commits, and its teardown discards
+# the worktree, so a scout launched in the primary checkout is at least as
+# dangerous as a ship launched there (#1746).
+IFS= read -r -d '' ISOLATION_ASSERTION <<'EOF' || true
+**Verify isolation before anything else.** Run `pwd -P` and `git rev-parse --show-toplevel`; both must resolve to the disposable task worktree you were launched in, such as a treehouse pool path or an Orca-managed worktree, not the primary checkout firstmate operates from.
+The path check is authoritative: `git rev-parse --git-dir` and `git rev-parse --git-common-dir` can help inspect the repo, but they do not prove you are outside the primary checkout.
+If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not branch, commit, install, or write anything here - append `blocked: launched in primary checkout, not an isolated worktree` to the status file and stop.
+EOF
+ISOLATION_ASSERTION=${ISOLATION_ASSERTION%$'\n'}
+
 if [ "$KIND" = scout ]; then
 cat > "$BRIEF" <<EOF
 You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.
@@ -309,8 +321,11 @@ $HERDR_SECTION
 
 # Setup
 You are in a disposable git worktree of $REPO, at a detached HEAD on a clean default branch.
+
+$ISOLATION_ASSERTION
+
 This is a SCOUT task: the deliverable is a written report, not a PR.
-The worktree is your laboratory - install, run, edit, and make scratch commits freely; all of it is discarded at teardown.
+Once isolation is verified, the worktree is your laboratory - install, run, edit, and make scratch commits freely; all of it is discarded at teardown.
 The report is the only thing that survives, so anything worth keeping must be in it.
 
 # Rules
@@ -420,9 +435,7 @@ $HERDR_SECTION
 # Setup
 You are in a disposable git worktree of $REPO, at a detached HEAD on a clean default branch.
 
-**Verify isolation before anything else.** Run \`pwd -P\` and \`git rev-parse --show-toplevel\`; both must resolve to the disposable task worktree you were launched in, such as a treehouse pool path or an Orca-managed worktree, not the primary checkout firstmate operates from.
-The path check is authoritative: \`git rev-parse --git-dir\` and \`git rev-parse --git-common-dir\` can help inspect the repo, but they do not prove you are outside the primary checkout.
-If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not branch or commit here - append \`blocked: launched in primary checkout, not an isolated worktree\` to the status file and stop.
+$ISOLATION_ASSERTION
 
 1. First action: create your branch: \`git checkout -b fm/$ID\`$SETUP2
 

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -4,6 +4,10 @@
 # clear volatile state, refresh/prune the project's clone for PR-based ship
 # tasks, then print a backlog-refresh reminder for ship and scout teardowns
 # (a secondmate teardown prints none, since secondmates are not backlog items).
+# REFUSES outright, --force included, when a ship or scout task's recorded
+# worktree resolves to the same path as its project clone: the discard target
+# would be the primary checkout rather than a disposable worktree. Only a
+# secondmate home is legitimately its own worktree.
 # REFUSES if the worktree holds work that has not LANDED, because cleanup
 # hard-resets/removes the worktree and kills its processes. Work has landed when it is
 # reachable from any remote-tracking branch (a fork counts as a remote, so
@@ -456,6 +460,22 @@ KIND=$(grep '^kind=' "$META" | cut -d= -f2- || true)
 [ -n "$KIND" ] || KIND=ship
 MODE=$(grep '^mode=' "$META" | cut -d= -f2- || true)
 [ -n "$MODE" ] || MODE=no-mistakes
+
+# A secondmate home IS its own worktree, so worktree= and project= naming the
+# same path is correct there and only there. For a ship or scout task that
+# equality means the recorded discard target is the project's own clone: hard
+# resetting it, removing it, or killing its processes would operate on the
+# captain's checkout. Refuse before any destructive step, including under
+# --force: discard authority covers a task's work, never the clone it came
+# from (#1746).
+if [ "$KIND" != secondmate ] && [ -n "$WT" ] && [ -n "$PROJ" ]; then
+  WT_REAL=$(CDPATH='' cd -- "$WT" 2>/dev/null && pwd -P) || WT_REAL=$WT
+  PROJ_REAL=$(CDPATH='' cd -- "$PROJ" 2>/dev/null && pwd -P) || PROJ_REAL=$PROJ
+  if [ "$WT_REAL" = "$PROJ_REAL" ]; then
+    echo "REFUSED: $ID records the project clone '$PROJ' as its worktree, so cleanup would discard the primary checkout; preserving task state. Correct worktree= in $META before tearing down." >&2
+    exit 1
+  fi
+fi
 PUBLIC_FOLLOWUP_HOME=$FM_HOME
 PUBLIC_FOLLOWUP_STATE=$STATE
 PUBLIC_FOLLOWUP_WORK_HOME=main

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -200,6 +200,7 @@ family_for_basename() {
     fm-herdr-session-cleanup.test.sh|fm-send-resolve-key.test.sh|fm-send-strict.test.sh|fm-spawn-batch.test.sh|\
     fm-spawn-dispatch-profile.test.sh|\
     fm-trace-context-spawn.test.sh|fm-spawn-worktree-settle.test.sh|\
+    fm-scout-isolation.test.sh|\
     fm-teardown-endpoint-safety.test.sh)
       printf '%s\n' backend-dispatch
       ;;

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -160,6 +160,8 @@ For ship and scout work, `fm-spawn.sh` refuses to launch unless the resolved tas
 `fm-spawn.sh` also owns the base-freshness boundary for every fresh ship and scout: no worker starts until its clean task worktree matches the fetched tip of origin's resolved default branch, and any unsafe or unverifiable base stops the spawn.
 Its header owns the exact refusal mechanics, while `tests/fm-spawn-pool-base-freshen.test.sh` owns the portable regression coverage.
 
+`fm-teardown.sh` closes the same hole from the other end: when a ship or scout task's recorded `worktree=` resolves to the same path as its `project=`, cleanup refuses outright, `--force` included, before any process kill, worktree return, or state removal, because the discard target would be the primary checkout (only a secondmate home is legitimately its own worktree).
+
 The firstmate repo has one extra exposure because it can dispatch crewmates to work on itself.
 Its operating checkout (`FM_ROOT`) and the disposable crewmate worktrees are all linked git worktrees of the same repository, so the valid discriminator is branch state, not whether the checkout is linked.
 The primary checkout is healthy on its default branch, and linked worktrees or secondmate homes are healthy at detached HEAD.
@@ -168,7 +170,7 @@ Only a named non-default branch checked out in `FM_ROOT` is a worktree tangle.
 `fm-tangle-lib.sh` resolves the default branch from `origin/HEAD`, then local `main` or `master`, and classifies that named non-default primary branch as the tangle.
 `fm-guard.sh` prints the repair command on the next mutable fleet action, while `bin/fm-session-start.sh` reports the same condition through bootstrap as a `TANGLE:` line at session start.
 If another live session holds the fleet lock, both surfaces keep the alarm but switch to read-only wording with no repair command.
-Ship briefs also tell the crewmate to verify `pwd -P` and `git rev-parse --show-toplevel` before creating `fm/<id>`, then stop with a blocked status if it landed in the primary checkout.
+Ship and scout briefs both open with the same assertion telling the crewmate to verify `pwd -P` and `git rev-parse --show-toplevel` before it branches, commits, or installs anything, then stop with a blocked status if it landed in the primary checkout.
 
 ## No-mistakes gate authority boundary
 

--- a/tests/fm-public-followup.test.sh
+++ b/tests/fm-public-followup.test.sh
@@ -593,7 +593,8 @@ test_secondmate_teardown_requires_parent_binding() {
   fm_write_meta "$parent/state/mate.meta" "kind=secondmate" "home=$child"
   fm_write_meta "$child/state/work-child.meta" \
     "window=firstmate:fm-work-child" "endpoint_task_id=work-child" \
-    "worktree=$child" "project=$child" "kind=ship" "mode=local-only"
+    "worktree=$child/projects/alpha-wt" "project=$child/projects/alpha" \
+    "kind=ship" "mode=local-only"
 
   PATH="$child/fakebin:$PATH" FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$child" \
     FM_STATE_OVERRIDE="$child/state" FM_DATA_OVERRIDE="$child/data" \
@@ -617,7 +618,8 @@ test_secondmate_teardown_requires_parent_binding() {
   fm_write_meta "$parent/state/mate.meta" "kind=secondmate" "home=$child"
   fm_write_meta "$child/state/work-child.meta" \
     "window=firstmate:fm-work-child" "endpoint_task_id=work-child" \
-    "worktree=$child" "project=$child" "kind=ship" "mode=local-only"
+    "worktree=$child/projects/alpha-wt" "project=$child/projects/alpha" \
+    "kind=ship" "mode=local-only"
   assert_absent "$child/.fm-secondmate-parent" \
     "the legacy env-only binding case must not gain a durable parent record"
 
@@ -726,7 +728,8 @@ test_secondmate_teardown_resolves_parent_from_durable_record_when_env_lost() {
   fm_write_meta "$parent/state/mate.meta" "kind=secondmate" "home=$child"
   fm_write_meta "$child/state/work-child.meta" \
     "window=firstmate:fm-work-child" "endpoint_task_id=work-child" \
-    "worktree=$child" "project=$child" "kind=ship" "mode=local-only"
+    "worktree=$child/projects/alpha-wt" "project=$child/projects/alpha" \
+    "kind=ship" "mode=local-only"
 
   # No FM_PUBLIC_FOLLOWUP_PRIMARY_HOME at all here: a restart of the secondmate
   # agent that drops the launch-time prefix must still find the real parent
@@ -759,7 +762,8 @@ test_secondmate_teardown_durable_record_missing_parent_registration_still_refuse
   assert_local_secondmate_parent_record "$child" "$parent_resolved"
   fm_write_meta "$child/state/work-child.meta" \
     "window=firstmate:fm-work-child" "endpoint_task_id=work-child" \
-    "worktree=$child" "project=$child" "kind=ship" "mode=local-only"
+    "worktree=$child/projects/alpha-wt" "project=$child/projects/alpha" \
+    "kind=ship" "mode=local-only"
   # No parent/state/mate.meta at all: the parent never recorded this secondmate's
   # own agent, so its side of the binding is genuinely missing. A durable LOCAL
   # record naming the real parent path must not be enough on its own to bypass
@@ -792,11 +796,11 @@ test_secondmate_teardown_durable_record_with_unknown_field_succeeds() {
   parent_alias="$TMP_ROOT/teardown-durable-clean-parent-alias"
   ln -s "$parent" "$parent_alias"
   fm_write_meta "$parent/state/mate.meta" "kind=secondmate" "home=$child"
-  fm_git_init_commit "$child/projects/worktree"
+  fm_git_worktree "$child/projects/worktree" "$child/projects/wt" fm/task-x1
   printf 'manual\n' > "$child/config/backlog-backend"
   fm_write_meta "$child/state/work-clean.meta" \
     "window=firstmate:fm-work-clean" "endpoint_task_id=work-clean" \
-    "worktree=$child/projects/worktree" "project=$child/projects/worktree" \
+    "worktree=$child/projects/wt" "project=$child/projects/worktree" \
     "kind=ship" "mode=local-only"
 
   rc=0
@@ -824,11 +828,11 @@ test_secondmate_teardown_rejects_conflicting_live_and_durable_parent_bindings() 
   fm_fake_exit0 "$child/fakebin" tmux treehouse no-mistakes gh gh-axi
   assert_local_secondmate_parent_record "$child" "$parent_resolved"
   fm_write_meta "$durable_parent/state/mate.meta" "kind=secondmate" "home=$child"
-  fm_git_init_commit "$child/projects/worktree"
+  fm_git_worktree "$child/projects/worktree" "$child/projects/wt" fm/task-x1
   printf 'manual\n' > "$child/config/backlog-backend"
   fm_write_meta "$child/state/work-conflict.meta" \
     "window=firstmate:fm-work-conflict" "endpoint_task_id=work-conflict" \
-    "worktree=$child/projects/worktree" "project=$child/projects/worktree" \
+    "worktree=$child/projects/wt" "project=$child/projects/worktree" \
     "kind=ship" "mode=local-only"
 
   PATH="$child/fakebin:$PATH" FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$child" \
@@ -856,7 +860,8 @@ test_secondmate_teardown_rejects_unsafe_durable_parent_records() {
     fm_fake_exit0 "$child/fakebin" tmux treehouse no-mistakes gh gh-axi
     fm_write_meta "$child/state/work-child.meta" \
       "window=firstmate:fm-work-child" "endpoint_task_id=work-child" \
-      "worktree=$child" "project=$child" "kind=ship" "mode=local-only"
+      "worktree=$child/projects/alpha-wt" "project=$child/projects/alpha" \
+    "kind=ship" "mode=local-only"
     parent_record="$child/.fm-secondmate-parent"
     case "$case_name" in
       symlink)
@@ -918,11 +923,11 @@ test_secondmate_teardown_rejects_nul_bearing_durable_parent_record() {
   fm_fake_exit0 "$child/fakebin" tmux treehouse no-mistakes gh gh-axi
   assert_local_secondmate_parent_record "$child" "$parent_resolved"
   fm_write_meta "$parent/state/mate.meta" "kind=secondmate" "home=$child"
-  fm_git_init_commit "$child/projects/worktree"
+  fm_git_worktree "$child/projects/worktree" "$child/projects/wt" fm/task-x1
   printf 'manual\n' > "$child/config/backlog-backend"
   fm_write_meta "$child/state/work-child.meta" \
     "window=firstmate:fm-work-child" "endpoint_task_id=work-child" \
-    "worktree=$child/projects/worktree" "project=$child/projects/worktree" \
+    "worktree=$child/projects/wt" "project=$child/projects/worktree" \
     "kind=ship" "mode=local-only"
   pre=${parent_resolved%??????}
   suf=${parent_resolved#"$pre"}
@@ -949,7 +954,7 @@ test_secondmate_teardown_rejects_nul_bearing_durable_parent_record() {
 test_relay_disabled_unmarked_teardown_skips_public_path() {
   local home tasks_log out rc
   home=$(make_home teardown-disabled-unmarked relay-off)
-  fm_git_init_commit "$home/projects/worktree"
+  fm_git_worktree "$home/projects/worktree" "$home/projects/wt" fm/task-x1
   tasks_log="$home/tasks-axi.log"; : > "$tasks_log"
   printf 'manual\n' > "$home/config/backlog-backend"
   cat > "$home/fakebin/tasks-axi" <<'SH'
@@ -960,7 +965,7 @@ SH
   chmod +x "$home/fakebin/tasks-axi"
   fm_write_meta "$home/state/work-disabled.meta" \
     "window=firstmate:fm-work-disabled" "endpoint_task_id=work-disabled" \
-    "worktree=$home/projects/worktree" "project=$home/projects/worktree" \
+    "worktree=$home/projects/wt" "project=$home/projects/worktree" \
     "kind=ship" "mode=local-only"
 
   rc=0
@@ -981,7 +986,7 @@ test_relay_disabled_parent_allows_marked_child_teardown() {
   local parent child tasks_log out rc
   parent=$(make_home teardown-disabled-parent relay-off)
   child=$(make_home teardown-disabled-child relay-off)
-  fm_git_init_commit "$child/projects/worktree"
+  fm_git_worktree "$child/projects/worktree" "$child/projects/wt" fm/task-x1
   printf '%s\n' disabled-mate > "$child/.fm-secondmate-home"
   printf -- '- disabled-mate - synthetic (home: %s; scope: synthetic; projects: ; added 2026-07-30)\n' \
     "$child" > "$parent/data/secondmates.md"
@@ -996,7 +1001,7 @@ SH
   chmod +x "$child/fakebin/tasks-axi"
   fm_write_meta "$child/state/work-disabled.meta" \
     "window=firstmate:fm-work-disabled" "endpoint_task_id=work-disabled" \
-    "worktree=$child/projects/worktree" "project=$child/projects/worktree" \
+    "worktree=$child/projects/wt" "project=$child/projects/worktree" \
     "kind=ship" "mode=local-only"
 
   rc=0
@@ -1025,7 +1030,8 @@ test_secondmate_parent_binding_matches_literal_id() {
   fm_write_meta "$parent/state/mate.id.meta" "kind=secondmate" "home=$child"
   fm_write_meta "$child/state/work-literal.meta" \
     "window=firstmate:fm-work-literal" "endpoint_task_id=work-literal" \
-    "worktree=$child" "project=$child" "kind=ship" "mode=local-only"
+    "worktree=$child/projects/alpha-wt" "project=$child/projects/alpha" \
+    "kind=ship" "mode=local-only"
 
   PATH="$child/fakebin:$PATH" FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$child" \
     FM_STATE_OVERRIDE="$child/state" FM_DATA_OVERRIDE="$child/data" \

--- a/tests/fm-remote-secondmate-parent-binding.test.sh
+++ b/tests/fm-remote-secondmate-parent-binding.test.sh
@@ -219,12 +219,13 @@ case "$DELIVERED" in
 esac
 
 # --- a finished child worker inside the remote secondmate home --------------
-CHILD_WT="$REMOTE_HOME/projects/alpha"
+CHILD_PROJ="$REMOTE_HOME/projects/alpha"
+CHILD_WT="$REMOTE_HOME/projects/alpha-wt"
 mkdir -p "$REMOTE_HOME/state"
 write_child_meta() {
   fm_write_meta "$REMOTE_HOME/state/work-child.meta" \
     "window=firstmate:fm-work-child" "endpoint_task_id=work-child" \
-    "worktree=$CHILD_WT" "project=$CHILD_WT" "harness=codex" "kind=ship" \
+    "worktree=$CHILD_WT" "project=$CHILD_PROJ" "harness=codex" "kind=ship" \
     "mode=local-only" "yolo=off"
 }
 mkdir -p "$TMP_ROOT/childfake"

--- a/tests/fm-scout-isolation.test.sh
+++ b/tests/fm-scout-isolation.test.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+# Regression tests for scout worktree isolation (#1746).
+#
+# A scout brief invites the worker to install, run, and make scratch commits in
+# its worktree, and teardown discards that worktree. When the recorded worktree
+# is the project's own clone instead of a disposable one, all three of those
+# become operations on the captain's primary checkout. These tests pin the
+# three guards that keep that impossible:
+#   - bin/fm-brief.sh --scout emits the isolation assertion ship briefs carry.
+#   - bin/fm-spawn.sh --scout refuses when the resolved path is not a real
+#     worktree distinct from the project, and writes no metadata.
+#   - bin/fm-teardown.sh refuses, --force included, when the recorded worktree
+#     resolves to the same path as the recorded project.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+BRIEF="$ROOT/bin/fm-brief.sh"
+SPAWN="$ROOT/bin/fm-spawn.sh"
+TEARDOWN="$ROOT/bin/fm-teardown.sh"
+TMP_ROOT=$(fm_test_tmproot fm-scout-isolation)
+
+# --- brief ------------------------------------------------------------------
+
+test_scout_brief_carries_the_isolation_assertion() {
+  local home="$TMP_ROOT/brief/home" id=scout-brief-a1 out
+  mkdir -p "$home/data" "$home/state"
+  FM_HOME="$home" FM_ROOT_OVERRIDE="$ROOT" \
+    FM_DATA_OVERRIDE="$home/data" FM_STATE_OVERRIDE="$home/state" \
+    "$BRIEF" "$id" some-repo --scout > /dev/null
+  out=$(cat "$home/data/$id/brief.md")
+  assert_contains "$out" 'Verify isolation before anything else' \
+    "scout brief has no isolation assertion"
+  assert_contains "$out" 'git rev-parse --show-toplevel' \
+    "scout brief does not tell the worker how to verify isolation"
+  assert_contains "$out" 'blocked: launched in primary checkout, not an isolated worktree' \
+    "scout brief does not tell the worker to stop and report"
+  pass "a scout brief carries the same isolation assertion a ship brief does"
+}
+
+# --- spawn ------------------------------------------------------------------
+
+# A fake tmux whose pane_current_path always reports FM_FAKE_PANE_PATH, standing
+# in for a `treehouse get` that left the pane somewhere that is not a real
+# worktree of its own.
+make_spawn_fakebin() {  # <dir>
+  local dir=$1 fakebin
+  fakebin=$(fm_fakebin "$dir")
+  cat > "$fakebin/tmux" <<'SH'
+#!/usr/bin/env bash
+set -u
+case "$*" in
+  *"#{pane_current_path}"*) printf '%s\n' "${FM_FAKE_PANE_PATH:-}"; exit 0 ;;
+esac
+case "${1:-}" in
+  display-message) printf 'firstmate\n'; exit 0 ;;
+  *) exit 0 ;;
+esac
+SH
+  chmod +x "$fakebin/tmux"
+  fm_fake_exit0 "$fakebin" treehouse
+  printf '%s\n' "$fakebin"
+}
+
+test_scout_spawn_refuses_a_path_that_is_not_its_own_worktree() {
+  local case_dir="$TMP_ROOT/spawn" home proj wt fakebin id=scout-spawn-b2 out status
+  home="$case_dir/home"
+  proj="$case_dir/project"
+  wt="$case_dir/wt"
+  mkdir -p "$home/data/$id" "$home/projects" "$home/state" "$home/config"
+  printf 'codex\n' > "$home/config/crew-harness"
+  fm_git_worktree "$proj" "$wt" wt-scout
+  printf 'brief for %s\n' "$id" > "$home/data/$id/brief.md"
+  touch "$home/state/.last-watcher-beat"
+  mkdir -p "$proj/scratch"
+  fakebin=$(make_spawn_fakebin "$case_dir/fake")
+
+  set +e
+  out=$(FM_ROOT_OVERRIDE='' FM_HOME="$home" \
+    FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
+    FM_PROJECTS_OVERRIDE="$home/projects" FM_CONFIG_OVERRIDE="$home/config" \
+    FM_SPAWN_NO_GUARD=1 TMUX="fake,1,0" \
+    FM_FAKE_PANE_PATH="$proj/scratch" PATH="$fakebin:$PATH" \
+    "$SPAWN" "$id" "$proj" --scout 2>&1)
+  status=$?
+  set -e
+  [ "$status" -ne 0 ] || fail "scout spawn succeeded from a non-worktree path: $out"
+  assert_contains "$out" 'did not yield an isolated worktree' \
+    "scout spawn did not refuse with the isolation error"
+  assert_absent "$home/state/$id.meta" \
+    "scout spawn recorded metadata for a non-isolated worktree"
+  pass "a scout spawn that cannot resolve its own worktree refuses and records nothing"
+}
+
+# --- teardown ---------------------------------------------------------------
+
+make_teardown_case() {  # <name>
+  local name=$1 dir fakebin
+  dir="$TMP_ROOT/teardown/$name"
+  mkdir -p "$dir/home/state" "$dir/home/data" "$dir/home/config" "$dir/project"
+  : > "$dir/project/sentinel"
+  : > "$dir/runtime.log"
+  fakebin=$(fm_fakebin "$dir")
+  cat > "$fakebin/tmux" <<'SH'
+#!/usr/bin/env bash
+printf 'tmux %s\n' "$*" >> "${FM_RUNTIME_LOG:?}"
+exit 0
+SH
+  cat > "$fakebin/treehouse" <<'SH'
+#!/usr/bin/env bash
+printf 'treehouse %s\n' "$*" >> "${FM_RUNTIME_LOG:?}"
+exit 0
+SH
+  chmod +x "$fakebin/tmux" "$fakebin/treehouse"
+  printf '%s\n' "$dir"
+}
+
+assert_teardown_refuses_clone_as_worktree() {  # <name> <kind> <force...>
+  local name=$1 kind=$2 dir id=clone-as-wt out status
+  shift 2
+  dir=$(make_teardown_case "$name")
+  fm_write_meta "$dir/home/state/$id.meta" \
+    "window=firstmate:fm-$id" \
+    "endpoint_task_id=$id" \
+    "worktree=$dir/project" \
+    "project=$dir/project" \
+    "kind=$kind"
+  set +e
+  out=$(FM_HOME="$dir/home" FM_ROOT_OVERRIDE="$ROOT" \
+    FM_RUNTIME_LOG="$dir/runtime.log" PATH="$dir/fakebin:$PATH" \
+    "$TEARDOWN" "$id" "$@" 2>&1)
+  status=$?
+  set -e
+  [ "$status" -ne 0 ] || fail "$name: teardown accepted the clone as its discard target"
+  assert_contains "$out" 'REFUSED' "$name: teardown did not refuse loudly"
+  assert_contains "$out" 'records the project clone' \
+    "$name: teardown refused for some other reason, not the clone-as-worktree record"
+  assert_present "$dir/project/sentinel" "$name: the clone was touched before refusal"
+  assert_present "$dir/home/state/$id.meta" "$name: task state was cleared before refusal"
+  [ ! -s "$dir/runtime.log" ] || fail "$name: a runtime command ran before refusal: $(cat "$dir/runtime.log")"
+}
+
+test_teardown_refuses_when_the_worktree_is_the_clone() {
+  assert_teardown_refuses_clone_as_worktree scout scout
+  assert_teardown_refuses_clone_as_worktree ship ship
+  pass "cleanup refuses when the recorded worktree is the project clone"
+}
+
+test_teardown_refuses_the_clone_even_under_force() {
+  assert_teardown_refuses_clone_as_worktree forced scout --force
+  pass "discard authority never extends to the project clone"
+}
+
+test_scout_brief_carries_the_isolation_assertion
+test_scout_spawn_refuses_a_path_that_is_not_its_own_worktree
+test_teardown_refuses_when_the_worktree_is_the_clone
+test_teardown_refuses_the_clone_even_under_force
+
+echo "# all fm-scout-isolation tests passed"


### PR DESCRIPTION
Closes #1746.

## The four suggested directions

The issue proposes four. Three are now in place; the fourth is deliberately out of scope.

**1. Give the scout scaffold the same isolation assertion ship briefs have.** Done, in `bin/fm-brief.sh`.
Rather than copying the ship wording, both scaffolds now render one shared `ISOLATION_ASSERTION` string,
so they cannot drift apart again — drift is how this defect arose in the first place. The assertion is
placed *ahead* of the scout's "the worktree is your laboratory — install, run, edit, and make scratch
commits freely" invitation, and its STOP clause was widened from "do not branch or commit here" to
"do not branch, commit, install, or write anything here", because a scout is invited to install and run,
not only to commit.

**2. Make `fm-spawn` fail closed for `--scout` when it cannot resolve a worktree distinct from the
project clone.** This already holds on `main`: `validate_spawn_worktree()` in `bin/fm-spawn.sh` refuses
when the resolved worktree path equals the primary checkout path, and it has no ship/scout branching.
No production change was needed and none was made. What this PR adds is a test that pins the behaviour
*on the scout path* so it cannot regress — see the note on the near-duplicate test below.

**3. Have teardown refuse outright when the recorded worktree resolves to the same path as the project
clone.** Done, in `bin/fm-teardown.sh`. The refusal lands before any endpoint kill, worktree return, or
state removal, and `--force` does not bypass it: discard authority covers a task's own work, never the
clone that work came from. `kind=secondmate` is exempt because a secondmate home legitimately *is* its
own worktree — `bin/fm-spawn.sh` is the only production writer of `worktree=` equal to `project=`.

**4. Reconcile the recorded worktree against the pane's real `cwd` at spawn time — deliberately left
out.** It is a genuinely different failure mode: not "the clone was recorded", but "a real worktree was
recorded and the agent then did not adopt it" (row 1 of the issue's evidence table). Closing it needs
per-backend live `cwd` polling at spawn, which is a different change with a different risk profile and
deserves its own review. The two guards here already make every row in that table safe to clean up,
which was the issue's own stated bar for direction 3. The leaked pool slot the issue notes under
consequence 2 is attributed upstream to #1441 and is likewise not addressed here.

## Why this is not theoretical

On 2026-08-06 a scout in our fleet created a `scratch/` directory **in the captain's primary checkout**
and reported a clean result from unisolated code. It was read-only, so nothing was lost. It surfaced only
because that particular brief happened to demand a path line — nothing in the tooling would have caught
it, which is precisely the gap direction 1 closes.

## The test that fails when the guard is removed

`tests/fm-scout-isolation.test.sh` is new, registered in `bin/fm-test-run.sh`. Deleting the
clone-as-worktree guard from `bin/fm-teardown.sh` and re-running the suite fails exactly one case:

```
not ok - scout: teardown refused for some other reason, not the clone-as-worktree record
         (missing: 'records the project clone')
```

The other three cases continue to pass, so the failure isolates the guard rather than the fixture.

## A note on one near-duplicate test

Automated review flagged `test_scout_spawn_refuses_a_path_that_is_not_its_own_worktree` as duplicating
`test_spawn_isolation_abort` in `tests/fm-tangle-guard.test.sh`, on the grounds that
`validate_spawn_worktree` is kind-agnostic and so `--scout` adds no line coverage. That observation is
correct, and we kept the case anyway — so the reasoning should be visible rather than left as an
unexplained near-duplicate.

The case does not exist to cover lines; it exists to pin that the guard applies **on the scout path
specifically**. The guard being kind-agnostic today is exactly what makes the pin cheap now and valuable
later: the day someone adds a kind-aware or scout-only branch, this is the test that fails. Coverage
cannot express that property, because the lines are the same lines — what is being pinned is *which
callers reach them*. And the defect being fixed here is itself a rule enforced on one path and absent
from another, so a differential pin is the natural anti-regression for the whole class. If you would
rather see it as a `--scout` row on the existing table in `fm-tangle-guard.test.sh`, or dropped
outright, say so and we will move it.

## One limit this change does not close

A linked git worktree does not isolate a third-party tool that resolves the repository root through the
`.git` **file** pointing back into the primary clone. We hit this while preparing this contribution: a
TypeScript build run inside a correctly isolated worktree wrote its cache directory into the primary
clone anyway, at the minute it ran. Every path check — including the ones added here — passes in that
case, because the worktree genuinely *is* isolated by every measure `pwd -P` and `git rev-parse` can see.

This change closes the spawn and cleanup paths. It does not close that one, and no assertion of this
shape can.

---

## What Changed

- `bin/fm-brief.sh` now builds the worktree-isolation assertion once and emits it in both the ship and scout scaffolds, so a scout stops with a `blocked: launched in primary checkout, not an isolated worktree` status before it branches, commits, or installs; the shared wording also covers installing/writing, and the scout's "laboratory" invitation is gated behind verifying isolation first.
- `bin/fm-teardown.sh` resolves a task's recorded `worktree=` and `project=` with `pwd -P` and refuses with a `REFUSED:` message and exit 1 when they are the same path for a ship or scout task, before any process kill, worktree return, or state removal, and `--force` does not bypass it; secondmate teardowns are exempt because a secondmate home legitimately is its own worktree.
- Added `tests/fm-scout-isolation.test.sh` (registered in the `backend-dispatch` family in `bin/fm-test-run.sh`) covering the scout brief assertion, scout spawn refusal on a non-worktree path, and teardown refusal on a clone with and without `--force`; existing teardown fixtures in `tests/fm-public-followup.test.sh` and `tests/fm-remote-secondmate-parent-binding.test.sh` were updated to record a worktree distinct from the project clone, and `AGENTS.md` / `docs/architecture.md` document both guards.

## Risk Assessment

✅ Low: The source change is narrow and fail-closed - the teardown guard refuses before any destructive step while preserving all task state, the brief refactor is a text extraction with no behavior change, and an exhaustive scan confirmed the fix round's fixture sweep left no teardown-invoking test with worktree= equal to project=; the remaining findings are test-selection and test-duplication issues that are safe to address as follow-ups.

## Testing

<code>Exercised the change the way an operator hits it: generated a real scout brief and drove fm-teardown.sh on a task whose meta records the project clone as its worktree, at both the base and target commits. Before the fix the scout brief carried no isolation assertion and `fm-teardown.sh &lt;id&gt; --force` completed, running `treehouse return --force &lt;project clone&gt;`, killing the window and deleting task state; after the fix the brief opens with the isolation assertion and teardown refuses with a clear REFUSED message both plain and under --force, executing no runtime command and preserving the meta. The new fm-scout-isolation suite passes and fails as expected against base bin/, the runner registers it under backend-dispatch, and the neighbouring brief/teardown/secondmate suites touched by the meta-fixture changes all pass. No UI surface is involved — this is CLI/brief-generation behavior, so evidence is CLI transcripts and generated brief text rather than screenshots.</code>

<details>
<summary>Evidence: Teardown refuses the project clone as discard target (base vs target, plain and --force)</summary>

<code>=== BEFORE fix (70aeba8) — with --force ===&#10;teardown scout-1746 complete (window firstmate:fm-scout-1746, worktree /tmp/fm1746-before-force.c7Q5X9/project)&#10;runtime commands run : 2 -&gt; treehouse return --force /tmp/fm1746-before-force.c7Q5X9/project;tmux kill-window -t =firstmate:=fm-scout-1746;&#10;task meta : REMOVED&#10;&#10;=== AFTER fix (954cb14) — with --force ===&#10;REFUSED: scout-1746 records the project clone &#39;/tmp/fm1746-after-force.LZLonx/project&#39; as its worktree, so cleanup would discard the primary checkout; preserving task state. Correct worktree= in .../state/scout-1746.meta before tearing down.&#10;[exit 1]&#10;runtime commands run : 0 -&gt;&#10;task meta : preserved</code>

```text
Scenario (#1746): scout task scout-1746 whose meta records the project clone as worktree=.
The clone is clean, has committed captain work, and the scout report exists, so nothing else blocks cleanup.

=== BEFORE fix: bin/fm-teardown.sh at base 70aeba8 ===
== task state before teardown ==
   window=firstmate:fm-scout-1746
   endpoint_task_id=scout-1746
   worktree=/tmp/fm1746-before.42QP0R/project
   project=/tmp/fm1746-before.42QP0R/project
   kind=scout
   mode=local-only
== fm-teardown.sh scout-1746  ==
   fm-decision-hold: compatible tasks-axi is required
   REFUSED: scout task scout-1746 has not passed the unresolved-decision completion gate.
   Inventory its report and any visual review through bin/fm-decision-hold.sh before teardown.
   [exit 1]
== aftermath ==
   project clone present : yes
   captain's file        : intact
   runtime commands run  : 0 -> 
   task meta             : preserved

== task state before teardown ==
   window=firstmate:fm-scout-1746
   endpoint_task_id=scout-1746
   worktree=/tmp/fm1746-before-force.c7Q5X9/project
   project=/tmp/fm1746-before-force.c7Q5X9/project
   kind=scout
   mode=local-only
== fm-teardown.sh scout-1746 --force ==
   teardown scout-1746 complete (window firstmate:fm-scout-1746, worktree /tmp/fm1746-before-force.c7Q5X9/project)
   Backlog: scout-1746 just finished. Update data/backlog.md - move scout-1746 to Done, keep Done to the 10 most recent, then re-scan Queued and dispatch only work whose blockers are gone and date is due.
   [exit 0]
== aftermath ==
   project clone present : yes
   captain's file        : intact
   runtime commands run  : 2 -> treehouse return --force /tmp/fm1746-before-force.c7Q5X9/project;tmux kill-window -t =firstmate:=fm-scout-1746;
   task meta             : REMOVED

=== AFTER fix: bin/fm-teardown.sh at 954cb14 ===
== task state before teardown ==
   window=firstmate:fm-scout-1746
   endpoint_task_id=scout-1746
   worktree=/tmp/fm1746-after.oX7gov/project
   project=/tmp/fm1746-after.oX7gov/project
   kind=scout
   mode=local-only
== fm-teardown.sh scout-1746  ==
   REFUSED: scout-1746 records the project clone '/tmp/fm1746-after.oX7gov/project' as its worktree, so cleanup would discard the primary checkout; preserving task state. Correct worktree= in /tmp/fm1746-after.oX7gov/home/state/scout-1746.meta before tearing down.
   [exit 1]
== aftermath ==
   project clone present : yes
   captain's file        : intact
   runtime commands run  : 0 -> 
   task meta             : preserved

== task state before teardown ==
   window=firstmate:fm-scout-1746
   endpoint_task_id=scout-1746
   worktree=/tmp/fm1746-after-force.LZLonx/project
   project=/tmp/fm1746-after-force.LZLonx/project
   kind=scout
   mode=local-only
== fm-teardown.sh scout-1746 --force ==
   REFUSED: scout-1746 records the project clone '/tmp/fm1746-after-force.LZLonx/project' as its worktree, so cleanup would discard the primary checkout; preserving task state. Correct worktree= in /tmp/fm1746-after-force.LZLonx/home/state/scout-1746.meta before tearing down.
   [exit 1]
== aftermath ==
   project clone present : yes
   captain's file        : intact
   runtime commands run  : 0 -> 
   task meta             : preserved
```
</details>
<details>
<summary>Evidence: Generated scout brief now opens with the isolation assertion</summary>

<code>$ bin/fm-brief.sh scout-1746 my-repo --scout # Setup section of data/scout-1746/brief.md&#10;&#10;# Setup&#10;You are in a disposable git worktree of my-repo, at a detached HEAD on a clean default branch.&#10;&#10;**Verify isolation before anything else.** Run `pwd -P` and `git rev-parse --show-toplevel`; both must resolve to the disposable task worktree you were launched in ... not the primary checkout firstmate operates from.&#10;The path check is authoritative: `git rev-parse --git-dir` and `git rev-parse --git-common-dir` can help inspect the repo, but they do not prove you are outside the primary checkout.&#10;If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not branch, commit, install, or write anything here - append `blocked: launched in primary checkout, not an isolated worktree` to the status file and stop.&#10;&#10;This is a SCOUT task: the deliverable is a written report, not a PR.&#10;Once isolation is verified, the worktree is your laboratory - install, run, edit, and make scratch commits freely; all of it is discarded at teardown.</code>

```text
$ bin/fm-brief.sh scout-1746 my-repo --scout   # Setup section of the generated scout brief (data/scout-1746/brief.md)

# Setup
You are in a disposable git worktree of my-repo, at a detached HEAD on a clean default branch.

**Verify isolation before anything else.** Run `pwd -P` and `git rev-parse --show-toplevel`; both must resolve to the disposable task worktree you were launched in, such as a treehouse pool path or an Orca-managed worktree, not the primary checkout firstmate operates from.
The path check is authoritative: `git rev-parse --git-dir` and `git rev-parse --git-common-dir` can help inspect the repo, but they do not prove you are outside the primary checkout.
If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not branch, commit, install, or write anything here - append `blocked: launched in primary checkout, not an isolated worktree` to the status file and stop.

This is a SCOUT task: the deliverable is a written report, not a PR.
Once isolation is verified, the worktree is your laboratory - install, run, edit, and make scratch commits freely; all of it is discarded at teardown.
The report is the only thing that survives, so anything worth keeping must be in it.
```
</details>
<details>
<summary>Evidence: Same scout brief at base commit — no assertion (regression proof)</summary>

<code>not ok - scout brief has no isolation assertion (missing: &#39;Verify isolation before anything else&#39;)&#10;(base brief Setup section: &#34;...This is a SCOUT task... The worktree is your laboratory - install, run, edit, and make scratch commits freely&#34; with no isolation check)</code>

```text
not ok - scout brief has no isolation assertion (missing: 'Verify isolation before anything else')
--- output ---
You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.
```
</details>
<details>
<summary>Evidence: Manual repro script used for the teardown transcript</summary>

```text
#!/usr/bin/env bash
# Manual repro (#1746): a task whose recorded worktree= IS the project clone.
# Run: repro-teardown-clone.sh <label> <fm-repo-root>
set -u
LABEL=$1; ROOT=$2; shift 2
D=$(mktemp -d "/tmp/fm1746-$LABEL.XXXXXX")
mkdir -p "$D/home/state" "$D/home/data" "$D/home/config" "$D/fakebin"
# the captain's project clone, with a file that must survive
git init -q "$D/project"; git -C "$D/project" -c user.email=t@t -c user.name=t commit -q --allow-empty -m init
printf 'the captains work\n' > "$D/project/IMPORTANT.txt"
git -C "$D/project" add -A >/dev/null; git -C "$D/project" -c user.email=t@t -c user.name=t commit -q -m work
mkdir -p "$D/home/data/scout-1746"; printf '# scout report\n' > "$D/home/data/scout-1746/report.md"
for t in tmux treehouse; do
  cat > "$D/fakebin/$t" <<SH
#!/usr/bin/env bash
printf '$t %s\n' "\$*" >> "$D/runtime.log"
exit 0
SH
  chmod +x "$D/fakebin/$t"
done
: > "$D/runtime.log"
cat > "$D/home/state/scout-1746.meta" <<SH
window=firstmate:fm-scout-1746
endpoint_task_id=scout-1746
worktree=$D/project
project=$D/project
kind=scout
mode=local-only
SH
echo "== task state before teardown =="
sed 's/^/   /' "$D/home/state/scout-1746.meta"
echo "== fm-teardown.sh scout-1746 $* =="
FM_HOME="$D/home" FM_ROOT_OVERRIDE="$ROOT" PATH="$D/fakebin:$PATH" \
  FM_GATE_REFUSE_BYPASS=1 "$ROOT/bin/fm-teardown.sh" scout-1746 "$@" > "$D/out.txt" 2>&1
rc=$?
grep -v '^●' "$D/out.txt" | sed 's/^/   /'
echo "   [exit $rc]"
echo "== aftermath =="
echo "   project clone present : $([ -d "$D/project" ] && echo yes || echo NO - DELETED)"
echo "   captain's file        : $([ -f "$D/project/IMPORTANT.txt" ] && echo intact || echo GONE)"
echo "   runtime commands run  : $(wc -l < "$D/runtime.log") -> $(tr '\n' ';' < "$D/runtime.log")"
echo "   task meta             : $([ -f "$D/home/state/scout-1746.meta" ] && echo preserved || echo REMOVED)"
rm -rf "$D"
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>⏭️ **intent** - skipped</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 3 issues (2 warnings, 1 info)</summary>

- 🚨 `bin/fm-teardown.sh:415` - The new clone-as-worktree refusal fires on eleven pre-existing kind=ship teardown fixtures that use worktree= == project= as shorthand. tests/fm-public-followup.test.sh writes such metas at lines 599, 623, 732, 765, 800, 832, 862, 926, 964, 1000 and 1031 and then runs $TEARDOWN, asserting rc 0 (line 807) or a specific different refusal (&#34;still owes a public reply&#34;, &#34;cannot resolve the primary home&#34;); tests/fm-remote-secondmate-parent-binding.test.sh:227 does the same in run_child_teardown with worktree=project=$REMOTE_HOME/projects/alpha and asserts rc 0. All of them now exit 1 with the new REFUSED before reaching the behavior under test. Give those fixtures a worktree path distinct from project; the guard behavior itself is correct.
- ⚠️ `AGENTS.md:491` - AGENTS.md still says &#34;Every ship brief must retain the worktree-isolation assertion and stop if launched in the primary checkout.&#34; Scout briefs now carry the same assertion, but the scout scaffold guard is prompt-level with no runtime enforcement, so an agent editing a generated scout brief per section 11 has no contract requiring it be kept - and stripping it re-opens the exact #1746 condition. Extend that line to cover scout briefs.
- ℹ️ `bin/fm-teardown.sh:419` - The commit says &#34;Closes #1746&#34;, but the issue&#39;s consequence 2 (a treehouse worktree allocated, recorded in worktree=, never adopted by the agent, and never reclaimed) is unaddressed. The new refusal also means an affected task cannot be torn down at all - pane, status file, meta and any leased pool slot persist until an operator hand-edits worktree=. The issue itself attributes the leak to #1441, so this is plausibly a deliberate split; confirm the closure scope is intended.

🔧 Fix: give teardown fixtures worktrees distinct from project
1 warning still open:
- ⚠️ `docs/architecture.md:149` - The &#34;Worktrees, not branches in your checkout&#34; section enumerates the isolation guarantees (line 139: fm-spawn refuses a path that is not a worktree distinct from the project; line 149: &#34;Ship briefs also tell the crewmate to verify `pwd -P` and `git rev-parse --show-toplevel`&#34;), but the change adds two guarantees to that same set without recording either: scout briefs now carry the identical assertion (bin/fm-brief.sh:302-311, shared by both scaffolds), and fm-teardown.sh now refuses outright - --force included - when worktree= resolves to project= (bin/fm-teardown.sh:412-424). AGENTS.md:491 was updated for the scout brief in the same change, so the doc set is now internally inconsistent, and the strongest of the three guards is undocumented outside the script header. Extend line 149 to &#34;Ship and scout briefs&#34; and add a sentence for the teardown refusal next to line 139. Same wording gap at AGENTS.md:401 (&#34;generated ship brief&#34;).

🔧 Fix: document scout brief and teardown isolation guards
3 issues (2 warnings, 1 info) still open:
- ⚠️ `bin/fm-test-run.sh:196` - tests/fm-scout-isolation.test.sh is classified into the backend-dispatch family, but the two scripts whose guards it pins map elsewhere in families_for_changed_path: bin/fm-teardown.sh emits pr-forge (line 919) and bin/fm-brief.sh emits pure-contract-unit (line 943). The scoped selector at line 1053 keeps only tests whose family_for_basename equals a selected family, so a later commit touching only bin/fm-teardown.sh runs pr-forge and skips this file entirely - the clone-as-worktree refusal and its --force case go unverified. Same for bin/fm-brief.sh and the scout-brief assertion test. Only a bin/fm-spawn.sh edit or a full run reaches it. Give bin/fm-teardown.sh and bin/fm-brief.sh their own arms that also emit backend-dispatch, following the two-family precedent already used for bin/fm-nm-run-lib.sh at line 923.
- ⚠️ `tests/fm-scout-isolation.test.sh:66` - test_scout_spawn_refuses_a_path_that_is_not_its_own_worktree duplicates tests/fm-tangle-guard.test.sh:190 test_spawn_isolation_abort, which already spawns with a pane resolving to a plain non-git dir and to $proj/sub inside the primary checkout, asserting both &#39;did not yield an isolated worktree&#39; and that no meta is recorded. make_spawn_fakebin at line 47 is a byte-level copy of fm-tangle-guard.test.sh:156. validate_spawn_worktree (bin/fm-spawn.sh:1398) has no kind branching and is reached only from the shared treehouse and orca paths, so --scout exercises the same code with no added coverage; the fm_git_worktree call at line 74 is dead fixture setup on top of that. Prefer adding a --scout row to the existing table in fm-tangle-guard.test.sh, or drop the duplicated case and helper here and keep this file to the genuinely new brief and teardown guards.
- ℹ️ `tests/fm-scout-isolation.test.sh:33` - The scout-brief test asserts only that the isolation assertion appears somewhere in the generated brief. Move $ISOLATION_ASSERTION (bin/fm-brief.sh:321) below the &#39;the worktree is your laboratory - install, run, edit, and make scratch commits freely&#39; line and all three assert_contains checks still pass, while the verify-before-you-install guarantee this change exists to create is gone. The ship counterpart already models the fix at fm-tangle-guard.test.sh:141-145: compare the assertion&#39;s line number against the laboratory line and require it to come first.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash tests/fm-scout-isolation.test.sh` (4 checks: scout brief assertion, scout spawn refusal + no metadata, teardown refusal for ship and scout, teardown refusal under --force)</code>
- <code>Regression proof for the brief: `git checkout 70aeba8 -- bin/fm-brief.sh bin/fm-teardown.sh` then re-ran the new suite — fails with `not ok - scout brief has no isolation assertion`; restored to 954cb14 and it passes</code>
- <code>Manual end-to-end teardown repro `/tmp/no-mistakes-evidence/01KZETM5M48WP38K4F0Q3B91WR/repro-teardown-clone.sh` run against base and target bin/fm-teardown.sh, with and without `--force`, using logging tmux/treehouse stubs</code>
- <code>Generated a real scout brief: `bin/fm-brief.sh scout-1746 my-repo --scout` and inspected the Setup section of data/scout-1746/brief.md</code>
- <code>Ship-brief diff: generated `bin/fm-brief.sh ship-x my-repo --mode local-only` at base vs target — only the widened STOP sentence differs</code>
- <code>`bash tests/fm-brief.test.sh`, `bash tests/fm-teardown.test.sh`, `bash tests/fm-teardown-endpoint-safety.test.sh`, `bash tests/fm-public-followup.test.sh`, `bash tests/fm-remote-secondmate-parent-binding.test.sh`, `bash tests/fm-secondmate-safety.test.sh` — all pass</code>
- <code>`bin/fm-test-run.sh --list --family backend-dispatch` lists tests/fm-scout-isolation.test.sh</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>

