### PR TITLE
feat(startup-network): record per-step elapsed times for the deferred stage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,7 +111,7 @@ state/               volatile runtime signals; gitignored
   x-outbox/          generated Relay dry-run reply and dismiss previews; inspect it when FMX_DRY_RUN is set (section 14)
   public-followup/   generated private transport for promised public replies: commitment registrations, typed terminal-result inbox, accepted/rejected ledgers (section 14; bin/fm-public-followup.sh)
   x-poll.error x-poll.claim-error  generated Relay and offer-claim diagnostic dedupe markers
-  .startup-network.*  status, report, inline-print claim, and lock for the deferred network stage session start runs off its blocking path; bin/fm-startup-network.sh
+  .startup-network.*  status, report, per-step elapsed timings, inline-print claim, and lock for the deferred network stage session start runs off its blocking path; bin/fm-startup-network.sh
   .wake-queue        durable queued wakes: epoch<TAB>seq<TAB>kind<TAB>key<TAB>payload
   .<id>.open-decisions-cursor  per-task byte cursor and folded open-decision set bounding the OPEN DECISIONS scan's cost to new status-log appends; written only by fm-classify-lib.sh's status_open_decisions_incremental, removed by teardown, safe to delete (forces one full re-fold)
   .afk               durable away-mode flag; present = sub-supervisor may inject escalations (set by /afk, cleared on user return)

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -150,6 +150,10 @@ DATA="${FM_DATA_OVERRIDE:-$FM_HOME/data}"
 . "$SCRIPT_DIR/fm-backend.sh"
 # shellcheck source=bin/fm-remote-readiness-lib.sh disable=SC1091
 . "$SCRIPT_DIR/fm-remote-readiness-lib.sh"
+# fm-timing-lib.sh is inert unless FM_TIMING_LOG names a file, which only the
+# deferred network stage sets, so an ordinary bootstrap run records nothing.
+# shellcheck source=bin/fm-timing-lib.sh disable=SC1091
+. "$SCRIPT_DIR/fm-timing-lib.sh"
 
 # Network-phase selection (see the header). An unrecognized value resolves to
 # `all` so a malformed override runs every step rather than silently dropping a
