### PR TITLE
feat(brief): add mechanism admission criteria

### DIFF
--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -41,6 +41,9 @@
 # to launch a ship task whose explicit --mode disagrees, so an adjusted brief and the
 # recorded task metadata cannot drift apart.
 # Ship briefs begin with a worktree-isolation assertion before the branch step.
+# Every ship brief carries the three-test admission contract for a proposed
+# mechanism, guard, or check. Agent-env ships also make passing that contract
+# and the CI change budget part of their definition of done.
 # --mode is refused on scout and secondmate scaffolds: a scout's deliverable is a
 # report rather than a merge, and a charter is not a delivery contract.
 # There is no --yolo flag here. The worker never owns approval decisions, so yolo is
@@ -409,6 +412,14 @@ esac
 # briefs stay byte-identical to the historical Bash 5 output.
 DOD=${DOD%$'\n'}
 
+if [ "$REPO" = agent-env ]; then
+DOD="$DOD
+
+Before this agent-env ship is done, every new mechanism, guard, or check must pass all three tests in \`# Mechanism admission\`.
+CI SLOs: fast lane (\`check\`) <= 5 minutes; full lane (\`full\`) <= 10 minutes (current baseline about 8m45s).
+If the PR adds more than 60 seconds to \`full\`, its body must state which new invariant this proves and why no existing check covers it."
+fi
+
 cat > "$BRIEF" <<EOF
 You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.
 
@@ -451,6 +462,12 @@ $RULE1
 7. Never stop, restart, or update the shared \`no-mistakes\` daemon - it is one instance serving
    every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
    daemon error, append \`blocked: {the daemon error}\` and stop; only firstmate manages the daemon.
+
+# Mechanism admission
+When proposing a new mechanism, guard, or check, apply all three tests:
+- **Owner:** Does it require agent-env or firstmate to understand another product's live state, config format, or launch lifecycle? If yes, route it upstream or raise a decision; do not code it here.
+- **Budget:** Is the guard larger than the payload it protects? If yes, keep it out of this PR and file it as a separate backlog candidate for decision.
+- **Trigger:** Does the proof run automatically on a defined trigger? If not, it is documentation; give it a trigger or write and name it as a textual assertion.
 
 # Project memory
 If \`AGENTS.md\` or \`CLAUDE.md\` already exists, or if this task produced durable project-intrinsic knowledge, run \`$FM_ROOT/bin/fm-ensure-agents-md.sh .\` in the worktree.

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -212,9 +212,49 @@ test_ship_modes_generate_clean_briefs() {
     assert_grep "{TASK}" "$brief" "$id: brief missing the {TASK} placeholder"
     assert_grep "mid-task \`working:\` line (including setup complete) is nonterminal" "$brief" \
       "$id: brief missing nonterminal working:/setup-complete gate protection"
+    assert_grep "# Mechanism admission" "$brief" \
+      "$id: ship brief missing the mechanism-admission contract"
+    assert_grep "**Owner:**" "$brief" \
+      "$id: ship brief missing the owner test"
+    assert_grep "**Budget:**" "$brief" \
+      "$id: ship brief missing the guard-to-payload budget test"
+    assert_grep "**Trigger:**" "$brief" \
+      "$id: ship brief missing the automatic-trigger test"
     assert_no_grep "EOF" "$brief" "$id: brief leaked a heredoc EOF marker (unterminated heredoc)"
   done
   pass "fm-brief.sh: no-mistakes/direct-PR/local-only briefs generate cleanly"
+}
+
+test_agent_env_ship_acceptance_carries_ci_budget() {
+  local home agent_env other scout
+  home="$TMP_ROOT/agent-env-acceptance-home"
+  mkdir -p "$home/data"
+
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" agent-env-ship agent-env --mode direct-PR >/dev/null 2>&1
+  agent_env="$home/data/agent-env-ship/brief.md"
+  assert_grep "every new mechanism, guard, or check must pass all three tests" "$agent_env" \
+    "agent-env definition of done did not require the admission tests"
+  assert_grep "fast lane (\`check\`) <= 5 minutes" "$agent_env" \
+    "agent-env definition of done lost the fast-lane SLO"
+  assert_grep "full lane (\`full\`) <= 10 minutes" "$agent_env" \
+    "agent-env definition of done lost the full-lane SLO"
+  assert_grep "If the PR adds more than 60 seconds to \`full\`" "$agent_env" \
+    "agent-env definition of done lost the per-change CI budget"
+  assert_grep "which new invariant this proves and why no existing check covers it" "$agent_env" \
+    "agent-env definition of done lost the required PR-body justification"
+
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" other-ship other-project --mode direct-PR >/dev/null 2>&1
+  other="$home/data/other-ship/brief.md"
+  assert_grep "# Mechanism admission" "$other" \
+    "ordinary ship brief did not carry the shared admission tests"
+  assert_no_grep "CI SLOs:" "$other" \
+    "ordinary ship brief inherited agent-env-specific CI acceptance"
+
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" scout-no-admission agent-env --scout >/dev/null 2>&1
+  scout="$home/data/scout-no-admission/brief.md"
+  assert_no_grep "# Mechanism admission" "$scout" \
+    "scout brief inherited the ship-only admission contract"
+  pass "fm-brief.sh: agent-env ships require admission tests and CI budgets without widening other definitions of done"
 }
 
 # A ship task's delivery mode is firstmate's per-task decision, so a missing or
@@ -714,6 +754,7 @@ test_script_parses
 test_no_heredoc_in_command_substitution
 test_help_includes_entire_header
 test_ship_modes_generate_clean_briefs
+test_agent_env_ship_acceptance_carries_ci_budget
 test_ship_mode_is_required_and_closed_set
 test_ship_mode_is_explicit_not_registry
 test_delivery_flags_are_refused_where_they_do_not_apply


### PR DESCRIPTION
## Summary

- Add the concise owner, budget, and trigger admission tests to every generated ship brief.
- Require agent-env ships to pass all three tests before done.
- Add the agent-env CI SLOs and the 60-second PR-body justification budget to its generated acceptance criteria.
- Keep scouts, secondmates, and non-agent-env CI acceptance unchanged.

## Retroactive validation

| Case | Result | Discriminating test |
|---|---|---|
| PR #117, Codex permissions | Reject | Owner and budget |
| PR #118, Lavish hooks | Reject | Owner |
| PR #115, Herdr containment | Reject | Trigger |
| PR #99, additive bootstrap | Reject | Budget |
| `herdr-pane-shell.nix` | Accept | Passes all three |
| `projected-files-tracked.sh` | Accept | Passes all three |

## Validation

- `PATH=/nix/store/9phb1flallb4fw685dlblzbqrh9qkphi-shellcheck-0.11.0-bin/bin:$PATH bin/fm-lint.sh`
- `bin/fm-test-run.sh tests/fm-brief.test.sh`

The broader changed-test selection exposed an unrelated Pi Calm E2E race, which is tracked separately and is not part of this branch.
