### PR TITLE
test(harness): pin crew-harness realignment safety for secondmates and crewmates

### DIFF
--- a/tests/fm-secondmate-harness.test.sh
+++ b/tests/fm-secondmate-harness.test.sh
@@ -41,6 +41,16 @@
 #      spawn only when the harness also resolves from that file, so the pin is
 #      durable across every respawn while explicit per-spawn harness/model/effort
 #      flags still win.
+#   D) Realignment safety. config/crew-harness answers two questions with one
+#      value - the crewmate fallback and the second link of the secondmate chain -
+#      so correcting it for one of them can silently re-answer the other. An
+#      explicitly pinned config/secondmate-harness insulates secondmate launches
+#      from that edit, and an unpinned one does not, which is why the pin must be
+#      set FIRST. An active config/crew-dispatch.json keeps the same edit away
+#      from crewmate launches entirely: a resolved profile ignores
+#      config/crew-harness and an unresolved spawn refuses instead of reading it.
+#      Each case carries its negative control, because every assertion here would
+#      also hold if config/crew-harness had simply stopped working everywhere.
 set -u
 
 # shellcheck source=tests/lib.sh
@@ -2463,6 +2473,209 @@ SH
   pass "B25 spawn quarantines stale rereads without blocking relaunch"
 }
 
