### PR TITLE
fix(bin): report a never-examined PR head as no-result, not failing

### DIFF
--- a/bin/fm-bearings-snapshot.sh
+++ b/bin/fm-bearings-snapshot.sh
@@ -56,6 +56,15 @@
 #   -h,--help        usage
 #
 # Output contract: `fm-bearings.v1`. Read-only; no locks, no mutation, no reports.
+#
+# candidate_prs[].checks reports one of none, failing, pending, no-result, or
+# passing, splitting adverse verdicts from absent ones on bin/fm-pr-lib.sh's
+# shared classification. "no-result" is the settled shape a queued run leaves
+# when the forge cancels it without ever assigning a runner: nothing is still
+# running, so it will not resolve on its own, and the head needs a fresh event
+# rather than a hunt for a defect no check ever observed. Sharing the owner also
+# keeps this view from calling a head "passing" that bin/fm-pr-merge.sh would
+# refuse to merge.
 set -u
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -63,6 +72,8 @@ FLEET="$SCRIPT_DIR/fm-fleet-snapshot.sh"
 # shellcheck source=bin/fm-timeout-lib.sh
 # shellcheck disable=SC1091
 . "$SCRIPT_DIR/fm-timeout-lib.sh"
+# shellcheck source=bin/fm-pr-lib.sh
+. "$SCRIPT_DIR/fm-pr-lib.sh"
 
 # Bounds (overridable for tests / large fleets).
 FM_BEARINGS_LANDED=${FM_BEARINGS_LANDED:-6}
@@ -232,7 +243,8 @@ EOF
         --json number,title,url,headRefName,reviewDecision,mergeable,statusCheckRollup 2>/dev/null) \
         || { nwarn=$((nwarn + 1)); continue; }
       [ -n "$out" ] || out='[]'
