### PR TITLE
feat(capabilities): add the typed capability catalog of sixteen fleet capabilities (CFVC-09)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,7 +38,7 @@ Hard rules, in priority order:
    If work failed, say so plainly with the evidence.
 
 You may maintain this repo's private operational state directly.
-Shared tracked material is `AGENTS.md`, `README.md`, `CONTRIBUTING.md`, `.tasks.toml`, `.github/workflows/`, `bin/`, `.agents/skills/`, and public `skills/`.
+Shared tracked material is `AGENTS.md`, `README.md`, `CONTRIBUTING.md`, `.tasks.toml`, `.github/workflows/`, `bin/`, `.agents/skills/`, `capabilities/`, and public `skills/`.
 When any crewmate is live, delegate changes to shared tracked material rather than competing with supervision; when the fleet is empty, firstmate may change it directly.
 This repo is a shared template, while `.env`, `data/`, `state/`, `config/`, `projects/`, and `.no-mistakes/` are captain-private and gitignored.
 Ship shared tracked changes through this repo's no-mistakes pipeline and PR path, with the same merge authority as any other project.
@@ -62,6 +62,7 @@ README.md            public overview and development notes
 .agents/skills/      firstmate-loaded internal skills, committed; each carries metadata.internal=true for installers
 .claude/skills       symlink to .agents/skills for claude compatibility
 skills/              standalone public installer-facing skills, committed; not loaded by firstmate