+# ===========================================================================
+# D) Realignment safety: correcting config/crew-harness must not move an
+#    explicitly pinned secondmate launch, and must not move crewmate dispatch
+#    at all while config/crew-dispatch.json is active.
+# ===========================================================================
+# config/crew-harness answers two questions with one value: it is the crewmate
+# fallback AND the second link of the secondmate chain. So an edit made to
+# correct the crewmate answer silently re-answers the secondmate one - unless
+# config/secondmate-harness is pinned first. That ordering is the safety
+# property, and both cases below assert it in BOTH directions. Without the
+# negative control half, each would also pass if config/crew-harness had no
+# effect anywhere, which is exactly the vacuous result that would hide a
+# regression in the fallback chain.
+
+# A crew-harness edit must not move a PINNED secondmate harness; with no pin,
+# the same edit MUST move it.
+test_pinned_secondmate_survives_a_crew_harness_realignment() {
+  local cfg before after crew
+  cfg="$TMP_ROOT/realign-pinned/config"
+  mkdir -p "$cfg"
+  printf 'claude\n' > "$cfg/crew-harness"
+  printf 'pi\n' > "$cfg/secondmate-harness"
+
+  before=$(CLAUDECODE=1 FM_CONFIG_OVERRIDE="$cfg" "$ROOT/bin/fm-harness.sh" secondmate)
+  [ "$before" = pi ] || fail "pinned: secondmate resolved '$before' before the edit, expected the pinned pi"
+  printf 'codex\n' > "$cfg/crew-harness"
+  after=$(CLAUDECODE=1 FM_CONFIG_OVERRIDE="$cfg" "$ROOT/bin/fm-harness.sh" secondmate)
+  [ "$after" = pi ] \
+    || fail "pinned: a config/crew-harness edit moved the secondmate harness to '$after'; an explicit pin must insulate it"
+  crew=$(CLAUDECODE=1 FM_CONFIG_OVERRIDE="$cfg" "$ROOT/bin/fm-harness.sh" crew)
+  [ "$crew" = codex ] \
+    || fail "pinned: crew resolution did not take the edit (got '$crew'), so the insulation assertion above is vacuous"
+
+  # Negative control: the same edit with NO pin must move the secondmate value.
+  cfg="$TMP_ROOT/realign-unpinned/config"
+  mkdir -p "$cfg"
+  printf 'claude\n' > "$cfg/crew-harness"
+  before=$(CLAUDECODE=1 FM_CONFIG_OVERRIDE="$cfg" "$ROOT/bin/fm-harness.sh" secondmate)
+  [ "$before" = claude ] || fail "unpinned: secondmate resolved '$before', expected the crew-harness value claude"
+  printf 'codex\n' > "$cfg/crew-harness"
+  after=$(CLAUDECODE=1 FM_CONFIG_OVERRIDE="$cfg" "$ROOT/bin/fm-harness.sh" secondmate)
+  [ "$after" = codex ] || fail "unpinned: secondmate resolved '$after' after the crew edit, expected codex"
+  [ "$before" != "$after" ] \
+    || fail "negative control did not diverge: config/crew-harness moved an unpinned secondmate nowhere, so the pinned case proves nothing"
+
+  pass "D1 a config/crew-harness realignment leaves a PINNED secondmate harness alone; an unpinned one moves with it (the pin-first ordering is load-bearing)"
+}
+
+# The same property at the spawn chokepoint, which is what actually launches an
+# agent: every spawn re-resolves, so the pin must still hold after the edit.
+test_pinned_secondmate_spawn_survives_a_crew_harness_realignment() {
+  local w meta
+  w="$TMP_ROOT/realign-spawn"
+  mkdir -p "$w/home/config"
+  printf 'claude\n' > "$w/home/config/crew-harness"
+  printf 'pi\n' > "$w/home/config/secondmate-harness"
+  make_seeded_home "$w/sm-before" sm-before
+  make_seeded_home "$w/sm-after" sm-after
+
+  spawn_secondmate "$w" sm-before "$w/sm-before"
+  meta="$w/home/state/sm-before.meta"
+  [ "$(meta_harness "$meta")" = pi ] \
+    || fail "pinned spawn: pre-edit secondmate launched on '$(meta_harness "$meta")', expected the pinned pi"
+
+  printf 'codex\n' > "$w/home/config/crew-harness"
+  spawn_secondmate "$w" sm-after "$w/sm-after"
+  meta="$w/home/state/sm-after.meta"
+  [ "$(meta_harness "$meta")" = pi ] \
+    || fail "pinned spawn: after a crew-harness edit the secondmate launched on '$(meta_harness "$meta")', expected the pinned pi"
+  [ "$(cat "$w/sm-after/config/crew-harness")" = codex ] \
+    || fail "pinned spawn: the edited crew-harness did not reach the secondmate home, so this case did not exercise the edit"
+
+  # Negative control: an unpinned home takes the edit at spawn time.
+  w="$TMP_ROOT/realign-spawn-unpinned"
+  mkdir -p "$w/home/config"
+  printf 'claude\n' > "$w/home/config/crew-harness"
+  make_seeded_home "$w/sm-before" sm-before
+  make_seeded_home "$w/sm-after" sm-after
+  spawn_secondmate "$w" sm-before "$w/sm-before"
+  [ "$(meta_harness "$w/home/state/sm-before.meta")" = claude ] \
+    || fail "unpinned spawn: expected the crew-harness value claude"
+  printf 'codex\n' > "$w/home/config/crew-harness"
+  spawn_secondmate "$w" sm-after "$w/sm-after"
+  [ "$(meta_harness "$w/home/state/sm-after.meta")" = codex ] \
+    || fail "unpinned spawn: a crew-harness edit did not reach an unpinned secondmate launch, so the pinned spawn case proves nothing"
+
+  pass "D2 spawn: a pinned config/secondmate-harness keeps launching its own harness across a crew-harness realignment; an unpinned home takes the edit"
+}
+
+# Spawn one ordinary ship task and echo fm-spawn's combined output.
+# <crew> is written to config/crew-harness; the literal '-' leaves it absent.
+# Remaining args are passed through to fm-spawn (an explicit --harness, or none).
+crew_ship_spawn() {
+  local w=$1 id=$2 crew=$3 home fakebin
+  shift 3
+  home="$w/home"
+  fakebin=$(make_launch_capturing_tmux "$w/tmux-$id")
+  mkdir -p "$home/data/$id" "$home/projects" "$home/state" "$home/config"
+  printf 'brief for %s\n' "$id" > "$home/data/$id/brief.md"
+  if [ "$crew" = "-" ]; then
+    rm -f "$home/config/crew-harness"
+  else
+    printf '%s\n' "$crew" > "$home/config/crew-harness"
+  fi
+  : > "$w/$id.launch.log"
+  PATH="$fakebin:$BASE_PATH" TMUX="fake,1,0" CLAUDECODE=1 \
+    FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" \
+    FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
+    FM_PROJECTS_OVERRIDE="$home/projects" FM_CONFIG_OVERRIDE="$home/config" \
+    FM_SPAWN_NO_GUARD=1 FM_FAKE_PANE_PATH="$w/wt" FM_FAKE_LAUNCH_LOG="$w/$id.launch.log" \
+    GROK_HOME="$home/grok-home" \
+    "$ROOT/bin/fm-spawn.sh" "$id" "$w/project" --mode no-mistakes --yolo off "$@" 2>&1
+}
+
+# While config/crew-dispatch.json is active, config/crew-harness cannot reach a
+# crewmate launch by ANY path: an explicitly resolved profile ignores its value,
+# and a spawn with no explicit harness refuses instead of falling back to it.
+# That is what makes realigning the file safe for crew work; the negative
+# control removes the dispatch file and shows the same knob is genuinely live
+# there, so the inertness above is caused by the dispatch file and not by
+# config/crew-harness having no effect anywhere.
+test_crew_harness_is_inert_for_dispatch_resolved_crewmates() {
+  local w crew profile id n out status launch meta first_launch first_meta
+  w="$TMP_ROOT/crew-inert"
+  mkdir -p "$w/home/config" "$w/home/state"
+  # Two rules plus the default, so "every matching rule" is more than one row.
+  printf '%s\n' '{"rules":[{"when":"current events","use":{"harness":"grok","model":"grok-4","effort":"high"}},{"when":"utility","use":{"harness":"pi","model":"openai-codex/gpt-5.6-terra","effort":"low"}}],"default":{"harness":"codex","model":"gpt-5","effort":"medium"}}' \
+    > "$w/home/config/crew-dispatch.json"
+  fm_git_worktree "$w/project" "$w/wt" wt-crew-inert
+  n=0
+  # <resolved-profile-flags> rows: one per matching dispatch rule, plus default.
+  while IFS='^' read -r profile; do
+    [ -n "$profile" ] || continue
+    first_launch=
+    first_meta=
+    # claude is the pre-realignment value, pi the post-realignment one, and '-'
+    # the absent case; a dispatch-resolved launch must not vary across them.
+    for crew in claude pi -; do
+      n=$((n + 1))
+      id="crew-inert-z$n"
+      # shellcheck disable=SC2086  # deliberate word-splitting: the row holds flags
+      out=$(crew_ship_spawn "$w" "$id" "$crew" $profile); status=$?
+      expect_code 0 "$status" \
+        "dispatch-resolved crew spawn failed with crew-harness='$crew'"$'\n'"$out"
+      meta=$(grep -E '^(harness|model|effort)=' "$w/home/state/$id.meta" | sort)
+      # The launch embeds this task's own brief path, so normalize the id out:
+      # what must be identical across crew-harness values is everything else.
+      launch=$(cat "$w/$id.launch.log")
+      launch=${launch//"$id"/TASKID}
+      if [ -z "$first_launch" ]; then
+        first_launch=$launch
+        first_meta=$meta
+      else
+        [ "$launch" = "$first_launch" ] \
+          || fail "crew-harness='$crew' changed the launch command of a dispatch-resolved crewmate ($profile)"$'\n'"--- expected ---"$'\n'"$first_launch"$'\n'"--- got ---"$'\n'"$launch"
+        [ "$meta" = "$first_meta" ] \
+          || fail "crew-harness='$crew' changed the recorded profile of a dispatch-resolved crewmate ($profile)"$'\n'"--- expected ---"$'\n'"$first_meta"$'\n'"--- got ---"$'\n'"$meta"
+      fi
+    done
+  done <<'ROWS'
+--harness grok --model grok-4 --effort high
+--harness pi --model openai-codex/gpt-5.6-terra --effort low
+--harness codex --model gpt-5 --effort medium
+ROWS
+
+  # With the dispatch file active and NO explicit harness, the spawn refuses
+  # rather than reading config/crew-harness - the consultation backstop.
+  for crew in claude pi -; do
+    n=$((n + 1))
+    id="crew-inert-z$n"
+    out=$(crew_ship_spawn "$w" "$id" "$crew"); status=$?
+    expect_code 1 "$status" "an unresolved crew spawn should refuse while dispatch profiles are active (crew-harness='$crew')"
+    assert_contains "$out" "config/crew-dispatch.json is active" \
+      "the refusal did not name the dispatch backstop (crew-harness='$crew')"
+    assert_absent "$w/home/state/$id.meta" "the refusal wrote a meta (crew-harness='$crew')"
+  done
+
+  # Negative control: with no dispatch file, that same unresolved spawn DOES
+  # resolve from config/crew-harness and its value changes the launch.
+  # Both launches are normalized the same way the inertness comparison above is,
+  # so the divergence this asserts comes from the harness and not from the task
+  # id embedded in each brief path - which would make the control vacuous.
+  rm -f "$w/home/config/crew-dispatch.json"
+  n=$((n + 1))
+  id="crew-live-z$n"
+  out=$(crew_ship_spawn "$w" "$id" claude); status=$?
+  expect_code 0 "$status" "with no dispatch file an unresolved crew spawn should fall back to crew-harness"$'\n'"$out"
+  first_launch=$(cat "$w/$id.launch.log")
+  first_launch=${first_launch//"$id"/TASKID}
+  assert_contains "$first_launch" "claude " "crew-harness=claude did not produce a claude launch"
+  n=$((n + 1))
+  id="crew-live-z$n"
+  out=$(crew_ship_spawn "$w" "$id" codex); status=$?
+  expect_code 0 "$status" "with no dispatch file an unresolved crew spawn should fall back to crew-harness"$'\n'"$out"
+  launch=$(cat "$w/$id.launch.log")
+  launch=${launch//"$id"/TASKID}
+  assert_contains "$launch" "codex " "crew-harness=codex did not produce a codex launch"
+  [ "$launch" != "$first_launch" ] \
+    || fail "negative control did not diverge: config/crew-harness changed nothing even with no dispatch file, so the inertness assertions prove nothing"
+
+  pass "D3 spawn: config/crew-harness cannot reach a crewmate launch while dispatch profiles are active, for every matching rule and the default; with no dispatch file it is live again"
+}
+
 test_harness_resolution
 test_secondmate_model_effort_tokens
 test_pi_signed_detection_and_session_lock_identity
@@ -2510,5 +2723,8 @@ test_config_reread_bootstrap_path_and_spawn_flexibility
 test_bootstrap_respawns_before_config_reread
 test_spawn_quarantines_pending_rereads_on_cleanup_failure
 test_bootstrap_detect_only_does_not_create_state
+test_pinned_secondmate_survives_a_crew_harness_realignment
+test_pinned_secondmate_spawn_survives_a_crew_harness_realignment
+test_crew_harness_is_inert_for_dispatch_resolved_crewmates
 
 echo "# all fm-secondmate-harness tests passed"

--- a/tests/fm-secondmate-harness.test.sh
+++ b/tests/fm-secondmate-harness.test.sh
@@ -3,7 +3,7 @@
 # tokens config/secondmate-harness carries alongside the harness, and the
 # primary->secondmate inherited local-material propagation.
 #
-# Three capabilities are under test:
+# Four capabilities are under test:
 #   A) Harness split. config/secondmate-harness sets the harness the PRIMARY uses
 #      to launch SECONDMATE agents, independent of config/crew-harness (the
 #      crewmate harness). fm-harness.sh secondmate resolves the fallback chain


### PR DESCRIPTION
## Intent

Split config/crew-harness's two jobs so the expiring temporary Claude crew-routing authorization (E-05, expires 2026-08-08) expires into a CORRECT default rather than a stale one. config/crew-harness has read 'claude' since 2026-07-22 and answers two different questions at once: it is a DEAD crewmate fallback (config/crew-dispatch.json is always active and its default is harness pi, and fm-spawn refuses an unresolved crewmate spawn rather than reading the file) and the LIVE second link of the secondmate launch chain (bin/fm-harness.sh secondmate resolves config/secondmate-harness -> config/crew-harness -> own). An exception that expires into a stale default has not expired.

Ordering is load-bearing and was specified up front: config/secondmate-harness must be set explicitly FIRST, then config/crew-harness aligned with the dispatch default. The reverse order changes secondmate launch behaviour as a side effect of a crewmate correction. No secondmate exists today, so this is the cheap moment.

DELIBERATE SCOPE DECISION, which is why this diff is tests-only: config/ and data/captain.md are LOCAL, gitignored files in the operator's private home. They cannot be changed from a worktree and are not tracked material, so the tracked deliverable is the resolution logic plus tests, and the exact local config writes were reported separately to the operator. The two local writes are: config/secondmate-harness = claude (already applied by the operator after the captain answered the one engineer question - secondmates launch on Claude, with Pi kept available as a deliberate later option), and config/crew-harness claude -> pi, to be applied on or after 2026-08-08 together with deleting the expiring captain-preferences section.

SECOND DELIBERATE DECISION: bin/fm-harness.sh was NOT modified. Its fallback chain already resolves an explicit config/secondmate-harness ahead of the crew fallback, verified directly against the live config bytes on a scratch copy. What was missing was ENFORCEMENT, not logic - nothing pinned the ordering property that makes the crew-harness realignment safe. So the change adds three regressions to the existing split suite tests/fm-secondmate-harness.test.sh (new section D), extending that file rather than adding a new runner:
- D1: with config/secondmate-harness pinned, editing config/crew-harness leaves fm-harness.sh secondmate unchanged.
- D2: the same property at the spawn chokepoint, which re-resolves on every launch, so the pin survives a respawn after the edit.
- D3: config/crew-harness cannot reach a crewmate launch while dispatch profiles are active, for each matching rule AND the default - identical launch command and recorded profile across crew-harness values - and an unresolved spawn refuses instead of reading the file.

Each case deliberately carries a NEGATIVE CONTROL, because all three assertions would also hold if config/crew-harness had simply stopped working everywhere: the unpinned secondmate must move with the edit, and with no dispatch file the crewmate launch must diverge by crew-harness value. The launch-command comparisons normalize the task id out of the embedded brief path, because otherwise the divergence control would pass vacuously on the differing ids alone. Both controls were confirmed non-vacuous by mutation testing: disabling the pin resolution fails D1/D2, and removing the dispatch backstop fails D3.

This touches worker-launch harness resolution and was treated with R1-RUNTIME rigor per the plan's certification note. bin/fm-lint.sh is clean, the full split suite and tests/fm-spawn-dispatch-profile.test.sh pass.

KNOWN PRE-EXISTING FAILURE, not caused by this change and deliberately not fixed here: tests/fm-secondmate-harness.test.sh's test_spawned_secondmate_uses_its_harness_supervision_model fails whenever the checkout sits on a named feature branch, because the worktree-tangle guard fires on it and its output reaches that assertion. Confirmed identical at base commit ed376cf with this change absent.

## What Changed

- Adds section D (three regressions) to `tests/fm-secondmate-harness.test.sh`: with `config/secondmate-harness` pinned, editing `config/crew-harness` leaves `fm-harness.sh secondmate` resolution unchanged (D1) and the pin survives a respawn through the spawn chokepoint, which re-resolves on every launch (D2); while dispatch profiles are active, `config/crew-harness` cannot reach a crewmate launch — launch command and recorded profile are identical across crew-harness values for each matching rule and the default, and an unresolved crewmate spawn refuses instead of reading the file (D3).
- Each case carries a negative control so the assertions can't pass vacuously — the unpinned secondmate must move with the crew-harness edit, and with no dispatch file the crewmate launch must diverge by crew-harness value — with task ids normalized out of the embedded brief path in launch-command comparisons; both controls were confirmed non-vacuous by mutation testing. Also fixes the stale capability count in the suite's header comment.
- No `bin/` or config changes: `bin/fm-harness.sh` already resolves an explicit `config/secondmate-harness` ahead of the crew fallback, and these tests enforce that ordering so the expiring E-05 crew-harness realignment (claude → pi on 2026-08-08) lands safely. The remaining files in the nominal range vs base 33a4287 are fork-trunk commits already landed through PRs #8–#48 that origin/main does not yet carry.

## Risk Assessment

✅ Low: A tests-only additive commit whose new assertions I verified statically against the unmodified production logic in bin/fm-harness.sh and bin/fm-spawn.sh (resolution chain, per-launch re-resolution, dispatch backstop message and exit code), each carrying non-vacuity negative controls, satisfying every required intent constraint and touching no production code.

## Testing

Ran the full fm-secondmate-harness suite (all 50 tests pass, D1–D3 included) plus the adjacent dispatch-profile suite, proved all three new regressions non-vacuous by mutating the pin resolution and the dispatch backstop in turn (each mutation is caught by its intended test), and captured a CLI transcript of the E-05 expiry scenario showing the pinned secondmate harness survives the crew-harness claude→pi realignment while the unpinned control moves; no visual evidence applies since this is a shell-CLI test harness with no rendered surface, and the worktree was left clean.

<details>
<summary>Evidence: E-05 expiry scenario CLI transcript (pinned secondmate survives crew-harness claude→pi; unpinned control moves)</summary>

<code>$ # STEP 1 - the 2026-08-08 realignment: crew-harness claude -&gt; pi&#10;$ echo pi &gt; config/crew-harness&#10;$ bin/fm-harness.sh secondmate # MUST stay claude: the explicit pin insulates secondmate launches&#10;claude&#10;$ bin/fm-harness.sh crew # crewmate fallback now matches the dispatch default (pi)&#10;pi&#10;$ # CONTROL - the same realignment with NO pin&#10;$ echo pi &gt; config/crew-harness &amp;&amp; bin/fm-harness.sh secondmate # unpinned: the edit moves secondmate launches too&#10;pi</code>

```text
$ # E-05 expiry scenario on a scratch config (FM_CONFIG_OVERRIDE), CLAUDECODE=1 (primary runs on claude)
$ # STEP 0 - state today: temporary E-05 authorization in effect, plus the operator's already-applied pin
$ cat config/secondmate-harness config/crew-harness
claude
claude
$ bin/fm-harness.sh secondmate   # second link of the launch chain resolves the pin
claude
$ bin/fm-harness.sh crew
claude

$ # STEP 1 - the 2026-08-08 realignment: crew-harness claude -> pi (align with the crew-dispatch default)
$ echo pi > config/crew-harness
$ bin/fm-harness.sh secondmate   # MUST stay claude: the explicit pin insulates secondmate launches
claude
$ bin/fm-harness.sh crew         # crewmate fallback now matches the dispatch default (pi)
pi

$ # CONTROL - the same realignment with NO pin (the ordering the change guards against)
$ rm config/secondmate-harness; echo claude > config/crew-harness
$ bin/fm-harness.sh secondmate
claude
$ echo pi > config/crew-harness && bin/fm-harness.sh secondmate   # unpinned: the edit moves secondmate launches too
pi
```
</details>
<details>
<summary>Evidence: New D-section regressions passing (baseline, unmodified bin/)</summary>

<code>ok - D1 a config/crew-harness realignment leaves a PINNED secondmate harness alone; an unpinned one moves with it (the pin-first ordering is load-bearing)&#10;ok - D2 spawn: a pinned config/secondmate-harness keeps launching its own harness across a crew-harness realignment; an unpinned home takes the edit&#10;ok - D3 spawn: config/crew-harness cannot reach a crewmate launch while dispatch profiles are active, for every matching rule and the default; with no dispatch file it is live again</code>

```text
=== BASELINE: the three new section-D regressions (trimmed runner over tests/fm-secondmate-harness.test.sh, unmodified bin/) ===
$ bash tests/.tmp-d-only.test.sh
ok - D1 a config/crew-harness realignment leaves a PINNED secondmate harness alone; an unpinned one moves with it (the pin-first ordering is load-bearing)
ok - D2 spawn: a pinned config/secondmate-harness keeps launching its own harness across a crew-harness realignment; an unpinned home takes the edit
ok - D3 spawn: config/crew-harness cannot reach a crewmate launch while dispatch profiles are active, for every matching rule and the default; with no dispatch file it is live again
# all D-section tests passed
exit=0
```
</details>
<details>
<summary>Evidence: Mutation A: pin resolution disabled in fm-harness.sh — D1 and D2 each fail (tests are non-vacuous)</summary>

<code>--- D1 alone ---&#10;not ok - pinned: secondmate resolved &#39;claude&#39; before the edit, expected the pinned pi&#10;exit=1&#10;--- D2 alone ---&#10;not ok - pinned spawn: pre-edit secondmate launched on &#39;claude&#39;, expected the pinned pi&#10;exit=1</code>

```text
=== MUTATION A: bin/fm-harness.sh resolve_secondmate() ignores config/secondmate-harness (pin resolution disabled) ===
--- diff applied ---
+++ bin/fm-harness.sh	2026-08-07 18:29:55.124262743 -0400
@@ -133,9 +133,7 @@
 # launched on the crew harness). config/secondmate-harness is the PRIMARY's own
 # setting and is never inherited downstream - secondmates do not spawn secondmates.
 resolve_secondmate() {
-  local sm
-  sm=$(secondmate_field 1)
-  if [ -z "$sm" ] || [ "$sm" = "default" ]; then resolve_crew; else echo "$sm"; fi
+  resolve_crew
 }
 
 # Print the optional model token (2nd field) from config/secondmate-harness, or
--- D1 alone ---
not ok - pinned: secondmate resolved 'claude' before the edit, expected the pinned pi
exit=1
--- D2 alone ---
not ok - pinned spawn: pre-edit secondmate launched on 'claude', expected the pinned pi
exit=1
```
</details>
<details>
<summary>Evidence: Mutation B: dispatch backstop removed from fm-spawn.sh — D3 fails (backstop assertion is live)</summary>

<code>--- D3 alone ---&#10;not ok - an unresolved crew spawn should refuse while dispatch profiles are active (crew-harness=&#39;claude&#39;): expected exit 1, got 0&#10;exit=1</code>

```text
=== MUTATION B: bin/fm-spawn.sh single-spawn dispatch backstop removed (unresolved crew spawn falls back to config/crew-harness) ===
--- diff applied ---
@@ -897,10 +897,6 @@
       HARNESS=$("$FM_ROOT/bin/fm-harness.sh" secondmate)
       harness_src='config/secondmate-harness (falling back to config/crew-harness)'
     else
-      if [ -f "$CONFIG/crew-dispatch.json" ]; then
-        echo "error: config/crew-dispatch.json is active - pass an explicit harness resolved from the dispatch rules (the consultation backstop, so the rules are never silently skipped)." >&2
-        exit 1
-      fi
       HARNESS=$("$FM_ROOT/bin/fm-harness.sh" crew)
       harness_src='config/crew-harness'
     fi
--- D3 alone ---
not ok - an unresolved crew spawn should refuse while dispatch profiles are active (crew-harness='claude'): expected exit 1, got 0
exit=1
```
</details>
<details>
<summary>Evidence: Full fm-secondmate-harness suite run (50 tests, exit 0)</summary>

```text
ok - A1 fm-harness.sh secondmate resolves the fallback chain; crew mode unchanged
ok - C1 fm-harness.sh secondmate-model/secondmate-effort resolve the optional tokens; bare harness stays empty (backward-compat)
ok - pi-signed identity: authoritative launch selection distinguishes shared wrapper ancestry
ok - harness identity: dash-leading ps command names are basename operands, not options
ok - B1 propagate_inheritable_config: copy, idempotence, convergence, absence-mirror, exclusion, no-op, skip diagnostics
ok - B2 spawn: secondmate runs the secondmate harness; its home inherits declared config
ok - B3 spawn: an absent secondmate-harness falls back to the crew harness (backward-compat)
ok - B4 spawn: no config at all -> own harness and no propagation side effects
ok - B5 spawn: an explicit per-spawn harness arg overrides config/secondmate-harness
ok - B6 spawn: an unverified resolved secondmate harness is refused (guard intact)
ok - B5b spawn: FM_BACKEND wins over inherited config/backend
ok - B5c spawn: explicit --backend wins over FM_BACKEND and inherited config/backend
ok - C2 spawn: a bare harness-only secondmate-harness file launches with no model/effort flag (backward-compat)
ok - C3 spawn: config/secondmate-harness's model token threads --model into the launch and meta
ok - C4 spawn: config/secondmate-harness's model+effort tokens thread into the launch and meta
ok - C5 spawn: an explicit --model overrides config/secondmate-harness's model token; the file's effort token still applies
ok - C6 spawn: an explicit --effort overrides config/secondmate-harness's effort token; the file's model token still applies
ok - C7 spawn: an explicit --harness starts with clean model/effort defaults
ok - C8 spawn: an explicit --harness still honors explicit model/effort flags
ok - C9 spawn: secondmate launch pins supervision to its own harness
ok - C9 spawn: the harness fallback chain still resolves with no tokens; crew/scout launches are unaffected by this feature
ok - B7 bootstrap sweep pushes, re-converges, and mirrors absence; never inherits secondmate-harness
ok - B8 bootstrap sweep propagates config even when the home's tracked files are already current
ok - B9 bootstrap sweep defers new inherited config until the home ignores it
ok - B10 bootstrap sweep materializes and inherits the startup-memory default while fast-forwarding
ok - B12b backend inheritance: present values and primary absence converge exactly
ok - B12c presentation inheritance: the primary default converges on, and only an explicit opt-out propagates off
ok - B11 bootstrap sweep surfaces config propagation failures
ok - B11 bootstrap rereads completed config writes after partial propagation
ok - B12 config-push propagates via shared live discovery, reports items, rereads on change only, and does not fast-forward
ok - B13 config-push reports dirty, non-allowing, and invalid homes without failing warnings-only runs
ok - B14 config-push exits nonzero on real propagation errors
ok - B14 config-push rereads completed config writes after partial propagation
ok - B15 config reread is per-home, exact-byte, ordered, and pointer-only
ok - B16 config reread isolation, ABSENT, generation safety, send failure, and retry
ok - B20 config reread publication failures retain exact generations for retry
ok - B21 config reread instruction-write failures retain exact retry generations
ok - B21 config reread preserves exact bytes when temporary adoption also fails
ok - B21 config reread serializes concurrent propagation and delivery
ok - B22 full config reread retry queues drain before new publication
ok - B23 mixed config reread delivery failures still bound sent history
ok - B26 config reread delivery stops after the oldest failed generation
ok - B17 config reread skips unchanged homes and reads destination post-write bytes
ok - B18 bootstrap config reread path works; spawn flexibility remains defaults-only
ok - B19 bootstrap respawns before inherited-config reread
ok - B25 spawn quarantines stale rereads without blocking relaunch
ok - B24 bootstrap detect-only mode remains filesystem read-only
ok - D1 a config/crew-harness realignment leaves a PINNED secondmate harness alone; an unpinned one moves with it (the pin-first ordering is load-bearing)
ok - D2 spawn: a pinned config/secondmate-harness keeps launching its own harness across a crew-harness realignment; an unpinned home takes the edit
ok - D3 spawn: config/crew-harness cannot reach a crewmate launch while dispatch profiles are active, for every matching rule and the default; with no dispatch file it is live again
# all fm-secondmate-harness tests passed
EXIT=0
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⏭️ **Rebase** - skipped</summary>

- ⚠️ `.agents/skills/afk/SKILL.md` - branch carries 46 commit(s) that exist on your local main branch but were never pushed to origin/main; rebasing would bundle this unrelated work (201 file(s)) into the PR:
- ed376cf fix(bin): refuse merges without verified green checks (land of upstream #1614) (#48)
- 744f982 fix(bin): resolve the fork trunk as a landing target (#47)
- 561f0bb fix(bin): keep the fleet view working past the per-argument cap (#46)
- aef7a6d fix(bin): resolve the wake sequence instead of trusting a supplied one (#45)
- f90ed1d fix(bin): detect child-process work during supervision (land of upstream #1676) (#44)
- 3611e49 fix(bin): separate task read and contribution bases (land of upstream #1613) (#43)
- dda7f30 fix: stop rechecking captain-gated pauses in away mode (land of upstream #1621) (#42)
- 4bee9f1 fix(bin): escalate blocked-on-human transitions past status-line dedupe (#41)
- 27c7a2d fix(bin): stop wedge alarms on settled terminal tasks (#40)
- ad53e97 reconcile: one landable base from the diverged fork and upstream trunks (#39)
- 9f914d1 feat: add the canonical LoopSpec representation, schema and register (#38)
- cc242ae feat: add research-approved-work skill and deterministic corpus scanner (#37)
- 50adfce fix(bin): measure pool-slot safety against the landing target (#36)
- 631c248 feat(bin): wake-outcome ledger for measured coordinator attention cost (#35)
- 817ee8e CI mirror: refuse local merges only on genuine working-tree collisions (#1)
- ef74752 fix(bin): recognize kimi variants and pi launcher basenames in harness detection (#20)
- 5e6e90f fix(bin): let a released task land through the sanctioned merge path (#34)
- 1149178 Merge pull request #33 from sbracewell64/fm/fork-upstream-resync-conflicts
- 490a371 reconcile: fork trunk with upstream main (0 behind, queue intact, 7 conflicts resolved) (#32)
- a004e4c Merge upstream 33a4287 into the fork trunk queue
- ecbbe30 fork-landing: Windows-to-WSL launcher bridge reconciled onto trunk (#31)
- abc2e7b fix(bin): prevent treehouse allocation from detaching live work (#25)
- 61a5ce8 feat(bin): carry standing worker rules into every generated brief (#23)
- 1ba6ffe fix(bin): allowlist the opencode turn-end plugin in teardown&#39;s dirty check (#12)
- 988dd4b fix(composer): read an NBSP-padded empty composer as empty and fail unshown herdr wedge alarms (#14)
- 0c83af2 test: reap leaked background processes on every suite ending (#16)
- 8e1eb2d feat(bin): wake firstmate when a monitored PR goes conflicting (#21)
- 3edbc23 CI mirror: feat(bin): add fleet admission control stages 0 and 1 (#8)
- cf8f2c6 feat(bin): trigger the 70% compaction doctrine from Claude&#39;s host-computed context telemetry (#11)
- e960b84 feat(bin): enforce the zero-budget model rule with a model registry, spawn gate, and probe verification (#10)
- d965699 feat(bin): mark crewmate and scout steers as from-firstmate and teach briefs to read the marker (#9)
- 9dbaa00 Merge fm/fm-launch-menu: fleet launcher menu (upstream PR #1288)
- 06a6fbd no-mistakes(review): add launch lock, reject leading-zero input, refresh evidence anchors
- fa1dcc7 test: replace launch-lib one-owner source assertions with behavioral coverage
- 74be2a6 no-mistakes(review): fix glob split, enforce backend, guard reattach, probe pi-signed
- cca9d3a feat(bin): add the fleet launcher menu, Herdr gate, and reattach guard
- a083886 no-mistakes(document): point harness-adapters launch facts at fm-launch-lib owner
- 0f42855 no-mistakes(review): bind consumer obligation to every primary, fix pi rationale
- 1154677 no-mistakes(review): bind consumer obligation to any bypass flag, add grok
- bf87246 no-mistakes(review): record primary autonomy evidence and consumer obligation
- abe3c8d no-mistakes(review): add grok --trust, refuse kimi primary, pin every primary shape
- dbfd400 no-mistakes(document): point grok adapter launch line at fm-launch-lib owner
- e067656 no-mistakes(review): use verified opencode --auto primary shape and tighten launch-lib ownership
- 7fd8e55 no-mistakes(document): point launch-command docs at new fm-launch-lib.sh owner
- 6e65a07 no-mistakes(review): map fm-launch-lib.sh into test selection, fixture, and docs
- 2c93585 refactor(bin): give launch knowledge one owner in fm-launch-lib.sh

Push main to origin, or rebase your branch onto origin/main, before gating.

</details>

<details>
<summary>⚠️ **Review** - 2 infos</summary>

- ℹ️ `tests/fm-secondmate-harness.test.sh:2590` - crew_ship_spawn does not pin CLAUDE_CONFIG_DIR, unlike the mirrored run_spawn helper in tests/fm-spawn-dispatch-profile.test.sh which pins it explicitly (with a rationale comment) because fm-spawn.sh prefixes &#39;CLAUDE_CONFIG_DIR=...&#39; onto claude launch commands. No current D3 assertion can be affected — the dispatch-profile rows use grok/pi/codex (never claude) and the negative control only does a substring check — but any future tightening of D3 to exact-launch comparisons involving claude would inherit a dependency on the developer&#39;s ambient environment. Purely a hardening/consistency note.
- ℹ️ `tests/fm-secondmate-harness.test.sh:1` - Scope note: the supplied base 33a4287 is the upstream merge-base, so the nominal range spans ~45 already-landed fork-trunk commits (each merged via its own PR, ending at ed376cf / PR #48). The branch&#39;s actual change is the single tests-only tip commit ef1e200 (+216 lines in tests/fm-secondmate-harness.test.sh), which is what this review assessed in depth and which matches the intent&#39;s &#39;tests-only&#39; claim exactly — no non-test files are touched by the tip commit.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash tests/fm-secondmate-harness.test.sh` — full changed suite, all 50 tests pass (exit 0), including new D1/D2/D3; the known branch-dependent supervision test passes on this detached-HEAD checkout, consistent with the intent&#39;s claim</code>
- <code>Trimmed D-only runner over the suite: `test_pinned_secondmate_survives_a_crew_harness_realignment` (D1), `test_pinned_secondmate_spawn_survives_a_crew_harness_realignment` (D2), `test_crew_harness_is_inert_for_dispatch_resolved_crewmates` (D3) — all pass on unmodified bin/</code>
- <code>`bash tests/fm-spawn-dispatch-profile.test.sh` — adjacent suite covering the dispatch backstop D3 leans on, all pass</code>
- `Mutation A (non-vacuity): made resolve_secondmate() in bin/fm-harness.sh ignore config/secondmate-harness — D1 and D2 each fail independently; reverted`
- `Mutation B (non-vacuity): removed the crew-dispatch.json consultation backstop from bin/fm-spawn.sh's single-spawn path — D3 fails; reverted`
- <code>Manual end-to-end E-05 expiry scenario via `FM_CONFIG_OVERRIDE` scratch config: pinned secondmate-harness=claude holds `fm-harness.sh secondmate`=claude across crew-harness claude→pi while `crew` moves to pi; unpinned control moves to pi with the edit</code>
- `Diff audit of ef1e200 vs its parent: single-file, tests-only (+216 lines), bin/ and config untouched — matches both deliberate scope decisions in the intent`
- <code>Post-test cleanup: mutations reverted via git checkout, temp runners deleted, `git status` clean, no leaked /tmp fixtures</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