-      repo_result=$(printf '%s' "$out" | jq --arg repo "$repo" --argjson limit "$FM_BEARINGS_PR_LIMIT" '
+      repo_result=$(printf '%s' "$out" | jq --arg repo "$repo" --argjson limit "$FM_BEARINGS_PR_LIMIT" \
+        --argjson adverse "$FM_PR_CHECK_ADVERSE" '
         [ .[] | {
           num:(.number|tostring),
           repo:$repo,
@@ -243,8 +255,9 @@ EOF
           checks:(
             (.statusCheckRollup // []) as $c
             | if ($c|length) == 0 then "none"
-              elif any($c[]; (.conclusion // .state // "") as $s | ($s=="FAILURE" or $s=="ERROR" or $s=="TIMED_OUT" or $s=="CANCELLED" or $s=="ACTION_REQUIRED")) then "failing"
+              elif any($c[]; ((.conclusion // .state // "") | ascii_upcase) as $s | ($adverse | index($s)) != null) then "failing"
               elif any($c[]; ((.status // "") != "COMPLETED") and ((.state // "") != "SUCCESS")) then "pending"
+              elif any($c[]; ((.conclusion // .state // "") | ascii_upcase) != "SUCCESS") then "no-result"
               else "passing" end)
         } ] as $rows | {returned:($rows | length), rows:$rows[:$limit]}') || { nwarn=$((nwarn + 1)); continue; }
       returned=$(printf '%s' "$repo_result" | jq '.returned')

--- a/bin/fm-pr-lib.sh
+++ b/bin/fm-pr-lib.sh
@@ -16,6 +16,29 @@
 # after its durable wake is appended.
 # The receipt binds the terminal observation to the canonical registration and
 # lets a restart finish fixed-path removal without executing state-file bytes.
+#
+# This file also owns how a forge check-rollup member's verdict is classified,
+# because the merge gate and every operator-facing view must agree on it.
+#
+# A CheckRun carries .conclusion (empty while queued or running); a legacy
+# StatusContext carries .state instead. Neither is treated as a pass unless it
+# says SUCCESS.
+#
+# Members split into three disjoint buckets, not two, because "ran and reported
+# a failure" and "never produced a result" are different facts about a head and
+# collapsing them loses whichever one the reader needed. A run that failed,
+# errored, timed out, or failed to start returned an adverse verdict; a run that
+# is queued, in progress, skipped, neutral, cancelled, stale, or held at
+# action_required returned no verdict at all. Both block a merge, and each says
+# so in its own words.
+#
+# FM_PR_CHECK_ADVERSE is the whole adverse set, so anything absent from it that
+# is not SUCCESS carries no verdict rather than a failure. Reporting a
+# no-verdict member as a failure sends readers hunting for a defect that the
+# forge never actually observed, which is why the two sets have one owner here
+# instead of a copy per caller.
+# shellcheck disable=SC2034 # Public source-library variable read by callers after sourcing.
+FM_PR_CHECK_ADVERSE='["FAILURE","ERROR","TIMED_OUT","STARTUP_FAILURE"]'
 
 FM_PR_PROVIDER=
 FM_PR_URL=

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -95,7 +95,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-peek.sh`             | Print a bounded tail of a crewmate endpoint                                          |
 | `fm-check-register.sh`   | Bind an intentional custom watcher check to its current bytes                       |
 | `fm-check-lib.sh`        | Validate custom-check registrations and prepare private execution snapshots          |
-| `fm-pr-lib.sh`           | Own canonical task and PR validation plus private atomic PR-poll publication and identity-bound retirement |
+| `fm-pr-lib.sh`           | Own canonical task and PR validation, the shared adverse/no-verdict check classification, plus private atomic PR-poll publication and identity-bound retirement |
 | `fm-pr-poll.sh`          | Provide the byte-static watcher program for validated PR/MR-poll sidecars           |
 | `fm-pr-check-migrate.sh` | Quarantine older task polls without execution and rebuild only canonical polls       |
 | `fm-pr-check.sh`         | Record validated `pr=` and `pr_head=` values, then atomically arm a static merge poll |

--- a/tests/fm-bearings-snapshot.test.sh
+++ b/tests/fm-bearings-snapshot.test.sh
@@ -44,6 +44,10 @@ SH
 echo "gh $*" >> "$NET_LOG"
 if [ "${FAKE_GH_FAIL:-0}" = 1 ]; then exit 1; fi
 if [ "${FAKE_GH_SLEEP:-0}" = 1 ]; then sleep 30; fi
+if [ -n "${FAKE_GH_ROLLUP:-}" ]; then
+  printf '[{"number":9,"title":"Ship the thing","url":"https://github.com/kunchenguid/firstmate/pull/9","headRefName":"fm/ship-task","reviewDecision":"APPROVED","mergeable":"MERGEABLE","statusCheckRollup":%s}]\n' "$FAKE_GH_ROLLUP"
+  exit 0
+fi
 if [ "${FAKE_GH_MANY:-0}" = 1 ]; then
   cat <<'JSON'
 [{"number":1,"title":"One","url":"https://github.com/acme/repo/pull/1","headRefName":"fm/one","reviewDecision":"","mergeable":"MERGEABLE","statusCheckRollup":[]},{"number":2,"title":"Two","url":"https://github.com/acme/repo/pull/2","headRefName":"fm/two","reviewDecision":"","mergeable":"MERGEABLE","statusCheckRollup":[]},{"number":3,"title":"Three","url":"https://github.com/acme/repo/pull/3","headRefName":"fm/three","reviewDecision":"","mergeable":"MERGEABLE","statusCheckRollup":[]}]
@@ -979,6 +983,35 @@ test_include_prs_is_the_only_fetch_path() {
     .candidate_prs | any(.[]; .num == "9" and .task == "ship-task" and .checks == "passing" and .review == "APPROVED")
   ' >/dev/null || fail "candidate_prs must carry the fetched PR cross-referenced to its task: $json"
   pass "--include-prs is the only path that fetches, and it enriches correctly"
+}
+
+# A forge that cancels a whole queued run without ever assigning it a runner
+# leaves every check COMPLETED/CANCELLED. That head was never examined, so
+# reporting it as "failing" sends the reader hunting for defects that no check
+# observed, and reporting it as "passing" would promise a merge the gate refuses.
+test_check_rollup_separates_absent_verdicts_from_failures() {
+  local home fakebin json case_name rollup want
+  home=$(make_home rollup); write_fixture "$home"
+  fakebin=$(make_fakebin "$home")
+  while IFS='|' read -r case_name rollup want; do
+    [ -n "$case_name" ] || continue
+    json=$(FAKE_GH_ROLLUP="$rollup" run "$home" "$fakebin" --include-prs --json)
+    printf '%s' "$json" | jq -e --arg want "$want" '
+      .candidate_prs | any(.[]; .num == "9" and .checks == $want)
+    ' >/dev/null || fail "$case_name must report checks=$want: $json"
+    pass "$case_name reports checks=$want"
+  done <<'CASES'
+a run cancelled before any runner was assigned|[{"status":"COMPLETED","conclusion":"CANCELLED"}]|no-result
+a check held for maintainer approval|[{"status":"COMPLETED","conclusion":"ACTION_REQUIRED"}]|no-result
+a skipped check the merge gate would refuse|[{"status":"COMPLETED","conclusion":"SUCCESS"},{"status":"COMPLETED","conclusion":"SKIPPED"}]|no-result
+a genuine test failure|[{"status":"COMPLETED","conclusion":"FAILURE"}]|failing
+a run that failed to start|[{"status":"COMPLETED","conclusion":"STARTUP_FAILURE"}]|failing
+a legacy status context reporting failure|[{"state":"FAILURE"}]|failing
+a still-queued check|[{"status":"QUEUED","conclusion":null}]|pending
+a cancelled check alongside one still running|[{"status":"IN_PROGRESS","conclusion":null},{"status":"COMPLETED","conclusion":"CANCELLED"}]|pending
+a failure alongside a cancellation|[{"status":"COMPLETED","conclusion":"CANCELLED"},{"status":"COMPLETED","conclusion":"FAILURE"}]|failing
+every check green|[{"status":"COMPLETED","conclusion":"SUCCESS"},{"status":"COMPLETED","conclusion":"SUCCESS"}]|passing
+CASES
 }
 
 test_partial_github_failure_degrades() {
@@ -1924,6 +1957,7 @@ test_open_decision_surfaces_end_to_end
 test_report_pointers_surface
 test_superseded_queued_item_dropped_by_default
 test_include_prs_is_the_only_fetch_path
+test_check_rollup_separates_absent_verdicts_from_failures
 test_partial_github_failure_degrades
 test_perl_fallback_bounds_github_call
 test_section_caps_and_expansion_flags


### PR DESCRIPTION
## Intent

Diagnose why fork PRs on sbracewell64/firstmate fail every CI check wholesale, then fix the systemic cause.

Measured 2026-08-07: PRs 51 and 52 each showed 0 passed / 14 failed / 14 total, with ALL checks red including trivially independent ones (Lint shell scripts, Repo invariants, Windows launcher bridge), indicating one systemic workflow-level cause rather than fourteen code bugs. PR 53 showed a different shape, "no CI checks configured", with zero runs. PRs 49 and 50 by contrast showed 12 passed / 2 failed, whose reds are the known structural attestation check rather than this defect. PR 54 was fresh and used as another data point.

The task required diagnosing first, from evidence, before touching anything: read the actual failing run logs for 51 and 52 to establish the shared first point of failure; establish why 53 runs nothing by comparing its branch workflow files and base against 51/52 and against the trunk .github/workflows; explain why 49/50 run and largely pass while 51/52 fail wholesale; check the known related recorded facts rather than assuming them (CI pins treehouse v2.0.1 while local uses v2.1.x; the portable serial CI lane runs close to its own timeout on trunk, backlog task ci-serial-lane-30s-from-timeout; workflows run from the PR branch's own .github/workflows content for pull_request events, so stale branches carry stale workflows); and distinguish branch-side causes, fixable by rebasing or refreshing those branches, from trunk/repo-side causes such as a broken workflow at the fork trunk, runner config, or missing secrets, proving the classification with log evidence.

Diagnosis established from evidence:

Shape A (51/52 wholesale red) is not failure at all. Every one of the 14 checks on each has conclusion "cancelled" with runner_id 0, runner_name empty, and steps [] - GitHub never assigned a runner to any job. The decisive control is the trivial "PR must be raised via no-mistakes" body-compliance job, which completes in about 3 seconds with a runner (PR 49, runner "GitHub Actions 1000001318", 3 steps) but sat queued 59 minutes on PR 51 before cancellation. No test content, timeout, or treehouse pin can produce that.

Shape B (53 zero runs) is the same outage one stage deeper: total_count 0 workflow runs for the branch, for both the "opened" event at 18:21:37 and a push 100 seconds later, while its workflow files are active and byte-identical to trunk.

The cause is NOT branch-side: ci.yml is the same blob 82061b8d on fork/main and on all six PR branches (49, 50, 51, 52, 53, 54), so the recorded "stale branches carry stale workflows" hypothesis is disproven for this defect. Only PR 52 modifies no-mistakes-required.yml, which is that PR's own subject. The cause is also NOT repo-side or fleet-side: Actions is enabled with allowed_actions all, both workflows are active, the repository is public so hosted runners are free, the account owns only two repositories and the other had zero runs, and the fork had zero concurrent Actions load at 16:37 because the previous run ended at 13:18 - which excludes account concurrency exhaustion. The degradation window was progressive: runner assignment failed from about 16:37 UTC on 2026-08-06, run creation itself failed by about 18:21, and it had cleared by 2026-08-07 11:27 when PR 54 ran normally in 9 minutes on the identical workflow. The remedy for 51/52/53 is therefore re-triggering, not a code change, and those branches belong to other lanes so they were deliberately not rewritten.

The one genuinely repo-side defect found, and the reason a runner outage was read as fourteen code bugs, is in firstmate's own reporting. bin/fm-bearings-snapshot.sh classified CANCELLED and ACTION_REQUIRED as adverse verdicts, so a head that was never examined rendered as "failing", indistinguishable from a head whose checks ran and found real defects. bin/fm-pr-merge.sh already drew this line correctly, refusing an adverse verdict and an absent one in separate words, but held its own private copy of the adverse set, and the two copies disagreed about exactly CANCELLED.

The fix gives that split one owner, FM_PR_CHECK_ADVERSE in bin/fm-pr-lib.sh, read by both callers, and adds a distinct "no-result" bucket to the bearings view for a head that was never examined: nothing is still running, so it will not resolve on its own and needs a fresh event rather than a defect hunt. Deliberate design decisions worth knowing: the classification order is none, failing, pending, no-result, passing, so a still-queued or in-progress check is reported as "pending" rather than "no-result" (a mixed rollup with one running and one cancelled check therefore reports "pending" and settles to "no-result" once the running one finishes); SKIPPED and NEUTRAL deliberately land in "no-result" rather than "passing" because bin/fm-pr-merge.sh refuses to merge on them, and the view must never call a head "passing" that the merge gate would refuse; and merge-gate behavior is intentionally unchanged, with fm-pr-merge.sh only swapping its literal for the shared constant so its existing cancelled, action_required, skipped, and neutral cases still pass.

Verification performed: a negative control reverted only the classification line and confirmed the new test fails on the old behavior before it was restored; tests/fm-bearings-snapshot.test.sh passes 51/51 with ten new table-driven cases covering cancelled, action_required, skipped, failure, startup_failure, a legacy status context, queued, mixed, and all-green rollups; tests/fm-pr-merge.test.sh passes 34/34 unchanged; bin/fm-lint.sh exits 0 and a direct shellcheck -x on the changed scripts is clean, following the repo's existing "# shellcheck disable=SC2034 # Public source-library variable" convention for a library constant read only by callers; and bin/fm-doc-audience-check.sh passes.

Per-PR remedies were reported to firstmate rather than applied, since those branches belong to other lanes: 49 and 50 need only the base-level fix, their single red being tests/fm-remote-secondmate-lifecycle-e2e.test.sh which is proven pre-existing on base main ed376cf by that commit's own push run 31068554687; 51 and 52 need their existing runs re-run; 53 needs a fresh pull_request event since there is nothing to re-run; and 54's second red, tests/fm-wake-ledger.test.sh "format: wake latency not computed", is proven that PR's own regression because the same test exits 0 on base in the run where it exits 1 on 54.

This is firstmate's own shared tracked material, so firstmate-coding-guidelines was loaded and followed: one owner for the contract, the full rationale patched into the owning file with a one-line cross-reference left at the former copy, mechanics documented in the script headers rather than in AGENTS.md, one sentence per line, plain dashes, no agent co-author, shellcheck-clean scripts, and tests colocated in the existing suite exercising behavior through the executable rather than asserting implementation source bytes.

## What Changed

- `bin/fm-bearings-snapshot.sh` no longer classifies a head whose checks were cancelled, skipped, or neutral (i.e. never actually examined by CI) as "failing": the adverse-verdict set now has one owner, `FM_PR_CHECK_ADVERSE` in `bin/fm-pr-lib.sh`, read by both the bearings view and `bin/fm-pr-merge.sh`, and the view gains a distinct "no-result" bucket (ordered none → failing → pending → no-result → passing) for settled runs with no verdict. Merge-gate behavior is unchanged — `fm-pr-merge.sh` only swaps its private literal for the shared constant, and `docs/scripts.md` records the shared ownership.
- Ten new table-driven cases in `tests/fm-bearings-snapshot.test.sh` cover cancelled, action_required, skipped, failure, startup_failure, legacy status contexts, queued, mixed, and all-green rollups; `tests/fm-pr-merge.test.sh` passes unchanged, and a negative control confirmed the new case fails on the old classification line.
- Because origin/main is behind the fork trunk, the branch delta also carries 46 previously-landed fork commits (~200 files): the fleet launcher menu and `fm-launch-lib.sh`, remote secondmate provisioning/jobs/doctor, the model registry with zero-budget enforcement, LoopSpec schema and register, fleet admission control, the wake-outcome ledger, worktree guard, merge-verification hardening, and their tests and docs. The pipeline's rebase stage flagged this bundling; pushing main to origin (or rebasing onto it) would shrink this PR to the check-verdict fix alone.

## Risk Assessment

✅ Low: The branch's new work is a single well-bounded four-file commit that keeps merge-gate behavior byte-identical (verified: the shared constant equals the removed literal and is sourced before use), adds only an additive "no-result" value to a view field with no machine consumers, deduplicates the adverse set to one owner with no remaining copies in bin/, and carries ten new behavioral test cases matching every shape the intent enumerates.

## Testing

Ran the two targeted suites (bearings 51/51, pr-merge 34/34, both green), reproduced the intent's negative control proving the new test fails on the pre-fix classification, verified the shared FM_PR_CHECK_ADVERSE constant has one owner read by both callers, and captured a CLI transcript demonstrating the end-user surface: a PR-51-shaped all-cancelled head renders checks=failing before the fix and checks=no-result after, while a head with a real FAILURE still renders failing. No visual artifact beyond the transcript because the product surface is a terminal TOON/JSON view, which the transcript shows directly.

<details>
<summary>Evidence: Before/after bearings-view transcript (PR-51-shaped all-cancelled head)</summary>

<code>--- BEFORE (3baabd0^): operator-facing bearings view (TOON) ---&#10;candidate_prs[1]{num,repo,task,url,review,mergeable,checks}:&#10;&#34;9&#34;,kunchenguid/firstmate,ship-task,&#34;https://github.com/kunchenguid/firstmate/pull/9&#34;,APPROVED,MERGEABLE,failing&#10;&#10;--- AFTER (3baabd0, the fix): operator-facing bearings view (TOON) ---&#10;candidate_prs[1]{num,repo,task,url,review,mergeable,checks}:&#10;&#34;9&#34;,kunchenguid/firstmate,ship-task,&#34;https://github.com/kunchenguid/firstmate/pull/9&#34;,APPROVED,MERGEABLE,no-result&#10;&#10;Control (one genuine FAILURE among the cancellations):&#10;{&#34;num&#34;:&#34;9&#34;,&#34;checks&#34;:&#34;failing&#34;}</code>

```text
==================================================================
Simulated head: PR whose queued run was cancelled before any runner
was assigned - statusCheckRollup = 14 x {COMPLETED, CANCELLED}
==================================================================

--- BEFORE (3baabd0^): operator-facing bearings view (TOON) ---
candidate_prs[1]{num,repo,task,url,review,mergeable,checks}:
  "9",kunchenguid/firstmate,ship-task,"https://github.com/kunchenguid/firstmate/pull/9",APPROVED,MERGEABLE,failing
omitted[7]{surface,reveal}:
  backlog item bodies,"--fields bodies"

--- BEFORE (3baabd0^): projected JSON row ---
{"num":"9","title":null,"checks":"failing"}

--- AFTER (3baabd0, the fix): operator-facing bearings view (TOON) ---
candidate_prs[1]{num,repo,task,url,review,mergeable,checks}:
  "9",kunchenguid/firstmate,ship-task,"https://github.com/kunchenguid/firstmate/pull/9",APPROVED,MERGEABLE,no-result
omitted[6]{surface,reveal}:
  backlog item bodies,"--fields bodies"

--- AFTER (3baabd0, the fix): projected JSON row ---
{"num":"9","title":null,"checks":"no-result"}

==================================================================
Control: a head whose checks RAN and found a real defect
(one FAILURE among the cancellations) must still read as failing
==================================================================

--- AFTER (3baabd0, the fix): projected JSON row ---
{"num":"9","title":null,"checks":"failing"}
```
</details>
<details>
<summary>Evidence: Reproducible demo script (reuses the suite&#39;s own fixture helpers)</summary>

```text
#!/usr/bin/env bash
# Manual end-to-end demonstration for "report a never-examined head as absent,
# not as failing" (commit 3baabd0).
#
# Reuses the bearings test suite's own fixture helpers (extracted verbatim from
# the prelude of tests/fm-bearings-snapshot.test.sh) and feeds both the pre-fix
# and the fixed bin/fm-bearings-snapshot.sh the real shape sbracewell64/firstmate
# PR 51 exhibited on 2026-08-06: 14 checks, every one COMPLETED/CANCELLED,
# because GitHub cancelled the queued run without ever assigning a runner.
set -u

WORKTREE=${1:?usage: demo-bearings-no-result.sh <worktree-root>}
cd "$WORKTREE" || exit 1

# Extract and eval the test suite's helper prelude (everything after the lib.sh
# source and before the first test_ function): make_fakebin, make_home,
# write_fixture, run, ... lib.sh is sourced directly since eval would resolve
# BASH_SOURCE to this demo script's directory.
# shellcheck disable=SC1091
. tests/lib.sh
PRELUDE=$(sed -n '13,216p' tests/fm-bearings-snapshot.test.sh)
eval "$PRELUDE"

# PR 51's measured shape: 14 distinct check names, all cancelled unrun.
ROLLUP=$(jq -nc '[range(14) | {"status":"COMPLETED","conclusion":"CANCELLED"}]')

home=$(make_home demo); write_fixture "$home"
fakebin=$(make_fakebin "$home")

# A sibling bin/ with the PRE-FIX bearings script (parent commit 3baabd0^), so
# the old classification runs against the same fleet-snapshot machinery.
OLDBIN=$TMP_ROOT/oldbin
mkdir -p "$OLDBIN"
cp -a "$ROOT/bin/." "$OLDBIN/"
git -C "$ROOT" show '3baabd0^:bin/fm-bearings-snapshot.sh' > "$OLDBIN/fm-bearings-snapshot.sh"
chmod +x "$OLDBIN/fm-bearings-snapshot.sh"

echo "=================================================================="
echo "Simulated head: PR whose queued run was cancelled before any runner"
echo "was assigned - statusCheckRollup = 14 x {COMPLETED, CANCELLED}"
echo "=================================================================="
echo
echo "--- BEFORE (3baabd0^): operator-facing bearings view (TOON) ---"
BEARINGS="$OLDBIN/fm-bearings-snapshot.sh"
FAKE_GH_ROLLUP="$ROLLUP" run "$home" "$fakebin" --include-prs | grep -A3 'candidate_prs'
echo
echo "--- BEFORE (3baabd0^): projected JSON row ---"
FAKE_GH_ROLLUP="$ROLLUP" run "$home" "$fakebin" --include-prs --json \
  | jq -c '.candidate_prs[] | {num, title, checks}'
echo
echo "--- AFTER (3baabd0, the fix): operator-facing bearings view (TOON) ---"
BEARINGS="$ROOT/bin/fm-bearings-snapshot.sh"
FAKE_GH_ROLLUP="$ROLLUP" run "$home" "$fakebin" --include-prs | grep -A3 'candidate_prs'
echo
echo "--- AFTER (3baabd0, the fix): projected JSON row ---"
FAKE_GH_ROLLUP="$ROLLUP" run "$home" "$fakebin" --include-prs --json \
  | jq -c '.candidate_prs[] | {num, title, checks}'
echo
echo "=================================================================="
echo "Control: a head whose checks RAN and found a real defect"
echo "(one FAILURE among the cancellations) must still read as failing"
echo "=================================================================="
ROLLUP_REAL=$(jq -nc '[range(13) | {"status":"COMPLETED","conclusion":"CANCELLED"}] + [{"status":"COMPLETED","conclusion":"FAILURE"}]')
echo
echo "--- AFTER (3baabd0, the fix): projected JSON row ---"
FAKE_GH_ROLLUP="$ROLLUP_REAL" run "$home" "$fakebin" --include-prs --json \
  | jq -c '.candidate_prs[] | {num, title, checks}'
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⏭️ **Rebase** - skipped</summary>

- ⚠️ `.agents/skills/afk/SKILL.md` - branch carries 46 commit(s) that exist on your local main branch but were never pushed to origin/main; rebasing would bundle this unrelated work (202 file(s)) into the PR:
- ed376cf fix(bin): refuse merges without verified green checks (land of upstream #1614) (#48)
- 744f982 fix(bin): resolve the fork trunk as a landing target (#47)
- 561f0bb fix(bin): keep the fleet view working past the per-argument cap (#46)
- aef7a6d fix(bin): resolve the wake sequence instead of trusting a supplied one (#45)
- f90ed1d fix(bin): detect child-process work during supervision (land of upstream #1676) (#44)
- 3611e49 fix(bin): separate task read and contribution bases (land of upstream #1613) (#43)
- dda7f30 fix: stop rechecking captain-gated pauses in away mode (land of upstream #1621) (#42)
- 4bee9f1 fix(bin): escalate blocked-on-human transitions past status-line dedupe (#41)
- 27c7a2d fix(bin): stop wedge alarms on settled terminal tasks (#40)
- ad53e97 reconcile: one landable base from the diverged fork and upstream trunks (#39)
- 9f914d1 feat: add the canonical LoopSpec representation, schema and register (#38)
- cc242ae feat: add research-approved-work skill and deterministic corpus scanner (#37)
- 50adfce fix(bin): measure pool-slot safety against the landing target (#36)
- 631c248 feat(bin): wake-outcome ledger for measured coordinator attention cost (#35)
- 817ee8e CI mirror: refuse local merges only on genuine working-tree collisions (#1)
- ef74752 fix(bin): recognize kimi variants and pi launcher basenames in harness detection (#20)
- 5e6e90f fix(bin): let a released task land through the sanctioned merge path (#34)
- 1149178 Merge pull request #33 from sbracewell64/fm/fork-upstream-resync-conflicts
- 490a371 reconcile: fork trunk with upstream main (0 behind, queue intact, 7 conflicts resolved) (#32)
- a004e4c Merge upstream 33a4287 into the fork trunk queue
- ecbbe30 fork-landing: Windows-to-WSL launcher bridge reconciled onto trunk (#31)
- abc2e7b fix(bin): prevent treehouse allocation from detaching live work (#25)
- 61a5ce8 feat(bin): carry standing worker rules into every generated brief (#23)
- 1ba6ffe fix(bin): allowlist the opencode turn-end plugin in teardown&#39;s dirty check (#12)
- 988dd4b fix(composer): read an NBSP-padded empty composer as empty and fail unshown herdr wedge alarms (#14)
- 0c83af2 test: reap leaked background processes on every suite ending (#16)
- 8e1eb2d feat(bin): wake firstmate when a monitored PR goes conflicting (#21)
- 3edbc23 CI mirror: feat(bin): add fleet admission control stages 0 and 1 (#8)
- cf8f2c6 feat(bin): trigger the 70% compaction doctrine from Claude&#39;s host-computed context telemetry (#11)
- e960b84 feat(bin): enforce the zero-budget model rule with a model registry, spawn gate, and probe verification (#10)
- d965699 feat(bin): mark crewmate and scout steers as from-firstmate and teach briefs to read the marker (#9)
- 9dbaa00 Merge fm/fm-launch-menu: fleet launcher menu (upstream PR #1288)
- 06a6fbd no-mistakes(review): add launch lock, reject leading-zero input, refresh evidence anchors
- fa1dcc7 test: replace launch-lib one-owner source assertions with behavioral coverage
- 74be2a6 no-mistakes(review): fix glob split, enforce backend, guard reattach, probe pi-signed
- cca9d3a feat(bin): add the fleet launcher menu, Herdr gate, and reattach guard
- a083886 no-mistakes(document): point harness-adapters launch facts at fm-launch-lib owner
- 0f42855 no-mistakes(review): bind consumer obligation to every primary, fix pi rationale
- 1154677 no-mistakes(review): bind consumer obligation to any bypass flag, add grok
- bf87246 no-mistakes(review): record primary autonomy evidence and consumer obligation
- abe3c8d no-mistakes(review): add grok --trust, refuse kimi primary, pin every primary shape
- dbfd400 no-mistakes(document): point grok adapter launch line at fm-launch-lib owner
- e067656 no-mistakes(review): use verified opencode --auto primary shape and tighten launch-lib ownership
- 7fd8e55 no-mistakes(document): point launch-command docs at new fm-launch-lib.sh owner
- 6e65a07 no-mistakes(review): map fm-launch-lib.sh into test selection, fixture, and docs
- 2c93585 refactor(bin): give launch knowledge one owner in fm-launch-lib.sh

Push main to origin, or rebase your branch onto origin/main, before gating.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ℹ️ `tests/fm-bearings-snapshot.test.sh:998` - The new table-driven test loop invokes the full bearings script with the case-table heredoc as its inherited stdin. Every read loop in the current call chain (fm-bearings-snapshot.sh, fm-fleet-snapshot.sh) redirects from its own heredoc or pipe, so it works today, but if any child ever gains a bare stdin read, later table cases would be silently consumed and skipped without failing the suite. Appending `&lt;/dev/null` to the `run` invocation (`json=$(FAKE_GH_ROLLUP=&#34;$rollup&#34; run &#34;$home&#34; &#34;$fakebin&#34; --include-prs --json &lt;/dev/null)`) closes the latent trap without changing behavior.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bash tests/fm-bearings-snapshot.test.sh (51/51 ok, includes the ten new table-driven check-rollup classification cases)`
- `bash tests/fm-pr-merge.test.sh (34/34 ok, exit 0; existing cancelled/action_required/skipped/neutral refusals and adverse-failure cases unchanged)`
- `Negative control: reverted only the jq classification line in bin/fm-bearings-snapshot.sh to the old adverse set, re-ran the suite (new case fails, suite exit 1), then restored via git checkout`
- `Structural one-owner check: grep confirms FM_PR_CHECK_ADVERSE is defined once in bin/fm-pr-lib.sh and read by bin/fm-bearings-snapshot.sh:250 and bin/fm-pr-merge.sh:148 after both source the lib`
- `Manual end-to-end demo: ran pre-fix (3baabd0^) and fixed bin/fm-bearings-snapshot.sh --include-prs against a faked gh returning PR 51's measured shape (14x COMPLETED/CANCELLED) using the suite's own fixture; TOON view and JSON flip failing -> no-result, and a control rollup containing a genuine FAILURE still reports failing`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