+capabilities/        capability catalog, committed: catalog.json names the sixteen typed capabilities and their existing owners. Definitions only - no runtime reads it, nothing is bound, and the file itself certifies that it is a capability boundary and not a security boundary
 bin/                 helper scripts, committed; read each script's header before first use
 .env                 optional Relay pairing token; LOCAL, gitignored; presence-gates section 14
 config/crew-harness  crewmate harness override; LOCAL, gitignored; absent or "default" = same as firstmate. Inherited as the literal file: a concrete primary adapter value also controls a secondmate home's own crewmates (section 4)

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -134,7 +134,7 @@ family_for_basename() {
   case "$1" in
     fm-arm-pretool-check.test.sh|fm-ask-user-authority.test.sh|\
     fm-brief.test.sh|fm-vendor-auth-probe.test.sh|\
-    fm-calm-pi-extension.test.sh|fm-cd-pretool-check.test.sh|\
+    fm-calm-pi-extension.test.sh|fm-capability-catalog.test.sh|fm-cd-pretool-check.test.sh|\
     fm-composer-ghost.test.sh|fm-composer-lib.test.sh|\
     fm-crew-state.test.sh|fm-decision-hold-lifecycle.test.sh|\
     fm-documentation-audiences.test.sh|fm-ensure-agents-md.test.sh|fm-grok-harness.test.sh|\

--- a/capabilities/catalog.json
+++ b/capabilities/catalog.json
@@ -1,0 +1,175 @@
+{
+  "capability_catalog_version": 1,
+  "description": "Harness-neutral catalog of the typed capabilities a Firstmate work identity may be said to hold. Definitions ONLY: nothing here is bound to an agent, nothing here executes, and no runtime reads this file. Each row names the existing owner that already implements the action, so the catalog renames a prose capability list ('use gh-axi, use chrome-devtools-axi') as typed rows without changing what any agent can do.",
+  "not_a_security_boundary": {
+    "statement": "This catalog is a CAPABILITY boundary, not a SECURITY boundary. It constrains a mistaken agent, never a hostile one.",
+    "why": "Every crewmate on every harness is currently launched with permission enforcement disabled - four through an explicit bypass flag and one because that harness has no permission system at all (bin/fm-launch-lib.sh; docs/launcher.md). The supported harnesses also do not share a sandbox. An agent that ignores a row, or a harness with no sandbox behind it, is not stopped by anything in this file.",
+    "consequence": "No decision anywhere may treat a row in this catalog as containment. A capability being named 'read-only' means the fleet intends it to be read-only, not that the host prevents a write.",
+    "when_this_changes": "Only when an enforcement point exists that refuses rather than truncates. CFVC-10 (capability binding record and issue-time authority law) is the increment that would create it, and it is deliberately not built here: it is blocked on the open work-identity ownership decision."
+  },
+  "authority_class": {
+    "source": "loopspecs/schema.json enums.authority_class",
+    "rule": "This catalog reuses that validated enum verbatim and never introduces a value of its own. A capability needing a class that does not exist is a change to the LoopSpec schema's enum, decided there, not a new vocabulary here.",
+    "meaning": {
+      "read-only": "Observes state and mutates nothing.",
+      "firstmate-routine": "Firstmate may exercise it within an already accepted task contract, with no fresh captain word.",
+      "captain-required": "Needs an explicit captain instruction for the concrete action, every time. Standing autonomy never substitutes."
+    }
+  },
+  "not_the_platform_capability_registry": "This is NOT the platform's CapabilityRegistry (its scripts/runtime_capabilities.py, a separate repository) and must never be merged into it. That registry answers a Kernel-side question - which service implementation handles a call - while this catalog answers an agent-side question - what a work identity is permitted to do. Conflating them would make a dispatch table look like an authority record.",
+  "field_contract": {
+    "name": "Dotted capability_id. Stable; the identity a future binding record would cite.",
+    "input_schema": "Typed inputs, using the loopspecs/schema.json type vocabulary (slug, string, string[], bool, object, pos_int).",
+    "output_schema": "Typed result of one successful exercise of the capability.",
+    "owner": "Repo-relative path to the file that already implements this action. Exactly one owner per row. null ONLY where the catalog deliberately defines a capability nothing owns.",
+    "authority_class": "A value from the enum above.",
+    "verifier": "Repo-relative path to the existing executable check that pins the owner's behavior. null where there is no owner to pin."
+  },
+  "capabilities": [
+    {
+      "name": "workspace.read",
+      "purpose": "Read files inside the work identity's own isolated task worktree.",
+      "input_schema": { "task_id": "slug", "path": "string" },
+      "output_schema": { "content": "string" },
+      "owner": "bin/fm-spawn.sh",
+      "authority_class": "read-only",
+      "verifier": "tests/fm-spawn-worktree-settle.test.sh"
+    },
+    {
+      "name": "workspace.write",
+      "purpose": "Create, edit, or delete files inside the work identity's own isolated task worktree, and nowhere else.",
+      "input_schema": { "task_id": "slug", "path": "string", "content": "string" },
+      "output_schema": { "path": "string", "written": "bool" },
+      "owner": "bin/fm-spawn.sh",
+      "authority_class": "firstmate-routine",
+      "verifier": "tests/fm-spawn-worktree-settle.test.sh"
+    },
+    {
+      "name": "worktree.allocate",
+      "purpose": "Obtain a disposable pool slot for a new task, refusing any slot that still holds live or unlanded work.",
+      "input_schema": { "task_id": "slug" },
+      "output_schema": { "worktree": "string", "slot": "string" },
+      "owner": "bin/fm-worktree-guard.sh",
+      "authority_class": "firstmate-routine",
+      "verifier": "tests/fm-worktree-guard.test.sh"
+    },
+    {
+      "name": "vcs.base.resolve",
+      "purpose": "Resolve a task's two base references - the slot base the worktree sits at, and the contribution target the work is offered to.",
+      "input_schema": { "task_id": "slug", "project": "slug" },
+      "output_schema": { "slot_base": "string", "contribution_target": "string", "base_state": "string" },
+      "owner": "bin/fm-task-base-lib.sh",
+      "authority_class": "read-only",
+      "verifier": "tests/fm-task-base.test.sh"
+    },
+    {
+      "name": "vcs.landed.verify",
+      "purpose": "Decide whether a branch's content is already contained in an accepted landing target, which is what makes discarding it safe.",
+      "input_schema": { "repo": "string", "ref": "string" },
+      "output_schema": { "landed": "bool", "landing_target": "string" },
+      "owner": "bin/fm-landed-lib.sh",
+      "authority_class": "read-only",
+      "verifier": "tests/fm-worktree-guard.test.sh"
+    },
+    {
+      "name": "vcs.merge.local",
+      "purpose": "Fast-forward a ready local-only branch onto the project's default branch.",
+      "input_schema": { "task_id": "slug" },
+      "output_schema": { "merged_ref": "string", "head": "string" },
+      "owner": "bin/fm-merge-local.sh",
+      "authority_class": "captain-required",
+      "verifier": "tests/fm-merge-local.test.sh"
+    },
+    {
+      "name": "forge.pr.read",
+      "purpose": "Read a pull or merge request's identity, head, and check state from the supported forges.",
+      "input_schema": { "url": "string" },
+      "output_schema": { "provider": "string", "number": "pos_int", "head": "string", "checks": "string" },
+      "owner": "bin/fm-pr-lib.sh",
+      "authority_class": "read-only",
+      "verifier": "tests/fm-pr-check-security.test.sh"
+    },
+    {
+      "name": "forge.pr.merge",
+      "purpose": "Merge a task's pull request after re-verifying that its current head is green, mergeable, and unblocked by review.",
+      "input_schema": { "task_id": "slug", "url": "string" },
+      "output_schema": { "merged": "bool", "merge_verified_head": "string" },
+      "owner": "bin/fm-pr-merge.sh",
+      "authority_class": "captain-required",
+      "verifier": "tests/fm-pr-merge.test.sh"
+    },
+    {
+      "name": "validation.run",
+      "purpose": "Attribute and drive a no-mistakes validation run for a worktree's current branch and code identity.",
+      "input_schema": { "task_id": "slug", "worktree": "string" },
+      "output_schema": { "run_id": "string", "step": "string" },
+      "owner": "bin/fm-nm-run-lib.sh",
+      "authority_class": "firstmate-routine",
+      "verifier": "tests/fm-crew-state.test.sh"
+    },
+    {
+      "name": "agent.spawn",
+      "purpose": "Launch a worker agent on a verified harness adapter with a resolved model and effort.",
+      "input_schema": { "task_id": "slug", "harness": "slug", "model": "string", "effort": "string" },
+      "output_schema": { "endpoint": "string", "harness": "slug" },
+      "owner": "bin/fm-launch-lib.sh",
+      "authority_class": "firstmate-routine",
+      "verifier": "tests/fm-launch-lib.test.sh"
+    },
+    {
+      "name": "agent.steer",
+      "purpose": "Deliver one marked operational message to a named agent endpoint.",
+      "input_schema": { "task_id": "slug", "message": "string" },
+      "output_schema": { "delivered": "bool" },
+      "owner": "bin/fm-send.sh",
+      "authority_class": "firstmate-routine",
+      "verifier": "tests/fm-send-strict.test.sh"
+    },
+    {
+      "name": "agent.state.read",
+      "purpose": "Reconcile an agent's current run state from live evidence rather than from its own status claims.",
+      "input_schema": { "task_id": "slug" },
+      "output_schema": { "state": "string", "evidence": "string[]" },
+      "owner": "bin/fm-crew-state.sh",
+      "authority_class": "read-only",
+      "verifier": "tests/fm-crew-state.test.sh"
+    },
+    {
+      "name": "agent.teardown",
+      "purpose": "Release a task's agent, worktree, and runtime records after proving its work is landed.",
+      "input_schema": { "task_id": "slug" },
+      "output_schema": { "released": "bool", "refusal_reason": "string" },
+      "owner": "bin/fm-teardown.sh",
+      "authority_class": "firstmate-routine",
+      "verifier": "tests/fm-teardown.test.sh"
+    },
+    {
+      "name": "backlog.update",
+      "purpose": "Record dispatch, completion, holds, and dependencies against the durable task queue.",
+      "input_schema": { "task_id": "slug", "state": "string", "note": "string" },
+      "output_schema": { "task_id": "slug", "state": "string" },
+      "owner": "bin/fm-tasks-axi-lib.sh",
+      "authority_class": "firstmate-routine",
+      "verifier": "tests/fm-backlog-handoff.test.sh"
+    },
+    {
+      "name": "decision.resolve",
+      "purpose": "Close a captain-gated decision hold against a recorded verdict, so an answered question stops being re-asked.",
+      "input_schema": { "hold_id": "slug", "verdict": "string" },
+      "output_schema": { "hold_id": "slug", "resolved": "bool" },
+      "owner": "bin/fm-decision-hold.sh",
+      "authority_class": "captain-required",
+      "verifier": "tests/fm-decision-hold-lifecycle.test.sh"
+    },
+    {
+      "name": "network.request",
+      "purpose": "Make an arbitrary outbound network request that is not already mediated by a named forge, quota, or vendor owner above.",
+      "input_schema": { "url": "string", "method": "string", "body": "string" },
+      "output_schema": { "status": "pos_int", "body": "string" },
+      "owner": null,
+      "authority_class": "captain-required",
+      "verifier": null,
+      "unowned_because": "Deliberate. Nothing in this repo mediates general outbound network access, so naming an owner would invent one. Every agent already has unmediated network access through its harness; recording that as captain-required states the intent and admits, honestly, that nothing enforces it. Siting an owner is CFVC-10's work, not this catalog's."
+    }
+  ]
+}

--- a/capabilities/catalog.json
+++ b/capabilities/catalog.json
@@ -19,7 +19,7 @@
   "not_the_platform_capability_registry": "This is NOT the platform's CapabilityRegistry (its scripts/runtime_capabilities.py, a separate repository) and must never be merged into it. That registry answers a Kernel-side question - which service implementation handles a call - while this catalog answers an agent-side question - what a work identity is permitted to do. Conflating them would make a dispatch table look like an authority record.",
   "field_contract": {
     "name": "Dotted capability_id. Stable; the identity a future binding record would cite.",
-    "input_schema": "Typed inputs, using the loopspecs/schema.json type vocabulary (slug, string, string[], bool, object, pos_int).",
+    "input_schema": "Typed inputs, using the LoopSpec type vocabulary (slug, string, string[], object, pos_int) plus bool, a catalog-local extension of it. The only vocabulary this catalog is required to reuse from loopspecs/schema.json is the authority_class enum.",
     "output_schema": "Typed result of one successful exercise of the capability.",
     "owner": "Repo-relative path to the file that already implements this action. Exactly one owner per row. null ONLY where the catalog deliberately defines a capability nothing owns.",
     "authority_class": "A value from the enum above.",
@@ -163,7 +163,7 @@
     },
     {
       "name": "network.request",
-      "purpose": "Make an arbitrary outbound network request that is not already mediated by a named forge, quota, or vendor owner above.",
+      "purpose": "Make an arbitrary outbound network request that is not already mediated by a named forge owner above.",
       "input_schema": { "url": "string", "method": "string", "body": "string" },
       "output_schema": { "status": "pos_int", "body": "string" },
       "owner": null,

--- a/tests/fm-capability-catalog.test.sh
+++ b/tests/fm-capability-catalog.test.sh
@@ -1,0 +1,223 @@
+#!/usr/bin/env bash
+# Behavior tests for capabilities/catalog.json - the typed capability catalog.
+#
+# The catalog is data with no runtime, so the guarantee under test is the data's
+# own contract rather than any executing code:
+#   (a) every capability names an owner file that exists in this repo
+#   (b) network.request is the ONE deliberately unowned row, and it is
+#       captain-required
+#   (c) every authority_class is a value already in loopspecs/schema.json's
+#       validated enum, so the catalog never grows a second vocabulary
+#   (d) the not-a-security-boundary certification is present and says what it
+#       must - the catalog constrains a mistaken agent, not a hostile one
+#
+# Each check runs against a MUTATED copy first and must fail there, so a pass on
+# the real catalog is evidence the check fires rather than evidence it is
+# vacuous. Every verifier path is pinned the same way: a row may name only a
+# check that exists.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+CATALOG="$ROOT/capabilities/catalog.json"
+SCHEMA="$ROOT/loopspecs/schema.json"
+
+command -v python3 >/dev/null 2>&1 || fail "capability catalog: python3 is required to read the catalog"
+
+# check <what> <catalog-path> - echoes one violation per line, exits 0 always.
+# The single validator both the real catalog and every mutated control run
+# through, so a negative control exercises the same code path as the real check.
+check() {
+  local what=$1 path=$2
+  python3 - "$what" "$path" "$ROOT" "$SCHEMA" <<'PY'
+import json, os, sys
+
+what, path, root, schema_path = sys.argv[1:5]
+
+def out(msg):
+    print(msg)
+
+try:
+    with open(path) as fh:
+        cat = json.load(fh)
+except Exception as exc:  # unreadable or malformed is a violation, never an empty pass
+    out("catalog unreadable: %s" % exc)
+    sys.exit(0)
+
+caps = cat.get("capabilities")
+if not isinstance(caps, list) or not caps:
+    out("catalog has no capabilities list")
+    sys.exit(0)
+
+if what == "owners":
+    for cap in caps:
+        name = cap.get("name", "<unnamed>")
+        owner = cap.get("owner")
+        if name == "network.request":
+            continue
+        if not owner:
+            out("%s has no owner" % name)
+        elif not os.path.exists(os.path.join(root, owner)):
+            out("%s owner does not exist: %s" % (name, owner))
+
+elif what == "verifiers":
+    for cap in caps:
+        name = cap.get("name", "<unnamed>")
+        verifier = cap.get("verifier")
+        if name == "network.request":
+            continue
+        if not verifier:
+            out("%s has no verifier" % name)
+        elif not os.path.exists(os.path.join(root, verifier)):
+            out("%s verifier does not exist: %s" % (name, verifier))
+
+elif what == "unowned":
+    rows = [c for c in caps if c.get("name") == "network.request"]
+    if len(rows) != 1:
+        out("expected exactly one network.request row, found %d" % len(rows))
+    else:
+        row = rows[0]
+        if row.get("owner") is not None:
+            out("network.request must stay unowned, found owner: %r" % row["owner"])
+        if row.get("authority_class") != "captain-required":
+            out("network.request must be captain-required, found: %r"
+                % row.get("authority_class"))
+    unowned = [c.get("name") for c in caps
+               if c.get("name") != "network.request" and not c.get("owner")]
+    for name in unowned:
+        out("%s is unowned but only network.request may be" % name)
+
+elif what == "enum":
+    with open(schema_path) as fh:
+        allowed = json.load(fh)["enums"]["authority_class"]
+    declared = cat.get("authority_class", {}).get("meaning", {})
+    for name in declared:
+        if name not in allowed:
+            out("documented class %r is not in the LoopSpec enum" % name)
+    for cap in caps:
+        cls = cap.get("authority_class")
+        if cls not in allowed:
+            out("%s has authority_class %r, not in the LoopSpec enum %r"
+                % (cap.get("name", "<unnamed>"), cls, allowed))
+
+elif what == "certification":
+    cert = cat.get("not_a_security_boundary")
+    if not isinstance(cert, dict):
+        out("the not-a-security-boundary certification is absent")
+    else:
+        blob = " ".join(str(v) for v in cert.values()).lower()
+        for phrase in ("not a security boundary", "mistaken agent"):
+            if phrase not in blob:
+                out("certification does not state %r" % phrase)
+
+else:
+    out("unknown check: %s" % what)
+PY
+}
+
+# mutate <python-expression-body> - writes a copy of the real catalog with the
+# named edit applied and echoes its path. `cat` is the parsed catalog.
+mutate() {
+  local body=$1 dest
+  dest="$TMP/mutated-$RANDOM.json"
+  python3 - "$CATALOG" "$dest" "$body" <<'PY'
+import json, sys
+src, dest, body = sys.argv[1:4]
+with open(src) as fh:
+    cat = json.load(fh)
+exec(body)  # noqa: S102 - test fixture mutation, not runtime code
+with open(dest, "w") as fh:
+    json.dump(cat, fh)
+PY
+  printf '%s\n' "$dest"
+}
+
+assert_clean() {  # <what> <label>
+  local got
+  got=$(check "$1" "$CATALOG")
+  [ -z "$got" ] || fail "$2: $got"
+}
+
+assert_control_fires() {  # <what> <mutation> <label>
+  local copy got
+  copy=$(mutate "$2")
+  got=$(check "$1" "$copy")
+  [ -n "$got" ] || fail "$3: negative control did not fire - the check is vacuous"
+}
+
+TMP=$(fm_test_tmproot fm-capability-catalog)
+
+test_every_owner_resolves() {
+  assert_control_fires owners \
+    'cat["capabilities"][0]["owner"] = "bin/fm-does-not-exist.sh"' \
+    "capability catalog: owner-existence control"
+  assert_control_fires owners \
+    'cat["capabilities"][0]["owner"] = None' \
+    "capability catalog: missing-owner control"
+  assert_clean owners "capability catalog: every owner must resolve to an existing file"
+  pass "capability catalog: every capability names an owner file that exists"
+}
+
+test_every_verifier_resolves() {
+  assert_control_fires verifiers \
+    'cat["capabilities"][0]["verifier"] = "tests/fm-does-not-exist.test.sh"' \
+    "capability catalog: verifier-existence control"
+  assert_clean verifiers "capability catalog: every verifier must resolve to an existing check"
+  pass "capability catalog: every verifier names a check that exists"
+}
+
+test_network_request_is_unowned_and_captain_required() {
+  assert_control_fires unowned \
+    'cat["capabilities"] = [c for c in cat["capabilities"] if c["name"] != "network.request"]' \
+    "capability catalog: network.request-present control"
+  assert_control_fires unowned \
+    '[c.update(owner="bin/fm-send.sh") for c in cat["capabilities"] if c["name"] == "network.request"]' \
+    "capability catalog: network.request-unowned control"
+  assert_control_fires unowned \
+    '[c.update(authority_class="read-only") for c in cat["capabilities"] if c["name"] == "network.request"]' \
+    "capability catalog: network.request-captain-required control"
+  assert_clean unowned "capability catalog: network.request contract"
+  pass "capability catalog: network.request is the only unowned row and is captain-required"
+}
+
+test_authority_class_reuses_the_existing_enum() {
+  assert_control_fires enum \
+    'cat["capabilities"][0]["authority_class"] = "worker-routine"' \
+    "capability catalog: new-authority_class control"
+  assert_control_fires enum \
+    'cat["authority_class"]["meaning"]["worker-routine"] = "invented"' \
+    "capability catalog: documented-class control"
+  assert_clean enum "capability catalog: authority_class must come from loopspecs/schema.json"
+  pass "capability catalog: every authority_class is in the existing LoopSpec enum"
+}
+
+test_security_boundary_disclaimer_is_present() {
+  assert_control_fires certification \
+    'del cat["not_a_security_boundary"]' \
+    "capability catalog: absent-certification control"
+  assert_control_fires certification \
+    'cat["not_a_security_boundary"] = {"statement": "this catalog contains the blast radius"}' \
+    "capability catalog: weakened-certification control"
+  assert_clean certification "capability catalog: security-boundary disclaimer"
+  pass "capability catalog: states it is a capability boundary, not a security boundary"
+}
+
+test_sixteen_capabilities_with_unique_names() {
+  local count dupes
+  count=$(python3 -c 'import json,sys; print(len(json.load(open(sys.argv[1]))["capabilities"]))' "$CATALOG")
+  [ "$count" = "16" ] || fail "capability catalog: expected 16 capabilities, found $count"
+  dupes=$(python3 -c '
+import json, sys, collections
+names = [c["name"] for c in json.load(open(sys.argv[1]))["capabilities"]]
+print(",".join(n for n, k in collections.Counter(names).items() if k > 1))' "$CATALOG")
+  [ -z "$dupes" ] || fail "capability catalog: duplicate capability names: $dupes"
+  pass "capability catalog: sixteen capabilities with unique names"
+}
+
+test_every_owner_resolves
+test_every_verifier_resolves
+test_network_request_is_unowned_and_captain_required
+test_authority_class_reuses_the_existing_enum
+test_security_boundary_disclaimer_is_present
+test_sixteen_capabilities_with_unique_names

--- a/tests/fm-capability-catalog.test.sh
+++ b/tests/fm-capability-catalog.test.sh
@@ -117,11 +117,13 @@ PY
 }
 
 # mutate <python-expression-body> - writes a copy of the real catalog with the
-# named edit applied and echoes its path. `cat` is the parsed catalog.
+# named edit applied and echoes its path. `cat` is the parsed catalog. A
+# mutation that does not apply fails the test: a control run against an
+# unwritten copy would fire on "catalog unreadable" and prove nothing.
 mutate() {
   local body=$1 dest
   dest="$TMP/mutated-$RANDOM.json"
-  python3 - "$CATALOG" "$dest" "$body" <<'PY'
+  if ! python3 - "$CATALOG" "$dest" "$body" <<'PY'
 import json, sys
 src, dest, body = sys.argv[1:4]
 with open(src) as fh:
@@ -130,6 +132,10 @@ exec(body)  # noqa: S102 - test fixture mutation, not runtime code
 with open(dest, "w") as fh:
     json.dump(cat, fh)
 PY
+  then
+    fail "capability catalog: mutation did not apply: $body"
+  fi
+  [ -f "$dest" ] || fail "capability catalog: mutation wrote no catalog: $body"
   printf '%s\n' "$dest"
 }
 
@@ -141,7 +147,7 @@ assert_clean() {  # <what> <label>
 
 assert_control_fires() {  # <what> <mutation> <label>
   local copy got
-  copy=$(mutate "$2")
+  copy=$(mutate "$2") || exit 1
   got=$(check "$1" "$copy")
   [ -n "$got" ] || fail "$3: negative control did not fire - the check is vacuous"
 }


### PR DESCRIPTION
## Intent

CFVC-09: build the capability catalog - typed definitions ONLY - per data/cfvc-synthesis-and-plan/report.md section 4's CFVC-09 table, which is the authoritative spec.

Goal: a harness-neutral catalog of typed capabilities, each naming an existing owner. Definitions only: nothing is bound, nothing executes, no runtime reads the file.

Context that explains the shape: every crewmate on every harness currently launches with all permission enforcement disabled (bin/fm-launch-lib.sh - four explicit bypass flags plus one harness with no permission system at all), so 'child_authority is a subset of parent_authority' is doctrinal only today. This increment NAMES capabilities. Enforcement arrives later via CFVC-10 (the capability binding record and issue-time authority law), which is deliberately split off and blocked on an open captain ownership decision (work-identity-owner). Building any binding record, broker, or enforcement point HERE was explicitly out of scope and was deliberately not done.

Accepted requirements, all from the spec:
1. Each capability is {name, input_schema, output_schema, owner, authority_class, verifier}.
2. authority_class REUSES loopspecs/schema.json's existing validated enum (read-only, firstmate-routine, captain-required) - never a new vocabulary. This is why the catalog documents the three classes rather than inventing worker-facing ones.
3. Sixteen capabilities, each naming an existing owner - with network.request the single deliberate exception: defined, left UNOWNED, and captain-required. It is unowned on purpose because nothing in this repo mediates general outbound network access, so naming an owner would invent one; the row records that reason in an unowned_because field rather than leaving it to look like an oversight.
4. Must NOT overload or merge into the platform's CapabilityRegistry (its scripts/runtime_capabilities.py, a separate repository): that answers a Kernel-side service-dispatch question, not an agent-side authority question. The catalog states this explicitly.
5. Certification text written into the artifact itself: this catalog is a CAPABILITY boundary, NOT a security boundary - the host constrains a mistaken agent, not a hostile one. It is written in so it can never be quietly assumed away, and it names the enforcement point (CFVC-10) that would change that.
6. Data only. Nothing changes for any agent; rollback is deleting the file.
7. Tests required by the spec: every capability names an owner file that exists; network.request has no owner and is captain-required; every authority_class value is in the existing enum. Completion criteria: every row's owner resolves, no new authority_class, security-boundary disclaimer present.
8. This is firstmate's own shared tracked material, so the firstmate-coding-guidelines skill was loaded and followed.

Decisions made while doing the work, which a reviewer reading only the diff would not know:
- File sited at capabilities/catalog.json, a peer of the existing loopspecs/ registry, rather than inside loopspecs/ (a LoopSpec is temporal recurrence only) and rather than in docs/ (it is typed data, not prose).
- The spec table does NOT enumerate the sixteen rows. It fixes the count, the field shape, the enum reuse and the network.request exception only, so which sixteen capabilities appear was the author's selection. No row was dropped from any authoritative list.
- Owners are all real files under bin/ that already implement the named action, so 'owner' is a statement of current fact rather than an aspiration. The spec's example providers (workspace_provider.py, git_provider.py, ...) live in the platform repo and would not resolve from here, so repo-local owners were chosen deliberately to keep the owner-resolution test meaningful.
- verifier was additionally constrained to name an existing check under tests/, and the test pins that too. The spec did not require it; it was added so no row can name a verifier that does not exist.
- The test runs every check against a MUTATED copy of the catalog first and requires it to FAIL there, then runs the real catalog. This follows the brief's verification discipline: without the negative control, a passing data check could be vacuous.
- Two one-line AGENTS.md updates (tracked-material list, layout tree) and one line in bin/fm-test-run.sh's family classifier, per the coding guidelines' size discipline: the substance lives in the artifact, not in AGENTS.md.
- Verified locally before committing: new test green with every negative control firing, bin/fm-lint.sh clean, bin/fm-doc-audience-check.sh ok, tests/fm-test-run.test.sh and tests/fm-documentation-audiences.test.sh green, and the changed-file selector picks up the new test with nothing unmapped.

Decisions already accepted on an earlier run of this same branch, which a fresh run should honour rather than re-litigate:
- The rebase step is deliberately SKIPPED. This branch is based on the fork trunk on purpose; the commits it carries ahead of upstream are this home's fork landing queue and must never be replayed or bundled into contribution history. Ruled under the captain's standing fork-retarget rule.
- Three review findings were raised and their fixes authorized, but the fix round died when the session limit hit, so none of them landed and the code still carries all three. If review raises them again, the authorized resolutions are:
(a) network.request's purpose says it covers requests 'not already mediated by a named forge, quota, or vendor owner above', but there are no quota or vendor rows. That is stale drafting by the author, confirmed. Fix by dropping the words 'quota, or vendor'. Do NOT add quota or vendor rows: the catalog is fixed at sixteen.
(b) field_contract claims every schema type comes from loopspecs/schema.json's type vocabulary, but 'bool' is a catalog-local extension used by six rows. The provenance claim is factually wrong in a fact-stating artifact. Fix the wording to say the catalog uses the LoopSpec type vocabulary plus 'bool', which extends it, and that the only thing this catalog must reuse from loopspecs/schema.json is the authority_class enum. Do NOT remove bool from the rows and do NOT add bool to loopspecs/schema.json.
(c) tests/fm-capability-catalog.test.sh's mutate() ignores python3's exit status, so a mutation that failed to apply would leave the control passing on a 'catalog unreadable' violation - a broken negative control reading as proof the check fires, the exact vacuity the controls exist to prevent. Fix mutate() to fail loudly when the mutation does not apply, keeping every existing mutation body and all six cases green.

## What Changed

- Adds `capabilities/catalog.json`, a harness-neutral, data-only catalog of sixteen typed capabilities, each defined as `{name, input_schema, output_schema, owner, authority_class, verifier}`. Every owner is an existing script under `bin/` and every verifier an existing check under `tests/`; `authority_class` reuses the validated enum from `loopspecs/schema.json` rather than inventing a new vocabulary. `network.request` is the single deliberate exception — defined, unowned, and captain-required, with the reason recorded in an `unowned_because` field. The artifact states in its own text that it is a capability boundary, not a security boundary, names CFVC-10 as the future enforcement point, and explicitly disclaims merging into the platform's CapabilityRegistry. No runtime reads the file; definitions only.
- Adds `tests/fm-capability-catalog.test.sh`, which runs every check against a mutated catalog copy first and requires it to fail there before accepting the real catalog. The pipeline's review round landed three authorized fixes on this branch: dropped the stale "quota, or vendor" wording from `network.request`'s purpose, corrected the field-contract text to state that `bool` is a catalog-local extension of the LoopSpec type vocabulary, and hardened the test's `mutate()` to fail loudly when a mutation does not apply so a broken negative control can't read as proof the check fires. The new test is wired into `bin/fm-test-run.sh`'s family classifier and the artifact is listed in AGENTS.md's tracked-material list and layout tree.
- The branch is deliberately based on the fork trunk (the pipeline's rebase step was skipped under the standing fork-retarget rule), so the full delta also carries the fork landing queue already merged there: the fleet launcher menu and launch library, admission control stages, model registry with the zero-budget spawn gate, LoopSpec schema and register, wake-outcome ledger, remote-secondmate tooling, and merge/teardown hardening.

## Risk Assessment

✅ Low: The only delta since the last reviewed head is one commit that applies the three author-authorized fixes exactly as specified (two wording corrections in the data-only catalog and a hardened negative-control mutate() whose failure path was verified to propagate via stderr and a non-zero exit through the command substitution), with every round-1 acceptance-criterion verification still holding.

## Testing

Ran the spec-required capability-catalog test (all six checks green), independently audited the catalog against every intent constraint (sixteen typed rows, resolving owners and verifiers, enum reuse, the unowned captain-required network.request exception, both written-in disclaimers), visibly demonstrated the negative controls firing on mutated copies and the hardened mutate() failing loudly, confirmed no runtime reads the file, verified the three previously-authorized review fixes landed in 04f99d0, and covered the peripheral classifier and AGENTS.md edits with their own focused tests — everything passed. No screenshot artifact because the change is a JSON data artifact plus a shell test with no rendered UI surface; CLI transcripts and the audit table are the end-user-facing evidence.

<details>
<summary>Evidence: Capability catalog test transcript (six checks green)</summary>

<code>ok - capability catalog: every capability names an owner file that exists&#10;ok - capability catalog: every verifier names a check that exists&#10;ok - capability catalog: network.request is the only unowned row and is captain-required&#10;ok - capability catalog: every authority_class is in the existing LoopSpec enum&#10;ok - capability catalog: states it is a capability boundary, not a security boundary&#10;ok - capability catalog: sixteen capabilities with unique names</code>

```text
ok - capability catalog: every capability names an owner file that exists
ok - capability catalog: every verifier names a check that exists
ok - capability catalog: network.request is the only unowned row and is captain-required
ok - capability catalog: every authority_class is in the existing LoopSpec enum
ok - capability catalog: states it is a capability boundary, not a security boundary
ok - capability catalog: sixteen capabilities with unique names
```
</details>
<details>
<summary>Evidence: Catalog audit vs CFVC-09 spec (rows, owners, enum, exception, certifications)</summary>

```text
=== capabilities/catalog.json audit (against the CFVC-09 spec) ===

row count: 16 (spec requires 16)
authority_class enum reused from loopspecs/schema.json: ['read-only', 'firstmate-routine', 'captain-required']

name               authority_class    owner                        owner?  verifier                                  verifier?
workspace.read     read-only          bin/fm-spawn.sh              EXISTS  tests/fm-spawn-worktree-settle.test.sh    EXISTS
workspace.write    firstmate-routine  bin/fm-spawn.sh              EXISTS  tests/fm-spawn-worktree-settle.test.sh    EXISTS
worktree.allocate  firstmate-routine  bin/fm-worktree-guard.sh     EXISTS  tests/fm-worktree-guard.test.sh           EXISTS
vcs.base.resolve   read-only          bin/fm-task-base-lib.sh      EXISTS  tests/fm-task-base.test.sh                EXISTS
vcs.landed.verify  read-only          bin/fm-landed-lib.sh         EXISTS  tests/fm-worktree-guard.test.sh           EXISTS
vcs.merge.local    captain-required   bin/fm-merge-local.sh        EXISTS  tests/fm-merge-local.test.sh              EXISTS
forge.pr.read      read-only          bin/fm-pr-lib.sh             EXISTS  tests/fm-pr-check-security.test.sh        EXISTS
forge.pr.merge     captain-required   bin/fm-pr-merge.sh           EXISTS  tests/fm-pr-merge.test.sh                 EXISTS
validation.run     firstmate-routine  bin/fm-nm-run-lib.sh         EXISTS  tests/fm-crew-state.test.sh               EXISTS
agent.spawn        firstmate-routine  bin/fm-launch-lib.sh         EXISTS  tests/fm-launch-lib.test.sh               EXISTS
agent.steer        firstmate-routine  bin/fm-send.sh               EXISTS  tests/fm-send-strict.test.sh              EXISTS
agent.state.read   read-only          bin/fm-crew-state.sh         EXISTS  tests/fm-crew-state.test.sh               EXISTS
agent.teardown     firstmate-routine  bin/fm-teardown.sh           EXISTS  tests/fm-teardown.test.sh                 EXISTS
backlog.update     firstmate-routine  bin/fm-tasks-axi-lib.sh      EXISTS  tests/fm-backlog-handoff.test.sh          EXISTS
decision.resolve   captain-required   bin/fm-decision-hold.sh      EXISTS  tests/fm-decision-hold-lifecycle.test.sh  EXISTS
network.request    captain-required   None                         n/a     None                                      n/a 

=== network.request (the single deliberate exception) ===
owner: None   authority_class: 'captain-required'
unowned_because present: True
purpose (fix a - no 'quota, or vendor'): 'Make an arbitrary outbound network request that is not already mediated by a named forge owner above.'

=== certification text written into the artifact ===
statement: This catalog is a CAPABILITY boundary, not a SECURITY boundary. It constrains a mistaken agent, never a hostile one.
names the enforcement point CFVC-10: True

=== field_contract provenance (fix b - 'bool' declared a catalog-local extension) ===
Typed inputs, using the LoopSpec type vocabulary (slug, string, string[], object, pos_int) plus bool, a catalog-local extension of it. The only vocabulary this catalog is required to reuse from loopspecs/schema.json is the authority_class enum.

=== platform CapabilityRegistry separation stated in the artifact ===
This is NOT the platform's CapabilityRegistry (its scripts/runtime_capabilities.py, a separate repository) and must never be merged into it. That registry answers a Kernel-side que...
```
</details>
<details>
<summary>Evidence: Negative controls firing on mutated copies + mutate() hardening demo</summary>

```text
=== Negative control demo: same validator run against mutated copies must emit violations ===
[       owners] mutated  -> workspace.read owner does not exist: bin/fm-does-not-exist.sh
[       owners] real     -> (clean)
[      unowned] mutated  -> network.request must stay unowned, found owner: 'bin/fm-send.sh'
[      unowned] real     -> (clean)
[         enum] mutated  -> workspace.read has authority_class 'worker-routine', not in the LoopSpec enum ['read-only', 'firstmate-routine', 'captain-required']
[         enum] real     -> (clean)
[certification] mutated  -> the not-a-security-boundary certification is absent
[certification] real     -> (clean)

=== Fix (c) demo: a mutation that fails to apply now exits non-zero (test would fail loudly) ===
Traceback (most recent call last):
  File "<stdin>", line 5, in <module>
  File "<string>", line 1, in <module>
RuntimeError: mutation did not apply
python3 exit status on failed mutation: 1 (non-zero -> mutate() calls fail)
136:    fail "capability catalog: mutation did not apply: $body"
```
</details>
<details>
<summary>Evidence: Changed-file selector picks up the new test with nothing unmapped</summary>

```text
tests/fm-admission.test.sh
tests/fm-arm-pretool-check.test.sh
tests/fm-ask-user-authority.test.sh
tests/fm-brief.test.sh
tests/fm-calm-pi-extension.test.sh
tests/fm-capability-catalog.test.sh
tests/fm-cd-pretool-check.test.sh
tests/fm-composer-ghost.test.sh
tests/fm-composer-lib.test.sh
tests/fm-context-statusline.test.sh
tests/fm-crew-state.test.sh
tests/fm-decision-hold-lifecycle.test.sh
tests/fm-documentation-audiences.test.sh
tests/fm-ensure-agents-md.test.sh
tests/fm-grok-harness.test.sh
tests/fm-herdr-lab.test.sh
tests/fm-kimi-harness.test.sh
tests/fm-launch-lib.test.sh
tests/fm-lint.test.sh
tests/fm-operational-input.test.sh
tests/fm-pi-primary-types.test.sh
tests/fm-send-popup-settle.test.sh
tests/fm-send-settle.test.sh
tests/fm-subagent-pretool-check.test.sh
tests/fm-supervision-instructions.test.sh
tests/fm-task-base.test.sh
tests/fm-task-delivery.test.sh
tests/fm-test-isolation-proof.test.sh
tests/fm-test-run.test.sh
tests/fm-tmux-submit-busy.test.sh
tests/fm-trace-context-lib.test.sh
tests/fm-transition-lib.test.sh
tests/fm-vendor-auth-probe.test.sh
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⏭️ **Rebase** - skipped</summary>

- ⚠️ `.agents/skills/afk/SKILL.md` - branch carries 46 commit(s) that exist on your local main branch but were never pushed to origin/main; rebasing would bundle this unrelated work (202 file(s)) into the PR:
- ed376cf fix(bin): refuse merges without verified green checks (land of upstream #1614) (#48)
- 744f982 fix(bin): resolve the fork trunk as a landing target (#47)
- 561f0bb fix(bin): keep the fleet view working past the per-argument cap (#46)
- aef7a6d fix(bin): resolve the wake sequence instead of trusting a supplied one (#45)
- f90ed1d fix(bin): detect child-process work during supervision (land of upstream #1676) (#44)
- 3611e49 fix(bin): separate task read and contribution bases (land of upstream #1613) (#43)
- dda7f30 fix: stop rechecking captain-gated pauses in away mode (land of upstream #1621) (#42)
- 4bee9f1 fix(bin): escalate blocked-on-human transitions past status-line dedupe (#41)
- 27c7a2d fix(bin): stop wedge alarms on settled terminal tasks (#40)
- ad53e97 reconcile: one landable base from the diverged fork and upstream trunks (#39)
- 9f914d1 feat: add the canonical LoopSpec representation, schema and register (#38)
- cc242ae feat: add research-approved-work skill and deterministic corpus scanner (#37)
- 50adfce fix(bin): measure pool-slot safety against the landing target (#36)
- 631c248 feat(bin): wake-outcome ledger for measured coordinator attention cost (#35)
- 817ee8e CI mirror: refuse local merges only on genuine working-tree collisions (#1)
- ef74752 fix(bin): recognize kimi variants and pi launcher basenames in harness detection (#20)
- 5e6e90f fix(bin): let a released task land through the sanctioned merge path (#34)
- 1149178 Merge pull request #33 from sbracewell64/fm/fork-upstream-resync-conflicts
- 490a371 reconcile: fork trunk with upstream main (0 behind, queue intact, 7 conflicts resolved) (#32)
- a004e4c Merge upstream 33a4287 into the fork trunk queue
- ecbbe30 fork-landing: Windows-to-WSL launcher bridge reconciled onto trunk (#31)
- abc2e7b fix(bin): prevent treehouse allocation from detaching live work (#25)
- 61a5ce8 feat(bin): carry standing worker rules into every generated brief (#23)
- 1ba6ffe fix(bin): allowlist the opencode turn-end plugin in teardown&#39;s dirty check (#12)
- 988dd4b fix(composer): read an NBSP-padded empty composer as empty and fail unshown herdr wedge alarms (#14)
- 0c83af2 test: reap leaked background processes on every suite ending (#16)
- 8e1eb2d feat(bin): wake firstmate when a monitored PR goes conflicting (#21)
- 3edbc23 CI mirror: feat(bin): add fleet admission control stages 0 and 1 (#8)
- cf8f2c6 feat(bin): trigger the 70% compaction doctrine from Claude&#39;s host-computed context telemetry (#11)
- e960b84 feat(bin): enforce the zero-budget model rule with a model registry, spawn gate, and probe verification (#10)
- d965699 feat(bin): mark crewmate and scout steers as from-firstmate and teach briefs to read the marker (#9)
- 9dbaa00 Merge fm/fm-launch-menu: fleet launcher menu (upstream PR #1288)
- 06a6fbd no-mistakes(review): add launch lock, reject leading-zero input, refresh evidence anchors
- fa1dcc7 test: replace launch-lib one-owner source assertions with behavioral coverage
- 74be2a6 no-mistakes(review): fix glob split, enforce backend, guard reattach, probe pi-signed
- cca9d3a feat(bin): add the fleet launcher menu, Herdr gate, and reattach guard
- a083886 no-mistakes(document): point harness-adapters launch facts at fm-launch-lib owner
- 0f42855 no-mistakes(review): bind consumer obligation to every primary, fix pi rationale
- 1154677 no-mistakes(review): bind consumer obligation to any bypass flag, add grok
- bf87246 no-mistakes(review): record primary autonomy evidence and consumer obligation
- abe3c8d no-mistakes(review): add grok --trust, refuse kimi primary, pin every primary shape
- dbfd400 no-mistakes(document): point grok adapter launch line at fm-launch-lib owner
- e067656 no-mistakes(review): use verified opencode --auto primary shape and tighten launch-lib ownership
- 7fd8e55 no-mistakes(document): point launch-command docs at new fm-launch-lib.sh owner
- 6e65a07 no-mistakes(review): map fm-launch-lib.sh into test selection, fixture, and docs
- 2c93585 refactor(bin): give launch knowledge one owner in fm-launch-lib.sh

Push main to origin, or rebase your branch onto origin/main, before gating.

</details>

<details>
<summary>🔧 **Review** - 3 issues found → auto-fixed ✅</summary>

- ⚠️ `capabilities/catalog.json:166` - network.request&#39;s purpose text says the capability covers requests &#34;not already mediated by a named forge, quota, or vendor owner above&#34;, but the catalog contains no quota or vendor rows — stale drafting in a fact-stating artifact. Author-confirmed with an authorized resolution: drop the words &#34;quota, or vendor&#34; from the purpose text. Do NOT add quota or vendor rows; the catalog is fixed at sixteen.
- ⚠️ `capabilities/catalog.json:22` - field_contract&#39;s input_schema entry claims the types &#34;(slug, string, string[], bool, object, pos_int)&#34; are &#34;the loopspecs/schema.json type vocabulary&#34;, but &#39;bool&#39; appears zero times in loopspecs/schema.json — it is a catalog-local extension used by six rows, so the provenance claim is factually wrong in a fact-stating artifact. Author-confirmed with an authorized resolution: reword to say the catalog uses the LoopSpec type vocabulary plus &#39;bool&#39;, which extends it, and that the only thing this catalog must reuse from loopspecs/schema.json is the authority_class enum. Do NOT remove bool from the rows and do NOT add bool to loopspecs/schema.json.
- ⚠️ `tests/fm-capability-catalog.test.sh:124` - mutate() ignores python3&#39;s exit status: if exec(body) raises (mutation fails to apply), the destination file is never written, but printf still echoes its path; check() then reports &#34;catalog unreadable&#34; on the missing file and assert_control_fires treats that as the control firing — a broken negative control reading as proof the check works, the exact vacuity the controls exist to prevent. Latent today (all six current mutation bodies apply cleanly), but it silently degrades the verification discipline. Author-confirmed with an authorized resolution: make mutate() fail loudly when the mutation does not apply, keeping every existing mutation body and all six test cases green.

🔧 Fix: fix stale catalog wording and harden mutate negative controls
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash tests/fm-capability-catalog.test.sh` — all six cases green (owners resolve, verifiers resolve, network.request unowned+captain-required, enum reuse, security-boundary disclaimer, sixteen unique rows)</code>
- <code>Manual audit script over `capabilities/catalog.json` vs the CFVC-09 spec: 16 rows, six required fields per row, all 15 owners and verifiers exist on disk, all authority_class values in loopspecs/schema.json&#39;s enum, unowned_because present, certification names CFVC-10, CapabilityRegistry separation stated</code>
- `Manual negative-control demo: ran the test's embedded validator against four mutated catalog copies (bad owner, owned network.request, invented authority class, deleted certification) — each emitted a violation while the real catalog ran clean`
- <code>Manual fix-(c) demo: a mutation body that raises exits python3 with status 1, triggering mutate()&#39;s new `fail &#34;mutation did not apply&#34;` guard</code>
- <code>`grep -rn &#34;capabilities/catalog&#34;` across the repo — only the test references the file, confirming the data-only/no-runtime-reader claim</code>
- <code>`bash bin/fm-test-run.sh --changed --base 571c60c^ --list` — exits 0 with nothing unmapped and selects tests/fm-capability-catalog.test.sh</code>
- <code>`bash tests/fm-test-run.test.sh` — green, covering the one-line family-classifier edit in bin/fm-test-run.sh</code>
- <code>`bash tests/fm-documentation-audiences.test.sh` — green, covering the two one-line AGENTS.md updates</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