@@ -483,17 +487,16 @@ secondmate_sync() {
     fm_lock_release "$home_lock" || true
   done < <(live_secondmate_meta_records "$STATE" "$DATA/secondmates.md")
 
-  # Remote routes converge through the generic transport. Their code root and
-  # inherited files are authoritative on that host; no local path probe or
-  # local fast-forward is attempted for them.
-  local remote_host sync_out inherit_out nudge_needed remote_marker remote_pending converged out remote_lock remote_generation
-  while IFS='|' read -r id _home _window meta; do
-    remote_host=$(fm_meta_get "$meta" remote_host)
-    [ -n "$remote_host" ] || continue
+  # One remote secondmate's convergence, split out of the loop so each host is
+  # individually timed; every `return` here was a `continue` and still means
+  # "move on to the next secondmate".
+  secondmate_sync_remote_one() {  # <id> <home> <remote-host>
+    local id=$1 _home=$2 remote_host=$3
+    local sync_out inherit_out nudge_needed remote_marker remote_pending converged out remote_lock remote_generation
     remote_lock=$(fm_remote_inherit_transaction_lock_path "$STATE" "$id" 2>/dev/null || true)
     if [ -z "$remote_lock" ] || ! fm_lock_acquire_wait "$remote_lock"; then
       echo "NUDGE_SECONDMATES: secondmate $id: send failed: cannot lock remote inheritance transaction"
-      continue
+      return 0
     fi
     if ! "$SCRIPT_DIR/fm-procevent-remote-reply.sh" arm "$id" >/dev/null 2>&1; then
       echo "SECONDMATE_LIVENESS: secondmate $id: skipped: remote reply source could not be registered"
@@ -502,7 +505,7 @@ secondmate_sync() {
     if [ -z "$remote_generation" ]; then
       echo "SECONDMATE_SYNC: secondmate $id: skipped: remote inheritance generation could not be published"
       fm_lock_release "$remote_lock" || true
-      continue
+      return 0
     fi
     remote_marker=$(secondmate_nudge_marker_path "$id" 2>/dev/null || true)
     remote_pending=0
@@ -511,7 +514,7 @@ secondmate_sync() {
       "$REMOTE_SECOND_MATE_NUDGE_MESSAGE" 1; then
       echo "NUDGE_SECONDMATES: secondmate $id: send failed: cannot record remote retry marker"
       fm_lock_release "$remote_lock" || true
-      continue
+      return 0
     fi
     nudge_needed=0
     converged=1
@@ -541,6 +544,19 @@ secondmate_sync() {
       rm -f "$remote_marker"
     fi
     fm_lock_release "$remote_lock" || true
+    return 0
+  }
+
+  # Remote routes converge through the generic transport. Their code root and
+  # inherited files are authoritative on that host; no local path probe or
+  # local fast-forward is attempted for them.
+  local remote_host __fm_timing_stamp
+  while IFS='|' read -r id _home _window meta; do
+    remote_host=$(fm_meta_get "$meta" remote_host)
+    [ -n "$remote_host" ] || continue
+    __fm_timing_stamp=$(fm_timing_now_ms)
+    secondmate_sync_remote_one "$id" "$_home" "$remote_host"
+    fm_timing_record secondmate convergence "$__fm_timing_stamp" "$id@$remote_host"
   done < <(live_secondmate_meta_records "$STATE" "$DATA/secondmates.md")
   return 0
 }
@@ -568,127 +584,146 @@ secondmate_liveness_sweep() {
   # primary-only no-op there. Mid-session liveness remains explicitly out of
   # scope and requires a separate periodic signal.
   [ -d "$STATE" ] || return 0
-  local meta id window harness backend target agent_state out cause remote_host remote_rc readiness_reason route_out remote_backend
+  local meta id remote_host label __fm_timing_stamp
   SECONDMATE_RESPAWNED_IDS=""
   for meta in "$STATE"/*.meta; do
     [ -f "$meta" ] || continue
     grep -q '^kind=secondmate$' "$meta" 2>/dev/null || continue
+    # Identity for the timing record is read here, in the loop, so the per-meta
+    # body below keeps its single-exit-per-outcome shape.
     id=$(basename "$meta" .meta)
-    window=$(fm_meta_get "$meta" window)
-    [ -n "$window" ] || continue
-    harness=$(fm_meta_get "$meta" harness)
     remote_host=$(fm_meta_get "$meta" remote_host)
-    if [ -n "$remote_host" ]; then
-      remote_rc=0
-      fm_remote_readiness_ensure "$SCRIPT_DIR" "$id" || remote_rc=$?
-      if [ "$remote_rc" -eq 255 ]; then
-        echo "SECONDMATE_LIVENESS: secondmate $id: skipped: remote host unavailable or endpoint state unknown; route preserved on $remote_host"
-        continue
-      fi
-      if [ "$remote_rc" -ne 0 ]; then
-        readiness_reason=$(printf '%s\n' "$FM_REMOTE_READINESS_OUT" \
-          | awk '/^check [^=]+=(fixable|human):|^action:|^error:/ { print; exit }')
-        [ -n "$readiness_reason" ] || readiness_reason=$(first_line "$FM_REMOTE_READINESS_OUT")
-        [ -n "$readiness_reason" ] || readiness_reason="unknown readiness failure"
-        echo "SECONDMATE_LIVENESS: secondmate $id: skipped: remote readiness failed on $remote_host: $readiness_reason"
-        continue
-      fi
-      if out=$("$SCRIPT_DIR/fm-on.sh" "$id" fm-remote-secondmate-control.sh state "$id" < /dev/null 2>/dev/null); then
-        remote_rc=0
-      else
-        remote_rc=$?
-      fi
-      if [ "$remote_rc" -eq 255 ]; then
-        echo "SECONDMATE_LIVENESS: secondmate $id: skipped: remote host unavailable or endpoint state unknown; route preserved on $remote_host"
-        continue
-      fi
-      if [ "$remote_rc" -ne 0 ]; then
-        echo "SECONDMATE_LIVENESS: secondmate $id: skipped: remote endpoint probe unreadable on $remote_host"
-        continue
-      fi
-      agent_state=$(printf '%s\n' "$out" | tail -1)
-      case "$agent_state" in
-        alive)
-          if route_out=$("$SCRIPT_DIR/fm-on.sh" "$id" fm-remote-secondmate-control.sh route "$id" < /dev/null 2>/dev/null); then
-            remote_rc=0
-          else
-            remote_rc=$?
-          fi
-          if [ "$remote_rc" -eq 255 ]; then
-            echo "SECONDMATE_LIVENESS: secondmate $id: skipped: remote host unavailable or endpoint route unknown; route preserved on $remote_host"
-            continue
-          fi
-          if [ "$remote_rc" -ne 0 ]; then
-            echo "SECONDMATE_LIVENESS: secondmate $id: skipped: alive remote endpoint route is unreadable on $remote_host; inspect and migrate or retire it explicitly"
-            continue
-          fi
-          remote_backend=$(printf '%s\n' "$route_out" | sed -n 's/^backend=//p' | tail -1)
-          if [ "$remote_backend" != herdr ]; then
-            echo "SECONDMATE_LIVENESS: secondmate $id: skipped: alive remote endpoint is recorded on backend '${remote_backend:-missing}'; migrate or retire it explicitly"
-            continue
-          fi
-          [ "${FM_BOOTSTRAP_VERBOSE_FACTS:-0}" != 1 ] || echo "BOOTSTRAP_INFO: remote secondmate $id already live (host=$remote_host)"
-          ;;
-        dead|missing)
-          cause="remote endpoint $agent_state on its configured host"
-          if out=$(FM_SPAWN_NO_GUARD=1 "$FM_ROOT/bin/fm-spawn.sh" "$id" --secondmate 2>&1); then
-            SECONDMATE_RESPAWNED_IDS="$SECONDMATE_RESPAWNED_IDS $id"
-            report_relaunch "$id" "$cause" "host=$remote_host"
-          else
-            echo "SECONDMATE_LIVENESS: secondmate $id: respawn failed after $cause: $(first_line "$out")"
-          fi
-          ;;
-        ambiguous|unreadable|unverified)
-          echo "SECONDMATE_LIVENESS: secondmate $id: skipped: remote endpoint state is $agent_state on $remote_host"
-          ;;
-        *) echo "SECONDMATE_LIVENESS: secondmate $id: skipped: remote endpoint returned an invalid state" ;;
-      esac
-      continue
+    label=$id
+    [ -z "$remote_host" ] || label="$id@$remote_host"
+    __fm_timing_stamp=$(fm_timing_now_ms)
+    secondmate_liveness_one "$meta" "$id"
+    fm_timing_record secondmate liveness "$__fm_timing_stamp" "$label"
+  done
+  return 0
+}
+
+# One secondmate's liveness check. Split out of the sweep so each is individually
+# timed; every `return` here was a `continue` in the loop and means exactly the
+# same thing - move on to the next secondmate. SECONDMATE_RESPAWNED_IDS stays a
+# global that this appends to, so the sweep's hand-off to secondmate_sync is
+# unchanged.
+secondmate_liveness_one() {  # <meta> <id>
+  local meta=$1 id=$2
+  local window harness backend target agent_state out cause remote_host remote_rc readiness_reason route_out remote_backend
+  window=$(fm_meta_get "$meta" window)
+  [ -n "$window" ] || return 0
+  harness=$(fm_meta_get "$meta" harness)
+  remote_host=$(fm_meta_get "$meta" remote_host)
+  if [ -n "$remote_host" ]; then
+    remote_rc=0
+    fm_remote_readiness_ensure "$SCRIPT_DIR" "$id" || remote_rc=$?
+    if [ "$remote_rc" -eq 255 ]; then
+      echo "SECONDMATE_LIVENESS: secondmate $id: skipped: remote host unavailable or endpoint state unknown; route preserved on $remote_host"
+      return 0
     fi
-    backend=$(fm_backend_of_meta "$meta")
-    target=$(fm_backend_target_of_meta "$meta")
-    [ -n "$target" ] || target="$window"
-    agent_state=$(fm_backend_agent_state "$backend" "$target" 2>/dev/null) || agent_state=unreadable
-    case "$harness" in
-      claude|codex|opencode|pi|pi-signed|grok|kimi) ;;
-      *)
-        case "$agent_state" in dead|missing) agent_state=unverified-harness ;; esac
-        ;;
-    esac
+    if [ "$remote_rc" -ne 0 ]; then
+      readiness_reason=$(printf '%s\n' "$FM_REMOTE_READINESS_OUT" \
+        | awk '/^check [^=]+=(fixable|human):|^action:|^error:/ { print; exit }')
+      [ -n "$readiness_reason" ] || readiness_reason=$(first_line "$FM_REMOTE_READINESS_OUT")
+      [ -n "$readiness_reason" ] || readiness_reason="unknown readiness failure"
+      echo "SECONDMATE_LIVENESS: secondmate $id: skipped: remote readiness failed on $remote_host: $readiness_reason"
+      return 0
+    fi
+    if out=$("$SCRIPT_DIR/fm-on.sh" "$id" fm-remote-secondmate-control.sh state "$id" < /dev/null 2>/dev/null); then
+      remote_rc=0
+    else
+      remote_rc=$?
+    fi
+    if [ "$remote_rc" -eq 255 ]; then
+      echo "SECONDMATE_LIVENESS: secondmate $id: skipped: remote host unavailable or endpoint state unknown; route preserved on $remote_host"
+      return 0
+    fi
+    if [ "$remote_rc" -ne 0 ]; then
+      echo "SECONDMATE_LIVENESS: secondmate $id: skipped: remote endpoint probe unreadable on $remote_host"
+      return 0
+    fi
+    agent_state=$(printf '%s\n' "$out" | tail -1)
     case "$agent_state" in
       alive)
-        if [ "${FM_BOOTSTRAP_VERBOSE_FACTS:-0}" = 1 ]; then
-          echo "BOOTSTRAP_INFO: secondmate $id already live (backend=$backend)"
+        if route_out=$("$SCRIPT_DIR/fm-on.sh" "$id" fm-remote-secondmate-control.sh route "$id" < /dev/null 2>/dev/null); then
+          remote_rc=0
+        else
+          remote_rc=$?
         fi
+        if [ "$remote_rc" -eq 255 ]; then
+          echo "SECONDMATE_LIVENESS: secondmate $id: skipped: remote host unavailable or endpoint route unknown; route preserved on $remote_host"
+          return 0
+        fi
+        if [ "$remote_rc" -ne 0 ]; then
+          echo "SECONDMATE_LIVENESS: secondmate $id: skipped: alive remote endpoint route is unreadable on $remote_host; inspect and migrate or retire it explicitly"
+          return 0
+        fi
+        remote_backend=$(printf '%s\n' "$route_out" | sed -n 's/^backend=//p' | tail -1)
+        if [ "$remote_backend" != herdr ]; then
+          echo "SECONDMATE_LIVENESS: secondmate $id: skipped: alive remote endpoint is recorded on backend '${remote_backend:-missing}'; migrate or retire it explicitly"
+          return 0
+        fi
+        [ "${FM_BOOTSTRAP_VERBOSE_FACTS:-0}" != 1 ] || echo "BOOTSTRAP_INFO: remote secondmate $id already live (host=$remote_host)"
         ;;
       dead|missing)
-        if [ "$agent_state" = dead ]; then
-          cause="confirmed agent absence on existing endpoint"
-          fm_backend_kill "$backend" "$target" 2>/dev/null || true
-        else
-          cause="recorded endpoint confidently missing"
-        fi
+        cause="remote endpoint $agent_state on its configured host"
         if out=$(FM_SPAWN_NO_GUARD=1 "$FM_ROOT/bin/fm-spawn.sh" "$id" --secondmate 2>&1); then
           SECONDMATE_RESPAWNED_IDS="$SECONDMATE_RESPAWNED_IDS $id"
-          report_relaunch "$id" "$cause" "backend=$backend"
+          report_relaunch "$id" "$cause" "host=$remote_host"
         else
           echo "SECONDMATE_LIVENESS: secondmate $id: respawn failed after $cause: $(first_line "$out")"
         fi
         ;;
-      ambiguous)
-        echo "SECONDMATE_LIVENESS: secondmate $id: skipped: existing endpoint has ambiguous agent process (backend=$backend)"
+      ambiguous|unreadable|unverified)
+        echo "SECONDMATE_LIVENESS: secondmate $id: skipped: remote endpoint state is $agent_state on $remote_host"
         ;;
-      unreadable)
-        echo "SECONDMATE_LIVENESS: secondmate $id: skipped: endpoint probe unreadable (backend=$backend)"
-        ;;
-      unverified-harness)
-        echo "SECONDMATE_LIVENESS: secondmate $id: skipped: recorded harness '$harness' is unverified for recovery (backend=$backend)"
-        ;;
-      *)
-        echo "SECONDMATE_LIVENESS: secondmate $id: skipped: agent recovery classifier unverified (backend=$backend)"
-        ;;
+      *) echo "SECONDMATE_LIVENESS: secondmate $id: skipped: remote endpoint returned an invalid state" ;;
     esac
-  done
+    return 0
+  fi
+  backend=$(fm_backend_of_meta "$meta")
+  target=$(fm_backend_target_of_meta "$meta")
+  [ -n "$target" ] || target="$window"
+  agent_state=$(fm_backend_agent_state "$backend" "$target" 2>/dev/null) || agent_state=unreadable
+  case "$harness" in
+    claude|codex|opencode|pi|pi-signed|grok|kimi) ;;
+    *)
+      case "$agent_state" in dead|missing) agent_state=unverified-harness ;; esac
+      ;;
+  esac
+  case "$agent_state" in
+    alive)
+      if [ "${FM_BOOTSTRAP_VERBOSE_FACTS:-0}" = 1 ]; then
+        echo "BOOTSTRAP_INFO: secondmate $id already live (backend=$backend)"
+      fi
+      ;;
+    dead|missing)
+      if [ "$agent_state" = dead ]; then
+        cause="confirmed agent absence on existing endpoint"
+        fm_backend_kill "$backend" "$target" 2>/dev/null || true
+      else
+        cause="recorded endpoint confidently missing"
+      fi
+      if out=$(FM_SPAWN_NO_GUARD=1 "$FM_ROOT/bin/fm-spawn.sh" "$id" --secondmate 2>&1); then
+        SECONDMATE_RESPAWNED_IDS="$SECONDMATE_RESPAWNED_IDS $id"
+        report_relaunch "$id" "$cause" "backend=$backend"
+      else
+        echo "SECONDMATE_LIVENESS: secondmate $id: respawn failed after $cause: $(first_line "$out")"
+      fi
+      ;;
+    ambiguous)
+      echo "SECONDMATE_LIVENESS: secondmate $id: skipped: existing endpoint has ambiguous agent process (backend=$backend)"
+      ;;
+    unreadable)
+      echo "SECONDMATE_LIVENESS: secondmate $id: skipped: endpoint probe unreadable (backend=$backend)"
+      ;;
+    unverified-harness)
+      echo "SECONDMATE_LIVENESS: secondmate $id: skipped: recorded harness '$harness' is unverified for recovery (backend=$backend)"
+      ;;
+    *)
+      echo "SECONDMATE_LIVENESS: secondmate $id: skipped: agent recovery classifier unverified (backend=$backend)"
+      ;;
+  esac
   return 0
 }
 
@@ -1151,21 +1186,49 @@ detect_local_config() {
 # `skip` run is the same output with the network lines removed rather than a
 # reshuffle. `gh auth status` sits between the two local blocks because that is
 # where it has always been.
+# Each network owner below is bracketed by an elapsed-time record, so a deferred
+# stage that ran long can be attributed to the phase that spent the time.
+# fm-timing-lib.sh discards the record unless the caller asked for timings, and
+# every sweep is still called directly and in the same order, so nothing about
+# what runs, in what sequence, or what it returns changes.
+# The stamp variable is named for the library rather than `start` on purpose:
+# fleet_sync and others assign plain names like `start` without `local`, and
+# bash's dynamic scoping would let them overwrite a stamp held by a caller.
 local_phase && detect_local_tools
-network_phase && { gh auth status >/dev/null 2>&1 || echo "NEEDS_GH_AUTH"; }
+if network_phase; then
+  __fm_timing_stamp=$(fm_timing_now_ms)
+  gh auth status >/dev/null 2>&1 || echo "NEEDS_GH_AUTH"
+  fm_timing_record phase gh-auth "$__fm_timing_stamp"
+fi
 local_phase && detect_local_config
 
 if [ "${FM_BOOTSTRAP_DETECT_ONLY:-0}" != 1 ]; then
   # secondmate_sync consumes SECONDMATE_RESPAWNED_IDS from the liveness sweep, so
   # those two always run together in the same phase.
   if network_phase; then
-    if network_sweep_authorized 'dead-secondmate relaunch'; then secondmate_liveness_sweep; fi
-    if network_sweep_authorized 'secondmate convergence'; then secondmate_sync; fi
-    if network_sweep_authorized 'pending handoff delivery'; then secondmate_handoff_resume; fi
+    if network_sweep_authorized 'dead-secondmate relaunch'; then
+      __fm_timing_stamp=$(fm_timing_now_ms)
+      secondmate_liveness_sweep
+      fm_timing_record phase secondmate-liveness "$__fm_timing_stamp"
+    fi
+    if network_sweep_authorized 'secondmate convergence'; then
+      __fm_timing_stamp=$(fm_timing_now_ms)
+      secondmate_sync
+      fm_timing_record phase secondmate-sync "$__fm_timing_stamp"
+    fi
+    if network_sweep_authorized 'pending handoff delivery'; then
+      __fm_timing_stamp=$(fm_timing_now_ms)
+      secondmate_handoff_resume
+      fm_timing_record phase handoff-delivery "$__fm_timing_stamp"
+    fi
   fi
   # x_mode_setup writes local Relay artifacts only and never leaves the machine.
   local_phase && x_mode_setup
-  if network_phase && network_sweep_authorized 'project clone refresh'; then fleet_sync; fi
+  if network_phase && network_sweep_authorized 'project clone refresh'; then
+    __fm_timing_stamp=$(fm_timing_now_ms)
+    fleet_sync
+    fm_timing_record phase fleet-sync "$__fm_timing_stamp"
+  fi
 fi
 local_phase && secondmate_handoff_detect
 exit 0

--- a/bin/fm-fleet-sync.sh
+++ b/bin/fm-fleet-sync.sh
@@ -35,6 +35,9 @@ FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
 PROJECTS="${FM_PROJECTS_OVERRIDE:-$FM_HOME/projects}"
 # shellcheck source=bin/fm-lock-lib.sh
 . "$SCRIPT_DIR/fm-lock-lib.sh"
+# Inert unless FM_TIMING_LOG names a file; only the deferred network stage sets it.
+# shellcheck source=bin/fm-timing-lib.sh
+. "$SCRIPT_DIR/fm-timing-lib.sh"
 FM_LOCK_LOG_PREFIX=fleet-sync
 "$FM_ROOT/bin/fm-guard.sh" || true
 
@@ -426,5 +429,10 @@ fi
 for proj in "$PROJECTS"/*; do
   [ -e "$proj" ] || continue
   [ -d "$proj" ] || continue
+  # Per-clone elapsed, so a fleet refresh that runs long names WHICH clone cost
+  # the time instead of only its total. Recording is a no-op unless the deferred
+  # network stage asked for it.
+  __fm_timing_stamp=$(fm_timing_now_ms)
   sync_project "$proj"
+  fm_timing_record clone sync "$__fm_timing_stamp" "$(basename "$proj")"
 done

--- a/bin/fm-startup-network.sh
+++ b/bin/fm-startup-network.sh
@@ -50,7 +50,11 @@
 #          Print the digest's NETWORK CHECKS section and release the inline-print
 #          claim. Called by bin/fm-session-start.sh, not by hand.
 #        fm-startup-network.sh report
-#          Print the current state and report without changing anything.
+#          Print the current state and report without changing anything, then the
+#          last run's per-step elapsed times. This is the ONLY command that prints
+#          those timings: `harvest` composes the session-start digest, and adding
+#          diagnostic detail there would make every startup pay for a question
+#          only a slow run raises.
 #        fm-startup-network.sh wait [<seconds>]
 #          Block until the report is published, up to <seconds> (default 120).
 #          For operators and tests only; a session start never waits.
@@ -71,6 +75,16 @@
 #                             a durable acknowledgement that harvest printed the
 #                             current finished result; only this suppresses its
 #                             wake.
+#   .startup-network.timings  per-step elapsed times for the last run, in
+#                             bin/fm-timing-lib.sh's tab-separated format: the
+#                             stage total, one record per network phase (gh auth,
+#                             secondmate liveness, secondmate convergence, handoff
+#                             delivery, fleet sync), one per secondmate for the
+#                             remote-touching steps (id and host), and one per
+#                             project clone. Published for a timed-out or failed
+#                             run too, where a partial record is the answer.
+#                             Diagnostic only: nothing reads it to make a
+#                             decision, and losing it never downgrades a run.
 #   .startup-network.lock     serializes publication, harvest acknowledgement,
 #                             and the wake decision.
 #
@@ -89,10 +103,16 @@ STATUS_FILE="$STATE/.startup-network.status"
 REPORT_FILE="$STATE/.startup-network.report"
 CLAIM_FILE="$STATE/.startup-network.claim"
 DELIVERED_FILE="$STATE/.startup-network.delivered"
+TIMINGS_FILE="$STATE/.startup-network.timings"
 PUBLISH_LOCK="$STATE/.startup-network.lock"
 
 # shellcheck source=bin/fm-timeout-lib.sh
 . "$SCRIPT_DIR/fm-timeout-lib.sh"
+# fm-timing-lib.sh owns the per-step elapsed record this stage publishes beside
+# its report. Recording is opt-in per run: it stays inert until cmd_run points
+# FM_TIMING_LOG at a file, so nothing else that sources these scripts pays for it.
+# shellcheck source=bin/fm-timing-lib.sh
+. "$SCRIPT_DIR/fm-timing-lib.sh"
 # fm-wake-lib.sh owns both the portable lock helpers used below and the durable
 # wake queue this stage publishes into.
 # shellcheck source=bin/fm-wake-lib.sh
@@ -323,12 +343,20 @@ EOF
   fm_lock_release "$PUBLISH_LOCK"
 }
 
-publish() {  # <generation> <state> <phases> <locked> <started> <rc> <output-file>
-  local generation=$1 state=$2 phases=$3 locked=$4 started=$5 rc=$6 out=$7 report_published=1
+publish() {  # <generation> <state> <phases> <locked> <started> <rc> <output-file> <timing-file>
+  local generation=$1 state=$2 phases=$3 locked=$4 started=$5 rc=$6 out=$7 timings=${8:-} report_published=1
   fm_lock_acquire_wait "$PUBLISH_LOCK"
   if [ "$(status_get generation)" != "$generation" ]; then
     fm_lock_release "$PUBLISH_LOCK"
     return 0
+  fi
+  # Timings are published for EVERY outcome, including timeout and failure: a run
+  # that hit the bound is exactly the run whose per-step record is worth having,
+  # and whatever the killed sweeps managed to append is a real partial answer.
+  # A timing record is diagnostic only, so a failure to publish it is discarded
+  # rather than downgrading the run - the report itself is the contract.
+  if [ -n "$timings" ] && [ -f "$timings" ]; then
+    write_atomic "$TIMINGS_FILE" < "$timings" || true
   fi
   if ! write_atomic "$REPORT_FILE" < "$out"; then
     state=failed
@@ -353,7 +381,7 @@ EOF
 }
 
 cmd_run() {  # <locked> <lock-pid> <generation>
-  local locked=$1 lock_pid=$2 generation=$3 phases started budget out rc sweep_locked=0 downgraded=0 internal=0 lease_held=0
+  local locked=$1 lock_pid=$2 generation=$3 phases started budget out rc sweep_locked=0 downgraded=0 internal=0 lease_held=0 timings stage_started
   mkdir -p "$STATE" 2>/dev/null || return 1
   started=$(now)
   budget=$(stage_budget)
@@ -400,6 +428,14 @@ EOF
   fi
 
   out=$(mktemp "${TMPDIR:-/tmp}/fm-startup-network.XXXXXX" 2>/dev/null) || return 1
+  # Recorded into a temp file rather than straight into state/ so a run that is
+  # killed mid-sweep cannot leave a half-written artifact where the previous
+  # run's complete one used to be; publish() promotes it atomically at the end.
+  # Sweeps run in child processes (bin/fm-bootstrap.sh, and bin/fm-fleet-sync.sh
+  # below it), so FM_TIMING_LOG is exported and appended to by all of them.
+  timings=$(mktemp "${TMPDIR:-/tmp}/fm-startup-network-timings.XXXXXX" 2>/dev/null) || timings=
+  [ -z "$timings" ] || fm_timing_start "$timings"
+  stage_started=$(fm_timing_now_ms)
   rc=0
   if [ "$sweep_locked" -eq 1 ]; then
     fm_lock_acquire_wait "$STATE/.lock.acquire"
@@ -419,24 +455,28 @@ EOF
       "$SCRIPT_DIR/fm-bootstrap.sh" >"$out" 2>&1 || rc=$?
   fi
   [ "$lease_held" -eq 0 ] || fm_lock_release "$STATE/.lock.acquire"
+  # The bounded run as a whole, so the per-phase records can be read against the
+  # total even when the bound cut some of them off.
+  fm_timing_record stage network-checks "$stage_started" "$phases"
 
   if [ "$downgraded" -eq 1 ]; then
     printf 'NETWORK_CHECKS: the fleet lock was no longer held by the session that requested these, so dead-secondmate relaunch, secondmate convergence, pending handoff delivery, and project clone refresh were skipped; they belong to whichever session holds the lock now\n' >> "$out"
   fi
   case "$rc" in
-    0) publish "$generation" 'done' "$phases" "$sweep_locked" "$started" "$rc" "$out" ;;
+    0) publish "$generation" 'done' "$phases" "$sweep_locked" "$started" "$rc" "$out" "$timings" ;;
     124)
       printf 'NETWORK_CHECKS: hit the %ss bound before finishing, so %s may be incomplete; rerun %s/bin/fm-startup-network.sh run --locked %s\n' \
         "$budget" "$(phase_label "$phases")" "$FM_ROOT" "$sweep_locked" >> "$out"
-      publish "$generation" timeout "$phases" "$sweep_locked" "$started" "$rc" "$out"
+      publish "$generation" timeout "$phases" "$sweep_locked" "$started" "$rc" "$out" "$timings"
       ;;
     *)
       printf 'NETWORK_CHECKS: the deferred check worker exited %s, so %s may be incomplete; rerun %s/bin/fm-startup-network.sh run --locked %s\n' \
         "$rc" "$(phase_label "$phases")" "$FM_ROOT" "$sweep_locked" >> "$out"
-      publish "$generation" failed "$phases" "$sweep_locked" "$started" "$rc" "$out"
+      publish "$generation" failed "$phases" "$sweep_locked" "$started" "$rc" "$out" "$timings"
       ;;
   esac
   rm -f "$out" 2>/dev/null || true
+  [ -z "$timings" ] || rm -f "$timings" 2>/dev/null || true
   return 0
 }
 
@@ -463,6 +503,15 @@ print_finished() {  # <state>
   else
     printf '(silent - no problems found)\n'
   fi
+}
+
+# Deliberately NOT part of print_state, and so deliberately not part of harvest:
+# harvest composes the digest's NETWORK CHECKS section, and this record is
+# diagnostic detail nobody needs on an ordinary session start. It is printed only
+# by the on-demand `report` command, so the timings cost a reader nothing until
+# a run is actually slow enough to ask about.
+print_timings() {
+  fm_timing_render "$TIMINGS_FILE"
 }
 
 print_pending() {
@@ -557,7 +606,7 @@ case "$MODE" in
   start) cmd_start "$LOCKED" "${HARVEST_PID:-0}" ;;
   run) cmd_run "$LOCKED" "$LOCK_PID" "$GENERATION" ;;
   harvest) cmd_harvest "${HARVEST_PID:-}" ;;
-  report) print_state ;;
+  report) print_state; print_timings ;;
   wait) cmd_wait "${1:-120}" || exit $? ;;
   -h|--help) usage ;;
   *)

--- a/bin/fm-timing-lib.sh
+++ b/bin/fm-timing-lib.sh
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+# fm-timing-lib.sh - the single owner of the deferred network stage's elapsed-time
+# instrumentation.
+#
+# Sourced, never executed.
+#
+# WHY THIS EXISTS. The deferred stage (bin/fm-startup-network.sh) publishes one
+# aggregate started/finished pair, so a run that took a minute could not be
+# attributed to a phase, a host, or a clone without re-running it by hand under
+# manual tracing. These helpers record per-step elapsed times as the run happens,
+# so the next slow run is answerable from the durable record alone.
+#
+# OFF BY DEFAULT, AND INERT. Every helper is a no-op unless FM_TIMING_LOG names a
+# file. Nothing here talks to the network, waits, locks, or changes control flow:
+# a failed append is discarded rather than propagated, because losing a diagnostic
+# line must never change what a sweep does or how it exits.
+#
+# ENVIRONMENT, both exported by the stage that owns a run:
+#   FM_TIMING_LOG       append-only record file. Unset or empty disables recording.
+#                       Exported across process boundaries on purpose: the phases
+#                       being measured run in bin/fm-bootstrap.sh and
+#                       bin/fm-fleet-sync.sh, which are children of the stage.
+#   FM_TIMING_EPOCH_MS  the run's start instant, so every record carries an offset
+#                       from ONE origin even though the records are written by
+#                       several processes. Defaults to the first recording
+#                       process's own start, which keeps a hand-run child readable.
+#
+# RECORD FORMAT, one tab-separated line per measured step:
+#   v1 <TAB> scope <TAB> name <TAB> start-offset-ms <TAB> elapsed-ms <TAB> detail
+# Appends are single short lines opened O_APPEND, so concurrent writers interleave
+# whole lines rather than corrupting each other.
+#
+# NO SECRETS, BY CONSTRUCTION. `detail` names an identity - a secondmate id, a
+# host, a clone directory name - and identities never contain whitespace, while
+# the things that must never reach this file (a command line, an environment
+# dump, a captured error) always do. So a detail carrying ANY whitespace is not a
+# truncated identity, it is free text that arrived from somewhere it should not
+# have, and it is dropped entirely rather than cleaned up: cleaning would leave
+# the token in `KEY=secret` behind, because a credential is made of exactly the
+# characters an identity is made of. What remains is then narrowed to
+# [A-Za-z0-9._@:/+-] and truncated, which is what stops a detail from forging
+# extra tab-separated records. Enforcing this here rather than at each call site
+# is what makes "this file cannot carry a credential or an argv" checkable in one
+# place.
+set -u
+
+FM_TIMING_DETAIL_MAX=${FM_TIMING_DETAIL_MAX:-80}
+
+fm_timing_enabled() {
+  [ -n "${FM_TIMING_LOG:-}" ]
+}
+
+# Milliseconds since the epoch. EPOCHREALTIME is a bash builtin (no fork) whose
+# decimal separator follows the locale, so both forms are accepted. A shell
+# without it - macOS's system bash 3.2, which `env bash` still resolves to on a
+# host with no newer bash on PATH - degrades to whole-second granularity rather
+# than losing the timing entirely. That is a coarser answer to "which host was
+# slow", not a missing one, because the steps being measured are seconds-scale.
+fm_timing_now_ms() {
+  local raw sec frac
+  raw=${EPOCHREALTIME:-}
+  case "$raw" in
+    *[0-9][.,][0-9]*)
+      sec=${raw%%[.,]*}
+      frac=${raw#*[.,]}
+      frac="${frac}000"
+      frac=${frac:0:3}
+      case "$sec$frac" in
+        ''|*[!0-9]*) ;;
+        *) printf '%s\n' "$(( sec * 1000 + 10#$frac ))"; return 0 ;;
+      esac
+      ;;
+  esac
+  sec=$(date +%s 2>/dev/null || printf '0')
+  case "$sec" in ''|*[!0-9]*) sec=0 ;; esac
+  printf '%s\n' "$(( sec * 1000 ))"
+}
+
+# Ensure FM_TIMING_EPOCH_MS holds the origin every offset is measured from.
+# Callers that own a run export it up front; a process that starts recording
+# without one adopts its own first measurement so its records stay internally
+# consistent instead of being silently dropped.
+#
+# This SETS the variable rather than printing it, because the caller must read it
+# as "$FM_TIMING_EPOCH_MS" and not through a command substitution: a substitution
+# runs in a subshell, so the lazily chosen origin would be discarded and every
+# record would recompute it, flattening every start offset to zero.
+fm_timing_epoch_ensure() {
+  case "${FM_TIMING_EPOCH_MS:-}" in
+    ''|*[!0-9]*)
+      FM_TIMING_EPOCH_MS=$(fm_timing_now_ms)
+      export FM_TIMING_EPOCH_MS
+      ;;
+  esac
+}
+
+# Start a run: point recording at <file> and stamp the shared origin. The file is
+# created empty so a run that dies before its first record still publishes an
+# empty-but-present artifact rather than looking like it was never instrumented.
+fm_timing_start() {  # <file>
+  local file=$1
+  [ -n "$file" ] || return 0
+  : > "$file" 2>/dev/null || return 0
+  FM_TIMING_LOG=$file
+  FM_TIMING_EPOCH_MS=$(fm_timing_now_ms)
+  export FM_TIMING_LOG FM_TIMING_EPOCH_MS
+}
+
+fm_timing_sanitize() {  # <text>
+  local text=${1:-}
+  case "$text" in
+    *[[:space:]]*) printf '%s\n' 'unrecordable'; return 0 ;;
+  esac
+  text=${text//[!A-Za-z0-9._@:\/+-]/_}
+  printf '%s\n' "${text:0:$FM_TIMING_DETAIL_MAX}"
+}
+
+# Record one measured step. Never fails the caller: a missing log, an unwritable
+# path, or a malformed start stamp all resolve to "no record", never an error.
+fm_timing_record() {  # <scope> <name> <start-ms> [detail]
+  local scope=$1 name=$2 start=$3 detail=${4:-} now offset elapsed
+  fm_timing_enabled || return 0
+  case "$start" in ''|*[!0-9]*) return 0 ;; esac
+  now=$(fm_timing_now_ms)
+  fm_timing_epoch_ensure
+  offset=$(( start - FM_TIMING_EPOCH_MS ))
+  [ "$offset" -ge 0 ] || offset=0
+  elapsed=$(( now - start ))
+  [ "$elapsed" -ge 0 ] || elapsed=0
+  printf 'v1\t%s\t%s\t%s\t%s\t%s\n' \
+    "$(fm_timing_sanitize "$scope")" "$(fm_timing_sanitize "$name")" \
+    "$offset" "$elapsed" "$(fm_timing_sanitize "$detail")" \
+    >> "$FM_TIMING_LOG" 2>/dev/null || true
+  return 0
+}
+
+# Render a recorded run for a human. Prints nothing at all when the file is
+# missing or holds no record, so an uninstrumented or empty run adds no output.
+fm_timing_render() {  # <file>
+  local file=$1
+  [ -n "$file" ] && [ -s "$file" ] || return 0
+  awk -F'\t' '
+    $1 != "v1" || NF < 5 { next }
+    {
+      records++
+      scope[records] = $2; name[records] = $3
+      offset[records] = $4 + 0; elapsed[records] = $5 + 0
+      detail[records] = $6
+    }
+    END {
+      if (records == 0) exit 0
+      print "TIMINGS - where the deferred network checks spent their time (ms):"
+      for (i = 1; i <= records; i++) {
+        label = name[i]
+        if (detail[i] != "") label = label " " detail[i]
+        printf "  %-11s %-42s start=+%-7d elapsed=%d\n", scope[i], label, offset[i], elapsed[i]
+      }
+      for (i = 1; i <= records; i++) {
+        for (j = i + 1; j <= records; j++) {
+          if (elapsed[j] > elapsed[i]) {
+            t = scope[i]; scope[i] = scope[j]; scope[j] = t
+            t = name[i]; name[i] = name[j]; name[j] = t
+            t = offset[i]; offset[i] = offset[j]; offset[j] = t
+            t = elapsed[i]; elapsed[i] = elapsed[j]; elapsed[j] = t
+            t = detail[i]; detail[i] = detail[j]; detail[j] = t
+          }
+        }
+      }
+      top = records < 3 ? records : 3
+      line = ""
+      for (i = 1; i <= top; i++) {
+        label = name[i]
+        if (detail[i] != "") label = label " " detail[i]
+        line = line (line == "" ? "" : ", ") scope[i] " " label " " elapsed[i] "ms"
+      }
+      print "  slowest: " line
+    }
+  ' "$file" 2>/dev/null || true
+}

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -78,6 +78,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-nm-run-lib.sh`       | Shared branch-and-code-identity attribution for no-mistakes runs                    |
 | `fm-tangle-lib.sh`       | Shared default-branch resolution and primary-checkout tangle classification          |
 | `fm-timeout-lib.sh`      | Single owner of hard-bounded command execution and its fallback watchdog |
+| `fm-timing-lib.sh`       | Single owner of the deferred network stage's per-step elapsed-time records, inert unless a run asks for them |
 | `fm-supervision-lib.sh`  | Shared in-flight-work-without-fresh-watcher-beacon predicate                         |
 | `fm-ff-lib.sh`           | Shared guarded fast-forward helper for origin pulls and local secondmate syncs       |
 | `fm-lock-lib.sh`         | Shared "is this git lock provably abandoned?" proof used by teardown and fleet-sync   |

--- a/tests/fm-bootstrap.test.sh
+++ b/tests/fm-bootstrap.test.sh
@@ -963,6 +963,71 @@ SH
 # The verdict costs three subprocesses, so a caller that already has it can hand
 # it over - but only one hop, and never onward into a spawned agent's
 # environment, where it could outlive a tasks-axi upgrade.
+# assert_timing_record <log> <scope> <name> <detail> <msg>: one bin/fm-timing-lib.sh
+# record with exactly these fields must exist. Field-exact rather than a substring
+# match, so a detail that landed in the wrong column cannot pass.
+assert_timing_record() {
+  local log=$1 scope=$2 name=$3 detail=$4 msg=$5
+  awk -F'\t' -v s="$scope" -v n="$name" -v d="$detail" '
+    $1 == "v1" && $2 == s && $3 == n && $6 == d { found = 1 }
+    END { exit found ? 0 : 1 }
+  ' "$log" || fail "$msg"$'\n'"$(cat "$log")"
+}
+
+# The deferred network stage publishes ONE started/finished pair, so a slow run
+# used to be unattributable without re-running it by hand. These are the records
+# that make it attributable, and they must come from the real sweeps rather than
+# a stand-in: what is being pinned is that each network owner is actually wrapped.
+# bin/fm-timing-lib.sh stays inert unless FM_TIMING_LOG names a file, so an
+# ordinary bootstrap run is unaffected either way, which is asserted here too.
+test_network_phases_record_per_step_elapsed_times() {
+  local case_dir fakebin log fields
+  case_dir="$TMP_ROOT/network-timings"
+  mkdir -p "$case_dir/home/config" "$case_dir/home/state" "$case_dir/home/data" "$case_dir/home/projects"
+  printf '%s\n' manual > "$case_dir/home/config/backlog-backend"
+  printf '%s\n' $$ > "$case_dir/home/state/.lock"
+  fakebin=$(make_fake_toolchain "$case_dir")
+  # A real clone with a real origin, so fm-fleet-sync.sh genuinely iterates it.
+  fm_git_init_commit "$case_dir/home/projects/alpha"
+  fm_git_add_origin "$case_dir/home/projects/alpha" "$case_dir/alpha-origin"
+  # A secondmate the liveness sweep must account for. Whatever verdict it reaches
+  # is owned elsewhere; what matters here is that the step is measured.
+  fm_write_secondmate_meta "$case_dir/home/state/mate-a.meta" "$case_dir/home"
+
+  log="$case_dir/timings.tsv"
+  PATH="$fakebin:$BASE_PATH" FM_HOME="$case_dir/home" FM_ROOT_OVERRIDE="$ROOT" \
+    FM_FAKE_TREEHOUSE_LEASE_HELP=1 FM_BOOTSTRAP_NETWORK=only \
+    FM_BOOTSTRAP_NETWORK_LOCK_PID=$$ FM_TIMING_LOG="$log" FM_TIMING_EPOCH_MS=0 \
+    "$ROOT/bin/fm-bootstrap.sh" >/dev/null 2>&1
+
+  assert_present "$log" "the network phase recorded no elapsed times at all"
+  assert_timing_record "$log" phase gh-auth '' "the GitHub auth probe was not timed"
+  assert_timing_record "$log" phase secondmate-liveness '' "the dead-secondmate relaunch sweep was not timed"
+  assert_timing_record "$log" phase secondmate-sync '' "the secondmate convergence sweep was not timed"
+  assert_timing_record "$log" phase handoff-delivery '' "the pending handoff sweep was not timed"
+  assert_timing_record "$log" phase fleet-sync '' "the project clone refresh was not timed"
+  assert_timing_record "$log" secondmate liveness mate-a \
+    "the liveness sweep was not attributed to the individual secondmate it checked"
+  assert_timing_record "$log" clone sync alpha \
+    "the clone refresh was not attributed to the individual clone it refreshed"
+
+  # Every record carries a start offset and an elapsed time, both numeric, so the
+  # artifact can be read as a timeline rather than a bag of durations.
+  fields=$(awk -F'\t' '$4 ~ /^[0-9]+$/ && $5 ~ /^[0-9]+$/ { n++ } END { print n+0 }' "$log")
+  [ "$fields" = "$(grep -c . "$log")" ] \
+    || fail "some records lack a numeric start offset and elapsed time: $(cat "$log")"
+
+  # And an ordinary run - the local half, or any caller that never asked for
+  # timings - writes nothing anywhere.
+  rm -f "$log"
+  PATH="$fakebin:$BASE_PATH" FM_HOME="$case_dir/home" FM_ROOT_OVERRIDE="$ROOT" \
+    FM_FAKE_TREEHOUSE_LEASE_HELP=1 FM_BOOTSTRAP_NETWORK=only \
+    FM_BOOTSTRAP_NETWORK_LOCK_PID=$$ \
+    "$ROOT/bin/fm-bootstrap.sh" >/dev/null 2>&1
+  assert_absent "$log" "a run that never asked for timings recorded them anyway"
+  pass "bootstrap: each deferred network phase, secondmate, and clone records its own elapsed time"
+}
+
 test_tasks_axi_verdict_handoff_is_consumed_once() {
   local case_dir fakebin log out
   case_dir="$TMP_ROOT/tasks-axi-handoff"
@@ -1105,6 +1170,7 @@ test_routine_bootstrap_confirmations_are_silent
 test_routine_bootstrap_contract_runs_under_system_bash
 test_network_phase_partitions_the_run
 test_network_sweeps_recheck_lock_ownership
+test_network_phases_record_per_step_elapsed_times
 test_tasks_axi_verdict_handoff_is_consumed_once
 test_crew_dispatch_active_rules_are_verbose_bootstrap_info
 test_crew_dispatch_validation

--- a/tests/fm-startup-network.test.sh
+++ b/tests/fm-startup-network.test.sh
@@ -48,6 +48,16 @@ set -u
 printf 'network=%s detect_only=%s\n' \
   "${FM_BOOTSTRAP_NETWORK:-all}" "${FM_BOOTSTRAP_DETECT_ONLY:-0}" \
   >> "${FM_FAKE_BOOTSTRAP_LOG:?}"
+# The real sweeps record their elapsed times through fm-timing-lib.sh, which
+# reaches them as an exported FM_TIMING_LOG. Recording the same way here proves
+# the stage actually hands that channel to its child and publishes what the child
+# wrote - the part of the contract this suite owns. What the real sweeps measure
+# is owned by tests/fm-bootstrap.test.sh.
+if [ -n "${FM_TIMING_LOG:-}" ]; then
+  . "$(dirname "$0")/fm-timing-lib.sh"
+  fm_timing_record phase "${FM_FAKE_TIMING_PHASE:-gh-auth}" \
+    "$(( $(fm_timing_now_ms) - 1500 ))" "${FM_FAKE_TIMING_DETAIL:-}"
+fi
 [ -z "${FM_FAKE_BOOTSTRAP_SLEEP:-}" ] || sleep "$FM_FAKE_BOOTSTRAP_SLEEP"
 [ -z "${FM_FAKE_BOOTSTRAP_OUT:-}" ] || printf '%s\n' "$FM_FAKE_BOOTSTRAP_OUT"
 exit "${FM_FAKE_BOOTSTRAP_RC:-0}"
@@ -457,6 +467,150 @@ EOF
   pass "fm-startup-network: fleet-lock takeover cannot overlap a mutating sweep"
 }
 
+# Every record carries a start offset from ONE origin, so the artifact reads as a
+# timeline and not just a bag of durations. The origin is normally exported by the
+# stage, but a process that starts recording without one has to adopt an origin
+# and KEEP it: recomputing it per record would silently flatten every offset to
+# zero and lose the ordering the artifact exists to show. Driven with explicit
+# start stamps so the assertion does not depend on the host clock's resolution.
+test_records_share_one_origin_so_offsets_form_a_timeline() {
+  local dir log offsets count second third
+  dir="$TMP_ROOT/timing-origin"
+  mkdir -p "$dir"
+  log="$dir/timings.tsv"
+
+  (
+    # shellcheck source=bin/fm-timing-lib.sh
+    . "$ROOT/bin/fm-timing-lib.sh"
+    unset FM_TIMING_EPOCH_MS
+    FM_TIMING_LOG=$log
+    export FM_TIMING_LOG
+    base=$(fm_timing_now_ms)
+    fm_timing_record phase first "$base"
+    fm_timing_record phase second "$(( base + 5000 ))"
+    fm_timing_record phase third "$(( base + 9000 ))"
+  )
+
+  # The origin lands within the first record, so that record's own offset rounds
+  # to zero; what proves the origin was KEPT is that the later records are spaced
+  # by exactly the interval they were given. Recomputing the origin per record
+  # would report every one of them as zero.
+  offsets=$(awk -F'\t' '$1 == "v1" { print $4 }' "$log")
+  count=$(printf '%s\n' "$offsets" | grep -c .)
+  second=$(printf '%s\n' "$offsets" | sed -n 2p)
+  third=$(printf '%s\n' "$offsets" | sed -n 3p)
+  [ "$count" -eq 3 ] || fail "expected three records, got: $offsets"
+  [ "$second" -gt 0 ] && [ "$third" -gt "$second" ] \
+    || fail "records did not share one origin - offsets were: $offsets"
+  [ "$(( third - second ))" -eq 4000 ] \
+    || fail "offsets did not preserve the interval between records: $offsets"
+  pass "fm-startup-network: timing records share one origin so their offsets form a timeline"
+}
+
+# The whole point of the artifact is that it is FREE until someone asks for it.
+# `harvest` is what composes a session start's NETWORK CHECKS section, so a
+# timing line leaking into it would be a change to every startup's output; only
+# the on-demand `report` may print them.
+test_timings_are_published_and_only_the_on_demand_report_prints_them() {
+  local rec home root log report_out harvest_out
+  rec=$(new_world timings-published)
+  IFS='|' read -r home root log <<EOF
+$rec
+EOF
+  printf '%s\n' $$ > "$home/state/.lock"
+
+  FM_FAKE_BOOTSTRAP_LOG="$log" FM_FAKE_BOOTSTRAP_OUT='sweep finding' \
+    FM_FAKE_TIMING_PHASE=fleet-sync FM_FAKE_TIMING_DETAIL=dotfiles-private \
+    run_stage "$home" "$root" run --locked 1
+
+  assert_present "$home/state/.startup-network.timings" \
+    "a finished run published no timing record"
+  assert_grep 'fleet-sync' "$home/state/.startup-network.timings" \
+    "the stage did not publish what the sweep recorded"
+  assert_grep 'stage	network-checks' "$home/state/.startup-network.timings" \
+    "the stage did not record its own bounded total"
+
+  report_out=$(run_stage "$home" "$root" report)
+  assert_contains "$report_out" "sweep finding" "report stopped printing the sweep result"
+  assert_contains "$report_out" "TIMINGS" "report did not print the per-step timings"
+  assert_contains "$report_out" "fleet-sync dotfiles-private" \
+    "report did not attribute the elapsed time to the clone that spent it"
+  assert_contains "$report_out" "slowest:" "report did not surface the slowest steps"
+
+  harvest_out=$(run_stage "$home" "$root" harvest --pid $$)
+  assert_contains "$harvest_out" "sweep finding" "harvest stopped printing the sweep result"
+  assert_not_contains "$harvest_out" "TIMINGS" \
+    "the timings leaked into the session-start digest section"
+  assert_not_contains "$harvest_out" "slowest:" \
+    "the timings leaked into the session-start digest section"
+  pass "fm-startup-network: timings are durable and printed only on demand"
+}
+
+# A run that hit the bound is exactly the run worth attributing, so whatever the
+# killed sweeps managed to record must survive rather than being discarded with
+# them.
+test_a_bounded_run_still_publishes_the_timings_it_managed_to_record() {
+  local rec home root log report_out
+  rec=$(new_world timings-partial)
+  IFS='|' read -r home root log <<EOF
+$rec
+EOF
+  printf '%s\n' $$ > "$home/state/.lock"
+
+  FM_STARTUP_NETWORK_TIMEOUT=1 FM_SESSION_START_TIMEOUT=2 \
+    FM_FAKE_BOOTSTRAP_LOG="$log" FM_FAKE_BOOTSTRAP_SLEEP=20 \
+    FM_FAKE_TIMING_PHASE=secondmate-liveness FM_FAKE_TIMING_DETAIL='mate-a@host-one' \
+    run_stage "$home" "$root" run --locked 1
+
+  [ "$(sed -n 's/^state=//p' "$home/state/.startup-network.status")" = timeout ] \
+    || fail "the bounded run did not record itself as timed out"
+  report_out=$(run_stage "$home" "$root" report)
+  assert_contains "$report_out" "hit the 1s bound" "the bound stopped being reported"
+  assert_contains "$report_out" "secondmate-liveness mate-a@host-one" \
+    "a timed-out run discarded the partial timings its sweeps had already recorded"
+  pass "fm-startup-network: a timed-out run still publishes the partial timings it recorded"
+}
+
+# The artifact is read by a human looking at a slow startup, so it must be
+# incapable of carrying an argv or a credential out of a sweep, and incapable of
+# being broken by one either: a detail with tabs or newlines would otherwise
+# forge extra records.
+test_the_timing_artifact_cannot_carry_a_command_line_or_forge_records() {
+  local rec home root log lines report_out
+  rec=$(new_world timings-sanitized)
+  IFS='|' read -r home root log <<EOF
+$rec
+EOF
+  printf '%s\n' $$ > "$home/state/.lock"
+
+  FM_FAKE_BOOTSTRAP_LOG="$log" FM_FAKE_TIMING_PHASE=secondmate-sync \
+    FM_FAKE_TIMING_DETAIL="ssh -i /key host	v1	forged	0	9999
+GITHUB_TOKEN=ghp_supersecretvalue" \
+    run_stage "$home" "$root" run --locked 1
+
+  assert_no_grep 'ghp_supersecretvalue' "$home/state/.startup-network.timings" \
+    "the timing artifact carried a credential-shaped value through"
+  assert_no_grep 'forged' "$home/state/.startup-network.timings" \
+    "a detail containing tabs forged an extra timing record"
+  assert_no_grep 'ssh' "$home/state/.startup-network.timings" \
+    "the timing artifact carried a command line through"
+  assert_grep 'unrecordable' "$home/state/.startup-network.timings" \
+    "free text was silently dropped instead of being marked unrecordable"
+  lines=$(grep -c . "$home/state/.startup-network.timings")
+  [ "$lines" -eq 2 ] \
+    || fail "one sweep record plus the stage total should be 2 lines, got $lines"
+
+  # The step itself is still measured - only its untrustworthy label is refused,
+  # so a sweep that mislabels itself still shows up as time spent.
+  assert_grep 'secondmate-sync' "$home/state/.startup-network.timings" \
+    "refusing the label also discarded the measurement"
+
+  report_out=$(run_stage "$home" "$root" report)
+  assert_not_contains "$report_out" "ghp_supersecretvalue" \
+    "the rendered report printed a credential-shaped value"
+  pass "fm-startup-network: the timing artifact cannot carry a command line or forge records"
+}
+
 test_wait_fails_without_a_published_stage
 test_start_returns_without_holding_the_callers_stdout
 test_harvest_acknowledgement_suppresses_the_wake_and_no_claim_produces_it
@@ -469,5 +623,8 @@ test_start_is_single_flight
 test_start_reserves_its_generation_before_returning
 test_new_lock_owner_does_not_reuse_the_previous_owners_worker
 test_lock_takeover_stays_read_only_while_a_sweep_holds_the_lease
-
+test_records_share_one_origin_so_offsets_form_a_timeline
+test_timings_are_published_and_only_the_on_demand_report_prints_them
+test_a_bounded_run_still_publishes_the_timings_it_managed_to_record
+test_the_timing_artifact_cannot_carry_a_command_line_or_forge_records
 echo "# fm-startup-network.test.sh: all assertions passed"


### PR DESCRIPTION
## Intent

Instrument firstmate's deferred startup-network stage with per-step elapsed timings so a slow run can be attributed without external tracing.

BACKGROUND: bin/fm-startup-network.sh runs session start's network work off the blocking path and publishes only an aggregate started/finished pair in state/.startup-network.status. Observed runs took 69s and 53s wall clock with no per-phase, per-secondmate, or per-clone detail, so a slow run could not be attributed without re-running it by hand under manual tracing.

CAPTAIN'S OVERRIDING CONSTRAINT (2026-08-07): the instrumentation must NOT affect user experience in any way. Zero synchronous blocking, zero UX change. It must simply produce an artifact somewhere that can be found if the captain asks. Specifically: no new chat noise, no new notifications, no new wake type, and no new mandatory file reads in the synchronous session-start digest. UX is unchanged unless the captain explicitly asks for the report.

WHAT WAS ASKED FOR:
- Per-phase elapsed timings for each mutating sweep owner that runs off the blocking path: gh auth probe, secondmate liveness, secondmate sync/convergence, pending handoff delivery, and fleet-sync (project clone refresh). Each phase's wall-time plus start offset from stage start.
- Per-secondmate elapsed for remote-touching steps (host + id), so the captain can see which host is slow, without printing secrets or full command lines.
- Per-clone, or at least aggregate+slowest, fleet-sync detail when refresh cost dominates.
- Keep the stage network-deferred and bounded (FM_STARTUP_NETWORK_TIMEOUT and the per-sweep timeouts owned by bin/fm-startup-network.sh / bin/fm-bootstrap.sh's network-only phase). No new blocking path, no new daemon, no parallel metrics system.
- Prefer minimal changes in bin/fm-startup-network.sh and the bootstrap network-only phase owners (bin/fm-bootstrap.sh network sweeps, bin/fm-fleet-sync.sh, secondmate liveness/sync helpers).
- Update contract/docs where the report format is part of an owned surface (e.g. bin/fm-startup-network.sh's header comments).
- Tests covering at least: (a) timing lines appear on a fake/fast path, (b) a failure/timeout still publishes partial timings when available, (c) the artifact is valid and does not leak secrets or command lines.

DELIBERATE DECISIONS MADE WHILE IMPLEMENTING (these are intentional, not oversights):

1. Timings are printed ONLY by the on-demand 'fm-startup-network.sh report' command, never by 'harvest'. The brief mentioned appending timings to the durable report body, but the report body is printed inline in the session-start digest by harvest, so doing that literally would have changed every startup's output and violated the captain's zero-UX-change constraint. They therefore live in a separate sidecar file, state/.startup-network.timings, which only 'report' renders. This resolves the tension in favour of the captain's overriding constraint. There is a test asserting both halves: report prints them, harvest does not.

2. A tab-separated record format was chosen over the optionally-suggested .timings.json sidecar. The brief said JSON was optional; TSV is already machine-readable, needs no jq dependency, and appends atomically as single short lines under PIPE_BUF so several concurrent writer processes interleave whole lines. Per the captain's standing preference, the simplest direct path was taken rather than adding machinery.

3. A new sourced library, bin/fm-timing-lib.sh, is the single owner of the record format, the clock, the sanitizer, and the renderer, rather than scattering printf calls across three scripts. It is inert unless FM_TIMING_LOG names a file, which only the deferred stage sets, so an ordinary bootstrap or fleet-sync run records nothing and pays nothing.

4. Secret safety is structural rather than cosmetic. A detail field carrying ANY whitespace is refused outright and recorded as the literal token 'unrecordable', instead of being character-sanitized. This is deliberate: identities (a secondmate id, a host, a clone directory name) never contain whitespace, while the things that must never reach the file (a command line, an environment dump, a captured error) always do. Merely sanitizing would leave the token in KEY=secret behind, because a credential is made of exactly the characters an identity is made of. The remaining text is then narrowed to [A-Za-z0-9._@:/+-] and truncated, which is what prevents a detail from forging extra tab-separated records. The measurement is still kept when its label is refused, so a mislabelled step still shows up as time spent.

5. Two per-item loop bodies in bin/fm-bootstrap.sh were split into their own functions (secondmate_liveness_one and the nested secondmate_sync_remote_one) so each iteration could be individually timed. Every 'continue' became a 'return 0' with identical meaning - move on to the next secondmate. The sweeps still run directly, in the same order, and hand off the same results; SECONDMATE_RESPAWNED_IDS remains a global that the liveness sweep passes to secondmate_sync. This produces a large whitespace-only reindentation in the diff; the semantic change is small.

6. Timing stamp variables are named __fm_timing_stamp rather than 'start'. This is not cosmetic: fleet_sync and several other swept functions assign plain names like 'start' without 'local', and bash's dynamic scoping had them overwrite the caller's stamp and report a nonsense elapsed time. That was a real bug found and fixed during implementation.

7. An earlier draft used a timed_network_phase wrapper that invoked each sweep as "$@". That was replaced with direct inline calls because the indirection made shellcheck unable to see any sweep being invoked, cascading SC2329 'never invoked' across the whole file. Direct calls keep bin/fm-lint.sh clean.

8. The lazily-adopted timing origin is set by a function that assigns FM_TIMING_EPOCH_MS rather than printing it, because reading it through a command substitution would compute it in a subshell, discard it, and flatten every start offset to zero. That was the second real bug found during implementation; there is a clock-independent regression test for it.

9. Timings are published for every outcome including timeout and failure, since a run that hit the bound is exactly the run whose per-step record is worth having. Publication failure of the timings is discarded rather than downgrading the run, because the report itself is the contract and the timings are diagnostic only.

10. On a host where 'env bash' resolves to macOS's system bash 3.2, EPOCHREALTIME is unavailable and timings degrade to whole-second granularity rather than being lost. This is accepted and documented in the library header: the steps being measured are seconds-scale, so it is a coarser answer to 'which host was slow', not a missing one.

This is firstmate's own shared tracked material, so the firstmate-coding-guidelines skill applies: one sentence per line in tracked Markdown, plain dash never an em dash, no agent co-author on commits, bin/*.sh must pass bin/fm-lint.sh, tests colocated in tests/ extending existing suites rather than new runners, and tests must exercise behavior through an executable interface rather than asserting implementation source text.

Acceptance: a completed deferred run's artifact lets firstmate answer 'what took the time' without external tracing; the artifact is silent in normal UX; contract docs are updated; and bin/fm-session-start.sh and bin/fm-startup-network.sh existing coverage still passes with no regression.

## What Changed

- Add `bin/fm-timing-lib.sh`, a sourced, off-by-default library that owns the deferred network stage's timing: a shared millisecond clock (EPOCHREALTIME with a whole-second fallback for bash 3.2), a lazily-adopted epoch origin, a whitespace-refusing `detail` sanitizer that structurally excludes command lines and secrets, and a renderer that prints all records plus the slowest few. It stays inert unless `FM_TIMING_LOG` names a file.
- Wire `bin/fm-startup-network.sh` to start a timing log (exported to child sweeps), record the bounded stage total, and publish per-step records into a new `state/.startup-network.timings` sidecar for every outcome including timeout and failure; the timings are rendered only by the on-demand `report` command, never by `harvest`, so ordinary session-start output is unchanged. Publishing the sidecar can fail without downgrading the run.
- Split the per-secondmate loop bodies in `bin/fm-bootstrap.sh` into `secondmate_liveness_one` and `secondmate_sync_remote_one` and time each iteration by host/id, and time each clone refresh in `bin/fm-fleet-sync.sh`; update `AGENTS.md` and `docs/scripts.md` for the new sidecar and library, and extend the bootstrap and startup-network test suites to cover timing lines on a fast path, partial timings on failure, secret/argv non-leakage, and that `report` prints timings while `harvest` does not.

## Risk Assessment

✅ Low: The change is well-bounded, opt-in and inert by default, adds no synchronous or blocking path, and its large diff is a faithful behavior-preserving extraction backed by behavioral tests that satisfy every required acceptance criterion.

## Testing

The fm-startup-network suite passed all 16 assertions covering the three required cases: timings appear on the fast path, a timed-out run still publishes partial records, and the artifact refuses whitespace-bearing details so it cannot leak a credential or forge records. The fm-bootstrap suite driving real per-phase, per-secondmate, and per-clone recording passed all 28 assertions including the per-step timing test. Report renders a labeled timeline attributing elapsed ms to each phase, secondmate by id and host, and clone, plus a slowest ranking, while harvest prints none of it and the raw TSV carries no secrets. No failures.

<details>
<summary>Evidence: Operator report transcript</summary>

```text
===== operator runs: fm-startup-network.sh report =====
completed off the startup path in 0s: GitHub authentication.
secondmate mate-a: converged
fleet-sync: 2 clones refreshed
NETWORK_CHECKS: the fleet lock was no longer held by the session that requested these, so dead-secondmate relaunch, secondmate convergence, pending handoff delivery, and project clone refresh were skipped; they belong to whichever session holds the lock now
These ran AFTER the sections above were composed, so re-read any record a line here names.
TIMINGS - where the deferred network checks spent their time (ms):
  phase       gh-auth                                    start=+0       elapsed=400
  phase       secondmate-liveness                        start=+0       elapsed=21002
  secondmate  liveness mate-a@build-host-01              start=+0       elapsed=21004
  phase       secondmate-sync                            start=+0       elapsed=12006
  secondmate  sync mate-a@build-host-01                  start=+0       elapsed=12008
  phase       handoff-delivery                           start=+0       elapsed=1210
  phase       fleet-sync                                 start=+0       elapsed=33012
  clone       sync dotfiles-private                      start=+0       elapsed=33013
  clone       sync notes                                 start=+0       elapsed=4015
  stage       network-checks probe                       start=+0       elapsed=247
  slowest: clone sync dotfiles-private 33013ms, phase fleet-sync 33012ms, secondmate liveness mate-a@build-host-01 21004ms

===== session-start digest (harvest) - timings MUST be absent =====
completed off the startup path in 0s: GitHub authentication.
secondmate mate-a: converged
fleet-sync: 2 clones refreshed
NETWORK_CHECKS: the fleet lock was no longer held by the session that requested these, so dead-secondmate relaunch, secondmate convergence, pending handoff delivery, and project clone refresh were skipped; they belong to whichever session holds the lock now
These ran AFTER the sections above were composed, so re-read any record a line here names.

===== raw sidecar artifact state/.startup-network.timings (TSV) =====
v1	phase	gh-auth	0	400	
v1	phase	secondmate-liveness	0	21002	
v1	secondmate	liveness	0	21004	mate-a@build-host-01
v1	phase	secondmate-sync	0	12006	
v1	secondmate	sync	0	12008	mate-a@build-host-01
v1	phase	handoff-delivery	0	1210	
v1	phase	fleet-sync	0	33012	
v1	clone	sync	0	33013	dotfiles-private
v1	clone	sync	0	4015	notes
v1	stage	network-checks	0	247	probe
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"57fc6b420fe259f73828490d749218bc0394c913","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bash tests/fm-startup-network.test.sh`
- `bash tests/fm-bootstrap.test.sh`
- `Manual E2E report and harvest run`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
